### PR TITLE
[agent-c][issue #1401] Remove producer-side store backend branching

### DIFF
--- a/cmd/swarm/main.go
+++ b/cmd/swarm/main.go
@@ -32,6 +32,7 @@ import (
 	"github.com/division-sh/swarm/internal/runtime"
 	runtimebootverify "github.com/division-sh/swarm/internal/runtime/bootverify"
 	"github.com/division-sh/swarm/internal/runtime/budgetspend"
+	runtimebundledelete "github.com/division-sh/swarm/internal/runtime/bundledelete"
 	runtimebus "github.com/division-sh/swarm/internal/runtime/bus"
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
 	runtimecorrelation "github.com/division-sh/swarm/internal/runtime/correlation"
@@ -124,31 +125,43 @@ type previousEnv struct {
 }
 
 type storeBundle struct {
-	Postgres            *store.PostgresStore
-	SQLDB               *sql.DB
-	RuntimeSQLDB        *sql.DB
-	RuntimeLogStore     runtime.RuntimeLogPersistence
-	RuntimeBlocker      string
-	SchemaBootstrapper  store.SchemaBootstrapper
-	EventStore          runtimebus.EventStore
-	PipelineStore       *runtimepipeline.WorkflowInstanceStore
-	SessionRegistry     sessions.Registry
-	ConversationStore   runtimellm.ConversationPersistence
-	ManagerStore        runtimemanager.ManagerPersistence
-	ScheduleStore       runtimepipeline.SchedulePersistence
-	MailboxMaterializer runtimepipeline.MailboxWriteMaterializationStore
-	MailboxStore        runtimetools.MailboxPersistence
-	ToolEntityStore     runtimetools.EntityPersistence
-	HumanTaskStore      runtimetools.HumanTaskPersistence
-	BudgetSpendStore    budgetspend.Store
-	MailboxAPIStore     apiv1.MailboxAPIStore
-	ObservabilityStore  apiv1.ObservabilityReadStore
-	AgentUsageStore     apiv1.AgentUsageReadStore
-	RuntimeIngressStore runtimeingress.Store
-	IdempotencyStore    apiv1.APIIdempotencyStore
-	TurnStore           runtimellm.TurnPersistence
-	StartupOwnership    runtimestartupownership.Store
-	RunQuiescenceStore  runtimerunquiescence.ServeAbandonStore
+	Postgres                     *store.PostgresStore
+	SQLDB                        *sql.DB
+	RuntimeSQLDB                 *sql.DB
+	Database                     apiv1.Pinger
+	RuntimeLogStore              runtime.RuntimeLogPersistence
+	RuntimeBlocker               string
+	SchemaBootstrapper           store.SchemaBootstrapper
+	EventStore                   runtimebus.EventStore
+	PipelineStore                *runtimepipeline.WorkflowInstanceStore
+	SessionRegistry              sessions.Registry
+	ConversationStore            runtimellm.ConversationPersistence
+	ManagerStore                 runtimemanager.ManagerPersistence
+	ScheduleStore                runtimepipeline.SchedulePersistence
+	MailboxMaterializer          runtimepipeline.MailboxWriteMaterializationStore
+	MailboxStore                 runtimetools.MailboxPersistence
+	ToolEntityStore              runtimetools.EntityPersistence
+	HumanTaskStore               runtimetools.HumanTaskPersistence
+	BudgetSpendStore             budgetspend.Store
+	MailboxAPIStore              apiv1.MailboxAPIStore
+	ObservabilityStore           apiv1.ObservabilityReadStore
+	AgentUsageStore              apiv1.AgentUsageReadStore
+	RuntimeIngressStore          runtimeingress.Store
+	IdempotencyStore             apiv1.APIIdempotencyStore
+	TurnStore                    runtimellm.TurnPersistence
+	StartupOwnership             runtimestartupownership.Store
+	RunQuiescenceStore           runtimerunquiescence.ServeAbandonStore
+	RunReadStore                 apiv1.RunReadStore
+	EntityReadStore              apiv1.EntityReadStore
+	AgentConversationReadStore   apiv1.AgentConversationReadStore
+	RunBundleContextStore        apiv1.RunBundleContextStore
+	BundleRuntimeCatalogStore    selectedBundleRuntimeCatalogStore
+	BundleSourceCatalogStore     selectedBundleSourceCatalogStore
+	RunBundleAvailabilityStore   selectedRunBundleAvailabilityStore
+	StartupRecoveryStore         selectedStartupRecoveryStore
+	RunStalledReader             runStalledReadStore
+	APIOptionalCapabilityBuilder selectedAPIOptionalCapabilityBuilder
+	RunForkRuntimeOwner          selectedRunForkRuntimeOwner
 }
 
 type sqlDBPinger struct {
@@ -160,6 +173,144 @@ func (p sqlDBPinger) Ping(ctx context.Context) error {
 		return errors.New("sql database is not configured")
 	}
 	return p.db.PingContext(ctx)
+}
+
+func selectedPostgresAPIOptionalCapabilityBuilder(pg *store.PostgresStore, stores storeBundle) selectedAPIOptionalCapabilityBuilder {
+	if pg == nil {
+		return nil
+	}
+	return func(req selectedAPICapabilityRequest) (selectedAPICapabilities, error) {
+		resetPlanner := runtimedestructivereset.InventoryPlanner{
+			Reader: runtimedestructivereset.CompositeInventoryReader{
+				Reader:     pg,
+				Containers: req.Workspaces,
+			},
+		}
+		runForkSourceLoader := runtimerunforkexecution.SelectedContractSourceLoader(runtimerunforkexecution.ContractBundleSourceLoader{
+			RepoRoot:         req.RepoRoot,
+			PlatformSpecPath: req.PlatformSpecPath,
+		})
+		if req.LoadedBundle.dbLoaded {
+			runForkSourceLoader = runtimerunforkexecution.BundleCatalogSelectedContractSourceLoader{
+				RepoRoot: req.RepoRoot,
+				Store:    pg,
+			}
+		}
+		apiRuntimeContexts, err := serveRuntimeContextManager(pg, req.RuntimeContexts)
+		if err != nil {
+			return selectedAPICapabilities{}, err
+		}
+		return selectedAPICapabilities{
+			BundleCatalog: pg,
+			BundleDelete: &runtimebundledelete.Coordinator{
+				Planner:            pg,
+				Cleaner:            pg,
+				Finalizer:          pg,
+				Locks:              pg,
+				ContainerInventory: req.Workspaces,
+				Containers:         runtimedestructivereset.ManagedContainerStopper{Runtime: req.Workspaces},
+			},
+			ConversationForks:   pg,
+			RunForkAvailability: pg,
+			RunFork: apiv1.SelectedContractRunForkExecutor{
+				ExecuteSelectedContractRunFork: selectedPostgresRunForkExecutionFunc(pg),
+				SourceLoader:                   runForkSourceLoader,
+				ContractSelection:              runtimerunforkadmission.SelectedContractSelection(req.Source, req.ContractsRoot),
+				AgentRuntime: runtimerunforkexecution.SelectedContractAgentRuntimeOptions{
+					Config:            req.Config,
+					EntityStore:       stores.ToolEntityStore,
+					HumanTaskStore:    stores.HumanTaskStore,
+					SessionRegistry:   stores.SessionRegistry,
+					ConversationStore: stores.ConversationStore,
+					TurnStore:         stores.TurnStore,
+					ScheduleStore:     stores.ScheduleStore,
+					MailboxStore:      stores.MailboxStore,
+					Workspace:         req.Workspaces,
+					Credentials:       req.Credentials,
+				},
+			},
+			RuntimeContexts:  apiRuntimeContexts,
+			ResetCoordinator: &runtimedestructivereset.Coordinator{Planner: resetPlanner, Locks: pg},
+			ResetQuiescer:    runtimedestructivereset.Quiescer{Store: pg},
+			ResetCleaner:     runtimedestructivereset.Cleaner{Store: pg},
+		}, nil
+	}
+}
+
+func selectedPostgresRunForkExecutionFunc(pg *store.PostgresStore) apiv1.SelectedContractRunForkExecutionFunc {
+	if pg == nil {
+		return nil
+	}
+	return func(ctx context.Context, req runtimerunforkexecution.SelectedContractExecutionRequest) (runtimerunforkexecution.SelectedContractExecutionResult, error) {
+		req.Store = pg
+		return runtimerunforkexecution.ExecuteSelectedContractRunFork(ctx, req)
+	}
+}
+
+func selectedPostgresRunForkRuntimeOwner(pg *store.PostgresStore) selectedRunForkRuntimeOwner {
+	if pg == nil {
+		return selectedRunForkRuntimeOwner{}
+	}
+	return selectedRunForkRuntimeOwner{
+		activateFunc: func(ctx context.Context, req runtimerunforkexecution.SelectedContractActivationGateRequest) (runtimerunforkexecution.SelectedContractActivationGateResult, error) {
+			req.Store = pg
+			return runtimerunforkexecution.ActivateSelectedContractRunFork(ctx, req)
+		},
+		materializeFunc: pg.MaterializeRunFork,
+		executeFunc: func(ctx context.Context, req runtimerunforkexecution.SelectedContractExecutionRequest) (runtimerunforkexecution.SelectedContractExecutionResult, error) {
+			req.Store = pg
+			return runtimerunforkexecution.ExecuteSelectedContractRunFork(ctx, req)
+		},
+		planFunc: pg.PlanRunFork,
+	}
+}
+
+func selectedPostgresStoreBundle(pg *store.PostgresStore, cfg *config.Config) storeBundle {
+	if pg == nil {
+		return storeBundle{}
+	}
+	if cfg == nil {
+		cfg = &config.Config{}
+	}
+	bundle := storeBundle{
+		Postgres:                   pg,
+		SQLDB:                      pg.DB,
+		RuntimeSQLDB:               pg.DB,
+		Database:                   pg,
+		RuntimeLogStore:            pg,
+		SchemaBootstrapper:         pg,
+		EventStore:                 pg,
+		PipelineStore:              runtimepipeline.NewWorkflowInstanceStore(pg.DB),
+		SessionRegistry:            sessions.NewPostgresRegistry(pg.DB, cfg.LLM.Session.LockTTL),
+		ConversationStore:          pg,
+		ManagerStore:               pg,
+		ScheduleStore:              pg,
+		MailboxMaterializer:        pg,
+		MailboxStore:               pg,
+		ToolEntityStore:            pg,
+		HumanTaskStore:             pg,
+		BudgetSpendStore:           pg,
+		MailboxAPIStore:            pg,
+		ObservabilityStore:         pg,
+		AgentUsageStore:            pg,
+		RuntimeIngressStore:        pg,
+		IdempotencyStore:           pg,
+		TurnStore:                  pg,
+		StartupOwnership:           pg,
+		RunQuiescenceStore:         pg,
+		RunReadStore:               pg,
+		EntityReadStore:            pg,
+		AgentConversationReadStore: pg,
+		RunBundleContextStore:      pg,
+		BundleRuntimeCatalogStore:  pg,
+		BundleSourceCatalogStore:   pg,
+		RunBundleAvailabilityStore: pg,
+		StartupRecoveryStore:       pg,
+		RunStalledReader:           pg,
+		RunForkRuntimeOwner:        selectedPostgresRunForkRuntimeOwner(pg),
+	}
+	bundle.APIOptionalCapabilityBuilder = selectedPostgresAPIOptionalCapabilityBuilder(pg, bundle)
+	return bundle
 }
 
 func (s storeBundle) runtimeStores() runtime.Stores {
@@ -419,7 +570,7 @@ func loadServeRuntimeBundle(ctx context.Context, repo string, stores storeBundle
 func loadServeRuntimeBundleFromCatalog(ctx context.Context, repo string, stores storeBundle, bundleHash string) (serveRuntimeBundle, error) {
 	catalog := stores.facade().bundleRuntimeCatalogStore()
 	if catalog == nil {
-		return serveRuntimeBundle{}, fmt.Errorf("BUNDLE_UNAVAILABLE: swarm serve --bundle-hash requires postgres bundle catalog store")
+		return serveRuntimeBundle{}, fmt.Errorf("BUNDLE_UNAVAILABLE: swarm serve --bundle-hash requires selected bundle catalog store")
 	}
 	if err := runtimecontracts.ValidateBundleHash(bundleHash); err != nil {
 		return serveRuntimeBundle{}, err
@@ -2353,32 +2504,7 @@ func buildStores(ctx context.Context, selection storebackend.Selection, cfg *con
 		if _, err := pg.BindSchemaCapabilities(ctx); err != nil {
 			return storeBundle{}, err
 		}
-		return storeBundle{
-			Postgres:            pg,
-			SQLDB:               pg.DB,
-			RuntimeSQLDB:        pg.DB,
-			RuntimeLogStore:     pg,
-			SchemaBootstrapper:  pg,
-			EventStore:          pg,
-			PipelineStore:       runtimepipeline.NewWorkflowInstanceStore(pg.DB),
-			SessionRegistry:     sessions.NewPostgresRegistry(pg.DB, cfg.LLM.Session.LockTTL),
-			ConversationStore:   pg,
-			ManagerStore:        pg,
-			ScheduleStore:       pg,
-			MailboxMaterializer: pg,
-			MailboxStore:        pg,
-			ToolEntityStore:     pg,
-			HumanTaskStore:      pg,
-			BudgetSpendStore:    pg,
-			MailboxAPIStore:     pg,
-			ObservabilityStore:  pg,
-			AgentUsageStore:     pg,
-			RuntimeIngressStore: pg,
-			IdempotencyStore:    pg,
-			TurnStore:           pg,
-			StartupOwnership:    pg,
-			RunQuiescenceStore:  pg,
-		}, nil
+		return selectedPostgresStoreBundle(pg, cfg), nil
 	case storebackend.BackendSQLite:
 		sqliteStore, err := store.NewSQLiteRuntimeStore(selection.SQLitePath)
 		if err != nil {
@@ -2394,28 +2520,33 @@ func buildStores(ctx context.Context, selection storebackend.Selection, cfg *con
 		}
 		sqliteStore.SetSessionLockTTL(cfg.LLM.Session.LockTTL)
 		return storeBundle{
-			SQLDB:               sqliteStore.DB,
-			RuntimeLogStore:     sqliteStore,
-			SchemaBootstrapper:  sqliteStore,
-			EventStore:          sqliteStore,
-			PipelineStore:       runtimepipeline.NewSQLiteWorkflowInstanceStoreWithRuntimeMutationRunner(sqliteStore.DB, sqliteStore),
-			SessionRegistry:     sqliteStore,
-			ConversationStore:   sqliteStore,
-			ManagerStore:        sqliteStore,
-			ScheduleStore:       sqliteStore,
-			MailboxMaterializer: sqliteStore,
-			MailboxStore:        sqliteStore,
-			ToolEntityStore:     sqliteStore,
-			HumanTaskStore:      sqliteStore,
-			BudgetSpendStore:    sqliteStore,
-			MailboxAPIStore:     sqliteStore,
-			ObservabilityStore:  sqliteStore,
-			AgentUsageStore:     sqliteStore,
-			RuntimeIngressStore: sqliteStore,
-			IdempotencyStore:    sqliteStore,
-			TurnStore:           sqliteStore,
-			StartupOwnership:    sqliteStore,
-			RunQuiescenceStore:  sqliteStore,
+			SQLDB:                 sqliteStore.DB,
+			Database:              sqlDBPinger{db: sqliteStore.DB},
+			RuntimeLogStore:       sqliteStore,
+			SchemaBootstrapper:    sqliteStore,
+			EventStore:            sqliteStore,
+			PipelineStore:         runtimepipeline.NewSQLiteWorkflowInstanceStoreWithRuntimeMutationRunner(sqliteStore.DB, sqliteStore),
+			SessionRegistry:       sqliteStore,
+			ConversationStore:     sqliteStore,
+			ManagerStore:          sqliteStore,
+			ScheduleStore:         sqliteStore,
+			MailboxMaterializer:   sqliteStore,
+			MailboxStore:          sqliteStore,
+			ToolEntityStore:       sqliteStore,
+			HumanTaskStore:        sqliteStore,
+			BudgetSpendStore:      sqliteStore,
+			MailboxAPIStore:       sqliteStore,
+			ObservabilityStore:    sqliteStore,
+			AgentUsageStore:       sqliteStore,
+			RuntimeIngressStore:   sqliteStore,
+			IdempotencyStore:      sqliteStore,
+			TurnStore:             sqliteStore,
+			StartupOwnership:      sqliteStore,
+			RunQuiescenceStore:    sqliteStore,
+			RunReadStore:          sqliteStore,
+			EntityReadStore:       sqliteStore,
+			RunBundleContextStore: sqliteStore,
+			RunStalledReader:      sqliteStore,
 		}, nil
 	default:
 		return storeBundle{}, fmt.Errorf("store backend selection is required; supported backends: %s, %s", storebackend.BackendPostgres, storebackend.BackendSQLite)

--- a/cmd/swarm/main_test.go
+++ b/cmd/swarm/main_test.go
@@ -40,7 +40,6 @@ import (
 	runtimerunforkexecution "github.com/division-sh/swarm/internal/runtime/runforkexecution"
 	runtimerunquiescence "github.com/division-sh/swarm/internal/runtime/runquiescence"
 	"github.com/division-sh/swarm/internal/runtime/semanticview"
-	"github.com/division-sh/swarm/internal/runtime/sessions"
 	runtimetools "github.com/division-sh/swarm/internal/runtime/tools"
 	workspace "github.com/division-sh/swarm/internal/runtime/workspace"
 	"github.com/division-sh/swarm/internal/store"
@@ -3031,11 +3030,12 @@ func TestLoadServeRuntimeBundleFromCatalogLoadsPersistedRuntimeSource(t *testing
 	}); err != nil {
 		t.Fatalf("UpsertBundleCatalog: %v", err)
 	}
-	if _, err := loadServeRuntimeBundleFromCatalog(ctx, repoRoot(), storeBundle{}, projection.BundleHash); err == nil || !strings.Contains(err.Error(), "requires postgres bundle catalog store") {
-		t.Fatalf("loadServeRuntimeBundleFromCatalog without Postgres err = %v, want Postgres-only failure", err)
+	if _, err := loadServeRuntimeBundleFromCatalog(ctx, repoRoot(), storeBundle{}, projection.BundleHash); err == nil || !strings.Contains(err.Error(), "requires selected bundle catalog store") {
+		t.Fatalf("loadServeRuntimeBundleFromCatalog without selected catalog err = %v, want selected-owner failure", err)
 	}
 
-	loaded, err := loadServeRuntimeBundleFromCatalog(ctx, repoRoot(), storeBundle{Postgres: pg}, projection.BundleHash)
+	stores := selectedPostgresStoreBundle(pg, &config.Config{})
+	loaded, err := loadServeRuntimeBundleFromCatalog(ctx, repoRoot(), stores, projection.BundleHash)
 	if err != nil {
 		t.Fatalf("loadServeRuntimeBundleFromCatalog: %v", err)
 	}
@@ -3062,14 +3062,14 @@ func TestLoadServeRuntimeBundleFromCatalogLoadsPersistedRuntimeSource(t *testing
 	if _, err := os.Stat(filepath.Join(loaded.contractsRoot, "flows", "support", "data", "exclusions.yaml")); err != nil {
 		t.Fatalf("DB-loaded source missing reconstructed data file: %v", err)
 	}
-	prepared, err := prepareLoadedServeBundleSource(ctx, storeBundle{Postgres: pg}, loaded, false)
+	prepared, err := prepareLoadedServeBundleSource(ctx, stores, loaded, false)
 	if err != nil {
 		t.Fatalf("prepareLoadedServeBundleSource: %v", err)
 	}
 	if prepared.BundleHash != projection.BundleHash || prepared.BundleSource != storerunlifecycle.BundleSourcePersisted {
 		t.Fatalf("prepared source fact = %#v, want persisted %s", prepared, projection.BundleHash)
 	}
-	if _, err := prepareLoadedServeBundleSource(ctx, storeBundle{Postgres: pg}, loaded, true); err == nil || !strings.Contains(err.Error(), "--bundle-hash is mutually exclusive with --dev") {
+	if _, err := prepareLoadedServeBundleSource(ctx, stores, loaded, true); err == nil || !strings.Contains(err.Error(), "--bundle-hash is mutually exclusive with --dev") {
 		t.Fatalf("prepareLoadedServeBundleSource dev error = %v", err)
 	}
 }
@@ -5648,26 +5648,7 @@ func installServeRuntimePostgresTestStoresForDatabase(t *testing.T, workspaceFac
 		if _, err := runtimePG.BindSchemaCapabilities(ctx); err != nil {
 			return storeBundle{}, err
 		}
-		return storeBundle{
-			Postgres:            runtimePG,
-			SQLDB:               runtimePG.DB,
-			RuntimeSQLDB:        runtimePG.DB,
-			RuntimeLogStore:     runtimePG,
-			SchemaBootstrapper:  runtimePG,
-			EventStore:          runtimePG,
-			PipelineStore:       runtimepipeline.NewWorkflowInstanceStore(runtimePG.DB),
-			SessionRegistry:     sessions.NewPostgresRegistry(runtimePG.DB, cfg.LLM.Session.LockTTL),
-			ConversationStore:   runtimePG,
-			ManagerStore:        runtimePG,
-			ScheduleStore:       runtimePG,
-			MailboxStore:        runtimePG,
-			MailboxAPIStore:     runtimePG,
-			ObservabilityStore:  runtimePG,
-			RuntimeIngressStore: runtimePG,
-			IdempotencyStore:    runtimePG,
-			TurnStore:           runtimePG,
-			RunQuiescenceStore:  runtimePG,
-		}, nil
+		return selectedPostgresStoreBundle(runtimePG, cfg), nil
 	}
 	configuredWorkspaceLifecycleForServe = func(_ *sql.DB, _ string, _ semanticview.Source, mountSources workspaceMountSources, _ workspaceBackendSelection) (serveWorkspaceLifecycle, error) {
 		return workspaceFactory(mountSources), nil
@@ -5832,7 +5813,7 @@ func TestPrepareServeBundleSourcePersistsCatalogForContractsServe(t *testing.T) 
 		t.Fatalf("BootBundleIdentity: %v", err)
 	}
 
-	fact, err := prepareServeBundleSource(ctx, storeBundle{Postgres: pg}, bundle, identity.Fingerprint, false)
+	fact, err := prepareServeBundleSource(ctx, selectedPostgresStoreBundle(pg, &config.Config{}), bundle, identity.Fingerprint, false)
 	if err != nil {
 		t.Fatalf("prepareServeBundleSource: %v", err)
 	}
@@ -5858,7 +5839,7 @@ func TestPrepareServeBundleSourceDevStampsEphemeralWithoutCatalogRow(t *testing.
 		t.Fatalf("BootBundleIdentity: %v", err)
 	}
 
-	fact, err := prepareServeBundleSource(ctx, storeBundle{Postgres: pg}, bundle, identity.Fingerprint, true)
+	fact, err := prepareServeBundleSource(ctx, selectedPostgresStoreBundle(pg, &config.Config{}), bundle, identity.Fingerprint, true)
 	if err != nil {
 		t.Fatalf("prepareServeBundleSource(dev): %v", err)
 	}
@@ -9080,7 +9061,7 @@ func TestInitializeStateStoresPostgresDoesNotCreateGeneratedEntityTables(t *test
 		}
 	})
 
-	if _, err := initializeStateStores(ctx, storeBundle{Postgres: pg, SchemaBootstrapper: pg}, bundle, false); err != nil {
+	if _, err := initializeStateStores(ctx, selectedPostgresStoreBundle(pg, &config.Config{}), bundle, false); err != nil {
 		t.Fatalf("initializeStateStores(postgres): %v", err)
 	}
 	if !postgresMainTestTableExists(t, db, "entity_state") {
@@ -9232,21 +9213,7 @@ func TestRunServeRuntimeVerboseEmitsPlatformSpecBootSequence(t *testing.T) {
 		if _, err := runtimePG.BindSchemaCapabilities(ctx); err != nil {
 			return storeBundle{}, err
 		}
-		return storeBundle{
-			Postgres:           runtimePG,
-			SQLDB:              runtimePG.DB,
-			RuntimeSQLDB:       runtimePG.DB,
-			RuntimeLogStore:    runtimePG,
-			SchemaBootstrapper: runtimePG,
-			EventStore:         runtimePG,
-			PipelineStore:      runtimepipeline.NewWorkflowInstanceStore(runtimePG.DB),
-			SessionRegistry:    sessions.NewPostgresRegistry(runtimePG.DB, cfg.LLM.Session.LockTTL),
-			ConversationStore:  runtimePG,
-			ManagerStore:       runtimePG,
-			ScheduleStore:      runtimePG,
-			TurnStore:          runtimePG,
-			RunQuiescenceStore: runtimePG,
-		}, nil
+		return selectedPostgresStoreBundle(runtimePG, cfg), nil
 	}
 	configuredWorkspaceLifecycleForServe = func(*sql.DB, string, semanticview.Source, workspaceMountSources, workspaceBackendSelection) (serveWorkspaceLifecycle, error) {
 		return serveRuntimeWorkspaceStub{}, nil
@@ -9319,21 +9286,7 @@ func TestRunServeRuntimeListenerBindFailuresExitBeforeReadiness(t *testing.T) {
 				if _, err := runtimePG.BindSchemaCapabilities(ctx); err != nil {
 					return storeBundle{}, err
 				}
-				return storeBundle{
-					Postgres:           runtimePG,
-					SQLDB:              runtimePG.DB,
-					RuntimeSQLDB:       runtimePG.DB,
-					RuntimeLogStore:    runtimePG,
-					SchemaBootstrapper: runtimePG,
-					EventStore:         runtimePG,
-					PipelineStore:      runtimepipeline.NewWorkflowInstanceStore(runtimePG.DB),
-					SessionRegistry:    sessions.NewPostgresRegistry(runtimePG.DB, cfg.LLM.Session.LockTTL),
-					ConversationStore:  runtimePG,
-					ManagerStore:       runtimePG,
-					ScheduleStore:      runtimePG,
-					TurnStore:          runtimePG,
-					RunQuiescenceStore: runtimePG,
-				}, nil
+				return selectedPostgresStoreBundle(runtimePG, cfg), nil
 			}
 			configuredWorkspaceLifecycleForServe = func(*sql.DB, string, semanticview.Source, workspaceMountSources, workspaceBackendSelection) (serveWorkspaceLifecycle, error) {
 				return serveRuntimeWorkspaceStub{}, nil
@@ -9488,21 +9441,7 @@ func TestRunServeRuntimeAbandonActiveRunsQuiescesBeforeBundleMatchAdmission(t *t
 		if _, err := runtimePG.BindSchemaCapabilities(ctx); err != nil {
 			return storeBundle{}, err
 		}
-		return storeBundle{
-			Postgres:           runtimePG,
-			SQLDB:              runtimePG.DB,
-			RuntimeSQLDB:       runtimePG.DB,
-			RuntimeLogStore:    runtimePG,
-			SchemaBootstrapper: runtimePG,
-			EventStore:         runtimePG,
-			PipelineStore:      runtimepipeline.NewWorkflowInstanceStore(runtimePG.DB),
-			SessionRegistry:    sessions.NewPostgresRegistry(runtimePG.DB, cfg.LLM.Session.LockTTL),
-			ConversationStore:  runtimePG,
-			ManagerStore:       runtimePG,
-			ScheduleStore:      runtimePG,
-			TurnStore:          runtimePG,
-			RunQuiescenceStore: runtimePG,
-		}, nil
+		return selectedPostgresStoreBundle(runtimePG, cfg), nil
 	}
 	configuredWorkspaceLifecycleForServe = func(*sql.DB, string, semanticview.Source, workspaceMountSources, workspaceBackendSelection) (serveWorkspaceLifecycle, error) {
 		return serveRuntimeWorkspaceStub{}, nil

--- a/cmd/swarm/run_stalled_monitor_test.go
+++ b/cmd/swarm/run_stalled_monitor_test.go
@@ -115,12 +115,12 @@ func TestServeRunStalledReaderLoadsSnapshotProgressFromStore(t *testing.T) {
 	}
 }
 
-func TestSelectedStoreFacadeRunStalledReaderPrefersPostgres(t *testing.T) {
+func TestSelectedStoreFacadeRunStalledReaderUsesSelectedOwner(t *testing.T) {
 	postgresStore := &store.PostgresStore{}
-	stores := storeBundle{Postgres: postgresStore}
+	stores := storeBundle{RunStalledReader: postgresStore}
 
 	if got := stores.facade().runStalledReader(); got != postgresStore {
-		t.Fatalf("run stalled reader = %T, want selected postgres store", got)
+		t.Fatalf("run stalled reader = %T, want selected run-stalled owner", got)
 	}
 }
 

--- a/cmd/swarm/store_facade.go
+++ b/cmd/swarm/store_facade.go
@@ -8,10 +8,7 @@ import (
 	apiv1 "github.com/division-sh/swarm/internal/apiv1"
 	"github.com/division-sh/swarm/internal/config"
 	"github.com/division-sh/swarm/internal/runtime"
-	runtimebundledelete "github.com/division-sh/swarm/internal/runtime/bundledelete"
 	runtimecredentials "github.com/division-sh/swarm/internal/runtime/credentials"
-	runtimedestructivereset "github.com/division-sh/swarm/internal/runtime/destructivereset"
-	runtimerunforkadmission "github.com/division-sh/swarm/internal/runtime/runforkadmission"
 	runtimerunforkexecution "github.com/division-sh/swarm/internal/runtime/runforkexecution"
 	"github.com/division-sh/swarm/internal/runtime/semanticview"
 	runtimestartuprecovery "github.com/division-sh/swarm/internal/runtime/startuprecovery"
@@ -76,8 +73,17 @@ type selectedAPICapabilityRequest struct {
 	Credentials      runtimecredentials.Store
 }
 
+type selectedAPIOptionalCapabilityBuilder func(selectedAPICapabilityRequest) (selectedAPICapabilities, error)
+
 type selectedRunForkRuntimeOwner struct {
-	store *store.PostgresStore
+	activateFunc    func(context.Context, runtimerunforkexecution.SelectedContractActivationGateRequest) (runtimerunforkexecution.SelectedContractActivationGateResult, error)
+	materializeFunc func(context.Context, store.RunForkMaterializeRequest) (store.RunForkMaterialization, error)
+	executeFunc     func(context.Context, runtimerunforkexecution.SelectedContractExecutionRequest) (runtimerunforkexecution.SelectedContractExecutionResult, error)
+	planFunc        func(context.Context, store.RunForkPlanRequest) (store.RunForkPlan, error)
+}
+
+func (o selectedRunForkRuntimeOwner) configured() bool {
+	return o.activateFunc != nil && o.materializeFunc != nil && o.executeFunc != nil && o.planFunc != nil
 }
 
 func (s storeBundle) facade() selectedRuntimeStoreFacade {
@@ -116,64 +122,31 @@ func (f selectedRuntimeStoreFacade) workspaceDB() *sql.DB {
 }
 
 func (f selectedRuntimeStoreFacade) pinger() apiv1.Pinger {
-	if f.stores.Postgres != nil {
-		return f.stores.Postgres
-	}
-	if f.stores.SQLDB != nil {
-		return sqlDBPinger{db: f.stores.SQLDB}
-	}
-	return nil
+	return f.stores.Database
 }
 
 func (f selectedRuntimeStoreFacade) apiRunBundleContextStore() apiv1.RunBundleContextStore {
-	if f.stores.Postgres != nil {
-		return f.stores.Postgres
-	}
-	runBundleContext, _ := f.stores.ObservabilityStore.(apiv1.RunBundleContextStore)
-	return runBundleContext
+	return f.stores.RunBundleContextStore
 }
 
 func (f selectedRuntimeStoreFacade) apiReadStores() (apiv1.RunReadStore, apiv1.EntityReadStore, apiv1.AgentConversationReadStore, apiv1.ObservabilityReadStore) {
-	if f.stores.Postgres != nil {
-		return f.stores.Postgres, f.stores.Postgres, f.stores.Postgres, f.stores.Postgres
-	}
-	var runs apiv1.RunReadStore
-	var entities apiv1.EntityReadStore
-	if runStore, ok := f.stores.ObservabilityStore.(apiv1.RunReadStore); ok {
-		runs = runStore
-	}
-	if entityStore, ok := f.stores.ObservabilityStore.(apiv1.EntityReadStore); ok {
-		entities = entityStore
-	}
-	return runs, entities, nil, f.stores.ObservabilityStore
+	return f.stores.RunReadStore, f.stores.EntityReadStore, f.stores.AgentConversationReadStore, f.stores.ObservabilityStore
 }
 
 func (f selectedRuntimeStoreFacade) bundleRuntimeCatalogStore() selectedBundleRuntimeCatalogStore {
-	if f.stores.Postgres == nil {
-		return nil
-	}
-	return f.stores.Postgres
+	return f.stores.BundleRuntimeCatalogStore
 }
 
 func (f selectedRuntimeStoreFacade) bundleSourceCatalogStore() selectedBundleSourceCatalogStore {
-	if f.stores.Postgres == nil {
-		return nil
-	}
-	return f.stores.Postgres
+	return f.stores.BundleSourceCatalogStore
 }
 
 func (f selectedRuntimeStoreFacade) runBundleAvailabilityStore() selectedRunBundleAvailabilityStore {
-	if f.stores.Postgres == nil {
-		return nil
-	}
-	return f.stores.Postgres
+	return f.stores.RunBundleAvailabilityStore
 }
 
 func (f selectedRuntimeStoreFacade) startupRecoveryStore() selectedStartupRecoveryStore {
-	if f.stores.Postgres == nil {
-		return nil
-	}
-	return f.stores.Postgres
+	return f.stores.StartupRecoveryStore
 }
 
 func (f selectedRuntimeStoreFacade) schemaCapabilityBinder() selectedSchemaCapabilityBinder {
@@ -182,11 +155,7 @@ func (f selectedRuntimeStoreFacade) schemaCapabilityBinder() selectedSchemaCapab
 }
 
 func (f selectedRuntimeStoreFacade) runStalledReader() runStalledReadStore {
-	if f.stores.Postgres != nil {
-		return f.stores.Postgres
-	}
-	readStore, _ := f.stores.ObservabilityStore.(runStalledReadStore)
-	return readStore
+	return f.stores.RunStalledReader
 }
 
 func (f selectedRuntimeStoreFacade) apiCapabilities(req selectedAPICapabilityRequest) (selectedAPICapabilities, error) {
@@ -199,100 +168,56 @@ func (f selectedRuntimeStoreFacade) apiCapabilities(req selectedAPICapabilityReq
 		Observability:      observability,
 		RunBundleContext:   f.apiRunBundleContextStore(),
 	}
-	if f.stores.Postgres == nil {
+	if f.stores.APIOptionalCapabilityBuilder == nil {
 		return caps, nil
 	}
-	resetPlanner := runtimedestructivereset.InventoryPlanner{
-		Reader: runtimedestructivereset.CompositeInventoryReader{
-			Reader:     f.stores.Postgres,
-			Containers: req.Workspaces,
-		},
-	}
-	runForkSourceLoader := runtimerunforkexecution.SelectedContractSourceLoader(runtimerunforkexecution.ContractBundleSourceLoader{
-		RepoRoot:         req.RepoRoot,
-		PlatformSpecPath: req.PlatformSpecPath,
-	})
-	if req.LoadedBundle.dbLoaded {
-		runForkSourceLoader = runtimerunforkexecution.BundleCatalogSelectedContractSourceLoader{
-			RepoRoot: req.RepoRoot,
-			Store:    f.stores.Postgres,
-		}
-	}
-	apiRuntimeContexts, err := serveRuntimeContextManager(f.stores.Postgres, req.RuntimeContexts)
+	optional, err := f.stores.APIOptionalCapabilityBuilder(req)
 	if err != nil {
 		return selectedAPICapabilities{}, err
 	}
-	caps.BundleCatalog = f.stores.Postgres
-	caps.BundleDelete = &runtimebundledelete.Coordinator{
-		Planner:            f.stores.Postgres,
-		Cleaner:            f.stores.Postgres,
-		Finalizer:          f.stores.Postgres,
-		Locks:              f.stores.Postgres,
-		ContainerInventory: req.Workspaces,
-		Containers:         runtimedestructivereset.ManagedContainerStopper{Runtime: req.Workspaces},
-	}
-	caps.ConversationForks = f.stores.Postgres
-	caps.RunForkAvailability = f.stores.Postgres
-	caps.RunFork = apiv1.SelectedContractRunForkExecutor{
-		Store:             f.stores.Postgres,
-		SourceLoader:      runForkSourceLoader,
-		ContractSelection: runtimerunforkadmission.SelectedContractSelection(req.Source, req.ContractsRoot),
-		AgentRuntime: runtimerunforkexecution.SelectedContractAgentRuntimeOptions{
-			Config:            req.Config,
-			EntityStore:       f.stores.ToolEntityStore,
-			HumanTaskStore:    f.stores.HumanTaskStore,
-			SessionRegistry:   f.stores.SessionRegistry,
-			ConversationStore: f.stores.ConversationStore,
-			TurnStore:         f.stores.TurnStore,
-			ScheduleStore:     f.stores.ScheduleStore,
-			MailboxStore:      f.stores.MailboxStore,
-			Workspace:         req.Workspaces,
-			Credentials:       req.Credentials,
-		},
-	}
-	caps.RuntimeContexts = apiRuntimeContexts
-	caps.ResetCoordinator = &runtimedestructivereset.Coordinator{
-		Planner: resetPlanner,
-		Locks:   f.stores.Postgres,
-	}
-	caps.ResetQuiescer = runtimedestructivereset.Quiescer{Store: f.stores.Postgres}
-	caps.ResetCleaner = runtimedestructivereset.Cleaner{Store: f.stores.Postgres}
+	caps.BundleCatalog = optional.BundleCatalog
+	caps.BundleDelete = optional.BundleDelete
+	caps.ConversationForks = optional.ConversationForks
+	caps.RunForkAvailability = optional.RunForkAvailability
+	caps.RunFork = optional.RunFork
+	caps.RuntimeContexts = optional.RuntimeContexts
+	caps.ResetCoordinator = optional.ResetCoordinator
+	caps.ResetQuiescer = optional.ResetQuiescer
+	caps.ResetCleaner = optional.ResetCleaner
 	return caps, nil
 }
 
 func (f selectedRuntimeStoreFacade) runForkRuntimeOwner() (selectedRunForkRuntimeOwner, bool) {
-	if f.stores.Postgres == nil {
+	if !f.stores.RunForkRuntimeOwner.configured() {
 		return selectedRunForkRuntimeOwner{}, false
 	}
-	return selectedRunForkRuntimeOwner{store: f.stores.Postgres}, true
+	return f.stores.RunForkRuntimeOwner, true
 }
 
 func (o selectedRunForkRuntimeOwner) activate(ctx context.Context, req runtimerunforkexecution.SelectedContractActivationGateRequest) (runtimerunforkexecution.SelectedContractActivationGateResult, error) {
-	if o.store == nil {
-		return runtimerunforkexecution.SelectedContractActivationGateResult{}, fmt.Errorf("postgres store required")
+	if o.activateFunc == nil {
+		return runtimerunforkexecution.SelectedContractActivationGateResult{}, fmt.Errorf("selected run.fork runtime owner is required")
 	}
-	req.Store = o.store
-	return runtimerunforkexecution.ActivateSelectedContractRunFork(ctx, req)
+	return o.activateFunc(ctx, req)
 }
 
 func (o selectedRunForkRuntimeOwner) materialize(ctx context.Context, req store.RunForkMaterializeRequest) (store.RunForkMaterialization, error) {
-	if o.store == nil {
-		return store.RunForkMaterialization{}, fmt.Errorf("postgres store required")
+	if o.materializeFunc == nil {
+		return store.RunForkMaterialization{}, fmt.Errorf("selected run.fork runtime owner is required")
 	}
-	return o.store.MaterializeRunFork(ctx, req)
+	return o.materializeFunc(ctx, req)
 }
 
 func (o selectedRunForkRuntimeOwner) execute(ctx context.Context, req runtimerunforkexecution.SelectedContractExecutionRequest) (runtimerunforkexecution.SelectedContractExecutionResult, error) {
-	if o.store == nil {
-		return runtimerunforkexecution.SelectedContractExecutionResult{}, fmt.Errorf("postgres store required")
+	if o.executeFunc == nil {
+		return runtimerunforkexecution.SelectedContractExecutionResult{}, fmt.Errorf("selected run.fork runtime owner is required")
 	}
-	req.Store = o.store
-	return runtimerunforkexecution.ExecuteSelectedContractRunFork(ctx, req)
+	return o.executeFunc(ctx, req)
 }
 
 func (o selectedRunForkRuntimeOwner) plan(ctx context.Context, req store.RunForkPlanRequest) (store.RunForkPlan, error) {
-	if o.store == nil {
-		return store.RunForkPlan{}, fmt.Errorf("postgres store required")
+	if o.planFunc == nil {
+		return store.RunForkPlan{}, fmt.Errorf("selected run.fork runtime owner is required")
 	}
-	return o.store.PlanRunFork(ctx, req)
+	return o.planFunc(ctx, req)
 }

--- a/cmd/swarm/store_facade_guard_test.go
+++ b/cmd/swarm/store_facade_guard_test.go
@@ -10,13 +10,16 @@ import (
 func TestSelectedStoreFacadeOwnsProducerBackendBranching(t *testing.T) {
 	allowed := map[string][]string{
 		filepath.Join("cmd", "swarm", "main.go"): {
-			"Postgres            *store.PostgresStore",
-			"RuntimeSQLDB        *sql.DB",
-			"pg, err := store.NewPostgresStore(dsn)",
-			"RuntimeSQLDB:        pg.DB",
-			"sqliteStore, err := store.NewSQLiteRuntimeStore(selection.SQLitePath)",
+			"*store.PostgresStore",
+			"RuntimeSQLDB",
+			"store.NewPostgresStore",
+			"store.NewSQLiteRuntimeStore",
 		},
-		filepath.Join("cmd", "swarm", "store_facade.go"): {"*"},
+		filepath.Join("cmd", "swarm", "store_facade.go"): {
+			"SQLDB:               s.RuntimeSQLDB",
+			"closeDB(f.stores.SQLDB)",
+			"return f.stores.SQLDB",
+		},
 	}
 	forbidden := []string{
 		"stores.Postgres",

--- a/internal/apiv1/operator_run_fork.go
+++ b/internal/apiv1/operator_run_fork.go
@@ -42,27 +42,28 @@ type RunForkExecutionResult struct {
 	ExecutedEventCount int    `json:"executed_event_count"`
 }
 
+type SelectedContractRunForkExecutionFunc func(context.Context, runtimerunforkexecution.SelectedContractExecutionRequest) (runtimerunforkexecution.SelectedContractExecutionResult, error)
+
 type SelectedContractRunForkExecutor struct {
-	Store             *store.PostgresStore
-	SourceLoader      runtimerunforkexecution.SelectedContractSourceLoader
-	ContractSelection store.RunForkContractSelection
-	AgentRuntime      runtimerunforkexecution.SelectedContractAgentRuntimeOptions
+	ExecuteSelectedContractRunFork SelectedContractRunForkExecutionFunc
+	SourceLoader                   runtimerunforkexecution.SelectedContractSourceLoader
+	ContractSelection              store.RunForkContractSelection
+	AgentRuntime                   runtimerunforkexecution.SelectedContractAgentRuntimeOptions
 }
 
 func (e SelectedContractRunForkExecutor) ExecuteRunFork(ctx context.Context, req RunForkExecutionRequest) (RunForkExecutionResult, error) {
-	if e.Store == nil {
-		return RunForkExecutionResult{}, fmt.Errorf("run.fork requires selected-contract store")
+	if e.ExecuteSelectedContractRunFork == nil {
+		return RunForkExecutionResult{}, fmt.Errorf("run.fork requires selected-contract executor")
 	}
 	selection := req.ContractSelection
 	if strings.TrimSpace(selection.Mode) == "" {
 		selection = e.ContractSelection
 	}
-	result, err := runtimerunforkexecution.ExecuteSelectedContractRunFork(ctx, runtimerunforkexecution.SelectedContractExecutionRequest{
+	result, err := e.ExecuteSelectedContractRunFork(ctx, runtimerunforkexecution.SelectedContractExecutionRequest{
 		SourceRunID:       strings.TrimSpace(req.SourceRunID),
 		At:                strings.TrimSpace(req.ForkEventID),
 		BundleHash:        strings.TrimSpace(req.BundleHash),
 		BundleSource:      storerunlifecycle.BundleSourcePersisted,
-		Store:             e.Store,
 		SourceLoader:      e.SourceLoader,
 		ContractSelection: selection,
 		AgentRuntime:      e.AgentRuntime,

--- a/internal/dashboard/server/observability_sql.go
+++ b/internal/dashboard/server/observability_sql.go
@@ -130,16 +130,26 @@ type incidentRecord struct {
 	LastSeen   string   `json:"last_seen,omitempty"`
 }
 
+type dashboardObservabilityReadOwner interface {
+	ListOperatorEvents(context.Context, store.OperatorEventListOptions) (store.OperatorEventListResult, error)
+	LoadOperatorEvent(context.Context, string) (store.OperatorEventFull, error)
+	ListOperatorRuntimeLogs(context.Context, store.OperatorRuntimeLogListOptions) (store.OperatorRuntimeLogListResult, error)
+	ListOperatorRuntimeIncidents(context.Context, store.OperatorRuntimeIncidentListOptions) (store.OperatorRuntimeIncidentListResult, error)
+}
+
 type SQLObservabilityReader struct {
-	db        *sql.DB
 	capSource schemaCapabilitySource
+	owner     dashboardObservabilityReadOwner
 }
 
 func NewSQLObservabilityReader(db *sql.DB, capSource schemaCapabilitySource) *SQLObservabilityReader {
 	if db == nil {
 		return nil
 	}
-	return &SQLObservabilityReader{db: db, capSource: capSource}
+	return &SQLObservabilityReader{
+		capSource: capSource,
+		owner:     store.NewOperatorObservabilityReadSurface(db, capSource),
+	}
 }
 
 func (r *SQLObservabilityReader) resolveCapabilities(ctx context.Context) (store.StoreSchemaCapabilities, error) {
@@ -150,7 +160,7 @@ func (r *SQLObservabilityReader) resolveCapabilities(ctx context.Context) (store
 }
 
 func (r *SQLObservabilityReader) ListEvents(ctx context.Context, filter EventFilter, limit int) ([]eventRecord, error) {
-	if r == nil || r.db == nil {
+	if r == nil || r.owner == nil {
 		return []eventRecord{}, nil
 	}
 	caps, err := r.resolveCapabilities(ctx)
@@ -160,8 +170,7 @@ func (r *SQLObservabilityReader) ListEvents(ctx context.Context, filter EventFil
 	if err := requireObservabilityEventCapabilities(caps); err != nil {
 		return nil, err
 	}
-	owner := &store.PostgresStore{DB: r.db}
-	result, err := owner.ListOperatorEvents(ctx, store.OperatorEventListOptions{
+	result, err := r.owner.ListOperatorEvents(ctx, store.OperatorEventListOptions{
 		Filter: store.OperatorEventListFilter{
 			EntityID:       filter.EntityID,
 			EventName:      filter.Type,
@@ -184,7 +193,7 @@ func (r *SQLObservabilityReader) ListEvents(ctx context.Context, filter EventFil
 }
 
 func (r *SQLObservabilityReader) GetEvent(ctx context.Context, id string) (eventRecord, bool, error) {
-	if r == nil || r.db == nil {
+	if r == nil || r.owner == nil {
 		return eventRecord{}, false, nil
 	}
 	caps, err := r.resolveCapabilities(ctx)
@@ -198,8 +207,7 @@ func (r *SQLObservabilityReader) GetEvent(ctx context.Context, id string) (event
 	if id == "" {
 		return eventRecord{}, false, nil
 	}
-	owner := &store.PostgresStore{DB: r.db}
-	event, err := owner.LoadOperatorEvent(ctx, id)
+	event, err := r.owner.LoadOperatorEvent(ctx, id)
 	if err == store.ErrEventNotFound {
 		return eventRecord{}, false, nil
 	}
@@ -210,7 +218,7 @@ func (r *SQLObservabilityReader) GetEvent(ctx context.Context, id string) (event
 }
 
 func (r *SQLObservabilityReader) ListRuntimeLogs(ctx context.Context, filter RuntimeLogFilter, limit int) ([]runtimeLogRecord, error) {
-	if r == nil || r.db == nil {
+	if r == nil || r.owner == nil {
 		return []runtimeLogRecord{}, nil
 	}
 	caps, err := r.resolveCapabilities(ctx)
@@ -220,8 +228,7 @@ func (r *SQLObservabilityReader) ListRuntimeLogs(ctx context.Context, filter Run
 	if err := requireObservabilityRuntimeLogCapabilities(caps); err != nil {
 		return nil, err
 	}
-	owner := &store.PostgresStore{DB: r.db}
-	result, err := owner.ListOperatorRuntimeLogs(ctx, store.OperatorRuntimeLogListOptions{
+	result, err := r.owner.ListOperatorRuntimeLogs(ctx, store.OperatorRuntimeLogListOptions{
 		EntityID:          filter.EntityID,
 		Component:         filter.Component,
 		Level:             filter.Level,
@@ -243,7 +250,7 @@ func (r *SQLObservabilityReader) ListRuntimeLogs(ctx context.Context, filter Run
 }
 
 func (r *SQLObservabilityReader) ListIncidents(ctx context.Context, filter IncidentFilter) ([]incidentRecord, error) {
-	if r == nil || r.db == nil {
+	if r == nil || r.owner == nil {
 		return []incidentRecord{}, nil
 	}
 	caps, err := r.resolveCapabilities(ctx)
@@ -253,8 +260,7 @@ func (r *SQLObservabilityReader) ListIncidents(ctx context.Context, filter Incid
 	if err := requireObservabilityRuntimeLogCapabilities(caps); err != nil {
 		return nil, err
 	}
-	owner := &store.PostgresStore{DB: r.db}
-	result, err := owner.ListOperatorRuntimeIncidents(ctx, store.OperatorRuntimeIncidentListOptions{
+	result, err := r.owner.ListOperatorRuntimeIncidents(ctx, store.OperatorRuntimeIncidentListOptions{
 		SinceHours: filter.SinceHours,
 		Component:  filter.Component,
 		Level:      filter.Level,

--- a/internal/dashboard/server/observability_sql.go
+++ b/internal/dashboard/server/observability_sql.go
@@ -160,7 +160,7 @@ func (r *SQLObservabilityReader) resolveCapabilities(ctx context.Context) (store
 }
 
 func (r *SQLObservabilityReader) ListEvents(ctx context.Context, filter EventFilter, limit int) ([]eventRecord, error) {
-	if r == nil || r.owner == nil {
+	if r == nil {
 		return []eventRecord{}, nil
 	}
 	caps, err := r.resolveCapabilities(ctx)
@@ -169,6 +169,9 @@ func (r *SQLObservabilityReader) ListEvents(ctx context.Context, filter EventFil
 	}
 	if err := requireObservabilityEventCapabilities(caps); err != nil {
 		return nil, err
+	}
+	if r.owner == nil {
+		return []eventRecord{}, nil
 	}
 	result, err := r.owner.ListOperatorEvents(ctx, store.OperatorEventListOptions{
 		Filter: store.OperatorEventListFilter{
@@ -193,7 +196,7 @@ func (r *SQLObservabilityReader) ListEvents(ctx context.Context, filter EventFil
 }
 
 func (r *SQLObservabilityReader) GetEvent(ctx context.Context, id string) (eventRecord, bool, error) {
-	if r == nil || r.owner == nil {
+	if r == nil {
 		return eventRecord{}, false, nil
 	}
 	caps, err := r.resolveCapabilities(ctx)
@@ -202,6 +205,9 @@ func (r *SQLObservabilityReader) GetEvent(ctx context.Context, id string) (event
 	}
 	if err := requireObservabilityEventCapabilities(caps); err != nil {
 		return eventRecord{}, false, err
+	}
+	if r.owner == nil {
+		return eventRecord{}, false, nil
 	}
 	id = strings.TrimSpace(id)
 	if id == "" {
@@ -218,7 +224,7 @@ func (r *SQLObservabilityReader) GetEvent(ctx context.Context, id string) (event
 }
 
 func (r *SQLObservabilityReader) ListRuntimeLogs(ctx context.Context, filter RuntimeLogFilter, limit int) ([]runtimeLogRecord, error) {
-	if r == nil || r.owner == nil {
+	if r == nil {
 		return []runtimeLogRecord{}, nil
 	}
 	caps, err := r.resolveCapabilities(ctx)
@@ -227,6 +233,9 @@ func (r *SQLObservabilityReader) ListRuntimeLogs(ctx context.Context, filter Run
 	}
 	if err := requireObservabilityRuntimeLogCapabilities(caps); err != nil {
 		return nil, err
+	}
+	if r.owner == nil {
+		return []runtimeLogRecord{}, nil
 	}
 	result, err := r.owner.ListOperatorRuntimeLogs(ctx, store.OperatorRuntimeLogListOptions{
 		EntityID:          filter.EntityID,
@@ -250,7 +259,7 @@ func (r *SQLObservabilityReader) ListRuntimeLogs(ctx context.Context, filter Run
 }
 
 func (r *SQLObservabilityReader) ListIncidents(ctx context.Context, filter IncidentFilter) ([]incidentRecord, error) {
-	if r == nil || r.owner == nil {
+	if r == nil {
 		return []incidentRecord{}, nil
 	}
 	caps, err := r.resolveCapabilities(ctx)
@@ -259,6 +268,9 @@ func (r *SQLObservabilityReader) ListIncidents(ctx context.Context, filter Incid
 	}
 	if err := requireObservabilityRuntimeLogCapabilities(caps); err != nil {
 		return nil, err
+	}
+	if r.owner == nil {
+		return []incidentRecord{}, nil
 	}
 	result, err := r.owner.ListOperatorRuntimeIncidents(ctx, store.OperatorRuntimeIncidentListOptions{
 		SinceHours: filter.SinceHours,

--- a/internal/dashboard/server/observability_sql_test.go
+++ b/internal/dashboard/server/observability_sql_test.go
@@ -27,9 +27,11 @@ func (s stubObservabilityCaps) ResolveSchemaCapabilities(context.Context) (store
 func canonicalObservabilityCaps() store.StoreSchemaCapabilities {
 	return store.StoreSchemaCapabilities{
 		Events: store.EventSchemaCapabilities{
-			Log:        store.SchemaFlavorCanonical,
-			Deliveries: store.SchemaFlavorCanonical,
-			Receipts:   store.SchemaFlavorCanonical,
+			Log:           store.SchemaFlavorCanonical,
+			Deliveries:    store.SchemaFlavorCanonical,
+			Receipts:      store.SchemaFlavorCanonical,
+			LogRunID:      true,
+			DeliveryRunID: true,
 		},
 	}
 }

--- a/internal/store/operator_observability_read_surface.go
+++ b/internal/store/operator_observability_read_surface.go
@@ -157,11 +157,53 @@ type observabilityPositionCursor struct {
 	LastSeen  string `json:"last_seen,omitempty"`
 }
 
-func (s *PostgresStore) requireOperatorObservabilityCapabilities(ctx context.Context) error {
-	if s == nil || s.DB == nil {
-		return fmt.Errorf("postgres store is required")
+type OperatorObservabilityCapabilitySource interface {
+	ResolveSchemaCapabilities(ctx context.Context) (StoreSchemaCapabilities, error)
+}
+
+type OperatorObservabilityReadSurface struct {
+	db        *sql.DB
+	capSource OperatorObservabilityCapabilitySource
+}
+
+func NewOperatorObservabilityReadSurface(db *sql.DB, capSource OperatorObservabilityCapabilitySource) *OperatorObservabilityReadSurface {
+	if db == nil || capSource == nil {
+		return nil
 	}
-	caps, err := s.schemaCapabilities(ctx)
+	return &OperatorObservabilityReadSurface{db: db, capSource: capSource}
+}
+
+func (s *PostgresStore) operatorObservabilityReadSurface() *OperatorObservabilityReadSurface {
+	if s == nil {
+		return nil
+	}
+	return NewOperatorObservabilityReadSurface(s.DB, s)
+}
+
+func (s *PostgresStore) ListOperatorEvents(ctx context.Context, opts OperatorEventListOptions) (OperatorEventListResult, error) {
+	return s.operatorObservabilityReadSurface().ListOperatorEvents(ctx, opts)
+}
+
+func (s *PostgresStore) LoadOperatorEvent(ctx context.Context, eventID string) (OperatorEventFull, error) {
+	return s.operatorObservabilityReadSurface().LoadOperatorEvent(ctx, eventID)
+}
+
+func (s *PostgresStore) ListOperatorRuntimeLogs(ctx context.Context, opts OperatorRuntimeLogListOptions) (OperatorRuntimeLogListResult, error) {
+	return s.operatorObservabilityReadSurface().ListOperatorRuntimeLogs(ctx, opts)
+}
+
+func (s *PostgresStore) ListOperatorRuntimeIncidents(ctx context.Context, opts OperatorRuntimeIncidentListOptions) (OperatorRuntimeIncidentListResult, error) {
+	return s.operatorObservabilityReadSurface().ListOperatorRuntimeIncidents(ctx, opts)
+}
+
+func (r *OperatorObservabilityReadSurface) requireOperatorObservabilityCapabilities(ctx context.Context) error {
+	if r == nil || r.db == nil {
+		return fmt.Errorf("operator observability read surface is required")
+	}
+	if r.capSource == nil {
+		return fmt.Errorf("operator observability read surface requires schema capabilities")
+	}
+	caps, err := r.capSource.ResolveSchemaCapabilities(ctx)
 	if err != nil {
 		return err
 	}
@@ -175,7 +217,7 @@ func (s *PostgresStore) requireOperatorObservabilityCapabilities(ctx context.Con
 	case !caps.Events.DeliveryRunID:
 		return fmt.Errorf("operator observability read surface requires canonical event_deliveries.run_id")
 	}
-	catalog, err := loadSchemaColumnCatalog(ctx, s.DB)
+	catalog, err := loadSchemaColumnCatalog(ctx, r.db)
 	if err != nil {
 		return err
 	}
@@ -205,8 +247,8 @@ func (s *PostgresStore) requireOperatorObservabilityCapabilities(ctx context.Con
 	return nil
 }
 
-func (s *PostgresStore) ListOperatorEvents(ctx context.Context, opts OperatorEventListOptions) (OperatorEventListResult, error) {
-	if err := s.requireOperatorObservabilityCapabilities(ctx); err != nil {
+func (r *OperatorObservabilityReadSurface) ListOperatorEvents(ctx context.Context, opts OperatorEventListOptions) (OperatorEventListResult, error) {
+	if err := r.requireOperatorObservabilityCapabilities(ctx); err != nil {
 		return OperatorEventListResult{}, err
 	}
 	opts = defaultOperatorEventListOptions(opts)
@@ -301,7 +343,7 @@ func (s *PostgresStore) ListOperatorEvents(ctx context.Context, opts OperatorEve
 	if opts.Order == "asc" {
 		orderSQL = "ASC"
 	}
-	rows, err := s.DB.QueryContext(ctx, `
+	rows, err := r.db.QueryContext(ctx, `
 		SELECT e.event_id::text
 		FROM events e
 		WHERE `+strings.Join(where, " AND ")+fmt.Sprintf(`
@@ -325,7 +367,7 @@ func (s *PostgresStore) ListOperatorEvents(ctx context.Context, opts OperatorEve
 	}
 	events := make([]OperatorEventFull, 0, minInt(len(ids), opts.Limit))
 	for _, id := range ids {
-		event, err := s.LoadOperatorEvent(ctx, id)
+		event, err := r.LoadOperatorEvent(ctx, id)
 		if err != nil {
 			return OperatorEventListResult{}, err
 		}
@@ -348,15 +390,15 @@ func (s *PostgresStore) ListOperatorEvents(ctx context.Context, opts OperatorEve
 	return OperatorEventListResult{Events: events, NextCursor: nextCursor}, nil
 }
 
-func (s *PostgresStore) LoadOperatorEvent(ctx context.Context, eventID string) (OperatorEventFull, error) {
-	if err := s.requireOperatorObservabilityCapabilities(ctx); err != nil {
+func (r *OperatorObservabilityReadSurface) LoadOperatorEvent(ctx context.Context, eventID string) (OperatorEventFull, error) {
+	if err := r.requireOperatorObservabilityCapabilities(ctx); err != nil {
 		return OperatorEventFull{}, err
 	}
 	eventID = strings.TrimSpace(eventID)
 	if eventID == "" {
 		return OperatorEventFull{}, ErrEventNotFound
 	}
-	row := s.DB.QueryRowContext(ctx, `
+	row := r.db.QueryRowContext(ctx, `
 		SELECT
 			e.event_id::text,
 			COALESCE(e.event_name, ''),
@@ -387,11 +429,11 @@ func (s *PostgresStore) LoadOperatorEvent(ctx context.Context, eventID string) (
 		return OperatorEventFull{}, fmt.Errorf("decode operator event payload: %w", err)
 	}
 	event.Payload = payload
-	deadLetters, err := s.loadOperatorEventDeadLetters(ctx, event.EventID)
+	deadLetters, err := r.loadOperatorEventDeadLetters(ctx, event.EventID)
 	if err != nil {
 		return OperatorEventFull{}, err
 	}
-	deliveries, err := s.loadOperatorEventDeliveries(ctx, event.EventID)
+	deliveries, err := r.loadOperatorEventDeliveries(ctx, event.EventID)
 	if err != nil {
 		return OperatorEventFull{}, err
 	}
@@ -406,8 +448,8 @@ func (s *PostgresStore) LoadOperatorEvent(ctx context.Context, eventID string) (
 	return event, nil
 }
 
-func (s *PostgresStore) loadOperatorEventDeliveries(ctx context.Context, eventID string) ([]OperatorEventDelivery, error) {
-	rows, err := s.DB.QueryContext(ctx, `
+func (r *OperatorObservabilityReadSurface) loadOperatorEventDeliveries(ctx context.Context, eventID string) ([]OperatorEventDelivery, error) {
+	rows, err := r.db.QueryContext(ctx, `
 		SELECT
 			d.delivery_id::text,
 			COALESCE(d.subscriber_type, ''),
@@ -497,8 +539,8 @@ func nullTimePtr(value sql.NullTime) *time.Time {
 	return &at
 }
 
-func (s *PostgresStore) loadOperatorEventDeadLetters(ctx context.Context, eventID string) ([]OperatorDeadLetterRecord, error) {
-	rows, err := s.DB.QueryContext(ctx, `
+func (r *OperatorObservabilityReadSurface) loadOperatorEventDeadLetters(ctx context.Context, eventID string) ([]OperatorDeadLetterRecord, error) {
+	rows, err := r.db.QueryContext(ctx, `
 		SELECT
 			dl.dead_letter_id::text,
 			COALESCE(dl.failure_type, ''),
@@ -529,8 +571,8 @@ func (s *PostgresStore) loadOperatorEventDeadLetters(ctx context.Context, eventI
 	return out, nil
 }
 
-func (s *PostgresStore) ListOperatorRuntimeLogs(ctx context.Context, opts OperatorRuntimeLogListOptions) (OperatorRuntimeLogListResult, error) {
-	if err := s.requireOperatorObservabilityCapabilities(ctx); err != nil {
+func (r *OperatorObservabilityReadSurface) ListOperatorRuntimeLogs(ctx context.Context, opts OperatorRuntimeLogListOptions) (OperatorRuntimeLogListResult, error) {
+	if err := r.requireOperatorObservabilityCapabilities(ctx); err != nil {
 		return OperatorRuntimeLogListResult{}, err
 	}
 	opts = defaultOperatorRuntimeLogListOptions(opts)
@@ -570,7 +612,7 @@ func (s *PostgresStore) ListOperatorRuntimeLogs(ctx context.Context, opts Operat
 		compareOrder = "ASC"
 	}
 	args = append(args, opts.Limit+1)
-	rows, err := s.DB.QueryContext(ctx, fmt.Sprintf(`
+	rows, err := r.db.QueryContext(ctx, fmt.Sprintf(`
 		SELECT
 			e.event_id::text,
 			COALESCE(e.run_id::text, ''),
@@ -641,13 +683,13 @@ func (s *PostgresStore) ListOperatorRuntimeLogs(ctx context.Context, opts Operat
 	return OperatorRuntimeLogListResult{Logs: logs, NextCursor: nextCursor}, nil
 }
 
-func (s *PostgresStore) ListOperatorRuntimeIncidents(ctx context.Context, opts OperatorRuntimeIncidentListOptions) (OperatorRuntimeIncidentListResult, error) {
-	if err := s.requireOperatorObservabilityCapabilities(ctx); err != nil {
+func (r *OperatorObservabilityReadSurface) ListOperatorRuntimeIncidents(ctx context.Context, opts OperatorRuntimeIncidentListOptions) (OperatorRuntimeIncidentListResult, error) {
+	if err := r.requireOperatorObservabilityCapabilities(ctx); err != nil {
 		return OperatorRuntimeIncidentListResult{}, err
 	}
 	opts = defaultOperatorRuntimeIncidentListOptions(opts)
 	cutoff := time.Now().UTC().Add(-time.Duration(opts.SinceHours) * time.Hour)
-	rows, err := s.DB.QueryContext(ctx, `
+	rows, err := r.db.QueryContext(ctx, `
 		SELECT
 			e.event_id::text,
 			COALESCE(e.run_id::text, ''),

--- a/internal/store/run_debug_read_surface.go
+++ b/internal/store/run_debug_read_surface.go
@@ -731,7 +731,7 @@ func (s *PostgresStore) loadRunDebugFailureDeliveries(ctx context.Context, runID
 		item.FinishedAt = nullTimePtr(finishedAt)
 		normalizeRunDebugFailureDelivery(&item)
 		if item.Status == "dead_letter" {
-			deadLetters, err := s.loadOperatorEventDeadLetters(ctx, item.EventID)
+			deadLetters, err := s.operatorObservabilityReadSurface().loadOperatorEventDeadLetters(ctx, item.EventID)
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
## Summary
- Moves selected API/store capability ownership out of producer-side `Postgres` checks and into explicit selected store bundle fields populated at construction.
- Keeps backend construction in `buildStores` / selected construction helpers, while `store_facade.go`, API setup, run-stalled, and run-fork public execution consume typed selected owners.
- Replaces dashboard observability local `PostgresStore` reconstruction with a store-owned observability read surface.
- Tightens the facade guard so `store_facade.go` no longer has a whole-file backend allowlist.

Closes #1401
Part of #1400

## Governing References
- `platform-spec.yaml` / `runtime_core_persistence_store_contracts.selected_contracts.runtime_store_bundle_construction`
- `platform-spec.yaml` / `runtime_core_persistence_store_contracts.selected_runtime_store_facade`
- `platform-spec.yaml` / `runtime_core_persistence_store_contracts.selected_runtime_store_capability_model`
- `platform-spec.yaml` / `runtime_core_persistence_store_contracts.backend_neutral_runtime_mutation_write_boundary`
- `platform-spec.yaml` / `runtime_core_persistence_store_contracts.raw_sql_runtime_consumer_boundary_for_sqlite`
- Binding issue/gate context: #1401 pre-implementation audit and lead gate approving the first-slice boundary.

## Semantic Migration
- New canonical owner: selected runtime store bundle capability fields constructed by `buildStores` / `selectedPostgresStoreBundle`, then consumed by `selectedRuntimeStoreFacade` and API/dashboard surfaces.
- Old producer paths now invalid: `store_facade.go` choosing behavior from `f.stores.Postgres`, public `SelectedContractRunForkExecutor.Store`, and dashboard observability rebuilding `&store.PostgresStore{DB: ...}`.
- Checked surviving old behavior: production scan for `f.stores.Postgres`, `stores.Postgres`, dashboard `&store.PostgresStore`, and public run-fork `Store` wiring outside tests.
- Migration completeness: complete for the approved #1401 first slice. Raw SQL/runtime mutation/UoW and broader store abstraction remain split under their own tracker issues.

## Validation
- `go test ./cmd/swarm -run 'TestSelectedStoreFacade|TestBuildStores|TestRunServeRuntimeEventPublish|TestCLIRuntimeStateAPIConsumersAreExplicitlyAccounted|TestServeRunStalled|TestPrepareServeBundleSource|TestRunServeRuntimeDBLoaded' -count=1`
- `go test ./internal/apiv1 -run 'TestOperatorEntityHandlersServeContractEntityTypesFrom(SQLite|Postgres)|TestSQLiteObservabilitySupportedSurface|TestSQLiteAgentUsageSupportedSurface|TestOperatorRunFork|TestOperatorRead|TestOpenRPC|TestOperatorEventPublish' -count=1`
- `go test ./internal/dashboard/server -run 'TestSQLObservabilityReader|TestHandler_RunLifecycleOverAPIAliases|TestHandler_.*Dashboard' -count=1`
- `go test ./internal/store -run 'TestSelectedSQLiteRuntimeWriterBoundaryAudit|TestSQLiteObservability|TestOperatorObservability|TestRunDebug' -count=1`
- `go test ./internal/runtime/conformance -run 'Test.*(SQLite|Postgres|Dashboard|Served|Public|Surface)' -count=1`
- `go test ./...`
