### PR TITLE
[agent-c][issue #1402] Add selected store abstraction proof matrix

### DIFF
--- a/cmd/swarm/store_facade_guard_test.go
+++ b/cmd/swarm/store_facade_guard_test.go
@@ -3,11 +3,53 @@ package main
 import (
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 )
 
 func TestSelectedStoreFacadeOwnsProducerBackendBranching(t *testing.T) {
+	files, err := os.ReadDir(".")
+	if err != nil {
+		t.Fatalf("read cmd/swarm: %v", err)
+	}
+	var failures []string
+	for _, file := range files {
+		name := file.Name()
+		if file.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		path := filepath.Join("cmd", "swarm", name)
+		body, err := os.ReadFile(name)
+		if err != nil {
+			t.Fatalf("read %s: %v", name, err)
+		}
+		failures = append(failures, selectedStoreFacadeProducerBackendReferences(path, string(body))...)
+	}
+	if len(failures) > 0 {
+		t.Fatalf("producer-side backend references outside selected store facade/construction boundary:\n%s", strings.Join(failures, "\n"))
+	}
+}
+
+func TestSelectedStoreFacadeBackendBranchingGuardRejectsProducerFixture(t *testing.T) {
+	const src = `package main
+
+func buildPublicSurfaceFromStore(stores storeBundle) {
+	if stores.Postgres != nil {
+		panic("producer inferred capability from concrete backend")
+	}
+}
+`
+	failures := selectedStoreFacadeProducerBackendReferences(filepath.Join("cmd", "swarm", "fixture.go"), src)
+	if len(failures) == 0 {
+		t.Fatal("expected producer-side concrete backend fixture to fail the guard")
+	}
+	if !strings.Contains(strings.Join(failures, "\n"), "stores.Postgres") {
+		t.Fatalf("expected failure to name stores.Postgres, got:\n%s", strings.Join(failures, "\n"))
+	}
+}
+
+func selectedStoreFacadeProducerBackendReferences(path, body string) []string {
 	allowed := map[string][]string{
 		filepath.Join("cmd", "swarm", "main.go"): {
 			"*store.PostgresStore",
@@ -31,33 +73,20 @@ func TestSelectedStoreFacadeOwnsProducerBackendBranching(t *testing.T) {
 		"RuntimeSQLDB",
 		"postgres bool",
 	}
-	files, err := os.ReadDir(".")
-	if err != nil {
-		t.Fatalf("read cmd/swarm: %v", err)
-	}
-	for _, file := range files {
-		name := file.Name()
-		if file.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
-			continue
-		}
-		path := filepath.Join("cmd", "swarm", name)
-		body, err := os.ReadFile(name)
-		if err != nil {
-			t.Fatalf("read %s: %v", name, err)
-		}
-		lines := strings.Split(string(body), "\n")
-		for i, line := range lines {
-			for _, token := range forbidden {
-				if !strings.Contains(line, token) {
-					continue
-				}
-				if storeFacadeGuardAllowed(path, line, allowed[path]) {
-					continue
-				}
-				t.Fatalf("%s:%d contains producer-side backend reference %q outside selected store facade/construction boundary: %s", path, i+1, token, strings.TrimSpace(line))
+	var failures []string
+	lines := strings.Split(body, "\n")
+	for i, line := range lines {
+		for _, token := range forbidden {
+			if !strings.Contains(line, token) {
+				continue
 			}
+			if storeFacadeGuardAllowed(path, line, allowed[path]) {
+				continue
+			}
+			failures = append(failures, filepath.ToSlash(path)+":"+strconv.Itoa(i+1)+" contains producer-side backend reference "+strconv.Quote(token)+": "+strings.TrimSpace(line))
 		}
 	}
+	return failures
 }
 
 func storeFacadeGuardAllowed(path, line string, allowed []string) bool {

--- a/internal/apiv1/public_surface_backend_matrix_test.go
+++ b/internal/apiv1/public_surface_backend_matrix_test.go
@@ -171,12 +171,54 @@ func TestPublicSurfaceBackendMatrixRejectsStaleReferences(t *testing.T) {
 			want: "api_idempotency_selected_store missing #1402 proof_ref TestOperatorRunStartHandlersPersistRootEventAndReplayIdempotency",
 		},
 		{
+			name: "api idempotency row classification is pinned",
+			mutate: func(matrix *publicSurfaceBackendMatrix) {
+				row := publicSurfaceMatrixRowByID(t, matrix, "api_idempotency_selected_store")
+				row.Classification = "different_semantic_concept_with_proof"
+			},
+			want: "api_idempotency_selected_store classification = \"different_semantic_concept_with_proof\", want \"already_covered_by_existing_proof\"",
+		},
+		{
+			name: "api idempotency row keeps both selected backends",
+			mutate: func(matrix *publicSurfaceBackendMatrix) {
+				row := publicSurfaceMatrixRowByID(t, matrix, "api_idempotency_selected_store")
+				row.Backends = []string{"explicit_postgres"}
+			},
+			want: "api_idempotency_selected_store backends = [explicit_postgres], want [default_sqlite explicit_postgres]",
+		},
+		{
+			name: "api idempotency row keeps run.start method dimensions",
+			mutate: func(matrix *publicSurfaceBackendMatrix) {
+				row := publicSurfaceMatrixRowByID(t, matrix, "api_idempotency_selected_store")
+				row.APIMethods = []string{"event.publish"}
+				row.OpenRPCMatrixMethods = []string{"event.publish"}
+			},
+			want: "api_idempotency_selected_store api_methods = [event.publish], want [event.publish run.start]",
+		},
+		{
 			name: "runtime log readback row requires sqlite proof",
 			mutate: func(matrix *publicSurfaceBackendMatrix) {
 				row := publicSurfaceMatrixRowByID(t, matrix, "runtime_log_readback_api")
 				row.ProofRefs = publicSurfaceProofRefsExcept(row.ProofRefs, "TestSQLiteRuntimeLogPersistenceWritesLoggerRowsForObservability")
 			},
 			want: "runtime_log_readback_api missing #1402 proof_ref TestSQLiteRuntimeLogPersistenceWritesLoggerRowsForObservability",
+		},
+		{
+			name: "runtime log readback row keeps subscribe logs method",
+			mutate: func(matrix *publicSurfaceBackendMatrix) {
+				row := publicSurfaceMatrixRowByID(t, matrix, "runtime_log_readback_api")
+				row.APIMethods = publicSurfaceStringsExcept(row.APIMethods, "runtime.subscribe_logs")
+				row.OpenRPCMatrixMethods = publicSurfaceStringsExcept(row.OpenRPCMatrixMethods, "runtime.subscribe_logs")
+			},
+			want: "runtime_log_readback_api api_methods = [run.trace runtime.logs], want [run.trace runtime.logs runtime.subscribe_logs]",
+		},
+		{
+			name: "runtime log readback row keeps selected store dimension",
+			mutate: func(matrix *publicSurfaceBackendMatrix) {
+				row := publicSurfaceMatrixRowByID(t, matrix, "runtime_log_readback_api")
+				row.ProofDimensions = publicSurfaceStringsExcept(row.ProofDimensions, "selected_store")
+			},
+			want: "runtime_log_readback_api proof_dimensions = [canonical_store_owner openrpc_publication real_v1_handler], want [canonical_store_owner openrpc_publication real_v1_handler selected_store]",
 		},
 	}
 
@@ -359,8 +401,68 @@ func validatePublicSurfaceBackendMatrix(root string, matrix publicSurfaceBackend
 			}
 		}
 	}
+	problems = append(problems, validatePublicSurfaceExpectedRowShapes(rowsByID)...)
 	sort.Strings(problems)
 	return problems
+}
+
+type publicSurfaceExpectedRowShape struct {
+	Classification       string
+	Tier                 string
+	Backends             []string
+	APIMethods           []string
+	OpenRPCMatrixMethods []string
+	ProofDimensions      []string
+}
+
+func validatePublicSurfaceExpectedRowShapes(rowsByID map[string]publicSurfaceMatrixRow) []string {
+	var problems []string
+	for id, want := range expectedPublicSurfaceRowShapes() {
+		row, ok := rowsByID[id]
+		if !ok {
+			continue
+		}
+		if row.Classification != want.Classification {
+			problems = append(problems, fmt.Sprintf("%s classification = %q, want %q", id, row.Classification, want.Classification))
+		}
+		if row.Tier != want.Tier {
+			problems = append(problems, fmt.Sprintf("%s tier = %q, want %q", id, row.Tier, want.Tier))
+		}
+		if !publicSurfaceSameStringSet(row.Backends, want.Backends) {
+			problems = append(problems, fmt.Sprintf("%s backends = %v, want %v", id, publicSurfaceSortedStrings(row.Backends), publicSurfaceSortedStrings(want.Backends)))
+		}
+		if !publicSurfaceSameStringSet(row.APIMethods, want.APIMethods) {
+			problems = append(problems, fmt.Sprintf("%s api_methods = %v, want %v", id, publicSurfaceSortedStrings(row.APIMethods), publicSurfaceSortedStrings(want.APIMethods)))
+		}
+		if !publicSurfaceSameStringSet(row.OpenRPCMatrixMethods, want.OpenRPCMatrixMethods) {
+			problems = append(problems, fmt.Sprintf("%s openrpc_matrix_methods = %v, want %v", id, publicSurfaceSortedStrings(row.OpenRPCMatrixMethods), publicSurfaceSortedStrings(want.OpenRPCMatrixMethods)))
+		}
+		if !publicSurfaceSameStringSet(row.ProofDimensions, want.ProofDimensions) {
+			problems = append(problems, fmt.Sprintf("%s proof_dimensions = %v, want %v", id, publicSurfaceSortedStrings(row.ProofDimensions), publicSurfaceSortedStrings(want.ProofDimensions)))
+		}
+	}
+	return problems
+}
+
+func expectedPublicSurfaceRowShapes() map[string]publicSurfaceExpectedRowShape {
+	return map[string]publicSurfaceExpectedRowShape{
+		"api_idempotency_selected_store": {
+			Classification:       "already_covered_by_existing_proof",
+			Tier:                 "required_smoke",
+			Backends:             []string{"default_sqlite", "explicit_postgres"},
+			APIMethods:           []string{"event.publish", "run.start"},
+			OpenRPCMatrixMethods: []string{"event.publish", "run.start"},
+			ProofDimensions:      []string{"canonical_store_owner", "openrpc_publication", "real_v1_handler", "selected_store"},
+		},
+		"runtime_log_readback_api": {
+			Classification:       "already_covered_by_existing_proof",
+			Tier:                 "required_smoke",
+			Backends:             []string{"default_sqlite", "explicit_postgres"},
+			APIMethods:           []string{"runtime.logs", "runtime.subscribe_logs", "run.trace"},
+			OpenRPCMatrixMethods: []string{"runtime.logs", "runtime.subscribe_logs", "run.trace"},
+			ProofDimensions:      []string{"canonical_store_owner", "openrpc_publication", "real_v1_handler", "selected_store"},
+		},
+	}
 }
 
 func validatePublicSurfaceSources(root string, source publicSurfaceMatrixSource) []string {
@@ -689,6 +791,37 @@ func publicSurfaceProofRefsExcept(refs []publicSurfaceProofRef, name string) []p
 		}
 		out = append(out, ref)
 	}
+	return out
+}
+
+func publicSurfaceStringsExcept(values []string, remove string) []string {
+	out := values[:0]
+	for _, value := range values {
+		if value == remove {
+			continue
+		}
+		out = append(out, value)
+	}
+	return out
+}
+
+func publicSurfaceSameStringSet(actual, want []string) bool {
+	actualSorted := publicSurfaceSortedStrings(actual)
+	wantSorted := publicSurfaceSortedStrings(want)
+	if len(actualSorted) != len(wantSorted) {
+		return false
+	}
+	for i := range actualSorted {
+		if actualSorted[i] != wantSorted[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func publicSurfaceSortedStrings(values []string) []string {
+	out := append([]string(nil), values...)
+	sort.Strings(out)
 	return out
 }
 

--- a/internal/apiv1/public_surface_backend_matrix_test.go
+++ b/internal/apiv1/public_surface_backend_matrix_test.go
@@ -162,6 +162,22 @@ func TestPublicSurfaceBackendMatrixRejectsStaleReferences(t *testing.T) {
 			},
 			want: "bundle_hash_catalog_boot_postgres_only fail-closed row requires at least one go_test proof_ref",
 		},
+		{
+			name: "api idempotency row requires run.start proof",
+			mutate: func(matrix *publicSurfaceBackendMatrix) {
+				row := publicSurfaceMatrixRowByID(t, matrix, "api_idempotency_selected_store")
+				row.ProofRefs = publicSurfaceProofRefsExcept(row.ProofRefs, "TestOperatorRunStartHandlersPersistRootEventAndReplayIdempotency")
+			},
+			want: "api_idempotency_selected_store missing #1402 proof_ref TestOperatorRunStartHandlersPersistRootEventAndReplayIdempotency",
+		},
+		{
+			name: "runtime log readback row requires sqlite proof",
+			mutate: func(matrix *publicSurfaceBackendMatrix) {
+				row := publicSurfaceMatrixRowByID(t, matrix, "runtime_log_readback_api")
+				row.ProofRefs = publicSurfaceProofRefsExcept(row.ProofRefs, "TestSQLiteRuntimeLogPersistenceWritesLoggerRowsForObservability")
+			},
+			want: "runtime_log_readback_api missing #1402 proof_ref TestSQLiteRuntimeLogPersistenceWritesLoggerRowsForObservability",
+		},
 	}
 
 	for _, tc := range tests {
@@ -316,6 +332,30 @@ func validatePublicSurfaceBackendMatrix(root string, matrix publicSurfaceBackend
 		} {
 			if !publicSurfaceHasGoTestProof(row.ProofRefs, proof) {
 				problems = append(problems, fmt.Sprintf("status_run_get_entity_count missing post-#1254 proof_ref %s", proof))
+			}
+		}
+	}
+	if row, ok := rowsByID["api_idempotency_selected_store"]; ok {
+		for _, proof := range []string{
+			"TestOperatorRunStartHandlersPersistRootEventAndReplayIdempotency",
+			"TestOperatorEventPublishSQLiteIdempotentFirstEventPublishesWithoutLock",
+			"TestOperatorEventPublishHandlersPersistEventReportDeliveriesAndReplayIdempotency",
+		} {
+			if !publicSurfaceHasGoTestProof(row.ProofRefs, proof) {
+				problems = append(problems, fmt.Sprintf("api_idempotency_selected_store missing #1402 proof_ref %s", proof))
+			}
+		}
+	}
+	if row, ok := rowsByID["runtime_log_readback_api"]; ok {
+		for _, proof := range []string{
+			"TestSQLiteRuntimeLogPersistenceWritesLoggerRowsForObservability",
+			"TestPostgresRuntimeLogPersistencePreservesRunSourceAndLineage",
+			"TestOpenRPCWebSocketRuntimeProbes",
+			"TestHandlerWebSocketRuntimeSubscribeLogsUsesOwnerFiltersAndReplay",
+			"TestHandlerWebSocketRunSubscribeTraceUsesOwnerReplayAndRunNotFound",
+		} {
+			if !publicSurfaceHasGoTestProof(row.ProofRefs, proof) {
+				problems = append(problems, fmt.Sprintf("runtime_log_readback_api missing #1402 proof_ref %s", proof))
 			}
 		}
 	}
@@ -641,6 +681,17 @@ func publicSurfaceHasGoTestProof(refs []publicSurfaceProofRef, want string) bool
 	return false
 }
 
+func publicSurfaceProofRefsExcept(refs []publicSurfaceProofRef, name string) []publicSurfaceProofRef {
+	out := refs[:0]
+	for _, ref := range refs {
+		if ref.Kind == "go_test" && ref.Name == name {
+			continue
+		}
+		out = append(out, ref)
+	}
+	return out
+}
+
 func requiredPublicSurfaceRows() map[string]struct{} {
 	return complianceStringSet([]string{
 		"serve_contracts_default_sqlite",
@@ -651,8 +702,10 @@ func requiredPublicSurfaceRows() map[string]struct{} {
 		"entity_read_cli",
 		"status_run_get_entity_count",
 		"event_publish_api",
+		"api_idempotency_selected_store",
 		"event_publish_cli",
 		"event_publish_existing_run_followup_served_path",
+		"runtime_log_readback_api",
 		"mailbox_read_api_after_mailbox_write",
 		"mailbox_read_cli",
 		"serve_dev_abandon_active_runs",

--- a/internal/apiv1/testdata/public_surface_backend_matrix.yaml
+++ b/internal/apiv1/testdata/public_surface_backend_matrix.yaml
@@ -214,6 +214,31 @@ rows:
       served follow-up state advance is covered by the dedicated served-path
       row below.
 
+  - id: api_idempotency_selected_store
+    surface: selected-store API idempotency rows for mutating public methods
+    classification: already_covered_by_existing_proof
+    tier: required_smoke
+    backends: [default_sqlite, explicit_postgres]
+    api_methods: [event.publish, run.start]
+    openrpc_matrix_methods: [event.publish, run.start]
+    store_owners:
+      - selectedRuntimeStoreFacade.apiCapabilities
+      - apiv1.APIIdempotencyStore
+      - internal/store API idempotency persistence
+    proof_dimensions: [selected_store, real_v1_handler, canonical_store_owner, openrpc_publication]
+    proof_refs:
+      - kind: go_test
+        name: TestOperatorRunStartHandlersPersistRootEventAndReplayIdempotency
+      - kind: go_test
+        name: TestOperatorEventPublishSQLiteIdempotentFirstEventPublishesWithoutLock
+      - kind: go_test
+        name: TestOperatorEventPublishHandlersPersistEventReportDeliveriesAndReplayIdempotency
+    notes: >
+      #1402 promotes API idempotency to first-class selected-store accounting.
+      The row proves representative mutating public methods consume selected
+      store idempotency owners without duplicating every idempotent OpenRPC
+      method across both backends.
+
   - id: event_publish_cli
     surface: swarm event publish create-new publication and exact v1 RPC command shape
     classification: already_covered_by_existing_proof
@@ -298,6 +323,34 @@ rows:
       dispatch/readback, trace/status/diagnose surfaces, and durable
       event.publish acceptance. This row does not claim full #1386 structural
       lifecycle parity enforcement.
+
+  - id: runtime_log_readback_api
+    surface: runtime logs, log subscription, and run trace readback over selected stores
+    classification: already_covered_by_existing_proof
+    tier: required_smoke
+    backends: [default_sqlite, explicit_postgres]
+    api_methods: [runtime.logs, runtime.subscribe_logs, run.trace]
+    openrpc_matrix_methods: [runtime.logs, runtime.subscribe_logs, run.trace]
+    store_owners:
+      - runtime.Stores.RuntimeLogStore
+      - apiv1.ObservabilityReadStore
+      - internal/store runtime log persistence
+    proof_dimensions: [selected_store, real_v1_handler, canonical_store_owner, openrpc_publication]
+    proof_refs:
+      - kind: go_test
+        name: TestSQLiteRuntimeLogPersistenceWritesLoggerRowsForObservability
+      - kind: go_test
+        name: TestPostgresRuntimeLogPersistencePreservesRunSourceAndLineage
+      - kind: go_test
+        name: TestOpenRPCWebSocketRuntimeProbes
+      - kind: go_test
+        name: TestHandlerWebSocketRuntimeSubscribeLogsUsesOwnerFiltersAndReplay
+      - kind: go_test
+        name: TestHandlerWebSocketRunSubscribeTraceUsesOwnerReplayAndRunNotFound
+    notes: >
+      #1402 promotes runtime-log/readback to first-class selected-store
+      accounting. Dashboard SQL readers are adjacent read-model consumers; this
+      row owns public API selected-store proof only.
 
   - id: mailbox_read_api_after_mailbox_write
     surface: mailbox.list and mailbox.get after handler-level mailbox_write on selected stores

--- a/internal/store/store_abstraction_guard_matrix_test.go
+++ b/internal/store/store_abstraction_guard_matrix_test.go
@@ -1,0 +1,426 @@
+package store
+
+import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+const selectedStoreAbstractionGuardMatrixPath = "internal/store/testdata/selected_store_abstraction_guard_matrix.yaml"
+
+type selectedStoreAbstractionGuardMatrix struct {
+	Version     int                                       `yaml:"version"`
+	Kind        string                                    `yaml:"kind"`
+	Issue       int                                       `yaml:"issue"`
+	ParentIssue int                                       `yaml:"parent_issue"`
+	Policy      selectedStoreAbstractionGuardMatrixPolicy `yaml:"policy"`
+	Rows        []selectedStoreAbstractionGuardMatrixRow  `yaml:"rows"`
+}
+
+type selectedStoreAbstractionGuardMatrixPolicy struct {
+	ClosureLevel                string `yaml:"closure_level"`
+	ClaimsParentClosure         bool   `yaml:"claims_parent_closure"`
+	RequiredSmokePolicy         string `yaml:"required_smoke_policy"`
+	NamedFastCommand            string `yaml:"named_fast_command"`
+	NamedFullConformanceCommand string `yaml:"named_full_conformance_command"`
+}
+
+type selectedStoreAbstractionGuardMatrixRow struct {
+	ID             string                             `yaml:"id"`
+	Classification string                             `yaml:"classification"`
+	Tier           string                             `yaml:"tier"`
+	Concepts       []string                           `yaml:"concepts"`
+	Owners         []string                           `yaml:"owners"`
+	SplitIssues    []int                              `yaml:"split_issues"`
+	ProofRefs      []selectedStoreAbstractionProofRef `yaml:"proof_refs"`
+	GuardProofRefs []selectedStoreAbstractionProofRef `yaml:"guard_proof_refs"`
+	Notes          string                             `yaml:"notes"`
+}
+
+type selectedStoreAbstractionProofRef struct {
+	Kind string `yaml:"kind"`
+	Name string `yaml:"name,omitempty"`
+	Path string `yaml:"path,omitempty"`
+}
+
+type selectedStoreAbstractionValidationContext struct {
+	goTests map[string]string
+}
+
+func TestSelectedStoreAbstractionGuardMatrixCoversApprovedBoundary(t *testing.T) {
+	root := selectedStoreAbstractionRepoRoot(t)
+	matrix := loadSelectedStoreAbstractionGuardMatrix(t, root)
+	ctx := newSelectedStoreAbstractionValidationContext(t, root)
+
+	if problems := validateSelectedStoreAbstractionGuardMatrix(root, matrix, ctx); len(problems) > 0 {
+		t.Fatalf("selected store abstraction guard matrix validation failed:\n- %s", strings.Join(problems, "\n- "))
+	}
+}
+
+func TestSelectedStoreAbstractionGuardMatrixRejectsStaleProofRefs(t *testing.T) {
+	root := selectedStoreAbstractionRepoRoot(t)
+	ctx := newSelectedStoreAbstractionValidationContext(t, root)
+	tests := []struct {
+		name   string
+		mutate func(*selectedStoreAbstractionGuardMatrix)
+		want   string
+	}{
+		{
+			name: "stale go test proof",
+			mutate: func(matrix *selectedStoreAbstractionGuardMatrix) {
+				row := selectedStoreAbstractionRowByID(t, matrix, "producer_backend_branching_guard")
+				row.ProofRefs[0].Name = "TestMissingStoreAbstractionProof"
+			},
+			want: "producer_backend_branching_guard go_test proof_ref TestMissingStoreAbstractionProof does not resolve",
+		},
+		{
+			name: "guard row requires regression proof",
+			mutate: func(matrix *selectedStoreAbstractionGuardMatrix) {
+				row := selectedStoreAbstractionRowByID(t, matrix, "raw_selected_runtime_writer_boundary_guard")
+				row.GuardProofRefs = nil
+			},
+			want: "raw_selected_runtime_writer_boundary_guard guard row missing guard_proof_refs",
+		},
+		{
+			name: "public idempotency row is required",
+			mutate: func(matrix *selectedStoreAbstractionGuardMatrix) {
+				matrix.Rows = selectedStoreAbstractionRowsExcept(matrix.Rows, "api_idempotency_public_surface_accounting")
+			},
+			want: "matrix missing required row api_idempotency_public_surface_accounting",
+		},
+		{
+			name: "runtime log readback row is required",
+			mutate: func(matrix *selectedStoreAbstractionGuardMatrix) {
+				matrix.Rows = selectedStoreAbstractionRowsExcept(matrix.Rows, "runtime_log_readback_public_surface_accounting")
+			},
+			want: "matrix missing required row runtime_log_readback_public_surface_accounting",
+		},
+		{
+			name: "workflow proof must resolve",
+			mutate: func(matrix *selectedStoreAbstractionGuardMatrix) {
+				row := selectedStoreAbstractionRowByID(t, matrix, "default_sqlite_required_smoke")
+				row.ProofRefs[0].Name = "missing-sqlite-local-dev-job"
+			},
+			want: "default_sqlite_required_smoke workflow proof_ref missing-sqlite-local-dev-job missing from .github/workflows/ci.yml",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			matrix := loadSelectedStoreAbstractionGuardMatrix(t, root)
+			tc.mutate(&matrix)
+			problems := validateSelectedStoreAbstractionGuardMatrix(root, matrix, ctx)
+			if !selectedStoreAbstractionProblemsContain(problems, tc.want) {
+				t.Fatalf("validation problems missing %q:\n- %s", tc.want, strings.Join(problems, "\n- "))
+			}
+		})
+	}
+}
+
+func loadSelectedStoreAbstractionGuardMatrix(t *testing.T, root string) selectedStoreAbstractionGuardMatrix {
+	t.Helper()
+	raw, err := os.ReadFile(filepath.Join(root, selectedStoreAbstractionGuardMatrixPath))
+	if err != nil {
+		t.Fatalf("read selected store abstraction guard matrix: %v", err)
+	}
+	var matrix selectedStoreAbstractionGuardMatrix
+	if err := yaml.Unmarshal(raw, &matrix); err != nil {
+		t.Fatalf("parse selected store abstraction guard matrix: %v", err)
+	}
+	return matrix
+}
+
+func newSelectedStoreAbstractionValidationContext(t *testing.T, root string) selectedStoreAbstractionValidationContext {
+	t.Helper()
+	goTests, err := loadSelectedStoreAbstractionGoTests(root)
+	if err != nil {
+		t.Fatalf("load selected store abstraction go test symbols: %v", err)
+	}
+	return selectedStoreAbstractionValidationContext{goTests: goTests}
+}
+
+func validateSelectedStoreAbstractionGuardMatrix(root string, matrix selectedStoreAbstractionGuardMatrix, ctx selectedStoreAbstractionValidationContext) []string {
+	var problems []string
+	if matrix.Version != 1 {
+		problems = append(problems, fmt.Sprintf("matrix version = %d, want 1", matrix.Version))
+	}
+	if matrix.Kind != "selected_runtime_store_abstraction_guard_matrix" {
+		problems = append(problems, fmt.Sprintf("matrix kind = %q, want selected_runtime_store_abstraction_guard_matrix", matrix.Kind))
+	}
+	if matrix.Issue != 1402 {
+		problems = append(problems, fmt.Sprintf("matrix issue = %d, want 1402", matrix.Issue))
+	}
+	if matrix.ParentIssue != 1400 {
+		problems = append(problems, fmt.Sprintf("matrix parent_issue = %d, want 1400", matrix.ParentIssue))
+	}
+	problems = append(problems, validateSelectedStoreAbstractionPolicy(matrix.Policy)...)
+
+	rowsByID := map[string]selectedStoreAbstractionGuardMatrixRow{}
+	for _, row := range matrix.Rows {
+		id := strings.TrimSpace(row.ID)
+		if id == "" {
+			problems = append(problems, "matrix row missing id")
+			continue
+		}
+		if _, exists := rowsByID[id]; exists {
+			problems = append(problems, fmt.Sprintf("matrix row %s appears more than once", id))
+		}
+		rowsByID[id] = row
+		problems = append(problems, validateSelectedStoreAbstractionRow(root, row, ctx)...)
+	}
+	for rowID := range requiredSelectedStoreAbstractionRows() {
+		if _, ok := rowsByID[rowID]; !ok {
+			problems = append(problems, fmt.Sprintf("matrix missing required row %s", rowID))
+		}
+	}
+	sort.Strings(problems)
+	return problems
+}
+
+func validateSelectedStoreAbstractionPolicy(policy selectedStoreAbstractionGuardMatrixPolicy) []string {
+	var problems []string
+	if policy.ClosureLevel != "matrix_guard_child_complete" {
+		problems = append(problems, fmt.Sprintf("policy closure_level = %q, want matrix_guard_child_complete", policy.ClosureLevel))
+	}
+	if policy.ClaimsParentClosure {
+		problems = append(problems, "policy claims_parent_closure = true, want false")
+	}
+	if strings.TrimSpace(policy.RequiredSmokePolicy) == "" {
+		problems = append(problems, "policy required_smoke_policy missing")
+	}
+	if !strings.Contains(policy.NamedFastCommand, "TestSelectedStoreAbstractionGuardMatrix") {
+		problems = append(problems, "policy named_fast_command missing selected store abstraction matrix proof")
+	}
+	if !strings.HasPrefix(strings.TrimSpace(policy.NamedFullConformanceCommand), "go test ./internal/runtime/cataloge2e") {
+		problems = append(problems, fmt.Sprintf("policy named_full_conformance_command = %q, want cataloge2e go test command", policy.NamedFullConformanceCommand))
+	}
+	return problems
+}
+
+func validateSelectedStoreAbstractionRow(root string, row selectedStoreAbstractionGuardMatrixRow, ctx selectedStoreAbstractionValidationContext) []string {
+	var problems []string
+	id := strings.TrimSpace(row.ID)
+	if _, ok := allowedSelectedStoreAbstractionClassifications()[row.Classification]; !ok {
+		problems = append(problems, fmt.Sprintf("%s classification %q is not allowed", id, row.Classification))
+	}
+	if _, ok := allowedSelectedStoreAbstractionTiers()[row.Tier]; !ok {
+		problems = append(problems, fmt.Sprintf("%s tier %q is not allowed", id, row.Tier))
+	}
+	if len(row.Concepts) == 0 {
+		problems = append(problems, fmt.Sprintf("%s missing concepts", id))
+	}
+	if len(row.Owners) == 0 {
+		problems = append(problems, fmt.Sprintf("%s missing owners", id))
+	}
+	if len(row.ProofRefs) == 0 {
+		problems = append(problems, fmt.Sprintf("%s missing proof_refs", id))
+	}
+	if row.Classification == "guard" && len(row.GuardProofRefs) == 0 {
+		problems = append(problems, fmt.Sprintf("%s guard row missing guard_proof_refs", id))
+	}
+	if row.Classification == "split_to_existing_issue" && len(row.SplitIssues) == 0 {
+		problems = append(problems, fmt.Sprintf("%s split row missing split_issues", id))
+	}
+	for _, issue := range row.SplitIssues {
+		switch issue {
+		case 1403, 1405:
+		default:
+			problems = append(problems, fmt.Sprintf("%s split_issue %d is not an approved #1402 sibling", id, issue))
+		}
+	}
+	problems = append(problems, validateSelectedStoreAbstractionProofRefs(root, id, row.ProofRefs, ctx)...)
+	problems = append(problems, validateSelectedStoreAbstractionProofRefs(root, id, row.GuardProofRefs, ctx)...)
+	return problems
+}
+
+func validateSelectedStoreAbstractionProofRefs(root, rowID string, refs []selectedStoreAbstractionProofRef, ctx selectedStoreAbstractionValidationContext) []string {
+	var problems []string
+	for _, ref := range refs {
+		kind := strings.TrimSpace(ref.Kind)
+		if _, ok := allowedSelectedStoreAbstractionProofKinds()[kind]; !ok {
+			problems = append(problems, fmt.Sprintf("%s proof_ref kind %q is not allowed", rowID, ref.Kind))
+			continue
+		}
+		switch kind {
+		case "go_test":
+			if strings.TrimSpace(ref.Name) == "" {
+				problems = append(problems, fmt.Sprintf("%s go_test proof_ref missing name", rowID))
+				continue
+			}
+			if _, ok := ctx.goTests[ref.Name]; !ok {
+				problems = append(problems, fmt.Sprintf("%s go_test proof_ref %s does not resolve", rowID, ref.Name))
+			}
+		case "artifact":
+			if strings.TrimSpace(ref.Path) == "" {
+				problems = append(problems, fmt.Sprintf("%s artifact proof_ref missing path", rowID))
+				continue
+			}
+			if filepath.IsAbs(ref.Path) || strings.HasPrefix(filepath.Clean(ref.Path), "..") {
+				problems = append(problems, fmt.Sprintf("%s artifact proof_ref path %s must be repo-relative", rowID, ref.Path))
+				continue
+			}
+			if _, err := os.Stat(filepath.Join(root, filepath.Clean(ref.Path))); err != nil {
+				problems = append(problems, fmt.Sprintf("%s artifact proof_ref path %s does not exist", rowID, ref.Path))
+			}
+		case "workflow":
+			if strings.TrimSpace(ref.Path) == "" || strings.TrimSpace(ref.Name) == "" {
+				problems = append(problems, fmt.Sprintf("%s workflow proof_ref requires path and name", rowID))
+				continue
+			}
+			raw, err := os.ReadFile(filepath.Join(root, filepath.Clean(ref.Path)))
+			if err != nil {
+				problems = append(problems, fmt.Sprintf("%s workflow proof_ref path %s does not exist", rowID, ref.Path))
+				continue
+			}
+			if !strings.Contains(string(raw), ref.Name) {
+				problems = append(problems, fmt.Sprintf("%s workflow proof_ref %s missing from %s", rowID, ref.Name, ref.Path))
+			}
+		}
+	}
+	return problems
+}
+
+func loadSelectedStoreAbstractionGoTests(root string) (map[string]string, error) {
+	out := map[string]string{}
+	err := filepath.WalkDir(root, func(path string, entry os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if entry.IsDir() {
+			switch entry.Name() {
+			case ".git", ".swarm", "node_modules", "vendor":
+				return filepath.SkipDir
+			default:
+				return nil
+			}
+		}
+		if !strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+		fileSet := token.NewFileSet()
+		parsed, err := parser.ParseFile(fileSet, path, nil, 0)
+		if err != nil {
+			return err
+		}
+		rel, _ := filepath.Rel(root, path)
+		for _, decl := range parsed.Decls {
+			fn, ok := decl.(*ast.FuncDecl)
+			if !ok || fn.Recv != nil {
+				continue
+			}
+			if name := fn.Name.Name; strings.HasPrefix(name, "Test") {
+				out[name] = rel
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func selectedStoreAbstractionRowByID(t *testing.T, matrix *selectedStoreAbstractionGuardMatrix, id string) *selectedStoreAbstractionGuardMatrixRow {
+	t.Helper()
+	for i := range matrix.Rows {
+		if matrix.Rows[i].ID == id {
+			return &matrix.Rows[i]
+		}
+	}
+	t.Fatalf("matrix row %s not found", id)
+	return nil
+}
+
+func selectedStoreAbstractionRowsExcept(rows []selectedStoreAbstractionGuardMatrixRow, id string) []selectedStoreAbstractionGuardMatrixRow {
+	out := rows[:0]
+	for _, row := range rows {
+		if row.ID != id {
+			out = append(out, row)
+		}
+	}
+	return out
+}
+
+func selectedStoreAbstractionProblemsContain(problems []string, want string) bool {
+	for _, problem := range problems {
+		if strings.Contains(problem, want) {
+			return true
+		}
+	}
+	return false
+}
+
+func requiredSelectedStoreAbstractionRows() map[string]struct{} {
+	return selectedStoreAbstractionStringSet([]string{
+		"public_surface_backend_matrix_accounting",
+		"producer_backend_branching_guard",
+		"raw_selected_runtime_writer_boundary_guard",
+		"sqlite_runtime_sqldb_omission_guard",
+		"postgres_not_forced_through_sqlite_serialization_guard",
+		"default_sqlite_required_smoke",
+		"explicit_postgres_required_smoke",
+		"api_idempotency_public_surface_accounting",
+		"runtime_log_readback_public_surface_accounting",
+		"mutation_uow_behavior_split",
+		"sqlite_busy_serialization_behavior_split",
+	})
+}
+
+func allowedSelectedStoreAbstractionClassifications() map[string]struct{} {
+	return selectedStoreAbstractionStringSet([]string{
+		"guard",
+		"matrix_owner",
+		"public_surface_accounting",
+		"required_smoke",
+		"split_to_existing_issue",
+	})
+}
+
+func allowedSelectedStoreAbstractionTiers() map[string]struct{} {
+	return selectedStoreAbstractionStringSet([]string{
+		"required_smoke",
+		"split_open",
+	})
+}
+
+func allowedSelectedStoreAbstractionProofKinds() map[string]struct{} {
+	return selectedStoreAbstractionStringSet([]string{
+		"artifact",
+		"go_test",
+		"workflow",
+	})
+}
+
+func selectedStoreAbstractionStringSet(values []string) map[string]struct{} {
+	out := make(map[string]struct{}, len(values))
+	for _, value := range values {
+		out[value] = struct{}{}
+	}
+	return out
+}
+
+func selectedStoreAbstractionRepoRoot(t *testing.T) string {
+	t.Helper()
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	for {
+		if _, err := os.Stat(filepath.Join(wd, "go.mod")); err == nil {
+			return wd
+		}
+		parent := filepath.Dir(wd)
+		if parent == wd {
+			t.Fatal("repo root not found")
+		}
+		wd = parent
+	}
+}

--- a/internal/store/store_abstraction_guard_matrix_test.go
+++ b/internal/store/store_abstraction_guard_matrix_test.go
@@ -90,6 +90,31 @@ func TestSelectedStoreAbstractionGuardMatrixRejectsStaleProofRefs(t *testing.T) 
 			want: "raw_selected_runtime_writer_boundary_guard guard row missing guard_proof_refs",
 		},
 		{
+			name: "guard row classification is pinned",
+			mutate: func(matrix *selectedStoreAbstractionGuardMatrix) {
+				row := selectedStoreAbstractionRowByID(t, matrix, "producer_backend_branching_guard")
+				row.Classification = "matrix_owner"
+			},
+			want: "producer_backend_branching_guard classification = \"matrix_owner\", want \"guard\"",
+		},
+		{
+			name: "split row classification is pinned",
+			mutate: func(matrix *selectedStoreAbstractionGuardMatrix) {
+				row := selectedStoreAbstractionRowByID(t, matrix, "sqlite_busy_serialization_behavior_split")
+				row.Classification = "guard"
+				row.Tier = "required_smoke"
+			},
+			want: "sqlite_busy_serialization_behavior_split classification = \"guard\", want \"split_to_existing_issue\"",
+		},
+		{
+			name: "split row issue set is pinned",
+			mutate: func(matrix *selectedStoreAbstractionGuardMatrix) {
+				row := selectedStoreAbstractionRowByID(t, matrix, "mutation_uow_behavior_split")
+				row.SplitIssues = nil
+			},
+			want: "mutation_uow_behavior_split split_issues = [], want [1403]",
+		},
+		{
 			name: "public idempotency row is required",
 			mutate: func(matrix *selectedStoreAbstractionGuardMatrix) {
 				matrix.Rows = selectedStoreAbstractionRowsExcept(matrix.Rows, "api_idempotency_public_surface_accounting")
@@ -189,6 +214,7 @@ func validateSelectedStoreAbstractionGuardMatrix(root string, matrix selectedSto
 			problems = append(problems, fmt.Sprintf("matrix missing required row %s", rowID))
 		}
 	}
+	problems = append(problems, validateSelectedStoreAbstractionRequiredRowShapes(rowsByID)...)
 	sort.Strings(problems)
 	return problems
 }
@@ -211,6 +237,93 @@ func validateSelectedStoreAbstractionPolicy(policy selectedStoreAbstractionGuard
 		problems = append(problems, fmt.Sprintf("policy named_full_conformance_command = %q, want cataloge2e go test command", policy.NamedFullConformanceCommand))
 	}
 	return problems
+}
+
+type selectedStoreAbstractionExpectedRowShape struct {
+	Classification         string
+	Tier                   string
+	SplitIssues            []int
+	RequiresGuardProofRefs bool
+}
+
+func validateSelectedStoreAbstractionRequiredRowShapes(rowsByID map[string]selectedStoreAbstractionGuardMatrixRow) []string {
+	var problems []string
+	for id, want := range expectedSelectedStoreAbstractionRowShapes() {
+		row, ok := rowsByID[id]
+		if !ok {
+			continue
+		}
+		if row.Classification != want.Classification {
+			problems = append(problems, fmt.Sprintf("%s classification = %q, want %q", id, row.Classification, want.Classification))
+		}
+		if row.Tier != want.Tier {
+			problems = append(problems, fmt.Sprintf("%s tier = %q, want %q", id, row.Tier, want.Tier))
+		}
+		if !selectedStoreAbstractionSameIntSet(row.SplitIssues, want.SplitIssues) {
+			problems = append(problems, fmt.Sprintf("%s split_issues = %v, want %v", id, selectedStoreAbstractionSortedInts(row.SplitIssues), selectedStoreAbstractionSortedInts(want.SplitIssues)))
+		}
+		if want.RequiresGuardProofRefs && len(row.GuardProofRefs) == 0 {
+			problems = append(problems, fmt.Sprintf("%s required row missing guard_proof_refs", id))
+		}
+	}
+	return problems
+}
+
+func expectedSelectedStoreAbstractionRowShapes() map[string]selectedStoreAbstractionExpectedRowShape {
+	return map[string]selectedStoreAbstractionExpectedRowShape{
+		"public_surface_backend_matrix_accounting": {
+			Classification:         "matrix_owner",
+			Tier:                   "required_smoke",
+			RequiresGuardProofRefs: true,
+		},
+		"producer_backend_branching_guard": {
+			Classification:         "guard",
+			Tier:                   "required_smoke",
+			RequiresGuardProofRefs: true,
+		},
+		"raw_selected_runtime_writer_boundary_guard": {
+			Classification:         "guard",
+			Tier:                   "required_smoke",
+			SplitIssues:            []int{1403, 1405},
+			RequiresGuardProofRefs: true,
+		},
+		"sqlite_runtime_sqldb_omission_guard": {
+			Classification:         "guard",
+			Tier:                   "required_smoke",
+			RequiresGuardProofRefs: true,
+		},
+		"postgres_not_forced_through_sqlite_serialization_guard": {
+			Classification:         "guard",
+			Tier:                   "required_smoke",
+			RequiresGuardProofRefs: true,
+		},
+		"default_sqlite_required_smoke": {
+			Classification: "required_smoke",
+			Tier:           "required_smoke",
+		},
+		"explicit_postgres_required_smoke": {
+			Classification: "required_smoke",
+			Tier:           "required_smoke",
+		},
+		"api_idempotency_public_surface_accounting": {
+			Classification: "public_surface_accounting",
+			Tier:           "required_smoke",
+		},
+		"runtime_log_readback_public_surface_accounting": {
+			Classification: "public_surface_accounting",
+			Tier:           "required_smoke",
+		},
+		"mutation_uow_behavior_split": {
+			Classification: "split_to_existing_issue",
+			Tier:           "split_open",
+			SplitIssues:    []int{1403},
+		},
+		"sqlite_busy_serialization_behavior_split": {
+			Classification: "split_to_existing_issue",
+			Tier:           "split_open",
+			SplitIssues:    []int{1405},
+		},
+	}
 }
 
 func validateSelectedStoreAbstractionRow(root string, row selectedStoreAbstractionGuardMatrixRow, ctx selectedStoreAbstractionValidationContext) []string {
@@ -416,6 +529,26 @@ func selectedStoreAbstractionStringSet(values []string) map[string]struct{} {
 	for _, value := range values {
 		out[value] = struct{}{}
 	}
+	return out
+}
+
+func selectedStoreAbstractionSameIntSet(actual, want []int) bool {
+	actualSorted := selectedStoreAbstractionSortedInts(actual)
+	wantSorted := selectedStoreAbstractionSortedInts(want)
+	if len(actualSorted) != len(wantSorted) {
+		return false
+	}
+	for i := range actualSorted {
+		if actualSorted[i] != wantSorted[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func selectedStoreAbstractionSortedInts(values []int) []int {
+	out := append([]int(nil), values...)
+	sort.Ints(out)
 	return out
 }
 

--- a/internal/store/store_abstraction_guard_matrix_test.go
+++ b/internal/store/store_abstraction_guard_matrix_test.go
@@ -111,6 +111,14 @@ func TestSelectedStoreAbstractionGuardMatrixRejectsStaleProofRefs(t *testing.T) 
 			},
 			want: "default_sqlite_required_smoke workflow proof_ref missing-sqlite-local-dev-job missing from .github/workflows/ci.yml",
 		},
+		{
+			name: "workflow proof path must be repo relative",
+			mutate: func(matrix *selectedStoreAbstractionGuardMatrix) {
+				row := selectedStoreAbstractionRowByID(t, matrix, "default_sqlite_required_smoke")
+				row.ProofRefs[0].Path = "../../etc/passwd"
+			},
+			want: "default_sqlite_required_smoke workflow proof_ref path ../../etc/passwd must be repo-relative",
+		},
 	}
 
 	for _, tc := range tests {
@@ -273,6 +281,10 @@ func validateSelectedStoreAbstractionProofRefs(root, rowID string, refs []select
 		case "workflow":
 			if strings.TrimSpace(ref.Path) == "" || strings.TrimSpace(ref.Name) == "" {
 				problems = append(problems, fmt.Sprintf("%s workflow proof_ref requires path and name", rowID))
+				continue
+			}
+			if filepath.IsAbs(ref.Path) || strings.HasPrefix(filepath.Clean(ref.Path), "..") {
+				problems = append(problems, fmt.Sprintf("%s workflow proof_ref path %s must be repo-relative", rowID, ref.Path))
 				continue
 			}
 			raw, err := os.ReadFile(filepath.Join(root, filepath.Clean(ref.Path)))

--- a/internal/store/testdata/selected_store_abstraction_guard_matrix.yaml
+++ b/internal/store/testdata/selected_store_abstraction_guard_matrix.yaml
@@ -1,0 +1,250 @@
+version: 1
+kind: selected_runtime_store_abstraction_guard_matrix
+issue: 1402
+parent_issue: 1400
+policy:
+  closure_level: matrix_guard_child_complete
+  claims_parent_closure: false
+  required_smoke_policy: >
+    Required PR smoke is the named guard/matrix validation plus the focused
+    proof refs listed here. The matrix composes selected-store guard owners and
+    public-surface accounting; it must not expand into a SQLite/Postgres
+    Cartesian suite.
+  named_fast_command: >
+    go test ./internal/store ./cmd/swarm ./internal/apiv1 -run
+    'TestSelectedStoreAbstractionGuardMatrix|TestSelectedStoreFacadeOwnsProducerBackendBranching|TestSelectedStoreFacadeBackendBranchingGuardRejectsProducerFixture|TestSelectedSQLiteRuntimeWriterBoundaryAudit|TestRuntimeWriterBoundaryGuardRejects|TestSelectedSQLiteRuntimeConstructionConsumesMutationBoundary|TestPublicSurfaceBackendMatrixCoversSelectedBackendRows|TestPublicSurfaceBackendMatrixRejectsStaleReferences' -count=1
+  named_full_conformance_command: go test ./internal/runtime/cataloge2e -count=1
+rows:
+  - id: public_surface_backend_matrix_accounting
+    classification: matrix_owner
+    tier: required_smoke
+    concepts:
+      - selected backend public API and CLI proof accounting
+      - default SQLite and explicit Postgres row classification
+    owners:
+      - internal/apiv1/testdata/public_surface_backend_matrix.yaml
+      - internal/apiv1 TestPublicSurfaceBackendMatrixCoversSelectedBackendRows
+    proof_refs:
+      - kind: artifact
+        path: internal/apiv1/testdata/public_surface_backend_matrix.yaml
+      - kind: go_test
+        name: TestPublicSurfaceBackendMatrixCoversSelectedBackendRows
+      - kind: go_test
+        name: TestPublicSurfaceBackendMatrixRejectsStaleReferences
+    guard_proof_refs:
+      - kind: go_test
+        name: TestPublicSurfaceBackendMatrixRejectsStaleReferences
+    notes: >
+      #1402 consumes the existing public-surface backend matrix instead of
+      replacing OpenRPC method/schema ownership.
+
+  - id: producer_backend_branching_guard
+    classification: guard
+    tier: required_smoke
+    concepts:
+      - producer-side backend branching after construction
+    owners:
+      - cmd/swarm/store_facade_guard_test.go
+      - selectedRuntimeStoreFacade
+    proof_refs:
+      - kind: go_test
+        name: TestSelectedStoreFacadeOwnsProducerBackendBranching
+    guard_proof_refs:
+      - kind: go_test
+        name: TestSelectedStoreFacadeBackendBranchingGuardRejectsProducerFixture
+    notes: >
+      Producer/public-surface assembly must not infer capability availability
+      from concrete Postgres/SQLite fields after store construction.
+
+  - id: raw_selected_runtime_writer_boundary_guard
+    classification: guard
+    tier: required_smoke
+    concepts:
+      - raw selected-runtime SQL writer and transaction bypasses
+    owners:
+      - internal/store/runtime_mutation_guard_test.go
+      - backend_neutral_runtime_mutation_write_boundary
+    proof_refs:
+      - kind: go_test
+        name: TestSelectedSQLiteRuntimeWriterBoundaryAudit
+    guard_proof_refs:
+      - kind: go_test
+        name: TestRuntimeWriterBoundaryGuardRejectsSelectedSQLiteBypassFixture
+      - kind: go_test
+        name: TestRuntimeWriterBoundaryGuardRejectsSameFunctionSQLiteBypassFixture
+      - kind: go_test
+        name: TestRuntimeWriterBoundaryGuardRejectsPipelineSQLiteDBHelperBypassFixture
+      - kind: go_test
+        name: TestRuntimeWriterBoundaryGuardRejectsPipelineSQLiteRawDBHelperFixture
+    split_issues: [1403, 1405]
+    notes: >
+      This row guards the boundary. Behavior-changing mutation UoW migration
+      remains #1403 and SQLite busy/serialization policy remains #1405.
+
+  - id: sqlite_runtime_sqldb_omission_guard
+    classification: guard
+    tier: required_smoke
+    concepts:
+      - raw SQLite runtime SQLDB exposure to producers
+    owners:
+      - cmd/swarm buildStores
+      - runtime.Stores.SQLDB
+      - raw_sql_runtime_consumer_boundary_for_sqlite
+    proof_refs:
+      - kind: go_test
+        name: TestBuildStoresAcceptsSQLiteSelectedCoreRuntimeStore
+      - kind: go_test
+        name: TestBuildStoresSQLiteRuntimeNoLongerFailsClosedOnMailboxMaterializationOwner
+      - kind: go_test
+        name: TestSelectedSQLiteRuntimeConstructionConsumesMutationBoundary
+    guard_proof_refs:
+      - kind: go_test
+        name: TestBuildStoresAcceptsSQLiteSelectedCoreRuntimeStore
+      - kind: go_test
+        name: TestBuildStoresSQLiteRuntimeNoLongerFailsClosedOnMailboxMaterializationOwner
+    notes: >
+      SQLite construction must keep runtime.Stores.SQLDB nil; promoted stores
+      consume typed selected owners instead.
+
+  - id: postgres_not_forced_through_sqlite_serialization_guard
+    classification: guard
+    tier: required_smoke
+    concepts:
+      - Postgres must not inherit SQLite global serialization or retry policy
+    owners:
+      - internal/store.PostgresStore transaction methods
+      - internal/runtime/pipeline.WorkflowInstanceStore Postgres dialect
+    proof_refs:
+      - kind: go_test
+        name: TestPostgresStore_RunEventTransactionDoesNotSerializeCallbacks
+      - kind: go_test
+        name: TestWorkflowInstanceStore_RunInPipelineTransactionDoesNotRetryPostgresDialect
+    guard_proof_refs:
+      - kind: go_test
+        name: TestPostgresStore_RunEventTransactionDoesNotSerializeCallbacks
+      - kind: go_test
+        name: TestWorkflowInstanceStore_RunInPipelineTransactionDoesNotRetryPostgresDialect
+    notes: >
+      SQLite-local busy handling is a store-internal backend policy; Postgres
+      keeps normal transaction behavior.
+
+  - id: default_sqlite_required_smoke
+    classification: required_smoke
+    tier: required_smoke
+    concepts:
+      - default SQLite serve/run public path
+    owners:
+      - .github/workflows/ci.yml sqlite-local-dev
+      - internal/store/backendselection
+      - cmd/swarm buildStores
+    proof_refs:
+      - kind: workflow
+        path: .github/workflows/ci.yml
+        name: sqlite-local-dev
+      - kind: go_test
+        name: TestBuildStoresAcceptsSQLiteSelectedCoreRuntimeStore
+      - kind: go_test
+        name: TestRunCommandLocalForegroundConsumesServeOwnerAndV1API
+    notes: >
+      Default SQLite proof stays fast and representative. It must not duplicate
+      every public surface across both backends.
+
+  - id: explicit_postgres_required_smoke
+    classification: required_smoke
+    tier: required_smoke
+    concepts:
+      - explicit Postgres opt-in public path
+    owners:
+      - .github/workflows/ci.yml Prove explicit Postgres opt-in selector
+      - internal/store/backendselection
+      - cmd/swarm buildStores
+    proof_refs:
+      - kind: workflow
+        path: .github/workflows/ci.yml
+        name: Prove explicit Postgres opt-in selector
+      - kind: go_test
+        name: TestRunServeRuntimeConsumesCanonicalStoreSelectionBeforeStoreConstruction
+      - kind: go_test
+        name: TestRunServeRuntimeFreshEmptyPostgresBootstrapsSchemaBeforeDiskContractsServe
+    notes: >
+      Explicit Postgres remains a required counterpart without forcing a
+      complete SQLite/Postgres Cartesian suite.
+
+  - id: api_idempotency_public_surface_accounting
+    classification: public_surface_accounting
+    tier: required_smoke
+    concepts:
+      - API idempotency through selected store capabilities
+    owners:
+      - internal/apiv1 APIIdempotencyStore
+      - internal/apiv1/testdata/public_surface_backend_matrix.yaml
+    proof_refs:
+      - kind: artifact
+        path: internal/apiv1/testdata/public_surface_backend_matrix.yaml
+      - kind: go_test
+        name: TestOperatorRunStartHandlersPersistRootEventAndReplayIdempotency
+      - kind: go_test
+        name: TestOperatorEventPublishSQLiteIdempotentFirstEventPublishesWithoutLock
+      - kind: go_test
+        name: TestOperatorEventPublishHandlersPersistEventReportDeliveriesAndReplayIdempotency
+    notes: >
+      First-class #1402 row required by gate. OpenRPC method-catalog and schema
+      proof remain adjacent owners.
+
+  - id: runtime_log_readback_public_surface_accounting
+    classification: public_surface_accounting
+    tier: required_smoke
+    concepts:
+      - runtime log and trace readback through selected store capabilities
+    owners:
+      - runtime.Stores.RuntimeLogStore
+      - apiv1.ObservabilityReadStore
+      - internal/apiv1/testdata/public_surface_backend_matrix.yaml
+    proof_refs:
+      - kind: artifact
+        path: internal/apiv1/testdata/public_surface_backend_matrix.yaml
+      - kind: go_test
+        name: TestSQLiteRuntimeLogPersistenceWritesLoggerRowsForObservability
+      - kind: go_test
+        name: TestPostgresRuntimeLogPersistencePreservesRunSourceAndLineage
+      - kind: go_test
+        name: TestOpenRPCWebSocketRuntimeProbes
+      - kind: go_test
+        name: TestHandlerWebSocketRuntimeSubscribeLogsUsesOwnerFiltersAndReplay
+      - kind: go_test
+        name: TestHandlerWebSocketRunSubscribeTraceUsesOwnerReplayAndRunNotFound
+    notes: >
+      First-class #1402 row required by gate. Dashboard SQL readers remain
+      adjacent read-model consumers and do not own selected runtime persistence.
+
+  - id: mutation_uow_behavior_split
+    classification: split_to_existing_issue
+    tier: split_open
+    concepts:
+      - typed backend-neutral runtime mutation unit of work
+    owners:
+      - backend_neutral_runtime_mutation_write_boundary
+      - future #1403 typed unit-of-work owner
+    split_issues: [1403]
+    proof_refs:
+      - kind: artifact
+        path: platform-spec.yaml
+    notes: >
+      #1402 may guard/account for this seam, but production mutation behavior
+      migration belongs to #1403.
+
+  - id: sqlite_busy_serialization_behavior_split
+    classification: split_to_existing_issue
+    tier: split_open
+    concepts:
+      - SQLite write serialization and SQLITE_BUSY policy
+    owners:
+      - internal/store.SQLiteRuntimeStore mutation executor
+      - future #1405 store-internal busy policy owner
+    split_issues: [1405]
+    proof_refs:
+      - kind: artifact
+        path: platform-spec.yaml
+    notes: >
+      #1402 may prove producers do not own SQLite busy policy. Moving the policy
+      fully below the store boundary remains #1405.


### PR DESCRIPTION
Closes #1402

## Summary
- Add a #1402-owned selected runtime store abstraction guard matrix and validator.
- Promote API idempotency and runtime log/readback to first-class rows in the public-surface backend matrix.
- Add a failing-fixture regression proof for producer-side concrete backend branching after selected store construction.

This PR is matrix/guard/proof only. It does not change production runtime behavior, platform architecture, store write policy, or public API semantics.

## Governing refs/context
Exact governing spec references:
- `platform-spec.yaml`: `runtime_store_backend_selection`
- `platform-spec.yaml`: `runtime_store_schema_dialect_bootstrap`
- `platform-spec.yaml`: `runtime_core_persistence_store_contracts`
- `platform-spec.yaml`: `selected_runtime_store_facade`
- `platform-spec.yaml`: `backend_neutral_runtime_mutation_write_boundary`
- `platform-spec.yaml`: `raw_sql_runtime_consumer_boundary_for_sqlite`

Binding issue/gate context:
- #1402 pre-audit and independent gate approved `selected_runtime_store_abstraction.guard_and_proof_matrix_durability` as a first slice.
- #1400 remains the parent full-abstraction tracker.
- #1403 typed mutation unit-of-work and #1405 SQLite busy/serialization remain split sibling behavior issues.

## Semantic migration
- New canonical owner for this child slice: `internal/store/testdata/selected_store_abstraction_guard_matrix.yaml` with `TestSelectedStoreAbstractionGuardMatrixCoversApprovedBoundary`.
- Existing owner consumed/refined: `internal/apiv1/testdata/public_surface_backend_matrix.yaml` with public API idempotency and runtime log/readback rows.
- Old producer/reader/writer path now invalid: untracked proof-by-convention for selected-store abstraction and producer-side concrete backend branching after construction.
- Production paths checked for surviving old behavior: `cmd/swarm` producer guard, internal store raw writer guard rows, public API matrix rows, CI workflow smoke rows, and catalog e2e conformance proof references.
- Migration completeness: complete for the #1402 matrix/guard child. It does not close parent #1400 and does not absorb #1403 or #1405.

## Validation
- `go test ./internal/store ./cmd/swarm ./internal/apiv1 -run 'TestSelectedStoreAbstractionGuardMatrix|TestSelectedStoreFacadeOwnsProducerBackendBranching|TestSelectedStoreFacadeBackendBranchingGuardRejectsProducerFixture|TestSelectedSQLiteRuntimeWriterBoundaryAudit|TestRuntimeWriterBoundaryGuardRejects|TestSelectedSQLiteRuntimeConstructionConsumesMutationBoundary|TestPublicSurfaceBackendMatrixCoversSelectedBackendRows|TestPublicSurfaceBackendMatrixRejectsStaleReferences' -count=1`
- `go test ./internal/runtime/cataloge2e -count=1`
- `go test ./...`
