### PR TITLE
[agent-c][issue #1405] Keep SQLite busy policy behind store boundary

### DIFF
--- a/internal/apiv1/operator_mailbox_write_supported_surface_test.go
+++ b/internal/apiv1/operator_mailbox_write_supported_surface_test.go
@@ -206,8 +206,8 @@ func newMailboxWriteSupportedSurfaceHandler(
 	}
 	module := newRunCompletionSystemNodeModule(t, source)
 	workflowStore := runtimepipeline.NewWorkflowInstanceStore(db)
-	if _, ok := persistence.(*store.SQLiteRuntimeStore); ok {
-		workflowStore = runtimepipeline.NewSQLiteWorkflowInstanceStore(db)
+	if sqliteStore, ok := persistence.(*store.SQLiteRuntimeStore); ok {
+		workflowStore = runtimepipeline.NewSQLiteWorkflowInstanceStoreWithRuntimeMutationRunner(db, sqliteStore)
 	}
 	coordinator = runtimepipeline.NewPipelineCoordinatorWithOptions(bus, db, runtimepipeline.PipelineCoordinatorOptions{
 		Module:                  module,

--- a/internal/runtime/pipeline/create_entity_exact_once_test.go
+++ b/internal/runtime/pipeline/create_entity_exact_once_test.go
@@ -25,7 +25,7 @@ func TestCreateEntityHandlerEffectsAreExactOnceAcrossStoreMutations(t *testing.T
 			setup: func(t *testing.T) (*PipelineCoordinator, context.Context, *recordingPipelineBus, *recordingScheduleStore, *recordingMailboxWriteMaterializer) {
 				db := newSQLiteWorkflowInstanceStoreTestDB(t)
 				ctx := sqliteExactOnceRunContext(t, db)
-				return newExactOnceCoordinator(t, db, NewSQLiteWorkflowInstanceStore(db)), ctx, nil, nil, nil
+				return newExactOnceCoordinator(t, db, newSQLiteWorkflowInstanceStoreForTest(t, db)), ctx, nil, nil, nil
 			},
 		},
 		{
@@ -120,7 +120,7 @@ func TestDispatchWorkflowNodeEventSkipsAlreadyProcessedCreateEntityHandler(t *te
 			name: "sqlite",
 			setup: func(t *testing.T) (*PipelineCoordinator, context.Context) {
 				db := newSQLiteWorkflowInstanceStoreTestDB(t)
-				pc := newExactOnceCoordinator(t, db, NewSQLiteWorkflowInstanceStore(db))
+				pc := newExactOnceCoordinator(t, db, newSQLiteWorkflowInstanceStoreForTest(t, db))
 				return pc, sqliteExactOnceRunContext(t, db)
 			},
 		},

--- a/internal/runtime/pipeline/sqlite_dynamic_activation_test.go
+++ b/internal/runtime/pipeline/sqlite_dynamic_activation_test.go
@@ -17,7 +17,7 @@ import (
 
 func TestSQLiteFanOutCreateFlowInstanceDeliveriesPersistWithoutDeadLetter(t *testing.T) {
 	db := newSQLiteWorkflowInstanceStoreTestDB(t)
-	workflowStore := NewSQLiteWorkflowInstanceStore(db)
+	workflowStore := newSQLiteWorkflowInstanceStoreForTest(t, db)
 	ctx := sqliteExactOnceRunContext(t, db)
 	pc, bus := newSQLiteDynamicActivationCoordinator(t, db, workflowStore)
 

--- a/internal/runtime/pipeline/system_node_receipt_store.go
+++ b/internal/runtime/pipeline/system_node_receipt_store.go
@@ -66,8 +66,6 @@ func (s *WorkflowInstanceStore) SystemNodeProcessed(ctx context.Context, nodeID,
 		return false, nil
 	}
 	if s.isSQLite() {
-		unlock := s.lockSQLitePipelineOperation(ctx)
-		defer unlock()
 		var ok bool
 		err := dbQueryRowContext(ctx, s.db, `
 			SELECT EXISTS(
@@ -103,8 +101,6 @@ func (s *WorkflowInstanceStore) SystemNodeDeliveryQuiesced(ctx context.Context, 
 		return false, nil
 	}
 	if s.isSQLite() {
-		unlock := s.lockSQLitePipelineOperation(ctx)
-		defer unlock()
 		var ok bool
 		err := dbQueryRowContext(ctx, s.db, `
 			SELECT EXISTS (

--- a/internal/runtime/pipeline/workflow_instance_store.go
+++ b/internal/runtime/pipeline/workflow_instance_store.go
@@ -5,10 +5,10 @@ import (
 	"database/sql"
 	"database/sql/driver"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"sort"
 	"strings"
-	"sync"
 	"time"
 
 	runtimeflowidentity "github.com/division-sh/swarm/internal/runtime/core/flowidentity"
@@ -95,10 +95,9 @@ type workflowInstancePersistedControl struct {
 }
 
 type WorkflowInstanceStore struct {
-	db                 *sql.DB
-	dialect            workflowStoreDialect
-	sqlitePipelineTxMu sync.Mutex
-	runtimeMutation    RuntimeMutationRunner
+	db              *sql.DB
+	dialect         workflowStoreDialect
+	runtimeMutation RuntimeMutationRunner
 }
 
 type RuntimeMutationRunner interface {
@@ -121,13 +120,9 @@ const (
 
 var workflowInstancePathNamespace = uuid.MustParse("5e7507c8-bd4f-46e0-a098-b016dc31df23")
 
-const (
-	workflowInstanceTimerOwnerNode = "workflow_instance_store"
+const workflowInstanceTimerOwnerNode = "workflow_instance_store"
 
-	sqlitePipelineTransactionRetryBudget = 5 * time.Second
-	sqlitePipelineTransactionBaseDelay   = 10 * time.Millisecond
-	sqlitePipelineTransactionMaxDelay    = 100 * time.Millisecond
-)
+var errSQLiteWorkflowInstanceStoreRuntimeMutationRunnerRequired = errors.New("sqlite workflow instance store requires runtime mutation runner")
 
 type workflowCreateEntityInitialValuesContextKey struct{}
 
@@ -178,8 +173,6 @@ func (s *WorkflowInstanceStore) Load(ctx context.Context, instanceID string) (Wo
 		return WorkflowInstance{}, false, nil
 	}
 	if s.isSQLite() {
-		unlock := s.lockSQLitePipelineOperation(ctx)
-		defer unlock()
 		return s.loadSQLite(ctx, instanceID)
 	}
 	keys := workflowInstanceLookupKeys(instanceID)
@@ -194,8 +187,6 @@ func (s *WorkflowInstanceStore) List(ctx context.Context) ([]WorkflowInstance, e
 		return nil, nil
 	}
 	if s.isSQLite() {
-		unlock := s.lockSQLitePipelineOperation(ctx)
-		defer unlock()
 		return s.listSQLite(ctx)
 	}
 	return s.listSpec(ctx)
@@ -210,8 +201,6 @@ func (s *WorkflowInstanceStore) SelectActiveByFields(ctx context.Context, scopeK
 		return nil, nil
 	}
 	if s.isSQLite() {
-		unlock := s.lockSQLitePipelineOperation(ctx)
-		defer unlock()
 		return s.selectActiveByFieldsSQLite(ctx, scopeKey, selectors, excludedStates)
 	}
 	return s.selectActiveByFieldsSpec(ctx, scopeKey, selectors, excludedStates)
@@ -408,17 +397,6 @@ func (s *WorkflowInstanceStore) isSQLite() bool {
 	return s != nil && s.dialect == workflowStoreDialectSQLite
 }
 
-func (s *WorkflowInstanceStore) lockSQLitePipelineOperation(ctx context.Context) func() {
-	if !s.isSQLite() {
-		return func() {}
-	}
-	if tx, ok := sqlTxFromContext(ctx); ok && tx != nil {
-		return func() {}
-	}
-	s.sqlitePipelineTxMu.Lock()
-	return s.sqlitePipelineTxMu.Unlock
-}
-
 func (s *WorkflowInstanceStore) RunInPipelineTransaction(ctx context.Context, fn func(context.Context, *sql.Tx) error) error {
 	if fn == nil {
 		return nil
@@ -430,120 +408,15 @@ func (s *WorkflowInstanceStore) RunInPipelineTransaction(ctx context.Context, fn
 		if s.runtimeMutation != nil {
 			return s.runtimeMutation.RunRuntimeMutation(ctx, fn)
 		}
-		return s.runInSQLitePipelineTransaction(ctx, fn)
+		return errSQLiteWorkflowInstanceStoreRuntimeMutationRunnerRequired
 	}
 	return s.runInPipelineTransactionOnce(ctx, fn)
-}
-
-func (s *WorkflowInstanceStore) runInSQLitePipelineTransaction(ctx context.Context, fn func(context.Context, *sql.Tx) error) error {
-	return s.runInSQLitePipelineTransactionWithBudget(ctx, fn, sqlitePipelineTransactionRetryBudget)
-}
-
-func (s *WorkflowInstanceStore) runInSQLitePipelineTransactionWithBudget(ctx context.Context, fn func(context.Context, *sql.Tx) error, retryBudget time.Duration) error {
-	if retryBudget <= 0 {
-		retryBudget = sqlitePipelineTransactionRetryBudget
-	}
-	retryDeadline := time.Now().Add(retryBudget)
-	retryDeadlineOwnedByBudget := true
-	if ctxDeadline, ok := ctx.Deadline(); ok && ctxDeadline.Before(retryDeadline) {
-		retryDeadline = ctxDeadline
-		retryDeadlineOwnedByBudget = false
-	}
-	var lastErr error
-	for attempt := 0; ; attempt++ {
-		if err := ctx.Err(); err != nil {
-			return err
-		}
-		if time.Until(retryDeadline) <= 0 {
-			if !retryDeadlineOwnedByBudget {
-				if err := ctx.Err(); err != nil {
-					return err
-				}
-				return context.DeadlineExceeded
-			}
-			return sqlitePipelineTransactionRetryBudgetError(retryBudget, lastErr)
-		}
-		attemptCtx, cancel := context.WithDeadline(ctx, retryDeadline)
-		err := s.runInPipelineTransactionOnce(attemptCtx, fn)
-		attemptErr := attemptCtx.Err()
-		cancel()
-		if err == nil {
-			if attemptErr != nil {
-				if err := ctx.Err(); err != nil {
-					return err
-				}
-				return sqlitePipelineTransactionRetryBudgetError(retryBudget, lastErr)
-			}
-			return nil
-		}
-		if attemptErr != nil {
-			if err := ctx.Err(); err != nil {
-				return err
-			}
-			return sqlitePipelineTransactionRetryBudgetError(retryBudget, lastErr)
-		}
-		if !sqlitePipelineBusyError(err) {
-			return err
-		}
-		lastErr = err
-		delay := sqlitePipelineTransactionRetryDelay(attempt)
-		if remaining := time.Until(retryDeadline); remaining <= 0 {
-			if !retryDeadlineOwnedByBudget {
-				if err := ctx.Err(); err != nil {
-					return err
-				}
-				return context.DeadlineExceeded
-			}
-			return sqlitePipelineTransactionRetryBudgetError(retryBudget, lastErr)
-		} else if delay > remaining {
-			delay = remaining
-		}
-		timer := time.NewTimer(delay)
-		select {
-		case <-ctx.Done():
-			timer.Stop()
-			return ctx.Err()
-		case <-timer.C:
-		}
-	}
-}
-
-func sqlitePipelineTransactionRetryBudgetError(retryBudget time.Duration, lastErr error) error {
-	if lastErr == nil {
-		return fmt.Errorf("sqlite pipeline transaction retry budget %s exceeded: %w", retryBudget, context.DeadlineExceeded)
-	}
-	return fmt.Errorf("sqlite pipeline transaction retry budget %s exceeded: %w", retryBudget, lastErr)
-}
-
-func sqlitePipelineTransactionRetryDelay(attempt int) time.Duration {
-	delay := time.Duration(attempt+1) * sqlitePipelineTransactionBaseDelay
-	if delay > sqlitePipelineTransactionMaxDelay {
-		return sqlitePipelineTransactionMaxDelay
-	}
-	return delay
-}
-
-func sqlitePipelineBusyError(err error) bool {
-	if err == nil {
-		return false
-	}
-	text := strings.ToLower(err.Error())
-	return strings.Contains(text, "sqlite_busy") ||
-		strings.Contains(text, "sqlite_locked") ||
-		strings.Contains(text, "database is locked") ||
-		strings.Contains(text, "database table is locked") ||
-		strings.Contains(text, "database is busy")
 }
 
 func (s *WorkflowInstanceStore) runInPipelineTransactionOnce(ctx context.Context, fn func(context.Context, *sql.Tx) error) error {
 	if s == nil || s.db == nil {
 		return fn(ctx, nil)
 	}
-	// SQLite has a single writer. Keep the local-dev pipeline transaction
-	// boundary authoritative instead of letting sibling handler activations
-	// race into SQLITE_BUSY at the first persisted row.
-	unlock := s.lockSQLitePipelineOperation(ctx)
-	defer unlock()
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
 		return err
@@ -566,8 +439,6 @@ func (s *WorkflowInstanceStore) QueryEntityCount(ctx context.Context, runID stri
 		return 0, nil
 	}
 	if s.isSQLite() {
-		unlock := s.lockSQLitePipelineOperation(ctx)
-		defer unlock()
 		return s.queryEntityStateCountSQLite(ctx, runID, source, contract, predicate)
 	}
 	return queryEntityStateCount(runID, s.db, source, contract, predicate)

--- a/internal/runtime/pipeline/workflow_instance_store_sqlite_test.go
+++ b/internal/runtime/pipeline/workflow_instance_store_sqlite_test.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"database/sql"
 	"errors"
-	"fmt"
-	"path/filepath"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -19,7 +17,7 @@ import (
 
 func TestSQLiteWorkflowInstanceStore_PreservesCreateEntityInitialValueMutationRows(t *testing.T) {
 	db := newSQLiteWorkflowInstanceStoreTestDB(t)
-	store := NewSQLiteWorkflowInstanceStore(db)
+	store := newSQLiteWorkflowInstanceStoreForTest(t, db)
 	runID := uuid.NewString()
 	ctx := runtimecorrelation.WithRunID(context.Background(), runID)
 	ctx = withWorkflowCreateEntityInitialValues(ctx, map[string]any{
@@ -53,7 +51,7 @@ func TestSQLiteWorkflowInstanceStore_PreservesCreateEntityInitialValueMutationRo
 
 func TestSQLiteWorkflowInstanceStore_PreservesParentRouteControlMetadata(t *testing.T) {
 	db := newSQLiteWorkflowInstanceStoreTestDB(t)
-	store := NewSQLiteWorkflowInstanceStore(db)
+	store := newSQLiteWorkflowInstanceStoreForTest(t, db)
 	ctx := runtimecorrelation.WithRunID(context.Background(), uuid.NewString())
 	storageRef := "review/inst-1"
 
@@ -133,163 +131,54 @@ func TestSQLiteWorkflowInstanceStore_MarkTerminatedUsesRuntimeMutationRunner(t *
 	}
 }
 
-func TestSQLiteWorkflowInstanceStore_RunInPipelineTransactionRetriesBusyAndFlushesPostCommitOnce(t *testing.T) {
-	db, lockDB := newSQLiteWorkflowInstanceStoreBusyTestDBs(t)
+func TestSQLiteWorkflowInstanceStore_RunInPipelineTransactionRequiresRuntimeMutationRunner(t *testing.T) {
+	db := newSQLiteWorkflowInstanceStoreTestDB(t)
 	store := NewSQLiteWorkflowInstanceStore(db)
-	ctx, cancel := context.WithTimeout(runtimecorrelation.WithRunID(context.Background(), uuid.NewString()), 2*time.Second)
-	defer cancel()
+	ctx := runtimecorrelation.WithRunID(context.Background(), uuid.NewString())
+	called := false
 
-	lockTx, err := lockDB.BeginTx(ctx, nil)
-	if err != nil {
-		t.Fatalf("begin locking tx: %v", err)
-	}
-	lockCommitted := false
-	t.Cleanup(func() {
-		if !lockCommitted {
-			_ = lockTx.Rollback()
-		}
+	err := store.RunInPipelineTransaction(ctx, func(context.Context, *sql.Tx) error {
+		called = true
+		return nil
 	})
-	if _, err := lockTx.ExecContext(ctx, `
-		INSERT INTO runs (run_id, status, started_at)
-		VALUES (?, 'running', ?)
-	`, uuid.NewString(), time.Now().UTC()); err != nil {
-		t.Fatalf("hold sqlite write lock: %v", err)
+	if !errors.Is(err, errSQLiteWorkflowInstanceStoreRuntimeMutationRunnerRequired) {
+		t.Fatalf("RunInPipelineTransaction error = %v, want runtime mutation runner required", err)
 	}
+	if called {
+		t.Fatal("RunInPipelineTransaction callback ran without runtime mutation runner")
+	}
+}
 
-	busySeen := make(chan struct{})
-	var closeBusy sync.Once
-	var attempts int32
+func TestSQLiteWorkflowInstanceStore_RunInPipelineTransactionUsesRuntimeMutationRunner(t *testing.T) {
+	db := newSQLiteWorkflowInstanceStoreTestDB(t)
+	runner := &recordingRuntimeMutationRunner{db: db}
+	store := NewSQLiteWorkflowInstanceStoreWithRuntimeMutationRunner(db, runner)
+	ctx := runtimecorrelation.WithRunID(context.Background(), uuid.NewString())
 	var postCommitActions int32
-	done := make(chan error, 1)
-	go func() {
-		done <- store.RunInPipelineTransaction(ctx, func(txctx context.Context, tx *sql.Tx) error {
-			if tx == nil {
-				return errors.New("pipeline transaction is required")
-			}
-			atomic.AddInt32(&attempts, 1)
-			if !QueuePipelinePostCommitAction(txctx, func() {
-				atomic.AddInt32(&postCommitActions, 1)
-			}) {
-				return errors.New("queue pipeline post-commit action")
-			}
-			_, err := tx.ExecContext(txctx, `
-				INSERT INTO runs (run_id, status, started_at)
-				VALUES (?, 'running', ?)
-			`, uuid.NewString(), time.Now().UTC())
-			if sqlitePipelineBusyError(err) {
-				closeBusy.Do(func() { close(busySeen) })
-			}
-			return err
-		})
-	}()
 
-	select {
-	case <-busySeen:
-	case <-ctx.Done():
-		t.Fatalf("wait for deterministic sqlite busy attempt: %v", ctx.Err())
-	}
-	if err := lockTx.Commit(); err != nil {
-		t.Fatalf("release sqlite write lock: %v", err)
-	}
-	lockCommitted = true
-
-	select {
-	case err := <-done:
-		if err != nil {
-			t.Fatalf("RunInPipelineTransaction after lock release: %v", err)
+	err := store.RunInPipelineTransaction(ctx, func(txctx context.Context, tx *sql.Tx) error {
+		if tx == nil {
+			return errors.New("pipeline transaction is required")
 		}
-	case <-ctx.Done():
-		t.Fatalf("wait for retried pipeline transaction: %v", ctx.Err())
+		if !QueuePipelinePostCommitAction(txctx, func() {
+			atomic.AddInt32(&postCommitActions, 1)
+		}) {
+			return errors.New("queue pipeline post-commit action")
+		}
+		_, err := tx.ExecContext(txctx, `
+			INSERT INTO runs (run_id, status, started_at)
+			VALUES (?, 'running', ?)
+		`, uuid.NewString(), time.Now().UTC())
+		return err
+	})
+	if err != nil {
+		t.Fatalf("RunInPipelineTransaction with runtime mutation runner: %v", err)
 	}
-	if got := atomic.LoadInt32(&attempts); got < 2 {
-		t.Fatalf("attempts = %d, want retry after busy", got)
+	if got := atomic.LoadInt32(&runner.calls); got != 1 {
+		t.Fatalf("runtime mutation calls = %d, want 1", got)
 	}
 	if got := atomic.LoadInt32(&postCommitActions); got != 1 {
-		t.Fatalf("post-commit actions = %d, want only successful attempt flushed", got)
-	}
-}
-
-func TestSQLiteWorkflowInstanceStore_RunInPipelineTransactionStopsRetryOnContextDeadline(t *testing.T) {
-	db, lockDB := newSQLiteWorkflowInstanceStoreBusyTestDBs(t)
-	store := NewSQLiteWorkflowInstanceStore(db)
-	baseCtx := runtimecorrelation.WithRunID(context.Background(), uuid.NewString())
-
-	lockTx, err := lockDB.BeginTx(baseCtx, nil)
-	if err != nil {
-		t.Fatalf("begin locking tx: %v", err)
-	}
-	t.Cleanup(func() { _ = lockTx.Rollback() })
-	if _, err := lockTx.ExecContext(baseCtx, `
-		INSERT INTO runs (run_id, status, started_at)
-		VALUES (?, 'running', ?)
-	`, uuid.NewString(), time.Now().UTC()); err != nil {
-		t.Fatalf("hold sqlite write lock: %v", err)
-	}
-
-	ctx, cancel := context.WithTimeout(baseCtx, 35*time.Millisecond)
-	defer cancel()
-	var attempts int32
-	err = store.RunInPipelineTransaction(ctx, func(txctx context.Context, tx *sql.Tx) error {
-		atomic.AddInt32(&attempts, 1)
-		_, err := tx.ExecContext(txctx, `
-			INSERT INTO runs (run_id, status, started_at)
-			VALUES (?, 'running', ?)
-		`, uuid.NewString(), time.Now().UTC())
-		return err
-	})
-	if !errors.Is(err, context.DeadlineExceeded) {
-		t.Fatalf("RunInPipelineTransaction error = %v, want context deadline", err)
-	}
-	if got := atomic.LoadInt32(&attempts); got == 0 {
-		t.Fatal("expected at least one busy attempt before context deadline")
-	}
-}
-
-func TestSQLiteWorkflowInstanceStore_RunInPipelineTransactionCapsProductionBusyTimeout(t *testing.T) {
-	const (
-		driverBusyTimeout = 50 * time.Millisecond
-		retryBudget       = 120 * time.Millisecond
-	)
-	db, lockDB := newSQLiteWorkflowInstanceStoreBusyTestDBsWithBusyTimeout(t, driverBusyTimeout)
-	store := NewSQLiteWorkflowInstanceStore(db)
-	baseCtx := runtimecorrelation.WithRunID(context.Background(), uuid.NewString())
-	ctx, cancel := context.WithTimeout(baseCtx, time.Second)
-	defer cancel()
-
-	lockTx, err := lockDB.BeginTx(ctx, nil)
-	if err != nil {
-		t.Fatalf("begin locking tx: %v", err)
-	}
-	t.Cleanup(func() { _ = lockTx.Rollback() })
-	if _, err := lockTx.ExecContext(ctx, `
-		INSERT INTO runs (run_id, status, started_at)
-		VALUES (?, 'running', ?)
-	`, uuid.NewString(), time.Now().UTC()); err != nil {
-		t.Fatalf("hold sqlite write lock: %v", err)
-	}
-
-	var attempts int32
-	start := time.Now()
-	err = store.runInSQLitePipelineTransactionWithBudget(ctx, func(txctx context.Context, tx *sql.Tx) error {
-		atomic.AddInt32(&attempts, 1)
-		_, err := tx.ExecContext(txctx, `
-			INSERT INTO runs (run_id, status, started_at)
-			VALUES (?, 'running', ?)
-		`, uuid.NewString(), time.Now().UTC())
-		return err
-	}, retryBudget)
-	elapsed := time.Since(start)
-	if err == nil {
-		t.Fatal("RunInPipelineTransaction succeeded under persistent sqlite write lock")
-	}
-	if !strings.Contains(err.Error(), "retry budget") || !sqlitePipelineBusyError(err) {
-		t.Fatalf("RunInPipelineTransaction error = %v, want busy retry budget exhaustion", err)
-	}
-	if got := atomic.LoadInt32(&attempts); got == 0 {
-		t.Fatal("expected at least one sqlite busy attempt before retry budget exhaustion")
-	}
-	if elapsed >= time.Second {
-		t.Fatalf("elapsed = %s, want retry budget to cap sqlite busy retries", elapsed)
+		t.Fatalf("post-commit actions = %d, want 1", got)
 	}
 }
 
@@ -341,11 +230,14 @@ func TestWorkflowInstanceStore_RunInPipelineTransactionDoesNotRetryPostgresDiale
 
 type recordingRuntimeMutationRunner struct {
 	db    *sql.DB
+	mu    sync.Mutex
 	calls int32
 }
 
 func (r *recordingRuntimeMutationRunner) RunRuntimeMutation(ctx context.Context, fn func(context.Context, *sql.Tx) error) error {
 	atomic.AddInt32(&r.calls, 1)
+	r.mu.Lock()
+	defer r.mu.Unlock()
 	tx, err := r.db.BeginTx(ctx, nil)
 	if err != nil {
 		return err
@@ -356,7 +248,8 @@ func (r *recordingRuntimeMutationRunner) RunRuntimeMutation(ctx context.Context,
 			_ = tx.Rollback()
 		}
 	}()
-	txctx := WithPipelineSQLTxContext(ctx, tx)
+	postCommit := make([]func(), 0, 4)
+	txctx := withPipelinePostCommitActions(WithPipelineSQLTxContext(ctx, tx), &postCommit)
 	if err := fn(txctx, tx); err != nil {
 		return err
 	}
@@ -364,7 +257,13 @@ func (r *recordingRuntimeMutationRunner) RunRuntimeMutation(ctx context.Context,
 		return err
 	}
 	committed = true
+	flushPipelinePostCommitActions(postCommit)
 	return nil
+}
+
+func newSQLiteWorkflowInstanceStoreForTest(t *testing.T, db *sql.DB) *WorkflowInstanceStore {
+	t.Helper()
+	return NewSQLiteWorkflowInstanceStoreWithRuntimeMutationRunner(db, &recordingRuntimeMutationRunner{db: db})
 }
 
 func newSQLiteWorkflowInstanceStoreTestDB(t *testing.T) *sql.DB {
@@ -376,45 +275,6 @@ func newSQLiteWorkflowInstanceStoreTestDB(t *testing.T) *sql.DB {
 	}
 	t.Cleanup(func() { _ = db.Close() })
 	createSQLiteWorkflowInstanceStoreTestSchema(t, db)
-	return db
-}
-
-func newSQLiteWorkflowInstanceStoreBusyTestDBs(t *testing.T) (*sql.DB, *sql.DB) {
-	t.Helper()
-	return newSQLiteWorkflowInstanceStoreBusyTestDBsWithBusyTimeout(t, time.Millisecond)
-}
-
-func newSQLiteWorkflowInstanceStoreBusyTestDBsWithBusyTimeout(t *testing.T, busyTimeout time.Duration) (*sql.DB, *sql.DB) {
-	t.Helper()
-	path := filepath.Join(t.TempDir(), "workflow.db")
-	workflowDB := openSQLiteWorkflowInstanceStoreBusyTestDB(t, path, busyTimeout)
-	lockDB := openSQLiteWorkflowInstanceStoreBusyTestDB(t, path, busyTimeout)
-	createSQLiteWorkflowInstanceStoreTestSchema(t, workflowDB)
-	return workflowDB, lockDB
-}
-
-func openSQLiteWorkflowInstanceStoreBusyTestDB(t *testing.T, path string, busyTimeout time.Duration) *sql.DB {
-	t.Helper()
-	db, err := sql.Open("sqlite", path)
-	if err != nil {
-		t.Fatalf("open sqlite file db: %v", err)
-	}
-	db.SetMaxOpenConns(4)
-	db.SetMaxIdleConns(4)
-	t.Cleanup(func() { _ = db.Close() })
-	busyTimeoutMillis := int(busyTimeout / time.Millisecond)
-	if busyTimeout > 0 && busyTimeoutMillis == 0 {
-		busyTimeoutMillis = 1
-	}
-	for _, stmt := range []string{
-		`PRAGMA foreign_keys = ON`,
-		`PRAGMA journal_mode = WAL`,
-		fmt.Sprintf(`PRAGMA busy_timeout = %d`, busyTimeoutMillis),
-	} {
-		if _, err := db.Exec(stmt); err != nil {
-			t.Fatalf("configure sqlite file db: %v", err)
-		}
-	}
 	return db
 }
 

--- a/internal/store/runtime_mutation_guard_test.go
+++ b/internal/store/runtime_mutation_guard_test.go
@@ -271,6 +271,25 @@ func TestSelectedSQLiteRuntimeConstructionConsumesMutationBoundary(t *testing.T)
 	if !strings.Contains(string(publishData), ".RunEventTransaction(ctx,") {
 		t.Fatal("event publish must consume EventTransactionRunner.RunEventTransaction when available")
 	}
+
+	pipelineData, err := os.ReadFile(filepath.Join(root, "internal", "runtime", "pipeline", "workflow_instance_store.go"))
+	if err != nil {
+		t.Fatalf("read internal/runtime/pipeline/workflow_instance_store.go: %v", err)
+	}
+	pipelineText := string(pipelineData)
+	for _, forbidden := range []string{
+		"runInSQLitePipelineTransaction",
+		"sqlitePipelineBusyError",
+		"sqlitePipelineTransactionRetry",
+		"lockSQLitePipelineOperation",
+	} {
+		if strings.Contains(pipelineText, forbidden) {
+			t.Fatalf("SQLite pipeline store must not own busy/retry policy through %s", forbidden)
+		}
+	}
+	if !strings.Contains(pipelineText, "errSQLiteWorkflowInstanceStoreRuntimeMutationRunnerRequired") {
+		t.Fatal("SQLite pipeline writes must fail closed when no RuntimeMutationRunner is injected")
+	}
 }
 
 func collectRuntimeWriterCallSites(root string) ([]runtimeWriterCallSite, error) {
@@ -722,11 +741,11 @@ func classifyWorkflowInstanceStoreSpecCallSite(site runtimeWriterCallSite) (runt
 	switch site.Function {
 	case "runInPipelineTransactionOnce":
 		if site.Kind == primitiveBegin {
-			return classSplitLegacy, "named pipeline transaction owner opens a transaction before invoking the callback", true
+			return classDifferentConcept, "Postgres workflow pipeline transaction owner; SQLite requires the selected runtime mutation boundary before this path", true
 		}
 	case "workflowInstanceStoreTx":
 		if site.Kind == primitiveBegin {
-			return classSplitLegacy, "named old fallback helper opens a transaction when no active pipeline tx exists", true
+			return classDifferentConcept, "Postgres workflow instance helper opens a local transaction; SQLite writes consume the selected runtime mutation boundary", true
 		}
 	case "MarkTerminated", "upsertSpec", "createSpec":
 		if site.CallReceiver == "tx" {

--- a/internal/store/sqlite_runtime_test.go
+++ b/internal/store/sqlite_runtime_test.go
@@ -298,7 +298,7 @@ func TestSQLiteRuntimeStoreUpsertAgentConsumesActivePipelineTransaction(t *testi
 func TestSQLiteDynamicFlowActivationRequiredAgentsUsePipelineTransaction(t *testing.T) {
 	ctx := runtimecorrelation.WithRunID(context.Background(), uuid.NewString())
 	sqliteStore := newBootstrappedSQLiteRuntimeStoreForTest(t)
-	workflowStore := runtimepipeline.NewSQLiteWorkflowInstanceStore(sqliteStore.DB)
+	workflowStore := runtimepipeline.NewSQLiteWorkflowInstanceStoreWithRuntimeMutationRunner(sqliteStore.DB, sqliteStore)
 	bus := &sqliteFlowActivationBus{}
 	manager := runtimemanager.NewAgentManagerWithOptions(bus, nil, runtimemanager.AgentManagerOptions{
 		WorkflowInstances: workflowStore,
@@ -337,7 +337,7 @@ func TestSQLiteDynamicFlowActivationRequiredAgentsUsePipelineTransaction(t *test
 func TestSQLiteDynamicFlowActivationConcurrentFanOutChildrenPersist(t *testing.T) {
 	ctx := runtimecorrelation.WithRunID(context.Background(), uuid.NewString())
 	sqliteStore := newBootstrappedSQLiteRuntimeStoreForTest(t)
-	workflowStore := runtimepipeline.NewSQLiteWorkflowInstanceStore(sqliteStore.DB)
+	workflowStore := runtimepipeline.NewSQLiteWorkflowInstanceStoreWithRuntimeMutationRunner(sqliteStore.DB, sqliteStore)
 	bus := &sqliteFlowActivationBus{}
 	manager := runtimemanager.NewAgentManagerWithOptions(bus, nil, runtimemanager.AgentManagerOptions{
 		WorkflowInstances: workflowStore,
@@ -843,7 +843,7 @@ func TestSQLiteRuntimeStorePipelineWorkflowInstanceOwner(t *testing.T) {
 	store := newBootstrappedSQLiteRuntimeStoreForTest(t)
 	runID := uuid.NewString()
 	ctx = runtimecorrelation.WithRunID(ctx, runID)
-	owner := runtimepipeline.NewSQLiteWorkflowInstanceStore(store.DB)
+	owner := runtimepipeline.NewSQLiteWorkflowInstanceStoreWithRuntimeMutationRunner(store.DB, store)
 	entityID := runtimepipeline.FlowInstanceEntityID("root/acme")
 	if err := owner.Create(ctx, runtimepipeline.WorkflowInstance{
 		InstanceID:      "acme",
@@ -908,7 +908,7 @@ func TestSQLiteRuntimeStoreSystemNodeReceiptOwnerSettlesDelivery(t *testing.T) {
 	if err := store.InsertEventDeliveryRoutes(ctx, eventID, []events.DeliveryRoute{{SubscriberType: "node", SubscriberID: "background-node"}}); err != nil {
 		t.Fatalf("InsertEventDeliveryRoutes: %v", err)
 	}
-	owner := runtimepipeline.NewSQLiteWorkflowInstanceStore(store.DB)
+	owner := runtimepipeline.NewSQLiteWorkflowInstanceStoreWithRuntimeMutationRunner(store.DB, store)
 	if processed, err := owner.SystemNodeProcessed(ctx, "background-node", eventID); err != nil || processed {
 		t.Fatalf("SystemNodeProcessed before mark = %v err=%v, want false nil", processed, err)
 	}
@@ -971,7 +971,7 @@ func TestSQLiteRuntimeStoreSystemNodeReceiptOwnerDeadLettersDelivery(t *testing.
 	if err := store.InsertEventDeliveryRoutes(ctx, eventID, []events.DeliveryRoute{{SubscriberType: "node", SubscriberID: "background-node"}}); err != nil {
 		t.Fatalf("InsertEventDeliveryRoutes: %v", err)
 	}
-	owner := runtimepipeline.NewSQLiteWorkflowInstanceStore(store.DB)
+	owner := runtimepipeline.NewSQLiteWorkflowInstanceStoreWithRuntimeMutationRunner(store.DB, store)
 	if err := owner.MarkSystemNodeDeliveryInProgress(ctx, "background-node", eventID, runtimepipeline.DefaultSystemNodeRetryLimit); err != nil {
 		t.Fatalf("MarkSystemNodeDeliveryInProgress: %v", err)
 	}
@@ -1019,7 +1019,7 @@ func TestSQLiteRuntimeStoreSystemNodeReceiptOwnerFailsWithoutDeliveryAuthority(t
 	if err := store.AppendEvent(ctx, evt); err != nil {
 		t.Fatalf("AppendEvent: %v", err)
 	}
-	owner := runtimepipeline.NewSQLiteWorkflowInstanceStore(store.DB)
+	owner := runtimepipeline.NewSQLiteWorkflowInstanceStoreWithRuntimeMutationRunner(store.DB, store)
 	err := owner.MarkSystemNodeProcessedAndSettleDelivery(ctx, "background-node", eventID, `{"idempotency_key":"test"}`)
 	if !errors.Is(err, runtimepipeline.ErrSystemNodeDeliveryAuthorityMissing) {
 		t.Fatalf("MarkSystemNodeProcessedAndSettleDelivery error = %v, want ErrSystemNodeDeliveryAuthorityMissing", err)
@@ -1079,7 +1079,7 @@ func TestSQLiteRuntimeStoreSystemNodeReceiptOwnerFailsWithTerminalDeliveryAuthor
 			`, uuid.NewString(), runID, eventID, tc.status, tc.retryCount, time.Now().UTC()); err != nil {
 				t.Fatalf("seed sqlite terminal node delivery: %v", err)
 			}
-			owner := runtimepipeline.NewSQLiteWorkflowInstanceStore(store.DB)
+			owner := runtimepipeline.NewSQLiteWorkflowInstanceStoreWithRuntimeMutationRunner(store.DB, store)
 			err := owner.MarkSystemNodeProcessedAndSettleDelivery(ctx, "background-node", eventID, `{"idempotency_key":"test"}`)
 			if !errors.Is(err, runtimepipeline.ErrSystemNodeDeliveryAuthorityMissing) {
 				t.Fatalf("MarkSystemNodeProcessedAndSettleDelivery error = %v, want ErrSystemNodeDeliveryAuthorityMissing", err)

--- a/internal/store/store_abstraction_guard_matrix_test.go
+++ b/internal/store/store_abstraction_guard_matrix_test.go
@@ -100,11 +100,11 @@ func TestSelectedStoreAbstractionGuardMatrixRejectsStaleProofRefs(t *testing.T) 
 		{
 			name: "split row classification is pinned",
 			mutate: func(matrix *selectedStoreAbstractionGuardMatrix) {
-				row := selectedStoreAbstractionRowByID(t, matrix, "sqlite_busy_serialization_behavior_split")
+				row := selectedStoreAbstractionRowByID(t, matrix, "mutation_uow_behavior_split")
 				row.Classification = "guard"
 				row.Tier = "required_smoke"
 			},
-			want: "sqlite_busy_serialization_behavior_split classification = \"guard\", want \"split_to_existing_issue\"",
+			want: "mutation_uow_behavior_split classification = \"guard\", want \"split_to_existing_issue\"",
 		},
 		{
 			name: "split row issue set is pinned",
@@ -284,7 +284,7 @@ func expectedSelectedStoreAbstractionRowShapes() map[string]selectedStoreAbstrac
 		"raw_selected_runtime_writer_boundary_guard": {
 			Classification:         "guard",
 			Tier:                   "required_smoke",
-			SplitIssues:            []int{1403, 1405},
+			SplitIssues:            []int{1403},
 			RequiresGuardProofRefs: true,
 		},
 		"sqlite_runtime_sqldb_omission_guard": {
@@ -318,10 +318,10 @@ func expectedSelectedStoreAbstractionRowShapes() map[string]selectedStoreAbstrac
 			Tier:           "split_open",
 			SplitIssues:    []int{1403},
 		},
-		"sqlite_busy_serialization_behavior_split": {
-			Classification: "split_to_existing_issue",
-			Tier:           "split_open",
-			SplitIssues:    []int{1405},
+		"sqlite_busy_serialization_behavior_guard": {
+			Classification:         "guard",
+			Tier:                   "required_smoke",
+			RequiresGuardProofRefs: true,
 		},
 	}
 }
@@ -495,7 +495,7 @@ func requiredSelectedStoreAbstractionRows() map[string]struct{} {
 		"api_idempotency_public_surface_accounting",
 		"runtime_log_readback_public_surface_accounting",
 		"mutation_uow_behavior_split",
-		"sqlite_busy_serialization_behavior_split",
+		"sqlite_busy_serialization_behavior_guard",
 	})
 }
 

--- a/internal/store/testdata/selected_store_abstraction_guard_matrix.yaml
+++ b/internal/store/testdata/selected_store_abstraction_guard_matrix.yaml
@@ -76,10 +76,11 @@ rows:
         name: TestRuntimeWriterBoundaryGuardRejectsPipelineSQLiteDBHelperBypassFixture
       - kind: go_test
         name: TestRuntimeWriterBoundaryGuardRejectsPipelineSQLiteRawDBHelperFixture
-    split_issues: [1403, 1405]
+    split_issues: [1403]
     notes: >
       This row guards the boundary. Behavior-changing mutation UoW migration
-      remains #1403 and SQLite busy/serialization policy remains #1405.
+      remains #1403; SQLite busy/serialization policy is guarded by the #1405
+      row in this matrix.
 
   - id: sqlite_runtime_sqldb_omission_guard
     classification: guard
@@ -233,18 +234,38 @@ rows:
       #1402 may guard/account for this seam, but production mutation behavior
       migration belongs to #1403.
 
-  - id: sqlite_busy_serialization_behavior_split
-    classification: split_to_existing_issue
-    tier: split_open
+  - id: sqlite_busy_serialization_behavior_guard
+    classification: guard
+    tier: required_smoke
     concepts:
       - SQLite write serialization and SQLITE_BUSY policy
     owners:
       - internal/store.SQLiteRuntimeStore mutation executor
-      - future #1405 store-internal busy policy owner
-    split_issues: [1405]
+      - internal/runtime/pipeline.WorkflowInstanceStore RuntimeMutationRunner requirement
+      - internal/store/runtime_mutation_guard_test.go
     proof_refs:
       - kind: artifact
         path: platform-spec.yaml
+      - kind: go_test
+        name: TestSQLiteRuntimeStore_RunRuntimeMutationRetriesBusyAndFlushesPostCommitOnce
+      - kind: go_test
+        name: TestSQLiteRuntimeStore_RunRuntimeMutationStopsRetryOnContextDeadline
+      - kind: go_test
+        name: TestSQLiteRuntimeStore_RunRuntimeMutationContextDeadlineCapsDriverBusyTimeout
+      - kind: go_test
+        name: TestSQLiteRuntimeStore_RunRuntimeMutationDoesNotRetryActiveTransaction
+      - kind: go_test
+        name: TestSQLiteWorkflowInstanceStore_RunInPipelineTransactionRequiresRuntimeMutationRunner
+      - kind: go_test
+        name: TestSQLiteWorkflowInstanceStore_RunInPipelineTransactionUsesRuntimeMutationRunner
+      - kind: go_test
+        name: TestPostgresStore_RunEventTransactionDoesNotSerializeCallbacks
+    guard_proof_refs:
+      - kind: go_test
+        name: TestSelectedSQLiteRuntimeConstructionConsumesMutationBoundary
+      - kind: go_test
+        name: TestSQLiteWorkflowInstanceStore_RunInPipelineTransactionRequiresRuntimeMutationRunner
     notes: >
-      #1402 may prove producers do not own SQLite busy policy. Moving the policy
-      fully below the store boundary remains #1405.
+      SQLite busy/retry policy belongs below the store boundary. Pipeline writes
+      require an injected RuntimeMutationRunner and must not own a fallback
+      SQLite retry classifier or queue.

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -2666,6 +2666,7 @@ engine:
         serialization or retry behavior.
       rules:
       - SQLite runtime mutation producers must not implement local SQLITE_BUSY retry loops or open independent write transactions when a selected runtime store boundary is available.
+      - SQLite workflow/pipeline mutation methods must consume the selected RuntimeMutationRunner and must fail closed instead of opening a local fallback transaction when that runner is absent.
       - SQLite driver busy_timeout must stay short; elapsed retry budget, cancellation, and backoff are owned by the selected mutation boundary rather than by long driver-level waits.
       - SQLite post-commit action flushing must happen after the selected mutation boundary releases its process-local write serialization lock, so post-commit callbacks can safely re-enter selected runtime mutation APIs.
       - SQLite API idempotency callback execution must stay outside the idempotency row write transaction; failed callbacks must not persist completion.
@@ -2702,7 +2703,9 @@ engine:
         persistence, background-node receipt settlement, pipeline receipt replay, process-local replay claims, and committed
         replay scope consumption. Production SQLite pipeline writes consume the backend_neutral_runtime_mutation_write_boundary
         instead of owning a separate local retry/serialization policy, so pipeline producers do not branch on backend write
-        contention. Postgres remains authoritative for production cross-runtime transaction and claim semantics.
+        contention. A SQLite WorkflowInstanceStore constructed without the selected RuntimeMutationRunner is not selected
+        runtime write authority and must fail closed for pipeline mutation entry points. Postgres remains authoritative for
+        production cross-runtime transaction and claim semantics.
       excludes:
       - tool executor entity and human-task persistence owned by runtime_tool_entity_and_human_task_rows
       - runtime diagnostics/logging owned by #1150


### PR DESCRIPTION
Closes #1405

## Summary
- removes the pipeline-local SQLite busy/retry/serialization implementation from `WorkflowInstanceStore`
- makes SQLite pipeline mutation entry points fail closed unless constructed with the selected `RuntimeMutationRunner`
- keeps busy retry/cancellation/post-commit ownership in `SQLiteRuntimeStore.RunRuntimeMutation` / `RunEventTransaction`
- updates the selected-store guard matrix and `platform-spec.yaml` to pin the #1405 boundary

## Governing refs
- `platform-spec.yaml`: `selected_runtime_mutation_unit_of_work`
- `platform-spec.yaml`: `backend_neutral_runtime_mutation_write_boundary`
- `platform-spec.yaml`: `pipeline_coordination_workflow_instance_and_replay_rows`
- `platform-spec.yaml`: `raw_sql_runtime_consumer_boundary_for_sqlite`
- #1405 pre-audit and approved gate outcome

## Semantic migration
- New canonical owner: `internal/store.SQLiteRuntimeStore.RunRuntimeMutation` and `RunEventTransaction` for SQLite selected-runtime busy/retry/serialization policy.
- Old producer/reader/writer path now invalid: `WorkflowInstanceStore` pipeline-local SQLite retry helpers, busy classifier, single-writer lock, and bare selected SQLite pipeline writes without a `RuntimeMutationRunner`.
- Production paths checked for surviving old behavior: cmd/swarm SQLite construction, event publish transaction owner, selected-store guard matrix, workflow pipeline tests, system-node receipt read-side locks, and bare `NewSQLiteWorkflowInstanceStore(sqliteStore.DB)` construction guard.
- Migration status: complete for the approved #1405 child class. #1403 typed runtime mutation UoW remains separate.

## Validation
- `go test ./internal/runtime/pipeline -run 'TestSQLiteWorkflowInstanceStore|TestCreateEntityHandlerEffectsAreExactOnceAcrossStoreMutations|TestDispatchWorkflowNodeEventSkipsAlreadyProcessedCreateEntityHandler|TestSQLiteFanOutCreateFlowInstanceDeliveriesPersistWithoutDeadLetter|TestWorkflowInstanceStore_RunInPipelineTransactionDoesNotRetryPostgresDialect' -count=1`
- `go test ./internal/store ./cmd/swarm ./internal/apiv1 -run 'TestSelectedStoreAbstractionGuardMatrix|TestSelectedStoreFacadeOwnsProducerBackendBranching|TestSelectedStoreFacadeBackendBranchingGuardRejectsProducerFixture|TestSelectedSQLiteRuntimeWriterBoundaryAudit|TestRuntimeWriterBoundaryGuardRejects|TestSelectedSQLiteRuntimeConstructionConsumesMutationBoundary|TestPublicSurfaceBackendMatrixCoversSelectedBackendRows|TestPublicSurfaceBackendMatrixRejectsStaleReferences|TestBuildStoresAcceptsSQLiteSelectedCoreRuntimeStore|TestBuildStoresSQLiteRuntimeNoLongerFailsClosedOnMailboxMaterializationOwner|TestRunCommandLocalForegroundConsumesServeOwnerAndV1API|TestRunServeRuntimeConsumesCanonicalStoreSelectionBeforeStoreConstruction|TestRunServeRuntimeFreshEmptyPostgresBootstrapsSchemaBeforeDiskContractsServe|TestOperatorMailboxWriteSupportedSurfacePublishesAndReadsAcrossBackends' -count=1`
- `go test ./...`
