### PR TITLE
[agent-c][issue #1414] Replace runtime mutation tx callbacks

### DIFF
--- a/internal/apiv1/operator_event_publish_test.go
+++ b/internal/apiv1/operator_event_publish_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/division-sh/swarm/internal/runtime/flowmodel"
 	runtimeingress "github.com/division-sh/swarm/internal/runtime/ingress"
 	"github.com/division-sh/swarm/internal/runtime/lifecycleprobe/lifecycletest"
+	runtimepipeline "github.com/division-sh/swarm/internal/runtime/pipeline"
 	runtimereplayclaim "github.com/division-sh/swarm/internal/runtime/replayclaim"
 	"github.com/division-sh/swarm/internal/runtime/semanticview"
 	"github.com/division-sh/swarm/internal/store"
@@ -1472,6 +1473,64 @@ func (s *failStandalonePipelineReceiptOnceStore) UpsertPipelineReceiptTx(ctx con
 type failCommittedReplayScopeStore struct {
 	*store.PostgresStore
 	err error
+}
+
+type failCommittedReplayScopeMutation struct {
+	ctx   context.Context
+	tx    *sql.Tx
+	store *failCommittedReplayScopeStore
+}
+
+func (s *failCommittedReplayScopeStore) RunEventMutation(ctx context.Context, fn func(runtimebus.EventMutation) error) error {
+	if fn == nil {
+		return nil
+	}
+	tx, err := s.DB.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	postCommit := make([]func(), 0, 4)
+	txctx := runtimepipeline.WithPipelineSQLTxContext(ctx, tx)
+	txctx = runtimepipeline.WithPipelinePostCommitActions(txctx, &postCommit)
+	mutation := &failCommittedReplayScopeMutation{tx: tx, store: s}
+	mutation.ctx = runtimebus.WithEventMutationContext(txctx, mutation)
+	if err := fn(mutation); err != nil {
+		_ = tx.Rollback()
+		return err
+	}
+	if err := tx.Commit(); err != nil {
+		return err
+	}
+	runtimepipeline.FlushPipelinePostCommitActions(postCommit)
+	return nil
+}
+
+func (m *failCommittedReplayScopeMutation) Context() context.Context {
+	return m.ctx
+}
+
+func (m *failCommittedReplayScopeMutation) AppendEvent(ctx context.Context, evt events.Event) error {
+	return m.store.AppendEventTx(ctx, m.tx, evt)
+}
+
+func (m *failCommittedReplayScopeMutation) InsertEventDeliveries(ctx context.Context, eventID string, agentIDs []string) error {
+	return m.store.InsertEventDeliveriesTx(ctx, m.tx, eventID, agentIDs)
+}
+
+func (m *failCommittedReplayScopeMutation) InsertEventDeliveriesWithTargets(ctx context.Context, eventID string, agentIDs []string, deliveryTargets map[string]events.RouteIdentity) error {
+	return m.store.InsertEventDeliveriesWithTargetsTx(ctx, m.tx, eventID, agentIDs, deliveryTargets)
+}
+
+func (m *failCommittedReplayScopeMutation) InsertEventDeliveryRoutes(ctx context.Context, eventID string, routes []events.DeliveryRoute) error {
+	return m.store.InsertEventDeliveryRoutesTx(ctx, m.tx, eventID, routes)
+}
+
+func (m *failCommittedReplayScopeMutation) UpsertCommittedReplayScope(ctx context.Context, eventID string, scope runtimereplayclaim.CommittedReplayScope) error {
+	return m.store.UpsertCommittedReplayScopeTx(ctx, m.tx, eventID, scope)
+}
+
+func (m *failCommittedReplayScopeMutation) UpsertPipelineReceipt(ctx context.Context, eventID, status, errText string) error {
+	return m.store.UpsertPipelineReceiptTx(ctx, m.tx, eventID, status, errText)
 }
 
 func (s *failCommittedReplayScopeStore) UpsertCommittedReplayScopeTx(ctx context.Context, tx *sql.Tx, eventID string, scope runtimereplayclaim.CommittedReplayScope) error {

--- a/internal/runtime/bus/eventbus_publish.go
+++ b/internal/runtime/bus/eventbus_publish.go
@@ -188,12 +188,15 @@ func (eb *EventBus) Publish(ctx context.Context, evt events.Event) (err error) {
 	defer func() {
 		runtimepipeline.FlushPipelineAfterPublishActions(afterPublishActions)
 	}()
-	if txStore, ok := eb.store.(TransactionalEventStore); ok {
-		if err := eb.publishTransactional(ictx, evt, start, &deferredTransitions, txStore); err != nil {
+	if mutationRunner, ok := eb.store.(EventMutationRunner); ok && mutationRunner != nil {
+		if err := eb.publishTransactional(ictx, evt, start, &deferredTransitions, mutationRunner); err != nil {
 			return err
 		}
 		eb.recordCommittedPublishConvergence(ictx, evt)
 		return nil
+	}
+	if _, ok := eb.store.(TransactionalEventStore); ok {
+		return errors.New("typed event mutation runner is required for transactional publish")
 	}
 
 	persisted := false
@@ -289,8 +292,11 @@ func (eb *EventBus) PublishAcknowledged(ctx context.Context, evt events.Event) e
 		return err
 	}
 
-	if txStore, ok := eb.store.(TransactionalEventStore); ok {
-		return eb.publishAcknowledgedTransactional(ictx, evt, start, txStore)
+	if mutationRunner, ok := eb.store.(EventMutationRunner); ok && mutationRunner != nil {
+		return eb.publishAcknowledgedTransactional(ictx, evt, start, mutationRunner)
+	}
+	if _, ok := eb.store.(TransactionalEventStore); ok {
+		return errors.New("typed event mutation runner is required for transactional acknowledged publish")
 	}
 
 	receiptOverride := &runtimepipeline.PipelineReceiptOverride{}
@@ -321,8 +327,8 @@ func (eb *EventBus) PublishAcknowledged(ctx context.Context, evt events.Event) e
 }
 
 // PublishTx persists the canonical event record and recipient manifest in a
-// caller-owned transaction. Callers use this when another persisted state
-// transition must commit atomically with event emission.
+// caller-owned transaction. This is a split legacy/public API hook; selected
+// event/pipeline producers use EventMutationRunner and EventMutation instead.
 func (eb *EventBus) PublishTx(ctx context.Context, tx *sql.Tx, evt events.Event) error {
 	ctx = WithCurrentRuntimeEpoch(ctx)
 	if err := ensurePublishEpoch(ctx); err != nil {
@@ -518,150 +524,20 @@ func (eb *EventBus) publishTransactional(
 	evt events.Event,
 	start time.Time,
 	deferredTransitions *[]runtimepipeline.DeferredPipelineTransition,
-	txStore TransactionalEventStore,
+	runner EventMutationRunner,
 ) error {
 	ctx = WithCurrentRuntimeEpoch(ctx)
 	if err := ensurePublishEpoch(ctx); err != nil {
 		return err
 	}
-	if runner, ok := txStore.(EventTransactionRunner); ok && runner != nil {
-		return eb.publishTransactionalWithRunner(ctx, evt, start, deferredTransitions, txStore, runner)
-	}
-	tx, err := txStore.BeginEventTx(ctx)
-	if err != nil {
-		return fmt.Errorf("begin publish tx: %w", err)
-	}
-	txPostCommitActions := make([]func(), 0, 8)
-	txctx := runtimepipeline.WithPipelineSQLTxContext(ctx, tx)
-	txctx = runtimepipeline.WithPipelinePostCommitActions(txctx, &txPostCommitActions)
-	receiptOverride := &runtimepipeline.PipelineReceiptOverride{}
-	txctx = runtimepipeline.WithPipelineReceiptOverride(txctx, receiptOverride)
-	committed := false
-	defer func() {
-		if !committed {
-			_ = tx.Rollback()
-		}
-	}()
-
-	if err := txStore.AppendEventTx(txctx, tx, evt); err != nil {
-		return fmt.Errorf("persist event: %w", err)
-	}
-
-	inboundPlan, err := eb.planSubscribedRoutePlan(txctx, evt, true)
-	if err != nil {
-		return err
-	}
-	if inboundPlan.HasPersistentDeliveries() {
-		if err := eb.insertEventDeliveriesTx(txctx, txStore, tx, evt.ID(), inboundPlan.PersistedRecipientIDs(), inboundPlan.DeliveryTargets(), inboundPlan.DeliveryRoutes()); err != nil {
-			return fmt.Errorf("persist event deliveries: %w", err)
-		}
-	}
-	if scopeWriter, ok := eb.store.(TransactionalEventReplayScopePersistence); ok && scopeWriter != nil {
-		if err := scopeWriter.UpsertCommittedReplayScopeTx(txctx, tx, evt.ID(), runtimereplayclaim.CommittedReplayScopeSubscribed); err != nil {
-			return fmt.Errorf("persist committed replay scope: %w", err)
-		}
-	} else if replayScopePersistenceRequired(eb.store) {
-		return fmt.Errorf("persist committed replay scope: %w", runtimereplayclaim.ErrMissingCommittedReplayScope)
-	}
-	if inboundPlan.TargetFailure != "" {
-		applyTargetDeliveryFailureReceipt(receiptOverride, inboundPlan.TargetFailure)
-		status, errText := pipelineReceiptStatus(txctx, nil)
-		if err := txStore.UpsertPipelineReceiptTx(txctx, tx, evt.ID(), status, errText); err != nil {
-			return fmt.Errorf("persist pipeline receipt: %w", err)
-		}
-		if err := tx.Commit(); err != nil {
-			return fmt.Errorf("commit publish tx: %w", err)
-		}
-		committed = true
-		runtimepipeline.FlushPipelinePostCommitActions(txPostCommitActions)
-		eb.notifyTestPublishPersisted(ctx, evt, inboundPlan)
-		eb.recordTargetDeliveryFailure(ctx, evt, inboundPlan)
-		eb.logPublished(ctx, evt, int(time.Since(start)/time.Microsecond))
-		return nil
-	}
-
-	if reason, err := eb.dispatchQueueReason(txctx, evt); err != nil {
-		return err
-	} else if reason != "" {
-		if err := tx.Commit(); err != nil {
-			return fmt.Errorf("commit publish tx: %w", err)
-		}
-		committed = true
-		eb.notifyTestPublishPersisted(ctx, evt, inboundPlan)
-		eb.logDispatchQueued(ctx, reason, evt, len(inboundPlan.RecipientIDs()), false, false)
-		eb.logPublished(ctx, evt, int(time.Since(start)/time.Microsecond))
-		return nil
-	}
-
-	if err := tx.Commit(); err != nil {
-		return fmt.Errorf("commit publish tx: %w", err)
-	}
-	committed = true
-	runtimepipeline.FlushPipelinePostCommitActions(txPostCommitActions)
-	eb.notifyTestPublishPersisted(ctx, evt, inboundPlan)
-
-	postCommitActions := make([]func(), 0, 8)
-	dispatchCtx := runtimepipeline.WithoutPipelineSQLTxContext(ctx)
-	dispatchCtx = runtimepipeline.WithPipelinePostCommitActions(dispatchCtx, &postCommitActions)
-	dispatchCtx = runtimepipeline.WithPipelineReceiptOverride(dispatchCtx, receiptOverride)
-	passthrough, deferred, err := eb.runInterceptors(dispatchCtx, evt)
-	if err != nil {
-		eb.recordCommittedPublishReceipt(dispatchCtx, evt, err)
-		return err
-	}
-	runtimepipeline.FlushPipelinePostCommitActions(postCommitActions)
-	if deferredTransitions != nil {
-		runtimepipeline.FlushDeferredPipelineTransitions(dispatchCtx, *deferredTransitions)
-	}
-
-	if passthrough {
-		recipients := inboundPlan.RecipientIDs()
-		if len(recipients) > 0 {
-			eb.logQueuedDeliveries(dispatchCtx, evt, inboundPlan.PersistedRecipientIDs(), "matched_agent_subscription", inboundPlan.ExtraDetail)
-			if err := eb.deliverToRecipientsWithRoutes(dispatchCtx, evt, recipients, inboundPlan.DeliveryRoutes()); err != nil {
-				eb.recordCommittedPublishReceipt(dispatchCtx, evt, err)
-				return nil
-			}
-			eb.logDelivery(dispatchCtx, evt, recipients, inboundPlan.ExtraDetail)
-		}
-		if inboundPlan.BlockedByCycle && inboundPlan.CycleEscalation != nil {
-			if err := eb.publishDeferred(dispatchCtx, *inboundPlan.CycleEscalation); err != nil {
-				eb.recordCommittedPublishReceipt(dispatchCtx, evt, err)
-				return nil
-			}
-		}
-		if strings.TrimSpace(inboundPlan.ContradictionReason) != "" {
-			_ = eb.emitContradiction(dispatchCtx, evt, inboundPlan.ContradictionReason)
-		}
-	}
-	eb.logPublished(dispatchCtx, evt, int(time.Since(start)/time.Microsecond))
-
-	for _, d := range deferred {
-		if err := eb.publishDeferred(dispatchCtx, d); err != nil {
-			eb.recordCommittedPublishReceipt(dispatchCtx, evt, err)
-			return nil
-		}
-	}
-	eb.recordCommittedPublishReceipt(dispatchCtx, evt, nil)
-	return nil
-}
-
-func (eb *EventBus) publishTransactionalWithRunner(
-	ctx context.Context,
-	evt events.Event,
-	start time.Time,
-	deferredTransitions *[]runtimepipeline.DeferredPipelineTransition,
-	txStore TransactionalEventStore,
-	runner EventTransactionRunner,
-) error {
 	var inboundPlan RoutePlan
 	receiptOverride := &runtimepipeline.PipelineReceiptOverride{}
 	targetFailure := false
 	dispatchQueued := false
 	queueReason := ""
-	if err := runner.RunEventTransaction(ctx, func(txctx context.Context, tx *sql.Tx) error {
-		txctx = runtimepipeline.WithPipelineReceiptOverride(txctx, receiptOverride)
-		if err := txStore.AppendEventTx(txctx, tx, evt); err != nil {
+	if err := runner.RunEventMutation(ctx, func(mutation EventMutation) error {
+		txctx := runtimepipeline.WithPipelineReceiptOverride(mutation.Context(), receiptOverride)
+		if err := mutation.AppendEvent(txctx, evt); err != nil {
 			return fmt.Errorf("persist event: %w", err)
 		}
 		plan, err := eb.planSubscribedRoutePlan(txctx, evt, true)
@@ -670,21 +546,17 @@ func (eb *EventBus) publishTransactionalWithRunner(
 		}
 		inboundPlan = plan
 		if inboundPlan.HasPersistentDeliveries() {
-			if err := eb.insertEventDeliveriesTx(txctx, txStore, tx, evt.ID(), inboundPlan.PersistedRecipientIDs(), inboundPlan.DeliveryTargets(), inboundPlan.DeliveryRoutes()); err != nil {
+			if err := eb.insertEventDeliveriesMutation(txctx, mutation, evt.ID(), inboundPlan.PersistedRecipientIDs(), inboundPlan.DeliveryTargets(), inboundPlan.DeliveryRoutes()); err != nil {
 				return fmt.Errorf("persist event deliveries: %w", err)
 			}
 		}
-		if scopeWriter, ok := eb.store.(TransactionalEventReplayScopePersistence); ok && scopeWriter != nil {
-			if err := scopeWriter.UpsertCommittedReplayScopeTx(txctx, tx, evt.ID(), runtimereplayclaim.CommittedReplayScopeSubscribed); err != nil {
-				return fmt.Errorf("persist committed replay scope: %w", err)
-			}
-		} else if replayScopePersistenceRequired(eb.store) {
-			return fmt.Errorf("persist committed replay scope: %w", runtimereplayclaim.ErrMissingCommittedReplayScope)
+		if err := eb.upsertCommittedReplayScopeMutation(txctx, mutation, evt.ID(), runtimereplayclaim.CommittedReplayScopeSubscribed); err != nil {
+			return err
 		}
 		if inboundPlan.TargetFailure != "" {
 			applyTargetDeliveryFailureReceipt(receiptOverride, inboundPlan.TargetFailure)
 			status, errText := pipelineReceiptStatus(txctx, nil)
-			if err := txStore.UpsertPipelineReceiptTx(txctx, tx, evt.ID(), status, errText); err != nil {
+			if err := mutation.UpsertPipelineReceipt(txctx, evt.ID(), status, errText); err != nil {
 				return fmt.Errorf("persist pipeline receipt: %w", err)
 			}
 			targetFailure = true
@@ -763,106 +635,20 @@ func (eb *EventBus) publishAcknowledgedTransactional(
 	ctx context.Context,
 	evt events.Event,
 	start time.Time,
-	txStore TransactionalEventStore,
+	runner EventMutationRunner,
 ) error {
 	ctx = WithCurrentRuntimeEpoch(ctx)
 	if err := ensurePublishEpoch(ctx); err != nil {
 		return err
 	}
-	if runner, ok := txStore.(EventTransactionRunner); ok && runner != nil {
-		return eb.publishAcknowledgedTransactionalWithRunner(ctx, evt, start, txStore, runner)
-	}
-	tx, err := txStore.BeginEventTx(ctx)
-	if err != nil {
-		return fmt.Errorf("begin publish tx: %w", err)
-	}
-	txPostCommitActions := make([]func(), 0, 8)
-	txctx := runtimepipeline.WithPipelineSQLTxContext(ctx, tx)
-	txctx = runtimepipeline.WithPipelinePostCommitActions(txctx, &txPostCommitActions)
-	receiptOverride := &runtimepipeline.PipelineReceiptOverride{}
-	txctx = runtimepipeline.WithPipelineReceiptOverride(txctx, receiptOverride)
-	committed := false
-	defer func() {
-		if !committed {
-			_ = tx.Rollback()
-		}
-	}()
-
-	if err := txStore.AppendEventTx(txctx, tx, evt); err != nil {
-		return fmt.Errorf("persist event: %w", err)
-	}
-	inboundPlan, err := eb.planSubscribedRoutePlan(txctx, evt, true)
-	if err != nil {
-		return err
-	}
-	if inboundPlan.HasPersistentDeliveries() {
-		if err := eb.insertEventDeliveriesTx(txctx, txStore, tx, evt.ID(), inboundPlan.PersistedRecipientIDs(), inboundPlan.DeliveryTargets(), inboundPlan.DeliveryRoutes()); err != nil {
-			return fmt.Errorf("persist event deliveries: %w", err)
-		}
-	}
-	if scopeWriter, ok := eb.store.(TransactionalEventReplayScopePersistence); ok && scopeWriter != nil {
-		if err := scopeWriter.UpsertCommittedReplayScopeTx(txctx, tx, evt.ID(), runtimereplayclaim.CommittedReplayScopeSubscribed); err != nil {
-			return fmt.Errorf("persist committed replay scope: %w", err)
-		}
-	} else if replayScopePersistenceRequired(eb.store) {
-		return fmt.Errorf("persist committed replay scope: %w", runtimereplayclaim.ErrMissingCommittedReplayScope)
-	}
-	if inboundPlan.TargetFailure != "" {
-		applyTargetDeliveryFailureReceipt(receiptOverride, inboundPlan.TargetFailure)
-		status, errText := pipelineReceiptStatus(txctx, nil)
-		if err := txStore.UpsertPipelineReceiptTx(txctx, tx, evt.ID(), status, errText); err != nil {
-			return fmt.Errorf("persist pipeline receipt: %w", err)
-		}
-		if err := tx.Commit(); err != nil {
-			return fmt.Errorf("commit publish tx: %w", err)
-		}
-		committed = true
-		runtimepipeline.FlushPipelinePostCommitActions(txPostCommitActions)
-		eb.notifyTestPublishPersisted(ctx, evt, inboundPlan)
-		eb.recordTargetDeliveryFailure(ctx, evt, inboundPlan)
-		eb.logPublished(ctx, evt, int(time.Since(start)/time.Microsecond))
-		eb.recordCommittedPublishConvergence(ctx, evt)
-		return nil
-	}
-	if reason, err := eb.dispatchQueueReason(txctx, evt); err != nil {
-		return err
-	} else if reason != "" {
-		if err := tx.Commit(); err != nil {
-			return fmt.Errorf("commit publish tx: %w", err)
-		}
-		committed = true
-		runtimepipeline.FlushPipelinePostCommitActions(txPostCommitActions)
-		eb.notifyTestPublishPersisted(ctx, evt, inboundPlan)
-		eb.logDispatchQueued(ctx, reason, evt, len(inboundPlan.RecipientIDs()), false, true)
-		eb.logPublished(ctx, evt, int(time.Since(start)/time.Microsecond))
-		eb.recordCommittedPublishConvergence(ctx, evt)
-		return nil
-	}
-	if err := tx.Commit(); err != nil {
-		return fmt.Errorf("commit publish tx: %w", err)
-	}
-	committed = true
-	runtimepipeline.FlushPipelinePostCommitActions(txPostCommitActions)
-	eb.notifyTestPublishPersisted(ctx, evt, inboundPlan)
-	eb.dispatchCommittedPublishAsync(ctx, evt, inboundPlan)
-	return nil
-}
-
-func (eb *EventBus) publishAcknowledgedTransactionalWithRunner(
-	ctx context.Context,
-	evt events.Event,
-	start time.Time,
-	txStore TransactionalEventStore,
-	runner EventTransactionRunner,
-) error {
 	var inboundPlan RoutePlan
 	receiptOverride := &runtimepipeline.PipelineReceiptOverride{}
 	targetFailure := false
 	dispatchQueued := false
 	queueReason := ""
-	if err := runner.RunEventTransaction(ctx, func(txctx context.Context, tx *sql.Tx) error {
-		txctx = runtimepipeline.WithPipelineReceiptOverride(txctx, receiptOverride)
-		if err := txStore.AppendEventTx(txctx, tx, evt); err != nil {
+	if err := runner.RunEventMutation(ctx, func(mutation EventMutation) error {
+		txctx := runtimepipeline.WithPipelineReceiptOverride(mutation.Context(), receiptOverride)
+		if err := mutation.AppendEvent(txctx, evt); err != nil {
 			return fmt.Errorf("persist event: %w", err)
 		}
 		plan, err := eb.planSubscribedRoutePlan(txctx, evt, true)
@@ -871,21 +657,17 @@ func (eb *EventBus) publishAcknowledgedTransactionalWithRunner(
 		}
 		inboundPlan = plan
 		if inboundPlan.HasPersistentDeliveries() {
-			if err := eb.insertEventDeliveriesTx(txctx, txStore, tx, evt.ID(), inboundPlan.PersistedRecipientIDs(), inboundPlan.DeliveryTargets(), inboundPlan.DeliveryRoutes()); err != nil {
+			if err := eb.insertEventDeliveriesMutation(txctx, mutation, evt.ID(), inboundPlan.PersistedRecipientIDs(), inboundPlan.DeliveryTargets(), inboundPlan.DeliveryRoutes()); err != nil {
 				return fmt.Errorf("persist event deliveries: %w", err)
 			}
 		}
-		if scopeWriter, ok := eb.store.(TransactionalEventReplayScopePersistence); ok && scopeWriter != nil {
-			if err := scopeWriter.UpsertCommittedReplayScopeTx(txctx, tx, evt.ID(), runtimereplayclaim.CommittedReplayScopeSubscribed); err != nil {
-				return fmt.Errorf("persist committed replay scope: %w", err)
-			}
-		} else if replayScopePersistenceRequired(eb.store) {
-			return fmt.Errorf("persist committed replay scope: %w", runtimereplayclaim.ErrMissingCommittedReplayScope)
+		if err := eb.upsertCommittedReplayScopeMutation(txctx, mutation, evt.ID(), runtimereplayclaim.CommittedReplayScopeSubscribed); err != nil {
+			return err
 		}
 		if inboundPlan.TargetFailure != "" {
 			applyTargetDeliveryFailureReceipt(receiptOverride, inboundPlan.TargetFailure)
 			status, errText := pipelineReceiptStatus(txctx, nil)
-			if err := txStore.UpsertPipelineReceiptTx(txctx, tx, evt.ID(), status, errText); err != nil {
+			if err := mutation.UpsertPipelineReceipt(txctx, evt.ID(), status, errText); err != nil {
 				return fmt.Errorf("persist pipeline receipt: %w", err)
 			}
 			targetFailure = true
@@ -1364,6 +1146,52 @@ func (eb *EventBus) insertEventDeliveriesTx(
 		return store.InsertEventDeliveriesWithTargetsTx(ctx, tx, eventID, recipients, deliveryTargets)
 	}
 	return txStore.InsertEventDeliveriesTx(ctx, tx, eventID, recipients)
+}
+
+func (eb *EventBus) insertEventDeliveriesMutation(
+	ctx context.Context,
+	mutation EventMutation,
+	eventID string,
+	recipients []string,
+	deliveryTargets map[string]events.RouteIdentity,
+	deliveryRoutes []events.DeliveryRoute,
+) error {
+	deliveryRoutes = events.NormalizeDeliveryRoutes(deliveryRoutes)
+	if len(deliveryRoutes) > 0 {
+		if err := mutation.InsertEventDeliveryRoutes(ctx, eventID, deliveryRoutes); err != nil {
+			return err
+		}
+		return nil
+	}
+	if deliveryRouteSetPersistenceRequired(deliveryRoutes) {
+		return errMissingEventDeliveryRouteSetPersistence
+	}
+	if len(deliveryTargets) > 0 {
+		return mutation.InsertEventDeliveriesWithTargets(ctx, eventID, recipients, deliveryTargets)
+	}
+	return mutation.InsertEventDeliveries(ctx, eventID, recipients)
+}
+
+func (eb *EventBus) upsertCommittedReplayScopeMutation(ctx context.Context, mutation EventMutation, eventID string, scope runtimereplayclaim.CommittedReplayScope) error {
+	err := mutation.UpsertCommittedReplayScope(ctx, eventID, scope)
+	if err == nil {
+		return nil
+	}
+	if errors.Is(err, runtimereplayclaim.ErrMissingCommittedReplayScope) && !replayScopePersistenceRequired(eb.store) {
+		return nil
+	}
+	return fmt.Errorf("persist committed replay scope: %w", err)
+}
+
+func (eb *EventBus) eventMutationFromContext(ctx context.Context) (EventMutation, bool) {
+	if mutation, ok := EventMutationFromContext(ctx); ok {
+		return mutation, true
+	}
+	provider, ok := eb.store.(EventMutationContextProvider)
+	if !ok || provider == nil {
+		return nil, false
+	}
+	return provider.EventMutationFromContext(ctx)
 }
 
 var errMissingEventDeliveryRouteSetPersistence = errors.New("event store does not support typed delivery route persistence")

--- a/internal/runtime/bus/outbox.go
+++ b/internal/runtime/bus/outbox.go
@@ -40,14 +40,11 @@ func (o engineOutbox) WriteOutbox(ctx context.Context, intents []runtimeengine.E
 	if o.bus == nil || len(intents) == 0 {
 		return nil
 	}
-	tx, ok := runtimepipeline.PipelineSQLTxFromContext(ctx)
-	if !ok || tx == nil {
+	mutation, ok := o.bus.eventMutationFromContext(ctx)
+	if !ok || mutation == nil {
 		return nil
 	}
-	txStore, ok := o.bus.store.(TransactionalEventStore)
-	if !ok {
-		return fmt.Errorf("event bus store does not support transactional outbox")
-	}
+	ctx = mutation.Context()
 	for i := range intents {
 		intent := &intents[i]
 		if strings.TrimSpace(string(intent.Event.Type())) == "" {
@@ -62,21 +59,17 @@ func (o engineOutbox) WriteOutbox(ctx context.Context, intents []runtimeengine.E
 		if err != nil {
 			return err
 		}
-		if err := txStore.AppendEventTx(ctx, tx, intent.Event); err != nil {
+		if err := mutation.AppendEvent(ctx, intent.Event); err != nil {
 			return fmt.Errorf("persist event: %w", err)
 		}
-		if err := o.bus.insertEventDeliveriesTx(ctx, txStore, tx, intent.Event.ID(), plan.PersistedRecipientIDs(), plan.DeliveryTargets(), plan.DeliveryRoutes()); err != nil {
+		if err := o.bus.insertEventDeliveriesMutation(ctx, mutation, intent.Event.ID(), plan.PersistedRecipientIDs(), plan.DeliveryTargets(), plan.DeliveryRoutes()); err != nil {
 			return fmt.Errorf("persist event deliveries: %w", err)
 		}
-		if scopeWriter, ok := o.bus.store.(TransactionalEventReplayScopePersistence); ok && scopeWriter != nil {
-			if err := scopeWriter.UpsertCommittedReplayScopeTx(ctx, tx, intent.Event.ID(), replayScopeForEmitIntent(*intent)); err != nil {
-				return fmt.Errorf("persist committed replay scope: %w", err)
-			}
-		} else if replayScopePersistenceRequired(o.bus.store) {
-			return fmt.Errorf("persist committed replay scope: %w", runtimereplayclaim.ErrMissingCommittedReplayScope)
+		if err := o.bus.upsertCommittedReplayScopeMutation(ctx, mutation, intent.Event.ID(), replayScopeForEmitIntent(*intent)); err != nil {
+			return err
 		}
 		if plan.TargetFailure != "" {
-			if err := txStore.UpsertPipelineReceiptTx(ctx, tx, intent.Event.ID(), "dead_letter", targetDeliveryFailureMessage(plan.TargetFailure)); err != nil {
+			if err := mutation.UpsertPipelineReceipt(ctx, intent.Event.ID(), "dead_letter", targetDeliveryFailureMessage(plan.TargetFailure)); err != nil {
 				return fmt.Errorf("persist pipeline receipt: %w", err)
 			}
 			failedEvent := intent.Event

--- a/internal/runtime/bus/outbox_test.go
+++ b/internal/runtime/bus/outbox_test.go
@@ -13,6 +13,7 @@ import (
 	runtimebus "github.com/division-sh/swarm/internal/runtime/bus"
 	runtimeengine "github.com/division-sh/swarm/internal/runtime/engine"
 	runtimepipeline "github.com/division-sh/swarm/internal/runtime/pipeline"
+	runtimereplayclaim "github.com/division-sh/swarm/internal/runtime/replayclaim"
 	"github.com/google/uuid"
 )
 
@@ -27,6 +28,11 @@ type directRecipientTransactionalStore struct {
 	events      []events.Event
 	deliveries  map[string][]string
 	routes      map[string][]events.DeliveryRoute
+}
+
+type directRecipientEventMutation struct {
+	ctx   context.Context
+	store *directRecipientTransactionalStore
 }
 
 func (s *recordingEventStore) AppendEvent(_ context.Context, evt events.Event) error {
@@ -80,6 +86,46 @@ func (s *directRecipientTransactionalStore) ListActiveAgentDescriptors(context.C
 
 func (*directRecipientTransactionalStore) BeginEventTx(context.Context) (*sql.Tx, error) {
 	return nil, nil
+}
+
+func (s *directRecipientTransactionalStore) EventMutationFromContext(ctx context.Context) (runtimebus.EventMutation, bool) {
+	if _, ok := runtimepipeline.PipelineSQLTxFromContext(ctx); !ok {
+		return nil, false
+	}
+	mutation := &directRecipientEventMutation{store: s}
+	mutation.ctx = runtimebus.WithEventMutationContext(ctx, mutation)
+	return mutation, true
+}
+
+func (m *directRecipientEventMutation) Context() context.Context {
+	if m == nil || m.ctx == nil {
+		return context.Background()
+	}
+	return m.ctx
+}
+
+func (m *directRecipientEventMutation) AppendEvent(ctx context.Context, evt events.Event) error {
+	return m.store.AppendEventTx(ctx, nil, evt)
+}
+
+func (m *directRecipientEventMutation) InsertEventDeliveries(ctx context.Context, eventID string, agentIDs []string) error {
+	return m.store.InsertEventDeliveriesTx(ctx, nil, eventID, agentIDs)
+}
+
+func (m *directRecipientEventMutation) InsertEventDeliveriesWithTargets(ctx context.Context, eventID string, agentIDs []string, _ map[string]events.RouteIdentity) error {
+	return m.store.InsertEventDeliveriesTx(ctx, nil, eventID, agentIDs)
+}
+
+func (m *directRecipientEventMutation) InsertEventDeliveryRoutes(ctx context.Context, eventID string, routes []events.DeliveryRoute) error {
+	return m.store.InsertEventDeliveryRoutesTx(ctx, nil, eventID, routes)
+}
+
+func (*directRecipientEventMutation) UpsertCommittedReplayScope(context.Context, string, runtimereplayclaim.CommittedReplayScope) error {
+	return nil
+}
+
+func (m *directRecipientEventMutation) UpsertPipelineReceipt(ctx context.Context, eventID, status, errText string) error {
+	return m.store.UpsertPipelineReceiptTx(ctx, nil, eventID, status, errText)
 }
 
 func (s *directRecipientTransactionalStore) AppendEventTx(_ context.Context, _ *sql.Tx, evt events.Event) error {

--- a/internal/runtime/bus/store.go
+++ b/internal/runtime/bus/store.go
@@ -127,13 +127,53 @@ type EventReplayScopePersistence interface {
 	UpsertCommittedReplayScope(ctx context.Context, eventID string, scope runtimereplayclaim.CommittedReplayScope) error
 }
 
+type eventMutationContextKey struct{}
+
+// EventMutation is the typed event-publish unit of work consumed by runtime
+// producers. Backend SQL transaction details stay below this semantic boundary.
+type EventMutation interface {
+	Context() context.Context
+	AppendEvent(ctx context.Context, evt events.Event) error
+	InsertEventDeliveries(ctx context.Context, eventID string, agentIDs []string) error
+	InsertEventDeliveriesWithTargets(ctx context.Context, eventID string, agentIDs []string, deliveryTargets map[string]events.RouteIdentity) error
+	InsertEventDeliveryRoutes(ctx context.Context, eventID string, deliveryRoutes []events.DeliveryRoute) error
+	UpsertCommittedReplayScope(ctx context.Context, eventID string, scope runtimereplayclaim.CommittedReplayScope) error
+	UpsertPipelineReceipt(ctx context.Context, eventID, status, errText string) error
+}
+
+type EventMutationRunner interface {
+	RunEventMutation(ctx context.Context, fn func(EventMutation) error) error
+}
+
+type EventMutationContextProvider interface {
+	EventMutationFromContext(ctx context.Context) (EventMutation, bool)
+}
+
+func WithEventMutationContext(ctx context.Context, mutation EventMutation) context.Context {
+	if mutation == nil {
+		return ctx
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	return context.WithValue(ctx, eventMutationContextKey{}, mutation)
+}
+
+func EventMutationFromContext(ctx context.Context) (EventMutation, bool) {
+	if ctx == nil {
+		return nil, false
+	}
+	mutation, ok := ctx.Value(eventMutationContextKey{}).(EventMutation)
+	return mutation, ok && mutation != nil
+}
+
 type TransactionalEventReplayScopePersistence interface {
 	UpsertCommittedReplayScopeTx(ctx context.Context, tx *sql.Tx, eventID string, scope runtimereplayclaim.CommittedReplayScope) error
 }
 
-// TransactionalEventStore is an optional capability for full publish-time
-// transactional semantics: interceptor state writes + event persistence +
-// deferred event persistence in one DB transaction.
+// TransactionalEventStore is the legacy raw-SQL transaction helper behind
+// split callers such as PublishTx and store implementations. Selected
+// event/pipeline mutation producers consume EventMutationRunner instead.
 type TransactionalEventStore interface {
 	BeginEventTx(ctx context.Context) (*sql.Tx, error)
 	AppendEventTx(ctx context.Context, tx *sql.Tx, evt events.Event) error

--- a/internal/runtime/manager/flow_activation_test.go
+++ b/internal/runtime/manager/flow_activation_test.go
@@ -2,7 +2,6 @@ package manager
 
 import (
 	"context"
-	"database/sql"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -1366,7 +1365,7 @@ func TestDeactivateFlowInstanceModel_PostCommitSideEffectsFollowTerminalCommit(t
 	if err := am.ActivateFlowInstance(ctx, req); err != nil {
 		t.Fatalf("ActivateFlowInstance: %v", err)
 	}
-	if err := store.RunInPipelineTransaction(ctx, func(txctx context.Context, _ *sql.Tx) error {
+	if err := store.RunPipelineMutation(ctx, func(txctx context.Context) error {
 		if err := store.Mutate(txctx, req.Instance.EntityID, func(instance *runtimepipeline.WorkflowInstance) {
 			instance.CurrentState = "completed"
 		}); err != nil {
@@ -1401,7 +1400,7 @@ func TestDeactivateFlowInstanceModel_PostCommitSideEffectsFollowTerminalCommit(t
 		}
 		return nil
 	}); err != nil {
-		t.Fatalf("RunInPipelineTransaction: %v", err)
+		t.Fatalf("RunPipelineMutation: %v", err)
 	}
 
 	var status string

--- a/internal/runtime/pipeline/engine_adapter.go
+++ b/internal/runtime/pipeline/engine_adapter.go
@@ -70,7 +70,6 @@ func (e pipelineEngineEvaluator) EvalValue(string, runtimeengine.BaseContext) (a
 
 type pipelineEngineTx struct {
 	ctx context.Context
-	tx  *sql.Tx
 }
 
 func (t pipelineEngineTx) Context() context.Context { return t.ctx }
@@ -83,8 +82,8 @@ func (r pipelineEngineTxRunner) Run(ctx context.Context, fn func(runtimeengine.T
 	if r.store == nil || !r.store.Enabled() {
 		return fn(pipelineEngineTx{ctx: ctx})
 	}
-	return r.store.RunInPipelineTransaction(ctx, func(txctx context.Context, tx *sql.Tx) error {
-		return fn(pipelineEngineTx{ctx: txctx, tx: tx})
+	return r.store.RunPipelineMutation(ctx, func(txctx context.Context) error {
+		return fn(pipelineEngineTx{ctx: txctx})
 	})
 }
 

--- a/internal/runtime/pipeline/runtime_interfaces.go
+++ b/internal/runtime/pipeline/runtime_interfaces.go
@@ -2,7 +2,6 @@ package pipeline
 
 import (
 	"context"
-	"database/sql"
 	"strings"
 	"time"
 
@@ -73,7 +72,7 @@ type SystemNodeReceiptPersistence interface {
 type Store interface {
 	WorkflowInstancePersistence
 	SystemNodeReceiptPersistence
-	RunInPipelineTransaction(ctx context.Context, fn func(context.Context, *sql.Tx) error) error
+	RunPipelineMutation(ctx context.Context, fn func(context.Context) error) error
 }
 
 type TransitionEvaluator interface {

--- a/internal/runtime/pipeline/system_node_receipt_store.go
+++ b/internal/runtime/pipeline/system_node_receipt_store.go
@@ -181,7 +181,7 @@ func (s *WorkflowInstanceStore) MarkSystemNodeDeliveryDeadLetter(ctx context.Con
 }
 
 func (s *WorkflowInstanceStore) markSQLiteSystemNodeProcessedAndSettleDelivery(ctx context.Context, nodeID, eventID, sideEffects string) error {
-	return s.RunInPipelineTransaction(ctx, func(txctx context.Context, tx *sql.Tx) error {
+	return s.runInPipelineTransaction(ctx, func(txctx context.Context, tx *sql.Tx) error {
 		retryLimit := normalizeSystemNodeRetryLimit(DefaultSystemNodeRetryLimit)
 		authorized, err := sqliteSystemNodeDeliveryAuthorizedTx(txctx, tx, nodeID, eventID, retryLimit)
 		if err != nil {
@@ -245,7 +245,7 @@ func (s *WorkflowInstanceStore) markSQLiteSystemNodeProcessedAndSettleDelivery(c
 
 func (s *WorkflowInstanceStore) markSQLiteSystemNodeDeliveryInProgress(ctx context.Context, nodeID, eventID string, retryLimit int) error {
 	retryLimit = normalizeSystemNodeRetryLimit(retryLimit)
-	return s.RunInPipelineTransaction(ctx, func(txctx context.Context, tx *sql.Tx) error {
+	return s.runInPipelineTransaction(ctx, func(txctx context.Context, tx *sql.Tx) error {
 		authorized, err := sqliteSystemNodeDeliveryAuthorizedTx(txctx, tx, nodeID, eventID, retryLimit)
 		if err != nil {
 			return fmt.Errorf("query sqlite system node delivery authority: %w", err)
@@ -282,7 +282,7 @@ func (s *WorkflowInstanceStore) markSQLiteSystemNodeDeliveryInProgress(ctx conte
 
 func (s *WorkflowInstanceStore) markSQLiteSystemNodeDeliveryFailed(ctx context.Context, nodeID, eventID, reasonCode, errText string, retryCount, retryLimit int) error {
 	retryLimit = normalizeSystemNodeRetryLimit(retryLimit)
-	return s.RunInPipelineTransaction(ctx, func(txctx context.Context, tx *sql.Tx) error {
+	return s.runInPipelineTransaction(ctx, func(txctx context.Context, tx *sql.Tx) error {
 		authorized, err := sqliteSystemNodeDeliveryAuthorizedTx(txctx, tx, nodeID, eventID, retryLimit)
 		if err != nil {
 			return fmt.Errorf("query sqlite system node delivery authority: %w", err)
@@ -317,7 +317,7 @@ func (s *WorkflowInstanceStore) markSQLiteSystemNodeDeliveryFailed(ctx context.C
 }
 
 func (s *WorkflowInstanceStore) markSQLiteSystemNodeDeliveryDeadLetter(ctx context.Context, nodeID, eventID, reasonCode, errText string, retryCount int, sideEffects string) error {
-	return s.RunInPipelineTransaction(ctx, func(txctx context.Context, tx *sql.Tx) error {
+	return s.runInPipelineTransaction(ctx, func(txctx context.Context, tx *sql.Tx) error {
 		exists, err := sqliteSystemNodeDeliveryRowExistsTx(txctx, tx, nodeID, eventID)
 		if err != nil {
 			return fmt.Errorf("query sqlite system node delivery row: %w", err)

--- a/internal/runtime/pipeline/workflow_instance_store.go
+++ b/internal/runtime/pipeline/workflow_instance_store.go
@@ -101,7 +101,7 @@ type WorkflowInstanceStore struct {
 }
 
 type RuntimeMutationRunner interface {
-	RunRuntimeMutation(ctx context.Context, fn func(context.Context, *sql.Tx) error) error
+	RunRuntimeMutationContext(ctx context.Context, fn func(context.Context) error) error
 }
 
 type WorkflowInstanceFieldSelector struct {
@@ -341,7 +341,7 @@ func (s *WorkflowInstanceStore) MarkTerminated(ctx context.Context, storageRef s
 		return nil
 	}
 	if s.isSQLite() {
-		return s.RunInPipelineTransaction(ctx, func(txctx context.Context, tx *sql.Tx) error {
+		return s.runInPipelineTransaction(ctx, func(txctx context.Context, tx *sql.Tx) error {
 			return s.markTerminatedSQLiteTx(txctx, tx, storageRef, terminatedAt)
 		})
 	}
@@ -397,7 +397,16 @@ func (s *WorkflowInstanceStore) isSQLite() bool {
 	return s != nil && s.dialect == workflowStoreDialectSQLite
 }
 
-func (s *WorkflowInstanceStore) RunInPipelineTransaction(ctx context.Context, fn func(context.Context, *sql.Tx) error) error {
+func (s *WorkflowInstanceStore) RunPipelineMutation(ctx context.Context, fn func(context.Context) error) error {
+	if fn == nil {
+		return nil
+	}
+	return s.runInPipelineTransaction(ctx, func(txctx context.Context, _ *sql.Tx) error {
+		return fn(txctx)
+	})
+}
+
+func (s *WorkflowInstanceStore) runInPipelineTransaction(ctx context.Context, fn func(context.Context, *sql.Tx) error) error {
 	if fn == nil {
 		return nil
 	}
@@ -406,7 +415,13 @@ func (s *WorkflowInstanceStore) RunInPipelineTransaction(ctx context.Context, fn
 	}
 	if s.isSQLite() {
 		if s.runtimeMutation != nil {
-			return s.runtimeMutation.RunRuntimeMutation(ctx, fn)
+			return s.runtimeMutation.RunRuntimeMutationContext(ctx, func(txctx context.Context) error {
+				tx, ok := sqlTxFromContext(txctx)
+				if !ok || tx == nil {
+					return fmt.Errorf("sqlite runtime mutation did not provide pipeline transaction")
+				}
+				return fn(txctx, tx)
+			})
 		}
 		return errSQLiteWorkflowInstanceStoreRuntimeMutationRunnerRequired
 	}

--- a/internal/runtime/pipeline/workflow_instance_store_sqlite.go
+++ b/internal/runtime/pipeline/workflow_instance_store_sqlite.go
@@ -175,7 +175,7 @@ func (s *WorkflowInstanceStore) createSQLite(ctx context.Context, instance Workf
 }
 
 func (s *WorkflowInstanceStore) mutateSQLite(ctx context.Context, instanceID string, fn func(*WorkflowInstance)) error {
-	return s.RunInPipelineTransaction(ctx, func(txctx context.Context, _ *sql.Tx) error {
+	return s.runInPipelineTransaction(ctx, func(txctx context.Context, _ *sql.Tx) error {
 		instance, ok, err := s.loadSQLite(txctx, instanceID)
 		if err != nil {
 			return err
@@ -219,7 +219,7 @@ func (s *WorkflowInstanceStore) writeSQLite(ctx context.Context, rowID, storageR
 	if err != nil {
 		return err
 	}
-	return s.RunInPipelineTransaction(ctx, func(txctx context.Context, tx *sql.Tx) error {
+	return s.runInPipelineTransaction(ctx, func(txctx context.Context, tx *sql.Tx) error {
 		if createOnly {
 			exists, err := workflowInstanceSQLiteCreateTargetExists(txctx, tx, runID, rowID, storageRef)
 			if err != nil {

--- a/internal/runtime/pipeline/workflow_instance_store_sqlite_test.go
+++ b/internal/runtime/pipeline/workflow_instance_store_sqlite_test.go
@@ -131,33 +131,34 @@ func TestSQLiteWorkflowInstanceStore_MarkTerminatedUsesRuntimeMutationRunner(t *
 	}
 }
 
-func TestSQLiteWorkflowInstanceStore_RunInPipelineTransactionRequiresRuntimeMutationRunner(t *testing.T) {
+func TestSQLiteWorkflowInstanceStore_RunPipelineMutationRequiresRuntimeMutationRunner(t *testing.T) {
 	db := newSQLiteWorkflowInstanceStoreTestDB(t)
 	store := NewSQLiteWorkflowInstanceStore(db)
 	ctx := runtimecorrelation.WithRunID(context.Background(), uuid.NewString())
 	called := false
 
-	err := store.RunInPipelineTransaction(ctx, func(context.Context, *sql.Tx) error {
+	err := store.RunPipelineMutation(ctx, func(context.Context) error {
 		called = true
 		return nil
 	})
 	if !errors.Is(err, errSQLiteWorkflowInstanceStoreRuntimeMutationRunnerRequired) {
-		t.Fatalf("RunInPipelineTransaction error = %v, want runtime mutation runner required", err)
+		t.Fatalf("RunPipelineMutation error = %v, want runtime mutation runner required", err)
 	}
 	if called {
-		t.Fatal("RunInPipelineTransaction callback ran without runtime mutation runner")
+		t.Fatal("RunPipelineMutation callback ran without runtime mutation runner")
 	}
 }
 
-func TestSQLiteWorkflowInstanceStore_RunInPipelineTransactionUsesRuntimeMutationRunner(t *testing.T) {
+func TestSQLiteWorkflowInstanceStore_RunPipelineMutationUsesRuntimeMutationRunner(t *testing.T) {
 	db := newSQLiteWorkflowInstanceStoreTestDB(t)
 	runner := &recordingRuntimeMutationRunner{db: db}
 	store := NewSQLiteWorkflowInstanceStoreWithRuntimeMutationRunner(db, runner)
 	ctx := runtimecorrelation.WithRunID(context.Background(), uuid.NewString())
 	var postCommitActions int32
 
-	err := store.RunInPipelineTransaction(ctx, func(txctx context.Context, tx *sql.Tx) error {
-		if tx == nil {
+	err := store.RunPipelineMutation(ctx, func(txctx context.Context) error {
+		tx, ok := PipelineSQLTxFromContext(txctx)
+		if !ok || tx == nil {
 			return errors.New("pipeline transaction is required")
 		}
 		if !QueuePipelinePostCommitAction(txctx, func() {
@@ -172,7 +173,7 @@ func TestSQLiteWorkflowInstanceStore_RunInPipelineTransactionUsesRuntimeMutation
 		return err
 	})
 	if err != nil {
-		t.Fatalf("RunInPipelineTransaction with runtime mutation runner: %v", err)
+		t.Fatalf("RunPipelineMutation with runtime mutation runner: %v", err)
 	}
 	if got := atomic.LoadInt32(&runner.calls); got != 1 {
 		t.Fatalf("runtime mutation calls = %d, want 1", got)
@@ -182,7 +183,7 @@ func TestSQLiteWorkflowInstanceStore_RunInPipelineTransactionUsesRuntimeMutation
 	}
 }
 
-func TestSQLiteWorkflowInstanceStore_RunInPipelineTransactionDoesNotRetryActiveTransaction(t *testing.T) {
+func TestSQLiteWorkflowInstanceStore_RunPipelineMutationDoesNotRetryActiveTransaction(t *testing.T) {
 	db := newSQLiteWorkflowInstanceStoreTestDB(t)
 	store := NewSQLiteWorkflowInstanceStore(db)
 	ctx := runtimecorrelation.WithRunID(context.Background(), uuid.NewString())
@@ -194,34 +195,38 @@ func TestSQLiteWorkflowInstanceStore_RunInPipelineTransactionDoesNotRetryActiveT
 
 	busyErr := errors.New("SQLITE_BUSY: database is locked")
 	var attempts int32
-	err = store.RunInPipelineTransaction(WithPipelineSQLTxContext(ctx, tx), func(txctx context.Context, gotTx *sql.Tx) error {
+	err = store.RunPipelineMutation(WithPipelineSQLTxContext(ctx, tx), func(txctx context.Context) error {
 		atomic.AddInt32(&attempts, 1)
+		gotTx, ok := PipelineSQLTxFromContext(txctx)
+		if !ok {
+			t.Fatal("active transaction missing from pipeline mutation context")
+		}
 		if gotTx != tx {
 			t.Fatalf("transaction = %#v, want active transaction", gotTx)
 		}
 		return busyErr
 	})
 	if !errors.Is(err, busyErr) {
-		t.Fatalf("RunInPipelineTransaction error = %v, want sentinel busy error", err)
+		t.Fatalf("RunPipelineMutation error = %v, want sentinel busy error", err)
 	}
 	if got := atomic.LoadInt32(&attempts); got != 1 {
 		t.Fatalf("attempts = %d, want no retry inside active transaction", got)
 	}
 }
 
-func TestWorkflowInstanceStore_RunInPipelineTransactionDoesNotRetryPostgresDialect(t *testing.T) {
+func TestWorkflowInstanceStore_RunPipelineMutationDoesNotRetryPostgresDialect(t *testing.T) {
 	db := newSQLiteWorkflowInstanceStoreTestDB(t)
 	store := NewWorkflowInstanceStore(db)
 	ctx := runtimecorrelation.WithRunID(context.Background(), uuid.NewString())
 	busyErr := errors.New("SQLITE_BUSY: database is locked")
 	var attempts int32
 
-	err := store.RunInPipelineTransaction(ctx, func(context.Context, *sql.Tx) error {
+	err := store.RunPipelineMutation(ctx, func(context.Context) error {
 		atomic.AddInt32(&attempts, 1)
 		return busyErr
 	})
 	if !errors.Is(err, busyErr) {
-		t.Fatalf("RunInPipelineTransaction error = %v, want sentinel busy error", err)
+		t.Fatalf("RunPipelineMutation error = %v, want sentinel busy error", err)
 	}
 	if got := atomic.LoadInt32(&attempts); got != 1 {
 		t.Fatalf("attempts = %d, want no retry for postgres dialect", got)
@@ -234,7 +239,7 @@ type recordingRuntimeMutationRunner struct {
 	calls int32
 }
 
-func (r *recordingRuntimeMutationRunner) RunRuntimeMutation(ctx context.Context, fn func(context.Context, *sql.Tx) error) error {
+func (r *recordingRuntimeMutationRunner) RunRuntimeMutationContext(ctx context.Context, fn func(context.Context) error) error {
 	atomic.AddInt32(&r.calls, 1)
 	r.mu.Lock()
 	defer r.mu.Unlock()
@@ -250,7 +255,7 @@ func (r *recordingRuntimeMutationRunner) RunRuntimeMutation(ctx context.Context,
 	}()
 	postCommit := make([]func(), 0, 4)
 	txctx := withPipelinePostCommitActions(WithPipelineSQLTxContext(ctx, tx), &postCommit)
-	if err := fn(txctx, tx); err != nil {
+	if err := fn(txctx); err != nil {
 		return err
 	}
 	if err := tx.Commit(); err != nil {

--- a/internal/store/event_mutation.go
+++ b/internal/store/event_mutation.go
@@ -1,0 +1,135 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+
+	"github.com/division-sh/swarm/internal/events"
+	runtimebus "github.com/division-sh/swarm/internal/runtime/bus"
+	runtimepipeline "github.com/division-sh/swarm/internal/runtime/pipeline"
+	runtimereplayclaim "github.com/division-sh/swarm/internal/runtime/replayclaim"
+)
+
+type sqlEventMutation struct {
+	ctx     context.Context
+	tx      *sql.Tx
+	txStore runtimebus.TransactionalEventStore
+	store   any
+}
+
+func newSQLEventMutation(ctx context.Context, tx *sql.Tx, txStore runtimebus.TransactionalEventStore, store any) runtimebus.EventMutation {
+	mutation := &sqlEventMutation{
+		ctx:     ctx,
+		tx:      tx,
+		txStore: txStore,
+		store:   store,
+	}
+	mutation.ctx = runtimebus.WithEventMutationContext(ctx, mutation)
+	return mutation
+}
+
+func (m *sqlEventMutation) Context() context.Context {
+	if m == nil || m.ctx == nil {
+		return context.Background()
+	}
+	return m.ctx
+}
+
+func (m *sqlEventMutation) operationContext(ctx context.Context) context.Context {
+	if ctx == nil {
+		return m.Context()
+	}
+	return ctx
+}
+
+func (m *sqlEventMutation) AppendEvent(ctx context.Context, evt events.Event) error {
+	if m == nil || m.txStore == nil {
+		return fmt.Errorf("event mutation store is required")
+	}
+	return m.txStore.AppendEventTx(m.operationContext(ctx), m.tx, evt)
+}
+
+func (m *sqlEventMutation) InsertEventDeliveries(ctx context.Context, eventID string, agentIDs []string) error {
+	if m == nil || m.txStore == nil {
+		return fmt.Errorf("event mutation store is required")
+	}
+	return m.txStore.InsertEventDeliveriesTx(m.operationContext(ctx), m.tx, eventID, agentIDs)
+}
+
+func (m *sqlEventMutation) InsertEventDeliveriesWithTargets(ctx context.Context, eventID string, agentIDs []string, deliveryTargets map[string]events.RouteIdentity) error {
+	if m == nil || m.txStore == nil {
+		return fmt.Errorf("event mutation store is required")
+	}
+	if writer, ok := m.store.(runtimebus.TransactionalEventDeliveryRoutePersistence); ok && writer != nil {
+		return writer.InsertEventDeliveriesWithTargetsTx(m.operationContext(ctx), m.tx, eventID, agentIDs, deliveryTargets)
+	}
+	return m.txStore.InsertEventDeliveriesTx(m.operationContext(ctx), m.tx, eventID, agentIDs)
+}
+
+func (m *sqlEventMutation) InsertEventDeliveryRoutes(ctx context.Context, eventID string, deliveryRoutes []events.DeliveryRoute) error {
+	if m == nil {
+		return fmt.Errorf("event mutation store is required")
+	}
+	if writer, ok := m.store.(runtimebus.TransactionalEventDeliveryRouteSetPersistence); ok && writer != nil {
+		return writer.InsertEventDeliveryRoutesTx(m.operationContext(ctx), m.tx, eventID, deliveryRoutes)
+	}
+	return fmt.Errorf("event mutation store does not support typed delivery routes")
+}
+
+func (m *sqlEventMutation) UpsertCommittedReplayScope(ctx context.Context, eventID string, scope runtimereplayclaim.CommittedReplayScope) error {
+	if m == nil {
+		return runtimereplayclaim.ErrMissingCommittedReplayScope
+	}
+	if writer, ok := m.store.(runtimebus.TransactionalEventReplayScopePersistence); ok && writer != nil {
+		return writer.UpsertCommittedReplayScopeTx(m.operationContext(ctx), m.tx, eventID, scope)
+	}
+	return runtimereplayclaim.ErrMissingCommittedReplayScope
+}
+
+func (m *sqlEventMutation) UpsertPipelineReceipt(ctx context.Context, eventID, status, errText string) error {
+	if m == nil || m.txStore == nil {
+		return fmt.Errorf("event mutation store is required")
+	}
+	return m.txStore.UpsertPipelineReceiptTx(m.operationContext(ctx), m.tx, eventID, status, errText)
+}
+
+func (s *SQLiteRuntimeStore) RunEventMutation(ctx context.Context, fn func(runtimebus.EventMutation) error) error {
+	if fn == nil {
+		return nil
+	}
+	return s.RunEventTransaction(ctx, func(txctx context.Context, tx *sql.Tx) error {
+		return fn(newSQLEventMutation(txctx, tx, s, s))
+	})
+}
+
+func (s *SQLiteRuntimeStore) EventMutationFromContext(ctx context.Context) (runtimebus.EventMutation, bool) {
+	if mutation, ok := runtimebus.EventMutationFromContext(ctx); ok {
+		return mutation, true
+	}
+	tx, ok := runtimepipeline.PipelineSQLTxFromContext(ctx)
+	if !ok || tx == nil {
+		return nil, false
+	}
+	return newSQLEventMutation(ctx, tx, s, s), true
+}
+
+func (s *PostgresStore) RunEventMutation(ctx context.Context, fn func(runtimebus.EventMutation) error) error {
+	if fn == nil {
+		return nil
+	}
+	return s.RunEventTransaction(ctx, func(txctx context.Context, tx *sql.Tx) error {
+		return fn(newSQLEventMutation(txctx, tx, s, s))
+	})
+}
+
+func (s *PostgresStore) EventMutationFromContext(ctx context.Context) (runtimebus.EventMutation, bool) {
+	if mutation, ok := runtimebus.EventMutationFromContext(ctx); ok {
+		return mutation, true
+	}
+	tx, ok := runtimepipeline.PipelineSQLTxFromContext(ctx)
+	if !ok || tx == nil {
+		return nil, false
+	}
+	return newSQLEventMutation(ctx, tx, s, s), true
+}

--- a/internal/store/runtime_mutation.go
+++ b/internal/store/runtime_mutation.go
@@ -24,6 +24,15 @@ func (s *SQLiteRuntimeStore) RunRuntimeMutation(ctx context.Context, fn func(con
 	return s.runRuntimeMutation(ctx, "sqlite runtime mutation", fn)
 }
 
+func (s *SQLiteRuntimeStore) RunRuntimeMutationContext(ctx context.Context, fn func(context.Context) error) error {
+	if fn == nil {
+		return nil
+	}
+	return s.runRuntimeMutation(ctx, "sqlite runtime mutation", func(txctx context.Context, _ *sql.Tx) error {
+		return fn(txctx)
+	})
+}
+
 func (s *SQLiteRuntimeStore) RunEventTransaction(ctx context.Context, fn func(context.Context, *sql.Tx) error) error {
 	return s.runRuntimeMutation(ctx, "sqlite event transaction", fn)
 }

--- a/internal/store/runtime_mutation_guard_test.go
+++ b/internal/store/runtime_mutation_guard_test.go
@@ -268,8 +268,8 @@ func TestSelectedSQLiteRuntimeConstructionConsumesMutationBoundary(t *testing.T)
 	if err != nil {
 		t.Fatalf("read internal/runtime/bus/eventbus_publish.go: %v", err)
 	}
-	if !strings.Contains(string(publishData), ".RunEventTransaction(ctx,") {
-		t.Fatal("event publish must consume EventTransactionRunner.RunEventTransaction when available")
+	if !strings.Contains(string(publishData), ".RunEventMutation(ctx,") {
+		t.Fatal("event publish must consume EventMutationRunner.RunEventMutation when available")
 	}
 
 	pipelineData, err := os.ReadFile(filepath.Join(root, "internal", "runtime", "pipeline", "workflow_instance_store.go"))
@@ -376,13 +376,13 @@ func collectRuntimeWriterCallSitesFromSource(path, src string) ([]runtimeWriterC
 				return true
 			}
 			switch primitive {
-			case "RunRuntimeMutation":
+			case "RunRuntimeMutation", "RunRuntimeMutationContext":
 				info.callsRuntimeMutation = true
 			case "runRuntimeMutation":
 				info.callsRuntimeMutation = true
-			case "RunEventTransaction":
+			case "RunEventTransaction", "RunEventMutation":
 				info.callsEventTransaction = true
-			case "RunInPipelineTransaction":
+			case "RunPipelineMutation", "runInPipelineTransaction":
 				info.callsPipelineTransaction = true
 			case "PipelineSQLTxFromContext", "sqlTxFromContext":
 				info.usesPipelineTxFromContext = true
@@ -471,7 +471,7 @@ func runtimeWriterPrimitive(call *ast.CallExpr) (string, runtimeWriterPrimitiveK
 		return name, primitiveWrite, true
 	case "Query", "QueryContext", "QueryRow", "QueryRowContext", "Prepare", "PrepareContext":
 		return name, primitiveRead, true
-	case "RunInPipelineTransaction", "RunRuntimeMutation", "runRuntimeMutation", "RunEventTransaction", "PipelineSQLTxFromContext", "sqlTxFromContext":
+	case "RunPipelineMutation", "runInPipelineTransaction", "RunRuntimeMutation", "RunRuntimeMutationContext", "runRuntimeMutation", "RunEventTransaction", "RunEventMutation", "PipelineSQLTxFromContext", "sqlTxFromContext":
 		return name, primitiveBoundary, true
 	default:
 		return "", "", false
@@ -491,11 +491,11 @@ func collectRuntimeWriterBoundaryCallbackScopes(body ast.Node) []runtimeWriterBo
 		}
 		scope := runtimeWriterBoundaryCallbackScope{}
 		switch primitive {
-		case "RunRuntimeMutation", "runRuntimeMutation":
+		case "RunRuntimeMutation", "RunRuntimeMutationContext", "runRuntimeMutation":
 			scope.runtime = true
-		case "RunEventTransaction":
+		case "RunEventTransaction", "RunEventMutation":
 			scope.event = true
-		case "RunInPipelineTransaction":
+		case "RunPipelineMutation", "runInPipelineTransaction":
 			scope.pipeline = true
 		default:
 			return true
@@ -664,10 +664,10 @@ func classifyRuntimeWriterCallSites(sites []runtimeWriterCallSite) ([]runtimeWri
 func classifyRuntimeWriterCallSite(site runtimeWriterCallSite) (runtimeWriterClassification, string, bool) {
 	if site.Kind == primitiveBoundary {
 		switch site.Primitive {
-		case "RunRuntimeMutation", "runRuntimeMutation", "RunEventTransaction":
+		case "RunRuntimeMutation", "RunRuntimeMutationContext", "runRuntimeMutation", "RunEventTransaction", "RunEventMutation":
 			return classConsumesCanonical, "canonical runtime mutation/event transaction boundary", true
-		case "RunInPipelineTransaction":
-			return classConsumesCanonical, "pipeline transaction owner delegates production SQLite writes to RunRuntimeMutation", true
+		case "RunPipelineMutation", "runInPipelineTransaction":
+			return classConsumesCanonical, "pipeline mutation owner delegates production SQLite writes to RunRuntimeMutationContext", true
 		case "PipelineSQLTxFromContext", "sqlTxFromContext":
 			return classActiveTxHelper, "active transaction context probe; not a writer by itself", true
 		}
@@ -774,11 +774,11 @@ func workflowInstanceStoreSQLiteBypassCandidate(site runtimeWriterCallSite) bool
 
 func classifySQLiteRuntimeStoreCallSite(site runtimeWriterCallSite) (runtimeWriterClassification, string, bool) {
 	switch site.Function {
-	case "RunRuntimeMutation", "RunEventTransaction", "runRuntimeMutation", "runRuntimeMutationOnce", "runRuntimeMutationOnceLocked":
+	case "RunRuntimeMutation", "RunRuntimeMutationContext", "RunEventTransaction", "RunEventMutation", "runRuntimeMutation", "runRuntimeMutationOnce", "runRuntimeMutationOnceLocked":
 		return classConsumesCanonical, "canonical SQLite runtime mutation owner", true
 	case "BeginEventTx":
 		if site.Kind == primitiveBegin {
-			return classSplitLegacy, "legacy TransactionalEventStore fallback; production SQLite publish uses RunEventTransaction", true
+			return classSplitLegacy, "legacy TransactionalEventStore fallback; production SQLite publish uses RunEventMutation", true
 		}
 	}
 	if site.Kind == primitiveWrite || site.Kind == primitiveBegin {

--- a/internal/store/sqlite_runtime_test.go
+++ b/internal/store/sqlite_runtime_test.go
@@ -2,7 +2,6 @@ package store
 
 import (
 	"context"
-	"database/sql"
 	"encoding/json"
 	"errors"
 	"os"
@@ -307,7 +306,7 @@ func TestSQLiteDynamicFlowActivationRequiredAgentsUsePipelineTransaction(t *test
 	bundle := sqliteFlowActivationBundle()
 
 	req := sqliteFlowActivationRequest(bundle, "review", "inst-1", "parent-ent", "review/inst-1")
-	if err := workflowStore.RunInPipelineTransaction(ctx, func(txctx context.Context, _ *sql.Tx) error {
+	if err := workflowStore.RunPipelineMutation(ctx, func(txctx context.Context) error {
 		return manager.ActivateFlowInstance(txctx, req)
 	}); err != nil {
 		t.Fatalf("ActivateFlowInstance inside sqlite pipeline transaction: %v", err)
@@ -355,7 +354,7 @@ func TestSQLiteDynamicFlowActivationConcurrentFanOutChildrenPersist(t *testing.T
 			defer wg.Done()
 			<-start
 			req := sqliteFlowActivationRequest(bundle, "review", instanceID, "parent-ent", "review/"+instanceID)
-			errs <- workflowStore.RunInPipelineTransaction(ctx, func(txctx context.Context, _ *sql.Tx) error {
+			errs <- workflowStore.RunPipelineMutation(ctx, func(txctx context.Context) error {
 				return manager.ActivateFlowInstance(txctx, req)
 			})
 		}()

--- a/internal/store/testdata/selected_store_abstraction_guard_matrix.yaml
+++ b/internal/store/testdata/selected_store_abstraction_guard_matrix.yaml
@@ -78,9 +78,10 @@ rows:
         name: TestRuntimeWriterBoundaryGuardRejectsPipelineSQLiteRawDBHelperFixture
     split_issues: [1403]
     notes: >
-      This row guards the boundary. Behavior-changing mutation UoW migration
-      remains #1403; SQLite busy/serialization policy is guarded by the #1405
-      row in this matrix.
+      This row guards the boundary. #1414 promotes the first typed event/pipeline
+      mutation UoW entrypoint slice; the broader row-family typed UoW migration
+      remains #1403. SQLite busy/serialization policy is guarded by the #1405 row
+      in this matrix.
 
   - id: sqlite_runtime_sqldb_omission_guard
     classification: guard
@@ -119,12 +120,12 @@ rows:
       - kind: go_test
         name: TestPostgresStore_RunEventTransactionDoesNotSerializeCallbacks
       - kind: go_test
-        name: TestWorkflowInstanceStore_RunInPipelineTransactionDoesNotRetryPostgresDialect
+        name: TestWorkflowInstanceStore_RunPipelineMutationDoesNotRetryPostgresDialect
     guard_proof_refs:
       - kind: go_test
         name: TestPostgresStore_RunEventTransactionDoesNotSerializeCallbacks
       - kind: go_test
-        name: TestWorkflowInstanceStore_RunInPipelineTransactionDoesNotRetryPostgresDialect
+        name: TestWorkflowInstanceStore_RunPipelineMutationDoesNotRetryPostgresDialect
     notes: >
       SQLite-local busy handling is a store-internal backend policy; Postgres
       keeps normal transaction behavior.
@@ -225,14 +226,15 @@ rows:
       - typed backend-neutral runtime mutation unit of work
     owners:
       - backend_neutral_runtime_mutation_write_boundary
-      - future #1403 typed unit-of-work owner
+      - '#1414 typed event/pipeline producer-visible unit-of-work entrypoints'
+      - 'remaining #1403 typed unit-of-work row-family owner'
     split_issues: [1403]
     proof_refs:
       - kind: artifact
         path: platform-spec.yaml
     notes: >
-      #1402 may guard/account for this seam, but production mutation behavior
-      migration belongs to #1403.
+      #1414 closes the producer-visible event/pipeline raw callback entrypoint
+      slice. Full production mutation behavior migration remains #1403.
 
   - id: sqlite_busy_serialization_behavior_guard
     classification: guard
@@ -255,16 +257,16 @@ rows:
       - kind: go_test
         name: TestSQLiteRuntimeStore_RunRuntimeMutationDoesNotRetryActiveTransaction
       - kind: go_test
-        name: TestSQLiteWorkflowInstanceStore_RunInPipelineTransactionRequiresRuntimeMutationRunner
+        name: TestSQLiteWorkflowInstanceStore_RunPipelineMutationRequiresRuntimeMutationRunner
       - kind: go_test
-        name: TestSQLiteWorkflowInstanceStore_RunInPipelineTransactionUsesRuntimeMutationRunner
+        name: TestSQLiteWorkflowInstanceStore_RunPipelineMutationUsesRuntimeMutationRunner
       - kind: go_test
         name: TestPostgresStore_RunEventTransactionDoesNotSerializeCallbacks
     guard_proof_refs:
       - kind: go_test
         name: TestSelectedSQLiteRuntimeConstructionConsumesMutationBoundary
       - kind: go_test
-        name: TestSQLiteWorkflowInstanceStore_RunInPipelineTransactionRequiresRuntimeMutationRunner
+        name: TestSQLiteWorkflowInstanceStore_RunPipelineMutationRequiresRuntimeMutationRunner
     notes: >
       SQLite busy/retry policy belongs below the store boundary. Pipeline writes
       require an injected RuntimeMutationRunner and must not own a fallback

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -2603,8 +2603,16 @@ engine:
         - selected DB ping
         rule: These raw database consumers are adjacent process/workspace capabilities, not selected runtime persistence authority. They must stay named and must not be reused as runtime store fallbacks.
       - name: selected_runtime_mutation_unit_of_work
-        owner: backend_neutral_runtime_mutation_write_boundary and future typed unit-of-work owner under '#1403'
-        rule: Mutation writers must consume a semantic mutation owner. SQLite serialization/retry policy is owned below the store boundary and remains split to #1405.
+        owner: backend_neutral_runtime_mutation_write_boundary plus typed producer-visible unit-of-work entrypoints under '#1414'
+        promoted_first_slice_by: '#1414'
+        typed_entrypoint_owners:
+        - runtimebus.EventMutationRunner and runtimebus.EventMutation for selected event publish/outbox atomic mutation groups
+        - runtimepipeline.Store.RunPipelineMutation for selected workflow pipeline mutation groups
+        rule: >
+          Mutation writers must consume a semantic mutation owner. Event publish/outbox and workflow pipeline producers
+          must not construct raw `func(context.Context, *sql.Tx) error` callbacks as their selected-runtime mutation
+          authority. Backend-specific SQL transaction mechanics may remain inside store implementations. SQLite
+          serialization/retry policy is owned below the store boundary and remains split to #1405.
       raw_sql_policy:
         allowed:
         - boundary: backend selection, store construction, schema/bootstrap, and backend-specific store implementations
@@ -2673,8 +2681,8 @@ engine:
       - Active pipeline transactions are already inside the selected mutation boundary and must be reused rather than nested.
       - Schema/bootstrap, bundle catalog, destructive reset, preservation cleanup, fork-specific mutation/recovery, and read-only projections remain separate concepts unless independently gated.
       consumers:
-      - runtimebus transactional publish through EventTransactionRunner
-      - runtimepipeline.WorkflowInstanceStore production SQLite construction through NewSQLiteWorkflowInstanceStoreWithRuntimeMutationRunner
+      - runtimebus transactional publish through EventMutationRunner
+      - runtimepipeline.WorkflowInstanceStore production SQLite construction through NewSQLiteWorkflowInstanceStoreWithRuntimeMutationRunner and RunPipelineMutation
       - SQLiteRuntimeStore selected runtime mutation methods for the named row families
     - name: event_append_and_run_lifecycle_rows
       owner: runtimebus.EventStore


### PR DESCRIPTION
## Summary

Closes #1414.

Part of #1403 and #1400.

This PR promotes the approved first-slice typed runtime mutation unit-of-work entrypoints:

- adds `runtimebus.EventMutationRunner` / `runtimebus.EventMutation` for selected event publish and engine outbox mutation groups;
- adds `runtimepipeline.Store.RunPipelineMutation` for selected workflow pipeline mutation groups;
- keeps raw `*sql.Tx` mechanics inside store implementations and explicitly leaves `PublishTx` / `TransactionalEventStore` as a split legacy public/API hook outside this child closure claim;
- updates guards, matrix proof names, and `platform-spec.yaml` for the #1414 typed event/pipeline UoW first slice.

## Governing Refs

Exact governing spec/context:

- `platform-spec.yaml` `runtime_core_persistence_store_contracts`
- `platform-spec.yaml` `selected_runtime_store_facade`
- `platform-spec.yaml` `selected_runtime_mutation_unit_of_work`
- `platform-spec.yaml` `backend_neutral_runtime_mutation_write_boundary`
- `platform-spec.yaml` `pipeline_coordination_workflow_instance_and_replay_rows`
- `platform-spec.yaml` `raw_sql_runtime_consumer_boundary_for_sqlite`
- `internal/store/testdata/selected_store_abstraction_guard_matrix.yaml` `mutation_uow_behavior_split`
- `internal/store/testdata/selected_store_abstraction_guard_matrix.yaml` `sqlite_busy_serialization_behavior_guard`
- #1403 pre-audit and gate outcome on #1403 approving #1414 as first slice

## Semantic Migration

New canonical owner for this child class:

- selected event publish/outbox mutation authority: `runtimebus.EventMutationRunner` and `runtimebus.EventMutation`, implemented by selected stores below the producer boundary;
- selected workflow pipeline mutation authority: `runtimepipeline.Store.RunPipelineMutation`, backed by `SQLiteRuntimeStore.RunRuntimeMutationContext` for SQLite and normal Postgres transactions for Postgres.

Old producer-visible paths now invalid / non-authoritative for this child class:

- event publish and acknowledged publish no longer use `EventTransactionRunner.RunEventTransaction(ctx, func(context.Context, *sql.Tx) error)` as selected publish authority;
- engine outbox no longer pulls `*sql.Tx` directly from pipeline context;
- `runtimepipeline.Store` no longer exposes `RunInPipelineTransaction(ctx, func(context.Context, *sql.Tx) error)` to producers.

Production paths checked for surviving old behavior:

- event publish / acknowledged publish;
- engine outbox and post-commit dispatcher behavior;
- workflow engine adapter;
- workflow instance SQLite writes;
- system-node receipt/delivery lifecycle writes;
- selected-store guard matrix and runtime writer boundary audit.

Migration completeness:

- complete for #1414 `producer_visible_runtime_mutation_uow_raw_tx_callback_surface`;
- not full #1403 closure. The remaining row-family typed UoW tail stays tracked by #1403/#1400.

## Validation

- `go test ./internal/runtime/bus ./internal/runtime/pipeline ./internal/store ./internal/runtime/manager`
- `go test ./internal/store -run 'TestSelectedSQLiteRuntimeWriterBoundaryAudit|TestSelectedSQLiteRuntimeConstructionConsumesMutationBoundary|TestSelectedStoreAbstractionGuardMatrixCoversApprovedBoundary|TestSelectedStoreAbstractionGuardMatrixRejectsStaleProofRefs' -count=1`
- `go test ./...`
- supported-surface proof: `go test ./internal/store ./internal/runtime/bus ./internal/runtime/pipeline -run 'TestSelectedSQLiteRuntimeWriterBoundaryAudit|TestSelectedSQLiteRuntimeConstructionConsumesMutationBoundary|TestSelectedStoreAbstractionGuardMatrixCoversApprovedBoundary|TestSQLiteRuntimeStore_RunRuntimeMutation(RetriesBusyAndFlushesPostCommitOnce|StopsRetryOnContextDeadline|ContextDeadlineCapsDriverBusyTimeout|DoesNotRetryActiveTransaction|PostCommitCanReenterRuntimeMutation)|TestPostgresStore_RunEventTransactionDoesNotSerializeCallbacks|TestSQLiteWorkflowInstanceStore_RunPipelineMutation(RequiresRuntimeMutationRunner|UsesRuntimeMutationRunner|DoesNotRetryActiveTransaction)|TestWorkflowInstanceStore_RunPipelineMutationDoesNotRetryPostgresDialect|TestEngineOutboxPersistsEventsAndDeliveriesInTransaction|TestEngineOutboxAndDispatcher_UseCanonicalDirectRecipientManifest' -count=1`
