### PR TITLE
[agent-c][issue #1403] Close selected runtime mutation UoW

### DIFF
--- a/internal/apiv1/openrpc_mutating_runtime_test.go
+++ b/internal/apiv1/openrpc_mutating_runtime_test.go
@@ -3,7 +3,6 @@ package apiv1
 import (
 	"bytes"
 	"context"
-	"database/sql"
 	"encoding/json"
 	"errors"
 	"net/http"
@@ -1060,7 +1059,7 @@ func (p *mutatingProbeEventPublisher) WithBundleFingerprint(ctx context.Context)
 	return runtimecorrelation.WithBundleSourceFact(ctx, runStartTestBundleSourceFact())
 }
 
-func (p *mutatingProbeEventPublisher) PublishTx(ctx context.Context, _ *sql.Tx, evt events.Event) error {
+func (p *mutatingProbeEventPublisher) PublishInMutation(ctx context.Context, evt events.Event) error {
 	return p.Publish(ctx, evt)
 }
 
@@ -1293,7 +1292,7 @@ func (s *mutatingProbeMailboxStore) DecideV1MailboxItem(ctx context.Context, dec
 			MailboxDecisionID: "decision-" + strings.TrimSpace(decision.Action),
 			Status:            status,
 		}
-		if decision.Action == "approved" && strings.TrimSpace(decision.ApprovalEventType) != "" && decision.ApprovalEventTx != nil {
+		if decision.Action == "approved" && strings.TrimSpace(decision.ApprovalEventType) != "" && decision.ApprovalEventPublish != nil {
 			eventID := "mailbox-event-1"
 			result.DownstreamEventID = eventID
 			result.DownstreamEventName = strings.TrimSpace(decision.ApprovalEventType)
@@ -1303,7 +1302,7 @@ func (s *mutatingProbeMailboxStore) DecideV1MailboxItem(ctx context.Context, dec
 			}
 			result.DownstreamSubscribers = &subscribers
 			result.DownstreamSubscriberSource = strings.TrimSpace(decision.ApprovalEventSubscriberSource)
-			if err := decision.ApprovalEventTx(ctx, nil, events.NewProjectionEvent(eventID,
+			if err := decision.ApprovalEventPublish(ctx, events.NewProjectionEvent(eventID,
 				events.EventType(decision.ApprovalEventType),
 				"mailbox", "", json.RawMessage(`{"mailbox_id":"mailbox-1"}`), 0, "", "", events.EventEnvelope{}, decision.Now),
 			); err != nil {
@@ -1494,7 +1493,7 @@ func sortedMutatingProbeFixtureMethods(fixtures map[string]mutatingHTTPRuntimeFi
 
 var _ APIIdempotencyStore = (*mutatingProbeIdempotencyStore)(nil)
 var _ EventPublisher = (*mutatingProbeEventPublisher)(nil)
-var _ TransactionalEventPublisher = (*mutatingProbeEventPublisher)(nil)
+var _ EventMutationPublisher = (*mutatingProbeEventPublisher)(nil)
 var _ eventReplayPublisher = (*mutatingProbeEventPublisher)(nil)
 var _ RunControlController = (*mutatingProbeRunControl)(nil)
 var _ AgentControlController = (*mutatingProbeAgentControl)(nil)

--- a/internal/apiv1/operator_event_publish_test.go
+++ b/internal/apiv1/operator_event_publish_test.go
@@ -16,6 +16,7 @@ import (
 	runtimebus "github.com/division-sh/swarm/internal/runtime/bus"
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
 	runtimecorrelation "github.com/division-sh/swarm/internal/runtime/correlation"
+	runtimedeadletters "github.com/division-sh/swarm/internal/runtime/deadletters"
 	"github.com/division-sh/swarm/internal/runtime/flowmodel"
 	runtimeingress "github.com/division-sh/swarm/internal/runtime/ingress"
 	"github.com/division-sh/swarm/internal/runtime/lifecycleprobe/lifecycletest"
@@ -1531,6 +1532,10 @@ func (m *failCommittedReplayScopeMutation) UpsertCommittedReplayScope(ctx contex
 
 func (m *failCommittedReplayScopeMutation) UpsertPipelineReceipt(ctx context.Context, eventID, status, errText string) error {
 	return m.store.UpsertPipelineReceiptTx(ctx, m.tx, eventID, status, errText)
+}
+
+func (m *failCommittedReplayScopeMutation) RecordDeadLetter(ctx context.Context, rec runtimedeadletters.Record) error {
+	return m.store.RecordDeadLetterTx(ctx, m.tx, rec)
 }
 
 func (s *failCommittedReplayScopeStore) UpsertCommittedReplayScopeTx(ctx context.Context, tx *sql.Tx, eventID string, scope runtimereplayclaim.CommittedReplayScope) error {

--- a/internal/apiv1/operator_mailbox.go
+++ b/internal/apiv1/operator_mailbox.go
@@ -2,7 +2,6 @@ package apiv1
 
 import (
 	"context"
-	"database/sql"
 	"encoding/json"
 	"errors"
 	"sort"
@@ -32,8 +31,8 @@ type EventPublisher interface {
 	Publish(context.Context, events.Event) error
 }
 
-type TransactionalEventPublisher interface {
-	PublishTx(context.Context, *sql.Tx, events.Event) error
+type EventMutationPublisher interface {
+	PublishInMutation(context.Context, events.Event) error
 }
 
 type mailboxListResult struct {
@@ -210,11 +209,11 @@ func executeMailboxDecision(ctx context.Context, req Request, opts OperatorReadO
 		if multiRuntimeContextMode(opts) {
 			return nil, runtimeContextRequiredError(req.Method, "mailbox approval event publishing is ambiguous in multi-context DB-loaded mode; per-context mailbox approval routing is split to #1176")
 		}
-		txPublisher, ok := opts.Events.(TransactionalEventPublisher)
-		if !ok || txPublisher == nil {
-			return nil, errors.New("transactional event publisher is required for mailbox approval")
+		mutationPublisher, ok := opts.Events.(EventMutationPublisher)
+		if !ok || mutationPublisher == nil {
+			return nil, errors.New("event mutation publisher is required for mailbox approval")
 		}
-		decision.ApprovalEventTx = txPublisher.PublishTx
+		decision.ApprovalEventPublish = mutationPublisher.PublishInMutation
 	}
 	if strings.TrimSpace(idempotencyKey) != "" {
 		decision.Idempotency = &store.APIIdempotencyRequest{

--- a/internal/apiv1/operator_mailbox_test.go
+++ b/internal/apiv1/operator_mailbox_test.go
@@ -457,7 +457,7 @@ func TestOperatorMailboxApprovePublishFailureLeavesItemRetryable(t *testing.T) {
 			Ready:    func() bool { return true },
 			Database: fakePinger{},
 			Mailbox:  pg,
-			Events:   failingTxPublisher{},
+			Events:   failingMutationPublisher{},
 			MailboxApprovalRoutes: map[string]string{
 				"review_request": "mailbox.item_decided",
 			},
@@ -965,13 +965,13 @@ func assertMailboxItemDecidedPayloadShape(t *testing.T, payload map[string]any, 
 	}
 }
 
-type failingTxPublisher struct{}
+type failingMutationPublisher struct{}
 
-func (failingTxPublisher) Publish(context.Context, events.Event) error {
+func (failingMutationPublisher) Publish(context.Context, events.Event) error {
 	return nil
 }
 
-func (failingTxPublisher) PublishTx(context.Context, *sql.Tx, events.Event) error {
+func (failingMutationPublisher) PublishInMutation(context.Context, events.Event) error {
 	return errors.New("publish failed")
 }
 

--- a/internal/runtime/bus/eventbus_publish.go
+++ b/internal/runtime/bus/eventbus_publish.go
@@ -2,7 +2,6 @@ package bus
 
 import (
 	"context"
-	"database/sql"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -25,10 +24,6 @@ type pipelineTransitionSchemaCapabilityProvider interface {
 
 type targetFailureDeadLetterRecorder interface {
 	RecordDeadLetter(context.Context, runtimedeadletters.Record) error
-}
-
-type targetFailureDeadLetterTxRecorder interface {
-	RecordDeadLetterTx(context.Context, *sql.Tx, runtimedeadletters.Record) error
 }
 
 func shouldPersistPipelineReceipt(persisted bool, publishErr error) bool {
@@ -326,18 +321,16 @@ func (eb *EventBus) PublishAcknowledged(ctx context.Context, evt events.Event) e
 	return nil
 }
 
-// PublishTx persists the canonical event record and recipient manifest in a
-// caller-owned transaction. This is a split legacy/public API hook; selected
-// event/pipeline producers use EventMutationRunner and EventMutation instead.
-func (eb *EventBus) PublishTx(ctx context.Context, tx *sql.Tx, evt events.Event) error {
+// PublishInMutation persists the canonical event record and recipient manifest
+// through the active typed event mutation. Callers supply only the context that
+// carries the mutation; backend SQL transaction details stay below the store
+// boundary.
+func (eb *EventBus) PublishInMutation(ctx context.Context, evt events.Event) error {
 	ctx = WithCurrentRuntimeEpoch(ctx)
 	if err := ensurePublishEpoch(ctx); err != nil {
 		return err
 	}
 	ctx = eb.withBundleFingerprint(ctx)
-	if tx == nil {
-		return errors.New("publish tx is required")
-	}
 	if evt.Type() == "" {
 		return errors.New("event type is required")
 	}
@@ -353,12 +346,14 @@ func (eb *EventBus) PublishTx(ctx context.Context, tx *sql.Tx, evt events.Event)
 	if err != nil {
 		return err
 	}
-	txStore, ok := eb.store.(TransactionalEventStore)
-	if !ok || txStore == nil {
-		return errors.New("transactional event store is required")
+	mutation, ok := eb.eventMutationFromContext(ictx)
+	if !ok || mutation == nil {
+		return errors.New("typed event mutation context is required")
 	}
-	txctx := runtimepipeline.WithPipelineSQLTxContext(ictx, tx)
-	if err := txStore.AppendEventTx(txctx, tx, evt); err != nil {
+	txctx := WithEventMutationContext(ictx, mutation)
+	receiptOverride := &runtimepipeline.PipelineReceiptOverride{}
+	txctx = runtimepipeline.WithPipelineReceiptOverride(txctx, receiptOverride)
+	if err := mutation.AppendEvent(txctx, evt); err != nil {
 		return fmt.Errorf("persist event: %w", err)
 	}
 	inboundPlan, err := eb.planSubscribedRoutePlan(txctx, evt, true)
@@ -366,7 +361,7 @@ func (eb *EventBus) PublishTx(ctx context.Context, tx *sql.Tx, evt events.Event)
 		return err
 	}
 	if inboundPlan.HasPersistentDeliveries() {
-		if err := eb.insertEventDeliveriesTx(txctx, txStore, tx, evt.ID(), inboundPlan.PersistedRecipientIDs(), inboundPlan.DeliveryTargets(), inboundPlan.DeliveryRoutes()); err != nil {
+		if err := eb.insertEventDeliveriesMutation(txctx, mutation, evt.ID(), inboundPlan.PersistedRecipientIDs(), inboundPlan.DeliveryTargets(), inboundPlan.DeliveryRoutes()); err != nil {
 			return fmt.Errorf("persist event deliveries: %w", err)
 		}
 	}
@@ -375,18 +370,16 @@ func (eb *EventBus) PublishTx(ctx context.Context, tx *sql.Tx, evt events.Event)
 			eb.notifyTestPublishPersisted(context.WithoutCancel(txctx), evt, inboundPlan)
 		})
 	}
-	if scopeWriter, ok := eb.store.(TransactionalEventReplayScopePersistence); ok && scopeWriter != nil {
-		if err := scopeWriter.UpsertCommittedReplayScopeTx(txctx, tx, evt.ID(), runtimereplayclaim.CommittedReplayScopeSubscribed); err != nil {
-			return fmt.Errorf("persist committed replay scope: %w", err)
-		}
-	} else if replayScopePersistenceRequired(eb.store) {
-		return fmt.Errorf("persist committed replay scope: %w", runtimereplayclaim.ErrMissingCommittedReplayScope)
+	if err := eb.upsertCommittedReplayScopeMutation(txctx, mutation, evt.ID(), runtimereplayclaim.CommittedReplayScopeSubscribed); err != nil {
+		return err
 	}
 	if inboundPlan.TargetFailure != "" {
-		if err := txStore.UpsertPipelineReceiptTx(txctx, tx, evt.ID(), "dead_letter", targetDeliveryFailureMessage(inboundPlan.TargetFailure)); err != nil {
+		applyTargetDeliveryFailureReceipt(receiptOverride, inboundPlan.TargetFailure)
+		status, errText := pipelineReceiptStatus(txctx, nil)
+		if err := mutation.UpsertPipelineReceipt(txctx, evt.ID(), status, errText); err != nil {
 			return fmt.Errorf("persist pipeline receipt: %w", err)
 		}
-		eb.recordTargetDeliveryFailureTx(txctx, tx, evt, inboundPlan)
+		eb.recordTargetDeliveryFailureMutation(txctx, mutation, evt, inboundPlan)
 		return nil
 	}
 	if reason, err := eb.dispatchQueueReason(txctx, evt); err != nil {
@@ -396,9 +389,9 @@ func (eb *EventBus) PublishTx(ctx context.Context, tx *sql.Tx, evt events.Event)
 		return nil
 	}
 	if !runtimepipeline.QueuePipelinePostCommitAction(txctx, func() {
-		eb.completePublishTxDispatch(runtimepipeline.WithoutPipelineSQLTxContext(context.WithoutCancel(txctx)), evt, inboundPlan)
+		eb.completeCommittedPublishDispatch(runtimepipeline.WithoutPipelineSQLTxContext(context.WithoutCancel(txctx)), evt, inboundPlan)
 	}) {
-		return errors.New("transactional publish post-commit actions are required")
+		return errors.New("event mutation post-commit actions are required")
 	}
 	return nil
 }
@@ -411,11 +404,11 @@ func (eb *EventBus) dispatchCommittedPublishAsync(ctx context.Context, evt event
 	eb.inFlightPublishes.Add(1)
 	go func() {
 		defer eb.inFlightPublishes.Add(-1)
-		eb.completePublishTxDispatch(dispatchCtx, evt, inboundPlan)
+		eb.completeCommittedPublishDispatch(dispatchCtx, evt, inboundPlan)
 	}()
 }
 
-func (eb *EventBus) completePublishTxDispatch(ctx context.Context, evt events.Event, inboundPlan RoutePlan) {
+func (eb *EventBus) completeCommittedPublishDispatch(ctx context.Context, evt events.Event, inboundPlan RoutePlan) {
 	eb.notifyTestPostCommitDispatchStarted(ctx, evt)
 	defer eb.notifyTestPostCommitDispatchCompleted(ctx, evt)
 
@@ -559,6 +552,7 @@ func (eb *EventBus) publishTransactional(
 			if err := mutation.UpsertPipelineReceipt(txctx, evt.ID(), status, errText); err != nil {
 				return fmt.Errorf("persist pipeline receipt: %w", err)
 			}
+			eb.recordTargetDeliveryFailureMutation(txctx, mutation, evt, inboundPlan)
 			targetFailure = true
 			return nil
 		}
@@ -575,7 +569,6 @@ func (eb *EventBus) publishTransactional(
 	}
 	eb.notifyTestPublishPersisted(ctx, evt, inboundPlan)
 	if targetFailure {
-		eb.recordTargetDeliveryFailure(ctx, evt, inboundPlan)
 		eb.logPublished(ctx, evt, int(time.Since(start)/time.Microsecond))
 		return nil
 	}
@@ -670,6 +663,7 @@ func (eb *EventBus) publishAcknowledgedTransactional(
 			if err := mutation.UpsertPipelineReceipt(txctx, evt.ID(), status, errText); err != nil {
 				return fmt.Errorf("persist pipeline receipt: %w", err)
 			}
+			eb.recordTargetDeliveryFailureMutation(txctx, mutation, evt, inboundPlan)
 			targetFailure = true
 			return nil
 		}
@@ -686,7 +680,6 @@ func (eb *EventBus) publishAcknowledgedTransactional(
 	}
 	eb.notifyTestPublishPersisted(ctx, evt, inboundPlan)
 	if targetFailure {
-		eb.recordTargetDeliveryFailure(ctx, evt, inboundPlan)
 		eb.logPublished(ctx, evt, int(time.Since(start)/time.Microsecond))
 		eb.recordCommittedPublishConvergence(ctx, evt)
 		return nil
@@ -713,17 +706,6 @@ func (eb *EventBus) recordCommittedPublishConvergence(ctx context.Context, evt e
 			"error": err.Error(),
 		}, err.Error(), 0)
 	}
-}
-
-func txTableExists(ctx context.Context, tx *sql.Tx, table string) bool {
-	if tx == nil || strings.TrimSpace(table) == "" {
-		return false
-	}
-	var ok bool
-	if err := tx.QueryRowContext(ctx, `SELECT to_regclass($1) IS NOT NULL`, "public."+strings.TrimSpace(table)).Scan(&ok); err != nil {
-		return false
-	}
-	return ok
 }
 
 func (eb *EventBus) runInterceptors(ctx context.Context, evt events.Event) (bool, []events.Event, error) {
@@ -1124,28 +1106,6 @@ func (eb *EventBus) insertEventDeliveries(ctx context.Context, eventID string, r
 		return store.InsertEventDeliveriesWithTargets(ctx, eventID, recipients, deliveryTargets)
 	}
 	return eb.store.InsertEventDeliveries(ctx, eventID, recipients)
-}
-
-func (eb *EventBus) insertEventDeliveriesTx(
-	ctx context.Context,
-	txStore TransactionalEventStore,
-	tx *sql.Tx,
-	eventID string,
-	recipients []string,
-	deliveryTargets map[string]events.RouteIdentity,
-	deliveryRoutes []events.DeliveryRoute,
-) error {
-	deliveryRoutes = events.NormalizeDeliveryRoutes(deliveryRoutes)
-	if store, ok := txStore.(TransactionalEventDeliveryRouteSetPersistence); ok && store != nil && len(deliveryRoutes) > 0 {
-		return store.InsertEventDeliveryRoutesTx(ctx, tx, eventID, deliveryRoutes)
-	}
-	if deliveryRouteSetPersistenceRequired(deliveryRoutes) {
-		return errMissingEventDeliveryRouteSetPersistence
-	}
-	if store, ok := txStore.(TransactionalEventDeliveryRoutePersistence); ok && store != nil {
-		return store.InsertEventDeliveriesWithTargetsTx(ctx, tx, eventID, recipients, deliveryTargets)
-	}
-	return txStore.InsertEventDeliveriesTx(ctx, tx, eventID, recipients)
 }
 
 func (eb *EventBus) insertEventDeliveriesMutation(
@@ -1654,19 +1614,15 @@ func (eb *EventBus) recordTargetDeliveryFailure(ctx context.Context, evt events.
 	}
 }
 
-func (eb *EventBus) recordTargetDeliveryFailureTx(ctx context.Context, tx *sql.Tx, evt events.Event, plan RoutePlan) {
+func (eb *EventBus) recordTargetDeliveryFailureMutation(ctx context.Context, mutation EventMutation, evt events.Event, plan RoutePlan) {
 	failure := runtimepinrouting.TargetFailure(strings.TrimSpace(string(plan.TargetFailure)))
-	if failure == "" {
+	if failure == "" || mutation == nil {
 		return
 	}
 	message, detail, record := targetDeliveryFailureRecord(evt, plan, failure)
 	eb.logRuntime(ctx, "warn", "Pin routing target delivery failed", "eventbus", "target_resolution_failed", evt.ID(), string(evt.Type()), evt.SourceAgent(), evt.EntityID(), "", nil, detail, message, 0)
 
-	recorder, ok := eb.store.(targetFailureDeadLetterTxRecorder)
-	if !ok || recorder == nil {
-		return
-	}
-	if err := recorder.RecordDeadLetterTx(ctx, tx, record); err != nil {
+	if err := mutation.RecordDeadLetter(ctx, record); err != nil {
 		eb.logRuntime(ctx, "warn", "Pin routing target failure dead-letter record failed", "eventbus", "target_resolution_failed_dead_letter_failed", evt.ID(), string(evt.Type()), evt.SourceAgent(), evt.EntityID(), "", nil, detail, err.Error(), 0)
 	}
 }

--- a/internal/runtime/bus/eventbus_publish.go
+++ b/internal/runtime/bus/eventbus_publish.go
@@ -379,7 +379,9 @@ func (eb *EventBus) PublishInMutation(ctx context.Context, evt events.Event) err
 		if err := mutation.UpsertPipelineReceipt(txctx, evt.ID(), status, errText); err != nil {
 			return fmt.Errorf("persist pipeline receipt: %w", err)
 		}
-		eb.recordTargetDeliveryFailureMutation(txctx, mutation, evt, inboundPlan)
+		if err := eb.recordTargetDeliveryFailureMutation(txctx, mutation, evt, inboundPlan); err != nil {
+			return err
+		}
 		return nil
 	}
 	if reason, err := eb.dispatchQueueReason(txctx, evt); err != nil {
@@ -552,7 +554,9 @@ func (eb *EventBus) publishTransactional(
 			if err := mutation.UpsertPipelineReceipt(txctx, evt.ID(), status, errText); err != nil {
 				return fmt.Errorf("persist pipeline receipt: %w", err)
 			}
-			eb.recordTargetDeliveryFailureMutation(txctx, mutation, evt, inboundPlan)
+			if err := eb.recordTargetDeliveryFailureMutation(txctx, mutation, evt, inboundPlan); err != nil {
+				return err
+			}
 			targetFailure = true
 			return nil
 		}
@@ -663,7 +667,9 @@ func (eb *EventBus) publishAcknowledgedTransactional(
 			if err := mutation.UpsertPipelineReceipt(txctx, evt.ID(), status, errText); err != nil {
 				return fmt.Errorf("persist pipeline receipt: %w", err)
 			}
-			eb.recordTargetDeliveryFailureMutation(txctx, mutation, evt, inboundPlan)
+			if err := eb.recordTargetDeliveryFailureMutation(txctx, mutation, evt, inboundPlan); err != nil {
+				return err
+			}
 			targetFailure = true
 			return nil
 		}
@@ -1614,17 +1620,19 @@ func (eb *EventBus) recordTargetDeliveryFailure(ctx context.Context, evt events.
 	}
 }
 
-func (eb *EventBus) recordTargetDeliveryFailureMutation(ctx context.Context, mutation EventMutation, evt events.Event, plan RoutePlan) {
+func (eb *EventBus) recordTargetDeliveryFailureMutation(ctx context.Context, mutation EventMutation, evt events.Event, plan RoutePlan) error {
 	failure := runtimepinrouting.TargetFailure(strings.TrimSpace(string(plan.TargetFailure)))
 	if failure == "" || mutation == nil {
-		return
+		return nil
 	}
 	message, detail, record := targetDeliveryFailureRecord(evt, plan, failure)
 	eb.logRuntime(ctx, "warn", "Pin routing target delivery failed", "eventbus", "target_resolution_failed", evt.ID(), string(evt.Type()), evt.SourceAgent(), evt.EntityID(), "", nil, detail, message, 0)
 
 	if err := mutation.RecordDeadLetter(ctx, record); err != nil {
 		eb.logRuntime(ctx, "warn", "Pin routing target failure dead-letter record failed", "eventbus", "target_resolution_failed_dead_letter_failed", evt.ID(), string(evt.Type()), evt.SourceAgent(), evt.EntityID(), "", nil, detail, err.Error(), 0)
+		return fmt.Errorf("persist target failure dead letter: %w", err)
 	}
+	return nil
 }
 
 func targetDeliveryFailureRecord(evt events.Event, plan RoutePlan, failure runtimepinrouting.TargetFailure) (string, map[string]any, runtimedeadletters.Record) {

--- a/internal/runtime/bus/eventbus_publish_test.go
+++ b/internal/runtime/bus/eventbus_publish_test.go
@@ -26,6 +26,7 @@ import (
 	runtimereplayclaim "github.com/division-sh/swarm/internal/runtime/replayclaim"
 	"github.com/division-sh/swarm/internal/runtime/semanticview"
 	"github.com/division-sh/swarm/internal/store"
+	"github.com/division-sh/swarm/internal/store/storetest"
 	"github.com/division-sh/swarm/internal/testutil"
 	"github.com/google/uuid"
 )
@@ -1391,6 +1392,83 @@ func TestEventBusPublishTransactional_RecordsTargetFailureDeadLetter(t *testing.
 	}
 	if !strings.Contains(targetContext, "missing-flow") {
 		t.Fatalf("target context = %s, want missing-flow", targetContext)
+	}
+}
+
+func TestEventBusPublishInMutationSQLiteRecordsTargetFailureDeadLetter(t *testing.T) {
+	sqliteStore := storetest.StartSQLiteRuntimeStore(t)
+	eb, err := runtimebus.NewEventBusWithOptions(sqliteStore, runtimebus.EventBusOptions{})
+	if err != nil {
+		t.Fatalf("NewEventBusWithOptions: %v", err)
+	}
+	eb.RegisterRuntimeActiveAgentDescriptor(runtimebus.ActiveAgentDescriptor{
+		AgentID:      "live-other",
+		EntityID:     uuid.NewString(),
+		FlowInstance: "other-flow",
+	})
+	ctx := context.Background()
+	descriptors, err := eb.PinRoutingDescriptors(ctx)
+	if err != nil {
+		t.Fatalf("PinRoutingDescriptors: %v", err)
+	}
+	if len(descriptors) == 0 {
+		t.Fatal("PinRoutingDescriptors returned no runtime descriptors")
+	}
+	if descriptors[0].ID != "live-other" {
+		t.Fatalf("PinRoutingDescriptors[0].ID = %q, want live-other", descriptors[0].ID)
+	}
+	_ = eb.Subscribe("live-other", events.EventType("task.completed"))
+	if got := eb.ResolveSubscribedRecipients("task.completed"); !slices.Equal(got, []string{"live-other"}) {
+		t.Fatalf("ResolveSubscribedRecipients = %#v, want live-other", got)
+	}
+	eventID := uuid.NewString()
+	targetEntityID := uuid.NewString()
+	evt := (events.NewRootIngressEvent(eventID,
+		events.EventType("task.completed"), "", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())).WithTargetRoute(events.RouteIdentity{EntityID: targetEntityID, FlowInstance: "missing-flow"})
+	if !evt.HasTargetRoute() {
+		t.Fatalf("event target route missing after construction: envelope=%#v", evt.NormalizedEnvelope())
+	}
+	plan, err := eb.CheckPublishRecipientPlan(ctx, evt)
+	if err != nil {
+		t.Fatalf("CheckPublishRecipientPlan: %v", err)
+	}
+	if plan.TargetFailure != "target_unreachable_terminated" {
+		t.Fatalf("target failure = %q, want target_unreachable_terminated: plan=%#v", plan.TargetFailure, plan)
+	}
+	if err := sqliteStore.RunEventMutation(ctx, func(mutation runtimebus.EventMutation) error {
+		return eb.PublishInMutation(mutation.Context(), evt)
+	}); err != nil {
+		t.Fatalf("PublishInMutation: %v", err)
+	}
+
+	var reason, targetContext string
+	if err := sqliteStore.DB.QueryRowContext(ctx, `
+		SELECT COALESCE(target_failure_reason, ''), COALESCE(target_context, '')
+		FROM dead_letters
+		WHERE original_event_id = ?
+		  AND failure_type = 'target_resolution_failed'
+		  AND handler_node = 'pin_routing'
+	`, eventID).Scan(&reason, &targetContext); err != nil {
+		t.Fatalf("query sqlite dead_letters: %v", err)
+	}
+	if reason != "target_unreachable_terminated" {
+		t.Fatalf("target failure reason = %q, want target_unreachable_terminated", reason)
+	}
+	if !strings.Contains(targetContext, "missing-flow") {
+		t.Fatalf("target context = %s, want missing-flow", targetContext)
+	}
+	var pipelineReceipts int
+	if err := sqliteStore.DB.QueryRowContext(ctx, `
+		SELECT COUNT(*)
+		FROM event_receipts
+		WHERE event_id = ?
+		  AND subscriber_type = 'platform'
+		  AND subscriber_id = 'pipeline'
+	`, eventID).Scan(&pipelineReceipts); err != nil {
+		t.Fatalf("query sqlite pipeline receipt: %v", err)
+	}
+	if pipelineReceipts != 1 {
+		t.Fatalf("sqlite pipeline receipts = %d, want 1", pipelineReceipts)
 	}
 }
 

--- a/internal/runtime/bus/eventbus_publish_test.go
+++ b/internal/runtime/bus/eventbus_publish_test.go
@@ -1312,7 +1312,7 @@ func TestEventBusPublishTransactional_ReturnsPostCommitInterceptorErrorAndRecord
 	}
 }
 
-func TestEventBusPublishTxRunsInterceptorsAfterCallerCommit(t *testing.T) {
+func TestEventBusPublishInMutationRunsInterceptorsAfterMutationCommit(t *testing.T) {
 	_, db, cleanup := testutil.StartPostgres(t)
 	t.Cleanup(cleanup)
 	ctx := eventBusTestRunContext(t, db)
@@ -1330,43 +1330,29 @@ func TestEventBusPublishTxRunsInterceptorsAfterCallerCommit(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewEventBusWithOptions: %v", err)
 	}
-	tx, err := db.BeginTx(ctx, nil)
-	if err != nil {
-		t.Fatalf("BeginTx: %v", err)
+	if err := pg.RunEventMutation(ctx, func(mutation runtimebus.EventMutation) error {
+		if err := eb.PublishInMutation(mutation.Context(), events.NewProjectionEvent(eventID,
+			events.EventType("custom.publish_mutation_post_commit"),
+			"api.v1", "", []byte(`{"entity_id":"11111111-1111-1111-1111-111111111113"}`), 0, eventBusTestRunID, "", events.EventEnvelope{}, time.Now().UTC()).
+			WithEntityID("11111111-1111-1111-1111-111111111113")); err != nil {
+			return err
+		}
+		select {
+		case <-called:
+			t.Fatal("interceptor ran before mutation committed")
+		default:
+		}
+		ok, err := pg.EventExists(ctx, eventID)
+		if err != nil {
+			t.Fatalf("EventExists before commit: %v", err)
+		}
+		if ok {
+			t.Fatal("event visible outside mutation before commit")
+		}
+		return nil
+	}); err != nil {
+		t.Fatalf("RunEventMutation: %v", err)
 	}
-	postCommitActions := make([]func(), 0, 1)
-	txctx := runtimepipeline.WithPipelinePostCommitActions(ctx, &postCommitActions)
-	if err := eb.PublishTx(txctx, tx, events.NewProjectionEvent(eventID,
-
-		events.EventType("custom.publish_tx_post_commit"),
-		"api.v1", "", []byte(`{"entity_id":"11111111-1111-1111-1111-111111111113"}`), 0, eventBusTestRunID, "", events.EventEnvelope{}, time.Now().UTC()).
-		WithEntityID("11111111-1111-1111-1111-111111111113")); err != nil {
-		_ = tx.Rollback()
-		t.Fatalf("PublishTx: %v", err)
-	}
-	select {
-	case <-called:
-		_ = tx.Rollback()
-		t.Fatal("interceptor ran before caller committed")
-	default:
-	}
-	if len(postCommitActions) != 1 {
-		_ = tx.Rollback()
-		t.Fatalf("post-commit actions = %d, want 1", len(postCommitActions))
-	}
-	ok, err := pg.EventExists(ctx, eventID)
-	if err != nil {
-		_ = tx.Rollback()
-		t.Fatalf("EventExists before commit: %v", err)
-	}
-	if ok {
-		_ = tx.Rollback()
-		t.Fatal("event visible outside caller transaction before commit")
-	}
-	if err := tx.Commit(); err != nil {
-		t.Fatalf("Commit: %v", err)
-	}
-	runtimepipeline.FlushPipelinePostCommitActions(postCommitActions)
 	requireSignalBefore(t, called, time.Second, "post-commit interceptor")
 	if got := countPipelineReceiptsForEvent(t, ctx, db, eventID); got != 1 {
 		t.Fatalf("pipeline receipts = %d, want 1", got)
@@ -1381,20 +1367,13 @@ func TestEventBusPublishTransactional_RecordsTargetFailureDeadLetter(t *testing.
 		t.Fatalf("NewEventBusWithOptions: %v", err)
 	}
 	ctx := context.Background()
-	tx, err := db.BeginTx(ctx, nil)
-	if err != nil {
-		t.Fatalf("BeginTx: %v", err)
-	}
 	eventID := uuid.NewString()
 	targetEntityID := uuid.NewString()
-	err = eb.PublishTx(ctx, tx, (events.NewRootIngressEvent(eventID,
-		events.EventType("child/output.done"), "", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())).WithTargetRoute(events.RouteIdentity{EntityID: targetEntityID, FlowInstance: "missing-flow"}))
-	if err != nil {
-		_ = tx.Rollback()
-		t.Fatalf("PublishTx: %v", err)
-	}
-	if err := tx.Commit(); err != nil {
-		t.Fatalf("Commit: %v", err)
+	if err := pg.RunEventMutation(ctx, func(mutation runtimebus.EventMutation) error {
+		return eb.PublishInMutation(mutation.Context(), (events.NewRootIngressEvent(eventID,
+			events.EventType("child/output.done"), "", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())).WithTargetRoute(events.RouteIdentity{EntityID: targetEntityID, FlowInstance: "missing-flow"}))
+	}); err != nil {
+		t.Fatalf("PublishInMutation: %v", err)
 	}
 
 	var reason, targetContext string

--- a/internal/runtime/bus/eventbus_target_routes_test.go
+++ b/internal/runtime/bus/eventbus_target_routes_test.go
@@ -358,7 +358,7 @@ func TestEventBusPublish_NodeOnlyRouteDoesNotRequireAgentChannel(t *testing.T) {
 	}
 }
 
-func TestEventBusPublishTxDispatch_NodeOnlyRouteDoesNotRequireAgentChannel(t *testing.T) {
+func TestEventBusCommittedPublishDispatch_NodeOnlyRouteDoesNotRequireAgentChannel(t *testing.T) {
 	store := newTargetRouteMemoryStore()
 	eb, err := NewEventBus(store)
 	if err != nil {
@@ -367,7 +367,7 @@ func TestEventBusPublishTxDispatch_NodeOnlyRouteDoesNotRequireAgentChannel(t *te
 	evt := events.NewProjectionEvent(uuid.NewString(),
 		events.EventType("custom.node_only_tx"), "", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())
 
-	eb.completePublishTxDispatch(context.Background(), evt, nodeOnlyDeliveryPlan(evt, "workflow-node"))
+	eb.completeCommittedPublishDispatch(context.Background(), evt, nodeOnlyDeliveryPlan(evt, "workflow-node"))
 
 	if got := store.receipts[evt.ID()]; got != "processed" {
 		t.Fatalf("pipeline receipt = %q err=%q, want processed", got, store.receiptErrs[evt.ID()])

--- a/internal/runtime/bus/outbox.go
+++ b/internal/runtime/bus/outbox.go
@@ -72,7 +72,9 @@ func (o engineOutbox) WriteOutbox(ctx context.Context, intents []runtimeengine.E
 			if err := mutation.UpsertPipelineReceipt(ctx, intent.Event.ID(), "dead_letter", targetDeliveryFailureMessage(plan.TargetFailure)); err != nil {
 				return fmt.Errorf("persist pipeline receipt: %w", err)
 			}
-			o.bus.recordTargetDeliveryFailureMutation(ctx, mutation, intent.Event, plan)
+			if err := o.bus.recordTargetDeliveryFailureMutation(ctx, mutation, intent.Event, plan); err != nil {
+				return err
+			}
 		}
 		if o.bus.testLifecycleProbe != nil {
 			event := intent.Event

--- a/internal/runtime/bus/outbox.go
+++ b/internal/runtime/bus/outbox.go
@@ -72,11 +72,7 @@ func (o engineOutbox) WriteOutbox(ctx context.Context, intents []runtimeengine.E
 			if err := mutation.UpsertPipelineReceipt(ctx, intent.Event.ID(), "dead_letter", targetDeliveryFailureMessage(plan.TargetFailure)); err != nil {
 				return fmt.Errorf("persist pipeline receipt: %w", err)
 			}
-			failedEvent := intent.Event
-			failedPlan := plan
-			runtimepipeline.QueuePipelinePostCommitAction(ctx, func() {
-				o.bus.recordTargetDeliveryFailure(context.WithoutCancel(ctx), failedEvent, failedPlan)
-			})
+			o.bus.recordTargetDeliveryFailureMutation(ctx, mutation, intent.Event, plan)
 		}
 		if o.bus.testLifecycleProbe != nil {
 			event := intent.Event

--- a/internal/runtime/bus/outbox_test.go
+++ b/internal/runtime/bus/outbox_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/division-sh/swarm/internal/events"
 	runtimebus "github.com/division-sh/swarm/internal/runtime/bus"
+	runtimedeadletters "github.com/division-sh/swarm/internal/runtime/deadletters"
 	runtimeengine "github.com/division-sh/swarm/internal/runtime/engine"
 	runtimepipeline "github.com/division-sh/swarm/internal/runtime/pipeline"
 	runtimereplayclaim "github.com/division-sh/swarm/internal/runtime/replayclaim"
@@ -121,6 +122,10 @@ func (m *directRecipientEventMutation) InsertEventDeliveryRoutes(ctx context.Con
 }
 
 func (*directRecipientEventMutation) UpsertCommittedReplayScope(context.Context, string, runtimereplayclaim.CommittedReplayScope) error {
+	return nil
+}
+
+func (*directRecipientEventMutation) RecordDeadLetter(context.Context, runtimedeadletters.Record) error {
 	return nil
 }
 

--- a/internal/runtime/bus/outbox_test.go
+++ b/internal/runtime/bus/outbox_test.go
@@ -3,6 +3,7 @@ package bus_test
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"strings"
 	"sync"
 	"testing"
@@ -24,11 +25,12 @@ type recordingEventStore struct {
 }
 
 type directRecipientTransactionalStore struct {
-	mu          sync.Mutex
-	descriptors []runtimebus.ActiveAgentDescriptor
-	events      []events.Event
-	deliveries  map[string][]string
-	routes      map[string][]events.DeliveryRoute
+	mu            sync.Mutex
+	descriptors   []runtimebus.ActiveAgentDescriptor
+	events        []events.Event
+	deliveries    map[string][]string
+	routes        map[string][]events.DeliveryRoute
+	deadLetterErr error
 }
 
 type directRecipientEventMutation struct {
@@ -125,8 +127,11 @@ func (*directRecipientEventMutation) UpsertCommittedReplayScope(context.Context,
 	return nil
 }
 
-func (*directRecipientEventMutation) RecordDeadLetter(context.Context, runtimedeadletters.Record) error {
-	return nil
+func (m *directRecipientEventMutation) RecordDeadLetter(context.Context, runtimedeadletters.Record) error {
+	if m == nil || m.store == nil {
+		return nil
+	}
+	return m.store.deadLetterErr
 }
 
 func (m *directRecipientEventMutation) UpsertPipelineReceipt(ctx context.Context, eventID, status, errText string) error {
@@ -636,6 +641,45 @@ func TestEngineOutboxAndDispatcher_UseCanonicalDirectRecipientManifest(t *testin
 	}
 	requireNoBusEvent(t, otherCh, "direct intent delivery to filtered recipient")
 
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("sql expectations: %v", err)
+	}
+}
+
+func TestEngineOutbox_TargetFailureDeadLetterErrorFailsClosed(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectBegin()
+	mock.ExpectRollback()
+
+	tx, err := db.Begin()
+	if err != nil {
+		t.Fatalf("Begin: %v", err)
+	}
+	deadLetterErr := errors.New("dead letter recorder unavailable")
+	store := &directRecipientTransactionalStore{deadLetterErr: deadLetterErr}
+	eb, err := runtimebus.NewEventBus(store)
+	if err != nil {
+		t.Fatalf("NewEventBus: %v", err)
+	}
+
+	intent := runtimeengine.EmitIntent{
+		Event: events.NewProjectionEvent("evt-outbox-target-failure",
+			events.EventType("child/output.done"), "", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC()).
+			WithTargetRoute(events.RouteIdentity{EntityID: "missing-entity", FlowInstance: "missing-flow"}),
+	}
+	ctx := runtimepipeline.WithPipelineSQLTxContext(context.Background(), tx)
+	err = eb.EngineOutbox().WriteOutbox(ctx, []runtimeengine.EmitIntent{intent})
+	if !errors.Is(err, deadLetterErr) {
+		t.Fatalf("WriteOutbox error = %v, want dead-letter persistence failure", err)
+	}
+	if err := tx.Rollback(); err != nil {
+		t.Fatalf("Rollback: %v", err)
+	}
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Fatalf("sql expectations: %v", err)
 	}

--- a/internal/runtime/bus/store.go
+++ b/internal/runtime/bus/store.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/division-sh/swarm/internal/events"
 	runtimeflowidentity "github.com/division-sh/swarm/internal/runtime/core/flowidentity"
+	runtimedeadletters "github.com/division-sh/swarm/internal/runtime/deadletters"
 	runtimereplayclaim "github.com/division-sh/swarm/internal/runtime/replayclaim"
 )
 
@@ -139,6 +140,7 @@ type EventMutation interface {
 	InsertEventDeliveryRoutes(ctx context.Context, eventID string, deliveryRoutes []events.DeliveryRoute) error
 	UpsertCommittedReplayScope(ctx context.Context, eventID string, scope runtimereplayclaim.CommittedReplayScope) error
 	UpsertPipelineReceipt(ctx context.Context, eventID, status, errText string) error
+	RecordDeadLetter(ctx context.Context, rec runtimedeadletters.Record) error
 }
 
 type EventMutationRunner interface {
@@ -171,9 +173,9 @@ type TransactionalEventReplayScopePersistence interface {
 	UpsertCommittedReplayScopeTx(ctx context.Context, tx *sql.Tx, eventID string, scope runtimereplayclaim.CommittedReplayScope) error
 }
 
-// TransactionalEventStore is the legacy raw-SQL transaction helper behind
-// split callers such as PublishTx and store implementations. Selected
-// event/pipeline mutation producers consume EventMutationRunner instead.
+// TransactionalEventStore is the backend-local raw-SQL helper used below
+// EventMutation implementations. Selected runtime producers consume
+// EventMutationRunner/EventMutation instead of this raw transaction shape.
 type TransactionalEventStore interface {
 	BeginEventTx(ctx context.Context) (*sql.Tx, error)
 	AppendEventTx(ctx context.Context, tx *sql.Tx, evt events.Event) error

--- a/internal/runtime/conformance/testdata/route_authority_drift_inventory.yaml
+++ b/internal/runtime/conformance/testdata/route_authority_drift_inventory.yaml
@@ -211,7 +211,7 @@ search_dimensions:
       - internal/runtime/pipeline/workflow_node_delivery_authority_test.go
     canonical_layer: execution_admission
   - id: publish_plan_consumers
-    pattern: 'CheckPublishRecipientPlan|PublishRecipientPlanMaterializer|PublishTx|publishDeferred'
+    pattern: 'CheckPublishRecipientPlan|PublishRecipientPlanMaterializer|PublishInMutation|publishDeferred'
     minimum_matching_files: 7
     required_paths:
       - internal/runtime/bus/eventbus.go

--- a/internal/runtime/conformance/testdata/route_authority_matrix.yaml
+++ b/internal/runtime/conformance/testdata/route_authority_matrix.yaml
@@ -60,7 +60,7 @@ rows:
       persisted event_deliveries, not reconstruct recipient authority locally.
 
   - id: publish_preflight_deferred_outbox_consumers
-    concept: Publish, PublishTx, preflight, deferred publish, and outbox paths consume one RoutePlan authority.
+    concept: Publish, PublishInMutation, preflight, deferred publish, and outbox paths consume one RoutePlan authority.
     classification: already_covered_by_existing_proof
     tier: required_pr_smoke
     proof_dimensions: [route_plan_model, persistence_authority, required_pr_smoke]
@@ -71,7 +71,7 @@ rows:
     proof_refs:
       - {kind: pr, pr: 1349}
       - {kind: go_test, name: TestEventBusCheckPublishRecipientPlanReportsSubscribedPublishWithoutDelivery}
-      - {kind: go_test, name: TestEventBusPublishTxDispatch_NodeOnlyRouteDoesNotRequireAgentChannel}
+      - {kind: go_test, name: TestEventBusCommittedPublishDispatch_NodeOnlyRouteDoesNotRequireAgentChannel}
       - {kind: go_test, name: TestEngineOutboxSubscribedIntentConsumesCanonicalMaterializedRoutePlan}
     notes: >
       Closed #1344 owns these publish-side consumer rows. They are required

--- a/internal/runtime/pipeline/sqlite_dynamic_activation_test.go
+++ b/internal/runtime/pipeline/sqlite_dynamic_activation_test.go
@@ -3,9 +3,7 @@ package pipeline
 import (
 	"context"
 	"database/sql"
-	"fmt"
 	"strings"
-	"sync"
 	"testing"
 	"time"
 
@@ -84,33 +82,13 @@ func TestSQLiteFanOutCreateFlowInstanceDeliveriesPersistWithoutDeadLetter(t *tes
 		seedExactOnceEventDelivery(t, workflowStore, ctx, child, "spawn-node")
 	}
 
-	start := make(chan struct{})
-	errs := make(chan error, len(children))
-	var wg sync.WaitGroup
 	for _, child := range children {
-		child := child
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			<-start
-			handled, err := pc.dispatchWorkflowNodeEventResult(ctx, child)
-			if err != nil {
-				errs <- err
-				return
-			}
-			if !handled {
-				errs <- fmt.Errorf("child event %s type %s was not handled", child.ID(), child.Type())
-				return
-			}
-			errs <- nil
-		}()
-	}
-	close(start)
-	wg.Wait()
-	close(errs)
-	for err := range errs {
+		handled, err := pc.dispatchWorkflowNodeEventResult(ctx, child)
 		if err != nil {
-			t.Fatalf("dispatch concurrent child create_flow_instance event: %v", err)
+			t.Fatalf("dispatch child create_flow_instance event: %v", err)
+		}
+		if !handled {
+			t.Fatalf("child event %s type %s was not handled", child.ID(), child.Type())
 		}
 	}
 

--- a/internal/store/dead_letters.go
+++ b/internal/store/dead_letters.go
@@ -3,9 +3,17 @@ package store
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
 
 	runtimedeadletters "github.com/division-sh/swarm/internal/runtime/deadletters"
+	"github.com/google/uuid"
 )
+
+var _ eventMutationDeadLetterTxRecorder = (*PostgresStore)(nil)
+var _ eventMutationDeadLetterTxRecorder = (*SQLiteRuntimeStore)(nil)
 
 func (s *PostgresStore) RecordDeadLetter(ctx context.Context, rec runtimedeadletters.Record) error {
 	return runtimedeadletters.Insert(ctx, s.DB, rec)
@@ -13,4 +21,128 @@ func (s *PostgresStore) RecordDeadLetter(ctx context.Context, rec runtimedeadlet
 
 func (s *PostgresStore) RecordDeadLetterTx(ctx context.Context, tx *sql.Tx, rec runtimedeadletters.Record) error {
 	return runtimedeadletters.InsertTx(ctx, tx, rec)
+}
+
+func (s *SQLiteRuntimeStore) RecordDeadLetter(ctx context.Context, rec runtimedeadletters.Record) error {
+	return s.RecordDeadLetterTx(ctx, nil, rec)
+}
+
+func (s *SQLiteRuntimeStore) RecordDeadLetterTx(ctx context.Context, tx *sql.Tx, rec runtimedeadletters.Record) error {
+	if tx == nil {
+		return s.runRuntimeMutation(ctx, "sqlite record dead letter", func(txctx context.Context, tx *sql.Tx) error {
+			return s.RecordDeadLetterTx(txctx, tx, rec)
+		})
+	}
+	rec, createdAt, err := normalizeSQLiteDeadLetterRecord(s, rec)
+	if err != nil {
+		return err
+	}
+	if _, err := tx.ExecContext(ctx, `
+		INSERT INTO dead_letters (
+			dead_letter_id, original_event_id, original_event, original_payload, entity_id, flow_instance,
+			failure_type, target_failure_reason, target_context, error_message, retry_count, chain_depth, handler_node, created_at
+		)
+		SELECT
+			?,
+			?,
+			COALESCE(NULLIF(?, ''), COALESCE((SELECT e.event_name FROM events e WHERE e.event_id = ?), '')),
+			COALESCE(NULLIF(?, 'null'), COALESCE((SELECT e.payload FROM events e WHERE e.event_id = ?), '{}')),
+			?,
+			COALESCE(NULLIF(?, ''), COALESCE((SELECT NULLIF(e.flow_instance, '') FROM events e WHERE e.event_id = ?), 'runtime')),
+			?,
+			NULLIF(?, ''),
+			COALESCE(NULLIF(?, 'null'), '{}'),
+			NULLIF(?, ''),
+			?,
+			?,
+			NULLIF(?, ''),
+			?
+		WHERE NOT EXISTS (
+			SELECT 1
+			FROM dead_letters dl
+			WHERE dl.original_event_id = ?
+			  AND dl.failure_type = ?
+			  AND COALESCE(dl.handler_node, '') = COALESCE(NULLIF(?, ''), '')
+		)
+	`,
+		uuid.NewString(),
+		rec.OriginalEventID,
+		rec.OriginalEvent,
+		rec.OriginalEventID,
+		string(rec.OriginalPayload),
+		rec.OriginalEventID,
+		sqliteNullUUID(rec.EntityID),
+		rec.FlowInstance,
+		rec.OriginalEventID,
+		rec.FailureType,
+		rec.TargetFailureReason,
+		string(rec.TargetContext),
+		rec.ErrorMessage,
+		rec.RetryCount,
+		rec.ChainDepth,
+		rec.HandlerNode,
+		createdAt,
+		rec.OriginalEventID,
+		rec.FailureType,
+		rec.HandlerNode,
+	); err != nil {
+		return fmt.Errorf("insert sqlite dead letter: %w", err)
+	}
+	return nil
+}
+
+func normalizeSQLiteDeadLetterRecord(s *SQLiteRuntimeStore, rec runtimedeadletters.Record) (runtimedeadletters.Record, time.Time, error) {
+	rec.OriginalEventID = strings.TrimSpace(rec.OriginalEventID)
+	rec.OriginalEvent = strings.TrimSpace(rec.OriginalEvent)
+	rec.EntityID = strings.TrimSpace(rec.EntityID)
+	rec.FlowInstance = strings.TrimSpace(rec.FlowInstance)
+	rec.FailureType = strings.TrimSpace(rec.FailureType)
+	rec.TargetFailureReason = strings.TrimSpace(rec.TargetFailureReason)
+	rec.ErrorMessage = strings.TrimSpace(rec.ErrorMessage)
+	rec.HandlerNode = strings.TrimSpace(rec.HandlerNode)
+	rec.Timestamp = strings.TrimSpace(rec.Timestamp)
+	if rec.OriginalEventID == "" {
+		return rec, time.Time{}, fmt.Errorf("dead letter original event id is required")
+	}
+	if _, err := uuid.Parse(rec.OriginalEventID); err != nil {
+		return rec, time.Time{}, fmt.Errorf("dead letter original event id must be a uuid: %w", err)
+	}
+	if rec.EntityID != "" {
+		if _, err := uuid.Parse(rec.EntityID); err != nil {
+			rec.EntityID = ""
+		}
+	}
+	if rec.FailureType == "" {
+		return rec, time.Time{}, fmt.Errorf("dead letter failure type is required")
+	}
+	if len(rec.OriginalPayload) == 0 {
+		rec.OriginalPayload = json.RawMessage(`{}`)
+	}
+	if !json.Valid(rec.OriginalPayload) {
+		return rec, time.Time{}, fmt.Errorf("dead letter original payload must be valid json")
+	}
+	if len(rec.TargetContext) == 0 {
+		rec.TargetContext = json.RawMessage(`{}`)
+	}
+	if !json.Valid(rec.TargetContext) {
+		return rec, time.Time{}, fmt.Errorf("dead letter target context must be valid json")
+	}
+	if rec.RetryCount < 0 {
+		rec.RetryCount = 0
+	}
+	if rec.ChainDepth < 0 {
+		rec.ChainDepth = 0
+	}
+	createdAt := time.Now().UTC()
+	if s != nil {
+		createdAt = s.now()
+	}
+	if rec.Timestamp != "" {
+		parsed, err := time.Parse(time.RFC3339Nano, rec.Timestamp)
+		if err != nil {
+			return rec, time.Time{}, fmt.Errorf("dead letter timestamp must be RFC3339Nano: %w", err)
+		}
+		createdAt = parsed.UTC()
+	}
+	return rec, createdAt, nil
 }

--- a/internal/store/event_mutation.go
+++ b/internal/store/event_mutation.go
@@ -7,9 +7,14 @@ import (
 
 	"github.com/division-sh/swarm/internal/events"
 	runtimebus "github.com/division-sh/swarm/internal/runtime/bus"
+	runtimedeadletters "github.com/division-sh/swarm/internal/runtime/deadletters"
 	runtimepipeline "github.com/division-sh/swarm/internal/runtime/pipeline"
 	runtimereplayclaim "github.com/division-sh/swarm/internal/runtime/replayclaim"
 )
+
+type eventMutationDeadLetterTxRecorder interface {
+	RecordDeadLetterTx(context.Context, *sql.Tx, runtimedeadletters.Record) error
+}
 
 type sqlEventMutation struct {
 	ctx     context.Context
@@ -92,6 +97,17 @@ func (m *sqlEventMutation) UpsertPipelineReceipt(ctx context.Context, eventID, s
 		return fmt.Errorf("event mutation store is required")
 	}
 	return m.txStore.UpsertPipelineReceiptTx(m.operationContext(ctx), m.tx, eventID, status, errText)
+}
+
+func (m *sqlEventMutation) RecordDeadLetter(ctx context.Context, rec runtimedeadletters.Record) error {
+	if m == nil {
+		return nil
+	}
+	recorder, ok := m.store.(eventMutationDeadLetterTxRecorder)
+	if !ok || recorder == nil {
+		return nil
+	}
+	return recorder.RecordDeadLetterTx(m.operationContext(ctx), m.tx, rec)
 }
 
 func (s *SQLiteRuntimeStore) RunEventMutation(ctx context.Context, fn func(runtimebus.EventMutation) error) error {

--- a/internal/store/event_mutation.go
+++ b/internal/store/event_mutation.go
@@ -101,11 +101,11 @@ func (m *sqlEventMutation) UpsertPipelineReceipt(ctx context.Context, eventID, s
 
 func (m *sqlEventMutation) RecordDeadLetter(ctx context.Context, rec runtimedeadletters.Record) error {
 	if m == nil {
-		return nil
+		return fmt.Errorf("event mutation store is required")
 	}
 	recorder, ok := m.store.(eventMutationDeadLetterTxRecorder)
 	if !ok || recorder == nil {
-		return nil
+		return fmt.Errorf("event mutation store %T does not support dead letters", m.store)
 	}
 	return recorder.RecordDeadLetterTx(m.operationContext(ctx), m.tx, rec)
 }

--- a/internal/store/mailbox_v1.go
+++ b/internal/store/mailbox_v1.go
@@ -90,7 +90,7 @@ type MailboxV1DecisionRequest struct {
 	ApprovalEventType             string
 	ApprovalEventSubscribers      []string
 	ApprovalEventSubscriberSource string
-	ApprovalEventTx               func(context.Context, *sql.Tx, events.Event) error
+	ApprovalEventPublish          func(context.Context, events.Event) error
 	Idempotency                   *APIIdempotencyRequest
 }
 
@@ -273,7 +273,8 @@ func (s *PostgresStore) DecideV1MailboxItem(ctx context.Context, input MailboxV1
 		return MailboxV1DecisionOutcome{}, fmt.Errorf("begin v1 mailbox decision tx: %w", err)
 	}
 	postCommitActions := make([]func(), 0, 4)
-	txctx := runtimepipeline.WithPipelinePostCommitActions(ctx, &postCommitActions)
+	txctx := runtimepipeline.WithPipelineSQLTxContext(ctx, tx)
+	txctx = runtimepipeline.WithPipelinePostCommitActions(txctx, &postCommitActions)
 	committed := false
 	defer func() {
 		if !committed {
@@ -286,13 +287,13 @@ func (s *PostgresStore) DecideV1MailboxItem(ctx context.Context, input MailboxV1
 		return MailboxV1DecisionOutcome{}, err
 	}
 	if hasIdempotency {
-		if _, err := tx.ExecContext(ctx, `SELECT pg_advisory_xact_lock(hashtext($1))`, apiIdempotencyLockKey(idempotencyReq.Method, idempotencyReq.ActorTokenID, idempotencyReq.IdempotencyKey)); err != nil {
+		if _, err := tx.ExecContext(txctx, `SELECT pg_advisory_xact_lock(hashtext($1))`, apiIdempotencyLockKey(idempotencyReq.Method, idempotencyReq.ActorTokenID, idempotencyReq.IdempotencyKey)); err != nil {
 			return MailboxV1DecisionOutcome{}, fmt.Errorf("lock api idempotency key: %w", err)
 		}
-		if err := purgeExpiredAPIIdempotency(ctx, tx, idempotencyReq.Now); err != nil {
+		if err := purgeExpiredAPIIdempotency(txctx, tx, idempotencyReq.Now); err != nil {
 			return MailboxV1DecisionOutcome{}, err
 		}
-		existing, ok, err := loadAPIIdempotency(ctx, tx, idempotencyReq)
+		existing, ok, err := loadAPIIdempotency(txctx, tx, idempotencyReq)
 		if err != nil {
 			return MailboxV1DecisionOutcome{}, err
 		}
@@ -309,7 +310,7 @@ func (s *PostgresStore) DecideV1MailboxItem(ctx context.Context, input MailboxV1
 			if err := json.Unmarshal(existing.Response, &result); err != nil {
 				return MailboxV1DecisionOutcome{}, fmt.Errorf("decode api idempotency mailbox response: %w", err)
 			}
-			if err := normalizeMailboxV1DecisionReplayResult(ctx, tx, &result); err != nil {
+			if err := normalizeMailboxV1DecisionReplayResult(txctx, tx, &result); err != nil {
 				return MailboxV1DecisionOutcome{}, err
 			}
 			if err := tx.Commit(); err != nil {
@@ -323,7 +324,7 @@ func (s *PostgresStore) DecideV1MailboxItem(ctx context.Context, input MailboxV1
 		return MailboxV1DecisionOutcome{}, &MailboxV1InvalidDeferUntilError{Reason: "in_past"}
 	}
 
-	row, err := s.loadMailboxV1RowTx(ctx, tx, input.MailboxID, true)
+	row, err := s.loadMailboxV1RowTx(txctx, tx, input.MailboxID, true)
 	if err != nil {
 		return MailboxV1DecisionOutcome{}, err
 	}
@@ -374,7 +375,7 @@ func (s *PostgresStore) DecideV1MailboxItem(ctx context.Context, input MailboxV1
 		outcome.Result.DownstreamSubscriberSource = subscriberSource
 		outcome.ApprovalEvent = &evt
 	}
-	res, err := tx.ExecContext(ctx, `
+	res, err := tx.ExecContext(txctx, `
 		UPDATE mailbox
 		SET status = 'decided',
 		    decision = $2,
@@ -389,7 +390,7 @@ func (s *PostgresStore) DecideV1MailboxItem(ctx context.Context, input MailboxV1
 		return MailboxV1DecisionOutcome{}, fmt.Errorf("decide v1 mailbox item: %w", err)
 	}
 	if rows, _ := res.RowsAffected(); rows == 0 {
-		latest, latestErr := s.loadMailboxV1RowTx(ctx, tx, row.ID, false)
+		latest, latestErr := s.loadMailboxV1RowTx(txctx, tx, row.ID, false)
 		if latestErr != nil {
 			return MailboxV1DecisionOutcome{}, latestErr
 		}
@@ -400,11 +401,13 @@ func (s *PostgresStore) DecideV1MailboxItem(ctx context.Context, input MailboxV1
 		}
 	}
 	if outcome.ApprovalEvent != nil {
-		publishTx := input.ApprovalEventTx
-		if publishTx == nil {
-			publishTx = s.appendMailboxV1ApprovalEventTx
+		publish := input.ApprovalEventPublish
+		if publish == nil {
+			publish = func(ctx context.Context, evt events.Event) error {
+				return s.appendMailboxV1ApprovalEventTx(ctx, tx, evt)
+			}
 		}
-		if err := publishTx(txctx, tx, *outcome.ApprovalEvent); err != nil {
+		if err := publish(txctx, *outcome.ApprovalEvent); err != nil {
 			return MailboxV1DecisionOutcome{}, fmt.Errorf("publish v1 mailbox approval event: %w", err)
 		}
 	}
@@ -413,7 +416,7 @@ func (s *PostgresStore) DecideV1MailboxItem(ctx context.Context, input MailboxV1
 		if err != nil {
 			return MailboxV1DecisionOutcome{}, err
 		}
-		if err := storeAPIIdempotency(ctx, tx, idempotencyReq, APIIdempotencyCompletion{
+		if err := storeAPIIdempotency(txctx, tx, idempotencyReq, APIIdempotencyCompletion{
 			ResourceID: row.ID,
 			Response:   raw,
 		}); err != nil {

--- a/internal/store/runtime_mutation_guard_test.go
+++ b/internal/store/runtime_mutation_guard_test.go
@@ -268,8 +268,26 @@ func TestSelectedSQLiteRuntimeConstructionConsumesMutationBoundary(t *testing.T)
 	if err != nil {
 		t.Fatalf("read internal/runtime/bus/eventbus_publish.go: %v", err)
 	}
-	if !strings.Contains(string(publishData), ".RunEventMutation(ctx,") {
+	publishText := string(publishData)
+	if !strings.Contains(publishText, ".RunEventMutation(ctx,") {
 		t.Fatal("event publish must consume EventMutationRunner.RunEventMutation when available")
+	}
+	if strings.Contains(publishText, "PublishTx") {
+		t.Fatal("event publish must not expose a producer-facing PublishTx raw transaction hook")
+	}
+
+	operatorMailboxData, err := os.ReadFile(filepath.Join(root, "internal", "apiv1", "operator_mailbox.go"))
+	if err != nil {
+		t.Fatalf("read internal/apiv1/operator_mailbox.go: %v", err)
+	}
+	operatorMailboxText := string(operatorMailboxData)
+	for _, forbidden := range []string{"TransactionalEventPublisher", "ApprovalEventTx", "*sql.Tx"} {
+		if strings.Contains(operatorMailboxText, forbidden) {
+			t.Fatalf("operator mailbox approval publish must consume typed event mutation API, found %s", forbidden)
+		}
+	}
+	if !strings.Contains(operatorMailboxText, "PublishInMutation") {
+		t.Fatal("operator mailbox approval publish must consume EventBus.PublishInMutation")
 	}
 
 	pipelineData, err := os.ReadFile(filepath.Join(root, "internal", "runtime", "pipeline", "workflow_instance_store.go"))

--- a/internal/store/sqlite_mailbox_v1.go
+++ b/internal/store/sqlite_mailbox_v1.go
@@ -252,11 +252,13 @@ func (s *SQLiteRuntimeStore) DecideV1MailboxItem(ctx context.Context, input Mail
 			}
 		}
 		if outcome.ApprovalEvent != nil {
-			publishTx := input.ApprovalEventTx
-			if publishTx == nil {
-				publishTx = s.appendSQLiteMailboxV1ApprovalEventTx
+			publish := input.ApprovalEventPublish
+			if publish == nil {
+				publish = func(ctx context.Context, evt events.Event) error {
+					return s.appendSQLiteMailboxV1ApprovalEventTx(ctx, tx, evt)
+				}
 			}
-			if err := publishTx(txctx, tx, *outcome.ApprovalEvent); err != nil {
+			if err := publish(txctx, *outcome.ApprovalEvent); err != nil {
 				return fmt.Errorf("publish sqlite v1 mailbox approval event: %w", err)
 			}
 		}

--- a/internal/store/sqlite_runtime_test.go
+++ b/internal/store/sqlite_runtime_test.go
@@ -789,7 +789,7 @@ func TestSQLiteRuntimeStoreAppendEventTxEnsuresFreshRunRow(t *testing.T) {
 	assertSQLiteRuntimeCount(t, store, `SELECT COUNT(*) FROM events WHERE event_id = ?`, 1, eventID)
 }
 
-func TestSQLiteRuntimeStoreRuntimeIngressReadDuringPublishTxDoesNotReenterWrite(t *testing.T) {
+func TestSQLiteRuntimeStoreRuntimeIngressReadDuringPublishDoesNotReenterWrite(t *testing.T) {
 	ctx := context.Background()
 	store := newBootstrappedSQLiteRuntimeStoreForTest(t)
 	runID := uuid.NewString()

--- a/internal/store/store_abstraction_guard_matrix_test.go
+++ b/internal/store/store_abstraction_guard_matrix_test.go
@@ -98,21 +98,22 @@ func TestSelectedStoreAbstractionGuardMatrixRejectsStaleProofRefs(t *testing.T) 
 			want: "producer_backend_branching_guard classification = \"matrix_owner\", want \"guard\"",
 		},
 		{
-			name: "split row classification is pinned",
+			name: "typed uow guard classification is pinned closed",
 			mutate: func(matrix *selectedStoreAbstractionGuardMatrix) {
-				row := selectedStoreAbstractionRowByID(t, matrix, "mutation_uow_behavior_split")
-				row.Classification = "guard"
-				row.Tier = "required_smoke"
+				row := selectedStoreAbstractionRowByID(t, matrix, "typed_runtime_mutation_uow_guard")
+				row.Classification = "split_to_existing_issue"
+				row.Tier = "split_open"
+				row.SplitIssues = []int{1403}
 			},
-			want: "mutation_uow_behavior_split classification = \"guard\", want \"split_to_existing_issue\"",
+			want: "typed_runtime_mutation_uow_guard classification = \"split_to_existing_issue\", want \"guard\"",
 		},
 		{
-			name: "split row issue set is pinned",
+			name: "typed uow guard split issue set is pinned closed",
 			mutate: func(matrix *selectedStoreAbstractionGuardMatrix) {
-				row := selectedStoreAbstractionRowByID(t, matrix, "mutation_uow_behavior_split")
-				row.SplitIssues = nil
+				row := selectedStoreAbstractionRowByID(t, matrix, "typed_runtime_mutation_uow_guard")
+				row.SplitIssues = []int{1403}
 			},
-			want: "mutation_uow_behavior_split split_issues = [], want [1403]",
+			want: "typed_runtime_mutation_uow_guard split_issues = [1403], want []",
 		},
 		{
 			name: "public idempotency row is required",
@@ -284,7 +285,6 @@ func expectedSelectedStoreAbstractionRowShapes() map[string]selectedStoreAbstrac
 		"raw_selected_runtime_writer_boundary_guard": {
 			Classification:         "guard",
 			Tier:                   "required_smoke",
-			SplitIssues:            []int{1403},
 			RequiresGuardProofRefs: true,
 		},
 		"sqlite_runtime_sqldb_omission_guard": {
@@ -313,10 +313,10 @@ func expectedSelectedStoreAbstractionRowShapes() map[string]selectedStoreAbstrac
 			Classification: "public_surface_accounting",
 			Tier:           "required_smoke",
 		},
-		"mutation_uow_behavior_split": {
-			Classification: "split_to_existing_issue",
-			Tier:           "split_open",
-			SplitIssues:    []int{1403},
+		"typed_runtime_mutation_uow_guard": {
+			Classification:         "guard",
+			Tier:                   "required_smoke",
+			RequiresGuardProofRefs: true,
 		},
 		"sqlite_busy_serialization_behavior_guard": {
 			Classification:         "guard",
@@ -494,7 +494,7 @@ func requiredSelectedStoreAbstractionRows() map[string]struct{} {
 		"explicit_postgres_required_smoke",
 		"api_idempotency_public_surface_accounting",
 		"runtime_log_readback_public_surface_accounting",
-		"mutation_uow_behavior_split",
+		"typed_runtime_mutation_uow_guard",
 		"sqlite_busy_serialization_behavior_guard",
 	})
 }

--- a/internal/store/testdata/selected_store_abstraction_guard_matrix.yaml
+++ b/internal/store/testdata/selected_store_abstraction_guard_matrix.yaml
@@ -76,12 +76,11 @@ rows:
         name: TestRuntimeWriterBoundaryGuardRejectsPipelineSQLiteDBHelperBypassFixture
       - kind: go_test
         name: TestRuntimeWriterBoundaryGuardRejectsPipelineSQLiteRawDBHelperFixture
-    split_issues: [1403]
     notes: >
-      This row guards the boundary. #1414 promotes the first typed event/pipeline
-      mutation UoW entrypoint slice; the broader row-family typed UoW migration
-      remains #1403. SQLite busy/serialization policy is guarded by the #1405 row
-      in this matrix.
+      This row guards the raw writer boundary. #1403 owns the typed selected-runtime
+      row-family mutation UoW closure; backend-local SQL helpers may remain only
+      below store implementations. SQLite busy/serialization policy is guarded by
+      the #1405 row in this matrix.
 
   - id: sqlite_runtime_sqldb_omission_guard
     classification: guard
@@ -219,22 +218,43 @@ rows:
       First-class #1402 row required by gate. Dashboard SQL readers remain
       adjacent read-model consumers and do not own selected runtime persistence.
 
-  - id: mutation_uow_behavior_split
-    classification: split_to_existing_issue
-    tier: split_open
+  - id: typed_runtime_mutation_uow_guard
+    classification: guard
+    tier: required_smoke
     concepts:
       - typed backend-neutral runtime mutation unit of work
     owners:
       - backend_neutral_runtime_mutation_write_boundary
-      - '#1414 typed event/pipeline producer-visible unit-of-work entrypoints'
-      - 'remaining #1403 typed unit-of-work row-family owner'
-    split_issues: [1403]
+      - runtimebus.EventMutationRunner/EventMutation
+      - EventBus.PublishInMutation
+      - runtimepipeline.Store.RunPipelineMutation
+      - SQLiteRuntimeStore.RunRuntimeMutation
+      - PostgresStore normal transaction methods
     proof_refs:
       - kind: artifact
         path: platform-spec.yaml
+      - kind: go_test
+        name: TestEventBusPublishInMutationRunsInterceptorsAfterMutationCommit
+      - kind: go_test
+        name: TestEventBusPublishTransactional_RecordsTargetFailureDeadLetter
+      - kind: go_test
+        name: TestSQLiteWorkflowInstanceStore_RunPipelineMutationUsesRuntimeMutationRunner
+      - kind: go_test
+        name: TestPostgresStore_RunEventTransactionDoesNotSerializeCallbacks
+      - kind: go_test
+        name: TestSelectedSQLiteRuntimeWriterBoundaryAudit
+    guard_proof_refs:
+      - kind: go_test
+        name: TestSelectedSQLiteRuntimeWriterBoundaryAudit
+      - kind: go_test
+        name: TestSelectedSQLiteRuntimeConstructionConsumesMutationBoundary
+      - kind: go_test
+        name: TestEventBusPublishInMutationRunsInterceptorsAfterMutationCommit
     notes: >
-      #1414 closes the producer-visible event/pipeline raw callback entrypoint
-      slice. Full production mutation behavior migration remains #1403.
+      #1414 closed the first event/pipeline callback slice. #1403 closes the
+      remaining selected runtime row-family typed UoW accounting: producers
+      consume typed mutation owners, while raw *Tx helpers remain backend-local
+      implementation detail below store boundaries.
 
   - id: sqlite_busy_serialization_behavior_guard
     classification: guard

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -650,7 +650,7 @@ contract_formats:
           split_owner: '#1345 owns the public/operator readback projection for delivery_id, subscriber_type, and subscriber_id; route-target public exposure remains split.'
         split_children:
           runtime_model: '#1343 owns the canonical internal EventBus RoutePlan model.'
-          publish_consumers: '#1344 owns Publish, PublishTx, deferred/outbox publish, and CheckPublishRecipientPlan consumption of one RoutePlan authority.'
+          publish_consumers: '#1344 owns Publish, PublishInMutation, deferred/outbox publish, and CheckPublishRecipientPlan consumption of one RoutePlan authority.'
           readback: '#1345 owns API/CLI/OpenRPC/readback consumption and any public subscriber_type exposure.'
           conformance: '#1346 owns the route-authority proof matrix.'
           execution_admission: '#1293 owns workflow-node execution admission against committed delivery authority.'
@@ -2603,16 +2603,21 @@ engine:
         - selected DB ping
         rule: These raw database consumers are adjacent process/workspace capabilities, not selected runtime persistence authority. They must stay named and must not be reused as runtime store fallbacks.
       - name: selected_runtime_mutation_unit_of_work
-        owner: backend_neutral_runtime_mutation_write_boundary plus typed producer-visible unit-of-work entrypoints under '#1414'
+        owner: backend_neutral_runtime_mutation_write_boundary plus typed selected-runtime row-family unit-of-work entrypoints under '#1403'
+        promoted_by: '#1403'
         promoted_first_slice_by: '#1414'
         typed_entrypoint_owners:
-        - runtimebus.EventMutationRunner and runtimebus.EventMutation for selected event publish/outbox atomic mutation groups
+        - runtimebus.EventMutationRunner and runtimebus.EventMutation for selected event publish, PublishInMutation, mailbox approval publish, and outbox atomic mutation groups
         - runtimepipeline.Store.RunPipelineMutation for selected workflow pipeline mutation groups
+        - internal/store.SQLiteRuntimeStore.RunRuntimeMutation for selected SQLite runtime row-family mutations
+        - internal/store.PostgresStore normal transaction methods for selected Postgres runtime row-family mutations
         rule: >
-          Mutation writers must consume a semantic mutation owner. Event publish/outbox and workflow pipeline producers
-          must not construct raw `func(context.Context, *sql.Tx) error` callbacks as their selected-runtime mutation
-          authority. Backend-specific SQL transaction mechanics may remain inside store implementations. SQLite
-          serialization/retry policy is owned below the store boundary and remains split to #1405.
+          Mutation writers must consume a semantic mutation owner. Event publish/outbox, mailbox approval publication,
+          workflow pipeline producers, and selected runtime row-family producers must not construct raw
+          `func(context.Context, *sql.Tx) error` callbacks, pass raw `*sql.Tx`, or branch on SQLite/Postgres transaction
+          mechanics as their selected-runtime mutation authority. Backend-specific SQL transaction mechanics may remain
+          inside store implementations and backend-local `*Tx` helpers. SQLite serialization/retry policy is owned below
+          the store boundary and remains guarded by #1405.
       raw_sql_policy:
         allowed:
         - boundary: backend selection, store construction, schema/bootstrap, and backend-specific store implementations
@@ -2644,8 +2649,8 @@ engine:
         classification: producer-facing raw/concrete escapes to classify and migrate under #1401/#1402 unless independently gated
       - dependency: selected-contract run.fork PostgresStore internals
         classification: optional product capability with current concrete escape; migrate under #1401/#1403 or a run-fork child
-      - dependency: RunRuntimeMutation, RunEventTransaction, RunInPipelineTransaction, and direct transaction helpers
-        classification: mutation/unit-of-work sibling class under #1403/#1405
+      - dependency: RunRuntimeMutation, RunEventMutation, RunPipelineMutation, and backend-local direct transaction helpers
+        classification: mutation/unit-of-work owner class under #1403/#1405; producers consume the typed entrypoints while raw helpers stay below store implementations
       - dependency: route planning, event admission/defaulting, delivery authority, startup readiness
         classification: different semantic concepts; explicitly split unless a later gate widens
       rules:
@@ -2856,7 +2861,7 @@ engine:
         SQLite startup ownership prevents competing runtimes inside the local process boundary. It is not a production
         multi-writer lock substitute.
     - name: event_delivery_receipt_and_replay_rows
-      owner: runtimebus.EventStore, runtimebus.TransactionalEventStore, runtimemanager.ManagerPersistence, and runtimereplayclaim committed replay contracts
+      owner: runtimebus.EventStore, runtimebus.EventMutationRunner/EventMutation, backend store implementations, runtimemanager.ManagerPersistence, and runtimereplayclaim committed replay contracts
       sqlite_owner: internal/store.SQLiteRuntimeStore delivery, receipt, pipeline receipt, committed replay scope, and replay-claim methods
       postgres_owner: internal/store.PostgresStore delivery, receipt, pipeline receipt, committed replay scope, and replay-claim methods
       scope: >


### PR DESCRIPTION
Closes #1403
Part of #1400
Related to #1239

## Summary

- Removes the producer-facing raw event transaction publish hook by replacing `EventBus.PublishTx` / API mailbox `TransactionalEventPublisher` use with typed `PublishInMutation` over `EventMutation`.
- Extends the typed event mutation owner to cover target-failure dead-letter persistence for publish/outbox mutation paths.
- Converts the selected-store guard matrix from an open #1403 split to a closed typed runtime mutation UoW guard, and updates `platform-spec.yaml` to make #1403 the selected row-family UoW owner.
- Removes a timing-sensitive in-memory SQLite fan-out test concurrency pattern that was causing package-level timeout flakes while preserving the delivery/no-dead-letter proof.

## Governing Context

Binding refs:

- `platform-spec.yaml` `runtime_core_persistence_store_contracts`
- `platform-spec.yaml` `selected_runtime_store_facade`
- `platform-spec.yaml` `selected_runtime_mutation_unit_of_work`
- `platform-spec.yaml` `backend_neutral_runtime_mutation_write_boundary`
- `platform-spec.yaml` `pipeline_coordination_workflow_instance_and_replay_rows`
- `platform-spec.yaml` `raw_sql_runtime_consumer_boundary_for_sqlite`
- #1403 gate outcome: `approved as broad refactor` for `selected_runtime_row_family_typed_uow_full_closure`
- Process docs: `docs/IMPLEMENTER_GUIDELINES.md`, `docs/SEMANTIC_DRIFT.md`

## Semantic Migration

New canonical owner:

- `selected_runtime_mutation_unit_of_work`, implemented through `runtimebus.EventMutationRunner/EventMutation`, `EventBus.PublishInMutation`, `runtimepipeline.Store.RunPipelineMutation`, `SQLiteRuntimeStore.RunRuntimeMutation`, and Postgres normal store transactions.

Old producer/writer paths now invalid or non-authoritative:

- `EventBus.PublishTx` producer-facing raw `*sql.Tx` publish hook is removed.
- API mailbox approval no longer accepts `TransactionalEventPublisher` / `ApprovalEventTx`; it requires typed `PublishInMutation`.
- `TransactionalEventStore` remains backend-local below `EventMutation`; it is not producer-facing selected runtime mutation authority.
- Backend-local `*Tx` helpers remain implementation detail below store boundaries.

Production paths checked for surviving old behavior:

- Event publish and acknowledged publish.
- Engine outbox writes and post-commit dispatch.
- Mailbox approval/decision publication.
- Workflow pipeline mutation entrypoints.
- Store guard matrix rows for selected runtime mutation row families.
- Default SQLite and explicit Postgres served paths.

Migration completeness:

- Complete for #1403. #1400 remains open for final backend-neutral store abstraction closure. Route planning, event admission/defaulting, delivery authority, startup readiness, schema/bootstrap, catalog/reset/preservation cleanup, optional run.fork internals, and broad #1239 parity remain out of this gate.

## Proof

- `go test ./...`
- `go test ./cmd/swarm -run 'TestRunCommandLocalForegroundConsumesServeOwnerAndV1API|TestRunServeRuntimeEventPublishRunIDFollowUpServedPathDefaultSQLite|TestRunServeRuntimeEventPublishRunIDFollowUpServedPathPostgres|TestRunServeRuntimeConsumesCanonicalStoreSelectionBeforeStoreConstruction|TestRunServeRuntimeFreshEmptyPostgresBootstrapsSchemaBeforeDiskContractsServe' -count=1`
- `go test ./internal/store ./internal/runtime/bus ./internal/runtime/pipeline -run 'TestSelectedSQLiteRuntimeWriterBoundaryAudit|TestSelectedSQLiteRuntimeConstructionConsumesMutationBoundary|TestSelectedStoreAbstractionGuardMatrixCoversApprovedBoundary|TestSelectedStoreAbstractionGuardMatrixRejectsStaleProofRefs|TestSQLiteRuntimeStore_RunRuntimeMutation(RetriesBusyAndFlushesPostCommitOnce|StopsRetryOnContextDeadline|ContextDeadlineCapsDriverBusyTimeout|DoesNotRetryActiveTransaction)|TestPostgresStore_RunEventTransactionDoesNotSerializeCallbacks|TestEventBusPublishInMutationRunsInterceptorsAfterMutationCommit|TestEventBusPublishTransactional_RecordsTargetFailureDeadLetter|TestSQLiteWorkflowInstanceStore_RunPipelineMutation(RequiresRuntimeMutationRunner|UsesRuntimeMutationRunner|DoesNotRetryActiveTransaction)|TestWorkflowInstanceStore_RunPipelineMutationDoesNotRetryPostgresDialect|TestSQLiteFanOutCreateFlowInstanceDeliveriesPersistWithoutDeadLetter' -count=1`

