### PR TITLE
[agent-c][issue #1409] Active flow targets

### DIFF
--- a/internal/runtime/bus/delivery_planner.go
+++ b/internal/runtime/bus/delivery_planner.go
@@ -64,7 +64,8 @@ type deliveryRecipientManifest struct {
 }
 
 type deliveryRecipientPolicy struct {
-	loadActiveAgentDescriptors func(context.Context) (map[string]ActiveAgentDescriptor, bool, error)
+	loadActiveAgentDescriptors  func(context.Context) (map[string]ActiveAgentDescriptor, bool, error)
+	loadActiveTargetDescriptors func(context.Context) ([]ActiveTargetDescriptor, bool, error)
 }
 
 func (p deliveryRecipientPolicy) Evaluate(ctx context.Context, evt events.Event, recipients []deliveryRecipientCandidate) (deliveryRecipientManifest, error) {
@@ -72,15 +73,31 @@ func (p deliveryRecipientPolicy) Evaluate(ctx context.Context, evt events.Event,
 	if err != nil {
 		return deliveryRecipientManifest{}, err
 	}
+	targetDescriptors := activeTargetDescriptorsFromAgents(descriptors)
+	targetDescriptorsOK := ok || len(targetDescriptors) > 0
+	if p.loadActiveTargetDescriptors != nil {
+		loaded, loadedOK, err := p.loadActiveTargetDescriptors(ctx)
+		if err != nil {
+			return deliveryRecipientManifest{}, err
+		}
+		if loadedOK {
+			targetDescriptors = loaded
+			targetDescriptorsOK = true
+		}
+	}
 	if !ok {
-		return deliveryRecipientManifest{
+		manifest := deliveryRecipientManifest{
 			Recipients:          deliveryRecipientIDs(recipients),
 			PersistedRecipients: persistedDeliveryRecipientIDs(recipients),
 			DeliveryTargets:     deliveryTargetsForManifest(evt, persistedDeliveryRecipientIDs(recipients), nil),
 			DeliveryRoutes:      agentDeliveryRoutesForRecipients(persistedDeliveryRecipientIDs(recipients), deliveryTargetsForManifest(evt, persistedDeliveryRecipientIDs(recipients), nil)),
-		}, nil
+		}
+		if targetDescriptorsOK && len(eventDeliveryTargetRoutes(evt)) > 0 && len(manifest.Recipients) == 0 {
+			manifest.TargetFailure = targetDeliveryFailure(evt, targetDescriptors)
+		}
+		return manifest, nil
 	}
-	return filterDeliveryRecipientCandidates(evt, recipients, descriptors), nil
+	return filterDeliveryRecipientCandidates(evt, recipients, descriptors, targetDescriptors), nil
 }
 
 type deliveryPlanner struct {
@@ -175,7 +192,8 @@ func (eb *EventBus) newEventBusDeliveryPlanner() deliveryPlanner {
 			describeSubscribersForEvent:         eb.describeSubscribersForEvent,
 		},
 		deliveryRecipientPolicy{
-			loadActiveAgentDescriptors: eb.activeAgentDescriptors,
+			loadActiveAgentDescriptors:  eb.activeAgentDescriptors,
+			loadActiveTargetDescriptors: eb.activeTargetDescriptors,
 		},
 	)
 }
@@ -312,13 +330,13 @@ func persistedDeliveryRecipientIDs(in []deliveryRecipientCandidate) []string {
 	return uniqueStrings(out)
 }
 
-func filterDeliveryRecipientCandidates(evt events.Event, recipients []deliveryRecipientCandidate, descriptors map[string]ActiveAgentDescriptor) deliveryRecipientManifest {
+func filterDeliveryRecipientCandidates(evt events.Event, recipients []deliveryRecipientCandidate, descriptors map[string]ActiveAgentDescriptor, targetDescriptors []ActiveTargetDescriptor) deliveryRecipientManifest {
 	recipients = normalizeDeliveryRecipientCandidates(recipients)
 	eventEntityID := strings.TrimSpace(evt.EntityID())
 	targets := eventDeliveryTargetRoutes(evt)
 	if len(recipients) == 0 {
 		return deliveryRecipientManifest{
-			TargetFailure: targetDeliveryFailure(evt, descriptors),
+			TargetFailure: targetDeliveryFailure(evt, targetDescriptors),
 		}
 	}
 	singularTarget := evt.TargetRoute()
@@ -365,7 +383,7 @@ func filterDeliveryRecipientCandidates(evt events.Event, recipients []deliveryRe
 		DeliveryRoutes:      events.NormalizeDeliveryRoutes(deliveryRoutes),
 	}
 	if len(targets) > 0 && len(manifest.Recipients) == 0 {
-		manifest.TargetFailure = targetDeliveryFailure(evt, descriptors)
+		manifest.TargetFailure = targetDeliveryFailure(evt, targetDescriptors)
 	}
 	return manifest
 }
@@ -932,7 +950,7 @@ func routeMatchesInternalSubscriber(route events.RouteIdentity, subscriber Subsc
 	return route.FlowInstance != "" && route.FlowInstance == path
 }
 
-func targetDeliveryFailure(evt events.Event, descriptors map[string]ActiveAgentDescriptor) runtimepinrouting.TargetFailure {
+func targetDeliveryFailure(evt events.Event, descriptors []ActiveTargetDescriptor) runtimepinrouting.TargetFailure {
 	targets := eventDeliveryTargetRoutes(evt)
 	if len(targets) == 0 {
 		return ""
@@ -950,7 +968,7 @@ func eventDeliveryTargetRoutes(evt events.Event) []events.RouteIdentity {
 	return evt.TargetRoutes()
 }
 
-func allTargetsHaveLiveDescriptor(targets []events.RouteIdentity, descriptors map[string]ActiveAgentDescriptor) bool {
+func allTargetsHaveLiveDescriptor(targets []events.RouteIdentity, descriptors []ActiveTargetDescriptor) bool {
 	if len(targets) == 0 {
 		return true
 	}
@@ -960,7 +978,7 @@ func allTargetsHaveLiveDescriptor(targets []events.RouteIdentity, descriptors ma
 	for _, target := range targets {
 		found := false
 		for _, descriptor := range descriptors {
-			if routeMatchesDescriptor(target, descriptor) {
+			if routeMatchesTargetDescriptor(target, descriptor) {
 				found = true
 				break
 			}
@@ -975,29 +993,43 @@ func allTargetsHaveLiveDescriptor(targets []events.RouteIdentity, descriptors ma
 func deliveryTargetForDescriptor(descriptor ActiveAgentDescriptor, singular events.RouteIdentity, targets []events.RouteIdentity) (events.RouteIdentity, bool) {
 	descriptor = descriptor.Normalized()
 	if !singular.Empty() {
-		return singular, routeMatchesDescriptor(singular, descriptor)
+		return singular, routeMatchesAgentDescriptor(singular, descriptor)
 	}
 	if len(targets) == 0 {
 		return events.RouteIdentity{}, true
 	}
 	for _, target := range targets {
-		if routeMatchesDescriptor(target, descriptor) {
+		if routeMatchesAgentDescriptor(target, descriptor) {
 			return target.Normalized(), true
 		}
 	}
 	return events.RouteIdentity{}, false
 }
 
-func routeMatchesDescriptor(route events.RouteIdentity, descriptor ActiveAgentDescriptor) bool {
+func routeMatchesAgentDescriptor(route events.RouteIdentity, descriptor ActiveAgentDescriptor) bool {
+	return routeMatchesTargetDescriptor(route, descriptor.TargetDescriptor())
+}
+
+func routeMatchesTargetDescriptor(route events.RouteIdentity, descriptor ActiveTargetDescriptor) bool {
 	route = route.Normalized()
 	descriptor = descriptor.Normalized()
-	if route.EntityID != "" && descriptor.EntityID != "" && route.EntityID != descriptor.EntityID {
+	if descriptor.EntityID == "" && descriptor.FlowInstance == "" {
 		return false
 	}
-	if route.FlowInstance != "" && descriptor.FlowInstance != "" && route.FlowInstance != descriptor.FlowInstance {
-		return false
+	matched := false
+	if route.EntityID != "" {
+		if descriptor.EntityID != route.EntityID {
+			return false
+		}
+		matched = true
 	}
-	return route.EntityID != "" || route.FlowInstance != ""
+	if route.FlowInstance != "" {
+		if descriptor.FlowInstance != route.FlowInstance {
+			return false
+		}
+		matched = true
+	}
+	return matched
 }
 
 func deliveryTargetsForManifest(evt events.Event, recipients []string, existing map[string]events.RouteIdentity) map[string]events.RouteIdentity {

--- a/internal/runtime/bus/delivery_planner_test.go
+++ b/internal/runtime/bus/delivery_planner_test.go
@@ -162,6 +162,63 @@ func TestDeliveryRecipientPolicy_TargetedEventFailsWhenTargetDoesNotSubscribe(t 
 	}
 }
 
+func TestDeliveryRecipientPolicy_TargetedFlowInstanceWithoutSubscriberIsNotSubscribed(t *testing.T) {
+	policy := deliveryRecipientPolicy{
+		loadActiveAgentDescriptors: func(context.Context) (map[string]ActiveAgentDescriptor, bool, error) {
+			return map[string]ActiveAgentDescriptor{}, true, nil
+		},
+		loadActiveTargetDescriptors: func(context.Context) ([]ActiveTargetDescriptor, bool, error) {
+			return []ActiveTargetDescriptor{{
+				FlowInstance: "component-scaffold/aaaaaaaa-1111-4111-8111-aaaaaaaa1111",
+			}}, true, nil
+		},
+	}
+	target := ActiveTargetDescriptor{FlowInstance: "component-scaffold/aaaaaaaa-1111-4111-8111-aaaaaaaa1111"}.Normalized()
+
+	manifest, err := policy.Evaluate(
+		context.Background(),
+		(events.NewProjectionEvent("", "component.service.completed", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{})).WithTargetRoute(events.RouteIdentity{
+			EntityID:     target.EntityID,
+			FlowInstance: target.FlowInstance,
+		}),
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("Evaluate: %v", err)
+	}
+	if manifest.TargetFailure != runtimepinrouting.FailureTargetNotSubscribed {
+		t.Fatalf("target failure = %q, want %q", manifest.TargetFailure, runtimepinrouting.FailureTargetNotSubscribed)
+	}
+}
+
+func TestDeliveryRecipientPolicy_TargetedFlowInstanceMissingIsUnreachableTerminated(t *testing.T) {
+	policy := deliveryRecipientPolicy{
+		loadActiveAgentDescriptors: func(context.Context) (map[string]ActiveAgentDescriptor, bool, error) {
+			return map[string]ActiveAgentDescriptor{}, true, nil
+		},
+		loadActiveTargetDescriptors: func(context.Context) ([]ActiveTargetDescriptor, bool, error) {
+			return []ActiveTargetDescriptor{{
+				FlowInstance: "component-scaffold/live",
+			}}, true, nil
+		},
+	}
+
+	manifest, err := policy.Evaluate(
+		context.Background(),
+		(events.NewProjectionEvent("", "component.service.completed", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{})).WithTargetRoute(events.RouteIdentity{
+			EntityID:     ActiveTargetDescriptor{FlowInstance: "component-scaffold/missing"}.Normalized().EntityID,
+			FlowInstance: "component-scaffold/missing",
+		}),
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("Evaluate: %v", err)
+	}
+	if manifest.TargetFailure != runtimepinrouting.FailureTargetUnreachableTerminated {
+		t.Fatalf("target failure = %q, want %q", manifest.TargetFailure, runtimepinrouting.FailureTargetUnreachableTerminated)
+	}
+}
+
 func TestDeliveryPlanner_ComposesRoutingPolicyAndManifest(t *testing.T) {
 	planner := newDeliveryPlanner(
 		deliveryRouteResolver{

--- a/internal/runtime/bus/eventbus_flow_instance_descriptors_test.go
+++ b/internal/runtime/bus/eventbus_flow_instance_descriptors_test.go
@@ -1,0 +1,61 @@
+package bus_test
+
+import (
+	"context"
+	"testing"
+
+	runtimebus "github.com/division-sh/swarm/internal/runtime/bus"
+	runtimeflowidentity "github.com/division-sh/swarm/internal/runtime/core/flowidentity"
+)
+
+type activeFlowInstanceDescriptorStore struct {
+	runtimebus.InMemoryEventStore
+	agents        []runtimebus.ActiveAgentDescriptor
+	flowInstances []runtimebus.ActiveFlowInstanceDescriptor
+}
+
+func (s *activeFlowInstanceDescriptorStore) ListActiveAgentDescriptors(context.Context) ([]runtimebus.ActiveAgentDescriptor, error) {
+	return append([]runtimebus.ActiveAgentDescriptor(nil), s.agents...), nil
+}
+
+func (s *activeFlowInstanceDescriptorStore) ListActiveFlowInstanceDescriptors(context.Context) ([]runtimebus.ActiveFlowInstanceDescriptor, error) {
+	return append([]runtimebus.ActiveFlowInstanceDescriptor(nil), s.flowInstances...), nil
+}
+
+func TestEventBusPinRoutingDescriptorsIncludeActiveDynamicFlowInstances(t *testing.T) {
+	const flowInstance = "component-scaffold/aaaaaaaa-1111-4111-8111-aaaaaaaa1111"
+	eb, err := runtimebus.NewEventBus(&activeFlowInstanceDescriptorStore{
+		agents: []runtimebus.ActiveAgentDescriptor{{
+			AgentID:      "service-owner",
+			EntityID:     "service-ent",
+			FlowInstance: "service-owner/root",
+		}},
+		flowInstances: []runtimebus.ActiveFlowInstanceDescriptor{{
+			FlowInstance: flowInstance,
+			FlowTemplate: "component-scaffold",
+		}},
+	})
+	if err != nil {
+		t.Fatalf("NewEventBus: %v", err)
+	}
+
+	descriptors, err := eb.PinRoutingDescriptors(context.Background())
+	if err != nil {
+		t.Fatalf("PinRoutingDescriptors: %v", err)
+	}
+	var foundFlow, foundAgent bool
+	for _, descriptor := range descriptors {
+		switch descriptor.FlowInstance {
+		case flowInstance:
+			foundFlow = descriptor.EntityID == runtimeflowidentity.EntityID(flowInstance)
+		case "service-owner/root":
+			foundAgent = descriptor.EntityID == "service-ent"
+		}
+	}
+	if !foundFlow {
+		t.Fatalf("PinRoutingDescriptors = %#v, want active flow instance descriptor for %s", descriptors, flowInstance)
+	}
+	if !foundAgent {
+		t.Fatalf("PinRoutingDescriptors = %#v, want active agent descriptor preserved", descriptors)
+	}
+}

--- a/internal/runtime/bus/eventbus_routing.go
+++ b/internal/runtime/bus/eventbus_routing.go
@@ -44,23 +44,76 @@ func (eb *EventBus) activeAgentDescriptors(ctx context.Context) (map[string]Acti
 }
 
 func (eb *EventBus) PinRoutingDescriptors(ctx context.Context) ([]runtimepinrouting.Descriptor, error) {
-	descriptors, _, err := eb.activeAgentDescriptors(ctx)
+	descriptors, _, err := eb.activeTargetDescriptors(ctx)
 	if err != nil {
 		return nil, err
 	}
 	out := make([]runtimepinrouting.Descriptor, 0, len(descriptors))
 	for _, descriptor := range descriptors {
 		descriptor = descriptor.Normalized()
-		if descriptor.AgentID == "" {
+		if descriptor.FlowInstance == "" && descriptor.EntityID == "" {
 			continue
 		}
 		out = append(out, runtimepinrouting.Descriptor{
-			ID:           descriptor.AgentID,
+			ID:           descriptor.ID,
 			EntityID:     descriptor.EntityID,
 			FlowInstance: descriptor.FlowInstance,
 		})
 	}
 	return out, nil
+}
+
+func (eb *EventBus) activeTargetDescriptors(ctx context.Context) ([]ActiveTargetDescriptor, bool, error) {
+	agentDescriptors, agentsOK, err := eb.activeAgentDescriptors(ctx)
+	if err != nil {
+		return nil, true, err
+	}
+	out := activeTargetDescriptorsFromAgents(agentDescriptors)
+	lister, flowOK := eb.store.(ActiveFlowInstanceDescriptorLister)
+	if !flowOK {
+		return out, agentsOK || len(out) > 0, nil
+	}
+	flowDescriptors, err := lister.ListActiveFlowInstanceDescriptors(ctx)
+	if err != nil {
+		return nil, true, err
+	}
+	out = appendActiveFlowInstanceTargetDescriptors(out, flowDescriptors)
+	return out, true, nil
+}
+
+func activeTargetDescriptorsFromAgents(descriptors map[string]ActiveAgentDescriptor) []ActiveTargetDescriptor {
+	if len(descriptors) == 0 {
+		return nil
+	}
+	out := make([]ActiveTargetDescriptor, 0, len(descriptors))
+	for _, descriptor := range descriptors {
+		out = appendActiveTargetDescriptor(out, descriptor.TargetDescriptor())
+	}
+	return out
+}
+
+func appendActiveFlowInstanceTargetDescriptors(out []ActiveTargetDescriptor, descriptors []ActiveFlowInstanceDescriptor) []ActiveTargetDescriptor {
+	if len(descriptors) == 0 {
+		return out
+	}
+	for _, descriptor := range descriptors {
+		out = appendActiveTargetDescriptor(out, descriptor.TargetDescriptor())
+	}
+	return out
+}
+
+func appendActiveTargetDescriptor(out []ActiveTargetDescriptor, descriptor ActiveTargetDescriptor) []ActiveTargetDescriptor {
+	descriptor = descriptor.Normalized()
+	if descriptor.FlowInstance == "" && descriptor.EntityID == "" {
+		return out
+	}
+	for _, existing := range out {
+		existing = existing.Normalized()
+		if existing.ID == descriptor.ID && existing.EntityID == descriptor.EntityID && existing.FlowInstance == descriptor.FlowInstance {
+			return out
+		}
+	}
+	return append(out, descriptor)
 }
 
 // RegisterRuntimeActiveAgentDescriptor adds in-memory active-agent metadata for

--- a/internal/runtime/bus/store.go
+++ b/internal/runtime/bus/store.go
@@ -50,10 +50,82 @@ func (d ActiveAgentDescriptor) Normalized() ActiveAgentDescriptor {
 	}
 }
 
+func (d ActiveAgentDescriptor) TargetDescriptor() ActiveTargetDescriptor {
+	d = d.Normalized()
+	return ActiveTargetDescriptor{
+		ID:           d.AgentID,
+		EntityID:     d.EntityID,
+		FlowInstance: d.FlowInstance,
+	}.Normalized()
+}
+
 // ActiveAgentDescriptorLister is an optional capability for runtime delivery
 // planning. PostgresStore implements this; InMemoryEventStore does not.
 type ActiveAgentDescriptorLister interface {
 	ListActiveAgentDescriptors(ctx context.Context) ([]ActiveAgentDescriptor, error)
+}
+
+type ActiveFlowInstanceDescriptor struct {
+	InstanceID   string
+	EntityID     string
+	FlowInstance string
+	FlowTemplate string
+}
+
+func (d ActiveFlowInstanceDescriptor) Normalized() ActiveFlowInstanceDescriptor {
+	flowInstance := strings.Trim(strings.TrimSpace(d.FlowInstance), "/")
+	instanceID := strings.TrimSpace(d.InstanceID)
+	if flowInstance == "" {
+		flowInstance = strings.Trim(strings.TrimSpace(instanceID), "/")
+	}
+	if instanceID == "" && flowInstance != "" {
+		instanceID = runtimeflowidentity.LogicalInstanceID(flowInstance)
+	}
+	entityID := strings.TrimSpace(d.EntityID)
+	if entityID == "" && flowInstance != "" {
+		entityID = runtimeflowidentity.EntityID(flowInstance)
+	}
+	return ActiveFlowInstanceDescriptor{
+		InstanceID:   instanceID,
+		EntityID:     entityID,
+		FlowInstance: flowInstance,
+		FlowTemplate: strings.TrimSpace(d.FlowTemplate),
+	}
+}
+
+func (d ActiveFlowInstanceDescriptor) TargetDescriptor() ActiveTargetDescriptor {
+	d = d.Normalized()
+	return ActiveTargetDescriptor{
+		ID:           d.InstanceID,
+		EntityID:     d.EntityID,
+		FlowInstance: d.FlowInstance,
+	}.Normalized()
+}
+
+// ActiveFlowInstanceDescriptorLister exposes active dynamic flow instances as
+// routable target descriptors. Stores implement this from persisted flow
+// instance state, not from live subscriptions or readback.
+type ActiveFlowInstanceDescriptorLister interface {
+	ListActiveFlowInstanceDescriptors(ctx context.Context) ([]ActiveFlowInstanceDescriptor, error)
+}
+
+type ActiveTargetDescriptor struct {
+	ID           string
+	EntityID     string
+	FlowInstance string
+}
+
+func (d ActiveTargetDescriptor) Normalized() ActiveTargetDescriptor {
+	flowInstance := strings.Trim(strings.TrimSpace(d.FlowInstance), "/")
+	entityID := strings.TrimSpace(d.EntityID)
+	if entityID == "" && flowInstance != "" {
+		entityID = runtimeflowidentity.EntityID(flowInstance)
+	}
+	return ActiveTargetDescriptor{
+		ID:           strings.TrimSpace(d.ID),
+		EntityID:     entityID,
+		FlowInstance: flowInstance,
+	}
 }
 
 // PipelineReceiptPersistence is an optional capability for marking whether

--- a/internal/runtime/cataloge2e/runtime_harness_test.go
+++ b/internal/runtime/cataloge2e/runtime_harness_test.go
@@ -211,6 +211,7 @@ func newRuntimeHarness(t *testing.T, fixtureRoot string, start bool) *runtimeHar
 			t.Fatalf("runtime.Start: %v", err)
 		}
 	}
+	startedAt := catalogHarnessDBTime(t, db)
 	t.Cleanup(func() { _ = rt.Shutdown() })
 
 	return &runtimeHarness{
@@ -224,12 +225,21 @@ func newRuntimeHarness(t *testing.T, fixtureRoot string, start bool) *runtimeHar
 		llm:            llmRuntime,
 		bundle:         bundle,
 		initialState:   strings.TrimSpace(rootSchema.InitialState),
-		startedAt:      time.Now().UTC(),
+		startedAt:      startedAt,
 		publishedIDs:   map[string]struct{}{},
 		publishedOrder: []string{},
 		eventEntityIDs: map[string]string{},
 		previews:       map[string]runtimepipeline.HandlerPreview{},
 	}
+}
+
+func catalogHarnessDBTime(t testing.TB, db *sql.DB) time.Time {
+	t.Helper()
+	var out time.Time
+	if err := db.QueryRowContext(context.Background(), `SELECT NOW()`).Scan(&out); err != nil {
+		t.Fatalf("query catalog harness db time: %v", err)
+	}
+	return out.UTC()
 }
 
 func loadAgentFixtures(t testing.TB, fixtureRoot string, llmRuntime *scriptedLLMRuntime) {

--- a/internal/runtime/cataloge2e/runtime_harness_test.go
+++ b/internal/runtime/cataloge2e/runtime_harness_test.go
@@ -211,7 +211,7 @@ func newRuntimeHarness(t *testing.T, fixtureRoot string, start bool) *runtimeHar
 			t.Fatalf("runtime.Start: %v", err)
 		}
 	}
-	startedAt := catalogHarnessDBTime(t, db)
+	startedAt := catalogHarnessStartBoundary(t, db)
 	t.Cleanup(func() { _ = rt.Shutdown() })
 
 	return &runtimeHarness{
@@ -233,13 +233,18 @@ func newRuntimeHarness(t *testing.T, fixtureRoot string, start bool) *runtimeHar
 	}
 }
 
-func catalogHarnessDBTime(t testing.TB, db *sql.DB) time.Time {
+func catalogHarnessStartBoundary(t testing.TB, db *sql.DB) time.Time {
 	t.Helper()
+	appTime := time.Now().UTC()
 	var out time.Time
 	if err := db.QueryRowContext(context.Background(), `SELECT NOW()`).Scan(&out); err != nil {
 		t.Fatalf("query catalog harness db time: %v", err)
 	}
-	return out.UTC()
+	dbTime := out.UTC()
+	if dbTime.Before(appTime) {
+		return dbTime.Add(-1 * time.Second)
+	}
+	return appTime.Add(-1 * time.Second)
 }
 
 func loadAgentFixtures(t testing.TB, fixtureRoot string, llmRuntime *scriptedLLMRuntime) {

--- a/internal/runtime/cataloge2e/tier11_flow_composition_e2e_test.go
+++ b/internal/runtime/cataloge2e/tier11_flow_composition_e2e_test.go
@@ -1,11 +1,15 @@
 package cataloge2e
 
 import (
+	"context"
+	"database/sql"
 	"os"
 	"path/filepath"
 	"sort"
 	"strings"
 	"testing"
+
+	runtimeflowidentity "github.com/division-sh/swarm/internal/runtime/core/flowidentity"
 )
 
 var tier11FlowCompositionFixtures = []string{
@@ -17,6 +21,7 @@ var tier11FlowCompositionFixtures = []string{
 	"test-child-flow-tool-inherit",
 	"test-data-pin-wiring",
 	"test-data-pin-write-conflict",
+	"test-dynamic-flow-instance",
 	"test-gates-in-child-flow",
 	"test-required-agents-child",
 	"test-child-flow-sibling-isolation",
@@ -28,7 +33,6 @@ var tier11FlowCompositionFixtures = []string{
 
 var tier11ExcludedFixtures = map[string]catalogExcludedFixture{
 	"test-child-flow-absolute-path":   {reason: "parent listener/back-propagation fixture depends on legacy cross-flow subject-link semantics; authored migration belongs to #416"},
-	"test-dynamic-flow-instance":      {reason: "create_flow_instance fixture now fails closed without required config_from; fixture migration belongs to #416"},
 	"test-tool-override":              {reason: "parent listener/back-propagation fixture depends on legacy cross-flow subject-link semantics; authored migration belongs to #416"},
 	"test-wildcard-deep-subscription": {reason: "parent wildcard back-propagation fixture depends on legacy cross-flow subject-link semantics; authored migration belongs to #416"},
 }
@@ -93,5 +97,85 @@ func TestTier11FlowCompositionCatalogFixtures_AreExplicitlyClassified(t *testing
 	expectedCount := len(tier11FlowCompositionFixtures) + len(tier11ExcludedFixtures)
 	if len(found) != expectedCount {
 		t.Fatalf("tier11 fixture accounting mismatch: found=%d supported=%d excluded=%d", len(found), len(tier11FlowCompositionFixtures), len(tier11ExcludedFixtures))
+	}
+}
+
+func TestTier11DynamicFlowInstanceFlowMatchTarget_RealRuntime(t *testing.T) {
+	repoRoot := repoRootFromCatalogE2E(t)
+	fixtureRoot := filepath.Join(repoRoot, "tests", "tier11-flow-composition", "test-dynamic-flow-instance")
+	var expected catalogExpectedDocument
+	loadYAML(t, filepath.Join(fixtureRoot, "expected.yaml"), &expected)
+
+	h := newRuntimeHarness(t, fixtureRoot, false)
+	h.seedEntityFields(expected)
+	for _, step := range expected.triggerSequence() {
+		h.publishAndWait(step, catalogRuntimePublishTimeout)
+	}
+	assertCatalogRuntimeOutcome(t, h, expected)
+	assertDynamicFlowInstanceFlowMatchDescriptorResolution(t, h, "worker/work.assign", "worker/w-001")
+}
+
+func assertDynamicFlowInstanceFlowMatchDescriptorResolution(t testing.TB, h *runtimeHarness, eventName, flowInstance string) {
+	t.Helper()
+	if h == nil || h.db == nil {
+		t.Fatal("runtime harness database is required")
+	}
+	flowInstance = strings.Trim(strings.TrimSpace(flowInstance), "/")
+	wantEntityID := runtimeflowidentity.EntityID(flowInstance)
+	var eventID, targetFlowInstance, targetEntityID, targetSet string
+	err := h.db.QueryRowContext(context.Background(), `
+		SELECT event_id::text,
+		       COALESCE(target_route->>'flow_instance', ''),
+		       COALESCE(target_route->>'entity_id', ''),
+		       COALESCE(target_set::text, '')
+		FROM events
+		WHERE event_name = $1
+		ORDER BY created_at DESC, event_id DESC
+		LIMIT 1
+	`, strings.TrimSpace(eventName)).Scan(&eventID, &targetFlowInstance, &targetEntityID, &targetSet)
+	if err == sql.ErrNoRows {
+		t.Fatalf("targeted event %q not persisted", strings.TrimSpace(eventName))
+	}
+	if err != nil {
+		t.Fatalf("query targeted event %q: %v", strings.TrimSpace(eventName), err)
+	}
+	if targetFlowInstance != flowInstance || targetEntityID != wantEntityID {
+		t.Fatalf("targeted event route = flow_instance:%q entity_id:%q target_set:%s, want flow_instance:%q entity_id:%q", targetFlowInstance, targetEntityID, targetSet, flowInstance, wantEntityID)
+	}
+
+	var deliveryCount int
+	if err := h.db.QueryRowContext(context.Background(), `
+		SELECT COUNT(*)
+		FROM event_deliveries
+		WHERE event_id = $1::uuid
+		  AND subscriber_type = 'node'
+		  AND COALESCE(delivery_target_route->>'flow_instance', '') = $2
+		  AND COALESCE(delivery_target_route->>'entity_id', '') = $3
+	`, eventID, flowInstance, wantEntityID).Scan(&deliveryCount); err != nil {
+		t.Fatalf("query targeted event deliveries: %v", err)
+	}
+	if deliveryCount != 0 {
+		t.Fatalf("targeted event %s node delivery count = %d, want 0 while #1410 owns targeted internal-node delivery row materialization", eventID, deliveryCount)
+	}
+
+	var failureReason, failureFlowInstance, failureEntityID string
+	err = h.db.QueryRowContext(context.Background(), `
+		SELECT COALESCE(target_failure_reason, ''),
+		       COALESCE(target_context->'target'->>'flow_instance', ''),
+		       COALESCE(target_context->'target'->>'entity_id', '')
+		FROM dead_letters
+		WHERE original_event_id = $1::uuid
+		  AND failure_type = 'target_resolution_failed'
+		ORDER BY created_at DESC
+		LIMIT 1
+	`, eventID).Scan(&failureReason, &failureFlowInstance, &failureEntityID)
+	if err == sql.ErrNoRows {
+		t.Fatalf("targeted event %s did not record #1410 split delivery-planning dead letter", eventID)
+	}
+	if err != nil {
+		t.Fatalf("query targeted event dead letter: %v", err)
+	}
+	if failureReason != "target_not_subscribed" || failureFlowInstance != flowInstance || failureEntityID != wantEntityID {
+		t.Fatalf("targeted event dead letter reason=%q route=%q/%q, want target_not_subscribed for %q/%q", failureReason, failureFlowInstance, failureEntityID, flowInstance, wantEntityID)
 	}
 }

--- a/internal/runtime/core/pinrouting/pinrouting_test.go
+++ b/internal/runtime/core/pinrouting/pinrouting_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/division-sh/swarm/internal/events"
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
+	runtimeflowidentity "github.com/division-sh/swarm/internal/runtime/core/flowidentity"
 	"github.com/division-sh/swarm/internal/runtime/flowmodel"
 	"github.com/division-sh/swarm/internal/runtime/semanticview"
 	"time"
@@ -107,6 +108,147 @@ func TestResolveFailsClosedForRootPinOutputWithoutTargetMechanism(t *testing.T) 
 	}
 }
 
+func TestResolveFlowMatchTargetsActiveDynamicInstanceByInstanceID(t *testing.T) {
+	source := testFlowMatchPinRoutingSource()
+	const flowInstance = "component-scaffold/aaaaaaaa-1111-4111-8111-aaaaaaaa1111"
+
+	result := Resolve(ResolutionInput{
+		Source:    source,
+		FlowID:    "service-owner",
+		EventType: "component.service.completed",
+		Emit: runtimecontracts.EmitSpec{
+			Target: runtimecontracts.EmitTargetSpec{
+				Flow:  "component-scaffold",
+				Match: map[string]runtimecontracts.ExpressionValue{"instance_id": runtimecontracts.RefExpression("payload.component_id")},
+			},
+		},
+		MatchValues: map[string]string{"instance_id": "aaaaaaaa-1111-4111-8111-aaaaaaaa1111"},
+		Descriptors: []Descriptor{{
+			FlowInstance: flowInstance,
+		}},
+	}, events.NewProjectionEvent("", "component.service.completed", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}))
+
+	if result.Failure != "" {
+		t.Fatalf("Failure = %q, want empty", result.Failure)
+	}
+	if result.Target.FlowInstance != flowInstance {
+		t.Fatalf("Target.FlowInstance = %q, want %q", result.Target.FlowInstance, flowInstance)
+	}
+	if result.Target.EntityID != runtimeflowidentity.EntityID(flowInstance) {
+		t.Fatalf("Target.EntityID = %q, want derived flow instance entity id", result.Target.EntityID)
+	}
+}
+
+func TestResolveFlowMatchTargetsActiveDynamicInstanceByFlowInstanceAndEntityID(t *testing.T) {
+	source := testFlowMatchPinRoutingSource()
+	const flowInstance = "component-scaffold/bbbbbbbb-2222-4222-8222-bbbbbbbb2222"
+	entityID := runtimeflowidentity.EntityID(flowInstance)
+
+	for _, tt := range []struct {
+		name       string
+		matchKey   string
+		matchValue string
+		descriptor Descriptor
+	}{
+		{
+			name:       "flow_instance",
+			matchKey:   "flow_instance",
+			matchValue: flowInstance,
+			descriptor: Descriptor{FlowInstance: flowInstance},
+		},
+		{
+			name:       "entity_id",
+			matchKey:   "entity_id",
+			matchValue: entityID,
+			descriptor: Descriptor{FlowInstance: flowInstance},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			result := Resolve(ResolutionInput{
+				Source:    source,
+				FlowID:    "service-owner",
+				EventType: "component.service.completed",
+				Emit: runtimecontracts.EmitSpec{
+					Target: runtimecontracts.EmitTargetSpec{
+						Flow:  "component-scaffold",
+						Match: map[string]runtimecontracts.ExpressionValue{tt.matchKey: runtimecontracts.RefExpression("payload." + tt.matchKey)},
+					},
+				},
+				MatchValues: map[string]string{tt.matchKey: tt.matchValue},
+				Descriptors: []Descriptor{tt.descriptor},
+			}, events.NewProjectionEvent("", "component.service.completed", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}))
+
+			if result.Failure != "" {
+				t.Fatalf("Failure = %q, want empty", result.Failure)
+			}
+			if result.Target.FlowInstance != flowInstance {
+				t.Fatalf("Target.FlowInstance = %q, want %q", result.Target.FlowInstance, flowInstance)
+			}
+			if result.Target.EntityID != entityID {
+				t.Fatalf("Target.EntityID = %q, want %q", result.Target.EntityID, entityID)
+			}
+		})
+	}
+}
+
+func TestResolveFlowMatchFailsClosedOnAmbiguousActiveDynamicInstances(t *testing.T) {
+	source := testFlowMatchPinRoutingSource()
+
+	result := Resolve(ResolutionInput{
+		Source:    source,
+		FlowID:    "service-owner",
+		EventType: "component.service.completed",
+		Emit: runtimecontracts.EmitSpec{
+			Target: runtimecontracts.EmitTargetSpec{
+				Flow:  "component-scaffold",
+				Match: map[string]runtimecontracts.ExpressionValue{"entity_id": runtimecontracts.RefExpression("payload.entity_id")},
+			},
+		},
+		MatchValues: map[string]string{"entity_id": "shared-entity"},
+		Descriptors: []Descriptor{
+			{EntityID: "shared-entity", FlowInstance: "component-scaffold/a"},
+			{EntityID: "shared-entity", FlowInstance: "component-scaffold/b"},
+		},
+	}, events.NewProjectionEvent("", "component.service.completed", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}))
+
+	if result.Failure != FailureTargetAmbiguous {
+		t.Fatalf("Failure = %q, want %q", result.Failure, FailureTargetAmbiguous)
+	}
+	if got := result.Event.TargetRoute(); !got.Empty() {
+		t.Fatalf("Event target = %#v, want empty on ambiguous target", got)
+	}
+}
+
+func TestResolveFlowMatchFailsClosedWhenDynamicInstanceDescriptorMissing(t *testing.T) {
+	source := testFlowMatchPinRoutingSource()
+
+	result := Resolve(ResolutionInput{
+		Source:    source,
+		FlowID:    "service-owner",
+		EventType: "component.service.completed",
+		Emit: runtimecontracts.EmitSpec{
+			Target: runtimecontracts.EmitTargetSpec{
+				Flow:  "component-scaffold",
+				Match: map[string]runtimecontracts.ExpressionValue{"instance_id": runtimecontracts.RefExpression("payload.component_id")},
+			},
+		},
+		MatchValues: map[string]string{"instance_id": "missing"},
+		Descriptors: []Descriptor{{
+			FlowInstance: "component-scaffold/live",
+		}},
+	}, events.NewProjectionEvent("", "component.service.completed", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}))
+
+	if result.Failure != FailureTargetUnreachableNoSub {
+		t.Fatalf("Failure = %q, want %q", result.Failure, FailureTargetUnreachableNoSub)
+	}
+	if got := result.Event.TargetRoute(); !got.Empty() {
+		t.Fatalf("Event target = %#v, want empty on missing target", got)
+	}
+	if len(result.Event.TargetRoutes()) != 0 {
+		t.Fatalf("Event target_set = %#v, want empty on missing target", result.Event.TargetRoutes())
+	}
+}
+
 func testPinRoutingSource() semanticview.Source {
 	child := runtimecontracts.FlowContractView{
 		Paths: runtimecontracts.FlowContractPaths{
@@ -129,6 +271,41 @@ func testPinRoutingSource() semanticview.Source {
 			},
 			ByID: map[string]*runtimecontracts.FlowContractView{
 				"child": &child,
+			},
+		},
+	})
+}
+
+func testFlowMatchPinRoutingSource() semanticview.Source {
+	serviceOwner := runtimecontracts.FlowContractView{
+		Paths: runtimecontracts.FlowContractPaths{
+			ID:   "service-owner",
+			Flow: "service-owner",
+		},
+		Schema: runtimecontracts.FlowSchemaDocument{
+			Pins: runtimecontracts.FlowPins{
+				Outputs: runtimecontracts.FlowOutputPins{
+					Events: []string{"component.service.completed"},
+				},
+			},
+		},
+		Path: "service-owner",
+	}
+	componentScaffold := runtimecontracts.FlowContractView{
+		Paths: runtimecontracts.FlowContractPaths{
+			ID:   "component-scaffold",
+			Flow: "component-scaffold",
+		},
+		Path: "component-scaffold",
+	}
+	return semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
+		FlowTree: flowmodel.Tree[runtimecontracts.FlowContractView]{
+			Root: &runtimecontracts.FlowContractView{
+				Children: []runtimecontracts.FlowContractView{serviceOwner, componentScaffold},
+			},
+			ByID: map[string]*runtimecontracts.FlowContractView{
+				"service-owner":      &serviceOwner,
+				"component-scaffold": &componentScaffold,
 			},
 		},
 	})

--- a/internal/store/agents_list.go
+++ b/internal/store/agents_list.go
@@ -7,6 +7,8 @@ import (
 	runtimebus "github.com/division-sh/swarm/internal/runtime/bus"
 )
 
+var _ runtimebus.ActiveFlowInstanceDescriptorLister = (*PostgresStore)(nil)
+
 // ListActiveAgentDescriptors implements runtime.ActiveAgentDescriptorLister for
 // explicit runtime delivery planning against persisted agent metadata.
 func (s *PostgresStore) ListActiveAgentDescriptors(ctx context.Context) ([]runtimebus.ActiveAgentDescriptor, error) {

--- a/internal/store/flow_instance_descriptors_sqlite_test.go
+++ b/internal/store/flow_instance_descriptors_sqlite_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	runtimeflowidentity "github.com/division-sh/swarm/internal/runtime/core/flowidentity"
+	runtimepipeline "github.com/division-sh/swarm/internal/runtime/pipeline"
 	"github.com/division-sh/swarm/internal/store/storetest"
 )
 
@@ -41,5 +42,30 @@ func TestSQLiteRuntimeStoreListActiveFlowInstanceDescriptorsFiltersToActiveTempl
 	}
 	if got.FlowTemplate != "component-scaffold" {
 		t.Fatalf("FlowTemplate = %q, want component-scaffold", got.FlowTemplate)
+	}
+}
+
+func TestSQLiteRuntimeStoreListActiveFlowInstanceDescriptorsReadsPipelineTransaction(t *testing.T) {
+	ctx := context.Background()
+	sqliteStore := storetest.StartSQLiteRuntimeStoreWithContext(t, ctx)
+
+	tx, err := sqliteStore.DB.BeginTx(ctx, nil)
+	if err != nil {
+		t.Fatalf("BeginTx: %v", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	if _, err := tx.ExecContext(ctx, `
+		INSERT INTO flow_instances (instance_id, flow_template, mode, config, status, created_at)
+		VALUES ('component-scaffold/uncommitted', 'component-scaffold', 'template', '{}', 'active', CURRENT_TIMESTAMP)
+	`); err != nil {
+		t.Fatalf("seed flow_instances in tx: %v", err)
+	}
+
+	descriptors, err := sqliteStore.ListActiveFlowInstanceDescriptors(runtimepipeline.WithPipelineSQLTxContext(ctx, tx))
+	if err != nil {
+		t.Fatalf("ListActiveFlowInstanceDescriptors: %v", err)
+	}
+	if len(descriptors) != 1 || descriptors[0].FlowInstance != "component-scaffold/uncommitted" {
+		t.Fatalf("descriptors = %#v, want uncommitted tx flow instance", descriptors)
 	}
 }

--- a/internal/store/flow_instance_descriptors_sqlite_test.go
+++ b/internal/store/flow_instance_descriptors_sqlite_test.go
@@ -1,0 +1,45 @@
+package store_test
+
+import (
+	"context"
+	"testing"
+
+	runtimeflowidentity "github.com/division-sh/swarm/internal/runtime/core/flowidentity"
+	"github.com/division-sh/swarm/internal/store/storetest"
+)
+
+func TestSQLiteRuntimeStoreListActiveFlowInstanceDescriptorsFiltersToActiveTemplates(t *testing.T) {
+	ctx := context.Background()
+	sqliteStore := storetest.StartSQLiteRuntimeStoreWithContext(t, ctx)
+
+	if _, err := sqliteStore.DB.ExecContext(ctx, `
+		INSERT INTO flow_instances (instance_id, flow_template, mode, config, status, created_at)
+		VALUES
+			('component-scaffold/active', 'component-scaffold', 'template', '{}', 'active', CURRENT_TIMESTAMP),
+			('component-scaffold/terminated', 'component-scaffold', 'template', '{}', 'terminated', CURRENT_TIMESTAMP),
+			('service-owner', 'service-owner', 'static', '{}', 'active', CURRENT_TIMESTAMP)
+	`); err != nil {
+		t.Fatalf("seed flow_instances: %v", err)
+	}
+
+	descriptors, err := sqliteStore.ListActiveFlowInstanceDescriptors(ctx)
+	if err != nil {
+		t.Fatalf("ListActiveFlowInstanceDescriptors: %v", err)
+	}
+	if len(descriptors) != 1 {
+		t.Fatalf("descriptors = %#v, want exactly active template descriptor", descriptors)
+	}
+	got := descriptors[0]
+	if got.FlowInstance != "component-scaffold/active" {
+		t.Fatalf("FlowInstance = %q, want component-scaffold/active", got.FlowInstance)
+	}
+	if got.InstanceID != "active" {
+		t.Fatalf("InstanceID = %q, want active", got.InstanceID)
+	}
+	if got.EntityID != runtimeflowidentity.EntityID("component-scaffold/active") {
+		t.Fatalf("EntityID = %q, want derived flow instance entity id", got.EntityID)
+	}
+	if got.FlowTemplate != "component-scaffold" {
+		t.Fatalf("FlowTemplate = %q, want component-scaffold", got.FlowTemplate)
+	}
+}

--- a/internal/store/flow_instance_routes.go
+++ b/internal/store/flow_instance_routes.go
@@ -177,3 +177,77 @@ func (s *PostgresStore) ListFlowInstanceRoutes(ctx context.Context) ([]runtimefl
 	}
 	return out, nil
 }
+
+func (s *PostgresStore) ListActiveFlowInstanceDescriptors(ctx context.Context) ([]runtimebus.ActiveFlowInstanceDescriptor, error) {
+	if s == nil || s.DB == nil {
+		return nil, fmt.Errorf("postgres store is required for active flow instance descriptors")
+	}
+	rows, err := s.DB.QueryContext(ctx, `
+		SELECT
+			COALESCE(instance_id, ''),
+			COALESCE(flow_template, '')
+		FROM flow_instances
+		WHERE COALESCE(status, '') = 'active'
+		  AND COALESCE(mode, '') = 'template'
+		  AND COALESCE(instance_id, '') <> ''
+		ORDER BY instance_id ASC
+	`)
+	if err != nil {
+		return nil, fmt.Errorf("list active flow instance descriptors: %w", err)
+	}
+	defer rows.Close()
+
+	out := []runtimebus.ActiveFlowInstanceDescriptor{}
+	for rows.Next() {
+		var descriptor runtimebus.ActiveFlowInstanceDescriptor
+		if err := rows.Scan(&descriptor.FlowInstance, &descriptor.FlowTemplate); err != nil {
+			return nil, fmt.Errorf("scan active flow instance descriptor: %w", err)
+		}
+		descriptor = descriptor.Normalized()
+		if descriptor.FlowInstance == "" {
+			continue
+		}
+		out = append(out, descriptor)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate active flow instance descriptors: %w", err)
+	}
+	return out, nil
+}
+
+func (s *SQLiteRuntimeStore) ListActiveFlowInstanceDescriptors(ctx context.Context) ([]runtimebus.ActiveFlowInstanceDescriptor, error) {
+	if s == nil || s.DB == nil {
+		return nil, fmt.Errorf("sqlite runtime store is required for active flow instance descriptors")
+	}
+	rows, err := s.DB.QueryContext(ctx, `
+		SELECT
+			COALESCE(instance_id, ''),
+			COALESCE(flow_template, '')
+		FROM flow_instances
+		WHERE COALESCE(status, '') = 'active'
+		  AND COALESCE(mode, '') = 'template'
+		  AND COALESCE(instance_id, '') <> ''
+		ORDER BY instance_id ASC
+	`)
+	if err != nil {
+		return nil, fmt.Errorf("list sqlite active flow instance descriptors: %w", err)
+	}
+	defer rows.Close()
+
+	out := []runtimebus.ActiveFlowInstanceDescriptor{}
+	for rows.Next() {
+		var descriptor runtimebus.ActiveFlowInstanceDescriptor
+		if err := rows.Scan(&descriptor.FlowInstance, &descriptor.FlowTemplate); err != nil {
+			return nil, fmt.Errorf("scan sqlite active flow instance descriptor: %w", err)
+		}
+		descriptor = descriptor.Normalized()
+		if descriptor.FlowInstance == "" {
+			continue
+		}
+		out = append(out, descriptor)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate sqlite active flow instance descriptors: %w", err)
+	}
+	return out, nil
+}

--- a/internal/store/flow_instance_routes.go
+++ b/internal/store/flow_instance_routes.go
@@ -9,7 +9,12 @@ import (
 
 	runtimebus "github.com/division-sh/swarm/internal/runtime/bus"
 	runtimeflowidentity "github.com/division-sh/swarm/internal/runtime/core/flowidentity"
+	runtimepipeline "github.com/division-sh/swarm/internal/runtime/pipeline"
 )
+
+type flowInstanceDescriptorQueryer interface {
+	QueryContext(ctx context.Context, query string, args ...any) (*sql.Rows, error)
+}
 
 func (s *PostgresStore) UpsertFlowInstanceRoute(ctx context.Context, route runtimebus.FlowInstanceRouteRecord) error {
 	if s == nil || s.DB == nil {
@@ -182,7 +187,11 @@ func (s *PostgresStore) ListActiveFlowInstanceDescriptors(ctx context.Context) (
 	if s == nil || s.DB == nil {
 		return nil, fmt.Errorf("postgres store is required for active flow instance descriptors")
 	}
-	rows, err := s.DB.QueryContext(ctx, `
+	q := flowInstanceDescriptorQueryer(s.DB)
+	if tx, ok := runtimepipeline.PipelineSQLTxFromContext(ctx); ok && tx != nil {
+		q = tx
+	}
+	rows, err := q.QueryContext(ctx, `
 		SELECT
 			COALESCE(instance_id, ''),
 			COALESCE(flow_template, '')
@@ -219,7 +228,11 @@ func (s *SQLiteRuntimeStore) ListActiveFlowInstanceDescriptors(ctx context.Conte
 	if s == nil || s.DB == nil {
 		return nil, fmt.Errorf("sqlite runtime store is required for active flow instance descriptors")
 	}
-	rows, err := s.DB.QueryContext(ctx, `
+	q := flowInstanceDescriptorQueryer(s.DB)
+	if tx, ok := runtimepipeline.PipelineSQLTxFromContext(ctx); ok && tx != nil {
+		q = tx
+	}
+	rows, err := q.QueryContext(ctx, `
 		SELECT
 			COALESCE(instance_id, ''),
 			COALESCE(flow_template, '')

--- a/internal/store/flow_instance_routes_test.go
+++ b/internal/store/flow_instance_routes_test.go
@@ -293,3 +293,41 @@ func TestPostgresStoreListFlowInstanceRoutesFiltersTerminatedInstances(t *testin
 		t.Fatalf("listed routes = %#v, want only active flow-instance route", routes)
 	}
 }
+
+func TestPostgresStoreListActiveFlowInstanceDescriptorsFiltersToActiveTemplates(t *testing.T) {
+	ctx := context.Background()
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &PostgresStore{DB: db}
+	ensureFlowInstanceRouteTables(t, ctx, db)
+
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO flow_instances (instance_id, flow_template, mode, config, status, created_at)
+		VALUES
+			('component-scaffold/active', 'component-scaffold', 'template', '{}'::jsonb, 'active', NOW()),
+			('component-scaffold/terminated', 'component-scaffold', 'template', '{}'::jsonb, 'terminated', NOW()),
+			('service-owner', 'service-owner', 'static', '{}'::jsonb, 'active', NOW())
+	`); err != nil {
+		t.Fatalf("seed flow_instances: %v", err)
+	}
+
+	descriptors, err := pg.ListActiveFlowInstanceDescriptors(ctx)
+	if err != nil {
+		t.Fatalf("ListActiveFlowInstanceDescriptors: %v", err)
+	}
+	if len(descriptors) != 1 {
+		t.Fatalf("descriptors = %#v, want exactly active template descriptor", descriptors)
+	}
+	got := descriptors[0]
+	if got.FlowInstance != "component-scaffold/active" {
+		t.Fatalf("FlowInstance = %q, want component-scaffold/active", got.FlowInstance)
+	}
+	if got.InstanceID != "active" {
+		t.Fatalf("InstanceID = %q, want active", got.InstanceID)
+	}
+	if got.EntityID != runtimeflowidentity.EntityID("component-scaffold/active") {
+		t.Fatalf("EntityID = %q, want derived flow instance entity id", got.EntityID)
+	}
+	if got.FlowTemplate != "component-scaffold" {
+		t.Fatalf("FlowTemplate = %q, want component-scaffold", got.FlowTemplate)
+	}
+}

--- a/internal/store/flow_instance_routes_test.go
+++ b/internal/store/flow_instance_routes_test.go
@@ -9,6 +9,7 @@ import (
 
 	runtimebus "github.com/division-sh/swarm/internal/runtime/bus"
 	runtimeflowidentity "github.com/division-sh/swarm/internal/runtime/core/flowidentity"
+	runtimepipeline "github.com/division-sh/swarm/internal/runtime/pipeline"
 	"github.com/division-sh/swarm/internal/testutil"
 )
 
@@ -329,5 +330,32 @@ func TestPostgresStoreListActiveFlowInstanceDescriptorsFiltersToActiveTemplates(
 	}
 	if got.FlowTemplate != "component-scaffold" {
 		t.Fatalf("FlowTemplate = %q, want component-scaffold", got.FlowTemplate)
+	}
+}
+
+func TestPostgresStoreListActiveFlowInstanceDescriptorsReadsPipelineTransaction(t *testing.T) {
+	ctx := context.Background()
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &PostgresStore{DB: db}
+	ensureFlowInstanceRouteTables(t, ctx, db)
+
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		t.Fatalf("BeginTx: %v", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	if _, err := tx.ExecContext(ctx, `
+		INSERT INTO flow_instances (instance_id, flow_template, mode, config, status, created_at)
+		VALUES ('component-scaffold/uncommitted', 'component-scaffold', 'template', '{}'::jsonb, 'active', NOW())
+	`); err != nil {
+		t.Fatalf("seed flow_instances in tx: %v", err)
+	}
+
+	descriptors, err := pg.ListActiveFlowInstanceDescriptors(runtimepipeline.WithPipelineSQLTxContext(ctx, tx))
+	if err != nil {
+		t.Fatalf("ListActiveFlowInstanceDescriptors: %v", err)
+	}
+	if len(descriptors) != 1 || descriptors[0].FlowInstance != "component-scaffold/uncommitted" {
+		t.Fatalf("descriptors = %#v, want uncommitted tx flow instance", descriptors)
 	}
 }

--- a/internal/store/sqlite_runtime.go
+++ b/internal/store/sqlite_runtime.go
@@ -45,6 +45,7 @@ type SQLiteRuntimeStore struct {
 
 var _ SchemaBootstrapper = (*SQLiteRuntimeStore)(nil)
 var _ runtimebus.EventStore = (*SQLiteRuntimeStore)(nil)
+var _ runtimebus.ActiveFlowInstanceDescriptorLister = (*SQLiteRuntimeStore)(nil)
 var _ runtimebus.RunLifecyclePersistence = (*SQLiteRuntimeStore)(nil)
 var _ runtimebus.RunLifecycleReadPersistence = (*SQLiteRuntimeStore)(nil)
 var _ runtimebus.StandaloneRuntimePlatformRunConvergencePersistence = (*SQLiteRuntimeStore)(nil)

--- a/tests/tier11-flow-composition/test-dynamic-flow-instance/events.yaml
+++ b/tests/tier11-flow-composition/test-dynamic-flow-instance/events.yaml
@@ -1,11 +1,14 @@
 spawn.requested:
   entity_id: string
   worker_id: string
+  task_label: string
 spawn.confirmed:
+  worker_id: string
+assign.requested:
   entity_id: string
-worker/worker.ready:
-  entity_id: string
+  worker_id: string
+  task_label: string
 worker/work.assign:
-  entity_id: string
+  task_label: string
 worker/work.done:
-  entity_id: string
+  task_label: string

--- a/tests/tier11-flow-composition/test-dynamic-flow-instance/expected.yaml
+++ b/tests/tier11-flow-composition/test-dynamic-flow-instance/expected.yaml
@@ -1,15 +1,22 @@
 trigger:
-  event: spawn.requested
-  payload:
-    entity_id: 11111111-1111-1111-1111-111111111111
-    worker_id: w-001
+  sequence:
+    - event: spawn.requested
+      payload:
+        entity_id: 11111111-1111-1111-1111-111111111111
+        worker_id: w-001
+        task_label: route-me
+    - event: assign.requested
+      payload:
+        entity_id: 11111111-1111-1111-1111-111111111111
+        worker_id: w-001
+        task_label: route-me
 
 expected:
   handler_outcome: success
   entity_state: done
-  emitted_events:
-    - spawn.confirmed
   flow_instance_created:
     template: worker
     instance_id: w-001
-    auto_emitted: worker/w-001/worker.ready
+    config:
+      worker_id: w-001
+      task_label: route-me

--- a/tests/tier11-flow-composition/test-dynamic-flow-instance/flows/worker/events.yaml
+++ b/tests/tier11-flow-composition/test-dynamic-flow-instance/flows/worker/events.yaml
@@ -1,6 +1,4 @@
-worker.ready:
-  entity_id: string
 work.assign:
-  entity_id: string
+  task_label: string
 work.done:
-  entity_id: string
+  task_label: string

--- a/tests/tier11-flow-composition/test-dynamic-flow-instance/flows/worker/nodes.yaml
+++ b/tests/tier11-flow-composition/test-dynamic-flow-instance/flows/worker/nodes.yaml
@@ -5,8 +5,9 @@ task-handler:
   produces: [work.done]
   event_handlers:
     work.assign:
-      create_entity: true
       advances_to: working
       emit:
         event: work.done
         broadcast: true
+        fields:
+          task_label: payload.task_label

--- a/tests/tier11-flow-composition/test-dynamic-flow-instance/flows/worker/schema.yaml
+++ b/tests/tier11-flow-composition/test-dynamic-flow-instance/flows/worker/schema.yaml
@@ -3,10 +3,11 @@ namespace: worker
 initial_state: idle
 terminal_states: [complete]
 states: [idle, working, complete]
-auto_emit_on_create:
-  event: worker.ready
+instance_variables:
+  worker_id: string
+  task_label: string
 pins:
   inputs:
     events: [work.assign]
   outputs:
-    events: [worker.ready, work.done]
+    events: [work.done]

--- a/tests/tier11-flow-composition/test-dynamic-flow-instance/nodes.yaml
+++ b/tests/tier11-flow-composition/test-dynamic-flow-instance/nodes.yaml
@@ -8,9 +8,31 @@ orchestrator:
       action: create_flow_instance
       template: worker
       instance_id_from: payload.worker_id
+      config_from:
+        worker_id: payload.worker_id
+        task_label: payload.task_label
       emit:
         event: spawn.confirmed
         broadcast: true
-      advances_to: done
+        fields:
+          worker_id: payload.worker_id
+      advances_to: spawned
   permissions:
   - create_flow_instance
+
+assigner:
+  id: assigner
+  execution_type: system_node
+  subscribes_to: [assign.requested]
+  produces: [worker/work.assign]
+  event_handlers:
+    assign.requested:
+      emit:
+        event: worker/work.assign
+        fields:
+          task_label: payload.task_label
+        target:
+          flow: worker
+          match:
+            instance_id: payload.worker_id
+      advances_to: done

--- a/tests/tier11-flow-composition/test-dynamic-flow-instance/schema.yaml
+++ b/tests/tier11-flow-composition/test-dynamic-flow-instance/schema.yaml
@@ -2,9 +2,9 @@ name: test-dynamic-flow-instance
 namespace: test-dynamic-flow-instance
 initial_state: pending
 terminal_states: [done]
-states: [pending, done]
+states: [pending, spawned, done]
 pins:
   inputs:
-    events: [spawn.requested]
+    events: [spawn.requested, assign.requested]
   outputs:
-    events: [spawn.confirmed]
+    events: [spawn.confirmed, worker/work.assign]


### PR DESCRIPTION
Closes #1409

## Summary

- Adds active dynamic flow-instance target descriptors from persisted `flow_instances` state for Postgres and SQLite.
- Makes `EventBus.PinRoutingDescriptors` merge active agents and active flow instances before calling the pure pin resolver.
- Makes delivery target failure taxonomy consume the same active target descriptor set, so a live-but-unsubscribed flow target reports `target_not_subscribed` instead of missing/terminated.
- Keeps route production and targeted internal-node delivery planning unchanged; #1410 remains split.

## Governing refs/context

Exact governing spec references:

- `platform-spec.yaml:270-315`: runtime-owned `event.source`, `event.target`, and `event.target_set`; legacy projections are not route authority.
- `platform-spec.yaml:437-512`: RoutePlan consumes topology and target context before persistence; live subscribers/readback/receipts are not authority.
- `platform-spec.yaml:1868-1943`: dynamic pairs require publish-time target resolution; `flow/match` is singular unless `allow_fanout:true`; failures are typed.
- `platform-spec.yaml:2054-2095`: `create_flow_instance` creates concrete paths and active runtime state; materialized route truth is consumed downstream.
- `platform-spec.yaml:5031-5052`: `routing_rules` remains the unified materialized route table.

Binding issue/gate context:

- Pre-Implementation Coverage Audit: https://github.com/division-sh/swarm/issues/1409#issuecomment-4702562543
- Gate approval: https://github.com/division-sh/swarm/issues/1409#issuecomment-4702601310

## Semantic migration

- New canonical owner for this slice: active dynamic flow-instance target facts exposed through `ActiveFlowInstanceDescriptorLister`, normalized into `ActiveTargetDescriptor` by the event bus adapter.
- Old non-authoritative path now invalid for this slice: active-agent-only descriptor construction as the exclusive source for pin `flow/match` target resolution and target failure classification.
- Invalid authority remains invalid: live subscribers, handler lookup, API/CLI readback, receipts, settlement, replay markers, and broadcast fallback.
- Production paths checked for surviving old behavior: `EventBus.PinRoutingDescriptors`, delivery planner target failure classification, `runtimepinrouting.ResolveEnvelope`, Postgres flow-instance descriptor listing, and SQLite flow-instance descriptor listing.
- Migration completion: complete for `active_dynamic_flow_instance_target_descriptor_authority`; parent route-authority model remains open under #1340/#1353 and targeted internal-node delivery remains split to #1410.

## Validation

- `go test ./internal/runtime/core/pinrouting -count=1`
- `go test ./internal/runtime/bus -run 'Test(EventBusPinRoutingDescriptorsIncludeActiveDynamicFlowInstances|DeliveryRecipientPolicy_TargetedFlowInstance|DeliveryRecipientPolicy_TargetedEvent)' -count=1`
- `go test ./internal/store -run 'Test(PostgresStoreListActiveFlowInstanceDescriptors|SQLiteRuntimeStoreListActiveFlowInstanceDescriptors|PostgresStoreListFlowInstanceRoutes|PostgresStoreFlowInstanceRoutes)' -count=1`
- `go test ./internal/runtime/bus -count=1`
- `go test ./internal/store -count=1`
- `go test ./...`
