### PR TITLE
[agent-c][issue #1410] Targeted node deliveries

### DIFF
--- a/internal/runtime/bus/delivery_planner.go
+++ b/internal/runtime/bus/delivery_planner.go
@@ -3,7 +3,6 @@ package bus
 import (
 	"context"
 	"errors"
-	"fmt"
 	"strings"
 
 	"github.com/division-sh/swarm/internal/events"
@@ -17,8 +16,6 @@ type deliveryRoutingResult struct {
 	SubscribedRecipients []string
 	ExtraDetail          map[string]any
 }
-
-var errAmbiguousTargetedNodeDelivery = errors.New("ambiguous targeted node delivery")
 
 type deliveryRecipientCandidate struct {
 	ID                string
@@ -132,11 +129,7 @@ func (p deliveryPlanner) Plan(ctx context.Context, evt events.Event) (eventDeliv
 	routePlan.AddDeliveryIntents(routedRootInputFlowNodeDeliveryIntentsForNoTargetEvent(evt, routing.RoutedRecipients)...)
 	routePlan.AddDeliveryIntents(routedNodeDeliveryIntentsForNoRecipientFlowInstanceEvent(evt, routing.RoutedRecipients, recipients, persisted)...)
 	routePlan.AddDeliveryIntents(routedNodeDeliveryIntentsForNoTargetEvent(evt, routing.RoutedRecipients, recipients, persisted)...)
-	targetedIntents, err := targetedRoutedNodeDeliveryIntents(evt, routing.RoutedRecipients)
-	if err != nil {
-		return eventDeliveryPlan{}, err
-	}
-	routePlan.AddDeliveryIntents(targetedIntents...)
+	routePlan.AddDeliveryIntents(targetedRoutedNodeDeliveryIntents(evt, routing.RoutedRecipients)...)
 	routePlan.AddDeliveryIntents(internalDeliveryIntentsForPlan(evt, recipients, persisted, routing.RoutedRecipients)...)
 	if routePlan.TargetFailure != "" && hasInternalRoutedSubscriberForTarget(evt, routing.RoutedRecipients) {
 		routePlan.TargetFailure = ""
@@ -465,21 +458,18 @@ func internalDeliveryIntentsForPlan(evt events.Event, recipients, persisted []st
 	return routePlanDeliveryIntentsFromRoutes(out, routePlanSourceInternalTarget, routePlanReasonInternalCarrier)
 }
 
-func targetedRoutedNodeDeliveryIntents(evt events.Event, routed []Subscriber) ([]RoutePlanDeliveryIntent, error) {
-	routes, err := targetedRoutedNodeDeliveryRoutes(evt, routed)
-	if err != nil {
-		return nil, err
-	}
+func targetedRoutedNodeDeliveryIntents(evt events.Event, routed []Subscriber) []RoutePlanDeliveryIntent {
+	routes := targetedRoutedNodeDeliveryRoutes(evt, routed)
 	if len(routes) == 0 {
-		return nil, nil
+		return nil
 	}
-	return routePlanDeliveryIntentsFromRoutes(routes, routePlanSourceInternalTarget, routePlanReasonRouteTableNode), nil
+	return routePlanDeliveryIntentsFromRoutes(routes, routePlanSourceInternalTarget, routePlanReasonRouteTableNode)
 }
 
-func targetedRoutedNodeDeliveryRoutes(evt events.Event, routed []Subscriber) ([]events.DeliveryRoute, error) {
+func targetedRoutedNodeDeliveryRoutes(evt events.Event, routed []Subscriber) []events.DeliveryRoute {
 	targets := eventDeliveryTargetRoutes(evt)
 	if len(targets) == 0 || len(routed) == 0 {
-		return nil, nil
+		return nil
 	}
 	out := make([]events.DeliveryRoute, 0, len(targets)*len(routed))
 	for _, target := range targets {
@@ -502,33 +492,7 @@ func targetedRoutedNodeDeliveryRoutes(evt events.Event, routed []Subscriber) ([]
 			})
 		}
 	}
-	out = events.NormalizeDeliveryRoutes(out)
-	if err := rejectAmbiguousTargetedNodeDeliveryRoutes(out); err != nil {
-		return nil, err
-	}
-	return out, nil
-}
-
-func rejectAmbiguousTargetedNodeDeliveryRoutes(routes []events.DeliveryRoute) error {
-	if len(routes) < 2 {
-		return nil
-	}
-	seen := make(map[string]events.RouteIdentity, len(routes))
-	for _, route := range routes {
-		if route.SubscriberType != "node" {
-			continue
-		}
-		key := strings.TrimSpace(route.SubscriberType) + "\x00" + strings.TrimSpace(route.SubscriberID)
-		if key == "\x00" {
-			continue
-		}
-		target := route.Target.Normalized()
-		if previous, ok := seen[key]; ok && previous != target {
-			return fmt.Errorf("%w: node %q has multiple target routes for one event", errAmbiguousTargetedNodeDelivery, route.SubscriberID)
-		}
-		seen[key] = target
-	}
-	return nil
+	return events.NormalizeDeliveryRoutes(out)
 }
 
 func routedNodeDeliveryIntentsForNoTargetEvent(evt events.Event, routed []Subscriber, recipients, persisted []string) []RoutePlanDeliveryIntent {

--- a/internal/runtime/bus/delivery_planner.go
+++ b/internal/runtime/bus/delivery_planner.go
@@ -3,6 +3,7 @@ package bus
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strings"
 
 	"github.com/division-sh/swarm/internal/events"
@@ -16,6 +17,8 @@ type deliveryRoutingResult struct {
 	SubscribedRecipients []string
 	ExtraDetail          map[string]any
 }
+
+var errAmbiguousTargetedNodeDelivery = errors.New("ambiguous targeted node delivery")
 
 type deliveryRecipientCandidate struct {
 	ID                string
@@ -129,7 +132,11 @@ func (p deliveryPlanner) Plan(ctx context.Context, evt events.Event) (eventDeliv
 	routePlan.AddDeliveryIntents(routedRootInputFlowNodeDeliveryIntentsForNoTargetEvent(evt, routing.RoutedRecipients)...)
 	routePlan.AddDeliveryIntents(routedNodeDeliveryIntentsForNoRecipientFlowInstanceEvent(evt, routing.RoutedRecipients, recipients, persisted)...)
 	routePlan.AddDeliveryIntents(routedNodeDeliveryIntentsForNoTargetEvent(evt, routing.RoutedRecipients, recipients, persisted)...)
-	routePlan.AddDeliveryIntents(targetedRoutedNodeDeliveryIntents(evt, routing.RoutedRecipients)...)
+	targetedIntents, err := targetedRoutedNodeDeliveryIntents(evt, routing.RoutedRecipients)
+	if err != nil {
+		return eventDeliveryPlan{}, err
+	}
+	routePlan.AddDeliveryIntents(targetedIntents...)
 	routePlan.AddDeliveryIntents(internalDeliveryIntentsForPlan(evt, recipients, persisted, routing.RoutedRecipients)...)
 	if routePlan.TargetFailure != "" && hasInternalRoutedSubscriberForTarget(evt, routing.RoutedRecipients) {
 		routePlan.TargetFailure = ""
@@ -458,18 +465,21 @@ func internalDeliveryIntentsForPlan(evt events.Event, recipients, persisted []st
 	return routePlanDeliveryIntentsFromRoutes(out, routePlanSourceInternalTarget, routePlanReasonInternalCarrier)
 }
 
-func targetedRoutedNodeDeliveryIntents(evt events.Event, routed []Subscriber) []RoutePlanDeliveryIntent {
-	routes := targetedRoutedNodeDeliveryRoutes(evt, routed)
-	if len(routes) == 0 {
-		return nil
+func targetedRoutedNodeDeliveryIntents(evt events.Event, routed []Subscriber) ([]RoutePlanDeliveryIntent, error) {
+	routes, err := targetedRoutedNodeDeliveryRoutes(evt, routed)
+	if err != nil {
+		return nil, err
 	}
-	return routePlanDeliveryIntentsFromRoutes(routes, routePlanSourceInternalTarget, routePlanReasonRouteTableNode)
+	if len(routes) == 0 {
+		return nil, nil
+	}
+	return routePlanDeliveryIntentsFromRoutes(routes, routePlanSourceInternalTarget, routePlanReasonRouteTableNode), nil
 }
 
-func targetedRoutedNodeDeliveryRoutes(evt events.Event, routed []Subscriber) []events.DeliveryRoute {
+func targetedRoutedNodeDeliveryRoutes(evt events.Event, routed []Subscriber) ([]events.DeliveryRoute, error) {
 	targets := eventDeliveryTargetRoutes(evt)
 	if len(targets) == 0 || len(routed) == 0 {
-		return nil
+		return nil, nil
 	}
 	out := make([]events.DeliveryRoute, 0, len(targets)*len(routed))
 	for _, target := range targets {
@@ -492,7 +502,33 @@ func targetedRoutedNodeDeliveryRoutes(evt events.Event, routed []Subscriber) []e
 			})
 		}
 	}
-	return events.NormalizeDeliveryRoutes(out)
+	out = events.NormalizeDeliveryRoutes(out)
+	if err := rejectAmbiguousTargetedNodeDeliveryRoutes(out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func rejectAmbiguousTargetedNodeDeliveryRoutes(routes []events.DeliveryRoute) error {
+	if len(routes) < 2 {
+		return nil
+	}
+	seen := make(map[string]events.RouteIdentity, len(routes))
+	for _, route := range routes {
+		if route.SubscriberType != "node" {
+			continue
+		}
+		key := strings.TrimSpace(route.SubscriberType) + "\x00" + strings.TrimSpace(route.SubscriberID)
+		if key == "\x00" {
+			continue
+		}
+		target := route.Target.Normalized()
+		if previous, ok := seen[key]; ok && previous != target {
+			return fmt.Errorf("%w: node %q has multiple target routes for one event", errAmbiguousTargetedNodeDelivery, route.SubscriberID)
+		}
+		seen[key] = target
+	}
+	return nil
 }
 
 func routedNodeDeliveryIntentsForNoTargetEvent(evt events.Event, routed []Subscriber, recipients, persisted []string) []RoutePlanDeliveryIntent {

--- a/internal/runtime/bus/delivery_planner.go
+++ b/internal/runtime/bus/delivery_planner.go
@@ -129,6 +129,7 @@ func (p deliveryPlanner) Plan(ctx context.Context, evt events.Event) (eventDeliv
 	routePlan.AddDeliveryIntents(routedRootInputFlowNodeDeliveryIntentsForNoTargetEvent(evt, routing.RoutedRecipients)...)
 	routePlan.AddDeliveryIntents(routedNodeDeliveryIntentsForNoRecipientFlowInstanceEvent(evt, routing.RoutedRecipients, recipients, persisted)...)
 	routePlan.AddDeliveryIntents(routedNodeDeliveryIntentsForNoTargetEvent(evt, routing.RoutedRecipients, recipients, persisted)...)
+	routePlan.AddDeliveryIntents(targetedRoutedNodeDeliveryIntents(evt, routing.RoutedRecipients)...)
 	routePlan.AddDeliveryIntents(internalDeliveryIntentsForPlan(evt, recipients, persisted, routing.RoutedRecipients)...)
 	if routePlan.TargetFailure != "" && hasInternalRoutedSubscriberForTarget(evt, routing.RoutedRecipients) {
 		routePlan.TargetFailure = ""
@@ -261,6 +262,37 @@ func routedEventKeysForPlan(evt events.Event) []string {
 	out := []string{eventType}
 	if concrete := concreteFlowInstanceEventKey(evt); concrete != "" {
 		out = append(out, concrete)
+	}
+	out = append(out, targetedConcreteEventKeysForPlan(evt)...)
+	return uniqueStrings(out)
+}
+
+func targetedConcreteEventKeysForPlan(evt events.Event) []string {
+	eventType := strings.Trim(strings.TrimSpace(string(evt.Type())), "/")
+	if eventType == "" {
+		return nil
+	}
+	targets := eventDeliveryTargetRoutes(evt)
+	if len(targets) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(targets))
+	for _, target := range targets {
+		target = target.Normalized()
+		flowInstance := strings.Trim(strings.TrimSpace(target.FlowInstance), "/")
+		if flowInstance == "" {
+			continue
+		}
+		staticScope := runtimeflowidentity.SemanticScopeFromInstancePath(flowInstance)
+		if staticScope == "" {
+			continue
+		}
+		localEvent := eventContextLocalEventForFlowInstance(eventType, staticScope)
+		if localEvent == "" {
+			continue
+		}
+		out = append(out, flowInstance+"/"+localEvent)
+		out = append(out, localEvent)
 	}
 	return uniqueStrings(out)
 }
@@ -424,6 +456,43 @@ func internalDeliveryIntentsForPlan(evt events.Event, recipients, persisted []st
 		}
 	}
 	return routePlanDeliveryIntentsFromRoutes(out, routePlanSourceInternalTarget, routePlanReasonInternalCarrier)
+}
+
+func targetedRoutedNodeDeliveryIntents(evt events.Event, routed []Subscriber) []RoutePlanDeliveryIntent {
+	routes := targetedRoutedNodeDeliveryRoutes(evt, routed)
+	if len(routes) == 0 {
+		return nil
+	}
+	return routePlanDeliveryIntentsFromRoutes(routes, routePlanSourceInternalTarget, routePlanReasonRouteTableNode)
+}
+
+func targetedRoutedNodeDeliveryRoutes(evt events.Event, routed []Subscriber) []events.DeliveryRoute {
+	targets := eventDeliveryTargetRoutes(evt)
+	if len(targets) == 0 || len(routed) == 0 {
+		return nil
+	}
+	out := make([]events.DeliveryRoute, 0, len(targets)*len(routed))
+	for _, target := range targets {
+		target = target.Normalized()
+		if target.Empty() {
+			continue
+		}
+		for _, subscriber := range routed {
+			subscriberID := strings.TrimSpace(subscriber.ID)
+			if subscriberID == "" || strings.TrimSpace(subscriber.Type) != "node" {
+				continue
+			}
+			if !routeMatchesInternalSubscriber(target, subscriber) {
+				continue
+			}
+			out = append(out, events.DeliveryRoute{
+				SubscriberType: "node",
+				SubscriberID:   subscriberID,
+				Target:         target,
+			})
+		}
+	}
+	return events.NormalizeDeliveryRoutes(out)
 }
 
 func routedNodeDeliveryIntentsForNoTargetEvent(evt events.Event, routed []Subscriber, recipients, persisted []string) []RoutePlanDeliveryIntent {

--- a/internal/runtime/bus/delivery_planner_test.go
+++ b/internal/runtime/bus/delivery_planner_test.go
@@ -450,7 +450,7 @@ func TestDeliveryPlanner_ExpandsTargetSetForInternalWorkflowRecipient(t *testing
 	}
 }
 
-func TestDeliveryPlanner_RejectsAmbiguousTargetSetForSameSemanticNode(t *testing.T) {
+func TestDeliveryPlanner_ExpandsTargetSetForSameSemanticNode(t *testing.T) {
 	planner := newDeliveryPlanner(
 		deliveryRouteResolver{
 			resolveRoutedSubscribers: func(events.Event) []Subscriber {
@@ -473,12 +473,26 @@ func TestDeliveryPlanner_RejectsAmbiguousTargetSetForSameSemanticNode(t *testing
 		},
 	)
 
-	_, err := planner.Plan(context.Background(), (events.NewProjectionEvent("", "worker/work.assign", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{})).WithTargetSet([]events.RouteIdentity{
+	plan, err := planner.Plan(context.Background(), (events.NewProjectionEvent("", "worker/work.assign", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{})).WithTargetSet([]events.RouteIdentity{
 		{FlowInstance: "worker/w-001", EntityID: "worker/w-001"},
 		{FlowInstance: "worker/w-002", EntityID: "worker/w-002"},
 	}))
-	if !errors.Is(err, errAmbiguousTargetedNodeDelivery) {
-		t.Fatalf("Plan error = %v, want ambiguous targeted node delivery", err)
+	if err != nil {
+		t.Fatalf("Plan: %v", err)
+	}
+	wantRoutes := []events.DeliveryRoute{
+		{SubscriberType: "node", SubscriberID: "task-handler", Target: events.RouteIdentity{FlowInstance: "worker/w-001", EntityID: "worker/w-001"}},
+		{SubscriberType: "node", SubscriberID: "task-handler", Target: events.RouteIdentity{FlowInstance: "worker/w-002", EntityID: "worker/w-002"}},
+		{SubscriberType: "node", SubscriberID: "workflow-runtime", Target: events.RouteIdentity{FlowInstance: "worker/w-001", EntityID: "worker/w-001"}},
+		{SubscriberType: "node", SubscriberID: "workflow-runtime", Target: events.RouteIdentity{FlowInstance: "worker/w-002", EntityID: "worker/w-002"}},
+	}
+	if got := len(plan.DeliveryRoutes); got != len(wantRoutes) {
+		t.Fatalf("delivery routes = %#v, want %d same-node target routes", plan.DeliveryRoutes, len(wantRoutes))
+	}
+	for _, wantRoute := range wantRoutes {
+		if !deliveryPlannerRoutesContain(plan.DeliveryRoutes, wantRoute) {
+			t.Fatalf("delivery routes = %#v, missing %#v", plan.DeliveryRoutes, wantRoute)
+		}
 	}
 }
 

--- a/internal/runtime/bus/delivery_planner_test.go
+++ b/internal/runtime/bus/delivery_planner_test.go
@@ -303,6 +303,57 @@ func TestDeliveryPlanner_DoesNotDeadLetterTargetedWorkflowNodeSubscriber(t *test
 	if plan.TargetFailure != "" {
 		t.Fatalf("target failure = %q, want none for routed workflow node subscriber", plan.TargetFailure)
 	}
+	wantRoute := events.DeliveryRoute{
+		SubscriberType: "node",
+		SubscriberID:   "parent-listener",
+		Target:         events.RouteIdentity{EntityID: "ent-1"},
+	}
+	if len(plan.DeliveryRoutes) != 1 || !deliveryPlannerRoutesContain(plan.DeliveryRoutes, wantRoute) {
+		t.Fatalf("delivery routes = %#v, want semantic node route %#v", plan.DeliveryRoutes, wantRoute)
+	}
+	if got, want := len(plan.RoutePlan.DeliveryIntents), 1; got != want {
+		t.Fatalf("route plan delivery intents = %d, want %d", got, want)
+	}
+	intent := plan.RoutePlan.DeliveryIntents[0]
+	if intent.Source != routePlanSourceInternalTarget || intent.Reason != routePlanReasonRouteTableNode {
+		t.Fatalf("route plan delivery intent = %#v, want internal targeted route-table node authority", intent)
+	}
+}
+
+func TestDeliveryPlanner_TargetedParentRoutePersistsSemanticNodeRoute(t *testing.T) {
+	planner := newDeliveryPlanner(
+		deliveryRouteResolver{
+			resolveRoutedSubscribers: func(events.Event) []Subscriber {
+				return []Subscriber{{ID: "parent-collector", Type: "node", Path: "parent/inst-1"}}
+			},
+			resolveSubscribedRecipients: func(string) []deliveryRecipientCandidate { return nil },
+			describeSubscribersForEvent: func(string, []Subscriber) []PublishDiagnosticRecipient {
+				return []PublishDiagnosticRecipient{{ID: "parent-collector", Type: "node", Path: "parent/inst-1"}}
+			},
+		},
+		deliveryRecipientPolicy{
+			loadActiveAgentDescriptors: func(context.Context) (map[string]ActiveAgentDescriptor, bool, error) {
+				return map[string]ActiveAgentDescriptor{}, true, nil
+			},
+		},
+	)
+
+	parentRoute := events.RouteIdentity{EntityID: "parent-entity", FlowInstance: "parent/inst-1"}
+	plan, err := planner.Plan(context.Background(), (events.NewProjectionEvent("", "child/output.done", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{})).WithTargetRoute(parentRoute))
+	if err != nil {
+		t.Fatalf("Plan: %v", err)
+	}
+	if plan.TargetFailure != "" {
+		t.Fatalf("target failure = %q, want none for targeted ParentRoute node subscriber", plan.TargetFailure)
+	}
+	wantRoute := events.DeliveryRoute{
+		SubscriberType: "node",
+		SubscriberID:   "parent-collector",
+		Target:         parentRoute,
+	}
+	if len(plan.DeliveryRoutes) != 1 || !deliveryPlannerRoutesContain(plan.DeliveryRoutes, wantRoute) {
+		t.Fatalf("delivery routes = %#v, want ParentRoute semantic node route %#v", plan.DeliveryRoutes, wantRoute)
+	}
 }
 
 func TestDeliveryPlanner_PreservesTargetFailureWhenRoutedNodeDoesNotMatchTarget(t *testing.T) {
@@ -368,24 +419,34 @@ func TestDeliveryPlanner_ExpandsTargetSetForInternalWorkflowRecipient(t *testing
 	if got := plan.Recipients; len(got) != 1 || got[0] != "workflow-runtime" {
 		t.Fatalf("recipients = %#v, want [workflow-runtime]", got)
 	}
-	if got := plan.DeliveryRoutes; len(got) != 2 {
-		t.Fatalf("delivery routes = %#v, want 2 target routes", got)
+	if got := plan.DeliveryRoutes; len(got) != 4 {
+		t.Fatalf("delivery routes = %#v, want 4 target routes", got)
 	}
-	for _, route := range plan.DeliveryRoutes {
-		if route.SubscriberType != "node" || route.SubscriberID != "workflow-runtime" {
-			t.Fatalf("delivery route = %#v, want node/workflow-runtime", route)
-		}
-		if route.Target.Empty() {
-			t.Fatalf("delivery route target is empty: %#v", route)
+	wantRoutes := []events.DeliveryRoute{
+		{SubscriberType: "node", SubscriberID: "child-a-listener", Target: events.RouteIdentity{FlowInstance: "child-a/inst-1", EntityID: "ent-a"}},
+		{SubscriberType: "node", SubscriberID: "child-b-listener", Target: events.RouteIdentity{FlowInstance: "child-b/inst-1", EntityID: "ent-b"}},
+		{SubscriberType: "node", SubscriberID: "workflow-runtime", Target: events.RouteIdentity{FlowInstance: "child-a/inst-1", EntityID: "ent-a"}},
+		{SubscriberType: "node", SubscriberID: "workflow-runtime", Target: events.RouteIdentity{FlowInstance: "child-b/inst-1", EntityID: "ent-b"}},
+	}
+	for _, wantRoute := range wantRoutes {
+		if !deliveryPlannerRoutesContain(plan.DeliveryRoutes, wantRoute) {
+			t.Fatalf("delivery routes = %#v, missing %#v", plan.DeliveryRoutes, wantRoute)
 		}
 	}
-	if got, want := len(plan.RoutePlan.DeliveryIntents), 2; got != want {
+	if got, want := len(plan.RoutePlan.DeliveryIntents), 4; got != want {
 		t.Fatalf("route plan delivery intents = %d, want %d", got, want)
 	}
+	var semanticNodeRoutes, carrierRoutes int
 	for _, intent := range plan.RoutePlan.DeliveryIntents {
-		if intent.Source != routePlanSourceInternalTarget || intent.Reason != routePlanReasonInternalCarrier {
-			t.Fatalf("route plan delivery intent = %#v, want internal target carrier source", intent)
+		if intent.Source == routePlanSourceInternalTarget && intent.Reason == routePlanReasonRouteTableNode && (intent.SubscriberID == "child-a-listener" || intent.SubscriberID == "child-b-listener") {
+			semanticNodeRoutes++
 		}
+		if intent.Source == routePlanSourceInternalTarget && intent.Reason == routePlanReasonInternalCarrier && intent.SubscriberID == "workflow-runtime" {
+			carrierRoutes++
+		}
+	}
+	if semanticNodeRoutes != 2 || carrierRoutes != 2 {
+		t.Fatalf("route plan delivery intents = %#v, want 2 semantic node routes and 2 internal carrier routes", plan.RoutePlan.DeliveryIntents)
 	}
 }
 
@@ -530,6 +591,16 @@ func TestRoutedEventKeysForPlan_RuntimeCallbackLocalEventWithFlowInstanceDerives
 			}
 		})
 	}
+}
+
+func deliveryPlannerRoutesContain(routes []events.DeliveryRoute, want events.DeliveryRoute) bool {
+	want = want.Normalized()
+	for _, got := range events.NormalizeDeliveryRoutes(routes) {
+		if got == want {
+			return true
+		}
+	}
+	return false
 }
 
 func TestResolveInternalRecipientsForRoutedNodePlanning_DoesNotSelectParentConcreteRouteForNestedSemanticScope(t *testing.T) {

--- a/internal/runtime/bus/delivery_planner_test.go
+++ b/internal/runtime/bus/delivery_planner_test.go
@@ -450,6 +450,38 @@ func TestDeliveryPlanner_ExpandsTargetSetForInternalWorkflowRecipient(t *testing
 	}
 }
 
+func TestDeliveryPlanner_RejectsAmbiguousTargetSetForSameSemanticNode(t *testing.T) {
+	planner := newDeliveryPlanner(
+		deliveryRouteResolver{
+			resolveRoutedSubscribers: func(events.Event) []Subscriber {
+				return []Subscriber{
+					{ID: "task-handler", Type: "node", Path: "worker/w-001"},
+					{ID: "task-handler", Type: "node", Path: "worker/w-002"},
+				}
+			},
+			resolveSubscribedRecipients: func(string) []deliveryRecipientCandidate {
+				return []deliveryRecipientCandidate{{ID: "workflow-runtime", PersistAsDelivery: false}}
+			},
+			describeSubscribersForEvent: func(string, []Subscriber) []PublishDiagnosticRecipient {
+				return nil
+			},
+		},
+		deliveryRecipientPolicy{
+			loadActiveAgentDescriptors: func(context.Context) (map[string]ActiveAgentDescriptor, bool, error) {
+				return map[string]ActiveAgentDescriptor{}, true, nil
+			},
+		},
+	)
+
+	_, err := planner.Plan(context.Background(), (events.NewProjectionEvent("", "worker/work.assign", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{})).WithTargetSet([]events.RouteIdentity{
+		{FlowInstance: "worker/w-001", EntityID: "worker/w-001"},
+		{FlowInstance: "worker/w-002", EntityID: "worker/w-002"},
+	}))
+	if !errors.Is(err, errAmbiguousTargetedNodeDelivery) {
+		t.Fatalf("Plan error = %v, want ambiguous targeted node delivery", err)
+	}
+}
+
 func TestDeliveryPlanner_NoTargetConcreteRoutedNodePersistsSemanticNodeRoute(t *testing.T) {
 	planner := newDeliveryPlanner(
 		deliveryRouteResolver{

--- a/internal/runtime/bus/eventbus_target_routes_test.go
+++ b/internal/runtime/bus/eventbus_target_routes_test.go
@@ -2,6 +2,7 @@ package bus
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -506,6 +507,50 @@ func TestEventBusPublish_TargetSetInternalDeliveryUsesPerTargetRoutes(t *testing
 		t.Fatalf("PublishPersistedRecipients: %v", err)
 	}
 	assertTargetRouteDeliveries(t, ch, "ent-a", "ent-b")
+}
+
+func TestEventBusPublish_RejectsAmbiguousTargetSetForSameSemanticNode(t *testing.T) {
+	store := newTargetRouteMemoryStore()
+	eb, err := NewEventBus(store)
+	if err != nil {
+		t.Fatalf("NewEventBus: %v", err)
+	}
+	eb.deliveryPlanner = newDeliveryPlanner(
+		deliveryRouteResolver{
+			resolveRoutedSubscribers: func(events.Event) []Subscriber {
+				return []Subscriber{
+					{ID: "task-handler", Type: "node", Path: "worker/w-001"},
+					{ID: "task-handler", Type: "node", Path: "worker/w-002"},
+				}
+			},
+			resolveSubscribedRecipients: func(string) []deliveryRecipientCandidate {
+				return []deliveryRecipientCandidate{{ID: "workflow-runtime", PersistAsDelivery: false}}
+			},
+			describeSubscribersForEvent: func(string, []Subscriber) []PublishDiagnosticRecipient {
+				return nil
+			},
+		},
+		deliveryRecipientPolicy{
+			loadActiveAgentDescriptors: func(context.Context) (map[string]ActiveAgentDescriptor, bool, error) {
+				return map[string]ActiveAgentDescriptor{}, true, nil
+			},
+		},
+	)
+
+	evt := (events.NewProjectionEvent(uuid.NewString(),
+		events.EventType("worker/work.assign"), "", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())).WithTargetSet([]events.RouteIdentity{
+		{FlowInstance: "worker/w-001", EntityID: "worker/w-001"},
+		{FlowInstance: "worker/w-002", EntityID: "worker/w-002"},
+	})
+	if err := eb.Publish(context.Background(), evt); !errors.Is(err, errAmbiguousTargetedNodeDelivery) {
+		t.Fatalf("Publish error = %v, want ambiguous targeted node delivery", err)
+	}
+	if _, ok := store.events[evt.ID()]; ok {
+		t.Fatalf("event %q persisted despite ambiguous targeted node delivery", evt.ID())
+	}
+	if routes := store.routes[evt.ID()]; len(routes) != 0 {
+		t.Fatalf("persisted delivery routes = %#v, want none for ambiguous targeted node delivery", routes)
+	}
 }
 
 func TestEventBusPublish_TargetedRouteTableNodePersistsSemanticNodeRoute(t *testing.T) {

--- a/internal/runtime/bus/eventbus_target_routes_test.go
+++ b/internal/runtime/bus/eventbus_target_routes_test.go
@@ -487,15 +487,18 @@ func TestEventBusPublish_TargetSetInternalDeliveryUsesPerTargetRoutes(t *testing
 	if got := persisted.FlowInstance(); got != "" {
 		t.Fatalf("persisted FlowInstance() = %q, want empty target_set projection", got)
 	}
-	if got := store.routes[evt.ID()]; len(got) != 2 {
-		t.Fatalf("persisted delivery routes = %#v, want 2", got)
+	if got := store.routes[evt.ID()]; len(got) != 4 {
+		t.Fatalf("persisted delivery routes = %#v, want 4", got)
 	}
-	for _, route := range store.routes[evt.ID()] {
-		if route.SubscriberType != "node" || route.SubscriberID != "workflow-runtime" {
-			t.Fatalf("delivery route = %#v, want node/workflow-runtime", route)
-		}
-		if route.Target.Empty() {
-			t.Fatalf("delivery route target is empty: %#v", route)
+	wantRoutes := []events.DeliveryRoute{
+		{SubscriberType: "node", SubscriberID: "child-a-listener", Target: events.RouteIdentity{FlowInstance: "child-a/inst-1", EntityID: "ent-a"}},
+		{SubscriberType: "node", SubscriberID: "child-b-listener", Target: events.RouteIdentity{FlowInstance: "child-b/inst-1", EntityID: "ent-b"}},
+		{SubscriberType: "node", SubscriberID: "workflow-runtime", Target: events.RouteIdentity{FlowInstance: "child-a/inst-1", EntityID: "ent-a"}},
+		{SubscriberType: "node", SubscriberID: "workflow-runtime", Target: events.RouteIdentity{FlowInstance: "child-b/inst-1", EntityID: "ent-b"}},
+	}
+	for _, wantRoute := range wantRoutes {
+		if !deliveryRoutesContain(store.routes[evt.ID()], wantRoute) {
+			t.Fatalf("persisted delivery routes = %#v, missing %#v", store.routes[evt.ID()], wantRoute)
 		}
 	}
 
@@ -503,6 +506,145 @@ func TestEventBusPublish_TargetSetInternalDeliveryUsesPerTargetRoutes(t *testing
 		t.Fatalf("PublishPersistedRecipients: %v", err)
 	}
 	assertTargetRouteDeliveries(t, ch, "ent-a", "ent-b")
+}
+
+func TestEventBusPublish_TargetedRouteTableNodePersistsSemanticNodeRoute(t *testing.T) {
+	store := newTargetRouteMemoryStore()
+	eb, err := NewEventBus(store)
+	if err != nil {
+		t.Fatalf("NewEventBus: %v", err)
+	}
+	eb.deliveryPlanner = newDeliveryPlanner(
+		deliveryRouteResolver{
+			resolveRoutedSubscribers: func(events.Event) []Subscriber {
+				return []Subscriber{{ID: "task-handler", Type: "node", Path: "worker/w-001"}}
+			},
+			resolveSubscribedRecipients: func(string) []deliveryRecipientCandidate { return nil },
+			describeSubscribersForEvent: func(string, []Subscriber) []PublishDiagnosticRecipient {
+				return []PublishDiagnosticRecipient{{ID: "task-handler", Type: "node", Path: "worker/w-001"}}
+			},
+		},
+		deliveryRecipientPolicy{
+			loadActiveAgentDescriptors: func(context.Context) (map[string]ActiveAgentDescriptor, bool, error) {
+				return map[string]ActiveAgentDescriptor{}, true, nil
+			},
+		},
+	)
+	evt := (events.NewProjectionEvent(uuid.NewString(),
+		events.EventType("worker/work.assign"), "", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())).
+		WithTargetRoute(events.RouteIdentity{FlowInstance: "worker/w-001", EntityID: "worker/w-001"})
+
+	if err := eb.Publish(context.Background(), evt); err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+	wantRoute := events.DeliveryRoute{
+		SubscriberType: "node",
+		SubscriberID:   "task-handler",
+		Target:         events.RouteIdentity{FlowInstance: "worker/w-001", EntityID: "worker/w-001"},
+	}
+	if got := store.routes[evt.ID()]; len(got) != 1 || !deliveryRoutesContain(got, wantRoute) {
+		t.Fatalf("persisted delivery routes = %#v, want semantic node route %#v", got, wantRoute)
+	}
+}
+
+func TestEventBusPublish_TargetedTemplateInstanceRouteTableNodePersistsSemanticNodeRoute(t *testing.T) {
+	store := newTargetRouteMemoryStore()
+	source := semanticview.Wrap(routedNodeTemplateBundle())
+	eb, err := NewEventBusWithOptions(store, EventBusOptions{ContractBundle: source})
+	if err != nil {
+		t.Fatalf("NewEventBusWithOptions: %v", err)
+	}
+	if err := eb.AddFlowInstanceRoute(FlowInstanceRouteMaterializationRequest{Identity: runtimeflowidentity.DeriveRoute("operating", "inst-1")}); err != nil {
+		t.Fatalf("AddFlowInstanceRoute: %v", err)
+	}
+	evt := (events.NewProjectionEvent(uuid.NewString(),
+		events.EventType("operating/opco.product_initialization_requested"), "", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())).
+		WithTargetRoute(events.RouteIdentity{FlowInstance: "operating/inst-1", EntityID: "ent-operating"})
+
+	plan, err := eb.CheckPublishRecipientPlan(context.Background(), evt)
+	if err != nil {
+		t.Fatalf("CheckPublishRecipientPlan: %v", err)
+	}
+	if len(plan.RoutedRecipients) != 1 || plan.RoutedRecipients[0].ID != "lifecycle-orchestrator" || plan.RoutedRecipients[0].Path != "operating/inst-1" {
+		t.Fatalf("routed recipients = %#v, want targeted lifecycle-orchestrator concrete instance route", plan.RoutedRecipients)
+	}
+	wantRoute := events.DeliveryRoute{
+		SubscriberType: "node",
+		SubscriberID:   "lifecycle-orchestrator",
+		Target: events.RouteIdentity{
+			FlowInstance: "operating/inst-1",
+			EntityID:     "ent-operating",
+		},
+	}
+	if len(plan.DeliveryRoutes) != 1 || !deliveryRoutesContain(plan.DeliveryRoutes, wantRoute) {
+		t.Fatalf("plan delivery routes = %#v, want semantic node route %#v", plan.DeliveryRoutes, wantRoute)
+	}
+
+	if err := eb.Publish(context.Background(), evt); err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+	if got := store.routes[evt.ID()]; len(got) != 1 || !deliveryRoutesContain(got, wantRoute) {
+		t.Fatalf("persisted delivery routes = %#v, want semantic node route %#v", got, wantRoute)
+	}
+}
+
+func TestEventBusPublish_TargetedDynamicFlowFixtureRouteTableNodePersistsSemanticNodeRoute(t *testing.T) {
+	store := newTargetRouteMemoryStore()
+	repoRoot := filepath.Clean(filepath.Join("..", "..", ".."))
+	fixtureRoot := filepath.Join(repoRoot, "tests", "tier11-flow-composition", "test-dynamic-flow-instance")
+	platformSpec := runtimecontracts.DefaultPlatformSpecFile(repoRoot)
+	bundle, err := runtimecontracts.LoadWorkflowContractBundleWithOverrides(repoRoot, fixtureRoot, platformSpec)
+	if err != nil {
+		t.Fatalf("load fixture bundle: %v", err)
+	}
+	eb, err := NewEventBusWithOptions(store, EventBusOptions{ContractBundle: semanticview.Wrap(bundle)})
+	if err != nil {
+		t.Fatalf("NewEventBusWithOptions: %v", err)
+	}
+	if err := eb.AddFlowInstanceRoute(FlowInstanceRouteMaterializationRequest{Identity: runtimeflowidentity.DeriveRoute("worker", "w-001")}); err != nil {
+		t.Fatalf("AddFlowInstanceRoute: %v", err)
+	}
+	materialized := eb.RouteTable().MaterializedRoutes(runtimeflowidentity.DeriveRoute("worker", "w-001"))
+	if len(materialized) != 1 || materialized[0].EventPattern != "work.assign" || materialized[0].SubscriberID != "task-handler" {
+		t.Fatalf("materialized routes = %#v, want task-handler local work.assign route; node entries=%v", materialized, sortedStringKeys(bundle.NodeEntries()))
+	}
+	target := events.RouteIdentity{
+		FlowInstance: "worker/w-001",
+		EntityID:     runtimeflowidentity.EntityID("worker/w-001"),
+	}
+	evt := (events.NewProjectionEvent(uuid.NewString(),
+		events.EventType("worker/work.assign"), "", "", []byte(`{"task_label":"route-me"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())).
+		WithTargetRoute(target)
+
+	plan, err := eb.CheckPublishRecipientPlan(context.Background(), evt)
+	if err != nil {
+		t.Fatalf("CheckPublishRecipientPlan: %v", err)
+	}
+	foundConcreteSubscriber := false
+	for _, recipient := range plan.RoutedRecipients {
+		if recipient.ID == "task-handler" && recipient.Path == "worker/w-001" {
+			foundConcreteSubscriber = true
+			break
+		}
+	}
+	if !foundConcreteSubscriber {
+		t.Fatalf("routed recipients = %#v, want targeted task-handler concrete worker route", plan.RoutedRecipients)
+	}
+	wantRoute := events.DeliveryRoute{
+		SubscriberType: "node",
+		SubscriberID:   "task-handler",
+		Target:         target,
+	}
+	if len(plan.DeliveryRoutes) != 1 || !deliveryRoutesContain(plan.DeliveryRoutes, wantRoute) {
+		t.Fatalf("plan delivery routes = %#v, want semantic node route %#v", plan.DeliveryRoutes, wantRoute)
+	}
+
+	if err := eb.Publish(context.Background(), evt); err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+	if got := store.routes[evt.ID()]; len(got) != 1 || !deliveryRoutesContain(got, wantRoute) {
+		t.Fatalf("persisted delivery routes = %#v, want semantic node route %#v", got, wantRoute)
+	}
 }
 
 func TestEventBusPublish_NoTargetConcreteRoutedNodePersistsSemanticNodeRoute(t *testing.T) {

--- a/internal/runtime/bus/eventbus_target_routes_test.go
+++ b/internal/runtime/bus/eventbus_target_routes_test.go
@@ -2,7 +2,6 @@ package bus
 
 import (
 	"context"
-	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -509,7 +508,7 @@ func TestEventBusPublish_TargetSetInternalDeliveryUsesPerTargetRoutes(t *testing
 	assertTargetRouteDeliveries(t, ch, "ent-a", "ent-b")
 }
 
-func TestEventBusPublish_RejectsAmbiguousTargetSetForSameSemanticNode(t *testing.T) {
+func TestEventBusPublish_TargetSetSameSemanticNodePersistsPerTargetRoutes(t *testing.T) {
 	store := newTargetRouteMemoryStore()
 	eb, err := NewEventBus(store)
 	if err != nil {
@@ -537,19 +536,29 @@ func TestEventBusPublish_RejectsAmbiguousTargetSetForSameSemanticNode(t *testing
 		},
 	)
 
+	ch := eb.SubscribeInternal("workflow-runtime", events.EventType("worker/work.assign"))
 	evt := (events.NewProjectionEvent(uuid.NewString(),
 		events.EventType("worker/work.assign"), "", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())).WithTargetSet([]events.RouteIdentity{
 		{FlowInstance: "worker/w-001", EntityID: "worker/w-001"},
 		{FlowInstance: "worker/w-002", EntityID: "worker/w-002"},
 	})
-	if err := eb.Publish(context.Background(), evt); !errors.Is(err, errAmbiguousTargetedNodeDelivery) {
-		t.Fatalf("Publish error = %v, want ambiguous targeted node delivery", err)
+	if err := eb.Publish(context.Background(), evt); err != nil {
+		t.Fatalf("Publish: %v", err)
 	}
-	if _, ok := store.events[evt.ID()]; ok {
-		t.Fatalf("event %q persisted despite ambiguous targeted node delivery", evt.ID())
+	assertTargetRouteDeliveries(t, ch, "worker/w-001", "worker/w-002")
+	wantRoutes := []events.DeliveryRoute{
+		{SubscriberType: "node", SubscriberID: "task-handler", Target: events.RouteIdentity{FlowInstance: "worker/w-001", EntityID: "worker/w-001"}},
+		{SubscriberType: "node", SubscriberID: "task-handler", Target: events.RouteIdentity{FlowInstance: "worker/w-002", EntityID: "worker/w-002"}},
+		{SubscriberType: "node", SubscriberID: "workflow-runtime", Target: events.RouteIdentity{FlowInstance: "worker/w-001", EntityID: "worker/w-001"}},
+		{SubscriberType: "node", SubscriberID: "workflow-runtime", Target: events.RouteIdentity{FlowInstance: "worker/w-002", EntityID: "worker/w-002"}},
 	}
-	if routes := store.routes[evt.ID()]; len(routes) != 0 {
-		t.Fatalf("persisted delivery routes = %#v, want none for ambiguous targeted node delivery", routes)
+	if got := len(store.routes[evt.ID()]); got != len(wantRoutes) {
+		t.Fatalf("persisted delivery routes = %#v, want %d same-node target routes", store.routes[evt.ID()], len(wantRoutes))
+	}
+	for _, wantRoute := range wantRoutes {
+		if !deliveryRoutesContain(store.routes[evt.ID()], wantRoute) {
+			t.Fatalf("persisted delivery routes = %#v, missing %#v", store.routes[evt.ID()], wantRoute)
+		}
 	}
 }
 

--- a/internal/runtime/cataloge2e/tier11_flow_composition_e2e_test.go
+++ b/internal/runtime/cataloge2e/tier11_flow_composition_e2e_test.go
@@ -106,21 +106,22 @@ func TestTier11DynamicFlowInstanceFlowMatchTarget_RealRuntime(t *testing.T) {
 	var expected catalogExpectedDocument
 	loadYAML(t, filepath.Join(fixtureRoot, "expected.yaml"), &expected)
 
-	h := newRuntimeHarness(t, fixtureRoot, false)
+	h := newRuntimeHarness(t, fixtureRoot, true)
 	h.seedEntityFields(expected)
 	for _, step := range expected.triggerSequence() {
 		h.publishAndWait(step, catalogRuntimePublishTimeout)
 	}
 	assertCatalogRuntimeOutcome(t, h, expected)
-	assertDynamicFlowInstanceFlowMatchDescriptorResolution(t, h, "worker/work.assign", "worker/w-001")
+	assertDynamicFlowInstanceFlowMatchTargetedNodeDelivery(t, h, "worker/work.assign", "worker/w-001", "task-handler")
 }
 
-func assertDynamicFlowInstanceFlowMatchDescriptorResolution(t testing.TB, h *runtimeHarness, eventName, flowInstance string) {
+func assertDynamicFlowInstanceFlowMatchTargetedNodeDelivery(t testing.TB, h *runtimeHarness, eventName, flowInstance, nodeID string) {
 	t.Helper()
 	if h == nil || h.db == nil {
 		t.Fatal("runtime harness database is required")
 	}
 	flowInstance = strings.Trim(strings.TrimSpace(flowInstance), "/")
+	nodeID = strings.TrimSpace(nodeID)
 	wantEntityID := runtimeflowidentity.EntityID(flowInstance)
 	var eventID, targetFlowInstance, targetEntityID, targetSet string
 	err := h.db.QueryRowContext(context.Background(), `
@@ -143,39 +144,89 @@ func assertDynamicFlowInstanceFlowMatchDescriptorResolution(t testing.TB, h *run
 		t.Fatalf("targeted event route = flow_instance:%q entity_id:%q target_set:%s, want flow_instance:%q entity_id:%q", targetFlowInstance, targetEntityID, targetSet, flowInstance, wantEntityID)
 	}
 
+	var deliveryStatus, reasonCode, deliveryFlowInstance, deliveryEntityID string
+	if err := h.db.QueryRowContext(context.Background(), `
+		SELECT COALESCE(status, ''),
+		       COALESCE(reason_code, ''),
+		       COALESCE(delivery_target_route->>'flow_instance', ''),
+		       COALESCE(delivery_target_route->>'entity_id', '')
+		FROM event_deliveries
+		WHERE event_id = $1::uuid
+		  AND subscriber_type = 'node'
+		  AND subscriber_id = $2
+		  AND COALESCE(delivery_target_route->>'flow_instance', '') = $3
+		  AND COALESCE(delivery_target_route->>'entity_id', '') = $4
+		ORDER BY created_at DESC, delivery_id DESC
+		LIMIT 1
+	`, eventID, nodeID, flowInstance, wantEntityID).Scan(&deliveryStatus, &reasonCode, &deliveryFlowInstance, &deliveryEntityID); err == sql.ErrNoRows {
+		t.Fatalf("targeted event %s did not persist node delivery for %s route %s/%s; deliveries=%s", eventID, nodeID, flowInstance, wantEntityID, dumpEventDeliveries(t, h.db, eventID))
+	} else if err != nil {
+		t.Fatalf("query targeted event delivery: %v", err)
+	}
+	if deliveryStatus != "delivered" || reasonCode != "node_processed" || deliveryFlowInstance != flowInstance || deliveryEntityID != wantEntityID {
+		t.Fatalf("targeted event delivery = status:%q reason:%q route:%q/%q, want delivered node_processed for %q/%q", deliveryStatus, reasonCode, deliveryFlowInstance, deliveryEntityID, flowInstance, wantEntityID)
+	}
+
 	var deliveryCount int
 	if err := h.db.QueryRowContext(context.Background(), `
 		SELECT COUNT(*)
 		FROM event_deliveries
 		WHERE event_id = $1::uuid
 		  AND subscriber_type = 'node'
-		  AND COALESCE(delivery_target_route->>'flow_instance', '') = $2
-		  AND COALESCE(delivery_target_route->>'entity_id', '') = $3
-	`, eventID, flowInstance, wantEntityID).Scan(&deliveryCount); err != nil {
+		  AND subscriber_id = $2
+		  AND COALESCE(delivery_target_route->>'flow_instance', '') = $3
+		  AND COALESCE(delivery_target_route->>'entity_id', '') = $4
+	`, eventID, nodeID, flowInstance, wantEntityID).Scan(&deliveryCount); err != nil {
 		t.Fatalf("query targeted event deliveries: %v", err)
 	}
-	if deliveryCount != 0 {
-		t.Fatalf("targeted event %s node delivery count = %d, want 0 while #1410 owns targeted internal-node delivery row materialization", eventID, deliveryCount)
+	if deliveryCount != 1 {
+		t.Fatalf("targeted event %s node delivery count = %d, want exactly one %s semantic node delivery", eventID, deliveryCount, nodeID)
 	}
 
-	var failureReason, failureFlowInstance, failureEntityID string
-	err = h.db.QueryRowContext(context.Background(), `
-		SELECT COALESCE(target_failure_reason, ''),
-		       COALESCE(target_context->'target'->>'flow_instance', ''),
-		       COALESCE(target_context->'target'->>'entity_id', '')
+	var deadLetterCount int
+	if err := h.db.QueryRowContext(context.Background(), `
+		SELECT COUNT(*)
 		FROM dead_letters
 		WHERE original_event_id = $1::uuid
 		  AND failure_type = 'target_resolution_failed'
-		ORDER BY created_at DESC
-		LIMIT 1
-	`, eventID).Scan(&failureReason, &failureFlowInstance, &failureEntityID)
-	if err == sql.ErrNoRows {
-		t.Fatalf("targeted event %s did not record #1410 split delivery-planning dead letter", eventID)
+	`, eventID).Scan(&deadLetterCount); err != nil {
+		t.Fatalf("query targeted event dead letters: %v", err)
 	}
+	if deadLetterCount != 0 {
+		t.Fatalf("targeted event %s target_resolution_failed dead letters = %d, want none", eventID, deadLetterCount)
+	}
+}
+
+func dumpEventDeliveries(t testing.TB, db *sql.DB, eventID string) string {
+	t.Helper()
+	rows, err := db.QueryContext(context.Background(), `
+		SELECT COALESCE(subscriber_type, ''),
+		       COALESCE(subscriber_id, ''),
+		       COALESCE(status, ''),
+		       COALESCE(reason_code, ''),
+		       COALESCE(delivery_target_route->>'flow_instance', ''),
+		       COALESCE(delivery_target_route->>'entity_id', '')
+		FROM event_deliveries
+		WHERE event_id = $1::uuid
+		ORDER BY created_at ASC, delivery_id ASC
+	`, eventID)
 	if err != nil {
-		t.Fatalf("query targeted event dead letter: %v", err)
+		return "query_error:" + err.Error()
 	}
-	if failureReason != "target_not_subscribed" || failureFlowInstance != flowInstance || failureEntityID != wantEntityID {
-		t.Fatalf("targeted event dead letter reason=%q route=%q/%q, want target_not_subscribed for %q/%q", failureReason, failureFlowInstance, failureEntityID, flowInstance, wantEntityID)
+	defer rows.Close()
+	var out []string
+	for rows.Next() {
+		var subscriberType, subscriberID, status, reason, flowInstance, entityID string
+		if err := rows.Scan(&subscriberType, &subscriberID, &status, &reason, &flowInstance, &entityID); err != nil {
+			return "scan_error:" + err.Error()
+		}
+		out = append(out, subscriberType+"/"+subscriberID+" status="+status+" reason="+reason+" route="+flowInstance+"/"+entityID)
 	}
+	if err := rows.Err(); err != nil {
+		return "rows_error:" + err.Error()
+	}
+	if len(out) == 0 {
+		return "<none>"
+	}
+	return strings.Join(out, "; ")
 }

--- a/internal/runtime/pipeline/node_system_runner.go
+++ b/internal/runtime/pipeline/node_system_runner.go
@@ -355,6 +355,14 @@ func (n *systemNodeRunner) isProcessed(ctx context.Context, evt events.Event) bo
 	if !n.eventReceiptsAvailable(ctx) {
 		return false
 	}
+	if target := systemNodeDeliveryTarget(evt); !target.Empty() {
+		targetStore, ok := n.receiptStore.(SystemNodeTargetReceiptPersistence)
+		if !ok {
+			return false
+		}
+		ok, err := targetStore.SystemNodeProcessedForTarget(ctx, n.nodeID, eventID, target)
+		return err == nil && ok
+	}
 	ok, err := n.receiptStore.SystemNodeProcessed(ctx, n.nodeID, eventID)
 	return err == nil && ok
 }
@@ -370,8 +378,9 @@ func (n *systemNodeRunner) markProcessed(ctx context.Context, evt events.Event) 
 	if !n.eventReceiptsAvailable(ctx) {
 		return
 	}
-	sideEffects := systemNodeProcessedReceiptSideEffects(n.nodeID, eventID)
-	if err := n.persistProcessedReceiptAndSettleDelivery(ctx, eventID, sideEffects); err != nil {
+	target := systemNodeDeliveryTarget(evt)
+	sideEffects := systemNodeProcessedReceiptSideEffects(n.nodeID, eventID, target)
+	if err := n.persistProcessedReceiptAndSettleDelivery(ctx, eventID, target, sideEffects); err != nil {
 		slog.Error("system node mark processed failed", "node_id", n.nodeID, "event_id", eventID, "error", err)
 		if logger, ok := n.bus.(systemNodeRuntimeLogger); ok && logger != nil {
 			logger.LogRuntime(ctx, RuntimeLogEntry{
@@ -402,6 +411,19 @@ func (n *systemNodeRunner) markDeliveryInProgress(ctx context.Context, evt event
 	if !n.eventReceiptsAvailable(ctx) {
 		return false
 	}
+	if target := systemNodeDeliveryTarget(evt); !target.Empty() {
+		targetStore, ok := n.receiptStore.(SystemNodeTargetReceiptPersistence)
+		if !ok {
+			n.logSystemNodeDeliveryTransitionError(ctx, evt, "mark_delivery_in_progress_failed", "Marking the targeted system node delivery in progress failed", ErrSystemNodeDeliveryAuthorityMissing)
+			return false
+		}
+		if err := targetStore.MarkSystemNodeDeliveryInProgressForTarget(ctx, n.nodeID, eventID, target, n.effectiveRetryLimit()); err != nil {
+			n.logSystemNodeDeliveryTransitionError(ctx, evt, "mark_delivery_in_progress_failed", "Marking the targeted system node delivery in progress failed", err)
+			return false
+		}
+		n.notifyTestLifecycleDeliveryStatus(ctx, evt, "in_progress")
+		return true
+	}
 	if err := n.receiptStore.MarkSystemNodeDeliveryInProgress(ctx, n.nodeID, eventID, n.effectiveRetryLimit()); err != nil {
 		n.logSystemNodeDeliveryTransitionError(ctx, evt, "mark_delivery_in_progress_failed", "Marking the system node delivery in progress failed", err)
 		return false
@@ -425,6 +447,19 @@ func (n *systemNodeRunner) markDeliveryFailed(ctx context.Context, evt events.Ev
 	if cause != nil {
 		errText = strings.TrimSpace(cause.Error())
 	}
+	if target := systemNodeDeliveryTarget(evt); !target.Empty() {
+		targetStore, ok := n.receiptStore.(SystemNodeTargetReceiptPersistence)
+		if !ok {
+			n.logSystemNodeDeliveryTransitionError(ctx, evt, "mark_delivery_failed_failed", "Marking the targeted system node delivery as failed failed", ErrSystemNodeDeliveryAuthorityMissing)
+			return
+		}
+		if err := targetStore.MarkSystemNodeDeliveryFailedForTarget(ctx, n.nodeID, eventID, target, reasonCode, errText, retryCount, n.effectiveRetryLimit()); err != nil {
+			n.logSystemNodeDeliveryTransitionError(ctx, evt, "mark_delivery_failed_failed", "Marking the targeted system node delivery as failed failed", err)
+			return
+		}
+		n.notifyTestLifecycleDeliveryStatus(ctx, evt, "failed")
+		return
+	}
 	if err := n.receiptStore.MarkSystemNodeDeliveryFailed(ctx, n.nodeID, eventID, reasonCode, errText, retryCount, n.effectiveRetryLimit()); err != nil {
 		n.logSystemNodeDeliveryTransitionError(ctx, evt, "mark_delivery_failed_failed", "Marking the system node delivery as failed failed", err)
 		return
@@ -447,7 +482,22 @@ func (n *systemNodeRunner) markDeliveryDeadLetter(ctx context.Context, evt event
 	if cause != nil {
 		errText = strings.TrimSpace(cause.Error())
 	}
-	sideEffects := systemNodeDeadLetterReceiptSideEffects(n.nodeID, eventID, reasonCode, errText, retryCount)
+	target := systemNodeDeliveryTarget(evt)
+	sideEffects := systemNodeDeadLetterReceiptSideEffects(n.nodeID, eventID, reasonCode, errText, retryCount, target)
+	if !target.Empty() {
+		targetStore, ok := n.receiptStore.(SystemNodeTargetReceiptPersistence)
+		if !ok {
+			n.logSystemNodeDeliveryTransitionError(ctx, evt, "mark_delivery_dead_letter_failed", "Marking the targeted system node delivery as dead_letter failed", ErrSystemNodeDeliveryAuthorityMissing)
+			return
+		}
+		if err := targetStore.MarkSystemNodeDeliveryDeadLetterForTarget(ctx, n.nodeID, eventID, target, reasonCode, errText, retryCount, sideEffects); err != nil {
+			n.logSystemNodeDeliveryTransitionError(ctx, evt, "mark_delivery_dead_letter_failed", "Marking the targeted system node delivery as dead_letter failed", err)
+			return
+		}
+		n.convergeNormalRunCompletion(ctx, evt)
+		n.notifyTestLifecycleDeliveryStatus(ctx, evt, "dead_letter")
+		return
+	}
 	if err := n.receiptStore.MarkSystemNodeDeliveryDeadLetter(ctx, n.nodeID, eventID, reasonCode, errText, retryCount, sideEffects); err != nil {
 		n.logSystemNodeDeliveryTransitionError(ctx, evt, "mark_delivery_dead_letter_failed", "Marking the system node delivery as dead_letter failed", err)
 		return
@@ -476,28 +526,154 @@ func (n *systemNodeRunner) logSystemNodeDeliveryTransitionError(ctx context.Cont
 	}
 }
 
-func (n *systemNodeRunner) persistProcessedReceiptAndSettleDelivery(ctx context.Context, eventID, sideEffects string) error {
+func (n *systemNodeRunner) persistProcessedReceiptAndSettleDelivery(ctx context.Context, eventID string, target events.RouteIdentity, sideEffects string) error {
 	if n == nil || n.receiptStore == nil {
 		return nil
+	}
+	target = target.Normalized()
+	if !target.Empty() {
+		targetStore, ok := n.receiptStore.(SystemNodeTargetReceiptPersistence)
+		if !ok {
+			return fmt.Errorf("%w: node %s event %s target %s", ErrSystemNodeDeliveryAuthorityMissing, n.nodeID, eventID, systemNodeRouteIdentityJSON(target))
+		}
+		return targetStore.MarkSystemNodeProcessedAndSettleDeliveryForTarget(ctx, n.nodeID, eventID, target, sideEffects)
 	}
 	return n.receiptStore.MarkSystemNodeProcessedAndSettleDelivery(ctx, n.nodeID, eventID, sideEffects)
 }
 
-func systemNodeProcessedReceiptSideEffects(nodeID, eventID string) string {
-	sideEffects, _ := json.Marshal(map[string]any{
-		"idempotency_key": SystemNodeReceiptIdempotencyKey(nodeID, eventID),
-	})
-	return string(sideEffects)
+func systemNodeProcessedReceiptSideEffects(nodeID, eventID string, target ...events.RouteIdentity) string {
+	deliveryTarget := optionalSystemNodeTarget(target)
+	sideEffects := map[string]any{
+		"idempotency_key": systemNodeReceiptIdempotencyKeyForTarget(nodeID, eventID, deliveryTarget),
+	}
+	if !deliveryTarget.Empty() {
+		sideEffects["delivery_target_route"] = deliveryTarget
+	}
+	encoded, _ := json.Marshal(sideEffects)
+	return string(encoded)
 }
 
-func systemNodeDeadLetterReceiptSideEffects(nodeID, eventID, reasonCode, errText string, retryCount int) string {
-	sideEffects, _ := json.Marshal(map[string]any{
-		"idempotency_key": SystemNodeReceiptIdempotencyKey(nodeID, eventID),
+func systemNodeDeadLetterReceiptSideEffects(nodeID, eventID, reasonCode, errText string, retryCount int, target ...events.RouteIdentity) string {
+	deliveryTarget := optionalSystemNodeTarget(target)
+	sideEffects := map[string]any{
+		"idempotency_key": systemNodeReceiptIdempotencyKeyForTarget(nodeID, eventID, deliveryTarget),
 		"failure_type":    strings.TrimSpace(reasonCode),
 		"retry_count":     sanitizedSystemNodeRetryCount(retryCount),
 		"error":           strings.TrimSpace(errText),
-	})
-	return string(sideEffects)
+	}
+	if !deliveryTarget.Empty() {
+		sideEffects["delivery_target_route"] = deliveryTarget
+	}
+	encoded, _ := json.Marshal(sideEffects)
+	return string(encoded)
+}
+
+func systemNodeDeliveryTarget(evt events.Event) events.RouteIdentity {
+	return evt.TargetRoute().Normalized()
+}
+
+func optionalSystemNodeTarget(targets []events.RouteIdentity) events.RouteIdentity {
+	if len(targets) == 0 {
+		return events.RouteIdentity{}
+	}
+	return targets[0].Normalized()
+}
+
+func SystemNodeReceiptIdempotencyKey(nodeID, eventID string) string {
+	return strings.TrimSpace(nodeID) + ":" + strings.TrimSpace(eventID)
+}
+
+func defaultSystemNodeBackoff(base time.Duration, attempt int) time.Duration {
+	if base <= 0 {
+		base = time.Second
+	}
+	if attempt < 1 {
+		attempt = 1
+	}
+	multiplier := time.Duration(30)
+	switch attempt {
+	case 1:
+		multiplier = 1
+	case 2:
+		multiplier = 5
+	}
+	d := base * multiplier
+	if d > 30*base {
+		return 30 * base
+	}
+	return d
+}
+
+func (n *systemNodeRunner) deliveryAuthorized(ctx context.Context, evt events.Event) bool {
+	eventID := strings.TrimSpace(evt.ID())
+	if n == nil || n.receiptStore == nil || eventID == "" {
+		return false
+	}
+	if !n.eventReceiptsAvailable(ctx) {
+		return false
+	}
+	if target := systemNodeDeliveryTarget(evt); !target.Empty() {
+		targetStore, ok := n.receiptStore.(SystemNodeTargetReceiptPersistence)
+		if !ok {
+			n.logMissingDeliveryAuthority(ctx, evt)
+			return false
+		}
+		ok, err := targetStore.SystemNodeDeliveryAuthorizedForTarget(ctx, n.nodeID, eventID, target, n.effectiveRetryLimit())
+		if err != nil {
+			n.logDeliveryAuthorityCheckError(ctx, evt, err)
+			return false
+		}
+		if !ok {
+			n.logMissingDeliveryAuthority(ctx, evt)
+		}
+		return ok
+	}
+	ok, err := n.receiptStore.SystemNodeDeliveryAuthorized(ctx, n.nodeID, eventID, n.effectiveRetryLimit())
+	if err != nil {
+		n.logDeliveryAuthorityCheckError(ctx, evt, err)
+		return false
+	}
+	if !ok {
+		n.logMissingDeliveryAuthority(ctx, evt)
+	}
+	return ok
+}
+
+func (n *systemNodeRunner) logDeliveryAuthorityCheckError(ctx context.Context, evt events.Event, err error) {
+	if n == nil || err == nil {
+		return
+	}
+	eventID := strings.TrimSpace(evt.ID())
+	slog.Error("system node delivery authority check failed", "node_id", n.nodeID, "event_id", eventID, "error", err)
+	if logger, ok := n.bus.(systemNodeRuntimeLogger); ok && logger != nil {
+		logger.LogRuntime(ctx, RuntimeLogEntry{
+			Level:     "error",
+			Message:   "Checking system node delivery authority failed",
+			Component: n.nodeID,
+			Action:    "delivery_authority_check_failed",
+			EventID:   eventID,
+			EventType: strings.TrimSpace(string(evt.Type())),
+			EntityID:  workflowEventEntityID(evt),
+			Error:     strings.TrimSpace(err.Error()),
+		})
+	}
+}
+
+func (n *systemNodeRunner) logMissingDeliveryAuthority(ctx context.Context, evt events.Event) {
+	if n == nil {
+		return
+	}
+	if logger, ok := n.bus.(systemNodeRuntimeLogger); ok && logger != nil {
+		logger.LogRuntime(ctx, RuntimeLogEntry{
+			Level:     "error",
+			Message:   "System node delivery authority is missing; handler execution skipped",
+			Component: n.nodeID,
+			Action:    "delivery_authority_missing",
+			EventID:   strings.TrimSpace(evt.ID()),
+			EventType: strings.TrimSpace(string(evt.Type())),
+			EntityID:  workflowEventEntityID(evt),
+		})
+	}
 }
 
 func persistSystemNodeProcessedReceiptAndSettleDelivery(ctx context.Context, db *sql.DB, nodeID, eventID, sideEffects string) error {
@@ -527,6 +703,42 @@ func persistSystemNodeProcessedReceiptAndSettleDelivery(ctx context.Context, db 
 	}
 	if err := tx.Commit(); err != nil {
 		return fmt.Errorf("commit system node processed receipt tx: %w", err)
+	}
+	committed = true
+	return nil
+}
+
+func persistSystemNodeProcessedReceiptAndSettleDeliveryForTarget(ctx context.Context, db *sql.DB, nodeID, eventID string, target events.RouteIdentity, sideEffects string) error {
+	target = target.Normalized()
+	if target.Empty() {
+		return persistSystemNodeProcessedReceiptAndSettleDelivery(ctx, db, nodeID, eventID, sideEffects)
+	}
+	if db == nil {
+		return nil
+	}
+	nodeID = strings.TrimSpace(nodeID)
+	eventID = strings.TrimSpace(eventID)
+	if nodeID == "" || eventID == "" {
+		return nil
+	}
+	if tx, ok := PipelineSQLTxFromContext(ctx); ok {
+		return persistSystemNodeProcessedReceiptAndSettleDeliveryForTargetTx(ctx, tx, nodeID, eventID, target, sideEffects)
+	}
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin targeted system node processed receipt tx: %w", err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Rollback()
+		}
+	}()
+	if err := persistSystemNodeProcessedReceiptAndSettleDeliveryForTargetTx(ctx, tx, nodeID, eventID, target, sideEffects); err != nil {
+		return err
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit targeted system node processed receipt tx: %w", err)
 	}
 	committed = true
 	return nil
@@ -592,6 +804,69 @@ func persistSystemNodeProcessedReceiptAndSettleDeliveryTx(ctx context.Context, t
 	return nil
 }
 
+func persistSystemNodeProcessedReceiptAndSettleDeliveryForTargetTx(ctx context.Context, tx *sql.Tx, nodeID, eventID string, target events.RouteIdentity, sideEffects string) error {
+	if tx == nil {
+		return nil
+	}
+	target = target.Normalized()
+	targetJSON := systemNodeRouteIdentityJSON(target)
+	retryLimit := normalizeSystemNodeRetryLimit(DefaultSystemNodeRetryLimit)
+	authorized, err := postgresSystemNodeDeliveryAuthorizedForTargetTx(ctx, tx, nodeID, eventID, target, retryLimit)
+	if err != nil {
+		return fmt.Errorf("query targeted system node delivery authority: %w", err)
+	}
+	if !authorized {
+		return fmt.Errorf("%w: node %s event %s target %s", ErrSystemNodeDeliveryAuthorityMissing, nodeID, eventID, targetJSON)
+	}
+	res, err := tx.ExecContext(ctx, `
+		INSERT INTO event_receipts (
+			event_id, subscriber_type, subscriber_id, entity_id, flow_instance,
+			outcome, reason_code, side_effects, idempotency_key, processed_at
+		)
+		SELECT
+			e.event_id, 'node', $2, e.entity_id, e.flow_instance,
+			'no_op', 'idempotent_no_op', $3::jsonb, $4, now()
+		FROM events e
+		WHERE e.event_id = $1::uuid
+		ON CONFLICT (event_id, subscriber_type, subscriber_id) DO UPDATE SET
+			entity_id = EXCLUDED.entity_id,
+			flow_instance = EXCLUDED.flow_instance,
+			outcome = EXCLUDED.outcome,
+			reason_code = EXCLUDED.reason_code,
+			side_effects = EXCLUDED.side_effects,
+			idempotency_key = EXCLUDED.idempotency_key,
+			processed_at = now()
+	`, eventID, nodeID, sideEffects, systemNodeReceiptIdempotencyKeyForTarget(nodeID, eventID, target))
+	if err != nil {
+		return fmt.Errorf("upsert targeted system node receipt: %w", err)
+	}
+	if rows, err := res.RowsAffected(); err == nil && rows == 0 {
+		return fmt.Errorf("upsert targeted system node receipt: event %s not found", eventID)
+	}
+	if _, err := tx.ExecContext(ctx, `
+		UPDATE event_deliveries
+		SET
+			status = 'delivered',
+			retry_count = COALESCE(retry_count, 0),
+			reason_code = 'node_processed',
+			last_error = NULL,
+			active_session_id = NULL,
+			started_at = COALESCE(started_at, created_at),
+			delivered_at = now()
+		WHERE event_id = $1::uuid
+		  AND subscriber_type = 'node'
+		  AND subscriber_id = $2
+		  AND COALESCE(delivery_target_route, '{}'::jsonb) = $3::jsonb
+		  AND (
+			status IN ('pending', 'in_progress')
+			OR (status = 'failed' AND COALESCE(retry_count, 0) < $4)
+		  )
+		`, eventID, nodeID, targetJSON, retryLimit); err != nil {
+		return fmt.Errorf("settle targeted system node delivery: %w", err)
+	}
+	return nil
+}
+
 func markPostgresSystemNodeDeliveryInProgress(ctx context.Context, db *sql.DB, nodeID, eventID string, retryLimit int) error {
 	if db == nil {
 		return nil
@@ -620,6 +895,43 @@ func markPostgresSystemNodeDeliveryInProgress(ctx context.Context, db *sql.DB, n
 	}
 	if err := tx.Commit(); err != nil {
 		return fmt.Errorf("commit system node delivery start tx: %w", err)
+	}
+	committed = true
+	return nil
+}
+
+func markPostgresSystemNodeDeliveryInProgressForTarget(ctx context.Context, db *sql.DB, nodeID, eventID string, target events.RouteIdentity, retryLimit int) error {
+	target = target.Normalized()
+	if target.Empty() {
+		return markPostgresSystemNodeDeliveryInProgress(ctx, db, nodeID, eventID, retryLimit)
+	}
+	if db == nil {
+		return nil
+	}
+	nodeID = strings.TrimSpace(nodeID)
+	eventID = strings.TrimSpace(eventID)
+	if nodeID == "" || eventID == "" {
+		return nil
+	}
+	retryLimit = normalizeSystemNodeRetryLimit(retryLimit)
+	if tx, ok := PipelineSQLTxFromContext(ctx); ok {
+		return markPostgresSystemNodeDeliveryInProgressForTargetTx(ctx, tx, nodeID, eventID, target, retryLimit)
+	}
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin targeted system node delivery start tx: %w", err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Rollback()
+		}
+	}()
+	if err := markPostgresSystemNodeDeliveryInProgressForTargetTx(ctx, tx, nodeID, eventID, target, retryLimit); err != nil {
+		return err
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit targeted system node delivery start tx: %w", err)
 	}
 	committed = true
 	return nil
@@ -663,6 +975,47 @@ func markPostgresSystemNodeDeliveryInProgressTx(ctx context.Context, tx *sql.Tx,
 	return nil
 }
 
+func markPostgresSystemNodeDeliveryInProgressForTargetTx(ctx context.Context, tx *sql.Tx, nodeID, eventID string, target events.RouteIdentity, retryLimit int) error {
+	if tx == nil {
+		return nil
+	}
+	target = target.Normalized()
+	targetJSON := systemNodeRouteIdentityJSON(target)
+	retryLimit = normalizeSystemNodeRetryLimit(retryLimit)
+	authorized, err := postgresSystemNodeDeliveryAuthorizedForTargetTx(ctx, tx, nodeID, eventID, target, retryLimit)
+	if err != nil {
+		return fmt.Errorf("query targeted system node delivery authority: %w", err)
+	}
+	if !authorized {
+		return fmt.Errorf("%w: node %s event %s target %s", ErrSystemNodeDeliveryAuthorityMissing, nodeID, eventID, targetJSON)
+	}
+	res, err := tx.ExecContext(ctx, `
+		UPDATE event_deliveries
+		SET
+			status = 'in_progress',
+			reason_code = 'node_processing',
+			last_error = NULL,
+			active_session_id = NULL,
+			started_at = COALESCE(started_at, now()),
+			delivered_at = NULL
+		WHERE event_id = $1::uuid
+		  AND subscriber_type = 'node'
+		  AND subscriber_id = $2
+		  AND COALESCE(delivery_target_route, '{}'::jsonb) = $3::jsonb
+		  AND (
+			status IN ('pending', 'in_progress')
+			OR (status = 'failed' AND COALESCE(retry_count, 0) < $4)
+		  )
+	`, eventID, nodeID, targetJSON, retryLimit)
+	if err != nil {
+		return fmt.Errorf("mark targeted system node delivery in progress: %w", err)
+	}
+	if rows, _ := res.RowsAffected(); rows == 0 {
+		return fmt.Errorf("%w: node %s event %s target %s", ErrSystemNodeDeliveryAuthorityMissing, nodeID, eventID, targetJSON)
+	}
+	return nil
+}
+
 func markPostgresSystemNodeDeliveryFailed(ctx context.Context, db *sql.DB, nodeID, eventID, reasonCode, errText string, retryCount, retryLimit int) error {
 	if db == nil {
 		return nil
@@ -691,6 +1044,43 @@ func markPostgresSystemNodeDeliveryFailed(ctx context.Context, db *sql.DB, nodeI
 	}
 	if err := tx.Commit(); err != nil {
 		return fmt.Errorf("commit system node delivery failure tx: %w", err)
+	}
+	committed = true
+	return nil
+}
+
+func markPostgresSystemNodeDeliveryFailedForTarget(ctx context.Context, db *sql.DB, nodeID, eventID string, target events.RouteIdentity, reasonCode, errText string, retryCount, retryLimit int) error {
+	target = target.Normalized()
+	if target.Empty() {
+		return markPostgresSystemNodeDeliveryFailed(ctx, db, nodeID, eventID, reasonCode, errText, retryCount, retryLimit)
+	}
+	if db == nil {
+		return nil
+	}
+	nodeID = strings.TrimSpace(nodeID)
+	eventID = strings.TrimSpace(eventID)
+	if nodeID == "" || eventID == "" {
+		return nil
+	}
+	retryLimit = normalizeSystemNodeRetryLimit(retryLimit)
+	if tx, ok := PipelineSQLTxFromContext(ctx); ok {
+		return markPostgresSystemNodeDeliveryFailedForTargetTx(ctx, tx, nodeID, eventID, target, reasonCode, errText, retryCount, retryLimit)
+	}
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin targeted system node delivery failure tx: %w", err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Rollback()
+		}
+	}()
+	if err := markPostgresSystemNodeDeliveryFailedForTargetTx(ctx, tx, nodeID, eventID, target, reasonCode, errText, retryCount, retryLimit); err != nil {
+		return err
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit targeted system node delivery failure tx: %w", err)
 	}
 	committed = true
 	return nil
@@ -733,6 +1123,46 @@ func markPostgresSystemNodeDeliveryFailedTx(ctx context.Context, tx *sql.Tx, nod
 	return nil
 }
 
+func markPostgresSystemNodeDeliveryFailedForTargetTx(ctx context.Context, tx *sql.Tx, nodeID, eventID string, target events.RouteIdentity, reasonCode, errText string, retryCount, retryLimit int) error {
+	if tx == nil {
+		return nil
+	}
+	target = target.Normalized()
+	targetJSON := systemNodeRouteIdentityJSON(target)
+	retryLimit = normalizeSystemNodeRetryLimit(retryLimit)
+	authorized, err := postgresSystemNodeDeliveryAuthorizedForTargetTx(ctx, tx, nodeID, eventID, target, retryLimit)
+	if err != nil {
+		return fmt.Errorf("query targeted system node delivery authority: %w", err)
+	}
+	if !authorized {
+		return fmt.Errorf("%w: node %s event %s target %s", ErrSystemNodeDeliveryAuthorityMissing, nodeID, eventID, targetJSON)
+	}
+	res, err := tx.ExecContext(ctx, `
+		UPDATE event_deliveries
+		SET
+			status = 'failed',
+			retry_count = $4,
+			reason_code = NULLIF($5, ''),
+			last_error = NULLIF($6, ''),
+			active_session_id = NULL,
+			started_at = COALESCE(started_at, created_at),
+			delivered_at = now()
+		WHERE event_id = $1::uuid
+		  AND subscriber_type = 'node'
+		  AND subscriber_id = $2
+		  AND COALESCE(delivery_target_route, '{}'::jsonb) = $3::jsonb
+		  AND status IN ('pending', 'in_progress', 'failed')
+		  AND COALESCE(retry_count, 0) < $7
+	`, eventID, nodeID, targetJSON, sanitizedSystemNodeRetryCount(retryCount), sanitizeSystemNodeReasonCode(reasonCode, "handler_error"), strings.TrimSpace(errText), retryLimit)
+	if err != nil {
+		return fmt.Errorf("mark targeted system node delivery failed: %w", err)
+	}
+	if rows, _ := res.RowsAffected(); rows == 0 {
+		return fmt.Errorf("%w: node %s event %s target %s", ErrSystemNodeDeliveryAuthorityMissing, nodeID, eventID, targetJSON)
+	}
+	return nil
+}
+
 func markPostgresSystemNodeDeliveryDeadLetter(ctx context.Context, db *sql.DB, nodeID, eventID, reasonCode, errText string, retryCount int, sideEffects string) error {
 	if db == nil {
 		return nil
@@ -760,6 +1190,42 @@ func markPostgresSystemNodeDeliveryDeadLetter(ctx context.Context, db *sql.DB, n
 	}
 	if err := tx.Commit(); err != nil {
 		return fmt.Errorf("commit system node delivery dead-letter tx: %w", err)
+	}
+	committed = true
+	return nil
+}
+
+func markPostgresSystemNodeDeliveryDeadLetterForTarget(ctx context.Context, db *sql.DB, nodeID, eventID string, target events.RouteIdentity, reasonCode, errText string, retryCount int, sideEffects string) error {
+	target = target.Normalized()
+	if target.Empty() {
+		return markPostgresSystemNodeDeliveryDeadLetter(ctx, db, nodeID, eventID, reasonCode, errText, retryCount, sideEffects)
+	}
+	if db == nil {
+		return nil
+	}
+	nodeID = strings.TrimSpace(nodeID)
+	eventID = strings.TrimSpace(eventID)
+	if nodeID == "" || eventID == "" {
+		return nil
+	}
+	if tx, ok := PipelineSQLTxFromContext(ctx); ok {
+		return markPostgresSystemNodeDeliveryDeadLetterForTargetTx(ctx, tx, nodeID, eventID, target, reasonCode, errText, retryCount, sideEffects)
+	}
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin targeted system node delivery dead-letter tx: %w", err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Rollback()
+		}
+	}()
+	if err := markPostgresSystemNodeDeliveryDeadLetterForTargetTx(ctx, tx, nodeID, eventID, target, reasonCode, errText, retryCount, sideEffects); err != nil {
+		return err
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit targeted system node delivery dead-letter tx: %w", err)
 	}
 	committed = true
 	return nil
@@ -827,6 +1293,71 @@ func markPostgresSystemNodeDeliveryDeadLetterTx(ctx context.Context, tx *sql.Tx,
 	return nil
 }
 
+func markPostgresSystemNodeDeliveryDeadLetterForTargetTx(ctx context.Context, tx *sql.Tx, nodeID, eventID string, target events.RouteIdentity, reasonCode, errText string, retryCount int, sideEffects string) error {
+	if tx == nil {
+		return nil
+	}
+	target = target.Normalized()
+	targetJSON := systemNodeRouteIdentityJSON(target)
+	exists, err := postgresSystemNodeDeliveryRowExistsForTargetTx(ctx, tx, nodeID, eventID, target)
+	if err != nil {
+		return fmt.Errorf("query targeted system node delivery row: %w", err)
+	}
+	if !exists {
+		return fmt.Errorf("%w: node %s event %s target %s", ErrSystemNodeDeliveryAuthorityMissing, nodeID, eventID, targetJSON)
+	}
+	reasonCode = sanitizeSystemNodeReasonCode(reasonCode, "retry_exhausted")
+	errText = strings.TrimSpace(errText)
+	res, err := tx.ExecContext(ctx, `
+		UPDATE event_deliveries
+		SET
+			status = 'dead_letter',
+			retry_count = $4,
+			reason_code = NULLIF($5, ''),
+			last_error = NULLIF($6, ''),
+			active_session_id = NULL,
+			started_at = COALESCE(started_at, created_at),
+			delivered_at = now()
+		WHERE event_id = $1::uuid
+		  AND subscriber_type = 'node'
+		  AND subscriber_id = $2
+		  AND COALESCE(delivery_target_route, '{}'::jsonb) = $3::jsonb
+		  AND status IN ('pending', 'in_progress', 'failed')
+	`, eventID, nodeID, targetJSON, sanitizedSystemNodeRetryCount(retryCount), reasonCode, errText)
+	if err != nil {
+		return fmt.Errorf("dead-letter targeted system node delivery: %w", err)
+	}
+	if rows, _ := res.RowsAffected(); rows == 0 {
+		return fmt.Errorf("%w: node %s event %s target %s", ErrSystemNodeDeliveryAuthorityMissing, nodeID, eventID, targetJSON)
+	}
+	res, err = tx.ExecContext(ctx, `
+		INSERT INTO event_receipts (
+			event_id, subscriber_type, subscriber_id, entity_id, flow_instance,
+			outcome, reason_code, side_effects, idempotency_key, processed_at
+		)
+		SELECT
+			e.event_id, 'node', $2, e.entity_id, e.flow_instance,
+			'dead_letter', NULLIF($3, ''), $4::jsonb, $5, now()
+		FROM events e
+		WHERE e.event_id = $1::uuid
+		ON CONFLICT (event_id, subscriber_type, subscriber_id) DO UPDATE SET
+			entity_id = EXCLUDED.entity_id,
+			flow_instance = EXCLUDED.flow_instance,
+			outcome = EXCLUDED.outcome,
+			reason_code = EXCLUDED.reason_code,
+			side_effects = EXCLUDED.side_effects,
+			idempotency_key = EXCLUDED.idempotency_key,
+			processed_at = now()
+	`, eventID, nodeID, reasonCode, sqliteNodeJSON(sideEffects), systemNodeReceiptIdempotencyKeyForTarget(nodeID, eventID, target))
+	if err != nil {
+		return fmt.Errorf("upsert targeted system node dead-letter receipt: %w", err)
+	}
+	if rows, err := res.RowsAffected(); err == nil && rows == 0 {
+		return fmt.Errorf("upsert targeted system node dead-letter receipt: event %s not found", eventID)
+	}
+	return nil
+}
+
 func postgresSystemNodeDeliveryAuthorizedTx(ctx context.Context, tx *sql.Tx, nodeID, eventID string, retryLimit int) (bool, error) {
 	if tx == nil {
 		return false, nil
@@ -852,6 +1383,32 @@ func postgresSystemNodeDeliveryAuthorizedTx(ctx context.Context, tx *sql.Tx, nod
 	return ok, err
 }
 
+func postgresSystemNodeDeliveryAuthorizedForTargetTx(ctx context.Context, tx *sql.Tx, nodeID, eventID string, target events.RouteIdentity, retryLimit int) (bool, error) {
+	if tx == nil {
+		return false, nil
+	}
+	retryLimit = normalizeSystemNodeRetryLimit(retryLimit)
+	if _, err := uuid.Parse(strings.TrimSpace(eventID)); err != nil {
+		return false, nil
+	}
+	var ok bool
+	err := tx.QueryRowContext(ctx, `
+		SELECT EXISTS (
+			SELECT 1
+			FROM event_deliveries
+			WHERE event_id = $1::uuid
+			  AND subscriber_type = 'node'
+			  AND subscriber_id = $2
+			  AND COALESCE(delivery_target_route, '{}'::jsonb) = $3::jsonb
+			  AND (
+				status IN ('pending', 'in_progress')
+				OR (status = 'failed' AND COALESCE(retry_count, 0) < $4)
+			  )
+			)
+	`, strings.TrimSpace(eventID), strings.TrimSpace(nodeID), systemNodeRouteIdentityJSON(target), retryLimit).Scan(&ok)
+	return ok, err
+}
+
 func postgresSystemNodeDeliveryRowExistsTx(ctx context.Context, tx *sql.Tx, nodeID, eventID string) (bool, error) {
 	if tx == nil {
 		return false, nil
@@ -869,6 +1426,27 @@ func postgresSystemNodeDeliveryRowExistsTx(ctx context.Context, tx *sql.Tx, node
 			  AND subscriber_id = $2
 		)
 	`, strings.TrimSpace(eventID), strings.TrimSpace(nodeID)).Scan(&ok)
+	return ok, err
+}
+
+func postgresSystemNodeDeliveryRowExistsForTargetTx(ctx context.Context, tx *sql.Tx, nodeID, eventID string, target events.RouteIdentity) (bool, error) {
+	if tx == nil {
+		return false, nil
+	}
+	if _, err := uuid.Parse(strings.TrimSpace(eventID)); err != nil {
+		return false, nil
+	}
+	var ok bool
+	err := tx.QueryRowContext(ctx, `
+		SELECT EXISTS (
+			SELECT 1
+			FROM event_deliveries
+			WHERE event_id = $1::uuid
+			  AND subscriber_type = 'node'
+			  AND subscriber_id = $2
+			  AND COALESCE(delivery_target_route, '{}'::jsonb) = $3::jsonb
+		)
+	`, strings.TrimSpace(eventID), strings.TrimSpace(nodeID), systemNodeRouteIdentityJSON(target)).Scan(&ok)
 	return ok, err
 }
 
@@ -917,47 +1495,6 @@ func (n *systemNodeRunner) isActiveRunQuiesced(ctx context.Context, evt events.E
 	return ok
 }
 
-func (n *systemNodeRunner) deliveryAuthorized(ctx context.Context, evt events.Event) bool {
-	eventID := strings.TrimSpace(evt.ID())
-	if n == nil || n.receiptStore == nil || eventID == "" {
-		return false
-	}
-	if !n.eventReceiptsAvailable(ctx) {
-		return false
-	}
-	ok, err := n.receiptStore.SystemNodeDeliveryAuthorized(ctx, n.nodeID, eventID, n.effectiveRetryLimit())
-	if err != nil {
-		slog.Error("system node delivery authority check failed", "node_id", n.nodeID, "event_id", eventID, "error", err)
-		if logger, ok := n.bus.(systemNodeRuntimeLogger); ok && logger != nil {
-			logger.LogRuntime(ctx, RuntimeLogEntry{
-				Level:     "error",
-				Message:   "Checking system node delivery authority failed",
-				Component: n.nodeID,
-				Action:    "delivery_authority_check_failed",
-				EventID:   eventID,
-				EventType: strings.TrimSpace(string(evt.Type())),
-				EntityID:  workflowEventEntityID(evt),
-				Error:     strings.TrimSpace(err.Error()),
-			})
-		}
-		return false
-	}
-	if !ok {
-		if logger, ok := n.bus.(systemNodeRuntimeLogger); ok && logger != nil {
-			logger.LogRuntime(ctx, RuntimeLogEntry{
-				Level:     "error",
-				Message:   "System node delivery authority is missing; handler execution skipped",
-				Component: n.nodeID,
-				Action:    "delivery_authority_missing",
-				EventID:   eventID,
-				EventType: strings.TrimSpace(string(evt.Type())),
-				EntityID:  workflowEventEntityID(evt),
-			})
-		}
-	}
-	return ok
-}
-
 func (n *systemNodeRunner) eventReceiptsAvailable(ctx context.Context) bool {
 	if n == nil || n.receiptStore == nil {
 		return false
@@ -983,29 +1520,4 @@ func (n *systemNodeRunner) String() string {
 		return ""
 	}
 	return n.nodeID
-}
-
-func defaultSystemNodeBackoff(base time.Duration, attempt int) time.Duration {
-	if base <= 0 {
-		base = time.Second
-	}
-	if attempt < 1 {
-		attempt = 1
-	}
-	multiplier := time.Duration(30)
-	switch attempt {
-	case 1:
-		multiplier = 1
-	case 2:
-		multiplier = 5
-	}
-	d := base * multiplier
-	if d > 30*base {
-		return 30 * base
-	}
-	return d
-}
-
-func SystemNodeReceiptIdempotencyKey(nodeID, eventID string) string {
-	return strings.TrimSpace(nodeID) + ":" + strings.TrimSpace(eventID)
 }

--- a/internal/runtime/pipeline/node_system_runner_completion_test.go
+++ b/internal/runtime/pipeline/node_system_runner_completion_test.go
@@ -108,6 +108,65 @@ func TestSystemNodeRunner_MarkProcessedSettlesNodeDeliveryAndTriggersNormalRunCo
 	}
 }
 
+func TestSystemNodeRunner_TargetSetSameNodeSettlesEachTargetDelivery(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	ctx := context.Background()
+	runID := uuid.NewString()
+	eventID := uuid.NewString()
+	entityID := uuid.NewString()
+	seedSystemNodeCompletionEventWithoutDelivery(t, db, runID, eventID, entityID)
+	targetOne := events.RouteIdentity{FlowInstance: "worker/w-001", EntityID: "worker/w-001"}
+	targetTwo := events.RouteIdentity{FlowInstance: "worker/w-002", EntityID: "worker/w-002"}
+	seedSystemNodeCompletionTargetDelivery(t, db, runID, eventID, "task-handler", targetOne)
+	seedSystemNodeCompletionTargetDelivery(t, db, runID, eventID, "task-handler", targetTwo)
+
+	var handledTargets []string
+	runner := newSystemNodeRunner("task-handler", &systemNodeCompletionBus{}, db, func() []events.EventType {
+		return []events.EventType{"worker/work.assign"}
+	}, func(ctx context.Context, evt events.Event) error {
+		target := evt.TargetRoute()
+		handledTargets = append(handledTargets, target.FlowInstance)
+		status := loadSystemNodeCompletionTargetDeliveryStatus(t, db, eventID, "task-handler", target)
+		if status != "in_progress" {
+			t.Fatalf("target %s handler observed status = %q, want in_progress", target.FlowInstance, status)
+		}
+		return nil
+	}, func(context.Context) (bool, error) { return true, nil })
+
+	base := events.NewProjectionEvent(eventID,
+		"worker/work.assign", "", "", []byte(`{}`), 0, runID, "", events.EventEnvelope{}, time.Now().UTC())
+	runner.ProcessEventForTest(ctx, base.WithTargetRoute(targetOne))
+	if got := loadSystemNodeCompletionTargetDeliveryStatus(t, db, eventID, "task-handler", targetOne); got != "delivered" {
+		t.Fatalf("target one status = %q, want delivered", got)
+	}
+	if got := loadSystemNodeCompletionTargetDeliveryStatus(t, db, eventID, "task-handler", targetTwo); got != "pending" {
+		t.Fatalf("target two status after first delivery = %q, want pending", got)
+	}
+
+	runner.ProcessEventForTest(ctx, base.WithTargetRoute(targetTwo))
+	if got := loadSystemNodeCompletionTargetDeliveryStatus(t, db, eventID, "task-handler", targetTwo); got != "delivered" {
+		t.Fatalf("target two status = %q, want delivered", got)
+	}
+	if len(handledTargets) != 2 || handledTargets[0] != "worker/w-001" || handledTargets[1] != "worker/w-002" {
+		t.Fatalf("handled targets = %#v, want both worker targets in order", handledTargets)
+	}
+	var deliveredRows int
+	if err := db.QueryRowContext(ctx, `
+		SELECT COUNT(*)
+		FROM event_deliveries
+		WHERE event_id = $1::uuid
+		  AND subscriber_type = 'node'
+		  AND subscriber_id = 'task-handler'
+		  AND status = 'delivered'
+		  AND reason_code = 'node_processed'
+	`, eventID).Scan(&deliveredRows); err != nil {
+		t.Fatalf("count delivered target rows: %v", err)
+	}
+	if deliveredRows != 2 {
+		t.Fatalf("delivered target rows = %d, want 2", deliveredRows)
+	}
+}
+
 func TestSystemNodeRunnerLifecycleProbeEmitsHandlerBoundaries(t *testing.T) {
 	_, db, _ := testutil.StartPostgres(t)
 	ctx := context.Background()
@@ -488,6 +547,35 @@ func seedSystemNodeCompletionRun(t *testing.T, db *sql.DB, runID, eventID, entit
 	`, runID, eventID, nodeID); err != nil {
 		t.Fatalf("seed node delivery: %v", err)
 	}
+}
+
+func seedSystemNodeCompletionTargetDelivery(t *testing.T, db *sql.DB, runID, eventID, nodeID string, target events.RouteIdentity) {
+	t.Helper()
+	if _, err := db.ExecContext(context.Background(), `
+		INSERT INTO event_deliveries (
+			run_id, event_id, subscriber_type, subscriber_id, delivery_target_route, status, reason_code, created_at
+		) VALUES (
+			$1::uuid, $2::uuid, 'node', $3, $4::jsonb, 'pending', 'matched_node_subscription', now()
+		)
+	`, runID, eventID, nodeID, systemNodeRouteIdentityJSON(target)); err != nil {
+		t.Fatalf("seed targeted node delivery: %v", err)
+	}
+}
+
+func loadSystemNodeCompletionTargetDeliveryStatus(t *testing.T, db *sql.DB, eventID, nodeID string, target events.RouteIdentity) string {
+	t.Helper()
+	var status string
+	if err := db.QueryRowContext(context.Background(), `
+		SELECT COALESCE(status, '')
+		FROM event_deliveries
+		WHERE event_id = $1::uuid
+		  AND subscriber_type = 'node'
+		  AND subscriber_id = $2
+		  AND delivery_target_route = $3::jsonb
+	`, eventID, nodeID, systemNodeRouteIdentityJSON(target)).Scan(&status); err != nil {
+		t.Fatalf("load targeted node delivery: %v", err)
+	}
+	return status
 }
 
 func seedSystemNodeCompletionEventWithoutDelivery(t *testing.T, db *sql.DB, runID, eventID, entityID string) {

--- a/internal/runtime/pipeline/node_system_runner_completion_test.go
+++ b/internal/runtime/pipeline/node_system_runner_completion_test.go
@@ -167,6 +167,162 @@ func TestSystemNodeRunner_TargetSetSameNodeSettlesEachTargetDelivery(t *testing.
 	}
 }
 
+func TestSystemNodeRunner_TargetSetSameNodeFailureKeepsSiblingPending(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	ctx := context.Background()
+	runID := uuid.NewString()
+	eventID := uuid.NewString()
+	entityID := uuid.NewString()
+	seedSystemNodeCompletionEventWithoutDelivery(t, db, runID, eventID, entityID)
+	targetOne := events.RouteIdentity{FlowInstance: "worker/w-001", EntityID: "worker/w-001"}
+	targetTwo := events.RouteIdentity{FlowInstance: "worker/w-002", EntityID: "worker/w-002"}
+	seedSystemNodeCompletionTargetDelivery(t, db, runID, eventID, "task-handler", targetOne)
+	seedSystemNodeCompletionTargetDelivery(t, db, runID, eventID, "task-handler", targetTwo)
+
+	attempts := 0
+	runner := newSystemNodeRunner("task-handler", &systemNodeCompletionBus{}, db, func() []events.EventType {
+		return []events.EventType{"worker/work.assign"}
+	}, func(context.Context, events.Event) error {
+		attempts++
+		if attempts == 1 {
+			return errors.New("temporary target failure")
+		}
+		return nil
+	}, func(context.Context) (bool, error) { return true, nil })
+	runner.SetRetryPolicyForTest(2, func(int) time.Duration {
+		targetOneDelivery := loadSystemNodeCompletionTargetDelivery(t, db, eventID, "task-handler", targetOne)
+		if targetOneDelivery.Status != "failed" || targetOneDelivery.Reason != "handler_error" || targetOneDelivery.RetryCount != 1 || targetOneDelivery.LastError == "" {
+			t.Fatalf("target one retry delivery = %+v, want failed/handler_error retry=1 with error", targetOneDelivery)
+		}
+		if got := loadSystemNodeCompletionTargetDeliveryStatus(t, db, eventID, "task-handler", targetTwo); got != "pending" {
+			t.Fatalf("target two status during target one retry = %q, want pending", got)
+		}
+		return 0
+	})
+
+	base := events.NewProjectionEvent(eventID,
+		"worker/work.assign", "", "", []byte(`{}`), 0, runID, "", events.EventEnvelope{}, time.Now().UTC())
+	runner.ProcessEventForTest(ctx, base.WithTargetRoute(targetOne))
+
+	if attempts != 2 {
+		t.Fatalf("attempts = %d, want 2", attempts)
+	}
+	if got := loadSystemNodeCompletionTargetDeliveryStatus(t, db, eventID, "task-handler", targetOne); got != "delivered" {
+		t.Fatalf("target one final status = %q, want delivered", got)
+	}
+	if got := loadSystemNodeCompletionTargetDeliveryStatus(t, db, eventID, "task-handler", targetTwo); got != "pending" {
+		t.Fatalf("target two final status = %q, want pending", got)
+	}
+}
+
+func TestSystemNodeRunner_TargetSetSameNodeDeadLetterKeepsSiblingExecutable(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	ctx := context.Background()
+	runID := uuid.NewString()
+	eventID := uuid.NewString()
+	entityID := uuid.NewString()
+	seedSystemNodeCompletionEventWithoutDelivery(t, db, runID, eventID, entityID)
+	targetOne := events.RouteIdentity{FlowInstance: "worker/w-001", EntityID: "worker/w-001"}
+	targetTwo := events.RouteIdentity{FlowInstance: "worker/w-002", EntityID: "worker/w-002"}
+	seedSystemNodeCompletionTargetDelivery(t, db, runID, eventID, "task-handler", targetOne)
+	seedSystemNodeCompletionTargetDelivery(t, db, runID, eventID, "task-handler", targetTwo)
+
+	failingRunner := newSystemNodeRunner("task-handler", &systemNodeCompletionBus{}, db, func() []events.EventType {
+		return []events.EventType{"worker/work.assign"}
+	}, func(context.Context, events.Event) error {
+		return errors.New("permanent target failure")
+	}, func(context.Context) (bool, error) { return true, nil })
+	failingRunner.SetRetryPolicyForTest(1, func(int) time.Duration { return 0 })
+
+	base := events.NewProjectionEvent(eventID,
+		"worker/work.assign", "", "", []byte(`{}`), 0, runID, "", events.EventEnvelope{}, time.Now().UTC())
+	failingRunner.ProcessEventForTest(ctx, base.WithTargetRoute(targetOne))
+
+	targetOneDelivery := loadSystemNodeCompletionTargetDelivery(t, db, eventID, "task-handler", targetOne)
+	if targetOneDelivery.Status != "dead_letter" || targetOneDelivery.Reason != "retry_exhausted" || targetOneDelivery.RetryCount != 1 || targetOneDelivery.LastError == "" {
+		t.Fatalf("target one dead-letter delivery = %+v, want dead_letter/retry_exhausted retry=1 with error", targetOneDelivery)
+	}
+	if got := loadSystemNodeCompletionTargetDeliveryStatus(t, db, eventID, "task-handler", targetTwo); got != "pending" {
+		t.Fatalf("target two status after target one dead-letter = %q, want pending", got)
+	}
+
+	successRunner := newSystemNodeRunner("task-handler", &systemNodeCompletionBus{}, db, func() []events.EventType {
+		return []events.EventType{"worker/work.assign"}
+	}, func(context.Context, events.Event) error {
+		return nil
+	}, func(context.Context) (bool, error) { return true, nil })
+	successRunner.ProcessEventForTest(ctx, base.WithTargetRoute(targetTwo))
+	if got := loadSystemNodeCompletionTargetDeliveryStatus(t, db, eventID, "task-handler", targetTwo); got != "delivered" {
+		t.Fatalf("target two status after target one dead-letter = %q, want delivered", got)
+	}
+}
+
+func TestSQLiteSystemNodeTargetSetSameNodeTransitionsAreTargetScoped(t *testing.T) {
+	db := newSQLiteWorkflowInstanceStoreTestDB(t)
+	store := newSQLiteWorkflowInstanceStoreForTest(t, db)
+	ctx := context.Background()
+	runID := uuid.NewString()
+	eventID := uuid.NewString()
+	entityID := uuid.NewString()
+	seedSQLiteSystemNodeCompletionEventWithoutDelivery(t, db, runID, eventID, entityID)
+	targetOne := events.RouteIdentity{FlowInstance: "worker/w-001", EntityID: "worker/w-001"}
+	targetTwo := events.RouteIdentity{FlowInstance: "worker/w-002", EntityID: "worker/w-002"}
+	seedSQLiteSystemNodeCompletionTargetDelivery(t, db, runID, eventID, "task-handler", targetOne)
+	seedSQLiteSystemNodeCompletionTargetDelivery(t, db, runID, eventID, "task-handler", targetTwo)
+
+	authorized, err := store.SystemNodeDeliveryAuthorizedForTarget(ctx, "task-handler", eventID, targetOne, DefaultSystemNodeRetryLimit)
+	if err != nil {
+		t.Fatalf("SystemNodeDeliveryAuthorizedForTarget target one: %v", err)
+	}
+	if !authorized {
+		t.Fatal("target one authorized = false, want true")
+	}
+	if err := store.MarkSystemNodeDeliveryInProgressForTarget(ctx, "task-handler", eventID, targetOne, DefaultSystemNodeRetryLimit); err != nil {
+		t.Fatalf("MarkSystemNodeDeliveryInProgressForTarget target one: %v", err)
+	}
+	if got := loadSQLiteSystemNodeCompletionTargetDeliveryStatus(t, db, eventID, "task-handler", targetOne); got != "in_progress" {
+		t.Fatalf("target one sqlite status = %q, want in_progress", got)
+	}
+	if got := loadSQLiteSystemNodeCompletionTargetDeliveryStatus(t, db, eventID, "task-handler", targetTwo); got != "pending" {
+		t.Fatalf("target two sqlite status after target one in-progress = %q, want pending", got)
+	}
+
+	if err := store.MarkSystemNodeDeliveryFailedForTarget(ctx, "task-handler", eventID, targetOne, "handler_error", "temporary target failure", 1, DefaultSystemNodeRetryLimit); err != nil {
+		t.Fatalf("MarkSystemNodeDeliveryFailedForTarget target one: %v", err)
+	}
+	targetOneDelivery := loadSQLiteSystemNodeCompletionTargetDelivery(t, db, eventID, "task-handler", targetOne)
+	if targetOneDelivery.Status != "failed" || targetOneDelivery.Reason != "handler_error" || targetOneDelivery.RetryCount != 1 || targetOneDelivery.LastError == "" {
+		t.Fatalf("target one sqlite failed delivery = %+v, want failed/handler_error retry=1 with error", targetOneDelivery)
+	}
+	if got := loadSQLiteSystemNodeCompletionTargetDeliveryStatus(t, db, eventID, "task-handler", targetTwo); got != "pending" {
+		t.Fatalf("target two sqlite status after target one failed = %q, want pending", got)
+	}
+
+	sideEffects := systemNodeDeadLetterReceiptSideEffects("task-handler", eventID, "retry_exhausted", "temporary target failure", DefaultSystemNodeRetryLimit, targetOne)
+	if err := store.MarkSystemNodeDeliveryDeadLetterForTarget(ctx, "task-handler", eventID, targetOne, "retry_exhausted", "temporary target failure", DefaultSystemNodeRetryLimit, sideEffects); err != nil {
+		t.Fatalf("MarkSystemNodeDeliveryDeadLetterForTarget target one: %v", err)
+	}
+	targetOneDelivery = loadSQLiteSystemNodeCompletionTargetDelivery(t, db, eventID, "task-handler", targetOne)
+	if targetOneDelivery.Status != "dead_letter" || targetOneDelivery.Reason != "retry_exhausted" || targetOneDelivery.RetryCount != DefaultSystemNodeRetryLimit || targetOneDelivery.LastError == "" {
+		t.Fatalf("target one sqlite dead-letter delivery = %+v, want dead_letter/retry_exhausted retry=%d with error", targetOneDelivery, DefaultSystemNodeRetryLimit)
+	}
+	targetTwoProcessed, err := store.SystemNodeProcessedForTarget(ctx, "task-handler", eventID, targetTwo)
+	if err != nil {
+		t.Fatalf("SystemNodeProcessedForTarget target two: %v", err)
+	}
+	if targetTwoProcessed {
+		t.Fatal("target two processed = true after target one dead-letter, want false")
+	}
+
+	sideEffects = systemNodeProcessedReceiptSideEffects("task-handler", eventID, targetTwo)
+	if err := store.MarkSystemNodeProcessedAndSettleDeliveryForTarget(ctx, "task-handler", eventID, targetTwo, sideEffects); err != nil {
+		t.Fatalf("MarkSystemNodeProcessedAndSettleDeliveryForTarget target two: %v", err)
+	}
+	if got := loadSQLiteSystemNodeCompletionTargetDeliveryStatus(t, db, eventID, "task-handler", targetTwo); got != "delivered" {
+		t.Fatalf("target two sqlite status after target one dead-letter = %q, want delivered", got)
+	}
+}
+
 func TestSystemNodeRunnerLifecycleProbeEmitsHandlerBoundaries(t *testing.T) {
 	_, db, _ := testutil.StartPostgres(t)
 	ctx := context.Background()
@@ -531,6 +687,13 @@ func TestSystemNodeProcessedSettlementFailsWithTerminalNodeDeliveryAuthority(t *
 	}
 }
 
+type systemNodeCompletionTargetDelivery struct {
+	Status     string
+	Reason     string
+	RetryCount int
+	LastError  string
+}
+
 func seedSystemNodeCompletionRun(t *testing.T, db *sql.DB, runID, eventID, entityID string, nodeIDs ...string) {
 	t.Helper()
 	nodeID := "terminal-node"
@@ -549,6 +712,29 @@ func seedSystemNodeCompletionRun(t *testing.T, db *sql.DB, runID, eventID, entit
 	}
 }
 
+func seedSQLiteSystemNodeCompletionEventWithoutDelivery(t *testing.T, db *sql.DB, runID, eventID, entityID string) {
+	t.Helper()
+	ctx := context.Background()
+	now := time.Now().UTC()
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO runs (run_id, status, started_at)
+		VALUES (?, 'running', ?)
+	`, runID, now); err != nil {
+		t.Fatalf("seed sqlite run: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO events (
+			event_id, run_id, event_name, entity_id, flow_instance, scope, payload,
+			chain_depth, produced_by_type, created_at
+		) VALUES (
+			?, ?, 'worker/work.assign', ?, 'example', 'entity', '{}',
+			0, 'external', ?
+		)
+	`, eventID, runID, entityID, now); err != nil {
+		t.Fatalf("seed sqlite event: %v", err)
+	}
+}
+
 func seedSystemNodeCompletionTargetDelivery(t *testing.T, db *sql.DB, runID, eventID, nodeID string, target events.RouteIdentity) {
 	t.Helper()
 	if _, err := db.ExecContext(context.Background(), `
@@ -562,20 +748,59 @@ func seedSystemNodeCompletionTargetDelivery(t *testing.T, db *sql.DB, runID, eve
 	}
 }
 
+func seedSQLiteSystemNodeCompletionTargetDelivery(t *testing.T, db *sql.DB, runID, eventID, nodeID string, target events.RouteIdentity) {
+	t.Helper()
+	if _, err := db.ExecContext(context.Background(), `
+		INSERT INTO event_deliveries (
+			delivery_id, run_id, event_id, subscriber_type, subscriber_id, delivery_target_route, status, retry_count, reason_code, created_at
+		) VALUES (
+			?, ?, ?, 'node', ?, ?, 'pending', 0, 'matched_node_subscription', ?
+		)
+	`, uuid.NewString(), runID, eventID, nodeID, systemNodeRouteIdentityJSON(target), time.Now().UTC()); err != nil {
+		t.Fatalf("seed sqlite targeted node delivery: %v", err)
+	}
+}
+
 func loadSystemNodeCompletionTargetDeliveryStatus(t *testing.T, db *sql.DB, eventID, nodeID string, target events.RouteIdentity) string {
 	t.Helper()
-	var status string
+	return loadSystemNodeCompletionTargetDelivery(t, db, eventID, nodeID, target).Status
+}
+
+func loadSystemNodeCompletionTargetDelivery(t *testing.T, db *sql.DB, eventID, nodeID string, target events.RouteIdentity) systemNodeCompletionTargetDelivery {
+	t.Helper()
+	var delivery systemNodeCompletionTargetDelivery
 	if err := db.QueryRowContext(context.Background(), `
-		SELECT COALESCE(status, '')
+		SELECT COALESCE(status, ''), COALESCE(reason_code, ''), COALESCE(retry_count, 0), COALESCE(last_error, '')
 		FROM event_deliveries
 		WHERE event_id = $1::uuid
 		  AND subscriber_type = 'node'
 		  AND subscriber_id = $2
 		  AND delivery_target_route = $3::jsonb
-	`, eventID, nodeID, systemNodeRouteIdentityJSON(target)).Scan(&status); err != nil {
+	`, eventID, nodeID, systemNodeRouteIdentityJSON(target)).Scan(&delivery.Status, &delivery.Reason, &delivery.RetryCount, &delivery.LastError); err != nil {
 		t.Fatalf("load targeted node delivery: %v", err)
 	}
-	return status
+	return delivery
+}
+
+func loadSQLiteSystemNodeCompletionTargetDeliveryStatus(t *testing.T, db *sql.DB, eventID, nodeID string, target events.RouteIdentity) string {
+	t.Helper()
+	return loadSQLiteSystemNodeCompletionTargetDelivery(t, db, eventID, nodeID, target).Status
+}
+
+func loadSQLiteSystemNodeCompletionTargetDelivery(t *testing.T, db *sql.DB, eventID, nodeID string, target events.RouteIdentity) systemNodeCompletionTargetDelivery {
+	t.Helper()
+	var delivery systemNodeCompletionTargetDelivery
+	if err := db.QueryRowContext(context.Background(), `
+		SELECT COALESCE(status, ''), COALESCE(reason_code, ''), COALESCE(retry_count, 0), COALESCE(last_error, '')
+		FROM event_deliveries
+		WHERE event_id = ?
+		  AND subscriber_type = 'node'
+		  AND subscriber_id = ?
+		  AND COALESCE(delivery_target_route, '{}') = ?
+	`, eventID, nodeID, systemNodeRouteIdentityJSON(target)).Scan(&delivery.Status, &delivery.Reason, &delivery.RetryCount, &delivery.LastError); err != nil {
+		t.Fatalf("load sqlite targeted node delivery: %v", err)
+	}
+	return delivery
 }
 
 func seedSystemNodeCompletionEventWithoutDelivery(t *testing.T, db *sql.DB, runID, eventID, entityID string) {

--- a/internal/runtime/pipeline/runtime_interfaces.go
+++ b/internal/runtime/pipeline/runtime_interfaces.go
@@ -69,6 +69,15 @@ type SystemNodeReceiptPersistence interface {
 	MarkSystemNodeProcessedAndSettleDelivery(ctx context.Context, nodeID, eventID, sideEffects string) error
 }
 
+type SystemNodeTargetReceiptPersistence interface {
+	SystemNodeDeliveryAuthorizedForTarget(ctx context.Context, nodeID, eventID string, target events.RouteIdentity, retryLimit int) (bool, error)
+	SystemNodeProcessedForTarget(ctx context.Context, nodeID, eventID string, target events.RouteIdentity) (bool, error)
+	MarkSystemNodeDeliveryInProgressForTarget(ctx context.Context, nodeID, eventID string, target events.RouteIdentity, retryLimit int) error
+	MarkSystemNodeDeliveryFailedForTarget(ctx context.Context, nodeID, eventID string, target events.RouteIdentity, reasonCode, errText string, retryCount, retryLimit int) error
+	MarkSystemNodeDeliveryDeadLetterForTarget(ctx context.Context, nodeID, eventID string, target events.RouteIdentity, reasonCode, errText string, retryCount int, sideEffects string) error
+	MarkSystemNodeProcessedAndSettleDeliveryForTarget(ctx context.Context, nodeID, eventID string, target events.RouteIdentity, sideEffects string) error
+}
+
 type Store interface {
 	WorkflowInstancePersistence
 	SystemNodeReceiptPersistence

--- a/internal/runtime/pipeline/system_node_receipt_store.go
+++ b/internal/runtime/pipeline/system_node_receipt_store.go
@@ -3,11 +3,13 @@ package pipeline
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
 	"time"
 
+	"github.com/division-sh/swarm/internal/events"
 	runtimedestructivereset "github.com/division-sh/swarm/internal/runtime/destructivereset"
 	runtimerunquiescence "github.com/division-sh/swarm/internal/runtime/runquiescence"
 	"github.com/google/uuid"
@@ -59,6 +61,57 @@ func (s *WorkflowInstanceStore) SystemNodeDeliveryAuthorized(ctx context.Context
 	return ok, err
 }
 
+func (s *WorkflowInstanceStore) SystemNodeDeliveryAuthorizedForTarget(ctx context.Context, nodeID, eventID string, target events.RouteIdentity, retryLimit int) (bool, error) {
+	target = target.Normalized()
+	if target.Empty() {
+		return s.SystemNodeDeliveryAuthorized(ctx, nodeID, eventID, retryLimit)
+	}
+	nodeID = strings.TrimSpace(nodeID)
+	eventID = strings.TrimSpace(eventID)
+	retryLimit = normalizeSystemNodeRetryLimit(retryLimit)
+	if s == nil || s.db == nil || nodeID == "" || eventID == "" {
+		return false, nil
+	}
+	if _, err := uuid.Parse(eventID); err != nil {
+		return false, nil
+	}
+	targetJSON := systemNodeRouteIdentityJSON(target)
+	if s.isSQLite() {
+		var ok bool
+		err := dbQueryRowContext(ctx, s.db, `
+			SELECT EXISTS (
+				SELECT 1
+				FROM event_deliveries
+				WHERE event_id = ?
+				  AND subscriber_type = 'node'
+				  AND subscriber_id = ?
+				  AND COALESCE(delivery_target_route, '{}') = ?
+				  AND (
+					status IN ('pending', 'in_progress')
+					OR (status = 'failed' AND COALESCE(retry_count, 0) < ?)
+				  )
+				)
+			`, eventID, nodeID, targetJSON, retryLimit).Scan(&ok)
+		return ok, err
+	}
+	var ok bool
+	err := dbQueryRowContext(ctx, s.db, `
+		SELECT EXISTS (
+			SELECT 1
+			FROM event_deliveries
+			WHERE event_id = $1::uuid
+			  AND subscriber_type = 'node'
+			  AND subscriber_id = $2
+			  AND COALESCE(delivery_target_route, '{}'::jsonb) = $3::jsonb
+			  AND (
+				status IN ('pending', 'in_progress')
+				OR (status = 'failed' AND COALESCE(retry_count, 0) < $4)
+			  )
+			)
+		`, eventID, nodeID, targetJSON, retryLimit).Scan(&ok)
+	return ok, err
+}
+
 func (s *WorkflowInstanceStore) SystemNodeProcessed(ctx context.Context, nodeID, eventID string) (bool, error) {
 	nodeID = strings.TrimSpace(nodeID)
 	eventID = strings.TrimSpace(eventID)
@@ -88,6 +141,43 @@ func (s *WorkflowInstanceStore) SystemNodeProcessed(ctx context.Context, nodeID,
 			  AND idempotency_key = $2
 		)
 	`, nodeID, SystemNodeReceiptIdempotencyKey(nodeID, eventID)).Scan(&ok)
+	return ok, err
+}
+
+func (s *WorkflowInstanceStore) SystemNodeProcessedForTarget(ctx context.Context, nodeID, eventID string, target events.RouteIdentity) (bool, error) {
+	target = target.Normalized()
+	if target.Empty() {
+		return s.SystemNodeProcessed(ctx, nodeID, eventID)
+	}
+	nodeID = strings.TrimSpace(nodeID)
+	eventID = strings.TrimSpace(eventID)
+	if s == nil || s.db == nil || nodeID == "" || eventID == "" {
+		return false, nil
+	}
+	idempotencyKey := systemNodeReceiptIdempotencyKeyForTarget(nodeID, eventID, target)
+	if s.isSQLite() {
+		var ok bool
+		err := dbQueryRowContext(ctx, s.db, `
+			SELECT EXISTS(
+				SELECT 1
+				FROM event_receipts
+				WHERE subscriber_type = 'node'
+				  AND subscriber_id = ?
+				  AND idempotency_key = ?
+			)
+		`, nodeID, idempotencyKey).Scan(&ok)
+		return ok, err
+	}
+	var ok bool
+	err := dbQueryRowContext(ctx, s.db, `
+		SELECT EXISTS(
+			SELECT 1
+			FROM event_receipts
+			WHERE subscriber_type = 'node'
+			  AND subscriber_id = $1
+			  AND idempotency_key = $2
+		)
+	`, nodeID, idempotencyKey).Scan(&ok)
 	return ok, err
 }
 
@@ -142,6 +232,22 @@ func (s *WorkflowInstanceStore) MarkSystemNodeProcessedAndSettleDelivery(ctx con
 	return persistSystemNodeProcessedReceiptAndSettleDelivery(ctx, s.db, nodeID, eventID, sideEffects)
 }
 
+func (s *WorkflowInstanceStore) MarkSystemNodeProcessedAndSettleDeliveryForTarget(ctx context.Context, nodeID, eventID string, target events.RouteIdentity, sideEffects string) error {
+	target = target.Normalized()
+	if target.Empty() {
+		return s.MarkSystemNodeProcessedAndSettleDelivery(ctx, nodeID, eventID, sideEffects)
+	}
+	nodeID = strings.TrimSpace(nodeID)
+	eventID = strings.TrimSpace(eventID)
+	if s == nil || s.db == nil || nodeID == "" || eventID == "" {
+		return nil
+	}
+	if s.isSQLite() {
+		return s.markSQLiteSystemNodeProcessedAndSettleDeliveryForTarget(ctx, nodeID, eventID, target, sideEffects)
+	}
+	return persistSystemNodeProcessedReceiptAndSettleDeliveryForTarget(ctx, s.db, nodeID, eventID, target, sideEffects)
+}
+
 func (s *WorkflowInstanceStore) MarkSystemNodeDeliveryInProgress(ctx context.Context, nodeID, eventID string, retryLimit int) error {
 	nodeID = strings.TrimSpace(nodeID)
 	eventID = strings.TrimSpace(eventID)
@@ -153,6 +259,23 @@ func (s *WorkflowInstanceStore) MarkSystemNodeDeliveryInProgress(ctx context.Con
 		return s.markSQLiteSystemNodeDeliveryInProgress(ctx, nodeID, eventID, retryLimit)
 	}
 	return markPostgresSystemNodeDeliveryInProgress(ctx, s.db, nodeID, eventID, retryLimit)
+}
+
+func (s *WorkflowInstanceStore) MarkSystemNodeDeliveryInProgressForTarget(ctx context.Context, nodeID, eventID string, target events.RouteIdentity, retryLimit int) error {
+	target = target.Normalized()
+	if target.Empty() {
+		return s.MarkSystemNodeDeliveryInProgress(ctx, nodeID, eventID, retryLimit)
+	}
+	nodeID = strings.TrimSpace(nodeID)
+	eventID = strings.TrimSpace(eventID)
+	retryLimit = normalizeSystemNodeRetryLimit(retryLimit)
+	if s == nil || s.db == nil || nodeID == "" || eventID == "" {
+		return nil
+	}
+	if s.isSQLite() {
+		return s.markSQLiteSystemNodeDeliveryInProgressForTarget(ctx, nodeID, eventID, target, retryLimit)
+	}
+	return markPostgresSystemNodeDeliveryInProgressForTarget(ctx, s.db, nodeID, eventID, target, retryLimit)
 }
 
 func (s *WorkflowInstanceStore) MarkSystemNodeDeliveryFailed(ctx context.Context, nodeID, eventID, reasonCode, errText string, retryCount, retryLimit int) error {
@@ -168,6 +291,23 @@ func (s *WorkflowInstanceStore) MarkSystemNodeDeliveryFailed(ctx context.Context
 	return markPostgresSystemNodeDeliveryFailed(ctx, s.db, nodeID, eventID, reasonCode, errText, retryCount, retryLimit)
 }
 
+func (s *WorkflowInstanceStore) MarkSystemNodeDeliveryFailedForTarget(ctx context.Context, nodeID, eventID string, target events.RouteIdentity, reasonCode, errText string, retryCount, retryLimit int) error {
+	target = target.Normalized()
+	if target.Empty() {
+		return s.MarkSystemNodeDeliveryFailed(ctx, nodeID, eventID, reasonCode, errText, retryCount, retryLimit)
+	}
+	nodeID = strings.TrimSpace(nodeID)
+	eventID = strings.TrimSpace(eventID)
+	retryLimit = normalizeSystemNodeRetryLimit(retryLimit)
+	if s == nil || s.db == nil || nodeID == "" || eventID == "" {
+		return nil
+	}
+	if s.isSQLite() {
+		return s.markSQLiteSystemNodeDeliveryFailedForTarget(ctx, nodeID, eventID, target, reasonCode, errText, retryCount, retryLimit)
+	}
+	return markPostgresSystemNodeDeliveryFailedForTarget(ctx, s.db, nodeID, eventID, target, reasonCode, errText, retryCount, retryLimit)
+}
+
 func (s *WorkflowInstanceStore) MarkSystemNodeDeliveryDeadLetter(ctx context.Context, nodeID, eventID, reasonCode, errText string, retryCount int, sideEffects string) error {
 	nodeID = strings.TrimSpace(nodeID)
 	eventID = strings.TrimSpace(eventID)
@@ -178,6 +318,22 @@ func (s *WorkflowInstanceStore) MarkSystemNodeDeliveryDeadLetter(ctx context.Con
 		return s.markSQLiteSystemNodeDeliveryDeadLetter(ctx, nodeID, eventID, reasonCode, errText, retryCount, sideEffects)
 	}
 	return markPostgresSystemNodeDeliveryDeadLetter(ctx, s.db, nodeID, eventID, reasonCode, errText, retryCount, sideEffects)
+}
+
+func (s *WorkflowInstanceStore) MarkSystemNodeDeliveryDeadLetterForTarget(ctx context.Context, nodeID, eventID string, target events.RouteIdentity, reasonCode, errText string, retryCount int, sideEffects string) error {
+	target = target.Normalized()
+	if target.Empty() {
+		return s.MarkSystemNodeDeliveryDeadLetter(ctx, nodeID, eventID, reasonCode, errText, retryCount, sideEffects)
+	}
+	nodeID = strings.TrimSpace(nodeID)
+	eventID = strings.TrimSpace(eventID)
+	if s == nil || s.db == nil || nodeID == "" || eventID == "" {
+		return nil
+	}
+	if s.isSQLite() {
+		return s.markSQLiteSystemNodeDeliveryDeadLetterForTarget(ctx, nodeID, eventID, target, reasonCode, errText, retryCount, sideEffects)
+	}
+	return markPostgresSystemNodeDeliveryDeadLetterForTarget(ctx, s.db, nodeID, eventID, target, reasonCode, errText, retryCount, sideEffects)
 }
 
 func (s *WorkflowInstanceStore) markSQLiteSystemNodeProcessedAndSettleDelivery(ctx context.Context, nodeID, eventID, sideEffects string) error {
@@ -243,6 +399,73 @@ func (s *WorkflowInstanceStore) markSQLiteSystemNodeProcessedAndSettleDelivery(c
 	})
 }
 
+func (s *WorkflowInstanceStore) markSQLiteSystemNodeProcessedAndSettleDeliveryForTarget(ctx context.Context, nodeID, eventID string, target events.RouteIdentity, sideEffects string) error {
+	target = target.Normalized()
+	targetJSON := systemNodeRouteIdentityJSON(target)
+	return s.runInPipelineTransaction(ctx, func(txctx context.Context, tx *sql.Tx) error {
+		retryLimit := normalizeSystemNodeRetryLimit(DefaultSystemNodeRetryLimit)
+		authorized, err := sqliteSystemNodeDeliveryAuthorizedForTargetTx(txctx, tx, nodeID, eventID, target, retryLimit)
+		if err != nil {
+			return fmt.Errorf("query sqlite system node delivery authority: %w", err)
+		}
+		if !authorized {
+			return fmt.Errorf("%w: node %s event %s target %s", ErrSystemNodeDeliveryAuthorityMissing, nodeID, eventID, targetJSON)
+		}
+		now := time.Now().UTC()
+		idempotencyKey := systemNodeReceiptIdempotencyKeyForTarget(nodeID, eventID, target)
+		res, err := tx.ExecContext(txctx, `
+			INSERT INTO event_receipts (
+				receipt_id, event_id, subscriber_type, subscriber_id, entity_id, flow_instance,
+				outcome, reason_code, side_effects, idempotency_key, processed_at
+			)
+			SELECT
+				?, e.event_id, 'node', ?, e.entity_id, e.flow_instance,
+				'no_op', 'idempotent_no_op', ?, ?, ?
+			FROM events e
+			WHERE e.event_id = ?
+			ON CONFLICT(event_id, subscriber_type, subscriber_id) DO UPDATE SET
+				entity_id = excluded.entity_id,
+				flow_instance = excluded.flow_instance,
+				outcome = excluded.outcome,
+				reason_code = excluded.reason_code,
+				side_effects = excluded.side_effects,
+				idempotency_key = excluded.idempotency_key,
+				processed_at = excluded.processed_at
+		`, uuid.NewString(), nodeID, sqliteNodeJSON(sideEffects), idempotencyKey, now, eventID)
+		if err != nil {
+			return fmt.Errorf("upsert sqlite targeted system node receipt: %w", err)
+		}
+		if rows, err := res.RowsAffected(); err == nil && rows == 0 {
+			return fmt.Errorf("upsert sqlite targeted system node receipt: event %s not found", eventID)
+		}
+		res, err = tx.ExecContext(txctx, `
+			UPDATE event_deliveries
+			SET status = 'delivered',
+			    retry_count = COALESCE(retry_count, 0),
+			    reason_code = 'node_processed',
+			    last_error = NULL,
+			    active_session_id = NULL,
+			    started_at = COALESCE(started_at, created_at),
+			    delivered_at = ?
+			WHERE event_id = ?
+			  AND subscriber_type = 'node'
+			  AND subscriber_id = ?
+			  AND COALESCE(delivery_target_route, '{}') = ?
+			  AND (
+				status IN ('pending', 'in_progress')
+				OR (status = 'failed' AND COALESCE(retry_count, 0) < ?)
+			  )
+			`, now, eventID, nodeID, targetJSON, retryLimit)
+		if err != nil {
+			return fmt.Errorf("settle sqlite targeted system node delivery: %w", err)
+		}
+		if rows, _ := res.RowsAffected(); rows > 0 {
+			return nil
+		}
+		return nil
+	})
+}
+
 func (s *WorkflowInstanceStore) markSQLiteSystemNodeDeliveryInProgress(ctx context.Context, nodeID, eventID string, retryLimit int) error {
 	retryLimit = normalizeSystemNodeRetryLimit(retryLimit)
 	return s.runInPipelineTransaction(ctx, func(txctx context.Context, tx *sql.Tx) error {
@@ -280,6 +503,46 @@ func (s *WorkflowInstanceStore) markSQLiteSystemNodeDeliveryInProgress(ctx conte
 	})
 }
 
+func (s *WorkflowInstanceStore) markSQLiteSystemNodeDeliveryInProgressForTarget(ctx context.Context, nodeID, eventID string, target events.RouteIdentity, retryLimit int) error {
+	retryLimit = normalizeSystemNodeRetryLimit(retryLimit)
+	target = target.Normalized()
+	targetJSON := systemNodeRouteIdentityJSON(target)
+	return s.runInPipelineTransaction(ctx, func(txctx context.Context, tx *sql.Tx) error {
+		authorized, err := sqliteSystemNodeDeliveryAuthorizedForTargetTx(txctx, tx, nodeID, eventID, target, retryLimit)
+		if err != nil {
+			return fmt.Errorf("query sqlite system node delivery authority: %w", err)
+		}
+		if !authorized {
+			return fmt.Errorf("%w: node %s event %s target %s", ErrSystemNodeDeliveryAuthorityMissing, nodeID, eventID, targetJSON)
+		}
+		now := time.Now().UTC()
+		res, err := tx.ExecContext(txctx, `
+			UPDATE event_deliveries
+			SET status = 'in_progress',
+			    reason_code = 'node_processing',
+			    last_error = NULL,
+			    active_session_id = NULL,
+			    started_at = COALESCE(started_at, ?),
+			    delivered_at = NULL
+			WHERE event_id = ?
+			  AND subscriber_type = 'node'
+			  AND subscriber_id = ?
+			  AND COALESCE(delivery_target_route, '{}') = ?
+			  AND (
+				status IN ('pending', 'in_progress')
+				OR (status = 'failed' AND COALESCE(retry_count, 0) < ?)
+			  )
+		`, now, eventID, nodeID, targetJSON, retryLimit)
+		if err != nil {
+			return fmt.Errorf("mark sqlite targeted system node delivery in progress: %w", err)
+		}
+		if rows, _ := res.RowsAffected(); rows == 0 {
+			return fmt.Errorf("%w: node %s event %s target %s", ErrSystemNodeDeliveryAuthorityMissing, nodeID, eventID, targetJSON)
+		}
+		return nil
+	})
+}
+
 func (s *WorkflowInstanceStore) markSQLiteSystemNodeDeliveryFailed(ctx context.Context, nodeID, eventID, reasonCode, errText string, retryCount, retryLimit int) error {
 	retryLimit = normalizeSystemNodeRetryLimit(retryLimit)
 	return s.runInPipelineTransaction(ctx, func(txctx context.Context, tx *sql.Tx) error {
@@ -311,6 +574,45 @@ func (s *WorkflowInstanceStore) markSQLiteSystemNodeDeliveryFailed(ctx context.C
 		}
 		if rows, _ := res.RowsAffected(); rows == 0 {
 			return fmt.Errorf("%w: node %s event %s", ErrSystemNodeDeliveryAuthorityMissing, nodeID, eventID)
+		}
+		return nil
+	})
+}
+
+func (s *WorkflowInstanceStore) markSQLiteSystemNodeDeliveryFailedForTarget(ctx context.Context, nodeID, eventID string, target events.RouteIdentity, reasonCode, errText string, retryCount, retryLimit int) error {
+	retryLimit = normalizeSystemNodeRetryLimit(retryLimit)
+	target = target.Normalized()
+	targetJSON := systemNodeRouteIdentityJSON(target)
+	return s.runInPipelineTransaction(ctx, func(txctx context.Context, tx *sql.Tx) error {
+		authorized, err := sqliteSystemNodeDeliveryAuthorizedForTargetTx(txctx, tx, nodeID, eventID, target, retryLimit)
+		if err != nil {
+			return fmt.Errorf("query sqlite system node delivery authority: %w", err)
+		}
+		if !authorized {
+			return fmt.Errorf("%w: node %s event %s target %s", ErrSystemNodeDeliveryAuthorityMissing, nodeID, eventID, targetJSON)
+		}
+		now := time.Now().UTC()
+		res, err := tx.ExecContext(txctx, `
+			UPDATE event_deliveries
+			SET status = 'failed',
+			    retry_count = ?,
+			    reason_code = NULLIF(?, ''),
+			    last_error = NULLIF(?, ''),
+			    active_session_id = NULL,
+			    started_at = COALESCE(started_at, created_at),
+			    delivered_at = ?
+			WHERE event_id = ?
+			  AND subscriber_type = 'node'
+			  AND subscriber_id = ?
+			  AND COALESCE(delivery_target_route, '{}') = ?
+			  AND status IN ('pending', 'in_progress', 'failed')
+			  AND COALESCE(retry_count, 0) < ?
+		`, sanitizedSystemNodeRetryCount(retryCount), sanitizeSystemNodeReasonCode(reasonCode, "handler_error"), strings.TrimSpace(errText), now, eventID, nodeID, targetJSON, retryLimit)
+		if err != nil {
+			return fmt.Errorf("mark sqlite targeted system node delivery failed: %w", err)
+		}
+		if rows, _ := res.RowsAffected(); rows == 0 {
+			return fmt.Errorf("%w: node %s event %s target %s", ErrSystemNodeDeliveryAuthorityMissing, nodeID, eventID, targetJSON)
 		}
 		return nil
 	})
@@ -377,6 +679,71 @@ func (s *WorkflowInstanceStore) markSQLiteSystemNodeDeliveryDeadLetter(ctx conte
 	})
 }
 
+func (s *WorkflowInstanceStore) markSQLiteSystemNodeDeliveryDeadLetterForTarget(ctx context.Context, nodeID, eventID string, target events.RouteIdentity, reasonCode, errText string, retryCount int, sideEffects string) error {
+	target = target.Normalized()
+	targetJSON := systemNodeRouteIdentityJSON(target)
+	return s.runInPipelineTransaction(ctx, func(txctx context.Context, tx *sql.Tx) error {
+		exists, err := sqliteSystemNodeDeliveryRowExistsForTargetTx(txctx, tx, nodeID, eventID, target)
+		if err != nil {
+			return fmt.Errorf("query sqlite targeted system node delivery row: %w", err)
+		}
+		if !exists {
+			return fmt.Errorf("%w: node %s event %s target %s", ErrSystemNodeDeliveryAuthorityMissing, nodeID, eventID, targetJSON)
+		}
+		now := time.Now().UTC()
+		reasonCode = sanitizeSystemNodeReasonCode(reasonCode, "retry_exhausted")
+		errText = strings.TrimSpace(errText)
+		res, err := tx.ExecContext(txctx, `
+			UPDATE event_deliveries
+			SET status = 'dead_letter',
+			    retry_count = ?,
+			    reason_code = NULLIF(?, ''),
+			    last_error = NULLIF(?, ''),
+			    active_session_id = NULL,
+			    started_at = COALESCE(started_at, created_at),
+			    delivered_at = ?
+			WHERE event_id = ?
+			  AND subscriber_type = 'node'
+			  AND subscriber_id = ?
+			  AND COALESCE(delivery_target_route, '{}') = ?
+			  AND status IN ('pending', 'in_progress', 'failed')
+		`, sanitizedSystemNodeRetryCount(retryCount), reasonCode, errText, now, eventID, nodeID, targetJSON)
+		if err != nil {
+			return fmt.Errorf("dead-letter sqlite targeted system node delivery: %w", err)
+		}
+		if rows, _ := res.RowsAffected(); rows == 0 {
+			return fmt.Errorf("%w: node %s event %s target %s", ErrSystemNodeDeliveryAuthorityMissing, nodeID, eventID, targetJSON)
+		}
+		idempotencyKey := systemNodeReceiptIdempotencyKeyForTarget(nodeID, eventID, target)
+		res, err = tx.ExecContext(txctx, `
+			INSERT INTO event_receipts (
+				receipt_id, event_id, subscriber_type, subscriber_id, entity_id, flow_instance,
+				outcome, reason_code, side_effects, idempotency_key, processed_at
+			)
+			SELECT
+				?, e.event_id, 'node', ?, e.entity_id, e.flow_instance,
+				'dead_letter', NULLIF(?, ''), ?, ?, ?
+			FROM events e
+			WHERE e.event_id = ?
+			ON CONFLICT(event_id, subscriber_type, subscriber_id) DO UPDATE SET
+				entity_id = excluded.entity_id,
+				flow_instance = excluded.flow_instance,
+				outcome = excluded.outcome,
+				reason_code = excluded.reason_code,
+				side_effects = excluded.side_effects,
+				idempotency_key = excluded.idempotency_key,
+				processed_at = excluded.processed_at
+		`, uuid.NewString(), nodeID, reasonCode, sqliteNodeJSON(sideEffects), idempotencyKey, now, eventID)
+		if err != nil {
+			return fmt.Errorf("upsert sqlite targeted system node dead-letter receipt: %w", err)
+		}
+		if rows, err := res.RowsAffected(); err == nil && rows == 0 {
+			return fmt.Errorf("upsert sqlite targeted system node dead-letter receipt: event %s not found", eventID)
+		}
+		return nil
+	})
+}
+
 func sqliteSystemNodeDeliveryAuthorizedTx(ctx context.Context, tx *sql.Tx, nodeID, eventID string, retryLimit int) (bool, error) {
 	if tx == nil {
 		return false, nil
@@ -402,6 +769,32 @@ func sqliteSystemNodeDeliveryAuthorizedTx(ctx context.Context, tx *sql.Tx, nodeI
 	return ok, err
 }
 
+func sqliteSystemNodeDeliveryAuthorizedForTargetTx(ctx context.Context, tx *sql.Tx, nodeID, eventID string, target events.RouteIdentity, retryLimit int) (bool, error) {
+	if tx == nil {
+		return false, nil
+	}
+	retryLimit = normalizeSystemNodeRetryLimit(retryLimit)
+	if _, err := uuid.Parse(strings.TrimSpace(eventID)); err != nil {
+		return false, nil
+	}
+	var ok bool
+	err := tx.QueryRowContext(ctx, `
+		SELECT EXISTS (
+			SELECT 1
+			FROM event_deliveries
+			WHERE event_id = ?
+			  AND subscriber_type = 'node'
+			  AND subscriber_id = ?
+			  AND COALESCE(delivery_target_route, '{}') = ?
+			  AND (
+				status IN ('pending', 'in_progress')
+				OR (status = 'failed' AND COALESCE(retry_count, 0) < ?)
+			  )
+			)
+	`, strings.TrimSpace(eventID), strings.TrimSpace(nodeID), systemNodeRouteIdentityJSON(target), retryLimit).Scan(&ok)
+	return ok, err
+}
+
 func sqliteSystemNodeDeliveryRowExistsTx(ctx context.Context, tx *sql.Tx, nodeID, eventID string) (bool, error) {
 	if tx == nil {
 		return false, nil
@@ -420,6 +813,58 @@ func sqliteSystemNodeDeliveryRowExistsTx(ctx context.Context, tx *sql.Tx, nodeID
 		)
 	`, strings.TrimSpace(eventID), strings.TrimSpace(nodeID)).Scan(&ok)
 	return ok, err
+}
+
+func sqliteSystemNodeDeliveryRowExistsForTargetTx(ctx context.Context, tx *sql.Tx, nodeID, eventID string, target events.RouteIdentity) (bool, error) {
+	if tx == nil {
+		return false, nil
+	}
+	if _, err := uuid.Parse(strings.TrimSpace(eventID)); err != nil {
+		return false, nil
+	}
+	var ok bool
+	err := tx.QueryRowContext(ctx, `
+		SELECT EXISTS (
+			SELECT 1
+			FROM event_deliveries
+			WHERE event_id = ?
+			  AND subscriber_type = 'node'
+			  AND subscriber_id = ?
+			  AND COALESCE(delivery_target_route, '{}') = ?
+		)
+	`, strings.TrimSpace(eventID), strings.TrimSpace(nodeID), systemNodeRouteIdentityJSON(target)).Scan(&ok)
+	return ok, err
+}
+
+func systemNodeRouteIdentityJSON(route events.RouteIdentity) string {
+	route = route.Normalized()
+	if route.Empty() {
+		return "{}"
+	}
+	payload := map[string]string{}
+	if route.FlowInstance != "" {
+		payload["flow_instance"] = route.FlowInstance
+	}
+	if route.EntityID != "" {
+		payload["entity_id"] = route.EntityID
+	}
+	if route.FlowID != "" {
+		payload["flow_id"] = route.FlowID
+	}
+	encoded, err := json.Marshal(payload)
+	if err != nil {
+		return "{}"
+	}
+	return string(encoded)
+}
+
+func systemNodeReceiptIdempotencyKeyForTarget(nodeID, eventID string, target events.RouteIdentity) string {
+	base := SystemNodeReceiptIdempotencyKey(nodeID, eventID)
+	target = target.Normalized()
+	if target.Empty() {
+		return base
+	}
+	return base + ":target:" + systemNodeRouteIdentityJSON(target)
 }
 
 func sqliteNodeJSON(raw string) string {

--- a/internal/runtime/pipeline/workflow_instance_store_sqlite_test.go
+++ b/internal/runtime/pipeline/workflow_instance_store_sqlite_test.go
@@ -378,6 +378,7 @@ func createSQLiteWorkflowInstanceStoreTestSchema(t *testing.T, db *sql.DB) {
 			event_id TEXT,
 			subscriber_type TEXT,
 			subscriber_id TEXT,
+			delivery_target_route TEXT,
 			status TEXT,
 			retry_count INTEGER,
 			reason_code TEXT,

--- a/internal/runtime/pipeline/workflow_nodes.go
+++ b/internal/runtime/pipeline/workflow_nodes.go
@@ -837,8 +837,15 @@ func (pc *PipelineCoordinator) markWorkflowNodeProcessed(ctx context.Context, no
 	if !pc.eventReceiptsAvailable(ctx) {
 		return
 	}
-	sideEffects := systemNodeProcessedReceiptSideEffects(nodeID, eventID)
-	if err := pc.workflowStore.MarkSystemNodeProcessedAndSettleDelivery(ctx, nodeID, eventID, sideEffects); err != nil {
+	target := systemNodeDeliveryTarget(evt)
+	sideEffects := systemNodeProcessedReceiptSideEffects(nodeID, eventID, target)
+	var err error
+	if !target.Empty() {
+		err = pc.workflowStore.MarkSystemNodeProcessedAndSettleDeliveryForTarget(ctx, nodeID, eventID, target, sideEffects)
+	} else {
+		err = pc.workflowStore.MarkSystemNodeProcessedAndSettleDelivery(ctx, nodeID, eventID, sideEffects)
+	}
+	if err != nil {
 		if logger, ok := pc.bus.(systemNodeRuntimeLogger); ok && logger != nil {
 			logger.LogRuntime(ctx, RuntimeLogEntry{
 				Level:     "error",
@@ -869,6 +876,14 @@ func (pc *PipelineCoordinator) markWorkflowNodeDeliveryInProgress(ctx context.Co
 	if !pc.eventReceiptsAvailable(ctx) {
 		return false
 	}
+	if target := systemNodeDeliveryTarget(evt); !target.Empty() {
+		if err := pc.workflowStore.MarkSystemNodeDeliveryInProgressForTarget(ctx, nodeID, eventID, target, DefaultSystemNodeRetryLimit); err != nil {
+			pc.logWorkflowNodeDeliveryTransitionError(ctx, nodeID, evt, "mark_delivery_in_progress_failed", "Marking the targeted workflow node delivery in progress failed", err)
+			return false
+		}
+		pc.notifyTestLifecycleDeliveryStatus(ctx, nodeID, evt, "in_progress")
+		return true
+	}
 	if err := pc.workflowStore.MarkSystemNodeDeliveryInProgress(ctx, nodeID, eventID, DefaultSystemNodeRetryLimit); err != nil {
 		pc.logWorkflowNodeDeliveryTransitionError(ctx, nodeID, evt, "mark_delivery_in_progress_failed", "Marking the workflow node delivery in progress failed", err)
 		return false
@@ -893,8 +908,15 @@ func (pc *PipelineCoordinator) markWorkflowNodeDeliveryDeadLetter(ctx context.Co
 	if cause != nil {
 		errText = strings.TrimSpace(cause.Error())
 	}
-	sideEffects := systemNodeDeadLetterReceiptSideEffects(nodeID, eventID, reasonCode, errText, retryCount)
-	if err := pc.workflowStore.MarkSystemNodeDeliveryDeadLetter(ctx, nodeID, eventID, reasonCode, errText, retryCount, sideEffects); err != nil {
+	target := systemNodeDeliveryTarget(evt)
+	sideEffects := systemNodeDeadLetterReceiptSideEffects(nodeID, eventID, reasonCode, errText, retryCount, target)
+	var err error
+	if !target.Empty() {
+		err = pc.workflowStore.MarkSystemNodeDeliveryDeadLetterForTarget(ctx, nodeID, eventID, target, reasonCode, errText, retryCount, sideEffects)
+	} else {
+		err = pc.workflowStore.MarkSystemNodeDeliveryDeadLetter(ctx, nodeID, eventID, reasonCode, errText, retryCount, sideEffects)
+	}
+	if err != nil {
 		pc.logWorkflowNodeDeliveryTransitionError(ctx, nodeID, evt, "mark_delivery_dead_letter_failed", "Marking the workflow node delivery as dead_letter failed", err)
 		return
 	}
@@ -937,6 +959,38 @@ func (pc *PipelineCoordinator) workflowNodeDeliveryAuthorized(ctx context.Contex
 	eventID := strings.TrimSpace(evt.ID())
 	if eventID == "" {
 		return false
+	}
+	if target := systemNodeDeliveryTarget(evt); !target.Empty() {
+		ok, err := pc.workflowStore.SystemNodeDeliveryAuthorizedForTarget(ctx, nodeID, eventID, target, DefaultSystemNodeRetryLimit)
+		if err != nil {
+			if logger, logOK := pc.bus.(systemNodeRuntimeLogger); logOK && logger != nil {
+				logger.LogRuntime(ctx, RuntimeLogEntry{
+					Level:     "error",
+					Message:   "Checking targeted workflow node delivery authority failed",
+					Component: nodeID,
+					Action:    "delivery_authority_check_failed",
+					EventID:   eventID,
+					EventType: strings.TrimSpace(string(evt.Type())),
+					EntityID:  workflowEventEntityID(evt),
+					Error:     strings.TrimSpace(err.Error()),
+				})
+			}
+			return false
+		}
+		if !ok {
+			if logger, logOK := pc.bus.(systemNodeRuntimeLogger); logOK && logger != nil {
+				logger.LogRuntime(ctx, RuntimeLogEntry{
+					Level:     "error",
+					Message:   "Targeted workflow node delivery authority is missing; handler execution skipped",
+					Component: nodeID,
+					Action:    "delivery_authority_missing",
+					EventID:   eventID,
+					EventType: strings.TrimSpace(string(evt.Type())),
+					EntityID:  workflowEventEntityID(evt),
+				})
+			}
+		}
+		return ok
 	}
 	ok, err := pc.workflowStore.SystemNodeDeliveryAuthorized(ctx, nodeID, eventID, DefaultSystemNodeRetryLimit)
 	if err != nil {
@@ -981,6 +1035,10 @@ func (pc *PipelineCoordinator) workflowNodeEventProcessed(ctx context.Context, n
 	}
 	if !pc.eventReceiptsAvailable(ctx) {
 		return false
+	}
+	if target := systemNodeDeliveryTarget(evt); !target.Empty() {
+		ok, err := pc.workflowStore.SystemNodeProcessedForTarget(ctx, nodeID, eventID, target)
+		return err == nil && ok
 	}
 	ok, err := pc.workflowStore.SystemNodeProcessed(ctx, nodeID, eventID)
 	return err == nil && ok


### PR DESCRIPTION
## Summary

- Derive targeted route-planning keys from `event.target` / `event.target_set` so materialized route-table node subscribers are visible to the publish-time RoutePlan.
- Persist targeted route-table workflow-node delivery intents as typed `event_deliveries` rows with the semantic node `subscriber_id` and concrete `delivery_target_route`.
- Replace the dynamic flow target split proof with successful `task-handler` delivery, no target-resolution dead letter, and `node_processed` execution proof.

Closes #1410

## Governing Refs

- `platform-spec.yaml:266-315`: route identity, `event.target`, `event.target_set`, and per-target delivery-row route identity.
- `platform-spec.yaml:437-660`: RoutePlan is publish-time route authority; `event_deliveries` is the durable authority sink.
- `platform-spec.yaml:1888-1943`: flow/match fan-out, structural ParentRoute, target filtering, and inherited persisted delivery list behavior.
- Binding issue/gate context: #1410 pre-audit and Gate C approval for `targeted_route_table_workflow_node_delivery_materialization`.

## Semantic Migration

- New canonical owner: EventBus RoutePlan / `delivery_planner.go` produces targeted workflow-node delivery intents; persisted `event_deliveries` rows remain the durable execution authority.
- Old invalid evidence: target envelope presence, live `workflow-runtime` carrier delivery, route-table existence, handler lookup, replay-scope rows, dead letters, receipts, or readback projections are not delivery authority.
- Production paths checked: singular `event.target`, dynamic flow match target, structural ParentRoute-shaped target, `event.target_set`, EventBus persistence, and runtime node execution through `node_processed`.
- Migration completeness: complete for the approved #1410 child class; broader routing architecture trackers #1340/#1353 remain open.

## Validation

- `go test ./internal/runtime/bus -run 'TestDeliveryPlanner_(DoesNotDeadLetterTargetedWorkflowNodeSubscriber|TargetedParentRoutePersistsSemanticNodeRoute|ExpandsTargetSetForInternalWorkflowRecipient)|TestEventBusPublish_(TargetSetInternalDeliveryUsesPerTargetRoutes|TargetedRouteTableNodePersistsSemanticNodeRoute|TargetedTemplateInstanceRouteTableNodePersistsSemanticNodeRoute|TargetedDynamicFlowFixtureRouteTableNodePersistsSemanticNodeRoute)' -count=1`
- `go test ./internal/runtime/cataloge2e -run TestTier11DynamicFlowInstanceFlowMatchTarget_RealRuntime -count=1`
- `go test ./internal/runtime/bus ./internal/runtime/cataloge2e -count=1`
- `go test ./...`
