### PR TITLE
[agent-b][issue #1420] Add trace delivery detail rendering

### DIFF
--- a/cmd/swarm/diagnostics.go
+++ b/cmd/swarm/diagnostics.go
@@ -33,6 +33,7 @@ type diagnosticTraceOptions struct {
 	apiOptions       rootCommandOptions
 	follow           bool
 	noRetry          bool
+	deliveryDetail   bool
 	since            string
 	until            string
 	limit            int
@@ -111,12 +112,16 @@ type diagnosticRunTraceRow struct {
 	EventName             string `json:"event_name"`
 	EventCreatedAt        string `json:"event_created_at"`
 	EntityID              string `json:"entity_id,omitempty"`
+	DeliveryID            string `json:"delivery_id,omitempty"`
 	DeliveryStatus        string `json:"delivery_status,omitempty"`
 	DeliveryReasonCode    string `json:"delivery_reason_code,omitempty"`
 	DeliveryLastError     string `json:"delivery_last_error,omitempty"`
 	DeliveryRetryCount    int    `json:"delivery_retry_count,omitempty"`
 	DeliveryRetryEligible bool   `json:"delivery_retry_eligible,omitempty"`
 	DeliveryTerminal      bool   `json:"delivery_terminal,omitempty"`
+	DeliveryCreatedAt     string `json:"delivery_created_at,omitempty"`
+	DeliveryStartedAt     string `json:"delivery_started_at,omitempty"`
+	DeliveryDeliveredAt   string `json:"delivery_delivered_at,omitempty"`
 	SubscriberType        string `json:"subscriber_type,omitempty"`
 	SubscriberID          string `json:"subscriber_id,omitempty"`
 	SessionID             string `json:"session_id,omitempty"`
@@ -260,6 +265,7 @@ func newTraceCommand(opts rootCommandOptions) *cobra.Command {
 	}
 	cmd.Flags().BoolVarP(&traceOpts.follow, "follow", "f", false, "Follow live trace rows through /v1/ws run.subscribe_trace")
 	cmd.Flags().BoolVar(&traceOpts.noRetry, "no-retry", false, "Disable trace follow reconnect/recovery retries")
+	cmd.Flags().BoolVar(&traceOpts.deliveryDetail, "delivery-detail", false, "Show snapshot delivery lifecycle fields from RunTraceRow")
 	cmd.Flags().StringVar(&traceOpts.since, "since", "", "Snapshot-only RFC3339 trace materialization watermark")
 	cmd.Flags().StringVar(&traceOpts.until, "until", "", "Snapshot-only inclusive RFC3339 trace materialization upper bound")
 	cmd.Flags().IntVar(&traceOpts.limit, "limit", 0, "Snapshot-only page size, 1-2000")
@@ -485,7 +491,7 @@ func runDiagnosticTraceCommand(ctx context.Context, out, errOut io.Writer, opts 
 	if err := validateDiagnosticRunTraceResult(result); err != nil {
 		return returnCLIAPIError(errOut, err, diagnosticRunAPIErrorClassifier())
 	}
-	writeDiagnosticRunTrace(out, runID, result)
+	writeDiagnosticRunTrace(out, runID, result, opts.deliveryDetail)
 	return nil
 }
 
@@ -556,6 +562,7 @@ func (o diagnosticTraceOptions) followParams() (map[string]any, error) {
 		{name: "--until", set: o.untilSet},
 		{name: "--limit", set: o.limitSet},
 		{name: "--cursor", set: o.cursorSet},
+		{name: "--delivery-detail", set: o.deliveryDetail},
 	} {
 		if flag.set {
 			return nil, fmt.Errorf("%s is not supported with --follow", flag.name)
@@ -1047,6 +1054,18 @@ func validateDiagnosticRunTraceResult(result diagnosticRunTraceResult) error {
 		if err := validateRequiredTimestamp(fmt.Sprintf("trace[%d].event_created_at", i), row.EventCreatedAt); err != nil {
 			return err
 		}
+		for _, field := range []struct {
+			name  string
+			value string
+		}{
+			{name: "delivery_created_at", value: row.DeliveryCreatedAt},
+			{name: "delivery_started_at", value: row.DeliveryStartedAt},
+			{name: "delivery_delivered_at", value: row.DeliveryDeliveredAt},
+		} {
+			if err := validateOptionalTimestamp(fmt.Sprintf("trace[%d].%s", i, field.name), field.value); err != nil {
+				return err
+			}
+		}
 	}
 	return nil
 }
@@ -1123,6 +1142,17 @@ func validateRequiredTimestamp(field, value string) error {
 	value = strings.TrimSpace(value)
 	if value == "" {
 		return fmt.Errorf("malformed result: %s is required", field)
+	}
+	if _, err := time.Parse(time.RFC3339Nano, value); err != nil {
+		return fmt.Errorf("malformed result: %s must be an RFC3339 timestamp: %w", field, err)
+	}
+	return nil
+}
+
+func validateOptionalTimestamp(field, value string) error {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return nil
 	}
 	if _, err := time.Parse(time.RFC3339Nano, value); err != nil {
 		return fmt.Errorf("malformed result: %s must be an RFC3339 timestamp: %w", field, err)
@@ -1219,13 +1249,15 @@ func writeDiagnosticRunDiagnosis(out io.Writer, result diagnosticRunDiagnosisRes
 	}
 }
 
-func writeDiagnosticRunTrace(out io.Writer, runID string, result diagnosticRunTraceResult) {
+func writeDiagnosticRunTrace(out io.Writer, runID string, result diagnosticRunTraceResult, deliveryDetail bool) {
 	if out == nil {
 		return
 	}
 	fmt.Fprintf(out, "run trace: run_id=%s\n", runID)
 	if len(result.Trace) == 0 {
 		fmt.Fprintln(out, "no trace rows")
+	} else if deliveryDetail {
+		writeDiagnosticRunTraceDeliveryDetail(out, result.Trace)
 	} else {
 		fmt.Fprintln(out, "EVENT AT\tEVENT\tEVENT ID\tDELIVERY\tSUBSCRIBER\tSESSION\tTURN")
 		for _, row := range result.Trace {
@@ -1244,6 +1276,46 @@ func writeDiagnosticRunTrace(out io.Writer, runID string, result diagnosticRunTr
 	if result.NextCursor != "" {
 		fmt.Fprintf(out, "next_cursor=%s\n", result.NextCursor)
 	}
+}
+
+func writeDiagnosticRunTraceDeliveryDetail(out io.Writer, rows []diagnosticRunTraceRow) {
+	fmt.Fprintln(out, "EVENT AT\tEVENT\tEVENT ID\tDELIVERY ID\tSUBSCRIBER\tSTATUS\tREASON\tDELIVERY CREATED\tDELIVERY STARTED\tDELIVERY DELIVERED\tQUEUE WAIT\tEXECUTION TIME\tSESSION\tTURN")
+	for _, row := range rows {
+		fmt.Fprintf(out, "%s\t%s\t%s\t%s\t%s/%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+			row.EventCreatedAt,
+			row.EventName,
+			row.EventID,
+			emptyDash(row.DeliveryID),
+			emptyDash(row.SubscriberType),
+			emptyDash(row.SubscriberID),
+			emptyDash(row.DeliveryStatus),
+			emptyDash(row.DeliveryReasonCode),
+			emptyDash(row.DeliveryCreatedAt),
+			emptyDash(row.DeliveryStartedAt),
+			emptyDash(row.DeliveryDeliveredAt),
+			traceDuration(row.DeliveryCreatedAt, row.DeliveryStartedAt),
+			traceDuration(row.DeliveryStartedAt, row.DeliveryDeliveredAt),
+			emptyDash(row.SessionID),
+			emptyDash(firstNonEmpty(row.TurnID, row.TurnTriggerEventType)),
+		)
+	}
+}
+
+func traceDuration(start, end string) string {
+	start = strings.TrimSpace(start)
+	end = strings.TrimSpace(end)
+	if start == "" || end == "" {
+		return "-"
+	}
+	startAt, err := time.Parse(time.RFC3339Nano, start)
+	if err != nil {
+		return "-"
+	}
+	endAt, err := time.Parse(time.RFC3339Nano, end)
+	if err != nil {
+		return "-"
+	}
+	return endAt.Sub(startAt).Round(time.Millisecond).String()
 }
 
 func writeDiagnosticHealth(out io.Writer, result diagnosticHealthCheckResult) {

--- a/cmd/swarm/diagnostics_test.go
+++ b/cmd/swarm/diagnostics_test.go
@@ -424,6 +424,65 @@ func TestTraceUsesRunTraceSnapshot(t *testing.T) {
 	}
 }
 
+func TestTraceDeliveryDetailRendersRunTraceLifecycleFields(t *testing.T) {
+	t.Setenv("SWARM_API_TOKEN", "test-token")
+	server, requests := newDiagnosticSuccessServer(t, func(req jsonRPCRequest, _ int) map[string]any {
+		if req.Method != "run.trace" {
+			t.Fatalf("method = %q, want run.trace", req.Method)
+		}
+		wantParams := map[string]any{"run_id": "run-1", "limit": float64(1)}
+		if !reflect.DeepEqual(req.Params, wantParams) {
+			t.Fatalf("params = %#v, want %#v", req.Params, wantParams)
+		}
+		return map[string]any{
+			"trace": []any{map[string]any{
+				"event_id":              "event-1",
+				"event_name":            "scan.requested",
+				"event_created_at":      "2026-05-13T10:00:01Z",
+				"delivery_id":           "delivery-1",
+				"delivery_status":       "delivered",
+				"delivery_reason_code":  "node_processed",
+				"delivery_created_at":   "2026-05-13T10:00:02Z",
+				"delivery_started_at":   "2026-05-13T10:00:04Z",
+				"delivery_delivered_at": "2026-05-13T10:00:09Z",
+				"subscriber_type":       "agent",
+				"subscriber_id":         "agent-1",
+				"session_id":            "session-1",
+				"turn_id":               "turn-1",
+			}},
+		}
+	})
+	defer server.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"trace", "run-1", "--delivery-detail", "--limit", "1"}, &stdout, &stderr, testRootCommandOptions(server))
+	if code != 0 {
+		t.Fatalf("code = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	if len(*requests) != 1 {
+		t.Fatalf("requests = %d, want 1", len(*requests))
+	}
+	for _, want := range []string{
+		"DELIVERY ID",
+		"delivery-1",
+		"agent/agent-1",
+		"delivered",
+		"node_processed",
+		"2026-05-13T10:00:02Z",
+		"2026-05-13T10:00:04Z",
+		"2026-05-13T10:00:09Z",
+		"2s",
+		"5s",
+	} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("stdout missing %q:\n%s", want, stdout.String())
+		}
+	}
+	if strings.TrimSpace(stderr.String()) != "" {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+}
+
 func wantFullTraceFilterParams() map[string]any {
 	return map[string]any{
 		"event_name":      []any{"scan.requested", "scan.completed"},
@@ -579,6 +638,9 @@ func TestTraceHelpPromotesNoRetryWithoutReplaySince(t *testing.T) {
 	}
 	if !strings.Contains(stdout.String(), "--until") {
 		t.Fatalf("help missing --until:\n%s", stdout.String())
+	}
+	if !strings.Contains(stdout.String(), "--delivery-detail") {
+		t.Fatalf("help missing --delivery-detail:\n%s", stdout.String())
 	}
 	if strings.Contains(stdout.String(), "--replay-since") {
 		t.Fatalf("help exposed unpromoted --replay-since:\n%s", stdout.String())
@@ -983,6 +1045,7 @@ func TestDiagnosticsRejectInvalidInputBeforeRequest(t *testing.T) {
 		{name: "trace follow rejects cursor", args: []string{"trace", "run-1", "--follow", "--cursor", "cur"}, wantStderr: "--cursor is not supported with --follow"},
 		{name: "trace follow rejects since", args: []string{"trace", "run-1", "--follow", "--since", "2026-05-13T10:00:00Z"}, wantStderr: "--since is not supported with --follow"},
 		{name: "trace follow rejects until", args: []string{"trace", "run-1", "--follow", "--until", "2026-05-13T10:05:00Z"}, wantStderr: "--until is not supported with --follow"},
+		{name: "trace follow rejects delivery detail", args: []string{"trace", "run-1", "--follow", "--delivery-detail"}, wantStderr: "--delivery-detail is not supported with --follow"},
 		{name: "trace shorthand follow rejects limit", args: []string{"trace", "run-1", "-f", "--limit", "5"}, wantStderr: "--limit is not supported with --follow"},
 		{name: "trace shorthand follow rejects cursor", args: []string{"trace", "run-1", "-f", "--cursor", "cur"}, wantStderr: "--cursor is not supported with --follow"},
 		{name: "trace shorthand follow rejects since", args: []string{"trace", "run-1", "-f", "--since", "2026-05-13T10:00:00Z"}, wantStderr: "--since is not supported with --follow"},
@@ -1025,6 +1088,7 @@ func TestDiagnosticsRequireAPITokenBeforeRequest(t *testing.T) {
 		{"runs"},
 		{"trace", "run-1"},
 		{"trace", "run-1", "--limit", "2", "--cursor", "cur", "--since", "2026-05-13T10:00:00Z", "--until", "2026-05-13T10:05:00Z"},
+		{"trace", "run-1", "--delivery-detail"},
 		{"trace", "run-1", "--event-name", "scan.requested", "--entity-id", "entity-1", "--delivery-status", "delivered", "--subscriber-id", "agent-1", "--subscriber-type", "agent"},
 		{"trace", "run-1", "--follow"},
 		{"trace", "run-1", "-f"},
@@ -1259,6 +1323,24 @@ func TestDiagnosticsFailClosedOnAPIAndMalformedResults(t *testing.T) {
 			},
 			wantCode:   3,
 			wantStderr: "trace is required",
+		},
+		{
+			name: "trace invalid delivery timestamp",
+			args: []string{"trace", "run-1", "--delivery-detail"},
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				var req jsonRPCRequest
+				_ = json.NewDecoder(r.Body).Decode(&req)
+				writeJSONRPCResult(t, w, req.ID, map[string]any{
+					"trace": []any{map[string]any{
+						"event_id":            "event-1",
+						"event_name":          "scan.requested",
+						"event_created_at":    "2026-05-13T10:00:01Z",
+						"delivery_created_at": "yesterday",
+					}},
+				})
+			},
+			wantCode:   3,
+			wantStderr: "trace[0].delivery_created_at must be an RFC3339 timestamp",
 		},
 		{
 			name: "health missing bundle fingerprint",

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -10170,7 +10170,7 @@ cli_specification:
       defaulting: If run-id is omitted, resolve the target through run.list with active-run preference.
       behavior: Run-scoped operational status projection. This is the v2 replacement for `swarm investigate run`.
     trace:
-      command: swarm trace [<run-id>] [--since <timestamp>] [--until <timestamp>] [--limit <n>] [--cursor <cursor>] [--event-name <name> ...] [--entity-id <entity-id> ...] [--delivery-status <pending|in_progress|delivered|failed|dead_letter> ...] [--subscriber-id <id> ...] [--subscriber-type <node|agent> ...] [--follow|-f] [--no-retry]
+      command: swarm trace [<run-id>] [--delivery-detail] [--since <timestamp>] [--until <timestamp>] [--limit <n>] [--cursor <cursor>] [--event-name <name> ...] [--entity-id <entity-id> ...] [--delivery-status <pending|in_progress|delivered|failed|dead_letter> ...] [--subscriber-id <id> ...] [--subscriber-type <node|agent> ...] [--follow|-f] [--no-retry]
       tier: must_have
       implementation_status: implemented
       owners: /v1/rpc run.trace for snapshot; /v1/ws run.subscribe_trace for --follow/-f
@@ -10211,11 +10211,16 @@ cli_specification:
           `/v1/rpc run.trace`. Follow `swarm trace --follow` / `swarm trace -f` consumes the same typed filter flags
           by sending `filter` to `/v1/ws run.subscribe_trace`; fixed-window snapshot controls `--since`, `--until`,
           `--limit`, and `--cursor` remain invalid with follow and must fail before any API or WebSocket request.
+          Snapshot `--delivery-detail` is a CLI-only rendering modifier over the same `/v1/rpc run.trace` response:
+          it renders delivery identity, subscriber identity, delivery status/reason, delivery lifecycle timestamps, and
+          queue/execution durations derived only from same-row RunTraceRow timestamps. `--delivery-detail` is invalid
+          with `--follow` and does not introduce a new API/store/runtime owner.
         proof_expectations:
         - exact /v1/rpc run.trace params for explicit run ids and omitted-run resolution through run.list
         - repeatable filter flags serialize as RunTraceFilter arrays under the single `filter` param and compose with since/until/limit/cursor
         - follow-mode repeatable filter flags serialize as RunTraceFilter arrays under the single `filter` param and are preserved across recovery requests
         - invalid --since, invalid --until, since-after-until, out-of-range --limit, blank --cursor, blank/invalid typed filters, and fixed-window snapshot controls combined with --follow fail before API/WS calls
+        - --delivery-detail renders only existing RunTraceRow delivery lifecycle facts and rejects --follow before API/WS calls
         - missing token fails before API calls through the shared CLI API client
         - no direct DB/store/runtime/EventBus/dashboard/Builder reads and no legacy /api, /rpc, /ws, or fallback token paths
       promoted_trace_follow_recovery_contract:


### PR DESCRIPTION
## Summary

Part of #1420.

Adds the approved first slice for `swarm trace` delivery lifecycle rendering:

- adds snapshot-only `swarm trace --delivery-detail`
- renders existing `/v1/rpc run.trace` / `RunTraceRow` delivery lifecycle fields, including delivery id, subscriber, status, reason, lifecycle timestamps, queue wait, and execution time
- rejects `--delivery-detail` with `--follow` before any API or WebSocket request
- updates the CLI command catalog in `platform-spec.yaml`

This intentionally does not implement `--delivery-summary`, SQLite pagination repair, `swarm run` trace rendering, `event.get` rendering, agent-scoped lifecycle diagnostics, raw route-target exposure, or status hints.

## Governing Context

Exact governing refs exist:

- `platform-spec.yaml` `cli_specification.command_catalog.trace`
- `platform-spec.yaml` `api_specification.method_catalog.run.trace`
- `platform-spec.yaml` `RunTraceRow`
- OpenRPC `run.trace` / `RunTraceRow`
- #1420 pre-audit and gate outcome

Canonical owner: `/v1/rpc run.trace` backed by `internal/store/run_debug_read_surface.go` `RunDebugTraceRow` / `LoadRunDebugTracePage`.

Invalid paths checked: CLI direct DB/store/runtime/EventBus/dashboard reads remain invalid; the trace CLI continues to consume only `/v1/rpc run.trace` for snapshot mode and `/v1/ws run.subscribe_trace` for follow mode.

## Validation

- `go test ./cmd/swarm -run 'TestTrace|TestDiagnosticsRejectInvalidInputBeforeRequest|TestDiagnosticsRequireAPITokenBeforeRequest|TestDiagnosticsFailClosedOnAPIAndMalformedResults' -count=1`
- `go test ./cmd/swarm -count=1`
- `go test ./...`
- `git diff --check`
- Static no-bypass scan over `cmd/swarm/diagnostics.go`, `cmd/swarm/run_command.go`, and `cmd/swarm/cli.go`
