### PR TITLE
[agent-b][issue #1421] Render event delivery lifecycle

### DIFF
--- a/cmd/swarm/events.go
+++ b/cmd/swarm/events.go
@@ -88,9 +88,9 @@ type eventDelivery struct {
 	SessionID      string            `json:"session_id,omitempty"`
 	ReasonCode     string            `json:"reason_code,omitempty"`
 	LastError      string            `json:"last_error,omitempty"`
-	RetryCount     int               `json:"retry_count"`
-	RetryEligible  bool              `json:"retry_eligible"`
-	Terminal       bool              `json:"terminal"`
+	RetryCount     *int              `json:"retry_count"`
+	RetryEligible  *bool             `json:"retry_eligible"`
+	Terminal       *bool             `json:"terminal"`
 	CreatedAt      string            `json:"created_at,omitempty"`
 	StartedAt      string            `json:"started_at,omitempty"`
 	FinishedAt     string            `json:"finished_at,omitempty"`
@@ -592,8 +592,29 @@ func validateEventDelivery(prefix string, delivery eventDelivery) error {
 	if _, ok := eventObservationValidDeliveryStatuses[strings.TrimSpace(delivery.Status)]; !ok {
 		return fmt.Errorf("malformed %s: status=%q is not a valid DeliveryStatus", prefix, delivery.Status)
 	}
-	if delivery.RetryCount < 0 {
+	if delivery.RetryCount == nil {
+		return fmt.Errorf("malformed %s: retry_count is required", prefix)
+	}
+	if *delivery.RetryCount < 0 {
 		return fmt.Errorf("malformed %s: retry_count must be >= 0", prefix)
+	}
+	if delivery.RetryEligible == nil {
+		return fmt.Errorf("malformed %s: retry_eligible is required", prefix)
+	}
+	if delivery.Terminal == nil {
+		return fmt.Errorf("malformed %s: terminal is required", prefix)
+	}
+	for _, field := range []struct {
+		name  string
+		value string
+	}{
+		{name: "created_at", value: delivery.CreatedAt},
+		{name: "started_at", value: delivery.StartedAt},
+		{name: "finished_at", value: delivery.FinishedAt},
+	} {
+		if err := validateOptionalTimestamp(prefix+"."+field.name, field.value); err != nil {
+			return err
+		}
 	}
 	for i, deadLetter := range delivery.DeadLetters {
 		if err := validateEventDeadLetter(fmt.Sprintf("%s.dead_letters[%d]", prefix, i), deadLetter); err != nil {
@@ -874,19 +895,25 @@ func writeEventDetailResult(out io.Writer, event eventFull) {
 	} else {
 		fmt.Fprintln(out, "deliveries:")
 		for _, delivery := range event.Deliveries {
-			fmt.Fprintf(out, "  delivery_id=%s subscriber=%s/%s status=%s session_id=%s reason_code=%s last_error=%s retry_count=%d retry_eligible=%t terminal=%t dead_letters=%d\n",
+			fmt.Fprintf(out, "  delivery_id=%s subscriber=%s/%s status=%s session_id=%s created_at=%s started_at=%s finished_at=%s reason_code=%s last_error=%s retry_count=%d retry_eligible=%t terminal=%t dead_letters=%d\n",
 				delivery.DeliveryID,
 				delivery.SubscriberType,
 				delivery.SubscriberID,
 				delivery.Status,
 				eventObservationDash(delivery.SessionID),
+				eventObservationDash(delivery.CreatedAt),
+				eventObservationDash(delivery.StartedAt),
+				eventObservationDash(delivery.FinishedAt),
 				eventObservationDash(delivery.ReasonCode),
 				eventObservationDash(delivery.LastError),
-				delivery.RetryCount,
-				delivery.RetryEligible,
-				delivery.Terminal,
+				*delivery.RetryCount,
+				*delivery.RetryEligible,
+				*delivery.Terminal,
 				len(delivery.DeadLetters),
 			)
+			for _, deadLetter := range delivery.DeadLetters {
+				writeEventDeadLetterLine(out, "    delivery_dead_letter", deadLetter)
+			}
 		}
 	}
 	if len(event.DeadLetters) == 0 {
@@ -894,17 +921,22 @@ func writeEventDetailResult(out io.Writer, event eventFull) {
 	} else {
 		fmt.Fprintln(out, "dead_letters:")
 		for _, deadLetter := range event.DeadLetters {
-			fmt.Fprintf(out, "  dead_letter_id=%s failure_type=%s retry_count=%d chain_depth=%d created_at=%s handler_node=%s error=%s\n",
-				deadLetter.DeadLetterID,
-				deadLetter.FailureType,
-				*deadLetter.RetryCount,
-				*deadLetter.ChainDepth,
-				deadLetter.CreatedAt,
-				eventObservationDash(deadLetter.HandlerNode),
-				eventObservationDash(deadLetter.ErrorMessage),
-			)
+			writeEventDeadLetterLine(out, "  dead_letter", deadLetter)
 		}
 	}
+}
+
+func writeEventDeadLetterLine(out io.Writer, prefix string, deadLetter eventDeadLetter) {
+	fmt.Fprintf(out, "%s dead_letter_id=%s failure_type=%s retry_count=%d chain_depth=%d created_at=%s handler_node=%s error=%s\n",
+		prefix,
+		deadLetter.DeadLetterID,
+		deadLetter.FailureType,
+		*deadLetter.RetryCount,
+		*deadLetter.ChainDepth,
+		deadLetter.CreatedAt,
+		eventObservationDash(deadLetter.HandlerNode),
+		eventObservationDash(deadLetter.ErrorMessage),
+	)
 }
 
 func writeEventFollowEvent(out io.Writer, event eventFull) {

--- a/cmd/swarm/events_test.go
+++ b/cmd/swarm/events_test.go
@@ -603,7 +603,21 @@ func TestEventsMapFailureExitCodes(t *testing.T) {
 			wantStderr: "terminal is required",
 		},
 		{
-			name: "malformed view delivery timestamp exits three",
+			name: "malformed view delivery created timestamp exits three",
+			args: []string{"event", "view", "event-1"},
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				var req jsonRPCRequest
+				_ = json.NewDecoder(r.Body).Decode(&req)
+				event := validEventObservationEvent("event-1")
+				delivery := event["deliveries"].([]any)[0].(map[string]any)
+				delivery["created_at"] = "not-a-timestamp"
+				writeJSONRPCResult(t, w, req.ID, event)
+			},
+			wantCode:   3,
+			wantStderr: "created_at must be an RFC3339 timestamp",
+		},
+		{
+			name: "malformed view delivery started timestamp exits three",
 			args: []string{"event", "view", "event-1"},
 			handler: func(w http.ResponseWriter, r *http.Request) {
 				var req jsonRPCRequest
@@ -615,6 +629,20 @@ func TestEventsMapFailureExitCodes(t *testing.T) {
 			},
 			wantCode:   3,
 			wantStderr: "started_at must be an RFC3339 timestamp",
+		},
+		{
+			name: "malformed view delivery finished timestamp exits three",
+			args: []string{"event", "view", "event-1"},
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				var req jsonRPCRequest
+				_ = json.NewDecoder(r.Body).Decode(&req)
+				event := validEventObservationEvent("event-1")
+				delivery := event["deliveries"].([]any)[0].(map[string]any)
+				delivery["finished_at"] = "not-a-timestamp"
+				writeJSONRPCResult(t, w, req.ID, event)
+			},
+			wantCode:   3,
+			wantStderr: "finished_at must be an RFC3339 timestamp",
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {

--- a/cmd/swarm/events_test.go
+++ b/cmd/swarm/events_test.go
@@ -114,11 +114,23 @@ func TestEventViewUsesEventGetV1RPC(t *testing.T) {
 		"source_event_id=source-event-1",
 		"payload={\"priority\":\"high\"}",
 		"delivery_id=delivery-1",
+		"created_at=2026-05-13T10:00:02Z",
+		"started_at=2026-05-13T10:00:03Z",
+		"finished_at=2026-05-13T10:00:05Z",
+		"reason_code=retry_exhausted",
+		"last_error=boom",
+		"retry_count=2",
+		"retry_eligible=false",
+		"terminal=true",
+		"delivery_dead_letter dead_letter_id=delivery-dead-1",
 		"dead_letter_id=dead-1",
 	} {
 		if !strings.Contains(stdout.String(), want) {
 			t.Fatalf("stdout missing %q:\n%s", want, stdout.String())
 		}
+	}
+	if strings.Contains(stdout.String(), "delivery_target_route") {
+		t.Fatalf("stdout exposed internal route target:\n%s", stdout.String())
 	}
 	if strings.TrimSpace(stderr.String()) != "" {
 		t.Fatalf("stderr = %q, want empty", stderr.String())
@@ -548,6 +560,62 @@ func TestEventsMapFailureExitCodes(t *testing.T) {
 			wantCode:   3,
 			wantStderr: "event_id is required",
 		},
+		{
+			name: "malformed view delivery retry count exits three",
+			args: []string{"event", "view", "event-1"},
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				var req jsonRPCRequest
+				_ = json.NewDecoder(r.Body).Decode(&req)
+				event := validEventObservationEvent("event-1")
+				delivery := event["deliveries"].([]any)[0].(map[string]any)
+				delete(delivery, "retry_count")
+				writeJSONRPCResult(t, w, req.ID, event)
+			},
+			wantCode:   3,
+			wantStderr: "retry_count is required",
+		},
+		{
+			name: "malformed view delivery retry eligible exits three",
+			args: []string{"event", "view", "event-1"},
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				var req jsonRPCRequest
+				_ = json.NewDecoder(r.Body).Decode(&req)
+				event := validEventObservationEvent("event-1")
+				delivery := event["deliveries"].([]any)[0].(map[string]any)
+				delete(delivery, "retry_eligible")
+				writeJSONRPCResult(t, w, req.ID, event)
+			},
+			wantCode:   3,
+			wantStderr: "retry_eligible is required",
+		},
+		{
+			name: "malformed view delivery terminal exits three",
+			args: []string{"event", "view", "event-1"},
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				var req jsonRPCRequest
+				_ = json.NewDecoder(r.Body).Decode(&req)
+				event := validEventObservationEvent("event-1")
+				delivery := event["deliveries"].([]any)[0].(map[string]any)
+				delete(delivery, "terminal")
+				writeJSONRPCResult(t, w, req.ID, event)
+			},
+			wantCode:   3,
+			wantStderr: "terminal is required",
+		},
+		{
+			name: "malformed view delivery timestamp exits three",
+			args: []string{"event", "view", "event-1"},
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				var req jsonRPCRequest
+				_ = json.NewDecoder(r.Body).Decode(&req)
+				event := validEventObservationEvent("event-1")
+				delivery := event["deliveries"].([]any)[0].(map[string]any)
+				delivery["started_at"] = "not-a-timestamp"
+				writeJSONRPCResult(t, w, req.ID, event)
+			},
+			wantCode:   3,
+			wantStderr: "started_at must be an RFC3339 timestamp",
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Setenv("SWARM_API_TOKEN", "test-token")
@@ -733,8 +801,27 @@ func validEventObservationEvent(eventID string) map[string]any {
 				"delivery_id":     "delivery-1",
 				"subscriber_type": "agent",
 				"subscriber_id":   "agent-1",
-				"status":          "delivered",
+				"status":          "dead_letter",
 				"session_id":      "session-1",
+				"reason_code":     "retry_exhausted",
+				"last_error":      "boom",
+				"retry_count":     2,
+				"retry_eligible":  false,
+				"terminal":        true,
+				"created_at":      "2026-05-13T10:00:02Z",
+				"started_at":      "2026-05-13T10:00:03Z",
+				"finished_at":     "2026-05-13T10:00:05Z",
+				"dead_letters": []any{
+					map[string]any{
+						"dead_letter_id": "delivery-dead-1",
+						"failure_type":   "retry_exhausted",
+						"retry_count":    2,
+						"chain_depth":    3,
+						"created_at":     "2026-05-13T10:00:05Z",
+						"handler_node":   "agent-1",
+						"error_message":  "boom",
+					},
+				},
 			},
 		},
 		"dead_letters": []any{


### PR DESCRIPTION
## Summary

Closes #1421
Part of #1411

This PR closes the approved #1421 class: `swarm event view` delivery lifecycle under-rendering and fail-closed validation drift over existing `/v1/rpc event.get` `EventFull.deliveries` facts.

Changes:
- renders owner-backed delivery lifecycle timestamps in `swarm event view`: `created_at`, `started_at`, and `finished_at`
- renders nested per-delivery dead-letter detail returned by `EventDelivery.dead_letters`
- makes schema-required delivery primitives fail closed when absent: `retry_count`, `retry_eligible`, and `terminal`
- validates newly rendered optional delivery timestamps when present
- keeps the `/v1/rpc event.get` request shape unchanged as `event_id` only

## Governing refs / context

Exact governing refs exist:
- `platform-spec.yaml` `cli_specification.command_catalog.event_view`
- `platform-spec.yaml` `api_specification.method_catalog.event.get`
- `platform-spec.yaml` schemas `EventFull`, `EventDelivery`, `DeadLetterRecord`, and `DeliveryStatus`
- `openrpc.json` generated `event.get -> EventFull` and `EventDelivery` / `DeadLetterRecord` schemas
- #1421 pre-audit: https://github.com/division-sh/swarm/issues/1421#issuecomment-4713306832
- #1421 gate: https://github.com/division-sh/swarm/issues/1421#issuecomment-4713365785

## Owner / migration notes

Canonical owner after the change remains `/v1/rpc event.get`, backed by `internal/apiv1/operator_read.go` and store `OperatorEventFull` / `OperatorEventDelivery` / `OperatorDeadLetterRecord`.

Old invalid paths remain invalid and are not introduced here: direct CLI reads from DB/store/runtime/EventBus/dashboard/Builder, reconstruction from `run.trace`, receipts, logs, runtime memory, or exposing raw `delivery_target_route`.

No platform-spec/OpenRPC change is needed because the existing owner schema already carries the consumed fields.

## Validation

- `go test ./cmd/swarm -run 'TestEventView|TestEvents' -count=1`
- `go test ./internal/store -run 'TestOperatorObservabilityEventOwnerFiltersDetailsAndCursor|TestOperatorObservabilityEventOwnerDoesNotPromotePayloadEntityIdentity' -count=1`
- `go test ./internal/apiv1 -run 'TestOperatorObservabilityHandlers|TestOpenRPCReadOnlyRuntimeProbes' -count=1`
- `go test ./...`
- `git diff --check`
- static no-bypass scan over `cmd/swarm/events.go`
