### PR TITLE
[agent-c][issue #1408] Preserve action result producer route context

### DIFF
--- a/internal/runtime/artifact_action_result_delivery_test.go
+++ b/internal/runtime/artifact_action_result_delivery_test.go
@@ -45,6 +45,7 @@ func TestArtifactRepoCommitResultEventsFlowThroughDurableCallbackDelivery(t *tes
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
+			resultEventType := "repo-scaffold/inst-1/" + tc.resultEventName
 			bundle := loadRuntimeTempBundle(t, artifactActionResultDeliveryFixtureFiles())
 			source := semanticview.Wrap(bundle)
 			_, db, cleanup := testutil.StartPostgres(t)
@@ -66,7 +67,7 @@ func TestArtifactRepoCommitResultEventsFlowThroughDurableCallbackDelivery(t *tes
 				WorkflowStore: workflowStore,
 				ArtifactRoot:  t.TempDir(),
 				TestWorkflowNodeHandlerStartHook: func(_ context.Context, nodeID string, evt events.Event) error {
-					if strings.TrimSpace(nodeID) == "repo-scaffold-node" && strings.TrimSpace(string(evt.Type())) == tc.resultEventName {
+					if strings.TrimSpace(nodeID) == "repo-scaffold-node" && strings.TrimSpace(string(evt.Type())) == resultEventType {
 						select {
 						case resultHandlerStarted <- evt.ID():
 						default:
@@ -119,11 +120,11 @@ func TestArtifactRepoCommitResultEventsFlowThroughDurableCallbackDelivery(t *tes
 				SELECT event_id::text
 				FROM events
 				WHERE event_name = $1 AND source_event_id = $2::uuid
-			`, []any{tc.resultEventName, tc.requestEventID})
-			assertArtifactActionResultEventContext(t, ctx, db, resultEventID, tc.resultKind)
-			assertArtifactActionResultNodeRoute(t, ctx, db, resultEventID)
+			`, []any{resultEventType, tc.requestEventID})
+			assertArtifactActionResultEventContext(t, ctx, db, resultEventID, tc.resultKind, "repo-scaffold/inst-1")
+			assertArtifactActionResultNodeRoute(t, ctx, db, resultEventID, "repo-scaffold/inst-1")
 			waitArtifactActionResultHandlerStarted(t, resultHandlerStarted, resultEventID)
-			waitRuntimeDBCount(t, ctx, db, `
+			waitArtifactActionResultDBCount(t, ctx, db, `
 				SELECT COUNT(*)
 				FROM event_deliveries
 				WHERE event_id = $1::uuid
@@ -133,18 +134,146 @@ func TestArtifactRepoCommitResultEventsFlowThroughDurableCallbackDelivery(t *tes
 				  AND reason_code = 'node_processed'
 				  AND delivered_at IS NOT NULL
 				  AND delivery_target_route @> $2::jsonb
-				  AND $2::jsonb @> delivery_target_route
-			`, 1, resultEventID, artifactActionResultDeliveryTargetRouteJSON())
-			waitRuntimeDBCount(t, ctx, db, `
+			`, 1, resultEventID, artifactActionResultDeliveryTargetRouteJSON("repo-scaffold/inst-1"))
+			waitArtifactActionResultDBCount(t, ctx, db, `
+				SELECT COUNT(*)
+				FROM event_receipts
+				WHERE event_id = $1::uuid
+					  AND subscriber_type = 'node'
+					  AND subscriber_id = 'repo-scaffold-node'
+					  AND entity_id = $2::uuid
+					  AND flow_instance = $3
+					  AND outcome = 'no_op'
+				`, 1, resultEventID, artifactActionResultEntityID, "repo-scaffold/inst-1")
+		})
+	}
+}
+
+func TestArtifactRepoCommitResultEventsFlowThroughStaticServiceCallbackDelivery(t *testing.T) {
+	tests := []struct {
+		name            string
+		requestEventID  string
+		requestID       string
+		mvpYAML         string
+		resultEventName string
+		resultKind      string
+	}{
+		{
+			name:            "success",
+			requestEventID:  "99999999-9999-4999-8999-999999999961",
+			requestID:       "99999999-9999-4999-8999-999999999971",
+			mvpYAML:         "name: Demo\n",
+			resultEventName: "repo_scaffold.repo_commit_succeeded",
+			resultKind:      "ready",
+		},
+		{
+			name:            "failure",
+			requestEventID:  "99999999-9999-4999-8999-999999999962",
+			requestID:       "99999999-9999-4999-8999-999999999972",
+			mvpYAML:         "title: Demo\n",
+			resultEventName: "repo_scaffold.repo_commit_failed",
+			resultKind:      "failed",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			resultEventType := "repo-scaffold/" + tc.resultEventName
+			bundle := loadRuntimeTempBundle(t, artifactActionResultStaticDeliveryFixtureFiles())
+			source := semanticview.Wrap(bundle)
+			_, db, cleanup := testutil.StartPostgres(t)
+			t.Cleanup(cleanup)
+			ctx := seedRuntimeTestRun(t, db)
+			pg := &store.PostgresStore{DB: db}
+			bus, err := runtimebus.NewEventBusWithOptions(pg, runtimebus.EventBusOptions{ContractBundle: source})
+			if err != nil {
+				t.Fatalf("NewEventBusWithOptions: %v", err)
+			}
+			workflowStore := runtimepipeline.NewWorkflowInstanceStore(db)
+			if err := workflowStore.Upsert(ctx, artifactActionResultStaticWorkflowInstance()); err != nil {
+				t.Fatalf("seed workflow instance: %v", err)
+			}
+			module := newRuntimeTestWorkflowModule(t, source)
+			resultHandlerStarted := make(chan string, 4)
+			pc := runtimepipeline.NewPipelineCoordinatorWithOptions(bus, db, runtimepipeline.PipelineCoordinatorOptions{
+				Module:        module,
+				WorkflowStore: workflowStore,
+				ArtifactRoot:  t.TempDir(),
+				TestWorkflowNodeHandlerStartHook: func(_ context.Context, nodeID string, evt events.Event) error {
+					if strings.TrimSpace(nodeID) == "repo-scaffold-node" && strings.TrimSpace(string(evt.Type())) == resultEventType {
+						select {
+						case resultHandlerStarted <- evt.ID():
+						default:
+						}
+					}
+					return nil
+				},
+				EventReceiptsCapability: func(context.Context) (bool, error) {
+					return true, nil
+				},
+			})
+			subscribed := make(chan struct{}, 1)
+			pc.SetTestSubscribeHook(func() { subscribed <- struct{}{} })
+			runCtx, cancel := context.WithCancel(ctx)
+			t.Cleanup(cancel)
+			go pc.Run(runCtx)
+			select {
+			case <-subscribed:
+			case <-time.After(2 * time.Second):
+				t.Fatal("workflow runtime did not subscribe")
+			}
+
+			requestPayload, err := json.Marshal(map[string]any{
+				"request_id": tc.requestID,
+				"mvp_yaml":   tc.mvpYAML,
+			})
+			if err != nil {
+				t.Fatalf("marshal request payload: %v", err)
+			}
+			requestEvent := events.NewProjectionEvent(
+				tc.requestEventID,
+				events.EventType("repo-scaffold/repo_scaffold.repo_commit_requested"),
+				"test",
+				"",
+				requestPayload,
+				0,
+				templateInstanceDeliveryRunID,
+				"",
+				events.EventEnvelope{},
+				time.Now().UTC(),
+			).WithEntityID(artifactActionResultEntityID).WithFlowInstance("repo-scaffold")
+			if err := bus.Publish(ctx, requestEvent); err != nil {
+				t.Fatalf("Publish request event: %v", err)
+			}
+
+			resultEventID := waitRuntimeEventID(t, ctx, db, `
+				SELECT event_id::text
+				FROM events
+				WHERE event_name = $1 AND source_event_id = $2::uuid
+			`, []any{resultEventType, tc.requestEventID})
+			assertArtifactActionResultEventContext(t, ctx, db, resultEventID, tc.resultKind, "repo-scaffold")
+			assertArtifactActionResultNodeRoute(t, ctx, db, resultEventID, "repo-scaffold")
+			waitArtifactActionResultHandlerStarted(t, resultHandlerStarted, resultEventID)
+			waitArtifactActionResultDBCount(t, ctx, db, `
+				SELECT COUNT(*)
+				FROM event_deliveries
+				WHERE event_id = $1::uuid
+				  AND subscriber_type = 'node'
+				  AND subscriber_id = 'repo-scaffold-node'
+				  AND status = 'delivered'
+				  AND reason_code = 'node_processed'
+				  AND delivered_at IS NOT NULL
+				  AND delivery_target_route @> $2::jsonb
+			`, 1, resultEventID, artifactActionResultDeliveryTargetRouteJSON("repo-scaffold"))
+			waitArtifactActionResultDBCount(t, ctx, db, `
 				SELECT COUNT(*)
 				FROM event_receipts
 				WHERE event_id = $1::uuid
 				  AND subscriber_type = 'node'
 				  AND subscriber_id = 'repo-scaffold-node'
 				  AND entity_id = $2::uuid
-				  AND flow_instance = 'repo-scaffold/inst-1'
+				  AND flow_instance = $3
 				  AND outcome = 'no_op'
-			`, 1, resultEventID, artifactActionResultEntityID)
+			`, 1, resultEventID, artifactActionResultEntityID, "repo-scaffold")
 		})
 	}
 }
@@ -170,7 +299,13 @@ func artifactActionResultWorkflowInstance() runtimepipeline.WorkflowInstance {
 	}
 }
 
-func assertArtifactActionResultEventContext(t *testing.T, ctx context.Context, db *sql.DB, eventID, resultKind string) {
+func artifactActionResultStaticWorkflowInstance() runtimepipeline.WorkflowInstance {
+	instance := artifactActionResultWorkflowInstance()
+	delete(instance.Metadata, "flow_path")
+	return instance
+}
+
+func assertArtifactActionResultEventContext(t *testing.T, ctx context.Context, db *sql.DB, eventID, resultKind, wantFlowInstance string) {
 	t.Helper()
 	var entityID, flowInstance, sourceRouteJSON, payloadJSON string
 	if err := db.QueryRowContext(ctx, `
@@ -183,8 +318,8 @@ func assertArtifactActionResultEventContext(t *testing.T, ctx context.Context, d
 	if entityID != artifactActionResultEntityID {
 		t.Fatalf("result event entity_id = %q, want %q", entityID, artifactActionResultEntityID)
 	}
-	if flowInstance != "repo-scaffold/inst-1" {
-		t.Fatalf("result event flow_instance = %q, want repo-scaffold/inst-1", flowInstance)
+	if flowInstance != wantFlowInstance {
+		t.Fatalf("result event flow_instance = %q, want %s", flowInstance, wantFlowInstance)
 	}
 	var sourceRoute map[string]any
 	if err := json.Unmarshal([]byte(sourceRouteJSON), &sourceRoute); err != nil {
@@ -193,8 +328,8 @@ func assertArtifactActionResultEventContext(t *testing.T, ctx context.Context, d
 	if got := strings.TrimSpace(asRuntimeTestString(sourceRoute["flow_id"])); got != "repo-scaffold" {
 		t.Fatalf("source route flow_id = %q, want repo-scaffold: %#v", got, sourceRoute)
 	}
-	if got := strings.TrimSpace(asRuntimeTestString(sourceRoute["flow_instance"])); got != "repo-scaffold/inst-1" {
-		t.Fatalf("source route flow_instance = %q, want repo-scaffold/inst-1: %#v", got, sourceRoute)
+	if got := strings.TrimSpace(asRuntimeTestString(sourceRoute["flow_instance"])); got != wantFlowInstance {
+		t.Fatalf("source route flow_instance = %q, want %s: %#v", got, wantFlowInstance, sourceRoute)
 	}
 	if got := strings.TrimSpace(asRuntimeTestString(sourceRoute["entity_id"])); got != artifactActionResultEntityID {
 		t.Fatalf("source route entity_id = %q, want %s: %#v", got, artifactActionResultEntityID, sourceRoute)
@@ -208,22 +343,49 @@ func assertArtifactActionResultEventContext(t *testing.T, ctx context.Context, d
 	}
 }
 
-func assertArtifactActionResultNodeRoute(t *testing.T, ctx context.Context, db *sql.DB, eventID string) {
+func assertArtifactActionResultNodeRoute(t *testing.T, ctx context.Context, db *sql.DB, eventID, wantFlowInstance string) {
 	t.Helper()
-	assertRuntimeDBCount(t, ctx, db, `
-		SELECT COUNT(*)
-		FROM event_deliveries
-		WHERE event_id = $1::uuid
-		  AND subscriber_type = 'node'
-		  AND subscriber_id = 'repo-scaffold-node'
-		  AND delivery_target_route @> $2::jsonb
-		  AND $2::jsonb @> delivery_target_route
-	`, 1, eventID, artifactActionResultDeliveryTargetRouteJSON())
+	wantRoute := artifactActionResultDeliveryTargetRouteJSON(wantFlowInstance)
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		var got int
+		if err := db.QueryRowContext(ctx, `
+			SELECT COUNT(*)
+			FROM event_deliveries
+			WHERE event_id = $1::uuid
+			  AND subscriber_type = 'node'
+			  AND subscriber_id = 'repo-scaffold-node'
+			  AND delivery_target_route @> $2::jsonb
+		`, eventID, wantRoute).Scan(&got); err != nil {
+			t.Fatalf("query result delivery route: %v", err)
+		}
+		if got == 1 {
+			return
+		}
+		if time.Now().After(deadline) {
+			var rows string
+			if err := db.QueryRowContext(ctx, `
+				SELECT COALESCE(jsonb_agg(jsonb_build_object(
+					'subscriber_type', subscriber_type,
+					'subscriber_id', subscriber_id,
+					'status', status,
+					'reason_code', reason_code,
+					'delivery_target_route', delivery_target_route
+				))::text, '[]')
+				FROM event_deliveries
+				WHERE event_id = $1::uuid
+			`, eventID).Scan(&rows); err != nil {
+				t.Fatalf("query result delivery route debug rows: %v", err)
+			}
+			t.Fatalf("delivery route for event %s missing route %s; rows=%s", eventID, wantRoute, rows)
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
 }
 
 func waitArtifactActionResultHandlerStarted(t *testing.T, started <-chan string, eventID string) {
 	t.Helper()
-	deadline := time.After(2 * time.Second)
+	deadline := time.After(5 * time.Second)
 	for {
 		select {
 		case got := <-started:
@@ -236,8 +398,26 @@ func waitArtifactActionResultHandlerStarted(t *testing.T, started <-chan string,
 	}
 }
 
-func artifactActionResultDeliveryTargetRouteJSON() string {
-	return `{"flow_instance":"repo-scaffold/inst-1","entity_id":"` + artifactActionResultEntityID + `"}`
+func waitArtifactActionResultDBCount(t *testing.T, ctx context.Context, db *sql.DB, query string, want int, args ...any) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		var got int
+		if err := db.QueryRowContext(ctx, query, args...).Scan(&got); err != nil {
+			t.Fatalf("query count: %v", err)
+		}
+		if got == want {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("count = %d, want %d for query %s", got, want, strings.TrimSpace(query))
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+}
+
+func artifactActionResultDeliveryTargetRouteJSON(flowInstance string) string {
+	return `{"flow_instance":"` + flowInstance + `","entity_id":"` + artifactActionResultEntityID + `"}`
 }
 
 func asRuntimeTestString(value any) string {
@@ -388,4 +568,10 @@ repo_scaffold.repo_commit_failed:
       sets_gate: result_callback_observed
 `,
 	}
+}
+
+func artifactActionResultStaticDeliveryFixtureFiles() map[string]string {
+	files := artifactActionResultDeliveryFixtureFiles()
+	files["package.yaml"] = strings.Replace(files["package.yaml"], "mode: template", "mode: static", 1)
+	return files
 }

--- a/internal/runtime/artifact_action_result_delivery_test.go
+++ b/internal/runtime/artifact_action_result_delivery_test.go
@@ -157,6 +157,8 @@ func TestArtifactRepoCommitResultEventsFlowThroughStaticServiceCallbackDelivery(
 		mvpYAML         string
 		resultEventName string
 		resultKind      string
+		requestFlowPath string
+		wantFlowPath    string
 	}{
 		{
 			name:            "success",
@@ -165,6 +167,8 @@ func TestArtifactRepoCommitResultEventsFlowThroughStaticServiceCallbackDelivery(
 			mvpYAML:         "name: Demo\n",
 			resultEventName: "repo_scaffold.repo_commit_succeeded",
 			resultKind:      "ready",
+			requestFlowPath: "repo-scaffold",
+			wantFlowPath:    "repo-scaffold",
 		},
 		{
 			name:            "failure",
@@ -173,6 +177,28 @@ func TestArtifactRepoCommitResultEventsFlowThroughStaticServiceCallbackDelivery(
 			mvpYAML:         "title: Demo\n",
 			resultEventName: "repo_scaffold.repo_commit_failed",
 			resultKind:      "failed",
+			requestFlowPath: "repo-scaffold",
+			wantFlowPath:    "repo-scaffold",
+		},
+		{
+			name:            "wildcard_child_inbound_success",
+			requestEventID:  "99999999-9999-4999-8999-999999999963",
+			requestID:       "99999999-9999-4999-8999-999999999973",
+			mvpYAML:         "name: Demo\n",
+			resultEventName: "repo_scaffold.repo_commit_succeeded",
+			resultKind:      "ready",
+			requestFlowPath: "repo-scaffold/child-1",
+			wantFlowPath:    "repo-scaffold",
+		},
+		{
+			name:            "wildcard_child_inbound_failure",
+			requestEventID:  "99999999-9999-4999-8999-999999999964",
+			requestID:       "99999999-9999-4999-8999-999999999974",
+			mvpYAML:         "title: Demo\n",
+			resultEventName: "repo_scaffold.repo_commit_failed",
+			resultKind:      "failed",
+			requestFlowPath: "repo-scaffold/child-1",
+			wantFlowPath:    "repo-scaffold",
 		},
 	}
 	for _, tc := range tests {
@@ -240,7 +266,7 @@ func TestArtifactRepoCommitResultEventsFlowThroughStaticServiceCallbackDelivery(
 				"",
 				events.EventEnvelope{},
 				time.Now().UTC(),
-			).WithEntityID(artifactActionResultEntityID).WithFlowInstance("repo-scaffold")
+			).WithEntityID(artifactActionResultEntityID).WithFlowInstance(tc.requestFlowPath)
 			if err := bus.Publish(ctx, requestEvent); err != nil {
 				t.Fatalf("Publish request event: %v", err)
 			}
@@ -250,8 +276,8 @@ func TestArtifactRepoCommitResultEventsFlowThroughStaticServiceCallbackDelivery(
 				FROM events
 				WHERE event_name = $1 AND source_event_id = $2::uuid
 			`, []any{resultEventType, tc.requestEventID})
-			assertArtifactActionResultEventContext(t, ctx, db, resultEventID, tc.resultKind, "repo-scaffold")
-			assertArtifactActionResultNodeRoute(t, ctx, db, resultEventID, "repo-scaffold")
+			assertArtifactActionResultEventContext(t, ctx, db, resultEventID, tc.resultKind, tc.wantFlowPath)
+			assertArtifactActionResultNodeRoute(t, ctx, db, resultEventID, tc.wantFlowPath)
 			waitArtifactActionResultHandlerStarted(t, resultHandlerStarted, resultEventID)
 			waitArtifactActionResultDBCount(t, ctx, db, `
 				SELECT COUNT(*)
@@ -263,7 +289,7 @@ func TestArtifactRepoCommitResultEventsFlowThroughStaticServiceCallbackDelivery(
 				  AND reason_code = 'node_processed'
 				  AND delivered_at IS NOT NULL
 				  AND delivery_target_route @> $2::jsonb
-			`, 1, resultEventID, artifactActionResultDeliveryTargetRouteJSON("repo-scaffold"))
+			`, 1, resultEventID, artifactActionResultDeliveryTargetRouteJSON(tc.wantFlowPath))
 			waitArtifactActionResultDBCount(t, ctx, db, `
 				SELECT COUNT(*)
 				FROM event_receipts
@@ -273,7 +299,7 @@ func TestArtifactRepoCommitResultEventsFlowThroughStaticServiceCallbackDelivery(
 				  AND entity_id = $2::uuid
 				  AND flow_instance = $3
 				  AND outcome = 'no_op'
-			`, 1, resultEventID, artifactActionResultEntityID, "repo-scaffold")
+			`, 1, resultEventID, artifactActionResultEntityID, tc.wantFlowPath)
 		})
 	}
 }

--- a/internal/runtime/engine/types.go
+++ b/internal/runtime/engine/types.go
@@ -213,6 +213,9 @@ type ExecutionRequest struct {
 	NodeID      identity.NodeID
 	FlowID      identity.FlowID
 	Event       events.Event
+	// ProducerRoute is the admitted handler/action route that owns runtime
+	// action result events emitted during this execution.
+	ProducerRoute events.RouteIdentity
 	// HandlerEventKey is the matched authored handler event key selected by
 	// runtime dispatch. Concrete Event.Type remains event provenance.
 	HandlerEventKey string

--- a/internal/runtime/pipeline/action_result_context.go
+++ b/internal/runtime/pipeline/action_result_context.go
@@ -20,12 +20,12 @@ func actionResultProducerRoute(source semanticview.Source, flowID, entityID stri
 			FlowInstance: asString(state.StateCarrier.Metadata["flow_path"]),
 			EntityID:     entityID,
 		},
+		staticActionResultProducerRoute(source, flowID, entityID),
 		{
 			FlowID:       flowID,
 			FlowInstance: evt.FlowInstance(),
 			EntityID:     entityID,
 		},
-		staticActionResultProducerRoute(source, flowID, entityID),
 	}
 	for _, candidate := range candidates {
 		if route, ok := normalizeActionResultProducerRouteCandidate(source, flowID, entityID, candidate); ok {
@@ -96,7 +96,24 @@ func actionResultFlowInstanceBelongsToFlow(source semanticview.Source, flowID, f
 	if flowPath == "" {
 		return source == nil
 	}
-	return flowInstance == flowPath || strings.HasPrefix(flowInstance, flowPath+"/")
+	if flowInstance == flowPath {
+		return true
+	}
+	if !actionResultFlowAllowsDescendantInstances(source, flowID) {
+		return false
+	}
+	return strings.HasPrefix(flowInstance, flowPath+"/")
+}
+
+func actionResultFlowAllowsDescendantInstances(source semanticview.Source, flowID string) bool {
+	if source == nil {
+		return true
+	}
+	scope, ok := source.FlowScopeByID(strings.TrimSpace(flowID))
+	if !ok {
+		return false
+	}
+	return strings.EqualFold(strings.TrimSpace(scope.Mode), "template")
 }
 
 func actionResultFlowPath(source semanticview.Source, flowID string) string {

--- a/internal/runtime/pipeline/action_result_context.go
+++ b/internal/runtime/pipeline/action_result_context.go
@@ -1,0 +1,180 @@
+package pipeline
+
+import (
+	"strings"
+
+	"github.com/division-sh/swarm/internal/events"
+	runtimeeventidentity "github.com/division-sh/swarm/internal/runtime/core/eventidentity"
+	runtimeengine "github.com/division-sh/swarm/internal/runtime/engine"
+	"github.com/division-sh/swarm/internal/runtime/semanticview"
+)
+
+func actionResultProducerRoute(source semanticview.Source, flowID, entityID string, evt events.Event, state runtimeengine.StateSnapshot, admitted events.RouteIdentity) events.RouteIdentity {
+	flowID = strings.TrimSpace(flowID)
+	entityID = strings.TrimSpace(entityID)
+	candidates := []events.RouteIdentity{
+		admitted,
+		evt.TargetRoute(),
+		{
+			FlowID:       flowID,
+			FlowInstance: asString(state.StateCarrier.Metadata["flow_path"]),
+			EntityID:     entityID,
+		},
+		{
+			FlowID:       flowID,
+			FlowInstance: evt.FlowInstance(),
+			EntityID:     entityID,
+		},
+		staticActionResultProducerRoute(source, flowID, entityID),
+	}
+	for _, candidate := range candidates {
+		if route, ok := normalizeActionResultProducerRouteCandidate(source, flowID, entityID, candidate); ok {
+			return route
+		}
+	}
+	return events.RouteIdentity{
+		FlowID:   flowID,
+		EntityID: entityID,
+	}.Normalized()
+}
+
+func normalizeActionResultProducerRouteCandidate(source semanticview.Source, flowID, entityID string, route events.RouteIdentity) (events.RouteIdentity, bool) {
+	route = route.Normalized()
+	if route.Empty() {
+		return events.RouteIdentity{}, false
+	}
+	if flowID != "" && route.FlowID != "" && route.FlowID != flowID {
+		return events.RouteIdentity{}, false
+	}
+	route.FlowID = firstNonEmptyString(flowID, route.FlowID)
+	if entityID != "" {
+		route.EntityID = entityID
+	}
+	if route.FlowInstance == "" {
+		if route.FlowID != "" {
+			if flowPath := actionResultFlowPath(source, route.FlowID); flowPath != "" {
+				return events.RouteIdentity{}, false
+			}
+		}
+		return route.Normalized(), true
+	}
+	if actionResultFlowInstanceBelongsToFlow(source, flowID, route.FlowInstance) {
+		return route.Normalized(), true
+	}
+	return events.RouteIdentity{}, false
+}
+
+func staticActionResultProducerRoute(source semanticview.Source, flowID, entityID string) events.RouteIdentity {
+	flowID = strings.TrimSpace(flowID)
+	if source == nil || flowID == "" {
+		return events.RouteIdentity{}
+	}
+	scope, ok := source.FlowScopeByID(flowID)
+	if ok && strings.EqualFold(strings.TrimSpace(scope.Mode), "template") {
+		return events.RouteIdentity{}
+	}
+	flowPath := strings.Trim(strings.TrimSpace(scope.Path), "/")
+	if flowPath == "" {
+		flowPath = strings.Trim(strings.TrimSpace(source.FlowPath(flowID)), "/")
+	}
+	if flowPath == "" {
+		return events.RouteIdentity{}
+	}
+	return events.RouteIdentity{
+		FlowID:       flowID,
+		FlowInstance: flowPath,
+		EntityID:     strings.TrimSpace(entityID),
+	}.Normalized()
+}
+
+func actionResultFlowInstanceBelongsToFlow(source semanticview.Source, flowID, flowInstance string) bool {
+	flowInstance = strings.Trim(strings.TrimSpace(flowInstance), "/")
+	if flowInstance == "" {
+		return false
+	}
+	flowPath := actionResultFlowPath(source, flowID)
+	if flowPath == "" {
+		return source == nil
+	}
+	return flowInstance == flowPath || strings.HasPrefix(flowInstance, flowPath+"/")
+}
+
+func actionResultFlowPath(source semanticview.Source, flowID string) string {
+	flowID = strings.TrimSpace(flowID)
+	if source == nil || flowID == "" {
+		return ""
+	}
+	if scope, ok := source.FlowScopeByID(flowID); ok {
+		if path := strings.Trim(strings.TrimSpace(scope.Path), "/"); path != "" {
+			return path
+		}
+	}
+	if path := strings.Trim(strings.TrimSpace(source.FlowPath(flowID)), "/"); path != "" {
+		return path
+	}
+	return flowID
+}
+
+func actionResultEventType(source semanticview.Source, flowID, eventType string, producerRoute events.RouteIdentity) string {
+	eventType = runtimeeventidentity.Normalize(eventType)
+	flowID = strings.TrimSpace(flowID)
+	if eventType == "" || source == nil || flowID == "" {
+		return eventType
+	}
+	flowPath := actionResultFlowPath(source, flowID)
+	if flowPath == "" {
+		return eventType
+	}
+	localEvent := actionResultLocalFlowEvent(source, flowID, flowPath, producerRoute.FlowInstance, eventType)
+	if localEvent == "" {
+		return eventType
+	}
+	namespace := runtimeeventidentity.Normalize(producerRoute.FlowInstance)
+	if namespace == "" || !actionResultFlowInstanceBelongsToFlow(source, flowID, namespace) {
+		namespace = flowPath
+	}
+	return namespace + "/" + localEvent
+}
+
+func actionResultLocalFlowEvent(source semanticview.Source, flowID, flowPath, flowInstance, eventType string) string {
+	scope, ok := semanticview.FlowScopeByID(source, flowID)
+	if !ok {
+		return ""
+	}
+	localEvents := actionResultFlowLocalEvents(scope)
+	if _, ok := localEvents[eventType]; ok {
+		return eventType
+	}
+	for _, prefix := range []string{flowInstance, flowPath} {
+		prefix = runtimeeventidentity.Normalize(prefix)
+		if prefix == "" || !strings.HasPrefix(eventType, prefix+"/") {
+			continue
+		}
+		local := strings.TrimPrefix(eventType, prefix+"/")
+		if _, ok := localEvents[local]; ok {
+			return local
+		}
+	}
+	if resolved := runtimeeventidentity.Normalize(source.ResolveFlowEventReference(flowID, eventType)); resolved != "" && resolved != eventType {
+		return actionResultLocalFlowEvent(source, flowID, flowPath, flowInstance, resolved)
+	}
+	return ""
+}
+
+func actionResultFlowLocalEvents(scope semanticview.FlowScope) map[string]struct{} {
+	out := make(map[string]struct{}, len(scope.Events)+len(scope.OutputEvents)+1)
+	for eventType := range scope.Events {
+		if eventType = runtimeeventidentity.Normalize(eventType); eventType != "" {
+			out[eventType] = struct{}{}
+		}
+	}
+	for _, eventType := range scope.OutputEvents {
+		if eventType = runtimeeventidentity.Normalize(eventType); eventType != "" {
+			out[eventType] = struct{}{}
+		}
+	}
+	if eventType := runtimeeventidentity.Normalize(scope.AutoEmitEvent); eventType != "" {
+		out[eventType] = struct{}{}
+	}
+	return out
+}

--- a/internal/runtime/pipeline/action_result_event_context_test.go
+++ b/internal/runtime/pipeline/action_result_event_context_test.go
@@ -25,6 +25,8 @@ func TestArtifactRepoResultEventPreservesScopedProducerSourceRoute(t *testing.T)
 		eventType       string
 		stateFlowPath   string
 		inboundFlowPath string
+		producerRoute   events.RouteIdentity
+		targetRoute     events.RouteIdentity
 		wantFlowPath    string
 	}{
 		{
@@ -40,16 +42,26 @@ func TestArtifactRepoResultEventPreservesScopedProducerSourceRoute(t *testing.T)
 			wantFlowPath:  "repo-scaffold/inst-1",
 		},
 		{
-			name:            "success falls back to inbound flow instance",
+			name:            "success uses admitted producer route over stale inbound flow instance",
 			eventType:       "repo_scaffold.repo_commit_succeeded",
-			inboundFlowPath: "repo-scaffold/inst-2",
-			wantFlowPath:    "repo-scaffold/inst-2",
+			inboundFlowPath: "component-scaffold/component-a",
+			producerRoute: events.RouteIdentity{
+				FlowID:       "repo-scaffold",
+				FlowInstance: "repo-scaffold",
+				EntityID:     "stale-ent",
+			},
+			wantFlowPath: "repo-scaffold",
 		},
 		{
-			name:            "failure falls back to inbound flow instance",
+			name:            "failure uses admitted delivery target route over stale inbound flow instance",
 			eventType:       "repo_scaffold.repo_commit_failed",
-			inboundFlowPath: "repo-scaffold/inst-2",
-			wantFlowPath:    "repo-scaffold/inst-2",
+			inboundFlowPath: "component-scaffold/component-a",
+			targetRoute: events.RouteIdentity{
+				FlowID:       "repo-scaffold",
+				FlowInstance: "repo-scaffold",
+				EntityID:     "stale-ent",
+			},
+			wantFlowPath: "repo-scaffold",
 		},
 	}
 
@@ -68,22 +80,31 @@ func TestArtifactRepoResultEventPreservesScopedProducerSourceRoute(t *testing.T)
 				"",
 				parentEnvelope,
 				time.Unix(1_700_000_000, 0).UTC(),
-			).WithSourceRoute(events.RouteIdentity{
-				FlowID:       "upstream",
-				FlowInstance: "upstream/inst-0",
-				EntityID:     "upstream-ent",
-			})
+			)
+			if tc.stateFlowPath != "" || !tc.producerRoute.Empty() || !tc.targetRoute.Empty() {
+				parent = parent.WithSourceRoute(events.RouteIdentity{
+					FlowID:       "upstream",
+					FlowInstance: "upstream/inst-0",
+					EntityID:     "upstream-ent",
+				})
+			}
+			if !tc.targetRoute.Empty() {
+				parent = parent.WithTargetRoute(tc.targetRoute)
+			} else if tc.inboundFlowPath != "" {
+				parent = parent.WithFlowInstance(tc.inboundFlowPath)
+			}
 			stateMetadata := map[string]any{}
 			if tc.stateFlowPath != "" {
 				stateMetadata["flow_path"] = tc.stateFlowPath
 			}
 			execCtx := runtimeengine.ExecutionContext{
 				Request: runtimeengine.ExecutionRequest{
-					EntityID:   identity.NormalizeEntityID(entityID),
-					FlowID:     identity.NormalizeFlowID("repo-scaffold"),
-					NodeID:     identity.NormalizeNodeID("repo-scaffold-node"),
-					Event:      parent,
-					ChainDepth: 4,
+					EntityID:      identity.NormalizeEntityID(entityID),
+					FlowID:        identity.NormalizeFlowID("repo-scaffold"),
+					NodeID:        identity.NormalizeNodeID("repo-scaffold-node"),
+					Event:         parent,
+					ChainDepth:    4,
+					ProducerRoute: tc.producerRoute,
 					State: runtimeengine.StateSnapshot{
 						EntityID:     identity.NormalizeEntityID(entityID),
 						StateCarrier: runtimeengine.NewStateCarrier(stateMetadata, nil, nil),
@@ -122,6 +143,9 @@ func TestArtifactRepoResultEventPreservesScopedProducerSourceRoute(t *testing.T)
 			if got := emitted.SourceRoute(); got != wantSource {
 				t.Fatalf("source route = %#v, want %#v", got, wantSource)
 			}
+			if got := emitted.TargetRoute(); !got.Empty() {
+				t.Fatalf("target route = %#v, want empty result-event target", got)
+			}
 			if got := emitted.ParentEventID(); got != parent.ID() {
 				t.Fatalf("parent_event_id = %q, want %q", got, parent.ID())
 			}
@@ -133,6 +157,71 @@ func TestArtifactRepoResultEventPreservesScopedProducerSourceRoute(t *testing.T)
 			}
 			if got := intents[0].ParentEventID; got != parent.ID() {
 				t.Fatalf("intent parent_event_id = %q, want %q", got, parent.ID())
+			}
+		})
+	}
+}
+
+func TestActionResultEventTypeResolvesAgainstProducerRoute(t *testing.T) {
+	source := loadWorkflowTempSource(t, map[string]string{
+		"package.yaml": `name: action-result-event-type
+version: 1.0.0
+flows:
+  - id: repo-scaffold
+    flow: repo-scaffold
+    mode: template
+`,
+		"flows/repo-scaffold/schema.yaml": `name: repo-scaffold
+initial_state: ready
+terminal_states: [done]
+states: [ready, done]
+`,
+		"flows/repo-scaffold/events.yaml": `repo_scaffold.repo_commit_succeeded: {}
+repo_scaffold.repo_commit_failed: {}
+`,
+	})
+	cases := []struct {
+		name          string
+		eventType     string
+		producerRoute events.RouteIdentity
+		want          string
+	}{
+		{
+			name:      "template instance local success event",
+			eventType: "repo_scaffold.repo_commit_succeeded",
+			producerRoute: events.RouteIdentity{
+				FlowID:       "repo-scaffold",
+				FlowInstance: "repo-scaffold/inst-1",
+				EntityID:     "ent-repo",
+			},
+			want: "repo-scaffold/inst-1/repo_scaffold.repo_commit_succeeded",
+		},
+		{
+			name:      "static service local failure event",
+			eventType: "repo_scaffold.repo_commit_failed",
+			producerRoute: events.RouteIdentity{
+				FlowID:       "repo-scaffold",
+				FlowInstance: "repo-scaffold",
+				EntityID:     "ent-repo",
+			},
+			want: "repo-scaffold/repo_scaffold.repo_commit_failed",
+		},
+		{
+			name:      "already scoped event is preserved",
+			eventType: "repo-scaffold/inst-1/repo_scaffold.repo_commit_succeeded",
+			producerRoute: events.RouteIdentity{
+				FlowID:       "repo-scaffold",
+				FlowInstance: "repo-scaffold/inst-1",
+				EntityID:     "ent-repo",
+			},
+			want: "repo-scaffold/inst-1/repo_scaffold.repo_commit_succeeded",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := actionResultEventType(source, "repo-scaffold", tc.eventType, tc.producerRoute)
+			if got != tc.want {
+				t.Fatalf("actionResultEventType() = %q, want %q", got, tc.want)
 			}
 		})
 	}

--- a/internal/runtime/pipeline/action_result_event_context_test.go
+++ b/internal/runtime/pipeline/action_result_event_context_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/division-sh/swarm/internal/events"
 	"github.com/division-sh/swarm/internal/runtime/core/identity"
 	runtimeengine "github.com/division-sh/swarm/internal/runtime/engine"
+	"github.com/division-sh/swarm/internal/runtime/semanticview"
 )
 
 func TestArtifactRepoResultEventPreservesScopedProducerSourceRoute(t *testing.T) {
@@ -162,31 +163,110 @@ func TestArtifactRepoResultEventPreservesScopedProducerSourceRoute(t *testing.T)
 	}
 }
 
-func TestActionResultEventTypeResolvesAgainstProducerRoute(t *testing.T) {
-	source := loadWorkflowTempSource(t, map[string]string{
-		"package.yaml": `name: action-result-event-type
-version: 1.0.0
-flows:
-  - id: repo-scaffold
-    flow: repo-scaffold
-    mode: template
-`,
-		"flows/repo-scaffold/schema.yaml": `name: repo-scaffold
-initial_state: ready
-terminal_states: [done]
-states: [ready, done]
-`,
-		"flows/repo-scaffold/events.yaml": `repo_scaffold.repo_commit_succeeded: {}
-repo_scaffold.repo_commit_failed: {}
-`,
-	})
+func TestActionResultProducerRouteCoversCurrentRouteShapes(t *testing.T) {
+	staticSource := actionResultRouteSource(t, "static")
+	templateSource := actionResultRouteSource(t, "template")
 	cases := []struct {
 		name          string
+		source        semanticview.Source
+		stateFlowPath string
+		eventFlowPath string
+		targetSet     []events.RouteIdentity
+		wantFlowPath  string
+	}{
+		{
+			name:          "static service ignores child inbound without admitted route",
+			source:        staticSource,
+			eventFlowPath: "repo-scaffold/child-1",
+			wantFlowPath:  "repo-scaffold",
+		},
+		{
+			name:         "static root input with no route uses service owner",
+			source:       staticSource,
+			wantFlowPath: "repo-scaffold",
+		},
+		{
+			name:   "static target set receiver does not become producer route",
+			source: staticSource,
+			targetSet: []events.RouteIdentity{{
+				FlowID:       "repo-scaffold",
+				FlowInstance: "repo-scaffold/child-1",
+				EntityID:     "child-ent",
+			}},
+			wantFlowPath: "repo-scaffold",
+		},
+		{
+			name:          "template nested state route remains concrete producer",
+			source:        templateSource,
+			stateFlowPath: "repo-scaffold/parent/child",
+			wantFlowPath:  "repo-scaffold/parent/child",
+		},
+		{
+			name:          "template nested inbound fallback remains concrete producer",
+			source:        templateSource,
+			eventFlowPath: "repo-scaffold/parent/child",
+			wantFlowPath:  "repo-scaffold/parent/child",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			evt := events.NewProjectionEvent(
+				"evt-parent",
+				"repo_scaffold.repo_commit_requested",
+				"workflow-runtime",
+				"",
+				json.RawMessage(`{"request_id":"req-1"}`),
+				0,
+				"run-1",
+				"",
+				events.EventEnvelope{},
+				time.Unix(1_700_000_000, 0).UTC(),
+			)
+			if tc.eventFlowPath != "" {
+				evt = evt.WithFlowInstance(tc.eventFlowPath)
+			}
+			if len(tc.targetSet) > 0 {
+				evt = evt.WithTargetSet(tc.targetSet)
+			}
+			stateMetadata := map[string]any{}
+			if tc.stateFlowPath != "" {
+				stateMetadata["flow_path"] = tc.stateFlowPath
+			}
+			route := actionResultProducerRoute(
+				tc.source,
+				"repo-scaffold",
+				"ent-repo",
+				evt,
+				runtimeengine.StateSnapshot{
+					EntityID:     identity.NormalizeEntityID("ent-repo"),
+					StateCarrier: runtimeengine.NewStateCarrier(stateMetadata, nil, nil),
+				},
+				events.RouteIdentity{},
+			)
+			wantRoute := events.RouteIdentity{
+				FlowID:       "repo-scaffold",
+				FlowInstance: tc.wantFlowPath,
+				EntityID:     "ent-repo",
+			}.Normalized()
+			if route != wantRoute {
+				t.Fatalf("producer route = %#v, want %#v", route, wantRoute)
+			}
+		})
+	}
+}
+
+func TestActionResultEventTypeResolvesAgainstProducerRoute(t *testing.T) {
+	templateSource := actionResultRouteSource(t, "template")
+	staticSource := actionResultRouteSource(t, "static")
+	cases := []struct {
+		name          string
+		source        semanticview.Source
 		eventType     string
 		producerRoute events.RouteIdentity
 		want          string
 	}{
 		{
+			source:    templateSource,
 			name:      "template instance local success event",
 			eventType: "repo_scaffold.repo_commit_succeeded",
 			producerRoute: events.RouteIdentity{
@@ -197,6 +277,7 @@ repo_scaffold.repo_commit_failed: {}
 			want: "repo-scaffold/inst-1/repo_scaffold.repo_commit_succeeded",
 		},
 		{
+			source:    staticSource,
 			name:      "static service local failure event",
 			eventType: "repo_scaffold.repo_commit_failed",
 			producerRoute: events.RouteIdentity{
@@ -207,6 +288,7 @@ repo_scaffold.repo_commit_failed: {}
 			want: "repo-scaffold/repo_scaffold.repo_commit_failed",
 		},
 		{
+			source:    templateSource,
 			name:      "already scoped event is preserved",
 			eventType: "repo-scaffold/inst-1/repo_scaffold.repo_commit_succeeded",
 			producerRoute: events.RouteIdentity{
@@ -216,15 +298,48 @@ repo_scaffold.repo_commit_failed: {}
 			},
 			want: "repo-scaffold/inst-1/repo_scaffold.repo_commit_succeeded",
 		},
+		{
+			source:    staticSource,
+			name:      "static manual prefix stays service scoped",
+			eventType: "repo-scaffold/repo_scaffold.repo_commit_failed",
+			producerRoute: events.RouteIdentity{
+				FlowID:       "repo-scaffold",
+				FlowInstance: "repo-scaffold",
+				EntityID:     "ent-repo",
+			},
+			want: "repo-scaffold/repo_scaffold.repo_commit_failed",
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := actionResultEventType(source, "repo-scaffold", tc.eventType, tc.producerRoute)
+			got := actionResultEventType(tc.source, "repo-scaffold", tc.eventType, tc.producerRoute)
 			if got != tc.want {
 				t.Fatalf("actionResultEventType() = %q, want %q", got, tc.want)
 			}
 		})
 	}
+}
+
+func actionResultRouteSource(t *testing.T, mode string) semanticview.Source {
+	t.Helper()
+	return loadWorkflowTempSource(t, map[string]string{
+		"package.yaml": `name: action-result-event-type
+version: 1.0.0
+flows:
+  - id: repo-scaffold
+    flow: repo-scaffold
+    mode: ` + mode + `
+`,
+		"flows/repo-scaffold/schema.yaml": `name: repo-scaffold
+initial_state: ready
+terminal_states: [done]
+states: [ready, done]
+`,
+		"flows/repo-scaffold/events.yaml": `repo_scaffold.repo_commit_requested: {}
+repo_scaffold.repo_commit_succeeded: {}
+repo_scaffold.repo_commit_failed: {}
+`,
+	})
 }
 
 func TestRuntimeActionResultEventProducerInventoryOnlyArtifactRepoQueuesResultEvents(t *testing.T) {

--- a/internal/runtime/pipeline/artifact_repo.go
+++ b/internal/runtime/pipeline/artifact_repo.go
@@ -36,6 +36,8 @@ const (
 	defaultRepoMaxBytes          = 50 << 20
 )
 
+var errArtifactRepoResultEmitCollectorMissing = errors.New("artifact_repo_commit result event requires transactional action emit collector")
+
 var invalidArtifactRootMounts = []string{"/workspace", "/data", "/opt/swarm/contracts"}
 
 type artifactRepoPreparedFile struct {
@@ -196,13 +198,7 @@ func (pc *PipelineCoordinator) persistAndPublishArtifactRepoFailure(ctx context.
 		}
 		return nil
 	}
-	if persistErr := pc.persistArtifactRepoResult(ctx, execCtx, spec, fields); persistErr != nil {
-		return errors.Join(cause, fmt.Errorf("artifact_repo_commit failed to persist failure state: %w", persistErr))
-	}
-	if publishErr := pc.publish(ctx, failureEvent, execCtx.Request.EntityID.String(), payload); publishErr != nil {
-		return errors.Join(cause, publishErr)
-	}
-	return cause
+	return errors.Join(cause, errArtifactRepoResultEmitCollectorMissing)
 }
 
 func (pc *PipelineCoordinator) persistAndPublishArtifactRepoSuccess(ctx context.Context, execCtx runtimeengine.ExecutionContext, spec *runtimecontracts.ArtifactRepoSpec, repoURL, ref string, manifest map[string]any, requestID, sourceEventID string, successPayload map[string]any) error {
@@ -225,14 +221,7 @@ func (pc *PipelineCoordinator) persistAndPublishArtifactRepoSuccess(ctx context.
 		fields[spec.Output.LastSourceEventID] = sourceEventID
 		return pc.persistArtifactRepoResult(ctx, execCtx, spec, fields)
 	}
-	if err := pc.persistArtifactRepoResult(ctx, execCtx, spec, fields); err != nil {
-		return err
-	}
-	if err := pc.publish(ctx, successEvent, execCtx.Request.EntityID.String(), successPayload); err != nil {
-		return err
-	}
-	fields[spec.Output.LastSourceEventID] = sourceEventID
-	return pc.persistArtifactRepoResult(ctx, execCtx, spec, fields)
+	return errArtifactRepoResultEmitCollectorMissing
 }
 
 func (pc *PipelineCoordinator) queueArtifactRepoResultEvent(ctx context.Context, execCtx runtimeengine.ExecutionContext, eventType string, payload map[string]any) (bool, error) {
@@ -254,16 +243,10 @@ func (pc *PipelineCoordinator) queueArtifactRepoResultEvent(ctx context.Context,
 	if chainDepth <= 0 {
 		chainDepth = 1
 	}
-	entityID := strings.TrimSpace(execCtx.Request.EntityID.String())
-	flowInstance := firstNonEmptyString(
-		normalizedArtifactRepoFlowInstance(asString(execCtx.Request.State.StateCarrier.Metadata["flow_path"])),
-		normalizedArtifactRepoFlowInstance(execCtx.Request.Event.FlowInstance()),
-	)
-	sourceRoute := events.RouteIdentity{
-		FlowID:       strings.TrimSpace(execCtx.Request.FlowID.String()),
-		FlowInstance: flowInstance,
-		EntityID:     entityID,
-	}.Normalized()
+	sourceRoute := pc.artifactRepoResultProducerRoute(execCtx)
+	eventType = actionResultEventType(pc.SemanticSource(), execCtx.Request.FlowID.String(), eventType, sourceRoute)
+	entityID := sourceRoute.EntityID
+	flowInstance := sourceRoute.FlowInstance
 	envelope := events.EventEnvelope{
 		EntityID:     entityID,
 		FlowInstance: flowInstance,
@@ -289,8 +272,15 @@ func (pc *PipelineCoordinator) queueArtifactRepoResultEvent(ctx context.Context,
 	}), nil
 }
 
-func normalizedArtifactRepoFlowInstance(value string) string {
-	return strings.Trim(strings.TrimSpace(value), "/")
+func (pc *PipelineCoordinator) artifactRepoResultProducerRoute(execCtx runtimeengine.ExecutionContext) events.RouteIdentity {
+	return actionResultProducerRoute(
+		pc.SemanticSource(),
+		execCtx.Request.FlowID.String(),
+		execCtx.Request.EntityID.String(),
+		execCtx.Request.Event,
+		execCtx.Request.State,
+		execCtx.Request.ProducerRoute,
+	)
 }
 
 func (pc *PipelineCoordinator) artifactRepoRoot() (string, error) {

--- a/internal/runtime/pipeline/engine_adapter_test.go
+++ b/internal/runtime/pipeline/engine_adapter_test.go
@@ -1219,12 +1219,10 @@ func TestPipelineEngineActionRunner_ArtifactRepoCommitRejectsAgentVisibleArtifac
 	}
 	action, execCtx := testArtifactRepoActionAndContext(entityID, initial, "33333333-3333-3333-3333-333333333333", "44444444-4444-4444-4444-444444444444", "name: Demo\n")
 
-	ok, err := pipelineEngineActionRunner{coordinator: pc}.ExecuteAction(ctx, action, runtimeregistry.ActionInstruction{Builtin: "artifact_repo_commit"}, execCtx)
-	if !ok {
-		t.Fatal("expected artifact_repo_commit action to be claimed")
-	}
-	if err == nil || !strings.Contains(err.Error(), "agent-visible mount /data") {
-		t.Fatalf("ExecuteAction error = %v, want invalid /data artifact root", err)
+	var intents []runtimeengine.EmitIntent
+	ok, err := pipelineEngineActionRunner{coordinator: pc}.ExecuteAction(runtimeengine.WithActionEmitIntentCollector(ctx, &intents), action, runtimeregistry.ActionInstruction{Builtin: "artifact_repo_commit"}, execCtx)
+	if !ok || err != nil {
+		t.Fatalf("ExecuteAction ok=%v err=%v, want handled failure result", ok, err)
 	}
 	instance, _, err := store.Load(ctx, entityID)
 	if err != nil {
@@ -1239,11 +1237,9 @@ func TestPipelineEngineActionRunner_ArtifactRepoCommitRejectsAgentVisibleArtifac
 	if _, exists := instance.Metadata["current_ref"]; exists {
 		t.Fatalf("current_ref should not be persisted on invalid artifact root: %#v", instance.Metadata["current_ref"])
 	}
-	if got := bus.publishedCount(); got != 1 {
-		t.Fatalf("failure event count = %d, want 1", got)
-	}
-	if got := string(bus.publishedEvent(0).Type()); got != "artifact_repo.commit_failed" {
-		t.Fatalf("failure event type = %q", got)
+	assertArtifactRepoQueuedIntent(t, intents, 0, "artifact_repo.commit_failed")
+	if got := bus.publishedCount(); got != 0 {
+		t.Fatalf("fallback published event count = %d, want 0", got)
 	}
 }
 
@@ -1298,12 +1294,10 @@ func TestPipelineEngineActionRunner_ArtifactRepoCommitRejectsUnusableArtifactRoo
 			}
 			action, execCtx := testArtifactRepoActionAndContext(entityID, initial, "33333333-3333-3333-3333-333333333333", "44444444-4444-4444-4444-444444444444", "name: Demo\n")
 
-			ok, err := pipelineEngineActionRunner{coordinator: pc}.ExecuteAction(ctx, action, runtimeregistry.ActionInstruction{Builtin: "artifact_repo_commit"}, execCtx)
-			if !ok {
-				t.Fatal("expected artifact_repo_commit action to be claimed")
-			}
-			if err == nil || !strings.Contains(err.Error(), "not writable by the runtime process") || !strings.Contains(err.Error(), "SWARM_ARTIFACT_ROOT=<writable runtime-private absolute path>") {
-				t.Fatalf("ExecuteAction error = %v, want unusable root remediation", err)
+			var intents []runtimeengine.EmitIntent
+			ok, err := pipelineEngineActionRunner{coordinator: pc}.ExecuteAction(runtimeengine.WithActionEmitIntentCollector(ctx, &intents), action, runtimeregistry.ActionInstruction{Builtin: "artifact_repo_commit"}, execCtx)
+			if !ok || err != nil {
+				t.Fatalf("ExecuteAction ok=%v err=%v, want handled failure result", ok, err)
 			}
 			instance, _, err := store.Load(ctx, entityID)
 			if err != nil {
@@ -1315,14 +1309,15 @@ func TestPipelineEngineActionRunner_ArtifactRepoCommitRejectsUnusableArtifactRoo
 			if got := strings.TrimSpace(asString(instance.Metadata["failure_reason"])); !strings.Contains(got, wantDetail) || !strings.Contains(got, "not writable by the runtime process") {
 				t.Fatalf("failure_reason = %q, want unusable root detail %q", got, wantDetail)
 			}
-			if got := bus.publishedCount(); got != 1 {
-				t.Fatalf("failure event count = %d, want 1", got)
+			assertArtifactRepoQueuedIntent(t, intents, 0, "artifact_repo.commit_failed")
+			if got := bus.publishedCount(); got != 0 {
+				t.Fatalf("fallback published event count = %d, want 0", got)
 			}
 		})
 	}
 }
 
-func TestPipelineEngineActionRunner_ArtifactRepoCommitPublishesSuccessResultEvent(t *testing.T) {
+func TestPipelineEngineActionRunner_ArtifactRepoCommitQueuesSuccessResultEvent(t *testing.T) {
 	_, db, cleanup := testutil.StartPostgres(t)
 	defer cleanup()
 	store := NewWorkflowInstanceStore(db)
@@ -1359,18 +1354,15 @@ func TestPipelineEngineActionRunner_ArtifactRepoCommitPublishesSuccessResultEven
 		"result_kind": runtimecontracts.LiteralExpression("ready"),
 	}
 
-	ok, err := pipelineEngineActionRunner{coordinator: pc}.ExecuteAction(ctx, action, runtimeregistry.ActionInstruction{Builtin: "artifact_repo_commit"}, execCtx)
+	var intents []runtimeengine.EmitIntent
+	actionCtx := runtimeengine.WithActionEmitIntentCollector(ctx, &intents)
+	ok, err := pipelineEngineActionRunner{coordinator: pc}.ExecuteAction(actionCtx, action, runtimeregistry.ActionInstruction{Builtin: "artifact_repo_commit"}, execCtx)
 	if !ok || err != nil {
 		t.Fatalf("ExecuteAction ok=%v err=%v", ok, err)
 	}
-	if got := bus.publishedCount(); got != 1 {
-		t.Fatalf("success event count = %d, want 1", got)
-	}
-	if got := string(bus.publishedEvent(0).Type()); got != "artifact_repo.commit_completed" {
-		t.Fatalf("success event type = %q", got)
-	}
+	resultEvent := assertArtifactRepoQueuedIntent(t, intents, 0, "artifact_repo.commit_completed")
 	var payload map[string]any
-	if err := json.Unmarshal(bus.publishedEvent(0).Payload(), &payload); err != nil {
+	if err := json.Unmarshal(resultEvent.Payload(), &payload); err != nil {
 		t.Fatalf("success event payload: %v", err)
 	}
 	if got := strings.TrimSpace(asString(payload["repo_id"])); got != initial["repo_id"].(string) {
@@ -1395,11 +1387,11 @@ func TestPipelineEngineActionRunner_ArtifactRepoCommitPublishesSuccessResultEven
 
 	replayCtx := execCtx
 	replayCtx.Request.State.StateCarrier.Metadata = cloneStringAnyMap(committed.Metadata)
-	if _, err := (pipelineEngineActionRunner{coordinator: pc}).ExecuteAction(ctx, action, runtimeregistry.ActionInstruction{Builtin: "artifact_repo_commit"}, replayCtx); err != nil {
+	if _, err := (pipelineEngineActionRunner{coordinator: pc}).ExecuteAction(actionCtx, action, runtimeregistry.ActionInstruction{Builtin: "artifact_repo_commit"}, replayCtx); err != nil {
 		t.Fatalf("same-source replay ExecuteAction: %v", err)
 	}
-	if got := bus.publishedCount(); got != 1 {
-		t.Fatalf("same-source replay success event count = %d, want 1", got)
+	if got := len(intents); got != 1 {
+		t.Fatalf("same-source replay queued success event count = %d, want 1", got)
 	}
 
 	if err := store.Upsert(ctx, WorkflowInstance{
@@ -1415,11 +1407,14 @@ func TestPipelineEngineActionRunner_ArtifactRepoCommitPublishesSuccessResultEven
 	repairAction, repairCtx := testArtifactRepoActionAndContext(entityID, initial, "55555555-5555-5555-5555-555555555555", "44444444-4444-4444-4444-444444444444", "name: Demo\n")
 	repairAction.ArtifactRepo.SuccessEvent = action.ArtifactRepo.SuccessEvent
 	repairAction.ArtifactRepo.SuccessPayload = action.ArtifactRepo.SuccessPayload
-	if _, err := (pipelineEngineActionRunner{coordinator: pc}).ExecuteAction(ctx, repairAction, runtimeregistry.ActionInstruction{Builtin: "artifact_repo_commit"}, repairCtx); err != nil {
+	if _, err := (pipelineEngineActionRunner{coordinator: pc}).ExecuteAction(actionCtx, repairAction, runtimeregistry.ActionInstruction{Builtin: "artifact_repo_commit"}, repairCtx); err != nil {
 		t.Fatalf("history repair ExecuteAction: %v", err)
 	}
-	if got := bus.publishedCount(); got != 2 {
-		t.Fatalf("history repair success event count = %d, want 2", got)
+	if got := len(intents); got != 2 {
+		t.Fatalf("history repair queued success event count = %d, want 2", got)
+	}
+	if got := bus.publishedCount(); got != 0 {
+		t.Fatalf("fallback published event count = %d, want 0", got)
 	}
 }
 
@@ -1654,11 +1649,11 @@ func TestExecuteNodeContractHandlerArtifactRepoCommitFailureResultOutboxFailureR
 	}
 }
 
-func TestPipelineEngineActionRunner_ArtifactRepoCommitRetriesSuccessEventAfterPublishFailure(t *testing.T) {
+func TestPipelineEngineActionRunner_ArtifactRepoCommitFailsClosedWithoutResultEventCollector(t *testing.T) {
 	_, db, cleanup := testutil.StartPostgres(t)
 	defer cleanup()
 	store := NewWorkflowInstanceStore(db)
-	bus := &recordingPipelineBus{publishErr: errors.New("transient publish failure")}
+	bus := &recordingPipelineBus{publishErr: errors.New("direct publish must not be used")}
 	source := testArtifactRepoResultEventSource(t)
 	bundle, ok := semanticview.Bundle(source)
 	if !ok {
@@ -1694,41 +1689,21 @@ func TestPipelineEngineActionRunner_ArtifactRepoCommitRetriesSuccessEventAfterPu
 	if !ok {
 		t.Fatal("expected artifact_repo_commit action to be claimed")
 	}
-	if err == nil || !strings.Contains(err.Error(), "transient publish failure") {
-		t.Fatalf("ExecuteAction error = %v, want transient publish failure", err)
+	if err == nil || !strings.Contains(err.Error(), errArtifactRepoResultEmitCollectorMissing.Error()) {
+		t.Fatalf("ExecuteAction error = %v, want missing result collector", err)
 	}
-	partiallyCommitted, _, err := store.Load(ctx, entityID)
+	instance, _, err := store.Load(ctx, entityID)
 	if err != nil {
-		t.Fatalf("load partially committed workflow instance: %v", err)
+		t.Fatalf("load workflow instance: %v", err)
 	}
-	if got := strings.TrimSpace(asString(partiallyCommitted.Metadata["status"])); got != "committed" {
-		t.Fatalf("status = %q, want committed", got)
+	if got := strings.TrimSpace(asString(instance.Metadata["status"])); got != "" {
+		t.Fatalf("status = %q, want unchanged without result collector", got)
 	}
-	if got := strings.TrimSpace(asString(partiallyCommitted.Metadata["current_ref"])); len(got) != 40 {
-		t.Fatalf("current_ref = %q, want committed ref", got)
-	}
-	if got := strings.TrimSpace(asString(partiallyCommitted.Metadata["last_source_event_id"])); got == execCtx.Request.Event.ID() {
-		t.Fatalf("last_source_event_id = %q; publish failure must not mark replay complete", got)
+	if _, exists := instance.Metadata["current_ref"]; exists {
+		t.Fatalf("current_ref should not be persisted without result collector: %#v", instance.Metadata["current_ref"])
 	}
 	if got := bus.publishedCount(); got != 0 {
-		t.Fatalf("success event count after failed publish = %d, want 0", got)
-	}
-
-	bus.publishErr = nil
-	retryCtx := execCtx
-	retryCtx.Request.State.StateCarrier.Metadata = cloneStringAnyMap(partiallyCommitted.Metadata)
-	if _, err := (pipelineEngineActionRunner{coordinator: pc}).ExecuteAction(ctx, action, runtimeregistry.ActionInstruction{Builtin: "artifact_repo_commit"}, retryCtx); err != nil {
-		t.Fatalf("retry ExecuteAction: %v", err)
-	}
-	if got := bus.publishedCount(); got != 1 {
-		t.Fatalf("success event count after retry = %d, want 1", got)
-	}
-	completed, _, err := store.Load(ctx, entityID)
-	if err != nil {
-		t.Fatalf("load completed workflow instance: %v", err)
-	}
-	if got := strings.TrimSpace(asString(completed.Metadata["last_source_event_id"])); got != execCtx.Request.Event.ID() {
-		t.Fatalf("last_source_event_id = %q, want %q", got, execCtx.Request.Event.ID())
+		t.Fatalf("fallback published event count = %d, want 0", got)
 	}
 }
 
@@ -1765,12 +1740,10 @@ func TestPipelineEngineActionRunner_ArtifactRepoCommitFailsClosedOnInvalidSucces
 	action, execCtx := testArtifactRepoActionAndContext(entityID, initial, "33333333-3333-3333-3333-333333333333", "44444444-4444-4444-4444-444444444444", "name: Demo\n")
 	action.ArtifactRepo.SuccessEvent = "artifact_repo.commit_completed"
 
-	ok, err := pipelineEngineActionRunner{coordinator: pc}.ExecuteAction(ctx, action, runtimeregistry.ActionInstruction{Builtin: "artifact_repo_commit"}, execCtx)
-	if !ok {
-		t.Fatal("expected artifact_repo_commit action to be claimed")
-	}
-	if err == nil || !strings.Contains(err.Error(), "payload violates schema") {
-		t.Fatalf("ExecuteAction error = %v, want success schema violation", err)
+	var intents []runtimeengine.EmitIntent
+	ok, err := pipelineEngineActionRunner{coordinator: pc}.ExecuteAction(runtimeengine.WithActionEmitIntentCollector(ctx, &intents), action, runtimeregistry.ActionInstruction{Builtin: "artifact_repo_commit"}, execCtx)
+	if !ok || err != nil {
+		t.Fatalf("ExecuteAction ok=%v err=%v, want handled failure result", ok, err)
 	}
 	instance, _, err := store.Load(ctx, entityID)
 	if err != nil {
@@ -1782,11 +1755,12 @@ func TestPipelineEngineActionRunner_ArtifactRepoCommitFailsClosedOnInvalidSucces
 	if got := strings.TrimSpace(asString(instance.Metadata["status"])); got != "failed" {
 		t.Fatalf("status = %q, want failed", got)
 	}
-	if got := bus.publishedCount(); got != 1 {
-		t.Fatalf("failure event count = %d, want 1", got)
+	if got := strings.TrimSpace(asString(instance.Metadata["failure_reason"])); !strings.Contains(got, "payload violates schema") {
+		t.Fatalf("failure_reason = %q, want schema violation detail", got)
 	}
-	if got := string(bus.publishedEvent(0).Type()); got != "artifact_repo.commit_failed" {
-		t.Fatalf("published event type = %q, want failure event", got)
+	assertArtifactRepoQueuedIntent(t, intents, 0, "artifact_repo.commit_failed")
+	if got := bus.publishedCount(); got != 0 {
+		t.Fatalf("fallback published event count = %d, want 0", got)
 	}
 }
 
@@ -1812,12 +1786,10 @@ func TestPipelineEngineActionRunner_ArtifactRepoCommitFailsClosedOnPathOutsideAl
 	action, execCtx := testArtifactRepoActionAndContext(entityID, initial, "33333333-3333-3333-3333-333333333333", "44444444-4444-4444-4444-444444444444", "name: Demo\n")
 	action.ArtifactRepo.Files[0].Path = runtimecontracts.LiteralExpression("../escape.yaml")
 
-	ok, err := pipelineEngineActionRunner{coordinator: pc}.ExecuteAction(ctx, action, runtimeregistry.ActionInstruction{Builtin: "artifact_repo_commit"}, execCtx)
-	if !ok {
-		t.Fatal("expected artifact_repo_commit action to be claimed")
-	}
-	if err == nil || !strings.Contains(err.Error(), "path traversal is not allowed") {
-		t.Fatalf("ExecuteAction error = %v, want path traversal", err)
+	var intents []runtimeengine.EmitIntent
+	ok, err := pipelineEngineActionRunner{coordinator: pc}.ExecuteAction(runtimeengine.WithActionEmitIntentCollector(ctx, &intents), action, runtimeregistry.ActionInstruction{Builtin: "artifact_repo_commit"}, execCtx)
+	if !ok || err != nil {
+		t.Fatalf("ExecuteAction ok=%v err=%v, want handled failure result", ok, err)
 	}
 	instance, _, err := store.Load(ctx, entityID)
 	if err != nil {
@@ -1832,14 +1804,9 @@ func TestPipelineEngineActionRunner_ArtifactRepoCommitFailsClosedOnPathOutsideAl
 	if got := strings.TrimSpace(asString(instance.Metadata["failure_reason"])); !strings.Contains(got, "path traversal is not allowed") {
 		t.Fatalf("failure_reason = %q, want traversal detail", got)
 	}
-	if got := bus.publishedCount(); got != 1 {
-		t.Fatalf("failure event count = %d, want 1", got)
-	}
-	if got := string(bus.publishedEvent(0).Type()); got != "artifact_repo.commit_failed" {
-		t.Fatalf("failure event type = %q", got)
-	}
+	failureEvent := assertArtifactRepoQueuedIntent(t, intents, 0, "artifact_repo.commit_failed")
 	var payload map[string]any
-	if err := json.Unmarshal(bus.publishedEvent(0).Payload(), &payload); err != nil {
+	if err := json.Unmarshal(failureEvent.Payload(), &payload); err != nil {
 		t.Fatalf("failure event payload: %v", err)
 	}
 	if got := strings.TrimSpace(asString(payload["namespace"])); got != initial["namespace"].(string) {
@@ -1854,6 +1821,9 @@ func TestPipelineEngineActionRunner_ArtifactRepoCommitFailsClosedOnPathOutsideAl
 	}
 	if got := strings.TrimSpace(asString(provenance["source_record_id"])); got != initial["source_record_id"].(string) {
 		t.Fatalf("failure payload provenance source_record_id = %q", got)
+	}
+	if got := bus.publishedCount(); got != 0 {
+		t.Fatalf("fallback published event count = %d, want 0", got)
 	}
 }
 
@@ -1878,12 +1848,10 @@ func TestPipelineEngineActionRunner_ArtifactRepoCommitFailsClosedOnYAMLSchemaMis
 	}
 	action, execCtx := testArtifactRepoActionAndContext(entityID, initial, "33333333-3333-3333-3333-333333333333", "44444444-4444-4444-4444-444444444444", "rank: 2\n")
 
-	ok, err := pipelineEngineActionRunner{coordinator: pc}.ExecuteAction(ctx, action, runtimeregistry.ActionInstruction{Builtin: "artifact_repo_commit"}, execCtx)
-	if !ok {
-		t.Fatal("expected artifact_repo_commit action to be claimed")
-	}
-	if err == nil || !strings.Contains(err.Error(), "missing required field name") {
-		t.Fatalf("ExecuteAction error = %v, want schema mismatch", err)
+	var intents []runtimeengine.EmitIntent
+	ok, err := pipelineEngineActionRunner{coordinator: pc}.ExecuteAction(runtimeengine.WithActionEmitIntentCollector(ctx, &intents), action, runtimeregistry.ActionInstruction{Builtin: "artifact_repo_commit"}, execCtx)
+	if !ok || err != nil {
+		t.Fatalf("ExecuteAction ok=%v err=%v, want handled failure result", ok, err)
 	}
 	instance, _, err := store.Load(ctx, entityID)
 	if err != nil {
@@ -1895,6 +1863,10 @@ func TestPipelineEngineActionRunner_ArtifactRepoCommitFailsClosedOnYAMLSchemaMis
 	if _, exists := instance.Metadata["current_ref"]; exists {
 		t.Fatalf("current_ref should not be persisted on failed commit: %#v", instance.Metadata["current_ref"])
 	}
+	if got := strings.TrimSpace(asString(instance.Metadata["failure_reason"])); !strings.Contains(got, "missing required field name") {
+		t.Fatalf("failure_reason = %q, want schema mismatch detail", got)
+	}
+	assertArtifactRepoQueuedIntent(t, intents, 0, "artifact_repo.commit_failed")
 }
 
 func TestPipelineEngineActionRunner_ArtifactRepoCommitRejectsRequestIDContentConflict(t *testing.T) {
@@ -1936,13 +1908,12 @@ func TestPipelineEngineActionRunner_ArtifactRepoCommitRejectsRequestIDContentCon
 	afterNext.Metadata["display_slug"] = "Renamed Artifact"
 
 	conflictAction, conflictCtx := testArtifactRepoActionAndContext(entityID, afterNext.Metadata, "77777777-7777-7777-7777-777777777777", "44444444-4444-4444-4444-444444444444", "name: Changed\n")
-	ok, err := pipelineEngineActionRunner{coordinator: pc}.ExecuteAction(ctx, conflictAction, runtimeregistry.ActionInstruction{Builtin: "artifact_repo_commit"}, conflictCtx)
-	if !ok {
-		t.Fatal("expected artifact_repo_commit action to be claimed")
+	var conflictIntents []runtimeengine.EmitIntent
+	ok, err := pipelineEngineActionRunner{coordinator: pc}.ExecuteAction(runtimeengine.WithActionEmitIntentCollector(ctx, &conflictIntents), conflictAction, runtimeregistry.ActionInstruction{Builtin: "artifact_repo_commit"}, conflictCtx)
+	if !ok || err != nil {
+		t.Fatalf("ExecuteAction ok=%v err=%v, want handled failure result", ok, err)
 	}
-	if err == nil || !strings.Contains(err.Error(), "conflicts with previously committed tree") {
-		t.Fatalf("ExecuteAction error = %v, want request conflict", err)
-	}
+	assertArtifactRepoQueuedIntent(t, conflictIntents, 0, "artifact_repo.commit_failed")
 }
 
 func TestPipelineEngineActionRunner_ArtifactRepoCommitRecordsNoDiffRequestHistory(t *testing.T) {
@@ -2008,18 +1979,14 @@ func TestPipelineEngineActionRunner_ArtifactRepoCommitRecordsNoDiffRequestHistor
 	}
 
 	conflictAction, conflictCtx := testArtifactRepoActionAndContext(entityID, afterNext.Metadata, "99999999-9999-9999-9999-999999999999", "66666666-6666-6666-6666-666666666666", "name: Changed\n")
-	ok, err := pipelineEngineActionRunner{coordinator: pc}.ExecuteAction(ctx, conflictAction, runtimeregistry.ActionInstruction{Builtin: "artifact_repo_commit"}, conflictCtx)
-	if !ok {
-		t.Fatal("expected artifact_repo_commit action to be claimed")
+	var conflictIntents []runtimeengine.EmitIntent
+	ok, err := pipelineEngineActionRunner{coordinator: pc}.ExecuteAction(runtimeengine.WithActionEmitIntentCollector(ctx, &conflictIntents), conflictAction, runtimeregistry.ActionInstruction{Builtin: "artifact_repo_commit"}, conflictCtx)
+	if !ok || err != nil {
+		t.Fatalf("ExecuteAction ok=%v err=%v, want handled failure result", ok, err)
 	}
-	if err == nil || !strings.Contains(err.Error(), "conflicts with previously committed tree") {
-		t.Fatalf("ExecuteAction error = %v, want same-tree request history conflict", err)
-	}
-	if got := bus.publishedCount(); got != 1 {
-		t.Fatalf("conflict failure event count = %d, want 1", got)
-	}
-	if got := string(bus.publishedEvent(0).Type()); got != "artifact_repo.commit_failed" {
-		t.Fatalf("conflict published event type = %q, want failure event", got)
+	assertArtifactRepoQueuedIntent(t, conflictIntents, 0, "artifact_repo.commit_failed")
+	if got := bus.publishedCount(); got != 0 {
+		t.Fatalf("fallback published event count = %d, want 0", got)
 	}
 }
 
@@ -2114,13 +2081,12 @@ func TestPipelineEngineActionRunner_ArtifactRepoCommitEnforcesProjectedRepoSize(
 		ContentType: "text",
 	}}
 	nextAction.ArtifactRepo.Limits.MaxRepoBytes = 30
-	ok, err := pipelineEngineActionRunner{coordinator: pc}.ExecuteAction(ctx, nextAction, runtimeregistry.ActionInstruction{Builtin: "artifact_repo_commit"}, nextCtx)
-	if !ok {
-		t.Fatal("expected artifact_repo_commit action to be claimed")
+	var intents []runtimeengine.EmitIntent
+	ok, err := pipelineEngineActionRunner{coordinator: pc}.ExecuteAction(runtimeengine.WithActionEmitIntentCollector(ctx, &intents), nextAction, runtimeregistry.ActionInstruction{Builtin: "artifact_repo_commit"}, nextCtx)
+	if !ok || err != nil {
+		t.Fatalf("ExecuteAction ok=%v err=%v, want handled failure result", ok, err)
 	}
-	if err == nil || !strings.Contains(err.Error(), "repository tree exceeds max repo bytes") {
-		t.Fatalf("ExecuteAction error = %v, want projected repo size failure", err)
-	}
+	assertArtifactRepoQueuedIntent(t, intents, 0, "artifact_repo.commit_failed")
 }
 
 func TestWriteArtifactRepoFilesRejectsSymlinkEscape(t *testing.T) {
@@ -2161,6 +2127,21 @@ func testProjectionEventWithSourceAgent(evt events.Event, sourceAgent string) ev
 		evt.Envelope(),
 		evt.CreatedAt(),
 	)
+}
+
+func assertArtifactRepoQueuedIntent(t *testing.T, intents []runtimeengine.EmitIntent, index int, eventType string) events.Event {
+	t.Helper()
+	if len(intents) <= index {
+		t.Fatalf("queued artifact result intents = %d, want index %d for %s", len(intents), index, eventType)
+	}
+	evt := intents[index].Event
+	if got := strings.TrimSpace(string(evt.Type())); got != eventType {
+		t.Fatalf("queued artifact result event type = %q, want %q", got, eventType)
+	}
+	if got := strings.TrimSpace(intents[index].ParentEventID); got == "" {
+		t.Fatalf("queued artifact result parent_event_id is empty for %s", eventType)
+	}
+	return evt
 }
 
 func testArtifactRepoResultEventSource(t *testing.T) semanticview.Source {

--- a/internal/runtime/pipeline/engine_bridge.go
+++ b/internal/runtime/pipeline/engine_bridge.go
@@ -235,11 +235,13 @@ func (pc *PipelineCoordinator) executeNodeContractHandler(
 	if err != nil {
 		return contractHandlerExecutionResult{}, err
 	}
+	producerRoute := actionResultProducerRoute(source, flowID, entityID, triggerCtx.Event, stateSnapshot, triggerCtx.Event.TargetRoute())
 	result, err := exec.Execute(ctx, runtimeengine.ExecutionRequest{
 		EntityID:        identity.NormalizeEntityID(entityID),
 		NodeID:          identity.NormalizeNodeID(nodeID),
 		FlowID:          identity.NormalizeFlowID(flowID),
 		Event:           triggerCtx.Event,
+		ProducerRoute:   producerRoute,
 		HandlerEventKey: handlerEventKey,
 		ChainDepth:      triggerCtx.Event.ChainDepth(),
 		Handler:         handler,


### PR DESCRIPTION
## Summary

Closes #1408.

This PR closes the approved first-slice class `runtime_action_result_event_producer_context_all_current_route_shapes` for `artifact_repo_commit` action result events.

It carries the admitted handler/action producer route into `runtimeengine.ExecutionRequest`, uses that route when constructing `artifact_repo_commit` success/failure result events, resolves local result event names against the producer flow context, and removes the direct `pc.publish` fallback so result events fail closed unless they go through the transactional action emit collector.

## Governing refs / context

Exact binding spec references:

- `platform-spec.yaml:266-315`: runtime-owned envelope split; source route identity is emitter context, target route identity is receiver selection.
- `platform-spec.yaml:451-470`: publish-time `RoutePlan` is workflow-node route authority and typed recipients must be persisted in `event_deliveries` before executable work.
- `platform-spec.yaml:523-555`: runtime-produced callback local events with scoped `flow_instance` normalize to concrete same-flow route context.
- `platform-spec.yaml:1579-1638`: `artifact_repo_commit` success/failure events are runtime-owned follow-up events written transactionally and dispatched after commit/failure.
- `platform-spec.yaml:1814-1850`: event identity/localization belongs to the canonical resolver model, not ad hoc action routing.
- `platform-spec.yaml:1919-1933` and `2178-2204`: target filtering/subscriber resolution and node handling consume persisted delivery authority.

Binding issue/gate context:

- #1408 issue body and pre-audit.
- Gate outcome: `approved as first slice` for `runtime_action_result_event_producer_context_all_current_route_shapes`.
- Gate conditions: prove both template-instance and Empire static/service shapes; source route must come from admitted handler/action route; success/failure must prove durable RoutePlan delivery, callback admission, settlement, and route-scoped receipt evidence; remove or close the `pc.publish` fallback; do not absorb #1340/#1353.

## Semantic migration

New canonical owner for this slice:

- `runtimeengine.ExecutionRequest.ProducerRoute`, established from the admitted workflow-node/action route in `engine_bridge.go`.
- `actionResultProducerRoute` / `actionResultEventType`, consumed by `artifact_repo_commit` result event construction.

Old non-authoritative paths now invalid:

- `artifact_repo_commit` result event route inference from only state `flow_path`.
- inbound `Event.FlowInstance()` as the only source of producer context.
- direct `pc.publish` fallback for configured action result events.
- receipt/readback/replay carrier/handler lookup as route authority.

Production paths checked for surviving old behavior:

- `artifact_repo_commit` success_event.
- `artifact_repo_commit` failure_event.
- direct action-runner tests with no collector.
- replay/history repair paths.
- invalid root, invalid payload/schema/path/size/conflict failure result paths.
- `QueueActionEmitIntent` inventory for runtime action result producers.

Migration status:

- Complete for the approved `artifact_repo_commit` action result producer-context class.
- Broader parent architecture trackers #1340 and #1353 remain open.

## Proof

- `go test ./internal/runtime/pipeline -run 'TestArtifactRepoResultEventPreservesScopedProducerSourceRoute|TestActionResultEventTypeResolvesAgainstProducerRoute|TestRuntimeActionResultEventProducerInventoryOnlyArtifactRepoQueuesResultEvents' -count=1`
- `go test ./internal/runtime -run 'TestArtifactRepoCommitResultEventsFlowThroughDurableCallbackDelivery' -count=1 -v`
- `go test ./internal/runtime -run 'TestArtifactRepoCommitResultEventsFlowThroughStaticServiceCallbackDelivery' -count=1 -v`
- `go test ./internal/runtime/pipeline -run 'TestArtifactRepoResultEventPreservesScopedProducerSourceRoute|TestActionResultEventTypeResolvesAgainstProducerRoute|TestRuntimeActionResultEventProducerInventoryOnlyArtifactRepoQueuesResultEvents|TestPipelineEngineActionRunner_ArtifactRepoCommit(RejectsAgentVisibleArtifactRoot|RejectsUnusableArtifactRoot|QueuesSuccessResultEvent|FailsClosedWithoutResultEventCollector|FailsClosedOnInvalidSuccessResultEvent|FailsClosedOnPathOutsideAllowlist|FailsClosedOnYAMLSchemaMismatch|RejectsRequestIDContentConflict|RecordsNoDiffRequestHistory|EnforcesProjectedRepoSize)|TestExecuteNodeContractHandlerArtifactRepoCommitQueues(Success|Failure)ResultThroughOutbox|TestExecuteNodeContractHandlerArtifactRepoCommitFailureResultOutboxFailureRollsBackState' -count=1`
- `go test ./internal/runtime/bus -run 'TestEventBusPublish_NoTargetScopedRoutedNodePersistsSemanticRouteBeforeInternalCarrier|TestEventBusPublish_WildcardStaticServiceNodePersistsRouteBeforeInternalCarrier|TestEventBusPublish_RuntimeCallbackLocalEventPersistsSameFlowNodeRouteBeforeInternalCarrier|TestRoutedEventKeysForPlan_RuntimeCallbackLocalEventWithFlowInstanceDerivesConcreteKey' -count=1`
- `go test ./internal/runtime -run 'TestArtifactRepoCommitResultEventsFlowThrough(DurableCallback|StaticServiceCallback)Delivery' -count=1`
- `go test ./...`
