### PR TITLE
[agent-b][issue #1428] SQLite run.trace pagination parity

### DIFF
--- a/internal/apiv1/sqlite_observability_supported_surface_test.go
+++ b/internal/apiv1/sqlite_observability_supported_surface_test.go
@@ -94,6 +94,93 @@ func TestSQLiteObservabilityOwnerBacksSupportedAPISurfaces(t *testing.T) {
 	})
 }
 
+func TestSQLiteRunTraceAPISurfacePaginatesAndUsesMaterializationWindow(t *testing.T) {
+	ctx := context.Background()
+	sqliteStore := storetest.StartSQLiteRuntimeStoreWithContext(t, ctx)
+	base := time.Unix(1700003100, 0).UTC()
+	runID := "00000000-0000-0000-0000-000000001429"
+	eventOnlyID := "00000000-0000-0000-0000-000000001401"
+	lateDeliveryID := "00000000-0000-0000-0000-000000001402"
+	secondDeliveryID := "00000000-0000-0000-0000-000000001403"
+	if _, err := sqliteStore.DB.ExecContext(ctx, `INSERT INTO runs (run_id, status, started_at) VALUES (?, 'running', ?)`, runID, base.Add(-time.Minute)); err != nil {
+		t.Fatalf("seed sqlite run: %v", err)
+	}
+	if _, err := sqliteStore.DB.ExecContext(ctx, `
+		INSERT INTO events (run_id, event_id, event_name, entity_id, scope, payload, produced_by, produced_by_type, created_at)
+		VALUES
+			(?, ?, 'trace.event_only', NULL, 'global', '{}', 'runtime', 'platform', ?),
+			(?, ?, 'trace.late_delivery', NULL, 'global', '{}', 'runtime', 'platform', ?),
+			(?, ?, 'trace.second_delivery', NULL, 'global', '{}', 'runtime', 'platform', ?)
+	`, runID, eventOnlyID, base, runID, lateDeliveryID, base, runID, secondDeliveryID, base.Add(time.Second)); err != nil {
+		t.Fatalf("seed sqlite events: %v", err)
+	}
+	if _, err := sqliteStore.DB.ExecContext(ctx, `
+		INSERT INTO event_deliveries (
+			delivery_id, run_id, event_id, subscriber_type, subscriber_id, status, reason_code, created_at, started_at, delivered_at
+		) VALUES
+			('00000000-0000-0000-0000-000000001411', ?, ?, 'agent', 'agent-late', 'delivered', 'ok', ?, ?, ?),
+			('00000000-0000-0000-0000-000000001412', ?, ?, 'agent', 'agent-second', 'delivered', 'ok', ?, ?, ?)
+	`, runID, lateDeliveryID, base.Add(time.Second), base.Add(2*time.Second), base.Add(3*time.Second),
+		runID, secondDeliveryID, base.Add(2*time.Second), base.Add(3*time.Second), base.Add(4*time.Second)); err != nil {
+		t.Fatalf("seed sqlite deliveries: %v", err)
+	}
+
+	handler := testHandler(t, Options{
+		AuthTokens: []string{testToken},
+		Handlers: OperatorReadHandlers(OperatorReadOptions{
+			Now:           func() time.Time { return base.Add(time.Minute) },
+			Observability: sqliteStore,
+		}),
+	})
+	page1 := rpcCall(t, handler, fmt.Sprintf(`{"jsonrpc":"2.0","id":"page1","method":"run.trace","params":{"run_id":%q,"limit":1,"filter":{"delivery_status":["delivered"]}}}`, runID))
+	if page1.Error != nil {
+		t.Fatalf("run.trace page1 error = %#v", page1.Error)
+	}
+	page1Result := asMap(t, page1.Result)
+	page1Rows, _ := page1Result["trace"].([]any)
+	nextCursor, _ := page1Result["next_cursor"].(string)
+	if len(page1Rows) != 1 || asMap(t, page1Rows[0])["event_id"] != lateDeliveryID || nextCursor == "" {
+		t.Fatalf("run.trace page1 result = %#v, want late delivery plus next_cursor", page1Result)
+	}
+	page2 := rpcCall(t, handler, fmt.Sprintf(`{"jsonrpc":"2.0","id":"page2","method":"run.trace","params":{"run_id":%q,"limit":1,"cursor":%q,"filter":{"delivery_status":["delivered"]}}}`, runID, nextCursor))
+	if page2.Error != nil {
+		t.Fatalf("run.trace page2 error = %#v", page2.Error)
+	}
+	page2Result := asMap(t, page2.Result)
+	page2Rows, _ := page2Result["trace"].([]any)
+	if len(page2Rows) != 1 || asMap(t, page2Rows[0])["event_id"] != secondDeliveryID || page2Result["next_cursor"] != nil {
+		t.Fatalf("run.trace page2 result = %#v, want second delivery and no next_cursor", page2Result)
+	}
+
+	since := base.Format(time.RFC3339Nano)
+	sinceResp := rpcCall(t, handler, fmt.Sprintf(`{"jsonrpc":"2.0","id":"since","method":"run.trace","params":{"run_id":%q,"limit":10,"since":%q}}`, runID, since))
+	if sinceResp.Error != nil {
+		t.Fatalf("run.trace since error = %#v", sinceResp.Error)
+	}
+	sinceRows, _ := asMap(t, sinceResp.Result)["trace"].([]any)
+	if len(sinceRows) != 2 || asMap(t, sinceRows[0])["event_id"] != lateDeliveryID || asMap(t, sinceRows[1])["event_id"] != secondDeliveryID {
+		t.Fatalf("run.trace since rows = %#v, want delivery-materialized rows only", sinceRows)
+	}
+	until := base.Add(2500 * time.Millisecond).Format(time.RFC3339Nano)
+	untilResp := rpcCall(t, handler, fmt.Sprintf(`{"jsonrpc":"2.0","id":"until","method":"run.trace","params":{"run_id":%q,"limit":10,"until":%q}}`, runID, until))
+	if untilResp.Error != nil {
+		t.Fatalf("run.trace until error = %#v", untilResp.Error)
+	}
+	untilRows, _ := asMap(t, untilResp.Result)["trace"].([]any)
+	if len(untilRows) != 1 || asMap(t, untilRows[0])["event_id"] != eventOnlyID {
+		t.Fatalf("run.trace until rows = %#v, want only event-only row before delivery materialization", untilRows)
+	}
+
+	invalid := rpcCall(t, handler, fmt.Sprintf(`{"jsonrpc":"2.0","id":"bad-cursor","method":"run.trace","params":{"run_id":%q,"cursor":"not-a-cursor"}}`, runID))
+	if invalid.Error == nil {
+		t.Fatal("run.trace invalid cursor error = nil")
+	}
+	details := asMap(t, invalid.Error.Data)
+	if nested := asMap(t, details["details"]); nested["field"] != "cursor" {
+		t.Fatalf("run.trace invalid cursor details = %#v, want cursor field", details)
+	}
+}
+
 type sqliteObservabilitySurfaceFixture struct {
 	store   *storepkg.SQLiteRuntimeStore
 	runID   string

--- a/internal/store/sqlite_run_trace_parity_test.go
+++ b/internal/store/sqlite_run_trace_parity_test.go
@@ -128,6 +128,82 @@ func TestSQLiteRunDebugTracePageDeterministicDeliveryAndTurnTiePaging(t *testing
 	}
 }
 
+func TestSQLiteRunDebugTracePageIncludesTaskAuditSessionsInWatermark(t *testing.T) {
+	ctx := context.Background()
+	sqliteStore := newBootstrappedSQLiteRuntimeStoreForTest(t)
+	base := time.Unix(1700003200, 0).UTC()
+	runID := "00000000-0000-0000-0000-000000001430"
+	eventID := "00000000-0000-0000-0000-000000001431"
+	deliveryID := "00000000-0000-0000-0000-000000001432"
+	sessionID := "00000000-0000-0000-0000-000000001433"
+	turnID := "00000000-0000-0000-0000-000000001434"
+	agentID := "agent-task"
+
+	if _, err := sqliteStore.DB.ExecContext(ctx, `INSERT INTO runs (run_id, status, started_at) VALUES (?, 'running', ?)`, runID, base.Add(-time.Minute)); err != nil {
+		t.Fatalf("seed run: %v", err)
+	}
+	if _, err := sqliteStore.DB.ExecContext(ctx, `
+		INSERT INTO events (run_id, event_id, event_name, entity_id, scope, payload, produced_by, produced_by_type, created_at)
+		VALUES (?, ?, 'trace.task_audit', NULL, 'global', '{}', 'runtime', 'platform', ?)
+	`, runID, eventID, base); err != nil {
+		t.Fatalf("seed event: %v", err)
+	}
+	seedSQLiteTraceAgent(t, ctx, sqliteStore, agentID, base)
+	if _, err := sqliteStore.DB.ExecContext(ctx, `
+		INSERT INTO agent_conversation_audits (
+			session_id, run_id, agent_id, entity_id, flow_instance, scope_key, scope,
+			conversation, turn_count, runtime_mode, runtime_state, status, created_at, updated_at
+		) VALUES (
+			?, ?, ?, NULL, 'flow-a', 'global', 'global',
+			'[]', 1, 'task', '{}', 'active', ?, ?
+		)
+	`, sessionID, runID, agentID, base.Add(time.Second), base.Add(5*time.Second)); err != nil {
+		t.Fatalf("seed task audit: %v", err)
+	}
+	if _, err := sqliteStore.DB.ExecContext(ctx, `
+		INSERT INTO event_deliveries (
+			delivery_id, run_id, event_id, subscriber_type, subscriber_id, status, reason_code, created_at, started_at, delivered_at
+		) VALUES (
+			?, ?, ?, 'agent', ?, 'delivered', 'ok', ?, ?, ?
+		)
+	`, deliveryID, runID, eventID, agentID, base.Add(time.Second), base.Add(time.Second), base.Add(2*time.Second)); err != nil {
+		t.Fatalf("seed delivery: %v", err)
+	}
+	insertSQLiteTraceTurnWithMode(t, ctx, sqliteStore, turnID, runID, agentID, sessionID, eventID, "trace.task_audit", "task", base.Add(2*time.Second))
+
+	rows, _, err := sqliteStore.LoadRunDebugTracePage(ctx, runID, RunDebugTraceQueryOptions{Limit: 10})
+	if err != nil {
+		t.Fatalf("LoadRunDebugTracePage: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("rows = %#v, want one task audit trace row", rows)
+	}
+	row := rows[0]
+	if row.SessionID != sessionID || row.SessionKind != "turn_audit" || row.SessionRuntimeMode != "task" {
+		t.Fatalf("task audit session fields = %#v, want turn_audit task session %s", row, sessionID)
+	}
+	if row.SessionUpdatedAt == nil || !row.SessionUpdatedAt.Equal(base.Add(5*time.Second)) {
+		t.Fatalf("task audit session updated_at = %#v, want %s", row.SessionUpdatedAt, base.Add(5*time.Second))
+	}
+
+	since := base.Add(4 * time.Second)
+	sinceRows, _, err := sqliteStore.LoadRunDebugTracePage(ctx, runID, RunDebugTraceQueryOptions{Limit: 10, Since: &since})
+	if err != nil {
+		t.Fatalf("LoadRunDebugTracePage since: %v", err)
+	}
+	if len(sinceRows) != 1 || sinceRows[0].EventID != eventID {
+		t.Fatalf("since rows = %#v, want task row included by audit updated_at watermark", sinceRows)
+	}
+	until := base.Add(4 * time.Second)
+	untilRows, _, err := sqliteStore.LoadRunDebugTracePage(ctx, runID, RunDebugTraceQueryOptions{Limit: 10, Until: &until})
+	if err != nil {
+		t.Fatalf("LoadRunDebugTracePage until: %v", err)
+	}
+	if len(untilRows) != 0 {
+		t.Fatalf("until rows = %#v, want task row excluded by audit updated_at watermark", untilRows)
+	}
+}
+
 type sqliteRunTraceParityFixture struct {
 	runID             string
 	eventOnlyID       string
@@ -246,6 +322,11 @@ func insertSQLiteTraceSession(t *testing.T, ctx context.Context, sqliteStore *SQ
 
 func insertSQLiteTraceTurn(t *testing.T, ctx context.Context, sqliteStore *SQLiteRuntimeStore, turnID, runID, agentID, sessionID, eventID, eventName string, createdAt time.Time) {
 	t.Helper()
+	insertSQLiteTraceTurnWithMode(t, ctx, sqliteStore, turnID, runID, agentID, sessionID, eventID, eventName, "session", createdAt)
+}
+
+func insertSQLiteTraceTurnWithMode(t *testing.T, ctx context.Context, sqliteStore *SQLiteRuntimeStore, turnID, runID, agentID, sessionID, eventID, eventName, runtimeMode string, createdAt time.Time) {
+	t.Helper()
 	if _, err := sqliteStore.DB.ExecContext(ctx, `
 		INSERT INTO agent_turns (
 			turn_id, run_id, agent_id, session_id, runtime_mode, scope_key, entity_id,
@@ -253,12 +334,12 @@ func insertSQLiteTraceTurn(t *testing.T, ctx context.Context, sqliteStore *SQLit
 			emitted_events, mcp_servers, mcp_tools_listed, mcp_tools_visible,
 			request_payload, response_payload, turn_blocks, parse_ok, latency_ms, retry_count, error, created_at
 		) VALUES (
-			?, ?, ?, ?, 'session', 'global', NULL,
+			?, ?, ?, ?, ?, 'global', NULL,
 			?, ?, 'task-1', '[]', '[]',
 			'[]', '{}', '[]', '[]',
 			'{}', '{}', '[]', 1, 0, 0, '', ?
 		)
-	`, turnID, runID, agentID, sessionID, eventID, eventName, createdAt); err != nil {
+	`, turnID, runID, agentID, sessionID, runtimeMode, eventID, eventName, createdAt); err != nil {
 		t.Fatalf("seed turn %s/%s: %v", agentID, turnID, err)
 	}
 }

--- a/internal/store/sqlite_run_trace_parity_test.go
+++ b/internal/store/sqlite_run_trace_parity_test.go
@@ -1,0 +1,284 @@
+package store
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestSQLiteRunDebugTracePagePaginationWindowAndFilterParity(t *testing.T) {
+	ctx := context.Background()
+	sqliteStore := newBootstrappedSQLiteRuntimeStoreForTest(t)
+	fixture := seedSQLiteRunTraceParityRows(t, ctx, sqliteStore)
+	mainFilter := RunDebugTraceFilter{
+		EventNames: []string{"trace.event_only", "trace.late_delivered", "trace.failed", "trace.second_delivered"},
+	}
+
+	page1, next, err := sqliteStore.LoadRunDebugTracePage(ctx, fixture.runID, RunDebugTraceQueryOptions{Limit: 2, Filter: mainFilter})
+	if err != nil {
+		t.Fatalf("LoadRunDebugTracePage page1: %v", err)
+	}
+	if len(page1) != 2 || page1[0].EventID != fixture.eventOnlyID || page1[1].EventID != fixture.lateDeliveredID || next == "" {
+		t.Fatalf("page1 rows=%#v next=%q, want event-only then late-delivered with next cursor", page1, next)
+	}
+	page2, next2, err := sqliteStore.LoadRunDebugTracePage(ctx, fixture.runID, RunDebugTraceQueryOptions{Limit: 2, Cursor: next, Filter: mainFilter})
+	if err != nil {
+		t.Fatalf("LoadRunDebugTracePage page2: %v", err)
+	}
+	if len(page2) != 2 || page2[0].EventID != fixture.failedID || page2[1].EventID != fixture.secondDeliveredID || next2 != "" {
+		t.Fatalf("page2 rows=%#v next=%q, want failed then second-delivered and no next cursor", page2, next2)
+	}
+	if _, _, err := sqliteStore.LoadRunDebugTracePage(ctx, fixture.runID, RunDebugTraceQueryOptions{Limit: 2, Cursor: "not-a-cursor"}); !errors.Is(err, ErrInvalidObservabilityCursor) {
+		t.Fatalf("invalid cursor error = %v, want ErrInvalidObservabilityCursor", err)
+	}
+
+	sinceRows, _, err := sqliteStore.LoadRunDebugTracePage(ctx, fixture.runID, RunDebugTraceQueryOptions{Limit: 10, Since: &fixture.base, Filter: mainFilter})
+	if err != nil {
+		t.Fatalf("LoadRunDebugTracePage since: %v", err)
+	}
+	if got := traceEventIDs(sinceRows); !sameStrings(got, []string{fixture.lateDeliveredID, fixture.failedID, fixture.secondDeliveredID}) {
+		t.Fatalf("since rows = %#v, want late materialized rows only", got)
+	}
+	until := fixture.base.Add(3500 * time.Millisecond)
+	untilRows, _, err := sqliteStore.LoadRunDebugTracePage(ctx, fixture.runID, RunDebugTraceQueryOptions{Limit: 10, Until: &until, Filter: mainFilter})
+	if err != nil {
+		t.Fatalf("LoadRunDebugTracePage until: %v", err)
+	}
+	if got := traceEventIDs(untilRows); !sameStrings(got, []string{fixture.eventOnlyID, fixture.failedID}) {
+		t.Fatalf("until rows = %#v, want rows whose materialization watermark is <= until", got)
+	}
+	emptyWindowRows, _, err := sqliteStore.LoadRunDebugTracePage(ctx, fixture.runID, RunDebugTraceQueryOptions{Limit: 10, Since: &fixture.base, Until: &fixture.base, Filter: mainFilter})
+	if err != nil {
+		t.Fatalf("LoadRunDebugTracePage equal since/until: %v", err)
+	}
+	if len(emptyWindowRows) != 0 {
+		t.Fatalf("equal since/until rows = %#v, want empty strict/inclusive window", emptyWindowRows)
+	}
+
+	deliveredPage1, deliveredNext, err := sqliteStore.LoadRunDebugTracePage(ctx, fixture.runID, RunDebugTraceQueryOptions{
+		Limit: 1,
+		Since: &fixture.base,
+		Filter: RunDebugTraceFilter{
+			EventNames:       []string{"trace.late_delivered", "trace.second_delivered"},
+			DeliveryStatuses: []string{"delivered"},
+			SubscriberTypes:  []string{"agent"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("LoadRunDebugTracePage delivered page1: %v", err)
+	}
+	if len(deliveredPage1) != 1 || deliveredPage1[0].EventID != fixture.lateDeliveredID || deliveredNext == "" {
+		t.Fatalf("delivered page1 rows=%#v next=%q, want late-delivered with next cursor", deliveredPage1, deliveredNext)
+	}
+	deliveredPage2, deliveredNext2, err := sqliteStore.LoadRunDebugTracePage(ctx, fixture.runID, RunDebugTraceQueryOptions{
+		Limit:  1,
+		Cursor: deliveredNext,
+		Since:  &fixture.base,
+		Filter: RunDebugTraceFilter{
+			EventNames:       []string{"trace.late_delivered", "trace.second_delivered"},
+			DeliveryStatuses: []string{"delivered"},
+			SubscriberTypes:  []string{"agent"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("LoadRunDebugTracePage delivered page2: %v", err)
+	}
+	if len(deliveredPage2) != 1 || deliveredPage2[0].EventID != fixture.secondDeliveredID || deliveredNext2 != "" {
+		t.Fatalf("delivered page2 rows=%#v next=%q, want second-delivered and no next cursor", deliveredPage2, deliveredNext2)
+	}
+}
+
+func TestSQLiteRunDebugTracePageDeterministicDeliveryAndTurnTiePaging(t *testing.T) {
+	ctx := context.Background()
+	sqliteStore := newBootstrappedSQLiteRuntimeStoreForTest(t)
+	fixture := seedSQLiteRunTraceParityRows(t, ctx, sqliteStore)
+
+	var got []string
+	cursor := ""
+	for {
+		rows, next, err := sqliteStore.LoadRunDebugTracePage(ctx, fixture.runID, RunDebugTraceQueryOptions{
+			Limit:  1,
+			Cursor: cursor,
+			Filter: RunDebugTraceFilter{
+				EventNames: []string{"trace.tie"},
+			},
+		})
+		if err != nil {
+			t.Fatalf("LoadRunDebugTracePage tie cursor=%q: %v", cursor, err)
+		}
+		for _, row := range rows {
+			got = append(got, row.DeliveryID+"/"+row.TurnID)
+		}
+		if next == "" {
+			break
+		}
+		if next == cursor {
+			t.Fatalf("cursor did not advance: %q", next)
+		}
+		cursor = next
+	}
+	want := []string{
+		fixture.tieDeliveryAID + "/" + fixture.tieTurnA1ID,
+		fixture.tieDeliveryAID + "/" + fixture.tieTurnA2ID,
+		fixture.tieDeliveryBID + "/" + fixture.tieTurnBID,
+	}
+	if !sameStrings(got, want) {
+		t.Fatalf("tie paging rows = %#v, want %#v", got, want)
+	}
+}
+
+type sqliteRunTraceParityFixture struct {
+	runID             string
+	eventOnlyID       string
+	lateDeliveredID   string
+	failedID          string
+	secondDeliveredID string
+	tieDeliveryAID    string
+	tieDeliveryBID    string
+	tieTurnA1ID       string
+	tieTurnA2ID       string
+	tieTurnBID        string
+	base              time.Time
+}
+
+func seedSQLiteRunTraceParityRows(t *testing.T, ctx context.Context, sqliteStore *SQLiteRuntimeStore) sqliteRunTraceParityFixture {
+	t.Helper()
+	base := time.Unix(1700003000, 0).UTC()
+	fixture := sqliteRunTraceParityFixture{
+		runID:             "00000000-0000-0000-0000-000000001428",
+		eventOnlyID:       "00000000-0000-0000-0000-000000000001",
+		lateDeliveredID:   "00000000-0000-0000-0000-000000000002",
+		failedID:          "00000000-0000-0000-0000-000000000003",
+		secondDeliveredID: "00000000-0000-0000-0000-000000000004",
+		tieDeliveryAID:    "00000000-0000-0000-0000-000000000101",
+		tieDeliveryBID:    "00000000-0000-0000-0000-000000000102",
+		tieTurnA1ID:       "00000000-0000-0000-0000-000000000201",
+		tieTurnA2ID:       "00000000-0000-0000-0000-000000000202",
+		tieTurnBID:        "00000000-0000-0000-0000-000000000203",
+		base:              base,
+	}
+	if _, err := sqliteStore.DB.ExecContext(ctx, `INSERT INTO runs (run_id, status, started_at) VALUES (?, 'running', ?)`, fixture.runID, base.Add(-time.Minute)); err != nil {
+		t.Fatalf("seed run: %v", err)
+	}
+	events := []struct {
+		id   string
+		name string
+		at   time.Time
+	}{
+		{fixture.eventOnlyID, "trace.event_only", base},
+		{fixture.lateDeliveredID, "trace.late_delivered", base},
+		{fixture.failedID, "trace.failed", base.Add(time.Second)},
+		{fixture.secondDeliveredID, "trace.second_delivered", base.Add(2 * time.Second)},
+		{"00000000-0000-0000-0000-000000000005", "trace.tie", base.Add(10 * time.Second)},
+	}
+	for _, event := range events {
+		if _, err := sqliteStore.DB.ExecContext(ctx, `
+			INSERT INTO events (run_id, event_id, event_name, entity_id, scope, payload, produced_by, produced_by_type, created_at)
+			VALUES (?, ?, ?, NULL, 'global', '{}', 'runtime', 'platform', ?)
+		`, fixture.runID, event.id, event.name, event.at); err != nil {
+			t.Fatalf("seed event %s: %v", event.name, err)
+		}
+	}
+	for _, agentID := range []string{"agent-late", "agent-failed", "agent-second", "agent-a", "agent-b"} {
+		seedSQLiteTraceAgent(t, ctx, sqliteStore, agentID, base)
+	}
+	insertSQLiteTraceSession(t, ctx, sqliteStore, "00000000-0000-0000-0000-000000000301", fixture.runID, "agent-late", base.Add(4*time.Second))
+	insertSQLiteTraceSession(t, ctx, sqliteStore, "00000000-0000-0000-0000-000000000302", fixture.runID, "agent-failed", base.Add(2500*time.Millisecond))
+	insertSQLiteTraceSession(t, ctx, sqliteStore, "00000000-0000-0000-0000-000000000303", fixture.runID, "agent-second", base.Add(6*time.Second))
+	insertSQLiteTraceSession(t, ctx, sqliteStore, "00000000-0000-0000-0000-000000000304", fixture.runID, "agent-a", base.Add(11*time.Second))
+	insertSQLiteTraceSession(t, ctx, sqliteStore, "00000000-0000-0000-0000-000000000305", fixture.runID, "agent-b", base.Add(11*time.Second))
+
+	if _, err := sqliteStore.DB.ExecContext(ctx, `
+		INSERT INTO event_deliveries (
+			delivery_id, run_id, event_id, subscriber_type, subscriber_id, status, reason_code, active_session_id, created_at, started_at, delivered_at
+		) VALUES
+			('00000000-0000-0000-0000-000000000011', ?, ?, 'agent', 'agent-late', 'delivered', 'ok', '00000000-0000-0000-0000-000000000301', ?, ?, ?),
+			('00000000-0000-0000-0000-000000000012', ?, ?, 'agent', 'agent-failed', 'failed', 'handler_error', '00000000-0000-0000-0000-000000000302', ?, ?, NULL),
+			('00000000-0000-0000-0000-000000000013', ?, ?, 'agent', 'agent-second', 'delivered', 'ok', '00000000-0000-0000-0000-000000000303', ?, ?, ?),
+			(?, ?, '00000000-0000-0000-0000-000000000005', 'agent', 'agent-a', 'delivered', 'ok', '00000000-0000-0000-0000-000000000304', ?, ?, ?),
+			(?, ?, '00000000-0000-0000-0000-000000000005', 'agent', 'agent-b', 'delivered', 'ok', '00000000-0000-0000-0000-000000000305', ?, ?, ?)
+	`, fixture.runID, fixture.lateDeliveredID, base.Add(time.Second), base.Add(2*time.Second), base.Add(3*time.Second),
+		fixture.runID, fixture.failedID, base.Add(1500*time.Millisecond), base.Add(2*time.Second),
+		fixture.runID, fixture.secondDeliveredID, base.Add(3*time.Second), base.Add(4*time.Second), base.Add(5*time.Second),
+		fixture.tieDeliveryAID, fixture.runID, base.Add(10*time.Second), base.Add(10*time.Second), base.Add(10*time.Second),
+		fixture.tieDeliveryBID, fixture.runID, base.Add(10*time.Second), base.Add(10*time.Second), base.Add(10*time.Second)); err != nil {
+		t.Fatalf("seed deliveries: %v", err)
+	}
+	insertSQLiteTraceTurn(t, ctx, sqliteStore, "00000000-0000-0000-0000-000000000401", fixture.runID, "agent-late", "00000000-0000-0000-0000-000000000301", fixture.lateDeliveredID, "trace.late_delivered", base.Add(5*time.Second))
+	insertSQLiteTraceTurn(t, ctx, sqliteStore, "00000000-0000-0000-0000-000000000402", fixture.runID, "agent-failed", "00000000-0000-0000-0000-000000000302", fixture.failedID, "trace.failed", base.Add(3*time.Second))
+	insertSQLiteTraceTurn(t, ctx, sqliteStore, "00000000-0000-0000-0000-000000000403", fixture.runID, "agent-second", "00000000-0000-0000-0000-000000000303", fixture.secondDeliveredID, "trace.second_delivered", base.Add(6*time.Second))
+	insertSQLiteTraceTurn(t, ctx, sqliteStore, fixture.tieTurnA1ID, fixture.runID, "agent-a", "00000000-0000-0000-0000-000000000304", "00000000-0000-0000-0000-000000000005", "trace.tie", base.Add(11*time.Second))
+	insertSQLiteTraceTurn(t, ctx, sqliteStore, fixture.tieTurnA2ID, fixture.runID, "agent-a", "00000000-0000-0000-0000-000000000304", "00000000-0000-0000-0000-000000000005", "trace.tie", base.Add(11*time.Second))
+	insertSQLiteTraceTurn(t, ctx, sqliteStore, fixture.tieTurnBID, fixture.runID, "agent-b", "00000000-0000-0000-0000-000000000305", "00000000-0000-0000-0000-000000000005", "trace.tie", base.Add(11*time.Second))
+	return fixture
+}
+
+func seedSQLiteTraceAgent(t *testing.T, ctx context.Context, sqliteStore *SQLiteRuntimeStore, agentID string, startedAt time.Time) {
+	t.Helper()
+	if _, err := sqliteStore.DB.ExecContext(ctx, `
+		INSERT INTO agents (
+			agent_id, role, model, llm_backend, conversation_mode,
+			config, subscriptions, emit_events, tools, permissions, runtime_descriptor, status, created_at
+		) VALUES (
+			?, 'operator', 'regular', 'anthropic', 'session',
+			'{}', '[]', '[]', '[]', '[]', '{}', 'active', ?
+		)
+	`, agentID, startedAt); err != nil {
+		t.Fatalf("seed agent %s: %v", agentID, err)
+	}
+}
+
+func insertSQLiteTraceSession(t *testing.T, ctx context.Context, sqliteStore *SQLiteRuntimeStore, sessionID, runID, agentID string, updatedAt time.Time) {
+	t.Helper()
+	if _, err := sqliteStore.DB.ExecContext(ctx, `
+		INSERT INTO agent_sessions (
+			session_id, run_id, agent_id, entity_id, flow_instance, scope_key, scope,
+			conversation, turn_count, runtime_mode, runtime_state, status, created_at, updated_at
+		) VALUES (
+			?, ?, ?, NULL, 'flow-a', 'global', 'global',
+			'[]', 1, 'session', '{}', 'active', ?, ?
+		)
+	`, sessionID, runID, agentID, updatedAt.Add(-time.Second), updatedAt); err != nil {
+		t.Fatalf("seed session %s: %v", agentID, err)
+	}
+}
+
+func insertSQLiteTraceTurn(t *testing.T, ctx context.Context, sqliteStore *SQLiteRuntimeStore, turnID, runID, agentID, sessionID, eventID, eventName string, createdAt time.Time) {
+	t.Helper()
+	if _, err := sqliteStore.DB.ExecContext(ctx, `
+		INSERT INTO agent_turns (
+			turn_id, run_id, agent_id, session_id, runtime_mode, scope_key, entity_id,
+			trigger_event_id, trigger_event_type, task_id, available_tools, tool_calls,
+			emitted_events, mcp_servers, mcp_tools_listed, mcp_tools_visible,
+			request_payload, response_payload, turn_blocks, parse_ok, latency_ms, retry_count, error, created_at
+		) VALUES (
+			?, ?, ?, ?, 'session', 'global', NULL,
+			?, ?, 'task-1', '[]', '[]',
+			'[]', '{}', '[]', '[]',
+			'{}', '{}', '[]', 1, 0, 0, '', ?
+		)
+	`, turnID, runID, agentID, sessionID, eventID, eventName, createdAt); err != nil {
+		t.Fatalf("seed turn %s/%s: %v", agentID, turnID, err)
+	}
+}
+
+func traceEventIDs(rows []RunDebugTraceRow) []string {
+	out := make([]string, 0, len(rows))
+	for _, row := range rows {
+		out = append(out, row.EventID)
+	}
+	return out
+}
+
+func sameStrings(got, want []string) bool {
+	if len(got) != len(want) {
+		return false
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/store/sqlite_runtime_observability.go
+++ b/internal/store/sqlite_runtime_observability.go
@@ -14,9 +14,7 @@ func (s *SQLiteRuntimeStore) LoadRunDebugTracePage(ctx context.Context, runID st
 	if runID == "" {
 		return nil, "", ErrRunNotFound
 	}
-	if opts.Cursor != "" {
-		return nil, "", ErrInvalidObservabilityCursor
-	}
+	opts = defaultRunDebugTraceQueryOptions(opts)
 	var exists bool
 	if err := s.DB.QueryRowContext(ctx, `SELECT EXISTS (SELECT 1 FROM runs WHERE run_id = ?)`, runID).Scan(&exists); err != nil {
 		return nil, "", fmt.Errorf("load sqlite run trace run existence: %w", err)
@@ -24,15 +22,51 @@ func (s *SQLiteRuntimeStore) LoadRunDebugTracePage(ctx context.Context, runID st
 	if !exists {
 		return nil, "", ErrRunNotFound
 	}
-	opts = defaultRunDebugTraceQueryOptions(opts)
 	where := []string{"e.run_id = ?", "NOT (COALESCE(d.subscriber_type, '') = ? AND COALESCE(d.subscriber_id, '') = ?)"}
 	args := []any{runID, replayScopeMarkerSubscriberType, replayScopeMarkerSubscriberID}
+	if opts.Cursor != "" {
+		cursor, err := decodeRunDebugTraceCursor(opts.Cursor)
+		if err != nil {
+			return nil, "", err
+		}
+		eventCreatedAt, err := sqliteRunTraceCursorTime(cursor.EventCreatedAt)
+		if err != nil {
+			return nil, "", err
+		}
+		eventID := strings.TrimSpace(cursor.EventID)
+		deliveryCreatedAt, err := sqliteRunTraceCursorOptionalTime(cursor.DeliveryCreatedAt)
+		if err != nil {
+			return nil, "", err
+		}
+		deliveryID := strings.TrimSpace(cursor.DeliveryID)
+		turnCreatedAt, err := sqliteRunTraceCursorOptionalTime(cursor.TurnCreatedAt)
+		if err != nil {
+			return nil, "", err
+		}
+		turnID := strings.TrimSpace(cursor.TurnID)
+		where = append(where, `(
+			e.created_at > ?
+			OR (e.created_at = ? AND e.event_id > ?)
+			OR (e.created_at = ? AND e.event_id = ? AND COALESCE(d.created_at, ?) > ?)
+			OR (e.created_at = ? AND e.event_id = ? AND COALESCE(d.created_at, ?) = ? AND COALESCE(d.delivery_id, '') > ?)
+			OR (e.created_at = ? AND e.event_id = ? AND COALESCE(d.created_at, ?) = ? AND COALESCE(d.delivery_id, '') = ? AND COALESCE(t.created_at, ?) > ?)
+			OR (e.created_at = ? AND e.event_id = ? AND COALESCE(d.created_at, ?) = ? AND COALESCE(d.delivery_id, '') = ? AND COALESCE(t.created_at, ?) = ? AND COALESCE(t.turn_id, '') > ?)
+		)`)
+		args = append(args,
+			eventCreatedAt,
+			eventCreatedAt, eventID,
+			eventCreatedAt, eventID, sqliteRunTraceCursorFloorTime(), deliveryCreatedAt,
+			eventCreatedAt, eventID, sqliteRunTraceCursorFloorTime(), deliveryCreatedAt, deliveryID,
+			eventCreatedAt, eventID, sqliteRunTraceCursorFloorTime(), deliveryCreatedAt, deliveryID, sqliteRunTraceCursorFloorTime(), turnCreatedAt,
+			eventCreatedAt, eventID, sqliteRunTraceCursorFloorTime(), deliveryCreatedAt, deliveryID, sqliteRunTraceCursorFloorTime(), turnCreatedAt, turnID,
+		)
+	}
 	if opts.Since != nil {
-		where = append(where, "e.created_at >= ?")
+		where = append(where, sqliteRunTraceWatermarkExpression()+" > ?")
 		args = append(args, opts.Since.UTC())
 	}
 	if opts.Until != nil {
-		where = append(where, "e.created_at <= ?")
+		where = append(where, sqliteRunTraceWatermarkExpression()+" <= ?")
 		args = append(args, opts.Until.UTC())
 	}
 	appendIn := func(column string, values []string) {
@@ -51,7 +85,7 @@ func (s *SQLiteRuntimeStore) LoadRunDebugTracePage(ctx context.Context, runID st
 	appendIn("COALESCE(d.status, '')", opts.Filter.DeliveryStatuses)
 	appendIn("COALESCE(d.subscriber_id, '')", opts.Filter.SubscriberIDs)
 	appendIn("COALESCE(d.subscriber_type, '')", opts.Filter.SubscriberTypes)
-	args = append(args, opts.Limit)
+	args = append(args, opts.Limit+1)
 	rows, err := s.DB.QueryContext(ctx, `
 		SELECT
 			e.event_id, e.event_name, COALESCE(e.source_event_id, ''), COALESCE(e.entity_id, ''),
@@ -68,17 +102,32 @@ func (s *SQLiteRuntimeStore) LoadRunDebugTracePage(ctx context.Context, runID st
 			COALESCE(t.error, ''), t.created_at
 		FROM events e
 		LEFT JOIN event_deliveries d ON d.event_id = e.event_id
-		LEFT JOIN agent_sessions ses ON ses.session_id = d.active_session_id
-		LEFT JOIN agent_turns t ON t.trigger_event_id = e.event_id
+		LEFT JOIN agent_turns t
+			ON t.run_id = e.run_id
+		   AND t.trigger_event_id = e.event_id
+		   AND (
+				d.delivery_id IS NULL
+				OR (
+					COALESCE(d.subscriber_type, '') = 'agent'
+					AND COALESCE(d.subscriber_id, '') <> ''
+					AND t.agent_id = d.subscriber_id
+				)
+		   )
+		LEFT JOIN agent_sessions ses
+			ON ses.session_id = COALESCE(t.session_id, d.active_session_id)
+		   AND (
+				ses.run_id = e.run_id
+				OR ses.run_id IS NULL
+		   )
 		WHERE `+strings.Join(where, " AND ")+`
-		ORDER BY e.created_at ASC, e.event_id ASC, d.created_at ASC, d.delivery_id ASC
+		ORDER BY e.created_at ASC, e.event_id ASC, d.created_at ASC, d.delivery_id ASC, t.created_at ASC, t.turn_id ASC
 		LIMIT ?
 	`, args...)
 	if err != nil {
 		return nil, "", fmt.Errorf("query sqlite run trace: %w", err)
 	}
 	defer rows.Close()
-	out := make([]RunDebugTraceRow, 0, opts.Limit)
+	out := make([]RunDebugTraceRow, 0, opts.Limit+1)
 	for rows.Next() {
 		var row RunDebugTraceRow
 		var eventCreatedRaw, deliveryCreatedRaw, deliveryStartedRaw, deliveryDeliveredRaw, sessionUpdatedRaw, turnCreatedRaw any
@@ -114,7 +163,49 @@ func (s *SQLiteRuntimeStore) LoadRunDebugTracePage(ctx context.Context, runID st
 	if err := rows.Err(); err != nil {
 		return nil, "", fmt.Errorf("read sqlite run trace: %w", err)
 	}
-	return out, "", nil
+	nextCursor := ""
+	if len(out) > opts.Limit {
+		out = out[:opts.Limit]
+		nextCursor = encodeRunDebugTraceCursor(out[len(out)-1])
+	}
+	return out, nextCursor, nil
+}
+
+const sqliteRunTraceCursorFloor = "0001-01-01T00:00:00Z"
+
+func sqliteRunTraceCursorFloorTime() time.Time {
+	return time.Date(1, 1, 1, 0, 0, 0, 0, time.UTC)
+}
+
+func sqliteRunTraceCursorTime(raw string) (time.Time, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return time.Time{}, ErrInvalidObservabilityCursor
+	}
+	parsed, err := time.Parse(time.RFC3339Nano, raw)
+	if err != nil {
+		return time.Time{}, ErrInvalidObservabilityCursor
+	}
+	return parsed.UTC(), nil
+}
+
+func sqliteRunTraceCursorOptionalTime(raw string) (time.Time, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return sqliteRunTraceCursorFloorTime(), nil
+	}
+	return sqliteRunTraceCursorTime(raw)
+}
+
+func sqliteRunTraceWatermarkExpression() string {
+	return `max(
+		e.created_at,
+		COALESCE(d.created_at, '` + sqliteRunTraceCursorFloor + `'),
+		COALESCE(d.started_at, '` + sqliteRunTraceCursorFloor + `'),
+		COALESCE(d.delivered_at, '` + sqliteRunTraceCursorFloor + `'),
+		COALESCE(ses.updated_at, '` + sqliteRunTraceCursorFloor + `'),
+		COALESCE(t.created_at, '` + sqliteRunTraceCursorFloor + `')
+	)`
 }
 
 func (s *SQLiteRuntimeStore) ListOperatorEvents(ctx context.Context, opts OperatorEventListOptions) (OperatorEventListResult, error) {

--- a/internal/store/sqlite_runtime_observability.go
+++ b/internal/store/sqlite_runtime_observability.go
@@ -87,6 +87,25 @@ func (s *SQLiteRuntimeStore) LoadRunDebugTracePage(ctx context.Context, runID st
 	appendIn("COALESCE(d.subscriber_type, '')", opts.Filter.SubscriberTypes)
 	args = append(args, opts.Limit+1)
 	rows, err := s.DB.QueryContext(ctx, `
+		WITH trace_sessions AS (
+			SELECT
+				session_id,
+				run_id,
+				'live_session' AS session_kind,
+				COALESCE(runtime_mode, '') AS runtime_mode,
+				COALESCE(status, '') AS status,
+				updated_at
+			FROM agent_sessions
+			UNION ALL
+			SELECT
+				session_id,
+				run_id,
+				'turn_audit' AS session_kind,
+				COALESCE(runtime_mode, '') AS runtime_mode,
+				COALESCE(status, '') AS status,
+				updated_at
+			FROM agent_conversation_audits
+		)
 		SELECT
 			e.event_id, e.event_name, COALESCE(e.source_event_id, ''), COALESCE(e.entity_id, ''),
 			COALESCE(e.produced_by, ''), COALESCE(e.produced_by_type, ''), e.created_at,
@@ -94,7 +113,7 @@ func (s *SQLiteRuntimeStore) LoadRunDebugTracePage(ctx context.Context, runID st
 				COALESCE(d.status, ''), COALESCE(d.reason_code, ''), COALESCE(d.last_error, ''), COALESCE(d.retry_count, 0),
 				COALESCE(d.active_session_id, ''),
 				d.created_at, d.started_at, d.delivered_at,
-			COALESCE(ses.session_id, ''), COALESCE(ses.scope, ''), COALESCE(ses.runtime_mode, ''),
+			COALESCE(ses.session_id, ''), COALESCE(ses.session_kind, ''), COALESCE(ses.runtime_mode, ''),
 			COALESCE(ses.status, ''), ses.updated_at,
 			COALESCE(t.turn_id, ''), COALESCE(t.trigger_event_id, ''), COALESCE(t.trigger_event_type, ''),
 			COALESCE(t.runtime_mode, ''), COALESCE(t.scope_key, ''), COALESCE(t.entity_id, ''),
@@ -113,7 +132,7 @@ func (s *SQLiteRuntimeStore) LoadRunDebugTracePage(ctx context.Context, runID st
 					AND t.agent_id = d.subscriber_id
 				)
 		   )
-		LEFT JOIN agent_sessions ses
+		LEFT JOIN trace_sessions ses
 			ON ses.session_id = COALESCE(t.session_id, d.active_session_id)
 		   AND (
 				ses.run_id = e.run_id


### PR DESCRIPTION
Closes #1428.

## Summary

This closes the widened #1428 SQLite `/v1/rpc run.trace` owner parity class:

- adds SQLite cursor decode/keyset pagination and `limit+1` `next_cursor` emission for `LoadRunDebugTracePage`
- aligns SQLite deterministic row ordering with the canonical event, delivery, and turn cursor identity
- applies SQLite `since`/`until` to the canonical `RunTraceRow` materialization watermark across event, delivery, session, and turn timestamps
- preserves `/v1/rpc run.trace` as the supported API owner; no CLI summary, direct DB reads, or dashboard/runtime bypasses are added

## Governing References

- `platform-spec.yaml` `api_specification.method_catalog.run.trace`: composed persisted run trace rows; clients must consume owner-emitted rows rather than reconstructing joins.
- `platform-spec.yaml` `api_specification.method_catalog.run.trace` `since`/`until`: materialization watermark is the greatest available timestamp across joined event, delivery, session, and turn fields; `since` is strict and `until` is inclusive.
- `platform-spec.yaml` `components.schemas.RunTraceListResult.next_cursor`: public paginated result shape.
- `platform-spec.yaml` `cli_specification.command_catalog.trace`: `swarm trace` snapshot owner is `/v1/rpc run.trace`.
- `openrpc.json` `run.trace`: publishes optional `limit`, `cursor`, `since`, `until`, and `RunTraceListResult.next_cursor`.
- Approved gate: https://github.com/division-sh/swarm/issues/1428#issuecomment-4719822533

## Semantic Migration

- New canonical owner: unchanged, `/v1/rpc run.trace` backed by `store.LoadRunDebugTracePage` and `store.RunDebugTraceRow`.
- Old producer/reader/writer path now invalid: SQLite rejecting public `run.trace` cursors, returning an empty `next_cursor` for truncated pages, and applying event-created-only inclusive windows.
- Production paths checked for surviving old behavior: SQLite `LoadRunDebugTracePage`, `/v1/rpc run.trace`, and `cmd/swarm/diagnostics.go` trace consumer path.
- Migration complete: yes for SQLite `run.trace` pagination/order/window parity. `swarm trace --delivery-summary` remains a downstream #1420 child and is not implemented here.

## Tests

- `go test ./internal/store -run 'SQLiteRunDebugTracePage' -count=1`
- `go test ./internal/apiv1 -run 'SQLiteRunTraceAPISurface' -count=1`
- `go test ./internal/store -run 'RunDebugTrace|SQLite.*Trace|TracePage' -count=1`
- `go test ./internal/apiv1 -run 'OperatorObservability|run.trace|RunTrace|OpenRPCReadOnlyRuntimeProbes|SQLiteRunTraceAPISurface' -count=1`
- `go test ./...`
