### PR TITLE
[agent-c][issue #1430] Use matched handler evidence target

### DIFF
--- a/internal/runtime/pipeline/engine_adapter.go
+++ b/internal/runtime/pipeline/engine_adapter.go
@@ -741,9 +741,9 @@ func (r pipelineEngineActionRunner) ExecuteAction(ctx context.Context, action ru
 	switch actionID {
 	case "record_evidence":
 		payload := parsePayloadMap(execCtx.Request.Event.Payload())
-		bucketID := pc.evidenceTargetForHandler(execCtx.Request.NodeID.String(), string(execCtx.Request.Event.Type()))
+		bucketID := recordEvidenceTarget(execCtx.Request)
 		if bucketID == "" {
-			return true, fmt.Errorf("node %s handler %s record_evidence is missing evidence_target", execCtx.Request.NodeID.String(), strings.TrimSpace(string(execCtx.Request.Event.Type())))
+			return true, fmt.Errorf("node %s handler %s record_evidence is missing evidence_target", execCtx.Request.NodeID.String(), recordEvidenceHandlerLabel(execCtx.Request))
 		}
 		if err := pc.recordWorkflowEvidence(ctx, execCtx.Request.EntityID.String(), bucketID, payload); err != nil {
 			return true, err
@@ -778,19 +778,15 @@ func (r pipelineEngineActionRunner) ExecuteAction(ctx context.Context, action ru
 	}
 }
 
-func (pc *PipelineCoordinator) evidenceTargetForHandler(nodeID, eventType string) string {
-	if pc == nil {
-		return ""
+func recordEvidenceTarget(req runtimeengine.ExecutionRequest) string {
+	return strings.TrimSpace(req.Handler.EvidenceTarget)
+}
+
+func recordEvidenceHandlerLabel(req runtimeengine.ExecutionRequest) string {
+	if handlerKey := strings.TrimSpace(req.HandlerEventKey); handlerKey != "" {
+		return handlerKey
 	}
-	source := pc.SemanticSource()
-	if source == nil {
-		return ""
-	}
-	handler, ok := source.NodeEventHandler(strings.TrimSpace(nodeID), strings.TrimSpace(eventType))
-	if !ok {
-		return ""
-	}
-	return strings.TrimSpace(handler.EvidenceTarget)
+	return strings.TrimSpace(string(req.Event.Type()))
 }
 
 type pipelineEnginePayloadShaper struct {

--- a/internal/runtime/pipeline/engine_adapter_test.go
+++ b/internal/runtime/pipeline/engine_adapter_test.go
@@ -711,9 +711,14 @@ func TestPipelineEngineActionRunner_RecordEvidenceReturnsMutationError(t *testin
 	runner := pipelineEngineActionRunner{coordinator: pc}
 	ok, err := runner.ExecuteAction(context.Background(), runtimecontracts.ActionSpec{ID: "record_evidence"}, runtimeregistry.ActionInstruction{Builtin: "record_evidence"}, runtimeengine.ExecutionContext{
 		Request: runtimeengine.ExecutionRequest{
-			EntityID: identity.NormalizeEntityID("11111111-1111-1111-1111-111111111111"),
-			NodeID:   identity.NormalizeNodeID("node-a"),
-			Event:    (events.NewProjectionEvent("", "research.completed", "", "", []byte(`{"summary":"done"}`), 0, "", "", events.EventEnvelope{}, time.Time{})).WithEntityID("11111111-1111-1111-1111-111111111111"),
+			EntityID:        identity.NormalizeEntityID("11111111-1111-1111-1111-111111111111"),
+			NodeID:          identity.NormalizeNodeID("node-a"),
+			Event:           (events.NewProjectionEvent("", "research.completed", "", "", []byte(`{"summary":"done"}`), 0, "", "", events.EventEnvelope{}, time.Time{})).WithEntityID("11111111-1111-1111-1111-111111111111"),
+			HandlerEventKey: "research.completed",
+			Handler: runtimecontracts.SystemNodeEventHandler{
+				Action:         runtimecontracts.ActionSpec{ID: "record_evidence"},
+				EvidenceTarget: "research",
+			},
 		},
 	})
 	if !ok {
@@ -721,6 +726,104 @@ func TestPipelineEngineActionRunner_RecordEvidenceReturnsMutationError(t *testin
 	}
 	if err == nil {
 		t.Fatal("expected record_evidence action to return mutation error")
+	}
+}
+
+func TestPipelineEngineActionRunner_RecordEvidenceUsesMatchedHandlerEvidenceTargetForConcreteEvents(t *testing.T) {
+	_, db, cleanup := testutil.StartPostgres(t)
+	t.Cleanup(cleanup)
+
+	store := NewWorkflowInstanceStore(db)
+	pc := &PipelineCoordinator{workflowStore: store}
+	runner := pipelineEngineActionRunner{coordinator: pc}
+
+	tests := []struct {
+		name            string
+		entityID        string
+		concreteEvent   events.EventType
+		handlerEventKey string
+		action          runtimecontracts.ActionSpec
+		handler         runtimecontracts.SystemNodeEventHandler
+		wantBucket      string
+		wantSummary     string
+	}{
+		{
+			name:            "handler action",
+			entityID:        "11111111-1111-1111-1111-111111111111",
+			concreteEvent:   "operating/instance-1/build_progress",
+			handlerEventKey: "build_progress",
+			action:          runtimecontracts.ActionSpec{ID: "record_evidence"},
+			handler: runtimecontracts.SystemNodeEventHandler{
+				Action:         runtimecontracts.ActionSpec{ID: "record_evidence"},
+				EvidenceTarget: "build_evidence",
+			},
+			wantBucket:  "build_evidence",
+			wantSummary: "compile complete",
+		},
+		{
+			name:            "selected rule action",
+			entityID:        "22222222-2222-2222-2222-222222222222",
+			concreteEvent:   "operating/instance-2/build_progress",
+			handlerEventKey: "build_progress",
+			action:          runtimecontracts.ActionSpec{ID: "record_evidence"},
+			handler: runtimecontracts.SystemNodeEventHandler{
+				Rules: []runtimecontracts.HandlerRuleEntry{{
+					ID:     "capture-progress",
+					Action: runtimecontracts.ActionSpec{ID: "record_evidence"},
+				}},
+				EvidenceTarget: "rule_evidence",
+			},
+			wantBucket:  "rule_evidence",
+			wantSummary: "rule branch complete",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := testWorkflowStoreRunContext(t, store)
+			if err := store.Upsert(ctx, WorkflowInstance{
+				InstanceID:      tt.entityID,
+				StorageRef:      tt.entityID,
+				WorkflowName:    "operating",
+				WorkflowVersion: "1.0.0",
+				CurrentState:    "initializing",
+				Metadata:        map[string]any{},
+				StateBuckets:    map[string]any{},
+			}); err != nil {
+				t.Fatalf("seed workflow instance: %v", err)
+			}
+
+			ok, err := runner.ExecuteAction(ctx, tt.action, runtimeregistry.ActionInstruction{Builtin: "record_evidence"}, runtimeengine.ExecutionContext{
+				Request: runtimeengine.ExecutionRequest{
+					EntityID:        identity.NormalizeEntityID(tt.entityID),
+					NodeID:          identity.NormalizeNodeID("build-orchestrator"),
+					Event:           events.NewProjectionEvent("", tt.concreteEvent, "", "", mustJSON(map[string]any{"summary": tt.wantSummary}), 0, "", "", events.EventEnvelope{}, time.Time{}).WithEntityID(tt.entityID),
+					HandlerEventKey: tt.handlerEventKey,
+					Handler:         tt.handler,
+				},
+			})
+			if !ok {
+				t.Fatal("expected record_evidence action to be claimed")
+			}
+			if err != nil {
+				t.Fatalf("ExecuteAction: %v", err)
+			}
+
+			instance, exists, err := store.Load(ctx, tt.entityID)
+			if err != nil {
+				t.Fatalf("load workflow instance: %v", err)
+			}
+			if !exists {
+				t.Fatal("expected workflow instance to exist")
+			}
+			entries := workflowEvidenceEntries(t, instance, tt.wantBucket)
+			if len(entries) != 1 {
+				t.Fatalf("evidence entries = %d, want 1", len(entries))
+			}
+			if got := entries[0]["summary"]; got != tt.wantSummary {
+				t.Fatalf("evidence summary = %#v, want %q", got, tt.wantSummary)
+			}
+		})
 	}
 }
 

--- a/internal/runtime/pipeline/workflow_instance_activation_test.go
+++ b/internal/runtime/pipeline/workflow_instance_activation_test.go
@@ -515,6 +515,103 @@ opco.ceo_ready:
 	}
 }
 
+func TestTemplateInstanceRecordEvidenceUsesLocalizedHandlerEvidenceTarget(t *testing.T) {
+	source := loadWorkflowTempSource(t, map[string]string{
+		"package.yaml": `name: test
+version: 1.0.0
+flows:
+  - id: operating
+    flow: operating
+    mode: template
+`,
+		"flows/operating/schema.yaml": `name: operating
+initial_state: initializing
+terminal_states: [ready]
+states: [initializing, ready]
+`,
+		"flows/operating/events.yaml": `build_progress:
+  entity_id: string
+  summary: string
+`,
+		"flows/operating/nodes.yaml": `build-orchestrator:
+  id: build-orchestrator
+  execution_type: system_node
+  subscribes_to: [build_progress]
+  event_handlers:
+    build_progress:
+      action: record_evidence
+      evidence_target: build_evidence
+`,
+	})
+	const entityID = "11111111-1111-1111-1111-111111111111"
+	evt := events.NewProjectionEvent(uuid.NewString(),
+		events.EventType("operating/inst-1/build_progress"), "", "", mustJSON(map[string]any{"entity_id": entityID, "summary": "compile complete"}), 0, "", "", events.EventEnvelope{}, time.Time{}).
+		WithEntityID(entityID).
+		WithFlowInstance("operating/inst-1")
+	if _, ok := source.NodeEventHandler("build-orchestrator", string(evt.Type())); ok {
+		t.Fatal("raw bundle handler lookup unexpectedly matched concrete instance event without delivery localization")
+	}
+	resolved := workflowNodeEventHandlerResolutionForDelivery(source, "build-orchestrator", evt)
+	if !resolved.Matched {
+		t.Fatal("expected concrete instance event to resolve to local build-orchestrator handler")
+	}
+	if got := resolved.HandlerEventKey; got != "build_progress" {
+		t.Fatalf("handler event key = %q, want build_progress", got)
+	}
+	if got := strings.TrimSpace(resolved.Handler.EvidenceTarget); got != "build_evidence" {
+		t.Fatalf("resolved evidence target = %q, want build_evidence", got)
+	}
+
+	_, db, cleanup := testutil.StartPostgres(t)
+	t.Cleanup(cleanup)
+	workflowStore := NewWorkflowInstanceStore(db)
+	pc := &PipelineCoordinator{
+		bus:                     &recordingPipelineBus{},
+		db:                      db,
+		workflowStore:           workflowStore,
+		expressionEval:          newWorkflowExpressionEvaluator(),
+		entityLocks:             map[string]*sync.Mutex{},
+		module:                  staticSemanticWorkflowModule{source: source},
+		eventReceiptsCapability: eventReceiptsCapabilityStub{enabled: true}.resolve,
+	}
+	ctx := testPipelineCoordinatorRunContext(t, pc)
+	if err := workflowStore.Upsert(ctx, WorkflowInstance{
+		InstanceID:      entityID,
+		StorageRef:      entityID,
+		WorkflowName:    "operating",
+		WorkflowVersion: "1.0.0",
+		CurrentState:    "initializing",
+		Metadata:        map[string]any{},
+		StateBuckets:    map[string]any{},
+	}); err != nil {
+		t.Fatalf("seed workflow instance: %v", err)
+	}
+	seedPipelineNodeDeliveryAuthority(t, db, evt, "build-orchestrator")
+
+	handled, err := pc.executeNodeHandlerPlanResult(ctx, "build-orchestrator", evt)
+	if err != nil {
+		t.Fatalf("executeNodeHandlerPlanResult: %v", err)
+	}
+	if !handled {
+		t.Fatal("executeNodeHandlerPlanResult handled = false, want true")
+	}
+
+	instance, ok, err := workflowStore.Load(ctx, entityID)
+	if err != nil {
+		t.Fatalf("load workflow instance: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected workflow instance to exist")
+	}
+	entries := workflowEvidenceEntries(t, instance, "build_evidence")
+	if len(entries) != 1 {
+		t.Fatalf("build_evidence entries = %d, want 1", len(entries))
+	}
+	if got := entries[0]["summary"]; got != "compile complete" {
+		t.Fatalf("evidence summary = %#v, want compile complete", got)
+	}
+}
+
 func loadWorkflowFixtureSource(t *testing.T, fixture string) semanticview.Source {
 	t.Helper()
 	return semanticview.Wrap(loadWorkflowFixtureBundle(t, fixture))


### PR DESCRIPTION
## Summary

Closes #1430.

`record_evidence` now resolves `evidence_target` from the matched handler carried on `runtimeengine.ExecutionRequest`, instead of re-looking up handler-local metadata by the concrete delivered event type.

This keeps concrete event type as provenance and uses the authored handler context selected by dispatch as the semantic owner for handler-local action metadata.

## Governing refs/context

Exact governing refs:

- `platform-spec.yaml:1814-1850`: canonical event identity model; handler lookup localizes external delivered names to local authored handler keys, and subsystems must not implement their own name-resolution logic.
- `platform-spec.yaml:4196-4204`: `record_evidence` is a handler/action-branch action and requires `evidence_target` on the handler.
- `platform-spec.yaml:1672-1675`: `evidence_target` names the accumulator key for `record_evidence`.

Adjacent split:

- #1432 tracks the spec contradiction around omitted `evidence_target` default-vs-required behavior. This PR does not change omitted-field behavior.

## Semantic migration

- New canonical owner consumed by `record_evidence`: `runtimeengine.ExecutionRequest.Handler` / `HandlerEventKey`, selected during handler dispatch.
- Old invalid path: `PipelineCoordinator.evidenceTargetForHandler(nodeID, raw Event.Type())` doing a second semantic-source lookup by concrete event provenance.
- Production paths checked: runtime delivery localization, engine bridge request construction, declarative fallback, preview path, accumulator/compute siblings, loader, bootverify, and other handler actions.
- Migration complete for the approved child class: `record_evidence` no longer uses raw concrete event type to resolve handler-local `EvidenceTarget`.

## Tests

- `go test ./internal/runtime/pipeline -run 'TestPipelineEngineActionRunner_RecordEvidenceReturnsMutationError|TestPipelineEngineActionRunner_RecordEvidenceUsesMatchedHandlerEvidenceTargetForConcreteEvents|TestTemplateInstanceRecordEvidenceUsesLocalizedHandlerEvidenceTarget|TestTemplateInstanceSystemNodeDeliveryLocalizesConcreteEventToHandlerKey' -count=1`
- `go test ./internal/runtime/engine -run 'TestExecutor_RuleActionRunsOnlyForSelectedRule|TestExecutor_AccumulatorBucketUsesMatchedHandlerEventKeyForScopedConcreteEvents|TestExecutor_ComputeReadsAccumulatorByMatchedHandlerEventKey' -count=1`
- `go test ./internal/runtime/contracts -run 'TestSystemNodeEventHandlerDecode_PreservesEvidenceTarget|TestLoadWorkflowContractBundle_PreservesEvidenceTarget' -count=1`
- `go test ./internal/runtime/bootverify -run 'TestRun_ReportsRecordEvidenceMissingEvidenceTarget' -count=1`
- `go test ./...`