### PR TITLE
[agent-c][issue #1434] Prove event.publish active-load ACK

### DIFF
--- a/cmd/swarm/main.go
+++ b/cmd/swarm/main.go
@@ -351,6 +351,7 @@ type serveOptions struct {
 	TestEntityStateHook              func(entityID, state string)
 	TestWorkflowNodeHandlerStartHook runtimepipeline.WorkflowNodeHandlerStartHook
 	TestLifecycleProbe               runtimelifecycleprobe.Observer
+	TestLLMRuntime                   runtimellm.Runtime
 	TestOutboxSweeperConfig          runtimebus.OutboxSweeperConfig
 	TestRuntimeReadyHook             func(*runtime.Runtime)
 }
@@ -707,6 +708,7 @@ func buildServeRuntimeBundleContext(req serveRuntimeBundleContextRequest) (serve
 			TestEntityStateHook:              req.Options.TestEntityStateHook,
 			TestWorkflowNodeHandlerStartHook: req.Options.TestWorkflowNodeHandlerStartHook,
 			TestLifecycleProbe:               req.Options.TestLifecycleProbe,
+			LLMRuntime:                       req.Options.TestLLMRuntime,
 			TestOutboxSweeperConfig:          req.Options.TestOutboxSweeperConfig,
 		},
 	})

--- a/cmd/swarm/main_test.go
+++ b/cmd/swarm/main_test.go
@@ -33,6 +33,7 @@ import (
 	runtimedeadletters "github.com/division-sh/swarm/internal/runtime/deadletters"
 	runtimedestructivereset "github.com/division-sh/swarm/internal/runtime/destructivereset"
 	"github.com/division-sh/swarm/internal/runtime/lifecycleprobe/lifecycletest"
+	runtimellm "github.com/division-sh/swarm/internal/runtime/llm"
 	runtimemanager "github.com/division-sh/swarm/internal/runtime/manager"
 	runtimemcp "github.com/division-sh/swarm/internal/runtime/mcp"
 	runtimepipeline "github.com/division-sh/swarm/internal/runtime/pipeline"
@@ -55,6 +56,11 @@ type delayedRunStatusAgent struct {
 	subscriptions []events.EventType
 	started       chan struct{}
 	release       chan struct{}
+}
+
+type servedEventPublishBlockingLLMRuntime struct {
+	started chan<- struct{}
+	release <-chan struct{}
 }
 
 func chdirForTest(t *testing.T, dir string) {
@@ -106,6 +112,37 @@ func (a delayedRunStatusAgent) OnEvent(ctx context.Context, evt events.Event) ([
 		events.EventType("scan.completed"),
 		a.id, "", []byte(`{}`), 0, evt.RunID(), "", events.EventEnvelope{}, time.Now().UTC())).WithEntityID(evt.EntityID())
 	return []events.Event{out}, nil
+}
+
+func (r servedEventPublishBlockingLLMRuntime) StartSession(_ context.Context, agentID string, systemPrompt string, tools []runtimellm.ToolDefinition) (*runtimellm.Session, error) {
+	return &runtimellm.Session{
+		ID:           uuid.NewString(),
+		AgentID:      agentID,
+		SystemPrompt: systemPrompt,
+		Tools:        append([]runtimellm.ToolDefinition(nil), tools...),
+	}, nil
+}
+
+func (r servedEventPublishBlockingLLMRuntime) ContinueSession(ctx context.Context, session *runtimellm.Session, message runtimellm.Message) (*runtimellm.Response, error) {
+	if r.started != nil {
+		select {
+		case r.started <- struct{}{}:
+		default:
+		}
+	}
+	select {
+	case <-r.release:
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+	sessionID := ""
+	if session != nil {
+		sessionID = session.ID
+	}
+	return &runtimellm.Response{
+		Message:   runtimellm.Message{Role: "assistant", Content: "acknowledged"},
+		SessionID: sessionID,
+	}, nil
 }
 
 func publishRunStatusRootEvent(t *testing.T, bus *runtimebus.EventBus, runID, entityID string) {
@@ -3493,6 +3530,80 @@ func TestRunServeRuntimeEventPublishRunIDFollowUpServedPathPostgres(t *testing.T
 	runServedEventPublishFollowUpProof(t, endpoint, db, "postgres", bundleHash, probe)
 }
 
+func TestRunServeRuntimeEventPublishExistingRunActiveLoadServedPathDefaultSQLite(t *testing.T) {
+	unsetStoreSelectorEnv(t)
+	stubServeRuntimeWorkspaceLifecycle(t)
+	sqlitePath := filepath.Join(t.TempDir(), ".swarm", "dev.db")
+	t.Setenv(storebackend.EnvSQLitePath, sqlitePath)
+	contractsPath := writeServedEventPublishActiveLoadFixture(t)
+	bundleHash := servedEventPublishFixtureBundleHash(t, contractsPath)
+	probe := lifecycletest.New(t, lifecycletest.WithTimeout(servedEventPublishLifecycleProbeWaitTimeout))
+	agentStarted := make(chan struct{}, 1)
+	release := make(chan struct{})
+	var releaseOnce sync.Once
+	oldBuildStores := buildStoresForServe
+	t.Cleanup(func() {
+		buildStoresForServe = oldBuildStores
+	})
+	var servedDB *sql.DB
+	buildStoresForServe = func(ctx context.Context, selection storebackend.Selection, cfg *config.Config) (storeBundle, error) {
+		stores, err := oldBuildStores(ctx, selection, cfg)
+		if err == nil {
+			servedDB = stores.SQLDB
+		}
+		return stores, err
+	}
+	endpoint, _ := startServedEventPublishFollowUpRuntime(t, serveOptions{
+		ConfigPath:              writeServeRuntimeTestConfig(t),
+		ContractsPath:           contractsPath,
+		PlatformSpecPath:        defaultPlatformSpecPath,
+		APIListenAddr:           "127.0.0.1:0",
+		MCPListenAddr:           "127.0.0.1:0",
+		SelfCheck:               true,
+		RequireBundleMatch:      false,
+		NoRequireBundleMatch:    true,
+		Verbose:                 true,
+		TestLifecycleProbe:      probe,
+		TestOutboxSweeperConfig: servedEventPublishProofOutboxSweeperConfig(),
+		TestLLMRuntime:          servedEventPublishBlockingLLMRuntime{started: agentStarted, release: release},
+	})
+	t.Cleanup(func() { releaseOnce.Do(func() { close(release) }) })
+	if servedDB == nil {
+		t.Fatal("served sqlite SQLDB is required for active-load event.publish proof")
+	}
+	runServedEventPublishActiveLoadProof(t, endpoint, servedDB, "sqlite", bundleHash, probe, agentStarted, release, &releaseOnce)
+}
+
+func TestRunServeRuntimeEventPublishExistingRunActiveLoadServedPathPostgres(t *testing.T) {
+	_, db, _ := installServeRuntimeEmptyPostgresTestStores(t, func() serveWorkspaceLifecycle {
+		return serveRuntimeWorkspaceStub{}
+	})
+	contractsPath := writeServedEventPublishActiveLoadFixture(t)
+	bundleHash := servedEventPublishFixtureBundleHash(t, contractsPath)
+	probe := lifecycletest.New(t, lifecycletest.WithTimeout(servedEventPublishLifecycleProbeWaitTimeout))
+	agentStarted := make(chan struct{}, 1)
+	release := make(chan struct{})
+	var releaseOnce sync.Once
+	endpoint, _ := startServedEventPublishFollowUpRuntime(t, serveOptions{
+		ConfigPath:              writeServeRuntimeTestConfig(t),
+		ContractsPath:           contractsPath,
+		PlatformSpecPath:        defaultPlatformSpecPath,
+		StoreMode:               "postgres",
+		StoreModeSet:            true,
+		APIListenAddr:           "127.0.0.1:0",
+		MCPListenAddr:           "127.0.0.1:0",
+		SelfCheck:               true,
+		RequireBundleMatch:      false,
+		Verbose:                 true,
+		TestLifecycleProbe:      probe,
+		TestLLMRuntime:          servedEventPublishBlockingLLMRuntime{started: agentStarted, release: release},
+		TestOutboxSweeperConfig: servedEventPublishProofOutboxSweeperConfig(),
+	})
+	t.Cleanup(func() { releaseOnce.Do(func() { close(release) }) })
+
+	runServedEventPublishActiveLoadProof(t, endpoint, db, "postgres", bundleHash, probe, agentStarted, release, &releaseOnce)
+}
+
 func TestRunServeRuntimeEventPublishDynamicAutoEmitServedPathDefaultSQLite(t *testing.T) {
 	unsetStoreSelectorEnv(t)
 	stubServeRuntimeWorkspaceLifecycle(t)
@@ -3731,6 +3842,14 @@ thing.reviewed:
   required:
     - entity_id
 
+thing.agent_hold:
+  swarm:
+    source: external
+  entity_id: string
+  note: text
+  required:
+    - entity_id
+
 thing.unhandled:
   swarm:
     source: external
@@ -3766,6 +3885,25 @@ entity-writer:
 	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "flows", "validation", "policy.yaml"), `{}`)
 	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "flows", "validation", "tools.yaml"), `{}`)
 	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "flows", "validation", "agents.yaml"), `{}`)
+	return root
+}
+
+func writeServedEventPublishActiveLoadFixture(t *testing.T) string {
+	t.Helper()
+	root := writeServedEventPublishFollowUpFixture(t)
+	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "flows", "validation", "agents.yaml"), `
+load-agent:
+  id: load-agent
+  role: load_agent
+  prompt_ref: load-agent
+  model: regular
+  conversation_mode: task
+  subscriptions:
+    - thing.agent_hold
+`)
+	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "flows", "validation", "prompts", "load-agent.md"), `
+Handle the active-load event and wait for test release.
+`)
 	return root
 }
 
@@ -4233,6 +4371,135 @@ func runServedEventPublishFollowUpProof(t *testing.T, endpoint string, db *sql.D
 	if got := servedEventPublishAPIIdempotencyCount(t, db, backend, "event.publish", unhandledIdempotencyKey); got != 0 {
 		t.Fatalf("%s idempotency rows for rejected follow-up = %d, want 0", backend, got)
 	}
+}
+
+func runServedEventPublishActiveLoadProof(
+	t *testing.T,
+	endpoint string,
+	db *sql.DB,
+	backend string,
+	bundleHash string,
+	probe *lifecycletest.Probe,
+	agentStarted <-chan struct{},
+	release chan struct{},
+	releaseOnce *sync.Once,
+) {
+	t.Helper()
+	initial := requireServedEventPublishRPCResult(t, endpoint, map[string]any{
+		"event_name":      "thing.created",
+		"bundle_hash":     bundleHash,
+		"payload":         map[string]any{"amount": 7, "who": "operator"},
+		"idempotency_key": "issue-1434-" + backend + "-initial",
+	})
+	runID := initial.RunID
+	initialEventID := initial.EventID
+	if !initial.NewRunCreated || runID == "" || initialEventID == "" {
+		t.Fatalf("%s initial event.publish result = %#v, want new run", backend, initial)
+	}
+	waitForServedEventPublishNodeDeliveryLifecycle(t, db, backend, runID, initialEventID, probe)
+	entityID := requireServedEventPublishEntityState(t, db, backend, runID, "", "waiting")
+
+	holdStart := time.Now()
+	holdEnvelope := requestServedJSONRPC(t, endpoint, "event.publish", map[string]any{
+		"event_name":      "validation/thing.agent_hold",
+		"run_id":          runID,
+		"source_event_id": initialEventID,
+		"payload":         map[string]any{"entity_id": entityID, "note": "hold active agent delivery"},
+		"idempotency_key": "issue-1434-" + backend + "-agent-hold",
+	})
+	holdElapsed := time.Since(holdStart)
+	if holdEnvelope.Error != nil {
+		t.Fatalf("%s agent-hold event.publish error = %#v", backend, holdEnvelope.Error)
+	}
+	if holdElapsed > time.Second {
+		t.Fatalf("%s agent-hold event.publish returned after %s, want durable ACK before held agent completes", backend, holdElapsed)
+	}
+	var hold servedEventPublishRPCResult
+	if err := json.Unmarshal(holdEnvelope.Result, &hold); err != nil {
+		t.Fatalf("%s decode agent-hold event.publish result: %v\n%s", backend, err, string(holdEnvelope.Result))
+	}
+	if hold.RunID != runID || hold.SourceEventID != initialEventID || hold.NewRunCreated || hold.EventID == "" {
+		t.Fatalf("%s agent-hold event.publish result = %#v, want existing run with source lineage", backend, hold)
+	}
+	if got := servedEventPublishScalarCount(t, db, backend, "event_deliveries", runID, hold.EventID); got == 0 {
+		t.Fatalf("%s agent-hold deliveries = %d, want persisted delivery authority\n%s", backend, got, servedEventPublishDebugSummary(t, db, backend, runID))
+	}
+	assertServedEventPublishDeliveriesContainStatus(t, hold.Deliveries, "agent", "load-agent", "pending", "in_progress")
+	select {
+	case <-agentStarted:
+	case <-time.After(servedEventPublishLifecycleProbeWaitTimeout):
+		t.Fatalf("%s timed out waiting for active-load agent to start\n%s", backend, servedEventPublishDebugSummary(t, db, backend, runID))
+	}
+	if got := servedEventPublishDeliveryStatusCount(t, db, backend, hold.EventID, "agent", "load-agent", "in_progress"); got != 1 {
+		t.Fatalf("%s agent-hold delivery in_progress count = %d, want active agent load before follow-up\n%s", backend, got, servedEventPublishDebugSummary(t, db, backend, runID))
+	}
+
+	unhandledKey := "issue-1434-" + backend + "-unhandled-active"
+	unhandledStart := time.Now()
+	unhandledEnvelope := requestServedJSONRPC(t, endpoint, "event.publish", map[string]any{
+		"event_name":      "validation/thing.unhandled",
+		"run_id":          runID,
+		"source_event_id": hold.EventID,
+		"payload":         map[string]any{"entity_id": entityID, "note": "unhandled under active load"},
+		"idempotency_key": unhandledKey,
+	})
+	unhandledElapsed := time.Since(unhandledStart)
+	if unhandledEnvelope.Error == nil {
+		t.Fatalf("%s unhandled event.publish error = nil, result=%s", backend, string(unhandledEnvelope.Result))
+	}
+	if unhandledElapsed > time.Second {
+		t.Fatalf("%s unhandled event.publish returned after %s, want typed fail-closed error before client timeout", backend, unhandledElapsed)
+	}
+	if unhandledEnvelope.Error.Data["code"] != apiv1.EventNotDeclaredCode {
+		t.Fatalf("%s unhandled event.publish error data = %#v, want %s", backend, unhandledEnvelope.Error.Data, apiv1.EventNotDeclaredCode)
+	}
+	if got := servedEventPublishEventCountByIdempotencyKey(t, db, backend, unhandledKey); got != 0 {
+		t.Fatalf("%s event rows for unhandled active-load idempotency key = %d, want 0", backend, got)
+	}
+	if got := servedEventPublishAPIIdempotencyCount(t, db, backend, "event.publish", unhandledKey); got != 0 {
+		t.Fatalf("%s idempotency rows for unhandled active-load publish = %d, want 0", backend, got)
+	}
+	if got := servedEventPublishDeliveryStatusCount(t, db, backend, hold.EventID, "agent", "load-agent", "in_progress"); got != 1 {
+		t.Fatalf("%s agent-hold delivery in_progress after fail-closed publish = %d, want still active\n%s", backend, got, servedEventPublishDebugSummary(t, db, backend, runID))
+	}
+
+	followStart := time.Now()
+	followEnvelope := requestServedJSONRPC(t, endpoint, "event.publish", map[string]any{
+		"event_name":      "validation/thing.reviewed",
+		"run_id":          runID,
+		"source_event_id": hold.EventID,
+		"payload":         map[string]any{"entity_id": entityID, "note": "approved under active load"},
+		"idempotency_key": "issue-1434-" + backend + "-follow-up",
+	})
+	followElapsed := time.Since(followStart)
+	if followEnvelope.Error != nil {
+		t.Fatalf("%s follow-up event.publish error = %#v", backend, followEnvelope.Error)
+	}
+	if followElapsed > time.Second {
+		t.Fatalf("%s follow-up event.publish returned after %s, want durable ACK while unrelated delivery remains active", backend, followElapsed)
+	}
+	var followUp servedEventPublishRPCResult
+	if err := json.Unmarshal(followEnvelope.Result, &followUp); err != nil {
+		t.Fatalf("%s decode follow-up event.publish result: %v\n%s", backend, err, string(followEnvelope.Result))
+	}
+	if followUp.RunID != runID || followUp.SourceEventID != hold.EventID || followUp.NewRunCreated || followUp.EventID == "" {
+		t.Fatalf("%s follow-up event.publish result = %#v, want existing run with hold event source lineage", backend, followUp)
+	}
+	if got := servedEventPublishScalarCount(t, db, backend, "event_deliveries", runID, followUp.EventID); got == 0 {
+		t.Fatalf("%s follow-up deliveries = %d, want persisted delivery authority\n%s", backend, got, servedEventPublishDebugSummary(t, db, backend, runID))
+	}
+	assertServedEventPublishDeliveriesContainStatus(t, followUp.Deliveries, "node", "entity-writer", "pending", "in_progress", "delivered")
+	if got := servedEventPublishDeliveryStatusCount(t, db, backend, hold.EventID, "agent", "load-agent", "in_progress"); got != 1 {
+		t.Fatalf("%s agent-hold delivery in_progress after follow-up ACK = %d, want ACK before unrelated agent delivery release\n%s", backend, got, servedEventPublishDebugSummary(t, db, backend, runID))
+	}
+	requireServedEventReadback(t, endpoint, followUp.EventID, runID, entityID, "validation/thing.reviewed", "entity-writer")
+
+	releaseOnce.Do(func() { close(release) })
+	waitServedEventPublishDeliveryStatusCount(t, db, backend, hold.EventID, "agent", "load-agent", "delivered", 1)
+	waitForServedEventPublishNodeDeliveryLifecycle(t, db, backend, runID, followUp.EventID, probe)
+	requireServedEventPublishEntityState(t, db, backend, runID, entityID, "done")
+	requireServedRunStatus(t, endpoint, runID, "completed")
+	requireServedTraceReadback(t, endpoint, runID, followUp.EventID, "validation/thing.reviewed", "entity-writer")
 }
 
 func runServedCLICommand(t *testing.T, endpoint string, args []string) (string, string, int) {

--- a/cmd/swarm/main_test.go
+++ b/cmd/swarm/main_test.go
@@ -4424,6 +4424,7 @@ func runServedEventPublishActiveLoadProof(
 	if got := servedEventPublishScalarCount(t, db, backend, "event_deliveries", runID, hold.EventID); got == 0 {
 		t.Fatalf("%s agent-hold deliveries = %d, want persisted delivery authority\n%s", backend, got, servedEventPublishDebugSummary(t, db, backend, runID))
 	}
+	requireServedEventPublishCommittedReplayScope(t, db, backend, runID, hold.EventID, "subscribed")
 	assertServedEventPublishDeliveriesContainStatus(t, hold.Deliveries, "agent", "load-agent", "pending", "in_progress")
 	select {
 	case <-agentStarted:
@@ -4488,6 +4489,7 @@ func runServedEventPublishActiveLoadProof(
 	if got := servedEventPublishScalarCount(t, db, backend, "event_deliveries", runID, followUp.EventID); got == 0 {
 		t.Fatalf("%s follow-up deliveries = %d, want persisted delivery authority\n%s", backend, got, servedEventPublishDebugSummary(t, db, backend, runID))
 	}
+	requireServedEventPublishCommittedReplayScope(t, db, backend, runID, followUp.EventID, "subscribed")
 	assertServedEventPublishDeliveriesContainStatus(t, followUp.Deliveries, "node", "entity-writer", "pending", "in_progress", "delivered")
 	if got := servedEventPublishDeliveryStatusCount(t, db, backend, hold.EventID, "agent", "load-agent", "in_progress"); got != 1 {
 		t.Fatalf("%s agent-hold delivery in_progress after follow-up ACK = %d, want ACK before unrelated agent delivery release\n%s", backend, got, servedEventPublishDebugSummary(t, db, backend, runID))
@@ -4998,6 +5000,52 @@ func servedEventPublishDeliveryStatusCount(t *testing.T, db *sql.DB, backend, ev
 		t.Fatalf("%s delivery count query failed: %v\n%s", backend, err, query)
 	}
 	return count
+}
+
+func requireServedEventPublishCommittedReplayScope(t *testing.T, db *sql.DB, backend, runID, eventID, wantScope string) {
+	t.Helper()
+	wantReason := "replay_scope_" + strings.TrimSpace(wantScope)
+	var (
+		query string
+		args  []any
+	)
+	switch backend {
+	case "postgres":
+		query = `
+			SELECT COUNT(*)
+			FROM event_deliveries
+			WHERE run_id = $1::uuid
+			  AND event_id = $2::uuid
+			  AND subscriber_type = 'node'
+			  AND subscriber_id = '__runtime_replay_scope__'
+			  AND status = 'delivered'
+			  AND reason_code = $3
+			  AND delivered_at IS NOT NULL
+		`
+		args = []any{runID, eventID, wantReason}
+	case "sqlite":
+		query = `
+			SELECT COUNT(*)
+			FROM event_deliveries
+			WHERE run_id = ?
+			  AND event_id = ?
+			  AND subscriber_type = 'node'
+			  AND subscriber_id = '__runtime_replay_scope__'
+			  AND status = 'delivered'
+			  AND reason_code = ?
+			  AND delivered_at IS NOT NULL
+		`
+		args = []any{runID, eventID, wantReason}
+	default:
+		t.Fatalf("unknown proof backend %q", backend)
+	}
+	var count int
+	if err := db.QueryRowContext(context.Background(), query, args...).Scan(&count); err != nil {
+		t.Fatalf("%s committed replay scope query failed: %v\n%s", backend, err, query)
+	}
+	if count != 1 {
+		t.Fatalf("%s committed replay scope rows for run=%s event=%s reason=%q = %d, want 1\n%s", backend, runID, eventID, wantReason, count, servedEventPublishDebugSummary(t, db, backend, runID))
+	}
 }
 
 func waitServedEventPublishReceiptOutcomeCount(t *testing.T, db *sql.DB, backend, eventID, subscriberType, subscriberID, outcome string, want int) {

--- a/internal/apiv1/public_surface_backend_matrix_test.go
+++ b/internal/apiv1/public_surface_backend_matrix_test.go
@@ -676,6 +676,8 @@ func expectedPublicSurfaceRowShapes() map[string]publicSurfaceExpectedRowShape {
 			GoTestProofRefs: []string{
 				"TestRunServeRuntimeEventPublishRunIDFollowUpServedPathDefaultSQLite",
 				"TestRunServeRuntimeEventPublishRunIDFollowUpServedPathPostgres",
+				"TestRunServeRuntimeEventPublishExistingRunActiveLoadServedPathDefaultSQLite",
+				"TestRunServeRuntimeEventPublishExistingRunActiveLoadServedPathPostgres",
 			},
 		},
 		"event_publish_dynamic_auto_emit_served_lifecycle": {

--- a/internal/apiv1/testdata/public_surface_backend_matrix.yaml
+++ b/internal/apiv1/testdata/public_surface_backend_matrix.yaml
@@ -285,6 +285,10 @@ rows:
       - kind: go_test
         name: TestRunServeRuntimeEventPublishRunIDFollowUpServedPathPostgres
       - kind: go_test
+        name: TestRunServeRuntimeEventPublishExistingRunActiveLoadServedPathDefaultSQLite
+      - kind: go_test
+        name: TestRunServeRuntimeEventPublishExistingRunActiveLoadServedPathPostgres
+      - kind: go_test
         name: TestBuildStoresSQLiteSelectsRunBundleContextForServedEventPublish
       - kind: go_test
         name: TestOperatorEventPublishSQLiteExplicitRunFollowUpUsesSelectedRun
@@ -295,6 +299,9 @@ rows:
       Postgres: `swarm event publish --run-id` publishes into the selected run,
       advances the system-node flow state, persists event/delivery evidence,
       and reads back through public event, trace, status, and entity surfaces.
+      #1434 extends this row with active-load liveness proof: existing-run
+      entity-targeted `event.publish` must ACK or fail closed while unrelated
+      delivery work remains in progress, without waiting for agent/handler completion.
 
   - id: event_publish_dynamic_auto_emit_served_lifecycle
     surface: /v1/rpc event.publish served dynamic auto_emit_on_create lifecycle parity


### PR DESCRIPTION
## Summary

- Adds a served regression for existing-run/entity-targeted `event.publish` while an unrelated static-agent delivery is actively in progress.
- Covers default SQLite and explicit Postgres served paths.
- Adds test-only served LLM runtime injection so the active agent delivery can be held deterministically without external LLM credentials.
- Records the active-load proof in the public surface backend matrix.

Closes #1434

## Governing Refs / Context

Exact binding refs from `platform-spec.yaml`:

- `methods.event.publish`: success is durable acceptance for the event row, selected delivery manifest, and committed replay scope; response delivery results come from persisted `event_deliveries`; ACK must not wait for system-node handler completion, dynamic auto-emit side effects, agent processing, downstream delivery, receipts, or replay delivery.
- `methods.event.publish.params.payload`: `payload.entity_id` remains business payload, not target/envelope/stateful-context authority.
- Route authority / delivery authority sections: publish-time RoutePlan persisted as `event_deliveries` is authoritative; live carriers, interceptors, handler lookup, receipts, and readback are consumers only.
- Backend-neutral runtime mutation / API idempotency sections: selected store mutation owners provide backend-neutral event mutation behavior; SQLite idempotency callback must not hold the idempotency row transaction while the callback writes through EventBus.

## Semantic Migration

No semantic migration and no production routing/admission behavior change.

- New canonical owner: unchanged, `EventBus.PublishAcknowledged` plus selected store `RunEventMutation`/persisted `event_deliveries`.
- Old producer/reader/writer path now invalid: none newly removed in this PR.
- Production paths checked for surviving old behavior: served API `event.publish` on default SQLite and explicit Postgres, with active agent work held in progress before follow-up publish ACK.
- Migration completeness: not applicable; this PR is a supported-surface regression/proof closure for the approved #1434 child class.

## Tests

- `go test ./cmd/swarm -run TestRunServeRuntimeEventPublishExistingRunActiveLoadServedPathDefaultSQLite -count=1`
- `go test ./cmd/swarm -run TestRunServeRuntimeEventPublishExistingRunActiveLoadServedPathPostgres -count=1`
- `go test ./cmd/swarm -run 'TestRunServeRuntimeEventPublish(RunIDFollowUpServedPath(DefaultSQLite|Postgres)|ExistingRunActiveLoadServedPath(DefaultSQLite|Postgres)|DynamicAutoEmitServedPath(DefaultSQLite|Postgres))$' -count=1`
- `go test ./internal/apiv1 -run TestPublicSurfaceBackendMatrix -count=1`
- `go test ./internal/runtime/conformance -run 'TestRouteAuthorityMatrix|TestRouteAuthorityDriftInventory' -count=1`
- `go test ./...`