### PR TITLE
[agent-b][issue #1420] Add trace delivery summary

### DIFF
--- a/cmd/swarm/diagnostics.go
+++ b/cmd/swarm/diagnostics.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"sort"
 	"strings"
 	"time"
 
@@ -17,6 +18,8 @@ const (
 	traceFollowMaximumBackoff   = time.Second
 	traceFollowRetryableReadErr = "read run.subscribe_trace notification:"
 )
+
+var traceDeliverySummaryStatuses = []string{"pending", "in_progress", "delivered", "failed", "dead_letter"}
 
 type diagnosticRunListOptions struct {
 	apiOptions rootCommandOptions
@@ -34,6 +37,7 @@ type diagnosticTraceOptions struct {
 	follow           bool
 	noRetry          bool
 	deliveryDetail   bool
+	deliverySummary  bool
 	since            string
 	until            string
 	limit            int
@@ -77,6 +81,29 @@ type diagnosticRunDiagnosisResult struct {
 type diagnosticRunTraceResult struct {
 	Trace      []diagnosticRunTraceRow `json:"trace"`
 	NextCursor string                  `json:"next_cursor,omitempty"`
+}
+
+type diagnosticRunTraceSummaryResult struct {
+	TraceRows       int
+	DeliveryRows    int
+	NonDeliveryRows int
+	Groups          []diagnosticRunTraceSummaryGroup
+}
+
+type diagnosticRunTraceSummaryGroup struct {
+	SubscriberType   string
+	SubscriberID     string
+	StatusCounts     map[string]int
+	QueueWait        diagnosticTraceDurationStats
+	ExecutionTime    diagnosticTraceDurationStats
+	UnavailableQueue int
+	UnavailableExec  int
+}
+
+type diagnosticTraceDurationStats struct {
+	Count int
+	Sum   time.Duration
+	Max   time.Duration
 }
 
 type diagnosticHealthCheckResult struct {
@@ -266,6 +293,7 @@ func newTraceCommand(opts rootCommandOptions) *cobra.Command {
 	cmd.Flags().BoolVarP(&traceOpts.follow, "follow", "f", false, "Follow live trace rows through /v1/ws run.subscribe_trace")
 	cmd.Flags().BoolVar(&traceOpts.noRetry, "no-retry", false, "Disable trace follow reconnect/recovery retries")
 	cmd.Flags().BoolVar(&traceOpts.deliveryDetail, "delivery-detail", false, "Show snapshot delivery lifecycle fields from RunTraceRow")
+	cmd.Flags().BoolVar(&traceOpts.deliverySummary, "delivery-summary", false, "Summarize snapshot delivery lifecycle fields from all RunTraceRow pages")
 	cmd.Flags().StringVar(&traceOpts.since, "since", "", "Snapshot-only RFC3339 trace materialization watermark")
 	cmd.Flags().StringVar(&traceOpts.until, "until", "", "Snapshot-only inclusive RFC3339 trace materialization upper bound")
 	cmd.Flags().IntVar(&traceOpts.limit, "limit", 0, "Snapshot-only page size, 1-2000")
@@ -484,6 +512,14 @@ func runDiagnosticTraceCommand(ctx context.Context, out, errOut io.Writer, opts 
 		return followDiagnosticTraceCommand(ctx, out, errOut, client, runID, opts, traceParams)
 	}
 	traceParams["run_id"] = runID
+	if opts.deliverySummary {
+		result, err := fetchDiagnosticRunTraceSummary(ctx, client, traceParams)
+		if err != nil {
+			return returnCLIAPIError(errOut, err, diagnosticRunAPIErrorClassifier())
+		}
+		writeDiagnosticRunTraceDeliverySummary(out, runID, result)
+		return nil
+	}
 	var result diagnosticRunTraceResult
 	if err := client.call(ctx, "run.trace", traceParams, &result); err != nil {
 		return returnCLIAPIError(errOut, err, diagnosticRunAPIErrorClassifier())
@@ -505,6 +541,9 @@ func (o diagnosticTraceOptions) traceParams() (map[string]any, error) {
 func (o diagnosticTraceOptions) snapshotParams() (map[string]any, error) {
 	if o.noRetry {
 		return nil, fmt.Errorf("--no-retry requires --follow")
+	}
+	if o.deliveryDetail && o.deliverySummary {
+		return nil, fmt.Errorf("--delivery-detail and --delivery-summary are mutually exclusive")
 	}
 	params := map[string]any{}
 	if o.limitSet {
@@ -563,6 +602,7 @@ func (o diagnosticTraceOptions) followParams() (map[string]any, error) {
 		{name: "--limit", set: o.limitSet},
 		{name: "--cursor", set: o.cursorSet},
 		{name: "--delivery-detail", set: o.deliveryDetail},
+		{name: "--delivery-summary", set: o.deliverySummary},
 	} {
 		if flag.set {
 			return nil, fmt.Errorf("%s is not supported with --follow", flag.name)
@@ -624,6 +664,130 @@ func (o diagnosticTraceOptions) traceFilter() (map[string]any, error) {
 		filter["subscriber_type"] = subscriberTypes
 	}
 	return filter, nil
+}
+
+func fetchDiagnosticRunTraceSummary(ctx context.Context, client *cliAPIClient, params map[string]any) (diagnosticRunTraceSummaryResult, error) {
+	pageParams := cloneDiagnosticTraceParams(params)
+	seenCursors := map[string]struct{}{}
+	if cursor, ok := pageParams["cursor"].(string); ok {
+		cursor = strings.TrimSpace(cursor)
+		if cursor != "" {
+			seenCursors[cursor] = struct{}{}
+		}
+	}
+	var rows []diagnosticRunTraceRow
+	for {
+		var page diagnosticRunTraceResult
+		if err := client.call(ctx, "run.trace", pageParams, &page); err != nil {
+			return diagnosticRunTraceSummaryResult{}, err
+		}
+		if err := validateDiagnosticRunTraceResult(page); err != nil {
+			return diagnosticRunTraceSummaryResult{}, err
+		}
+		if err := validateDiagnosticRunTraceSummaryRows(page.Trace); err != nil {
+			return diagnosticRunTraceSummaryResult{}, err
+		}
+		rows = append(rows, page.Trace...)
+		if page.NextCursor == "" {
+			break
+		}
+		nextCursor := strings.TrimSpace(page.NextCursor)
+		if nextCursor == "" {
+			return diagnosticRunTraceSummaryResult{}, fmt.Errorf("malformed run.trace result: next_cursor must not be empty")
+		}
+		if _, ok := seenCursors[nextCursor]; ok {
+			return diagnosticRunTraceSummaryResult{}, fmt.Errorf("malformed run.trace result: repeated next_cursor %q", nextCursor)
+		}
+		seenCursors[nextCursor] = struct{}{}
+		pageParams["cursor"] = nextCursor
+	}
+	return summarizeDiagnosticRunTraceRows(rows), nil
+}
+
+func cloneDiagnosticTraceParams(params map[string]any) map[string]any {
+	out := make(map[string]any, len(params))
+	for key, value := range params {
+		out[key] = value
+	}
+	return out
+}
+
+func validateDiagnosticRunTraceSummaryRows(rows []diagnosticRunTraceRow) error {
+	for i, row := range rows {
+		if strings.TrimSpace(row.DeliveryID) == "" {
+			continue
+		}
+		if strings.TrimSpace(row.SubscriberType) == "" {
+			return fmt.Errorf("malformed run.trace result: trace[%d].subscriber_type is required when delivery_id is present", i)
+		}
+		if _, ok := eventObservationValidSubscriberTypes[strings.TrimSpace(row.SubscriberType)]; !ok {
+			return fmt.Errorf("malformed run.trace result: trace[%d].subscriber_type=%q is not a valid SubscriberType", i, row.SubscriberType)
+		}
+		if strings.TrimSpace(row.SubscriberID) == "" {
+			return fmt.Errorf("malformed run.trace result: trace[%d].subscriber_id is required when delivery_id is present", i)
+		}
+		if strings.TrimSpace(row.DeliveryStatus) == "" {
+			return fmt.Errorf("malformed run.trace result: trace[%d].delivery_status is required when delivery_id is present", i)
+		}
+		if _, ok := eventObservationValidDeliveryStatuses[strings.TrimSpace(row.DeliveryStatus)]; !ok {
+			return fmt.Errorf("malformed run.trace result: trace[%d].delivery_status=%q is not a valid DeliveryStatus", i, row.DeliveryStatus)
+		}
+	}
+	return nil
+}
+
+func summarizeDiagnosticRunTraceRows(rows []diagnosticRunTraceRow) diagnosticRunTraceSummaryResult {
+	result := diagnosticRunTraceSummaryResult{TraceRows: len(rows)}
+	groups := map[string]*diagnosticRunTraceSummaryGroup{}
+	for _, row := range rows {
+		if strings.TrimSpace(row.DeliveryID) == "" {
+			result.NonDeliveryRows++
+			continue
+		}
+		result.DeliveryRows++
+		subscriberType := strings.TrimSpace(row.SubscriberType)
+		subscriberID := strings.TrimSpace(row.SubscriberID)
+		key := subscriberType + "\x00" + subscriberID
+		group, ok := groups[key]
+		if !ok {
+			group = &diagnosticRunTraceSummaryGroup{
+				SubscriberType: subscriberType,
+				SubscriberID:   subscriberID,
+				StatusCounts:   make(map[string]int, len(traceDeliverySummaryStatuses)),
+			}
+			groups[key] = group
+		}
+		group.StatusCounts[strings.TrimSpace(row.DeliveryStatus)]++
+		if duration, ok := traceDurationValue(row.DeliveryCreatedAt, row.DeliveryStartedAt); ok {
+			group.QueueWait.Add(duration)
+		} else {
+			group.UnavailableQueue++
+		}
+		if duration, ok := traceDurationValue(row.DeliveryStartedAt, row.DeliveryDeliveredAt); ok {
+			group.ExecutionTime.Add(duration)
+		} else {
+			group.UnavailableExec++
+		}
+	}
+	result.Groups = make([]diagnosticRunTraceSummaryGroup, 0, len(groups))
+	for _, group := range groups {
+		result.Groups = append(result.Groups, *group)
+	}
+	sort.Slice(result.Groups, func(i, j int) bool {
+		if result.Groups[i].SubscriberType == result.Groups[j].SubscriberType {
+			return result.Groups[i].SubscriberID < result.Groups[j].SubscriberID
+		}
+		return result.Groups[i].SubscriberType < result.Groups[j].SubscriberType
+	})
+	return result
+}
+
+func (s *diagnosticTraceDurationStats) Add(value time.Duration) {
+	s.Count++
+	s.Sum += value
+	if s.Count == 1 || value > s.Max {
+		s.Max = value
+	}
 }
 
 func traceStringList(flag string, values []string) ([]string, error) {
@@ -1278,6 +1442,40 @@ func writeDiagnosticRunTrace(out io.Writer, runID string, result diagnosticRunTr
 	}
 }
 
+func writeDiagnosticRunTraceDeliverySummary(out io.Writer, runID string, result diagnosticRunTraceSummaryResult) {
+	if out == nil {
+		return
+	}
+	fmt.Fprintf(out, "run trace delivery summary: run_id=%s snapshot=point-in-time trace_rows=%d delivery_rows=%d non_delivery_rows=%d\n",
+		runID,
+		result.TraceRows,
+		result.DeliveryRows,
+		result.NonDeliveryRows,
+	)
+	if len(result.Groups) == 0 {
+		fmt.Fprintln(out, "no delivery rows")
+		return
+	}
+	fmt.Fprintln(out, "SUBSCRIBER\tPENDING\tIN_PROGRESS\tDELIVERED\tFAILED\tDEAD_LETTER\tAVG_QUEUE_WAIT\tMAX_QUEUE_WAIT\tAVG_EXECUTION_TIME\tMAX_EXECUTION_TIME\tQUEUE_UNAVAILABLE\tEXECUTION_UNAVAILABLE")
+	for _, group := range result.Groups {
+		fmt.Fprintf(out, "%s/%s\t%d\t%d\t%d\t%d\t%d\t%s\t%s\t%s\t%s\t%d\t%d\n",
+			group.SubscriberType,
+			group.SubscriberID,
+			group.StatusCounts["pending"],
+			group.StatusCounts["in_progress"],
+			group.StatusCounts["delivered"],
+			group.StatusCounts["failed"],
+			group.StatusCounts["dead_letter"],
+			traceDurationAverage(group.QueueWait),
+			traceDurationMax(group.QueueWait),
+			traceDurationAverage(group.ExecutionTime),
+			traceDurationMax(group.ExecutionTime),
+			group.UnavailableQueue,
+			group.UnavailableExec,
+		)
+	}
+}
+
 func writeDiagnosticRunTraceDeliveryDetail(out io.Writer, rows []diagnosticRunTraceRow) {
 	fmt.Fprintln(out, "EVENT AT\tEVENT\tEVENT ID\tDELIVERY ID\tSUBSCRIBER\tSTATUS\tREASON\tDELIVERY CREATED\tDELIVERY STARTED\tDELIVERY DELIVERED\tQUEUE WAIT\tEXECUTION TIME\tSESSION\tTURN")
 	for _, row := range rows {
@@ -1301,21 +1499,43 @@ func writeDiagnosticRunTraceDeliveryDetail(out io.Writer, rows []diagnosticRunTr
 	}
 }
 
+func traceDurationAverage(stats diagnosticTraceDurationStats) string {
+	if stats.Count == 0 {
+		return "-"
+	}
+	return (stats.Sum / time.Duration(stats.Count)).Round(time.Millisecond).String()
+}
+
+func traceDurationMax(stats diagnosticTraceDurationStats) string {
+	if stats.Count == 0 {
+		return "-"
+	}
+	return stats.Max.Round(time.Millisecond).String()
+}
+
 func traceDuration(start, end string) string {
+	duration, ok := traceDurationValue(start, end)
+	if !ok {
+		return "-"
+	}
+	return duration.Round(time.Millisecond).String()
+}
+
+func traceDurationValue(start, end string) (time.Duration, bool) {
 	start = strings.TrimSpace(start)
 	end = strings.TrimSpace(end)
 	if start == "" || end == "" {
-		return "-"
+		return 0, false
 	}
 	startAt, err := time.Parse(time.RFC3339Nano, start)
 	if err != nil {
-		return "-"
+		return 0, false
 	}
 	endAt, err := time.Parse(time.RFC3339Nano, end)
 	if err != nil {
-		return "-"
+		return 0, false
 	}
-	return endAt.Sub(startAt).Round(time.Millisecond).String()
+	return endAt.Sub(startAt), true
 }
 
 func writeDiagnosticHealth(out io.Writer, result diagnosticHealthCheckResult) {

--- a/cmd/swarm/diagnostics.go
+++ b/cmd/swarm/diagnostics.go
@@ -90,6 +90,13 @@ type diagnosticRunTraceSummaryResult struct {
 	Groups          []diagnosticRunTraceSummaryGroup
 }
 
+type diagnosticRunTraceSummaryAccumulator struct {
+	traceRows       int
+	deliveryRows    int
+	nonDeliveryRows int
+	groups          map[string]*diagnosticRunTraceSummaryGroup
+}
+
 type diagnosticRunTraceSummaryGroup struct {
 	SubscriberType   string
 	SubscriberID     string
@@ -513,6 +520,9 @@ func runDiagnosticTraceCommand(ctx context.Context, out, errOut io.Writer, opts 
 	}
 	traceParams["run_id"] = runID
 	if opts.deliverySummary {
+		if !opts.untilSet {
+			traceParams["until"] = time.Now().UTC().Format(time.RFC3339Nano)
+		}
 		result, err := fetchDiagnosticRunTraceSummary(ctx, client, traceParams)
 		if err != nil {
 			return returnCLIAPIError(errOut, err, diagnosticRunAPIErrorClassifier())
@@ -675,7 +685,7 @@ func fetchDiagnosticRunTraceSummary(ctx context.Context, client *cliAPIClient, p
 			seenCursors[cursor] = struct{}{}
 		}
 	}
-	var rows []diagnosticRunTraceRow
+	summary := newDiagnosticRunTraceSummaryAccumulator()
 	for {
 		var page diagnosticRunTraceResult
 		if err := client.call(ctx, "run.trace", pageParams, &page); err != nil {
@@ -687,7 +697,7 @@ func fetchDiagnosticRunTraceSummary(ctx context.Context, client *cliAPIClient, p
 		if err := validateDiagnosticRunTraceSummaryRows(page.Trace); err != nil {
 			return diagnosticRunTraceSummaryResult{}, err
 		}
-		rows = append(rows, page.Trace...)
+		summary.AddRows(page.Trace)
 		if page.NextCursor == "" {
 			break
 		}
@@ -701,7 +711,7 @@ func fetchDiagnosticRunTraceSummary(ctx context.Context, client *cliAPIClient, p
 		seenCursors[nextCursor] = struct{}{}
 		pageParams["cursor"] = nextCursor
 	}
-	return summarizeDiagnosticRunTraceRows(rows), nil
+	return summary.Result(), nil
 }
 
 func cloneDiagnosticTraceParams(params map[string]any) map[string]any {
@@ -736,26 +746,29 @@ func validateDiagnosticRunTraceSummaryRows(rows []diagnosticRunTraceRow) error {
 	return nil
 }
 
-func summarizeDiagnosticRunTraceRows(rows []diagnosticRunTraceRow) diagnosticRunTraceSummaryResult {
-	result := diagnosticRunTraceSummaryResult{TraceRows: len(rows)}
-	groups := map[string]*diagnosticRunTraceSummaryGroup{}
+func newDiagnosticRunTraceSummaryAccumulator() *diagnosticRunTraceSummaryAccumulator {
+	return &diagnosticRunTraceSummaryAccumulator{groups: map[string]*diagnosticRunTraceSummaryGroup{}}
+}
+
+func (s *diagnosticRunTraceSummaryAccumulator) AddRows(rows []diagnosticRunTraceRow) {
 	for _, row := range rows {
+		s.traceRows++
 		if strings.TrimSpace(row.DeliveryID) == "" {
-			result.NonDeliveryRows++
+			s.nonDeliveryRows++
 			continue
 		}
-		result.DeliveryRows++
+		s.deliveryRows++
 		subscriberType := strings.TrimSpace(row.SubscriberType)
 		subscriberID := strings.TrimSpace(row.SubscriberID)
 		key := subscriberType + "\x00" + subscriberID
-		group, ok := groups[key]
+		group, ok := s.groups[key]
 		if !ok {
 			group = &diagnosticRunTraceSummaryGroup{
 				SubscriberType: subscriberType,
 				SubscriberID:   subscriberID,
 				StatusCounts:   make(map[string]int, len(traceDeliverySummaryStatuses)),
 			}
-			groups[key] = group
+			s.groups[key] = group
 		}
 		group.StatusCounts[strings.TrimSpace(row.DeliveryStatus)]++
 		if duration, ok := traceDurationValue(row.DeliveryCreatedAt, row.DeliveryStartedAt); ok {
@@ -769,8 +782,16 @@ func summarizeDiagnosticRunTraceRows(rows []diagnosticRunTraceRow) diagnosticRun
 			group.UnavailableExec++
 		}
 	}
-	result.Groups = make([]diagnosticRunTraceSummaryGroup, 0, len(groups))
-	for _, group := range groups {
+}
+
+func (s *diagnosticRunTraceSummaryAccumulator) Result() diagnosticRunTraceSummaryResult {
+	result := diagnosticRunTraceSummaryResult{
+		TraceRows:       s.traceRows,
+		DeliveryRows:    s.deliveryRows,
+		NonDeliveryRows: s.nonDeliveryRows,
+		Groups:          make([]diagnosticRunTraceSummaryGroup, 0, len(s.groups)),
+	}
+	for _, group := range s.groups {
 		result.Groups = append(result.Groups, *group)
 	}
 	sort.Slice(result.Groups, func(i, j int) bool {

--- a/cmd/swarm/diagnostics_test.go
+++ b/cmd/swarm/diagnostics_test.go
@@ -604,6 +604,7 @@ func TestTraceDeliverySummaryExhaustsRunTracePages(t *testing.T) {
 
 func TestTraceDeliverySummaryUsesOmittedRunResolver(t *testing.T) {
 	t.Setenv("SWARM_API_TOKEN", "test-token")
+	var capturedUntil string
 	server, requests := newDiagnosticSuccessServer(t, func(req jsonRPCRequest, callIndex int) map[string]any {
 		switch callIndex {
 		case 0:
@@ -615,9 +616,20 @@ func TestTraceDeliverySummaryUsesOmittedRunResolver(t *testing.T) {
 			if req.Method != "run.trace" {
 				t.Fatalf("method[%d] = %q, want run.trace", callIndex, req.Method)
 			}
-			if !reflect.DeepEqual(req.Params, map[string]any{"run_id": "active-run"}) {
+			if req.Params["run_id"] != "active-run" {
 				t.Fatalf("params[%d] = %#v, want active run trace", callIndex, req.Params)
 			}
+			until, ok := req.Params["until"].(string)
+			if !ok || strings.TrimSpace(until) == "" {
+				t.Fatalf("params[%d] = %#v, want captured until bound", callIndex, req.Params)
+			}
+			if _, err := time.Parse(time.RFC3339Nano, until); err != nil {
+				t.Fatalf("until = %q, want RFC3339Nano: %v", until, err)
+			}
+			if _, ok := req.Params["cursor"]; ok {
+				t.Fatalf("params[%d] = %#v, want no cursor on first summary page", callIndex, req.Params)
+			}
+			capturedUntil = until
 			return map[string]any{"trace": []any{map[string]any{
 				"event_id":              "event-1",
 				"event_name":            "scan.completed",
@@ -629,7 +641,15 @@ func TestTraceDeliverySummaryUsesOmittedRunResolver(t *testing.T) {
 				"delivery_delivered_at": "2026-05-13T10:00:03Z",
 				"subscriber_type":       "agent",
 				"subscriber_id":         "agent-1",
-			}}}
+			}}, "next_cursor": "page-2"}
+		case 2:
+			if req.Method != "run.trace" {
+				t.Fatalf("method[%d] = %q, want run.trace", callIndex, req.Method)
+			}
+			if req.Params["run_id"] != "active-run" || req.Params["cursor"] != "page-2" || req.Params["until"] != capturedUntil {
+				t.Fatalf("params[%d] = %#v, want same captured until and advanced cursor", callIndex, req.Params)
+			}
+			return map[string]any{"trace": []any{}}
 		default:
 			t.Fatalf("unexpected request[%d]: %#v", callIndex, req)
 		}
@@ -642,8 +662,8 @@ func TestTraceDeliverySummaryUsesOmittedRunResolver(t *testing.T) {
 	if code != 0 {
 		t.Fatalf("code = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
 	}
-	if len(*requests) != 2 {
-		t.Fatalf("requests = %d, want run.list then run.trace", len(*requests))
+	if len(*requests) != 3 {
+		t.Fatalf("requests = %d, want run.list then two run.trace pages", len(*requests))
 	}
 	if !strings.Contains(stdout.String(), "run trace delivery summary: run_id=active-run snapshot=point-in-time") {
 		t.Fatalf("stdout = %q, want resolved active-run summary", stdout.String())

--- a/cmd/swarm/diagnostics_test.go
+++ b/cmd/swarm/diagnostics_test.go
@@ -483,6 +483,176 @@ func TestTraceDeliveryDetailRendersRunTraceLifecycleFields(t *testing.T) {
 	}
 }
 
+func TestTraceDeliverySummaryExhaustsRunTracePages(t *testing.T) {
+	t.Setenv("SWARM_API_TOKEN", "test-token")
+	server, requests := newDiagnosticSuccessServer(t, func(req jsonRPCRequest, callIndex int) map[string]any {
+		if req.Method != "run.trace" {
+			t.Fatalf("method[%d] = %q, want run.trace", callIndex, req.Method)
+		}
+		baseParams := map[string]any{
+			"run_id": "run-1",
+			"limit":  float64(1),
+			"since":  "2026-05-13T10:00:00Z",
+			"until":  "2026-05-13T10:05:00Z",
+			"filter": map[string]any{
+				"delivery_status": []any{"in_progress", "delivered", "failed"},
+				"subscriber_type": []any{"agent", "node"},
+			},
+		}
+		switch callIndex {
+		case 0:
+			baseParams["cursor"] = "start-cur"
+			if !reflect.DeepEqual(req.Params, baseParams) {
+				t.Fatalf("params[%d] = %#v, want %#v", callIndex, req.Params, baseParams)
+			}
+			return map[string]any{
+				"trace": []any{
+					map[string]any{
+						"event_id":         "event-only",
+						"event_name":       "scan.created",
+						"event_created_at": "2026-05-13T10:00:00Z",
+					},
+					map[string]any{
+						"event_id":            "event-1",
+						"event_name":          "scan.requested",
+						"event_created_at":    "2026-05-13T10:00:01Z",
+						"delivery_id":         "delivery-1",
+						"delivery_status":     "in_progress",
+						"delivery_created_at": "2026-05-13T10:00:01Z",
+						"delivery_started_at": "2026-05-13T10:00:04Z",
+						"subscriber_type":     "agent",
+						"subscriber_id":       "agent-1",
+					},
+				},
+				"next_cursor": "page-2",
+			}
+		case 1:
+			baseParams["cursor"] = "page-2"
+			if !reflect.DeepEqual(req.Params, baseParams) {
+				t.Fatalf("params[%d] = %#v, want %#v", callIndex, req.Params, baseParams)
+			}
+			return map[string]any{
+				"trace": []any{
+					map[string]any{
+						"event_id":              "event-2",
+						"event_name":            "scan.completed",
+						"event_created_at":      "2026-05-13T10:00:05Z",
+						"delivery_id":           "delivery-2",
+						"delivery_status":       "delivered",
+						"delivery_created_at":   "2026-05-13T10:00:05Z",
+						"delivery_started_at":   "2026-05-13T10:00:07Z",
+						"delivery_delivered_at": "2026-05-13T10:00:12Z",
+						"subscriber_type":       "agent",
+						"subscriber_id":         "agent-1",
+					},
+					map[string]any{
+						"event_id":            "event-3",
+						"event_name":          "scan.failed",
+						"event_created_at":    "2026-05-13T10:00:06Z",
+						"delivery_id":         "delivery-3",
+						"delivery_status":     "failed",
+						"delivery_created_at": "2026-05-13T10:00:06Z",
+						"subscriber_type":     "node",
+						"subscriber_id":       "node-1",
+					},
+				},
+			}
+		default:
+			t.Fatalf("unexpected request[%d]: %#v", callIndex, req)
+		}
+		return nil
+	})
+	defer server.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{
+		"trace", "run-1",
+		"--delivery-summary",
+		"--limit", "1",
+		"--cursor", "start-cur",
+		"--since", "2026-05-13T10:00:00Z",
+		"--until", "2026-05-13T10:05:00Z",
+		"--delivery-status", "in_progress",
+		"--delivery-status", "delivered",
+		"--delivery-status", "failed",
+		"--subscriber-type", "agent",
+		"--subscriber-type", "node",
+	}, &stdout, &stderr, testRootCommandOptions(server))
+	if code != 0 {
+		t.Fatalf("code = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	if len(*requests) != 2 {
+		t.Fatalf("requests = %d, want 2 paged run.trace calls", len(*requests))
+	}
+	for _, want := range []string{
+		"run trace delivery summary: run_id=run-1 snapshot=point-in-time trace_rows=4 delivery_rows=3 non_delivery_rows=1",
+		"SUBSCRIBER\tPENDING\tIN_PROGRESS\tDELIVERED\tFAILED\tDEAD_LETTER",
+		"agent/agent-1\t0\t1\t1\t0\t0\t2.5s\t3s\t5s\t5s\t0\t1",
+		"node/node-1\t0\t0\t0\t1\t0\t-\t-\t-\t-\t1\t1",
+	} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("stdout missing %q:\n%s", want, stdout.String())
+		}
+	}
+	if strings.Contains(stdout.String(), "next_cursor=") {
+		t.Fatalf("stdout = %q, want summary to exhaust pages instead of printing next_cursor", stdout.String())
+	}
+	if strings.TrimSpace(stderr.String()) != "" {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+}
+
+func TestTraceDeliverySummaryUsesOmittedRunResolver(t *testing.T) {
+	t.Setenv("SWARM_API_TOKEN", "test-token")
+	server, requests := newDiagnosticSuccessServer(t, func(req jsonRPCRequest, callIndex int) map[string]any {
+		switch callIndex {
+		case 0:
+			if req.Method != "run.list" {
+				t.Fatalf("method[%d] = %q, want run.list", callIndex, req.Method)
+			}
+			return map[string]any{"runs": []any{validDiagnosticRunHeaderWithStatus("active-run", "running")}}
+		case 1:
+			if req.Method != "run.trace" {
+				t.Fatalf("method[%d] = %q, want run.trace", callIndex, req.Method)
+			}
+			if !reflect.DeepEqual(req.Params, map[string]any{"run_id": "active-run"}) {
+				t.Fatalf("params[%d] = %#v, want active run trace", callIndex, req.Params)
+			}
+			return map[string]any{"trace": []any{map[string]any{
+				"event_id":              "event-1",
+				"event_name":            "scan.completed",
+				"event_created_at":      "2026-05-13T10:00:00Z",
+				"delivery_id":           "delivery-1",
+				"delivery_status":       "delivered",
+				"delivery_created_at":   "2026-05-13T10:00:00Z",
+				"delivery_started_at":   "2026-05-13T10:00:01Z",
+				"delivery_delivered_at": "2026-05-13T10:00:03Z",
+				"subscriber_type":       "agent",
+				"subscriber_id":         "agent-1",
+			}}}
+		default:
+			t.Fatalf("unexpected request[%d]: %#v", callIndex, req)
+		}
+		return nil
+	})
+	defer server.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"trace", "--delivery-summary"}, &stdout, &stderr, testRootCommandOptions(server))
+	if code != 0 {
+		t.Fatalf("code = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	if len(*requests) != 2 {
+		t.Fatalf("requests = %d, want run.list then run.trace", len(*requests))
+	}
+	if !strings.Contains(stdout.String(), "run trace delivery summary: run_id=active-run snapshot=point-in-time") {
+		t.Fatalf("stdout = %q, want resolved active-run summary", stdout.String())
+	}
+	if strings.TrimSpace(stderr.String()) != "" {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+}
+
 func wantFullTraceFilterParams() map[string]any {
 	return map[string]any{
 		"event_name":      []any{"scan.requested", "scan.completed"},
@@ -641,6 +811,9 @@ func TestTraceHelpPromotesNoRetryWithoutReplaySince(t *testing.T) {
 	}
 	if !strings.Contains(stdout.String(), "--delivery-detail") {
 		t.Fatalf("help missing --delivery-detail:\n%s", stdout.String())
+	}
+	if !strings.Contains(stdout.String(), "--delivery-summary") {
+		t.Fatalf("help missing --delivery-summary:\n%s", stdout.String())
 	}
 	if strings.Contains(stdout.String(), "--replay-since") {
 		t.Fatalf("help exposed unpromoted --replay-since:\n%s", stdout.String())
@@ -1041,11 +1214,13 @@ func TestDiagnosticsRejectInvalidInputBeforeRequest(t *testing.T) {
 		{name: "trace since after until", args: []string{"trace", "run-1", "--since", "2026-05-13T10:05:00Z", "--until", "2026-05-13T10:00:00Z"}, wantStderr: "--until must be at or after --since"},
 		{name: "trace blank cursor", args: []string{"trace", "run-1", "--cursor", " "}, wantStderr: "--cursor must not be empty"},
 		{name: "trace no retry requires follow", args: []string{"trace", "run-1", "--no-retry"}, wantStderr: "--no-retry requires --follow"},
+		{name: "trace delivery detail and summary are mutually exclusive", args: []string{"trace", "run-1", "--delivery-detail", "--delivery-summary"}, wantStderr: "--delivery-detail and --delivery-summary are mutually exclusive"},
 		{name: "trace follow rejects limit", args: []string{"trace", "run-1", "--follow", "--limit", "5"}, wantStderr: "--limit is not supported with --follow"},
 		{name: "trace follow rejects cursor", args: []string{"trace", "run-1", "--follow", "--cursor", "cur"}, wantStderr: "--cursor is not supported with --follow"},
 		{name: "trace follow rejects since", args: []string{"trace", "run-1", "--follow", "--since", "2026-05-13T10:00:00Z"}, wantStderr: "--since is not supported with --follow"},
 		{name: "trace follow rejects until", args: []string{"trace", "run-1", "--follow", "--until", "2026-05-13T10:05:00Z"}, wantStderr: "--until is not supported with --follow"},
 		{name: "trace follow rejects delivery detail", args: []string{"trace", "run-1", "--follow", "--delivery-detail"}, wantStderr: "--delivery-detail is not supported with --follow"},
+		{name: "trace follow rejects delivery summary", args: []string{"trace", "run-1", "--follow", "--delivery-summary"}, wantStderr: "--delivery-summary is not supported with --follow"},
 		{name: "trace shorthand follow rejects limit", args: []string{"trace", "run-1", "-f", "--limit", "5"}, wantStderr: "--limit is not supported with --follow"},
 		{name: "trace shorthand follow rejects cursor", args: []string{"trace", "run-1", "-f", "--cursor", "cur"}, wantStderr: "--cursor is not supported with --follow"},
 		{name: "trace shorthand follow rejects since", args: []string{"trace", "run-1", "-f", "--since", "2026-05-13T10:00:00Z"}, wantStderr: "--since is not supported with --follow"},
@@ -1089,6 +1264,7 @@ func TestDiagnosticsRequireAPITokenBeforeRequest(t *testing.T) {
 		{"trace", "run-1"},
 		{"trace", "run-1", "--limit", "2", "--cursor", "cur", "--since", "2026-05-13T10:00:00Z", "--until", "2026-05-13T10:05:00Z"},
 		{"trace", "run-1", "--delivery-detail"},
+		{"trace", "run-1", "--delivery-summary"},
 		{"trace", "run-1", "--event-name", "scan.requested", "--entity-id", "entity-1", "--delivery-status", "delivered", "--subscriber-id", "agent-1", "--subscriber-type", "agent"},
 		{"trace", "run-1", "--follow"},
 		{"trace", "run-1", "-f"},
@@ -1341,6 +1517,39 @@ func TestDiagnosticsFailClosedOnAPIAndMalformedResults(t *testing.T) {
 			},
 			wantCode:   3,
 			wantStderr: "trace[0].delivery_created_at must be an RFC3339 timestamp",
+		},
+		{
+			name: "trace summary repeated cursor",
+			args: []string{"trace", "run-1", "--delivery-summary", "--cursor", "same-cur"},
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				var req jsonRPCRequest
+				_ = json.NewDecoder(r.Body).Decode(&req)
+				writeJSONRPCResult(t, w, req.ID, map[string]any{
+					"trace":       []any{},
+					"next_cursor": "same-cur",
+				})
+			},
+			wantCode:   3,
+			wantStderr: `repeated next_cursor "same-cur"`,
+		},
+		{
+			name: "trace summary delivery row missing subscriber",
+			args: []string{"trace", "run-1", "--delivery-summary"},
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				var req jsonRPCRequest
+				_ = json.NewDecoder(r.Body).Decode(&req)
+				writeJSONRPCResult(t, w, req.ID, map[string]any{
+					"trace": []any{map[string]any{
+						"event_id":         "event-1",
+						"event_name":       "scan.requested",
+						"event_created_at": "2026-05-13T10:00:01Z",
+						"delivery_id":      "delivery-1",
+						"delivery_status":  "delivered",
+					}},
+				})
+			},
+			wantCode:   3,
+			wantStderr: "trace[0].subscriber_type is required when delivery_id is present",
 		},
 		{
 			name: "health missing bundle fingerprint",

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -10170,7 +10170,7 @@ cli_specification:
       defaulting: If run-id is omitted, resolve the target through run.list with active-run preference.
       behavior: Run-scoped operational status projection. This is the v2 replacement for `swarm investigate run`.
     trace:
-      command: swarm trace [<run-id>] [--delivery-detail] [--since <timestamp>] [--until <timestamp>] [--limit <n>] [--cursor <cursor>] [--event-name <name> ...] [--entity-id <entity-id> ...] [--delivery-status <pending|in_progress|delivered|failed|dead_letter> ...] [--subscriber-id <id> ...] [--subscriber-type <node|agent> ...] [--follow|-f] [--no-retry]
+      command: swarm trace [<run-id>] [--delivery-detail|--delivery-summary] [--since <timestamp>] [--until <timestamp>] [--limit <n>] [--cursor <cursor>] [--event-name <name> ...] [--entity-id <entity-id> ...] [--delivery-status <pending|in_progress|delivered|failed|dead_letter> ...] [--subscriber-id <id> ...] [--subscriber-type <node|agent> ...] [--follow|-f] [--no-retry]
       tier: must_have
       implementation_status: implemented
       owners: /v1/rpc run.trace for snapshot; /v1/ws run.subscribe_trace for --follow/-f
@@ -10215,12 +10215,19 @@ cli_specification:
           it renders delivery identity, subscriber identity, delivery status/reason, delivery lifecycle timestamps, and
           queue/execution durations derived only from same-row RunTraceRow timestamps. `--delivery-detail` is invalid
           with `--follow` and does not introduce a new API/store/runtime owner.
+          Snapshot `--delivery-summary` is a CLI-only exhaustive projection over `/v1/rpc run.trace`: it follows
+          returned `next_cursor` values until none remain, preserving run_id, since, until, filter, and page-size
+          limit while advancing only cursor. It groups rows that carry delivery_id by subscriber_type/subscriber_id
+          and delivery_status, derives queue and execution timing only from same-row RunTraceRow timestamps, treats
+          event-only rows as non-delivery trace rows, and renders point-in-time snapshot wording. `--delivery-summary`
+          is invalid with `--follow` and is mutually exclusive with `--delivery-detail`.
         proof_expectations:
         - exact /v1/rpc run.trace params for explicit run ids and omitted-run resolution through run.list
         - repeatable filter flags serialize as RunTraceFilter arrays under the single `filter` param and compose with since/until/limit/cursor
         - follow-mode repeatable filter flags serialize as RunTraceFilter arrays under the single `filter` param and are preserved across recovery requests
         - invalid --since, invalid --until, since-after-until, out-of-range --limit, blank --cursor, blank/invalid typed filters, and fixed-window snapshot controls combined with --follow fail before API/WS calls
         - --delivery-detail renders only existing RunTraceRow delivery lifecycle facts and rejects --follow before API/WS calls
+        - --delivery-summary exhausts /v1/rpc run.trace pagination across returned next_cursor values, treats --limit as page size rather than a total cap, rejects --follow and --delivery-detail before API/WS calls, fails closed on repeated/non-advancing cursors or malformed delivery rows, and renders only aggregate facts derived from existing RunTraceRow delivery fields
         - missing token fails before API calls through the shared CLI API client
         - no direct DB/store/runtime/EventBus/dashboard/Builder reads and no legacy /api, /rpc, /ws, or fallback token paths
       promoted_trace_follow_recovery_contract:

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -10217,7 +10217,8 @@ cli_specification:
           with `--follow` and does not introduce a new API/store/runtime owner.
           Snapshot `--delivery-summary` is a CLI-only exhaustive projection over `/v1/rpc run.trace`: it follows
           returned `next_cursor` values until none remain, preserving run_id, since, until, filter, and page-size
-          limit while advancing only cursor. It groups rows that carry delivery_id by subscriber_type/subscriber_id
+          limit while advancing only cursor. If the caller omits `--until`, the CLI captures one RFC3339Nano
+          point-in-time upper bound before the first request and reuses that `until` value for every page. It groups rows that carry delivery_id by subscriber_type/subscriber_id
           and delivery_status, derives queue and execution timing only from same-row RunTraceRow timestamps, treats
           event-only rows as non-delivery trace rows, and renders point-in-time snapshot wording. `--delivery-summary`
           is invalid with `--follow` and is mutually exclusive with `--delivery-detail`.
@@ -10227,7 +10228,7 @@ cli_specification:
         - follow-mode repeatable filter flags serialize as RunTraceFilter arrays under the single `filter` param and are preserved across recovery requests
         - invalid --since, invalid --until, since-after-until, out-of-range --limit, blank --cursor, blank/invalid typed filters, and fixed-window snapshot controls combined with --follow fail before API/WS calls
         - --delivery-detail renders only existing RunTraceRow delivery lifecycle facts and rejects --follow before API/WS calls
-        - --delivery-summary exhausts /v1/rpc run.trace pagination across returned next_cursor values, treats --limit as page size rather than a total cap, rejects --follow and --delivery-detail before API/WS calls, fails closed on repeated/non-advancing cursors or malformed delivery rows, and renders only aggregate facts derived from existing RunTraceRow delivery fields
+        - --delivery-summary exhausts /v1/rpc run.trace pagination across returned next_cursor values, captures and reuses a fixed until bound when the caller omits --until, treats --limit as page size rather than a total cap, rejects --follow and --delivery-detail before API/WS calls, fails closed on repeated/non-advancing cursors or malformed delivery rows, and renders only aggregate facts derived from existing RunTraceRow delivery fields
         - missing token fails before API calls through the shared CLI API client
         - no direct DB/store/runtime/EventBus/dashboard/Builder reads and no legacy /api, /rpc, /ws, or fallback token paths
       promoted_trace_follow_recovery_contract:


### PR DESCRIPTION
## Summary

Closes #1420
Part of #1411

Adds the approved remaining #1420 surface:

- `swarm trace <run-id> --delivery-summary`
- exhausts `/v1/rpc run.trace` pages until `next_cursor` is empty
- treats `--limit` as page size, not a total summary cap
- preserves `run_id`, `since`, `until`, and `filter` params while advancing only `cursor`
- groups delivery rows by `subscriber_type/subscriber_id` and delivery status
- derives queue/execution timing only from same-row `RunTraceRow` delivery timestamps
- rejects `--delivery-summary` with `--follow` and with `--delivery-detail`
- updates authoritative `platform-spec.yaml` for the new CLI surface

## Governing Context

Exact governing refs exist:

- `platform-spec.yaml` `cli_specification.command_catalog.trace`
- `platform-spec.yaml` `api_specification.method_catalog.run.trace`
- `platform-spec.yaml` `RunTraceRow`, `RunTraceListResult`, and `RunTraceFilter`
- `openrpc.json` `run.trace`, `RunTraceRow`, and `RunTraceListResult.next_cursor`
- #1420 refreshed pre-audit and Gate B approval

Canonical owner after the change remains `/v1/rpc run.trace`, backed by `internal/store/run_debug_read_surface.go` / SQLite parity owner and exposed through `internal/apiv1/operator_read.go`.

## Owner / Migration Notes

This is a CLI projection, not a runtime/API migration.

New supported CLI consumer: `cmd/swarm/diagnostics.go` `swarm trace --delivery-summary`.

Old invalid paths remain invalid:

- first-page-only summary labeled as exhaustive
- direct CLI DB/store/runtime/EventBus/dashboard reads
- CLI reconstruction from separate event/delivery/session/turn list owners
- raw route-target exposure
- `swarm run`, trace follow streaming, event view, agent lifecycle diagnostics, concurrency/backpressure, and status hints

Production paths checked for surviving old behavior: `cmd/swarm/diagnostics.go`, `cmd/swarm/run_command.go`, and `cmd/swarm/cli.go`. The trace summary path uses only the shared v1 API client and `/v1/rpc run.trace`.

Migration completeness: complete for the approved #1420 remaining `swarm trace --delivery-summary` class. Parent #1411 remains open for separate sibling concepts.

## Validation

- `go test ./cmd/swarm -run 'TestTrace|TestDiagnosticsRejectInvalidInputBeforeRequest|TestDiagnosticsRequireAPITokenBeforeRequest|TestDiagnosticsFailClosedOnAPIAndMalformedResults' -count=1`
- `go test ./cmd/swarm -count=1`
- `go test ./internal/apiv1 -run 'TestOperatorObservabilityHandlers|TestOpenRPCReadOnlyRuntimeProbes|TestSQLiteObservabilitySupportedSurface' -count=1`
- `go test ./internal/store -run 'TestRunDebugTracePage|TestSQLiteRunDebugTracePage' -count=1`
- `go test ./...`
- `git diff --check`
- static no-bypass scan over `cmd/swarm/diagnostics.go`, `cmd/swarm/run_command.go`, and `cmd/swarm/cli.go`
