### PR TITLE
[agent-b][issue #1437] Add agent delivery lifecycle CLI

### DIFF
--- a/cmd/swarm/agent_deliveries_test.go
+++ b/cmd/swarm/agent_deliveries_test.go
@@ -1,0 +1,403 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+func TestAgentDeliveriesUsesAgentDeliveryLifecycleAndRendersRows(t *testing.T) {
+	t.Setenv("SWARM_API_TOKEN", "test-token")
+	var captured jsonRPCRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/rpc" {
+			t.Errorf("path = %q, want /v1/rpc", r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer test-token" {
+			t.Errorf("Authorization = %q, want bearer token", got)
+		}
+		if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
+			t.Errorf("decode request: %v", err)
+		}
+		writeJSONRPCResult(t, w, captured.ID, validAgentDeliveryLifecycleResult())
+	}))
+	defer server.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{
+		"agent", "deliveries", " agent-1 ",
+		"--run-id", "run-1",
+		"--delivery-status", "pending",
+		"--delivery-status", "delivered",
+		"--limit", "2",
+		"--cursor", "cursor-1",
+	}, &stdout, &stderr, testRootCommandOptions(server))
+	if code != 0 {
+		t.Fatalf("code = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	if captured.JSONRPC != "2.0" || captured.Method != "agent.delivery_lifecycle" {
+		t.Fatalf("request jsonrpc/method = %s/%s, want 2.0/agent.delivery_lifecycle", captured.JSONRPC, captured.Method)
+	}
+	assertAgentDeliveriesParams(t, captured.Params, map[string]any{
+		"agent_id":        "agent-1",
+		"run_id":          "run-1",
+		"delivery_status": []string{"pending", "delivered"},
+		"limit":           float64(2),
+		"cursor":          "cursor-1",
+	})
+	for _, want := range []string{
+		"Agent agent-1 deliveries",
+		"delivery: delivery_id=delivery-1 event_name=platform.agent_directive event_id=event-1 run_id=run-1 entity_id=entity-1 status=delivered delivery_created_at=2026-05-18T03:01:00Z delivery_started_at=2026-05-18T03:02:00Z delivery_delivered_at=2026-05-18T03:03:00Z retry_count=1 reason_code=- last_error=-",
+		"delivery: delivery_id=delivery-2 event_name=platform.agent_followup event_id=event-2 run_id=- entity_id=- status=pending delivery_created_at=2026-05-18T03:04:00Z delivery_started_at=- delivery_delivered_at=- retry_count=0 reason_code=queued last_error=waiting",
+		"next_cursor=cursor-2",
+	} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("stdout missing %q:\n%s", want, stdout.String())
+		}
+	}
+	for _, notWant := range []string{"run.trace", "event.get", "agent.diagnose", "agent.delivery_diagnostics", "delivery_target_route", "dead_letters", "retry_policy"} {
+		if strings.Contains(stdout.String(), notWant) {
+			t.Fatalf("stdout contains split or forbidden concept %q:\n%s", notWant, stdout.String())
+		}
+	}
+	if strings.TrimSpace(stderr.String()) != "" {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+}
+
+func TestAgentDeliveriesEmptyResult(t *testing.T) {
+	t.Setenv("SWARM_API_TOKEN", "test-token")
+	var captured jsonRPCRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
+			t.Errorf("decode request: %v", err)
+		}
+		writeJSONRPCResult(t, w, captured.ID, map[string]any{"agent_id": "agent-1", "deliveries": []any{}})
+	}))
+	defer server.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"agent", "deliveries", "agent-1"}, &stdout, &stderr, testRootCommandOptions(server))
+	if code != 0 {
+		t.Fatalf("code = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	if captured.Method != "agent.delivery_lifecycle" {
+		t.Fatalf("method = %q, want agent.delivery_lifecycle", captured.Method)
+	}
+	assertAgentDeliveriesParams(t, captured.Params, map[string]any{"agent_id": "agent-1"})
+	if !strings.Contains(stdout.String(), "No deliveries match the filter.") {
+		t.Fatalf("stdout = %q, want empty result message", stdout.String())
+	}
+	if strings.Contains(stdout.String(), "next_cursor=") {
+		t.Fatalf("stdout rendered absent cursor:\n%s", stdout.String())
+	}
+	if strings.TrimSpace(stderr.String()) != "" {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+}
+
+func TestAgentDeliveriesJSONPreservesAPIResultShape(t *testing.T) {
+	t.Setenv("SWARM_API_TOKEN", "test-token")
+	var captured jsonRPCRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
+			t.Errorf("decode request: %v", err)
+		}
+		result := validAgentDeliveryLifecycleResult()
+		result["forbidden_local_field"] = "dropped"
+		writeJSONRPCResult(t, w, captured.ID, result)
+	}))
+	defer server.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"agent", "deliveries", "agent-1", "--json"}, &stdout, &stderr, testRootCommandOptions(server))
+	if code != 0 {
+		t.Fatalf("code = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	if captured.Method != "agent.delivery_lifecycle" {
+		t.Fatalf("method = %q, want agent.delivery_lifecycle", captured.Method)
+	}
+	var decoded map[string]any
+	if err := json.Unmarshal(stdout.Bytes(), &decoded); err != nil {
+		t.Fatalf("decode stdout JSON: %v\n%s", err, stdout.String())
+	}
+	if decoded["agent_id"] != "agent-1" {
+		t.Fatalf("agent_id = %#v, want agent-1", decoded["agent_id"])
+	}
+	deliveries, ok := decoded["deliveries"].([]any)
+	if !ok || len(deliveries) != 2 {
+		t.Fatalf("deliveries = %#v, want two rows", decoded["deliveries"])
+	}
+	if decoded["next_cursor"] != "cursor-2" {
+		t.Fatalf("next_cursor = %#v, want cursor-2", decoded["next_cursor"])
+	}
+	for _, wrapper := range []string{"agent", "delivery_lifecycle", "forbidden_local_field"} {
+		if _, ok := decoded[wrapper]; ok {
+			t.Fatalf("json output contains wrapper or non-owner field %q: %#v", wrapper, decoded)
+		}
+	}
+	if row, ok := deliveries[0].(map[string]any); !ok || row["delivery_id"] != "delivery-1" || row["retry_count"] != float64(1) {
+		t.Fatalf("first row = %#v", deliveries[0])
+	}
+	if strings.TrimSpace(stderr.String()) != "" {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+}
+
+func TestAgentDeliveriesRejectsInvalidInputBeforeRequest(t *testing.T) {
+	t.Setenv("SWARM_API_TOKEN", "test-token")
+	var calls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		writeJSONRPCResult(t, w, "unexpected", validAgentDeliveryLifecycleResult())
+	}))
+	defer server.Close()
+
+	for _, tc := range []struct {
+		name       string
+		args       []string
+		wantStderr string
+	}{
+		{name: "missing id", args: []string{"agent", "deliveries"}, wantStderr: "accepts 1 arg(s)"},
+		{name: "blank id", args: []string{"agent", "deliveries", "  "}, wantStderr: "agent id is required"},
+		{name: "invalid id", args: []string{"agent", "deliveries", "bad id!"}, wantStderr: "agent id must match OpaqueId pattern"},
+		{name: "extra arg", args: []string{"agent", "deliveries", "agent-1", "extra"}, wantStderr: "accepts 1 arg(s)"},
+		{name: "unsupported flag", args: []string{"agent", "deliveries", "agent-1", "--unknown"}, wantStderr: "unknown flag"},
+		{name: "limit too small", args: []string{"agent", "deliveries", "agent-1", "--limit", "0"}, wantStderr: "--limit must be between 1 and 200"},
+		{name: "limit too large", args: []string{"agent", "deliveries", "agent-1", "--limit", "201"}, wantStderr: "--limit must be between 1 and 200"},
+		{name: "blank cursor", args: []string{"agent", "deliveries", "agent-1", "--cursor", ""}, wantStderr: "--cursor is required when provided"},
+		{name: "blank run id", args: []string{"agent", "deliveries", "agent-1", "--run-id", ""}, wantStderr: "--run-id is required when provided"},
+		{name: "invalid run id", args: []string{"agent", "deliveries", "agent-1", "--run-id", "bad id!"}, wantStderr: "--run-id must match OpaqueId pattern"},
+		{name: "blank status", args: []string{"agent", "deliveries", "agent-1", "--delivery-status", ""}, wantStderr: "--delivery-status must not be empty"},
+		{name: "invalid status", args: []string{"agent", "deliveries", "agent-1", "--delivery-status", "done"}, wantStderr: "--delivery-status must be one of"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			calls.Store(0)
+			var stdout, stderr bytes.Buffer
+			code := executeRootCommandWithOptions(context.Background(), t.TempDir(), tc.args, &stdout, &stderr, testRootCommandOptions(server))
+			if code != cliExitValidation {
+				t.Fatalf("code = %d, want %d stdout=%s stderr=%s", code, cliExitValidation, stdout.String(), stderr.String())
+			}
+			if !strings.Contains(stderr.String(), tc.wantStderr) {
+				t.Fatalf("stderr = %q, want substring %q", stderr.String(), tc.wantStderr)
+			}
+			if calls.Load() != 0 {
+				t.Fatalf("RPC calls = %d, want 0", calls.Load())
+			}
+		})
+	}
+}
+
+func TestAgentDeliveriesFailClosedWithoutToken(t *testing.T) {
+	t.Setenv("SWARM_API_TOKEN", "")
+	var calls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		writeJSONRPCResult(t, w, "unexpected", validAgentDeliveryLifecycleResult())
+	}))
+	defer server.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"agent", "deliveries", "agent-1"}, &stdout, &stderr, testRootCommandOptions(server))
+	if code != cliExitAuth {
+		t.Fatalf("code = %d, want %d stdout=%s stderr=%s", code, cliExitAuth, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "SWARM_API_TOKEN is required") {
+		t.Fatalf("stderr = %q, want token failure", stderr.String())
+	}
+	if calls.Load() != 0 {
+		t.Fatalf("RPC calls = %d, want 0", calls.Load())
+	}
+}
+
+func TestAgentDeliveriesFailClosedOnRPCAndMalformedResponses(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		handler    http.HandlerFunc
+		wantCode   int
+		wantStderr string
+	}{
+		{
+			name: "http auth failure",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				http.Error(w, "unauthorized", http.StatusUnauthorized)
+			},
+			wantCode:   cliExitAuth,
+			wantStderr: "v1 RPC HTTP 401",
+		},
+		{
+			name: "agent not found",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				var req jsonRPCRequest
+				_ = json.NewDecoder(r.Body).Decode(&req)
+				writeAgentJSONRPCError(t, w, req.ID, "AGENT_NOT_FOUND")
+			},
+			wantCode:   cliExitNotFound,
+			wantStderr: "AGENT_NOT_FOUND: Application error: AGENT_NOT_FOUND",
+		},
+		{
+			name: "api invalid params",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				var req jsonRPCRequest
+				_ = json.NewDecoder(r.Body).Decode(&req)
+				writeAgentInvalidParamsJSONRPCError(t, w, req.ID, "Invalid params: delivery_status")
+			},
+			wantCode:   cliExitRuntime,
+			wantStderr: "Invalid params: delivery_status",
+		},
+		{
+			name: "missing deliveries",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				var req jsonRPCRequest
+				_ = json.NewDecoder(r.Body).Decode(&req)
+				writeJSONRPCResult(t, w, req.ID, map[string]any{"agent_id": "agent-1"})
+			},
+			wantCode:   cliExitRuntime,
+			wantStderr: "malformed agent.delivery_lifecycle result: deliveries is required",
+		},
+		{
+			name: "missing delivery id",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				var req jsonRPCRequest
+				_ = json.NewDecoder(r.Body).Decode(&req)
+				result := validAgentDeliveryLifecycleResult()
+				row := result["deliveries"].([]map[string]any)[0]
+				delete(row, "delivery_id")
+				writeJSONRPCResult(t, w, req.ID, result)
+			},
+			wantCode:   cliExitRuntime,
+			wantStderr: "malformed agent.delivery_lifecycle result: deliveries[0].delivery_id is required",
+		},
+		{
+			name: "missing retry count",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				var req jsonRPCRequest
+				_ = json.NewDecoder(r.Body).Decode(&req)
+				result := validAgentDeliveryLifecycleResult()
+				row := result["deliveries"].([]map[string]any)[0]
+				delete(row, "retry_count")
+				writeJSONRPCResult(t, w, req.ID, result)
+			},
+			wantCode:   cliExitRuntime,
+			wantStderr: "malformed agent.delivery_lifecycle result: deliveries[0].retry_count is required",
+		},
+		{
+			name: "negative retry count",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				var req jsonRPCRequest
+				_ = json.NewDecoder(r.Body).Decode(&req)
+				result := validAgentDeliveryLifecycleResult()
+				row := result["deliveries"].([]map[string]any)[0]
+				row["retry_count"] = -1
+				writeJSONRPCResult(t, w, req.ID, result)
+			},
+			wantCode:   cliExitRuntime,
+			wantStderr: "malformed agent.delivery_lifecycle result: deliveries[0].retry_count must be non-negative",
+		},
+		{
+			name: "invalid timestamp",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				var req jsonRPCRequest
+				_ = json.NewDecoder(r.Body).Decode(&req)
+				result := validAgentDeliveryLifecycleResult()
+				row := result["deliveries"].([]map[string]any)[0]
+				row["delivery_created_at"] = "not-time"
+				writeJSONRPCResult(t, w, req.ID, result)
+			},
+			wantCode:   cliExitRuntime,
+			wantStderr: "malformed agent.delivery_lifecycle result: deliveries[0].delivery_created_at must be an RFC3339 timestamp",
+		},
+		{
+			name: "empty next cursor",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				var req jsonRPCRequest
+				_ = json.NewDecoder(r.Body).Decode(&req)
+				result := validAgentDeliveryLifecycleResult()
+				result["next_cursor"] = ""
+				writeJSONRPCResult(t, w, req.ID, result)
+			},
+			wantCode:   cliExitRuntime,
+			wantStderr: "malformed agent.delivery_lifecycle result: next_cursor is empty",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("SWARM_API_TOKEN", "test-token")
+			server := httptest.NewServer(tc.handler)
+			defer server.Close()
+
+			var stdout, stderr bytes.Buffer
+			code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"agent", "deliveries", "agent-1"}, &stdout, &stderr, testRootCommandOptions(server))
+			if code != tc.wantCode {
+				t.Fatalf("code = %d, want %d stdout=%s stderr=%s", code, tc.wantCode, stdout.String(), stderr.String())
+			}
+			if !strings.Contains(stderr.String(), tc.wantStderr) {
+				t.Fatalf("stderr = %q, want substring %q", stderr.String(), tc.wantStderr)
+			}
+		})
+	}
+}
+
+func validAgentDeliveryLifecycleResult() map[string]any {
+	return map[string]any{
+		"agent_id": "agent-1",
+		"deliveries": []map[string]any{
+			{
+				"delivery_id":           "delivery-1",
+				"event_id":              "event-1",
+				"event_name":            "platform.agent_directive",
+				"run_id":                "run-1",
+				"entity_id":             "entity-1",
+				"status":                "delivered",
+				"retry_count":           1,
+				"delivery_created_at":   "2026-05-18T03:01:00Z",
+				"delivery_started_at":   "2026-05-18T03:02:00Z",
+				"delivery_delivered_at": "2026-05-18T03:03:00Z",
+			},
+			{
+				"delivery_id":         "delivery-2",
+				"event_id":            "event-2",
+				"event_name":          "platform.agent_followup",
+				"status":              "pending",
+				"retry_count":         0,
+				"reason_code":         "queued",
+				"last_error":          "waiting",
+				"delivery_created_at": "2026-05-18T03:04:00Z",
+			},
+		},
+		"next_cursor": "cursor-2",
+	}
+}
+
+func assertAgentDeliveriesParams(t *testing.T, got map[string]any, want map[string]any) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Fatalf("params = %#v, want %#v", got, want)
+	}
+	for key, wantValue := range want {
+		gotValue, ok := got[key]
+		if !ok {
+			t.Fatalf("params missing %q: %#v", key, got)
+		}
+		switch wantTyped := wantValue.(type) {
+		case []string:
+			gotList, ok := gotValue.([]any)
+			if !ok || len(gotList) != len(wantTyped) {
+				t.Fatalf("params[%s] = %#v, want %#v", key, gotValue, wantTyped)
+			}
+			for i, item := range wantTyped {
+				if gotList[i] != item {
+					t.Fatalf("params[%s][%d] = %#v, want %q", key, i, gotList[i], item)
+				}
+			}
+		default:
+			if gotValue != wantValue {
+				t.Fatalf("params[%s] = %#v, want %#v", key, gotValue, wantValue)
+			}
+		}
+	}
+}

--- a/cmd/swarm/agents.go
+++ b/cmd/swarm/agents.go
@@ -28,6 +28,19 @@ type agentDiagnoseCommandOptions struct {
 	queueCursorSet bool
 }
 
+type agentDeliveriesCommandOptions struct {
+	apiOptions       rootCommandOptions
+	runID            string
+	deliveryStatuses []string
+	limit            int
+	cursor           string
+	asJSON           bool
+
+	runIDSet  bool
+	limitSet  bool
+	cursorSet bool
+}
+
 type agentListResult struct {
 	Agents []agentSummary `json:"agents"`
 }
@@ -48,6 +61,27 @@ type agentDiagnosisResult struct {
 	RuntimeState      *agentDiagnosisRuntimeState      `json:"runtime_state,omitempty"`
 	Active            *agentDiagnosisActive            `json:"active,omitempty"`
 	LastToolOutcome   *agentDiagnosisLastToolOutcome   `json:"last_tool_outcome,omitempty"`
+}
+
+type agentDeliveryLifecycleListResult struct {
+	AgentID    string                      `json:"agent_id"`
+	Deliveries []agentDeliveryLifecycleRow `json:"deliveries"`
+	NextCursor *string                     `json:"next_cursor,omitempty"`
+}
+
+type agentDeliveryLifecycleRow struct {
+	DeliveryID          string  `json:"delivery_id"`
+	EventID             string  `json:"event_id"`
+	EventName           string  `json:"event_name"`
+	RunID               *string `json:"run_id,omitempty"`
+	EntityID            *string `json:"entity_id,omitempty"`
+	Status              string  `json:"status"`
+	RetryCount          *int    `json:"retry_count"`
+	ReasonCode          string  `json:"reason_code,omitempty"`
+	LastError           string  `json:"last_error,omitempty"`
+	DeliveryCreatedAt   string  `json:"delivery_created_at"`
+	DeliveryStartedAt   *string `json:"delivery_started_at,omitempty"`
+	DeliveryDeliveredAt *string `json:"delivery_delivered_at,omitempty"`
 }
 
 type agentDiagnosisQueue struct {
@@ -163,11 +197,34 @@ func newAgentCommand(opts rootCommandOptions) *cobra.Command {
 	cmd.AddCommand(
 		newAgentViewCommand(opts),
 		newAgentDiagnoseCommand(opts),
+		newAgentDeliveriesCommand(opts),
 		newAgentRestartCommand(opts),
 		newAgentReplayCommand(opts),
 		newAgentReplayBacklogCommand(opts),
 		newAgentDirectiveCommand(opts),
 	)
+	return cmd
+}
+
+func newAgentDeliveriesCommand(opts rootCommandOptions) *cobra.Command {
+	deliveryOpts := agentDeliveriesCommandOptions{apiOptions: opts}
+	cmd := &cobra.Command{
+		Use:   "deliveries <agent-id>",
+		Short: "List one agent's delivery lifecycle rows through v1 RPC.",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			deliveryOpts.runIDSet = cmd.Flags().Changed("run-id")
+			deliveryOpts.limitSet = cmd.Flags().Changed("limit")
+			deliveryOpts.cursorSet = cmd.Flags().Changed("cursor")
+			return runAgentDeliveriesCommand(cmd.Context(), cmd.OutOrStdout(), cmd.ErrOrStderr(), deliveryOpts, args[0])
+		},
+	}
+	cmd.Flags().StringVar(&deliveryOpts.runID, "run-id", "", "Filter by run id")
+	cmd.Flags().StringArrayVar(&deliveryOpts.deliveryStatuses, "delivery-status", nil, "Delivery status filter; repeat to match any")
+	cmd.Flags().IntVar(&deliveryOpts.limit, "limit", 0, "Max lifecycle rows to return (1-200)")
+	cmd.Flags().StringVar(&deliveryOpts.cursor, "cursor", "", "Opaque cursor returned by the previous lifecycle result")
+	cmd.Flags().BoolVar(&deliveryOpts.asJSON, "json", false, cliOutputJSONFlagHelp)
+	bindCLIAPIConnectionFlags(cmd, &deliveryOpts.apiOptions)
 	return cmd
 }
 
@@ -257,6 +314,32 @@ func runAgentViewCommand(ctx context.Context, out, errOut io.Writer, opts rootCo
 	return nil
 }
 
+func runAgentDeliveriesCommand(ctx context.Context, out, errOut io.Writer, opts agentDeliveriesCommandOptions, agentID string) error {
+	params, err := opts.params(agentID)
+	if err != nil {
+		return returnCLIValidationError(errOut, err)
+	}
+	client, err := newCLIAPIClient(opts.apiOptions)
+	if err != nil {
+		return returnCLIAPIError(errOut, err, agentDeliveryLifecycleAPIErrorClassifier())
+	}
+	var result agentDeliveryLifecycleListResult
+	if err := client.call(ctx, "agent.delivery_lifecycle", params, &result); err != nil {
+		return returnCLIAPIError(errOut, err, agentDeliveryLifecycleAPIErrorClassifier())
+	}
+	if err := validateAgentDeliveryLifecycleListResult(result); err != nil {
+		return returnCLIAPIError(errOut, err, agentDeliveryLifecycleAPIErrorClassifier())
+	}
+	if opts.asJSON {
+		if err := json.NewEncoder(out).Encode(result); err != nil {
+			return returnCLIValidationError(errOut, fmt.Errorf("render json output: %w", err))
+		}
+		return nil
+	}
+	writeAgentDeliveryLifecycleListResult(out, result)
+	return nil
+}
+
 func runAgentDiagnoseCommand(ctx context.Context, out, errOut io.Writer, opts agentDiagnoseCommandOptions, agentID string) error {
 	params, err := opts.params(agentID)
 	if err != nil {
@@ -295,6 +378,10 @@ func agentDiagnoseAPIErrorClassifier() cliAPIErrorClassifier {
 	return cliAPIErrorClassifier{notFoundCodes: []string{"AGENT_NOT_FOUND"}}
 }
 
+func agentDeliveryLifecycleAPIErrorClassifier() cliAPIErrorClassifier {
+	return cliAPIErrorClassifier{notFoundCodes: []string{"AGENT_NOT_FOUND"}}
+}
+
 func (opts agentListCommandOptions) params() map[string]any {
 	params := map[string]any{}
 	if flow := strings.TrimSpace(opts.flow); flow != "" {
@@ -324,6 +411,48 @@ func (opts agentDiagnoseCommandOptions) params(agentID string) (map[string]any, 
 			return nil, fmt.Errorf("--queue-cursor is required when provided")
 		}
 		params["queue_cursor"] = cursor
+	}
+	return params, nil
+}
+
+func (opts agentDeliveriesCommandOptions) params(agentID string) (map[string]any, error) {
+	agentID = strings.TrimSpace(agentID)
+	if agentID == "" {
+		return nil, fmt.Errorf("agent id is required")
+	}
+	if err := validateEntityOpaqueIDArg("agent id", agentID); err != nil {
+		return nil, err
+	}
+	params := map[string]any{"agent_id": agentID}
+	if opts.runIDSet {
+		runID := strings.TrimSpace(opts.runID)
+		if runID == "" {
+			return nil, fmt.Errorf("--run-id is required when provided")
+		}
+		if err := validateEntityOpaqueIDArg("--run-id", runID); err != nil {
+			return nil, err
+		}
+		params["run_id"] = runID
+	}
+	statuses, err := traceEnumList("--delivery-status", opts.deliveryStatuses, eventObservationValidDeliveryStatuses, "pending, in_progress, delivered, failed, dead_letter")
+	if err != nil {
+		return nil, err
+	}
+	if len(statuses) > 0 {
+		params["delivery_status"] = statuses
+	}
+	if opts.limitSet {
+		if opts.limit < 1 || opts.limit > 200 {
+			return nil, fmt.Errorf("--limit must be between 1 and 200")
+		}
+		params["limit"] = opts.limit
+	}
+	if opts.cursorSet {
+		cursor := strings.TrimSpace(opts.cursor)
+		if cursor == "" {
+			return nil, fmt.Errorf("--cursor is required when provided")
+		}
+		params["cursor"] = cursor
 	}
 	return params, nil
 }
@@ -445,6 +574,88 @@ func validateAgentDiagnosisResult(result agentDiagnosisResult) error {
 		}
 		if strings.TrimSpace(outcome.TurnID) != strings.TrimSpace(result.Active.TurnID) {
 			return fmt.Errorf("malformed agent.diagnose result: last_tool_outcome.turn_id %q must match active.turn_id %q", outcome.TurnID, result.Active.TurnID)
+		}
+	}
+	return nil
+}
+
+func validateAgentDeliveryLifecycleListResult(result agentDeliveryLifecycleListResult) error {
+	if strings.TrimSpace(result.AgentID) == "" {
+		return fmt.Errorf("malformed agent.delivery_lifecycle result: agent_id is required")
+	}
+	if err := validateEntityOpaqueIDArg("agent.delivery_lifecycle result.agent_id", result.AgentID); err != nil {
+		return fmt.Errorf("malformed agent.delivery_lifecycle result: %w", err)
+	}
+	if result.Deliveries == nil {
+		return fmt.Errorf("malformed agent.delivery_lifecycle result: deliveries is required")
+	}
+	if result.NextCursor != nil && strings.TrimSpace(*result.NextCursor) == "" {
+		return fmt.Errorf("malformed agent.delivery_lifecycle result: next_cursor is empty")
+	}
+	for i, delivery := range result.Deliveries {
+		if err := validateAgentDeliveryLifecycleRow(delivery, i); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateAgentDeliveryLifecycleRow(row agentDeliveryLifecycleRow, index int) error {
+	prefix := fmt.Sprintf("deliveries[%d]", index)
+	requiredOpaque := []struct {
+		field string
+		value string
+	}{
+		{field: "delivery_id", value: row.DeliveryID},
+		{field: "event_id", value: row.EventID},
+	}
+	for _, item := range requiredOpaque {
+		if strings.TrimSpace(item.value) == "" {
+			return fmt.Errorf("malformed agent.delivery_lifecycle result: %s.%s is required", prefix, item.field)
+		}
+		if err := validateEntityOpaqueIDArg("agent.delivery_lifecycle result."+prefix+"."+item.field, item.value); err != nil {
+			return fmt.Errorf("malformed agent.delivery_lifecycle result: %w", err)
+		}
+	}
+	if strings.TrimSpace(row.EventName) == "" {
+		return fmt.Errorf("malformed agent.delivery_lifecycle result: %s.event_name is required", prefix)
+	}
+	if optional := row.RunID; optional != nil {
+		if strings.TrimSpace(*optional) == "" {
+			return fmt.Errorf("malformed agent.delivery_lifecycle result: %s.run_id is empty", prefix)
+		}
+		if err := validateEntityOpaqueIDArg("agent.delivery_lifecycle result."+prefix+".run_id", *optional); err != nil {
+			return fmt.Errorf("malformed agent.delivery_lifecycle result: %w", err)
+		}
+	}
+	if optional := row.EntityID; optional != nil {
+		if strings.TrimSpace(*optional) == "" {
+			return fmt.Errorf("malformed agent.delivery_lifecycle result: %s.entity_id is empty", prefix)
+		}
+		if err := validateEntityOpaqueIDArg("agent.delivery_lifecycle result."+prefix+".entity_id", *optional); err != nil {
+			return fmt.Errorf("malformed agent.delivery_lifecycle result: %w", err)
+		}
+	}
+	if _, ok := eventObservationValidDeliveryStatuses[strings.TrimSpace(row.Status)]; !ok {
+		return fmt.Errorf("malformed agent.delivery_lifecycle result: %s.status=%q is not a valid DeliveryStatus", prefix, row.Status)
+	}
+	if row.RetryCount == nil {
+		return fmt.Errorf("malformed agent.delivery_lifecycle result: %s.retry_count is required", prefix)
+	}
+	if *row.RetryCount < 0 {
+		return fmt.Errorf("malformed agent.delivery_lifecycle result: %s.retry_count must be non-negative", prefix)
+	}
+	if err := validateAgentDeliveryLifecycleTimestamp(prefix+".delivery_created_at", row.DeliveryCreatedAt); err != nil {
+		return err
+	}
+	if timestamp := row.DeliveryStartedAt; timestamp != nil {
+		if err := validateAgentDeliveryLifecycleTimestamp(prefix+".delivery_started_at", *timestamp); err != nil {
+			return err
+		}
+	}
+	if timestamp := row.DeliveryDeliveredAt; timestamp != nil {
+		if err := validateAgentDeliveryLifecycleTimestamp(prefix+".delivery_delivered_at", *timestamp); err != nil {
+			return err
 		}
 	}
 	return nil
@@ -574,6 +785,17 @@ func validateAgentSummary(agent agentSummary) error {
 	return nil
 }
 
+func validateAgentDeliveryLifecycleTimestamp(field, value string) error {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return fmt.Errorf("malformed agent.delivery_lifecycle result: %s is required", field)
+	}
+	if _, err := time.Parse(time.RFC3339Nano, value); err != nil {
+		return fmt.Errorf("malformed agent.delivery_lifecycle result: %s must be an RFC3339 timestamp: %w", field, err)
+	}
+	return nil
+}
+
 func validateAgentDiagnosisTimestamp(field, value string) error {
 	value = strings.TrimSpace(value)
 	if value == "" {
@@ -615,6 +837,36 @@ func writeAgentListResult(out io.Writer, result agentListResult) {
 			agent.ConversationMode,
 			agent.SessionScope,
 		)
+	}
+}
+
+func writeAgentDeliveryLifecycleListResult(out io.Writer, result agentDeliveryLifecycleListResult) {
+	if out == nil {
+		return
+	}
+	fmt.Fprintf(out, "Agent %s deliveries\n", result.AgentID)
+	if len(result.Deliveries) == 0 {
+		fmt.Fprintln(out, "No deliveries match the filter.")
+	} else {
+		for _, delivery := range result.Deliveries {
+			fmt.Fprintf(out, "delivery: delivery_id=%s event_name=%s event_id=%s run_id=%s entity_id=%s status=%s delivery_created_at=%s delivery_started_at=%s delivery_delivered_at=%s retry_count=%d reason_code=%s last_error=%s\n",
+				delivery.DeliveryID,
+				delivery.EventName,
+				delivery.EventID,
+				agentOptionalStringDash(delivery.RunID),
+				agentOptionalStringDash(delivery.EntityID),
+				delivery.Status,
+				delivery.DeliveryCreatedAt,
+				agentOptionalStringDash(delivery.DeliveryStartedAt),
+				agentOptionalStringDash(delivery.DeliveryDeliveredAt),
+				*delivery.RetryCount,
+				agentDash(delivery.ReasonCode),
+				agentDash(delivery.LastError),
+			)
+		}
+	}
+	if result.NextCursor != nil {
+		fmt.Fprintf(out, "next_cursor=%s\n", strings.TrimSpace(*result.NextCursor))
 	}
 }
 

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -10607,6 +10607,47 @@ cli_specification:
       - --json preserves the AgentDiagnosis result shape without adding token usage, failures, dead letters, full runtime_state enum, top-level watchdog, run_id, bundle_version, dashboard state, or richer per-tool diagnostics
       - AGENT_NOT_FOUND, invalid params, HTTP failures, and malformed AgentDiagnosis responses fail closed with tested exit codes
       - no direct DB/store/runtime/EventBus/agentcontrol/dashboard/Builder reads and no legacy /api/*, /rpc, /api/rpc, /ws, /api/ws, conversation, run, trace, agent.get, or agent.list method usage
+    agent_deliveries:
+      command: swarm agent deliveries <agent-id> [--run-id <run-id>] [--delivery-status <pending|in_progress|delivered|failed|dead_letter> ...] [--limit <n>] [--cursor <cursor>] [--json]
+      tier: should_have
+      implementation_status: implemented
+      owner: /v1/rpc agent.delivery_lifecycle
+      behavior: >
+        Read-only single-agent delivery lifecycle CLI consumer. The CLI sends only
+        agent_id, optional run_id, optional repeated delivery_status, optional
+        limit, and optional cursor to /v1/rpc agent.delivery_lifecycle. Pagination
+        is caller-driven one-page list semantics: the CLI renders the returned
+        next_cursor when present but does not exhaust pages or aggregate rows.
+        Human output renders only AgentDeliveryLifecycleList / AgentDeliveryLifecycleRow
+        facts returned by the API owner. --json emits the AgentDeliveryLifecycleList
+        result shape exactly with no CLI wrapper and no reconstructed fields.
+        The CLI MUST NOT synthesize lifecycle rows from run.trace, event.get,
+        event.list, agent.diagnose, agent.delivery_diagnostics, DB/store reads,
+        runtime memory, EventBus state, dashboard/Builder helpers, logs, receipts,
+        or CLI-local state.
+      output:
+        header: Agent <agent-id> deliveries
+        empty: No deliveries match the filter.
+        row_fields: delivery_id, event_name, event_id, run_id, entity_id, status, delivery_created_at, delivery_started_at, delivery_delivered_at, retry_count, reason_code, last_error
+        pagination: next_cursor=<cursor> when the owner returns a cursor
+        json: --json emits AgentDeliveryLifecycleList exactly, with no CLI wrapper
+      exit_codes:
+        success: 0
+        cli_validation: 2
+        transport_or_malformed_response: 3
+        auth_or_missing_token: 4
+        not_found: 5
+      not_found_errors:
+      - AGENT_NOT_FOUND
+      proof_expectations:
+      - exact /v1/rpc agent.delivery_lifecycle call with agent_id plus run_id, delivery_status, limit, and cursor only when explicitly provided
+      - repeated --delivery-status serializes as the canonical delivery_status array and rejects values outside pending, in_progress, delivered, failed, and dead_letter before any API request
+      - --run-id, --limit, and --cursor validate before any API request; --limit must be in the API-owned 1..200 range and an explicitly blank cursor or run id is invalid
+      - human output renders only API-owned AgentDeliveryLifecycleRow facts, including optional fields as dash placeholders and next_cursor when present
+      - empty results render an explicit no-match line
+      - --json preserves the AgentDeliveryLifecycleList result shape without adding wrappers, aggregates, route-targets, dead-letter records, retry-policy recommendations, status hints, or reconstructed fields
+      - AGENT_NOT_FOUND, invalid params, HTTP failures, and malformed AgentDeliveryLifecycleList / AgentDeliveryLifecycleRow responses fail closed with tested exit codes
+      - no direct DB/store/runtime/EventBus/agentcontrol/dashboard/Builder reads and no legacy /api/*, /rpc, /api/rpc, /ws, /api/ws, run.trace, event.get, event.list, agent.diagnose, or agent.delivery_diagnostics method usage
     agent_restart:
       command: swarm agent restart <agent-id> [--idempotency-key <key>]
       tier: should_have

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -10637,8 +10637,8 @@ cli_specification:
         transport_or_malformed_response: 3
         auth_or_missing_token: 4
         not_found: 5
-      not_found_errors:
-      - AGENT_NOT_FOUND
+        not_found_errors:
+        - AGENT_NOT_FOUND
       proof_expectations:
       - exact /v1/rpc agent.delivery_lifecycle call with agent_id plus run_id, delivery_status, limit, and cursor only when explicitly provided
       - repeated --delivery-status serializes as the canonical delivery_status array and rejects values outside pending, in_progress, delivered, failed, and dead_letter before any API request


### PR DESCRIPTION
## Summary

Adds the supported `swarm agent deliveries <agent-id>` CLI consumer for the already-promoted `/v1/rpc agent.delivery_lifecycle` owner.

The command maps only the approved owner params (`agent_id`, optional `run_id`, repeated `delivery_status`, optional `limit`, optional `cursor`), renders caller-driven one-page results with `next_cursor`, and emits exact `AgentDeliveryLifecycleList` JSON when `--json` is used.

Closes #1437
Part of #1411

## Governing refs and gate

- `platform-spec.yaml` `api_specification.method_catalog.agent.delivery_lifecycle`
- `platform-spec.yaml` schemas `AgentDeliveryLifecycleList` / `AgentDeliveryLifecycleRow`
- `platform-spec.yaml` `cli_specification.command_catalog.agent_deliveries`
- `openrpc.json` `agent.delivery_lifecycle`, `AgentDeliveryLifecycleList`, and `AgentDeliveryLifecycleRow`
- Pre-audit: https://github.com/division-sh/swarm/issues/1437#issuecomment-4745926722
- Gate approval: https://github.com/division-sh/swarm/issues/1437#issuecomment-4746194274

## Semantic migration

- New canonical CLI consumer: `swarm agent deliveries <agent-id>`.
- Canonical owner consumed by the CLI: `/v1/rpc agent.delivery_lifecycle`.
- Old/non-authoritative paths remain invalid for this command: `run.trace`, `event.get`, `event.list`, `agent.diagnose`, `agent.delivery_diagnostics`, direct DB/store/runtime/EventBus reads, dashboard/Builder helpers, logs, receipts, and CLI-local state.
- Production paths checked for surviving old behavior: the new command path calls only `agent.delivery_lifecycle`; no API/store/OpenRPC source-owner changes are made.
- Migration complete for the #1437 CLI-consumer class. Parent #1411 remains for lead closeout decision.

## Verification

- `go test ./cmd/swarm -run 'TestAgentDeliveries|TestAgentDiagnose|TestAgentsList|TestAgentView|TestCLIAPIConnectionFlagsSurfaceAndIsolation' -count=1`
- `go test ./internal/apiv1 -run 'TestOperatorAgentConversationHandlersExposeReadOwner|TestOperatorAgentDeliveryLifecycleFailsClosedOnMalformedOwnerData|TestOperatorAgentDeliveryLifecycleRejectsBadCursorAndStatuses|TestOpenRPCReadOnlyRuntimeProbes|TestSQLiteAgentDeliveryLifecycleOwnerBacksSupportedAPISurface' -count=1`
- `go test ./internal/store -run 'TestOperatorAgentReadSurfaceLoadAgentDeliveryLifecyclePostgres|TestSQLiteRuntimeStoreLoadAgentDeliveryLifecycle' -count=1`
- `go test ./cmd/swarm -count=1`
- `go run ./cmd/swarm-openrpc-gen --check`
- `git diff --check`
- `go test ./...`