### PR TITLE
[agent-a][issue #1451] Add flow package import completeness checks

### DIFF
--- a/internal/runtime/bootverify/checks.go
+++ b/internal/runtime/bootverify/checks.go
@@ -124,6 +124,9 @@ type checkerContext struct {
 	nodeStateSchemaLoaded   bool
 	nodeStateSchemaFindings []Finding
 
+	flowPackageImportLoaded   bool
+	flowPackageImportFindings []Finding
+
 	accumulatorProjectionLoaded   bool
 	accumulatorProjectionFindings []Finding
 
@@ -241,6 +244,7 @@ var bootCheckRegistry = []Check{
 	{ID: "timer_validation", Severity: "error", Run: checkTimerValidation},
 	{ID: "write_pin_ownership_validation", Severity: "error", Run: checkWritePinOwnershipValidation},
 	{ID: "gate_schema_validation", Severity: "error", Run: checkGateSchemaValidation},
+	{ID: "flow_package_import_completeness", Severity: SeverityHardInvalidity, Run: checkFlowPackageImportCompleteness},
 	{ID: "input_pin_wiring", Severity: "warning", Run: checkInputPinWiring},
 	{ID: "pin_target_resolution", Severity: "error", Run: checkPinTargetResolution},
 	{ID: "redundant_in_topology_select_entity", Severity: "warning", Run: checkRedundantInTopologySelectEntity},

--- a/internal/runtime/bootverify/flow_data_access_test.go
+++ b/internal/runtime/bootverify/flow_data_access_test.go
@@ -66,8 +66,8 @@ func TestRun_ValidatesFlowDataAccessDeclarations(t *testing.T) {
 }
 
 func TestBootCheckRegistry_HasFlowDataAccessCheckCount(t *testing.T) {
-	if got := len(bootCheckRegistry); got != 54 {
-		t.Fatalf("bootCheckRegistry count = %d, want 54", got)
+	if got := len(bootCheckRegistry); got != 55 {
+		t.Fatalf("bootCheckRegistry count = %d, want 55", got)
 	}
 }
 

--- a/internal/runtime/bootverify/flow_package_import_completeness_checks.go
+++ b/internal/runtime/bootverify/flow_package_import_completeness_checks.go
@@ -1,0 +1,180 @@
+package bootverify
+
+import (
+	"fmt"
+	"path"
+	"sort"
+	"strings"
+
+	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
+	"github.com/division-sh/swarm/internal/runtime/semanticview"
+)
+
+func checkFlowPackageImportCompleteness(c *checkerContext) []Finding {
+	if c.flowPackageImportLoaded {
+		return c.flowPackageImportFindings
+	}
+	c.flowPackageImportLoaded = true
+	c.flowPackageImportFindings = flowPackageImportCompleteness(c.source)
+	return c.flowPackageImportFindings
+}
+
+func flowPackageImportCompleteness(source semanticview.Source) []Finding {
+	scopes := source.ProjectScopes()
+	if len(scopes) == 0 {
+		return nil
+	}
+	scopeByKey := make(map[string]semanticview.ProjectScope, len(scopes))
+	for _, scope := range scopes {
+		key := normalizePackageKey(scope.Key)
+		if key == "" {
+			continue
+		}
+		scope.Key = key
+		scopeByKey[key] = scope
+	}
+
+	var findings []Finding
+	for _, parent := range scopes {
+		parent.Key = normalizePackageKey(parent.Key)
+		for _, importSite := range flowPackageImportSites(parent) {
+			child, ok := scopeByKey[importSite.PackageKey]
+			if !ok || flowPackageRequiresEmpty(child.Manifest.Requires) {
+				continue
+			}
+			findings = append(findings, flowPackageImportCompletenessFindings(parent, child, importSite)...)
+		}
+	}
+	return findings
+}
+
+type flowPackageImportSite struct {
+	Kind       string
+	PackageKey string
+	Label      string
+	Bind       runtimecontracts.FlowPackageBind
+}
+
+func flowPackageImportSites(scope semanticview.ProjectScope) []flowPackageImportSite {
+	var sites []flowPackageImportSite
+	for _, flow := range scope.Manifest.Flows {
+		flowDir := strings.TrimSpace(flow.Flow)
+		if flowDir == "" {
+			continue
+		}
+		key := joinPackageKey(scope.Key, "flows", flowDir)
+		sites = append(sites, flowPackageImportSite{
+			Kind:       "flow",
+			PackageKey: key,
+			Label:      fmt.Sprintf("flow %s", strings.TrimSpace(flow.ID)),
+			Bind:       flow.Bind,
+		})
+	}
+	for _, ref := range scope.Manifest.ChildPackages() {
+		location := importPackageLocation(ref)
+		if location == "" {
+			continue
+		}
+		key := joinPackageKey(scope.Key, location)
+		sites = append(sites, flowPackageImportSite{
+			Kind:       "package",
+			PackageKey: key,
+			Label:      fmt.Sprintf("package %s", location),
+			Bind:       ref.Bind,
+		})
+	}
+	return sites
+}
+
+func importPackageLocation(ref runtimecontracts.ProjectPackageRef) string {
+	location := strings.TrimSpace(ref.ResolveLocation())
+	if location == "" {
+		return ""
+	}
+	location = strings.Trim(path.Clean(strings.ReplaceAll(location, "\\", "/")), "/")
+	if strings.HasSuffix(strings.ToLower(location), ".yaml") {
+		location = path.Dir(location)
+	}
+	if location == "." {
+		return ""
+	}
+	return location
+}
+
+func flowPackageImportCompletenessFindings(parent, child semanticview.ProjectScope, site flowPackageImportSite) []Finding {
+	requires := child.Manifest.Requires
+	checks := []struct {
+		kind     string
+		required []string
+		bindings map[string]string
+	}{
+		{kind: "input", required: requires.Inputs, bindings: site.Bind.Inputs},
+		{kind: "output", required: requires.Outputs, bindings: site.Bind.Outputs},
+		{kind: "policy", required: requires.Policy, bindings: site.Bind.Policy},
+		{kind: "credential", required: requires.Credentials, bindings: site.Bind.Credentials},
+	}
+
+	var findings []Finding
+	for _, check := range checks {
+		missing := missingFlowPackageBindings(check.required, check.bindings)
+		if len(missing) == 0 {
+			continue
+		}
+		findings = append(findings, Finding{
+			CheckID:  "flow_package_import_completeness",
+			Severity: SeverityHardInvalidity,
+			Message:  fmt.Sprintf("imported package %s declares required %s bindings %s, but parent %s import site %s does not bind them", child.Key, check.kind, strings.Join(missing, ", "), parent.Key, site.Label),
+			Location: child.Key,
+		})
+	}
+	return findings
+}
+
+func missingFlowPackageBindings(required []string, bindings map[string]string) []string {
+	out := make([]string, 0)
+	for _, item := range required {
+		item = strings.TrimSpace(item)
+		if item == "" {
+			continue
+		}
+		if strings.TrimSpace(bindings[item]) == "" {
+			out = append(out, item)
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+func flowPackageRequiresEmpty(requires runtimecontracts.FlowPackageRequires) bool {
+	return len(requires.Inputs) == 0 &&
+		len(requires.Outputs) == 0 &&
+		len(requires.Policy) == 0 &&
+		len(requires.Credentials) == 0 &&
+		strings.TrimSpace(requires.PlatformVersion) == ""
+}
+
+func joinPackageKey(base string, segments ...string) string {
+	parts := make([]string, 0, 1+len(segments))
+	if base = normalizePackageKey(base); base != "" && base != "." {
+		parts = append(parts, base)
+	}
+	for _, segment := range segments {
+		segment = strings.Trim(path.Clean(strings.ReplaceAll(strings.TrimSpace(segment), "\\", "/")), "/")
+		if segment == "" || segment == "." {
+			continue
+		}
+		parts = append(parts, segment)
+	}
+	if len(parts) == 0 {
+		return "."
+	}
+	return normalizePackageKey(path.Join(parts...))
+}
+
+func normalizePackageKey(key string) string {
+	key = strings.Trim(path.Clean(strings.ReplaceAll(strings.TrimSpace(key), "\\", "/")), "/")
+	if key == "" || key == "." {
+		return "."
+	}
+	return key
+}

--- a/internal/runtime/bootverify/flow_package_import_completeness_checks_test.go
+++ b/internal/runtime/bootverify/flow_package_import_completeness_checks_test.go
@@ -1,0 +1,177 @@
+package bootverify
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
+	"github.com/division-sh/swarm/internal/runtime/semanticview"
+)
+
+func TestRun_FlowPackageImportCompletenessAcceptsFullyBoundFlowPackage(t *testing.T) {
+	root := writeFlowPackageImportCompletenessFixture(t, flowPackageImportFixtureOptions{
+		importKind: "flow",
+		bind:       allFlowPackageBindingsYAML(),
+		requires:   allFlowPackageRequiresYAML(),
+	})
+	source := loadFlowPackageImportCompletenessSource(t, root)
+
+	report := Run(context.Background(), source, Options{})
+
+	if reportContains(report.HardInvalidities(), "flow_package_import_completeness", "imported package") {
+		t.Fatalf("unexpected flow_package_import_completeness invalidity: %#v", report.HardInvalidities())
+	}
+}
+
+func TestRun_FlowPackageImportCompletenessFailsClosedOnMissingBindings(t *testing.T) {
+	tests := []struct {
+		name        string
+		bind        string
+		wantMessage string
+	}{
+		{
+			name:        "input",
+			bind:        strings.ReplaceAll(allFlowPackageBindingsYAML(), "        work.requested: parent.work_requested\n", ""),
+			wantMessage: "required input bindings work.requested",
+		},
+		{
+			name:        "output",
+			bind:        strings.ReplaceAll(allFlowPackageBindingsYAML(), "        work.completed: parent.work_completed\n", ""),
+			wantMessage: "required output bindings work.completed",
+		},
+		{
+			name:        "policy",
+			bind:        strings.ReplaceAll(allFlowPackageBindingsYAML(), "        provider.threshold: parent.policy.threshold\n", ""),
+			wantMessage: "required policy bindings provider.threshold",
+		},
+		{
+			name:        "credential",
+			bind:        strings.ReplaceAll(allFlowPackageBindingsYAML(), "        provider_token: parent_provider_token\n", ""),
+			wantMessage: "required credential bindings provider_token",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			root := writeFlowPackageImportCompletenessFixture(t, flowPackageImportFixtureOptions{
+				importKind: "flow",
+				bind:       tc.bind,
+				requires:   allFlowPackageRequiresYAML(),
+			})
+			source := loadFlowPackageImportCompletenessSource(t, root)
+
+			report := Run(context.Background(), source, Options{})
+
+			if !reportContains(report.HardInvalidities(), "flow_package_import_completeness", tc.wantMessage) {
+				t.Fatalf("expected flow_package_import_completeness %q, got %#v", tc.wantMessage, report.HardInvalidities())
+			}
+		})
+	}
+}
+
+func TestRun_FlowPackageImportCompletenessAcceptsFullyBoundProjectPackageRef(t *testing.T) {
+	root := writeFlowPackageImportCompletenessFixture(t, flowPackageImportFixtureOptions{
+		importKind: "package",
+		bind:       allFlowPackageBindingsYAML(),
+		requires:   allFlowPackageRequiresYAML(),
+	})
+	source := loadFlowPackageImportCompletenessSource(t, root)
+
+	report := Run(context.Background(), source, Options{})
+
+	if reportContains(report.HardInvalidities(), "flow_package_import_completeness", "imported package") {
+		t.Fatalf("unexpected package ref import completeness invalidity: %#v", report.HardInvalidities())
+	}
+}
+
+func TestRun_FlowPackageImportCompletenessIgnoresImportsWithoutRequires(t *testing.T) {
+	root := writeFlowPackageImportCompletenessFixture(t, flowPackageImportFixtureOptions{
+		importKind: "flow",
+		bind:       "",
+		requires:   "",
+	})
+	source := loadFlowPackageImportCompletenessSource(t, root)
+
+	report := Run(context.Background(), source, Options{})
+
+	if reportContains(report.HardInvalidities(), "flow_package_import_completeness", "imported package") {
+		t.Fatalf("unexpected import completeness invalidity for package without requires: %#v", report.HardInvalidities())
+	}
+}
+
+type flowPackageImportFixtureOptions struct {
+	importKind string
+	bind       string
+	requires   string
+}
+
+func writeFlowPackageImportCompletenessFixture(t *testing.T, opts flowPackageImportFixtureOptions) string {
+	t.Helper()
+	root := t.TempDir()
+
+	switch opts.importKind {
+	case "package":
+		writeBootverifyFixtureFile(t, filepath.Join(root, "package.yaml"), `
+name: package-import-completeness
+version: "1.0.0"
+packages:
+  - path: packages/worker
+`+opts.bind)
+		writeBootverifyFixtureFile(t, filepath.Join(root, "packages", "worker", "package.yaml"), `
+name: worker-package
+version: "1.0.0"
+`+opts.requires)
+	case "flow":
+		writeBootverifyFixtureFile(t, filepath.Join(root, "package.yaml"), `
+name: flow-import-completeness
+version: "1.0.0"
+flows:
+  - id: worker
+    flow: worker
+    mode: static
+`+opts.bind)
+		writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "worker", "package.yaml"), `
+name: worker-package
+version: "1.0.0"
+`+opts.requires)
+		writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "worker", "schema.yaml"), "name: worker\nmode: static\n")
+	default:
+		t.Fatalf("unknown import kind %q", opts.importKind)
+	}
+	writeBootverifyFixtureFile(t, filepath.Join(root, "schema.yaml"), "name: flow-import-completeness\n")
+	writeBootverifyFixtureFile(t, filepath.Join(root, "policy.yaml"), "provider:\n  threshold: 0.8\n")
+	writeBootverifyFixtureFile(t, filepath.Join(root, "tools.yaml"), "{}\n")
+	writeBootverifyFixtureFile(t, filepath.Join(root, "agents.yaml"), "{}\n")
+	writeBootverifyFixtureFile(t, filepath.Join(root, "events.yaml"), "{}\n")
+	writeBootverifyFixtureFile(t, filepath.Join(root, "nodes.yaml"), "{}\n")
+	return root
+}
+
+func loadFlowPackageImportCompletenessSource(t *testing.T, root string) semanticview.Source {
+	t.Helper()
+	bundle := loadFixtureBundleAt(t, repoRootForBootverifyTest(t), root, runtimecontracts.DefaultPlatformSpecFile(repoRootForBootverifyTest(t)))
+	return semanticview.Wrap(bundle)
+}
+
+func allFlowPackageRequiresYAML() string {
+	return `requires:
+  inputs: [work.requested]
+  outputs: [work.completed]
+  policy: [provider.threshold]
+  credentials: [provider_token]
+`
+}
+
+func allFlowPackageBindingsYAML() string {
+	return `    bind:
+      inputs:
+        work.requested: parent.work_requested
+      outputs:
+        work.completed: parent.work_completed
+      policy:
+        provider.threshold: parent.policy.threshold
+      credentials:
+        provider_token: parent_provider_token
+`
+}

--- a/internal/runtime/bootverify/report_test.go
+++ b/internal/runtime/bootverify/report_test.go
@@ -4747,8 +4747,8 @@ func TestRun_ReportsMissingRuntimeExecutorForOwnedRuntimeEvent(t *testing.T) {
 }
 
 func TestBootCheckRegistry_HasSpecCheckCount(t *testing.T) {
-	if got := len(bootCheckRegistry); got != 54 {
-		t.Fatalf("bootCheckRegistry count = %d, want 54", got)
+	if got := len(bootCheckRegistry); got != 55 {
+		t.Fatalf("bootCheckRegistry count = %d, want 55", got)
 	}
 	if got := len(supplementalChecks); got != 3 {
 		t.Fatalf("supplementalChecks count = %d, want 3", got)

--- a/internal/runtime/contracts/workflow_contract_types.go
+++ b/internal/runtime/contracts/workflow_contract_types.go
@@ -578,6 +578,7 @@ type ProjectPackageDocument struct {
 	PlatformVersion string              `yaml:"platform_version"`
 	Author          string              `yaml:"author"`
 	Description     string              `yaml:"description"`
+	Requires        FlowPackageRequires `yaml:"requires"`
 	Flows           []ProjectFlowRef    `yaml:"flows"`
 	Packages        []ProjectPackageRef `yaml:"packages"`
 	Children        []ProjectPackageRef `yaml:"children"`
@@ -629,16 +630,31 @@ type EntityFieldDecl struct {
 	UnusedReaderReason string         `yaml:"_unused_reader_reason"`
 }
 type ProjectPackageRef struct {
-	ID      string `yaml:"id"`
-	Path    string `yaml:"path"`
-	Package string `yaml:"package"`
-	Dir     string `yaml:"dir"`
+	ID      string          `yaml:"id"`
+	Path    string          `yaml:"path"`
+	Package string          `yaml:"package"`
+	Dir     string          `yaml:"dir"`
+	Bind    FlowPackageBind `yaml:"bind"`
 }
 type ProjectFlowRef struct {
-	ID        string `yaml:"id"`
-	Flow      string `yaml:"flow"`
-	Namespace string `yaml:"namespace"`
-	Mode      string `yaml:"mode"`
+	ID        string          `yaml:"id"`
+	Flow      string          `yaml:"flow"`
+	Namespace string          `yaml:"namespace"`
+	Mode      string          `yaml:"mode"`
+	Bind      FlowPackageBind `yaml:"bind"`
+}
+type FlowPackageRequires struct {
+	Inputs          []string `yaml:"inputs"`
+	Outputs         []string `yaml:"outputs"`
+	Policy          []string `yaml:"policy"`
+	Credentials     []string `yaml:"credentials"`
+	PlatformVersion string   `yaml:"platform_version"`
+}
+type FlowPackageBind struct {
+	Inputs      map[string]string `yaml:"inputs"`
+	Outputs     map[string]string `yaml:"outputs"`
+	Policy      map[string]string `yaml:"policy"`
+	Credentials map[string]string `yaml:"credentials"`
 }
 type ProjectHandoff struct {
 	Event       string `yaml:"event"`

--- a/internal/runtime/contracts/workflow_contract_yaml_test.go
+++ b/internal/runtime/contracts/workflow_contract_yaml_test.go
@@ -8,6 +8,126 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+func TestProjectPackageDocumentDecode_PreservesRequiresAndImportBinds(t *testing.T) {
+	var doc ProjectPackageDocument
+	if err := yaml.Unmarshal([]byte(`
+name: package-boundary
+version: "1.0.0"
+platform_version: ">=1.0.0"
+requires:
+  inputs: [work.requested]
+  outputs: [work.completed]
+  policy: [provider.threshold]
+  credentials: [provider_token]
+  platform_version: ">=1.6.0"
+flows:
+  - id: worker
+    flow: worker
+    bind:
+      inputs:
+        work.requested: parent.work_requested
+      outputs:
+        work.completed: parent.work_completed
+      policy:
+        provider.threshold: parent.policy.threshold
+      credentials:
+        provider_token: parent_provider_token
+packages:
+  - path: packages/child
+    bind:
+      inputs:
+        child.requested: parent.child_requested
+      outputs:
+        child.completed: parent.child_completed
+      policy:
+        child.policy: parent.policy.child
+      credentials:
+        child_token: parent_child_token
+`), &doc); err != nil {
+		t.Fatalf("yaml.Unmarshal: %v", err)
+	}
+	if got := strings.Join(doc.Requires.Inputs, ","); got != "work.requested" {
+		t.Fatalf("Requires.Inputs = %q", got)
+	}
+	if got := strings.Join(doc.Requires.Outputs, ","); got != "work.completed" {
+		t.Fatalf("Requires.Outputs = %q", got)
+	}
+	if got := strings.Join(doc.Requires.Policy, ","); got != "provider.threshold" {
+		t.Fatalf("Requires.Policy = %q", got)
+	}
+	if got := strings.Join(doc.Requires.Credentials, ","); got != "provider_token" {
+		t.Fatalf("Requires.Credentials = %q", got)
+	}
+	if got := doc.Requires.PlatformVersion; got != ">=1.6.0" {
+		t.Fatalf("Requires.PlatformVersion = %q", got)
+	}
+	if got := doc.Flows[0].Bind.Inputs["work.requested"]; got != "parent.work_requested" {
+		t.Fatalf("flow bind input = %q", got)
+	}
+	if got := doc.Flows[0].Bind.Outputs["work.completed"]; got != "parent.work_completed" {
+		t.Fatalf("flow bind output = %q", got)
+	}
+	if got := doc.Flows[0].Bind.Policy["provider.threshold"]; got != "parent.policy.threshold" {
+		t.Fatalf("flow bind policy = %q", got)
+	}
+	if got := doc.Flows[0].Bind.Credentials["provider_token"]; got != "parent_provider_token" {
+		t.Fatalf("flow bind credential = %q", got)
+	}
+	if got := doc.Packages[0].Bind.Inputs["child.requested"]; got != "parent.child_requested" {
+		t.Fatalf("package bind input = %q", got)
+	}
+}
+
+func TestProjectPackageDocumentDecode_RejectsMalformedRequiresAndBindShape(t *testing.T) {
+	tests := []struct {
+		name    string
+		body    string
+		wantErr string
+	}{
+		{
+			name: "unknown requires field",
+			body: `
+name: invalid
+requires:
+  inputz: [work.requested]
+`,
+			wantErr: "UNDEFINED-FIELD",
+		},
+		{
+			name: "bind inputs must be mapping",
+			body: `
+name: invalid
+flows:
+  - id: worker
+    flow: worker
+    bind:
+      inputs: [work.requested]
+`,
+			wantErr: "bind.inputs",
+		},
+		{
+			name: "unknown bind field",
+			body: `
+name: invalid
+packages:
+  - path: packages/child
+    bind:
+      credential: {}
+`,
+			wantErr: "UNDEFINED-FIELD",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var doc ProjectPackageDocument
+			err := yaml.Unmarshal([]byte(tc.body), &doc)
+			if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("yaml.Unmarshal error = %v, want %q", err, tc.wantErr)
+			}
+		})
+	}
+}
+
 func TestHandlerRuleEntryDecode_RejectsLegacyComputeExpressionShorthand(t *testing.T) {
 	var rule HandlerRuleEntry
 	err := yaml.Unmarshal([]byte(`

--- a/internal/runtime/contracts/workflow_contract_yaml_wave1.go
+++ b/internal/runtime/contracts/workflow_contract_yaml_wave1.go
@@ -29,6 +29,7 @@ func (p *ProjectPackageDocument) UnmarshalYAML(node *yaml.Node) error {
 		PlatformVersion string              `yaml:"platform_version"`
 		Author          string              `yaml:"author"`
 		Description     string              `yaml:"description"`
+		Requires        FlowPackageRequires `yaml:"requires"`
 		Flows           []ProjectFlowRef    `yaml:"flows"`
 		Packages        []ProjectPackageRef `yaml:"packages"`
 		Children        []ProjectPackageRef `yaml:"children"`
@@ -45,6 +46,7 @@ func (p *ProjectPackageDocument) UnmarshalYAML(node *yaml.Node) error {
 		PlatformVersion: aux.PlatformVersion,
 		Author:          aux.Author,
 		Description:     aux.Description,
+		Requires:        aux.Requires.normalized(),
 		Flows:           append([]ProjectFlowRef(nil), aux.Flows...),
 		Packages:        append([]ProjectPackageRef(nil), aux.Packages...),
 		Children:        append([]ProjectPackageRef(nil), aux.Children...),
@@ -53,6 +55,132 @@ func (p *ProjectPackageDocument) UnmarshalYAML(node *yaml.Node) error {
 		EntitySchema:    aux.EntitySchema,
 	}
 	return nil
+}
+
+func (r *FlowPackageRequires) UnmarshalYAML(node *yaml.Node) error {
+	if r == nil {
+		return nil
+	}
+	if node == nil || node.Kind == 0 {
+		*r = FlowPackageRequires{}
+		return nil
+	}
+	if node.Kind != yaml.MappingNode {
+		return fmt.Errorf("requires must be a mapping")
+	}
+	var out FlowPackageRequires
+	for i := 0; i+1 < len(node.Content); i += 2 {
+		key := strings.TrimSpace(node.Content[i].Value)
+		value := node.Content[i+1]
+		switch key {
+		case "":
+			continue
+		case "inputs":
+			if err := value.Decode(&out.Inputs); err != nil {
+				return fmt.Errorf("requires.inputs: %w", err)
+			}
+		case "outputs":
+			if err := value.Decode(&out.Outputs); err != nil {
+				return fmt.Errorf("requires.outputs: %w", err)
+			}
+		case "policy":
+			if err := value.Decode(&out.Policy); err != nil {
+				return fmt.Errorf("requires.policy: %w", err)
+			}
+		case "credentials":
+			if err := value.Decode(&out.Credentials); err != nil {
+				return fmt.Errorf("requires.credentials: %w", err)
+			}
+		case "platform_version":
+			if err := value.Decode(&out.PlatformVersion); err != nil {
+				return fmt.Errorf("requires.platform_version: %w", err)
+			}
+		default:
+			return fmt.Errorf("UNDEFINED-FIELD: requires field %q not in platform spec", key)
+		}
+	}
+	*r = out.normalized()
+	return nil
+}
+
+func (b *FlowPackageBind) UnmarshalYAML(node *yaml.Node) error {
+	if b == nil {
+		return nil
+	}
+	if node == nil || node.Kind == 0 {
+		*b = FlowPackageBind{}
+		return nil
+	}
+	if node.Kind != yaml.MappingNode {
+		return fmt.Errorf("bind must be a mapping")
+	}
+	var out FlowPackageBind
+	for i := 0; i+1 < len(node.Content); i += 2 {
+		key := strings.TrimSpace(node.Content[i].Value)
+		value := node.Content[i+1]
+		switch key {
+		case "":
+			continue
+		case "inputs":
+			if err := value.Decode(&out.Inputs); err != nil {
+				return fmt.Errorf("bind.inputs: %w", err)
+			}
+		case "outputs":
+			if err := value.Decode(&out.Outputs); err != nil {
+				return fmt.Errorf("bind.outputs: %w", err)
+			}
+		case "policy":
+			if err := value.Decode(&out.Policy); err != nil {
+				return fmt.Errorf("bind.policy: %w", err)
+			}
+		case "credentials":
+			if err := value.Decode(&out.Credentials); err != nil {
+				return fmt.Errorf("bind.credentials: %w", err)
+			}
+		default:
+			return fmt.Errorf("UNDEFINED-FIELD: bind field %q not in platform spec", key)
+		}
+	}
+	*b = out.normalized()
+	return nil
+}
+
+func (r FlowPackageRequires) normalized() FlowPackageRequires {
+	return FlowPackageRequires{
+		Inputs:          normalizeStrings(r.Inputs),
+		Outputs:         normalizeStrings(r.Outputs),
+		Policy:          normalizeStrings(r.Policy),
+		Credentials:     normalizeStrings(r.Credentials),
+		PlatformVersion: strings.TrimSpace(r.PlatformVersion),
+	}
+}
+
+func (b FlowPackageBind) normalized() FlowPackageBind {
+	return FlowPackageBind{
+		Inputs:      normalizeStringMap(b.Inputs),
+		Outputs:     normalizeStringMap(b.Outputs),
+		Policy:      normalizeStringMap(b.Policy),
+		Credentials: normalizeStringMap(b.Credentials),
+	}
+}
+
+func normalizeStringMap(in map[string]string) map[string]string {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(in))
+	for key, value := range in {
+		key = strings.TrimSpace(key)
+		value = strings.TrimSpace(value)
+		if key == "" || value == "" {
+			continue
+		}
+		out[key] = value
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
 }
 
 func (d *TypeCatalogDocument) UnmarshalYAML(node *yaml.Node) error {

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -4547,6 +4547,51 @@ flow_model:
       policy.yaml: Flow-specific config (optional — inherits root)
       prompts/: Agent prompt files (optional)
       flows/: Child flows (optional)
+    import_boundary:
+      description: >
+        Imported flow packages declare their required public interface and dependency surface in their own package.yaml
+        `requires` block. The parent import site in package.yaml must satisfy those declarations with an explicit `bind`
+        block on the corresponding `flows[]`, `packages[]`, `children[]`, or `subpackages[]` entry. This is the canonical
+        source authority for import-boundary completeness; raw same-name pins, ambient parent policy inheritance, flat
+        credential names, and wildcard reachability are not proof that a declared import requirement is satisfied.
+      requires_manifest:
+        owner: Imported package package.yaml `requires`
+        fields:
+          inputs: List of package-local input event pin names the importing parent must bind.
+          outputs: List of package-local output event pin names the importing parent must bind when the imported package
+            exposes them as required public outputs.
+          policy: List of package-local policy dependency names the importing parent must bind.
+          credentials: List of package-local credential dependency names the importing parent must bind.
+          platform_version: Optional imported package platform-version constraint. The current first slice preserves and
+            exposes this value; existing top-level `platform_version` remains the package load/admission constraint until
+            a later source-authority change promotes different runtime semantics.
+      import_site_bind:
+        owner: Parent package.yaml import site `bind`
+        locations:
+        - flows[]
+        - packages[]
+        - children[]
+        - subpackages[]
+        fields:
+          inputs: Map keyed by imported package `requires.inputs` item. Each value names the parent-facing event binding.
+          outputs: Map keyed by imported package `requires.outputs` item. Each value names the parent-facing event binding.
+          policy: Map keyed by imported package `requires.policy` item. Each value names the parent policy reference that
+            will satisfy that package-local dependency.
+          credentials: Map keyed by imported package `requires.credentials` item. Each value names the parent/deployment
+            credential reference that will satisfy that package-local dependency.
+      fail_closed_minimal_verify:
+        rule: >
+          If an imported package declares any item under `requires.inputs`, `requires.outputs`, `requires.policy`, or
+          `requires.credentials`, boot/verify must report a hard invalidity unless the parent import site provides a
+          non-empty `bind` entry for that exact item in the matching field. This first slice verifies binding presence
+          only; it does not execute runtime pin alias delivery or runtime policy/credential resolution.
+        unsupported_shapes: Unknown `requires` or `bind` fields, non-list `requires` fields, and non-map `bind` fields are
+          malformed contract input and must fail closed during contract parsing.
+      split_runtime_semantics:
+        pin_alias_delivery: Runtime delivery through `bind.inputs` / `bind.outputs` is tracked separately by #1452.
+        policy_credential_resolution: Runtime per-import policy and credential resolution is tracked separately by #1453.
+        wildcard_grants: Wildcard subtree and cross-tree grant behavior is tracked separately by #1454.
+        final_e2e_package_proof: Final multi-package marketplace-style runtime proof is tracked separately by #1455.
   nesting:
     description: 'Flows nest recursively. A flow''s package.yaml declares child flows in its flows: list. Each child is a
       directory under flows/ with the same structure. There is no depth limit. The platform discovers flows by walking the


### PR DESCRIPTION
Closes #1451

## Summary

This PR implements the approved first-slice boundary for flow-package import completeness:

- Promotes the authoritative `requires` / import-site `bind` contract into `platform-spec.yaml#flow_model.flow_package.import_boundary`.
- Adds typed `requires` and `bind` fields to the package manifest model and YAML parser.
- Adds a bootverify hard invalidity check that fails closed when an imported package declares required inputs, outputs, policy, or credentials and the parent import site does not provide the corresponding non-empty binding.
- Adds parser/model and bootverify regression tests for valid bindings, malformed shapes, missing bindings, and authored imports without `requires`.

## Governing Refs

- Source authority: `platform-spec.yaml#flow_model.flow_package.import_boundary`
- Binding issue/gate context: #1451 and parent #1450
- Explicit sibling splits: #1452 runtime pin alias delivery, #1453 runtime per-import policy/credential resolution, #1454 wildcard subtree grants, #1455 final E2E package proof

## Semantic Migration

- New canonical owner: `platform-spec.yaml#flow_model.flow_package.import_boundary`, consumed by `internal/runtime/contracts` package manifest parsing/model preservation and `internal/runtime/bootverify` import-completeness validation.
- Old non-authoritative behavior now invalid for this class: treating loaded child package paths, raw same-name pins, ambient parent/root policy inheritance, flat credential-store names, or wildcard reachability as proof that declared package requirements are satisfied.
- Production paths checked: package manifest YAML parsing, package tree/semanticview manifest exposure, bootverify registry, `swarm verify` CLI path.
- Migration completeness: complete for #1451 source authority + minimal verify completeness. Runtime alias delivery, runtime policy/credential resolution, wildcard grants, and final E2E package composition remain split to the existing sibling issues.

## Proof

- `python3 - <<'PY' ... yaml.safe_load(open('platform-spec.yaml')) ... PY`
- `go test ./internal/runtime/contracts -run 'TestProjectPackageDocumentDecode|TestDiscoverProjectPackagePathsIncludesNestedFlowPackages|TestLoadWorkflowContractBundleBuildsRecursiveFlowTree' -count=1`
- `go test ./internal/runtime/bootverify -run 'TestRun_FlowPackageImportCompleteness' -count=1`
- `go test ./internal/runtime/bootverify -count=1`
- `go test ./...`
- `go run ./cmd/swarm verify --contracts <valid requires/bind fixture>` returned `verify ok`
- `go run ./cmd/swarm verify --contracts <missing bind.inputs fixture>` exited nonzero with `flow_package_import_completeness` and `work.requested`