### PR TITLE
[agent-a][issue #1452] Route flow package pin aliases through bind

### DIFF
--- a/internal/runtime/bootverify/checks.go
+++ b/internal/runtime/bootverify/checks.go
@@ -245,6 +245,7 @@ var bootCheckRegistry = []Check{
 	{ID: "write_pin_ownership_validation", Severity: "error", Run: checkWritePinOwnershipValidation},
 	{ID: "gate_schema_validation", Severity: "error", Run: checkGateSchemaValidation},
 	{ID: "flow_package_import_completeness", Severity: SeverityHardInvalidity, Run: checkFlowPackageImportCompleteness},
+	{ID: "flow_package_pin_bind_alias_validation", Severity: SeverityHardInvalidity, Run: checkFlowPackagePinBindAliasValidation},
 	{ID: "input_pin_wiring", Severity: "warning", Run: checkInputPinWiring},
 	{ID: "pin_target_resolution", Severity: "error", Run: checkPinTargetResolution},
 	{ID: "redundant_in_topology_select_entity", Severity: "warning", Run: checkRedundantInTopologySelectEntity},

--- a/internal/runtime/bootverify/flow_data_access_test.go
+++ b/internal/runtime/bootverify/flow_data_access_test.go
@@ -66,8 +66,8 @@ func TestRun_ValidatesFlowDataAccessDeclarations(t *testing.T) {
 }
 
 func TestBootCheckRegistry_HasFlowDataAccessCheckCount(t *testing.T) {
-	if got := len(bootCheckRegistry); got != 55 {
-		t.Fatalf("bootCheckRegistry count = %d, want 55", got)
+	if got := len(bootCheckRegistry); got != 56 {
+		t.Fatalf("bootCheckRegistry count = %d, want 56", got)
 	}
 }
 

--- a/internal/runtime/bootverify/flow_package_import_completeness_checks.go
+++ b/internal/runtime/bootverify/flow_package_import_completeness_checks.go
@@ -19,6 +19,39 @@ func checkFlowPackageImportCompleteness(c *checkerContext) []Finding {
 	return c.flowPackageImportFindings
 }
 
+func checkFlowPackagePinBindAliasValidation(c *checkerContext) []Finding {
+	var findings []Finding
+	for _, issue := range semanticview.ImportBoundaryPinAliasIssues(c.source) {
+		findings = append(findings, Finding{
+			CheckID:  "flow_package_pin_bind_alias_validation",
+			Severity: SeverityHardInvalidity,
+			Message:  flowPackagePinBindAliasMessage(issue),
+			Location: strings.TrimSpace(issue.ChildPackageKey),
+		})
+	}
+	return findings
+}
+
+func flowPackagePinBindAliasMessage(issue semanticview.ImportBoundaryPinAliasIssue) string {
+	direction := strings.TrimSpace(issue.Direction)
+	if direction == "" {
+		direction = "pin"
+	}
+	pin := strings.TrimSpace(issue.Pin)
+	if pin == "" {
+		pin = "<empty>"
+	}
+	parentEvent := strings.TrimSpace(issue.ParentEvent)
+	if parentEvent == "" {
+		parentEvent = "<empty>"
+	}
+	detail := strings.TrimSpace(issue.Message)
+	if detail == "" {
+		detail = strings.TrimSpace(issue.Kind)
+	}
+	return fmt.Sprintf("imported package %s %s bind for pin %s to parent event %s is invalid: %s", strings.TrimSpace(issue.ChildPackageKey), direction, pin, parentEvent, detail)
+}
+
 func flowPackageImportCompleteness(source semanticview.Source) []Finding {
 	scopes := source.ProjectScopes()
 	if len(scopes) == 0 {

--- a/internal/runtime/bootverify/flow_package_import_completeness_checks_test.go
+++ b/internal/runtime/bootverify/flow_package_import_completeness_checks_test.go
@@ -100,6 +100,62 @@ func TestRun_FlowPackageImportCompletenessIgnoresImportsWithoutRequires(t *testi
 	}
 }
 
+func TestRun_FlowPackagePinBindAliasValidationAcceptsValidAliases(t *testing.T) {
+	source := loadFlowPackageAliasValidationSource(t, flowPackageAliasValidationOptions{})
+
+	report := Run(context.Background(), source, Options{})
+
+	if got := report.HardInvalidities(); reportContains(got, "flow_package_pin_bind_alias_validation", "invalid") {
+		t.Fatalf("unexpected flow_package_pin_bind_alias_validation invalidity: %#v", got)
+	}
+	if reportContains(report.Warnings(), "input_pin_wiring", "work.requested") {
+		t.Fatalf("input alias should satisfy input pin wiring, got warnings %#v", report.Warnings())
+	}
+}
+
+func TestRun_FlowPackagePinBindAliasValidationFailsClosed(t *testing.T) {
+	tests := []struct {
+		name        string
+		opts        flowPackageAliasValidationOptions
+		wantMessage string
+	}{
+		{
+			name: "unknown package input pin",
+			opts: flowPackageAliasValidationOptions{
+				extraInputBind: "unknown.pin: parent.lead_captured",
+			},
+			wantMessage: "bind key is not declared",
+		},
+		{
+			name: "unknown parent event",
+			opts: flowPackageAliasValidationOptions{
+				inputBind: "parent.missing_event",
+			},
+			wantMessage: "does not resolve to a parent-facing event",
+		},
+		{
+			name: "ambiguous parent event",
+			opts: flowPackageAliasValidationOptions{
+				inputBind:        "shared.ready",
+				producerOutput:   "shared.ready",
+				secondProducerID: "producer_b",
+			},
+			wantMessage: "multiple parent-facing event producers",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			source := loadFlowPackageAliasValidationSource(t, tc.opts)
+
+			report := Run(context.Background(), source, Options{})
+
+			if !reportContains(report.HardInvalidities(), "flow_package_pin_bind_alias_validation", tc.wantMessage) {
+				t.Fatalf("expected flow_package_pin_bind_alias_validation %q, got %#v", tc.wantMessage, report.HardInvalidities())
+			}
+		})
+	}
+}
+
 type flowPackageImportFixtureOptions struct {
 	importKind string
 	bind       string
@@ -174,4 +230,118 @@ func allFlowPackageBindingsYAML() string {
       credentials:
         provider_token: parent_provider_token
 `
+}
+
+type flowPackageAliasValidationOptions struct {
+	inputBind        string
+	outputBind       string
+	extraInputBind   string
+	producerOutput   string
+	secondProducerID string
+}
+
+func loadFlowPackageAliasValidationSource(t *testing.T, opts flowPackageAliasValidationOptions) semanticview.Source {
+	t.Helper()
+	root := writeFlowPackageAliasValidationFixture(t, opts)
+	bundle := loadFixtureBundleAt(t, repoRootForBootverifyTest(t), root, runtimecontracts.DefaultPlatformSpecFile(repoRootForBootverifyTest(t)))
+	return semanticview.Wrap(bundle)
+}
+
+func writeFlowPackageAliasValidationFixture(t *testing.T, opts flowPackageAliasValidationOptions) string {
+	t.Helper()
+	if opts.inputBind == "" {
+		opts.inputBind = "parent.lead_captured"
+	}
+	if opts.outputBind == "" {
+		opts.outputBind = "parent.lead_enriched"
+	}
+	root := t.TempDir()
+	flows := ""
+	if opts.producerOutput != "" {
+		flows += `  - id: producer
+    flow: producer
+    mode: static
+`
+	}
+	if opts.secondProducerID != "" {
+		flows += `  - id: ` + opts.secondProducerID + `
+    flow: ` + opts.secondProducerID + `
+    mode: static
+`
+	}
+	flows += `  - id: worker
+    flow: worker
+    mode: static
+    bind:
+      inputs:
+        work.requested: ` + opts.inputBind + `
+`
+	if opts.extraInputBind != "" {
+		flows += `        ` + opts.extraInputBind + `
+`
+	}
+	flows += `      outputs:
+        work.completed: ` + opts.outputBind + `
+`
+	writeBootverifyFixtureFile(t, filepath.Join(root, "package.yaml"), `
+name: flow-package-alias-validation
+version: "1.0.0"
+platform_version: ">=1.6.0"
+flows:
+`+flows)
+	writeBootverifyFixtureFile(t, filepath.Join(root, "schema.yaml"), "name: flow-package-alias-validation\n")
+	writeBootverifyFixtureFile(t, filepath.Join(root, "policy.yaml"), "{}\n")
+	writeBootverifyFixtureFile(t, filepath.Join(root, "tools.yaml"), "{}\n")
+	writeBootverifyFixtureFile(t, filepath.Join(root, "agents.yaml"), "{}\n")
+	writeBootverifyFixtureFile(t, filepath.Join(root, "nodes.yaml"), "{}\n")
+	writeBootverifyFixtureFile(t, filepath.Join(root, "events.yaml"), `
+parent.lead_captured: {}
+parent.lead_enriched: {}
+`)
+	writeFlowPackageAliasValidationFlow(t, root, "worker", `
+pins:
+  inputs:
+    events: [work.requested]
+  outputs:
+    events: [work.completed]
+`, "")
+	if opts.producerOutput != "" {
+		writeFlowPackageAliasValidationFlow(t, root, "producer", `
+pins:
+  outputs:
+    events: [`+opts.producerOutput+`]
+`, opts.producerOutput)
+	}
+	if opts.secondProducerID != "" {
+		writeFlowPackageAliasValidationFlow(t, root, opts.secondProducerID, `
+pins:
+  outputs:
+    events: [`+opts.producerOutput+`]
+`, opts.producerOutput)
+	}
+	return root
+}
+
+func writeFlowPackageAliasValidationFlow(t *testing.T, root, flowID, schemaTail, outputEvent string) {
+	t.Helper()
+	requires := "requires:\n  inputs: []\n  outputs: []\n"
+	if flowID == "worker" {
+		requires = "requires:\n  inputs: [work.requested]\n  outputs: [work.completed]\n"
+	}
+	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", flowID, "package.yaml"), `
+name: `+flowID+`
+version: "1.0.0"
+`+requires)
+	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", flowID, "schema.yaml"), `
+name: `+flowID+`
+mode: static
+`+schemaTail)
+	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", flowID, "policy.yaml"), "{}\n")
+	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", flowID, "agents.yaml"), "{}\n")
+	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", flowID, "nodes.yaml"), "{}\n")
+	if outputEvent == "" {
+		writeBootverifyFixtureFile(t, filepath.Join(root, "flows", flowID, "events.yaml"), "{}\n")
+		return
+	}
+	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", flowID, "events.yaml"), outputEvent+": {}\n")
 }

--- a/internal/runtime/bootverify/report_test.go
+++ b/internal/runtime/bootverify/report_test.go
@@ -4747,8 +4747,8 @@ func TestRun_ReportsMissingRuntimeExecutorForOwnedRuntimeEvent(t *testing.T) {
 }
 
 func TestBootCheckRegistry_HasSpecCheckCount(t *testing.T) {
-	if got := len(bootCheckRegistry); got != 55 {
-		t.Fatalf("bootCheckRegistry count = %d, want 55", got)
+	if got := len(bootCheckRegistry); got != 56 {
+		t.Fatalf("bootCheckRegistry count = %d, want 56", got)
 	}
 	if got := len(supplementalChecks); got != 3 {
 		t.Fatalf("supplementalChecks count = %d, want 3", got)

--- a/internal/runtime/bootverify/workflow_flow_boundary_checks.go
+++ b/internal/runtime/bootverify/workflow_flow_boundary_checks.go
@@ -2,6 +2,7 @@ package bootverify
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
@@ -171,6 +172,22 @@ func (c *checkerContext) inputPinProducerPaths(flowID, eventType string, flowSco
 }
 
 func (c *checkerContext) inputPinSiblingFlowOutputPath(flowID, localEvent string) string {
+	aliases := semanticview.ImportBoundaryInputAliases(c.source, flowID, localEvent)
+	if len(aliases) > 0 {
+		patterns := make([]string, 0, len(aliases))
+		for _, alias := range aliases {
+			if pattern := eventidentity.Normalize(alias.EventPattern); pattern != "" {
+				patterns = append(patterns, pattern)
+			}
+		}
+		sort.Strings(patterns)
+		if len(patterns) > 0 {
+			return fmt.Sprintf("found via %s", strings.Join(patterns, ", "))
+		}
+	}
+	if semanticview.ImportBoundaryInputAliasRequired(c.source, flowID, localEvent) {
+		return "not found"
+	}
 	matches := map[string]struct{}{}
 	for otherFlowID := range c.source.FlowSchemaEntries() {
 		otherFlowID = strings.TrimSpace(otherFlowID)

--- a/internal/runtime/bus/delivery_planner.go
+++ b/internal/runtime/bus/delivery_planner.go
@@ -853,6 +853,9 @@ func routedRootNodeMatchesNoTargetEvent(evt events.Event, subscriber Subscriber)
 	if !strings.Contains(eventType, "/") {
 		return true
 	}
+	if strings.TrimSpace(subscriber.RouteSource) == "pin_bind_output_alias" {
+		return true
+	}
 	matchPattern := strings.Trim(strings.TrimSpace(subscriber.MatchPattern), "/")
 	return matchPattern != "" && !strings.Contains(matchPattern, "*") && eventType == matchPattern
 }

--- a/internal/runtime/bus/delivery_planner.go
+++ b/internal/runtime/bus/delivery_planner.go
@@ -806,7 +806,9 @@ func routedRootInputFlowNodeMatchesNoTargetEvent(evt events.Event, subscriber Su
 	if strings.TrimSpace(subscriber.ID) == "" || strings.TrimSpace(subscriber.Type) != "node" {
 		return false
 	}
-	if strings.TrimSpace(subscriber.RouteSource) != "root_input_flow" {
+	switch strings.TrimSpace(subscriber.RouteSource) {
+	case "root_input_flow", "pin_bind_input_alias":
+	default:
 		return false
 	}
 	if strings.Trim(strings.TrimSpace(subscriber.Path), "/") == "" {

--- a/internal/runtime/bus/eventbus_publish.go
+++ b/internal/runtime/bus/eventbus_publish.go
@@ -1283,6 +1283,9 @@ func (eb *EventBus) localizedSubscriberEvent(eventType string, subscriber Subscr
 	if strings.TrimSpace(subscriber.Type) != "node" {
 		return ""
 	}
+	if localized := eventidentity.Normalize(subscriber.LocalizedEvent); localized != "" {
+		return localized
+	}
 	candidates := []string{eventType, subscriber.MatchPattern}
 	if eb != nil && eb.semanticSource != nil {
 		flowID := strings.TrimSpace(routeFlowIDForPath(eb.semanticSource, subscriber.Path))

--- a/internal/runtime/bus/import_boundary_alias_routing_test.go
+++ b/internal/runtime/bus/import_boundary_alias_routing_test.go
@@ -1,0 +1,271 @@
+package bus_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/division-sh/swarm/internal/events"
+	runtimebus "github.com/division-sh/swarm/internal/runtime/bus"
+	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
+	runtimeflowidentity "github.com/division-sh/swarm/internal/runtime/core/flowidentity"
+	"github.com/division-sh/swarm/internal/runtime/semanticview"
+)
+
+func TestImportBoundaryInputAliasRoutesParentEventToPackageInputPin(t *testing.T) {
+	source := loadBusImportBoundaryAliasSource(t)
+	rt, err := runtimebus.DeriveRouteTable(source)
+	if err != nil {
+		t.Fatalf("DeriveRouteTable: %v", err)
+	}
+	routes := rt.Resolve("parent.lead_captured")
+	if len(routes) != 1 || routes[0].ID != "worker-node" {
+		t.Fatalf("Resolve(parent.lead_captured) = %#v, want worker-node", routes)
+	}
+	if got := routes[0].LocalizedEvent; got != "work.requested" {
+		t.Fatalf("localized event = %q, want work.requested", got)
+	}
+	if got := rt.Resolve("work.requested"); len(got) != 0 {
+		t.Fatalf("Resolve(work.requested) = %#v, want no raw fallback", got)
+	}
+
+	store := &routePersistenceTestStore{}
+	eb, err := runtimebus.NewEventBusWithOptions(store, runtimebus.EventBusOptions{ContractBundle: source})
+	if err != nil {
+		t.Fatalf("NewEventBusWithOptions: %v", err)
+	}
+	evt := events.NewProjectionEvent("evt-input-alias", "parent.lead_captured", "", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())
+	plan, err := eb.CheckPublishRecipientPlan(context.Background(), evt)
+	if err != nil {
+		t.Fatalf("CheckPublishRecipientPlan: %v", err)
+	}
+	if len(plan.RoutedRecipients) != 1 || plan.RoutedRecipients[0].ID != "worker-node" {
+		t.Fatalf("routed recipients = %#v, want worker-node", plan.RoutedRecipients)
+	}
+	if got := plan.RoutedRecipients[0].LocalizedEvent; got != "work.requested" {
+		t.Fatalf("plan localized event = %q, want work.requested", got)
+	}
+	if err := eb.Publish(context.Background(), evt); err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+	if got := store.deliveries["evt-input-alias"]; len(got) != 1 || got[0] != "worker-node" {
+		t.Fatalf("persisted deliveries = %#v, want worker-node", got)
+	}
+}
+
+func TestImportBoundaryOutputAliasRoutesPackageOutputToParentEvent(t *testing.T) {
+	source := loadBusImportBoundaryAliasSource(t)
+	rt, err := runtimebus.DeriveRouteTable(source)
+	if err != nil {
+		t.Fatalf("DeriveRouteTable: %v", err)
+	}
+	routes := rt.Resolve("worker/work.completed")
+	if len(routes) != 1 || routes[0].ID != "parent-listener" {
+		t.Fatalf("Resolve(worker/work.completed) = %#v, want parent-listener", routes)
+	}
+	if got := routes[0].LocalizedEvent; got != "parent.lead_enriched" {
+		t.Fatalf("localized event = %q, want parent.lead_enriched", got)
+	}
+
+	store := &routePersistenceTestStore{}
+	eb, err := runtimebus.NewEventBusWithOptions(store, runtimebus.EventBusOptions{ContractBundle: source})
+	if err != nil {
+		t.Fatalf("NewEventBusWithOptions: %v", err)
+	}
+	evt := events.NewProjectionEvent("evt-output-alias", "worker/work.completed", "", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())
+	plan, err := eb.CheckPublishRecipientPlan(context.Background(), evt)
+	if err != nil {
+		t.Fatalf("CheckPublishRecipientPlan: %v", err)
+	}
+	if len(plan.RoutedRecipients) != 1 || plan.RoutedRecipients[0].ID != "parent-listener" {
+		t.Fatalf("routed recipients = %#v, want parent-listener", plan.RoutedRecipients)
+	}
+	if got := plan.RoutedRecipients[0].LocalizedEvent; got != "parent.lead_enriched" {
+		t.Fatalf("plan localized event = %q, want parent.lead_enriched", got)
+	}
+	if err := eb.Publish(context.Background(), evt); err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+	if got := store.deliveries["evt-output-alias"]; len(got) != 1 || got[0] != "parent-listener" {
+		t.Fatalf("persisted deliveries = %#v, want parent-listener", got)
+	}
+}
+
+func TestImportBoundaryInputAliasMaterializesTemplateRoute(t *testing.T) {
+	source := loadBusImportBoundaryAliasTemplateSource(t)
+	rt, err := runtimebus.DeriveRouteTable(source)
+	if err != nil {
+		t.Fatalf("DeriveRouteTable: %v", err)
+	}
+	if got := rt.Resolve("parent.lead_captured"); len(got) != 0 {
+		t.Fatalf("Resolve(parent.lead_captured) before materialization = %#v, want none", got)
+	}
+	if err := rt.AddFlowInstanceRoute(runtimebus.FlowInstanceRouteMaterializationRequest{
+		Identity: runtimeflowidentity.DeriveRoute("worker", "inst-1"),
+	}); err != nil {
+		t.Fatalf("AddFlowInstanceRoute: %v", err)
+	}
+	routes := rt.Resolve("parent.lead_captured")
+	if len(routes) != 1 || routes[0].ID != "worker-node" {
+		t.Fatalf("Resolve(parent.lead_captured) = %#v, want worker-node", routes)
+	}
+	if got := routes[0].Path; got != "worker/inst-1" {
+		t.Fatalf("route path = %q, want worker/inst-1", got)
+	}
+	if got := routes[0].LocalizedEvent; got != "work.requested" {
+		t.Fatalf("localized event = %q, want work.requested", got)
+	}
+	if got := rt.Resolve("work.requested"); len(got) != 0 {
+		t.Fatalf("Resolve(work.requested) = %#v, want no raw template fallback", got)
+	}
+}
+
+func (s *routePersistenceTestStore) InsertEventDeliveryRoutes(_ context.Context, eventID string, routes []events.DeliveryRoute) error {
+	if s.deliveries == nil {
+		s.deliveries = map[string][]string{}
+	}
+	recipients := make([]string, 0, len(routes))
+	for _, route := range events.NormalizeDeliveryRoutes(routes) {
+		if route.SubscriberID != "" {
+			recipients = append(recipients, route.SubscriberID)
+		}
+	}
+	s.deliveries[eventID] = recipients
+	return nil
+}
+
+func loadBusImportBoundaryAliasSource(t *testing.T) semanticview.Source {
+	t.Helper()
+	repoRoot, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd: %v", err)
+	}
+	repoRoot = filepath.Clean(filepath.Join(repoRoot, "..", "..", ".."))
+	root := writeBusImportBoundaryAliasFixture(t)
+	bundle, err := runtimecontracts.LoadWorkflowContractBundleWithOverrides(repoRoot, root, runtimecontracts.DefaultPlatformSpecFile(repoRoot))
+	if err != nil {
+		t.Fatalf("LoadWorkflowContractBundleWithOverrides: %v", err)
+	}
+	return semanticview.Wrap(bundle)
+}
+
+func loadBusImportBoundaryAliasTemplateSource(t *testing.T) semanticview.Source {
+	t.Helper()
+	repoRoot, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd: %v", err)
+	}
+	repoRoot = filepath.Clean(filepath.Join(repoRoot, "..", "..", ".."))
+	root := writeBusImportBoundaryAliasTemplateFixture(t)
+	bundle, err := runtimecontracts.LoadWorkflowContractBundleWithOverrides(repoRoot, root, runtimecontracts.DefaultPlatformSpecFile(repoRoot))
+	if err != nil {
+		t.Fatalf("LoadWorkflowContractBundleWithOverrides: %v", err)
+	}
+	return semanticview.Wrap(bundle)
+}
+
+func writeBusImportBoundaryAliasFixture(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	writeBusImportBoundaryFixtureFile(t, filepath.Join(root, "package.yaml"), `
+name: bus-import-boundary-alias
+version: "1.0.0"
+platform_version: ">=1.6.0"
+flows:
+  - id: worker
+    flow: worker
+    mode: static
+    bind:
+      inputs:
+        work.requested: parent.lead_captured
+      outputs:
+        work.completed: parent.lead_enriched
+`)
+	writeBusImportBoundaryFixtureFile(t, filepath.Join(root, "schema.yaml"), "name: bus-import-boundary-alias\n")
+	writeBusImportBoundaryFixtureFile(t, filepath.Join(root, "policy.yaml"), "{}\n")
+	writeBusImportBoundaryFixtureFile(t, filepath.Join(root, "tools.yaml"), "{}\n")
+	writeBusImportBoundaryFixtureFile(t, filepath.Join(root, "agents.yaml"), "{}\n")
+	writeBusImportBoundaryFixtureFile(t, filepath.Join(root, "events.yaml"), `
+parent.lead_captured: {}
+parent.lead_enriched: {}
+`)
+	writeBusImportBoundaryFixtureFile(t, filepath.Join(root, "nodes.yaml"), `
+parent-listener:
+  id: parent-listener
+  execution_type: system_node
+  subscribes_to: [parent.lead_enriched]
+  event_handlers:
+    parent.lead_enriched: {}
+`)
+	writeBusImportBoundaryFixtureFile(t, filepath.Join(root, "flows", "worker", "package.yaml"), `
+name: worker
+version: "1.0.0"
+requires:
+  inputs: [work.requested]
+  outputs: [work.completed]
+`)
+	writeBusImportBoundaryFixtureFile(t, filepath.Join(root, "flows", "worker", "schema.yaml"), `
+name: worker
+mode: static
+pins:
+  inputs:
+    events: [work.requested]
+  outputs:
+    events: [work.completed]
+`)
+	writeBusImportBoundaryFixtureFile(t, filepath.Join(root, "flows", "worker", "policy.yaml"), "{}\n")
+	writeBusImportBoundaryFixtureFile(t, filepath.Join(root, "flows", "worker", "agents.yaml"), "{}\n")
+	writeBusImportBoundaryFixtureFile(t, filepath.Join(root, "flows", "worker", "events.yaml"), "work.completed: {}\n")
+	writeBusImportBoundaryFixtureFile(t, filepath.Join(root, "flows", "worker", "nodes.yaml"), `
+worker-node:
+  id: worker-node
+  execution_type: system_node
+  subscribes_to: [work.requested]
+  produces: [work.completed]
+  event_handlers:
+    work.requested:
+      emit: work.completed
+`)
+	return root
+}
+
+func writeBusImportBoundaryAliasTemplateFixture(t *testing.T) string {
+	t.Helper()
+	root := writeBusImportBoundaryAliasFixture(t)
+	writeBusImportBoundaryFixtureFile(t, filepath.Join(root, "package.yaml"), `
+name: bus-import-boundary-alias
+version: "1.0.0"
+platform_version: ">=1.6.0"
+flows:
+  - id: worker
+    flow: worker
+    mode: template
+    bind:
+      inputs:
+        work.requested: parent.lead_captured
+      outputs:
+        work.completed: parent.lead_enriched
+`)
+	writeBusImportBoundaryFixtureFile(t, filepath.Join(root, "flows", "worker", "schema.yaml"), `
+name: worker
+mode: template
+pins:
+  inputs:
+    events: [work.requested]
+  outputs:
+    events: [work.completed]
+`)
+	return root
+}
+
+func writeBusImportBoundaryFixtureFile(t *testing.T, path, contents string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir fixture dir: %v", err)
+	}
+	if err := os.WriteFile(path, []byte(contents), 0o644); err != nil {
+		t.Fatalf("write fixture %s: %v", path, err)
+	}
+}

--- a/internal/runtime/bus/import_boundary_alias_routing_test.go
+++ b/internal/runtime/bus/import_boundary_alias_routing_test.go
@@ -93,6 +93,47 @@ func TestImportBoundaryOutputAliasRoutesPackageOutputToParentEvent(t *testing.T)
 	}
 }
 
+func TestImportBoundaryOutputAliasRoutesPackageOutputToWildcardParentSubscriber(t *testing.T) {
+	source := loadBusImportBoundaryAliasWildcardOutputSource(t)
+	rt, err := runtimebus.DeriveRouteTable(source)
+	if err != nil {
+		t.Fatalf("DeriveRouteTable: %v", err)
+	}
+	routes := rt.Resolve("worker/work.completed")
+	if len(routes) != 1 || routes[0].ID != "parent-listener" {
+		t.Fatalf("Resolve(worker/work.completed) = %#v, want parent-listener", routes)
+	}
+	if got := routes[0].MatchPattern; got != "parent.*" {
+		t.Fatalf("match pattern = %q, want parent.*", got)
+	}
+	if got := routes[0].LocalizedEvent; got != "parent.lead_enriched" {
+		t.Fatalf("localized event = %q, want parent.lead_enriched", got)
+	}
+
+	store := &routePersistenceTestStore{}
+	eb, err := runtimebus.NewEventBusWithOptions(store, runtimebus.EventBusOptions{ContractBundle: source})
+	if err != nil {
+		t.Fatalf("NewEventBusWithOptions: %v", err)
+	}
+	evt := events.NewProjectionEvent("evt-output-alias-wildcard", "worker/work.completed", "", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())
+	plan, err := eb.CheckPublishRecipientPlan(context.Background(), evt)
+	if err != nil {
+		t.Fatalf("CheckPublishRecipientPlan: %v", err)
+	}
+	if len(plan.RoutedRecipients) != 1 || plan.RoutedRecipients[0].ID != "parent-listener" {
+		t.Fatalf("routed recipients = %#v, want parent-listener", plan.RoutedRecipients)
+	}
+	if got := plan.RoutedRecipients[0].LocalizedEvent; got != "parent.lead_enriched" {
+		t.Fatalf("plan localized event = %q, want parent.lead_enriched", got)
+	}
+	if err := eb.Publish(context.Background(), evt); err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+	if got := store.deliveries["evt-output-alias-wildcard"]; len(got) != 1 || got[0] != "parent-listener" {
+		t.Fatalf("persisted deliveries = %#v, want parent-listener", got)
+	}
+}
+
 func TestImportBoundaryInputAliasMaterializesTemplateRoute(t *testing.T) {
 	source := loadBusImportBoundaryAliasTemplateSource(t)
 	rt, err := runtimebus.DeriveRouteTable(source)
@@ -151,6 +192,21 @@ func loadBusImportBoundaryAliasSource(t *testing.T) semanticview.Source {
 	return semanticview.Wrap(bundle)
 }
 
+func loadBusImportBoundaryAliasWildcardOutputSource(t *testing.T) semanticview.Source {
+	t.Helper()
+	repoRoot, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd: %v", err)
+	}
+	repoRoot = filepath.Clean(filepath.Join(repoRoot, "..", "..", ".."))
+	root := writeBusImportBoundaryAliasFixtureWithParentSubscription(t, "parent.*")
+	bundle, err := runtimecontracts.LoadWorkflowContractBundleWithOverrides(repoRoot, root, runtimecontracts.DefaultPlatformSpecFile(repoRoot))
+	if err != nil {
+		t.Fatalf("LoadWorkflowContractBundleWithOverrides: %v", err)
+	}
+	return semanticview.Wrap(bundle)
+}
+
 func loadBusImportBoundaryAliasTemplateSource(t *testing.T) semanticview.Source {
 	t.Helper()
 	repoRoot, err := os.Getwd()
@@ -167,6 +223,10 @@ func loadBusImportBoundaryAliasTemplateSource(t *testing.T) semanticview.Source 
 }
 
 func writeBusImportBoundaryAliasFixture(t *testing.T) string {
+	return writeBusImportBoundaryAliasFixtureWithParentSubscription(t, "parent.lead_enriched")
+}
+
+func writeBusImportBoundaryAliasFixtureWithParentSubscription(t *testing.T, parentSubscription string) string {
 	t.Helper()
 	root := t.TempDir()
 	writeBusImportBoundaryFixtureFile(t, filepath.Join(root, "package.yaml"), `
@@ -195,7 +255,7 @@ parent.lead_enriched: {}
 parent-listener:
   id: parent-listener
   execution_type: system_node
-  subscribes_to: [parent.lead_enriched]
+  subscribes_to: [`+parentSubscription+`]
   event_handlers:
     parent.lead_enriched: {}
 `)

--- a/internal/runtime/bus/routing_derivation.go
+++ b/internal/runtime/bus/routing_derivation.go
@@ -13,11 +13,12 @@ import (
 )
 
 type Subscriber struct {
-	ID           string
-	Type         string
-	Path         string
-	MatchPattern string
-	RouteSource  string
+	ID             string
+	Type           string
+	Path           string
+	MatchPattern   string
+	RouteSource    string
+	LocalizedEvent string
 }
 
 type RouteTable struct {
@@ -39,6 +40,7 @@ type routePattern struct {
 }
 
 type routeFlowTemplate struct {
+	PackageKey  string
 	FlowID      string
 	InputEvents []string
 	LocalEvents map[string]struct{}
@@ -52,8 +54,9 @@ type routeSubscriberTemplate struct {
 }
 
 type routeResolvedPattern struct {
-	EventPattern string
-	RouteSource  string
+	EventPattern   string
+	RouteSource    string
+	LocalizedEvent string
 }
 
 func DeriveRouteTable(source semanticview.Source) (*RouteTable, error) {
@@ -64,9 +67,22 @@ func DeriveRouteTable(source semanticview.Source) (*RouteTable, error) {
 
 	for _, scope := range semanticview.ProjectScopes(source) {
 		localEvents := routeProjectLocalEventSet(scope)
-		rt.addEventPathsLocked("", localEvents)
-		rt.addAgentPatternsLocked(source, "", nil, "", localEvents, scope.Agents)
-		rt.addNodePatternsLocked(source, "", nil, "", localEvents, scope.Nodes)
+		owningFlowID := ""
+		basePath := ""
+		var inputEvents []string
+		if routeProjectScopeRequiresPinAliases(scope) {
+			owningFlowID = strings.TrimSpace(scope.OwningFlowID)
+		}
+		if owningFlowID != "" {
+			inputEvents = source.FlowInputEvents(owningFlowID)
+			basePath = routeFlowPath(source, owningFlowID)
+		}
+		if routeProjectScopeOwnedByTemplateFlow(source, owningFlowID) {
+			continue
+		}
+		rt.addEventPathsLocked(basePath, localEvents)
+		rt.addAgentPatternsLocked(source, scope.Key, owningFlowID, inputEvents, basePath, localEvents, scope.Agents)
+		rt.addNodePatternsLocked(source, scope.Key, owningFlowID, inputEvents, basePath, localEvents, scope.Nodes)
 	}
 
 	for _, scope := range semanticview.FlowScopes(source) {
@@ -74,6 +90,7 @@ func DeriveRouteTable(source semanticview.Source) (*RouteTable, error) {
 		localEvents := routeFlowLocalEventSet(source, scope)
 		if strings.EqualFold(scope.Mode, "template") {
 			rt.templates[flowPath] = routeFlowTemplate{
+				PackageKey:  scope.PackageKey,
 				FlowID:      scope.ID,
 				InputEvents: append([]string{}, scope.InputEvents...),
 				LocalEvents: cloneStringSet(localEvents),
@@ -82,14 +99,27 @@ func DeriveRouteTable(source semanticview.Source) (*RouteTable, error) {
 			continue
 		}
 		rt.addEventPathsLocked(flowPath, localEvents)
-		rt.addAgentPatternsLocked(source, scope.ID, scope.InputEvents, flowPath, localEvents, scope.Agents)
-		rt.addNodePatternsLocked(source, scope.ID, scope.InputEvents, flowPath, localEvents, scope.Nodes)
+		rt.addAgentPatternsLocked(source, scope.PackageKey, scope.ID, scope.InputEvents, flowPath, localEvents, scope.Agents)
+		rt.addNodePatternsLocked(source, scope.PackageKey, scope.ID, scope.InputEvents, flowPath, localEvents, scope.Nodes)
 	}
 
 	rt.addTopLevelRootInputNodeRoutesLocked(source)
 	rt.addRootInputFlowNodeRoutesLocked(source)
 	rt.rebuildLocked()
 	return rt, nil
+}
+
+func routeProjectScopeRequiresPinAliases(scope semanticview.ProjectScope) bool {
+	return len(scope.Manifest.Requires.Inputs) > 0 || len(scope.Manifest.Requires.Outputs) > 0
+}
+
+func routeProjectScopeOwnedByTemplateFlow(source semanticview.Source, flowID string) bool {
+	flowID = strings.TrimSpace(flowID)
+	if source == nil || flowID == "" {
+		return false
+	}
+	scope, ok := source.FlowScopeByID(flowID)
+	return ok && strings.EqualFold(scope.Mode, "template")
 }
 
 func (rt *RouteTable) Resolve(eventType string) []Subscriber {
@@ -155,14 +185,14 @@ func (rt *RouteTable) AddFlowInstanceRoute(req FlowInstanceRouteMaterializationR
 				Path: instancePath,
 			}
 			for _, rawPattern := range subscriberTemplate.RawPatterns {
-				for _, resolved := range routeResolveSubscriberPatterns(rt.source, templateDef.FlowID, templateDef.InputEvents, instancePath, templateDef.LocalEvents, rawPattern) {
+				for _, resolved := range routeResolveSubscriberPatterns(rt.source, templateDef.PackageKey, templateDef.FlowID, templateDef.InputEvents, instancePath, templateDef.LocalEvents, rawPattern) {
 					if strings.TrimSpace(resolved.EventPattern) == "" {
 						continue
 					}
-					subscriber.RouteSource = resolved.RouteSource
+					resolvedSubscriber := routeApplyResolvedPattern(subscriber, resolved)
 					rt.patterns = append(rt.patterns, routePattern{
 						EventPattern: resolved.EventPattern,
-						Subscriber:   subscriber,
+						Subscriber:   resolvedSubscriber,
 						InstancePath: instancePath,
 					})
 				}
@@ -187,14 +217,14 @@ func (rt *RouteTable) AddFlowInstanceRoute(req FlowInstanceRouteMaterializationR
 		Path: instancePath,
 	}
 	for _, rawPattern := range normalizeStringList(req.Template.SubscribesTo) {
-		for _, resolved := range routeResolveSubscriberPatterns(rt.source, templateID, nil, instancePath, localEvents, rawPattern) {
+		for _, resolved := range routeResolveSubscriberPatterns(rt.source, "", templateID, nil, instancePath, localEvents, rawPattern) {
 			if strings.TrimSpace(resolved.EventPattern) == "" {
 				continue
 			}
-			subscriber.RouteSource = resolved.RouteSource
+			resolvedSubscriber := routeApplyResolvedPattern(subscriber, resolved)
 			rt.patterns = append(rt.patterns, routePattern{
 				EventPattern: resolved.EventPattern,
-				Subscriber:   subscriber,
+				Subscriber:   resolvedSubscriber,
 				InstancePath: instancePath,
 			})
 		}
@@ -416,7 +446,7 @@ func (rt *RouteTable) addEventPathsLocked(basePath string, localEvents map[strin
 	return added
 }
 
-func (rt *RouteTable) addAgentPatternsLocked(source semanticview.Source, flowID string, inputEvents []string, basePath string, localEvents map[string]struct{}, agents map[string]runtimecontracts.AgentRegistryEntry) {
+func (rt *RouteTable) addAgentPatternsLocked(source semanticview.Source, packageKey, flowID string, inputEvents []string, basePath string, localEvents map[string]struct{}, agents map[string]runtimecontracts.AgentRegistryEntry) {
 	for _, key := range sortedStringKeys(agents) {
 		entry := agents[key]
 		subscriber := Subscriber{
@@ -425,21 +455,21 @@ func (rt *RouteTable) addAgentPatternsLocked(source semanticview.Source, flowID 
 			Path: strings.Trim(strings.TrimSpace(basePath), "/"),
 		}
 		for _, rawPattern := range normalizeStringList(entry.Subscriptions) {
-			for _, resolved := range routeResolveSubscriberPatterns(source, flowID, inputEvents, basePath, localEvents, rawPattern) {
+			for _, resolved := range routeResolveSubscriberPatterns(source, packageKey, flowID, inputEvents, basePath, localEvents, rawPattern) {
 				if strings.TrimSpace(resolved.EventPattern) == "" {
 					continue
 				}
-				subscriber.RouteSource = resolved.RouteSource
+				resolvedSubscriber := routeApplyResolvedPattern(subscriber, resolved)
 				rt.patterns = append(rt.patterns, routePattern{
 					EventPattern: resolved.EventPattern,
-					Subscriber:   subscriber,
+					Subscriber:   resolvedSubscriber,
 				})
 			}
 		}
 	}
 }
 
-func (rt *RouteTable) addNodePatternsLocked(source semanticview.Source, flowID string, inputEvents []string, basePath string, localEvents map[string]struct{}, nodes map[string]runtimecontracts.SystemNodeContract) {
+func (rt *RouteTable) addNodePatternsLocked(source semanticview.Source, packageKey, flowID string, inputEvents []string, basePath string, localEvents map[string]struct{}, nodes map[string]runtimecontracts.SystemNodeContract) {
 	for _, key := range sortedStringKeys(nodes) {
 		entry := nodes[key]
 		nodeID := strings.TrimSpace(entry.ID)
@@ -456,25 +486,34 @@ func (rt *RouteTable) addNodePatternsLocked(source semanticview.Source, flowID s
 			patterns = source.NodeRuntimeSubscriptions(nodeID)
 		}
 		for _, rawPattern := range patterns {
-			for _, resolved := range routeResolveSubscriberPatterns(source, flowID, inputEvents, basePath, localEvents, rawPattern) {
+			for _, resolved := range routeResolveSubscriberPatterns(source, packageKey, flowID, inputEvents, basePath, localEvents, rawPattern) {
 				if strings.TrimSpace(resolved.EventPattern) == "" {
 					continue
 				}
-				subscriber.RouteSource = resolved.RouteSource
+				resolvedSubscriber := routeApplyResolvedPattern(subscriber, resolved)
 				rt.patterns = append(rt.patterns, routePattern{
 					EventPattern: resolved.EventPattern,
-					Subscriber:   subscriber,
+					Subscriber:   resolvedSubscriber,
 				})
 			}
+			if routeInputAliasRequiresExclusivePatterns(source, flowID, rawPattern) {
+				continue
+			}
 			if resolved := routeResolveNodeCanonicalPattern(source, basePath, nodeID, rawPattern); strings.TrimSpace(resolved.EventPattern) != "" {
-				subscriber.RouteSource = resolved.RouteSource
+				resolvedSubscriber := routeApplyResolvedPattern(subscriber, resolved)
 				rt.patterns = append(rt.patterns, routePattern{
 					EventPattern: resolved.EventPattern,
-					Subscriber:   subscriber,
+					Subscriber:   resolvedSubscriber,
 				})
 			}
 		}
 	}
+}
+
+func routeApplyResolvedPattern(subscriber Subscriber, resolved routeResolvedPattern) Subscriber {
+	subscriber.RouteSource = strings.TrimSpace(resolved.RouteSource)
+	subscriber.LocalizedEvent = eventidentity.Normalize(resolved.LocalizedEvent)
+	return subscriber
 }
 
 func routeResolveNodeCanonicalPattern(source semanticview.Source, basePath, nodeID, rawPattern string) routeResolvedPattern {
@@ -545,7 +584,21 @@ func routeFlowInputHasExternalProducer(source semanticview.Source, flowID, event
 	if source == nil {
 		return false
 	}
+	if semanticview.ImportBoundaryInputAliasRequired(source, flowID, eventType) {
+		return true
+	}
 	return len(source.ResolveFlowInputAutoWire(flowID, eventType).Patterns) > 0
+}
+
+func routeInputAliasRequiresExclusivePatterns(source semanticview.Source, flowID, eventType string) bool {
+	if source == nil || strings.TrimSpace(flowID) == "" {
+		return false
+	}
+	eventType = eventidentity.Normalize(eventType)
+	if eventType == "" || !source.FlowHasInputEvent(flowID, eventType) {
+		return false
+	}
+	return semanticview.ImportBoundaryInputAliasRequired(source, flowID, eventType)
 }
 
 func routeNodeLocalEventSet(node runtimecontracts.SystemNodeContract) map[string]struct{} {
@@ -642,15 +695,15 @@ func routeFlowIDForPath(source semanticview.Source, flowPath string) string {
 	return ""
 }
 
-func routeResolvedPatternsForList(source semanticview.Source, flowID string, inputEvents []string, basePath string, localEvents map[string]struct{}, patterns []string) []routeResolvedPattern {
+func routeResolvedPatternsForList(source semanticview.Source, packageKey, flowID string, inputEvents []string, basePath string, localEvents map[string]struct{}, patterns []string) []routeResolvedPattern {
 	out := make([]routeResolvedPattern, 0, len(patterns))
 	for _, raw := range patterns {
-		out = append(out, routeResolveSubscriberPatterns(source, flowID, inputEvents, basePath, localEvents, raw)...)
+		out = append(out, routeResolveSubscriberPatterns(source, packageKey, flowID, inputEvents, basePath, localEvents, raw)...)
 	}
 	return out
 }
 
-func routeResolveSubscriberPatterns(source semanticview.Source, flowID string, inputEvents []string, basePath string, localEvents map[string]struct{}, raw string) []routeResolvedPattern {
+func routeResolveSubscriberPatterns(source semanticview.Source, packageKey, flowID string, inputEvents []string, basePath string, localEvents map[string]struct{}, raw string) []routeResolvedPattern {
 	raw = eventidentity.Normalize(raw)
 	flowID = strings.TrimSpace(flowID)
 	if raw == "" {
@@ -659,7 +712,36 @@ func routeResolveSubscriberPatterns(source semanticview.Source, flowID string, i
 	if flowID != "" && source != nil && source.FlowHasInputEvent(flowID, raw) {
 		patterns := routeInputProducerPatterns(source.ResolveFlowInputAutoWire(flowID, raw))
 		if len(patterns) > 0 {
+			if len(semanticview.ImportBoundaryInputAliases(source, flowID, raw)) > 0 {
+				for i := range patterns {
+					patterns[i].RouteSource = "pin_bind_input_alias"
+					patterns[i].LocalizedEvent = raw
+				}
+			}
 			return patterns
+		}
+		if semanticview.ImportBoundaryInputAliasRequired(source, flowID, raw) {
+			return nil
+		}
+	}
+	if source != nil {
+		outputAliases := semanticview.ImportBoundaryOutputAliasesForParentEvent(source, packageKey, flowID, raw)
+		if len(outputAliases) > 0 {
+			out := make([]routeResolvedPattern, 0, len(outputAliases))
+			for _, alias := range outputAliases {
+				pattern := eventidentity.Normalize(alias.EventPattern)
+				if pattern == "" {
+					continue
+				}
+				out = append(out, routeResolvedPattern{
+					EventPattern:   pattern,
+					RouteSource:    "pin_bind_output_alias",
+					LocalizedEvent: raw,
+				})
+			}
+			if len(out) > 0 {
+				return out
+			}
 		}
 	}
 	scope := routeEventIdentityScope(basePath, localEvents, inputEvents)

--- a/internal/runtime/bus/routing_derivation.go
+++ b/internal/runtime/bus/routing_derivation.go
@@ -55,6 +55,7 @@ type routeSubscriberTemplate struct {
 
 type routeResolvedPattern struct {
 	EventPattern   string
+	MatchPattern   string
 	RouteSource    string
 	LocalizedEvent string
 }
@@ -513,6 +514,9 @@ func (rt *RouteTable) addNodePatternsLocked(source semanticview.Source, packageK
 func routeApplyResolvedPattern(subscriber Subscriber, resolved routeResolvedPattern) Subscriber {
 	subscriber.RouteSource = strings.TrimSpace(resolved.RouteSource)
 	subscriber.LocalizedEvent = eventidentity.Normalize(resolved.LocalizedEvent)
+	if matchPattern := eventidentity.Normalize(resolved.MatchPattern); matchPattern != "" {
+		subscriber.MatchPattern = matchPattern
+	}
 	return subscriber
 }
 
@@ -542,14 +546,18 @@ func (rt *RouteTable) rebuildLocked() {
 			for _, eventType := range eventTypes {
 				if RouteMatches(pattern.EventPattern, eventType) {
 					subscriber := pattern.Subscriber
-					subscriber.MatchPattern = pattern.EventPattern
+					if strings.TrimSpace(subscriber.MatchPattern) == "" {
+						subscriber.MatchPattern = pattern.EventPattern
+					}
 					rt.routes[eventType] = appendUniqueSubscriber(rt.routes[eventType], subscriber)
 				}
 			}
 			continue
 		}
 		subscriber := pattern.Subscriber
-		subscriber.MatchPattern = pattern.EventPattern
+		if strings.TrimSpace(subscriber.MatchPattern) == "" {
+			subscriber.MatchPattern = pattern.EventPattern
+		}
 		rt.routes[pattern.EventPattern] = appendUniqueSubscriber(rt.routes[pattern.EventPattern], subscriber)
 	}
 }
@@ -737,6 +745,26 @@ func routeResolveSubscriberPatterns(source semanticview.Source, packageKey, flow
 					EventPattern:   pattern,
 					RouteSource:    "pin_bind_output_alias",
 					LocalizedEvent: raw,
+				})
+			}
+			if len(out) > 0 {
+				return out
+			}
+		}
+		if strings.Contains(raw, "*") {
+			outputAliases := semanticview.ImportBoundaryOutputAliasesForParent(source, packageKey, flowID)
+			out := make([]routeResolvedPattern, 0, len(outputAliases))
+			for _, alias := range outputAliases {
+				parentEvent := eventidentity.Normalize(alias.ParentEvent)
+				pattern := eventidentity.Normalize(alias.EventPattern)
+				if parentEvent == "" || pattern == "" || !RouteMatches(raw, parentEvent) {
+					continue
+				}
+				out = append(out, routeResolvedPattern{
+					EventPattern:   pattern,
+					MatchPattern:   raw,
+					RouteSource:    "pin_bind_output_alias",
+					LocalizedEvent: parentEvent,
 				})
 			}
 			if len(out) > 0 {

--- a/internal/runtime/pipeline/workflow_nodes.go
+++ b/internal/runtime/pipeline/workflow_nodes.go
@@ -157,9 +157,12 @@ func workflowNodeEventHandlerResolutionForDelivery(source semanticview.Source, n
 	}
 	localizedEventType := workflowNodeConcreteInstanceLocalEventType(source, nodeID, evt)
 	if localizedEventType == "" || localizedEventType == rawEventType {
-		return workflowNodeEventHandlerResolution{}
+		return workflowNodeOutputAliasEventHandlerResolution(source, nodeID, rawEventType)
 	}
-	return workflowNodeEventHandlerResolutionForEventType(source, nodeID, localizedEventType)
+	if resolved := workflowNodeEventHandlerResolutionForEventType(source, nodeID, localizedEventType); resolved.Matched {
+		return resolved
+	}
+	return workflowNodeOutputAliasEventHandlerResolution(source, nodeID, rawEventType)
 }
 
 func workflowNodeEventHandlerResolutionForEventType(source semanticview.Source, nodeID, eventType string) workflowNodeEventHandlerResolution {
@@ -409,21 +412,30 @@ func workflowNodeSubscriptionAliases(source semanticview.Source, nodeID, eventTy
 		}
 		out = append(out, value)
 	}
-	appendAlias(source.ResolveNodeEventReference(nodeID, eventType))
 	contractSource, ok := source.NodeContractSource(nodeID)
 	if !ok {
+		appendAlias(source.ResolveNodeEventReference(nodeID, eventType))
 		return out
 	}
 	flowID := strings.TrimSpace(contractSource.FlowID)
+	for _, alias := range semanticview.ImportBoundaryOutputAliasesForParentEvent(source, contractSource.PackageKey, flowID, eventType) {
+		appendAlias(alias.EventPattern)
+	}
 	if flowID == "" {
+		appendAlias(source.ResolveNodeEventReference(nodeID, eventType))
 		return out
 	}
 	if !source.FlowHasInputEvent(flowID, eventType) {
+		appendAlias(source.ResolveNodeEventReference(nodeID, eventType))
 		return out
 	}
 	for _, pattern := range source.FlowInputProducerPatterns(flowID, eventType) {
 		appendAlias(pattern)
 	}
+	if semanticview.ImportBoundaryInputAliasRequired(source, flowID, eventType) {
+		return out
+	}
+	appendAlias(source.ResolveNodeEventReference(nodeID, eventType))
 	appendAlias(eventType)
 	return out
 }
@@ -433,6 +445,22 @@ func workflowFlowInputProducerAliases(source semanticview.Source, targetFlowID, 
 		return nil
 	}
 	return append([]string{}, source.ResolveFlowInputAutoWire(targetFlowID, eventType).Patterns...)
+}
+
+func workflowNodeOutputAliasEventHandlerResolution(source semanticview.Source, nodeID, rawEventType string) workflowNodeEventHandlerResolution {
+	if source == nil {
+		return workflowNodeEventHandlerResolution{}
+	}
+	contractSource, ok := source.NodeContractSource(nodeID)
+	if !ok {
+		return workflowNodeEventHandlerResolution{}
+	}
+	for _, parentEvent := range semanticview.ImportBoundaryOutputParentEventsForEvent(source, contractSource.PackageKey, strings.TrimSpace(contractSource.FlowID), rawEventType) {
+		if resolved := workflowNodeEventHandlerResolutionForEventType(source, nodeID, parentEvent); resolved.Matched {
+			return resolved
+		}
+	}
+	return workflowNodeEventHandlerResolution{}
 }
 
 func workflowFlowHasInputEvent(source semanticview.Source, flowID, eventType string) bool {

--- a/internal/runtime/pipeline/workflow_nodes.go
+++ b/internal/runtime/pipeline/workflow_nodes.go
@@ -440,6 +440,15 @@ func workflowNodeSubscriptionAliases(source semanticview.Source, nodeID, eventTy
 	for _, alias := range semanticview.ImportBoundaryOutputAliasesForParentEvent(source, contractSource.PackageKey, flowID, eventType) {
 		appendAlias(alias.EventPattern)
 	}
+	if strings.Contains(eventType, "*") {
+		for _, alias := range semanticview.ImportBoundaryOutputAliasesForParent(source, contractSource.PackageKey, flowID) {
+			parentEvent := eventidentity.Normalize(alias.ParentEvent)
+			if parentEvent == "" || !eventidentity.MatchPattern(eventType, parentEvent) {
+				continue
+			}
+			appendAlias(alias.EventPattern)
+		}
+	}
 	if flowID == "" {
 		appendAlias(source.ResolveNodeEventReference(nodeID, eventType))
 		return out

--- a/internal/runtime/pipeline/workflow_nodes.go
+++ b/internal/runtime/pipeline/workflow_nodes.go
@@ -155,6 +155,9 @@ func workflowNodeEventHandlerResolutionForDelivery(source semanticview.Source, n
 	if resolved := workflowNodeEventHandlerResolutionForEventType(source, nodeID, rawEventType); resolved.Matched {
 		return resolved
 	}
+	if resolved := workflowNodeInputAliasEventHandlerResolution(source, nodeID, rawEventType); resolved.Matched {
+		return resolved
+	}
 	localizedEventType := workflowNodeConcreteInstanceLocalEventType(source, nodeID, evt)
 	if localizedEventType == "" || localizedEventType == rawEventType {
 		return workflowNodeOutputAliasEventHandlerResolution(source, nodeID, rawEventType)
@@ -219,6 +222,22 @@ func workflowNodeMatchedHandlerEventKey(source semanticview.Source, nodeID, even
 		}
 	}
 	return eventType
+}
+
+func workflowNodeInputAliasEventHandlerResolution(source semanticview.Source, nodeID, rawEventType string) workflowNodeEventHandlerResolution {
+	if source == nil {
+		return workflowNodeEventHandlerResolution{}
+	}
+	contractSource, ok := source.NodeContractSource(nodeID)
+	if !ok {
+		return workflowNodeEventHandlerResolution{}
+	}
+	for _, alias := range semanticview.ImportBoundaryInputAliasesForParentEvent(source, strings.TrimSpace(contractSource.FlowID), rawEventType) {
+		if resolved := workflowNodeEventHandlerResolutionForEventType(source, nodeID, alias.Pin); resolved.Matched {
+			return resolved
+		}
+	}
+	return workflowNodeEventHandlerResolution{}
 }
 
 func workflowNodeHandlerEventKeyForExecution(source semanticview.Source, nodeID string, evt events.Event) string {

--- a/internal/runtime/pipeline/workflow_nodes_test.go
+++ b/internal/runtime/pipeline/workflow_nodes_test.go
@@ -203,6 +203,14 @@ func TestLoadWorkflowNodes_UsesImportBoundaryInputAlias(t *testing.T) {
 	if workflowNodeHasSubscriptionForTest(*worker, "work.requested") || workflowNodeHasSubscriptionForTest(*worker, "worker/work.requested") {
 		t.Fatalf("worker-node subscriptions = %#v, should not preserve raw required-import input fallback", worker.Subscriptions)
 	}
+	evt := events.NewProjectionEvent("", "parent.lead_captured", "", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Unix(1, 0).UTC())
+	resolved := workflowNodeEventHandlerResolutionForDelivery(source, "worker-node", evt)
+	if !resolved.Matched {
+		t.Fatal("expected worker-node handler to resolve through input alias")
+	}
+	if got := resolved.HandlerEventKey; got != "work.requested" {
+		t.Fatalf("handler event key = %q, want work.requested", got)
+	}
 }
 
 func TestLoadWorkflowNodes_UsesImportBoundaryOutputAliasForParentHandler(t *testing.T) {

--- a/internal/runtime/pipeline/workflow_nodes_test.go
+++ b/internal/runtime/pipeline/workflow_nodes_test.go
@@ -236,9 +236,37 @@ func TestLoadWorkflowNodes_UsesImportBoundaryOutputAliasForParentHandler(t *test
 	}
 }
 
+func TestLoadWorkflowNodes_UsesImportBoundaryOutputAliasForWildcardParentSubscription(t *testing.T) {
+	source := loadPipelineImportBoundaryAliasSourceWithParentSubscription(t, "parent.*")
+	nodes, err := LoadWorkflowNodes(source)
+	if err != nil {
+		t.Fatalf("LoadWorkflowNodes: %v", err)
+	}
+	parent := workflowNodeByIDForTest(nodes, "parent-listener")
+	if parent == nil {
+		t.Fatalf("parent-listener missing from %#v", nodes)
+	}
+	if !workflowNodeHasSubscriptionForTest(*parent, "worker/work.completed") {
+		t.Fatalf("parent-listener subscriptions = %#v, want worker/work.completed output alias for wildcard parent subscription", parent.Subscriptions)
+	}
+	evt := events.NewProjectionEvent("", "worker/work.completed", "", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Unix(1, 0).UTC())
+	resolved := workflowNodeEventHandlerResolutionForDelivery(source, "parent-listener", evt)
+	if !resolved.Matched {
+		t.Fatal("expected parent-listener handler to resolve through output alias")
+	}
+	if got := resolved.HandlerEventKey; got != "parent.lead_enriched" {
+		t.Fatalf("handler event key = %q, want parent.lead_enriched", got)
+	}
+}
+
 func loadPipelineImportBoundaryAliasSource(t *testing.T) semanticview.Source {
 	t.Helper()
-	root := writePipelineImportBoundaryAliasFixture(t)
+	return loadPipelineImportBoundaryAliasSourceWithParentSubscription(t, "parent.lead_enriched")
+}
+
+func loadPipelineImportBoundaryAliasSourceWithParentSubscription(t *testing.T, parentSubscription string) semanticview.Source {
+	t.Helper()
+	root := writePipelineImportBoundaryAliasFixture(t, parentSubscription)
 	bundle, err := runtimecontracts.LoadWorkflowContractBundleWithOverrides(contractComplianceRepoRoot(t), root, runtimecontracts.DefaultPlatformSpecFile(contractComplianceRepoRoot(t)))
 	if err != nil {
 		t.Fatalf("LoadWorkflowContractBundleWithOverrides: %v", err)
@@ -246,7 +274,7 @@ func loadPipelineImportBoundaryAliasSource(t *testing.T) semanticview.Source {
 	return semanticview.Wrap(bundle)
 }
 
-func writePipelineImportBoundaryAliasFixture(t *testing.T) string {
+func writePipelineImportBoundaryAliasFixture(t *testing.T, parentSubscription string) string {
 	t.Helper()
 	root := t.TempDir()
 	writePipelineFixtureFile(t, filepath.Join(root, "package.yaml"), `
@@ -275,7 +303,7 @@ parent.lead_enriched: {}
 parent-listener:
   id: parent-listener
   execution_type: system_node
-  subscribes_to: [parent.lead_enriched]
+  subscribes_to: [`+parentSubscription+`]
   event_handlers:
     parent.lead_enriched: {}
 `)

--- a/internal/runtime/pipeline/workflow_nodes_test.go
+++ b/internal/runtime/pipeline/workflow_nodes_test.go
@@ -3,7 +3,9 @@ package pipeline
 import (
 	"path/filepath"
 	"testing"
+	"time"
 
+	"github.com/division-sh/swarm/internal/events"
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
 	"github.com/division-sh/swarm/internal/runtime/flowmodel"
 	"github.com/division-sh/swarm/internal/runtime/semanticview"
@@ -183,4 +185,138 @@ func TestLoadWorkflowNodes_UsesHandlerKeysForCrossFlowPinAutoWire(t *testing.T) 
 		}
 	}
 	t.Fatalf("Subscriptions = %#v, want producer/scan.requested", nodes[0].Subscriptions)
+}
+
+func TestLoadWorkflowNodes_UsesImportBoundaryInputAlias(t *testing.T) {
+	source := loadPipelineImportBoundaryAliasSource(t)
+	nodes, err := LoadWorkflowNodes(source)
+	if err != nil {
+		t.Fatalf("LoadWorkflowNodes: %v", err)
+	}
+	worker := workflowNodeByIDForTest(nodes, "worker-node")
+	if worker == nil {
+		t.Fatalf("worker-node missing from %#v", nodes)
+	}
+	if !workflowNodeHasSubscriptionForTest(*worker, "parent.lead_captured") {
+		t.Fatalf("worker-node subscriptions = %#v, want parent.lead_captured", worker.Subscriptions)
+	}
+	if workflowNodeHasSubscriptionForTest(*worker, "work.requested") || workflowNodeHasSubscriptionForTest(*worker, "worker/work.requested") {
+		t.Fatalf("worker-node subscriptions = %#v, should not preserve raw required-import input fallback", worker.Subscriptions)
+	}
+}
+
+func TestLoadWorkflowNodes_UsesImportBoundaryOutputAliasForParentHandler(t *testing.T) {
+	source := loadPipelineImportBoundaryAliasSource(t)
+	nodes, err := LoadWorkflowNodes(source)
+	if err != nil {
+		t.Fatalf("LoadWorkflowNodes: %v", err)
+	}
+	parent := workflowNodeByIDForTest(nodes, "parent-listener")
+	if parent == nil {
+		t.Fatalf("parent-listener missing from %#v", nodes)
+	}
+	if !workflowNodeHasSubscriptionForTest(*parent, "worker/work.completed") {
+		t.Fatalf("parent-listener subscriptions = %#v, want worker/work.completed output alias", parent.Subscriptions)
+	}
+	evt := events.NewProjectionEvent("", "worker/work.completed", "", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Unix(1, 0).UTC())
+	resolved := workflowNodeEventHandlerResolutionForDelivery(source, "parent-listener", evt)
+	if !resolved.Matched {
+		t.Fatal("expected parent-listener handler to resolve through output alias")
+	}
+	if got := resolved.HandlerEventKey; got != "parent.lead_enriched" {
+		t.Fatalf("handler event key = %q, want parent.lead_enriched", got)
+	}
+}
+
+func loadPipelineImportBoundaryAliasSource(t *testing.T) semanticview.Source {
+	t.Helper()
+	root := writePipelineImportBoundaryAliasFixture(t)
+	bundle, err := runtimecontracts.LoadWorkflowContractBundleWithOverrides(contractComplianceRepoRoot(t), root, runtimecontracts.DefaultPlatformSpecFile(contractComplianceRepoRoot(t)))
+	if err != nil {
+		t.Fatalf("LoadWorkflowContractBundleWithOverrides: %v", err)
+	}
+	return semanticview.Wrap(bundle)
+}
+
+func writePipelineImportBoundaryAliasFixture(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	writePipelineFixtureFile(t, filepath.Join(root, "package.yaml"), `
+name: pipeline-import-boundary-alias
+version: "1.0.0"
+platform_version: ">=1.6.0"
+flows:
+  - id: worker
+    flow: worker
+    mode: static
+    bind:
+      inputs:
+        work.requested: parent.lead_captured
+      outputs:
+        work.completed: parent.lead_enriched
+`)
+	writePipelineFixtureFile(t, filepath.Join(root, "schema.yaml"), "name: pipeline-import-boundary-alias\n")
+	writePipelineFixtureFile(t, filepath.Join(root, "policy.yaml"), "{}\n")
+	writePipelineFixtureFile(t, filepath.Join(root, "tools.yaml"), "{}\n")
+	writePipelineFixtureFile(t, filepath.Join(root, "agents.yaml"), "{}\n")
+	writePipelineFixtureFile(t, filepath.Join(root, "events.yaml"), `
+parent.lead_captured: {}
+parent.lead_enriched: {}
+`)
+	writePipelineFixtureFile(t, filepath.Join(root, "nodes.yaml"), `
+parent-listener:
+  id: parent-listener
+  execution_type: system_node
+  subscribes_to: [parent.lead_enriched]
+  event_handlers:
+    parent.lead_enriched: {}
+`)
+	writePipelineFixtureFile(t, filepath.Join(root, "flows", "worker", "package.yaml"), `
+name: worker
+version: "1.0.0"
+requires:
+  inputs: [work.requested]
+  outputs: [work.completed]
+`)
+	writePipelineFixtureFile(t, filepath.Join(root, "flows", "worker", "schema.yaml"), `
+name: worker
+mode: static
+pins:
+  inputs:
+    events: [work.requested]
+  outputs:
+    events: [work.completed]
+`)
+	writePipelineFixtureFile(t, filepath.Join(root, "flows", "worker", "policy.yaml"), "{}\n")
+	writePipelineFixtureFile(t, filepath.Join(root, "flows", "worker", "agents.yaml"), "{}\n")
+	writePipelineFixtureFile(t, filepath.Join(root, "flows", "worker", "events.yaml"), "work.completed: {}\n")
+	writePipelineFixtureFile(t, filepath.Join(root, "flows", "worker", "nodes.yaml"), `
+worker-node:
+  id: worker-node
+  execution_type: system_node
+  subscribes_to: [work.requested]
+  produces: [work.completed]
+  event_handlers:
+    work.requested:
+      emit: work.completed
+`)
+	return root
+}
+
+func workflowNodeByIDForTest(nodes []WorkflowNode, id string) *WorkflowNode {
+	for i := range nodes {
+		if nodes[i].ID == id {
+			return &nodes[i]
+		}
+	}
+	return nil
+}
+
+func workflowNodeHasSubscriptionForTest(node WorkflowNode, eventType string) bool {
+	for _, subscription := range node.Subscriptions {
+		if string(subscription) == eventType {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/runtime/semanticview/bundle_source.go
+++ b/internal/runtime/semanticview/bundle_source.go
@@ -224,10 +224,10 @@ func (s bundleSource) FlowHasOutputEvent(flowID, eventType string) bool {
 	return s.bundle.FlowHasOutputEvent(flowID, eventType)
 }
 func (s bundleSource) ResolveFlowInputAutoWire(flowID, eventType string) runtimecontracts.FlowInputAutoWireResolution {
-	return s.bundle.ResolveFlowInputAutoWire(flowID, eventType)
+	return ResolveFlowInputAutoWire(s, flowID, eventType)
 }
 func (s bundleSource) FlowInputProducerPatterns(flowID, eventType string) []string {
-	return s.bundle.FlowInputProducerPatterns(flowID, eventType)
+	return FlowInputProducerPatterns(s, flowID, eventType)
 }
 func (s bundleSource) ResolveFlowEventReference(flowID, eventType string) string {
 	return s.bundle.ResolveFlowEventReference(flowID, eventType)

--- a/internal/runtime/semanticview/import_boundary_aliases.go
+++ b/internal/runtime/semanticview/import_boundary_aliases.go
@@ -103,6 +103,52 @@ func ImportBoundaryInputAliases(source Source, targetFlowID, eventType string) [
 	return out
 }
 
+func ImportBoundaryInputAliasesForParentEvent(source Source, targetFlowID, parentEvent string) []ImportBoundaryPinAlias {
+	targetFlowID = strings.TrimSpace(targetFlowID)
+	parentEvent = eventidentity.Normalize(parentEvent)
+	if source == nil || targetFlowID == "" || parentEvent == "" {
+		return nil
+	}
+	var out []ImportBoundaryPinAlias
+	for _, alias := range importBoundaryPinAliases(source) {
+		if alias.Direction != ImportBoundaryAliasInput {
+			continue
+		}
+		if strings.TrimSpace(alias.FlowID) != targetFlowID {
+			continue
+		}
+		if eventidentity.Normalize(alias.ParentEvent) != parentEvent && eventidentity.Normalize(alias.EventPattern) != parentEvent {
+			continue
+		}
+		out = append(out, alias)
+	}
+	sortImportBoundaryAliases(out)
+	return out
+}
+
+func ImportBoundaryOutputAliasesForParent(source Source, parentPackageKey, parentFlowID string) []ImportBoundaryPinAlias {
+	parentPackageKey = normalizeImportPackageKey(parentPackageKey)
+	parentFlowID = strings.TrimSpace(parentFlowID)
+	if source == nil {
+		return nil
+	}
+	var out []ImportBoundaryPinAlias
+	for _, alias := range importBoundaryPinAliases(source) {
+		if alias.Direction != ImportBoundaryAliasOutput {
+			continue
+		}
+		if parentPackageKey != "" && normalizeImportPackageKey(alias.ParentPackageKey) != parentPackageKey {
+			continue
+		}
+		if parentFlowID != "" && !importBoundaryParentFlowMayConsume(source, parentFlowID, alias.ParentPackageKey) {
+			continue
+		}
+		out = append(out, alias)
+	}
+	sortImportBoundaryAliases(out)
+	return out
+}
+
 func ImportBoundaryOutputAliasesForParentEvent(source Source, parentPackageKey, parentFlowID, eventType string) []ImportBoundaryPinAlias {
 	parentPackageKey = normalizeImportPackageKey(parentPackageKey)
 	parentFlowID = strings.TrimSpace(parentFlowID)

--- a/internal/runtime/semanticview/import_boundary_aliases.go
+++ b/internal/runtime/semanticview/import_boundary_aliases.go
@@ -1,0 +1,641 @@
+package semanticview
+
+import (
+	"path"
+	"sort"
+	"strings"
+
+	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
+	"github.com/division-sh/swarm/internal/runtime/core/eventidentity"
+)
+
+const (
+	ImportBoundaryAliasInput  = "input"
+	ImportBoundaryAliasOutput = "output"
+)
+
+type ImportBoundaryPinAlias struct {
+	Direction        string
+	ParentPackageKey string
+	ChildPackageKey  string
+	ImportLabel      string
+	FlowID           string
+	Pin              string
+	ParentEvent      string
+	EventPattern     string
+}
+
+type ImportBoundaryPinAliasIssue struct {
+	Direction        string
+	Kind             string
+	ParentPackageKey string
+	ChildPackageKey  string
+	ImportLabel      string
+	FlowID           string
+	Pin              string
+	ParentEvent      string
+	Message          string
+}
+
+type importBoundarySite struct {
+	PackageKey string
+	Label      string
+	FlowID     string
+	Bind       runtimecontracts.FlowPackageBind
+}
+
+func ResolveFlowInputAutoWire(source Source, targetFlowID, eventType string) runtimecontracts.FlowInputAutoWireResolution {
+	targetFlowID = strings.TrimSpace(targetFlowID)
+	eventType = eventidentity.Normalize(eventType)
+	if source == nil || targetFlowID == "" || eventType == "" || !source.FlowHasInputEvent(targetFlowID, eventType) {
+		return runtimecontracts.FlowInputAutoWireResolution{EventType: eventType}
+	}
+	if importRequiresInput(source, targetFlowID, eventType) {
+		out := runtimecontracts.FlowInputAutoWireResolution{EventType: eventType}
+		seen := map[string]struct{}{}
+		for _, alias := range ImportBoundaryInputAliases(source, targetFlowID, eventType) {
+			pattern := eventidentity.Normalize(alias.EventPattern)
+			if pattern == "" {
+				continue
+			}
+			if _, ok := seen[pattern]; ok {
+				continue
+			}
+			seen[pattern] = struct{}{}
+			out.Patterns = append(out.Patterns, pattern)
+		}
+		sort.Strings(out.Patterns)
+		return out
+	}
+	return rawResolveFlowInputAutoWire(source, targetFlowID, eventType)
+}
+
+func FlowInputProducerPatterns(source Source, targetFlowID, eventType string) []string {
+	return append([]string{}, ResolveFlowInputAutoWire(source, targetFlowID, eventType).Patterns...)
+}
+
+func ImportBoundaryInputAliasRequired(source Source, targetFlowID, eventType string) bool {
+	targetFlowID = strings.TrimSpace(targetFlowID)
+	eventType = eventidentity.Normalize(eventType)
+	if source == nil || targetFlowID == "" || eventType == "" {
+		return false
+	}
+	return importRequiresInput(source, targetFlowID, eventType)
+}
+
+func ImportBoundaryInputAliases(source Source, targetFlowID, eventType string) []ImportBoundaryPinAlias {
+	targetFlowID = strings.TrimSpace(targetFlowID)
+	eventType = eventidentity.Normalize(eventType)
+	if source == nil || targetFlowID == "" || eventType == "" {
+		return nil
+	}
+	var out []ImportBoundaryPinAlias
+	for _, alias := range importBoundaryPinAliases(source) {
+		if alias.Direction != ImportBoundaryAliasInput {
+			continue
+		}
+		if strings.TrimSpace(alias.FlowID) != targetFlowID || eventidentity.Normalize(alias.Pin) != eventType {
+			continue
+		}
+		out = append(out, alias)
+	}
+	sortImportBoundaryAliases(out)
+	return out
+}
+
+func ImportBoundaryOutputAliasesForParentEvent(source Source, parentPackageKey, parentFlowID, eventType string) []ImportBoundaryPinAlias {
+	parentPackageKey = normalizeImportPackageKey(parentPackageKey)
+	parentFlowID = strings.TrimSpace(parentFlowID)
+	eventType = eventidentity.Normalize(eventType)
+	if source == nil || eventType == "" {
+		return nil
+	}
+	var out []ImportBoundaryPinAlias
+	for _, alias := range importBoundaryPinAliases(source) {
+		if alias.Direction != ImportBoundaryAliasOutput {
+			continue
+		}
+		if parentPackageKey != "" && normalizeImportPackageKey(alias.ParentPackageKey) != parentPackageKey {
+			continue
+		}
+		if parentFlowID != "" && !importBoundaryParentFlowMayConsume(source, parentFlowID, alias.ParentPackageKey) {
+			continue
+		}
+		if eventidentity.Normalize(alias.ParentEvent) != eventType {
+			continue
+		}
+		out = append(out, alias)
+	}
+	sortImportBoundaryAliases(out)
+	return out
+}
+
+func ImportBoundaryOutputParentEventsForEvent(source Source, parentPackageKey, parentFlowID, eventType string) []string {
+	parentPackageKey = normalizeImportPackageKey(parentPackageKey)
+	parentFlowID = strings.TrimSpace(parentFlowID)
+	eventType = eventidentity.Normalize(eventType)
+	if source == nil || eventType == "" {
+		return nil
+	}
+	seen := map[string]struct{}{}
+	var out []string
+	for _, alias := range importBoundaryPinAliases(source) {
+		if alias.Direction != ImportBoundaryAliasOutput {
+			continue
+		}
+		if parentPackageKey != "" && normalizeImportPackageKey(alias.ParentPackageKey) != parentPackageKey {
+			continue
+		}
+		if parentFlowID != "" && !importBoundaryParentFlowMayConsume(source, parentFlowID, alias.ParentPackageKey) {
+			continue
+		}
+		if eventidentity.Normalize(alias.EventPattern) != eventType {
+			continue
+		}
+		parentEvent := eventidentity.Normalize(alias.ParentEvent)
+		if parentEvent == "" {
+			continue
+		}
+		if _, ok := seen[parentEvent]; ok {
+			continue
+		}
+		seen[parentEvent] = struct{}{}
+		out = append(out, parentEvent)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func ImportBoundaryPinAliasIssues(source Source) []ImportBoundaryPinAliasIssue {
+	if source == nil {
+		return nil
+	}
+	projectByKey, flowByPackage := importBoundaryScopeIndexes(source)
+	var issues []ImportBoundaryPinAliasIssue
+	for _, parent := range source.ProjectScopes() {
+		parent.Key = normalizeImportPackageKey(parent.Key)
+		for _, site := range importBoundarySites(parent) {
+			child, ok := projectByKey[site.PackageKey]
+			if !ok || importRequiresEmpty(child.Manifest.Requires) {
+				continue
+			}
+			flows := importBoundarySiteFlows(source, site, flowByPackage)
+			issues = append(issues, importBoundaryDirectionIssues(source, parent, child, site, flows, ImportBoundaryAliasInput, child.Manifest.Requires.Inputs, site.Bind.Inputs)...)
+			issues = append(issues, importBoundaryDirectionIssues(source, parent, child, site, flows, ImportBoundaryAliasOutput, child.Manifest.Requires.Outputs, site.Bind.Outputs)...)
+		}
+	}
+	sort.Slice(issues, func(i, j int) bool {
+		return strings.Compare(importBoundaryIssueSortKey(issues[i]), importBoundaryIssueSortKey(issues[j])) < 0
+	})
+	return issues
+}
+
+func importBoundaryDirectionIssues(source Source, parent, child ProjectScope, site importBoundarySite, flows []FlowScope, direction string, required []string, bindings map[string]string) []ImportBoundaryPinAliasIssue {
+	requiredSet := normalizeImportStringSet(required)
+	pinExists := importBoundaryPinSet(flows, direction)
+	var issues []ImportBoundaryPinAliasIssue
+	for _, pin := range sortedStringSet(requiredSet) {
+		if _, ok := pinExists[pin]; !ok {
+			issues = append(issues, ImportBoundaryPinAliasIssue{
+				Direction:        direction,
+				Kind:             "undeclared_package_pin",
+				ParentPackageKey: parent.Key,
+				ChildPackageKey:  child.Key,
+				ImportLabel:      site.Label,
+				Pin:              pin,
+				Message:          "required package pin is not declared by any imported flow schema",
+			})
+		}
+	}
+	for pin, parentEvent := range bindings {
+		pin = eventidentity.Normalize(pin)
+		parentEvent = eventidentity.Normalize(parentEvent)
+		if pin == "" {
+			continue
+		}
+		if _, ok := requiredSet[pin]; !ok {
+			issues = append(issues, ImportBoundaryPinAliasIssue{
+				Direction:        direction,
+				Kind:             "unknown_required_pin",
+				ParentPackageKey: parent.Key,
+				ChildPackageKey:  child.Key,
+				ImportLabel:      site.Label,
+				Pin:              pin,
+				ParentEvent:      parentEvent,
+				Message:          "bind key is not declared in the imported package requires list",
+			})
+			continue
+		}
+		matches := importBoundaryParentEventMatches(source, parent, flows, parentEvent)
+		if len(matches) == 0 {
+			issues = append(issues, ImportBoundaryPinAliasIssue{
+				Direction:        direction,
+				Kind:             "unknown_parent_event",
+				ParentPackageKey: parent.Key,
+				ChildPackageKey:  child.Key,
+				ImportLabel:      site.Label,
+				Pin:              pin,
+				ParentEvent:      parentEvent,
+				Message:          "bind value does not resolve to a parent-facing event",
+			})
+			continue
+		}
+		if len(matches) > 1 {
+			issues = append(issues, ImportBoundaryPinAliasIssue{
+				Direction:        direction,
+				Kind:             "ambiguous_parent_event",
+				ParentPackageKey: parent.Key,
+				ChildPackageKey:  child.Key,
+				ImportLabel:      site.Label,
+				Pin:              pin,
+				ParentEvent:      parentEvent,
+				Message:          "bind value resolves to multiple parent-facing event producers",
+			})
+		}
+	}
+	return issues
+}
+
+func importBoundaryPinAliases(source Source) []ImportBoundaryPinAlias {
+	if source == nil {
+		return nil
+	}
+	projectByKey, flowByPackage := importBoundaryScopeIndexes(source)
+	var out []ImportBoundaryPinAlias
+	for _, parent := range source.ProjectScopes() {
+		parent.Key = normalizeImportPackageKey(parent.Key)
+		for _, site := range importBoundarySites(parent) {
+			child, ok := projectByKey[site.PackageKey]
+			if !ok || importRequiresEmpty(child.Manifest.Requires) {
+				continue
+			}
+			for _, flow := range importBoundarySiteFlows(source, site, flowByPackage) {
+				out = append(out, importBoundaryDirectionAliases(source, parent, child, site, flow, ImportBoundaryAliasInput, child.Manifest.Requires.Inputs, site.Bind.Inputs)...)
+				out = append(out, importBoundaryDirectionAliases(source, parent, child, site, flow, ImportBoundaryAliasOutput, child.Manifest.Requires.Outputs, site.Bind.Outputs)...)
+			}
+		}
+	}
+	sortImportBoundaryAliases(out)
+	return out
+}
+
+func importBoundaryDirectionAliases(source Source, parent, child ProjectScope, site importBoundarySite, flow FlowScope, direction string, required []string, bindings map[string]string) []ImportBoundaryPinAlias {
+	requiredSet := normalizeImportStringSet(required)
+	pinSet := importBoundaryPinSet([]FlowScope{flow}, direction)
+	var out []ImportBoundaryPinAlias
+	for _, pin := range sortedStringSet(requiredSet) {
+		if _, ok := pinSet[pin]; !ok {
+			continue
+		}
+		parentEvent := eventidentity.Normalize(bindings[pin])
+		if parentEvent == "" {
+			continue
+		}
+		pattern := parentEvent
+		if direction == ImportBoundaryAliasOutput {
+			pattern = eventidentity.Normalize(source.ResolveFlowEventReference(flow.ID, pin))
+		}
+		out = append(out, ImportBoundaryPinAlias{
+			Direction:        direction,
+			ParentPackageKey: parent.Key,
+			ChildPackageKey:  child.Key,
+			ImportLabel:      site.Label,
+			FlowID:           strings.TrimSpace(flow.ID),
+			Pin:              pin,
+			ParentEvent:      parentEvent,
+			EventPattern:     pattern,
+		})
+	}
+	return out
+}
+
+func importRequiresInput(source Source, flowID, eventType string) bool {
+	scope, ok := source.FlowScopeByID(flowID)
+	if !ok {
+		return false
+	}
+	projectByKey, _ := importBoundaryScopeIndexes(source)
+	project, ok := projectByKey[normalizeImportPackageKey(scope.PackageKey)]
+	if ok {
+		required := normalizeImportStringSet(project.Manifest.Requires.Inputs)
+		if _, ok := required[eventidentity.Normalize(eventType)]; ok {
+			return true
+		}
+	}
+	for _, parent := range source.ProjectScopes() {
+		parent.Key = normalizeImportPackageKey(parent.Key)
+		for _, site := range importBoundarySites(parent) {
+			if strings.TrimSpace(site.FlowID) != flowID {
+				continue
+			}
+			child, ok := projectByKey[site.PackageKey]
+			if !ok {
+				continue
+			}
+			required := normalizeImportStringSet(child.Manifest.Requires.Inputs)
+			if _, ok := required[eventidentity.Normalize(eventType)]; ok {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func rawResolveFlowInputAutoWire(source Source, targetFlowID, eventType string) runtimecontracts.FlowInputAutoWireResolution {
+	if bundle, ok := Bundle(source); ok && bundle != nil {
+		return bundle.ResolveFlowInputAutoWire(targetFlowID, eventType)
+	}
+	out := runtimecontracts.FlowInputAutoWireResolution{EventType: eventidentity.Normalize(eventType)}
+	if source == nil || targetFlowID == "" || out.EventType == "" || !source.FlowHasInputEvent(targetFlowID, out.EventType) {
+		return out
+	}
+	seenPatterns := map[string]struct{}{}
+	appendPattern := func(value string) {
+		value = eventidentity.Normalize(value)
+		if value == "" {
+			return
+		}
+		if _, ok := seenPatterns[value]; ok {
+			return
+		}
+		seenPatterns[value] = struct{}{}
+		out.Patterns = append(out.Patterns, value)
+	}
+	for _, scope := range source.ProjectScopes() {
+		if _, ok := scope.Events[out.EventType]; ok {
+			appendPattern(out.EventType)
+		}
+	}
+	seenFlows := map[string]struct{}{}
+	for _, scope := range source.FlowScopes() {
+		flowID := strings.TrimSpace(scope.ID)
+		if flowID == "" || flowID == targetFlowID || !source.FlowHasOutputEvent(flowID, out.EventType) {
+			continue
+		}
+		if _, ok := seenFlows[flowID]; ok {
+			continue
+		}
+		seenFlows[flowID] = struct{}{}
+		out.ProducerFlows = append(out.ProducerFlows, flowID)
+	}
+	sort.Strings(out.ProducerFlows)
+	if len(out.ProducerFlows) == 1 {
+		appendPattern(importBoundaryFlowEventReference(source, out.ProducerFlows[0], out.EventType))
+	}
+	sort.Strings(out.Patterns)
+	return out
+}
+
+func importBoundaryScopeIndexes(source Source) (map[string]ProjectScope, map[string][]FlowScope) {
+	projectByKey := map[string]ProjectScope{}
+	for _, scope := range source.ProjectScopes() {
+		scope.Key = normalizeImportPackageKey(scope.Key)
+		if scope.Key != "" {
+			projectByKey[scope.Key] = scope
+		}
+	}
+	flowByPackage := map[string][]FlowScope{}
+	for _, scope := range source.FlowScopes() {
+		key := normalizeImportPackageKey(scope.PackageKey)
+		if key == "" {
+			continue
+		}
+		flowByPackage[key] = append(flowByPackage[key], scope)
+	}
+	for key := range flowByPackage {
+		sort.Slice(flowByPackage[key], func(i, j int) bool {
+			return strings.Compare(flowByPackage[key][i].ID, flowByPackage[key][j].ID) < 0
+		})
+	}
+	return projectByKey, flowByPackage
+}
+
+func importBoundarySites(scope ProjectScope) []importBoundarySite {
+	scope.Key = normalizeImportPackageKey(scope.Key)
+	var sites []importBoundarySite
+	for _, flow := range scope.Manifest.Flows {
+		flowDir := strings.TrimSpace(flow.Flow)
+		if flowDir == "" {
+			continue
+		}
+		sites = append(sites, importBoundarySite{
+			PackageKey: joinImportPackageKey(scope.Key, "flows", flowDir),
+			Label:      "flow " + strings.TrimSpace(flow.ID),
+			FlowID:     strings.TrimSpace(flow.ID),
+			Bind:       flow.Bind,
+		})
+	}
+	for _, ref := range scope.Manifest.ChildPackages() {
+		location := importBoundaryPackageLocation(ref)
+		if location == "" {
+			continue
+		}
+		sites = append(sites, importBoundarySite{
+			PackageKey: joinImportPackageKey(scope.Key, location),
+			Label:      "package " + location,
+			Bind:       ref.Bind,
+		})
+	}
+	sort.Slice(sites, func(i, j int) bool {
+		return strings.Compare(sites[i].PackageKey+"|"+sites[i].Label, sites[j].PackageKey+"|"+sites[j].Label) < 0
+	})
+	return sites
+}
+
+func importBoundaryPackageLocation(ref runtimecontracts.ProjectPackageRef) string {
+	location := strings.TrimSpace(ref.ResolveLocation())
+	if location == "" {
+		return ""
+	}
+	location = strings.Trim(path.Clean(strings.ReplaceAll(location, "\\", "/")), "/")
+	if strings.HasSuffix(strings.ToLower(location), ".yaml") {
+		location = path.Dir(location)
+	}
+	if location == "." {
+		return ""
+	}
+	return location
+}
+
+func importBoundaryPinSet(flows []FlowScope, direction string) map[string]struct{} {
+	out := map[string]struct{}{}
+	for _, flow := range flows {
+		var pins []string
+		if direction == ImportBoundaryAliasOutput {
+			pins = flow.OutputEvents
+		} else {
+			pins = flow.InputEvents
+		}
+		for _, pin := range pins {
+			pin = eventidentity.Normalize(pin)
+			if pin != "" {
+				out[pin] = struct{}{}
+			}
+		}
+	}
+	return out
+}
+
+func importBoundaryParentEventMatches(source Source, parent ProjectScope, childFlows []FlowScope, parentEvent string) []string {
+	parentEvent = eventidentity.Normalize(parentEvent)
+	if source == nil || parentEvent == "" {
+		return nil
+	}
+	excludedFlowIDs := map[string]struct{}{}
+	for _, flow := range childFlows {
+		if flowID := strings.TrimSpace(flow.ID); flowID != "" {
+			excludedFlowIDs[flowID] = struct{}{}
+		}
+	}
+	seen := map[string]struct{}{}
+	appendMatch := func(value string) {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			return
+		}
+		seen[value] = struct{}{}
+	}
+	if _, ok := parent.Events[parentEvent]; ok {
+		appendMatch("project:" + normalizeImportPackageKey(parent.Key))
+	}
+	for _, flow := range source.FlowScopes() {
+		if _, excluded := excludedFlowIDs[strings.TrimSpace(flow.ID)]; excluded {
+			continue
+		}
+		for _, output := range flow.OutputEvents {
+			output = eventidentity.Normalize(output)
+			if output == "" {
+				continue
+			}
+			if output == parentEvent || eventidentity.Normalize(importBoundaryFlowEventReference(source, flow.ID, output)) == parentEvent {
+				appendMatch("flow:" + strings.TrimSpace(flow.ID))
+			}
+		}
+	}
+	return sortedStringSet(seen)
+}
+
+func importBoundarySiteFlows(source Source, site importBoundarySite, flowByPackage map[string][]FlowScope) []FlowScope {
+	if flowID := strings.TrimSpace(site.FlowID); flowID != "" {
+		if flow, ok := source.FlowScopeByID(flowID); ok {
+			return []FlowScope{flow}
+		}
+		return nil
+	}
+	return flowByPackage[site.PackageKey]
+}
+
+func importBoundaryFlowEventReference(source Source, flowID, eventType string) string {
+	if source == nil {
+		return eventidentity.Normalize(eventType)
+	}
+	if ref := eventidentity.Normalize(source.ResolveFlowEventReference(flowID, eventType)); ref != "" {
+		return ref
+	}
+	flowPath := eventidentity.Normalize(source.FlowPath(flowID))
+	eventType = eventidentity.Normalize(eventType)
+	if flowPath == "" {
+		return eventType
+	}
+	if eventType == "" {
+		return flowPath
+	}
+	return flowPath + "/" + eventType
+}
+
+func importBoundaryParentFlowMayConsume(source Source, parentFlowID, parentPackageKey string) bool {
+	if parentFlowID == "" {
+		return true
+	}
+	scope, ok := source.FlowScopeByID(parentFlowID)
+	if !ok {
+		return false
+	}
+	return normalizeImportPackageKey(scope.PackageKey) == normalizeImportPackageKey(parentPackageKey)
+}
+
+func normalizeImportStringSet(values []string) map[string]struct{} {
+	out := map[string]struct{}{}
+	for _, value := range values {
+		value = eventidentity.Normalize(value)
+		if value != "" {
+			out[value] = struct{}{}
+		}
+	}
+	return out
+}
+
+func importRequiresEmpty(requires runtimecontracts.FlowPackageRequires) bool {
+	return len(requires.Inputs) == 0 &&
+		len(requires.Outputs) == 0 &&
+		len(requires.Policy) == 0 &&
+		len(requires.Credentials) == 0 &&
+		strings.TrimSpace(requires.PlatformVersion) == ""
+}
+
+func joinImportPackageKey(base string, segments ...string) string {
+	parts := make([]string, 0, 1+len(segments))
+	if base = normalizeImportPackageKey(base); base != "" && base != "." {
+		parts = append(parts, base)
+	}
+	for _, segment := range segments {
+		segment = strings.Trim(path.Clean(strings.ReplaceAll(strings.TrimSpace(segment), "\\", "/")), "/")
+		if segment == "" || segment == "." {
+			continue
+		}
+		parts = append(parts, segment)
+	}
+	if len(parts) == 0 {
+		return "."
+	}
+	return normalizeImportPackageKey(path.Join(parts...))
+}
+
+func normalizeImportPackageKey(key string) string {
+	key = strings.Trim(path.Clean(strings.ReplaceAll(strings.TrimSpace(key), "\\", "/")), "/")
+	if key == "" || key == "." {
+		return "."
+	}
+	return key
+}
+
+func sortedStringSet(values map[string]struct{}) []string {
+	out := make([]string, 0, len(values))
+	for value := range values {
+		if strings.TrimSpace(value) != "" {
+			out = append(out, value)
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+func sortImportBoundaryAliases(values []ImportBoundaryPinAlias) {
+	sort.Slice(values, func(i, j int) bool {
+		return strings.Compare(importBoundaryAliasSortKey(values[i]), importBoundaryAliasSortKey(values[j])) < 0
+	})
+}
+
+func importBoundaryAliasSortKey(alias ImportBoundaryPinAlias) string {
+	return strings.Join([]string{
+		alias.Direction,
+		alias.ParentPackageKey,
+		alias.ChildPackageKey,
+		alias.FlowID,
+		alias.Pin,
+		alias.ParentEvent,
+		alias.EventPattern,
+	}, "|")
+}
+
+func importBoundaryIssueSortKey(issue ImportBoundaryPinAliasIssue) string {
+	return strings.Join([]string{
+		issue.Direction,
+		issue.Kind,
+		issue.ParentPackageKey,
+		issue.ChildPackageKey,
+		issue.FlowID,
+		issue.Pin,
+		issue.ParentEvent,
+	}, "|")
+}

--- a/internal/runtime/semanticview/import_boundary_aliases_test.go
+++ b/internal/runtime/semanticview/import_boundary_aliases_test.go
@@ -18,6 +18,13 @@ func TestImportBoundaryPinAliasesResolveInputAndOutputBindings(t *testing.T) {
 	if !ImportBoundaryInputAliasRequired(source, "worker", "work.requested") {
 		t.Fatal("expected work.requested to require import-boundary input alias")
 	}
+	inputs := ImportBoundaryInputAliasesForParentEvent(source, "worker", "parent.lead_captured")
+	if len(inputs) != 1 {
+		t.Fatalf("input aliases for parent event = %#v, want one", inputs)
+	}
+	if got, want := inputs[0].Pin, "work.requested"; got != want {
+		t.Fatalf("input alias pin = %q, want %q", got, want)
+	}
 
 	outputs := ImportBoundaryOutputAliasesForParentEvent(source, ".", "", "parent.lead_enriched")
 	if len(outputs) != 1 {
@@ -25,6 +32,10 @@ func TestImportBoundaryPinAliasesResolveInputAndOutputBindings(t *testing.T) {
 	}
 	if got, want := outputs[0].EventPattern, "worker/work.completed"; got != want {
 		t.Fatalf("output event pattern = %q, want %q", got, want)
+	}
+	scopedOutputs := ImportBoundaryOutputAliasesForParent(source, ".", "")
+	if len(scopedOutputs) != 1 {
+		t.Fatalf("scoped output aliases = %#v, want one", scopedOutputs)
 	}
 
 	parentEvents := ImportBoundaryOutputParentEventsForEvent(source, ".", "", "worker/work.completed")

--- a/internal/runtime/semanticview/import_boundary_aliases_test.go
+++ b/internal/runtime/semanticview/import_boundary_aliases_test.go
@@ -1,0 +1,199 @@
+package semanticview
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
+)
+
+func TestImportBoundaryPinAliasesResolveInputAndOutputBindings(t *testing.T) {
+	source := loadImportBoundaryAliasFixture(t, importBoundaryAliasFixtureOptions{})
+
+	resolution := source.ResolveFlowInputAutoWire("worker", "work.requested")
+	if got, want := resolution.Patterns, []string{"parent.lead_captured"}; len(got) != len(want) || got[0] != want[0] {
+		t.Fatalf("ResolveFlowInputAutoWire patterns = %#v, want %#v", got, want)
+	}
+	if !ImportBoundaryInputAliasRequired(source, "worker", "work.requested") {
+		t.Fatal("expected work.requested to require import-boundary input alias")
+	}
+
+	outputs := ImportBoundaryOutputAliasesForParentEvent(source, ".", "", "parent.lead_enriched")
+	if len(outputs) != 1 {
+		t.Fatalf("output aliases = %#v, want one", outputs)
+	}
+	if got, want := outputs[0].EventPattern, "worker/work.completed"; got != want {
+		t.Fatalf("output event pattern = %q, want %q", got, want)
+	}
+
+	parentEvents := ImportBoundaryOutputParentEventsForEvent(source, ".", "", "worker/work.completed")
+	if got, want := parentEvents, []string{"parent.lead_enriched"}; len(got) != len(want) || got[0] != want[0] {
+		t.Fatalf("output parent events = %#v, want %#v", got, want)
+	}
+}
+
+func TestImportBoundaryInputAliasRequiredDoesNotRawFallbackToSameNameProducer(t *testing.T) {
+	source := loadImportBoundaryAliasFixture(t, importBoundaryAliasFixtureOptions{
+		producerOutput: "work.requested",
+	})
+
+	resolution := source.ResolveFlowInputAutoWire("worker", "work.requested")
+	if got, want := resolution.Patterns, []string{"parent.lead_captured"}; len(got) != len(want) || got[0] != want[0] {
+		t.Fatalf("ResolveFlowInputAutoWire patterns = %#v, want only explicit bind %#v", got, want)
+	}
+}
+
+func TestImportBoundaryPinAliasIssuesReportUnknownAndAmbiguousParentEvents(t *testing.T) {
+	t.Run("unknown parent event", func(t *testing.T) {
+		source := loadImportBoundaryAliasFixture(t, importBoundaryAliasFixtureOptions{
+			inputBind: "parent.missing_event",
+		})
+		issues := ImportBoundaryPinAliasIssues(source)
+		if !importBoundaryAliasIssueContains(issues, "unknown_parent_event", "parent.missing_event") {
+			t.Fatalf("issues = %#v, want unknown parent event", issues)
+		}
+	})
+
+	t.Run("ambiguous parent event", func(t *testing.T) {
+		source := loadImportBoundaryAliasFixture(t, importBoundaryAliasFixtureOptions{
+			inputBind:        "shared.ready",
+			producerOutput:   "shared.ready",
+			secondProducerID: "producer_b",
+		})
+		issues := ImportBoundaryPinAliasIssues(source)
+		if !importBoundaryAliasIssueContains(issues, "ambiguous_parent_event", "shared.ready") {
+			t.Fatalf("issues = %#v, want ambiguous parent event", issues)
+		}
+	})
+}
+
+func importBoundaryAliasIssueContains(issues []ImportBoundaryPinAliasIssue, kind, parentEvent string) bool {
+	for _, issue := range issues {
+		if issue.Kind == kind && issue.ParentEvent == parentEvent {
+			return true
+		}
+	}
+	return false
+}
+
+type importBoundaryAliasFixtureOptions struct {
+	inputBind        string
+	outputBind       string
+	producerOutput   string
+	secondProducerID string
+}
+
+func loadImportBoundaryAliasFixture(t *testing.T, opts importBoundaryAliasFixtureOptions) Source {
+	t.Helper()
+	repoRoot, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd: %v", err)
+	}
+	repoRoot = filepath.Clean(filepath.Join(repoRoot, "..", "..", ".."))
+	root := writeImportBoundaryAliasFixture(t, opts)
+	bundle, err := runtimecontracts.LoadWorkflowContractBundleWithOverrides(repoRoot, root, runtimecontracts.DefaultPlatformSpecFile(repoRoot))
+	if err != nil {
+		t.Fatalf("LoadWorkflowContractBundleWithOverrides: %v", err)
+	}
+	return Wrap(bundle)
+}
+
+func writeImportBoundaryAliasFixture(t *testing.T, opts importBoundaryAliasFixtureOptions) string {
+	t.Helper()
+	if opts.inputBind == "" {
+		opts.inputBind = "parent.lead_captured"
+	}
+	if opts.outputBind == "" {
+		opts.outputBind = "parent.lead_enriched"
+	}
+	root := t.TempDir()
+	flows := `  - id: worker
+    flow: worker
+    mode: static
+    bind:
+      inputs:
+        work.requested: ` + opts.inputBind + `
+      outputs:
+        work.completed: ` + opts.outputBind + `
+`
+	if opts.producerOutput != "" {
+		flows = `  - id: producer
+    flow: producer
+    mode: static
+` + flows
+	}
+	if opts.secondProducerID != "" {
+		flows = `  - id: ` + opts.secondProducerID + `
+    flow: ` + opts.secondProducerID + `
+    mode: static
+` + flows
+	}
+	writeSemanticviewFixtureFile(t, filepath.Join(root, "package.yaml"), `
+name: import-boundary-alias
+version: "1.0.0"
+platform_version: ">=1.6.0"
+flows:
+`+flows)
+	writeSemanticviewFixtureFile(t, filepath.Join(root, "schema.yaml"), "name: import-boundary-alias\n")
+	writeSemanticviewFixtureFile(t, filepath.Join(root, "policy.yaml"), "{}\n")
+	writeSemanticviewFixtureFile(t, filepath.Join(root, "tools.yaml"), "{}\n")
+	writeSemanticviewFixtureFile(t, filepath.Join(root, "agents.yaml"), "{}\n")
+	writeSemanticviewFixtureFile(t, filepath.Join(root, "events.yaml"), `
+parent.lead_captured: {}
+parent.lead_enriched: {}
+`)
+	writeImportBoundaryAliasFlow(t, root, "worker", `
+pins:
+  inputs:
+    events: [work.requested]
+  outputs:
+    events: [work.completed]
+`, "")
+	if opts.producerOutput != "" {
+		writeImportBoundaryAliasFlow(t, root, "producer", `
+pins:
+  outputs:
+    events: [`+opts.producerOutput+`]
+`, opts.producerOutput)
+	}
+	if opts.secondProducerID != "" {
+		writeImportBoundaryAliasFlow(t, root, opts.secondProducerID, `
+pins:
+  outputs:
+    events: [`+opts.producerOutput+`]
+`, opts.producerOutput)
+	}
+	return root
+}
+
+func writeImportBoundaryAliasFlow(t *testing.T, root, flowID, schemaTail, outputEvent string) {
+	t.Helper()
+	writeSemanticviewFixtureFile(t, filepath.Join(root, "flows", flowID, "package.yaml"), `
+name: `+flowID+`
+version: "1.0.0"
+requires:
+  inputs: []
+  outputs: []
+`)
+	if flowID == "worker" {
+		writeSemanticviewFixtureFile(t, filepath.Join(root, "flows", flowID, "package.yaml"), `
+name: worker
+version: "1.0.0"
+requires:
+  inputs: [work.requested]
+  outputs: [work.completed]
+`)
+	}
+	writeSemanticviewFixtureFile(t, filepath.Join(root, "flows", flowID, "schema.yaml"), `
+name: `+flowID+`
+mode: static
+`+schemaTail)
+	writeSemanticviewFixtureFile(t, filepath.Join(root, "flows", flowID, "policy.yaml"), "{}\n")
+	writeSemanticviewFixtureFile(t, filepath.Join(root, "flows", flowID, "agents.yaml"), "{}\n")
+	if outputEvent == "" {
+		writeSemanticviewFixtureFile(t, filepath.Join(root, "flows", flowID, "events.yaml"), "{}\n")
+		return
+	}
+	writeSemanticviewFixtureFile(t, filepath.Join(root, "flows", flowID, "events.yaml"), outputEvent+": {}\n")
+}

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -4583,12 +4583,32 @@ flow_model:
         rule: >
           If an imported package declares any item under `requires.inputs`, `requires.outputs`, `requires.policy`, or
           `requires.credentials`, boot/verify must report a hard invalidity unless the parent import site provides a
-          non-empty `bind` entry for that exact item in the matching field. This first slice verifies binding presence
-          only; it does not execute runtime pin alias delivery or runtime policy/credential resolution.
+          non-empty `bind` entry for that exact item in the matching field. For `requires.inputs` and
+          `requires.outputs`, boot/verify must also fail closed when a `bind` key is not declared by the imported
+          package public pin list, when the package-local pin is not declared by an imported flow schema, or when the
+          parent-facing event binding is unknown or ambiguous.
         unsupported_shapes: Unknown `requires` or `bind` fields, non-list `requires` fields, and non-map `bind` fields are
           malformed contract input and must fail closed during contract parsing.
+      pin_alias_delivery:
+        owner: Runtime import-boundary pin alias resolver over semanticview ProjectScopes and FlowScopes.
+        inputs: >
+          For an imported package with a declared `requires.inputs` pin, the parent import-site `bind.inputs` value is
+          the canonical producer pattern consumed by flow input auto-wire, boot/verify input pin wiring, RouteTable
+          static/template derivation, EventBus recipient planning/persistence, and workflow-node materialization.
+          The child handler still consumes the package-local input pin name as its localized event. Raw same-name
+          local input fallback is forbidden for declared imported package input pins; same-name fallback remains valid
+          only for authored/local flows or imports that do not declare the input requirement.
+        outputs: >
+          For an imported package with a declared `requires.outputs` pin, the emitted/persisted event identity remains
+          the child flow output event pattern. Parent-facing subscribers consume the parent import-site `bind.outputs`
+          event name through the same runtime alias resolver. Delivery/readback localized event for the parent consumer
+          is the parent-facing event name; the source event identity, replay scope, target routing metadata, broadcast
+          semantics, correlation, and cardinality are not rewritten by the alias.
+        fail_closed: >
+          Runtime consumers must use the shared import-boundary alias resolver; local helpers must not independently
+          reinterpret package-local pins, parent event names, or raw same-name fallback for declared imported package
+          pins.
       split_runtime_semantics:
-        pin_alias_delivery: Runtime delivery through `bind.inputs` / `bind.outputs` is tracked separately by #1452.
         policy_credential_resolution: Runtime per-import policy and credential resolution is tracked separately by #1453.
         wildcard_grants: Wildcard subtree and cross-tree grant behavior is tracked separately by #1454.
         final_e2e_package_proof: Final multi-package marketplace-style runtime proof is tracked separately by #1455.


### PR DESCRIPTION
## Summary
- Promotes runtime delivery semantics for imported package `bind.inputs` / `bind.outputs` into `platform-spec.yaml` under `flow_model.flow_package.import_boundary.pin_alias_delivery`.
- Adds a shared semanticview import-boundary pin alias resolver over `ProjectScopes()` / `FlowScopes()`.
- Moves flow input auto-wire, bootverify input-pin wiring/alias validation, RouteTable/EventBus delivery planning, and workflow-node materialization/handler readback onto that shared owner.

Closes #1452
Part of #1450

## Governing refs / context
- `platform-spec.yaml#flow_model.flow_package.import_boundary.requires_manifest`
- `platform-spec.yaml#flow_model.flow_package.import_boundary.import_site_bind`
- `platform-spec.yaml#flow_model.flow_package.import_boundary.fail_closed_minimal_verify`
- New merge artifact in this PR: `platform-spec.yaml#flow_model.flow_package.import_boundary.pin_alias_delivery`
- Approved gate: #1452 Pre-Implementation Coverage Audit and lead approval.

## Semantic migration
- New canonical owner: runtime import-boundary pin alias resolver in `internal/runtime/semanticview/import_boundary_aliases.go`, consuming semanticview `ProjectScopes()` and `FlowScopes()`.
- Old non-authoritative paths now invalid: local/raw same-name fallback for declared imported package `requires.inputs`; per-consumer reinterpretation in flow auto-wire, bootverify input-pin wiring, RouteTable derivation, EventBus localized readback, and workflow-node materialization.
- Surviving old behavior checked: authored/local flows and imports without declared `requires.inputs` / `requires.outputs` still keep legacy same-name behavior, including tier11 catalog fixtures.
- Migration completeness: complete for #1452 pin alias delivery/readback only. Remaining out of scope: #1453 policy/credential resolution, #1454 wildcard grants, #1455 final package e2e, and #1461 target/broadcast/correlation/cardinality semantics.

## Proof
- `ruby -e 'require "yaml"; YAML.load_file("platform-spec.yaml"); puts "platform-spec.yaml parsed"'`
- `go test ./internal/runtime/semanticview ./internal/runtime/bootverify ./internal/runtime/bus ./internal/runtime/pipeline -run 'ImportBoundary|FlowPackage|FlowInputAutoWire|InputPin|PinTarget|DeriveRouteTable|CheckPublishRecipientPlan|Publish|WorkflowNode|WorkflowFlowInputProducerAliases' -count=1`
- `go test ./internal/runtime/bootverify ./internal/runtime/cataloge2e ./internal/runtime/semanticview ./internal/runtime/bus ./internal/runtime/pipeline -run 'BootCheckRegistry|Tier11FlowCompositionCatalogFixtures_RealRuntime|ImportBoundary|FlowPackage|WorkflowNode' -count=1`
- `go test ./...`