### PR TITLE
[agent-a][issue #1467] Define composition routing source authority

### DIFF
--- a/internal/apispec/platform_spec_composition_routing_test.go
+++ b/internal/apispec/platform_spec_composition_routing_test.go
@@ -1,8 +1,11 @@
 package apispec
 
 import (
+	"os"
+	"strings"
 	"testing"
 
+	"github.com/division-sh/swarm/internal/platform"
 	"gopkg.in/yaml.v3"
 )
 
@@ -88,20 +91,31 @@ func TestPlatformSpecCompositionRoutingDemotesProducerTargetAuthority(t *testing
 	if !sequenceContainsScalar(mustYAMLPath(t, crossFlow, "target_resolution", "precedence"), "lowered parent connect route plan") {
 		t.Fatal("cross_flow_routing target precedence must start from lowered parent connect route plan")
 	}
-	assertScalarContains(t, mustYAMLPath(t, crossFlow, "target_resolution", "explicit_target_wins"), "exceptional dynamic-routing escape hatch")
+	assertScalarContains(t, mustYAMLPath(t, crossFlow, "target_resolution", "explicit_target_escape_hatch"), "exceptional dynamic-routing escape hatch")
+	assertScalarContains(t, mustYAMLPath(t, crossFlow, "target_resolution", "explicit_target_escape_hatch"), "must not replace lowered parent connect")
 	assertScalarContains(t, mustYAMLPath(t, crossFlow, "target_resolution", "fail_closed"), "no lowered parent connect route")
 	assertScalarContains(t, mustYAMLPath(t, crossFlow, "auto_wiring", "description"), "only as an inference candidate")
+	assertScalarContains(t, mustYAMLPath(t, crossFlow, "activation", "rule"), "valid lowered parent connect route")
+	assertScalarContains(t, mustYAMLPath(t, crossFlow, "auto_wiring", "template_pairs"), "lowered parent connect route facts")
 
 	assertScalarContains(t, mustYAMLPath(t, crossFlow, "target_forms", "flow_match_allow_fanout"), "explicit dynamic fan-out escape hatch")
 	assertScalarContains(t, mustYAMLPath(t, crossFlow, "target_forms", "broadcast"), "producer-authored explicit opt-out escape hatch")
+	assertScalarContains(t, mustYAMLPath(t, crossFlow, "structural_binding", "precedence_guard"), "lower precedence than lowered parent connect")
+	assertScalarContains(t, mustYAMLPath(t, crossFlow, "structural_binding", "child_to_parent"), "no lowered parent connect route")
+	assertScalarContains(t, mustYAMLPath(t, crossFlow, "structural_binding", "static_child_no_instance"), "without a lowered parent connect route")
+	assertScalarContains(t, mustYAMLPath(t, crossFlow, "parent_route", "read_rule"), "no lowered parent connect route applies")
 
 	pinAuthority := mustYAMLPath(t, root, "flow_model", "pins", "routing_authority")
 	assertScalarContains(t, pinAuthority, "Parent package connect entries own common inter-flow topology")
 	assertScalarContains(t, pinAuthority, "flow_model.flow_package.composition_routing")
+	assertScalarContains(t, mustYAMLPath(t, root, "flow_model", "pins", "output_event_pins", "description"), "no lowered connect route applies")
 
 	pinTargetResolution := mustYAMLPath(t, root, "static_analyzer", "slice_3a_pin_target_resolution")
 	assertScalarValue(t, mustMappingValue(t, pinTargetResolution, "canonical_replacement"), "flow_model.flow_package.composition_routing.analyzer_verify_requirements")
 	assertScalarContains(t, mustYAMLPath(t, pinTargetResolution, "accepted_target_mechanisms", "lowered_parent_connect", "rule"), "Parent connect")
+	assertScalarContains(t, mustYAMLPath(t, pinTargetResolution, "accepted_target_mechanisms", "structural_parent_route", "rule"), "no lowered parent connect route applies")
+	assertScalarContains(t, mustYAMLPath(t, pinTargetResolution, "scope", "description"), "no lowered connect route applies")
+	assertScalarContains(t, mustYAMLPath(t, pinTargetResolution, "scope", "description"), "eligible static child delivery-entity")
 }
 
 func TestPlatformSpecCompositionRoutingCatalogSurfacesConsumeConnectAuthority(t *testing.T) {
@@ -115,6 +129,7 @@ func TestPlatformSpecCompositionRoutingCatalogSurfacesConsumeConnectAuthority(t 
 		assertScalarContains(t, node, "lowered parent connect")
 		assertScalarContains(t, node, "explicit target")
 		assertScalarContains(t, node, "broadcast:true")
+		assertScalarContains(t, node, "eligible static child delivery-entity route")
 	}
 
 	checks := mustYAMLPath(t, root, "engine", "boot_verification", "checks")
@@ -125,6 +140,38 @@ func TestPlatformSpecCompositionRoutingCatalogSurfacesConsumeConnectAuthority(t 
 	pinTargetResolution := mustSequenceMappingByScalarField(t, checks, "id", "pin_target_resolution")
 	assertScalarContains(t, mustMappingValue(t, pinTargetResolution, "trigger"), "lowered parent connect route")
 	assertScalarContains(t, mustMappingValue(t, pinTargetResolution, "trigger"), "explicit target escape hatch")
+	assertScalarContains(t, mustMappingValue(t, pinTargetResolution, "trigger"), "eligible static child delivery-entity route")
+
+	bootSteps := mustYAMLPath(t, root, "engine", "boot_sequence", "steps")
+	validatePins := mustSequenceMappingByScalarField(t, bootSteps, "name", "validate_pins")
+	assertScalarContains(t, mustMappingValue(t, validatePins, "action"), "flow_model.flow_package.composition_routing")
+	assertScalarContains(t, mustMappingValue(t, validatePins, "action"), "lowered parent connect supplies singular event.target")
+	assertScalarContains(t, mustMappingValue(t, validatePins, "action"), "event.target_set route facts")
+	assertScalarContains(t, mustMappingValue(t, validatePins, "action"), "when no lowered connect route applies")
+	assertScalarContains(t, mustMappingValue(t, validatePins, "action"), "broadcast:true is the explicit no-target opt-out")
+}
+
+func TestPlatformSpecCompositionRoutingRejectsStaleParentRouteAuthorityPhrases(t *testing.T) {
+	specPath := platform.DefaultPlatformSpecFile(repoRoot(t))
+	raw, err := os.ReadFile(specPath)
+	if err != nil {
+		t.Fatalf("read %s: %v", specPath, err)
+	}
+	text := string(raw)
+	for _, phrase := range []string{
+		"without explicit target route to the recorded ParentRoute",
+		"writes event.target when no explicit target exists",
+		"must have a target mechanism or broadcast:true",
+		"Pin-declared output has no target, no structural ParentRoute",
+		"No explicit target, no structural ParentRoute",
+		"checks only sibling flow output pins",
+		"pin target mechanism",
+		"explicit_target_wins",
+	} {
+		if strings.Contains(text, phrase) {
+			t.Fatalf("platform-spec.yaml still contains stale composition-routing authority phrase %q", phrase)
+		}
+	}
 }
 
 func mustYAMLPath(t *testing.T, node *yaml.Node, keys ...string) *yaml.Node {

--- a/internal/apispec/platform_spec_composition_routing_test.go
+++ b/internal/apispec/platform_spec_composition_routing_test.go
@@ -104,6 +104,29 @@ func TestPlatformSpecCompositionRoutingDemotesProducerTargetAuthority(t *testing
 	assertScalarContains(t, mustYAMLPath(t, pinTargetResolution, "accepted_target_mechanisms", "lowered_parent_connect", "rule"), "Parent connect")
 }
 
+func TestPlatformSpecCompositionRoutingCatalogSurfacesConsumeConnectAuthority(t *testing.T) {
+	root := loadPlatformSpecYAMLNode(t)
+
+	targetRequiredMissing := collectMappingValuesByKey(root, "target_required_missing")
+	if len(targetRequiredMissing) == 0 {
+		t.Fatal("expected at least one target_required_missing spec surface")
+	}
+	for _, node := range targetRequiredMissing {
+		assertScalarContains(t, node, "lowered parent connect")
+		assertScalarContains(t, node, "explicit target")
+		assertScalarContains(t, node, "broadcast:true")
+	}
+
+	checks := mustYAMLPath(t, root, "engine", "boot_verification", "checks")
+	inputPinWiring := mustSequenceMappingByScalarField(t, checks, "id", "input_pin_wiring")
+	assertScalarContains(t, mustMappingValue(t, inputPinWiring, "trigger"), "parent package.yaml connect entries")
+	assertScalarContains(t, mustMappingValue(t, inputPinWiring, "trigger"), "safe same-name sibling")
+
+	pinTargetResolution := mustSequenceMappingByScalarField(t, checks, "id", "pin_target_resolution")
+	assertScalarContains(t, mustMappingValue(t, pinTargetResolution, "trigger"), "lowered parent connect route")
+	assertScalarContains(t, mustMappingValue(t, pinTargetResolution, "trigger"), "explicit target escape hatch")
+}
+
 func mustYAMLPath(t *testing.T, node *yaml.Node, keys ...string) *yaml.Node {
 	t.Helper()
 	current := node
@@ -111,4 +134,45 @@ func mustYAMLPath(t *testing.T, node *yaml.Node, keys ...string) *yaml.Node {
 		current = mustMappingValue(t, current, key)
 	}
 	return current
+}
+
+func mustSequenceMappingByScalarField(t *testing.T, node *yaml.Node, field, value string) *yaml.Node {
+	t.Helper()
+	if node == nil || node.Kind != yaml.SequenceNode {
+		t.Fatalf("node is kind %v, want sequence", nodeKind(node))
+	}
+	for _, item := range node.Content {
+		if scalarValue(mappingValue(item, field)) == value {
+			return item
+		}
+	}
+	t.Fatalf("sequence mapping with %s=%q not found", field, value)
+	return nil
+}
+
+func collectMappingValuesByKey(node *yaml.Node, key string) []*yaml.Node {
+	if node == nil {
+		return nil
+	}
+	var out []*yaml.Node
+	if node.Kind == yaml.MappingNode {
+		for i := 0; i+1 < len(node.Content); i += 2 {
+			if node.Content[i].Value == key {
+				out = append(out, node.Content[i+1])
+			}
+			out = append(out, collectMappingValuesByKey(node.Content[i+1], key)...)
+		}
+		return out
+	}
+	for _, child := range node.Content {
+		out = append(out, collectMappingValuesByKey(child, key)...)
+	}
+	return out
+}
+
+func nodeKind(node *yaml.Node) yaml.Kind {
+	if node == nil {
+		return 0
+	}
+	return node.Kind
 }

--- a/internal/apispec/platform_spec_composition_routing_test.go
+++ b/internal/apispec/platform_spec_composition_routing_test.go
@@ -1,0 +1,114 @@
+package apispec
+
+import (
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestPlatformSpecCompositionRoutingSourceAuthority(t *testing.T) {
+	root := loadPlatformSpecYAMLNode(t)
+	composition := mustYAMLPath(t, root, "flow_model", "flow_package", "composition_routing")
+
+	assertScalarValue(t, mustMappingValue(t, composition, "status"), "source_authority_promoted_runtime_migration_pending")
+	assertScalarValue(t, mustMappingValue(t, composition, "promoted_by"), "#1467")
+	assertScalarValue(t, mustMappingValue(t, composition, "parent_decision"), "#1466")
+	assertScalarValue(t, mustMappingValue(t, composition, "owner"), "platform-spec.yaml#flow_model.flow_package.composition_routing")
+	assertScalarContains(t, mustMappingValue(t, composition, "rule"), "Parent-authored composition routing is the canonical source authority")
+	assertScalarContains(t, mustMappingValue(t, composition, "rule"), "Producer emit sites MUST NOT own consumer routing")
+
+	authored := mustMappingValue(t, composition, "authored_shapes")
+	addressed := mustMappingValue(t, authored, "addressed_input_pin")
+	assertScalarContains(t, mustMappingValue(t, addressed, "canonical_form"), "{name, event, address}")
+	assertScalarContains(t, mustYAMLPath(t, addressed, "address_fields", "cardinality"), "one and many")
+
+	connect := mustMappingValue(t, authored, "parent_connect")
+	assertScalarValue(t, mustMappingValue(t, connect, "location"), "parent package.yaml connect")
+	assertScalarContains(t, mustMappingValue(t, connect, "canonical_form"), "`connect` is a list")
+	assertScalarContains(t, mustYAMLPath(t, connect, "fields", "from"), "producer")
+	assertScalarContains(t, mustYAMLPath(t, connect, "fields", "to"), "receiver")
+
+	ownership := mustMappingValue(t, composition, "ownership_split")
+	assertScalarContains(t, mustMappingValue(t, ownership, "parent_connect"), "owns inter-flow delivery topology")
+	assertScalarContains(t, mustMappingValue(t, ownership, "input_pins"), "receiver address resolution")
+	assertScalarContains(t, mustMappingValue(t, ownership, "producer_emit_target"), "exceptional dynamic routing")
+
+	verify := mustMappingValue(t, composition, "analyzer_verify_requirements")
+	for _, key := range []string{
+		"producer_flow_exists",
+		"producer_output_pin_exists",
+		"receiver_flow_exists",
+		"receiver_input_pin_exists",
+		"event_alias_or_adapter_valid",
+		"output_carries_address_key",
+		"receiver_address_rule_present",
+		"key_types_compatible",
+		"delivery_topology_valid",
+		"reply_lineage_usable",
+		"inference_unambiguous",
+		"lowered_route_plan_concrete",
+	} {
+		if !hasMappingKey(verify, key) {
+			t.Fatalf("composition_routing analyzer_verify_requirements missing %s", key)
+		}
+	}
+
+	lowering := mustMappingValue(t, composition, "route_plan_lowering")
+	assertScalarValue(t, mustMappingValue(t, lowering, "owner"), "platform-spec.yaml#flow_model.flow_package.composition_routing.route_plan_lowering")
+	for _, want := range []string{
+		"parent package.yaml connect entries",
+		"receiver addressed input pin rules",
+		"import-boundary pin alias bindings",
+	} {
+		if !sequenceContainsScalar(mustMappingValue(t, lowering, "consumes"), want) {
+			t.Fatalf("route_plan_lowering consumes missing %q", want)
+		}
+	}
+	for _, want := range []string{
+		"concrete target route for delivery: one",
+		"concrete target_set routes for delivery: many or broadcast",
+		"reply route lineage for delivery: reply",
+	} {
+		if !sequenceContainsScalar(mustMappingValue(t, lowering, "produces"), want) {
+			t.Fatalf("route_plan_lowering produces missing %q", want)
+		}
+	}
+
+	assertScalarContains(t, mustYAMLPath(t, composition, "pin_alias_delivery_composition", "owner_consumed"), "pin_alias_delivery")
+	assertScalarContains(t, mustYAMLPath(t, composition, "emit_target_escape_hatch", "role"), "not a compatibility path")
+	assertScalarContains(t, mustYAMLPath(t, composition, "split_boundaries", "runtime_route_consumption"), "does not claim runtime behavior closure")
+}
+
+func TestPlatformSpecCompositionRoutingDemotesProducerTargetAuthority(t *testing.T) {
+	root := loadPlatformSpecYAMLNode(t)
+
+	crossFlow := mustYAMLPath(t, root, "engine", "cross_flow_routing")
+	assertScalarValue(t, mustMappingValue(t, crossFlow, "canonical_owner"), "platform-spec.yaml#flow_model.flow_package.composition_routing")
+	assertScalarValue(t, mustMappingValue(t, crossFlow, "implementation_status"), "source_authority_promoted_runtime_migration_pending")
+	if !sequenceContainsScalar(mustYAMLPath(t, crossFlow, "target_resolution", "precedence"), "lowered parent connect route plan") {
+		t.Fatal("cross_flow_routing target precedence must start from lowered parent connect route plan")
+	}
+	assertScalarContains(t, mustYAMLPath(t, crossFlow, "target_resolution", "explicit_target_wins"), "exceptional dynamic-routing escape hatch")
+	assertScalarContains(t, mustYAMLPath(t, crossFlow, "target_resolution", "fail_closed"), "no lowered parent connect route")
+	assertScalarContains(t, mustYAMLPath(t, crossFlow, "auto_wiring", "description"), "only as an inference candidate")
+
+	assertScalarContains(t, mustYAMLPath(t, crossFlow, "target_forms", "flow_match_allow_fanout"), "explicit dynamic fan-out escape hatch")
+	assertScalarContains(t, mustYAMLPath(t, crossFlow, "target_forms", "broadcast"), "producer-authored explicit opt-out escape hatch")
+
+	pinAuthority := mustYAMLPath(t, root, "flow_model", "pins", "routing_authority")
+	assertScalarContains(t, pinAuthority, "Parent package connect entries own common inter-flow topology")
+	assertScalarContains(t, pinAuthority, "flow_model.flow_package.composition_routing")
+
+	pinTargetResolution := mustYAMLPath(t, root, "static_analyzer", "slice_3a_pin_target_resolution")
+	assertScalarValue(t, mustMappingValue(t, pinTargetResolution, "canonical_replacement"), "flow_model.flow_package.composition_routing.analyzer_verify_requirements")
+	assertScalarContains(t, mustYAMLPath(t, pinTargetResolution, "accepted_target_mechanisms", "lowered_parent_connect", "rule"), "Parent connect")
+}
+
+func mustYAMLPath(t *testing.T, node *yaml.Node, keys ...string) *yaml.Node {
+	t.Helper()
+	current := node
+	for _, key := range keys {
+		current = mustMappingValue(t, current, key)
+	}
+	return current
+}

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -306,7 +306,10 @@ contract_formats:
           fields:
           - flow_instance
           - entity_id
-          rule: Pin-declared output emits MUST either resolve a singular target from lowered parent connect topology, resolve target_set from lowered fan-out topology, use the explicit producer target escape hatch, use a structural ParentRoute target, or explicitly opt out with broadcast:true.
+          rule: Pin-declared output emits MUST either resolve a singular target from lowered parent connect topology,
+            resolve target_set from lowered fan-out topology, use the explicit producer target escape hatch, use a structural
+            ParentRoute target only when no lowered connect target applies, use an eligible static child delivery-entity route,
+            or explicitly opt out with broadcast:true.
           absent_means: event.target is absent when event.target_set is present, when broadcast:true is used, or when uncontrolled external ingress has not yet been receiver-bound.
           mutual_exclusion: event.target and event.target_set MUST NOT both be populated on the persisted event.
         target_set:
@@ -513,6 +516,7 @@ contract_formats:
             - event.target
             - event.target_set
             - delivery_target_route
+            - lowered connect route-plan facts
             - explicit target routes
             - structural ParentRoute
             - flow_instance
@@ -1217,10 +1221,12 @@ handler_specification:
           guard, data_accumulation, emit.fields, action, and state transition processing.
       pin_routing_interaction:
         receiver_context_order: 'For pin-routed events, handler entity context resolves in this order: event.target when set;
-          otherwise select_or_create_entity late binding when declared; otherwise event.source.'
+          otherwise current delivery target from event.target_set when present; otherwise select_or_create_entity late binding
+          when declared; otherwise event.source.'
         canonical_uses: External or mixed-provenance events where the receiving service owns the entity identity and may need
           to mint the entity on zero-match.
-        non_canonical_use: In-topology pin routing where the producer or structural binding already supplies event.target.
+        non_canonical_use: In-topology pin routing where lowered parent connect, the explicit target escape hatch, structural
+          fallback, or target_set delivery already supplies the receiver route context.
       restrictions:
         lifecycle_scope: Valid only on stateful static-flow input-pin handlers. Stateless flows do not have stateful entity
           acquisition. Template flows acquire entities through create_flow_instance.
@@ -1460,9 +1466,10 @@ handler_specification:
           facts, use the explicit target escape hatch, use structural child-to-parent ParentRoute binding, use the static
           no-instance child-flow delivery-entity route where eligible, or declare broadcast:true. No silent fallback to
           event-type broadcast is allowed.
-        explicit_target_precedence: Producer target is an exceptional override over structural binding and lowered connect
-          topology. Structural binding writes event.target only when the emit site has no explicit target, no lowered connect
-          target applies, and broadcast:true is absent.
+        explicit_target_precedence: Producer target is an exceptional dynamic-routing escape hatch, not the common route
+          owner for parent-composed topology. Lowered parent connect remains the common source authority for connected pins;
+          structural binding writes event.target only when the emit site has no explicit target, no lowered connect target
+          applies, and broadcast:true is absent.
       target_forms:
         sender: Copy inbound event.source into the new event.target. Sender is the immediate inbound sender, not a chain ancestor.
         instance_id: Resolve a target instance in the addressed child/template scope using the instance_id known to the producer.
@@ -1472,7 +1479,7 @@ handler_specification:
           on the persisted event, and persist one delivery target per recipient route. It must not silently collapse to one target.
       target_failures:
         target_required_missing: Pin-declared output has no lowered parent connect route, no explicit target escape hatch,
-          no structural ParentRoute, and no broadcast:true.
+          no structural ParentRoute, no eligible static child delivery-entity route, and no broadcast:true.
         target_invalid_syntax: Target form is malformed or has invalid literal fields.
         target_unknown_flow: target.flow names a flow outside the loaded registry.
         target_sender_no_inbound: target:sender is used where no inbound event source can exist.
@@ -1874,8 +1881,9 @@ engine:
     implementation_status: source_authority_promoted_runtime_migration_pending
     activation:
       rule: Pin routing activates when the emitter flow declares the emitted event in schema.yaml pins.outputs.events and the
-        event is admitted through a valid parent connect, structural ParentRoute, explicit dynamic target escape hatch, or
-        explicit broadcast escape hatch.
+        event is admitted through a valid lowered parent connect route, explicit dynamic target escape hatch, structural
+        ParentRoute fallback when no lowered connect route applies, eligible static child delivery-entity route, or explicit
+        broadcast escape hatch.
       no_separate_flag: The output pin declaration is the activation switch.
       ad_hoc_emits: Events not declared in the emitter flow's output pins remain ordinary event-loop emits.
       aggressive_day_one: Pin routing is the default for pin-declared outputs; implicit event-type broadcast is not a compatibility mode.
@@ -1893,8 +1901,9 @@ engine:
         unless the parent connect, alias/adapter, scoped subscription escape hatch, or explicit target escape hatch
         disambiguates the route.'
       static_pairs: Static-to-static pairs may resolve to a single instance pair at boot.
-      template_pairs: Template or dynamic-instance pairs require receiver address resolution from the addressed input pin or
-        explicit dynamic target escape hatch at emit/publish time unless structural binding supplies ParentRoute.
+      template_pairs: Template or dynamic-instance pairs require lowered parent connect route facts from the addressed input
+        pin, or an explicit dynamic target escape hatch at emit/publish time. Structural ParentRoute binding is only a
+        child-to-parent fallback when no lowered connect target applies.
     target_resolution:
       precedence:
       - lowered parent connect route plan
@@ -1902,10 +1911,11 @@ engine:
       - structural ParentRoute for child-to-parent pin outputs
       - receiver-side select_entity/select_or_create_entity late binding for external or mixed-provenance no-target events
       - source fallback for explicit broadcast or legacy external paths
-      explicit_target_wins: Producer target wins only as an exceptional dynamic-routing escape hatch. It must not be treated
-        as the common parent-composed routing owner.
+      explicit_target_escape_hatch: Producer target is only an exceptional dynamic-routing escape hatch. It must not be
+        treated as the common parent-composed routing owner and must not replace lowered parent connect as the common source
+        authority for connected pins.
       fail_closed: A pin-declared output that has no lowered parent connect route, no explicit target escape hatch, no structural
-        ParentRoute, and no broadcast:true is invalid.
+        ParentRoute, no eligible static child delivery-entity route, and no broadcast:true is invalid.
       no_silent_broadcast_fallback: Missing, malformed, ambiguous, or unreachable targets must fail with a typed reason.
     target_forms:
       sender: |
@@ -1928,18 +1938,22 @@ engine:
         event.target absent and uses the ordinary no-target event-type delivery path. Parent-authored broadcast/fan-out should
         use connect topology and lower to concrete route-plan facts.
     structural_binding:
-      child_to_parent: A child flow instance has exactly one parent in v1. Child pin-declared outputs without explicit target
-        route to the recorded ParentRoute of the instance that created the child.
+      precedence_guard: Structural binding is lower precedence than lowered parent connect and the explicit target escape
+        hatch. It may write event.target only for a child-to-parent pin output when no lowered parent connect target applies,
+        no explicit target is present, and broadcast:true is absent.
+      child_to_parent: A child flow instance has exactly one parent in v1. A child pin-declared output routes to the recorded
+        ParentRoute of the instance that created the child only when the emit has no lowered parent connect route and no
+        explicit target.
       static_child_no_instance: Nested static child flows that are not template/dynamic instances have no persisted ParentRoute
-        row. When such a child emits a pin-declared output without explicit target or broadcast:true, the runtime may target
-        only the current delivery entity route. Eligibility requires the resolved flow scope path to be nested. This exception
-        must not read inbound event.source as structural parent authority and does not satisfy ParentRoute metadata for
-        template/dynamic instances.
+        row. When such a child emits a pin-declared output without a lowered parent connect route, without explicit target,
+        and without broadcast:true, the runtime may target only the current delivery entity route. Eligibility requires the
+        resolved flow scope path to be nested. This exception must not read inbound event.source as structural parent authority
+        and does not satisfy ParentRoute metadata for template/dynamic instances.
       parent_to_child: Parent-to-child routing is never inferred structurally in v1. The parent must use target:{instance_id}
         or the canonical parent connect topology with addressed receiver input pins.
       grandchildren: A grandchild's structural pin output routes to its immediate parent only. Multi-level retargeting is v2.
-      multiple_parents: Per-child multi-parent routing is v2. A parent that needs multi-consumer fan-out consumes first and
-        re-emits with explicit target forms.
+      multiple_parents: Per-child multi-parent structural routing is v2. Parent-authored multi-consumer fan-out uses connect
+        topology and lowers to target_set route-plan facts; explicit target forms remain only the dynamic escape hatch.
     parent_route:
       description: Full parent route identity recorded at create_flow_instance time.
       fields:
@@ -1947,7 +1961,8 @@ engine:
         parent_entity_id: parent entity id
         parent_flow_id: parent flow id, defensive and derivable from path
       exposed_type: 'ParentRoute { FlowInstance, EntityID, FlowID }'
-      read_rule: Child pin-output emit reads ParentRoute from local instance metadata and writes event.target when no explicit target exists.
+      read_rule: Child pin-output emit reads ParentRoute from local instance metadata and writes event.target only when no
+        lowered parent connect route applies, no explicit target exists, and broadcast:true is absent.
       stale_instance_policy: Pre-existing children with only parent_entity_id and no complete ParentRoute fail closed with parent_route_incomplete.
     delivery_filter:
       rule: Filter once at publish-time recipient construction, persist the narrowed recipient list, and make all downstream
@@ -1976,7 +1991,7 @@ engine:
     target_resolution_failure_taxonomy:
       boot_verify:
         target_required_missing: Pin-declared output emit with no lowered parent connect route, no explicit target escape
-          hatch, no structural binding, and no broadcast:true.
+          hatch, no structural binding, no eligible static child delivery-entity route, and no broadcast:true.
         target_invalid_syntax: Literal target spec is malformed or incomplete.
         target_unknown_flow: target.flow does not exist in the loaded flow registry.
         target_sender_no_inbound: target:sender appears on a handler whose only triggers cannot supply inbound source.
@@ -2115,7 +2130,8 @@ engine:
           parent_flow_instance: Parent flow instance path from the calling handler context.
           parent_entity_id: Parent entity id from the calling handler context.
           parent_flow_id: Parent flow id, defensively recorded even when derivable from parent_flow_instance.
-        required_for: Child-to-parent pin-declared output emits when the emit site has no explicit target and no broadcast:true.
+        required_for: Child-to-parent pin-declared output emits when the emit site has no lowered parent connect route, no
+          explicit target, and no broadcast:true.
         incomplete_policy: A child instance with incomplete ParentRoute metadata MUST fail closed with parent_route_incomplete
           before emitting a structurally routed pin output.
         single_parent_v1: Each child has exactly one ParentRoute in v1. Multiple parents are v2.
@@ -2176,9 +2192,13 @@ engine:
         as absolute from root. Wildcards expand to matching paths.
     - step: 7
       name: validate_pins
-      action: 'For each flow: required input event pins must be wired (some other flow emits them), pin-declared output emits
-        must have a target mechanism or broadcast:true, target specs must be well formed, and no two flows may write the same
-        entity field (write conflict = boot error).'
+      action: 'For each flow: required input event pins must be satisfied by parent connect topology, safe unambiguous inference,
+        explicit external source metadata, or another accepted producer path. Pin-declared output emits consume
+        flow_model.flow_package.composition_routing: lowered parent connect supplies singular event.target or fan-out
+        event.target_set route facts; explicit target is only the dynamic escape hatch; structural ParentRoute and eligible
+        static-child delivery-entity routing are fallback paths when no lowered connect route applies; broadcast:true is the
+        explicit no-target opt-out. Target specs must be well formed, and no two flows may write the same entity field (write
+        conflict = boot error).'
     - step: 8
       name: validate_required_agents
       action: Every flow's required_agents roles must be fulfilled by agents in that flow's agents.yaml.
@@ -3974,7 +3994,8 @@ engine:
       severity: error
       scope: per-emit-site
       trigger: A pin-declared output emit lacks a lowered parent connect route, explicit target escape hatch, structural
-        ParentRoute eligibility, or broadcast:true; has malformed target syntax; references an unknown target.flow; uses
+        ParentRoute eligibility, eligible static child delivery-entity route, or broadcast:true; has malformed target syntax;
+        references an unknown target.flow; uses
         target:sender where no inbound source can exist; or uses target:sender only on external-sourced inputs with empty source.
       when: boot-only
     - id: redundant_in_topology_select_entity
@@ -4809,8 +4830,9 @@ flow_model:
       required: true
     output_event_pins:
       description: Events the flow emits across its public interface. Optional, but when an emit site emits one of these
-        events, pin routing is active and routing must be supplied by parent connect lowering, structural ParentRoute,
-        explicit dynamic target escape hatch, or explicit broadcast escape hatch.
+        events, pin routing is active and routing must be supplied by parent connect lowering, explicit dynamic target escape
+        hatch, structural ParentRoute fallback when no lowered connect route applies, an eligible static child delivery-entity
+        route, or explicit broadcast escape hatch.
       required: false
     input_data_pins:
       description: Entity fields the flow reads. Required pins must be written by a prior flow or initial data.
@@ -8300,8 +8322,9 @@ static_analyzer:
     scope:
       description: For every system-node emit site whose emitted event is declared in the emitter flow's pins.outputs.events,
         verify that the authored contract supplies lowered parent connect topology, a valid target escape hatch, structural
-        binding, or explicit broadcast opt-out. Current runtime implementation may still enforce the pre-connect target
-        surface until the composition-routing migration child lands; this slice is not the canonical parent-composed route owner.
+        binding only when no lowered connect route applies, eligible static child delivery-entity routing, or explicit broadcast
+        opt-out. Current runtime implementation may still enforce the pre-connect target surface until the composition-routing
+        migration child lands; this slice is not the canonical parent-composed route owner.
       applies_to:
       - handler top-level single-emit
       - rules entries
@@ -8327,8 +8350,8 @@ static_analyzer:
         rule: flow_match_allow_fanout resolves to event.target_set, not singular event.target. The runtime must persist concrete
           target_set route identities and one delivery target per recipient; it must not persist only the authored selector.
       structural_parent_route:
-        rule: Child-to-parent structural binding is valid only for child/template instances that will record full ParentRoute
-          at create_flow_instance time.
+        rule: Child-to-parent structural binding is valid only when no lowered parent connect route applies and only for
+          child/template instances that will record full ParentRoute at create_flow_instance time.
       static_child_delivery_entity:
         rule: Nested static child flows without a materialized instance row may use the current delivery entity as the only
           implicit target route for pin-declared outputs; root static flows still require an explicit target or broadcast:true.
@@ -8337,7 +8360,7 @@ static_analyzer:
         rule: broadcast:true is a deliberate opt-out and is the only no-target form accepted for a pin-declared output.
     static_failure_reasons:
       target_required_missing: No lowered parent connect route, no explicit target escape hatch, no structural ParentRoute
-        eligibility, and no broadcast:true.
+        eligibility, no eligible static child delivery-entity route, and no broadcast:true.
       target_invalid_syntax: Literal target spec is malformed or incomplete.
       target_unknown_flow: target.flow is not present in the loaded flow registry.
       target_sender_no_inbound: target:sender is used from a handler whose only triggers cannot supply inbound event.source.
@@ -8352,8 +8375,8 @@ static_analyzer:
       emit_time_tool_error:
       - target_sender_no_inbound_runtime
       - target_sender_empty_source_runtime
-    rule: Emit hard invalidity for every statically detectable missing or malformed pin target mechanism. Runtime failure reasons
-      cover the cases boot verification cannot prove; no case may silently fall back to broadcast.
+    rule: Emit hard invalidity for every statically detectable missing or malformed accepted pin route source. Runtime failure
+      reasons cover the cases boot verification cannot prove; no case may silently fall back to broadcast.
   slice_3b_select_entity_pin_coexistence:
     id: select_entity_pin_coexistence
     domain: semantic_drift

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -1471,7 +1471,8 @@ handler_specification:
           MUST materialize event.target_set as the complete concrete recipient route list, leave singular event.target absent
           on the persisted event, and persist one delivery target per recipient route. It must not silently collapse to one target.
       target_failures:
-        target_required_missing: Pin-declared output has no target, no structural ParentRoute, and no broadcast:true.
+        target_required_missing: Pin-declared output has no lowered parent connect route, no explicit target escape hatch,
+          no structural ParentRoute, and no broadcast:true.
         target_invalid_syntax: Target form is malformed or has invalid literal fields.
         target_unknown_flow: target.flow names a flow outside the loaded registry.
         target_sender_no_inbound: target:sender is used where no inbound event source can exist.
@@ -1974,7 +1975,8 @@ engine:
         no_target: Existing no-target event-type fan-out semantics.
     target_resolution_failure_taxonomy:
       boot_verify:
-        target_required_missing: Pin-declared output emit with no target, no structural binding, and no broadcast:true.
+        target_required_missing: Pin-declared output emit with no lowered parent connect route, no explicit target escape
+          hatch, no structural binding, and no broadcast:true.
         target_invalid_syntax: Literal target spec is malformed or incomplete.
         target_unknown_flow: target.flow does not exist in the loaded flow registry.
         target_sender_no_inbound: target:sender appears on a handler whose only triggers cannot supply inbound source.
@@ -3963,16 +3965,17 @@ engine:
       severity: warning
       scope: per-flow
       trigger: 'A flow''s required input event pin (from schema.yaml pins.inputs.events) has no satisfiable authored producer
-        path on the static verify surface. The warning checks only sibling flow output pins, root agent emit_events, root
-        node handler emit sites, exact platform_events catalog matches, swarm.source values starting with external, and same-flow
-        timer declarations. It does not use produces or swarm.status: planned as input-pin proof.'
+        path on the static verify surface. The warning checks parent package.yaml connect entries, safe same-name sibling
+        flow output-pin inference, root agent emit_events, root node handler emit sites, exact platform_events catalog matches,
+        swarm.source values starting with external, and same-flow timer declarations. It does not use produces or swarm.status:
+        planned as input-pin proof.'
       when: boot-only
     - id: pin_target_resolution
       severity: error
       scope: per-emit-site
-      trigger: A pin-declared output emit lacks an explicit target, structural ParentRoute eligibility, or broadcast:true; has
-        malformed target syntax; references an unknown target.flow; uses target:sender where no inbound source can exist; or
-        uses target:sender only on external-sourced inputs with empty source.
+      trigger: A pin-declared output emit lacks a lowered parent connect route, explicit target escape hatch, structural
+        ParentRoute eligibility, or broadcast:true; has malformed target syntax; references an unknown target.flow; uses
+        target:sender where no inbound source can exist; or uses target:sender only on external-sourced inputs with empty source.
       when: boot-only
     - id: redundant_in_topology_select_entity
       severity: warning
@@ -8333,7 +8336,8 @@ static_analyzer:
       explicit_broadcast:
         rule: broadcast:true is a deliberate opt-out and is the only no-target form accepted for a pin-declared output.
     static_failure_reasons:
-      target_required_missing: No explicit target, no structural ParentRoute eligibility, and no broadcast:true.
+      target_required_missing: No lowered parent connect route, no explicit target escape hatch, no structural ParentRoute
+        eligibility, and no broadcast:true.
       target_invalid_syntax: Literal target spec is malformed or incomplete.
       target_unknown_flow: target.flow is not present in the loaded flow registry.
       target_sender_no_inbound: target:sender is used from a handler whose only triggers cannot supply inbound event.source.

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -272,14 +272,17 @@ contract_formats:
           emits this is always set from the emitter's flow_instance and
           entity_id at emit time. Source lineage is never overwritten by
           receiver selection, replay, or target resolution.
-        - event.target: the singular recipient route identity. It is set by
-          explicit producer target, by structural child-to-parent binding, or
-          by receiver-side late binding when resolution yields exactly one
+        - event.target: the singular recipient route identity. It is set by a
+          lowered parent `connect` route plan, by the exceptional explicit
+          producer target escape hatch, by structural child-to-parent binding,
+          or by receiver-side late binding when resolution yields exactly one
           recipient.
         - event.target_set: a concrete list of recipient route identities for
-          explicit fan-out targeting. It is produced only by
-          `target: { flow, match, allow_fanout: true }` after publish-time
-          resolution. It is not a selector and it is not broadcast.
+          fan-out targeting. It is produced by lowered parent `connect`
+          fan-out/topology or by the exceptional
+          `target: { flow, match, allow_fanout: true }` escape hatch after
+          publish-time resolution. It is not a selector and it is not
+          broadcast.
 
         Legacy top-level event.entity_id and event.flow_instance references
         are receiver-context projections only. They must resolve from
@@ -303,15 +306,15 @@ contract_formats:
           fields:
           - flow_instance
           - entity_id
-          rule: Pin-declared output emits MUST either resolve a singular target, resolve target_set, use a structural ParentRoute target, or explicitly opt out with broadcast:true.
+          rule: Pin-declared output emits MUST either resolve a singular target from lowered parent connect topology, resolve target_set from lowered fan-out topology, use the explicit producer target escape hatch, use a structural ParentRoute target, or explicitly opt out with broadcast:true.
           absent_means: event.target is absent when event.target_set is present, when broadcast:true is used, or when uncontrolled external ingress has not yet been receiver-bound.
           mutual_exclusion: event.target and event.target_set MUST NOT both be populated on the persisted event.
         target_set:
           fields:
           - flow_instance
           - entity_id
-          rule: Explicit flow/match fan-out MUST materialize a concrete ordered list of recipient route identities at publish time.
-          not_a_selector: The persisted event.target_set stores resolved route identities, not the authored flow/match selector.
+          rule: Parent connect fan-out and explicit flow/match fan-out MUST materialize a concrete ordered list of recipient route identities at publish time.
+          not_a_selector: The persisted event.target_set stores resolved route identities, not the authored connect or flow/match selector.
           delivery_rule: Each persisted delivery row MUST carry one target_set member as its delivery target. Dispatch exposes that per-recipient target as event.target for the receiver context.
         receiver_context_order:
         - event.target
@@ -439,10 +442,12 @@ contract_formats:
       intra_flow: 'Within a flow, routing derives from local subscriptions — agents.yaml subscriptions,
         nodes.yaml subscribes_to, and event_handlers keys. The platform matches local event names
         against local subscriber declarations.'
-      cross_flow: 'Between flows, routing derives from pins by default — source flow pins.outputs.events
-        matched against target flow pins.inputs.events. See engine.cross_flow_routing for details.
-        Explicit scoped subscriptions (e.g., scoring/vertical.shortlisted) are an escape hatch for
-        cases where auto-wiring is insufficient.'
+      cross_flow: 'Between flows, authored topology derives from parent package connect entries
+        over output and input pins. Output pins declare event identity, input pins declare receiver
+        address resolution, and parent connect lowers into concrete route-plan facts. See
+        flow_model.flow_package.composition_routing and engine.cross_flow_routing for details.
+        Explicit scoped subscriptions (e.g., scoring/vertical.shortlisted) remain an escape hatch for
+        cases outside the pin/connect interface.'
       delivery_rules:
         owning_node: If a system node subscribes_to the event → that node owns it
         dual_delivery: If a node AND agents subscribe → route to both
@@ -490,14 +495,19 @@ contract_formats:
               inconsistent with the publish request.
           route_topology:
             fields:
+            - parent package.yaml connect entries
+            - addressed input pin receiver resolution rules
+            - lowered connect route-plan facts
             - RouteTable semantic subscribers
             - nodes.yaml subscribes_to entries
             - agents.yaml subscriptions
             - event_handlers keys
             - pins.inputs.events and pins.outputs.events
             rule: Semantic route topology is the source for recipient
-              derivation. Live subscription channels, active descriptors, and
-              handler lookup are not topology authority.
+              derivation. Parent connect topology and addressed input pins are
+              the authored cross-flow source authority; RouteTable and RoutePlan
+              consume the lowered facts. Live subscription channels, active
+              descriptors, and handler lookup are not topology authority.
           target_context:
             fields:
             - event.target
@@ -1436,18 +1446,23 @@ handler_specification:
         fields: map of output_field_name → CEL expression evaluated against handler context. Optional. If omitted, the emitted
           payload contains no business fields. Runtime-owned envelope context is attached on the event carrier and is accessed
           through event.* rather than payload.*.
-        target: optional controlled pin-routing target spec. Valid forms are sender, {instance_id}, {flow, match}, and {flow, match, allow_fanout}.
-          This field is not payload and is the only producer-authored path that may ask the platform to populate event.target.
-        broadcast: optional boolean. Only true is meaningful. For a pin-declared output, broadcast:true is an explicit opt-out
-          from target-required pin routing and leaves event.target absent.
+        target: optional controlled dynamic-routing escape hatch. Valid forms are sender, {instance_id}, {flow, match},
+          and {flow, match, allow_fanout}. This field is not payload and is the only producer-authored path that may ask
+          the platform to populate event.target or event.target_set. It is not the common consumer-routing surface for
+          parent-composed flow packages; common cross-flow delivery is owned by parent connect lowering.
+        broadcast: optional boolean. Only true is meaningful. For a pin-declared output, broadcast:true is an explicit
+          producer-authored opt-out escape hatch that leaves event.target absent. Parent-authored broadcast/fan-out uses
+          connect lowering rather than producer broadcast.
       pin_routing_activation:
         rule: Pin routing activates if and only if the emitted event is declared in the emitter flow's schema.yaml pins.outputs.events.
         ad_hoc_emits: Emits not declared in pins.outputs.events are ordinary event-loop emits and do not require target or broadcast.
-        target_requirement: A pin-declared output emit MUST resolve an explicit target, use structural child-to-parent ParentRoute
-          binding, use the static no-instance child-flow delivery-entity route where eligible, or declare broadcast:true. No
-          silent fallback to event-type broadcast is allowed.
-        explicit_target_precedence: Producer target wins over structural binding. Structural binding writes event.target only
-          when the emit site has no explicit target and broadcast:true is absent.
+        target_requirement: A pin-declared output emit in parent-composed topology MUST resolve through lowered parent connect
+          facts, use the explicit target escape hatch, use structural child-to-parent ParentRoute binding, use the static
+          no-instance child-flow delivery-entity route where eligible, or declare broadcast:true. No silent fallback to
+          event-type broadcast is allowed.
+        explicit_target_precedence: Producer target is an exceptional override over structural binding and lowered connect
+          topology. Structural binding writes event.target only when the emit site has no explicit target, no lowered connect
+          target applies, and broadcast:true is absent.
       target_forms:
         sender: Copy inbound event.source into the new event.target. Sender is the immediate inbound sender, not a chain ancestor.
         instance_id: Resolve a target instance in the addressed child/template scope using the instance_id known to the producer.
@@ -1849,32 +1864,47 @@ engine:
       Match(pattern, eventName) → bool. ResolveInputAlias(flowID, eventName) → local handler key.
       No subsystem may implement its own name resolution logic.'
   cross_flow_routing:
-    description: 'Pin declarations are the canonical cross-flow routing surface. For pin-declared
-      outputs, the platform routes by source/target identity, not by unconstrained event-type broadcast.'
+    description: 'Composition-first pin routing is the canonical cross-flow routing surface. Parent package
+      connect entries own inter-flow delivery topology, output pins declare the event identity being produced,
+      input pins declare the receiver address resolution contract, and the analyzer lowers the connection into
+      concrete route-plan facts. For pin-declared outputs, the platform routes by resolved source/target
+      identity, not by unconstrained event-type broadcast.'
+    canonical_owner: platform-spec.yaml#flow_model.flow_package.composition_routing
+    implementation_status: source_authority_promoted_runtime_migration_pending
     activation:
-      rule: Pin routing activates if and only if the emitter flow declares the emitted event in schema.yaml pins.outputs.events.
+      rule: Pin routing activates when the emitter flow declares the emitted event in schema.yaml pins.outputs.events and the
+        event is admitted through a valid parent connect, structural ParentRoute, explicit dynamic target escape hatch, or
+        explicit broadcast escape hatch.
       no_separate_flag: The output pin declaration is the activation switch.
       ad_hoc_emits: Events not declared in the emitter flow's output pins remain ordinary event-loop emits.
       aggressive_day_one: Pin routing is the default for pin-declared outputs; implicit event-type broadcast is not a compatibility mode.
     auto_wiring:
-      description: 'At boot, the platform validates pin topology and derives route candidates from declared pins:
+      status: safe_inference_only
+      description: 'At boot, the platform validates parent connect topology and may infer same-name wiring only when the
+        inference is unambiguous and lowers to the same concrete route-plan facts as an explicit connect:
         1. For each flow, collect pins.outputs.events.
         2. For each flow, collect pins.inputs.events.
-        3. Match local event names across output and input pins to establish allowed producer-consumer topology.
+        3. Match local event names across output and input pins only as an inference candidate, not as topology authority.
         4. Preserve local handler lookup by local event name in the target flow.
-        5. Do not treat the topology match as permission to broadcast to every instance; publish-time target resolution still applies.'
+        5. Persist or expose the lowered parent-connect route facts; do not treat a topology match as permission to broadcast
+           to every instance.'
       ambiguity: 'If an input pin event name matches output pins from multiple flows, boot MUST fail
-        unless the contract disambiguates explicitly through a scoped subscription or explicit target semantics.'
+        unless the parent connect, alias/adapter, scoped subscription escape hatch, or explicit target escape hatch
+        disambiguates the route.'
       static_pairs: Static-to-static pairs may resolve to a single instance pair at boot.
-      template_pairs: Template or dynamic-instance pairs require target resolution at emit/publish time unless structural binding supplies ParentRoute.
+      template_pairs: Template or dynamic-instance pairs require receiver address resolution from the addressed input pin or
+        explicit dynamic target escape hatch at emit/publish time unless structural binding supplies ParentRoute.
     target_resolution:
       precedence:
-      - explicit emit target
+      - lowered parent connect route plan
+      - explicit emit target escape hatch
       - structural ParentRoute for child-to-parent pin outputs
       - receiver-side select_entity/select_or_create_entity late binding for external or mixed-provenance no-target events
       - source fallback for explicit broadcast or legacy external paths
-      explicit_target_wins: Producer target wins over structural binding.
-      fail_closed: A pin-declared output that has no explicit target, no structural ParentRoute, and no broadcast:true is invalid.
+      explicit_target_wins: Producer target wins only as an exceptional dynamic-routing escape hatch. It must not be treated
+        as the common parent-composed routing owner.
+      fail_closed: A pin-declared output that has no lowered parent connect route, no explicit target escape hatch, no structural
+        ParentRoute, and no broadcast:true is invalid.
       no_silent_broadcast_fallback: Missing, malformed, ambiguous, or unreachable targets must fail with a typed reason.
     target_forms:
       sender: |
@@ -1887,13 +1917,15 @@ engine:
         `target: { flow, match }` resolves target.flow plus declared entity-field matches to exactly one target instance.
         Zero matches and more than one match fail closed at publish time.
       flow_match_allow_fanout: |
-        `target: { flow, match, allow_fanout: true }` is the explicit fan-out form for flow/match targeting. It permits more
-        than one matched recipient. Publish-time resolution materializes event.target_set as the concrete ordered recipient
-        route list, leaves singular event.target absent on the persisted event, and persists one delivery target per recipient.
-        The authored flow/match selector is not the persisted routing authority after resolution.
+        `target: { flow, match, allow_fanout: true }` is the explicit dynamic fan-out escape hatch for flow/match targeting.
+        It permits more than one matched recipient. Parent-authored fan-out should use connect topology. Publish-time
+        resolution materializes event.target_set as the concrete ordered recipient route list, leaves singular event.target
+        absent on the persisted event, and persists one delivery target per recipient. The authored flow/match selector is
+        not the persisted routing authority after resolution.
       broadcast: |
-        `broadcast: true` is the explicit opt-out for pin-declared output routing. It leaves event.target absent and uses the
-        ordinary no-target event-type delivery path. Broadcast intent must be authored per emit site.
+        `broadcast: true` is the producer-authored explicit opt-out escape hatch for pin-declared output routing. It leaves
+        event.target absent and uses the ordinary no-target event-type delivery path. Parent-authored broadcast/fan-out should
+        use connect topology and lower to concrete route-plan facts.
     structural_binding:
       child_to_parent: A child flow instance has exactly one parent in v1. Child pin-declared outputs without explicit target
         route to the recorded ParentRoute of the instance that created the child.
@@ -1903,7 +1935,7 @@ engine:
         must not read inbound event.source as structural parent authority and does not satisfy ParentRoute metadata for
         template/dynamic instances.
       parent_to_child: Parent-to-child routing is never inferred structurally in v1. The parent must use target:{instance_id}
-        or another explicit target form.
+        or the canonical parent connect topology with addressed receiver input pins.
       grandchildren: A grandchild's structural pin output routes to its immediate parent only. Multi-level retargeting is v2.
       multiple_parents: Per-child multi-parent routing is v2. A parent that needs multi-consumer fan-out consumes first and
         re-emits with explicit target forms.
@@ -1932,7 +1964,7 @@ engine:
         target_set flow_instances. The publish plan MUST persist one delivery row per target route/recipient pair. Dispatch
         MUST expose the delivery row's target route as the receiver's singular event.target view.
       target_absent: When event.target and event.target_set are both absent, no target filter applies. This is the explicit
-        broadcast/external path.
+        broadcast/external path. It is not the normal parent-composed pin route.
       internal_observation_hooks: Audit logging, debug streams, metric taps, and test-only live observers are not routing-execution
         subscribers and may observe all events regardless of target.
       match_count_behavior:
@@ -1973,7 +2005,8 @@ engine:
       - dedicated route-inspection CLI
     select_entity_coexistence:
       canonical: External webhook ingress, events declared with swarm.source beginning with external, and mixed-provenance no-target events.
-      non_canonical: In-topology pin routing. Receivers should not depend on select_entity to repair broadcast to the right entity.
+      non_canonical: In-topology parent-connect pin routing. Receivers should declare addressed input pin resolution rather
+        than depend on select_entity to repair broadcast to the right entity.
       receiver_context_order:
       - event.target
       - select_entity_or_select_or_create_entity
@@ -1999,7 +2032,9 @@ engine:
       subscribes_to: Local names by default. Flow-prefixed only as escape hatch.
       emit_events: Always local names. The platform externalizes at emission time.
       events_yaml: Always local names. Flow-scoped at load time.
-      pins: Always local names. The platform matches pins by name for topology, then target rules choose instance recipients.
+      pins: Always local names. Parent connect binds output pins to receiver input pins for topology; same-name pin matching
+        is only a safe analyzer inference when unambiguous. Target rules materialize concrete instance recipients after
+        connect lowering or explicit escape-hatch targeting.
     wildcards:
       description: Pattern matching for subscriptions across flow instances. Wildcards do not override target filtering when event.target or event.target_set is set.
       patterns:
@@ -4612,6 +4647,139 @@ flow_model:
         policy_credential_resolution: Runtime per-import policy and credential resolution is tracked separately by #1453.
         wildcard_grants: Wildcard subtree and cross-tree grant behavior is tracked separately by #1454.
         final_e2e_package_proof: Final multi-package marketplace-style runtime proof is tracked separately by #1455.
+    composition_routing:
+      status: source_authority_promoted_runtime_migration_pending
+      promoted_by: '#1467'
+      parent_decision: '#1466'
+      owner: platform-spec.yaml#flow_model.flow_package.composition_routing
+      rule: >
+        Parent-authored composition routing is the canonical source authority for common cross-flow pin delivery.
+        Output pins declare the event identity and producer interface; input pins declare the receiver interface and
+        any receiver address resolution; parent package.yaml `connect` entries declare inter-flow delivery topology.
+        The analyzer verifies those authored facts, infers only safe and unambiguous defaults, rejects ambiguity
+        fail-closed, and lowers each accepted connection into concrete route-plan facts consumed by runtime RoutePlan.
+        Producer emit sites MUST NOT own consumer routing on the common composed path.
+      authored_shapes:
+        addressed_input_pin:
+          location: schema.yaml pins.inputs.events
+          canonical_form: >
+            An input event pin MAY be authored as an object when it needs receiver address resolution:
+            `{name, event, address}`. `name` is the local public input pin name. `event` is the local event
+            identity accepted by the receiver handler. `address` declares how the receiver entity or flow instance
+            is selected for in-topology delivery.
+          scalar_form: >
+            A scalar input event pin remains valid only for receivers that need no receiver address resolution or where
+            the parent connect/lowering rule supplies a complete receiver route without receiver-side key selection.
+          address_fields:
+            by: Required receiver address key name when address is present.
+            source: Optional source expression such as payload.vertical_id or event.source.entity_id. If omitted, the analyzer may infer it only when the output payload exposes exactly one compatible field for `by`.
+            target: Optional receiver expression such as entity.vertical_id, config.vertical_id, or instance.vertical_id. If omitted, the analyzer may infer it only when the receiver declares exactly one compatible owned key for `by`.
+            cardinality: Required when address is present; valid values are one and many. one lowers to singular target; many lowers to target_set/fan-out.
+            mode: Optional receiver acquisition mode. Valid values are select_existing, select_or_create, and static_instance. Omitted mode means select_existing.
+          example: |
+            pins:
+              inputs:
+                events:
+                  - name: deploy_completed
+                    event: deploy.completed
+                    address:
+                      by: vertical_id
+                      source: payload.vertical_id
+                      target: entity.vertical_id
+                      cardinality: one
+        parent_connect:
+          location: parent package.yaml connect
+          canonical_form: >
+            `connect` is a list of structured connections. Each entry binds one producer output pin to one receiver
+            input pin, optionally names an alias/adapter, and declares or confirms delivery topology. `from` and `to`
+            use flow-id plus local pin names, not handler keys and not runtime instance paths.
+          fields:
+            from: Required producer reference `{producer_flow_id}.{output_pin_name}`.
+            to: Required receiver reference `{receiver_flow_id}.{input_pin_name}`.
+            adapter: Optional named payload/event adapter when producer output and receiver input names or payload keys differ.
+            map: Optional explicit map from receiver address keys to source/target expressions. Required when inference would be ambiguous or names differ.
+            delivery: Optional delivery topology; valid values are one, many, broadcast, and reply. If omitted, the analyzer may infer only when unambiguous from the addressed input pin cardinality.
+            reply: Optional reply lineage declaration for response routing; required when delivery is reply and usable request lineage is not otherwise provable.
+          example: |
+            connect:
+              - from: holding_devops.deploy_completed
+                to: operating.deploy_completed
+                delivery: one
+                map:
+                  vertical_id:
+                    source: payload.vertical_id
+                    target: entity.vertical_id
+      ownership_split:
+        output_pins: Output pins own producer event identity and public producer interface only.
+        input_pins: Input pins own receiver interface and receiver address resolution requirements.
+        parent_connect: Parent connect owns inter-flow delivery topology, including point-to-point, broadcast/fan-out, and reply/sender routing.
+        analyzer: Analyzer owns validation, safe inference, alias/adapter expansion, and lowering to concrete route-plan facts.
+        route_plan: Runtime RoutePlan owns publish-time concrete recipient authority after lowering; it consumes authored topology and MUST NOT reconstruct it from live subscribers.
+        producer_emit_target: Producer `emit.target` owns only exceptional dynamic routing and MUST NOT be used as the common parent-composed routing surface.
+      analyzer_verify_requirements:
+        producer_flow_exists: The `from` flow must exist in the loaded package registry.
+        producer_output_pin_exists: The `from` pin must exist in the producer schema output event pins.
+        receiver_flow_exists: The `to` flow must exist in the loaded package registry.
+        receiver_input_pin_exists: The `to` pin must exist in the receiver schema input event pins.
+        event_alias_or_adapter_valid: Differing local event names or payload keys require an explicit alias/adapter or unambiguous bind-derived alias; raw same-name fallback is not valid for declared imported package pins.
+        output_carries_address_key: The producer output event payload or envelope must carry every receiver address key required by the target input pin, or the connect entry must map it explicitly.
+        receiver_address_rule_present: Stateful or instance-addressed receivers must declare or inherit an input-pin address rule unless the connection lowers to a statically unique receiver.
+        key_types_compatible: Source and target key types must be compatible before route-plan lowering.
+        delivery_topology_valid: The declared delivery topology must match addressed input cardinality and available receiver instances.
+        reply_lineage_usable: Reply delivery must prove usable request lineage; missing or ambiguous lineage fails closed.
+        inference_unambiguous: Analyzer inference is allowed only when exactly one producer, receiver, key, adapter, and topology match is possible.
+        lowered_route_plan_concrete: Accepted connections must lower to concrete route-plan inputs; no runtime path may recover by broadcasting or reinterpreting raw pin names.
+      route_plan_lowering:
+        owner: platform-spec.yaml#flow_model.flow_package.composition_routing.route_plan_lowering
+        consumes:
+        - parent package.yaml connect entries
+        - producer output pin event identity
+        - receiver addressed input pin rules
+        - import-boundary pin alias bindings
+        - explicit adapter/map entries
+        produces:
+        - semantic producer scope and local output pin identity
+        - semantic receiver scope and local input pin identity
+        - external persisted event identity
+        - receiver-local handler event identity
+        - 'concrete target route for delivery: one'
+        - 'concrete target_set routes for delivery: many or broadcast'
+        - 'reply route lineage for delivery: reply'
+        - typed failure reason when lowering cannot produce a concrete plan
+        delivery_mapping:
+          one: Lower to a singular event.target and one delivery row.
+          many: Lower to event.target_set and one delivery row per concrete recipient.
+          broadcast: Lower to explicit parent-authored fan-out route facts; producer broadcast:true is not required.
+          reply: Lower through the recorded request lineage; missing or ambiguous lineage fails closed.
+        invalid_outputs:
+        - raw same-name pin match used as final topology authority
+        - live subscription list used to invent missing connect topology
+        - producer emit.target used as common parent-composed routing owner
+        - select_entity used to repair an in-topology broadcast
+      pin_alias_delivery_composition:
+        rule: >
+          Import-boundary `requires`/`bind` pin aliases from #1452 are lower-level name-adaptation inputs to connect
+          lowering. They may rename the parent-facing input/output pin, but they do not rewrite source event identity,
+          replay scope, target metadata, broadcast semantics, correlation, cardinality, or delivery topology.
+        owner_consumed: platform-spec.yaml#flow_model.flow_package.import_boundary.pin_alias_delivery
+      emit_target_escape_hatch:
+        role: >
+          `emit.target` remains the only producer-authored dynamic routing escape hatch. It is valid for cases where the
+          producer genuinely knows a runtime recipient that parent connect cannot statically express. It is not a
+          compatibility path for missing parent connect entries, missing addressed input pins, or ambiguous topology.
+        limits:
+        - Must use the target forms defined by handler_specification.handler_fields.emit and engine.cross_flow_routing.target_forms.
+        - Must fail closed for malformed, unreachable, ambiguous, or unauthorized targets.
+        - Must not satisfy parent connect requirements for imported package public pins.
+        - Must not be introduced as a producer route-default surface.
+      split_boundaries:
+        runtime_route_consumption: Runtime RouteTable/EventBus/RoutePlan migration is a follow-up implementation child; this source-authority section does not claim runtime behavior closure.
+        parser_model_support: Parser/model support beyond source-authority fixtures is follow-up unless an implementation gate explicitly widens.
+        policy_credential_resolution: '#1453 remains separate.'
+        wildcard_scoping: '#1454 remains separate.'
+        final_e2e_package_proof: '#1455 remains separate.'
+        route_explain_describe: '#1442 tooling remains separate.'
+        agent_output_pin_runtime_failure: '#1444 must be re-audited against this source authority before runtime implementation.'
   nesting:
     description: 'Flows nest recursively. A flow''s package.yaml declares child flows in its flows: list. Each child is a
       directory under flows/ with the same structure. There is no depth limit. The platform discovers flows by walking the
@@ -4633,11 +4801,13 @@ flow_model:
   pins:
     description: Flows have typed input/output pins, like IC chips in a circuit. The platform validates pin wiring at boot.
     input_event_pins:
-      description: Events the flow subscribes to. Required pins must be wired (some other flow emits them) or boot warns.
+      description: Events the flow subscribes to through its public receiver interface. Required pins must be wired by parent
+        connect, a safe analyzer inference, an explicit external source, or another accepted producer path.
       required: true
     output_event_pins:
       description: Events the flow emits across its public interface. Optional, but when an emit site emits one of these
-        events, pin routing is active and the emit must provide a target mechanism, structural ParentRoute, or broadcast:true.
+        events, pin routing is active and routing must be supplied by parent connect lowering, structural ParentRoute,
+        explicit dynamic target escape hatch, or explicit broadcast escape hatch.
       required: false
     input_data_pins:
       description: Entity fields the flow reads. Required pins must be written by a prior flow or initial data.
@@ -4650,8 +4820,9 @@ flow_model:
       pins. They are implementation details, not part of the flow's public contract. Only events that cross flow boundaries
       or trigger/complete the flow appear in pins.
     routing_authority: Output event pins are the activation switch for source/target pin routing. Input event pins define
-      the allowed receiving interface. Runtime implementation and flow migration must consume engine.cross_flow_routing as
-      the authoritative source for target semantics.
+      the allowed receiving interface and any receiver address resolution. Parent package connect entries own common
+      inter-flow topology. Runtime implementation and flow migration must consume flow_model.flow_package.composition_routing
+      and engine.cross_flow_routing as the authoritative source for composed route semantics.
   required_agents:
     description: 'Each flow schema declares required_agents — agent role sockets that the root flow must fill. Each entry
       specifies: role name, events the agent subscribes to, events it emits, and a description. The platform validates at
@@ -8075,6 +8246,7 @@ static_analyzer:
     canonical_owner: internal/runtime/bootverify
     supported_surface: cmd/swarm verify
     spec_basis:
+    - flow_model.flow_package.composition_routing
     - flow_model.state_composition.cross_flow_handoff
     - engine.cross_flow_routing.auto_wiring
     - engine.event_identity
@@ -8091,8 +8263,11 @@ static_analyzer:
       - produces-based proof
       - swarm.status-based lifecycle suppression
     accepted_producer_paths:
+      parent_connect:
+        rule: Parent package.yaml connect binds a producer output pin to this receiver input pin and lowers to a concrete route plan.
       sibling_flow_output_pin:
-        rule: Another flow declares the same local event name in schema.yaml pins.outputs.events.
+        rule: Another flow declares the same local event name in schema.yaml pins.outputs.events and the analyzer can prove
+          this is the unique safe inference for parent connect topology.
       root_agent_emit_events:
         rule: A root-level agent declares the event in emit_events.
       root_node_handler_emits:
@@ -8114,12 +8289,16 @@ static_analyzer:
     canonical_owner: internal/runtime/bootverify
     supported_surface: cmd/swarm verify
     spec_basis:
+    - flow_model.flow_package.composition_routing
     - engine.cross_flow_routing
     - handler_specification.handler_fields.emit
     - contract_formats.event_schema.strict_payload_contract.envelope_identity
+    canonical_replacement: flow_model.flow_package.composition_routing.analyzer_verify_requirements
     scope:
       description: For every system-node emit site whose emitted event is declared in the emitter flow's pins.outputs.events,
-        verify that the authored contract supplies a valid target mechanism or explicit broadcast opt-out.
+        verify that the authored contract supplies lowered parent connect topology, a valid target escape hatch, structural
+        binding, or explicit broadcast opt-out. Current runtime implementation may still enforce the pre-connect target
+        surface until the composition-routing migration child lands; this slice is not the canonical parent-composed route owner.
       applies_to:
       - handler top-level single-emit
       - rules entries
@@ -8132,6 +8311,8 @@ static_analyzer:
       - mixed-trigger path disambiguation beyond statically singular handlers
       - runtime delivery correctness after a target has been resolved
     accepted_target_mechanisms:
+      lowered_parent_connect:
+        rule: Parent connect plus receiver addressed input pin lowering provides concrete route-plan facts before runtime dispatch.
       explicit_target:
         forms:
         - sender


### PR DESCRIPTION
## Summary

Defines the #1467 composition-first routing source authority in `platform-spec.yaml`:

- Adds `flow_model.flow_package.composition_routing` as the canonical owner for addressed input pins, parent `connect`, analyzer/verify requirements, route-plan lowering, #1452 alias composition, and `emit.target` escape-hatch limits.
- Updates adjacent routing/envelope/pin/static-analyzer sections so parent `connect` is the common authored topology owner and producer `emit.target` / `broadcast` are escape hatches, not the common consumer-routing surface.
- Adds focused parsed-spec proof in `internal/apispec` so the source-authority owner and demotion rules cannot silently drift.

Closes #1467.
Part of #1466 and #1450.

## Governing Refs / Context

Exact governing spec references touched:

- `platform-spec.yaml#flow_model.flow_package.composition_routing`
- `platform-spec.yaml#engine.cross_flow_routing`
- `platform-spec.yaml#handler_specification.handler_fields.emit`
- `platform-spec.yaml#contract_formats.event_schema.routing_derivation.route_plan_authority`
- `platform-spec.yaml#contract_formats.event_schema.strict_payload_contract.envelope_identity`
- `platform-spec.yaml#flow_model.pins`
- `platform-spec.yaml#static_analyzer.slice_3_input_pin_producer_path_satisfaction`
- `platform-spec.yaml#static_analyzer.slice_3a_pin_target_resolution`

Binding issue context:

- #1467 approved gate comment: source-authority/spec first slice only.
- #1466 final design: output pins declare event/identity, input pins declare receiver address resolution, parent `connect` declares topology, analyzer lowers, and producer `emit.target` is exceptional dynamic routing only.

## Semantic Migration Accounting

New canonical owner:

- `platform-spec.yaml#flow_model.flow_package.composition_routing`

Old non-authoritative producer/reader/writer paths now invalid as common-path ownership:

- Raw same-name pin matching as final topology authority.
- Producer `emit.target` / `broadcast` as the normal consumer-routing surface.
- Receiver `select_entity` as repair for in-topology broadcast.
- Runtime RouteTable/EventBus/RoutePlan deriving authored topology instead of consuming lowered connect facts.

Production paths checked for surviving old behavior:

- Spec sections for route-plan authority, handler `emit`, `engine.cross_flow_routing`, `flow_model.pins`, static analyzer pin wiring/target resolution, and #1452 import-boundary aliasing.
- Code seams were checked during the gate in contracts, semanticview, bootverify, bus, pipeline, and pinrouting; this PR intentionally does not migrate runtime/parser/model behavior.

Migration completeness:

- Source-authority/spec class complete for #1467.
- Runtime/parser/model/bootverify/RouteTable/EventBus consumption remains explicitly split under #1466/#1450 and must not be claimed closed by this PR.

## Validation

- `go test ./internal/apispec`
- `go test ./...`