### PR TITLE
[agent-a][issue #1471] Validate composition connect source authority

### DIFF
--- a/internal/runtime/bootverify/checks.go
+++ b/internal/runtime/bootverify/checks.go
@@ -246,6 +246,7 @@ var bootCheckRegistry = []Check{
 	{ID: "gate_schema_validation", Severity: "error", Run: checkGateSchemaValidation},
 	{ID: "flow_package_import_completeness", Severity: SeverityHardInvalidity, Run: checkFlowPackageImportCompleteness},
 	{ID: "flow_package_pin_bind_alias_validation", Severity: SeverityHardInvalidity, Run: checkFlowPackagePinBindAliasValidation},
+	{ID: "composition_connect_validation", Severity: "error", Run: checkCompositionConnectValidation},
 	{ID: "input_pin_wiring", Severity: "warning", Run: checkInputPinWiring},
 	{ID: "pin_target_resolution", Severity: "error", Run: checkPinTargetResolution},
 	{ID: "redundant_in_topology_select_entity", Severity: "warning", Run: checkRedundantInTopologySelectEntity},

--- a/internal/runtime/bootverify/flow_data_access_test.go
+++ b/internal/runtime/bootverify/flow_data_access_test.go
@@ -66,8 +66,8 @@ func TestRun_ValidatesFlowDataAccessDeclarations(t *testing.T) {
 }
 
 func TestBootCheckRegistry_HasFlowDataAccessCheckCount(t *testing.T) {
-	if got := len(bootCheckRegistry); got != 56 {
-		t.Fatalf("bootCheckRegistry count = %d, want 56", got)
+	if got := len(bootCheckRegistry); got != 57 {
+		t.Fatalf("bootCheckRegistry count = %d, want 57", got)
 	}
 }
 

--- a/internal/runtime/bootverify/report_test.go
+++ b/internal/runtime/bootverify/report_test.go
@@ -4747,8 +4747,8 @@ func TestRun_ReportsMissingRuntimeExecutorForOwnedRuntimeEvent(t *testing.T) {
 }
 
 func TestBootCheckRegistry_HasSpecCheckCount(t *testing.T) {
-	if got := len(bootCheckRegistry); got != 56 {
-		t.Fatalf("bootCheckRegistry count = %d, want 56", got)
+	if got := len(bootCheckRegistry); got != 57 {
+		t.Fatalf("bootCheckRegistry count = %d, want 57", got)
 	}
 	if got := len(supplementalChecks); got != 3 {
 		t.Fatalf("supplementalChecks count = %d, want 3", got)

--- a/internal/runtime/bootverify/workflow_composition_connect_checks.go
+++ b/internal/runtime/bootverify/workflow_composition_connect_checks.go
@@ -1,0 +1,365 @@
+package bootverify
+
+import (
+	"fmt"
+	"strings"
+
+	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
+	"github.com/division-sh/swarm/internal/runtime/core/eventidentity"
+	"github.com/division-sh/swarm/internal/runtime/entityruntime"
+	"github.com/division-sh/swarm/internal/runtime/semanticview"
+)
+
+func checkCompositionConnectValidation(c *checkerContext) []Finding {
+	if c == nil || c.source == nil {
+		return nil
+	}
+	var findings []Finding
+	for _, connect := range c.source.CompositionConnects() {
+		findings = append(findings, validateCompositionConnect(c.source, connect)...)
+	}
+	return findings
+}
+
+func validateCompositionConnect(source semanticview.Source, connect runtimecontracts.FlowPackageConnect) []Finding {
+	var findings []Finding
+	from, fromErr := connect.FromRef()
+	to, toErr := connect.ToRef()
+	if fromErr != nil {
+		findings = append(findings, compositionConnectFinding(connect, "producer_reference_invalid", fromErr.Error(), ""))
+	}
+	if toErr != nil {
+		findings = append(findings, compositionConnectFinding(connect, "receiver_reference_invalid", toErr.Error(), ""))
+	}
+	if fromErr != nil || toErr != nil {
+		return findings
+	}
+
+	if _, ok := source.FlowSchemaByID(from.FlowID); !ok {
+		findings = append(findings, compositionConnectFinding(connect, "producer_flow_missing", fmt.Sprintf("producer flow %s does not exist", from.FlowID), from.FlowID))
+		return findings
+	}
+	receiverSchema, ok := source.FlowSchemaByID(to.FlowID)
+	if !ok {
+		findings = append(findings, compositionConnectFinding(connect, "receiver_flow_missing", fmt.Sprintf("receiver flow %s does not exist", to.FlowID), to.FlowID))
+		return findings
+	}
+
+	outputPin, ok := source.FlowOutputEventPin(from.FlowID, from.Pin)
+	if !ok {
+		findings = append(findings, compositionConnectFinding(connect, "producer_output_pin_missing", fmt.Sprintf("producer flow %s does not declare output pin %s", from.FlowID, from.Pin), from.FlowID))
+		return findings
+	}
+	inputPin, ok := source.FlowInputEventPin(to.FlowID, to.Pin)
+	if !ok {
+		findings = append(findings, compositionConnectFinding(connect, "receiver_input_pin_missing", fmt.Sprintf("receiver flow %s does not declare input pin %s", to.FlowID, to.Pin), to.FlowID))
+		return findings
+	}
+
+	if !compositionConnectEventCompatible(source, connect, from, to, outputPin, inputPin) {
+		findings = append(findings, compositionConnectFinding(
+			connect,
+			"event_alias_or_adapter_invalid",
+			fmt.Sprintf("producer output event %s and receiver input event %s differ without an explicit adapter or import-boundary alias", outputPin.EventType(), inputPin.EventType()),
+			to.FlowID,
+		))
+	}
+
+	findings = append(findings, validateCompositionConnectDelivery(connect, inputPin, receiverSchema, to.FlowID)...)
+	findings = append(findings, validateCompositionConnectAddress(source, connect, outputPin, inputPin, from.FlowID, to.FlowID)...)
+	return findings
+}
+
+func compositionConnectFinding(connect runtimecontracts.FlowPackageConnect, reason, detail, location string) Finding {
+	if strings.TrimSpace(location) == "" {
+		if to, err := connect.ToRef(); err == nil {
+			location = strings.TrimSpace(to.FlowID)
+		}
+	}
+	if strings.TrimSpace(location) == "" {
+		location = "package.yaml"
+	}
+	return Finding{
+		CheckID:  "composition_connect_validation",
+		Severity: "error",
+		Message:  fmt.Sprintf("connect %s -> %s is invalid: %s: %s", strings.TrimSpace(connect.From), strings.TrimSpace(connect.To), reason, detail),
+		Location: location,
+	}
+}
+
+func compositionConnectEventCompatible(source semanticview.Source, connect runtimecontracts.FlowPackageConnect, from, to runtimecontracts.FlowPackagePinRef, outputPin runtimecontracts.FlowOutputEventPin, inputPin runtimecontracts.FlowInputEventPin) bool {
+	outputEvent := eventidentity.Normalize(outputPin.EventType())
+	inputEvent := eventidentity.Normalize(inputPin.EventType())
+	if outputEvent == "" || inputEvent == "" || outputEvent == inputEvent {
+		return true
+	}
+	if strings.TrimSpace(connect.Adapter) != "" {
+		return true
+	}
+	candidates := map[string]struct{}{
+		outputEvent: {},
+		eventidentity.Normalize(source.ResolveFlowEventReference(from.FlowID, outputPin.EventType())): {},
+	}
+	candidateEvents := make([]string, 0, len(candidates))
+	for candidate := range candidates {
+		candidateEvents = append(candidateEvents, candidate)
+	}
+	for _, candidate := range candidateEvents {
+		for _, parentEvent := range semanticview.ImportBoundaryOutputParentEventsForEvent(source, connect.PackageKey, "", candidate) {
+			if parentEvent = eventidentity.Normalize(parentEvent); parentEvent != "" {
+				candidates[parentEvent] = struct{}{}
+			}
+		}
+	}
+	if _, ok := candidates[inputEvent]; ok {
+		return true
+	}
+	for _, alias := range semanticview.ImportBoundaryInputAliases(source, to.FlowID, inputPin.PinName()) {
+		if _, ok := candidates[eventidentity.Normalize(alias.ParentEvent)]; ok {
+			return true
+		}
+		if _, ok := candidates[eventidentity.Normalize(alias.EventPattern)]; ok {
+			return true
+		}
+	}
+	for _, alias := range semanticview.ImportBoundaryInputAliases(source, to.FlowID, inputPin.EventType()) {
+		if _, ok := candidates[eventidentity.Normalize(alias.ParentEvent)]; ok {
+			return true
+		}
+		if _, ok := candidates[eventidentity.Normalize(alias.EventPattern)]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+func validateCompositionConnectDelivery(connect runtimecontracts.FlowPackageConnect, inputPin runtimecontracts.FlowInputEventPin, receiverSchema runtimecontracts.FlowSchemaDocument, receiverFlowID string) []Finding {
+	var findings []Finding
+	delivery := strings.TrimSpace(connect.Delivery)
+	if delivery == "" && inputPin.Address != nil {
+		delivery = strings.TrimSpace(inputPin.Address.Cardinality)
+	}
+	switch delivery {
+	case "", "one", "many", "broadcast", "reply":
+	default:
+		findings = append(findings, compositionConnectFinding(connect, "delivery_topology_invalid", fmt.Sprintf("delivery %q is not one, many, broadcast, or reply", delivery), receiverFlowID))
+	}
+	if delivery == "reply" && len(connect.Reply) == 0 {
+		findings = append(findings, compositionConnectFinding(connect, "reply_lineage_missing", "reply delivery requires a reply lineage declaration", receiverFlowID))
+	}
+	if inputPin.Address == nil {
+		if compositionReceiverAddressRequired(receiverSchema) && delivery != "broadcast" {
+			findings = append(findings, compositionConnectFinding(connect, "receiver_address_rule_missing", fmt.Sprintf("receiver flow %s requires an addressed input pin", receiverFlowID), receiverFlowID))
+		}
+		return findings
+	}
+	cardinality := strings.TrimSpace(inputPin.Address.Cardinality)
+	switch cardinality {
+	case "one", "many":
+	default:
+		findings = append(findings, compositionConnectFinding(connect, "delivery_topology_invalid", fmt.Sprintf("input pin address cardinality %q is not one or many", cardinality), receiverFlowID))
+	}
+	if delivery == "one" && cardinality == "many" {
+		findings = append(findings, compositionConnectFinding(connect, "delivery_topology_invalid", "delivery one is incompatible with address cardinality many", receiverFlowID))
+	}
+	if delivery == "many" && cardinality == "one" {
+		findings = append(findings, compositionConnectFinding(connect, "delivery_topology_invalid", "delivery many is incompatible with address cardinality one", receiverFlowID))
+	}
+	if delivery == "broadcast" && cardinality == "one" {
+		findings = append(findings, compositionConnectFinding(connect, "delivery_topology_invalid", "delivery broadcast is incompatible with address cardinality one", receiverFlowID))
+	}
+	mode := strings.TrimSpace(inputPin.Address.Mode)
+	switch mode {
+	case "", "select_existing", "select_or_create", "static_instance":
+	default:
+		findings = append(findings, compositionConnectFinding(connect, "receiver_address_rule_invalid", fmt.Sprintf("address mode %q is not supported", mode), receiverFlowID))
+	}
+	return findings
+}
+
+func compositionReceiverAddressRequired(schema runtimecontracts.FlowSchemaDocument) bool {
+	return strings.EqualFold(strings.TrimSpace(schema.Mode), "template")
+}
+
+func validateCompositionConnectAddress(source semanticview.Source, connect runtimecontracts.FlowPackageConnect, outputPin runtimecontracts.FlowOutputEventPin, inputPin runtimecontracts.FlowInputEventPin, producerFlowID, receiverFlowID string) []Finding {
+	if inputPin.Address == nil {
+		for key := range connect.Map {
+			return []Finding{compositionConnectFinding(connect, "receiver_address_rule_missing", fmt.Sprintf("connect map key %s has no receiver input-pin address rule", key), receiverFlowID)}
+		}
+		return nil
+	}
+	address := runtimecontracts.FlowInputPinAddress{
+		By:          strings.TrimSpace(inputPin.Address.By),
+		Source:      strings.TrimSpace(inputPin.Address.Source),
+		Target:      strings.TrimSpace(inputPin.Address.Target),
+		Cardinality: strings.TrimSpace(inputPin.Address.Cardinality),
+		Mode:        strings.TrimSpace(inputPin.Address.Mode),
+	}
+	if address.By == "" {
+		return []Finding{compositionConnectFinding(connect, "receiver_address_rule_missing", "input pin address.by is required", receiverFlowID)}
+	}
+	for key := range connect.Map {
+		if strings.TrimSpace(key) != address.By {
+			return []Finding{compositionConnectFinding(connect, "connect_map_unknown_address_key", fmt.Sprintf("connect map key %s is not declared by receiver address key %s", key, address.By), receiverFlowID)}
+		}
+	}
+	mapEntry := connect.Map[address.By]
+	sourceExpr := firstNonEmpty(mapEntry.Source, address.Source)
+	if sourceExpr == "" {
+		sourceExpr = "payload." + address.By
+	}
+	targetExpr := firstNonEmpty(mapEntry.Target, address.Target)
+	if targetExpr == "" {
+		targetExpr = "entity." + address.By
+	}
+	sourceType, err := compositionConnectSourceType(source, producerFlowID, outputPin.EventType(), sourceExpr)
+	if err != nil {
+		return []Finding{compositionConnectFinding(connect, "output_carries_address_key", err.Error(), producerFlowID)}
+	}
+	targetType, err := compositionConnectTargetType(source, receiverFlowID, targetExpr)
+	if err != nil {
+		return []Finding{compositionConnectFinding(connect, "receiver_address_rule_invalid", err.Error(), receiverFlowID)}
+	}
+	if !compositionConnectTypesCompatible(sourceType, targetType) {
+		return []Finding{compositionConnectFinding(connect, "key_types_incompatible", fmt.Sprintf("source %s type %s is incompatible with target %s type %s", sourceExpr, sourceType, targetExpr, targetType), receiverFlowID)}
+	}
+	return nil
+}
+
+func compositionConnectSourceType(source semanticview.Source, flowID, eventType, expr string) (string, error) {
+	expr = strings.TrimSpace(expr)
+	if expr == "" {
+		return "", fmt.Errorf("source expression is required")
+	}
+	if strings.HasPrefix(expr, "event.source.") {
+		return "string", nil
+	}
+	if !strings.HasPrefix(expr, "payload.") {
+		return "", fmt.Errorf("source expression %q must be payload.* or event.source.*", expr)
+	}
+	fieldPath := strings.TrimPrefix(expr, "payload.")
+	if fieldPath == "" || strings.Contains(fieldPath, ".") {
+		return "", fmt.Errorf("source expression %q must reference a single payload field", expr)
+	}
+	resolution := semanticview.ResolveEventSchema(source, flowID, eventType)
+	if !resolution.HasSchema {
+		return "", fmt.Errorf("producer output event %s has no payload schema", eventType)
+	}
+	props, _ := resolution.Schema.Schema["properties"].(map[string]any)
+	raw, ok := props[fieldPath]
+	if !ok {
+		return "", fmt.Errorf("producer output event %s does not carry payload field %s", eventType, fieldPath)
+	}
+	prop, _ := raw.(map[string]any)
+	typ, _ := prop["type"].(string)
+	typ = strings.TrimSpace(typ)
+	if typ == "" {
+		return "", fmt.Errorf("producer output event %s payload field %s has no scalar type", eventType, fieldPath)
+	}
+	return typ, nil
+}
+
+func compositionConnectTargetType(source semanticview.Source, flowID, expr string) (string, error) {
+	expr = strings.TrimSpace(expr)
+	if expr == "" {
+		return "", fmt.Errorf("target expression is required")
+	}
+	if strings.HasPrefix(expr, "entity.") {
+		fieldPath := strings.TrimPrefix(expr, "entity.")
+		contract, ok := entityruntime.ResolveForFlow(source, flowID)
+		if !ok {
+			return "", fmt.Errorf("receiver flow %s has no entity contract for %s", flowID, expr)
+		}
+		field, err := entityruntime.ResolveLeafField(contract, fieldPath)
+		if err != nil {
+			return "", fmt.Errorf("receiver target %s is invalid: %v", expr, err)
+		}
+		return field.Type, nil
+	}
+	if strings.HasPrefix(expr, "config.") {
+		field := strings.TrimPrefix(expr, "config.")
+		schema, ok := source.FlowSchemaByID(flowID)
+		if !ok {
+			return "", fmt.Errorf("receiver flow %s does not exist", flowID)
+		}
+		variable, ok := schema.InstanceVariables.Variables[field]
+		if !ok {
+			return "", fmt.Errorf("receiver config field %s is not declared", field)
+		}
+		if strings.TrimSpace(variable.Type) == "" {
+			return "", fmt.Errorf("receiver config field %s has no type", field)
+		}
+		return variable.Type, nil
+	}
+	if strings.HasPrefix(expr, "instance.") {
+		return "string", nil
+	}
+	return "", fmt.Errorf("target expression %q must be entity.*, config.*, or instance.*", expr)
+}
+
+func compositionConnectTypesCompatible(sourceType, targetType string) bool {
+	sourceType = compositionConnectTypeFamily(sourceType)
+	targetType = compositionConnectTypeFamily(targetType)
+	return sourceType != "" && targetType != "" && sourceType == targetType
+}
+
+func compositionConnectTypeFamily(raw string) string {
+	raw = strings.ToLower(strings.TrimSpace(raw))
+	switch raw {
+	case "string", "text", "uuid", "timestamp":
+		return "string"
+	case "integer", "number", "numeric", "float", "double", "real":
+		return "number"
+	case "boolean", "bool":
+		return "boolean"
+	default:
+		return raw
+	}
+}
+
+func compositionConnectsToInput(source semanticview.Source, flowID, pinOrEvent string) bool {
+	if source == nil {
+		return false
+	}
+	pinOrEvent = eventidentity.Normalize(pinOrEvent)
+	if pinOrEvent == "" {
+		return false
+	}
+	for _, pin := range source.FlowInputEventPins(flowID) {
+		if eventidentity.Normalize(pin.PinName()) != pinOrEvent && eventidentity.Normalize(pin.EventType()) != pinOrEvent {
+			continue
+		}
+		if len(source.CompositionConnectsTo(flowID, pin.PinName())) > 0 {
+			return true
+		}
+	}
+	return false
+}
+
+func compositionConnectsFromOutputEvent(source semanticview.Source, flowID, eventType string) bool {
+	if source == nil {
+		return false
+	}
+	eventType = eventidentity.Normalize(eventType)
+	if eventType == "" {
+		return false
+	}
+	for _, pin := range source.FlowOutputEventPins(flowID) {
+		if eventidentity.Normalize(pin.PinName()) != eventType && eventidentity.Normalize(pin.EventType()) != eventType {
+			continue
+		}
+		if len(source.CompositionConnectsFrom(flowID, pin.PinName())) > 0 {
+			return true
+		}
+	}
+	return false
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if trimmed := strings.TrimSpace(value); trimmed != "" {
+			return trimmed
+		}
+	}
+	return ""
+}

--- a/internal/runtime/bootverify/workflow_composition_connect_checks_test.go
+++ b/internal/runtime/bootverify/workflow_composition_connect_checks_test.go
@@ -1,0 +1,562 @@
+package bootverify
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
+	"github.com/division-sh/swarm/internal/runtime/semanticview"
+)
+
+func TestRun_AllowsParentCompositionConnectAsVerifyRouteProof(t *testing.T) {
+	root := writeCompositionConnectBootverifyFixture(t, compositionConnectFixtureOptions{})
+	bundle := loadFixtureBundleAt(t, repoRootForBootverifyTest(t), root, runtimecontracts.DefaultPlatformSpecFile(repoRootForBootverifyTest(t)))
+
+	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+
+	if reportContains(report.Errors(), "composition_connect_validation", "") {
+		t.Fatalf("unexpected composition_connect_validation error: %#v", report.Errors())
+	}
+	if reportContains(report.Errors(), "pin_target_resolution", "deploy.done") {
+		t.Fatalf("parent connect should satisfy output pin target proof, got %#v", report.Errors())
+	}
+	if reportContains(report.Warnings(), "input_pin_wiring", "deploy.completed") {
+		t.Fatalf("parent connect should satisfy input pin wiring proof, got %#v", report.Warnings())
+	}
+}
+
+func TestRun_FailsClosedForInvalidParentCompositionConnect(t *testing.T) {
+	tests := []struct {
+		name      string
+		opts      compositionConnectFixtureOptions
+		want      string
+		wantExtra string
+	}{
+		{
+			name: "missing producer flow",
+			opts: compositionConnectFixtureOptions{
+				connectFrom: "missing.deploy_done",
+			},
+			want: "producer_flow_missing",
+		},
+		{
+			name: "missing producer output pin",
+			opts: compositionConnectFixtureOptions{
+				connectFrom: "producer.missing_pin",
+			},
+			want: "producer_output_pin_missing",
+		},
+		{
+			name: "missing receiver flow",
+			opts: compositionConnectFixtureOptions{
+				connectTo: "missing.deploy_completed",
+			},
+			want: "receiver_flow_missing",
+		},
+		{
+			name: "missing receiver input pin",
+			opts: compositionConnectFixtureOptions{
+				connectTo: "consumer.missing_pin",
+			},
+			want: "receiver_input_pin_missing",
+		},
+		{
+			name: "event names differ without adapter",
+			opts: compositionConnectFixtureOptions{
+				noAdapter: true,
+			},
+			want: "event_alias_or_adapter_invalid",
+		},
+		{
+			name: "missing address key",
+			opts: compositionConnectFixtureOptions{
+				mapSource: "payload.missing_vertical_id",
+			},
+			want:      "output_carries_address_key",
+			wantExtra: "missing_vertical_id",
+		},
+		{
+			name: "incompatible address key types",
+			opts: compositionConnectFixtureOptions{
+				consumerEntityType: "integer",
+			},
+			want: "key_types_incompatible",
+		},
+		{
+			name: "invalid delivery topology",
+			opts: compositionConnectFixtureOptions{
+				delivery: "many",
+			},
+			want: "delivery_topology_invalid",
+		},
+		{
+			name: "broadcast delivery with singular address",
+			opts: compositionConnectFixtureOptions{
+				delivery: "broadcast",
+			},
+			want:      "delivery_topology_invalid",
+			wantExtra: "broadcast",
+		},
+		{
+			name: "missing reply lineage",
+			opts: compositionConnectFixtureOptions{
+				delivery: "reply",
+			},
+			want: "reply_lineage_missing",
+		},
+		{
+			name: "template receiver missing address rule",
+			opts: compositionConnectFixtureOptions{
+				consumerMode:        "template",
+				consumerScalarInput: true,
+				connectTo:           "consumer.deploy.completed",
+			},
+			want: "receiver_address_rule_missing",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			root := writeCompositionConnectBootverifyFixture(t, tc.opts)
+			bundle := loadFixtureBundleAt(t, repoRootForBootverifyTest(t), root, runtimecontracts.DefaultPlatformSpecFile(repoRootForBootverifyTest(t)))
+
+			report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+
+			if !reportContains(report.Errors(), "composition_connect_validation", tc.want) {
+				t.Fatalf("expected composition_connect_validation %q, got %#v", tc.want, report.Errors())
+			}
+			if tc.wantExtra != "" && !reportContains(report.Errors(), "composition_connect_validation", tc.wantExtra) {
+				t.Fatalf("expected composition_connect_validation detail %q, got %#v", tc.wantExtra, report.Errors())
+			}
+		})
+	}
+}
+
+func TestRun_AllowsImportBoundaryAliasAsConnectEventAdapter(t *testing.T) {
+	root := writeCompositionConnectBootverifyFixture(t, compositionConnectFixtureOptions{
+		consumerRequiresInput: true,
+		consumerInputBind:     "deploy.done",
+		consumerScalarInput:   true,
+		connectTo:             "consumer.deploy.completed",
+		noAdapter:             true,
+		omitMap:               true,
+	})
+	bundle := loadFixtureBundleAt(t, repoRootForBootverifyTest(t), root, runtimecontracts.DefaultPlatformSpecFile(repoRootForBootverifyTest(t)))
+
+	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+
+	if reportContains(report.Errors(), "composition_connect_validation", "event_alias_or_adapter_invalid") {
+		t.Fatalf("import-boundary alias should satisfy connect event adaptation, got %#v", report.Errors())
+	}
+}
+
+func TestRun_AllowsOutputBoundaryAliasAsConnectEventAdapter(t *testing.T) {
+	root := writeCompositionConnectBootverifyFixture(t, compositionConnectFixtureOptions{
+		producerRequiresOutput: true,
+		producerOutputBind:     "deploy.completed",
+		consumerScalarInput:    true,
+		noAdapter:              true,
+		omitMap:                true,
+	})
+	bundle := loadFixtureBundleAt(t, repoRootForBootverifyTest(t), root, runtimecontracts.DefaultPlatformSpecFile(repoRootForBootverifyTest(t)))
+
+	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+
+	if reportContains(report.Errors(), "composition_connect_validation", "event_alias_or_adapter_invalid") {
+		t.Fatalf("producer import-boundary alias should satisfy connect event adaptation, got %#v", report.Errors())
+	}
+}
+
+func TestRun_AllowsParentCompositionConnectAsCrossFlowAmbiguityProof(t *testing.T) {
+	root := writeCompositionConnectAmbiguityFixture(t)
+	bundle := loadFixtureBundleAt(t, repoRootForBootverifyTest(t), root, runtimecontracts.DefaultPlatformSpecFile(repoRootForBootverifyTest(t)))
+
+	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+
+	if reportContains(report.Errors(), "composition_connect_validation", "") {
+		t.Fatalf("unexpected composition_connect_validation error: %#v", report.Errors())
+	}
+	if reportContains(report.Errors(), "cross_flow_pin_ambiguity_validation", "ticket.ready") {
+		t.Fatalf("parent connect should disambiguate cross-flow input pin, got %#v", report.Errors())
+	}
+}
+
+func TestRun_TreatsParentCompositionConnectAsEventTopologyProof(t *testing.T) {
+	root := writeCompositionConnectTopologyFixture(t)
+	bundle := loadFixtureBundleAt(t, repoRootForBootverifyTest(t), root, runtimecontracts.DefaultPlatformSpecFile(repoRootForBootverifyTest(t)))
+
+	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+
+	if reportContains(report.Errors(), "composition_connect_validation", "") {
+		t.Fatalf("unexpected composition_connect_validation error: %#v", report.Errors())
+	}
+	if reportContains(report.Warnings(), "event_producer_exists", "consumer/deploy.completed") {
+		t.Fatalf("parent connect should prove receiver input has a producer, got %#v", report.Warnings())
+	}
+	if reportContains(report.Warnings(), "event_consumer_exists", "producer/deploy.done") {
+		t.Fatalf("parent connect should prove producer output has a consumer, got %#v", report.Warnings())
+	}
+	for _, eventRef := range []string{"producer/deploy.done", "consumer/deploy.completed"} {
+		if reportContains(report.Warnings(), "semantic_drift_dead_event_schema", eventRef) {
+			t.Fatalf("parent connect should mark %s as active, got %#v", eventRef, report.Warnings())
+		}
+	}
+}
+
+type compositionConnectFixtureOptions struct {
+	connectFrom            string
+	connectTo              string
+	delivery               string
+	noAdapter              bool
+	mapSource              string
+	mapTarget              string
+	omitMap                bool
+	consumerMode           string
+	consumerScalarInput    bool
+	consumerEntityType     string
+	consumerRequiresInput  bool
+	consumerInputBind      string
+	producerRequiresOutput bool
+	producerOutputBind     string
+}
+
+func writeCompositionConnectBootverifyFixture(t *testing.T, opts compositionConnectFixtureOptions) string {
+	t.Helper()
+	root := t.TempDir()
+	connectFrom := firstTestValue(opts.connectFrom, "producer.deploy_done")
+	connectTo := firstTestValue(opts.connectTo, "consumer.deploy_completed")
+	delivery := firstTestValue(opts.delivery, "one")
+	adapter := "    adapter: deploy_done_to_completed\n"
+	if opts.noAdapter {
+		adapter = ""
+	}
+	mapSource := firstTestValue(opts.mapSource, "payload.vertical_id")
+	mapTarget := firstTestValue(opts.mapTarget, "entity.vertical_id")
+	mapBlock := ""
+	if !opts.omitMap {
+		mapBlock = `
+    map:
+      vertical_id:
+        source: ` + mapSource + `
+        target: ` + mapTarget
+	}
+	flowBind := ""
+	if opts.consumerRequiresInput {
+		bind := firstTestValue(opts.consumerInputBind, "deploy.done")
+		flowBind = `
+    bind:
+      inputs:
+        deploy.completed: ` + bind
+	}
+	producerBind := ""
+	if opts.producerRequiresOutput {
+		bind := firstTestValue(opts.producerOutputBind, "deploy.completed")
+		producerBind = `
+    bind:
+      outputs:
+        deploy.done: ` + bind
+	}
+	writeBootverifyFixtureFile(t, filepath.Join(root, "package.yaml"), `
+name: composition-connect-bootverify
+version: "1.0.0"
+platform_version: ">=1.6.0"
+flows:
+  - id: producer
+    flow: producer
+    mode: static`+producerBind+`
+  - id: consumer
+    flow: consumer
+    mode: `+firstTestValue(opts.consumerMode, "static")+flowBind+`
+connect:
+  - from: `+connectFrom+`
+    to: `+connectTo+`
+`+adapter+`    delivery: `+delivery+`
+`+mapBlock+`
+`)
+	writeBootverifyFixtureFile(t, filepath.Join(root, "schema.yaml"), "name: composition-connect-bootverify\n")
+	writeBootverifyFixtureFile(t, filepath.Join(root, "policy.yaml"), "{}\n")
+	writeBootverifyFixtureFile(t, filepath.Join(root, "tools.yaml"), "{}\n")
+	writeBootverifyFixtureFile(t, filepath.Join(root, "agents.yaml"), "{}\n")
+	rootEvents := "{}\n"
+	if opts.producerRequiresOutput {
+		rootEvents = "deploy.completed:\n  vertical_id: string\n"
+	}
+	writeBootverifyFixtureFile(t, filepath.Join(root, "events.yaml"), rootEvents)
+	writeBootverifyFixtureFile(t, filepath.Join(root, "nodes.yaml"), "{}\n")
+	writeCompositionConnectProducerFlow(t, root, opts)
+	writeCompositionConnectConsumerFlow(t, root, opts)
+	return root
+}
+
+func writeCompositionConnectTopologyFixture(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	writeCompositionConnectRootPackage(t, root, "composition-connect-topology", `
+  - from: producer.deploy_done
+    to: consumer.deploy_completed
+    adapter: deploy_done_to_completed
+    delivery: one
+    map:
+      vertical_id:
+        source: payload.vertical_id
+        target: entity.vertical_id
+`)
+	writeCompositionConnectProducerSchemaOnlyFlow(t, root)
+	writeCompositionConnectConsumerSchemaOnlyFlow(t, root)
+	return root
+}
+
+func writeCompositionConnectAmbiguityFixture(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	writeBootverifyFixtureFile(t, filepath.Join(root, "package.yaml"), `
+name: composition-connect-ambiguity
+version: "1.0.0"
+platform_version: ">=1.6.0"
+flows:
+  - id: producer_a
+    flow: producer_a
+    mode: static
+  - id: producer_b
+    flow: producer_b
+    mode: static
+  - id: consumer
+    flow: consumer
+    mode: static
+connect:
+  - from: producer_a.ticket.ready
+    to: consumer.ticket.ready
+    delivery: one
+`)
+	writeBootverifyFixtureFile(t, filepath.Join(root, "schema.yaml"), "name: composition-connect-ambiguity\n")
+	writeBootverifyFixtureFile(t, filepath.Join(root, "policy.yaml"), "{}\n")
+	writeBootverifyFixtureFile(t, filepath.Join(root, "tools.yaml"), "{}\n")
+	writeBootverifyFixtureFile(t, filepath.Join(root, "agents.yaml"), "{}\n")
+	writeBootverifyFixtureFile(t, filepath.Join(root, "events.yaml"), "{}\n")
+	writeBootverifyFixtureFile(t, filepath.Join(root, "nodes.yaml"), "{}\n")
+	for _, flowID := range []string{"producer_a", "producer_b"} {
+		writeBootverifyFixtureFile(t, filepath.Join(root, "flows", flowID, "schema.yaml"), `
+name: `+flowID+`
+mode: static
+pins:
+  outputs:
+    events:
+      - ticket.ready
+`)
+		writeBootverifyFixtureFile(t, filepath.Join(root, "flows", flowID, "policy.yaml"), "{}\n")
+		writeBootverifyFixtureFile(t, filepath.Join(root, "flows", flowID, "agents.yaml"), "{}\n")
+		writeBootverifyFixtureFile(t, filepath.Join(root, "flows", flowID, "entities.yaml"), "{}\n")
+		writeBootverifyFixtureFile(t, filepath.Join(root, "flows", flowID, "events.yaml"), `
+ticket.ready:
+  entity_id: string
+`)
+		writeBootverifyFixtureFile(t, filepath.Join(root, "flows", flowID, "nodes.yaml"), "{}\n")
+	}
+	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "consumer", "schema.yaml"), `
+name: consumer
+mode: static
+pins:
+  inputs:
+    events:
+      - ticket.ready
+`)
+	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "consumer", "policy.yaml"), "{}\n")
+	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "consumer", "agents.yaml"), "{}\n")
+	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "consumer", "entities.yaml"), "{}\n")
+	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "consumer", "events.yaml"), `
+ticket.ready:
+  entity_id: string
+`)
+	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "consumer", "nodes.yaml"), "{}\n")
+	return root
+}
+
+func writeCompositionConnectRootPackage(t *testing.T, root, name, connectEntries string) {
+	t.Helper()
+	writeBootverifyFixtureFile(t, filepath.Join(root, "package.yaml"), `
+name: `+name+`
+version: "1.0.0"
+platform_version: ">=1.6.0"
+flows:
+  - id: producer
+    flow: producer
+    mode: static
+  - id: consumer
+    flow: consumer
+    mode: static
+connect:
+`+connectEntries)
+	writeBootverifyFixtureFile(t, filepath.Join(root, "schema.yaml"), "name: "+name+"\n")
+	writeBootverifyFixtureFile(t, filepath.Join(root, "policy.yaml"), "{}\n")
+	writeBootverifyFixtureFile(t, filepath.Join(root, "tools.yaml"), "{}\n")
+	writeBootverifyFixtureFile(t, filepath.Join(root, "agents.yaml"), "{}\n")
+	writeBootverifyFixtureFile(t, filepath.Join(root, "events.yaml"), "{}\n")
+	writeBootverifyFixtureFile(t, filepath.Join(root, "nodes.yaml"), "{}\n")
+}
+
+func writeCompositionConnectProducerSchemaOnlyFlow(t *testing.T, root string) {
+	t.Helper()
+	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "producer", "schema.yaml"), `
+name: producer
+mode: static
+pins:
+  outputs:
+    events:
+      - name: deploy_done
+        event: deploy.done
+`)
+	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "producer", "policy.yaml"), "{}\n")
+	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "producer", "agents.yaml"), "{}\n")
+	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "producer", "entities.yaml"), "{}\n")
+	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "producer", "events.yaml"), `
+deploy.done:
+  vertical_id: string
+`)
+	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "producer", "nodes.yaml"), "{}\n")
+}
+
+func writeCompositionConnectConsumerSchemaOnlyFlow(t *testing.T, root string) {
+	t.Helper()
+	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "consumer", "schema.yaml"), `
+name: consumer
+mode: static
+pins:
+  inputs:
+    events:
+      - name: deploy_completed
+        event: deploy.completed
+        address:
+          by: vertical_id
+          source: payload.vertical_id
+          target: entity.vertical_id
+          cardinality: one
+`)
+	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "consumer", "policy.yaml"), "{}\n")
+	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "consumer", "agents.yaml"), "{}\n")
+	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "consumer", "events.yaml"), `
+deploy.completed:
+  vertical_id: string
+`)
+	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "consumer", "entities.yaml"), `
+deployment:
+  vertical_id:
+    type: string
+    _unused_reason: composition connect topology proof field
+`)
+	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "consumer", "nodes.yaml"), "{}\n")
+}
+
+func writeCompositionConnectProducerFlow(t *testing.T, root string, opts compositionConnectFixtureOptions) {
+	t.Helper()
+	if opts.producerRequiresOutput {
+		writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "producer", "package.yaml"), `
+name: producer
+version: "1.0.0"
+requires:
+  inputs: []
+  outputs: [deploy.done]
+`)
+	}
+	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "producer", "schema.yaml"), `
+name: producer
+mode: static
+pins:
+  outputs:
+    events:
+      - name: deploy_done
+        event: deploy.done
+`)
+	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "producer", "policy.yaml"), "{}\n")
+	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "producer", "agents.yaml"), "{}\n")
+	if !opts.producerRequiresOutput {
+		writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "producer", "entities.yaml"), "{}\n")
+	}
+	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "producer", "events.yaml"), `
+deploy.requested:
+  vertical_id: string
+deploy.done:
+  vertical_id: string
+`)
+	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "producer", "nodes.yaml"), `
+producer-node:
+  id: producer-node
+  execution_type: system_node
+  subscribes_to: [deploy.requested]
+  event_handlers:
+    deploy.requested:
+      emit:
+        event: deploy.done
+        fields:
+          vertical_id: payload.vertical_id
+`)
+}
+
+func writeCompositionConnectConsumerFlow(t *testing.T, root string, opts compositionConnectFixtureOptions) {
+	t.Helper()
+	if opts.consumerRequiresInput {
+		writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "consumer", "package.yaml"), `
+name: consumer
+version: "1.0.0"
+requires:
+  inputs: [deploy.completed]
+  outputs: []
+`)
+	}
+	inputEvents := `
+      - name: deploy_completed
+        event: deploy.completed
+        address:
+          by: vertical_id
+          source: payload.vertical_id
+          target: entity.vertical_id
+          cardinality: one
+`
+	if opts.consumerScalarInput {
+		inputEvents = `
+      - deploy.completed
+`
+	}
+	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "consumer", "schema.yaml"), `
+name: consumer
+mode: `+firstTestValue(opts.consumerMode, "static")+`
+initial_state: idle
+terminal_states: [done]
+states: [idle, done]
+pins:
+  inputs:
+    events:`+inputEvents)
+	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "consumer", "policy.yaml"), "{}\n")
+	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "consumer", "agents.yaml"), "{}\n")
+	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "consumer", "events.yaml"), `
+deploy.completed:
+  vertical_id: string
+`)
+	if !opts.consumerScalarInput {
+		entityType := firstTestValue(opts.consumerEntityType, "string")
+		writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "consumer", "entities.yaml"), `
+deployment:
+  vertical_id:
+    type: `+entityType+`
+`)
+	}
+	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "consumer", "nodes.yaml"), `
+consumer-node:
+  id: consumer-node
+  execution_type: system_node
+  subscribes_to: [deploy.completed]
+  event_handlers:
+    deploy.completed:
+      create_entity: true
+      advances_to: done
+`)
+}
+
+func firstTestValue(values ...string) string {
+	for _, value := range values {
+		if trimmed := strings.TrimSpace(value); trimmed != "" {
+			return trimmed
+		}
+	}
+	return ""
+}

--- a/internal/runtime/bootverify/workflow_dead_event_schema_checks.go
+++ b/internal/runtime/bootverify/workflow_dead_event_schema_checks.go
@@ -23,6 +23,8 @@ type deadEventSchemaUsage struct {
 	autoEmitOnCreate   bool
 	externalSource     bool
 	externalConsumer   bool
+	connectOutputs     int
+	connectInputs      int
 }
 
 func (u deadEventSchemaUsage) hasAny() bool {
@@ -34,7 +36,9 @@ func (u deadEventSchemaUsage) hasAny() bool {
 		u.fanOutEmit > 0 ||
 		u.autoEmitOnCreate ||
 		u.externalSource ||
-		u.externalConsumer
+		u.externalConsumer ||
+		u.connectOutputs > 0 ||
+		u.connectInputs > 0
 }
 
 func (c *checkerContext) deadEventSchema() []Finding {
@@ -58,7 +62,7 @@ func (c *checkerContext) deadEventSchema() []Finding {
 			CheckID:  "semantic_drift_dead_event_schema",
 			Severity: "warning",
 			Message: fmt.Sprintf(
-				"Event %s declared in %s has no active role in the authored bundle.\n\nChecked usage sites:\n- Handler emits: %d\n- Handler subscribes: %d\n- Agent emit_events: %d\n- Agent subscriptions: %d\n- Timer fire/start/cancel references: %d\n- External source metadata (swarm.source): %s\n- External consumer metadata (swarm.consumer): %s\n- Fan-out emit: %d\n- Auto-emit-on-create: %s\n\nIf this event is no longer used, remove it from %s.\nIf it is used by an external system, add swarm.source: external or swarm.consumer: ... to document the external role.",
+				"Event %s declared in %s has no active role in the authored bundle.\n\nChecked usage sites:\n- Handler emits: %d\n- Handler subscribes: %d\n- Agent emit_events: %d\n- Agent subscriptions: %d\n- Timer fire/start/cancel references: %d\n- External source metadata (swarm.source): %s\n- External consumer metadata (swarm.consumer): %s\n- Fan-out emit: %d\n- Auto-emit-on-create: %s\n- Parent connect outputs: %d\n- Parent connect inputs: %d\n\nIf this event is no longer used, remove it from %s.\nIf it is used by an external system, add swarm.source: external or swarm.consumer: ... to document the external role.",
 				decl.Canonical,
 				fileLabel,
 				usage.handlerEmits,
@@ -70,6 +74,8 @@ func (c *checkerContext) deadEventSchema() []Finding {
 				yesNoLocal(usage.externalConsumer),
 				usage.fanOutEmit,
 				yesNoLocal(usage.autoEmitOnCreate),
+				usage.connectOutputs,
+				usage.connectInputs,
 				fileLabel,
 			),
 			Location: decl.Canonical,
@@ -260,6 +266,20 @@ func (c *checkerContext) deadEventSchemaUsageFor(decl deadEventDeclaration) dead
 		for _, eventType := range deadEventTimerReferences(timer) {
 			if deadEventRoleMatches(c.source, decl, timerFlowID, eventType) {
 				usage.timerReferences++
+			}
+		}
+	}
+	for _, connect := range c.source.CompositionConnects() {
+		from, fromErr := connect.FromRef()
+		if fromErr == nil {
+			if outputPin, ok := c.source.FlowOutputEventPin(from.FlowID, from.Pin); ok && deadEventRoleMatches(c.source, decl, from.FlowID, outputPin.EventType()) {
+				usage.connectOutputs++
+			}
+		}
+		to, toErr := connect.ToRef()
+		if toErr == nil {
+			if inputPin, ok := c.source.FlowInputEventPin(to.FlowID, to.Pin); ok && deadEventRoleMatches(c.source, decl, to.FlowID, inputPin.EventType()) {
+				usage.connectInputs++
 			}
 		}
 	}

--- a/internal/runtime/bootverify/workflow_event_topology_checks.go
+++ b/internal/runtime/bootverify/workflow_event_topology_checks.go
@@ -143,6 +143,7 @@ func (c *checkerContext) eventWarnings() []Finding {
 			}
 		}
 	}
+	addCompositionConnectEventProofsLocal(c.source, emittedRefs, subscribedRefs)
 	for _, key := range sortedSetKeysLocal(emittedRefs) {
 		ref := emittedRefs[key]
 		if !ref.HasSchema {
@@ -189,6 +190,30 @@ func (c *checkerContext) eventWarnings() []Finding {
 		})
 	}
 	return c.eventWarningFindings
+}
+
+func addCompositionConnectEventProofsLocal(source semanticview.Source, emittedRefs, subscribedRefs map[string]semanticview.FlowEventProof) {
+	if source == nil {
+		return
+	}
+	for _, connect := range source.CompositionConnects() {
+		from, fromErr := connect.FromRef()
+		to, toErr := connect.ToRef()
+		if fromErr == nil {
+			if outputPin, ok := source.FlowOutputEventPin(from.FlowID, from.Pin); ok {
+				eventType := outputPin.EventType()
+				addEventProofLocal(emittedRefs, source, from.FlowID, eventType)
+				addEventProofLocal(subscribedRefs, source, from.FlowID, eventType)
+			}
+		}
+		if toErr == nil {
+			if inputPin, ok := source.FlowInputEventPin(to.FlowID, to.Pin); ok {
+				eventType := inputPin.EventType()
+				addEventProofLocal(emittedRefs, source, to.FlowID, eventType)
+				addEventProofLocal(subscribedRefs, source, to.FlowID, eventType)
+			}
+		}
+	}
 }
 
 type eventPatternLocal struct {

--- a/internal/runtime/bootverify/workflow_flow_boundary_checks.go
+++ b/internal/runtime/bootverify/workflow_flow_boundary_checks.go
@@ -92,6 +92,7 @@ func (c *checkerContext) inputPinWiring() []Finding {
 }
 
 type inputPinProducerPaths struct {
+	parentConnect        string
 	siblingFlowOutputPin string
 	rootAgentEmit        string
 	rootNodeHandlerEmit  string
@@ -102,6 +103,7 @@ type inputPinProducerPaths struct {
 
 func (p inputPinProducerPaths) hasAny() bool {
 	for _, detail := range []string{
+		p.parentConnect,
 		p.siblingFlowOutputPin,
 		p.rootAgentEmit,
 		p.rootNodeHandlerEmit,
@@ -120,9 +122,10 @@ func (p inputPinProducerPaths) message(flowID, eventType string) string {
 	flowID = strings.TrimSpace(flowID)
 	eventType = strings.TrimSpace(eventType)
 	return fmt.Sprintf(
-		"Flow %s declares input pin event %s but no producer path was found in the authored bundle.\n\nChecked producer paths:\n- Sibling flow output pin: %s\n- Root agent emit_events: %s\n- Root node handler emits: %s\n- Platform event catalog: %s\n- External source metadata (swarm.source): %s\n- Same-flow timer declaration: %s\n\nFix one of:\n- Add %s to a producing flow's pins.outputs.events\n- Add %s to a root agent's emit_events\n- Add swarm.source: external to %s's events.yaml entry if produced externally",
+		"Flow %s declares input pin event %s but no producer path was found in the authored bundle.\n\nChecked producer paths:\n- Parent connect: %s\n- Sibling flow output pin: %s\n- Root agent emit_events: %s\n- Root node handler emits: %s\n- Platform event catalog: %s\n- External source metadata (swarm.source): %s\n- Same-flow timer declaration: %s\n\nFix one of:\n- Add a parent package.yaml connect entry to this input pin\n- Add %s to a producing flow's pins.outputs.events\n- Add %s to a root agent's emit_events\n- Add swarm.source: external to %s's events.yaml entry if produced externally",
 		flowID,
 		eventType,
+		p.parentConnect,
 		p.siblingFlowOutputPin,
 		p.rootAgentEmit,
 		p.rootNodeHandlerEmit,
@@ -162,6 +165,7 @@ func (c *checkerContext) inputPinProducerPaths(flowID, eventType string, flowSco
 	localEvent := eventidentity.Normalize(eventType)
 	canonicalEvent := eventidentity.Normalize(c.source.ResolveFlowEventReference(flowID, eventType))
 	return inputPinProducerPaths{
+		parentConnect:        c.inputPinParentConnectPath(flowID, localEvent),
 		siblingFlowOutputPin: c.inputPinSiblingFlowOutputPath(flowID, localEvent),
 		rootAgentEmit:        c.inputPinRootAgentPath(localEvent, canonicalEvent, flowScopedAgents),
 		rootNodeHandlerEmit:  c.inputPinRootNodeHandlerPath(localEvent, canonicalEvent, flowScopedNodes),
@@ -169,6 +173,25 @@ func (c *checkerContext) inputPinProducerPaths(flowID, eventType string, flowSco
 		externalSource:       c.inputPinExternalSourcePath(flowID, eventType),
 		sameFlowTimer:        c.inputPinSameFlowTimerPath(flowID, eventType, canonicalEvent),
 	}
+}
+
+func (c *checkerContext) inputPinParentConnectPath(flowID, localEvent string) string {
+	for _, pin := range c.source.FlowInputEventPins(flowID) {
+		if eventidentity.Normalize(pin.EventType()) != localEvent && eventidentity.Normalize(pin.PinName()) != localEvent {
+			continue
+		}
+		connects := c.source.CompositionConnectsTo(flowID, pin.PinName())
+		if len(connects) == 0 {
+			return "not found"
+		}
+		refs := make([]string, 0, len(connects))
+		for _, connect := range connects {
+			refs = append(refs, strings.TrimSpace(connect.From))
+		}
+		sort.Strings(refs)
+		return fmt.Sprintf("found via parent connect from %s", strings.Join(refs, ", "))
+	}
+	return "not found"
 }
 
 func (c *checkerContext) inputPinSiblingFlowOutputPath(flowID, localEvent string) string {
@@ -394,6 +417,9 @@ func (c *checkerContext) crossFlowPinAmbiguityValidation() []Finding {
 			}
 			producers := c.source.ResolveFlowInputAutoWire(flowID, eventType).ProducerFlows
 			if len(producers) <= 1 {
+				continue
+			}
+			if compositionConnectsToInput(c.source, flowID, eventType) {
 				continue
 			}
 			if flowHasScopedInputEscapeHatch(c.source, flowID, eventType) {

--- a/internal/runtime/bootverify/workflow_pin_routing_checks.go
+++ b/internal/runtime/bootverify/workflow_pin_routing_checks.go
@@ -15,6 +15,9 @@ func checkPinTargetResolution(c *checkerContext) []Finding {
 		if !runtimepinrouting.PinDeclaredOutput(c.source, site.FlowID, site.Spec.EventType()) {
 			continue
 		}
+		if compositionConnectsFromOutputEvent(c.source, site.FlowID, site.Spec.EventType()) {
+			continue
+		}
 		structuralParent := pinRoutingStructuralParentRouteEligible(c.source, site.FlowID)
 		if failure := runtimepinrouting.ValidateTargetSpec(c.source, site.FlowID, site.Spec, structuralParent); failure != "" {
 			findings = append(findings, pinTargetFinding(site, string(failure)))

--- a/internal/runtime/contracts/workflow_contract_accessors.go
+++ b/internal/runtime/contracts/workflow_contract_accessors.go
@@ -407,6 +407,98 @@ func (b *WorkflowContractBundle) FlowOutputEvents(flowID string) []string {
 	}
 	return append([]string{}, b.Semantics.FlowOutputs[strings.TrimSpace(flowID)]...)
 }
+func (b *WorkflowContractBundle) FlowInputEventPins(flowID string) []FlowInputEventPin {
+	if b == nil {
+		return nil
+	}
+	flowID = strings.TrimSpace(flowID)
+	if pins := b.Semantics.FlowInputEventPins[flowID]; len(pins) > 0 {
+		return cloneFlowInputEventPins(pins)
+	}
+	if schema, ok := b.FlowSchemas[flowID]; ok {
+		return semanticInputEventPins(schema.Pins.Inputs)
+	}
+	return inputEventPinsFromEvents(b.Semantics.FlowInputs[flowID])
+}
+func (b *WorkflowContractBundle) FlowOutputEventPins(flowID string) []FlowOutputEventPin {
+	if b == nil {
+		return nil
+	}
+	flowID = strings.TrimSpace(flowID)
+	if pins := b.Semantics.FlowOutputEventPins[flowID]; len(pins) > 0 {
+		return cloneFlowOutputEventPins(pins)
+	}
+	if schema, ok := b.FlowSchemas[flowID]; ok {
+		return semanticOutputEventPins(schema.Pins.Outputs)
+	}
+	return outputEventPinsFromEvents(b.Semantics.FlowOutputs[flowID])
+}
+func (b *WorkflowContractBundle) FlowInputEventPin(flowID, pinName string) (FlowInputEventPin, bool) {
+	pinName = strings.TrimSpace(pinName)
+	if pinName == "" {
+		return FlowInputEventPin{}, false
+	}
+	for _, pin := range b.FlowInputEventPins(flowID) {
+		if strings.TrimSpace(pin.Name) == pinName {
+			return pin, true
+		}
+	}
+	return FlowInputEventPin{}, false
+}
+func (b *WorkflowContractBundle) FlowOutputEventPin(flowID, pinName string) (FlowOutputEventPin, bool) {
+	pinName = strings.TrimSpace(pinName)
+	if pinName == "" {
+		return FlowOutputEventPin{}, false
+	}
+	for _, pin := range b.FlowOutputEventPins(flowID) {
+		if strings.TrimSpace(pin.Name) == pinName {
+			return pin, true
+		}
+	}
+	return FlowOutputEventPin{}, false
+}
+func (b *WorkflowContractBundle) CompositionConnects() []FlowPackageConnect {
+	if b == nil {
+		return nil
+	}
+	return cloneFlowPackageConnects(b.Semantics.CompositionConnects)
+}
+func (b *WorkflowContractBundle) CompositionConnectsTo(flowID, pinName string) []FlowPackageConnect {
+	flowID = strings.TrimSpace(flowID)
+	pinName = strings.TrimSpace(pinName)
+	if b == nil || flowID == "" || pinName == "" {
+		return nil
+	}
+	var out []FlowPackageConnect
+	for _, connect := range b.CompositionConnects() {
+		ref, err := connect.ToRef()
+		if err != nil {
+			continue
+		}
+		if ref.FlowID == flowID && ref.Pin == pinName {
+			out = append(out, connect)
+		}
+	}
+	return out
+}
+func (b *WorkflowContractBundle) CompositionConnectsFrom(flowID, pinName string) []FlowPackageConnect {
+	flowID = strings.TrimSpace(flowID)
+	pinName = strings.TrimSpace(pinName)
+	if b == nil || flowID == "" || pinName == "" {
+		return nil
+	}
+	var out []FlowPackageConnect
+	for _, connect := range b.CompositionConnects() {
+		ref, err := connect.FromRef()
+		if err != nil {
+			continue
+		}
+		if ref.FlowID == flowID && ref.Pin == pinName {
+			out = append(out, connect)
+		}
+	}
+	return out
+}
 func (b *WorkflowContractBundle) FlowReadPins(flowID string) []string {
 	if b == nil {
 		return nil

--- a/internal/runtime/contracts/workflow_contract_connect.go
+++ b/internal/runtime/contracts/workflow_contract_connect.go
@@ -1,0 +1,194 @@
+package contracts
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+func (p FlowInputEventPin) PinName() string {
+	return strings.TrimSpace(p.Name)
+}
+
+func (p FlowInputEventPin) EventType() string {
+	if eventType := strings.TrimSpace(p.Event); eventType != "" {
+		return eventType
+	}
+	return strings.TrimSpace(p.Name)
+}
+
+func (p FlowInputEventPin) normalized() FlowInputEventPin {
+	out := FlowInputEventPin{
+		Name:  strings.TrimSpace(p.Name),
+		Event: strings.TrimSpace(p.Event),
+	}
+	if out.Event == "" {
+		out.Event = out.Name
+	}
+	if p.Address != nil {
+		address := p.Address.normalized()
+		out.Address = &address
+	}
+	return out
+}
+
+func (p FlowOutputEventPin) PinName() string {
+	return strings.TrimSpace(p.Name)
+}
+
+func (p FlowOutputEventPin) EventType() string {
+	if eventType := strings.TrimSpace(p.Event); eventType != "" {
+		return eventType
+	}
+	return strings.TrimSpace(p.Name)
+}
+
+func (p FlowOutputEventPin) normalized() FlowOutputEventPin {
+	out := FlowOutputEventPin{
+		Name:  strings.TrimSpace(p.Name),
+		Event: strings.TrimSpace(p.Event),
+	}
+	if out.Event == "" {
+		out.Event = out.Name
+	}
+	return out
+}
+
+func (a FlowInputPinAddress) normalized() FlowInputPinAddress {
+	return FlowInputPinAddress{
+		By:          strings.TrimSpace(a.By),
+		Source:      strings.TrimSpace(a.Source),
+		Target:      strings.TrimSpace(a.Target),
+		Cardinality: strings.TrimSpace(a.Cardinality),
+		Mode:        strings.TrimSpace(a.Mode),
+	}
+}
+
+func (c FlowPackageConnect) FromRef() (FlowPackagePinRef, error) {
+	return parseFlowPackagePinRef(c.From)
+}
+
+func (c FlowPackageConnect) ToRef() (FlowPackagePinRef, error) {
+	return parseFlowPackagePinRef(c.To)
+}
+
+func (c FlowPackageConnect) WithPackageKey(packageKey string) FlowPackageConnect {
+	out := c.normalized()
+	out.PackageKey = strings.TrimSpace(packageKey)
+	return out
+}
+
+func (c FlowPackageConnect) normalized() FlowPackageConnect {
+	return FlowPackageConnect{
+		PackageKey: strings.TrimSpace(c.PackageKey),
+		From:       strings.TrimSpace(c.From),
+		To:         strings.TrimSpace(c.To),
+		Adapter:    strings.TrimSpace(c.Adapter),
+		Map:        cloneFlowPackageConnectMap(c.Map),
+		Delivery:   strings.TrimSpace(c.Delivery),
+		Reply:      normalizeStringMap(c.Reply),
+	}
+}
+
+func parseFlowPackagePinRef(raw string) (FlowPackagePinRef, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return FlowPackagePinRef{}, fmt.Errorf("pin reference is required")
+	}
+	idx := strings.Index(raw, ".")
+	if idx <= 0 || idx >= len(raw)-1 {
+		return FlowPackagePinRef{}, fmt.Errorf("pin reference %q must use {flow_id}.{pin_name}", raw)
+	}
+	ref := FlowPackagePinRef{
+		FlowID: strings.TrimSpace(raw[:idx]),
+		Pin:    strings.TrimSpace(raw[idx+1:]),
+	}
+	if ref.FlowID == "" || ref.Pin == "" {
+		return FlowPackagePinRef{}, fmt.Errorf("pin reference %q must use non-empty flow and pin names", raw)
+	}
+	return ref, nil
+}
+
+func inputEventPinsFromEvents(events []string) []FlowInputEventPin {
+	out := make([]FlowInputEventPin, 0, len(events))
+	for _, eventType := range events {
+		eventType = strings.TrimSpace(eventType)
+		if eventType == "" {
+			continue
+		}
+		out = append(out, FlowInputEventPin{Name: eventType, Event: eventType})
+	}
+	return out
+}
+
+func outputEventPinsFromEvents(events []string) []FlowOutputEventPin {
+	out := make([]FlowOutputEventPin, 0, len(events))
+	for _, eventType := range events {
+		eventType = strings.TrimSpace(eventType)
+		if eventType == "" {
+			continue
+		}
+		out = append(out, FlowOutputEventPin{Name: eventType, Event: eventType})
+	}
+	return out
+}
+
+func cloneFlowInputEventPins(in []FlowInputEventPin) []FlowInputEventPin {
+	out := make([]FlowInputEventPin, 0, len(in))
+	for _, pin := range in {
+		normalized := pin.normalized()
+		if normalized.PinName() == "" {
+			continue
+		}
+		out = append(out, normalized)
+	}
+	return out
+}
+
+func cloneFlowOutputEventPins(in []FlowOutputEventPin) []FlowOutputEventPin {
+	out := make([]FlowOutputEventPin, 0, len(in))
+	for _, pin := range in {
+		normalized := pin.normalized()
+		if normalized.PinName() == "" {
+			continue
+		}
+		out = append(out, normalized)
+	}
+	return out
+}
+
+func cloneFlowPackageConnects(in []FlowPackageConnect) []FlowPackageConnect {
+	out := make([]FlowPackageConnect, 0, len(in))
+	for _, connect := range in {
+		normalized := connect.normalized()
+		out = append(out, normalized)
+	}
+	return out
+}
+
+func cloneFlowPackageConnectMap(in map[string]FlowPackageConnectMap) map[string]FlowPackageConnectMap {
+	if len(in) == 0 {
+		return nil
+	}
+	keys := make([]string, 0, len(in))
+	for key := range in {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	out := make(map[string]FlowPackageConnectMap, len(in))
+	for _, key := range keys {
+		normalizedKey := strings.TrimSpace(key)
+		if normalizedKey == "" {
+			continue
+		}
+		entry := in[key]
+		out[normalizedKey] = FlowPackageConnectMap{
+			Source: strings.TrimSpace(entry.Source),
+			Target: strings.TrimSpace(entry.Target),
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}

--- a/internal/runtime/contracts/workflow_contract_semantics.go
+++ b/internal/runtime/contracts/workflow_contract_semantics.go
@@ -34,8 +34,11 @@ func populateWorkflowSemantics(bundle *WorkflowContractBundle) {
 		FlowRules:              map[string]string{},
 		FlowInputs:             map[string][]string{},
 		FlowOutputs:            map[string][]string{},
+		FlowInputEventPins:     map[string][]FlowInputEventPin{},
+		FlowOutputEventPins:    map[string][]FlowOutputEventPin{},
 		FlowReads:              map[string][]string{},
 		FlowWrites:             map[string][]string{},
+		CompositionConnects:    nil,
 		FlowAgents:             map[string][]FlowRequiredAgent{},
 		WritePinOwners:         map[string][]string{},
 		NodeHandlers:           map[string]map[string]SystemNodeEventHandler{},
@@ -71,6 +74,8 @@ func populateWorkflowSemantics(bundle *WorkflowContractBundle) {
 		semantics.FlowRules[flowID] = strings.TrimSpace(schema.NamespaceRule)
 		semantics.FlowInputs[flowID] = append([]string{}, schema.Pins.Inputs.Events...)
 		semantics.FlowOutputs[flowID] = append([]string{}, schema.Pins.Outputs.Events...)
+		semantics.FlowInputEventPins[flowID] = semanticInputEventPins(schema.Pins.Inputs)
+		semantics.FlowOutputEventPins[flowID] = semanticOutputEventPins(schema.Pins.Outputs)
 		semantics.FlowReads[flowID] = append([]string{}, schema.Pins.Inputs.Reads...)
 		semantics.FlowWrites[flowID] = append([]string{}, schema.Pins.Outputs.Writes...)
 		semantics.FlowAgents[flowID] = append([]FlowRequiredAgent{}, schema.RequiredAgents...)
@@ -80,6 +85,11 @@ func populateWorkflowSemantics(bundle *WorkflowContractBundle) {
 				continue
 			}
 			semantics.WritePinOwners[writePin] = appendIfMissingString(semantics.WritePinOwners[writePin], flowID)
+		}
+	}
+	for _, pkg := range bundle.PackageTree {
+		for _, connect := range pkg.Manifest.Connect {
+			semantics.CompositionConnects = append(semantics.CompositionConnects, connect.WithPackageKey(pkg.Key))
 		}
 	}
 	for nodeID, node := range bundle.Nodes {
@@ -145,6 +155,20 @@ func populateWorkflowSemantics(bundle *WorkflowContractBundle) {
 		semantics.NodeHandlers[nodeID] = handlers
 	}
 	bundle.Semantics = semantics
+}
+
+func semanticInputEventPins(pins FlowInputPins) []FlowInputEventPin {
+	if len(pins.EventPins) > 0 {
+		return cloneFlowInputEventPins(pins.EventPins)
+	}
+	return inputEventPinsFromEvents(pins.Events)
+}
+
+func semanticOutputEventPins(pins FlowOutputPins) []FlowOutputEventPin {
+	if len(pins.EventPins) > 0 {
+		return cloneFlowOutputEventPins(pins.EventPins)
+	}
+	return outputEventPinsFromEvents(pins.Events)
 }
 
 func legacyWorkflowEntitySchema(bundle *WorkflowContractBundle) EntitySchema {

--- a/internal/runtime/contracts/workflow_contract_types.go
+++ b/internal/runtime/contracts/workflow_contract_types.go
@@ -88,8 +88,11 @@ type WorkflowSemanticView struct {
 	FlowRules              map[string]string
 	FlowInputs             map[string][]string
 	FlowOutputs            map[string][]string
+	FlowInputEventPins     map[string][]FlowInputEventPin
+	FlowOutputEventPins    map[string][]FlowOutputEventPin
 	FlowReads              map[string][]string
 	FlowWrites             map[string][]string
+	CompositionConnects    []FlowPackageConnect
 	FlowAgents             map[string][]FlowRequiredAgent
 	WritePinOwners         map[string][]string
 	NodeHandlers           map[string]map[string]SystemNodeEventHandler
@@ -573,18 +576,19 @@ type FlowContractPaths struct {
 	PromptsDir   string
 }
 type ProjectPackageDocument struct {
-	Name            string              `yaml:"name"`
-	Version         string              `yaml:"version"`
-	PlatformVersion string              `yaml:"platform_version"`
-	Author          string              `yaml:"author"`
-	Description     string              `yaml:"description"`
-	Requires        FlowPackageRequires `yaml:"requires"`
-	Flows           []ProjectFlowRef    `yaml:"flows"`
-	Packages        []ProjectPackageRef `yaml:"packages"`
-	Children        []ProjectPackageRef `yaml:"children"`
-	Subpackages     []ProjectPackageRef `yaml:"subpackages"`
-	Handoffs        []ProjectHandoff    `yaml:"handoffs"`
-	EntitySchema    EntitySchema        `yaml:"entity_schema"`
+	Name            string               `yaml:"name"`
+	Version         string               `yaml:"version"`
+	PlatformVersion string               `yaml:"platform_version"`
+	Author          string               `yaml:"author"`
+	Description     string               `yaml:"description"`
+	Requires        FlowPackageRequires  `yaml:"requires"`
+	Flows           []ProjectFlowRef     `yaml:"flows"`
+	Packages        []ProjectPackageRef  `yaml:"packages"`
+	Children        []ProjectPackageRef  `yaml:"children"`
+	Subpackages     []ProjectPackageRef  `yaml:"subpackages"`
+	Connect         []FlowPackageConnect `yaml:"connect"`
+	Handoffs        []ProjectHandoff     `yaml:"handoffs"`
+	EntitySchema    EntitySchema         `yaml:"entity_schema"`
 }
 
 type TypeCatalogDocument struct {
@@ -721,12 +725,47 @@ type FlowPins struct {
 	Outputs FlowOutputPins `yaml:"outputs"`
 }
 type FlowInputPins struct {
-	Events []string `yaml:"events"`
-	Reads  []string `yaml:"reads"`
+	Events    []string            `yaml:"events"`
+	EventPins []FlowInputEventPin `yaml:"-"`
+	Reads     []string            `yaml:"reads"`
 }
 type FlowOutputPins struct {
-	Events []string `yaml:"events"`
-	Writes []string `yaml:"writes"`
+	Events    []string             `yaml:"events"`
+	EventPins []FlowOutputEventPin `yaml:"-"`
+	Writes    []string             `yaml:"writes"`
+}
+type FlowInputEventPin struct {
+	Name    string               `yaml:"name"`
+	Event   string               `yaml:"event"`
+	Address *FlowInputPinAddress `yaml:"address"`
+}
+type FlowOutputEventPin struct {
+	Name  string `yaml:"name"`
+	Event string `yaml:"event"`
+}
+type FlowInputPinAddress struct {
+	By          string `yaml:"by"`
+	Source      string `yaml:"source"`
+	Target      string `yaml:"target"`
+	Cardinality string `yaml:"cardinality"`
+	Mode        string `yaml:"mode"`
+}
+type FlowPackageConnect struct {
+	PackageKey string                           `yaml:"-"`
+	From       string                           `yaml:"from"`
+	To         string                           `yaml:"to"`
+	Adapter    string                           `yaml:"adapter"`
+	Map        map[string]FlowPackageConnectMap `yaml:"map"`
+	Delivery   string                           `yaml:"delivery"`
+	Reply      map[string]string                `yaml:"reply"`
+}
+type FlowPackageConnectMap struct {
+	Source string `yaml:"source"`
+	Target string `yaml:"target"`
+}
+type FlowPackagePinRef struct {
+	FlowID string
+	Pin    string
 }
 type FlowRequiredAgent struct {
 	Role         string   `yaml:"role"`

--- a/internal/runtime/contracts/workflow_contract_yaml_flow.go
+++ b/internal/runtime/contracts/workflow_contract_yaml_flow.go
@@ -68,7 +68,7 @@ func (p *FlowInputPins) UnmarshalYAML(node *yaml.Node) error {
 	if err := node.Decode(&aux); err != nil {
 		return err
 	}
-	events, err := decodeFlowPinEventsNode(&aux.Events)
+	events, eventPins, err := decodeFlowInputPinEventsNode(&aux.Events)
 	if err != nil {
 		return err
 	}
@@ -77,8 +77,9 @@ func (p *FlowInputPins) UnmarshalYAML(node *yaml.Node) error {
 		return err
 	}
 	*p = FlowInputPins{
-		Events: events,
-		Reads:  reads,
+		Events:    events,
+		EventPins: eventPins,
+		Reads:     reads,
 	}
 	return nil
 }
@@ -94,7 +95,7 @@ func (p *FlowOutputPins) UnmarshalYAML(node *yaml.Node) error {
 	if err := node.Decode(&aux); err != nil {
 		return err
 	}
-	events, err := decodeFlowPinEventsNode(&aux.Events)
+	events, eventPins, err := decodeFlowOutputPinEventsNode(&aux.Events)
 	if err != nil {
 		return err
 	}
@@ -103,36 +104,185 @@ func (p *FlowOutputPins) UnmarshalYAML(node *yaml.Node) error {
 		return err
 	}
 	*p = FlowOutputPins{
-		Events: events,
-		Writes: writes,
+		Events:    events,
+		EventPins: eventPins,
+		Writes:    writes,
 	}
 	return nil
 }
 
-func decodeFlowPinEventsNode(node *yaml.Node) ([]string, error) {
+func decodeFlowInputPinEventsNode(node *yaml.Node) ([]string, []FlowInputEventPin, error) {
 	if node == nil || node.Kind == 0 {
-		return nil, nil
+		return nil, nil, nil
 	}
-	var legacy []string
-	if err := node.Decode(&legacy); err == nil {
-		return append([]string{}, legacy...), nil
+	if node.Kind != yaml.SequenceNode {
+		return nil, nil, fmt.Errorf("flow pin events must be a sequence")
 	}
-
-	var structured []struct {
-		Name string `yaml:"name"`
-	}
-	if err := node.Decode(&structured); err != nil {
-		return nil, err
-	}
-	events := make([]string, 0, len(structured))
-	for _, entry := range structured {
-		name := strings.TrimSpace(entry.Name)
-		if name == "" {
+	events := make([]string, 0, len(node.Content))
+	pins := make([]FlowInputEventPin, 0, len(node.Content))
+	for _, entry := range node.Content {
+		pin, err := decodeFlowInputPinEventNode(entry)
+		if err != nil {
+			return nil, nil, err
+		}
+		pin = pin.normalized()
+		if pin.PinName() == "" {
 			continue
 		}
-		events = append(events, name)
+		events = append(events, pin.EventType())
+		pins = append(pins, pin)
 	}
-	return events, nil
+	return events, pins, nil
+}
+
+func decodeFlowOutputPinEventsNode(node *yaml.Node) ([]string, []FlowOutputEventPin, error) {
+	if node == nil || node.Kind == 0 {
+		return nil, nil, nil
+	}
+	if node.Kind != yaml.SequenceNode {
+		return nil, nil, fmt.Errorf("flow pin events must be a sequence")
+	}
+	events := make([]string, 0, len(node.Content))
+	pins := make([]FlowOutputEventPin, 0, len(node.Content))
+	for _, entry := range node.Content {
+		pin, err := decodeFlowOutputPinEventNode(entry)
+		if err != nil {
+			return nil, nil, err
+		}
+		pin = pin.normalized()
+		if pin.PinName() == "" {
+			continue
+		}
+		events = append(events, pin.EventType())
+		pins = append(pins, pin)
+	}
+	return events, pins, nil
+}
+
+func decodeFlowInputPinEventNode(node *yaml.Node) (FlowInputEventPin, error) {
+	if node == nil || node.Kind == 0 {
+		return FlowInputEventPin{}, nil
+	}
+	if node.Kind == yaml.ScalarNode {
+		value := strings.TrimSpace(node.Value)
+		return FlowInputEventPin{Name: value, Event: value}, nil
+	}
+	if node.Kind != yaml.MappingNode {
+		return FlowInputEventPin{}, fmt.Errorf("flow input event pin must be a string or mapping")
+	}
+	var out FlowInputEventPin
+	for i := 0; i+1 < len(node.Content); i += 2 {
+		key := strings.TrimSpace(node.Content[i].Value)
+		value := node.Content[i+1]
+		switch key {
+		case "":
+			continue
+		case "name":
+			if err := value.Decode(&out.Name); err != nil {
+				return FlowInputEventPin{}, fmt.Errorf("input event pin name: %w", err)
+			}
+		case "event":
+			if err := value.Decode(&out.Event); err != nil {
+				return FlowInputEventPin{}, fmt.Errorf("input event pin event: %w", err)
+			}
+		case "address":
+			var address FlowInputPinAddress
+			if err := value.Decode(&address); err != nil {
+				return FlowInputEventPin{}, fmt.Errorf("input event pin address: %w", err)
+			}
+			out.Address = &address
+		default:
+			return FlowInputEventPin{}, fmt.Errorf("UNDEFINED-FIELD: input event pin field %q not in platform spec", key)
+		}
+	}
+	out = out.normalized()
+	if out.PinName() == "" {
+		return FlowInputEventPin{}, fmt.Errorf("input event pin name is required")
+	}
+	return out, nil
+}
+
+func decodeFlowOutputPinEventNode(node *yaml.Node) (FlowOutputEventPin, error) {
+	if node == nil || node.Kind == 0 {
+		return FlowOutputEventPin{}, nil
+	}
+	if node.Kind == yaml.ScalarNode {
+		value := strings.TrimSpace(node.Value)
+		return FlowOutputEventPin{Name: value, Event: value}, nil
+	}
+	if node.Kind != yaml.MappingNode {
+		return FlowOutputEventPin{}, fmt.Errorf("flow output event pin must be a string or mapping")
+	}
+	var out FlowOutputEventPin
+	for i := 0; i+1 < len(node.Content); i += 2 {
+		key := strings.TrimSpace(node.Content[i].Value)
+		value := node.Content[i+1]
+		switch key {
+		case "":
+			continue
+		case "name":
+			if err := value.Decode(&out.Name); err != nil {
+				return FlowOutputEventPin{}, fmt.Errorf("output event pin name: %w", err)
+			}
+		case "event":
+			if err := value.Decode(&out.Event); err != nil {
+				return FlowOutputEventPin{}, fmt.Errorf("output event pin event: %w", err)
+			}
+		default:
+			return FlowOutputEventPin{}, fmt.Errorf("UNDEFINED-FIELD: output event pin field %q not in platform spec", key)
+		}
+	}
+	out = out.normalized()
+	if out.PinName() == "" {
+		return FlowOutputEventPin{}, fmt.Errorf("output event pin name is required")
+	}
+	return out, nil
+}
+
+func (a *FlowInputPinAddress) UnmarshalYAML(node *yaml.Node) error {
+	if a == nil {
+		return nil
+	}
+	if node == nil || node.Kind == 0 {
+		*a = FlowInputPinAddress{}
+		return nil
+	}
+	if node.Kind != yaml.MappingNode {
+		return fmt.Errorf("input event pin address must be a mapping")
+	}
+	var out FlowInputPinAddress
+	for i := 0; i+1 < len(node.Content); i += 2 {
+		key := strings.TrimSpace(node.Content[i].Value)
+		value := node.Content[i+1]
+		switch key {
+		case "":
+			continue
+		case "by":
+			if err := value.Decode(&out.By); err != nil {
+				return fmt.Errorf("address.by: %w", err)
+			}
+		case "source":
+			if err := value.Decode(&out.Source); err != nil {
+				return fmt.Errorf("address.source: %w", err)
+			}
+		case "target":
+			if err := value.Decode(&out.Target); err != nil {
+				return fmt.Errorf("address.target: %w", err)
+			}
+		case "cardinality":
+			if err := value.Decode(&out.Cardinality); err != nil {
+				return fmt.Errorf("address.cardinality: %w", err)
+			}
+		case "mode":
+			if err := value.Decode(&out.Mode); err != nil {
+				return fmt.Errorf("address.mode: %w", err)
+			}
+		default:
+			return fmt.Errorf("UNDEFINED-FIELD: input event pin address field %q not in platform spec", key)
+		}
+	}
+	*a = out.normalized()
+	return nil
 }
 
 func decodeFlowPinFieldNamesNode(node *yaml.Node) ([]string, error) {

--- a/internal/runtime/contracts/workflow_contract_yaml_test.go
+++ b/internal/runtime/contracts/workflow_contract_yaml_test.go
@@ -43,6 +43,14 @@ packages:
         child.policy: parent.policy.child
       credentials:
         child_token: parent_child_token
+connect:
+  - from: worker.work.completed
+    to: worker.work.requested
+    delivery: one
+    map:
+      work_id:
+        source: payload.work_id
+        target: entity.work_id
 `), &doc); err != nil {
 		t.Fatalf("yaml.Unmarshal: %v", err)
 	}
@@ -75,6 +83,15 @@ packages:
 	}
 	if got := doc.Packages[0].Bind.Inputs["child.requested"]; got != "parent.child_requested" {
 		t.Fatalf("package bind input = %q", got)
+	}
+	if len(doc.Connect) != 1 {
+		t.Fatalf("Connect len = %d, want 1", len(doc.Connect))
+	}
+	if got, want := doc.Connect[0].From, "worker.work.completed"; got != want {
+		t.Fatalf("Connect[0].From = %q, want %q", got, want)
+	}
+	if got, want := doc.Connect[0].Map["work_id"].Target, "entity.work_id"; got != want {
+		t.Fatalf("Connect[0].Map[work_id].Target = %q, want %q", got, want)
 	}
 }
 
@@ -116,6 +133,17 @@ packages:
 `,
 			wantErr: "UNDEFINED-FIELD",
 		},
+		{
+			name: "unknown connect field",
+			body: `
+name: invalid
+connect:
+  - from: producer.ready
+    to: consumer.ready
+    topic: unsupported
+`,
+			wantErr: "UNDEFINED-FIELD",
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -125,6 +153,74 @@ packages:
 				t.Fatalf("yaml.Unmarshal error = %v, want %q", err, tc.wantErr)
 			}
 		})
+	}
+}
+
+func TestFlowSchemaDocumentDecode_PreservesAddressedInputPins(t *testing.T) {
+	var doc FlowSchemaDocument
+	if err := yaml.Unmarshal([]byte(`
+name: addressed-pins
+pins:
+  inputs:
+    events:
+      - work.started
+      - name: deploy_completed
+        event: deploy.completed
+        address:
+          by: vertical_id
+          source: payload.vertical_id
+          target: entity.vertical_id
+          cardinality: one
+          mode: select_existing
+  outputs:
+    events:
+      - name: deploy_done
+        event: deploy.done
+`), &doc); err != nil {
+		t.Fatalf("yaml.Unmarshal: %v", err)
+	}
+	if got, want := strings.Join(doc.Pins.Inputs.Events, ","), "work.started,deploy.completed"; got != want {
+		t.Fatalf("input Events = %q, want %q", got, want)
+	}
+	if len(doc.Pins.Inputs.EventPins) != 2 {
+		t.Fatalf("input EventPins len = %d, want 2", len(doc.Pins.Inputs.EventPins))
+	}
+	addressed := doc.Pins.Inputs.EventPins[1]
+	if got, want := addressed.PinName(), "deploy_completed"; got != want {
+		t.Fatalf("addressed PinName = %q, want %q", got, want)
+	}
+	if got, want := addressed.EventType(), "deploy.completed"; got != want {
+		t.Fatalf("addressed EventType = %q, want %q", got, want)
+	}
+	if addressed.Address == nil {
+		t.Fatal("expected addressed input pin address")
+	}
+	if got, want := addressed.Address.Target, "entity.vertical_id"; got != want {
+		t.Fatalf("Address.Target = %q, want %q", got, want)
+	}
+	if got, want := strings.Join(doc.Pins.Outputs.Events, ","), "deploy.done"; got != want {
+		t.Fatalf("output Events = %q, want %q", got, want)
+	}
+	if got, want := doc.Pins.Outputs.EventPins[0].PinName(), "deploy_done"; got != want {
+		t.Fatalf("output PinName = %q, want %q", got, want)
+	}
+}
+
+func TestFlowSchemaDocumentDecode_RejectsUnsupportedAddressedPinFields(t *testing.T) {
+	var doc FlowSchemaDocument
+	err := yaml.Unmarshal([]byte(`
+name: invalid-pins
+pins:
+  inputs:
+    events:
+      - name: deploy_completed
+        event: deploy.completed
+        address:
+          by: vertical_id
+          unsupported: nope
+`), &doc)
+	if err == nil || !strings.Contains(err.Error(), "UNDEFINED-FIELD") {
+		t.Fatalf("yaml.Unmarshal error = %v, want UNDEFINED-FIELD", err)
 	}
 }
 
@@ -281,15 +377,15 @@ terminal_states: []
 pins:
   inputs:
     events:
-      - name: check.requested
-        required: false
+      - name: check_requested
+        event: check.requested
     reads:
       - field: entity.score
         type: number
   outputs:
     events:
-      - name: check.passed
-        required: false
+      - name: check_passed
+        event: check.passed
     writes:
       - field: entity.status
         type: string
@@ -302,8 +398,14 @@ pins:
 	if got := schema.Pins.Inputs.Events[0]; got != "check.requested" {
 		t.Fatalf("Inputs.Events[0] = %q", got)
 	}
+	if got := schema.Pins.Inputs.EventPins[0].PinName(); got != "check_requested" {
+		t.Fatalf("Inputs.EventPins[0].PinName() = %q", got)
+	}
 	if got := schema.Pins.Outputs.Events[0]; got != "check.passed" {
 		t.Fatalf("Outputs.Events[0] = %q", got)
+	}
+	if got := schema.Pins.Outputs.EventPins[0].PinName(); got != "check_passed" {
+		t.Fatalf("Outputs.EventPins[0].PinName() = %q", got)
 	}
 	if got := schema.Pins.Inputs.Reads[0]; got != "entity.score" {
 		t.Fatalf("Inputs.Reads[0] = %q", got)

--- a/internal/runtime/contracts/workflow_contract_yaml_wave1.go
+++ b/internal/runtime/contracts/workflow_contract_yaml_wave1.go
@@ -24,18 +24,19 @@ func (p *ProjectPackageDocument) UnmarshalYAML(node *yaml.Node) error {
 		return fmt.Errorf("RETIRED: package.yaml entity_schema is no longer supported; migrate to entities.yaml")
 	}
 	var aux struct {
-		Name            string              `yaml:"name"`
-		Version         string              `yaml:"version"`
-		PlatformVersion string              `yaml:"platform_version"`
-		Author          string              `yaml:"author"`
-		Description     string              `yaml:"description"`
-		Requires        FlowPackageRequires `yaml:"requires"`
-		Flows           []ProjectFlowRef    `yaml:"flows"`
-		Packages        []ProjectPackageRef `yaml:"packages"`
-		Children        []ProjectPackageRef `yaml:"children"`
-		Subpackages     []ProjectPackageRef `yaml:"subpackages"`
-		Handoffs        []ProjectHandoff    `yaml:"handoffs"`
-		EntitySchema    EntitySchema        `yaml:"entity_schema"`
+		Name            string               `yaml:"name"`
+		Version         string               `yaml:"version"`
+		PlatformVersion string               `yaml:"platform_version"`
+		Author          string               `yaml:"author"`
+		Description     string               `yaml:"description"`
+		Requires        FlowPackageRequires  `yaml:"requires"`
+		Flows           []ProjectFlowRef     `yaml:"flows"`
+		Packages        []ProjectPackageRef  `yaml:"packages"`
+		Children        []ProjectPackageRef  `yaml:"children"`
+		Subpackages     []ProjectPackageRef  `yaml:"subpackages"`
+		Connect         []FlowPackageConnect `yaml:"connect"`
+		Handoffs        []ProjectHandoff     `yaml:"handoffs"`
+		EntitySchema    EntitySchema         `yaml:"entity_schema"`
 	}
 	if err := node.Decode(&aux); err != nil {
 		return err
@@ -51,6 +52,7 @@ func (p *ProjectPackageDocument) UnmarshalYAML(node *yaml.Node) error {
 		Packages:        append([]ProjectPackageRef(nil), aux.Packages...),
 		Children:        append([]ProjectPackageRef(nil), aux.Children...),
 		Subpackages:     append([]ProjectPackageRef(nil), aux.Subpackages...),
+		Connect:         cloneFlowPackageConnects(aux.Connect),
 		Handoffs:        append([]ProjectHandoff(nil), aux.Handoffs...),
 		EntitySchema:    aux.EntitySchema,
 	}
@@ -162,6 +164,93 @@ func (b FlowPackageBind) normalized() FlowPackageBind {
 		Policy:      normalizeStringMap(b.Policy),
 		Credentials: normalizeStringMap(b.Credentials),
 	}
+}
+
+func (c *FlowPackageConnect) UnmarshalYAML(node *yaml.Node) error {
+	if c == nil {
+		return nil
+	}
+	if node == nil || node.Kind == 0 {
+		*c = FlowPackageConnect{}
+		return nil
+	}
+	if node.Kind != yaml.MappingNode {
+		return fmt.Errorf("connect entry must be a mapping")
+	}
+	var out FlowPackageConnect
+	for i := 0; i+1 < len(node.Content); i += 2 {
+		key := strings.TrimSpace(node.Content[i].Value)
+		value := node.Content[i+1]
+		switch key {
+		case "":
+			continue
+		case "from":
+			if err := value.Decode(&out.From); err != nil {
+				return fmt.Errorf("connect.from: %w", err)
+			}
+		case "to":
+			if err := value.Decode(&out.To); err != nil {
+				return fmt.Errorf("connect.to: %w", err)
+			}
+		case "adapter":
+			if err := value.Decode(&out.Adapter); err != nil {
+				return fmt.Errorf("connect.adapter: %w", err)
+			}
+		case "map":
+			if err := value.Decode(&out.Map); err != nil {
+				return fmt.Errorf("connect.map: %w", err)
+			}
+		case "delivery":
+			if err := value.Decode(&out.Delivery); err != nil {
+				return fmt.Errorf("connect.delivery: %w", err)
+			}
+		case "reply":
+			if err := value.Decode(&out.Reply); err != nil {
+				return fmt.Errorf("connect.reply: %w", err)
+			}
+		default:
+			return fmt.Errorf("UNDEFINED-FIELD: connect field %q not in platform spec", key)
+		}
+	}
+	*c = out.normalized()
+	return nil
+}
+
+func (m *FlowPackageConnectMap) UnmarshalYAML(node *yaml.Node) error {
+	if m == nil {
+		return nil
+	}
+	if node == nil || node.Kind == 0 {
+		*m = FlowPackageConnectMap{}
+		return nil
+	}
+	if node.Kind != yaml.MappingNode {
+		return fmt.Errorf("connect map entry must be a mapping")
+	}
+	var out FlowPackageConnectMap
+	for i := 0; i+1 < len(node.Content); i += 2 {
+		key := strings.TrimSpace(node.Content[i].Value)
+		value := node.Content[i+1]
+		switch key {
+		case "":
+			continue
+		case "source":
+			if err := value.Decode(&out.Source); err != nil {
+				return fmt.Errorf("connect map source: %w", err)
+			}
+		case "target":
+			if err := value.Decode(&out.Target); err != nil {
+				return fmt.Errorf("connect map target: %w", err)
+			}
+		default:
+			return fmt.Errorf("UNDEFINED-FIELD: connect map field %q not in platform spec", key)
+		}
+	}
+	*m = FlowPackageConnectMap{
+		Source: strings.TrimSpace(out.Source),
+		Target: strings.TrimSpace(out.Target),
+	}
+	return nil
 }
 
 func normalizeStringMap(in map[string]string) map[string]string {

--- a/internal/runtime/semanticview/bundle_source.go
+++ b/internal/runtime/semanticview/bundle_source.go
@@ -215,6 +215,27 @@ func (s bundleSource) FlowInputEvents(flowID string) []string {
 func (s bundleSource) FlowOutputEvents(flowID string) []string {
 	return s.bundle.FlowOutputEvents(flowID)
 }
+func (s bundleSource) FlowInputEventPins(flowID string) []runtimecontracts.FlowInputEventPin {
+	return s.bundle.FlowInputEventPins(flowID)
+}
+func (s bundleSource) FlowOutputEventPins(flowID string) []runtimecontracts.FlowOutputEventPin {
+	return s.bundle.FlowOutputEventPins(flowID)
+}
+func (s bundleSource) FlowInputEventPin(flowID, pinName string) (runtimecontracts.FlowInputEventPin, bool) {
+	return s.bundle.FlowInputEventPin(flowID, pinName)
+}
+func (s bundleSource) FlowOutputEventPin(flowID, pinName string) (runtimecontracts.FlowOutputEventPin, bool) {
+	return s.bundle.FlowOutputEventPin(flowID, pinName)
+}
+func (s bundleSource) CompositionConnects() []runtimecontracts.FlowPackageConnect {
+	return s.bundle.CompositionConnects()
+}
+func (s bundleSource) CompositionConnectsTo(flowID, pinName string) []runtimecontracts.FlowPackageConnect {
+	return s.bundle.CompositionConnectsTo(flowID, pinName)
+}
+func (s bundleSource) CompositionConnectsFrom(flowID, pinName string) []runtimecontracts.FlowPackageConnect {
+	return s.bundle.CompositionConnectsFrom(flowID, pinName)
+}
 func (s bundleSource) FlowWritePins(flowID string) []string { return s.bundle.FlowWritePins(flowID) }
 func (s bundleSource) WritePinOwners(pin string) []string   { return s.bundle.WritePinOwners(pin) }
 func (s bundleSource) FlowHasInputEvent(flowID, eventType string) bool {

--- a/internal/runtime/semanticview/composition_connect_test.go
+++ b/internal/runtime/semanticview/composition_connect_test.go
@@ -1,0 +1,130 @@
+package semanticview
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
+)
+
+func TestCompositionConnectFactsExposeTypedPinsAndParentConnect(t *testing.T) {
+	repoRoot, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd: %v", err)
+	}
+	repoRoot = filepath.Clean(filepath.Join(repoRoot, "..", "..", ".."))
+	root := writeCompositionConnectSemanticFixture(t)
+	bundle, err := runtimecontracts.LoadWorkflowContractBundleWithOverrides(repoRoot, root, runtimecontracts.DefaultPlatformSpecFile(repoRoot))
+	if err != nil {
+		t.Fatalf("LoadWorkflowContractBundleWithOverrides: %v", err)
+	}
+	source := Wrap(bundle)
+
+	inputPins := source.FlowInputEventPins("consumer")
+	if len(inputPins) != 1 {
+		t.Fatalf("FlowInputEventPins = %#v, want one", inputPins)
+	}
+	if got, want := inputPins[0].PinName(), "deploy_completed"; got != want {
+		t.Fatalf("input pin name = %q, want %q", got, want)
+	}
+	if got, want := inputPins[0].EventType(), "deploy.completed"; got != want {
+		t.Fatalf("input pin event = %q, want %q", got, want)
+	}
+	if inputPins[0].Address == nil || inputPins[0].Address.By != "vertical_id" {
+		t.Fatalf("input pin address = %#v, want vertical_id", inputPins[0].Address)
+	}
+
+	outputPins := source.FlowOutputEventPins("producer")
+	if len(outputPins) != 1 {
+		t.Fatalf("FlowOutputEventPins = %#v, want one", outputPins)
+	}
+	if got, want := outputPins[0].PinName(), "deploy_done"; got != want {
+		t.Fatalf("output pin name = %q, want %q", got, want)
+	}
+
+	connects := source.CompositionConnects()
+	if len(connects) != 1 {
+		t.Fatalf("CompositionConnects = %#v, want one", connects)
+	}
+	if got, want := connects[0].From, "producer.deploy_done"; got != want {
+		t.Fatalf("connect from = %q, want %q", got, want)
+	}
+	if got, want := connects[0].To, "consumer.deploy_completed"; got != want {
+		t.Fatalf("connect to = %q, want %q", got, want)
+	}
+	if got, want := source.CompositionConnectsFrom("producer", "deploy_done"), connects; len(got) != len(want) || got[0].From != want[0].From {
+		t.Fatalf("CompositionConnectsFrom = %#v, want %#v", got, want)
+	}
+	if got, want := source.CompositionConnectsTo("consumer", "deploy_completed"), connects; len(got) != len(want) || got[0].To != want[0].To {
+		t.Fatalf("CompositionConnectsTo = %#v, want %#v", got, want)
+	}
+}
+
+func writeCompositionConnectSemanticFixture(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	writeSemanticviewFixtureFile(t, filepath.Join(root, "package.yaml"), `
+name: composition-connect-semantic
+version: "1.0.0"
+platform_version: ">=1.6.0"
+flows:
+  - id: producer
+    flow: producer
+    mode: static
+  - id: consumer
+    flow: consumer
+    mode: static
+connect:
+  - from: producer.deploy_done
+    to: consumer.deploy_completed
+    delivery: one
+    map:
+      vertical_id:
+        source: payload.vertical_id
+        target: entity.vertical_id
+`)
+	writeSemanticviewFixtureFile(t, filepath.Join(root, "schema.yaml"), "name: composition-connect-semantic\n")
+	writeSemanticviewFixtureFile(t, filepath.Join(root, "policy.yaml"), "{}\n")
+	writeSemanticviewFixtureFile(t, filepath.Join(root, "tools.yaml"), "{}\n")
+	writeSemanticviewFixtureFile(t, filepath.Join(root, "agents.yaml"), "{}\n")
+	writeSemanticviewFixtureFile(t, filepath.Join(root, "events.yaml"), "{}\n")
+	writeSemanticviewFixtureFile(t, filepath.Join(root, "nodes.yaml"), "{}\n")
+	writeCompositionConnectFlow(t, root, "producer", `
+pins:
+  outputs:
+    events:
+      - name: deploy_done
+        event: deploy.done
+`, "deploy.done: {}\n", "{}\n")
+	writeCompositionConnectFlow(t, root, "consumer", `
+pins:
+  inputs:
+    events:
+      - name: deploy_completed
+        event: deploy.completed
+        address:
+          by: vertical_id
+          source: payload.vertical_id
+          target: entity.vertical_id
+          cardinality: one
+`, "deploy.completed: {}\n", `
+deployment:
+  vertical_id:
+    type: string
+`)
+	return root
+}
+
+func writeCompositionConnectFlow(t *testing.T, root, flowID, schemaTail, events, entities string) {
+	t.Helper()
+	writeSemanticviewFixtureFile(t, filepath.Join(root, "flows", flowID, "schema.yaml"), `
+name: `+flowID+`
+mode: static
+`+schemaTail)
+	writeSemanticviewFixtureFile(t, filepath.Join(root, "flows", flowID, "policy.yaml"), "{}\n")
+	writeSemanticviewFixtureFile(t, filepath.Join(root, "flows", flowID, "agents.yaml"), "{}\n")
+	writeSemanticviewFixtureFile(t, filepath.Join(root, "flows", flowID, "nodes.yaml"), "{}\n")
+	writeSemanticviewFixtureFile(t, filepath.Join(root, "flows", flowID, "events.yaml"), events)
+	writeSemanticviewFixtureFile(t, filepath.Join(root, "flows", flowID, "entities.yaml"), entities)
+}

--- a/internal/runtime/semanticview/source.go
+++ b/internal/runtime/semanticview/source.go
@@ -31,6 +31,13 @@ type Source interface {
 	FlowPath(flowID string) string
 	FlowInputEvents(flowID string) []string
 	FlowOutputEvents(flowID string) []string
+	FlowInputEventPins(flowID string) []runtimecontracts.FlowInputEventPin
+	FlowOutputEventPins(flowID string) []runtimecontracts.FlowOutputEventPin
+	FlowInputEventPin(flowID, pinName string) (runtimecontracts.FlowInputEventPin, bool)
+	FlowOutputEventPin(flowID, pinName string) (runtimecontracts.FlowOutputEventPin, bool)
+	CompositionConnects() []runtimecontracts.FlowPackageConnect
+	CompositionConnectsTo(flowID, pinName string) []runtimecontracts.FlowPackageConnect
+	CompositionConnectsFrom(flowID, pinName string) []runtimecontracts.FlowPackageConnect
 	FlowWritePins(flowID string) []string
 	WritePinOwners(pin string) []string
 	FlowHasInputEvent(flowID, eventType string) bool

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -8377,6 +8377,53 @@ static_analyzer:
       - target_sender_empty_source_runtime
     rule: Emit hard invalidity for every statically detectable missing or malformed accepted pin route source. Runtime failure
       reasons cover the cases boot verification cannot prove; no case may silently fall back to broadcast.
+  slice_3a1_composition_connect_validation:
+    id: composition_connect_validation
+    domain: semantic_validity
+    authority: hard_invalidity
+    severity: error
+    canonical_owner: internal/runtime/bootverify
+    supported_surface: cmd/swarm verify
+    spec_basis:
+    - flow_model.flow_package.composition_routing
+    - flow_model.flow_package.import_boundary.pin_alias_delivery
+    - engine.cross_flow_routing
+    scope:
+      description: Validate parser/model/semantic-view consumption of parent package.yaml connect entries and receiver
+        addressed input pins before runtime route-plan lowering. This check proves authored composition facts are present,
+        typed, and lowerable as semantic route facts, but it does not execute EventBus/RouteTable delivery.
+      applies_to:
+      - parent package.yaml connect entries
+      - schema.yaml pins.inputs.events addressed input pin objects
+      - schema.yaml pins.outputs.events structured output pin objects
+      - import-boundary requires/bind aliases used as lower-level name adaptation
+      excludes:
+      - runtime RoutePlan artifact lowering
+      - EventBus or RouteTable publish execution
+      - persisted delivery rows, receipts, readback, or replay
+      - agent/node parity for connected output pins
+      - retiring producer emit.target or broadcast escape hatches
+    validation_requirements:
+      producer_flow_exists: connect.from flow id must exist in the loaded flow registry.
+      producer_output_pin_exists: connect.from pin must exist in the producer schema output event pins.
+      receiver_flow_exists: connect.to flow id must exist in the loaded flow registry.
+      receiver_input_pin_exists: connect.to pin must exist in the receiver schema input event pins.
+      event_alias_or_adapter_valid: Differing producer and receiver event identities require an explicit adapter or an
+        import-boundary alias from requires/bind on either the producer output side or receiver input side; alias/bind
+        adapts names only and does not own topology.
+      output_carries_address_key: The producer output event payload or explicit connect.map source must carry every receiver
+        address key needed by the input pin.
+      receiver_address_rule_present: Template or instance-addressed receivers must declare an addressed input pin unless
+        delivery is an explicit broadcast.
+      key_types_compatible: Payload/config/entity/instance source and target key types must be compatible before lowering.
+      delivery_topology_valid: Delivery must be one, many, broadcast, or reply and must match addressed input cardinality;
+        fan-out delivery such as many or broadcast is invalid for a singular addressed input pin.
+      reply_lineage_usable: reply delivery must declare usable reply lineage; missing lineage fails closed.
+      event_topology_roles_consume_connect: Verify-time producer/consumer and dead-event schema checks must treat valid
+        connect output/input facts as authored event roles so parent topology does not require runtime reconstruction to
+        silence missing producer, missing consumer, or dead-schema diagnostics.
+      no_runtime_reconstruction: Accepted verify-time facts must not require EventBus/RouteTable or workflow-node materialization
+        to reconstruct missing connect topology.
   slice_3b_select_entity_pin_coexistence:
     id: select_entity_pin_coexistence
     domain: semantic_drift

--- a/tests/tier1-primitives/test-guard-pass/schema.yaml
+++ b/tests/tier1-primitives/test-guard-pass/schema.yaml
@@ -8,10 +8,8 @@ pins:
   inputs:
     events:
       - name: check.requested
-        required: false
     reads: []
   outputs:
     events:
       - name: check.passed
-        required: false
     writes: []

--- a/tests/tier11-flow-composition/test-gates-in-child-flow/flows/child/schema.yaml
+++ b/tests/tier11-flow-composition/test-gates-in-child-flow/flows/child/schema.yaml
@@ -8,11 +8,9 @@ pins:
   inputs:
     events:
       - name: validate.start
-        required: false
     reads: []
   outputs:
     events:
       - name: validation.done
-        required: false
     writes: []
 name: child

--- a/tests/tier11-flow-composition/test-gates-in-child-flow/schema.yaml
+++ b/tests/tier11-flow-composition/test-gates-in-child-flow/schema.yaml
@@ -8,10 +8,8 @@ pins:
   inputs:
     events:
       - name: validate.requested
-        required: false
     reads: []
   outputs:
     events:
       - name: validate.passed
-        required: false
     writes: []


### PR DESCRIPTION
## Summary

Closes #1471.
Part of #1466.

Implements the approved first-slice boundary for parent `package.yaml connect` and addressed input-pin source authority:

- parses and preserves typed `connect:` entries plus structured input/output event pins
- exposes those facts through the canonical workflow semantic view
- adds `composition_connect_validation` to `swarm verify` / bootverify
- lets input-pin wiring, pin target resolution, cross-flow ambiguity, event producer/consumer checks, and dead-event schema checks consume validated parent connect facts instead of treating producer-local targets/broadcasts as the topology owner
- updates `platform-spec.yaml` with the shipped verify-time authority and explicit downstream exclusions

## Governing refs / context

Exact spec authority:

- `platform-spec.yaml#flow_model.flow_package.composition_routing`
- `platform-spec.yaml#flow_model.flow_package.import_boundary.pin_alias_delivery`
- `platform-spec.yaml#engine.cross_flow_routing`
- `platform-spec.yaml#static_analyzer.slice_3a1_composition_connect_validation`

Gate context:

- #1471 pre-audit: https://github.com/division-sh/swarm/issues/1471#issuecomment-4794208204
- #1471 gate approval: https://github.com/division-sh/swarm/issues/1471#issuecomment-4794304013

## Semantic migration

New canonical owner for this slice:

- source authority: parent `package.yaml connect` + flow schema structured event pins, as specified in `platform-spec.yaml`
- code owner: `internal/runtime/contracts` typed model/parser, `internal/runtime/semanticview` accessors, and `internal/runtime/bootverify` `composition_connect_validation`

Old producer / reader / writer paths now invalid or non-authoritative:

- same-name output-pin autowiring is no longer a sufficient topology owner when parent `connect` is present
- producer-local `emit.target` / implicit broadcast remain runtime seams but are not authoritative for this verify-time topology slice
- raw string-only pin views remain supported only as scalar pin compatibility, not as addressed connect metadata
- unsupported structured pin fields such as `required:` now fail closed; affected test fixtures were migrated

Production paths checked for surviving old behavior:

- parser/model: `ProjectPackageDocument.Connect`, structured input/output event pins, unknown-field rejection
- semantic view: typed pin and composition connect accessors
- bootverify: composition connect validation, input pin wiring, pin target resolution, cross-flow ambiguity, event topology producer/consumer checks, dead-event schema checks, import-boundary alias adaptation, address/key type validation

Migration completeness:

- complete for the approved parser/model/semantic-view/bootverify first slice
- downstream runtime RoutePlan artifact lowering, EventBus/RouteTable delivery, workflow-node materialization, agent/node parity, and producer target/broadcast retirement remain split to the approved downstream children and are intentionally not implemented here

## Validation

- `go test ./internal/runtime/bootverify -run 'CompositionConnect|EventProducer|EventConsumer|DeadEvent' -count=1`
- temporary `go run ./cmd/swarm verify --contracts <tmp-composition-connect-fixture> --platform-spec platform-spec.yaml --quiet` returned `ok`
- `go test ./internal/runtime/contracts ./internal/runtime/semanticview ./internal/runtime/bootverify ./internal/apispec -run 'CompositionConnect|AddressedInput|ProjectPackageDocumentDecode|FlowPackage|FlowInput|PinTarget|InputPin|ImportBoundary|PlatformSpec' -count=1`
- `go test ./internal/runtime/contracts ./internal/runtime/semanticview ./internal/runtime/bootverify ./internal/apispec -count=1`
- `go test ./internal/runtime/bus ./internal/runtime/cataloge2e ./internal/runtime/pipeline -count=1`
- `go test ./...`