### PR TITLE
[agent-a][issue #1472] Lower connect route plans

### DIFF
--- a/internal/runtime/core/pinrouting/connect_route_plan.go
+++ b/internal/runtime/core/pinrouting/connect_route_plan.go
@@ -1,0 +1,469 @@
+package pinrouting
+
+import (
+	"sort"
+	"strings"
+
+	"github.com/division-sh/swarm/internal/events"
+	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
+	"github.com/division-sh/swarm/internal/runtime/core/eventidentity"
+	runtimeflowidentity "github.com/division-sh/swarm/internal/runtime/core/flowidentity"
+	"github.com/division-sh/swarm/internal/runtime/semanticview"
+)
+
+type ConnectRoutePlanDelivery string
+
+const (
+	ConnectDeliveryOne       ConnectRoutePlanDelivery = "one"
+	ConnectDeliveryMany      ConnectRoutePlanDelivery = "many"
+	ConnectDeliveryBroadcast ConnectRoutePlanDelivery = "broadcast"
+	ConnectDeliveryReply     ConnectRoutePlanDelivery = "reply"
+)
+
+type ConnectRoutePlanTargetKind string
+
+const (
+	ConnectTargetKindTarget    ConnectRoutePlanTargetKind = "target"
+	ConnectTargetKindTargetSet ConnectRoutePlanTargetKind = "target_set"
+	ConnectTargetKindReply     ConnectRoutePlanTargetKind = "reply"
+)
+
+type ConnectRoutePlanFailure string
+
+const (
+	ConnectFailureSourceMissing              ConnectRoutePlanFailure = "source_missing"
+	ConnectFailurePinRefInvalid              ConnectRoutePlanFailure = "connect_pin_ref_invalid"
+	ConnectFailureProducerFlowMissing        ConnectRoutePlanFailure = "producer_flow_missing"
+	ConnectFailureProducerOutputPinMissing   ConnectRoutePlanFailure = "producer_output_pin_missing"
+	ConnectFailureReceiverFlowMissing        ConnectRoutePlanFailure = "receiver_flow_missing"
+	ConnectFailureReceiverInputPinMissing    ConnectRoutePlanFailure = "receiver_input_pin_missing"
+	ConnectFailureReceiverAddressRuleMissing ConnectRoutePlanFailure = "receiver_address_rule_missing"
+	ConnectFailureDeliveryTopologyInvalid    ConnectRoutePlanFailure = "delivery_topology_invalid"
+	ConnectFailureReplyLineageMissing        ConnectRoutePlanFailure = "reply_lineage_missing"
+	ConnectFailureAddressValueMissing        ConnectRoutePlanFailure = "route_plan_address_value_missing"
+	ConnectFailureTargetUnsupported          ConnectRoutePlanFailure = "route_plan_target_unsupported"
+	ConnectFailureTargetUnresolved           ConnectRoutePlanFailure = "route_plan_target_unresolved"
+	ConnectFailureTargetAmbiguous            ConnectRoutePlanFailure = "route_plan_target_ambiguous"
+)
+
+type ConnectRoutePlanEndpoint struct {
+	FlowID        string
+	FlowPath      string
+	Mode          string
+	Pin           string
+	Event         string
+	ResolvedEvent string
+}
+
+type ConnectRoutePlanAddress struct {
+	By          string
+	Source      string
+	Target      string
+	Cardinality string
+	Mode        string
+}
+
+type ConnectRoutePlanMapEntry struct {
+	Key    string
+	Source string
+	Target string
+}
+
+type ConnectRoutePlan struct {
+	PackageKey                string
+	Source                    ConnectRoutePlanEndpoint
+	Receiver                  ConnectRoutePlanEndpoint
+	Adapter                   string
+	Delivery                  ConnectRoutePlanDelivery
+	TargetKind                ConnectRoutePlanTargetKind
+	Address                   *ConnectRoutePlanAddress
+	Map                       []ConnectRoutePlanMapEntry
+	Reply                     map[string]string
+	Target                    events.RouteIdentity
+	TargetSet                 []events.RouteIdentity
+	RequiresRuntimeResolution bool
+}
+
+type ConnectRoutePlanIssue struct {
+	Connect runtimecontracts.FlowPackageConnect
+	Failure ConnectRoutePlanFailure
+	Detail  string
+}
+
+type ConnectRoutePlanMaterializationInput struct {
+	MatchValues map[string]string
+	Descriptors []Descriptor
+}
+
+type ConnectRoutePlanMaterialization struct {
+	Target    events.RouteIdentity
+	TargetSet []events.RouteIdentity
+	Failure   ConnectRoutePlanFailure
+}
+
+func LowerCompositionConnectRoutePlans(source semanticview.Source) ([]ConnectRoutePlan, []ConnectRoutePlanIssue) {
+	if source == nil {
+		return nil, []ConnectRoutePlanIssue{{Failure: ConnectFailureSourceMissing, Detail: "semantic source is required"}}
+	}
+	plans := make([]ConnectRoutePlan, 0, len(source.CompositionConnects()))
+	var issues []ConnectRoutePlanIssue
+	for _, connect := range source.CompositionConnects() {
+		plan, issue := LowerCompositionConnectRoutePlan(source, connect)
+		if issue.Failure != "" {
+			issues = append(issues, issue)
+			continue
+		}
+		plans = append(plans, plan)
+	}
+	sort.SliceStable(plans, func(i, j int) bool {
+		if plans[i].Source.FlowID != plans[j].Source.FlowID {
+			return plans[i].Source.FlowID < plans[j].Source.FlowID
+		}
+		if plans[i].Source.Pin != plans[j].Source.Pin {
+			return plans[i].Source.Pin < plans[j].Source.Pin
+		}
+		if plans[i].Receiver.FlowID != plans[j].Receiver.FlowID {
+			return plans[i].Receiver.FlowID < plans[j].Receiver.FlowID
+		}
+		return plans[i].Receiver.Pin < plans[j].Receiver.Pin
+	})
+	return plans, issues
+}
+
+func LowerCompositionConnectRoutePlan(source semanticview.Source, connect runtimecontracts.FlowPackageConnect) (ConnectRoutePlan, ConnectRoutePlanIssue) {
+	if source == nil {
+		return ConnectRoutePlan{}, ConnectRoutePlanIssue{Connect: connect, Failure: ConnectFailureSourceMissing, Detail: "semantic source is required"}
+	}
+	from, err := connect.FromRef()
+	if err != nil {
+		return ConnectRoutePlan{}, ConnectRoutePlanIssue{Connect: connect, Failure: ConnectFailurePinRefInvalid, Detail: err.Error()}
+	}
+	to, err := connect.ToRef()
+	if err != nil {
+		return ConnectRoutePlan{}, ConnectRoutePlanIssue{Connect: connect, Failure: ConnectFailurePinRefInvalid, Detail: err.Error()}
+	}
+	sourceScope, ok := source.FlowScopeByID(from.FlowID)
+	if !ok {
+		return ConnectRoutePlan{}, ConnectRoutePlanIssue{Connect: connect, Failure: ConnectFailureProducerFlowMissing, Detail: from.FlowID}
+	}
+	receiverScope, ok := source.FlowScopeByID(to.FlowID)
+	if !ok {
+		return ConnectRoutePlan{}, ConnectRoutePlanIssue{Connect: connect, Failure: ConnectFailureReceiverFlowMissing, Detail: to.FlowID}
+	}
+	outputPin, ok := source.FlowOutputEventPin(from.FlowID, from.Pin)
+	if !ok {
+		return ConnectRoutePlan{}, ConnectRoutePlanIssue{Connect: connect, Failure: ConnectFailureProducerOutputPinMissing, Detail: connect.From}
+	}
+	inputPin, ok := source.FlowInputEventPin(to.FlowID, to.Pin)
+	if !ok {
+		return ConnectRoutePlan{}, ConnectRoutePlanIssue{Connect: connect, Failure: ConnectFailureReceiverInputPinMissing, Detail: connect.To}
+	}
+	delivery, failure := connectDelivery(connect, inputPin)
+	if failure != "" {
+		return ConnectRoutePlan{}, ConnectRoutePlanIssue{Connect: connect, Failure: failure, Detail: strings.TrimSpace(connect.Delivery)}
+	}
+	address := connectAddress(connect, inputPin)
+	if receiverRequiresRuntimeResolution(receiverScope) && address == nil && delivery != ConnectDeliveryBroadcast {
+		return ConnectRoutePlan{}, ConnectRoutePlanIssue{Connect: connect, Failure: ConnectFailureReceiverAddressRuleMissing, Detail: to.FlowID}
+	}
+	targetKind := connectTargetKind(delivery)
+	plan := ConnectRoutePlan{
+		PackageKey: strings.TrimSpace(connect.PackageKey),
+		Source: ConnectRoutePlanEndpoint{
+			FlowID:        strings.TrimSpace(from.FlowID),
+			FlowPath:      strings.Trim(strings.TrimSpace(sourceScope.Path), "/"),
+			Mode:          strings.TrimSpace(sourceScope.Mode),
+			Pin:           strings.TrimSpace(from.Pin),
+			Event:         eventidentity.Normalize(outputPin.EventType()),
+			ResolvedEvent: eventidentity.Normalize(source.ResolveFlowEventReference(from.FlowID, outputPin.EventType())),
+		},
+		Receiver: ConnectRoutePlanEndpoint{
+			FlowID:        strings.TrimSpace(to.FlowID),
+			FlowPath:      strings.Trim(strings.TrimSpace(receiverScope.Path), "/"),
+			Mode:          strings.TrimSpace(receiverScope.Mode),
+			Pin:           strings.TrimSpace(to.Pin),
+			Event:         eventidentity.Normalize(inputPin.EventType()),
+			ResolvedEvent: eventidentity.Normalize(source.ResolveFlowEventReference(to.FlowID, inputPin.EventType())),
+		},
+		Adapter:    strings.TrimSpace(connect.Adapter),
+		Delivery:   delivery,
+		TargetKind: targetKind,
+		Address:    address,
+		Map:        connectMapEntries(connect.Map),
+		Reply:      cloneStringMap(connect.Reply),
+	}
+	if !receiverRequiresRuntimeResolution(receiverScope) {
+		route := staticConnectRoute(source, to.FlowID)
+		if !route.Empty() {
+			switch targetKind {
+			case ConnectTargetKindTarget, ConnectTargetKindReply:
+				plan.Target = route
+			case ConnectTargetKindTargetSet:
+				plan.TargetSet = []events.RouteIdentity{route}
+			}
+		}
+		return plan, ConnectRoutePlanIssue{}
+	}
+	plan.RequiresRuntimeResolution = true
+	return plan, ConnectRoutePlanIssue{}
+}
+
+func MaterializeConnectRoutePlan(plan ConnectRoutePlan, input ConnectRoutePlanMaterializationInput) ConnectRoutePlanMaterialization {
+	if !plan.Target.Empty() {
+		return ConnectRoutePlanMaterialization{Target: plan.Target}
+	}
+	if len(plan.TargetSet) > 0 {
+		return ConnectRoutePlanMaterialization{TargetSet: append([]events.RouteIdentity{}, plan.TargetSet...)}
+	}
+	if plan.Address == nil {
+		return ConnectRoutePlanMaterialization{Failure: ConnectFailureReceiverAddressRuleMissing}
+	}
+	value := connectAddressValue(plan, input.MatchValues)
+	if value == "" {
+		return ConnectRoutePlanMaterialization{Failure: ConnectFailureAddressValueMissing}
+	}
+	targetExpr := strings.TrimSpace(plan.Address.Target)
+	if targetExpr == "" {
+		return ConnectRoutePlanMaterialization{Failure: ConnectFailureTargetUnsupported}
+	}
+	routes, supported := materializeConnectRoutes(plan, targetExpr, value, input.Descriptors)
+	if !supported {
+		return ConnectRoutePlanMaterialization{Failure: ConnectFailureTargetUnsupported}
+	}
+	routes = uniqueRoutes(routes)
+	if len(routes) == 0 {
+		return ConnectRoutePlanMaterialization{Failure: ConnectFailureTargetUnresolved}
+	}
+	switch plan.TargetKind {
+	case ConnectTargetKindTarget, ConnectTargetKindReply:
+		if len(routes) > 1 {
+			return ConnectRoutePlanMaterialization{Failure: ConnectFailureTargetAmbiguous}
+		}
+		return ConnectRoutePlanMaterialization{Target: routes[0]}
+	case ConnectTargetKindTargetSet:
+		return ConnectRoutePlanMaterialization{TargetSet: routes}
+	default:
+		return ConnectRoutePlanMaterialization{Failure: ConnectFailureDeliveryTopologyInvalid}
+	}
+}
+
+func connectDelivery(connect runtimecontracts.FlowPackageConnect, inputPin runtimecontracts.FlowInputEventPin) (ConnectRoutePlanDelivery, ConnectRoutePlanFailure) {
+	delivery := strings.TrimSpace(connect.Delivery)
+	cardinality := ""
+	if inputPin.Address != nil {
+		cardinality = strings.TrimSpace(inputPin.Address.Cardinality)
+	}
+	if delivery == "" {
+		switch cardinality {
+		case "one", "many":
+			delivery = cardinality
+		default:
+			delivery = string(ConnectDeliveryOne)
+		}
+	}
+	switch ConnectRoutePlanDelivery(delivery) {
+	case ConnectDeliveryOne:
+		if cardinality == "many" {
+			return "", ConnectFailureDeliveryTopologyInvalid
+		}
+		return ConnectDeliveryOne, ""
+	case ConnectDeliveryMany:
+		if cardinality == "one" {
+			return "", ConnectFailureDeliveryTopologyInvalid
+		}
+		return ConnectDeliveryMany, ""
+	case ConnectDeliveryBroadcast:
+		if cardinality == "one" {
+			return "", ConnectFailureDeliveryTopologyInvalid
+		}
+		return ConnectDeliveryBroadcast, ""
+	case ConnectDeliveryReply:
+		if len(connect.Reply) == 0 {
+			return "", ConnectFailureReplyLineageMissing
+		}
+		return ConnectDeliveryReply, ""
+	default:
+		return "", ConnectFailureDeliveryTopologyInvalid
+	}
+}
+
+func connectAddress(connect runtimecontracts.FlowPackageConnect, inputPin runtimecontracts.FlowInputEventPin) *ConnectRoutePlanAddress {
+	if inputPin.Address == nil {
+		return nil
+	}
+	address := inputPin.Address
+	out := ConnectRoutePlanAddress{
+		By:          strings.TrimSpace(address.By),
+		Source:      strings.TrimSpace(address.Source),
+		Target:      strings.TrimSpace(address.Target),
+		Cardinality: strings.TrimSpace(address.Cardinality),
+		Mode:        strings.TrimSpace(address.Mode),
+	}
+	if mapped, ok := connect.Map[out.By]; ok {
+		if source := strings.TrimSpace(mapped.Source); source != "" {
+			out.Source = source
+		}
+		if target := strings.TrimSpace(mapped.Target); target != "" {
+			out.Target = target
+		}
+	}
+	return &out
+}
+
+func connectMapEntries(in map[string]runtimecontracts.FlowPackageConnectMap) []ConnectRoutePlanMapEntry {
+	if len(in) == 0 {
+		return nil
+	}
+	keys := make([]string, 0, len(in))
+	for key := range in {
+		key = strings.TrimSpace(key)
+		if key != "" {
+			keys = append(keys, key)
+		}
+	}
+	sort.Strings(keys)
+	out := make([]ConnectRoutePlanMapEntry, 0, len(keys))
+	for _, key := range keys {
+		entry := in[key]
+		out = append(out, ConnectRoutePlanMapEntry{
+			Key:    key,
+			Source: strings.TrimSpace(entry.Source),
+			Target: strings.TrimSpace(entry.Target),
+		})
+	}
+	return out
+}
+
+func connectTargetKind(delivery ConnectRoutePlanDelivery) ConnectRoutePlanTargetKind {
+	switch delivery {
+	case ConnectDeliveryMany, ConnectDeliveryBroadcast:
+		return ConnectTargetKindTargetSet
+	case ConnectDeliveryReply:
+		return ConnectTargetKindReply
+	default:
+		return ConnectTargetKindTarget
+	}
+}
+
+func receiverRequiresRuntimeResolution(scope semanticview.FlowScope) bool {
+	switch strings.TrimSpace(scope.Mode) {
+	case "template", "dynamic":
+		return true
+	default:
+		return false
+	}
+}
+
+func staticConnectRoute(source semanticview.Source, flowID string) events.RouteIdentity {
+	flowInstance := strings.Trim(strings.TrimSpace(runtimeflowidentity.ScopeKey(source, flowID)), "/")
+	if flowInstance == "" {
+		return events.RouteIdentity{}
+	}
+	return events.RouteIdentity{
+		FlowID:       strings.TrimSpace(flowID),
+		FlowInstance: flowInstance,
+		EntityID:     runtimeflowidentity.EntityID(flowInstance),
+	}.Normalized()
+}
+
+func connectAddressValue(plan ConnectRoutePlan, values map[string]string) string {
+	if len(values) == 0 || plan.Address == nil {
+		return ""
+	}
+	keys := []string{
+		plan.Address.By,
+		plan.Address.Source,
+		expressionLeaf(plan.Address.Source),
+	}
+	for _, key := range keys {
+		key = strings.TrimSpace(key)
+		if key == "" {
+			continue
+		}
+		if value := strings.TrimSpace(values[key]); value != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func materializeConnectRoutes(plan ConnectRoutePlan, targetExpr, value string, descriptors []Descriptor) ([]events.RouteIdentity, bool) {
+	if !addressTargetSupported(targetExpr) {
+		return nil, false
+	}
+	var routes []events.RouteIdentity
+	for _, descriptor := range descriptors {
+		route := descriptorRoute(nil, plan.Receiver.FlowID, descriptor)
+		if route.Empty() {
+			continue
+		}
+		if route.FlowID != "" && plan.Receiver.FlowID != "" && route.FlowID != plan.Receiver.FlowID {
+			continue
+		}
+		matches := connectDescriptorMatches(targetExpr, value, descriptor, route)
+		if matches {
+			routes = append(routes, route)
+		}
+	}
+	return routes, true
+}
+
+func connectDescriptorMatches(targetExpr, value string, descriptor Descriptor, route events.RouteIdentity) bool {
+	target := normalizeAddressTarget(targetExpr)
+	value = strings.Trim(strings.TrimSpace(value), "/")
+	switch target {
+	case "entity_id":
+		return strings.TrimSpace(descriptor.EntityID) == value || route.EntityID == value
+	case "flow_instance":
+		return strings.Trim(strings.TrimSpace(descriptor.FlowInstance), "/") == value || route.FlowInstance == value
+	case "instance_id":
+		return strings.TrimSpace(descriptor.ID) == value || runtimeflowidentity.LogicalInstanceID(route.FlowInstance) == value
+	default:
+		return false
+	}
+}
+
+func addressTargetSupported(expr string) bool {
+	switch normalizeAddressTarget(expr) {
+	case "entity_id", "flow_instance", "instance_id":
+		return true
+	default:
+		return false
+	}
+}
+
+func normalizeAddressTarget(expr string) string {
+	expr = strings.TrimSpace(expr)
+	for _, prefix := range []string{"entity.", "instance.", "event.target.", "target."} {
+		if strings.HasPrefix(expr, prefix) {
+			return strings.TrimSpace(strings.TrimPrefix(expr, prefix))
+		}
+	}
+	return expr
+}
+
+func expressionLeaf(expr string) string {
+	expr = strings.TrimSpace(expr)
+	if idx := strings.LastIndex(expr, "."); idx >= 0 && idx < len(expr)-1 {
+		return strings.TrimSpace(expr[idx+1:])
+	}
+	return expr
+}
+
+func cloneStringMap(in map[string]string) map[string]string {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(in))
+	for key, value := range in {
+		key = strings.TrimSpace(key)
+		if key == "" {
+			continue
+		}
+		out[key] = strings.TrimSpace(value)
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}

--- a/internal/runtime/core/pinrouting/connect_route_plan.go
+++ b/internal/runtime/core/pinrouting/connect_route_plan.go
@@ -215,6 +215,9 @@ func MaterializeConnectRoutePlan(plan ConnectRoutePlan, input ConnectRoutePlanMa
 	if len(plan.TargetSet) > 0 {
 		return ConnectRoutePlanMaterialization{TargetSet: append([]events.RouteIdentity{}, plan.TargetSet...)}
 	}
+	if plan.TargetKind == ConnectTargetKindTargetSet && plan.Delivery == ConnectDeliveryBroadcast && plan.Address == nil {
+		return materializeBroadcastConnectRoutePlan(plan, input.Descriptors)
+	}
 	if plan.Address == nil {
 		return ConnectRoutePlanMaterialization{Failure: ConnectFailureReceiverAddressRuleMissing}
 	}
@@ -245,6 +248,22 @@ func MaterializeConnectRoutePlan(plan ConnectRoutePlan, input ConnectRoutePlanMa
 	default:
 		return ConnectRoutePlanMaterialization{Failure: ConnectFailureDeliveryTopologyInvalid}
 	}
+}
+
+func materializeBroadcastConnectRoutePlan(plan ConnectRoutePlan, descriptors []Descriptor) ConnectRoutePlanMaterialization {
+	routes := make([]events.RouteIdentity, 0, len(descriptors))
+	for _, descriptor := range descriptors {
+		route := descriptorRouteForReceiver(plan, descriptor)
+		if route.Empty() {
+			continue
+		}
+		routes = append(routes, route)
+	}
+	routes = uniqueRoutes(routes)
+	if len(routes) == 0 {
+		return ConnectRoutePlanMaterialization{Failure: ConnectFailureTargetUnresolved}
+	}
+	return ConnectRoutePlanMaterialization{TargetSet: routes}
 }
 
 func connectDelivery(connect runtimecontracts.FlowPackageConnect, inputPin runtimecontracts.FlowInputEventPin) (ConnectRoutePlanDelivery, ConnectRoutePlanFailure) {
@@ -393,11 +412,8 @@ func materializeConnectRoutes(plan ConnectRoutePlan, targetExpr, value string, d
 	}
 	var routes []events.RouteIdentity
 	for _, descriptor := range descriptors {
-		route := descriptorRoute(nil, plan.Receiver.FlowID, descriptor)
+		route := descriptorRouteForReceiver(plan, descriptor)
 		if route.Empty() {
-			continue
-		}
-		if route.FlowID != "" && plan.Receiver.FlowID != "" && route.FlowID != plan.Receiver.FlowID {
 			continue
 		}
 		matches := connectDescriptorMatches(targetExpr, value, descriptor, route)
@@ -421,6 +437,25 @@ func connectDescriptorMatches(targetExpr, value string, descriptor Descriptor, r
 	default:
 		return false
 	}
+}
+
+func descriptorRouteForReceiver(plan ConnectRoutePlan, descriptor Descriptor) events.RouteIdentity {
+	if !descriptorBelongsToReceiver(plan, descriptor) {
+		return events.RouteIdentity{}
+	}
+	return descriptorRoute(nil, plan.Receiver.FlowID, descriptor)
+}
+
+func descriptorBelongsToReceiver(plan ConnectRoutePlan, descriptor Descriptor) bool {
+	flowInstance := strings.Trim(strings.TrimSpace(descriptor.FlowInstance), "/")
+	if flowInstance == "" {
+		return false
+	}
+	receiverPath := strings.Trim(strings.TrimSpace(plan.Receiver.FlowPath), "/")
+	if receiverPath == "" {
+		receiverPath = strings.Trim(strings.TrimSpace(plan.Receiver.FlowID), "/")
+	}
+	return receiverPath != "" && (flowInstance == receiverPath || strings.HasPrefix(flowInstance, receiverPath+"/"))
 }
 
 func addressTargetSupported(expr string) bool {

--- a/internal/runtime/core/pinrouting/connect_route_plan_test.go
+++ b/internal/runtime/core/pinrouting/connect_route_plan_test.go
@@ -178,6 +178,7 @@ func TestMaterializeConnectRoutePlanFanoutForTemplateDescriptors(t *testing.T) {
 		Descriptors: []Descriptor{
 			{EntityID: "team-a", FlowInstance: "worker/alpha"},
 			{EntityID: "team-a", FlowInstance: "worker/beta"},
+			{EntityID: "team-a", FlowInstance: "other/alpha"},
 			{EntityID: "team-b", FlowInstance: "worker/gamma"},
 		},
 	})
@@ -189,6 +190,55 @@ func TestMaterializeConnectRoutePlanFanoutForTemplateDescriptors(t *testing.T) {
 	}
 	if materialized.TargetSet[0].FlowInstance != "worker/alpha" || materialized.TargetSet[1].FlowInstance != "worker/beta" {
 		t.Fatalf("TargetSet = %#v, want deterministic worker alpha/beta routes", materialized.TargetSet)
+	}
+}
+
+func TestMaterializeConnectRoutePlanBroadcastsAddresslessTemplateDescriptors(t *testing.T) {
+	source := testConnectRoutePlanSource([]connectRoutePlanFlow{
+		{
+			id:   "producer",
+			mode: "static",
+			outputs: []runtimecontracts.FlowOutputEventPin{{
+				Name:  "notice_ready",
+				Event: "notice.ready",
+			}},
+		},
+		{
+			id:   "worker",
+			mode: "template",
+			inputs: []runtimecontracts.FlowInputEventPin{{
+				Name:  "notice_ready",
+				Event: "notice.ready",
+			}},
+		},
+	}, []runtimecontracts.FlowPackageConnect{{
+		From:     "producer.notice_ready",
+		To:       "worker.notice_ready",
+		Delivery: "broadcast",
+	}})
+
+	plans, issues := LowerCompositionConnectRoutePlans(source)
+	if len(issues) != 0 {
+		t.Fatalf("issues = %#v, want none", issues)
+	}
+	if len(plans) != 1 {
+		t.Fatalf("plans = %#v, want one", plans)
+	}
+	materialized := MaterializeConnectRoutePlan(plans[0], ConnectRoutePlanMaterializationInput{
+		Descriptors: []Descriptor{
+			{FlowInstance: "worker/alpha"},
+			{FlowInstance: "other/alpha"},
+			{FlowInstance: "worker/beta"},
+		},
+	})
+	if materialized.Failure != "" {
+		t.Fatalf("Failure = %q, want empty", materialized.Failure)
+	}
+	if len(materialized.TargetSet) != 2 {
+		t.Fatalf("TargetSet = %#v, want two worker routes", materialized.TargetSet)
+	}
+	if materialized.TargetSet[0].FlowInstance != "worker/alpha" || materialized.TargetSet[1].FlowInstance != "worker/beta" {
+		t.Fatalf("TargetSet = %#v, want receiver-scoped worker routes only", materialized.TargetSet)
 	}
 }
 

--- a/internal/runtime/core/pinrouting/connect_route_plan_test.go
+++ b/internal/runtime/core/pinrouting/connect_route_plan_test.go
@@ -1,0 +1,539 @@
+package pinrouting
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
+	"github.com/division-sh/swarm/internal/runtime/core/flowidentity"
+	"github.com/division-sh/swarm/internal/runtime/flowmodel"
+	"github.com/division-sh/swarm/internal/runtime/semanticview"
+)
+
+func TestLowerCompositionConnectRoutePlansFromLoadedPackageFixture(t *testing.T) {
+	repoRoot, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd: %v", err)
+	}
+	repoRoot = filepath.Clean(filepath.Join(repoRoot, "..", "..", "..", ".."))
+	root := writeConnectRoutePlanPackageFixture(t)
+	bundle, err := runtimecontracts.LoadWorkflowContractBundleWithOverrides(repoRoot, root, runtimecontracts.DefaultPlatformSpecFile(repoRoot))
+	if err != nil {
+		t.Fatalf("LoadWorkflowContractBundleWithOverrides: %v", err)
+	}
+
+	plans, issues := LowerCompositionConnectRoutePlans(semanticview.Wrap(bundle))
+	if len(issues) != 0 {
+		t.Fatalf("issues = %#v, want none", issues)
+	}
+	if len(plans) != 1 {
+		t.Fatalf("plans = %#v, want one", plans)
+	}
+	plan := plans[0]
+	if got, want := plan.Source.ResolvedEvent, "producer/deploy.done"; got != want {
+		t.Fatalf("Source.ResolvedEvent = %q, want %q", got, want)
+	}
+	if got, want := plan.Receiver.ResolvedEvent, "consumer/deploy.completed"; got != want {
+		t.Fatalf("Receiver.ResolvedEvent = %q, want %q", got, want)
+	}
+	if plan.Address == nil || plan.Address.By != "vertical_id" {
+		t.Fatalf("Address = %#v, want loaded vertical_id address", plan.Address)
+	}
+	if plan.Target.FlowInstance != "consumer" {
+		t.Fatalf("Target = %#v, want concrete static consumer route", plan.Target)
+	}
+}
+
+func TestLowerCompositionConnectRoutePlansOneToOneStatic(t *testing.T) {
+	source := testConnectRoutePlanSource([]connectRoutePlanFlow{
+		{
+			id:   "producer",
+			mode: "static",
+			outputs: []runtimecontracts.FlowOutputEventPin{{
+				Name:  "deploy_done",
+				Event: "deploy.done",
+			}},
+		},
+		{
+			id:   "consumer",
+			mode: "static",
+			inputs: []runtimecontracts.FlowInputEventPin{{
+				Name:  "deploy_completed",
+				Event: "deploy.completed",
+				Address: &runtimecontracts.FlowInputPinAddress{
+					By:          "vertical_id",
+					Source:      "payload.vertical_id",
+					Target:      "entity.vertical_id",
+					Cardinality: "one",
+				},
+			}},
+		},
+	}, []runtimecontracts.FlowPackageConnect{{
+		From:     "producer.deploy_done",
+		To:       "consumer.deploy_completed",
+		Adapter:  "deploy_done_to_completed",
+		Delivery: "one",
+		Map: map[string]runtimecontracts.FlowPackageConnectMap{
+			"vertical_id": {Source: "payload.vertical_id", Target: "entity.vertical_id"},
+		},
+	}})
+
+	plans, issues := LowerCompositionConnectRoutePlans(source)
+	if len(issues) != 0 {
+		t.Fatalf("issues = %#v, want none", issues)
+	}
+	if len(plans) != 1 {
+		t.Fatalf("plans = %#v, want one", plans)
+	}
+	plan := plans[0]
+	if got, want := plan.Source.FlowID, "producer"; got != want {
+		t.Fatalf("Source.FlowID = %q, want %q", got, want)
+	}
+	if got, want := plan.Source.Pin, "deploy_done"; got != want {
+		t.Fatalf("Source.Pin = %q, want %q", got, want)
+	}
+	if got, want := plan.Source.Event, "deploy.done"; got != want {
+		t.Fatalf("Source.Event = %q, want %q", got, want)
+	}
+	if got, want := plan.Source.ResolvedEvent, "producer/deploy.done"; got != want {
+		t.Fatalf("Source.ResolvedEvent = %q, want %q", got, want)
+	}
+	if got, want := plan.Receiver.Pin, "deploy_completed"; got != want {
+		t.Fatalf("Receiver.Pin = %q, want %q", got, want)
+	}
+	if got, want := plan.Receiver.Event, "deploy.completed"; got != want {
+		t.Fatalf("Receiver.Event = %q, want %q", got, want)
+	}
+	if got, want := plan.Delivery, ConnectDeliveryOne; got != want {
+		t.Fatalf("Delivery = %q, want %q", got, want)
+	}
+	if got, want := plan.TargetKind, ConnectTargetKindTarget; got != want {
+		t.Fatalf("TargetKind = %q, want %q", got, want)
+	}
+	if plan.Address == nil || plan.Address.By != "vertical_id" || plan.Address.Source != "payload.vertical_id" || plan.Address.Target != "entity.vertical_id" {
+		t.Fatalf("Address = %#v, want vertical_id payload/entity mapping", plan.Address)
+	}
+	if len(plan.Map) != 1 || plan.Map[0].Key != "vertical_id" {
+		t.Fatalf("Map = %#v, want vertical_id entry", plan.Map)
+	}
+	if plan.Target.FlowInstance != "consumer" {
+		t.Fatalf("Target.FlowInstance = %q, want consumer", plan.Target.FlowInstance)
+	}
+	if plan.Target.EntityID != flowidentity.EntityID("consumer") {
+		t.Fatalf("Target.EntityID = %q, want static route entity id", plan.Target.EntityID)
+	}
+	if plan.RequiresRuntimeResolution {
+		t.Fatal("static connect should not require runtime descriptor resolution")
+	}
+}
+
+func TestMaterializeConnectRoutePlanFanoutForTemplateDescriptors(t *testing.T) {
+	source := testConnectRoutePlanSource([]connectRoutePlanFlow{
+		{
+			id:   "producer",
+			mode: "static",
+			outputs: []runtimecontracts.FlowOutputEventPin{{
+				Name:  "ticket_ready",
+				Event: "ticket.ready",
+			}},
+		},
+		{
+			id:   "worker",
+			mode: "template",
+			inputs: []runtimecontracts.FlowInputEventPin{{
+				Name:  "ticket_ready",
+				Event: "ticket.ready",
+				Address: &runtimecontracts.FlowInputPinAddress{
+					By:          "team_entity",
+					Source:      "payload.team_entity",
+					Target:      "entity.entity_id",
+					Cardinality: "many",
+				},
+			}},
+		},
+	}, []runtimecontracts.FlowPackageConnect{{
+		From:     "producer.ticket_ready",
+		To:       "worker.ticket_ready",
+		Delivery: "many",
+	}})
+
+	plans, issues := LowerCompositionConnectRoutePlans(source)
+	if len(issues) != 0 {
+		t.Fatalf("issues = %#v, want none", issues)
+	}
+	if len(plans) != 1 {
+		t.Fatalf("plans = %#v, want one", plans)
+	}
+	plan := plans[0]
+	if !plan.RequiresRuntimeResolution {
+		t.Fatal("template receiver should require runtime descriptor resolution")
+	}
+	if got, want := plan.TargetKind, ConnectTargetKindTargetSet; got != want {
+		t.Fatalf("TargetKind = %q, want %q", got, want)
+	}
+
+	materialized := MaterializeConnectRoutePlan(plan, ConnectRoutePlanMaterializationInput{
+		MatchValues: map[string]string{"team_entity": "team-a"},
+		Descriptors: []Descriptor{
+			{EntityID: "team-a", FlowInstance: "worker/alpha"},
+			{EntityID: "team-a", FlowInstance: "worker/beta"},
+			{EntityID: "team-b", FlowInstance: "worker/gamma"},
+		},
+	})
+	if materialized.Failure != "" {
+		t.Fatalf("Failure = %q, want empty", materialized.Failure)
+	}
+	if len(materialized.TargetSet) != 2 {
+		t.Fatalf("TargetSet = %#v, want two team-a routes", materialized.TargetSet)
+	}
+	if materialized.TargetSet[0].FlowInstance != "worker/alpha" || materialized.TargetSet[1].FlowInstance != "worker/beta" {
+		t.Fatalf("TargetSet = %#v, want deterministic worker alpha/beta routes", materialized.TargetSet)
+	}
+}
+
+func TestLowerCompositionConnectRoutePlanPreservesReplyLineage(t *testing.T) {
+	source := testConnectRoutePlanSource([]connectRoutePlanFlow{
+		{
+			id:   "requester",
+			mode: "static",
+			outputs: []runtimecontracts.FlowOutputEventPin{{
+				Name:  "approval_requested",
+				Event: "approval.requested",
+			}},
+		},
+		{
+			id:   "approver",
+			mode: "static",
+			inputs: []runtimecontracts.FlowInputEventPin{{
+				Name:  "approval_requested",
+				Event: "approval.requested",
+			}},
+		},
+	}, []runtimecontracts.FlowPackageConnect{{
+		From:     "requester.approval_requested",
+		To:       "approver.approval_requested",
+		Delivery: "reply",
+		Reply: map[string]string{
+			"source_event_id": "event.source_event_id",
+			"target":          "event.source",
+		},
+	}})
+
+	plan, issue := LowerCompositionConnectRoutePlan(source, source.CompositionConnects()[0])
+	if issue.Failure != "" {
+		t.Fatalf("issue = %#v, want none", issue)
+	}
+	if got, want := plan.Delivery, ConnectDeliveryReply; got != want {
+		t.Fatalf("Delivery = %q, want %q", got, want)
+	}
+	if got, want := plan.TargetKind, ConnectTargetKindReply; got != want {
+		t.Fatalf("TargetKind = %q, want %q", got, want)
+	}
+	if plan.Reply["source_event_id"] != "event.source_event_id" || plan.Reply["target"] != "event.source" {
+		t.Fatalf("Reply = %#v, want lineage preserved", plan.Reply)
+	}
+	if plan.Target.FlowInstance != "approver" {
+		t.Fatalf("Target = %#v, want static approver route", plan.Target)
+	}
+}
+
+func TestLowerCompositionConnectRoutePlanDoesNotDependOnRawPinNamesOrProducerTargets(t *testing.T) {
+	source := testConnectRoutePlanSource([]connectRoutePlanFlow{
+		{
+			id:   "producer",
+			mode: "static",
+			outputs: []runtimecontracts.FlowOutputEventPin{{
+				Name:  "public_done",
+				Event: "internal.done",
+			}},
+		},
+		{
+			id:   "consumer",
+			mode: "static",
+			inputs: []runtimecontracts.FlowInputEventPin{{
+				Name:  "accept_completed",
+				Event: "external.completed",
+			}},
+		},
+	}, []runtimecontracts.FlowPackageConnect{{
+		From:     "producer.public_done",
+		To:       "consumer.accept_completed",
+		Adapter:  "public_done_to_accept_completed",
+		Delivery: "one",
+	}})
+
+	plan, issue := LowerCompositionConnectRoutePlan(source, source.CompositionConnects()[0])
+	if issue.Failure != "" {
+		t.Fatalf("issue = %#v, want none", issue)
+	}
+	if got, want := plan.Source.Pin, "public_done"; got != want {
+		t.Fatalf("Source.Pin = %q, want %q", got, want)
+	}
+	if got, want := plan.Source.Event, "internal.done"; got != want {
+		t.Fatalf("Source.Event = %q, want %q", got, want)
+	}
+	if got, want := plan.Receiver.Pin, "accept_completed"; got != want {
+		t.Fatalf("Receiver.Pin = %q, want %q", got, want)
+	}
+	if got, want := plan.Receiver.Event, "external.completed"; got != want {
+		t.Fatalf("Receiver.Event = %q, want %q", got, want)
+	}
+	if got, want := plan.Adapter, "public_done_to_accept_completed"; got != want {
+		t.Fatalf("Adapter = %q, want %q", got, want)
+	}
+}
+
+func TestLowerCompositionConnectRoutePlanFailsClosedForInvalidInputs(t *testing.T) {
+	tests := []struct {
+		name    string
+		connect runtimecontracts.FlowPackageConnect
+		want    ConnectRoutePlanFailure
+	}{
+		{
+			name:    "missing output pin",
+			connect: runtimecontracts.FlowPackageConnect{From: "producer.missing", To: "consumer.deploy_completed", Delivery: "one"},
+			want:    ConnectFailureProducerOutputPinMissing,
+		},
+		{
+			name:    "invalid delivery",
+			connect: runtimecontracts.FlowPackageConnect{From: "producer.deploy_done", To: "consumer.deploy_completed", Delivery: "maybe"},
+			want:    ConnectFailureDeliveryTopologyInvalid,
+		},
+		{
+			name:    "reply without lineage",
+			connect: runtimecontracts.FlowPackageConnect{From: "producer.deploy_done", To: "consumer.deploy_completed", Delivery: "reply"},
+			want:    ConnectFailureReplyLineageMissing,
+		},
+	}
+	source := testConnectRoutePlanSource([]connectRoutePlanFlow{
+		{
+			id:   "producer",
+			mode: "static",
+			outputs: []runtimecontracts.FlowOutputEventPin{{
+				Name:  "deploy_done",
+				Event: "deploy.done",
+			}},
+		},
+		{
+			id:   "consumer",
+			mode: "static",
+			inputs: []runtimecontracts.FlowInputEventPin{{
+				Name:  "deploy_completed",
+				Event: "deploy.completed",
+			}},
+		},
+	}, nil)
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, issue := LowerCompositionConnectRoutePlan(source, tc.connect)
+			if issue.Failure != tc.want {
+				t.Fatalf("Failure = %q, want %q (issue %#v)", issue.Failure, tc.want, issue)
+			}
+		})
+	}
+}
+
+func TestMaterializeConnectRoutePlanFailsClosedForUnsupportedAddressTarget(t *testing.T) {
+	source := testConnectRoutePlanSource([]connectRoutePlanFlow{
+		{
+			id:   "producer",
+			mode: "static",
+			outputs: []runtimecontracts.FlowOutputEventPin{{
+				Name:  "deploy_done",
+				Event: "deploy.done",
+			}},
+		},
+		{
+			id:   "consumer",
+			mode: "template",
+			inputs: []runtimecontracts.FlowInputEventPin{{
+				Name:  "deploy_completed",
+				Event: "deploy.completed",
+				Address: &runtimecontracts.FlowInputPinAddress{
+					By:          "vertical_id",
+					Source:      "payload.vertical_id",
+					Target:      "entity.vertical_id",
+					Cardinality: "one",
+				},
+			}},
+		},
+	}, []runtimecontracts.FlowPackageConnect{{
+		From:     "producer.deploy_done",
+		To:       "consumer.deploy_completed",
+		Delivery: "one",
+	}})
+
+	plans, issues := LowerCompositionConnectRoutePlans(source)
+	if len(issues) != 0 {
+		t.Fatalf("issues = %#v, want none", issues)
+	}
+	materialized := MaterializeConnectRoutePlan(plans[0], ConnectRoutePlanMaterializationInput{
+		MatchValues: map[string]string{"vertical_id": "v1"},
+		Descriptors: []Descriptor{{
+			EntityID:     "entity-1",
+			FlowInstance: "consumer/inst-1",
+		}},
+	})
+	if materialized.Failure != ConnectFailureTargetUnsupported {
+		t.Fatalf("Failure = %q, want %q", materialized.Failure, ConnectFailureTargetUnsupported)
+	}
+}
+
+type connectRoutePlanFlow struct {
+	id      string
+	mode    string
+	inputs  []runtimecontracts.FlowInputEventPin
+	outputs []runtimecontracts.FlowOutputEventPin
+}
+
+func testConnectRoutePlanSource(flows []connectRoutePlanFlow, connects []runtimecontracts.FlowPackageConnect) semanticview.Source {
+	children := make([]runtimecontracts.FlowContractView, 0, len(flows))
+	byID := make(map[string]*runtimecontracts.FlowContractView, len(flows))
+	inputPins := make(map[string][]runtimecontracts.FlowInputEventPin, len(flows))
+	outputPins := make(map[string][]runtimecontracts.FlowOutputEventPin, len(flows))
+	flowInputs := make(map[string][]string, len(flows))
+	flowOutputs := make(map[string][]string, len(flows))
+	flowSchemas := make(map[string]runtimecontracts.FlowSchemaDocument, len(flows))
+	for _, flow := range flows {
+		view := runtimecontracts.FlowContractView{
+			Paths: runtimecontracts.FlowContractPaths{
+				ID:   flow.id,
+				Flow: flow.id,
+			},
+			Schema: runtimecontracts.FlowSchemaDocument{
+				Mode: flow.mode,
+				Pins: runtimecontracts.FlowPins{
+					Inputs: runtimecontracts.FlowInputPins{
+						Events:    inputEventNames(flow.inputs),
+						EventPins: flow.inputs,
+					},
+					Outputs: runtimecontracts.FlowOutputPins{
+						Events:    outputEventNames(flow.outputs),
+						EventPins: flow.outputs,
+					},
+				},
+			},
+			Path: flow.id,
+		}
+		children = append(children, view)
+		viewCopy := view
+		byID[flow.id] = &viewCopy
+		inputPins[flow.id] = append([]runtimecontracts.FlowInputEventPin{}, flow.inputs...)
+		outputPins[flow.id] = append([]runtimecontracts.FlowOutputEventPin{}, flow.outputs...)
+		flowInputs[flow.id] = inputEventNames(flow.inputs)
+		flowOutputs[flow.id] = outputEventNames(flow.outputs)
+		flowSchemas[flow.id] = view.Schema
+	}
+	return semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
+		Semantics: runtimecontracts.WorkflowSemanticView{
+			FlowInputs:          flowInputs,
+			FlowOutputs:         flowOutputs,
+			FlowInputEventPins:  inputPins,
+			FlowOutputEventPins: outputPins,
+			CompositionConnects: connects,
+		},
+		FlowSchemas: flowSchemas,
+		FlowTree: flowmodel.Tree[runtimecontracts.FlowContractView]{
+			Root: &runtimecontracts.FlowContractView{
+				Children: children,
+			},
+			ByID: byID,
+		},
+	})
+}
+
+func inputEventNames(pins []runtimecontracts.FlowInputEventPin) []string {
+	out := make([]string, 0, len(pins))
+	for _, pin := range pins {
+		out = append(out, pin.EventType())
+	}
+	return out
+}
+
+func outputEventNames(pins []runtimecontracts.FlowOutputEventPin) []string {
+	out := make([]string, 0, len(pins))
+	for _, pin := range pins {
+		out = append(out, pin.EventType())
+	}
+	return out
+}
+
+func writeConnectRoutePlanPackageFixture(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	writeConnectRoutePlanFixtureFile(t, filepath.Join(root, "package.yaml"), `
+name: connect-route-plan-package
+version: "1.0.0"
+platform_version: ">=1.6.0"
+flows:
+  - id: producer
+    flow: producer
+    mode: static
+  - id: consumer
+    flow: consumer
+    mode: static
+connect:
+  - from: producer.deploy_done
+    to: consumer.deploy_completed
+    adapter: deploy_done_to_completed
+    delivery: one
+    map:
+      vertical_id:
+        source: payload.vertical_id
+        target: entity.vertical_id
+`)
+	writeConnectRoutePlanFixtureFile(t, filepath.Join(root, "schema.yaml"), "name: connect-route-plan-package\n")
+	writeConnectRoutePlanFixtureFile(t, filepath.Join(root, "policy.yaml"), "{}\n")
+	writeConnectRoutePlanFixtureFile(t, filepath.Join(root, "tools.yaml"), "{}\n")
+	writeConnectRoutePlanFixtureFile(t, filepath.Join(root, "agents.yaml"), "{}\n")
+	writeConnectRoutePlanFixtureFile(t, filepath.Join(root, "events.yaml"), "{}\n")
+	writeConnectRoutePlanFixtureFile(t, filepath.Join(root, "nodes.yaml"), "{}\n")
+	writeConnectRoutePlanFlowFixture(t, root, "producer", `
+pins:
+  outputs:
+    events:
+      - name: deploy_done
+        event: deploy.done
+`, "deploy.done: {}\n", "{}\n")
+	writeConnectRoutePlanFlowFixture(t, root, "consumer", `
+pins:
+  inputs:
+    events:
+      - name: deploy_completed
+        event: deploy.completed
+        address:
+          by: vertical_id
+          source: payload.vertical_id
+          target: entity.vertical_id
+          cardinality: one
+`, "deploy.completed: {}\n", `
+deployment:
+  vertical_id:
+    type: string
+`)
+	return root
+}
+
+func writeConnectRoutePlanFlowFixture(t *testing.T, root, flowID, schemaTail, events, entities string) {
+	t.Helper()
+	writeConnectRoutePlanFixtureFile(t, filepath.Join(root, "flows", flowID, "schema.yaml"), `
+name: `+flowID+`
+mode: static
+`+schemaTail)
+	writeConnectRoutePlanFixtureFile(t, filepath.Join(root, "flows", flowID, "policy.yaml"), "{}\n")
+	writeConnectRoutePlanFixtureFile(t, filepath.Join(root, "flows", flowID, "agents.yaml"), "{}\n")
+	writeConnectRoutePlanFixtureFile(t, filepath.Join(root, "flows", flowID, "nodes.yaml"), "{}\n")
+	writeConnectRoutePlanFixtureFile(t, filepath.Join(root, "flows", flowID, "events.yaml"), events)
+	writeConnectRoutePlanFixtureFile(t, filepath.Join(root, "flows", flowID, "entities.yaml"), entities)
+}
+
+func writeConnectRoutePlanFixtureFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("MkdirAll(%s): %v", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("WriteFile(%s): %v", path, err)
+	}
+}

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -4798,7 +4798,8 @@ flow_model:
             runtime_resolution_flag: Template or dynamic receivers keep an explicit runtime-resolution requirement instead of fabricating concrete delivery rows.
           materialization_boundary:
             static_receivers: Static receivers can materialize target route facts during lowering because the receiver flow path is concrete.
-            template_receivers: Template/dynamic receivers may materialize route facts only from explicit addressed-input keys and runtime descriptors; descriptor materialization remains pre-dispatch route evidence, not delivery execution.
+            template_receivers: Template/dynamic receivers may materialize route facts only from explicit addressed-input keys and runtime descriptors, or for delivery:broadcast by enumerating receiver-scope descriptors; descriptor materialization remains pre-dispatch route evidence, not delivery execution.
+            descriptor_scope: Descriptor materialization MUST reject descriptors whose flow_instance is not the receiver semantic flow path or a child instance under that path before stamping the receiver flow id onto the route.
             supported_descriptor_targets:
             - entity_id / entity.entity_id
             - flow_instance / instance.flow_instance

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -4775,6 +4775,60 @@ flow_model:
           many: Lower to event.target_set and one delivery row per concrete recipient.
           broadcast: Lower to explicit parent-authored fan-out route facts; producer broadcast:true is not required.
           reply: Lower through the recorded request lineage; missing or ambiguous lineage fails closed.
+        implementation_slice_1472:
+          status: merge_bearing_runtime_artifact
+          canonical_code_owner: internal/runtime/core/pinrouting.ConnectRoutePlan
+          rule: |
+            Runtime lowering of verified parent connect facts is represented by
+            a stage-specific typed artifact before EventBus dispatch. The
+            artifact MUST consume the verified semantic source facts exposed by
+            contracts/semanticview and MUST NOT reconstruct topology from raw
+            output pin names, live subscription lists, producer emit.target,
+            producer broadcast, or structural ParentRoute.
+          artifact_fields:
+            package_key: Parent package key that authored the connect entry when available.
+            producer_endpoint: Producer semantic flow id/path, output pin name, local output event identity, and scoped resolved event identity.
+            receiver_endpoint: Receiver semantic flow id/path/mode, input pin name, local receiver event identity, and scoped resolved event identity.
+            adapter_and_map: Explicit adapter plus sorted address-key map entries used for alias/key adaptation.
+            delivery: one, many, broadcast, or reply after analyzer/default inference.
+            target_kind: target for singular delivery, target_set for fanout/broadcast, reply for reply-lineage delivery.
+            address_rule: Receiver-owned address key, source expression, target expression, cardinality, and mode when runtime descriptor materialization is required.
+            reply_lineage: 'The explicit reply lineage map for delivery: reply.'
+            static_target_route: Static receiver flows may lower immediately to a concrete target or single target_set member using the receiver flow path and canonical flow-instance entity id.
+            runtime_resolution_flag: Template or dynamic receivers keep an explicit runtime-resolution requirement instead of fabricating concrete delivery rows.
+          materialization_boundary:
+            static_receivers: Static receivers can materialize target route facts during lowering because the receiver flow path is concrete.
+            template_receivers: Template/dynamic receivers may materialize route facts only from explicit addressed-input keys and runtime descriptors; descriptor materialization remains pre-dispatch route evidence, not delivery execution.
+            supported_descriptor_targets:
+            - entity_id / entity.entity_id
+            - flow_instance / instance.flow_instance
+            - instance_id / instance.instance_id
+            unsupported_descriptor_targets: Arbitrary business fields such as entity.vertical_id remain fail-closed until a later gate promotes a typed descriptor/index owner for those fields.
+          failure_reasons:
+          - source_missing
+          - connect_pin_ref_invalid
+          - producer_flow_missing
+          - producer_output_pin_missing
+          - receiver_flow_missing
+          - receiver_input_pin_missing
+          - receiver_address_rule_missing
+          - delivery_topology_invalid
+          - reply_lineage_missing
+          - route_plan_address_value_missing
+          - route_plan_target_unsupported
+          - route_plan_target_unresolved
+          - route_plan_target_ambiguous
+          stage_boundary:
+            produces: Typed lowered connect route artifacts and optional descriptor-materialized target/target_set facts.
+            does_not_produce:
+            - EventBus dispatch
+            - RouteTable publish consumption
+            - event_deliveries rows
+            - receipts
+            - replay-scope rows
+            - recovery or retry work
+            - agent/node delivery parity
+            - producer target/broadcast retirement
         invalid_outputs:
         - raw same-name pin match used as final topology authority
         - live subscription list used to invent missing connect topology


### PR DESCRIPTION
## Summary

Closes #1472.

This PR implements the approved first slice for `verified_connect_route_plan_artifact_lowering_missing`: verified parent `connect` facts now lower into typed pre-dispatch route-plan artifacts in `internal/runtime/core/pinrouting`, with fail-closed lowering/materialization diagnostics and focused proof for one-to-one, fanout, reply, package-loader, alias/non-name-matching, and negative cases.

It does not implement EventBus dispatch, RouteTable publish consumption, persisted delivery rows, receipts, replay, recovery, agent/node parity, or producer `target` / `broadcast` retirement. Those remain split to #1473, #1474, and #1475 under #1466.

## Governing Refs / Context

Exact authoritative spec sections consumed and updated:

- `platform-spec.yaml#flow_model.flow_package.composition_routing`
- `platform-spec.yaml#flow_model.flow_package.composition_routing.route_plan_lowering`
- `platform-spec.yaml#contract_formats.event_schema.routing_derivation.route_plan_authority`
- `platform-spec.yaml#static_analyzer.slice_3a_pin_target_resolution`
- `platform-spec.yaml#static_analyzer.slice_3a1_composition_connect_validation`

Issue/gate context:

- #1472 Pre-Implementation Coverage Audit and approved first-slice gate.
- #1471 / PR #1477 upstream parser/model/semantic-view/bootverify source-authority closure.
- #1466 parent/watchpoint split list.

## Semantic Migration

New canonical owner:

- Spec: `platform-spec.yaml#flow_model.flow_package.composition_routing.route_plan_lowering.implementation_slice_1472`
- Code: `internal/runtime/core/pinrouting.ConnectRoutePlan`, `LowerCompositionConnectRoutePlans`, and `MaterializeConnectRoutePlan`

Old producer / reader / writer paths now invalid for this artifact owner:

- Raw same-name output/input pin matching as topology authority.
- Live subscription / RouteTable reconstruction as lowered-connect topology authority.
- Producer `emit.target` or `broadcast` as the common parent-composed route owner.
- Structural `ParentRoute` as the common parent-composed route owner.

Production paths checked for surviving old behavior:

- `internal/runtime/bus` remains a downstream publish-time RoutePlan consumer, not modified here.
- `internal/runtime/pipeline`, `internal/runtime/runforkadmission`, `internal/runtime/runforkexecution`, and `internal/store` remain downstream split consumers for #1473.
- Agent/node delivery parity remains split to #1474.
- Producer target/broadcast retirement remains split to #1475.

Migration completeness:

- Complete for the approved #1472 artifact-lowering class.
- Parent composition-routing execution remains open under #1466 via #1473/#1474/#1475.

## Proof

- `go test ./internal/runtime/core/pinrouting ./internal/apispec -run 'ConnectRoutePlan|MaterializeConnectRoutePlan|CompositionRouting' -count=1`
- `go test ./internal/runtime/bus ./internal/runtime/core/pinrouting ./internal/runtime/contracts ./internal/runtime/semanticview ./internal/runtime/bootverify ./internal/runtime/pipeline ./internal/runtime/runforkadmission ./internal/runtime/runforkexecution ./internal/apispec -run 'RoutePlan|DeriveRoute|CompositionConnect|PinTarget|PinRouting|Target|WorkflowNode|ContractFrontier|CompositionRouting' -count=1`
- `go test ./...`