### PR TITLE
[agent-a][issue #1473] Dispatch lowered connect route plans

### DIFF
--- a/internal/apispec/platform_spec_composition_routing_test.go
+++ b/internal/apispec/platform_spec_composition_routing_test.go
@@ -79,7 +79,12 @@ func TestPlatformSpecCompositionRoutingSourceAuthority(t *testing.T) {
 
 	assertScalarContains(t, mustYAMLPath(t, composition, "pin_alias_delivery_composition", "owner_consumed"), "pin_alias_delivery")
 	assertScalarContains(t, mustYAMLPath(t, composition, "emit_target_escape_hatch", "role"), "not a compatibility path")
-	assertScalarContains(t, mustYAMLPath(t, composition, "split_boundaries", "runtime_route_consumption"), "does not claim runtime behavior closure")
+	assertScalarContains(t, mustYAMLPath(t, composition, "split_boundaries", "runtime_route_consumption"), "#1473 closes supported EventBus publish/preflight/outbox")
+	assertScalarContains(t, mustYAMLPath(t, composition, "split_boundaries", "runtime_route_consumption"), "selected-contract runfork readiness")
+	slice1473 := mustYAMLPath(t, composition, "route_plan_lowering", "implementation_slice_1473")
+	assertScalarValue(t, mustMappingValue(t, slice1473, "status"), "merge_bearing_runtime_behavior")
+	assertScalarContains(t, mustMappingValue(t, slice1473, "canonical_code_owner"), "internal/runtime/bus.RoutePlan")
+	assertScalarContains(t, mustMappingValue(t, slice1473, "rule"), "Supported EventBus publish/preflight/outbox dispatch consumes lowered ConnectRoutePlan")
 }
 
 func TestPlatformSpecCompositionRoutingDemotesProducerTargetAuthority(t *testing.T) {
@@ -87,7 +92,7 @@ func TestPlatformSpecCompositionRoutingDemotesProducerTargetAuthority(t *testing
 
 	crossFlow := mustYAMLPath(t, root, "engine", "cross_flow_routing")
 	assertScalarValue(t, mustMappingValue(t, crossFlow, "canonical_owner"), "platform-spec.yaml#flow_model.flow_package.composition_routing")
-	assertScalarValue(t, mustMappingValue(t, crossFlow, "implementation_status"), "source_authority_promoted_runtime_migration_pending")
+	assertScalarValue(t, mustMappingValue(t, crossFlow, "implementation_status"), "source_authority_promoted_eventbus_dispatch_partial")
 	if !sequenceContainsScalar(mustYAMLPath(t, crossFlow, "target_resolution", "precedence"), "lowered parent connect route plan") {
 		t.Fatal("cross_flow_routing target precedence must start from lowered parent connect route plan")
 	}

--- a/internal/runtime/bus/connect_route_plan_dispatch.go
+++ b/internal/runtime/bus/connect_route_plan_dispatch.go
@@ -1,0 +1,409 @@
+package bus
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/division-sh/swarm/internal/events"
+	runtimeflowidentity "github.com/division-sh/swarm/internal/runtime/core/flowidentity"
+	runtimepinrouting "github.com/division-sh/swarm/internal/runtime/core/pinrouting"
+	"github.com/division-sh/swarm/internal/runtime/semanticview"
+)
+
+type connectRoutePlanDescriptorLoader func(context.Context) ([]runtimepinrouting.Descriptor, error)
+
+type connectRoutePlanResolver struct {
+	source          semanticview.Source
+	routeTable      *RouteTable
+	plans           []runtimepinrouting.ConnectRoutePlan
+	issues          []runtimepinrouting.ConnectRoutePlanIssue
+	loadDescriptors connectRoutePlanDescriptorLoader
+}
+
+type connectRoutePlanDispatch struct {
+	Matched          bool
+	Failure          runtimepinrouting.TargetFailure
+	LiveRecipients   []RoutePlanLiveRecipient
+	DeliveryIntents  []RoutePlanDeliveryIntent
+	RoutedRecipients []Subscriber
+	ExtraDetail      map[string]any
+}
+
+func newConnectRoutePlanResolver(source semanticview.Source, routeTable *RouteTable, loadDescriptors connectRoutePlanDescriptorLoader) connectRoutePlanResolver {
+	if source == nil {
+		return connectRoutePlanResolver{routeTable: routeTable, loadDescriptors: loadDescriptors}
+	}
+	plans, issues := runtimepinrouting.LowerCompositionConnectRoutePlans(source)
+	return connectRoutePlanResolver{
+		source:          source,
+		routeTable:      routeTable,
+		plans:           append([]runtimepinrouting.ConnectRoutePlan(nil), plans...),
+		issues:          append([]runtimepinrouting.ConnectRoutePlanIssue(nil), issues...),
+		loadDescriptors: loadDescriptors,
+	}
+}
+
+func (r connectRoutePlanResolver) Plan(ctx context.Context, evt events.Event) (connectRoutePlanDispatch, error) {
+	if len(r.plans) == 0 && len(r.issues) == 0 {
+		return connectRoutePlanDispatch{}, nil
+	}
+	for _, issue := range r.issues {
+		if r.connectIssueMatchesEvent(issue, evt) {
+			return connectRoutePlanDispatch{
+				Matched: true,
+				Failure: connectRoutePlanTargetFailure(issue.Failure),
+				ExtraDetail: map[string]any{
+					"connect_route_plan_failure": string(issue.Failure),
+					"connect_route_plan_detail":  strings.TrimSpace(issue.Detail),
+				},
+			}, nil
+		}
+	}
+
+	matched := r.matchedPlans(evt)
+	if len(matched) == 0 {
+		return connectRoutePlanDispatch{}, nil
+	}
+	descriptors, err := r.descriptorsForPlans(ctx, matched)
+	if err != nil {
+		return connectRoutePlanDispatch{}, err
+	}
+	values := connectRoutePlanMatchValues(evt)
+	out := connectRoutePlanDispatch{
+		Matched: true,
+		ExtraDetail: map[string]any{
+			"connect_route_plans_count": len(matched),
+		},
+	}
+	for _, plan := range matched {
+		materialized := runtimepinrouting.MaterializeConnectRoutePlan(plan, runtimepinrouting.ConnectRoutePlanMaterializationInput{
+			MatchValues: values,
+			Descriptors: descriptors,
+		})
+		if materialized.Failure != "" {
+			out.Failure = connectRoutePlanTargetFailure(materialized.Failure)
+			out.ExtraDetail["connect_route_plan_failure"] = string(materialized.Failure)
+			out.ExtraDetail["connect_route_plan_source_event"] = plan.Source.ResolvedEvent
+			out.ExtraDetail["connect_route_plan_receiver_event"] = plan.Receiver.ResolvedEvent
+			return out, nil
+		}
+		routes, subscribers := r.deliveryRoutesForMaterialization(plan, materialized)
+		if len(routes) == 0 {
+			out.Failure = runtimepinrouting.FailureTargetNotSubscribed
+			out.ExtraDetail["connect_route_plan_failure"] = string(runtimepinrouting.FailureTargetNotSubscribed)
+			out.ExtraDetail["connect_route_plan_source_event"] = plan.Source.ResolvedEvent
+			out.ExtraDetail["connect_route_plan_receiver_event"] = plan.Receiver.ResolvedEvent
+			return out, nil
+		}
+		out.DeliveryIntents = append(out.DeliveryIntents, routePlanDeliveryIntentsFromRoutes(routes, routePlanSourceConnectRoutePlan, routePlanReasonLoweredConnectRoutePlan)...)
+		out.LiveRecipients = append(out.LiveRecipients, connectRoutePlanLiveRecipients(routes)...)
+		out.RoutedRecipients = append(out.RoutedRecipients, subscribers...)
+		if len(plan.Reply) > 0 {
+			out.ExtraDetail["connect_route_plan_reply"] = cloneStringMap(plan.Reply)
+		}
+	}
+	out.LiveRecipients = normalizeRoutePlanLiveRecipients(out.LiveRecipients)
+	out.DeliveryIntents = normalizeRoutePlanDeliveryIntents(out.DeliveryIntents)
+	out.RoutedRecipients = dedupeSubscribers(out.RoutedRecipients)
+	return out, nil
+}
+
+func (r connectRoutePlanResolver) matchedPlans(evt events.Event) []runtimepinrouting.ConnectRoutePlan {
+	if len(r.plans) == 0 {
+		return nil
+	}
+	out := make([]runtimepinrouting.ConnectRoutePlan, 0, len(r.plans))
+	for _, plan := range r.plans {
+		if connectEndpointMatchesEvent(plan.Source, evt) {
+			out = append(out, plan)
+		}
+	}
+	return out
+}
+
+func (r connectRoutePlanResolver) descriptorsForPlans(ctx context.Context, plans []runtimepinrouting.ConnectRoutePlan) ([]runtimepinrouting.Descriptor, error) {
+	needsDescriptors := false
+	for _, plan := range plans {
+		if plan.RequiresRuntimeResolution {
+			needsDescriptors = true
+			break
+		}
+	}
+	if !needsDescriptors || r.loadDescriptors == nil {
+		return nil, nil
+	}
+	return r.loadDescriptors(ctx)
+}
+
+func (r connectRoutePlanResolver) deliveryRoutesForMaterialization(plan runtimepinrouting.ConnectRoutePlan, materialized runtimepinrouting.ConnectRoutePlanMaterialization) ([]events.DeliveryRoute, []Subscriber) {
+	targets := connectMaterializedTargets(materialized)
+	if len(targets) == 0 {
+		return nil, nil
+	}
+	routes := make([]events.DeliveryRoute, 0, len(targets))
+	subscribers := make([]Subscriber, 0, len(targets))
+	for _, target := range targets {
+		target = target.Normalized()
+		matchedSubscribers := r.resolveReceiverSubscribers(plan, target)
+		if len(matchedSubscribers) == 0 {
+			return nil, nil
+		}
+		subscribers = append(subscribers, matchedSubscribers...)
+		for _, subscriber := range matchedSubscribers {
+			subscriberType := strings.TrimSpace(subscriber.Type)
+			if subscriberType == "" {
+				subscriberType = "node"
+			}
+			routes = append(routes, events.DeliveryRoute{
+				SubscriberType: subscriberType,
+				SubscriberID:   strings.TrimSpace(subscriber.ID),
+				Target:         target,
+			})
+		}
+	}
+	return events.NormalizeDeliveryRoutes(routes), dedupeSubscribers(subscribers)
+}
+
+func (r connectRoutePlanResolver) resolveReceiverSubscribers(plan runtimepinrouting.ConnectRoutePlan, target events.RouteIdentity) []Subscriber {
+	if r.routeTable == nil {
+		return nil
+	}
+	keys := connectReceiverRouteKeys(plan, target)
+	out := make([]Subscriber, 0, len(keys))
+	for _, key := range keys {
+		for _, subscriber := range r.routeTable.Resolve(key) {
+			if !connectSubscriberMatchesTarget(subscriber, target) {
+				continue
+			}
+			out = append(out, subscriber)
+		}
+	}
+	return dedupeSubscribers(out)
+}
+
+func (r connectRoutePlanResolver) connectIssueMatchesEvent(issue runtimepinrouting.ConnectRoutePlanIssue, evt events.Event) bool {
+	if r.source == nil || issue.Failure == "" {
+		return false
+	}
+	from, err := issue.Connect.FromRef()
+	if err != nil {
+		return false
+	}
+	outputPin, ok := r.source.FlowOutputEventPin(from.FlowID, from.Pin)
+	if !ok {
+		return false
+	}
+	endpoint := runtimepinrouting.ConnectRoutePlanEndpoint{
+		FlowID:        strings.TrimSpace(from.FlowID),
+		FlowPath:      strings.Trim(strings.TrimSpace(routeFlowPath(r.source, from.FlowID)), "/"),
+		Pin:           strings.TrimSpace(from.Pin),
+		Event:         strings.TrimSpace(outputPin.EventType()),
+		ResolvedEvent: strings.TrimSpace(r.source.ResolveFlowEventReference(from.FlowID, outputPin.EventType())),
+	}
+	return connectEndpointMatchesEvent(endpoint, evt)
+}
+
+func connectEndpointMatchesEvent(endpoint runtimepinrouting.ConnectRoutePlanEndpoint, evt events.Event) bool {
+	eventType := strings.Trim(strings.TrimSpace(string(evt.Type())), "/")
+	if eventType == "" {
+		return false
+	}
+	sourceLocal := strings.Trim(strings.TrimSpace(endpoint.Event), "/")
+	sourceResolved := strings.Trim(strings.TrimSpace(endpoint.ResolvedEvent), "/")
+	sourcePath := strings.Trim(strings.TrimSpace(endpoint.FlowPath), "/")
+	if sourcePath == "" {
+		sourcePath = strings.Trim(strings.TrimSpace(endpoint.FlowID), "/")
+	}
+	sourceScoped := sourceLocal
+	if sourcePath != "" && sourceLocal != "" {
+		sourceScoped = sourcePath + "/" + sourceLocal
+	}
+	for _, candidate := range uniqueStrings([]string{sourceResolved, sourceScoped}) {
+		if candidate != "" && eventType == candidate {
+			return true
+		}
+	}
+	if sourceLocal != "" && eventType == sourceLocal {
+		return eventFlowInstanceMatchesSourcePath(evt.FlowInstance(), sourcePath)
+	}
+	flowInstance := strings.Trim(strings.TrimSpace(evt.FlowInstance()), "/")
+	if flowInstance != "" && sourceLocal != "" && eventType == flowInstance+"/"+sourceLocal {
+		return eventFlowInstanceMatchesSourcePath(flowInstance, sourcePath)
+	}
+	for _, key := range routedEventKeysForPlan(evt) {
+		key = strings.Trim(strings.TrimSpace(key), "/")
+		if key != "" && (key == sourceResolved || key == sourceScoped) {
+			return true
+		}
+	}
+	return false
+}
+
+func eventFlowInstanceMatchesSourcePath(flowInstance, sourcePath string) bool {
+	flowInstance = strings.Trim(strings.TrimSpace(flowInstance), "/")
+	sourcePath = strings.Trim(strings.TrimSpace(sourcePath), "/")
+	if sourcePath == "" {
+		return flowInstance == ""
+	}
+	if flowInstance == sourcePath {
+		return true
+	}
+	return runtimeflowidentity.SemanticScopeFromInstancePath(flowInstance) == sourcePath
+}
+
+func connectMaterializedTargets(materialized runtimepinrouting.ConnectRoutePlanMaterialization) []events.RouteIdentity {
+	if !materialized.Target.Empty() {
+		return []events.RouteIdentity{materialized.Target.Normalized()}
+	}
+	return uniqueRouteIdentities(materialized.TargetSet)
+}
+
+func connectReceiverRouteKeys(plan runtimepinrouting.ConnectRoutePlan, target events.RouteIdentity) []string {
+	target = target.Normalized()
+	local := strings.Trim(strings.TrimSpace(plan.Receiver.Event), "/")
+	resolved := strings.Trim(strings.TrimSpace(plan.Receiver.ResolvedEvent), "/")
+	receiverPath := strings.Trim(strings.TrimSpace(plan.Receiver.FlowPath), "/")
+	if receiverPath == "" {
+		receiverPath = strings.Trim(strings.TrimSpace(plan.Receiver.FlowID), "/")
+	}
+	sourceLocal := strings.Trim(strings.TrimSpace(plan.Source.Event), "/")
+	sourceResolved := strings.Trim(strings.TrimSpace(plan.Source.ResolvedEvent), "/")
+	sourcePath := strings.Trim(strings.TrimSpace(plan.Source.FlowPath), "/")
+	if sourcePath == "" {
+		sourcePath = strings.Trim(strings.TrimSpace(plan.Source.FlowID), "/")
+	}
+	sourceScoped := sourceLocal
+	if sourcePath != "" && sourceLocal != "" {
+		sourceScoped = sourcePath + "/" + sourceLocal
+	}
+	out := make([]string, 0, 6)
+	if target.FlowInstance != "" && local != "" {
+		out = append(out, target.FlowInstance+"/"+local)
+	}
+	if receiverPath != "" && local != "" {
+		out = append(out, receiverPath+"/"+local)
+	}
+	out = append(out, resolved)
+	out = append(out, sourceResolved, sourceScoped)
+	if receiverPath == "" {
+		out = append(out, local)
+	}
+	return uniqueStrings(out)
+}
+
+func connectSubscriberMatchesTarget(subscriber Subscriber, target events.RouteIdentity) bool {
+	if strings.TrimSpace(subscriber.ID) == "" {
+		return false
+	}
+	subscriberType := strings.TrimSpace(subscriber.Type)
+	if subscriberType == "" {
+		return false
+	}
+	if target.Empty() {
+		return true
+	}
+	return routeMatchesInternalSubscriber(target, subscriber)
+}
+
+func connectRoutePlanLiveRecipients(routes []events.DeliveryRoute) []RoutePlanLiveRecipient {
+	routes = events.NormalizeDeliveryRoutes(routes)
+	if len(routes) == 0 {
+		return nil
+	}
+	out := make([]RoutePlanLiveRecipient, 0, len(routes))
+	for _, route := range routes {
+		subscriberType := strings.TrimSpace(route.SubscriberType)
+		subscriberID := strings.TrimSpace(route.SubscriberID)
+		if subscriberType == "" || subscriberID == "" {
+			continue
+		}
+		out = append(out, RoutePlanLiveRecipient{
+			RecipientID:       subscriberID,
+			SubscriberType:    subscriberType,
+			PersistAsDelivery: subscriberType == routePlanSubscriberAgent,
+			Source:            routePlanSourceConnectRoutePlan,
+			Reason:            routePlanReasonLoweredConnectRoutePlan,
+		})
+	}
+	return normalizeRoutePlanLiveRecipients(out)
+}
+
+func connectRoutePlanTargetFailure(failure runtimepinrouting.ConnectRoutePlanFailure) runtimepinrouting.TargetFailure {
+	if failure == "" {
+		return ""
+	}
+	return runtimepinrouting.TargetFailure(strings.TrimSpace(string(failure)))
+}
+
+func connectRoutePlanMatchValues(evt events.Event) map[string]string {
+	out := map[string]string{}
+	for key, value := range flattenConnectRouteValues("payload", payloadObject(evt.Payload())) {
+		out[key] = value
+		if leaf := connectExpressionLeaf(key); leaf != "" {
+			out[leaf] = value
+		}
+	}
+	for key, value := range flattenConnectRouteValues("event", evt.ContextMap("")) {
+		out[key] = value
+		if leaf := connectExpressionLeaf(key); leaf != "" {
+			out[leaf] = value
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+func payloadObject(raw json.RawMessage) map[string]any {
+	if len(raw) == 0 {
+		return nil
+	}
+	var out map[string]any
+	if err := json.Unmarshal(raw, &out); err != nil {
+		return nil
+	}
+	return out
+}
+
+func flattenConnectRouteValues(prefix string, source map[string]any) map[string]string {
+	out := map[string]string{}
+	var walk func(string, any)
+	walk = func(path string, value any) {
+		path = strings.Trim(strings.TrimSpace(path), ".")
+		switch typed := value.(type) {
+		case map[string]any:
+			for key, child := range typed {
+				key = strings.TrimSpace(key)
+				if key == "" {
+					continue
+				}
+				next := key
+				if path != "" {
+					next = path + "." + key
+				}
+				walk(next, child)
+			}
+		default:
+			if path == "" || value == nil {
+				return
+			}
+			str := strings.TrimSpace(fmt.Sprint(value))
+			if str != "" {
+				out[path] = str
+			}
+		}
+	}
+	walk(strings.TrimSpace(prefix), source)
+	return out
+}
+
+func connectExpressionLeaf(expr string) string {
+	expr = strings.TrimSpace(expr)
+	if idx := strings.LastIndex(expr, "."); idx >= 0 && idx < len(expr)-1 {
+		return strings.TrimSpace(expr[idx+1:])
+	}
+	return expr
+}

--- a/internal/runtime/bus/connect_route_plan_dispatch_test.go
+++ b/internal/runtime/bus/connect_route_plan_dispatch_test.go
@@ -3,6 +3,7 @@ package bus
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"testing"
 	"time"
 
@@ -29,6 +30,10 @@ type connectRoutePlanTestFlow struct {
 type connectRoutePlanDescriptorStore struct {
 	*targetRouteMemoryStore
 	flowInstances []ActiveFlowInstanceDescriptor
+}
+
+type connectRoutePlanFailingAgentDescriptorStore struct {
+	*targetRouteMemoryStore
 }
 
 type connectRoutePlanMutationStore struct {
@@ -90,6 +95,10 @@ func (s *connectRoutePlanDescriptorStore) ListActiveFlowInstanceDescriptors(cont
 	return append([]ActiveFlowInstanceDescriptor(nil), s.flowInstances...), nil
 }
 
+func (s *connectRoutePlanFailingAgentDescriptorStore) ListActiveAgentDescriptors(context.Context) ([]ActiveAgentDescriptor, error) {
+	return nil, errors.New("legacy active-agent descriptor path should not run for static connect route plans")
+}
+
 func TestEventBusPublish_ConnectRoutePlanPersistsSingularTargetWithoutLiveSubscriber(t *testing.T) {
 	source := connectRoutePlanStaticSource(runtimecontracts.FlowPackageConnect{
 		From:     "producer.deploy_done",
@@ -146,6 +155,32 @@ func TestEventBusPublish_ConnectRoutePlanPersistsSingularTargetWithoutLiveSubscr
 	}
 	if !deliveryRoutesContain(replayRoutes, want) {
 		t.Fatalf("replay delivery routes = %#v, want %#v", replayRoutes, want)
+	}
+}
+
+func TestEventBusCheckPublishRecipientPlan_ConnectRoutePlanPrecedesLegacyDescriptorPolicy(t *testing.T) {
+	source := connectRoutePlanStaticSource(runtimecontracts.FlowPackageConnect{
+		From:     "producer.deploy_done",
+		To:       "consumer.deploy_completed",
+		Delivery: "one",
+	})
+	store := &connectRoutePlanFailingAgentDescriptorStore{targetRouteMemoryStore: newTargetRouteMemoryStore()}
+	eb, err := NewEventBusWithOptions(store, EventBusOptions{ContractBundle: source})
+	if err != nil {
+		t.Fatalf("NewEventBusWithOptions: %v", err)
+	}
+	evt := events.NewProjectionEvent(uuid.NewString(),
+		events.EventType("producer/deploy.done"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Now().UTC())
+
+	plan, err := eb.CheckPublishRecipientPlan(context.Background(), evt)
+	if err != nil {
+		t.Fatalf("CheckPublishRecipientPlan: %v", err)
+	}
+	if plan.TargetFailure != "" {
+		t.Fatalf("target failure = %q, want none", plan.TargetFailure)
+	}
+	if !deliveryRoutesContain(plan.DeliveryRoutes, connectRoutePlanStaticDeliveryRoute()) {
+		t.Fatalf("preflight delivery routes = %#v, want static connect route", plan.DeliveryRoutes)
 	}
 }
 

--- a/internal/runtime/bus/connect_route_plan_dispatch_test.go
+++ b/internal/runtime/bus/connect_route_plan_dispatch_test.go
@@ -246,40 +246,7 @@ func TestEventBusPlan_ConnectRoutePlanPreservesReplyLineage(t *testing.T) {
 }
 
 func TestEventBusPublish_ConnectRoutePlanPersistsTargetSetFanout(t *testing.T) {
-	source := semanticview.Wrap(connectRoutePlanTestBundle([]connectRoutePlanTestFlow{
-		{
-			id:   "producer",
-			mode: "static",
-			outputs: []runtimecontracts.FlowOutputEventPin{{
-				Name:  "ticket_ready",
-				Event: "ticket.ready",
-			}},
-		},
-		{
-			id:   "worker",
-			mode: "template",
-			inputs: []runtimecontracts.FlowInputEventPin{{
-				Name:  "ticket_ready",
-				Event: "ticket.ready",
-				Address: &runtimecontracts.FlowInputPinAddress{
-					By:          "team_entity",
-					Source:      "payload.team_entity",
-					Target:      "entity.entity_id",
-					Cardinality: "many",
-				},
-			}},
-			nodes: map[string]runtimecontracts.SystemNodeContract{
-				"worker-node": {
-					ID:            "worker-{instance_id}",
-					EventHandlers: map[string]runtimecontracts.SystemNodeEventHandler{"ticket.ready": {}},
-				},
-			},
-		},
-	}, []runtimecontracts.FlowPackageConnect{{
-		From:     "producer.ticket_ready",
-		To:       "worker.ticket_ready",
-		Delivery: "many",
-	}}))
+	source := connectRoutePlanFanoutSource()
 	store := &connectRoutePlanDescriptorStore{
 		targetRouteMemoryStore: newTargetRouteMemoryStore(),
 		flowInstances: []ActiveFlowInstanceDescriptor{
@@ -314,6 +281,49 @@ func TestEventBusPublish_ConnectRoutePlanPersistsTargetSetFanout(t *testing.T) {
 	}
 	if len(routes) != 2 {
 		t.Fatalf("persisted delivery routes = %#v, want exactly two team-a fanout routes", routes)
+	}
+}
+
+func TestEventBusResetInMemoryStateRefreshesConnectRoutePlanner(t *testing.T) {
+	source := connectRoutePlanFanoutSource()
+	store := &connectRoutePlanDescriptorStore{
+		targetRouteMemoryStore: newTargetRouteMemoryStore(),
+		flowInstances:          []ActiveFlowInstanceDescriptor{{InstanceID: "alpha", EntityID: "team-a", FlowInstance: "worker/alpha"}},
+	}
+	eb, err := NewEventBusWithOptions(store, EventBusOptions{ContractBundle: source})
+	if err != nil {
+		t.Fatalf("NewEventBusWithOptions: %v", err)
+	}
+	if err := eb.AddFlowInstanceRoute(FlowInstanceRouteMaterializationRequest{
+		Identity: runtimeflowidentity.DeriveRoute("worker", "alpha"),
+	}); err != nil {
+		t.Fatalf("AddFlowInstanceRoute(alpha): %v", err)
+	}
+
+	if err := eb.ResetInMemoryState(); err != nil {
+		t.Fatalf("ResetInMemoryState: %v", err)
+	}
+	store.flowInstances = []ActiveFlowInstanceDescriptor{{InstanceID: "beta", EntityID: "team-a", FlowInstance: "worker/beta"}}
+	if err := eb.AddFlowInstanceRoute(FlowInstanceRouteMaterializationRequest{
+		Identity: runtimeflowidentity.DeriveRoute("worker", "beta"),
+	}); err != nil {
+		t.Fatalf("AddFlowInstanceRoute(beta): %v", err)
+	}
+
+	eventID := uuid.NewString()
+	evt := events.NewProjectionEvent(eventID,
+		events.EventType("producer/ticket.ready"), "", "", json.RawMessage(`{"team_entity":"team-a"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())
+	wantBeta := events.DeliveryRoute{SubscriberType: "node", SubscriberID: "worker-beta", Target: events.RouteIdentity{FlowID: "worker", FlowInstance: "worker/beta", EntityID: "team-a"}}
+
+	if err := eb.Publish(context.Background(), evt); err != nil {
+		t.Fatalf("Publish after reset: %v", err)
+	}
+	routes := store.routes[eventID]
+	if !deliveryRoutesContain(routes, wantBeta) {
+		t.Fatalf("persisted delivery routes = %#v, want refreshed beta route", routes)
+	}
+	if len(routes) != 1 {
+		t.Fatalf("persisted delivery routes = %#v, want only refreshed beta route", routes)
 	}
 }
 
@@ -445,6 +455,43 @@ func connectRoutePlanStaticDeliveryRoute() events.DeliveryRoute {
 			EntityID:     runtimeflowidentity.EntityID("consumer"),
 		},
 	}
+}
+
+func connectRoutePlanFanoutSource() semanticview.Source {
+	return semanticview.Wrap(connectRoutePlanTestBundle([]connectRoutePlanTestFlow{
+		{
+			id:   "producer",
+			mode: "static",
+			outputs: []runtimecontracts.FlowOutputEventPin{{
+				Name:  "ticket_ready",
+				Event: "ticket.ready",
+			}},
+		},
+		{
+			id:   "worker",
+			mode: "template",
+			inputs: []runtimecontracts.FlowInputEventPin{{
+				Name:  "ticket_ready",
+				Event: "ticket.ready",
+				Address: &runtimecontracts.FlowInputPinAddress{
+					By:          "team_entity",
+					Source:      "payload.team_entity",
+					Target:      "entity.entity_id",
+					Cardinality: "many",
+				},
+			}},
+			nodes: map[string]runtimecontracts.SystemNodeContract{
+				"worker-node": {
+					ID:            "worker-{instance_id}",
+					EventHandlers: map[string]runtimecontracts.SystemNodeEventHandler{"ticket.ready": {}},
+				},
+			},
+		},
+	}, []runtimecontracts.FlowPackageConnect{{
+		From:     "producer.ticket_ready",
+		To:       "worker.ticket_ready",
+		Delivery: "many",
+	}}))
 }
 
 func connectRoutePlanTestBundle(flows []connectRoutePlanTestFlow, connects []runtimecontracts.FlowPackageConnect) *runtimecontracts.WorkflowContractBundle {

--- a/internal/runtime/bus/connect_route_plan_dispatch_test.go
+++ b/internal/runtime/bus/connect_route_plan_dispatch_test.go
@@ -1,0 +1,525 @@
+package bus
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/division-sh/swarm/internal/events"
+	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
+	runtimeflowidentity "github.com/division-sh/swarm/internal/runtime/core/flowidentity"
+	runtimedeadletters "github.com/division-sh/swarm/internal/runtime/deadletters"
+	runtimeengine "github.com/division-sh/swarm/internal/runtime/engine"
+	"github.com/division-sh/swarm/internal/runtime/flowmodel"
+	runtimepipeline "github.com/division-sh/swarm/internal/runtime/pipeline"
+	runtimereplayclaim "github.com/division-sh/swarm/internal/runtime/replayclaim"
+	"github.com/division-sh/swarm/internal/runtime/semanticview"
+	"github.com/google/uuid"
+)
+
+type connectRoutePlanTestFlow struct {
+	id      string
+	mode    string
+	inputs  []runtimecontracts.FlowInputEventPin
+	outputs []runtimecontracts.FlowOutputEventPin
+	nodes   map[string]runtimecontracts.SystemNodeContract
+}
+
+type connectRoutePlanDescriptorStore struct {
+	*targetRouteMemoryStore
+	flowInstances []ActiveFlowInstanceDescriptor
+}
+
+type connectRoutePlanMutationStore struct {
+	*targetRouteMemoryStore
+}
+
+type targetRouteMemoryEventMutation struct {
+	ctx   context.Context
+	store *connectRoutePlanMutationStore
+}
+
+func (s *connectRoutePlanMutationStore) RunEventMutation(ctx context.Context, fn func(EventMutation) error) error {
+	mutation := &targetRouteMemoryEventMutation{store: s}
+	mutation.ctx = WithEventMutationContext(ctx, mutation)
+	return fn(mutation)
+}
+
+func (m *targetRouteMemoryEventMutation) Context() context.Context {
+	if m == nil || m.ctx == nil {
+		return context.Background()
+	}
+	return m.ctx
+}
+
+func (m *targetRouteMemoryEventMutation) AppendEvent(ctx context.Context, evt events.Event) error {
+	return m.store.AppendEvent(ctx, evt)
+}
+
+func (m *targetRouteMemoryEventMutation) InsertEventDeliveries(ctx context.Context, eventID string, agentIDs []string) error {
+	return m.store.InsertEventDeliveries(ctx, eventID, agentIDs)
+}
+
+func (m *targetRouteMemoryEventMutation) InsertEventDeliveriesWithTargets(ctx context.Context, eventID string, agentIDs []string, deliveryTargets map[string]events.RouteIdentity) error {
+	return m.InsertEventDeliveryRoutes(ctx, eventID, deliveryRoutesFromTargetMap(agentIDs, routePlanSubscriberAgent, deliveryTargets))
+}
+
+func (m *targetRouteMemoryEventMutation) InsertEventDeliveryRoutes(_ context.Context, eventID string, deliveryRoutes []events.DeliveryRoute) error {
+	if m.store.routes == nil {
+		m.store.routes = map[string][]events.DeliveryRoute{}
+	}
+	m.store.routes[eventID] = events.NormalizeDeliveryRoutes(deliveryRoutes)
+	return nil
+}
+
+func (m *targetRouteMemoryEventMutation) UpsertCommittedReplayScope(_ context.Context, eventID string, scope runtimereplayclaim.CommittedReplayScope) error {
+	m.store.scopes[eventID] = scope
+	return nil
+}
+
+func (m *targetRouteMemoryEventMutation) UpsertPipelineReceipt(ctx context.Context, eventID, status, errText string) error {
+	return m.store.UpsertPipelineReceipt(ctx, eventID, status, errText)
+}
+
+func (*targetRouteMemoryEventMutation) RecordDeadLetter(context.Context, runtimedeadletters.Record) error {
+	return nil
+}
+
+func (s *connectRoutePlanDescriptorStore) ListActiveFlowInstanceDescriptors(context.Context) ([]ActiveFlowInstanceDescriptor, error) {
+	return append([]ActiveFlowInstanceDescriptor(nil), s.flowInstances...), nil
+}
+
+func TestEventBusPublish_ConnectRoutePlanPersistsSingularTargetWithoutLiveSubscriber(t *testing.T) {
+	source := connectRoutePlanStaticSource(runtimecontracts.FlowPackageConnect{
+		From:     "producer.deploy_done",
+		To:       "consumer.deploy_completed",
+		Delivery: "one",
+	})
+	store := newTargetRouteMemoryStore()
+	eb, err := NewEventBusWithOptions(store, EventBusOptions{ContractBundle: source})
+	if err != nil {
+		t.Fatalf("NewEventBusWithOptions: %v", err)
+	}
+	eventID := uuid.NewString()
+	evt := events.NewProjectionEvent(eventID,
+		events.EventType("producer/deploy.done"), "", "", json.RawMessage(`{"ignored":"yes"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())
+	want := events.DeliveryRoute{
+		SubscriberType: "node",
+		SubscriberID:   "consumer-node",
+		Target: events.RouteIdentity{
+			FlowID:       "consumer",
+			FlowInstance: "consumer",
+			EntityID:     runtimeflowidentity.EntityID("consumer"),
+		},
+	}
+
+	plan, err := eb.CheckPublishRecipientPlan(context.Background(), evt)
+	if err != nil {
+		t.Fatalf("CheckPublishRecipientPlan: %v", err)
+	}
+	if plan.TargetFailure != "" {
+		t.Fatalf("target failure = %q, want none", plan.TargetFailure)
+	}
+	if !deliveryRoutesContain(plan.DeliveryRoutes, want) {
+		t.Fatalf("preflight delivery routes = %#v, want %#v", plan.DeliveryRoutes, want)
+	}
+
+	if err := eb.Publish(context.Background(), evt); err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+	if routes := store.routes[eventID]; !deliveryRoutesContain(routes, want) {
+		t.Fatalf("persisted delivery routes = %#v, want %#v", routes, want)
+	}
+	if got := store.scopes[eventID]; got != runtimereplayclaim.CommittedReplayScopeSubscribed {
+		t.Fatalf("committed replay scope = %q, want subscribed", got)
+	}
+	if got := store.receipts[eventID]; got != "processed" {
+		t.Fatalf("pipeline receipt = %q, want processed", got)
+	}
+	live, internal, replayRoutes, err := eb.replayRecipientsForCommittedEvent(context.Background(), evt, nil, runtimereplayclaim.CommittedReplayScopeSubscribed)
+	if err != nil {
+		t.Fatalf("replayRecipientsForCommittedEvent: %v", err)
+	}
+	if !containsString(live, "consumer-node") || !containsString(internal, "consumer-node") {
+		t.Fatalf("replay live=%#v internal=%#v, want consumer-node from persisted connect route", live, internal)
+	}
+	if !deliveryRoutesContain(replayRoutes, want) {
+		t.Fatalf("replay delivery routes = %#v, want %#v", replayRoutes, want)
+	}
+}
+
+func TestEventBusPublishInMutation_ConnectRoutePlanPersistsSharedRoutePlan(t *testing.T) {
+	source := connectRoutePlanStaticSource(runtimecontracts.FlowPackageConnect{
+		From:     "producer.deploy_done",
+		To:       "consumer.deploy_completed",
+		Delivery: "one",
+	})
+	store := &connectRoutePlanMutationStore{targetRouteMemoryStore: newTargetRouteMemoryStore()}
+	eb, err := NewEventBusWithOptions(store, EventBusOptions{ContractBundle: source})
+	if err != nil {
+		t.Fatalf("NewEventBusWithOptions: %v", err)
+	}
+	eventID := uuid.NewString()
+	evt := events.NewProjectionEvent(eventID,
+		events.EventType("producer/deploy.done"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Now().UTC())
+	want := connectRoutePlanStaticDeliveryRoute()
+	postCommitActions := make([]func(), 0, 1)
+	ctx := runtimepipeline.WithPipelinePostCommitActions(context.Background(), &postCommitActions)
+
+	if err := store.RunEventMutation(ctx, func(mutation EventMutation) error {
+		return eb.PublishInMutation(mutation.Context(), evt)
+	}); err != nil {
+		t.Fatalf("PublishInMutation: %v", err)
+	}
+	if routes := store.routes[eventID]; !deliveryRoutesContain(routes, want) {
+		t.Fatalf("persisted delivery routes = %#v, want %#v", routes, want)
+	}
+	if got := store.scopes[eventID]; got != runtimereplayclaim.CommittedReplayScopeSubscribed {
+		t.Fatalf("committed replay scope = %q, want subscribed", got)
+	}
+	runtimepipeline.FlushPipelinePostCommitActions(postCommitActions)
+	if got := store.receipts[eventID]; got != "processed" {
+		t.Fatalf("pipeline receipt = %q, want processed", got)
+	}
+}
+
+func TestEngineOutbox_ConnectRoutePlanPersistsSharedRoutePlan(t *testing.T) {
+	source := connectRoutePlanStaticSource(runtimecontracts.FlowPackageConnect{
+		From:     "producer.deploy_done",
+		To:       "consumer.deploy_completed",
+		Delivery: "one",
+	})
+	store := &connectRoutePlanMutationStore{targetRouteMemoryStore: newTargetRouteMemoryStore()}
+	eb, err := NewEventBusWithOptions(store, EventBusOptions{ContractBundle: source})
+	if err != nil {
+		t.Fatalf("NewEventBusWithOptions: %v", err)
+	}
+	eventID := uuid.NewString()
+	evt := events.NewProjectionEvent(eventID,
+		events.EventType("producer/deploy.done"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Now().UTC())
+	want := connectRoutePlanStaticDeliveryRoute()
+
+	if err := store.RunEventMutation(context.Background(), func(mutation EventMutation) error {
+		return eb.EngineOutbox().WriteOutbox(mutation.Context(), []runtimeengine.EmitIntent{{Event: evt}})
+	}); err != nil {
+		t.Fatalf("WriteOutbox: %v", err)
+	}
+	if routes := store.routes[eventID]; !deliveryRoutesContain(routes, want) {
+		t.Fatalf("persisted delivery routes = %#v, want %#v", routes, want)
+	}
+	if got := store.scopes[eventID]; got != runtimereplayclaim.CommittedReplayScopeSubscribed {
+		t.Fatalf("committed replay scope = %q, want subscribed", got)
+	}
+}
+
+func TestEventBusPlan_ConnectRoutePlanPreservesReplyLineage(t *testing.T) {
+	source := connectRoutePlanStaticSource(runtimecontracts.FlowPackageConnect{
+		From:     "producer.deploy_done",
+		To:       "consumer.deploy_completed",
+		Delivery: "reply",
+		Reply: map[string]string{
+			"correlation_id": "event.correlation_id",
+		},
+	})
+	eb, err := NewEventBusWithOptions(newTargetRouteMemoryStore(), EventBusOptions{ContractBundle: source})
+	if err != nil {
+		t.Fatalf("NewEventBusWithOptions: %v", err)
+	}
+	evt := events.NewProjectionEvent(uuid.NewString(),
+		events.EventType("producer/deploy.done"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Now().UTC())
+
+	plan, err := eb.planSubscribedRoutePlan(context.Background(), evt, false)
+	if err != nil {
+		t.Fatalf("planSubscribedRoutePlan: %v", err)
+	}
+	reply, ok := plan.ExtraDetail["connect_route_plan_reply"].(map[string]string)
+	if !ok {
+		t.Fatalf("connect_route_plan_reply = %#v, want map[string]string", plan.ExtraDetail["connect_route_plan_reply"])
+	}
+	if got, want := reply["correlation_id"], "event.correlation_id"; got != want {
+		t.Fatalf("reply correlation_id = %q, want %q", got, want)
+	}
+	if !deliveryRoutesContain(plan.DeliveryRoutes(), connectRoutePlanStaticDeliveryRoute()) {
+		t.Fatalf("delivery routes = %#v, want static connected route", plan.DeliveryRoutes())
+	}
+}
+
+func TestEventBusPublish_ConnectRoutePlanPersistsTargetSetFanout(t *testing.T) {
+	source := semanticview.Wrap(connectRoutePlanTestBundle([]connectRoutePlanTestFlow{
+		{
+			id:   "producer",
+			mode: "static",
+			outputs: []runtimecontracts.FlowOutputEventPin{{
+				Name:  "ticket_ready",
+				Event: "ticket.ready",
+			}},
+		},
+		{
+			id:   "worker",
+			mode: "template",
+			inputs: []runtimecontracts.FlowInputEventPin{{
+				Name:  "ticket_ready",
+				Event: "ticket.ready",
+				Address: &runtimecontracts.FlowInputPinAddress{
+					By:          "team_entity",
+					Source:      "payload.team_entity",
+					Target:      "entity.entity_id",
+					Cardinality: "many",
+				},
+			}},
+			nodes: map[string]runtimecontracts.SystemNodeContract{
+				"worker-node": {
+					ID:            "worker-{instance_id}",
+					EventHandlers: map[string]runtimecontracts.SystemNodeEventHandler{"ticket.ready": {}},
+				},
+			},
+		},
+	}, []runtimecontracts.FlowPackageConnect{{
+		From:     "producer.ticket_ready",
+		To:       "worker.ticket_ready",
+		Delivery: "many",
+	}}))
+	store := &connectRoutePlanDescriptorStore{
+		targetRouteMemoryStore: newTargetRouteMemoryStore(),
+		flowInstances: []ActiveFlowInstanceDescriptor{
+			{InstanceID: "alpha", EntityID: "team-a", FlowInstance: "worker/alpha"},
+			{InstanceID: "beta", EntityID: "team-a", FlowInstance: "worker/beta"},
+			{InstanceID: "gamma", EntityID: "team-b", FlowInstance: "worker/gamma"},
+		},
+	}
+	eb, err := NewEventBusWithOptions(store, EventBusOptions{ContractBundle: source})
+	if err != nil {
+		t.Fatalf("NewEventBusWithOptions: %v", err)
+	}
+	for _, instanceID := range []string{"alpha", "beta", "gamma"} {
+		if err := eb.AddFlowInstanceRoute(FlowInstanceRouteMaterializationRequest{
+			Identity: runtimeflowidentity.DeriveRoute("worker", instanceID),
+		}); err != nil {
+			t.Fatalf("AddFlowInstanceRoute(%s): %v", instanceID, err)
+		}
+	}
+	eventID := uuid.NewString()
+	evt := events.NewProjectionEvent(eventID,
+		events.EventType("producer/ticket.ready"), "", "", json.RawMessage(`{"team_entity":"team-a"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())
+	wantAlpha := events.DeliveryRoute{SubscriberType: "node", SubscriberID: "worker-alpha", Target: events.RouteIdentity{FlowID: "worker", FlowInstance: "worker/alpha", EntityID: "team-a"}}
+	wantBeta := events.DeliveryRoute{SubscriberType: "node", SubscriberID: "worker-beta", Target: events.RouteIdentity{FlowID: "worker", FlowInstance: "worker/beta", EntityID: "team-a"}}
+
+	if err := eb.Publish(context.Background(), evt); err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+	routes := store.routes[eventID]
+	if !deliveryRoutesContain(routes, wantAlpha) || !deliveryRoutesContain(routes, wantBeta) {
+		t.Fatalf("persisted delivery routes = %#v, want alpha and beta", routes)
+	}
+	if len(routes) != 2 {
+		t.Fatalf("persisted delivery routes = %#v, want exactly two team-a fanout routes", routes)
+	}
+}
+
+func TestEventBusPublish_ConnectRoutePlanFailsClosedForUnsupportedBusinessFieldTarget(t *testing.T) {
+	source := semanticview.Wrap(connectRoutePlanTestBundle([]connectRoutePlanTestFlow{
+		{
+			id:   "producer",
+			mode: "static",
+			outputs: []runtimecontracts.FlowOutputEventPin{{
+				Name:  "deploy_done",
+				Event: "deploy.done",
+			}},
+		},
+		{
+			id:   "consumer",
+			mode: "template",
+			inputs: []runtimecontracts.FlowInputEventPin{{
+				Name:  "deploy_completed",
+				Event: "deploy.completed",
+				Address: &runtimecontracts.FlowInputPinAddress{
+					By:          "vertical_id",
+					Source:      "payload.vertical_id",
+					Target:      "entity.vertical_id",
+					Cardinality: "one",
+				},
+			}},
+		},
+	}, []runtimecontracts.FlowPackageConnect{{
+		From:     "producer.deploy_done",
+		To:       "consumer.deploy_completed",
+		Delivery: "one",
+	}}))
+	store := &connectRoutePlanDescriptorStore{
+		targetRouteMemoryStore: newTargetRouteMemoryStore(),
+		flowInstances:          []ActiveFlowInstanceDescriptor{{InstanceID: "one", EntityID: "ent-1", FlowInstance: "consumer/one"}},
+	}
+	eb, err := NewEventBusWithOptions(store, EventBusOptions{ContractBundle: source})
+	if err != nil {
+		t.Fatalf("NewEventBusWithOptions: %v", err)
+	}
+	evt := events.NewProjectionEvent(uuid.NewString(),
+		events.EventType("producer/deploy.done"), "", "", json.RawMessage(`{"vertical_id":"v-1"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())
+
+	plan, err := eb.CheckPublishRecipientPlan(context.Background(), evt)
+	if err != nil {
+		t.Fatalf("CheckPublishRecipientPlan: %v", err)
+	}
+	if got, want := plan.TargetFailure, "route_plan_target_unsupported"; got != want {
+		t.Fatalf("target failure = %q, want %q", got, want)
+	}
+	if len(plan.DeliveryRoutes) != 0 {
+		t.Fatalf("delivery routes = %#v, want none on unsupported business-field target", plan.DeliveryRoutes)
+	}
+}
+
+func TestEventBusPublish_ConnectRoutePlanFailsClosedForInvalidLoweredPlan(t *testing.T) {
+	source := semanticview.Wrap(connectRoutePlanTestBundle([]connectRoutePlanTestFlow{
+		{
+			id:   "producer",
+			mode: "static",
+			outputs: []runtimecontracts.FlowOutputEventPin{{
+				Name:  "deploy_done",
+				Event: "deploy.done",
+			}},
+		},
+		{
+			id:     "consumer",
+			mode:   "static",
+			inputs: []runtimecontracts.FlowInputEventPin{{Name: "deploy_completed", Event: "deploy.completed"}},
+		},
+	}, []runtimecontracts.FlowPackageConnect{{
+		From:     "producer.deploy_done",
+		To:       "consumer.missing_input",
+		Delivery: "one",
+	}}))
+	eb, err := NewEventBusWithOptions(newTargetRouteMemoryStore(), EventBusOptions{ContractBundle: source})
+	if err != nil {
+		t.Fatalf("NewEventBusWithOptions: %v", err)
+	}
+	evt := events.NewProjectionEvent(uuid.NewString(),
+		events.EventType("producer/deploy.done"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Now().UTC())
+
+	plan, err := eb.CheckPublishRecipientPlan(context.Background(), evt)
+	if err != nil {
+		t.Fatalf("CheckPublishRecipientPlan: %v", err)
+	}
+	if got, want := plan.TargetFailure, "receiver_input_pin_missing"; got != want {
+		t.Fatalf("target failure = %q, want %q", got, want)
+	}
+	if len(plan.DeliveryRoutes) != 0 {
+		t.Fatalf("delivery routes = %#v, want none when lowered plan is invalid", plan.DeliveryRoutes)
+	}
+}
+
+func connectRoutePlanStaticSource(connect runtimecontracts.FlowPackageConnect) semanticview.Source {
+	return semanticview.Wrap(connectRoutePlanTestBundle([]connectRoutePlanTestFlow{
+		{
+			id:   "producer",
+			mode: "static",
+			outputs: []runtimecontracts.FlowOutputEventPin{{
+				Name:  "deploy_done",
+				Event: "deploy.done",
+			}},
+		},
+		{
+			id:   "consumer",
+			mode: "static",
+			inputs: []runtimecontracts.FlowInputEventPin{{
+				Name:  "deploy_completed",
+				Event: "deploy.completed",
+			}},
+			nodes: map[string]runtimecontracts.SystemNodeContract{
+				"consumer-node": {
+					ID:            "consumer-node",
+					EventHandlers: map[string]runtimecontracts.SystemNodeEventHandler{"deploy.completed": {}},
+				},
+			},
+		},
+	}, []runtimecontracts.FlowPackageConnect{connect}))
+}
+
+func connectRoutePlanStaticDeliveryRoute() events.DeliveryRoute {
+	return events.DeliveryRoute{
+		SubscriberType: "node",
+		SubscriberID:   "consumer-node",
+		Target: events.RouteIdentity{
+			FlowID:       "consumer",
+			FlowInstance: "consumer",
+			EntityID:     runtimeflowidentity.EntityID("consumer"),
+		},
+	}
+}
+
+func connectRoutePlanTestBundle(flows []connectRoutePlanTestFlow, connects []runtimecontracts.FlowPackageConnect) *runtimecontracts.WorkflowContractBundle {
+	children := make([]runtimecontracts.FlowContractView, 0, len(flows))
+	byID := make(map[string]*runtimecontracts.FlowContractView, len(flows))
+	flowSchemas := make(map[string]runtimecontracts.FlowSchemaDocument, len(flows))
+	flowInputs := make(map[string][]string, len(flows))
+	flowOutputs := make(map[string][]string, len(flows))
+	flowInputPins := make(map[string][]runtimecontracts.FlowInputEventPin, len(flows))
+	flowOutputPins := make(map[string][]runtimecontracts.FlowOutputEventPin, len(flows))
+	nodeHandlers := map[string]map[string]runtimecontracts.SystemNodeEventHandler{}
+	for _, flow := range flows {
+		schema := runtimecontracts.FlowSchemaDocument{
+			Mode: flow.mode,
+			Pins: runtimecontracts.FlowPins{
+				Inputs: runtimecontracts.FlowInputPins{
+					Events:    connectRoutePlanInputEvents(flow.inputs),
+					EventPins: flow.inputs,
+				},
+				Outputs: runtimecontracts.FlowOutputPins{
+					Events:    connectRoutePlanOutputEvents(flow.outputs),
+					EventPins: flow.outputs,
+				},
+			},
+		}
+		view := runtimecontracts.FlowContractView{
+			Paths:  runtimecontracts.FlowContractPaths{ID: flow.id, Flow: flow.id},
+			Schema: schema,
+			Path:   flow.id,
+			Nodes:  flow.nodes,
+		}
+		children = append(children, view)
+		viewCopy := view
+		byID[flow.id] = &viewCopy
+		flowSchemas[flow.id] = schema
+		flowInputs[flow.id] = append([]string(nil), schema.Pins.Inputs.Events...)
+		flowOutputs[flow.id] = append([]string(nil), schema.Pins.Outputs.Events...)
+		flowInputPins[flow.id] = append([]runtimecontracts.FlowInputEventPin(nil), flow.inputs...)
+		flowOutputPins[flow.id] = append([]runtimecontracts.FlowOutputEventPin(nil), flow.outputs...)
+		for _, node := range flow.nodes {
+			if len(node.EventHandlers) > 0 {
+				nodeHandlers[node.ID] = node.EventHandlers
+			}
+		}
+	}
+	root := runtimecontracts.FlowContractView{Children: children}
+	return &runtimecontracts.WorkflowContractBundle{
+		FlowTree: flowmodel.Tree[runtimecontracts.FlowContractView]{
+			Root: &root,
+			ByID: byID,
+		},
+		FlowSchemas: flowSchemas,
+		Semantics: runtimecontracts.WorkflowSemanticView{
+			FlowInputs:          flowInputs,
+			FlowOutputs:         flowOutputs,
+			FlowInputEventPins:  flowInputPins,
+			FlowOutputEventPins: flowOutputPins,
+			CompositionConnects: connects,
+			NodeHandlers:        nodeHandlers,
+		},
+	}
+}
+
+func connectRoutePlanInputEvents(pins []runtimecontracts.FlowInputEventPin) []string {
+	out := make([]string, 0, len(pins))
+	for _, pin := range pins {
+		out = append(out, pin.EventType())
+	}
+	return out
+}
+
+func connectRoutePlanOutputEvents(pins []runtimecontracts.FlowOutputEventPin) []string {
+	out := make([]string, 0, len(pins))
+	for _, pin := range pins {
+		out = append(out, pin.EventType())
+	}
+	return out
+}

--- a/internal/runtime/bus/connect_route_plan_dispatch_test.go
+++ b/internal/runtime/bus/connect_route_plan_dispatch_test.go
@@ -453,6 +453,59 @@ func TestEventBusPublish_ConnectRoutePlanFailsClosedForInvalidLoweredPlan(t *tes
 	}
 }
 
+func TestEventBusPublish_ConnectRoutePlanFailureSkipsRecipientPlanMaterializer(t *testing.T) {
+	source := semanticview.Wrap(connectRoutePlanTestBundle([]connectRoutePlanTestFlow{
+		{
+			id:   "producer",
+			mode: "static",
+			outputs: []runtimecontracts.FlowOutputEventPin{{
+				Name:  "deploy_done",
+				Event: "deploy.done",
+			}},
+		},
+		{
+			id:     "consumer",
+			mode:   "static",
+			inputs: []runtimecontracts.FlowInputEventPin{{Name: "deploy_completed", Event: "deploy.completed"}},
+		},
+	}, []runtimecontracts.FlowPackageConnect{{
+		From:     "producer.deploy_done",
+		To:       "consumer.missing_input",
+		Delivery: "one",
+	}}))
+	materializerCalled := false
+	eb, err := NewEventBusWithOptions(newTargetRouteMemoryStore(), EventBusOptions{
+		ContractBundle: source,
+		RecipientPlanMaterializer: func(context.Context, events.Event, PublishRecipientPlan) ([]events.DeliveryRoute, error) {
+			materializerCalled = true
+			return []events.DeliveryRoute{{
+				SubscriberType: "node",
+				SubscriberID:   "bogus-node",
+				Target:         events.RouteIdentity{FlowID: "bogus", FlowInstance: "bogus", EntityID: "bogus"},
+			}}, nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewEventBusWithOptions: %v", err)
+	}
+	evt := events.NewProjectionEvent(uuid.NewString(),
+		events.EventType("producer/deploy.done"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Now().UTC())
+
+	plan, err := eb.CheckPublishRecipientPlan(context.Background(), evt)
+	if err != nil {
+		t.Fatalf("CheckPublishRecipientPlan: %v", err)
+	}
+	if materializerCalled {
+		t.Fatalf("recipient plan materializer was called for matched lowered connect failure")
+	}
+	if got, want := plan.TargetFailure, "receiver_input_pin_missing"; got != want {
+		t.Fatalf("target failure = %q, want %q", got, want)
+	}
+	if len(plan.DeliveryRoutes) != 0 {
+		t.Fatalf("delivery routes = %#v, want none when matched lowered plan fails", plan.DeliveryRoutes)
+	}
+}
+
 func connectRoutePlanStaticSource(connect runtimecontracts.FlowPackageConnect) semanticview.Source {
 	return semanticview.Wrap(connectRoutePlanTestBundle([]connectRoutePlanTestFlow{
 		{

--- a/internal/runtime/bus/delivery_planner.go
+++ b/internal/runtime/bus/delivery_planner.go
@@ -103,13 +103,18 @@ func (p deliveryRecipientPolicy) Evaluate(ctx context.Context, evt events.Event,
 type deliveryPlanner struct {
 	routeResolver   deliveryRouteResolver
 	recipientPolicy deliveryRecipientPolicy
+	connectPlanner  connectRoutePlanResolver
 }
 
-func newDeliveryPlanner(routeResolver deliveryRouteResolver, recipientPolicy deliveryRecipientPolicy) deliveryPlanner {
-	return deliveryPlanner{
+func newDeliveryPlanner(routeResolver deliveryRouteResolver, recipientPolicy deliveryRecipientPolicy, connectPlanners ...connectRoutePlanResolver) deliveryPlanner {
+	planner := deliveryPlanner{
 		routeResolver:   routeResolver,
 		recipientPolicy: recipientPolicy,
 	}
+	if len(connectPlanners) > 0 {
+		planner.connectPlanner = connectPlanners[0]
+	}
+	return planner
 }
 
 func (p deliveryPlanner) Plan(ctx context.Context, evt events.Event) (eventDeliveryPlan, error) {
@@ -131,12 +136,45 @@ func (p deliveryPlanner) Plan(ctx context.Context, evt events.Event) (eventDeliv
 	routePlan.AddDeliveryIntents(routedNodeDeliveryIntentsForNoTargetEvent(evt, routing.RoutedRecipients, recipients, persisted)...)
 	routePlan.AddDeliveryIntents(targetedRoutedNodeDeliveryIntents(evt, routing.RoutedRecipients)...)
 	routePlan.AddDeliveryIntents(internalDeliveryIntentsForPlan(evt, recipients, persisted, routing.RoutedRecipients)...)
-	if routePlan.TargetFailure != "" && hasInternalRoutedSubscriberForTarget(evt, routing.RoutedRecipients) {
+	extraDetail := cloneAnyMap(routing.ExtraDetail)
+	connectPlan, err := p.connectPlanner.Plan(ctx, evt)
+	if err != nil {
+		return eventDeliveryPlan{}, err
+	}
+	connectFailure := false
+	if connectPlan.Matched {
+		extraDetail = map[string]any{}
+		routing.SubscribedRecipients = nil
+		if connectPlan.Failure != "" {
+			connectFailure = true
+			routePlan = newRoutePlan(evt)
+			routePlan.TargetFailure = connectPlan.Failure
+			routing.RoutedRecipients = nil
+			routing.SubscribedRecipients = nil
+			for key, value := range connectPlan.ExtraDetail {
+				extraDetail[key] = value
+			}
+		} else {
+			routePlan = newRoutePlan(evt)
+			routePlan.AddLiveRecipients(connectPlan.LiveRecipients...)
+			routePlan.AddDeliveryIntents(connectPlan.DeliveryIntents...)
+			if len(connectPlan.RoutedRecipients) > 0 {
+				routing.RoutedRecipients = dedupeSubscribers(connectPlan.RoutedRecipients)
+			}
+			for key, value := range connectPlan.ExtraDetail {
+				extraDetail[key] = value
+			}
+			if len(connectPlan.DeliveryIntents) > 0 {
+				routePlan.TargetFailure = ""
+			}
+		}
+	}
+	if !connectFailure && routePlan.TargetFailure != "" && hasInternalRoutedSubscriberForTarget(evt, routing.RoutedRecipients) {
 		routePlan.TargetFailure = ""
 	}
 	routePlan.RoutedRecipients = routing.RoutedRecipients
 	routePlan.SubscribedRecipients = routing.SubscribedRecipients
-	routePlan.ExtraDetail = routing.ExtraDetail
+	routePlan.ExtraDetail = extraDetail
 	return routePlan.EventDeliveryPlan(), nil
 }
 
@@ -184,6 +222,14 @@ func filteredRecipients(requested, allowed []string) []string {
 	return out
 }
 
+func cloneAnyMap(in map[string]any) map[string]any {
+	out := map[string]any{}
+	for key, value := range in {
+		out[key] = value
+	}
+	return out
+}
+
 func (eb *EventBus) newEventBusDeliveryPlanner() deliveryPlanner {
 	return newDeliveryPlanner(
 		deliveryRouteResolver{
@@ -196,6 +242,7 @@ func (eb *EventBus) newEventBusDeliveryPlanner() deliveryPlanner {
 			loadActiveAgentDescriptors:  eb.activeAgentDescriptors,
 			loadActiveTargetDescriptors: eb.activeTargetDescriptors,
 		},
+		eb.connectRoutePlanner,
 	)
 }
 

--- a/internal/runtime/bus/delivery_planner.go
+++ b/internal/runtime/bus/delivery_planner.go
@@ -122,6 +122,13 @@ func (p deliveryPlanner) Plan(ctx context.Context, evt events.Event) (eventDeliv
 	if evt.Type() == events.EventType("platform.runtime_log") {
 		return routePlan.EventDeliveryPlan(), nil
 	}
+	connectPlan, err := p.connectPlanner.Plan(ctx, evt)
+	if err != nil {
+		return eventDeliveryPlan{}, err
+	}
+	if connectPlan.Matched {
+		return eventDeliveryPlanFromConnectRouteDispatch(evt, connectPlan), nil
+	}
 	routing := p.routeResolver.Resolve(evt)
 	manifest, err := p.recipientPolicy.Evaluate(ctx, evt, routing.Recipients)
 	if err != nil {
@@ -137,45 +144,26 @@ func (p deliveryPlanner) Plan(ctx context.Context, evt events.Event) (eventDeliv
 	routePlan.AddDeliveryIntents(targetedRoutedNodeDeliveryIntents(evt, routing.RoutedRecipients)...)
 	routePlan.AddDeliveryIntents(internalDeliveryIntentsForPlan(evt, recipients, persisted, routing.RoutedRecipients)...)
 	extraDetail := cloneAnyMap(routing.ExtraDetail)
-	connectPlan, err := p.connectPlanner.Plan(ctx, evt)
-	if err != nil {
-		return eventDeliveryPlan{}, err
-	}
-	connectFailure := false
-	if connectPlan.Matched {
-		extraDetail = map[string]any{}
-		routing.SubscribedRecipients = nil
-		if connectPlan.Failure != "" {
-			connectFailure = true
-			routePlan = newRoutePlan(evt)
-			routePlan.TargetFailure = connectPlan.Failure
-			routing.RoutedRecipients = nil
-			routing.SubscribedRecipients = nil
-			for key, value := range connectPlan.ExtraDetail {
-				extraDetail[key] = value
-			}
-		} else {
-			routePlan = newRoutePlan(evt)
-			routePlan.AddLiveRecipients(connectPlan.LiveRecipients...)
-			routePlan.AddDeliveryIntents(connectPlan.DeliveryIntents...)
-			if len(connectPlan.RoutedRecipients) > 0 {
-				routing.RoutedRecipients = dedupeSubscribers(connectPlan.RoutedRecipients)
-			}
-			for key, value := range connectPlan.ExtraDetail {
-				extraDetail[key] = value
-			}
-			if len(connectPlan.DeliveryIntents) > 0 {
-				routePlan.TargetFailure = ""
-			}
-		}
-	}
-	if !connectFailure && routePlan.TargetFailure != "" && hasInternalRoutedSubscriberForTarget(evt, routing.RoutedRecipients) {
+	if routePlan.TargetFailure != "" && hasInternalRoutedSubscriberForTarget(evt, routing.RoutedRecipients) {
 		routePlan.TargetFailure = ""
 	}
 	routePlan.RoutedRecipients = routing.RoutedRecipients
 	routePlan.SubscribedRecipients = routing.SubscribedRecipients
 	routePlan.ExtraDetail = extraDetail
 	return routePlan.EventDeliveryPlan(), nil
+}
+
+func eventDeliveryPlanFromConnectRouteDispatch(evt events.Event, connectPlan connectRoutePlanDispatch) eventDeliveryPlan {
+	routePlan := newRoutePlan(evt)
+	if connectPlan.Failure != "" {
+		routePlan.TargetFailure = connectPlan.Failure
+	} else {
+		routePlan.AddLiveRecipients(connectPlan.LiveRecipients...)
+		routePlan.AddDeliveryIntents(connectPlan.DeliveryIntents...)
+	}
+	routePlan.RoutedRecipients = dedupeSubscribers(connectPlan.RoutedRecipients)
+	routePlan.ExtraDetail = cloneAnyMap(connectPlan.ExtraDetail)
+	return routePlan.EventDeliveryPlan()
 }
 
 func (p deliveryPlanner) PlanDirect(ctx context.Context, evt events.Event, recipients []string) (eventDeliveryPlan, error) {

--- a/internal/runtime/bus/eventbus.go
+++ b/internal/runtime/bus/eventbus.go
@@ -36,6 +36,7 @@ type EventBus struct {
 	pendingInternalByID         map[string][]events.DeliveryRoute
 	routeTable                  *RouteTable
 	runtimeAgentDescriptors     map[string]ActiveAgentDescriptor
+	connectRoutePlanner         connectRoutePlanResolver
 	deliveryPlanner             deliveryPlanner
 	interceptors                []EventInterceptor
 	interceptorProvider         func() []EventInterceptor
@@ -173,6 +174,7 @@ func NewEventBusWithOptions(store EventStore, opts EventBusOptions) (*EventBus, 
 		bundleSourceFact:            opts.BundleSourceFact.Normalized(),
 		testLifecycleProbe:          opts.TestLifecycleProbe,
 	}
+	eb.connectRoutePlanner = newConnectRoutePlanResolver(semanticSource, routeTable, eb.PinRoutingDescriptors)
 	eb.deliveryPlanner = eb.newEventBusDeliveryPlanner()
 	return eb, nil
 }

--- a/internal/runtime/bus/eventbus.go
+++ b/internal/runtime/bus/eventbus.go
@@ -174,9 +174,16 @@ func NewEventBusWithOptions(store EventStore, opts EventBusOptions) (*EventBus, 
 		bundleSourceFact:            opts.BundleSourceFact.Normalized(),
 		testLifecycleProbe:          opts.TestLifecycleProbe,
 	}
-	eb.connectRoutePlanner = newConnectRoutePlanResolver(semanticSource, routeTable, eb.PinRoutingDescriptors)
-	eb.deliveryPlanner = eb.newEventBusDeliveryPlanner()
+	eb.rebuildRoutePlanners()
 	return eb, nil
+}
+
+func (eb *EventBus) rebuildRoutePlanners() {
+	if eb == nil {
+		return
+	}
+	eb.connectRoutePlanner = newConnectRoutePlanResolver(eb.semanticSource, eb.routeTable, eb.PinRoutingDescriptors)
+	eb.deliveryPlanner = eb.newEventBusDeliveryPlanner()
 }
 
 func (eb *EventBus) SetRunDispatchGate(gate RunDispatchGate) {
@@ -331,6 +338,7 @@ func (eb *EventBus) ResetInMemoryState() error {
 		return err
 	}
 	eb.routeTable = routeTable
+	eb.rebuildRoutePlanners()
 	eb.inFlightPublishes.Store(0)
 	return nil
 }

--- a/internal/runtime/bus/eventbus_publish.go
+++ b/internal/runtime/bus/eventbus_publish.go
@@ -945,6 +945,9 @@ func (eb *EventBus) materializePublishRecipientPlan(ctx context.Context, evt eve
 	if eb == nil || eb.recipientPlanMaterializer == nil {
 		return plan, nil
 	}
+	if eventDeliveryPlanUsesConnectRoutePlan(plan) {
+		return plan, nil
+	}
 	routes, err := eb.recipientPlanMaterializer(ctx, evt, eb.publishRecipientPlan(evt, plan.CanonicalRoutePlan()))
 	if err != nil {
 		return eventDeliveryPlan{}, err
@@ -955,6 +958,26 @@ func (eb *EventBus) materializePublishRecipientPlan(ctx context.Context, evt eve
 	routePlan := plan.CanonicalRoutePlan()
 	routePlan.AddDeliveryIntents(routePlanDeliveryIntentsFromRoutes(routes, routePlanSourceRecipientMaterializer, routePlanReasonMaterializedRoute)...)
 	return plan.WithCanonicalRoutePlan(routePlan), nil
+}
+
+func eventDeliveryPlanUsesConnectRoutePlan(plan eventDeliveryPlan) bool {
+	routePlan := plan.CanonicalRoutePlan().Normalized()
+	for _, intent := range routePlan.DeliveryIntents {
+		if intent.Source == routePlanSourceConnectRoutePlan || intent.Reason == routePlanReasonLoweredConnectRoutePlan {
+			return true
+		}
+	}
+	for _, recipient := range routePlan.LiveRecipients {
+		if recipient.Source == routePlanSourceConnectRoutePlan || recipient.Reason == routePlanReasonLoweredConnectRoutePlan {
+			return true
+		}
+	}
+	for key := range routePlan.ExtraDetail {
+		if strings.HasPrefix(key, "connect_route_plan") || strings.HasPrefix(key, "connect_route_plans") {
+			return true
+		}
+	}
+	return false
 }
 
 func (eb *EventBus) authorizePublishRecipientPlan(ctx context.Context, evt events.Event, plan eventDeliveryPlan) error {

--- a/internal/runtime/bus/route_plan.go
+++ b/internal/runtime/bus/route_plan.go
@@ -19,6 +19,7 @@ const (
 	routePlanSourceRootNodeRoute         = "root_node_route"
 	routePlanSourceRootInputFlowNode     = "root_input_flow_node_route"
 	routePlanSourceRecipientMaterializer = "recipient_plan_materializer"
+	routePlanSourceConnectRoutePlan      = "connect_route_plan"
 	routePlanSourceLegacyProjection      = "legacy_projection"
 
 	routePlanReasonMatchedAgentSubscription = "matched_agent_subscription"
@@ -26,6 +27,7 @@ const (
 	routePlanReasonInternalCarrier          = "internal_carrier"
 	routePlanReasonRouteTableNode           = "route_table_node"
 	routePlanReasonMaterializedRoute        = "materialized_route"
+	routePlanReasonLoweredConnectRoutePlan  = "lowered_connect_route_plan"
 )
 
 // RoutePlan is the EventBus-owned publish-time route authority. It records the

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -494,8 +494,11 @@ contract_formats:
           - fail-closed TargetFailure values for missing, invalid, unsupported, unresolved, or unsubscribed lowered plans
           rule: |
             Supported EventBus subscribed publish planning MUST prefer a matched lowered ConnectRoutePlan over lower-precedence
-            RouteTable/subscriber, raw event-name, producer target, producer broadcast, or structural fallback routing.
+            RouteTable/subscriber, raw event-name, producer target, producer broadcast, legacy recipient-policy/descriptor,
+            or structural fallback routing.
             Publish, PublishInMutation, CheckPublishRecipientPlan, and engineOutbox MUST share this RoutePlan authority path.
+            Static lowered ConnectRoutePlan matches MUST NOT require or be blocked by legacy active-agent descriptor lookup;
+            descriptor loading is limited to lowered plans whose supported target form requires runtime resolution.
             When a lowered plan matches but cannot materialize or resolve to supported concrete receiver routes, planning MUST
             fail closed and MUST NOT preserve previously inferred live-subscriber fallback recipients. RouteTable may be used
             only as a consumer that locates the concrete receiver handler/carrier for the already-selected target route identity.
@@ -4870,8 +4873,9 @@ flow_model:
           rule: |
             Supported EventBus publish/preflight/outbox dispatch consumes lowered ConnectRoutePlan artifacts as the
             publish-time route authority. A matched lowered plan replaces lower-precedence RouteTable/live-subscriber/raw-name
-            inference for the publish operation. Singular, fanout, and reply plans materialize into typed RoutePlan delivery
-            intents before persistence; matching lowered-plan failures hard-cut legacy fallback delivery.
+            inference and legacy recipient-policy/descriptor evaluation for the publish operation. Singular, fanout, and reply
+            plans materialize into typed RoutePlan delivery intents before persistence; matching lowered-plan failures hard-cut
+            legacy fallback delivery.
           consumes:
           - implementation_slice_1472 typed ConnectRoutePlan artifacts
           - supported descriptor materialization targets from implementation_slice_1472

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -495,13 +495,15 @@ contract_formats:
           rule: |
             Supported EventBus subscribed publish planning MUST prefer a matched lowered ConnectRoutePlan over lower-precedence
             RouteTable/subscriber, raw event-name, producer target, producer broadcast, legacy recipient-policy/descriptor,
-            or structural fallback routing.
+            recipient-plan materializer, or structural fallback routing.
             Publish, PublishInMutation, CheckPublishRecipientPlan, and engineOutbox MUST share this RoutePlan authority path.
             Static lowered ConnectRoutePlan matches MUST NOT require or be blocked by legacy active-agent descriptor lookup;
             descriptor loading is limited to lowered plans whose supported target form requires runtime resolution.
             When a lowered plan matches but cannot materialize or resolve to supported concrete receiver routes, planning MUST
             fail closed and MUST NOT preserve previously inferred live-subscriber fallback recipients. RouteTable may be used
             only as a consumer that locates the concrete receiver handler/carrier for the already-selected target route identity.
+            A matched lowered ConnectRoutePlan decision, including fail-closed diagnostics, MUST NOT be repaired or augmented
+            by post-planning recipient materialization hooks.
           supported_surface:
           - static receiver singular delivery
           - identity-style template/dynamic receiver fanout through supported descriptor targets
@@ -4873,9 +4875,9 @@ flow_model:
           rule: |
             Supported EventBus publish/preflight/outbox dispatch consumes lowered ConnectRoutePlan artifacts as the
             publish-time route authority. A matched lowered plan replaces lower-precedence RouteTable/live-subscriber/raw-name
-            inference and legacy recipient-policy/descriptor evaluation for the publish operation. Singular, fanout, and reply
-            plans materialize into typed RoutePlan delivery intents before persistence; matching lowered-plan failures hard-cut
-            legacy fallback delivery.
+            inference, legacy recipient-policy/descriptor evaluation, and recipient-plan materialization for the publish
+            operation. Singular, fanout, and reply plans materialize into typed RoutePlan delivery intents before persistence;
+            matching lowered-plan failures hard-cut legacy fallback delivery and cannot be repaired by later materializer hooks.
           consumes:
           - implementation_slice_1472 typed ConnectRoutePlan artifacts
           - supported descriptor materialization targets from implementation_slice_1472

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -476,6 +476,40 @@ contract_formats:
           descriptor lookup, live carriers, and interceptors consume or observe
           RoutePlan results; they MUST NOT create, replace, or repair missing
           route authority.
+        lowered_connect_route_plan_consumption:
+          status: merge_bearing_runtime_behavior
+          implementation_slice: '#1473'
+          canonical_code_owner: internal/runtime/bus.RoutePlan via deliveryPlanner.Plan and connectRoutePlanResolver
+          consumes:
+          - internal/runtime/core/pinrouting.ConnectRoutePlan
+          - lowered connect-route failure issues from route_plan_lowering
+          - EventBus semantic source selected for the publish operation
+          - RouteTable concrete receiver subscribers only after a lowered plan selects the receiver route identity
+          - active flow-instance descriptors for supported identity-style addressed template targets
+          produces:
+          - typed RoutePlanDeliveryIntent rows with source=connect_route_plan and reason=lowered_connect_route_plan
+          - concrete delivery_target_route values for supported singular event.target delivery
+          - concrete delivery_target_route values for each supported event.target_set fanout member
+          - reply-lineage route metadata on the RoutePlan when delivery=reply carries reply context
+          - fail-closed TargetFailure values for missing, invalid, unsupported, unresolved, or unsubscribed lowered plans
+          rule: |
+            Supported EventBus subscribed publish planning MUST prefer a matched lowered ConnectRoutePlan over lower-precedence
+            RouteTable/subscriber, raw event-name, producer target, producer broadcast, or structural fallback routing.
+            Publish, PublishInMutation, CheckPublishRecipientPlan, and engineOutbox MUST share this RoutePlan authority path.
+            When a lowered plan matches but cannot materialize or resolve to supported concrete receiver routes, planning MUST
+            fail closed and MUST NOT preserve previously inferred live-subscriber fallback recipients. RouteTable may be used
+            only as a consumer that locates the concrete receiver handler/carrier for the already-selected target route identity.
+          supported_surface:
+          - static receiver singular delivery
+          - identity-style template/dynamic receiver fanout through supported descriptor targets
+          - reply delivery metadata preservation
+          - persisted delivery rows, pipeline receipts, and committed replay scope as separate owners
+          unsupported_or_split:
+            business_field_descriptor_targets: '#1479 owns typed descriptor/index materialization for targets such as entity.vertical_id.'
+            agent_node_emitter_parity: '#1474 remains open.'
+            producer_target_broadcast_retirement: '#1475 remains open.'
+            selected_contract_runfork_readiness: 'Tracked under #1466/watchlist; not closed by #1473.'
+            parent_composition_routing_closure: '#1466 remains open.'
         inputs:
           event_identity:
             fields:
@@ -1878,7 +1912,7 @@ engine:
       concrete route-plan facts. For pin-declared outputs, the platform routes by resolved source/target
       identity, not by unconstrained event-type broadcast.'
     canonical_owner: platform-spec.yaml#flow_model.flow_package.composition_routing
-    implementation_status: source_authority_promoted_runtime_migration_pending
+    implementation_status: source_authority_promoted_eventbus_dispatch_partial
     activation:
       rule: Pin routing activates when the emitter flow declares the emitted event in schema.yaml pins.outputs.events and the
         event is admitted through a valid lowered parent connect route, explicit dynamic target escape hatch, structural
@@ -4830,6 +4864,28 @@ flow_model:
             - recovery or retry work
             - agent/node delivery parity
             - producer target/broadcast retirement
+        implementation_slice_1473:
+          status: merge_bearing_runtime_behavior
+          canonical_code_owner: internal/runtime/bus.RoutePlan via deliveryPlanner.Plan and connectRoutePlanResolver
+          rule: |
+            Supported EventBus publish/preflight/outbox dispatch consumes lowered ConnectRoutePlan artifacts as the
+            publish-time route authority. A matched lowered plan replaces lower-precedence RouteTable/live-subscriber/raw-name
+            inference for the publish operation. Singular, fanout, and reply plans materialize into typed RoutePlan delivery
+            intents before persistence; matching lowered-plan failures hard-cut legacy fallback delivery.
+          consumes:
+          - implementation_slice_1472 typed ConnectRoutePlan artifacts
+          - supported descriptor materialization targets from implementation_slice_1472
+          - RouteTable concrete receiver subscribers only after target route identity selection
+          produces:
+          - persisted event_deliveries delivery_target_route rows for supported connected outputs
+          - pipeline receipt settlement through normal EventBus delivery consumers
+          - committed replay-scope rows separate from executable delivery rows
+          - fail-closed target diagnostics for unsupported or invalid lowered route plans
+          proof_obligations:
+          - Publish, PublishInMutation, CheckPublishRecipientPlan, and engineOutbox use the same corrected planner
+          - singular target, target_set fanout, and reply metadata are covered
+          - unsupported business-field descriptor targets remain fail-closed and split to #1479
+          - '#1473 does not close #1474, #1475, selected-contract runfork readiness, or #1466 parent closure'
         invalid_outputs:
         - raw same-name pin match used as final topology authority
         - live subscription list used to invent missing connect topology
@@ -4852,7 +4908,7 @@ flow_model:
         - Must not satisfy parent connect requirements for imported package public pins.
         - Must not be introduced as a producer route-default surface.
       split_boundaries:
-        runtime_route_consumption: Runtime RouteTable/EventBus/RoutePlan migration is a follow-up implementation child; this source-authority section does not claim runtime behavior closure.
+        runtime_route_consumption: '#1473 closes supported EventBus publish/preflight/outbox consumption of lowered ConnectRoutePlan artifacts only; selected-contract runfork readiness, full agent/node parity, producer target/broadcast retirement, and parent #1466 closure remain separate tracked work.'
         parser_model_support: Parser/model support beyond source-authority fixtures is follow-up unless an implementation gate explicitly widens.
         policy_credential_resolution: '#1453 remains separate.'
         wildcard_scoping: '#1454 remains separate.'


### PR DESCRIPTION
Closes #1473

## Summary

- Adds EventBus consumption of lowered `ConnectRoutePlan` artifacts as the supported publish-time `RoutePlan` authority.
- Routes supported connected output pins through typed delivery intents for singular target, target_set fanout, and reply metadata.
- Hard-cuts legacy subscriber/RouteTable fallback when a matched lowered plan is invalid, unsupported, unresolved, or unsubscribed.
- Updates `platform-spec.yaml` and apispec assertions for the shipped #1473 runtime behavior slice.

## Governing refs

- `platform-spec.yaml#contract_formats.event_schema.routing_derivation.route_plan_authority`
- `platform-spec.yaml#contract_formats.event_schema.routing_derivation.route_plan_authority.lowered_connect_route_plan_consumption`
- `platform-spec.yaml#flow_model.flow_package.composition_routing.route_plan_lowering.implementation_slice_1472`
- `platform-spec.yaml#flow_model.flow_package.composition_routing.route_plan_lowering.implementation_slice_1473`
- `platform-spec.yaml#engine.cross_flow_routing`
- Binding gate: #1473 approved first-slice boundary in https://github.com/division-sh/swarm/issues/1473#issuecomment-4795223838

## Semantic migration

- New canonical owner for this slice: EventBus `RoutePlan` through `deliveryPlanner.Plan` plus `connectRoutePlanResolver`, consuming `internal/runtime/core/pinrouting.ConnectRoutePlan`.
- Old producer/reader/writer paths now invalid for matched supported connect outputs: raw event-name topology repair, live subscriber list invention, producer `target`, producer `broadcast`, and RouteTable fallback as route authority.
- Production paths checked for surviving old behavior: `Publish`, `PublishInMutation`, `CheckPublishRecipientPlan`, and `engineOutbox` now share the corrected planner; replay consumes persisted delivery routes.
- Migration completeness: complete for #1473 supported EventBus publish/preflight/outbox dispatch; not claiming #1474, #1475, #1479, selected-contract runfork readiness, or parent #1466 closure.

## Verification

- `python3 -c 'import yaml, pathlib; yaml.safe_load(pathlib.Path("platform-spec.yaml").read_text())'`
- `go test ./internal/runtime/bus -run 'ConnectRoutePlan|EngineOutbox' -count=1`
- `go test ./internal/runtime/bus -count=1`
- `go test ./internal/runtime/core/pinrouting ./internal/runtime/bus ./internal/runtime/pipeline ./internal/runtime/runforkadmission ./internal/runtime/runforkexecution -run 'ConnectRoutePlan|RoutePlan|RecipientPlan|SelectedContract|WorkflowNode|Outbox|Replay|Delivery|RouteAuthority|CheckPublishRecipientPlan' -count=1`
- `go test ./internal/apispec ./internal/runtime/bus -count=1`
- `go test ./...`