### PR TITLE
[agent-a][issue #1482] Add explicit RoutePlan authority state

### DIFF
--- a/internal/runtime/bus/connect_route_plan_dispatch_test.go
+++ b/internal/runtime/bus/connect_route_plan_dispatch_test.go
@@ -254,6 +254,17 @@ func TestEngineOutbox_ConnectRoutePlanPersistsSharedRoutePlan(t *testing.T) {
 		events.EventType("producer/deploy.done"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Now().UTC())
 	want := connectRoutePlanStaticDeliveryRoute()
 
+	planned, err := (engineOutbox{bus: eb}).deliveryPlanForIntent(context.Background(), runtimeengine.EmitIntent{Event: evt})
+	if err != nil {
+		t.Fatalf("deliveryPlanForIntent: %v", err)
+	}
+	if planned.AuthorityState != RoutePlanAuthorityCanonicalMatched || planned.AuthorityOwner != routePlanSourceConnectRoutePlan {
+		t.Fatalf("outbox route plan authority = %q/%q, want matched connect route plan", planned.AuthorityState, planned.AuthorityOwner)
+	}
+	if !deliveryRoutesContain(planned.DeliveryRoutes(), want) {
+		t.Fatalf("outbox route plan delivery routes = %#v, want %#v", planned.DeliveryRoutes(), want)
+	}
+
 	if err := store.RunEventMutation(context.Background(), func(mutation EventMutation) error {
 		return eb.EngineOutbox().WriteOutbox(mutation.Context(), []runtimeengine.EmitIntent{{Event: evt}})
 	}); err != nil {
@@ -610,6 +621,35 @@ func TestRoutePlanCanonicalFailClosedDropsExecutableRoutes(t *testing.T) {
 	}
 	if len(got.LiveRecipients) != 0 || len(got.DeliveryIntents) != 0 || len(got.DeliveryRoutes()) != 0 || len(got.PersistedRecipientIDs()) != 0 {
 		t.Fatalf("fail-closed plan exposed executable routes: live=%#v intents=%#v routes=%#v persisted=%#v", got.LiveRecipients, got.DeliveryIntents, got.DeliveryRoutes(), got.PersistedRecipientIDs())
+	}
+}
+
+func TestRoutePlanProjectionPreservesAuthorityState(t *testing.T) {
+	evt := events.NewProjectionEvent(uuid.NewString(),
+		events.EventType("producer/deploy.done"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Now().UTC())
+	routePlan := newRoutePlan(evt)
+	routePlan.MarkCanonicalRouteMatched(routePlanSourceConnectRoutePlan)
+	routePlan.AddDeliveryIntents(RoutePlanDeliveryIntent{
+		SubscriberType: "node",
+		SubscriberID:   "consumer-node",
+		Target:         connectRoutePlanStaticDeliveryRoute().Target,
+		Source:         routePlanSourceConnectRoutePlan,
+		Reason:         routePlanReasonLoweredConnectRoutePlan,
+		Persist:        true,
+	})
+
+	projected := routePlan.EventDeliveryPlan()
+	canonical := projected.CanonicalRoutePlan()
+	if canonical.AuthorityState != RoutePlanAuthorityCanonicalMatched || canonical.AuthorityOwner != routePlanSourceConnectRoutePlan {
+		t.Fatalf("canonical route plan authority = %q/%q, want matched connect route plan", canonical.AuthorityState, canonical.AuthorityOwner)
+	}
+
+	replaced := projected.WithCanonicalRoutePlan(routePlan).CanonicalRoutePlan()
+	if replaced.AuthorityState != RoutePlanAuthorityCanonicalMatched || replaced.AuthorityOwner != routePlanSourceConnectRoutePlan {
+		t.Fatalf("replaced route plan authority = %q/%q, want matched connect route plan", replaced.AuthorityState, replaced.AuthorityOwner)
+	}
+	if !deliveryRoutesContain(replaced.DeliveryRoutes(), connectRoutePlanStaticDeliveryRoute()) {
+		t.Fatalf("replaced route plan delivery routes = %#v, want static connect route", replaced.DeliveryRoutes())
 	}
 }
 

--- a/internal/runtime/bus/connect_route_plan_dispatch_test.go
+++ b/internal/runtime/bus/connect_route_plan_dispatch_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/division-sh/swarm/internal/events"
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
 	runtimeflowidentity "github.com/division-sh/swarm/internal/runtime/core/flowidentity"
+	runtimepinrouting "github.com/division-sh/swarm/internal/runtime/core/pinrouting"
 	runtimedeadletters "github.com/division-sh/swarm/internal/runtime/deadletters"
 	runtimeengine "github.com/division-sh/swarm/internal/runtime/engine"
 	"github.com/division-sh/swarm/internal/runtime/flowmodel"
@@ -123,6 +124,17 @@ func TestEventBusPublish_ConnectRoutePlanPersistsSingularTargetWithoutLiveSubscr
 		},
 	}
 
+	routePlan, err := eb.planSubscribedRoutePlan(context.Background(), evt, false)
+	if err != nil {
+		t.Fatalf("planSubscribedRoutePlan: %v", err)
+	}
+	if routePlan.AuthorityState != RoutePlanAuthorityCanonicalMatched || routePlan.AuthorityOwner != routePlanSourceConnectRoutePlan {
+		t.Fatalf("route plan authority = %q/%q, want matched connect route plan", routePlan.AuthorityState, routePlan.AuthorityOwner)
+	}
+	if !deliveryRoutesContain(routePlan.DeliveryRoutes(), want) {
+		t.Fatalf("route plan delivery routes = %#v, want %#v", routePlan.DeliveryRoutes(), want)
+	}
+
 	plan, err := eb.CheckPublishRecipientPlan(context.Background(), evt)
 	if err != nil {
 		t.Fatalf("CheckPublishRecipientPlan: %v", err)
@@ -178,6 +190,13 @@ func TestEventBusCheckPublishRecipientPlan_ConnectRoutePlanPrecedesLegacyDescrip
 	}
 	if plan.TargetFailure != "" {
 		t.Fatalf("target failure = %q, want none", plan.TargetFailure)
+	}
+	routePlan, err := eb.planSubscribedRoutePlan(context.Background(), evt, false)
+	if err != nil {
+		t.Fatalf("planSubscribedRoutePlan: %v", err)
+	}
+	if routePlan.AuthorityState != RoutePlanAuthorityCanonicalMatched || routePlan.AuthorityOwner != routePlanSourceConnectRoutePlan {
+		t.Fatalf("route plan authority = %q/%q, want matched connect route plan", routePlan.AuthorityState, routePlan.AuthorityOwner)
 	}
 	if !deliveryRoutesContain(plan.DeliveryRoutes, connectRoutePlanStaticDeliveryRoute()) {
 		t.Fatalf("preflight delivery routes = %#v, want static connect route", plan.DeliveryRoutes)
@@ -441,6 +460,20 @@ func TestEventBusPublish_ConnectRoutePlanFailsClosedForInvalidLoweredPlan(t *tes
 	evt := events.NewProjectionEvent(uuid.NewString(),
 		events.EventType("producer/deploy.done"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Now().UTC())
 
+	routePlan, err := eb.planSubscribedRoutePlan(context.Background(), evt, false)
+	if err != nil {
+		t.Fatalf("planSubscribedRoutePlan: %v", err)
+	}
+	if routePlan.AuthorityState != RoutePlanAuthorityCanonicalFailedClosed || routePlan.AuthorityOwner != routePlanSourceConnectRoutePlan {
+		t.Fatalf("route plan authority = %q/%q, want fail-closed connect route plan", routePlan.AuthorityState, routePlan.AuthorityOwner)
+	}
+	if got, want := routePlan.TargetFailure, runtimepinrouting.TargetFailure("receiver_input_pin_missing"); got != want {
+		t.Fatalf("target failure = %q, want %q", got, want)
+	}
+	if len(routePlan.LiveRecipients) != 0 || len(routePlan.DeliveryIntents) != 0 || len(routePlan.DeliveryRoutes()) != 0 {
+		t.Fatalf("fail-closed plan has executable routes: live=%#v intents=%#v routes=%#v", routePlan.LiveRecipients, routePlan.DeliveryIntents, routePlan.DeliveryRoutes())
+	}
+
 	plan, err := eb.CheckPublishRecipientPlan(context.Background(), evt)
 	if err != nil {
 		t.Fatalf("CheckPublishRecipientPlan: %v", err)
@@ -491,6 +524,20 @@ func TestEventBusPublish_ConnectRoutePlanFailureSkipsRecipientPlanMaterializer(t
 	evt := events.NewProjectionEvent(uuid.NewString(),
 		events.EventType("producer/deploy.done"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Now().UTC())
 
+	routePlan, err := eb.planSubscribedRoutePlan(context.Background(), evt, false)
+	if err != nil {
+		t.Fatalf("planSubscribedRoutePlan: %v", err)
+	}
+	if materializerCalled {
+		t.Fatalf("recipient plan materializer was called for matched lowered connect failure")
+	}
+	if routePlan.AuthorityState != RoutePlanAuthorityCanonicalFailedClosed || routePlan.AuthorityOwner != routePlanSourceConnectRoutePlan {
+		t.Fatalf("route plan authority = %q/%q, want fail-closed connect route plan", routePlan.AuthorityState, routePlan.AuthorityOwner)
+	}
+	if len(routePlan.LiveRecipients) != 0 || len(routePlan.DeliveryIntents) != 0 || len(routePlan.DeliveryRoutes()) != 0 {
+		t.Fatalf("fail-closed plan has executable routes: live=%#v intents=%#v routes=%#v", routePlan.LiveRecipients, routePlan.DeliveryIntents, routePlan.DeliveryRoutes())
+	}
+
 	plan, err := eb.CheckPublishRecipientPlan(context.Background(), evt)
 	if err != nil {
 		t.Fatalf("CheckPublishRecipientPlan: %v", err)
@@ -503,6 +550,66 @@ func TestEventBusPublish_ConnectRoutePlanFailureSkipsRecipientPlanMaterializer(t
 	}
 	if len(plan.DeliveryRoutes) != 0 {
 		t.Fatalf("delivery routes = %#v, want none when matched lowered plan fails", plan.DeliveryRoutes)
+	}
+}
+
+func TestEventBusPlan_UnmatchedCanonicalRouteUsesLowerPrecedenceFallback(t *testing.T) {
+	eb, err := NewEventBus(InMemoryEventStore{})
+	if err != nil {
+		t.Fatalf("NewEventBus: %v", err)
+	}
+	ch := eb.Subscribe("legacy-agent", events.EventType("legacy.event"))
+	defer eb.Unsubscribe("legacy-agent")
+	evt := events.NewProjectionEvent(uuid.NewString(),
+		events.EventType("legacy.event"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Now().UTC())
+
+	routePlan, err := eb.planSubscribedRoutePlan(context.Background(), evt, false)
+	if err != nil {
+		t.Fatalf("planSubscribedRoutePlan: %v", err)
+	}
+	if routePlan.AuthorityState != RoutePlanAuthorityLowerPrecedence || routePlan.AuthorityOwner != routePlanSourceAgentPolicy {
+		t.Fatalf("route plan authority = %q/%q, want lower-precedence agent policy", routePlan.AuthorityState, routePlan.AuthorityOwner)
+	}
+	if !containsString(routePlan.RecipientIDs(), "legacy-agent") {
+		t.Fatalf("route plan recipients = %#v, want legacy-agent", routePlan.RecipientIDs())
+	}
+
+	if err := eb.Publish(context.Background(), evt); err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+	requireBusEvent(t, ch, "legacy fallback delivery")
+}
+
+func TestRoutePlanCanonicalFailClosedDropsExecutableRoutes(t *testing.T) {
+	evt := events.NewProjectionEvent(uuid.NewString(),
+		events.EventType("producer/deploy.done"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Now().UTC())
+	routePlan := newRoutePlan(evt)
+	routePlan.MarkCanonicalRouteFailedClosed(routePlanSourceConnectRoutePlan, runtimepinrouting.FailureTargetNotSubscribed)
+	routePlan.AddLiveRecipients(RoutePlanLiveRecipient{
+		RecipientID:       "bogus-node",
+		SubscriberType:    "node",
+		PersistAsDelivery: true,
+		Source:            routePlanSourceRecipientMaterializer,
+		Reason:            routePlanReasonMaterializedRoute,
+	})
+	routePlan.AddDeliveryIntents(RoutePlanDeliveryIntent{
+		SubscriberType: "node",
+		SubscriberID:   "bogus-node",
+		Target:         events.RouteIdentity{FlowID: "bogus", FlowInstance: "bogus", EntityID: "bogus"},
+		Source:         routePlanSourceRecipientMaterializer,
+		Reason:         routePlanReasonMaterializedRoute,
+		Persist:        true,
+	})
+
+	got := routePlan.Normalized()
+	if got.AuthorityState != RoutePlanAuthorityCanonicalFailedClosed || got.AuthorityOwner != routePlanSourceConnectRoutePlan {
+		t.Fatalf("route plan authority = %q/%q, want fail-closed connect route plan", got.AuthorityState, got.AuthorityOwner)
+	}
+	if got.TargetFailure != runtimepinrouting.FailureTargetNotSubscribed {
+		t.Fatalf("target failure = %q, want %q", got.TargetFailure, runtimepinrouting.FailureTargetNotSubscribed)
+	}
+	if len(got.LiveRecipients) != 0 || len(got.DeliveryIntents) != 0 || len(got.DeliveryRoutes()) != 0 || len(got.PersistedRecipientIDs()) != 0 {
+		t.Fatalf("fail-closed plan exposed executable routes: live=%#v intents=%#v routes=%#v persisted=%#v", got.LiveRecipients, got.DeliveryIntents, got.DeliveryRoutes(), got.PersistedRecipientIDs())
 	}
 }
 

--- a/internal/runtime/bus/delivery_planner.go
+++ b/internal/runtime/bus/delivery_planner.go
@@ -156,8 +156,9 @@ func (p deliveryPlanner) Plan(ctx context.Context, evt events.Event) (eventDeliv
 func eventDeliveryPlanFromConnectRouteDispatch(evt events.Event, connectPlan connectRoutePlanDispatch) eventDeliveryPlan {
 	routePlan := newRoutePlan(evt)
 	if connectPlan.Failure != "" {
-		routePlan.TargetFailure = connectPlan.Failure
+		routePlan.MarkCanonicalRouteFailedClosed(routePlanSourceConnectRoutePlan, connectPlan.Failure)
 	} else {
+		routePlan.MarkCanonicalRouteMatched(routePlanSourceConnectRoutePlan)
 		routePlan.AddLiveRecipients(connectPlan.LiveRecipients...)
 		routePlan.AddDeliveryIntents(connectPlan.DeliveryIntents...)
 	}

--- a/internal/runtime/bus/eventbus_publish.go
+++ b/internal/runtime/bus/eventbus_publish.go
@@ -945,39 +945,20 @@ func (eb *EventBus) materializePublishRecipientPlan(ctx context.Context, evt eve
 	if eb == nil || eb.recipientPlanMaterializer == nil {
 		return plan, nil
 	}
-	if eventDeliveryPlanUsesConnectRoutePlan(plan) {
+	routePlan := plan.CanonicalRoutePlan()
+	if !routePlan.AllowsLowerPrecedenceRouteProduction() {
 		return plan, nil
 	}
-	routes, err := eb.recipientPlanMaterializer(ctx, evt, eb.publishRecipientPlan(evt, plan.CanonicalRoutePlan()))
+	routes, err := eb.recipientPlanMaterializer(ctx, evt, eb.publishRecipientPlan(evt, routePlan))
 	if err != nil {
 		return eventDeliveryPlan{}, err
 	}
 	if len(routes) == 0 {
 		return plan, nil
 	}
-	routePlan := plan.CanonicalRoutePlan()
+	routePlan.MarkLowerPrecedenceRouteProduction(routePlanSourceRecipientMaterializer)
 	routePlan.AddDeliveryIntents(routePlanDeliveryIntentsFromRoutes(routes, routePlanSourceRecipientMaterializer, routePlanReasonMaterializedRoute)...)
 	return plan.WithCanonicalRoutePlan(routePlan), nil
-}
-
-func eventDeliveryPlanUsesConnectRoutePlan(plan eventDeliveryPlan) bool {
-	routePlan := plan.CanonicalRoutePlan().Normalized()
-	for _, intent := range routePlan.DeliveryIntents {
-		if intent.Source == routePlanSourceConnectRoutePlan || intent.Reason == routePlanReasonLoweredConnectRoutePlan {
-			return true
-		}
-	}
-	for _, recipient := range routePlan.LiveRecipients {
-		if recipient.Source == routePlanSourceConnectRoutePlan || recipient.Reason == routePlanReasonLoweredConnectRoutePlan {
-			return true
-		}
-	}
-	for key := range routePlan.ExtraDetail {
-		if strings.HasPrefix(key, "connect_route_plan") || strings.HasPrefix(key, "connect_route_plans") {
-			return true
-		}
-	}
-	return false
 }
 
 func (eb *EventBus) authorizePublishRecipientPlan(ctx context.Context, evt events.Event, plan eventDeliveryPlan) error {

--- a/internal/runtime/bus/eventbus_target_routes_test.go
+++ b/internal/runtime/bus/eventbus_target_routes_test.go
@@ -207,8 +207,12 @@ func TestEventBusRecipientPlanMaterializerNormalizesIntoCanonicalRoutePlan(t *te
 		t.Fatalf("NewEventBusWithOptions: %v", err)
 	}
 	evt := events.NewProjectionEvent(uuid.NewString(), events.EventType("review/inst-1/task.started"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{})
+	emptyAgentPolicyPlan := routePlanFromManifest(evt, deliveryRecipientManifest{}, routePlanSourceAgentPolicy, routePlanReasonMatchedAgentSubscription)
+	if emptyAgentPolicyPlan.AuthorityState != RoutePlanAuthorityNoCanonicalMatch || emptyAgentPolicyPlan.AuthorityOwner != "" {
+		t.Fatalf("empty agent-policy route plan authority = %q/%q, want no canonical match", emptyAgentPolicyPlan.AuthorityState, emptyAgentPolicyPlan.AuthorityOwner)
+	}
 
-	plan, err := eb.materializePublishRecipientPlan(context.Background(), evt, newRoutePlan(evt).EventDeliveryPlan())
+	plan, err := eb.materializePublishRecipientPlan(context.Background(), evt, emptyAgentPolicyPlan.EventDeliveryPlan())
 	if err != nil {
 		t.Fatalf("materializePublishRecipientPlan: %v", err)
 	}

--- a/internal/runtime/bus/eventbus_target_routes_test.go
+++ b/internal/runtime/bus/eventbus_target_routes_test.go
@@ -215,6 +215,9 @@ func TestEventBusRecipientPlanMaterializerNormalizesIntoCanonicalRoutePlan(t *te
 	if got, wantLen := len(plan.RoutePlan.DeliveryIntents), 1; got != wantLen {
 		t.Fatalf("route plan delivery intents = %d, want %d", got, wantLen)
 	}
+	if plan.RoutePlan.AuthorityState != RoutePlanAuthorityLowerPrecedence || plan.RoutePlan.AuthorityOwner != routePlanSourceRecipientMaterializer {
+		t.Fatalf("route plan authority = %q/%q, want lower-precedence materializer", plan.RoutePlan.AuthorityState, plan.RoutePlan.AuthorityOwner)
+	}
 	intent := plan.RoutePlan.DeliveryIntents[0]
 	if intent.SubscriberType != want.SubscriberType || intent.SubscriberID != want.SubscriberID || intent.Target != want.Target {
 		t.Fatalf("route plan delivery intent = %#v, want route %#v", intent, want)

--- a/internal/runtime/bus/route_plan.go
+++ b/internal/runtime/bus/route_plan.go
@@ -400,10 +400,12 @@ func routePlanDeliveryIntentsFromRoutes(routes []events.DeliveryRoute, source, r
 
 func routePlanFromManifest(evt events.Event, manifest deliveryRecipientManifest, source, reason string) RoutePlan {
 	plan := newRoutePlan(evt)
-	plan.MarkLowerPrecedenceRouteProduction(source)
 	plan.AddLiveRecipients(routePlanLiveRecipientsFromManifest(manifest, source, reason)...)
 	plan.AddDeliveryIntents(routePlanDeliveryIntentsFromRoutes(manifest.DeliveryRoutes, source, reason)...)
 	plan.TargetFailure = manifest.TargetFailure
+	if len(plan.LiveRecipients) > 0 || len(plan.DeliveryIntents) > 0 || plan.TargetFailure != "" {
+		plan.MarkLowerPrecedenceRouteProduction(source)
+	}
 	return plan.Normalized()
 }
 

--- a/internal/runtime/bus/route_plan.go
+++ b/internal/runtime/bus/route_plan.go
@@ -30,11 +30,22 @@ const (
 	routePlanReasonLoweredConnectRoutePlan  = "lowered_connect_route_plan"
 )
 
+type RoutePlanAuthorityState string
+
+const (
+	RoutePlanAuthorityNoCanonicalMatch      RoutePlanAuthorityState = "no_canonical_match"
+	RoutePlanAuthorityCanonicalMatched      RoutePlanAuthorityState = "canonical_matched"
+	RoutePlanAuthorityCanonicalFailedClosed RoutePlanAuthorityState = "canonical_failed_closed"
+	RoutePlanAuthorityLowerPrecedence       RoutePlanAuthorityState = "lower_precedence"
+)
+
 // RoutePlan is the EventBus-owned publish-time route authority. It records the
 // typed delivery intents that should be persisted and the live dispatch
 // recipients that remain only projections/consumers of that authority.
 type RoutePlan struct {
 	Event                events.Event
+	AuthorityState       RoutePlanAuthorityState
+	AuthorityOwner       string
 	LiveRecipients       []RoutePlanLiveRecipient
 	DeliveryIntents      []RoutePlanDeliveryIntent
 	RoutedRecipients     []Subscriber
@@ -64,10 +75,12 @@ type RoutePlanDeliveryIntent struct {
 }
 
 func newRoutePlan(evt events.Event) RoutePlan {
-	return RoutePlan{Event: evt}
+	return RoutePlan{Event: evt, AuthorityState: RoutePlanAuthorityNoCanonicalMatch}
 }
 
 func (p RoutePlan) Normalized() RoutePlan {
+	p.AuthorityState = normalizeRoutePlanAuthorityState(p.AuthorityState)
+	p.AuthorityOwner = strings.TrimSpace(p.AuthorityOwner)
 	p.LiveRecipients = normalizeRoutePlanLiveRecipients(p.LiveRecipients)
 	p.DeliveryIntents = normalizeRoutePlanDeliveryIntents(p.DeliveryIntents)
 	p.RoutedRecipients = append([]Subscriber(nil), p.RoutedRecipients...)
@@ -79,7 +92,65 @@ func (p RoutePlan) Normalized() RoutePlan {
 		evt := *p.CycleEscalation
 		p.CycleEscalation = &evt
 	}
+	if p.AuthorityState == RoutePlanAuthorityCanonicalMatched && p.TargetFailure != "" {
+		p.AuthorityState = RoutePlanAuthorityCanonicalFailedClosed
+	}
+	if p.AuthorityState == RoutePlanAuthorityCanonicalFailedClosed {
+		p.LiveRecipients = nil
+		p.DeliveryIntents = nil
+		p.RoutedRecipients = nil
+		p.SubscribedRecipients = nil
+	}
 	return p
+}
+
+func (p *RoutePlan) MarkCanonicalRouteMatched(owner string) {
+	if p == nil {
+		return
+	}
+	p.AuthorityState = RoutePlanAuthorityCanonicalMatched
+	p.AuthorityOwner = strings.TrimSpace(owner)
+}
+
+func (p *RoutePlan) MarkCanonicalRouteFailedClosed(owner string, failure runtimepinrouting.TargetFailure) {
+	if p == nil {
+		return
+	}
+	p.AuthorityState = RoutePlanAuthorityCanonicalFailedClosed
+	p.AuthorityOwner = strings.TrimSpace(owner)
+	p.TargetFailure = runtimepinrouting.TargetFailure(strings.TrimSpace(string(failure)))
+	p.LiveRecipients = nil
+	p.DeliveryIntents = nil
+	p.RoutedRecipients = nil
+	p.SubscribedRecipients = nil
+}
+
+func (p *RoutePlan) MarkLowerPrecedenceRouteProduction(owner string) {
+	if p == nil || p.CanonicalRouteOwnerMatched() {
+		return
+	}
+	p.AuthorityState = RoutePlanAuthorityLowerPrecedence
+	if strings.TrimSpace(p.AuthorityOwner) == "" {
+		p.AuthorityOwner = strings.TrimSpace(owner)
+	}
+}
+
+func (p RoutePlan) CanonicalRouteOwnerMatched() bool {
+	switch normalizeRoutePlanAuthorityState(p.AuthorityState) {
+	case RoutePlanAuthorityCanonicalMatched, RoutePlanAuthorityCanonicalFailedClosed:
+		return true
+	default:
+		return false
+	}
+}
+
+func (p RoutePlan) AllowsLowerPrecedenceRouteProduction() bool {
+	switch normalizeRoutePlanAuthorityState(p.AuthorityState) {
+	case RoutePlanAuthorityNoCanonicalMatch, RoutePlanAuthorityLowerPrecedence:
+		return true
+	default:
+		return false
+	}
 }
 
 func (p *RoutePlan) AddLiveRecipients(recipients ...RoutePlanLiveRecipient) {
@@ -238,6 +309,9 @@ func (p eventDeliveryPlan) WithCanonicalRoutePlan(routePlan RoutePlan) eventDeli
 
 func routePlanFromLegacyEventDeliveryPlan(plan eventDeliveryPlan) RoutePlan {
 	out := newRoutePlan(plan.Event)
+	if len(plan.Recipients) > 0 || len(plan.PersistedRecipients) > 0 || len(plan.DeliveryRoutes) > 0 || plan.TargetFailure != "" {
+		out.MarkLowerPrecedenceRouteProduction(routePlanSourceLegacyProjection)
+	}
 	persisted := make(map[string]struct{}, len(plan.PersistedRecipients))
 	for _, recipient := range uniqueStrings(plan.PersistedRecipients) {
 		persisted[recipient] = struct{}{}
@@ -326,10 +400,24 @@ func routePlanDeliveryIntentsFromRoutes(routes []events.DeliveryRoute, source, r
 
 func routePlanFromManifest(evt events.Event, manifest deliveryRecipientManifest, source, reason string) RoutePlan {
 	plan := newRoutePlan(evt)
+	plan.MarkLowerPrecedenceRouteProduction(source)
 	plan.AddLiveRecipients(routePlanLiveRecipientsFromManifest(manifest, source, reason)...)
 	plan.AddDeliveryIntents(routePlanDeliveryIntentsFromRoutes(manifest.DeliveryRoutes, source, reason)...)
 	plan.TargetFailure = manifest.TargetFailure
 	return plan.Normalized()
+}
+
+func normalizeRoutePlanAuthorityState(state RoutePlanAuthorityState) RoutePlanAuthorityState {
+	switch RoutePlanAuthorityState(strings.TrimSpace(string(state))) {
+	case RoutePlanAuthorityCanonicalMatched:
+		return RoutePlanAuthorityCanonicalMatched
+	case RoutePlanAuthorityCanonicalFailedClosed:
+		return RoutePlanAuthorityCanonicalFailedClosed
+	case RoutePlanAuthorityLowerPrecedence:
+		return RoutePlanAuthorityLowerPrecedence
+	default:
+		return RoutePlanAuthorityNoCanonicalMatch
+	}
 }
 
 func normalizeRoutePlanLiveRecipients(in []RoutePlanLiveRecipient) []RoutePlanLiveRecipient {

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -476,6 +476,34 @@ contract_formats:
           descriptor lookup, live carriers, and interceptors consume or observe
           RoutePlan results; they MUST NOT create, replace, or repair missing
           route authority.
+        decision_state:
+          status: merge_bearing_runtime_behavior
+          implementation_slice: '#1482'
+          canonical_code_owner: internal/runtime/bus.RoutePlan.AuthorityState
+          states:
+          - no_canonical_match
+          - canonical_matched
+          - canonical_failed_closed
+          - lower_precedence
+          rule: |
+            RoutePlan authority decisions MUST be represented by first-class
+            runtime state, not reconstructed from ExtraDetail, TargetFailure,
+            Source, Reason, or prose diagnostics. no_canonical_match means no
+            canonical route owner matched the publish operation and lower-
+            precedence route production may run. canonical_matched means a
+            canonical route owner matched and produced executable recipients;
+            lower-precedence producers such as legacy recipient materializers
+            MUST NOT add, replace, or repair routes afterward.
+            canonical_failed_closed means a canonical route owner matched and
+            failed closed; the final RoutePlan MUST expose zero executable
+            LiveRecipients, DeliveryIntents, DeliveryRoutes, and persisted
+            recipients unless a later spec explicitly defines partial-delivery
+            semantics. lower_precedence means legacy or compatibility route
+            production was used only after no canonical owner matched.
+            Publish, PublishInMutation, CheckPublishRecipientPlan, and
+            engineOutbox MUST preserve this decision state across RoutePlan
+            projection, materialization, diagnostics, persistence, and delivery
+            consumers.
         lowered_connect_route_plan_consumption:
           status: merge_bearing_runtime_behavior
           implementation_slice: '#1473'
@@ -503,7 +531,9 @@ contract_formats:
             fail closed and MUST NOT preserve previously inferred live-subscriber fallback recipients. RouteTable may be used
             only as a consumer that locates the concrete receiver handler/carrier for the already-selected target route identity.
             A matched lowered ConnectRoutePlan decision, including fail-closed diagnostics, MUST NOT be repaired or augmented
-            by post-planning recipient materialization hooks.
+            by post-planning recipient materialization hooks. #1482 promotes this matched decision into explicit
+            RoutePlan authority state so materializer eligibility and fail-closed zero-route behavior are structural rather
+            than inferred from connect-route metadata.
           supported_surface:
           - static receiver singular delivery
           - identity-style template/dynamic receiver fanout through supported descriptor targets


### PR DESCRIPTION
Closes #1482

## Summary

- Adds first-class EventBus `RoutePlan` authority state for no canonical match, canonical matched success, canonical fail-closed, and lower-precedence route production.
- Replaces heuristic connect-authority detection from `Source` / `Reason` / `ExtraDetail` with explicit state-driven materializer eligibility.
- Enforces matched canonical fail-closed plans as zero executable live recipients, delivery intents, delivery routes, and persisted recipients.
- Adds adversarial and regression proof for matched success, matched fail-closed, bogus materializer repair, unmatched legacy fallback, and legitimate non-connect materializer behavior.
- Updates `platform-spec.yaml` in the same PR for the shipped #1482 runtime semantics.

## Governing refs

- `platform-spec.yaml#contract_formats.event_schema.routing_derivation.route_plan_authority`
- `platform-spec.yaml#contract_formats.event_schema.routing_derivation.route_plan_authority.decision_state`
- `platform-spec.yaml#contract_formats.event_schema.routing_derivation.route_plan_authority.lowered_connect_route_plan_consumption`
- `platform-spec.yaml#flow_model.flow_package.composition_routing.route_plan_lowering.implementation_slice_1473`
- Pre-audit: https://github.com/division-sh/swarm/issues/1482#issuecomment-4800595758
- Gate A approval: https://github.com/division-sh/swarm/issues/1482#issuecomment-4801370567

## Semantic migration

- New canonical owner: `internal/runtime/bus.RoutePlan.AuthorityState` plus `AuthorityOwner` for EventBus publish-time route decision state.
- Old producer / reader / writer paths now invalid: `eventDeliveryPlanUsesConnectRoutePlan`, connect authority inferred from `ExtraDetail`, `Source`, `Reason`, or `TargetFailure` alone, and recipient-plan materializer repair after matched canonical route decisions.
- Production paths checked for surviving old behavior: `deliveryPlanner.Plan`, `eventDeliveryPlan.CanonicalRoutePlan`, `WithCanonicalRoutePlan`, `materializePublishRecipientPlan`, `Publish`, `PublishInMutation`, `CheckPublishRecipientPlan`, and `engineOutbox`.
- Migration completeness: complete for #1482 supported EventBus publish/preflight/outbox authority-state and fail-closed repair guards. Remaining open parent/sibling trackers: #1481, #1466, #1340, #1353, #1485, #1486, #1474, #1475, and #1479.

## Verification

- `python3 -c 'import yaml, pathlib; yaml.safe_load(pathlib.Path("platform-spec.yaml").read_text())'`
- `go test ./internal/runtime/bus -run 'ConnectRoutePlan|RecipientPlanMaterializer|RoutePlanCanonicalFailClosed|UnmatchedCanonical|RoutePlanProjection' -count=1`
- `go test ./internal/runtime/core/pinrouting ./internal/runtime/bus ./internal/runtime/pipeline ./internal/runtime/runforkadmission ./internal/runtime/runforkexecution -run 'ConnectRoutePlan|RoutePlan|RecipientPlan|SelectedContract|WorkflowNode|Outbox|Replay|Delivery|RouteAuthority|CheckPublishRecipientPlan' -count=1`
- `go test ./internal/apispec ./internal/runtime/bus -count=1`
- `go test ./...`