### PR TITLE
[agent-a][issue #1486] Add route authority conformance probes

### DIFF
--- a/internal/runtime/bus/connect_route_plan_dispatch_test.go
+++ b/internal/runtime/bus/connect_route_plan_dispatch_test.go
@@ -96,6 +96,14 @@ func (s *connectRoutePlanDescriptorStore) ListActiveFlowInstanceDescriptors(cont
 	return append([]ActiveFlowInstanceDescriptor(nil), s.flowInstances...), nil
 }
 
+func (s *targetRouteMemoryStore) UpsertCommittedReplayScope(_ context.Context, eventID string, scope runtimereplayclaim.CommittedReplayScope) error {
+	if s.scopes == nil {
+		s.scopes = map[string]runtimereplayclaim.CommittedReplayScope{}
+	}
+	s.scopes[eventID] = scope
+	return nil
+}
+
 func (s *connectRoutePlanFailingAgentDescriptorStore) ListActiveAgentDescriptors(context.Context) ([]ActiveAgentDescriptor, error) {
 	return nil, errors.New("legacy active-agent descriptor path should not run for static connect route plans")
 }
@@ -380,6 +388,28 @@ func TestEventBusResetInMemoryStateRefreshesConnectRoutePlanner(t *testing.T) {
 		events.EventType("producer/ticket.ready"), "", "", json.RawMessage(`{"team_entity":"team-a"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())
 	wantBeta := events.DeliveryRoute{SubscriberType: "node", SubscriberID: "worker-beta", Target: events.RouteIdentity{FlowID: "worker", FlowInstance: "worker/beta", EntityID: "team-a"}}
 
+	routePlan, err := eb.planSubscribedRoutePlan(context.Background(), evt, false)
+	if err != nil {
+		t.Fatalf("planSubscribedRoutePlan after reset: %v", err)
+	}
+	if routePlan.AuthorityState != RoutePlanAuthorityCanonicalMatched || routePlan.AuthorityOwner != routePlanSourceConnectRoutePlan {
+		t.Fatalf("route plan authority = %q/%q, want matched connect route plan", routePlan.AuthorityState, routePlan.AuthorityOwner)
+	}
+	if !deliveryRoutesContain(routePlan.DeliveryRoutes(), wantBeta) || len(routePlan.DeliveryRoutes()) != 1 {
+		t.Fatalf("route plan delivery routes = %#v, want only refreshed beta route", routePlan.DeliveryRoutes())
+	}
+
+	plan, err := eb.CheckPublishRecipientPlan(context.Background(), evt)
+	if err != nil {
+		t.Fatalf("CheckPublishRecipientPlan after reset: %v", err)
+	}
+	if plan.TargetFailure != "" {
+		t.Fatalf("target failure = %q, want none", plan.TargetFailure)
+	}
+	if !deliveryRoutesContain(plan.DeliveryRoutes, wantBeta) || len(plan.DeliveryRoutes) != 1 {
+		t.Fatalf("preflight delivery routes = %#v, want only refreshed beta route", plan.DeliveryRoutes)
+	}
+
 	if err := eb.Publish(context.Background(), evt); err != nil {
 		t.Fatalf("Publish after reset: %v", err)
 	}
@@ -432,6 +462,22 @@ func TestEventBusPublish_ConnectRoutePlanFailsClosedForUnsupportedBusinessFieldT
 	evt := events.NewProjectionEvent(uuid.NewString(),
 		events.EventType("producer/deploy.done"), "", "", json.RawMessage(`{"vertical_id":"v-1"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())
 
+	routePlan, err := eb.planSubscribedRoutePlan(context.Background(), evt, false)
+	if err != nil {
+		t.Fatalf("planSubscribedRoutePlan: %v", err)
+	}
+	if routePlan.AuthorityState != RoutePlanAuthorityCanonicalFailedClosed || routePlan.AuthorityOwner != routePlanSourceConnectRoutePlan {
+		t.Fatalf("route plan authority = %q/%q, want fail-closed connect route plan", routePlan.AuthorityState, routePlan.AuthorityOwner)
+	}
+	if got, want := routePlan.TargetFailure, runtimepinrouting.TargetFailure(runtimepinrouting.ConnectFailureTargetUnsupported); got != want {
+		t.Fatalf("route plan target failure = %q, want %q", got, want)
+	}
+	if len(routePlan.LiveRecipients) != 0 || len(routePlan.DeliveryIntents) != 0 || len(routePlan.RoutedRecipients) != 0 ||
+		len(routePlan.RecipientIDs()) != 0 || len(routePlan.PersistedRecipientIDs()) != 0 || len(routePlan.DeliveryRoutes()) != 0 {
+		t.Fatalf("unsupported target exposed executable routes: live=%#v intents=%#v routed=%#v recipients=%#v persisted=%#v routes=%#v",
+			routePlan.LiveRecipients, routePlan.DeliveryIntents, routePlan.RoutedRecipients, routePlan.RecipientIDs(), routePlan.PersistedRecipientIDs(), routePlan.DeliveryRoutes())
+	}
+
 	plan, err := eb.CheckPublishRecipientPlan(context.Background(), evt)
 	if err != nil {
 		t.Fatalf("CheckPublishRecipientPlan: %v", err)
@@ -439,9 +485,100 @@ func TestEventBusPublish_ConnectRoutePlanFailsClosedForUnsupportedBusinessFieldT
 	if got, want := plan.TargetFailure, "route_plan_target_unsupported"; got != want {
 		t.Fatalf("target failure = %q, want %q", got, want)
 	}
-	if len(plan.DeliveryRoutes) != 0 {
-		t.Fatalf("delivery routes = %#v, want none on unsupported business-field target", plan.DeliveryRoutes)
+	if len(plan.Recipients) != 0 || len(plan.PersistedRecipients) != 0 || len(plan.RoutedRecipients) != 0 ||
+		len(plan.SubscriptionRecipients) != 0 || len(plan.DeliveryRoutes) != 0 {
+		t.Fatalf("unsupported target preflight exposed executable routes: recipients=%#v persisted=%#v routed=%#v subscriptions=%#v routes=%#v",
+			plan.Recipients, plan.PersistedRecipients, plan.RoutedRecipients, plan.SubscriptionRecipients, plan.DeliveryRoutes)
 	}
+}
+
+func TestEventBusPublish_ConnectRoutePlanWithOnlySourceAndRawSubscribersFailsClosed(t *testing.T) {
+	source := semanticview.Wrap(connectRoutePlanTestBundle([]connectRoutePlanTestFlow{
+		{
+			id:   "producer",
+			mode: "static",
+			outputs: []runtimecontracts.FlowOutputEventPin{{
+				Name:  "deploy_done",
+				Event: "deploy.done",
+			}},
+			nodes: map[string]runtimecontracts.SystemNodeContract{
+				"producer-node": {
+					ID:            "producer-node",
+					EventHandlers: map[string]runtimecontracts.SystemNodeEventHandler{"deploy.done": {}},
+				},
+			},
+		},
+		{
+			id:   "consumer",
+			mode: "static",
+			inputs: []runtimecontracts.FlowInputEventPin{{
+				Name:  "deploy_completed",
+				Event: "deploy.completed",
+			}},
+		},
+	}, []runtimecontracts.FlowPackageConnect{{
+		From:     "producer.deploy_done",
+		To:       "consumer.deploy_completed",
+		Delivery: "one",
+	}}))
+	store := newTargetRouteMemoryStore()
+	eb, err := NewEventBusWithOptions(store, EventBusOptions{ContractBundle: source})
+	if err != nil {
+		t.Fatalf("NewEventBusWithOptions: %v", err)
+	}
+	sourceCh := eb.Subscribe("source-raw-listener", events.EventType("producer/deploy.done"), events.EventType("deploy.done"))
+	defer eb.Unsubscribe("source-raw-listener")
+	eventID := uuid.NewString()
+	evt := events.NewProjectionEvent(eventID,
+		events.EventType("producer/deploy.done"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Now().UTC())
+
+	routePlan, err := eb.planSubscribedRoutePlan(context.Background(), evt, false)
+	if err != nil {
+		t.Fatalf("planSubscribedRoutePlan: %v", err)
+	}
+	if routePlan.AuthorityState != RoutePlanAuthorityCanonicalFailedClosed || routePlan.AuthorityOwner != routePlanSourceConnectRoutePlan {
+		t.Fatalf("route plan authority = %q/%q, want fail-closed connect route plan", routePlan.AuthorityState, routePlan.AuthorityOwner)
+	}
+	if got, want := routePlan.TargetFailure, runtimepinrouting.FailureTargetNotSubscribed; got != want {
+		t.Fatalf("target failure = %q, want %q", got, want)
+	}
+	if len(routePlan.LiveRecipients) != 0 || len(routePlan.DeliveryIntents) != 0 || len(routePlan.RoutedRecipients) != 0 ||
+		len(routePlan.SubscribedRecipients) != 0 || len(routePlan.RecipientIDs()) != 0 ||
+		len(routePlan.PersistedRecipientIDs()) != 0 || len(routePlan.DeliveryRoutes()) != 0 {
+		t.Fatalf("fail-closed connect route exposed lower-precedence fallback: live=%#v intents=%#v routed=%#v subscriptions=%#v recipients=%#v persisted=%#v routes=%#v",
+			routePlan.LiveRecipients, routePlan.DeliveryIntents, routePlan.RoutedRecipients, routePlan.SubscribedRecipients,
+			routePlan.RecipientIDs(), routePlan.PersistedRecipientIDs(), routePlan.DeliveryRoutes())
+	}
+
+	plan, err := eb.CheckPublishRecipientPlan(context.Background(), evt)
+	if err != nil {
+		t.Fatalf("CheckPublishRecipientPlan: %v", err)
+	}
+	if got, want := plan.TargetFailure, string(runtimepinrouting.FailureTargetNotSubscribed); got != want {
+		t.Fatalf("target failure = %q, want %q", got, want)
+	}
+	if len(plan.Recipients) != 0 || len(plan.PersistedRecipients) != 0 || len(plan.RoutedRecipients) != 0 ||
+		len(plan.SubscriptionRecipients) != 0 || len(plan.DeliveryRoutes) != 0 {
+		t.Fatalf("preflight exposed lower-precedence fallback: recipients=%#v persisted=%#v routed=%#v subscriptions=%#v routes=%#v",
+			plan.Recipients, plan.PersistedRecipients, plan.RoutedRecipients, plan.SubscriptionRecipients, plan.DeliveryRoutes)
+	}
+
+	if err := eb.Publish(context.Background(), evt); err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+	if routes := store.routes[eventID]; len(routes) != 0 {
+		t.Fatalf("persisted delivery routes = %#v, want none when matched connect receiver is unsubscribed", routes)
+	}
+	if got := store.scopes[eventID]; got != runtimereplayclaim.CommittedReplayScopeSubscribed {
+		t.Fatalf("committed replay scope = %q, want subscribed", got)
+	}
+	if got := store.receipts[eventID]; got != "dead_letter" {
+		t.Fatalf("pipeline receipt = %q, want dead_letter target-delivery receipt", got)
+	}
+	if got, want := store.receiptErrs[eventID], "pin routing target delivery failed: target_not_subscribed"; got != want {
+		t.Fatalf("pipeline receipt error = %q, want %q", got, want)
+	}
+	requireNoConnectRoutePlanBusEvent(t, sourceCh, "source/raw subscriber fallback")
 }
 
 func TestEventBusPublish_ConnectRoutePlanFailsClosedForInvalidLoweredPlan(t *testing.T) {
@@ -804,4 +941,13 @@ func connectRoutePlanOutputEvents(pins []runtimecontracts.FlowOutputEventPin) []
 		out = append(out, pin.EventType())
 	}
 	return out
+}
+
+func requireNoConnectRoutePlanBusEvent(t testing.TB, ch <-chan events.Event, context string) {
+	t.Helper()
+	select {
+	case evt := <-ch:
+		t.Fatalf("%s: unexpected lower-precedence bus event: %#v", context, evt)
+	default:
+	}
 }

--- a/internal/runtime/manager/recovery_test.go
+++ b/internal/runtime/manager/recovery_test.go
@@ -205,12 +205,40 @@ func TestRecoverRestoresSelectedContractRouteRecoveriesFromForkLocalOwner(t *tes
 	if len(snapshot) != 1 {
 		t.Fatalf("selected route recovery snapshot len = %d, want 1", len(snapshot))
 	}
-	if got := snapshot[forkRunID]; got.Record.Owner != SelectedContractRoutePersistenceOwner ||
+	got := snapshot[forkRunID]
+	if got.Record.Owner != SelectedContractRoutePersistenceOwner ||
 		got.Record.RuntimeRecoveryOwner != SelectedContractRouteRecoveryOwner ||
 		got.RouteTopology.Owner != selectedContractRouteTopologyOwner ||
 		got.RecipientPlanning.Owner != selectedContractRecipientPlanningOwner ||
 		len(got.RecipientPlanning.RecipientPlanEvents) != 1 {
 		t.Fatalf("selected route recovery truth = %#v, want canonical recovered topology and recipient planning", got)
+	}
+	classification := struct {
+		consumer       string
+		owner          string
+		classification string
+		consumedOwners []string
+	}{
+		consumer:       "internal/runtime/manager.restoreSelectedContractRouteRecoveries/SelectedContractRouteRecoveryRecipientGuard",
+		owner:          got.Record.RuntimeRecoveryOwner,
+		classification: "carrier_readiness_consumer",
+		consumedOwners: []string{
+			got.Record.Owner,
+			got.Record.RouteTopologyOwner,
+			got.Record.RecipientPlanningOwner,
+			got.RecipientPlanning.RouteTopologyOwner,
+		},
+	}
+	if strings.TrimSpace(classification.owner) == "" {
+		t.Fatalf("%s has empty owner in classification row %#v", classification.consumer, classification)
+	}
+	if classification.classification == "route_authority" {
+		t.Fatalf("%s incorrectly classified as live EventBus route authority", classification.consumer)
+	}
+	for _, owner := range classification.consumedOwners {
+		if strings.TrimSpace(owner) == "" {
+			t.Fatalf("%s has empty consumed owner in classification row %#v", classification.consumer, classification)
+		}
 	}
 	guard, ok := am.SelectedContractRouteRecoveryRecipientGuard(forkRunID)
 	if !ok {

--- a/internal/runtime/runforkexecution/readiness_classifier_test.go
+++ b/internal/runtime/runforkexecution/readiness_classifier_test.go
@@ -143,7 +143,70 @@ func TestSelectedContractRunForkRouteConsumersAreClassifiedOutsideEventBusRouteA
 		t.Fatalf("BuildSelectedContractReadinessClassifier: %v", err)
 	}
 	selectedAdmission := testContractSwapSelectedExecutionAdmission(frontier.ContractSelection)
+	selectedAdmission.RecipientPlanning.RecipientPlanEvents = []store.RunForkSelectedContractRecipientPlanEvent{{
+		SourceEventID: "source-event",
+		EventName:     "work.begin",
+		Recipients: []store.RunForkContractFrontierRecipient{{
+			SubscriberType: "node",
+			SubscriberID:   "worker",
+			Path:           "flow-a/worker",
+			RouteSource:    "selected_contracts",
+		}},
+		Disposition: store.RunForkSelectedContractDispositionForkLocalTruth,
+	}}
 	routeRecovery := testContractSwapRouteRecovery(selectedAdmission)
+	replayAdmission := store.RunForkReplayResumeAdmission{
+		Owner:                    store.RunForkReplayResumeAdmissionOwner,
+		DeliveryEventReplayReady: true,
+		Dispositions: []store.RunForkReplayResumeDisposition{{
+			Fact:        store.RunForkReplayResumeFactDeliveryPendingHistory,
+			Disposition: store.RunForkReplayResumeDispositionForkReplay,
+			Message:     "pending selected-contract source delivery can be replayed",
+		}},
+	}
+	contractSwapAdmission, err := BuildContractSwapBootResumeAdmission(ContractSwapBootResumeAdmissionRequest{
+		SelectedExecutionAdmission: selectedAdmission,
+		ReplayResumeAdmission:      replayAdmission,
+		RouteRecovery:              &routeRecovery,
+	})
+	if err != nil {
+		t.Fatalf("BuildContractSwapBootResumeAdmission: %v", err)
+	}
+	historicalAdmission, err := BuildHistoricalReplayExecutionAdmission(HistoricalReplayExecutionAdmissionRequest{
+		ReplayResumeAdmission:      replayAdmission,
+		SelectedExecutionAdmission: selectedAdmission,
+		ContractSwapAdmission:      contractSwapAdmission,
+		RouteRecovery:              &routeRecovery,
+	})
+	if err != nil {
+		t.Fatalf("BuildHistoricalReplayExecutionAdmission: %v", err)
+	}
+	historicalExecution, err := BuildHistoricalReplayExecution(HistoricalReplayExecutionRequest{
+		Admission:             historicalAdmission,
+		ReplayResumeAdmission: replayAdmission,
+		PendingWork: []store.RunForkPendingWork{{
+			EventID:        "source-event",
+			EventName:      "work.begin",
+			DeliveryID:     "source-delivery-1",
+			SubscriberType: "agent",
+			SubscriberID:   "source-agent",
+			Status:         "pending",
+			Classification: store.RunForkPendingClassificationPending,
+		}},
+	})
+	if err != nil {
+		t.Fatalf("BuildHistoricalReplayExecution: %v", err)
+	}
+	contractSwapExecution, err := BuildHistoricalReplayContractSwapBootResumeExecution(HistoricalReplayContractSwapBootResumeRequest{
+		SelectedExecutionAdmission: selectedAdmission,
+		ContractSwapAdmission:      contractSwapAdmission,
+		HistoricalReplayAdmission:  historicalAdmission,
+		HistoricalReplayExecution:  historicalExecution,
+		RouteRecovery:              &routeRecovery,
+	})
+	if err != nil {
+		t.Fatalf("BuildHistoricalReplayContractSwapBootResumeExecution: %v", err)
+	}
 
 	const (
 		routeAuthorityClass           = "route_authority"
@@ -155,6 +218,7 @@ func TestSelectedContractRunForkRouteConsumersAreClassifiedOutsideEventBusRouteA
 		consumer       string
 		owner          string
 		classification string
+		consumedOwners []string
 	}{
 		{
 			consumer:       "internal/runtime/runforkadmission.AdmitSelectedContractRouteHistory",
@@ -165,11 +229,13 @@ func TestSelectedContractRunForkRouteConsumersAreClassifiedOutsideEventBusRouteA
 			consumer:       "internal/runtime/runforkexecution.BuildSelectedContractRouteTopology",
 			owner:          routeTopology.Owner,
 			classification: separateOwnerClass,
+			consumedOwners: []string{routeTopology.RouteAdmissionOwner},
 		},
 		{
 			consumer:       "internal/runtime/runforkexecution.BuildSelectedContractRecipientPlanning",
 			owner:          recipientPlanning.Owner,
 			classification: separateOwnerClass,
+			consumedOwners: []string{recipientPlanning.RouteAdmissionOwner, recipientPlanning.RouteTopologyOwner},
 		},
 		{
 			consumer:       "selected_contract_recipient_planning.eventbus_publish_recipient_guard",
@@ -180,26 +246,36 @@ func TestSelectedContractRunForkRouteConsumersAreClassifiedOutsideEventBusRouteA
 			consumer:       "internal/runtime/runforkexecution.BuildSelectedContractExecutionModel",
 			owner:          model.Owner,
 			classification: carrierReadinessConsumerClass,
+			consumedOwners: []string{model.RouteTopology.Owner, model.RouteTopology.RouteAdmissionOwner},
 		},
 		{
 			consumer:       "internal/runtime/runforkexecution.BuildSelectedContractExecutionAdmission",
 			owner:          selectedAdmission.Owner,
 			classification: carrierReadinessConsumerClass,
+			consumedOwners: []string{
+				selectedAdmission.ContractBindingOwner,
+				selectedAdmission.ExecutionModelOwner,
+				selectedAdmission.RouteTopology.Owner,
+				selectedAdmission.RecipientPlanning.Owner,
+			},
 		},
 		{
 			consumer:       "store.RecordRunForkSelectedContractRouteRecovery",
 			owner:          routeRecovery.Owner,
 			classification: separateOwnerClass,
+			consumedOwners: []string{routeRecovery.RouteTopologyOwner, routeRecovery.RecipientPlanningOwner},
 		},
 		{
 			consumer:       "internal/runtime/runforkexecution.RecoverSelectedContractRouteTruth",
 			owner:          routeRecovery.RuntimeRecoveryOwner,
 			classification: carrierReadinessConsumerClass,
+			consumedOwners: []string{routeRecovery.Owner, routeRecovery.RouteTopologyOwner, routeRecovery.RecipientPlanningOwner},
 		},
 		{
 			consumer:       "internal/runtime/runforkexecution.BuildSelectedContractReadinessClassifier",
 			owner:          readiness.Owner,
 			classification: diagnosticObserverClass,
+			consumedOwners: []string{readiness.RouteTopologyOwner, readiness.RecipientPlanningOwner, readiness.SelectedExecutionModelOwner},
 		},
 		{
 			consumer:       "internal/runtime/runforkexecution.ActivateSelectedContractRunFork",
@@ -220,10 +296,53 @@ func TestSelectedContractRunForkRouteConsumersAreClassifiedOutsideEventBusRouteA
 			consumer:       "runtime.run_fork.selected_contract_execution",
 			owner:          model.FutureExecutionOwner,
 			classification: carrierReadinessConsumerClass,
+			consumedOwners: []string{model.Owner, model.RouteTopology.Owner, model.RouteTopology.RouteAdmissionOwner},
+		},
+		{
+			consumer:       "internal/runtime/runforkexecution.BuildContractSwapBootResumeAdmission",
+			owner:          contractSwapAdmission.Owner,
+			classification: carrierReadinessConsumerClass,
+			consumedOwners: []string{
+				contractSwapAdmission.SelectedExecutionAdmissionOwner,
+				contractSwapAdmission.ReplayResumeAdmissionOwner,
+				contractSwapAdmission.RouteTopologyOwner,
+				contractSwapAdmission.RouteRecoveryOwner,
+				contractSwapAdmission.RuntimeRouteRecoveryOwner,
+				contractSwapAdmission.RecipientPlanningOwner,
+			},
+		},
+		{
+			consumer:       "internal/runtime/runforkexecution.BuildHistoricalReplayExecutionAdmission",
+			owner:          historicalAdmission.Owner,
+			classification: carrierReadinessConsumerClass,
+			consumedOwners: []string{
+				historicalAdmission.SelectedExecutionAdmissionOwner,
+				historicalAdmission.ContractSwapAdmissionOwner,
+				historicalAdmission.RouteTopologyOwner,
+				historicalAdmission.RouteRecoveryOwner,
+				historicalAdmission.RuntimeRouteRecoveryOwner,
+				historicalAdmission.RecipientPlanningOwner,
+			},
+		},
+		{
+			consumer:       "internal/runtime/runforkexecution.BuildHistoricalReplayContractSwapBootResumeExecution",
+			owner:          contractSwapExecution.Owner,
+			classification: carrierReadinessConsumerClass,
+			consumedOwners: []string{
+				contractSwapExecution.ParentHistoricalReplayExecutionOwner,
+				contractSwapExecution.HistoricalReplayExecutionAdmissionOwner,
+				contractSwapExecution.ContractSwapAdmissionOwner,
+				contractSwapExecution.SelectedExecutionAdmissionOwner,
+				contractSwapExecution.RouteTopologyOwner,
+				contractSwapExecution.RouteRecoveryOwner,
+				contractSwapExecution.RuntimeRouteRecoveryOwner,
+				contractSwapExecution.RecipientPlanningOwner,
+			},
 		},
 	}
-	if len(rows) != 13 {
-		t.Fatalf("classification rows = %d, want 13 current route/readiness consumers", len(rows))
+	const expectedRunForkExecutionRouteConsumerRows = 16
+	if len(rows) != expectedRunForkExecutionRouteConsumerRows {
+		t.Fatalf("classification rows = %d, want %d current runforkexecution route/readiness consumers", len(rows), expectedRunForkExecutionRouteConsumerRows)
 	}
 	allowed := map[string]struct{}{
 		routeAuthorityClass:           {},
@@ -241,6 +360,11 @@ func TestSelectedContractRunForkRouteConsumersAreClassifiedOutsideEventBusRouteA
 		if row.classification == routeAuthorityClass {
 			t.Fatalf("%s incorrectly classified as live EventBus route authority", row.consumer)
 		}
+		for _, owner := range row.consumedOwners {
+			if strings.TrimSpace(owner) == "" {
+				t.Fatalf("%s has empty consumed owner in classification row %#v", row.consumer, row)
+			}
+		}
 	}
 
 	if !model.NonMutating || model.ExecutionSupported {
@@ -253,6 +377,24 @@ func TestSelectedContractRunForkRouteConsumersAreClassifiedOutsideEventBusRouteA
 		readiness.RecipientPlanningOwner != store.RunForkSelectedContractRecipientPlanningOwner ||
 		readiness.SelectedExecutionModelOwner != store.RunForkSelectedContractExecutionModelOwner {
 		t.Fatalf("readiness owner consumption = %#v", readiness)
+	}
+	if contractSwapAdmission.RouteTopologyOwner != store.RunForkSelectedContractRouteTopologyOwner ||
+		contractSwapAdmission.RouteRecoveryOwner != store.RunForkSelectedContractRoutePersistenceOwner ||
+		contractSwapAdmission.RuntimeRouteRecoveryOwner != store.RunForkSelectedContractRouteRecoveryOwner ||
+		contractSwapAdmission.RecipientPlanningOwner != store.RunForkSelectedContractRecipientPlanningOwner {
+		t.Fatalf("contract-swap admission route owner consumption = %#v", contractSwapAdmission)
+	}
+	if historicalAdmission.RouteTopologyOwner != store.RunForkSelectedContractRouteTopologyOwner ||
+		historicalAdmission.RouteRecoveryOwner != store.RunForkSelectedContractRoutePersistenceOwner ||
+		historicalAdmission.RuntimeRouteRecoveryOwner != store.RunForkSelectedContractRouteRecoveryOwner ||
+		historicalAdmission.RecipientPlanningOwner != store.RunForkSelectedContractRecipientPlanningOwner {
+		t.Fatalf("historical replay admission route owner consumption = %#v", historicalAdmission)
+	}
+	if contractSwapExecution.RouteTopologyOwner != store.RunForkSelectedContractRouteTopologyOwner ||
+		contractSwapExecution.RouteRecoveryOwner != store.RunForkSelectedContractRoutePersistenceOwner ||
+		contractSwapExecution.RuntimeRouteRecoveryOwner != store.RunForkSelectedContractRouteRecoveryOwner ||
+		contractSwapExecution.RecipientPlanningOwner != store.RunForkSelectedContractRecipientPlanningOwner {
+		t.Fatalf("contract-swap execution route owner consumption = %#v", contractSwapExecution)
 	}
 	if !executionBoundaryHas(recipientPlanning.InvalidPaths, "delivery_planner_as_canonical_owner", store.RunForkSelectedContractDispositionInvalid) {
 		t.Fatalf("recipient planning invalid paths = %#v, want generic delivery planner invalid as canonical owner", recipientPlanning.InvalidPaths)

--- a/internal/runtime/runforkexecution/readiness_classifier_test.go
+++ b/internal/runtime/runforkexecution/readiness_classifier_test.go
@@ -91,6 +91,174 @@ func TestBuildSelectedContractReadinessClassifierEmitsCompleteOwnerMatrix(t *tes
 	}
 }
 
+func TestSelectedContractRunForkRouteConsumersAreClassifiedOutsideEventBusRouteAuthority(t *testing.T) {
+	frontier := store.RunForkContractFrontierAdmission{
+		Owner:                        store.RunForkContractFrontierAdmissionOwner,
+		NonMutating:                  true,
+		HistoricalExecutionSupported: false,
+		ContractSelection: store.RunForkContractSelection{
+			Mode:            "selected_contracts",
+			ContractsRoot:   "/tmp/contracts",
+			WorkflowName:    "workflow",
+			WorkflowVersion: "v1",
+		},
+		FrontierEventCount: 1,
+		FrontierEvents: []store.RunForkContractFrontierEvent{{
+			SourceEventID: "source-event",
+			EventName:     "work.begin",
+			DerivedRecipients: []store.RunForkContractFrontierRecipient{{
+				SubscriberType: "node",
+				SubscriberID:   "worker",
+				Path:           "flow-a/worker",
+				RouteSource:    "selected_contracts",
+			}},
+		}},
+	}
+	routeAdmission := testSelectedContractRouteAdmission(frontier)
+	routeTopology := testSelectedContractRouteTopologyFromAdmission(t, frontier, routeAdmission)
+	recipientPlanning, err := BuildSelectedContractRecipientPlanning(SelectedContractRecipientPlanningRequest{
+		Admission:      frontier,
+		RouteAdmission: routeAdmission,
+		RouteTopology:  routeTopology,
+	})
+	if err != nil {
+		t.Fatalf("BuildSelectedContractRecipientPlanning: %v", err)
+	}
+	model, err := BuildSelectedContractExecutionModel(SelectedContractExecutionModelRequest{
+		Admission:      frontier,
+		RouteAdmission: routeAdmission,
+		RouteTopology:  routeTopology,
+	})
+	if err != nil {
+		t.Fatalf("BuildSelectedContractExecutionModel: %v", err)
+	}
+	readiness, err := BuildSelectedContractReadinessClassifier(SelectedContractReadinessClassifierRequest{
+		Plan: store.RunForkPlan{
+			ReplayResumeAdmission: store.RunForkReplayResumeAdmission{Owner: store.RunForkReplayResumeAdmissionOwner},
+		},
+		ContractFrontierAdmission: frontier,
+		SelectedContractExecution: model,
+	})
+	if err != nil {
+		t.Fatalf("BuildSelectedContractReadinessClassifier: %v", err)
+	}
+	selectedAdmission := testContractSwapSelectedExecutionAdmission(frontier.ContractSelection)
+	routeRecovery := testContractSwapRouteRecovery(selectedAdmission)
+
+	const (
+		routeAuthorityClass           = "route_authority"
+		separateOwnerClass            = "separate_owner"
+		carrierReadinessConsumerClass = "carrier_readiness_consumer"
+		diagnosticObserverClass       = "diagnostic_observer"
+	)
+	rows := []struct {
+		consumer       string
+		owner          string
+		classification string
+	}{
+		{
+			consumer:       "internal/runtime/runforkadmission.AdmitSelectedContractRouteHistory",
+			owner:          routeAdmission.Owner,
+			classification: separateOwnerClass,
+		},
+		{
+			consumer:       "internal/runtime/runforkexecution.BuildSelectedContractRouteTopology",
+			owner:          routeTopology.Owner,
+			classification: separateOwnerClass,
+		},
+		{
+			consumer:       "internal/runtime/runforkexecution.BuildSelectedContractRecipientPlanning",
+			owner:          recipientPlanning.Owner,
+			classification: separateOwnerClass,
+		},
+		{
+			consumer:       "selected_contract_recipient_planning.eventbus_publish_recipient_guard",
+			owner:          runForkBoundaryOwner(t, recipientPlanning.RequiredConsumers, "eventbus_publish_recipient_guard"),
+			classification: carrierReadinessConsumerClass,
+		},
+		{
+			consumer:       "internal/runtime/runforkexecution.BuildSelectedContractExecutionModel",
+			owner:          model.Owner,
+			classification: carrierReadinessConsumerClass,
+		},
+		{
+			consumer:       "internal/runtime/runforkexecution.BuildSelectedContractExecutionAdmission",
+			owner:          selectedAdmission.Owner,
+			classification: carrierReadinessConsumerClass,
+		},
+		{
+			consumer:       "store.RecordRunForkSelectedContractRouteRecovery",
+			owner:          routeRecovery.Owner,
+			classification: separateOwnerClass,
+		},
+		{
+			consumer:       "internal/runtime/runforkexecution.RecoverSelectedContractRouteTruth",
+			owner:          routeRecovery.RuntimeRecoveryOwner,
+			classification: carrierReadinessConsumerClass,
+		},
+		{
+			consumer:       "internal/runtime/runforkexecution.BuildSelectedContractReadinessClassifier",
+			owner:          readiness.Owner,
+			classification: diagnosticObserverClass,
+		},
+		{
+			consumer:       "internal/runtime/runforkexecution.ActivateSelectedContractRunFork",
+			owner:          store.RunForkSelectedContractExecutionActivationGateOwner,
+			classification: carrierReadinessConsumerClass,
+		},
+		{
+			consumer:       "internal/runtime/runforkexecution.selectedContractForkLocalRuntimeContainer",
+			owner:          store.RunForkSelectedContractForkLocalRuntimeContainerOwner,
+			classification: carrierReadinessConsumerClass,
+		},
+		{
+			consumer:       "internal/runtime/runforkexecution.RequireSelectedContractAgentDeliveryMaterialization",
+			owner:          store.RunForkSelectedContractAuthoritativeAgentDeliveryMaterializationOwner,
+			classification: carrierReadinessConsumerClass,
+		},
+		{
+			consumer:       "runtime.run_fork.selected_contract_execution",
+			owner:          model.FutureExecutionOwner,
+			classification: carrierReadinessConsumerClass,
+		},
+	}
+	if len(rows) != 13 {
+		t.Fatalf("classification rows = %d, want 13 current route/readiness consumers", len(rows))
+	}
+	allowed := map[string]struct{}{
+		routeAuthorityClass:           {},
+		separateOwnerClass:            {},
+		carrierReadinessConsumerClass: {},
+		diagnosticObserverClass:       {},
+	}
+	for _, row := range rows {
+		if strings.TrimSpace(row.owner) == "" {
+			t.Fatalf("%s has empty owner in classification row %#v", row.consumer, row)
+		}
+		if _, ok := allowed[row.classification]; !ok {
+			t.Fatalf("%s classification = %q, want supported classification", row.consumer, row.classification)
+		}
+		if row.classification == routeAuthorityClass {
+			t.Fatalf("%s incorrectly classified as live EventBus route authority", row.consumer)
+		}
+	}
+
+	if !model.NonMutating || model.ExecutionSupported {
+		t.Fatalf("selected execution model mutation flags = non_mutating:%v execution:%v", model.NonMutating, model.ExecutionSupported)
+	}
+	if !recipientPlanning.NonMutating || recipientPlanning.DeliveryWritesSupported {
+		t.Fatalf("recipient planning mutation flags = non_mutating:%v delivery_writes:%v", recipientPlanning.NonMutating, recipientPlanning.DeliveryWritesSupported)
+	}
+	if readiness.RouteTopologyOwner != store.RunForkSelectedContractRouteTopologyOwner ||
+		readiness.RecipientPlanningOwner != store.RunForkSelectedContractRecipientPlanningOwner ||
+		readiness.SelectedExecutionModelOwner != store.RunForkSelectedContractExecutionModelOwner {
+		t.Fatalf("readiness owner consumption = %#v", readiness)
+	}
+	if !executionBoundaryHas(recipientPlanning.InvalidPaths, "delivery_planner_as_canonical_owner", store.RunForkSelectedContractDispositionInvalid) {
+		t.Fatalf("recipient planning invalid paths = %#v, want generic delivery planner invalid as canonical owner", recipientPlanning.InvalidPaths)
+	}
+}
+
 func TestBuildSelectedContractReadinessClassifierRejectsLocalExecutionModel(t *testing.T) {
 	_, err := BuildSelectedContractReadinessClassifier(SelectedContractReadinessClassifierRequest{
 		Plan: store.RunForkPlan{
@@ -159,4 +327,15 @@ func assertReadinessFact(t *testing.T, facts []store.RunForkSelectedContractRead
 		}
 	}
 	t.Fatalf("readiness fact %s missing from %#v", fact, facts)
+}
+
+func runForkBoundaryOwner(t *testing.T, items []store.RunForkSelectedContractExecutionBoundary, concept string) string {
+	t.Helper()
+	for _, item := range items {
+		if item.Concept == concept {
+			return item.Owner
+		}
+	}
+	t.Fatalf("boundary %s missing from %#v", concept, items)
+	return ""
 }


### PR DESCRIPTION
## Summary

- Adds the missing source/raw-subscriber/no receiver-handler ConnectRoutePlan probe and asserts final RoutePlan, CheckPublishRecipientPlan, persisted delivery, replay-scope, receipt, and no live fallback behavior.
- Strengthens existing reset/rebuild and unsupported business-field negative guards to assert final RoutePlan / PublishRecipientPlan executable-route state.
- Adds selected-contract runfork route/readiness consumer classification proof so those consumers remain classified outside live EventBus RoutePlan authority.

Closes #1486

## Governing Refs / Context

- `platform-spec.yaml`: `contract_formats.event_schema.routing_derivation.delivery_rules.workflow_node_route_authority`
- `platform-spec.yaml`: `route_plan_authority`, `route_plan_authority.decision_state`, `route_plan_authority.lowered_connect_route_plan_consumption`
- `platform-spec.yaml`: `implementation_slice_1473`
- `platform-spec.yaml`: `runtime_operations.run_fork.selected_contract_readiness_classifier`, `selected_contract_route_admission`, `selected_contract_route_topology`, `selected_contract_route_persistence_recovery`, `selected_contract_recipient_planning`
- Roadmap rows: `3b1`, `3e`, `3f`, `3f1`, `3g`
- Gate context: #1486 pre-audit and approved first-slice boundary

This PR is intentionally test/conformance-only. It does not change runtime semantics, so no `platform-spec.yaml` runtime semantic update is included.

## Semantic Migration

- New canonical owner: unchanged. EventBus publish-time route authority remains `RoutePlan.AuthorityState`; selected-contract runfork route/readiness remains owned by the existing `runtime.run_fork.*` evidence/readiness owners.
- Old producer / reader / writer path now invalid: unchanged. The PR adds durable proof that source/raw subscribers, legacy descriptor paths, unsupported business-field targets, and recipient materializer repair cannot become executable routes after matched canonical fail-closed.
- Production paths checked for surviving old behavior: `Publish`, `CheckPublishRecipientPlan`, reset/rebuild planner state, persisted delivery rows, committed replay scope, receipt path, live subscriber fallback, and selected-contract runfork consumer classification.
- Migration complete: no migration performed; this closes the conformance/classification slice only.

## Validation

- `go test ./internal/runtime/bus ./internal/runtime/core/pinrouting ./internal/runtime/runforkadmission ./internal/runtime/runforkexecution ./internal/store -run 'ConnectRoutePlan|RoutePlan|RecipientPlan|SelectedContract|RouteTopology|RouteHistory|Readiness|RouteRecovery|UnmatchedCanonical|ResetInMemoryState|BusinessField' -count=1`
- `go test ./...`