### PR TITLE
[agent-a][issue #1485] Isolate connect receiver carrier lookup

### DIFF
--- a/internal/runtime/bus/connect_route_plan_dispatch.go
+++ b/internal/runtime/bus/connect_route_plan_dispatch.go
@@ -146,7 +146,7 @@ func (r connectRoutePlanResolver) deliveryRoutesForMaterialization(plan runtimep
 	subscribers := make([]Subscriber, 0, len(targets))
 	for _, target := range targets {
 		target = target.Normalized()
-		matchedSubscribers := r.resolveReceiverSubscribers(plan, target)
+		matchedSubscribers := r.resolveSelectedReceiverCarriers(plan, target)
 		if len(matchedSubscribers) == 0 {
 			return nil, nil
 		}
@@ -166,11 +166,11 @@ func (r connectRoutePlanResolver) deliveryRoutesForMaterialization(plan runtimep
 	return events.NormalizeDeliveryRoutes(routes), dedupeSubscribers(subscribers)
 }
 
-func (r connectRoutePlanResolver) resolveReceiverSubscribers(plan runtimepinrouting.ConnectRoutePlan, target events.RouteIdentity) []Subscriber {
+func (r connectRoutePlanResolver) resolveSelectedReceiverCarriers(plan runtimepinrouting.ConnectRoutePlan, target events.RouteIdentity) []Subscriber {
 	if r.routeTable == nil {
 		return nil
 	}
-	keys := connectReceiverRouteKeys(plan, target)
+	keys := connectReceiverCarrierRouteKeys(plan, target)
 	out := make([]Subscriber, 0, len(keys))
 	for _, key := range keys {
 		for _, subscriber := range r.routeTable.Resolve(key) {
@@ -260,23 +260,13 @@ func connectMaterializedTargets(materialized runtimepinrouting.ConnectRoutePlanM
 	return uniqueRouteIdentities(materialized.TargetSet)
 }
 
-func connectReceiverRouteKeys(plan runtimepinrouting.ConnectRoutePlan, target events.RouteIdentity) []string {
+func connectReceiverCarrierRouteKeys(plan runtimepinrouting.ConnectRoutePlan, target events.RouteIdentity) []string {
 	target = target.Normalized()
 	local := strings.Trim(strings.TrimSpace(plan.Receiver.Event), "/")
 	resolved := strings.Trim(strings.TrimSpace(plan.Receiver.ResolvedEvent), "/")
 	receiverPath := strings.Trim(strings.TrimSpace(plan.Receiver.FlowPath), "/")
 	if receiverPath == "" {
 		receiverPath = strings.Trim(strings.TrimSpace(plan.Receiver.FlowID), "/")
-	}
-	sourceLocal := strings.Trim(strings.TrimSpace(plan.Source.Event), "/")
-	sourceResolved := strings.Trim(strings.TrimSpace(plan.Source.ResolvedEvent), "/")
-	sourcePath := strings.Trim(strings.TrimSpace(plan.Source.FlowPath), "/")
-	if sourcePath == "" {
-		sourcePath = strings.Trim(strings.TrimSpace(plan.Source.FlowID), "/")
-	}
-	sourceScoped := sourceLocal
-	if sourcePath != "" && sourceLocal != "" {
-		sourceScoped = sourcePath + "/" + sourceLocal
 	}
 	out := make([]string, 0, 6)
 	if target.FlowInstance != "" && local != "" {
@@ -286,7 +276,6 @@ func connectReceiverRouteKeys(plan runtimepinrouting.ConnectRoutePlan, target ev
 		out = append(out, receiverPath+"/"+local)
 	}
 	out = append(out, resolved)
-	out = append(out, sourceResolved, sourceScoped)
 	if receiverPath == "" {
 		out = append(out, local)
 	}

--- a/internal/runtime/bus/connect_route_plan_dispatch_test.go
+++ b/internal/runtime/bus/connect_route_plan_dispatch_test.go
@@ -30,7 +30,8 @@ type connectRoutePlanTestFlow struct {
 
 type connectRoutePlanDescriptorStore struct {
 	*targetRouteMemoryStore
-	flowInstances []ActiveFlowInstanceDescriptor
+	flowInstances               []ActiveFlowInstanceDescriptor
+	flowInstanceDescriptorCalls int
 }
 
 type connectRoutePlanFailingAgentDescriptorStore struct {
@@ -93,6 +94,7 @@ func (*targetRouteMemoryEventMutation) RecordDeadLetter(context.Context, runtime
 }
 
 func (s *connectRoutePlanDescriptorStore) ListActiveFlowInstanceDescriptors(context.Context) ([]ActiveFlowInstanceDescriptor, error) {
+	s.flowInstanceDescriptorCalls++
 	return append([]ActiveFlowInstanceDescriptor(nil), s.flowInstances...), nil
 }
 
@@ -208,6 +210,71 @@ func TestEventBusCheckPublishRecipientPlan_ConnectRoutePlanPrecedesLegacyDescrip
 	}
 	if !deliveryRoutesContain(plan.DeliveryRoutes, connectRoutePlanStaticDeliveryRoute()) {
 		t.Fatalf("preflight delivery routes = %#v, want static connect route", plan.DeliveryRoutes)
+	}
+}
+
+func TestConnectRoutePlanReceiverCarrierKeysUseSelectedReceiverIdentity(t *testing.T) {
+	plan := runtimepinrouting.ConnectRoutePlan{
+		Source: runtimepinrouting.ConnectRoutePlanEndpoint{
+			FlowID:        "producer",
+			FlowPath:      "producer",
+			Event:         "deploy.done",
+			ResolvedEvent: "producer/deploy.done",
+		},
+		Receiver: runtimepinrouting.ConnectRoutePlanEndpoint{
+			FlowID:        "consumer",
+			FlowPath:      "consumer",
+			Event:         "deploy.completed",
+			ResolvedEvent: "consumer/deploy.completed",
+		},
+	}
+	target := events.RouteIdentity{
+		FlowID:       "consumer",
+		FlowInstance: "consumer/alpha",
+		EntityID:     "entity-alpha",
+	}
+
+	keys := connectReceiverCarrierRouteKeys(plan, target)
+	for _, want := range []string{"consumer/alpha/deploy.completed", "consumer/deploy.completed"} {
+		if !containsString(keys, want) {
+			t.Fatalf("carrier keys = %#v, want selected receiver key %q", keys, want)
+		}
+	}
+	for _, forbidden := range []string{"producer/deploy.done", "deploy.done"} {
+		if containsString(keys, forbidden) {
+			t.Fatalf("carrier keys = %#v, must not include source endpoint key %q", keys, forbidden)
+		}
+	}
+	if got, want := len(keys), len(uniqueStrings(keys)); got != want {
+		t.Fatalf("carrier keys = %#v, want unique selected receiver keys", keys)
+	}
+}
+
+func TestConnectRoutePlanDescriptorsLoadOnlyForRuntimeResolution(t *testing.T) {
+	calls := 0
+	resolver := connectRoutePlanResolver{
+		loadDescriptors: func(context.Context) ([]runtimepinrouting.Descriptor, error) {
+			calls++
+			return []runtimepinrouting.Descriptor{{ID: "alpha", EntityID: "team-a", FlowInstance: "worker/alpha"}}, nil
+		},
+	}
+
+	if _, err := resolver.descriptorsForPlans(context.Background(), []runtimepinrouting.ConnectRoutePlan{{
+		RequiresRuntimeResolution: false,
+	}}); err != nil {
+		t.Fatalf("descriptorsForPlans static: %v", err)
+	}
+	if calls != 0 {
+		t.Fatalf("descriptor loader calls after static plan = %d, want 0", calls)
+	}
+
+	if _, err := resolver.descriptorsForPlans(context.Background(), []runtimepinrouting.ConnectRoutePlan{{
+		RequiresRuntimeResolution: true,
+	}}); err != nil {
+		t.Fatalf("descriptorsForPlans runtime: %v", err)
+	}
+	if calls != 1 {
+		t.Fatalf("descriptor loader calls after runtime-resolution plan = %d, want 1", calls)
 	}
 }
 
@@ -339,6 +406,10 @@ func TestEventBusPublish_ConnectRoutePlanPersistsTargetSetFanout(t *testing.T) {
 			t.Fatalf("AddFlowInstanceRoute(%s): %v", instanceID, err)
 		}
 	}
+	resolvedAlpha := eb.RouteTable().Resolve("worker/alpha/ticket.ready")
+	if !subscriberListContains(resolvedAlpha, "worker-alpha", "worker/alpha") {
+		t.Fatalf("receiver carrier route worker/alpha/ticket.ready = %#v, want worker-alpha", resolvedAlpha)
+	}
 	eventID := uuid.NewString()
 	evt := events.NewProjectionEvent(eventID,
 		events.EventType("producer/ticket.ready"), "", "", json.RawMessage(`{"team_entity":"team-a"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())
@@ -347,6 +418,9 @@ func TestEventBusPublish_ConnectRoutePlanPersistsTargetSetFanout(t *testing.T) {
 
 	if err := eb.Publish(context.Background(), evt); err != nil {
 		t.Fatalf("Publish: %v", err)
+	}
+	if store.flowInstanceDescriptorCalls == 0 {
+		t.Fatalf("flow-instance descriptor loader was not called for descriptor-backed connect fanout")
 	}
 	routes := store.routes[eventID]
 	if !deliveryRoutesContain(routes, wantAlpha) || !deliveryRoutesContain(routes, wantBeta) {
@@ -950,4 +1024,13 @@ func requireNoConnectRoutePlanBusEvent(t testing.TB, ch <-chan events.Event, con
 		t.Fatalf("%s: unexpected lower-precedence bus event: %#v", context, evt)
 	default:
 	}
+}
+
+func subscriberListContains(in []Subscriber, id, path string) bool {
+	for _, subscriber := range in {
+		if subscriber.ID == id && subscriber.Path == path {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/runtime/bus/connect_route_plan_dispatch_test.go
+++ b/internal/runtime/bus/connect_route_plan_dispatch_test.go
@@ -411,8 +411,8 @@ func TestEventBusPublish_ConnectRoutePlanPersistsTargetSetFanout(t *testing.T) {
 		}
 	}
 	resolvedAlpha := eb.RouteTable().Resolve("worker/alpha/ticket.ready")
-	if !subscriberListContains(resolvedAlpha, "worker-alpha", "worker/alpha") {
-		t.Fatalf("receiver carrier route worker/alpha/ticket.ready = %#v, want worker-alpha", resolvedAlpha)
+	if !subscriberListContainsRouteSource(resolvedAlpha, "worker-alpha", "worker/alpha", "receiver_carrier") {
+		t.Fatalf("receiver carrier route worker/alpha/ticket.ready = %#v, want worker-alpha receiver_carrier", resolvedAlpha)
 	}
 	eventID := uuid.NewString()
 	evt := events.NewProjectionEvent(eventID,

--- a/internal/runtime/bus/connect_route_plan_dispatch_test.go
+++ b/internal/runtime/bus/connect_route_plan_dispatch_test.go
@@ -121,6 +121,10 @@ func TestEventBusPublish_ConnectRoutePlanPersistsSingularTargetWithoutLiveSubscr
 	if err != nil {
 		t.Fatalf("NewEventBusWithOptions: %v", err)
 	}
+	receiverCarriers := eb.RouteTable().Resolve("consumer/deploy.completed")
+	if !subscriberListContainsRouteSource(receiverCarriers, "consumer-node", "consumer", "receiver_carrier") {
+		t.Fatalf("receiver carrier route consumer/deploy.completed = %#v, want consumer-node receiver_carrier", receiverCarriers)
+	}
 	eventID := uuid.NewString()
 	evt := events.NewProjectionEvent(eventID,
 		events.EventType("producer/deploy.done"), "", "", json.RawMessage(`{"ignored":"yes"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())
@@ -1029,6 +1033,15 @@ func requireNoConnectRoutePlanBusEvent(t testing.TB, ch <-chan events.Event, con
 func subscriberListContains(in []Subscriber, id, path string) bool {
 	for _, subscriber := range in {
 		if subscriber.ID == id && subscriber.Path == path {
+			return true
+		}
+	}
+	return false
+}
+
+func subscriberListContainsRouteSource(in []Subscriber, id, path, routeSource string) bool {
+	for _, subscriber := range in {
+		if subscriber.ID == id && subscriber.Path == path && subscriber.RouteSource == routeSource {
 			return true
 		}
 	}

--- a/internal/runtime/bus/eventbus_target_routes_test.go
+++ b/internal/runtime/bus/eventbus_target_routes_test.go
@@ -674,8 +674,8 @@ func TestEventBusPublish_TargetedDynamicFlowFixtureRouteTableNodePersistsSemanti
 		}
 		return false
 	}
-	if !hasRoute("work.assign") || !hasRoute("worker/w-001/work.assign") {
-		t.Fatalf("materialized routes = %#v, want task-handler local and selected receiver-carrier work.assign routes; node entries=%v", materialized, sortedStringKeys(bundle.NodeEntries()))
+	if !hasRoute("work.assign") {
+		t.Fatalf("materialized routes = %#v, want task-handler local work.assign route; node entries=%v", materialized, sortedStringKeys(bundle.NodeEntries()))
 	}
 	target := events.RouteIdentity{
 		FlowInstance: "worker/w-001",

--- a/internal/runtime/bus/eventbus_target_routes_test.go
+++ b/internal/runtime/bus/eventbus_target_routes_test.go
@@ -677,6 +677,12 @@ func TestEventBusPublish_TargetedDynamicFlowFixtureRouteTableNodePersistsSemanti
 	if !hasRoute("work.assign") {
 		t.Fatalf("materialized routes = %#v, want task-handler local work.assign route; node entries=%v", materialized, sortedStringKeys(bundle.NodeEntries()))
 	}
+	if hasRoute("worker/w-001/work.assign") {
+		t.Fatalf("materialized routes = %#v, want no selected receiver-carrier route for unrelated target-route fixture", materialized)
+	}
+	if resolved := eb.RouteTable().Resolve("worker/w-001/work.assign"); subscriberListContainsRouteSource(resolved, "task-handler", "worker/w-001", "receiver_carrier") {
+		t.Fatalf("Resolve(worker/w-001/work.assign) = %#v, want no receiver_carrier route for unrelated target-route fixture", resolved)
+	}
 	target := events.RouteIdentity{
 		FlowInstance: "worker/w-001",
 		EntityID:     runtimeflowidentity.EntityID("worker/w-001"),

--- a/internal/runtime/bus/eventbus_target_routes_test.go
+++ b/internal/runtime/bus/eventbus_target_routes_test.go
@@ -666,8 +666,16 @@ func TestEventBusPublish_TargetedDynamicFlowFixtureRouteTableNodePersistsSemanti
 		t.Fatalf("AddFlowInstanceRoute: %v", err)
 	}
 	materialized := eb.RouteTable().MaterializedRoutes(runtimeflowidentity.DeriveRoute("worker", "w-001"))
-	if len(materialized) != 1 || materialized[0].EventPattern != "work.assign" || materialized[0].SubscriberID != "task-handler" {
-		t.Fatalf("materialized routes = %#v, want task-handler local work.assign route; node entries=%v", materialized, sortedStringKeys(bundle.NodeEntries()))
+	hasRoute := func(eventPattern string) bool {
+		for _, route := range materialized {
+			if route.EventPattern == eventPattern && route.SubscriberID == "task-handler" {
+				return true
+			}
+		}
+		return false
+	}
+	if !hasRoute("work.assign") || !hasRoute("worker/w-001/work.assign") {
+		t.Fatalf("materialized routes = %#v, want task-handler local and selected receiver-carrier work.assign routes; node entries=%v", materialized, sortedStringKeys(bundle.NodeEntries()))
 	}
 	target := events.RouteIdentity{
 		FlowInstance: "worker/w-001",

--- a/internal/runtime/bus/routing_derivation.go
+++ b/internal/runtime/bus/routing_derivation.go
@@ -197,6 +197,9 @@ func (rt *RouteTable) AddFlowInstanceRoute(req FlowInstanceRouteMaterializationR
 						InstancePath: instancePath,
 					})
 				}
+				if !routeFlowInputHasLoweredConnectReceiver(rt.source, templateDef.FlowID, rawPattern) {
+					continue
+				}
 				for _, resolved := range routeReceiverCarrierSubscriberPatterns(templateDef.InputEvents, instancePath, rawPattern) {
 					resolvedSubscriber := routeApplyResolvedPattern(subscriber, resolved)
 					rt.patterns = append(rt.patterns, routePattern{
@@ -464,6 +467,9 @@ func (rt *RouteTable) addAgentPatternsLocked(source semanticview.Source, package
 			Path: strings.Trim(strings.TrimSpace(basePath), "/"),
 		}
 		for _, rawPattern := range normalizeStringList(entry.Subscriptions) {
+			if routeFlowInputHasLoweredConnectReceiver(source, flowID, rawPattern) && !routeInputAliasRequiresExclusivePatterns(source, flowID, rawPattern) {
+				rt.addReceiverCarrierPatternsLocked(inputEvents, basePath, subscriber, rawPattern)
+			}
 			for _, resolved := range routeResolveSubscriberPatterns(source, packageKey, flowID, inputEvents, basePath, localEvents, rawPattern) {
 				if strings.TrimSpace(resolved.EventPattern) == "" {
 					continue
@@ -495,6 +501,9 @@ func (rt *RouteTable) addNodePatternsLocked(source semanticview.Source, packageK
 			patterns = source.NodeRuntimeSubscriptions(nodeID)
 		}
 		for _, rawPattern := range patterns {
+			if routeFlowInputHasLoweredConnectReceiver(source, flowID, rawPattern) && !routeInputAliasRequiresExclusivePatterns(source, flowID, rawPattern) {
+				rt.addReceiverCarrierPatternsLocked(inputEvents, basePath, subscriber, rawPattern)
+			}
 			for _, resolved := range routeResolveSubscriberPatterns(source, packageKey, flowID, inputEvents, basePath, localEvents, rawPattern) {
 				if strings.TrimSpace(resolved.EventPattern) == "" {
 					continue
@@ -516,6 +525,16 @@ func (rt *RouteTable) addNodePatternsLocked(source semanticview.Source, packageK
 				})
 			}
 		}
+	}
+}
+
+func (rt *RouteTable) addReceiverCarrierPatternsLocked(inputEvents []string, basePath string, subscriber Subscriber, rawPattern string) {
+	for _, resolved := range routeReceiverCarrierSubscriberPatterns(inputEvents, basePath, rawPattern) {
+		resolvedSubscriber := routeApplyResolvedPattern(subscriber, resolved)
+		rt.patterns = append(rt.patterns, routePattern{
+			EventPattern: resolved.EventPattern,
+			Subscriber:   resolvedSubscriber,
+		})
 	}
 }
 
@@ -604,6 +623,30 @@ func routeFlowInputHasExternalProducer(source semanticview.Source, flowID, event
 		return true
 	}
 	return len(source.ResolveFlowInputAutoWire(flowID, eventType).Patterns) > 0
+}
+
+func routeFlowInputHasLoweredConnectReceiver(source semanticview.Source, flowID, eventType string) bool {
+	if source == nil || strings.TrimSpace(flowID) == "" {
+		return false
+	}
+	eventType = eventidentity.Normalize(eventType)
+	if eventType == "" {
+		return false
+	}
+	for _, connect := range source.CompositionConnects() {
+		to, err := connect.ToRef()
+		if err != nil || strings.TrimSpace(to.FlowID) != strings.TrimSpace(flowID) {
+			continue
+		}
+		inputPin, ok := source.FlowInputEventPin(to.FlowID, to.Pin)
+		if !ok {
+			continue
+		}
+		if eventidentity.Normalize(inputPin.EventType()) == eventType {
+			return true
+		}
+	}
+	return false
 }
 
 func routeInputAliasRequiresExclusivePatterns(source semanticview.Source, flowID, eventType string) bool {

--- a/internal/runtime/bus/routing_derivation.go
+++ b/internal/runtime/bus/routing_derivation.go
@@ -197,6 +197,14 @@ func (rt *RouteTable) AddFlowInstanceRoute(req FlowInstanceRouteMaterializationR
 						InstancePath: instancePath,
 					})
 				}
+				for _, resolved := range routeReceiverCarrierSubscriberPatterns(templateDef.InputEvents, instancePath, rawPattern) {
+					resolvedSubscriber := routeApplyResolvedPattern(subscriber, resolved)
+					rt.patterns = append(rt.patterns, routePattern{
+						EventPattern: resolved.EventPattern,
+						Subscriber:   resolvedSubscriber,
+						InstancePath: instancePath,
+					})
+				}
 			}
 		}
 		rt.rebuildLocked()
@@ -778,6 +786,23 @@ func routeResolveSubscriberPatterns(source semanticview.Source, packageKey, flow
 		return nil
 	}
 	return []routeResolvedPattern{{EventPattern: pattern, RouteSource: "subscription"}}
+}
+
+func routeReceiverCarrierSubscriberPatterns(inputEvents []string, instancePath, raw string) []routeResolvedPattern {
+	raw = eventidentity.Normalize(raw)
+	instancePath = strings.Trim(strings.TrimSpace(instancePath), "/")
+	if raw == "" || strings.Contains(raw, "*") || instancePath == "" {
+		return nil
+	}
+	if !routeFlowHasInputEvent(inputEvents, raw) {
+		return nil
+	}
+	return []routeResolvedPattern{{
+		EventPattern:   instancePath + "/" + raw,
+		MatchPattern:   raw,
+		RouteSource:    "receiver_carrier",
+		LocalizedEvent: raw,
+	}}
 }
 
 func routeFlowHasInputEvent(inputEvents []string, eventType string) bool {

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -548,6 +548,10 @@ contract_formats:
               interpretation. If the selected receiver identity cannot locate a
               concrete receiver carrier, the matched plan fails closed instead
               of recovering through source/raw/legacy subscriber routes.
+              Static and template lowered-connect receiver subscribers for
+              concrete flow input events MUST materialize receiver-carrier
+              evidence at the selected receiver path, except where
+              import-boundary alias policy requires exclusive alias patterns.
           descriptor_evidence_boundary:
             status: merge_bearing_runtime_behavior
             implementation_slice: '#1485'
@@ -4960,7 +4964,10 @@ flow_model:
             interpretations are not carrier lookup inputs for a matched lowered
             plan. Descriptor loading in the EventBus connect resolver is
             limited to matched plans whose supported target form requires
-            runtime descriptor evidence.
+            runtime descriptor evidence. Static and template lowered-connect
+            receiver subscribers for concrete flow input events materialize
+            receiver carrier evidence at the selected receiver path rather than
+            relying on producer-key subscription projection.
           does_not_close:
           - legacy eventDeliveryPlan compatibility collapse or removal
           - direct-recipient publish policy
@@ -4969,6 +4976,7 @@ flow_model:
           - broad composition-first routing parent closure
           proof_obligations:
           - matched connect receiver carrier lookup excludes source/raw fallback keys
+          - static and template lowered-connect receiver input subscribers materialize selected receiver-carrier keys
           - static matched connect plans do not load descriptors
           - descriptor-backed matched connect plans load only supported descriptor evidence
           - Publish, PublishInMutation, CheckPublishRecipientPlan, and engineOutbox preserve the corrected RoutePlan path where relevant

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -534,6 +534,32 @@ contract_formats:
             by post-planning recipient materialization hooks. #1482 promotes this matched decision into explicit
             RoutePlan authority state so materializer eligibility and fail-closed zero-route behavior are structural rather
             than inferred from connect-route metadata.
+          receiver_carrier_lookup_boundary:
+            status: merge_bearing_runtime_behavior
+            implementation_slice: '#1485'
+            canonical_code_owner: internal/runtime/bus.connectReceiverCarrierRouteKeys
+            rule: |
+              For a matched lowered ConnectRoutePlan, RouteTable lookup is a
+              concrete receiver-carrier lookup only. Lookup keys MUST be derived
+              from the selected materialized receiver target identity and the
+              receiver endpoint. They MUST NOT include the producer/source
+              endpoint, raw producer event name, source-scoped event name, live
+              subscriber fallback keys, or any other lower-precedence route
+              interpretation. If the selected receiver identity cannot locate a
+              concrete receiver carrier, the matched plan fails closed instead
+              of recovering through source/raw/legacy subscriber routes.
+          descriptor_evidence_boundary:
+            status: merge_bearing_runtime_behavior
+            implementation_slice: '#1485'
+            canonical_code_owner: internal/runtime/bus.connectRoutePlanResolver.descriptorsForPlans
+            rule: |
+              Descriptor loading during lowered-connect EventBus planning is
+              evidence for supported runtime-resolution target forms only.
+              Static lowered ConnectRoutePlan matches MUST NOT load or depend on
+              legacy active-agent recipient-policy descriptors. Runtime
+              descriptor evidence MUST NOT promote unsupported arbitrary
+              business-field targets; those remain fail-closed until a separate
+              typed descriptor/index owner is promoted.
           supported_surface:
           - static receiver singular delivery
           - identity-style template/dynamic receiver fanout through supported descriptor targets
@@ -4922,6 +4948,30 @@ flow_model:
           - singular target, target_set fanout, and reply metadata are covered
           - unsupported business-field descriptor targets remain fail-closed and split to #1479
           - '#1473 does not close #1474, #1475, selected-contract runfork readiness, or #1466 parent closure'
+        implementation_slice_1485:
+          status: merge_bearing_runtime_behavior
+          canonical_code_owner: internal/runtime/bus.connectRoutePlanResolver with connectReceiverCarrierRouteKeys
+          rule: |
+            Lower-precedence route interpreters are separated from matched
+            lowered-connect RoutePlan authority. RouteTable may locate concrete
+            receiver carriers only after the lowered plan has selected a
+            receiver target identity; source endpoint keys, raw producer event
+            names, live subscriber fallback, and legacy route/subscriber
+            interpretations are not carrier lookup inputs for a matched lowered
+            plan. Descriptor loading in the EventBus connect resolver is
+            limited to matched plans whose supported target form requires
+            runtime descriptor evidence.
+          does_not_close:
+          - legacy eventDeliveryPlan compatibility collapse or removal
+          - direct-recipient publish policy
+          - positive arbitrary business-field descriptor/index support
+          - selected-contract runfork route/readiness mutation
+          - broad composition-first routing parent closure
+          proof_obligations:
+          - matched connect receiver carrier lookup excludes source/raw fallback keys
+          - static matched connect plans do not load descriptors
+          - descriptor-backed matched connect plans load only supported descriptor evidence
+          - Publish, PublishInMutation, CheckPublishRecipientPlan, and engineOutbox preserve the corrected RoutePlan path where relevant
         invalid_outputs:
         - raw same-name pin match used as final topology authority
         - live subscription list used to invent missing connect topology


### PR DESCRIPTION
## Summary

Part of #1485.

This implements the approved first slice `lowered_connect_receiver_carrier_lookup_and_descriptor_evidence_boundary`:

- removes producer/source endpoint keys from matched lowered-connect receiver carrier lookup;
- materializes template instance receiver-carrier route keys so descriptor-backed connected outputs can resolve through selected receiver identity instead of source fallback;
- proves static connect does not load descriptor evidence, while descriptor-backed fanout does;
- updates `platform-spec.yaml` with the #1485 receiver-carrier and descriptor-evidence boundaries.

## Governing refs

- `platform-spec.yaml#contract_formats.event_schema.routing_derivation.delivery_rules.workflow_node_route_authority`
- `platform-spec.yaml#contract_formats.event_schema.routing_derivation.route_plan_authority`
- `platform-spec.yaml#contract_formats.event_schema.routing_derivation.route_plan_authority.decision_state`
- `platform-spec.yaml#contract_formats.event_schema.routing_derivation.route_plan_authority.lowered_connect_route_plan_consumption`
- `platform-spec.yaml#flow_model.flow_package.composition_routing.route_plan_lowering`
- `platform-spec.yaml#flow_model.flow_package.composition_routing.route_plan_lowering.implementation_slice_1473`
- New in this PR: `receiver_carrier_lookup_boundary`, `descriptor_evidence_boundary`, and `implementation_slice_1485`.

## Semantic migration

- New canonical owner for this slice: `internal/runtime/bus.connectReceiverCarrierRouteKeys` plus `connectRoutePlanResolver` after `RoutePlan.AuthorityState` selects matched lowered-connect authority.
- Old invalid path: `connectReceiverRouteKeys` included producer/source endpoint keys, allowing matched connect receiver lookup to depend on lower-precedence source route interpretation.
- Production paths checked: `Publish`, `PublishAcknowledged`, `PublishInMutation`, `CheckPublishRecipientPlan`, `engineOutbox`, `RouteTable.Resolve`, descriptor loaders, and legacy compatibility accounting.
- Migration completeness: complete for the approved first slice. Full #1485 remains open for legacy `eventDeliveryPlan` compatibility/direct-delivery tail unless separately gated.

## Proof

- `go test ./internal/runtime/bus ./internal/runtime/core/pinrouting ./internal/runtime/runforkadmission ./internal/runtime/runforkexecution -run 'ConnectRoutePlan|RoutePlan|RecipientPlan|RouteTable|Descriptor|eventDeliveryPlan|PublishInMutation|EngineOutbox|SelectedContract|RouteTopology|RouteHistory|Readiness|RouteRecovery|BusinessField' -count=1`
- `go test ./...`
