### PR TITLE
[agent-a][issue #1494] Harden route authority drift guardrails

### DIFF
--- a/internal/runtime/conformance/route_authority_drift_inventory_test.go
+++ b/internal/runtime/conformance/route_authority_drift_inventory_test.go
@@ -15,17 +15,18 @@ import (
 const routeAuthorityDriftInventoryPath = "internal/runtime/conformance/testdata/route_authority_drift_inventory.yaml"
 
 type routeAuthorityDriftInventory struct {
-	Version            int                                  `yaml:"version"`
-	Kind               string                               `yaml:"kind"`
-	Issue              int                                  `yaml:"issue"`
-	ParentIssues       []int                                `yaml:"parent_issues"`
-	Watchlist          string                               `yaml:"watchlist"`
-	Policy             routeAuthorityDriftInventoryPolicy   `yaml:"policy"`
-	Sources            routeAuthorityDriftInventorySources  `yaml:"sources"`
-	SearchDimensions   []routeAuthorityDriftSearchDimension `yaml:"search_dimensions"`
-	SeamFamilies       []routeAuthorityDriftSeamFamily      `yaml:"seam_families"`
-	GuardrailProposals []routeAuthorityDriftGuardrail       `yaml:"guardrail_proposals"`
-	FollowUpDecision   routeAuthorityDriftFollowUpDecision  `yaml:"follow_up_decision"`
+	Version              int                                  `yaml:"version"`
+	Kind                 string                               `yaml:"kind"`
+	Issue                int                                  `yaml:"issue"`
+	ImplementationIssues []int                                `yaml:"implementation_issues"`
+	ParentIssues         []int                                `yaml:"parent_issues"`
+	Watchlist            string                               `yaml:"watchlist"`
+	Policy               routeAuthorityDriftInventoryPolicy   `yaml:"policy"`
+	Sources              routeAuthorityDriftInventorySources  `yaml:"sources"`
+	SearchDimensions     []routeAuthorityDriftSearchDimension `yaml:"search_dimensions"`
+	SeamFamilies         []routeAuthorityDriftSeamFamily      `yaml:"seam_families"`
+	GuardrailProposals   []routeAuthorityDriftGuardrail       `yaml:"guardrail_proposals"`
+	FollowUpDecision     routeAuthorityDriftFollowUpDecision  `yaml:"follow_up_decision"`
 }
 
 type routeAuthorityDriftInventoryPolicy struct {
@@ -45,11 +46,12 @@ type routeAuthorityDriftInventorySources struct {
 }
 
 type routeAuthorityDriftSearchDimension struct {
-	ID                   string   `yaml:"id"`
-	Pattern              string   `yaml:"pattern"`
-	MinimumMatchingFiles int      `yaml:"minimum_matching_files"`
-	RequiredPaths        []string `yaml:"required_paths"`
-	CanonicalLayer       string   `yaml:"canonical_layer"`
+	ID                      string   `yaml:"id"`
+	Pattern                 string   `yaml:"pattern"`
+	MinimumMatchingFiles    int      `yaml:"minimum_matching_files"`
+	RequiredPaths           []string `yaml:"required_paths"`
+	CanonicalLayer          string   `yaml:"canonical_layer"`
+	ClassifiedPathsRequired bool     `yaml:"classified_paths_required"`
 }
 
 type routeAuthorityDriftSeamFamily struct {
@@ -136,6 +138,13 @@ func TestRouteAuthorityDriftInventoryRejectsNarrowOrStaleAudit(t *testing.T) {
 			},
 			want: "policy claims_runtime_behavior_closure = true, want false",
 		},
+		{
+			name: "current child issue must stay visible",
+			mutate: func(inventory *routeAuthorityDriftInventory) {
+				inventory.ImplementationIssues = []int{1364}
+			},
+			want: "inventory implementation_issues missing #1494",
+		},
 	}
 
 	for _, tc := range tests {
@@ -150,6 +159,22 @@ func TestRouteAuthorityDriftInventoryRejectsNarrowOrStaleAudit(t *testing.T) {
 				t.Fatalf("validation problems missing %q:\n- %s", tc.want, strings.Join(problems, "\n- "))
 			}
 		})
+	}
+}
+
+func TestRouteAuthorityDriftInventoryRejectsUnclassifiedRouteLikeProducer(t *testing.T) {
+	root := conformanceRepoRoot(t)
+	inventory := loadRouteAuthorityDriftInventory(t, root)
+	corpus := routeAuthorityDriftNewValidationCorpus(root)
+	corpus.Files = append(corpus.Files, routeAuthorityDriftRepoFile{
+		Path: "internal/runtime/bus/untracked_route_authority.go",
+		Raw:  []byte("package bus\n\nfunc untracked(plan ConnectRoutePlan) { _ = plan }\n"),
+	})
+
+	problems := validateRouteAuthorityDriftInventoryWithCorpus(root, corpus, inventory)
+	want := "connect_route_plan matched unclassified path internal/runtime/bus/untracked_route_authority.go"
+	if !routeAuthorityProblemsContain(problems, want) {
+		t.Fatalf("validation problems missing %q:\n- %s", want, strings.Join(problems, "\n- "))
 	}
 }
 
@@ -182,7 +207,12 @@ func validateRouteAuthorityDriftInventoryWithCorpus(root string, corpus *routeAu
 	if inventory.Issue != 1364 {
 		problems = append(problems, fmt.Sprintf("inventory issue = #%d, want #1364", inventory.Issue))
 	}
-	for _, issue := range []int{1340, 1353} {
+	for _, issue := range []int{1364, 1494} {
+		if !routeAuthorityDriftHasInt(inventory.ImplementationIssues, issue) {
+			problems = append(problems, fmt.Sprintf("inventory implementation_issues missing #%d", issue))
+		}
+	}
+	for _, issue := range []int{1340, 1353, 1481, 1493} {
 		if !routeAuthorityDriftHasInt(inventory.ParentIssues, issue) {
 			problems = append(problems, fmt.Sprintf("inventory parent_issues missing #%d", issue))
 		}
@@ -230,6 +260,7 @@ func validateRouteAuthorityDriftInventoryWithCorpus(root string, corpus *routeAu
 			problems = append(problems, fmt.Sprintf("missing required seam_family %s", id))
 		}
 	}
+	problems = append(problems, validateRouteAuthorityDriftClassifiedMatches(root, corpus, dimensionsByID, familiesByID)...)
 	problems = append(problems, validateRouteAuthorityDriftGuardrails(root, inventory.GuardrailProposals)...)
 	if inventory.FollowUpDecision.NewChildRequiredBeforeCoding {
 		problems = append(problems, "follow_up_decision new_child_required_before_coding = true, want false for approved audit slice")
@@ -247,10 +278,39 @@ func validateRouteAuthorityDriftInventoryWithCorpus(root string, corpus *routeAu
 	return problems
 }
 
+func validateRouteAuthorityDriftClassifiedMatches(root string, corpus *routeAuthorityDriftValidationCorpus, dimensions map[string]routeAuthorityDriftSearchDimension, families map[string]routeAuthorityDriftSeamFamily) []string {
+	var problems []string
+	classifiedPaths := map[string]struct{}{}
+	for _, family := range families {
+		for _, path := range family.Paths {
+			classifiedPaths[filepath.ToSlash(filepath.Clean(path))] = struct{}{}
+		}
+	}
+	for _, dimension := range dimensions {
+		if !dimension.ClassifiedPathsRequired {
+			continue
+		}
+		re, err := regexp.Compile(strings.TrimSpace(dimension.Pattern))
+		if err != nil {
+			continue
+		}
+		for _, path := range routeAuthorityDriftMatchingFiles(corpus, dimension.Pattern, re) {
+			path = filepath.ToSlash(filepath.Clean(path))
+			if routeAuthorityDriftSelfAuditFile(path) {
+				continue
+			}
+			if _, ok := classifiedPaths[path]; !ok {
+				problems = append(problems, fmt.Sprintf("%s matched unclassified path %s", dimension.ID, path))
+			}
+		}
+	}
+	return problems
+}
+
 func validateRouteAuthorityDriftPolicy(policy routeAuthorityDriftInventoryPolicy) []string {
 	var problems []string
-	if policy.ClosureLevel != "repo_wide_inventory_and_guardrail_proposal" {
-		problems = append(problems, fmt.Sprintf("policy closure_level = %q, want repo_wide_inventory_and_guardrail_proposal", policy.ClosureLevel))
+	if policy.ClosureLevel != "route_authority_seam_inventory_guardrail_first_slice" {
+		problems = append(problems, fmt.Sprintf("policy closure_level = %q, want route_authority_seam_inventory_guardrail_first_slice", policy.ClosureLevel))
 	}
 	if policy.ClaimsParentClosure {
 		problems = append(problems, "policy claims_parent_closure = true, want false")
@@ -519,6 +579,13 @@ func requiredRouteAuthorityDriftSearchDimensions() []string {
 		"event_deliveries",
 		"delivery_route_model",
 		"route_plan",
+		"connect_route_plan",
+		"route_table_resolve",
+		"receiver_carrier",
+		"descriptor_evidence",
+		"event_delivery_plan_compatibility",
+		"direct_delivery_path",
+		"route_plan_source_reason",
 		"flow_instance",
 		"event_name_type",
 		"semantic_scope",
@@ -547,6 +614,13 @@ func requiredRouteAuthorityDriftSeamFamilies() []string {
 		"event_context_inputs",
 		"route_topology_and_table",
 		"eventbus_route_plan_authority",
+		"lowered_connect_route_intent_authority",
+		"route_table_resolve_role_separation",
+		"receiver_carrier_evidence",
+		"descriptor_evidence_non_authority",
+		"event_delivery_plan_compatibility_adapter",
+		"direct_delivery_path_classification",
+		"route_plan_source_reason_constants",
 		"durable_delivery_authority_writers",
 		"workflow_node_execution_admission",
 		"live_carriers_internal_subscriptions",
@@ -561,20 +635,22 @@ func requiredRouteAuthorityDriftSeamFamilies() []string {
 
 func allowedRouteAuthorityDriftLayers() map[string]struct{} {
 	return map[string]struct{}{
-		"spec_authority":                    {},
-		"event_context":                     {},
-		"route_topology":                    {},
-		"route_plan_authority":              {},
-		"route_plan_consumers":              {},
-		"durable_delivery_authority":        {},
-		"execution_admission":               {},
-		"live_dispatch_non_authority":       {},
-		"completion_evidence_non_authority": {},
-		"replay_recovery_consumers":         {},
-		"public_projection_non_authority":   {},
-		"invalid_old_authority":             {},
-		"test_fixture_semantics":            {},
-		"conformance_guardrails":            {},
+		"spec_authority":                      {},
+		"event_context":                       {},
+		"route_topology":                      {},
+		"route_plan_authority":                {},
+		"route_plan_consumers":                {},
+		"descriptor_evidence_non_authority":   {},
+		"compatibility_adapter_non_authority": {},
+		"durable_delivery_authority":          {},
+		"execution_admission":                 {},
+		"live_dispatch_non_authority":         {},
+		"completion_evidence_non_authority":   {},
+		"replay_recovery_consumers":           {},
+		"public_projection_non_authority":     {},
+		"invalid_old_authority":               {},
+		"test_fixture_semantics":              {},
+		"conformance_guardrails":              {},
 	}
 }
 

--- a/internal/runtime/conformance/route_authority_drift_inventory_test.go
+++ b/internal/runtime/conformance/route_authority_drift_inventory_test.go
@@ -178,6 +178,41 @@ func TestRouteAuthorityDriftInventoryRejectsUnclassifiedRouteLikeProducer(t *tes
 	}
 }
 
+func TestRouteAuthorityDriftInventoryRejectsDimensionMismatchClassification(t *testing.T) {
+	root := conformanceRepoRoot(t)
+	inventory := loadRouteAuthorityDriftInventory(t, root)
+	corpus := routeAuthorityDriftNewValidationCorpus(root)
+	const path = "internal/runtime/bus/misclassified_route_authority.go"
+	corpus.Files = append(corpus.Files, routeAuthorityDriftRepoFile{
+		Path: path,
+		Raw:  []byte("package bus\n\nfunc misclassified(plan ConnectRoutePlan) { _ = plan }\n"),
+	})
+	family := routeAuthorityDriftSeamFamilyByID(t, &inventory, "event_context_inputs")
+	family.Paths = append(family.Paths, path)
+
+	problems := validateRouteAuthorityDriftInventoryWithCorpus(root, corpus, inventory)
+	want := "connect_route_plan matched unclassified path internal/runtime/bus/misclassified_route_authority.go"
+	if !routeAuthorityProblemsContain(problems, want) {
+		t.Fatalf("validation problems missing %q:\n- %s", want, strings.Join(problems, "\n- "))
+	}
+}
+
+func TestRouteAuthorityDriftInventoryRejectsUnclassifiedDirectDeliveryPath(t *testing.T) {
+	root := conformanceRepoRoot(t)
+	inventory := loadRouteAuthorityDriftInventory(t, root)
+	corpus := routeAuthorityDriftNewValidationCorpus(root)
+	corpus.Files = append(corpus.Files, routeAuthorityDriftRepoFile{
+		Path: "internal/runtime/bus/untracked_direct_delivery.go",
+		Raw:  []byte("package bus\n\nfunc (b *bus) PublishDirect(ctx context.Context, evt events.Event, recipients []string) error { return nil }\n"),
+	})
+
+	problems := validateRouteAuthorityDriftInventoryWithCorpus(root, corpus, inventory)
+	want := "direct_delivery_path matched unclassified path internal/runtime/bus/untracked_direct_delivery.go"
+	if !routeAuthorityProblemsContain(problems, want) {
+		t.Fatalf("validation problems missing %q:\n- %s", want, strings.Join(problems, "\n- "))
+	}
+}
+
 func loadRouteAuthorityDriftInventory(t *testing.T, root string) routeAuthorityDriftInventory {
 	t.Helper()
 	raw, err := os.ReadFile(filepath.Join(root, routeAuthorityDriftInventoryPath))
@@ -280,16 +315,11 @@ func validateRouteAuthorityDriftInventoryWithCorpus(root string, corpus *routeAu
 
 func validateRouteAuthorityDriftClassifiedMatches(root string, corpus *routeAuthorityDriftValidationCorpus, dimensions map[string]routeAuthorityDriftSearchDimension, families map[string]routeAuthorityDriftSeamFamily) []string {
 	var problems []string
-	classifiedPaths := map[string]struct{}{}
-	for _, family := range families {
-		for _, path := range family.Paths {
-			classifiedPaths[filepath.ToSlash(filepath.Clean(path))] = struct{}{}
-		}
-	}
 	for _, dimension := range dimensions {
 		if !dimension.ClassifiedPathsRequired {
 			continue
 		}
+		classifiedPaths := routeAuthorityDriftClassifiedPathsForDimension(dimension.ID, families)
 		re, err := regexp.Compile(strings.TrimSpace(dimension.Pattern))
 		if err != nil {
 			continue
@@ -305,6 +335,28 @@ func validateRouteAuthorityDriftClassifiedMatches(root string, corpus *routeAuth
 		}
 	}
 	return problems
+}
+
+func routeAuthorityDriftClassifiedPathsForDimension(dimensionID string, families map[string]routeAuthorityDriftSeamFamily) map[string]struct{} {
+	classifiedPaths := map[string]struct{}{}
+	for _, family := range families {
+		if !routeAuthorityDriftFamilyReferencesDimension(family, dimensionID) {
+			continue
+		}
+		for _, path := range family.Paths {
+			classifiedPaths[filepath.ToSlash(filepath.Clean(path))] = struct{}{}
+		}
+	}
+	return classifiedPaths
+}
+
+func routeAuthorityDriftFamilyReferencesDimension(family routeAuthorityDriftSeamFamily, dimensionID string) bool {
+	for _, dimension := range family.SearchDimensions {
+		if dimension == dimensionID {
+			return true
+		}
+	}
+	return false
 }
 
 func validateRouteAuthorityDriftPolicy(policy routeAuthorityDriftInventoryPolicy) []string {
@@ -476,7 +528,7 @@ func routeAuthorityDriftRepoFiles(root string) []routeAuthorityDriftRepoFile {
 		}
 		if entry.IsDir() {
 			switch entry.Name() {
-			case ".git", "vendor", "node_modules", "tmp":
+			case ".git", "vendor", "node_modules", "tmp", "test-results":
 				return filepath.SkipDir
 			}
 			return nil
@@ -552,6 +604,17 @@ func routeAuthorityDriftSearchDimensionByID(t *testing.T, inventory *routeAuthor
 		}
 	}
 	t.Fatalf("search dimension %s not found", id)
+	return nil
+}
+
+func routeAuthorityDriftSeamFamilyByID(t *testing.T, inventory *routeAuthorityDriftInventory, id string) *routeAuthorityDriftSeamFamily {
+	t.Helper()
+	for i := range inventory.SeamFamilies {
+		if inventory.SeamFamilies[i].ID == id {
+			return &inventory.SeamFamilies[i]
+		}
+	}
+	t.Fatalf("seam family %s not found", id)
 	return nil
 }
 

--- a/internal/runtime/conformance/route_authority_matrix_test.go
+++ b/internal/runtime/conformance/route_authority_matrix_test.go
@@ -213,7 +213,7 @@ func validateRouteAuthorityMatrix(root string, matrix routeAuthorityMatrix, ctx 
 		}
 		activeTrackers[key] = struct{}{}
 	}
-	for _, issue := range []int{1340} {
+	for _, issue := range []int{1340, 1481, 1493, 1494, 1495, 1496} {
 		key := routeAuthorityTrackerKey(issue, "runtime_operations.delivery_and_replay_ownership")
 		if _, ok := activeTrackers[key]; !ok {
 			problems = append(problems, fmt.Sprintf("active_trackers missing #%d runtime_operations.delivery_and_replay_ownership", issue))
@@ -469,6 +469,14 @@ func requiredRouteAuthorityRows() []string {
 		"workflow_node_execution_admission",
 		"wildcard_static_service_route_production",
 		"runtime_callback_flow_instance_localization",
+		"route_authority_drift_guardrail_inventory",
+		"lowered_connect_route_plan_authority_input",
+		"route_table_resolve_role_separation",
+		"receiver_carrier_lookup_not_authority",
+		"descriptor_evidence_not_authority",
+		"event_delivery_plan_compatibility_split",
+		"direct_delivery_path_split",
+		"route_plan_source_reason_constants",
 		"live_carriers_handler_lookup_descriptors_not_authority",
 		"receipts_settlement_backfill_not_authority",
 		"replay_markers_not_authority",
@@ -481,7 +489,10 @@ func requiredRouteAuthorityRows() []string {
 }
 
 func requiredRouteAuthoritySplitRows() map[string]int {
-	return nil
+	return map[string]int{
+		"event_delivery_plan_compatibility_split": 1496,
+		"direct_delivery_path_split":              1496,
+	}
 }
 
 func requiredRouteAuthorityCoveredRows() map[string]string {
@@ -493,6 +504,8 @@ func requiredRouteAuthorityCoveredRows() map[string]string {
 func requiredRouteAuthorityNegativeRows() []string {
 	return []string{
 		"live_carriers_handler_lookup_descriptors_not_authority",
+		"receiver_carrier_lookup_not_authority",
+		"descriptor_evidence_not_authority",
 		"receipts_settlement_backfill_not_authority",
 		"replay_markers_not_authority",
 		"readback_not_authority",
@@ -521,22 +534,29 @@ func allowedRouteAuthorityTiers() map[string]struct{} {
 
 func allowedRouteAuthorityProofDimensions() map[string]struct{} {
 	return map[string]struct{}{
-		"catalog_tiering":       {},
-		"cli_v1_path":           {},
-		"default_sqlite":        {},
-		"explicit_postgres":     {},
-		"full_conformance":      {},
-		"negative_authority":    {},
-		"openrpc_publication":   {},
-		"obsolete_duplicate":    {},
-		"persistence_authority": {},
-		"public_projection":     {},
-		"real_v1_handler":       {},
-		"replay_recovery":       {},
-		"required_pr_smoke":     {},
-		"route_plan_model":      {},
-		"source_authority":      {},
-		"split_tracker":         {},
+		"catalog_tiering":         {},
+		"cli_v1_path":             {},
+		"compatibility_adapter":   {},
+		"connect_route_plan":      {},
+		"direct_delivery":         {},
+		"default_sqlite":          {},
+		"descriptor_evidence":     {},
+		"explicit_postgres":       {},
+		"full_conformance":        {},
+		"guardrail_inventory":     {},
+		"negative_authority":      {},
+		"openrpc_publication":     {},
+		"obsolete_duplicate":      {},
+		"persistence_authority":   {},
+		"public_projection":       {},
+		"real_v1_handler":         {},
+		"replay_recovery":         {},
+		"required_pr_smoke":       {},
+		"route_plan_model":        {},
+		"route_table_resolve":     {},
+		"source_authority":        {},
+		"source_reason_constants": {},
+		"split_tracker":           {},
 	}
 }
 

--- a/internal/runtime/conformance/testdata/route_authority_drift_inventory.yaml
+++ b/internal/runtime/conformance/testdata/route_authority_drift_inventory.yaml
@@ -122,6 +122,7 @@ search_dimensions:
       - internal/runtime/manager/types.go
       - internal/runtime/tools/deps.go
     canonical_layer: route_plan_consumers
+    classified_paths_required: true
   - id: route_plan_source_reason
     pattern: 'routePlanSource|routePlanReason|RoutePlanAuthorityState|RoutePlanDeliveryIntent'
     minimum_matching_files: 7
@@ -377,6 +378,7 @@ seam_families:
     layer: route_topology
     classification: valid_consumer
     paths:
+      - internal/runtime/conformance/testdata/route_authority_matrix.yaml
       - internal/runtime/bus/connect_route_plan_dispatch.go
       - internal/runtime/runforkadmission/contract_frontier.go
       - internal/runtime/runforkadmission/selected_route_history.go
@@ -396,6 +398,7 @@ seam_families:
       - internal/runtime/bus/connect_route_plan_dispatch_test.go
       - internal/runtime/bus/eventbus_target_routes_test.go
       - internal/runtime/bus/routing_derivation.go
+      - internal/runtime/conformance/route_authority_matrix_test.go
       - internal/runtime/conformance/testdata/route_authority_matrix.yaml
     search_dimensions: [receiver_carrier, connect_route_plan]
     invalid_authority:
@@ -438,6 +441,7 @@ seam_families:
     layer: compatibility_adapter_non_authority
     classification: split_open_sibling
     paths:
+      - platform-spec.yaml
       - internal/runtime/bus/route_plan.go
       - internal/runtime/bus/delivery_planner.go
       - internal/runtime/bus/eventbus.go
@@ -458,13 +462,36 @@ seam_families:
     layer: route_plan_consumers
     classification: split_open_sibling
     paths:
+      - internal/apiv1/openrpc_mutating_runtime_test.go
+      - internal/apiv1/operator_event_replay.go
+      - internal/apiv1/operator_event_replay_test.go
+      - internal/runtime/agents/agent_llm_test.go
       - internal/runtime/bus/delivery_planner.go
       - internal/runtime/bus/eventbus_publish.go
-      - internal/runtime/bus/outbox.go
-      - internal/apiv1/operator_event_replay.go
-      - internal/runtime/pipeline/coordinator.go
+      - internal/runtime/bus/eventbus_publish_test.go
+      - internal/runtime/conformance/delivery_lifecycle_conformance_test.go
+      - internal/runtime/conformance/session_scope_conformance_test.go
+      - internal/runtime/manager/flow_activation_test.go
+      - internal/runtime/manager/receipts_test.go
+      - internal/runtime/manager/recovery_test.go
+      - internal/runtime/manager/runtime_chat_test.go
+      - internal/runtime/manager/runtime_reset_test.go
       - internal/runtime/manager/types.go
+      - internal/runtime/pipeline/handler_engine_transaction_test.go
+      - internal/runtime/pipeline/internal_subscription_test.go
+      - internal/runtime/pipeline/coordinator.go
+      - internal/runtime/pipeline/on_timeout_pipeline_test.go
+      - internal/runtime/pipeline/runtime_support.go
+      - internal/runtime/pipeline/workflow_conformance_test.go
+      - internal/runtime/pipeline/workflow_handler_preview.go
+      - internal/store/run_fork_selected_contract_route_recovery_test.go
+      - internal/store/sqlite_runtime_test.go
       - internal/runtime/tools/deps.go
+      - internal/runtime/tools/executor_agents.go
+      - internal/runtime/tools/executor_agents_test.go
+      - internal/runtime/tools/executor_emit_test.go
+      - internal/runtime/tools/executor_entity_test.go
+      - internal/runtime/tools/executor_telemetry_test.go
       - internal/runtime/conformance/testdata/route_authority_matrix.yaml
     search_dimensions: [direct_delivery_path, route_plan, publish_plan_consumers]
     invalid_authority:

--- a/internal/runtime/conformance/testdata/route_authority_drift_inventory.yaml
+++ b/internal/runtime/conformance/testdata/route_authority_drift_inventory.yaml
@@ -1,10 +1,11 @@
 version: 1
 kind: route_authority_drift_inventory
 issue: 1364
-parent_issues: [1340, 1353]
+implementation_issues: [1364, 1494]
+parent_issues: [1340, 1353, 1481, 1493]
 watchlist: runtime_operations.delivery_and_replay_ownership
 policy:
-  closure_level: repo_wide_inventory_and_guardrail_proposal
+  closure_level: route_authority_seam_inventory_guardrail_first_slice
   claims_parent_closure: false
   claims_runtime_behavior_closure: false
   runtime_behavior_changes_allowed: false
@@ -13,7 +14,10 @@ policy:
     interpreters, observers, projections, replay/recovery paths, store
     readers/writers, public readback, and test fixtures across the repository.
     It explicitly covers event name/type, semantic scope, entity/run/source
-    event context, and route/event-key derivation helpers. It must not be used
+    event context, route/event-key derivation helpers, lowered ConnectRoutePlan
+    artifacts, RouteTable.Resolve role boundaries, receiver-carrier evidence,
+    descriptor evidence, direct-delivery paths, legacy eventDeliveryPlan
+    compatibility, and RoutePlan source/reason constants. It must not be used
     as proof that runtime behavior changed.
 sources:
   platform_spec: platform-spec.yaml
@@ -49,6 +53,85 @@ search_dimensions:
       - internal/runtime/bus/route_plan.go
       - internal/runtime/conformance/testdata/route_authority_matrix.yaml
     canonical_layer: route_plan_authority
+  - id: connect_route_plan
+    pattern: '\bConnectRoutePlan\b|LowerCompositionConnectRoutePlans|connect_route_plan'
+    minimum_matching_files: 7
+    required_paths:
+      - platform-spec.yaml
+      - internal/runtime/core/pinrouting/connect_route_plan.go
+      - internal/runtime/core/pinrouting/connect_route_plan_test.go
+      - internal/runtime/bus/connect_route_plan_dispatch.go
+      - internal/runtime/bus/connect_route_plan_dispatch_test.go
+      - internal/runtime/bus/route_plan.go
+      - internal/apispec/platform_spec_composition_routing_test.go
+    canonical_layer: route_plan_authority
+    classified_paths_required: true
+  - id: route_table_resolve
+    pattern: '\bRouteTable\.Resolve\b|\brouteTable\.Resolve\b'
+    minimum_matching_files: 4
+    required_paths:
+      - internal/runtime/bus/connect_route_plan_dispatch.go
+      - internal/runtime/runforkadmission/contract_frontier.go
+      - internal/runtime/runforkadmission/selected_route_history.go
+      - internal/runtime/runstart/root_inputs.go
+    canonical_layer: route_topology
+    classified_paths_required: true
+  - id: receiver_carrier
+    pattern: 'receiver_carrier|connectReceiverCarrier|resolveSelectedReceiverCarriers|receiver carrier'
+    minimum_matching_files: 5
+    required_paths:
+      - platform-spec.yaml
+      - internal/runtime/bus/connect_route_plan_dispatch.go
+      - internal/runtime/bus/connect_route_plan_dispatch_test.go
+      - internal/runtime/bus/eventbus_target_routes_test.go
+      - internal/runtime/bus/routing_derivation.go
+    canonical_layer: live_dispatch_non_authority
+    classified_paths_required: true
+  - id: descriptor_evidence
+    pattern: 'PinRoutingDescriptors|TargetDescriptors|activeTargetDescriptors|activeAgentDescriptors|descriptorsForPlans|descriptor evidence|descriptor lookup|active descriptor'
+    minimum_matching_files: 11
+    required_paths:
+      - platform-spec.yaml
+      - internal/runtime/bus/connect_route_plan_dispatch.go
+      - internal/runtime/bus/delivery_planner.go
+      - internal/runtime/bus/eventbus.go
+      - internal/runtime/engine/interfaces.go
+      - internal/runtime/pipeline/engine_adapter.go
+    canonical_layer: descriptor_evidence_non_authority
+    classified_paths_required: true
+  - id: event_delivery_plan_compatibility
+    pattern: 'eventDeliveryPlan|CanonicalRoutePlan|routePlanFromLegacyEventDeliveryPlan'
+    minimum_matching_files: 6
+    required_paths:
+      - internal/runtime/bus/route_plan.go
+      - internal/runtime/bus/delivery_planner.go
+      - internal/runtime/bus/eventbus.go
+      - internal/runtime/bus/eventbus_publish.go
+      - internal/runtime/bus/connect_route_plan_dispatch_test.go
+      - internal/runtime/bus/eventbus_target_routes_test.go
+    canonical_layer: compatibility_adapter_non_authority
+    classified_paths_required: true
+  - id: direct_delivery_path
+    pattern: '\bPlanDirect\b|\bPublishDirect\(|\bCheckDirectRecipients\('
+    minimum_matching_files: 7
+    required_paths:
+      - internal/runtime/bus/delivery_planner.go
+      - internal/runtime/bus/eventbus_publish.go
+      - internal/apiv1/operator_event_replay.go
+      - internal/runtime/pipeline/coordinator.go
+      - internal/runtime/manager/types.go
+      - internal/runtime/tools/deps.go
+    canonical_layer: route_plan_consumers
+  - id: route_plan_source_reason
+    pattern: 'routePlanSource|routePlanReason|RoutePlanAuthorityState|RoutePlanDeliveryIntent'
+    minimum_matching_files: 7
+    required_paths:
+      - internal/runtime/bus/route_plan.go
+      - internal/runtime/bus/delivery_planner.go
+      - internal/runtime/bus/connect_route_plan_dispatch.go
+      - internal/runtime/bus/eventbus_publish.go
+    canonical_layer: route_plan_authority
+    classified_paths_required: true
   - id: flow_instance
     pattern: 'flow_instance|FlowInstance|flow instance|flow-instance'
     minimum_matching_files: 282
@@ -273,6 +356,141 @@ seam_families:
       EventBus owns the canonical RoutePlan model, typed delivery intents, and
       materializers. Publish, preflight, transactional, deferred, and outbox
       paths consume this owner.
+  - id: lowered_connect_route_intent_authority
+    layer: route_plan_authority
+    classification: canonical_owner
+    paths:
+      - platform-spec.yaml
+      - internal/apispec/platform_spec_composition_routing_test.go
+      - internal/runtime/core/pinrouting/connect_route_plan.go
+      - internal/runtime/core/pinrouting/connect_route_plan_test.go
+      - internal/runtime/bus/connect_route_plan_dispatch.go
+      - internal/runtime/bus/connect_route_plan_dispatch_test.go
+      - internal/runtime/bus/route_plan.go
+      - internal/runtime/conformance/testdata/route_authority_matrix.yaml
+    search_dimensions: [connect_route_plan, route_plan, route_plan_source_reason]
+    notes: >
+      Lowered ConnectRoutePlan is the typed route-intent artifact consumed by
+      EventBus planning. #1494 classifies it as route authority input and guard
+      surface; #1495 owns broader producer migration.
+  - id: route_table_resolve_role_separation
+    layer: route_topology
+    classification: valid_consumer
+    paths:
+      - internal/runtime/bus/connect_route_plan_dispatch.go
+      - internal/runtime/runforkadmission/contract_frontier.go
+      - internal/runtime/runforkadmission/selected_route_history.go
+      - internal/runtime/runstart/root_inputs.go
+    search_dimensions: [route_table_resolve, route_event_key_derivation]
+    notes: >
+      RouteTable.Resolve must be classified by role. EventBus lowered-connect
+      use is post-identity receiver-carrier lookup; runstart/runfork uses are
+      separate admission/readiness route-fact consumers, not publish-time route
+      authority.
+  - id: receiver_carrier_evidence
+    layer: live_dispatch_non_authority
+    classification: valid_consumer
+    paths:
+      - platform-spec.yaml
+      - internal/runtime/bus/connect_route_plan_dispatch.go
+      - internal/runtime/bus/connect_route_plan_dispatch_test.go
+      - internal/runtime/bus/eventbus_target_routes_test.go
+      - internal/runtime/bus/routing_derivation.go
+      - internal/runtime/conformance/testdata/route_authority_matrix.yaml
+    search_dimensions: [receiver_carrier, connect_route_plan]
+    invalid_authority:
+      - producer/source endpoint key
+      - raw producer event name
+      - live subscriber fallback key
+      - legacy route/subscriber interpretation after matched ConnectRoutePlan
+    notes: >
+      Receiver carriers are concrete dispatch evidence after a lowered plan
+      selects target identity. They must not repair or replace the route
+      authority decision.
+  - id: descriptor_evidence_non_authority
+    layer: descriptor_evidence_non_authority
+    classification: non_authoritative_observer_projection
+    paths:
+      - platform-spec.yaml
+      - internal/runtime/bus/connect_route_plan_dispatch.go
+      - internal/runtime/bus/connect_route_plan_dispatch_test.go
+      - internal/runtime/bus/delivery_planner.go
+      - internal/runtime/bus/delivery_planner_test.go
+      - internal/runtime/bus/eventbus.go
+      - internal/runtime/bus/eventbus_flow_instance_descriptors_test.go
+      - internal/runtime/bus/eventbus_publish_test.go
+      - internal/runtime/bus/eventbus_routing.go
+      - internal/runtime/engine/executor.go
+      - internal/runtime/engine/interfaces.go
+      - internal/runtime/pipeline/engine_adapter.go
+      - internal/runtime/conformance/testdata/route_authority_matrix.yaml
+    search_dimensions: [descriptor_evidence, connect_route_plan]
+    invalid_authority:
+      - active-agent descriptor lookup
+      - active target descriptors
+      - handler descriptor lookup
+      - unsupported business-field descriptor target
+    notes: >
+      Descriptor evidence may support explicitly approved target materialization
+      but is not delivery authority. Business-field descriptor/index support
+      remains split to #1479.
+  - id: event_delivery_plan_compatibility_adapter
+    layer: compatibility_adapter_non_authority
+    classification: split_open_sibling
+    paths:
+      - internal/runtime/bus/route_plan.go
+      - internal/runtime/bus/delivery_planner.go
+      - internal/runtime/bus/eventbus.go
+      - internal/runtime/bus/eventbus_publish.go
+      - internal/runtime/bus/connect_route_plan_dispatch_test.go
+      - internal/runtime/bus/eventbus_target_routes_test.go
+      - internal/runtime/conformance/testdata/route_authority_matrix.yaml
+    search_dimensions: [event_delivery_plan_compatibility, route_plan]
+    invalid_authority:
+      - legacy eventDeliveryPlan as final authority
+      - CanonicalRoutePlan fallback from legacy projection
+      - routePlanFromLegacyEventDeliveryPlan as new producer
+    notes: >
+      eventDeliveryPlan remains a compatibility projection around RoutePlan.
+      #1494 classifies and guards it; #1496 owns compatibility collapse or
+      isolation if behavior changes are needed.
+  - id: direct_delivery_path_classification
+    layer: route_plan_consumers
+    classification: split_open_sibling
+    paths:
+      - internal/runtime/bus/delivery_planner.go
+      - internal/runtime/bus/eventbus_publish.go
+      - internal/runtime/bus/outbox.go
+      - internal/apiv1/operator_event_replay.go
+      - internal/runtime/pipeline/coordinator.go
+      - internal/runtime/manager/types.go
+      - internal/runtime/tools/deps.go
+      - internal/runtime/conformance/testdata/route_authority_matrix.yaml
+    search_dimensions: [direct_delivery_path, route_plan, publish_plan_consumers]
+    invalid_authority:
+      - caller-supplied direct recipient list as subscribed route authority
+      - operator replay direct path as fresh publish-time route planner
+    notes: >
+      Direct delivery uses explicit caller recipients and delivery policy. It is
+      classified now so it cannot masquerade as subscribed RoutePlan authority;
+      #1496 owns further direct-delivery compatibility isolation.
+  - id: route_plan_source_reason_constants
+    layer: route_plan_authority
+    classification: canonical_owner
+    paths:
+      - internal/runtime/bus/route_plan.go
+      - internal/runtime/bus/delivery_planner.go
+      - internal/runtime/bus/delivery_planner_test.go
+      - internal/runtime/bus/connect_route_plan_dispatch.go
+      - internal/runtime/bus/connect_route_plan_dispatch_test.go
+      - internal/runtime/bus/eventbus_publish.go
+      - internal/runtime/bus/eventbus_target_routes_test.go
+      - internal/runtime/conformance/testdata/route_authority_matrix.yaml
+    search_dimensions: [route_plan_source_reason, route_plan]
+    notes: >
+      RoutePlan source/reason/authority-state constants are the current typed
+      route-intent metadata owner. #1494 guards their use until #1495 promotes
+      the broader typed route-intent model.
   - id: durable_delivery_authority_writers
     layer: durable_delivery_authority
     classification: canonical_owner
@@ -415,7 +633,7 @@ seam_families:
       - internal/runtime/conformance/testdata/route_authority_matrix.yaml
       - internal/runtime/conformance/route_authority_matrix_test.go
       - internal/runtime/conformance/testdata/route_authority_drift_inventory.yaml
-    search_dimensions: [route_plan, event_deliveries, workflow_runtime_carrier]
+    search_dimensions: [route_plan, event_deliveries, workflow_runtime_carrier, connect_route_plan, event_delivery_plan_compatibility]
     notes: >
       The matrix proves selected route-authority rows. This inventory proves
       the repo-wide drift audit boundary and identifies guardrails that should
@@ -435,11 +653,12 @@ guardrail_proposals:
       - marking parent route-authority closure while #1364-class drift inventory remains open
       - covering rows without a matrix or inventory proof reference
   - id: negative_authority_static_scan
-    implementation_state: ready_for_followup
-    target: internal/runtime/conformance
+    implementation_state: implemented_in_this_pr
+    target: internal/runtime/conformance/route_authority_drift_inventory_test.go
     prevents:
       - workflow-runtime carriers, live subscriptions, receipts, replay markers, or readback from becoming execution authority
       - new helper names that imply route authority outside EventContext or RoutePlan owners
+      - new ConnectRoutePlan, RouteTable.Resolve, eventDeliveryPlan, descriptor, receiver-carrier, or route source/reason paths from appearing without seam-family classification
   - id: direct_sql_fixture_classification_guard
     implementation_state: ready_for_followup
     target: internal/runtime/conformance
@@ -447,10 +666,10 @@ guardrail_proposals:
       - direct SQL tests from asserting delivery counts without typed semantic subscriber identity
       - store fixtures from becoming undocumented route-authority interpreters
 follow_up_decision:
-  tracker_state: "#1340 and #1353 remain sufficient parent trackers."
+  tracker_state: "#1494 extends the closed #1364 inventory owner under #1493; #1495/#1496/#1479/#1466/#1481 remain open for behavior or broader architecture work."
   new_child_required_before_coding: false
   runtime_behavior_child_required_now: false
   notes: >
-    No runtime behavior is selected in #1364. Concrete bypasses discovered
+    No runtime behavior is selected in #1494. Concrete bypasses discovered
     after this inventory must open or update a child issue and receive an
     independent implementation gate before coding.

--- a/internal/runtime/conformance/testdata/route_authority_matrix.yaml
+++ b/internal/runtime/conformance/testdata/route_authority_matrix.yaml
@@ -23,6 +23,21 @@ active_trackers:
   - kind: github_issue
     issue: 1340
     watchlist: runtime_operations.delivery_and_replay_ownership
+  - kind: github_issue
+    issue: 1481
+    watchlist: runtime_operations.delivery_and_replay_ownership
+  - kind: github_issue
+    issue: 1493
+    watchlist: runtime_operations.delivery_and_replay_ownership
+  - kind: github_issue
+    issue: 1494
+    watchlist: runtime_operations.delivery_and_replay_ownership
+  - kind: github_issue
+    issue: 1495
+    watchlist: runtime_operations.delivery_and_replay_ownership
+  - kind: github_issue
+    issue: 1496
+    watchlist: runtime_operations.delivery_and_replay_ownership
 rows:
   - id: route_plan_spec_contract
     concept: RoutePlan is the publish-time typed authority and event_deliveries is the durable authority sink.
@@ -283,6 +298,181 @@ rows:
       normalizes them to repo-scaffold/<id>/<local_event>, RoutePlan produces
       typed node recipients, and event_deliveries persists node authority
       before workflow-runtime carrier dispatch or #1293 execution admission.
+
+  - id: route_authority_drift_guardrail_inventory
+    concept: The #1364 route-authority drift inventory/matrix is promoted for #1494 as the conformance guardrail owner.
+    classification: already_covered_by_existing_proof
+    tier: required_pr_smoke
+    proof_dimensions: [guardrail_inventory, source_authority, required_pr_smoke]
+    owner_refs:
+      - {kind: artifact, path: internal/runtime/conformance/testdata/route_authority_drift_inventory.yaml}
+      - {kind: artifact, path: internal/runtime/conformance/route_authority_drift_inventory_test.go}
+      - {kind: artifact, path: internal/runtime/conformance/testdata/route_authority_matrix.yaml}
+      - {kind: spec_ref, path: platform-spec.yaml, ref: route_authority_drift_guardrails}
+    proof_refs:
+      - {kind: issue, issue: 1494}
+      - {kind: go_test, name: TestRouteAuthorityDriftInventoryCoversRepoWideSearchDimensions}
+      - {kind: go_test, name: TestRouteAuthorityDriftInventoryRejectsUnclassifiedRouteLikeProducer}
+      - {kind: go_test, name: TestRouteAuthorityMatrixCoversApprovedRows}
+    notes: >
+      #1494 reuses and hardens the existing #1364 conformance owner instead of
+      creating a parallel route-seam inventory. The inventory now has
+      CI-visible classified-path guards for route-like producers/interpreters.
+
+  - id: lowered_connect_route_plan_authority_input
+    concept: Lowered ConnectRoutePlan artifacts are route-intent authority inputs consumed by EventBus RoutePlan production.
+    classification: already_covered_by_existing_proof
+    tier: required_pr_smoke
+    proof_dimensions: [connect_route_plan, route_plan_model, source_authority, required_pr_smoke]
+    owner_refs:
+      - {kind: spec_ref, path: platform-spec.yaml, ref: route_plan_lowering}
+      - {kind: spec_ref, path: platform-spec.yaml, ref: lowered_connect_route_plan_consumption}
+      - {kind: artifact, path: internal/runtime/core/pinrouting/connect_route_plan.go}
+      - {kind: artifact, path: internal/runtime/bus/connect_route_plan_dispatch.go}
+    proof_refs:
+      - {kind: issue, issue: 1472}
+      - {kind: issue, issue: 1473}
+      - {kind: issue, issue: 1494}
+      - {kind: go_test, name: TestLowerCompositionConnectRoutePlanDoesNotDependOnRawPinNamesOrProducerTargets}
+      - {kind: go_test, name: TestEventBusPublish_ConnectRoutePlanPersistsSingularTargetWithoutLiveSubscriber}
+      - {kind: go_test, name: TestEventBusPublish_ConnectRoutePlanFailsClosedForUnsupportedBusinessFieldTarget}
+    notes: >
+      ConnectRoutePlan is a typed route-intent input, not an untracked string
+      fallback. #1495 owns additional typed producer migration after this
+      guardrail is in place.
+
+  - id: route_table_resolve_role_separation
+    concept: RouteTable.Resolve usages must be classified by role instead of treated as generic route authority.
+    classification: already_covered_by_existing_proof
+    tier: required_pr_smoke
+    proof_dimensions: [route_table_resolve, connect_route_plan, split_tracker, required_pr_smoke]
+    owner_refs:
+      - {kind: artifact, path: internal/runtime/bus/connect_route_plan_dispatch.go}
+      - {kind: artifact, path: internal/runtime/runforkadmission/contract_frontier.go}
+      - {kind: artifact, path: internal/runtime/runforkadmission/selected_route_history.go}
+      - {kind: artifact, path: internal/runtime/runstart/root_inputs.go}
+      - {kind: spec_ref, path: platform-spec.yaml, ref: receiver_carrier_lookup_boundary}
+    proof_refs:
+      - {kind: issue, issue: 1485}
+      - {kind: issue, issue: 1494}
+      - {kind: go_test, name: TestConnectRoutePlanReceiverCarrierKeysUseSelectedReceiverIdentity}
+      - {kind: go_test, name: TestSelectedContractRunForkRouteConsumersAreClassifiedOutsideEventBusRouteAuthority}
+      - {kind: go_test, name: TestDeriveRootInputSetRequiresDeclaredAndRoutableRootInput}
+    notes: >
+      EventBus connect dispatch uses RouteTable only as selected receiver-carrier
+      lookup. Runstart/runfork use RouteTable for split admission/readiness
+      route facts, not EventBus publish-time authority.
+
+  - id: receiver_carrier_lookup_not_authority
+    concept: Receiver-carrier lookup is post-identity carrier evidence and cannot repair a matched ConnectRoutePlan decision.
+    classification: already_covered_by_existing_proof
+    tier: required_pr_smoke
+    proof_dimensions: [connect_route_plan, route_table_resolve, negative_authority, required_pr_smoke]
+    invalid_authority:
+      - producer/source endpoint keys
+      - raw producer event names
+      - live subscriber fallback keys
+      - legacy route/subscriber interpretations after matched ConnectRoutePlan
+    owner_refs:
+      - {kind: spec_ref, path: platform-spec.yaml, ref: receiver_carrier_lookup_boundary}
+      - {kind: artifact, path: internal/runtime/bus/connect_route_plan_dispatch.go}
+      - {kind: artifact, path: internal/runtime/bus/routing_derivation.go}
+    proof_refs:
+      - {kind: issue, issue: 1485}
+      - {kind: go_test, name: TestConnectRoutePlanReceiverCarrierKeysUseSelectedReceiverIdentity}
+      - {kind: go_test, name: TestEventBusPublish_ConnectRoutePlanWithOnlySourceAndRawSubscribersFailsClosed}
+      - {kind: go_test, name: TestEventBusPublish_ConnectRoutePlanFailureSkipsRecipientPlanMaterializer}
+    notes: >
+      Receiver carriers may locate the concrete runtime handler after selected
+      route identity exists. They are invalid authority for source/raw fallback
+      and cannot revive a failed matched ConnectRoutePlan.
+
+  - id: descriptor_evidence_not_authority
+    concept: Descriptor evidence may support approved runtime target materialization but is not route authority.
+    classification: add_to_matrix
+    tier: required_pr_smoke
+    proof_dimensions: [descriptor_evidence, negative_authority, split_tracker, required_pr_smoke]
+    invalid_authority:
+      - active-agent descriptor lookup
+      - active target descriptors
+      - handler descriptor lookup
+      - unsupported business-field descriptor targets
+    owner_refs:
+      - {kind: spec_ref, path: platform-spec.yaml, ref: descriptor_evidence_boundary}
+      - {kind: spec_ref, path: platform-spec.yaml, ref: supported_descriptor_targets}
+      - {kind: artifact, path: internal/runtime/bus/connect_route_plan_dispatch.go}
+      - {kind: artifact, path: internal/runtime/bus/eventbus.go}
+      - {kind: artifact, path: internal/runtime/engine/interfaces.go}
+    proof_refs:
+      - {kind: issue, issue: 1479}
+      - {kind: issue, issue: 1494}
+      - {kind: go_test, name: TestConnectRoutePlanDescriptorsLoadOnlyForRuntimeResolution}
+      - {kind: go_test, name: TestEventBusPublish_ConnectRoutePlanFailsClosedForUnsupportedBusinessFieldTarget}
+      - {kind: go_test, name: TestEventBusPinRoutingDescriptorsIncludeActiveDynamicFlowInstances}
+    notes: >
+      Descriptor evidence remains limited to supported identity-style targets.
+      Arbitrary business-field descriptor/index support stays split to #1479.
+
+  - id: event_delivery_plan_compatibility_split
+    concept: eventDeliveryPlan and legacy CanonicalRoutePlan projection are compatibility adapters around RoutePlan, not a second authority owner.
+    classification: split_to_existing_issue
+    tier: split_open
+    split_issue: 1496
+    proof_dimensions: [compatibility_adapter, route_plan_model, split_tracker]
+    invalid_authority:
+      - legacy eventDeliveryPlan as final authority
+      - CanonicalRoutePlan fallback from legacy projection
+      - routePlanFromLegacyEventDeliveryPlan as new producer
+    owner_refs:
+      - {kind: artifact, path: internal/runtime/bus/route_plan.go}
+      - {kind: artifact, path: internal/runtime/bus/eventbus_publish.go}
+      - {kind: spec_ref, path: platform-spec.yaml, ref: route_authority_drift_guardrails}
+    proof_refs:
+      - {kind: tracker, issue: 1496, watchlist: runtime_operations.delivery_and_replay_ownership}
+      - {kind: issue, issue: 1494}
+    notes: >
+      #1494 classifies and guards the adapter surface. #1496 owns behavior work
+      to collapse or isolate compatibility paths if runtime migration is needed.
+
+  - id: direct_delivery_path_split
+    concept: Direct delivery and operator replay direct publish are explicitly classified route paths, not subscribed RoutePlan authority.
+    classification: split_to_existing_issue
+    tier: split_open
+    split_issue: 1496
+    proof_dimensions: [direct_delivery, route_plan_model, split_tracker]
+    invalid_authority:
+      - caller-supplied direct recipient list as subscribed route authority
+      - operator replay direct path as fresh route planner
+    owner_refs:
+      - {kind: artifact, path: internal/runtime/bus/delivery_planner.go}
+      - {kind: artifact, path: internal/runtime/bus/eventbus_publish.go}
+      - {kind: artifact, path: internal/apiv1/operator_event_replay.go}
+      - {kind: spec_ref, path: platform-spec.yaml, ref: route_authority_drift_guardrails}
+    proof_refs:
+      - {kind: tracker, issue: 1496, watchlist: runtime_operations.delivery_and_replay_ownership}
+      - {kind: issue, issue: 1494}
+    notes: >
+      Direct delivery stays classified as a separate path in this child. #1496
+      owns further compatibility isolation so #1494 does not silently migrate
+      direct-recipient behavior.
+
+  - id: route_plan_source_reason_constants
+    concept: RoutePlan source/reason constants and authority state carry the current route-intent decision metadata.
+    classification: already_covered_by_existing_proof
+    tier: required_pr_smoke
+    proof_dimensions: [source_reason_constants, route_plan_model, guardrail_inventory, required_pr_smoke]
+    owner_refs:
+      - {kind: artifact, path: internal/runtime/bus/route_plan.go}
+      - {kind: artifact, path: internal/runtime/conformance/testdata/route_authority_drift_inventory.yaml}
+      - {kind: spec_ref, path: platform-spec.yaml, ref: decision_state}
+    proof_refs:
+      - {kind: issue, issue: 1494}
+      - {kind: go_test, name: TestRoutePlanCanonicalFailClosedDropsExecutableRoutes}
+      - {kind: go_test, name: TestRouteAuthorityDriftInventoryCoversRepoWideSearchDimensions}
+      - {kind: go_test, name: TestRouteAuthorityDriftInventoryRejectsUnclassifiedRouteLikeProducer}
+    notes: >
+      The current source/reason constants remain the typed metadata owner until
+      #1495 promotes a broader typed route-intent model.
 
   - id: live_carriers_handler_lookup_descriptors_not_authority
     concept: Live carriers, interceptors, handler lookup, and active descriptors are consumers or observations only.

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -564,6 +564,30 @@ contract_formats:
               descriptor evidence MUST NOT promote unsupported arbitrary
               business-field targets; those remain fail-closed until a separate
               typed descriptor/index owner is promoted.
+          route_authority_drift_guardrails:
+            status: merge_bearing_conformance_guardrail
+            implementation_slice: '#1494'
+            canonical_artifacts:
+            - internal/runtime/conformance/testdata/route_authority_drift_inventory.yaml
+            - internal/runtime/conformance/route_authority_drift_inventory_test.go
+            - internal/runtime/conformance/testdata/route_authority_matrix.yaml
+            - internal/runtime/conformance/route_authority_matrix_test.go
+            rule: |
+              Route-authority conformance guardrails MUST extend the existing
+              route_authority_drift_inventory and route_authority_matrix owners
+              instead of creating parallel inventories. Guardrails MUST classify
+              route-like seams by role before they can be treated as approved:
+              canonical RoutePlan/ConnectRoutePlan production, RouteTable
+              carrier lookup, descriptor evidence, eventDeliveryPlan
+              compatibility, direct delivery, durable persistence sinks,
+              replay/readback consumers, diagnostics, or explicitly split
+              concepts.
+              New route-like producers, compatibility interpreters, source/reason
+              owners, or carrier/descriptor/direct-delivery seams MUST fail CI
+              until they are added to the conformance inventory with a named
+              classification and tracker disposition. These guardrails are
+              source-authority checks only; they MUST NOT migrate runtime
+              behavior without a separately approved issue gate.
           supported_surface:
           - static receiver singular delivery
           - identity-style template/dynamic receiver fanout through supported descriptor targets


### PR DESCRIPTION
## Summary
- Extend the existing #1364 route-authority drift inventory/matrix owners for the #1494 first slice instead of adding a parallel inventory owner.
- Add CI-visible guardrails for unclassified route-like producer/interpreter seams, including `ConnectRoutePlan`, `RouteTable.Resolve`, receiver-carrier evidence, descriptor evidence, legacy `eventDeliveryPlan` compatibility, direct-delivery classification, and RoutePlan source/reason metadata.
- Add the merge-bearing `platform-spec.yaml` source-authority anchor for route-authority drift guardrails.

Closes #1494

## Governing Refs / Context
- `platform-spec.yaml`: `runtime.event_bus.workflow_node_route_authority`
- `platform-spec.yaml`: `runtime.event_bus.route_plan_authority`
- `platform-spec.yaml`: `runtime.event_bus.route_plan_authority.decision_state`
- `platform-spec.yaml`: `runtime.event_bus.route_plan_authority.lowered_connect_route_plan_consumption`
- `platform-spec.yaml`: `runtime.event_bus.route_plan_authority.lowered_connect_route_plan_consumption.receiver_carrier_lookup_boundary`
- `platform-spec.yaml`: `runtime.event_bus.route_plan_authority.lowered_connect_route_plan_consumption.descriptor_evidence_boundary`
- `platform-spec.yaml`: `runtime.event_bus.route_plan_authority.lowered_connect_route_plan_consumption.route_authority_drift_guardrails`
- `platform-spec.yaml`: `flow_model.flow_package.composition_routing.route_plan_lowering`
- #1494 pre-audit: https://github.com/division-sh/swarm/issues/1494#issuecomment-4804998850
- #1494 gate: https://github.com/division-sh/swarm/issues/1494#issuecomment-4805019946

## Semantic Migration / Authority Notes
- New canonical guardrail owner: the existing #1364 `internal/runtime/conformance/testdata/route_authority_drift_inventory.yaml`, `internal/runtime/conformance/route_authority_drift_inventory_test.go`, `internal/runtime/conformance/testdata/route_authority_matrix.yaml`, and `internal/runtime/conformance/route_authority_matrix_test.go`, now extended for #1494.
- Old invalid path: ad hoc/parallel route-authority inventories or unclassified route-like producers/interpreters. New route-like seams must be classified in the existing inventory/matrix or CI fails.
- Production paths checked for surviving old behavior: `RoutePlan`, `ConnectRoutePlan`, `RouteTable.Resolve`, receiver-carrier evidence, descriptor evidence, legacy `eventDeliveryPlan`, direct delivery, delivery persistence/readback/replay, and source/reason constants.
- Migration completeness: complete for the approved #1494 conformance/source-authority guardrail slice. Runtime behavior migrations remain explicitly open under #1495, #1496, #1479, #1466, and #1481 unless separately gated.

## Tests
- `go test ./internal/runtime/conformance -run 'TestRouteAuthorityDriftInventory' -count=1`
- `go test ./internal/runtime/conformance -run 'TestRouteAuthority(Matrix|DriftInventory)' -count=1`
- `go test ./internal/runtime/conformance -run 'TestRouteAuthority' -count=1`
- `go test ./internal/runtime/bus ./internal/runtime/core/pinrouting ./internal/runtime/runstart ./internal/runtime/runforkadmission ./internal/runtime/runforkexecution ./internal/store ./internal/apiv1 -run 'Test.*(ConnectRoutePlan|RouteTable|RouteAuthority|Direct|EventDeliveryRoutes|Replay|SelectedContractRunForkRouteConsumers|DeriveRootInputSet|RouteHistory|RootInput)' -count=1`
- `go test ./...`