### PR TITLE
[agent-a][issue #1495] Type route intent producers

### DIFF
--- a/internal/runtime/bus/connect_route_plan_dispatch.go
+++ b/internal/runtime/bus/connect_route_plan_dispatch.go
@@ -97,7 +97,7 @@ func (r connectRoutePlanResolver) Plan(ctx context.Context, evt events.Event) (c
 			out.ExtraDetail["connect_route_plan_receiver_event"] = plan.Receiver.ResolvedEvent
 			return out, nil
 		}
-		out.DeliveryIntents = append(out.DeliveryIntents, routePlanDeliveryIntentsFromRoutes(routes, routePlanSourceConnectRoutePlan, routePlanReasonLoweredConnectRoutePlan)...)
+		out.DeliveryIntents = append(out.DeliveryIntents, routePlanDeliveryIntentsFromRoutes(routes, routeIntentProducerConnectRoutePlan)...)
 		out.LiveRecipients = append(out.LiveRecipients, connectRoutePlanLiveRecipients(routes)...)
 		out.RoutedRecipients = append(out.RoutedRecipients, subscribers...)
 		if len(plan.Reply) > 0 {
@@ -312,8 +312,7 @@ func connectRoutePlanLiveRecipients(routes []events.DeliveryRoute) []RoutePlanLi
 			RecipientID:       subscriberID,
 			SubscriberType:    subscriberType,
 			PersistAsDelivery: subscriberType == routePlanSubscriberAgent,
-			Source:            routePlanSourceConnectRoutePlan,
-			Reason:            routePlanReasonLoweredConnectRoutePlan,
+			Producer:          routeIntentProducerConnectRoutePlan,
 		})
 	}
 	return normalizeRoutePlanLiveRecipients(out)

--- a/internal/runtime/bus/connect_route_plan_dispatch_test.go
+++ b/internal/runtime/bus/connect_route_plan_dispatch_test.go
@@ -810,20 +810,18 @@ func TestRoutePlanCanonicalFailClosedDropsExecutableRoutes(t *testing.T) {
 	evt := events.NewProjectionEvent(uuid.NewString(),
 		events.EventType("producer/deploy.done"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Now().UTC())
 	routePlan := newRoutePlan(evt)
-	routePlan.MarkCanonicalRouteFailedClosed(routePlanSourceConnectRoutePlan, runtimepinrouting.FailureTargetNotSubscribed)
+	routePlan.MarkCanonicalRouteFailedClosed(routeIntentProducerConnectRoutePlan, runtimepinrouting.FailureTargetNotSubscribed)
 	routePlan.AddLiveRecipients(RoutePlanLiveRecipient{
 		RecipientID:       "bogus-node",
 		SubscriberType:    "node",
 		PersistAsDelivery: true,
-		Source:            routePlanSourceRecipientMaterializer,
-		Reason:            routePlanReasonMaterializedRoute,
+		Producer:          routeIntentProducerRecipientMaterializer,
 	})
 	routePlan.AddDeliveryIntents(RoutePlanDeliveryIntent{
 		SubscriberType: "node",
 		SubscriberID:   "bogus-node",
 		Target:         events.RouteIdentity{FlowID: "bogus", FlowInstance: "bogus", EntityID: "bogus"},
-		Source:         routePlanSourceRecipientMaterializer,
-		Reason:         routePlanReasonMaterializedRoute,
+		Producer:       routeIntentProducerRecipientMaterializer,
 		Persist:        true,
 	})
 
@@ -843,13 +841,12 @@ func TestRoutePlanProjectionPreservesAuthorityState(t *testing.T) {
 	evt := events.NewProjectionEvent(uuid.NewString(),
 		events.EventType("producer/deploy.done"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Now().UTC())
 	routePlan := newRoutePlan(evt)
-	routePlan.MarkCanonicalRouteMatched(routePlanSourceConnectRoutePlan)
+	routePlan.MarkCanonicalRouteMatched(routeIntentProducerConnectRoutePlan)
 	routePlan.AddDeliveryIntents(RoutePlanDeliveryIntent{
 		SubscriberType: "node",
 		SubscriberID:   "consumer-node",
 		Target:         connectRoutePlanStaticDeliveryRoute().Target,
-		Source:         routePlanSourceConnectRoutePlan,
-		Reason:         routePlanReasonLoweredConnectRoutePlan,
+		Producer:       routeIntentProducerConnectRoutePlan,
 		Persist:        true,
 	})
 

--- a/internal/runtime/bus/delivery_planner.go
+++ b/internal/runtime/bus/delivery_planner.go
@@ -134,7 +134,7 @@ func (p deliveryPlanner) Plan(ctx context.Context, evt events.Event) (eventDeliv
 	if err != nil {
 		return eventDeliveryPlan{}, err
 	}
-	routePlan = routePlanFromManifest(evt, manifest, routePlanSourceAgentPolicy, routePlanReasonMatchedAgentSubscription)
+	routePlan = routePlanFromManifest(evt, manifest, routeIntentProducerAgentPolicy)
 	recipients := routePlan.RecipientIDs()
 	persisted := routePlan.PersistedRecipientIDs()
 	routePlan.AddDeliveryIntents(routedRootNodeDeliveryIntentsForNoTargetEvent(evt, routing.RoutedRecipients)...)
@@ -156,9 +156,9 @@ func (p deliveryPlanner) Plan(ctx context.Context, evt events.Event) (eventDeliv
 func eventDeliveryPlanFromConnectRouteDispatch(evt events.Event, connectPlan connectRoutePlanDispatch) eventDeliveryPlan {
 	routePlan := newRoutePlan(evt)
 	if connectPlan.Failure != "" {
-		routePlan.MarkCanonicalRouteFailedClosed(routePlanSourceConnectRoutePlan, connectPlan.Failure)
+		routePlan.MarkCanonicalRouteFailedClosed(routeIntentProducerConnectRoutePlan, connectPlan.Failure)
 	} else {
-		routePlan.MarkCanonicalRouteMatched(routePlanSourceConnectRoutePlan)
+		routePlan.MarkCanonicalRouteMatched(routeIntentProducerConnectRoutePlan)
 		routePlan.AddLiveRecipients(connectPlan.LiveRecipients...)
 		routePlan.AddDeliveryIntents(connectPlan.DeliveryIntents...)
 	}
@@ -180,7 +180,7 @@ func (p deliveryPlanner) PlanDirect(ctx context.Context, evt events.Event, recip
 	if err != nil {
 		return eventDeliveryPlan{}, err
 	}
-	routePlan = routePlanFromManifest(evt, manifest, routePlanSourceDirectPolicy, routePlanReasonDirectPublish)
+	routePlan = routePlanFromManifest(evt, manifest, routeIntentProducerDirectPolicy)
 	routePlan.ExtraDetail = map[string]any{
 		"direct":                     true,
 		"requested_recipients":       append([]string(nil), requested...),
@@ -491,7 +491,7 @@ func internalDeliveryIntentsForPlan(evt events.Event, recipients, persisted []st
 			})
 		}
 	}
-	return routePlanDeliveryIntentsFromRoutes(out, routePlanSourceInternalTarget, routePlanReasonInternalCarrier)
+	return routePlanDeliveryIntentsFromRoutes(out, routeIntentProducerInternalTargetCarrier)
 }
 
 func targetedRoutedNodeDeliveryIntents(evt events.Event, routed []Subscriber) []RoutePlanDeliveryIntent {
@@ -499,7 +499,7 @@ func targetedRoutedNodeDeliveryIntents(evt events.Event, routed []Subscriber) []
 	if len(routes) == 0 {
 		return nil
 	}
-	return routePlanDeliveryIntentsFromRoutes(routes, routePlanSourceInternalTarget, routePlanReasonRouteTableNode)
+	return routePlanDeliveryIntentsFromRoutes(routes, routeIntentProducerInternalTargetRoute)
 }
 
 func targetedRoutedNodeDeliveryRoutes(evt events.Event, routed []Subscriber) []events.DeliveryRoute {
@@ -537,13 +537,13 @@ func routedNodeDeliveryIntentsForNoTargetEvent(evt events.Event, routed []Subscr
 	}
 	var intents []RoutePlanDeliveryIntent
 	if routes := routedConcreteNoTargetNodeDeliveryRoutes(evt, routed); len(routes) > 0 {
-		intents = append(intents, routePlanDeliveryIntentsFromRoutes(routes, routePlanSourceConcreteNodeRoute, routePlanReasonRouteTableNode)...)
+		intents = append(intents, routePlanDeliveryIntentsFromRoutes(routes, routeIntentProducerConcreteNodeRoute)...)
 	}
 	if routes := routedScopedNoTargetNodeDeliveryRoutes(evt, routed); len(routes) > 0 {
-		intents = append(intents, routePlanDeliveryIntentsFromRoutes(routes, routePlanSourceScopedNodeRoute, routePlanReasonRouteTableNode)...)
+		intents = append(intents, routePlanDeliveryIntentsFromRoutes(routes, routeIntentProducerScopedNodeRoute)...)
 	}
 	if routes := routedWildcardStaticServiceNoTargetNodeDeliveryRoutes(evt, routed); len(routes) > 0 {
-		intents = append(intents, routePlanDeliveryIntentsFromRoutes(routes, routePlanSourceScopedNodeRoute, routePlanReasonRouteTableNode)...)
+		intents = append(intents, routePlanDeliveryIntentsFromRoutes(routes, routeIntentProducerScopedNodeRoute)...)
 	}
 	if len(intents) > 0 {
 		return intents
@@ -579,7 +579,7 @@ func routedNodeDeliveryIntentsForNoTargetEvent(evt events.Event, routed []Subscr
 			},
 		})
 	}
-	return routePlanDeliveryIntentsFromRoutes(out, routePlanSourceConcreteNodeRoute, routePlanReasonRouteTableNode)
+	return routePlanDeliveryIntentsFromRoutes(out, routeIntentProducerConcreteNodeRoute)
 }
 
 func routedConcreteNoTargetNodeDeliveryRoutes(evt events.Event, routed []Subscriber) []events.DeliveryRoute {
@@ -786,7 +786,7 @@ func routedNodeDeliveryIntentsForNoRecipientFlowInstanceEvent(evt events.Event, 
 			},
 		})
 	}
-	return routePlanDeliveryIntentsFromRoutes(out, routePlanSourceConcreteNodeRoute, routePlanReasonRouteTableNode)
+	return routePlanDeliveryIntentsFromRoutes(out, routeIntentProducerConcreteNodeRoute)
 }
 
 func routedRootNodeDeliveryIntentsForNoTargetEvent(evt events.Event, routed []Subscriber) []RoutePlanDeliveryIntent {
@@ -804,7 +804,7 @@ func routedRootNodeDeliveryIntentsForNoTargetEvent(evt events.Event, routed []Su
 			SubscriberID:   recipient,
 		})
 	}
-	return routePlanDeliveryIntentsFromRoutes(out, routePlanSourceRootNodeRoute, routePlanReasonRouteTableNode)
+	return routePlanDeliveryIntentsFromRoutes(out, routeIntentProducerRootNodeRoute)
 }
 
 func routedRootInputFlowNodeDeliveryIntentsForNoTargetEvent(evt events.Event, routed []Subscriber) []RoutePlanDeliveryIntent {
@@ -835,7 +835,7 @@ func routedRootInputFlowNodeDeliveryIntentsForNoTargetEvent(evt events.Event, ro
 			SubscriberID:   recipient,
 		})
 	}
-	return routePlanDeliveryIntentsFromRoutes(out, routePlanSourceRootInputFlowNode, routePlanReasonRouteTableNode)
+	return routePlanDeliveryIntentsFromRoutes(out, routeIntentProducerRootInputFlowNode)
 }
 
 func routedRootInputFlowNodeMatchesNoTargetEvent(evt events.Event, subscriber Subscriber) bool {

--- a/internal/runtime/bus/delivery_planner_test.go
+++ b/internal/runtime/bus/delivery_planner_test.go
@@ -263,10 +263,10 @@ func TestDeliveryPlanner_ComposesRoutingPolicyAndManifest(t *testing.T) {
 	}
 	var sawObserverAgent, sawWorkerNode bool
 	for _, intent := range plan.RoutePlan.DeliveryIntents {
-		if intent.SubscriberType == "agent" && intent.SubscriberID == "observer" && intent.Source == routePlanSourceAgentPolicy && intent.Reason == routePlanReasonMatchedAgentSubscription {
+		if intent.SubscriberType == "agent" && intent.SubscriberID == "observer" && intent.Producer == routeIntentProducerAgentPolicy {
 			sawObserverAgent = true
 		}
-		if intent.SubscriberType == "node" && intent.SubscriberID == "worker" && intent.Source == routePlanSourceRootNodeRoute && intent.Reason == routePlanReasonRouteTableNode {
+		if intent.SubscriberType == "node" && intent.SubscriberID == "worker" && intent.Producer == routeIntentProducerRootNodeRoute {
 			sawWorkerNode = true
 		}
 	}
@@ -315,7 +315,7 @@ func TestDeliveryPlanner_DoesNotDeadLetterTargetedWorkflowNodeSubscriber(t *test
 		t.Fatalf("route plan delivery intents = %d, want %d", got, want)
 	}
 	intent := plan.RoutePlan.DeliveryIntents[0]
-	if intent.Source != routePlanSourceInternalTarget || intent.Reason != routePlanReasonRouteTableNode {
+	if intent.Producer != routeIntentProducerInternalTargetRoute {
 		t.Fatalf("route plan delivery intent = %#v, want internal targeted route-table node authority", intent)
 	}
 }
@@ -438,10 +438,10 @@ func TestDeliveryPlanner_ExpandsTargetSetForInternalWorkflowRecipient(t *testing
 	}
 	var semanticNodeRoutes, carrierRoutes int
 	for _, intent := range plan.RoutePlan.DeliveryIntents {
-		if intent.Source == routePlanSourceInternalTarget && intent.Reason == routePlanReasonRouteTableNode && (intent.SubscriberID == "child-a-listener" || intent.SubscriberID == "child-b-listener") {
+		if intent.Producer == routeIntentProducerInternalTargetRoute && (intent.SubscriberID == "child-a-listener" || intent.SubscriberID == "child-b-listener") {
 			semanticNodeRoutes++
 		}
-		if intent.Source == routePlanSourceInternalTarget && intent.Reason == routePlanReasonInternalCarrier && intent.SubscriberID == "workflow-runtime" {
+		if intent.Producer == routeIntentProducerInternalTargetCarrier && intent.SubscriberID == "workflow-runtime" {
 			carrierRoutes++
 		}
 	}
@@ -548,7 +548,7 @@ func TestDeliveryPlanner_NoTargetConcreteRoutedNodePersistsSemanticNodeRoute(t *
 		t.Fatalf("route plan delivery intents = %d, want %d", got, want)
 	}
 	intent := plan.RoutePlan.DeliveryIntents[0]
-	if intent.Source != routePlanSourceConcreteNodeRoute || intent.Reason != routePlanReasonRouteTableNode {
+	if intent.Producer != routeIntentProducerConcreteNodeRoute {
 		t.Fatalf("route plan delivery intent = %#v, want concrete route-table semantic node source", intent)
 	}
 }
@@ -769,7 +769,7 @@ func TestDeliveryPlanner_NoTargetRootLocalEventWithFlowInstanceUsesRootNodeRoute
 		t.Fatalf("route plan delivery intents = %d, want %d", got, want)
 	}
 	intent := plan.RoutePlan.DeliveryIntents[0]
-	if intent.Source != routePlanSourceRootNodeRoute || intent.Reason != routePlanReasonRouteTableNode {
+	if intent.Producer != routeIntentProducerRootNodeRoute {
 		t.Fatalf("route plan delivery intent = %#v, want root route-table node source", intent)
 	}
 }
@@ -827,7 +827,7 @@ func TestDeliveryPlanner_NoTargetScopedRoutedNodeUsesSemanticNodeDeliveryRoute(t
 		t.Fatalf("route plan delivery intents = %d, want %d", got, want)
 	}
 	intent := plan.RoutePlan.DeliveryIntents[0]
-	if intent.Source != routePlanSourceScopedNodeRoute || intent.Reason != routePlanReasonRouteTableNode {
+	if intent.Producer != routeIntentProducerScopedNodeRoute {
 		t.Fatalf("route plan delivery intent = %#v, want scoped route-table node source", intent)
 	}
 }
@@ -950,7 +950,7 @@ func TestDeliveryPlanner_NoTargetCrossFlowStaticRoutedNodeUsesSubscriberScope(t 
 		t.Fatalf("route plan delivery intents = %d, want %d", got, want)
 	}
 	intent := plan.RoutePlan.DeliveryIntents[0]
-	if intent.Source != routePlanSourceScopedNodeRoute || intent.Reason != routePlanReasonRouteTableNode {
+	if intent.Producer != routeIntentProducerScopedNodeRoute {
 		t.Fatalf("route plan delivery intent = %#v, want scoped route-table node source", intent)
 	}
 }
@@ -1008,7 +1008,7 @@ func TestDeliveryPlanner_NoTargetWildcardStaticServiceRoutedNodeUsesSubscriberSc
 		t.Fatalf("route plan delivery intents = %d, want %d", got, want)
 	}
 	intent := plan.RoutePlan.DeliveryIntents[0]
-	if intent.Source != routePlanSourceScopedNodeRoute || intent.Reason != routePlanReasonRouteTableNode {
+	if intent.Producer != routeIntentProducerScopedNodeRoute {
 		t.Fatalf("route plan delivery intent = %#v, want scoped route-table node source", intent)
 	}
 }
@@ -1066,7 +1066,7 @@ func TestDeliveryPlanner_NoTargetDescendantScopedRoutedNodeUsesParentInstanceRou
 		t.Fatalf("route plan delivery intents = %d, want %d", got, want)
 	}
 	intent := plan.RoutePlan.DeliveryIntents[0]
-	if intent.Source != routePlanSourceScopedNodeRoute || intent.Reason != routePlanReasonRouteTableNode {
+	if intent.Producer != routeIntentProducerScopedNodeRoute {
 		t.Fatalf("route plan delivery intent = %#v, want scoped route-table node source", intent)
 	}
 }

--- a/internal/runtime/bus/eventbus_publish.go
+++ b/internal/runtime/bus/eventbus_publish.go
@@ -956,8 +956,8 @@ func (eb *EventBus) materializePublishRecipientPlan(ctx context.Context, evt eve
 	if len(routes) == 0 {
 		return plan, nil
 	}
-	routePlan.MarkLowerPrecedenceRouteProduction(routePlanSourceRecipientMaterializer)
-	routePlan.AddDeliveryIntents(routePlanDeliveryIntentsFromRoutes(routes, routePlanSourceRecipientMaterializer, routePlanReasonMaterializedRoute)...)
+	routePlan.MarkLowerPrecedenceRouteProduction(routeIntentProducerRecipientMaterializer)
+	routePlan.AddDeliveryIntents(routePlanDeliveryIntentsFromRoutes(routes, routeIntentProducerRecipientMaterializer)...)
 	return plan.WithCanonicalRoutePlan(routePlan), nil
 }
 

--- a/internal/runtime/bus/eventbus_target_routes_test.go
+++ b/internal/runtime/bus/eventbus_target_routes_test.go
@@ -207,7 +207,7 @@ func TestEventBusRecipientPlanMaterializerNormalizesIntoCanonicalRoutePlan(t *te
 		t.Fatalf("NewEventBusWithOptions: %v", err)
 	}
 	evt := events.NewProjectionEvent(uuid.NewString(), events.EventType("review/inst-1/task.started"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{})
-	emptyAgentPolicyPlan := routePlanFromManifest(evt, deliveryRecipientManifest{}, routePlanSourceAgentPolicy, routePlanReasonMatchedAgentSubscription)
+	emptyAgentPolicyPlan := routePlanFromManifest(evt, deliveryRecipientManifest{}, routeIntentProducerAgentPolicy)
 	if emptyAgentPolicyPlan.AuthorityState != RoutePlanAuthorityNoCanonicalMatch || emptyAgentPolicyPlan.AuthorityOwner != "" {
 		t.Fatalf("empty agent-policy route plan authority = %q/%q, want no canonical match", emptyAgentPolicyPlan.AuthorityState, emptyAgentPolicyPlan.AuthorityOwner)
 	}
@@ -226,8 +226,8 @@ func TestEventBusRecipientPlanMaterializerNormalizesIntoCanonicalRoutePlan(t *te
 	if intent.SubscriberType != want.SubscriberType || intent.SubscriberID != want.SubscriberID || intent.Target != want.Target {
 		t.Fatalf("route plan delivery intent = %#v, want route %#v", intent, want)
 	}
-	if intent.Source != routePlanSourceRecipientMaterializer || intent.Reason != routePlanReasonMaterializedRoute {
-		t.Fatalf("route plan materializer source/reason = %q/%q, want materializer route", intent.Source, intent.Reason)
+	if intent.Producer != routeIntentProducerRecipientMaterializer {
+		t.Fatalf("route plan materializer producer = %s, want materializer route", intent.Producer)
 	}
 	projected := eb.publishRecipientPlan(evt, plan.CanonicalRoutePlan())
 	if !deliveryRoutesContain(projected.DeliveryRoutes, want) {
@@ -331,14 +331,12 @@ func nodeOnlyDeliveryPlan(evt events.Event, nodeID string) RoutePlan {
 		RecipientID:       nodeID,
 		SubscriberType:    routePlanSubscriberInternal,
 		PersistAsDelivery: false,
-		Source:            "test",
-		Reason:            "test",
+		Producer:          routeIntentProducerInternalTargetCarrier,
 	})
 	plan.AddDeliveryIntents(RoutePlanDeliveryIntent{
 		SubscriberType: "node",
 		SubscriberID:   nodeID,
-		Source:         "test",
-		Reason:         "test",
+		Producer:       routeIntentProducerInternalTargetCarrier,
 		Persist:        true,
 	})
 	return plan.Normalized()

--- a/internal/runtime/bus/route_plan.go
+++ b/internal/runtime/bus/route_plan.go
@@ -10,25 +10,136 @@ import (
 const (
 	routePlanSubscriberAgent    = "agent"
 	routePlanSubscriberInternal = "internal"
-
-	routePlanSourceAgentPolicy           = "agent_policy"
-	routePlanSourceDirectPolicy          = "direct_policy"
-	routePlanSourceInternalTarget        = "internal_target_route"
-	routePlanSourceConcreteNodeRoute     = "concrete_node_route"
-	routePlanSourceScopedNodeRoute       = "scoped_node_route"
-	routePlanSourceRootNodeRoute         = "root_node_route"
-	routePlanSourceRootInputFlowNode     = "root_input_flow_node_route"
-	routePlanSourceRecipientMaterializer = "recipient_plan_materializer"
-	routePlanSourceConnectRoutePlan      = "connect_route_plan"
-	routePlanSourceLegacyProjection      = "legacy_projection"
-
-	routePlanReasonMatchedAgentSubscription = "matched_agent_subscription"
-	routePlanReasonDirectPublish            = "direct_publish"
-	routePlanReasonInternalCarrier          = "internal_carrier"
-	routePlanReasonRouteTableNode           = "route_table_node"
-	routePlanReasonMaterializedRoute        = "materialized_route"
-	routePlanReasonLoweredConnectRoutePlan  = "lowered_connect_route_plan"
 )
+
+type routePlanSource string
+type routePlanReason string
+
+const (
+	routePlanSourceAgentPolicy           routePlanSource = "agent_policy"
+	routePlanSourceDirectPolicy          routePlanSource = "direct_policy"
+	routePlanSourceInternalTarget        routePlanSource = "internal_target_route"
+	routePlanSourceConcreteNodeRoute     routePlanSource = "concrete_node_route"
+	routePlanSourceScopedNodeRoute       routePlanSource = "scoped_node_route"
+	routePlanSourceRootNodeRoute         routePlanSource = "root_node_route"
+	routePlanSourceRootInputFlowNode     routePlanSource = "root_input_flow_node_route"
+	routePlanSourceRecipientMaterializer routePlanSource = "recipient_plan_materializer"
+	routePlanSourceConnectRoutePlan      routePlanSource = "connect_route_plan"
+	routePlanSourceLegacyProjection      routePlanSource = "legacy_projection"
+
+	routePlanReasonMatchedAgentSubscription routePlanReason = "matched_agent_subscription"
+	routePlanReasonDirectPublish            routePlanReason = "direct_publish"
+	routePlanReasonInternalCarrier          routePlanReason = "internal_carrier"
+	routePlanReasonRouteTableNode           routePlanReason = "route_table_node"
+	routePlanReasonMaterializedRoute        routePlanReason = "materialized_route"
+	routePlanReasonLoweredConnectRoutePlan  routePlanReason = "lowered_connect_route_plan"
+	routePlanReasonLegacyProjection         routePlanReason = "legacy_projection"
+)
+
+type routeIntentProducer uint8
+
+const (
+	routeIntentProducerUnknown routeIntentProducer = iota
+	routeIntentProducerAgentPolicy
+	routeIntentProducerDirectPolicy
+	routeIntentProducerInternalTargetCarrier
+	routeIntentProducerInternalTargetRoute
+	routeIntentProducerConcreteNodeRoute
+	routeIntentProducerScopedNodeRoute
+	routeIntentProducerRootNodeRoute
+	routeIntentProducerRootInputFlowNode
+	routeIntentProducerRecipientMaterializer
+	routeIntentProducerConnectRoutePlan
+	routeIntentProducerLegacyProjection
+)
+
+func (p routeIntentProducer) Normalized() routeIntentProducer {
+	switch p {
+	case routeIntentProducerAgentPolicy,
+		routeIntentProducerDirectPolicy,
+		routeIntentProducerInternalTargetCarrier,
+		routeIntentProducerInternalTargetRoute,
+		routeIntentProducerConcreteNodeRoute,
+		routeIntentProducerScopedNodeRoute,
+		routeIntentProducerRootNodeRoute,
+		routeIntentProducerRootInputFlowNode,
+		routeIntentProducerRecipientMaterializer,
+		routeIntentProducerConnectRoutePlan,
+		routeIntentProducerLegacyProjection:
+		return p
+	default:
+		return routeIntentProducerUnknown
+	}
+}
+
+func (p routeIntentProducer) Source() routePlanSource {
+	switch p.Normalized() {
+	case routeIntentProducerAgentPolicy:
+		return routePlanSourceAgentPolicy
+	case routeIntentProducerDirectPolicy:
+		return routePlanSourceDirectPolicy
+	case routeIntentProducerInternalTargetCarrier, routeIntentProducerInternalTargetRoute:
+		return routePlanSourceInternalTarget
+	case routeIntentProducerConcreteNodeRoute:
+		return routePlanSourceConcreteNodeRoute
+	case routeIntentProducerScopedNodeRoute:
+		return routePlanSourceScopedNodeRoute
+	case routeIntentProducerRootNodeRoute:
+		return routePlanSourceRootNodeRoute
+	case routeIntentProducerRootInputFlowNode:
+		return routePlanSourceRootInputFlowNode
+	case routeIntentProducerRecipientMaterializer:
+		return routePlanSourceRecipientMaterializer
+	case routeIntentProducerConnectRoutePlan:
+		return routePlanSourceConnectRoutePlan
+	case routeIntentProducerLegacyProjection:
+		return routePlanSourceLegacyProjection
+	default:
+		return ""
+	}
+}
+
+func (p routeIntentProducer) Reason() routePlanReason {
+	switch p.Normalized() {
+	case routeIntentProducerAgentPolicy:
+		return routePlanReasonMatchedAgentSubscription
+	case routeIntentProducerDirectPolicy:
+		return routePlanReasonDirectPublish
+	case routeIntentProducerInternalTargetCarrier:
+		return routePlanReasonInternalCarrier
+	case routeIntentProducerInternalTargetRoute,
+		routeIntentProducerConcreteNodeRoute,
+		routeIntentProducerScopedNodeRoute,
+		routeIntentProducerRootNodeRoute,
+		routeIntentProducerRootInputFlowNode:
+		return routePlanReasonRouteTableNode
+	case routeIntentProducerRecipientMaterializer:
+		return routePlanReasonMaterializedRoute
+	case routeIntentProducerConnectRoutePlan:
+		return routePlanReasonLoweredConnectRoutePlan
+	case routeIntentProducerLegacyProjection:
+		return routePlanReasonLegacyProjection
+	default:
+		return ""
+	}
+}
+
+func (p routeIntentProducer) Empty() bool {
+	return p.Normalized() == routeIntentProducerUnknown
+}
+
+func (p routeIntentProducer) String() string {
+	p = p.Normalized()
+	source := p.Source()
+	reason := p.Reason()
+	if source == "" {
+		return string(reason)
+	}
+	if reason == "" {
+		return string(source)
+	}
+	return string(source) + "/" + string(reason)
+}
 
 type RoutePlanAuthorityState string
 
@@ -45,7 +156,7 @@ const (
 type RoutePlan struct {
 	Event                events.Event
 	AuthorityState       RoutePlanAuthorityState
-	AuthorityOwner       string
+	AuthorityOwner       routePlanSource
 	LiveRecipients       []RoutePlanLiveRecipient
 	DeliveryIntents      []RoutePlanDeliveryIntent
 	RoutedRecipients     []Subscriber
@@ -61,16 +172,14 @@ type RoutePlanLiveRecipient struct {
 	RecipientID       string
 	SubscriberType    string
 	PersistAsDelivery bool
-	Source            string
-	Reason            string
+	Producer          routeIntentProducer
 }
 
 type RoutePlanDeliveryIntent struct {
 	SubscriberType string
 	SubscriberID   string
 	Target         events.RouteIdentity
-	Source         string
-	Reason         string
+	Producer       routeIntentProducer
 	Persist        bool
 }
 
@@ -80,7 +189,7 @@ func newRoutePlan(evt events.Event) RoutePlan {
 
 func (p RoutePlan) Normalized() RoutePlan {
 	p.AuthorityState = normalizeRoutePlanAuthorityState(p.AuthorityState)
-	p.AuthorityOwner = strings.TrimSpace(p.AuthorityOwner)
+	p.AuthorityOwner = normalizeRoutePlanSource(p.AuthorityOwner)
 	p.LiveRecipients = normalizeRoutePlanLiveRecipients(p.LiveRecipients)
 	p.DeliveryIntents = normalizeRoutePlanDeliveryIntents(p.DeliveryIntents)
 	p.RoutedRecipients = append([]Subscriber(nil), p.RoutedRecipients...)
@@ -104,20 +213,20 @@ func (p RoutePlan) Normalized() RoutePlan {
 	return p
 }
 
-func (p *RoutePlan) MarkCanonicalRouteMatched(owner string) {
+func (p *RoutePlan) MarkCanonicalRouteMatched(producer routeIntentProducer) {
 	if p == nil {
 		return
 	}
 	p.AuthorityState = RoutePlanAuthorityCanonicalMatched
-	p.AuthorityOwner = strings.TrimSpace(owner)
+	p.AuthorityOwner = producer.Source()
 }
 
-func (p *RoutePlan) MarkCanonicalRouteFailedClosed(owner string, failure runtimepinrouting.TargetFailure) {
+func (p *RoutePlan) MarkCanonicalRouteFailedClosed(producer routeIntentProducer, failure runtimepinrouting.TargetFailure) {
 	if p == nil {
 		return
 	}
 	p.AuthorityState = RoutePlanAuthorityCanonicalFailedClosed
-	p.AuthorityOwner = strings.TrimSpace(owner)
+	p.AuthorityOwner = producer.Source()
 	p.TargetFailure = runtimepinrouting.TargetFailure(strings.TrimSpace(string(failure)))
 	p.LiveRecipients = nil
 	p.DeliveryIntents = nil
@@ -125,13 +234,13 @@ func (p *RoutePlan) MarkCanonicalRouteFailedClosed(owner string, failure runtime
 	p.SubscribedRecipients = nil
 }
 
-func (p *RoutePlan) MarkLowerPrecedenceRouteProduction(owner string) {
+func (p *RoutePlan) MarkLowerPrecedenceRouteProduction(producer routeIntentProducer) {
 	if p == nil || p.CanonicalRouteOwnerMatched() {
 		return
 	}
 	p.AuthorityState = RoutePlanAuthorityLowerPrecedence
-	if strings.TrimSpace(p.AuthorityOwner) == "" {
-		p.AuthorityOwner = strings.TrimSpace(owner)
+	if p.AuthorityOwner == "" {
+		p.AuthorityOwner = producer.Source()
 	}
 }
 
@@ -310,7 +419,7 @@ func (p eventDeliveryPlan) WithCanonicalRoutePlan(routePlan RoutePlan) eventDeli
 func routePlanFromLegacyEventDeliveryPlan(plan eventDeliveryPlan) RoutePlan {
 	out := newRoutePlan(plan.Event)
 	if len(plan.Recipients) > 0 || len(plan.PersistedRecipients) > 0 || len(plan.DeliveryRoutes) > 0 || plan.TargetFailure != "" {
-		out.MarkLowerPrecedenceRouteProduction(routePlanSourceLegacyProjection)
+		out.MarkLowerPrecedenceRouteProduction(routeIntentProducerLegacyProjection)
 	}
 	persisted := make(map[string]struct{}, len(plan.PersistedRecipients))
 	for _, recipient := range uniqueStrings(plan.PersistedRecipients) {
@@ -327,8 +436,7 @@ func routePlanFromLegacyEventDeliveryPlan(plan eventDeliveryPlan) RoutePlan {
 			RecipientID:       recipient,
 			SubscriberType:    subscriberType,
 			PersistAsDelivery: persist,
-			Source:            routePlanSourceLegacyProjection,
-			Reason:            routePlanSourceLegacyProjection,
+			Producer:          routeIntentProducerLegacyProjection,
 		})
 	}
 	for recipient := range persisted {
@@ -339,11 +447,10 @@ func routePlanFromLegacyEventDeliveryPlan(plan eventDeliveryPlan) RoutePlan {
 			RecipientID:       recipient,
 			SubscriberType:    routePlanSubscriberAgent,
 			PersistAsDelivery: true,
-			Source:            routePlanSourceLegacyProjection,
-			Reason:            routePlanSourceLegacyProjection,
+			Producer:          routeIntentProducerLegacyProjection,
 		})
 	}
-	out.AddDeliveryIntents(routePlanDeliveryIntentsFromRoutes(plan.DeliveryRoutes, routePlanSourceLegacyProjection, routePlanSourceLegacyProjection)...)
+	out.AddDeliveryIntents(routePlanDeliveryIntentsFromRoutes(plan.DeliveryRoutes, routeIntentProducerLegacyProjection)...)
 	out.RoutedRecipients = append([]Subscriber(nil), plan.RoutedRecipients...)
 	out.SubscribedRecipients = uniqueStrings(plan.SubscribedRecipients)
 	out.ExtraDetail = cloneStringAnyMap(plan.ExtraDetail)
@@ -354,7 +461,7 @@ func routePlanFromLegacyEventDeliveryPlan(plan eventDeliveryPlan) RoutePlan {
 	return out.Normalized()
 }
 
-func routePlanLiveRecipientsFromManifest(manifest deliveryRecipientManifest, source, reason string) []RoutePlanLiveRecipient {
+func routePlanLiveRecipientsFromManifest(manifest deliveryRecipientManifest, producer routeIntentProducer) []RoutePlanLiveRecipient {
 	persisted := make(map[string]struct{}, len(manifest.PersistedRecipients))
 	for _, recipient := range uniqueStrings(manifest.PersistedRecipients) {
 		persisted[recipient] = struct{}{}
@@ -372,14 +479,13 @@ func routePlanLiveRecipientsFromManifest(manifest deliveryRecipientManifest, sou
 			RecipientID:       recipient,
 			SubscriberType:    subscriberType,
 			PersistAsDelivery: persist,
-			Source:            source,
-			Reason:            reason,
+			Producer:          producer,
 		})
 	}
 	return normalizeRoutePlanLiveRecipients(out)
 }
 
-func routePlanDeliveryIntentsFromRoutes(routes []events.DeliveryRoute, source, reason string) []RoutePlanDeliveryIntent {
+func routePlanDeliveryIntentsFromRoutes(routes []events.DeliveryRoute, producer routeIntentProducer) []RoutePlanDeliveryIntent {
 	routes = events.NormalizeDeliveryRoutes(routes)
 	if len(routes) == 0 {
 		return nil
@@ -390,21 +496,20 @@ func routePlanDeliveryIntentsFromRoutes(routes []events.DeliveryRoute, source, r
 			SubscriberType: route.SubscriberType,
 			SubscriberID:   route.SubscriberID,
 			Target:         route.Target,
-			Source:         source,
-			Reason:         reason,
+			Producer:       producer,
 			Persist:        true,
 		})
 	}
 	return normalizeRoutePlanDeliveryIntents(out)
 }
 
-func routePlanFromManifest(evt events.Event, manifest deliveryRecipientManifest, source, reason string) RoutePlan {
+func routePlanFromManifest(evt events.Event, manifest deliveryRecipientManifest, producer routeIntentProducer) RoutePlan {
 	plan := newRoutePlan(evt)
-	plan.AddLiveRecipients(routePlanLiveRecipientsFromManifest(manifest, source, reason)...)
-	plan.AddDeliveryIntents(routePlanDeliveryIntentsFromRoutes(manifest.DeliveryRoutes, source, reason)...)
+	plan.AddLiveRecipients(routePlanLiveRecipientsFromManifest(manifest, producer)...)
+	plan.AddDeliveryIntents(routePlanDeliveryIntentsFromRoutes(manifest.DeliveryRoutes, producer)...)
 	plan.TargetFailure = manifest.TargetFailure
 	if len(plan.LiveRecipients) > 0 || len(plan.DeliveryIntents) > 0 || plan.TargetFailure != "" {
-		plan.MarkLowerPrecedenceRouteProduction(source)
+		plan.MarkLowerPrecedenceRouteProduction(producer)
 	}
 	return plan.Normalized()
 }
@@ -422,6 +527,10 @@ func normalizeRoutePlanAuthorityState(state RoutePlanAuthorityState) RoutePlanAu
 	}
 }
 
+func normalizeRoutePlanSource(source routePlanSource) routePlanSource {
+	return routePlanSource(strings.TrimSpace(string(source)))
+}
+
 func normalizeRoutePlanLiveRecipients(in []RoutePlanLiveRecipient) []RoutePlanLiveRecipient {
 	if len(in) == 0 {
 		return nil
@@ -431,8 +540,7 @@ func normalizeRoutePlanLiveRecipients(in []RoutePlanLiveRecipient) []RoutePlanLi
 	for _, recipient := range in {
 		recipient.RecipientID = strings.TrimSpace(recipient.RecipientID)
 		recipient.SubscriberType = strings.TrimSpace(recipient.SubscriberType)
-		recipient.Source = strings.TrimSpace(recipient.Source)
-		recipient.Reason = strings.TrimSpace(recipient.Reason)
+		recipient.Producer = recipient.Producer.Normalized()
 		if recipient.RecipientID == "" {
 			continue
 		}
@@ -446,11 +554,8 @@ func normalizeRoutePlanLiveRecipients(in []RoutePlanLiveRecipient) []RoutePlanLi
 		key := strings.Join([]string{recipient.SubscriberType, recipient.RecipientID}, "\x00")
 		if idx, ok := indexByKey[key]; ok {
 			out[idx].PersistAsDelivery = out[idx].PersistAsDelivery || recipient.PersistAsDelivery
-			if out[idx].Source == "" {
-				out[idx].Source = recipient.Source
-			}
-			if out[idx].Reason == "" {
-				out[idx].Reason = recipient.Reason
+			if out[idx].Producer.Empty() {
+				out[idx].Producer = recipient.Producer
 			}
 			continue
 		}
@@ -470,19 +575,15 @@ func normalizeRoutePlanDeliveryIntents(in []RoutePlanDeliveryIntent) []RoutePlan
 		intent.SubscriberType = strings.TrimSpace(intent.SubscriberType)
 		intent.SubscriberID = strings.TrimSpace(intent.SubscriberID)
 		intent.Target = intent.Target.Normalized()
-		intent.Source = strings.TrimSpace(intent.Source)
-		intent.Reason = strings.TrimSpace(intent.Reason)
+		intent.Producer = intent.Producer.Normalized()
 		if intent.SubscriberType == "" || intent.SubscriberID == "" {
 			continue
 		}
 		key := strings.Join([]string{intent.SubscriberType, intent.SubscriberID, intent.Target.FlowID, intent.Target.FlowInstance, intent.Target.EntityID}, "\x00")
 		if idx, ok := indexByKey[key]; ok {
 			out[idx].Persist = out[idx].Persist || intent.Persist
-			if out[idx].Source == "" {
-				out[idx].Source = intent.Source
-			}
-			if out[idx].Reason == "" {
-				out[idx].Reason = intent.Reason
+			if out[idx].Producer.Empty() {
+				out[idx].Producer = intent.Producer
 			}
 			continue
 		}

--- a/internal/runtime/bus/route_plan_test.go
+++ b/internal/runtime/bus/route_plan_test.go
@@ -1,0 +1,62 @@
+package bus
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/division-sh/swarm/internal/events"
+)
+
+func TestRoutePlanDeliveryIntentsCarryTypedProducer(t *testing.T) {
+	routes := []events.DeliveryRoute{{
+		SubscriberType: "node",
+		SubscriberID:   "consumer-node",
+		Target: events.RouteIdentity{
+			FlowInstance: "consumer/inst-1",
+			EntityID:     "ent-consumer",
+		},
+	}}
+
+	intents := routePlanDeliveryIntentsFromRoutes(routes, routeIntentProducerConnectRoutePlan)
+	if got, want := len(intents), 1; got != want {
+		t.Fatalf("delivery intents = %d, want %d", got, want)
+	}
+	intent := intents[0]
+	if intent.Producer != routeIntentProducerConnectRoutePlan {
+		t.Fatalf("intent producer = %s, want %s", intent.Producer, routeIntentProducerConnectRoutePlan)
+	}
+	if intent.Producer.Source() != routePlanSourceConnectRoutePlan || intent.Producer.Reason() != routePlanReasonLoweredConnectRoutePlan {
+		t.Fatalf("intent producer source/reason = %s/%s, want connect route plan/lowered connect", intent.Producer.Source(), intent.Producer.Reason())
+	}
+}
+
+func TestRoutePlanProducerHelpersRequireTypedProducer(t *testing.T) {
+	_, testFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime caller unavailable")
+	}
+	raw, err := os.ReadFile(filepath.Join(filepath.Dir(testFile), "route_plan.go"))
+	if err != nil {
+		t.Fatalf("read route_plan.go: %v", err)
+	}
+	source := string(raw)
+	for _, forbidden := range []string{
+		"routePlanLiveRecipientsFromManifest(manifest deliveryRecipientManifest, source, reason string)",
+		"routePlanDeliveryIntentsFromRoutes(routes []events.DeliveryRoute, source, reason string)",
+		"routePlanFromManifest(evt events.Event, manifest deliveryRecipientManifest, source, reason string)",
+		"type routeIntentProducer struct",
+		"routeIntentProducer{source:",
+		"AuthorityOwner       string",
+		"Source            string",
+		"Reason            string",
+		"Source         string",
+		"Reason         string",
+	} {
+		if strings.Contains(source, forbidden) {
+			t.Fatalf("route_plan.go still exposes raw route-intent producer shape %q", forbidden)
+		}
+	}
+}

--- a/internal/runtime/conformance/route_authority_drift_inventory_test.go
+++ b/internal/runtime/conformance/route_authority_drift_inventory_test.go
@@ -139,11 +139,18 @@ func TestRouteAuthorityDriftInventoryRejectsNarrowOrStaleAudit(t *testing.T) {
 			want: "policy claims_runtime_behavior_closure = true, want false",
 		},
 		{
-			name: "current child issue must stay visible",
+			name: "guardrail child issue must stay visible",
 			mutate: func(inventory *routeAuthorityDriftInventory) {
 				inventory.ImplementationIssues = []int{1364}
 			},
 			want: "inventory implementation_issues missing #1494",
+		},
+		{
+			name: "typed producer child issue must stay visible",
+			mutate: func(inventory *routeAuthorityDriftInventory) {
+				inventory.ImplementationIssues = []int{1364, 1494}
+			},
+			want: "inventory implementation_issues missing #1495",
 		},
 	}
 
@@ -242,7 +249,7 @@ func validateRouteAuthorityDriftInventoryWithCorpus(root string, corpus *routeAu
 	if inventory.Issue != 1364 {
 		problems = append(problems, fmt.Sprintf("inventory issue = #%d, want #1364", inventory.Issue))
 	}
-	for _, issue := range []int{1364, 1494} {
+	for _, issue := range []int{1364, 1494, 1495} {
 		if !routeAuthorityDriftHasInt(inventory.ImplementationIssues, issue) {
 			problems = append(problems, fmt.Sprintf("inventory implementation_issues missing #%d", issue))
 		}

--- a/internal/runtime/conformance/testdata/route_authority_drift_inventory.yaml
+++ b/internal/runtime/conformance/testdata/route_authority_drift_inventory.yaml
@@ -1,7 +1,7 @@
 version: 1
 kind: route_authority_drift_inventory
 issue: 1364
-implementation_issues: [1364, 1494]
+implementation_issues: [1364, 1494, 1495]
 parent_issues: [1340, 1353, 1481, 1493]
 watchlist: runtime_operations.delivery_and_replay_ownership
 policy:
@@ -124,7 +124,7 @@ search_dimensions:
     canonical_layer: route_plan_consumers
     classified_paths_required: true
   - id: route_plan_source_reason
-    pattern: 'routePlanSource|routePlanReason|RoutePlanAuthorityState|RoutePlanDeliveryIntent'
+    pattern: 'routePlanSource|routePlanReason|routeIntentProducer|RoutePlanAuthorityState|RoutePlanDeliveryIntent|RoutePlanLiveRecipient'
     minimum_matching_files: 7
     required_paths:
       - internal/runtime/bus/route_plan.go
@@ -510,14 +510,16 @@ seam_families:
       - internal/runtime/bus/delivery_planner_test.go
       - internal/runtime/bus/connect_route_plan_dispatch.go
       - internal/runtime/bus/connect_route_plan_dispatch_test.go
+      - internal/runtime/bus/route_plan_test.go
       - internal/runtime/bus/eventbus_publish.go
       - internal/runtime/bus/eventbus_target_routes_test.go
       - internal/runtime/conformance/testdata/route_authority_matrix.yaml
     search_dimensions: [route_plan_source_reason, route_plan]
     notes: >
-      RoutePlan source/reason/authority-state constants are the current typed
-      route-intent metadata owner. #1494 guards their use until #1495 promotes
-      the broader typed route-intent model.
+      RoutePlan source/reason/authority-state constants are now carried through
+      the #1495 typed route-intent producer model. #1494 guards their use and
+      #1495 removes broad raw string producer helper entry points for EventBus
+      RoutePlan production.
   - id: durable_delivery_authority_writers
     layer: durable_delivery_authority
     classification: canonical_owner
@@ -693,7 +695,7 @@ guardrail_proposals:
       - direct SQL tests from asserting delivery counts without typed semantic subscriber identity
       - store fixtures from becoming undocumented route-authority interpreters
 follow_up_decision:
-  tracker_state: "#1494 extends the closed #1364 inventory owner under #1493; #1495/#1496/#1479/#1466/#1481 remain open for behavior or broader architecture work."
+  tracker_state: "#1494 extends the closed #1364 inventory owner under #1493; #1495 promotes typed EventBus route-intent producer ownership; #1496/#1479/#1466/#1481 remain open for compatibility, descriptor, or broader architecture work."
   new_child_required_before_coding: false
   runtime_behavior_child_required_now: false
   notes: >

--- a/internal/runtime/conformance/testdata/route_authority_matrix.yaml
+++ b/internal/runtime/conformance/testdata/route_authority_matrix.yaml
@@ -457,7 +457,7 @@ rows:
       direct-recipient behavior.
 
   - id: route_plan_source_reason_constants
-    concept: RoutePlan source/reason constants and authority state carry the current route-intent decision metadata.
+    concept: RoutePlan source/reason constants and authority state are carried by the typed EventBus route-intent producer model.
     classification: already_covered_by_existing_proof
     tier: required_pr_smoke
     proof_dimensions: [source_reason_constants, route_plan_model, guardrail_inventory, required_pr_smoke]
@@ -465,14 +465,19 @@ rows:
       - {kind: artifact, path: internal/runtime/bus/route_plan.go}
       - {kind: artifact, path: internal/runtime/conformance/testdata/route_authority_drift_inventory.yaml}
       - {kind: spec_ref, path: platform-spec.yaml, ref: decision_state}
+      - {kind: spec_ref, path: platform-spec.yaml, ref: route_intent_producer_model}
     proof_refs:
       - {kind: issue, issue: 1494}
+      - {kind: issue, issue: 1495}
       - {kind: go_test, name: TestRoutePlanCanonicalFailClosedDropsExecutableRoutes}
+      - {kind: go_test, name: TestRoutePlanDeliveryIntentsCarryTypedProducer}
+      - {kind: go_test, name: TestRoutePlanProducerHelpersRequireTypedProducer}
       - {kind: go_test, name: TestRouteAuthorityDriftInventoryCoversRepoWideSearchDimensions}
       - {kind: go_test, name: TestRouteAuthorityDriftInventoryRejectsUnclassifiedRouteLikeProducer}
     notes: >
-      The current source/reason constants remain the typed metadata owner until
-      #1495 promotes a broader typed route-intent model.
+      #1495 promotes source/reason metadata into a typed route-intent producer
+      model so EventBus RoutePlan producers no longer call broad helper APIs with
+      independent raw source/reason strings.
 
   - id: live_carriers_handler_lookup_descriptors_not_authority
     concept: Live carriers, interceptors, handler lookup, and active descriptors are consumers or observations only.

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -504,6 +504,40 @@ contract_formats:
             engineOutbox MUST preserve this decision state across RoutePlan
             projection, materialization, diagnostics, persistence, and delivery
             consumers.
+        route_intent_producer_model:
+          status: merge_bearing_runtime_behavior
+          implementation_slice: '#1495'
+          canonical_code_owner: internal/runtime/bus.routeIntentProducer
+          producers:
+          - agent_policy / matched_agent_subscription
+          - direct_policy / direct_publish
+          - internal_target_route / internal_carrier
+          - internal_target_route / route_table_node
+          - concrete_node_route / route_table_node
+          - scoped_node_route / route_table_node
+          - root_node_route / route_table_node
+          - root_input_flow_node_route / route_table_node
+          - recipient_plan_materializer / materialized_route
+          - connect_route_plan / lowered_connect_route_plan
+          - legacy_projection / legacy_projection
+          rule: |
+            EventBus RoutePlan producer identity MUST be represented by a closed
+            typed route-intent producer role, not by broad helper APIs accepting
+            raw source/reason strings and not by a producer-local pair of
+            independently assigned source and reason values. RoutePlan
+            live-recipient and delivery-intent metadata MUST carry the same typed
+            producer role so source and reason are derived from one role and
+            cannot drift independently across producers.
+            The typed producer model is metadata and ownership proof; it does
+            not by itself create delivery authority, override
+            RoutePlanAuthorityState, or permit lower-precedence repair after a
+            canonical matched or canonical failed-closed route decision.
+            Connect-route producer roles, lower-precedence agent/subscription
+            roles, internal-target roles, concrete/scoped/root node roles,
+            root-input roles, and recipient-materializer roles MUST be produced
+            through the typed model. The legacy eventDeliveryPlan and direct
+            delivery compatibility paths remain explicitly split until their
+            own approved migration removes or isolates them.
         lowered_connect_route_plan_consumption:
           status: merge_bearing_runtime_behavior
           implementation_slice: '#1473'


### PR DESCRIPTION
## Summary

Closes #1495.

This PR promotes EventBus RoutePlan producer identity from independent source/reason string pairs to a closed typed route-intent producer role. Source/reason metadata is now derived from that role, so in-scope producers cannot pair arbitrary source and reason values or call broad helper APIs with raw strings.

## Governing Refs

- `platform-spec.yaml`: `contract_formats.event_schema.routing_derivation.route_plan_authority.decision_state`
- `platform-spec.yaml`: `contract_formats.event_schema.routing_derivation.route_plan_authority.route_intent_producer_model`
- `platform-spec.yaml`: `contract_formats.event_schema.routing_derivation.route_plan_authority.lowered_connect_route_plan_consumption`
- `platform-spec.yaml`: `contract_formats.event_schema.routing_derivation.route_plan_authority.receiver_carrier_lookup_boundary`
- `platform-spec.yaml`: `contract_formats.event_schema.routing_derivation.route_plan_authority.descriptor_evidence_boundary`
- Binding gate: #1495 Pre-Implementation Coverage Audit and lead gate approval.

## Semantic Migration

- New canonical owner: `internal/runtime/bus.routeIntentProducer`, backed by `platform-spec.yaml` `route_intent_producer_model`.
- Old invalid path: EventBus RoutePlan helper APIs accepting `source, reason string` and `RoutePlanLiveRecipient` / `RoutePlanDeliveryIntent` carrying separately assignable `Source` / `Reason` fields.
- Production paths checked and migrated: connect route plan, lower-precedence agent policy, internal target carrier, internal target route, concrete node route, scoped node route, root node route, root-input flow-node route, and recipient-plan materializer.
- Migration status: complete for the approved #1495 first slice. Legacy `eventDeliveryPlan`, direct delivery, operator replay direct paths, descriptor/index support, and composition-first routing remain explicitly split to their existing trackers and are not claimed closed here.

## Proof

- `go test ./internal/runtime/bus ./internal/runtime/core/pinrouting ./internal/runtime/conformance -run 'Test(RoutePlan|EventBusPublish_ConnectRoutePlan|ConnectRoutePlan|EventBusCheckPublishRecipientPlan_ConnectRoutePlan|EventBusPublishInMutation_ConnectRoutePlan|EngineOutbox_ConnectRoutePlan|EventBusPlan_UnmatchedCanonicalRouteUsesLowerPrecedenceFallback|RouteAuthority)' -count=1`
- `go test ./...`