### PR TITLE
[agent-a][issue #1493] Remove obsolete route projection producer

### DIFF
--- a/internal/runtime/bus/route_plan.go
+++ b/internal/runtime/bus/route_plan.go
@@ -25,7 +25,6 @@ const (
 	routePlanSourceRootInputFlowNode     routePlanSource = "root_input_flow_node_route"
 	routePlanSourceRecipientMaterializer routePlanSource = "recipient_plan_materializer"
 	routePlanSourceConnectRoutePlan      routePlanSource = "connect_route_plan"
-	routePlanSourceLegacyProjection      routePlanSource = "legacy_projection"
 
 	routePlanReasonMatchedAgentSubscription routePlanReason = "matched_agent_subscription"
 	routePlanReasonDirectPublish            routePlanReason = "direct_publish"
@@ -33,7 +32,6 @@ const (
 	routePlanReasonRouteTableNode           routePlanReason = "route_table_node"
 	routePlanReasonMaterializedRoute        routePlanReason = "materialized_route"
 	routePlanReasonLoweredConnectRoutePlan  routePlanReason = "lowered_connect_route_plan"
-	routePlanReasonLegacyProjection         routePlanReason = "legacy_projection"
 )
 
 type routeIntentProducer uint8
@@ -50,7 +48,6 @@ const (
 	routeIntentProducerRootInputFlowNode
 	routeIntentProducerRecipientMaterializer
 	routeIntentProducerConnectRoutePlan
-	routeIntentProducerLegacyProjection
 )
 
 func (p routeIntentProducer) Normalized() routeIntentProducer {
@@ -64,8 +61,7 @@ func (p routeIntentProducer) Normalized() routeIntentProducer {
 		routeIntentProducerRootNodeRoute,
 		routeIntentProducerRootInputFlowNode,
 		routeIntentProducerRecipientMaterializer,
-		routeIntentProducerConnectRoutePlan,
-		routeIntentProducerLegacyProjection:
+		routeIntentProducerConnectRoutePlan:
 		return p
 	default:
 		return routeIntentProducerUnknown
@@ -92,8 +88,6 @@ func (p routeIntentProducer) Source() routePlanSource {
 		return routePlanSourceRecipientMaterializer
 	case routeIntentProducerConnectRoutePlan:
 		return routePlanSourceConnectRoutePlan
-	case routeIntentProducerLegacyProjection:
-		return routePlanSourceLegacyProjection
 	default:
 		return ""
 	}
@@ -117,8 +111,6 @@ func (p routeIntentProducer) Reason() routePlanReason {
 		return routePlanReasonMaterializedRoute
 	case routeIntentProducerConnectRoutePlan:
 		return routePlanReasonLoweredConnectRoutePlan
-	case routeIntentProducerLegacyProjection:
-		return routePlanReasonLegacyProjection
 	default:
 		return ""
 	}

--- a/internal/runtime/conformance/route_authority_matrix_test.go
+++ b/internal/runtime/conformance/route_authority_matrix_test.go
@@ -213,7 +213,7 @@ func validateRouteAuthorityMatrix(root string, matrix routeAuthorityMatrix, ctx 
 		}
 		activeTrackers[key] = struct{}{}
 	}
-	for _, issue := range []int{1340, 1481, 1493} {
+	for _, issue := range []int{1340, 1481} {
 		key := routeAuthorityTrackerKey(issue, "runtime_operations.delivery_and_replay_ownership")
 		if _, ok := activeTrackers[key]; !ok {
 			problems = append(problems, fmt.Sprintf("active_trackers missing #%d runtime_operations.delivery_and_replay_ownership", issue))

--- a/internal/runtime/conformance/route_authority_matrix_test.go
+++ b/internal/runtime/conformance/route_authority_matrix_test.go
@@ -213,7 +213,7 @@ func validateRouteAuthorityMatrix(root string, matrix routeAuthorityMatrix, ctx 
 		}
 		activeTrackers[key] = struct{}{}
 	}
-	for _, issue := range []int{1340, 1481, 1493, 1494, 1495, 1496} {
+	for _, issue := range []int{1340, 1481, 1493} {
 		key := routeAuthorityTrackerKey(issue, "runtime_operations.delivery_and_replay_ownership")
 		if _, ok := activeTrackers[key]; !ok {
 			problems = append(problems, fmt.Sprintf("active_trackers missing #%d runtime_operations.delivery_and_replay_ownership", issue))

--- a/internal/runtime/conformance/testdata/route_authority_drift_inventory.yaml
+++ b/internal/runtime/conformance/testdata/route_authority_drift_inventory.yaml
@@ -689,11 +689,11 @@ guardrail_proposals:
       - direct SQL tests from asserting delivery counts without typed semantic subscriber identity
       - store fixtures from becoming undocumented route-authority interpreters
 follow_up_decision:
-  tracker_state: "#1494, #1495, and #1496 are closed capped children under #1493; #1479/#1466/#1481 remain open for descriptor, composition-first architecture, or broader route-authority work."
+  tracker_state: "#1494, #1495, and #1496 are closed capped children; #1493 is closed by #1503 after its parent-tail cleanup; #1340/#1481 remain active route-authority trackers, and #1479/#1466 remain open for descriptor or composition-first architecture work."
   new_child_required_before_coding: false
   runtime_behavior_child_required_now: false
   notes: >
-    #1493 owns the parent-tail closeout after the capped route-authority
-    children. Concrete bypasses discovered after this inventory must open or
-    update a child issue and receive an independent implementation gate before
-    coding.
+    #1493 is historical closed parent-tail context after #1503 merges, not an
+    active route-authority tracker. Concrete bypasses discovered after this
+    inventory must open or update a child issue and receive an independent
+    implementation gate before coding.

--- a/internal/runtime/conformance/testdata/route_authority_drift_inventory.yaml
+++ b/internal/runtime/conformance/testdata/route_authority_drift_inventory.yaml
@@ -689,10 +689,11 @@ guardrail_proposals:
       - direct SQL tests from asserting delivery counts without typed semantic subscriber identity
       - store fixtures from becoming undocumented route-authority interpreters
 follow_up_decision:
-  tracker_state: "#1494 extends the closed #1364 inventory owner under #1493; #1495 promotes typed EventBus route-intent producer ownership; #1496/#1479/#1466/#1481 remain open for compatibility, descriptor, or broader architecture work."
+  tracker_state: "#1494, #1495, and #1496 are closed capped children under #1493; #1479/#1466/#1481 remain open for descriptor, composition-first architecture, or broader route-authority work."
   new_child_required_before_coding: false
   runtime_behavior_child_required_now: false
   notes: >
-    No runtime behavior is selected in #1494. Concrete bypasses discovered
-    after this inventory must open or update a child issue and receive an
-    independent implementation gate before coding.
+    #1493 owns the parent-tail closeout after the capped route-authority
+    children. Concrete bypasses discovered after this inventory must open or
+    update a child issue and receive an independent implementation gate before
+    coding.

--- a/internal/runtime/conformance/testdata/route_authority_matrix.yaml
+++ b/internal/runtime/conformance/testdata/route_authority_matrix.yaml
@@ -26,9 +26,6 @@ active_trackers:
   - kind: github_issue
     issue: 1481
     watchlist: runtime_operations.delivery_and_replay_ownership
-  - kind: github_issue
-    issue: 1493
-    watchlist: runtime_operations.delivery_and_replay_ownership
 rows:
   - id: route_plan_spec_contract
     concept: RoutePlan is the publish-time typed authority and event_deliveries is the durable authority sink.

--- a/internal/runtime/conformance/testdata/route_authority_matrix.yaml
+++ b/internal/runtime/conformance/testdata/route_authority_matrix.yaml
@@ -29,15 +29,6 @@ active_trackers:
   - kind: github_issue
     issue: 1493
     watchlist: runtime_operations.delivery_and_replay_ownership
-  - kind: github_issue
-    issue: 1494
-    watchlist: runtime_operations.delivery_and_replay_ownership
-  - kind: github_issue
-    issue: 1495
-    watchlist: runtime_operations.delivery_and_replay_ownership
-  - kind: github_issue
-    issue: 1496
-    watchlist: runtime_operations.delivery_and_replay_ownership
 rows:
   - id: route_plan_spec_contract
     concept: RoutePlan is the publish-time typed authority and event_deliveries is the durable authority sink.

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -519,7 +519,6 @@ contract_formats:
           - root_input_flow_node_route / route_table_node
           - recipient_plan_materializer / materialized_route
           - connect_route_plan / lowered_connect_route_plan
-          - legacy_projection / legacy_projection
           rule: |
             EventBus RoutePlan producer identity MUST be represented by a closed
             typed route-intent producer role, not by broad helper APIs accepting
@@ -537,8 +536,10 @@ contract_formats:
             root-input roles, and recipient-materializer roles MUST be produced
             through the typed model. #1496 removes the legacy EventBus
             eventDeliveryPlan compatibility projection as a live route
-            interpreter; direct delivery remains an explicit direct-recipient
-            RoutePlan-backed producer/consumer path.
+            interpreter, and #1493 removes the obsolete legacy projection
+            producer vocabulary left behind after that collapse. Direct delivery
+            remains an explicit direct-recipient RoutePlan-backed
+            producer/consumer path.
         legacy_event_delivery_plan_collapse:
           status: merge_bearing_runtime_behavior
           implementation_slice: '#1496'


### PR DESCRIPTION
## Summary
- Removes the obsolete `legacy_projection` route-intent producer/source/reason vocabulary left after #1496 / PR #1502 collapsed the legacy eventDeliveryPlan compatibility path.
- Updates `platform-spec.yaml` in the same PR so the typed RoutePlan producer list matches shipped code.
- Updates route-authority matrix/drift tracker state so #1494, #1495, and #1496 are no longer listed as active trackers while preserving them as closed proof history.

Closes #1493.

## Governing refs / context
- `platform-spec.yaml` `route_intent_producer_model`
- `platform-spec.yaml` `legacy_event_delivery_plan_collapse`
- Route-authority parent #1493, after capped children #1494/#1495/#1496 closed by PRs #1500/#1501/#1502.

## Semantic cleanup
- New canonical owner remains `internal/runtime/bus.RoutePlan` plus typed `routeIntentProducer` roles.
- Old path invalidated: dormant `legacy_projection / legacy_projection` producer vocabulary, formerly left as a historical source/reason role after the live eventDeliveryPlan adapter was removed.
- Production paths checked for surviving old behavior: repo-wide searches for `legacy_projection`, legacy producer constants, `eventDeliveryPlan`, `CanonicalRoutePlan`, `WithCanonicalRoutePlan`, and `routePlanFromLegacyEventDeliveryPlan`.
- Migration is complete for the #1493 capped route-authority parent tail after this PR merges; broader route-authority residuals remain tracked separately by #1479, #1466, #1481, and #1485.

## Proof
- `rg -n "legacy_projection|routeIntentProducerLegacyProjection|routePlanSourceLegacyProjection|routePlanReasonLegacyProjection" internal/runtime/bus internal/runtime/conformance platform-spec.yaml` returned no matches.
- `go test ./internal/runtime/conformance -run 'TestRouteAuthority(Matrix|Drift)' -count=1`
- `go test ./internal/runtime/bus -run 'TestRoutePlan|TestEventBusRecipientPlanMaterializerNormalizesRoutePlanDirectly|TestEventBusPublishDirect|TestEngineOutboxAndDispatcher_UseCanonicalDirectRecipientManifest' -count=1`
- `go test ./...`