### PR TITLE
[agent-a][issue #1479] Support indexed business-field connect targets

### DIFF
--- a/internal/apispec/platform_spec_composition_routing_test.go
+++ b/internal/apispec/platform_spec_composition_routing_test.go
@@ -89,11 +89,14 @@ func TestPlatformSpecCompositionRoutingSourceAuthority(t *testing.T) {
 	entityContracts := mustYAMLPath(t, root, "entity_contracts")
 	assertScalarContains(t, mustYAMLPath(t, entityContracts, "routing_indexes", "rule"), "indexed: true")
 	assertScalarContains(t, mustYAMLPath(t, entityContracts, "routing_indexes", "rule"), "descriptor/index materialization")
+	assertScalarContains(t, mustYAMLPath(t, entityContracts, "routing_indexes", "rule"), "top-level")
+	assertScalarContains(t, mustYAMLPath(t, entityContracts, "routing_indexes", "rule"), "Nested entity paths")
 
 	slice1479 := mustYAMLPath(t, composition, "route_plan_lowering", "implementation_slice_1479")
 	assertScalarValue(t, mustMappingValue(t, slice1479, "status"), "merge_bearing_runtime_behavior")
 	assertScalarContains(t, mustMappingValue(t, slice1479, "canonical_code_owner"), "MaterializeConnectRoutePlan")
 	assertScalarContains(t, mustMappingValue(t, slice1479, "rule"), "indexed: true")
+	assertScalarContains(t, mustMappingValue(t, slice1479, "rule"), "nested")
 	assertScalarContains(t, mustMappingValue(t, slice1479, "rule"), "zero executable routes")
 }
 

--- a/internal/apispec/platform_spec_composition_routing_test.go
+++ b/internal/apispec/platform_spec_composition_routing_test.go
@@ -85,6 +85,16 @@ func TestPlatformSpecCompositionRoutingSourceAuthority(t *testing.T) {
 	assertScalarValue(t, mustMappingValue(t, slice1473, "status"), "merge_bearing_runtime_behavior")
 	assertScalarContains(t, mustMappingValue(t, slice1473, "canonical_code_owner"), "internal/runtime/bus.RoutePlan")
 	assertScalarContains(t, mustMappingValue(t, slice1473, "rule"), "Supported EventBus publish/preflight/outbox dispatch consumes lowered ConnectRoutePlan")
+
+	entityContracts := mustYAMLPath(t, root, "entity_contracts")
+	assertScalarContains(t, mustYAMLPath(t, entityContracts, "routing_indexes", "rule"), "indexed: true")
+	assertScalarContains(t, mustYAMLPath(t, entityContracts, "routing_indexes", "rule"), "descriptor/index materialization")
+
+	slice1479 := mustYAMLPath(t, composition, "route_plan_lowering", "implementation_slice_1479")
+	assertScalarValue(t, mustMappingValue(t, slice1479, "status"), "merge_bearing_runtime_behavior")
+	assertScalarContains(t, mustMappingValue(t, slice1479, "canonical_code_owner"), "MaterializeConnectRoutePlan")
+	assertScalarContains(t, mustMappingValue(t, slice1479, "rule"), "indexed: true")
+	assertScalarContains(t, mustMappingValue(t, slice1479, "rule"), "zero executable routes")
 }
 
 func TestPlatformSpecCompositionRoutingDemotesProducerTargetAuthority(t *testing.T) {

--- a/internal/runtime/bootverify/workflow_composition_connect_checks.go
+++ b/internal/runtime/bootverify/workflow_composition_connect_checks.go
@@ -216,11 +216,11 @@ func validateCompositionConnectAddress(source semanticview.Source, connect runti
 	if err != nil {
 		return []Finding{compositionConnectFinding(connect, "output_carries_address_key", err.Error(), producerFlowID)}
 	}
-	targetType, err := compositionConnectTargetType(source, receiverFlowID, targetExpr)
-	if err != nil {
+	if err := compositionConnectTargetIndexed(source, receiverFlowID, targetExpr); err != nil {
 		return []Finding{compositionConnectFinding(connect, "receiver_address_rule_invalid", err.Error(), receiverFlowID)}
 	}
-	if err := compositionConnectTargetIndexed(source, receiverFlowID, targetExpr); err != nil {
+	targetType, err := compositionConnectTargetType(source, receiverFlowID, targetExpr)
+	if err != nil {
 		return []Finding{compositionConnectFinding(connect, "receiver_address_rule_invalid", err.Error(), receiverFlowID)}
 	}
 	if !compositionConnectTypesCompatible(sourceType, targetType) {
@@ -308,6 +308,9 @@ func compositionConnectTargetIndexed(source semanticview.Source, flowID, expr st
 		switch fieldPath {
 		case "", "entity_id":
 			return nil
+		}
+		if strings.Contains(fieldPath, ".") {
+			return fmt.Errorf("receiver target %s uses a nested entity path; #1479 supports only top-level indexed entity fields as descriptor/index route evidence", expr)
 		}
 		contract, ok := entityruntime.ResolveForFlow(source, flowID)
 		if !ok {

--- a/internal/runtime/bootverify/workflow_composition_connect_checks.go
+++ b/internal/runtime/bootverify/workflow_composition_connect_checks.go
@@ -220,6 +220,9 @@ func validateCompositionConnectAddress(source semanticview.Source, connect runti
 	if err != nil {
 		return []Finding{compositionConnectFinding(connect, "receiver_address_rule_invalid", err.Error(), receiverFlowID)}
 	}
+	if err := compositionConnectTargetIndexed(source, receiverFlowID, targetExpr); err != nil {
+		return []Finding{compositionConnectFinding(connect, "receiver_address_rule_invalid", err.Error(), receiverFlowID)}
+	}
 	if !compositionConnectTypesCompatible(sourceType, targetType) {
 		return []Finding{compositionConnectFinding(connect, "key_types_incompatible", fmt.Sprintf("source %s type %s is incompatible with target %s type %s", sourceExpr, sourceType, targetExpr, targetType), receiverFlowID)}
 	}
@@ -295,6 +298,42 @@ func compositionConnectTargetType(source semanticview.Source, flowID, expr strin
 		return "string", nil
 	}
 	return "", fmt.Errorf("target expression %q must be entity.*, config.*, or instance.*", expr)
+}
+
+func compositionConnectTargetIndexed(source semanticview.Source, flowID, expr string) error {
+	expr = strings.TrimSpace(expr)
+	switch {
+	case strings.HasPrefix(expr, "entity."):
+		fieldPath := strings.TrimSpace(strings.TrimPrefix(expr, "entity."))
+		switch fieldPath {
+		case "", "entity_id":
+			return nil
+		}
+		contract, ok := entityruntime.ResolveForFlow(source, flowID)
+		if !ok {
+			return fmt.Errorf("receiver flow %s has no entity contract for %s", flowID, expr)
+		}
+		field, err := entityruntime.ResolveLeafField(contract, fieldPath)
+		if err != nil {
+			return fmt.Errorf("receiver target %s is invalid: %v", expr, err)
+		}
+		if !field.FieldDecl.Indexed {
+			return fmt.Errorf("receiver target %s must declare indexed: true before it can be used as descriptor/index route evidence", expr)
+		}
+		return nil
+	case strings.HasPrefix(expr, "config."):
+		return fmt.Errorf("receiver target %s has no typed descriptor/index owner; use an indexed entity field or an identity descriptor target", expr)
+	case strings.HasPrefix(expr, "instance."):
+		fieldPath := strings.TrimSpace(strings.TrimPrefix(expr, "instance."))
+		switch fieldPath {
+		case "flow_instance", "instance_id":
+			return nil
+		default:
+			return fmt.Errorf("receiver target %s has no typed descriptor/index owner; use an indexed entity field or an identity descriptor target", expr)
+		}
+	default:
+		return nil
+	}
 }
 
 func compositionConnectTypesCompatible(sourceType, targetType string) bool {

--- a/internal/runtime/bootverify/workflow_composition_connect_checks_test.go
+++ b/internal/runtime/bootverify/workflow_composition_connect_checks_test.go
@@ -93,6 +93,14 @@ func TestRun_FailsClosedForInvalidParentCompositionConnect(t *testing.T) {
 			wantExtra: "indexed: true",
 		},
 		{
+			name: "nested business-field target",
+			opts: compositionConnectFixtureOptions{
+				mapTarget: "entity.profile.vertical_id",
+			},
+			want:      "receiver_address_rule_invalid",
+			wantExtra: "top-level indexed entity fields",
+		},
+		{
 			name: "invalid delivery topology",
 			opts: compositionConnectFixtureOptions{
 				delivery: "many",

--- a/internal/runtime/bootverify/workflow_composition_connect_checks_test.go
+++ b/internal/runtime/bootverify/workflow_composition_connect_checks_test.go
@@ -85,6 +85,14 @@ func TestRun_FailsClosedForInvalidParentCompositionConnect(t *testing.T) {
 			want: "key_types_incompatible",
 		},
 		{
+			name: "unindexed business-field target",
+			opts: compositionConnectFixtureOptions{
+				consumerEntityUnindexed: true,
+			},
+			want:      "receiver_address_rule_invalid",
+			wantExtra: "indexed: true",
+		},
+		{
 			name: "invalid delivery topology",
 			opts: compositionConnectFixtureOptions{
 				delivery: "many",
@@ -205,20 +213,21 @@ func TestRun_TreatsParentCompositionConnectAsEventTopologyProof(t *testing.T) {
 }
 
 type compositionConnectFixtureOptions struct {
-	connectFrom            string
-	connectTo              string
-	delivery               string
-	noAdapter              bool
-	mapSource              string
-	mapTarget              string
-	omitMap                bool
-	consumerMode           string
-	consumerScalarInput    bool
-	consumerEntityType     string
-	consumerRequiresInput  bool
-	consumerInputBind      string
-	producerRequiresOutput bool
-	producerOutputBind     string
+	connectFrom             string
+	connectTo               string
+	delivery                string
+	noAdapter               bool
+	mapSource               string
+	mapTarget               string
+	omitMap                 bool
+	consumerMode            string
+	consumerScalarInput     bool
+	consumerEntityType      string
+	consumerEntityUnindexed bool
+	consumerRequiresInput   bool
+	consumerInputBind       string
+	producerRequiresOutput  bool
+	producerOutputBind      string
 }
 
 func writeCompositionConnectBootverifyFixture(t *testing.T, opts compositionConnectFixtureOptions) string {
@@ -442,6 +451,7 @@ deploy.completed:
 deployment:
   vertical_id:
     type: string
+    indexed: true
     _unused_reason: composition connect topology proof field
 `)
 	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "consumer", "nodes.yaml"), "{}\n")
@@ -534,10 +544,15 @@ deploy.completed:
 `)
 	if !opts.consumerScalarInput {
 		entityType := firstTestValue(opts.consumerEntityType, "string")
+		indexed := "\n    indexed: true"
+		if opts.consumerEntityUnindexed {
+			indexed = ""
+		}
 		writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "consumer", "entities.yaml"), `
 deployment:
   vertical_id:
     type: `+entityType+`
+`+indexed+`
 `)
 	}
 	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "consumer", "nodes.yaml"), `

--- a/internal/runtime/bus/connect_route_plan_dispatch.go
+++ b/internal/runtime/bus/connect_route_plan_dispatch.go
@@ -9,6 +9,7 @@ import (
 	"github.com/division-sh/swarm/internal/events"
 	runtimeflowidentity "github.com/division-sh/swarm/internal/runtime/core/flowidentity"
 	runtimepinrouting "github.com/division-sh/swarm/internal/runtime/core/pinrouting"
+	runtimecorrelation "github.com/division-sh/swarm/internal/runtime/correlation"
 	"github.com/division-sh/swarm/internal/runtime/semanticview"
 )
 
@@ -66,6 +67,7 @@ func (r connectRoutePlanResolver) Plan(ctx context.Context, evt events.Event) (c
 	if len(matched) == 0 {
 		return connectRoutePlanDispatch{}, nil
 	}
+	ctx = runtimecorrelation.WithInboundEvent(ctx, evt)
 	descriptors, err := r.descriptorsForPlans(ctx, matched)
 	if err != nil {
 		return connectRoutePlanDispatch{}, err
@@ -79,8 +81,9 @@ func (r connectRoutePlanResolver) Plan(ctx context.Context, evt events.Event) (c
 	}
 	for _, plan := range matched {
 		materialized := runtimepinrouting.MaterializeConnectRoutePlan(plan, runtimepinrouting.ConnectRoutePlanMaterializationInput{
-			MatchValues: values,
-			Descriptors: descriptors,
+			MatchValues:             values,
+			Descriptors:             descriptors,
+			SupportedAddressTargets: runtimepinrouting.SupportedConnectAddressTargets(r.source, plan),
 		})
 		if materialized.Failure != "" {
 			out.Failure = connectRoutePlanTargetFailure(materialized.Failure)

--- a/internal/runtime/bus/connect_route_plan_dispatch_test.go
+++ b/internal/runtime/bus/connect_route_plan_dispatch_test.go
@@ -625,6 +625,18 @@ func TestEventBusPublish_ConnectRoutePlanFailsClosedForBusinessFieldDescriptorGa
 			wantFailure: runtimepinrouting.TargetFailure(runtimepinrouting.ConnectFailureTargetUnsupported),
 		},
 		{
+			name:    "unsupported nested target",
+			source:  connectRoutePlanBusinessFieldSourceWithTarget("one", true, "entity.profile.vertical_id"),
+			payload: `{"vertical_id":"v-1"}`,
+			flowInstances: []ActiveFlowInstanceDescriptor{{
+				InstanceID:    "one",
+				EntityID:      "ent-1",
+				FlowInstance:  "consumer/one",
+				AddressFields: map[string]string{"entity.profile.vertical_id": "v-1"},
+			}},
+			wantFailure: runtimepinrouting.TargetFailure(runtimepinrouting.ConnectFailureTargetUnsupported),
+		},
+		{
 			name:    "wrong receiver scope",
 			source:  connectRoutePlanBusinessFieldSource("one", true),
 			payload: `{"vertical_id":"v-1"}`,
@@ -1083,6 +1095,10 @@ func connectRoutePlanFanoutSource() semanticview.Source {
 }
 
 func connectRoutePlanBusinessFieldSource(cardinality string, indexed bool) semanticview.Source {
+	return connectRoutePlanBusinessFieldSourceWithTarget(cardinality, indexed, "entity.vertical_id")
+}
+
+func connectRoutePlanBusinessFieldSourceWithTarget(cardinality string, indexed bool, target string) semanticview.Source {
 	return semanticview.Wrap(connectRoutePlanTestBundle([]connectRoutePlanTestFlow{
 		{
 			id:   "producer",
@@ -1101,7 +1117,7 @@ func connectRoutePlanBusinessFieldSource(cardinality string, indexed bool) seman
 				Address: &runtimecontracts.FlowInputPinAddress{
 					By:          "vertical_id",
 					Source:      "payload.vertical_id",
-					Target:      "entity.vertical_id",
+					Target:      target,
 					Cardinality: cardinality,
 				},
 			}},

--- a/internal/runtime/bus/connect_route_plan_dispatch_test.go
+++ b/internal/runtime/bus/connect_route_plan_dispatch_test.go
@@ -21,11 +21,12 @@ import (
 )
 
 type connectRoutePlanTestFlow struct {
-	id      string
-	mode    string
-	inputs  []runtimecontracts.FlowInputEventPin
-	outputs []runtimecontracts.FlowOutputEventPin
-	nodes   map[string]runtimecontracts.SystemNodeContract
+	id           string
+	mode         string
+	inputs       []runtimecontracts.FlowInputEventPin
+	outputs      []runtimecontracts.FlowOutputEventPin
+	nodes        map[string]runtimecontracts.SystemNodeContract
+	entityFields map[string]runtimecontracts.EntityFieldDecl
 }
 
 type connectRoutePlanDescriptorStore struct {
@@ -500,38 +501,184 @@ func TestEventBusResetInMemoryStateRefreshesConnectRoutePlanner(t *testing.T) {
 	}
 }
 
-func TestEventBusPublish_ConnectRoutePlanFailsClosedForUnsupportedBusinessFieldTarget(t *testing.T) {
-	source := semanticview.Wrap(connectRoutePlanTestBundle([]connectRoutePlanTestFlow{
-		{
-			id:   "producer",
-			mode: "static",
-			outputs: []runtimecontracts.FlowOutputEventPin{{
-				Name:  "deploy_done",
-				Event: "deploy.done",
-			}},
-		},
-		{
-			id:   "consumer",
-			mode: "template",
-			inputs: []runtimecontracts.FlowInputEventPin{{
-				Name:  "deploy_completed",
-				Event: "deploy.completed",
-				Address: &runtimecontracts.FlowInputPinAddress{
-					By:          "vertical_id",
-					Source:      "payload.vertical_id",
-					Target:      "entity.vertical_id",
-					Cardinality: "one",
-				},
-			}},
-		},
-	}, []runtimecontracts.FlowPackageConnect{{
-		From:     "producer.deploy_done",
-		To:       "consumer.deploy_completed",
-		Delivery: "one",
-	}}))
+func TestEventBusPublish_ConnectRoutePlanPersistsIndexedBusinessFieldTarget(t *testing.T) {
+	source := connectRoutePlanBusinessFieldSource("one", true)
 	store := &connectRoutePlanDescriptorStore{
 		targetRouteMemoryStore: newTargetRouteMemoryStore(),
-		flowInstances:          []ActiveFlowInstanceDescriptor{{InstanceID: "one", EntityID: "ent-1", FlowInstance: "consumer/one"}},
+		flowInstances: []ActiveFlowInstanceDescriptor{{
+			InstanceID:    "one",
+			EntityID:      "ent-1",
+			FlowInstance:  "consumer/one",
+			AddressFields: map[string]string{"entity.vertical_id": "v-1"},
+		}},
+	}
+	eb, err := NewEventBusWithOptions(store, EventBusOptions{ContractBundle: source})
+	if err != nil {
+		t.Fatalf("NewEventBusWithOptions: %v", err)
+	}
+	if err := eb.AddFlowInstanceRoute(FlowInstanceRouteMaterializationRequest{Identity: runtimeflowidentity.DeriveRoute("consumer", "one")}); err != nil {
+		t.Fatalf("AddFlowInstanceRoute: %v", err)
+	}
+	eventID := uuid.NewString()
+	evt := events.NewProjectionEvent(eventID,
+		events.EventType("producer/deploy.done"), "", "", json.RawMessage(`{"vertical_id":"v-1"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())
+	want := events.DeliveryRoute{SubscriberType: "node", SubscriberID: "consumer-node-one", Target: events.RouteIdentity{FlowID: "consumer", FlowInstance: "consumer/one", EntityID: "ent-1"}}
+
+	routePlan, err := eb.planSubscribedRoutePlan(context.Background(), evt, false)
+	if err != nil {
+		t.Fatalf("planSubscribedRoutePlan: %v", err)
+	}
+	if routePlan.AuthorityState != RoutePlanAuthorityCanonicalMatched || routePlan.AuthorityOwner != routePlanSourceConnectRoutePlan {
+		t.Fatalf("route plan authority = %q/%q, want matched connect route plan", routePlan.AuthorityState, routePlan.AuthorityOwner)
+	}
+	if !deliveryRoutesContain(routePlan.DeliveryRoutes(), want) || len(routePlan.DeliveryRoutes()) != 1 {
+		t.Fatalf("route plan delivery routes = %#v, want indexed business-field route %#v", routePlan.DeliveryRoutes(), want)
+	}
+	if err := eb.Publish(context.Background(), evt); err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+	if !deliveryRoutesContain(store.routes[eventID], want) || len(store.routes[eventID]) != 1 {
+		t.Fatalf("persisted delivery routes = %#v, want indexed business-field route %#v", store.routes[eventID], want)
+	}
+}
+
+func TestEventBusPublish_ConnectRoutePlanPersistsIndexedBusinessFieldTargetSet(t *testing.T) {
+	source := connectRoutePlanBusinessFieldSource("many", true)
+	store := &connectRoutePlanDescriptorStore{
+		targetRouteMemoryStore: newTargetRouteMemoryStore(),
+		flowInstances: []ActiveFlowInstanceDescriptor{
+			{InstanceID: "one", EntityID: "ent-1", FlowInstance: "consumer/one", AddressFields: map[string]string{"entity.vertical_id": "v-1"}},
+			{InstanceID: "two", EntityID: "ent-2", FlowInstance: "consumer/two", AddressFields: map[string]string{"entity.vertical_id": "v-1"}},
+			{InstanceID: "other", EntityID: "ent-3", FlowInstance: "consumer/other", AddressFields: map[string]string{"entity.vertical_id": "v-2"}},
+		},
+	}
+	eb, err := NewEventBusWithOptions(store, EventBusOptions{ContractBundle: source})
+	if err != nil {
+		t.Fatalf("NewEventBusWithOptions: %v", err)
+	}
+	for _, id := range []string{"one", "two", "other"} {
+		if err := eb.AddFlowInstanceRoute(FlowInstanceRouteMaterializationRequest{Identity: runtimeflowidentity.DeriveRoute("consumer", id)}); err != nil {
+			t.Fatalf("AddFlowInstanceRoute(%s): %v", id, err)
+		}
+	}
+	eventID := uuid.NewString()
+	evt := events.NewProjectionEvent(eventID,
+		events.EventType("producer/deploy.done"), "", "", json.RawMessage(`{"vertical_id":"v-1"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())
+	wantOne := events.DeliveryRoute{SubscriberType: "node", SubscriberID: "consumer-node-one", Target: events.RouteIdentity{FlowID: "consumer", FlowInstance: "consumer/one", EntityID: "ent-1"}}
+	wantTwo := events.DeliveryRoute{SubscriberType: "node", SubscriberID: "consumer-node-two", Target: events.RouteIdentity{FlowID: "consumer", FlowInstance: "consumer/two", EntityID: "ent-2"}}
+
+	if err := eb.Publish(context.Background(), evt); err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+	routes := store.routes[eventID]
+	if !deliveryRoutesContain(routes, wantOne) || !deliveryRoutesContain(routes, wantTwo) || len(routes) != 2 {
+		t.Fatalf("persisted target_set delivery routes = %#v, want one/two only", routes)
+	}
+}
+
+func TestEventBusPublish_ConnectRoutePlanFailsClosedForBusinessFieldDescriptorGaps(t *testing.T) {
+	tests := []struct {
+		name          string
+		source        semanticview.Source
+		payload       string
+		flowInstances []ActiveFlowInstanceDescriptor
+		wantFailure   runtimepinrouting.TargetFailure
+	}{
+		{
+			name:        "missing source value",
+			source:      connectRoutePlanBusinessFieldSource("one", true),
+			payload:     `{}`,
+			wantFailure: runtimepinrouting.TargetFailure(runtimepinrouting.ConnectFailureAddressValueMissing),
+		},
+		{
+			name:    "no descriptor match",
+			source:  connectRoutePlanBusinessFieldSource("one", true),
+			payload: `{"vertical_id":"v-1"}`,
+			flowInstances: []ActiveFlowInstanceDescriptor{{
+				InstanceID:    "one",
+				EntityID:      "ent-1",
+				FlowInstance:  "consumer/one",
+				AddressFields: map[string]string{"entity.vertical_id": "v-2"},
+			}},
+			wantFailure: runtimepinrouting.TargetFailure(runtimepinrouting.ConnectFailureTargetUnresolved),
+		},
+		{
+			name:    "ambiguous singular target",
+			source:  connectRoutePlanBusinessFieldSource("one", true),
+			payload: `{"vertical_id":"v-1"}`,
+			flowInstances: []ActiveFlowInstanceDescriptor{
+				{InstanceID: "one", EntityID: "ent-1", FlowInstance: "consumer/one", AddressFields: map[string]string{"entity.vertical_id": "v-1"}},
+				{InstanceID: "two", EntityID: "ent-2", FlowInstance: "consumer/two", AddressFields: map[string]string{"entity.vertical_id": "v-1"}},
+			},
+			wantFailure: runtimepinrouting.TargetFailure(runtimepinrouting.ConnectFailureTargetAmbiguous),
+		},
+		{
+			name:    "unsupported unindexed target",
+			source:  connectRoutePlanBusinessFieldSource("one", false),
+			payload: `{"vertical_id":"v-1"}`,
+			flowInstances: []ActiveFlowInstanceDescriptor{{
+				InstanceID:    "one",
+				EntityID:      "ent-1",
+				FlowInstance:  "consumer/one",
+				AddressFields: map[string]string{"entity.vertical_id": "v-1"},
+			}},
+			wantFailure: runtimepinrouting.TargetFailure(runtimepinrouting.ConnectFailureTargetUnsupported),
+		},
+		{
+			name:    "wrong receiver scope",
+			source:  connectRoutePlanBusinessFieldSource("one", true),
+			payload: `{"vertical_id":"v-1"}`,
+			flowInstances: []ActiveFlowInstanceDescriptor{{
+				InstanceID:    "one",
+				EntityID:      "ent-1",
+				FlowInstance:  "other/one",
+				AddressFields: map[string]string{"entity.vertical_id": "v-1"},
+			}},
+			wantFailure: runtimepinrouting.TargetFailure(runtimepinrouting.ConnectFailureTargetUnresolved),
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			store := &connectRoutePlanDescriptorStore{
+				targetRouteMemoryStore: newTargetRouteMemoryStore(),
+				flowInstances:          tc.flowInstances,
+			}
+			eb, err := NewEventBusWithOptions(store, EventBusOptions{ContractBundle: tc.source})
+			if err != nil {
+				t.Fatalf("NewEventBusWithOptions: %v", err)
+			}
+			evt := events.NewProjectionEvent(uuid.NewString(),
+				events.EventType("producer/deploy.done"), "", "", json.RawMessage(tc.payload), 0, "", "", events.EventEnvelope{}, time.Now().UTC())
+
+			routePlan, err := eb.planSubscribedRoutePlan(context.Background(), evt, false)
+			if err != nil {
+				t.Fatalf("planSubscribedRoutePlan: %v", err)
+			}
+			if routePlan.AuthorityState != RoutePlanAuthorityCanonicalFailedClosed || routePlan.AuthorityOwner != routePlanSourceConnectRoutePlan {
+				t.Fatalf("route plan authority = %q/%q, want fail-closed connect route plan", routePlan.AuthorityState, routePlan.AuthorityOwner)
+			}
+			if routePlan.TargetFailure != tc.wantFailure {
+				t.Fatalf("target failure = %q, want %q", routePlan.TargetFailure, tc.wantFailure)
+			}
+			if len(routePlan.LiveRecipients) != 0 || len(routePlan.DeliveryIntents) != 0 || len(routePlan.RoutedRecipients) != 0 ||
+				len(routePlan.RecipientIDs()) != 0 || len(routePlan.PersistedRecipientIDs()) != 0 || len(routePlan.DeliveryRoutes()) != 0 {
+				t.Fatalf("fail-closed business-field route exposed executable routes: live=%#v intents=%#v routed=%#v recipients=%#v persisted=%#v routes=%#v",
+					routePlan.LiveRecipients, routePlan.DeliveryIntents, routePlan.RoutedRecipients, routePlan.RecipientIDs(), routePlan.PersistedRecipientIDs(), routePlan.DeliveryRoutes())
+			}
+		})
+	}
+}
+
+func TestEventBusPublish_ConnectRoutePlanFailsClosedForUnsupportedBusinessFieldTarget(t *testing.T) {
+	source := connectRoutePlanBusinessFieldSource("one", false)
+	store := &connectRoutePlanDescriptorStore{
+		targetRouteMemoryStore: newTargetRouteMemoryStore(),
+		flowInstances: []ActiveFlowInstanceDescriptor{{
+			InstanceID:    "one",
+			EntityID:      "ent-1",
+			FlowInstance:  "consumer/one",
+			AddressFields: map[string]string{"entity.vertical_id": "v-1"},
+		}},
 	}
 	eb, err := NewEventBusWithOptions(store, EventBusOptions{ContractBundle: source})
 	if err != nil {
@@ -935,6 +1082,46 @@ func connectRoutePlanFanoutSource() semanticview.Source {
 	}}))
 }
 
+func connectRoutePlanBusinessFieldSource(cardinality string, indexed bool) semanticview.Source {
+	return semanticview.Wrap(connectRoutePlanTestBundle([]connectRoutePlanTestFlow{
+		{
+			id:   "producer",
+			mode: "static",
+			outputs: []runtimecontracts.FlowOutputEventPin{{
+				Name:  "deploy_done",
+				Event: "deploy.done",
+			}},
+		},
+		{
+			id:   "consumer",
+			mode: "template",
+			inputs: []runtimecontracts.FlowInputEventPin{{
+				Name:  "deploy_completed",
+				Event: "deploy.completed",
+				Address: &runtimecontracts.FlowInputPinAddress{
+					By:          "vertical_id",
+					Source:      "payload.vertical_id",
+					Target:      "entity.vertical_id",
+					Cardinality: cardinality,
+				},
+			}},
+			nodes: map[string]runtimecontracts.SystemNodeContract{
+				"consumer-node": {
+					ID:            "consumer-node-{instance_id}",
+					EventHandlers: map[string]runtimecontracts.SystemNodeEventHandler{"deploy.completed": {}},
+				},
+			},
+			entityFields: map[string]runtimecontracts.EntityFieldDecl{
+				"vertical_id": {Type: "string", Indexed: indexed},
+			},
+		},
+	}, []runtimecontracts.FlowPackageConnect{{
+		From:     "producer.deploy_done",
+		To:       "consumer.deploy_completed",
+		Delivery: cardinality,
+	}}))
+}
+
 func connectRoutePlanTestBundle(flows []connectRoutePlanTestFlow, connects []runtimecontracts.FlowPackageConnect) *runtimecontracts.WorkflowContractBundle {
 	children := make([]runtimecontracts.FlowContractView, 0, len(flows))
 	byID := make(map[string]*runtimecontracts.FlowContractView, len(flows))
@@ -944,6 +1131,8 @@ func connectRoutePlanTestBundle(flows []connectRoutePlanTestFlow, connects []run
 	flowInputPins := make(map[string][]runtimecontracts.FlowInputEventPin, len(flows))
 	flowOutputPins := make(map[string][]runtimecontracts.FlowOutputEventPin, len(flows))
 	nodeHandlers := map[string]map[string]runtimecontracts.SystemNodeEventHandler{}
+	workflowName := ""
+	rootEntities := runtimecontracts.EntityContractsDocument{}
 	for _, flow := range flows {
 		schema := runtimecontracts.FlowSchemaDocument{
 			Mode: flow.mode,
@@ -977,15 +1166,21 @@ func connectRoutePlanTestBundle(flows []connectRoutePlanTestFlow, connects []run
 				nodeHandlers[node.ID] = node.EventHandlers
 			}
 		}
+		if len(flow.entityFields) > 0 && workflowName == "" {
+			workflowName = flow.id
+			rootEntities["test_entity"] = runtimecontracts.EntityContract{Fields: flow.entityFields}
+		}
 	}
 	root := runtimecontracts.FlowContractView{Children: children}
 	return &runtimecontracts.WorkflowContractBundle{
+		RootEntities: rootEntities,
 		FlowTree: flowmodel.Tree[runtimecontracts.FlowContractView]{
 			Root: &root,
 			ByID: byID,
 		},
 		FlowSchemas: flowSchemas,
 		Semantics: runtimecontracts.WorkflowSemanticView{
+			Name:                workflowName,
 			FlowInputs:          flowInputs,
 			FlowOutputs:         flowOutputs,
 			FlowInputEventPins:  flowInputPins,

--- a/internal/runtime/bus/eventbus_routing.go
+++ b/internal/runtime/bus/eventbus_routing.go
@@ -55,9 +55,10 @@ func (eb *EventBus) PinRoutingDescriptors(ctx context.Context) ([]runtimepinrout
 			continue
 		}
 		out = append(out, runtimepinrouting.Descriptor{
-			ID:           descriptor.ID,
-			EntityID:     descriptor.EntityID,
-			FlowInstance: descriptor.FlowInstance,
+			ID:            descriptor.ID,
+			EntityID:      descriptor.EntityID,
+			FlowInstance:  descriptor.FlowInstance,
+			AddressFields: normalizeDescriptorAddressFields(descriptor.AddressFields),
 		})
 	}
 	return out, nil

--- a/internal/runtime/bus/store.go
+++ b/internal/runtime/bus/store.go
@@ -66,10 +66,11 @@ type ActiveAgentDescriptorLister interface {
 }
 
 type ActiveFlowInstanceDescriptor struct {
-	InstanceID   string
-	EntityID     string
-	FlowInstance string
-	FlowTemplate string
+	InstanceID    string
+	EntityID      string
+	FlowInstance  string
+	FlowTemplate  string
+	AddressFields map[string]string
 }
 
 func (d ActiveFlowInstanceDescriptor) Normalized() ActiveFlowInstanceDescriptor {
@@ -86,19 +87,21 @@ func (d ActiveFlowInstanceDescriptor) Normalized() ActiveFlowInstanceDescriptor 
 		entityID = runtimeflowidentity.EntityID(flowInstance)
 	}
 	return ActiveFlowInstanceDescriptor{
-		InstanceID:   instanceID,
-		EntityID:     entityID,
-		FlowInstance: flowInstance,
-		FlowTemplate: strings.TrimSpace(d.FlowTemplate),
+		InstanceID:    instanceID,
+		EntityID:      entityID,
+		FlowInstance:  flowInstance,
+		FlowTemplate:  strings.TrimSpace(d.FlowTemplate),
+		AddressFields: normalizeDescriptorAddressFields(d.AddressFields),
 	}
 }
 
 func (d ActiveFlowInstanceDescriptor) TargetDescriptor() ActiveTargetDescriptor {
 	d = d.Normalized()
 	return ActiveTargetDescriptor{
-		ID:           d.InstanceID,
-		EntityID:     d.EntityID,
-		FlowInstance: d.FlowInstance,
+		ID:            d.InstanceID,
+		EntityID:      d.EntityID,
+		FlowInstance:  d.FlowInstance,
+		AddressFields: normalizeDescriptorAddressFields(d.AddressFields),
 	}.Normalized()
 }
 
@@ -110,9 +113,10 @@ type ActiveFlowInstanceDescriptorLister interface {
 }
 
 type ActiveTargetDescriptor struct {
-	ID           string
-	EntityID     string
-	FlowInstance string
+	ID            string
+	EntityID      string
+	FlowInstance  string
+	AddressFields map[string]string
 }
 
 func (d ActiveTargetDescriptor) Normalized() ActiveTargetDescriptor {
@@ -122,10 +126,30 @@ func (d ActiveTargetDescriptor) Normalized() ActiveTargetDescriptor {
 		entityID = runtimeflowidentity.EntityID(flowInstance)
 	}
 	return ActiveTargetDescriptor{
-		ID:           strings.TrimSpace(d.ID),
-		EntityID:     entityID,
-		FlowInstance: flowInstance,
+		ID:            strings.TrimSpace(d.ID),
+		EntityID:      entityID,
+		FlowInstance:  flowInstance,
+		AddressFields: normalizeDescriptorAddressFields(d.AddressFields),
 	}
+}
+
+func normalizeDescriptorAddressFields(in map[string]string) map[string]string {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(in))
+	for key, value := range in {
+		key = strings.TrimSpace(key)
+		value = strings.TrimSpace(value)
+		if key == "" || value == "" {
+			continue
+		}
+		out[key] = value
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
 }
 
 // PipelineReceiptPersistence is an optional capability for marking whether

--- a/internal/runtime/conformance/testdata/route_authority_drift_inventory.yaml
+++ b/internal/runtime/conformance/testdata/route_authority_drift_inventory.yaml
@@ -431,13 +431,14 @@ seam_families:
       - active-agent descriptor lookup
       - active target descriptors
       - handler descriptor lookup
-      - unsupported or unindexed business-field descriptor target
+      - unsupported, nested, or unindexed business-field descriptor target
     notes: >
       Descriptor evidence may support explicitly approved target materialization
-      but is not delivery authority. #1479 implements declared indexed receiver
-      entity fields as supported descriptor evidence; arbitrary, undeclared,
-      unindexed, config, and instance business-field descriptor/index authority
-      remains split to #1466 or later gated children.
+      but is not delivery authority. #1479 implements declared indexed
+      top-level receiver entity fields as supported descriptor evidence;
+      nested, arbitrary, undeclared, unindexed, config, and instance
+      business-field descriptor/index authority remains split to #1466 or
+      later gated children.
   - id: event_delivery_plan_compatibility_adapter
     layer: invalid_old_authority
     classification: invalid_old_authority_path

--- a/internal/runtime/conformance/testdata/route_authority_drift_inventory.yaml
+++ b/internal/runtime/conformance/testdata/route_authority_drift_inventory.yaml
@@ -429,11 +429,13 @@ seam_families:
       - active-agent descriptor lookup
       - active target descriptors
       - handler descriptor lookup
-      - unsupported business-field descriptor target
+      - unsupported or unindexed business-field descriptor target
     notes: >
       Descriptor evidence may support explicitly approved target materialization
-      but is not delivery authority. Business-field descriptor/index support
-      remains split to #1479.
+      but is not delivery authority. #1479 implements declared indexed receiver
+      entity fields as supported descriptor evidence; arbitrary, undeclared,
+      unindexed, config, and instance business-field descriptor/index authority
+      remains split to #1466 or later gated children.
   - id: event_delivery_plan_compatibility_adapter
     layer: invalid_old_authority
     classification: invalid_old_authority_path
@@ -689,7 +691,7 @@ guardrail_proposals:
       - direct SQL tests from asserting delivery counts without typed semantic subscriber identity
       - store fixtures from becoming undocumented route-authority interpreters
 follow_up_decision:
-  tracker_state: "#1494, #1495, and #1496 are closed capped children; #1493 is closed by #1503 after its parent-tail cleanup; #1340/#1481 remain active route-authority trackers, and #1479/#1466 remain open for descriptor or composition-first architecture work."
+  tracker_state: "#1494, #1495, and #1496 are closed capped children; #1493 is closed by #1503 after its parent-tail cleanup; #1479 implements declared indexed receiver entity-field descriptor evidence; #1466 remains open for broader composition-first architecture work, with #1340/#1481 as route-authority context."
   new_child_required_before_coding: false
   runtime_behavior_child_required_now: false
   notes: >

--- a/internal/runtime/conformance/testdata/route_authority_drift_inventory.yaml
+++ b/internal/runtime/conformance/testdata/route_authority_drift_inventory.yaml
@@ -424,6 +424,8 @@ seam_families:
       - internal/runtime/engine/interfaces.go
       - internal/runtime/pipeline/engine_adapter.go
       - internal/runtime/conformance/testdata/route_authority_matrix.yaml
+      - internal/store/flow_instance_descriptors_sqlite_test.go
+      - internal/store/flow_instance_routes_test.go
     search_dimensions: [descriptor_evidence, connect_route_plan]
     invalid_authority:
       - active-agent descriptor lookup

--- a/internal/runtime/conformance/testdata/route_authority_matrix.yaml
+++ b/internal/runtime/conformance/testdata/route_authority_matrix.yaml
@@ -384,7 +384,7 @@ rows:
       - active-agent descriptor lookup
       - active target descriptors
       - handler descriptor lookup
-      - unsupported or unindexed business-field descriptor targets
+      - unsupported, nested, or unindexed business-field descriptor targets
     owner_refs:
       - {kind: spec_ref, path: platform-spec.yaml, ref: descriptor_evidence_boundary}
       - {kind: spec_ref, path: platform-spec.yaml, ref: supported_descriptor_targets}
@@ -404,11 +404,11 @@ rows:
       - {kind: go_test, name: TestSQLiteRuntimeStoreListActiveFlowInstanceDescriptorsFiltersToActiveTemplates}
     notes: >
       Descriptor evidence remains limited to identity-style targets and
-      receiver entity fields explicitly declared with indexed: true. It is
-      evidence for ConnectRoutePlan materialization, not topology authority.
-      Arbitrary, undeclared, unindexed, config, and instance business-field
-      descriptor/index authority remains split to #1466 or later gated
-      children.
+      top-level receiver entity fields explicitly declared with indexed: true.
+      It is evidence for ConnectRoutePlan materialization, not topology
+      authority. Nested, arbitrary, undeclared, unindexed, config, and instance
+      business-field descriptor/index authority remains split to #1466 or later
+      gated children.
 
   - id: event_delivery_plan_compatibility_removed
     concept: Legacy eventDeliveryPlan and CanonicalRoutePlan compatibility projection are invalid old authority paths removed behind RoutePlan.

--- a/internal/runtime/conformance/testdata/route_authority_matrix.yaml
+++ b/internal/runtime/conformance/testdata/route_authority_matrix.yaml
@@ -384,7 +384,7 @@ rows:
       - active-agent descriptor lookup
       - active target descriptors
       - handler descriptor lookup
-      - unsupported business-field descriptor targets
+      - unsupported or unindexed business-field descriptor targets
     owner_refs:
       - {kind: spec_ref, path: platform-spec.yaml, ref: descriptor_evidence_boundary}
       - {kind: spec_ref, path: platform-spec.yaml, ref: supported_descriptor_targets}
@@ -395,11 +395,20 @@ rows:
       - {kind: issue, issue: 1479}
       - {kind: issue, issue: 1494}
       - {kind: go_test, name: TestConnectRoutePlanDescriptorsLoadOnlyForRuntimeResolution}
+      - {kind: go_test, name: TestEventBusPublish_ConnectRoutePlanPersistsIndexedBusinessFieldTarget}
+      - {kind: go_test, name: TestEventBusPublish_ConnectRoutePlanPersistsIndexedBusinessFieldTargetSet}
+      - {kind: go_test, name: TestEventBusPublish_ConnectRoutePlanFailsClosedForBusinessFieldDescriptorGaps}
       - {kind: go_test, name: TestEventBusPublish_ConnectRoutePlanFailsClosedForUnsupportedBusinessFieldTarget}
       - {kind: go_test, name: TestEventBusPinRoutingDescriptorsIncludeActiveDynamicFlowInstances}
+      - {kind: go_test, name: TestPostgresStoreListActiveFlowInstanceDescriptorsFiltersToActiveTemplates}
+      - {kind: go_test, name: TestSQLiteRuntimeStoreListActiveFlowInstanceDescriptorsFiltersToActiveTemplates}
     notes: >
-      Descriptor evidence remains limited to supported identity-style targets.
-      Arbitrary business-field descriptor/index support stays split to #1479.
+      Descriptor evidence remains limited to identity-style targets and
+      receiver entity fields explicitly declared with indexed: true. It is
+      evidence for ConnectRoutePlan materialization, not topology authority.
+      Arbitrary, undeclared, unindexed, config, and instance business-field
+      descriptor/index authority remains split to #1466 or later gated
+      children.
 
   - id: event_delivery_plan_compatibility_removed
     concept: Legacy eventDeliveryPlan and CanonicalRoutePlan compatibility projection are invalid old authority paths removed behind RoutePlan.

--- a/internal/runtime/contracts/workflow_contract_semantics.go
+++ b/internal/runtime/contracts/workflow_contract_semantics.go
@@ -204,6 +204,7 @@ func entityContractsToLegacyEntitySchema(entities EntityContractsDocument) Entit
 				Name:        strings.TrimSpace(fieldName),
 				Type:        strings.TrimSpace(field.Type),
 				Initial:     field.Initial,
+				Indexed:     field.Indexed,
 				Description: field.Description,
 			})
 		}

--- a/internal/runtime/contracts/workflow_contract_types.go
+++ b/internal/runtime/contracts/workflow_contract_types.go
@@ -626,6 +626,7 @@ type EntityContract struct {
 type EntityFieldDecl struct {
 	Type               string         `yaml:"type"`
 	Initial            any            `yaml:"initial"`
+	Indexed            bool           `yaml:"indexed"`
 	Immutable          bool           `yaml:"immutable"`
 	Description        string         `yaml:"description"`
 	MaterializeFrom    string         `yaml:"materialize_from"`

--- a/internal/runtime/contracts/workflow_contract_wave1_test.go
+++ b/internal/runtime/contracts/workflow_contract_wave1_test.go
@@ -55,6 +55,7 @@ vertical:
   name: text
   review_count:
     type: integer
+    indexed: true
     initial: 0
 `)
 	writeFixtureFile(t, root+"/flows/scoring/events.yaml", `
@@ -92,6 +93,9 @@ vertical.shortlisted:
 	}
 	if got := entity.Fields["review_count"].Type; got != "integer" {
 		t.Fatalf("review_count type = %q", got)
+	}
+	if !entity.Fields["review_count"].Indexed {
+		t.Fatal("review_count Indexed = false, want true")
 	}
 	resolvedTypes := bundle.ResolvedTypeCatalogForFlow("scoring")
 	if _, ok := resolvedTypes.Scalars["URL"]; !ok {

--- a/internal/runtime/contracts/workflow_contract_yaml_test.go
+++ b/internal/runtime/contracts/workflow_contract_yaml_test.go
@@ -1324,6 +1324,19 @@ project:
 	}
 }
 
+func TestEntityFieldDeclDecode_PreservesIndexed(t *testing.T) {
+	var field EntityFieldDecl
+	if err := yaml.Unmarshal([]byte(`
+type: text
+indexed: true
+`), &field); err != nil {
+		t.Fatalf("yaml.Unmarshal: %v", err)
+	}
+	if !field.Indexed {
+		t.Fatal("Indexed = false, want true")
+	}
+}
+
 func TestEntityFieldDeclDecode_PreservesUnusedReaderReason(t *testing.T) {
 	var field EntityFieldDecl
 	if err := yaml.Unmarshal([]byte(`

--- a/internal/runtime/contracts/workflow_contract_yaml_wave1.go
+++ b/internal/runtime/contracts/workflow_contract_yaml_wave1.go
@@ -493,6 +493,7 @@ func (f *EntityFieldDecl) UnmarshalYAML(node *yaml.Node) error {
 		Context:                 "entity field",
 		AllowInitial:            true,
 		AllowImmutable:          true,
+		AllowIndexed:            true,
 		AllowUnusedReason:       true,
 		AllowUnusedReaderReason: true,
 		AllowMaterializeFrom:    true,
@@ -503,6 +504,7 @@ func (f *EntityFieldDecl) UnmarshalYAML(node *yaml.Node) error {
 	}
 	f.Type = parsed.Type
 	f.Initial = parsed.Initial
+	f.Indexed = parsed.Indexed
 	f.Immutable = parsed.Immutable
 	f.Description = parsed.Description
 	f.MaterializeFrom = parsed.MaterializeFrom
@@ -554,6 +556,9 @@ func decodeWave1FieldNode(node *yaml.Node, opts wave1FieldNodeOptions) (wave1Par
 	if opts.AllowImmutable {
 		allowed["immutable"] = struct{}{}
 	}
+	if opts.AllowIndexed {
+		allowed["indexed"] = struct{}{}
+	}
 	if opts.AllowUnusedReason {
 		allowed["_unused_reason"] = struct{}{}
 	}
@@ -586,7 +591,7 @@ func decodeWave1FieldNode(node *yaml.Node, opts wave1FieldNodeOptions) (wave1Par
 				}
 				listOf = listValue
 				continue
-			case "initial", "immutable", "_unused_reason", "_unused_reader_reason", "materialize_from", "project":
+			case "initial", "immutable", "indexed", "_unused_reason", "_unused_reader_reason", "materialize_from", "project":
 				return wave1ParsedFieldNode{}, fmt.Errorf("UNDEFINED-FIELD: %s field %q not in platform spec", opts.Context, key)
 			default:
 				return wave1ParsedFieldNode{}, fmt.Errorf("UNDEFINED-FIELD: %s field %q not in platform spec", opts.Context, key)
@@ -617,6 +622,12 @@ func decodeWave1FieldNode(node *yaml.Node, opts wave1FieldNodeOptions) (wave1Par
 				return wave1ParsedFieldNode{}, err
 			}
 			field.Immutable = immutable
+		case "indexed":
+			indexed, err := decodeBoolNode(value)
+			if err != nil {
+				return wave1ParsedFieldNode{}, err
+			}
+			field.Indexed = indexed
 		case "_unused_reason":
 			text, err := decodeScalarStringNode(value)
 			if err != nil {
@@ -759,6 +770,7 @@ type wave1FieldNodeOptions struct {
 	Context                 string
 	AllowInitial            bool
 	AllowImmutable          bool
+	AllowIndexed            bool
 	AllowUnusedReason       bool
 	AllowUnusedReaderReason bool
 	AllowMaterializeFrom    bool
@@ -768,6 +780,7 @@ type wave1FieldNodeOptions struct {
 type wave1ParsedFieldNode struct {
 	Type               string
 	Initial            any
+	Indexed            bool
 	Immutable          bool
 	Description        string
 	MaterializeFrom    string

--- a/internal/runtime/core/pinrouting/connect_route_plan.go
+++ b/internal/runtime/core/pinrouting/connect_route_plan.go
@@ -8,6 +8,7 @@ import (
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
 	"github.com/division-sh/swarm/internal/runtime/core/eventidentity"
 	runtimeflowidentity "github.com/division-sh/swarm/internal/runtime/core/flowidentity"
+	"github.com/division-sh/swarm/internal/runtime/entityruntime"
 	"github.com/division-sh/swarm/internal/runtime/semanticview"
 )
 
@@ -91,8 +92,9 @@ type ConnectRoutePlanIssue struct {
 }
 
 type ConnectRoutePlanMaterializationInput struct {
-	MatchValues map[string]string
-	Descriptors []Descriptor
+	MatchValues             map[string]string
+	Descriptors             []Descriptor
+	SupportedAddressTargets []string
 }
 
 type ConnectRoutePlanMaterialization struct {
@@ -229,7 +231,7 @@ func MaterializeConnectRoutePlan(plan ConnectRoutePlan, input ConnectRoutePlanMa
 	if targetExpr == "" {
 		return ConnectRoutePlanMaterialization{Failure: ConnectFailureTargetUnsupported}
 	}
-	routes, supported := materializeConnectRoutes(plan, targetExpr, value, input.Descriptors)
+	routes, supported := materializeConnectRoutes(plan, targetExpr, value, input.Descriptors, input.SupportedAddressTargets)
 	if !supported {
 		return ConnectRoutePlanMaterialization{Failure: ConnectFailureTargetUnsupported}
 	}
@@ -406,8 +408,8 @@ func connectAddressValue(plan ConnectRoutePlan, values map[string]string) string
 	return ""
 }
 
-func materializeConnectRoutes(plan ConnectRoutePlan, targetExpr, value string, descriptors []Descriptor) ([]events.RouteIdentity, bool) {
-	if !addressTargetSupported(targetExpr) {
+func materializeConnectRoutes(plan ConnectRoutePlan, targetExpr, value string, descriptors []Descriptor, supportedTargets []string) ([]events.RouteIdentity, bool) {
+	if !addressTargetSupported(targetExpr, supportedTargets) {
 		return nil, false
 	}
 	var routes []events.RouteIdentity
@@ -435,7 +437,8 @@ func connectDescriptorMatches(targetExpr, value string, descriptor Descriptor, r
 	case "instance_id":
 		return strings.TrimSpace(descriptor.ID) == value || runtimeflowidentity.LogicalInstanceID(route.FlowInstance) == value
 	default:
-		return false
+		fieldValue, ok := descriptor.AddressFields[normalizeAddressTargetKey(targetExpr)]
+		return ok && strings.Trim(strings.TrimSpace(fieldValue), "/") == value
 	}
 }
 
@@ -458,11 +461,17 @@ func descriptorBelongsToReceiver(plan ConnectRoutePlan, descriptor Descriptor) b
 	return receiverPath != "" && (flowInstance == receiverPath || strings.HasPrefix(flowInstance, receiverPath+"/"))
 }
 
-func addressTargetSupported(expr string) bool {
+func addressTargetSupported(expr string, supportedTargets []string) bool {
 	switch normalizeAddressTarget(expr) {
 	case "entity_id", "flow_instance", "instance_id":
 		return true
 	default:
+		needle := normalizeAddressTargetKey(expr)
+		for _, supported := range supportedTargets {
+			if normalizeAddressTargetKey(supported) == needle {
+				return true
+			}
+		}
 		return false
 	}
 }
@@ -475,6 +484,59 @@ func normalizeAddressTarget(expr string) string {
 		}
 	}
 	return expr
+}
+
+func normalizeAddressTargetKey(expr string) string {
+	expr = strings.TrimSpace(expr)
+	if expr == "" {
+		return ""
+	}
+	if strings.HasPrefix(expr, "entity.") {
+		return "entity." + strings.TrimSpace(strings.TrimPrefix(expr, "entity."))
+	}
+	if strings.HasPrefix(expr, "config.") {
+		return "config." + strings.TrimSpace(strings.TrimPrefix(expr, "config."))
+	}
+	if strings.HasPrefix(expr, "instance.") {
+		return "instance." + strings.TrimSpace(strings.TrimPrefix(expr, "instance."))
+	}
+	switch normalizeAddressTarget(expr) {
+	case "entity_id":
+		return "entity.entity_id"
+	case "flow_instance":
+		return "instance.flow_instance"
+	case "instance_id":
+		return "instance.instance_id"
+	default:
+		return expr
+	}
+}
+
+func SupportedConnectAddressTargets(source semanticview.Source, plan ConnectRoutePlan) []string {
+	if plan.Address == nil {
+		return nil
+	}
+	target := normalizeAddressTargetKey(plan.Address.Target)
+	if target == "" {
+		return nil
+	}
+	switch normalizeAddressTarget(target) {
+	case "entity_id", "flow_instance", "instance_id":
+		return nil
+	}
+	fieldPath, ok := strings.CutPrefix(target, "entity.")
+	if !ok || strings.TrimSpace(fieldPath) == "" {
+		return nil
+	}
+	contract, ok := entityruntime.ResolveForFlow(source, plan.Receiver.FlowID)
+	if !ok {
+		return nil
+	}
+	field, err := entityruntime.ResolveLeafField(contract, fieldPath)
+	if err != nil || !field.FieldDecl.Indexed {
+		return nil
+	}
+	return []string{target}
 }
 
 func expressionLeaf(expr string) string {

--- a/internal/runtime/core/pinrouting/connect_route_plan.go
+++ b/internal/runtime/core/pinrouting/connect_route_plan.go
@@ -525,7 +525,8 @@ func SupportedConnectAddressTargets(source semanticview.Source, plan ConnectRout
 		return nil
 	}
 	fieldPath, ok := strings.CutPrefix(target, "entity.")
-	if !ok || strings.TrimSpace(fieldPath) == "" {
+	fieldPath = strings.TrimSpace(fieldPath)
+	if !ok || fieldPath == "" || strings.Contains(fieldPath, ".") {
 		return nil
 	}
 	contract, ok := entityruntime.ResolveForFlow(source, plan.Receiver.FlowID)

--- a/internal/runtime/core/pinrouting/pinrouting.go
+++ b/internal/runtime/core/pinrouting/pinrouting.go
@@ -34,9 +34,10 @@ type AuthoredTarget struct {
 }
 
 type Descriptor struct {
-	ID           string
-	EntityID     string
-	FlowInstance string
+	ID            string
+	EntityID      string
+	FlowInstance  string
+	AddressFields map[string]string
 }
 
 type ResolutionInput struct {

--- a/internal/store/flow_instance_descriptors_sqlite_test.go
+++ b/internal/store/flow_instance_descriptors_sqlite_test.go
@@ -33,7 +33,7 @@ func TestSQLiteRuntimeStoreListActiveFlowInstanceDescriptorsFiltersToActiveTempl
 	if _, err := sqliteStore.DB.ExecContext(ctx, `
 		INSERT INTO entity_state (entity_id, run_id, flow_instance, entity_type, current_state, fields, created_at, updated_at)
 		VALUES
-			('22222222-2222-4222-8222-222222222222', ?, 'component-scaffold/active', 'component', 'ready', '{"vertical_id":"v-active"}', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+			('22222222-2222-4222-8222-222222222222', ?, 'component-scaffold/active', 'component', 'ready', '{"vertical_id":"v-active","weight":1.1234567}', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
 			('33333333-3333-4333-8333-333333333333', '44444444-4444-4444-8444-444444444444', 'component-scaffold/active', 'component', 'ready', '{"vertical_id":"wrong-run"}', datetime('now', '+1 minute'), datetime('now', '+1 minute'))
 	`, runID); err != nil {
 		t.Fatalf("seed entity_state: %v", err)
@@ -61,6 +61,44 @@ func TestSQLiteRuntimeStoreListActiveFlowInstanceDescriptorsFiltersToActiveTempl
 	}
 	if got.AddressFields["entity.vertical_id"] != "v-active" {
 		t.Fatalf("AddressFields[entity.vertical_id] = %q, want v-active", got.AddressFields["entity.vertical_id"])
+	}
+	if got.AddressFields["entity.weight"] != "1.1234567" {
+		t.Fatalf("AddressFields[entity.weight] = %q, want 1.1234567", got.AddressFields["entity.weight"])
+	}
+}
+
+func TestSQLiteRuntimeStoreListActiveFlowInstanceDescriptorsOmitsAddressFieldsWithoutRunScope(t *testing.T) {
+	ctx := context.Background()
+	sqliteStore := storetest.StartSQLiteRuntimeStoreWithContext(t, ctx)
+
+	if _, err := sqliteStore.DB.ExecContext(ctx, `
+		INSERT INTO flow_instances (instance_id, flow_template, mode, config, status, created_at)
+		VALUES ('component-scaffold/active', 'component-scaffold', 'template', '{}', 'active', CURRENT_TIMESTAMP)
+	`); err != nil {
+		t.Fatalf("seed flow_instances: %v", err)
+	}
+	if _, err := sqliteStore.DB.ExecContext(ctx, `
+		INSERT INTO runs (run_id, status)
+		VALUES ('44444444-4444-4444-8444-444444444444', 'running')
+	`); err != nil {
+		t.Fatalf("seed runs: %v", err)
+	}
+	if _, err := sqliteStore.DB.ExecContext(ctx, `
+		INSERT INTO entity_state (entity_id, run_id, flow_instance, entity_type, current_state, fields, created_at, updated_at)
+		VALUES ('33333333-3333-4333-8333-333333333333', '44444444-4444-4444-8444-444444444444', 'component-scaffold/active', 'component', 'ready', '{"vertical_id":"wrong-run"}', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+	`); err != nil {
+		t.Fatalf("seed entity_state: %v", err)
+	}
+
+	descriptors, err := sqliteStore.ListActiveFlowInstanceDescriptors(ctx)
+	if err != nil {
+		t.Fatalf("ListActiveFlowInstanceDescriptors: %v", err)
+	}
+	if len(descriptors) != 1 {
+		t.Fatalf("descriptors = %#v, want exactly active template descriptor", descriptors)
+	}
+	if len(descriptors[0].AddressFields) != 0 {
+		t.Fatalf("AddressFields = %#v, want no run-scoped descriptor evidence without run_id", descriptors[0].AddressFields)
 	}
 }
 

--- a/internal/store/flow_instance_descriptors_sqlite_test.go
+++ b/internal/store/flow_instance_descriptors_sqlite_test.go
@@ -5,12 +5,14 @@ import (
 	"testing"
 
 	runtimeflowidentity "github.com/division-sh/swarm/internal/runtime/core/flowidentity"
+	runtimecorrelation "github.com/division-sh/swarm/internal/runtime/correlation"
 	runtimepipeline "github.com/division-sh/swarm/internal/runtime/pipeline"
 	"github.com/division-sh/swarm/internal/store/storetest"
 )
 
 func TestSQLiteRuntimeStoreListActiveFlowInstanceDescriptorsFiltersToActiveTemplates(t *testing.T) {
-	ctx := context.Background()
+	const runID = "11111111-1111-4111-8111-111111111111"
+	ctx := runtimecorrelation.WithRunID(context.Background(), runID)
 	sqliteStore := storetest.StartSQLiteRuntimeStoreWithContext(t, ctx)
 
 	if _, err := sqliteStore.DB.ExecContext(ctx, `
@@ -21,6 +23,20 @@ func TestSQLiteRuntimeStoreListActiveFlowInstanceDescriptorsFiltersToActiveTempl
 			('service-owner', 'service-owner', 'static', '{}', 'active', CURRENT_TIMESTAMP)
 	`); err != nil {
 		t.Fatalf("seed flow_instances: %v", err)
+	}
+	if _, err := sqliteStore.DB.ExecContext(ctx, `
+		INSERT INTO runs (run_id, status)
+		VALUES (?, 'running'), ('44444444-4444-4444-8444-444444444444', 'running')
+	`, runID); err != nil {
+		t.Fatalf("seed runs: %v", err)
+	}
+	if _, err := sqliteStore.DB.ExecContext(ctx, `
+		INSERT INTO entity_state (entity_id, run_id, flow_instance, entity_type, current_state, fields, created_at, updated_at)
+		VALUES
+			('22222222-2222-4222-8222-222222222222', ?, 'component-scaffold/active', 'component', 'ready', '{"vertical_id":"v-active"}', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+			('33333333-3333-4333-8333-333333333333', '44444444-4444-4444-8444-444444444444', 'component-scaffold/active', 'component', 'ready', '{"vertical_id":"wrong-run"}', datetime('now', '+1 minute'), datetime('now', '+1 minute'))
+	`, runID); err != nil {
+		t.Fatalf("seed entity_state: %v", err)
 	}
 
 	descriptors, err := sqliteStore.ListActiveFlowInstanceDescriptors(ctx)
@@ -42,6 +58,9 @@ func TestSQLiteRuntimeStoreListActiveFlowInstanceDescriptorsFiltersToActiveTempl
 	}
 	if got.FlowTemplate != "component-scaffold" {
 		t.Fatalf("FlowTemplate = %q, want component-scaffold", got.FlowTemplate)
+	}
+	if got.AddressFields["entity.vertical_id"] != "v-active" {
+		t.Fatalf("AddressFields[entity.vertical_id] = %q, want v-active", got.AddressFields["entity.vertical_id"])
 	}
 }
 

--- a/internal/store/flow_instance_routes.go
+++ b/internal/store/flow_instance_routes.go
@@ -3,12 +3,14 @@ package store
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
 
 	runtimebus "github.com/division-sh/swarm/internal/runtime/bus"
 	runtimeflowidentity "github.com/division-sh/swarm/internal/runtime/core/flowidentity"
+	runtimecurrentstate "github.com/division-sh/swarm/internal/runtime/currentstate"
 	runtimepipeline "github.com/division-sh/swarm/internal/runtime/pipeline"
 )
 
@@ -191,16 +193,36 @@ func (s *PostgresStore) ListActiveFlowInstanceDescriptors(ctx context.Context) (
 	if tx, ok := runtimepipeline.PipelineSQLTxFromContext(ctx); ok && tx != nil {
 		q = tx
 	}
-	rows, err := q.QueryContext(ctx, `
+	runID, hasRunID, err := activeFlowInstanceDescriptorRunID(ctx)
+	if err != nil {
+		return nil, err
+	}
+	query := `
 		SELECT
-			COALESCE(instance_id, ''),
-			COALESCE(flow_template, '')
-		FROM flow_instances
-		WHERE COALESCE(status, '') = 'active'
-		  AND COALESCE(mode, '') = 'template'
-		  AND COALESCE(instance_id, '') <> ''
-		ORDER BY instance_id ASC
-	`)
+			COALESCE(fi.instance_id, ''),
+			COALESCE(fi.flow_template, ''),
+			COALESCE(es.fields, '{}'::jsonb)
+		FROM flow_instances fi
+		LEFT JOIN LATERAL (
+			SELECT fields
+			FROM entity_state es
+			WHERE es.flow_instance = fi.instance_id
+`
+	args := []any{}
+	if hasRunID {
+		query += `			  AND es.run_id = $1::uuid
+`
+		args = append(args, runID)
+	}
+	query += `			ORDER BY es.updated_at DESC, es.created_at DESC, es.entity_id::text ASC
+			LIMIT 1
+		) es ON true
+		WHERE COALESCE(fi.status, '') = 'active'
+		  AND COALESCE(fi.mode, '') = 'template'
+		  AND COALESCE(fi.instance_id, '') <> ''
+		ORDER BY fi.instance_id ASC
+	`
+	rows, err := q.QueryContext(ctx, query, args...)
 	if err != nil {
 		return nil, fmt.Errorf("list active flow instance descriptors: %w", err)
 	}
@@ -209,9 +231,11 @@ func (s *PostgresStore) ListActiveFlowInstanceDescriptors(ctx context.Context) (
 	out := []runtimebus.ActiveFlowInstanceDescriptor{}
 	for rows.Next() {
 		var descriptor runtimebus.ActiveFlowInstanceDescriptor
-		if err := rows.Scan(&descriptor.FlowInstance, &descriptor.FlowTemplate); err != nil {
+		var fieldsRaw any
+		if err := rows.Scan(&descriptor.FlowInstance, &descriptor.FlowTemplate, &fieldsRaw); err != nil {
 			return nil, fmt.Errorf("scan active flow instance descriptor: %w", err)
 		}
+		descriptor.AddressFields = descriptorAddressFields(fieldsRaw)
 		descriptor = descriptor.Normalized()
 		if descriptor.FlowInstance == "" {
 			continue
@@ -232,16 +256,35 @@ func (s *SQLiteRuntimeStore) ListActiveFlowInstanceDescriptors(ctx context.Conte
 	if tx, ok := runtimepipeline.PipelineSQLTxFromContext(ctx); ok && tx != nil {
 		q = tx
 	}
+	runID, hasRunID, err := activeFlowInstanceDescriptorRunID(ctx)
+	if err != nil {
+		return nil, err
+	}
+	fieldsSubquery := `
+			SELECT es.fields
+			FROM entity_state es
+			WHERE es.flow_instance = fi.instance_id
+`
+	args := []any{}
+	if hasRunID {
+		fieldsSubquery += `			  AND es.run_id = ?
+`
+		args = append(args, runID)
+	}
+	fieldsSubquery += `			ORDER BY es.updated_at DESC, es.created_at DESC, es.entity_id ASC
+			LIMIT 1
+`
 	rows, err := q.QueryContext(ctx, `
 		SELECT
-			COALESCE(instance_id, ''),
-			COALESCE(flow_template, '')
-		FROM flow_instances
-		WHERE COALESCE(status, '') = 'active'
-		  AND COALESCE(mode, '') = 'template'
-		  AND COALESCE(instance_id, '') <> ''
-		ORDER BY instance_id ASC
-	`)
+			COALESCE(fi.instance_id, ''),
+			COALESCE(fi.flow_template, ''),
+			COALESCE((`+fieldsSubquery+`), '{}')
+		FROM flow_instances fi
+		WHERE COALESCE(fi.status, '') = 'active'
+		  AND COALESCE(fi.mode, '') = 'template'
+		  AND COALESCE(fi.instance_id, '') <> ''
+		ORDER BY fi.instance_id ASC
+	`, args...)
 	if err != nil {
 		return nil, fmt.Errorf("list sqlite active flow instance descriptors: %w", err)
 	}
@@ -250,9 +293,11 @@ func (s *SQLiteRuntimeStore) ListActiveFlowInstanceDescriptors(ctx context.Conte
 	out := []runtimebus.ActiveFlowInstanceDescriptor{}
 	for rows.Next() {
 		var descriptor runtimebus.ActiveFlowInstanceDescriptor
-		if err := rows.Scan(&descriptor.FlowInstance, &descriptor.FlowTemplate); err != nil {
+		var fieldsRaw any
+		if err := rows.Scan(&descriptor.FlowInstance, &descriptor.FlowTemplate, &fieldsRaw); err != nil {
 			return nil, fmt.Errorf("scan sqlite active flow instance descriptor: %w", err)
 		}
+		descriptor.AddressFields = descriptorAddressFields(fieldsRaw)
 		descriptor = descriptor.Normalized()
 		if descriptor.FlowInstance == "" {
 			continue
@@ -263,4 +308,72 @@ func (s *SQLiteRuntimeStore) ListActiveFlowInstanceDescriptors(ctx context.Conte
 		return nil, fmt.Errorf("iterate sqlite active flow instance descriptors: %w", err)
 	}
 	return out, nil
+}
+
+func activeFlowInstanceDescriptorRunID(ctx context.Context) (string, bool, error) {
+	runID, ok, err := runtimecurrentstate.RunIDFromContext(ctx)
+	if err != nil {
+		return "", false, fmt.Errorf("active flow instance descriptor run scope: %w", err)
+	}
+	return runID, ok, nil
+}
+
+func descriptorAddressFields(fieldsRaw any) map[string]string {
+	return descriptorAddressFieldsFromJSON(fieldsRaw, "entity.")
+}
+
+func descriptorAddressFieldsFromJSON(raw any, prefix string) map[string]string {
+	values, err := decodeDescriptorJSONMap(raw)
+	if err != nil || len(values) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(values))
+	for key, value := range values {
+		key = strings.TrimSpace(key)
+		if key == "" {
+			continue
+		}
+		scalar, ok := descriptorScalarString(value)
+		if !ok || scalar == "" {
+			continue
+		}
+		out[prefix+key] = scalar
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+func decodeDescriptorJSONMap(raw any) (map[string]any, error) {
+	data := jsonRawMessageValue(raw)
+	if len(data) == 0 || strings.TrimSpace(string(data)) == "" || strings.TrimSpace(string(data)) == "null" {
+		return map[string]any{}, nil
+	}
+	var out map[string]any
+	if err := json.Unmarshal(data, &out); err != nil {
+		return nil, err
+	}
+	if out == nil {
+		return map[string]any{}, nil
+	}
+	return out, nil
+}
+
+func descriptorScalarString(value any) (string, bool) {
+	switch typed := value.(type) {
+	case string:
+		return strings.TrimSpace(typed), true
+	case bool:
+		if typed {
+			return "true", true
+		}
+		return "false", true
+	case float64:
+		return strings.TrimRight(strings.TrimRight(fmt.Sprintf("%f", typed), "0"), "."), true
+	case json.Number:
+		return typed.String(), true
+	default:
+		return "", false
+	}
 }

--- a/internal/store/flow_instance_routes.go
+++ b/internal/store/flow_instance_routes.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strconv"
 	"strings"
 
 	runtimebus "github.com/division-sh/swarm/internal/runtime/bus"
@@ -201,23 +202,28 @@ func (s *PostgresStore) ListActiveFlowInstanceDescriptors(ctx context.Context) (
 		SELECT
 			COALESCE(fi.instance_id, ''),
 			COALESCE(fi.flow_template, ''),
-			COALESCE(es.fields, '{}'::jsonb)
+`
+	args := []any{}
+	if hasRunID {
+		query += `			COALESCE(es.fields, '{}'::jsonb)
 		FROM flow_instances fi
 		LEFT JOIN LATERAL (
 			SELECT fields
 			FROM entity_state es
 			WHERE es.flow_instance = fi.instance_id
-`
-	args := []any{}
-	if hasRunID {
-		query += `			  AND es.run_id = $1::uuid
+			  AND es.run_id = $1::uuid
 `
 		args = append(args, runID)
-	}
-	query += `			ORDER BY es.updated_at DESC, es.created_at DESC, es.entity_id::text ASC
+		query += `			ORDER BY es.updated_at DESC, es.created_at DESC, es.entity_id::text ASC
 			LIMIT 1
 		) es ON true
-		WHERE COALESCE(fi.status, '') = 'active'
+`
+	} else {
+		query += `			'{}'::jsonb
+		FROM flow_instances fi
+`
+	}
+	query += `		WHERE COALESCE(fi.status, '') = 'active'
 		  AND COALESCE(fi.mode, '') = 'template'
 		  AND COALESCE(fi.instance_id, '') <> ''
 		ORDER BY fi.instance_id ASC
@@ -260,25 +266,26 @@ func (s *SQLiteRuntimeStore) ListActiveFlowInstanceDescriptors(ctx context.Conte
 	if err != nil {
 		return nil, err
 	}
-	fieldsSubquery := `
+	args := []any{}
+	fieldsExpr := `'{}'`
+	if hasRunID {
+		fieldsSubquery := `
 			SELECT es.fields
 			FROM entity_state es
 			WHERE es.flow_instance = fi.instance_id
-`
-	args := []any{}
-	if hasRunID {
-		fieldsSubquery += `			  AND es.run_id = ?
+			  AND es.run_id = ?
 `
 		args = append(args, runID)
-	}
-	fieldsSubquery += `			ORDER BY es.updated_at DESC, es.created_at DESC, es.entity_id ASC
+		fieldsSubquery += `			ORDER BY es.updated_at DESC, es.created_at DESC, es.entity_id ASC
 			LIMIT 1
 `
+		fieldsExpr = `COALESCE((` + fieldsSubquery + `), '{}')`
+	}
 	rows, err := q.QueryContext(ctx, `
 		SELECT
 			COALESCE(fi.instance_id, ''),
 			COALESCE(fi.flow_template, ''),
-			COALESCE((`+fieldsSubquery+`), '{}')
+			`+fieldsExpr+`
 		FROM flow_instances fi
 		WHERE COALESCE(fi.status, '') = 'active'
 		  AND COALESCE(fi.mode, '') = 'template'
@@ -370,7 +377,7 @@ func descriptorScalarString(value any) (string, bool) {
 		}
 		return "false", true
 	case float64:
-		return strings.TrimRight(strings.TrimRight(fmt.Sprintf("%f", typed), "0"), "."), true
+		return strconv.FormatFloat(typed, 'g', -1, 64), true
 	case json.Number:
 		return typed.String(), true
 	default:

--- a/internal/store/flow_instance_routes_test.go
+++ b/internal/store/flow_instance_routes_test.go
@@ -9,6 +9,7 @@ import (
 
 	runtimebus "github.com/division-sh/swarm/internal/runtime/bus"
 	runtimeflowidentity "github.com/division-sh/swarm/internal/runtime/core/flowidentity"
+	runtimecorrelation "github.com/division-sh/swarm/internal/runtime/correlation"
 	runtimepipeline "github.com/division-sh/swarm/internal/runtime/pipeline"
 	"github.com/division-sh/swarm/internal/testutil"
 )
@@ -27,6 +28,20 @@ func ensureFlowInstanceRouteTables(t *testing.T, ctx context.Context, db *sql.DB
 		)
 	`); err != nil {
 		t.Fatalf("ensure flow_instances table: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		CREATE TABLE IF NOT EXISTS entity_state (
+			entity_id UUID PRIMARY KEY,
+			run_id UUID NOT NULL,
+			flow_instance TEXT NOT NULL,
+			entity_type TEXT NOT NULL DEFAULT '',
+			current_state TEXT NOT NULL DEFAULT '',
+			fields JSONB NOT NULL DEFAULT '{}'::jsonb,
+			created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+			updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+		)
+	`); err != nil {
+		t.Fatalf("ensure entity_state table: %v", err)
 	}
 	if _, err := db.ExecContext(ctx, `
 		CREATE TABLE IF NOT EXISTS routing_rules (
@@ -296,7 +311,8 @@ func TestPostgresStoreListFlowInstanceRoutesFiltersTerminatedInstances(t *testin
 }
 
 func TestPostgresStoreListActiveFlowInstanceDescriptorsFiltersToActiveTemplates(t *testing.T) {
-	ctx := context.Background()
+	const runID = "11111111-1111-4111-8111-111111111111"
+	ctx := runtimecorrelation.WithRunID(context.Background(), runID)
 	_, db, _ := testutil.StartPostgres(t)
 	pg := &PostgresStore{DB: db}
 	ensureFlowInstanceRouteTables(t, ctx, db)
@@ -309,6 +325,20 @@ func TestPostgresStoreListActiveFlowInstanceDescriptorsFiltersToActiveTemplates(
 			('service-owner', 'service-owner', 'static', '{}'::jsonb, 'active', NOW())
 	`); err != nil {
 		t.Fatalf("seed flow_instances: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO runs (run_id, status)
+		VALUES ($1::uuid, 'running'), ('44444444-4444-4444-8444-444444444444'::uuid, 'running')
+	`, runID); err != nil {
+		t.Fatalf("seed runs: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO entity_state (entity_id, run_id, flow_instance, entity_type, current_state, fields, created_at, updated_at)
+		VALUES
+			('22222222-2222-4222-8222-222222222222', $1::uuid, 'component-scaffold/active', 'component', 'ready', '{"vertical_id":"v-active"}'::jsonb, NOW(), NOW()),
+			('33333333-3333-4333-8333-333333333333', '44444444-4444-4444-8444-444444444444'::uuid, 'component-scaffold/active', 'component', 'ready', '{"vertical_id":"wrong-run"}'::jsonb, NOW() + INTERVAL '1 minute', NOW() + INTERVAL '1 minute')
+	`, runID); err != nil {
+		t.Fatalf("seed entity_state: %v", err)
 	}
 
 	descriptors, err := pg.ListActiveFlowInstanceDescriptors(ctx)
@@ -330,6 +360,9 @@ func TestPostgresStoreListActiveFlowInstanceDescriptorsFiltersToActiveTemplates(
 	}
 	if got.FlowTemplate != "component-scaffold" {
 		t.Fatalf("FlowTemplate = %q, want component-scaffold", got.FlowTemplate)
+	}
+	if got.AddressFields["entity.vertical_id"] != "v-active" {
+		t.Fatalf("AddressFields[entity.vertical_id] = %q, want v-active", got.AddressFields["entity.vertical_id"])
 	}
 }
 

--- a/internal/store/flow_instance_routes_test.go
+++ b/internal/store/flow_instance_routes_test.go
@@ -335,7 +335,7 @@ func TestPostgresStoreListActiveFlowInstanceDescriptorsFiltersToActiveTemplates(
 	if _, err := db.ExecContext(ctx, `
 		INSERT INTO entity_state (entity_id, run_id, flow_instance, entity_type, current_state, fields, created_at, updated_at)
 		VALUES
-			('22222222-2222-4222-8222-222222222222', $1::uuid, 'component-scaffold/active', 'component', 'ready', '{"vertical_id":"v-active"}'::jsonb, NOW(), NOW()),
+			('22222222-2222-4222-8222-222222222222', $1::uuid, 'component-scaffold/active', 'component', 'ready', '{"vertical_id":"v-active","weight":1.1234567}'::jsonb, NOW(), NOW()),
 			('33333333-3333-4333-8333-333333333333', '44444444-4444-4444-8444-444444444444'::uuid, 'component-scaffold/active', 'component', 'ready', '{"vertical_id":"wrong-run"}'::jsonb, NOW() + INTERVAL '1 minute', NOW() + INTERVAL '1 minute')
 	`, runID); err != nil {
 		t.Fatalf("seed entity_state: %v", err)
@@ -363,6 +363,46 @@ func TestPostgresStoreListActiveFlowInstanceDescriptorsFiltersToActiveTemplates(
 	}
 	if got.AddressFields["entity.vertical_id"] != "v-active" {
 		t.Fatalf("AddressFields[entity.vertical_id] = %q, want v-active", got.AddressFields["entity.vertical_id"])
+	}
+	if got.AddressFields["entity.weight"] != "1.1234567" {
+		t.Fatalf("AddressFields[entity.weight] = %q, want 1.1234567", got.AddressFields["entity.weight"])
+	}
+}
+
+func TestPostgresStoreListActiveFlowInstanceDescriptorsOmitsAddressFieldsWithoutRunScope(t *testing.T) {
+	ctx := context.Background()
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &PostgresStore{DB: db}
+	ensureFlowInstanceRouteTables(t, ctx, db)
+
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO flow_instances (instance_id, flow_template, mode, config, status, created_at)
+		VALUES ('component-scaffold/active', 'component-scaffold', 'template', '{}'::jsonb, 'active', NOW())
+	`); err != nil {
+		t.Fatalf("seed flow_instances: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO runs (run_id, status)
+		VALUES ('44444444-4444-4444-8444-444444444444'::uuid, 'running')
+	`); err != nil {
+		t.Fatalf("seed runs: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO entity_state (entity_id, run_id, flow_instance, entity_type, current_state, fields, created_at, updated_at)
+		VALUES ('33333333-3333-4333-8333-333333333333', '44444444-4444-4444-8444-444444444444'::uuid, 'component-scaffold/active', 'component', 'ready', '{"vertical_id":"wrong-run"}'::jsonb, NOW(), NOW())
+	`); err != nil {
+		t.Fatalf("seed entity_state: %v", err)
+	}
+
+	descriptors, err := pg.ListActiveFlowInstanceDescriptors(ctx)
+	if err != nil {
+		t.Fatalf("ListActiveFlowInstanceDescriptors: %v", err)
+	}
+	if len(descriptors) != 1 {
+		t.Fatalf("descriptors = %#v, want exactly active template descriptor", descriptors)
+	}
+	if len(descriptors[0].AddressFields) != 0 {
+		t.Fatalf("AddressFields = %#v, want no run-scoped descriptor evidence without run_id", descriptors[0].AddressFields)
 	}
 }
 

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -628,7 +628,7 @@ contract_formats:
               Static lowered ConnectRoutePlan matches MUST NOT load or depend on
               legacy active-agent recipient-policy descriptors. Runtime
               descriptor evidence may materialize identity-style targets and
-              declared receiver entity fields marked `indexed: true`. Descriptor
+              declared top-level receiver entity fields marked `indexed: true`. Descriptor
               evidence MUST NOT promote unsupported arbitrary business fields,
               unindexed entity fields, config fields, instance fields, delivery
               rows, receipts, replay/readback, RouteTable state, live
@@ -663,7 +663,7 @@ contract_formats:
           - reply delivery metadata preservation
           - persisted delivery rows, pipeline receipts, and committed replay scope as separate owners
           unsupported_or_split:
-            business_field_descriptor_targets: 'Declared receiver entity fields with indexed: true are implemented by #1479; arbitrary, undeclared, unindexed, config, and instance business-field descriptor targets remain split to #1466 or later gated children.'
+            business_field_descriptor_targets: 'Declared top-level receiver entity fields with indexed: true are implemented by #1479; nested entity paths, arbitrary, undeclared, unindexed, config, and instance business-field descriptor targets remain split to #1466 or later gated children.'
             agent_node_emitter_parity: '#1474 remains open.'
             producer_target_broadcast_retirement: '#1475 remains open.'
             selected_contract_runfork_readiness: 'Tracked under #1466/watchlist; not closed by #1473.'
@@ -1077,22 +1077,24 @@ entity_contracts:
     - '`_unused_reader_reason` documents that a field is intentionally read only outside platform-visible internal handlers.
       It suppresses only the informational `entity_reader_coverage` slice; it does not count as writer coverage, authorize
       runtime/API reads, or change persistence semantics.'
-    - '`indexed: true` declares a field as addressable descriptor/index evidence for supported runtime receiver selection.
+    - '`indexed: true` declares a top-level entity field as addressable descriptor/index evidence for supported runtime receiver selection.
       It does not make the field route topology authority, dynamically index arbitrary payload fields, or authorize
-      undeclared business-field routing.'
+      undeclared or nested business-field routing.'
     - 'A `materialize_from` field is runtime-owned and not agent-writable.'
   routing_indexes:
     status: merge_bearing_runtime_behavior
     implementation_slice: '#1479'
     rule: |
-      A receiver entity field with `indexed: true` may be used as descriptor
+      A top-level receiver entity field with `indexed: true` may be used as descriptor
       evidence for a composition-routing addressed input target such as
       `entity.vertical_id`. The receiver input pin and parent connect entry
       still own the route topology. The indexed entity field only authorizes
       runtime descriptor/index materialization to answer which active receiver
-      instance has the declared field value. Missing, unindexed, undeclared,
-      ambiguous, unsupported, or wrong-scope targets fail closed and produce no
-      executable routes.
+      instance has the declared top-level field value. Nested entity paths such
+      as `entity.profile.vertical_id` are unsupported in the #1479 slice because
+      runtime descriptor evidence is emitted only for top-level scalar entity
+      fields. Missing, unindexed, undeclared, nested, ambiguous, unsupported, or
+      wrong-scope targets fail closed and produce no executable routes.
   accumulator_entity_projection:
     description: |
       `materialize_from` declares a downstream typed entity-field copy of a
@@ -5012,8 +5014,8 @@ flow_model:
             - entity_id / entity.entity_id
             - flow_instance / instance.flow_instance
             - instance_id / instance.instance_id
-            - entity.<field> when the receiver entity contract declares that field with indexed: true
-            unsupported_descriptor_targets: Undeclared or unindexed entity fields, config.<field>, instance.<field>, and other arbitrary business fields remain fail-closed unless a later approved spec+runtime child promotes a typed descriptor/index owner for those forms.
+            - entity.<field> when the receiver entity contract declares that top-level field with indexed: true
+            unsupported_descriptor_targets: Nested entity paths, undeclared or unindexed entity fields, config.<field>, instance.<field>, and other arbitrary business fields remain fail-closed unless a later approved spec+runtime child promotes a typed descriptor/index owner for those forms.
           failure_reasons:
           - source_missing
           - connect_pin_ref_invalid
@@ -5117,8 +5119,9 @@ flow_model:
           rule: |
             Supported receiver business-field descriptor/index materialization is
             limited to addressed input targets whose receiver entity contract
-            declares the target field with `indexed: true`. Bootverify MUST
-            reject unsupported or unindexed non-identity targets before runtime.
+            declares the top-level target field with `indexed: true`.
+            Bootverify MUST reject unsupported, nested, or unindexed
+            non-identity targets before runtime.
             Runtime planning MUST pass the supported target list from the
             loaded semantic source into `MaterializeConnectRoutePlan`; the
             materializer MUST compare event source values only with descriptor
@@ -5128,12 +5131,12 @@ flow_model:
             cardinality produces exactly one concrete target route; cardinality
             many produces a target_set/fanout over all matching receiver-scope descriptors.
             Missing source values, no matches, ambiguous cardinality-one
-            matches, unsupported/unindexed targets, and wrong receiver scope
-            fail closed with zero executable routes.
+            matches, unsupported/unindexed/nested targets, and wrong receiver
+            scope fail closed with zero executable routes.
           consumes:
           - receiver addressed input pin address.target
           - parent connect map target expression
-          - receiver entity contract field indexed: true
+          - receiver entity contract top-level field indexed: true
           - active flow-instance descriptor address fields loaded from current run entity_state
           - lowered ConnectRoutePlan runtime-resolution requirements
           produces:
@@ -5142,6 +5145,7 @@ flow_model:
           - fail-closed target diagnostics for unsupported, missing, unresolved, ambiguous, or wrong-scope descriptor evidence
           does_not_close:
           - arbitrary config.<field> or instance.<field> descriptor/index authority
+          - nested entity path descriptor/index authority
           - dynamic indexing of arbitrary payload/entity fields
           - select_entity/select_or_create_entity receiver-local mutation semantics
           - selected-contract runfork route/readiness mutation

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -5122,9 +5122,11 @@ flow_model:
             Runtime planning MUST pass the supported target list from the
             loaded semantic source into `MaterializeConnectRoutePlan`; the
             materializer MUST compare event source values only with descriptor
-            evidence for those supported targets. Singular cardinality produces
-            exactly one concrete target route; cardinality many produces a
-            target_set/fanout over all matching receiver-scope descriptors.
+            evidence for those supported targets. Runtime descriptor loaders
+            MUST omit run-scoped entity address fields when no run id is
+            available rather than selecting entity state across runs. Singular
+            cardinality produces exactly one concrete target route; cardinality
+            many produces a target_set/fanout over all matching receiver-scope descriptors.
             Missing source values, no matches, ambiguous cardinality-one
             matches, unsupported/unindexed targets, and wrong receiver scope
             fail closed with zero executable routes.

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -620,16 +620,19 @@ contract_formats:
               import-boundary alias policy requires exclusive alias patterns.
           descriptor_evidence_boundary:
             status: merge_bearing_runtime_behavior
-            implementation_slice: '#1485'
-            canonical_code_owner: internal/runtime/bus.connectRoutePlanResolver.descriptorsForPlans
+            implementation_slice: '#1485/#1479'
+            canonical_code_owner: internal/runtime/bus.connectRoutePlanResolver.descriptorsForPlans and internal/runtime/core/pinrouting.MaterializeConnectRoutePlan
             rule: |
               Descriptor loading during lowered-connect EventBus planning is
               evidence for supported runtime-resolution target forms only.
               Static lowered ConnectRoutePlan matches MUST NOT load or depend on
               legacy active-agent recipient-policy descriptors. Runtime
-              descriptor evidence MUST NOT promote unsupported arbitrary
-              business-field targets; those remain fail-closed until a separate
-              typed descriptor/index owner is promoted.
+              descriptor evidence may materialize identity-style targets and
+              declared receiver entity fields marked `indexed: true`. Descriptor
+              evidence MUST NOT promote unsupported arbitrary business fields,
+              unindexed entity fields, config fields, instance fields, delivery
+              rows, receipts, replay/readback, RouteTable state, live
+              subscriptions, or handler lookup into route topology authority.
           route_authority_drift_guardrails:
             status: merge_bearing_conformance_guardrail
             implementation_slice: '#1494'
@@ -660,7 +663,7 @@ contract_formats:
           - reply delivery metadata preservation
           - persisted delivery rows, pipeline receipts, and committed replay scope as separate owners
           unsupported_or_split:
-            business_field_descriptor_targets: '#1479 owns typed descriptor/index materialization for targets such as entity.vertical_id.'
+            business_field_descriptor_targets: 'Declared receiver entity fields with indexed: true are implemented by #1479; arbitrary, undeclared, unindexed, config, and instance business-field descriptor targets remain split to #1466 or later gated children.'
             agent_node_emitter_parity: '#1474 remains open.'
             producer_target_broadcast_retirement: '#1475 remains open.'
             selected_contract_runfork_readiness: 'Tracked under #1466/watchlist; not closed by #1473.'
@@ -1056,6 +1059,7 @@ entity_contracts:
           type: <type>
           initial: <value>
           immutable: <bool>
+          indexed: <bool>
           description: <text>
           materialize_from: <node_id>.<accumulator_name>
           project:
@@ -1073,7 +1077,22 @@ entity_contracts:
     - '`_unused_reader_reason` documents that a field is intentionally read only outside platform-visible internal handlers.
       It suppresses only the informational `entity_reader_coverage` slice; it does not count as writer coverage, authorize
       runtime/API reads, or change persistence semantics.'
+    - '`indexed: true` declares a field as addressable descriptor/index evidence for supported runtime receiver selection.
+      It does not make the field route topology authority, dynamically index arbitrary payload fields, or authorize
+      undeclared business-field routing.'
     - 'A `materialize_from` field is runtime-owned and not agent-writable.'
+  routing_indexes:
+    status: merge_bearing_runtime_behavior
+    implementation_slice: '#1479'
+    rule: |
+      A receiver entity field with `indexed: true` may be used as descriptor
+      evidence for a composition-routing addressed input target such as
+      `entity.vertical_id`. The receiver input pin and parent connect entry
+      still own the route topology. The indexed entity field only authorizes
+      runtime descriptor/index materialization to answer which active receiver
+      instance has the declared field value. Missing, unindexed, undeclared,
+      ambiguous, unsupported, or wrong-scope targets fail closed and produce no
+      executable routes.
   accumulator_entity_projection:
     description: |
       `materialize_from` declares a downstream typed entity-field copy of a
@@ -4993,7 +5012,8 @@ flow_model:
             - entity_id / entity.entity_id
             - flow_instance / instance.flow_instance
             - instance_id / instance.instance_id
-            unsupported_descriptor_targets: Arbitrary business fields such as entity.vertical_id remain fail-closed until a later gate promotes a typed descriptor/index owner for those fields.
+            - entity.<field> when the receiver entity contract declares that field with indexed: true
+            unsupported_descriptor_targets: Undeclared or unindexed entity fields, config.<field>, instance.<field>, and other arbitrary business fields remain fail-closed unless a later approved spec+runtime child promotes a typed descriptor/index owner for those forms.
           failure_reasons:
           - source_missing
           - connect_pin_ref_invalid
@@ -5040,7 +5060,7 @@ flow_model:
           proof_obligations:
           - Publish, PublishInMutation, CheckPublishRecipientPlan, and engineOutbox use the same corrected planner
           - singular target, target_set fanout, and reply metadata are covered
-          - unsupported business-field descriptor targets remain fail-closed and split to #1479
+          - unsupported or unindexed business-field descriptor targets remain fail-closed and split to #1466 or later gated children
           - '#1473 does not close #1474, #1475, selected-contract runfork readiness, or #1466 parent closure'
         implementation_slice_1485:
           status: merge_bearing_runtime_behavior
@@ -5059,7 +5079,7 @@ flow_model:
             receiver carrier evidence at the selected receiver path rather than
             relying on producer-key subscription projection.
           does_not_close:
-          - positive arbitrary business-field descriptor/index support
+          - arbitrary business-field descriptor/index support outside declared indexed receiver entity fields
           - selected-contract runfork route/readiness mutation
           - broad composition-first routing parent closure
           proof_obligations:
@@ -5082,7 +5102,7 @@ flow_model:
             semantics backed by PlanDirect RoutePlan production, not subscribed
             route-authority reconstruction.
           does_not_close:
-          - positive arbitrary business-field descriptor/index support
+          - arbitrary business-field descriptor/index support outside declared indexed receiver entity fields
           - selected-contract runfork route/readiness mutation
           - broad composition-first routing parent closure
           proof_obligations:
@@ -5091,6 +5111,45 @@ flow_model:
           - Publish, PublishInMutation, CheckPublishRecipientPlan, and engineOutbox preserve RoutePlan authority after materialization and guard checks
           - PublishDirect and CheckDirectRecipients preserve direct RoutePlan behavior and CommittedReplayScopeDirect persistence
           - operator event.replay proves direct-recipient preflight and direct publish through the same RoutePlan-backed path
+        implementation_slice_1479:
+          status: merge_bearing_runtime_behavior
+          canonical_code_owner: internal/runtime/core/pinrouting.MaterializeConnectRoutePlan with internal/runtime/bus.connectRoutePlanResolver
+          rule: |
+            Supported receiver business-field descriptor/index materialization is
+            limited to addressed input targets whose receiver entity contract
+            declares the target field with `indexed: true`. Bootverify MUST
+            reject unsupported or unindexed non-identity targets before runtime.
+            Runtime planning MUST pass the supported target list from the
+            loaded semantic source into `MaterializeConnectRoutePlan`; the
+            materializer MUST compare event source values only with descriptor
+            evidence for those supported targets. Singular cardinality produces
+            exactly one concrete target route; cardinality many produces a
+            target_set/fanout over all matching receiver-scope descriptors.
+            Missing source values, no matches, ambiguous cardinality-one
+            matches, unsupported/unindexed targets, and wrong receiver scope
+            fail closed with zero executable routes.
+          consumes:
+          - receiver addressed input pin address.target
+          - parent connect map target expression
+          - receiver entity contract field indexed: true
+          - active flow-instance descriptor address fields loaded from current run entity_state
+          - lowered ConnectRoutePlan runtime-resolution requirements
+          produces:
+          - concrete target route for supported singular business-field receiver selection
+          - concrete target_set routes for supported many business-field receiver selection
+          - fail-closed target diagnostics for unsupported, missing, unresolved, ambiguous, or wrong-scope descriptor evidence
+          does_not_close:
+          - arbitrary config.<field> or instance.<field> descriptor/index authority
+          - dynamic indexing of arbitrary payload/entity fields
+          - select_entity/select_or_create_entity receiver-local mutation semantics
+          - selected-contract runfork route/readiness mutation
+          - broad #1466 composition-first routing parent closure
+          proof_obligations:
+          - bootverify rejects unindexed receiver business-field address targets
+          - EventBus publish proves indexed singular entity business-field target materializes one concrete delivery route
+          - EventBus publish proves indexed many entity business-field target materializes target_set fanout
+          - negative proof covers missing source, no match, ambiguous one, unsupported/unindexed, and wrong receiver scope with zero executable routes
+          - SQLite and Postgres active descriptor loading preserve run-scoped indexed entity address fields
         invalid_outputs:
         - raw same-name pin match used as final topology authority
         - live subscription list used to invent missing connect topology


### PR DESCRIPTION
## Summary
- Promotes `indexed: true` receiver entity fields as the typed descriptor/index owner for supported business-field connect targets.
- Updates `platform-spec.yaml` with the #1479 runtime behavior, supported/unsupported target forms, and proof obligations in the same PR as code.
- Routes EventBus lowered `ConnectRoutePlan` materialization through explicit supported-target state and store-backed run-scoped descriptor evidence for SQLite/Postgres.

Closes #1479

## Governing refs/context
- `platform-spec.yaml#flow_model.flow_package.composition_routing`
- `platform-spec.yaml#contract_formats.event_schema.routing_derivation.route_plan_authority.lowered_connect_route_plan_consumption.descriptor_evidence_boundary`
- `platform-spec.yaml#entity_contracts.routing_indexes`
- `platform-spec.yaml#flow_model.flow_package.composition_routing.route_plan_lowering.implementation_slice_1479`
- Binding issue/gate context: #1479 pre-audit and approved first-slice gate under #1466.

## Semantic migration
- New canonical owner: receiver entity contract fields declaring `indexed: true`, consumed by bootverify and `runtimepinrouting.SupportedConnectAddressTargets` / `MaterializeConnectRoutePlan`.
- Old invalid path: treating all non-identity business-field descriptor targets as unsupported forever, or allowing RouteTable/live subscriptions/handler lookup/delivery rows to infer business-field recipients.
- Production paths checked: `Publish`, `PublishInMutation`/planner shared path, `CheckPublishRecipientPlan` planner path via RoutePlan owner, EventBus route materialization, descriptor loading, delivery persistence, SQLite descriptor store, and Postgres descriptor store.
- Migration completeness: complete for #1479 declared indexed receiver entity-field targets; arbitrary `config.<field>`, `instance.<field>`, undeclared, and unindexed business fields remain fail-closed and split to #1466/later gated children.

## Proof
- `go test ./...`
- Focused positive proof: indexed singular target and indexed `target_set` fanout.
- Focused negative proof: missing source, no match, ambiguous singular, unsupported/unindexed target, and wrong receiver scope with zero executable routes.
- Store parity proof: SQLite and Postgres active descriptor loading preserve run-scoped entity-state address fields.