### PR TITLE
[agent-a][issue #1474] Route agent output pins through route plans

### DIFF
--- a/internal/runtime/bus/eventbus.go
+++ b/internal/runtime/bus/eventbus.go
@@ -62,6 +62,7 @@ type PublishRecipientPlan struct {
 	SubscriptionRecipients []string
 	DeliveryRoutes         []events.DeliveryRoute
 	TargetFailure          string
+	canonicalAuthority     bool
 }
 
 type DirectRecipientStatus struct {

--- a/internal/runtime/bus/eventbus_publish.go
+++ b/internal/runtime/bus/eventbus_publish.go
@@ -976,6 +976,7 @@ func (eb *EventBus) publishRecipientPlan(evt events.Event, routePlan RoutePlan) 
 		SubscriptionRecipients: uniqueStrings(routePlan.SubscribedRecipients),
 		DeliveryRoutes:         routePlan.DeliveryRoutes(),
 		TargetFailure:          strings.TrimSpace(string(routePlan.TargetFailure)),
+		canonicalAuthority:     routePlan.CanonicalRouteOwnerMatched() && routePlan.AuthorityOwner == routePlanSourceConnectRoutePlan,
 	}
 	if eb != nil {
 		out.RoutedRecipients = eb.describeSubscribersForEvent(string(evt.Type()), routePlan.RoutedRecipients)

--- a/internal/runtime/bus/route_plan.go
+++ b/internal/runtime/bus/route_plan.go
@@ -254,6 +254,10 @@ func (p RoutePlan) AllowsLowerPrecedenceRouteProduction() bool {
 	}
 }
 
+func (p PublishRecipientPlan) UsesCanonicalRouteAuthority() bool {
+	return p.canonicalAuthority
+}
+
 func (p *RoutePlan) AddLiveRecipients(recipients ...RoutePlanLiveRecipient) {
 	if p == nil {
 		return

--- a/internal/runtime/tools/executor_emit.go
+++ b/internal/runtime/tools/executor_emit.go
@@ -16,6 +16,10 @@ import (
 	"github.com/google/uuid"
 )
 
+type publishRecipientPlanner interface {
+	CheckPublishRecipientPlan(context.Context, events.Event) (runtimebus.PublishRecipientPlan, error)
+}
+
 func (e *Executor) handleEmitTool(ctx context.Context, actor models.AgentConfig, toolName string, input any) (any, error) {
 	eventType, eventSchema, ok := e.emitRegistry.EventSchemaForActorTool(actor, toolName)
 	if !ok {
@@ -111,54 +115,88 @@ func (e *Executor) handleEmitTool(ctx context.Context, actor models.AgentConfig,
 		time.Now(),
 	)
 	if runtimepinrouting.PinDeclaredOutput(e.workflowSource, flowID, eventType) {
-		spec := runtimecontracts.EmitSpec{Event: eventType}
-		parentRoute, allowEntityOnlyParentRoute, err := e.emitParentRouteForActor(ctx, actor, flowID, flowInstance, inbound)
-		if err != nil {
-			wrapped := WrapRuntimeError(
-				"parent_route_lookup_failed",
-				"tool-executor",
-				"handle_emit_tool.parent_route",
-				true,
-				err,
-				"failed to resolve emit tool parent route",
-			)
-			e.logEmitToolOutcome(ctx, actor, toolName, schemaEventType, eventType, preValidationPayload, postEnrichmentPayload, emitted, "parent_route_lookup_failed", "publish", "parent_route", wrapped)
-			return nil, wrapped
+		usePublishAuthority := false
+		if planner, ok := e.bus.(publishRecipientPlanner); ok && planner != nil {
+			plan, err := planner.CheckPublishRecipientPlan(ctx, emitted)
+			if err != nil {
+				wrapped := WrapRuntimeError(
+					"route_plan_preflight_failed",
+					"tool-executor",
+					"handle_emit_tool.route_plan_preflight",
+					true,
+					err,
+					"failed to preflight emit tool route plan",
+				)
+				e.logEmitToolOutcome(ctx, actor, toolName, schemaEventType, eventType, preValidationPayload, postEnrichmentPayload, emitted, "route_plan_preflight_failed", "publish", "route_plan_preflight", wrapped)
+				return nil, wrapped
+			}
+			if plan.UsesCanonicalRouteAuthority() {
+				if plan.TargetFailure != "" {
+					wrapped := NewRuntimeError(
+						plan.TargetFailure,
+						"tool-executor",
+						"handle_emit_tool.route_plan_preflight",
+						false,
+						"emit tool %s attempted pin-declared output %s without supported route plan target",
+						toolName,
+						eventType,
+					)
+					e.logEmitToolOutcome(ctx, actor, toolName, schemaEventType, eventType, preValidationPayload, postEnrichmentPayload, emitted, "route_plan_preflight_failed", "publish", "route_plan_preflight", wrapped)
+					return nil, wrapped
+				}
+				usePublishAuthority = true
+			}
 		}
-		resolution := runtimepinrouting.ResolveEnvelope(runtimepinrouting.ResolutionInput{
-			Source:                     e.workflowSource,
-			FlowID:                     flowID,
-			EventType:                  eventType,
-			Emit:                       spec,
-			SourceRoute:                sourceRoute,
-			Inbound:                    inbound,
-			ParentRoute:                parentRoute,
-			AllowEntityOnlyParentRoute: allowEntityOnlyParentRoute,
-		}, envelope)
-		if resolution.Failure != "" {
-			wrapped := NewRuntimeError(
-				string(resolution.Failure),
-				"tool-executor",
-				"handle_emit_tool.pin_target_resolution",
-				false,
-				"emit tool %s attempted pin-declared output %s without supported target mechanism",
-				toolName,
-				eventType,
+		if !usePublishAuthority {
+			spec := runtimecontracts.EmitSpec{Event: eventType}
+			parentRoute, allowEntityOnlyParentRoute, err := e.emitParentRouteForActor(ctx, actor, flowID, flowInstance, inbound)
+			if err != nil {
+				wrapped := WrapRuntimeError(
+					"parent_route_lookup_failed",
+					"tool-executor",
+					"handle_emit_tool.parent_route",
+					true,
+					err,
+					"failed to resolve emit tool parent route",
+				)
+				e.logEmitToolOutcome(ctx, actor, toolName, schemaEventType, eventType, preValidationPayload, postEnrichmentPayload, emitted, "parent_route_lookup_failed", "publish", "parent_route", wrapped)
+				return nil, wrapped
+			}
+			resolution := runtimepinrouting.ResolveEnvelope(runtimepinrouting.ResolutionInput{
+				Source:                     e.workflowSource,
+				FlowID:                     flowID,
+				EventType:                  eventType,
+				Emit:                       spec,
+				SourceRoute:                sourceRoute,
+				Inbound:                    inbound,
+				ParentRoute:                parentRoute,
+				AllowEntityOnlyParentRoute: allowEntityOnlyParentRoute,
+			}, envelope)
+			if resolution.Failure != "" {
+				wrapped := NewRuntimeError(
+					string(resolution.Failure),
+					"tool-executor",
+					"handle_emit_tool.pin_target_resolution",
+					false,
+					"emit tool %s attempted pin-declared output %s without supported target mechanism",
+					toolName,
+					eventType,
+				)
+				e.logEmitToolOutcome(ctx, actor, toolName, schemaEventType, eventType, preValidationPayload, postEnrichmentPayload, emitted, "pin_target_resolution_failed", "publish", "pin_target_resolution", wrapped)
+				return nil, wrapped
+			}
+			emitted = events.NewChildEvent(
+				emitted.ID(),
+				emitted.Type(),
+				emitted.SourceAgent(),
+				emitted.TaskID(),
+				emitted.Payload(),
+				emitted.ChainDepth(),
+				inbound,
+				resolution.Envelope,
+				emitted.CreatedAt(),
 			)
-			e.logEmitToolOutcome(ctx, actor, toolName, schemaEventType, eventType, preValidationPayload, postEnrichmentPayload, emitted, "pin_target_resolution_failed", "publish", "pin_target_resolution", wrapped)
-			return nil, wrapped
 		}
-		emitted = events.NewChildEvent(
-			emitted.ID(),
-			emitted.Type(),
-			emitted.SourceAgent(),
-			emitted.TaskID(),
-			emitted.Payload(),
-			emitted.ChainDepth(),
-			inbound,
-			resolution.Envelope,
-			emitted.CreatedAt(),
-		)
 	}
 	if err := e.bus.Publish(ctx, emitted); err != nil {
 		wrapped := WrapRuntimeError(

--- a/internal/runtime/tools/executor_emit_test.go
+++ b/internal/runtime/tools/executor_emit_test.go
@@ -10,8 +10,11 @@ import (
 	runtimebus "github.com/division-sh/swarm/internal/runtime/bus"
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
 	models "github.com/division-sh/swarm/internal/runtime/core/actors"
+	runtimeflowidentity "github.com/division-sh/swarm/internal/runtime/core/flowidentity"
 	"github.com/division-sh/swarm/internal/runtime/flowmodel"
+	llm "github.com/division-sh/swarm/internal/runtime/llm"
 	runtimepipeline "github.com/division-sh/swarm/internal/runtime/pipeline"
+	runtimereplayclaim "github.com/division-sh/swarm/internal/runtime/replayclaim"
 	"github.com/division-sh/swarm/internal/runtime/semanticview"
 	"time"
 )
@@ -46,6 +49,58 @@ func (l emitWorkflowInstanceLoader) Load(_ context.Context, ref string) (runtime
 	}
 	instance, ok := l.rows[strings.TrimSpace(ref)]
 	return instance, ok, nil
+}
+
+type emitRoutePlanStore struct {
+	events      map[string]events.Event
+	routes      map[string][]events.DeliveryRoute
+	scopes      map[string]runtimereplayclaim.CommittedReplayScope
+	receipts    map[string]string
+	receiptErrs map[string]string
+}
+
+func newEmitRoutePlanStore() *emitRoutePlanStore {
+	return &emitRoutePlanStore{
+		events:      map[string]events.Event{},
+		routes:      map[string][]events.DeliveryRoute{},
+		scopes:      map[string]runtimereplayclaim.CommittedReplayScope{},
+		receipts:    map[string]string{},
+		receiptErrs: map[string]string{},
+	}
+}
+
+func (s *emitRoutePlanStore) AppendEvent(_ context.Context, evt events.Event) error {
+	s.events[evt.ID()] = evt
+	return nil
+}
+
+func (s *emitRoutePlanStore) InsertEventDeliveries(_ context.Context, _ string, _ []string) error {
+	return nil
+}
+
+func (s *emitRoutePlanStore) ListEventDeliveryRecipients(_ context.Context, eventID string) ([]string, error) {
+	var out []string
+	for _, route := range s.routes[eventID] {
+		if route.SubscriberType == "agent" {
+			out = append(out, route.SubscriberID)
+		}
+	}
+	return out, nil
+}
+
+func (s *emitRoutePlanStore) SupportsPersistedReplay() bool { return true }
+
+func (s *emitRoutePlanStore) PersistEventWithDeliveryRouteSetAndScope(_ context.Context, evt events.Event, routes []events.DeliveryRoute, scope runtimereplayclaim.CommittedReplayScope) error {
+	s.events[evt.ID()] = evt
+	s.routes[evt.ID()] = events.NormalizeDeliveryRoutes(routes)
+	s.scopes[evt.ID()] = scope
+	return nil
+}
+
+func (s *emitRoutePlanStore) UpsertPipelineReceipt(_ context.Context, eventID, status, errText string) error {
+	s.receipts[eventID] = status
+	s.receiptErrs[eventID] = errText
+	return nil
 }
 
 func TestHandleEmitTool_PreservesPayloadForFlowScopedEmit(t *testing.T) {
@@ -613,6 +668,126 @@ func TestHandleEmitTool_RootSchemaPinOutputStillRequiresTarget(t *testing.T) {
 	}
 }
 
+func TestHandleEmitTool_RoutesConnectedOutputPinThroughCanonicalRouteAuthority(t *testing.T) {
+	source := emitRoutePlanStaticSource(runtimecontracts.FlowPackageConnect{
+		From:     "producer.deploy_done",
+		To:       "consumer.deploy_completed",
+		Delivery: "one",
+	})
+	store := newEmitRoutePlanStore()
+	eb, err := runtimebus.NewEventBusWithOptions(store, runtimebus.EventBusOptions{ContractBundle: source})
+	if err != nil {
+		t.Fatalf("NewEventBusWithOptions: %v", err)
+	}
+	emitRegistry := NewEmitRegistry(source, nil)
+	actor := models.AgentConfig{
+		ID:         "producer-agent",
+		Role:       "producer",
+		Mode:       "producer",
+		FlowPath:   "producer",
+		EntityID:   "producer-entity",
+		EmitEvents: []string{"deploy.done"},
+	}
+	if tools := emitRegistry.GenerateEmitToolsForActor(actor, nil); !emitToolDefinitionsContain(tools, "emit_deploy_done") {
+		t.Fatalf("generated emit tools = %#v, want emit_deploy_done", tools)
+	}
+	exec := NewExecutorWithOptions(eb, nil, ExecutorOptions{WorkflowSource: source, EmitRegistry: emitRegistry})
+
+	ctx := runtimebus.WithInboundEvent(context.Background(), events.NewProjectionEvent(
+		"evt-parent",
+		events.EventType("producer/deploy.requested"),
+		"runtime",
+		"",
+		nil,
+		0,
+		"run-1474",
+		"",
+		events.EventEnvelope{},
+		time.Now().UTC(),
+	))
+	out, err := exec.handleEmitTool(ctx, actor, "emit_deploy_done", map[string]any{})
+	if err != nil {
+		t.Fatalf("handleEmitTool: %v", err)
+	}
+	eventID := emitToolResultString(t, out, "event_id")
+	persisted := store.events[eventID]
+	if got, want := string(persisted.Type()), "producer/deploy.done"; got != want {
+		t.Fatalf("persisted event type = %q, want %q", got, want)
+	}
+	if persisted.HasTargetRoute() {
+		t.Fatalf("persisted event target route = %#v, want no producer-authored target", persisted.TargetRoute())
+	}
+	wantRoute := events.DeliveryRoute{
+		SubscriberType: "node",
+		SubscriberID:   "consumer-node",
+		Target: events.RouteIdentity{
+			FlowID:       "consumer",
+			FlowInstance: "consumer",
+			EntityID:     runtimeflowidentity.EntityID("consumer"),
+		},
+	}
+	if !emitDeliveryRoutesContain(store.routes[eventID], wantRoute) {
+		t.Fatalf("persisted delivery routes = %#v, want %#v", store.routes[eventID], wantRoute)
+	}
+	if got := store.receipts[eventID]; got != "processed" {
+		t.Fatalf("pipeline receipt = %q, want processed", got)
+	}
+	if got := store.scopes[eventID]; got != runtimereplayclaim.CommittedReplayScopeSubscribed {
+		t.Fatalf("committed replay scope = %q, want subscribed", got)
+	}
+}
+
+func TestHandleEmitTool_FailsClosedForConnectedOutputWithoutCanonicalRouteAuthority(t *testing.T) {
+	source := emitRoutePlanSource(nil)
+	store := newEmitRoutePlanStore()
+	eb, err := runtimebus.NewEventBusWithOptions(store, runtimebus.EventBusOptions{ContractBundle: source})
+	if err != nil {
+		t.Fatalf("NewEventBusWithOptions: %v", err)
+	}
+	raw := eb.SubscribeInternal("raw-listener", events.EventType("producer/deploy.done"), events.EventType("deploy.done"))
+	emitRegistry := NewEmitRegistry(source, nil)
+	actor := models.AgentConfig{
+		ID:         "producer-agent",
+		Role:       "producer",
+		Mode:       "producer",
+		FlowPath:   "producer",
+		EntityID:   "producer-entity",
+		EmitEvents: []string{"deploy.done"},
+	}
+	exec := NewExecutorWithOptions(eb, nil, ExecutorOptions{WorkflowSource: source, EmitRegistry: emitRegistry})
+
+	ctx := runtimebus.WithInboundEvent(context.Background(), events.NewProjectionEvent(
+		"evt-parent",
+		events.EventType("producer/deploy.requested"),
+		"runtime",
+		"",
+		nil,
+		0,
+		"run-1474",
+		"",
+		events.EventEnvelope{},
+		time.Now().UTC(),
+	))
+	_, err = exec.handleEmitTool(ctx, actor, "emit_deploy_done", map[string]any{})
+	if err == nil {
+		t.Fatal("handleEmitTool error = nil, want target_required_missing")
+	}
+	if !strings.Contains(err.Error(), "target_required_missing") {
+		t.Fatalf("handleEmitTool error = %v, want target_required_missing", err)
+	}
+	if len(store.events) != 0 {
+		t.Fatalf("persisted events = %#v, want none", store.events)
+	}
+	if len(store.routes) != 0 {
+		t.Fatalf("persisted routes = %#v, want none", store.routes)
+	}
+	select {
+	case evt := <-raw:
+		t.Fatalf("raw subscriber received %#v, want no lower-precedence rescue", evt)
+	default:
+	}
+}
+
 func TestHandleEmitTool_FailsClosedOnUndeclaredPayloadField(t *testing.T) {
 	bundle := &runtimecontracts.WorkflowContractBundle{
 		Events: map[string]runtimecontracts.EventCatalogEntry{
@@ -986,4 +1161,159 @@ func TestHandleEmitTool_FailsClosedOnNamedTypeViolation(t *testing.T) {
 	if bus.count != 0 {
 		t.Fatalf("publish count = %d, want 0", bus.count)
 	}
+}
+
+type emitRoutePlanTestFlow struct {
+	id      string
+	mode    string
+	inputs  []runtimecontracts.FlowInputEventPin
+	outputs []runtimecontracts.FlowOutputEventPin
+	nodes   map[string]runtimecontracts.SystemNodeContract
+}
+
+func emitRoutePlanStaticSource(connect runtimecontracts.FlowPackageConnect) semanticview.Source {
+	return emitRoutePlanSource([]runtimecontracts.FlowPackageConnect{connect})
+}
+
+func emitRoutePlanSource(connects []runtimecontracts.FlowPackageConnect) semanticview.Source {
+	return semanticview.Wrap(emitRoutePlanTestBundle([]emitRoutePlanTestFlow{
+		{
+			id:   "producer",
+			mode: "static",
+			outputs: []runtimecontracts.FlowOutputEventPin{{
+				Name:  "deploy_done",
+				Event: "deploy.done",
+			}},
+		},
+		{
+			id:   "consumer",
+			mode: "static",
+			inputs: []runtimecontracts.FlowInputEventPin{{
+				Name:  "deploy_completed",
+				Event: "deploy.completed",
+			}},
+			nodes: map[string]runtimecontracts.SystemNodeContract{
+				"consumer-node": {
+					ID:            "consumer-node",
+					EventHandlers: map[string]runtimecontracts.SystemNodeEventHandler{"deploy.completed": {}},
+				},
+			},
+		},
+	}, connects))
+}
+
+func emitRoutePlanTestBundle(flows []emitRoutePlanTestFlow, connects []runtimecontracts.FlowPackageConnect) *runtimecontracts.WorkflowContractBundle {
+	children := make([]runtimecontracts.FlowContractView, 0, len(flows))
+	byID := make(map[string]*runtimecontracts.FlowContractView, len(flows))
+	flowSchemas := make(map[string]runtimecontracts.FlowSchemaDocument, len(flows))
+	flowInputs := make(map[string][]string, len(flows))
+	flowOutputs := make(map[string][]string, len(flows))
+	flowInputPins := make(map[string][]runtimecontracts.FlowInputEventPin, len(flows))
+	flowOutputPins := make(map[string][]runtimecontracts.FlowOutputEventPin, len(flows))
+	nodeHandlers := map[string]map[string]runtimecontracts.SystemNodeEventHandler{}
+	eventCatalog := map[string]runtimecontracts.EventCatalogEntry{}
+	for _, flow := range flows {
+		schema := runtimecontracts.FlowSchemaDocument{
+			Mode: flow.mode,
+			Pins: runtimecontracts.FlowPins{
+				Inputs: runtimecontracts.FlowInputPins{
+					Events:    emitRoutePlanInputEvents(flow.inputs),
+					EventPins: flow.inputs,
+				},
+				Outputs: runtimecontracts.FlowOutputPins{
+					Events:    emitRoutePlanOutputEvents(flow.outputs),
+					EventPins: flow.outputs,
+				},
+			},
+		}
+		flowEvents := map[string]runtimecontracts.EventCatalogEntry{}
+		for _, eventType := range append(schema.Pins.Inputs.Events, schema.Pins.Outputs.Events...) {
+			eventCatalog[eventType] = runtimecontracts.EventCatalogEntry{Payload: runtimecontracts.EventPayloadSpec{Type: "object"}}
+			flowEvents[eventType] = runtimecontracts.EventCatalogEntry{}
+		}
+		view := runtimecontracts.FlowContractView{
+			Paths:  runtimecontracts.FlowContractPaths{ID: flow.id, Flow: flow.id},
+			Schema: schema,
+			Events: flowEvents,
+			Path:   flow.id,
+			Nodes:  flow.nodes,
+		}
+		children = append(children, view)
+		viewCopy := view
+		byID[flow.id] = &viewCopy
+		flowSchemas[flow.id] = schema
+		flowInputs[flow.id] = append([]string(nil), schema.Pins.Inputs.Events...)
+		flowOutputs[flow.id] = append([]string(nil), schema.Pins.Outputs.Events...)
+		flowInputPins[flow.id] = append([]runtimecontracts.FlowInputEventPin(nil), flow.inputs...)
+		flowOutputPins[flow.id] = append([]runtimecontracts.FlowOutputEventPin(nil), flow.outputs...)
+		for _, node := range flow.nodes {
+			if len(node.EventHandlers) > 0 {
+				nodeHandlers[node.ID] = node.EventHandlers
+			}
+		}
+	}
+	root := runtimecontracts.FlowContractView{Children: children}
+	return &runtimecontracts.WorkflowContractBundle{
+		Events: eventCatalog,
+		FlowTree: flowmodel.Tree[runtimecontracts.FlowContractView]{
+			Root: &root,
+			ByID: byID,
+		},
+		FlowSchemas: flowSchemas,
+		Semantics: runtimecontracts.WorkflowSemanticView{
+			FlowInputs:          flowInputs,
+			FlowOutputs:         flowOutputs,
+			FlowInputEventPins:  flowInputPins,
+			FlowOutputEventPins: flowOutputPins,
+			CompositionConnects: connects,
+			NodeHandlers:        nodeHandlers,
+		},
+	}
+}
+
+func emitRoutePlanInputEvents(pins []runtimecontracts.FlowInputEventPin) []string {
+	out := make([]string, 0, len(pins))
+	for _, pin := range pins {
+		out = append(out, pin.EventType())
+	}
+	return out
+}
+
+func emitRoutePlanOutputEvents(pins []runtimecontracts.FlowOutputEventPin) []string {
+	out := make([]string, 0, len(pins))
+	for _, pin := range pins {
+		out = append(out, pin.EventType())
+	}
+	return out
+}
+
+func emitDeliveryRoutesContain(in []events.DeliveryRoute, want events.DeliveryRoute) bool {
+	for _, route := range events.NormalizeDeliveryRoutes(in) {
+		if route == want {
+			return true
+		}
+	}
+	return false
+}
+
+func emitToolDefinitionsContain(in []llm.ToolDefinition, name string) bool {
+	for _, tool := range in {
+		if tool.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+func emitToolResultString(t testing.TB, out any, key string) string {
+	t.Helper()
+	result, ok := out.(map[string]any)
+	if !ok {
+		t.Fatalf("emit tool result = %#v, want map", out)
+	}
+	value, ok := result[key].(string)
+	if !ok || value == "" {
+		t.Fatalf("emit tool result[%q] = %#v, want non-empty string", key, result[key])
+	}
+	return value
 }

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -664,7 +664,7 @@ contract_formats:
           - persisted delivery rows, pipeline receipts, and committed replay scope as separate owners
           unsupported_or_split:
             business_field_descriptor_targets: 'Declared top-level receiver entity fields with indexed: true are implemented by #1479; nested entity paths, arbitrary, undeclared, unindexed, config, and instance business-field descriptor targets remain split to #1466 or later gated children.'
-            agent_node_emitter_parity: '#1474 remains open.'
+            agent_node_emitter_parity: 'Closed by #1474: generated agent emit tools and node/system emits for supported connected output pins consume the same EventBus RoutePlan authority from lowered parent connect facts. Producer target/broadcast retirement remains split to #1475; broader composition-first closure remains #1466.'
             producer_target_broadcast_retirement: '#1475 remains open.'
             selected_contract_runfork_readiness: 'Tracked under #1466/watchlist; not closed by #1473.'
             parent_composition_routing_closure: '#1466 remains open.'
@@ -3521,8 +3521,18 @@ engine:
         tools in tools.
       naming: 'emit_{event_name} where dots are replaced with underscores. Example: emit_events: [score.dimension_complete]
         → tool: emit_score_dimension_complete'
-      behavior: Each emit tool accepts a payload object matching the event's schema in events.yaml. The platform validates
+      behavior: |
+        Each emit tool accepts a payload object matching the event's schema in events.yaml. The platform validates
         the payload, attaches sender context, and publishes the event.
+        For pin-declared output events, generated agent emit tools MUST consume the same publish-time RoutePlan
+        authority as node/system emits. If EventBus preflight reports a canonical lowered parent-connect route
+        decision, the tool MUST admit the event to Publish so that EventBus persists and dispatches the typed
+        RoutePlan delivery intents; if that canonical decision failed closed, the tool MUST fail closed before
+        publish with zero executable route rows. Raw event-name subscribers, RouteTable fallback, live subscriptions,
+        materializer repair, or producer target/broadcast escape hatches MUST NOT rescue a matched canonical
+        failure. When no canonical lowered route applies, retained explicit target, structural ParentRoute,
+        static child-flow delivery-entity, and broadcast escape behavior remains governed by handler_specification.handler_fields.emit
+        and engine.cross_flow_routing.
       universal_tools: 'The following tools are auto-granted to all agents without explicit tools listing: agent_message
         and mailbox_send. Generated emit tools are derived from emit_events. Entity tools are governed by
         contract_formats.persistence_model.role_scoped_entity_tools and tool_model.agent_tool_filtering, not by prompt prose.'
@@ -5064,6 +5074,33 @@ flow_model:
           - singular target, target_set fanout, and reply metadata are covered
           - unsupported or unindexed business-field descriptor targets remain fail-closed and split to #1466 or later gated children
           - '#1473 does not close #1474, #1475, selected-contract runfork readiness, or #1466 parent closure'
+        implementation_slice_1474:
+          status: merge_bearing_runtime_behavior
+          canonical_code_owner: internal/runtime/bus.RoutePlan via CheckPublishRecipientPlan and Publish, consumed by internal/runtime/tools.Executor.handleEmitTool
+          rule: |
+            Generated agent emit tools for pin-declared output events MUST NOT
+            reject connected output-pin emits before EventBus can evaluate the
+            lowered parent-connect RoutePlan authority. The tool may preflight
+            EventBus planning only to distinguish canonical lowered-route
+            decisions from lower-precedence subscriber/materializer fallback:
+            canonical matched plans are admitted to Publish; canonical
+            fail-closed plans fail before publish with zero executable routes;
+            lower-precedence or no-canonical plans continue through retained
+            explicit target, structural ParentRoute, static child delivery-entity,
+            and broadcast escape handling. Node/system emits remain consumers of
+            the same RoutePlan authority through engine outbox/dispatcher paths.
+          consumes:
+          - implementation_slice_1473 EventBus RoutePlan publish authority
+          - implementation_slice_1472 lowered ConnectRoutePlan artifacts
+          - agent sender/source route context from generated emit tool execution
+          produces:
+          - no-relay generated-agent delivery for supported connected output pins
+          - node/system output-pin parity through the same persisted RoutePlan sink
+          - fail-closed unresolved connected output pins with no raw subscriber fallback
+          does_not_close:
+          - '#1475 producer target/broadcast retirement'
+          - '#1466 composition-first parent closure'
+          - '#1444 final turnkey composition behavior'
         implementation_slice_1485:
           status: merge_bearing_runtime_behavior
           canonical_code_owner: internal/runtime/bus.connectRoutePlanResolver with connectReceiverCarrierRouteKeys


### PR DESCRIPTION
## Summary

Closes #1474.

This PR closes the approved first-slice class `agent_node_connected_output_pin_emitter_parity_under_lowered_connect_route_plan` by allowing generated agent emit tools for connected output pins to consume the existing EventBus publish-time RoutePlan authority instead of failing before EventBus can evaluate lowered parent-connect route plans.

## Governing refs / context

Exact governing spec refs updated and consumed in this PR:

- `platform-spec.yaml#contract_formats.routing_derivation.route_plan_authority.lowered_connect_route_plan_consumption`
- `platform-spec.yaml#handler_specification.handler_fields.emit`
- `platform-spec.yaml#engine.cross_flow_routing`
- `platform-spec.yaml#engine.agent_session_management.emit_tool_convention`
- `platform-spec.yaml#flow_model.flow_package.composition_routing.implementation_slice_1474`

Issue/gate refs:

- #1474 Pre-Implementation Coverage Audit
- #1474 approved gate outcome: approved as first slice
- Parent/splits remain #1466 and #1475.

## Semantic migration

- New canonical owner consumed by agent emit tools: EventBus `RoutePlan` through `CheckPublishRecipientPlan` and `Publish`.
- Old non-authoritative path now invalid for connected output pins: `Executor.handleEmitTool` rejecting pin-declared output events solely through pre-publish `runtimepinrouting.ResolveEnvelope` before EventBus route-plan authority can run.
- Production paths checked for surviving old behavior: generated agent emit tool path, EventBus publish/preflight path, engine outbox node/system path, explicit target/target_set/broadcast regressions, route-authority conformance guardrails.
- Migration completeness: complete for #1474 supported connected output-pin surface. Producer target/broadcast retirement remains split to #1475; broader composition-first closure remains #1466.

## Proof

- `go test ./internal/runtime/tools ./internal/runtime/bus ./internal/runtime/conformance -run 'HandleEmitTool_RoutesConnectedOutputPinThroughCanonicalRouteAuthority|HandleEmitTool_FailsClosedForConnectedOutputWithoutCanonicalRouteAuthority|HandleEmitTool_RootSchemaPinOutputStillRequiresTarget|HandleEmitTool_TargetsParentRouteForChildPinOutput|ConnectRoutePlan|RouteAuthority|RoutePlan' -count=1`
- `go test ./internal/runtime/tools ./internal/runtime/engine ./internal/runtime/bus ./internal/runtime/bootverify ./internal/runtime/conformance -run 'EmitTool|ConnectRoutePlan|PinTarget|RouteAuthority|Outbox|RoutePlan|FlowBoundary|CompositionConnect|Target|Broadcast' -count=1`
- `go test ./...`