### PR TITLE
[agent-a][issue #1475] Retire producer routing common path

### DIFF
--- a/internal/apispec/platform_spec_composition_routing_test.go
+++ b/internal/apispec/platform_spec_composition_routing_test.go
@@ -91,6 +91,10 @@ func TestPlatformSpecCompositionRoutingSourceAuthority(t *testing.T) {
 	assertScalarContains(t, mustMappingValue(t, slice1475, "canonical_code_owner"), "ProducerRouteCommonPathFailure")
 	assertScalarContains(t, mustMappingValue(t, slice1475, "rule"), "not valid common-path")
 	assertScalarContains(t, mustMappingValue(t, slice1475, "rule"), "does not grandfather")
+	assertScalarContains(t, mustMappingValue(t, slice1475, "rule"), "alias/adapter connect")
+	if !sequenceContainsScalar(mustMappingValue(t, slice1475, "consumes"), "loaded package receiver input pins and parent connect graph edges, including alias/adapter connects") {
+		t.Fatal("implementation_slice_1475 missing connected adapter proof surface")
+	}
 	if !sequenceContainsScalar(mustMappingValue(t, slice1475, "produces"), "producer_target_common_path_forbidden for loaded flow-scope target.flow/match common-path composition") {
 		t.Fatal("implementation_slice_1475 missing producer_target_common_path_forbidden proof surface")
 	}

--- a/internal/apispec/platform_spec_composition_routing_test.go
+++ b/internal/apispec/platform_spec_composition_routing_test.go
@@ -86,6 +86,18 @@ func TestPlatformSpecCompositionRoutingSourceAuthority(t *testing.T) {
 	assertScalarContains(t, mustMappingValue(t, slice1473, "canonical_code_owner"), "internal/runtime/bus.RoutePlan")
 	assertScalarContains(t, mustMappingValue(t, slice1473, "rule"), "Supported EventBus publish/preflight/outbox dispatch consumes lowered ConnectRoutePlan")
 
+	slice1475 := mustYAMLPath(t, composition, "route_plan_lowering", "implementation_slice_1475")
+	assertScalarValue(t, mustMappingValue(t, slice1475, "status"), "merge_bearing_runtime_behavior")
+	assertScalarContains(t, mustMappingValue(t, slice1475, "canonical_code_owner"), "ProducerRouteCommonPathFailure")
+	assertScalarContains(t, mustMappingValue(t, slice1475, "rule"), "not valid common-path")
+	assertScalarContains(t, mustMappingValue(t, slice1475, "rule"), "does not grandfather")
+	if !sequenceContainsScalar(mustMappingValue(t, slice1475, "produces"), "producer_target_common_path_forbidden for loaded flow-scope target.flow/match common-path composition") {
+		t.Fatal("implementation_slice_1475 missing producer_target_common_path_forbidden proof surface")
+	}
+	if !sequenceContainsScalar(mustMappingValue(t, slice1475, "produces"), "producer_broadcast_common_path_forbidden for loaded flow-scope broadcast:true common-path composition") {
+		t.Fatal("implementation_slice_1475 missing producer_broadcast_common_path_forbidden proof surface")
+	}
+
 	entityContracts := mustYAMLPath(t, root, "entity_contracts")
 	assertScalarContains(t, mustYAMLPath(t, entityContracts, "routing_indexes", "rule"), "indexed: true")
 	assertScalarContains(t, mustYAMLPath(t, entityContracts, "routing_indexes", "rule"), "descriptor/index materialization")
@@ -111,13 +123,16 @@ func TestPlatformSpecCompositionRoutingDemotesProducerTargetAuthority(t *testing
 	}
 	assertScalarContains(t, mustYAMLPath(t, crossFlow, "target_resolution", "explicit_target_escape_hatch"), "exceptional dynamic-routing escape hatch")
 	assertScalarContains(t, mustYAMLPath(t, crossFlow, "target_resolution", "explicit_target_escape_hatch"), "must not replace lowered parent connect")
+	assertScalarContains(t, mustYAMLPath(t, crossFlow, "target_resolution", "explicit_target_escape_hatch"), "illegal common-path composition routing")
 	assertScalarContains(t, mustYAMLPath(t, crossFlow, "target_resolution", "fail_closed"), "no lowered parent connect route")
 	assertScalarContains(t, mustYAMLPath(t, crossFlow, "auto_wiring", "description"), "only as an inference candidate")
 	assertScalarContains(t, mustYAMLPath(t, crossFlow, "activation", "rule"), "valid lowered parent connect route")
 	assertScalarContains(t, mustYAMLPath(t, crossFlow, "auto_wiring", "template_pairs"), "lowered parent connect route facts")
 
 	assertScalarContains(t, mustYAMLPath(t, crossFlow, "target_forms", "flow_match_allow_fanout"), "explicit dynamic fan-out escape hatch")
+	assertScalarContains(t, mustYAMLPath(t, crossFlow, "target_forms", "flow_match"), "as package-internal composition")
 	assertScalarContains(t, mustYAMLPath(t, crossFlow, "target_forms", "broadcast"), "producer-authored explicit opt-out escape hatch")
+	assertScalarContains(t, mustYAMLPath(t, crossFlow, "target_forms", "broadcast"), "forbidden when it functions as")
 	assertScalarContains(t, mustYAMLPath(t, crossFlow, "structural_binding", "precedence_guard"), "lower precedence than lowered parent connect")
 	assertScalarContains(t, mustYAMLPath(t, crossFlow, "structural_binding", "child_to_parent"), "no lowered parent connect route")
 	assertScalarContains(t, mustYAMLPath(t, crossFlow, "structural_binding", "static_child_no_instance"), "without a lowered parent connect route")
@@ -131,9 +146,13 @@ func TestPlatformSpecCompositionRoutingDemotesProducerTargetAuthority(t *testing
 	pinTargetResolution := mustYAMLPath(t, root, "static_analyzer", "slice_3a_pin_target_resolution")
 	assertScalarValue(t, mustMappingValue(t, pinTargetResolution, "canonical_replacement"), "flow_model.flow_package.composition_routing.analyzer_verify_requirements")
 	assertScalarContains(t, mustYAMLPath(t, pinTargetResolution, "accepted_target_mechanisms", "lowered_parent_connect", "rule"), "Parent connect")
+	assertScalarContains(t, mustYAMLPath(t, pinTargetResolution, "accepted_target_mechanisms", "explicit_target", "rule"), "genuine dynamic escape hatch")
+	assertScalarContains(t, mustYAMLPath(t, pinTargetResolution, "accepted_target_mechanisms", "explicit_broadcast", "rule"), "no loaded package receiver input")
 	assertScalarContains(t, mustYAMLPath(t, pinTargetResolution, "accepted_target_mechanisms", "structural_parent_route", "rule"), "no lowered parent connect route applies")
 	assertScalarContains(t, mustYAMLPath(t, pinTargetResolution, "scope", "description"), "no lowered connect route applies")
 	assertScalarContains(t, mustYAMLPath(t, pinTargetResolution, "scope", "description"), "eligible static child delivery-entity")
+	assertScalarContains(t, mustYAMLPath(t, pinTargetResolution, "static_failure_reasons", "producer_target_common_path_forbidden"), "parent connect is the required route owner")
+	assertScalarContains(t, mustYAMLPath(t, pinTargetResolution, "static_failure_reasons", "producer_broadcast_common_path_forbidden"), "parent connect broadcast/fan-out")
 }
 
 func TestPlatformSpecCompositionRoutingCatalogSurfacesConsumeConnectAuthority(t *testing.T) {
@@ -159,6 +178,7 @@ func TestPlatformSpecCompositionRoutingCatalogSurfacesConsumeConnectAuthority(t 
 	assertScalarContains(t, mustMappingValue(t, pinTargetResolution, "trigger"), "lowered parent connect route")
 	assertScalarContains(t, mustMappingValue(t, pinTargetResolution, "trigger"), "explicit target escape hatch")
 	assertScalarContains(t, mustMappingValue(t, pinTargetResolution, "trigger"), "eligible static child delivery-entity route")
+	assertScalarContains(t, mustMappingValue(t, pinTargetResolution, "trigger"), "producer target/broadcast")
 
 	bootSteps := mustYAMLPath(t, root, "engine", "boot_sequence", "steps")
 	validatePins := mustSequenceMappingByScalarField(t, bootSteps, "name", "validate_pins")

--- a/internal/runtime/bootverify/workflow_pin_routing_checks.go
+++ b/internal/runtime/bootverify/workflow_pin_routing_checks.go
@@ -15,6 +15,10 @@ func checkPinTargetResolution(c *checkerContext) []Finding {
 		if !runtimepinrouting.PinDeclaredOutput(c.source, site.FlowID, site.Spec.EventType()) {
 			continue
 		}
+		if failure := runtimepinrouting.ProducerRouteCommonPathFailure(c.source, site.FlowID, site.Spec.EventType(), site.Spec); failure != "" {
+			findings = append(findings, pinTargetFinding(site, string(failure)))
+			continue
+		}
 		if compositionConnectsFromOutputEvent(c.source, site.FlowID, site.Spec.EventType()) {
 			continue
 		}
@@ -157,7 +161,8 @@ func pinRoutingAllKnownProducersTargeted(source semanticview.Source, flowID, eve
 		}
 		producers++
 		structuralParent := pinRoutingStructuralParentRouteEligible(source, site.FlowID)
-		if site.Spec.HasTarget() || (structuralParent && !site.Spec.Broadcast) {
+		if (site.Spec.HasTarget() && runtimepinrouting.ProducerRouteCommonPathFailure(source, site.FlowID, site.Spec.EventType(), site.Spec) == "") ||
+			(structuralParent && !site.Spec.Broadcast) {
 			targeted++
 		}
 	}

--- a/internal/runtime/bootverify/workflow_pin_routing_checks.go
+++ b/internal/runtime/bootverify/workflow_pin_routing_checks.go
@@ -19,12 +19,16 @@ func checkPinTargetResolution(c *checkerContext) []Finding {
 			findings = append(findings, pinTargetFinding(site, string(failure)))
 			continue
 		}
-		if compositionConnectsFromOutputEvent(c.source, site.FlowID, site.Spec.EventType()) {
-			continue
-		}
+		connectedOutput := compositionConnectsFromOutputEvent(c.source, site.FlowID, site.Spec.EventType())
 		structuralParent := pinRoutingStructuralParentRouteEligible(c.source, site.FlowID)
+		if connectedOutput {
+			structuralParent = true
+		}
 		if failure := runtimepinrouting.ValidateTargetSpec(c.source, site.FlowID, site.Spec, structuralParent); failure != "" {
 			findings = append(findings, pinTargetFinding(site, string(failure)))
+			continue
+		}
+		if connectedOutput {
 			continue
 		}
 		if site.Spec.Target.Normalized().Kind == runtimecontracts.EmitTargetKindSender && pinRoutingEventExternalSource(c.source, site.FlowID, site.HandlerEvent) {

--- a/internal/runtime/bootverify/workflow_pin_routing_checks_test.go
+++ b/internal/runtime/bootverify/workflow_pin_routing_checks_test.go
@@ -78,6 +78,24 @@ func TestPinTargetResolution_FailsClosedForProducerTargetCommonPathEvenWithParen
 	}
 }
 
+func TestPinTargetResolution_FailsClosedForUnknownProducerTargetFlowEvenWithParentConnect(t *testing.T) {
+	bundle := loadPinRoutingProducerRouteBundle(t, `
+      emit:
+        event: shared.ready
+        fields:
+          entity_id: payload.entity_id
+        target:
+          flow: missing-consumer
+          match:
+            entity_id: payload.entity_id
+`, true, pinRoutingProducerRouteConnect())
+
+	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+	if !reportContains(report.Errors(), "pin_target_resolution", "target_unknown_flow") {
+		t.Fatalf("expected target_unknown_flow with parent connect, got %#v", report.Errors())
+	}
+}
+
 func TestPinTargetResolution_AllowsExplicitTargetEscapeHatches(t *testing.T) {
 	for _, tt := range []struct {
 		name      string

--- a/internal/runtime/bootverify/workflow_pin_routing_checks_test.go
+++ b/internal/runtime/bootverify/workflow_pin_routing_checks_test.go
@@ -60,6 +60,39 @@ func TestPinTargetResolution_FailsClosedForProducerBroadcastCommonCompositionPat
 	}
 }
 
+func TestPinTargetResolution_FailsClosedForProducerTargetAdaptedConnectCommonPath(t *testing.T) {
+	bundle := loadPinRoutingProducerRouteBundleForEvents(t, "shared.ready", "consumer.ready", `
+      emit:
+        event: shared.ready
+        fields:
+          entity_id: payload.entity_id
+        target:
+          flow: consumer
+          match:
+            entity_id: payload.entity_id
+`, pinRoutingProducerRouteAdaptedConnect())
+
+	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+	if !reportContains(report.Errors(), "pin_target_resolution", "producer_target_common_path_forbidden") {
+		t.Fatalf("expected producer_target_common_path_forbidden for adapted connect, got %#v", report.Errors())
+	}
+}
+
+func TestPinTargetResolution_FailsClosedForProducerBroadcastAdaptedConnectCommonPath(t *testing.T) {
+	bundle := loadPinRoutingProducerRouteBundleForEvents(t, "shared.ready", "consumer.ready", `
+      emit:
+        event: shared.ready
+        fields:
+          entity_id: payload.entity_id
+        broadcast: true
+`, pinRoutingProducerRouteAdaptedConnect())
+
+	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+	if !reportContains(report.Errors(), "pin_target_resolution", "producer_broadcast_common_path_forbidden") {
+		t.Fatalf("expected producer_broadcast_common_path_forbidden for adapted connect, got %#v", report.Errors())
+	}
+}
+
 func TestPinTargetResolution_FailsClosedForProducerTargetCommonPathEvenWithParentConnect(t *testing.T) {
 	bundle := loadPinRoutingProducerRouteBundle(t, `
       emit:
@@ -424,6 +457,15 @@ func pinRoutingProducerRouteConnect() string {
 connect:
   - from: producer.shared.ready
     to: consumer.shared.ready
+`
+}
+
+func pinRoutingProducerRouteAdaptedConnect() string {
+	return `
+connect:
+  - from: producer.shared.ready
+    to: consumer.consumer.ready
+    adapter: producer-shared-to-consumer-ready
 `
 }
 

--- a/internal/runtime/bootverify/workflow_pin_routing_checks_test.go
+++ b/internal/runtime/bootverify/workflow_pin_routing_checks_test.go
@@ -27,6 +27,100 @@ func TestPinTargetResolution_AllowsExplicitBroadcastOptOut(t *testing.T) {
 	}
 }
 
+func TestPinTargetResolution_FailsClosedForProducerTargetCommonCompositionPath(t *testing.T) {
+	bundle := loadPinRoutingProducerRouteBundle(t, `
+      emit:
+        event: shared.ready
+        fields:
+          entity_id: payload.entity_id
+        target:
+          flow: consumer
+          match:
+            entity_id: payload.entity_id
+`, true)
+
+	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+	if !reportContains(report.Errors(), "pin_target_resolution", "producer_target_common_path_forbidden") {
+		t.Fatalf("expected producer_target_common_path_forbidden, got %#v", report.Errors())
+	}
+}
+
+func TestPinTargetResolution_FailsClosedForProducerBroadcastCommonCompositionPath(t *testing.T) {
+	bundle := loadPinRoutingProducerRouteBundle(t, `
+      emit:
+        event: shared.ready
+        fields:
+          entity_id: payload.entity_id
+        broadcast: true
+`, true)
+
+	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+	if !reportContains(report.Errors(), "pin_target_resolution", "producer_broadcast_common_path_forbidden") {
+		t.Fatalf("expected producer_broadcast_common_path_forbidden, got %#v", report.Errors())
+	}
+}
+
+func TestPinTargetResolution_FailsClosedForProducerTargetCommonPathEvenWithParentConnect(t *testing.T) {
+	bundle := loadPinRoutingProducerRouteBundle(t, `
+      emit:
+        event: shared.ready
+        fields:
+          entity_id: payload.entity_id
+        target:
+          flow: consumer
+          match:
+            entity_id: payload.entity_id
+`, true, pinRoutingProducerRouteConnect())
+
+	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+	if !reportContains(report.Errors(), "pin_target_resolution", "producer_target_common_path_forbidden") {
+		t.Fatalf("expected producer_target_common_path_forbidden with parent connect, got %#v", report.Errors())
+	}
+}
+
+func TestPinTargetResolution_AllowsExplicitTargetEscapeHatches(t *testing.T) {
+	for _, tt := range []struct {
+		name      string
+		emitBlock string
+	}{
+		{
+			name:      "sender",
+			emitBlock: "emit:\n        event: result.ready\n        target: sender\n",
+		},
+		{
+			name:      "instance_id",
+			emitBlock: "emit:\n        event: result.ready\n        target:\n          instance_id: worker-001\n",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			bundle := loadPinRoutingVerifyBundle(t, tt.emitBlock)
+			report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+			if reportContains(report.Errors(), "pin_target_resolution", "") {
+				t.Fatalf("unexpected pin_target_resolution error: %#v", report.Errors())
+			}
+		})
+	}
+}
+
+func TestPinTargetResolution_AllowsDynamicFlowMatchWhenNotPackageComposition(t *testing.T) {
+	bundle := loadPinRoutingProducerRouteBundle(t, `
+      emit:
+        event: shared.ready
+        fields:
+          entity_id: payload.entity_id
+        target:
+          flow: consumer
+          match:
+            entity_id: payload.entity_id
+          allow_fanout: true
+`, false)
+
+	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+	if reportContains(report.Errors(), "pin_target_resolution", "producer_target_common_path_forbidden") {
+		t.Fatalf("unexpected producer_target_common_path_forbidden for non-receiver dynamic target: %#v", report.Errors())
+	}
+}
+
 func TestPinTargetResolution_FailsClosedForRootPinOutputWithoutTargetMechanism(t *testing.T) {
 	bundle := loadPinRoutingVerifySourceFixture(t, pinRoutingVerifySourceFixture{
 		rootNodes: pinRoutingVerifyNodeYAML("root-node", "root.start", "root.ready", false),
@@ -171,6 +265,100 @@ worker-node:
 		t.Fatalf("LoadWorkflowContractBundleWithOverrides: %v", err)
 	}
 	return bundle
+}
+
+func loadPinRoutingProducerRouteBundle(t *testing.T, producerHandlerBody string, consumerConsumesSharedReady bool, connectBlocks ...string) *runtimecontracts.WorkflowContractBundle {
+	t.Helper()
+	root := t.TempDir()
+	writePinRoutingVerifyFile(t, filepath.Join(root, "package.yaml"), `
+name: pin-routing-producer-route
+version: "1.0.0"
+platform_version: ">=1.6.0"
+flows:
+  - id: producer
+    flow: producer
+    mode: static
+  - id: consumer
+    flow: consumer
+    mode: static
+`+strings.Join(connectBlocks, ""))
+	writePinRoutingVerifyFile(t, filepath.Join(root, "schema.yaml"), "name: pin-routing-producer-route\n")
+	writePinRoutingVerifyFile(t, filepath.Join(root, "policy.yaml"), "{}\n")
+	writePinRoutingVerifyFile(t, filepath.Join(root, "tools.yaml"), "{}\n")
+	writePinRoutingVerifyFile(t, filepath.Join(root, "agents.yaml"), "{}\n")
+	writePinRoutingVerifyFile(t, filepath.Join(root, "events.yaml"), "{}\n")
+	writePinRoutingVerifyFile(t, filepath.Join(root, "entities.yaml"), "{}\n")
+	writePinRoutingVerifyFile(t, filepath.Join(root, "flows", "producer", "schema.yaml"), `
+name: producer
+initial_state: pending
+states: [pending, done]
+terminal_states: [done]
+pins:
+  inputs:
+    events: [producer.start]
+  outputs:
+    events: [shared.ready]
+`)
+	writePinRoutingVerifyFile(t, filepath.Join(root, "flows", "producer", "events.yaml"), `
+producer.start:
+  entity_id: text
+shared.ready:
+  entity_id: text
+`)
+	writePinRoutingVerifyFile(t, filepath.Join(root, "flows", "producer", "entities.yaml"), `
+producer:
+  entity_id: text
+`)
+	writePinRoutingVerifyFile(t, filepath.Join(root, "flows", "producer", "nodes.yaml"), `
+producer-node:
+  id: producer-node
+  execution_type: system_node
+  event_handlers:
+    producer.start:
+`+producerHandlerBody+`
+`)
+	consumerInput := "events: [consumer.start]"
+	if consumerConsumesSharedReady {
+		consumerInput = "events: [shared.ready]"
+	}
+	writePinRoutingVerifyFile(t, filepath.Join(root, "flows", "consumer", "schema.yaml"), `
+name: consumer
+initial_state: pending
+states: [pending, done]
+terminal_states: [done]
+pins:
+  inputs:
+    `+consumerInput+`
+  outputs:
+    events: [consumer.done]
+`)
+	writePinRoutingVerifyFile(t, filepath.Join(root, "flows", "consumer", "events.yaml"), `
+consumer.start:
+  entity_id: text
+shared.ready:
+  entity_id: text
+consumer.done:
+  entity_id: text
+`)
+	writePinRoutingVerifyFile(t, filepath.Join(root, "flows", "consumer", "entities.yaml"), `
+consumer:
+  entity_id: text
+`)
+	writePinRoutingVerifyFile(t, filepath.Join(root, "flows", "consumer", "nodes.yaml"), "{}\n")
+	repoRoot := filepath.Clean(filepath.Join("..", "..", ".."))
+	bundle, err := runtimecontracts.LoadWorkflowContractBundleWithOverrides(repoRoot, root, runtimecontracts.DefaultPlatformSpecFile(repoRoot))
+	if err != nil {
+		t.Fatalf("LoadWorkflowContractBundleWithOverrides: %v", err)
+	}
+	return bundle
+}
+
+func pinRoutingProducerRouteConnect() string {
+	return `
+connect:
+  - from: producer.shared.ready
+    to: consumer.shared.ready
+`
 }
 
 type pinRoutingVerifySourceFixture struct {

--- a/internal/runtime/bootverify/workflow_pin_routing_checks_test.go
+++ b/internal/runtime/bootverify/workflow_pin_routing_checks_test.go
@@ -121,6 +121,45 @@ func TestPinTargetResolution_AllowsDynamicFlowMatchWhenNotPackageComposition(t *
 	}
 }
 
+func TestPinTargetResolution_DoesNotLeafMatchDistinctQualifiedEvents(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		body string
+	}{
+		{
+			name: "broadcast",
+			body: `
+      emit:
+        event: billing/order.completed
+        fields:
+          entity_id: payload.entity_id
+        broadcast: true
+`,
+		},
+		{
+			name: "target_flow_match",
+			body: `
+      emit:
+        event: billing/order.completed
+        fields:
+          entity_id: payload.entity_id
+        target:
+          flow: consumer
+          match:
+            entity_id: payload.entity_id
+`,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			bundle := loadPinRoutingProducerRouteBundleForEvents(t, "billing/order.completed", "shipping/order.completed", tt.body)
+			report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+			if reportContains(report.Errors(), "pin_target_resolution", "producer_") {
+				t.Fatalf("unexpected producer common-path failure for distinct qualified events: %#v", report.Errors())
+			}
+		})
+	}
+}
+
 func TestPinTargetResolution_FailsClosedForRootPinOutputWithoutTargetMechanism(t *testing.T) {
 	bundle := loadPinRoutingVerifySourceFixture(t, pinRoutingVerifySourceFixture{
 		rootNodes: pinRoutingVerifyNodeYAML("root-node", "root.start", "root.ready", false),
@@ -268,6 +307,14 @@ worker-node:
 }
 
 func loadPinRoutingProducerRouteBundle(t *testing.T, producerHandlerBody string, consumerConsumesSharedReady bool, connectBlocks ...string) *runtimecontracts.WorkflowContractBundle {
+	consumerInputEvent := "consumer.start"
+	if consumerConsumesSharedReady {
+		consumerInputEvent = "shared.ready"
+	}
+	return loadPinRoutingProducerRouteBundleForEvents(t, "shared.ready", consumerInputEvent, producerHandlerBody, connectBlocks...)
+}
+
+func loadPinRoutingProducerRouteBundleForEvents(t *testing.T, producerOutputEvent, consumerInputEvent, producerHandlerBody string, connectBlocks ...string) *runtimecontracts.WorkflowContractBundle {
 	t.Helper()
 	root := t.TempDir()
 	writePinRoutingVerifyFile(t, filepath.Join(root, "package.yaml"), `
@@ -297,12 +344,12 @@ pins:
   inputs:
     events: [producer.start]
   outputs:
-    events: [shared.ready]
+    events: [`+producerOutputEvent+`]
 `)
 	writePinRoutingVerifyFile(t, filepath.Join(root, "flows", "producer", "events.yaml"), `
 producer.start:
   entity_id: text
-shared.ready:
+`+producerOutputEvent+`:
   entity_id: text
 `)
 	writePinRoutingVerifyFile(t, filepath.Join(root, "flows", "producer", "entities.yaml"), `
@@ -317,10 +364,6 @@ producer-node:
     producer.start:
 `+producerHandlerBody+`
 `)
-	consumerInput := "events: [consumer.start]"
-	if consumerConsumesSharedReady {
-		consumerInput = "events: [shared.ready]"
-	}
 	writePinRoutingVerifyFile(t, filepath.Join(root, "flows", "consumer", "schema.yaml"), `
 name: consumer
 initial_state: pending
@@ -328,18 +371,23 @@ states: [pending, done]
 terminal_states: [done]
 pins:
   inputs:
-    `+consumerInput+`
+    events: [`+consumerInputEvent+`]
   outputs:
     events: [consumer.done]
 `)
-	writePinRoutingVerifyFile(t, filepath.Join(root, "flows", "consumer", "events.yaml"), `
+	consumerEvents := `
 consumer.start:
   entity_id: text
-shared.ready:
+`
+	if consumerInputEvent != "consumer.start" {
+		consumerEvents += consumerInputEvent + `:
   entity_id: text
-consumer.done:
+`
+	}
+	consumerEvents += `consumer.done:
   entity_id: text
-`)
+`
+	writePinRoutingVerifyFile(t, filepath.Join(root, "flows", "consumer", "events.yaml"), consumerEvents)
 	writePinRoutingVerifyFile(t, filepath.Join(root, "flows", "consumer", "entities.yaml"), `
 consumer:
   entity_id: text

--- a/internal/runtime/core/pinrouting/pinrouting.go
+++ b/internal/runtime/core/pinrouting/pinrouting.go
@@ -26,6 +26,8 @@ const (
 	FailureTargetUnknownFlow              TargetFailure = "target_unknown_flow"
 	FailureTargetSenderNoInboundRuntime   TargetFailure = "target_sender_no_inbound_runtime"
 	FailureTargetSenderEmptySourceRuntime TargetFailure = "target_sender_empty_source_runtime"
+	FailureProducerTargetCommonPath       TargetFailure = "producer_target_common_path_forbidden"
+	FailureProducerBroadcastCommonPath    TargetFailure = "producer_broadcast_common_path_forbidden"
 )
 
 type AuthoredTarget struct {
@@ -95,6 +97,142 @@ func PinDeclaredOutput(source semanticview.Source, flowID, eventType string) boo
 	return false
 }
 
+func ProducerRouteCommonPathFailure(source semanticview.Source, flowID, eventType string, spec runtimecontracts.EmitSpec) TargetFailure {
+	flowID = strings.TrimSpace(flowID)
+	eventType = eventidentity.Normalize(eventType)
+	if source == nil || eventType == "" || !PinDeclaredOutput(source, flowID, eventType) {
+		return ""
+	}
+	if flowID == "" {
+		return ""
+	}
+	if _, ok := source.FlowScopeByID(flowID); !ok {
+		return ""
+	}
+	if spec.Broadcast {
+		if producerRouteKnownReceiverConsumesOutput(source, flowID, eventType, "") {
+			return FailureProducerBroadcastCommonPath
+		}
+		return ""
+	}
+	target := spec.Target.Normalized()
+	if target.Empty() {
+		return ""
+	}
+	switch target.Kind {
+	case runtimecontracts.EmitTargetKindSender, runtimecontracts.EmitTargetKindInstanceID:
+		return ""
+	case runtimecontracts.EmitTargetKindFlowMatch:
+		if producerRouteKnownReceiverConsumesOutput(source, flowID, eventType, target.Flow) {
+			return FailureProducerTargetCommonPath
+		}
+	}
+	return ""
+}
+
+func compositionConnectsFromOutputEvent(source semanticview.Source, flowID, eventType string) bool {
+	if source == nil {
+		return false
+	}
+	for _, pin := range outputPinsForEvent(source, flowID, eventType) {
+		if len(source.CompositionConnectsFrom(flowID, pin.PinName())) > 0 {
+			return true
+		}
+	}
+	return false
+}
+
+func outputPinsForEvent(source semanticview.Source, flowID, eventType string) []runtimecontracts.FlowOutputEventPin {
+	if source == nil {
+		return nil
+	}
+	candidates := eventReferenceCandidates(source, flowID, eventType)
+	out := []runtimecontracts.FlowOutputEventPin{}
+	for _, pin := range source.FlowOutputEventPins(flowID) {
+		if eventCandidatesContain(candidates, pin.PinName()) ||
+			eventCandidatesContain(candidates, pin.EventType()) ||
+			eventCandidatesContain(candidates, source.ResolveFlowEventReference(flowID, pin.EventType())) {
+			out = append(out, pin)
+		}
+	}
+	return out
+}
+
+func producerRouteKnownReceiverConsumesOutput(source semanticview.Source, producerFlowID, eventType, targetFlowID string) bool {
+	if source == nil {
+		return false
+	}
+	producerFlowID = strings.TrimSpace(producerFlowID)
+	targetFlowID = strings.TrimSpace(targetFlowID)
+	if targetFlowID != "" {
+		if _, ok := source.FlowScopeByID(targetFlowID); !ok {
+			return false
+		}
+		return targetFlowID != producerFlowID && flowInputConsumesOutput(source, producerFlowID, eventType, targetFlowID)
+	}
+	for _, scope := range source.FlowScopes() {
+		receiverFlowID := strings.TrimSpace(scope.ID)
+		if receiverFlowID == "" || receiverFlowID == producerFlowID {
+			continue
+		}
+		if flowInputConsumesOutput(source, producerFlowID, eventType, receiverFlowID) {
+			return true
+		}
+	}
+	return false
+}
+
+func flowInputConsumesOutput(source semanticview.Source, producerFlowID, eventType, receiverFlowID string) bool {
+	if source == nil {
+		return false
+	}
+	outputCandidates := eventReferenceCandidates(source, producerFlowID, eventType)
+	for _, pin := range source.FlowInputEventPins(receiverFlowID) {
+		if eventCandidatesContain(outputCandidates, pin.PinName()) ||
+			eventCandidatesContain(outputCandidates, pin.EventType()) ||
+			eventCandidatesContain(outputCandidates, source.ResolveFlowEventReference(receiverFlowID, pin.EventType())) {
+			return true
+		}
+	}
+	return false
+}
+
+func eventReferenceCandidates(source semanticview.Source, flowID, eventType string) map[string]struct{} {
+	candidates := map[string]struct{}{}
+	addEventCandidate(candidates, eventType)
+	if source != nil {
+		addEventCandidate(candidates, source.ResolveFlowEventReference(flowID, eventType))
+	}
+	return candidates
+}
+
+func addEventCandidate(candidates map[string]struct{}, eventType string) {
+	eventType = eventidentity.Normalize(eventType)
+	if eventType == "" {
+		return
+	}
+	candidates[eventType] = struct{}{}
+	if leaf := eventidentity.LeafName(eventType); leaf != "" {
+		candidates[leaf] = struct{}{}
+	}
+}
+
+func eventCandidatesContain(candidates map[string]struct{}, eventType string) bool {
+	eventType = eventidentity.Normalize(eventType)
+	if eventType == "" {
+		return false
+	}
+	if _, ok := candidates[eventType]; ok {
+		return true
+	}
+	leaf := eventidentity.LeafName(eventType)
+	if leaf == "" {
+		return false
+	}
+	_, ok := candidates[leaf]
+	return ok
+}
+
 func rootPinDeclaredOutput(source semanticview.Source, eventType string) bool {
 	bundle, ok := semanticview.Bundle(source)
 	if !ok || bundle == nil || bundle.RootSchema == nil {
@@ -148,6 +286,12 @@ func ResolveEnvelope(input ResolutionInput, envelope events.EventEnvelope) Resol
 		envelope = events.EnvelopeForSourceRoute(envelope, input.SourceRoute)
 	}
 	if !PinDeclaredOutput(input.Source, input.FlowID, input.EventType) {
+		return Resolution{Envelope: envelope.Normalized()}
+	}
+	if failure := ProducerRouteCommonPathFailure(input.Source, input.FlowID, input.EventType, input.Emit); failure != "" {
+		return Resolution{Envelope: envelope.Normalized(), Failure: failure}
+	}
+	if compositionConnectsFromOutputEvent(input.Source, input.FlowID, input.EventType) {
 		return Resolution{Envelope: envelope.Normalized()}
 	}
 	if input.Emit.Broadcast {

--- a/internal/runtime/core/pinrouting/pinrouting.go
+++ b/internal/runtime/core/pinrouting/pinrouting.go
@@ -303,6 +303,9 @@ func ResolveEnvelope(input ResolutionInput, envelope events.EventEnvelope) Resol
 		return Resolution{Envelope: envelope.Normalized(), Failure: failure}
 	}
 	if compositionConnectsFromOutputEvent(input.Source, input.FlowID, input.EventType) {
+		if failure := ValidateTargetSpec(input.Source, input.FlowID, input.Emit, true); failure != "" {
+			return Resolution{Envelope: envelope.Normalized(), Failure: failure}
+		}
 		return Resolution{Envelope: envelope.Normalized()}
 	}
 	if input.Emit.Broadcast {

--- a/internal/runtime/core/pinrouting/pinrouting.go
+++ b/internal/runtime/core/pinrouting/pinrouting.go
@@ -146,12 +146,9 @@ func outputPinsForEvent(source semanticview.Source, flowID, eventType string) []
 	if source == nil {
 		return nil
 	}
-	candidates := eventReferenceCandidates(source, flowID, eventType)
 	out := []runtimecontracts.FlowOutputEventPin{}
 	for _, pin := range source.FlowOutputEventPins(flowID) {
-		if eventCandidatesContain(candidates, pin.PinName()) ||
-			eventCandidatesContain(candidates, pin.EventType()) ||
-			eventCandidatesContain(candidates, source.ResolveFlowEventReference(flowID, pin.EventType())) {
+		if eventReferencesOverlap(source, flowID, []string{eventType}, flowID, []string{pin.PinName(), pin.EventType()}) {
 			out = append(out, pin)
 		}
 	}
@@ -186,51 +183,65 @@ func flowInputConsumesOutput(source semanticview.Source, producerFlowID, eventTy
 	if source == nil {
 		return false
 	}
-	outputCandidates := eventReferenceCandidates(source, producerFlowID, eventType)
 	for _, pin := range source.FlowInputEventPins(receiverFlowID) {
-		if eventCandidatesContain(outputCandidates, pin.PinName()) ||
-			eventCandidatesContain(outputCandidates, pin.EventType()) ||
-			eventCandidatesContain(outputCandidates, source.ResolveFlowEventReference(receiverFlowID, pin.EventType())) {
+		if eventReferencesOverlap(source, producerFlowID, []string{eventType}, receiverFlowID, []string{pin.PinName(), pin.EventType()}) {
 			return true
 		}
 	}
 	return false
 }
 
-func eventReferenceCandidates(source semanticview.Source, flowID, eventType string) map[string]struct{} {
-	candidates := map[string]struct{}{}
-	addEventCandidate(candidates, eventType)
-	if source != nil {
-		addEventCandidate(candidates, source.ResolveFlowEventReference(flowID, eventType))
+func eventReferencesOverlap(source semanticview.Source, leftFlowID string, leftEvents []string, rightFlowID string, rightEvents []string) bool {
+	leftRefs := eventReferences(source, leftFlowID, leftEvents...)
+	rightRefs := eventReferences(source, rightFlowID, rightEvents...)
+	for _, left := range leftRefs {
+		for _, right := range rightRefs {
+			if eventReferencesMatch(left, right) {
+				return true
+			}
+		}
 	}
-	return candidates
+	return false
 }
 
-func addEventCandidate(candidates map[string]struct{}, eventType string) {
-	eventType = eventidentity.Normalize(eventType)
-	if eventType == "" {
-		return
+func eventReferences(source semanticview.Source, flowID string, eventTypes ...string) []string {
+	out := []string{}
+	seen := map[string]struct{}{}
+	add := func(eventType string) {
+		eventType = eventidentity.Normalize(eventType)
+		if eventType == "" {
+			return
+		}
+		if _, ok := seen[eventType]; ok {
+			return
+		}
+		seen[eventType] = struct{}{}
+		out = append(out, eventType)
 	}
-	candidates[eventType] = struct{}{}
-	if leaf := eventidentity.LeafName(eventType); leaf != "" {
-		candidates[leaf] = struct{}{}
+	for _, eventType := range eventTypes {
+		add(eventType)
+		if source != nil {
+			add(source.ResolveFlowEventReference(flowID, eventType))
+		}
 	}
+	return out
 }
 
-func eventCandidatesContain(candidates map[string]struct{}, eventType string) bool {
-	eventType = eventidentity.Normalize(eventType)
-	if eventType == "" {
+func eventReferencesMatch(left, right string) bool {
+	left = eventidentity.Normalize(left)
+	right = eventidentity.Normalize(right)
+	if left == "" || right == "" {
 		return false
 	}
-	if _, ok := candidates[eventType]; ok {
+	if left == right {
 		return true
 	}
-	leaf := eventidentity.LeafName(eventType)
-	if leaf == "" {
+	leftQualified := strings.Contains(left, "/")
+	rightQualified := strings.Contains(right, "/")
+	if leftQualified == rightQualified {
 		return false
 	}
-	_, ok := candidates[leaf]
-	return ok
+	return eventidentity.LeafName(left) == eventidentity.LeafName(right)
 }
 
 func rootPinDeclaredOutput(source semanticview.Source, eventType string) bool {

--- a/internal/runtime/core/pinrouting/pinrouting.go
+++ b/internal/runtime/core/pinrouting/pinrouting.go
@@ -110,7 +110,8 @@ func ProducerRouteCommonPathFailure(source semanticview.Source, flowID, eventTyp
 		return ""
 	}
 	if spec.Broadcast {
-		if producerRouteKnownReceiverConsumesOutput(source, flowID, eventType, "") {
+		if compositionConnectsFromOutputEvent(source, flowID, eventType) ||
+			producerRouteKnownReceiverConsumesOutput(source, flowID, eventType, "") {
 			return FailureProducerBroadcastCommonPath
 		}
 		return ""
@@ -123,7 +124,8 @@ func ProducerRouteCommonPathFailure(source semanticview.Source, flowID, eventTyp
 	case runtimecontracts.EmitTargetKindSender, runtimecontracts.EmitTargetKindInstanceID:
 		return ""
 	case runtimecontracts.EmitTargetKindFlowMatch:
-		if producerRouteKnownReceiverConsumesOutput(source, flowID, eventType, target.Flow) {
+		if compositionConnectsFromOutputEventToFlow(source, flowID, eventType, target.Flow) ||
+			producerRouteKnownReceiverConsumesOutput(source, flowID, eventType, target.Flow) {
 			return FailureProducerTargetCommonPath
 		}
 	}
@@ -137,6 +139,28 @@ func compositionConnectsFromOutputEvent(source semanticview.Source, flowID, even
 	for _, pin := range outputPinsForEvent(source, flowID, eventType) {
 		if len(source.CompositionConnectsFrom(flowID, pin.PinName())) > 0 {
 			return true
+		}
+	}
+	return false
+}
+
+func compositionConnectsFromOutputEventToFlow(source semanticview.Source, flowID, eventType, targetFlowID string) bool {
+	if source == nil {
+		return false
+	}
+	targetFlowID = strings.TrimSpace(targetFlowID)
+	if targetFlowID == "" {
+		return false
+	}
+	if _, ok := source.FlowScopeByID(targetFlowID); !ok {
+		return false
+	}
+	for _, pin := range outputPinsForEvent(source, flowID, eventType) {
+		for _, connect := range source.CompositionConnectsFrom(flowID, pin.PinName()) {
+			to, err := connect.ToRef()
+			if err == nil && strings.TrimSpace(to.FlowID) == targetFlowID {
+				return true
+			}
 		}
 	}
 	return false

--- a/internal/runtime/core/pinrouting/pinrouting_test.go
+++ b/internal/runtime/core/pinrouting/pinrouting_test.go
@@ -196,6 +196,28 @@ func TestResolveAllowsParentConnectToOwnPinDeclaredOutput(t *testing.T) {
 	}
 }
 
+func TestResolveFailsClosedForUnknownProducerTargetFlowEvenWithParentConnect(t *testing.T) {
+	result := Resolve(ResolutionInput{
+		Source:    testProducerConnectSource(),
+		FlowID:    "producer",
+		EventType: "shared.ready",
+		Emit: runtimecontracts.EmitSpec{
+			Target: runtimecontracts.EmitTargetSpec{
+				Flow:  "missing-consumer",
+				Match: map[string]runtimecontracts.ExpressionValue{"entity_id": runtimecontracts.RefExpression("payload.entity_id")},
+			},
+		},
+		MatchValues: map[string]string{"entity_id": "entity-1"},
+	}, events.NewProjectionEvent("", "shared.ready", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}))
+
+	if result.Failure != FailureTargetUnknownFlow {
+		t.Fatalf("Failure = %q, want %q", result.Failure, FailureTargetUnknownFlow)
+	}
+	if got := result.Event.TargetRoute(); !got.Empty() {
+		t.Fatalf("Event target = %#v, want empty on unknown producer target flow", got)
+	}
+}
+
 func TestResolveAllowsExplicitInstanceTargetEscape(t *testing.T) {
 	result := Resolve(ResolutionInput{
 		Source:    testProducerCommonPathSource(),

--- a/internal/runtime/core/pinrouting/pinrouting_test.go
+++ b/internal/runtime/core/pinrouting/pinrouting_test.go
@@ -108,6 +108,103 @@ func TestResolveFailsClosedForRootPinOutputWithoutTargetMechanism(t *testing.T) 
 	}
 }
 
+func TestResolveFailsClosedForProducerTargetCommonCompositionPath(t *testing.T) {
+	result := Resolve(ResolutionInput{
+		Source:    testProducerCommonPathSource(),
+		FlowID:    "producer",
+		EventType: "shared.ready",
+		Emit: runtimecontracts.EmitSpec{
+			Target: runtimecontracts.EmitTargetSpec{
+				Flow:  "consumer",
+				Match: map[string]runtimecontracts.ExpressionValue{"entity_id": runtimecontracts.RefExpression("payload.entity_id")},
+			},
+		},
+		MatchValues: map[string]string{"entity_id": "entity-1"},
+		Descriptors: []Descriptor{{
+			EntityID:     "entity-1",
+			FlowInstance: "consumer/inst-1",
+		}},
+	}, events.NewProjectionEvent("", "shared.ready", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}))
+
+	if result.Failure != FailureProducerTargetCommonPath {
+		t.Fatalf("Failure = %q, want %q", result.Failure, FailureProducerTargetCommonPath)
+	}
+	if got := result.Event.TargetRoute(); !got.Empty() {
+		t.Fatalf("Event target = %#v, want empty on producer target common path", got)
+	}
+}
+
+func TestResolveFailsClosedForProducerBroadcastCommonCompositionPath(t *testing.T) {
+	result := Resolve(ResolutionInput{
+		Source:    testProducerCommonPathSource(),
+		FlowID:    "producer",
+		EventType: "shared.ready",
+		Emit: runtimecontracts.EmitSpec{
+			Broadcast: true,
+		},
+	}, events.NewProjectionEvent("", "shared.ready", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}))
+
+	if result.Failure != FailureProducerBroadcastCommonPath {
+		t.Fatalf("Failure = %q, want %q", result.Failure, FailureProducerBroadcastCommonPath)
+	}
+	if result.Broadcast {
+		t.Fatal("Broadcast = true, want false on producer broadcast common path")
+	}
+}
+
+func TestResolveAllowsParentConnectToOwnPinDeclaredOutput(t *testing.T) {
+	result := Resolve(ResolutionInput{
+		Source:    testProducerConnectSource(),
+		FlowID:    "producer",
+		EventType: "shared.ready",
+	}, events.NewProjectionEvent("", "shared.ready", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}))
+
+	if result.Failure != "" {
+		t.Fatalf("Failure = %q, want empty", result.Failure)
+	}
+	if got := result.Event.TargetRoute(); !got.Empty() {
+		t.Fatalf("Event target = %#v, want empty before EventBus RoutePlan", got)
+	}
+}
+
+func TestResolveAllowsExplicitInstanceTargetEscape(t *testing.T) {
+	result := Resolve(ResolutionInput{
+		Source:    testProducerCommonPathSource(),
+		FlowID:    "producer",
+		EventType: "shared.ready",
+		Emit: runtimecontracts.EmitSpec{
+			Target: runtimecontracts.EmitTargetSpec{
+				InstanceID: "producer-1",
+			},
+		},
+	}, events.NewProjectionEvent("", "shared.ready", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}))
+
+	if result.Failure != "" {
+		t.Fatalf("Failure = %q, want empty", result.Failure)
+	}
+	if result.Target.FlowID != "producer" {
+		t.Fatalf("Target.FlowID = %q, want producer", result.Target.FlowID)
+	}
+}
+
+func TestResolveAllowsBroadcastWhenNoPackageReceiverConsumesOutput(t *testing.T) {
+	result := Resolve(ResolutionInput{
+		Source:    testPinRoutingSource(),
+		FlowID:    "child",
+		EventType: "child.done",
+		Emit: runtimecontracts.EmitSpec{
+			Broadcast: true,
+		},
+	}, events.NewProjectionEvent("", "child.done", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}))
+
+	if result.Failure != "" {
+		t.Fatalf("Failure = %q, want empty", result.Failure)
+	}
+	if !result.Broadcast {
+		t.Fatal("Broadcast = false, want true")
+	}
+}
+
 func TestResolveFlowMatchTargetsActiveDynamicInstanceByInstanceID(t *testing.T) {
 	source := testFlowMatchPinRoutingSource()
 	const flowInstance = "component-scaffold/aaaaaaaa-1111-4111-8111-aaaaaaaa1111"
@@ -271,6 +368,78 @@ func testPinRoutingSource() semanticview.Source {
 			},
 			ByID: map[string]*runtimecontracts.FlowContractView{
 				"child": &child,
+			},
+		},
+	})
+}
+
+func testProducerCommonPathSource() semanticview.Source {
+	return testProducerRouteSource(nil)
+}
+
+func testProducerConnectSource() semanticview.Source {
+	return testProducerRouteSource([]runtimecontracts.FlowPackageConnect{{
+		From: "producer.shared.ready",
+		To:   "consumer.shared.ready",
+	}})
+}
+
+func testProducerRouteSource(connects []runtimecontracts.FlowPackageConnect) semanticview.Source {
+	producer := runtimecontracts.FlowContractView{
+		Paths: runtimecontracts.FlowContractPaths{
+			ID:   "producer",
+			Flow: "producer",
+		},
+		Schema: runtimecontracts.FlowSchemaDocument{
+			Pins: runtimecontracts.FlowPins{
+				Outputs: runtimecontracts.FlowOutputPins{
+					Events: []string{"shared.ready"},
+				},
+			},
+		},
+		Path: "producer",
+	}
+	consumer := runtimecontracts.FlowContractView{
+		Paths: runtimecontracts.FlowContractPaths{
+			ID:   "consumer",
+			Flow: "consumer",
+		},
+		Schema: runtimecontracts.FlowSchemaDocument{
+			Pins: runtimecontracts.FlowPins{
+				Inputs: runtimecontracts.FlowInputPins{
+					Events: []string{"shared.ready"},
+				},
+			},
+		},
+		Path: "consumer",
+	}
+	return semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
+		FlowSchemas: map[string]runtimecontracts.FlowSchemaDocument{
+			"producer": producer.Schema,
+			"consumer": consumer.Schema,
+		},
+		Semantics: runtimecontracts.WorkflowSemanticView{
+			FlowInputs: map[string][]string{
+				"consumer": {"shared.ready"},
+			},
+			FlowOutputs: map[string][]string{
+				"producer": {"shared.ready"},
+			},
+			FlowInputEventPins: map[string][]runtimecontracts.FlowInputEventPin{
+				"consumer": {{Name: "shared.ready", Event: "shared.ready"}},
+			},
+			FlowOutputEventPins: map[string][]runtimecontracts.FlowOutputEventPin{
+				"producer": {{Name: "shared.ready", Event: "shared.ready"}},
+			},
+			CompositionConnects: connects,
+		},
+		FlowTree: flowmodel.Tree[runtimecontracts.FlowContractView]{
+			Root: &runtimecontracts.FlowContractView{
+				Children: []runtimecontracts.FlowContractView{producer, consumer},
+			},
+			ByID: map[string]*runtimecontracts.FlowContractView{
+				"producer": &producer,
+				"consumer": &consumer,
 			},
 		},
 	})

--- a/internal/runtime/core/pinrouting/pinrouting_test.go
+++ b/internal/runtime/core/pinrouting/pinrouting_test.go
@@ -152,6 +152,50 @@ func TestResolveFailsClosedForProducerBroadcastCommonCompositionPath(t *testing.
 	}
 }
 
+func TestResolveFailsClosedForProducerTargetAdaptedConnectCommonPath(t *testing.T) {
+	result := Resolve(ResolutionInput{
+		Source:    testProducerAdaptedConnectSource(),
+		FlowID:    "producer",
+		EventType: "shared.ready",
+		Emit: runtimecontracts.EmitSpec{
+			Target: runtimecontracts.EmitTargetSpec{
+				Flow:  "consumer",
+				Match: map[string]runtimecontracts.ExpressionValue{"entity_id": runtimecontracts.RefExpression("payload.entity_id")},
+			},
+		},
+		MatchValues: map[string]string{"entity_id": "entity-1"},
+		Descriptors: []Descriptor{{
+			EntityID:     "entity-1",
+			FlowInstance: "consumer/inst-1",
+		}},
+	}, events.NewProjectionEvent("", "shared.ready", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}))
+
+	if result.Failure != FailureProducerTargetCommonPath {
+		t.Fatalf("Failure = %q, want %q", result.Failure, FailureProducerTargetCommonPath)
+	}
+	if got := result.Event.TargetRoute(); !got.Empty() {
+		t.Fatalf("Event target = %#v, want empty on adapted producer target common path", got)
+	}
+}
+
+func TestResolveFailsClosedForProducerBroadcastAdaptedConnectCommonPath(t *testing.T) {
+	result := Resolve(ResolutionInput{
+		Source:    testProducerAdaptedConnectSource(),
+		FlowID:    "producer",
+		EventType: "shared.ready",
+		Emit: runtimecontracts.EmitSpec{
+			Broadcast: true,
+		},
+	}, events.NewProjectionEvent("", "shared.ready", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}))
+
+	if result.Failure != FailureProducerBroadcastCommonPath {
+		t.Fatalf("Failure = %q, want %q", result.Failure, FailureProducerBroadcastCommonPath)
+	}
+	if result.Broadcast {
+		t.Fatal("Broadcast = true, want false on adapted producer broadcast common path")
+	}
+}
+
 func TestProducerRouteCommonPathDoesNotLeafMatchDistinctQualifiedEvents(t *testing.T) {
 	source := testProducerQualifiedMismatchSource()
 	for _, tt := range []struct {
@@ -432,6 +476,14 @@ func testProducerConnectSource() semanticview.Source {
 	return testProducerRouteSource([]runtimecontracts.FlowPackageConnect{{
 		From: "producer.shared.ready",
 		To:   "consumer.shared.ready",
+	}})
+}
+
+func testProducerAdaptedConnectSource() semanticview.Source {
+	return testProducerRouteSourceWithEvents("shared.ready", "consumer.ready", []runtimecontracts.FlowPackageConnect{{
+		From:    "producer.shared.ready",
+		To:      "consumer.consumer.ready",
+		Adapter: "producer-shared-to-consumer-ready",
 	}})
 }
 

--- a/internal/runtime/core/pinrouting/pinrouting_test.go
+++ b/internal/runtime/core/pinrouting/pinrouting_test.go
@@ -152,6 +152,35 @@ func TestResolveFailsClosedForProducerBroadcastCommonCompositionPath(t *testing.
 	}
 }
 
+func TestProducerRouteCommonPathDoesNotLeafMatchDistinctQualifiedEvents(t *testing.T) {
+	source := testProducerQualifiedMismatchSource()
+	for _, tt := range []struct {
+		name string
+		emit runtimecontracts.EmitSpec
+	}{
+		{
+			name: "broadcast",
+			emit: runtimecontracts.EmitSpec{Broadcast: true},
+		},
+		{
+			name: "target_flow_match",
+			emit: runtimecontracts.EmitSpec{
+				Target: runtimecontracts.EmitTargetSpec{
+					Flow:  "consumer",
+					Match: map[string]runtimecontracts.ExpressionValue{"entity_id": runtimecontracts.RefExpression("payload.entity_id")},
+				},
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			failure := ProducerRouteCommonPathFailure(source, "producer", "billing/order.completed", tt.emit)
+			if failure != "" {
+				t.Fatalf("ProducerRouteCommonPathFailure = %q, want empty for distinct qualified receiver event", failure)
+			}
+		})
+	}
+}
+
 func TestResolveAllowsParentConnectToOwnPinDeclaredOutput(t *testing.T) {
 	result := Resolve(ResolutionInput{
 		Source:    testProducerConnectSource(),
@@ -384,7 +413,15 @@ func testProducerConnectSource() semanticview.Source {
 	}})
 }
 
+func testProducerQualifiedMismatchSource() semanticview.Source {
+	return testProducerRouteSourceWithEvents("billing/order.completed", "shipping/order.completed", nil)
+}
+
 func testProducerRouteSource(connects []runtimecontracts.FlowPackageConnect) semanticview.Source {
+	return testProducerRouteSourceWithEvents("shared.ready", "shared.ready", connects)
+}
+
+func testProducerRouteSourceWithEvents(outputEvent, inputEvent string, connects []runtimecontracts.FlowPackageConnect) semanticview.Source {
 	producer := runtimecontracts.FlowContractView{
 		Paths: runtimecontracts.FlowContractPaths{
 			ID:   "producer",
@@ -393,7 +430,7 @@ func testProducerRouteSource(connects []runtimecontracts.FlowPackageConnect) sem
 		Schema: runtimecontracts.FlowSchemaDocument{
 			Pins: runtimecontracts.FlowPins{
 				Outputs: runtimecontracts.FlowOutputPins{
-					Events: []string{"shared.ready"},
+					Events: []string{outputEvent},
 				},
 			},
 		},
@@ -407,7 +444,7 @@ func testProducerRouteSource(connects []runtimecontracts.FlowPackageConnect) sem
 		Schema: runtimecontracts.FlowSchemaDocument{
 			Pins: runtimecontracts.FlowPins{
 				Inputs: runtimecontracts.FlowInputPins{
-					Events: []string{"shared.ready"},
+					Events: []string{inputEvent},
 				},
 			},
 		},
@@ -420,16 +457,16 @@ func testProducerRouteSource(connects []runtimecontracts.FlowPackageConnect) sem
 		},
 		Semantics: runtimecontracts.WorkflowSemanticView{
 			FlowInputs: map[string][]string{
-				"consumer": {"shared.ready"},
+				"consumer": {inputEvent},
 			},
 			FlowOutputs: map[string][]string{
-				"producer": {"shared.ready"},
+				"producer": {outputEvent},
 			},
 			FlowInputEventPins: map[string][]runtimecontracts.FlowInputEventPin{
-				"consumer": {{Name: "shared.ready", Event: "shared.ready"}},
+				"consumer": {{Name: inputEvent, Event: inputEvent}},
 			},
 			FlowOutputEventPins: map[string][]runtimecontracts.FlowOutputEventPin{
-				"producer": {{Name: "shared.ready", Event: "shared.ready"}},
+				"producer": {{Name: outputEvent, Event: outputEvent}},
 			},
 			CompositionConnects: connects,
 		},

--- a/internal/runtime/testdata/generic-swarm-bundle/flows/intake/nodes.yaml
+++ b/internal/runtime/testdata/generic-swarm-bundle/flows/intake/nodes.yaml
@@ -42,7 +42,6 @@ intake-router:
           advances_to: ready
           emit:
             event: item.review_requested
-            broadcast: true
       sets_gate: intake_ready
       clear_gates:
         - needs_revision

--- a/internal/runtime/testdata/generic-swarm-bundle/flows/processing/nodes.yaml
+++ b/internal/runtime/testdata/generic-swarm-bundle/flows/processing/nodes.yaml
@@ -22,11 +22,9 @@ processing-node:
           then:
             emit:
               event: item.completed
-              broadcast: true
           else:
             emit:
               event: item.rejected
-              broadcast: true
       compute:
         operation: pick_or_average
         store_as: score
@@ -43,13 +41,11 @@ processing-node:
           advances_to: approved
           emit:
             event: item.completed
-            broadcast: true
         reject:
           condition: else
           advances_to: rejected
           emit:
             event: item.rejected
-            broadcast: true
       sets_gate: score_ready
       clear_gates:
         - intake_open

--- a/internal/runtime/testdata/generic-swarm-bundle/package.yaml
+++ b/internal/runtime/testdata/generic-swarm-bundle/package.yaml
@@ -12,3 +12,13 @@ flows:
   - id: delivery
     flow: delivery
     mode: template
+connect:
+  - from: intake.item.review_requested
+    to: processing.item.review_requested
+  - from: intake.item.rejected
+    to: processing.item.rejected
+  - from: processing.item.completed
+    to: delivery.item.completed
+    delivery: broadcast
+  - from: processing.item.rejected
+    to: intake.item.rejected

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -664,8 +664,8 @@ contract_formats:
           - persisted delivery rows, pipeline receipts, and committed replay scope as separate owners
           unsupported_or_split:
             business_field_descriptor_targets: 'Declared top-level receiver entity fields with indexed: true are implemented by #1479; nested entity paths, arbitrary, undeclared, unindexed, config, and instance business-field descriptor targets remain split to #1466 or later gated children.'
-            agent_node_emitter_parity: 'Closed by #1474: generated agent emit tools and node/system emits for supported connected output pins consume the same EventBus RoutePlan authority from lowered parent connect facts. Producer target/broadcast retirement remains split to #1475; broader composition-first closure remains #1466.'
-            producer_target_broadcast_retirement: '#1475 remains open.'
+            agent_node_emitter_parity: 'Closed by #1474: generated agent emit tools and node/system emits for supported connected output pins consume the same EventBus RoutePlan authority from lowered parent connect facts.'
+            producer_target_broadcast_retirement: 'Closed by #1475 for loaded flow-scope target.flow/match and broadcast:true common-path package composition; broader root/package composition-first closure remains #1466.'
             selected_contract_runfork_readiness: 'Tracked under #1466/watchlist; not closed by #1473.'
             parent_composition_routing_closure: '#1466 remains open.'
         inputs:
@@ -1665,21 +1665,25 @@ handler_specification:
         target: optional controlled dynamic-routing escape hatch. Valid forms are sender, {instance_id}, {flow, match},
           and {flow, match, allow_fanout}. This field is not payload and is the only producer-authored path that may ask
           the platform to populate event.target or event.target_set. It is not the common consumer-routing surface for
-          parent-composed flow packages; common cross-flow delivery is owned by parent connect lowering.
+          parent-composed flow packages; common cross-flow delivery is owned by parent connect lowering. A loaded flow-scope
+          producer target that selects a loaded package receiver input for the same pin-declared output is invalid common-path
+          routing, not an escape hatch.
         broadcast: optional boolean. Only true is meaningful. For a pin-declared output, broadcast:true is an explicit
           producer-authored opt-out escape hatch that leaves event.target absent. Parent-authored broadcast/fan-out uses
-          connect lowering rather than producer broadcast.
+          connect lowering rather than producer broadcast. Loaded flow-scope producer broadcast is invalid when it is used
+          as package-internal delivery to known receiver input pins that require parent connect topology.
       pin_routing_activation:
         rule: Pin routing activates if and only if the emitted event is declared in the emitter flow's schema.yaml pins.outputs.events.
         ad_hoc_emits: Emits not declared in pins.outputs.events are ordinary event-loop emits and do not require target or broadcast.
         target_requirement: A pin-declared output emit in parent-composed topology MUST resolve through lowered parent connect
-          facts, use the explicit target escape hatch, use structural child-to-parent ParentRoute binding, use the static
-          no-instance child-flow delivery-entity route where eligible, or declare broadcast:true. No silent fallback to
-          event-type broadcast is allowed.
+          facts, use structural child-to-parent ParentRoute binding, or use the static no-instance child-flow delivery-entity
+          route where eligible. Explicit target and broadcast remain escape hatches only for cases outside known
+          parent-composed receiver-input routing. No silent fallback to event-type broadcast is allowed.
         explicit_target_precedence: Producer target is an exceptional dynamic-routing escape hatch, not the common route
           owner for parent-composed topology. Lowered parent connect remains the common source authority for connected pins;
-          structural binding writes event.target only when the emit site has no explicit target, no lowered connect target
-          applies, and broadcast:true is absent.
+          loaded flow-scope producer target/broadcast on the common path must be removed or fail closed even if a parent
+          connect is also present. Structural binding writes event.target only when the emit site has no explicit target,
+          no lowered connect target applies, and broadcast:true is absent.
       target_forms:
         sender: Copy inbound event.source into the new event.target. Sender is the immediate inbound sender, not a chain ancestor.
         instance_id: Resolve a target instance in the addressed child/template scope using the instance_id known to the producer.
@@ -1694,6 +1698,10 @@ handler_specification:
         target_unknown_flow: target.flow names a flow outside the loaded registry.
         target_sender_no_inbound: target:sender is used where no inbound event source can exist.
         target_sender_empty_source: target:sender is used where inbound source is statically external or empty.
+        producer_target_common_path_forbidden: A loaded flow-scope producer target.flow/match selects a loaded package
+          receiver input for the same pin-declared output; parent connect is the required route owner.
+        producer_broadcast_common_path_forbidden: Loaded flow-scope broadcast:true is used as package-internal delivery to
+          known receiver input pins for the same pin-declared output; parent connect broadcast/fan-out is the required route owner.
       single_emit_handler_rule: 'A handler top-level emit is valid only when the handler has exactly one possible emit site.
         If the handler also declares rules, on_complete, accumulate.on_timeout, or fan_out emit, boot fails with ambiguity.
         Payload ownership must move to the active emit site.'
@@ -2123,7 +2131,8 @@ engine:
       - source fallback for explicit broadcast or legacy external paths
       explicit_target_escape_hatch: Producer target is only an exceptional dynamic-routing escape hatch. It must not be
         treated as the common parent-composed routing owner and must not replace lowered parent connect as the common source
-        authority for connected pins.
+        authority for connected pins. target.flow/match from a loaded flow-scope producer that selects a loaded package
+        receiver input for the same pin-declared output is illegal common-path composition routing, including when a parent connect also exists.
       fail_closed: A pin-declared output that has no lowered parent connect route, no explicit target escape hatch, no structural
         ParentRoute, no eligible static child delivery-entity route, and no broadcast:true is invalid.
       no_silent_broadcast_fallback: Missing, malformed, ambiguous, or unreachable targets must fail with a typed reason.
@@ -2136,17 +2145,21 @@ engine:
         is explicit because a parent can have many children of the same flow type.
       flow_match: |
         `target: { flow, match }` resolves target.flow plus declared entity-field matches to exactly one target instance.
-        Zero matches and more than one match fail closed at publish time.
+        Zero matches and more than one match fail closed at publish time. From loaded flow-scope producers, it is forbidden
+        as package-internal composition routing when target.flow has a receiver input for the same pin-declared output event;
+        parent connect owns that route.
       flow_match_allow_fanout: |
         `target: { flow, match, allow_fanout: true }` is the explicit dynamic fan-out escape hatch for flow/match targeting.
         It permits more than one matched recipient. Parent-authored fan-out should use connect topology. Publish-time
         resolution materializes event.target_set as the concrete ordered recipient route list, leaves singular event.target
-        absent on the persisted event, and persists one delivery target per recipient. The authored flow/match selector is
-        not the persisted routing authority after resolution.
+        absent on the persisted event, and persists one delivery target per recipient. It is not valid as a compatibility
+        surface for package-internal fan-out that parent connect/broadcast lowering can express. The authored flow/match
+        selector is not the persisted routing authority after resolution.
       broadcast: |
         `broadcast: true` is the producer-authored explicit opt-out escape hatch for pin-declared output routing. It leaves
         event.target absent and uses the ordinary no-target event-type delivery path. Parent-authored broadcast/fan-out should
-        use connect topology and lower to concrete route-plan facts.
+        use connect topology and lower to concrete route-plan facts. From loaded flow-scope producers, broadcast:true is
+        forbidden when it functions as package-internal delivery to loaded receiver input pins for the same pin-declared output.
     structural_binding:
       precedence_guard: Structural binding is lower precedence than lowered parent connect and the explicit target escape
         hatch. It may write event.target only for a child-to-parent pin output when no lowered parent connect target applies,
@@ -2206,6 +2219,10 @@ engine:
         target_unknown_flow: target.flow does not exist in the loaded flow registry.
         target_sender_no_inbound: target:sender appears on a handler whose only triggers cannot supply inbound source.
         target_sender_empty_source: target:sender appears on a handler subscribed only to external-sourced events with empty source.
+        producer_target_common_path_forbidden: A loaded flow-scope producer target.flow/match selects a loaded package
+          receiver input for the same pin-declared output; parent connect is the required route owner.
+        producer_broadcast_common_path_forbidden: Loaded flow-scope broadcast:true is used as package-internal delivery to
+          known receiver input pins for the same pin-declared output; parent connect broadcast/fan-out is the required route owner.
       publish_time_dead_letter:
         target_unreachable_no_subscriber: Target resolution finds no recipient for the requested target.
         target_unreachable_terminated: Target or ParentRoute referred to an instance that no longer exists.
@@ -4216,7 +4233,9 @@ engine:
       trigger: A pin-declared output emit lacks a lowered parent connect route, explicit target escape hatch, structural
         ParentRoute eligibility, eligible static child delivery-entity route, or broadcast:true; has malformed target syntax;
         references an unknown target.flow; uses
-        target:sender where no inbound source can exist; or uses target:sender only on external-sourced inputs with empty source.
+        target:sender where no inbound source can exist; uses target:sender only on external-sourced inputs with empty
+        source; or uses loaded flow-scope producer target/broadcast as package-internal delivery to a known receiver input
+        where parent connect is required.
       when: boot-only
     - id: redundant_in_topology_select_entity
       severity: warning
@@ -5101,6 +5120,42 @@ flow_model:
           - '#1475 producer target/broadcast retirement'
           - '#1466 composition-first parent closure'
           - '#1444 final turnkey composition behavior'
+        implementation_slice_1475:
+          status: merge_bearing_runtime_behavior
+          canonical_code_owner: internal/runtime/core/pinrouting.ProducerRouteCommonPathFailure consumed by internal/runtime/bootverify and runtime pin-route resolution
+          rule: |
+            Producer-authored emit.target and broadcast:true are retained as
+            explicit escape-hatch syntax, but they are not valid common-path
+            composition routing for loaded package receiver inputs from loaded
+            flow-scope producers. If a pin-declared flow output targets a
+            loaded receiver flow input for the same event with target.flow/match,
+            or broadcasts to loaded package receiver inputs for the same event,
+            verification and runtime resolution MUST fail closed with a typed
+            reason. Adding a parent connect does not grandfather the producer
+            target/broadcast writer; the producer route must be removed or
+            proven to be a different escape hatch. Parent connect remains the
+            topology owner and EventBus RoutePlan remains the concrete delivery
+            authority. Root-level producer target/broadcast composition remains
+            a #1466/root-connect source-authority residual, not part of this
+            closed child slice.
+          consumes:
+          - loaded flow-scope producer output pin event identity
+          - authored emit target/broadcast syntax
+          - loaded package receiver input pins
+          - parent composition route-authority contract from #1466
+          produces:
+          - producer_target_common_path_forbidden for loaded flow-scope target.flow/match common-path composition
+          - producer_broadcast_common_path_forbidden for loaded flow-scope broadcast:true common-path composition
+          - preserved sender, explicit instance_id, genuine dynamic flow/match, target_set, and external/no-receiver broadcast escape hatches
+          proof_obligations:
+          - bootverify rejects loaded flow-scope target.flow/match and broadcast:true when used as package-internal composition routing
+          - runtime pin-route resolution rejects the same stale producer route before it can populate event.target or event.target_set
+          - explicit sender, instance_id, genuine dynamic flow/match/allow_fanout, target_set, and external/no-receiver broadcast remain supported escape hatches
+          - connected agent/node output pins continue through EventBus RoutePlan without relay nodes or producer target/broadcast
+          does_not_close:
+          - '#1466 composition-first parent closure'
+          - '#1474 already closed generated agent/node EventBus RoutePlan consumption'
+          - '#1479 already closed declared indexed business-field descriptor materialization'
         implementation_slice_1485:
           status: merge_bearing_runtime_behavior
           canonical_code_owner: internal/runtime/bus.connectRoutePlanResolver with connectReceiverCarrierRouteKeys
@@ -5215,7 +5270,7 @@ flow_model:
         - Must not satisfy parent connect requirements for imported package public pins.
         - Must not be introduced as a producer route-default surface.
       split_boundaries:
-        runtime_route_consumption: '#1473 closes supported EventBus publish/preflight/outbox consumption of lowered ConnectRoutePlan artifacts only; selected-contract runfork readiness, full agent/node parity, producer target/broadcast retirement, and parent #1466 closure remain separate tracked work.'
+        runtime_route_consumption: '#1473 closes supported EventBus publish/preflight/outbox consumption of lowered ConnectRoutePlan artifacts only; selected-contract runfork readiness, full agent/node parity, and parent #1466 closure remain separate tracked work. Loaded flow-scope producer target/broadcast common-path retirement is closed by #1475.'
         parser_model_support: Parser/model support beyond source-authority fixtures is follow-up unless an implementation gate explicitly widens.
         policy_credential_resolution: '#1453 remains separate.'
         wildcard_scoping: '#1454 remains separate.'
@@ -8741,8 +8796,8 @@ static_analyzer:
       description: For every system-node emit site whose emitted event is declared in the emitter flow's pins.outputs.events,
         verify that the authored contract supplies lowered parent connect topology, a valid target escape hatch, structural
         binding only when no lowered connect route applies, eligible static child delivery-entity routing, or explicit broadcast
-        opt-out. Current runtime implementation may still enforce the pre-connect target surface until the composition-routing
-        migration child lands; this slice is not the canonical parent-composed route owner.
+        opt-out. Loaded flow-scope producer target/broadcast that selects a known package receiver input for the same
+        pin-declared output is rejected as common-path composition routing; parent connect is the route owner.
       applies_to:
       - handler top-level single-emit
       - rules entries
@@ -8763,7 +8818,9 @@ static_analyzer:
         - instance_id
         - flow_match
         - flow_match_allow_fanout
-      rule: Target form must be syntactically valid and reference loaded flow topology where statically known.
+        rule: Target form must be syntactically valid and reference loaded flow topology where statically known. flow_match
+          target forms from loaded flow-scope producers are invalid when they select a loaded package receiver input for the
+          same pin-declared output instead of acting as a genuine dynamic escape hatch.
       fanout_representation:
         rule: flow_match_allow_fanout resolves to event.target_set, not singular event.target. The runtime must persist concrete
           target_set route identities and one delivery target per recipient; it must not persist only the authored selector.
@@ -8775,7 +8832,9 @@ static_analyzer:
           implicit target route for pin-declared outputs; root static flows still require an explicit target or broadcast:true.
           This path is not ParentRoute metadata and must not fall back to inbound event.source.
       explicit_broadcast:
-        rule: broadcast:true is a deliberate opt-out and is the only no-target form accepted for a pin-declared output.
+        rule: broadcast:true is a deliberate opt-out and is the only no-target form accepted for a pin-declared output when
+          no loaded package receiver input consumes the same output event from a loaded flow-scope producer. Parent-composed
+          broadcast/fan-out uses connect.
     static_failure_reasons:
       target_required_missing: No lowered parent connect route, no explicit target escape hatch, no structural ParentRoute
         eligibility, no eligible static child delivery-entity route, and no broadcast:true.
@@ -8783,6 +8842,10 @@ static_analyzer:
       target_unknown_flow: target.flow is not present in the loaded flow registry.
       target_sender_no_inbound: target:sender is used from a handler whose only triggers cannot supply inbound event.source.
       target_sender_empty_source: target:sender is used only from external-sourced event types with empty source.
+      producer_target_common_path_forbidden: A loaded flow-scope producer target.flow/match selects a loaded package
+        receiver input for the same pin-declared output; parent connect is the required route owner.
+      producer_broadcast_common_path_forbidden: Loaded flow-scope broadcast:true is used as package-internal delivery to
+        known receiver input pins for the same pin-declared output; parent connect broadcast/fan-out is the required route owner.
     runtime_failure_reasons:
       publish_time_dead_letter:
       - target_unreachable_no_subscriber
@@ -8793,6 +8856,8 @@ static_analyzer:
       emit_time_tool_error:
       - target_sender_no_inbound_runtime
       - target_sender_empty_source_runtime
+      - producer_target_common_path_forbidden
+      - producer_broadcast_common_path_forbidden
     rule: Emit hard invalidity for every statically detectable missing or malformed accepted pin route source. Runtime failure
       reasons cover the cases boot verification cannot prove; no case may silently fall back to broadcast.
   slice_3a1_composition_connect_validation:

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -1666,8 +1666,8 @@ handler_specification:
           and {flow, match, allow_fanout}. This field is not payload and is the only producer-authored path that may ask
           the platform to populate event.target or event.target_set. It is not the common consumer-routing surface for
           parent-composed flow packages; common cross-flow delivery is owned by parent connect lowering. A loaded flow-scope
-          producer target that selects a loaded package receiver input for the same pin-declared output is invalid common-path
-          routing, not an escape hatch.
+          producer target that selects a loaded package receiver input for the same pin-declared output or a receiver flow
+          reached by the parent connect graph is invalid common-path routing, not an escape hatch.
         broadcast: optional boolean. Only true is meaningful. For a pin-declared output, broadcast:true is an explicit
           producer-authored opt-out escape hatch that leaves event.target absent. Parent-authored broadcast/fan-out uses
           connect lowering rather than producer broadcast. Loaded flow-scope producer broadcast is invalid when it is used
@@ -1699,9 +1699,10 @@ handler_specification:
         target_sender_no_inbound: target:sender is used where no inbound event source can exist.
         target_sender_empty_source: target:sender is used where inbound source is statically external or empty.
         producer_target_common_path_forbidden: A loaded flow-scope producer target.flow/match selects a loaded package
-          receiver input for the same pin-declared output; parent connect is the required route owner.
+          receiver input for the same pin-declared output or a receiver flow reached by the parent connect graph;
+          parent connect is the required route owner.
         producer_broadcast_common_path_forbidden: Loaded flow-scope broadcast:true is used as package-internal delivery to
-          known receiver input pins for the same pin-declared output; parent connect broadcast/fan-out is the required route owner.
+          known receiver input pins for the same pin-declared output or connected output pin; parent connect broadcast/fan-out is the required route owner.
       single_emit_handler_rule: 'A handler top-level emit is valid only when the handler has exactly one possible emit site.
         If the handler also declares rules, on_complete, accumulate.on_timeout, or fan_out emit, boot fails with ambiguity.
         Payload ownership must move to the active emit site.'
@@ -2132,7 +2133,7 @@ engine:
       explicit_target_escape_hatch: Producer target is only an exceptional dynamic-routing escape hatch. It must not be
         treated as the common parent-composed routing owner and must not replace lowered parent connect as the common source
         authority for connected pins. target.flow/match from a loaded flow-scope producer that selects a loaded package
-        receiver input for the same pin-declared output is illegal common-path composition routing, including when a parent connect also exists.
+        receiver input for the same pin-declared output or a receiver flow reached by the parent connect graph is illegal common-path composition routing, including when a parent connect or alias/adapter connect also exists.
       fail_closed: A pin-declared output that has no lowered parent connect route, no explicit target escape hatch, no structural
         ParentRoute, no eligible static child delivery-entity route, and no broadcast:true is invalid.
       no_silent_broadcast_fallback: Missing, malformed, ambiguous, or unreachable targets must fail with a typed reason.
@@ -2146,7 +2147,7 @@ engine:
       flow_match: |
         `target: { flow, match }` resolves target.flow plus declared entity-field matches to exactly one target instance.
         Zero matches and more than one match fail closed at publish time. From loaded flow-scope producers, it is forbidden
-        as package-internal composition routing when target.flow has a receiver input for the same pin-declared output event;
+        as package-internal composition routing when target.flow has a receiver input for the same pin-declared output event or is reached by the parent connect graph;
         parent connect owns that route.
       flow_match_allow_fanout: |
         `target: { flow, match, allow_fanout: true }` is the explicit dynamic fan-out escape hatch for flow/match targeting.
@@ -2159,7 +2160,7 @@ engine:
         `broadcast: true` is the producer-authored explicit opt-out escape hatch for pin-declared output routing. It leaves
         event.target absent and uses the ordinary no-target event-type delivery path. Parent-authored broadcast/fan-out should
         use connect topology and lower to concrete route-plan facts. From loaded flow-scope producers, broadcast:true is
-        forbidden when it functions as package-internal delivery to loaded receiver input pins for the same pin-declared output.
+        forbidden when it functions as package-internal delivery to loaded receiver input pins for the same pin-declared output or connected output pin.
     structural_binding:
       precedence_guard: Structural binding is lower precedence than lowered parent connect and the explicit target escape
         hatch. It may write event.target only for a child-to-parent pin output when no lowered parent connect target applies,
@@ -2220,9 +2221,10 @@ engine:
         target_sender_no_inbound: target:sender appears on a handler whose only triggers cannot supply inbound source.
         target_sender_empty_source: target:sender appears on a handler subscribed only to external-sourced events with empty source.
         producer_target_common_path_forbidden: A loaded flow-scope producer target.flow/match selects a loaded package
-          receiver input for the same pin-declared output; parent connect is the required route owner.
+          receiver input for the same pin-declared output or a receiver flow reached by the parent connect graph;
+          parent connect is the required route owner.
         producer_broadcast_common_path_forbidden: Loaded flow-scope broadcast:true is used as package-internal delivery to
-          known receiver input pins for the same pin-declared output; parent connect broadcast/fan-out is the required route owner.
+          known receiver input pins for the same pin-declared output or connected output pin; parent connect broadcast/fan-out is the required route owner.
       publish_time_dead_letter:
         target_unreachable_no_subscriber: Target resolution finds no recipient for the requested target.
         target_unreachable_terminated: Target or ParentRoute referred to an instance that no longer exists.
@@ -5129,19 +5131,21 @@ flow_model:
             composition routing for loaded package receiver inputs from loaded
             flow-scope producers. If a pin-declared flow output targets a
             loaded receiver flow input for the same event with target.flow/match,
-            or broadcasts to loaded package receiver inputs for the same event,
-            verification and runtime resolution MUST fail closed with a typed
-            reason. Adding a parent connect does not grandfather the producer
-            target/broadcast writer; the producer route must be removed or
-            proven to be a different escape hatch. Parent connect remains the
-            topology owner and EventBus RoutePlan remains the concrete delivery
-            authority. Root-level producer target/broadcast composition remains
+            targets a loaded receiver flow reached by the parent connect graph
+            for that output pin, or broadcasts to loaded package receiver inputs
+            for the same event or connected output pin, verification and runtime
+            resolution MUST fail closed with a typed reason. Adding a parent
+            connect, including an alias/adapter connect, does not grandfather
+            the producer target/broadcast writer; the producer route must be
+            removed or proven to be a different escape hatch. Parent connect
+            remains the topology owner and EventBus RoutePlan remains the
+            concrete delivery authority. Root-level producer target/broadcast composition remains
             a #1466/root-connect source-authority residual, not part of this
             closed child slice.
           consumes:
           - loaded flow-scope producer output pin event identity
           - authored emit target/broadcast syntax
-          - loaded package receiver input pins
+          - loaded package receiver input pins and parent connect graph edges, including alias/adapter connects
           - parent composition route-authority contract from #1466
           produces:
           - producer_target_common_path_forbidden for loaded flow-scope target.flow/match common-path composition
@@ -8820,7 +8824,8 @@ static_analyzer:
         - flow_match_allow_fanout
         rule: Target form must be syntactically valid and reference loaded flow topology where statically known. flow_match
           target forms from loaded flow-scope producers are invalid when they select a loaded package receiver input for the
-          same pin-declared output instead of acting as a genuine dynamic escape hatch.
+          same pin-declared output or a receiver flow reached by the parent connect graph instead of acting as a genuine
+          dynamic escape hatch.
       fanout_representation:
         rule: flow_match_allow_fanout resolves to event.target_set, not singular event.target. The runtime must persist concrete
           target_set route identities and one delivery target per recipient; it must not persist only the authored selector.
@@ -8833,8 +8838,8 @@ static_analyzer:
           This path is not ParentRoute metadata and must not fall back to inbound event.source.
       explicit_broadcast:
         rule: broadcast:true is a deliberate opt-out and is the only no-target form accepted for a pin-declared output when
-          no loaded package receiver input consumes the same output event from a loaded flow-scope producer. Parent-composed
-          broadcast/fan-out uses connect.
+          no loaded package receiver input consumes the same output event and no parent connect graph edge consumes the
+          output pin from a loaded flow-scope producer. Parent-composed broadcast/fan-out uses connect.
     static_failure_reasons:
       target_required_missing: No lowered parent connect route, no explicit target escape hatch, no structural ParentRoute
         eligibility, no eligible static child delivery-entity route, and no broadcast:true.
@@ -8843,9 +8848,10 @@ static_analyzer:
       target_sender_no_inbound: target:sender is used from a handler whose only triggers cannot supply inbound event.source.
       target_sender_empty_source: target:sender is used only from external-sourced event types with empty source.
       producer_target_common_path_forbidden: A loaded flow-scope producer target.flow/match selects a loaded package
-        receiver input for the same pin-declared output; parent connect is the required route owner.
+        receiver input for the same pin-declared output or a receiver flow reached by the parent connect graph;
+        parent connect is the required route owner.
       producer_broadcast_common_path_forbidden: Loaded flow-scope broadcast:true is used as package-internal delivery to
-        known receiver input pins for the same pin-declared output; parent connect broadcast/fan-out is the required route owner.
+        known receiver input pins for the same pin-declared output or connected output pin; parent connect broadcast/fan-out is the required route owner.
     runtime_failure_reasons:
       publish_time_dead_letter:
       - target_unreachable_no_subscriber

--- a/tests/tier7-composition/test-cross-flow-subscription/flows/flow-b/nodes.yaml
+++ b/tests/tier7-composition/test-cross-flow-subscription/flows/flow-b/nodes.yaml
@@ -9,4 +9,3 @@ flow-b-node:
       advances_to: done
       emit:
         event: order.completed
-        broadcast: true

--- a/tests/tier7-composition/test-cross-flow-subscription/package.yaml
+++ b/tests/tier7-composition/test-cross-flow-subscription/package.yaml
@@ -9,3 +9,7 @@ flows:
   - id: flow-b
     flow: flow-b
     mode: static
+connect:
+  - from: flow-b.order.completed
+    to: flow-a.flow-b/order.completed
+    adapter: flow-b-order-completed


### PR DESCRIPTION
## Summary

Closes #1475.

Retires loaded flow-scope producer `emit.target` / `broadcast:true` as the common package-composition route path. The canonical owner after this PR is `internal/runtime/core/pinrouting.ProducerRouteCommonPathFailure`, consumed by boot verification and runtime pin-route resolution. Parent `connect` remains the topology owner and EventBus `RoutePlan` remains the concrete delivery authority.

## Governing Spec / Context

Exact spec refs updated in this PR:

- `platform-spec.yaml#handler_specification.handler_fields.emit`
- `platform-spec.yaml#engine.cross_flow_routing`
- `platform-spec.yaml#flow_model.flow_package.composition_routing.route_plan_lowering.implementation_slice_1475`
- `platform-spec.yaml#static_analyzer.slice_3a_pin_target_resolution`

Binding gate/context:

- #1475 Pre-Implementation Coverage Audit and approved gate boundary.
- Parent #1466 composition-first routing source-authority model.
- Prior #1474 EventBus RoutePlan consumption path remains supported and regressed here.

## Semantic Migration

New canonical owner:

- `internal/runtime/core/pinrouting.ProducerRouteCommonPathFailure`

Old producer/reader/writer paths now invalid:

- Loaded flow-scope producer `target.flow/match` selecting a loaded package receiver input for the same pin-declared output.
- Loaded flow-scope `broadcast:true` used as package-internal delivery to known receiver input pins for the same pin-declared output.
- Stale fixture/common-path broadcasts in `tests/tier7-composition/test-cross-flow-subscription` and `internal/runtime/testdata/generic-swarm-bundle`.

Production paths checked for surviving old behavior:

- Boot verification `pin_target_resolution`.
- Runtime `pinrouting.ResolveEnvelope` / engine pre-route resolution.
- Generated emit-tool/EventBus RoutePlan regressions from #1474.
- Catalog e2e and generic bundle fixtures that previously used producer broadcast/target as composition routing.

Migration completeness:

- Complete for the approved #1475 loaded flow-scope common-path class.
- Root-level producer target/broadcast composition remains explicitly split to #1466/root-connect source-authority modeling; this PR does not claim that parent closure.

## Proof

- `go test ./internal/runtime/core/pinrouting ./internal/runtime/bootverify ./internal/apispec -run 'Producer|PinTargetResolution|Resolve|CompositionRouting' -count=1`
- `go test ./internal/runtime/tools -run 'RoutePlan|Connected|target_required_missing|EmitTool' -count=1`
- `go test ./internal/runtime/bus -run 'ConnectRoutePlan|RoutePlan|PlanDirect|PublishDirect' -count=1`
- `go test ./internal/runtime/engine -run 'Emit|Outbox|RoutePlan|Connected' -count=1`
- `go test ./internal/runtime/cataloge2e -run 'Tier11FlowComposition|Tier11DynamicFlowInstance|Tier7Composition' -count=1`
- `go test ./internal/runtime/testcases -run 'GenericBundle' -count=1`
- `go test ./internal/runtime/bootverify -run 'PinTargetResolution' -count=1`
- `go test ./...`