### PR TITLE
[agent-a][issue #1444] Verify agent output pin emit events

### DIFF
--- a/internal/apispec/platform_spec_composition_routing_test.go
+++ b/internal/apispec/platform_spec_composition_routing_test.go
@@ -155,8 +155,13 @@ func TestPlatformSpecCompositionRoutingDemotesProducerTargetAuthority(t *testing
 	assertScalarContains(t, mustYAMLPath(t, pinTargetResolution, "accepted_target_mechanisms", "structural_parent_route", "rule"), "no lowered parent connect route applies")
 	assertScalarContains(t, mustYAMLPath(t, pinTargetResolution, "scope", "description"), "no lowered connect route applies")
 	assertScalarContains(t, mustYAMLPath(t, pinTargetResolution, "scope", "description"), "eligible static child delivery-entity")
+	assertScalarContains(t, mustYAMLPath(t, pinTargetResolution, "scope", "description"), "agent emit_events")
+	assertScalarContains(t, mustYAMLPath(t, pinTargetResolution, "scope", "description"), "do not require producer")
 	assertScalarContains(t, mustYAMLPath(t, pinTargetResolution, "static_failure_reasons", "producer_target_common_path_forbidden"), "parent connect is the required route owner")
 	assertScalarContains(t, mustYAMLPath(t, pinTargetResolution, "static_failure_reasons", "producer_broadcast_common_path_forbidden"), "parent connect broadcast/fan-out")
+	assertScalarContains(t, mustYAMLPath(t, pinTargetResolution, "implementation_slice_1444", "rule"), "Agent emit_events declarations")
+	assertScalarContains(t, mustYAMLPath(t, pinTargetResolution, "implementation_slice_1444", "rule"), "MUST NOT require producer target")
+	assertScalarContains(t, mustYAMLPath(t, pinTargetResolution, "implementation_slice_1444", "canonical_code_owner"), "pinRoutingAgentEmitSites")
 }
 
 func TestPlatformSpecCompositionRoutingCatalogSurfacesConsumeConnectAuthority(t *testing.T) {
@@ -179,6 +184,7 @@ func TestPlatformSpecCompositionRoutingCatalogSurfacesConsumeConnectAuthority(t 
 	assertScalarContains(t, mustMappingValue(t, inputPinWiring, "trigger"), "safe same-name sibling")
 
 	pinTargetResolution := mustSequenceMappingByScalarField(t, checks, "id", "pin_target_resolution")
+	assertScalarContains(t, mustMappingValue(t, pinTargetResolution, "trigger"), "agent emit_events")
 	assertScalarContains(t, mustMappingValue(t, pinTargetResolution, "trigger"), "lowered parent connect route")
 	assertScalarContains(t, mustMappingValue(t, pinTargetResolution, "trigger"), "explicit target escape hatch")
 	assertScalarContains(t, mustMappingValue(t, pinTargetResolution, "trigger"), "eligible static child delivery-entity route")

--- a/internal/runtime/bootverify/workflow_pin_routing_checks.go
+++ b/internal/runtime/bootverify/workflow_pin_routing_checks.go
@@ -2,6 +2,7 @@ package bootverify
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
@@ -33,6 +34,20 @@ func checkPinTargetResolution(c *checkerContext) []Finding {
 		}
 		if site.Spec.Target.Normalized().Kind == runtimecontracts.EmitTargetKindSender && pinRoutingEventExternalSource(c.source, site.FlowID, site.HandlerEvent) {
 			findings = append(findings, pinTargetFinding(site, "target_sender_empty_source"))
+		}
+	}
+	for _, site := range pinRoutingAgentEmitSites(c.source) {
+		if !runtimepinrouting.PinDeclaredOutput(c.source, site.FlowID, site.EventType) {
+			continue
+		}
+		spec := runtimecontracts.EmitSpec{Event: site.EventType}
+		connectedOutput := compositionConnectsFromOutputEvent(c.source, site.FlowID, spec.EventType())
+		structuralParent := pinRoutingStructuralParentRouteEligible(c.source, site.FlowID)
+		if connectedOutput {
+			structuralParent = true
+		}
+		if failure := runtimepinrouting.ValidateTargetSpec(c.source, site.FlowID, spec, structuralParent); failure != "" {
+			findings = append(findings, pinTargetAgentFinding(site, string(failure)))
 		}
 	}
 	return findings
@@ -114,6 +129,75 @@ func pinRoutingEmitSites(source semanticview.Source) []semanticview.AuthoredEmit
 	return semanticview.AuthoredEmitSites(source)
 }
 
+type pinRoutingAgentEmitSite struct {
+	FlowID    string
+	AgentID   string
+	EventType string
+}
+
+func pinRoutingAgentEmitSites(source semanticview.Source) []pinRoutingAgentEmitSite {
+	if source == nil {
+		return nil
+	}
+	seen := map[string]struct{}{}
+	sites := []pinRoutingAgentEmitSite{}
+	appendAgent := func(flowID, agentID string, entry runtimecontracts.AgentRegistryEntry) {
+		flowID = strings.TrimSpace(flowID)
+		agentID = strings.TrimSpace(agentID)
+		if agentID == "" {
+			agentID = strings.TrimSpace(entry.ID)
+		}
+		if agentID == "" {
+			return
+		}
+		for _, rawEventType := range entry.EmitEvents {
+			eventType := strings.TrimSpace(rawEventType)
+			if eventType == "" {
+				continue
+			}
+			key := flowID + "\x00" + agentID + "\x00" + eventType
+			if _, ok := seen[key]; ok {
+				continue
+			}
+			seen[key] = struct{}{}
+			sites = append(sites, pinRoutingAgentEmitSite{
+				FlowID:    flowID,
+				AgentID:   agentID,
+				EventType: eventType,
+			})
+		}
+	}
+	rootAgents := source.AgentEntries()
+	for _, agentID := range sortedSetKeysLocal(rootAgents) {
+		appendAgent("", agentID, rootAgents[agentID])
+	}
+	flowScopes := append([]semanticview.FlowScope{}, source.FlowScopes()...)
+	sort.SliceStable(flowScopes, func(i, j int) bool {
+		if strings.TrimSpace(flowScopes[i].ID) != strings.TrimSpace(flowScopes[j].ID) {
+			return strings.TrimSpace(flowScopes[i].ID) < strings.TrimSpace(flowScopes[j].ID)
+		}
+		if strings.TrimSpace(flowScopes[i].Path) != strings.TrimSpace(flowScopes[j].Path) {
+			return strings.TrimSpace(flowScopes[i].Path) < strings.TrimSpace(flowScopes[j].Path)
+		}
+		return strings.TrimSpace(flowScopes[i].PackageKey) < strings.TrimSpace(flowScopes[j].PackageKey)
+	})
+	for _, scope := range flowScopes {
+		for _, agentID := range sortedSetKeysLocal(scope.Agents) {
+			appendAgent(scope.ID, agentID, scope.Agents[agentID])
+		}
+	}
+	sort.SliceStable(sites, func(i, j int) bool {
+		if sites[i].FlowID != sites[j].FlowID {
+			return sites[i].FlowID < sites[j].FlowID
+		}
+		if sites[i].AgentID != sites[j].AgentID {
+			return sites[i].AgentID < sites[j].AgentID
+		}
+		return sites[i].EventType < sites[j].EventType
+	})
+	return sites
+}
+
 func pinTargetFinding(site semanticview.AuthoredEmitSite, reason string) Finding {
 	scope := fmt.Sprintf("flow %s", site.FlowID)
 	location := site.FlowID
@@ -125,6 +209,21 @@ func pinTargetFinding(site semanticview.AuthoredEmitSite, reason string) Finding
 		CheckID:  "pin_target_resolution",
 		Severity: "error",
 		Message:  fmt.Sprintf("%s %s on node %s emits pin-declared output %s without valid target mechanism: %s", scope, site.Site, site.NodeID, site.Spec.EventType(), reason),
+		Location: location,
+	}
+}
+
+func pinTargetAgentFinding(site pinRoutingAgentEmitSite, reason string) Finding {
+	scope := fmt.Sprintf("flow %s", site.FlowID)
+	location := site.FlowID
+	if strings.TrimSpace(site.FlowID) == "" {
+		scope = "root"
+		location = "root"
+	}
+	return Finding{
+		CheckID:  "pin_target_resolution",
+		Severity: "error",
+		Message:  fmt.Sprintf("%s agent emit_events on agent %s emits pin-declared output %s without valid target mechanism: %s", scope, site.AgentID, site.EventType, reason),
 		Location: location,
 	}
 }

--- a/internal/runtime/bootverify/workflow_pin_routing_checks.go
+++ b/internal/runtime/bootverify/workflow_pin_routing_checks.go
@@ -167,9 +167,20 @@ func pinRoutingAgentEmitSites(source semanticview.Source) []pinRoutingAgentEmitS
 			})
 		}
 	}
-	rootAgents := source.AgentEntries()
-	for _, agentID := range sortedSetKeysLocal(rootAgents) {
-		appendAgent("", agentID, rootAgents[agentID])
+	projectScopes := append([]semanticview.ProjectScope{}, source.ProjectScopes()...)
+	sort.SliceStable(projectScopes, func(i, j int) bool {
+		if strings.TrimSpace(projectScopes[i].Key) != strings.TrimSpace(projectScopes[j].Key) {
+			return strings.TrimSpace(projectScopes[i].Key) < strings.TrimSpace(projectScopes[j].Key)
+		}
+		return strings.TrimSpace(projectScopes[i].OwningFlowID) < strings.TrimSpace(projectScopes[j].OwningFlowID)
+	})
+	for _, scope := range projectScopes {
+		if pinRoutingAgentSkipsProjectScope(scope) {
+			continue
+		}
+		for _, agentID := range sortedSetKeysLocal(scope.Agents) {
+			appendAgent(scope.OwningFlowID, agentID, scope.Agents[agentID])
+		}
 	}
 	flowScopes := append([]semanticview.FlowScope{}, source.FlowScopes()...)
 	sort.SliceStable(flowScopes, func(i, j int) bool {
@@ -186,6 +197,12 @@ func pinRoutingAgentEmitSites(source semanticview.Source) []pinRoutingAgentEmitS
 			appendAgent(scope.ID, agentID, scope.Agents[agentID])
 		}
 	}
+	if len(projectScopes) == 0 && len(flowScopes) == 0 {
+		rootAgents := source.AgentEntries()
+		for _, agentID := range sortedSetKeysLocal(rootAgents) {
+			appendAgent("", agentID, rootAgents[agentID])
+		}
+	}
 	sort.SliceStable(sites, func(i, j int) bool {
 		if sites[i].FlowID != sites[j].FlowID {
 			return sites[i].FlowID < sites[j].FlowID
@@ -196,6 +213,10 @@ func pinRoutingAgentEmitSites(source semanticview.Source) []pinRoutingAgentEmitS
 		return sites[i].EventType < sites[j].EventType
 	})
 	return sites
+}
+
+func pinRoutingAgentSkipsProjectScope(scope semanticview.ProjectScope) bool {
+	return strings.TrimSpace(scope.Key) == "." && strings.TrimSpace(scope.OwningFlowID) != ""
 }
 
 func pinTargetFinding(site semanticview.AuthoredEmitSite, reason string) Finding {

--- a/internal/runtime/bootverify/workflow_pin_routing_checks_test.go
+++ b/internal/runtime/bootverify/workflow_pin_routing_checks_test.go
@@ -129,6 +129,25 @@ func TestPinTargetResolution_FailsClosedForUnknownProducerTargetFlowEvenWithPare
 	}
 }
 
+func TestPinTargetResolution_AllowsFlowScopedAgentEmitEventsThroughParentConnect(t *testing.T) {
+	bundle := loadPinRoutingProducerAgentRouteBundleForEvents(t, "shared.ready", "shared.ready", pinRoutingProducerRouteConnect())
+
+	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+	if reportContains(report.Errors(), "pin_target_resolution", "producer-agent") {
+		t.Fatalf("parent connect should satisfy agent emit_events output pin target proof, got %#v", report.Errors())
+	}
+}
+
+func TestPinTargetResolution_FailsClosedForFlowScopedAgentEmitEventsWithoutRouteAuthority(t *testing.T) {
+	bundle := loadPinRoutingProducerAgentRouteBundleForEvents(t, "shared.ready", "shared.ready")
+
+	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+	if !reportContains(report.Errors(), "pin_target_resolution", "flow producer agent emit_events on agent producer-agent") ||
+		!reportContains(report.Errors(), "pin_target_resolution", "target_required_missing") {
+		t.Fatalf("expected agent emit_events target_required_missing, got %#v", report.Errors())
+	}
+}
+
 func TestPinTargetResolution_AllowsExplicitTargetEscapeHatches(t *testing.T) {
 	for _, tt := range []struct {
 		name      string
@@ -415,6 +434,93 @@ producer-node:
     producer.start:
 `+producerHandlerBody+`
 `)
+	writePinRoutingVerifyFile(t, filepath.Join(root, "flows", "consumer", "schema.yaml"), `
+name: consumer
+initial_state: pending
+states: [pending, done]
+terminal_states: [done]
+pins:
+  inputs:
+    events: [`+consumerInputEvent+`]
+  outputs:
+    events: [consumer.done]
+`)
+	consumerEvents := `
+consumer.start:
+  entity_id: text
+`
+	if consumerInputEvent != "consumer.start" {
+		consumerEvents += consumerInputEvent + `:
+  entity_id: text
+`
+	}
+	consumerEvents += `consumer.done:
+  entity_id: text
+`
+	writePinRoutingVerifyFile(t, filepath.Join(root, "flows", "consumer", "events.yaml"), consumerEvents)
+	writePinRoutingVerifyFile(t, filepath.Join(root, "flows", "consumer", "entities.yaml"), `
+consumer:
+  entity_id: text
+`)
+	writePinRoutingVerifyFile(t, filepath.Join(root, "flows", "consumer", "nodes.yaml"), "{}\n")
+	repoRoot := filepath.Clean(filepath.Join("..", "..", ".."))
+	bundle, err := runtimecontracts.LoadWorkflowContractBundleWithOverrides(repoRoot, root, runtimecontracts.DefaultPlatformSpecFile(repoRoot))
+	if err != nil {
+		t.Fatalf("LoadWorkflowContractBundleWithOverrides: %v", err)
+	}
+	return bundle
+}
+
+func loadPinRoutingProducerAgentRouteBundleForEvents(t *testing.T, producerOutputEvent, consumerInputEvent string, connectBlocks ...string) *runtimecontracts.WorkflowContractBundle {
+	t.Helper()
+	root := t.TempDir()
+	writePinRoutingVerifyFile(t, filepath.Join(root, "package.yaml"), `
+name: pin-routing-producer-agent-route
+version: "1.0.0"
+platform_version: ">=1.6.0"
+flows:
+  - id: producer
+    flow: producer
+    mode: static
+  - id: consumer
+    flow: consumer
+    mode: static
+`+strings.Join(connectBlocks, ""))
+	writePinRoutingVerifyFile(t, filepath.Join(root, "schema.yaml"), "name: pin-routing-producer-agent-route\n")
+	writePinRoutingVerifyFile(t, filepath.Join(root, "policy.yaml"), "{}\n")
+	writePinRoutingVerifyFile(t, filepath.Join(root, "tools.yaml"), "{}\n")
+	writePinRoutingVerifyFile(t, filepath.Join(root, "agents.yaml"), "{}\n")
+	writePinRoutingVerifyFile(t, filepath.Join(root, "events.yaml"), "{}\n")
+	writePinRoutingVerifyFile(t, filepath.Join(root, "entities.yaml"), "{}\n")
+	writePinRoutingVerifyFile(t, filepath.Join(root, "flows", "producer", "schema.yaml"), `
+name: producer
+initial_state: pending
+states: [pending, done]
+terminal_states: [done]
+pins:
+  inputs:
+    events: [producer.start]
+  outputs:
+    events: [`+producerOutputEvent+`]
+`)
+	writePinRoutingVerifyFile(t, filepath.Join(root, "flows", "producer", "events.yaml"), `
+producer.start:
+  entity_id: text
+`+producerOutputEvent+`:
+  entity_id: text
+`)
+	writePinRoutingVerifyFile(t, filepath.Join(root, "flows", "producer", "entities.yaml"), `
+producer:
+  entity_id: text
+`)
+	writePinRoutingVerifyFile(t, filepath.Join(root, "flows", "producer", "agents.yaml"), `
+producer-agent:
+  id: producer-agent
+  role: producer
+  emit_events:
+    - `+producerOutputEvent+`
+`)
+	writePinRoutingVerifyFile(t, filepath.Join(root, "flows", "producer", "nodes.yaml"), "{}\n")
 	writePinRoutingVerifyFile(t, filepath.Join(root, "flows", "consumer", "schema.yaml"), `
 name: consumer
 initial_state: pending

--- a/internal/runtime/bootverify/workflow_pin_routing_checks_test.go
+++ b/internal/runtime/bootverify/workflow_pin_routing_checks_test.go
@@ -138,6 +138,18 @@ func TestPinTargetResolution_AllowsFlowScopedAgentEmitEventsThroughParentConnect
 	}
 }
 
+func TestPinTargetResolution_DoesNotTreatMergedFlowAgentAsRootEmitSite(t *testing.T) {
+	bundle := loadPinRoutingProducerAgentRouteBundleWithRootOutputs(t, "shared.ready", "shared.ready", []string{"shared.ready"}, pinRoutingProducerRouteConnect())
+
+	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+	if reportContains(report.Errors(), "pin_target_resolution", "root agent emit_events on agent producer-agent") {
+		t.Fatalf("flow-scoped agent was evaluated as root: %#v", report.Errors())
+	}
+	if reportContains(report.Errors(), "pin_target_resolution", "producer-agent") {
+		t.Fatalf("parent connect should satisfy the real flow-scoped agent emit_events site, got %#v", report.Errors())
+	}
+}
+
 func TestPinTargetResolution_FailsClosedForFlowScopedAgentEmitEventsWithoutRouteAuthority(t *testing.T) {
 	bundle := loadPinRoutingProducerAgentRouteBundleForEvents(t, "shared.ready", "shared.ready")
 
@@ -145,6 +157,23 @@ func TestPinTargetResolution_FailsClosedForFlowScopedAgentEmitEventsWithoutRoute
 	if !reportContains(report.Errors(), "pin_target_resolution", "flow producer agent emit_events on agent producer-agent") ||
 		!reportContains(report.Errors(), "pin_target_resolution", "target_required_missing") {
 		t.Fatalf("expected agent emit_events target_required_missing, got %#v", report.Errors())
+	}
+}
+
+func TestPinTargetResolution_ChecksProjectScopeAgentUnderOwningFlow(t *testing.T) {
+	bundle := loadPinRoutingVerifySourceFixture(t, pinRoutingVerifySourceFixture{
+		extrasAgents: `
+extras-agent:
+  id: extras-agent
+  role: producer
+  emit_events:
+    - support.ready
+`,
+	})
+	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+	if !reportContains(report.Errors(), "pin_target_resolution", "flow support agent emit_events on agent extras-agent") ||
+		!reportContains(report.Errors(), "pin_target_resolution", "target_required_missing") {
+		t.Fatalf("expected project-scope agent under support flow to fail closed, got %#v", report.Errors())
 	}
 }
 
@@ -472,6 +501,10 @@ consumer:
 }
 
 func loadPinRoutingProducerAgentRouteBundleForEvents(t *testing.T, producerOutputEvent, consumerInputEvent string, connectBlocks ...string) *runtimecontracts.WorkflowContractBundle {
+	return loadPinRoutingProducerAgentRouteBundleWithRootOutputs(t, producerOutputEvent, consumerInputEvent, nil, connectBlocks...)
+}
+
+func loadPinRoutingProducerAgentRouteBundleWithRootOutputs(t *testing.T, producerOutputEvent, consumerInputEvent string, rootOutputEvents []string, connectBlocks ...string) *runtimecontracts.WorkflowContractBundle {
 	t.Helper()
 	root := t.TempDir()
 	writePinRoutingVerifyFile(t, filepath.Join(root, "package.yaml"), `
@@ -486,7 +519,16 @@ flows:
     flow: consumer
     mode: static
 `+strings.Join(connectBlocks, ""))
-	writePinRoutingVerifyFile(t, filepath.Join(root, "schema.yaml"), "name: pin-routing-producer-agent-route\n")
+	rootSchema := "name: pin-routing-producer-agent-route\n"
+	if len(rootOutputEvents) > 0 {
+		rootSchema = `
+name: pin-routing-producer-agent-route
+pins:
+  outputs:
+    events: [` + strings.Join(rootOutputEvents, ", ") + `]
+`
+	}
+	writePinRoutingVerifyFile(t, filepath.Join(root, "schema.yaml"), rootSchema)
 	writePinRoutingVerifyFile(t, filepath.Join(root, "policy.yaml"), "{}\n")
 	writePinRoutingVerifyFile(t, filepath.Join(root, "tools.yaml"), "{}\n")
 	writePinRoutingVerifyFile(t, filepath.Join(root, "agents.yaml"), "{}\n")
@@ -579,6 +621,7 @@ type pinRoutingVerifySourceFixture struct {
 	rootNodes        string
 	supportFlowNodes string
 	extrasNodes      string
+	extrasAgents     string
 }
 
 func loadPinRoutingVerifySourceFixture(t *testing.T, opts pinRoutingVerifySourceFixture) *runtimecontracts.WorkflowContractBundle {
@@ -641,6 +684,7 @@ version: "1.0.0"
 flows: []
 `)
 	writePinRoutingVerifyFile(t, filepath.Join(root, "extras", "nodes.yaml"), defaultPinRoutingFixtureYAML(opts.extrasNodes))
+	writePinRoutingVerifyFile(t, filepath.Join(root, "extras", "agents.yaml"), defaultPinRoutingFixtureYAML(opts.extrasAgents))
 	repoRoot := filepath.Clean(filepath.Join("..", "..", ".."))
 	bundle, err := runtimecontracts.LoadWorkflowContractBundleWithOverrides(repoRoot, root, runtimecontracts.DefaultPlatformSpecFile(repoRoot))
 	if err != nil {

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -4232,9 +4232,9 @@ engine:
     - id: pin_target_resolution
       severity: error
       scope: per-emit-site
-      trigger: A pin-declared output emit lacks a lowered parent connect route, explicit target escape hatch, structural
-        ParentRoute eligibility, eligible static child delivery-entity route, or broadcast:true; has malformed target syntax;
-        references an unknown target.flow; uses
+      trigger: A pin-declared output emit or agent emit_events declaration lacks a lowered parent connect route, explicit target
+        escape hatch, structural ParentRoute eligibility, eligible static child delivery-entity route, or broadcast:true;
+        has malformed target syntax; references an unknown target.flow; uses
         target:sender where no inbound source can exist; uses target:sender only on external-sourced inputs with empty
         source; or uses loaded flow-scope producer target/broadcast as package-internal delivery to a known receiver input
         where parent connect is required.
@@ -5121,7 +5121,7 @@ flow_model:
           does_not_close:
           - '#1475 producer target/broadcast retirement'
           - '#1466 composition-first parent closure'
-          - '#1444 final turnkey composition behavior'
+          - '#1444 static verifier coverage, later closed by static_analyzer.slice_3a_pin_target_resolution.implementation_slice_1444'
         implementation_slice_1475:
           status: merge_bearing_runtime_behavior
           canonical_code_owner: internal/runtime/core/pinrouting.ProducerRouteCommonPathFailure consumed by internal/runtime/bootverify and runtime pin-route resolution
@@ -5280,7 +5280,7 @@ flow_model:
         wildcard_scoping: '#1454 remains separate.'
         final_e2e_package_proof: '#1455 remains separate.'
         route_explain_describe: '#1442 tooling remains separate.'
-        agent_output_pin_runtime_failure: '#1444 must be re-audited against this source authority before runtime implementation.'
+        agent_output_pin_static_verify: '#1444 closes static bootverify coverage for agent emit_events under composition-first route authority; runtime generated-agent route-plan admission closed by #1474.'
   nesting:
     description: 'Flows nest recursively. A flow''s package.yaml declares child flows in its flows: list. Each child is a
       directory under flows/ with the same structure. There is no depth limit. The platform discovers flows by walking the
@@ -8797,17 +8797,20 @@ static_analyzer:
     - contract_formats.event_schema.strict_payload_contract.envelope_identity
     canonical_replacement: flow_model.flow_package.composition_routing.analyzer_verify_requirements
     scope:
-      description: For every system-node emit site whose emitted event is declared in the emitter flow's pins.outputs.events,
-        verify that the authored contract supplies lowered parent connect topology, a valid target escape hatch, structural
-        binding only when no lowered connect route applies, eligible static child delivery-entity routing, or explicit broadcast
-        opt-out. Loaded flow-scope producer target/broadcast that selects a known package receiver input for the same
-        pin-declared output is rejected as common-path composition routing; parent connect is the route owner.
+      description: For every system-node emit site or agent emit_events declaration whose emitted event is declared in the
+        emitter flow's pins.outputs.events, verify that the authored contract supplies lowered parent connect topology,
+        a valid target escape hatch, structural binding only when no lowered connect route applies, eligible static child
+        delivery-entity routing, or explicit broadcast opt-out. Agent emit_events declarations do not require producer
+        target, broadcast:true, or relay-node workarounds when parent connect supplies route authority. Loaded flow-scope
+        producer target/broadcast that selects a known package receiver input for the same pin-declared output is rejected
+        as common-path composition routing; parent connect is the route owner.
       applies_to:
       - handler top-level single-emit
       - rules entries
       - on_complete branches
       - accumulate.on_timeout
       - fan_out per-item emit
+      - agent emit_events declarations
       excludes:
       - runtime instance liveness
       - payload-dependent target.match cardinality
@@ -8866,6 +8869,38 @@ static_analyzer:
       - producer_broadcast_common_path_forbidden
     rule: Emit hard invalidity for every statically detectable missing or malformed accepted pin route source. Runtime failure
       reasons cover the cases boot verification cannot prove; no case may silently fall back to broadcast.
+    implementation_slice_1444:
+      status: merge_bearing_static_verify_behavior
+      canonical_code_owner: internal/runtime/bootverify.checkPinTargetResolution with pinRoutingAgentEmitSites
+      rule: |
+        Agent emit_events declarations that name a pin-declared output event are
+        static emit sites for pin_target_resolution. They consume the same
+        composition-first route authority as node/system emits: lowered parent
+        connect, structural ParentRoute/static child delivery-entity eligibility,
+        or a spec-authorized explicit dynamic escape hatch. A lowered parent
+        connect is sufficient and MUST NOT require producer target, broadcast:true,
+        relay nodes, raw same-name fallback, or live-subscription compatibility
+        fallback. If no accepted route proof exists, verification fails closed
+        before runtime with target_required_missing.
+      consumes:
+      - root/project agent emit_events declarations
+      - flow-scoped agent emit_events declarations
+      - flow pins.outputs.events event identity
+      - lowered parent connect proof from flow_model.flow_package.composition_routing
+      - existing node/system pin_target_resolution target validation owner
+      produces:
+      - agent emit_events pin-declared output coverage on cmd/swarm verify
+      - connected agent output-pin verification success without producer target/broadcast/relay requirements
+      - unconnected or unsupported agent output-pin verification failure with pin_target_resolution
+      proof_obligations:
+      - flow-scoped agent emit_events with a parent connect output route verifies successfully
+      - flow-scoped agent emit_events without parent connect, structural route, static child delivery-entity route, or explicit dynamic escape fails with target_required_missing
+      - node/system pin_target_resolution behavior remains unchanged
+      - fixture contracts that intentionally test prompt/tool/agent delivery behavior do not declare stale output pins unless they also provide route authority
+      does_not_close:
+      - broad #1466 composition-first parent closure
+      - #1474 runtime generated-agent EventBus RoutePlan admission, already closed separately
+      - marketplace/address-key or other final turnkey composition behavior outside static verify coverage
   slice_3a1_composition_connect_validation:
     id: composition_connect_validation
     domain: semantic_validity

--- a/tests/tier11-flow-composition/test-child-flow-tool-inherit/flows/child/schema.yaml
+++ b/tests/tier11-flow-composition/test-child-flow-tool-inherit/flows/child/schema.yaml
@@ -6,4 +6,4 @@ pins:
   inputs:
     events: [child.task]
   outputs:
-    events: [child.result]
+    events: []

--- a/tests/tier11-flow-composition/test-required-agents-child/fixtures.yaml
+++ b/tests/tier11-flow-composition/test-required-agents-child/fixtures.yaml
@@ -1,0 +1,6 @@
+agent_fixtures:
+  analyzer:
+    - on: analysis.requested
+      emits: []
+    - on: analyzer-flow/analysis.requested
+      emits: []

--- a/tests/tier11-flow-composition/test-required-agents-child/flows/analyzer-flow/schema.yaml
+++ b/tests/tier11-flow-composition/test-required-agents-child/flows/analyzer-flow/schema.yaml
@@ -11,4 +11,4 @@ pins:
   inputs:
     events: [analysis.requested]
   outputs:
-    events: [analysis.done]
+    events: []

--- a/tests/tier7-composition/test-dual-delivery/schema.yaml
+++ b/tests/tier7-composition/test-dual-delivery/schema.yaml
@@ -7,4 +7,4 @@ pins:
   inputs:
     events: [task.completed]
   outputs:
-    events: [task.finalized, task.audited]
+    events: [task.finalized]

--- a/tests/tier8-boot-verification/test-boot-prompt-missing/schema.yaml
+++ b/tests/tier8-boot-verification/test-boot-prompt-missing/schema.yaml
@@ -5,4 +5,4 @@ pins:
   inputs:
     events: [task.requested]
   outputs:
-    events: [task.completed]
+    events: []

--- a/tests/tier8-boot-verification/test-boot-prompt-ref-stub/schema.yaml
+++ b/tests/tier8-boot-verification/test-boot-prompt-ref-stub/schema.yaml
@@ -5,4 +5,4 @@ pins:
   inputs:
     events: [task.requested]
   outputs:
-    events: [task.completed]
+    events: []

--- a/tests/tier8-boot-verification/test-boot-prompt-ref/schema.yaml
+++ b/tests/tier8-boot-verification/test-boot-prompt-ref/schema.yaml
@@ -5,4 +5,4 @@ pins:
   inputs:
     events: [task.requested]
   outputs:
-    events: [task.completed]
+    events: []

--- a/tests/tier8-boot-verification/test-boot-prompt-stub/schema.yaml
+++ b/tests/tier8-boot-verification/test-boot-prompt-stub/schema.yaml
@@ -5,4 +5,4 @@ pins:
   inputs:
     events: [task.requested]
   outputs:
-    events: [task.completed]
+    events: []

--- a/tests/tier8-boot-verification/test-boot-tool-missing/schema.yaml
+++ b/tests/tier8-boot-verification/test-boot-tool-missing/schema.yaml
@@ -5,4 +5,4 @@ pins:
   inputs:
     events: [task.requested]
   outputs:
-    events: [task.completed]
+    events: []


### PR DESCRIPTION
## Summary

Closes #1444.

This PR closes the focused static-verifier gap for agent `emit_events` under the composition-first route authority:

- adds agent `emit_events` declarations to `pin_target_resolution` when they name pin-declared output events
- preserves parent `connect` as sufficient proof, with no producer `target`, no `broadcast:true`, and no relay-node workaround requirement
- fails closed during `swarm verify` when an agent output-pin declaration has no accepted route proof
- updates `platform-spec.yaml` and apispec assertions so the static analyzer contract stays in sync
- cleans stale catalog fixtures that declared agent output pins without route authority while testing unrelated prompt/tool/agent-delivery behavior

## Governing Refs / Context

Exact spec refs:

- `platform-spec.yaml#flow_model.flow_package.composition_routing.route_plan_lowering.implementation_slice_1474`
- `platform-spec.yaml#static_analyzer.slice_3a_pin_target_resolution`
- New: `platform-spec.yaml#static_analyzer.slice_3a_pin_target_resolution.implementation_slice_1444`

Binding issue/thread context:

- #1444 original verify-green/runtime-fail symptom for agent `emit_events`
- #1444 reclassification comment: agent/node pin-declared output emits must fail only when there is no valid parent `connect`, structural route, static child delivery-entity route, or explicit dynamic-routing escape hatch
- #1474 / PR #1505: runtime generated-agent EventBus `RoutePlan` admission is already the runtime owner
- #1475 / PR #1506: producer target/broadcast common-path compatibility is not the owner

## Semantic Owner / Migration

Canonical owner after this PR:

- Static verifier owner: `internal/runtime/bootverify.checkPinTargetResolution`
- Agent declaration inventory for this check: `pinRoutingAgentEmitSites`
- Runtime route authority remains unchanged: EventBus `RoutePlan` via #1474

Old non-authoritative path now invalid:

- Treating `semanticview.AuthoredEmitSites` node/system inventory as the full `pin_target_resolution` surface. It remains authoritative for node emit sites, but is not sufficient for agent `emit_events` coverage.

Production paths checked for surviving old behavior:

- Root/project agent `emit_events`
- Flow-scoped agent `emit_events`
- Node/system authored emit sites remain on the existing path
- Runtime generated emit-tool behavior is not changed by this PR

Migration completeness:

- Complete for #1444 focused static verify closure. Broader #1466 composition-first parent closure remains separate.

## Verification

Passed:

- `go test ./internal/runtime/bootverify -run 'TestPinTargetResolution_(AllowsFlowScopedAgentEmitEventsThroughParentConnect|FailsClosedForFlowScopedAgentEmitEventsWithoutRouteAuthority)' -count=1`
- `go test ./internal/apispec -run 'TestPlatformSpecCompositionRouting(DemotesProducerTargetAuthority|CatalogSurfacesConsumeConnectAuthority)' -count=1`
- `go test ./internal/runtime/cataloge2e -run 'TestTier(7Composition|11FlowComposition)CatalogFixtures_RealRuntime' -count=1`
- `go test ./internal/runtime/bootverify ./internal/apispec -count=1`

Full suite run:

- `go test ./...` was run and failed only at `TestTier12RuntimeFork_SelectedContractForkExecutionFixture` with `selected-contract execution requires selected frontier events`.
- I reproduced the same deterministic failure on a clean temporary `origin/master` worktree, so this is upstream/pre-existing and not introduced by this PR.