### PR TITLE
[agent-x][issue #1508] Add root connect route authority

### DIFF
--- a/internal/runtime/bootverify/workflow_composition_connect_checks.go
+++ b/internal/runtime/bootverify/workflow_composition_connect_checks.go
@@ -35,8 +35,14 @@ func validateCompositionConnect(source semanticview.Source, connect runtimecontr
 		return findings
 	}
 
-	if _, ok := source.FlowSchemaByID(from.FlowID); !ok {
-		findings = append(findings, compositionConnectFinding(connect, "producer_flow_missing", fmt.Sprintf("producer flow %s does not exist", from.FlowID), from.FlowID))
+	if !from.Root {
+		if _, ok := source.FlowSchemaByID(from.FlowID); !ok {
+			findings = append(findings, compositionConnectFinding(connect, "producer_flow_missing", fmt.Sprintf("producer flow %s does not exist", from.FlowID), from.FlowID))
+			return findings
+		}
+	}
+	if to.Root {
+		findings = append(findings, compositionConnectFinding(connect, "receiver_root_unsupported", "root receiver endpoints are not supported by this composition-routing slice", "root"))
 		return findings
 	}
 	receiverSchema, ok := source.FlowSchemaByID(to.FlowID)
@@ -47,7 +53,13 @@ func validateCompositionConnect(source semanticview.Source, connect runtimecontr
 
 	outputPin, ok := source.FlowOutputEventPin(from.FlowID, from.Pin)
 	if !ok {
-		findings = append(findings, compositionConnectFinding(connect, "producer_output_pin_missing", fmt.Sprintf("producer flow %s does not declare output pin %s", from.FlowID, from.Pin), from.FlowID))
+		location := from.FlowID
+		producerLabel := fmt.Sprintf("producer flow %s", from.FlowID)
+		if from.Root {
+			location = "root"
+			producerLabel = "root schema"
+		}
+		findings = append(findings, compositionConnectFinding(connect, "producer_output_pin_missing", fmt.Sprintf("%s does not declare output pin %s", producerLabel, from.Pin), location))
 		return findings
 	}
 	inputPin, ok := source.FlowInputEventPin(to.FlowID, to.Pin)

--- a/internal/runtime/bootverify/workflow_composition_connect_checks_test.go
+++ b/internal/runtime/bootverify/workflow_composition_connect_checks_test.go
@@ -27,6 +27,20 @@ func TestRun_AllowsParentCompositionConnectAsVerifyRouteProof(t *testing.T) {
 	}
 }
 
+func TestRun_AllowsRootProducerCompositionConnectAsRouteProof(t *testing.T) {
+	root := writeRootCompositionConnectBootverifyFixture(t)
+	bundle := loadFixtureBundleAt(t, repoRootForBootverifyTest(t), root, runtimecontracts.DefaultPlatformSpecFile(repoRootForBootverifyTest(t)))
+
+	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+
+	if reportContains(report.Errors(), "composition_connect_validation", "") {
+		t.Fatalf("unexpected composition_connect_validation error: %#v", report.Errors())
+	}
+	if reportContains(report.Errors(), "pin_target_resolution", "root.ready") {
+		t.Fatalf("root connect should satisfy root output pin target proof, got %#v", report.Errors())
+	}
+}
+
 func TestRun_FailsClosedForInvalidParentCompositionConnect(t *testing.T) {
 	tests := []struct {
 		name      string
@@ -61,6 +75,13 @@ func TestRun_FailsClosedForInvalidParentCompositionConnect(t *testing.T) {
 				connectTo: "consumer.missing_pin",
 			},
 			want: "receiver_input_pin_missing",
+		},
+		{
+			name: "root receiver unsupported",
+			opts: compositionConnectFixtureOptions{
+				connectTo: ".deploy_completed",
+			},
+			want: "receiver_root_unsupported",
 		},
 		{
 			name: "event names differ without adapter",
@@ -303,6 +324,72 @@ connect:
 	writeBootverifyFixtureFile(t, filepath.Join(root, "nodes.yaml"), "{}\n")
 	writeCompositionConnectProducerFlow(t, root, opts)
 	writeCompositionConnectConsumerFlow(t, root, opts)
+	return root
+}
+
+func writeRootCompositionConnectBootverifyFixture(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	writeBootverifyFixtureFile(t, filepath.Join(root, "package.yaml"), `
+name: root-composition-connect-bootverify
+version: "1.0.0"
+platform_version: ">=1.6.0"
+flows:
+  - id: consumer
+    flow: consumer
+    mode: static
+connect:
+  - from: .root_ready
+    to: consumer.ready
+    delivery: one
+`)
+	writeBootverifyFixtureFile(t, filepath.Join(root, "schema.yaml"), `
+name: root-composition-connect-bootverify
+pins:
+  inputs:
+    events: [root.start]
+  outputs:
+    events:
+      - name: root_ready
+        event: root.ready
+`)
+	writeBootverifyFixtureFile(t, filepath.Join(root, "policy.yaml"), "{}\n")
+	writeBootverifyFixtureFile(t, filepath.Join(root, "tools.yaml"), "{}\n")
+	writeBootverifyFixtureFile(t, filepath.Join(root, "agents.yaml"), "{}\n")
+	writeBootverifyFixtureFile(t, filepath.Join(root, "events.yaml"), `
+root.start:
+  entity_id: text
+root.ready:
+  entity_id: text
+`)
+	writeBootverifyFixtureFile(t, filepath.Join(root, "nodes.yaml"), `
+root-node:
+  id: root-node
+  execution_type: system_node
+  event_handlers:
+    root.start:
+      emit:
+        event: root.ready
+        fields:
+          entity_id: payload.entity_id
+`)
+	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "consumer", "schema.yaml"), `
+name: consumer
+mode: static
+pins:
+  inputs:
+    events:
+      - name: ready
+        event: root.ready
+`)
+	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "consumer", "policy.yaml"), "{}\n")
+	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "consumer", "agents.yaml"), "{}\n")
+	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "consumer", "events.yaml"), `
+root.ready:
+  entity_id: text
+`)
+	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "consumer", "entities.yaml"), "{}\n")
+	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "consumer", "nodes.yaml"), "{}\n")
 	return root
 }
 

--- a/internal/runtime/bootverify/workflow_pin_routing_checks_test.go
+++ b/internal/runtime/bootverify/workflow_pin_routing_checks_test.go
@@ -299,6 +299,50 @@ func TestPinTargetResolution_AllowsRootExplicitBroadcastOptOut(t *testing.T) {
 	}
 }
 
+func TestPinTargetResolution_AllowsRootPinOutputThroughRootConnect(t *testing.T) {
+	bundle := loadPinRoutingRootConnectBundle(t, `
+      emit:
+        event: root.ready
+        fields:
+          entity_id: payload.entity_id
+`)
+	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+	if reportContains(report.Errors(), "pin_target_resolution", "root") {
+		t.Fatalf("root connect should satisfy root pin target proof, got %#v", report.Errors())
+	}
+}
+
+func TestPinTargetResolution_FailsClosedForRootProducerBroadcastCommonPath(t *testing.T) {
+	bundle := loadPinRoutingRootConnectBundle(t, `
+      emit:
+        event: root.ready
+        fields:
+          entity_id: payload.entity_id
+        broadcast: true
+`)
+	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+	if !reportContains(report.Errors(), "pin_target_resolution", "producer_broadcast_common_path_forbidden") {
+		t.Fatalf("expected root producer_broadcast_common_path_forbidden, got %#v", report.Errors())
+	}
+}
+
+func TestPinTargetResolution_FailsClosedForRootProducerTargetCommonPath(t *testing.T) {
+	bundle := loadPinRoutingRootConnectBundle(t, `
+      emit:
+        event: root.ready
+        fields:
+          entity_id: payload.entity_id
+        target:
+          flow: consumer
+          match:
+            entity_id: payload.entity_id
+`)
+	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+	if !reportContains(report.Errors(), "pin_target_resolution", "producer_target_common_path_forbidden") {
+		t.Fatalf("expected root producer_target_common_path_forbidden, got %#v", report.Errors())
+	}
+}
+
 func TestPinTargetResolution_ChecksRootNodeWhenFlowNodeIDCollides(t *testing.T) {
 	bundle := loadPinRoutingVerifySourceFixture(t, pinRoutingVerifySourceFixture{
 		rootNodes:        pinRoutingVerifyNodeYAML("shared-node", "root.start", "root.ready", false),
@@ -685,6 +729,75 @@ flows: []
 `)
 	writePinRoutingVerifyFile(t, filepath.Join(root, "extras", "nodes.yaml"), defaultPinRoutingFixtureYAML(opts.extrasNodes))
 	writePinRoutingVerifyFile(t, filepath.Join(root, "extras", "agents.yaml"), defaultPinRoutingFixtureYAML(opts.extrasAgents))
+	repoRoot := filepath.Clean(filepath.Join("..", "..", ".."))
+	bundle, err := runtimecontracts.LoadWorkflowContractBundleWithOverrides(repoRoot, root, runtimecontracts.DefaultPlatformSpecFile(repoRoot))
+	if err != nil {
+		t.Fatalf("LoadWorkflowContractBundleWithOverrides: %v", err)
+	}
+	return bundle
+}
+
+func loadPinRoutingRootConnectBundle(t *testing.T, emitBlock string) *runtimecontracts.WorkflowContractBundle {
+	t.Helper()
+	root := t.TempDir()
+	writePinRoutingVerifyFile(t, filepath.Join(root, "package.yaml"), `
+name: pin-routing-root-connect
+version: "1.0.0"
+platform_version: ">=1.6.0"
+flows:
+  - id: consumer
+    flow: consumer
+    mode: static
+connect:
+  - from: .root_ready
+    to: consumer.ready
+    delivery: one
+`)
+	writePinRoutingVerifyFile(t, filepath.Join(root, "schema.yaml"), `
+name: pin-routing-root-connect
+pins:
+  inputs:
+    events: [root.start]
+  outputs:
+    events:
+      - name: root_ready
+        event: root.ready
+`)
+	writePinRoutingVerifyFile(t, filepath.Join(root, "events.yaml"), `
+root.start:
+  entity_id: text
+root.ready:
+  entity_id: text
+`)
+	writePinRoutingVerifyFile(t, filepath.Join(root, "policy.yaml"), "{}\n")
+	writePinRoutingVerifyFile(t, filepath.Join(root, "tools.yaml"), "{}\n")
+	writePinRoutingVerifyFile(t, filepath.Join(root, "agents.yaml"), "{}\n")
+	writePinRoutingVerifyFile(t, filepath.Join(root, "entities.yaml"), "{}\n")
+	writePinRoutingVerifyFile(t, filepath.Join(root, "nodes.yaml"), `
+root-node:
+  id: root-node
+  execution_type: system_node
+  event_handlers:
+    root.start:
+`+emitBlock+`
+`)
+	writePinRoutingVerifyFile(t, filepath.Join(root, "flows", "consumer", "schema.yaml"), `
+name: consumer
+mode: static
+pins:
+  inputs:
+    events:
+      - name: ready
+        event: root.ready
+`)
+	writePinRoutingVerifyFile(t, filepath.Join(root, "flows", "consumer", "events.yaml"), `
+root.ready:
+  entity_id: text
+`)
+	writePinRoutingVerifyFile(t, filepath.Join(root, "flows", "consumer", "entities.yaml"), "{}\n")
+	writePinRoutingVerifyFile(t, filepath.Join(root, "flows", "consumer", "policy.yaml"), "{}\n")
+	writePinRoutingVerifyFile(t, filepath.Join(root, "flows", "consumer", "agents.yaml"), "{}\n")
+	writePinRoutingVerifyFile(t, filepath.Join(root, "flows", "consumer", "nodes.yaml"), "{}\n")
 	repoRoot := filepath.Clean(filepath.Join("..", "..", ".."))
 	bundle, err := runtimecontracts.LoadWorkflowContractBundleWithOverrides(repoRoot, root, runtimecontracts.DefaultPlatformSpecFile(repoRoot))
 	if err != nil {

--- a/internal/runtime/bus/connect_route_plan_dispatch.go
+++ b/internal/runtime/bus/connect_route_plan_dispatch.go
@@ -214,6 +214,9 @@ func connectEndpointMatchesEvent(endpoint runtimepinrouting.ConnectRoutePlanEndp
 	if eventType == "" {
 		return false
 	}
+	if endpoint.Root && !eventFlowInstanceMatchesSourcePath(evt.FlowInstance(), "") {
+		return false
+	}
 	sourceLocal := strings.Trim(strings.TrimSpace(endpoint.Event), "/")
 	sourceResolved := strings.Trim(strings.TrimSpace(endpoint.ResolvedEvent), "/")
 	sourcePath := strings.Trim(strings.TrimSpace(endpoint.FlowPath), "/")

--- a/internal/runtime/bus/connect_route_plan_dispatch.go
+++ b/internal/runtime/bus/connect_route_plan_dispatch.go
@@ -199,6 +199,7 @@ func (r connectRoutePlanResolver) connectIssueMatchesEvent(issue runtimepinrouti
 		return false
 	}
 	endpoint := runtimepinrouting.ConnectRoutePlanEndpoint{
+		Root:          from.Root,
 		FlowID:        strings.TrimSpace(from.FlowID),
 		FlowPath:      strings.Trim(strings.TrimSpace(routeFlowPath(r.source, from.FlowID)), "/"),
 		Pin:           strings.TrimSpace(from.Pin),

--- a/internal/runtime/bus/connect_route_plan_dispatch_test.go
+++ b/internal/runtime/bus/connect_route_plan_dispatch_test.go
@@ -245,6 +245,47 @@ func TestEventBusPublish_RootConnectRoutePlanPersistsSingularTarget(t *testing.T
 	}
 }
 
+func TestEventBusPublish_RootConnectRoutePlanDoesNotCaptureChildScopedSameNameEvent(t *testing.T) {
+	source := connectRoutePlanRootProducerStaticSource()
+	store := newTargetRouteMemoryStore()
+	eb, err := NewEventBusWithOptions(store, EventBusOptions{ContractBundle: source})
+	if err != nil {
+		t.Fatalf("NewEventBusWithOptions: %v", err)
+	}
+	eventID := uuid.NewString()
+	evt := events.NewProjectionEvent(eventID,
+		events.EventType("root.ready"), "", "", json.RawMessage(`{"entity_id":"entity-1"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC()).
+		WithFlowInstance("producer/child-1")
+	forbidden := events.DeliveryRoute{
+		SubscriberType: "node",
+		SubscriberID:   "consumer-node",
+		Target: events.RouteIdentity{
+			FlowID:       "consumer",
+			FlowInstance: "consumer",
+			EntityID:     runtimeflowidentity.EntityID("consumer"),
+		},
+	}
+
+	routePlan, err := eb.planSubscribedRoutePlan(context.Background(), evt, false)
+	if err != nil {
+		t.Fatalf("planSubscribedRoutePlan: %v", err)
+	}
+	if routePlan.AuthorityOwner == routePlanSourceConnectRoutePlan || routePlan.AuthorityState == RoutePlanAuthorityCanonicalMatched {
+		t.Fatalf("route plan authority = %q/%q, root connect must not match child-scoped same-name event", routePlan.AuthorityState, routePlan.AuthorityOwner)
+	}
+	if deliveryRoutesContain(routePlan.DeliveryRoutes(), forbidden) {
+		t.Fatalf("route plan delivery routes = %#v, must not include root-connect receiver for child-scoped same-name event", routePlan.DeliveryRoutes())
+	}
+
+	plan, err := eb.CheckPublishRecipientPlan(context.Background(), evt)
+	if err != nil {
+		t.Fatalf("CheckPublishRecipientPlan: %v", err)
+	}
+	if deliveryRoutesContain(plan.DeliveryRoutes, forbidden) {
+		t.Fatalf("preflight delivery routes = %#v, must not include root-connect receiver for child-scoped same-name event", plan.DeliveryRoutes)
+	}
+}
+
 func TestEventBusCheckPublishRecipientPlan_ConnectRoutePlanPrecedesLegacyDescriptorPolicy(t *testing.T) {
 	source := connectRoutePlanStaticSource(runtimecontracts.FlowPackageConnect{
 		From:     "producer.deploy_done",

--- a/internal/runtime/bus/connect_route_plan_dispatch_test.go
+++ b/internal/runtime/bus/connect_route_plan_dispatch_test.go
@@ -185,6 +185,66 @@ func TestEventBusPublish_ConnectRoutePlanPersistsSingularTargetWithoutLiveSubscr
 	}
 }
 
+func TestEventBusPublish_RootConnectRoutePlanPersistsSingularTarget(t *testing.T) {
+	source := connectRoutePlanRootProducerStaticSource()
+	store := newTargetRouteMemoryStore()
+	eb, err := NewEventBusWithOptions(store, EventBusOptions{ContractBundle: source})
+	if err != nil {
+		t.Fatalf("NewEventBusWithOptions: %v", err)
+	}
+	receiverCarriers := eb.RouteTable().Resolve("consumer/root.ready")
+	if !subscriberListContainsRouteSource(receiverCarriers, "consumer-node", "consumer", "receiver_carrier") {
+		t.Fatalf("receiver carrier route consumer/root.ready = %#v, want consumer-node receiver_carrier", receiverCarriers)
+	}
+	eventID := uuid.NewString()
+	evt := events.NewProjectionEvent(eventID,
+		events.EventType("root.ready"), "", "", json.RawMessage(`{"entity_id":"entity-1"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())
+	want := events.DeliveryRoute{
+		SubscriberType: "node",
+		SubscriberID:   "consumer-node",
+		Target: events.RouteIdentity{
+			FlowID:       "consumer",
+			FlowInstance: "consumer",
+			EntityID:     runtimeflowidentity.EntityID("consumer"),
+		},
+	}
+
+	routePlan, err := eb.planSubscribedRoutePlan(context.Background(), evt, false)
+	if err != nil {
+		t.Fatalf("planSubscribedRoutePlan: %v", err)
+	}
+	if routePlan.AuthorityState != RoutePlanAuthorityCanonicalMatched || routePlan.AuthorityOwner != routePlanSourceConnectRoutePlan {
+		t.Fatalf("route plan authority = %q/%q, want matched root connect route plan", routePlan.AuthorityState, routePlan.AuthorityOwner)
+	}
+	if !deliveryRoutesContain(routePlan.DeliveryRoutes(), want) {
+		t.Fatalf("route plan delivery routes = %#v, want %#v", routePlan.DeliveryRoutes(), want)
+	}
+
+	plan, err := eb.CheckPublishRecipientPlan(context.Background(), evt)
+	if err != nil {
+		t.Fatalf("CheckPublishRecipientPlan: %v", err)
+	}
+	if plan.TargetFailure != "" {
+		t.Fatalf("target failure = %q, want none", plan.TargetFailure)
+	}
+	if !deliveryRoutesContain(plan.DeliveryRoutes, want) {
+		t.Fatalf("preflight delivery routes = %#v, want %#v", plan.DeliveryRoutes, want)
+	}
+
+	if err := eb.Publish(context.Background(), evt); err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+	if routes := store.routes[eventID]; !deliveryRoutesContain(routes, want) {
+		t.Fatalf("persisted delivery routes = %#v, want %#v", routes, want)
+	}
+	if got := store.scopes[eventID]; got != runtimereplayclaim.CommittedReplayScopeSubscribed {
+		t.Fatalf("committed replay scope = %q, want subscribed", got)
+	}
+	if got := store.receipts[eventID]; got != "processed" {
+		t.Fatalf("pipeline receipt = %q, want processed", got)
+	}
+}
+
 func TestEventBusCheckPublishRecipientPlan_ConnectRoutePlanPrecedesLegacyDescriptorPolicy(t *testing.T) {
 	source := connectRoutePlanStaticSource(runtimecontracts.FlowPackageConnect{
 		From:     "producer.deploy_done",
@@ -1043,6 +1103,43 @@ func connectRoutePlanStaticSource(connect runtimecontracts.FlowPackageConnect) s
 			},
 		},
 	}, []runtimecontracts.FlowPackageConnect{connect}))
+}
+
+func connectRoutePlanRootProducerStaticSource() semanticview.Source {
+	bundle := connectRoutePlanTestBundle([]connectRoutePlanTestFlow{
+		{
+			id:   "consumer",
+			mode: "static",
+			inputs: []runtimecontracts.FlowInputEventPin{{
+				Name:  "ready",
+				Event: "root.ready",
+			}},
+			nodes: map[string]runtimecontracts.SystemNodeContract{
+				"consumer-node": {
+					ID:            "consumer-node",
+					EventHandlers: map[string]runtimecontracts.SystemNodeEventHandler{"root.ready": {}},
+				},
+			},
+		},
+	}, []runtimecontracts.FlowPackageConnect{{
+		From:     ".root_ready",
+		To:       "consumer.ready",
+		Delivery: "one",
+	}})
+	bundle.RootSchema = &runtimecontracts.FlowSchemaDocument{
+		Pins: runtimecontracts.FlowPins{
+			Outputs: runtimecontracts.FlowOutputPins{
+				EventPins: []runtimecontracts.FlowOutputEventPin{{
+					Name:  "root_ready",
+					Event: "root.ready",
+				}},
+			},
+		},
+	}
+	bundle.Events = map[string]runtimecontracts.EventCatalogEntry{
+		"root.ready": {},
+	}
+	return semanticview.Wrap(bundle)
 }
 
 func connectRoutePlanStaticDeliveryRoute() events.DeliveryRoute {

--- a/internal/runtime/cataloge2e/tier12_runtime_fork_e2e_test.go
+++ b/internal/runtime/cataloge2e/tier12_runtime_fork_e2e_test.go
@@ -428,9 +428,13 @@ func publishCatalogTriggerAtFuture(t testing.TB, h *runtimeHarness, step catalog
 		t.Fatalf("marshal trigger payload: %v", err)
 	}
 	eventID := uuid.NewString()
+	future := timeout + time.Second
+	if future <= time.Second {
+		future = time.Second
+	}
 	evt := events.NewProjectionEvent(eventID,
 		events.EventType(strings.TrimSpace(step.Event)),
-		"cataloge2e", "", raw, 0, catalogRuntimeRunID, "", events.EventEnvelope{}, time.Now().UTC().Add(time.Second))
+		"cataloge2e", "", raw, 0, catalogRuntimeRunID, "", events.EventEnvelope{}, time.Now().UTC().Add(future))
 
 	if entityID := triggerPayloadEntityID(payload); entityID != "" {
 		evt = evt.WithEntityID(entityID)

--- a/internal/runtime/contracts/workflow_contract_accessors.go
+++ b/internal/runtime/contracts/workflow_contract_accessors.go
@@ -399,19 +399,30 @@ func (b *WorkflowContractBundle) FlowInputEvents(flowID string) []string {
 	if b == nil {
 		return nil
 	}
-	return append([]string{}, b.Semantics.FlowInputs[strings.TrimSpace(flowID)]...)
+	flowID = strings.TrimSpace(flowID)
+	if flowID == "" && b.RootSchema != nil {
+		return append([]string{}, b.RootSchema.Pins.Inputs.Events...)
+	}
+	return append([]string{}, b.Semantics.FlowInputs[flowID]...)
 }
 func (b *WorkflowContractBundle) FlowOutputEvents(flowID string) []string {
 	if b == nil {
 		return nil
 	}
-	return append([]string{}, b.Semantics.FlowOutputs[strings.TrimSpace(flowID)]...)
+	flowID = strings.TrimSpace(flowID)
+	if flowID == "" && b.RootSchema != nil {
+		return append([]string{}, b.RootSchema.Pins.Outputs.Events...)
+	}
+	return append([]string{}, b.Semantics.FlowOutputs[flowID]...)
 }
 func (b *WorkflowContractBundle) FlowInputEventPins(flowID string) []FlowInputEventPin {
 	if b == nil {
 		return nil
 	}
 	flowID = strings.TrimSpace(flowID)
+	if flowID == "" && b.RootSchema != nil {
+		return semanticInputEventPins(b.RootSchema.Pins.Inputs)
+	}
 	if pins := b.Semantics.FlowInputEventPins[flowID]; len(pins) > 0 {
 		return cloneFlowInputEventPins(pins)
 	}
@@ -425,6 +436,9 @@ func (b *WorkflowContractBundle) FlowOutputEventPins(flowID string) []FlowOutput
 		return nil
 	}
 	flowID = strings.TrimSpace(flowID)
+	if flowID == "" && b.RootSchema != nil {
+		return semanticOutputEventPins(b.RootSchema.Pins.Outputs)
+	}
 	if pins := b.Semantics.FlowOutputEventPins[flowID]; len(pins) > 0 {
 		return cloneFlowOutputEventPins(pins)
 	}
@@ -466,7 +480,7 @@ func (b *WorkflowContractBundle) CompositionConnects() []FlowPackageConnect {
 func (b *WorkflowContractBundle) CompositionConnectsTo(flowID, pinName string) []FlowPackageConnect {
 	flowID = strings.TrimSpace(flowID)
 	pinName = strings.TrimSpace(pinName)
-	if b == nil || flowID == "" || pinName == "" {
+	if b == nil || pinName == "" {
 		return nil
 	}
 	var out []FlowPackageConnect
@@ -475,7 +489,7 @@ func (b *WorkflowContractBundle) CompositionConnectsTo(flowID, pinName string) [
 		if err != nil {
 			continue
 		}
-		if ref.FlowID == flowID && ref.Pin == pinName {
+		if flowPackagePinRefMatches(ref, flowID, pinName) {
 			out = append(out, connect)
 		}
 	}
@@ -484,7 +498,7 @@ func (b *WorkflowContractBundle) CompositionConnectsTo(flowID, pinName string) [
 func (b *WorkflowContractBundle) CompositionConnectsFrom(flowID, pinName string) []FlowPackageConnect {
 	flowID = strings.TrimSpace(flowID)
 	pinName = strings.TrimSpace(pinName)
-	if b == nil || flowID == "" || pinName == "" {
+	if b == nil || pinName == "" {
 		return nil
 	}
 	var out []FlowPackageConnect
@@ -493,11 +507,23 @@ func (b *WorkflowContractBundle) CompositionConnectsFrom(flowID, pinName string)
 		if err != nil {
 			continue
 		}
-		if ref.FlowID == flowID && ref.Pin == pinName {
+		if flowPackagePinRefMatches(ref, flowID, pinName) {
 			out = append(out, connect)
 		}
 	}
 	return out
+}
+
+func flowPackagePinRefMatches(ref FlowPackagePinRef, flowID, pinName string) bool {
+	flowID = strings.TrimSpace(flowID)
+	pinName = strings.TrimSpace(pinName)
+	if pinName == "" {
+		return false
+	}
+	if ref.Root {
+		return flowID == "" && strings.TrimSpace(ref.Pin) == pinName
+	}
+	return strings.TrimSpace(ref.FlowID) == flowID && strings.TrimSpace(ref.Pin) == pinName
 }
 func (b *WorkflowContractBundle) FlowReadPins(flowID string) []string {
 	if b == nil {
@@ -948,8 +974,15 @@ func (b *WorkflowContractBundle) flowLocalEvents(flowID string) []string {
 
 func (b *WorkflowContractBundle) flowEventScope(flowID string) eventidentity.Scope {
 	flowID = strings.TrimSpace(flowID)
-	if b == nil || flowID == "" {
+	if b == nil {
 		return eventidentity.Scope{}
+	}
+	if flowID == "" {
+		return eventidentity.Scope{
+			LocalEvents:  b.rootLocalEvents(),
+			InputEvents:  b.FlowInputEvents(""),
+			OutputEvents: b.FlowOutputEvents(""),
+		}
 	}
 	view, ok := b.FlowViewByID(flowID)
 	if !ok || view == nil {
@@ -961,6 +994,41 @@ func (b *WorkflowContractBundle) flowEventScope(flowID string) eventidentity.Sco
 		InputEvents:  append([]string{}, view.Schema.Pins.Inputs.Events...),
 		OutputEvents: append([]string{}, view.Schema.Pins.Outputs.Events...),
 	}
+}
+
+func (b *WorkflowContractBundle) rootLocalEvents() []string {
+	if b == nil {
+		return nil
+	}
+	seen := make(map[string]struct{})
+	out := make([]string, 0)
+	appendEvent := func(eventType string) {
+		eventType = strings.TrimSpace(eventType)
+		if eventType == "" {
+			return
+		}
+		if _, ok := seen[eventType]; ok {
+			return
+		}
+		seen[eventType] = struct{}{}
+		out = append(out, eventType)
+	}
+	if b.RootSchema != nil {
+		for _, eventType := range b.RootSchema.Pins.Inputs.Events {
+			appendEvent(eventType)
+		}
+		for _, eventType := range b.RootSchema.Pins.Outputs.Events {
+			appendEvent(eventType)
+		}
+		if autoEmit := strings.TrimSpace(b.RootSchema.AutoEmitOnCreate.Event); autoEmit != "" {
+			appendEvent(autoEmit)
+		}
+	}
+	for eventType := range b.Events {
+		appendEvent(eventType)
+	}
+	sort.Strings(out)
+	return out
 }
 
 func (b *WorkflowContractBundle) flowEventDescendants(flowID string) []eventidentity.DescendantScope {

--- a/internal/runtime/contracts/workflow_contract_connect.go
+++ b/internal/runtime/contracts/workflow_contract_connect.go
@@ -95,16 +95,26 @@ func parseFlowPackagePinRef(raw string) (FlowPackagePinRef, error) {
 	if raw == "" {
 		return FlowPackagePinRef{}, fmt.Errorf("pin reference is required")
 	}
+	if strings.HasPrefix(raw, ".") {
+		pin := strings.TrimSpace(strings.TrimPrefix(raw, "."))
+		if pin == "" {
+			return FlowPackagePinRef{}, fmt.Errorf("pin reference %q must use .{root_pin_name} or {flow_id}.{pin_name}", raw)
+		}
+		return FlowPackagePinRef{
+			Root: true,
+			Pin:  pin,
+		}, nil
+	}
 	idx := strings.Index(raw, ".")
 	if idx <= 0 || idx >= len(raw)-1 {
-		return FlowPackagePinRef{}, fmt.Errorf("pin reference %q must use {flow_id}.{pin_name}", raw)
+		return FlowPackagePinRef{}, fmt.Errorf("pin reference %q must use .{root_pin_name} or {flow_id}.{pin_name}", raw)
 	}
 	ref := FlowPackagePinRef{
 		FlowID: strings.TrimSpace(raw[:idx]),
 		Pin:    strings.TrimSpace(raw[idx+1:]),
 	}
 	if ref.FlowID == "" || ref.Pin == "" {
-		return FlowPackagePinRef{}, fmt.Errorf("pin reference %q must use non-empty flow and pin names", raw)
+		return FlowPackagePinRef{}, fmt.Errorf("pin reference %q must use .{root_pin_name} or non-empty flow and pin names", raw)
 	}
 	return ref, nil
 }

--- a/internal/runtime/contracts/workflow_contract_types.go
+++ b/internal/runtime/contracts/workflow_contract_types.go
@@ -765,6 +765,7 @@ type FlowPackageConnectMap struct {
 	Target string `yaml:"target"`
 }
 type FlowPackagePinRef struct {
+	Root   bool
 	FlowID string
 	Pin    string
 }

--- a/internal/runtime/core/pinrouting/connect_route_plan.go
+++ b/internal/runtime/core/pinrouting/connect_route_plan.go
@@ -36,6 +36,7 @@ const (
 	ConnectFailurePinRefInvalid              ConnectRoutePlanFailure = "connect_pin_ref_invalid"
 	ConnectFailureProducerFlowMissing        ConnectRoutePlanFailure = "producer_flow_missing"
 	ConnectFailureProducerOutputPinMissing   ConnectRoutePlanFailure = "producer_output_pin_missing"
+	ConnectFailureReceiverRootUnsupported    ConnectRoutePlanFailure = "receiver_root_unsupported"
 	ConnectFailureReceiverFlowMissing        ConnectRoutePlanFailure = "receiver_flow_missing"
 	ConnectFailureReceiverInputPinMissing    ConnectRoutePlanFailure = "receiver_input_pin_missing"
 	ConnectFailureReceiverAddressRuleMissing ConnectRoutePlanFailure = "receiver_address_rule_missing"
@@ -48,6 +49,7 @@ const (
 )
 
 type ConnectRoutePlanEndpoint struct {
+	Root          bool
 	FlowID        string
 	FlowPath      string
 	Mode          string
@@ -144,17 +146,16 @@ func LowerCompositionConnectRoutePlan(source semanticview.Source, connect runtim
 	if err != nil {
 		return ConnectRoutePlan{}, ConnectRoutePlanIssue{Connect: connect, Failure: ConnectFailurePinRefInvalid, Detail: err.Error()}
 	}
-	sourceScope, ok := source.FlowScopeByID(from.FlowID)
-	if !ok {
-		return ConnectRoutePlan{}, ConnectRoutePlanIssue{Connect: connect, Failure: ConnectFailureProducerFlowMissing, Detail: from.FlowID}
+	sourceEndpoint, _, sourceIssue := connectRoutePlanSourceEndpoint(source, from, connect)
+	if sourceIssue.Failure != "" {
+		return ConnectRoutePlan{}, sourceIssue
+	}
+	if to.Root {
+		return ConnectRoutePlan{}, ConnectRoutePlanIssue{Connect: connect, Failure: ConnectFailureReceiverRootUnsupported, Detail: strings.TrimSpace(connect.To)}
 	}
 	receiverScope, ok := source.FlowScopeByID(to.FlowID)
 	if !ok {
 		return ConnectRoutePlan{}, ConnectRoutePlanIssue{Connect: connect, Failure: ConnectFailureReceiverFlowMissing, Detail: to.FlowID}
-	}
-	outputPin, ok := source.FlowOutputEventPin(from.FlowID, from.Pin)
-	if !ok {
-		return ConnectRoutePlan{}, ConnectRoutePlanIssue{Connect: connect, Failure: ConnectFailureProducerOutputPinMissing, Detail: connect.From}
 	}
 	inputPin, ok := source.FlowInputEventPin(to.FlowID, to.Pin)
 	if !ok {
@@ -171,14 +172,7 @@ func LowerCompositionConnectRoutePlan(source semanticview.Source, connect runtim
 	targetKind := connectTargetKind(delivery)
 	plan := ConnectRoutePlan{
 		PackageKey: strings.TrimSpace(connect.PackageKey),
-		Source: ConnectRoutePlanEndpoint{
-			FlowID:        strings.TrimSpace(from.FlowID),
-			FlowPath:      strings.Trim(strings.TrimSpace(sourceScope.Path), "/"),
-			Mode:          strings.TrimSpace(sourceScope.Mode),
-			Pin:           strings.TrimSpace(from.Pin),
-			Event:         eventidentity.Normalize(outputPin.EventType()),
-			ResolvedEvent: eventidentity.Normalize(source.ResolveFlowEventReference(from.FlowID, outputPin.EventType())),
-		},
+		Source:     sourceEndpoint,
 		Receiver: ConnectRoutePlanEndpoint{
 			FlowID:        strings.TrimSpace(to.FlowID),
 			FlowPath:      strings.Trim(strings.TrimSpace(receiverScope.Path), "/"),
@@ -208,6 +202,38 @@ func LowerCompositionConnectRoutePlan(source semanticview.Source, connect runtim
 	}
 	plan.RequiresRuntimeResolution = true
 	return plan, ConnectRoutePlanIssue{}
+}
+
+func connectRoutePlanSourceEndpoint(source semanticview.Source, from runtimecontracts.FlowPackagePinRef, connect runtimecontracts.FlowPackageConnect) (ConnectRoutePlanEndpoint, runtimecontracts.FlowOutputEventPin, ConnectRoutePlanIssue) {
+	if from.Root {
+		outputPin, ok := source.FlowOutputEventPin("", from.Pin)
+		if !ok {
+			return ConnectRoutePlanEndpoint{}, runtimecontracts.FlowOutputEventPin{}, ConnectRoutePlanIssue{Connect: connect, Failure: ConnectFailureProducerOutputPinMissing, Detail: strings.TrimSpace(connect.From)}
+		}
+		return ConnectRoutePlanEndpoint{
+			Root:          true,
+			Pin:           strings.TrimSpace(from.Pin),
+			Event:         eventidentity.Normalize(outputPin.EventType()),
+			ResolvedEvent: eventidentity.Normalize(source.ResolveFlowEventReference("", outputPin.EventType())),
+			Mode:          "root",
+		}, outputPin, ConnectRoutePlanIssue{}
+	}
+	sourceScope, ok := source.FlowScopeByID(from.FlowID)
+	if !ok {
+		return ConnectRoutePlanEndpoint{}, runtimecontracts.FlowOutputEventPin{}, ConnectRoutePlanIssue{Connect: connect, Failure: ConnectFailureProducerFlowMissing, Detail: strings.TrimSpace(from.FlowID)}
+	}
+	outputPin, ok := source.FlowOutputEventPin(from.FlowID, from.Pin)
+	if !ok {
+		return ConnectRoutePlanEndpoint{}, runtimecontracts.FlowOutputEventPin{}, ConnectRoutePlanIssue{Connect: connect, Failure: ConnectFailureProducerOutputPinMissing, Detail: strings.TrimSpace(connect.From)}
+	}
+	return ConnectRoutePlanEndpoint{
+		FlowID:        strings.TrimSpace(from.FlowID),
+		FlowPath:      strings.Trim(strings.TrimSpace(sourceScope.Path), "/"),
+		Mode:          strings.TrimSpace(sourceScope.Mode),
+		Pin:           strings.TrimSpace(from.Pin),
+		Event:         eventidentity.Normalize(outputPin.EventType()),
+		ResolvedEvent: eventidentity.Normalize(source.ResolveFlowEventReference(from.FlowID, outputPin.EventType())),
+	}, outputPin, ConnectRoutePlanIssue{}
 }
 
 func MaterializeConnectRoutePlan(plan ConnectRoutePlan, input ConnectRoutePlanMaterializationInput) ConnectRoutePlanMaterialization {

--- a/internal/runtime/core/pinrouting/connect_route_plan_test.go
+++ b/internal/runtime/core/pinrouting/connect_route_plan_test.go
@@ -128,6 +128,80 @@ func TestLowerCompositionConnectRoutePlansOneToOneStatic(t *testing.T) {
 	}
 }
 
+func TestLowerCompositionConnectRoutePlansRootProducerToStaticReceiver(t *testing.T) {
+	source := testRootConnectRoutePlanSource([]runtimecontracts.FlowOutputEventPin{{
+		Name:  "root_ready",
+		Event: "root.ready",
+	}}, []connectRoutePlanFlow{
+		{
+			id:   "consumer",
+			mode: "static",
+			inputs: []runtimecontracts.FlowInputEventPin{{
+				Name:  "ready",
+				Event: "root.ready",
+			}},
+		},
+	}, []runtimecontracts.FlowPackageConnect{{
+		From:     ".root_ready",
+		To:       "consumer.ready",
+		Delivery: "one",
+	}})
+
+	plans, issues := LowerCompositionConnectRoutePlans(source)
+	if len(issues) != 0 {
+		t.Fatalf("issues = %#v, want none", issues)
+	}
+	if len(plans) != 1 {
+		t.Fatalf("plans = %#v, want one", plans)
+	}
+	plan := plans[0]
+	if !plan.Source.Root {
+		t.Fatalf("Source.Root = false, want true: %#v", plan.Source)
+	}
+	if got, want := plan.Source.FlowID, ""; got != want {
+		t.Fatalf("Source.FlowID = %q, want root empty flow id", got)
+	}
+	if got, want := plan.Source.Pin, "root_ready"; got != want {
+		t.Fatalf("Source.Pin = %q, want %q", got, want)
+	}
+	if got, want := plan.Source.ResolvedEvent, "root.ready"; got != want {
+		t.Fatalf("Source.ResolvedEvent = %q, want %q", got, want)
+	}
+	if got, want := plan.Receiver.FlowID, "consumer"; got != want {
+		t.Fatalf("Receiver.FlowID = %q, want %q", got, want)
+	}
+	if plan.Target.FlowInstance != "consumer" {
+		t.Fatalf("Target.FlowInstance = %q, want consumer", plan.Target.FlowInstance)
+	}
+}
+
+func TestLowerCompositionConnectRoutePlansRejectsRootReceiverEndpoint(t *testing.T) {
+	source := testRootConnectRoutePlanSource([]runtimecontracts.FlowOutputEventPin{{
+		Name:  "root_ready",
+		Event: "root.ready",
+	}}, []connectRoutePlanFlow{
+		{
+			id:   "producer",
+			mode: "static",
+			outputs: []runtimecontracts.FlowOutputEventPin{{
+				Name:  "ready",
+				Event: "root.ready",
+			}},
+		},
+	}, []runtimecontracts.FlowPackageConnect{{
+		From: "producer.ready",
+		To:   ".root_ready",
+	}})
+
+	plans, issues := LowerCompositionConnectRoutePlans(source)
+	if len(plans) != 0 {
+		t.Fatalf("plans = %#v, want none", plans)
+	}
+	if len(issues) != 1 || issues[0].Failure != ConnectFailureReceiverRootUnsupported {
+		t.Fatalf("issues = %#v, want receiver_root_unsupported", issues)
+	}
+}
+
 func TestMaterializeConnectRoutePlanFanoutForTemplateDescriptors(t *testing.T) {
 	source := testConnectRoutePlanSource([]connectRoutePlanFlow{
 		{
@@ -438,6 +512,10 @@ type connectRoutePlanFlow struct {
 }
 
 func testConnectRoutePlanSource(flows []connectRoutePlanFlow, connects []runtimecontracts.FlowPackageConnect) semanticview.Source {
+	return testRootConnectRoutePlanSource(nil, flows, connects)
+}
+
+func testRootConnectRoutePlanSource(rootOutputs []runtimecontracts.FlowOutputEventPin, flows []connectRoutePlanFlow, connects []runtimecontracts.FlowPackageConnect) semanticview.Source {
 	children := make([]runtimecontracts.FlowContractView, 0, len(flows))
 	byID := make(map[string]*runtimecontracts.FlowContractView, len(flows))
 	inputPins := make(map[string][]runtimecontracts.FlowInputEventPin, len(flows))
@@ -476,6 +554,17 @@ func testConnectRoutePlanSource(flows []connectRoutePlanFlow, connects []runtime
 		flowSchemas[flow.id] = view.Schema
 	}
 	return semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
+		RootSchema: &runtimecontracts.FlowSchemaDocument{
+			Pins: runtimecontracts.FlowPins{
+				Outputs: runtimecontracts.FlowOutputPins{
+					Events:    outputEventNames(rootOutputs),
+					EventPins: rootOutputs,
+				},
+			},
+		},
+		Events: map[string]runtimecontracts.EventCatalogEntry{
+			"root.ready": {},
+		},
 		Semantics: runtimecontracts.WorkflowSemanticView{
 			FlowInputs:          flowInputs,
 			FlowOutputs:         flowOutputs,

--- a/internal/runtime/core/pinrouting/pinrouting.go
+++ b/internal/runtime/core/pinrouting/pinrouting.go
@@ -103,15 +103,16 @@ func ProducerRouteCommonPathFailure(source semanticview.Source, flowID, eventTyp
 	if source == nil || eventType == "" || !PinDeclaredOutput(source, flowID, eventType) {
 		return ""
 	}
-	if flowID == "" {
-		return ""
-	}
-	if _, ok := source.FlowScopeByID(flowID); !ok {
+	if flowID != "" {
+		if _, ok := source.FlowScopeByID(flowID); !ok {
+			return ""
+		}
+	} else if !compositionConnectsFromOutputEvent(source, flowID, eventType) {
 		return ""
 	}
 	if spec.Broadcast {
 		if compositionConnectsFromOutputEvent(source, flowID, eventType) ||
-			producerRouteKnownReceiverConsumesOutput(source, flowID, eventType, "") {
+			(flowID != "" && producerRouteKnownReceiverConsumesOutput(source, flowID, eventType, "")) {
 			return FailureProducerBroadcastCommonPath
 		}
 		return ""
@@ -125,7 +126,7 @@ func ProducerRouteCommonPathFailure(source semanticview.Source, flowID, eventTyp
 		return ""
 	case runtimecontracts.EmitTargetKindFlowMatch:
 		if compositionConnectsFromOutputEventToFlow(source, flowID, eventType, target.Flow) ||
-			producerRouteKnownReceiverConsumesOutput(source, flowID, eventType, target.Flow) {
+			(flowID != "" && producerRouteKnownReceiverConsumesOutput(source, flowID, eventType, target.Flow)) {
 			return FailureProducerTargetCommonPath
 		}
 	}
@@ -269,16 +270,15 @@ func eventReferencesMatch(left, right string) bool {
 }
 
 func rootPinDeclaredOutput(source semanticview.Source, eventType string) bool {
-	bundle, ok := semanticview.Bundle(source)
-	if !ok || bundle == nil || bundle.RootSchema == nil {
+	if source == nil {
 		return false
 	}
 	eventType = eventidentity.Normalize(eventType)
 	if eventType == "" {
 		return false
 	}
-	for _, output := range bundle.RootSchema.Pins.Outputs.Events {
-		output = eventidentity.Normalize(output)
+	for _, pin := range source.FlowOutputEventPins("") {
+		output := eventidentity.Normalize(pin.EventType())
 		if output == "" {
 			continue
 		}

--- a/internal/runtime/core/pinrouting/pinrouting_test.go
+++ b/internal/runtime/core/pinrouting/pinrouting_test.go
@@ -108,6 +108,60 @@ func TestResolveFailsClosedForRootPinOutputWithoutTargetMechanism(t *testing.T) 
 	}
 }
 
+func TestResolveAllowsRootPinOutputWithRootConnectAuthority(t *testing.T) {
+	result := Resolve(ResolutionInput{
+		Source:    testRootConnectPinRoutingSource(),
+		EventType: "root.ready",
+	}, events.NewProjectionEvent("", "root.ready", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}))
+
+	if result.Failure != "" {
+		t.Fatalf("Failure = %q, want empty", result.Failure)
+	}
+	if result.Broadcast {
+		t.Fatal("root connect authority should not lower to producer broadcast")
+	}
+	if got := result.Event.TargetRoute(); !got.Empty() {
+		t.Fatalf("Event target = %#v, want EventBus RoutePlan authority", got)
+	}
+}
+
+func TestResolveFailsClosedForRootProducerBroadcastCommonCompositionPath(t *testing.T) {
+	result := Resolve(ResolutionInput{
+		Source:    testRootConnectPinRoutingSource(),
+		EventType: "root.ready",
+		Emit: runtimecontracts.EmitSpec{
+			Broadcast: true,
+		},
+	}, events.NewProjectionEvent("", "root.ready", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}))
+
+	if result.Failure != FailureProducerBroadcastCommonPath {
+		t.Fatalf("Failure = %q, want %q", result.Failure, FailureProducerBroadcastCommonPath)
+	}
+	if result.Broadcast {
+		t.Fatal("root producer broadcast repaired a canonical root connect route")
+	}
+}
+
+func TestResolveFailsClosedForRootProducerTargetCommonCompositionPath(t *testing.T) {
+	result := Resolve(ResolutionInput{
+		Source:    testRootConnectPinRoutingSource(),
+		EventType: "root.ready",
+		Emit: runtimecontracts.EmitSpec{
+			Target: runtimecontracts.EmitTargetSpec{
+				Flow:  "consumer",
+				Match: map[string]runtimecontracts.ExpressionValue{"entity_id": runtimecontracts.RefExpression("payload.entity_id")},
+			},
+		},
+	}, events.NewProjectionEvent("", "root.ready", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}))
+
+	if result.Failure != FailureProducerTargetCommonPath {
+		t.Fatalf("Failure = %q, want %q", result.Failure, FailureProducerTargetCommonPath)
+	}
+	if got := result.Event.TargetRoute(); !got.Empty() {
+		t.Fatalf("Event target = %#v, want empty on root producer target common path", got)
+	}
+}
+
 func TestResolveFailsClosedForProducerTargetCommonCompositionPath(t *testing.T) {
 	result := Resolve(ResolutionInput{
 		Source:    testProducerCommonPathSource(),
@@ -602,6 +656,64 @@ func testRootPinRoutingSource() semanticview.Source {
 		},
 		Events: map[string]runtimecontracts.EventCatalogEntry{
 			"root.ready": {},
+		},
+	})
+}
+
+func testRootConnectPinRoutingSource() semanticview.Source {
+	consumer := runtimecontracts.FlowContractView{
+		Paths: runtimecontracts.FlowContractPaths{
+			ID:   "consumer",
+			Flow: "consumer",
+		},
+		Schema: runtimecontracts.FlowSchemaDocument{
+			Pins: runtimecontracts.FlowPins{
+				Inputs: runtimecontracts.FlowInputPins{
+					EventPins: []runtimecontracts.FlowInputEventPin{{
+						Name:  "ready",
+						Event: "root.ready",
+					}},
+				},
+			},
+		},
+		Path: "consumer",
+	}
+	return semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
+		RootSchema: &runtimecontracts.FlowSchemaDocument{
+			Pins: runtimecontracts.FlowPins{
+				Outputs: runtimecontracts.FlowOutputPins{
+					EventPins: []runtimecontracts.FlowOutputEventPin{{
+						Name:  "root_ready",
+						Event: "root.ready",
+					}},
+				},
+			},
+		},
+		Events: map[string]runtimecontracts.EventCatalogEntry{
+			"root.ready": {},
+		},
+		FlowSchemas: map[string]runtimecontracts.FlowSchemaDocument{
+			"consumer": consumer.Schema,
+		},
+		Semantics: runtimecontracts.WorkflowSemanticView{
+			FlowInputs: map[string][]string{
+				"consumer": {"root.ready"},
+			},
+			FlowInputEventPins: map[string][]runtimecontracts.FlowInputEventPin{
+				"consumer": {{Name: "ready", Event: "root.ready"}},
+			},
+			CompositionConnects: []runtimecontracts.FlowPackageConnect{{
+				From: ".root_ready",
+				To:   "consumer.ready",
+			}},
+		},
+		FlowTree: flowmodel.Tree[runtimecontracts.FlowContractView]{
+			Root: &runtimecontracts.FlowContractView{
+				Children: []runtimecontracts.FlowContractView{consumer},
+			},
+			ByID: map[string]*runtimecontracts.FlowContractView{
+				"consumer": &consumer,
+			},
 		},
 	})
 }

--- a/internal/runtime/semanticview/composition_connect_test.go
+++ b/internal/runtime/semanticview/composition_connect_test.go
@@ -61,6 +61,43 @@ func TestCompositionConnectFactsExposeTypedPinsAndParentConnect(t *testing.T) {
 	}
 }
 
+func TestCompositionConnectFactsExposeRootProducerEndpoint(t *testing.T) {
+	repoRoot, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd: %v", err)
+	}
+	repoRoot = filepath.Clean(filepath.Join(repoRoot, "..", "..", ".."))
+	root := writeRootCompositionConnectSemanticFixture(t)
+	bundle, err := runtimecontracts.LoadWorkflowContractBundleWithOverrides(repoRoot, root, runtimecontracts.DefaultPlatformSpecFile(repoRoot))
+	if err != nil {
+		t.Fatalf("LoadWorkflowContractBundleWithOverrides: %v", err)
+	}
+	source := Wrap(bundle)
+
+	outputPins := source.FlowOutputEventPins("")
+	if len(outputPins) != 1 {
+		t.Fatalf("root FlowOutputEventPins = %#v, want one", outputPins)
+	}
+	if got, want := outputPins[0].PinName(), "root_ready"; got != want {
+		t.Fatalf("root output pin name = %q, want %q", got, want)
+	}
+
+	connects := source.CompositionConnects()
+	if len(connects) != 1 {
+		t.Fatalf("CompositionConnects = %#v, want one", connects)
+	}
+	from, err := connects[0].FromRef()
+	if err != nil {
+		t.Fatalf("FromRef: %v", err)
+	}
+	if !from.Root || from.FlowID != "" || from.Pin != "root_ready" {
+		t.Fatalf("FromRef = %#v, want root root_ready", from)
+	}
+	if got, want := source.CompositionConnectsFrom("", "root_ready"), connects; len(got) != len(want) || got[0].From != want[0].From {
+		t.Fatalf("CompositionConnectsFrom root = %#v, want %#v", got, want)
+	}
+}
+
 func writeCompositionConnectSemanticFixture(t *testing.T) string {
 	t.Helper()
 	root := t.TempDir()
@@ -113,6 +150,45 @@ deployment:
   vertical_id:
     type: string
 `)
+	return root
+}
+
+func writeRootCompositionConnectSemanticFixture(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	writeSemanticviewFixtureFile(t, filepath.Join(root, "package.yaml"), `
+name: root-composition-connect-semantic
+version: "1.0.0"
+platform_version: ">=1.6.0"
+flows:
+  - id: consumer
+    flow: consumer
+    mode: static
+connect:
+  - from: .root_ready
+    to: consumer.ready
+    delivery: one
+`)
+	writeSemanticviewFixtureFile(t, filepath.Join(root, "schema.yaml"), `
+name: root-composition-connect-semantic
+pins:
+  outputs:
+    events:
+      - name: root_ready
+        event: root.ready
+`)
+	writeSemanticviewFixtureFile(t, filepath.Join(root, "policy.yaml"), "{}\n")
+	writeSemanticviewFixtureFile(t, filepath.Join(root, "tools.yaml"), "{}\n")
+	writeSemanticviewFixtureFile(t, filepath.Join(root, "agents.yaml"), "{}\n")
+	writeSemanticviewFixtureFile(t, filepath.Join(root, "events.yaml"), "root.ready: {}\n")
+	writeSemanticviewFixtureFile(t, filepath.Join(root, "nodes.yaml"), "{}\n")
+	writeCompositionConnectFlow(t, root, "consumer", `
+pins:
+  inputs:
+    events:
+      - name: ready
+        event: root.ready
+`, "root.ready: {}\n", "{}\n")
 	return root
 }
 

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -665,9 +665,9 @@ contract_formats:
           unsupported_or_split:
             business_field_descriptor_targets: 'Declared top-level receiver entity fields with indexed: true are implemented by #1479; nested entity paths, arbitrary, undeclared, unindexed, config, and instance business-field descriptor targets remain split to #1466 or later gated children.'
             agent_node_emitter_parity: 'Closed by #1474: generated agent emit tools and node/system emits for supported connected output pins consume the same EventBus RoutePlan authority from lowered parent connect facts.'
-            producer_target_broadcast_retirement: 'Closed by #1475 for loaded flow-scope target.flow/match and broadcast:true common-path package composition; broader root/package composition-first closure remains #1466.'
+            producer_target_broadcast_retirement: 'Closed by #1475 for loaded flow-scope target.flow/match and broadcast:true common-path package composition; #1508 adds explicit package-root producer endpoints and retires root producer target/broadcast common-path composition when root connect authority applies.'
             selected_contract_runfork_readiness: 'Tracked under #1466/watchlist; not closed by #1473.'
-            parent_composition_routing_closure: '#1466 remains open.'
+            parent_composition_routing_closure: '#1466 remains open until root-connect #1508 closeout is merged and audited.'
         inputs:
           event_identity:
             fields:
@@ -1666,12 +1666,14 @@ handler_specification:
           and {flow, match, allow_fanout}. This field is not payload and is the only producer-authored path that may ask
           the platform to populate event.target or event.target_set. It is not the common consumer-routing surface for
           parent-composed flow packages; common cross-flow delivery is owned by parent connect lowering. A loaded flow-scope
-          producer target that selects a loaded package receiver input for the same pin-declared output or a receiver flow
-          reached by the parent connect graph is invalid common-path routing, not an escape hatch.
+          producer target, or package-root producer target from a root output pin consumed by an explicit root connect endpoint,
+          that selects a loaded package receiver input for the same pin-declared output or a receiver flow reached by the parent
+          connect graph is invalid common-path routing, not an escape hatch.
         broadcast: optional boolean. Only true is meaningful. For a pin-declared output, broadcast:true is an explicit
           producer-authored opt-out escape hatch that leaves event.target absent. Parent-authored broadcast/fan-out uses
-          connect lowering rather than producer broadcast. Loaded flow-scope producer broadcast is invalid when it is used
-          as package-internal delivery to known receiver input pins that require parent connect topology.
+          connect lowering rather than producer broadcast. Loaded flow-scope producer broadcast, and package-root producer
+          broadcast from a root output pin consumed by an explicit root connect endpoint, is invalid when it is used as
+          package-internal delivery to receiver input pins that require parent connect topology.
       pin_routing_activation:
         rule: Pin routing activates if and only if the emitted event is declared in the emitter flow's schema.yaml pins.outputs.events.
         ad_hoc_emits: Emits not declared in pins.outputs.events are ordinary event-loop emits and do not require target or broadcast.
@@ -1681,8 +1683,8 @@ handler_specification:
           parent-composed receiver-input routing. No silent fallback to event-type broadcast is allowed.
         explicit_target_precedence: Producer target is an exceptional dynamic-routing escape hatch, not the common route
           owner for parent-composed topology. Lowered parent connect remains the common source authority for connected pins;
-          loaded flow-scope producer target/broadcast on the common path must be removed or fail closed even if a parent
-          connect is also present. Structural binding writes event.target only when the emit site has no explicit target,
+          loaded flow-scope producer target/broadcast and package-root producer target/broadcast on the common path must
+          be removed or fail closed even if a parent connect is also present. Structural binding writes event.target only when the emit site has no explicit target,
           no lowered connect target applies, and broadcast:true is absent.
       target_forms:
         sender: Copy inbound event.source into the new event.target. Sender is the immediate inbound sender, not a chain ancestor.
@@ -1698,11 +1700,12 @@ handler_specification:
         target_unknown_flow: target.flow names a flow outside the loaded registry.
         target_sender_no_inbound: target:sender is used where no inbound event source can exist.
         target_sender_empty_source: target:sender is used where inbound source is statically external or empty.
-        producer_target_common_path_forbidden: A loaded flow-scope producer target.flow/match selects a loaded package
-          receiver input for the same pin-declared output or a receiver flow reached by the parent connect graph;
-          parent connect is the required route owner.
-        producer_broadcast_common_path_forbidden: Loaded flow-scope broadcast:true is used as package-internal delivery to
-          known receiver input pins for the same pin-declared output or connected output pin; parent connect broadcast/fan-out is the required route owner.
+        producer_target_common_path_forbidden: A loaded flow-scope producer or package-root producer target.flow/match
+          selects a loaded package receiver input for the same pin-declared output or a receiver flow reached by the
+          parent connect graph; parent connect is the required route owner.
+        producer_broadcast_common_path_forbidden: Loaded flow-scope or package-root broadcast:true is used as package-internal
+          delivery to receiver input pins for the same pin-declared output or connected output pin; parent connect
+          broadcast/fan-out is the required route owner.
       single_emit_handler_rule: 'A handler top-level emit is valid only when the handler has exactly one possible emit site.
         If the handler also declares rules, on_complete, accumulate.on_timeout, or fan_out emit, boot fails with ambiguity.
         Payload ownership must move to the active emit site.'
@@ -2132,8 +2135,10 @@ engine:
       - source fallback for explicit broadcast or legacy external paths
       explicit_target_escape_hatch: Producer target is only an exceptional dynamic-routing escape hatch. It must not be
         treated as the common parent-composed routing owner and must not replace lowered parent connect as the common source
-        authority for connected pins. target.flow/match from a loaded flow-scope producer that selects a loaded package
-        receiver input for the same pin-declared output or a receiver flow reached by the parent connect graph is illegal common-path composition routing, including when a parent connect or alias/adapter connect also exists.
+        authority for connected pins. target.flow/match from a loaded flow-scope producer, or from a package-root
+        producer output pin consumed by explicit root connect authority, that selects a loaded package receiver input for
+        the same pin-declared output or a receiver flow reached by the parent connect graph is illegal common-path
+        composition routing, including when a parent connect or alias/adapter connect also exists.
       fail_closed: A pin-declared output that has no lowered parent connect route, no explicit target escape hatch, no structural
         ParentRoute, no eligible static child delivery-entity route, and no broadcast:true is invalid.
       no_silent_broadcast_fallback: Missing, malformed, ambiguous, or unreachable targets must fail with a typed reason.
@@ -2146,9 +2151,10 @@ engine:
         is explicit because a parent can have many children of the same flow type.
       flow_match: |
         `target: { flow, match }` resolves target.flow plus declared entity-field matches to exactly one target instance.
-        Zero matches and more than one match fail closed at publish time. From loaded flow-scope producers, it is forbidden
-        as package-internal composition routing when target.flow has a receiver input for the same pin-declared output event or is reached by the parent connect graph;
-        parent connect owns that route.
+        Zero matches and more than one match fail closed at publish time. From loaded flow-scope producers, or package-root
+        producers whose output pin is consumed by explicit root connect authority, it is forbidden as package-internal composition
+        routing when target.flow has a receiver input for the same pin-declared output event or is reached by the parent
+        connect graph; parent connect owns that route.
       flow_match_allow_fanout: |
         `target: { flow, match, allow_fanout: true }` is the explicit dynamic fan-out escape hatch for flow/match targeting.
         It permits more than one matched recipient. Parent-authored fan-out should use connect topology. Publish-time
@@ -2159,8 +2165,9 @@ engine:
       broadcast: |
         `broadcast: true` is the producer-authored explicit opt-out escape hatch for pin-declared output routing. It leaves
         event.target absent and uses the ordinary no-target event-type delivery path. Parent-authored broadcast/fan-out should
-        use connect topology and lower to concrete route-plan facts. From loaded flow-scope producers, broadcast:true is
-        forbidden when it functions as package-internal delivery to loaded receiver input pins for the same pin-declared output or connected output pin.
+        use connect topology and lower to concrete route-plan facts. From loaded flow-scope producers, or package-root
+        producers whose output pin is consumed by explicit root connect authority, broadcast:true is forbidden when it functions as
+        package-internal delivery to loaded receiver input pins for the same pin-declared output or connected output pin.
     structural_binding:
       precedence_guard: Structural binding is lower precedence than lowered parent connect and the explicit target escape
         hatch. It may write event.target only for a child-to-parent pin output when no lowered parent connect target applies,
@@ -2220,11 +2227,12 @@ engine:
         target_unknown_flow: target.flow does not exist in the loaded flow registry.
         target_sender_no_inbound: target:sender appears on a handler whose only triggers cannot supply inbound source.
         target_sender_empty_source: target:sender appears on a handler subscribed only to external-sourced events with empty source.
-        producer_target_common_path_forbidden: A loaded flow-scope producer target.flow/match selects a loaded package
-          receiver input for the same pin-declared output or a receiver flow reached by the parent connect graph;
-          parent connect is the required route owner.
-        producer_broadcast_common_path_forbidden: Loaded flow-scope broadcast:true is used as package-internal delivery to
-          known receiver input pins for the same pin-declared output or connected output pin; parent connect broadcast/fan-out is the required route owner.
+        producer_target_common_path_forbidden: A loaded flow-scope producer or package-root producer target.flow/match
+          selects a loaded package receiver input for the same pin-declared output or a receiver flow reached by the
+          parent connect graph; parent connect is the required route owner.
+        producer_broadcast_common_path_forbidden: Loaded flow-scope or package-root broadcast:true is used as package-internal
+          delivery to receiver input pins for the same pin-declared output or connected output pin; parent connect
+          broadcast/fan-out is the required route owner.
       publish_time_dead_letter:
         target_unreachable_no_subscriber: Target resolution finds no recipient for the requested target.
         target_unreachable_terminated: Target or ParentRoute referred to an instance that no longer exists.
@@ -4236,8 +4244,8 @@ engine:
         escape hatch, structural ParentRoute eligibility, eligible static child delivery-entity route, or broadcast:true;
         has malformed target syntax; references an unknown target.flow; uses
         target:sender where no inbound source can exist; uses target:sender only on external-sourced inputs with empty
-        source; or uses loaded flow-scope producer target/broadcast as package-internal delivery to a known receiver input
-        where parent connect is required.
+        source; or uses loaded flow-scope or package-root producer target/broadcast as package-internal delivery to a
+        receiver input where parent connect is required.
       when: boot-only
     - id: redundant_in_topology_select_entity
       severity: warning
@@ -4956,10 +4964,11 @@ flow_model:
           location: parent package.yaml connect
           canonical_form: >
             `connect` is a list of structured connections. Each entry binds one producer output pin to one receiver
-            input pin, optionally names an alias/adapter, and declares or confirms delivery topology. `from` and `to`
-            use flow-id plus local pin names, not handler keys and not runtime instance paths.
+            input pin, optionally names an alias/adapter, and declares or confirms delivery topology. `from` uses either
+            flow-id plus local pin name or the explicit package-root endpoint form `.{root_output_pin_name}`. `to` uses
+            flow-id plus local input pin name in this slice. Connect refs are not handler keys and not runtime instance paths.
           fields:
-            from: Required producer reference `{producer_flow_id}.{output_pin_name}`.
+            from: Required producer reference `{producer_flow_id}.{output_pin_name}` or package-root producer reference `.{root_output_pin_name}`.
             to: Required receiver reference `{receiver_flow_id}.{input_pin_name}`.
             adapter: Optional named payload/event adapter when producer output and receiver input names or payload keys differ.
             map: Optional explicit map from receiver address keys to source/target expressions. Required when inference would be ambiguous or names differ.
@@ -4974,6 +4983,9 @@ flow_model:
                   vertical_id:
                     source: payload.vertical_id
                     target: entity.vertical_id
+              - from: .root_ready
+                to: operating.root_ready
+                delivery: one
       ownership_split:
         output_pins: Output pins own producer event identity and public producer interface only.
         input_pins: Input pins own receiver interface and receiver address resolution requirements.
@@ -4982,9 +4994,12 @@ flow_model:
         route_plan: Runtime RoutePlan owns publish-time concrete recipient authority after lowering; it consumes authored topology and MUST NOT reconstruct it from live subscribers.
         producer_emit_target: Producer `emit.target` owns only exceptional dynamic routing and MUST NOT be used as the common parent-composed routing surface.
       analyzer_verify_requirements:
-        producer_flow_exists: The `from` flow must exist in the loaded package registry.
-        producer_output_pin_exists: The `from` pin must exist in the producer schema output event pins.
+        producer_flow_exists: The `from` flow must exist in the loaded package registry unless `from` is the explicit
+          package-root endpoint form `.{root_output_pin_name}`.
+        producer_output_pin_exists: The `from` pin must exist in the producer schema output event pins; for package-root
+          endpoints it must exist in root schema.yaml pins.outputs.events.
         receiver_flow_exists: The `to` flow must exist in the loaded package registry.
+        receiver_root_unsupported: Root receiver endpoints are not supported by #1508; `to` must name a loaded receiver flow input pin.
         receiver_input_pin_exists: The `to` pin must exist in the receiver schema input event pins.
         event_alias_or_adapter_valid: Differing local event names or payload keys require an explicit alias/adapter or unambiguous bind-derived alias; raw same-name fallback is not valid for declared imported package pins.
         output_carries_address_key: The producer output event payload or envelope must carry every receiver address key required by the target input pin, or the connect entry must map it explicitly.
@@ -4998,7 +5013,7 @@ flow_model:
         owner: platform-spec.yaml#flow_model.flow_package.composition_routing.route_plan_lowering
         consumes:
         - parent package.yaml connect entries
-        - producer output pin event identity
+        - producer output pin event identity, including explicit package-root `.pin_name` output endpoints
         - receiver addressed input pin rules
         - import-boundary pin alias bindings
         - explicit adapter/map entries
@@ -5028,7 +5043,7 @@ flow_model:
             producer broadcast, or structural ParentRoute.
           artifact_fields:
             package_key: Parent package key that authored the connect entry when available.
-            producer_endpoint: Producer semantic flow id/path, output pin name, local output event identity, and scoped resolved event identity.
+            producer_endpoint: Producer semantic flow id/path or package-root marker, output pin name, local output event identity, and scoped resolved event identity.
             receiver_endpoint: Receiver semantic flow id/path/mode, input pin name, local receiver event identity, and scoped resolved event identity.
             adapter_and_map: Explicit adapter plus sorted address-key map entries used for alias/key adaptation.
             delivery: one, many, broadcast, or reply after analyzer/default inference.
@@ -5052,6 +5067,7 @@ flow_model:
           - connect_pin_ref_invalid
           - producer_flow_missing
           - producer_output_pin_missing
+          - receiver_root_unsupported
           - receiver_flow_missing
           - receiver_input_pin_missing
           - receiver_address_rule_missing
@@ -5139,9 +5155,9 @@ flow_model:
             the producer target/broadcast writer; the producer route must be
             removed or proven to be a different escape hatch. Parent connect
             remains the topology owner and EventBus RoutePlan remains the
-            concrete delivery authority. Root-level producer target/broadcast composition remains
-            a #1466/root-connect source-authority residual, not part of this
-            closed child slice.
+            concrete delivery authority. Root-level producer target/broadcast composition
+            is closed separately by implementation_slice_1508 when an explicit root connect
+            endpoint consumes the package-root output pin.
           consumes:
           - loaded flow-scope producer output pin event identity
           - authored emit target/broadcast syntax
@@ -5158,6 +5174,45 @@ flow_model:
           - connected agent/node output pins continue through EventBus RoutePlan without relay nodes or producer target/broadcast
           does_not_close:
           - '#1466 composition-first parent closure'
+        implementation_slice_1508:
+          status: merge_bearing_runtime_behavior
+          canonical_code_owner: internal/runtime/contracts.FlowPackageConnect plus internal/runtime/core/pinrouting.ConnectRoutePlan and ProducerRouteCommonPathFailure
+          rule: |
+            Parent connect may name a package-root producer output pin with
+            `from: .{root_output_pin_name}`. That root endpoint is a first-class
+            source-authority fact: contracts parsing, semanticview connect lookups,
+            bootverify composition validation, pin target resolution, EventBus
+            lowered ConnectRoutePlan consumption, and delivery persistence MUST all
+            consume the same explicit connect owner. A package-root producer emit
+            target.flow/match or broadcast:true is invalid common-path topology when
+            an explicit root connect consumes that output pin and routes to the
+            same loaded receiver flow. Runtime must fail closed before producer
+            target/broadcast can repair or override the canonical root connect
+            decision. Root receiver endpoints are not supported in this slice and
+            fail closed as receiver_root_unsupported.
+          root_endpoint_syntax:
+            producer: '`.{root_output_pin_name}` in connect.from names root schema.yaml pins.outputs.events only.'
+            receiver: 'Unsupported in #1508; connect.to must name `{receiver_flow_id}.{input_pin_name}`.'
+          consumes:
+          - root schema.yaml pins.outputs.events
+          - parent package.yaml connect.from `.{root_output_pin_name}` entries
+          - receiver flow input pin declarations and addressed-input route-plan lowering
+          - root producer authored emit target/broadcast syntax
+          produces:
+          - typed root ConnectRoutePlan producer endpoints
+          - producer_target_common_path_forbidden for root target.flow/match common-path composition where root connect authority applies
+          - producer_broadcast_common_path_forbidden for root broadcast:true common-path composition where root connect authority applies
+          - receiver_root_unsupported for attempted root connect receivers
+          proof_obligations:
+          - semanticview exposes root connect facts through CompositionConnectsFrom("", pin)
+          - bootverify accepts root outputs with root connect and no producer target/broadcast
+          - bootverify rejects root producer target.flow/match and broadcast:true when root connect authority applies
+          - EventBus persists delivery rows and subscribed replay scope from lowered root ConnectRoutePlan authority
+          - existing loaded flow-scope connect/target/broadcast regressions remain covered
+          does_not_close:
+          - '#1479 business-field descriptor/index materialization'
+          - '#1450 broader package policy/grants/final e2e work'
+          - 'root connect receiver semantics'
           - '#1474 already closed generated agent/node EventBus RoutePlan consumption'
           - '#1479 already closed declared indexed business-field descriptor materialization'
         implementation_slice_1485:
@@ -8803,7 +8858,8 @@ static_analyzer:
         delivery-entity routing, or explicit broadcast opt-out. Agent emit_events declarations do not require producer
         target, broadcast:true, or relay-node workarounds when parent connect supplies route authority. Loaded flow-scope
         producer target/broadcast that selects a known package receiver input for the same pin-declared output is rejected
-        as common-path composition routing; parent connect is the route owner.
+        as common-path composition routing; package-root producer target/broadcast is rejected the same way when an
+        explicit root connect endpoint consumes that root output pin. Parent connect is the route owner.
       applies_to:
       - handler top-level single-emit
       - rules entries
@@ -8826,8 +8882,9 @@ static_analyzer:
         - flow_match
         - flow_match_allow_fanout
         rule: Target form must be syntactically valid and reference loaded flow topology where statically known. flow_match
-          target forms from loaded flow-scope producers are invalid when they select a loaded package receiver input for the
-          same pin-declared output or a receiver flow reached by the parent connect graph instead of acting as a genuine
+          target forms from loaded flow-scope producers, or package-root producers whose output pin is consumed by
+          explicit root connect authority, are invalid when they select a loaded package receiver input for the same
+          pin-declared output or a receiver flow reached by the parent connect graph instead of acting as a genuine
           dynamic escape hatch.
       fanout_representation:
         rule: flow_match_allow_fanout resolves to event.target_set, not singular event.target. The runtime must persist concrete
@@ -8837,12 +8894,14 @@ static_analyzer:
           child/template instances that will record full ParentRoute at create_flow_instance time.
       static_child_delivery_entity:
         rule: Nested static child flows without a materialized instance row may use the current delivery entity as the only
-          implicit target route for pin-declared outputs; root static flows still require an explicit target or broadcast:true.
+          implicit target route for pin-declared outputs; root static flows require lowered root connect authority,
+          explicit target, or broadcast:true. When explicit root connect authority consumes the root output pin,
+          producer target/broadcast is no longer accepted as common topology.
           This path is not ParentRoute metadata and must not fall back to inbound event.source.
       explicit_broadcast:
         rule: broadcast:true is a deliberate opt-out and is the only no-target form accepted for a pin-declared output when
           no loaded package receiver input consumes the same output event and no parent connect graph edge consumes the
-          output pin from a loaded flow-scope producer. Parent-composed broadcast/fan-out uses connect.
+          output pin from a loaded flow-scope producer or package-root producer. Parent-composed broadcast/fan-out uses connect.
     static_failure_reasons:
       target_required_missing: No lowered parent connect route, no explicit target escape hatch, no structural ParentRoute
         eligibility, no eligible static child delivery-entity route, and no broadcast:true.
@@ -8850,11 +8909,12 @@ static_analyzer:
       target_unknown_flow: target.flow is not present in the loaded flow registry.
       target_sender_no_inbound: target:sender is used from a handler whose only triggers cannot supply inbound event.source.
       target_sender_empty_source: target:sender is used only from external-sourced event types with empty source.
-      producer_target_common_path_forbidden: A loaded flow-scope producer target.flow/match selects a loaded package
-        receiver input for the same pin-declared output or a receiver flow reached by the parent connect graph;
-        parent connect is the required route owner.
-      producer_broadcast_common_path_forbidden: Loaded flow-scope broadcast:true is used as package-internal delivery to
-        known receiver input pins for the same pin-declared output or connected output pin; parent connect broadcast/fan-out is the required route owner.
+      producer_target_common_path_forbidden: A loaded flow-scope producer or package-root producer target.flow/match
+        selects a loaded package receiver input for the same pin-declared output or a receiver flow reached by the
+        parent connect graph; parent connect is the required route owner.
+      producer_broadcast_common_path_forbidden: Loaded flow-scope or package-root broadcast:true is used as package-internal
+        delivery to receiver input pins for the same pin-declared output or connected output pin; parent connect
+        broadcast/fan-out is the required route owner.
     runtime_failure_reasons:
       publish_time_dead_letter:
       - target_unreachable_no_subscriber


### PR DESCRIPTION
Closes #1508

Governing refs/context:
- `platform-spec.yaml#flow_model.flow_package.composition_routing.parent_connect`
- `platform-spec.yaml#flow_model.flow_package.composition_routing.route_plan_lowering`
- `platform-spec.yaml#engine.event_routing`
- `platform-spec.yaml#handler_specification.handler_fields.emit`
- Approved #1508 gate boundary: explicit package-root producer endpoint source authority first, no root receiver support in this slice, no legacy target/broadcast compatibility shim.

Summary:
- Adds explicit package-root producer connect refs using `.{root_output_pin}` in FlowPackageConnect parsing/model and semantic accessors.
- Lowers root producer connect refs into typed ConnectRoutePlan endpoints and feeds that root authority through EventBus route-plan dispatch.
- Makes bootverify and pinrouting fail closed for root producer `target.flow/match` and `broadcast:true` common-path composition when explicit root connect authority consumes that root output pin.
- Keeps root receiver endpoints unsupported with typed `receiver_root_unsupported` proof.
- Updates `platform-spec.yaml` in the same PR so shipped runtime semantics and spec stay aligned.
- Fixes the tier12 selected-contract catalog test helper timestamp boundary so the fork planner can see publish-created pending delivery rows at the event-id fork cursor.

Semantic migration:
- New canonical owner: parent `package.yaml connect` entries, including explicit package-root producer refs `.{root_output_pin}`, lowered by `LowerCompositionConnectRoutePlan` and consumed by EventBus/RoutePlan, bootverify, semanticview, and pinrouting.
- Old path now invalid for this class: package-root producer `target.flow/match` or `broadcast:true` as common package-internal composition routing when that root output pin is consumed by explicit root connect authority.
- Production paths checked: FlowPackageConnect parsing/model, CompositionConnectsFrom/To, semanticview connect facts, bootverify connect validation and pin routing checks, ConnectRoutePlan lowering, EventBus route-plan dispatch, runtime pinrouting, and catalog/conformance regression surfaces.
- Migration complete for the approved #1508 first slice. Root receiver connect endpoints remain explicitly unsupported and are not treated as closure-bearing.

Proof run:
- `go test ./internal/runtime/contracts ./internal/runtime/semanticview ./internal/runtime/core/pinrouting ./internal/runtime/bootverify ./internal/runtime/bus ./internal/runtime/conformance -run 'FlowPackage|CompositionConnect|Root|PinTargetResolution|ProducerRoute|ConnectRoutePlan|RouteAuthority' -count=1`
- `go test ./internal/apispec -run TestPlatformSpecCompositionRoutingDemotesProducerTargetAuthority -count=1`
- `go test ./internal/runtime/cataloge2e -run TestTier12RuntimeFork_SelectedContractForkExecutionFixture -count=1 -v`
- `go test ./...`