### PR TITLE
[agent-a][issue #1453] Bind imported package dependencies

### DIFF
--- a/internal/runtime/bootverify/checks.go
+++ b/internal/runtime/bootverify/checks.go
@@ -245,6 +245,7 @@ var bootCheckRegistry = []Check{
 	{ID: "write_pin_ownership_validation", Severity: "error", Run: checkWritePinOwnershipValidation},
 	{ID: "gate_schema_validation", Severity: "error", Run: checkGateSchemaValidation},
 	{ID: "flow_package_import_completeness", Severity: SeverityHardInvalidity, Run: checkFlowPackageImportCompleteness},
+	{ID: "flow_package_dependency_binding", Severity: SeverityHardInvalidity, Run: checkFlowPackageDependencyBinding},
 	{ID: "flow_package_pin_bind_alias_validation", Severity: SeverityHardInvalidity, Run: checkFlowPackagePinBindAliasValidation},
 	{ID: "composition_connect_validation", Severity: "error", Run: checkCompositionConnectValidation},
 	{ID: "input_pin_wiring", Severity: "warning", Run: checkInputPinWiring},

--- a/internal/runtime/bootverify/flow_data_access_test.go
+++ b/internal/runtime/bootverify/flow_data_access_test.go
@@ -66,8 +66,8 @@ func TestRun_ValidatesFlowDataAccessDeclarations(t *testing.T) {
 }
 
 func TestBootCheckRegistry_HasFlowDataAccessCheckCount(t *testing.T) {
-	if got := len(bootCheckRegistry); got != 57 {
-		t.Fatalf("bootCheckRegistry count = %d, want 57", got)
+	if got := len(bootCheckRegistry); got != 58 {
+		t.Fatalf("bootCheckRegistry count = %d, want 58", got)
 	}
 }
 

--- a/internal/runtime/bootverify/flow_package_import_completeness_checks.go
+++ b/internal/runtime/bootverify/flow_package_import_completeness_checks.go
@@ -32,6 +32,35 @@ func checkFlowPackagePinBindAliasValidation(c *checkerContext) []Finding {
 	return findings
 }
 
+func checkFlowPackageDependencyBinding(c *checkerContext) []Finding {
+	var findings []Finding
+	for _, issue := range semanticview.ImportBoundaryDependencyIssues(c.source) {
+		findings = append(findings, Finding{
+			CheckID:  "flow_package_dependency_binding",
+			Severity: SeverityHardInvalidity,
+			Message:  flowPackageDependencyBindingMessage(issue),
+			Location: strings.TrimSpace(issue.ChildPackageKey),
+		})
+	}
+	return findings
+}
+
+func flowPackageDependencyBindingMessage(issue semanticview.ImportBoundaryDependencyIssue) string {
+	dependency := strings.TrimSpace(issue.Dependency)
+	if dependency == "" {
+		dependency = "<empty>"
+	}
+	message := strings.TrimSpace(issue.Message)
+	if message == "" {
+		message = strings.TrimSpace(issue.Kind)
+	}
+	ref := strings.TrimSpace(issue.Reference)
+	if ref != "" {
+		return fmt.Sprintf("imported package %s dependency %s binding %s via %s is invalid: %s", strings.TrimSpace(issue.ChildPackageKey), dependency, ref, strings.TrimSpace(issue.ImportLabel), message)
+	}
+	return fmt.Sprintf("imported package %s dependency %s via %s is invalid: %s", strings.TrimSpace(issue.ChildPackageKey), dependency, strings.TrimSpace(issue.ImportLabel), message)
+}
+
 func flowPackagePinBindAliasMessage(issue semanticview.ImportBoundaryPinAliasIssue) string {
 	direction := strings.TrimSpace(issue.Direction)
 	if direction == "" {
@@ -140,16 +169,17 @@ func flowPackageImportCompletenessFindings(parent, child semanticview.ProjectSco
 		kind     string
 		required []string
 		bindings map[string]string
+		defaults map[string]runtimecontracts.PolicyValue
 	}{
 		{kind: "input", required: requires.Inputs, bindings: site.Bind.Inputs},
 		{kind: "output", required: requires.Outputs, bindings: site.Bind.Outputs},
-		{kind: "policy", required: requires.Policy, bindings: site.Bind.Policy},
+		{kind: "policy", required: requires.Policy, bindings: site.Bind.Policy, defaults: requires.PolicyDefaults},
 		{kind: "credential", required: requires.Credentials, bindings: site.Bind.Credentials},
 	}
 
 	var findings []Finding
 	for _, check := range checks {
-		missing := missingFlowPackageBindings(check.required, check.bindings)
+		missing := missingFlowPackageBindings(check.required, check.bindings, check.defaults)
 		if len(missing) == 0 {
 			continue
 		}
@@ -163,7 +193,7 @@ func flowPackageImportCompletenessFindings(parent, child semanticview.ProjectSco
 	return findings
 }
 
-func missingFlowPackageBindings(required []string, bindings map[string]string) []string {
+func missingFlowPackageBindings(required []string, bindings map[string]string, defaults map[string]runtimecontracts.PolicyValue) []string {
 	out := make([]string, 0)
 	for _, item := range required {
 		item = strings.TrimSpace(item)
@@ -171,6 +201,9 @@ func missingFlowPackageBindings(required []string, bindings map[string]string) [
 			continue
 		}
 		if strings.TrimSpace(bindings[item]) == "" {
+			if _, ok := defaults[item]; ok {
+				continue
+			}
 			out = append(out, item)
 		}
 	}

--- a/internal/runtime/bootverify/flow_package_import_completeness_checks_test.go
+++ b/internal/runtime/bootverify/flow_package_import_completeness_checks_test.go
@@ -25,6 +25,101 @@ func TestRun_FlowPackageImportCompletenessAcceptsFullyBoundFlowPackage(t *testin
 	}
 }
 
+func TestRun_FlowPackageDependencyBindingAcceptsDeclaredPolicyDefault(t *testing.T) {
+	root := writeFlowPackageImportCompletenessFixture(t, flowPackageImportFixtureOptions{
+		importKind: "flow",
+		bind: strings.ReplaceAll(
+			allFlowPackageBindingsYAML(),
+			"      policy:\n        provider.threshold: parent.policy.provider.threshold\n",
+			"",
+		),
+		requires: `requires:
+  inputs: [work.requested]
+  outputs: [work.completed]
+  policy:
+    provider.threshold:
+      default: 0.8
+  credentials: [provider_token]
+`,
+	})
+	source := loadFlowPackageImportCompletenessSource(t, root)
+
+	report := Run(context.Background(), source, Options{})
+
+	if reportContains(report.HardInvalidities(), "flow_package_import_completeness", "required policy bindings provider.threshold") {
+		t.Fatalf("policy default should satisfy import completeness, got %#v", report.HardInvalidities())
+	}
+	if reportContains(report.HardInvalidities(), "flow_package_dependency_binding", "provider.threshold") {
+		t.Fatalf("policy default should satisfy dependency binding, got %#v", report.HardInvalidities())
+	}
+}
+
+func TestRun_FlowPackageDependencyBindingFailsClosedOnInvalidPolicyCredentialBindings(t *testing.T) {
+	tests := []struct {
+		name        string
+		bind        string
+		requires    string
+		wantMessage string
+	}{
+		{
+			name: "missing policy binding without default ignores same-name parent policy",
+			bind: strings.ReplaceAll(
+				allFlowPackageBindingsYAML(),
+				"      policy:\n        provider.threshold: parent.policy.provider.threshold\n",
+				"",
+			),
+			requires:    allFlowPackageRequiresYAML(),
+			wantMessage: "declared package policy dependency has no import binding or package default",
+		},
+		{
+			name: "unsupported policy reference",
+			bind: strings.ReplaceAll(
+				allFlowPackageBindingsYAML(),
+				"parent.policy.provider.threshold",
+				"global.policy.provider.threshold",
+			),
+			requires:    allFlowPackageRequiresYAML(),
+			wantMessage: "policy binding must reference parent.policy.<path> or policy.<path>",
+		},
+		{
+			name: "unknown credential binding",
+			bind: strings.ReplaceAll(
+				allFlowPackageBindingsYAML(),
+				"        provider_token: parent_provider_token\n",
+				"        provider_token: parent_provider_token\n        undeclared_token: stray_key\n",
+			),
+			requires:    allFlowPackageRequiresYAML(),
+			wantMessage: "credential bind key is not declared",
+		},
+		{
+			name: "missing credential binding",
+			bind: strings.ReplaceAll(
+				allFlowPackageBindingsYAML(),
+				"        provider_token: parent_provider_token\n",
+				"",
+			),
+			requires:    allFlowPackageRequiresYAML(),
+			wantMessage: "declared package credential dependency has no import binding",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			root := writeFlowPackageImportCompletenessFixture(t, flowPackageImportFixtureOptions{
+				importKind: "flow",
+				bind:       tc.bind,
+				requires:   tc.requires,
+			})
+			source := loadFlowPackageImportCompletenessSource(t, root)
+
+			report := Run(context.Background(), source, Options{})
+
+			if !reportContains(report.HardInvalidities(), "flow_package_dependency_binding", tc.wantMessage) {
+				t.Fatalf("expected flow_package_dependency_binding %q, got %#v", tc.wantMessage, report.HardInvalidities())
+			}
+		})
+	}
+}
+
 func TestRun_FlowPackageImportCompletenessFailsClosedOnMissingBindings(t *testing.T) {
 	tests := []struct {
 		name        string
@@ -43,7 +138,7 @@ func TestRun_FlowPackageImportCompletenessFailsClosedOnMissingBindings(t *testin
 		},
 		{
 			name:        "policy",
-			bind:        strings.ReplaceAll(allFlowPackageBindingsYAML(), "        provider.threshold: parent.policy.threshold\n", ""),
+			bind:        strings.ReplaceAll(allFlowPackageBindingsYAML(), "        provider.threshold: parent.policy.provider.threshold\n", ""),
 			wantMessage: "required policy bindings provider.threshold",
 		},
 		{
@@ -226,7 +321,7 @@ func allFlowPackageBindingsYAML() string {
       outputs:
         work.completed: parent.work_completed
       policy:
-        provider.threshold: parent.policy.threshold
+        provider.threshold: parent.policy.provider.threshold
       credentials:
         provider_token: parent_provider_token
 `

--- a/internal/runtime/bootverify/report_test.go
+++ b/internal/runtime/bootverify/report_test.go
@@ -4747,8 +4747,8 @@ func TestRun_ReportsMissingRuntimeExecutorForOwnedRuntimeEvent(t *testing.T) {
 }
 
 func TestBootCheckRegistry_HasSpecCheckCount(t *testing.T) {
-	if got := len(bootCheckRegistry); got != 57 {
-		t.Fatalf("bootCheckRegistry count = %d, want 57", got)
+	if got := len(bootCheckRegistry); got != 58 {
+		t.Fatalf("bootCheckRegistry count = %d, want 58", got)
 	}
 	if got := len(supplementalChecks); got != 3 {
 		t.Fatalf("supplementalChecks count = %d, want 3", got)

--- a/internal/runtime/contracts/prompts.go
+++ b/internal/runtime/contracts/prompts.go
@@ -30,8 +30,15 @@ type PromptFileResolution struct {
 type BundlePromptResolver struct {
 	bundle            *WorkflowContractBundle
 	repoRoot          string
+	policyResolver    PromptPolicyResolver
 	promptVariablesMu sync.RWMutex
 	promptVariables   map[string]map[string]any
+}
+
+type PromptPolicyResolver func(source ContractItemSource) PolicyDocument
+
+type BundlePromptResolverOptions struct {
+	PolicyResolver PromptPolicyResolver
 }
 
 var (
@@ -40,9 +47,14 @@ var (
 )
 
 func NewBundlePromptResolver(bundle *WorkflowContractBundle) *BundlePromptResolver {
+	return NewBundlePromptResolverWithOptions(bundle, BundlePromptResolverOptions{})
+}
+
+func NewBundlePromptResolverWithOptions(bundle *WorkflowContractBundle, opts BundlePromptResolverOptions) *BundlePromptResolver {
 	return &BundlePromptResolver{
 		bundle:          bundle,
 		repoRoot:        promptContractsRepoRoot(),
+		policyResolver:  opts.PolicyResolver,
 		promptVariables: map[string]map[string]any{},
 	}
 }
@@ -73,7 +85,7 @@ func (r *BundlePromptResolver) ResolvePromptFileForAgent(cfg models.AgentConfig,
 	for _, agentID := range candidates {
 		record := bundleAgentRecord{}
 		if bundle != nil {
-			record, _ = bundleAgentRecordByLogicalID(bundle, agentID)
+			record, _ = bundlePromptAgentRecordByLogicalID(bundle, agentID)
 		}
 		resolution, found, err := resolvePromptFileInDirs(dirs[agentID], agentID, record.Entry, record.Source, mode)
 		if err != nil {
@@ -84,6 +96,23 @@ func (r *BundlePromptResolver) ResolvePromptFileForAgent(cfg models.AgentConfig,
 		}
 	}
 	return PromptFileResolution{}, false, nil
+}
+
+func bundlePromptAgentRecordByLogicalID(bundle *WorkflowContractBundle, logicalID string) (bundleAgentRecord, bool) {
+	record, found := bundleAgentRecordByLogicalID(bundle, logicalID)
+	if bundle == nil {
+		return record, found
+	}
+	source, sourceOK := bundle.AgentContractSource(logicalID)
+	entry, entryOK := bundle.AgentEntry(logicalID)
+	if !sourceOK || !entryOK {
+		return record, found
+	}
+	return bundleAgentRecord{
+		LogicalID: strings.TrimSpace(logicalID),
+		Entry:     entry,
+		Source:    source,
+	}, true
 }
 
 func ResolvePromptFileForContractAgent(bundle *WorkflowContractBundle, logicalID string, entry AgentRegistryEntry, source ContractItemSource, mode string) (PromptFileResolution, bool, error) {
@@ -470,12 +499,19 @@ func (r *BundlePromptResolver) promptRuntimeVariables(repoRoot string, source Co
 	}
 	r.promptVariablesMu.RUnlock()
 
-	vars := promptVariableValues(bundle, source, cfg)
+	vars := promptVariableValuesWithPolicy(bundle, source, cfg, r.promptPolicy(source))
 
 	r.promptVariablesMu.Lock()
 	r.promptVariables[scopeKey] = clonePromptVariables(vars)
 	r.promptVariablesMu.Unlock()
 	return vars, nil
+}
+
+func (r *BundlePromptResolver) promptPolicy(source ContractItemSource) PolicyDocument {
+	if r != nil && r.policyResolver != nil {
+		return r.policyResolver(source)
+	}
+	return promptResolvedPolicy(r.workflowBundle(), source)
 }
 
 func promptVariableScopeKey(source ContractItemSource, cfg models.AgentConfig) string {
@@ -516,11 +552,14 @@ func promptResolvedPolicy(bundle *WorkflowContractBundle, source ContractItemSou
 }
 
 func promptVariableValues(bundle *WorkflowContractBundle, source ContractItemSource, cfg models.AgentConfig) map[string]any {
+	return promptVariableValuesWithPolicy(bundle, source, cfg, promptResolvedPolicy(bundle, source))
+}
+
+func promptVariableValuesWithPolicy(bundle *WorkflowContractBundle, source ContractItemSource, cfg models.AgentConfig, policy PolicyDocument) map[string]any {
 	vars := promptRuntimeTokens(cfg)
 	for key, value := range promptEntityStateFields(cfg.Config) {
 		vars[key] = value
 	}
-	policy := promptResolvedPolicy(bundle, source)
 	for key, value := range policy.Values {
 		key = strings.TrimSpace(key)
 		if key == "" {

--- a/internal/runtime/contracts/workflow_contract_types.go
+++ b/internal/runtime/contracts/workflow_contract_types.go
@@ -649,11 +649,12 @@ type ProjectFlowRef struct {
 	Bind      FlowPackageBind `yaml:"bind"`
 }
 type FlowPackageRequires struct {
-	Inputs          []string `yaml:"inputs"`
-	Outputs         []string `yaml:"outputs"`
-	Policy          []string `yaml:"policy"`
-	Credentials     []string `yaml:"credentials"`
-	PlatformVersion string   `yaml:"platform_version"`
+	Inputs          []string               `yaml:"inputs"`
+	Outputs         []string               `yaml:"outputs"`
+	Policy          []string               `yaml:"policy"`
+	PolicyDefaults  map[string]PolicyValue `yaml:"-"`
+	Credentials     []string               `yaml:"credentials"`
+	PlatformVersion string                 `yaml:"platform_version"`
 }
 type FlowPackageBind struct {
 	Inputs      map[string]string `yaml:"inputs"`

--- a/internal/runtime/contracts/workflow_contract_yaml_test.go
+++ b/internal/runtime/contracts/workflow_contract_yaml_test.go
@@ -95,12 +95,79 @@ connect:
 	}
 }
 
+func TestProjectPackageDocumentDecode_PreservesPolicyRequiresDefaults(t *testing.T) {
+	var doc ProjectPackageDocument
+	if err := yaml.Unmarshal([]byte(`
+name: package-boundary
+requires:
+  policy:
+    provider.threshold:
+      type: number
+      description: Non-secret provider threshold.
+      default: 0.8
+    provider.mode: {}
+`), &doc); err != nil {
+		t.Fatalf("yaml.Unmarshal: %v", err)
+	}
+	if got := strings.Join(doc.Requires.Policy, ","); got != "provider.threshold,provider.mode" {
+		t.Fatalf("Requires.Policy = %q", got)
+	}
+	threshold, ok := doc.Requires.PolicyDefaults["provider.threshold"]
+	if !ok {
+		t.Fatalf("provider.threshold default missing: %#v", doc.Requires.PolicyDefaults)
+	}
+	if got, ok := threshold.Value.(float64); !ok || got != 0.8 {
+		t.Fatalf("provider.threshold default = %#v, want 0.8", threshold.Value)
+	}
+	if _, ok := doc.Requires.PolicyDefaults["provider.mode"]; ok {
+		t.Fatalf("provider.mode unexpectedly has a default: %#v", doc.Requires.PolicyDefaults["provider.mode"])
+	}
+}
+
+func TestProjectPackageDocumentDecode_ListPolicyRequiresAreRequiredNoDefault(t *testing.T) {
+	var doc ProjectPackageDocument
+	if err := yaml.Unmarshal([]byte(`
+name: package-boundary
+requires:
+  policy: [provider.threshold]
+`), &doc); err != nil {
+		t.Fatalf("yaml.Unmarshal: %v", err)
+	}
+	if got := strings.Join(doc.Requires.Policy, ","); got != "provider.threshold" {
+		t.Fatalf("Requires.Policy = %q", got)
+	}
+	if len(doc.Requires.PolicyDefaults) != 0 {
+		t.Fatalf("PolicyDefaults = %#v, want none", doc.Requires.PolicyDefaults)
+	}
+}
+
 func TestProjectPackageDocumentDecode_RejectsMalformedRequiresAndBindShape(t *testing.T) {
 	tests := []struct {
 		name    string
 		body    string
 		wantErr string
 	}{
+		{
+			name: "unknown policy requirement option",
+			body: `
+name: invalid
+requires:
+  policy:
+    provider.threshold:
+      fallback: 0.8
+`,
+			wantErr: "UNDEFINED-FIELD",
+		},
+		{
+			name: "policy requirement must be mapping",
+			body: `
+name: invalid
+requires:
+  policy:
+    provider.threshold: 0.8
+`,
+			wantErr: "policy requirement must be a mapping",
+		},
 		{
 			name: "unknown requires field",
 			body: `

--- a/internal/runtime/contracts/workflow_contract_yaml_wave1.go
+++ b/internal/runtime/contracts/workflow_contract_yaml_wave1.go
@@ -86,9 +86,12 @@ func (r *FlowPackageRequires) UnmarshalYAML(node *yaml.Node) error {
 				return fmt.Errorf("requires.outputs: %w", err)
 			}
 		case "policy":
-			if err := value.Decode(&out.Policy); err != nil {
+			policy, defaults, err := decodeFlowPackagePolicyRequires(value)
+			if err != nil {
 				return fmt.Errorf("requires.policy: %w", err)
 			}
+			out.Policy = policy
+			out.PolicyDefaults = defaults
 		case "credentials":
 			if err := value.Decode(&out.Credentials); err != nil {
 				return fmt.Errorf("requires.credentials: %w", err)
@@ -152,9 +155,98 @@ func (r FlowPackageRequires) normalized() FlowPackageRequires {
 		Inputs:          normalizeStrings(r.Inputs),
 		Outputs:         normalizeStrings(r.Outputs),
 		Policy:          normalizeStrings(r.Policy),
+		PolicyDefaults:  normalizePolicyDefaults(r.PolicyDefaults),
 		Credentials:     normalizeStrings(r.Credentials),
 		PlatformVersion: strings.TrimSpace(r.PlatformVersion),
 	}
+}
+
+func decodeFlowPackagePolicyRequires(node *yaml.Node) ([]string, map[string]PolicyValue, error) {
+	if node == nil || node.Kind == 0 {
+		return nil, nil, nil
+	}
+	switch node.Kind {
+	case yaml.SequenceNode:
+		var values []string
+		if err := node.Decode(&values); err != nil {
+			return nil, nil, err
+		}
+		return values, nil, nil
+	case yaml.MappingNode:
+		var policy []string
+		defaults := map[string]PolicyValue{}
+		for i := 0; i+1 < len(node.Content); i += 2 {
+			key := strings.TrimSpace(node.Content[i].Value)
+			if key == "" {
+				continue
+			}
+			policy = append(policy, key)
+			defaultValue, ok, err := decodeFlowPackagePolicyDefault(node.Content[i+1])
+			if err != nil {
+				return nil, nil, fmt.Errorf("%s: %w", key, err)
+			}
+			if ok {
+				defaults[key] = PolicyValue{Value: defaultValue}
+			}
+		}
+		if len(defaults) == 0 {
+			defaults = nil
+		}
+		return policy, defaults, nil
+	default:
+		return nil, nil, fmt.Errorf("must be a list of policy keys or a mapping of policy keys to requirement objects")
+	}
+}
+
+func decodeFlowPackagePolicyDefault(node *yaml.Node) (any, bool, error) {
+	if node == nil || node.Kind == 0 {
+		return nil, false, nil
+	}
+	if node.Kind != yaml.MappingNode {
+		return nil, false, fmt.Errorf("policy requirement must be a mapping with optional default")
+	}
+	var out any
+	hasDefault := false
+	for i := 0; i+1 < len(node.Content); i += 2 {
+		key := strings.TrimSpace(node.Content[i].Value)
+		value := node.Content[i+1]
+		switch key {
+		case "":
+			continue
+		case "default":
+			if err := value.Decode(&out); err != nil {
+				return nil, false, fmt.Errorf("default: %w", err)
+			}
+			hasDefault = true
+		case "type", "description", "required":
+			continue
+		default:
+			return nil, false, fmt.Errorf("UNDEFINED-FIELD: requires.policy option %q not in platform spec", key)
+		}
+	}
+	return out, hasDefault, nil
+}
+
+func normalizePolicyDefaults(in map[string]PolicyValue) map[string]PolicyValue {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make(map[string]PolicyValue, len(in))
+	for key, value := range in {
+		key = strings.TrimSpace(key)
+		if key == "" {
+			continue
+		}
+		out[key] = PolicyValue{
+			Value:       value.Value,
+			Description: strings.TrimSpace(value.Description),
+			Override:    value.Override,
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
 }
 
 func (b FlowPackageBind) normalized() FlowPackageBind {

--- a/internal/runtime/credentials/requirements.go
+++ b/internal/runtime/credentials/requirements.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
 	"github.com/division-sh/swarm/internal/runtime/semanticview"
 )
 
@@ -32,18 +33,12 @@ func BuildRequirementIndex(source semanticview.Source) map[string][]Requirement 
 	if source == nil {
 		return index
 	}
-	for name, entry := range source.ToolEntries() {
-		name = strings.TrimSpace(name)
-		if name == "" {
-			continue
-		}
-		for _, key := range entry.Credentials {
-			key = strings.TrimSpace(key)
-			if key == "" {
-				continue
-			}
-			index[key] = append(index[key], Requirement{Kind: "tool", Name: name})
-		}
+	appendToolRequirements(index, source, "", source.ToolEntries())
+	for _, scope := range source.ProjectScopes() {
+		appendToolRequirements(index, source, strings.TrimSpace(scope.OwningFlowID), scope.Tools)
+	}
+	for _, scope := range source.FlowScopes() {
+		appendToolRequirements(index, source, strings.TrimSpace(scope.ID), scope.Tools)
 	}
 	if value, ok := semanticview.PolicyValueForFlow(source, "", "mcp_servers"); ok {
 		for name, key := range parseMCPServerCredentialKeys(value.Value) {
@@ -67,6 +62,30 @@ func BuildRequirementIndex(source semanticview.Source) map[string][]Requirement 
 		index[key] = normalizeRequirements(refs)
 	}
 	return index
+}
+
+func appendToolRequirements(index map[string][]Requirement, source semanticview.Source, flowID string, entries map[string]runtimecontracts.ToolSchemaEntry) {
+	for name, entry := range entries {
+		name = strings.TrimSpace(name)
+		if name == "" {
+			continue
+		}
+		for _, key := range entry.Credentials {
+			key = strings.TrimSpace(key)
+			if key == "" {
+				continue
+			}
+			storeKey, mapped := semanticview.CredentialStoreKeyForFlow(source, flowID, key)
+			if mapped && strings.TrimSpace(storeKey) == "" {
+				continue
+			}
+			storeKey = strings.TrimSpace(storeKey)
+			if storeKey == "" {
+				continue
+			}
+			index[storeKey] = append(index[storeKey], Requirement{Kind: "tool", Name: name})
+		}
+	}
 }
 
 func Describe(ctx context.Context, store Store, source semanticview.Source, key string) (Descriptor, error) {

--- a/internal/runtime/credentials/requirements.go
+++ b/internal/runtime/credentials/requirements.go
@@ -40,23 +40,9 @@ func BuildRequirementIndex(source semanticview.Source) map[string][]Requirement 
 	for _, scope := range source.FlowScopes() {
 		appendToolRequirements(index, source, strings.TrimSpace(scope.ID), scope.Tools)
 	}
-	if value, ok := semanticview.PolicyValueForFlow(source, "", "mcp_servers"); ok {
-		for name, key := range parseMCPServerCredentialKeys(value.Value) {
-			key = strings.TrimSpace(key)
-			if key == "" {
-				continue
-			}
-			index[key] = append(index[key], Requirement{Kind: "mcp_server", Name: name})
-		}
-	}
-	if value, ok := semanticview.PolicyValueForFlow(source, "", "web_search_provider"); ok {
-		for name, key := range parseWebSearchProviderCredentialKeys(value.Value) {
-			key = strings.TrimSpace(key)
-			if key == "" {
-				continue
-			}
-			index[key] = append(index[key], Requirement{Kind: "web_search_provider", Name: name})
-		}
+	appendPolicyCredentialRequirements(index, source, "")
+	for _, scope := range source.FlowScopes() {
+		appendPolicyCredentialRequirements(index, source, strings.TrimSpace(scope.ID))
 	}
 	for key, refs := range index {
 		index[key] = normalizeRequirements(refs)
@@ -86,6 +72,35 @@ func appendToolRequirements(index map[string][]Requirement, source semanticview.
 			index[storeKey] = append(index[storeKey], Requirement{Kind: "tool", Name: name})
 		}
 	}
+}
+
+func appendPolicyCredentialRequirements(index map[string][]Requirement, source semanticview.Source, flowID string) {
+	if value, ok := semanticview.PolicyValueForFlow(source, flowID, "mcp_servers"); ok {
+		for name, key := range parseMCPServerCredentialKeys(value.Value) {
+			appendPolicyCredentialRequirement(index, source, flowID, key, Requirement{Kind: "mcp_server", Name: name})
+		}
+	}
+	if value, ok := semanticview.PolicyValueForFlow(source, flowID, "web_search_provider"); ok {
+		for name, key := range parseWebSearchProviderCredentialKeys(value.Value) {
+			appendPolicyCredentialRequirement(index, source, flowID, key, Requirement{Kind: "web_search_provider", Name: name})
+		}
+	}
+}
+
+func appendPolicyCredentialRequirement(index map[string][]Requirement, source semanticview.Source, flowID, key string, ref Requirement) {
+	key = strings.TrimSpace(key)
+	if key == "" {
+		return
+	}
+	storeKey, mapped := semanticview.CredentialStoreKeyForFlow(source, flowID, key)
+	if mapped && strings.TrimSpace(storeKey) == "" {
+		return
+	}
+	storeKey = strings.TrimSpace(storeKey)
+	if storeKey == "" {
+		return
+	}
+	index[storeKey] = append(index[storeKey], ref)
 }
 
 func Describe(ctx context.Context, store Store, source semanticview.Source, key string) (Descriptor, error) {

--- a/internal/runtime/credentials/store_test.go
+++ b/internal/runtime/credentials/store_test.go
@@ -120,6 +120,69 @@ func TestListDescriptors_IndexesToolsMCPServersAndWebSearchProvider(t *testing.T
 	}
 }
 
+func TestBuildRequirementIndex_IndexesImportedPackageCredentialBindings(t *testing.T) {
+	repoRoot := credentialsRepoRootForTest(t)
+	root := t.TempDir()
+	writeCredentialsFixtureFile(t, filepath.Join(root, "package.yaml"), `
+name: credential-binding
+version: "1.0.0"
+flows:
+  - id: alpha
+    flow: alpha
+    mode: static
+    bind:
+      credentials:
+        provider_key: tenant_alpha_key
+  - id: beta
+    flow: beta
+    mode: static
+    bind:
+      credentials:
+        provider_key: tenant_beta_key
+`)
+	writeCredentialsFixtureFile(t, filepath.Join(root, "schema.yaml"), "name: credential-binding\n")
+	writeCredentialsFixtureFile(t, filepath.Join(root, "policy.yaml"), "{}\n")
+	writeCredentialsFixtureFile(t, filepath.Join(root, "tools.yaml"), "{}\n")
+	writeCredentialsFixtureFile(t, filepath.Join(root, "agents.yaml"), "{}\n")
+	writeCredentialsFixtureFile(t, filepath.Join(root, "events.yaml"), "{}\n")
+	for _, flowID := range []string{"alpha", "beta"} {
+		writeCredentialsFixtureFile(t, filepath.Join(root, "flows", flowID, "package.yaml"), `
+name: worker-package
+version: "1.0.0"
+requires:
+  credentials: [provider_key]
+`)
+		writeCredentialsFixtureFile(t, filepath.Join(root, "flows", flowID, "schema.yaml"), "name: "+flowID+"\nmode: static\n")
+		writeCredentialsFixtureFile(t, filepath.Join(root, "flows", flowID, "policy.yaml"), "{}\n")
+		writeCredentialsFixtureFile(t, filepath.Join(root, "flows", flowID, "tools.yaml"), `
+call_provider:
+  handler_type: http
+  credentials: [provider_key]
+  http:
+    method: GET
+    url: https://provider.example.test
+`)
+		writeCredentialsFixtureFile(t, filepath.Join(root, "flows", flowID, "agents.yaml"), "{}\n")
+		writeCredentialsFixtureFile(t, filepath.Join(root, "flows", flowID, "events.yaml"), "{}\n")
+	}
+	bundle, err := runtimecontracts.LoadWorkflowContractBundleWithOverrides(repoRoot, root, runtimecontracts.DefaultPlatformSpecFile(repoRoot))
+	if err != nil {
+		t.Fatalf("LoadWorkflowContractBundleWithOverrides: %v", err)
+	}
+
+	index := BuildRequirementIndex(semanticview.Wrap(bundle))
+
+	if refs := index["provider_key"]; len(refs) != 0 {
+		t.Fatalf("raw package credential handle indexed as deployment key: %#v", refs)
+	}
+	if refs := index["tenant_alpha_key"]; len(refs) != 1 || refs[0].Kind != "tool" || refs[0].Name != "call_provider" {
+		t.Fatalf("tenant_alpha_key refs = %#v, want call_provider tool", refs)
+	}
+	if refs := index["tenant_beta_key"]; len(refs) != 1 || refs[0].Kind != "tool" || refs[0].Name != "call_provider" {
+		t.Fatalf("tenant_beta_key refs = %#v, want call_provider tool", refs)
+	}
+}
+
 func TestDefaultFilePath_UsesSwarmConfigDir(t *testing.T) {
 	tmp := t.TempDir()
 	t.Setenv("HOME", tmp)
@@ -140,5 +203,24 @@ func TestDefaultFilePath_UsesSwarmConfigDir(t *testing.T) {
 	}
 	if !strings.HasPrefix(path, configRoot) {
 		t.Fatalf("expected credential path under temp config dir %q, got %q", configRoot, path)
+	}
+}
+
+func credentialsRepoRootForTest(t *testing.T) string {
+	t.Helper()
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd: %v", err)
+	}
+	return filepath.Clean(filepath.Join(wd, "..", "..", ".."))
+}
+
+func writeCredentialsFixtureFile(t *testing.T, path, contents string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("MkdirAll(%s): %v", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, []byte(strings.TrimLeft(contents, "\n")), 0o644); err != nil {
+		t.Fatalf("WriteFile(%s): %v", path, err)
 	}
 }

--- a/internal/runtime/credentials/store_test.go
+++ b/internal/runtime/credentials/store_test.go
@@ -183,6 +183,94 @@ call_provider:
 	}
 }
 
+func TestMissingRequired_IndexesImportedNativeWebSearchCredentialBinding(t *testing.T) {
+	ctx := context.Background()
+	store, err := NewFileStore(filepath.Join(t.TempDir(), "credentials.json"))
+	if err != nil {
+		t.Fatalf("NewFileStore: %v", err)
+	}
+	if err := store.Set(ctx, "provider_key", "raw-secret"); err != nil {
+		t.Fatalf("Set provider_key: %v", err)
+	}
+
+	repoRoot := credentialsRepoRootForTest(t)
+	root := t.TempDir()
+	writeCredentialsFixtureFile(t, filepath.Join(root, "package.yaml"), `
+name: native-web-search-credential-binding
+version: "1.0.0"
+flows:
+  - id: worker
+    flow: worker
+    mode: static
+    bind:
+      credentials:
+        provider_key: tenant_provider_key
+`)
+	writeCredentialsFixtureFile(t, filepath.Join(root, "schema.yaml"), "name: native-web-search-credential-binding\n")
+	writeCredentialsFixtureFile(t, filepath.Join(root, "policy.yaml"), "{}\n")
+	writeCredentialsFixtureFile(t, filepath.Join(root, "tools.yaml"), "{}\n")
+	writeCredentialsFixtureFile(t, filepath.Join(root, "agents.yaml"), "{}\n")
+	writeCredentialsFixtureFile(t, filepath.Join(root, "events.yaml"), "{}\n")
+	writeCredentialsFixtureFile(t, filepath.Join(root, "nodes.yaml"), "{}\n")
+	writeCredentialsFixtureFile(t, filepath.Join(root, "flows", "worker", "package.yaml"), `
+name: worker-package
+version: "1.0.0"
+requires:
+  credentials: [provider_key]
+`)
+	writeCredentialsFixtureFile(t, filepath.Join(root, "flows", "worker", "schema.yaml"), "name: worker\nmode: static\n")
+	writeCredentialsFixtureFile(t, filepath.Join(root, "flows", "worker", "policy.yaml"), `
+web_search_provider:
+  provider: brave
+  credentials_key: provider_key
+`)
+	writeCredentialsFixtureFile(t, filepath.Join(root, "flows", "worker", "tools.yaml"), "{}\n")
+	writeCredentialsFixtureFile(t, filepath.Join(root, "flows", "worker", "agents.yaml"), `
+worker-agent:
+  id: worker-agent
+  model: regular
+  native_tools:
+    web_search: true
+`)
+	writeCredentialsFixtureFile(t, filepath.Join(root, "flows", "worker", "events.yaml"), "{}\n")
+
+	bundle, err := runtimecontracts.LoadWorkflowContractBundleWithOverrides(repoRoot, root, runtimecontracts.DefaultPlatformSpecFile(repoRoot))
+	if err != nil {
+		t.Fatalf("LoadWorkflowContractBundleWithOverrides: %v", err)
+	}
+	source := semanticview.Wrap(bundle)
+	index := BuildRequirementIndex(source)
+	if refs := index["provider_key"]; len(refs) != 0 {
+		t.Fatalf("raw provider_key refs = %#v, want none", refs)
+	}
+	if refs := index["tenant_provider_key"]; len(refs) != 1 || refs[0].Kind != "web_search_provider" || refs[0].Name != "brave" {
+		t.Fatalf("tenant_provider_key refs = %#v, want brave web_search_provider", refs)
+	}
+
+	missing, err := MissingRequired(ctx, store, source)
+	if err != nil {
+		t.Fatalf("MissingRequired: %v", err)
+	}
+	if len(missing) != 1 || missing[0].Key != "tenant_provider_key" {
+		t.Fatalf("MissingRequired = %#v, want only tenant_provider_key", missing)
+	}
+	if len(missing[0].RequiredBy) != 1 || missing[0].RequiredBy[0].Kind != "web_search_provider" || missing[0].RequiredBy[0].Name != "brave" {
+		t.Fatalf("tenant_provider_key RequiredBy = %#v, want brave web_search_provider", missing[0].RequiredBy)
+	}
+
+	descriptors, err := ListDescriptors(ctx, store, source)
+	if err != nil {
+		t.Fatalf("ListDescriptors: %v", err)
+	}
+	byKey := map[string]Descriptor{}
+	for _, desc := range descriptors {
+		byKey[desc.Key] = desc
+	}
+	if got := byKey["provider_key"]; !got.Present || len(got.RequiredBy) != 0 {
+		t.Fatalf("raw provider_key descriptor = %+v, want present with no requirement", got)
+	}
+}
+
 func TestDefaultFilePath_UsesSwarmConfigDir(t *testing.T) {
 	tmp := t.TempDir()
 	t.Setenv("HOME", tmp)

--- a/internal/runtime/mcp/client.go
+++ b/internal/runtime/mcp/client.go
@@ -49,6 +49,8 @@ type Client struct {
 	tools   map[string]DiscoveredTool
 }
 
+type CredentialKeyResolver func(string) (string, error)
+
 type registeredServer struct {
 	cfg   ServerConfig
 	stdio *stdioRPCClient
@@ -133,6 +135,10 @@ func (c *Client) DiscoveredTools() map[string]DiscoveredTool {
 }
 
 func (c *Client) Call(ctx context.Context, prefixedName string, arguments any) (any, error) {
+	return c.CallWithCredentialKeyResolver(ctx, prefixedName, arguments, nil)
+}
+
+func (c *Client) CallWithCredentialKeyResolver(ctx context.Context, prefixedName string, arguments any, resolver CredentialKeyResolver) (any, error) {
 	if c == nil {
 		return nil, fmt.Errorf("mcp client is not configured")
 	}
@@ -156,7 +162,7 @@ func (c *Client) Call(ctx context.Context, prefixedName string, arguments any) (
 		},
 		ID: prefixedName + "-call",
 	}
-	resp, err := c.callServer(ctx, server, req)
+	resp, err := c.callServerWithCredentialKeyResolver(ctx, server, req, resolver)
 	if err != nil {
 		return nil, err
 	}
@@ -243,6 +249,10 @@ func (c *Client) discoverServerTools(ctx context.Context, source semanticview.So
 }
 
 func (c *Client) callServer(ctx context.Context, server *registeredServer, req RPCRequest) (RPCResponse, error) {
+	return c.callServerWithCredentialKeyResolver(ctx, server, req, nil)
+}
+
+func (c *Client) callServerWithCredentialKeyResolver(ctx context.Context, server *registeredServer, req RPCRequest, resolver CredentialKeyResolver) (RPCResponse, error) {
 	switch strings.ToLower(strings.TrimSpace(server.cfg.Transport)) {
 	case "stdio":
 		if server.stdio == nil {
@@ -250,13 +260,17 @@ func (c *Client) callServer(ctx context.Context, server *registeredServer, req R
 		}
 		return server.stdio.Call(ctx, req)
 	case "http", "":
-		return c.callHTTPServer(ctx, server.cfg, req)
+		return c.callHTTPServerWithCredentialKeyResolver(ctx, server.cfg, req, resolver)
 	default:
 		return RPCResponse{}, fmt.Errorf("unsupported mcp transport %q", server.cfg.Transport)
 	}
 }
 
 func (c *Client) callHTTPServer(ctx context.Context, cfg ServerConfig, req RPCRequest) (RPCResponse, error) {
+	return c.callHTTPServerWithCredentialKeyResolver(ctx, cfg, req, nil)
+}
+
+func (c *Client) callHTTPServerWithCredentialKeyResolver(ctx context.Context, cfg ServerConfig, req RPCRequest, resolver CredentialKeyResolver) (RPCResponse, error) {
 	body, err := json.Marshal(req)
 	if err != nil {
 		return RPCResponse{}, err
@@ -267,7 +281,15 @@ func (c *Client) callHTTPServer(ctx context.Context, cfg ServerConfig, req RPCRe
 	}
 	httpReq.Header.Set("content-type", "application/json")
 	httpReq.Header.Set("mcp-protocol-version", "2025-03-26")
-	if token, ok, err := c.credentialValue(ctx, cfg.CredentialsKey); err != nil {
+	credentialKey := strings.TrimSpace(cfg.CredentialsKey)
+	if resolver != nil && credentialKey != "" {
+		resolved, err := resolver(credentialKey)
+		if err != nil {
+			return RPCResponse{}, err
+		}
+		credentialKey = strings.TrimSpace(resolved)
+	}
+	if token, ok, err := c.credentialValue(ctx, credentialKey); err != nil {
 		return RPCResponse{}, err
 	} else if ok && strings.TrimSpace(token) != "" {
 		httpReq.Header.Set("authorization", "Bearer "+strings.TrimSpace(token))

--- a/internal/runtime/mcp/client_test.go
+++ b/internal/runtime/mcp/client_test.go
@@ -1,0 +1,68 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+
+	runtimecredentials "github.com/division-sh/swarm/internal/runtime/credentials"
+)
+
+func TestClientCallWithCredentialKeyResolverUsesBoundDeploymentCredential(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got, want := r.Header.Get("Authorization"), "Bearer mcp-secret"; got != want {
+			t.Fatalf("Authorization = %q, want %q", got, want)
+		}
+		var req map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatalf("Decode request: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"jsonrpc": "2.0",
+			"id":      req["id"],
+			"result": map[string]any{
+				"structuredContent": map[string]any{"ok": true},
+			},
+		})
+	}))
+	defer server.Close()
+
+	store, err := runtimecredentials.NewFileStore(filepath.Join(t.TempDir(), "credentials.json"))
+	if err != nil {
+		t.Fatalf("NewFileStore: %v", err)
+	}
+	if err := store.Set(context.Background(), "tenant_mcp_key", "mcp-secret"); err != nil {
+		t.Fatalf("Set tenant_mcp_key: %v", err)
+	}
+	client := NewClient(store)
+	client.httpClient = server.Client()
+	client.servers["infra"] = &registeredServer{cfg: ServerConfig{
+		Name:           "infra",
+		Transport:      "http",
+		URL:            server.URL,
+		CredentialsKey: "provider_key",
+	}}
+	client.tools["infra.ping"] = DiscoveredTool{
+		Name:       "infra.ping",
+		RemoteName: "ping",
+		ServerName: "infra",
+	}
+
+	out, err := client.CallWithCredentialKeyResolver(context.Background(), "infra.ping", map[string]any{}, func(key string) (string, error) {
+		if key != "provider_key" {
+			t.Fatalf("resolver key = %q, want package handle provider_key", key)
+		}
+		return "tenant_mcp_key", nil
+	})
+	if err != nil {
+		t.Fatalf("CallWithCredentialKeyResolver: %v", err)
+	}
+	result, ok := out.(map[string]any)
+	if !ok || result["ok"] != true {
+		t.Fatalf("result = %#v, want ok=true", out)
+	}
+}

--- a/internal/runtime/runforkexecution/agent_runtime_materialization.go
+++ b/internal/runtime/runforkexecution/agent_runtime_materialization.go
@@ -368,7 +368,14 @@ func selectedContractPromptResolver(source semanticview.Source) (runtimecontract
 	if !ok {
 		return nil, nil
 	}
-	return runtimecontracts.NewBundlePromptResolver(bundle), nil
+	return runtimecontracts.NewBundlePromptResolverWithOptions(bundle, runtimecontracts.BundlePromptResolverOptions{
+		PolicyResolver: func(itemSource runtimecontracts.ContractItemSource) runtimecontracts.PolicyDocument {
+			if flowID := strings.TrimSpace(itemSource.FlowID); flowID != "" {
+				return semanticview.ResolvePolicyForFlow(source, flowID)
+			}
+			return semanticview.ResolvePolicyForFlow(source, "")
+		},
+	}), nil
 }
 
 func (r *selectedContractAgentRuntime) Shutdown() error {

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -278,7 +278,14 @@ func newRuntimePromptResolver(source semanticview.Source) (runtimecontracts.Prom
 	if !ok {
 		return nil, fmt.Errorf("bundle-backed semantic source is required for contract prompt resolution")
 	}
-	return runtimecontracts.NewBundlePromptResolver(bundle), nil
+	return runtimecontracts.NewBundlePromptResolverWithOptions(bundle, runtimecontracts.BundlePromptResolverOptions{
+		PolicyResolver: func(itemSource runtimecontracts.ContractItemSource) runtimecontracts.PolicyDocument {
+			if flowID := strings.TrimSpace(itemSource.FlowID); flowID != "" {
+				return semanticview.ResolvePolicyForFlow(source, flowID)
+			}
+			return semanticview.ResolvePolicyForFlow(source, "")
+		},
+	}), nil
 }
 
 // Validate checks the NewRuntime boot dependency graph without constructing a runtime.

--- a/internal/runtime/runtime_prompt_resolver_test.go
+++ b/internal/runtime/runtime_prompt_resolver_test.go
@@ -1,10 +1,14 @@
 package runtime
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
+	models "github.com/division-sh/swarm/internal/runtime/core/actors"
+	runtimepipeline "github.com/division-sh/swarm/internal/runtime/pipeline"
 	"github.com/division-sh/swarm/internal/runtime/semanticview"
 )
 
@@ -20,5 +24,77 @@ func TestNewRuntimePromptResolver_RejectsNonBundleSemanticSource(t *testing.T) {
 	_, err := newRuntimePromptResolver(source)
 	if err == nil || !strings.Contains(err.Error(), "bundle-backed semantic source is required") {
 		t.Fatalf("newRuntimePromptResolver err = %v, want bundle-backed source error", err)
+	}
+}
+
+func TestNewRuntimePromptResolver_UsesImportBoundaryPolicyResolution(t *testing.T) {
+	repoRoot := runtimepipeline.WorkflowRepoRoot()
+	root := t.TempDir()
+
+	writeRuntimePromptResolverFixtureFile(t, filepath.Join(root, "package.yaml"), `
+name: prompt-import-policy
+version: "1.0.0"
+flows:
+  - id: worker
+    flow: worker
+    mode: static
+    bind:
+      policy:
+        threshold: parent.policy.tenant_threshold
+`)
+	writeRuntimePromptResolverFixtureFile(t, filepath.Join(root, "schema.yaml"), "name: prompt-import-policy\n")
+	writeRuntimePromptResolverFixtureFile(t, filepath.Join(root, "policy.yaml"), `
+threshold: 999
+tenant_threshold: 42
+`)
+	writeRuntimePromptResolverFixtureFile(t, filepath.Join(root, "tools.yaml"), "{}\n")
+	writeRuntimePromptResolverFixtureFile(t, filepath.Join(root, "agents.yaml"), "{}\n")
+	writeRuntimePromptResolverFixtureFile(t, filepath.Join(root, "events.yaml"), "{}\n")
+	writeRuntimePromptResolverFixtureFile(t, filepath.Join(root, "nodes.yaml"), "{}\n")
+	writeRuntimePromptResolverFixtureFile(t, filepath.Join(root, "flows", "worker", "package.yaml"), `
+name: worker-package
+version: "1.0.0"
+requires:
+  policy: [threshold]
+`)
+	writeRuntimePromptResolverFixtureFile(t, filepath.Join(root, "flows", "worker", "schema.yaml"), "name: worker\nmode: static\n")
+	writeRuntimePromptResolverFixtureFile(t, filepath.Join(root, "flows", "worker", "policy.yaml"), "threshold: 10\n")
+	writeRuntimePromptResolverFixtureFile(t, filepath.Join(root, "flows", "worker", "tools.yaml"), "{}\n")
+	writeRuntimePromptResolverFixtureFile(t, filepath.Join(root, "flows", "worker", "agents.yaml"), `
+worker-agent:
+  id: worker-agent
+  role: worker
+  model: regular
+`)
+	writeRuntimePromptResolverFixtureFile(t, filepath.Join(root, "flows", "worker", "events.yaml"), "{}\n")
+	writeRuntimePromptResolverFixtureFile(t, filepath.Join(root, "flows", "worker", "prompts", "worker-agent.md"), "threshold={{threshold}}\n")
+
+	bundle, err := runtimecontracts.LoadWorkflowContractBundleWithOverrides(repoRoot, root, runtimecontracts.DefaultPlatformSpecFile(repoRoot))
+	if err != nil {
+		t.Fatalf("LoadWorkflowContractBundleWithOverrides: %v", err)
+	}
+	resolver, err := newRuntimePromptResolver(semanticview.Wrap(bundle))
+	if err != nil {
+		t.Fatalf("newRuntimePromptResolver: %v", err)
+	}
+	prompt, found, err := resolver.LoadPromptForAgent(models.AgentConfig{ID: "worker-agent"}, "")
+	if err != nil {
+		t.Fatalf("LoadPromptForAgent: %v", err)
+	}
+	if !found {
+		t.Fatal("prompt not found")
+	}
+	if got, want := strings.TrimSpace(prompt), "threshold=42"; got != want {
+		t.Fatalf("prompt = %q, want %q", got, want)
+	}
+}
+
+func writeRuntimePromptResolverFixtureFile(t *testing.T, path, contents string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("MkdirAll(%s): %v", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, []byte(strings.TrimLeft(contents, "\n")), 0o644); err != nil {
+		t.Fatalf("WriteFile(%s): %v", path, err)
 	}
 }

--- a/internal/runtime/semanticview/bundle_source.go
+++ b/internal/runtime/semanticview/bundle_source.go
@@ -266,10 +266,10 @@ func (s bundleSource) FlowRequiredAgents(flowID string) []runtimecontracts.FlowR
 	return s.bundle.FlowRequiredAgents(flowID)
 }
 func (s bundleSource) ResolvedPolicyForFlow(flowID string) runtimecontracts.PolicyDocument {
-	return s.bundle.ResolvedPolicyForFlow(flowID)
+	return ResolvePolicyForFlow(s, flowID)
 }
 func (s bundleSource) ResolvedPolicyForNode(nodeID string) runtimecontracts.PolicyDocument {
-	return s.bundle.ResolvedPolicyForNode(nodeID)
+	return ResolvePolicyForNode(s, nodeID)
 }
 func (s bundleSource) ResolvedEventCatalog() map[string]runtimecontracts.EventCatalogEntry {
 	return s.bundle.ResolvedEventCatalog()

--- a/internal/runtime/semanticview/import_boundary_dependencies.go
+++ b/internal/runtime/semanticview/import_boundary_dependencies.go
@@ -1,0 +1,454 @@
+package semanticview
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
+)
+
+const (
+	ImportBoundaryDependencyPolicy     = "policy"
+	ImportBoundaryDependencyCredential = "credential"
+)
+
+type ImportBoundaryDependencyIssue struct {
+	Kind             string
+	Dependency       string
+	ParentPackageKey string
+	ChildPackageKey  string
+	ImportLabel      string
+	Reference        string
+	Message          string
+}
+
+func ResolvePolicyForFlow(source Source, flowID string) runtimecontracts.PolicyDocument {
+	if source == nil {
+		return emptyPolicyDocument()
+	}
+	if bundle, ok := Bundle(source); ok && bundle != nil {
+		return resolvePolicyForFlowWithRaw(source, flowID, bundle.ResolvedPolicyForFlow)
+	}
+	return resolvePolicyForFlowWithRaw(source, flowID, source.ResolvedPolicyForFlow)
+}
+
+func ResolvePolicyForNode(source Source, nodeID string) runtimecontracts.PolicyDocument {
+	if source == nil {
+		return emptyPolicyDocument()
+	}
+	if nodeSource, ok := source.NodeContractSource(nodeID); ok {
+		return ResolvePolicyForFlow(source, nodeSource.FlowID)
+	}
+	return ResolvePolicyForFlow(source, "")
+}
+
+func CredentialStoreKeyForFlow(source Source, flowID, key string) (string, bool) {
+	key = strings.TrimSpace(key)
+	if source == nil || key == "" {
+		return key, false
+	}
+	deps, ok := importBoundaryDependencyContext(source, flowID)
+	if !ok || len(deps.child.Manifest.Requires.Credentials) == 0 {
+		return key, false
+	}
+	required := normalizeDependencySet(deps.child.Manifest.Requires.Credentials)
+	if _, ok := required[key]; !ok {
+		return "", true
+	}
+	value := strings.TrimSpace(deps.site.Bind.Credentials[key])
+	return value, true
+}
+
+func CredentialStoreKeyForActor(source Source, actorID, key string) (string, bool) {
+	actorID = strings.TrimSpace(actorID)
+	if source == nil || actorID == "" {
+		return strings.TrimSpace(key), false
+	}
+	if agentSource, ok := source.AgentContractSource(actorID); ok {
+		return CredentialStoreKeyForFlow(source, agentSource.FlowID, key)
+	}
+	return strings.TrimSpace(key), false
+}
+
+func ImportBoundaryDependencyIssues(source Source) []ImportBoundaryDependencyIssue {
+	if source == nil {
+		return nil
+	}
+	var issues []ImportBoundaryDependencyIssue
+	for _, deps := range importBoundaryDependencyContexts(source) {
+		issues = append(issues, importBoundaryPolicyDependencyIssues(source, deps)...)
+		issues = append(issues, importBoundaryCredentialDependencyIssues(deps)...)
+	}
+	sort.Slice(issues, func(i, j int) bool {
+		return strings.Compare(importBoundaryDependencyIssueSortKey(issues[i]), importBoundaryDependencyIssueSortKey(issues[j])) < 0
+	})
+	return issues
+}
+
+func resolvePolicyForFlowWithRaw(source Source, flowID string, raw func(string) runtimecontracts.PolicyDocument) runtimecontracts.PolicyDocument {
+	flowID = strings.TrimSpace(flowID)
+	if source == nil || raw == nil {
+		return emptyPolicyDocument()
+	}
+	deps, ok := importBoundaryDependencyContext(source, flowID)
+	if !ok {
+		return clonePolicyDocument(raw(flowID))
+	}
+	doc := localPolicyForImportedFlow(source, deps.child, flowID)
+	parentFlowID := strings.TrimSpace(deps.parent.OwningFlowID)
+	parentPolicy := clonePolicyDocument(raw(parentFlowID))
+	for _, key := range deps.child.Manifest.Requires.Policy {
+		key = strings.TrimSpace(key)
+		if key == "" {
+			continue
+		}
+		deletePolicyValueAtPath(&doc, key)
+		if ref := strings.TrimSpace(deps.site.Bind.Policy[key]); ref != "" {
+			if path, ok := importBoundaryParentPolicyPath(ref); ok {
+				if value, found := policyValueAtPath(parentPolicy, path); found {
+					setPolicyValueAtPath(&doc, key, value)
+				}
+			}
+			continue
+		}
+		if value, ok := deps.child.Manifest.Requires.PolicyDefaults[key]; ok {
+			setPolicyValueAtPath(&doc, key, value)
+		}
+	}
+	return doc
+}
+
+type importBoundaryDependencyCtx struct {
+	parent ProjectScope
+	child  ProjectScope
+	site   importBoundarySite
+}
+
+func importBoundaryDependencyContext(source Source, flowID string) (importBoundaryDependencyCtx, bool) {
+	flowID = strings.TrimSpace(flowID)
+	if source == nil || flowID == "" {
+		return importBoundaryDependencyCtx{}, false
+	}
+	flow, ok := source.FlowScopeByID(flowID)
+	if !ok {
+		return importBoundaryDependencyCtx{}, false
+	}
+	flowPackageKey := normalizeImportPackageKey(flow.PackageKey)
+	for _, deps := range importBoundaryDependencyContexts(source) {
+		siteFlowID := strings.TrimSpace(deps.site.FlowID)
+		if siteFlowID != "" {
+			if siteFlowID == flowID {
+				return deps, true
+			}
+			continue
+		}
+		childKey := normalizeImportPackageKey(deps.child.Key)
+		if flowPackageKey != "" && flowPackageKey != "." && childKey == flowPackageKey {
+			return deps, true
+		}
+		if strings.TrimSpace(deps.child.OwningFlowID) == flowID {
+			return deps, true
+		}
+	}
+	return importBoundaryDependencyCtx{}, false
+}
+
+func importBoundaryDependencyContexts(source Source) []importBoundaryDependencyCtx {
+	projectByKey, _ := importBoundaryScopeIndexes(source)
+	var out []importBoundaryDependencyCtx
+	for _, parent := range source.ProjectScopes() {
+		parent.Key = normalizeImportPackageKey(parent.Key)
+		for _, site := range importBoundarySites(parent) {
+			child, ok := projectByKey[site.PackageKey]
+			if !ok || importRequiresEmpty(child.Manifest.Requires) {
+				continue
+			}
+			out = append(out, importBoundaryDependencyCtx{parent: parent, child: child, site: site})
+		}
+	}
+	return out
+}
+
+func importBoundaryPolicyDependencyIssues(source Source, deps importBoundaryDependencyCtx) []ImportBoundaryDependencyIssue {
+	required := normalizeDependencySet(deps.child.Manifest.Requires.Policy)
+	var issues []ImportBoundaryDependencyIssue
+	for key := range required {
+		ref := strings.TrimSpace(deps.site.Bind.Policy[key])
+		if ref == "" {
+			if _, ok := deps.child.Manifest.Requires.PolicyDefaults[key]; !ok {
+				issues = append(issues, importBoundaryDependencyIssue(deps, "missing_policy_binding", key, "", "declared package policy dependency has no import binding or package default"))
+			}
+			continue
+		}
+		path, ok := importBoundaryParentPolicyPath(ref)
+		if !ok {
+			issues = append(issues, importBoundaryDependencyIssue(deps, "unsupported_policy_reference", key, ref, "policy binding must reference parent.policy.<path> or policy.<path>"))
+			continue
+		}
+		parentPolicy := ResolvePolicyForFlow(source, deps.parent.OwningFlowID)
+		if _, ok := policyValueAtPath(parentPolicy, path); !ok {
+			issues = append(issues, importBoundaryDependencyIssue(deps, "missing_parent_policy", key, ref, "policy binding references a parent policy value that does not exist"))
+		}
+	}
+	for key := range deps.site.Bind.Policy {
+		key = strings.TrimSpace(key)
+		if key == "" {
+			continue
+		}
+		if _, ok := required[key]; !ok {
+			issues = append(issues, importBoundaryDependencyIssue(deps, "unknown_policy_binding", key, deps.site.Bind.Policy[key], "policy bind key is not declared by the imported package requires.policy"))
+		}
+	}
+	return issues
+}
+
+func importBoundaryCredentialDependencyIssues(deps importBoundaryDependencyCtx) []ImportBoundaryDependencyIssue {
+	required := normalizeDependencySet(deps.child.Manifest.Requires.Credentials)
+	var issues []ImportBoundaryDependencyIssue
+	for key := range required {
+		if strings.TrimSpace(deps.site.Bind.Credentials[key]) == "" {
+			issues = append(issues, importBoundaryDependencyIssue(deps, "missing_credential_binding", key, "", "declared package credential dependency has no import binding"))
+		}
+	}
+	for key := range deps.site.Bind.Credentials {
+		key = strings.TrimSpace(key)
+		if key == "" {
+			continue
+		}
+		if _, ok := required[key]; !ok {
+			issues = append(issues, importBoundaryDependencyIssue(deps, "unknown_credential_binding", key, deps.site.Bind.Credentials[key], "credential bind key is not declared by the imported package requires.credentials"))
+		}
+	}
+	return issues
+}
+
+func importBoundaryDependencyIssue(deps importBoundaryDependencyCtx, kind, dependency, ref, message string) ImportBoundaryDependencyIssue {
+	return ImportBoundaryDependencyIssue{
+		Kind:             kind,
+		Dependency:       strings.TrimSpace(dependency),
+		ParentPackageKey: normalizeImportPackageKey(deps.parent.Key),
+		ChildPackageKey:  normalizeImportPackageKey(deps.child.Key),
+		ImportLabel:      strings.TrimSpace(deps.site.Label),
+		Reference:        strings.TrimSpace(ref),
+		Message:          strings.TrimSpace(message),
+	}
+}
+
+func localPolicyForImportedFlow(source Source, child ProjectScope, flowID string) runtimecontracts.PolicyDocument {
+	out := clonePolicyDocument(child.Policy)
+	if flow, ok := source.FlowScopeByID(flowID); ok {
+		mergePolicyValues(&out, flow.Policy)
+	}
+	return out
+}
+
+func importBoundaryParentPolicyPath(ref string) (string, bool) {
+	ref = strings.TrimSpace(ref)
+	switch {
+	case strings.HasPrefix(ref, "parent.policy."):
+		return strings.TrimSpace(strings.TrimPrefix(ref, "parent.policy.")), true
+	case strings.HasPrefix(ref, "policy."):
+		return strings.TrimSpace(strings.TrimPrefix(ref, "policy.")), true
+	default:
+		return "", false
+	}
+}
+
+func policyValueAtPath(doc runtimecontracts.PolicyDocument, path string) (runtimecontracts.PolicyValue, bool) {
+	path = strings.TrimSpace(path)
+	if path == "" || len(doc.Values) == 0 {
+		return runtimecontracts.PolicyValue{}, false
+	}
+	root, rest := splitPolicyKey(path)
+	value, ok := doc.Values[root]
+	if !ok {
+		return runtimecontracts.PolicyValue{}, false
+	}
+	if strings.TrimSpace(rest) == "" {
+		return clonePolicyValue(value), true
+	}
+	descended, ok := descendPolicyValue(value.Value, rest)
+	if !ok {
+		return runtimecontracts.PolicyValue{}, false
+	}
+	return runtimecontracts.PolicyValue{Value: cloneAny(descended)}, true
+}
+
+func setPolicyValueAtPath(doc *runtimecontracts.PolicyDocument, path string, value runtimecontracts.PolicyValue) {
+	if doc == nil {
+		return
+	}
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return
+	}
+	if doc.Values == nil {
+		doc.Values = map[string]runtimecontracts.PolicyValue{}
+	}
+	root, rest := splitPolicyKey(path)
+	if rest == "" {
+		doc.Values[root] = clonePolicyValue(value)
+		return
+	}
+	current := map[string]any{}
+	if existing, ok := doc.Values[root]; ok {
+		if typed, ok := cloneAny(existing.Value).(map[string]any); ok {
+			current = typed
+		}
+	}
+	setNestedValue(current, rest, cloneAny(value.Value))
+	doc.Values[root] = runtimecontracts.PolicyValue{Value: current}
+}
+
+func setNestedValue(root map[string]any, path string, value any) {
+	parts := strings.Split(strings.TrimSpace(path), ".")
+	current := root
+	for i, part := range parts {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			return
+		}
+		if i == len(parts)-1 {
+			current[part] = value
+			return
+		}
+		next, _ := current[part].(map[string]any)
+		if next == nil {
+			next = map[string]any{}
+			current[part] = next
+		}
+		current = next
+	}
+}
+
+func mergePolicyValues(dst *runtimecontracts.PolicyDocument, src runtimecontracts.PolicyDocument) {
+	if dst == nil {
+		return
+	}
+	if dst.Values == nil {
+		dst.Values = map[string]runtimecontracts.PolicyValue{}
+	}
+	for key, value := range src.Values {
+		key = strings.TrimSpace(key)
+		if key == "" {
+			continue
+		}
+		dst.Values[key] = clonePolicyValue(value)
+	}
+}
+
+func deletePolicyValueAtPath(doc *runtimecontracts.PolicyDocument, path string) {
+	if doc == nil || len(doc.Values) == 0 {
+		return
+	}
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return
+	}
+	root, rest := splitPolicyKey(path)
+	if rest == "" {
+		delete(doc.Values, root)
+		return
+	}
+	existing, ok := doc.Values[root]
+	if !ok {
+		return
+	}
+	current, ok := cloneAny(existing.Value).(map[string]any)
+	if !ok {
+		return
+	}
+	deleteNestedValue(current, rest)
+	doc.Values[root] = runtimecontracts.PolicyValue{Value: current}
+}
+
+func deleteNestedValue(root map[string]any, path string) {
+	parts := strings.Split(strings.TrimSpace(path), ".")
+	current := root
+	for i, part := range parts {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			return
+		}
+		if i == len(parts)-1 {
+			delete(current, part)
+			return
+		}
+		next, _ := current[part].(map[string]any)
+		if next == nil {
+			return
+		}
+		current = next
+	}
+}
+
+func clonePolicyDocument(in runtimecontracts.PolicyDocument) runtimecontracts.PolicyDocument {
+	out := runtimecontracts.PolicyDocument{Values: map[string]runtimecontracts.PolicyValue{}}
+	for key, value := range in.Values {
+		key = strings.TrimSpace(key)
+		if key == "" {
+			continue
+		}
+		out.Values[key] = clonePolicyValue(value)
+	}
+	return out
+}
+
+func clonePolicyValue(in runtimecontracts.PolicyValue) runtimecontracts.PolicyValue {
+	return runtimecontracts.PolicyValue{
+		Value:       cloneAny(in.Value),
+		Description: strings.TrimSpace(in.Description),
+		Override:    in.Override,
+	}
+}
+
+func cloneAny(value any) any {
+	switch typed := value.(type) {
+	case map[string]any:
+		out := make(map[string]any, len(typed))
+		for key, item := range typed {
+			out[key] = cloneAny(item)
+		}
+		return out
+	case map[any]any:
+		out := make(map[string]any, len(typed))
+		for key, item := range typed {
+			out[fmt.Sprint(key)] = cloneAny(item)
+		}
+		return out
+	case []any:
+		out := make([]any, len(typed))
+		for i, item := range typed {
+			out[i] = cloneAny(item)
+		}
+		return out
+	default:
+		return value
+	}
+}
+
+func emptyPolicyDocument() runtimecontracts.PolicyDocument {
+	return runtimecontracts.PolicyDocument{Values: map[string]runtimecontracts.PolicyValue{}}
+}
+
+func normalizeDependencySet(values []string) map[string]struct{} {
+	out := map[string]struct{}{}
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value != "" {
+			out[value] = struct{}{}
+		}
+	}
+	return out
+}
+
+func importBoundaryDependencyIssueSortKey(issue ImportBoundaryDependencyIssue) string {
+	return strings.Join([]string{
+		issue.Kind,
+		issue.ParentPackageKey,
+		issue.ChildPackageKey,
+		issue.Dependency,
+		issue.Reference,
+	}, "|")
+}

--- a/internal/runtime/semanticview/import_boundary_dependencies.go
+++ b/internal/runtime/semanticview/import_boundary_dependencies.go
@@ -105,7 +105,7 @@ func resolvePolicyForFlowWithRaw(source Source, flowID string, raw func(string) 
 	}
 	doc := localPolicyForImportedFlow(source, deps.child, flowID)
 	parentFlowID := strings.TrimSpace(deps.parent.OwningFlowID)
-	parentPolicy := clonePolicyDocument(raw(parentFlowID))
+	parentPolicy := ResolvePolicyForFlow(source, parentFlowID)
 	for _, key := range deps.child.Manifest.Requires.Policy {
 		key = strings.TrimSpace(key)
 		if key == "" {

--- a/internal/runtime/semanticview/import_boundary_dependencies.go
+++ b/internal/runtime/semanticview/import_boundary_dependencies.go
@@ -49,7 +49,7 @@ func CredentialStoreKeyForFlow(source Source, flowID, key string) (string, bool)
 		return key, false
 	}
 	deps, ok := importBoundaryDependencyContext(source, flowID)
-	if !ok || len(deps.child.Manifest.Requires.Credentials) == 0 {
+	if !ok {
 		return key, false
 	}
 	required := normalizeDependencySet(deps.child.Manifest.Requires.Credentials)
@@ -61,9 +61,17 @@ func CredentialStoreKeyForFlow(source Source, flowID, key string) (string, bool)
 }
 
 func CredentialStoreKeyForActor(source Source, actorID, key string) (string, bool) {
+	return CredentialStoreKeyForActorFlow(source, actorID, "", key)
+}
+
+func CredentialStoreKeyForActorFlow(source Source, actorID, flowID, key string) (string, bool) {
 	actorID = strings.TrimSpace(actorID)
-	if source == nil || actorID == "" {
+	flowID = strings.TrimSpace(flowID)
+	if source == nil {
 		return strings.TrimSpace(key), false
+	}
+	if flowID != "" {
+		return CredentialStoreKeyForFlow(source, flowID, key)
 	}
 	if agentSource, ok := source.AgentContractSource(actorID); ok {
 		return CredentialStoreKeyForFlow(source, agentSource.FlowID, key)
@@ -135,6 +143,8 @@ func importBoundaryDependencyContext(source Source, flowID string) (importBounda
 		return importBoundaryDependencyCtx{}, false
 	}
 	flowPackageKey := normalizeImportPackageKey(flow.PackageKey)
+	var bestPackage importBoundaryDependencyCtx
+	bestPackageLen := -1
 	for _, deps := range importBoundaryDependencyContexts(source) {
 		siteFlowID := strings.TrimSpace(deps.site.FlowID)
 		if siteFlowID != "" {
@@ -144,14 +154,30 @@ func importBoundaryDependencyContext(source Source, flowID string) (importBounda
 			continue
 		}
 		childKey := normalizeImportPackageKey(deps.child.Key)
-		if flowPackageKey != "" && flowPackageKey != "." && childKey == flowPackageKey {
-			return deps, true
+		if importBoundaryPackageKeyContains(childKey, flowPackageKey) {
+			if keyLen := len(childKey); keyLen > bestPackageLen {
+				bestPackage = deps
+				bestPackageLen = keyLen
+			}
+			continue
 		}
 		if strings.TrimSpace(deps.child.OwningFlowID) == flowID {
 			return deps, true
 		}
 	}
+	if bestPackageLen >= 0 {
+		return bestPackage, true
+	}
 	return importBoundaryDependencyCtx{}, false
+}
+
+func importBoundaryPackageKeyContains(parentKey, flowPackageKey string) bool {
+	parentKey = normalizeImportPackageKey(parentKey)
+	flowPackageKey = normalizeImportPackageKey(flowPackageKey)
+	if parentKey == "" || parentKey == "." || flowPackageKey == "" || flowPackageKey == "." {
+		return false
+	}
+	return flowPackageKey == parentKey || strings.HasPrefix(flowPackageKey, parentKey+"/")
 }
 
 func importBoundaryDependencyContexts(source Source) []importBoundaryDependencyCtx {

--- a/internal/runtime/semanticview/import_boundary_dependencies.go
+++ b/internal/runtime/semanticview/import_boundary_dependencies.go
@@ -145,6 +145,8 @@ func importBoundaryDependencyContext(source Source, flowID string) (importBounda
 	flowPackageKey := normalizeImportPackageKey(flow.PackageKey)
 	var bestPackage importBoundaryDependencyCtx
 	bestPackageLen := -1
+	var bestPackageWithRequires importBoundaryDependencyCtx
+	bestPackageWithRequiresLen := -1
 	for _, deps := range importBoundaryDependencyContexts(source) {
 		siteFlowID := strings.TrimSpace(deps.site.FlowID)
 		if siteFlowID != "" {
@@ -159,11 +161,20 @@ func importBoundaryDependencyContext(source Source, flowID string) (importBounda
 				bestPackage = deps
 				bestPackageLen = keyLen
 			}
+			if !importRequiresEmpty(deps.child.Manifest.Requires) {
+				if keyLen := len(childKey); keyLen > bestPackageWithRequiresLen {
+					bestPackageWithRequires = deps
+					bestPackageWithRequiresLen = keyLen
+				}
+			}
 			continue
 		}
 		if strings.TrimSpace(deps.child.OwningFlowID) == flowID {
 			return deps, true
 		}
+	}
+	if bestPackageWithRequiresLen >= 0 {
+		return bestPackageWithRequires, true
 	}
 	if bestPackageLen >= 0 {
 		return bestPackage, true
@@ -187,7 +198,7 @@ func importBoundaryDependencyContexts(source Source) []importBoundaryDependencyC
 		parent.Key = normalizeImportPackageKey(parent.Key)
 		for _, site := range importBoundarySites(parent) {
 			child, ok := projectByKey[site.PackageKey]
-			if !ok || importRequiresEmpty(child.Manifest.Requires) {
+			if !ok {
 				continue
 			}
 			out = append(out, importBoundaryDependencyCtx{parent: parent, child: child, site: site})

--- a/internal/runtime/semanticview/import_boundary_dependencies_test.go
+++ b/internal/runtime/semanticview/import_boundary_dependencies_test.go
@@ -83,6 +83,20 @@ func TestImportBoundaryCredentialStoreKeyRequiresDeclaredBinding(t *testing.T) {
 	}
 }
 
+func TestImportBoundaryDependencyContextWithoutRequiresStillFailsClosed(t *testing.T) {
+	source := loadImportBoundaryDependencyFixture(t, importBoundaryDependencyFixtureOptions{})
+
+	if _, ok := PolicyValueForFlow(source, "worker", "provider.parent_only"); ok {
+		t.Fatal("imported flow with empty requires inherited parent-only policy key")
+	}
+	if got, ok := PolicyValueForFlow(source, "worker", "provider.package_only"); !ok || got.Value != "visible" {
+		t.Fatalf("provider.package_only = (%#v, %v), want child local package policy", got.Value, ok)
+	}
+	if got, mapped := CredentialStoreKeyForFlow(source, "worker", "provider_key"); !mapped || got != "" {
+		t.Fatalf("CredentialStoreKeyForFlow(provider_key) with empty requires = (%q, %v), want empty mapped fail-closed", got, mapped)
+	}
+}
+
 func TestImportBoundaryCredentialStoreKeyUsesExplicitActorFlowContext(t *testing.T) {
 	source := loadImportBoundaryDependencyFixture(t, importBoundaryDependencyFixtureOptions{
 		policyRequires:     "  policy: [provider.threshold]\n",

--- a/internal/runtime/semanticview/import_boundary_dependencies_test.go
+++ b/internal/runtime/semanticview/import_boundary_dependencies_test.go
@@ -1,0 +1,160 @@
+package semanticview
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
+)
+
+func TestImportBoundaryPolicyResolutionUsesBindingThenPackageDefault(t *testing.T) {
+	source := loadImportBoundaryDependencyFixture(t, importBoundaryDependencyFixtureOptions{
+		policyBind: "        provider.threshold: parent.policy.provider.threshold\n",
+		policyRequires: `  policy:
+    provider.threshold: {}
+    provider.mode:
+      default: strict
+`,
+		credentialRequires: "  credentials: [provider_key]\n",
+		credentialBind:     "        provider_key: tenant_provider_key\n",
+	})
+
+	if got, ok := PolicyValueForFlow(source, "worker", "provider.threshold"); !ok || got.Value != 0.91 {
+		t.Fatalf("provider.threshold = (%#v, %v), want bound parent value 0.91", got.Value, ok)
+	}
+	if got, ok := PolicyValueForFlow(source, "worker", "provider.mode"); !ok || got.Value != "strict" {
+		t.Fatalf("provider.mode = (%#v, %v), want package default strict", got.Value, ok)
+	}
+	if _, ok := PolicyValueForFlow(source, "worker", "provider.parent_only"); ok {
+		t.Fatal("imported flow inherited parent-only policy key without explicit binding")
+	}
+	if got, ok := PolicyValueForFlow(source, "worker", "provider.package_only"); !ok || got.Value != "visible" {
+		t.Fatalf("provider.package_only = (%#v, %v), want child local package policy", got.Value, ok)
+	}
+}
+
+func TestImportBoundaryPolicyResolutionFailsClosedWithoutBindingOrDefaultEvenWithParentSameName(t *testing.T) {
+	source := loadImportBoundaryDependencyFixture(t, importBoundaryDependencyFixtureOptions{
+		policyRequires:     "  policy: [provider.threshold]\n",
+		credentialRequires: "  credentials: [provider_key]\n",
+		credentialBind:     "        provider_key: tenant_provider_key\n",
+	})
+
+	issues := ImportBoundaryDependencyIssues(source)
+	if !importBoundaryDependencyIssueContains(issues, "missing_policy_binding", "provider.threshold") {
+		t.Fatalf("expected missing_policy_binding for provider.threshold, got %#v", issues)
+	}
+	if _, ok := PolicyValueForFlow(source, "worker", "provider.threshold"); ok {
+		t.Fatal("unbound imported policy key resolved through ambient parent same-name policy")
+	}
+}
+
+func TestImportBoundaryPolicyResolutionDoesNotInheritParentPolicyForUndeclaredKeys(t *testing.T) {
+	source := loadImportBoundaryDependencyFixture(t, importBoundaryDependencyFixtureOptions{
+		credentialRequires: "  credentials: [provider_key]\n",
+		credentialBind:     "        provider_key: tenant_provider_key\n",
+	})
+
+	if _, ok := PolicyValueForFlow(source, "worker", "provider.parent_only"); ok {
+		t.Fatal("imported flow inherited undeclared parent policy through dependency context")
+	}
+	if got, ok := PolicyValueForFlow(source, "worker", "provider.package_only"); !ok || got.Value != "visible" {
+		t.Fatalf("provider.package_only = (%#v, %v), want child local package policy", got.Value, ok)
+	}
+}
+
+func TestImportBoundaryCredentialStoreKeyRequiresDeclaredBinding(t *testing.T) {
+	source := loadImportBoundaryDependencyFixture(t, importBoundaryDependencyFixtureOptions{
+		policyRequires:     "  policy: [provider.threshold]\n",
+		policyBind:         "        provider.threshold: parent.policy.provider.threshold\n",
+		credentialRequires: "  credentials: [provider_key]\n",
+		credentialBind:     "        provider_key: tenant_provider_key\n",
+	})
+
+	if got, mapped := CredentialStoreKeyForFlow(source, "worker", "provider_key"); !mapped || got != "tenant_provider_key" {
+		t.Fatalf("CredentialStoreKeyForFlow(provider_key) = (%q, %v), want tenant_provider_key, mapped", got, mapped)
+	}
+	if got, mapped := CredentialStoreKeyForFlow(source, "worker", "undeclared_key"); !mapped || got != "" {
+		t.Fatalf("CredentialStoreKeyForFlow(undeclared_key) = (%q, %v), want empty mapped fail-closed", got, mapped)
+	}
+	if got, mapped := CredentialStoreKeyForFlow(source, "", "provider_key"); mapped || got != "provider_key" {
+		t.Fatalf("root CredentialStoreKeyForFlow(provider_key) = (%q, %v), want raw unmapped key", got, mapped)
+	}
+}
+
+func importBoundaryDependencyIssueContains(issues []ImportBoundaryDependencyIssue, kind, dependency string) bool {
+	for _, issue := range issues {
+		if issue.Kind == kind && issue.Dependency == dependency {
+			return true
+		}
+	}
+	return false
+}
+
+type importBoundaryDependencyFixtureOptions struct {
+	policyRequires     string
+	policyBind         string
+	credentialRequires string
+	credentialBind     string
+}
+
+func loadImportBoundaryDependencyFixture(t *testing.T, opts importBoundaryDependencyFixtureOptions) Source {
+	t.Helper()
+	repoRoot, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd: %v", err)
+	}
+	repoRoot = filepath.Clean(filepath.Join(repoRoot, "..", "..", ".."))
+	root := t.TempDir()
+
+	bindPolicy := ""
+	if opts.policyBind != "" {
+		bindPolicy = "      policy:\n" + opts.policyBind
+	}
+	bindCredentials := ""
+	if opts.credentialBind != "" {
+		bindCredentials = "      credentials:\n" + opts.credentialBind
+	}
+	writeSemanticviewFixtureFile(t, filepath.Join(root, "package.yaml"), `
+name: import-boundary-dependencies
+version: "1.0.0"
+flows:
+  - id: worker
+    flow: worker
+    mode: static
+    bind:
+`+bindPolicy+bindCredentials)
+	writeSemanticviewFixtureFile(t, filepath.Join(root, "schema.yaml"), "name: import-boundary-dependencies\n")
+	writeSemanticviewFixtureFile(t, filepath.Join(root, "policy.yaml"), `
+provider:
+  threshold: 0.91
+  parent_only: leaked
+`)
+	writeSemanticviewFixtureFile(t, filepath.Join(root, "tools.yaml"), "{}\n")
+	writeSemanticviewFixtureFile(t, filepath.Join(root, "agents.yaml"), "{}\n")
+	writeSemanticviewFixtureFile(t, filepath.Join(root, "events.yaml"), "{}\n")
+	writeSemanticviewFixtureFile(t, filepath.Join(root, "nodes.yaml"), "{}\n")
+
+	writeSemanticviewFixtureFile(t, filepath.Join(root, "flows", "worker", "package.yaml"), `
+name: worker-package
+version: "1.0.0"
+requires:
+`+opts.policyRequires+opts.credentialRequires)
+	writeSemanticviewFixtureFile(t, filepath.Join(root, "flows", "worker", "schema.yaml"), "name: worker\nmode: static\n")
+	writeSemanticviewFixtureFile(t, filepath.Join(root, "flows", "worker", "policy.yaml"), `
+provider:
+  threshold: child-local
+  mode: child-local
+  package_only: visible
+`)
+	writeSemanticviewFixtureFile(t, filepath.Join(root, "flows", "worker", "tools.yaml"), "{}\n")
+	writeSemanticviewFixtureFile(t, filepath.Join(root, "flows", "worker", "agents.yaml"), "{}\n")
+	writeSemanticviewFixtureFile(t, filepath.Join(root, "flows", "worker", "events.yaml"), "{}\n")
+
+	bundle, err := runtimecontracts.LoadWorkflowContractBundleWithOverrides(repoRoot, root, runtimecontracts.DefaultPlatformSpecFile(repoRoot))
+	if err != nil {
+		t.Fatalf("LoadWorkflowContractBundleWithOverrides: %v", err)
+	}
+	return Wrap(bundle)
+}

--- a/internal/runtime/semanticview/import_boundary_dependencies_test.go
+++ b/internal/runtime/semanticview/import_boundary_dependencies_test.go
@@ -83,6 +83,43 @@ func TestImportBoundaryCredentialStoreKeyRequiresDeclaredBinding(t *testing.T) {
 	}
 }
 
+func TestImportBoundaryCredentialStoreKeyUsesExplicitActorFlowContext(t *testing.T) {
+	source := loadImportBoundaryDependencyFixture(t, importBoundaryDependencyFixtureOptions{
+		policyRequires:     "  policy: [provider.threshold]\n",
+		policyBind:         "        provider.threshold: parent.policy.provider.threshold\n",
+		credentialRequires: "  credentials: [provider_key]\n",
+		credentialBind:     "        provider_key: tenant_provider_key\n",
+	})
+
+	if got, mapped := CredentialStoreKeyForActorFlow(source, "worker-agent-instance", "worker", "provider_key"); !mapped || got != "tenant_provider_key" {
+		t.Fatalf("CredentialStoreKeyForActorFlow(provider_key) = (%q, %v), want tenant_provider_key, mapped", got, mapped)
+	}
+	if got, mapped := CredentialStoreKeyForActor(source, "worker-agent-instance", "provider_key"); mapped || got != "provider_key" {
+		t.Fatalf("CredentialStoreKeyForActor without flow context = (%q, %v), want raw unmapped key", got, mapped)
+	}
+}
+
+func TestImportBoundaryDependencyContextMatchesDescendantPackageFlow(t *testing.T) {
+	source := loadImportBoundaryDescendantPackageDependencyFixture(t)
+	flow, ok := source.FlowScopeByID("worker")
+	if !ok {
+		t.Fatal("worker flow scope missing")
+	}
+	if got := filepath.ToSlash(flow.PackageKey); got != "packages/vendor/subpkg" {
+		t.Fatalf("worker PackageKey = %q, want descendant packages/vendor/subpkg", flow.PackageKey)
+	}
+
+	if got, ok := PolicyValueForFlow(source, "worker", "provider.threshold"); !ok || got.Value != 0.91 {
+		t.Fatalf("descendant provider.threshold = (%#v, %v), want bound parent value 0.91", got.Value, ok)
+	}
+	if got, mapped := CredentialStoreKeyForFlow(source, "worker", "provider_key"); !mapped || got != "tenant_provider_key" {
+		t.Fatalf("descendant CredentialStoreKeyForFlow(provider_key) = (%q, %v), want tenant_provider_key, mapped", got, mapped)
+	}
+	if got, mapped := CredentialStoreKeyForFlow(source, "worker", "undeclared_key"); !mapped || got != "" {
+		t.Fatalf("descendant CredentialStoreKeyForFlow(undeclared_key) = (%q, %v), want empty mapped fail-closed", got, mapped)
+	}
+}
+
 func importBoundaryDependencyIssueContains(issues []ImportBoundaryDependencyIssue, kind, dependency string) bool {
 	for _, issue := range issues {
 		if issue.Kind == kind && issue.Dependency == dependency {
@@ -151,6 +188,66 @@ provider:
 	writeSemanticviewFixtureFile(t, filepath.Join(root, "flows", "worker", "tools.yaml"), "{}\n")
 	writeSemanticviewFixtureFile(t, filepath.Join(root, "flows", "worker", "agents.yaml"), "{}\n")
 	writeSemanticviewFixtureFile(t, filepath.Join(root, "flows", "worker", "events.yaml"), "{}\n")
+
+	bundle, err := runtimecontracts.LoadWorkflowContractBundleWithOverrides(repoRoot, root, runtimecontracts.DefaultPlatformSpecFile(repoRoot))
+	if err != nil {
+		t.Fatalf("LoadWorkflowContractBundleWithOverrides: %v", err)
+	}
+	return Wrap(bundle)
+}
+
+func loadImportBoundaryDescendantPackageDependencyFixture(t *testing.T) Source {
+	t.Helper()
+	repoRoot, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd: %v", err)
+	}
+	repoRoot = filepath.Clean(filepath.Join(repoRoot, "..", "..", ".."))
+	root := t.TempDir()
+
+	writeSemanticviewFixtureFile(t, filepath.Join(root, "package.yaml"), `
+name: import-boundary-descendant-dependencies
+version: "1.0.0"
+packages:
+  - path: packages/vendor
+    bind:
+      policy:
+        provider.threshold: parent.policy.provider.threshold
+      credentials:
+        provider_key: tenant_provider_key
+`)
+	writeSemanticviewFixtureFile(t, filepath.Join(root, "schema.yaml"), "name: import-boundary-descendant-dependencies\n")
+	writeSemanticviewFixtureFile(t, filepath.Join(root, "policy.yaml"), `
+provider:
+  threshold: 0.91
+`)
+	writeSemanticviewFixtureFile(t, filepath.Join(root, "tools.yaml"), "{}\n")
+	writeSemanticviewFixtureFile(t, filepath.Join(root, "agents.yaml"), "{}\n")
+	writeSemanticviewFixtureFile(t, filepath.Join(root, "events.yaml"), "{}\n")
+	writeSemanticviewFixtureFile(t, filepath.Join(root, "nodes.yaml"), "{}\n")
+
+	writeSemanticviewFixtureFile(t, filepath.Join(root, "packages", "vendor", "package.yaml"), `
+name: vendor-package
+version: "1.0.0"
+requires:
+  policy: [provider.threshold]
+  credentials: [provider_key]
+packages:
+  - path: subpkg
+`)
+	writeSemanticviewFixtureFile(t, filepath.Join(root, "packages", "vendor", "subpkg", "package.yaml"), `
+name: vendor-subpackage
+version: "1.0.0"
+flows:
+  - id: worker
+    flow: worker
+    mode: static
+`)
+	writeSemanticviewFixtureFile(t, filepath.Join(root, "packages", "vendor", "subpkg", "flows", "worker", "schema.yaml"), "name: worker\nmode: static\n")
+	writeSemanticviewFixtureFile(t, filepath.Join(root, "packages", "vendor", "subpkg", "flows", "worker", "policy.yaml"), "{}\n")
+	writeSemanticviewFixtureFile(t, filepath.Join(root, "packages", "vendor", "subpkg", "flows", "worker", "tools.yaml"), "{}\n")
+	writeSemanticviewFixtureFile(t, filepath.Join(root, "packages", "vendor", "subpkg", "flows", "worker", "agents.yaml"), "{}\n")
+	writeSemanticviewFixtureFile(t, filepath.Join(root, "packages", "vendor", "subpkg", "flows", "worker", "events.yaml"), "{}\n")
 
 	bundle, err := runtimecontracts.LoadWorkflowContractBundleWithOverrides(repoRoot, root, runtimecontracts.DefaultPlatformSpecFile(repoRoot))
 	if err != nil {

--- a/internal/runtime/semanticview/import_boundary_dependencies_test.go
+++ b/internal/runtime/semanticview/import_boundary_dependencies_test.go
@@ -34,6 +34,20 @@ func TestImportBoundaryPolicyResolutionUsesBindingThenPackageDefault(t *testing.
 	}
 }
 
+func TestImportBoundaryPolicyResolutionUsesResolvedParentPolicyForNestedBinding(t *testing.T) {
+	source := loadNestedImportBoundaryPolicyFixture(t)
+
+	if got, ok := PolicyValueForFlow(source, "child", "threshold"); !ok || got.Value != 70 {
+		t.Fatalf("child threshold = (%#v, %v), want bound root value 70", got.Value, ok)
+	}
+	if got, ok := PolicyValueForFlow(source, "grandchild", "threshold"); !ok || got.Value != 70 {
+		t.Fatalf("grandchild threshold = (%#v, %v), want child resolved parent value 70", got.Value, ok)
+	}
+	if issues := ImportBoundaryDependencyIssues(source); len(issues) != 0 {
+		t.Fatalf("ImportBoundaryDependencyIssues = %#v, want none", issues)
+	}
+}
+
 func TestImportBoundaryPolicyResolutionFailsClosedWithoutBindingOrDefaultEvenWithParentSameName(t *testing.T) {
 	source := loadImportBoundaryDependencyFixture(t, importBoundaryDependencyFixtureOptions{
 		policyRequires:     "  policy: [provider.threshold]\n",
@@ -202,6 +216,71 @@ provider:
 	writeSemanticviewFixtureFile(t, filepath.Join(root, "flows", "worker", "tools.yaml"), "{}\n")
 	writeSemanticviewFixtureFile(t, filepath.Join(root, "flows", "worker", "agents.yaml"), "{}\n")
 	writeSemanticviewFixtureFile(t, filepath.Join(root, "flows", "worker", "events.yaml"), "{}\n")
+
+	bundle, err := runtimecontracts.LoadWorkflowContractBundleWithOverrides(repoRoot, root, runtimecontracts.DefaultPlatformSpecFile(repoRoot))
+	if err != nil {
+		t.Fatalf("LoadWorkflowContractBundleWithOverrides: %v", err)
+	}
+	return Wrap(bundle)
+}
+
+func loadNestedImportBoundaryPolicyFixture(t *testing.T) Source {
+	t.Helper()
+	repoRoot, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd: %v", err)
+	}
+	repoRoot = filepath.Clean(filepath.Join(repoRoot, "..", "..", ".."))
+	root := t.TempDir()
+
+	writeSemanticviewFixtureFile(t, filepath.Join(root, "package.yaml"), `
+name: nested-import-policy
+version: "1.0.0"
+flows:
+  - id: child
+    flow: child
+    mode: static
+    bind:
+      policy:
+        threshold: parent.policy.root_threshold
+`)
+	writeSemanticviewFixtureFile(t, filepath.Join(root, "schema.yaml"), "name: nested-import-policy\n")
+	writeSemanticviewFixtureFile(t, filepath.Join(root, "policy.yaml"), "root_threshold: 70\n")
+	writeSemanticviewFixtureFile(t, filepath.Join(root, "tools.yaml"), "{}\n")
+	writeSemanticviewFixtureFile(t, filepath.Join(root, "agents.yaml"), "{}\n")
+	writeSemanticviewFixtureFile(t, filepath.Join(root, "events.yaml"), "{}\n")
+	writeSemanticviewFixtureFile(t, filepath.Join(root, "nodes.yaml"), "{}\n")
+
+	writeSemanticviewFixtureFile(t, filepath.Join(root, "flows", "child", "package.yaml"), `
+name: child-package
+version: "1.0.0"
+requires:
+  policy: [threshold]
+flows:
+  - id: grandchild
+    flow: grandchild
+    mode: static
+    bind:
+      policy:
+        threshold: parent.policy.threshold
+`)
+	writeSemanticviewFixtureFile(t, filepath.Join(root, "flows", "child", "schema.yaml"), "name: child\nmode: static\n")
+	writeSemanticviewFixtureFile(t, filepath.Join(root, "flows", "child", "policy.yaml"), "{}\n")
+	writeSemanticviewFixtureFile(t, filepath.Join(root, "flows", "child", "tools.yaml"), "{}\n")
+	writeSemanticviewFixtureFile(t, filepath.Join(root, "flows", "child", "agents.yaml"), "{}\n")
+	writeSemanticviewFixtureFile(t, filepath.Join(root, "flows", "child", "events.yaml"), "{}\n")
+
+	writeSemanticviewFixtureFile(t, filepath.Join(root, "flows", "child", "flows", "grandchild", "package.yaml"), `
+name: grandchild-package
+version: "1.0.0"
+requires:
+  policy: [threshold]
+`)
+	writeSemanticviewFixtureFile(t, filepath.Join(root, "flows", "child", "flows", "grandchild", "schema.yaml"), "name: grandchild\nmode: static\n")
+	writeSemanticviewFixtureFile(t, filepath.Join(root, "flows", "child", "flows", "grandchild", "policy.yaml"), "{}\n")
+	writeSemanticviewFixtureFile(t, filepath.Join(root, "flows", "child", "flows", "grandchild", "tools.yaml"), "{}\n")
+	writeSemanticviewFixtureFile(t, filepath.Join(root, "flows", "child", "flows", "grandchild", "agents.yaml"), "{}\n")
+	writeSemanticviewFixtureFile(t, filepath.Join(root, "flows", "child", "flows", "grandchild", "events.yaml"), "{}\n")
 
 	bundle, err := runtimecontracts.LoadWorkflowContractBundleWithOverrides(repoRoot, root, runtimecontracts.DefaultPlatformSpecFile(repoRoot))
 	if err != nil {

--- a/internal/runtime/tools/executor_http.go
+++ b/internal/runtime/tools/executor_http.go
@@ -153,8 +153,9 @@ func (e *Executor) execMCPTool(ctx context.Context, actor models.AgentConfig, to
 	e.mu.RLock()
 	source := e.workflowSource
 	e.mu.RUnlock()
+	flowID := emitActorFlowID(source, actor, "")
 	return e.mcpClient.CallWithCredentialKeyResolver(ctx, tool.Name, input, func(key string) (string, error) {
-		storeKey, mapped := semanticview.CredentialStoreKeyForActor(source, actor.ID, key)
+		storeKey, mapped := semanticview.CredentialStoreKeyForActorFlow(source, actor.ID, flowID, key)
 		if mapped && strings.TrimSpace(storeKey) == "" {
 			return "", fmt.Errorf("credential %q is not declared and bound for imported package actor %s", key, strings.TrimSpace(actor.ID))
 		}
@@ -170,8 +171,9 @@ func (e *Executor) resolveToolCredentialsForActor(ctx context.Context, actor mod
 	e.mu.RLock()
 	source := e.workflowSource
 	e.mu.RUnlock()
+	flowID := emitActorFlowID(source, actor, "")
 	return e.resolveToolCredentialsWithMapper(ctx, keys, func(key string) (string, error) {
-		storeKey, mapped := semanticview.CredentialStoreKeyForActor(source, actor.ID, key)
+		storeKey, mapped := semanticview.CredentialStoreKeyForActorFlow(source, actor.ID, flowID, key)
 		if mapped && strings.TrimSpace(storeKey) == "" {
 			return "", fmt.Errorf("credential %q is not declared and bound for imported package actor %s", key, strings.TrimSpace(actor.ID))
 		}

--- a/internal/runtime/tools/executor_http.go
+++ b/internal/runtime/tools/executor_http.go
@@ -13,11 +13,12 @@ import (
 	"time"
 
 	models "github.com/division-sh/swarm/internal/runtime/core/actors"
+	"github.com/division-sh/swarm/internal/runtime/semanticview"
 )
 
 var toolTemplatePattern = regexp.MustCompile(`\{\{\s*([^{}]+?)\s*\}\}`)
 
-func (e *Executor) execHTTPTool(ctx context.Context, _ models.AgentConfig, tool RegisteredTool, input any) (any, error) {
+func (e *Executor) execHTTPTool(ctx context.Context, actor models.AgentConfig, tool RegisteredTool, input any) (any, error) {
 	if tool.HTTP == nil {
 		return nil, fmt.Errorf("http tool %s is missing http configuration", tool.Name)
 	}
@@ -28,7 +29,7 @@ func (e *Executor) execHTTPTool(ctx context.Context, _ models.AgentConfig, tool 
 	if payload == nil {
 		payload = map[string]any{}
 	}
-	credentials, err := e.resolveToolCredentials(ctx, tool.Credentials)
+	credentials, err := e.resolveToolCredentialsForActor(ctx, actor, tool.Credentials)
 	if err != nil {
 		return nil, err
 	}
@@ -145,29 +146,63 @@ func (e *Executor) execHTTPRequestOnce(ctx context.Context, method, url string, 
 	return resolveTemplateTree(tool.ResponseMapping, responseEnv)
 }
 
-func (e *Executor) execMCPTool(ctx context.Context, _ models.AgentConfig, tool RegisteredTool, input any) (any, error) {
+func (e *Executor) execMCPTool(ctx context.Context, actor models.AgentConfig, tool RegisteredTool, input any) (any, error) {
 	if e.mcpClient == nil {
 		return nil, fmt.Errorf("mcp client is not configured")
 	}
-	return e.mcpClient.Call(ctx, tool.Name, input)
+	e.mu.RLock()
+	source := e.workflowSource
+	e.mu.RUnlock()
+	return e.mcpClient.CallWithCredentialKeyResolver(ctx, tool.Name, input, func(key string) (string, error) {
+		storeKey, mapped := semanticview.CredentialStoreKeyForActor(source, actor.ID, key)
+		if mapped && strings.TrimSpace(storeKey) == "" {
+			return "", fmt.Errorf("credential %q is not declared and bound for imported package actor %s", key, strings.TrimSpace(actor.ID))
+		}
+		return storeKey, nil
+	})
 }
 
 func (e *Executor) resolveToolCredentials(ctx context.Context, keys []string) (map[string]any, error) {
+	return e.resolveToolCredentialsWithMapper(ctx, keys, func(key string) (string, error) { return key, nil })
+}
+
+func (e *Executor) resolveToolCredentialsForActor(ctx context.Context, actor models.AgentConfig, keys []string) (map[string]any, error) {
+	e.mu.RLock()
+	source := e.workflowSource
+	e.mu.RUnlock()
+	return e.resolveToolCredentialsWithMapper(ctx, keys, func(key string) (string, error) {
+		storeKey, mapped := semanticview.CredentialStoreKeyForActor(source, actor.ID, key)
+		if mapped && strings.TrimSpace(storeKey) == "" {
+			return "", fmt.Errorf("credential %q is not declared and bound for imported package actor %s", key, strings.TrimSpace(actor.ID))
+		}
+		return storeKey, nil
+	})
+}
+
+func (e *Executor) resolveToolCredentialsWithMapper(ctx context.Context, keys []string, mapKey func(string) (string, error)) (map[string]any, error) {
 	out := make(map[string]any, len(keys))
 	for _, key := range keys {
 		key = strings.TrimSpace(key)
 		if key == "" {
 			continue
 		}
+		storeKey, err := mapKey(key)
+		if err != nil {
+			return nil, err
+		}
+		storeKey = strings.TrimSpace(storeKey)
+		if storeKey == "" {
+			return nil, fmt.Errorf("credential %q does not resolve to a deployment credential key", key)
+		}
 		if e.credentials == nil {
 			return nil, fmt.Errorf("credential store is not configured")
 		}
-		value, ok, err := e.credentials.Get(ctx, key)
+		value, ok, err := e.credentials.Get(ctx, storeKey)
 		if err != nil {
 			return nil, err
 		}
 		if !ok {
-			return nil, fmt.Errorf("missing credential %q", key)
+			return nil, fmt.Errorf("missing credential %q", storeKey)
 		}
 		out[key] = value
 	}

--- a/internal/runtime/tools/executor_native.go
+++ b/internal/runtime/tools/executor_native.go
@@ -441,12 +441,7 @@ func (e *Executor) resolveWebSearchProviderConfig(actor models.AgentConfig) (web
 	e.mu.RLock()
 	source := e.workflowSource
 	e.mu.RUnlock()
-	flowID := ""
-	if source != nil && strings.TrimSpace(actor.ID) != "" {
-		if agentSource, ok := source.AgentContractSource(actor.ID); ok {
-			flowID = strings.TrimSpace(agentSource.FlowID)
-		}
-	}
+	flowID := emitActorFlowID(source, actor, "")
 	return resolveWebSearchProviderConfigFromSourceForFlow(source, flowID)
 }
 

--- a/internal/runtime/tools/executor_native.go
+++ b/internal/runtime/tools/executor_native.go
@@ -141,7 +141,7 @@ func (e *Executor) execNativeWriteFile(ctx context.Context, actor models.AgentCo
 	}, nil
 }
 
-func (e *Executor) execNativeWebSearch(ctx context.Context, _ models.AgentConfig, input any) (any, error) {
+func (e *Executor) execNativeWebSearch(ctx context.Context, actor models.AgentConfig, input any) (any, error) {
 	var in nativeWebSearchInput
 	if err := decodeToolInput(input, &in); err != nil {
 		return nil, err
@@ -150,7 +150,7 @@ func (e *Executor) execNativeWebSearch(ctx context.Context, _ models.AgentConfig
 	if query == "" {
 		return nil, fmt.Errorf("web_search.query is required")
 	}
-	cfg, err := e.resolveWebSearchProviderConfig()
+	cfg, err := e.resolveWebSearchProviderConfig(actor)
 	if err != nil {
 		return nil, err
 	}
@@ -163,7 +163,7 @@ func (e *Executor) execNativeWebSearch(ctx context.Context, _ models.AgentConfig
 	}
 	credentialValue := ""
 	if strings.TrimSpace(cfg.CredentialsKey) != "" {
-		credentials, err := e.resolveToolCredentials(ctx, []string{cfg.CredentialsKey})
+		credentials, err := e.resolveToolCredentialsForActor(ctx, actor, []string{cfg.CredentialsKey})
 		if err != nil {
 			return nil, err
 		}
@@ -437,18 +437,28 @@ func hostFileErrorMessage(err error) string {
 	}
 }
 
-func (e *Executor) resolveWebSearchProviderConfig() (webSearchProviderConfig, error) {
+func (e *Executor) resolveWebSearchProviderConfig(actor models.AgentConfig) (webSearchProviderConfig, error) {
 	e.mu.RLock()
 	source := e.workflowSource
 	e.mu.RUnlock()
-	return resolveWebSearchProviderConfigFromSource(source)
+	flowID := ""
+	if source != nil && strings.TrimSpace(actor.ID) != "" {
+		if agentSource, ok := source.AgentContractSource(actor.ID); ok {
+			flowID = strings.TrimSpace(agentSource.FlowID)
+		}
+	}
+	return resolveWebSearchProviderConfigFromSourceForFlow(source, flowID)
 }
 
 func resolveWebSearchProviderConfigFromSource(source semanticview.Source) (webSearchProviderConfig, error) {
+	return resolveWebSearchProviderConfigFromSourceForFlow(source, "")
+}
+
+func resolveWebSearchProviderConfigFromSourceForFlow(source semanticview.Source, flowID string) (webSearchProviderConfig, error) {
 	if source == nil {
 		return webSearchProviderConfig{}, fmt.Errorf("web_search provider is unavailable without a workflow source")
 	}
-	value, ok := semanticview.PolicyValueForFlow(source, "", "web_search_provider")
+	value, ok := semanticview.PolicyValueForFlow(source, strings.TrimSpace(flowID), "web_search_provider")
 	if !ok {
 		return webSearchProviderConfig{}, fmt.Errorf("policy.web_search_provider is not configured")
 	}

--- a/internal/runtime/tools/tool_model_test.go
+++ b/internal/runtime/tools/tool_model_test.go
@@ -5,10 +5,14 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
 	models "github.com/division-sh/swarm/internal/runtime/core/actors"
+	runtimecredentials "github.com/division-sh/swarm/internal/runtime/credentials"
 	"github.com/division-sh/swarm/internal/runtime/semanticview"
 )
 
@@ -75,6 +79,107 @@ func TestExecutor_HTTPToolExecutesTemplateAndResponseMapping(t *testing.T) {
 	}
 	if got, ok := result["status"].(int); !ok || got != 200 {
 		t.Fatalf("status = %#v, want 200", result["status"])
+	}
+}
+
+func TestExecutor_HTTPToolUsesImportedPackageCredentialBinding(t *testing.T) {
+	var sawAuth string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		sawAuth = r.Header.Get("Authorization")
+		if want := "Bearer tenant-secret"; sawAuth != want {
+			t.Fatalf("Authorization = %q, want %q", sawAuth, want)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"ok": true})
+	}))
+	defer server.Close()
+
+	source := loadToolImportDependencySource(t, toolImportDependencyOptions{
+		serverURL:      server.URL,
+		credentialBind: "        provider_key: tenant_provider_key\n",
+	})
+	store, err := runtimecredentials.NewFileStore(filepath.Join(t.TempDir(), "credentials.json"))
+	if err != nil {
+		t.Fatalf("NewFileStore: %v", err)
+	}
+	if err := store.Set(context.Background(), "tenant_provider_key", "tenant-secret"); err != nil {
+		t.Fatalf("Set tenant_provider_key: %v", err)
+	}
+	exec := NewExecutorWithOptions(nil, nil, ExecutorOptions{WorkflowSource: source, Credentials: store})
+	ctx := models.WithActor(context.Background(), models.AgentConfig{
+		ID:    "worker-agent",
+		Tools: []string{"send_provider"},
+	})
+
+	out, err := exec.Execute(ctx, "send_provider", map[string]any{})
+	if err != nil {
+		t.Fatalf("Execute(send_provider): %v", err)
+	}
+	if got := out.(map[string]any)["ok"]; got != true {
+		t.Fatalf("result ok = %#v, want true", got)
+	}
+}
+
+func TestExecutor_HTTPToolFailsClosedWhenImportedCredentialBindingMissing(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		t.Fatal("HTTP server should not be called when imported credential binding is missing")
+	}))
+	defer server.Close()
+
+	source := loadToolImportDependencySource(t, toolImportDependencyOptions{serverURL: server.URL})
+	store, err := runtimecredentials.NewFileStore(filepath.Join(t.TempDir(), "credentials.json"))
+	if err != nil {
+		t.Fatalf("NewFileStore: %v", err)
+	}
+	if err := store.Set(context.Background(), "provider_key", "ambient-secret"); err != nil {
+		t.Fatalf("Set provider_key: %v", err)
+	}
+	exec := NewExecutorWithOptions(nil, nil, ExecutorOptions{WorkflowSource: source, Credentials: store})
+	ctx := models.WithActor(context.Background(), models.AgentConfig{
+		ID:    "worker-agent",
+		Tools: []string{"send_provider"},
+	})
+
+	_, err = exec.Execute(ctx, "send_provider", map[string]any{})
+	if err == nil || !strings.Contains(err.Error(), "not declared and bound") {
+		t.Fatalf("Execute(send_provider) err = %v, want missing binding fail-closed", err)
+	}
+}
+
+func TestExecutor_NativeWebSearchUsesImportedPolicyAndCredentialBinding(t *testing.T) {
+	source := loadToolImportDependencySource(t, toolImportDependencyOptions{
+		credentialBind: "        provider_key: tenant_provider_key\n",
+		policyRequires: `  policy:
+    web_search_provider:
+      default:
+        provider: brave
+        credentials_key: provider_key
+        max_results_default: 3
+`,
+	})
+	store, err := runtimecredentials.NewFileStore(filepath.Join(t.TempDir(), "credentials.json"))
+	if err != nil {
+		t.Fatalf("NewFileStore: %v", err)
+	}
+	if err := store.Set(context.Background(), "tenant_provider_key", "native-secret"); err != nil {
+		t.Fatalf("Set tenant_provider_key: %v", err)
+	}
+	exec := NewExecutorWithOptions(nil, nil, ExecutorOptions{WorkflowSource: source, Credentials: store})
+	actor := models.AgentConfig{ID: "worker-agent", NativeTools: models.NativeToolConfig{WebSearch: true}}
+
+	cfg, err := exec.resolveWebSearchProviderConfig(actor)
+	if err != nil {
+		t.Fatalf("resolveWebSearchProviderConfig: %v", err)
+	}
+	if cfg.Provider != "brave" || cfg.CredentialsKey != "provider_key" || cfg.MaxResultsDefault != 3 {
+		t.Fatalf("web search cfg = %+v, want imported policy default provider_key", cfg)
+	}
+	creds, err := exec.resolveToolCredentialsForActor(context.Background(), actor, []string{cfg.CredentialsKey})
+	if err != nil {
+		t.Fatalf("resolveToolCredentialsForActor: %v", err)
+	}
+	if got := creds["provider_key"]; got != "native-secret" {
+		t.Fatalf("provider_key credential = %#v, want native-secret from bound deployment key", got)
 	}
 }
 
@@ -257,4 +362,100 @@ func mustToolConfigJSON(t *testing.T, value any) json.RawMessage {
 		t.Fatalf("json.Marshal: %v", err)
 	}
 	return raw
+}
+
+type toolImportDependencyOptions struct {
+	serverURL      string
+	credentialBind string
+	policyRequires string
+}
+
+func loadToolImportDependencySource(t *testing.T, opts toolImportDependencyOptions) semanticview.Source {
+	t.Helper()
+	repoRoot := toolsRepoRootForTest(t)
+	root := t.TempDir()
+	bindCredentials := ""
+	if strings.TrimSpace(opts.credentialBind) != "" {
+		bindCredentials = "      credentials:\n" + opts.credentialBind
+	}
+	policyRequires := opts.policyRequires
+	if strings.TrimSpace(policyRequires) == "" {
+		policyRequires = "  policy: [web_search_provider]\n"
+	}
+	serverURL := strings.TrimSpace(opts.serverURL)
+	if serverURL == "" {
+		serverURL = "https://provider.example.test"
+	}
+	writeToolFixtureFile(t, filepath.Join(root, "package.yaml"), `
+name: tool-import-dependencies
+version: "1.0.0"
+flows:
+  - id: worker
+    flow: worker
+    mode: static
+    bind:
+`+bindCredentials)
+	writeToolFixtureFile(t, filepath.Join(root, "schema.yaml"), "name: tool-import-dependencies\n")
+	writeToolFixtureFile(t, filepath.Join(root, "policy.yaml"), `
+web_search_provider:
+  provider: brave
+  credentials_key: provider_key
+`)
+	writeToolFixtureFile(t, filepath.Join(root, "tools.yaml"), "{}\n")
+	writeToolFixtureFile(t, filepath.Join(root, "agents.yaml"), "{}\n")
+	writeToolFixtureFile(t, filepath.Join(root, "events.yaml"), "{}\n")
+	writeToolFixtureFile(t, filepath.Join(root, "nodes.yaml"), "{}\n")
+	writeToolFixtureFile(t, filepath.Join(root, "flows", "worker", "package.yaml"), `
+name: worker-package
+version: "1.0.0"
+requires:
+`+policyRequires+`  credentials: [provider_key]
+`)
+	writeToolFixtureFile(t, filepath.Join(root, "flows", "worker", "schema.yaml"), "name: worker\nmode: static\n")
+	writeToolFixtureFile(t, filepath.Join(root, "flows", "worker", "policy.yaml"), "{}\n")
+	writeToolFixtureFile(t, filepath.Join(root, "flows", "worker", "agents.yaml"), `
+worker-agent:
+  id: worker-agent
+  model: regular
+  tools: [send_provider]
+`)
+	writeToolFixtureFile(t, filepath.Join(root, "flows", "worker", "tools.yaml"), `
+send_provider:
+  handler_type: http
+  credentials: [provider_key]
+  input_schema:
+    type: object
+  http:
+    method: GET
+    url: `+serverURL+`
+    headers:
+      Authorization: Bearer {{credentials.provider_key}}
+  response_mapping:
+    ok: '{{response.body.ok}}'
+`)
+	writeToolFixtureFile(t, filepath.Join(root, "flows", "worker", "events.yaml"), "{}\n")
+	bundle, err := runtimecontracts.LoadWorkflowContractBundleWithOverrides(repoRoot, root, runtimecontracts.DefaultPlatformSpecFile(repoRoot))
+	if err != nil {
+		t.Fatalf("LoadWorkflowContractBundleWithOverrides: %v", err)
+	}
+	return semanticview.Wrap(bundle)
+}
+
+func toolsRepoRootForTest(t *testing.T) string {
+	t.Helper()
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd: %v", err)
+	}
+	return filepath.Clean(filepath.Join(wd, "..", "..", ".."))
+}
+
+func writeToolFixtureFile(t *testing.T, path, contents string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("MkdirAll(%s): %v", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, []byte(strings.TrimLeft(contents, "\n")), 0o644); err != nil {
+		t.Fatalf("WriteFile(%s): %v", path, err)
+	}
 }

--- a/internal/runtime/tools/tool_model_test.go
+++ b/internal/runtime/tools/tool_model_test.go
@@ -185,6 +185,35 @@ func TestExecutor_HTTPToolFailsClosedWhenImportedCredentialBindingMissing(t *tes
 	}
 }
 
+func TestExecutor_HTTPToolFailsClosedWhenImportedCredentialRequiresMissing(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		t.Fatal("HTTP server should not be called when imported credential dependency is undeclared")
+	}))
+	defer server.Close()
+
+	source := loadToolImportDependencySource(t, toolImportDependencyOptions{
+		serverURL:              server.URL,
+		omitCredentialRequires: true,
+	})
+	store, err := runtimecredentials.NewFileStore(filepath.Join(t.TempDir(), "credentials.json"))
+	if err != nil {
+		t.Fatalf("NewFileStore: %v", err)
+	}
+	if err := store.Set(context.Background(), "provider_key", "ambient-secret"); err != nil {
+		t.Fatalf("Set provider_key: %v", err)
+	}
+	exec := NewExecutorWithOptions(nil, nil, ExecutorOptions{WorkflowSource: source, Credentials: store})
+	ctx := models.WithActor(context.Background(), models.AgentConfig{
+		ID:    "worker-agent",
+		Tools: []string{"send_provider"},
+	})
+
+	_, err = exec.Execute(ctx, "send_provider", map[string]any{})
+	if err == nil || !strings.Contains(err.Error(), "not declared and bound") {
+		t.Fatalf("Execute(send_provider) err = %v, want undeclared credential fail-closed", err)
+	}
+}
+
 func TestExecutor_NativeWebSearchUsesImportedPolicyAndCredentialBinding(t *testing.T) {
 	source := loadToolImportDependencySource(t, toolImportDependencyOptions{
 		credentialBind: "        provider_key: tenant_provider_key\n",
@@ -404,9 +433,10 @@ func mustToolConfigJSON(t *testing.T, value any) json.RawMessage {
 }
 
 type toolImportDependencyOptions struct {
-	serverURL      string
-	credentialBind string
-	policyRequires string
+	serverURL              string
+	credentialBind         string
+	policyRequires         string
+	omitCredentialRequires bool
 }
 
 func loadToolImportDependencySource(t *testing.T, opts toolImportDependencyOptions) semanticview.Source {
@@ -420,6 +450,10 @@ func loadToolImportDependencySource(t *testing.T, opts toolImportDependencyOptio
 	policyRequires := opts.policyRequires
 	if strings.TrimSpace(policyRequires) == "" {
 		policyRequires = "  policy: [web_search_provider]\n"
+	}
+	credentialRequires := "  credentials: [provider_key]\n"
+	if opts.omitCredentialRequires {
+		credentialRequires = ""
 	}
 	serverURL := strings.TrimSpace(opts.serverURL)
 	if serverURL == "" {
@@ -448,7 +482,7 @@ web_search_provider:
 name: worker-package
 version: "1.0.0"
 requires:
-`+policyRequires+`  credentials: [provider_key]
+`+policyRequires+credentialRequires+`
 `)
 	writeToolFixtureFile(t, filepath.Join(root, "flows", "worker", "schema.yaml"), "name: worker\nmode: static\n")
 	writeToolFixtureFile(t, filepath.Join(root, "flows", "worker", "policy.yaml"), "{}\n")

--- a/internal/runtime/tools/tool_model_test.go
+++ b/internal/runtime/tools/tool_model_test.go
@@ -120,6 +120,45 @@ func TestExecutor_HTTPToolUsesImportedPackageCredentialBinding(t *testing.T) {
 	}
 }
 
+func TestExecutor_HTTPToolUsesImportedPackageCredentialBindingForRenderedActorID(t *testing.T) {
+	var sawAuth string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		sawAuth = r.Header.Get("Authorization")
+		if want := "Bearer tenant-secret"; sawAuth != want {
+			t.Fatalf("Authorization = %q, want %q", sawAuth, want)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"ok": true})
+	}))
+	defer server.Close()
+
+	source := loadToolImportDependencySource(t, toolImportDependencyOptions{
+		serverURL:      server.URL,
+		credentialBind: "        provider_key: tenant_provider_key\n",
+	})
+	store, err := runtimecredentials.NewFileStore(filepath.Join(t.TempDir(), "credentials.json"))
+	if err != nil {
+		t.Fatalf("NewFileStore: %v", err)
+	}
+	if err := store.Set(context.Background(), "tenant_provider_key", "tenant-secret"); err != nil {
+		t.Fatalf("Set tenant_provider_key: %v", err)
+	}
+	exec := NewExecutorWithOptions(nil, nil, ExecutorOptions{WorkflowSource: source, Credentials: store})
+	ctx := models.WithActor(context.Background(), models.AgentConfig{
+		ID:       "worker-agent-rendered",
+		FlowPath: "worker/instance-1",
+		Tools:    []string{"send_provider"},
+	})
+
+	out, err := exec.Execute(ctx, "send_provider", map[string]any{})
+	if err != nil {
+		t.Fatalf("Execute(send_provider): %v", err)
+	}
+	if got := out.(map[string]any)["ok"]; got != true {
+		t.Fatalf("result ok = %#v, want true", got)
+	}
+}
+
 func TestExecutor_HTTPToolFailsClosedWhenImportedCredentialBindingMissing(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
 		t.Fatal("HTTP server should not be called when imported credential binding is missing")
@@ -165,7 +204,7 @@ func TestExecutor_NativeWebSearchUsesImportedPolicyAndCredentialBinding(t *testi
 		t.Fatalf("Set tenant_provider_key: %v", err)
 	}
 	exec := NewExecutorWithOptions(nil, nil, ExecutorOptions{WorkflowSource: source, Credentials: store})
-	actor := models.AgentConfig{ID: "worker-agent", NativeTools: models.NativeToolConfig{WebSearch: true}}
+	actor := models.AgentConfig{ID: "worker-agent-rendered", FlowPath: "worker/instance-1", NativeTools: models.NativeToolConfig{WebSearch: true}}
 
 	cfg, err := exec.resolveWebSearchProviderConfig(actor)
 	if err != nil {

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -4868,7 +4868,13 @@ flow_model:
           inputs: List of package-local input event pin names the importing parent must bind.
           outputs: List of package-local output event pin names the importing parent must bind when the imported package
             exposes them as required public outputs.
-          policy: List of package-local policy dependency names the importing parent must bind.
+          policy: >
+            Package-local policy dependency declarations. The list shorthand declares required policy keys with no default.
+            The mapping form is keyed by package-local policy path and accepts a requirement object with optional
+            non-secret `default`; `type`, `description`, and `required` are accepted as descriptive annotations/reserved
+            metadata and do not change runtime resolution. Unknown requirement-object fields fail closed during contract
+            parsing. A declared policy dependency is an externally supplied slot and is not satisfied by same-name
+            child-local policy or parent ambient inheritance.
           credentials: List of package-local credential dependency names the importing parent must bind.
           platform_version: Optional imported package platform-version constraint. The current first slice preserves and
             exposes this value; existing top-level `platform_version` remains the package load/admission constraint until
@@ -4884,19 +4890,43 @@ flow_model:
           inputs: Map keyed by imported package `requires.inputs` item. Each value names the parent-facing event binding.
           outputs: Map keyed by imported package `requires.outputs` item. Each value names the parent-facing event binding.
           policy: Map keyed by imported package `requires.policy` item. Each value names the parent policy reference that
-            will satisfy that package-local dependency.
+            will satisfy that package-local dependency. Supported references are `parent.policy.<path>` and `policy.<path>`.
           credentials: Map keyed by imported package `requires.credentials` item. Each value names the parent/deployment
             credential reference that will satisfy that package-local dependency.
       fail_closed_minimal_verify:
         rule: >
           If an imported package declares any item under `requires.inputs`, `requires.outputs`, `requires.policy`, or
           `requires.credentials`, boot/verify must report a hard invalidity unless the parent import site provides a
-          non-empty `bind` entry for that exact item in the matching field. For `requires.inputs` and
+          non-empty `bind` entry for that exact item in the matching field. `requires.policy` may instead be satisfied by
+          an explicit declared package default. For `requires.inputs` and
           `requires.outputs`, boot/verify must also fail closed when a `bind` key is not declared by the imported
           package public pin list, when the package-local pin is not declared by an imported flow schema, or when the
           parent-facing event binding is unknown or ambiguous.
-        unsupported_shapes: Unknown `requires` or `bind` fields, non-list `requires` fields, and non-map `bind` fields are
-          malformed contract input and must fail closed during contract parsing.
+        unsupported_shapes: >
+          Unknown `requires` or `bind` fields, malformed non-list/non-map `requires.policy` shapes, non-list
+          `requires.inputs` / `requires.outputs` / `requires.credentials` fields, and non-map `bind` fields are malformed
+          contract input and must fail closed during contract parsing.
+      dependency_resolution:
+        owner: Runtime import-boundary dependency resolver over semanticview ProjectScopes, FlowScopes, and import-site binds.
+        policy: >
+          Imported package policy dependencies resolve exactly in this order: explicit import-site `bind.policy` reference
+          to parent policy, then declared non-secret package default, then hard verify/runtime error. Once an imported
+          package declares any import-boundary dependency, its runtime policy context is package-local policy plus declared
+          resolved dependency slots; ambient parent/root policy inheritance is disabled for that imported package context.
+          Declared dependency paths are removed from the child-local policy document before resolution is applied, so
+          child-local policy at the same path, same-name parent/root policy inheritance, and ambient contract-merger fallback
+          are not proof that the dependency is satisfied. Existing root/non-imported flow policy inheritance remains a
+          different semantic concept and must not be used as an import compatibility shim.
+        credentials: >
+          Imported package credential dependencies resolve exactly in this order: package-local credential handle,
+          import-site `bind.credentials` value, deployment credential-store key, credential-store value at call time.
+          Credentials have no package defaults and no same-name raw-key fallback. Tool, MCP, native web-search, bootverify,
+          and credential metadata consumers must map package handles through this resolver before reading or indexing
+          deployment credential keys. The credential store remains the only owner of secret values; the import-boundary
+          resolver never exposes or persists credential values.
+        fail_closed: >
+          Runtime and verify consumers must use the shared import-boundary dependency resolver. A remaining same-concept
+          helper that independently interprets imported package policy or credential handles is non-authoritative.
       pin_alias_delivery:
         owner: Runtime import-boundary pin alias resolver over semanticview ProjectScopes and FlowScopes.
         inputs: >
@@ -4917,7 +4947,6 @@ flow_model:
           reinterpret package-local pins, parent event names, or raw same-name fallback for declared imported package
           pins.
       split_runtime_semantics:
-        policy_credential_resolution: Runtime per-import policy and credential resolution is tracked separately by #1453.
         wildcard_grants: Wildcard subtree and cross-tree grant behavior is tracked separately by #1454.
         final_e2e_package_proof: Final multi-package marketplace-style runtime proof is tracked separately by #1455.
     composition_routing:

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -4910,9 +4910,10 @@ flow_model:
         owner: Runtime import-boundary dependency resolver over semanticview ProjectScopes, FlowScopes, and import-site binds.
         policy: >
           Imported package policy dependencies resolve exactly in this order: explicit import-site `bind.policy` reference
-          to parent policy, then declared non-secret package default, then hard verify/runtime error. Once an imported
-          package declares any import-boundary dependency, its runtime policy context is package-local policy plus declared
-          resolved dependency slots; ambient parent/root policy inheritance is disabled for that imported package context.
+          to parent policy, then declared non-secret package default, then hard verify/runtime error. For every imported
+          package context, runtime policy is package-local policy plus declared resolved dependency slots; ambient
+          parent/root policy inheritance is disabled for that imported package context, even when `requires.policy` is
+          empty.
           Declared dependency paths are removed from the child-local policy document before resolution is applied, so
           child-local policy at the same path, same-name parent/root policy inheritance, and ambient contract-merger fallback
           are not proof that the dependency is satisfied. Existing root/non-imported flow policy inheritance remains a
@@ -4926,7 +4927,9 @@ flow_model:
           resolver never exposes or persists credential values.
         fail_closed: >
           Runtime and verify consumers must use the shared import-boundary dependency resolver. A remaining same-concept
-          helper that independently interprets imported package policy or credential handles is non-authoritative.
+          helper that independently interprets imported package policy or credential handles is non-authoritative. Imported
+          package credential use with no declared `requires.credentials` item must resolve as an import-boundary miss, not
+          as a raw deployment credential key.
       pin_alias_delivery:
         owner: Runtime import-boundary pin alias resolver over semanticview ProjectScopes and FlowScopes.
         inputs: >

--- a/tests/tier11-flow-composition/test-multi-level-policy-inherit/flows/child/flows/grandchild/package.yaml
+++ b/tests/tier11-flow-composition/test-multi-level-policy-inherit/flows/child/flows/grandchild/package.yaml
@@ -1,5 +1,7 @@
 name: grandchild
 version: 1.0.0
-description: Grandchild flow overrides mode to relaxed. Inherits threshold from child.
+description: Grandchild flow overrides mode to relaxed and explicitly requires the child threshold binding.
 platform_version: ">=1.1.0"
+requires:
+  policy: [threshold]
 flows: []

--- a/tests/tier11-flow-composition/test-multi-level-policy-inherit/flows/child/package.yaml
+++ b/tests/tier11-flow-composition/test-multi-level-policy-inherit/flows/child/package.yaml
@@ -6,3 +6,6 @@ flows:
 - id: grandchild
   flow: grandchild
   mode: static
+  bind:
+    policy:
+      threshold: parent.policy.threshold


### PR DESCRIPTION
## Summary

Closes #1453.

Implements per-import policy and credential binding for imported flow packages:

- adds `platform-spec.yaml#flow_model.flow_package.import_boundary.dependency_resolution` as the shipped spec authority for #1453 semantics
- adds a shared semanticview import-boundary dependency resolver for imported-package policy and credential handles
- makes bootverify fail closed for missing/unsupported/unknown policy and credential dependency bindings
- routes HTTP tool, MCP call-time credentials, native web-search provider credentials, and credential metadata indexing through the import-boundary resolver
- preserves existing non-import/root-flow policy inheritance and raw credential-store behavior as a different semantic concept

## Governing refs / context

Exact spec refs updated or consumed:

- `platform-spec.yaml#flow_model.flow_package.import_boundary.requires_manifest`
- `platform-spec.yaml#flow_model.flow_package.import_boundary.import_site_bind`
- `platform-spec.yaml#flow_model.flow_package.import_boundary.fail_closed_minimal_verify`
- `platform-spec.yaml#flow_model.flow_package.import_boundary.dependency_resolution`
- `platform-spec.yaml#credential_store`

Issue/gate refs:

- #1453 issue body and Pre-Implementation Coverage Audit
- #1453 Gate A approval comment: approved as first slice
- Parent #1450 remains open for #1454 wildcard behavior and #1455 final marketplace/conformance proof

Requested docs note: `docs/IMPLEMENTER_GUIDELINES.md` and `docs/SEMANTIC_DRIFT.md` are not present on current master, matching the pre-audit finding.

## Semantic migration

New canonical owner:

- `platform-spec.yaml#flow_model.flow_package.import_boundary.dependency_resolution`
- code owner: `internal/runtime/semanticview/import_boundary_dependencies.go`

Old non-authoritative behavior now invalid for imported package dependency contexts:

- ambient parent/root policy inheritance as proof for package policy dependencies
- child-local same-path policy satisfying a declared external policy dependency without declared default/bind
- package credential handle used directly as deployment credential-store key
- bootverify treating non-empty binds as enough without validating dependency semantics
- credential metadata indexing raw package handles instead of bound deployment keys

Production paths checked for surviving old behavior:

- semanticview policy resolution for flows and nodes
- engine/context policy consumers through `Source.ResolvedPolicyForFlow/Node`
- HTTP tool credentials
- MCP HTTP call-time credentials
- native web-search provider credential resolution
- credential metadata / bootverify missing-required indexing
- non-import/root behavior regression path

Migration completeness:

- complete for the approved #1453 child class: imported-package policy/credential dependencies now resolve through the import-boundary dependency owner or fail closed.
- parent #1450 remains open for #1454 wildcard scope/grants and #1455 final marketplace fixture.

## Verification

- `go test ./internal/runtime/contracts ./internal/runtime/semanticview ./internal/runtime/bootverify ./internal/runtime/credentials ./internal/runtime/tools ./internal/runtime/mcp -run 'FlowPackage|Policy|Credential|NativeWebSearch|HTTPTool|MCP|Import|Requires|Bind|ClientCallWithCredentialKeyResolver|RequirementIndex' -count=1`
- `go test ./...`