### PR TITLE
[agent-a][issue #1454] Scope imported wildcard grants

### DIFF
--- a/internal/runtime/accprojection/resolver.go
+++ b/internal/runtime/accprojection/resolver.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
+	"github.com/division-sh/swarm/internal/runtime/core/eventidentity"
 	"github.com/division-sh/swarm/internal/runtime/semanticview"
 )
 
@@ -136,6 +137,17 @@ func activeHandlerResolution(source semanticview.Source, nodeID, eventType strin
 	if source == nil {
 		return active
 	}
+	if handler, ok := source.NodeEventHandler(nodeID, eventType); ok {
+		active.AuthoredEventType = activeHandlerAuthoredEventType(source, nodeID, eventType)
+		active.CanonicalEventType = canonicalNodeEvent(source, nodeID, active.AuthoredEventType)
+		if handler.Accumulate != nil {
+			active.AccumulatorName = strings.TrimSpace(handler.Accumulate.Into)
+		}
+		return active
+	}
+	if semanticview.ImportBoundaryWildcardHandlerFallbackDenied(source, nodeID, eventType) {
+		return active
+	}
 	if bundle, ok := semanticview.Bundle(source); ok && bundle != nil {
 		resolved := bundle.ResolveNodeEventHandler(nodeID, eventType)
 		if resolved.Matched {
@@ -159,6 +171,35 @@ func activeHandlerResolution(source semanticview.Source, nodeID, eventType strin
 	active.CanonicalEventType = canonicalNodeEvent(source, nodeID, eventType)
 	active.AccumulatorName = strings.TrimSpace(handler.Accumulate.Into)
 	return active
+}
+
+func activeHandlerAuthoredEventType(source semanticview.Source, nodeID, eventType string) string {
+	eventType = normalizeEventType(eventType)
+	if source == nil || eventType == "" {
+		return eventType
+	}
+	handlers := source.NodeEventHandlers(nodeID)
+	for key := range handlers {
+		if normalizeEventType(key) == eventType {
+			return strings.TrimSpace(key)
+		}
+	}
+	for key := range handlers {
+		pattern := normalizeEventType(key)
+		if pattern == "" || !strings.Contains(pattern, "*") {
+			continue
+		}
+		if matched, scoped := semanticview.ImportBoundaryWildcardSubscriptionMatchesNode(source, nodeID, pattern, eventType); scoped {
+			if matched {
+				return strings.TrimSpace(key)
+			}
+			continue
+		}
+		if eventidentity.MatchPattern(pattern, eventType) {
+			return strings.TrimSpace(key)
+		}
+	}
+	return eventType
 }
 
 func issueRelevantToHandler(source semanticview.Source, issue Issue, flowID, nodeID, eventType, accumulatorName string, active activeHandler) bool {
@@ -201,6 +242,9 @@ func handlerEventMatches(source semanticview.Source, nodeID, authoredEventType, 
 	authoredEventType = normalizeEventType(authoredEventType)
 	runtimeEventType = normalizeEventType(runtimeEventType)
 	if authoredEventType == "" || runtimeEventType == "" {
+		return false
+	}
+	if semanticview.ImportBoundaryWildcardHandlerFallbackDenied(source, nodeID, runtimeEventType) {
 		return false
 	}
 	if authoredEventType == runtimeEventType {

--- a/internal/runtime/accprojection/resolver_test.go
+++ b/internal/runtime/accprojection/resolver_test.go
@@ -111,6 +111,31 @@ func TestForHandler_ResolvesQualifiedRuntimeEventToLocalProjectionBinding(t *tes
 	}
 }
 
+func TestActiveHandlerResolution_DeniesImportBoundaryWildcardRawFallback(t *testing.T) {
+	source := semanticview.Wrap(loadProjectionImportBoundaryWildcardBundle(t, ""))
+	active := activeHandlerResolution(source, "worker-listener", "producer/task.done")
+	if active.AccumulatorName != "" || active.AuthoredEventType != "" || active.CanonicalEventType != "" {
+		t.Fatalf("active handler = %#v, want empty for ungranted sibling event", active)
+	}
+	if handlerEventMatches(source, "worker-listener", "**/task.done", "producer/task.done", active) {
+		t.Fatal("handlerEventMatches accepted ungranted sibling event")
+	}
+}
+
+func TestActiveHandlerResolution_AllowsGrantedImportBoundaryWildcard(t *testing.T) {
+	source := semanticview.Wrap(loadProjectionImportBoundaryWildcardBundle(t, "      observe:\n        - source: producer\n          events: [task.done]\n"))
+	active := activeHandlerResolution(source, "worker-listener", "producer/task.done")
+	if got := active.AccumulatorName; got != "tasks" {
+		t.Fatalf("ActiveAccumulatorName = %q, want tasks", got)
+	}
+	if got := active.AuthoredEventType; got != "**/task.done" {
+		t.Fatalf("ActiveAuthoredEventType = %q, want **/task.done", got)
+	}
+	if !handlerEventMatches(source, "worker-listener", "**/task.done", "producer/task.done", active) {
+		t.Fatal("handlerEventMatches denied granted sibling event")
+	}
+}
+
 func issuesContain(issues []Issue, want string) bool {
 	for _, issue := range issues {
 		if strings.Contains(issue.Message, want) {
@@ -180,6 +205,89 @@ scoring-node:
     fields:
       dimensions_received: "[DimensionScore]"
 `)
+
+	repoRoot := repoRootForProjectionTest(t)
+	bundle, err := runtimecontracts.LoadWorkflowContractBundleWithOverrides(repoRoot, root, runtimecontracts.DefaultPlatformSpecFile(repoRoot))
+	if err != nil {
+		t.Fatalf("LoadWorkflowContractBundleWithOverrides: %v", err)
+	}
+	return bundle
+}
+
+func loadProjectionImportBoundaryWildcardBundle(t *testing.T, observeGrant string) *runtimecontracts.WorkflowContractBundle {
+	t.Helper()
+	root := t.TempDir()
+	workerBind := ""
+	if strings.TrimSpace(observeGrant) != "" {
+		workerBind = "    bind:\n" + observeGrant
+	}
+	writeProjectionFixtureFile(t, filepath.Join(root, "package.yaml"), `
+name: projection-import-boundary-wildcard
+version: "1.0.0"
+platform_version: ">=1.6.0"
+flows:
+  - id: worker
+    flow: worker
+    mode: static
+`+workerBind+`  - id: producer
+    flow: producer
+    mode: static
+`)
+	writeProjectionFixtureFile(t, filepath.Join(root, "schema.yaml"), "name: projection-import-boundary-wildcard\n")
+	writeProjectionFixtureFile(t, filepath.Join(root, "policy.yaml"), "{}\n")
+	writeProjectionFixtureFile(t, filepath.Join(root, "tools.yaml"), "{}\n")
+	writeProjectionFixtureFile(t, filepath.Join(root, "agents.yaml"), "{}\n")
+	writeProjectionFixtureFile(t, filepath.Join(root, "events.yaml"), "{}\n")
+	writeProjectionFixtureFile(t, filepath.Join(root, "entities.yaml"), "{}\n")
+	writeProjectionFixtureFile(t, filepath.Join(root, "nodes.yaml"), "{}\n")
+	writeProjectionFixtureFile(t, filepath.Join(root, "flows", "worker", "package.yaml"), "name: worker\nversion: \"1.0.0\"\n")
+	writeProjectionFixtureFile(t, filepath.Join(root, "flows", "worker", "schema.yaml"), `
+name: worker
+mode: static
+initial_state: active
+states: [active, done]
+terminal_states: [done]
+pins:
+  outputs:
+    events: [task.done]
+`)
+	writeProjectionFixtureFile(t, filepath.Join(root, "flows", "worker", "policy.yaml"), "{}\n")
+	writeProjectionFixtureFile(t, filepath.Join(root, "flows", "worker", "agents.yaml"), "{}\n")
+	writeProjectionFixtureFile(t, filepath.Join(root, "flows", "worker", "events.yaml"), `
+task.done:
+  task_id: text
+`)
+	writeProjectionFixtureFile(t, filepath.Join(root, "flows", "worker", "nodes.yaml"), `
+worker-listener:
+  id: worker-listener
+  execution_type: system_node
+  subscribes_to: ["**/task.done"]
+  event_handlers:
+    "**/task.done":
+      accumulate:
+        into: tasks
+  state_schema:
+    fields:
+      tasks: text
+`)
+	writeProjectionFixtureFile(t, filepath.Join(root, "flows", "producer", "package.yaml"), "name: producer\nversion: \"1.0.0\"\n")
+	writeProjectionFixtureFile(t, filepath.Join(root, "flows", "producer", "schema.yaml"), `
+name: producer
+mode: static
+initial_state: active
+states: [active, done]
+terminal_states: [done]
+pins:
+  outputs:
+    events: [task.done]
+`)
+	writeProjectionFixtureFile(t, filepath.Join(root, "flows", "producer", "policy.yaml"), "{}\n")
+	writeProjectionFixtureFile(t, filepath.Join(root, "flows", "producer", "agents.yaml"), "{}\n")
+	writeProjectionFixtureFile(t, filepath.Join(root, "flows", "producer", "events.yaml"), `
+task.done:
+  task_id: text
+`)
+	writeProjectionFixtureFile(t, filepath.Join(root, "flows", "producer", "nodes.yaml"), "{}\n")
 
 	repoRoot := repoRootForProjectionTest(t)
 	bundle, err := runtimecontracts.LoadWorkflowContractBundleWithOverrides(repoRoot, root, runtimecontracts.DefaultPlatformSpecFile(repoRoot))

--- a/internal/runtime/bootverify/checks.go
+++ b/internal/runtime/bootverify/checks.go
@@ -247,6 +247,7 @@ var bootCheckRegistry = []Check{
 	{ID: "flow_package_import_completeness", Severity: SeverityHardInvalidity, Run: checkFlowPackageImportCompleteness},
 	{ID: "flow_package_dependency_binding", Severity: SeverityHardInvalidity, Run: checkFlowPackageDependencyBinding},
 	{ID: "flow_package_pin_bind_alias_validation", Severity: SeverityHardInvalidity, Run: checkFlowPackagePinBindAliasValidation},
+	{ID: "flow_package_wildcard_observe_grant", Severity: SeverityHardInvalidity, Run: checkFlowPackageWildcardObserveGrant},
 	{ID: "composition_connect_validation", Severity: "error", Run: checkCompositionConnectValidation},
 	{ID: "input_pin_wiring", Severity: "warning", Run: checkInputPinWiring},
 	{ID: "pin_target_resolution", Severity: "error", Run: checkPinTargetResolution},

--- a/internal/runtime/bootverify/flow_data_access_test.go
+++ b/internal/runtime/bootverify/flow_data_access_test.go
@@ -66,8 +66,8 @@ func TestRun_ValidatesFlowDataAccessDeclarations(t *testing.T) {
 }
 
 func TestBootCheckRegistry_HasFlowDataAccessCheckCount(t *testing.T) {
-	if got := len(bootCheckRegistry); got != 58 {
-		t.Fatalf("bootCheckRegistry count = %d, want 58", got)
+	if got := len(bootCheckRegistry); got != 59 {
+		t.Fatalf("bootCheckRegistry count = %d, want 59", got)
 	}
 }
 

--- a/internal/runtime/bootverify/flow_package_import_completeness_checks.go
+++ b/internal/runtime/bootverify/flow_package_import_completeness_checks.go
@@ -45,6 +45,43 @@ func checkFlowPackageDependencyBinding(c *checkerContext) []Finding {
 	return findings
 }
 
+func checkFlowPackageWildcardObserveGrant(c *checkerContext) []Finding {
+	var findings []Finding
+	for _, issue := range semanticview.ImportBoundaryWildcardGrantIssues(c.source) {
+		findings = append(findings, Finding{
+			CheckID:  "flow_package_wildcard_observe_grant",
+			Severity: SeverityHardInvalidity,
+			Message:  flowPackageWildcardObserveGrantMessage(issue),
+			Location: strings.TrimSpace(issue.ChildPackageKey),
+		})
+	}
+	for _, issue := range semanticview.ImportBoundaryWildcardSubscriptionIssues(c.source) {
+		findings = append(findings, Finding{
+			CheckID:  "flow_package_wildcard_observe_grant",
+			Severity: SeverityHardInvalidity,
+			Message:  flowPackageWildcardObserveGrantMessage(issue),
+			Location: strings.TrimSpace(issue.ChildPackageKey),
+		})
+	}
+	return findings
+}
+
+func flowPackageWildcardObserveGrantMessage(issue semanticview.ImportBoundaryWildcardIssue) string {
+	source := strings.TrimSpace(issue.Source)
+	if source == "" {
+		source = "<empty>"
+	}
+	eventPattern := strings.TrimSpace(issue.EventPattern)
+	if eventPattern == "" {
+		eventPattern = "<empty>"
+	}
+	detail := strings.TrimSpace(issue.Message)
+	if detail == "" {
+		detail = strings.TrimSpace(issue.Kind)
+	}
+	return fmt.Sprintf("imported package %s observe grant from %s event %s via %s is invalid: %s", strings.TrimSpace(issue.ChildPackageKey), source, eventPattern, strings.TrimSpace(issue.ImportLabel), detail)
+}
+
 func flowPackageDependencyBindingMessage(issue semanticview.ImportBoundaryDependencyIssue) string {
 	dependency := strings.TrimSpace(issue.Dependency)
 	if dependency == "" {

--- a/internal/runtime/bootverify/report_test.go
+++ b/internal/runtime/bootverify/report_test.go
@@ -4747,8 +4747,8 @@ func TestRun_ReportsMissingRuntimeExecutorForOwnedRuntimeEvent(t *testing.T) {
 }
 
 func TestBootCheckRegistry_HasSpecCheckCount(t *testing.T) {
-	if got := len(bootCheckRegistry); got != 58 {
-		t.Fatalf("bootCheckRegistry count = %d, want 58", got)
+	if got := len(bootCheckRegistry); got != 59 {
+		t.Fatalf("bootCheckRegistry count = %d, want 59", got)
 	}
 	if got := len(supplementalChecks); got != 3 {
 		t.Fatalf("supplementalChecks count = %d, want 3", got)

--- a/internal/runtime/bootverify/workflow_event_topology_checks.go
+++ b/internal/runtime/bootverify/workflow_event_topology_checks.go
@@ -51,7 +51,7 @@ func (c *checkerContext) eventWarnings() []Finding {
 				continue
 			}
 			if strings.Contains(eventType, "*") {
-				addEventPatternLocal(subscriptionPatterns, scope.ID, eventType)
+				addEventPatternLocal(subscriptionPatterns, scope.PackageKey, scope.ID, eventType)
 			} else {
 				addEventProofLocal(subscribedRefs, c.source, scope.ID, eventType)
 			}
@@ -66,7 +66,7 @@ func (c *checkerContext) eventWarnings() []Finding {
 					continue
 				}
 				if strings.Contains(eventType, "*") {
-					addEventPatternLocal(subscriptionPatterns, scope.ID, eventType)
+					addEventPatternLocal(subscriptionPatterns, scope.PackageKey, scope.ID, eventType)
 				} else {
 					addEventProofLocal(subscribedRefs, c.source, scope.ID, eventType)
 				}
@@ -83,7 +83,7 @@ func (c *checkerContext) eventWarnings() []Finding {
 				continue
 			}
 			if strings.Contains(eventType, "*") {
-				addEventPatternLocal(subscriptionPatterns, "", eventType)
+				addEventPatternLocal(subscriptionPatterns, "", "", eventType)
 			} else {
 				addEventProofLocal(subscribedRefs, c.source, "", eventType)
 			}
@@ -98,7 +98,7 @@ func (c *checkerContext) eventWarnings() []Finding {
 				continue
 			}
 			if strings.Contains(eventType, "*") {
-				addEventPatternLocal(subscriptionPatterns, flowID, eventType)
+				addEventPatternLocal(subscriptionPatterns, nodeSource.PackageKey, flowID, eventType)
 			} else {
 				addEventProofLocal(subscribedRefs, c.source, flowID, eventType)
 			}
@@ -109,7 +109,7 @@ func (c *checkerContext) eventWarnings() []Finding {
 				continue
 			}
 			if strings.Contains(eventType, "*") {
-				addEventPatternLocal(subscriptionPatterns, flowID, eventType)
+				addEventPatternLocal(subscriptionPatterns, nodeSource.PackageKey, flowID, eventType)
 			} else {
 				addEventProofLocal(subscribedRefs, c.source, flowID, eventType)
 			}
@@ -137,7 +137,7 @@ func (c *checkerContext) eventWarnings() []Finding {
 				continue
 			}
 			if strings.Contains(eventType, "*") {
-				addEventPatternLocal(subscriptionPatterns, flowID, eventType)
+				addEventPatternLocal(subscriptionPatterns, agentSource.PackageKey, flowID, eventType)
 			} else {
 				addEventProofLocal(subscribedRefs, c.source, flowID, eventType)
 			}
@@ -217,8 +217,9 @@ func addCompositionConnectEventProofsLocal(source semanticview.Source, emittedRe
 }
 
 type eventPatternLocal struct {
-	FlowID string
-	Base   string
+	PackageKey string
+	FlowID     string
+	Base       string
 }
 
 func addEventProofLocal(refs map[string]semanticview.FlowEventProof, source semanticview.Source, flowID, eventType string) {
@@ -230,13 +231,17 @@ func addEventProofLocal(refs map[string]semanticview.FlowEventProof, source sema
 	refs[key] = ref
 }
 
-func addEventPatternLocal(refs map[string]eventPatternLocal, flowID, eventType string) {
+func addEventPatternLocal(refs map[string]eventPatternLocal, packageKey, flowID, eventType string) {
 	eventType = strings.TrimSpace(eventType)
 	if eventType == "" {
 		return
 	}
-	ref := eventPatternLocal{Base: eventType, FlowID: strings.TrimSpace(flowID)}
-	key := ref.FlowID + "::" + ref.Base
+	ref := eventPatternLocal{
+		PackageKey: strings.TrimSpace(packageKey),
+		FlowID:     strings.TrimSpace(flowID),
+		Base:       eventType,
+	}
+	key := ref.PackageKey + "::" + ref.FlowID + "::" + ref.Base
 	refs[key] = ref
 }
 
@@ -247,6 +252,12 @@ func eventRefConsumedLocal(source semanticview.Source, eventType string, subscri
 		}
 	}
 	for _, pattern := range patterns {
+		if matched, scoped := semanticview.ImportBoundaryWildcardSubscriptionMatches(source, pattern.PackageKey, pattern.FlowID, "", nil, pattern.Base, eventType); scoped {
+			if matched {
+				return true
+			}
+			continue
+		}
 		if source.FlowEventMatches(pattern.FlowID, pattern.Base, eventType) {
 			return true
 		}

--- a/internal/runtime/bus/import_boundary_wildcard_routing_test.go
+++ b/internal/runtime/bus/import_boundary_wildcard_routing_test.go
@@ -31,6 +31,9 @@ func TestImportBoundaryWildcardScopesImportedPackageToOwnSubtreeByDefault(t *tes
 	if owners := source.RuntimeEventOwners("producer/task.done"); len(owners) != 0 {
 		t.Fatalf("RuntimeEventOwners(producer/task.done) = %#v, want no sibling owner without grant", owners)
 	}
+	if _, ok := source.NodeEventHandler("worker-listener", "producer/task.done"); ok {
+		t.Fatal("NodeEventHandler(worker-listener, producer/task.done) matched ungranted sibling event")
+	}
 
 	store := &routePersistenceTestStore{}
 	eb, err := runtimebus.NewEventBusWithOptions(store, runtimebus.EventBusOptions{ContractBundle: source})

--- a/internal/runtime/bus/import_boundary_wildcard_routing_test.go
+++ b/internal/runtime/bus/import_boundary_wildcard_routing_test.go
@@ -1,0 +1,304 @@
+package bus_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/division-sh/swarm/internal/events"
+	"github.com/division-sh/swarm/internal/runtime/bootverify"
+	runtimebus "github.com/division-sh/swarm/internal/runtime/bus"
+	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
+	runtimeflowidentity "github.com/division-sh/swarm/internal/runtime/core/flowidentity"
+	"github.com/division-sh/swarm/internal/runtime/semanticview"
+)
+
+func TestImportBoundaryWildcardScopesImportedPackageToOwnSubtreeByDefault(t *testing.T) {
+	source := loadBusImportBoundaryWildcardSource(t, importBoundaryWildcardFixtureOptions{})
+	rt, err := runtimebus.DeriveRouteTable(source)
+	if err != nil {
+		t.Fatalf("DeriveRouteTable: %v", err)
+	}
+	if routes := rt.Resolve("worker/task.done"); len(routes) != 1 || routes[0].ID != "worker-listener" {
+		t.Fatalf("Resolve(worker/task.done) = %#v, want worker-listener", routes)
+	}
+	if routes := rt.Resolve("producer/task.done"); len(routes) != 0 {
+		t.Fatalf("Resolve(producer/task.done) = %#v, want no sibling route without grant", routes)
+	}
+	if owners := source.RuntimeEventOwners("producer/task.done"); len(owners) != 0 {
+		t.Fatalf("RuntimeEventOwners(producer/task.done) = %#v, want no sibling owner without grant", owners)
+	}
+
+	store := &routePersistenceTestStore{}
+	eb, err := runtimebus.NewEventBusWithOptions(store, runtimebus.EventBusOptions{ContractBundle: source})
+	if err != nil {
+		t.Fatalf("NewEventBusWithOptions: %v", err)
+	}
+	local := events.NewProjectionEvent("evt-worker-local", "worker/task.done", "", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())
+	if err := eb.Publish(context.Background(), local); err != nil {
+		t.Fatalf("Publish local: %v", err)
+	}
+	if got := store.deliveries["evt-worker-local"]; len(got) != 1 || got[0] != "worker-listener" {
+		t.Fatalf("local persisted deliveries = %#v, want worker-listener", got)
+	}
+	sibling := events.NewProjectionEvent("evt-producer-sibling", "producer/task.done", "", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())
+	if err := eb.Publish(context.Background(), sibling); err != nil {
+		t.Fatalf("Publish sibling: %v", err)
+	}
+	if got := store.deliveries["evt-producer-sibling"]; len(got) != 0 {
+		t.Fatalf("sibling persisted deliveries = %#v, want none without grant", got)
+	}
+}
+
+func TestImportBoundaryWildcardObserveGrantAddsNarrowSiblingCandidate(t *testing.T) {
+	source := loadBusImportBoundaryWildcardSource(t, importBoundaryWildcardFixtureOptions{
+		ObserveGrant: "      observe:\n        - source: producer\n          events: [task.done]\n",
+	})
+	rt, err := runtimebus.DeriveRouteTable(source)
+	if err != nil {
+		t.Fatalf("DeriveRouteTable: %v", err)
+	}
+	if routes := rt.Resolve("producer/task.done"); len(routes) != 1 || routes[0].ID != "worker-listener" || routes[0].RouteSource != "import_boundary_wildcard_grant" {
+		t.Fatalf("Resolve(producer/task.done) = %#v, want worker-listener via grant", routes)
+	}
+	if owners := source.RuntimeEventOwners("producer/task.done"); len(owners) != 1 || owners[0] != "worker-listener" {
+		t.Fatalf("RuntimeEventOwners(producer/task.done) = %#v, want worker-listener", owners)
+	}
+	if _, ok := source.NodeEventHandler("worker-listener", "producer/task.done"); !ok {
+		t.Fatal("NodeEventHandler(worker-listener, producer/task.done) did not resolve through grant")
+	}
+
+	store := &routePersistenceTestStore{}
+	eb, err := runtimebus.NewEventBusWithOptions(store, runtimebus.EventBusOptions{ContractBundle: source})
+	if err != nil {
+		t.Fatalf("NewEventBusWithOptions: %v", err)
+	}
+	evt := events.NewProjectionEvent("evt-granted-sibling", "producer/task.done", "", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())
+	plan, err := eb.CheckPublishRecipientPlan(context.Background(), evt)
+	if err != nil {
+		t.Fatalf("CheckPublishRecipientPlan: %v", err)
+	}
+	if len(plan.RoutedRecipients) != 1 || plan.RoutedRecipients[0].ID != "worker-listener" {
+		t.Fatalf("routed recipients = %#v, want worker-listener", plan.RoutedRecipients)
+	}
+	if err := eb.Publish(context.Background(), evt); err != nil {
+		t.Fatalf("Publish granted sibling: %v", err)
+	}
+	if got := store.deliveries["evt-granted-sibling"]; len(got) != 1 || got[0] != "worker-listener" {
+		t.Fatalf("persisted deliveries = %#v, want worker-listener", got)
+	}
+
+}
+
+func TestImportBoundaryWildcardGrantFailsClosedWhenInvalid(t *testing.T) {
+	cases := []struct {
+		name        string
+		grant       string
+		wantMessage string
+	}{
+		{
+			name:        "unknown source",
+			grant:       "      observe:\n        - source: missing\n          events: [task.done]\n",
+			wantMessage: "does not resolve",
+		},
+		{
+			name:        "broad event",
+			grant:       "      observe:\n        - source: producer\n          events: [\"**\"]\n",
+			wantMessage: "unbounded wildcard",
+		},
+		{
+			name:        "unknown event",
+			grant:       "      observe:\n        - source: producer\n          events: [missing.done]\n",
+			wantMessage: "does not match any event",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			source := loadBusImportBoundaryWildcardSource(t, importBoundaryWildcardFixtureOptions{ObserveGrant: tc.grant})
+			report := bootverify.Run(context.Background(), source, bootverify.Options{})
+			if !importBoundaryWildcardReportContains(report.Errors(), "flow_package_wildcard_observe_grant", tc.wantMessage) {
+				t.Fatalf("expected flow_package_wildcard_observe_grant containing %q, got %#v", tc.wantMessage, report.Errors())
+			}
+		})
+	}
+}
+
+func TestImportBoundaryWildcardExplicitCrossTreeSubscriptionWithoutGrantFailsClosed(t *testing.T) {
+	source := loadBusImportBoundaryWildcardSource(t, importBoundaryWildcardFixtureOptions{WorkerSubscription: "producer/**/task.done"})
+	report := bootverify.Run(context.Background(), source, bootverify.Options{})
+	if !importBoundaryWildcardReportContains(report.Errors(), "flow_package_wildcard_observe_grant", "no package-subtree candidate") {
+		t.Fatalf("expected ungranted_or_unknown_subscription, got %#v", report.Errors())
+	}
+	rt, err := runtimebus.DeriveRouteTable(source)
+	if err != nil {
+		t.Fatalf("DeriveRouteTable: %v", err)
+	}
+	if routes := rt.Resolve("producer/task.done"); len(routes) != 0 {
+		t.Fatalf("Resolve(producer/task.done) = %#v, want no route for ungranted explicit cross-tree wildcard", routes)
+	}
+}
+
+func TestImportBoundaryWildcardPreservesTemplateInstanceSubtree(t *testing.T) {
+	source := loadBusImportBoundaryWildcardSource(t, importBoundaryWildcardFixtureOptions{WorkerMode: "template"})
+	rt, err := runtimebus.DeriveRouteTable(source)
+	if err != nil {
+		t.Fatalf("DeriveRouteTable: %v", err)
+	}
+	if routes := rt.Resolve("worker/inst-1/task.done"); len(routes) != 0 {
+		t.Fatalf("Resolve before materialization = %#v, want none", routes)
+	}
+	if err := rt.AddFlowInstanceRoute(runtimebus.FlowInstanceRouteMaterializationRequest{
+		Identity: runtimeflowidentity.DeriveRoute("worker", "inst-1"),
+	}); err != nil {
+		t.Fatalf("AddFlowInstanceRoute: %v", err)
+	}
+	routes := rt.Resolve("worker/inst-1/task.done")
+	if len(routes) != 1 || routes[0].ID != "worker-listener" || routes[0].Path != "worker/inst-1" {
+		t.Fatalf("Resolve(worker/inst-1/task.done) = %#v, want materialized worker-listener", routes)
+	}
+	if sibling := rt.Resolve("producer/task.done"); len(sibling) != 0 {
+		t.Fatalf("Resolve(producer/task.done) = %#v, want no sibling route for template wildcard without grant", sibling)
+	}
+}
+
+func TestRootWildcardSubscriptionsRemainUnchanged(t *testing.T) {
+	source := loadBusImportBoundaryWildcardSource(t, importBoundaryWildcardFixtureOptions{RootWildcard: true})
+	rt, err := runtimebus.DeriveRouteTable(source)
+	if err != nil {
+		t.Fatalf("DeriveRouteTable: %v", err)
+	}
+	if routes := rt.Resolve("producer/task.done"); len(routes) != 1 || routes[0].ID != "root-listener" {
+		t.Fatalf("Resolve(producer/task.done) = %#v, want root-listener", routes)
+	}
+}
+
+type importBoundaryWildcardFixtureOptions struct {
+	ObserveGrant       string
+	WorkerMode         string
+	WorkerSubscription string
+	RootWildcard       bool
+}
+
+func loadBusImportBoundaryWildcardSource(t *testing.T, opts importBoundaryWildcardFixtureOptions) semanticview.Source {
+	t.Helper()
+	repoRoot, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd: %v", err)
+	}
+	repoRoot = filepath.Clean(filepath.Join(repoRoot, "..", "..", ".."))
+	root := writeBusImportBoundaryWildcardFixture(t, opts)
+	bundle, err := runtimecontracts.LoadWorkflowContractBundleWithOverrides(repoRoot, root, runtimecontracts.DefaultPlatformSpecFile(repoRoot))
+	if err != nil {
+		t.Fatalf("LoadWorkflowContractBundleWithOverrides: %v", err)
+	}
+	return semanticview.Wrap(bundle)
+}
+
+func writeBusImportBoundaryWildcardFixture(t *testing.T, opts importBoundaryWildcardFixtureOptions) string {
+	t.Helper()
+	root := t.TempDir()
+	mode := strings.TrimSpace(opts.WorkerMode)
+	if mode == "" {
+		mode = "static"
+	}
+	workerSubscription := strings.TrimSpace(opts.WorkerSubscription)
+	if workerSubscription == "" {
+		workerSubscription = "**/task.done"
+	}
+	rootNode := ""
+	if opts.RootWildcard {
+		rootNode = `
+root-listener:
+  id: root-listener
+  execution_type: system_node
+  subscribes_to: ["**/task.done"]
+  event_handlers:
+    "**/task.done": {}
+`
+	}
+	workerBind := ""
+	if strings.TrimSpace(opts.ObserveGrant) != "" {
+		workerBind = "    bind:\n" + opts.ObserveGrant
+	}
+	writeBusImportBoundaryWildcardFixtureFile(t, filepath.Join(root, "package.yaml"), `
+name: bus-import-boundary-wildcard
+version: "1.0.0"
+platform_version: ">=1.6.0"
+flows:
+  - id: worker
+    flow: worker
+    mode: `+mode+`
+`+workerBind+`  - id: producer
+    flow: producer
+    mode: static
+`)
+	writeBusImportBoundaryWildcardFixtureFile(t, filepath.Join(root, "schema.yaml"), "name: bus-import-boundary-wildcard\n")
+	writeBusImportBoundaryWildcardFixtureFile(t, filepath.Join(root, "policy.yaml"), "{}\n")
+	writeBusImportBoundaryWildcardFixtureFile(t, filepath.Join(root, "tools.yaml"), "{}\n")
+	writeBusImportBoundaryWildcardFixtureFile(t, filepath.Join(root, "agents.yaml"), "{}\n")
+	writeBusImportBoundaryWildcardFixtureFile(t, filepath.Join(root, "events.yaml"), "{}\n")
+	writeBusImportBoundaryWildcardFixtureFile(t, filepath.Join(root, "nodes.yaml"), rootNode)
+	writeBusImportBoundaryWildcardFixtureFile(t, filepath.Join(root, "flows", "worker", "package.yaml"), "name: worker\nversion: \"1.0.0\"\n")
+	writeBusImportBoundaryWildcardFixtureFile(t, filepath.Join(root, "flows", "worker", "schema.yaml"), `
+name: worker
+mode: `+mode+`
+initial_state: active
+terminal_states: [done]
+states: [active, done]
+pins:
+  outputs:
+    events: [task.done]
+`)
+	writeBusImportBoundaryWildcardFixtureFile(t, filepath.Join(root, "flows", "worker", "policy.yaml"), "{}\n")
+	writeBusImportBoundaryWildcardFixtureFile(t, filepath.Join(root, "flows", "worker", "agents.yaml"), "{}\n")
+	writeBusImportBoundaryWildcardFixtureFile(t, filepath.Join(root, "flows", "worker", "events.yaml"), "task.done: {}\n")
+	writeBusImportBoundaryWildcardFixtureFile(t, filepath.Join(root, "flows", "worker", "nodes.yaml"), `
+worker-listener:
+  id: worker-listener
+  execution_type: system_node
+  subscribes_to: ["`+workerSubscription+`"]
+  event_handlers:
+    "`+workerSubscription+`": {}
+`)
+	writeBusImportBoundaryWildcardFixtureFile(t, filepath.Join(root, "flows", "producer", "package.yaml"), "name: producer\nversion: \"1.0.0\"\n")
+	writeBusImportBoundaryWildcardFixtureFile(t, filepath.Join(root, "flows", "producer", "schema.yaml"), `
+name: producer
+mode: static
+initial_state: active
+terminal_states: [done]
+states: [active, done]
+pins:
+  outputs:
+    events: [task.done]
+`)
+	writeBusImportBoundaryWildcardFixtureFile(t, filepath.Join(root, "flows", "producer", "policy.yaml"), "{}\n")
+	writeBusImportBoundaryWildcardFixtureFile(t, filepath.Join(root, "flows", "producer", "agents.yaml"), "{}\n")
+	writeBusImportBoundaryWildcardFixtureFile(t, filepath.Join(root, "flows", "producer", "events.yaml"), "task.done: {}\n")
+	writeBusImportBoundaryWildcardFixtureFile(t, filepath.Join(root, "flows", "producer", "nodes.yaml"), "{}\n")
+	return root
+}
+
+func writeBusImportBoundaryWildcardFixtureFile(t *testing.T, path, contents string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir fixture dir: %v", err)
+	}
+	if err := os.WriteFile(path, []byte(contents), 0o644); err != nil {
+		t.Fatalf("write fixture %s: %v", path, err)
+	}
+}
+
+func importBoundaryWildcardReportContains(findings []bootverify.Finding, checkID, substr string) bool {
+	for _, finding := range findings {
+		if strings.TrimSpace(finding.CheckID) != checkID {
+			continue
+		}
+		if substr == "" || strings.Contains(finding.Message, substr) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/runtime/bus/routing_derivation.go
+++ b/internal/runtime/bus/routing_derivation.go
@@ -58,6 +58,7 @@ type routeResolvedPattern struct {
 	MatchPattern   string
 	RouteSource    string
 	LocalizedEvent string
+	RoutePath      string
 }
 
 func DeriveRouteTable(source semanticview.Source) (*RouteTable, error) {
@@ -73,6 +74,9 @@ func DeriveRouteTable(source semanticview.Source) (*RouteTable, error) {
 		var inputEvents []string
 		if routeProjectScopeRequiresPinAliases(scope) {
 			owningFlowID = strings.TrimSpace(scope.OwningFlowID)
+		}
+		if importedFlowID := routeProjectScopeImportedFlowID(source, scope); importedFlowID != "" && routeProjectScopeOwnedByTemplateFlow(source, importedFlowID) {
+			continue
 		}
 		if owningFlowID != "" {
 			inputEvents = source.FlowInputEvents(owningFlowID)
@@ -108,6 +112,24 @@ func DeriveRouteTable(source semanticview.Source) (*RouteTable, error) {
 	rt.addRootInputFlowNodeRoutesLocked(source)
 	rt.rebuildLocked()
 	return rt, nil
+}
+
+func routeProjectScopeImportedFlowID(source semanticview.Source, scope semanticview.ProjectScope) string {
+	if source == nil {
+		return ""
+	}
+	key := strings.Trim(strings.TrimSpace(scope.Key), "/")
+	if key == "" {
+		key = "."
+	}
+	for _, parent := range semanticview.ProjectScopes(source) {
+		for _, site := range semanticview.ImportBoundaryFlowSites(parent) {
+			if strings.Trim(strings.TrimSpace(site.PackageKey), "/") == key {
+				return strings.TrimSpace(site.FlowID)
+			}
+		}
+	}
+	return ""
 }
 
 func routeProjectScopeRequiresPinAliases(scope semanticview.ProjectScope) bool {
@@ -544,7 +566,30 @@ func routeApplyResolvedPattern(subscriber Subscriber, resolved routeResolvedPatt
 	if matchPattern := eventidentity.Normalize(resolved.MatchPattern); matchPattern != "" {
 		subscriber.MatchPattern = matchPattern
 	}
+	if subscriber.Path == "" {
+		if routePath := eventidentity.Normalize(resolved.RoutePath); routePath != "" {
+			subscriber.Path = routePath
+		} else if strings.HasPrefix(subscriber.RouteSource, "import_boundary_wildcard") {
+			subscriber.Path = routeStaticPrefixBeforeWildcard(resolved.EventPattern)
+		}
+	}
 	return subscriber
+}
+
+func routeStaticPrefixBeforeWildcard(pattern string) string {
+	pattern = eventidentity.Normalize(pattern)
+	if pattern == "" || !strings.Contains(pattern, "*") {
+		return ""
+	}
+	segments := strings.Split(pattern, "/")
+	prefix := make([]string, 0, len(segments))
+	for _, segment := range segments {
+		if strings.Contains(segment, "*") {
+			break
+		}
+		prefix = append(prefix, segment)
+	}
+	return strings.Join(prefix, "/")
 }
 
 func routeResolveNodeCanonicalPattern(source semanticview.Source, basePath, nodeID, rawPattern string) routeResolvedPattern {
@@ -822,13 +867,65 @@ func routeResolveSubscriberPatterns(source semanticview.Source, packageKey, flow
 				return out
 			}
 		}
+		if strings.Contains(raw, "*") {
+			resolution := semanticview.ResolveImportBoundaryWildcardSubscription(source, packageKey, flowID, basePath, localEvents, raw)
+			if resolution.Scoped {
+				out := make([]routeResolvedPattern, 0, len(resolution.Patterns))
+				for _, pattern := range resolution.Patterns {
+					eventPattern := eventidentity.Normalize(pattern.EventPattern)
+					if eventPattern == "" {
+						continue
+					}
+					out = append(out, routeResolvedPattern{
+						EventPattern:   eventPattern,
+						MatchPattern:   pattern.MatchPattern,
+						RouteSource:    pattern.RouteSource,
+						LocalizedEvent: pattern.LocalizedEvent,
+						RoutePath:      routeImportBoundarySubscriberPath(source, packageKey, flowID, basePath),
+					})
+				}
+				return out
+			}
+		}
 	}
 	scope := routeEventIdentityScope(basePath, localEvents, inputEvents)
 	pattern := scope.ResolveSubscriptionPattern(raw, routeDescendantScopes(source, flowID))
+	if pattern == raw && !strings.Contains(raw, "/") && strings.Trim(strings.TrimSpace(basePath), "/") != "" {
+		for localEvent := range localEvents {
+			if eventidentity.MatchPattern(raw, localEvent) {
+				pattern = eventidentity.Normalize(strings.Trim(strings.TrimSpace(basePath), "/") + "/" + raw)
+				break
+			}
+		}
+	}
 	if pattern == "" {
 		return nil
 	}
 	return []routeResolvedPattern{{EventPattern: pattern, RouteSource: "subscription"}}
+}
+
+func routeImportBoundarySubscriberPath(source semanticview.Source, packageKey, flowID, basePath string) string {
+	if path := eventidentity.Normalize(basePath); path != "" {
+		return path
+	}
+	if flowID = strings.TrimSpace(flowID); flowID != "" {
+		return routeFlowPath(source, flowID)
+	}
+	packageKey = strings.Trim(strings.TrimSpace(packageKey), "/")
+	if packageKey == "" {
+		packageKey = "."
+	}
+	if source == nil {
+		return ""
+	}
+	for _, parent := range semanticview.ProjectScopes(source) {
+		for _, site := range semanticview.ImportBoundaryFlowSites(parent) {
+			if strings.Trim(strings.TrimSpace(site.PackageKey), "/") == packageKey {
+				return routeFlowPath(source, site.FlowID)
+			}
+		}
+	}
+	return ""
 }
 
 func routeReceiverCarrierSubscriberPatterns(inputEvents []string, instancePath, raw string) []routeResolvedPattern {

--- a/internal/runtime/contracts/workflow_contract_types.go
+++ b/internal/runtime/contracts/workflow_contract_types.go
@@ -657,10 +657,15 @@ type FlowPackageRequires struct {
 	PlatformVersion string                 `yaml:"platform_version"`
 }
 type FlowPackageBind struct {
-	Inputs      map[string]string `yaml:"inputs"`
-	Outputs     map[string]string `yaml:"outputs"`
-	Policy      map[string]string `yaml:"policy"`
-	Credentials map[string]string `yaml:"credentials"`
+	Inputs      map[string]string         `yaml:"inputs"`
+	Outputs     map[string]string         `yaml:"outputs"`
+	Policy      map[string]string         `yaml:"policy"`
+	Credentials map[string]string         `yaml:"credentials"`
+	Observe     []FlowPackageObserveGrant `yaml:"observe"`
+}
+type FlowPackageObserveGrant struct {
+	Source string   `yaml:"source"`
+	Events []string `yaml:"events"`
 }
 type ProjectHandoff struct {
 	Event       string `yaml:"event"`

--- a/internal/runtime/contracts/workflow_contract_yaml_wave1.go
+++ b/internal/runtime/contracts/workflow_contract_yaml_wave1.go
@@ -142,6 +142,10 @@ func (b *FlowPackageBind) UnmarshalYAML(node *yaml.Node) error {
 			if err := value.Decode(&out.Credentials); err != nil {
 				return fmt.Errorf("bind.credentials: %w", err)
 			}
+		case "observe":
+			if err := value.Decode(&out.Observe); err != nil {
+				return fmt.Errorf("bind.observe: %w", err)
+			}
 		default:
 			return fmt.Errorf("UNDEFINED-FIELD: bind field %q not in platform spec", key)
 		}
@@ -255,7 +259,30 @@ func (b FlowPackageBind) normalized() FlowPackageBind {
 		Outputs:     normalizeStringMap(b.Outputs),
 		Policy:      normalizeStringMap(b.Policy),
 		Credentials: normalizeStringMap(b.Credentials),
+		Observe:     normalizeFlowPackageObserveGrants(b.Observe),
 	}
+}
+
+func normalizeFlowPackageObserveGrants(in []FlowPackageObserveGrant) []FlowPackageObserveGrant {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]FlowPackageObserveGrant, 0, len(in))
+	for _, grant := range in {
+		source := strings.TrimSpace(grant.Source)
+		events := normalizeStrings(grant.Events)
+		if source == "" && len(events) == 0 {
+			continue
+		}
+		out = append(out, FlowPackageObserveGrant{
+			Source: source,
+			Events: events,
+		})
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
 }
 
 func (c *FlowPackageConnect) UnmarshalYAML(node *yaml.Node) error {

--- a/internal/runtime/engine/declarative_node.go
+++ b/internal/runtime/engine/declarative_node.go
@@ -76,29 +76,27 @@ func resolvedExecutionHandler(source semanticview.Source, nodeID, eventType stri
 	if source == nil {
 		return executionHandlerResolution{}
 	}
+	if handler, ok := source.NodeEventHandler(nodeID, eventType); ok {
+		return executionHandlerResolution{
+			handler:         handler,
+			handlerEventKey: matchedHandlerEventKeyFromHandlers(source.NodeEventHandlers(nodeID), eventType),
+			matched:         true,
+		}
+	}
+	if semanticview.ImportBoundaryWildcardHandlerFallbackDenied(source, nodeID, eventType) {
+		return executionHandlerResolution{}
+	}
 	if bundle, ok := semanticview.Bundle(source); ok {
 		resolved := bundle.ResolveNodeEventHandler(nodeID, eventType)
 		if resolved.Matched {
-			handler, ok := source.NodeEventHandler(nodeID, eventType)
-			if !ok {
-				handler = resolved.Handler
-			}
 			return executionHandlerResolution{
-				handler:         handler,
+				handler:         resolved.Handler,
 				handlerEventKey: strings.TrimSpace(resolved.AuthoredEventType),
 				matched:         true,
 			}
 		}
 	}
-	handler, ok := source.NodeEventHandler(nodeID, eventType)
-	if !ok {
-		return executionHandlerResolution{}
-	}
-	return executionHandlerResolution{
-		handler:         handler,
-		handlerEventKey: matchedHandlerEventKeyFromHandlers(source.NodeEventHandlers(nodeID), eventType),
-		matched:         true,
-	}
+	return executionHandlerResolution{}
 }
 
 func matchedHandlerEventKeyFromHandlers(handlers map[string]runtimecontracts.SystemNodeEventHandler, eventType string) string {

--- a/internal/runtime/engine/declarative_node_test.go
+++ b/internal/runtime/engine/declarative_node_test.go
@@ -2,13 +2,17 @@ package engine
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"reflect"
+	stdruntime "runtime"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/division-sh/swarm/internal/events"
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
 	"github.com/division-sh/swarm/internal/runtime/semanticview"
-	"time"
 )
 
 func TestNewDeclarativeNode_RequiresExecutor(t *testing.T) {
@@ -127,5 +131,123 @@ func TestDeclarativeNode_HandleUsesExplicitHandlerWithoutLookup(t *testing.T) {
 	}
 	if !reflect.DeepEqual(result.ClearGates, []string{"gate_a"}) {
 		t.Fatalf("ClearGates = %#v", result.ClearGates)
+	}
+}
+
+func TestResolvedExecutionHandler_DeniesImportBoundaryWildcardRawFallback(t *testing.T) {
+	source := loadEngineImportBoundaryWildcardSource(t, "")
+	resolved := resolvedExecutionHandler(source, "worker-listener", "producer/task.done")
+	if resolved.matched {
+		t.Fatalf("resolvedExecutionHandler matched ungranted sibling event through raw fallback: %#v", resolved)
+	}
+}
+
+func TestResolvedExecutionHandler_AllowsGrantedImportBoundaryWildcard(t *testing.T) {
+	source := loadEngineImportBoundaryWildcardSource(t, "      observe:\n        - source: producer\n          events: [task.done]\n")
+	resolved := resolvedExecutionHandler(source, "worker-listener", "producer/task.done")
+	if !resolved.matched {
+		t.Fatal("resolvedExecutionHandler did not match granted sibling event")
+	}
+	if got := resolved.handlerEventKey; got != "**/task.done" {
+		t.Fatalf("handler event key = %q, want **/task.done", got)
+	}
+	if !reflect.DeepEqual(resolved.handler.ClearGates, []string{"sibling_gate"}) {
+		t.Fatalf("handler = %#v, want sibling_gate clear handler", resolved.handler)
+	}
+}
+
+func loadEngineImportBoundaryWildcardSource(t *testing.T, observeGrant string) semanticview.Source {
+	t.Helper()
+	repoRoot := engineRepoRoot(t)
+	root := writeEngineImportBoundaryWildcardFixture(t, observeGrant)
+	bundle, err := runtimecontracts.LoadWorkflowContractBundleWithOverrides(repoRoot, root, runtimecontracts.DefaultPlatformSpecFile(repoRoot))
+	if err != nil {
+		t.Fatalf("LoadWorkflowContractBundleWithOverrides: %v", err)
+	}
+	return semanticview.Wrap(bundle)
+}
+
+func engineRepoRoot(t *testing.T) string {
+	t.Helper()
+	_, file, _, ok := stdruntime.Caller(0)
+	if !ok {
+		t.Fatal("resolve runtime caller")
+	}
+	return filepath.Clean(filepath.Join(filepath.Dir(file), "..", "..", ".."))
+}
+
+func writeEngineImportBoundaryWildcardFixture(t *testing.T, observeGrant string) string {
+	t.Helper()
+	root := t.TempDir()
+	workerBind := ""
+	if strings.TrimSpace(observeGrant) != "" {
+		workerBind = "    bind:\n" + observeGrant
+	}
+	writeEngineFixtureFile(t, filepath.Join(root, "package.yaml"), `
+name: engine-import-boundary-wildcard
+version: "1.0.0"
+platform_version: ">=1.6.0"
+flows:
+  - id: worker
+    flow: worker
+    mode: static
+`+workerBind+`  - id: producer
+    flow: producer
+    mode: static
+`)
+	writeEngineFixtureFile(t, filepath.Join(root, "schema.yaml"), "name: engine-import-boundary-wildcard\n")
+	writeEngineFixtureFile(t, filepath.Join(root, "policy.yaml"), "{}\n")
+	writeEngineFixtureFile(t, filepath.Join(root, "tools.yaml"), "{}\n")
+	writeEngineFixtureFile(t, filepath.Join(root, "agents.yaml"), "{}\n")
+	writeEngineFixtureFile(t, filepath.Join(root, "events.yaml"), "{}\n")
+	writeEngineFixtureFile(t, filepath.Join(root, "nodes.yaml"), "{}\n")
+	writeEngineFixtureFile(t, filepath.Join(root, "flows", "worker", "package.yaml"), "name: worker\nversion: \"1.0.0\"\n")
+	writeEngineFixtureFile(t, filepath.Join(root, "flows", "worker", "schema.yaml"), `
+name: worker
+mode: static
+initial_state: active
+terminal_states: [done]
+states: [active, done]
+pins:
+  outputs:
+    events: [task.done]
+`)
+	writeEngineFixtureFile(t, filepath.Join(root, "flows", "worker", "policy.yaml"), "{}\n")
+	writeEngineFixtureFile(t, filepath.Join(root, "flows", "worker", "agents.yaml"), "{}\n")
+	writeEngineFixtureFile(t, filepath.Join(root, "flows", "worker", "events.yaml"), "task.done: {}\n")
+	writeEngineFixtureFile(t, filepath.Join(root, "flows", "worker", "nodes.yaml"), `
+worker-listener:
+  id: worker-listener
+  execution_type: system_node
+  subscribes_to: ["**/task.done"]
+  event_handlers:
+    "**/task.done":
+      clear_gates: [sibling_gate]
+`)
+	writeEngineFixtureFile(t, filepath.Join(root, "flows", "producer", "package.yaml"), "name: producer\nversion: \"1.0.0\"\n")
+	writeEngineFixtureFile(t, filepath.Join(root, "flows", "producer", "schema.yaml"), `
+name: producer
+mode: static
+initial_state: active
+terminal_states: [done]
+states: [active, done]
+pins:
+  outputs:
+    events: [task.done]
+`)
+	writeEngineFixtureFile(t, filepath.Join(root, "flows", "producer", "policy.yaml"), "{}\n")
+	writeEngineFixtureFile(t, filepath.Join(root, "flows", "producer", "agents.yaml"), "{}\n")
+	writeEngineFixtureFile(t, filepath.Join(root, "flows", "producer", "events.yaml"), "task.done: {}\n")
+	writeEngineFixtureFile(t, filepath.Join(root, "flows", "producer", "nodes.yaml"), "{}\n")
+	return root
+}
+
+func writeEngineFixtureFile(t *testing.T, path string, contents string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, []byte(contents), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
 	}
 }

--- a/internal/runtime/pipeline/node_declarative.go
+++ b/internal/runtime/pipeline/node_declarative.go
@@ -176,13 +176,16 @@ func (n *DeclarativeNode) HandleEvent(ctx context.Context, evt Event) (*HandlerO
 	eventType := strings.TrimSpace(string(evt.Type()))
 	handlerEventKey := eventType
 	handler, ok := n.resolvedHandlerForDelivery(evt)
+	denyRawHandlerFallback := n.source != nil && semanticview.ImportBoundaryWildcardHandlerFallbackDenied(n.source, n.NodeID(), eventType)
 	if !ok {
-		handler, ok = n.contract.EventHandlers[eventType]
+		if !denyRawHandlerFallback {
+			handler, ok = n.contract.EventHandlers[eventType]
+		}
 	}
 	if ok {
 		handlerEventKey = workflowNodeHandlerEventKeyForExecution(n.source, n.NodeID(), evt)
 	}
-	if !ok {
+	if !ok && !denyRawHandlerFallback {
 		for pattern, candidate := range n.contract.EventHandlers {
 			if strings.TrimSpace(pattern) == eventType {
 				continue

--- a/internal/runtime/pipeline/timeout_selection_test.go
+++ b/internal/runtime/pipeline/timeout_selection_test.go
@@ -103,6 +103,39 @@ func TestDeclarativeNodeHandleEvent_MatchesWildcardHandler(t *testing.T) {
 	}
 }
 
+func TestDeclarativeNodeHandleEvent_DeniesImportBoundaryWildcardRawFallback(t *testing.T) {
+	source := loadPipelineImportBoundaryWildcardSource(t, "")
+	entry := source.NodeEntries()["worker-listener"]
+	engine := &recordingExecutionEngine{}
+	node := NewNode(entry, source, engine, nil)
+
+	handled := node.Handle(context.Background(), events.NewProjectionEvent("", "producer/task.done", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}))
+	if handled {
+		t.Fatal("expected ungranted sibling event not to be handled")
+	}
+	if engine.called {
+		t.Fatal("execution engine was called through raw wildcard fallback")
+	}
+}
+
+func TestDeclarativeNodeHandleEvent_AllowsGrantedImportBoundaryWildcard(t *testing.T) {
+	source := loadPipelineImportBoundaryWildcardSource(t, "      observe:\n        - source: producer\n          events: [task.done]\n")
+	entry := source.NodeEntries()["worker-listener"]
+	engine := &recordingExecutionEngine{}
+	node := NewNode(entry, source, engine, nil)
+
+	handled := node.Handle(context.Background(), events.NewProjectionEvent("", "producer/task.done", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}))
+	if !handled {
+		t.Fatal("expected granted sibling event to be handled")
+	}
+	if !engine.called {
+		t.Fatal("expected execution engine to be called")
+	}
+	if got := engine.handlerEventKey; got != "**/task.done" {
+		t.Fatalf("handler event key = %q, want **/task.done", got)
+	}
+}
+
 func TestWorkflowNodeEventPolicy_MatchesWildcardSubscription(t *testing.T) {
 	repoRoot := filepath.Clean(filepath.Join("..", "..", ".."))
 	fixtureRoot := filepath.Join(repoRoot, "tests", "tier5-flow-lifecycle", "test-wildcard-subscription")

--- a/internal/runtime/pipeline/workflow_handler_preview.go
+++ b/internal/runtime/pipeline/workflow_handler_preview.go
@@ -88,17 +88,17 @@ func PreviewContractHandlerExecution(ctx context.Context, bundle *runtimecontrac
 	if nodeID == "" {
 		return HandlerPreview{}, fmt.Errorf("node id is required")
 	}
-	handler, ok := bundle.NodeEventHandler(nodeID, strings.TrimSpace(string(evt.Type())))
+	previewBundle := semanticview.CloneBundleForPreview(bundle, policyOverrides)
+	source := semanticview.Wrap(previewBundle)
+	handler, ok := source.NodeEventHandler(nodeID, strings.TrimSpace(string(evt.Type())))
 	if !ok {
 		return HandlerPreview{}, fmt.Errorf("missing handler %s/%s", nodeID, evt.Type())
 	}
-
-	previewBundle := semanticview.CloneBundleForPreview(bundle, policyOverrides)
-	workflow, err := LoadWorkflowDefinition(semanticview.Wrap(previewBundle))
+	workflow, err := LoadWorkflowDefinition(source)
 	if err != nil {
 		return HandlerPreview{}, err
 	}
-	nodes, err := LoadWorkflowNodes(semanticview.Wrap(previewBundle))
+	nodes, err := LoadWorkflowNodes(source)
 	if err != nil {
 		return HandlerPreview{}, err
 	}
@@ -106,8 +106,8 @@ func PreviewContractHandlerExecution(ctx context.Context, bundle *runtimecontrac
 		bundle:         previewBundle,
 		workflow:       workflow,
 		workflowNodes:  nodes,
-		guardRegistry:  NewContractGuardRegistry(semanticview.Wrap(previewBundle)),
-		actionRegistry: NewContractActionRegistry(semanticview.Wrap(previewBundle)),
+		guardRegistry:  NewContractGuardRegistry(source),
+		actionRegistry: NewContractActionRegistry(source),
 	}
 	pc := NewPipelineCoordinatorWithOptions(previewBus{}, nil, PipelineCoordinatorOptions{Module: module})
 	if pc == nil {

--- a/internal/runtime/pipeline/workflow_handler_preview_test.go
+++ b/internal/runtime/pipeline/workflow_handler_preview_test.go
@@ -1,0 +1,46 @@
+package pipeline
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/division-sh/swarm/internal/events"
+)
+
+func TestPreviewContractHandlerExecution_DeniesImportBoundaryWildcardRawFallback(t *testing.T) {
+	bundle := loadPipelineImportBoundaryWildcardBundle(t, "")
+	_, err := PreviewContractHandlerExecution(
+		context.Background(),
+		bundle,
+		"worker-listener",
+		events.NewProjectionEvent("", "producer/task.done", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}),
+		WorkflowState{},
+		nil,
+	)
+	if err == nil {
+		t.Fatal("expected preview to deny ungranted sibling event")
+	}
+	if !strings.Contains(err.Error(), "missing handler worker-listener/producer/task.done") {
+		t.Fatalf("preview error = %v, want missing handler denial", err)
+	}
+}
+
+func TestPreviewContractHandlerExecution_AllowsGrantedImportBoundaryWildcard(t *testing.T) {
+	bundle := loadPipelineImportBoundaryWildcardBundle(t, "      observe:\n        - source: producer\n          events: [task.done]\n")
+	preview, err := PreviewContractHandlerExecution(
+		context.Background(),
+		bundle,
+		"worker-listener",
+		events.NewProjectionEvent("", "producer/task.done", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}),
+		WorkflowState{},
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("PreviewContractHandlerExecution: %v", err)
+	}
+	if !containsString(preview.ClearGates, "sibling_gate") {
+		t.Fatalf("preview ClearGates = %#v, want sibling_gate", preview.ClearGates)
+	}
+}

--- a/internal/runtime/pipeline/workflow_nodes.go
+++ b/internal/runtime/pipeline/workflow_nodes.go
@@ -183,6 +183,9 @@ func workflowNodeEventHandlerResolutionForEventType(source semanticview.Source, 
 			Matched:         true,
 		}
 	}
+	if semanticview.ImportBoundaryWildcardHandlerFallbackDenied(source, nodeID, eventType) {
+		return workflowNodeEventHandlerResolution{}
+	}
 	if bundle, ok := semanticview.Bundle(source); ok {
 		resolved := bundle.ResolveNodeEventHandler(nodeID, eventType)
 		if resolved.Matched {

--- a/internal/runtime/pipeline/workflow_nodes.go
+++ b/internal/runtime/pipeline/workflow_nodes.go
@@ -176,29 +176,24 @@ func workflowNodeEventHandlerResolutionForEventType(source semanticview.Source, 
 	if eventType == "" {
 		return workflowNodeEventHandlerResolution{}
 	}
+	if handler, ok := source.NodeEventHandler(nodeID, eventType); ok {
+		return workflowNodeEventHandlerResolution{
+			Handler:         handler,
+			HandlerEventKey: workflowNodeMatchedHandlerEventKey(source, nodeID, eventType),
+			Matched:         true,
+		}
+	}
 	if bundle, ok := semanticview.Bundle(source); ok {
 		resolved := bundle.ResolveNodeEventHandler(nodeID, eventType)
 		if resolved.Matched {
-			handler, ok := source.NodeEventHandler(nodeID, eventType)
-			if !ok {
-				handler = resolved.Handler
-			}
 			return workflowNodeEventHandlerResolution{
-				Handler:         handler,
+				Handler:         resolved.Handler,
 				HandlerEventKey: strings.TrimSpace(resolved.AuthoredEventType),
 				Matched:         true,
 			}
 		}
 	}
-	handler, ok := source.NodeEventHandler(nodeID, eventType)
-	if !ok {
-		return workflowNodeEventHandlerResolution{}
-	}
-	return workflowNodeEventHandlerResolution{
-		Handler:         handler,
-		HandlerEventKey: workflowNodeMatchedHandlerEventKey(source, nodeID, eventType),
-		Matched:         true,
-	}
+	return workflowNodeEventHandlerResolution{}
 }
 
 func workflowNodeMatchedHandlerEventKey(source semanticview.Source, nodeID, eventType string) string {
@@ -441,6 +436,12 @@ func workflowNodeSubscriptionAliases(source semanticview.Source, nodeID, eventTy
 		appendAlias(alias.EventPattern)
 	}
 	if strings.Contains(eventType, "*") {
+		if resolution := semanticview.ResolveImportBoundaryWildcardSubscriptionForNode(source, nodeID, eventType); resolution.Scoped {
+			for _, pattern := range resolution.Patterns {
+				appendAlias(pattern.EventPattern)
+			}
+			return out
+		}
 		for _, alias := range semanticview.ImportBoundaryOutputAliasesForParent(source, contractSource.PackageKey, flowID) {
 			parentEvent := eventidentity.Normalize(alias.ParentEvent)
 			if parentEvent == "" || !eventidentity.MatchPattern(eventType, parentEvent) {

--- a/internal/runtime/pipeline/workflow_nodes_test.go
+++ b/internal/runtime/pipeline/workflow_nodes_test.go
@@ -2,6 +2,7 @@ package pipeline
 
 import (
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -259,6 +260,30 @@ func TestLoadWorkflowNodes_UsesImportBoundaryOutputAliasForWildcardParentSubscri
 	}
 }
 
+func TestWorkflowNodeHandlerResolution_DeniesImportBoundaryWildcardRawFallback(t *testing.T) {
+	source := loadPipelineImportBoundaryWildcardSource(t, "")
+	evt := events.NewProjectionEvent("", "producer/task.done", "", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Unix(1, 0).UTC())
+	resolved := workflowNodeEventHandlerResolutionForDelivery(source, "worker-listener", evt)
+	if resolved.Matched {
+		t.Fatalf("worker-listener matched ungranted sibling event through raw wildcard fallback: %#v", resolved)
+	}
+	if _, ok := source.NodeEventHandler("worker-listener", "producer/task.done"); ok {
+		t.Fatal("semantic source NodeEventHandler matched ungranted sibling event")
+	}
+}
+
+func TestWorkflowNodeHandlerResolution_AllowsGrantedImportBoundaryWildcard(t *testing.T) {
+	source := loadPipelineImportBoundaryWildcardSource(t, "      observe:\n        - source: producer\n          events: [task.done]\n")
+	evt := events.NewProjectionEvent("", "producer/task.done", "", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Unix(1, 0).UTC())
+	resolved := workflowNodeEventHandlerResolutionForDelivery(source, "worker-listener", evt)
+	if !resolved.Matched {
+		t.Fatal("worker-listener did not match granted sibling event")
+	}
+	if got := resolved.HandlerEventKey; got != "**/task.done" {
+		t.Fatalf("handler event key = %q, want **/task.done", got)
+	}
+}
+
 func loadPipelineImportBoundaryAliasSource(t *testing.T) semanticview.Source {
 	t.Helper()
 	return loadPipelineImportBoundaryAliasSourceWithParentSubscription(t, "parent.lead_enriched")
@@ -336,6 +361,82 @@ worker-node:
     work.requested:
       emit: work.completed
 `)
+	return root
+}
+
+func loadPipelineImportBoundaryWildcardSource(t *testing.T, observeGrant string) semanticview.Source {
+	t.Helper()
+	root := writePipelineImportBoundaryWildcardFixture(t, observeGrant)
+	bundle, err := runtimecontracts.LoadWorkflowContractBundleWithOverrides(contractComplianceRepoRoot(t), root, runtimecontracts.DefaultPlatformSpecFile(contractComplianceRepoRoot(t)))
+	if err != nil {
+		t.Fatalf("LoadWorkflowContractBundleWithOverrides: %v", err)
+	}
+	return semanticview.Wrap(bundle)
+}
+
+func writePipelineImportBoundaryWildcardFixture(t *testing.T, observeGrant string) string {
+	t.Helper()
+	root := t.TempDir()
+	workerBind := ""
+	if strings.TrimSpace(observeGrant) != "" {
+		workerBind = "    bind:\n" + observeGrant
+	}
+	writePipelineFixtureFile(t, filepath.Join(root, "package.yaml"), `
+name: pipeline-import-boundary-wildcard
+version: "1.0.0"
+platform_version: ">=1.6.0"
+flows:
+  - id: worker
+    flow: worker
+    mode: static
+`+workerBind+`  - id: producer
+    flow: producer
+    mode: static
+`)
+	writePipelineFixtureFile(t, filepath.Join(root, "schema.yaml"), "name: pipeline-import-boundary-wildcard\n")
+	writePipelineFixtureFile(t, filepath.Join(root, "policy.yaml"), "{}\n")
+	writePipelineFixtureFile(t, filepath.Join(root, "tools.yaml"), "{}\n")
+	writePipelineFixtureFile(t, filepath.Join(root, "agents.yaml"), "{}\n")
+	writePipelineFixtureFile(t, filepath.Join(root, "events.yaml"), "{}\n")
+	writePipelineFixtureFile(t, filepath.Join(root, "nodes.yaml"), "{}\n")
+	writePipelineFixtureFile(t, filepath.Join(root, "flows", "worker", "package.yaml"), "name: worker\nversion: \"1.0.0\"\n")
+	writePipelineFixtureFile(t, filepath.Join(root, "flows", "worker", "schema.yaml"), `
+name: worker
+mode: static
+initial_state: active
+terminal_states: [done]
+states: [active, done]
+pins:
+  outputs:
+    events: [task.done]
+`)
+	writePipelineFixtureFile(t, filepath.Join(root, "flows", "worker", "policy.yaml"), "{}\n")
+	writePipelineFixtureFile(t, filepath.Join(root, "flows", "worker", "agents.yaml"), "{}\n")
+	writePipelineFixtureFile(t, filepath.Join(root, "flows", "worker", "events.yaml"), "task.done: {}\n")
+	writePipelineFixtureFile(t, filepath.Join(root, "flows", "worker", "nodes.yaml"), `
+worker-listener:
+  id: worker-listener
+  execution_type: system_node
+  subscribes_to: ["**/task.done"]
+  event_handlers:
+    "**/task.done":
+      clear_gates: [sibling_gate]
+`)
+	writePipelineFixtureFile(t, filepath.Join(root, "flows", "producer", "package.yaml"), "name: producer\nversion: \"1.0.0\"\n")
+	writePipelineFixtureFile(t, filepath.Join(root, "flows", "producer", "schema.yaml"), `
+name: producer
+mode: static
+initial_state: active
+terminal_states: [done]
+states: [active, done]
+pins:
+  outputs:
+    events: [task.done]
+`)
+	writePipelineFixtureFile(t, filepath.Join(root, "flows", "producer", "policy.yaml"), "{}\n")
+	writePipelineFixtureFile(t, filepath.Join(root, "flows", "producer", "agents.yaml"), "{}\n")
+	writePipelineFixtureFile(t, filepath.Join(root, "flows", "producer", "events.yaml"), "task.done: {}\n")
+	writePipelineFixtureFile(t, filepath.Join(root, "flows", "producer", "nodes.yaml"), "{}\n")
 	return root
 }
 

--- a/internal/runtime/pipeline/workflow_nodes_test.go
+++ b/internal/runtime/pipeline/workflow_nodes_test.go
@@ -366,12 +366,18 @@ worker-node:
 
 func loadPipelineImportBoundaryWildcardSource(t *testing.T, observeGrant string) semanticview.Source {
 	t.Helper()
+	bundle := loadPipelineImportBoundaryWildcardBundle(t, observeGrant)
+	return semanticview.Wrap(bundle)
+}
+
+func loadPipelineImportBoundaryWildcardBundle(t *testing.T, observeGrant string) *runtimecontracts.WorkflowContractBundle {
+	t.Helper()
 	root := writePipelineImportBoundaryWildcardFixture(t, observeGrant)
 	bundle, err := runtimecontracts.LoadWorkflowContractBundleWithOverrides(contractComplianceRepoRoot(t), root, runtimecontracts.DefaultPlatformSpecFile(contractComplianceRepoRoot(t)))
 	if err != nil {
 		t.Fatalf("LoadWorkflowContractBundleWithOverrides: %v", err)
 	}
-	return semanticview.Wrap(bundle)
+	return bundle
 }
 
 func writePipelineImportBoundaryWildcardFixture(t *testing.T, observeGrant string) string {

--- a/internal/runtime/semanticview/bundle_source.go
+++ b/internal/runtime/semanticview/bundle_source.go
@@ -254,9 +254,33 @@ func (s bundleSource) ResolveFlowEventReference(flowID, eventType string) string
 	return s.bundle.ResolveFlowEventReference(flowID, eventType)
 }
 func (s bundleSource) ResolveFlowEventPattern(flowID, pattern string) string {
+	if resolution := ResolveImportBoundaryWildcardSubscription(
+		s,
+		"",
+		flowID,
+		s.FlowPath(flowID),
+		flowLocalEventSetForWildcardSource(s, flowID),
+		pattern,
+	); resolution.Scoped {
+		if len(resolution.Patterns) == 1 {
+			return resolution.Patterns[0].EventPattern
+		}
+		return ""
+	}
 	return s.bundle.ResolveFlowEventPattern(flowID, pattern)
 }
 func (s bundleSource) FlowEventMatches(flowID, subscription, eventType string) bool {
+	if matched, scoped := ImportBoundaryWildcardSubscriptionMatches(
+		s,
+		"",
+		flowID,
+		s.FlowPath(flowID),
+		flowLocalEventSetForWildcardSource(s, flowID),
+		subscription,
+		eventType,
+	); scoped {
+		return matched
+	}
 	return s.bundle.FlowEventMatches(flowID, subscription, eventType)
 }
 func (s bundleSource) RequiredAgents() []runtimecontracts.FlowRequiredAgent {
@@ -281,7 +305,7 @@ func (s bundleSource) DerivedHandlerTransitions() []runtimecontracts.HandlerTran
 	return s.bundle.DerivedHandlerTransitions()
 }
 func (s bundleSource) RuntimeEventOwners(eventType string) []string {
-	return s.bundle.RuntimeEventOwners(eventType)
+	return RuntimeEventOwners(s, eventType)
 }
 func (s bundleSource) NodeContractSource(nodeID string) (runtimecontracts.ContractItemSource, bool) {
 	return s.bundle.NodeContractSource(nodeID)
@@ -302,6 +326,20 @@ func (s bundleSource) NodeEventHandlers(nodeID string) map[string]runtimecontrac
 	return s.bundle.NodeEventHandlers(nodeID)
 }
 func (s bundleSource) NodeEventHandler(nodeID, eventType string) (runtimecontracts.SystemNodeEventHandler, bool) {
+	nodeID = strings.TrimSpace(nodeID)
+	eventType = strings.TrimSpace(eventType)
+	for pattern := range s.bundle.NodeEventHandlers(nodeID) {
+		if !strings.Contains(pattern, "*") {
+			continue
+		}
+		matched, scoped := ImportBoundaryWildcardSubscriptionMatchesNode(s, nodeID, pattern, eventType)
+		if !scoped {
+			continue
+		}
+		if matched {
+			return s.bundle.NodeEventHandler(nodeID, pattern)
+		}
+	}
 	return s.bundle.NodeEventHandler(nodeID, eventType)
 }
 func (s bundleSource) NodeEntries() map[string]runtimecontracts.SystemNodeContract {
@@ -321,4 +359,16 @@ func (s bundleSource) ToolEntries() map[string]runtimecontracts.ToolSchemaEntry 
 }
 func (s bundleSource) ToolEntryForAgent(agentID, toolID string) (runtimecontracts.ToolSchemaEntry, bool) {
 	return s.bundle.ToolEntryForAgent(agentID, toolID)
+}
+
+func flowLocalEventSetForWildcardSource(source Source, flowID string) map[string]struct{} {
+	flowID = strings.TrimSpace(flowID)
+	if source == nil || flowID == "" {
+		return nil
+	}
+	scope, ok := source.FlowScopeByID(flowID)
+	if !ok {
+		return nil
+	}
+	return importBoundaryFlowLocalEventSet(source, scope)
 }

--- a/internal/runtime/semanticview/bundle_source.go
+++ b/internal/runtime/semanticview/bundle_source.go
@@ -340,6 +340,9 @@ func (s bundleSource) NodeEventHandler(nodeID, eventType string) (runtimecontrac
 			return s.bundle.NodeEventHandler(nodeID, pattern)
 		}
 	}
+	if ImportBoundaryWildcardHandlerFallbackDenied(s, nodeID, eventType) {
+		return runtimecontracts.SystemNodeEventHandler{}, false
+	}
 	return s.bundle.NodeEventHandler(nodeID, eventType)
 }
 func (s bundleSource) NodeEntries() map[string]runtimecontracts.SystemNodeContract {

--- a/internal/runtime/semanticview/import_boundary_aliases.go
+++ b/internal/runtime/semanticview/import_boundary_aliases.go
@@ -44,6 +44,26 @@ type importBoundarySite struct {
 	Bind       runtimecontracts.FlowPackageBind
 }
 
+type ImportBoundaryFlowSite struct {
+	PackageKey string
+	FlowID     string
+}
+
+func ImportBoundaryFlowSites(scope ProjectScope) []ImportBoundaryFlowSite {
+	sites := importBoundarySites(scope)
+	out := make([]ImportBoundaryFlowSite, 0, len(sites))
+	for _, site := range sites {
+		if strings.TrimSpace(site.FlowID) == "" {
+			continue
+		}
+		out = append(out, ImportBoundaryFlowSite{
+			PackageKey: site.PackageKey,
+			FlowID:     site.FlowID,
+		})
+	}
+	return out
+}
+
 func ResolveFlowInputAutoWire(source Source, targetFlowID, eventType string) runtimecontracts.FlowInputAutoWireResolution {
 	targetFlowID = strings.TrimSpace(targetFlowID)
 	eventType = eventidentity.Normalize(eventType)

--- a/internal/runtime/semanticview/import_boundary_wildcards.go
+++ b/internal/runtime/semanticview/import_boundary_wildcards.go
@@ -1,0 +1,887 @@
+package semanticview
+
+import (
+	"sort"
+	"strings"
+
+	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
+	"github.com/division-sh/swarm/internal/runtime/core/eventidentity"
+)
+
+type ImportBoundaryWildcardPattern struct {
+	ParentPackageKey string
+	ChildPackageKey  string
+	ImportLabel      string
+	Source           string
+	EventPattern     string
+	MatchPattern     string
+	LocalizedEvent   string
+	RouteSource      string
+}
+
+type ImportBoundaryWildcardIssue struct {
+	Kind             string
+	ParentPackageKey string
+	ChildPackageKey  string
+	ImportLabel      string
+	Source           string
+	EventPattern     string
+	Message          string
+}
+
+type ImportBoundaryWildcardSubscriptionResolution struct {
+	Scoped   bool
+	Patterns []ImportBoundaryWildcardPattern
+}
+
+type importBoundaryWildcardScope struct {
+	Kind        string
+	ID          string
+	PackageKey  string
+	Path        string
+	LocalEvents map[string]struct{}
+}
+
+type importBoundaryWildcardGrantPattern struct {
+	ParentPackageKey string
+	ChildPackageKey  string
+	ImportLabel      string
+	Source           string
+	EventPattern     string
+	LocalizedEvent   string
+}
+
+func ResolveImportBoundaryWildcardSubscription(source Source, packageKey, flowID, basePath string, localEvents map[string]struct{}, raw string) ImportBoundaryWildcardSubscriptionResolution {
+	raw = eventidentity.Normalize(raw)
+	if source == nil || raw == "" || !strings.Contains(raw, "*") {
+		return ImportBoundaryWildcardSubscriptionResolution{}
+	}
+	packageKey = importBoundaryPackageKeyForContext(source, packageKey, flowID)
+	if !importBoundaryPackageImported(source, packageKey) {
+		return ImportBoundaryWildcardSubscriptionResolution{}
+	}
+	resolution := ImportBoundaryWildcardSubscriptionResolution{Scoped: true}
+	for _, pattern := range importBoundaryDefaultWildcardPatterns(source, packageKey, flowID, basePath, localEvents, raw) {
+		resolution.Patterns = appendUniqueImportBoundaryWildcardPattern(resolution.Patterns, pattern)
+	}
+	for _, grant := range importBoundaryWildcardGrantPatterns(source, packageKey) {
+		if !importBoundaryWildcardGrantIntersects(raw, grant.LocalizedEvent, grant.EventPattern) {
+			continue
+		}
+		resolution.Patterns = appendUniqueImportBoundaryWildcardPattern(resolution.Patterns, ImportBoundaryWildcardPattern{
+			ParentPackageKey: grant.ParentPackageKey,
+			ChildPackageKey:  grant.ChildPackageKey,
+			ImportLabel:      grant.ImportLabel,
+			Source:           grant.Source,
+			EventPattern:     grant.EventPattern,
+			MatchPattern:     raw,
+			LocalizedEvent:   grant.LocalizedEvent,
+			RouteSource:      "import_boundary_wildcard_grant",
+		})
+	}
+	sortImportBoundaryWildcardPatterns(resolution.Patterns)
+	return resolution
+}
+
+func ResolveImportBoundaryWildcardSubscriptionForNode(source Source, nodeID, raw string) ImportBoundaryWildcardSubscriptionResolution {
+	if source == nil {
+		return ImportBoundaryWildcardSubscriptionResolution{}
+	}
+	contractSource, ok := source.NodeContractSource(strings.TrimSpace(nodeID))
+	if !ok {
+		return ImportBoundaryWildcardSubscriptionResolution{}
+	}
+	return ResolveImportBoundaryWildcardSubscription(
+		source,
+		contractSource.PackageKey,
+		contractSource.FlowID,
+		importBoundaryBasePathForFlow(source, contractSource.FlowID),
+		importBoundaryNodeLocalEvents(source, nodeID, contractSource),
+		raw,
+	)
+}
+
+func ImportBoundaryWildcardSubscriptionMatches(source Source, packageKey, flowID, basePath string, localEvents map[string]struct{}, raw, eventType string) (bool, bool) {
+	eventType = eventidentity.Normalize(eventType)
+	if eventType == "" {
+		return false, false
+	}
+	resolution := ResolveImportBoundaryWildcardSubscription(source, packageKey, flowID, basePath, localEvents, raw)
+	if !resolution.Scoped {
+		return false, false
+	}
+	for _, pattern := range resolution.Patterns {
+		if eventidentity.MatchPattern(pattern.EventPattern, eventType) {
+			return true, true
+		}
+	}
+	return false, true
+}
+
+func ImportBoundaryWildcardSubscriptionMatchesNode(source Source, nodeID, raw, eventType string) (bool, bool) {
+	eventType = eventidentity.Normalize(eventType)
+	if eventType == "" {
+		return false, false
+	}
+	resolution := ResolveImportBoundaryWildcardSubscriptionForNode(source, nodeID, raw)
+	if !resolution.Scoped {
+		return false, false
+	}
+	for _, pattern := range resolution.Patterns {
+		if eventidentity.MatchPattern(pattern.EventPattern, eventType) {
+			return true, true
+		}
+	}
+	return false, true
+}
+
+func ImportBoundaryWildcardGrantIssues(source Source) []ImportBoundaryWildcardIssue {
+	if source == nil {
+		return nil
+	}
+	projectByKey, _ := importBoundaryScopeIndexes(source)
+	var issues []ImportBoundaryWildcardIssue
+	for _, parent := range source.ProjectScopes() {
+		parent.Key = normalizeImportPackageKey(parent.Key)
+		for _, site := range importBoundarySites(parent) {
+			if len(site.Bind.Observe) == 0 {
+				continue
+			}
+			child, ok := projectByKey[site.PackageKey]
+			if !ok {
+				continue
+			}
+			child.Key = normalizeImportPackageKey(child.Key)
+			for _, grant := range site.Bind.Observe {
+				issues = append(issues, importBoundaryWildcardGrantIssues(source, parent, child, site, grant)...)
+			}
+		}
+	}
+	sort.Slice(issues, func(i, j int) bool {
+		return strings.Compare(importBoundaryWildcardIssueSortKey(issues[i]), importBoundaryWildcardIssueSortKey(issues[j])) < 0
+	})
+	return issues
+}
+
+func ImportBoundaryWildcardSubscriptionIssues(source Source) []ImportBoundaryWildcardIssue {
+	if source == nil {
+		return nil
+	}
+	var issues []ImportBoundaryWildcardIssue
+	for _, scope := range source.ProjectScopes() {
+		packageKey := normalizeImportPackageKey(scope.Key)
+		if !importBoundaryPackageImported(source, packageKey) {
+			continue
+		}
+		for _, pattern := range importBoundaryProjectWildcardSubscriptions(scope) {
+			resolution := ResolveImportBoundaryWildcardSubscription(source, packageKey, "", "", importBoundaryProjectLocalEventSet(scope), pattern)
+			if resolution.Scoped && len(resolution.Patterns) == 0 {
+				issues = append(issues, ImportBoundaryWildcardIssue{
+					Kind:            "ungranted_or_unknown_subscription",
+					ChildPackageKey: packageKey,
+					EventPattern:    eventidentity.Normalize(pattern),
+					Message:         "imported-package wildcard subscription has no package-subtree candidate and no matching observe grant",
+				})
+			}
+		}
+	}
+	for _, scope := range source.FlowScopes() {
+		packageKey := normalizeImportPackageKey(scope.PackageKey)
+		if !importBoundaryPackageImported(source, packageKey) {
+			continue
+		}
+		localEvents := importBoundaryFlowLocalEventSet(source, scope)
+		for _, pattern := range importBoundaryFlowWildcardSubscriptions(scope) {
+			resolution := ResolveImportBoundaryWildcardSubscription(source, packageKey, scope.ID, importBoundaryBasePathForFlow(source, scope.ID), localEvents, pattern)
+			if resolution.Scoped && len(resolution.Patterns) == 0 {
+				issues = append(issues, ImportBoundaryWildcardIssue{
+					Kind:            "ungranted_or_unknown_subscription",
+					ChildPackageKey: packageKey,
+					EventPattern:    eventidentity.Normalize(pattern),
+					Message:         "imported-package wildcard subscription has no package-subtree candidate and no matching observe grant",
+				})
+			}
+		}
+	}
+	sort.Slice(issues, func(i, j int) bool {
+		return strings.Compare(importBoundaryWildcardIssueSortKey(issues[i]), importBoundaryWildcardIssueSortKey(issues[j])) < 0
+	})
+	return issues
+}
+
+func RuntimeEventOwners(source Source, eventType string) []string {
+	bundle, ok := Bundle(source)
+	if !ok || bundle == nil {
+		return nil
+	}
+	eventType = eventidentity.Normalize(eventType)
+	if eventType == "" {
+		return nil
+	}
+	owners := importBoundaryRuntimeDirectOwners(bundle, eventType)
+	for nodeID, handlers := range bundle.Semantics.NodeHandlers {
+		for pattern := range handlers {
+			pattern = eventidentity.Normalize(pattern)
+			if pattern == "" || !strings.Contains(pattern, "*") {
+				continue
+			}
+			matched, scoped := ImportBoundaryWildcardSubscriptionMatchesNode(source, nodeID, pattern, eventType)
+			if scoped {
+				if matched {
+					owners = appendUniqueStringLocal(owners, strings.TrimSpace(nodeID))
+				}
+				continue
+			}
+			nodeSource, _ := source.NodeContractSource(nodeID)
+			basePath := importBoundaryBasePathForFlow(source, nodeSource.FlowID)
+			localEvents := importBoundaryNodeLocalEvents(source, nodeID, nodeSource)
+			resolved := importBoundaryResolvePatternInScope(importBoundaryWildcardScope{
+				Path:        basePath,
+				LocalEvents: localEvents,
+			}, pattern)
+			if resolved == "" {
+				resolved = pattern
+			}
+			if eventidentity.MatchPattern(resolved, eventType) {
+				owners = appendUniqueStringLocal(owners, strings.TrimSpace(nodeID))
+			}
+		}
+	}
+	sort.Strings(owners)
+	return owners
+}
+
+func importBoundaryProjectWildcardSubscriptions(scope ProjectScope) []string {
+	seen := map[string]struct{}{}
+	appendPattern := func(pattern string) {
+		pattern = eventidentity.Normalize(pattern)
+		if pattern == "" || !strings.Contains(pattern, "*") {
+			return
+		}
+		seen[pattern] = struct{}{}
+	}
+	for _, entry := range scope.Agents {
+		for _, pattern := range append(append([]string{}, entry.Subscriptions...), entry.SubscribesTo...) {
+			appendPattern(pattern)
+		}
+	}
+	for _, entry := range scope.Nodes {
+		for _, pattern := range entry.SubscribesTo {
+			appendPattern(pattern)
+		}
+		for pattern := range entry.EventHandlers {
+			appendPattern(pattern)
+		}
+	}
+	return sortedStringSet(seen)
+}
+
+func importBoundaryFlowWildcardSubscriptions(scope FlowScope) []string {
+	seen := map[string]struct{}{}
+	appendPattern := func(pattern string) {
+		pattern = eventidentity.Normalize(pattern)
+		if pattern == "" || !strings.Contains(pattern, "*") {
+			return
+		}
+		seen[pattern] = struct{}{}
+	}
+	for _, pattern := range scope.InputEvents {
+		appendPattern(pattern)
+	}
+	for _, entry := range scope.Agents {
+		for _, pattern := range append(append([]string{}, entry.Subscriptions...), entry.SubscribesTo...) {
+			appendPattern(pattern)
+		}
+	}
+	for _, entry := range scope.Nodes {
+		for _, pattern := range entry.SubscribesTo {
+			appendPattern(pattern)
+		}
+		for pattern := range entry.EventHandlers {
+			appendPattern(pattern)
+		}
+	}
+	return sortedStringSet(seen)
+}
+
+func importBoundaryRuntimeDirectOwners(bundle *runtimecontracts.WorkflowContractBundle, eventType string) []string {
+	if bundle == nil {
+		return nil
+	}
+	if owners := bundle.Semantics.EventOwners[eventType]; len(owners) > 0 {
+		return append([]string{}, owners...)
+	}
+	if strings.Contains(eventType, "/") {
+		return nil
+	}
+	var matched []string
+	for canonical, owners := range bundle.Semantics.EventOwners {
+		canonical = eventidentity.Normalize(canonical)
+		if eventidentity.LeafName(canonical) != eventType {
+			continue
+		}
+		if matched != nil {
+			return nil
+		}
+		matched = append([]string{}, owners...)
+	}
+	return matched
+}
+
+func importBoundaryWildcardGrantIssues(source Source, parent, child ProjectScope, site importBoundarySite, grant runtimecontracts.FlowPackageObserveGrant) []ImportBoundaryWildcardIssue {
+	sourceRef := strings.TrimSpace(grant.Source)
+	base := ImportBoundaryWildcardIssue{
+		ParentPackageKey: parent.Key,
+		ChildPackageKey:  child.Key,
+		ImportLabel:      site.Label,
+		Source:           sourceRef,
+	}
+	if sourceRef == "" {
+		base.Kind = "empty_source"
+		base.Message = "observe grant source is required"
+		return []ImportBoundaryWildcardIssue{base}
+	}
+	if normalizeImportPackageKey(sourceRef) == "." {
+		base.Kind = "broad_source"
+		base.Message = "observe grant source must name a narrow parent-visible flow or package, not the root package"
+		return []ImportBoundaryWildcardIssue{base}
+	}
+	sourceScopes, kind, message := importBoundaryResolveWildcardGrantSource(source, parent, sourceRef)
+	if kind != "" {
+		base.Kind = kind
+		base.Message = message
+		return []ImportBoundaryWildcardIssue{base}
+	}
+	if len(grant.Events) == 0 {
+		base.Kind = "empty_events"
+		base.Message = "observe grant events list is required"
+		return []ImportBoundaryWildcardIssue{base}
+	}
+	var issues []ImportBoundaryWildcardIssue
+	for _, eventPattern := range grant.Events {
+		eventPattern = eventidentity.Normalize(eventPattern)
+		issue := base
+		issue.EventPattern = eventPattern
+		if eventPattern == "" {
+			issue.Kind = "empty_event_pattern"
+			issue.Message = "observe grant event pattern is required"
+			issues = append(issues, issue)
+			continue
+		}
+		if importBoundaryWildcardGrantPatternBroad(eventPattern) {
+			issue.Kind = "broad_event_pattern"
+			issue.Message = "observe grant event pattern must include a concrete event family, not an unbounded wildcard"
+			issues = append(issues, issue)
+			continue
+		}
+		if !importBoundaryGrantPatternMatchesKnownEvent(sourceScopes, eventPattern) {
+			issue.Kind = "unknown_event_pattern"
+			issue.Message = "observe grant event pattern does not match any event under the grant source"
+			issues = append(issues, issue)
+		}
+	}
+	return issues
+}
+
+func importBoundaryWildcardGrantPatterns(source Source, childPackageKey string) []importBoundaryWildcardGrantPattern {
+	childPackageKey = normalizeImportPackageKey(childPackageKey)
+	if source == nil || childPackageKey == "" {
+		return nil
+	}
+	projectByKey, _ := importBoundaryScopeIndexes(source)
+	var out []importBoundaryWildcardGrantPattern
+	for _, parent := range source.ProjectScopes() {
+		parent.Key = normalizeImportPackageKey(parent.Key)
+		for _, site := range importBoundarySites(parent) {
+			if !importBoundaryPackageInSubtree(childPackageKey, site.PackageKey) || len(site.Bind.Observe) == 0 {
+				continue
+			}
+			child, ok := projectByKey[site.PackageKey]
+			if !ok {
+				continue
+			}
+			child.Key = normalizeImportPackageKey(child.Key)
+			for _, grant := range site.Bind.Observe {
+				sourceScopes, kind, _ := importBoundaryResolveWildcardGrantSource(source, parent, grant.Source)
+				if kind != "" {
+					continue
+				}
+				for _, eventPattern := range grant.Events {
+					eventPattern = eventidentity.Normalize(eventPattern)
+					if eventPattern == "" || importBoundaryWildcardGrantPatternBroad(eventPattern) || !importBoundaryGrantPatternMatchesKnownEvent(sourceScopes, eventPattern) {
+						continue
+					}
+					for _, resolved := range importBoundaryResolveGrantPatterns(sourceScopes, eventPattern) {
+						out = append(out, importBoundaryWildcardGrantPattern{
+							ParentPackageKey: parent.Key,
+							ChildPackageKey:  child.Key,
+							ImportLabel:      site.Label,
+							Source:           strings.TrimSpace(grant.Source),
+							EventPattern:     resolved,
+							LocalizedEvent:   eventPattern,
+						})
+					}
+				}
+			}
+		}
+	}
+	sort.Slice(out, func(i, j int) bool {
+		return strings.Compare(importBoundaryWildcardGrantPatternSortKey(out[i]), importBoundaryWildcardGrantPatternSortKey(out[j])) < 0
+	})
+	return out
+}
+
+func importBoundaryDefaultWildcardPatterns(source Source, packageKey, flowID, basePath string, localEvents map[string]struct{}, raw string) []ImportBoundaryWildcardPattern {
+	var out []ImportBoundaryWildcardPattern
+	for _, scope := range importBoundaryDefaultWildcardScopes(source, packageKey, flowID, basePath, localEvents) {
+		pattern := importBoundaryResolvePatternInScope(scope, raw)
+		if pattern == "" || !importBoundaryWildcardPatternWithinScope(pattern, scope) {
+			continue
+		}
+		out = appendUniqueImportBoundaryWildcardPattern(out, ImportBoundaryWildcardPattern{
+			ChildPackageKey: packageKey,
+			EventPattern:    pattern,
+			MatchPattern:    raw,
+			LocalizedEvent:  raw,
+			RouteSource:     "import_boundary_wildcard_subtree",
+		})
+	}
+	return out
+}
+
+func importBoundaryDefaultWildcardScopes(source Source, packageKey, flowID, basePath string, localEvents map[string]struct{}) []importBoundaryWildcardScope {
+	packageKey = normalizeImportPackageKey(packageKey)
+	flowID = strings.TrimSpace(flowID)
+	basePath = eventidentity.Normalize(basePath)
+	if source == nil || packageKey == "" {
+		return nil
+	}
+	if flowID != "" {
+		if basePath == "" {
+			basePath = importBoundaryBasePathForFlow(source, flowID)
+		}
+		events := cloneImportBoundaryEventSet(localEvents)
+		if len(events) == 0 {
+			if scope, ok := source.FlowScopeByID(flowID); ok {
+				events = importBoundaryFlowLocalEventSet(source, scope)
+			}
+		}
+		return []importBoundaryWildcardScope{{
+			Kind:        "flow",
+			ID:          flowID,
+			PackageKey:  packageKey,
+			Path:        basePath,
+			LocalEvents: events,
+		}}
+	}
+	projectByKey, flowByPackage := importBoundaryScopeIndexes(source)
+	project := projectByKey[packageKey]
+	if owner := strings.TrimSpace(project.OwningFlowID); owner != "" {
+		events := cloneImportBoundaryEventSet(localEvents)
+		if len(events) == 0 {
+			events = importBoundaryProjectLocalEventSet(project)
+		}
+		return []importBoundaryWildcardScope{{
+			Kind:        "package",
+			ID:          packageKey,
+			PackageKey:  packageKey,
+			Path:        importBoundaryBasePathForFlow(source, owner),
+			LocalEvents: events,
+		}}
+	}
+	var out []importBoundaryWildcardScope
+	for key, flows := range flowByPackage {
+		if !importBoundaryPackageInSubtree(key, packageKey) {
+			continue
+		}
+		for _, flow := range flows {
+			out = append(out, importBoundaryWildcardScope{
+				Kind:        "flow",
+				ID:          strings.TrimSpace(flow.ID),
+				PackageKey:  normalizeImportPackageKey(flow.PackageKey),
+				Path:        importBoundaryBasePathForFlow(source, flow.ID),
+				LocalEvents: importBoundaryFlowLocalEventSet(source, flow),
+			})
+		}
+	}
+	sort.Slice(out, func(i, j int) bool {
+		return strings.Compare(out[i].Path+"|"+out[i].ID, out[j].Path+"|"+out[j].ID) < 0
+	})
+	return out
+}
+
+func importBoundaryResolveWildcardGrantSource(source Source, parent ProjectScope, raw string) ([]importBoundaryWildcardScope, string, string) {
+	raw = strings.TrimSpace(raw)
+	if source == nil || raw == "" {
+		return nil, "empty_source", "observe grant source is required"
+	}
+	parent.Key = normalizeImportPackageKey(parent.Key)
+	var matches [][]importBoundaryWildcardScope
+	for _, site := range importBoundarySites(parent) {
+		if strings.TrimSpace(site.FlowID) != raw {
+			continue
+		}
+		if flow, ok := source.FlowScopeByID(site.FlowID); ok {
+			matches = append(matches, []importBoundaryWildcardScope{{
+				Kind:        "flow",
+				ID:          strings.TrimSpace(flow.ID),
+				PackageKey:  normalizeImportPackageKey(site.PackageKey),
+				Path:        importBoundaryBasePathForFlow(source, flow.ID),
+				LocalEvents: importBoundaryFlowLocalEventSet(source, flow),
+			}})
+		}
+	}
+	for _, flow := range source.FlowScopes() {
+		if strings.TrimSpace(flow.ID) != raw {
+			continue
+		}
+		if !importBoundaryPackageInSubtree(flow.PackageKey, parent.Key) {
+			continue
+		}
+		matches = append(matches, []importBoundaryWildcardScope{{
+			Kind:        "flow",
+			ID:          strings.TrimSpace(flow.ID),
+			PackageKey:  normalizeImportPackageKey(flow.PackageKey),
+			Path:        importBoundaryBasePathForFlow(source, flow.ID),
+			LocalEvents: importBoundaryFlowLocalEventSet(source, flow),
+		}})
+	}
+	projectByKey, flowByPackage := importBoundaryScopeIndexes(source)
+	if project, ok := projectByKey[normalizeImportPackageKey(raw)]; ok && importBoundaryPackageInSubtree(project.Key, parent.Key) {
+		scopes := importBoundaryPackageWildcardScopes(source, project, flowByPackage)
+		if len(scopes) > 0 {
+			matches = append(matches, scopes)
+		}
+	}
+	switch len(matches) {
+	case 0:
+		return nil, "unknown_source", "observe grant source does not resolve to one parent-visible flow or package"
+	case 1:
+		return matches[0], "", ""
+	default:
+		return nil, "ambiguous_source", "observe grant source resolves to multiple parent-visible typed sources"
+	}
+}
+
+func importBoundaryPackageWildcardScopes(source Source, project ProjectScope, flowByPackage map[string][]FlowScope) []importBoundaryWildcardScope {
+	project.Key = normalizeImportPackageKey(project.Key)
+	if source == nil || project.Key == "" {
+		return nil
+	}
+	if owner := strings.TrimSpace(project.OwningFlowID); owner != "" {
+		return []importBoundaryWildcardScope{{
+			Kind:        "package",
+			ID:          project.Key,
+			PackageKey:  project.Key,
+			Path:        importBoundaryBasePathForFlow(source, owner),
+			LocalEvents: importBoundaryProjectLocalEventSet(project),
+		}}
+	}
+	var out []importBoundaryWildcardScope
+	for key, flows := range flowByPackage {
+		if !importBoundaryPackageInSubtree(key, project.Key) {
+			continue
+		}
+		for _, flow := range flows {
+			out = append(out, importBoundaryWildcardScope{
+				Kind:        "flow",
+				ID:          strings.TrimSpace(flow.ID),
+				PackageKey:  normalizeImportPackageKey(flow.PackageKey),
+				Path:        importBoundaryBasePathForFlow(source, flow.ID),
+				LocalEvents: importBoundaryFlowLocalEventSet(source, flow),
+			})
+		}
+	}
+	return out
+}
+
+func importBoundaryGrantPatternMatchesKnownEvent(scopes []importBoundaryWildcardScope, raw string) bool {
+	for _, scope := range scopes {
+		pattern := importBoundaryResolvePatternInScope(scope, raw)
+		if pattern == "" {
+			continue
+		}
+		for eventType := range scope.LocalEvents {
+			concrete := importBoundaryResolveEventInScope(scope, eventType)
+			if concrete != "" && eventidentity.MatchPattern(pattern, concrete) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func importBoundaryResolveGrantPatterns(scopes []importBoundaryWildcardScope, raw string) []string {
+	seen := map[string]struct{}{}
+	var out []string
+	for _, scope := range scopes {
+		pattern := importBoundaryResolvePatternInScope(scope, raw)
+		if pattern == "" {
+			continue
+		}
+		if _, ok := seen[pattern]; ok {
+			continue
+		}
+		seen[pattern] = struct{}{}
+		out = append(out, pattern)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func importBoundaryResolvePatternInScope(scope importBoundaryWildcardScope, raw string) string {
+	raw = eventidentity.Normalize(raw)
+	if raw == "" {
+		return ""
+	}
+	identityScope := rawWildcardScope(scope.Path, scope.LocalEvents)
+	pattern := eventidentity.Normalize(identityScope.ResolveSubscriptionPattern(raw, nil))
+	if pattern != "" && pattern != raw {
+		return pattern
+	}
+	if strings.Contains(raw, "/") || scope.Path == "" {
+		return pattern
+	}
+	for local := range scope.LocalEvents {
+		if eventidentity.MatchPattern(raw, local) {
+			return eventidentity.Normalize(scope.Path + "/" + raw)
+		}
+	}
+	return pattern
+}
+
+func importBoundaryResolveEventInScope(scope importBoundaryWildcardScope, raw string) string {
+	return eventidentity.Normalize(rawWildcardScope(scope.Path, scope.LocalEvents).ResolveEvent(raw, nil))
+}
+
+func rawWildcardScope(basePath string, localEvents map[string]struct{}) eventidentity.Scope {
+	return eventidentity.Scope{
+		Path:        eventidentity.Normalize(basePath),
+		LocalEvents: sortedStringSet(localEvents),
+	}
+}
+
+func importBoundaryWildcardGrantIntersects(raw, grantLocal, grantPattern string) bool {
+	raw = eventidentity.Normalize(raw)
+	grantLocal = eventidentity.Normalize(grantLocal)
+	grantPattern = eventidentity.Normalize(grantPattern)
+	if raw == "" {
+		return false
+	}
+	if grantLocal != "" && eventidentity.MatchPattern(raw, grantLocal) {
+		return true
+	}
+	if grantPattern != "" && eventidentity.MatchPattern(raw, grantPattern) {
+		return true
+	}
+	if leaf := eventidentity.LeafName(grantPattern); leaf != "" && eventidentity.MatchPattern(raw, leaf) {
+		return true
+	}
+	return false
+}
+
+func importBoundaryWildcardGrantPatternBroad(raw string) bool {
+	raw = eventidentity.Normalize(raw)
+	if raw == "" || raw == "*" || raw == "**" {
+		return true
+	}
+	leaf := strings.TrimSpace(eventidentity.LeafName(raw))
+	if leaf == "" || leaf == "*" || leaf == "**" {
+		return true
+	}
+	return strings.Trim(leaf, "*") == ""
+}
+
+func importBoundaryWildcardPatternWithinScope(pattern string, scope importBoundaryWildcardScope) bool {
+	pattern = eventidentity.Normalize(pattern)
+	base := eventidentity.Normalize(scope.Path)
+	if pattern == "" {
+		return false
+	}
+	if base == "" {
+		return !strings.Contains(pattern, "/")
+	}
+	return pattern == base || strings.HasPrefix(pattern, base+"/")
+}
+
+func importBoundaryPackageKeyForContext(source Source, packageKey, flowID string) string {
+	packageKey = normalizeImportPackageKey(packageKey)
+	if packageKey != "." || strings.TrimSpace(flowID) == "" || source == nil {
+		return packageKey
+	}
+	for _, parent := range source.ProjectScopes() {
+		for _, site := range importBoundarySites(parent) {
+			if strings.TrimSpace(site.FlowID) == strings.TrimSpace(flowID) {
+				return normalizeImportPackageKey(site.PackageKey)
+			}
+		}
+	}
+	if scope, ok := source.FlowScopeByID(flowID); ok {
+		return normalizeImportPackageKey(scope.PackageKey)
+	}
+	return packageKey
+}
+
+func importBoundaryPackageImported(source Source, packageKey string) bool {
+	packageKey = normalizeImportPackageKey(packageKey)
+	if source == nil || packageKey == "" || packageKey == "." {
+		return false
+	}
+	projectByKey, _ := importBoundaryScopeIndexes(source)
+	project, ok := projectByKey[packageKey]
+	return ok && project.Depth > 0
+}
+
+func importBoundaryPackageInSubtree(candidate, parent string) bool {
+	candidate = normalizeImportPackageKey(candidate)
+	parent = normalizeImportPackageKey(parent)
+	if candidate == "" || parent == "" {
+		return false
+	}
+	if parent == "." {
+		return candidate != "."
+	}
+	return candidate == parent || strings.HasPrefix(candidate, parent+"/")
+}
+
+func importBoundaryBasePathForFlow(source Source, flowID string) string {
+	flowID = strings.TrimSpace(flowID)
+	if source == nil || flowID == "" {
+		return ""
+	}
+	return eventidentity.Normalize(source.FlowPath(flowID))
+}
+
+func importBoundaryNodeLocalEvents(source Source, nodeID string, itemSource runtimecontracts.ContractItemSource) map[string]struct{} {
+	if source == nil {
+		return nil
+	}
+	if flowID := strings.TrimSpace(itemSource.FlowID); flowID != "" {
+		if flow, ok := source.FlowScopeByID(flowID); ok {
+			return importBoundaryFlowLocalEventSet(source, flow)
+		}
+	}
+	projectByKey, _ := importBoundaryScopeIndexes(source)
+	if project, ok := projectByKey[normalizeImportPackageKey(itemSource.PackageKey)]; ok {
+		return importBoundaryProjectLocalEventSet(project)
+	}
+	return nil
+}
+
+func importBoundaryFlowLocalEventSet(source Source, scope FlowScope) map[string]struct{} {
+	out := map[string]struct{}{}
+	for eventType := range scope.Events {
+		if eventType = eventidentity.Normalize(eventType); eventType != "" {
+			out[eventType] = struct{}{}
+		}
+	}
+	for _, eventType := range scope.OutputEvents {
+		if eventType = eventidentity.Normalize(eventType); eventType != "" {
+			out[eventType] = struct{}{}
+		}
+	}
+	for _, eventType := range scope.InputEvents {
+		eventType = eventidentity.Normalize(eventType)
+		if eventType == "" || importBoundaryFlowInputHasExternalProducer(source, scope.ID, eventType) {
+			continue
+		}
+		out[eventType] = struct{}{}
+	}
+	if autoEmit := eventidentity.Normalize(scope.AutoEmitEvent); autoEmit != "" {
+		out[autoEmit] = struct{}{}
+	}
+	return out
+}
+
+func importBoundaryFlowInputHasExternalProducer(source Source, flowID, eventType string) bool {
+	if source == nil || strings.TrimSpace(flowID) == "" || eventidentity.Normalize(eventType) == "" {
+		return false
+	}
+	return ImportBoundaryInputAliasRequired(source, flowID, eventType) || len(source.ResolveFlowInputAutoWire(flowID, eventType).Patterns) > 0
+}
+
+func importBoundaryProjectLocalEventSet(scope ProjectScope) map[string]struct{} {
+	out := map[string]struct{}{}
+	for eventType := range scope.Events {
+		if eventType = eventidentity.Normalize(eventType); eventType != "" {
+			out[eventType] = struct{}{}
+		}
+	}
+	return out
+}
+
+func cloneImportBoundaryEventSet(in map[string]struct{}) map[string]struct{} {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make(map[string]struct{}, len(in))
+	for key := range in {
+		if key = eventidentity.Normalize(key); key != "" {
+			out[key] = struct{}{}
+		}
+	}
+	return out
+}
+
+func appendUniqueImportBoundaryWildcardPattern(in []ImportBoundaryWildcardPattern, value ImportBoundaryWildcardPattern) []ImportBoundaryWildcardPattern {
+	value.EventPattern = eventidentity.Normalize(value.EventPattern)
+	if value.EventPattern == "" {
+		return in
+	}
+	for _, existing := range in {
+		if existing.EventPattern == value.EventPattern && existing.RouteSource == value.RouteSource && existing.Source == value.Source {
+			return in
+		}
+	}
+	return append(in, value)
+}
+
+func appendUniqueStringLocal(in []string, value string) []string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return in
+	}
+	for _, existing := range in {
+		if strings.TrimSpace(existing) == value {
+			return in
+		}
+	}
+	return append(in, value)
+}
+
+func sortImportBoundaryWildcardPatterns(values []ImportBoundaryWildcardPattern) {
+	sort.Slice(values, func(i, j int) bool {
+		return strings.Compare(importBoundaryWildcardPatternSortKey(values[i]), importBoundaryWildcardPatternSortKey(values[j])) < 0
+	})
+}
+
+func importBoundaryWildcardPatternSortKey(value ImportBoundaryWildcardPattern) string {
+	return strings.Join([]string{
+		value.RouteSource,
+		value.ParentPackageKey,
+		value.ChildPackageKey,
+		value.Source,
+		value.EventPattern,
+	}, "|")
+}
+
+func importBoundaryWildcardGrantPatternSortKey(value importBoundaryWildcardGrantPattern) string {
+	return strings.Join([]string{
+		value.ParentPackageKey,
+		value.ChildPackageKey,
+		value.ImportLabel,
+		value.Source,
+		value.EventPattern,
+	}, "|")
+}
+
+func importBoundaryWildcardIssueSortKey(issue ImportBoundaryWildcardIssue) string {
+	return strings.Join([]string{
+		issue.Kind,
+		issue.ParentPackageKey,
+		issue.ChildPackageKey,
+		issue.ImportLabel,
+		issue.Source,
+		issue.EventPattern,
+	}, "|")
+}

--- a/internal/runtime/semanticview/import_boundary_wildcards.go
+++ b/internal/runtime/semanticview/import_boundary_wildcards.go
@@ -517,14 +517,27 @@ func importBoundaryResolveWildcardGrantSource(source Source, parent ProjectScope
 	}
 	parent.Key = normalizeImportPackageKey(parent.Key)
 	var matches [][]importBoundaryWildcardScope
+	seenMatches := map[string]struct{}{}
+	appendMatch := func(key string, scopes []importBoundaryWildcardScope) {
+		key = strings.TrimSpace(key)
+		if key == "" || len(scopes) == 0 {
+			return
+		}
+		if _, ok := seenMatches[key]; ok {
+			return
+		}
+		seenMatches[key] = struct{}{}
+		matches = append(matches, scopes)
+	}
 	for _, site := range importBoundarySites(parent) {
 		if strings.TrimSpace(site.FlowID) != raw {
 			continue
 		}
 		if flow, ok := source.FlowScopeByID(site.FlowID); ok {
-			matches = append(matches, []importBoundaryWildcardScope{{
+			flowID := strings.TrimSpace(flow.ID)
+			appendMatch("flow:"+flowID, []importBoundaryWildcardScope{{
 				Kind:        "flow",
-				ID:          strings.TrimSpace(flow.ID),
+				ID:          flowID,
 				PackageKey:  normalizeImportPackageKey(site.PackageKey),
 				Path:        importBoundaryBasePathForFlow(source, flow.ID),
 				LocalEvents: importBoundaryFlowLocalEventSet(source, flow),
@@ -538,9 +551,10 @@ func importBoundaryResolveWildcardGrantSource(source Source, parent ProjectScope
 		if !importBoundaryPackageInSubtree(flow.PackageKey, parent.Key) {
 			continue
 		}
-		matches = append(matches, []importBoundaryWildcardScope{{
+		flowID := strings.TrimSpace(flow.ID)
+		appendMatch("flow:"+flowID, []importBoundaryWildcardScope{{
 			Kind:        "flow",
-			ID:          strings.TrimSpace(flow.ID),
+			ID:          flowID,
 			PackageKey:  normalizeImportPackageKey(flow.PackageKey),
 			Path:        importBoundaryBasePathForFlow(source, flow.ID),
 			LocalEvents: importBoundaryFlowLocalEventSet(source, flow),
@@ -550,7 +564,7 @@ func importBoundaryResolveWildcardGrantSource(source Source, parent ProjectScope
 	if project, ok := projectByKey[normalizeImportPackageKey(raw)]; ok && importBoundaryPackageInSubtree(project.Key, parent.Key) {
 		scopes := importBoundaryPackageWildcardScopes(source, project, flowByPackage)
 		if len(scopes) > 0 {
-			matches = append(matches, scopes)
+			appendMatch("package:"+normalizeImportPackageKey(project.Key), scopes)
 		}
 	}
 	switch len(matches) {

--- a/internal/runtime/semanticview/import_boundary_wildcards.go
+++ b/internal/runtime/semanticview/import_boundary_wildcards.go
@@ -135,6 +135,55 @@ func ImportBoundaryWildcardSubscriptionMatchesNode(source Source, nodeID, raw, e
 	return false, true
 }
 
+func ImportBoundaryWildcardHandlerFallbackDenied(source Source, nodeID, eventType string) bool {
+	if source == nil {
+		return false
+	}
+	bundle, ok := Bundle(source)
+	if !ok || bundle == nil {
+		return false
+	}
+	resolved := bundle.ResolveNodeEventHandler(nodeID, eventType)
+	authoredEventType := eventidentity.Normalize(resolved.AuthoredEventType)
+	if !resolved.Matched || authoredEventType == "" || !strings.Contains(authoredEventType, "*") {
+		return false
+	}
+
+	scoped := false
+	for _, candidate := range importBoundaryHandlerResolutionEventCandidates(resolved, eventType) {
+		matched, candidateScoped := ImportBoundaryWildcardSubscriptionMatchesNode(source, nodeID, authoredEventType, candidate)
+		if !candidateScoped {
+			continue
+		}
+		scoped = true
+		if matched {
+			return false
+		}
+	}
+	return scoped
+}
+
+func importBoundaryHandlerResolutionEventCandidates(resolved runtimecontracts.NodeEventHandlerResolution, eventType string) []string {
+	seen := map[string]struct{}{}
+	var out []string
+	appendCandidate := func(candidate string) {
+		candidate = eventidentity.Normalize(candidate)
+		if candidate == "" {
+			return
+		}
+		if _, ok := seen[candidate]; ok {
+			return
+		}
+		seen[candidate] = struct{}{}
+		out = append(out, candidate)
+	}
+	appendCandidate(eventType)
+	appendCandidate(resolved.RawEventType)
+	appendCandidate(resolved.LocalizedEventType)
+	appendCandidate(resolved.CanonicalEventType)
+	return out
+}
+
 func ImportBoundaryWildcardGrantIssues(source Source) []ImportBoundaryWildcardIssue {
 	if source == nil {
 		return nil

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -4998,7 +4998,9 @@ flow_model:
           RouteTable static derivation, template-instance route materialization, EventBus recipient planning/persistence,
           runtime owner lookup, workflow-node handler lookup, and boot verification must consume this same resolver.
           Low-level event identity wildcard matching remains only the primitive matcher inside the candidate set supplied
-          by this resolver; it is not package-boundary authority.
+          by this resolver; it is not package-boundary authority. If this resolver scopes an imported-package wildcard
+          handler and denies a concrete event, raw bundle/contract handler fallback must not resurrect that handler for
+          delivery, replay, direct execution, preview/admission, or accumulator metadata.
         non_import_behavior: >
           Root and non-imported flow wildcard subscriptions keep their existing wildcard route behavior. Target and
           target_set delivery narrowing still applies after the scoped wildcard candidate is produced; wildcard grants

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -4957,8 +4957,53 @@ flow_model:
           Runtime consumers must use the shared import-boundary alias resolver; local helpers must not independently
           reinterpret package-local pins, parent event names, or raw same-name fallback for declared imported package
           pins.
+      wildcard_subscription_scope:
+        owner: Runtime import-boundary wildcard scope/grant resolver over semanticview ProjectScopes, FlowScopes, and
+          parent import-site `bind.observe` grants.
+        default_scope: >
+          A wildcard subscription authored inside an imported package is scoped to that imported package subtree by
+          default. The candidate set includes events from the imported package's own flow/package subtree, including
+          materialized template instances for that imported package. The candidate set does not include sibling package
+          events merely because the raw event name matches `*`, `**`, or an unqualified local wildcard such as
+          `task.*`.
+        import_site_grants:
+          field: bind.observe
+          shape: >
+            `bind.observe` is a list of narrow observation grants on the parent package.yaml import-site entry. Each
+            grant MUST name a parent-visible typed `source` and an `events` list. `source` resolves to exactly one
+            parent-visible flow import ID or package key. Each event pattern is evaluated relative to that source and
+            intersected with the imported package's authored wildcard subscription before the event becomes a route
+            candidate.
+          example: |
+            flows:
+              - id: observer
+                flow: observer
+                bind:
+                  observe:
+                    - source: producer
+                      events: [task.done]
+              - id: producer
+                flow: producer
+          forbidden_compatibility_shapes: >
+            Broad compatibility grants such as observe-all, all-siblings, global/root observation, or raw path-prefix
+            fallbacks are not valid authority. A grant source must resolve through import/flow/package metadata, not
+            through string prefix matching alone.
+        fail_closed: >
+          Verify/boot and runtime route derivation must use the shared import-boundary wildcard resolver. A grant with
+          an empty, unknown, ambiguous, root/global, or non-parent-visible source is hard invalid. A grant with an empty,
+          unknown, malformed, or unbounded event pattern such as `*` or `**` is hard invalid. An imported package
+          wildcard subscription that has no package-subtree candidate and no matching explicit observe grant is hard
+          invalid and must not fall back to global wildcard matching.
+        runtime_parity: >
+          RouteTable static derivation, template-instance route materialization, EventBus recipient planning/persistence,
+          runtime owner lookup, workflow-node handler lookup, and boot verification must consume this same resolver.
+          Low-level event identity wildcard matching remains only the primitive matcher inside the candidate set supplied
+          by this resolver; it is not package-boundary authority.
+        non_import_behavior: >
+          Root and non-imported flow wildcard subscriptions keep their existing wildcard route behavior. Target and
+          target_set delivery narrowing still applies after the scoped wildcard candidate is produced; wildcard grants
+          do not override delivery target filtering.
       split_runtime_semantics:
-        wildcard_grants: Wildcard subtree and cross-tree grant behavior is tracked separately by #1454.
         final_e2e_package_proof: Final multi-package marketplace-style runtime proof is tracked separately by #1455.
     composition_routing:
       status: source_authority_promoted_runtime_migration_pending


### PR DESCRIPTION
## Summary

Closes #1454.

This PR makes imported-package authored wildcard subscriptions package-subtree-scoped by default and admits sibling/cross-tree wildcard observation only through a narrow parent import-site `bind.observe` grant.

## Governing refs / context

- `platform-spec.yaml#flow_model.flow_package.import_boundary.wildcard_subscription_scope`
- `platform-spec.yaml#flow_model.flow_package.import_boundary.import_site_bind`
- `platform-spec.yaml#flow_model.uri_addressing.wildcards`
- `platform-spec.yaml#flow_model.dynamic_instance_lifecycle.wildcard_subscriptions`
- `platform-spec.yaml#flow_model.cross_flow_routing.delivery_filter`
- Binding issue/gate context: #1454 pre-audit and Gate A approval.

## Semantic migration

- New canonical owner: semanticview import-boundary wildcard scope/grant resolver over `ProjectScopes`, `FlowScopes`, and import-site `bind.observe`.
- New authored surface: `bind.observe: [{source, events}]` on parent import-site entries.
- Old invalid paths: raw imported-package `*` / `**` global matching, route-table-only wildcard lowering, raw `RuntimeEventOwners` wildcard owner matching, and workflow handler/subscription lookup that bypasses import-boundary scope.
- Production paths checked/moved: bootverify event proof, RouteTable static derivation, template `AddFlowInstanceRoute`, EventBus recipient planning/persistence, runtime owner lookup, workflow-node subscription materialization, and handler lookup.
- Migration completeness: complete for #1454 chosen class. #1450 remains open only for #1455 final package fixture/parent closeout.

## Verification

- `go test ./internal/runtime/contracts ./internal/runtime/semanticview ./internal/runtime/bootverify ./internal/runtime/bus ./internal/runtime/pipeline ./internal/runtime/cataloge2e ./internal/runtime/core/eventidentity -count=1`
- `go test ./internal/runtime/bus -run 'ImportBoundaryWildcard|ConnectRoutePlanPersistsIndexedBusinessFieldTarget|ConnectRoutePlanPersistsIndexedBusinessFieldTargetSet' -count=1`
- `go test ./...`