### PR TITLE
[agent-e][issue #1443] Encode HTTP tool URL templates

### DIFF
--- a/internal/runtime/tools/executor_http.go
+++ b/internal/runtime/tools/executor_http.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"regexp"
 	"strconv"
 	"strings"
@@ -38,11 +39,11 @@ func (e *Executor) execHTTPTool(ctx context.Context, actor models.AgentConfig, t
 		"credentials": credentials,
 	}
 
-	urlValue, err := resolveTemplateValue(tool.HTTP.URL, templateEnv)
+	resolvedURL, err := resolveHTTPURLTemplate(tool.HTTP.URL, templateEnv)
 	if err != nil {
 		return nil, err
 	}
-	url := strings.TrimSpace(asString(urlValue))
+	url := strings.TrimSpace(resolvedURL)
 	if url == "" {
 		return nil, fmt.Errorf("http tool %s resolved an empty url", tool.Name)
 	}
@@ -263,6 +264,51 @@ func resolveTemplateValue(raw string, env map[string]any) (any, error) {
 	}
 	builder.WriteString(raw[last:])
 	return builder.String(), nil
+}
+
+func resolveHTTPURLTemplate(raw string, env map[string]any) (string, error) {
+	matches := toolTemplatePattern.FindAllStringSubmatchIndex(raw, -1)
+	if len(matches) == 0 {
+		return raw, nil
+	}
+	if len(matches) == 1 && matches[0][0] == 0 && matches[0][1] == len(raw) {
+		path := strings.TrimSpace(raw[matches[0][2]:matches[0][3]])
+		value, err := lookupTemplatePath(env, path)
+		if err != nil {
+			return "", err
+		}
+		return asString(value), nil
+	}
+	var builder strings.Builder
+	last := 0
+	for _, match := range matches {
+		builder.WriteString(raw[last:match[0]])
+		path := strings.TrimSpace(raw[match[2]:match[3]])
+		value, err := lookupTemplatePath(env, path)
+		if err != nil {
+			return "", err
+		}
+		builder.WriteString(escapeHTTPURLTemplateComponent(raw, match[0], asString(value)))
+		last = match[1]
+	}
+	builder.WriteString(raw[last:])
+	return builder.String(), nil
+}
+
+func escapeHTTPURLTemplateComponent(raw string, offset int, value string) string {
+	if httpURLTemplateOffsetInQuery(raw, offset) {
+		return strings.ReplaceAll(url.QueryEscape(value), "+", "%20")
+	}
+	return url.PathEscape(value)
+}
+
+func httpURLTemplateOffsetInQuery(raw string, offset int) bool {
+	queryStart := strings.Index(raw, "?")
+	if queryStart < 0 || queryStart > offset {
+		return false
+	}
+	fragmentStart := strings.Index(raw, "#")
+	return fragmentStart < 0 || offset < fragmentStart
 }
 
 func lookupTemplatePath(env map[string]any, path string) (any, error) {

--- a/internal/runtime/tools/executor_http.go
+++ b/internal/runtime/tools/executor_http.go
@@ -288,16 +288,19 @@ func resolveHTTPURLTemplate(raw string, env map[string]any) (string, error) {
 		if err != nil {
 			return "", err
 		}
-		builder.WriteString(escapeHTTPURLTemplateComponent(raw, match[0], asString(value)))
+		builder.WriteString(escapeHTTPURLTemplateComponent(raw, match[0], match[1], asString(value)))
 		last = match[1]
 	}
 	builder.WriteString(raw[last:])
 	return builder.String(), nil
 }
 
-func escapeHTTPURLTemplateComponent(raw string, offset int, value string) string {
-	if httpURLTemplateOffsetInQuery(raw, offset) {
+func escapeHTTPURLTemplateComponent(raw string, start, end int, value string) string {
+	if httpURLTemplateOffsetInQuery(raw, start) {
 		return strings.ReplaceAll(url.QueryEscape(value), "+", "%20")
+	}
+	if httpURLTemplatePlaceholderInURLBaseOrAuthority(raw, start, end, value) {
+		return value
 	}
 	return url.PathEscape(value)
 }
@@ -309,6 +312,31 @@ func httpURLTemplateOffsetInQuery(raw string, offset int) bool {
 	}
 	fragmentStart := strings.Index(raw, "#")
 	return fragmentStart < 0 || offset < fragmentStart
+}
+
+func httpURLTemplatePlaceholderInURLBaseOrAuthority(raw string, start, end int, value string) bool {
+	prefix := raw[:start]
+	suffix := raw[end:]
+	if strings.HasPrefix(suffix, "://") {
+		return true
+	}
+	if strings.HasSuffix(prefix, "://") {
+		return true
+	}
+	schemeIndex := strings.LastIndex(prefix, "://")
+	if schemeIndex >= 0 {
+		authorityPrefix := prefix[schemeIndex+len("://"):]
+		return !strings.ContainsAny(authorityPrefix, "/?#")
+	}
+	if start == 0 {
+		return httpURLTemplateValueHasSchemeAuthority(value)
+	}
+	return false
+}
+
+func httpURLTemplateValueHasSchemeAuthority(value string) bool {
+	parsed, err := url.Parse(strings.TrimSpace(value))
+	return err == nil && parsed.Scheme != "" && parsed.Host != ""
 }
 
 func lookupTemplatePath(env map[string]any, path string) (any, error) {

--- a/internal/runtime/tools/executor_native.go
+++ b/internal/runtime/tools/executor_native.go
@@ -225,11 +225,11 @@ func (e *Executor) executeCustomWebSearch(ctx context.Context, cfg webSearchProv
 		},
 		"credentials": credentials,
 	}
-	urlValue, err := resolveTemplateValue(cfg.HTTP.URL, templateEnv)
+	resolvedURL, err := resolveHTTPURLTemplate(cfg.HTTP.URL, templateEnv)
 	if err != nil {
 		return nil, err
 	}
-	url := strings.TrimSpace(asString(urlValue))
+	url := strings.TrimSpace(resolvedURL)
 	headers := make(http.Header, len(cfg.HTTP.Headers))
 	for key, value := range cfg.HTTP.Headers {
 		resolved, err := resolveTemplateValue(value, templateEnv)

--- a/internal/runtime/tools/tool_model_test.go
+++ b/internal/runtime/tools/tool_model_test.go
@@ -174,6 +174,50 @@ func TestResolveHTTPURLTemplatePreservesCompleteURL(t *testing.T) {
 	}
 }
 
+func TestResolveHTTPURLTemplatePreservesURLBaseAndAuthorityPlaceholders(t *testing.T) {
+	env := map[string]any{
+		"credentials": map[string]any{
+			"base_url": "https://api.example.com:8443",
+		},
+		"input": map[string]any{
+			"scheme": "https",
+			"host":   "api.example.com:8443",
+			"query":  "agentic orchestration",
+		},
+	}
+	for _, tt := range []struct {
+		name string
+		raw  string
+		want string
+	}{
+		{
+			name: "base URL placeholder with fixed path",
+			raw:  "{{credentials.base_url}}/v1/search?q={{input.query}}",
+			want: "https://api.example.com:8443/v1/search?q=agentic%20orchestration",
+		},
+		{
+			name: "scheme placeholder",
+			raw:  "{{input.scheme}}://api.example.com/v1/search?q={{input.query}}",
+			want: "https://api.example.com/v1/search?q=agentic%20orchestration",
+		},
+		{
+			name: "authority placeholder",
+			raw:  "https://{{input.host}}/v1/search?q={{input.query}}",
+			want: "https://api.example.com:8443/v1/search?q=agentic%20orchestration",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := resolveHTTPURLTemplate(tt.raw, env)
+			if err != nil {
+				t.Fatalf("resolveHTTPURLTemplate: %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("resolved URL = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestExecutor_CustomWebSearchEncodesHTTPURLTemplateComponents(t *testing.T) {
 	query := `to:karpathy (agent OR "agentic")`
 	var sawEscapedPath string

--- a/internal/runtime/tools/tool_model_test.go
+++ b/internal/runtime/tools/tool_model_test.go
@@ -3,6 +3,7 @@ package tools
 import (
 	"context"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -79,6 +80,140 @@ func TestExecutor_HTTPToolExecutesTemplateAndResponseMapping(t *testing.T) {
 	}
 	if got, ok := result["status"].(int); !ok || got != 200 {
 		t.Fatalf("status = %#v, want 200", result["status"])
+	}
+}
+
+func TestExecutor_HTTPToolEncodesURLTemplateComponentsAndPreservesRawHeaderBody(t *testing.T) {
+	query := `to:karpathy (agent OR "agentic")`
+	var sawEscapedPath string
+	var sawRawQuery string
+	var sawHeader string
+	var sawBody map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		sawEscapedPath = r.URL.EscapedPath()
+		sawRawQuery = r.URL.RawQuery
+		sawHeader = r.Header.Get("X-Search-Query")
+		rawBody, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("ReadAll body: %v", err)
+		}
+		if err := json.Unmarshal(rawBody, &sawBody); err != nil {
+			t.Fatalf("Unmarshal body %s: %v", rawBody, err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"ok": true})
+	}))
+	defer server.Close()
+
+	source := semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
+		Tools: map[string]runtimecontracts.ToolSchemaEntry{
+			"x_search_tweets": {
+				Description: "Search X tweets",
+				HandlerType: "http",
+				InputSchema: runtimecontracts.ToolInputSchema{
+					Type:     "object",
+					Required: []string{"segment", "query", "cursor"},
+					Properties: map[string]runtimecontracts.ToolInputSchema{
+						"segment": {Type: "string"},
+						"query":   {Type: "string"},
+						"cursor":  {Type: "string"},
+					},
+				},
+				HTTP: &runtimecontracts.HTTPToolSpec{
+					Method: "POST",
+					URL:    server.URL + "/profiles/{{input.segment}}/search?q={{input.query}}&cursor={{input.cursor}}",
+					Headers: map[string]string{
+						"X-Search-Query": "raw {{input.query}}",
+					},
+					Body: map[string]any{
+						"query": "{{input.query}}",
+					},
+				},
+			},
+		},
+	})
+
+	exec := NewExecutorWithOptions(nil, nil, ExecutorOptions{WorkflowSource: source})
+	ctx := models.WithActor(context.Background(), models.AgentConfig{
+		ID:    "agent-1",
+		Tools: []string{"x_search_tweets"},
+	})
+	if _, err := exec.Execute(ctx, "x_search_tweets", map[string]any{
+		"segment": "team/a b",
+		"query":   query,
+		"cursor":  "page 1",
+	}); err != nil {
+		t.Fatalf("Execute(x_search_tweets): %v", err)
+	}
+	if want := "/profiles/team%2Fa%20b/search"; sawEscapedPath != want {
+		t.Fatalf("escaped path = %q, want %q", sawEscapedPath, want)
+	}
+	if want := "q=to%3Akarpathy%20%28agent%20OR%20%22agentic%22%29&cursor=page%201"; sawRawQuery != want {
+		t.Fatalf("raw query = %q, want %q", sawRawQuery, want)
+	}
+	if want := "raw " + query; sawHeader != want {
+		t.Fatalf("header = %q, want %q", sawHeader, want)
+	}
+	if got := sawBody["query"]; got != query {
+		t.Fatalf("body query = %#v, want %q", got, query)
+	}
+}
+
+func TestResolveHTTPURLTemplatePreservesCompleteURL(t *testing.T) {
+	want := "https://example.test/search?q=to%3Akarpathy%20%28agent%29"
+	got, err := resolveHTTPURLTemplate("{{input.url}}", map[string]any{
+		"input": map[string]any{
+			"url": want,
+		},
+	})
+	if err != nil {
+		t.Fatalf("resolveHTTPURLTemplate: %v", err)
+	}
+	if got != want {
+		t.Fatalf("resolved URL = %q, want %q", got, want)
+	}
+}
+
+func TestExecutor_CustomWebSearchEncodesHTTPURLTemplateComponents(t *testing.T) {
+	query := `to:karpathy (agent OR "agentic")`
+	var sawEscapedPath string
+	var sawRawQuery string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		sawEscapedPath = r.URL.EscapedPath()
+		sawRawQuery = r.URL.RawQuery
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"results": []map[string]any{
+				{"title": "hit", "url": "https://example.test/hit", "snippet": "body"},
+			},
+		})
+	}))
+	defer server.Close()
+
+	exec := NewExecutorWithOptions(nil, nil, ExecutorOptions{})
+	results, err := exec.executeCustomWebSearch(context.Background(), webSearchProviderConfig{
+		HTTP: &runtimecontracts.HTTPToolSpec{
+			Method: "GET",
+			URL:    server.URL + "/search/{{input.max_results}}?q={{input.query}}",
+		},
+		ResponsePath: "results",
+		FieldMapping: map[string]string{
+			"title":   "title",
+			"url":     "url",
+			"snippet": "snippet",
+		},
+	}, query, 20, "")
+	if err != nil {
+		t.Fatalf("executeCustomWebSearch: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("results = %#v, want one result", results)
+	}
+	if want := "/search/20"; sawEscapedPath != want {
+		t.Fatalf("escaped path = %q, want %q", sawEscapedPath, want)
+	}
+	if want := "q=to%3Akarpathy%20%28agent%20OR%20%22agentic%22%29"; sawRawQuery != want {
+		t.Fatalf("raw query = %q, want %q", sawRawQuery, want)
 	}
 }
 

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -4682,6 +4682,8 @@ tool_model:
           url: string — URL template. Supports {{input.field_name}} substitution. Embedded substitutions inside the
             URL are percent-encoded as URL components by the runtime before request construction. Query-component
             substitutions encode spaces as `%20`, not `+`; path-component substitutions are escaped as path segments.
+            Substitutions that provide the URL scheme, authority, or an absolute base URL are preserved as URL syntax rather
+            than path-escaped.
             If the full url value is exactly one template variable, for example `{{input.url}}`, the resolved value is
             treated as a complete URL and is not component-encoded.
         optional:

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -4679,7 +4679,11 @@ tool_model:
       http_block:
         required:
           method: string — GET | POST | PUT | PATCH | DELETE
-          url: string — URL template. Supports {{input.field_name}} substitution.
+          url: string — URL template. Supports {{input.field_name}} substitution. Embedded substitutions inside the
+            URL are percent-encoded as URL components by the runtime before request construction. Query-component
+            substitutions encode spaces as `%20`, not `+`; path-component substitutions are escaped as path segments.
+            If the full url value is exactly one template variable, for example `{{input.url}}`, the resolved value is
+            treated as a complete URL and is not component-encoded.
         optional:
           headers: object — header name to value template. Supports {{credentials.key}} and {{input.field_name}} substitution.
           body: object — request body template. Same substitution. Sent as JSON.
@@ -4692,7 +4696,9 @@ tool_model:
         credentials: list of strings — credential store key names this tool needs. The platform resolves them from the credential
           store at call time and makes them available as {{credentials.key}} in templates.
     template_resolution:
-      description: Template variables in url, headers, body, and response_mapping are resolved at tool call time.
+      description: Template variables in url, headers, body, and response_mapping are resolved at tool call time. URL
+        template resolution is context-aware and performs URL-component percent-encoding for embedded substitutions;
+        headers, body, and response_mapping resolve raw semantic values.
       variables:
         input: Tool call arguments from the agent. Accessed as {{input.field_name}}.
         credentials: Values from the credential store for keys listed in the tool's credentials field. Accessed as {{credentials.key_name}}.


### PR DESCRIPTION
## Summary

- Adds a URL-aware HTTPToolSpec URL resolver for embedded URL template substitutions.
- Routes both generic `handler_type: http` execution and custom policy web-search HTTP provider URLs through that resolver.
- Preserves complete-URL passthrough, scheme/authority/base-URL placeholders, and raw header/body/response mapping substitutions.
- Updates root `platform-spec.yaml` with the authoritative URL template encoding semantics.

Closes #1443

## Governing Refs / Context

Exact spec refs updated in this PR:

- `platform-spec.yaml` `tool_model.http_tool_definition.schema.http_block.url`
- `platform-spec.yaml` `tool_model.http_tool_definition.template_resolution`

Binding issue/gate context:

- #1443 issue body and reproduction.
- #1443 Pre-Implementation Coverage Audit.
- #1443 independent gate outcome: approved for `runtime.http_tool_url_template_component_encoding`, with required coverage for generic HTTP tools, custom web-search HTTP provider, full-URL passthrough, path/query component escaping, raw headers/body preservation, and root spec update.
- PR review feedback on #1513 requiring scheme/authority/base-URL placeholders such as `{{credentials.base_url}}/v1/search?q={{input.query}}` to remain URL syntax rather than being path-escaped.

## Semantic Migration

New canonical owner:

- `internal/runtime/tools.resolveHTTPURLTemplate`, with `escapeHTTPURLTemplateComponent` owning embedded URL component escaping and URL-syntax preservation.

Old non-authoritative path now invalid:

- `resolveTemplateValue` as the direct resolver for `HTTPToolSpec.http.url` embedded values. It remains valid for raw semantic template contexts: headers, JSON bodies, and response mappings.

Production paths checked for surviving old behavior:

- `execHTTPTool` now consumes the URL-aware owner.
- `executeCustomWebSearch` now consumes the same URL-aware owner.
- Header substitution remains raw through `resolveTemplateValue`.
- Body substitution remains raw through `resolveTemplateTree` / `resolveTemplateValue`.
- Response mapping remains raw through `resolveTemplateTree` / `resolveTemplateValue`.
- Full URL, scheme, authority, and absolute base URL placeholders remain URL syntax rather than path-escaped.
- Native Brave search remains a hardcoded provider URL builder and is not the canonical HTTPToolSpec owner.
- CLI provider-native `native_tools.web_search`, MCP URL policy substitution, and prompt templating remain separate concepts.

Migration completeness:

- Complete for the chosen class `runtime.http_tool_url_template_component_encoding`: all known HTTPToolSpec URL construction consumers now use the canonical URL-aware owner.

## Tests

Latest focused proof after review fix:

- `go test ./internal/runtime/tools -run 'TestExecutor_HTTPToolEncodesURLTemplateComponentsAndPreservesRawHeaderBody|TestResolveHTTPURLTemplatePreservesCompleteURL|TestResolveHTTPURLTemplatePreservesURLBaseAndAuthorityPlaceholders|TestExecutor_CustomWebSearchEncodesHTTPURLTemplateComponents' -count=1`
- `go test ./internal/runtime/tools -count=1`
- `go test ./internal/apispec -count=1`

Whole-suite status:

- `go test ./...` passed on the initial implementation commit `7320e4b8e85a4ab0936a4fa723437798d43f601f`.
- After the review-fix commit `28731310cd6a4463a37271de857d1ee323bf7aab`, rerunning `go test ./...` failed in unrelated runtime timing/database-closed tests outside this PR's touched surface: `internal/apiv1`, `internal/runtime`, and `internal/runtime/cataloge2e`. The touched packages `internal/runtime/tools` and `internal/apispec` passed after the review fix.