### PR TITLE
[agent-c][issue #1511] Replace test event fixtures with typed builders

### DIFF
--- a/cmd/swarm/main_test.go
+++ b/cmd/swarm/main_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/division-sh/swarm/internal/apiv1"
 	"github.com/division-sh/swarm/internal/config"
 	"github.com/division-sh/swarm/internal/events"
+	"github.com/division-sh/swarm/internal/events/eventtest"
 	runtimepkg "github.com/division-sh/swarm/internal/runtime"
 	runtimebus "github.com/division-sh/swarm/internal/runtime/bus"
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
@@ -107,10 +108,11 @@ func (a delayedRunStatusAgent) OnEvent(ctx context.Context, evt events.Event) ([
 	case <-ctx.Done():
 		return nil, ctx.Err()
 	}
-	out := (events.NewProjectionEvent(uuid.NewString(),
+	out := eventtest.WithEntityID((eventtest.Projection(uuid.NewString(),
 
 		events.EventType("scan.completed"),
-		a.id, "", []byte(`{}`), 0, evt.RunID(), "", events.EventEnvelope{}, time.Now().UTC())).WithEntityID(evt.EntityID())
+		a.id, "", []byte(`{}`), 0, evt.RunID(), "", events.EventEnvelope{}, time.Now().UTC())), evt.EntityID())
+
 	return []events.Event{out}, nil
 }
 
@@ -147,10 +149,10 @@ func (r servedEventPublishBlockingLLMRuntime) ContinueSession(ctx context.Contex
 
 func publishRunStatusRootEvent(t *testing.T, bus *runtimebus.EventBus, runID, entityID string) {
 	t.Helper()
-	if err := bus.Publish(context.Background(), (events.NewProjectionEvent(uuid.NewString(),
+	if err := bus.Publish(context.Background(), eventtest.WithEntityID((eventtest.Projection(uuid.NewString(),
 
 		events.EventType("scan.requested"),
-		"api.v1", "", []byte(`{"topic":"sample"}`), 0, runID, "", events.EventEnvelope{}, time.Now().UTC())).WithEntityID(entityID)); err != nil {
+		"api.v1", "", []byte(`{"topic":"sample"}`), 0, runID, "", events.EventEnvelope{}, time.Now().UTC())), entityID)); err != nil {
 		t.Fatalf("publish root event: %v", err)
 	}
 }

--- a/cmd/swarm/main_test.go
+++ b/cmd/swarm/main_test.go
@@ -108,10 +108,18 @@ func (a delayedRunStatusAgent) OnEvent(ctx context.Context, evt events.Event) ([
 	case <-ctx.Done():
 		return nil, ctx.Err()
 	}
-	out := eventtest.WithEntityID((eventtest.Projection(uuid.NewString(),
-
+	out := eventtest.RootIngress(
+		uuid.NewString(),
 		events.EventType("scan.completed"),
-		a.id, "", []byte(`{}`), 0, evt.RunID(), "", events.EventEnvelope{}, time.Now().UTC())), evt.EntityID())
+		a.id,
+		"",
+		[]byte(`{}`),
+		0,
+		evt.RunID(),
+		"",
+		events.EnvelopeForEntityID(events.EventEnvelope{}, evt.EntityID()),
+		time.Now().UTC(),
+	)
 
 	return []events.Event{out}, nil
 }
@@ -149,10 +157,18 @@ func (r servedEventPublishBlockingLLMRuntime) ContinueSession(ctx context.Contex
 
 func publishRunStatusRootEvent(t *testing.T, bus *runtimebus.EventBus, runID, entityID string) {
 	t.Helper()
-	if err := bus.Publish(context.Background(), eventtest.WithEntityID((eventtest.Projection(uuid.NewString(),
-
+	if err := bus.Publish(context.Background(), eventtest.RootIngress(
+		uuid.NewString(),
 		events.EventType("scan.requested"),
-		"api.v1", "", []byte(`{"topic":"sample"}`), 0, runID, "", events.EventEnvelope{}, time.Now().UTC())), entityID)); err != nil {
+		"api.v1",
+		"",
+		[]byte(`{"topic":"sample"}`),
+		0,
+		runID,
+		"",
+		events.EnvelopeForEntityID(events.EventEnvelope{}, entityID),
+		time.Now().UTC(),
+	)); err != nil {
 		t.Fatalf("publish root event: %v", err)
 	}
 }

--- a/internal/apiv1/openrpc_mutating_runtime_test.go
+++ b/internal/apiv1/openrpc_mutating_runtime_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/division-sh/swarm/internal/apispec"
 	"github.com/division-sh/swarm/internal/events"
+	"github.com/division-sh/swarm/internal/events/eventtest"
 	runtimeagentcontrol "github.com/division-sh/swarm/internal/runtime/agentcontrol"
 	"github.com/division-sh/swarm/internal/runtime/bundledelete"
 	runtimebus "github.com/division-sh/swarm/internal/runtime/bus"
@@ -1302,10 +1303,9 @@ func (s *mutatingProbeMailboxStore) DecideV1MailboxItem(ctx context.Context, dec
 			}
 			result.DownstreamSubscribers = &subscribers
 			result.DownstreamSubscriberSource = strings.TrimSpace(decision.ApprovalEventSubscriberSource)
-			if err := decision.ApprovalEventPublish(ctx, events.NewProjectionEvent(eventID,
+			if err := decision.ApprovalEventPublish(ctx, eventtest.Projection(eventID,
 				events.EventType(decision.ApprovalEventType),
-				"mailbox", "", json.RawMessage(`{"mailbox_id":"mailbox-1"}`), 0, "", "", events.EventEnvelope{}, decision.Now),
-			); err != nil {
+				"mailbox", "", json.RawMessage(`{"mailbox_id":"mailbox-1"}`), 0, "", "", events.EventEnvelope{}, decision.Now)); err != nil {
 				return store.APIIdempotencyCompletion{}, err
 			}
 		}

--- a/internal/apiv1/openrpc_mutating_runtime_test.go
+++ b/internal/apiv1/openrpc_mutating_runtime_test.go
@@ -1303,7 +1303,7 @@ func (s *mutatingProbeMailboxStore) DecideV1MailboxItem(ctx context.Context, dec
 			}
 			result.DownstreamSubscribers = &subscribers
 			result.DownstreamSubscriberSource = strings.TrimSpace(decision.ApprovalEventSubscriberSource)
-			if err := decision.ApprovalEventPublish(ctx, eventtest.PersistedProjection(eventID,
+			if err := decision.ApprovalEventPublish(ctx, eventtest.RootIngress(eventID,
 				events.EventType(decision.ApprovalEventType),
 				"mailbox", "", json.RawMessage(`{"mailbox_id":"mailbox-1"}`), 0, "", "", events.EventEnvelope{}, decision.Now)); err != nil {
 				return store.APIIdempotencyCompletion{}, err

--- a/internal/apiv1/openrpc_mutating_runtime_test.go
+++ b/internal/apiv1/openrpc_mutating_runtime_test.go
@@ -1303,7 +1303,7 @@ func (s *mutatingProbeMailboxStore) DecideV1MailboxItem(ctx context.Context, dec
 			}
 			result.DownstreamSubscribers = &subscribers
 			result.DownstreamSubscriberSource = strings.TrimSpace(decision.ApprovalEventSubscriberSource)
-			if err := decision.ApprovalEventPublish(ctx, eventtest.Projection(eventID,
+			if err := decision.ApprovalEventPublish(ctx, eventtest.PersistedProjection(eventID,
 				events.EventType(decision.ApprovalEventType),
 				"mailbox", "", json.RawMessage(`{"mailbox_id":"mailbox-1"}`), 0, "", "", events.EventEnvelope{}, decision.Now)); err != nil {
 				return store.APIIdempotencyCompletion{}, err

--- a/internal/apiv1/operator_event_replay_test.go
+++ b/internal/apiv1/operator_event_replay_test.go
@@ -290,7 +290,7 @@ func TestOperatorEventReplaySubsetAndFailClosedCases(t *testing.T) {
 		pg := &store.PostgresStore{DB: db}
 		eventID := uuid.NewString()
 		runID := uuid.NewString()
-		if err := pg.AppendEvent(ctx, eventtest.Projection(
+		if err := pg.AppendEvent(ctx, eventtest.PersistedProjection(
 			eventID,
 			events.EventType("scan.requested"),
 			"workflow-runtime",
@@ -663,10 +663,18 @@ func seedReplayableOperatorEvent(t *testing.T, ctx context.Context, pg *store.Po
 	t.Helper()
 	eventID := uuid.NewString()
 	runID := uuid.NewString()
-	if err := pg.AppendEvent(ctx, eventtest.WithEntityID((eventtest.Projection(eventID,
-
+	if err := pg.AppendEvent(ctx, eventtest.PersistedProjection(
+		eventID,
 		events.EventType(eventName),
-		"origin-agent", "", []byte(`{"topic":"medicine"}`), 0, runID, "", events.EventEnvelope{}, time.Now().UTC())), runID)); err != nil {
+		"origin-agent",
+		"",
+		[]byte(`{"topic":"medicine"}`),
+		0,
+		runID,
+		"",
+		events.EnvelopeForEntityID(events.EventEnvelope{}, runID),
+		time.Now().UTC(),
+	)); err != nil {
 		t.Fatalf("AppendEvent: %v", err)
 	}
 	if err := pg.InsertEventDeliveries(ctx, eventID, subscribers); err != nil {
@@ -721,7 +729,7 @@ func assertNoReplayEvent(t *testing.T, ch <-chan events.Event) {
 func fillAgentChannel(t *testing.T, ctx context.Context, bus *runtimebus.EventBus, agentID string, count int) {
 	t.Helper()
 	for i := 0; i < count; i++ {
-		err := bus.PublishDirect(ctx, events.NewRootIngressEvent(uuid.NewString(),
+		err := bus.PublishDirect(ctx, eventtest.RootIngress(uuid.NewString(),
 			events.EventType("filler.event"), "", "", []byte(`{"ok":true}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC()), []string{agentID})
 		if err != nil {
 			t.Fatalf("fill agent channel publish %d: %v", i, err)

--- a/internal/apiv1/operator_event_replay_test.go
+++ b/internal/apiv1/operator_event_replay_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/division-sh/swarm/internal/events"
+	"github.com/division-sh/swarm/internal/events/eventtest"
 	runtimebus "github.com/division-sh/swarm/internal/runtime/bus"
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
 	"github.com/division-sh/swarm/internal/runtime/semanticview"
@@ -289,7 +290,7 @@ func TestOperatorEventReplaySubsetAndFailClosedCases(t *testing.T) {
 		pg := &store.PostgresStore{DB: db}
 		eventID := uuid.NewString()
 		runID := uuid.NewString()
-		if err := pg.AppendEvent(ctx, events.NewProjectionEvent(
+		if err := pg.AppendEvent(ctx, eventtest.Projection(
 			eventID,
 			events.EventType("scan.requested"),
 			"workflow-runtime",
@@ -299,8 +300,7 @@ func TestOperatorEventReplaySubsetAndFailClosedCases(t *testing.T) {
 			runID,
 			"",
 			events.EventEnvelope{EntityID: runID},
-			time.Now().UTC(),
-		)); err != nil {
+			time.Now().UTC())); err != nil {
 			t.Fatalf("AppendEvent: %v", err)
 		}
 		if _, err := db.ExecContext(ctx, `
@@ -663,10 +663,10 @@ func seedReplayableOperatorEvent(t *testing.T, ctx context.Context, pg *store.Po
 	t.Helper()
 	eventID := uuid.NewString()
 	runID := uuid.NewString()
-	if err := pg.AppendEvent(ctx, (events.NewProjectionEvent(eventID,
+	if err := pg.AppendEvent(ctx, eventtest.WithEntityID((eventtest.Projection(eventID,
 
 		events.EventType(eventName),
-		"origin-agent", "", []byte(`{"topic":"medicine"}`), 0, runID, "", events.EventEnvelope{}, time.Now().UTC())).WithEntityID(runID)); err != nil {
+		"origin-agent", "", []byte(`{"topic":"medicine"}`), 0, runID, "", events.EventEnvelope{}, time.Now().UTC())), runID)); err != nil {
 		t.Fatalf("AppendEvent: %v", err)
 	}
 	if err := pg.InsertEventDeliveries(ctx, eventID, subscribers); err != nil {

--- a/internal/apiv1/operator_mailbox_materialization_test.go
+++ b/internal/apiv1/operator_mailbox_materialization_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/division-sh/swarm/internal/events"
+	"github.com/division-sh/swarm/internal/events/eventtest"
 	runtimepipeline "github.com/division-sh/swarm/internal/runtime/pipeline"
 	storepkg "github.com/division-sh/swarm/internal/store"
 	"github.com/division-sh/swarm/internal/store/storetest"
@@ -19,9 +20,10 @@ func TestOperatorMailboxHandlersSQLiteReadsMaterializedMailboxWrite(t *testing.T
 	runID := uuid.NewString()
 	eventID := uuid.NewString()
 	entityID := uuid.NewString()
-	if err := sqliteStore.AppendEvent(ctx, (events.NewProjectionEvent(eventID,
+	if err := sqliteStore.AppendEvent(ctx, eventtest.WithFlowInstance(eventtest.WithEntityID((eventtest.Projection(eventID,
 
-		"mailbox.review_requested", "", "", json.RawMessage(`{"kind":"review"}`), 0, runID, "", events.EventEnvelope{}, time.Now().UTC())).WithEntityID(entityID).WithFlowInstance("validation/case-1")); err != nil {
+		"mailbox.review_requested", "", "", json.RawMessage(`{"kind":"review"}`), 0, runID, "", events.EventEnvelope{}, time.Now().UTC())), entityID),
+		"validation/case-1")); err != nil {
 		t.Fatalf("AppendEvent: %v", err)
 	}
 	itemID := uuid.NewString()

--- a/internal/apiv1/operator_mailbox_materialization_test.go
+++ b/internal/apiv1/operator_mailbox_materialization_test.go
@@ -20,10 +20,18 @@ func TestOperatorMailboxHandlersSQLiteReadsMaterializedMailboxWrite(t *testing.T
 	runID := uuid.NewString()
 	eventID := uuid.NewString()
 	entityID := uuid.NewString()
-	if err := sqliteStore.AppendEvent(ctx, eventtest.WithFlowInstance(eventtest.WithEntityID((eventtest.Projection(eventID,
-
-		"mailbox.review_requested", "", "", json.RawMessage(`{"kind":"review"}`), 0, runID, "", events.EventEnvelope{}, time.Now().UTC())), entityID),
-		"validation/case-1")); err != nil {
+	if err := sqliteStore.AppendEvent(ctx, eventtest.PersistedProjection(
+		eventID,
+		"mailbox.review_requested",
+		"",
+		"",
+		json.RawMessage(`{"kind":"review"}`),
+		0,
+		runID,
+		"",
+		events.EnvelopeForFlowInstance(events.EnvelopeForEntityID(events.EventEnvelope{}, entityID), "validation/case-1"),
+		time.Now().UTC(),
+	)); err != nil {
 		t.Fatalf("AppendEvent: %v", err)
 	}
 	itemID := uuid.NewString()

--- a/internal/apiv1/operator_mailbox_test.go
+++ b/internal/apiv1/operator_mailbox_test.go
@@ -54,10 +54,18 @@ func TestOperatorMailboxHandlersSupportedRPCPath(t *testing.T) {
 	`, runID, entityID, base); err != nil {
 		t.Fatalf("seed entity_state: %v", err)
 	}
-	if err := pg.AppendEvent(ctx, eventtest.WithFlowInstance(eventtest.WithEntityID(events.NewRootIngressEvent(sourceEventID,
-		"review.requested", "", "", json.RawMessage(`{"request":true}`), 0, runID, "", events.EventEnvelope{}, time.Time{}),
-		entityID),
-		"empire/review")); err != nil {
+	if err := pg.AppendEvent(ctx, eventtest.RootIngress(
+		sourceEventID,
+		"review.requested",
+		"",
+		"",
+		json.RawMessage(`{"request":true}`),
+		0,
+		runID,
+		"",
+		events.EnvelopeForFlowInstance(events.EnvelopeForEntityID(events.EventEnvelope{}, entityID), "empire/review"),
+		time.Time{},
+	)); err != nil {
 		t.Fatalf("append source event: %v", err)
 	}
 	mailboxID, err := pg.InsertMailboxItem(ctx, runtimetools.MailboxItem{
@@ -373,9 +381,18 @@ func TestOperatorMailboxApproveRejectsUndeclaredMailboxPayloadSchemaAndRollsBack
 	ctx := context.Background()
 	sourceEventID := uuid.NewString()
 	entityID := uuid.NewString()
-	if err := pg.AppendEvent(ctx, eventtest.WithEntityID(events.NewRootIngressEvent(sourceEventID,
-		"review.requested", "", "", json.RawMessage(`{"request":true}`), 0, uuid.NewString(), "", events.EventEnvelope{}, time.Time{}),
-		entityID)); err != nil {
+	if err := pg.AppendEvent(ctx, eventtest.RootIngress(
+		sourceEventID,
+		"review.requested",
+		"",
+		"",
+		json.RawMessage(`{"request":true}`),
+		0,
+		uuid.NewString(),
+		"",
+		events.EnvelopeForEntityID(events.EventEnvelope{}, entityID),
+		time.Time{},
+	)); err != nil {
 		t.Fatalf("append source event: %v", err)
 	}
 	mailboxID, err := pg.InsertMailboxItem(ctx, runtimetools.MailboxItem{
@@ -436,9 +453,18 @@ func TestOperatorMailboxApprovePublishFailureLeavesItemRetryable(t *testing.T) {
 	ctx := context.Background()
 	sourceEventID := uuid.NewString()
 	entityID := uuid.NewString()
-	if err := pg.AppendEvent(ctx, eventtest.WithEntityID(events.NewRootIngressEvent(sourceEventID,
-		"review.requested", "", "", json.RawMessage(`{"request":true}`), 0, uuid.NewString(), "", events.EventEnvelope{}, time.Time{}),
-		entityID)); err != nil {
+	if err := pg.AppendEvent(ctx, eventtest.RootIngress(
+		sourceEventID,
+		"review.requested",
+		"",
+		"",
+		json.RawMessage(`{"request":true}`),
+		0,
+		uuid.NewString(),
+		"",
+		events.EnvelopeForEntityID(events.EventEnvelope{}, entityID),
+		time.Time{},
+	)); err != nil {
 		t.Fatalf("append source event: %v", err)
 	}
 	mailboxID, err := pg.InsertMailboxItem(ctx, runtimetools.MailboxItem{
@@ -550,10 +576,18 @@ func TestOperatorMailboxApproveQueuesTransactionalPublishWhileRuntimePaused(t *t
 	runID := uuid.NewString()
 	entityID := uuid.NewString()
 	sourceEventID := uuid.NewString()
-	if err := pg.AppendEvent(ctx, eventtest.WithFlowInstance(eventtest.WithEntityID(events.NewRootIngressEvent(sourceEventID,
-		"review.requested", "", "", json.RawMessage(`{"request":true}`), 0, runID, "", events.EventEnvelope{}, time.Time{}),
-		entityID),
-		"empire/review")); err != nil {
+	if err := pg.AppendEvent(ctx, eventtest.RootIngress(
+		sourceEventID,
+		"review.requested",
+		"",
+		"",
+		json.RawMessage(`{"request":true}`),
+		0,
+		runID,
+		"",
+		events.EnvelopeForFlowInstance(events.EnvelopeForEntityID(events.EventEnvelope{}, entityID), "empire/review"),
+		time.Time{},
+	)); err != nil {
 		t.Fatalf("append source event: %v", err)
 	}
 	mailboxID, err := pg.InsertMailboxItem(ctx, runtimetools.MailboxItem{
@@ -667,10 +701,18 @@ func TestOperatorMailboxApproveRunsPublishDispatchAfterDecisionCommit(t *testing
 	runID := uuid.NewString()
 	entityID := uuid.NewString()
 	sourceEventID := uuid.NewString()
-	if err := pg.AppendEvent(ctx, eventtest.WithFlowInstance(eventtest.WithEntityID(events.NewRootIngressEvent(sourceEventID,
-		"review.requested", "", "", json.RawMessage(`{"request":true}`), 0, runID, "", events.EventEnvelope{}, time.Time{}),
-		entityID),
-		"empire/review")); err != nil {
+	if err := pg.AppendEvent(ctx, eventtest.RootIngress(
+		sourceEventID,
+		"review.requested",
+		"",
+		"",
+		json.RawMessage(`{"request":true}`),
+		0,
+		runID,
+		"",
+		events.EnvelopeForFlowInstance(events.EnvelopeForEntityID(events.EventEnvelope{}, entityID), "empire/review"),
+		time.Time{},
+	)); err != nil {
 		t.Fatalf("append source event: %v", err)
 	}
 	mailboxID, err := pg.InsertMailboxItem(ctx, runtimetools.MailboxItem{

--- a/internal/apiv1/operator_mailbox_test.go
+++ b/internal/apiv1/operator_mailbox_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/division-sh/swarm/internal/events"
+	"github.com/division-sh/swarm/internal/events/eventtest"
 	runtimebus "github.com/division-sh/swarm/internal/runtime/bus"
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
 	runtimeactors "github.com/division-sh/swarm/internal/runtime/core/actors"
@@ -53,9 +54,10 @@ func TestOperatorMailboxHandlersSupportedRPCPath(t *testing.T) {
 	`, runID, entityID, base); err != nil {
 		t.Fatalf("seed entity_state: %v", err)
 	}
-	if err := pg.AppendEvent(ctx, events.NewRootIngressEvent(sourceEventID,
-		"review.requested", "", "", json.RawMessage(`{"request":true}`), 0, runID, "", events.EventEnvelope{}, time.Time{}).
-		WithEntityID(entityID).WithFlowInstance("empire/review")); err != nil {
+	if err := pg.AppendEvent(ctx, eventtest.WithFlowInstance(eventtest.WithEntityID(events.NewRootIngressEvent(sourceEventID,
+		"review.requested", "", "", json.RawMessage(`{"request":true}`), 0, runID, "", events.EventEnvelope{}, time.Time{}),
+		entityID),
+		"empire/review")); err != nil {
 		t.Fatalf("append source event: %v", err)
 	}
 	mailboxID, err := pg.InsertMailboxItem(ctx, runtimetools.MailboxItem{
@@ -371,9 +373,9 @@ func TestOperatorMailboxApproveRejectsUndeclaredMailboxPayloadSchemaAndRollsBack
 	ctx := context.Background()
 	sourceEventID := uuid.NewString()
 	entityID := uuid.NewString()
-	if err := pg.AppendEvent(ctx, events.NewRootIngressEvent(sourceEventID,
-		"review.requested", "", "", json.RawMessage(`{"request":true}`), 0, uuid.NewString(), "", events.EventEnvelope{}, time.Time{}).
-		WithEntityID(entityID)); err != nil {
+	if err := pg.AppendEvent(ctx, eventtest.WithEntityID(events.NewRootIngressEvent(sourceEventID,
+		"review.requested", "", "", json.RawMessage(`{"request":true}`), 0, uuid.NewString(), "", events.EventEnvelope{}, time.Time{}),
+		entityID)); err != nil {
 		t.Fatalf("append source event: %v", err)
 	}
 	mailboxID, err := pg.InsertMailboxItem(ctx, runtimetools.MailboxItem{
@@ -434,9 +436,9 @@ func TestOperatorMailboxApprovePublishFailureLeavesItemRetryable(t *testing.T) {
 	ctx := context.Background()
 	sourceEventID := uuid.NewString()
 	entityID := uuid.NewString()
-	if err := pg.AppendEvent(ctx, events.NewRootIngressEvent(sourceEventID,
-		"review.requested", "", "", json.RawMessage(`{"request":true}`), 0, uuid.NewString(), "", events.EventEnvelope{}, time.Time{}).
-		WithEntityID(entityID)); err != nil {
+	if err := pg.AppendEvent(ctx, eventtest.WithEntityID(events.NewRootIngressEvent(sourceEventID,
+		"review.requested", "", "", json.RawMessage(`{"request":true}`), 0, uuid.NewString(), "", events.EventEnvelope{}, time.Time{}),
+		entityID)); err != nil {
 		t.Fatalf("append source event: %v", err)
 	}
 	mailboxID, err := pg.InsertMailboxItem(ctx, runtimetools.MailboxItem{
@@ -548,9 +550,10 @@ func TestOperatorMailboxApproveQueuesTransactionalPublishWhileRuntimePaused(t *t
 	runID := uuid.NewString()
 	entityID := uuid.NewString()
 	sourceEventID := uuid.NewString()
-	if err := pg.AppendEvent(ctx, events.NewRootIngressEvent(sourceEventID,
-		"review.requested", "", "", json.RawMessage(`{"request":true}`), 0, runID, "", events.EventEnvelope{}, time.Time{}).
-		WithEntityID(entityID).WithFlowInstance("empire/review")); err != nil {
+	if err := pg.AppendEvent(ctx, eventtest.WithFlowInstance(eventtest.WithEntityID(events.NewRootIngressEvent(sourceEventID,
+		"review.requested", "", "", json.RawMessage(`{"request":true}`), 0, runID, "", events.EventEnvelope{}, time.Time{}),
+		entityID),
+		"empire/review")); err != nil {
 		t.Fatalf("append source event: %v", err)
 	}
 	mailboxID, err := pg.InsertMailboxItem(ctx, runtimetools.MailboxItem{
@@ -664,9 +667,10 @@ func TestOperatorMailboxApproveRunsPublishDispatchAfterDecisionCommit(t *testing
 	runID := uuid.NewString()
 	entityID := uuid.NewString()
 	sourceEventID := uuid.NewString()
-	if err := pg.AppendEvent(ctx, events.NewRootIngressEvent(sourceEventID,
-		"review.requested", "", "", json.RawMessage(`{"request":true}`), 0, runID, "", events.EventEnvelope{}, time.Time{}).
-		WithEntityID(entityID).WithFlowInstance("empire/review")); err != nil {
+	if err := pg.AppendEvent(ctx, eventtest.WithFlowInstance(eventtest.WithEntityID(events.NewRootIngressEvent(sourceEventID,
+		"review.requested", "", "", json.RawMessage(`{"request":true}`), 0, runID, "", events.EventEnvelope{}, time.Time{}),
+		entityID),
+		"empire/review")); err != nil {
 		t.Fatalf("append source event: %v", err)
 	}
 	mailboxID, err := pg.InsertMailboxItem(ctx, runtimetools.MailboxItem{

--- a/internal/apiv1/operator_mailbox_write_supported_surface_test.go
+++ b/internal/apiv1/operator_mailbox_write_supported_surface_test.go
@@ -381,7 +381,7 @@ func loadMailboxWritePersistedEvent(t *testing.T, db *sql.DB, backend, eventID s
 	); err != nil {
 		t.Fatalf("%s load event %s: %v", backend, eventID, err)
 	}
-	return eventtest.Projection(
+	return eventtest.PersistedProjection(
 		id,
 		events.EventType(eventName),
 		producedBy,

--- a/internal/apiv1/operator_mailbox_write_supported_surface_test.go
+++ b/internal/apiv1/operator_mailbox_write_supported_surface_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/division-sh/swarm/internal/events"
+	"github.com/division-sh/swarm/internal/events/eventtest"
 	runtimebus "github.com/division-sh/swarm/internal/runtime/bus"
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
 	runtimecorrelation "github.com/division-sh/swarm/internal/runtime/correlation"
@@ -380,7 +381,7 @@ func loadMailboxWritePersistedEvent(t *testing.T, db *sql.DB, backend, eventID s
 	); err != nil {
 		t.Fatalf("%s load event %s: %v", backend, eventID, err)
 	}
-	return events.NewProjectionEvent(
+	return eventtest.Projection(
 		id,
 		events.EventType(eventName),
 		producedBy,
@@ -390,8 +391,8 @@ func loadMailboxWritePersistedEvent(t *testing.T, db *sql.DB, backend, eventID s
 		runID,
 		sourceEventID,
 		mailboxWriteDBEnvelope(t, entityID, flowInstance, scope, sourceRouteRaw, targetRouteRaw, targetSetRaw),
-		mailboxWriteDBTime(createdAtRaw),
-	)
+		mailboxWriteDBTime(createdAtRaw))
+
 }
 
 func mailboxWriteDBEnvelope(t *testing.T, entityID, flowInstance, scope string, sourceRouteRaw, targetRouteRaw, targetSetRaw any) events.EventEnvelope {

--- a/internal/apiv1/sqlite_observability_supported_surface_test.go
+++ b/internal/apiv1/sqlite_observability_supported_surface_test.go
@@ -197,7 +197,7 @@ func newSQLiteObservabilitySurfaceFixture(t *testing.T, ctx context.Context) sql
 	now := time.Unix(1700002000, 0).UTC()
 	runID := uuid.NewString()
 	eventID := uuid.NewString()
-	if err := sqliteStore.PersistEventWithDeliveries(ctx, eventtest.Projection(eventID,
+	if err := sqliteStore.PersistEventWithDeliveries(ctx, eventtest.PersistedProjection(eventID,
 
 		events.EventType("trace.visible"),
 		"agent-1", "", json.RawMessage(`{"trace":true}`), 0, runID, "", events.EventEnvelope{}, now),

--- a/internal/apiv1/sqlite_observability_supported_surface_test.go
+++ b/internal/apiv1/sqlite_observability_supported_surface_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/division-sh/swarm/internal/events"
+	"github.com/division-sh/swarm/internal/events/eventtest"
 	runtimepkg "github.com/division-sh/swarm/internal/runtime"
 	runtimecorrelation "github.com/division-sh/swarm/internal/runtime/correlation"
 	storepkg "github.com/division-sh/swarm/internal/store"
@@ -196,10 +197,12 @@ func newSQLiteObservabilitySurfaceFixture(t *testing.T, ctx context.Context) sql
 	now := time.Unix(1700002000, 0).UTC()
 	runID := uuid.NewString()
 	eventID := uuid.NewString()
-	if err := sqliteStore.PersistEventWithDeliveries(ctx, events.NewProjectionEvent(eventID,
+	if err := sqliteStore.PersistEventWithDeliveries(ctx, eventtest.Projection(eventID,
 
 		events.EventType("trace.visible"),
-		"agent-1", "", json.RawMessage(`{"trace":true}`), 0, runID, "", events.EventEnvelope{}, now), []string{"agent-1"}); err != nil {
+		"agent-1", "", json.RawMessage(`{"trace":true}`), 0, runID, "", events.EventEnvelope{}, now),
+
+		[]string{"agent-1"}); err != nil {
 		t.Fatalf("PersistEventWithDeliveries: %v", err)
 	}
 	if err := sqliteStore.MarkEventDeliveryInProgress(ctx, eventID, "agent-1", "session-1"); err != nil {

--- a/internal/dashboard/server/server_test.go
+++ b/internal/dashboard/server/server_test.go
@@ -1082,7 +1082,7 @@ func (e *directiveSurfaceToolExecutor) Execute(ctx context.Context, name string,
 	e.executed = append(e.executed, strings.TrimSpace(name))
 	if strings.HasPrefix(strings.TrimSpace(name), "emit_") {
 		if rec, ok := runtimebus.EmittedEventsRecorderFromContext(ctx); ok && rec != nil {
-			rec.Append(eventtest.Projection("", events.EventType(strings.TrimPrefix(strings.TrimSpace(name), "emit_")), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}))
+			rec.Append(eventtest.PersistedProjection("", events.EventType(strings.TrimPrefix(strings.TrimSpace(name), "emit_")), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}))
 		}
 		return map[string]any{"status": "published"}, nil
 	}
@@ -3879,15 +3879,23 @@ func TestHandler_RunEventReplayUsesCanonicalPersistedRunDebugOwner(t *testing.T)
 	t.Skip("legacy dashboard/Builder operator endpoint retired under #731; canonical v1 owner tests cover this behavior")
 	now := time.Unix(1700000000, 0).UTC()
 	runID := "run_replay_001"
-	rootEvent := eventtest.WithEntityID((eventtest.Projection("evt-root",
-
+	rootEvent := eventtest.PersistedProjection(
+		"evt-root",
 		events.EventType("scan.requested"),
-		"builder", "", json.RawMessage(`{"topic":"sample"}`), 0, runID, "", events.EventEnvelope{}, now)), runID)
+		"builder",
+		"",
+		json.RawMessage(`{"topic":"sample"}`),
+		0,
+		runID,
+		"",
+		events.EnvelopeForEntityID(events.EventEnvelope{}, runID),
+		now,
+	)
 
 	storeStub := &stubBuilderRunStore{
 		events: []events.Event{
 			rootEvent,
-			eventtest.Projection("evt-log", events.EventType("platform.runtime_log"), "runtime", "", json.RawMessage(`{"log_level":"warn","message":"runtime log","details":{"component":"scheduler","action":"checkpoint","error":"boom"}}`), 0, runID, "", events.EventEnvelope{}, now.Add(2*time.Second)),
+			eventtest.PersistedProjection("evt-log", events.EventType("platform.runtime_log"), "runtime", "", json.RawMessage(`{"log_level":"warn","message":"runtime log","details":{"component":"scheduler","action":"checkpoint","error":"boom"}}`), 0, runID, "", events.EventEnvelope{}, now.Add(2*time.Second)),
 		},
 		snapshots: map[string]runtimebus.RunLifecycleSnapshot{
 			runID: {
@@ -4119,7 +4127,7 @@ func TestHandler_RunEventStreamPreservesCanonicalRuntimeLogWithoutEntityID(t *te
 	}
 
 	logPayload := json.RawMessage(`{"log_level":"warn","message":"runtime log","details":{"component":"scheduler","action":"canonical-owner","error":"boom"}}`)
-	if err := storeStub.AppendEvent(context.Background(), eventtest.Projection("evt-runtime-log",
+	if err := storeStub.AppendEvent(context.Background(), eventtest.PersistedProjection("evt-runtime-log",
 
 		events.EventType("platform.runtime_log"),
 		"runtime", "", logPayload, 0, runID, "", events.EventEnvelope{}, now)); err != nil {

--- a/internal/dashboard/server/server_test.go
+++ b/internal/dashboard/server/server_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/DATA-DOG/go-sqlmock"
 	builderpkg "github.com/division-sh/swarm/internal/builder"
 	"github.com/division-sh/swarm/internal/events"
+	"github.com/division-sh/swarm/internal/events/eventtest"
 	runtimepkg "github.com/division-sh/swarm/internal/runtime"
 	runtimeagentcontrol "github.com/division-sh/swarm/internal/runtime/agentcontrol"
 	runtimeagents "github.com/division-sh/swarm/internal/runtime/agents"
@@ -1081,7 +1082,7 @@ func (e *directiveSurfaceToolExecutor) Execute(ctx context.Context, name string,
 	e.executed = append(e.executed, strings.TrimSpace(name))
 	if strings.HasPrefix(strings.TrimSpace(name), "emit_") {
 		if rec, ok := runtimebus.EmittedEventsRecorderFromContext(ctx); ok && rec != nil {
-			rec.Append(events.NewProjectionEvent("", events.EventType(strings.TrimPrefix(strings.TrimSpace(name), "emit_")), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}))
+			rec.Append(eventtest.Projection("", events.EventType(strings.TrimPrefix(strings.TrimSpace(name), "emit_")), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}))
 		}
 		return map[string]any{"status": "published"}, nil
 	}
@@ -3878,14 +3879,15 @@ func TestHandler_RunEventReplayUsesCanonicalPersistedRunDebugOwner(t *testing.T)
 	t.Skip("legacy dashboard/Builder operator endpoint retired under #731; canonical v1 owner tests cover this behavior")
 	now := time.Unix(1700000000, 0).UTC()
 	runID := "run_replay_001"
-	rootEvent := (events.NewProjectionEvent("evt-root",
+	rootEvent := eventtest.WithEntityID((eventtest.Projection("evt-root",
 
 		events.EventType("scan.requested"),
-		"builder", "", json.RawMessage(`{"topic":"sample"}`), 0, runID, "", events.EventEnvelope{}, now)).WithEntityID(runID)
+		"builder", "", json.RawMessage(`{"topic":"sample"}`), 0, runID, "", events.EventEnvelope{}, now)), runID)
+
 	storeStub := &stubBuilderRunStore{
 		events: []events.Event{
 			rootEvent,
-			events.NewProjectionEvent("evt-log", events.EventType("platform.runtime_log"), "runtime", "", json.RawMessage(`{"log_level":"warn","message":"runtime log","details":{"component":"scheduler","action":"checkpoint","error":"boom"}}`), 0, runID, "", events.EventEnvelope{}, now.Add(2*time.Second)),
+			eventtest.Projection("evt-log", events.EventType("platform.runtime_log"), "runtime", "", json.RawMessage(`{"log_level":"warn","message":"runtime log","details":{"component":"scheduler","action":"checkpoint","error":"boom"}}`), 0, runID, "", events.EventEnvelope{}, now.Add(2*time.Second)),
 		},
 		snapshots: map[string]runtimebus.RunLifecycleSnapshot{
 			runID: {
@@ -4117,11 +4119,10 @@ func TestHandler_RunEventStreamPreservesCanonicalRuntimeLogWithoutEntityID(t *te
 	}
 
 	logPayload := json.RawMessage(`{"log_level":"warn","message":"runtime log","details":{"component":"scheduler","action":"canonical-owner","error":"boom"}}`)
-	if err := storeStub.AppendEvent(context.Background(), events.NewProjectionEvent("evt-runtime-log",
+	if err := storeStub.AppendEvent(context.Background(), eventtest.Projection("evt-runtime-log",
 
 		events.EventType("platform.runtime_log"),
-		"runtime", "", logPayload, 0, runID, "", events.EventEnvelope{}, now),
-	); err != nil {
+		"runtime", "", logPayload, 0, runID, "", events.EventEnvelope{}, now)); err != nil {
 		t.Fatalf("append canonical runtime log: %v", err)
 	}
 

--- a/internal/events/construction_test.go
+++ b/internal/events/construction_test.go
@@ -320,10 +320,18 @@ func checkTestEventFixtureFile(t *testing.T, repoRoot, path string) {
 	}
 	eventtestAliases := importAliases(file, "github.com/division-sh/swarm/internal/events/eventtest")
 	packageAliases := allImportAliases(file)
+	persistedProjectionVars := testPersistedProjectionVars(file, eventtestAliases)
 	ast.Inspect(file, func(n ast.Node) bool {
 		call, ok := n.(*ast.CallExpr)
 		if !ok {
 			return true
+		}
+		if isPublishSurfaceCall(call) {
+			for _, arg := range call.Args {
+				if exprContainsEventtestPersistedProjection(arg, eventtestAliases, persistedProjectionVars) {
+					t.Fatalf("%s:%d passes eventtest.PersistedProjection to a publish/runtime producer API; use a runtime-intent fixture such as eventtest.RootIngress", relativePath, fset.Position(call.Pos()).Line)
+				}
+			}
 		}
 		if isNewProjectionEventCall(call, eventAliases) {
 			t.Fatalf("%s:%d calls events.NewProjectionEvent directly in a test; use internal/events/eventtest fixture builders or add a narrow internal/events unit-test allowlist", relativePath, fset.Position(call.Pos()).Line)
@@ -350,6 +358,34 @@ func checkTestEventFixtureFile(t *testing.T, repoRoot, path string) {
 		t.Fatalf("%s:%d calls %s directly in a test; route fixture event patching through internal/events/eventtest", relativePath, fset.Position(sel.Pos()).Line, sel.Sel.Name)
 		return false
 	})
+}
+
+func testPersistedProjectionVars(file *ast.File, eventtestAliases map[string]struct{}) map[string]struct{} {
+	vars := map[string]struct{}{}
+	ast.Inspect(file, func(n ast.Node) bool {
+		switch node := n.(type) {
+		case *ast.AssignStmt:
+			for idx, rhs := range node.Rhs {
+				if !exprContainsEventtestPersistedProjection(rhs, eventtestAliases, nil) || idx >= len(node.Lhs) {
+					continue
+				}
+				if ident, ok := node.Lhs[idx].(*ast.Ident); ok && ident.Name != "_" {
+					vars[ident.Name] = struct{}{}
+				}
+			}
+		case *ast.ValueSpec:
+			for idx, value := range node.Values {
+				if !exprContainsEventtestPersistedProjection(value, eventtestAliases, nil) || idx >= len(node.Names) {
+					continue
+				}
+				if name := node.Names[idx].Name; name != "_" {
+					vars[name] = struct{}{}
+				}
+			}
+		}
+		return true
+	})
+	return vars
 }
 
 func eventImportAliases(file *ast.File) (map[string]struct{}, bool) {
@@ -441,6 +477,47 @@ func testEventConstructorCallName(call *ast.CallExpr, eventAliases map[string]st
 func isEventtestProjectionCall(call *ast.CallExpr, eventtestAliases map[string]struct{}) bool {
 	selector, ok := call.Fun.(*ast.SelectorExpr)
 	return ok && selector.Sel.Name == "Projection" && isPackageIdent(selector.X, eventtestAliases)
+}
+
+func isEventtestPersistedProjectionCall(call *ast.CallExpr, eventtestAliases map[string]struct{}) bool {
+	selector, ok := call.Fun.(*ast.SelectorExpr)
+	return ok && selector.Sel.Name == "PersistedProjection" && isPackageIdent(selector.X, eventtestAliases)
+}
+
+func isPublishSurfaceCall(call *ast.CallExpr) bool {
+	selector, ok := call.Fun.(*ast.SelectorExpr)
+	if !ok {
+		return false
+	}
+	switch selector.Sel.Name {
+	case "Publish", "PublishDirect", "PublishInMutation", "ApprovalEventPublish":
+		return true
+	default:
+		return false
+	}
+}
+
+func exprContainsEventtestPersistedProjection(expr ast.Expr, eventtestAliases map[string]struct{}, persistedProjectionVars map[string]struct{}) bool {
+	found := false
+	ast.Inspect(expr, func(n ast.Node) bool {
+		if found {
+			return false
+		}
+		switch node := n.(type) {
+		case *ast.CallExpr:
+			if isEventtestPersistedProjectionCall(node, eventtestAliases) {
+				found = true
+				return false
+			}
+		case *ast.Ident:
+			if _, ok := persistedProjectionVars[node.Name]; ok {
+				found = true
+				return false
+			}
+		}
+		return true
+	})
+	return found
 }
 
 func productionFunctionScope(fn *ast.FuncDecl) string {

--- a/internal/events/construction_test.go
+++ b/internal/events/construction_test.go
@@ -160,6 +160,37 @@ func TestProductionEventConstructionUsesPublicAPI(t *testing.T) {
 	assertExactConstructorAllowlist(t, "NewRouteProbeEvent", productionRouteProbeEventAllowlist, routeProbeCallCounts)
 }
 
+func TestTestEventFixturesUseFixtureBuilders(t *testing.T) {
+	repoRoot := repositoryRoot(t)
+	for _, dir := range []string{"internal", "cmd"} {
+		root := filepath.Join(repoRoot, dir)
+		if _, err := os.Stat(root); err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			t.Fatalf("stat %s: %v", root, err)
+		}
+		if err := filepath.WalkDir(root, func(path string, entry os.DirEntry, walkErr error) error {
+			if walkErr != nil {
+				return walkErr
+			}
+			if entry.IsDir() {
+				if path == filepath.Join(repoRoot, "internal", "events") {
+					return filepath.SkipDir
+				}
+				return nil
+			}
+			if !strings.HasSuffix(path, "_test.go") {
+				return nil
+			}
+			checkTestEventFixtureFile(t, repoRoot, path)
+			return nil
+		}); err != nil {
+			t.Fatalf("walk %s: %v", root, err)
+		}
+	}
+}
+
 func assertExactConstructorAllowlist(t *testing.T, constructor string, allowlist map[eventConstructorCallsite]int, counts map[eventConstructorCallsite]int) {
 	t.Helper()
 	for site, want := range allowlist {
@@ -190,11 +221,14 @@ func checkProductionEventConstructionFile(t *testing.T, repoRoot, path string, p
 	if err != nil {
 		t.Fatalf("parse %s: %v", path, err)
 	}
+	relativePath := slashPath(repoRoot, path)
+	if importsPath(file, "github.com/division-sh/swarm/internal/events/eventtest") {
+		t.Fatalf("%s imports internal/events/eventtest from production code; test fixture builders are test-only", relativePath)
+	}
 	eventAliases, dotImported := eventImportAliases(file)
 	if len(eventAliases) == 0 {
 		return
 	}
-	relativePath := slashPath(repoRoot, path)
 	if dotImported {
 		t.Fatalf("%s dot-imports internal/events; use a named import so the production construction guard can classify constructor calls", relativePath)
 	}
@@ -272,24 +306,101 @@ func checkProductionEventConstructionFile(t *testing.T, repoRoot, path string, p
 	}
 }
 
+func checkTestEventFixtureFile(t *testing.T, repoRoot, path string) {
+	t.Helper()
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, path, nil, 0)
+	if err != nil {
+		t.Fatalf("parse %s: %v", path, err)
+	}
+	relativePath := slashPath(repoRoot, path)
+	eventAliases, dotImported := eventImportAliases(file)
+	if dotImported {
+		t.Fatalf("%s dot-imports internal/events; use a named import so the test fixture guard can classify constructor calls", relativePath)
+	}
+	eventtestAliases := importAliases(file, "github.com/division-sh/swarm/internal/events/eventtest")
+	packageAliases := allImportAliases(file)
+	ast.Inspect(file, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		if isNewProjectionEventCall(call, eventAliases) {
+			t.Fatalf("%s:%d calls events.NewProjectionEvent directly in a test; use internal/events/eventtest fixture builders or add a narrow internal/events unit-test allowlist", relativePath, fset.Position(call.Pos()).Line)
+		}
+		if isNewRouteProbeEventCall(call, eventAliases) {
+			t.Fatalf("%s:%d calls events.NewRouteProbeEvent directly in a test; use internal/events/eventtest.RouteProbe or add a narrow internal/events unit-test allowlist", relativePath, fset.Position(call.Pos()).Line)
+		}
+		sel, ok := call.Fun.(*ast.SelectorExpr)
+		if !ok || !isEventProjectionMethod(sel.Sel.Name) {
+			return true
+		}
+		if isPackageIdent(sel.X, eventtestAliases) {
+			return true
+		}
+		if isPackageIdent(sel.X, packageAliases) {
+			return true
+		}
+		t.Fatalf("%s:%d calls %s directly in a test; route fixture event patching through internal/events/eventtest", relativePath, fset.Position(sel.Pos()).Line, sel.Sel.Name)
+		return false
+	})
+}
+
 func eventImportAliases(file *ast.File) (map[string]struct{}, bool) {
-	aliases := map[string]struct{}{}
+	aliases := importAliases(file, "github.com/division-sh/swarm/internal/events")
 	dotImported := false
 	for _, imp := range file.Imports {
 		if strings.Trim(imp.Path.Value, `"`) != "github.com/division-sh/swarm/internal/events" {
 			continue
 		}
 		switch {
-		case imp.Name == nil:
-			aliases["events"] = struct{}{}
-		case imp.Name.Name == ".":
+		case imp.Name != nil && imp.Name.Name == ".":
 			dotImported = true
-			aliases["events"] = struct{}{}
+		}
+	}
+	return aliases, dotImported
+}
+
+func importAliases(file *ast.File, importPath string) map[string]struct{} {
+	aliases := map[string]struct{}{}
+	for _, imp := range file.Imports {
+		if strings.Trim(imp.Path.Value, `"`) != importPath {
+			continue
+		}
+		switch {
+		case imp.Name == nil:
+			aliases[filepath.Base(importPath)] = struct{}{}
+		case imp.Name.Name == ".":
+			aliases[filepath.Base(importPath)] = struct{}{}
 		case imp.Name.Name != "_":
 			aliases[imp.Name.Name] = struct{}{}
 		}
 	}
-	return aliases, dotImported
+	return aliases
+}
+
+func allImportAliases(file *ast.File) map[string]struct{} {
+	aliases := map[string]struct{}{}
+	for _, imp := range file.Imports {
+		if imp.Name != nil {
+			if imp.Name.Name != "." && imp.Name.Name != "_" {
+				aliases[imp.Name.Name] = struct{}{}
+			}
+			continue
+		}
+		importPath := strings.Trim(imp.Path.Value, `"`)
+		aliases[filepath.Base(importPath)] = struct{}{}
+	}
+	return aliases
+}
+
+func importsPath(file *ast.File, importPath string) bool {
+	for _, imp := range file.Imports {
+		if strings.Trim(imp.Path.Value, `"`) == importPath {
+			return true
+		}
+	}
+	return false
 }
 
 func isNewProjectionEventCall(call *ast.CallExpr, eventAliases map[string]struct{}) bool {
@@ -379,11 +490,15 @@ func isEventsEventType(expr ast.Expr, eventAliases map[string]struct{}) bool {
 }
 
 func isEventsPackageIdent(expr ast.Expr, eventAliases map[string]struct{}) bool {
+	return isPackageIdent(expr, eventAliases)
+}
+
+func isPackageIdent(expr ast.Expr, aliases map[string]struct{}) bool {
 	ident, ok := expr.(*ast.Ident)
 	if !ok {
 		return false
 	}
-	_, ok = eventAliases[ident.Name]
+	_, ok = aliases[ident.Name]
 	return ok
 }
 

--- a/internal/events/construction_test.go
+++ b/internal/events/construction_test.go
@@ -331,12 +331,18 @@ func checkTestEventFixtureFile(t *testing.T, repoRoot, path string) {
 		if isNewRouteProbeEventCall(call, eventAliases) {
 			t.Fatalf("%s:%d calls events.NewRouteProbeEvent directly in a test; use internal/events/eventtest.RouteProbe or add a narrow internal/events unit-test allowlist", relativePath, fset.Position(call.Pos()).Line)
 		}
+		if constructor, ok := testEventConstructorCallName(call, eventAliases); ok {
+			t.Fatalf("%s:%d calls events.%s directly in a test; use the matching internal/events/eventtest fixture builder outside internal/events constructor unit tests", relativePath, fset.Position(call.Pos()).Line, constructor)
+		}
+		if isEventtestProjectionCall(call, eventtestAliases) {
+			t.Fatalf("%s:%d calls eventtest.Projection in a test; choose eventtest.RootIngress, eventtest.ChildWithLineage, eventtest.Replay, runtime diagnostic/control helpers, or eventtest.PersistedProjection for persisted/readback fixtures", relativePath, fset.Position(call.Pos()).Line)
+		}
 		sel, ok := call.Fun.(*ast.SelectorExpr)
 		if !ok || !isEventProjectionMethod(sel.Sel.Name) {
 			return true
 		}
 		if isPackageIdent(sel.X, eventtestAliases) {
-			return true
+			t.Fatalf("%s:%d calls eventtest.%s in a test; pass the final EventEnvelope/route context to the typed fixture constructor", relativePath, fset.Position(sel.Pos()).Line, sel.Sel.Name)
 		}
 		if isPackageIdent(sel.X, packageAliases) {
 			return true
@@ -411,6 +417,30 @@ func isNewProjectionEventCall(call *ast.CallExpr, eventAliases map[string]struct
 func isNewRouteProbeEventCall(call *ast.CallExpr, eventAliases map[string]struct{}) bool {
 	selector, ok := call.Fun.(*ast.SelectorExpr)
 	return ok && selector.Sel.Name == "NewRouteProbeEvent" && isEventsPackageIdent(selector.X, eventAliases)
+}
+
+func testEventConstructorCallName(call *ast.CallExpr, eventAliases map[string]struct{}) (string, bool) {
+	selector, ok := call.Fun.(*ast.SelectorExpr)
+	if !ok || !isEventsPackageIdent(selector.X, eventAliases) {
+		return "", false
+	}
+	switch selector.Sel.Name {
+	case "NewRootIngressEvent",
+		"NewRuntimeControlEvent",
+		"NewRuntimeDiagnosticEvent",
+		"NewDiagnosticDirectEvent",
+		"NewChildEvent",
+		"NewChildEventWithLineage",
+		"NewReplayEvent":
+		return selector.Sel.Name, true
+	default:
+		return "", false
+	}
+}
+
+func isEventtestProjectionCall(call *ast.CallExpr, eventtestAliases map[string]struct{}) bool {
+	selector, ok := call.Fun.(*ast.SelectorExpr)
+	return ok && selector.Sel.Name == "Projection" && isPackageIdent(selector.X, eventtestAliases)
 }
 
 func productionFunctionScope(fn *ast.FuncDecl) string {

--- a/internal/events/eventtest/eventtest.go
+++ b/internal/events/eventtest/eventtest.go
@@ -48,10 +48,11 @@ func Replay(id string, eventType events.EventType, sourceAgent, taskID string, p
 	return events.NewReplayEvent(id, eventType, sourceAgent, taskID, payload, chainDepth, lineage, envelope, createdAt)
 }
 
-// Projection builds a persisted projection/readback fixture from authoritative
-// event facts. Prefer the runtime-intent helpers above when a test fixture is
-// modeling a producer-created event.
-func Projection(id string, eventType events.EventType, sourceAgent, taskID string, payload json.RawMessage, chainDepth int, runID, parentEventID string, envelope events.EventEnvelope, createdAt time.Time) events.Event {
+// PersistedProjection builds a persisted projection/readback fixture from
+// authoritative event facts. Runtime producer fixtures should use RootIngress,
+// ChildWithLineage, Replay, RuntimeControl, RuntimeDiagnostic, or
+// DiagnosticDirect instead.
+func PersistedProjection(id string, eventType events.EventType, sourceAgent, taskID string, payload json.RawMessage, chainDepth int, runID, parentEventID string, envelope events.EventEnvelope, createdAt time.Time) events.Event {
 	return events.NewProjectionEvent(id, eventType, sourceAgent, taskID, payload, chainDepth, runID, parentEventID, envelope, createdAt)
 }
 
@@ -60,38 +61,54 @@ func RouteProbe(eventType events.EventType) events.Event {
 	return events.NewRouteProbeEvent(eventType)
 }
 
-// WithEnvelope keeps legacy fixture migration behind this test-only owner.
-// Prefer passing the envelope to the semantic fixture constructor when possible.
-func WithEnvelope(evt events.Event, envelope events.EventEnvelope) events.Event {
-	return evt.WithEnvelope(envelope)
+// MalformedChildWithoutLineage builds the explicit negative fixture for
+// admission tests that assert child events without lineage are rejected.
+func MalformedChildWithoutLineage(eventType events.EventType, sourceAgent string, payload json.RawMessage) events.Event {
+	return events.NewChildEventWithLineage(
+		"",
+		eventType,
+		sourceAgent,
+		"",
+		payload,
+		0,
+		events.EventLineage{},
+		events.EventEnvelope{},
+		time.Time{},
+	)
 }
 
-// WithEntityID keeps legacy fixture migration behind this test-only owner.
-// Prefer passing EntityID through EventEnvelope at construction when possible.
-func WithEntityID(evt events.Event, entityID string) events.Event {
-	return evt.WithEntityID(entityID)
+// MalformedProjectionWithoutAuthoritativeFacts builds the explicit negative
+// fixture for projection persistence tests that assert authoritative facts are
+// required.
+func MalformedProjectionWithoutAuthoritativeFacts(eventType events.EventType, sourceAgent string, payload json.RawMessage) events.Event {
+	return events.NewProjectionEvent(
+		"",
+		eventType,
+		sourceAgent,
+		"",
+		payload,
+		0,
+		"",
+		"",
+		events.EventEnvelope{},
+		time.Time{},
+	)
 }
 
-// WithFlowInstance keeps legacy fixture migration behind this test-only owner.
-// Prefer passing FlowInstance through EventEnvelope at construction when possible.
-func WithFlowInstance(evt events.Event, flowInstance string) events.Event {
-	return evt.WithFlowInstance(flowInstance)
-}
-
-// WithSourceRoute keeps route-context fixture patching behind this test-only
-// owner while route identity remains the concept under test.
-func WithSourceRoute(evt events.Event, route events.RouteIdentity) events.Event {
-	return evt.WithSourceRoute(route)
-}
-
-// WithTargetRoute keeps route-context fixture patching behind this test-only
-// owner while route identity remains the concept under test.
-func WithTargetRoute(evt events.Event, route events.RouteIdentity) events.Event {
-	return evt.WithTargetRoute(route)
-}
-
-// WithTargetSet keeps route-context fixture patching behind this test-only owner
-// while route identity remains the concept under test.
-func WithTargetSet(evt events.Event, routes []events.RouteIdentity) events.Event {
-	return evt.WithTargetSet(routes)
+// MalformedProjectionWithoutAuthoritativeRun builds the explicit negative
+// fixture for projection persistence tests where an event id and timestamp are
+// present but run lineage is intentionally absent.
+func MalformedProjectionWithoutAuthoritativeRun(id string, eventType events.EventType, sourceAgent string, payload json.RawMessage, createdAt time.Time) events.Event {
+	return events.NewProjectionEvent(
+		id,
+		eventType,
+		sourceAgent,
+		"",
+		payload,
+		0,
+		"",
+		"",
+		events.EventEnvelope{},
+		createdAt,
+	)
 }

--- a/internal/events/eventtest/eventtest.go
+++ b/internal/events/eventtest/eventtest.go
@@ -1,0 +1,97 @@
+// Package eventtest owns semantic event fixture construction for tests.
+//
+// Production code must use internal/events constructors directly. Tests should
+// choose the helper that names their fixture intent instead of constructing a
+// broad projection event and patching runtime-owned envelope fields afterward.
+package eventtest
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/division-sh/swarm/internal/events"
+)
+
+// RootIngress builds a test fixture for a root ingress event.
+func RootIngress(id string, eventType events.EventType, sourceAgent, taskID string, payload json.RawMessage, chainDepth int, runID, parentEventID string, envelope events.EventEnvelope, createdAt time.Time) events.Event {
+	return events.NewRootIngressEvent(id, eventType, sourceAgent, taskID, payload, chainDepth, runID, parentEventID, envelope, createdAt)
+}
+
+// RuntimeControl builds a test fixture for a runtime control event.
+func RuntimeControl(id string, eventType events.EventType, sourceAgent, taskID string, payload json.RawMessage, chainDepth int, runID, parentEventID string, envelope events.EventEnvelope, createdAt time.Time) events.Event {
+	return events.NewRuntimeControlEvent(id, eventType, sourceAgent, taskID, payload, chainDepth, runID, parentEventID, envelope, createdAt)
+}
+
+// RuntimeDiagnostic builds a test fixture for a runtime diagnostic event.
+func RuntimeDiagnostic(id string, eventType events.EventType, sourceAgent, taskID string, payload json.RawMessage, chainDepth int, runID, parentEventID string, envelope events.EventEnvelope, createdAt time.Time) events.Event {
+	return events.NewRuntimeDiagnosticEvent(id, eventType, sourceAgent, taskID, payload, chainDepth, runID, parentEventID, envelope, createdAt)
+}
+
+// DiagnosticDirect builds a test fixture for direct diagnostic persistence.
+func DiagnosticDirect(id string, eventType events.EventType, sourceAgent, taskID string, payload json.RawMessage, chainDepth int, runID, parentEventID string, envelope events.EventEnvelope, createdAt time.Time) events.Event {
+	return events.NewDiagnosticDirectEvent(id, eventType, sourceAgent, taskID, payload, chainDepth, runID, parentEventID, envelope, createdAt)
+}
+
+// Child builds a test fixture for a runtime child event derived from a parent.
+func Child(id string, eventType events.EventType, sourceAgent, taskID string, payload json.RawMessage, chainDepth int, parent events.Event, envelope events.EventEnvelope, createdAt time.Time) events.Event {
+	return events.NewChildEvent(id, eventType, sourceAgent, taskID, payload, chainDepth, parent, envelope, createdAt)
+}
+
+// ChildWithLineage builds a test fixture for a runtime child event when the
+// parent carrier is not available in the fixture.
+func ChildWithLineage(id string, eventType events.EventType, sourceAgent, taskID string, payload json.RawMessage, chainDepth int, lineage events.EventLineage, envelope events.EventEnvelope, createdAt time.Time) events.Event {
+	return events.NewChildEventWithLineage(id, eventType, sourceAgent, taskID, payload, chainDepth, lineage, envelope, createdAt)
+}
+
+// Replay builds a test fixture for replaying an already-recorded event.
+func Replay(id string, eventType events.EventType, sourceAgent, taskID string, payload json.RawMessage, chainDepth int, lineage events.EventLineage, envelope events.EventEnvelope, createdAt time.Time) events.Event {
+	return events.NewReplayEvent(id, eventType, sourceAgent, taskID, payload, chainDepth, lineage, envelope, createdAt)
+}
+
+// Projection builds a persisted projection/readback fixture from authoritative
+// event facts. Prefer the runtime-intent helpers above when a test fixture is
+// modeling a producer-created event.
+func Projection(id string, eventType events.EventType, sourceAgent, taskID string, payload json.RawMessage, chainDepth int, runID, parentEventID string, envelope events.EventEnvelope, createdAt time.Time) events.Event {
+	return events.NewProjectionEvent(id, eventType, sourceAgent, taskID, payload, chainDepth, runID, parentEventID, envelope, createdAt)
+}
+
+// RouteProbe builds a route-resolution probe fixture.
+func RouteProbe(eventType events.EventType) events.Event {
+	return events.NewRouteProbeEvent(eventType)
+}
+
+// WithEnvelope keeps legacy fixture migration behind this test-only owner.
+// Prefer passing the envelope to the semantic fixture constructor when possible.
+func WithEnvelope(evt events.Event, envelope events.EventEnvelope) events.Event {
+	return evt.WithEnvelope(envelope)
+}
+
+// WithEntityID keeps legacy fixture migration behind this test-only owner.
+// Prefer passing EntityID through EventEnvelope at construction when possible.
+func WithEntityID(evt events.Event, entityID string) events.Event {
+	return evt.WithEntityID(entityID)
+}
+
+// WithFlowInstance keeps legacy fixture migration behind this test-only owner.
+// Prefer passing FlowInstance through EventEnvelope at construction when possible.
+func WithFlowInstance(evt events.Event, flowInstance string) events.Event {
+	return evt.WithFlowInstance(flowInstance)
+}
+
+// WithSourceRoute keeps route-context fixture patching behind this test-only
+// owner while route identity remains the concept under test.
+func WithSourceRoute(evt events.Event, route events.RouteIdentity) events.Event {
+	return evt.WithSourceRoute(route)
+}
+
+// WithTargetRoute keeps route-context fixture patching behind this test-only
+// owner while route identity remains the concept under test.
+func WithTargetRoute(evt events.Event, route events.RouteIdentity) events.Event {
+	return evt.WithTargetRoute(route)
+}
+
+// WithTargetSet keeps route-context fixture patching behind this test-only owner
+// while route identity remains the concept under test.
+func WithTargetSet(evt events.Event, routes []events.RouteIdentity) events.Event {
+	return evt.WithTargetSet(routes)
+}

--- a/internal/runtime/agents/agent_llm_test.go
+++ b/internal/runtime/agents/agent_llm_test.go
@@ -29,7 +29,7 @@ import (
 func testBoardDirective(text string) runtimeagentcontrol.BoardDirective {
 	return runtimeagentcontrol.BoardDirective{
 		Directive: text,
-		Event: eventtest.Projection("00000000-0000-0000-0000-000000000101",
+		Event: eventtest.RootIngress("00000000-0000-0000-0000-000000000101",
 			events.EventType(runtimeagentcontrol.DirectiveEventType),
 			"runtime", "", []byte(`{"directive_text":"`+text+`","mode":"directive","run_id":"00000000-0000-0000-0000-000000000201","run_id_resolution":"new_run_allocated","source":"test"}`), 0, "00000000-0000-0000-0000-000000000201", "", events.EventEnvelope{}, time.Time{}),
 
@@ -45,11 +45,18 @@ func TestFormatEventForAgent_UsesPostCompositionToolSurface(t *testing.T) {
 		Mode:  "task",
 		Tools: []string{"schedule", "get_entity", "emit_example"},
 	}
-	evt := eventtest.WithEntityID((eventtest.Projection("evt-1",
+	evt := eventtest.RootIngress(
+		"evt-1",
 		"item.created",
 		"runtime",
 		"task-1",
-		[]byte(`{"item_id":"x"}`), 0, "", "", events.EventEnvelope{}, time.Time{})), "entity-1")
+		[]byte(`{"item_id":"x"}`),
+		0,
+		"",
+		"",
+		events.EnvelopeForEntityID(events.EventEnvelope{}, "entity-1"),
+		time.Time{},
+	)
 
 	formatted := formatEventForAgent(cfg, evt, []llm.ToolDefinition{
 		{Name: "get_entity"},
@@ -90,11 +97,18 @@ func TestFormatEventForAgent_UsesCanonicalNativeBuiltinNames(t *testing.T) {
 			Bash:   true,
 		},
 	}
-	evt := eventtest.WithEntityID((eventtest.Projection("evt-1",
+	evt := eventtest.RootIngress(
+		"evt-1",
 		"item.created",
 		"runtime",
 		"task-1",
-		[]byte(`{"item_id":"x"}`), 0, "", "", events.EventEnvelope{}, time.Time{})), "entity-1")
+		[]byte(`{"item_id":"x"}`),
+		0,
+		"",
+		"",
+		events.EnvelopeForEntityID(events.EventEnvelope{}, "entity-1"),
+		time.Time{},
+	)
 
 	formatted := formatEventForAgent(cfg, evt, []llm.ToolDefinition{
 		{Name: "query_entities"},
@@ -114,11 +128,18 @@ func TestFormatEventForAgent_DoesNotAdvertiseCLIOnlyControlTools(t *testing.T) {
 		Role: "operator",
 		Mode: "task",
 	}
-	evt := eventtest.WithEntityID((eventtest.Projection("evt-1",
+	evt := eventtest.RootIngress(
+		"evt-1",
 		"item.created",
 		"runtime",
 		"task-1",
-		[]byte(`{"item_id":"x"}`), 0, "", "", events.EventEnvelope{}, time.Time{})), "entity-1")
+		[]byte(`{"item_id":"x"}`),
+		0,
+		"",
+		"",
+		events.EnvelopeForEntityID(events.EventEnvelope{}, "entity-1"),
+		time.Time{},
+	)
 
 	formatted := formatEventForAgent(cfg, evt, []llm.ToolDefinition{
 		{Name: "query_entities"},
@@ -479,9 +500,18 @@ func TestLLMAgent_OnEvent_UsesSinglePostStepExecutionPath(t *testing.T) {
 		nil,
 	)
 
-	evt := eventtest.WithEntityID((eventtest.Projection("evt-1",
+	evt := eventtest.RootIngress(
+		"evt-1",
 		"analysis/requested",
-		"runtime", "", []byte(`{"entity_id":"ent-1"}`), 0, "", "", events.EventEnvelope{}, time.Time{})), "ent-1")
+		"runtime",
+		"",
+		[]byte(`{"entity_id":"ent-1"}`),
+		0,
+		"",
+		"",
+		events.EnvelopeForEntityID(events.EventEnvelope{}, "ent-1"),
+		time.Time{},
+	)
 
 	if _, err := agent.OnEvent(context.Background(), evt); err != nil {
 		t.Fatalf("OnEvent: %v", err)
@@ -495,7 +525,7 @@ type boardEmitExecutor struct{}
 
 func (boardEmitExecutor) Execute(ctx context.Context, name string, input any) (any, error) {
 	if rec, ok := runtimebus.EmittedEventsRecorderFromContext(ctx); ok && rec != nil {
-		rec.Append(eventtest.Projection("", events.EventType(strings.TrimPrefix(name, "emit_")), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}))
+		rec.Append(eventtest.RootIngress("", events.EventType(strings.TrimPrefix(name, "emit_")), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}))
 	}
 	return map[string]any{"ok": true, "name": name, "input": input}, nil
 }
@@ -707,9 +737,18 @@ func TestLLMAgentOnEvent_FiltersRoleScopedToolsByTurnEntityEligibility(t *testin
 		t.Fatalf("factory: %v", err)
 	}
 	llmAgent := agent.(*LLMAgent)
-	evt := eventtest.WithEntityID(eventtest.Projection("evt-root",
-		events.EventType("discovery/market_research.corpus_file_assigned"), "", "", []byte(`{"assignment":{"scan_id":"root-run-id","geography":"US"}}`), 0, "run-1", "", events.EventEnvelope{}, time.Time{}),
-		"root-run-id")
+	evt := eventtest.RootIngress(
+		"evt-root",
+		events.EventType("discovery/market_research.corpus_file_assigned"),
+		"",
+		"",
+		[]byte(`{"assignment":{"scan_id":"root-run-id","geography":"US"}}`),
+		0,
+		"run-1",
+		"",
+		events.EnvelopeForEntityID(events.EventEnvelope{}, "root-run-id"),
+		time.Time{},
+	)
 
 	if _, err := llmAgent.OnEvent(context.Background(), evt); err != nil {
 		t.Fatalf("OnEvent: %v", err)
@@ -959,9 +998,18 @@ func TestLLMAgent_TaskScopedFatalCLIErrorResetsConversationAndRetries(t *testing
 		nil,
 	)
 
-	evt := eventtest.WithEntityID((eventtest.Projection("evt-1",
+	evt := eventtest.RootIngress(
+		"evt-1",
 		"validation/spec_review.requested",
-		"runtime", "", []byte(`{"entity_id":"ent-1"}`), 0, "", "", events.EventEnvelope{}, time.Time{})), "ent-1")
+		"runtime",
+		"",
+		[]byte(`{"entity_id":"ent-1"}`),
+		0,
+		"",
+		"",
+		events.EnvelopeForEntityID(events.EventEnvelope{}, "ent-1"),
+		time.Time{},
+	)
 
 	if _, err := agent.OnEvent(context.Background(), evt); err != nil {
 		t.Fatalf("OnEvent: %v", err)
@@ -1002,10 +1050,18 @@ func TestLLMAgent_OnEvent_SeedsRunIDIntoConversationContext(t *testing.T) {
 		nil,
 	)
 
-	evt := eventtest.WithEntityID((eventtest.Projection("evt-1",
-
+	evt := eventtest.RootIngress(
+		"evt-1",
 		"scoring/scoring.requested",
-		"runtime", "", []byte(`{"entity_id":"ent-1"}`), 0, "run-123", "", events.EventEnvelope{}, time.Time{})), "ent-1")
+		"runtime",
+		"",
+		[]byte(`{"entity_id":"ent-1"}`),
+		0,
+		"run-123",
+		"",
+		events.EnvelopeForEntityID(events.EventEnvelope{}, "ent-1"),
+		time.Time{},
+	)
 
 	if _, err := agent.OnEvent(context.Background(), evt); err != nil {
 		t.Fatalf("OnEvent: %v", err)

--- a/internal/runtime/agents/agent_llm_test.go
+++ b/internal/runtime/agents/agent_llm_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/division-sh/swarm/internal/events"
+	"github.com/division-sh/swarm/internal/events/eventtest"
 	runtimeagentcontrol "github.com/division-sh/swarm/internal/runtime/agentcontrol"
 	runtimeauthority "github.com/division-sh/swarm/internal/runtime/authority"
 	runtimebus "github.com/division-sh/swarm/internal/runtime/bus"
@@ -28,7 +29,7 @@ import (
 func testBoardDirective(text string) runtimeagentcontrol.BoardDirective {
 	return runtimeagentcontrol.BoardDirective{
 		Directive: text,
-		Event: events.NewProjectionEvent("00000000-0000-0000-0000-000000000101",
+		Event: eventtest.Projection("00000000-0000-0000-0000-000000000101",
 			events.EventType(runtimeagentcontrol.DirectiveEventType),
 			"runtime", "", []byte(`{"directive_text":"`+text+`","mode":"directive","run_id":"00000000-0000-0000-0000-000000000201","run_id_resolution":"new_run_allocated","source":"test"}`), 0, "00000000-0000-0000-0000-000000000201", "", events.EventEnvelope{}, time.Time{}),
 
@@ -44,11 +45,11 @@ func TestFormatEventForAgent_UsesPostCompositionToolSurface(t *testing.T) {
 		Mode:  "task",
 		Tools: []string{"schedule", "get_entity", "emit_example"},
 	}
-	evt := (events.NewProjectionEvent("evt-1",
+	evt := eventtest.WithEntityID((eventtest.Projection("evt-1",
 		"item.created",
 		"runtime",
 		"task-1",
-		[]byte(`{"item_id":"x"}`), 0, "", "", events.EventEnvelope{}, time.Time{})).WithEntityID("entity-1")
+		[]byte(`{"item_id":"x"}`), 0, "", "", events.EventEnvelope{}, time.Time{})), "entity-1")
 
 	formatted := formatEventForAgent(cfg, evt, []llm.ToolDefinition{
 		{Name: "get_entity"},
@@ -89,11 +90,11 @@ func TestFormatEventForAgent_UsesCanonicalNativeBuiltinNames(t *testing.T) {
 			Bash:   true,
 		},
 	}
-	evt := (events.NewProjectionEvent("evt-1",
+	evt := eventtest.WithEntityID((eventtest.Projection("evt-1",
 		"item.created",
 		"runtime",
 		"task-1",
-		[]byte(`{"item_id":"x"}`), 0, "", "", events.EventEnvelope{}, time.Time{})).WithEntityID("entity-1")
+		[]byte(`{"item_id":"x"}`), 0, "", "", events.EventEnvelope{}, time.Time{})), "entity-1")
 
 	formatted := formatEventForAgent(cfg, evt, []llm.ToolDefinition{
 		{Name: "query_entities"},
@@ -113,11 +114,11 @@ func TestFormatEventForAgent_DoesNotAdvertiseCLIOnlyControlTools(t *testing.T) {
 		Role: "operator",
 		Mode: "task",
 	}
-	evt := (events.NewProjectionEvent("evt-1",
+	evt := eventtest.WithEntityID((eventtest.Projection("evt-1",
 		"item.created",
 		"runtime",
 		"task-1",
-		[]byte(`{"item_id":"x"}`), 0, "", "", events.EventEnvelope{}, time.Time{})).WithEntityID("entity-1")
+		[]byte(`{"item_id":"x"}`), 0, "", "", events.EventEnvelope{}, time.Time{})), "entity-1")
 
 	formatted := formatEventForAgent(cfg, evt, []llm.ToolDefinition{
 		{Name: "query_entities"},
@@ -478,9 +479,9 @@ func TestLLMAgent_OnEvent_UsesSinglePostStepExecutionPath(t *testing.T) {
 		nil,
 	)
 
-	evt := (events.NewProjectionEvent("evt-1",
+	evt := eventtest.WithEntityID((eventtest.Projection("evt-1",
 		"analysis/requested",
-		"runtime", "", []byte(`{"entity_id":"ent-1"}`), 0, "", "", events.EventEnvelope{}, time.Time{})).WithEntityID("ent-1")
+		"runtime", "", []byte(`{"entity_id":"ent-1"}`), 0, "", "", events.EventEnvelope{}, time.Time{})), "ent-1")
 
 	if _, err := agent.OnEvent(context.Background(), evt); err != nil {
 		t.Fatalf("OnEvent: %v", err)
@@ -494,7 +495,7 @@ type boardEmitExecutor struct{}
 
 func (boardEmitExecutor) Execute(ctx context.Context, name string, input any) (any, error) {
 	if rec, ok := runtimebus.EmittedEventsRecorderFromContext(ctx); ok && rec != nil {
-		rec.Append(events.NewProjectionEvent("", events.EventType(strings.TrimPrefix(name, "emit_")), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}))
+		rec.Append(eventtest.Projection("", events.EventType(strings.TrimPrefix(name, "emit_")), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}))
 	}
 	return map[string]any{"ok": true, "name": name, "input": input}, nil
 }
@@ -706,9 +707,10 @@ func TestLLMAgentOnEvent_FiltersRoleScopedToolsByTurnEntityEligibility(t *testin
 		t.Fatalf("factory: %v", err)
 	}
 	llmAgent := agent.(*LLMAgent)
-	evt := events.NewProjectionEvent("evt-root",
-		events.EventType("discovery/market_research.corpus_file_assigned"), "", "", []byte(`{"assignment":{"scan_id":"root-run-id","geography":"US"}}`), 0, "run-1", "", events.EventEnvelope{}, time.Time{}).
-		WithEntityID("root-run-id")
+	evt := eventtest.WithEntityID(eventtest.Projection("evt-root",
+		events.EventType("discovery/market_research.corpus_file_assigned"), "", "", []byte(`{"assignment":{"scan_id":"root-run-id","geography":"US"}}`), 0, "run-1", "", events.EventEnvelope{}, time.Time{}),
+		"root-run-id")
+
 	if _, err := llmAgent.OnEvent(context.Background(), evt); err != nil {
 		t.Fatalf("OnEvent: %v", err)
 	}
@@ -957,9 +959,9 @@ func TestLLMAgent_TaskScopedFatalCLIErrorResetsConversationAndRetries(t *testing
 		nil,
 	)
 
-	evt := (events.NewProjectionEvent("evt-1",
+	evt := eventtest.WithEntityID((eventtest.Projection("evt-1",
 		"validation/spec_review.requested",
-		"runtime", "", []byte(`{"entity_id":"ent-1"}`), 0, "", "", events.EventEnvelope{}, time.Time{})).WithEntityID("ent-1")
+		"runtime", "", []byte(`{"entity_id":"ent-1"}`), 0, "", "", events.EventEnvelope{}, time.Time{})), "ent-1")
 
 	if _, err := agent.OnEvent(context.Background(), evt); err != nil {
 		t.Fatalf("OnEvent: %v", err)
@@ -1000,10 +1002,10 @@ func TestLLMAgent_OnEvent_SeedsRunIDIntoConversationContext(t *testing.T) {
 		nil,
 	)
 
-	evt := (events.NewProjectionEvent("evt-1",
+	evt := eventtest.WithEntityID((eventtest.Projection("evt-1",
 
 		"scoring/scoring.requested",
-		"runtime", "", []byte(`{"entity_id":"ent-1"}`), 0, "run-123", "", events.EventEnvelope{}, time.Time{})).WithEntityID("ent-1")
+		"runtime", "", []byte(`{"entity_id":"ent-1"}`), 0, "run-123", "", events.EventEnvelope{}, time.Time{})), "ent-1")
 
 	if _, err := agent.OnEvent(context.Background(), evt); err != nil {
 		t.Fatalf("OnEvent: %v", err)

--- a/internal/runtime/artifact_action_result_delivery_test.go
+++ b/internal/runtime/artifact_action_result_delivery_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/division-sh/swarm/internal/events"
+	"github.com/division-sh/swarm/internal/events/eventtest"
 	runtimebus "github.com/division-sh/swarm/internal/runtime/bus"
 	runtimeflowidentity "github.com/division-sh/swarm/internal/runtime/core/flowidentity"
 	runtimepipeline "github.com/division-sh/swarm/internal/runtime/pipeline"
@@ -100,7 +101,7 @@ func TestArtifactRepoCommitResultEventsFlowThroughDurableCallbackDelivery(t *tes
 			if err != nil {
 				t.Fatalf("marshal request payload: %v", err)
 			}
-			requestEvent := events.NewProjectionEvent(
+			requestEvent := eventtest.WithFlowInstance(eventtest.WithEntityID(eventtest.Projection(
 				tc.requestEventID,
 				events.EventType("repo-scaffold/inst-1/repo_scaffold.repo_commit_requested"),
 				"test",
@@ -110,8 +111,10 @@ func TestArtifactRepoCommitResultEventsFlowThroughDurableCallbackDelivery(t *tes
 				templateInstanceDeliveryRunID,
 				"",
 				events.EventEnvelope{},
-				time.Now().UTC(),
-			).WithEntityID(artifactActionResultEntityID).WithFlowInstance("repo-scaffold/inst-1")
+				time.Now().UTC()),
+				artifactActionResultEntityID),
+				"repo-scaffold/inst-1")
+
 			if err := bus.Publish(ctx, requestEvent); err != nil {
 				t.Fatalf("Publish request event: %v", err)
 			}
@@ -255,7 +258,7 @@ func TestArtifactRepoCommitResultEventsFlowThroughStaticServiceCallbackDelivery(
 			if err != nil {
 				t.Fatalf("marshal request payload: %v", err)
 			}
-			requestEvent := events.NewProjectionEvent(
+			requestEvent := eventtest.WithFlowInstance(eventtest.WithEntityID(eventtest.Projection(
 				tc.requestEventID,
 				events.EventType("repo-scaffold/repo_scaffold.repo_commit_requested"),
 				"test",
@@ -265,8 +268,10 @@ func TestArtifactRepoCommitResultEventsFlowThroughStaticServiceCallbackDelivery(
 				templateInstanceDeliveryRunID,
 				"",
 				events.EventEnvelope{},
-				time.Now().UTC(),
-			).WithEntityID(artifactActionResultEntityID).WithFlowInstance(tc.requestFlowPath)
+				time.Now().UTC()),
+				artifactActionResultEntityID),
+				tc.requestFlowPath)
+
 			if err := bus.Publish(ctx, requestEvent); err != nil {
 				t.Fatalf("Publish request event: %v", err)
 			}

--- a/internal/runtime/artifact_action_result_delivery_test.go
+++ b/internal/runtime/artifact_action_result_delivery_test.go
@@ -101,7 +101,7 @@ func TestArtifactRepoCommitResultEventsFlowThroughDurableCallbackDelivery(t *tes
 			if err != nil {
 				t.Fatalf("marshal request payload: %v", err)
 			}
-			requestEvent := eventtest.WithFlowInstance(eventtest.WithEntityID(eventtest.Projection(
+			requestEvent := eventtest.RootIngress(
 				tc.requestEventID,
 				events.EventType("repo-scaffold/inst-1/repo_scaffold.repo_commit_requested"),
 				"test",
@@ -110,10 +110,9 @@ func TestArtifactRepoCommitResultEventsFlowThroughDurableCallbackDelivery(t *tes
 				0,
 				templateInstanceDeliveryRunID,
 				"",
-				events.EventEnvelope{},
-				time.Now().UTC()),
-				artifactActionResultEntityID),
-				"repo-scaffold/inst-1")
+				events.EnvelopeForFlowInstance(events.EnvelopeForEntityID(events.EventEnvelope{}, artifactActionResultEntityID), "repo-scaffold/inst-1"),
+				time.Now().UTC(),
+			)
 
 			if err := bus.Publish(ctx, requestEvent); err != nil {
 				t.Fatalf("Publish request event: %v", err)
@@ -258,7 +257,7 @@ func TestArtifactRepoCommitResultEventsFlowThroughStaticServiceCallbackDelivery(
 			if err != nil {
 				t.Fatalf("marshal request payload: %v", err)
 			}
-			requestEvent := eventtest.WithFlowInstance(eventtest.WithEntityID(eventtest.Projection(
+			requestEvent := eventtest.RootIngress(
 				tc.requestEventID,
 				events.EventType("repo-scaffold/repo_scaffold.repo_commit_requested"),
 				"test",
@@ -267,10 +266,9 @@ func TestArtifactRepoCommitResultEventsFlowThroughStaticServiceCallbackDelivery(
 				0,
 				templateInstanceDeliveryRunID,
 				"",
-				events.EventEnvelope{},
-				time.Now().UTC()),
-				artifactActionResultEntityID),
-				tc.requestFlowPath)
+				events.EnvelopeForFlowInstance(events.EnvelopeForEntityID(events.EventEnvelope{}, artifactActionResultEntityID), tc.requestFlowPath),
+				time.Now().UTC(),
+			)
 
 			if err := bus.Publish(ctx, requestEvent); err != nil {
 				t.Fatalf("Publish request event: %v", err)

--- a/internal/runtime/bus/connect_route_plan_dispatch_test.go
+++ b/internal/runtime/bus/connect_route_plan_dispatch_test.go
@@ -128,7 +128,7 @@ func TestEventBusPublish_ConnectRoutePlanPersistsSingularTargetWithoutLiveSubscr
 		t.Fatalf("receiver carrier route consumer/deploy.completed = %#v, want consumer-node receiver_carrier", receiverCarriers)
 	}
 	eventID := uuid.NewString()
-	evt := eventtest.Projection(eventID,
+	evt := eventtest.RootIngress(eventID,
 		events.EventType("producer/deploy.done"), "", "", json.RawMessage(`{"ignored":"yes"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())
 
 	want := events.DeliveryRoute{
@@ -199,7 +199,7 @@ func TestEventBusPublish_RootConnectRoutePlanPersistsSingularTarget(t *testing.T
 		t.Fatalf("receiver carrier route consumer/root.ready = %#v, want consumer-node receiver_carrier", receiverCarriers)
 	}
 	eventID := uuid.NewString()
-	evt := eventtest.Projection(eventID,
+	evt := eventtest.RootIngress(eventID,
 		events.EventType("root.ready"), "", "", json.RawMessage(`{"entity_id":"entity-1"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())
 
 	want := events.DeliveryRoute{
@@ -256,9 +256,18 @@ func TestEventBusPublish_RootConnectRoutePlanDoesNotCaptureChildScopedSameNameEv
 		t.Fatalf("NewEventBusWithOptions: %v", err)
 	}
 	eventID := uuid.NewString()
-	evt := eventtest.WithFlowInstance(eventtest.Projection(eventID,
-		events.EventType("root.ready"), "", "", json.RawMessage(`{"entity_id":"entity-1"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC()),
-		"producer/child-1")
+	evt := eventtest.RootIngress(
+		eventID,
+		events.EventType("root.ready"),
+		"",
+		"",
+		json.RawMessage(`{"entity_id":"entity-1"}`),
+		0,
+		"",
+		"",
+		events.EnvelopeForFlowInstance(events.EventEnvelope{}, "producer/child-1"),
+		time.Now().UTC(),
+	)
 
 	forbidden := events.DeliveryRoute{
 		SubscriberType: "node",
@@ -301,7 +310,7 @@ func TestEventBusCheckPublishRecipientPlan_ConnectRoutePlanPrecedesLegacyDescrip
 	if err != nil {
 		t.Fatalf("NewEventBusWithOptions: %v", err)
 	}
-	evt := eventtest.Projection(uuid.NewString(),
+	evt := eventtest.RootIngress(uuid.NewString(),
 		events.EventType("producer/deploy.done"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Now().UTC())
 
 	plan, err := eb.CheckPublishRecipientPlan(context.Background(), evt)
@@ -400,7 +409,7 @@ func TestEventBusPublishInMutation_ConnectRoutePlanPersistsSharedRoutePlan(t *te
 		t.Fatalf("NewEventBusWithOptions: %v", err)
 	}
 	eventID := uuid.NewString()
-	evt := eventtest.Projection(eventID,
+	evt := eventtest.RootIngress(eventID,
 		events.EventType("producer/deploy.done"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Now().UTC())
 
 	want := connectRoutePlanStaticDeliveryRoute()
@@ -436,7 +445,7 @@ func TestEngineOutbox_ConnectRoutePlanPersistsSharedRoutePlan(t *testing.T) {
 		t.Fatalf("NewEventBusWithOptions: %v", err)
 	}
 	eventID := uuid.NewString()
-	evt := eventtest.Projection(eventID,
+	evt := eventtest.RootIngress(eventID,
 		events.EventType("producer/deploy.done"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Now().UTC())
 
 	want := connectRoutePlanStaticDeliveryRoute()
@@ -478,7 +487,7 @@ func TestEventBusPlan_ConnectRoutePlanPreservesReplyLineage(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewEventBusWithOptions: %v", err)
 	}
-	evt := eventtest.Projection(uuid.NewString(),
+	evt := eventtest.RootIngress(uuid.NewString(),
 		events.EventType("producer/deploy.done"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Now().UTC())
 
 	plan, err := eb.planSubscribedRoutePlan(context.Background(), evt, false)
@@ -523,7 +532,7 @@ func TestEventBusPublish_ConnectRoutePlanPersistsTargetSetFanout(t *testing.T) {
 		t.Fatalf("receiver carrier route worker/alpha/ticket.ready = %#v, want worker-alpha receiver_carrier", resolvedAlpha)
 	}
 	eventID := uuid.NewString()
-	evt := eventtest.Projection(eventID,
+	evt := eventtest.RootIngress(eventID,
 		events.EventType("producer/ticket.ready"), "", "", json.RawMessage(`{"team_entity":"team-a"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())
 
 	wantAlpha := events.DeliveryRoute{SubscriberType: "node", SubscriberID: "worker-alpha", Target: events.RouteIdentity{FlowID: "worker", FlowInstance: "worker/alpha", EntityID: "team-a"}}
@@ -571,7 +580,7 @@ func TestEventBusResetInMemoryStateRefreshesConnectRoutePlanner(t *testing.T) {
 	}
 
 	eventID := uuid.NewString()
-	evt := eventtest.Projection(eventID,
+	evt := eventtest.RootIngress(eventID,
 		events.EventType("producer/ticket.ready"), "", "", json.RawMessage(`{"team_entity":"team-a"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())
 
 	wantBeta := events.DeliveryRoute{SubscriberType: "node", SubscriberID: "worker-beta", Target: events.RouteIdentity{FlowID: "worker", FlowInstance: "worker/beta", EntityID: "team-a"}}
@@ -629,7 +638,7 @@ func TestEventBusPublish_ConnectRoutePlanPersistsIndexedBusinessFieldTarget(t *t
 		t.Fatalf("AddFlowInstanceRoute: %v", err)
 	}
 	eventID := uuid.NewString()
-	evt := eventtest.Projection(eventID,
+	evt := eventtest.RootIngress(eventID,
 		events.EventType("producer/deploy.done"), "", "", json.RawMessage(`{"vertical_id":"v-1"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())
 
 	want := events.DeliveryRoute{SubscriberType: "node", SubscriberID: "consumer-node-one", Target: events.RouteIdentity{FlowID: "consumer", FlowInstance: "consumer/one", EntityID: "ent-1"}}
@@ -672,7 +681,7 @@ func TestEventBusPublish_ConnectRoutePlanPersistsIndexedBusinessFieldTargetSet(t
 		}
 	}
 	eventID := uuid.NewString()
-	evt := eventtest.Projection(eventID,
+	evt := eventtest.RootIngress(eventID,
 		events.EventType("producer/deploy.done"), "", "", json.RawMessage(`{"vertical_id":"v-1"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())
 
 	wantOne := events.DeliveryRoute{SubscriberType: "node", SubscriberID: "consumer-node-one", Target: events.RouteIdentity{FlowID: "consumer", FlowInstance: "consumer/one", EntityID: "ent-1"}}
@@ -770,7 +779,7 @@ func TestEventBusPublish_ConnectRoutePlanFailsClosedForBusinessFieldDescriptorGa
 			if err != nil {
 				t.Fatalf("NewEventBusWithOptions: %v", err)
 			}
-			evt := eventtest.Projection(uuid.NewString(),
+			evt := eventtest.RootIngress(uuid.NewString(),
 				events.EventType("producer/deploy.done"), "", "", json.RawMessage(tc.payload), 0, "", "", events.EventEnvelope{}, time.Now().UTC())
 
 			routePlan, err := eb.planSubscribedRoutePlan(context.Background(), evt, false)
@@ -807,7 +816,7 @@ func TestEventBusPublish_ConnectRoutePlanFailsClosedForUnsupportedBusinessFieldT
 	if err != nil {
 		t.Fatalf("NewEventBusWithOptions: %v", err)
 	}
-	evt := eventtest.Projection(uuid.NewString(),
+	evt := eventtest.RootIngress(uuid.NewString(),
 		events.EventType("producer/deploy.done"), "", "", json.RawMessage(`{"vertical_id":"v-1"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())
 
 	routePlan, err := eb.planSubscribedRoutePlan(context.Background(), evt, false)
@@ -877,7 +886,7 @@ func TestEventBusPublish_ConnectRoutePlanWithOnlySourceAndRawSubscribersFailsClo
 	sourceCh := eb.Subscribe("source-raw-listener", events.EventType("producer/deploy.done"), events.EventType("deploy.done"))
 	defer eb.Unsubscribe("source-raw-listener")
 	eventID := uuid.NewString()
-	evt := eventtest.Projection(eventID,
+	evt := eventtest.RootIngress(eventID,
 		events.EventType("producer/deploy.done"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Now().UTC())
 
 	routePlan, err := eb.planSubscribedRoutePlan(context.Background(), evt, false)
@@ -953,7 +962,7 @@ func TestEventBusPublish_ConnectRoutePlanFailsClosedForInvalidLoweredPlan(t *tes
 	if err != nil {
 		t.Fatalf("NewEventBusWithOptions: %v", err)
 	}
-	evt := eventtest.Projection(uuid.NewString(),
+	evt := eventtest.RootIngress(uuid.NewString(),
 		events.EventType("producer/deploy.done"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Now().UTC())
 
 	routePlan, err := eb.planSubscribedRoutePlan(context.Background(), evt, false)
@@ -1017,7 +1026,7 @@ func TestEventBusPublish_ConnectRoutePlanFailureSkipsRecipientPlanMaterializer(t
 	if err != nil {
 		t.Fatalf("NewEventBusWithOptions: %v", err)
 	}
-	evt := eventtest.Projection(uuid.NewString(),
+	evt := eventtest.RootIngress(uuid.NewString(),
 		events.EventType("producer/deploy.done"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Now().UTC())
 
 	routePlan, err := eb.planSubscribedRoutePlan(context.Background(), evt, false)
@@ -1056,7 +1065,7 @@ func TestEventBusPlan_UnmatchedCanonicalRouteUsesLowerPrecedenceFallback(t *test
 	}
 	ch := eb.Subscribe("legacy-agent", events.EventType("legacy.event"))
 	defer eb.Unsubscribe("legacy-agent")
-	evt := eventtest.Projection(uuid.NewString(),
+	evt := eventtest.RootIngress(uuid.NewString(),
 		events.EventType("legacy.event"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Now().UTC())
 
 	routePlan, err := eb.planSubscribedRoutePlan(context.Background(), evt, false)
@@ -1077,7 +1086,7 @@ func TestEventBusPlan_UnmatchedCanonicalRouteUsesLowerPrecedenceFallback(t *test
 }
 
 func TestRoutePlanCanonicalFailClosedDropsExecutableRoutes(t *testing.T) {
-	evt := eventtest.Projection(uuid.NewString(),
+	evt := eventtest.RootIngress(uuid.NewString(),
 		events.EventType("producer/deploy.done"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Now().UTC())
 
 	routePlan := newRoutePlan(evt)
@@ -1109,7 +1118,7 @@ func TestRoutePlanCanonicalFailClosedDropsExecutableRoutes(t *testing.T) {
 }
 
 func TestRoutePlanNormalizationPreservesAuthorityState(t *testing.T) {
-	evt := eventtest.Projection(uuid.NewString(),
+	evt := eventtest.RootIngress(uuid.NewString(),
 		events.EventType("producer/deploy.done"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Now().UTC())
 
 	routePlan := newRoutePlan(evt)

--- a/internal/runtime/bus/connect_route_plan_dispatch_test.go
+++ b/internal/runtime/bus/connect_route_plan_dispatch_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/division-sh/swarm/internal/events"
+	"github.com/division-sh/swarm/internal/events/eventtest"
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
 	runtimeflowidentity "github.com/division-sh/swarm/internal/runtime/core/flowidentity"
 	runtimepinrouting "github.com/division-sh/swarm/internal/runtime/core/pinrouting"
@@ -127,8 +128,9 @@ func TestEventBusPublish_ConnectRoutePlanPersistsSingularTargetWithoutLiveSubscr
 		t.Fatalf("receiver carrier route consumer/deploy.completed = %#v, want consumer-node receiver_carrier", receiverCarriers)
 	}
 	eventID := uuid.NewString()
-	evt := events.NewProjectionEvent(eventID,
+	evt := eventtest.Projection(eventID,
 		events.EventType("producer/deploy.done"), "", "", json.RawMessage(`{"ignored":"yes"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())
+
 	want := events.DeliveryRoute{
 		SubscriberType: "node",
 		SubscriberID:   "consumer-node",
@@ -197,8 +199,9 @@ func TestEventBusPublish_RootConnectRoutePlanPersistsSingularTarget(t *testing.T
 		t.Fatalf("receiver carrier route consumer/root.ready = %#v, want consumer-node receiver_carrier", receiverCarriers)
 	}
 	eventID := uuid.NewString()
-	evt := events.NewProjectionEvent(eventID,
+	evt := eventtest.Projection(eventID,
 		events.EventType("root.ready"), "", "", json.RawMessage(`{"entity_id":"entity-1"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())
+
 	want := events.DeliveryRoute{
 		SubscriberType: "node",
 		SubscriberID:   "consumer-node",
@@ -253,9 +256,10 @@ func TestEventBusPublish_RootConnectRoutePlanDoesNotCaptureChildScopedSameNameEv
 		t.Fatalf("NewEventBusWithOptions: %v", err)
 	}
 	eventID := uuid.NewString()
-	evt := events.NewProjectionEvent(eventID,
-		events.EventType("root.ready"), "", "", json.RawMessage(`{"entity_id":"entity-1"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC()).
-		WithFlowInstance("producer/child-1")
+	evt := eventtest.WithFlowInstance(eventtest.Projection(eventID,
+		events.EventType("root.ready"), "", "", json.RawMessage(`{"entity_id":"entity-1"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC()),
+		"producer/child-1")
+
 	forbidden := events.DeliveryRoute{
 		SubscriberType: "node",
 		SubscriberID:   "consumer-node",
@@ -297,7 +301,7 @@ func TestEventBusCheckPublishRecipientPlan_ConnectRoutePlanPrecedesLegacyDescrip
 	if err != nil {
 		t.Fatalf("NewEventBusWithOptions: %v", err)
 	}
-	evt := events.NewProjectionEvent(uuid.NewString(),
+	evt := eventtest.Projection(uuid.NewString(),
 		events.EventType("producer/deploy.done"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Now().UTC())
 
 	plan, err := eb.CheckPublishRecipientPlan(context.Background(), evt)
@@ -396,8 +400,9 @@ func TestEventBusPublishInMutation_ConnectRoutePlanPersistsSharedRoutePlan(t *te
 		t.Fatalf("NewEventBusWithOptions: %v", err)
 	}
 	eventID := uuid.NewString()
-	evt := events.NewProjectionEvent(eventID,
+	evt := eventtest.Projection(eventID,
 		events.EventType("producer/deploy.done"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Now().UTC())
+
 	want := connectRoutePlanStaticDeliveryRoute()
 	postCommitActions := make([]func(), 0, 1)
 	ctx := runtimepipeline.WithPipelinePostCommitActions(context.Background(), &postCommitActions)
@@ -431,8 +436,9 @@ func TestEngineOutbox_ConnectRoutePlanPersistsSharedRoutePlan(t *testing.T) {
 		t.Fatalf("NewEventBusWithOptions: %v", err)
 	}
 	eventID := uuid.NewString()
-	evt := events.NewProjectionEvent(eventID,
+	evt := eventtest.Projection(eventID,
 		events.EventType("producer/deploy.done"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Now().UTC())
+
 	want := connectRoutePlanStaticDeliveryRoute()
 
 	planned, err := (engineOutbox{bus: eb}).deliveryPlanForIntent(context.Background(), runtimeengine.EmitIntent{Event: evt})
@@ -472,7 +478,7 @@ func TestEventBusPlan_ConnectRoutePlanPreservesReplyLineage(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewEventBusWithOptions: %v", err)
 	}
-	evt := events.NewProjectionEvent(uuid.NewString(),
+	evt := eventtest.Projection(uuid.NewString(),
 		events.EventType("producer/deploy.done"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Now().UTC())
 
 	plan, err := eb.planSubscribedRoutePlan(context.Background(), evt, false)
@@ -517,8 +523,9 @@ func TestEventBusPublish_ConnectRoutePlanPersistsTargetSetFanout(t *testing.T) {
 		t.Fatalf("receiver carrier route worker/alpha/ticket.ready = %#v, want worker-alpha receiver_carrier", resolvedAlpha)
 	}
 	eventID := uuid.NewString()
-	evt := events.NewProjectionEvent(eventID,
+	evt := eventtest.Projection(eventID,
 		events.EventType("producer/ticket.ready"), "", "", json.RawMessage(`{"team_entity":"team-a"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())
+
 	wantAlpha := events.DeliveryRoute{SubscriberType: "node", SubscriberID: "worker-alpha", Target: events.RouteIdentity{FlowID: "worker", FlowInstance: "worker/alpha", EntityID: "team-a"}}
 	wantBeta := events.DeliveryRoute{SubscriberType: "node", SubscriberID: "worker-beta", Target: events.RouteIdentity{FlowID: "worker", FlowInstance: "worker/beta", EntityID: "team-a"}}
 
@@ -564,8 +571,9 @@ func TestEventBusResetInMemoryStateRefreshesConnectRoutePlanner(t *testing.T) {
 	}
 
 	eventID := uuid.NewString()
-	evt := events.NewProjectionEvent(eventID,
+	evt := eventtest.Projection(eventID,
 		events.EventType("producer/ticket.ready"), "", "", json.RawMessage(`{"team_entity":"team-a"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())
+
 	wantBeta := events.DeliveryRoute{SubscriberType: "node", SubscriberID: "worker-beta", Target: events.RouteIdentity{FlowID: "worker", FlowInstance: "worker/beta", EntityID: "team-a"}}
 
 	routePlan, err := eb.planSubscribedRoutePlan(context.Background(), evt, false)
@@ -621,8 +629,9 @@ func TestEventBusPublish_ConnectRoutePlanPersistsIndexedBusinessFieldTarget(t *t
 		t.Fatalf("AddFlowInstanceRoute: %v", err)
 	}
 	eventID := uuid.NewString()
-	evt := events.NewProjectionEvent(eventID,
+	evt := eventtest.Projection(eventID,
 		events.EventType("producer/deploy.done"), "", "", json.RawMessage(`{"vertical_id":"v-1"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())
+
 	want := events.DeliveryRoute{SubscriberType: "node", SubscriberID: "consumer-node-one", Target: events.RouteIdentity{FlowID: "consumer", FlowInstance: "consumer/one", EntityID: "ent-1"}}
 
 	routePlan, err := eb.planSubscribedRoutePlan(context.Background(), evt, false)
@@ -663,8 +672,9 @@ func TestEventBusPublish_ConnectRoutePlanPersistsIndexedBusinessFieldTargetSet(t
 		}
 	}
 	eventID := uuid.NewString()
-	evt := events.NewProjectionEvent(eventID,
+	evt := eventtest.Projection(eventID,
 		events.EventType("producer/deploy.done"), "", "", json.RawMessage(`{"vertical_id":"v-1"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())
+
 	wantOne := events.DeliveryRoute{SubscriberType: "node", SubscriberID: "consumer-node-one", Target: events.RouteIdentity{FlowID: "consumer", FlowInstance: "consumer/one", EntityID: "ent-1"}}
 	wantTwo := events.DeliveryRoute{SubscriberType: "node", SubscriberID: "consumer-node-two", Target: events.RouteIdentity{FlowID: "consumer", FlowInstance: "consumer/two", EntityID: "ent-2"}}
 
@@ -760,7 +770,7 @@ func TestEventBusPublish_ConnectRoutePlanFailsClosedForBusinessFieldDescriptorGa
 			if err != nil {
 				t.Fatalf("NewEventBusWithOptions: %v", err)
 			}
-			evt := events.NewProjectionEvent(uuid.NewString(),
+			evt := eventtest.Projection(uuid.NewString(),
 				events.EventType("producer/deploy.done"), "", "", json.RawMessage(tc.payload), 0, "", "", events.EventEnvelope{}, time.Now().UTC())
 
 			routePlan, err := eb.planSubscribedRoutePlan(context.Background(), evt, false)
@@ -797,7 +807,7 @@ func TestEventBusPublish_ConnectRoutePlanFailsClosedForUnsupportedBusinessFieldT
 	if err != nil {
 		t.Fatalf("NewEventBusWithOptions: %v", err)
 	}
-	evt := events.NewProjectionEvent(uuid.NewString(),
+	evt := eventtest.Projection(uuid.NewString(),
 		events.EventType("producer/deploy.done"), "", "", json.RawMessage(`{"vertical_id":"v-1"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())
 
 	routePlan, err := eb.planSubscribedRoutePlan(context.Background(), evt, false)
@@ -867,7 +877,7 @@ func TestEventBusPublish_ConnectRoutePlanWithOnlySourceAndRawSubscribersFailsClo
 	sourceCh := eb.Subscribe("source-raw-listener", events.EventType("producer/deploy.done"), events.EventType("deploy.done"))
 	defer eb.Unsubscribe("source-raw-listener")
 	eventID := uuid.NewString()
-	evt := events.NewProjectionEvent(eventID,
+	evt := eventtest.Projection(eventID,
 		events.EventType("producer/deploy.done"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Now().UTC())
 
 	routePlan, err := eb.planSubscribedRoutePlan(context.Background(), evt, false)
@@ -943,7 +953,7 @@ func TestEventBusPublish_ConnectRoutePlanFailsClosedForInvalidLoweredPlan(t *tes
 	if err != nil {
 		t.Fatalf("NewEventBusWithOptions: %v", err)
 	}
-	evt := events.NewProjectionEvent(uuid.NewString(),
+	evt := eventtest.Projection(uuid.NewString(),
 		events.EventType("producer/deploy.done"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Now().UTC())
 
 	routePlan, err := eb.planSubscribedRoutePlan(context.Background(), evt, false)
@@ -1007,7 +1017,7 @@ func TestEventBusPublish_ConnectRoutePlanFailureSkipsRecipientPlanMaterializer(t
 	if err != nil {
 		t.Fatalf("NewEventBusWithOptions: %v", err)
 	}
-	evt := events.NewProjectionEvent(uuid.NewString(),
+	evt := eventtest.Projection(uuid.NewString(),
 		events.EventType("producer/deploy.done"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Now().UTC())
 
 	routePlan, err := eb.planSubscribedRoutePlan(context.Background(), evt, false)
@@ -1046,7 +1056,7 @@ func TestEventBusPlan_UnmatchedCanonicalRouteUsesLowerPrecedenceFallback(t *test
 	}
 	ch := eb.Subscribe("legacy-agent", events.EventType("legacy.event"))
 	defer eb.Unsubscribe("legacy-agent")
-	evt := events.NewProjectionEvent(uuid.NewString(),
+	evt := eventtest.Projection(uuid.NewString(),
 		events.EventType("legacy.event"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Now().UTC())
 
 	routePlan, err := eb.planSubscribedRoutePlan(context.Background(), evt, false)
@@ -1067,8 +1077,9 @@ func TestEventBusPlan_UnmatchedCanonicalRouteUsesLowerPrecedenceFallback(t *test
 }
 
 func TestRoutePlanCanonicalFailClosedDropsExecutableRoutes(t *testing.T) {
-	evt := events.NewProjectionEvent(uuid.NewString(),
+	evt := eventtest.Projection(uuid.NewString(),
 		events.EventType("producer/deploy.done"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Now().UTC())
+
 	routePlan := newRoutePlan(evt)
 	routePlan.MarkCanonicalRouteFailedClosed(routeIntentProducerConnectRoutePlan, runtimepinrouting.FailureTargetNotSubscribed)
 	routePlan.AddLiveRecipients(RoutePlanLiveRecipient{
@@ -1098,8 +1109,9 @@ func TestRoutePlanCanonicalFailClosedDropsExecutableRoutes(t *testing.T) {
 }
 
 func TestRoutePlanNormalizationPreservesAuthorityState(t *testing.T) {
-	evt := events.NewProjectionEvent(uuid.NewString(),
+	evt := eventtest.Projection(uuid.NewString(),
 		events.EventType("producer/deploy.done"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Now().UTC())
+
 	routePlan := newRoutePlan(evt)
 	routePlan.MarkCanonicalRouteMatched(routeIntentProducerConnectRoutePlan)
 	routePlan.AddDeliveryIntents(RoutePlanDeliveryIntent{

--- a/internal/runtime/bus/delivery_planner_test.go
+++ b/internal/runtime/bus/delivery_planner_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/division-sh/swarm/internal/events"
+	"github.com/division-sh/swarm/internal/events/eventtest"
 	runtimepinrouting "github.com/division-sh/swarm/internal/runtime/core/pinrouting"
 	"time"
 )
@@ -40,7 +41,7 @@ func TestDeliveryRouteResolver_SeparatesRouteResolutionAndDiagnostics(t *testing
 		},
 	}
 
-	result := resolver.Resolve(events.NewProjectionEvent("", events.EventType("producer/scan.requested"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}))
+	result := resolver.Resolve(eventtest.Projection("", events.EventType("producer/scan.requested"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}))
 	if got, want := len(result.RoutedRecipients), 1; got != want {
 		t.Fatalf("routed recipients = %d, want %d", got, want)
 	}
@@ -79,7 +80,7 @@ func TestDeliveryRecipientPolicy_FiltersExplicitAgentScopeIntoManifest(t *testin
 		},
 	}
 
-	manifest, err := policy.Evaluate(context.Background(), (events.NewProjectionEvent("", "task.completed", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{})).WithEntityID("ent-1"), agentDeliveryRecipientCandidates([]string{"entity-agent", "other-agent", "shared-agent"}))
+	manifest, err := policy.Evaluate(context.Background(), eventtest.WithEntityID((eventtest.Projection("", "task.completed", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{})), "ent-1"), agentDeliveryRecipientCandidates([]string{"entity-agent", "other-agent", "shared-agent"}))
 	if err != nil {
 		t.Fatalf("Evaluate: %v", err)
 	}
@@ -103,7 +104,7 @@ func TestDeliveryRecipientPolicy_KeepsInternalSubscribersLiveOnlyUnderDescriptor
 		},
 	}
 
-	manifest, err := policy.Evaluate(context.Background(), events.NewProjectionEvent("", "task.completed", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}), []deliveryRecipientCandidate{
+	manifest, err := policy.Evaluate(context.Background(), eventtest.Projection("", "task.completed", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}), []deliveryRecipientCandidate{
 		{ID: "workflow-runtime", PersistAsDelivery: false},
 		{ID: "node:scan-orchestrator", PersistAsDelivery: false},
 		{ID: "agent-a", PersistAsDelivery: true},
@@ -129,7 +130,7 @@ func TestDeliveryRecipientPolicy_TargetedEventFailsWhenTargetInstanceIsGone(t *t
 		},
 	}
 
-	manifest, err := policy.Evaluate(context.Background(), (events.NewProjectionEvent("", "task.completed", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{})).WithTargetRoute(events.RouteIdentity{EntityID: "ent-2", FlowInstance: "flow/missing"}), agentDeliveryRecipientCandidates([]string{"agent-a"}))
+	manifest, err := policy.Evaluate(context.Background(), eventtest.WithTargetRoute((eventtest.Projection("", "task.completed", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{})), events.RouteIdentity{EntityID: "ent-2", FlowInstance: "flow/missing"}), agentDeliveryRecipientCandidates([]string{"agent-a"}))
 	if err != nil {
 		t.Fatalf("Evaluate: %v", err)
 	}
@@ -150,7 +151,7 @@ func TestDeliveryRecipientPolicy_TargetedEventFailsWhenTargetDoesNotSubscribe(t 
 		},
 	}
 
-	manifest, err := policy.Evaluate(context.Background(), (events.NewProjectionEvent("", "task.completed", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{})).WithTargetRoute(events.RouteIdentity{EntityID: "ent-1", FlowInstance: "flow/target"}), agentDeliveryRecipientCandidates([]string{"other-agent"}))
+	manifest, err := policy.Evaluate(context.Background(), eventtest.WithTargetRoute((eventtest.Projection("", "task.completed", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{})), events.RouteIdentity{EntityID: "ent-1", FlowInstance: "flow/target"}), agentDeliveryRecipientCandidates([]string{"other-agent"}))
 	if err != nil {
 		t.Fatalf("Evaluate: %v", err)
 	}
@@ -177,10 +178,11 @@ func TestDeliveryRecipientPolicy_TargetedFlowInstanceWithoutSubscriberIsNotSubsc
 
 	manifest, err := policy.Evaluate(
 		context.Background(),
-		(events.NewProjectionEvent("", "component.service.completed", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{})).WithTargetRoute(events.RouteIdentity{
+		eventtest.WithTargetRoute((eventtest.Projection("", "component.service.completed", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{})), events.RouteIdentity{
 			EntityID:     target.EntityID,
 			FlowInstance: target.FlowInstance,
 		}),
+
 		nil,
 	)
 	if err != nil {
@@ -205,10 +207,11 @@ func TestDeliveryRecipientPolicy_TargetedFlowInstanceMissingIsUnreachableTermina
 
 	manifest, err := policy.Evaluate(
 		context.Background(),
-		(events.NewProjectionEvent("", "component.service.completed", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{})).WithTargetRoute(events.RouteIdentity{
+		eventtest.WithTargetRoute((eventtest.Projection("", "component.service.completed", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{})), events.RouteIdentity{
 			EntityID:     ActiveTargetDescriptor{FlowInstance: "component-scaffold/missing"}.Normalized().EntityID,
 			FlowInstance: "component-scaffold/missing",
 		}),
+
 		nil,
 	)
 	if err != nil {
@@ -242,7 +245,7 @@ func TestDeliveryPlanner_ComposesRoutingPolicyAndManifest(t *testing.T) {
 		},
 	)
 
-	plan, err := planner.Plan(context.Background(), events.NewProjectionEvent("", "task.completed", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}))
+	plan, err := planner.Plan(context.Background(), eventtest.Projection("", "task.completed", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}))
 	if err != nil {
 		t.Fatalf("Plan: %v", err)
 	}
@@ -296,7 +299,7 @@ func TestDeliveryPlanner_DoesNotDeadLetterTargetedWorkflowNodeSubscriber(t *test
 		},
 	)
 
-	plan, err := planner.Plan(context.Background(), (events.NewProjectionEvent("", "child/output.done", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{})).WithTargetRoute(events.RouteIdentity{EntityID: "ent-1"}))
+	plan, err := planner.Plan(context.Background(), eventtest.WithTargetRoute((eventtest.Projection("", "child/output.done", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{})), events.RouteIdentity{EntityID: "ent-1"}))
 	if err != nil {
 		t.Fatalf("Plan: %v", err)
 	}
@@ -339,7 +342,7 @@ func TestDeliveryPlanner_TargetedParentRoutePersistsSemanticNodeRoute(t *testing
 	)
 
 	parentRoute := events.RouteIdentity{EntityID: "parent-entity", FlowInstance: "parent/inst-1"}
-	plan, err := planner.Plan(context.Background(), (events.NewProjectionEvent("", "child/output.done", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{})).WithTargetRoute(parentRoute))
+	plan, err := planner.Plan(context.Background(), eventtest.WithTargetRoute((eventtest.Projection("", "child/output.done", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{})), parentRoute))
 	if err != nil {
 		t.Fatalf("Plan: %v", err)
 	}
@@ -374,7 +377,7 @@ func TestDeliveryPlanner_PreservesTargetFailureWhenRoutedNodeDoesNotMatchTarget(
 		},
 	)
 
-	plan, err := planner.Plan(context.Background(), (events.NewProjectionEvent("", "child/output.done", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{})).WithTargetRoute(events.RouteIdentity{EntityID: "ent-1", FlowInstance: "target-flow"}))
+	plan, err := planner.Plan(context.Background(), eventtest.WithTargetRoute((eventtest.Projection("", "child/output.done", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{})), events.RouteIdentity{EntityID: "ent-1", FlowInstance: "target-flow"}))
 	if err != nil {
 		t.Fatalf("Plan: %v", err)
 	}
@@ -406,7 +409,7 @@ func TestDeliveryPlanner_ExpandsTargetSetForInternalWorkflowRecipient(t *testing
 		},
 	)
 
-	plan, err := planner.Plan(context.Background(), (events.NewProjectionEvent("", "child/output.done", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{})).WithTargetSet([]events.RouteIdentity{
+	plan, err := planner.Plan(context.Background(), eventtest.WithTargetSet((eventtest.Projection("", "child/output.done", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{})), []events.RouteIdentity{
 		{FlowInstance: "child-a/inst-1", EntityID: "ent-a"},
 		{FlowInstance: "child-b/inst-1", EntityID: "ent-b"},
 	}))
@@ -473,7 +476,7 @@ func TestDeliveryPlanner_ExpandsTargetSetForSameSemanticNode(t *testing.T) {
 		},
 	)
 
-	plan, err := planner.Plan(context.Background(), (events.NewProjectionEvent("", "worker/work.assign", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{})).WithTargetSet([]events.RouteIdentity{
+	plan, err := planner.Plan(context.Background(), eventtest.WithTargetSet((eventtest.Projection("", "worker/work.assign", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{})), []events.RouteIdentity{
 		{FlowInstance: "worker/w-001", EntityID: "worker/w-001"},
 		{FlowInstance: "worker/w-002", EntityID: "worker/w-002"},
 	}))
@@ -521,7 +524,7 @@ func TestDeliveryPlanner_NoTargetConcreteRoutedNodePersistsSemanticNodeRoute(t *
 		},
 	)
 
-	plan, err := planner.Plan(context.Background(), (events.NewProjectionEvent("", "operating/inst-1/opco.product_initialization_requested", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{})).WithEntityID("ent-operating").WithFlowInstance("operating/inst-1"))
+	plan, err := planner.Plan(context.Background(), eventtest.WithFlowInstance(eventtest.WithEntityID((eventtest.Projection("", "operating/inst-1/opco.product_initialization_requested", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{})), "ent-operating"), "operating/inst-1"))
 	if err != nil {
 		t.Fatalf("Plan: %v", err)
 	}
@@ -554,7 +557,7 @@ func TestDeliveryPlanner_NoTargetConcreteRoutedNodePersistsSemanticNodeRoute(t *
 }
 
 func TestRoutedNodeInternalSubscriptionAliases_NestedSemanticScopeDoesNotLeakParentConcreteRoute(t *testing.T) {
-	evt := (events.NewProjectionEvent("", events.EventType("child/grandchild/micro.started"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{})).WithFlowInstance("child/grandchild/inst-1")
+	evt := eventtest.WithFlowInstance((eventtest.Projection("", events.EventType("child/grandchild/micro.started"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{})), "child/grandchild/inst-1")
 
 	aliases := routedNodeInternalSubscriptionAliases(evt, []Subscriber{{
 		ID:   "grandchild-worker",
@@ -626,7 +629,7 @@ func TestRoutedEventKeysForPlan_RuntimeCallbackLocalEventWithFlowInstanceDerives
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			got := routedEventKeysForPlan((events.NewProjectionEvent("", events.EventType(tc.eventType), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{})).WithFlowInstance(tc.flowInstance))
+			got := routedEventKeysForPlan(eventtest.WithFlowInstance((eventtest.Projection("", events.EventType(tc.eventType), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{})), tc.flowInstance))
 			if len(got) != len(tc.want) {
 				t.Fatalf("event keys = %#v, want %#v", got, tc.want)
 			}
@@ -657,7 +660,7 @@ func TestResolveInternalRecipientsForRoutedNodePlanning_DoesNotSelectParentConcr
 	eb.SubscribeInternal("parent-carrier", events.EventType("child/inst-1/micro.started"))
 	defer eb.Unsubscribe("parent-carrier")
 
-	evt := (events.NewProjectionEvent("", events.EventType("child/grandchild/micro.started"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{})).WithFlowInstance("child/grandchild/inst-1")
+	evt := eventtest.WithFlowInstance((eventtest.Projection("", events.EventType("child/grandchild/micro.started"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{})), "child/grandchild/inst-1")
 	got := eb.resolveInternalRecipientsForRoutedNodePlanning(evt, []Subscriber{{
 		ID:   "grandchild-worker",
 		Type: "node",
@@ -693,7 +696,7 @@ func TestDeliveryPlanner_NoTargetRootRoutedNodeUsesSemanticNodeDeliveryRoute(t *
 		},
 	)
 
-	plan, err := planner.Plan(context.Background(), (events.NewProjectionEvent("", "opco.spinup_requested", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{})).WithEntityID("ent-root"))
+	plan, err := planner.Plan(context.Background(), eventtest.WithEntityID((eventtest.Projection("", "opco.spinup_requested", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{})), "ent-root"))
 	if err != nil {
 		t.Fatalf("Plan: %v", err)
 	}
@@ -745,7 +748,7 @@ func TestDeliveryPlanner_NoTargetRootLocalEventWithFlowInstanceUsesRootNodeRoute
 		},
 	)
 
-	plan, err := planner.Plan(context.Background(), (events.NewProjectionEvent("", "timer.check", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{})).WithEntityID("ent-root").WithFlowInstance("11111111-1111-4111-8111-111111111111"))
+	plan, err := planner.Plan(context.Background(), eventtest.WithFlowInstance(eventtest.WithEntityID((eventtest.Projection("", "timer.check", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{})), "ent-root"), "11111111-1111-4111-8111-111111111111"))
 	if err != nil {
 		t.Fatalf("Plan: %v", err)
 	}
@@ -803,7 +806,7 @@ func TestDeliveryPlanner_NoTargetScopedRoutedNodeUsesSemanticNodeDeliveryRoute(t
 		},
 	)
 
-	plan, err := planner.Plan(context.Background(), (events.NewProjectionEvent("", "child/child.start", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{})).WithEntityID("ent-child"))
+	plan, err := planner.Plan(context.Background(), eventtest.WithEntityID((eventtest.Projection("", "child/child.start", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{})), "ent-child"))
 	if err != nil {
 		t.Fatalf("Plan: %v", err)
 	}
@@ -869,7 +872,7 @@ func TestDeliveryPlanner_NoTargetScopedEventPreservesPathlessRoutedNodeRoute(t *
 		},
 	)
 
-	plan, err := planner.Plan(context.Background(), (events.NewProjectionEvent("", "child/child.start", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{})).WithEntityID("ent-child"))
+	plan, err := planner.Plan(context.Background(), eventtest.WithEntityID((eventtest.Projection("", "child/child.start", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{})), "ent-child"))
 	if err != nil {
 		t.Fatalf("Plan: %v", err)
 	}
@@ -926,7 +929,7 @@ func TestDeliveryPlanner_NoTargetCrossFlowStaticRoutedNodeUsesSubscriberScope(t 
 		},
 	)
 
-	plan, err := planner.Plan(context.Background(), (events.NewProjectionEvent("", "flow-b/order.completed", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{})).WithEntityID("ent-flow-b").WithFlowInstance("flow-b/inst-1"))
+	plan, err := planner.Plan(context.Background(), eventtest.WithFlowInstance(eventtest.WithEntityID((eventtest.Projection("", "flow-b/order.completed", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{})), "ent-flow-b"), "flow-b/inst-1"))
 	if err != nil {
 		t.Fatalf("Plan: %v", err)
 	}
@@ -984,7 +987,7 @@ func TestDeliveryPlanner_NoTargetWildcardStaticServiceRoutedNodeUsesSubscriberSc
 		},
 	)
 
-	plan, err := planner.Plan(context.Background(), (events.NewProjectionEvent("", "component-scaffold/component-a/opco.repo_scaffold_requested", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{})).WithEntityID("ent-component").WithFlowInstance("component-scaffold/component-a"))
+	plan, err := planner.Plan(context.Background(), eventtest.WithFlowInstance(eventtest.WithEntityID((eventtest.Projection("", "component-scaffold/component-a/opco.repo_scaffold_requested", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{})), "ent-component"), "component-scaffold/component-a"))
 	if err != nil {
 		t.Fatalf("Plan: %v", err)
 	}
@@ -1042,7 +1045,7 @@ func TestDeliveryPlanner_NoTargetDescendantScopedRoutedNodeUsesParentInstanceRou
 		},
 	)
 
-	plan, err := planner.Plan(context.Background(), (events.NewProjectionEvent("", "child/grandchild/micro.start", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{})).WithEntityID("ent-child").WithFlowInstance("child/inst-1"))
+	plan, err := planner.Plan(context.Background(), eventtest.WithFlowInstance(eventtest.WithEntityID((eventtest.Projection("", "child/grandchild/micro.start", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{})), "ent-child"), "child/inst-1"))
 	if err != nil {
 		t.Fatalf("Plan: %v", err)
 	}
@@ -1087,7 +1090,7 @@ func TestDeliveryPlanner_FailsClosedOnPolicyError(t *testing.T) {
 		},
 	)
 
-	_, err := planner.Plan(context.Background(), events.NewProjectionEvent("", "task.completed", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}))
+	_, err := planner.Plan(context.Background(), eventtest.Projection("", "task.completed", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}))
 	if err == nil || err.Error() != "descriptor store unavailable" {
 		t.Fatalf("Plan err = %v, want descriptor store unavailable", err)
 	}

--- a/internal/runtime/bus/delivery_planner_test.go
+++ b/internal/runtime/bus/delivery_planner_test.go
@@ -41,7 +41,7 @@ func TestDeliveryRouteResolver_SeparatesRouteResolutionAndDiagnostics(t *testing
 		},
 	}
 
-	result := resolver.Resolve(eventtest.Projection("", events.EventType("producer/scan.requested"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}))
+	result := resolver.Resolve(eventtest.RootIngress("", events.EventType("producer/scan.requested"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}))
 	if got, want := len(result.RoutedRecipients), 1; got != want {
 		t.Fatalf("routed recipients = %d, want %d", got, want)
 	}
@@ -80,7 +80,7 @@ func TestDeliveryRecipientPolicy_FiltersExplicitAgentScopeIntoManifest(t *testin
 		},
 	}
 
-	manifest, err := policy.Evaluate(context.Background(), eventtest.WithEntityID((eventtest.Projection("", "task.completed", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{})), "ent-1"), agentDeliveryRecipientCandidates([]string{"entity-agent", "other-agent", "shared-agent"}))
+	manifest, err := policy.Evaluate(context.Background(), eventtest.RootIngress("", "task.completed", "", "", nil, 0, "", "", events.EnvelopeForEntityID(events.EventEnvelope{}, "ent-1"), time.Time{}), agentDeliveryRecipientCandidates([]string{"entity-agent", "other-agent", "shared-agent"}))
 	if err != nil {
 		t.Fatalf("Evaluate: %v", err)
 	}
@@ -104,7 +104,7 @@ func TestDeliveryRecipientPolicy_KeepsInternalSubscribersLiveOnlyUnderDescriptor
 		},
 	}
 
-	manifest, err := policy.Evaluate(context.Background(), eventtest.Projection("", "task.completed", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}), []deliveryRecipientCandidate{
+	manifest, err := policy.Evaluate(context.Background(), eventtest.RootIngress("", "task.completed", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}), []deliveryRecipientCandidate{
 		{ID: "workflow-runtime", PersistAsDelivery: false},
 		{ID: "node:scan-orchestrator", PersistAsDelivery: false},
 		{ID: "agent-a", PersistAsDelivery: true},
@@ -130,7 +130,18 @@ func TestDeliveryRecipientPolicy_TargetedEventFailsWhenTargetInstanceIsGone(t *t
 		},
 	}
 
-	manifest, err := policy.Evaluate(context.Background(), eventtest.WithTargetRoute((eventtest.Projection("", "task.completed", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{})), events.RouteIdentity{EntityID: "ent-2", FlowInstance: "flow/missing"}), agentDeliveryRecipientCandidates([]string{"agent-a"}))
+	manifest, err := policy.Evaluate(context.Background(), eventtest.RootIngress(
+		"",
+		"task.completed",
+		"",
+		"",
+		nil,
+		0,
+		"",
+		"",
+		events.EnvelopeForTargetRoute(events.EventEnvelope{}, events.RouteIdentity{EntityID: "ent-2", FlowInstance: "flow/missing"}),
+		time.Time{},
+	), agentDeliveryRecipientCandidates([]string{"agent-a"}))
 	if err != nil {
 		t.Fatalf("Evaluate: %v", err)
 	}
@@ -151,7 +162,18 @@ func TestDeliveryRecipientPolicy_TargetedEventFailsWhenTargetDoesNotSubscribe(t 
 		},
 	}
 
-	manifest, err := policy.Evaluate(context.Background(), eventtest.WithTargetRoute((eventtest.Projection("", "task.completed", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{})), events.RouteIdentity{EntityID: "ent-1", FlowInstance: "flow/target"}), agentDeliveryRecipientCandidates([]string{"other-agent"}))
+	manifest, err := policy.Evaluate(context.Background(), eventtest.RootIngress(
+		"",
+		"task.completed",
+		"",
+		"",
+		nil,
+		0,
+		"",
+		"",
+		events.EnvelopeForTargetRoute(events.EventEnvelope{}, events.RouteIdentity{EntityID: "ent-1", FlowInstance: "flow/target"}),
+		time.Time{},
+	), agentDeliveryRecipientCandidates([]string{"other-agent"}))
 	if err != nil {
 		t.Fatalf("Evaluate: %v", err)
 	}
@@ -178,10 +200,21 @@ func TestDeliveryRecipientPolicy_TargetedFlowInstanceWithoutSubscriberIsNotSubsc
 
 	manifest, err := policy.Evaluate(
 		context.Background(),
-		eventtest.WithTargetRoute((eventtest.Projection("", "component.service.completed", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{})), events.RouteIdentity{
-			EntityID:     target.EntityID,
-			FlowInstance: target.FlowInstance,
-		}),
+		eventtest.RootIngress(
+			"",
+			"component.service.completed",
+			"",
+			"",
+			nil,
+			0,
+			"",
+			"",
+			events.EnvelopeForTargetRoute(events.EventEnvelope{}, events.RouteIdentity{
+				EntityID:     target.EntityID,
+				FlowInstance: target.FlowInstance,
+			}),
+			time.Time{},
+		),
 
 		nil,
 	)
@@ -207,10 +240,21 @@ func TestDeliveryRecipientPolicy_TargetedFlowInstanceMissingIsUnreachableTermina
 
 	manifest, err := policy.Evaluate(
 		context.Background(),
-		eventtest.WithTargetRoute((eventtest.Projection("", "component.service.completed", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{})), events.RouteIdentity{
-			EntityID:     ActiveTargetDescriptor{FlowInstance: "component-scaffold/missing"}.Normalized().EntityID,
-			FlowInstance: "component-scaffold/missing",
-		}),
+		eventtest.RootIngress(
+			"",
+			"component.service.completed",
+			"",
+			"",
+			nil,
+			0,
+			"",
+			"",
+			events.EnvelopeForTargetRoute(events.EventEnvelope{}, events.RouteIdentity{
+				EntityID:     ActiveTargetDescriptor{FlowInstance: "component-scaffold/missing"}.Normalized().EntityID,
+				FlowInstance: "component-scaffold/missing",
+			}),
+			time.Time{},
+		),
 
 		nil,
 	)
@@ -245,7 +289,7 @@ func TestDeliveryPlanner_ComposesRoutingPolicyAndManifest(t *testing.T) {
 		},
 	)
 
-	plan, err := planner.Plan(context.Background(), eventtest.Projection("", "task.completed", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}))
+	plan, err := planner.Plan(context.Background(), eventtest.RootIngress("", "task.completed", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}))
 	if err != nil {
 		t.Fatalf("Plan: %v", err)
 	}
@@ -299,7 +343,18 @@ func TestDeliveryPlanner_DoesNotDeadLetterTargetedWorkflowNodeSubscriber(t *test
 		},
 	)
 
-	plan, err := planner.Plan(context.Background(), eventtest.WithTargetRoute((eventtest.Projection("", "child/output.done", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{})), events.RouteIdentity{EntityID: "ent-1"}))
+	plan, err := planner.Plan(context.Background(), eventtest.RootIngress(
+		"",
+		"child/output.done",
+		"",
+		"",
+		nil,
+		0,
+		"",
+		"",
+		events.EnvelopeForTargetRoute(events.EventEnvelope{}, events.RouteIdentity{EntityID: "ent-1"}),
+		time.Time{},
+	))
 	if err != nil {
 		t.Fatalf("Plan: %v", err)
 	}
@@ -342,7 +397,7 @@ func TestDeliveryPlanner_TargetedParentRoutePersistsSemanticNodeRoute(t *testing
 	)
 
 	parentRoute := events.RouteIdentity{EntityID: "parent-entity", FlowInstance: "parent/inst-1"}
-	plan, err := planner.Plan(context.Background(), eventtest.WithTargetRoute((eventtest.Projection("", "child/output.done", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{})), parentRoute))
+	plan, err := planner.Plan(context.Background(), eventtest.RootIngress("", "child/output.done", "", "", nil, 0, "", "", events.EnvelopeForTargetRoute(events.EventEnvelope{}, parentRoute), time.Time{}))
 	if err != nil {
 		t.Fatalf("Plan: %v", err)
 	}
@@ -377,7 +432,18 @@ func TestDeliveryPlanner_PreservesTargetFailureWhenRoutedNodeDoesNotMatchTarget(
 		},
 	)
 
-	plan, err := planner.Plan(context.Background(), eventtest.WithTargetRoute((eventtest.Projection("", "child/output.done", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{})), events.RouteIdentity{EntityID: "ent-1", FlowInstance: "target-flow"}))
+	plan, err := planner.Plan(context.Background(), eventtest.RootIngress(
+		"",
+		"child/output.done",
+		"",
+		"",
+		nil,
+		0,
+		"",
+		"",
+		events.EnvelopeForTargetRoute(events.EventEnvelope{}, events.RouteIdentity{EntityID: "ent-1", FlowInstance: "target-flow"}),
+		time.Time{},
+	))
 	if err != nil {
 		t.Fatalf("Plan: %v", err)
 	}
@@ -409,10 +475,21 @@ func TestDeliveryPlanner_ExpandsTargetSetForInternalWorkflowRecipient(t *testing
 		},
 	)
 
-	plan, err := planner.Plan(context.Background(), eventtest.WithTargetSet((eventtest.Projection("", "child/output.done", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{})), []events.RouteIdentity{
-		{FlowInstance: "child-a/inst-1", EntityID: "ent-a"},
-		{FlowInstance: "child-b/inst-1", EntityID: "ent-b"},
-	}))
+	plan, err := planner.Plan(context.Background(), eventtest.RootIngress(
+		"",
+		"child/output.done",
+		"",
+		"",
+		nil,
+		0,
+		"",
+		"",
+		events.EnvelopeForTargetSet(events.EventEnvelope{}, []events.RouteIdentity{
+			{FlowInstance: "child-a/inst-1", EntityID: "ent-a"},
+			{FlowInstance: "child-b/inst-1", EntityID: "ent-b"},
+		}),
+		time.Time{},
+	))
 	if err != nil {
 		t.Fatalf("Plan: %v", err)
 	}
@@ -476,10 +553,21 @@ func TestDeliveryPlanner_ExpandsTargetSetForSameSemanticNode(t *testing.T) {
 		},
 	)
 
-	plan, err := planner.Plan(context.Background(), eventtest.WithTargetSet((eventtest.Projection("", "worker/work.assign", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{})), []events.RouteIdentity{
-		{FlowInstance: "worker/w-001", EntityID: "worker/w-001"},
-		{FlowInstance: "worker/w-002", EntityID: "worker/w-002"},
-	}))
+	plan, err := planner.Plan(context.Background(), eventtest.RootIngress(
+		"",
+		"worker/work.assign",
+		"",
+		"",
+		nil,
+		0,
+		"",
+		"",
+		events.EnvelopeForTargetSet(events.EventEnvelope{}, []events.RouteIdentity{
+			{FlowInstance: "worker/w-001", EntityID: "worker/w-001"},
+			{FlowInstance: "worker/w-002", EntityID: "worker/w-002"},
+		}),
+		time.Time{},
+	))
 	if err != nil {
 		t.Fatalf("Plan: %v", err)
 	}
@@ -524,7 +612,18 @@ func TestDeliveryPlanner_NoTargetConcreteRoutedNodePersistsSemanticNodeRoute(t *
 		},
 	)
 
-	plan, err := planner.Plan(context.Background(), eventtest.WithFlowInstance(eventtest.WithEntityID((eventtest.Projection("", "operating/inst-1/opco.product_initialization_requested", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{})), "ent-operating"), "operating/inst-1"))
+	plan, err := planner.Plan(context.Background(), eventtest.RootIngress(
+		"",
+		"operating/inst-1/opco.product_initialization_requested",
+		"",
+		"",
+		nil,
+		0,
+		"",
+		"",
+		events.EnvelopeForFlowInstance(events.EnvelopeForEntityID(events.EventEnvelope{}, "ent-operating"), "operating/inst-1"),
+		time.Time{},
+	))
 	if err != nil {
 		t.Fatalf("Plan: %v", err)
 	}
@@ -557,7 +656,18 @@ func TestDeliveryPlanner_NoTargetConcreteRoutedNodePersistsSemanticNodeRoute(t *
 }
 
 func TestRoutedNodeInternalSubscriptionAliases_NestedSemanticScopeDoesNotLeakParentConcreteRoute(t *testing.T) {
-	evt := eventtest.WithFlowInstance((eventtest.Projection("", events.EventType("child/grandchild/micro.started"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{})), "child/grandchild/inst-1")
+	evt := eventtest.RootIngress(
+		"",
+		events.EventType("child/grandchild/micro.started"),
+		"",
+		"",
+		nil,
+		0,
+		"",
+		"",
+		events.EnvelopeForFlowInstance(events.EventEnvelope{}, "child/grandchild/inst-1"),
+		time.Time{},
+	)
 
 	aliases := routedNodeInternalSubscriptionAliases(evt, []Subscriber{{
 		ID:   "grandchild-worker",
@@ -629,7 +739,18 @@ func TestRoutedEventKeysForPlan_RuntimeCallbackLocalEventWithFlowInstanceDerives
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			got := routedEventKeysForPlan(eventtest.WithFlowInstance((eventtest.Projection("", events.EventType(tc.eventType), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{})), tc.flowInstance))
+			got := routedEventKeysForPlan(eventtest.RootIngress(
+				"",
+				events.EventType(tc.eventType),
+				"",
+				"",
+				nil,
+				0,
+				"",
+				"",
+				events.EnvelopeForFlowInstance(events.EventEnvelope{}, tc.flowInstance),
+				time.Time{},
+			))
 			if len(got) != len(tc.want) {
 				t.Fatalf("event keys = %#v, want %#v", got, tc.want)
 			}
@@ -660,7 +781,18 @@ func TestResolveInternalRecipientsForRoutedNodePlanning_DoesNotSelectParentConcr
 	eb.SubscribeInternal("parent-carrier", events.EventType("child/inst-1/micro.started"))
 	defer eb.Unsubscribe("parent-carrier")
 
-	evt := eventtest.WithFlowInstance((eventtest.Projection("", events.EventType("child/grandchild/micro.started"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{})), "child/grandchild/inst-1")
+	evt := eventtest.RootIngress(
+		"",
+		events.EventType("child/grandchild/micro.started"),
+		"",
+		"",
+		nil,
+		0,
+		"",
+		"",
+		events.EnvelopeForFlowInstance(events.EventEnvelope{}, "child/grandchild/inst-1"),
+		time.Time{},
+	)
 	got := eb.resolveInternalRecipientsForRoutedNodePlanning(evt, []Subscriber{{
 		ID:   "grandchild-worker",
 		Type: "node",
@@ -696,7 +828,7 @@ func TestDeliveryPlanner_NoTargetRootRoutedNodeUsesSemanticNodeDeliveryRoute(t *
 		},
 	)
 
-	plan, err := planner.Plan(context.Background(), eventtest.WithEntityID((eventtest.Projection("", "opco.spinup_requested", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{})), "ent-root"))
+	plan, err := planner.Plan(context.Background(), eventtest.RootIngress("", "opco.spinup_requested", "", "", nil, 0, "", "", events.EnvelopeForEntityID(events.EventEnvelope{}, "ent-root"), time.Time{}))
 	if err != nil {
 		t.Fatalf("Plan: %v", err)
 	}
@@ -748,7 +880,18 @@ func TestDeliveryPlanner_NoTargetRootLocalEventWithFlowInstanceUsesRootNodeRoute
 		},
 	)
 
-	plan, err := planner.Plan(context.Background(), eventtest.WithFlowInstance(eventtest.WithEntityID((eventtest.Projection("", "timer.check", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{})), "ent-root"), "11111111-1111-4111-8111-111111111111"))
+	plan, err := planner.Plan(context.Background(), eventtest.RootIngress(
+		"",
+		"timer.check",
+		"",
+		"",
+		nil,
+		0,
+		"",
+		"",
+		events.EnvelopeForFlowInstance(events.EnvelopeForEntityID(events.EventEnvelope{}, "ent-root"), "11111111-1111-4111-8111-111111111111"),
+		time.Time{},
+	))
 	if err != nil {
 		t.Fatalf("Plan: %v", err)
 	}
@@ -806,7 +949,7 @@ func TestDeliveryPlanner_NoTargetScopedRoutedNodeUsesSemanticNodeDeliveryRoute(t
 		},
 	)
 
-	plan, err := planner.Plan(context.Background(), eventtest.WithEntityID((eventtest.Projection("", "child/child.start", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{})), "ent-child"))
+	plan, err := planner.Plan(context.Background(), eventtest.RootIngress("", "child/child.start", "", "", nil, 0, "", "", events.EnvelopeForEntityID(events.EventEnvelope{}, "ent-child"), time.Time{}))
 	if err != nil {
 		t.Fatalf("Plan: %v", err)
 	}
@@ -872,7 +1015,7 @@ func TestDeliveryPlanner_NoTargetScopedEventPreservesPathlessRoutedNodeRoute(t *
 		},
 	)
 
-	plan, err := planner.Plan(context.Background(), eventtest.WithEntityID((eventtest.Projection("", "child/child.start", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{})), "ent-child"))
+	plan, err := planner.Plan(context.Background(), eventtest.RootIngress("", "child/child.start", "", "", nil, 0, "", "", events.EnvelopeForEntityID(events.EventEnvelope{}, "ent-child"), time.Time{}))
 	if err != nil {
 		t.Fatalf("Plan: %v", err)
 	}
@@ -929,7 +1072,18 @@ func TestDeliveryPlanner_NoTargetCrossFlowStaticRoutedNodeUsesSubscriberScope(t 
 		},
 	)
 
-	plan, err := planner.Plan(context.Background(), eventtest.WithFlowInstance(eventtest.WithEntityID((eventtest.Projection("", "flow-b/order.completed", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{})), "ent-flow-b"), "flow-b/inst-1"))
+	plan, err := planner.Plan(context.Background(), eventtest.RootIngress(
+		"",
+		"flow-b/order.completed",
+		"",
+		"",
+		nil,
+		0,
+		"",
+		"",
+		events.EnvelopeForFlowInstance(events.EnvelopeForEntityID(events.EventEnvelope{}, "ent-flow-b"), "flow-b/inst-1"),
+		time.Time{},
+	))
 	if err != nil {
 		t.Fatalf("Plan: %v", err)
 	}
@@ -987,7 +1141,18 @@ func TestDeliveryPlanner_NoTargetWildcardStaticServiceRoutedNodeUsesSubscriberSc
 		},
 	)
 
-	plan, err := planner.Plan(context.Background(), eventtest.WithFlowInstance(eventtest.WithEntityID((eventtest.Projection("", "component-scaffold/component-a/opco.repo_scaffold_requested", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{})), "ent-component"), "component-scaffold/component-a"))
+	plan, err := planner.Plan(context.Background(), eventtest.RootIngress(
+		"",
+		"component-scaffold/component-a/opco.repo_scaffold_requested",
+		"",
+		"",
+		nil,
+		0,
+		"",
+		"",
+		events.EnvelopeForFlowInstance(events.EnvelopeForEntityID(events.EventEnvelope{}, "ent-component"), "component-scaffold/component-a"),
+		time.Time{},
+	))
 	if err != nil {
 		t.Fatalf("Plan: %v", err)
 	}
@@ -1045,7 +1210,18 @@ func TestDeliveryPlanner_NoTargetDescendantScopedRoutedNodeUsesParentInstanceRou
 		},
 	)
 
-	plan, err := planner.Plan(context.Background(), eventtest.WithFlowInstance(eventtest.WithEntityID((eventtest.Projection("", "child/grandchild/micro.start", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{})), "ent-child"), "child/inst-1"))
+	plan, err := planner.Plan(context.Background(), eventtest.RootIngress(
+		"",
+		"child/grandchild/micro.start",
+		"",
+		"",
+		nil,
+		0,
+		"",
+		"",
+		events.EnvelopeForFlowInstance(events.EnvelopeForEntityID(events.EventEnvelope{}, "ent-child"), "child/inst-1"),
+		time.Time{},
+	))
 	if err != nil {
 		t.Fatalf("Plan: %v", err)
 	}
@@ -1090,7 +1266,7 @@ func TestDeliveryPlanner_FailsClosedOnPolicyError(t *testing.T) {
 		},
 	)
 
-	_, err := planner.Plan(context.Background(), eventtest.Projection("", "task.completed", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}))
+	_, err := planner.Plan(context.Background(), eventtest.RootIngress("", "task.completed", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}))
 	if err == nil || err.Error() != "descriptor store unavailable" {
 		t.Fatalf("Plan err = %v, want descriptor store unavailable", err)
 	}

--- a/internal/runtime/bus/eventbus_internal_test_helpers_test.go
+++ b/internal/runtime/bus/eventbus_internal_test_helpers_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/division-sh/swarm/internal/events"
+	"github.com/division-sh/swarm/internal/events/eventtest"
 	"time"
 )
 
@@ -14,6 +15,6 @@ func requireBusEvent(t testing.TB, ch <-chan events.Event, context string) event
 		return evt
 	default:
 		t.Fatalf("%s: expected queued bus event", context)
-		return events.NewProjectionEvent("", events.EventType(""), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{})
+		return eventtest.Projection("", events.EventType(""), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{})
 	}
 }

--- a/internal/runtime/bus/eventbus_internal_test_helpers_test.go
+++ b/internal/runtime/bus/eventbus_internal_test_helpers_test.go
@@ -15,6 +15,6 @@ func requireBusEvent(t testing.TB, ch <-chan events.Event, context string) event
 		return evt
 	default:
 		t.Fatalf("%s: expected queued bus event", context)
-		return eventtest.Projection("", events.EventType(""), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{})
+		return eventtest.RootIngress("", events.EventType(""), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{})
 	}
 }

--- a/internal/runtime/bus/eventbus_publish_test.go
+++ b/internal/runtime/bus/eventbus_publish_test.go
@@ -123,7 +123,7 @@ func (deferredChainInterceptor) Intercept(_ context.Context, evt events.Event) (
 	default:
 		return true, nil, nil
 	}
-	return false, []events.Event{eventtest.WithEntityID((eventtest.Projection("", events.EventType(next), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Now().UTC())), evt.EntityID())}, nil
+	return false, []events.Event{eventtest.RootIngress("", events.EventType(next), "", "", nil, 0, "", "", events.EnvelopeForEntityID(events.EventEnvelope{}, evt.EntityID()), time.Now().UTC())}, nil
 }
 
 type singleDeferredInterceptor struct{}
@@ -132,7 +132,18 @@ func (singleDeferredInterceptor) Intercept(_ context.Context, evt events.Event) 
 	if evt.Type() != events.EventType("custom.root") {
 		return true, nil, nil
 	}
-	return false, []events.Event{eventtest.WithEntityID((eventtest.Projection("", events.EventType("custom.middle"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Now().UTC())), evt.EntityID())}, nil
+	return false, []events.Event{eventtest.RootIngress(
+		"",
+		events.EventType("custom.middle"),
+		"",
+		"",
+		nil,
+		0,
+		"",
+		"",
+		events.EnvelopeForEntityID(events.EventEnvelope{}, evt.EntityID()),
+		time.Now().UTC(),
+	)}, nil
 }
 
 type nonTransactionalPersistedBeforeInterceptor struct {
@@ -231,7 +242,7 @@ func (i deferredEventVisibleInterceptor) Intercept(ctx context.Context, evt even
 	i.t.Helper()
 	if evt.Type() == events.EventType("custom.root") {
 		return false, []events.Event{
-			eventtest.Projection(i.eventID, i.checkFor, "", "", []byte(`{"entity_id":"ent-1"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC()),
+			eventtest.RootIngress(i.eventID, i.checkFor, "", "", []byte(`{"entity_id":"ent-1"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC()),
 		}, nil
 	}
 	if evt.Type() != i.checkFor {
@@ -468,11 +479,18 @@ func TestEventBusPublishTransactionalPostCommitReceiptFailureIsRecoverable(t *te
 	ch := eb.Subscribe(agentID, events.EventType("custom.receipt_failure"))
 	defer eb.Unsubscribe(agentID)
 
-	if err := eb.Publish(ctx, eventtest.WithEntityID(eventtest.Projection(eventID,
-
+	if err := eb.Publish(ctx, eventtest.RootIngress(
+		eventID,
 		events.EventType("custom.receipt_failure"),
-		"api.v1", "", []byte(`{"entity_id":"21000000-0000-0000-0000-000000000012"}`), 0, eventBusTestRunID, "", events.EventEnvelope{}, time.Now().UTC()),
-		"21000000-0000-0000-0000-000000000012")); err != nil {
+		"api.v1",
+		"",
+		[]byte(`{"entity_id":"21000000-0000-0000-0000-000000000012"}`),
+		0,
+		eventBusTestRunID,
+		"",
+		events.EnvelopeForEntityID(events.EventEnvelope{}, "21000000-0000-0000-0000-000000000012"),
+		time.Now().UTC(),
+	)); err != nil {
 		t.Fatalf("Publish with post-commit receipt failure: %v", err)
 	}
 	ok, err := pg.EventExists(ctx, eventID)
@@ -526,11 +544,18 @@ func TestEventBusPublishTransactionalPostCommitCompletionFailureIsRecoverable(t 
 	ch := eb.Subscribe(agentID, events.EventType("custom.completion_failure"))
 	defer eb.Unsubscribe(agentID)
 
-	if err := eb.Publish(ctx, eventtest.WithEntityID(eventtest.Projection(eventID,
-
+	if err := eb.Publish(ctx, eventtest.RootIngress(
+		eventID,
 		events.EventType("custom.completion_failure"),
-		"api.v1", "", []byte(`{"entity_id":"21000000-0000-0000-0000-000000000022"}`), 0, eventBusTestRunID, "", events.EventEnvelope{}, time.Now().UTC()),
-		"21000000-0000-0000-0000-000000000022")); err != nil {
+		"api.v1",
+		"",
+		[]byte(`{"entity_id":"21000000-0000-0000-0000-000000000022"}`),
+		0,
+		eventBusTestRunID,
+		"",
+		events.EnvelopeForEntityID(events.EventEnvelope{}, "21000000-0000-0000-0000-000000000022"),
+		time.Now().UTC(),
+	)); err != nil {
 		t.Fatalf("Publish with post-commit completion failure: %v", err)
 	}
 	ok, err := pg.EventExists(ctx, eventID)
@@ -642,9 +667,18 @@ func TestEventBusPublish_LogsQueuedDeliveryLifecycleTransition(t *testing.T) {
 	}
 	ch := bus.Subscribe("agent-1", events.EventType("task.requested"))
 
-	evt := eventtest.WithEntityID(eventtest.Projection(uuid.NewString(),
-		events.EventType("task.requested"), "", "", []byte(`{"entity_id":"ent-1"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC()),
-		"ent-1")
+	evt := eventtest.RootIngress(
+		uuid.NewString(),
+		events.EventType("task.requested"),
+		"",
+		"",
+		[]byte(`{"entity_id":"ent-1"}`),
+		0,
+		"",
+		"",
+		events.EnvelopeForEntityID(events.EventEnvelope{}, "ent-1"),
+		time.Now().UTC(),
+	)
 
 	if err := bus.Publish(context.Background(), evt); err != nil {
 		t.Fatalf("Publish: %v", err)
@@ -688,9 +722,18 @@ func TestEventBusPublish_AttachesTypedRuntimeDiagnosticLineage(t *testing.T) {
 	})
 	ctx = runtimecorrelation.WithRunID(ctx, runID)
 
-	if err := bus.Publish(ctx, eventtest.WithEntityID(eventtest.Projection(eventID,
-		events.EventType("task.requested"), "", "", []byte(`{"entity_id":"ent-1"}`), 0, runID, "", events.EventEnvelope{}, time.Now().UTC()),
-		"ent-1")); err != nil {
+	if err := bus.Publish(ctx, eventtest.RootIngress(
+		eventID,
+		events.EventType("task.requested"),
+		"",
+		"",
+		[]byte(`{"entity_id":"ent-1"}`),
+		0,
+		runID,
+		"",
+		events.EnvelopeForEntityID(events.EventEnvelope{}, "ent-1"),
+		time.Now().UTC(),
+	)); err != nil {
 		t.Fatalf("Publish: %v", err)
 	}
 
@@ -728,9 +771,18 @@ func TestEventBusPublish_AttachesBundleSourceFactToRuntimeLogs(t *testing.T) {
 		t.Fatalf("NewEventBusWithOptions: %v", err)
 	}
 	ch := bus.Subscribe("agent-1", events.EventType("task.requested"))
-	if err := bus.Publish(context.Background(), eventtest.WithEntityID(eventtest.Projection(uuid.NewString(),
-		events.EventType("task.requested"), "", "", []byte(`{"entity_id":"ent-1"}`), 0, uuid.NewString(), "", events.EventEnvelope{}, time.Now().UTC()),
-		"ent-1")); err != nil {
+	if err := bus.Publish(context.Background(), eventtest.RootIngress(
+		uuid.NewString(),
+		events.EventType("task.requested"),
+		"",
+		"",
+		[]byte(`{"entity_id":"ent-1"}`),
+		0,
+		uuid.NewString(),
+		"",
+		events.EnvelopeForEntityID(events.EventEnvelope{}, "ent-1"),
+		time.Now().UTC(),
+	)); err != nil {
 		t.Fatalf("Publish: %v", err)
 	}
 	_ = requireBusEvent(t, ch, "bundle source fact delivery")
@@ -757,7 +809,7 @@ func TestEventBusPublish_UsesPayloadValidator(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewEventBusWithOptions: %v", err)
 	}
-	if err := eb.Publish(context.Background(), eventtest.Projection("", "task.completed", "", "", []byte(`{"ok":true}`), 0, "", "", events.EventEnvelope{}, time.Time{})); err != nil {
+	if err := eb.Publish(context.Background(), eventtest.RootIngress("", "task.completed", "", "", []byte(`{"ok":true}`), 0, "", "", events.EventEnvelope{}, time.Time{})); err != nil {
 		t.Fatalf("Publish: %v", err)
 	}
 }
@@ -771,7 +823,7 @@ func TestEventBusPublish_PayloadValidatorFailureAbortsPublish(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewEventBusWithOptions: %v", err)
 	}
-	err = eb.Publish(context.Background(), eventtest.Projection("", "task.completed", "", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Time{}))
+	err = eb.Publish(context.Background(), eventtest.RootIngress("", "task.completed", "", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Time{}))
 	if err == nil || !errors.Is(err, runtimebus.ErrPayloadValidation) {
 		t.Fatalf("expected payload validator failure, got %v", err)
 	}
@@ -785,7 +837,7 @@ func TestEventBusPublish_FailsClosedWhenReplayCapableAtomicStoreOmitsCommittedRe
 	}
 	eb.Subscribe("agent-a", events.EventType("custom.replay.checked"))
 
-	err = eb.Publish(context.Background(), eventtest.Projection(uuid.NewString(),
+	err = eb.Publish(context.Background(), eventtest.RootIngress(uuid.NewString(),
 		events.EventType("custom.replay.checked"), "", "", []byte(`{"ok":true}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC()))
 	if !errors.Is(err, runtimereplayclaim.ErrMissingCommittedReplayScope) {
 		t.Fatalf("Publish error = %v, want missing committed replay scope", err)
@@ -801,7 +853,7 @@ func TestEventBusPublishDirect_PayloadValidatorFailureAbortsPublish(t *testing.T
 	if err != nil {
 		t.Fatalf("NewEventBusWithOptions: %v", err)
 	}
-	err = eb.PublishDirect(context.Background(), eventtest.Projection("", "task.completed", "", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Time{}), []string{"agent-a"})
+	err = eb.PublishDirect(context.Background(), eventtest.RootIngress("", "task.completed", "", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Time{}), []string{"agent-a"})
 	if err == nil || !errors.Is(err, runtimebus.ErrPayloadValidation) {
 		t.Fatalf("expected payload validator failure, got %v", err)
 	}
@@ -817,7 +869,7 @@ func TestEventBusCheckDirectRecipients_PayloadValidatorFailureAbortsBeforeRecipi
 		t.Fatalf("NewEventBusWithOptions: %v", err)
 	}
 
-	status, err := eb.CheckDirectRecipients(context.Background(), eventtest.Projection("", "task.completed", "", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Time{}), []string{"agent-a"})
+	status, err := eb.CheckDirectRecipients(context.Background(), eventtest.RootIngress("", "task.completed", "", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Time{}), []string{"agent-a"})
 	if err == nil || !errors.Is(err, runtimebus.ErrPayloadValidation) {
 		t.Fatalf("expected payload validator failure, got %v", err)
 	}
@@ -836,7 +888,7 @@ func TestEventBusCheckPublishRecipientPlanReportsSubscribedPublishWithoutDeliver
 	}
 	ch := eb.Subscribe("agent-a", events.EventType("task.completed"))
 
-	plan, err := eb.CheckPublishRecipientPlan(context.Background(), eventtest.Projection("", "task.completed", "", "", []byte(`{"ok":true}`), 0, "", "", events.EventEnvelope{}, time.Time{}))
+	plan, err := eb.CheckPublishRecipientPlan(context.Background(), eventtest.RootIngress("", "task.completed", "", "", []byte(`{"ok":true}`), 0, "", "", events.EventEnvelope{}, time.Time{}))
 	if err != nil {
 		t.Fatalf("CheckPublishRecipientPlan: %v", err)
 	}
@@ -867,8 +919,18 @@ func TestEventBusPublishDirect_PersistsButDoesNotMarkDeliveredBeforeRealFanOut(t
 		t.Fatalf("NewEventBus: %v", err)
 	}
 
-	err = eb.PublishDirect(context.Background(), eventtest.WithEntityID((eventtest.Projection(uuid.NewString(),
-		events.EventType("custom.direct"), "", "", []byte(`{"entity_id":"ent-1"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())), "ent-1"),
+	err = eb.PublishDirect(context.Background(), eventtest.RootIngress(
+		uuid.NewString(),
+		events.EventType("custom.direct"),
+		"",
+		"",
+		[]byte(`{"entity_id":"ent-1"}`),
+		0,
+		"",
+		"",
+		events.EnvelopeForEntityID(events.EventEnvelope{}, "ent-1"),
+		time.Now().UTC(),
+	),
 		[]string{"agent-a"})
 	if err == nil || !strings.Contains(err.Error(), "authoritative delivery incomplete") {
 		t.Fatalf("PublishDirect missing recipient error = %v, want authoritative delivery incomplete", err)
@@ -892,8 +954,18 @@ func TestEventBusPublishDirect_FiltersEntityScopedRecipientsByExplicitMetadata(t
 	matchCh := eb.Subscribe("reviewer-ent-1")
 	otherCh := eb.Subscribe("reviewer-ent-2")
 
-	err = eb.PublishDirect(context.Background(), eventtest.WithEntityID(eventtest.Projection("", events.EventType("custom.direct"), "", "", []byte(`{"entity_id":"ent-1"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC()),
-		"ent-1"),
+	err = eb.PublishDirect(context.Background(), eventtest.RootIngress(
+		"",
+		events.EventType("custom.direct"),
+		"",
+		"",
+		[]byte(`{"entity_id":"ent-1"}`),
+		0,
+		"",
+		"",
+		events.EnvelopeForEntityID(events.EventEnvelope{}, "ent-1"),
+		time.Now().UTC(),
+	),
 		[]string{"control-plane", "reviewer-ent-1", "reviewer-ent-2", "missing-agent"})
 	if err != nil {
 		t.Fatalf("PublishDirect: %v", err)
@@ -928,8 +1000,18 @@ func TestEventBusPublish_FiltersEntityScopedRecipientsByExplicitMetadata(t *test
 	matchCh := eb.Subscribe("reviewer-ent-1", events.EventType("custom.trigger"))
 	otherCh := eb.Subscribe("reviewer-ent-2", events.EventType("custom.trigger"))
 
-	if err := eb.Publish(context.Background(), eventtest.WithEntityID(eventtest.Projection("", events.EventType("custom.trigger"), "", "", []byte(`{"entity_id":"ent-1"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC()),
-		"ent-1")); err != nil {
+	if err := eb.Publish(context.Background(), eventtest.RootIngress(
+		"",
+		events.EventType("custom.trigger"),
+		"",
+		"",
+		[]byte(`{"entity_id":"ent-1"}`),
+		0,
+		"",
+		"",
+		events.EnvelopeForEntityID(events.EventEnvelope{}, "ent-1"),
+		time.Now().UTC(),
+	)); err != nil {
 		t.Fatalf("Publish: %v", err)
 	}
 
@@ -960,7 +1042,18 @@ func TestEventBusPublish_FiltersEntityScopedRecipientsByTypedEnvelopeNotPayload(
 	matchCh := eb.Subscribe("reviewer-ent-1", events.EventType("custom.trigger"))
 	otherCh := eb.Subscribe("reviewer-ent-2", events.EventType("custom.trigger"))
 
-	err = eb.Publish(context.Background(), eventtest.WithEnvelope((eventtest.Projection("", events.EventType("custom.trigger"), "", "", []byte(`{"entity_id":"ent-2"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())), events.EventEnvelope{EntityID: "ent-1"}))
+	err = eb.Publish(context.Background(), eventtest.RootIngress(
+		"",
+		events.EventType("custom.trigger"),
+		"",
+		"",
+		[]byte(`{"entity_id":"ent-2"}`),
+		0,
+		"",
+		"",
+		events.EventEnvelope{EntityID: "ent-1"},
+		time.Now().UTC(),
+	))
 	if err != nil {
 		t.Fatalf("Publish: %v", err)
 	}
@@ -986,8 +1079,18 @@ func TestEventBusPublish_DropsRecipientsMissingExplicitDescriptor(t *testing.T) 
 	controlCh := eb.Subscribe("control-plane", events.EventType("custom.trigger"))
 	missingCh := eb.Subscribe("reviewer-ent-1", events.EventType("custom.trigger"))
 
-	if err := eb.Publish(context.Background(), eventtest.WithEntityID(eventtest.Projection("", events.EventType("custom.trigger"), "", "", []byte(`{"entity_id":"ent-1"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC()),
-		"ent-1")); err != nil {
+	if err := eb.Publish(context.Background(), eventtest.RootIngress(
+		"",
+		events.EventType("custom.trigger"),
+		"",
+		"",
+		[]byte(`{"entity_id":"ent-1"}`),
+		0,
+		"",
+		"",
+		events.EnvelopeForEntityID(events.EventEnvelope{}, "ent-1"),
+		time.Now().UTC(),
+	)); err != nil {
 		t.Fatalf("Publish: %v", err)
 	}
 
@@ -1012,8 +1115,18 @@ func TestEventBusPublish_KeepsInternalSubscribersLiveOnlyUnderDescriptorPlanning
 	agentCh := eb.Subscribe("agent-a", events.EventType("custom.trigger"))
 	missingCh := eb.Subscribe("agent-missing", events.EventType("custom.trigger"))
 
-	if err := eb.Publish(context.Background(), eventtest.WithEntityID(eventtest.Projection("", events.EventType("custom.trigger"), "", "", []byte(`{"entity_id":"ent-1"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC()),
-		"ent-1")); err != nil {
+	if err := eb.Publish(context.Background(), eventtest.RootIngress(
+		"",
+		events.EventType("custom.trigger"),
+		"",
+		"",
+		[]byte(`{"entity_id":"ent-1"}`),
+		0,
+		"",
+		"",
+		events.EnvelopeForEntityID(events.EventEnvelope{}, "ent-1"),
+		time.Now().UTC(),
+	)); err != nil {
 		t.Fatalf("Publish: %v", err)
 	}
 
@@ -1051,7 +1164,18 @@ func TestEventBusPublishDeferred_UsesCanonicalSubscribedRecipientFiltering(t *te
 	agentCh := eb.Subscribe("agent-a", events.EventType("custom.middle"))
 	otherCh := eb.Subscribe("agent-b", events.EventType("custom.middle"))
 
-	if err := eb.Publish(context.Background(), eventtest.WithEntityID((eventtest.Projection("", events.EventType("custom.root"), "", "", []byte(`{"entity_id":"ent-1"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())), "ent-1")); err != nil {
+	if err := eb.Publish(context.Background(), eventtest.RootIngress(
+		"",
+		events.EventType("custom.root"),
+		"",
+		"",
+		[]byte(`{"entity_id":"ent-1"}`),
+		0,
+		"",
+		"",
+		events.EnvelopeForEntityID(events.EventEnvelope{}, "ent-1"),
+		time.Now().UTC(),
+	)); err != nil {
 		t.Fatalf("Publish: %v", err)
 	}
 
@@ -1078,8 +1202,18 @@ func TestEventBusPublish_FailsClosedWhenDescriptorLookupFails(t *testing.T) {
 	}
 	ch := eb.Subscribe("reviewer-ent-1", events.EventType("custom.trigger"))
 
-	err = eb.Publish(context.Background(), eventtest.WithEntityID(eventtest.Projection("", events.EventType("custom.trigger"), "", "", []byte(`{"entity_id":"ent-1"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC()),
-		"ent-1"))
+	err = eb.Publish(context.Background(), eventtest.RootIngress(
+		"",
+		events.EventType("custom.trigger"),
+		"",
+		"",
+		[]byte(`{"entity_id":"ent-1"}`),
+		0,
+		"",
+		"",
+		events.EnvelopeForEntityID(events.EventEnvelope{}, "ent-1"),
+		time.Now().UTC(),
+	))
 	if err == nil || !strings.Contains(err.Error(), "descriptor lookup failed") {
 		t.Fatalf("Publish error = %v, want descriptor lookup failure", err)
 	}
@@ -1101,7 +1235,7 @@ func TestEventBusWaitForQuiescenceWaitsForPublishCompletion(t *testing.T) {
 
 	publishDone := make(chan error, 1)
 	go func() {
-		publishDone <- eb.Publish(context.Background(), eventtest.Projection("", "task.completed", "", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Time{}))
+		publishDone <- eb.Publish(context.Background(), eventtest.RootIngress("", "task.completed", "", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Time{}))
 	}()
 
 	requireSignalBefore(t, started, 500*time.Millisecond, "interceptor start")
@@ -1145,7 +1279,7 @@ func TestEventBusPublishAcknowledgedReturnsBeforePostCommitDispatchCompletes(t *
 
 	publishDone := make(chan error, 1)
 	go func() {
-		publishDone <- eb.PublishAcknowledged(ctx, eventtest.Projection(
+		publishDone <- eb.PublishAcknowledged(ctx, eventtest.RootIngress(
 			eventID,
 			events.EventType("task.completed"),
 			"api.v1",
@@ -1216,7 +1350,7 @@ func TestEventBusPublish_InterceptsMultiHopDeferredChains(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewEventBusWithOptions: %v", err)
 	}
-	if err := eb.Publish(context.Background(), eventtest.WithEntityID((eventtest.Projection("", events.EventType("custom.root"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Now().UTC())), "ent-1")); err != nil {
+	if err := eb.Publish(context.Background(), eventtest.RootIngress("", events.EventType("custom.root"), "", "", nil, 0, "", "", events.EnvelopeForEntityID(events.EventEnvelope{}, "ent-1"), time.Now().UTC())); err != nil {
 		t.Fatalf("Publish: %v", err)
 	}
 	if got := store.eventTypes(); len(got) < 4 || got[0] != "custom.root" || got[1] != "custom.middle" || got[2] != "custom.leaf" || got[3] != "custom.final" {
@@ -1232,7 +1366,18 @@ func TestEventBusPublishNonTransactional_PersistsBeforeInterceptorsRun(t *testin
 	if err != nil {
 		t.Fatalf("NewEventBusWithOptions: %v", err)
 	}
-	if err := eb.Publish(context.Background(), eventtest.WithEntityID((eventtest.Projection("", events.EventType("custom.non_transactional"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Now().UTC())), "ent-1")); err != nil {
+	if err := eb.Publish(context.Background(), eventtest.RootIngress(
+		"",
+		events.EventType("custom.non_transactional"),
+		"",
+		"",
+		nil,
+		0,
+		"",
+		"",
+		events.EnvelopeForEntityID(events.EventEnvelope{}, "ent-1"),
+		time.Now().UTC(),
+	)); err != nil {
 		t.Fatalf("Publish: %v", err)
 	}
 }
@@ -1261,11 +1406,18 @@ func TestEventBusPublishTransactional_RunsInterceptorsAfterCommit(t *testing.T) 
 	}
 	ch := eb.Subscribe(agentID, events.EventType("task.completed"))
 	defer eb.Unsubscribe(agentID)
-	if err := eb.Publish(ctx, eventtest.WithEntityID(eventtest.Projection(eventID,
-
+	if err := eb.Publish(ctx, eventtest.RootIngress(
+		eventID,
 		events.EventType("task.completed"),
-		"api.v1", "", []byte(`{"entity_id":"11111111-1111-1111-1111-111111111114"}`), 0, eventBusTestRunID, "", events.EventEnvelope{}, time.Now().UTC()),
-		"11111111-1111-1111-1111-111111111114")); err != nil {
+		"api.v1",
+		"",
+		[]byte(`{"entity_id":"11111111-1111-1111-1111-111111111114"}`),
+		0,
+		eventBusTestRunID,
+		"",
+		events.EnvelopeForEntityID(events.EventEnvelope{}, "11111111-1111-1111-1111-111111111114"),
+		time.Now().UTC(),
+	)); err != nil {
 		t.Fatalf("Publish: %v", err)
 	}
 	requireSignalBefore(t, called, time.Second, "post-commit interceptor")
@@ -1293,10 +1445,18 @@ func TestEventBusPublishTransactional_ReturnsPostCommitInterceptorErrorAndRecord
 	if err != nil {
 		t.Fatalf("NewEventBusWithOptions: %v", err)
 	}
-	err = eb.Publish(ctx, eventtest.WithEntityID(eventtest.Projection(eventID,
-
-		events.EventType("task.failed"), "", "", []byte(`{"entity_id":"11111111-1111-1111-1111-111111111114"}`), 0, eventBusTestRunID, "", events.EventEnvelope{}, time.Now().UTC()),
-		"11111111-1111-1111-1111-111111111114"))
+	err = eb.Publish(ctx, eventtest.RootIngress(
+		eventID,
+		events.EventType("task.failed"),
+		"",
+		"",
+		[]byte(`{"entity_id":"11111111-1111-1111-1111-111111111114"}`),
+		0,
+		eventBusTestRunID,
+		"",
+		events.EnvelopeForEntityID(events.EventEnvelope{}, "11111111-1111-1111-1111-111111111114"),
+		time.Now().UTC(),
+	))
 	if !errors.Is(err, wantErr) {
 		t.Fatalf("Publish error = %v, want %v", err, wantErr)
 	}
@@ -1334,10 +1494,18 @@ func TestEventBusPublishInMutationRunsInterceptorsAfterMutationCommit(t *testing
 		t.Fatalf("NewEventBusWithOptions: %v", err)
 	}
 	if err := pg.RunEventMutation(ctx, func(mutation runtimebus.EventMutation) error {
-		if err := eb.PublishInMutation(mutation.Context(), eventtest.WithEntityID(eventtest.Projection(eventID,
+		if err := eb.PublishInMutation(mutation.Context(), eventtest.RootIngress(
+			eventID,
 			events.EventType("custom.publish_mutation_post_commit"),
-			"api.v1", "", []byte(`{"entity_id":"11111111-1111-1111-1111-111111111113"}`), 0, eventBusTestRunID, "", events.EventEnvelope{}, time.Now().UTC()),
-			"11111111-1111-1111-1111-111111111113")); err != nil {
+			"api.v1",
+			"",
+			[]byte(`{"entity_id":"11111111-1111-1111-1111-111111111113"}`),
+			0,
+			eventBusTestRunID,
+			"",
+			events.EnvelopeForEntityID(events.EventEnvelope{}, "11111111-1111-1111-1111-111111111113"),
+			time.Now().UTC(),
+		)); err != nil {
 			return err
 		}
 		select {
@@ -1373,8 +1541,18 @@ func TestEventBusPublishTransactional_RecordsTargetFailureDeadLetter(t *testing.
 	eventID := uuid.NewString()
 	targetEntityID := uuid.NewString()
 	if err := pg.RunEventMutation(ctx, func(mutation runtimebus.EventMutation) error {
-		return eb.PublishInMutation(mutation.Context(), eventtest.WithTargetRoute((events.NewRootIngressEvent(eventID,
-			events.EventType("child/output.done"), "", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())), events.RouteIdentity{EntityID: targetEntityID, FlowInstance: "missing-flow"}))
+		return eb.PublishInMutation(mutation.Context(), eventtest.RootIngress(
+			eventID,
+			events.EventType("child/output.done"),
+			"",
+			"",
+			[]byte(`{}`),
+			0,
+			"",
+			"",
+			events.EnvelopeForTargetRoute(events.EventEnvelope{}, events.RouteIdentity{EntityID: targetEntityID, FlowInstance: "missing-flow"}),
+			time.Now().UTC(),
+		))
 	}); err != nil {
 		t.Fatalf("PublishInMutation: %v", err)
 	}
@@ -1425,8 +1603,18 @@ func TestEventBusPublishInMutationSQLiteRecordsTargetFailureDeadLetter(t *testin
 	}
 	eventID := uuid.NewString()
 	targetEntityID := uuid.NewString()
-	evt := eventtest.WithTargetRoute((events.NewRootIngressEvent(eventID,
-		events.EventType("task.completed"), "", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())), events.RouteIdentity{EntityID: targetEntityID, FlowInstance: "missing-flow"})
+	evt := eventtest.RootIngress(
+		eventID,
+		events.EventType("task.completed"),
+		"",
+		"",
+		[]byte(`{}`),
+		0,
+		"",
+		"",
+		events.EnvelopeForTargetRoute(events.EventEnvelope{}, events.RouteIdentity{EntityID: targetEntityID, FlowInstance: "missing-flow"}),
+		time.Now().UTC(),
+	)
 
 	if !evt.HasTargetRoute() {
 		t.Fatalf("event target route missing after construction: envelope=%#v", evt.NormalizedEnvelope())
@@ -1486,7 +1674,7 @@ func TestEventBusPublish_ClassifiesRunBundleSourceThroughRunLifecycleOwner(t *te
 	if err != nil {
 		t.Fatalf("NewEventBusWithOptions: %v", err)
 	}
-	if err := eb.Publish(context.Background(), eventtest.Projection(uuid.NewString(),
+	if err := eb.Publish(context.Background(), eventtest.RootIngress(uuid.NewString(),
 
 		events.EventType("scan.requested"),
 		"test", "", []byte(`{}`), 0, runID, "", events.EventEnvelope{}, time.Now().UTC())); err != nil {
@@ -1526,7 +1714,7 @@ func TestEventBusPublishDirect_StampsBundleSourceFactOnRunRow(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewEventBusWithOptions: %v", err)
 	}
-	if err := eb.PublishDirect(context.Background(), eventtest.Projection(uuid.NewString(),
+	if err := eb.PublishDirect(context.Background(), eventtest.RootIngress(uuid.NewString(),
 
 		events.EventType("scan.requested"),
 		"test", "", []byte(`{}`), 0, runID, "", events.EventEnvelope{}, time.Now().UTC()),
@@ -1562,7 +1750,7 @@ func TestEventBusPublishDeferred_RunsInterceptorsAfterDeferredEventCommit(t *tes
 	if err != nil {
 		t.Fatalf("NewEventBusWithOptions: %v", err)
 	}
-	if err := eb.Publish(context.Background(), events.NewRootIngressEvent("11111111-1111-1111-1111-111111111111",
+	if err := eb.Publish(context.Background(), eventtest.RootIngress("11111111-1111-1111-1111-111111111111",
 		events.EventType("custom.root"), "", "", []byte(`{"entity_id":"ent-1"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC()),
 	); err != nil {
 		t.Fatalf("Publish: %v", err)
@@ -1575,9 +1763,9 @@ func TestEventBusPublish_InheritsRunAndParentFromInboundContext(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewEventBus: %v", err)
 	}
-	ctx := runtimecorrelation.WithInboundEvent(context.Background(), eventtest.Projection("evt-parent",
+	ctx := runtimecorrelation.WithInboundEvent(context.Background(), eventtest.RootIngress("evt-parent",
 		events.EventType("task.started"), "", "", nil, 0, "run-abc", "", events.EventEnvelope{}, time.Time{}))
-	if err := eb.Publish(ctx, eventtest.Projection("evt-child",
+	if err := eb.Publish(ctx, eventtest.RootIngress("evt-child",
 		events.EventType("task.completed"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{})); err != nil {
 		t.Fatalf("Publish: %v", err)
 	}
@@ -1614,7 +1802,7 @@ func TestEventBusPublish_ZeroRecipientsDoesNotEmitContradiction(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewEventBus: %v", err)
 	}
-	if err := eb.Publish(context.Background(), eventtest.Projection("evt-zero",
+	if err := eb.Publish(context.Background(), eventtest.RootIngress("evt-zero",
 		events.EventType("custom.no_subscribers"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{})); err != nil {
 		t.Fatalf("Publish: %v", err)
 	}
@@ -1630,7 +1818,7 @@ func TestEventBusPublish_RuntimeLogBypassesContradictionRouting(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewEventBus: %v", err)
 	}
-	if err := eb.Publish(context.Background(), eventtest.Projection("evt-log",
+	if err := eb.Publish(context.Background(), eventtest.RootIngress("evt-log",
 		events.EventType("platform.runtime_log"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{})); err != nil {
 		t.Fatalf("Publish: %v", err)
 	}
@@ -1662,7 +1850,7 @@ func TestEventBusPublish_RuntimeOwnedStandalonePlatformRunsConvergeWithoutPersis
 			eventID:   "10000000-0000-0000-0000-000000000001",
 			eventType: events.EventType("platform.boot"),
 			event: func(id string, eventType events.EventType) events.Event {
-				return events.NewRuntimeControlEvent(id, eventType, "runtime", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())
+				return eventtest.RuntimeControl(id, eventType, "runtime", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())
 			},
 		},
 		{
@@ -1670,7 +1858,7 @@ func TestEventBusPublish_RuntimeOwnedStandalonePlatformRunsConvergeWithoutPersis
 			eventID:   "10000000-0000-0000-0000-000000000002",
 			eventType: events.EventType("platform.recovery_failed"),
 			event: func(id string, eventType events.EventType) events.Event {
-				return events.NewRuntimeDiagnosticEvent(id, eventType, "runtime", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())
+				return eventtest.RuntimeDiagnostic(id, eventType, "runtime", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())
 			},
 		},
 	}
@@ -1731,7 +1919,7 @@ func TestEventBusPublish_RuntimeOwnedStandalonePlatformRunsConvergeAfterFinalRec
 			eventID:   "20000000-0000-0000-0000-000000000001",
 			eventType: events.EventType("platform.agent_failed"),
 			event: func(id string, eventType events.EventType) events.Event {
-				return events.NewRuntimeDiagnosticEvent(id, eventType, "runtime", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())
+				return eventtest.RuntimeDiagnostic(id, eventType, "runtime", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())
 			},
 		},
 		{
@@ -1739,7 +1927,7 @@ func TestEventBusPublish_RuntimeOwnedStandalonePlatformRunsConvergeAfterFinalRec
 			eventID:   "20000000-0000-0000-0000-000000000002",
 			eventType: events.EventType("platform.paused"),
 			event: func(id string, eventType events.EventType) events.Event {
-				return events.NewRuntimeControlEvent(id, eventType, "runtime", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())
+				return eventtest.RuntimeControl(id, eventType, "runtime", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())
 			},
 		},
 		{
@@ -1747,7 +1935,7 @@ func TestEventBusPublish_RuntimeOwnedStandalonePlatformRunsConvergeAfterFinalRec
 			eventID:   "20000000-0000-0000-0000-000000000003",
 			eventType: events.EventType("platform.budget_threshold_crossed"),
 			event: func(id string, eventType events.EventType) events.Event {
-				return events.NewRuntimeDiagnosticEvent(id, eventType, "runtime", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())
+				return eventtest.RuntimeDiagnostic(id, eventType, "runtime", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())
 			},
 		},
 		{
@@ -1755,7 +1943,7 @@ func TestEventBusPublish_RuntimeOwnedStandalonePlatformRunsConvergeAfterFinalRec
 			eventID:   "20000000-0000-0000-0000-000000000004",
 			eventType: events.EventType("platform.run_stalled"),
 			event: func(id string, eventType events.EventType) events.Event {
-				return events.NewRuntimeDiagnosticEvent(id, eventType, "runtime", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())
+				return eventtest.RuntimeDiagnostic(id, eventType, "runtime", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())
 			},
 		},
 	}
@@ -1824,11 +2012,18 @@ func TestEventBusRuntimeIngressPauseQueuesAndResumeReleases(t *testing.T) {
 	}
 
 	eventID := "21000000-0000-0000-0000-000000000001"
-	if err := eb.Publish(ctx, eventtest.WithEntityID(eventtest.Projection(eventID,
-
+	if err := eb.Publish(ctx, eventtest.RootIngress(
+		eventID,
 		eventType,
-		"api.v1", "", []byte(`{"entity_id":"21000000-0000-0000-0000-000000000002"}`), 0, eventBusTestRunID, "", events.EventEnvelope{}, time.Now().UTC()),
-		"21000000-0000-0000-0000-000000000002")); err != nil {
+		"api.v1",
+		"",
+		[]byte(`{"entity_id":"21000000-0000-0000-0000-000000000002"}`),
+		0,
+		eventBusTestRunID,
+		"",
+		events.EnvelopeForEntityID(events.EventEnvelope{}, "21000000-0000-0000-0000-000000000002"),
+		time.Now().UTC(),
+	)); err != nil {
 		t.Fatalf("Publish while paused: %v", err)
 	}
 
@@ -1867,7 +2062,7 @@ func TestEventBusPublish_HumanTaskEventsRouteBySubscriptionOnly(t *testing.T) {
 	ch := eb.Subscribe("requester")
 	defer eb.Unsubscribe("requester")
 
-	if err := eb.Publish(context.Background(), eventtest.Projection("", events.EventType("human_task.approved"), "", "", []byte(`{"requesting_agent":"requester"}`), 0, "", "", events.EventEnvelope{}, time.Time{})); err != nil {
+	if err := eb.Publish(context.Background(), eventtest.RootIngress("", events.EventType("human_task.approved"), "", "", []byte(`{"requesting_agent":"requester"}`), 0, "", "", events.EventEnvelope{}, time.Time{})); err != nil {
 		t.Fatalf("Publish: %v", err)
 	}
 
@@ -1922,7 +2117,7 @@ func TestEventBusPublish_LogsRoutedAndSubscribedRecipientsSeparately(t *testing.
 	defer eb.Unsubscribe("direct-agent")
 	defer eb.Unsubscribe("scan-orchestrator")
 
-	if err := eb.Publish(context.Background(), eventtest.Projection("", events.EventType("producer/scan.requested"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{})); err != nil {
+	if err := eb.Publish(context.Background(), eventtest.RootIngress("", events.EventType("producer/scan.requested"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{})); err != nil {
 		t.Fatalf("Publish: %v", err)
 	}
 
@@ -2024,7 +2219,7 @@ func TestEventBusPublish_RecordsPublishDiagnosticsInTurnRecorder(t *testing.T) {
 	defer eb.Unsubscribe("scan-orchestrator")
 	recorder := runtimebus.NewEmittedEventsRecorder()
 	ctx := runtimebus.WithEmittedEventsRecorder(context.Background(), recorder)
-	if err := eb.Publish(ctx, eventtest.WithEntityID((eventtest.Projection("", "producer/scan.requested", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{})), "ent-1")); err != nil {
+	if err := eb.Publish(ctx, eventtest.RootIngress("", "producer/scan.requested", "", "", nil, 0, "", "", events.EnvelopeForEntityID(events.EventEnvelope{}, "ent-1"), time.Time{})); err != nil {
 		t.Fatalf("Publish: %v", err)
 	}
 	diags := recorder.SnapshotPublishes()
@@ -2125,9 +2320,18 @@ func TestEventBusPublish_NestedDescendantCompletionDoesNotEmitChildContinuation(
 		}
 	}
 
-	if err := eb.Publish(ctx, eventtest.WithEntityID((eventtest.Projection("11111111-2222-3333-4444-555555555555",
+	if err := eb.Publish(ctx, eventtest.RootIngress(
+		"11111111-2222-3333-4444-555555555555",
 		events.EventType("child/grandchild/micro.done"),
-		"cataloge2e", "", []byte(`{"entity_id":"`+grandchildEntityID+`"}`), 0, eventBusTestRunID, "", events.EventEnvelope{}, time.Now().UTC())), grandchildEntityID)); err != nil {
+		"cataloge2e",
+		"",
+		[]byte(`{"entity_id":"`+grandchildEntityID+`"}`),
+		0,
+		eventBusTestRunID,
+		"",
+		events.EnvelopeForEntityID(events.EventEnvelope{}, grandchildEntityID),
+		time.Now().UTC(),
+	)); err != nil {
 		t.Fatalf("Publish: %v", err)
 	}
 	if err := eb.WaitForQuiescence(ctx); err != nil {
@@ -2235,9 +2439,18 @@ func TestEventBusPublish_NestedThreeLevelChain_FromRootStartCompletesWithoutChil
 		t.Fatalf("seed root instance: %v", err)
 	}
 
-	if err := eb.Publish(ctx, eventtest.WithEntityID((eventtest.Projection("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+	if err := eb.Publish(ctx, eventtest.RootIngress(
+		"aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
 		events.EventType("pipeline.start"),
-		"cataloge2e", "", []byte(`{"entity_id":"`+rootEntityID+`"}`), 0, eventBusTestRunID, "", events.EventEnvelope{}, time.Now().UTC())), rootEntityID)); err != nil {
+		"cataloge2e",
+		"",
+		[]byte(`{"entity_id":"`+rootEntityID+`"}`),
+		0,
+		eventBusTestRunID,
+		"",
+		events.EnvelopeForEntityID(events.EventEnvelope{}, rootEntityID),
+		time.Now().UTC(),
+	)); err != nil {
 		t.Fatalf("Publish: %v", err)
 	}
 	if err := eb.WaitForQuiescence(ctx); err != nil {
@@ -2363,9 +2576,18 @@ func TestEventBusPublish_GatedChildFlowCompletionAdvancesRoot(t *testing.T) {
 		t.Fatalf("seed root instance: %v", err)
 	}
 
-	if err := eb.Publish(ctx, eventtest.WithEntityID((eventtest.Projection("11111111-2222-3333-4444-555555555555",
+	if err := eb.Publish(ctx, eventtest.RootIngress(
+		"11111111-2222-3333-4444-555555555555",
 		events.EventType("validate.requested"),
-		"cataloge2e", "", []byte(`{"entity_id":"`+rootEntityID+`"}`), 0, eventBusTestRunID, "", events.EventEnvelope{}, time.Now().UTC())), rootEntityID)); err != nil {
+		"cataloge2e",
+		"",
+		[]byte(`{"entity_id":"`+rootEntityID+`"}`),
+		0,
+		eventBusTestRunID,
+		"",
+		events.EnvelopeForEntityID(events.EventEnvelope{}, rootEntityID),
+		time.Now().UTC(),
+	)); err != nil {
 		t.Fatalf("Publish: %v", err)
 	}
 	if err := eb.WaitForQuiescence(ctx); err != nil {
@@ -2445,7 +2667,7 @@ func TestEventBusPublish_RecordsNestedDescendantLocalizedEvent(t *testing.T) {
 	defer eb.Unsubscribe("child-aggregator")
 	recorder := runtimebus.NewEmittedEventsRecorder()
 	ctx := runtimebus.WithEmittedEventsRecorder(context.Background(), recorder)
-	if err := eb.Publish(ctx, eventtest.WithEntityID((eventtest.Projection("", "child/grandchild/micro.done", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{})), "ent-grandchild")); err != nil {
+	if err := eb.Publish(ctx, eventtest.RootIngress("", "child/grandchild/micro.done", "", "", nil, 0, "", "", events.EnvelopeForEntityID(events.EventEnvelope{}, "ent-grandchild"), time.Time{})); err != nil {
 		t.Fatalf("Publish: %v", err)
 	}
 	diags := recorder.SnapshotPublishes()
@@ -2502,7 +2724,18 @@ func TestEventBusPublish_RecordsNestedTemplateInstanceLocalizedEvent(t *testing.
 	defer eb.Unsubscribe("worker-inst-1")
 	recorder := runtimebus.NewEmittedEventsRecorder()
 	ctx := runtimebus.WithEmittedEventsRecorder(context.Background(), recorder)
-	if err := eb.Publish(ctx, eventtest.WithEntityID((eventtest.Projection("", "child/grandchild/inst-1/micro.done", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{})), "ent-grandchild")); err != nil {
+	if err := eb.Publish(ctx, eventtest.RootIngress(
+		"",
+		"child/grandchild/inst-1/micro.done",
+		"",
+		"",
+		nil,
+		0,
+		"",
+		"",
+		events.EnvelopeForEntityID(events.EventEnvelope{}, "ent-grandchild"),
+		time.Time{},
+	)); err != nil {
 		t.Fatalf("Publish: %v", err)
 	}
 	diags := recorder.SnapshotPublishes()

--- a/internal/runtime/bus/eventbus_publish_test.go
+++ b/internal/runtime/bus/eventbus_publish_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/division-sh/swarm/internal/events"
+	"github.com/division-sh/swarm/internal/events/eventtest"
 	runtimebus "github.com/division-sh/swarm/internal/runtime/bus"
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
 	runtimeactors "github.com/division-sh/swarm/internal/runtime/core/actors"
@@ -122,7 +123,7 @@ func (deferredChainInterceptor) Intercept(_ context.Context, evt events.Event) (
 	default:
 		return true, nil, nil
 	}
-	return false, []events.Event{(events.NewProjectionEvent("", events.EventType(next), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Now().UTC())).WithEntityID(evt.EntityID())}, nil
+	return false, []events.Event{eventtest.WithEntityID((eventtest.Projection("", events.EventType(next), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Now().UTC())), evt.EntityID())}, nil
 }
 
 type singleDeferredInterceptor struct{}
@@ -131,7 +132,7 @@ func (singleDeferredInterceptor) Intercept(_ context.Context, evt events.Event) 
 	if evt.Type() != events.EventType("custom.root") {
 		return true, nil, nil
 	}
-	return false, []events.Event{(events.NewProjectionEvent("", events.EventType("custom.middle"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Now().UTC())).WithEntityID(evt.EntityID())}, nil
+	return false, []events.Event{eventtest.WithEntityID((eventtest.Projection("", events.EventType("custom.middle"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Now().UTC())), evt.EntityID())}, nil
 }
 
 type nonTransactionalPersistedBeforeInterceptor struct {
@@ -230,7 +231,7 @@ func (i deferredEventVisibleInterceptor) Intercept(ctx context.Context, evt even
 	i.t.Helper()
 	if evt.Type() == events.EventType("custom.root") {
 		return false, []events.Event{
-			events.NewProjectionEvent(i.eventID, i.checkFor, "", "", []byte(`{"entity_id":"ent-1"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC()),
+			eventtest.Projection(i.eventID, i.checkFor, "", "", []byte(`{"entity_id":"ent-1"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC()),
 		}, nil
 	}
 	if evt.Type() != i.checkFor {
@@ -467,11 +468,11 @@ func TestEventBusPublishTransactionalPostCommitReceiptFailureIsRecoverable(t *te
 	ch := eb.Subscribe(agentID, events.EventType("custom.receipt_failure"))
 	defer eb.Unsubscribe(agentID)
 
-	if err := eb.Publish(ctx, events.NewProjectionEvent(eventID,
+	if err := eb.Publish(ctx, eventtest.WithEntityID(eventtest.Projection(eventID,
 
 		events.EventType("custom.receipt_failure"),
-		"api.v1", "", []byte(`{"entity_id":"21000000-0000-0000-0000-000000000012"}`), 0, eventBusTestRunID, "", events.EventEnvelope{}, time.Now().UTC()).
-		WithEntityID("21000000-0000-0000-0000-000000000012")); err != nil {
+		"api.v1", "", []byte(`{"entity_id":"21000000-0000-0000-0000-000000000012"}`), 0, eventBusTestRunID, "", events.EventEnvelope{}, time.Now().UTC()),
+		"21000000-0000-0000-0000-000000000012")); err != nil {
 		t.Fatalf("Publish with post-commit receipt failure: %v", err)
 	}
 	ok, err := pg.EventExists(ctx, eventID)
@@ -525,11 +526,11 @@ func TestEventBusPublishTransactionalPostCommitCompletionFailureIsRecoverable(t 
 	ch := eb.Subscribe(agentID, events.EventType("custom.completion_failure"))
 	defer eb.Unsubscribe(agentID)
 
-	if err := eb.Publish(ctx, events.NewProjectionEvent(eventID,
+	if err := eb.Publish(ctx, eventtest.WithEntityID(eventtest.Projection(eventID,
 
 		events.EventType("custom.completion_failure"),
-		"api.v1", "", []byte(`{"entity_id":"21000000-0000-0000-0000-000000000022"}`), 0, eventBusTestRunID, "", events.EventEnvelope{}, time.Now().UTC()).
-		WithEntityID("21000000-0000-0000-0000-000000000022")); err != nil {
+		"api.v1", "", []byte(`{"entity_id":"21000000-0000-0000-0000-000000000022"}`), 0, eventBusTestRunID, "", events.EventEnvelope{}, time.Now().UTC()),
+		"21000000-0000-0000-0000-000000000022")); err != nil {
 		t.Fatalf("Publish with post-commit completion failure: %v", err)
 	}
 	ok, err := pg.EventExists(ctx, eventID)
@@ -641,9 +642,10 @@ func TestEventBusPublish_LogsQueuedDeliveryLifecycleTransition(t *testing.T) {
 	}
 	ch := bus.Subscribe("agent-1", events.EventType("task.requested"))
 
-	evt := events.NewProjectionEvent(uuid.NewString(),
-		events.EventType("task.requested"), "", "", []byte(`{"entity_id":"ent-1"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC()).
-		WithEntityID("ent-1")
+	evt := eventtest.WithEntityID(eventtest.Projection(uuid.NewString(),
+		events.EventType("task.requested"), "", "", []byte(`{"entity_id":"ent-1"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC()),
+		"ent-1")
+
 	if err := bus.Publish(context.Background(), evt); err != nil {
 		t.Fatalf("Publish: %v", err)
 	}
@@ -686,9 +688,9 @@ func TestEventBusPublish_AttachesTypedRuntimeDiagnosticLineage(t *testing.T) {
 	})
 	ctx = runtimecorrelation.WithRunID(ctx, runID)
 
-	if err := bus.Publish(ctx, events.NewProjectionEvent(eventID,
-		events.EventType("task.requested"), "", "", []byte(`{"entity_id":"ent-1"}`), 0, runID, "", events.EventEnvelope{}, time.Now().UTC()).
-		WithEntityID("ent-1")); err != nil {
+	if err := bus.Publish(ctx, eventtest.WithEntityID(eventtest.Projection(eventID,
+		events.EventType("task.requested"), "", "", []byte(`{"entity_id":"ent-1"}`), 0, runID, "", events.EventEnvelope{}, time.Now().UTC()),
+		"ent-1")); err != nil {
 		t.Fatalf("Publish: %v", err)
 	}
 
@@ -726,9 +728,9 @@ func TestEventBusPublish_AttachesBundleSourceFactToRuntimeLogs(t *testing.T) {
 		t.Fatalf("NewEventBusWithOptions: %v", err)
 	}
 	ch := bus.Subscribe("agent-1", events.EventType("task.requested"))
-	if err := bus.Publish(context.Background(), events.NewProjectionEvent(uuid.NewString(),
-		events.EventType("task.requested"), "", "", []byte(`{"entity_id":"ent-1"}`), 0, uuid.NewString(), "", events.EventEnvelope{}, time.Now().UTC()).
-		WithEntityID("ent-1")); err != nil {
+	if err := bus.Publish(context.Background(), eventtest.WithEntityID(eventtest.Projection(uuid.NewString(),
+		events.EventType("task.requested"), "", "", []byte(`{"entity_id":"ent-1"}`), 0, uuid.NewString(), "", events.EventEnvelope{}, time.Now().UTC()),
+		"ent-1")); err != nil {
 		t.Fatalf("Publish: %v", err)
 	}
 	_ = requireBusEvent(t, ch, "bundle source fact delivery")
@@ -755,7 +757,7 @@ func TestEventBusPublish_UsesPayloadValidator(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewEventBusWithOptions: %v", err)
 	}
-	if err := eb.Publish(context.Background(), events.NewProjectionEvent("", "task.completed", "", "", []byte(`{"ok":true}`), 0, "", "", events.EventEnvelope{}, time.Time{})); err != nil {
+	if err := eb.Publish(context.Background(), eventtest.Projection("", "task.completed", "", "", []byte(`{"ok":true}`), 0, "", "", events.EventEnvelope{}, time.Time{})); err != nil {
 		t.Fatalf("Publish: %v", err)
 	}
 }
@@ -769,7 +771,7 @@ func TestEventBusPublish_PayloadValidatorFailureAbortsPublish(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewEventBusWithOptions: %v", err)
 	}
-	err = eb.Publish(context.Background(), events.NewProjectionEvent("", "task.completed", "", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Time{}))
+	err = eb.Publish(context.Background(), eventtest.Projection("", "task.completed", "", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Time{}))
 	if err == nil || !errors.Is(err, runtimebus.ErrPayloadValidation) {
 		t.Fatalf("expected payload validator failure, got %v", err)
 	}
@@ -783,9 +785,8 @@ func TestEventBusPublish_FailsClosedWhenReplayCapableAtomicStoreOmitsCommittedRe
 	}
 	eb.Subscribe("agent-a", events.EventType("custom.replay.checked"))
 
-	err = eb.Publish(context.Background(), events.NewProjectionEvent(uuid.NewString(),
-		events.EventType("custom.replay.checked"), "", "", []byte(`{"ok":true}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC()),
-	)
+	err = eb.Publish(context.Background(), eventtest.Projection(uuid.NewString(),
+		events.EventType("custom.replay.checked"), "", "", []byte(`{"ok":true}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC()))
 	if !errors.Is(err, runtimereplayclaim.ErrMissingCommittedReplayScope) {
 		t.Fatalf("Publish error = %v, want missing committed replay scope", err)
 	}
@@ -800,7 +801,7 @@ func TestEventBusPublishDirect_PayloadValidatorFailureAbortsPublish(t *testing.T
 	if err != nil {
 		t.Fatalf("NewEventBusWithOptions: %v", err)
 	}
-	err = eb.PublishDirect(context.Background(), events.NewProjectionEvent("", "task.completed", "", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Time{}), []string{"agent-a"})
+	err = eb.PublishDirect(context.Background(), eventtest.Projection("", "task.completed", "", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Time{}), []string{"agent-a"})
 	if err == nil || !errors.Is(err, runtimebus.ErrPayloadValidation) {
 		t.Fatalf("expected payload validator failure, got %v", err)
 	}
@@ -816,7 +817,7 @@ func TestEventBusCheckDirectRecipients_PayloadValidatorFailureAbortsBeforeRecipi
 		t.Fatalf("NewEventBusWithOptions: %v", err)
 	}
 
-	status, err := eb.CheckDirectRecipients(context.Background(), events.NewProjectionEvent("", "task.completed", "", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Time{}), []string{"agent-a"})
+	status, err := eb.CheckDirectRecipients(context.Background(), eventtest.Projection("", "task.completed", "", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Time{}), []string{"agent-a"})
 	if err == nil || !errors.Is(err, runtimebus.ErrPayloadValidation) {
 		t.Fatalf("expected payload validator failure, got %v", err)
 	}
@@ -835,7 +836,7 @@ func TestEventBusCheckPublishRecipientPlanReportsSubscribedPublishWithoutDeliver
 	}
 	ch := eb.Subscribe("agent-a", events.EventType("task.completed"))
 
-	plan, err := eb.CheckPublishRecipientPlan(context.Background(), events.NewProjectionEvent("", "task.completed", "", "", []byte(`{"ok":true}`), 0, "", "", events.EventEnvelope{}, time.Time{}))
+	plan, err := eb.CheckPublishRecipientPlan(context.Background(), eventtest.Projection("", "task.completed", "", "", []byte(`{"ok":true}`), 0, "", "", events.EventEnvelope{}, time.Time{}))
 	if err != nil {
 		t.Fatalf("CheckPublishRecipientPlan: %v", err)
 	}
@@ -866,8 +867,9 @@ func TestEventBusPublishDirect_PersistsButDoesNotMarkDeliveredBeforeRealFanOut(t
 		t.Fatalf("NewEventBus: %v", err)
 	}
 
-	err = eb.PublishDirect(context.Background(), (events.NewProjectionEvent(uuid.NewString(),
-		events.EventType("custom.direct"), "", "", []byte(`{"entity_id":"ent-1"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())).WithEntityID("ent-1"), []string{"agent-a"})
+	err = eb.PublishDirect(context.Background(), eventtest.WithEntityID((eventtest.Projection(uuid.NewString(),
+		events.EventType("custom.direct"), "", "", []byte(`{"entity_id":"ent-1"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())), "ent-1"),
+		[]string{"agent-a"})
 	if err == nil || !strings.Contains(err.Error(), "authoritative delivery incomplete") {
 		t.Fatalf("PublishDirect missing recipient error = %v, want authoritative delivery incomplete", err)
 	}
@@ -890,8 +892,9 @@ func TestEventBusPublishDirect_FiltersEntityScopedRecipientsByExplicitMetadata(t
 	matchCh := eb.Subscribe("reviewer-ent-1")
 	otherCh := eb.Subscribe("reviewer-ent-2")
 
-	err = eb.PublishDirect(context.Background(), events.NewProjectionEvent("", events.EventType("custom.direct"), "", "", []byte(`{"entity_id":"ent-1"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC()).
-		WithEntityID("ent-1"), []string{"control-plane", "reviewer-ent-1", "reviewer-ent-2", "missing-agent"})
+	err = eb.PublishDirect(context.Background(), eventtest.WithEntityID(eventtest.Projection("", events.EventType("custom.direct"), "", "", []byte(`{"entity_id":"ent-1"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC()),
+		"ent-1"),
+		[]string{"control-plane", "reviewer-ent-1", "reviewer-ent-2", "missing-agent"})
 	if err != nil {
 		t.Fatalf("PublishDirect: %v", err)
 	}
@@ -925,8 +928,8 @@ func TestEventBusPublish_FiltersEntityScopedRecipientsByExplicitMetadata(t *test
 	matchCh := eb.Subscribe("reviewer-ent-1", events.EventType("custom.trigger"))
 	otherCh := eb.Subscribe("reviewer-ent-2", events.EventType("custom.trigger"))
 
-	if err := eb.Publish(context.Background(), events.NewProjectionEvent("", events.EventType("custom.trigger"), "", "", []byte(`{"entity_id":"ent-1"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC()).
-		WithEntityID("ent-1")); err != nil {
+	if err := eb.Publish(context.Background(), eventtest.WithEntityID(eventtest.Projection("", events.EventType("custom.trigger"), "", "", []byte(`{"entity_id":"ent-1"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC()),
+		"ent-1")); err != nil {
 		t.Fatalf("Publish: %v", err)
 	}
 
@@ -957,7 +960,7 @@ func TestEventBusPublish_FiltersEntityScopedRecipientsByTypedEnvelopeNotPayload(
 	matchCh := eb.Subscribe("reviewer-ent-1", events.EventType("custom.trigger"))
 	otherCh := eb.Subscribe("reviewer-ent-2", events.EventType("custom.trigger"))
 
-	err = eb.Publish(context.Background(), (events.NewProjectionEvent("", events.EventType("custom.trigger"), "", "", []byte(`{"entity_id":"ent-2"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())).WithEnvelope(events.EventEnvelope{EntityID: "ent-1"}))
+	err = eb.Publish(context.Background(), eventtest.WithEnvelope((eventtest.Projection("", events.EventType("custom.trigger"), "", "", []byte(`{"entity_id":"ent-2"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())), events.EventEnvelope{EntityID: "ent-1"}))
 	if err != nil {
 		t.Fatalf("Publish: %v", err)
 	}
@@ -983,8 +986,8 @@ func TestEventBusPublish_DropsRecipientsMissingExplicitDescriptor(t *testing.T) 
 	controlCh := eb.Subscribe("control-plane", events.EventType("custom.trigger"))
 	missingCh := eb.Subscribe("reviewer-ent-1", events.EventType("custom.trigger"))
 
-	if err := eb.Publish(context.Background(), events.NewProjectionEvent("", events.EventType("custom.trigger"), "", "", []byte(`{"entity_id":"ent-1"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC()).
-		WithEntityID("ent-1")); err != nil {
+	if err := eb.Publish(context.Background(), eventtest.WithEntityID(eventtest.Projection("", events.EventType("custom.trigger"), "", "", []byte(`{"entity_id":"ent-1"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC()),
+		"ent-1")); err != nil {
 		t.Fatalf("Publish: %v", err)
 	}
 
@@ -1009,8 +1012,8 @@ func TestEventBusPublish_KeepsInternalSubscribersLiveOnlyUnderDescriptorPlanning
 	agentCh := eb.Subscribe("agent-a", events.EventType("custom.trigger"))
 	missingCh := eb.Subscribe("agent-missing", events.EventType("custom.trigger"))
 
-	if err := eb.Publish(context.Background(), events.NewProjectionEvent("", events.EventType("custom.trigger"), "", "", []byte(`{"entity_id":"ent-1"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC()).
-		WithEntityID("ent-1")); err != nil {
+	if err := eb.Publish(context.Background(), eventtest.WithEntityID(eventtest.Projection("", events.EventType("custom.trigger"), "", "", []byte(`{"entity_id":"ent-1"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC()),
+		"ent-1")); err != nil {
 		t.Fatalf("Publish: %v", err)
 	}
 
@@ -1048,7 +1051,7 @@ func TestEventBusPublishDeferred_UsesCanonicalSubscribedRecipientFiltering(t *te
 	agentCh := eb.Subscribe("agent-a", events.EventType("custom.middle"))
 	otherCh := eb.Subscribe("agent-b", events.EventType("custom.middle"))
 
-	if err := eb.Publish(context.Background(), (events.NewProjectionEvent("", events.EventType("custom.root"), "", "", []byte(`{"entity_id":"ent-1"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())).WithEntityID("ent-1")); err != nil {
+	if err := eb.Publish(context.Background(), eventtest.WithEntityID((eventtest.Projection("", events.EventType("custom.root"), "", "", []byte(`{"entity_id":"ent-1"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())), "ent-1")); err != nil {
 		t.Fatalf("Publish: %v", err)
 	}
 
@@ -1075,8 +1078,8 @@ func TestEventBusPublish_FailsClosedWhenDescriptorLookupFails(t *testing.T) {
 	}
 	ch := eb.Subscribe("reviewer-ent-1", events.EventType("custom.trigger"))
 
-	err = eb.Publish(context.Background(), events.NewProjectionEvent("", events.EventType("custom.trigger"), "", "", []byte(`{"entity_id":"ent-1"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC()).
-		WithEntityID("ent-1"))
+	err = eb.Publish(context.Background(), eventtest.WithEntityID(eventtest.Projection("", events.EventType("custom.trigger"), "", "", []byte(`{"entity_id":"ent-1"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC()),
+		"ent-1"))
 	if err == nil || !strings.Contains(err.Error(), "descriptor lookup failed") {
 		t.Fatalf("Publish error = %v, want descriptor lookup failure", err)
 	}
@@ -1098,7 +1101,7 @@ func TestEventBusWaitForQuiescenceWaitsForPublishCompletion(t *testing.T) {
 
 	publishDone := make(chan error, 1)
 	go func() {
-		publishDone <- eb.Publish(context.Background(), events.NewProjectionEvent("", "task.completed", "", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Time{}))
+		publishDone <- eb.Publish(context.Background(), eventtest.Projection("", "task.completed", "", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Time{}))
 	}()
 
 	requireSignalBefore(t, started, 500*time.Millisecond, "interceptor start")
@@ -1142,7 +1145,7 @@ func TestEventBusPublishAcknowledgedReturnsBeforePostCommitDispatchCompletes(t *
 
 	publishDone := make(chan error, 1)
 	go func() {
-		publishDone <- eb.PublishAcknowledged(ctx, events.NewProjectionEvent(
+		publishDone <- eb.PublishAcknowledged(ctx, eventtest.Projection(
 			eventID,
 			events.EventType("task.completed"),
 			"api.v1",
@@ -1152,8 +1155,7 @@ func TestEventBusPublishAcknowledgedReturnsBeforePostCommitDispatchCompletes(t *
 			eventBusTestRunID,
 			"",
 			events.EventEnvelope{EntityID: "11111111-1111-1111-1111-111111111137"},
-			time.Now().UTC(),
-		))
+			time.Now().UTC()))
 	}()
 	if err := requireErrorBefore(t, publishDone, 250*time.Millisecond, "acknowledged publish return before interceptor release"); err != nil {
 		t.Fatalf("PublishAcknowledged: %v", err)
@@ -1214,7 +1216,7 @@ func TestEventBusPublish_InterceptsMultiHopDeferredChains(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewEventBusWithOptions: %v", err)
 	}
-	if err := eb.Publish(context.Background(), (events.NewProjectionEvent("", events.EventType("custom.root"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Now().UTC())).WithEntityID("ent-1")); err != nil {
+	if err := eb.Publish(context.Background(), eventtest.WithEntityID((eventtest.Projection("", events.EventType("custom.root"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Now().UTC())), "ent-1")); err != nil {
 		t.Fatalf("Publish: %v", err)
 	}
 	if got := store.eventTypes(); len(got) < 4 || got[0] != "custom.root" || got[1] != "custom.middle" || got[2] != "custom.leaf" || got[3] != "custom.final" {
@@ -1230,7 +1232,7 @@ func TestEventBusPublishNonTransactional_PersistsBeforeInterceptorsRun(t *testin
 	if err != nil {
 		t.Fatalf("NewEventBusWithOptions: %v", err)
 	}
-	if err := eb.Publish(context.Background(), (events.NewProjectionEvent("", events.EventType("custom.non_transactional"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Now().UTC())).WithEntityID("ent-1")); err != nil {
+	if err := eb.Publish(context.Background(), eventtest.WithEntityID((eventtest.Projection("", events.EventType("custom.non_transactional"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Now().UTC())), "ent-1")); err != nil {
 		t.Fatalf("Publish: %v", err)
 	}
 }
@@ -1259,11 +1261,11 @@ func TestEventBusPublishTransactional_RunsInterceptorsAfterCommit(t *testing.T) 
 	}
 	ch := eb.Subscribe(agentID, events.EventType("task.completed"))
 	defer eb.Unsubscribe(agentID)
-	if err := eb.Publish(ctx, events.NewProjectionEvent(eventID,
+	if err := eb.Publish(ctx, eventtest.WithEntityID(eventtest.Projection(eventID,
 
 		events.EventType("task.completed"),
-		"api.v1", "", []byte(`{"entity_id":"11111111-1111-1111-1111-111111111114"}`), 0, eventBusTestRunID, "", events.EventEnvelope{}, time.Now().UTC()).
-		WithEntityID("11111111-1111-1111-1111-111111111114")); err != nil {
+		"api.v1", "", []byte(`{"entity_id":"11111111-1111-1111-1111-111111111114"}`), 0, eventBusTestRunID, "", events.EventEnvelope{}, time.Now().UTC()),
+		"11111111-1111-1111-1111-111111111114")); err != nil {
 		t.Fatalf("Publish: %v", err)
 	}
 	requireSignalBefore(t, called, time.Second, "post-commit interceptor")
@@ -1291,10 +1293,10 @@ func TestEventBusPublishTransactional_ReturnsPostCommitInterceptorErrorAndRecord
 	if err != nil {
 		t.Fatalf("NewEventBusWithOptions: %v", err)
 	}
-	err = eb.Publish(ctx, events.NewProjectionEvent(eventID,
+	err = eb.Publish(ctx, eventtest.WithEntityID(eventtest.Projection(eventID,
 
-		events.EventType("task.failed"), "", "", []byte(`{"entity_id":"11111111-1111-1111-1111-111111111114"}`), 0, eventBusTestRunID, "", events.EventEnvelope{}, time.Now().UTC()).
-		WithEntityID("11111111-1111-1111-1111-111111111114"))
+		events.EventType("task.failed"), "", "", []byte(`{"entity_id":"11111111-1111-1111-1111-111111111114"}`), 0, eventBusTestRunID, "", events.EventEnvelope{}, time.Now().UTC()),
+		"11111111-1111-1111-1111-111111111114"))
 	if !errors.Is(err, wantErr) {
 		t.Fatalf("Publish error = %v, want %v", err, wantErr)
 	}
@@ -1332,10 +1334,10 @@ func TestEventBusPublishInMutationRunsInterceptorsAfterMutationCommit(t *testing
 		t.Fatalf("NewEventBusWithOptions: %v", err)
 	}
 	if err := pg.RunEventMutation(ctx, func(mutation runtimebus.EventMutation) error {
-		if err := eb.PublishInMutation(mutation.Context(), events.NewProjectionEvent(eventID,
+		if err := eb.PublishInMutation(mutation.Context(), eventtest.WithEntityID(eventtest.Projection(eventID,
 			events.EventType("custom.publish_mutation_post_commit"),
-			"api.v1", "", []byte(`{"entity_id":"11111111-1111-1111-1111-111111111113"}`), 0, eventBusTestRunID, "", events.EventEnvelope{}, time.Now().UTC()).
-			WithEntityID("11111111-1111-1111-1111-111111111113")); err != nil {
+			"api.v1", "", []byte(`{"entity_id":"11111111-1111-1111-1111-111111111113"}`), 0, eventBusTestRunID, "", events.EventEnvelope{}, time.Now().UTC()),
+			"11111111-1111-1111-1111-111111111113")); err != nil {
 			return err
 		}
 		select {
@@ -1371,8 +1373,8 @@ func TestEventBusPublishTransactional_RecordsTargetFailureDeadLetter(t *testing.
 	eventID := uuid.NewString()
 	targetEntityID := uuid.NewString()
 	if err := pg.RunEventMutation(ctx, func(mutation runtimebus.EventMutation) error {
-		return eb.PublishInMutation(mutation.Context(), (events.NewRootIngressEvent(eventID,
-			events.EventType("child/output.done"), "", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())).WithTargetRoute(events.RouteIdentity{EntityID: targetEntityID, FlowInstance: "missing-flow"}))
+		return eb.PublishInMutation(mutation.Context(), eventtest.WithTargetRoute((events.NewRootIngressEvent(eventID,
+			events.EventType("child/output.done"), "", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())), events.RouteIdentity{EntityID: targetEntityID, FlowInstance: "missing-flow"}))
 	}); err != nil {
 		t.Fatalf("PublishInMutation: %v", err)
 	}
@@ -1423,8 +1425,9 @@ func TestEventBusPublishInMutationSQLiteRecordsTargetFailureDeadLetter(t *testin
 	}
 	eventID := uuid.NewString()
 	targetEntityID := uuid.NewString()
-	evt := (events.NewRootIngressEvent(eventID,
-		events.EventType("task.completed"), "", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())).WithTargetRoute(events.RouteIdentity{EntityID: targetEntityID, FlowInstance: "missing-flow"})
+	evt := eventtest.WithTargetRoute((events.NewRootIngressEvent(eventID,
+		events.EventType("task.completed"), "", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())), events.RouteIdentity{EntityID: targetEntityID, FlowInstance: "missing-flow"})
+
 	if !evt.HasTargetRoute() {
 		t.Fatalf("event target route missing after construction: envelope=%#v", evt.NormalizedEnvelope())
 	}
@@ -1483,11 +1486,10 @@ func TestEventBusPublish_ClassifiesRunBundleSourceThroughRunLifecycleOwner(t *te
 	if err != nil {
 		t.Fatalf("NewEventBusWithOptions: %v", err)
 	}
-	if err := eb.Publish(context.Background(), events.NewProjectionEvent(uuid.NewString(),
+	if err := eb.Publish(context.Background(), eventtest.Projection(uuid.NewString(),
 
 		events.EventType("scan.requested"),
-		"test", "", []byte(`{}`), 0, runID, "", events.EventEnvelope{}, time.Now().UTC()),
-	); err != nil {
+		"test", "", []byte(`{}`), 0, runID, "", events.EventEnvelope{}, time.Now().UTC())); err != nil {
 		t.Fatalf("Publish: %v", err)
 	}
 	var bundleHash, bundleSource, legacyFingerprint string
@@ -1524,10 +1526,12 @@ func TestEventBusPublishDirect_StampsBundleSourceFactOnRunRow(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewEventBusWithOptions: %v", err)
 	}
-	if err := eb.PublishDirect(context.Background(), events.NewProjectionEvent(uuid.NewString(),
+	if err := eb.PublishDirect(context.Background(), eventtest.Projection(uuid.NewString(),
 
 		events.EventType("scan.requested"),
-		"test", "", []byte(`{}`), 0, runID, "", events.EventEnvelope{}, time.Now().UTC()), []string{"agent-a"}); err != nil {
+		"test", "", []byte(`{}`), 0, runID, "", events.EventEnvelope{}, time.Now().UTC()),
+
+		[]string{"agent-a"}); err != nil {
 		t.Fatalf("PublishDirect: %v", err)
 	}
 	var bundleHash, bundleSource, legacyFingerprint string
@@ -1571,12 +1575,10 @@ func TestEventBusPublish_InheritsRunAndParentFromInboundContext(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewEventBus: %v", err)
 	}
-	ctx := runtimecorrelation.WithInboundEvent(context.Background(), events.NewProjectionEvent("evt-parent",
-		events.EventType("task.started"), "", "", nil, 0, "run-abc", "", events.EventEnvelope{}, time.Time{}),
-	)
-	if err := eb.Publish(ctx, events.NewProjectionEvent("evt-child",
-		events.EventType("task.completed"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}),
-	); err != nil {
+	ctx := runtimecorrelation.WithInboundEvent(context.Background(), eventtest.Projection("evt-parent",
+		events.EventType("task.started"), "", "", nil, 0, "run-abc", "", events.EventEnvelope{}, time.Time{}))
+	if err := eb.Publish(ctx, eventtest.Projection("evt-child",
+		events.EventType("task.completed"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{})); err != nil {
 		t.Fatalf("Publish: %v", err)
 	}
 	if len(store.events) != 1 {
@@ -1612,9 +1614,8 @@ func TestEventBusPublish_ZeroRecipientsDoesNotEmitContradiction(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewEventBus: %v", err)
 	}
-	if err := eb.Publish(context.Background(), events.NewProjectionEvent("evt-zero",
-		events.EventType("custom.no_subscribers"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}),
-	); err != nil {
+	if err := eb.Publish(context.Background(), eventtest.Projection("evt-zero",
+		events.EventType("custom.no_subscribers"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{})); err != nil {
 		t.Fatalf("Publish: %v", err)
 	}
 	got := store.eventTypes()
@@ -1629,9 +1630,8 @@ func TestEventBusPublish_RuntimeLogBypassesContradictionRouting(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewEventBus: %v", err)
 	}
-	if err := eb.Publish(context.Background(), events.NewProjectionEvent("evt-log",
-		events.EventType("platform.runtime_log"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}),
-	); err != nil {
+	if err := eb.Publish(context.Background(), eventtest.Projection("evt-log",
+		events.EventType("platform.runtime_log"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{})); err != nil {
 		t.Fatalf("Publish: %v", err)
 	}
 	got := store.eventTypes()
@@ -1824,11 +1824,11 @@ func TestEventBusRuntimeIngressPauseQueuesAndResumeReleases(t *testing.T) {
 	}
 
 	eventID := "21000000-0000-0000-0000-000000000001"
-	if err := eb.Publish(ctx, events.NewProjectionEvent(eventID,
+	if err := eb.Publish(ctx, eventtest.WithEntityID(eventtest.Projection(eventID,
 
 		eventType,
-		"api.v1", "", []byte(`{"entity_id":"21000000-0000-0000-0000-000000000002"}`), 0, eventBusTestRunID, "", events.EventEnvelope{}, time.Now().UTC()).
-		WithEntityID("21000000-0000-0000-0000-000000000002")); err != nil {
+		"api.v1", "", []byte(`{"entity_id":"21000000-0000-0000-0000-000000000002"}`), 0, eventBusTestRunID, "", events.EventEnvelope{}, time.Now().UTC()),
+		"21000000-0000-0000-0000-000000000002")); err != nil {
 		t.Fatalf("Publish while paused: %v", err)
 	}
 
@@ -1867,7 +1867,7 @@ func TestEventBusPublish_HumanTaskEventsRouteBySubscriptionOnly(t *testing.T) {
 	ch := eb.Subscribe("requester")
 	defer eb.Unsubscribe("requester")
 
-	if err := eb.Publish(context.Background(), events.NewProjectionEvent("", events.EventType("human_task.approved"), "", "", []byte(`{"requesting_agent":"requester"}`), 0, "", "", events.EventEnvelope{}, time.Time{})); err != nil {
+	if err := eb.Publish(context.Background(), eventtest.Projection("", events.EventType("human_task.approved"), "", "", []byte(`{"requesting_agent":"requester"}`), 0, "", "", events.EventEnvelope{}, time.Time{})); err != nil {
 		t.Fatalf("Publish: %v", err)
 	}
 
@@ -1922,7 +1922,7 @@ func TestEventBusPublish_LogsRoutedAndSubscribedRecipientsSeparately(t *testing.
 	defer eb.Unsubscribe("direct-agent")
 	defer eb.Unsubscribe("scan-orchestrator")
 
-	if err := eb.Publish(context.Background(), events.NewProjectionEvent("", events.EventType("producer/scan.requested"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{})); err != nil {
+	if err := eb.Publish(context.Background(), eventtest.Projection("", events.EventType("producer/scan.requested"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{})); err != nil {
 		t.Fatalf("Publish: %v", err)
 	}
 
@@ -2024,7 +2024,7 @@ func TestEventBusPublish_RecordsPublishDiagnosticsInTurnRecorder(t *testing.T) {
 	defer eb.Unsubscribe("scan-orchestrator")
 	recorder := runtimebus.NewEmittedEventsRecorder()
 	ctx := runtimebus.WithEmittedEventsRecorder(context.Background(), recorder)
-	if err := eb.Publish(ctx, (events.NewProjectionEvent("", "producer/scan.requested", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{})).WithEntityID("ent-1")); err != nil {
+	if err := eb.Publish(ctx, eventtest.WithEntityID((eventtest.Projection("", "producer/scan.requested", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{})), "ent-1")); err != nil {
 		t.Fatalf("Publish: %v", err)
 	}
 	diags := recorder.SnapshotPublishes()
@@ -2125,9 +2125,9 @@ func TestEventBusPublish_NestedDescendantCompletionDoesNotEmitChildContinuation(
 		}
 	}
 
-	if err := eb.Publish(ctx, (events.NewProjectionEvent("11111111-2222-3333-4444-555555555555",
+	if err := eb.Publish(ctx, eventtest.WithEntityID((eventtest.Projection("11111111-2222-3333-4444-555555555555",
 		events.EventType("child/grandchild/micro.done"),
-		"cataloge2e", "", []byte(`{"entity_id":"`+grandchildEntityID+`"}`), 0, eventBusTestRunID, "", events.EventEnvelope{}, time.Now().UTC())).WithEntityID(grandchildEntityID)); err != nil {
+		"cataloge2e", "", []byte(`{"entity_id":"`+grandchildEntityID+`"}`), 0, eventBusTestRunID, "", events.EventEnvelope{}, time.Now().UTC())), grandchildEntityID)); err != nil {
 		t.Fatalf("Publish: %v", err)
 	}
 	if err := eb.WaitForQuiescence(ctx); err != nil {
@@ -2235,9 +2235,9 @@ func TestEventBusPublish_NestedThreeLevelChain_FromRootStartCompletesWithoutChil
 		t.Fatalf("seed root instance: %v", err)
 	}
 
-	if err := eb.Publish(ctx, (events.NewProjectionEvent("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+	if err := eb.Publish(ctx, eventtest.WithEntityID((eventtest.Projection("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
 		events.EventType("pipeline.start"),
-		"cataloge2e", "", []byte(`{"entity_id":"`+rootEntityID+`"}`), 0, eventBusTestRunID, "", events.EventEnvelope{}, time.Now().UTC())).WithEntityID(rootEntityID)); err != nil {
+		"cataloge2e", "", []byte(`{"entity_id":"`+rootEntityID+`"}`), 0, eventBusTestRunID, "", events.EventEnvelope{}, time.Now().UTC())), rootEntityID)); err != nil {
 		t.Fatalf("Publish: %v", err)
 	}
 	if err := eb.WaitForQuiescence(ctx); err != nil {
@@ -2363,9 +2363,9 @@ func TestEventBusPublish_GatedChildFlowCompletionAdvancesRoot(t *testing.T) {
 		t.Fatalf("seed root instance: %v", err)
 	}
 
-	if err := eb.Publish(ctx, (events.NewProjectionEvent("11111111-2222-3333-4444-555555555555",
+	if err := eb.Publish(ctx, eventtest.WithEntityID((eventtest.Projection("11111111-2222-3333-4444-555555555555",
 		events.EventType("validate.requested"),
-		"cataloge2e", "", []byte(`{"entity_id":"`+rootEntityID+`"}`), 0, eventBusTestRunID, "", events.EventEnvelope{}, time.Now().UTC())).WithEntityID(rootEntityID)); err != nil {
+		"cataloge2e", "", []byte(`{"entity_id":"`+rootEntityID+`"}`), 0, eventBusTestRunID, "", events.EventEnvelope{}, time.Now().UTC())), rootEntityID)); err != nil {
 		t.Fatalf("Publish: %v", err)
 	}
 	if err := eb.WaitForQuiescence(ctx); err != nil {
@@ -2445,7 +2445,7 @@ func TestEventBusPublish_RecordsNestedDescendantLocalizedEvent(t *testing.T) {
 	defer eb.Unsubscribe("child-aggregator")
 	recorder := runtimebus.NewEmittedEventsRecorder()
 	ctx := runtimebus.WithEmittedEventsRecorder(context.Background(), recorder)
-	if err := eb.Publish(ctx, (events.NewProjectionEvent("", "child/grandchild/micro.done", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{})).WithEntityID("ent-grandchild")); err != nil {
+	if err := eb.Publish(ctx, eventtest.WithEntityID((eventtest.Projection("", "child/grandchild/micro.done", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{})), "ent-grandchild")); err != nil {
 		t.Fatalf("Publish: %v", err)
 	}
 	diags := recorder.SnapshotPublishes()
@@ -2502,7 +2502,7 @@ func TestEventBusPublish_RecordsNestedTemplateInstanceLocalizedEvent(t *testing.
 	defer eb.Unsubscribe("worker-inst-1")
 	recorder := runtimebus.NewEmittedEventsRecorder()
 	ctx := runtimebus.WithEmittedEventsRecorder(context.Background(), recorder)
-	if err := eb.Publish(ctx, (events.NewProjectionEvent("", "child/grandchild/inst-1/micro.done", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{})).WithEntityID("ent-grandchild")); err != nil {
+	if err := eb.Publish(ctx, eventtest.WithEntityID((eventtest.Projection("", "child/grandchild/inst-1/micro.done", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{})), "ent-grandchild")); err != nil {
 		t.Fatalf("Publish: %v", err)
 	}
 	diags := recorder.SnapshotPublishes()

--- a/internal/runtime/bus/eventbus_target_routes_test.go
+++ b/internal/runtime/bus/eventbus_target_routes_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/division-sh/swarm/internal/events"
+	"github.com/division-sh/swarm/internal/events/eventtest"
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
 	runtimeflowidentity "github.com/division-sh/swarm/internal/runtime/core/flowidentity"
 	runtimeownership "github.com/division-sh/swarm/internal/runtime/core/ownership"
@@ -174,9 +175,8 @@ func TestEventBusRecipientPlanMaterializerPersistsRoutesBeforeInterceptors(t *te
 	if err != nil {
 		t.Fatalf("NewEventBusWithOptions: %v", err)
 	}
-	if err := eb.Publish(context.Background(), events.NewProjectionEvent(eventID,
-		events.EventType("review/inst-1/task.started"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Now().UTC()),
-	); err != nil {
+	if err := eb.Publish(context.Background(), eventtest.Projection(eventID,
+		events.EventType("review/inst-1/task.started"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Now().UTC())); err != nil {
 		t.Fatalf("Publish: %v", err)
 	}
 	if !guardSawMaterializedRoute {
@@ -206,7 +206,7 @@ func TestEventBusRecipientPlanMaterializerNormalizesRoutePlanDirectly(t *testing
 	if err != nil {
 		t.Fatalf("NewEventBusWithOptions: %v", err)
 	}
-	evt := events.NewProjectionEvent(uuid.NewString(), events.EventType("review/inst-1/task.started"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{})
+	evt := eventtest.Projection(uuid.NewString(), events.EventType("review/inst-1/task.started"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{})
 	emptyAgentPolicyPlan := routePlanFromManifest(evt, deliveryRecipientManifest{}, routeIntentProducerAgentPolicy)
 	if emptyAgentPolicyPlan.AuthorityState != RoutePlanAuthorityNoCanonicalMatch || emptyAgentPolicyPlan.AuthorityOwner != "" {
 		t.Fatalf("empty agent-policy route plan authority = %q/%q, want no canonical match", emptyAgentPolicyPlan.AuthorityState, emptyAgentPolicyPlan.AuthorityOwner)
@@ -244,7 +244,7 @@ func TestEventBusAgentDispatchIgnoresSameIDNodeRouteTargets(t *testing.T) {
 	ch := eb.Subscribe("shared-subscriber", events.EventType("review/inst-1/task.started"))
 	defer eb.Unsubscribe("shared-subscriber")
 
-	evt := events.NewProjectionEvent(uuid.NewString(),
+	evt := eventtest.Projection(uuid.NewString(),
 		events.EventType("review/inst-1/task.started"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Now().UTC())
 
 	if err := eb.deliverToRecipientsWithRoutes(context.Background(), evt, []string{"shared-subscriber"}, []events.DeliveryRoute{{
@@ -349,7 +349,7 @@ func TestEventBusPublish_NodeOnlyRouteDoesNotRequireAgentChannel(t *testing.T) {
 		t.Fatalf("NewEventBus: %v", err)
 	}
 	eb.deliveryPlanner = nodeOnlyDeliveryPlanner("workflow-node")
-	evt := events.NewProjectionEvent(uuid.NewString(),
+	evt := eventtest.Projection(uuid.NewString(),
 		events.EventType("custom.node_only"), "", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())
 
 	if err := eb.Publish(context.Background(), evt); err != nil {
@@ -369,7 +369,7 @@ func TestEventBusCommittedPublishDispatch_NodeOnlyRouteDoesNotRequireAgentChanne
 	if err != nil {
 		t.Fatalf("NewEventBus: %v", err)
 	}
-	evt := events.NewProjectionEvent(uuid.NewString(),
+	evt := eventtest.Projection(uuid.NewString(),
 		events.EventType("custom.node_only_tx"), "", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())
 
 	eb.completeCommittedPublishDispatch(context.Background(), evt, nodeOnlyDeliveryPlan(evt, "workflow-node"))
@@ -385,7 +385,7 @@ func TestEngineDispatcher_NodeOnlyRouteDoesNotRequireAgentChannel(t *testing.T) 
 	if err != nil {
 		t.Fatalf("NewEventBus: %v", err)
 	}
-	evt := events.NewProjectionEvent(uuid.NewString(),
+	evt := eventtest.Projection(uuid.NewString(),
 		events.EventType("custom.node_only_outbox"), "", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())
 
 	store.events[evt.ID()] = evt
@@ -401,7 +401,7 @@ func TestEngineDispatcher_NodeOnlyRouteDoesNotRequireAgentChannel(t *testing.T) 
 
 func TestSweepUndispatched_NodeOnlyRouteDoesNotRequireAgentChannel(t *testing.T) {
 	store := newTargetRouteMemoryStore()
-	evt := events.NewProjectionEvent(uuid.NewString(),
+	evt := eventtest.Projection(uuid.NewString(),
 		events.EventType("custom.node_only_sweep"), "", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())
 
 	store.events[evt.ID()] = evt
@@ -433,7 +433,7 @@ func TestEventBusPublish_MixedNodeAgentRouteStillRequiresAgentChannel(t *testing
 		t.Fatalf("NewEventBus: %v", err)
 	}
 	eb.deliveryPlanner = mixedNodeAgentDeliveryPlanner("workflow-node", "agent-missing")
-	evt := events.NewProjectionEvent(uuid.NewString(),
+	evt := eventtest.Projection(uuid.NewString(),
 		events.EventType("custom.mixed_node_agent"), "", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())
 
 	err = eb.Publish(context.Background(), evt)
@@ -474,8 +474,8 @@ func TestEventBusPublish_TargetSetInternalDeliveryUsesPerTargetRoutes(t *testing
 	)
 
 	ch := eb.SubscribeInternal("workflow-runtime", events.EventType("child/output.done"))
-	evt := (events.NewProjectionEvent(uuid.NewString(),
-		events.EventType("child/output.done"), "", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())).WithTargetSet([]events.RouteIdentity{
+	evt := eventtest.WithTargetSet((eventtest.Projection(uuid.NewString(),
+		events.EventType("child/output.done"), "", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())), []events.RouteIdentity{
 		{FlowInstance: "child-a/inst-1", EntityID: "ent-a"},
 		{FlowInstance: "child-b/inst-1", EntityID: "ent-b"},
 	})
@@ -542,11 +542,12 @@ func TestEventBusPublish_TargetSetSameSemanticNodePersistsPerTargetRoutes(t *tes
 	)
 
 	ch := eb.SubscribeInternal("workflow-runtime", events.EventType("worker/work.assign"))
-	evt := (events.NewProjectionEvent(uuid.NewString(),
-		events.EventType("worker/work.assign"), "", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())).WithTargetSet([]events.RouteIdentity{
+	evt := eventtest.WithTargetSet((eventtest.Projection(uuid.NewString(),
+		events.EventType("worker/work.assign"), "", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())), []events.RouteIdentity{
 		{FlowInstance: "worker/w-001", EntityID: "worker/w-001"},
 		{FlowInstance: "worker/w-002", EntityID: "worker/w-002"},
 	})
+
 	if err := eb.Publish(context.Background(), evt); err != nil {
 		t.Fatalf("Publish: %v", err)
 	}
@@ -589,9 +590,9 @@ func TestEventBusPublish_TargetedRouteTableNodePersistsSemanticNodeRoute(t *test
 			},
 		},
 	)
-	evt := (events.NewProjectionEvent(uuid.NewString(),
-		events.EventType("worker/work.assign"), "", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())).
-		WithTargetRoute(events.RouteIdentity{FlowInstance: "worker/w-001", EntityID: "worker/w-001"})
+	evt := eventtest.WithTargetRoute((eventtest.Projection(uuid.NewString(),
+		events.EventType("worker/work.assign"), "", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())),
+		events.RouteIdentity{FlowInstance: "worker/w-001", EntityID: "worker/w-001"})
 
 	if err := eb.Publish(context.Background(), evt); err != nil {
 		t.Fatalf("Publish: %v", err)
@@ -616,9 +617,9 @@ func TestEventBusPublish_TargetedTemplateInstanceRouteTableNodePersistsSemanticN
 	if err := eb.AddFlowInstanceRoute(FlowInstanceRouteMaterializationRequest{Identity: runtimeflowidentity.DeriveRoute("operating", "inst-1")}); err != nil {
 		t.Fatalf("AddFlowInstanceRoute: %v", err)
 	}
-	evt := (events.NewProjectionEvent(uuid.NewString(),
-		events.EventType("operating/opco.product_initialization_requested"), "", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())).
-		WithTargetRoute(events.RouteIdentity{FlowInstance: "operating/inst-1", EntityID: "ent-operating"})
+	evt := eventtest.WithTargetRoute((eventtest.Projection(uuid.NewString(),
+		events.EventType("operating/opco.product_initialization_requested"), "", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())),
+		events.RouteIdentity{FlowInstance: "operating/inst-1", EntityID: "ent-operating"})
 
 	plan, err := eb.CheckPublishRecipientPlan(context.Background(), evt)
 	if err != nil {
@@ -685,9 +686,9 @@ func TestEventBusPublish_TargetedDynamicFlowFixtureRouteTableNodePersistsSemanti
 		FlowInstance: "worker/w-001",
 		EntityID:     runtimeflowidentity.EntityID("worker/w-001"),
 	}
-	evt := (events.NewProjectionEvent(uuid.NewString(),
-		events.EventType("worker/work.assign"), "", "", []byte(`{"task_label":"route-me"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())).
-		WithTargetRoute(target)
+	evt := eventtest.WithTargetRoute((eventtest.Projection(uuid.NewString(),
+		events.EventType("worker/work.assign"), "", "", []byte(`{"task_label":"route-me"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())),
+		target)
 
 	plan, err := eb.CheckPublishRecipientPlan(context.Background(), evt)
 	if err != nil {
@@ -731,8 +732,9 @@ func TestEventBusPublish_NoTargetConcreteRoutedNodePersistsSemanticNodeRoute(t *
 		t.Fatalf("AddFlowInstanceRoute: %v", err)
 	}
 	ch := eb.SubscribeInternal("workflow-runtime", events.EventType("operating/opco.product_initialization_requested"))
-	evt := (events.NewProjectionEvent(uuid.NewString(),
-		events.EventType("operating/inst-1/opco.product_initialization_requested"), "", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())).WithEntityID("ent-operating").WithFlowInstance("operating/inst-1")
+	evt := eventtest.WithFlowInstance(eventtest.WithEntityID((eventtest.Projection(uuid.NewString(),
+		events.EventType("operating/inst-1/opco.product_initialization_requested"), "", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())), "ent-operating"),
+		"operating/inst-1")
 
 	if err := eb.Publish(context.Background(), evt); err != nil {
 		t.Fatalf("Publish: %v", err)
@@ -793,8 +795,9 @@ func TestEventBusPublish_SemanticScopeFlowInstanceResolvesConcreteRoute(t *testi
 		t.Fatalf("AddFlowInstanceRoute: %v", err)
 	}
 	ch := eb.SubscribeInternal("workflow-runtime", events.EventType("operating/opco.product_initialization_requested"))
-	evt := (events.NewProjectionEvent(uuid.NewString(),
-		events.EventType("operating/opco.product_initialization_requested"), "", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())).WithEntityID("ent-operating").WithFlowInstance("operating/inst-1")
+	evt := eventtest.WithFlowInstance(eventtest.WithEntityID((eventtest.Projection(uuid.NewString(),
+		events.EventType("operating/opco.product_initialization_requested"), "", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())), "ent-operating"),
+		"operating/inst-1")
 
 	plan, err := eb.CheckPublishRecipientPlan(context.Background(), evt)
 	if err != nil {
@@ -858,9 +861,10 @@ func TestEventBusPublish_RuntimeCallbackLocalEventPersistsSameFlowNodeRouteBefor
 			concreteEventType := "repo-scaffold/inst-1/" + tc.eventType
 			ch := eb.SubscribeInternal("workflow-runtime", events.EventType(concreteEventType))
 			defer eb.Unsubscribe("workflow-runtime")
-			evt := (events.NewProjectionEvent(eventID,
+			evt := eventtest.WithFlowInstance(eventtest.WithEntityID((eventtest.Projection(eventID,
 				events.EventType(tc.eventType),
-				"workflow-runtime", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())).WithEntityID("ent-repo").WithFlowInstance("repo-scaffold/inst-1")
+				"workflow-runtime", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())), "ent-repo"),
+				"repo-scaffold/inst-1")
 
 			plan, err := eb.CheckPublishRecipientPlan(context.Background(), evt)
 			if err != nil {
@@ -903,8 +907,9 @@ func TestEventBusCheckPublishRecipientPlan_SemanticScopeFlowInstanceMaterializes
 		t.Fatalf("NewEventBusWithOptions: %v", err)
 	}
 	ch := eb.SubscribeInternal("workflow-runtime", events.EventType("validation/thing.reviewed"))
-	evt := (events.NewProjectionEvent(uuid.NewString(),
-		events.EventType("validation/thing.reviewed"), "", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())).WithEntityID("ent-validation").WithFlowInstance("validation/inst-1")
+	evt := eventtest.WithFlowInstance(eventtest.WithEntityID((eventtest.Projection(uuid.NewString(),
+		events.EventType("validation/thing.reviewed"), "", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())), "ent-validation"),
+		"validation/inst-1")
 
 	plan, err := eb.CheckPublishRecipientPlan(context.Background(), evt)
 	if err != nil {
@@ -948,8 +953,9 @@ func TestEventBusCheckPublishRecipientPlan_SemanticScopeFlowInstanceMaterializes
 	if err != nil {
 		t.Fatalf("NewEventBusWithOptions: %v", err)
 	}
-	evt := (events.NewProjectionEvent(uuid.NewString(),
-		events.EventType("validation/thing.reviewed"), "", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())).WithEntityID("ent-validation").WithFlowInstance("validation/inst-1")
+	evt := eventtest.WithFlowInstance(eventtest.WithEntityID((eventtest.Projection(uuid.NewString(),
+		events.EventType("validation/thing.reviewed"), "", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())), "ent-validation"),
+		"validation/inst-1")
 
 	plan, err := eb.CheckPublishRecipientPlan(context.Background(), evt)
 	if err != nil {
@@ -990,8 +996,9 @@ func TestEventBusPublish_NoTargetScopedRoutedNodePersistsSemanticRouteBeforeInte
 		t.Fatalf("NewEventBusWithOptions: %v", err)
 	}
 	ch := eb.SubscribeInternal("workflow-runtime", events.EventType("child/child.start"))
-	evt := (events.NewProjectionEvent(uuid.NewString(),
-		events.EventType("child/child.start"), "", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())).WithEntityID("ent-child")
+	evt := eventtest.WithEntityID((eventtest.Projection(uuid.NewString(),
+		events.EventType("child/child.start"), "", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())), "ent-child")
+
 	want := events.DeliveryRoute{
 		SubscriberType: "node",
 		SubscriberID:   "child-intake",
@@ -1092,8 +1099,9 @@ func TestEventBusPublish_WildcardStaticServiceNodePersistsRouteBeforeInternalCar
 	}
 	ch := eb.SubscribeInternal("workflow-runtime", events.EventType(eventType))
 	defer eb.Unsubscribe("workflow-runtime")
-	evt := (events.NewProjectionEvent(eventID,
-		events.EventType(eventType), "", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())).WithEntityID("ent-component").WithFlowInstance("component-scaffold/component-a")
+	evt := eventtest.WithFlowInstance(eventtest.WithEntityID((eventtest.Projection(eventID,
+		events.EventType(eventType), "", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())), "ent-component"),
+		"component-scaffold/component-a")
 
 	plan, err := eb.CheckPublishRecipientPlan(context.Background(), evt)
 	if err != nil {
@@ -1171,8 +1179,8 @@ func TestEventBusPublish_RootInputFlowNodePersistsRouteBeforeDispatch(t *testing
 		t.Fatalf("NewEventBusWithOptions: %v", err)
 	}
 	ch := eb.SubscribeInternal("workflow-runtime", events.EventType("thing.created"))
-	evt := (events.NewProjectionEvent(eventID,
-		events.EventType("thing.created"), "", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())).WithEntityID("ent-root-input")
+	evt := eventtest.WithEntityID((eventtest.Projection(eventID,
+		events.EventType("thing.created"), "", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())), "ent-root-input")
 
 	plan, err := eb.CheckPublishRecipientPlan(context.Background(), evt)
 	if err != nil {
@@ -1223,8 +1231,8 @@ func TestEventBusPublish_RootInputFlowNodePersistsRouteBeforeInterceptorWithoutI
 	if err != nil {
 		t.Fatalf("NewEventBusWithOptions: %v", err)
 	}
-	evt := (events.NewProjectionEvent(eventID,
-		events.EventType("thing.created"), "", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())).WithEntityID("ent-root-input")
+	evt := eventtest.WithEntityID((eventtest.Projection(eventID,
+		events.EventType("thing.created"), "", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())), "ent-root-input")
 
 	plan, err := eb.CheckPublishRecipientPlan(context.Background(), evt)
 	if err != nil {
@@ -1281,8 +1289,8 @@ func TestEventBusPublish_LoadedRootInputProjectEventPersistsRouteBeforeDispatch(
 		t.Fatalf("NewEventBusWithOptions: %v", err)
 	}
 	ch := eb.SubscribeInternal("workflow-runtime", events.EventType("thing.created"))
-	evt := (events.NewProjectionEvent(eventID,
-		events.EventType("thing.created"), "", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())).WithEntityID("ent-loaded-root-input")
+	evt := eventtest.WithEntityID((eventtest.Projection(eventID,
+		events.EventType("thing.created"), "", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())), "ent-loaded-root-input")
 
 	plan, err := eb.CheckPublishRecipientPlan(context.Background(), evt)
 	if err != nil {
@@ -1318,8 +1326,8 @@ func TestEventBusPublish_NoTargetRootRoutedNodeUsesSemanticNodeDeliveryRoute(t *
 		t.Fatalf("NewEventBusWithOptions: %v", err)
 	}
 	ch := eb.SubscribeInternal("portfolio-node", events.EventType("opco.spinup_requested"))
-	evt := (events.NewProjectionEvent(uuid.NewString(),
-		events.EventType("opco.spinup_requested"), "", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())).WithEntityID("ent-root")
+	evt := eventtest.WithEntityID((eventtest.Projection(uuid.NewString(),
+		events.EventType("opco.spinup_requested"), "", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())), "ent-root")
 
 	if err := eb.Publish(context.Background(), evt); err != nil {
 		t.Fatalf("Publish: %v", err)
@@ -1371,8 +1379,8 @@ func TestEventBusPublish_NoTargetRootRoutedNodePersistsSemanticRouteWithoutInter
 	if err != nil {
 		t.Fatalf("NewEventBusWithOptions: %v", err)
 	}
-	evt := (events.NewProjectionEvent(uuid.NewString(),
-		events.EventType("opco.spinup_requested"), "", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())).WithEntityID("ent-root")
+	evt := eventtest.WithEntityID((eventtest.Projection(uuid.NewString(),
+		events.EventType("opco.spinup_requested"), "", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())), "ent-root")
 
 	if err := eb.Publish(context.Background(), evt); err != nil {
 		t.Fatalf("Publish: %v", err)
@@ -1448,8 +1456,8 @@ func TestEventBusPublish_TopLevelProjectNodePersistsRouteBeforeInterceptor(t *te
 	}
 	eb.RegisterRuntimeActiveAgentDescriptor(ActiveAgentDescriptor{AgentID: "workflow-runtime"})
 	ch := eb.Subscribe("workflow-runtime", events.EventType("thing.created"))
-	evt := (events.NewProjectionEvent(eventID,
-		events.EventType("thing.created"), "", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())).WithEntityID("ent-project")
+	evt := eventtest.WithEntityID((eventtest.Projection(eventID,
+		events.EventType("thing.created"), "", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())), "ent-project")
 
 	plan, err := eb.CheckPublishRecipientPlan(context.Background(), evt)
 	if err != nil {
@@ -1481,9 +1489,8 @@ func TestEventBusPublish_NodeRouteFailsClosedWithoutRouteSetPersistence(t *testi
 	if err != nil {
 		t.Fatalf("NewEventBusWithOptions: %v", err)
 	}
-	if err := eb.Publish(context.Background(), events.NewProjectionEvent(uuid.NewString(),
-		events.EventType("thing.created"), "", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC()),
-	); err == nil || !strings.Contains(err.Error(), "typed delivery route persistence") {
+	if err := eb.Publish(context.Background(), eventtest.Projection(uuid.NewString(),
+		events.EventType("thing.created"), "", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())); err == nil || !strings.Contains(err.Error(), "typed delivery route persistence") {
 		t.Fatalf("Publish error = %v, want typed delivery route persistence failure", err)
 	}
 }

--- a/internal/runtime/bus/eventbus_target_routes_test.go
+++ b/internal/runtime/bus/eventbus_target_routes_test.go
@@ -175,7 +175,7 @@ func TestEventBusRecipientPlanMaterializerPersistsRoutesBeforeInterceptors(t *te
 	if err != nil {
 		t.Fatalf("NewEventBusWithOptions: %v", err)
 	}
-	if err := eb.Publish(context.Background(), eventtest.Projection(eventID,
+	if err := eb.Publish(context.Background(), eventtest.RootIngress(eventID,
 		events.EventType("review/inst-1/task.started"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Now().UTC())); err != nil {
 		t.Fatalf("Publish: %v", err)
 	}
@@ -206,7 +206,7 @@ func TestEventBusRecipientPlanMaterializerNormalizesRoutePlanDirectly(t *testing
 	if err != nil {
 		t.Fatalf("NewEventBusWithOptions: %v", err)
 	}
-	evt := eventtest.Projection(uuid.NewString(), events.EventType("review/inst-1/task.started"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{})
+	evt := eventtest.RootIngress(uuid.NewString(), events.EventType("review/inst-1/task.started"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{})
 	emptyAgentPolicyPlan := routePlanFromManifest(evt, deliveryRecipientManifest{}, routeIntentProducerAgentPolicy)
 	if emptyAgentPolicyPlan.AuthorityState != RoutePlanAuthorityNoCanonicalMatch || emptyAgentPolicyPlan.AuthorityOwner != "" {
 		t.Fatalf("empty agent-policy route plan authority = %q/%q, want no canonical match", emptyAgentPolicyPlan.AuthorityState, emptyAgentPolicyPlan.AuthorityOwner)
@@ -244,7 +244,7 @@ func TestEventBusAgentDispatchIgnoresSameIDNodeRouteTargets(t *testing.T) {
 	ch := eb.Subscribe("shared-subscriber", events.EventType("review/inst-1/task.started"))
 	defer eb.Unsubscribe("shared-subscriber")
 
-	evt := eventtest.Projection(uuid.NewString(),
+	evt := eventtest.RootIngress(uuid.NewString(),
 		events.EventType("review/inst-1/task.started"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Now().UTC())
 
 	if err := eb.deliverToRecipientsWithRoutes(context.Background(), evt, []string{"shared-subscriber"}, []events.DeliveryRoute{{
@@ -349,7 +349,7 @@ func TestEventBusPublish_NodeOnlyRouteDoesNotRequireAgentChannel(t *testing.T) {
 		t.Fatalf("NewEventBus: %v", err)
 	}
 	eb.deliveryPlanner = nodeOnlyDeliveryPlanner("workflow-node")
-	evt := eventtest.Projection(uuid.NewString(),
+	evt := eventtest.RootIngress(uuid.NewString(),
 		events.EventType("custom.node_only"), "", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())
 
 	if err := eb.Publish(context.Background(), evt); err != nil {
@@ -369,7 +369,7 @@ func TestEventBusCommittedPublishDispatch_NodeOnlyRouteDoesNotRequireAgentChanne
 	if err != nil {
 		t.Fatalf("NewEventBus: %v", err)
 	}
-	evt := eventtest.Projection(uuid.NewString(),
+	evt := eventtest.RootIngress(uuid.NewString(),
 		events.EventType("custom.node_only_tx"), "", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())
 
 	eb.completeCommittedPublishDispatch(context.Background(), evt, nodeOnlyDeliveryPlan(evt, "workflow-node"))
@@ -385,7 +385,7 @@ func TestEngineDispatcher_NodeOnlyRouteDoesNotRequireAgentChannel(t *testing.T) 
 	if err != nil {
 		t.Fatalf("NewEventBus: %v", err)
 	}
-	evt := eventtest.Projection(uuid.NewString(),
+	evt := eventtest.RootIngress(uuid.NewString(),
 		events.EventType("custom.node_only_outbox"), "", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())
 
 	store.events[evt.ID()] = evt
@@ -401,7 +401,7 @@ func TestEngineDispatcher_NodeOnlyRouteDoesNotRequireAgentChannel(t *testing.T) 
 
 func TestSweepUndispatched_NodeOnlyRouteDoesNotRequireAgentChannel(t *testing.T) {
 	store := newTargetRouteMemoryStore()
-	evt := eventtest.Projection(uuid.NewString(),
+	evt := eventtest.RootIngress(uuid.NewString(),
 		events.EventType("custom.node_only_sweep"), "", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())
 
 	store.events[evt.ID()] = evt
@@ -433,7 +433,7 @@ func TestEventBusPublish_MixedNodeAgentRouteStillRequiresAgentChannel(t *testing
 		t.Fatalf("NewEventBus: %v", err)
 	}
 	eb.deliveryPlanner = mixedNodeAgentDeliveryPlanner("workflow-node", "agent-missing")
-	evt := eventtest.Projection(uuid.NewString(),
+	evt := eventtest.RootIngress(uuid.NewString(),
 		events.EventType("custom.mixed_node_agent"), "", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())
 
 	err = eb.Publish(context.Background(), evt)
@@ -474,11 +474,21 @@ func TestEventBusPublish_TargetSetInternalDeliveryUsesPerTargetRoutes(t *testing
 	)
 
 	ch := eb.SubscribeInternal("workflow-runtime", events.EventType("child/output.done"))
-	evt := eventtest.WithTargetSet((eventtest.Projection(uuid.NewString(),
-		events.EventType("child/output.done"), "", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())), []events.RouteIdentity{
-		{FlowInstance: "child-a/inst-1", EntityID: "ent-a"},
-		{FlowInstance: "child-b/inst-1", EntityID: "ent-b"},
-	})
+	evt := eventtest.RootIngress(
+		uuid.NewString(),
+		events.EventType("child/output.done"),
+		"",
+		"",
+		[]byte(`{}`),
+		0,
+		"",
+		"",
+		events.EnvelopeForTargetSet(events.EventEnvelope{}, []events.RouteIdentity{
+			{FlowInstance: "child-a/inst-1", EntityID: "ent-a"},
+			{FlowInstance: "child-b/inst-1", EntityID: "ent-b"},
+		}),
+		time.Now().UTC(),
+	)
 
 	if err := eb.Publish(context.Background(), evt); err != nil {
 		t.Fatalf("Publish: %v", err)
@@ -542,11 +552,21 @@ func TestEventBusPublish_TargetSetSameSemanticNodePersistsPerTargetRoutes(t *tes
 	)
 
 	ch := eb.SubscribeInternal("workflow-runtime", events.EventType("worker/work.assign"))
-	evt := eventtest.WithTargetSet((eventtest.Projection(uuid.NewString(),
-		events.EventType("worker/work.assign"), "", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())), []events.RouteIdentity{
-		{FlowInstance: "worker/w-001", EntityID: "worker/w-001"},
-		{FlowInstance: "worker/w-002", EntityID: "worker/w-002"},
-	})
+	evt := eventtest.RootIngress(
+		uuid.NewString(),
+		events.EventType("worker/work.assign"),
+		"",
+		"",
+		[]byte(`{}`),
+		0,
+		"",
+		"",
+		events.EnvelopeForTargetSet(events.EventEnvelope{}, []events.RouteIdentity{
+			{FlowInstance: "worker/w-001", EntityID: "worker/w-001"},
+			{FlowInstance: "worker/w-002", EntityID: "worker/w-002"},
+		}),
+		time.Now().UTC(),
+	)
 
 	if err := eb.Publish(context.Background(), evt); err != nil {
 		t.Fatalf("Publish: %v", err)
@@ -590,9 +610,18 @@ func TestEventBusPublish_TargetedRouteTableNodePersistsSemanticNodeRoute(t *test
 			},
 		},
 	)
-	evt := eventtest.WithTargetRoute((eventtest.Projection(uuid.NewString(),
-		events.EventType("worker/work.assign"), "", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())),
-		events.RouteIdentity{FlowInstance: "worker/w-001", EntityID: "worker/w-001"})
+	evt := eventtest.RootIngress(
+		uuid.NewString(),
+		events.EventType("worker/work.assign"),
+		"",
+		"",
+		[]byte(`{}`),
+		0,
+		"",
+		"",
+		events.EnvelopeForTargetRoute(events.EventEnvelope{}, events.RouteIdentity{FlowInstance: "worker/w-001", EntityID: "worker/w-001"}),
+		time.Now().UTC(),
+	)
 
 	if err := eb.Publish(context.Background(), evt); err != nil {
 		t.Fatalf("Publish: %v", err)
@@ -617,9 +646,18 @@ func TestEventBusPublish_TargetedTemplateInstanceRouteTableNodePersistsSemanticN
 	if err := eb.AddFlowInstanceRoute(FlowInstanceRouteMaterializationRequest{Identity: runtimeflowidentity.DeriveRoute("operating", "inst-1")}); err != nil {
 		t.Fatalf("AddFlowInstanceRoute: %v", err)
 	}
-	evt := eventtest.WithTargetRoute((eventtest.Projection(uuid.NewString(),
-		events.EventType("operating/opco.product_initialization_requested"), "", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())),
-		events.RouteIdentity{FlowInstance: "operating/inst-1", EntityID: "ent-operating"})
+	evt := eventtest.RootIngress(
+		uuid.NewString(),
+		events.EventType("operating/opco.product_initialization_requested"),
+		"",
+		"",
+		[]byte(`{}`),
+		0,
+		"",
+		"",
+		events.EnvelopeForTargetRoute(events.EventEnvelope{}, events.RouteIdentity{FlowInstance: "operating/inst-1", EntityID: "ent-operating"}),
+		time.Now().UTC(),
+	)
 
 	plan, err := eb.CheckPublishRecipientPlan(context.Background(), evt)
 	if err != nil {
@@ -686,9 +724,18 @@ func TestEventBusPublish_TargetedDynamicFlowFixtureRouteTableNodePersistsSemanti
 		FlowInstance: "worker/w-001",
 		EntityID:     runtimeflowidentity.EntityID("worker/w-001"),
 	}
-	evt := eventtest.WithTargetRoute((eventtest.Projection(uuid.NewString(),
-		events.EventType("worker/work.assign"), "", "", []byte(`{"task_label":"route-me"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())),
-		target)
+	evt := eventtest.RootIngress(
+		uuid.NewString(),
+		events.EventType("worker/work.assign"),
+		"",
+		"",
+		[]byte(`{"task_label":"route-me"}`),
+		0,
+		"",
+		"",
+		events.EnvelopeForTargetRoute(events.EventEnvelope{}, target),
+		time.Now().UTC(),
+	)
 
 	plan, err := eb.CheckPublishRecipientPlan(context.Background(), evt)
 	if err != nil {
@@ -732,9 +779,18 @@ func TestEventBusPublish_NoTargetConcreteRoutedNodePersistsSemanticNodeRoute(t *
 		t.Fatalf("AddFlowInstanceRoute: %v", err)
 	}
 	ch := eb.SubscribeInternal("workflow-runtime", events.EventType("operating/opco.product_initialization_requested"))
-	evt := eventtest.WithFlowInstance(eventtest.WithEntityID((eventtest.Projection(uuid.NewString(),
-		events.EventType("operating/inst-1/opco.product_initialization_requested"), "", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())), "ent-operating"),
-		"operating/inst-1")
+	evt := eventtest.RootIngress(
+		uuid.NewString(),
+		events.EventType("operating/inst-1/opco.product_initialization_requested"),
+		"",
+		"",
+		[]byte(`{}`),
+		0,
+		"",
+		"",
+		events.EnvelopeForFlowInstance(events.EnvelopeForEntityID(events.EventEnvelope{}, "ent-operating"), "operating/inst-1"),
+		time.Now().UTC(),
+	)
 
 	if err := eb.Publish(context.Background(), evt); err != nil {
 		t.Fatalf("Publish: %v", err)
@@ -795,9 +851,18 @@ func TestEventBusPublish_SemanticScopeFlowInstanceResolvesConcreteRoute(t *testi
 		t.Fatalf("AddFlowInstanceRoute: %v", err)
 	}
 	ch := eb.SubscribeInternal("workflow-runtime", events.EventType("operating/opco.product_initialization_requested"))
-	evt := eventtest.WithFlowInstance(eventtest.WithEntityID((eventtest.Projection(uuid.NewString(),
-		events.EventType("operating/opco.product_initialization_requested"), "", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())), "ent-operating"),
-		"operating/inst-1")
+	evt := eventtest.RootIngress(
+		uuid.NewString(),
+		events.EventType("operating/opco.product_initialization_requested"),
+		"",
+		"",
+		[]byte(`{}`),
+		0,
+		"",
+		"",
+		events.EnvelopeForFlowInstance(events.EnvelopeForEntityID(events.EventEnvelope{}, "ent-operating"), "operating/inst-1"),
+		time.Now().UTC(),
+	)
 
 	plan, err := eb.CheckPublishRecipientPlan(context.Background(), evt)
 	if err != nil {
@@ -861,10 +926,18 @@ func TestEventBusPublish_RuntimeCallbackLocalEventPersistsSameFlowNodeRouteBefor
 			concreteEventType := "repo-scaffold/inst-1/" + tc.eventType
 			ch := eb.SubscribeInternal("workflow-runtime", events.EventType(concreteEventType))
 			defer eb.Unsubscribe("workflow-runtime")
-			evt := eventtest.WithFlowInstance(eventtest.WithEntityID((eventtest.Projection(eventID,
+			evt := eventtest.RootIngress(
+				eventID,
 				events.EventType(tc.eventType),
-				"workflow-runtime", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())), "ent-repo"),
-				"repo-scaffold/inst-1")
+				"workflow-runtime",
+				"",
+				[]byte(`{}`),
+				0,
+				"",
+				"",
+				events.EnvelopeForFlowInstance(events.EnvelopeForEntityID(events.EventEnvelope{}, "ent-repo"), "repo-scaffold/inst-1"),
+				time.Now().UTC(),
+			)
 
 			plan, err := eb.CheckPublishRecipientPlan(context.Background(), evt)
 			if err != nil {
@@ -907,9 +980,18 @@ func TestEventBusCheckPublishRecipientPlan_SemanticScopeFlowInstanceMaterializes
 		t.Fatalf("NewEventBusWithOptions: %v", err)
 	}
 	ch := eb.SubscribeInternal("workflow-runtime", events.EventType("validation/thing.reviewed"))
-	evt := eventtest.WithFlowInstance(eventtest.WithEntityID((eventtest.Projection(uuid.NewString(),
-		events.EventType("validation/thing.reviewed"), "", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())), "ent-validation"),
-		"validation/inst-1")
+	evt := eventtest.RootIngress(
+		uuid.NewString(),
+		events.EventType("validation/thing.reviewed"),
+		"",
+		"",
+		[]byte(`{}`),
+		0,
+		"",
+		"",
+		events.EnvelopeForFlowInstance(events.EnvelopeForEntityID(events.EventEnvelope{}, "ent-validation"), "validation/inst-1"),
+		time.Now().UTC(),
+	)
 
 	plan, err := eb.CheckPublishRecipientPlan(context.Background(), evt)
 	if err != nil {
@@ -953,9 +1035,18 @@ func TestEventBusCheckPublishRecipientPlan_SemanticScopeFlowInstanceMaterializes
 	if err != nil {
 		t.Fatalf("NewEventBusWithOptions: %v", err)
 	}
-	evt := eventtest.WithFlowInstance(eventtest.WithEntityID((eventtest.Projection(uuid.NewString(),
-		events.EventType("validation/thing.reviewed"), "", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())), "ent-validation"),
-		"validation/inst-1")
+	evt := eventtest.RootIngress(
+		uuid.NewString(),
+		events.EventType("validation/thing.reviewed"),
+		"",
+		"",
+		[]byte(`{}`),
+		0,
+		"",
+		"",
+		events.EnvelopeForFlowInstance(events.EnvelopeForEntityID(events.EventEnvelope{}, "ent-validation"), "validation/inst-1"),
+		time.Now().UTC(),
+	)
 
 	plan, err := eb.CheckPublishRecipientPlan(context.Background(), evt)
 	if err != nil {
@@ -996,8 +1087,18 @@ func TestEventBusPublish_NoTargetScopedRoutedNodePersistsSemanticRouteBeforeInte
 		t.Fatalf("NewEventBusWithOptions: %v", err)
 	}
 	ch := eb.SubscribeInternal("workflow-runtime", events.EventType("child/child.start"))
-	evt := eventtest.WithEntityID((eventtest.Projection(uuid.NewString(),
-		events.EventType("child/child.start"), "", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())), "ent-child")
+	evt := eventtest.RootIngress(
+		uuid.NewString(),
+		events.EventType("child/child.start"),
+		"",
+		"",
+		[]byte(`{}`),
+		0,
+		"",
+		"",
+		events.EnvelopeForEntityID(events.EventEnvelope{}, "ent-child"),
+		time.Now().UTC(),
+	)
 
 	want := events.DeliveryRoute{
 		SubscriberType: "node",
@@ -1099,9 +1200,18 @@ func TestEventBusPublish_WildcardStaticServiceNodePersistsRouteBeforeInternalCar
 	}
 	ch := eb.SubscribeInternal("workflow-runtime", events.EventType(eventType))
 	defer eb.Unsubscribe("workflow-runtime")
-	evt := eventtest.WithFlowInstance(eventtest.WithEntityID((eventtest.Projection(eventID,
-		events.EventType(eventType), "", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())), "ent-component"),
-		"component-scaffold/component-a")
+	evt := eventtest.RootIngress(
+		eventID,
+		events.EventType(eventType),
+		"",
+		"",
+		[]byte(`{}`),
+		0,
+		"",
+		"",
+		events.EnvelopeForFlowInstance(events.EnvelopeForEntityID(events.EventEnvelope{}, "ent-component"), "component-scaffold/component-a"),
+		time.Now().UTC(),
+	)
 
 	plan, err := eb.CheckPublishRecipientPlan(context.Background(), evt)
 	if err != nil {
@@ -1179,8 +1289,18 @@ func TestEventBusPublish_RootInputFlowNodePersistsRouteBeforeDispatch(t *testing
 		t.Fatalf("NewEventBusWithOptions: %v", err)
 	}
 	ch := eb.SubscribeInternal("workflow-runtime", events.EventType("thing.created"))
-	evt := eventtest.WithEntityID((eventtest.Projection(eventID,
-		events.EventType("thing.created"), "", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())), "ent-root-input")
+	evt := eventtest.RootIngress(
+		eventID,
+		events.EventType("thing.created"),
+		"",
+		"",
+		[]byte(`{}`),
+		0,
+		"",
+		"",
+		events.EnvelopeForEntityID(events.EventEnvelope{}, "ent-root-input"),
+		time.Now().UTC(),
+	)
 
 	plan, err := eb.CheckPublishRecipientPlan(context.Background(), evt)
 	if err != nil {
@@ -1231,8 +1351,18 @@ func TestEventBusPublish_RootInputFlowNodePersistsRouteBeforeInterceptorWithoutI
 	if err != nil {
 		t.Fatalf("NewEventBusWithOptions: %v", err)
 	}
-	evt := eventtest.WithEntityID((eventtest.Projection(eventID,
-		events.EventType("thing.created"), "", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())), "ent-root-input")
+	evt := eventtest.RootIngress(
+		eventID,
+		events.EventType("thing.created"),
+		"",
+		"",
+		[]byte(`{}`),
+		0,
+		"",
+		"",
+		events.EnvelopeForEntityID(events.EventEnvelope{}, "ent-root-input"),
+		time.Now().UTC(),
+	)
 
 	plan, err := eb.CheckPublishRecipientPlan(context.Background(), evt)
 	if err != nil {
@@ -1289,8 +1419,18 @@ func TestEventBusPublish_LoadedRootInputProjectEventPersistsRouteBeforeDispatch(
 		t.Fatalf("NewEventBusWithOptions: %v", err)
 	}
 	ch := eb.SubscribeInternal("workflow-runtime", events.EventType("thing.created"))
-	evt := eventtest.WithEntityID((eventtest.Projection(eventID,
-		events.EventType("thing.created"), "", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())), "ent-loaded-root-input")
+	evt := eventtest.RootIngress(
+		eventID,
+		events.EventType("thing.created"),
+		"",
+		"",
+		[]byte(`{}`),
+		0,
+		"",
+		"",
+		events.EnvelopeForEntityID(events.EventEnvelope{}, "ent-loaded-root-input"),
+		time.Now().UTC(),
+	)
 
 	plan, err := eb.CheckPublishRecipientPlan(context.Background(), evt)
 	if err != nil {
@@ -1326,8 +1466,18 @@ func TestEventBusPublish_NoTargetRootRoutedNodeUsesSemanticNodeDeliveryRoute(t *
 		t.Fatalf("NewEventBusWithOptions: %v", err)
 	}
 	ch := eb.SubscribeInternal("portfolio-node", events.EventType("opco.spinup_requested"))
-	evt := eventtest.WithEntityID((eventtest.Projection(uuid.NewString(),
-		events.EventType("opco.spinup_requested"), "", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())), "ent-root")
+	evt := eventtest.RootIngress(
+		uuid.NewString(),
+		events.EventType("opco.spinup_requested"),
+		"",
+		"",
+		[]byte(`{}`),
+		0,
+		"",
+		"",
+		events.EnvelopeForEntityID(events.EventEnvelope{}, "ent-root"),
+		time.Now().UTC(),
+	)
 
 	if err := eb.Publish(context.Background(), evt); err != nil {
 		t.Fatalf("Publish: %v", err)
@@ -1379,8 +1529,18 @@ func TestEventBusPublish_NoTargetRootRoutedNodePersistsSemanticRouteWithoutInter
 	if err != nil {
 		t.Fatalf("NewEventBusWithOptions: %v", err)
 	}
-	evt := eventtest.WithEntityID((eventtest.Projection(uuid.NewString(),
-		events.EventType("opco.spinup_requested"), "", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())), "ent-root")
+	evt := eventtest.RootIngress(
+		uuid.NewString(),
+		events.EventType("opco.spinup_requested"),
+		"",
+		"",
+		[]byte(`{}`),
+		0,
+		"",
+		"",
+		events.EnvelopeForEntityID(events.EventEnvelope{}, "ent-root"),
+		time.Now().UTC(),
+	)
 
 	if err := eb.Publish(context.Background(), evt); err != nil {
 		t.Fatalf("Publish: %v", err)
@@ -1456,8 +1616,18 @@ func TestEventBusPublish_TopLevelProjectNodePersistsRouteBeforeInterceptor(t *te
 	}
 	eb.RegisterRuntimeActiveAgentDescriptor(ActiveAgentDescriptor{AgentID: "workflow-runtime"})
 	ch := eb.Subscribe("workflow-runtime", events.EventType("thing.created"))
-	evt := eventtest.WithEntityID((eventtest.Projection(eventID,
-		events.EventType("thing.created"), "", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())), "ent-project")
+	evt := eventtest.RootIngress(
+		eventID,
+		events.EventType("thing.created"),
+		"",
+		"",
+		[]byte(`{}`),
+		0,
+		"",
+		"",
+		events.EnvelopeForEntityID(events.EventEnvelope{}, "ent-project"),
+		time.Now().UTC(),
+	)
 
 	plan, err := eb.CheckPublishRecipientPlan(context.Background(), evt)
 	if err != nil {
@@ -1489,7 +1659,7 @@ func TestEventBusPublish_NodeRouteFailsClosedWithoutRouteSetPersistence(t *testi
 	if err != nil {
 		t.Fatalf("NewEventBusWithOptions: %v", err)
 	}
-	if err := eb.Publish(context.Background(), eventtest.Projection(uuid.NewString(),
+	if err := eb.Publish(context.Background(), eventtest.RootIngress(uuid.NewString(),
 		events.EventType("thing.created"), "", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())); err == nil || !strings.Contains(err.Error(), "typed delivery route persistence") {
 		t.Fatalf("Publish error = %v, want typed delivery route persistence failure", err)
 	}

--- a/internal/runtime/bus/eventbus_test_helpers_test.go
+++ b/internal/runtime/bus/eventbus_test_helpers_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/division-sh/swarm/internal/events"
+	"github.com/division-sh/swarm/internal/events/eventtest"
 )
 
 func requireBusEvent(t testing.TB, ch <-chan events.Event, context string) events.Event {
@@ -14,7 +15,7 @@ func requireBusEvent(t testing.TB, ch <-chan events.Event, context string) event
 		return evt
 	default:
 		t.Fatalf("%s: expected queued bus event", context)
-		return events.NewProjectionEvent("", events.EventType(""), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{})
+		return eventtest.Projection("", events.EventType(""), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{})
 	}
 }
 

--- a/internal/runtime/bus/eventbus_test_helpers_test.go
+++ b/internal/runtime/bus/eventbus_test_helpers_test.go
@@ -15,7 +15,7 @@ func requireBusEvent(t testing.TB, ch <-chan events.Event, context string) event
 		return evt
 	default:
 		t.Fatalf("%s: expected queued bus event", context)
-		return eventtest.Projection("", events.EventType(""), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{})
+		return eventtest.RootIngress("", events.EventType(""), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{})
 	}
 }
 

--- a/internal/runtime/bus/import_boundary_alias_routing_test.go
+++ b/internal/runtime/bus/import_boundary_alias_routing_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/division-sh/swarm/internal/events"
+	"github.com/division-sh/swarm/internal/events/eventtest"
 	runtimebus "github.com/division-sh/swarm/internal/runtime/bus"
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
 	runtimeflowidentity "github.com/division-sh/swarm/internal/runtime/core/flowidentity"
@@ -36,7 +37,7 @@ func TestImportBoundaryInputAliasRoutesParentEventToPackageInputPin(t *testing.T
 	if err != nil {
 		t.Fatalf("NewEventBusWithOptions: %v", err)
 	}
-	evt := events.NewProjectionEvent("evt-input-alias", "parent.lead_captured", "", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())
+	evt := eventtest.Projection("evt-input-alias", "parent.lead_captured", "", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())
 	plan, err := eb.CheckPublishRecipientPlan(context.Background(), evt)
 	if err != nil {
 		t.Fatalf("CheckPublishRecipientPlan: %v", err)
@@ -74,7 +75,7 @@ func TestImportBoundaryOutputAliasRoutesPackageOutputToParentEvent(t *testing.T)
 	if err != nil {
 		t.Fatalf("NewEventBusWithOptions: %v", err)
 	}
-	evt := events.NewProjectionEvent("evt-output-alias", "worker/work.completed", "", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())
+	evt := eventtest.Projection("evt-output-alias", "worker/work.completed", "", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())
 	plan, err := eb.CheckPublishRecipientPlan(context.Background(), evt)
 	if err != nil {
 		t.Fatalf("CheckPublishRecipientPlan: %v", err)
@@ -115,7 +116,7 @@ func TestImportBoundaryOutputAliasRoutesPackageOutputToWildcardParentSubscriber(
 	if err != nil {
 		t.Fatalf("NewEventBusWithOptions: %v", err)
 	}
-	evt := events.NewProjectionEvent("evt-output-alias-wildcard", "worker/work.completed", "", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())
+	evt := eventtest.Projection("evt-output-alias-wildcard", "worker/work.completed", "", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())
 	plan, err := eb.CheckPublishRecipientPlan(context.Background(), evt)
 	if err != nil {
 		t.Fatalf("CheckPublishRecipientPlan: %v", err)

--- a/internal/runtime/bus/import_boundary_alias_routing_test.go
+++ b/internal/runtime/bus/import_boundary_alias_routing_test.go
@@ -37,7 +37,7 @@ func TestImportBoundaryInputAliasRoutesParentEventToPackageInputPin(t *testing.T
 	if err != nil {
 		t.Fatalf("NewEventBusWithOptions: %v", err)
 	}
-	evt := eventtest.Projection("evt-input-alias", "parent.lead_captured", "", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())
+	evt := eventtest.RootIngress("evt-input-alias", "parent.lead_captured", "", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())
 	plan, err := eb.CheckPublishRecipientPlan(context.Background(), evt)
 	if err != nil {
 		t.Fatalf("CheckPublishRecipientPlan: %v", err)
@@ -75,7 +75,7 @@ func TestImportBoundaryOutputAliasRoutesPackageOutputToParentEvent(t *testing.T)
 	if err != nil {
 		t.Fatalf("NewEventBusWithOptions: %v", err)
 	}
-	evt := eventtest.Projection("evt-output-alias", "worker/work.completed", "", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())
+	evt := eventtest.RootIngress("evt-output-alias", "worker/work.completed", "", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())
 	plan, err := eb.CheckPublishRecipientPlan(context.Background(), evt)
 	if err != nil {
 		t.Fatalf("CheckPublishRecipientPlan: %v", err)
@@ -116,7 +116,7 @@ func TestImportBoundaryOutputAliasRoutesPackageOutputToWildcardParentSubscriber(
 	if err != nil {
 		t.Fatalf("NewEventBusWithOptions: %v", err)
 	}
-	evt := eventtest.Projection("evt-output-alias-wildcard", "worker/work.completed", "", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())
+	evt := eventtest.RootIngress("evt-output-alias-wildcard", "worker/work.completed", "", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())
 	plan, err := eb.CheckPublishRecipientPlan(context.Background(), evt)
 	if err != nil {
 		t.Fatalf("CheckPublishRecipientPlan: %v", err)

--- a/internal/runtime/bus/import_boundary_wildcard_routing_test.go
+++ b/internal/runtime/bus/import_boundary_wildcard_routing_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/division-sh/swarm/internal/events"
+	"github.com/division-sh/swarm/internal/events/eventtest"
 	"github.com/division-sh/swarm/internal/runtime/bootverify"
 	runtimebus "github.com/division-sh/swarm/internal/runtime/bus"
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
@@ -40,14 +41,14 @@ func TestImportBoundaryWildcardScopesImportedPackageToOwnSubtreeByDefault(t *tes
 	if err != nil {
 		t.Fatalf("NewEventBusWithOptions: %v", err)
 	}
-	local := events.NewProjectionEvent("evt-worker-local", "worker/task.done", "", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())
+	local := eventtest.RootIngress("evt-worker-local", "worker/task.done", "", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())
 	if err := eb.Publish(context.Background(), local); err != nil {
 		t.Fatalf("Publish local: %v", err)
 	}
 	if got := store.deliveries["evt-worker-local"]; len(got) != 1 || got[0] != "worker-listener" {
 		t.Fatalf("local persisted deliveries = %#v, want worker-listener", got)
 	}
-	sibling := events.NewProjectionEvent("evt-producer-sibling", "producer/task.done", "", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())
+	sibling := eventtest.RootIngress("evt-producer-sibling", "producer/task.done", "", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())
 	if err := eb.Publish(context.Background(), sibling); err != nil {
 		t.Fatalf("Publish sibling: %v", err)
 	}
@@ -79,7 +80,7 @@ func TestImportBoundaryWildcardObserveGrantAddsNarrowSiblingCandidate(t *testing
 	if err != nil {
 		t.Fatalf("NewEventBusWithOptions: %v", err)
 	}
-	evt := events.NewProjectionEvent("evt-granted-sibling", "producer/task.done", "", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())
+	evt := eventtest.RootIngress("evt-granted-sibling", "producer/task.done", "", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())
 	plan, err := eb.CheckPublishRecipientPlan(context.Background(), evt)
 	if err != nil {
 		t.Fatalf("CheckPublishRecipientPlan: %v", err)

--- a/internal/runtime/bus/outbox_test.go
+++ b/internal/runtime/bus/outbox_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/division-sh/swarm/internal/events"
+	"github.com/division-sh/swarm/internal/events/eventtest"
 	runtimebus "github.com/division-sh/swarm/internal/runtime/bus"
 	runtimedeadletters "github.com/division-sh/swarm/internal/runtime/deadletters"
 	runtimeengine "github.com/division-sh/swarm/internal/runtime/engine"
@@ -195,8 +196,8 @@ func (interceptingTestHandler) Intercept(_ context.Context, evt events.Event) (b
 	if evt.Type() != events.EventType("custom.emitted") {
 		return true, nil, nil
 	}
-	return false, []events.Event{(events.NewProjectionEvent("", events.EventType("custom.followup"),
-		"runtime", "", nil, 0, "", "", events.EventEnvelope{}, time.Now().UTC())).WithEntityID(evt.EntityID())}, nil
+	return false, []events.Event{eventtest.WithEntityID((eventtest.Projection("", events.EventType("custom.followup"),
+		"runtime", "", nil, 0, "", "", events.EventEnvelope{}, time.Now().UTC())), evt.EntityID())}, nil
 }
 
 func TestEngineDispatcherCollectsEmitIntentsWithChainDepth(t *testing.T) {
@@ -209,7 +210,7 @@ func TestEngineDispatcherCollectsEmitIntentsWithChainDepth(t *testing.T) {
 	ctx := runtimepipeline.WithPipelineEmitCollectors(context.Background(), &eventCollector, &intentCollector)
 
 	intent := runtimeengine.EmitIntent{
-		Event:      (events.NewProjectionEvent("", events.EventType("custom.emitted"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{})).WithEntityID("ent-1"),
+		Event:      eventtest.WithEntityID((eventtest.Projection("", events.EventType("custom.emitted"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{})), "ent-1"),
 		ChainDepth: 3,
 	}
 	if err := eb.EngineDispatcher().DispatchPostCommit(ctx, []runtimeengine.EmitIntent{intent}); err != nil {
@@ -253,9 +254,9 @@ func TestEngineDispatcherQueuesWhenPipelineSQLTxActive(t *testing.T) {
 	defer eb.Unsubscribe("agent-a")
 
 	intent := runtimeengine.EmitIntent{
-		Event: events.NewProjectionEvent("evt-post-commit-dispatch",
-			events.EventType("custom.emitted"), "", "", []byte(`{"entity_id":"ent-1"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC()).
-			WithEntityID("ent-1"),
+		Event: eventtest.WithEntityID(eventtest.Projection("evt-post-commit-dispatch",
+			events.EventType("custom.emitted"), "", "", []byte(`{"entity_id":"ent-1"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC()),
+			"ent-1"),
 	}
 	postCommitActions := make([]func(), 0, 1)
 	txctx := runtimepipeline.WithPipelineSQLTxContext(context.Background(), tx)
@@ -315,7 +316,7 @@ func TestEngineDispatcherQueuesImmutableIntentSnapshotWhenPipelineSQLTxActive(t 
 	targetSet := []events.RouteIdentity{{FlowInstance: "flow-original", EntityID: "entity-original"}}
 	recipients := []string{"agent-original"}
 	intents := []runtimeengine.EmitIntent{{
-		Event: events.NewProjectionEvent("evt-queued-snapshot",
+		Event: eventtest.Projection("evt-queued-snapshot",
 			events.EventType("custom.snapshot"), "", "", payload, 0, "", "", events.EventEnvelope{TargetSet: targetSet},
 			time.Now().UTC()),
 
@@ -336,7 +337,7 @@ func TestEngineDispatcherQueuesImmutableIntentSnapshotWhenPipelineSQLTxActive(t 
 	copy(payload, []byte(`{"value":"mutated!"}`))
 	targetSet[0] = events.RouteIdentity{FlowInstance: "flow-mutated", EntityID: "entity-mutated"}
 	recipients[0] = "agent-mutated"
-	intents[0].Event = events.NewProjectionEvent(
+	intents[0].Event = eventtest.Projection(
 		intents[0].Event.ID(),
 		intents[0].Event.Type(),
 		intents[0].Event.SourceAgent(),
@@ -346,8 +347,8 @@ func TestEngineDispatcherQueuesImmutableIntentSnapshotWhenPipelineSQLTxActive(t 
 		intents[0].Event.RunID(),
 		intents[0].Event.ParentEventID(),
 		events.EventEnvelope{TargetSet: []events.RouteIdentity{{FlowInstance: "flow-reassigned", EntityID: "entity-reassigned"}}},
-		intents[0].Event.CreatedAt(),
-	)
+		intents[0].Event.CreatedAt())
+
 	intents[0].Recipients = []string{"agent-reassigned"}
 
 	if err := tx.Commit(); err != nil {
@@ -388,9 +389,9 @@ func TestEngineDispatcherFailsClosedWithSQLTxAndNoPostCommitQueue(t *testing.T) 
 	}
 	ctx := runtimepipeline.WithPipelineSQLTxContext(context.Background(), tx)
 	err = eb.EngineDispatcher().DispatchPostCommit(ctx, []runtimeengine.EmitIntent{{
-		Event: events.NewProjectionEvent("evt-no-post-commit-queue",
-			events.EventType("custom.emitted"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Now().UTC()).
-			WithEntityID("ent-1"),
+		Event: eventtest.WithEntityID(eventtest.Projection("evt-no-post-commit-queue",
+			events.EventType("custom.emitted"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Now().UTC()),
+			"ent-1"),
 	}})
 	if err == nil {
 		_ = tx.Rollback()
@@ -434,9 +435,10 @@ func TestEngineOutboxPersistsEventsAndDeliveriesInTransaction(t *testing.T) {
 	}
 	ctx := runtimepipeline.WithPipelineSQLTxContext(context.Background(), tx)
 	intent := runtimeengine.EmitIntent{
-		Event: events.NewProjectionEvent("evt-1",
-			events.EventType("custom.emitted"), "", "", []byte(`{"entity_id":"`+entityID+`"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC()).
-			WithEntityID(entityID),
+		Event: eventtest.WithEntityID(eventtest.Projection("evt-1",
+			events.EventType("custom.emitted"), "", "", []byte(`{"entity_id":"`+entityID+`"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC()),
+			entityID),
+
 		Recipients: []string{"reviewer"},
 	}
 	if err := eb.EngineOutbox().WriteOutbox(ctx, []runtimeengine.EmitIntent{intent}); err != nil {
@@ -481,7 +483,7 @@ func TestEngineOutboxSkipsEmptyNoopIntentBeforeAdmission(t *testing.T) {
 	}
 	ctx := runtimepipeline.WithPipelineSQLTxContext(context.Background(), tx)
 	intents := []runtimeengine.EmitIntent{{
-		Event: events.NewProjectionEvent("evt-empty-noop", "", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Now().UTC()),
+		Event: eventtest.Projection("evt-empty-noop", "", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Now().UTC()),
 	}}
 	if err := eb.EngineOutbox().WriteOutbox(ctx, intents); err != nil {
 		t.Fatalf("WriteOutbox empty noop: %v", err)
@@ -503,7 +505,7 @@ func TestEngineDispatcherSkipsEmptyNoopIntentBeforeAdmission(t *testing.T) {
 		t.Fatalf("NewEventBus: %v", err)
 	}
 	intents := []runtimeengine.EmitIntent{{
-		Event: events.NewProjectionEvent("evt-empty-noop-dispatch", "", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Now().UTC()),
+		Event: eventtest.Projection("evt-empty-noop-dispatch", "", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Now().UTC()),
 	}}
 	if err := eb.EngineDispatcher().DispatchPostCommit(context.Background(), intents); err != nil {
 		t.Fatalf("DispatchPostCommit empty noop: %v", err)
@@ -558,7 +560,7 @@ func TestEngineOutboxSubscribedIntentConsumesCanonicalMaterializedRoutePlan(t *t
 		t.Fatalf("NewEventBusWithOptions: %v", err)
 	}
 	intent := runtimeengine.EmitIntent{
-		Event: events.NewProjectionEvent("evt-outbox-materialized-route",
+		Event: eventtest.Projection("evt-outbox-materialized-route",
 			events.EventType("review/inst-1/task.started"), "", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC()),
 	}
 	ctx := runtimepipeline.WithPipelineSQLTxContext(context.Background(), tx)
@@ -609,9 +611,10 @@ func TestEngineOutboxAndDispatcher_UseCanonicalDirectRecipientManifest(t *testin
 	otherCh := eb.Subscribe("reviewer-ent-2")
 
 	intent := runtimeengine.EmitIntent{
-		Event: events.NewProjectionEvent("evt-direct-intent",
-			events.EventType("custom.direct"), "", "", []byte(`{"entity_id":"ent-1"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC()).
-			WithEntityID("ent-1"),
+		Event: eventtest.WithEntityID(eventtest.Projection("evt-direct-intent",
+			events.EventType("custom.direct"), "", "", []byte(`{"entity_id":"ent-1"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC()),
+			"ent-1"),
+
 		Recipients: []string{"control-plane", "reviewer-ent-1", "reviewer-ent-2", "missing-agent"},
 	}
 	ctx := runtimepipeline.WithPipelineSQLTxContext(context.Background(), tx)
@@ -668,9 +671,9 @@ func TestEngineOutbox_TargetFailureDeadLetterErrorFailsClosed(t *testing.T) {
 	}
 
 	intent := runtimeengine.EmitIntent{
-		Event: events.NewProjectionEvent("evt-outbox-target-failure",
-			events.EventType("child/output.done"), "", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC()).
-			WithTargetRoute(events.RouteIdentity{EntityID: "missing-entity", FlowInstance: "missing-flow"}),
+		Event: eventtest.WithTargetRoute(eventtest.Projection("evt-outbox-target-failure",
+			events.EventType("child/output.done"), "", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC()),
+			events.RouteIdentity{EntityID: "missing-entity", FlowInstance: "missing-flow"}),
 	}
 	ctx := runtimepipeline.WithPipelineSQLTxContext(context.Background(), tx)
 	err = eb.EngineOutbox().WriteOutbox(ctx, []runtimeengine.EmitIntent{intent})
@@ -712,9 +715,9 @@ func TestEngineOutboxAndDispatcher_DeliverInternalSubscribersOutsidePersistedMan
 	agentCh := eb.Subscribe("agent-a", events.EventType("custom.emitted"))
 
 	intent := runtimeengine.EmitIntent{
-		Event: events.NewProjectionEvent("evt-internal-live",
-			events.EventType("custom.emitted"), "", "", []byte(`{"entity_id":"ent-1"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC()).
-			WithEntityID("ent-1"),
+		Event: eventtest.WithEntityID(eventtest.Projection("evt-internal-live",
+			events.EventType("custom.emitted"), "", "", []byte(`{"entity_id":"ent-1"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC()),
+			"ent-1"),
 	}
 	ctx := runtimepipeline.WithPipelineSQLTxContext(context.Background(), tx)
 	if err := eb.EngineOutbox().WriteOutbox(ctx, []runtimeengine.EmitIntent{intent}); err != nil {
@@ -758,9 +761,9 @@ func TestEngineDispatcherRunsInterceptorsForPersistedEmitIntents(t *testing.T) {
 	eb.SetInterceptors(interceptingTestHandler{})
 
 	intent := runtimeengine.EmitIntent{
-		Event: events.NewProjectionEvent("evt-1",
-			events.EventType("custom.emitted"), "", "", []byte(`{"entity_id":"ent-1"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC()).
-			WithEntityID("ent-1"),
+		Event: eventtest.WithEntityID(eventtest.Projection("evt-1",
+			events.EventType("custom.emitted"), "", "", []byte(`{"entity_id":"ent-1"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC()),
+			"ent-1"),
 	}
 	if err := eb.EngineDispatcher().DispatchPostCommit(context.Background(), []runtimeengine.EmitIntent{intent}); err != nil {
 		t.Fatalf("DispatchPostCommit: %v", err)
@@ -778,9 +781,9 @@ func TestEngineDispatcher_FailsClosedWithoutAuthoritativeRecipientManifestOnInMe
 	}
 
 	intent := runtimeengine.EmitIntent{
-		Event: events.NewProjectionEvent("evt-missing-manifest",
-			events.EventType("custom.emitted"), "", "", []byte(`{"entity_id":"ent-1"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC()).
-			WithEntityID("ent-1"),
+		Event: eventtest.WithEntityID(eventtest.Projection("evt-missing-manifest",
+			events.EventType("custom.emitted"), "", "", []byte(`{"entity_id":"ent-1"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC()),
+			"ent-1"),
 	}
 
 	err = eb.EngineDispatcher().DispatchPostCommit(context.Background(), []runtimeengine.EmitIntent{intent})
@@ -800,9 +803,10 @@ func TestEngineDispatcher_DirectIntentUsesExplicitRecipientsWhenManifestWasNotPe
 	recipientCh := eb.Subscribe("agent-a")
 
 	intent := runtimeengine.EmitIntent{
-		Event: events.NewProjectionEvent("evt-direct-no-tx",
-			events.EventType("custom.emitted"), "", "", []byte(`{"entity_id":"ent-1"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC()).
-			WithEntityID("ent-1"),
+		Event: eventtest.WithEntityID(eventtest.Projection("evt-direct-no-tx",
+			events.EventType("custom.emitted"), "", "", []byte(`{"entity_id":"ent-1"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC()),
+			"ent-1"),
+
 		Recipients: []string{"agent-a"},
 	}
 
@@ -842,9 +846,10 @@ func TestEngineDispatcher_TransactionalDirectIntentHonorsEmptyPersistedManifest(
 	filteredCh := eb.Subscribe("reviewer-ent-2")
 
 	intent := runtimeengine.EmitIntent{
-		Event: events.NewProjectionEvent("evt-empty-direct-manifest",
-			events.EventType("custom.direct"), "", "", []byte(`{"entity_id":"ent-1"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC()).
-			WithEntityID("ent-1"),
+		Event: eventtest.WithEntityID(eventtest.Projection("evt-empty-direct-manifest",
+			events.EventType("custom.direct"), "", "", []byte(`{"entity_id":"ent-1"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC()),
+			"ent-1"),
+
 		Recipients: []string{"reviewer-ent-2"},
 	}
 	ctx := runtimepipeline.WithPipelineSQLTxContext(context.Background(), tx)

--- a/internal/runtime/bus/outbox_test.go
+++ b/internal/runtime/bus/outbox_test.go
@@ -196,8 +196,18 @@ func (interceptingTestHandler) Intercept(_ context.Context, evt events.Event) (b
 	if evt.Type() != events.EventType("custom.emitted") {
 		return true, nil, nil
 	}
-	return false, []events.Event{eventtest.WithEntityID((eventtest.Projection("", events.EventType("custom.followup"),
-		"runtime", "", nil, 0, "", "", events.EventEnvelope{}, time.Now().UTC())), evt.EntityID())}, nil
+	return false, []events.Event{eventtest.RootIngress(
+		"",
+		events.EventType("custom.followup"),
+		"runtime",
+		"",
+		nil,
+		0,
+		"",
+		"",
+		events.EnvelopeForEntityID(events.EventEnvelope{}, evt.EntityID()),
+		time.Now().UTC(),
+	)}, nil
 }
 
 func TestEngineDispatcherCollectsEmitIntentsWithChainDepth(t *testing.T) {
@@ -210,7 +220,7 @@ func TestEngineDispatcherCollectsEmitIntentsWithChainDepth(t *testing.T) {
 	ctx := runtimepipeline.WithPipelineEmitCollectors(context.Background(), &eventCollector, &intentCollector)
 
 	intent := runtimeengine.EmitIntent{
-		Event:      eventtest.WithEntityID((eventtest.Projection("", events.EventType("custom.emitted"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{})), "ent-1"),
+		Event:      eventtest.RootIngress("", events.EventType("custom.emitted"), "", "", nil, 0, "", "", events.EnvelopeForEntityID(events.EventEnvelope{}, "ent-1"), time.Time{}),
 		ChainDepth: 3,
 	}
 	if err := eb.EngineDispatcher().DispatchPostCommit(ctx, []runtimeengine.EmitIntent{intent}); err != nil {
@@ -254,9 +264,18 @@ func TestEngineDispatcherQueuesWhenPipelineSQLTxActive(t *testing.T) {
 	defer eb.Unsubscribe("agent-a")
 
 	intent := runtimeengine.EmitIntent{
-		Event: eventtest.WithEntityID(eventtest.Projection("evt-post-commit-dispatch",
-			events.EventType("custom.emitted"), "", "", []byte(`{"entity_id":"ent-1"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC()),
-			"ent-1"),
+		Event: eventtest.RootIngress(
+			"evt-post-commit-dispatch",
+			events.EventType("custom.emitted"),
+			"",
+			"",
+			[]byte(`{"entity_id":"ent-1"}`),
+			0,
+			"",
+			"",
+			events.EnvelopeForEntityID(events.EventEnvelope{}, "ent-1"),
+			time.Now().UTC(),
+		),
 	}
 	postCommitActions := make([]func(), 0, 1)
 	txctx := runtimepipeline.WithPipelineSQLTxContext(context.Background(), tx)
@@ -316,7 +335,7 @@ func TestEngineDispatcherQueuesImmutableIntentSnapshotWhenPipelineSQLTxActive(t 
 	targetSet := []events.RouteIdentity{{FlowInstance: "flow-original", EntityID: "entity-original"}}
 	recipients := []string{"agent-original"}
 	intents := []runtimeengine.EmitIntent{{
-		Event: eventtest.Projection("evt-queued-snapshot",
+		Event: eventtest.RootIngress("evt-queued-snapshot",
 			events.EventType("custom.snapshot"), "", "", payload, 0, "", "", events.EventEnvelope{TargetSet: targetSet},
 			time.Now().UTC()),
 
@@ -337,7 +356,7 @@ func TestEngineDispatcherQueuesImmutableIntentSnapshotWhenPipelineSQLTxActive(t 
 	copy(payload, []byte(`{"value":"mutated!"}`))
 	targetSet[0] = events.RouteIdentity{FlowInstance: "flow-mutated", EntityID: "entity-mutated"}
 	recipients[0] = "agent-mutated"
-	intents[0].Event = eventtest.Projection(
+	intents[0].Event = eventtest.RootIngress(
 		intents[0].Event.ID(),
 		intents[0].Event.Type(),
 		intents[0].Event.SourceAgent(),
@@ -389,9 +408,18 @@ func TestEngineDispatcherFailsClosedWithSQLTxAndNoPostCommitQueue(t *testing.T) 
 	}
 	ctx := runtimepipeline.WithPipelineSQLTxContext(context.Background(), tx)
 	err = eb.EngineDispatcher().DispatchPostCommit(ctx, []runtimeengine.EmitIntent{{
-		Event: eventtest.WithEntityID(eventtest.Projection("evt-no-post-commit-queue",
-			events.EventType("custom.emitted"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Now().UTC()),
-			"ent-1"),
+		Event: eventtest.RootIngress(
+			"evt-no-post-commit-queue",
+			events.EventType("custom.emitted"),
+			"",
+			"",
+			nil,
+			0,
+			"",
+			"",
+			events.EnvelopeForEntityID(events.EventEnvelope{}, "ent-1"),
+			time.Now().UTC(),
+		),
 	}})
 	if err == nil {
 		_ = tx.Rollback()
@@ -435,9 +463,18 @@ func TestEngineOutboxPersistsEventsAndDeliveriesInTransaction(t *testing.T) {
 	}
 	ctx := runtimepipeline.WithPipelineSQLTxContext(context.Background(), tx)
 	intent := runtimeengine.EmitIntent{
-		Event: eventtest.WithEntityID(eventtest.Projection("evt-1",
-			events.EventType("custom.emitted"), "", "", []byte(`{"entity_id":"`+entityID+`"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC()),
-			entityID),
+		Event: eventtest.RootIngress(
+			"evt-1",
+			events.EventType("custom.emitted"),
+			"",
+			"",
+			[]byte(`{"entity_id":"`+entityID+`"}`),
+			0,
+			"",
+			"",
+			events.EnvelopeForEntityID(events.EventEnvelope{}, entityID),
+			time.Now().UTC(),
+		),
 
 		Recipients: []string{"reviewer"},
 	}
@@ -483,7 +520,7 @@ func TestEngineOutboxSkipsEmptyNoopIntentBeforeAdmission(t *testing.T) {
 	}
 	ctx := runtimepipeline.WithPipelineSQLTxContext(context.Background(), tx)
 	intents := []runtimeengine.EmitIntent{{
-		Event: eventtest.Projection("evt-empty-noop", "", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Now().UTC()),
+		Event: eventtest.RootIngress("evt-empty-noop", "", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Now().UTC()),
 	}}
 	if err := eb.EngineOutbox().WriteOutbox(ctx, intents); err != nil {
 		t.Fatalf("WriteOutbox empty noop: %v", err)
@@ -505,7 +542,7 @@ func TestEngineDispatcherSkipsEmptyNoopIntentBeforeAdmission(t *testing.T) {
 		t.Fatalf("NewEventBus: %v", err)
 	}
 	intents := []runtimeengine.EmitIntent{{
-		Event: eventtest.Projection("evt-empty-noop-dispatch", "", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Now().UTC()),
+		Event: eventtest.RootIngress("evt-empty-noop-dispatch", "", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Now().UTC()),
 	}}
 	if err := eb.EngineDispatcher().DispatchPostCommit(context.Background(), intents); err != nil {
 		t.Fatalf("DispatchPostCommit empty noop: %v", err)
@@ -560,7 +597,7 @@ func TestEngineOutboxSubscribedIntentConsumesCanonicalMaterializedRoutePlan(t *t
 		t.Fatalf("NewEventBusWithOptions: %v", err)
 	}
 	intent := runtimeengine.EmitIntent{
-		Event: eventtest.Projection("evt-outbox-materialized-route",
+		Event: eventtest.RootIngress("evt-outbox-materialized-route",
 			events.EventType("review/inst-1/task.started"), "", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC()),
 	}
 	ctx := runtimepipeline.WithPipelineSQLTxContext(context.Background(), tx)
@@ -611,9 +648,18 @@ func TestEngineOutboxAndDispatcher_UseCanonicalDirectRecipientManifest(t *testin
 	otherCh := eb.Subscribe("reviewer-ent-2")
 
 	intent := runtimeengine.EmitIntent{
-		Event: eventtest.WithEntityID(eventtest.Projection("evt-direct-intent",
-			events.EventType("custom.direct"), "", "", []byte(`{"entity_id":"ent-1"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC()),
-			"ent-1"),
+		Event: eventtest.RootIngress(
+			"evt-direct-intent",
+			events.EventType("custom.direct"),
+			"",
+			"",
+			[]byte(`{"entity_id":"ent-1"}`),
+			0,
+			"",
+			"",
+			events.EnvelopeForEntityID(events.EventEnvelope{}, "ent-1"),
+			time.Now().UTC(),
+		),
 
 		Recipients: []string{"control-plane", "reviewer-ent-1", "reviewer-ent-2", "missing-agent"},
 	}
@@ -671,9 +717,18 @@ func TestEngineOutbox_TargetFailureDeadLetterErrorFailsClosed(t *testing.T) {
 	}
 
 	intent := runtimeengine.EmitIntent{
-		Event: eventtest.WithTargetRoute(eventtest.Projection("evt-outbox-target-failure",
-			events.EventType("child/output.done"), "", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC()),
-			events.RouteIdentity{EntityID: "missing-entity", FlowInstance: "missing-flow"}),
+		Event: eventtest.RootIngress(
+			"evt-outbox-target-failure",
+			events.EventType("child/output.done"),
+			"",
+			"",
+			[]byte(`{}`),
+			0,
+			"",
+			"",
+			events.EnvelopeForTargetRoute(events.EventEnvelope{}, events.RouteIdentity{EntityID: "missing-entity", FlowInstance: "missing-flow"}),
+			time.Now().UTC(),
+		),
 	}
 	ctx := runtimepipeline.WithPipelineSQLTxContext(context.Background(), tx)
 	err = eb.EngineOutbox().WriteOutbox(ctx, []runtimeengine.EmitIntent{intent})
@@ -715,9 +770,18 @@ func TestEngineOutboxAndDispatcher_DeliverInternalSubscribersOutsidePersistedMan
 	agentCh := eb.Subscribe("agent-a", events.EventType("custom.emitted"))
 
 	intent := runtimeengine.EmitIntent{
-		Event: eventtest.WithEntityID(eventtest.Projection("evt-internal-live",
-			events.EventType("custom.emitted"), "", "", []byte(`{"entity_id":"ent-1"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC()),
-			"ent-1"),
+		Event: eventtest.RootIngress(
+			"evt-internal-live",
+			events.EventType("custom.emitted"),
+			"",
+			"",
+			[]byte(`{"entity_id":"ent-1"}`),
+			0,
+			"",
+			"",
+			events.EnvelopeForEntityID(events.EventEnvelope{}, "ent-1"),
+			time.Now().UTC(),
+		),
 	}
 	ctx := runtimepipeline.WithPipelineSQLTxContext(context.Background(), tx)
 	if err := eb.EngineOutbox().WriteOutbox(ctx, []runtimeengine.EmitIntent{intent}); err != nil {
@@ -761,9 +825,18 @@ func TestEngineDispatcherRunsInterceptorsForPersistedEmitIntents(t *testing.T) {
 	eb.SetInterceptors(interceptingTestHandler{})
 
 	intent := runtimeengine.EmitIntent{
-		Event: eventtest.WithEntityID(eventtest.Projection("evt-1",
-			events.EventType("custom.emitted"), "", "", []byte(`{"entity_id":"ent-1"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC()),
-			"ent-1"),
+		Event: eventtest.RootIngress(
+			"evt-1",
+			events.EventType("custom.emitted"),
+			"",
+			"",
+			[]byte(`{"entity_id":"ent-1"}`),
+			0,
+			"",
+			"",
+			events.EnvelopeForEntityID(events.EventEnvelope{}, "ent-1"),
+			time.Now().UTC(),
+		),
 	}
 	if err := eb.EngineDispatcher().DispatchPostCommit(context.Background(), []runtimeengine.EmitIntent{intent}); err != nil {
 		t.Fatalf("DispatchPostCommit: %v", err)
@@ -781,9 +854,18 @@ func TestEngineDispatcher_FailsClosedWithoutAuthoritativeRecipientManifestOnInMe
 	}
 
 	intent := runtimeengine.EmitIntent{
-		Event: eventtest.WithEntityID(eventtest.Projection("evt-missing-manifest",
-			events.EventType("custom.emitted"), "", "", []byte(`{"entity_id":"ent-1"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC()),
-			"ent-1"),
+		Event: eventtest.RootIngress(
+			"evt-missing-manifest",
+			events.EventType("custom.emitted"),
+			"",
+			"",
+			[]byte(`{"entity_id":"ent-1"}`),
+			0,
+			"",
+			"",
+			events.EnvelopeForEntityID(events.EventEnvelope{}, "ent-1"),
+			time.Now().UTC(),
+		),
 	}
 
 	err = eb.EngineDispatcher().DispatchPostCommit(context.Background(), []runtimeengine.EmitIntent{intent})
@@ -803,9 +885,18 @@ func TestEngineDispatcher_DirectIntentUsesExplicitRecipientsWhenManifestWasNotPe
 	recipientCh := eb.Subscribe("agent-a")
 
 	intent := runtimeengine.EmitIntent{
-		Event: eventtest.WithEntityID(eventtest.Projection("evt-direct-no-tx",
-			events.EventType("custom.emitted"), "", "", []byte(`{"entity_id":"ent-1"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC()),
-			"ent-1"),
+		Event: eventtest.RootIngress(
+			"evt-direct-no-tx",
+			events.EventType("custom.emitted"),
+			"",
+			"",
+			[]byte(`{"entity_id":"ent-1"}`),
+			0,
+			"",
+			"",
+			events.EnvelopeForEntityID(events.EventEnvelope{}, "ent-1"),
+			time.Now().UTC(),
+		),
 
 		Recipients: []string{"agent-a"},
 	}
@@ -846,9 +937,18 @@ func TestEngineDispatcher_TransactionalDirectIntentHonorsEmptyPersistedManifest(
 	filteredCh := eb.Subscribe("reviewer-ent-2")
 
 	intent := runtimeengine.EmitIntent{
-		Event: eventtest.WithEntityID(eventtest.Projection("evt-empty-direct-manifest",
-			events.EventType("custom.direct"), "", "", []byte(`{"entity_id":"ent-1"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC()),
-			"ent-1"),
+		Event: eventtest.RootIngress(
+			"evt-empty-direct-manifest",
+			events.EventType("custom.direct"),
+			"",
+			"",
+			[]byte(`{"entity_id":"ent-1"}`),
+			0,
+			"",
+			"",
+			events.EnvelopeForEntityID(events.EventEnvelope{}, "ent-1"),
+			time.Now().UTC(),
+		),
 
 		Recipients: []string{"reviewer-ent-2"},
 	}

--- a/internal/runtime/bus/routing_derivation_internal_test.go
+++ b/internal/runtime/bus/routing_derivation_internal_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/division-sh/swarm/internal/events"
+	"github.com/division-sh/swarm/internal/events/eventtest"
 	"time"
 )
 
@@ -144,7 +145,7 @@ func TestEventBusPublish_UsesRouteTableWildcardSubscriberResolution(t *testing.T
 	recorder := NewEmittedEventsRecorder()
 	ctx := WithEmittedEventsRecorder(context.Background(), recorder)
 
-	if err := eb.Publish(ctx, events.NewProjectionEvent("", eventType, "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{})); err != nil {
+	if err := eb.Publish(ctx, eventtest.Projection("", eventType, "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{})); err != nil {
 		t.Fatalf("Publish: %v", err)
 	}
 	evt := requireBusEvent(t, ch, "routed wildcard delivery")

--- a/internal/runtime/bus/routing_derivation_internal_test.go
+++ b/internal/runtime/bus/routing_derivation_internal_test.go
@@ -145,7 +145,7 @@ func TestEventBusPublish_UsesRouteTableWildcardSubscriberResolution(t *testing.T
 	recorder := NewEmittedEventsRecorder()
 	ctx := WithEmittedEventsRecorder(context.Background(), recorder)
 
-	if err := eb.Publish(ctx, eventtest.Projection("", eventType, "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{})); err != nil {
+	if err := eb.Publish(ctx, eventtest.RootIngress("", eventType, "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{})); err != nil {
 		t.Fatalf("Publish: %v", err)
 	}
 	evt := requireBusEvent(t, ch, "routed wildcard delivery")

--- a/internal/runtime/bus/routing_derivation_test.go
+++ b/internal/runtime/bus/routing_derivation_test.go
@@ -186,7 +186,7 @@ func TestEventBusFlowInstanceRoutePersistsAndDeliversRenderedActivationConfigSub
 
 	eb.Subscribe("ceo-11111111-1111-4111-8111-111111111111")
 	defer eb.Unsubscribe("ceo-11111111-1111-4111-8111-111111111111")
-	evt := eventtest.Projection("event-rendered-route-delivery",
+	evt := eventtest.RootIngress("event-rendered-route-delivery",
 		events.EventType("operating/11111111-1111-4111-8111-111111111111/opco.product_initialization_requested"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{})
 
 	if err := eb.Publish(context.Background(), evt); err != nil {

--- a/internal/runtime/bus/routing_derivation_test.go
+++ b/internal/runtime/bus/routing_derivation_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/division-sh/swarm/internal/events"
+	"github.com/division-sh/swarm/internal/events/eventtest"
 	runtimebus "github.com/division-sh/swarm/internal/runtime/bus"
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
 	runtimeflowidentity "github.com/division-sh/swarm/internal/runtime/core/flowidentity"
@@ -185,7 +186,7 @@ func TestEventBusFlowInstanceRoutePersistsAndDeliversRenderedActivationConfigSub
 
 	eb.Subscribe("ceo-11111111-1111-4111-8111-111111111111")
 	defer eb.Unsubscribe("ceo-11111111-1111-4111-8111-111111111111")
-	evt := events.NewProjectionEvent("event-rendered-route-delivery",
+	evt := eventtest.Projection("event-rendered-route-delivery",
 		events.EventType("operating/11111111-1111-4111-8111-111111111111/opco.product_initialization_requested"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{})
 
 	if err := eb.Publish(context.Background(), evt); err != nil {

--- a/internal/runtime/bus/run_completion_test.go
+++ b/internal/runtime/bus/run_completion_test.go
@@ -54,7 +54,7 @@ func TestEventBusStandalonePlatformConvergenceAlsoProbesNormalRunCompletion(t *t
 	if err != nil {
 		t.Fatalf("NewEventBus: %v", err)
 	}
-	evt := eventtest.Projection("event-2", events.EventType("platform.boot"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{})
+	evt := eventtest.RootIngress("event-2", events.EventType("platform.boot"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{})
 	if err := eb.convergeStandaloneRuntimePlatformRun(context.Background(), evt); err != nil {
 		t.Fatalf("convergeStandaloneRuntimePlatformRun: %v", err)
 	}

--- a/internal/runtime/bus/run_completion_test.go
+++ b/internal/runtime/bus/run_completion_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/division-sh/swarm/internal/events"
+	"github.com/division-sh/swarm/internal/events/eventtest"
 	"time"
 )
 
@@ -53,7 +54,7 @@ func TestEventBusStandalonePlatformConvergenceAlsoProbesNormalRunCompletion(t *t
 	if err != nil {
 		t.Fatalf("NewEventBus: %v", err)
 	}
-	evt := events.NewProjectionEvent("event-2", events.EventType("platform.boot"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{})
+	evt := eventtest.Projection("event-2", events.EventType("platform.boot"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{})
 	if err := eb.convergeStandaloneRuntimePlatformRun(context.Background(), evt); err != nil {
 		t.Fatalf("convergeStandaloneRuntimePlatformRun: %v", err)
 	}

--- a/internal/runtime/bus/run_control_dispatch_test.go
+++ b/internal/runtime/bus/run_control_dispatch_test.go
@@ -48,11 +48,18 @@ func TestEventBusRunControlPauseQueuesOnlyTargetRunAndContinueReleases(t *testin
 	}
 
 	pausedEventID := uuid.NewString()
-	if err := eb.Publish(ctx, eventtest.WithEntityID(eventtest.Projection(pausedEventID,
-
+	if err := eb.Publish(ctx, eventtest.RootIngress(
+		pausedEventID,
 		eventType,
-		"api.v1", "", []byte(`{"entity_id":"21000000-0000-0000-0000-000000000002"}`), 0, pausedRunID, "", events.EventEnvelope{}, time.Now().UTC()),
-		"21000000-0000-0000-0000-000000000002")); err != nil {
+		"api.v1",
+		"",
+		[]byte(`{"entity_id":"21000000-0000-0000-0000-000000000002"}`),
+		0,
+		pausedRunID,
+		"",
+		events.EnvelopeForEntityID(events.EventEnvelope{}, "21000000-0000-0000-0000-000000000002"),
+		time.Now().UTC(),
+	)); err != nil {
 		t.Fatalf("Publish paused run event: %v", err)
 	}
 	requireNoBusEvent(t, ch, "paused run before continue")
@@ -61,11 +68,18 @@ func TestEventBusRunControlPauseQueuesOnlyTargetRunAndContinueReleases(t *testin
 	}
 
 	otherEventID := uuid.NewString()
-	if err := eb.Publish(ctx, eventtest.WithEntityID(eventtest.Projection(otherEventID,
-
+	if err := eb.Publish(ctx, eventtest.RootIngress(
+		otherEventID,
 		eventType,
-		"api.v1", "", []byte(`{"entity_id":"21000000-0000-0000-0000-000000000003"}`), 0, otherRunID, "", events.EventEnvelope{}, time.Now().UTC()),
-		"21000000-0000-0000-0000-000000000003")); err != nil {
+		"api.v1",
+		"",
+		[]byte(`{"entity_id":"21000000-0000-0000-0000-000000000003"}`),
+		0,
+		otherRunID,
+		"",
+		events.EnvelopeForEntityID(events.EventEnvelope{}, "21000000-0000-0000-0000-000000000003"),
+		time.Now().UTC(),
+	)); err != nil {
 		t.Fatalf("Publish other run event: %v", err)
 	}
 	got := requireBusEvent(t, ch, "other run dispatch")
@@ -124,11 +138,18 @@ func TestEventBusRunControlPauseQueuesBeforeInterceptorsAndContinueReplaysThem(t
 	}
 
 	queuedEventID := uuid.NewString()
-	if err := eb.Publish(ctx, eventtest.WithEntityID(eventtest.Projection(queuedEventID,
-
+	if err := eb.Publish(ctx, eventtest.RootIngress(
+		queuedEventID,
 		eventType,
-		"api.v1", "", []byte(`{"entity_id":"22000000-0000-0000-0000-000000000001"}`), 0, runID, "", events.EventEnvelope{}, time.Now().UTC()),
-		"22000000-0000-0000-0000-000000000001")); err != nil {
+		"api.v1",
+		"",
+		[]byte(`{"entity_id":"22000000-0000-0000-0000-000000000001"}`),
+		0,
+		runID,
+		"",
+		events.EnvelopeForEntityID(events.EventEnvelope{}, "22000000-0000-0000-0000-000000000001"),
+		time.Now().UTC(),
+	)); err != nil {
 		t.Fatalf("Publish paused run event: %v", err)
 	}
 	requireNoBusEvent(t, ch, "paused intercepted run before continue")
@@ -188,11 +209,18 @@ func TestEventBusRunControlPauseQueuesPostCommitEmitBeforeInterceptors(t *testin
 	}
 
 	intent := runtimeengine.EmitIntent{
-		Event: eventtest.WithEntityID(eventtest.Projection(uuid.NewString(),
-
+		Event: eventtest.RootIngress(
+			uuid.NewString(),
 			eventType,
-			"runtime", "", []byte(`{"entity_id":"23000000-0000-0000-0000-000000000001"}`), 0, runID, "", events.EventEnvelope{}, time.Now().UTC()),
-			"23000000-0000-0000-0000-000000000001"),
+			"runtime",
+			"",
+			[]byte(`{"entity_id":"23000000-0000-0000-0000-000000000001"}`),
+			0,
+			runID,
+			"",
+			events.EnvelopeForEntityID(events.EventEnvelope{}, "23000000-0000-0000-0000-000000000001"),
+			time.Now().UTC(),
+		),
 	}
 	tx, err := db.BeginTx(ctx, nil)
 	if err != nil {
@@ -251,10 +279,18 @@ func (i *runControlRecordingInterceptor) Intercept(_ context.Context, evt events
 	i.mu.Lock()
 	i.seen = append(i.seen, evt.ID())
 	i.mu.Unlock()
-	return true, []events.Event{eventtest.WithEntityID((eventtest.Projection(uuid.NewString(),
-
+	return true, []events.Event{eventtest.RootIngress(
+		uuid.NewString(),
 		i.deferredType,
-		"runtime", "", []byte(`{"entity_id":"22000000-0000-0000-0000-000000000002"}`), 0, evt.RunID(), "", events.EventEnvelope{}, time.Now().UTC())), "22000000-0000-0000-0000-000000000002")}, nil
+		"runtime",
+		"",
+		[]byte(`{"entity_id":"22000000-0000-0000-0000-000000000002"}`),
+		0,
+		evt.RunID(),
+		"",
+		events.EnvelopeForEntityID(events.EventEnvelope{}, "22000000-0000-0000-0000-000000000002"),
+		time.Now().UTC(),
+	)}, nil
 }
 
 func (i *runControlRecordingInterceptor) count() int {

--- a/internal/runtime/bus/run_control_dispatch_test.go
+++ b/internal/runtime/bus/run_control_dispatch_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/division-sh/swarm/internal/events"
+	"github.com/division-sh/swarm/internal/events/eventtest"
 	runtimebus "github.com/division-sh/swarm/internal/runtime/bus"
 	runtimeengine "github.com/division-sh/swarm/internal/runtime/engine"
 	runtimepipeline "github.com/division-sh/swarm/internal/runtime/pipeline"
@@ -47,11 +48,11 @@ func TestEventBusRunControlPauseQueuesOnlyTargetRunAndContinueReleases(t *testin
 	}
 
 	pausedEventID := uuid.NewString()
-	if err := eb.Publish(ctx, events.NewProjectionEvent(pausedEventID,
+	if err := eb.Publish(ctx, eventtest.WithEntityID(eventtest.Projection(pausedEventID,
 
 		eventType,
-		"api.v1", "", []byte(`{"entity_id":"21000000-0000-0000-0000-000000000002"}`), 0, pausedRunID, "", events.EventEnvelope{}, time.Now().UTC()).
-		WithEntityID("21000000-0000-0000-0000-000000000002")); err != nil {
+		"api.v1", "", []byte(`{"entity_id":"21000000-0000-0000-0000-000000000002"}`), 0, pausedRunID, "", events.EventEnvelope{}, time.Now().UTC()),
+		"21000000-0000-0000-0000-000000000002")); err != nil {
 		t.Fatalf("Publish paused run event: %v", err)
 	}
 	requireNoBusEvent(t, ch, "paused run before continue")
@@ -60,11 +61,11 @@ func TestEventBusRunControlPauseQueuesOnlyTargetRunAndContinueReleases(t *testin
 	}
 
 	otherEventID := uuid.NewString()
-	if err := eb.Publish(ctx, events.NewProjectionEvent(otherEventID,
+	if err := eb.Publish(ctx, eventtest.WithEntityID(eventtest.Projection(otherEventID,
 
 		eventType,
-		"api.v1", "", []byte(`{"entity_id":"21000000-0000-0000-0000-000000000003"}`), 0, otherRunID, "", events.EventEnvelope{}, time.Now().UTC()).
-		WithEntityID("21000000-0000-0000-0000-000000000003")); err != nil {
+		"api.v1", "", []byte(`{"entity_id":"21000000-0000-0000-0000-000000000003"}`), 0, otherRunID, "", events.EventEnvelope{}, time.Now().UTC()),
+		"21000000-0000-0000-0000-000000000003")); err != nil {
 		t.Fatalf("Publish other run event: %v", err)
 	}
 	got := requireBusEvent(t, ch, "other run dispatch")
@@ -123,11 +124,11 @@ func TestEventBusRunControlPauseQueuesBeforeInterceptorsAndContinueReplaysThem(t
 	}
 
 	queuedEventID := uuid.NewString()
-	if err := eb.Publish(ctx, events.NewProjectionEvent(queuedEventID,
+	if err := eb.Publish(ctx, eventtest.WithEntityID(eventtest.Projection(queuedEventID,
 
 		eventType,
-		"api.v1", "", []byte(`{"entity_id":"22000000-0000-0000-0000-000000000001"}`), 0, runID, "", events.EventEnvelope{}, time.Now().UTC()).
-		WithEntityID("22000000-0000-0000-0000-000000000001")); err != nil {
+		"api.v1", "", []byte(`{"entity_id":"22000000-0000-0000-0000-000000000001"}`), 0, runID, "", events.EventEnvelope{}, time.Now().UTC()),
+		"22000000-0000-0000-0000-000000000001")); err != nil {
 		t.Fatalf("Publish paused run event: %v", err)
 	}
 	requireNoBusEvent(t, ch, "paused intercepted run before continue")
@@ -187,11 +188,11 @@ func TestEventBusRunControlPauseQueuesPostCommitEmitBeforeInterceptors(t *testin
 	}
 
 	intent := runtimeengine.EmitIntent{
-		Event: events.NewProjectionEvent(uuid.NewString(),
+		Event: eventtest.WithEntityID(eventtest.Projection(uuid.NewString(),
 
 			eventType,
-			"runtime", "", []byte(`{"entity_id":"23000000-0000-0000-0000-000000000001"}`), 0, runID, "", events.EventEnvelope{}, time.Now().UTC()).
-			WithEntityID("23000000-0000-0000-0000-000000000001"),
+			"runtime", "", []byte(`{"entity_id":"23000000-0000-0000-0000-000000000001"}`), 0, runID, "", events.EventEnvelope{}, time.Now().UTC()),
+			"23000000-0000-0000-0000-000000000001"),
 	}
 	tx, err := db.BeginTx(ctx, nil)
 	if err != nil {
@@ -250,10 +251,10 @@ func (i *runControlRecordingInterceptor) Intercept(_ context.Context, evt events
 	i.mu.Lock()
 	i.seen = append(i.seen, evt.ID())
 	i.mu.Unlock()
-	return true, []events.Event{(events.NewProjectionEvent(uuid.NewString(),
+	return true, []events.Event{eventtest.WithEntityID((eventtest.Projection(uuid.NewString(),
 
 		i.deferredType,
-		"runtime", "", []byte(`{"entity_id":"22000000-0000-0000-0000-000000000002"}`), 0, evt.RunID(), "", events.EventEnvelope{}, time.Now().UTC())).WithEntityID("22000000-0000-0000-0000-000000000002")}, nil
+		"runtime", "", []byte(`{"entity_id":"22000000-0000-0000-0000-000000000002"}`), 0, evt.RunID(), "", events.EventEnvelope{}, time.Now().UTC())), "22000000-0000-0000-0000-000000000002")}, nil
 }
 
 func (i *runControlRecordingInterceptor) count() int {

--- a/internal/runtime/bus/sweeper_test.go
+++ b/internal/runtime/bus/sweeper_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/division-sh/swarm/internal/events"
+	"github.com/division-sh/swarm/internal/events/eventtest"
 	runtimebus "github.com/division-sh/swarm/internal/runtime/bus"
 	runtimeownership "github.com/division-sh/swarm/internal/runtime/core/ownership"
 	runtimereplayclaim "github.com/division-sh/swarm/internal/runtime/replayclaim"
@@ -108,8 +109,8 @@ func (l sweeperClaimLease) Release(context.Context) error {
 func TestSweepUndispatchedUsesPersistedDeliveryRecipients(t *testing.T) {
 	store := &sweeperTestStore{
 		events: []events.PersistedReplayEvent{
-			{Event: (events.NewProjectionEvent("evt-1",
-				events.EventType("custom.emitted"), "", "", []byte(`{"entity_id":"ent-1"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())).WithEntityID("ent-1")},
+			{Event: eventtest.WithEntityID((eventtest.Projection("evt-1",
+				events.EventType("custom.emitted"), "", "", []byte(`{"entity_id":"ent-1"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())), "ent-1")},
 		},
 		deliveries: map[string][]string{"evt-1": {"agent-a"}},
 		scopes:     map[string]runtimereplayclaim.CommittedReplayScope{"evt-1": runtimereplayclaim.CommittedReplayScopeSubscribed},
@@ -139,8 +140,8 @@ func TestSweepUndispatchedUsesPersistedDeliveryRecipients(t *testing.T) {
 func TestSweepUndispatched_UsesAuthoritativeEmptyFanOutWithoutSubscribedFallback(t *testing.T) {
 	store := &sweeperTestStore{
 		events: []events.PersistedReplayEvent{
-			{Event: (events.NewProjectionEvent("evt-2",
-				events.EventType("custom.routed"), "", "", []byte(`{"entity_id":"ent-2"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())).WithEntityID("ent-2")},
+			{Event: eventtest.WithEntityID((eventtest.Projection("evt-2",
+				events.EventType("custom.routed"), "", "", []byte(`{"entity_id":"ent-2"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())), "ent-2")},
 		},
 		deliveries: map[string][]string{},
 		scopes:     map[string]runtimereplayclaim.CommittedReplayScope{"evt-2": runtimereplayclaim.CommittedReplayScopeDirect},
@@ -167,8 +168,8 @@ func TestSweepUndispatched_UsesAuthoritativeEmptyFanOutWithoutSubscribedFallback
 func TestSweepUndispatched_ReplaysSubscribedInternalOnlyUsingReplayScope(t *testing.T) {
 	store := &sweeperTestStore{
 		events: []events.PersistedReplayEvent{
-			{Event: (events.NewProjectionEvent("evt-internal-only",
-				events.EventType("custom.internal"), "", "", []byte(`{"entity_id":"ent-internal"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())).WithEntityID("ent-internal")},
+			{Event: eventtest.WithEntityID((eventtest.Projection("evt-internal-only",
+				events.EventType("custom.internal"), "", "", []byte(`{"entity_id":"ent-internal"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())), "ent-internal")},
 		},
 		deliveries: map[string][]string{},
 		scopes:     map[string]runtimereplayclaim.CommittedReplayScope{"evt-internal-only": runtimereplayclaim.CommittedReplayScopeSubscribed},
@@ -198,8 +199,8 @@ func TestSweepUndispatched_ReplaysSubscribedInternalOnlyUsingReplayScope(t *test
 func TestSweepUndispatched_ReplaysSubscribedMixedRecipientsUsingReplayScope(t *testing.T) {
 	store := &sweeperTestStore{
 		events: []events.PersistedReplayEvent{
-			{Event: (events.NewProjectionEvent("evt-mixed",
-				events.EventType("custom.mixed"), "", "", []byte(`{"entity_id":"ent-mixed"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())).WithEntityID("ent-mixed")},
+			{Event: eventtest.WithEntityID((eventtest.Projection("evt-mixed",
+				events.EventType("custom.mixed"), "", "", []byte(`{"entity_id":"ent-mixed"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())), "ent-mixed")},
 		},
 		deliveries: map[string][]string{"evt-mixed": {"agent-a"}},
 		scopes:     map[string]runtimereplayclaim.CommittedReplayScope{"evt-mixed": runtimereplayclaim.CommittedReplayScopeSubscribed},
@@ -231,8 +232,8 @@ func TestSweepUndispatched_ReplaysSubscribedMixedRecipientsUsingReplayScope(t *t
 func TestSweepUndispatched_DirectScopeDoesNotBroadenToCurrentInternalSubscribers(t *testing.T) {
 	store := &sweeperTestStore{
 		events: []events.PersistedReplayEvent{
-			{Event: (events.NewProjectionEvent("evt-direct-mixed",
-				events.EventType("custom.direct"), "", "", []byte(`{"entity_id":"ent-direct"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())).WithEntityID("ent-direct")},
+			{Event: eventtest.WithEntityID((eventtest.Projection("evt-direct-mixed",
+				events.EventType("custom.direct"), "", "", []byte(`{"entity_id":"ent-direct"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())), "ent-direct")},
 		},
 		deliveries: map[string][]string{"evt-direct-mixed": {"agent-a"}},
 		scopes: map[string]runtimereplayclaim.CommittedReplayScope{
@@ -263,8 +264,8 @@ func TestSweepUndispatched_DirectScopeDoesNotBroadenToCurrentInternalSubscribers
 func TestSweepUndispatched_DirectEmptyManifestDoesNotBroadenToCurrentInternalSubscribers(t *testing.T) {
 	store := &sweeperTestStore{
 		events: []events.PersistedReplayEvent{
-			{Event: (events.NewProjectionEvent("evt-direct-empty",
-				events.EventType("custom.direct.empty"), "", "", []byte(`{"entity_id":"ent-direct-empty"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())).WithEntityID("ent-direct-empty")},
+			{Event: eventtest.WithEntityID((eventtest.Projection("evt-direct-empty",
+				events.EventType("custom.direct.empty"), "", "", []byte(`{"entity_id":"ent-direct-empty"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())), "ent-direct-empty")},
 		},
 		deliveries: map[string][]string{},
 		scopes: map[string]runtimereplayclaim.CommittedReplayScope{
@@ -294,14 +295,14 @@ func TestSweepUndispatched_SkipsMalformedReplayRowsAndContinues(t *testing.T) {
 	store := &sweeperTestStore{
 		events: []events.PersistedReplayEvent{
 			{
-				Event: events.NewProjectionEvent("evt-bad",
+				Event: eventtest.Projection("evt-bad",
 					events.EventType("custom.bad"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Now().UTC()),
 
 				ReplayError: "missing canonical run_id",
 			},
 			{
-				Event: (events.NewProjectionEvent("evt-good",
-					events.EventType("custom.good"), "", "", []byte(`{"entity_id":"ent-good"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())).WithEntityID("ent-good"),
+				Event: eventtest.WithEntityID((eventtest.Projection("evt-good",
+					events.EventType("custom.good"), "", "", []byte(`{"entity_id":"ent-good"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())), "ent-good"),
 			},
 		},
 		deliveries: map[string][]string{"evt-good": {"agent-good"}},
@@ -338,12 +339,10 @@ func TestSweepUndispatched_SkipsMalformedReplayRowsAndContinues(t *testing.T) {
 func TestSweepUndispatched_TerminallyMarksMissingCommittedReplayScopeAndContinues(t *testing.T) {
 	store := &sweeperTestStore{
 		events: []events.PersistedReplayEvent{
-			{Event: events.NewProjectionEvent("evt-markerless",
-				events.EventType("custom.markerless"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Now().UTC()),
-			},
-			{Event: events.NewProjectionEvent("evt-good-after-markerless",
-				events.EventType("custom.good"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Now().UTC()),
-			},
+			{Event: eventtest.Projection("evt-markerless",
+				events.EventType("custom.markerless"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Now().UTC())},
+			{Event: eventtest.Projection("evt-good-after-markerless",
+				events.EventType("custom.good"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Now().UTC())},
 		},
 		deliveries: map[string][]string{
 			"evt-markerless":            {"agent-missing"},
@@ -399,8 +398,8 @@ func TestSweepUndispatched_TerminallyMarksMissingCommittedReplayScopeAndContinue
 func TestSweepUndispatched_ClaimsReplayOwnershipBeforeDispatch(t *testing.T) {
 	store := &sweeperTestStore{
 		events: []events.PersistedReplayEvent{
-			{Event: (events.NewProjectionEvent("evt-claim",
-				events.EventType("custom.claimed"), "", "", []byte(`{"entity_id":"ent-claim"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())).WithEntityID("ent-claim")},
+			{Event: eventtest.WithEntityID((eventtest.Projection("evt-claim",
+				events.EventType("custom.claimed"), "", "", []byte(`{"entity_id":"ent-claim"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())), "ent-claim")},
 		},
 		deliveries:  map[string][]string{"evt-claim": {"agent-claim"}},
 		scopes:      map[string]runtimereplayclaim.CommittedReplayScope{"evt-claim": runtimereplayclaim.CommittedReplayScopeSubscribed},
@@ -444,9 +443,8 @@ func TestSweepUndispatched_ClaimsReplayOwnershipBeforeDispatch(t *testing.T) {
 func TestSweepUndispatched_FailsClosedWithoutReplayClaimOwner(t *testing.T) {
 	store := &sweeperMissingClaimStore{
 		events: []events.PersistedReplayEvent{
-			{Event: events.NewProjectionEvent("evt-claim-missing",
-				events.EventType("custom.claimed"), "", "", []byte(`{"entity_id":"ent-claim"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC()),
-			},
+			{Event: eventtest.Projection("evt-claim-missing",
+				events.EventType("custom.claimed"), "", "", []byte(`{"entity_id":"ent-claim"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())},
 		},
 		deliveries: map[string][]string{"evt-claim-missing": {"agent-a"}},
 	}

--- a/internal/runtime/bus/sweeper_test.go
+++ b/internal/runtime/bus/sweeper_test.go
@@ -109,8 +109,18 @@ func (l sweeperClaimLease) Release(context.Context) error {
 func TestSweepUndispatchedUsesPersistedDeliveryRecipients(t *testing.T) {
 	store := &sweeperTestStore{
 		events: []events.PersistedReplayEvent{
-			{Event: eventtest.WithEntityID((eventtest.Projection("evt-1",
-				events.EventType("custom.emitted"), "", "", []byte(`{"entity_id":"ent-1"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())), "ent-1")},
+			{Event: eventtest.RootIngress(
+				"evt-1",
+				events.EventType("custom.emitted"),
+				"",
+				"",
+				[]byte(`{"entity_id":"ent-1"}`),
+				0,
+				"",
+				"",
+				events.EnvelopeForEntityID(events.EventEnvelope{}, "ent-1"),
+				time.Now().UTC(),
+			)},
 		},
 		deliveries: map[string][]string{"evt-1": {"agent-a"}},
 		scopes:     map[string]runtimereplayclaim.CommittedReplayScope{"evt-1": runtimereplayclaim.CommittedReplayScopeSubscribed},
@@ -140,8 +150,18 @@ func TestSweepUndispatchedUsesPersistedDeliveryRecipients(t *testing.T) {
 func TestSweepUndispatched_UsesAuthoritativeEmptyFanOutWithoutSubscribedFallback(t *testing.T) {
 	store := &sweeperTestStore{
 		events: []events.PersistedReplayEvent{
-			{Event: eventtest.WithEntityID((eventtest.Projection("evt-2",
-				events.EventType("custom.routed"), "", "", []byte(`{"entity_id":"ent-2"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())), "ent-2")},
+			{Event: eventtest.RootIngress(
+				"evt-2",
+				events.EventType("custom.routed"),
+				"",
+				"",
+				[]byte(`{"entity_id":"ent-2"}`),
+				0,
+				"",
+				"",
+				events.EnvelopeForEntityID(events.EventEnvelope{}, "ent-2"),
+				time.Now().UTC(),
+			)},
 		},
 		deliveries: map[string][]string{},
 		scopes:     map[string]runtimereplayclaim.CommittedReplayScope{"evt-2": runtimereplayclaim.CommittedReplayScopeDirect},
@@ -168,8 +188,18 @@ func TestSweepUndispatched_UsesAuthoritativeEmptyFanOutWithoutSubscribedFallback
 func TestSweepUndispatched_ReplaysSubscribedInternalOnlyUsingReplayScope(t *testing.T) {
 	store := &sweeperTestStore{
 		events: []events.PersistedReplayEvent{
-			{Event: eventtest.WithEntityID((eventtest.Projection("evt-internal-only",
-				events.EventType("custom.internal"), "", "", []byte(`{"entity_id":"ent-internal"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())), "ent-internal")},
+			{Event: eventtest.RootIngress(
+				"evt-internal-only",
+				events.EventType("custom.internal"),
+				"",
+				"",
+				[]byte(`{"entity_id":"ent-internal"}`),
+				0,
+				"",
+				"",
+				events.EnvelopeForEntityID(events.EventEnvelope{}, "ent-internal"),
+				time.Now().UTC(),
+			)},
 		},
 		deliveries: map[string][]string{},
 		scopes:     map[string]runtimereplayclaim.CommittedReplayScope{"evt-internal-only": runtimereplayclaim.CommittedReplayScopeSubscribed},
@@ -199,8 +229,18 @@ func TestSweepUndispatched_ReplaysSubscribedInternalOnlyUsingReplayScope(t *test
 func TestSweepUndispatched_ReplaysSubscribedMixedRecipientsUsingReplayScope(t *testing.T) {
 	store := &sweeperTestStore{
 		events: []events.PersistedReplayEvent{
-			{Event: eventtest.WithEntityID((eventtest.Projection("evt-mixed",
-				events.EventType("custom.mixed"), "", "", []byte(`{"entity_id":"ent-mixed"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())), "ent-mixed")},
+			{Event: eventtest.RootIngress(
+				"evt-mixed",
+				events.EventType("custom.mixed"),
+				"",
+				"",
+				[]byte(`{"entity_id":"ent-mixed"}`),
+				0,
+				"",
+				"",
+				events.EnvelopeForEntityID(events.EventEnvelope{}, "ent-mixed"),
+				time.Now().UTC(),
+			)},
 		},
 		deliveries: map[string][]string{"evt-mixed": {"agent-a"}},
 		scopes:     map[string]runtimereplayclaim.CommittedReplayScope{"evt-mixed": runtimereplayclaim.CommittedReplayScopeSubscribed},
@@ -232,8 +272,18 @@ func TestSweepUndispatched_ReplaysSubscribedMixedRecipientsUsingReplayScope(t *t
 func TestSweepUndispatched_DirectScopeDoesNotBroadenToCurrentInternalSubscribers(t *testing.T) {
 	store := &sweeperTestStore{
 		events: []events.PersistedReplayEvent{
-			{Event: eventtest.WithEntityID((eventtest.Projection("evt-direct-mixed",
-				events.EventType("custom.direct"), "", "", []byte(`{"entity_id":"ent-direct"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())), "ent-direct")},
+			{Event: eventtest.RootIngress(
+				"evt-direct-mixed",
+				events.EventType("custom.direct"),
+				"",
+				"",
+				[]byte(`{"entity_id":"ent-direct"}`),
+				0,
+				"",
+				"",
+				events.EnvelopeForEntityID(events.EventEnvelope{}, "ent-direct"),
+				time.Now().UTC(),
+			)},
 		},
 		deliveries: map[string][]string{"evt-direct-mixed": {"agent-a"}},
 		scopes: map[string]runtimereplayclaim.CommittedReplayScope{
@@ -264,8 +314,18 @@ func TestSweepUndispatched_DirectScopeDoesNotBroadenToCurrentInternalSubscribers
 func TestSweepUndispatched_DirectEmptyManifestDoesNotBroadenToCurrentInternalSubscribers(t *testing.T) {
 	store := &sweeperTestStore{
 		events: []events.PersistedReplayEvent{
-			{Event: eventtest.WithEntityID((eventtest.Projection("evt-direct-empty",
-				events.EventType("custom.direct.empty"), "", "", []byte(`{"entity_id":"ent-direct-empty"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())), "ent-direct-empty")},
+			{Event: eventtest.RootIngress(
+				"evt-direct-empty",
+				events.EventType("custom.direct.empty"),
+				"",
+				"",
+				[]byte(`{"entity_id":"ent-direct-empty"}`),
+				0,
+				"",
+				"",
+				events.EnvelopeForEntityID(events.EventEnvelope{}, "ent-direct-empty"),
+				time.Now().UTC(),
+			)},
 		},
 		deliveries: map[string][]string{},
 		scopes: map[string]runtimereplayclaim.CommittedReplayScope{
@@ -295,14 +355,24 @@ func TestSweepUndispatched_SkipsMalformedReplayRowsAndContinues(t *testing.T) {
 	store := &sweeperTestStore{
 		events: []events.PersistedReplayEvent{
 			{
-				Event: eventtest.Projection("evt-bad",
+				Event: eventtest.RootIngress("evt-bad",
 					events.EventType("custom.bad"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Now().UTC()),
 
 				ReplayError: "missing canonical run_id",
 			},
 			{
-				Event: eventtest.WithEntityID((eventtest.Projection("evt-good",
-					events.EventType("custom.good"), "", "", []byte(`{"entity_id":"ent-good"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())), "ent-good"),
+				Event: eventtest.RootIngress(
+					"evt-good",
+					events.EventType("custom.good"),
+					"",
+					"",
+					[]byte(`{"entity_id":"ent-good"}`),
+					0,
+					"",
+					"",
+					events.EnvelopeForEntityID(events.EventEnvelope{}, "ent-good"),
+					time.Now().UTC(),
+				),
 			},
 		},
 		deliveries: map[string][]string{"evt-good": {"agent-good"}},
@@ -339,9 +409,9 @@ func TestSweepUndispatched_SkipsMalformedReplayRowsAndContinues(t *testing.T) {
 func TestSweepUndispatched_TerminallyMarksMissingCommittedReplayScopeAndContinues(t *testing.T) {
 	store := &sweeperTestStore{
 		events: []events.PersistedReplayEvent{
-			{Event: eventtest.Projection("evt-markerless",
+			{Event: eventtest.RootIngress("evt-markerless",
 				events.EventType("custom.markerless"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Now().UTC())},
-			{Event: eventtest.Projection("evt-good-after-markerless",
+			{Event: eventtest.RootIngress("evt-good-after-markerless",
 				events.EventType("custom.good"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Now().UTC())},
 		},
 		deliveries: map[string][]string{
@@ -398,8 +468,18 @@ func TestSweepUndispatched_TerminallyMarksMissingCommittedReplayScopeAndContinue
 func TestSweepUndispatched_ClaimsReplayOwnershipBeforeDispatch(t *testing.T) {
 	store := &sweeperTestStore{
 		events: []events.PersistedReplayEvent{
-			{Event: eventtest.WithEntityID((eventtest.Projection("evt-claim",
-				events.EventType("custom.claimed"), "", "", []byte(`{"entity_id":"ent-claim"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())), "ent-claim")},
+			{Event: eventtest.RootIngress(
+				"evt-claim",
+				events.EventType("custom.claimed"),
+				"",
+				"",
+				[]byte(`{"entity_id":"ent-claim"}`),
+				0,
+				"",
+				"",
+				events.EnvelopeForEntityID(events.EventEnvelope{}, "ent-claim"),
+				time.Now().UTC(),
+			)},
 		},
 		deliveries:  map[string][]string{"evt-claim": {"agent-claim"}},
 		scopes:      map[string]runtimereplayclaim.CommittedReplayScope{"evt-claim": runtimereplayclaim.CommittedReplayScopeSubscribed},
@@ -443,7 +523,7 @@ func TestSweepUndispatched_ClaimsReplayOwnershipBeforeDispatch(t *testing.T) {
 func TestSweepUndispatched_FailsClosedWithoutReplayClaimOwner(t *testing.T) {
 	store := &sweeperMissingClaimStore{
 		events: []events.PersistedReplayEvent{
-			{Event: eventtest.Projection("evt-claim-missing",
+			{Event: eventtest.RootIngress("evt-claim-missing",
 				events.EventType("custom.claimed"), "", "", []byte(`{"entity_id":"ent-claim"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())},
 		},
 		deliveries: map[string][]string{"evt-claim-missing": {"agent-a"}},

--- a/internal/runtime/cataloge2e/assertions_test.go
+++ b/internal/runtime/cataloge2e/assertions_test.go
@@ -56,20 +56,46 @@ func TestCatalogCausalEntityIDs_FollowsSourceEventIDChain(t *testing.T) {
 	rootEventID := uuid.NewString()
 	childEventID := uuid.NewString()
 	grandchildEventID := uuid.NewString()
-	if err := pg.AppendEvent(context.Background(), eventtest.WithEntityID((eventtest.Projection(rootEventID,
-		"root.started", "", "", []byte(`{"entity_id":"`+rootID+`"}`), 0, catalogRuntimeRunID, "", events.EventEnvelope{}, time.Now().UTC())), rootID)); err != nil {
+	if err := pg.AppendEvent(context.Background(), eventtest.RootIngress(
+		rootEventID,
+		"root.started",
+		"",
+		"",
+		[]byte(`{"entity_id":"`+rootID+`"}`),
+		0,
+		catalogRuntimeRunID,
+		"",
+		events.EnvelopeForEntityID(events.EventEnvelope{}, rootID),
+		time.Now().UTC(),
+	)); err != nil {
 		t.Fatalf("append root event: %v", err)
 	}
-	if err := pg.AppendEvent(context.Background(), eventtest.WithEntityID((eventtest.Projection(childEventID,
-		"child.started", "", "", []byte(`{"entity_id":"`+childID+`"}`), 0, catalogRuntimeRunID,
-
-		rootEventID, events.EventEnvelope{}, time.Now().UTC())), childID)); err != nil {
+	if err := pg.AppendEvent(context.Background(), eventtest.RootIngress(
+		childEventID,
+		"child.started",
+		"",
+		"",
+		[]byte(`{"entity_id":"`+childID+`"}`),
+		0,
+		catalogRuntimeRunID,
+		rootEventID,
+		events.EnvelopeForEntityID(events.EventEnvelope{}, childID),
+		time.Now().UTC(),
+	)); err != nil {
 		t.Fatalf("append child event: %v", err)
 	}
-	if err := pg.AppendEvent(context.Background(), eventtest.WithEntityID((eventtest.Projection(grandchildEventID,
-		"grandchild.done", "", "", []byte(`{"entity_id":"`+grandchildID+`"}`), 0, catalogRuntimeRunID,
-
-		childEventID, events.EventEnvelope{}, time.Now().UTC())), grandchildID)); err != nil {
+	if err := pg.AppendEvent(context.Background(), eventtest.RootIngress(
+		grandchildEventID,
+		"grandchild.done",
+		"",
+		"",
+		[]byte(`{"entity_id":"`+grandchildID+`"}`),
+		0,
+		catalogRuntimeRunID,
+		childEventID,
+		events.EnvelopeForEntityID(events.EventEnvelope{}, grandchildID),
+		time.Now().UTC(),
+	)); err != nil {
 		t.Fatalf("append grandchild event: %v", err)
 	}
 
@@ -187,9 +213,18 @@ func TestAssertEmittedEvents_AcceptsCrossFlowInheritDispatcherEmission(t *testin
 	h.bundle = bundle
 
 	insertCatalogAssertionEntityState(t, h, entityID, "dispatched")
-	if err := h.pg.AppendEvent(context.Background(), eventtest.WithEntityID((eventtest.Projection(uuid.NewString(),
+	if err := h.pg.AppendEvent(context.Background(), eventtest.RootIngress(
+		uuid.NewString(),
 		"score.requested",
-		"runtime", "", []byte(`{"entity_id":"`+entityID+`"}`), 0, catalogRuntimeRunID, "", events.EventEnvelope{}, time.Now().UTC())), entityID)); err != nil {
+		"runtime",
+		"",
+		[]byte(`{"entity_id":"`+entityID+`"}`),
+		0,
+		catalogRuntimeRunID,
+		"",
+		events.EnvelopeForEntityID(events.EventEnvelope{}, entityID),
+		time.Now().UTC(),
+	)); err != nil {
 		t.Fatalf("append score.requested event: %v", err)
 	}
 
@@ -240,9 +275,18 @@ func insertCatalogAssertionEntityState(t *testing.T, h *runtimeHarness, entityID
 
 func insertCatalogAssertionDeadLetterEvent(t *testing.T, h *runtimeHarness, entityID string) {
 	t.Helper()
-	if err := h.pg.AppendEvent(context.Background(), eventtest.WithEntityID((eventtest.Projection(uuid.NewString(),
+	if err := h.pg.AppendEvent(context.Background(), eventtest.RootIngress(
+		uuid.NewString(),
 		"platform.dead_letter",
-		"runtime", "", []byte(`{"entity_id":"`+entityID+`"}`), 0, catalogRuntimeRunID, "", events.EventEnvelope{}, time.Now().UTC())), entityID)); err != nil {
+		"runtime",
+		"",
+		[]byte(`{"entity_id":"`+entityID+`"}`),
+		0,
+		catalogRuntimeRunID,
+		"",
+		events.EnvelopeForEntityID(events.EventEnvelope{}, entityID),
+		time.Now().UTC(),
+	)); err != nil {
 		t.Fatalf("append platform.dead_letter event: %v", err)
 	}
 }

--- a/internal/runtime/cataloge2e/assertions_test.go
+++ b/internal/runtime/cataloge2e/assertions_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/division-sh/swarm/internal/events"
+	"github.com/division-sh/swarm/internal/events/eventtest"
 	runtimepipeline "github.com/division-sh/swarm/internal/runtime/pipeline"
 	"github.com/division-sh/swarm/internal/runtime/semanticview"
 	"github.com/division-sh/swarm/internal/store"
@@ -55,20 +56,20 @@ func TestCatalogCausalEntityIDs_FollowsSourceEventIDChain(t *testing.T) {
 	rootEventID := uuid.NewString()
 	childEventID := uuid.NewString()
 	grandchildEventID := uuid.NewString()
-	if err := pg.AppendEvent(context.Background(), (events.NewProjectionEvent(rootEventID,
-		"root.started", "", "", []byte(`{"entity_id":"`+rootID+`"}`), 0, catalogRuntimeRunID, "", events.EventEnvelope{}, time.Now().UTC())).WithEntityID(rootID)); err != nil {
+	if err := pg.AppendEvent(context.Background(), eventtest.WithEntityID((eventtest.Projection(rootEventID,
+		"root.started", "", "", []byte(`{"entity_id":"`+rootID+`"}`), 0, catalogRuntimeRunID, "", events.EventEnvelope{}, time.Now().UTC())), rootID)); err != nil {
 		t.Fatalf("append root event: %v", err)
 	}
-	if err := pg.AppendEvent(context.Background(), (events.NewProjectionEvent(childEventID,
+	if err := pg.AppendEvent(context.Background(), eventtest.WithEntityID((eventtest.Projection(childEventID,
 		"child.started", "", "", []byte(`{"entity_id":"`+childID+`"}`), 0, catalogRuntimeRunID,
 
-		rootEventID, events.EventEnvelope{}, time.Now().UTC())).WithEntityID(childID)); err != nil {
+		rootEventID, events.EventEnvelope{}, time.Now().UTC())), childID)); err != nil {
 		t.Fatalf("append child event: %v", err)
 	}
-	if err := pg.AppendEvent(context.Background(), (events.NewProjectionEvent(grandchildEventID,
+	if err := pg.AppendEvent(context.Background(), eventtest.WithEntityID((eventtest.Projection(grandchildEventID,
 		"grandchild.done", "", "", []byte(`{"entity_id":"`+grandchildID+`"}`), 0, catalogRuntimeRunID,
 
-		childEventID, events.EventEnvelope{}, time.Now().UTC())).WithEntityID(grandchildID)); err != nil {
+		childEventID, events.EventEnvelope{}, time.Now().UTC())), grandchildID)); err != nil {
 		t.Fatalf("append grandchild event: %v", err)
 	}
 
@@ -186,9 +187,9 @@ func TestAssertEmittedEvents_AcceptsCrossFlowInheritDispatcherEmission(t *testin
 	h.bundle = bundle
 
 	insertCatalogAssertionEntityState(t, h, entityID, "dispatched")
-	if err := h.pg.AppendEvent(context.Background(), (events.NewProjectionEvent(uuid.NewString(),
+	if err := h.pg.AppendEvent(context.Background(), eventtest.WithEntityID((eventtest.Projection(uuid.NewString(),
 		"score.requested",
-		"runtime", "", []byte(`{"entity_id":"`+entityID+`"}`), 0, catalogRuntimeRunID, "", events.EventEnvelope{}, time.Now().UTC())).WithEntityID(entityID)); err != nil {
+		"runtime", "", []byte(`{"entity_id":"`+entityID+`"}`), 0, catalogRuntimeRunID, "", events.EventEnvelope{}, time.Now().UTC())), entityID)); err != nil {
 		t.Fatalf("append score.requested event: %v", err)
 	}
 
@@ -239,9 +240,9 @@ func insertCatalogAssertionEntityState(t *testing.T, h *runtimeHarness, entityID
 
 func insertCatalogAssertionDeadLetterEvent(t *testing.T, h *runtimeHarness, entityID string) {
 	t.Helper()
-	if err := h.pg.AppendEvent(context.Background(), (events.NewProjectionEvent(uuid.NewString(),
+	if err := h.pg.AppendEvent(context.Background(), eventtest.WithEntityID((eventtest.Projection(uuid.NewString(),
 		"platform.dead_letter",
-		"runtime", "", []byte(`{"entity_id":"`+entityID+`"}`), 0, catalogRuntimeRunID, "", events.EventEnvelope{}, time.Now().UTC())).WithEntityID(entityID)); err != nil {
+		"runtime", "", []byte(`{"entity_id":"`+entityID+`"}`), 0, catalogRuntimeRunID, "", events.EventEnvelope{}, time.Now().UTC())), entityID)); err != nil {
 		t.Fatalf("append platform.dead_letter event: %v", err)
 	}
 }

--- a/internal/runtime/cataloge2e/runtime_harness_test.go
+++ b/internal/runtime/cataloge2e/runtime_harness_test.go
@@ -325,13 +325,13 @@ func (h *runtimeHarness) publishConcurrentAndWait(steps []catalogTriggerStep, ti
 		if err != nil {
 			h.t.Fatalf("marshal concurrent trigger payload: %v", err)
 		}
-		evt := eventtest.Projection(uuid.NewString(),
-			events.EventType(strings.TrimSpace(step.Event)),
-			"cataloge2e", "", raw, 0, catalogRuntimeRunID, "", events.EventEnvelope{}, time.Now().UTC())
-
+		eventEnvelope := events.EventEnvelope{}
 		if entityID := triggerPayloadEntityID(payload); entityID != "" {
-			evt = eventtest.WithEntityID(evt, entityID)
+			eventEnvelope = events.EnvelopeForEntityID(eventEnvelope, entityID)
 		}
+		evt := eventtest.RootIngress(uuid.NewString(),
+			events.EventType(strings.TrimSpace(step.Event)),
+			"cataloge2e", "", raw, 0, catalogRuntimeRunID, "", eventEnvelope, time.Now().UTC())
 		if preview, ok := h.previewHandlerOutcome(evt); ok {
 			h.mu.Lock()
 			h.previews[evt.ID()] = preview
@@ -383,13 +383,13 @@ func (h *runtimeHarness) publishRuntimeEventResult(eventType, sourceAgent string
 	if err != nil {
 		return err
 	}
-	evt := eventtest.Projection(uuid.NewString(),
-		events.EventType(strings.TrimSpace(eventType)),
-		strings.TrimSpace(sourceAgent), "", raw, 0, catalogRuntimeRunID, "", events.EventEnvelope{}, time.Now().UTC())
-
+	eventEnvelope := events.EventEnvelope{}
 	if entityID := triggerPayloadEntityID(payload); entityID != "" {
-		evt = eventtest.WithEntityID(evt, entityID)
+		eventEnvelope = events.EnvelopeForEntityID(eventEnvelope, entityID)
 	}
+	evt := eventtest.RootIngress(uuid.NewString(),
+		events.EventType(strings.TrimSpace(eventType)),
+		strings.TrimSpace(sourceAgent), "", raw, 0, catalogRuntimeRunID, "", eventEnvelope, time.Now().UTC())
 	if recordOutcome {
 		if preview, ok := h.previewHandlerOutcome(evt); ok {
 			h.mu.Lock()

--- a/internal/runtime/cataloge2e/runtime_harness_test.go
+++ b/internal/runtime/cataloge2e/runtime_harness_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/division-sh/swarm/internal/events"
+	"github.com/division-sh/swarm/internal/events/eventtest"
 	runtime "github.com/division-sh/swarm/internal/runtime"
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
 	runtimecorrelation "github.com/division-sh/swarm/internal/runtime/correlation"
@@ -324,12 +325,12 @@ func (h *runtimeHarness) publishConcurrentAndWait(steps []catalogTriggerStep, ti
 		if err != nil {
 			h.t.Fatalf("marshal concurrent trigger payload: %v", err)
 		}
-		evt := events.NewProjectionEvent(uuid.NewString(),
+		evt := eventtest.Projection(uuid.NewString(),
 			events.EventType(strings.TrimSpace(step.Event)),
 			"cataloge2e", "", raw, 0, catalogRuntimeRunID, "", events.EventEnvelope{}, time.Now().UTC())
 
 		if entityID := triggerPayloadEntityID(payload); entityID != "" {
-			evt = evt.WithEntityID(entityID)
+			evt = eventtest.WithEntityID(evt, entityID)
 		}
 		if preview, ok := h.previewHandlerOutcome(evt); ok {
 			h.mu.Lock()
@@ -382,12 +383,12 @@ func (h *runtimeHarness) publishRuntimeEventResult(eventType, sourceAgent string
 	if err != nil {
 		return err
 	}
-	evt := events.NewProjectionEvent(uuid.NewString(),
+	evt := eventtest.Projection(uuid.NewString(),
 		events.EventType(strings.TrimSpace(eventType)),
 		strings.TrimSpace(sourceAgent), "", raw, 0, catalogRuntimeRunID, "", events.EventEnvelope{}, time.Now().UTC())
 
 	if entityID := triggerPayloadEntityID(payload); entityID != "" {
-		evt = evt.WithEntityID(entityID)
+		evt = eventtest.WithEntityID(evt, entityID)
 	}
 	if recordOutcome {
 		if preview, ok := h.previewHandlerOutcome(evt); ok {

--- a/internal/runtime/cataloge2e/tier12_runtime_fork_e2e_test.go
+++ b/internal/runtime/cataloge2e/tier12_runtime_fork_e2e_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/google/uuid"
 
 	"github.com/division-sh/swarm/internal/events"
+	"github.com/division-sh/swarm/internal/events/eventtest"
 	runtimebus "github.com/division-sh/swarm/internal/runtime/bus"
 	runtimeruncontrol "github.com/division-sh/swarm/internal/runtime/runcontrol"
 	"github.com/division-sh/swarm/internal/runtime/runforkadmission"
@@ -432,12 +433,12 @@ func publishCatalogTriggerAtFuture(t testing.TB, h *runtimeHarness, step catalog
 	if future <= time.Second {
 		future = time.Second
 	}
-	evt := events.NewProjectionEvent(eventID,
+	evt := eventtest.Projection(eventID,
 		events.EventType(strings.TrimSpace(step.Event)),
 		"cataloge2e", "", raw, 0, catalogRuntimeRunID, "", events.EventEnvelope{}, time.Now().UTC().Add(future))
 
 	if entityID := triggerPayloadEntityID(payload); entityID != "" {
-		evt = evt.WithEntityID(entityID)
+		evt = eventtest.WithEntityID(evt, entityID)
 	}
 	ctx, cancel := context.WithTimeout(h.ctx, timeout)
 	defer cancel()

--- a/internal/runtime/cataloge2e/tier12_runtime_fork_e2e_test.go
+++ b/internal/runtime/cataloge2e/tier12_runtime_fork_e2e_test.go
@@ -433,13 +433,13 @@ func publishCatalogTriggerAtFuture(t testing.TB, h *runtimeHarness, step catalog
 	if future <= time.Second {
 		future = time.Second
 	}
-	evt := eventtest.Projection(eventID,
-		events.EventType(strings.TrimSpace(step.Event)),
-		"cataloge2e", "", raw, 0, catalogRuntimeRunID, "", events.EventEnvelope{}, time.Now().UTC().Add(future))
-
+	eventEnvelope := events.EventEnvelope{}
 	if entityID := triggerPayloadEntityID(payload); entityID != "" {
-		evt = eventtest.WithEntityID(evt, entityID)
+		eventEnvelope = events.EnvelopeForEntityID(eventEnvelope, entityID)
 	}
+	evt := eventtest.RootIngress(eventID,
+		events.EventType(strings.TrimSpace(step.Event)),
+		"cataloge2e", "", raw, 0, catalogRuntimeRunID, "", eventEnvelope, time.Now().UTC().Add(future))
 	ctx, cancel := context.WithTimeout(h.ctx, timeout)
 	defer cancel()
 	if err := h.publishBusEvent(ctx, evt); err != nil {

--- a/internal/runtime/conformance/delivery_lifecycle_conformance_test.go
+++ b/internal/runtime/conformance/delivery_lifecycle_conformance_test.go
@@ -262,9 +262,18 @@ func (fx *deliveryLifecycleFixture) publishDirectEvent(t *testing.T, ctx context
 	ch := fx.bus.Subscribe(fx.agentID)
 	defer fx.bus.Unsubscribe(fx.agentID)
 
-	evt := eventtest.WithEntityID((events.NewRootIngressEvent(eventID,
+	evt := eventtest.RootIngress(
+		eventID,
 		events.EventType("review.requested"),
-		"runtime", "", []byte(`{"ok":true}`), 0, "", "", events.EventEnvelope{}, time.Now().Add(-2*time.Hour).UTC())), uuid.NewString())
+		"runtime",
+		"",
+		[]byte(`{"ok":true}`),
+		0,
+		"",
+		"",
+		events.EnvelopeForEntityID(events.EventEnvelope{}, uuid.NewString()),
+		time.Now().Add(-2*time.Hour).UTC(),
+	)
 
 	if err := fx.bus.PublishDirect(ctx, evt, []string{fx.agentID}); err != nil {
 		t.Fatalf("PublishDirect: %v", err)

--- a/internal/runtime/conformance/delivery_lifecycle_conformance_test.go
+++ b/internal/runtime/conformance/delivery_lifecycle_conformance_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/division-sh/swarm/internal/events"
+	"github.com/division-sh/swarm/internal/events/eventtest"
 	runtimebus "github.com/division-sh/swarm/internal/runtime/bus"
 	runtimeactors "github.com/division-sh/swarm/internal/runtime/core/actors"
 	runtimemanager "github.com/division-sh/swarm/internal/runtime/manager"
@@ -261,9 +262,10 @@ func (fx *deliveryLifecycleFixture) publishDirectEvent(t *testing.T, ctx context
 	ch := fx.bus.Subscribe(fx.agentID)
 	defer fx.bus.Unsubscribe(fx.agentID)
 
-	evt := (events.NewRootIngressEvent(eventID,
+	evt := eventtest.WithEntityID((events.NewRootIngressEvent(eventID,
 		events.EventType("review.requested"),
-		"runtime", "", []byte(`{"ok":true}`), 0, "", "", events.EventEnvelope{}, time.Now().Add(-2*time.Hour).UTC())).WithEntityID(uuid.NewString())
+		"runtime", "", []byte(`{"ok":true}`), 0, "", "", events.EventEnvelope{}, time.Now().Add(-2*time.Hour).UTC())), uuid.NewString())
+
 	if err := fx.bus.PublishDirect(ctx, evt, []string{fx.agentID}); err != nil {
 		t.Fatalf("PublishDirect: %v", err)
 	}

--- a/internal/runtime/conformance/persisted_surfaces_test.go
+++ b/internal/runtime/conformance/persisted_surfaces_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/division-sh/swarm/internal/config"
 	dashboardserver "github.com/division-sh/swarm/internal/dashboard/server"
 	"github.com/division-sh/swarm/internal/events"
+	"github.com/division-sh/swarm/internal/events/eventtest"
 	runtimepkg "github.com/division-sh/swarm/internal/runtime"
 	runtimebus "github.com/division-sh/swarm/internal/runtime/bus"
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
@@ -224,12 +225,12 @@ func TestReusedLiveSessionKeepsDeliveryFrontierBoundToCanonicalSession(t *testin
 		t.Fatalf("seed run: %v", err)
 	}
 
-	event1 := events.NewProjectionEvent(uuid.NewString(),
+	event1 := eventtest.Projection(uuid.NewString(),
 
 		events.EventType("review.requested"),
 		"runtime", "", []byte(`{"turn":1}`), 0, runID, "", events.EventEnvelope{}, time.Now().Add(-2*time.Minute).UTC())
 
-	event2 := events.NewProjectionEvent(uuid.NewString(),
+	event2 := eventtest.Projection(uuid.NewString(),
 
 		events.EventType("review.requested"),
 		"runtime", "", []byte(`{"turn":2}`), 0, runID, "", events.EventEnvelope{}, time.Now().Add(-1*time.Minute).UTC())
@@ -381,7 +382,7 @@ func TestRotatedLiveSessionRebindsDeliveryFrontierToSuccessorSession(t *testing.
 	}
 
 	eventID := uuid.NewString()
-	evt := events.NewProjectionEvent(eventID,
+	evt := eventtest.Projection(eventID,
 
 		events.EventType("review.requested"),
 		"runtime", "", []byte(`{"turn":1}`), 0, runID, "", events.EventEnvelope{}, time.Now().UTC())
@@ -809,8 +810,8 @@ func TestAccumulatorCompletionOutcomeSurface_RoundTripsThroughObservabilityReade
 		if err != nil {
 			t.Fatalf("marshal payload: %v", err)
 		}
-		if err := rt.Bus.Publish(ctx, (events.NewProjectionEvent(uuid.NewString(),
-			events.EventType("score.received"), "", "", payload, 0, "", "", events.EventEnvelope{}, time.Now().UTC().Add(time.Duration(idx)*time.Millisecond))).WithEntityID(entityID)); err != nil {
+		if err := rt.Bus.Publish(ctx, eventtest.WithEntityID((eventtest.Projection(uuid.NewString(),
+			events.EventType("score.received"), "", "", payload, 0, "", "", events.EventEnvelope{}, time.Now().UTC().Add(time.Duration(idx)*time.Millisecond))), entityID)); err != nil {
 			t.Fatalf("Publish(%d): %v", idx, err)
 		}
 	}
@@ -1229,7 +1230,7 @@ func TestStartupRecoveryFailurePlatformEventSurface_PreservesRecoveryFailedWitho
 	eventStore := conformanceRecoveryFailureEventStore{
 		store: pg,
 		missing: []events.PersistedReplayEvent{{
-			Event: events.NewProjectionEvent(uuid.NewString(),
+			Event: eventtest.Projection(uuid.NewString(),
 				events.EventType("support.item_created"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Now().Add(-time.Minute).UTC()),
 		}},
 		claimErr: errors.New("claim failed"),
@@ -1593,10 +1594,10 @@ func TestStartupManagerReplayAftermathSurface_RoundTripsThroughObservabilityRead
 		}},
 		pending: map[string][]events.Event{
 			"agent-a": {
-				events.NewProjectionEvent("evt-replay", events.EventType("support.replay.ok"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Now().Add(-4*time.Minute).UTC()),
-				events.NewProjectionEvent("evt-skip", events.EventType("support.replay.skip"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Now().Add(-3*time.Minute).UTC()),
-				events.NewProjectionEvent("evt-leased", events.EventType("support.replay.leased"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Now().Add(-2*time.Minute).UTC()),
-				events.NewProjectionEvent("evt-drop", events.EventType("support.replay.drop"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Now().Add(-time.Minute).UTC()),
+				eventtest.Projection("evt-replay", events.EventType("support.replay.ok"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Now().Add(-4*time.Minute).UTC()),
+				eventtest.Projection("evt-skip", events.EventType("support.replay.skip"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Now().Add(-3*time.Minute).UTC()),
+				eventtest.Projection("evt-leased", events.EventType("support.replay.leased"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Now().Add(-2*time.Minute).UTC()),
+				eventtest.Projection("evt-drop", events.EventType("support.replay.drop"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Now().Add(-time.Minute).UTC()),
 			},
 		},
 		receipts: map[string]runtimemanager.EventReceipt{
@@ -1729,17 +1730,15 @@ func TestStartupPipelineReplayAftermathSurface_RoundTripsThroughObservabilityRea
 	replayRunID := uuid.NewString()
 	replayParentID := uuid.NewString()
 	replayChildID := uuid.NewString()
-	if err := pg.AppendEvent(ctx, events.NewProjectionEvent(replayParentID,
+	if err := pg.AppendEvent(ctx, eventtest.Projection(replayParentID,
 		events.EventType("system.parent"),
-		"runtime", "", []byte(`{"ok":true}`), 0, replayRunID, "", events.EventEnvelope{}, time.Now().Add(-3*time.Minute).UTC()),
-	); err != nil {
+		"runtime", "", []byte(`{"ok":true}`), 0, replayRunID, "", events.EventEnvelope{}, time.Now().Add(-3*time.Minute).UTC())); err != nil {
 		t.Fatalf("AppendEvent(replay parent): %v", err)
 	}
-	if err := pg.AppendEvent(ctx, events.NewProjectionEvent(replayChildID,
+	if err := pg.AppendEvent(ctx, eventtest.Projection(replayChildID,
 		events.EventType("system.recover.replay"),
 		"runtime", "", []byte(`{"ok":true}`), 0, replayRunID,
-		replayParentID, events.EventEnvelope{}, time.Now().Add(-2*time.Minute).UTC()),
-	); err != nil {
+		replayParentID, events.EventEnvelope{}, time.Now().Add(-2*time.Minute).UTC())); err != nil {
 		t.Fatalf("AppendEvent(replay child): %v", err)
 	}
 	if err := pg.InsertEventDeliveries(ctx, replayChildID, []string{replayRecipient}); err != nil {
@@ -1755,17 +1754,15 @@ func TestStartupPipelineReplayAftermathSurface_RoundTripsThroughObservabilityRea
 	skipRunID := uuid.NewString()
 	skipParentID := uuid.NewString()
 	skipChildID := uuid.NewString()
-	if err := pg.AppendEvent(ctx, events.NewProjectionEvent(skipParentID,
+	if err := pg.AppendEvent(ctx, eventtest.Projection(skipParentID,
 		events.EventType("system.parent"),
-		"runtime", "", []byte(`{"ok":true}`), 0, skipRunID, "", events.EventEnvelope{}, time.Now().Add(-3*time.Minute).UTC()),
-	); err != nil {
+		"runtime", "", []byte(`{"ok":true}`), 0, skipRunID, "", events.EventEnvelope{}, time.Now().Add(-3*time.Minute).UTC())); err != nil {
 		t.Fatalf("AppendEvent(skip parent): %v", err)
 	}
-	if err := pg.AppendEvent(ctx, events.NewProjectionEvent(skipChildID,
+	if err := pg.AppendEvent(ctx, eventtest.Projection(skipChildID,
 		events.EventType("system.recover.skip"),
 		"runtime", "", []byte(`{"ok":true}`), 0, skipRunID,
-		skipParentID, events.EventEnvelope{}, time.Now().Add(-2*time.Minute).UTC()),
-	); err != nil {
+		skipParentID, events.EventEnvelope{}, time.Now().Add(-2*time.Minute).UTC())); err != nil {
 		t.Fatalf("AppendEvent(skip child): %v", err)
 	}
 	if err := pg.UpsertCommittedReplayScope(ctx, skipChildID, runtimereplayclaim.CommittedReplayScopeDirect); err != nil {

--- a/internal/runtime/conformance/persisted_surfaces_test.go
+++ b/internal/runtime/conformance/persisted_surfaces_test.go
@@ -810,7 +810,7 @@ func TestAccumulatorCompletionOutcomeSurface_RoundTripsThroughObservabilityReade
 		if err != nil {
 			t.Fatalf("marshal payload: %v", err)
 		}
-		if err := rt.Bus.Publish(ctx, eventtest.PersistedProjection(
+		if err := rt.Bus.Publish(ctx, eventtest.RootIngress(
 			uuid.NewString(),
 			events.EventType("score.received"),
 			"",

--- a/internal/runtime/conformance/persisted_surfaces_test.go
+++ b/internal/runtime/conformance/persisted_surfaces_test.go
@@ -225,12 +225,12 @@ func TestReusedLiveSessionKeepsDeliveryFrontierBoundToCanonicalSession(t *testin
 		t.Fatalf("seed run: %v", err)
 	}
 
-	event1 := eventtest.Projection(uuid.NewString(),
+	event1 := eventtest.PersistedProjection(uuid.NewString(),
 
 		events.EventType("review.requested"),
 		"runtime", "", []byte(`{"turn":1}`), 0, runID, "", events.EventEnvelope{}, time.Now().Add(-2*time.Minute).UTC())
 
-	event2 := eventtest.Projection(uuid.NewString(),
+	event2 := eventtest.PersistedProjection(uuid.NewString(),
 
 		events.EventType("review.requested"),
 		"runtime", "", []byte(`{"turn":2}`), 0, runID, "", events.EventEnvelope{}, time.Now().Add(-1*time.Minute).UTC())
@@ -382,7 +382,7 @@ func TestRotatedLiveSessionRebindsDeliveryFrontierToSuccessorSession(t *testing.
 	}
 
 	eventID := uuid.NewString()
-	evt := eventtest.Projection(eventID,
+	evt := eventtest.PersistedProjection(eventID,
 
 		events.EventType("review.requested"),
 		"runtime", "", []byte(`{"turn":1}`), 0, runID, "", events.EventEnvelope{}, time.Now().UTC())
@@ -810,8 +810,18 @@ func TestAccumulatorCompletionOutcomeSurface_RoundTripsThroughObservabilityReade
 		if err != nil {
 			t.Fatalf("marshal payload: %v", err)
 		}
-		if err := rt.Bus.Publish(ctx, eventtest.WithEntityID((eventtest.Projection(uuid.NewString(),
-			events.EventType("score.received"), "", "", payload, 0, "", "", events.EventEnvelope{}, time.Now().UTC().Add(time.Duration(idx)*time.Millisecond))), entityID)); err != nil {
+		if err := rt.Bus.Publish(ctx, eventtest.PersistedProjection(
+			uuid.NewString(),
+			events.EventType("score.received"),
+			"",
+			"",
+			payload,
+			0,
+			"",
+			"",
+			events.EnvelopeForEntityID(events.EventEnvelope{}, entityID),
+			time.Now().UTC().Add(time.Duration(idx)*time.Millisecond),
+		)); err != nil {
 			t.Fatalf("Publish(%d): %v", idx, err)
 		}
 	}
@@ -1230,7 +1240,7 @@ func TestStartupRecoveryFailurePlatformEventSurface_PreservesRecoveryFailedWitho
 	eventStore := conformanceRecoveryFailureEventStore{
 		store: pg,
 		missing: []events.PersistedReplayEvent{{
-			Event: eventtest.Projection(uuid.NewString(),
+			Event: eventtest.PersistedProjection(uuid.NewString(),
 				events.EventType("support.item_created"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Now().Add(-time.Minute).UTC()),
 		}},
 		claimErr: errors.New("claim failed"),
@@ -1594,10 +1604,10 @@ func TestStartupManagerReplayAftermathSurface_RoundTripsThroughObservabilityRead
 		}},
 		pending: map[string][]events.Event{
 			"agent-a": {
-				eventtest.Projection("evt-replay", events.EventType("support.replay.ok"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Now().Add(-4*time.Minute).UTC()),
-				eventtest.Projection("evt-skip", events.EventType("support.replay.skip"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Now().Add(-3*time.Minute).UTC()),
-				eventtest.Projection("evt-leased", events.EventType("support.replay.leased"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Now().Add(-2*time.Minute).UTC()),
-				eventtest.Projection("evt-drop", events.EventType("support.replay.drop"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Now().Add(-time.Minute).UTC()),
+				eventtest.PersistedProjection("evt-replay", events.EventType("support.replay.ok"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Now().Add(-4*time.Minute).UTC()),
+				eventtest.PersistedProjection("evt-skip", events.EventType("support.replay.skip"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Now().Add(-3*time.Minute).UTC()),
+				eventtest.PersistedProjection("evt-leased", events.EventType("support.replay.leased"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Now().Add(-2*time.Minute).UTC()),
+				eventtest.PersistedProjection("evt-drop", events.EventType("support.replay.drop"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Now().Add(-time.Minute).UTC()),
 			},
 		},
 		receipts: map[string]runtimemanager.EventReceipt{
@@ -1730,12 +1740,12 @@ func TestStartupPipelineReplayAftermathSurface_RoundTripsThroughObservabilityRea
 	replayRunID := uuid.NewString()
 	replayParentID := uuid.NewString()
 	replayChildID := uuid.NewString()
-	if err := pg.AppendEvent(ctx, eventtest.Projection(replayParentID,
+	if err := pg.AppendEvent(ctx, eventtest.PersistedProjection(replayParentID,
 		events.EventType("system.parent"),
 		"runtime", "", []byte(`{"ok":true}`), 0, replayRunID, "", events.EventEnvelope{}, time.Now().Add(-3*time.Minute).UTC())); err != nil {
 		t.Fatalf("AppendEvent(replay parent): %v", err)
 	}
-	if err := pg.AppendEvent(ctx, eventtest.Projection(replayChildID,
+	if err := pg.AppendEvent(ctx, eventtest.PersistedProjection(replayChildID,
 		events.EventType("system.recover.replay"),
 		"runtime", "", []byte(`{"ok":true}`), 0, replayRunID,
 		replayParentID, events.EventEnvelope{}, time.Now().Add(-2*time.Minute).UTC())); err != nil {
@@ -1754,12 +1764,12 @@ func TestStartupPipelineReplayAftermathSurface_RoundTripsThroughObservabilityRea
 	skipRunID := uuid.NewString()
 	skipParentID := uuid.NewString()
 	skipChildID := uuid.NewString()
-	if err := pg.AppendEvent(ctx, eventtest.Projection(skipParentID,
+	if err := pg.AppendEvent(ctx, eventtest.PersistedProjection(skipParentID,
 		events.EventType("system.parent"),
 		"runtime", "", []byte(`{"ok":true}`), 0, skipRunID, "", events.EventEnvelope{}, time.Now().Add(-3*time.Minute).UTC())); err != nil {
 		t.Fatalf("AppendEvent(skip parent): %v", err)
 	}
-	if err := pg.AppendEvent(ctx, eventtest.Projection(skipChildID,
+	if err := pg.AppendEvent(ctx, eventtest.PersistedProjection(skipChildID,
 		events.EventType("system.recover.skip"),
 		"runtime", "", []byte(`{"ok":true}`), 0, skipRunID,
 		skipParentID, events.EventEnvelope{}, time.Now().Add(-2*time.Minute).UTC())); err != nil {

--- a/internal/runtime/core/pinrouting/pinrouting_test.go
+++ b/internal/runtime/core/pinrouting/pinrouting_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/division-sh/swarm/internal/events"
+	"github.com/division-sh/swarm/internal/events/eventtest"
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
 	runtimeflowidentity "github.com/division-sh/swarm/internal/runtime/core/flowidentity"
 	"github.com/division-sh/swarm/internal/runtime/flowmodel"
@@ -24,7 +25,7 @@ func TestResolveTargetsCompleteParentRouteForPinDeclaredOutput(t *testing.T) {
 		FlowID:      "child",
 		EventType:   "child.done",
 		ParentRoute: parent,
-	}, events.NewProjectionEvent("", "child.done", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}))
+	}, eventtest.Projection("", "child.done", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}))
 
 	if result.Failure != "" {
 		t.Fatalf("Failure = %q, want empty", result.Failure)
@@ -46,7 +47,7 @@ func TestResolveFailsClosedOnIncompleteParentRouteForPinDeclaredOutput(t *testin
 			FlowID:   "root",
 			EntityID: "parent-ent",
 		},
-	}, events.NewProjectionEvent("", "child.done", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}))
+	}, eventtest.Projection("", "child.done", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}))
 
 	if result.Failure != FailureParentRouteIncomplete {
 		t.Fatalf("Failure = %q, want %q", result.Failure, FailureParentRouteIncomplete)
@@ -63,7 +64,7 @@ func TestResolveAllowsEntityOnlyParentRouteOnlyWhenExplicitlyAllowed(t *testing.
 		FlowID:      "child",
 		EventType:   "child.done",
 		ParentRoute: parent,
-	}, events.NewProjectionEvent("", "child.done", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}))
+	}, eventtest.Projection("", "child.done", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}))
 	if blocked.Failure != FailureParentRouteIncomplete {
 		t.Fatalf("blocked Failure = %q, want %q", blocked.Failure, FailureParentRouteIncomplete)
 	}
@@ -74,7 +75,7 @@ func TestResolveAllowsEntityOnlyParentRouteOnlyWhenExplicitlyAllowed(t *testing.
 		EventType:                  "child.done",
 		ParentRoute:                parent,
 		AllowEntityOnlyParentRoute: true,
-	}, events.NewProjectionEvent("", "child.done", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}))
+	}, eventtest.Projection("", "child.done", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}))
 	if allowed.Failure != "" {
 		t.Fatalf("allowed Failure = %q, want empty", allowed.Failure)
 	}
@@ -98,7 +99,7 @@ func TestResolveFailsClosedForRootPinOutputWithoutTargetMechanism(t *testing.T) 
 	result := Resolve(ResolutionInput{
 		Source:    testRootPinRoutingSource(),
 		EventType: "root.ready",
-	}, events.NewProjectionEvent("", "root.ready", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}))
+	}, eventtest.Projection("", "root.ready", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}))
 
 	if result.Failure != FailureTargetRequiredMissing {
 		t.Fatalf("Failure = %q, want %q", result.Failure, FailureTargetRequiredMissing)
@@ -112,7 +113,7 @@ func TestResolveAllowsRootPinOutputWithRootConnectAuthority(t *testing.T) {
 	result := Resolve(ResolutionInput{
 		Source:    testRootConnectPinRoutingSource(),
 		EventType: "root.ready",
-	}, events.NewProjectionEvent("", "root.ready", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}))
+	}, eventtest.Projection("", "root.ready", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}))
 
 	if result.Failure != "" {
 		t.Fatalf("Failure = %q, want empty", result.Failure)
@@ -132,7 +133,7 @@ func TestResolveFailsClosedForRootProducerBroadcastCommonCompositionPath(t *test
 		Emit: runtimecontracts.EmitSpec{
 			Broadcast: true,
 		},
-	}, events.NewProjectionEvent("", "root.ready", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}))
+	}, eventtest.Projection("", "root.ready", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}))
 
 	if result.Failure != FailureProducerBroadcastCommonPath {
 		t.Fatalf("Failure = %q, want %q", result.Failure, FailureProducerBroadcastCommonPath)
@@ -152,7 +153,7 @@ func TestResolveFailsClosedForRootProducerTargetCommonCompositionPath(t *testing
 				Match: map[string]runtimecontracts.ExpressionValue{"entity_id": runtimecontracts.RefExpression("payload.entity_id")},
 			},
 		},
-	}, events.NewProjectionEvent("", "root.ready", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}))
+	}, eventtest.Projection("", "root.ready", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}))
 
 	if result.Failure != FailureProducerTargetCommonPath {
 		t.Fatalf("Failure = %q, want %q", result.Failure, FailureProducerTargetCommonPath)
@@ -178,7 +179,7 @@ func TestResolveFailsClosedForProducerTargetCommonCompositionPath(t *testing.T) 
 			EntityID:     "entity-1",
 			FlowInstance: "consumer/inst-1",
 		}},
-	}, events.NewProjectionEvent("", "shared.ready", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}))
+	}, eventtest.Projection("", "shared.ready", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}))
 
 	if result.Failure != FailureProducerTargetCommonPath {
 		t.Fatalf("Failure = %q, want %q", result.Failure, FailureProducerTargetCommonPath)
@@ -196,7 +197,7 @@ func TestResolveFailsClosedForProducerBroadcastCommonCompositionPath(t *testing.
 		Emit: runtimecontracts.EmitSpec{
 			Broadcast: true,
 		},
-	}, events.NewProjectionEvent("", "shared.ready", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}))
+	}, eventtest.Projection("", "shared.ready", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}))
 
 	if result.Failure != FailureProducerBroadcastCommonPath {
 		t.Fatalf("Failure = %q, want %q", result.Failure, FailureProducerBroadcastCommonPath)
@@ -222,7 +223,7 @@ func TestResolveFailsClosedForProducerTargetAdaptedConnectCommonPath(t *testing.
 			EntityID:     "entity-1",
 			FlowInstance: "consumer/inst-1",
 		}},
-	}, events.NewProjectionEvent("", "shared.ready", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}))
+	}, eventtest.Projection("", "shared.ready", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}))
 
 	if result.Failure != FailureProducerTargetCommonPath {
 		t.Fatalf("Failure = %q, want %q", result.Failure, FailureProducerTargetCommonPath)
@@ -240,7 +241,7 @@ func TestResolveFailsClosedForProducerBroadcastAdaptedConnectCommonPath(t *testi
 		Emit: runtimecontracts.EmitSpec{
 			Broadcast: true,
 		},
-	}, events.NewProjectionEvent("", "shared.ready", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}))
+	}, eventtest.Projection("", "shared.ready", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}))
 
 	if result.Failure != FailureProducerBroadcastCommonPath {
 		t.Fatalf("Failure = %q, want %q", result.Failure, FailureProducerBroadcastCommonPath)
@@ -284,7 +285,7 @@ func TestResolveAllowsParentConnectToOwnPinDeclaredOutput(t *testing.T) {
 		Source:    testProducerConnectSource(),
 		FlowID:    "producer",
 		EventType: "shared.ready",
-	}, events.NewProjectionEvent("", "shared.ready", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}))
+	}, eventtest.Projection("", "shared.ready", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}))
 
 	if result.Failure != "" {
 		t.Fatalf("Failure = %q, want empty", result.Failure)
@@ -306,7 +307,7 @@ func TestResolveFailsClosedForUnknownProducerTargetFlowEvenWithParentConnect(t *
 			},
 		},
 		MatchValues: map[string]string{"entity_id": "entity-1"},
-	}, events.NewProjectionEvent("", "shared.ready", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}))
+	}, eventtest.Projection("", "shared.ready", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}))
 
 	if result.Failure != FailureTargetUnknownFlow {
 		t.Fatalf("Failure = %q, want %q", result.Failure, FailureTargetUnknownFlow)
@@ -326,7 +327,7 @@ func TestResolveAllowsExplicitInstanceTargetEscape(t *testing.T) {
 				InstanceID: "producer-1",
 			},
 		},
-	}, events.NewProjectionEvent("", "shared.ready", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}))
+	}, eventtest.Projection("", "shared.ready", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}))
 
 	if result.Failure != "" {
 		t.Fatalf("Failure = %q, want empty", result.Failure)
@@ -344,7 +345,7 @@ func TestResolveAllowsBroadcastWhenNoPackageReceiverConsumesOutput(t *testing.T)
 		Emit: runtimecontracts.EmitSpec{
 			Broadcast: true,
 		},
-	}, events.NewProjectionEvent("", "child.done", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}))
+	}, eventtest.Projection("", "child.done", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}))
 
 	if result.Failure != "" {
 		t.Fatalf("Failure = %q, want empty", result.Failure)
@@ -372,7 +373,7 @@ func TestResolveFlowMatchTargetsActiveDynamicInstanceByInstanceID(t *testing.T) 
 		Descriptors: []Descriptor{{
 			FlowInstance: flowInstance,
 		}},
-	}, events.NewProjectionEvent("", "component.service.completed", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}))
+	}, eventtest.Projection("", "component.service.completed", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}))
 
 	if result.Failure != "" {
 		t.Fatalf("Failure = %q, want empty", result.Failure)
@@ -422,7 +423,7 @@ func TestResolveFlowMatchTargetsActiveDynamicInstanceByFlowInstanceAndEntityID(t
 				},
 				MatchValues: map[string]string{tt.matchKey: tt.matchValue},
 				Descriptors: []Descriptor{tt.descriptor},
-			}, events.NewProjectionEvent("", "component.service.completed", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}))
+			}, eventtest.Projection("", "component.service.completed", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}))
 
 			if result.Failure != "" {
 				t.Fatalf("Failure = %q, want empty", result.Failure)
@@ -455,7 +456,7 @@ func TestResolveFlowMatchFailsClosedOnAmbiguousActiveDynamicInstances(t *testing
 			{EntityID: "shared-entity", FlowInstance: "component-scaffold/a"},
 			{EntityID: "shared-entity", FlowInstance: "component-scaffold/b"},
 		},
-	}, events.NewProjectionEvent("", "component.service.completed", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}))
+	}, eventtest.Projection("", "component.service.completed", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}))
 
 	if result.Failure != FailureTargetAmbiguous {
 		t.Fatalf("Failure = %q, want %q", result.Failure, FailureTargetAmbiguous)
@@ -482,7 +483,7 @@ func TestResolveFlowMatchFailsClosedWhenDynamicInstanceDescriptorMissing(t *test
 		Descriptors: []Descriptor{{
 			FlowInstance: "component-scaffold/live",
 		}},
-	}, events.NewProjectionEvent("", "component.service.completed", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}))
+	}, eventtest.Projection("", "component.service.completed", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}))
 
 	if result.Failure != FailureTargetUnreachableNoSub {
 		t.Fatalf("Failure = %q, want %q", result.Failure, FailureTargetUnreachableNoSub)

--- a/internal/runtime/core/pinrouting/pinrouting_test.go
+++ b/internal/runtime/core/pinrouting/pinrouting_test.go
@@ -25,7 +25,7 @@ func TestResolveTargetsCompleteParentRouteForPinDeclaredOutput(t *testing.T) {
 		FlowID:      "child",
 		EventType:   "child.done",
 		ParentRoute: parent,
-	}, eventtest.Projection("", "child.done", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}))
+	}, eventtest.RootIngress("", "child.done", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}))
 
 	if result.Failure != "" {
 		t.Fatalf("Failure = %q, want empty", result.Failure)
@@ -47,7 +47,7 @@ func TestResolveFailsClosedOnIncompleteParentRouteForPinDeclaredOutput(t *testin
 			FlowID:   "root",
 			EntityID: "parent-ent",
 		},
-	}, eventtest.Projection("", "child.done", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}))
+	}, eventtest.RootIngress("", "child.done", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}))
 
 	if result.Failure != FailureParentRouteIncomplete {
 		t.Fatalf("Failure = %q, want %q", result.Failure, FailureParentRouteIncomplete)
@@ -64,7 +64,7 @@ func TestResolveAllowsEntityOnlyParentRouteOnlyWhenExplicitlyAllowed(t *testing.
 		FlowID:      "child",
 		EventType:   "child.done",
 		ParentRoute: parent,
-	}, eventtest.Projection("", "child.done", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}))
+	}, eventtest.RootIngress("", "child.done", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}))
 	if blocked.Failure != FailureParentRouteIncomplete {
 		t.Fatalf("blocked Failure = %q, want %q", blocked.Failure, FailureParentRouteIncomplete)
 	}
@@ -75,7 +75,7 @@ func TestResolveAllowsEntityOnlyParentRouteOnlyWhenExplicitlyAllowed(t *testing.
 		EventType:                  "child.done",
 		ParentRoute:                parent,
 		AllowEntityOnlyParentRoute: true,
-	}, eventtest.Projection("", "child.done", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}))
+	}, eventtest.RootIngress("", "child.done", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}))
 	if allowed.Failure != "" {
 		t.Fatalf("allowed Failure = %q, want empty", allowed.Failure)
 	}
@@ -99,7 +99,7 @@ func TestResolveFailsClosedForRootPinOutputWithoutTargetMechanism(t *testing.T) 
 	result := Resolve(ResolutionInput{
 		Source:    testRootPinRoutingSource(),
 		EventType: "root.ready",
-	}, eventtest.Projection("", "root.ready", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}))
+	}, eventtest.RootIngress("", "root.ready", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}))
 
 	if result.Failure != FailureTargetRequiredMissing {
 		t.Fatalf("Failure = %q, want %q", result.Failure, FailureTargetRequiredMissing)
@@ -113,7 +113,7 @@ func TestResolveAllowsRootPinOutputWithRootConnectAuthority(t *testing.T) {
 	result := Resolve(ResolutionInput{
 		Source:    testRootConnectPinRoutingSource(),
 		EventType: "root.ready",
-	}, eventtest.Projection("", "root.ready", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}))
+	}, eventtest.RootIngress("", "root.ready", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}))
 
 	if result.Failure != "" {
 		t.Fatalf("Failure = %q, want empty", result.Failure)
@@ -133,7 +133,7 @@ func TestResolveFailsClosedForRootProducerBroadcastCommonCompositionPath(t *test
 		Emit: runtimecontracts.EmitSpec{
 			Broadcast: true,
 		},
-	}, eventtest.Projection("", "root.ready", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}))
+	}, eventtest.RootIngress("", "root.ready", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}))
 
 	if result.Failure != FailureProducerBroadcastCommonPath {
 		t.Fatalf("Failure = %q, want %q", result.Failure, FailureProducerBroadcastCommonPath)
@@ -153,7 +153,7 @@ func TestResolveFailsClosedForRootProducerTargetCommonCompositionPath(t *testing
 				Match: map[string]runtimecontracts.ExpressionValue{"entity_id": runtimecontracts.RefExpression("payload.entity_id")},
 			},
 		},
-	}, eventtest.Projection("", "root.ready", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}))
+	}, eventtest.RootIngress("", "root.ready", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}))
 
 	if result.Failure != FailureProducerTargetCommonPath {
 		t.Fatalf("Failure = %q, want %q", result.Failure, FailureProducerTargetCommonPath)
@@ -179,7 +179,7 @@ func TestResolveFailsClosedForProducerTargetCommonCompositionPath(t *testing.T) 
 			EntityID:     "entity-1",
 			FlowInstance: "consumer/inst-1",
 		}},
-	}, eventtest.Projection("", "shared.ready", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}))
+	}, eventtest.RootIngress("", "shared.ready", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}))
 
 	if result.Failure != FailureProducerTargetCommonPath {
 		t.Fatalf("Failure = %q, want %q", result.Failure, FailureProducerTargetCommonPath)
@@ -197,7 +197,7 @@ func TestResolveFailsClosedForProducerBroadcastCommonCompositionPath(t *testing.
 		Emit: runtimecontracts.EmitSpec{
 			Broadcast: true,
 		},
-	}, eventtest.Projection("", "shared.ready", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}))
+	}, eventtest.RootIngress("", "shared.ready", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}))
 
 	if result.Failure != FailureProducerBroadcastCommonPath {
 		t.Fatalf("Failure = %q, want %q", result.Failure, FailureProducerBroadcastCommonPath)
@@ -223,7 +223,7 @@ func TestResolveFailsClosedForProducerTargetAdaptedConnectCommonPath(t *testing.
 			EntityID:     "entity-1",
 			FlowInstance: "consumer/inst-1",
 		}},
-	}, eventtest.Projection("", "shared.ready", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}))
+	}, eventtest.RootIngress("", "shared.ready", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}))
 
 	if result.Failure != FailureProducerTargetCommonPath {
 		t.Fatalf("Failure = %q, want %q", result.Failure, FailureProducerTargetCommonPath)
@@ -241,7 +241,7 @@ func TestResolveFailsClosedForProducerBroadcastAdaptedConnectCommonPath(t *testi
 		Emit: runtimecontracts.EmitSpec{
 			Broadcast: true,
 		},
-	}, eventtest.Projection("", "shared.ready", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}))
+	}, eventtest.RootIngress("", "shared.ready", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}))
 
 	if result.Failure != FailureProducerBroadcastCommonPath {
 		t.Fatalf("Failure = %q, want %q", result.Failure, FailureProducerBroadcastCommonPath)
@@ -285,7 +285,7 @@ func TestResolveAllowsParentConnectToOwnPinDeclaredOutput(t *testing.T) {
 		Source:    testProducerConnectSource(),
 		FlowID:    "producer",
 		EventType: "shared.ready",
-	}, eventtest.Projection("", "shared.ready", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}))
+	}, eventtest.RootIngress("", "shared.ready", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}))
 
 	if result.Failure != "" {
 		t.Fatalf("Failure = %q, want empty", result.Failure)
@@ -307,7 +307,7 @@ func TestResolveFailsClosedForUnknownProducerTargetFlowEvenWithParentConnect(t *
 			},
 		},
 		MatchValues: map[string]string{"entity_id": "entity-1"},
-	}, eventtest.Projection("", "shared.ready", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}))
+	}, eventtest.RootIngress("", "shared.ready", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}))
 
 	if result.Failure != FailureTargetUnknownFlow {
 		t.Fatalf("Failure = %q, want %q", result.Failure, FailureTargetUnknownFlow)
@@ -327,7 +327,7 @@ func TestResolveAllowsExplicitInstanceTargetEscape(t *testing.T) {
 				InstanceID: "producer-1",
 			},
 		},
-	}, eventtest.Projection("", "shared.ready", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}))
+	}, eventtest.RootIngress("", "shared.ready", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}))
 
 	if result.Failure != "" {
 		t.Fatalf("Failure = %q, want empty", result.Failure)
@@ -345,7 +345,7 @@ func TestResolveAllowsBroadcastWhenNoPackageReceiverConsumesOutput(t *testing.T)
 		Emit: runtimecontracts.EmitSpec{
 			Broadcast: true,
 		},
-	}, eventtest.Projection("", "child.done", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}))
+	}, eventtest.RootIngress("", "child.done", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}))
 
 	if result.Failure != "" {
 		t.Fatalf("Failure = %q, want empty", result.Failure)
@@ -373,7 +373,7 @@ func TestResolveFlowMatchTargetsActiveDynamicInstanceByInstanceID(t *testing.T) 
 		Descriptors: []Descriptor{{
 			FlowInstance: flowInstance,
 		}},
-	}, eventtest.Projection("", "component.service.completed", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}))
+	}, eventtest.RootIngress("", "component.service.completed", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}))
 
 	if result.Failure != "" {
 		t.Fatalf("Failure = %q, want empty", result.Failure)
@@ -423,7 +423,7 @@ func TestResolveFlowMatchTargetsActiveDynamicInstanceByFlowInstanceAndEntityID(t
 				},
 				MatchValues: map[string]string{tt.matchKey: tt.matchValue},
 				Descriptors: []Descriptor{tt.descriptor},
-			}, eventtest.Projection("", "component.service.completed", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}))
+			}, eventtest.RootIngress("", "component.service.completed", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}))
 
 			if result.Failure != "" {
 				t.Fatalf("Failure = %q, want empty", result.Failure)
@@ -456,7 +456,7 @@ func TestResolveFlowMatchFailsClosedOnAmbiguousActiveDynamicInstances(t *testing
 			{EntityID: "shared-entity", FlowInstance: "component-scaffold/a"},
 			{EntityID: "shared-entity", FlowInstance: "component-scaffold/b"},
 		},
-	}, eventtest.Projection("", "component.service.completed", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}))
+	}, eventtest.RootIngress("", "component.service.completed", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}))
 
 	if result.Failure != FailureTargetAmbiguous {
 		t.Fatalf("Failure = %q, want %q", result.Failure, FailureTargetAmbiguous)
@@ -483,7 +483,7 @@ func TestResolveFlowMatchFailsClosedWhenDynamicInstanceDescriptorMissing(t *test
 		Descriptors: []Descriptor{{
 			FlowInstance: "component-scaffold/live",
 		}},
-	}, eventtest.Projection("", "component.service.completed", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}))
+	}, eventtest.RootIngress("", "component.service.completed", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}))
 
 	if result.Failure != FailureTargetUnreachableNoSub {
 		t.Fatalf("Failure = %q, want %q", result.Failure, FailureTargetUnreachableNoSub)

--- a/internal/runtime/correlation/context_test.go
+++ b/internal/runtime/correlation/context_test.go
@@ -10,12 +10,12 @@ import (
 )
 
 func TestCorrelateEvent_InheritsRunAndParentWithoutGeneratingTrace(t *testing.T) {
-	inbound := eventtest.Projection("evt-parent",
+	inbound := eventtest.RootIngress("evt-parent",
 		events.EventType("task.started"), "", "", nil, 0, "run-123", "", events.EventEnvelope{}, time.Time{})
 
 	ctx := WithInboundEvent(context.Background(), inbound)
 
-	ctx, child := CorrelateEvent(ctx, eventtest.Projection("evt-child",
+	ctx, child := CorrelateEvent(ctx, eventtest.RootIngress("evt-child",
 		events.EventType("task.completed"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}))
 
 	if got := child.RunID(); got != "run-123" {
@@ -30,7 +30,7 @@ func TestCorrelateEvent_InheritsRunAndParentWithoutGeneratingTrace(t *testing.T)
 }
 
 func TestCorrelateEvent_DoesNotGenerateRunWithoutAdmission(t *testing.T) {
-	ctx, evt := CorrelateEvent(context.Background(), eventtest.Projection("evt-root",
+	ctx, evt := CorrelateEvent(context.Background(), eventtest.RootIngress("evt-root",
 		events.EventType("task.started"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}))
 	if evt.RunID() != "" {
 		t.Fatalf("run_id = %q, want empty before admission", evt.RunID())
@@ -44,7 +44,7 @@ func TestCorrelateEvent_DoesNotGenerateRunWithoutAdmission(t *testing.T) {
 }
 
 func TestCorrelateEvent_PreservesExplicitEventRunID(t *testing.T) {
-	ctx, evt := CorrelateEvent(context.Background(), eventtest.Projection("evt-child",
+	ctx, evt := CorrelateEvent(context.Background(), eventtest.RootIngress("evt-child",
 		events.EventType("task.started"), "", "", nil, 0, "run-explicit", "", events.EventEnvelope{}, time.Time{}))
 	if got := evt.RunID(); got != "run-explicit" {
 		t.Fatalf("event run_id = %q, want run-explicit", got)
@@ -67,7 +67,7 @@ func TestCorrelateEvent_UsesTypedRuntimeLineageParent(t *testing.T) {
 		SelectedForkContext: true,
 	})
 
-	_, child := CorrelateEvent(ctx, eventtest.Projection("evt-child",
+	_, child := CorrelateEvent(ctx, eventtest.RootIngress("evt-child",
 		events.EventType("task.completed"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}))
 
 	if got := child.RunID(); got != "run-fork" {
@@ -85,7 +85,7 @@ func TestCorrelateEvent_DoesNotSelfParentTypedRuntimeLineageSubject(t *testing.T
 		ParentEventID:  "evt-selected",
 	})
 
-	_, selected := CorrelateEvent(ctx, eventtest.Projection("evt-selected",
+	_, selected := CorrelateEvent(ctx, eventtest.RootIngress("evt-selected",
 		events.EventType("validation/validation.package_ready"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}))
 
 	if got := selected.RunID(); got != "run-fork" {
@@ -102,7 +102,7 @@ func TestWithInboundEvent_RefinesTypedRuntimeLineageSubject(t *testing.T) {
 		RunID:               "run-fork",
 		SelectedForkContext: true,
 	})
-	ctx = WithInboundEvent(ctx, eventtest.Projection("evt-selected",
+	ctx = WithInboundEvent(ctx, eventtest.RootIngress("evt-selected",
 		events.EventType("task.assigned"), "", "", nil, 0, "run-fork", "", events.EventEnvelope{}, time.Time{}))
 
 	lineage, ok := RuntimeLineageFromContext(ctx)

--- a/internal/runtime/correlation/context_test.go
+++ b/internal/runtime/correlation/context_test.go
@@ -5,18 +5,18 @@ import (
 	"testing"
 
 	"github.com/division-sh/swarm/internal/events"
+	"github.com/division-sh/swarm/internal/events/eventtest"
 	"time"
 )
 
 func TestCorrelateEvent_InheritsRunAndParentWithoutGeneratingTrace(t *testing.T) {
-	inbound := events.NewProjectionEvent("evt-parent",
+	inbound := eventtest.Projection("evt-parent",
 		events.EventType("task.started"), "", "", nil, 0, "run-123", "", events.EventEnvelope{}, time.Time{})
 
 	ctx := WithInboundEvent(context.Background(), inbound)
 
-	ctx, child := CorrelateEvent(ctx, events.NewProjectionEvent("evt-child",
-		events.EventType("task.completed"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}),
-	)
+	ctx, child := CorrelateEvent(ctx, eventtest.Projection("evt-child",
+		events.EventType("task.completed"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}))
 
 	if got := child.RunID(); got != "run-123" {
 		t.Fatalf("child run_id = %q, want run-123", got)
@@ -30,9 +30,8 @@ func TestCorrelateEvent_InheritsRunAndParentWithoutGeneratingTrace(t *testing.T)
 }
 
 func TestCorrelateEvent_DoesNotGenerateRunWithoutAdmission(t *testing.T) {
-	ctx, evt := CorrelateEvent(context.Background(), events.NewProjectionEvent("evt-root",
-		events.EventType("task.started"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}),
-	)
+	ctx, evt := CorrelateEvent(context.Background(), eventtest.Projection("evt-root",
+		events.EventType("task.started"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}))
 	if evt.RunID() != "" {
 		t.Fatalf("run_id = %q, want empty before admission", evt.RunID())
 	}
@@ -45,9 +44,8 @@ func TestCorrelateEvent_DoesNotGenerateRunWithoutAdmission(t *testing.T) {
 }
 
 func TestCorrelateEvent_PreservesExplicitEventRunID(t *testing.T) {
-	ctx, evt := CorrelateEvent(context.Background(), events.NewProjectionEvent("evt-child",
-		events.EventType("task.started"), "", "", nil, 0, "run-explicit", "", events.EventEnvelope{}, time.Time{}),
-	)
+	ctx, evt := CorrelateEvent(context.Background(), eventtest.Projection("evt-child",
+		events.EventType("task.started"), "", "", nil, 0, "run-explicit", "", events.EventEnvelope{}, time.Time{}))
 	if got := evt.RunID(); got != "run-explicit" {
 		t.Fatalf("event run_id = %q, want run-explicit", got)
 	}
@@ -69,9 +67,8 @@ func TestCorrelateEvent_UsesTypedRuntimeLineageParent(t *testing.T) {
 		SelectedForkContext: true,
 	})
 
-	_, child := CorrelateEvent(ctx, events.NewProjectionEvent("evt-child",
-		events.EventType("task.completed"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}),
-	)
+	_, child := CorrelateEvent(ctx, eventtest.Projection("evt-child",
+		events.EventType("task.completed"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}))
 
 	if got := child.RunID(); got != "run-fork" {
 		t.Fatalf("child run_id = %q, want run-fork", got)
@@ -88,9 +85,8 @@ func TestCorrelateEvent_DoesNotSelfParentTypedRuntimeLineageSubject(t *testing.T
 		ParentEventID:  "evt-selected",
 	})
 
-	_, selected := CorrelateEvent(ctx, events.NewProjectionEvent("evt-selected",
-		events.EventType("validation/validation.package_ready"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}),
-	)
+	_, selected := CorrelateEvent(ctx, eventtest.Projection("evt-selected",
+		events.EventType("validation/validation.package_ready"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}))
 
 	if got := selected.RunID(); got != "run-fork" {
 		t.Fatalf("selected run_id = %q, want run-fork", got)
@@ -106,9 +102,8 @@ func TestWithInboundEvent_RefinesTypedRuntimeLineageSubject(t *testing.T) {
 		RunID:               "run-fork",
 		SelectedForkContext: true,
 	})
-	ctx = WithInboundEvent(ctx, events.NewProjectionEvent("evt-selected",
-		events.EventType("task.assigned"), "", "", nil, 0, "run-fork", "", events.EventEnvelope{}, time.Time{}),
-	)
+	ctx = WithInboundEvent(ctx, eventtest.Projection("evt-selected",
+		events.EventType("task.assigned"), "", "", nil, 0, "run-fork", "", events.EventEnvelope{}, time.Time{}))
 
 	lineage, ok := RuntimeLineageFromContext(ctx)
 	if !ok {

--- a/internal/runtime/engine/declarative_node_test.go
+++ b/internal/runtime/engine/declarative_node_test.go
@@ -75,7 +75,7 @@ func TestDeclarativeNode_HandleResolvesHandlerFromSemanticSource(t *testing.T) {
 	result, err := node.Handle(context.Background(), ExecutionRequest{
 		EntityID: "entity-1",
 		FlowID:   "flow-1",
-		Event:    eventtest.Projection("evt-1", "task.completed", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}),
+		Event:    eventtest.RootIngress("evt-1", "task.completed", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}),
 		State:    StateSnapshot{CurrentState: "pending"},
 	})
 	if err != nil {
@@ -101,7 +101,7 @@ func TestDeclarativeNode_HandleRequiresHandlerWhenNotResolvable(t *testing.T) {
 	node := NewDeclarativeNode("node-a", exec)
 	_, err = node.Handle(context.Background(), ExecutionRequest{
 		EntityID: "entity-1",
-		Event:    eventtest.Projection("", "task.completed", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}),
+		Event:    eventtest.RootIngress("", "task.completed", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}),
 	})
 	if err != ErrMissingNodeHandler {
 		t.Fatalf("Handle error = %v, want %v", err, ErrMissingNodeHandler)
@@ -123,7 +123,7 @@ func TestDeclarativeNode_HandleUsesExplicitHandlerWithoutLookup(t *testing.T) {
 	node := NewDeclarativeNode("node-a", exec)
 	result, err := node.Handle(context.Background(), ExecutionRequest{
 		EntityID: "entity-1",
-		Event:    eventtest.Projection("", "task.completed", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}),
+		Event:    eventtest.RootIngress("", "task.completed", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}),
 		Handler:  runtimecontracts.SystemNodeEventHandler{ClearGates: []string{"gate_a"}},
 		State:    StateSnapshot{StateCarrier: NewStateCarrier(nil, map[string]bool{"gate_a": true}, nil)},
 	})

--- a/internal/runtime/engine/declarative_node_test.go
+++ b/internal/runtime/engine/declarative_node_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/division-sh/swarm/internal/events"
+	"github.com/division-sh/swarm/internal/events/eventtest"
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
 	"github.com/division-sh/swarm/internal/runtime/semanticview"
 )
@@ -74,7 +75,7 @@ func TestDeclarativeNode_HandleResolvesHandlerFromSemanticSource(t *testing.T) {
 	result, err := node.Handle(context.Background(), ExecutionRequest{
 		EntityID: "entity-1",
 		FlowID:   "flow-1",
-		Event:    events.NewProjectionEvent("evt-1", "task.completed", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}),
+		Event:    eventtest.Projection("evt-1", "task.completed", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}),
 		State:    StateSnapshot{CurrentState: "pending"},
 	})
 	if err != nil {
@@ -100,7 +101,7 @@ func TestDeclarativeNode_HandleRequiresHandlerWhenNotResolvable(t *testing.T) {
 	node := NewDeclarativeNode("node-a", exec)
 	_, err = node.Handle(context.Background(), ExecutionRequest{
 		EntityID: "entity-1",
-		Event:    events.NewProjectionEvent("", "task.completed", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}),
+		Event:    eventtest.Projection("", "task.completed", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}),
 	})
 	if err != ErrMissingNodeHandler {
 		t.Fatalf("Handle error = %v, want %v", err, ErrMissingNodeHandler)
@@ -122,7 +123,7 @@ func TestDeclarativeNode_HandleUsesExplicitHandlerWithoutLookup(t *testing.T) {
 	node := NewDeclarativeNode("node-a", exec)
 	result, err := node.Handle(context.Background(), ExecutionRequest{
 		EntityID: "entity-1",
-		Event:    events.NewProjectionEvent("", "task.completed", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}),
+		Event:    eventtest.Projection("", "task.completed", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}),
 		Handler:  runtimecontracts.SystemNodeEventHandler{ClearGates: []string{"gate_a"}},
 		State:    StateSnapshot{StateCarrier: NewStateCarrier(nil, map[string]bool{"gate_a": true}, nil)},
 	})

--- a/internal/runtime/engine/executor_enforcement_test.go
+++ b/internal/runtime/engine/executor_enforcement_test.go
@@ -109,7 +109,7 @@ func TestExecutor_RejectsInvalidAdvancesToTransition(t *testing.T) {
 		EntityID: "entity-1",
 		NodeID:   "node-1",
 		FlowID:   "flow-1",
-		Event:    eventtest.Projection("evt-1", "task.completed", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Now().UTC()),
+		Event:    eventtest.RootIngress("evt-1", "task.completed", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Now().UTC()),
 		Handler: runtimecontracts.SystemNodeEventHandler{
 			AdvancesTo: "unreachable_state",
 		},
@@ -156,7 +156,7 @@ func TestExecutor_GuardBlocksTransitionForTerminalState(t *testing.T) {
 		EntityID: "entity-1",
 		NodeID:   "node-1",
 		FlowID:   "flow-1",
-		Event:    eventtest.Projection("evt-1", "task.completed", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Now().UTC()),
+		Event:    eventtest.RootIngress("evt-1", "task.completed", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Now().UTC()),
 		Handler: runtimecontracts.SystemNodeEventHandler{
 			Guard:      &runtimecontracts.GuardSpec{ID: "not_in_terminal_state"},
 			AdvancesTo: "reopened",
@@ -196,7 +196,7 @@ func TestExecutor_CELGuardEvaluatesAgainstEntityState(t *testing.T) {
 		EntityID: "entity-1",
 		NodeID:   "node-1",
 		FlowID:   "flow-1",
-		Event:    eventtest.Projection("evt-1", "task.completed", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Now().UTC()),
+		Event:    eventtest.RootIngress("evt-1", "task.completed", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Now().UTC()),
 		Handler: runtimecontracts.SystemNodeEventHandler{
 			Guard: &runtimecontracts.GuardSpec{
 				Check:  "entity.score >= 75",
@@ -216,7 +216,7 @@ func TestExecutor_CELGuardEvaluatesAgainstEntityState(t *testing.T) {
 		EntityID: "entity-1",
 		NodeID:   "node-1",
 		FlowID:   "flow-1",
-		Event:    eventtest.Projection("evt-2", "task.completed", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Now().UTC()),
+		Event:    eventtest.RootIngress("evt-2", "task.completed", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Now().UTC()),
 		Handler: runtimecontracts.SystemNodeEventHandler{
 			Guard: &runtimecontracts.GuardSpec{
 				Check:  "entity.score >= 75",
@@ -272,7 +272,7 @@ func TestExecutor_AccumulateOnTimeoutAppliesRule(t *testing.T) {
 	result, err := exec.Execute(context.Background(), ExecutionRequest{
 		EntityID: "entity-1",
 		NodeID:   "node-1",
-		Event: eventtest.Projection("timeout-1",
+		Event: eventtest.RootIngress("timeout-1",
 			events.EventType("accumulate.timeout"), "", "", mustEncodeJSON(t, map[string]any{
 				"timer_handle": map[string]any{
 					"kind": "accumulation_timeout",
@@ -342,7 +342,7 @@ func TestExecutor_OnCompleteRuleComputeAppliesValue(t *testing.T) {
 	result, err := exec.Execute(context.Background(), ExecutionRequest{
 		EntityID: "ent-1",
 		NodeID:   "node-1",
-		Event: eventtest.Projection("evt-1",
+		Event: eventtest.RootIngress("evt-1",
 			"item.evaluated", "", "", json.RawMessage(`{"entity_id":"ent-1","score":80}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC()),
 
 		Handler: runtimecontracts.SystemNodeEventHandler{
@@ -405,7 +405,7 @@ func TestExecutor_AccumulationDeduplicatesRepeatedEvent(t *testing.T) {
 		EntityID: "entity-1",
 		NodeID:   "node-1",
 		FlowID:   "flow-1",
-		Event: eventtest.Projection("evt-1",
+		Event: eventtest.RootIngress("evt-1",
 			"task.completed", "", "", json.RawMessage(`{"item_id":"item-1"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC()),
 
 		Handler: runtimecontracts.SystemNodeEventHandler{

--- a/internal/runtime/engine/executor_enforcement_test.go
+++ b/internal/runtime/engine/executor_enforcement_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/division-sh/swarm/internal/events"
+	"github.com/division-sh/swarm/internal/events/eventtest"
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
 	"github.com/division-sh/swarm/internal/runtime/core/identity"
 	runtimeregistry "github.com/division-sh/swarm/internal/runtime/core/registry"
@@ -108,7 +109,7 @@ func TestExecutor_RejectsInvalidAdvancesToTransition(t *testing.T) {
 		EntityID: "entity-1",
 		NodeID:   "node-1",
 		FlowID:   "flow-1",
-		Event:    events.NewProjectionEvent("evt-1", "task.completed", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Now().UTC()),
+		Event:    eventtest.Projection("evt-1", "task.completed", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Now().UTC()),
 		Handler: runtimecontracts.SystemNodeEventHandler{
 			AdvancesTo: "unreachable_state",
 		},
@@ -155,7 +156,7 @@ func TestExecutor_GuardBlocksTransitionForTerminalState(t *testing.T) {
 		EntityID: "entity-1",
 		NodeID:   "node-1",
 		FlowID:   "flow-1",
-		Event:    events.NewProjectionEvent("evt-1", "task.completed", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Now().UTC()),
+		Event:    eventtest.Projection("evt-1", "task.completed", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Now().UTC()),
 		Handler: runtimecontracts.SystemNodeEventHandler{
 			Guard:      &runtimecontracts.GuardSpec{ID: "not_in_terminal_state"},
 			AdvancesTo: "reopened",
@@ -195,7 +196,7 @@ func TestExecutor_CELGuardEvaluatesAgainstEntityState(t *testing.T) {
 		EntityID: "entity-1",
 		NodeID:   "node-1",
 		FlowID:   "flow-1",
-		Event:    events.NewProjectionEvent("evt-1", "task.completed", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Now().UTC()),
+		Event:    eventtest.Projection("evt-1", "task.completed", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Now().UTC()),
 		Handler: runtimecontracts.SystemNodeEventHandler{
 			Guard: &runtimecontracts.GuardSpec{
 				Check:  "entity.score >= 75",
@@ -215,7 +216,7 @@ func TestExecutor_CELGuardEvaluatesAgainstEntityState(t *testing.T) {
 		EntityID: "entity-1",
 		NodeID:   "node-1",
 		FlowID:   "flow-1",
-		Event:    events.NewProjectionEvent("evt-2", "task.completed", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Now().UTC()),
+		Event:    eventtest.Projection("evt-2", "task.completed", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Now().UTC()),
 		Handler: runtimecontracts.SystemNodeEventHandler{
 			Guard: &runtimecontracts.GuardSpec{
 				Check:  "entity.score >= 75",
@@ -271,7 +272,7 @@ func TestExecutor_AccumulateOnTimeoutAppliesRule(t *testing.T) {
 	result, err := exec.Execute(context.Background(), ExecutionRequest{
 		EntityID: "entity-1",
 		NodeID:   "node-1",
-		Event: events.NewProjectionEvent("timeout-1",
+		Event: eventtest.Projection("timeout-1",
 			events.EventType("accumulate.timeout"), "", "", mustEncodeJSON(t, map[string]any{
 				"timer_handle": map[string]any{
 					"kind": "accumulation_timeout",
@@ -341,7 +342,7 @@ func TestExecutor_OnCompleteRuleComputeAppliesValue(t *testing.T) {
 	result, err := exec.Execute(context.Background(), ExecutionRequest{
 		EntityID: "ent-1",
 		NodeID:   "node-1",
-		Event: events.NewProjectionEvent("evt-1",
+		Event: eventtest.Projection("evt-1",
 			"item.evaluated", "", "", json.RawMessage(`{"entity_id":"ent-1","score":80}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC()),
 
 		Handler: runtimecontracts.SystemNodeEventHandler{
@@ -404,7 +405,7 @@ func TestExecutor_AccumulationDeduplicatesRepeatedEvent(t *testing.T) {
 		EntityID: "entity-1",
 		NodeID:   "node-1",
 		FlowID:   "flow-1",
-		Event: events.NewProjectionEvent("evt-1",
+		Event: eventtest.Projection("evt-1",
 			"task.completed", "", "", json.RawMessage(`{"item_id":"item-1"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC()),
 
 		Handler: runtimecontracts.SystemNodeEventHandler{

--- a/internal/runtime/engine/executor_test.go
+++ b/internal/runtime/engine/executor_test.go
@@ -524,9 +524,18 @@ func TestExecutor_LoadsStateInsideEntityLock(t *testing.T) {
 		EntityID: identity.NormalizeEntityID("11111111-1111-1111-1111-111111111111"),
 		NodeID:   identity.NodeID("node-1"),
 		FlowID:   identity.FlowID("flow-1"),
-		Event: eventtest.WithEntityID(eventtest.Projection("evt-1",
-			events.EventType("test.event"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Now().UTC()),
-			"11111111-1111-1111-1111-111111111111"),
+		Event: eventtest.RootIngress(
+			"evt-1",
+			events.EventType("test.event"),
+			"",
+			"",
+			nil,
+			0,
+			"",
+			"",
+			events.EnvelopeForEntityID(events.EventEnvelope{}, "11111111-1111-1111-1111-111111111111"),
+			time.Now().UTC(),
+		),
 
 		State: StateSnapshot{StateCarrier: NewStateCarrier(map[string]any{}, nil, map[string]map[string]any{})},
 	})
@@ -585,9 +594,18 @@ func TestExecutor_ShapeEmitPayloadUsesUpdatedState(t *testing.T) {
 		EntityID: identity.NormalizeEntityID("11111111-1111-1111-1111-111111111111"),
 		NodeID:   identity.NodeID("scoring-node"),
 		FlowID:   identity.FlowID("scoring"),
-		Event: eventtest.WithEntityID(eventtest.Projection("evt-1",
-			events.EventType("scoring/score.dimension_complete"), "", "", []byte(`{"dimension":"build_complexity","score":80}`), 0, "", "", events.EventEnvelope{}, time.Date(2026, time.January, 1, 0, 0, 0, 0, time.UTC)),
-			"11111111-1111-1111-1111-111111111111"),
+		Event: eventtest.RootIngress(
+			"evt-1",
+			events.EventType("scoring/score.dimension_complete"),
+			"",
+			"",
+			[]byte(`{"dimension":"build_complexity","score":80}`),
+			0,
+			"",
+			"",
+			events.EnvelopeForEntityID(events.EventEnvelope{}, "11111111-1111-1111-1111-111111111111"),
+			time.Date(2026, time.January, 1, 0, 0, 0, 0, time.UTC),
+		),
 
 		State: StateSnapshot{
 			EntityID:     identity.NormalizeEntityID("11111111-1111-1111-1111-111111111111"),
@@ -746,7 +764,7 @@ func TestExecutor_AccumulatorProjectionMaterializesTypedEntityFieldBeforeEmit(t 
 	result, err := exec.Execute(context.Background(), ExecutionRequest{
 		EntityID: "entity-1",
 		NodeID:   "scoring-node",
-		Event: eventtest.Projection("evt-1",
+		Event: eventtest.RootIngress("evt-1",
 			"score.dimension_complete", "", "", json.RawMessage(`{"vertical_id":"11111111-1111-1111-1111-111111111111","dimension":"market","tier":2,"score":87,"evidence":"strong","confidence":"high"}`), 0, "", "", events.EventEnvelope{}, time.Time{}),
 
 		Handler: handler,
@@ -820,7 +838,7 @@ func TestExecutor_AccumulatorProjectionMaterializesForQualifiedRuntimeEvent(t *t
 		EntityID: "entity-1",
 		NodeID:   "scoring-node",
 		FlowID:   "scoring",
-		Event: eventtest.Projection("evt-1",
+		Event: eventtest.RootIngress("evt-1",
 			"scoring/score.dimension_complete", "", "", json.RawMessage(`{"dimension":"market","score":87}`), 0, "", "", events.EventEnvelope{}, time.Time{}),
 
 		HandlerEventKey: "score.dimension_complete",
@@ -877,9 +895,18 @@ func TestExecutor_AccumulatorBucketUsesMatchedHandlerEventKeyForScopedConcreteEv
 		EntityID: "entity-1",
 		NodeID:   "lifecycle-orchestrator",
 		FlowID:   "operating",
-		Event: eventtest.WithEntityID(eventtest.Projection("evt-a",
-			"component-scaffold/a/component.scaffolded", "", "", json.RawMessage(`{"component_id":"a"}`), 0, "", "", events.EventEnvelope{}, time.Date(2026, time.January, 1, 0, 0, 0, 0, time.UTC)),
-			"entity-1"),
+		Event: eventtest.RootIngress(
+			"evt-a",
+			"component-scaffold/a/component.scaffolded",
+			"",
+			"",
+			json.RawMessage(`{"component_id":"a"}`),
+			0,
+			"",
+			"",
+			events.EnvelopeForEntityID(events.EventEnvelope{}, "entity-1"),
+			time.Date(2026, time.January, 1, 0, 0, 0, 0, time.UTC),
+		),
 
 		HandlerEventKey: "component.scaffolded",
 		Handler:         handler,
@@ -896,9 +923,18 @@ func TestExecutor_AccumulatorBucketUsesMatchedHandlerEventKeyForScopedConcreteEv
 		EntityID: "entity-1",
 		NodeID:   "lifecycle-orchestrator",
 		FlowID:   "operating",
-		Event: eventtest.WithEntityID(eventtest.Projection("evt-b",
-			"component-scaffold/b/component.scaffolded", "", "", json.RawMessage(`{"component_id":"b"}`), 0, "", "", events.EventEnvelope{}, time.Date(2026, time.January, 1, 0, 0, 1, 0, time.UTC)),
-			"entity-1"),
+		Event: eventtest.RootIngress(
+			"evt-b",
+			"component-scaffold/b/component.scaffolded",
+			"",
+			"",
+			json.RawMessage(`{"component_id":"b"}`),
+			0,
+			"",
+			"",
+			events.EnvelopeForEntityID(events.EventEnvelope{}, "entity-1"),
+			time.Date(2026, time.January, 1, 0, 0, 1, 0, time.UTC),
+		),
 
 		HandlerEventKey: "component.scaffolded",
 		Handler:         handler,
@@ -955,9 +991,18 @@ func TestExecutor_ComputeReadsAccumulatorByMatchedHandlerEventKey(t *testing.T) 
 		EntityID: "entity-1",
 		NodeID:   "lifecycle-orchestrator",
 		FlowID:   "operating",
-		Event: eventtest.WithEntityID(eventtest.Projection("evt-b",
-			"component-scaffold/b/component.scaffolded", "", "", json.RawMessage(`{"component_id":"b"}`), 0, "", "", events.EventEnvelope{}, time.Time{}),
-			"entity-1"),
+		Event: eventtest.RootIngress(
+			"evt-b",
+			"component-scaffold/b/component.scaffolded",
+			"",
+			"",
+			json.RawMessage(`{"component_id":"b"}`),
+			0,
+			"",
+			"",
+			events.EnvelopeForEntityID(events.EventEnvelope{}, "entity-1"),
+			time.Time{},
+		),
 
 		HandlerEventKey: "component.scaffolded",
 		Handler: runtimecontracts.SystemNodeEventHandler{
@@ -997,7 +1042,7 @@ func TestExecutor_AccumulatorProjectionFailsClosedWhenDeclaredBindingDoesNotReso
 		EntityID: "entity-1",
 		NodeID:   "scoring-node",
 		FlowID:   "scoring",
-		Event: eventtest.Projection("evt-1",
+		Event: eventtest.RootIngress("evt-1",
 			"scoring/score.unregistered_dimension_complete", "", "", json.RawMessage(`{"dimension":"market","score":87}`), 0, "", "", events.EventEnvelope{}, time.Time{}),
 
 		Handler: handler,
@@ -1075,7 +1120,7 @@ func TestExecutor_ExecuteUsesAtomicEnvelopeAndOrderedSteps(t *testing.T) {
 		EntityID: "entity-1",
 		NodeID:   "node-1",
 		FlowID:   "flow-1",
-		Event:    eventtest.Projection("evt-1", "task.completed", "", "", json.RawMessage(`{"score":9}`), 0, "", "", events.EventEnvelope{}, time.Time{}),
+		Event:    eventtest.RootIngress("evt-1", "task.completed", "", "", json.RawMessage(`{"score":9}`), 0, "", "", events.EventEnvelope{}, time.Time{}),
 		Handler: runtimecontracts.SystemNodeEventHandler{
 			AdvancesTo: "done",
 			ClearGates: []string{"gate_a"},
@@ -1143,7 +1188,7 @@ func TestExecutor_ListPrimitivesMutateState(t *testing.T) {
 		EntityID: "entity-1",
 		NodeID:   "node-1",
 		FlowID:   "flow-1",
-		Event:    eventtest.Projection("evt-1", "items.submitted", "", "", json.RawMessage(`{"items":[{"score":60,"active":true},{"score":40,"active":true},{"score":60,"active":false}]}`), 0, "", "", events.EventEnvelope{}, time.Time{}),
+		Event:    eventtest.RootIngress("evt-1", "items.submitted", "", "", json.RawMessage(`{"items":[{"score":60,"active":true},{"score":40,"active":true},{"score":60,"active":false}]}`), 0, "", "", events.EventEnvelope{}, time.Time{}),
 		Handler: runtimecontracts.SystemNodeEventHandler{
 			Query: &runtimecontracts.QuerySpec{
 				Source:  "payload.items",
@@ -1216,7 +1261,7 @@ func TestExecutor_QueryGroupByStoresCounts(t *testing.T) {
 		EntityID: "entity-1",
 		NodeID:   "node-1",
 		FlowID:   "flow-1",
-		Event:    eventtest.Projection("evt-2", "digest.requested", "", "", json.RawMessage(`{"items":[{"status":"queued"},{"status":"queued"},{"status":"done"}]}`), 0, "", "", events.EventEnvelope{}, time.Time{}),
+		Event:    eventtest.RootIngress("evt-2", "digest.requested", "", "", json.RawMessage(`{"items":[{"status":"queued"},{"status":"queued"},{"status":"done"}]}`), 0, "", "", events.EventEnvelope{}, time.Time{}),
 		Handler: runtimecontracts.SystemNodeEventHandler{
 			Query: &runtimecontracts.QuerySpec{
 				Source:  "payload.items",
@@ -1255,7 +1300,7 @@ func TestExecutor_QueryFilterUsesExplicitCollidingScopes(t *testing.T) {
 		EntityID: "entity-1",
 		NodeID:   "node-1",
 		FlowID:   "flow-1",
-		Event:    eventtest.Projection("evt-2", "digest.requested", "", "", json.RawMessage(`{"score":5,"items":[{"score":7},{"score":5}]}`), 0, "", "", events.EventEnvelope{}, time.Time{}),
+		Event:    eventtest.RootIngress("evt-2", "digest.requested", "", "", json.RawMessage(`{"score":5,"items":[{"score":7},{"score":5}]}`), 0, "", "", events.EventEnvelope{}, time.Time{}),
 		Handler: runtimecontracts.SystemNodeEventHandler{
 			Query: &runtimecontracts.QuerySpec{
 				Source:  "payload.items",
@@ -1294,7 +1339,7 @@ func TestExecutor_FilterRejectsUnqualifiedConditionField(t *testing.T) {
 		EntityID: "entity-1",
 		NodeID:   "node-1",
 		FlowID:   "flow-1",
-		Event:    eventtest.Projection("evt-1", "items.submitted", "", "", json.RawMessage(`{"score":5,"items":[{"score":7}]}`), 0, "", "", events.EventEnvelope{}, time.Time{}),
+		Event:    eventtest.RootIngress("evt-1", "items.submitted", "", "", json.RawMessage(`{"score":5,"items":[{"score":7}]}`), 0, "", "", events.EventEnvelope{}, time.Time{}),
 		Handler: runtimecontracts.SystemNodeEventHandler{
 			Filter: &runtimecontracts.FilterSpec{
 				ItemsFrom: "payload.items",
@@ -1335,7 +1380,7 @@ func TestExecutor_GuardRecursesAndUsesRegistryCheck(t *testing.T) {
 		EntityID: "entity-1",
 		NodeID:   "node-1",
 		FlowID:   "flow-1",
-		Event:    eventtest.Projection("evt-1", "task.completed", "", "", json.RawMessage(`{"score":9}`), 0, "", "", events.EventEnvelope{}, time.Time{}),
+		Event:    eventtest.RootIngress("evt-1", "task.completed", "", "", json.RawMessage(`{"score":9}`), 0, "", "", events.EventEnvelope{}, time.Time{}),
 		Handler: runtimecontracts.SystemNodeEventHandler{
 			Guard: &runtimecontracts.GuardSpec{
 				Checks: []runtimecontracts.GuardCheck{
@@ -1374,7 +1419,7 @@ func TestExecutor_RulesUseFirstMatchAndSkipLaterEntries(t *testing.T) {
 		EntityID: "entity-1",
 		NodeID:   "node-1",
 		FlowID:   "flow-1",
-		Event:    eventtest.Projection("evt-1", "task.completed", "", "", json.RawMessage(`{"score":9}`), 0, "", "", events.EventEnvelope{}, time.Time{}),
+		Event:    eventtest.RootIngress("evt-1", "task.completed", "", "", json.RawMessage(`{"score":9}`), 0, "", "", events.EventEnvelope{}, time.Time{}),
 		Handler: runtimecontracts.SystemNodeEventHandler{
 			AdvancesTo: "default",
 			Rules: []runtimecontracts.HandlerRuleEntry{
@@ -1414,7 +1459,7 @@ func TestExecutor_RejectsAmbiguousHandlerTopLevelEmitWithRules(t *testing.T) {
 		NodeID:     "node-1",
 		FlowID:     "flow-1",
 		ChainDepth: 1,
-		Event:      eventtest.Projection("evt-1", "task.completed", "", "", json.RawMessage(`{"score":9}`), 0, "", "", events.EventEnvelope{}, time.Time{}),
+		Event:      eventtest.RootIngress("evt-1", "task.completed", "", "", json.RawMessage(`{"score":9}`), 0, "", "", events.EventEnvelope{}, time.Time{}),
 		Handler: runtimecontracts.SystemNodeEventHandler{
 			Emit: runtimecontracts.EmitSpec{Event: "handler.emitted"},
 			Rules: []runtimecontracts.HandlerRuleEntry{{
@@ -1452,7 +1497,7 @@ func TestExecutor_RejectsAmbiguousHandlerTopLevelEmitWithRulesWithoutRuleEmit(t 
 		NodeID:     "node-1",
 		FlowID:     "flow-1",
 		ChainDepth: 1,
-		Event:      eventtest.Projection("evt-1", "task.completed", "", "", json.RawMessage(`{"score":9}`), 0, "", "", events.EventEnvelope{}, time.Time{}),
+		Event:      eventtest.RootIngress("evt-1", "task.completed", "", "", json.RawMessage(`{"score":9}`), 0, "", "", events.EventEnvelope{}, time.Time{}),
 		Handler: runtimecontracts.SystemNodeEventHandler{
 			Emit: runtimecontracts.EmitSpec{Event: "handler.emitted"},
 			Rules: []runtimecontracts.HandlerRuleEntry{{
@@ -1487,7 +1532,7 @@ func TestExecutor_RuleDataAccumulationRunsBeforeTopLevelWrites(t *testing.T) {
 		EntityID: "entity-1",
 		NodeID:   "node-1",
 		FlowID:   "flow-1",
-		Event:    eventtest.Projection("evt-1", "task.completed", "", "", json.RawMessage(`{"score":9}`), 0, "", "", events.EventEnvelope{}, time.Time{}),
+		Event:    eventtest.RootIngress("evt-1", "task.completed", "", "", json.RawMessage(`{"score":9}`), 0, "", "", events.EventEnvelope{}, time.Time{}),
 		Handler: runtimecontracts.SystemNodeEventHandler{
 			DataAccumulation: runtimecontracts.WorkflowDataAccumulation{
 				Writes: []runtimecontracts.WorkflowDataWrite{{
@@ -1541,7 +1586,7 @@ func TestExecutor_RulesDoNotSeeCurrentHandlerTopLevelWritesBeforeSelection(t *te
 		EntityID: "entity-1",
 		NodeID:   "node-1",
 		FlowID:   "flow-1",
-		Event:    eventtest.Projection("evt-1", "task.completed", "", "", json.RawMessage(`{}`), 0, "", "", events.EventEnvelope{}, time.Time{}),
+		Event:    eventtest.RootIngress("evt-1", "task.completed", "", "", json.RawMessage(`{}`), 0, "", "", events.EventEnvelope{}, time.Time{}),
 		Handler: runtimecontracts.SystemNodeEventHandler{
 			DataAccumulation: runtimecontracts.WorkflowDataAccumulation{
 				Writes: []runtimecontracts.WorkflowDataWrite{{
@@ -1596,7 +1641,7 @@ func TestExecutor_OnCompleteDoesNotSeeCurrentHandlerTopLevelWritesBeforeSelectio
 		EntityID: "entity-1",
 		NodeID:   "node-1",
 		FlowID:   "flow-1",
-		Event:    eventtest.Projection("evt-1", "task.completed", "", "", json.RawMessage(`{}`), 0, "", "", events.EventEnvelope{}, time.Time{}),
+		Event:    eventtest.RootIngress("evt-1", "task.completed", "", "", json.RawMessage(`{}`), 0, "", "", events.EventEnvelope{}, time.Time{}),
 		Handler: runtimecontracts.SystemNodeEventHandler{
 			DataAccumulation: runtimecontracts.WorkflowDataAccumulation{
 				Writes: []runtimecontracts.WorkflowDataWrite{{
@@ -1644,7 +1689,7 @@ func TestExecutor_ChainDepthOverflowInterceptsEmitsButSucceeds(t *testing.T) {
 		NodeID:     "node-1",
 		FlowID:     "flow-1",
 		ChainDepth: 1,
-		Event:      eventtest.Projection("evt-1", "task.completed", "", "", json.RawMessage(`{}`), 0, "", "", events.EventEnvelope{}, time.Time{}),
+		Event:      eventtest.RootIngress("evt-1", "task.completed", "", "", json.RawMessage(`{}`), 0, "", "", events.EventEnvelope{}, time.Time{}),
 		Handler: runtimecontracts.SystemNodeEventHandler{
 			AdvancesTo: "done",
 			Emit:       runtimecontracts.EmitSpec{Event: "task.followup"},
@@ -1690,7 +1735,7 @@ func TestExecutor_FanOutCreatesShapedEmitIntentsAndStopsLoop(t *testing.T) {
 		NodeID:     "node-1",
 		FlowID:     "flow-1",
 		ChainDepth: 1,
-		Event:      eventtest.Projection("evt-1", "task.completed", "", "", json.RawMessage(`{"items":["a","b"]}`), 0, "", "", events.EventEnvelope{}, time.Time{}),
+		Event:      eventtest.RootIngress("evt-1", "task.completed", "", "", json.RawMessage(`{"items":["a","b"]}`), 0, "", "", events.EventEnvelope{}, time.Time{}),
 		Handler: runtimecontracts.SystemNodeEventHandler{
 			FanOut: &runtimecontracts.FanOutSpec{
 				ItemsFrom: "payload.items",
@@ -1748,7 +1793,7 @@ func TestExecutor_PayloadTransformSeesDataAccumulationWrites(t *testing.T) {
 		EntityID: "vertical-1",
 		NodeID:   "node-1",
 		FlowID:   "flow-1",
-		Event: eventtest.Projection("evt-1",
+		Event: eventtest.RootIngress("evt-1",
 			"vertical.discovered", "", "", json.RawMessage(`{"mode":"corpus","discovery_context":{"source":"corpus"}}`), 0, "", "", events.EventEnvelope{}, time.Time{}),
 
 		Handler: runtimecontracts.SystemNodeEventHandler{
@@ -1842,9 +1887,18 @@ func TestExecutor_EmitIntentUsesTargetStateFlowIdentityBeforeInboundSource(t *te
 				EntityID: targetEntityID,
 				NodeID:   "validation-router",
 				FlowID:   "validation",
-				Event: eventtest.WithFlowInstance(eventtest.WithEntityID((eventtest.Projection("evt-1",
-					"scoring/vertical.resumed", "", "", json.RawMessage(`{"vertical_id":"`+sourceEntityID+`"}`), 0, "", "", events.EventEnvelope{}, time.Time{})), sourceEntityID),
-					sourceFlowInstance),
+				Event: eventtest.RootIngress(
+					"evt-1",
+					"scoring/vertical.resumed",
+					"",
+					"",
+					json.RawMessage(`{"vertical_id":"`+sourceEntityID+`"}`),
+					0,
+					"",
+					"",
+					events.EnvelopeForFlowInstance(events.EnvelopeForEntityID(events.EventEnvelope{}, sourceEntityID), sourceFlowInstance),
+					time.Time{},
+				),
 
 				Handler: runtimecontracts.SystemNodeEventHandler{
 					Emit: runtimecontracts.EmitSpec{
@@ -1901,9 +1955,18 @@ func TestExecutor_EmitIntentFallsBackToInboundFlowWhenStateFlowPathNormalizesEmp
 		EntityID: "entity-1",
 		NodeID:   "node-1",
 		FlowID:   "root",
-		Event: eventtest.WithFlowInstance(eventtest.WithEntityID((eventtest.Projection("evt-1",
-			"root.started", "", "", json.RawMessage(`{}`), 0, "", "", events.EventEnvelope{}, time.Time{})), "entity-1"),
-			"source/inst-1"),
+		Event: eventtest.RootIngress(
+			"evt-1",
+			"root.started",
+			"",
+			"",
+			json.RawMessage(`{}`),
+			0,
+			"",
+			"",
+			events.EnvelopeForFlowInstance(events.EnvelopeForEntityID(events.EventEnvelope{}, "entity-1"), "source/inst-1"),
+			time.Time{},
+		),
 
 		Handler: runtimecontracts.SystemNodeEventHandler{
 			Emit: runtimecontracts.EmitSpec{Event: "root.done"},
@@ -2017,7 +2080,7 @@ func TestExecutor_DeclarativeEmitSurfacesUseProducerSourceRouteNamespace(t *test
 				EntityID: "component-entity",
 				NodeID:   "component-node",
 				FlowID:   "component-scaffold",
-				Event:    eventtest.Projection("evt-1", events.EventType(eventType), "", "", payload, 0, "", "", events.EventEnvelope{}, time.Time{}),
+				Event:    eventtest.RootIngress("evt-1", events.EventType(eventType), "", "", payload, 0, "", "", events.EventEnvelope{}, time.Time{}),
 				Handler:  tc.handler,
 				State: testStateSnapshot("ready", map[string]any{
 					"flow_path":            "component-scaffold/component-1",
@@ -2063,7 +2126,7 @@ func TestExecutor_FanOutEmitUsesProducerSourceRouteNamespace(t *testing.T) {
 		EntityID: "component-entity",
 		NodeID:   "component-node",
 		FlowID:   "component-scaffold",
-		Event:    eventtest.Projection("evt-1", "repo-scaffold/repo_scaffold.repo_scaffolded", "", "", json.RawMessage(`{"items":[{"id":"a"},{"id":"b"}]}`), 0, "", "", events.EventEnvelope{}, time.Time{}),
+		Event:    eventtest.RootIngress("evt-1", "repo-scaffold/repo_scaffold.repo_scaffolded", "", "", json.RawMessage(`{"items":[{"id":"a"},{"id":"b"}]}`), 0, "", "", events.EventEnvelope{}, time.Time{}),
 		Handler: runtimecontracts.SystemNodeEventHandler{
 			FanOut: &runtimecontracts.FanOutSpec{
 				ItemsFrom: "payload.items",
@@ -2112,7 +2175,7 @@ func TestExecutor_StaticProducerTargetRouteDoesNotOwnEventNamespace(t *testing.T
 		EntityID: "repo-entity",
 		NodeID:   "repo-node",
 		FlowID:   "repo-scaffold",
-		Event:    eventtest.Projection("evt-1", "repo.commit_ready", "", "", json.RawMessage(`{}`), 0, "", "", events.EventEnvelope{}, time.Time{}),
+		Event:    eventtest.RootIngress("evt-1", "repo.commit_ready", "", "", json.RawMessage(`{}`), 0, "", "", events.EventEnvelope{}, time.Time{}),
 		Handler: runtimecontracts.SystemNodeEventHandler{
 			Emit: runtimecontracts.EmitSpec{
 				Event: "repo-scaffold/repo_scaffold.repo_scaffolded",
@@ -2178,14 +2241,22 @@ func TestExecutor_ChildPinOutputTargetsStoredParentRoute(t *testing.T) {
 		EntityID: "child-ent",
 		NodeID:   "child-node",
 		FlowID:   "child",
-		Event: eventtest.WithSourceRoute(eventtest.WithFlowInstance(eventtest.WithEntityID((eventtest.Projection("evt-1",
-			"child/requested", "", "", json.RawMessage(`{}`), 0, "", "", events.EventEnvelope{}, time.Time{})), "wrong-parent"),
-			"wrong/root"),
-			events.RouteIdentity{
+		Event: eventtest.RootIngress(
+			"evt-1",
+			"child/requested",
+			"",
+			"",
+			json.RawMessage(`{}`),
+			0,
+			"",
+			"",
+			events.EnvelopeForSourceRoute(events.EnvelopeForFlowInstance(events.EnvelopeForEntityID(events.EventEnvelope{}, "wrong-parent"), "wrong/root"), events.RouteIdentity{
 				FlowID:       "wrong",
 				FlowInstance: "wrong/root",
 				EntityID:     "wrong-parent",
 			}),
+			time.Time{},
+		),
 
 		Handler: runtimecontracts.SystemNodeEventHandler{
 			Emit: runtimecontracts.EmitSpec{Event: "child.done"},
@@ -2248,7 +2319,7 @@ func TestExecutor_DataAccumulationTargetPathWritesNestedEntityLeaf(t *testing.T)
 	result, err := exec.Execute(context.Background(), ExecutionRequest{
 		EntityID: "entity-1",
 		NodeID:   "node-1",
-		Event:    eventtest.Projection("evt-1", "task.completed", "", "", json.RawMessage(`{"summary":"ready"}`), 0, "", "", events.EventEnvelope{}, time.Time{}),
+		Event:    eventtest.RootIngress("evt-1", "task.completed", "", "", json.RawMessage(`{"summary":"ready"}`), 0, "", "", events.EventEnvelope{}, time.Time{}),
 		Handler: runtimecontracts.SystemNodeEventHandler{
 			DataAccumulation: runtimecontracts.WorkflowDataAccumulation{
 				Writes: []runtimecontracts.WorkflowDataWrite{{
@@ -2294,7 +2365,7 @@ func TestExecutor_RejectsUndeclaredNestedEntityWriteBeforeExecution(t *testing.T
 	_, err = exec.Execute(context.Background(), ExecutionRequest{
 		EntityID: "entity-1",
 		NodeID:   "node-1",
-		Event:    eventtest.Projection("evt-1", "task.completed", "", "", json.RawMessage(`{}`), 0, "", "", events.EventEnvelope{}, time.Time{}),
+		Event:    eventtest.RootIngress("evt-1", "task.completed", "", "", json.RawMessage(`{}`), 0, "", "", events.EventEnvelope{}, time.Time{}),
 		Handler: runtimecontracts.SystemNodeEventHandler{
 			Compute: &runtimecontracts.ComputeSpec{
 				Operation: runtimecontracts.ComputeOpCount,
@@ -2329,7 +2400,7 @@ func TestExecutor_ClearRemovesNestedEntityLeaf(t *testing.T) {
 	result, err := exec.Execute(context.Background(), ExecutionRequest{
 		EntityID: "entity-1",
 		NodeID:   "node-1",
-		Event:    eventtest.Projection("evt-1", "task.completed", "", "", json.RawMessage(`{}`), 0, "", "", events.EventEnvelope{}, time.Time{}),
+		Event:    eventtest.RootIngress("evt-1", "task.completed", "", "", json.RawMessage(`{}`), 0, "", "", events.EventEnvelope{}, time.Time{}),
 		Handler: runtimecontracts.SystemNodeEventHandler{
 			Clear: &runtimecontracts.ClearSpec{Target: "entity.analysis.summary"},
 		},
@@ -2380,7 +2451,7 @@ func TestExecutor_ClearSpecialTargetsBypassContractValidation(t *testing.T) {
 		EntityID: "entity-1",
 		NodeID:   "node-1",
 		FlowID:   "root",
-		Event:    eventtest.Projection("evt-1", "task.completed", "", "", json.RawMessage(`{}`), 0, "", "", events.EventEnvelope{}, time.Time{}),
+		Event:    eventtest.RootIngress("evt-1", "task.completed", "", "", json.RawMessage(`{}`), 0, "", "", events.EventEnvelope{}, time.Time{}),
 		Handler: runtimecontracts.SystemNodeEventHandler{
 			Clear: &runtimecontracts.ClearSpec{Targets: []string{"pending_dedup", "accumulator_state"}},
 		},
@@ -2418,7 +2489,7 @@ func TestExecutor_EmitFieldsCELFailureReturnsError(t *testing.T) {
 		EntityID: "vertical-1",
 		NodeID:   "node-1",
 		FlowID:   "flow-1",
-		Event: eventtest.Projection("evt-1",
+		Event: eventtest.RootIngress("evt-1",
 			"vertical.discovered", "", "", json.RawMessage(`{"mode":"corpus"}`), 0, "", "", events.EventEnvelope{}, time.Time{}),
 
 		Handler: runtimecontracts.SystemNodeEventHandler{
@@ -2452,7 +2523,7 @@ func TestExecutor_FanOutEmptyPersistsCountAndContinues(t *testing.T) {
 		EntityID: "entity-1",
 		NodeID:   "node-1",
 		FlowID:   "flow-1",
-		Event:    eventtest.Projection("evt-1", "task.completed", "", "", json.RawMessage(`{"items":[]}`), 0, "", "", events.EventEnvelope{}, time.Time{}),
+		Event:    eventtest.RootIngress("evt-1", "task.completed", "", "", json.RawMessage(`{"items":[]}`), 0, "", "", events.EventEnvelope{}, time.Time{}),
 		Handler: runtimecontracts.SystemNodeEventHandler{
 			FanOut: &runtimecontracts.FanOutSpec{
 				ItemsFrom: "payload.items",
@@ -2492,7 +2563,7 @@ func TestExecutor_FanOutInternalCountBypassesEntityContractValidation(t *testing
 		EntityID: "entity-1",
 		NodeID:   "node-1",
 		FlowID:   "root",
-		Event:    eventtest.Projection("evt-1", "task.completed", "", "", json.RawMessage(`{"items":[]}`), 0, "", "", events.EventEnvelope{}, time.Time{}),
+		Event:    eventtest.RootIngress("evt-1", "task.completed", "", "", json.RawMessage(`{"items":[]}`), 0, "", "", events.EventEnvelope{}, time.Time{}),
 		Handler: runtimecontracts.SystemNodeEventHandler{
 			FanOut: &runtimecontracts.FanOutSpec{
 				ItemsFrom: "payload.items",
@@ -2529,7 +2600,7 @@ func TestExecutor_FanOutUsesExplicitEmitEvent(t *testing.T) {
 		NodeID:     "node-1",
 		FlowID:     "flow-1",
 		ChainDepth: 1,
-		Event:      eventtest.Projection("evt-1", "batch.submitted", "", "", json.RawMessage(`{"items":[{"kind":"a"},{"kind":"b"}]}`), 0, "", "", events.EventEnvelope{}, time.Time{}),
+		Event:      eventtest.RootIngress("evt-1", "batch.submitted", "", "", json.RawMessage(`{"items":[{"kind":"a"},{"kind":"b"}]}`), 0, "", "", events.EventEnvelope{}, time.Time{}),
 		Handler: runtimecontracts.SystemNodeEventHandler{
 			FanOut: &runtimecontracts.FanOutSpec{
 				ItemsFrom: "payload.items",
@@ -2571,7 +2642,7 @@ func TestExecutor_GuardKillTransitionsToKilledStateWhenDeclared(t *testing.T) {
 		EntityID: "entity-1",
 		NodeID:   "node-1",
 		FlowID:   "flow-1",
-		Event:    eventtest.Projection("evt-1", "check.requested", "", "", json.RawMessage(`{"score":50}`), 0, "", "", events.EventEnvelope{}, time.Time{}),
+		Event:    eventtest.RootIngress("evt-1", "check.requested", "", "", json.RawMessage(`{"score":50}`), 0, "", "", events.EventEnvelope{}, time.Time{}),
 		Handler: runtimecontracts.SystemNodeEventHandler{
 			Guard: &runtimecontracts.GuardSpec{
 				Check:  "payload.score >= policy.threshold",
@@ -2612,7 +2683,7 @@ func TestExecutor_GroupByStoresGroupedItems(t *testing.T) {
 		EntityID: "entity-1",
 		NodeID:   "node-1",
 		FlowID:   "flow-1",
-		Event:    eventtest.Projection("evt-1", "items.submitted", "", "", json.RawMessage(`{"items":[{"name":"a","category":"x"},{"name":"b","category":"y"},{"name":"c","category":"x"}]}`), 0, "", "", events.EventEnvelope{}, time.Time{}),
+		Event:    eventtest.RootIngress("evt-1", "items.submitted", "", "", json.RawMessage(`{"items":[{"name":"a","category":"x"},{"name":"b","category":"y"},{"name":"c","category":"x"}]}`), 0, "", "", events.EventEnvelope{}, time.Time{}),
 		Handler: runtimecontracts.SystemNodeEventHandler{
 			GroupBy: &runtimecontracts.GroupBySpec{
 				ItemsFrom: "payload.items",
@@ -2656,7 +2727,7 @@ func TestExecutor_GroupByBareKeyUsesItemScopeWithoutFallbackAcrossRoots(t *testi
 		EntityID: "entity-1",
 		NodeID:   "node-1",
 		FlowID:   "flow-1",
-		Event:    eventtest.Projection("evt-1", "items.submitted", "", "", json.RawMessage(`{"category":"payload","items":[{"name":"a","category":"x"},{"name":"b","category":"y"},{"name":"c","category":"x"}]}`), 0, "", "", events.EventEnvelope{}, time.Time{}),
+		Event:    eventtest.RootIngress("evt-1", "items.submitted", "", "", json.RawMessage(`{"category":"payload","items":[{"name":"a","category":"x"},{"name":"b","category":"y"},{"name":"c","category":"x"}]}`), 0, "", "", events.EventEnvelope{}, time.Time{}),
 		Handler: runtimecontracts.SystemNodeEventHandler{
 			GroupBy: &runtimecontracts.GroupBySpec{
 				ItemsFrom: "payload.items",
@@ -2706,7 +2777,7 @@ func TestExecutor_ClearGatesWildcardUsesNodeGateSchema(t *testing.T) {
 		EntityID: "entity-1",
 		NodeID:   "node-1",
 		FlowID:   "flow-1",
-		Event:    eventtest.Projection("evt-1", "task.completed", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}),
+		Event:    eventtest.RootIngress("evt-1", "task.completed", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}),
 		Handler: runtimecontracts.SystemNodeEventHandler{
 			ClearGates: []string{"*"},
 		},
@@ -2749,7 +2820,7 @@ func TestExecutor_ClearGatesRunsBeforeGuardEvaluation(t *testing.T) {
 		EntityID: "entity-1",
 		NodeID:   "node-1",
 		FlowID:   "flow-1",
-		Event:    eventtest.Projection("evt-1", "task.completed", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}),
+		Event:    eventtest.RootIngress("evt-1", "task.completed", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}),
 		Handler: runtimecontracts.SystemNodeEventHandler{
 			ClearGates: []string{"review"},
 			Guard: &runtimecontracts.GuardSpec{
@@ -2792,7 +2863,7 @@ func TestExecutor_ActionRegistryEmitsAndRunsActionRunner(t *testing.T) {
 		EntityID: "entity-1",
 		NodeID:   "node-1",
 		FlowID:   "flow-1",
-		Event:    eventtest.Projection("evt-1", "task.completed", "", "", json.RawMessage(`{"score":9}`), 0, "", "", events.EventEnvelope{}, time.Time{}),
+		Event:    eventtest.RootIngress("evt-1", "task.completed", "", "", json.RawMessage(`{"score":9}`), 0, "", "", events.EventEnvelope{}, time.Time{}),
 		Handler: runtimecontracts.SystemNodeEventHandler{
 			Action: runtimecontracts.ActionSpec{ID: "notify"},
 		},
@@ -2847,7 +2918,7 @@ func TestExecutor_RuleActionRunsOnlyForSelectedRule(t *testing.T) {
 		EntityID: "entity-1",
 		NodeID:   "node-1",
 		FlowID:   "flow-1",
-		Event:    eventtest.Projection("evt-1", "refund.requested", "", "", json.RawMessage(`{"amount":250}`), 0, "", "", events.EventEnvelope{}, time.Time{}),
+		Event:    eventtest.RootIngress("evt-1", "refund.requested", "", "", json.RawMessage(`{"amount":250}`), 0, "", "", events.EventEnvelope{}, time.Time{}),
 		Handler: runtimecontracts.SystemNodeEventHandler{
 			Rules: []runtimecontracts.HandlerRuleEntry{
 				{
@@ -2900,7 +2971,7 @@ func TestExecutor_RejectsAmbiguousHandlerTopLevelActionWithRules(t *testing.T) {
 		EntityID: "entity-1",
 		NodeID:   "node-1",
 		FlowID:   "flow-1",
-		Event:    eventtest.Projection("evt-1", "refund.requested", "", "", json.RawMessage(`{"amount":250}`), 0, "", "", events.EventEnvelope{}, time.Time{}),
+		Event:    eventtest.RootIngress("evt-1", "refund.requested", "", "", json.RawMessage(`{"amount":250}`), 0, "", "", events.EventEnvelope{}, time.Time{}),
 		Handler: runtimecontracts.SystemNodeEventHandler{
 			Action: runtimecontracts.ActionSpec{ID: "handler_action"},
 			Rules: []runtimecontracts.HandlerRuleEntry{{
@@ -2987,7 +3058,7 @@ func TestExecutor_RejectsUnsupportedRuleActionContextsBeforeExecution(t *testing
 				EntityID: "entity-1",
 				NodeID:   "node-1",
 				FlowID:   "flow-1",
-				Event:    eventtest.Projection("evt-1", "task.completed", "", "", json.RawMessage(`{"ok":true}`), 0, "", "", events.EventEnvelope{}, time.Time{}),
+				Event:    eventtest.RootIngress("evt-1", "task.completed", "", "", json.RawMessage(`{"ok":true}`), 0, "", "", events.EventEnvelope{}, time.Time{}),
 				Handler:  tc.handler,
 				State:    testStateSnapshot("pending", map[string]any{}, nil, map[string]map[string]any{}),
 			})
@@ -3098,7 +3169,7 @@ func TestExecutor_ActionRegistryEmitContractViolationRejectsHandler(t *testing.T
 		EntityID: "entity-1",
 		NodeID:   "node-1",
 		FlowID:   "flow-1",
-		Event:    eventtest.Projection("evt-1", "task.completed", "", "", json.RawMessage(`{"score":9}`), 0, "", "", events.EventEnvelope{}, time.Time{}),
+		Event:    eventtest.RootIngress("evt-1", "task.completed", "", "", json.RawMessage(`{"score":9}`), 0, "", "", events.EventEnvelope{}, time.Time{}),
 		Handler: runtimecontracts.SystemNodeEventHandler{
 			Action: runtimecontracts.ActionSpec{ID: "notify"},
 		},
@@ -3149,7 +3220,7 @@ func TestExecutor_GuardOnFailEscalateCreatesEmitIntent(t *testing.T) {
 		NodeID:     "node-1",
 		FlowID:     "flow-1",
 		ChainDepth: 1,
-		Event:      eventtest.Projection("evt-1", "task.completed", "", "", json.RawMessage(`{"ok":false}`), 0, "", "", events.EventEnvelope{}, time.Time{}),
+		Event:      eventtest.RootIngress("evt-1", "task.completed", "", "", json.RawMessage(`{"ok":false}`), 0, "", "", events.EventEnvelope{}, time.Time{}),
 		Handler: runtimecontracts.SystemNodeEventHandler{
 			Guard: &runtimecontracts.GuardSpec{
 				Check:  "payload.ok == true",

--- a/internal/runtime/engine/executor_test.go
+++ b/internal/runtime/engine/executor_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/division-sh/swarm/internal/events"
+	"github.com/division-sh/swarm/internal/events/eventtest"
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
 	"github.com/division-sh/swarm/internal/runtime/core/identity"
 	runtimeregistry "github.com/division-sh/swarm/internal/runtime/core/registry"
@@ -523,9 +524,10 @@ func TestExecutor_LoadsStateInsideEntityLock(t *testing.T) {
 		EntityID: identity.NormalizeEntityID("11111111-1111-1111-1111-111111111111"),
 		NodeID:   identity.NodeID("node-1"),
 		FlowID:   identity.FlowID("flow-1"),
-		Event: events.NewProjectionEvent("evt-1",
-			events.EventType("test.event"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Now().UTC()).
-			WithEntityID("11111111-1111-1111-1111-111111111111"),
+		Event: eventtest.WithEntityID(eventtest.Projection("evt-1",
+			events.EventType("test.event"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Now().UTC()),
+			"11111111-1111-1111-1111-111111111111"),
+
 		State: StateSnapshot{StateCarrier: NewStateCarrier(map[string]any{}, nil, map[string]map[string]any{})},
 	})
 	if err != nil {
@@ -583,9 +585,10 @@ func TestExecutor_ShapeEmitPayloadUsesUpdatedState(t *testing.T) {
 		EntityID: identity.NormalizeEntityID("11111111-1111-1111-1111-111111111111"),
 		NodeID:   identity.NodeID("scoring-node"),
 		FlowID:   identity.FlowID("scoring"),
-		Event: events.NewProjectionEvent("evt-1",
-			events.EventType("scoring/score.dimension_complete"), "", "", []byte(`{"dimension":"build_complexity","score":80}`), 0, "", "", events.EventEnvelope{}, time.Date(2026, time.January, 1, 0, 0, 0, 0, time.UTC)).
-			WithEntityID("11111111-1111-1111-1111-111111111111"),
+		Event: eventtest.WithEntityID(eventtest.Projection("evt-1",
+			events.EventType("scoring/score.dimension_complete"), "", "", []byte(`{"dimension":"build_complexity","score":80}`), 0, "", "", events.EventEnvelope{}, time.Date(2026, time.January, 1, 0, 0, 0, 0, time.UTC)),
+			"11111111-1111-1111-1111-111111111111"),
+
 		State: StateSnapshot{
 			EntityID:     identity.NormalizeEntityID("11111111-1111-1111-1111-111111111111"),
 			CurrentState: "discovered",
@@ -743,7 +746,7 @@ func TestExecutor_AccumulatorProjectionMaterializesTypedEntityFieldBeforeEmit(t 
 	result, err := exec.Execute(context.Background(), ExecutionRequest{
 		EntityID: "entity-1",
 		NodeID:   "scoring-node",
-		Event: events.NewProjectionEvent("evt-1",
+		Event: eventtest.Projection("evt-1",
 			"score.dimension_complete", "", "", json.RawMessage(`{"vertical_id":"11111111-1111-1111-1111-111111111111","dimension":"market","tier":2,"score":87,"evidence":"strong","confidence":"high"}`), 0, "", "", events.EventEnvelope{}, time.Time{}),
 
 		Handler: handler,
@@ -817,7 +820,7 @@ func TestExecutor_AccumulatorProjectionMaterializesForQualifiedRuntimeEvent(t *t
 		EntityID: "entity-1",
 		NodeID:   "scoring-node",
 		FlowID:   "scoring",
-		Event: events.NewProjectionEvent("evt-1",
+		Event: eventtest.Projection("evt-1",
 			"scoring/score.dimension_complete", "", "", json.RawMessage(`{"dimension":"market","score":87}`), 0, "", "", events.EventEnvelope{}, time.Time{}),
 
 		HandlerEventKey: "score.dimension_complete",
@@ -874,9 +877,10 @@ func TestExecutor_AccumulatorBucketUsesMatchedHandlerEventKeyForScopedConcreteEv
 		EntityID: "entity-1",
 		NodeID:   "lifecycle-orchestrator",
 		FlowID:   "operating",
-		Event: events.NewProjectionEvent("evt-a",
-			"component-scaffold/a/component.scaffolded", "", "", json.RawMessage(`{"component_id":"a"}`), 0, "", "", events.EventEnvelope{}, time.Date(2026, time.January, 1, 0, 0, 0, 0, time.UTC)).
-			WithEntityID("entity-1"),
+		Event: eventtest.WithEntityID(eventtest.Projection("evt-a",
+			"component-scaffold/a/component.scaffolded", "", "", json.RawMessage(`{"component_id":"a"}`), 0, "", "", events.EventEnvelope{}, time.Date(2026, time.January, 1, 0, 0, 0, 0, time.UTC)),
+			"entity-1"),
+
 		HandlerEventKey: "component.scaffolded",
 		Handler:         handler,
 		State:           firstState,
@@ -892,9 +896,10 @@ func TestExecutor_AccumulatorBucketUsesMatchedHandlerEventKeyForScopedConcreteEv
 		EntityID: "entity-1",
 		NodeID:   "lifecycle-orchestrator",
 		FlowID:   "operating",
-		Event: events.NewProjectionEvent("evt-b",
-			"component-scaffold/b/component.scaffolded", "", "", json.RawMessage(`{"component_id":"b"}`), 0, "", "", events.EventEnvelope{}, time.Date(2026, time.January, 1, 0, 0, 1, 0, time.UTC)).
-			WithEntityID("entity-1"),
+		Event: eventtest.WithEntityID(eventtest.Projection("evt-b",
+			"component-scaffold/b/component.scaffolded", "", "", json.RawMessage(`{"component_id":"b"}`), 0, "", "", events.EventEnvelope{}, time.Date(2026, time.January, 1, 0, 0, 1, 0, time.UTC)),
+			"entity-1"),
+
 		HandlerEventKey: "component.scaffolded",
 		Handler:         handler,
 		State:           secondState,
@@ -950,9 +955,10 @@ func TestExecutor_ComputeReadsAccumulatorByMatchedHandlerEventKey(t *testing.T) 
 		EntityID: "entity-1",
 		NodeID:   "lifecycle-orchestrator",
 		FlowID:   "operating",
-		Event: events.NewProjectionEvent("evt-b",
-			"component-scaffold/b/component.scaffolded", "", "", json.RawMessage(`{"component_id":"b"}`), 0, "", "", events.EventEnvelope{}, time.Time{}).
-			WithEntityID("entity-1"),
+		Event: eventtest.WithEntityID(eventtest.Projection("evt-b",
+			"component-scaffold/b/component.scaffolded", "", "", json.RawMessage(`{"component_id":"b"}`), 0, "", "", events.EventEnvelope{}, time.Time{}),
+			"entity-1"),
+
 		HandlerEventKey: "component.scaffolded",
 		Handler: runtimecontracts.SystemNodeEventHandler{
 			Compute: &runtimecontracts.ComputeSpec{
@@ -991,7 +997,7 @@ func TestExecutor_AccumulatorProjectionFailsClosedWhenDeclaredBindingDoesNotReso
 		EntityID: "entity-1",
 		NodeID:   "scoring-node",
 		FlowID:   "scoring",
-		Event: events.NewProjectionEvent("evt-1",
+		Event: eventtest.Projection("evt-1",
 			"scoring/score.unregistered_dimension_complete", "", "", json.RawMessage(`{"dimension":"market","score":87}`), 0, "", "", events.EventEnvelope{}, time.Time{}),
 
 		Handler: handler,
@@ -1069,7 +1075,7 @@ func TestExecutor_ExecuteUsesAtomicEnvelopeAndOrderedSteps(t *testing.T) {
 		EntityID: "entity-1",
 		NodeID:   "node-1",
 		FlowID:   "flow-1",
-		Event:    events.NewProjectionEvent("evt-1", "task.completed", "", "", json.RawMessage(`{"score":9}`), 0, "", "", events.EventEnvelope{}, time.Time{}),
+		Event:    eventtest.Projection("evt-1", "task.completed", "", "", json.RawMessage(`{"score":9}`), 0, "", "", events.EventEnvelope{}, time.Time{}),
 		Handler: runtimecontracts.SystemNodeEventHandler{
 			AdvancesTo: "done",
 			ClearGates: []string{"gate_a"},
@@ -1137,7 +1143,7 @@ func TestExecutor_ListPrimitivesMutateState(t *testing.T) {
 		EntityID: "entity-1",
 		NodeID:   "node-1",
 		FlowID:   "flow-1",
-		Event:    events.NewProjectionEvent("evt-1", "items.submitted", "", "", json.RawMessage(`{"items":[{"score":60,"active":true},{"score":40,"active":true},{"score":60,"active":false}]}`), 0, "", "", events.EventEnvelope{}, time.Time{}),
+		Event:    eventtest.Projection("evt-1", "items.submitted", "", "", json.RawMessage(`{"items":[{"score":60,"active":true},{"score":40,"active":true},{"score":60,"active":false}]}`), 0, "", "", events.EventEnvelope{}, time.Time{}),
 		Handler: runtimecontracts.SystemNodeEventHandler{
 			Query: &runtimecontracts.QuerySpec{
 				Source:  "payload.items",
@@ -1210,7 +1216,7 @@ func TestExecutor_QueryGroupByStoresCounts(t *testing.T) {
 		EntityID: "entity-1",
 		NodeID:   "node-1",
 		FlowID:   "flow-1",
-		Event:    events.NewProjectionEvent("evt-2", "digest.requested", "", "", json.RawMessage(`{"items":[{"status":"queued"},{"status":"queued"},{"status":"done"}]}`), 0, "", "", events.EventEnvelope{}, time.Time{}),
+		Event:    eventtest.Projection("evt-2", "digest.requested", "", "", json.RawMessage(`{"items":[{"status":"queued"},{"status":"queued"},{"status":"done"}]}`), 0, "", "", events.EventEnvelope{}, time.Time{}),
 		Handler: runtimecontracts.SystemNodeEventHandler{
 			Query: &runtimecontracts.QuerySpec{
 				Source:  "payload.items",
@@ -1249,7 +1255,7 @@ func TestExecutor_QueryFilterUsesExplicitCollidingScopes(t *testing.T) {
 		EntityID: "entity-1",
 		NodeID:   "node-1",
 		FlowID:   "flow-1",
-		Event:    events.NewProjectionEvent("evt-2", "digest.requested", "", "", json.RawMessage(`{"score":5,"items":[{"score":7},{"score":5}]}`), 0, "", "", events.EventEnvelope{}, time.Time{}),
+		Event:    eventtest.Projection("evt-2", "digest.requested", "", "", json.RawMessage(`{"score":5,"items":[{"score":7},{"score":5}]}`), 0, "", "", events.EventEnvelope{}, time.Time{}),
 		Handler: runtimecontracts.SystemNodeEventHandler{
 			Query: &runtimecontracts.QuerySpec{
 				Source:  "payload.items",
@@ -1288,7 +1294,7 @@ func TestExecutor_FilterRejectsUnqualifiedConditionField(t *testing.T) {
 		EntityID: "entity-1",
 		NodeID:   "node-1",
 		FlowID:   "flow-1",
-		Event:    events.NewProjectionEvent("evt-1", "items.submitted", "", "", json.RawMessage(`{"score":5,"items":[{"score":7}]}`), 0, "", "", events.EventEnvelope{}, time.Time{}),
+		Event:    eventtest.Projection("evt-1", "items.submitted", "", "", json.RawMessage(`{"score":5,"items":[{"score":7}]}`), 0, "", "", events.EventEnvelope{}, time.Time{}),
 		Handler: runtimecontracts.SystemNodeEventHandler{
 			Filter: &runtimecontracts.FilterSpec{
 				ItemsFrom: "payload.items",
@@ -1329,7 +1335,7 @@ func TestExecutor_GuardRecursesAndUsesRegistryCheck(t *testing.T) {
 		EntityID: "entity-1",
 		NodeID:   "node-1",
 		FlowID:   "flow-1",
-		Event:    events.NewProjectionEvent("evt-1", "task.completed", "", "", json.RawMessage(`{"score":9}`), 0, "", "", events.EventEnvelope{}, time.Time{}),
+		Event:    eventtest.Projection("evt-1", "task.completed", "", "", json.RawMessage(`{"score":9}`), 0, "", "", events.EventEnvelope{}, time.Time{}),
 		Handler: runtimecontracts.SystemNodeEventHandler{
 			Guard: &runtimecontracts.GuardSpec{
 				Checks: []runtimecontracts.GuardCheck{
@@ -1368,7 +1374,7 @@ func TestExecutor_RulesUseFirstMatchAndSkipLaterEntries(t *testing.T) {
 		EntityID: "entity-1",
 		NodeID:   "node-1",
 		FlowID:   "flow-1",
-		Event:    events.NewProjectionEvent("evt-1", "task.completed", "", "", json.RawMessage(`{"score":9}`), 0, "", "", events.EventEnvelope{}, time.Time{}),
+		Event:    eventtest.Projection("evt-1", "task.completed", "", "", json.RawMessage(`{"score":9}`), 0, "", "", events.EventEnvelope{}, time.Time{}),
 		Handler: runtimecontracts.SystemNodeEventHandler{
 			AdvancesTo: "default",
 			Rules: []runtimecontracts.HandlerRuleEntry{
@@ -1408,7 +1414,7 @@ func TestExecutor_RejectsAmbiguousHandlerTopLevelEmitWithRules(t *testing.T) {
 		NodeID:     "node-1",
 		FlowID:     "flow-1",
 		ChainDepth: 1,
-		Event:      events.NewProjectionEvent("evt-1", "task.completed", "", "", json.RawMessage(`{"score":9}`), 0, "", "", events.EventEnvelope{}, time.Time{}),
+		Event:      eventtest.Projection("evt-1", "task.completed", "", "", json.RawMessage(`{"score":9}`), 0, "", "", events.EventEnvelope{}, time.Time{}),
 		Handler: runtimecontracts.SystemNodeEventHandler{
 			Emit: runtimecontracts.EmitSpec{Event: "handler.emitted"},
 			Rules: []runtimecontracts.HandlerRuleEntry{{
@@ -1446,7 +1452,7 @@ func TestExecutor_RejectsAmbiguousHandlerTopLevelEmitWithRulesWithoutRuleEmit(t 
 		NodeID:     "node-1",
 		FlowID:     "flow-1",
 		ChainDepth: 1,
-		Event:      events.NewProjectionEvent("evt-1", "task.completed", "", "", json.RawMessage(`{"score":9}`), 0, "", "", events.EventEnvelope{}, time.Time{}),
+		Event:      eventtest.Projection("evt-1", "task.completed", "", "", json.RawMessage(`{"score":9}`), 0, "", "", events.EventEnvelope{}, time.Time{}),
 		Handler: runtimecontracts.SystemNodeEventHandler{
 			Emit: runtimecontracts.EmitSpec{Event: "handler.emitted"},
 			Rules: []runtimecontracts.HandlerRuleEntry{{
@@ -1481,7 +1487,7 @@ func TestExecutor_RuleDataAccumulationRunsBeforeTopLevelWrites(t *testing.T) {
 		EntityID: "entity-1",
 		NodeID:   "node-1",
 		FlowID:   "flow-1",
-		Event:    events.NewProjectionEvent("evt-1", "task.completed", "", "", json.RawMessage(`{"score":9}`), 0, "", "", events.EventEnvelope{}, time.Time{}),
+		Event:    eventtest.Projection("evt-1", "task.completed", "", "", json.RawMessage(`{"score":9}`), 0, "", "", events.EventEnvelope{}, time.Time{}),
 		Handler: runtimecontracts.SystemNodeEventHandler{
 			DataAccumulation: runtimecontracts.WorkflowDataAccumulation{
 				Writes: []runtimecontracts.WorkflowDataWrite{{
@@ -1535,7 +1541,7 @@ func TestExecutor_RulesDoNotSeeCurrentHandlerTopLevelWritesBeforeSelection(t *te
 		EntityID: "entity-1",
 		NodeID:   "node-1",
 		FlowID:   "flow-1",
-		Event:    events.NewProjectionEvent("evt-1", "task.completed", "", "", json.RawMessage(`{}`), 0, "", "", events.EventEnvelope{}, time.Time{}),
+		Event:    eventtest.Projection("evt-1", "task.completed", "", "", json.RawMessage(`{}`), 0, "", "", events.EventEnvelope{}, time.Time{}),
 		Handler: runtimecontracts.SystemNodeEventHandler{
 			DataAccumulation: runtimecontracts.WorkflowDataAccumulation{
 				Writes: []runtimecontracts.WorkflowDataWrite{{
@@ -1590,7 +1596,7 @@ func TestExecutor_OnCompleteDoesNotSeeCurrentHandlerTopLevelWritesBeforeSelectio
 		EntityID: "entity-1",
 		NodeID:   "node-1",
 		FlowID:   "flow-1",
-		Event:    events.NewProjectionEvent("evt-1", "task.completed", "", "", json.RawMessage(`{}`), 0, "", "", events.EventEnvelope{}, time.Time{}),
+		Event:    eventtest.Projection("evt-1", "task.completed", "", "", json.RawMessage(`{}`), 0, "", "", events.EventEnvelope{}, time.Time{}),
 		Handler: runtimecontracts.SystemNodeEventHandler{
 			DataAccumulation: runtimecontracts.WorkflowDataAccumulation{
 				Writes: []runtimecontracts.WorkflowDataWrite{{
@@ -1638,7 +1644,7 @@ func TestExecutor_ChainDepthOverflowInterceptsEmitsButSucceeds(t *testing.T) {
 		NodeID:     "node-1",
 		FlowID:     "flow-1",
 		ChainDepth: 1,
-		Event:      events.NewProjectionEvent("evt-1", "task.completed", "", "", json.RawMessage(`{}`), 0, "", "", events.EventEnvelope{}, time.Time{}),
+		Event:      eventtest.Projection("evt-1", "task.completed", "", "", json.RawMessage(`{}`), 0, "", "", events.EventEnvelope{}, time.Time{}),
 		Handler: runtimecontracts.SystemNodeEventHandler{
 			AdvancesTo: "done",
 			Emit:       runtimecontracts.EmitSpec{Event: "task.followup"},
@@ -1684,7 +1690,7 @@ func TestExecutor_FanOutCreatesShapedEmitIntentsAndStopsLoop(t *testing.T) {
 		NodeID:     "node-1",
 		FlowID:     "flow-1",
 		ChainDepth: 1,
-		Event:      events.NewProjectionEvent("evt-1", "task.completed", "", "", json.RawMessage(`{"items":["a","b"]}`), 0, "", "", events.EventEnvelope{}, time.Time{}),
+		Event:      eventtest.Projection("evt-1", "task.completed", "", "", json.RawMessage(`{"items":["a","b"]}`), 0, "", "", events.EventEnvelope{}, time.Time{}),
 		Handler: runtimecontracts.SystemNodeEventHandler{
 			FanOut: &runtimecontracts.FanOutSpec{
 				ItemsFrom: "payload.items",
@@ -1742,7 +1748,7 @@ func TestExecutor_PayloadTransformSeesDataAccumulationWrites(t *testing.T) {
 		EntityID: "vertical-1",
 		NodeID:   "node-1",
 		FlowID:   "flow-1",
-		Event: events.NewProjectionEvent("evt-1",
+		Event: eventtest.Projection("evt-1",
 			"vertical.discovered", "", "", json.RawMessage(`{"mode":"corpus","discovery_context":{"source":"corpus"}}`), 0, "", "", events.EventEnvelope{}, time.Time{}),
 
 		Handler: runtimecontracts.SystemNodeEventHandler{
@@ -1836,8 +1842,10 @@ func TestExecutor_EmitIntentUsesTargetStateFlowIdentityBeforeInboundSource(t *te
 				EntityID: targetEntityID,
 				NodeID:   "validation-router",
 				FlowID:   "validation",
-				Event: (events.NewProjectionEvent("evt-1",
-					"scoring/vertical.resumed", "", "", json.RawMessage(`{"vertical_id":"`+sourceEntityID+`"}`), 0, "", "", events.EventEnvelope{}, time.Time{})).WithEntityID(sourceEntityID).WithFlowInstance(sourceFlowInstance),
+				Event: eventtest.WithFlowInstance(eventtest.WithEntityID((eventtest.Projection("evt-1",
+					"scoring/vertical.resumed", "", "", json.RawMessage(`{"vertical_id":"`+sourceEntityID+`"}`), 0, "", "", events.EventEnvelope{}, time.Time{})), sourceEntityID),
+					sourceFlowInstance),
+
 				Handler: runtimecontracts.SystemNodeEventHandler{
 					Emit: runtimecontracts.EmitSpec{
 						Event: eventType,
@@ -1893,8 +1901,10 @@ func TestExecutor_EmitIntentFallsBackToInboundFlowWhenStateFlowPathNormalizesEmp
 		EntityID: "entity-1",
 		NodeID:   "node-1",
 		FlowID:   "root",
-		Event: (events.NewProjectionEvent("evt-1",
-			"root.started", "", "", json.RawMessage(`{}`), 0, "", "", events.EventEnvelope{}, time.Time{})).WithEntityID("entity-1").WithFlowInstance("source/inst-1"),
+		Event: eventtest.WithFlowInstance(eventtest.WithEntityID((eventtest.Projection("evt-1",
+			"root.started", "", "", json.RawMessage(`{}`), 0, "", "", events.EventEnvelope{}, time.Time{})), "entity-1"),
+			"source/inst-1"),
+
 		Handler: runtimecontracts.SystemNodeEventHandler{
 			Emit: runtimecontracts.EmitSpec{Event: "root.done"},
 		},
@@ -2007,7 +2017,7 @@ func TestExecutor_DeclarativeEmitSurfacesUseProducerSourceRouteNamespace(t *test
 				EntityID: "component-entity",
 				NodeID:   "component-node",
 				FlowID:   "component-scaffold",
-				Event:    events.NewProjectionEvent("evt-1", events.EventType(eventType), "", "", payload, 0, "", "", events.EventEnvelope{}, time.Time{}),
+				Event:    eventtest.Projection("evt-1", events.EventType(eventType), "", "", payload, 0, "", "", events.EventEnvelope{}, time.Time{}),
 				Handler:  tc.handler,
 				State: testStateSnapshot("ready", map[string]any{
 					"flow_path":            "component-scaffold/component-1",
@@ -2053,7 +2063,7 @@ func TestExecutor_FanOutEmitUsesProducerSourceRouteNamespace(t *testing.T) {
 		EntityID: "component-entity",
 		NodeID:   "component-node",
 		FlowID:   "component-scaffold",
-		Event:    events.NewProjectionEvent("evt-1", "repo-scaffold/repo_scaffold.repo_scaffolded", "", "", json.RawMessage(`{"items":[{"id":"a"},{"id":"b"}]}`), 0, "", "", events.EventEnvelope{}, time.Time{}),
+		Event:    eventtest.Projection("evt-1", "repo-scaffold/repo_scaffold.repo_scaffolded", "", "", json.RawMessage(`{"items":[{"id":"a"},{"id":"b"}]}`), 0, "", "", events.EventEnvelope{}, time.Time{}),
 		Handler: runtimecontracts.SystemNodeEventHandler{
 			FanOut: &runtimecontracts.FanOutSpec{
 				ItemsFrom: "payload.items",
@@ -2102,7 +2112,7 @@ func TestExecutor_StaticProducerTargetRouteDoesNotOwnEventNamespace(t *testing.T
 		EntityID: "repo-entity",
 		NodeID:   "repo-node",
 		FlowID:   "repo-scaffold",
-		Event:    events.NewProjectionEvent("evt-1", "repo.commit_ready", "", "", json.RawMessage(`{}`), 0, "", "", events.EventEnvelope{}, time.Time{}),
+		Event:    eventtest.Projection("evt-1", "repo.commit_ready", "", "", json.RawMessage(`{}`), 0, "", "", events.EventEnvelope{}, time.Time{}),
 		Handler: runtimecontracts.SystemNodeEventHandler{
 			Emit: runtimecontracts.EmitSpec{
 				Event: "repo-scaffold/repo_scaffold.repo_scaffolded",
@@ -2168,12 +2178,15 @@ func TestExecutor_ChildPinOutputTargetsStoredParentRoute(t *testing.T) {
 		EntityID: "child-ent",
 		NodeID:   "child-node",
 		FlowID:   "child",
-		Event: (events.NewProjectionEvent("evt-1",
-			"child/requested", "", "", json.RawMessage(`{}`), 0, "", "", events.EventEnvelope{}, time.Time{})).WithEntityID("wrong-parent").WithFlowInstance("wrong/root").WithSourceRoute(events.RouteIdentity{
-			FlowID:       "wrong",
-			FlowInstance: "wrong/root",
-			EntityID:     "wrong-parent",
-		}),
+		Event: eventtest.WithSourceRoute(eventtest.WithFlowInstance(eventtest.WithEntityID((eventtest.Projection("evt-1",
+			"child/requested", "", "", json.RawMessage(`{}`), 0, "", "", events.EventEnvelope{}, time.Time{})), "wrong-parent"),
+			"wrong/root"),
+			events.RouteIdentity{
+				FlowID:       "wrong",
+				FlowInstance: "wrong/root",
+				EntityID:     "wrong-parent",
+			}),
+
 		Handler: runtimecontracts.SystemNodeEventHandler{
 			Emit: runtimecontracts.EmitSpec{Event: "child.done"},
 		},
@@ -2235,7 +2248,7 @@ func TestExecutor_DataAccumulationTargetPathWritesNestedEntityLeaf(t *testing.T)
 	result, err := exec.Execute(context.Background(), ExecutionRequest{
 		EntityID: "entity-1",
 		NodeID:   "node-1",
-		Event:    events.NewProjectionEvent("evt-1", "task.completed", "", "", json.RawMessage(`{"summary":"ready"}`), 0, "", "", events.EventEnvelope{}, time.Time{}),
+		Event:    eventtest.Projection("evt-1", "task.completed", "", "", json.RawMessage(`{"summary":"ready"}`), 0, "", "", events.EventEnvelope{}, time.Time{}),
 		Handler: runtimecontracts.SystemNodeEventHandler{
 			DataAccumulation: runtimecontracts.WorkflowDataAccumulation{
 				Writes: []runtimecontracts.WorkflowDataWrite{{
@@ -2281,7 +2294,7 @@ func TestExecutor_RejectsUndeclaredNestedEntityWriteBeforeExecution(t *testing.T
 	_, err = exec.Execute(context.Background(), ExecutionRequest{
 		EntityID: "entity-1",
 		NodeID:   "node-1",
-		Event:    events.NewProjectionEvent("evt-1", "task.completed", "", "", json.RawMessage(`{}`), 0, "", "", events.EventEnvelope{}, time.Time{}),
+		Event:    eventtest.Projection("evt-1", "task.completed", "", "", json.RawMessage(`{}`), 0, "", "", events.EventEnvelope{}, time.Time{}),
 		Handler: runtimecontracts.SystemNodeEventHandler{
 			Compute: &runtimecontracts.ComputeSpec{
 				Operation: runtimecontracts.ComputeOpCount,
@@ -2316,7 +2329,7 @@ func TestExecutor_ClearRemovesNestedEntityLeaf(t *testing.T) {
 	result, err := exec.Execute(context.Background(), ExecutionRequest{
 		EntityID: "entity-1",
 		NodeID:   "node-1",
-		Event:    events.NewProjectionEvent("evt-1", "task.completed", "", "", json.RawMessage(`{}`), 0, "", "", events.EventEnvelope{}, time.Time{}),
+		Event:    eventtest.Projection("evt-1", "task.completed", "", "", json.RawMessage(`{}`), 0, "", "", events.EventEnvelope{}, time.Time{}),
 		Handler: runtimecontracts.SystemNodeEventHandler{
 			Clear: &runtimecontracts.ClearSpec{Target: "entity.analysis.summary"},
 		},
@@ -2367,7 +2380,7 @@ func TestExecutor_ClearSpecialTargetsBypassContractValidation(t *testing.T) {
 		EntityID: "entity-1",
 		NodeID:   "node-1",
 		FlowID:   "root",
-		Event:    events.NewProjectionEvent("evt-1", "task.completed", "", "", json.RawMessage(`{}`), 0, "", "", events.EventEnvelope{}, time.Time{}),
+		Event:    eventtest.Projection("evt-1", "task.completed", "", "", json.RawMessage(`{}`), 0, "", "", events.EventEnvelope{}, time.Time{}),
 		Handler: runtimecontracts.SystemNodeEventHandler{
 			Clear: &runtimecontracts.ClearSpec{Targets: []string{"pending_dedup", "accumulator_state"}},
 		},
@@ -2405,7 +2418,7 @@ func TestExecutor_EmitFieldsCELFailureReturnsError(t *testing.T) {
 		EntityID: "vertical-1",
 		NodeID:   "node-1",
 		FlowID:   "flow-1",
-		Event: events.NewProjectionEvent("evt-1",
+		Event: eventtest.Projection("evt-1",
 			"vertical.discovered", "", "", json.RawMessage(`{"mode":"corpus"}`), 0, "", "", events.EventEnvelope{}, time.Time{}),
 
 		Handler: runtimecontracts.SystemNodeEventHandler{
@@ -2439,7 +2452,7 @@ func TestExecutor_FanOutEmptyPersistsCountAndContinues(t *testing.T) {
 		EntityID: "entity-1",
 		NodeID:   "node-1",
 		FlowID:   "flow-1",
-		Event:    events.NewProjectionEvent("evt-1", "task.completed", "", "", json.RawMessage(`{"items":[]}`), 0, "", "", events.EventEnvelope{}, time.Time{}),
+		Event:    eventtest.Projection("evt-1", "task.completed", "", "", json.RawMessage(`{"items":[]}`), 0, "", "", events.EventEnvelope{}, time.Time{}),
 		Handler: runtimecontracts.SystemNodeEventHandler{
 			FanOut: &runtimecontracts.FanOutSpec{
 				ItemsFrom: "payload.items",
@@ -2479,7 +2492,7 @@ func TestExecutor_FanOutInternalCountBypassesEntityContractValidation(t *testing
 		EntityID: "entity-1",
 		NodeID:   "node-1",
 		FlowID:   "root",
-		Event:    events.NewProjectionEvent("evt-1", "task.completed", "", "", json.RawMessage(`{"items":[]}`), 0, "", "", events.EventEnvelope{}, time.Time{}),
+		Event:    eventtest.Projection("evt-1", "task.completed", "", "", json.RawMessage(`{"items":[]}`), 0, "", "", events.EventEnvelope{}, time.Time{}),
 		Handler: runtimecontracts.SystemNodeEventHandler{
 			FanOut: &runtimecontracts.FanOutSpec{
 				ItemsFrom: "payload.items",
@@ -2516,7 +2529,7 @@ func TestExecutor_FanOutUsesExplicitEmitEvent(t *testing.T) {
 		NodeID:     "node-1",
 		FlowID:     "flow-1",
 		ChainDepth: 1,
-		Event:      events.NewProjectionEvent("evt-1", "batch.submitted", "", "", json.RawMessage(`{"items":[{"kind":"a"},{"kind":"b"}]}`), 0, "", "", events.EventEnvelope{}, time.Time{}),
+		Event:      eventtest.Projection("evt-1", "batch.submitted", "", "", json.RawMessage(`{"items":[{"kind":"a"},{"kind":"b"}]}`), 0, "", "", events.EventEnvelope{}, time.Time{}),
 		Handler: runtimecontracts.SystemNodeEventHandler{
 			FanOut: &runtimecontracts.FanOutSpec{
 				ItemsFrom: "payload.items",
@@ -2558,7 +2571,7 @@ func TestExecutor_GuardKillTransitionsToKilledStateWhenDeclared(t *testing.T) {
 		EntityID: "entity-1",
 		NodeID:   "node-1",
 		FlowID:   "flow-1",
-		Event:    events.NewProjectionEvent("evt-1", "check.requested", "", "", json.RawMessage(`{"score":50}`), 0, "", "", events.EventEnvelope{}, time.Time{}),
+		Event:    eventtest.Projection("evt-1", "check.requested", "", "", json.RawMessage(`{"score":50}`), 0, "", "", events.EventEnvelope{}, time.Time{}),
 		Handler: runtimecontracts.SystemNodeEventHandler{
 			Guard: &runtimecontracts.GuardSpec{
 				Check:  "payload.score >= policy.threshold",
@@ -2599,7 +2612,7 @@ func TestExecutor_GroupByStoresGroupedItems(t *testing.T) {
 		EntityID: "entity-1",
 		NodeID:   "node-1",
 		FlowID:   "flow-1",
-		Event:    events.NewProjectionEvent("evt-1", "items.submitted", "", "", json.RawMessage(`{"items":[{"name":"a","category":"x"},{"name":"b","category":"y"},{"name":"c","category":"x"}]}`), 0, "", "", events.EventEnvelope{}, time.Time{}),
+		Event:    eventtest.Projection("evt-1", "items.submitted", "", "", json.RawMessage(`{"items":[{"name":"a","category":"x"},{"name":"b","category":"y"},{"name":"c","category":"x"}]}`), 0, "", "", events.EventEnvelope{}, time.Time{}),
 		Handler: runtimecontracts.SystemNodeEventHandler{
 			GroupBy: &runtimecontracts.GroupBySpec{
 				ItemsFrom: "payload.items",
@@ -2643,7 +2656,7 @@ func TestExecutor_GroupByBareKeyUsesItemScopeWithoutFallbackAcrossRoots(t *testi
 		EntityID: "entity-1",
 		NodeID:   "node-1",
 		FlowID:   "flow-1",
-		Event:    events.NewProjectionEvent("evt-1", "items.submitted", "", "", json.RawMessage(`{"category":"payload","items":[{"name":"a","category":"x"},{"name":"b","category":"y"},{"name":"c","category":"x"}]}`), 0, "", "", events.EventEnvelope{}, time.Time{}),
+		Event:    eventtest.Projection("evt-1", "items.submitted", "", "", json.RawMessage(`{"category":"payload","items":[{"name":"a","category":"x"},{"name":"b","category":"y"},{"name":"c","category":"x"}]}`), 0, "", "", events.EventEnvelope{}, time.Time{}),
 		Handler: runtimecontracts.SystemNodeEventHandler{
 			GroupBy: &runtimecontracts.GroupBySpec{
 				ItemsFrom: "payload.items",
@@ -2693,7 +2706,7 @@ func TestExecutor_ClearGatesWildcardUsesNodeGateSchema(t *testing.T) {
 		EntityID: "entity-1",
 		NodeID:   "node-1",
 		FlowID:   "flow-1",
-		Event:    events.NewProjectionEvent("evt-1", "task.completed", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}),
+		Event:    eventtest.Projection("evt-1", "task.completed", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}),
 		Handler: runtimecontracts.SystemNodeEventHandler{
 			ClearGates: []string{"*"},
 		},
@@ -2736,7 +2749,7 @@ func TestExecutor_ClearGatesRunsBeforeGuardEvaluation(t *testing.T) {
 		EntityID: "entity-1",
 		NodeID:   "node-1",
 		FlowID:   "flow-1",
-		Event:    events.NewProjectionEvent("evt-1", "task.completed", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}),
+		Event:    eventtest.Projection("evt-1", "task.completed", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}),
 		Handler: runtimecontracts.SystemNodeEventHandler{
 			ClearGates: []string{"review"},
 			Guard: &runtimecontracts.GuardSpec{
@@ -2779,7 +2792,7 @@ func TestExecutor_ActionRegistryEmitsAndRunsActionRunner(t *testing.T) {
 		EntityID: "entity-1",
 		NodeID:   "node-1",
 		FlowID:   "flow-1",
-		Event:    events.NewProjectionEvent("evt-1", "task.completed", "", "", json.RawMessage(`{"score":9}`), 0, "", "", events.EventEnvelope{}, time.Time{}),
+		Event:    eventtest.Projection("evt-1", "task.completed", "", "", json.RawMessage(`{"score":9}`), 0, "", "", events.EventEnvelope{}, time.Time{}),
 		Handler: runtimecontracts.SystemNodeEventHandler{
 			Action: runtimecontracts.ActionSpec{ID: "notify"},
 		},
@@ -2834,7 +2847,7 @@ func TestExecutor_RuleActionRunsOnlyForSelectedRule(t *testing.T) {
 		EntityID: "entity-1",
 		NodeID:   "node-1",
 		FlowID:   "flow-1",
-		Event:    events.NewProjectionEvent("evt-1", "refund.requested", "", "", json.RawMessage(`{"amount":250}`), 0, "", "", events.EventEnvelope{}, time.Time{}),
+		Event:    eventtest.Projection("evt-1", "refund.requested", "", "", json.RawMessage(`{"amount":250}`), 0, "", "", events.EventEnvelope{}, time.Time{}),
 		Handler: runtimecontracts.SystemNodeEventHandler{
 			Rules: []runtimecontracts.HandlerRuleEntry{
 				{
@@ -2887,7 +2900,7 @@ func TestExecutor_RejectsAmbiguousHandlerTopLevelActionWithRules(t *testing.T) {
 		EntityID: "entity-1",
 		NodeID:   "node-1",
 		FlowID:   "flow-1",
-		Event:    events.NewProjectionEvent("evt-1", "refund.requested", "", "", json.RawMessage(`{"amount":250}`), 0, "", "", events.EventEnvelope{}, time.Time{}),
+		Event:    eventtest.Projection("evt-1", "refund.requested", "", "", json.RawMessage(`{"amount":250}`), 0, "", "", events.EventEnvelope{}, time.Time{}),
 		Handler: runtimecontracts.SystemNodeEventHandler{
 			Action: runtimecontracts.ActionSpec{ID: "handler_action"},
 			Rules: []runtimecontracts.HandlerRuleEntry{{
@@ -2974,7 +2987,7 @@ func TestExecutor_RejectsUnsupportedRuleActionContextsBeforeExecution(t *testing
 				EntityID: "entity-1",
 				NodeID:   "node-1",
 				FlowID:   "flow-1",
-				Event:    events.NewProjectionEvent("evt-1", "task.completed", "", "", json.RawMessage(`{"ok":true}`), 0, "", "", events.EventEnvelope{}, time.Time{}),
+				Event:    eventtest.Projection("evt-1", "task.completed", "", "", json.RawMessage(`{"ok":true}`), 0, "", "", events.EventEnvelope{}, time.Time{}),
 				Handler:  tc.handler,
 				State:    testStateSnapshot("pending", map[string]any{}, nil, map[string]map[string]any{}),
 			})
@@ -3085,7 +3098,7 @@ func TestExecutor_ActionRegistryEmitContractViolationRejectsHandler(t *testing.T
 		EntityID: "entity-1",
 		NodeID:   "node-1",
 		FlowID:   "flow-1",
-		Event:    events.NewProjectionEvent("evt-1", "task.completed", "", "", json.RawMessage(`{"score":9}`), 0, "", "", events.EventEnvelope{}, time.Time{}),
+		Event:    eventtest.Projection("evt-1", "task.completed", "", "", json.RawMessage(`{"score":9}`), 0, "", "", events.EventEnvelope{}, time.Time{}),
 		Handler: runtimecontracts.SystemNodeEventHandler{
 			Action: runtimecontracts.ActionSpec{ID: "notify"},
 		},
@@ -3136,7 +3149,7 @@ func TestExecutor_GuardOnFailEscalateCreatesEmitIntent(t *testing.T) {
 		NodeID:     "node-1",
 		FlowID:     "flow-1",
 		ChainDepth: 1,
-		Event:      events.NewProjectionEvent("evt-1", "task.completed", "", "", json.RawMessage(`{"ok":false}`), 0, "", "", events.EventEnvelope{}, time.Time{}),
+		Event:      eventtest.Projection("evt-1", "task.completed", "", "", json.RawMessage(`{"ok":false}`), 0, "", "", events.EventEnvelope{}, time.Time{}),
 		Handler: runtimecontracts.SystemNodeEventHandler{
 			Guard: &runtimecontracts.GuardSpec{
 				Check:  "payload.ok == true",

--- a/internal/runtime/engine/helpers_test.go
+++ b/internal/runtime/engine/helpers_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func TestArrivalIdentifier_PriorityOrder(t *testing.T) {
-	evt := eventtest.Projection("evt-1", events.EventType(""), "agent-source", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{})
+	evt := eventtest.RootIngress("evt-1", events.EventType(""), "agent-source", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{})
 	payload := map[string]any{
 		"id":       "payload-id",
 		"event_id": "payload-event",
@@ -30,19 +30,19 @@ func TestArrivalIdentifier_PriorityOrder(t *testing.T) {
 		t.Fatalf("arrivalIdentifier = %q", got)
 	}
 
-	if got := arrivalIdentifier(eventtest.Projection("", events.EventType(""), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}), payload); got != "payload-event" {
+	if got := arrivalIdentifier(eventtest.RootIngress("", events.EventType(""), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}), payload); got != "payload-event" {
 		t.Fatalf("arrivalIdentifier payload event fallback = %q", got)
 	}
 	delete(payload, "event_id")
-	if got := arrivalIdentifier(eventtest.Projection("", events.EventType(""), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}), payload); got != "payload-id" {
+	if got := arrivalIdentifier(eventtest.RootIngress("", events.EventType(""), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}), payload); got != "payload-id" {
 		t.Fatalf("arrivalIdentifier payload id fallback = %q", got)
 	}
 	delete(payload, "id")
-	if got := arrivalIdentifier(eventtest.Projection("", events.EventType(""), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}), payload); got != "payload-item" {
+	if got := arrivalIdentifier(eventtest.RootIngress("", events.EventType(""), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}), payload); got != "payload-item" {
 		t.Fatalf("arrivalIdentifier item fallback = %q", got)
 	}
 
-	if got := arrivalIdentifier(eventtest.Projection("evt-2", events.EventType(""), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}), map[string]any{"dimension": "not-identity"}); got != "evt-2" {
+	if got := arrivalIdentifier(eventtest.RootIngress("evt-2", events.EventType(""), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}), map[string]any{"dimension": "not-identity"}); got != "evt-2" {
 		t.Fatalf("arrivalIdentifier should ignore dimension payloads, got %q", got)
 	}
 }
@@ -52,7 +52,7 @@ func TestDedupIdentifier_UsesContractConfiguredKey(t *testing.T) {
 		"dimension": "retention_architecture",
 		"from":      "legacy-sender",
 	})}
-	got := dedupIdentifier(base, ExecutionState{}, eventtest.Projection("evt-1", events.EventType(""), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}), &runtimecontracts.AccumulateSpec{
+	got := dedupIdentifier(base, ExecutionState{}, eventtest.RootIngress("evt-1", events.EventType(""), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}), &runtimecontracts.AccumulateSpec{
 		DedupBy:   "payload.dimension",
 		DedupPath: paths.Parse("payload.dimension"),
 	})
@@ -66,7 +66,7 @@ func TestDedupIdentifier_DefaultsToEventIdentityBeforeSource(t *testing.T) {
 		"item_id": "payload-item",
 		"source":  "legacy-source",
 	})}
-	got := dedupIdentifier(base, ExecutionState{}, eventtest.Projection("evt-1", events.EventType(""), "agent-source", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}), nil)
+	got := dedupIdentifier(base, ExecutionState{}, eventtest.RootIngress("evt-1", events.EventType(""), "agent-source", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}), nil)
 	if got != "evt-1" {
 		t.Fatalf("dedupIdentifier default = %q", got)
 	}

--- a/internal/runtime/engine/helpers_test.go
+++ b/internal/runtime/engine/helpers_test.go
@@ -10,12 +10,13 @@ import (
 	"github.com/division-sh/swarm/internal/runtime/core/values"
 	"github.com/division-sh/swarm/internal/runtime/workflowexpr"
 
+	"github.com/division-sh/swarm/internal/events/eventtest"
 	"gopkg.in/yaml.v3"
 	"time"
 )
 
 func TestArrivalIdentifier_PriorityOrder(t *testing.T) {
-	evt := events.NewProjectionEvent("evt-1", events.EventType(""), "agent-source", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{})
+	evt := eventtest.Projection("evt-1", events.EventType(""), "agent-source", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{})
 	payload := map[string]any{
 		"id":       "payload-id",
 		"event_id": "payload-event",
@@ -29,19 +30,19 @@ func TestArrivalIdentifier_PriorityOrder(t *testing.T) {
 		t.Fatalf("arrivalIdentifier = %q", got)
 	}
 
-	if got := arrivalIdentifier(events.NewProjectionEvent("", events.EventType(""), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}), payload); got != "payload-event" {
+	if got := arrivalIdentifier(eventtest.Projection("", events.EventType(""), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}), payload); got != "payload-event" {
 		t.Fatalf("arrivalIdentifier payload event fallback = %q", got)
 	}
 	delete(payload, "event_id")
-	if got := arrivalIdentifier(events.NewProjectionEvent("", events.EventType(""), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}), payload); got != "payload-id" {
+	if got := arrivalIdentifier(eventtest.Projection("", events.EventType(""), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}), payload); got != "payload-id" {
 		t.Fatalf("arrivalIdentifier payload id fallback = %q", got)
 	}
 	delete(payload, "id")
-	if got := arrivalIdentifier(events.NewProjectionEvent("", events.EventType(""), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}), payload); got != "payload-item" {
+	if got := arrivalIdentifier(eventtest.Projection("", events.EventType(""), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}), payload); got != "payload-item" {
 		t.Fatalf("arrivalIdentifier item fallback = %q", got)
 	}
 
-	if got := arrivalIdentifier(events.NewProjectionEvent("evt-2", events.EventType(""), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}), map[string]any{"dimension": "not-identity"}); got != "evt-2" {
+	if got := arrivalIdentifier(eventtest.Projection("evt-2", events.EventType(""), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}), map[string]any{"dimension": "not-identity"}); got != "evt-2" {
 		t.Fatalf("arrivalIdentifier should ignore dimension payloads, got %q", got)
 	}
 }
@@ -51,7 +52,7 @@ func TestDedupIdentifier_UsesContractConfiguredKey(t *testing.T) {
 		"dimension": "retention_architecture",
 		"from":      "legacy-sender",
 	})}
-	got := dedupIdentifier(base, ExecutionState{}, events.NewProjectionEvent("evt-1", events.EventType(""), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}), &runtimecontracts.AccumulateSpec{
+	got := dedupIdentifier(base, ExecutionState{}, eventtest.Projection("evt-1", events.EventType(""), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}), &runtimecontracts.AccumulateSpec{
 		DedupBy:   "payload.dimension",
 		DedupPath: paths.Parse("payload.dimension"),
 	})
@@ -65,7 +66,7 @@ func TestDedupIdentifier_DefaultsToEventIdentityBeforeSource(t *testing.T) {
 		"item_id": "payload-item",
 		"source":  "legacy-source",
 	})}
-	got := dedupIdentifier(base, ExecutionState{}, events.NewProjectionEvent("evt-1", events.EventType(""), "agent-source", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}), nil)
+	got := dedupIdentifier(base, ExecutionState{}, eventtest.Projection("evt-1", events.EventType(""), "agent-source", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}), nil)
 	if got != "evt-1" {
 		t.Fatalf("dedupIdentifier default = %q", got)
 	}

--- a/internal/runtime/llm/cli_runtime_supported_path_test.go
+++ b/internal/runtime/llm/cli_runtime_supported_path_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/division-sh/swarm/internal/config"
 	"github.com/division-sh/swarm/internal/events"
+	"github.com/division-sh/swarm/internal/events/eventtest"
 	runtimebus "github.com/division-sh/swarm/internal/runtime/bus"
 	runtimeactors "github.com/division-sh/swarm/internal/runtime/core/actors"
 	"github.com/division-sh/swarm/internal/runtime/core/toolcapabilities"
@@ -35,7 +36,7 @@ func (e *firstTurnWorkflowToolExec) Execute(ctx context.Context, name string, in
 		return e.readPayload, nil
 	case "emit_category_assessed":
 		if recorder, ok := runtimebus.EmittedEventsRecorderFromContext(ctx); ok {
-			recorder.Append(events.NewProjectionEvent("", events.EventType("discovery/category.assessed"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}))
+			recorder.Append(eventtest.Projection("", events.EventType("discovery/category.assessed"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}))
 		}
 		return map[string]any{"emitted": true, "input": input}, nil
 	default:

--- a/internal/runtime/llm/cli_runtime_supported_path_test.go
+++ b/internal/runtime/llm/cli_runtime_supported_path_test.go
@@ -36,7 +36,7 @@ func (e *firstTurnWorkflowToolExec) Execute(ctx context.Context, name string, in
 		return e.readPayload, nil
 	case "emit_category_assessed":
 		if recorder, ok := runtimebus.EmittedEventsRecorderFromContext(ctx); ok {
-			recorder.Append(eventtest.Projection("", events.EventType("discovery/category.assessed"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}))
+			recorder.Append(eventtest.RootIngress("", events.EventType("discovery/category.assessed"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}))
 		}
 		return map[string]any{"emitted": true, "input": input}, nil
 	default:

--- a/internal/runtime/llm/session_events_test.go
+++ b/internal/runtime/llm/session_events_test.go
@@ -768,7 +768,7 @@ func TestAnthropicAPIRuntime_ContinueSessionReMarksInboundDeliveryForReusedSessi
 
 	ctx := runtimeactors.WithActor(
 		runtimebus.WithInboundEvent(
-			sessions.WithScope(context.Background(), sessions.RuntimeModeSession.String(), sessions.SessionScopeFlow.String(), "support/inst-1"), eventtest.Projection("evt-1", events.EventType(""), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}),
+			sessions.WithScope(context.Background(), sessions.RuntimeModeSession.String(), sessions.SessionScopeFlow.String(), "support/inst-1"), eventtest.RootIngress("evt-1", events.EventType(""), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}),
 		),
 		runtimeactors.AgentConfig{
 			ID:           "agent-1",
@@ -809,7 +809,7 @@ func TestAnthropicAPIRuntime_ContinueSessionFailsClosedWhenDeliveryRestampFails(
 	}, sessions.NewInMemoryRegistry(0), "worker-1", nil, nil, nil, publisher)
 	ctx := runtimeactors.WithActor(
 		runtimebus.WithInboundEvent(
-			sessions.WithScope(context.Background(), sessions.RuntimeModeSession.String(), sessions.SessionScopeFlow.String(), "support/inst-1"), eventtest.Projection("evt-1", events.EventType(""), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}),
+			sessions.WithScope(context.Background(), sessions.RuntimeModeSession.String(), sessions.SessionScopeFlow.String(), "support/inst-1"), eventtest.RootIngress("evt-1", events.EventType(""), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}),
 		),
 		runtimeactors.AgentConfig{
 			ID:           "agent-1",
@@ -843,7 +843,7 @@ func TestClaudeCLIRuntime_ContinueSessionFailsClosedWhenDeliveryRestampFails(t *
 	runtime := NewClaudeCLIRuntime(&config.Config{}, sessions.NewInMemoryRegistry(0), "worker-1", nil, nil, nil, nil, publisher)
 	ctx := runtimeactors.WithActor(
 		runtimebus.WithInboundEvent(
-			sessions.WithScope(context.Background(), sessions.RuntimeModeSession.String(), sessions.SessionScopeFlow.String(), "support/inst-1"), eventtest.Projection("evt-1", events.EventType(""), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}),
+			sessions.WithScope(context.Background(), sessions.RuntimeModeSession.String(), sessions.SessionScopeFlow.String(), "support/inst-1"), eventtest.RootIngress("evt-1", events.EventType(""), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}),
 		),
 		runtimeactors.AgentConfig{
 			ID:           "agent-1",
@@ -874,13 +874,22 @@ func TestClaudeCLIRuntime_ContinueSessionFailsClosedWhenDeliveryRestampFails(t *
 
 func TestEnrichTurnRecordIncludesTriggerToolsAndEmits(t *testing.T) {
 	ctx := runtimecorrelation.WithRunID(context.Background(), "run-123")
-	ctx = runtimebus.WithInboundEvent(ctx, eventtest.WithEnvelope((eventtest.Projection("11111111-1111-1111-1111-111111111111",
-
-		events.EventType("scan.requested"), "", "", []byte(`{"entity_id":"22222222-2222-2222-2222-222222222222"}`), 0, "run-123", "", events.EventEnvelope{}, time.Time{})), events.EventEnvelope{EntityID: "22222222-2222-2222-2222-222222222222"}))
+	ctx = runtimebus.WithInboundEvent(ctx, eventtest.RootIngress(
+		"11111111-1111-1111-1111-111111111111",
+		events.EventType("scan.requested"),
+		"",
+		"",
+		[]byte(`{"entity_id":"22222222-2222-2222-2222-222222222222"}`),
+		0,
+		"run-123",
+		"",
+		events.EventEnvelope{EntityID: "22222222-2222-2222-2222-222222222222"},
+		time.Time{},
+	))
 	recorder := runtimebus.NewEmittedEventsRecorder()
-	recorder.Append(eventtest.Projection("", events.EventType("discovery/category.assessed"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}))
-	recorder.Append(eventtest.Projection("", events.EventType("discovery/category.assessed"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}))
-	recorder.Append(eventtest.Projection("", events.EventType("discovery/scan_complete"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}))
+	recorder.Append(eventtest.RootIngress("", events.EventType("discovery/category.assessed"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}))
+	recorder.Append(eventtest.RootIngress("", events.EventType("discovery/category.assessed"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}))
+	recorder.Append(eventtest.RootIngress("", events.EventType("discovery/scan_complete"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}))
 	recorder.AppendPublish(runtimebus.PublishDiagnostic{
 		EventID:   "44444444-4444-4444-4444-444444444444",
 		EventType: "discovery/category.assessed",

--- a/internal/runtime/llm/session_events_test.go
+++ b/internal/runtime/llm/session_events_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/division-sh/swarm/internal/config"
 	"github.com/division-sh/swarm/internal/events"
+	"github.com/division-sh/swarm/internal/events/eventtest"
 	runtimebus "github.com/division-sh/swarm/internal/runtime/bus"
 	runtimeactors "github.com/division-sh/swarm/internal/runtime/core/actors"
 	runtimecorrelation "github.com/division-sh/swarm/internal/runtime/correlation"
@@ -767,7 +768,7 @@ func TestAnthropicAPIRuntime_ContinueSessionReMarksInboundDeliveryForReusedSessi
 
 	ctx := runtimeactors.WithActor(
 		runtimebus.WithInboundEvent(
-			sessions.WithScope(context.Background(), sessions.RuntimeModeSession.String(), sessions.SessionScopeFlow.String(), "support/inst-1"), events.NewProjectionEvent("evt-1", events.EventType(""), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}),
+			sessions.WithScope(context.Background(), sessions.RuntimeModeSession.String(), sessions.SessionScopeFlow.String(), "support/inst-1"), eventtest.Projection("evt-1", events.EventType(""), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}),
 		),
 		runtimeactors.AgentConfig{
 			ID:           "agent-1",
@@ -808,7 +809,7 @@ func TestAnthropicAPIRuntime_ContinueSessionFailsClosedWhenDeliveryRestampFails(
 	}, sessions.NewInMemoryRegistry(0), "worker-1", nil, nil, nil, publisher)
 	ctx := runtimeactors.WithActor(
 		runtimebus.WithInboundEvent(
-			sessions.WithScope(context.Background(), sessions.RuntimeModeSession.String(), sessions.SessionScopeFlow.String(), "support/inst-1"), events.NewProjectionEvent("evt-1", events.EventType(""), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}),
+			sessions.WithScope(context.Background(), sessions.RuntimeModeSession.String(), sessions.SessionScopeFlow.String(), "support/inst-1"), eventtest.Projection("evt-1", events.EventType(""), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}),
 		),
 		runtimeactors.AgentConfig{
 			ID:           "agent-1",
@@ -842,7 +843,7 @@ func TestClaudeCLIRuntime_ContinueSessionFailsClosedWhenDeliveryRestampFails(t *
 	runtime := NewClaudeCLIRuntime(&config.Config{}, sessions.NewInMemoryRegistry(0), "worker-1", nil, nil, nil, nil, publisher)
 	ctx := runtimeactors.WithActor(
 		runtimebus.WithInboundEvent(
-			sessions.WithScope(context.Background(), sessions.RuntimeModeSession.String(), sessions.SessionScopeFlow.String(), "support/inst-1"), events.NewProjectionEvent("evt-1", events.EventType(""), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}),
+			sessions.WithScope(context.Background(), sessions.RuntimeModeSession.String(), sessions.SessionScopeFlow.String(), "support/inst-1"), eventtest.Projection("evt-1", events.EventType(""), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}),
 		),
 		runtimeactors.AgentConfig{
 			ID:           "agent-1",
@@ -873,13 +874,13 @@ func TestClaudeCLIRuntime_ContinueSessionFailsClosedWhenDeliveryRestampFails(t *
 
 func TestEnrichTurnRecordIncludesTriggerToolsAndEmits(t *testing.T) {
 	ctx := runtimecorrelation.WithRunID(context.Background(), "run-123")
-	ctx = runtimebus.WithInboundEvent(ctx, (events.NewProjectionEvent("11111111-1111-1111-1111-111111111111",
+	ctx = runtimebus.WithInboundEvent(ctx, eventtest.WithEnvelope((eventtest.Projection("11111111-1111-1111-1111-111111111111",
 
-		events.EventType("scan.requested"), "", "", []byte(`{"entity_id":"22222222-2222-2222-2222-222222222222"}`), 0, "run-123", "", events.EventEnvelope{}, time.Time{})).WithEnvelope(events.EventEnvelope{EntityID: "22222222-2222-2222-2222-222222222222"}))
+		events.EventType("scan.requested"), "", "", []byte(`{"entity_id":"22222222-2222-2222-2222-222222222222"}`), 0, "run-123", "", events.EventEnvelope{}, time.Time{})), events.EventEnvelope{EntityID: "22222222-2222-2222-2222-222222222222"}))
 	recorder := runtimebus.NewEmittedEventsRecorder()
-	recorder.Append(events.NewProjectionEvent("", events.EventType("discovery/category.assessed"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}))
-	recorder.Append(events.NewProjectionEvent("", events.EventType("discovery/category.assessed"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}))
-	recorder.Append(events.NewProjectionEvent("", events.EventType("discovery/scan_complete"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}))
+	recorder.Append(eventtest.Projection("", events.EventType("discovery/category.assessed"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}))
+	recorder.Append(eventtest.Projection("", events.EventType("discovery/category.assessed"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}))
+	recorder.Append(eventtest.Projection("", events.EventType("discovery/scan_complete"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}))
 	recorder.AppendPublish(runtimebus.PublishDiagnostic{
 		EventID:   "44444444-4444-4444-4444-444444444444",
 		EventType: "discovery/category.assessed",

--- a/internal/runtime/manager/flow_activation_test.go
+++ b/internal/runtime/manager/flow_activation_test.go
@@ -384,7 +384,7 @@ func testActivationRequest(bundle *runtimecontracts.WorkflowContractBundle, temp
 }
 
 func testFlowActivationTriggerEvent(eventID string) events.Event {
-	return eventtest.Projection(strings.TrimSpace(eventID),
+	return eventtest.RootIngress(strings.TrimSpace(eventID),
 		events.EventType("spawn.requested"),
 		"spawner", "", json.RawMessage(`{}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())
 
@@ -410,7 +410,7 @@ func findPublishedFlowActivationEvent(t *testing.T, bus *flowActivationTestBus, 
 		}
 	}
 	t.Fatalf("published events = %#v, want %s", bus.published, eventType)
-	return eventtest.Projection("", events.EventType(""), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{})
+	return eventtest.RootIngress("", events.EventType(""), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{})
 }
 
 func TestActivateFlowInstanceAddsDerivedRouteTableInstance(t *testing.T) {

--- a/internal/runtime/manager/flow_activation_test.go
+++ b/internal/runtime/manager/flow_activation_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/division-sh/swarm/internal/events"
+	"github.com/division-sh/swarm/internal/events/eventtest"
 	runtimebus "github.com/division-sh/swarm/internal/runtime/bus"
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
 	models "github.com/division-sh/swarm/internal/runtime/core/actors"
@@ -383,7 +384,7 @@ func testActivationRequest(bundle *runtimecontracts.WorkflowContractBundle, temp
 }
 
 func testFlowActivationTriggerEvent(eventID string) events.Event {
-	return events.NewProjectionEvent(strings.TrimSpace(eventID),
+	return eventtest.Projection(strings.TrimSpace(eventID),
 		events.EventType("spawn.requested"),
 		"spawner", "", json.RawMessage(`{}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())
 
@@ -409,7 +410,7 @@ func findPublishedFlowActivationEvent(t *testing.T, bus *flowActivationTestBus, 
 		}
 	}
 	t.Fatalf("published events = %#v, want %s", bus.published, eventType)
-	return events.NewProjectionEvent("", events.EventType(""), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{})
+	return eventtest.Projection("", events.EventType(""), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{})
 }
 
 func TestActivateFlowInstanceAddsDerivedRouteTableInstance(t *testing.T) {

--- a/internal/runtime/manager/receipts_test.go
+++ b/internal/runtime/manager/receipts_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/division-sh/swarm/internal/events"
+	"github.com/division-sh/swarm/internal/events/eventtest"
 	runtimebus "github.com/division-sh/swarm/internal/runtime/bus"
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
 	runtimeactors "github.com/division-sh/swarm/internal/runtime/core/actors"
@@ -157,7 +158,7 @@ func (a *outputRecordingAgent) Subscriptions() []events.EventType { return nil }
 func (a *outputRecordingAgent) OnEvent(context.Context, events.Event) ([]events.Event, error) {
 	a.calls++
 	return []events.Event{
-		events.NewProjectionEvent("out-1", events.EventType("task.done"), "agent-a", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Time{}),
+		eventtest.Projection("out-1", events.EventType("task.done"), "agent-a", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Time{}),
 	}, nil
 }
 
@@ -176,13 +177,12 @@ func TestMaybeTripAuthCircuitBreaker_PublishesFlowScopedAuthRequired(t *testing.
 	am := NewAgentManagerWithOptions(bus, nil, AgentManagerOptions{
 		RuntimeIngressSafetyPause: func(ctx context.Context, reason string) error {
 			pauseCalls++
-			return bus.Publish(ctx, events.NewProjectionEvent("", events.EventType("platform.paused"),
+			return bus.Publish(ctx, eventtest.Projection("", events.EventType("platform.paused"),
 				"runtime", "", mustJSON(map[string]any{
 					"reason":    reason,
 					"paused_by": "runtime",
 					"timestamp": time.Now().UTC().Format(time.RFC3339Nano),
-				}), 0, "", "", events.EventEnvelope{}, time.Now().UTC()),
-			)
+				}), 0, "", "", events.EventEnvelope{}, time.Now().UTC()))
 		},
 	})
 	am.agentCfg["agent-a"] = runtimeactors.AgentConfig{
@@ -191,7 +191,7 @@ func TestMaybeTripAuthCircuitBreaker_PublishesFlowScopedAuthRequired(t *testing.
 		FlowPath: "review/inst-1",
 	}
 
-	inbound := events.NewProjectionEvent("evt-1",
+	inbound := eventtest.Projection("evt-1",
 		events.EventType("work.requested"), "", "", nil, 0, "run-1", "", events.EventEnvelope{}, time.Time{})
 
 	ctx := runtimecorrelation.WithInboundEvent(context.Background(), inbound)
@@ -247,7 +247,7 @@ func TestMaybeTripAuthCircuitBreaker_PreservesCanceledEventLineage(t *testing.T)
 	bus := &recordingReceiptBus{}
 	am := NewAgentManager(bus, nil)
 
-	inbound := events.NewProjectionEvent("evt-canceled",
+	inbound := eventtest.Projection("evt-canceled",
 		events.EventType("work.requested"), "", "", nil, 0, "run-canceled", "", events.EventEnvelope{}, time.Time{})
 
 	ctx := runtimecorrelation.WithInboundEvent(context.Background(), inbound)
@@ -434,7 +434,7 @@ func TestRecordPoisonQuarantine_RequiresDistinctEntities(t *testing.T) {
 func TestProcessEvent_PropagatesInboundParentWithoutTraceSeeding(t *testing.T) {
 	agent := &traceRecordingAgent{}
 	am := NewAgentManager(nil, nil)
-	evt := events.NewProjectionEvent("evt-123",
+	evt := eventtest.Projection("evt-123",
 		events.EventType("discovery/market_research.scan_assigned"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{})
 
 	if err := am.processEvent(context.Background(), agent, evt); err != nil {
@@ -470,7 +470,7 @@ func TestProcessEvent_LogsLaunchingDeliveryLifecycleTransition(t *testing.T) {
 	bus := &recordingReceiptBus{}
 	store := &deliveryLifecycleStoreStub{}
 	am := NewAgentManager(bus, nil, store)
-	evt := events.NewProjectionEvent("evt-1", events.EventType("task.started"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{})
+	evt := eventtest.Projection("evt-1", events.EventType("task.started"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{})
 	agent := traceRecordingAgent{parent: ""}
 
 	if err := am.processEvent(context.Background(), &agent, evt); err != nil {
@@ -498,7 +498,7 @@ func TestProcessEvent_SkipsLateOutputAndReceiptAfterDestructiveResetQuiescence(t
 	am := NewAgentManager(bus, nil, store)
 	agent := &outputRecordingAgent{}
 
-	result := am.processEventDetailed(context.Background(), agent, events.NewProjectionEvent(uuid.NewString(), events.EventType("task.started"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}))
+	result := am.processEventDetailed(context.Background(), agent, eventtest.Projection(uuid.NewString(), events.EventType("task.started"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}))
 	if result.err != nil {
 		t.Fatalf("processEventDetailed error = %v", result.err)
 	}

--- a/internal/runtime/manager/receipts_test.go
+++ b/internal/runtime/manager/receipts_test.go
@@ -158,7 +158,7 @@ func (a *outputRecordingAgent) Subscriptions() []events.EventType { return nil }
 func (a *outputRecordingAgent) OnEvent(context.Context, events.Event) ([]events.Event, error) {
 	a.calls++
 	return []events.Event{
-		eventtest.Projection("out-1", events.EventType("task.done"), "agent-a", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Time{}),
+		eventtest.RootIngress("out-1", events.EventType("task.done"), "agent-a", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Time{}),
 	}, nil
 }
 
@@ -177,7 +177,7 @@ func TestMaybeTripAuthCircuitBreaker_PublishesFlowScopedAuthRequired(t *testing.
 	am := NewAgentManagerWithOptions(bus, nil, AgentManagerOptions{
 		RuntimeIngressSafetyPause: func(ctx context.Context, reason string) error {
 			pauseCalls++
-			return bus.Publish(ctx, eventtest.Projection("", events.EventType("platform.paused"),
+			return bus.Publish(ctx, eventtest.RootIngress("", events.EventType("platform.paused"),
 				"runtime", "", mustJSON(map[string]any{
 					"reason":    reason,
 					"paused_by": "runtime",
@@ -191,7 +191,7 @@ func TestMaybeTripAuthCircuitBreaker_PublishesFlowScopedAuthRequired(t *testing.
 		FlowPath: "review/inst-1",
 	}
 
-	inbound := eventtest.Projection("evt-1",
+	inbound := eventtest.RootIngress("evt-1",
 		events.EventType("work.requested"), "", "", nil, 0, "run-1", "", events.EventEnvelope{}, time.Time{})
 
 	ctx := runtimecorrelation.WithInboundEvent(context.Background(), inbound)
@@ -247,7 +247,7 @@ func TestMaybeTripAuthCircuitBreaker_PreservesCanceledEventLineage(t *testing.T)
 	bus := &recordingReceiptBus{}
 	am := NewAgentManager(bus, nil)
 
-	inbound := eventtest.Projection("evt-canceled",
+	inbound := eventtest.RootIngress("evt-canceled",
 		events.EventType("work.requested"), "", "", nil, 0, "run-canceled", "", events.EventEnvelope{}, time.Time{})
 
 	ctx := runtimecorrelation.WithInboundEvent(context.Background(), inbound)
@@ -434,7 +434,7 @@ func TestRecordPoisonQuarantine_RequiresDistinctEntities(t *testing.T) {
 func TestProcessEvent_PropagatesInboundParentWithoutTraceSeeding(t *testing.T) {
 	agent := &traceRecordingAgent{}
 	am := NewAgentManager(nil, nil)
-	evt := eventtest.Projection("evt-123",
+	evt := eventtest.RootIngress("evt-123",
 		events.EventType("discovery/market_research.scan_assigned"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{})
 
 	if err := am.processEvent(context.Background(), agent, evt); err != nil {
@@ -470,7 +470,7 @@ func TestProcessEvent_LogsLaunchingDeliveryLifecycleTransition(t *testing.T) {
 	bus := &recordingReceiptBus{}
 	store := &deliveryLifecycleStoreStub{}
 	am := NewAgentManager(bus, nil, store)
-	evt := eventtest.Projection("evt-1", events.EventType("task.started"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{})
+	evt := eventtest.RootIngress("evt-1", events.EventType("task.started"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{})
 	agent := traceRecordingAgent{parent: ""}
 
 	if err := am.processEvent(context.Background(), &agent, evt); err != nil {
@@ -498,7 +498,7 @@ func TestProcessEvent_SkipsLateOutputAndReceiptAfterDestructiveResetQuiescence(t
 	am := NewAgentManager(bus, nil, store)
 	agent := &outputRecordingAgent{}
 
-	result := am.processEventDetailed(context.Background(), agent, eventtest.Projection(uuid.NewString(), events.EventType("task.started"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}))
+	result := am.processEventDetailed(context.Background(), agent, eventtest.RootIngress(uuid.NewString(), events.EventType("task.started"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}))
 	if result.err != nil {
 		t.Fatalf("processEventDetailed error = %v", result.err)
 	}

--- a/internal/runtime/manager/recovery_test.go
+++ b/internal/runtime/manager/recovery_test.go
@@ -246,7 +246,7 @@ func TestRecoverRestoresSelectedContractRouteRecoveriesFromForkLocalOwner(t *tes
 		t.Fatalf("missing selected route recovery recipient guard for %s", forkRunID)
 	}
 	guard.ExpectForkEvent("fork-event-1", "source-event-1")
-	evt := eventtest.Projection("fork-event-1",
+	evt := eventtest.RootIngress("fork-event-1",
 		events.EventType("work.ready"),
 		selectedContractExecutionOwner, "", nil, 0, "", "", events.EventEnvelope{}, time.Time{})
 
@@ -505,7 +505,7 @@ func TestRecover_UsesCanonicalPipelineReplayAftermathDiagnostics(t *testing.T) {
 	parentID := "evt-parent"
 	bus := &recoveryTestBus{
 		replayable: []events.PersistedReplayEvent{{
-			Event: eventtest.Projection(childID,
+			Event: eventtest.RootIngress(childID,
 				events.EventType("system.recover"), "", "", nil, 0, "run-1",
 				parentID, events.EventEnvelope{}, time.Now().UTC()),
 		}},
@@ -542,11 +542,11 @@ func TestRecoverWithStartupReplayDiagnostics_LogsCanonicalManagerReplayAftermath
 		},
 		pending: map[string][]events.Event{
 			"agent-a": {
-				eventtest.Projection("evt-replay", events.EventType("system.recover.ok"), "", "", nil, 0, "", "", events.EventEnvelope{}, now.Add(-5*time.Minute)),
-				eventtest.Projection("evt-receipt", events.EventType("system.recover.receipt"), "", "", nil, 0, "", "", events.EventEnvelope{}, now.Add(-4*time.Minute)),
-				eventtest.Projection("evt-inflight", events.EventType("system.recover.inflight"), "", "", nil, 0, "", "", events.EventEnvelope{}, now.Add(-3*time.Minute)),
-				eventtest.Projection("evt-leased", events.EventType("system.recover.leased"), "", "", nil, 0, "", "", events.EventEnvelope{}, now.Add(-2*time.Minute)),
-				eventtest.Projection("evt-drop", events.EventType("system.recover.drop"), "", "", nil, 0, "", "", events.EventEnvelope{}, now.Add(-time.Minute)),
+				eventtest.RootIngress("evt-replay", events.EventType("system.recover.ok"), "", "", nil, 0, "", "", events.EventEnvelope{}, now.Add(-5*time.Minute)),
+				eventtest.RootIngress("evt-receipt", events.EventType("system.recover.receipt"), "", "", nil, 0, "", "", events.EventEnvelope{}, now.Add(-4*time.Minute)),
+				eventtest.RootIngress("evt-inflight", events.EventType("system.recover.inflight"), "", "", nil, 0, "", "", events.EventEnvelope{}, now.Add(-3*time.Minute)),
+				eventtest.RootIngress("evt-leased", events.EventType("system.recover.leased"), "", "", nil, 0, "", "", events.EventEnvelope{}, now.Add(-2*time.Minute)),
+				eventtest.RootIngress("evt-drop", events.EventType("system.recover.drop"), "", "", nil, 0, "", "", events.EventEnvelope{}, now.Add(-time.Minute)),
 			},
 		},
 		receipts: map[string]EventReceipt{
@@ -613,7 +613,7 @@ func TestReplayAgentBacklog_DoesNotEmitStartupAftermathOutsideStartupRecovery(t 
 	store := &startupReplayTestStore{
 		pending: map[string][]events.Event{
 			"agent-a": {
-				eventtest.Projection("evt-drop", events.EventType("system.recover.drop"), "", "", nil, 0, "", "", events.EventEnvelope{}, now.Add(-time.Minute)),
+				eventtest.RootIngress("evt-drop", events.EventType("system.recover.drop"), "", "", nil, 0, "", "", events.EventEnvelope{}, now.Add(-time.Minute)),
 			},
 		},
 	}
@@ -649,8 +649,8 @@ func TestReplayBacklogReportsDirectReplayCount(t *testing.T) {
 	store := &startupReplayTestStore{
 		pending: map[string][]events.Event{
 			"agent-a": {
-				eventtest.Projection("evt-1", events.EventType("system.recover.ok"), "", "", nil, 0, "", "", events.EventEnvelope{}, now.Add(-2*time.Minute)),
-				eventtest.Projection("evt-2", events.EventType("system.recover.ok"), "", "", nil, 0, "", "", events.EventEnvelope{}, now.Add(-time.Minute)),
+				eventtest.RootIngress("evt-1", events.EventType("system.recover.ok"), "", "", nil, 0, "", "", events.EventEnvelope{}, now.Add(-2*time.Minute)),
+				eventtest.RootIngress("evt-2", events.EventType("system.recover.ok"), "", "", nil, 0, "", "", events.EventEnvelope{}, now.Add(-time.Minute)),
 			},
 		},
 	}

--- a/internal/runtime/manager/recovery_test.go
+++ b/internal/runtime/manager/recovery_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/division-sh/swarm/internal/events"
+	"github.com/division-sh/swarm/internal/events/eventtest"
 	runtimeagentcontrol "github.com/division-sh/swarm/internal/runtime/agentcontrol"
 	runtimebus "github.com/division-sh/swarm/internal/runtime/bus"
 	models "github.com/division-sh/swarm/internal/runtime/core/actors"
@@ -245,7 +246,7 @@ func TestRecoverRestoresSelectedContractRouteRecoveriesFromForkLocalOwner(t *tes
 		t.Fatalf("missing selected route recovery recipient guard for %s", forkRunID)
 	}
 	guard.ExpectForkEvent("fork-event-1", "source-event-1")
-	evt := events.NewProjectionEvent("fork-event-1",
+	evt := eventtest.Projection("fork-event-1",
 		events.EventType("work.ready"),
 		selectedContractExecutionOwner, "", nil, 0, "", "", events.EventEnvelope{}, time.Time{})
 
@@ -504,7 +505,7 @@ func TestRecover_UsesCanonicalPipelineReplayAftermathDiagnostics(t *testing.T) {
 	parentID := "evt-parent"
 	bus := &recoveryTestBus{
 		replayable: []events.PersistedReplayEvent{{
-			Event: events.NewProjectionEvent(childID,
+			Event: eventtest.Projection(childID,
 				events.EventType("system.recover"), "", "", nil, 0, "run-1",
 				parentID, events.EventEnvelope{}, time.Now().UTC()),
 		}},
@@ -541,11 +542,11 @@ func TestRecoverWithStartupReplayDiagnostics_LogsCanonicalManagerReplayAftermath
 		},
 		pending: map[string][]events.Event{
 			"agent-a": {
-				events.NewProjectionEvent("evt-replay", events.EventType("system.recover.ok"), "", "", nil, 0, "", "", events.EventEnvelope{}, now.Add(-5*time.Minute)),
-				events.NewProjectionEvent("evt-receipt", events.EventType("system.recover.receipt"), "", "", nil, 0, "", "", events.EventEnvelope{}, now.Add(-4*time.Minute)),
-				events.NewProjectionEvent("evt-inflight", events.EventType("system.recover.inflight"), "", "", nil, 0, "", "", events.EventEnvelope{}, now.Add(-3*time.Minute)),
-				events.NewProjectionEvent("evt-leased", events.EventType("system.recover.leased"), "", "", nil, 0, "", "", events.EventEnvelope{}, now.Add(-2*time.Minute)),
-				events.NewProjectionEvent("evt-drop", events.EventType("system.recover.drop"), "", "", nil, 0, "", "", events.EventEnvelope{}, now.Add(-time.Minute)),
+				eventtest.Projection("evt-replay", events.EventType("system.recover.ok"), "", "", nil, 0, "", "", events.EventEnvelope{}, now.Add(-5*time.Minute)),
+				eventtest.Projection("evt-receipt", events.EventType("system.recover.receipt"), "", "", nil, 0, "", "", events.EventEnvelope{}, now.Add(-4*time.Minute)),
+				eventtest.Projection("evt-inflight", events.EventType("system.recover.inflight"), "", "", nil, 0, "", "", events.EventEnvelope{}, now.Add(-3*time.Minute)),
+				eventtest.Projection("evt-leased", events.EventType("system.recover.leased"), "", "", nil, 0, "", "", events.EventEnvelope{}, now.Add(-2*time.Minute)),
+				eventtest.Projection("evt-drop", events.EventType("system.recover.drop"), "", "", nil, 0, "", "", events.EventEnvelope{}, now.Add(-time.Minute)),
 			},
 		},
 		receipts: map[string]EventReceipt{
@@ -612,7 +613,7 @@ func TestReplayAgentBacklog_DoesNotEmitStartupAftermathOutsideStartupRecovery(t 
 	store := &startupReplayTestStore{
 		pending: map[string][]events.Event{
 			"agent-a": {
-				events.NewProjectionEvent("evt-drop", events.EventType("system.recover.drop"), "", "", nil, 0, "", "", events.EventEnvelope{}, now.Add(-time.Minute)),
+				eventtest.Projection("evt-drop", events.EventType("system.recover.drop"), "", "", nil, 0, "", "", events.EventEnvelope{}, now.Add(-time.Minute)),
 			},
 		},
 	}
@@ -648,8 +649,8 @@ func TestReplayBacklogReportsDirectReplayCount(t *testing.T) {
 	store := &startupReplayTestStore{
 		pending: map[string][]events.Event{
 			"agent-a": {
-				events.NewProjectionEvent("evt-1", events.EventType("system.recover.ok"), "", "", nil, 0, "", "", events.EventEnvelope{}, now.Add(-2*time.Minute)),
-				events.NewProjectionEvent("evt-2", events.EventType("system.recover.ok"), "", "", nil, 0, "", "", events.EventEnvelope{}, now.Add(-time.Minute)),
+				eventtest.Projection("evt-1", events.EventType("system.recover.ok"), "", "", nil, 0, "", "", events.EventEnvelope{}, now.Add(-2*time.Minute)),
+				eventtest.Projection("evt-2", events.EventType("system.recover.ok"), "", "", nil, 0, "", "", events.EventEnvelope{}, now.Add(-time.Minute)),
 			},
 		},
 	}

--- a/internal/runtime/manager/runtime_shutdown_admission_test.go
+++ b/internal/runtime/manager/runtime_shutdown_admission_test.go
@@ -145,7 +145,7 @@ func TestResetRuntimeState_KeepsManagerAdmissionClosedDuringManagerLocalShutdown
 	}
 
 	am.Run(context.Background())
-	if err := bus.Publish(context.Background(), eventtest.Projection("evt-in-1",
+	if err := bus.Publish(context.Background(), eventtest.RootIngress("evt-in-1",
 		events.EventType("test.in"),
 		"tester", "", nil, 0, "", "", events.EventEnvelope{}, time.Now().UTC())); err != nil {
 		t.Fatalf("Publish: %v", err)
@@ -224,7 +224,7 @@ func TestAuthBreakerShutdown_KeepsManagerAdmissionClosedDuringManagerLocalShutdo
 	}
 
 	am.Run(context.Background())
-	if err := bus.Publish(context.Background(), eventtest.Projection("evt-in-1",
+	if err := bus.Publish(context.Background(), eventtest.RootIngress("evt-in-1",
 		events.EventType("test.in"),
 		"tester", "", nil, 0, "", "", events.EventEnvelope{}, time.Now().UTC())); err != nil {
 		t.Fatalf("Publish: %v", err)

--- a/internal/runtime/manager/runtime_shutdown_admission_test.go
+++ b/internal/runtime/manager/runtime_shutdown_admission_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/division-sh/swarm/internal/events"
+	"github.com/division-sh/swarm/internal/events/eventtest"
 	runtimebus "github.com/division-sh/swarm/internal/runtime/bus"
 	runtimeactors "github.com/division-sh/swarm/internal/runtime/core/actors"
 )
@@ -144,10 +145,9 @@ func TestResetRuntimeState_KeepsManagerAdmissionClosedDuringManagerLocalShutdown
 	}
 
 	am.Run(context.Background())
-	if err := bus.Publish(context.Background(), events.NewProjectionEvent("evt-in-1",
+	if err := bus.Publish(context.Background(), eventtest.Projection("evt-in-1",
 		events.EventType("test.in"),
-		"tester", "", nil, 0, "", "", events.EventEnvelope{}, time.Now().UTC()),
-	); err != nil {
+		"tester", "", nil, 0, "", "", events.EventEnvelope{}, time.Now().UTC())); err != nil {
 		t.Fatalf("Publish: %v", err)
 	}
 
@@ -224,10 +224,9 @@ func TestAuthBreakerShutdown_KeepsManagerAdmissionClosedDuringManagerLocalShutdo
 	}
 
 	am.Run(context.Background())
-	if err := bus.Publish(context.Background(), events.NewProjectionEvent("evt-in-1",
+	if err := bus.Publish(context.Background(), eventtest.Projection("evt-in-1",
 		events.EventType("test.in"),
-		"tester", "", nil, 0, "", "", events.EventEnvelope{}, time.Now().UTC()),
-	); err != nil {
+		"tester", "", nil, 0, "", "", events.EventEnvelope{}, time.Now().UTC())); err != nil {
 		t.Fatalf("Publish: %v", err)
 	}
 

--- a/internal/runtime/manager/shutdown_test.go
+++ b/internal/runtime/manager/shutdown_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/division-sh/swarm/internal/events"
+	"github.com/division-sh/swarm/internal/events/eventtest"
 	runtimebus "github.com/division-sh/swarm/internal/runtime/bus"
 	runtimeactors "github.com/division-sh/swarm/internal/runtime/core/actors"
 )
@@ -54,7 +55,7 @@ func TestShutdown_DrainsInFlightWorkBeforeCancellingLoopContext(t *testing.T) {
 			}
 			ctxErrCh <- ctx.Err()
 			return []events.Event{
-				events.NewProjectionEvent("evt-out-1", events.EventType("test.out"), "agent-1", "", nil, 0, "", "", events.EventEnvelope{}, time.Now().UTC()),
+				eventtest.Projection("evt-out-1", events.EventType("test.out"), "agent-1", "", nil, 0, "", "", events.EventEnvelope{}, time.Now().UTC()),
 			}, nil
 		},
 	}
@@ -72,10 +73,9 @@ func TestShutdown_DrainsInFlightWorkBeforeCancellingLoopContext(t *testing.T) {
 	}
 
 	am.Run(context.Background())
-	if err := bus.Publish(context.Background(), events.NewProjectionEvent("evt-in-1",
+	if err := bus.Publish(context.Background(), eventtest.Projection("evt-in-1",
 		events.EventType("test.in"),
-		"tester", "", nil, 0, "", "", events.EventEnvelope{}, time.Now().UTC()),
-	); err != nil {
+		"tester", "", nil, 0, "", "", events.EventEnvelope{}, time.Now().UTC())); err != nil {
 		t.Fatalf("Publish: %v", err)
 	}
 
@@ -158,10 +158,9 @@ func TestShutdownWithOptions_TimesOutAfterConfiguredGraceAndCancelsLoopContext(t
 	}
 
 	am.Run(context.Background())
-	if err := bus.Publish(context.Background(), events.NewProjectionEvent("evt-in-1",
+	if err := bus.Publish(context.Background(), eventtest.Projection("evt-in-1",
 		events.EventType("test.in"),
-		"tester", "", nil, 0, "", "", events.EventEnvelope{}, time.Now().UTC()),
-	); err != nil {
+		"tester", "", nil, 0, "", "", events.EventEnvelope{}, time.Now().UTC())); err != nil {
 		t.Fatalf("Publish: %v", err)
 	}
 
@@ -241,10 +240,9 @@ func TestShutdown_DoesNotStartQueuedWorkAfterDrainBegins(t *testing.T) {
 
 	am.Run(context.Background())
 	for _, eventID := range []string{"evt-in-1", "evt-in-2"} {
-		if err := bus.Publish(context.Background(), events.NewProjectionEvent(eventID,
+		if err := bus.Publish(context.Background(), eventtest.Projection(eventID,
 			events.EventType("test.in"),
-			"tester", "", nil, 0, "", "", events.EventEnvelope{}, time.Now().UTC()),
-		); err != nil {
+			"tester", "", nil, 0, "", "", events.EventEnvelope{}, time.Now().UTC())); err != nil {
 			t.Fatalf("Publish(%s): %v", eventID, err)
 		}
 	}
@@ -325,10 +323,9 @@ func TestShutdown_DoesNotAllowRunToReplaceActiveRunContextDuringDrain(t *testing
 		t.Fatal("expected initial run context")
 	}
 
-	if err := bus.Publish(context.Background(), events.NewProjectionEvent("evt-in-1",
+	if err := bus.Publish(context.Background(), eventtest.Projection("evt-in-1",
 		events.EventType("test.in"),
-		"tester", "", nil, 0, "", "", events.EventEnvelope{}, time.Now().UTC()),
-	); err != nil {
+		"tester", "", nil, 0, "", "", events.EventEnvelope{}, time.Now().UTC())); err != nil {
 		t.Fatalf("Publish: %v", err)
 	}
 

--- a/internal/runtime/manager/shutdown_test.go
+++ b/internal/runtime/manager/shutdown_test.go
@@ -55,7 +55,7 @@ func TestShutdown_DrainsInFlightWorkBeforeCancellingLoopContext(t *testing.T) {
 			}
 			ctxErrCh <- ctx.Err()
 			return []events.Event{
-				eventtest.Projection("evt-out-1", events.EventType("test.out"), "agent-1", "", nil, 0, "", "", events.EventEnvelope{}, time.Now().UTC()),
+				eventtest.RootIngress("evt-out-1", events.EventType("test.out"), "agent-1", "", nil, 0, "", "", events.EventEnvelope{}, time.Now().UTC()),
 			}, nil
 		},
 	}
@@ -73,7 +73,7 @@ func TestShutdown_DrainsInFlightWorkBeforeCancellingLoopContext(t *testing.T) {
 	}
 
 	am.Run(context.Background())
-	if err := bus.Publish(context.Background(), eventtest.Projection("evt-in-1",
+	if err := bus.Publish(context.Background(), eventtest.RootIngress("evt-in-1",
 		events.EventType("test.in"),
 		"tester", "", nil, 0, "", "", events.EventEnvelope{}, time.Now().UTC())); err != nil {
 		t.Fatalf("Publish: %v", err)
@@ -158,7 +158,7 @@ func TestShutdownWithOptions_TimesOutAfterConfiguredGraceAndCancelsLoopContext(t
 	}
 
 	am.Run(context.Background())
-	if err := bus.Publish(context.Background(), eventtest.Projection("evt-in-1",
+	if err := bus.Publish(context.Background(), eventtest.RootIngress("evt-in-1",
 		events.EventType("test.in"),
 		"tester", "", nil, 0, "", "", events.EventEnvelope{}, time.Now().UTC())); err != nil {
 		t.Fatalf("Publish: %v", err)
@@ -240,7 +240,7 @@ func TestShutdown_DoesNotStartQueuedWorkAfterDrainBegins(t *testing.T) {
 
 	am.Run(context.Background())
 	for _, eventID := range []string{"evt-in-1", "evt-in-2"} {
-		if err := bus.Publish(context.Background(), eventtest.Projection(eventID,
+		if err := bus.Publish(context.Background(), eventtest.RootIngress(eventID,
 			events.EventType("test.in"),
 			"tester", "", nil, 0, "", "", events.EventEnvelope{}, time.Now().UTC())); err != nil {
 			t.Fatalf("Publish(%s): %v", eventID, err)
@@ -323,7 +323,7 @@ func TestShutdown_DoesNotAllowRunToReplaceActiveRunContextDuringDrain(t *testing
 		t.Fatal("expected initial run context")
 	}
 
-	if err := bus.Publish(context.Background(), eventtest.Projection("evt-in-1",
+	if err := bus.Publish(context.Background(), eventtest.RootIngress("evt-in-1",
 		events.EventType("test.in"),
 		"tester", "", nil, 0, "", "", events.EventEnvelope{}, time.Now().UTC())); err != nil {
 		t.Fatalf("Publish: %v", err)

--- a/internal/runtime/mcp/context_test.go
+++ b/internal/runtime/mcp/context_test.go
@@ -55,7 +55,7 @@ func TestTurnContextRegistry_PreservesTypedRuntimeLineage(t *testing.T) {
 		Classification:      runtimecorrelation.RuntimeLineageClassificationForkLocal,
 		SelectedForkContext: true,
 	})
-	ctx = runtimebus.WithInboundEvent(ctx, eventtest.Projection("4078d35c-3a8a-40ea-a5f5-01b35a9ff59a",
+	ctx = runtimebus.WithInboundEvent(ctx, eventtest.RootIngress("4078d35c-3a8a-40ea-a5f5-01b35a9ff59a",
 		events.EventType("validation/validation.package_ready"), "", "", nil, 0, "9b06692c-353c-4479-8e92-70927f5e4937", "", events.EventEnvelope{}, time.Time{}))
 
 	token := registry.RegisterTurnContext(ctx)

--- a/internal/runtime/mcp/context_test.go
+++ b/internal/runtime/mcp/context_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/division-sh/swarm/internal/events"
+	"github.com/division-sh/swarm/internal/events/eventtest"
 	runtimebus "github.com/division-sh/swarm/internal/runtime/bus"
 	models "github.com/division-sh/swarm/internal/runtime/core/actors"
 	runtimecorrelation "github.com/division-sh/swarm/internal/runtime/correlation"
@@ -54,9 +55,8 @@ func TestTurnContextRegistry_PreservesTypedRuntimeLineage(t *testing.T) {
 		Classification:      runtimecorrelation.RuntimeLineageClassificationForkLocal,
 		SelectedForkContext: true,
 	})
-	ctx = runtimebus.WithInboundEvent(ctx, events.NewProjectionEvent("4078d35c-3a8a-40ea-a5f5-01b35a9ff59a",
-		events.EventType("validation/validation.package_ready"), "", "", nil, 0, "9b06692c-353c-4479-8e92-70927f5e4937", "", events.EventEnvelope{}, time.Time{}),
-	)
+	ctx = runtimebus.WithInboundEvent(ctx, eventtest.Projection("4078d35c-3a8a-40ea-a5f5-01b35a9ff59a",
+		events.EventType("validation/validation.package_ready"), "", "", nil, 0, "9b06692c-353c-4479-8e92-70927f5e4937", "", events.EventEnvelope{}, time.Time{}))
 
 	token := registry.RegisterTurnContext(ctx)
 	if token == "" {

--- a/internal/runtime/mcp/gateway_test.go
+++ b/internal/runtime/mcp/gateway_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/division-sh/swarm/internal/events"
+	"github.com/division-sh/swarm/internal/events/eventtest"
 	runtimebus "github.com/division-sh/swarm/internal/runtime/bus"
 	models "github.com/division-sh/swarm/internal/runtime/core/actors"
 	"github.com/division-sh/swarm/internal/runtime/core/toolcapabilities"
@@ -879,18 +880,20 @@ func TestGatewayMCPToolsForRequest_FiltersRoleScopedToolsByTurnEntityEligibility
 	actor := models.AgentConfig{ID: "market-research-agent", Role: "market_research"}
 	putTestTurnContext(t, registry, "ctx-invalid-current-entity", TurnContext{
 		Actor: actor,
-		Inbound: events.NewProjectionEvent("evt-root",
-			events.EventType("discovery/market_research.corpus_file_assigned"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}).
-			WithEntityID("root-run-id"),
+		Inbound: eventtest.WithEntityID(eventtest.Projection("evt-root",
+			events.EventType("discovery/market_research.corpus_file_assigned"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}),
+			"root-run-id"),
+
 		HasInbound: true,
 		CreatedAt:  time.Now().UTC(),
 		ExpiresAt:  time.Now().UTC().Add(time.Hour),
 	})
 	putTestTurnContext(t, registry, "ctx-valid-current-entity", TurnContext{
 		Actor: actor,
-		Inbound: events.NewProjectionEvent("evt-scan",
-			events.EventType("discovery/market_research.corpus_file_assigned"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}).
-			WithEntityID("valid-scan-campaign-id"),
+		Inbound: eventtest.WithEntityID(eventtest.Projection("evt-scan",
+			events.EventType("discovery/market_research.corpus_file_assigned"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}),
+			"valid-scan-campaign-id"),
+
 		HasInbound: true,
 		CreatedAt:  time.Now().UTC(),
 		ExpiresAt:  time.Now().UTC().Add(time.Hour),
@@ -1820,7 +1823,7 @@ func TestGatewayExecutionContext_UsesInboundTraceNotRequestTraceOnResolvedTurn(t
 	})
 	putTestTurnContext(t, registry, "ctx-trace", TurnContext{
 		Actor:      models.AgentConfig{ID: "analysis-agent", Role: "analysis"},
-		Inbound:    events.NewProjectionEvent("evt-1", events.EventType(""), "", "", nil, 0, "run-1", "", events.EventEnvelope{}, time.Time{}),
+		Inbound:    eventtest.Projection("evt-1", events.EventType(""), "", "", nil, 0, "run-1", "", events.EventEnvelope{}, time.Time{}),
 		HasInbound: true,
 		CreatedAt:  time.Now().UTC(),
 		ExpiresAt:  time.Now().UTC().Add(time.Hour),
@@ -1843,7 +1846,7 @@ func TestGatewayExecutionContext_RestoresTypedRuntimeLineageOnResolvedTurn(t *te
 	})
 	putTestTurnContext(t, registry, "ctx-lineage", TurnContext{
 		Actor: models.AgentConfig{ID: "validation-coordinator", Role: "validation"},
-		Inbound: events.NewProjectionEvent("3134bdf0-2ce0-4260-93bd-f0a45371b7d7",
+		Inbound: eventtest.Projection("3134bdf0-2ce0-4260-93bd-f0a45371b7d7",
 			events.EventType("validation/validation.package_ready"), "", "", nil, 0, "a6f6861a-d154-4d38-a2d6-1388f5bb6daf", "", events.EventEnvelope{}, time.Time{}),
 
 		HasInbound: true,

--- a/internal/runtime/mcp/gateway_test.go
+++ b/internal/runtime/mcp/gateway_test.go
@@ -880,9 +880,18 @@ func TestGatewayMCPToolsForRequest_FiltersRoleScopedToolsByTurnEntityEligibility
 	actor := models.AgentConfig{ID: "market-research-agent", Role: "market_research"}
 	putTestTurnContext(t, registry, "ctx-invalid-current-entity", TurnContext{
 		Actor: actor,
-		Inbound: eventtest.WithEntityID(eventtest.Projection("evt-root",
-			events.EventType("discovery/market_research.corpus_file_assigned"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}),
-			"root-run-id"),
+		Inbound: eventtest.RootIngress(
+			"evt-root",
+			events.EventType("discovery/market_research.corpus_file_assigned"),
+			"",
+			"",
+			nil,
+			0,
+			"",
+			"",
+			events.EnvelopeForEntityID(events.EventEnvelope{}, "root-run-id"),
+			time.Time{},
+		),
 
 		HasInbound: true,
 		CreatedAt:  time.Now().UTC(),
@@ -890,9 +899,18 @@ func TestGatewayMCPToolsForRequest_FiltersRoleScopedToolsByTurnEntityEligibility
 	})
 	putTestTurnContext(t, registry, "ctx-valid-current-entity", TurnContext{
 		Actor: actor,
-		Inbound: eventtest.WithEntityID(eventtest.Projection("evt-scan",
-			events.EventType("discovery/market_research.corpus_file_assigned"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}),
-			"valid-scan-campaign-id"),
+		Inbound: eventtest.RootIngress(
+			"evt-scan",
+			events.EventType("discovery/market_research.corpus_file_assigned"),
+			"",
+			"",
+			nil,
+			0,
+			"",
+			"",
+			events.EnvelopeForEntityID(events.EventEnvelope{}, "valid-scan-campaign-id"),
+			time.Time{},
+		),
 
 		HasInbound: true,
 		CreatedAt:  time.Now().UTC(),
@@ -1823,7 +1841,7 @@ func TestGatewayExecutionContext_UsesInboundTraceNotRequestTraceOnResolvedTurn(t
 	})
 	putTestTurnContext(t, registry, "ctx-trace", TurnContext{
 		Actor:      models.AgentConfig{ID: "analysis-agent", Role: "analysis"},
-		Inbound:    eventtest.Projection("evt-1", events.EventType(""), "", "", nil, 0, "run-1", "", events.EventEnvelope{}, time.Time{}),
+		Inbound:    eventtest.RootIngress("evt-1", events.EventType(""), "", "", nil, 0, "run-1", "", events.EventEnvelope{}, time.Time{}),
 		HasInbound: true,
 		CreatedAt:  time.Now().UTC(),
 		ExpiresAt:  time.Now().UTC().Add(time.Hour),
@@ -1846,7 +1864,7 @@ func TestGatewayExecutionContext_RestoresTypedRuntimeLineageOnResolvedTurn(t *te
 	})
 	putTestTurnContext(t, registry, "ctx-lineage", TurnContext{
 		Actor: models.AgentConfig{ID: "validation-coordinator", Role: "validation"},
-		Inbound: eventtest.Projection("3134bdf0-2ce0-4260-93bd-f0a45371b7d7",
+		Inbound: eventtest.RootIngress("3134bdf0-2ce0-4260-93bd-f0a45371b7d7",
 			events.EventType("validation/validation.package_ready"), "", "", nil, 0, "a6f6861a-d154-4d38-a2d6-1388f5bb6daf", "", events.EventEnvelope{}, time.Time{}),
 
 		HasInbound: true,

--- a/internal/runtime/pipeline/action_result_event_context_test.go
+++ b/internal/runtime/pipeline/action_result_event_context_test.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/division-sh/swarm/internal/events"
+	"github.com/division-sh/swarm/internal/events/eventtest"
 	"github.com/division-sh/swarm/internal/runtime/core/identity"
 	runtimeengine "github.com/division-sh/swarm/internal/runtime/engine"
 	"github.com/division-sh/swarm/internal/runtime/semanticview"
@@ -70,7 +71,7 @@ func TestArtifactRepoResultEventPreservesScopedProducerSourceRoute(t *testing.T)
 		t.Run(tc.name, func(t *testing.T) {
 			entityID := "ent-repo"
 			parentEnvelope := events.EventEnvelope{EntityID: "upstream-ent", FlowInstance: tc.inboundFlowPath}
-			parent := events.NewProjectionEvent(
+			parent := eventtest.Projection(
 				"evt-parent",
 				"repo_scaffold.repo_commit_requested",
 				"workflow-runtime",
@@ -80,19 +81,20 @@ func TestArtifactRepoResultEventPreservesScopedProducerSourceRoute(t *testing.T)
 				"run-1",
 				"",
 				parentEnvelope,
-				time.Unix(1_700_000_000, 0).UTC(),
-			)
+				time.Unix(1_700_000_000, 0).UTC())
+
 			if tc.stateFlowPath != "" || !tc.producerRoute.Empty() || !tc.targetRoute.Empty() {
-				parent = parent.WithSourceRoute(events.RouteIdentity{
+				parent = eventtest.WithSourceRoute(parent, events.RouteIdentity{
 					FlowID:       "upstream",
 					FlowInstance: "upstream/inst-0",
 					EntityID:     "upstream-ent",
 				})
+
 			}
 			if !tc.targetRoute.Empty() {
-				parent = parent.WithTargetRoute(tc.targetRoute)
+				parent = eventtest.WithTargetRoute(parent, tc.targetRoute)
 			} else if tc.inboundFlowPath != "" {
-				parent = parent.WithFlowInstance(tc.inboundFlowPath)
+				parent = eventtest.WithFlowInstance(parent, tc.inboundFlowPath)
 			}
 			stateMetadata := map[string]any{}
 			if tc.stateFlowPath != "" {
@@ -210,7 +212,7 @@ func TestActionResultProducerRouteCoversCurrentRouteShapes(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			evt := events.NewProjectionEvent(
+			evt := eventtest.Projection(
 				"evt-parent",
 				"repo_scaffold.repo_commit_requested",
 				"workflow-runtime",
@@ -220,13 +222,13 @@ func TestActionResultProducerRouteCoversCurrentRouteShapes(t *testing.T) {
 				"run-1",
 				"",
 				events.EventEnvelope{},
-				time.Unix(1_700_000_000, 0).UTC(),
-			)
+				time.Unix(1_700_000_000, 0).UTC())
+
 			if tc.eventFlowPath != "" {
-				evt = evt.WithFlowInstance(tc.eventFlowPath)
+				evt = eventtest.WithFlowInstance(evt, tc.eventFlowPath)
 			}
 			if len(tc.targetSet) > 0 {
-				evt = evt.WithTargetSet(tc.targetSet)
+				evt = eventtest.WithTargetSet(evt, tc.targetSet)
 			}
 			stateMetadata := map[string]any{}
 			if tc.stateFlowPath != "" {

--- a/internal/runtime/pipeline/action_result_event_context_test.go
+++ b/internal/runtime/pipeline/action_result_event_context_test.go
@@ -71,7 +71,20 @@ func TestArtifactRepoResultEventPreservesScopedProducerSourceRoute(t *testing.T)
 		t.Run(tc.name, func(t *testing.T) {
 			entityID := "ent-repo"
 			parentEnvelope := events.EventEnvelope{EntityID: "upstream-ent", FlowInstance: tc.inboundFlowPath}
-			parent := eventtest.Projection(
+			if tc.stateFlowPath != "" || !tc.producerRoute.Empty() || !tc.targetRoute.Empty() {
+				parentEnvelope = events.EnvelopeForSourceRoute(parentEnvelope, events.RouteIdentity{
+					FlowID:       "upstream",
+					FlowInstance: "upstream/inst-0",
+					EntityID:     "upstream-ent",
+				})
+
+			}
+			if !tc.targetRoute.Empty() {
+				parentEnvelope = events.EnvelopeForTargetRoute(parentEnvelope, tc.targetRoute)
+			} else if tc.inboundFlowPath != "" {
+				parentEnvelope = events.EnvelopeForFlowInstance(parentEnvelope, tc.inboundFlowPath)
+			}
+			parent := eventtest.RootIngress(
 				"evt-parent",
 				"repo_scaffold.repo_commit_requested",
 				"workflow-runtime",
@@ -82,20 +95,6 @@ func TestArtifactRepoResultEventPreservesScopedProducerSourceRoute(t *testing.T)
 				"",
 				parentEnvelope,
 				time.Unix(1_700_000_000, 0).UTC())
-
-			if tc.stateFlowPath != "" || !tc.producerRoute.Empty() || !tc.targetRoute.Empty() {
-				parent = eventtest.WithSourceRoute(parent, events.RouteIdentity{
-					FlowID:       "upstream",
-					FlowInstance: "upstream/inst-0",
-					EntityID:     "upstream-ent",
-				})
-
-			}
-			if !tc.targetRoute.Empty() {
-				parent = eventtest.WithTargetRoute(parent, tc.targetRoute)
-			} else if tc.inboundFlowPath != "" {
-				parent = eventtest.WithFlowInstance(parent, tc.inboundFlowPath)
-			}
 			stateMetadata := map[string]any{}
 			if tc.stateFlowPath != "" {
 				stateMetadata["flow_path"] = tc.stateFlowPath
@@ -212,7 +211,14 @@ func TestActionResultProducerRouteCoversCurrentRouteShapes(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			evt := eventtest.Projection(
+			eventEnvelope := events.EventEnvelope{}
+			if tc.eventFlowPath != "" {
+				eventEnvelope = events.EnvelopeForFlowInstance(eventEnvelope, tc.eventFlowPath)
+			}
+			if len(tc.targetSet) > 0 {
+				eventEnvelope = events.EnvelopeForTargetSet(eventEnvelope, tc.targetSet)
+			}
+			evt := eventtest.RootIngress(
 				"evt-parent",
 				"repo_scaffold.repo_commit_requested",
 				"workflow-runtime",
@@ -221,15 +227,8 @@ func TestActionResultProducerRouteCoversCurrentRouteShapes(t *testing.T) {
 				0,
 				"run-1",
 				"",
-				events.EventEnvelope{},
+				eventEnvelope,
 				time.Unix(1_700_000_000, 0).UTC())
-
-			if tc.eventFlowPath != "" {
-				evt = eventtest.WithFlowInstance(evt, tc.eventFlowPath)
-			}
-			if len(tc.targetSet) > 0 {
-				evt = eventtest.WithTargetSet(evt, tc.targetSet)
-			}
 			stateMetadata := map[string]any{}
 			if tc.stateFlowPath != "" {
 				stateMetadata["flow_path"] = tc.stateFlowPath

--- a/internal/runtime/pipeline/coordinator_recovery_test.go
+++ b/internal/runtime/pipeline/coordinator_recovery_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/division-sh/swarm/internal/events"
+	"github.com/division-sh/swarm/internal/events/eventtest"
 	runtimebus "github.com/division-sh/swarm/internal/runtime/bus"
 	runtimepipeline "github.com/division-sh/swarm/internal/runtime/pipeline"
 	runtimereplayclaim "github.com/division-sh/swarm/internal/runtime/replayclaim"
@@ -187,11 +188,11 @@ func TestRecoveryManager_ReplaysPersistedCorrelationEnvelope(t *testing.T) {
 	parentID := uuid.NewString()
 	childID := uuid.NewString()
 
-	parent := events.NewProjectionEvent(parentID,
+	parent := eventtest.Projection(parentID,
 		events.EventType("system.parent"),
 		"runtime", "", []byte(`{"ok":true}`), 0, runID, "", events.EventEnvelope{}, time.Now().Add(-2*time.Minute).UTC())
 
-	child := events.NewProjectionEvent(childID,
+	child := eventtest.Projection(childID,
 		events.EventType("system.recover"),
 		"runtime", "", []byte(`{"ok":true}`), 0, runID,
 		parentID, events.EventEnvelope{}, time.Now().Add(-1*time.Minute).UTC())
@@ -452,17 +453,15 @@ func TestRecoveryManager_QuarantinesMissingPersistedRunIDAndContinues(t *testing
 	`, badEventID); err != nil {
 		t.Fatalf("seed malformed event: %v", err)
 	}
-	if err := pg.AppendEvent(ctx, events.NewProjectionEvent(goodParentID,
+	if err := pg.AppendEvent(ctx, eventtest.Projection(goodParentID,
 		events.EventType("system.parent"),
-		"runtime", "", []byte(`{"ok":true}`), 0, goodRunID, "", events.EventEnvelope{}, time.Now().Add(-2*time.Minute).UTC()),
-	); err != nil {
+		"runtime", "", []byte(`{"ok":true}`), 0, goodRunID, "", events.EventEnvelope{}, time.Now().Add(-2*time.Minute).UTC())); err != nil {
 		t.Fatalf("AppendEvent(good parent): %v", err)
 	}
-	if err := pg.AppendEvent(ctx, events.NewProjectionEvent(goodEventID,
+	if err := pg.AppendEvent(ctx, eventtest.Projection(goodEventID,
 		events.EventType("system.recover.good"),
 		"runtime", "", []byte(`{"ok":true}`), 0, goodRunID,
-		goodParentID, events.EventEnvelope{}, time.Now().Add(-1*time.Minute).UTC()),
-	); err != nil {
+		goodParentID, events.EventEnvelope{}, time.Now().Add(-1*time.Minute).UTC())); err != nil {
 		t.Fatalf("AppendEvent(good child): %v", err)
 	}
 	if err := pg.InsertEventDeliveries(ctx, goodEventID, []string{goodRecipientID}); err != nil {
@@ -536,10 +535,9 @@ func TestRecoveryManager_QuarantinesMissingRunIDSchemaCapability(t *testing.T) {
 
 	eventID := uuid.NewString()
 	parentID := uuid.NewString()
-	if err := pg.AppendEvent(ctx, events.NewProjectionEvent(eventID,
+	if err := pg.AppendEvent(ctx, eventtest.Projection(eventID,
 		events.EventType("system.recover.no-run-id"),
-		"runtime", "", []byte(`{"ok":true}`), 0, "", parentID, events.EventEnvelope{}, time.Now().Add(-time.Minute).UTC()),
-	); err != nil {
+		"runtime", "", []byte(`{"ok":true}`), 0, "", parentID, events.EventEnvelope{}, time.Now().Add(-time.Minute).UTC())); err != nil {
 		t.Fatalf("AppendEvent: %v", err)
 	}
 
@@ -583,17 +581,15 @@ func TestRecoveryManager_ClaimsReplayOwnershipUnderOverlap(t *testing.T) {
 	if _, err := db.ExecContext(ctx, `INSERT INTO runs (run_id, status) VALUES ($1::uuid, 'running')`, runID); err != nil {
 		t.Fatalf("seed run: %v", err)
 	}
-	if err := pg1.AppendEvent(ctx, events.NewProjectionEvent(parentID,
+	if err := pg1.AppendEvent(ctx, eventtest.Projection(parentID,
 		events.EventType("system.parent"),
-		"runtime", "", []byte(`{"ok":true}`), 0, runID, "", events.EventEnvelope{}, time.Now().Add(-2*time.Minute).UTC()),
-	); err != nil {
+		"runtime", "", []byte(`{"ok":true}`), 0, runID, "", events.EventEnvelope{}, time.Now().Add(-2*time.Minute).UTC())); err != nil {
 		t.Fatalf("AppendEvent(parent): %v", err)
 	}
-	if err := pg1.AppendEvent(ctx, events.NewProjectionEvent(childID,
+	if err := pg1.AppendEvent(ctx, eventtest.Projection(childID,
 		events.EventType("system.recover"),
 		"runtime", "", []byte(`{"ok":true}`), 0, runID,
-		parentID, events.EventEnvelope{}, time.Now().Add(-time.Minute).UTC()),
-	); err != nil {
+		parentID, events.EventEnvelope{}, time.Now().Add(-time.Minute).UTC())); err != nil {
 		t.Fatalf("AppendEvent(child): %v", err)
 	}
 	if err := pg1.InsertEventDeliveries(ctx, childID, []string{"agent-recovery"}); err != nil {
@@ -669,11 +665,11 @@ func TestRecoveryManager_ExplicitlySkipsReplayWithoutPersistedRecipients(t *test
 	parentID := uuid.NewString()
 	childID := uuid.NewString()
 
-	parent := events.NewProjectionEvent(parentID,
+	parent := eventtest.Projection(parentID,
 		events.EventType("system.parent"),
 		"runtime", "", []byte(`{"ok":true}`), 0, runID, "", events.EventEnvelope{}, time.Now().Add(-2*time.Minute).UTC())
 
-	child := events.NewProjectionEvent(childID,
+	child := eventtest.Projection(childID,
 		events.EventType("system.recover.no_recipients"),
 		"runtime", "", []byte(`{"ok":true}`), 0, runID,
 		parentID, events.EventEnvelope{}, time.Now().Add(-1*time.Minute).UTC())
@@ -775,19 +771,20 @@ func TestRecoveryManager_UsesPersistedDeliveryRecipientsInsteadOfCurrentSubscrip
 	eventID := uuid.NewString()
 	entityID := uuid.NewString()
 
-	if err := pg.AppendEvent(ctx, events.NewProjectionEvent(parentID,
+	if err := pg.AppendEvent(ctx, eventtest.WithEntityID(eventtest.Projection(parentID,
 		events.EventType("system.parent"),
-		"runtime", "", []byte(`{"entity_id":"`+entityID+`"}`), 0, runID, "", events.EventEnvelope{}, time.Now().Add(-2*time.Minute).UTC()).
-		WithEntityID(entityID)); err != nil {
+		"runtime", "", []byte(`{"entity_id":"`+entityID+`"}`), 0, runID, "", events.EventEnvelope{}, time.Now().Add(-2*time.Minute).UTC()),
+		entityID)); err != nil {
 		t.Fatalf("AppendEvent(parent): %v", err)
 	}
 	if err := pg.UpsertPipelineReceipt(ctx, parentID, "processed", ""); err != nil {
 		t.Fatalf("UpsertPipelineReceipt(parent): %v", err)
 	}
-	child := (events.NewProjectionEvent(eventID,
+	child := eventtest.WithEntityID((eventtest.Projection(eventID,
 		events.EventType("system.recover.explicit"),
 		"runtime", "", []byte(`{"entity_id":"`+entityID+`"}`), 0, runID,
-		parentID, events.EventEnvelope{}, time.Now().Add(-time.Minute).UTC())).WithEntityID(entityID)
+		parentID, events.EventEnvelope{}, time.Now().Add(-time.Minute).UTC())), entityID)
+
 	if err := pg.AppendEvent(ctx, child); err != nil {
 		t.Fatalf("AppendEvent(child): %v", err)
 	}
@@ -851,20 +848,18 @@ func TestRecoveryManager_ReplaysSubscribedInternalOnlyUsingCommittedReplayScope(
 	parentID := uuid.NewString()
 	eventID := uuid.NewString()
 
-	if err := pg.AppendEvent(ctx, events.NewProjectionEvent(parentID,
+	if err := pg.AppendEvent(ctx, eventtest.Projection(parentID,
 		events.EventType("system.parent"),
-		"runtime", "", []byte(`{"ok":true}`), 0, runID, "", events.EventEnvelope{}, time.Now().Add(-2*time.Minute).UTC()),
-	); err != nil {
+		"runtime", "", []byte(`{"ok":true}`), 0, runID, "", events.EventEnvelope{}, time.Now().Add(-2*time.Minute).UTC())); err != nil {
 		t.Fatalf("AppendEvent(parent): %v", err)
 	}
 	if err := pg.UpsertPipelineReceipt(ctx, parentID, "processed", ""); err != nil {
 		t.Fatalf("UpsertPipelineReceipt(parent): %v", err)
 	}
-	if err := pg.AppendEvent(ctx, events.NewProjectionEvent(eventID,
+	if err := pg.AppendEvent(ctx, eventtest.Projection(eventID,
 		events.EventType("system.recover.internal"),
 		"runtime", "", []byte(`{"ok":true}`), 0, runID,
-		parentID, events.EventEnvelope{}, time.Now().Add(-time.Minute).UTC()),
-	); err != nil {
+		parentID, events.EventEnvelope{}, time.Now().Add(-time.Minute).UTC())); err != nil {
 		t.Fatalf("AppendEvent(child): %v", err)
 	}
 	persistCommittedReplayScope(t, ctx, pg, eventID, runtimereplayclaim.CommittedReplayScopeSubscribed)
@@ -904,20 +899,18 @@ func TestRecoveryManager_DirectEmptyManifestDoesNotBroadenToCurrentInternalSubsc
 	parentID := uuid.NewString()
 	eventID := uuid.NewString()
 
-	if err := pg.AppendEvent(ctx, events.NewProjectionEvent(parentID,
+	if err := pg.AppendEvent(ctx, eventtest.Projection(parentID,
 		events.EventType("system.parent"),
-		"runtime", "", []byte(`{"ok":true}`), 0, runID, "", events.EventEnvelope{}, time.Now().Add(-2*time.Minute).UTC()),
-	); err != nil {
+		"runtime", "", []byte(`{"ok":true}`), 0, runID, "", events.EventEnvelope{}, time.Now().Add(-2*time.Minute).UTC())); err != nil {
 		t.Fatalf("AppendEvent(parent): %v", err)
 	}
 	if err := pg.UpsertPipelineReceipt(ctx, parentID, "processed", ""); err != nil {
 		t.Fatalf("UpsertPipelineReceipt(parent): %v", err)
 	}
-	if err := pg.AppendEvent(ctx, events.NewProjectionEvent(eventID,
+	if err := pg.AppendEvent(ctx, eventtest.Projection(eventID,
 		events.EventType("system.recover.direct_empty"),
 		"runtime", "", []byte(`{"ok":true}`), 0, runID,
-		parentID, events.EventEnvelope{}, time.Now().Add(-time.Minute).UTC()),
-	); err != nil {
+		parentID, events.EventEnvelope{}, time.Now().Add(-time.Minute).UTC())); err != nil {
 		t.Fatalf("AppendEvent(child): %v", err)
 	}
 	persistCommittedReplayScope(t, ctx, pg, eventID, runtimereplayclaim.CommittedReplayScopeDirect)
@@ -942,9 +935,8 @@ func TestRecoveryManager_DirectEmptyManifestDoesNotBroadenToCurrentInternalSubsc
 func TestRecoveryManager_FailsClosedWithoutReplayClaimOwner(t *testing.T) {
 	store := &recoveryMissingClaimStore{
 		events: []events.PersistedReplayEvent{
-			{Event: events.NewProjectionEvent("evt-missing-claim",
-				events.EventType("system.recover"), "", "", []byte(`{"ok":true}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC()),
-			},
+			{Event: eventtest.Projection("evt-missing-claim",
+				events.EventType("system.recover"), "", "", []byte(`{"ok":true}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())},
 		},
 		deliveries: map[string][]string{"evt-missing-claim": {"agent-a"}},
 	}

--- a/internal/runtime/pipeline/coordinator_recovery_test.go
+++ b/internal/runtime/pipeline/coordinator_recovery_test.go
@@ -188,11 +188,11 @@ func TestRecoveryManager_ReplaysPersistedCorrelationEnvelope(t *testing.T) {
 	parentID := uuid.NewString()
 	childID := uuid.NewString()
 
-	parent := eventtest.Projection(parentID,
+	parent := eventtest.RootIngress(parentID,
 		events.EventType("system.parent"),
 		"runtime", "", []byte(`{"ok":true}`), 0, runID, "", events.EventEnvelope{}, time.Now().Add(-2*time.Minute).UTC())
 
-	child := eventtest.Projection(childID,
+	child := eventtest.RootIngress(childID,
 		events.EventType("system.recover"),
 		"runtime", "", []byte(`{"ok":true}`), 0, runID,
 		parentID, events.EventEnvelope{}, time.Now().Add(-1*time.Minute).UTC())
@@ -453,12 +453,12 @@ func TestRecoveryManager_QuarantinesMissingPersistedRunIDAndContinues(t *testing
 	`, badEventID); err != nil {
 		t.Fatalf("seed malformed event: %v", err)
 	}
-	if err := pg.AppendEvent(ctx, eventtest.Projection(goodParentID,
+	if err := pg.AppendEvent(ctx, eventtest.RootIngress(goodParentID,
 		events.EventType("system.parent"),
 		"runtime", "", []byte(`{"ok":true}`), 0, goodRunID, "", events.EventEnvelope{}, time.Now().Add(-2*time.Minute).UTC())); err != nil {
 		t.Fatalf("AppendEvent(good parent): %v", err)
 	}
-	if err := pg.AppendEvent(ctx, eventtest.Projection(goodEventID,
+	if err := pg.AppendEvent(ctx, eventtest.RootIngress(goodEventID,
 		events.EventType("system.recover.good"),
 		"runtime", "", []byte(`{"ok":true}`), 0, goodRunID,
 		goodParentID, events.EventEnvelope{}, time.Now().Add(-1*time.Minute).UTC())); err != nil {
@@ -535,7 +535,7 @@ func TestRecoveryManager_QuarantinesMissingRunIDSchemaCapability(t *testing.T) {
 
 	eventID := uuid.NewString()
 	parentID := uuid.NewString()
-	if err := pg.AppendEvent(ctx, eventtest.Projection(eventID,
+	if err := pg.AppendEvent(ctx, eventtest.RootIngress(eventID,
 		events.EventType("system.recover.no-run-id"),
 		"runtime", "", []byte(`{"ok":true}`), 0, "", parentID, events.EventEnvelope{}, time.Now().Add(-time.Minute).UTC())); err != nil {
 		t.Fatalf("AppendEvent: %v", err)
@@ -581,12 +581,12 @@ func TestRecoveryManager_ClaimsReplayOwnershipUnderOverlap(t *testing.T) {
 	if _, err := db.ExecContext(ctx, `INSERT INTO runs (run_id, status) VALUES ($1::uuid, 'running')`, runID); err != nil {
 		t.Fatalf("seed run: %v", err)
 	}
-	if err := pg1.AppendEvent(ctx, eventtest.Projection(parentID,
+	if err := pg1.AppendEvent(ctx, eventtest.RootIngress(parentID,
 		events.EventType("system.parent"),
 		"runtime", "", []byte(`{"ok":true}`), 0, runID, "", events.EventEnvelope{}, time.Now().Add(-2*time.Minute).UTC())); err != nil {
 		t.Fatalf("AppendEvent(parent): %v", err)
 	}
-	if err := pg1.AppendEvent(ctx, eventtest.Projection(childID,
+	if err := pg1.AppendEvent(ctx, eventtest.RootIngress(childID,
 		events.EventType("system.recover"),
 		"runtime", "", []byte(`{"ok":true}`), 0, runID,
 		parentID, events.EventEnvelope{}, time.Now().Add(-time.Minute).UTC())); err != nil {
@@ -665,11 +665,11 @@ func TestRecoveryManager_ExplicitlySkipsReplayWithoutPersistedRecipients(t *test
 	parentID := uuid.NewString()
 	childID := uuid.NewString()
 
-	parent := eventtest.Projection(parentID,
+	parent := eventtest.RootIngress(parentID,
 		events.EventType("system.parent"),
 		"runtime", "", []byte(`{"ok":true}`), 0, runID, "", events.EventEnvelope{}, time.Now().Add(-2*time.Minute).UTC())
 
-	child := eventtest.Projection(childID,
+	child := eventtest.RootIngress(childID,
 		events.EventType("system.recover.no_recipients"),
 		"runtime", "", []byte(`{"ok":true}`), 0, runID,
 		parentID, events.EventEnvelope{}, time.Now().Add(-1*time.Minute).UTC())
@@ -771,19 +771,35 @@ func TestRecoveryManager_UsesPersistedDeliveryRecipientsInsteadOfCurrentSubscrip
 	eventID := uuid.NewString()
 	entityID := uuid.NewString()
 
-	if err := pg.AppendEvent(ctx, eventtest.WithEntityID(eventtest.Projection(parentID,
+	if err := pg.AppendEvent(ctx, eventtest.RootIngress(
+		parentID,
 		events.EventType("system.parent"),
-		"runtime", "", []byte(`{"entity_id":"`+entityID+`"}`), 0, runID, "", events.EventEnvelope{}, time.Now().Add(-2*time.Minute).UTC()),
-		entityID)); err != nil {
+		"runtime",
+		"",
+		[]byte(`{"entity_id":"`+entityID+`"}`),
+		0,
+		runID,
+		"",
+		events.EnvelopeForEntityID(events.EventEnvelope{}, entityID),
+		time.Now().Add(-2*time.Minute).UTC(),
+	)); err != nil {
 		t.Fatalf("AppendEvent(parent): %v", err)
 	}
 	if err := pg.UpsertPipelineReceipt(ctx, parentID, "processed", ""); err != nil {
 		t.Fatalf("UpsertPipelineReceipt(parent): %v", err)
 	}
-	child := eventtest.WithEntityID((eventtest.Projection(eventID,
+	child := eventtest.RootIngress(
+		eventID,
 		events.EventType("system.recover.explicit"),
-		"runtime", "", []byte(`{"entity_id":"`+entityID+`"}`), 0, runID,
-		parentID, events.EventEnvelope{}, time.Now().Add(-time.Minute).UTC())), entityID)
+		"runtime",
+		"",
+		[]byte(`{"entity_id":"`+entityID+`"}`),
+		0,
+		runID,
+		parentID,
+		events.EnvelopeForEntityID(events.EventEnvelope{}, entityID),
+		time.Now().Add(-time.Minute).UTC(),
+	)
 
 	if err := pg.AppendEvent(ctx, child); err != nil {
 		t.Fatalf("AppendEvent(child): %v", err)
@@ -848,7 +864,7 @@ func TestRecoveryManager_ReplaysSubscribedInternalOnlyUsingCommittedReplayScope(
 	parentID := uuid.NewString()
 	eventID := uuid.NewString()
 
-	if err := pg.AppendEvent(ctx, eventtest.Projection(parentID,
+	if err := pg.AppendEvent(ctx, eventtest.RootIngress(parentID,
 		events.EventType("system.parent"),
 		"runtime", "", []byte(`{"ok":true}`), 0, runID, "", events.EventEnvelope{}, time.Now().Add(-2*time.Minute).UTC())); err != nil {
 		t.Fatalf("AppendEvent(parent): %v", err)
@@ -856,7 +872,7 @@ func TestRecoveryManager_ReplaysSubscribedInternalOnlyUsingCommittedReplayScope(
 	if err := pg.UpsertPipelineReceipt(ctx, parentID, "processed", ""); err != nil {
 		t.Fatalf("UpsertPipelineReceipt(parent): %v", err)
 	}
-	if err := pg.AppendEvent(ctx, eventtest.Projection(eventID,
+	if err := pg.AppendEvent(ctx, eventtest.RootIngress(eventID,
 		events.EventType("system.recover.internal"),
 		"runtime", "", []byte(`{"ok":true}`), 0, runID,
 		parentID, events.EventEnvelope{}, time.Now().Add(-time.Minute).UTC())); err != nil {
@@ -899,7 +915,7 @@ func TestRecoveryManager_DirectEmptyManifestDoesNotBroadenToCurrentInternalSubsc
 	parentID := uuid.NewString()
 	eventID := uuid.NewString()
 
-	if err := pg.AppendEvent(ctx, eventtest.Projection(parentID,
+	if err := pg.AppendEvent(ctx, eventtest.RootIngress(parentID,
 		events.EventType("system.parent"),
 		"runtime", "", []byte(`{"ok":true}`), 0, runID, "", events.EventEnvelope{}, time.Now().Add(-2*time.Minute).UTC())); err != nil {
 		t.Fatalf("AppendEvent(parent): %v", err)
@@ -907,7 +923,7 @@ func TestRecoveryManager_DirectEmptyManifestDoesNotBroadenToCurrentInternalSubsc
 	if err := pg.UpsertPipelineReceipt(ctx, parentID, "processed", ""); err != nil {
 		t.Fatalf("UpsertPipelineReceipt(parent): %v", err)
 	}
-	if err := pg.AppendEvent(ctx, eventtest.Projection(eventID,
+	if err := pg.AppendEvent(ctx, eventtest.RootIngress(eventID,
 		events.EventType("system.recover.direct_empty"),
 		"runtime", "", []byte(`{"ok":true}`), 0, runID,
 		parentID, events.EventEnvelope{}, time.Now().Add(-time.Minute).UTC())); err != nil {
@@ -935,7 +951,7 @@ func TestRecoveryManager_DirectEmptyManifestDoesNotBroadenToCurrentInternalSubsc
 func TestRecoveryManager_FailsClosedWithoutReplayClaimOwner(t *testing.T) {
 	store := &recoveryMissingClaimStore{
 		events: []events.PersistedReplayEvent{
-			{Event: eventtest.Projection("evt-missing-claim",
+			{Event: eventtest.RootIngress("evt-missing-claim",
 				events.EventType("system.recover"), "", "", []byte(`{"ok":true}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())},
 		},
 		deliveries: map[string][]string{"evt-missing-claim": {"agent-a"}},

--- a/internal/runtime/pipeline/create_entity_exact_once_test.go
+++ b/internal/runtime/pipeline/create_entity_exact_once_test.go
@@ -45,7 +45,7 @@ func TestCreateEntityHandlerEffectsAreExactOnceAcrossStoreMutations(t *testing.T
 			schedules := pc.timerScheduleStore.(*recordingScheduleStore)
 			mailbox := pc.mailboxMaterializer.(*recordingMailboxWriteMaterializer)
 			eventID := uuid.NewString()
-			evt := eventtest.Projection(eventID,
+			evt := eventtest.RootIngress(eventID,
 				events.EventType("thing.created"), "", "", mustJSON(map[string]any{"amount": 250, "who": "alice"}), 0, runtimecorrelation.RunIDFromContext(ctx), "", events.EventEnvelope{}, time.Now().UTC())
 
 			seedExactOnceEvent(t, pc.workflowStore, ctx, evt)
@@ -140,7 +140,7 @@ func TestDispatchWorkflowNodeEventSkipsAlreadyProcessedCreateEntityHandler(t *te
 			bus := pc.bus.(*recordingPipelineBus)
 			mailbox := pc.mailboxMaterializer.(*recordingMailboxWriteMaterializer)
 			eventID := uuid.NewString()
-			evt := eventtest.Projection(eventID,
+			evt := eventtest.RootIngress(eventID,
 				events.EventType("thing.created"), "", "", mustJSON(map[string]any{"amount": 250, "who": "alice"}), 0, runtimecorrelation.RunIDFromContext(ctx), "", events.EventEnvelope{}, time.Now().UTC())
 
 			seedExactOnceEventDelivery(t, pc.workflowStore, ctx, evt, "w-node")

--- a/internal/runtime/pipeline/create_entity_exact_once_test.go
+++ b/internal/runtime/pipeline/create_entity_exact_once_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/division-sh/swarm/internal/events"
+	"github.com/division-sh/swarm/internal/events/eventtest"
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
 	runtimecorrelation "github.com/division-sh/swarm/internal/runtime/correlation"
 	"github.com/division-sh/swarm/internal/runtime/semanticview"
@@ -44,7 +45,7 @@ func TestCreateEntityHandlerEffectsAreExactOnceAcrossStoreMutations(t *testing.T
 			schedules := pc.timerScheduleStore.(*recordingScheduleStore)
 			mailbox := pc.mailboxMaterializer.(*recordingMailboxWriteMaterializer)
 			eventID := uuid.NewString()
-			evt := events.NewProjectionEvent(eventID,
+			evt := eventtest.Projection(eventID,
 				events.EventType("thing.created"), "", "", mustJSON(map[string]any{"amount": 250, "who": "alice"}), 0, runtimecorrelation.RunIDFromContext(ctx), "", events.EventEnvelope{}, time.Now().UTC())
 
 			seedExactOnceEvent(t, pc.workflowStore, ctx, evt)
@@ -139,7 +140,7 @@ func TestDispatchWorkflowNodeEventSkipsAlreadyProcessedCreateEntityHandler(t *te
 			bus := pc.bus.(*recordingPipelineBus)
 			mailbox := pc.mailboxMaterializer.(*recordingMailboxWriteMaterializer)
 			eventID := uuid.NewString()
-			evt := events.NewProjectionEvent(eventID,
+			evt := eventtest.Projection(eventID,
 				events.EventType("thing.created"), "", "", mustJSON(map[string]any{"amount": 250, "who": "alice"}), 0, runtimecorrelation.RunIDFromContext(ctx), "", events.EventEnvelope{}, time.Now().UTC())
 
 			seedExactOnceEventDelivery(t, pc.workflowStore, ctx, evt, "w-node")

--- a/internal/runtime/pipeline/dead_letters_test.go
+++ b/internal/runtime/pipeline/dead_letters_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/division-sh/swarm/internal/events"
+	"github.com/division-sh/swarm/internal/events/eventtest"
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
 	runtimedestructivereset "github.com/division-sh/swarm/internal/runtime/destructivereset"
 	runtimerterr "github.com/division-sh/swarm/internal/runtime/rterrors"
@@ -78,7 +79,7 @@ func TestSystemNodeRunner_RecordsDeadLetterRow(t *testing.T) {
 	}, eventReceiptsCapabilityStub{enabled: true}.resolve)
 	runner.SetRetryPolicyForTest(2, func(int) time.Duration { return 0 })
 
-	evt := events.NewProjectionEvent(uuid.NewString(),
+	evt := eventtest.Projection(uuid.NewString(),
 		"source.evt",
 		"src", "", []byte(`{"entity_id":"`+uuid.NewString()+`"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())
 
@@ -143,11 +144,12 @@ func TestCoordinator_RecordsChainDepthDeadLetterRow(t *testing.T) {
 	_, db, _ := testutil.StartPostgres(t)
 	ctx := context.Background()
 	entityID := uuid.NewString()
-	evt := (events.NewProjectionEvent(uuid.NewString(),
+	evt := eventtest.WithEntityID((eventtest.Projection(uuid.NewString(),
 		"chain.start",
 		"src", "", []byte(`{}`),
 
-		5, testPipelineRunID, "", events.EventEnvelope{}, time.Now().UTC())).WithEntityID(entityID)
+		5, testPipelineRunID, "", events.EventEnvelope{}, time.Now().UTC())), entityID)
+
 	if _, err := db.ExecContext(ctx, `
 		INSERT INTO events (event_id, event_name, entity_id, flow_instance, scope, payload, produced_by, produced_by_type, created_at)
 		VALUES ($1::uuid, $2, $3::uuid, 'runtime', 'entity', $4::jsonb, 'src', 'agent', now())
@@ -230,7 +232,7 @@ func TestSystemNodeRunner_SkipsQuiescedDestructiveResetDelivery(t *testing.T) {
 		return errors.New("should not run")
 	})
 
-	runner.ProcessEventForTest(ctx, events.NewProjectionEvent(eventID, "source.evt", "", "", []byte(`{}`), 0, testPipelineRunID, "", events.EventEnvelope{}, time.Now().UTC()))
+	runner.ProcessEventForTest(ctx, eventtest.Projection(eventID, "source.evt", "", "", []byte(`{}`), 0, testPipelineRunID, "", events.EventEnvelope{}, time.Now().UTC()))
 
 	if handled != 0 {
 		t.Fatalf("handler calls = %d, want 0 for quiesced delivery", handled)
@@ -257,7 +259,7 @@ func TestSystemNodeRunner_NonRetryableRuntimeErrorDeadLettersImmediately(t *test
 	}, 0, eventReceiptsCapabilityStub{enabled: true}.resolve)
 	runner.SetRetryPolicyForTest(5, func(int) time.Duration { return 0 })
 
-	evt := events.NewProjectionEvent(uuid.NewString(),
+	evt := eventtest.Projection(uuid.NewString(),
 		"source.evt",
 		"src", "", []byte(`{"entity_id":"ent-1"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())
 
@@ -292,9 +294,10 @@ func TestSystemNodeRunner_FailsClosedWithoutCanonicalEventReceiptsCapability(t *
 	_, db, _ := testutil.StartPostgres(t)
 	ctx := context.Background()
 	entityID := uuid.NewString()
-	evt := (events.NewProjectionEvent(uuid.NewString(),
+	evt := eventtest.WithEntityID((eventtest.Projection(uuid.NewString(),
 		"source.evt",
-		"src", "", []byte(`{"entity_id":"`+entityID+`"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())).WithEntityID(entityID)
+		"src", "", []byte(`{"entity_id":"`+entityID+`"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())), entityID)
+
 	if _, err := db.ExecContext(ctx, `
 		INSERT INTO events (event_id, event_name, entity_id, flow_instance, scope, payload, produced_by, produced_by_type, created_at)
 		VALUES ($1::uuid, $2, $3::uuid, 'runtime', 'entity', $4::jsonb, 'src', 'agent', now())
@@ -325,9 +328,10 @@ func TestSystemNodeRunner_UsesCanonicalEventReceiptsCapabilityForIdempotency(t *
 	_, db, _ := testutil.StartPostgres(t)
 	ctx := context.Background()
 	entityID := uuid.NewString()
-	evt := (events.NewProjectionEvent(uuid.NewString(),
+	evt := eventtest.WithEntityID((eventtest.Projection(uuid.NewString(),
 		"source.evt",
-		"src", "", []byte(`{"entity_id":"`+entityID+`"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())).WithEntityID(entityID)
+		"src", "", []byte(`{"entity_id":"`+entityID+`"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())), entityID)
+
 	if _, err := db.ExecContext(ctx, `
 		INSERT INTO events (event_id, event_name, entity_id, flow_instance, scope, payload, produced_by, produced_by_type, created_at)
 		VALUES ($1::uuid, $2, $3::uuid, 'runtime', 'entity', $4::jsonb, 'src', 'agent', now())
@@ -365,9 +369,10 @@ func TestSystemNodeRunner_SkipsWithoutPersistedNodeDeliveryAuthority(t *testing.
 	_, db, _ := testutil.StartPostgres(t)
 	ctx := context.Background()
 	entityID := uuid.NewString()
-	evt := (events.NewProjectionEvent(uuid.NewString(),
+	evt := eventtest.WithEntityID((eventtest.Projection(uuid.NewString(),
 		"source.evt",
-		"src", "", []byte(`{"entity_id":"`+entityID+`"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())).WithEntityID(entityID)
+		"src", "", []byte(`{"entity_id":"`+entityID+`"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())), entityID)
+
 	if _, err := db.ExecContext(ctx, `
 		INSERT INTO events (event_id, event_name, entity_id, flow_instance, scope, payload, produced_by, produced_by_type, created_at)
 		VALUES ($1::uuid, $2, $3::uuid, 'runtime', 'entity', $4::jsonb, 'src', 'agent', now())
@@ -413,7 +418,7 @@ func TestSystemNodeRunner_UsesTypedReceiptOwnerWithoutRawDB(t *testing.T) {
 		attempts++
 		return nil
 	}, 0, eventReceiptsCapabilityStub{enabled: true}.resolve)
-	evt := events.NewProjectionEvent(uuid.NewString(),
+	evt := eventtest.Projection(uuid.NewString(),
 		"source.evt", "", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())
 
 	runner.ProcessEventForTest(ctx, evt)
@@ -456,9 +461,10 @@ func TestCoordinator_InterceptHandlerErrorDoesNotSilentlyFallback(t *testing.T) 
 		},
 		EventReceiptsCapability: eventReceiptsCapabilityStub{enabled: true}.resolve,
 	})
-	evt := (events.NewProjectionEvent(uuid.NewString(),
+	evt := eventtest.WithEntityID((eventtest.Projection(uuid.NewString(),
 		events.EventType("score.dimension_complete"),
-		"analysis-agent", "", []byte(`{"entity_id":"`+uuid.NewString()+`","dimension":"expansion_potential","score":74,"tier":3}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())).WithEntityID(uuid.NewString())
+		"analysis-agent", "", []byte(`{"entity_id":"`+uuid.NewString()+`","dimension":"expansion_potential","score":74,"tier":3}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())), uuid.NewString())
+
 	if _, err := db.ExecContext(context.Background(), `
 		INSERT INTO events (event_id, event_name, entity_id, flow_instance, scope, payload, produced_by, produced_by_type, created_at)
 		VALUES ($1::uuid, $2, NULLIF($3,'')::uuid, 'runtime', 'entity', $4::jsonb, 'analysis-agent', 'agent', now())

--- a/internal/runtime/pipeline/dead_letters_test.go
+++ b/internal/runtime/pipeline/dead_letters_test.go
@@ -79,7 +79,7 @@ func TestSystemNodeRunner_RecordsDeadLetterRow(t *testing.T) {
 	}, eventReceiptsCapabilityStub{enabled: true}.resolve)
 	runner.SetRetryPolicyForTest(2, func(int) time.Duration { return 0 })
 
-	evt := eventtest.Projection(uuid.NewString(),
+	evt := eventtest.RootIngress(uuid.NewString(),
 		"source.evt",
 		"src", "", []byte(`{"entity_id":"`+uuid.NewString()+`"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())
 
@@ -144,11 +144,18 @@ func TestCoordinator_RecordsChainDepthDeadLetterRow(t *testing.T) {
 	_, db, _ := testutil.StartPostgres(t)
 	ctx := context.Background()
 	entityID := uuid.NewString()
-	evt := eventtest.WithEntityID((eventtest.Projection(uuid.NewString(),
+	evt := eventtest.RootIngress(
+		uuid.NewString(),
 		"chain.start",
-		"src", "", []byte(`{}`),
-
-		5, testPipelineRunID, "", events.EventEnvelope{}, time.Now().UTC())), entityID)
+		"src",
+		"",
+		[]byte(`{}`),
+		5,
+		testPipelineRunID,
+		"",
+		events.EnvelopeForEntityID(events.EventEnvelope{}, entityID),
+		time.Now().UTC(),
+	)
 
 	if _, err := db.ExecContext(ctx, `
 		INSERT INTO events (event_id, event_name, entity_id, flow_instance, scope, payload, produced_by, produced_by_type, created_at)
@@ -232,7 +239,7 @@ func TestSystemNodeRunner_SkipsQuiescedDestructiveResetDelivery(t *testing.T) {
 		return errors.New("should not run")
 	})
 
-	runner.ProcessEventForTest(ctx, eventtest.Projection(eventID, "source.evt", "", "", []byte(`{}`), 0, testPipelineRunID, "", events.EventEnvelope{}, time.Now().UTC()))
+	runner.ProcessEventForTest(ctx, eventtest.RootIngress(eventID, "source.evt", "", "", []byte(`{}`), 0, testPipelineRunID, "", events.EventEnvelope{}, time.Now().UTC()))
 
 	if handled != 0 {
 		t.Fatalf("handler calls = %d, want 0 for quiesced delivery", handled)
@@ -259,7 +266,7 @@ func TestSystemNodeRunner_NonRetryableRuntimeErrorDeadLettersImmediately(t *test
 	}, 0, eventReceiptsCapabilityStub{enabled: true}.resolve)
 	runner.SetRetryPolicyForTest(5, func(int) time.Duration { return 0 })
 
-	evt := eventtest.Projection(uuid.NewString(),
+	evt := eventtest.RootIngress(uuid.NewString(),
 		"source.evt",
 		"src", "", []byte(`{"entity_id":"ent-1"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())
 
@@ -294,9 +301,18 @@ func TestSystemNodeRunner_FailsClosedWithoutCanonicalEventReceiptsCapability(t *
 	_, db, _ := testutil.StartPostgres(t)
 	ctx := context.Background()
 	entityID := uuid.NewString()
-	evt := eventtest.WithEntityID((eventtest.Projection(uuid.NewString(),
+	evt := eventtest.RootIngress(
+		uuid.NewString(),
 		"source.evt",
-		"src", "", []byte(`{"entity_id":"`+entityID+`"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())), entityID)
+		"src",
+		"",
+		[]byte(`{"entity_id":"`+entityID+`"}`),
+		0,
+		"",
+		"",
+		events.EnvelopeForEntityID(events.EventEnvelope{}, entityID),
+		time.Now().UTC(),
+	)
 
 	if _, err := db.ExecContext(ctx, `
 		INSERT INTO events (event_id, event_name, entity_id, flow_instance, scope, payload, produced_by, produced_by_type, created_at)
@@ -328,9 +344,18 @@ func TestSystemNodeRunner_UsesCanonicalEventReceiptsCapabilityForIdempotency(t *
 	_, db, _ := testutil.StartPostgres(t)
 	ctx := context.Background()
 	entityID := uuid.NewString()
-	evt := eventtest.WithEntityID((eventtest.Projection(uuid.NewString(),
+	evt := eventtest.RootIngress(
+		uuid.NewString(),
 		"source.evt",
-		"src", "", []byte(`{"entity_id":"`+entityID+`"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())), entityID)
+		"src",
+		"",
+		[]byte(`{"entity_id":"`+entityID+`"}`),
+		0,
+		"",
+		"",
+		events.EnvelopeForEntityID(events.EventEnvelope{}, entityID),
+		time.Now().UTC(),
+	)
 
 	if _, err := db.ExecContext(ctx, `
 		INSERT INTO events (event_id, event_name, entity_id, flow_instance, scope, payload, produced_by, produced_by_type, created_at)
@@ -369,9 +394,18 @@ func TestSystemNodeRunner_SkipsWithoutPersistedNodeDeliveryAuthority(t *testing.
 	_, db, _ := testutil.StartPostgres(t)
 	ctx := context.Background()
 	entityID := uuid.NewString()
-	evt := eventtest.WithEntityID((eventtest.Projection(uuid.NewString(),
+	evt := eventtest.RootIngress(
+		uuid.NewString(),
 		"source.evt",
-		"src", "", []byte(`{"entity_id":"`+entityID+`"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())), entityID)
+		"src",
+		"",
+		[]byte(`{"entity_id":"`+entityID+`"}`),
+		0,
+		"",
+		"",
+		events.EnvelopeForEntityID(events.EventEnvelope{}, entityID),
+		time.Now().UTC(),
+	)
 
 	if _, err := db.ExecContext(ctx, `
 		INSERT INTO events (event_id, event_name, entity_id, flow_instance, scope, payload, produced_by, produced_by_type, created_at)
@@ -418,7 +452,7 @@ func TestSystemNodeRunner_UsesTypedReceiptOwnerWithoutRawDB(t *testing.T) {
 		attempts++
 		return nil
 	}, 0, eventReceiptsCapabilityStub{enabled: true}.resolve)
-	evt := eventtest.Projection(uuid.NewString(),
+	evt := eventtest.RootIngress(uuid.NewString(),
 		"source.evt", "", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())
 
 	runner.ProcessEventForTest(ctx, evt)
@@ -461,9 +495,18 @@ func TestCoordinator_InterceptHandlerErrorDoesNotSilentlyFallback(t *testing.T) 
 		},
 		EventReceiptsCapability: eventReceiptsCapabilityStub{enabled: true}.resolve,
 	})
-	evt := eventtest.WithEntityID((eventtest.Projection(uuid.NewString(),
+	evt := eventtest.RootIngress(
+		uuid.NewString(),
 		events.EventType("score.dimension_complete"),
-		"analysis-agent", "", []byte(`{"entity_id":"`+uuid.NewString()+`","dimension":"expansion_potential","score":74,"tier":3}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())), uuid.NewString())
+		"analysis-agent",
+		"",
+		[]byte(`{"entity_id":"`+uuid.NewString()+`","dimension":"expansion_potential","score":74,"tier":3}`),
+		0,
+		"",
+		"",
+		events.EnvelopeForEntityID(events.EventEnvelope{}, uuid.NewString()),
+		time.Now().UTC(),
+	)
 
 	if _, err := db.ExecContext(context.Background(), `
 		INSERT INTO events (event_id, event_name, entity_id, flow_instance, scope, payload, produced_by, produced_by_type, created_at)

--- a/internal/runtime/pipeline/declarative_default_node_test.go
+++ b/internal/runtime/pipeline/declarative_default_node_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/division-sh/swarm/internal/events"
+	"github.com/division-sh/swarm/internal/events/eventtest"
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
 	"github.com/division-sh/swarm/internal/runtime/semanticview"
 	"time"
@@ -23,7 +24,7 @@ func TestCoordinatorHandlerExecutionEngineUsesRuntimeEnginePath(t *testing.T) {
 	}
 	outcome, err := engine.ExecuteHandlerSteps(context.Background(), runtimecontracts.SystemNodeEventHandler{
 		Emit: runtimecontracts.EmitSpec{Event: "custom.emitted"},
-	}, events.NewProjectionEvent("", events.EventType("custom.trigger"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}).WithEntityID("ent-1"), "custom.trigger")
+	}, eventtest.WithEntityID(eventtest.Projection("", events.EventType("custom.trigger"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}), "ent-1"), "custom.trigger")
 	if err != nil {
 		t.Fatalf("ExecuteHandlerSteps: %v", err)
 	}
@@ -70,7 +71,7 @@ func TestEnsureHandlerEntityIDMintsForEntityMaterializingHandler(t *testing.T) {
 		},
 	}
 
-	entityID, evt := ensureHandlerEntityID(source, "", handler, "", events.NewProjectionEvent("", events.EventType("custom.trigger"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}))
+	entityID, evt := ensureHandlerEntityID(source, "", handler, "", eventtest.Projection("", events.EventType("custom.trigger"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}))
 
 	if entityID == "" {
 		t.Fatal("expected minted entity_id")
@@ -82,7 +83,7 @@ func TestEnsureHandlerEntityIDMintsForEntityMaterializingHandler(t *testing.T) {
 
 func TestEnsureHandlerEntityIDCreateEntityKeepsInboundEventReference(t *testing.T) {
 	handler := runtimecontracts.SystemNodeEventHandler{CreateEntity: true}
-	inbound := events.NewProjectionEvent("", events.EventType("custom.trigger"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}).WithEntityID("ent-parent")
+	inbound := eventtest.WithEntityID(eventtest.Projection("", events.EventType("custom.trigger"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}), "ent-parent")
 
 	entityID, evt := ensureHandlerEntityID(nil, "", handler, "ent-parent", inbound)
 

--- a/internal/runtime/pipeline/declarative_default_node_test.go
+++ b/internal/runtime/pipeline/declarative_default_node_test.go
@@ -24,7 +24,7 @@ func TestCoordinatorHandlerExecutionEngineUsesRuntimeEnginePath(t *testing.T) {
 	}
 	outcome, err := engine.ExecuteHandlerSteps(context.Background(), runtimecontracts.SystemNodeEventHandler{
 		Emit: runtimecontracts.EmitSpec{Event: "custom.emitted"},
-	}, eventtest.WithEntityID(eventtest.Projection("", events.EventType("custom.trigger"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}), "ent-1"), "custom.trigger")
+	}, eventtest.RootIngress("", events.EventType("custom.trigger"), "", "", nil, 0, "", "", events.EnvelopeForEntityID(events.EventEnvelope{}, "ent-1"), time.Time{}), "custom.trigger")
 	if err != nil {
 		t.Fatalf("ExecuteHandlerSteps: %v", err)
 	}
@@ -71,7 +71,7 @@ func TestEnsureHandlerEntityIDMintsForEntityMaterializingHandler(t *testing.T) {
 		},
 	}
 
-	entityID, evt := ensureHandlerEntityID(source, "", handler, "", eventtest.Projection("", events.EventType("custom.trigger"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}))
+	entityID, evt := ensureHandlerEntityID(source, "", handler, "", eventtest.RootIngress("", events.EventType("custom.trigger"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}))
 
 	if entityID == "" {
 		t.Fatal("expected minted entity_id")
@@ -83,7 +83,18 @@ func TestEnsureHandlerEntityIDMintsForEntityMaterializingHandler(t *testing.T) {
 
 func TestEnsureHandlerEntityIDCreateEntityKeepsInboundEventReference(t *testing.T) {
 	handler := runtimecontracts.SystemNodeEventHandler{CreateEntity: true}
-	inbound := eventtest.WithEntityID(eventtest.Projection("", events.EventType("custom.trigger"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}), "ent-parent")
+	inbound := eventtest.RootIngress(
+		"",
+		events.EventType("custom.trigger"),
+		"",
+		"",
+		nil,
+		0,
+		"",
+		"",
+		events.EnvelopeForEntityID(events.EventEnvelope{}, "ent-parent"),
+		time.Time{},
+	)
 
 	entityID, evt := ensureHandlerEntityID(nil, "", handler, "ent-parent", inbound)
 

--- a/internal/runtime/pipeline/engine_adapter_test.go
+++ b/internal/runtime/pipeline/engine_adapter_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/division-sh/swarm/internal/events"
+	"github.com/division-sh/swarm/internal/events/eventtest"
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
 	runtimeflowidentity "github.com/division-sh/swarm/internal/runtime/core/flowidentity"
 	"github.com/division-sh/swarm/internal/runtime/core/identity"
@@ -248,7 +249,7 @@ func assertMutationParentRoutePinOutputFailure(t *testing.T, metadata map[string
 			FlowInstance: route.FlowInstance,
 			EntityID:     route.EntityID,
 		},
-	}, events.NewProjectionEvent("", events.EventType("child.done"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}))
+	}, eventtest.Projection("", events.EventType("child.done"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}))
 	if result.Failure != want {
 		t.Fatalf("pin output failure = %q, want %q (metadata=%#v)", result.Failure, want, metadata)
 	}
@@ -713,7 +714,7 @@ func TestPipelineEngineActionRunner_RecordEvidenceReturnsMutationError(t *testin
 		Request: runtimeengine.ExecutionRequest{
 			EntityID:        identity.NormalizeEntityID("11111111-1111-1111-1111-111111111111"),
 			NodeID:          identity.NormalizeNodeID("node-a"),
-			Event:           (events.NewProjectionEvent("", "research.completed", "", "", []byte(`{"summary":"done"}`), 0, "", "", events.EventEnvelope{}, time.Time{})).WithEntityID("11111111-1111-1111-1111-111111111111"),
+			Event:           eventtest.WithEntityID((eventtest.Projection("", "research.completed", "", "", []byte(`{"summary":"done"}`), 0, "", "", events.EventEnvelope{}, time.Time{})), "11111111-1111-1111-1111-111111111111"),
 			HandlerEventKey: "research.completed",
 			Handler: runtimecontracts.SystemNodeEventHandler{
 				Action:         runtimecontracts.ActionSpec{ID: "record_evidence"},
@@ -797,7 +798,7 @@ func TestPipelineEngineActionRunner_RecordEvidenceUsesMatchedHandlerEvidenceTarg
 				Request: runtimeengine.ExecutionRequest{
 					EntityID:        identity.NormalizeEntityID(tt.entityID),
 					NodeID:          identity.NormalizeNodeID("build-orchestrator"),
-					Event:           events.NewProjectionEvent("", tt.concreteEvent, "", "", mustJSON(map[string]any{"summary": tt.wantSummary}), 0, "", "", events.EventEnvelope{}, time.Time{}).WithEntityID(tt.entityID),
+					Event:           eventtest.WithEntityID(eventtest.Projection("", tt.concreteEvent, "", "", mustJSON(map[string]any{"summary": tt.wantSummary}), 0, "", "", events.EventEnvelope{}, time.Time{}), tt.entityID),
 					HandlerEventKey: tt.handlerEventKey,
 					Handler:         tt.handler,
 				},
@@ -836,8 +837,8 @@ func TestPipelineEngineActionRunner_CreateFlowInstanceUsesExecutionBaseContextFo
 		},
 	}
 	runner := pipelineEngineActionRunner{coordinator: pc}
-	evt := (events.NewProjectionEvent("evt-123",
-		"spawn.requested", "", "", []byte(`{"instance_id":"inst-42","name":"alpha","template_id":"application-basic-v1"}`), 0, "", "source-evt-1", events.EventEnvelope{}, time.Time{})).WithEnvelope(events.EventEnvelope{
+	evt := eventtest.WithEnvelope((eventtest.Projection("evt-123",
+		"spawn.requested", "", "", []byte(`{"instance_id":"inst-42","name":"alpha","template_id":"application-basic-v1"}`), 0, "", "source-evt-1", events.EventEnvelope{}, time.Time{})), events.EventEnvelope{
 		EntityID: "ent-1",
 		Source: events.RouteIdentity{
 			FlowID:       "parent-flow",
@@ -845,6 +846,7 @@ func TestPipelineEngineActionRunner_CreateFlowInstanceUsesExecutionBaseContextFo
 			EntityID:     "ent-parent",
 		},
 	})
+
 	base := values.NewContext()
 	base.Event = values.Wrap(evt.ContextMap("ready"))
 	base.Payload = values.Wrap(parsePayloadMap(evt.Payload()))
@@ -916,12 +918,13 @@ func TestPipelineEngineActionRunner_MailboxWriteMaterializesIdempotentRow(t *tes
 			},
 		},
 	}
-	evt := (events.NewProjectionEvent(eventID,
-		"mailbox.review_requested", "", "", []byte(`{"review_kind":"validation"}`), 0, "", "", events.EventEnvelope{}, time.Time{})).WithEnvelope(events.EventEnvelope{
+	evt := eventtest.WithEnvelope((eventtest.Projection(eventID,
+		"mailbox.review_requested", "", "", []byte(`{"review_kind":"validation"}`), 0, "", "", events.EventEnvelope{}, time.Time{})), events.EventEnvelope{
 		EntityID:     entityID,
 		FlowInstance: "validation/case-1",
 		Scope:        events.EventScopeEntity,
 	})
+
 	base := values.NewContext()
 	base.Event = values.Wrap(evt.ContextMap(""))
 	base.Payload = values.Wrap(parsePayloadMap(evt.Payload()))
@@ -983,7 +986,7 @@ func TestPipelineEngineActionRunner_MailboxWriteFailsClosedOnMissingRequiredExpr
 			Summary:  runtimecontracts.RefExpression("payload.missing_summary"),
 		},
 	}
-	evt := events.NewProjectionEvent(eventID, "mailbox.review_requested", "", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Time{})
+	evt := eventtest.Projection(eventID, "mailbox.review_requested", "", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Time{})
 	base := values.NewContext()
 	base.Event = values.Wrap(evt.ContextMap(""))
 	base.Payload = values.Wrap(parsePayloadMap(evt.Payload()))
@@ -2218,7 +2221,7 @@ func TestArtifactRepoPathRejectsUnsafeGenericSegments(t *testing.T) {
 }
 
 func testProjectionEventWithSourceAgent(evt events.Event, sourceAgent string) events.Event {
-	return events.NewProjectionEvent(
+	return eventtest.Projection(
 		evt.ID(),
 		evt.Type(),
 		sourceAgent,
@@ -2228,8 +2231,8 @@ func testProjectionEventWithSourceAgent(evt events.Event, sourceAgent string) ev
 		evt.RunID(),
 		evt.ParentEventID(),
 		evt.Envelope(),
-		evt.CreatedAt(),
-	)
+		evt.CreatedAt())
+
 }
 
 func assertArtifactRepoQueuedIntent(t *testing.T, intents []runtimeengine.EmitIntent, index int, eventType string) events.Event {
@@ -2322,9 +2325,10 @@ func testArtifactRepoActionAndContext(entityID string, entity map[string]any, ev
 		"mvp_yaml":   content,
 	}
 	payloadBytes, _ := json.Marshal(payload)
-	evt := events.NewProjectionEvent(eventID,
-		"artifact_repo.commit_requested", "", "", payloadBytes, 0, testPipelineRunID, "", events.EventEnvelope{}, time.Unix(1_700_000_000, 0).UTC()).
-		WithEnvelope(events.EventEnvelope{EntityID: entityID})
+	evt := eventtest.WithEnvelope(eventtest.Projection(eventID,
+		"artifact_repo.commit_requested", "", "", payloadBytes, 0, testPipelineRunID, "", events.EventEnvelope{}, time.Unix(1_700_000_000, 0).UTC()),
+		events.EventEnvelope{EntityID: entityID})
+
 	base := values.NewContext()
 	base.Event = values.Wrap(evt.ContextMap("ready"))
 	base.Payload = values.Wrap(payload)
@@ -2456,8 +2460,9 @@ func TestPipelineEnginePayloadShaper_UsesParentEntityForCrossFlowOutputs(t *test
 	req := runtimeengine.ExecutionRequest{
 		EntityID: identity.NormalizeEntityID("ent-child"),
 		FlowID:   identity.NormalizeFlowID("child"),
-		Event: events.NewProjectionEvent("", events.EventType("child/child.internal"), "", "", json.RawMessage(`{"entity_id":"ent-child","step":"done"}`), 0, "", "", events.EventEnvelope{}, time.Time{}).
-			WithEntityID("ent-child"),
+		Event: eventtest.WithEntityID(eventtest.Projection("", events.EventType("child/child.internal"), "", "", json.RawMessage(`{"entity_id":"ent-child","step":"done"}`), 0, "", "", events.EventEnvelope{}, time.Time{}),
+			"ent-child"),
+
 		State: runtimeengine.StateSnapshot{
 			EntityID:     identity.NormalizeEntityID("ent-child"),
 			StateCarrier: runtimeengine.NewStateCarrier(map[string]any{"flow_path": "child/inst-1", "subject_id": "ent-parent", "parent_entity_id": "ent-parent"}, nil, nil),
@@ -2499,8 +2504,9 @@ func TestPipelineEnginePayloadShaper_RejectsUndeclaredFieldsAcrossCrossFlowOutpu
 	req := runtimeengine.ExecutionRequest{
 		EntityID: identity.NormalizeEntityID("ent-child"),
 		FlowID:   identity.NormalizeFlowID("child"),
-		Event: events.NewProjectionEvent("", events.EventType("child/child.internal"), "", "", json.RawMessage(`{"entity_id":"ent-child"}`), 0, "", "", events.EventEnvelope{}, time.Time{}).
-			WithEntityID("ent-child"),
+		Event: eventtest.WithEntityID(eventtest.Projection("", events.EventType("child/child.internal"), "", "", json.RawMessage(`{"entity_id":"ent-child"}`), 0, "", "", events.EventEnvelope{}, time.Time{}),
+			"ent-child"),
+
 		State: runtimeengine.StateSnapshot{
 			EntityID:     identity.NormalizeEntityID("ent-child"),
 			StateCarrier: runtimeengine.NewStateCarrier(map[string]any{"flow_path": "child/inst-1", "subject_id": "ent-parent", "parent_entity_id": "ent-parent"}, nil, nil),
@@ -2536,8 +2542,9 @@ func TestPipelineEnginePayloadShaper_AllowsDeclaredPayloadOnActionSurface(t *tes
 	req := runtimeengine.ExecutionRequest{
 		EntityID: identity.NormalizeEntityID("ent-child"),
 		FlowID:   identity.NormalizeFlowID("child"),
-		Event: events.NewProjectionEvent("", events.EventType("child/child.internal"), "", "", json.RawMessage(`{"entity_id":"ent-child","step":"done"}`), 0, "", "", events.EventEnvelope{}, time.Time{}).
-			WithEntityID("ent-child"),
+		Event: eventtest.WithEntityID(eventtest.Projection("", events.EventType("child/child.internal"), "", "", json.RawMessage(`{"entity_id":"ent-child","step":"done"}`), 0, "", "", events.EventEnvelope{}, time.Time{}),
+			"ent-child"),
+
 		State: runtimeengine.StateSnapshot{
 			EntityID:     identity.NormalizeEntityID("ent-child"),
 			StateCarrier: runtimeengine.NewStateCarrier(map[string]any{"flow_path": "child/inst-1", "subject_id": "ent-parent", "parent_entity_id": "ent-parent"}, nil, nil),
@@ -2578,8 +2585,9 @@ func TestPipelineEnginePayloadShaper_RejectsMissingRequiredFieldsOnActionSurface
 	req := runtimeengine.ExecutionRequest{
 		EntityID: identity.NormalizeEntityID("ent-child"),
 		FlowID:   identity.NormalizeFlowID("child"),
-		Event: events.NewProjectionEvent("", events.EventType("child/child.start"), "", "", json.RawMessage(`{"entity_id":"ent-child"}`), 0, "", "", events.EventEnvelope{}, time.Time{}).
-			WithEntityID("ent-child"),
+		Event: eventtest.WithEntityID(eventtest.Projection("", events.EventType("child/child.start"), "", "", json.RawMessage(`{"entity_id":"ent-child"}`), 0, "", "", events.EventEnvelope{}, time.Time{}),
+			"ent-child"),
+
 		State: runtimeengine.StateSnapshot{
 			EntityID:     identity.NormalizeEntityID("ent-child"),
 			StateCarrier: runtimeengine.NewStateCarrier(map[string]any{"flow_path": "child/inst-1", "subject_id": "ent-parent", "parent_entity_id": "ent-parent"}, nil, nil),
@@ -2622,8 +2630,9 @@ func TestPipelineEnginePayloadShaper_RejectsMissingRequiredFieldsForConcreteTemp
 	req := runtimeengine.ExecutionRequest{
 		EntityID: identity.NormalizeEntityID("ent-child"),
 		FlowID:   identity.NormalizeFlowID("child"),
-		Event: events.NewProjectionEvent("", events.EventType("child/child.start"), "", "", json.RawMessage(`{"entity_id":"ent-child"}`), 0, "", "", events.EventEnvelope{}, time.Time{}).
-			WithEntityID("ent-child"),
+		Event: eventtest.WithEntityID(eventtest.Projection("", events.EventType("child/child.start"), "", "", json.RawMessage(`{"entity_id":"ent-child"}`), 0, "", "", events.EventEnvelope{}, time.Time{}),
+			"ent-child"),
+
 		State: runtimeengine.StateSnapshot{
 			EntityID:     identity.NormalizeEntityID("ent-child"),
 			StateCarrier: runtimeengine.NewStateCarrier(map[string]any{"flow_path": "child/inst-1", "subject_id": "ent-parent", "parent_entity_id": "ent-parent"}, nil, nil),
@@ -2667,8 +2676,9 @@ func TestPipelineEnginePayloadShaper_RejectsEnvelopeOnlyRequiredFieldOnActionSur
 	req := runtimeengine.ExecutionRequest{
 		EntityID: identity.NormalizeEntityID("ent-child"),
 		FlowID:   identity.NormalizeFlowID("child"),
-		Event: events.NewProjectionEvent("", events.EventType("child/child.start"), "", "", json.RawMessage(`{"entity_id":"ent-child"}`), 0, "", "", events.EventEnvelope{}, time.Time{}).
-			WithEntityID("ent-child"),
+		Event: eventtest.WithEntityID(eventtest.Projection("", events.EventType("child/child.start"), "", "", json.RawMessage(`{"entity_id":"ent-child"}`), 0, "", "", events.EventEnvelope{}, time.Time{}),
+			"ent-child"),
+
 		State: runtimeengine.StateSnapshot{
 			EntityID:     identity.NormalizeEntityID("ent-child"),
 			StateCarrier: runtimeengine.NewStateCarrier(map[string]any{"flow_path": "child/inst-1", "subject_id": "ent-parent", "parent_entity_id": "ent-parent"}, nil, nil),
@@ -2733,8 +2743,9 @@ func TestPipelineEnginePayloadShaper_UsesRootNamedTypeSchemaForChildOutput(t *te
 	req := runtimeengine.ExecutionRequest{
 		EntityID: identity.NormalizeEntityID("ent-child"),
 		FlowID:   identity.NormalizeFlowID("child"),
-		Event: events.NewProjectionEvent("", events.EventType("child/child.internal"), "", "", json.RawMessage(`{"entity_id":"ent-child"}`), 0, "", "", events.EventEnvelope{}, time.Time{}).
-			WithEntityID("ent-child"),
+		Event: eventtest.WithEntityID(eventtest.Projection("", events.EventType("child/child.internal"), "", "", json.RawMessage(`{"entity_id":"ent-child"}`), 0, "", "", events.EventEnvelope{}, time.Time{}),
+			"ent-child"),
+
 		State: runtimeengine.StateSnapshot{
 			EntityID:     identity.NormalizeEntityID("ent-child"),
 			StateCarrier: runtimeengine.NewStateCarrier(map[string]any{"flow_path": "child/inst-1"}, nil, nil),
@@ -2787,8 +2798,9 @@ func TestPipelineEnginePayloadShaper_RejectsUndeclaredFieldsOnActionSurface(t *t
 	req := runtimeengine.ExecutionRequest{
 		EntityID: identity.NormalizeEntityID("ent-child"),
 		FlowID:   identity.NormalizeFlowID("child"),
-		Event: events.NewProjectionEvent("", events.EventType("child/child.internal"), "", "", json.RawMessage(`{"entity_id":"ent-child","step":"done"}`), 0, "", "", events.EventEnvelope{}, time.Time{}).
-			WithEntityID("ent-child"),
+		Event: eventtest.WithEntityID(eventtest.Projection("", events.EventType("child/child.internal"), "", "", json.RawMessage(`{"entity_id":"ent-child","step":"done"}`), 0, "", "", events.EventEnvelope{}, time.Time{}),
+			"ent-child"),
+
 		State: runtimeengine.StateSnapshot{
 			EntityID:     identity.NormalizeEntityID("ent-child"),
 			StateCarrier: runtimeengine.NewStateCarrier(map[string]any{"flow_path": "child/inst-1", "subject_id": "ent-parent", "parent_entity_id": "ent-parent"}, nil, nil),

--- a/internal/runtime/pipeline/engine_adapter_test.go
+++ b/internal/runtime/pipeline/engine_adapter_test.go
@@ -249,7 +249,7 @@ func assertMutationParentRoutePinOutputFailure(t *testing.T, metadata map[string
 			FlowInstance: route.FlowInstance,
 			EntityID:     route.EntityID,
 		},
-	}, eventtest.Projection("", events.EventType("child.done"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}))
+	}, eventtest.RootIngress("", events.EventType("child.done"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}))
 	if result.Failure != want {
 		t.Fatalf("pin output failure = %q, want %q (metadata=%#v)", result.Failure, want, metadata)
 	}
@@ -712,9 +712,20 @@ func TestPipelineEngineActionRunner_RecordEvidenceReturnsMutationError(t *testin
 	runner := pipelineEngineActionRunner{coordinator: pc}
 	ok, err := runner.ExecuteAction(context.Background(), runtimecontracts.ActionSpec{ID: "record_evidence"}, runtimeregistry.ActionInstruction{Builtin: "record_evidence"}, runtimeengine.ExecutionContext{
 		Request: runtimeengine.ExecutionRequest{
-			EntityID:        identity.NormalizeEntityID("11111111-1111-1111-1111-111111111111"),
-			NodeID:          identity.NormalizeNodeID("node-a"),
-			Event:           eventtest.WithEntityID((eventtest.Projection("", "research.completed", "", "", []byte(`{"summary":"done"}`), 0, "", "", events.EventEnvelope{}, time.Time{})), "11111111-1111-1111-1111-111111111111"),
+			EntityID: identity.NormalizeEntityID("11111111-1111-1111-1111-111111111111"),
+			NodeID:   identity.NormalizeNodeID("node-a"),
+			Event: eventtest.RootIngress(
+				"",
+				"research.completed",
+				"",
+				"",
+				[]byte(`{"summary":"done"}`),
+				0,
+				"",
+				"",
+				events.EnvelopeForEntityID(events.EventEnvelope{}, "11111111-1111-1111-1111-111111111111"),
+				time.Time{},
+			),
 			HandlerEventKey: "research.completed",
 			Handler: runtimecontracts.SystemNodeEventHandler{
 				Action:         runtimecontracts.ActionSpec{ID: "record_evidence"},
@@ -796,9 +807,20 @@ func TestPipelineEngineActionRunner_RecordEvidenceUsesMatchedHandlerEvidenceTarg
 
 			ok, err := runner.ExecuteAction(ctx, tt.action, runtimeregistry.ActionInstruction{Builtin: "record_evidence"}, runtimeengine.ExecutionContext{
 				Request: runtimeengine.ExecutionRequest{
-					EntityID:        identity.NormalizeEntityID(tt.entityID),
-					NodeID:          identity.NormalizeNodeID("build-orchestrator"),
-					Event:           eventtest.WithEntityID(eventtest.Projection("", tt.concreteEvent, "", "", mustJSON(map[string]any{"summary": tt.wantSummary}), 0, "", "", events.EventEnvelope{}, time.Time{}), tt.entityID),
+					EntityID: identity.NormalizeEntityID(tt.entityID),
+					NodeID:   identity.NormalizeNodeID("build-orchestrator"),
+					Event: eventtest.RootIngress(
+						"",
+						tt.concreteEvent,
+						"",
+						"",
+						mustJSON(map[string]any{"summary": tt.wantSummary}),
+						0,
+						"",
+						"",
+						events.EnvelopeForEntityID(events.EventEnvelope{}, tt.entityID),
+						time.Time{},
+					),
 					HandlerEventKey: tt.handlerEventKey,
 					Handler:         tt.handler,
 				},
@@ -837,15 +859,25 @@ func TestPipelineEngineActionRunner_CreateFlowInstanceUsesExecutionBaseContextFo
 		},
 	}
 	runner := pipelineEngineActionRunner{coordinator: pc}
-	evt := eventtest.WithEnvelope((eventtest.Projection("evt-123",
-		"spawn.requested", "", "", []byte(`{"instance_id":"inst-42","name":"alpha","template_id":"application-basic-v1"}`), 0, "", "source-evt-1", events.EventEnvelope{}, time.Time{})), events.EventEnvelope{
-		EntityID: "ent-1",
-		Source: events.RouteIdentity{
-			FlowID:       "parent-flow",
-			FlowInstance: "parent-flow/source-1",
-			EntityID:     "ent-parent",
+	evt := eventtest.RootIngress(
+		"evt-123",
+		"spawn.requested",
+		"",
+		"",
+		[]byte(`{"instance_id":"inst-42","name":"alpha","template_id":"application-basic-v1"}`),
+		0,
+		"",
+		"source-evt-1",
+		events.EventEnvelope{
+			EntityID: "ent-1",
+			Source: events.RouteIdentity{
+				FlowID:       "parent-flow",
+				FlowInstance: "parent-flow/source-1",
+				EntityID:     "ent-parent",
+			},
 		},
-	})
+		time.Time{},
+	)
 
 	base := values.NewContext()
 	base.Event = values.Wrap(evt.ContextMap("ready"))
@@ -918,12 +950,22 @@ func TestPipelineEngineActionRunner_MailboxWriteMaterializesIdempotentRow(t *tes
 			},
 		},
 	}
-	evt := eventtest.WithEnvelope((eventtest.Projection(eventID,
-		"mailbox.review_requested", "", "", []byte(`{"review_kind":"validation"}`), 0, "", "", events.EventEnvelope{}, time.Time{})), events.EventEnvelope{
-		EntityID:     entityID,
-		FlowInstance: "validation/case-1",
-		Scope:        events.EventScopeEntity,
-	})
+	evt := eventtest.RootIngress(
+		eventID,
+		"mailbox.review_requested",
+		"",
+		"",
+		[]byte(`{"review_kind":"validation"}`),
+		0,
+		"",
+		"",
+		events.EventEnvelope{
+			EntityID:     entityID,
+			FlowInstance: "validation/case-1",
+			Scope:        events.EventScopeEntity,
+		},
+		time.Time{},
+	)
 
 	base := values.NewContext()
 	base.Event = values.Wrap(evt.ContextMap(""))
@@ -986,7 +1028,7 @@ func TestPipelineEngineActionRunner_MailboxWriteFailsClosedOnMissingRequiredExpr
 			Summary:  runtimecontracts.RefExpression("payload.missing_summary"),
 		},
 	}
-	evt := eventtest.Projection(eventID, "mailbox.review_requested", "", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Time{})
+	evt := eventtest.RootIngress(eventID, "mailbox.review_requested", "", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Time{})
 	base := values.NewContext()
 	base.Event = values.Wrap(evt.ContextMap(""))
 	base.Payload = values.Wrap(parsePayloadMap(evt.Payload()))
@@ -2221,7 +2263,7 @@ func TestArtifactRepoPathRejectsUnsafeGenericSegments(t *testing.T) {
 }
 
 func testProjectionEventWithSourceAgent(evt events.Event, sourceAgent string) events.Event {
-	return eventtest.Projection(
+	return eventtest.RootIngress(
 		evt.ID(),
 		evt.Type(),
 		sourceAgent,
@@ -2325,9 +2367,18 @@ func testArtifactRepoActionAndContext(entityID string, entity map[string]any, ev
 		"mvp_yaml":   content,
 	}
 	payloadBytes, _ := json.Marshal(payload)
-	evt := eventtest.WithEnvelope(eventtest.Projection(eventID,
-		"artifact_repo.commit_requested", "", "", payloadBytes, 0, testPipelineRunID, "", events.EventEnvelope{}, time.Unix(1_700_000_000, 0).UTC()),
-		events.EventEnvelope{EntityID: entityID})
+	evt := eventtest.RootIngress(
+		eventID,
+		"artifact_repo.commit_requested",
+		"",
+		"",
+		payloadBytes,
+		0,
+		testPipelineRunID,
+		"",
+		events.EventEnvelope{EntityID: entityID},
+		time.Unix(1_700_000_000, 0).UTC(),
+	)
 
 	base := values.NewContext()
 	base.Event = values.Wrap(evt.ContextMap("ready"))
@@ -2460,8 +2511,18 @@ func TestPipelineEnginePayloadShaper_UsesParentEntityForCrossFlowOutputs(t *test
 	req := runtimeengine.ExecutionRequest{
 		EntityID: identity.NormalizeEntityID("ent-child"),
 		FlowID:   identity.NormalizeFlowID("child"),
-		Event: eventtest.WithEntityID(eventtest.Projection("", events.EventType("child/child.internal"), "", "", json.RawMessage(`{"entity_id":"ent-child","step":"done"}`), 0, "", "", events.EventEnvelope{}, time.Time{}),
-			"ent-child"),
+		Event: eventtest.RootIngress(
+			"",
+			events.EventType("child/child.internal"),
+			"",
+			"",
+			json.RawMessage(`{"entity_id":"ent-child","step":"done"}`),
+			0,
+			"",
+			"",
+			events.EnvelopeForEntityID(events.EventEnvelope{}, "ent-child"),
+			time.Time{},
+		),
 
 		State: runtimeengine.StateSnapshot{
 			EntityID:     identity.NormalizeEntityID("ent-child"),
@@ -2504,8 +2565,18 @@ func TestPipelineEnginePayloadShaper_RejectsUndeclaredFieldsAcrossCrossFlowOutpu
 	req := runtimeengine.ExecutionRequest{
 		EntityID: identity.NormalizeEntityID("ent-child"),
 		FlowID:   identity.NormalizeFlowID("child"),
-		Event: eventtest.WithEntityID(eventtest.Projection("", events.EventType("child/child.internal"), "", "", json.RawMessage(`{"entity_id":"ent-child"}`), 0, "", "", events.EventEnvelope{}, time.Time{}),
-			"ent-child"),
+		Event: eventtest.RootIngress(
+			"",
+			events.EventType("child/child.internal"),
+			"",
+			"",
+			json.RawMessage(`{"entity_id":"ent-child"}`),
+			0,
+			"",
+			"",
+			events.EnvelopeForEntityID(events.EventEnvelope{}, "ent-child"),
+			time.Time{},
+		),
 
 		State: runtimeengine.StateSnapshot{
 			EntityID:     identity.NormalizeEntityID("ent-child"),
@@ -2542,8 +2613,18 @@ func TestPipelineEnginePayloadShaper_AllowsDeclaredPayloadOnActionSurface(t *tes
 	req := runtimeengine.ExecutionRequest{
 		EntityID: identity.NormalizeEntityID("ent-child"),
 		FlowID:   identity.NormalizeFlowID("child"),
-		Event: eventtest.WithEntityID(eventtest.Projection("", events.EventType("child/child.internal"), "", "", json.RawMessage(`{"entity_id":"ent-child","step":"done"}`), 0, "", "", events.EventEnvelope{}, time.Time{}),
-			"ent-child"),
+		Event: eventtest.RootIngress(
+			"",
+			events.EventType("child/child.internal"),
+			"",
+			"",
+			json.RawMessage(`{"entity_id":"ent-child","step":"done"}`),
+			0,
+			"",
+			"",
+			events.EnvelopeForEntityID(events.EventEnvelope{}, "ent-child"),
+			time.Time{},
+		),
 
 		State: runtimeengine.StateSnapshot{
 			EntityID:     identity.NormalizeEntityID("ent-child"),
@@ -2585,8 +2666,18 @@ func TestPipelineEnginePayloadShaper_RejectsMissingRequiredFieldsOnActionSurface
 	req := runtimeengine.ExecutionRequest{
 		EntityID: identity.NormalizeEntityID("ent-child"),
 		FlowID:   identity.NormalizeFlowID("child"),
-		Event: eventtest.WithEntityID(eventtest.Projection("", events.EventType("child/child.start"), "", "", json.RawMessage(`{"entity_id":"ent-child"}`), 0, "", "", events.EventEnvelope{}, time.Time{}),
-			"ent-child"),
+		Event: eventtest.RootIngress(
+			"",
+			events.EventType("child/child.start"),
+			"",
+			"",
+			json.RawMessage(`{"entity_id":"ent-child"}`),
+			0,
+			"",
+			"",
+			events.EnvelopeForEntityID(events.EventEnvelope{}, "ent-child"),
+			time.Time{},
+		),
 
 		State: runtimeengine.StateSnapshot{
 			EntityID:     identity.NormalizeEntityID("ent-child"),
@@ -2630,8 +2721,18 @@ func TestPipelineEnginePayloadShaper_RejectsMissingRequiredFieldsForConcreteTemp
 	req := runtimeengine.ExecutionRequest{
 		EntityID: identity.NormalizeEntityID("ent-child"),
 		FlowID:   identity.NormalizeFlowID("child"),
-		Event: eventtest.WithEntityID(eventtest.Projection("", events.EventType("child/child.start"), "", "", json.RawMessage(`{"entity_id":"ent-child"}`), 0, "", "", events.EventEnvelope{}, time.Time{}),
-			"ent-child"),
+		Event: eventtest.RootIngress(
+			"",
+			events.EventType("child/child.start"),
+			"",
+			"",
+			json.RawMessage(`{"entity_id":"ent-child"}`),
+			0,
+			"",
+			"",
+			events.EnvelopeForEntityID(events.EventEnvelope{}, "ent-child"),
+			time.Time{},
+		),
 
 		State: runtimeengine.StateSnapshot{
 			EntityID:     identity.NormalizeEntityID("ent-child"),
@@ -2676,8 +2777,18 @@ func TestPipelineEnginePayloadShaper_RejectsEnvelopeOnlyRequiredFieldOnActionSur
 	req := runtimeengine.ExecutionRequest{
 		EntityID: identity.NormalizeEntityID("ent-child"),
 		FlowID:   identity.NormalizeFlowID("child"),
-		Event: eventtest.WithEntityID(eventtest.Projection("", events.EventType("child/child.start"), "", "", json.RawMessage(`{"entity_id":"ent-child"}`), 0, "", "", events.EventEnvelope{}, time.Time{}),
-			"ent-child"),
+		Event: eventtest.RootIngress(
+			"",
+			events.EventType("child/child.start"),
+			"",
+			"",
+			json.RawMessage(`{"entity_id":"ent-child"}`),
+			0,
+			"",
+			"",
+			events.EnvelopeForEntityID(events.EventEnvelope{}, "ent-child"),
+			time.Time{},
+		),
 
 		State: runtimeengine.StateSnapshot{
 			EntityID:     identity.NormalizeEntityID("ent-child"),
@@ -2743,8 +2854,18 @@ func TestPipelineEnginePayloadShaper_UsesRootNamedTypeSchemaForChildOutput(t *te
 	req := runtimeengine.ExecutionRequest{
 		EntityID: identity.NormalizeEntityID("ent-child"),
 		FlowID:   identity.NormalizeFlowID("child"),
-		Event: eventtest.WithEntityID(eventtest.Projection("", events.EventType("child/child.internal"), "", "", json.RawMessage(`{"entity_id":"ent-child"}`), 0, "", "", events.EventEnvelope{}, time.Time{}),
-			"ent-child"),
+		Event: eventtest.RootIngress(
+			"",
+			events.EventType("child/child.internal"),
+			"",
+			"",
+			json.RawMessage(`{"entity_id":"ent-child"}`),
+			0,
+			"",
+			"",
+			events.EnvelopeForEntityID(events.EventEnvelope{}, "ent-child"),
+			time.Time{},
+		),
 
 		State: runtimeengine.StateSnapshot{
 			EntityID:     identity.NormalizeEntityID("ent-child"),
@@ -2798,8 +2919,18 @@ func TestPipelineEnginePayloadShaper_RejectsUndeclaredFieldsOnActionSurface(t *t
 	req := runtimeengine.ExecutionRequest{
 		EntityID: identity.NormalizeEntityID("ent-child"),
 		FlowID:   identity.NormalizeFlowID("child"),
-		Event: eventtest.WithEntityID(eventtest.Projection("", events.EventType("child/child.internal"), "", "", json.RawMessage(`{"entity_id":"ent-child","step":"done"}`), 0, "", "", events.EventEnvelope{}, time.Time{}),
-			"ent-child"),
+		Event: eventtest.RootIngress(
+			"",
+			events.EventType("child/child.internal"),
+			"",
+			"",
+			json.RawMessage(`{"entity_id":"ent-child","step":"done"}`),
+			0,
+			"",
+			"",
+			events.EnvelopeForEntityID(events.EventEnvelope{}, "ent-child"),
+			time.Time{},
+		),
 
 		State: runtimeengine.StateSnapshot{
 			EntityID:     identity.NormalizeEntityID("ent-child"),

--- a/internal/runtime/pipeline/flow_instance_identity_test.go
+++ b/internal/runtime/pipeline/flow_instance_identity_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/division-sh/swarm/internal/events"
+	"github.com/division-sh/swarm/internal/events/eventtest"
 )
 
 func TestFlowInstanceIdentity_DistinguishesScopeKeyInstancePathAndEntityID(t *testing.T) {
@@ -186,5 +187,5 @@ func TestWorkflowInstanceOwnedByFlow_UsesExactSemanticScope(t *testing.T) {
 }
 
 func mustEvent(eventType, entityID string) Event {
-	return events.NewProjectionEvent("", events.EventType(eventType), "", "", nil, 0, "", "", events.EventEnvelope{EntityID: entityID}, time.Time{})
+	return eventtest.Projection("", events.EventType(eventType), "", "", nil, 0, "", "", events.EventEnvelope{EntityID: entityID}, time.Time{})
 }

--- a/internal/runtime/pipeline/flow_instance_identity_test.go
+++ b/internal/runtime/pipeline/flow_instance_identity_test.go
@@ -187,5 +187,5 @@ func TestWorkflowInstanceOwnedByFlow_UsesExactSemanticScope(t *testing.T) {
 }
 
 func mustEvent(eventType, entityID string) Event {
-	return eventtest.Projection("", events.EventType(eventType), "", "", nil, 0, "", "", events.EventEnvelope{EntityID: entityID}, time.Time{})
+	return eventtest.RootIngress("", events.EventType(eventType), "", "", nil, 0, "", "", events.EventEnvelope{EntityID: entityID}, time.Time{})
 }

--- a/internal/runtime/pipeline/handler_engine_transaction_test.go
+++ b/internal/runtime/pipeline/handler_engine_transaction_test.go
@@ -154,7 +154,7 @@ func TestExecuteNodeContractHandlerFlushesCollectedEventsToParentCollector(t *te
 	result, err := pc.executeNodeContractHandler(ctx, "node-a", runtimecontracts.SystemNodeEventHandler{
 		Emit: runtimecontracts.EmitSpec{Event: "custom.emitted"},
 	}, workflowTriggerContext{
-		Event: eventtest.WithEntityID(eventtest.Projection("", events.EventType("custom.trigger"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}), "ent-1"),
+		Event: eventtest.RootIngress("", events.EventType("custom.trigger"), "", "", nil, 0, "", "", events.EnvelopeForEntityID(events.EventEnvelope{}, "ent-1"), time.Time{}),
 		State: WorkflowState{Stage: WorkflowStateID("queued"), Metadata: map[string]any{}},
 	}, false)
 	if err != nil {
@@ -185,7 +185,7 @@ func TestExecuteNodeContractHandlerPublishesCollectedEventsWithoutParentCollecto
 	result, err := pc.executeNodeContractHandler(testPipelineCoordinatorRunContext(t, pc), "node-a", runtimecontracts.SystemNodeEventHandler{
 		Emit: runtimecontracts.EmitSpec{Event: "custom.emitted"},
 	}, workflowTriggerContext{
-		Event: eventtest.WithEntityID(eventtest.Projection("", events.EventType("custom.trigger"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}), "ent-1"),
+		Event: eventtest.RootIngress("", events.EventType("custom.trigger"), "", "", nil, 0, "", "", events.EnvelopeForEntityID(events.EventEnvelope{}, "ent-1"), time.Time{}),
 		State: WorkflowState{Stage: WorkflowStateID("queued"), Metadata: map[string]any{}},
 	}, false)
 	if err != nil {
@@ -210,7 +210,18 @@ func TestExecuteNodeContractHandlerUsesTypedEnvelopeIdentityOverPayload(t *testi
 	result, err := pc.executeNodeContractHandler(testPipelineCoordinatorRunContext(t, pc), "node-a", runtimecontracts.SystemNodeEventHandler{
 		Emit: runtimecontracts.EmitSpec{Event: "custom.emitted"},
 	}, workflowTriggerContext{
-		Event: eventtest.WithEnvelope((eventtest.Projection("", events.EventType("custom.trigger"), "", "", []byte(`{"entity_id":"payload-ent"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())), events.EventEnvelope{EntityID: "env-ent"}),
+		Event: eventtest.RootIngress(
+			"",
+			events.EventType("custom.trigger"),
+			"",
+			"",
+			[]byte(`{"entity_id":"payload-ent"}`),
+			0,
+			"",
+			"",
+			events.EventEnvelope{EntityID: "env-ent"},
+			time.Now().UTC(),
+		),
 		State: WorkflowState{Stage: WorkflowStateID("queued"), Metadata: map[string]any{}},
 	}, false)
 	if err != nil {
@@ -284,7 +295,7 @@ node-a:
 		},
 		Emit: runtimecontracts.EmitSpec{Event: "custom.emitted"},
 	}, workflowTriggerContext{
-		Event: eventtest.Projection("", events.EventType("custom.trigger"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}),
+		Event: eventtest.RootIngress("", events.EventType("custom.trigger"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}),
 		State: WorkflowState{Stage: WorkflowStateID(""), Metadata: map[string]any{}},
 	}, false)
 	if err != nil {
@@ -328,8 +339,18 @@ func TestExecuteNodeContractHandlerRejectsEmitWhenPersistencePrerequisiteFieldIs
 		Emit:       runtimecontracts.EmitSpec{Event: "spec.requested"},
 		AdvancesTo: "mvp_speccing",
 	}, workflowTriggerContext{
-		Event: eventtest.WithEntityID(eventtest.Projection("", events.EventType("research.completed"), "", "", mustJSON(map[string]any{}), 0, "", "", events.EventEnvelope{}, time.Time{}),
-			entityID),
+		Event: eventtest.RootIngress(
+			"",
+			events.EventType("research.completed"),
+			"",
+			"",
+			mustJSON(map[string]any{}),
+			0,
+			"",
+			"",
+			events.EnvelopeForEntityID(events.EventEnvelope{}, entityID),
+			time.Time{},
+		),
 
 		State: WorkflowState{
 			EntityID: entityID,
@@ -386,10 +407,20 @@ func TestExecuteNodeContractHandlerPublishesAfterPersistencePrerequisiteFieldSuc
 		Emit:       runtimecontracts.EmitSpec{Event: "spec.requested"},
 		AdvancesTo: "mvp_speccing",
 	}, workflowTriggerContext{
-		Event: eventtest.WithEntityID(eventtest.Projection("", events.EventType("research.completed"), "", "", mustJSON(map[string]any{
-			"business_brief": map[string]any{"summary": "validated"},
-		}), 0, "", "", events.EventEnvelope{}, time.Time{}),
-			entityID),
+		Event: eventtest.RootIngress(
+			"",
+			events.EventType("research.completed"),
+			"",
+			"",
+			mustJSON(map[string]any{
+				"business_brief": map[string]any{"summary": "validated"},
+			}),
+			0,
+			"",
+			"",
+			events.EnvelopeForEntityID(events.EventEnvelope{}, entityID),
+			time.Time{},
+		),
 
 		State: WorkflowState{
 			EntityID: entityID,
@@ -464,8 +495,18 @@ func TestExecuteNodeContractHandlerLogsAccumulatorCompletionCommittedOutcome(t *
 			payload["business_brief"] = map[string]any{"summary": "validated"}
 		}
 		result, err := pc.executeNodeContractHandler(testPipelineCoordinatorRunContext(t, pc), "node-a", handler, workflowTriggerContext{
-			Event: eventtest.WithEntityID(eventtest.Projection("", events.EventType("research.completed"), "", "", mustJSON(payload), 0, "", "", events.EventEnvelope{}, time.Time{}),
-				entityID),
+			Event: eventtest.RootIngress(
+				"",
+				events.EventType("research.completed"),
+				"",
+				"",
+				mustJSON(payload),
+				0,
+				"",
+				"",
+				events.EnvelopeForEntityID(events.EventEnvelope{}, entityID),
+				time.Time{},
+			),
 
 			State: pc.currentWorkflowState(testPipelineCoordinatorRunContext(t, pc), entityID),
 		}, false)
@@ -536,8 +577,18 @@ func TestExecuteNodeContractHandlerLogsAccumulatorCompletionEvaluationFailure(t 
 			{ID: "bad", Condition: `entity.branch_target == "go"`, AdvancesTo: "mvp_speccing"},
 		},
 	}, workflowTriggerContext{
-		Event: eventtest.WithEntityID(eventtest.Projection("", events.EventType("research.completed"), "", "", mustJSON(map[string]any{"item_id": 1}), 0, "", "", events.EventEnvelope{}, time.Time{}),
-			entityID),
+		Event: eventtest.RootIngress(
+			"",
+			events.EventType("research.completed"),
+			"",
+			"",
+			mustJSON(map[string]any{"item_id": 1}),
+			0,
+			"",
+			"",
+			events.EnvelopeForEntityID(events.EventEnvelope{}, entityID),
+			time.Time{},
+		),
 
 		State: pc.currentWorkflowState(testPipelineCoordinatorRunContext(t, pc), entityID),
 	}, false)
@@ -600,8 +651,18 @@ func TestExecuteNodeContractHandlerLogsAccumulatorCompletionCommitFailure(t *tes
 			{ID: "complete", Condition: "true", AdvancesTo: "mvp_speccing", Emit: runtimecontracts.EmitSpec{Event: "spec.requested"}},
 		},
 	}, workflowTriggerContext{
-		Event: eventtest.WithEntityID(eventtest.Projection("", events.EventType("research.completed"), "", "", mustJSON(map[string]any{"item_id": 1}), 0, "", "", events.EventEnvelope{}, time.Time{}),
-			entityID),
+		Event: eventtest.RootIngress(
+			"",
+			events.EventType("research.completed"),
+			"",
+			"",
+			mustJSON(map[string]any{"item_id": 1}),
+			0,
+			"",
+			"",
+			events.EnvelopeForEntityID(events.EventEnvelope{}, entityID),
+			time.Time{},
+		),
 
 		State: pc.currentWorkflowState(testPipelineCoordinatorRunContext(t, pc), entityID),
 	}, false)
@@ -676,7 +737,18 @@ func TestExecuteNodeContractHandlerPersistsArithmeticDataAccumulationExpression(
 			},
 		},
 	}, workflowTriggerContext{
-		Event: eventtest.WithEntityID(eventtest.Projection("", events.EventType("validation.spec_requested"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}), entityID),
+		Event: eventtest.RootIngress(
+			"",
+			events.EventType("validation.spec_requested"),
+			"",
+			"",
+			nil,
+			0,
+			"",
+			"",
+			events.EnvelopeForEntityID(events.EventEnvelope{}, entityID),
+			time.Time{},
+		),
 		State: pc.currentWorkflowState(testPipelineCoordinatorRunContext(t, pc), entityID),
 	}, false)
 	if err != nil {
@@ -745,7 +817,18 @@ func TestExecuteNodeContractHandlerFailsClosedOnDataAccumulationCELRuntimeError(
 			},
 		},
 	}, workflowTriggerContext{
-		Event: eventtest.WithEntityID(eventtest.Projection("", events.EventType("validation.spec_requested"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}), entityID),
+		Event: eventtest.RootIngress(
+			"",
+			events.EventType("validation.spec_requested"),
+			"",
+			"",
+			nil,
+			0,
+			"",
+			"",
+			events.EnvelopeForEntityID(events.EventEnvelope{}, entityID),
+			time.Time{},
+		),
 		State: pc.currentWorkflowState(testPipelineCoordinatorRunContext(t, pc), entityID),
 	}, false)
 	if err == nil {
@@ -809,7 +892,18 @@ func TestExecuteNodeContractHandlerPersistsNullPresenceCheckDataAccumulationExpr
 			},
 		},
 	}, workflowTriggerContext{
-		Event: eventtest.WithEntityID(eventtest.Projection("", events.EventType("validation.spec_requested"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}), entityID),
+		Event: eventtest.RootIngress(
+			"",
+			events.EventType("validation.spec_requested"),
+			"",
+			"",
+			nil,
+			0,
+			"",
+			"",
+			events.EnvelopeForEntityID(events.EventEnvelope{}, entityID),
+			time.Time{},
+		),
 		State: pc.currentWorkflowState(testPipelineCoordinatorRunContext(t, pc), entityID),
 	}, false)
 	if err != nil {
@@ -853,8 +947,18 @@ func TestResolveHandlerEntityIDForFlowKeepsSameFlowEntity(t *testing.T) {
 	const entityID = "ent-1"
 	state := WorkflowState{EntityID: entityID}
 
-	gotID, gotEvt := resolveHandlerEntityIDForFlow(source, "scoring", handler, entityID, eventtest.WithEntityID(eventtest.Projection("", events.EventType("vertical.discovered"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}),
-		entityID),
+	gotID, gotEvt := resolveHandlerEntityIDForFlow(source, "scoring", handler, entityID, eventtest.RootIngress(
+		"",
+		events.EventType("vertical.discovered"),
+		"",
+		"",
+		nil,
+		0,
+		"",
+		"",
+		events.EnvelopeForEntityID(events.EventEnvelope{}, entityID),
+		time.Time{},
+	),
 		&state)
 
 	if gotID != entityID {
@@ -992,8 +1096,18 @@ func TestResolveHandlerEntityIDForFlowPreservesCrossFlowEntityWithoutCreateEntit
 	const incomingEntityID = "ent-discovery"
 	state := WorkflowState{EntityID: incomingEntityID}
 
-	gotID, gotEvt := resolveHandlerEntityIDForFlow(source, "scoring", handler, incomingEntityID, eventtest.WithEnvelope(eventtest.Projection("", events.EventType("vertical.discovered"), "", "", mustJSON(map[string]any{"entity_id": incomingEntityID}), 0, "", "", events.EventEnvelope{}, time.Time{}),
-		events.EventEnvelope{EntityID: incomingEntityID}),
+	gotID, gotEvt := resolveHandlerEntityIDForFlow(source, "scoring", handler, incomingEntityID, eventtest.RootIngress(
+		"",
+		events.EventType("vertical.discovered"),
+		"",
+		"",
+		mustJSON(map[string]any{"entity_id": incomingEntityID}),
+		0,
+		"",
+		"",
+		events.EventEnvelope{EntityID: incomingEntityID},
+		time.Time{},
+	),
 		&state)
 
 	if gotID != incomingEntityID {
@@ -1017,8 +1131,18 @@ func TestResolveHandlerEntityIDForRootKeepsFlowScopedInboundEntity(t *testing.T)
 		Metadata: map[string]any{},
 	}
 
-	gotID, gotEvt := resolveHandlerEntityIDForFlow(nil, "", handler, inboundEntityID, eventtest.WithEntityID(eventtest.Projection("", events.EventType("child/grandchild/task.done"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}),
-		inboundEntityID),
+	gotID, gotEvt := resolveHandlerEntityIDForFlow(nil, "", handler, inboundEntityID, eventtest.RootIngress(
+		"",
+		events.EventType("child/grandchild/task.done"),
+		"",
+		"",
+		nil,
+		0,
+		"",
+		"",
+		events.EnvelopeForEntityID(events.EventEnvelope{}, inboundEntityID),
+		time.Time{},
+	),
 		&state)
 
 	if gotID != inboundEntityID {
@@ -1046,8 +1170,18 @@ func TestResolveHandlerEntityIDForFlowKeepsInboundEntityForDescendantScopedInbou
 		},
 	}
 
-	gotID, gotEvt := resolveHandlerEntityIDForFlow(nil, "child", handler, inboundEntityID, eventtest.WithEntityID(eventtest.Projection("", events.EventType("child/grandchild/micro.done"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}),
-		inboundEntityID),
+	gotID, gotEvt := resolveHandlerEntityIDForFlow(nil, "child", handler, inboundEntityID, eventtest.RootIngress(
+		"",
+		events.EventType("child/grandchild/micro.done"),
+		"",
+		"",
+		nil,
+		0,
+		"",
+		"",
+		events.EnvelopeForEntityID(events.EventEnvelope{}, inboundEntityID),
+		time.Time{},
+	),
 		&state)
 
 	if gotID != inboundEntityID {
@@ -1077,8 +1211,18 @@ func TestResolveHandlerEntityIDForFlowDoesNotRetargetSameFlowInstancePath(t *tes
 		},
 	}
 
-	gotID, gotEvt := resolveHandlerEntityIDForFlow(nil, "child", handler, entityID, eventtest.WithEntityID(eventtest.Projection("", events.EventType("child/grandchild/micro.done"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}),
-		entityID),
+	gotID, gotEvt := resolveHandlerEntityIDForFlow(nil, "child", handler, entityID, eventtest.RootIngress(
+		"",
+		events.EventType("child/grandchild/micro.done"),
+		"",
+		"",
+		nil,
+		0,
+		"",
+		"",
+		events.EnvelopeForEntityID(events.EventEnvelope{}, entityID),
+		time.Time{},
+	),
 		&state)
 
 	if gotID != entityID {
@@ -1128,8 +1272,18 @@ vertical:
 		Status:   "active",
 		Metadata: map[string]any{"name": "Parent"},
 	}
-	inbound := eventtest.WithEnvelope(eventtest.Projection("", events.EventType("vertical.discovered"), "", "", mustJSON(map[string]any{"entity_id": inboundEntityID, "name": "Parent"}), 0, "", "", events.EventEnvelope{}, time.Time{}),
-		events.EventEnvelope{EntityID: inboundEntityID})
+	inbound := eventtest.RootIngress(
+		"",
+		events.EventType("vertical.discovered"),
+		"",
+		"",
+		mustJSON(map[string]any{"entity_id": inboundEntityID, "name": "Parent"}),
+		0,
+		"",
+		"",
+		events.EventEnvelope{EntityID: inboundEntityID},
+		time.Time{},
+	)
 
 	gotID, gotEvt := resolveHandlerEntityIDForFlow(source, "scoring", handler, inboundEntityID, inbound, &state)
 
@@ -1225,7 +1379,7 @@ func TestExecuteNodeContractHandlerRejectsMalformedPersistedGateShape(t *testing
 	}
 
 	_, err := pc.executeNodeContractHandler(testPipelineCoordinatorRunContext(t, pc), "node-a", runtimecontracts.SystemNodeEventHandler{}, workflowTriggerContext{
-		Event: eventtest.WithEntityID(eventtest.Projection("", events.EventType("custom.trigger"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}), "ent-1"),
+		Event: eventtest.RootIngress("", events.EventType("custom.trigger"), "", "", nil, 0, "", "", events.EnvelopeForEntityID(events.EventEnvelope{}, "ent-1"), time.Time{}),
 		State: WorkflowState{
 			Stage:    WorkflowStateID("queued"),
 			Metadata: map[string]any{"gates": "invalid"},
@@ -1243,7 +1397,7 @@ func TestResolveHandlerEntityIDForFlowCreateEntityDoesNotSeedSubjectID(t *testin
 	handler := runtimecontracts.SystemNodeEventHandler{CreateEntity: true}
 	state := WorkflowState{}
 
-	gotID, _ := resolveHandlerEntityIDForFlow(nil, "scoring", handler, "", eventtest.Projection("", events.EventType("vertical.discovered"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}), &state)
+	gotID, _ := resolveHandlerEntityIDForFlow(nil, "scoring", handler, "", eventtest.RootIngress("", events.EventType("vertical.discovered"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}), &state)
 
 	if gotID == "" {
 		t.Fatal("expected fresh entity id")
@@ -1319,7 +1473,7 @@ node-a:
 			},
 		},
 	}, workflowTriggerContext{
-		Event: eventtest.Projection("", events.EventType("candidate.discovered"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}),
+		Event: eventtest.RootIngress("", events.EventType("candidate.discovered"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}),
 		State: WorkflowState{},
 	}, false)
 	if err != nil {
@@ -1461,9 +1615,18 @@ node-a:
 	}
 	runHandler := func(entityID, requestID string) error {
 		_, err := pc.executeNodeContractHandler(ctx, "node-a", handler, workflowTriggerContext{
-			Event: eventtest.WithEntityID(eventtest.Projection("evt-"+requestID,
-				events.EventType("request.received"), "", "", mustJSON(map[string]any{"request_id": requestID}), 0, testPipelineRunID, "", events.EventEnvelope{}, time.Time{}),
-				entityID),
+			Event: eventtest.RootIngress(
+				"evt-"+requestID,
+				events.EventType("request.received"),
+				"",
+				"",
+				mustJSON(map[string]any{"request_id": requestID}),
+				0,
+				testPipelineRunID,
+				"",
+				events.EnvelopeForEntityID(events.EventEnvelope{}, entityID),
+				time.Time{},
+			),
 
 			State: WorkflowState{EntityID: entityID, Stage: WorkflowStateID("queued"), Metadata: map[string]any{}},
 		}, false)
@@ -1566,7 +1729,7 @@ node-a:
 			},
 		},
 	}, workflowTriggerContext{
-		Event: eventtest.Projection("", events.EventType("candidate.ready"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}),
+		Event: eventtest.RootIngress("", events.EventType("candidate.ready"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}),
 		State: WorkflowState{},
 	}, false)
 	if err != nil {
@@ -1688,7 +1851,7 @@ node-a:
 		Clear:        &runtimecontracts.ClearSpec{Target: "entity.revision_count"},
 		Emit:         runtimecontracts.EmitSpec{Event: "entity.created"},
 	}, workflowTriggerContext{
-		Event: eventtest.Projection("", events.EventType("candidate.discovered"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}),
+		Event: eventtest.RootIngress("", events.EventType("candidate.discovered"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}),
 		State: WorkflowState{},
 	}, false)
 	if err != nil {
@@ -1789,7 +1952,7 @@ node-a:
 		t.Fatal("expected temp workflow bundle")
 	}
 
-	preview, err := PreviewContractHandlerExecution(context.Background(), bundle, "node-a", eventtest.Projection("", events.EventType("candidate.discovered"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}), WorkflowState{}, nil)
+	preview, err := PreviewContractHandlerExecution(context.Background(), bundle, "node-a", eventtest.RootIngress("", events.EventType("candidate.discovered"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}), WorkflowState{}, nil)
 	if err != nil {
 		t.Fatalf("PreviewContractHandlerExecution: %v", err)
 	}
@@ -1846,7 +2009,7 @@ func TestExecuteNodeContractHandlerReturnsTerminalRejectForTerminalEntity(t *tes
 	}
 
 	result, err := pc.executeNodeContractHandler(testPipelineCoordinatorRunContext(t, pc), "node-a", runtimecontracts.SystemNodeEventHandler{}, workflowTriggerContext{
-		Event: eventtest.WithEntityID(eventtest.Projection("", events.EventType("custom.trigger"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}), "ent-1"),
+		Event: eventtest.RootIngress("", events.EventType("custom.trigger"), "", "", nil, 0, "", "", events.EnvelopeForEntityID(events.EventEnvelope{}, "ent-1"), time.Time{}),
 		State: WorkflowState{Stage: WorkflowStateID("done"), Metadata: map[string]any{}},
 	}, false)
 	if err != nil {
@@ -1879,8 +2042,18 @@ func TestExecuteNodeContractHandlerAppliesEmitFieldsToEmittedEvent(t *testing.T)
 			},
 		},
 	}, workflowTriggerContext{
-		Event: eventtest.WithEntityID(eventtest.Projection("", events.EventType("custom.trigger"), "", "", mustJSON(map[string]any{"entity_id": "ent-1"}), 0, "", "", events.EventEnvelope{}, time.Time{}),
-			"ent-1"),
+		Event: eventtest.RootIngress(
+			"",
+			events.EventType("custom.trigger"),
+			"",
+			"",
+			mustJSON(map[string]any{"entity_id": "ent-1"}),
+			0,
+			"",
+			"",
+			events.EnvelopeForEntityID(events.EventEnvelope{}, "ent-1"),
+			time.Time{},
+		),
 
 		State: WorkflowState{Stage: WorkflowStateID("queued"), Metadata: map[string]any{"stage": "queued"}},
 	}, false)
@@ -1929,8 +2102,18 @@ func TestExecuteNodeContractHandlerAppliesEmitFieldsSparseFieldPresenceCheck(t *
 			},
 		},
 	}, workflowTriggerContext{
-		Event: eventtest.WithEntityID(eventtest.Projection("", events.EventType("custom.trigger"), "", "", mustJSON(map[string]any{"entity_id": "ent-1"}), 0, "", "", events.EventEnvelope{}, time.Time{}),
-			"ent-1"),
+		Event: eventtest.RootIngress(
+			"",
+			events.EventType("custom.trigger"),
+			"",
+			"",
+			mustJSON(map[string]any{"entity_id": "ent-1"}),
+			0,
+			"",
+			"",
+			events.EnvelopeForEntityID(events.EventEnvelope{}, "ent-1"),
+			time.Time{},
+		),
 
 		State: WorkflowState{Stage: WorkflowStateID("queued"), Metadata: map[string]any{}},
 	}, false)
@@ -2001,7 +2184,7 @@ node-a:
 			},
 		},
 	}, workflowTriggerContext{
-		Event: eventtest.Projection("", events.EventType("custom.trigger"), "", "", mustJSON(map[string]any{"reason": "active"}), 0, "", "", events.EventEnvelope{}, time.Time{}),
+		Event: eventtest.RootIngress("", events.EventType("custom.trigger"), "", "", mustJSON(map[string]any{"reason": "active"}), 0, "", "", events.EventEnvelope{}, time.Time{}),
 
 		State: WorkflowState{Stage: WorkflowStateID("queued"), Metadata: map[string]any{}},
 	}, false)
@@ -2081,13 +2264,33 @@ func TestExecuteNodeHandlerPlanResult_NestedDescendantCompletionDoesNotBackPropa
 	}); err != nil {
 		t.Fatalf("seed grandchild instance: %v", err)
 	}
-	if consume, handled := pc.workflowNodeInterceptPolicy("child/grandchild/micro.done", eventtest.WithEntityID((eventtest.Projection("", events.EventType("child/grandchild/micro.done"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{})), grandchildEntityID)); !handled {
+	if consume, handled := pc.workflowNodeInterceptPolicy("child/grandchild/micro.done", eventtest.RootIngress(
+		"",
+		events.EventType("child/grandchild/micro.done"),
+		"",
+		"",
+		nil,
+		0,
+		"",
+		"",
+		events.EnvelopeForEntityID(events.EventEnvelope{}, grandchildEntityID),
+		time.Time{},
+	)); !handled {
 		t.Fatalf("workflowNodeInterceptPolicy handled = %v, consume = %v, want handled", handled, consume)
 	}
 
-	evt := eventtest.WithEntityID(eventtest.Projection(uuid.NewString(),
-		events.EventType("child/grandchild/micro.done"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}),
-		grandchildEntityID)
+	evt := eventtest.RootIngress(
+		uuid.NewString(),
+		events.EventType("child/grandchild/micro.done"),
+		"",
+		"",
+		nil,
+		0,
+		"",
+		"",
+		events.EnvelopeForEntityID(events.EventEnvelope{}, grandchildEntityID),
+		time.Time{},
+	)
 
 	seedPipelineNodeDeliveryAuthority(t, db, evt, "root-collector")
 	handled, err := pc.dispatchWorkflowNodeEventResult(testWorkflowStoreRunContext(t, store), evt)
@@ -2126,8 +2329,18 @@ func TestExecuteNodeContractHandlerRejectsAmbiguousHandlerTopLevelEmitWithRules(
 			{ID: "pick-rule", Condition: "true", Emit: runtimecontracts.EmitSpec{Event: "rule.emitted"}},
 		},
 	}, workflowTriggerContext{
-		Event: eventtest.WithEntityID(eventtest.Projection("", events.EventType("custom.trigger"), "", "", mustJSON(map[string]any{"entity_id": "ent-1"}), 0, "", "", events.EventEnvelope{}, time.Time{}),
-			"ent-1"),
+		Event: eventtest.RootIngress(
+			"",
+			events.EventType("custom.trigger"),
+			"",
+			"",
+			mustJSON(map[string]any{"entity_id": "ent-1"}),
+			0,
+			"",
+			"",
+			events.EnvelopeForEntityID(events.EventEnvelope{}, "ent-1"),
+			time.Time{},
+		),
 
 		State: WorkflowState{Stage: WorkflowStateID("queued"), Metadata: map[string]any{}},
 	}, false)
@@ -2153,8 +2366,18 @@ func TestExecuteNodeContractHandlerRejectsAmbiguousHandlerTopLevelEmitWithRulesW
 			{ID: "pick-rule", Condition: "true", AdvancesTo: "done"},
 		},
 	}, workflowTriggerContext{
-		Event: eventtest.WithEntityID(eventtest.Projection("", events.EventType("custom.trigger"), "", "", mustJSON(map[string]any{"entity_id": "ent-1"}), 0, "", "", events.EventEnvelope{}, time.Time{}),
-			"ent-1"),
+		Event: eventtest.RootIngress(
+			"",
+			events.EventType("custom.trigger"),
+			"",
+			"",
+			mustJSON(map[string]any{"entity_id": "ent-1"}),
+			0,
+			"",
+			"",
+			events.EnvelopeForEntityID(events.EventEnvelope{}, "ent-1"),
+			time.Time{},
+		),
 
 		State: WorkflowState{Stage: WorkflowStateID("queued"), Metadata: map[string]any{}},
 	}, false)
@@ -2184,8 +2407,7 @@ func TestExecuteNodeContractHandlerOnCompleteDoesNotSeeCurrentHandlerTopLevelWri
 			{ID: "too-early", Condition: `"branch_target" in entity && entity.branch_target == "handler"`, Emit: runtimecontracts.EmitSpec{Event: "branch.selected"}},
 		},
 	}, workflowTriggerContext{
-		Event: eventtest.WithEntityID(eventtest.Projection("", events.EventType("custom.trigger"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}),
-			"ent-1"),
+		Event: eventtest.RootIngress("", events.EventType("custom.trigger"), "", "", nil, 0, "", "", events.EnvelopeForEntityID(events.EventEnvelope{}, "ent-1"), time.Time{}),
 
 		State: WorkflowState{EntityID: "ent-1", Stage: WorkflowStateID("queued"), Metadata: map[string]any{}},
 	}, false)
@@ -2207,7 +2429,7 @@ func TestExecuteNodeContractHandlerExecutesEmitInsideEngine(t *testing.T) {
 	result, err := pc.executeNodeContractHandler(testPipelineCoordinatorRunContext(t, pc), "node-a", runtimecontracts.SystemNodeEventHandler{
 		Emit: runtimecontracts.EmitSpec{Event: "custom.emitted"},
 	}, workflowTriggerContext{
-		Event: eventtest.WithEntityID(eventtest.Projection("", events.EventType("custom.trigger"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}), entityID),
+		Event: eventtest.RootIngress("", events.EventType("custom.trigger"), "", "", nil, 0, "", "", events.EnvelopeForEntityID(events.EventEnvelope{}, entityID), time.Time{}),
 		State: WorkflowState{Stage: WorkflowStateID("queued"), Metadata: map[string]any{}},
 	}, false)
 	if err != nil {
@@ -2272,8 +2494,18 @@ func TestExecuteNodeContractHandler_UsesEmitFieldsAsOnlyBusinessPayloadSource(t 
 			},
 		},
 	}, workflowTriggerContext{
-		Event: eventtest.WithEntityID(eventtest.Projection("", events.EventType("custom.trigger"), "", "", mustJSON(map[string]any{"entity_id": "ent-1", "legacy": "should-not-pass"}), 0, "", "", events.EventEnvelope{}, time.Time{}),
-			"ent-1"),
+		Event: eventtest.RootIngress(
+			"",
+			events.EventType("custom.trigger"),
+			"",
+			"",
+			mustJSON(map[string]any{"entity_id": "ent-1", "legacy": "should-not-pass"}),
+			0,
+			"",
+			"",
+			events.EnvelopeForEntityID(events.EventEnvelope{}, "ent-1"),
+			time.Time{},
+		),
 
 		State: WorkflowState{EntityID: "ent-1", Stage: WorkflowStateID("queued"), Metadata: map[string]any{"legacy_entity": "should-not-pass"}},
 	}, false)
@@ -2324,8 +2556,18 @@ func TestExecuteNodeContractHandler_GuardEscalateUsesOnlyRuntimeOwnedEnvelope(t 
 			OnFail: "escalate:guard.failed",
 		},
 	}, workflowTriggerContext{
-		Event: eventtest.WithEntityID(eventtest.Projection("", events.EventType("custom.trigger"), "", "", mustJSON(map[string]any{"entity_id": "ent-1", "score": 50, "legacy": "should-not-pass"}), 0, "", "", events.EventEnvelope{}, time.Time{}),
-			"ent-1"),
+		Event: eventtest.RootIngress(
+			"",
+			events.EventType("custom.trigger"),
+			"",
+			"",
+			mustJSON(map[string]any{"entity_id": "ent-1", "score": 50, "legacy": "should-not-pass"}),
+			0,
+			"",
+			"",
+			events.EnvelopeForEntityID(events.EventEnvelope{}, "ent-1"),
+			time.Time{},
+		),
 
 		State: WorkflowState{EntityID: "ent-1", Stage: WorkflowStateID("queued"), Metadata: map[string]any{"legacy_entity": "should-not-pass"}},
 	}, false)
@@ -2371,7 +2613,7 @@ func TestExecuteNodeContractHandler_RejectsUndeclaredBusinessPayloadAcrossSuppor
 	}{
 		{
 			name:  "handler top level",
-			event: eventtest.WithEntityID(eventtest.Projection("", events.EventType("custom.trigger"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}), "ent-1"),
+			event: eventtest.RootIngress("", events.EventType("custom.trigger"), "", "", nil, 0, "", "", events.EnvelopeForEntityID(events.EventEnvelope{}, "ent-1"), time.Time{}),
 			state: WorkflowState{EntityID: "ent-1", Stage: WorkflowStateID("queued"), Metadata: map[string]any{}},
 			handler: runtimecontracts.SystemNodeEventHandler{
 				Emit: runtimecontracts.EmitSpec{
@@ -2385,7 +2627,7 @@ func TestExecuteNodeContractHandler_RejectsUndeclaredBusinessPayloadAcrossSuppor
 		},
 		{
 			name:  "rules",
-			event: eventtest.WithEntityID(eventtest.Projection("", events.EventType("custom.trigger"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}), "ent-1"),
+			event: eventtest.RootIngress("", events.EventType("custom.trigger"), "", "", nil, 0, "", "", events.EnvelopeForEntityID(events.EventEnvelope{}, "ent-1"), time.Time{}),
 			state: WorkflowState{EntityID: "ent-1", Stage: WorkflowStateID("queued"), Metadata: map[string]any{}},
 			handler: runtimecontracts.SystemNodeEventHandler{
 				Rules: []runtimecontracts.HandlerRuleEntry{{
@@ -2403,7 +2645,7 @@ func TestExecuteNodeContractHandler_RejectsUndeclaredBusinessPayloadAcrossSuppor
 		},
 		{
 			name:  "on_complete",
-			event: eventtest.WithEntityID(eventtest.Projection("", events.EventType("custom.trigger"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}), "ent-1"),
+			event: eventtest.RootIngress("", events.EventType("custom.trigger"), "", "", nil, 0, "", "", events.EnvelopeForEntityID(events.EventEnvelope{}, "ent-1"), time.Time{}),
 			state: WorkflowState{EntityID: "ent-1", Stage: WorkflowStateID("queued"), Metadata: map[string]any{}},
 			handler: runtimecontracts.SystemNodeEventHandler{
 				OnComplete: []runtimecontracts.HandlerRuleEntry{{
@@ -2421,16 +2663,26 @@ func TestExecuteNodeContractHandler_RejectsUndeclaredBusinessPayloadAcrossSuppor
 		},
 		{
 			name: "accumulate.on_timeout",
-			event: eventtest.WithEntityID(eventtest.Projection("", events.EventType("accumulate.timeout"), "", "", mustJSON(map[string]any{
-				"timer_handle": map[string]any{
-					"kind": "accumulation_timeout",
-					"bucket": map[string]any{
-						"node_id":    "node-a",
-						"event_type": "item.arrived",
+			event: eventtest.RootIngress(
+				"",
+				events.EventType("accumulate.timeout"),
+				"",
+				"",
+				mustJSON(map[string]any{
+					"timer_handle": map[string]any{
+						"kind": "accumulation_timeout",
+						"bucket": map[string]any{
+							"node_id":    "node-a",
+							"event_type": "item.arrived",
+						},
 					},
-				},
-			}), 0, "", "", events.EventEnvelope{}, time.Time{}),
-				"ent-1"),
+				}),
+				0,
+				"",
+				"",
+				events.EnvelopeForEntityID(events.EventEnvelope{}, "ent-1"),
+				time.Time{},
+			),
 
 			state: WorkflowState{EntityID: "ent-1", Stage: WorkflowStateID("collecting"), Metadata: map[string]any{"expected_count": 2}},
 			handler: runtimecontracts.SystemNodeEventHandler{
@@ -2453,8 +2705,18 @@ func TestExecuteNodeContractHandler_RejectsUndeclaredBusinessPayloadAcrossSuppor
 		},
 		{
 			name: "fan_out",
-			event: eventtest.WithEntityID(eventtest.Projection("", events.EventType("batch.submitted"), "", "", mustJSON(map[string]any{"items": []any{map[string]any{"label": "x"}}}), 0, "", "", events.EventEnvelope{}, time.Time{}),
-				"ent-1"),
+			event: eventtest.RootIngress(
+				"",
+				events.EventType("batch.submitted"),
+				"",
+				"",
+				mustJSON(map[string]any{"items": []any{map[string]any{"label": "x"}}}),
+				0,
+				"",
+				"",
+				events.EnvelopeForEntityID(events.EventEnvelope{}, "ent-1"),
+				time.Time{},
+			),
 
 			state: WorkflowState{EntityID: "ent-1", Stage: WorkflowStateID("queued"), Metadata: map[string]any{}},
 			handler: runtimecontracts.SystemNodeEventHandler{

--- a/internal/runtime/pipeline/handler_engine_transaction_test.go
+++ b/internal/runtime/pipeline/handler_engine_transaction_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/division-sh/swarm/internal/events"
+	"github.com/division-sh/swarm/internal/events/eventtest"
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
 	runtimecorrelation "github.com/division-sh/swarm/internal/runtime/correlation"
 	runtimeengine "github.com/division-sh/swarm/internal/runtime/engine"
@@ -153,7 +154,7 @@ func TestExecuteNodeContractHandlerFlushesCollectedEventsToParentCollector(t *te
 	result, err := pc.executeNodeContractHandler(ctx, "node-a", runtimecontracts.SystemNodeEventHandler{
 		Emit: runtimecontracts.EmitSpec{Event: "custom.emitted"},
 	}, workflowTriggerContext{
-		Event: events.NewProjectionEvent("", events.EventType("custom.trigger"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}).WithEntityID("ent-1"),
+		Event: eventtest.WithEntityID(eventtest.Projection("", events.EventType("custom.trigger"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}), "ent-1"),
 		State: WorkflowState{Stage: WorkflowStateID("queued"), Metadata: map[string]any{}},
 	}, false)
 	if err != nil {
@@ -184,7 +185,7 @@ func TestExecuteNodeContractHandlerPublishesCollectedEventsWithoutParentCollecto
 	result, err := pc.executeNodeContractHandler(testPipelineCoordinatorRunContext(t, pc), "node-a", runtimecontracts.SystemNodeEventHandler{
 		Emit: runtimecontracts.EmitSpec{Event: "custom.emitted"},
 	}, workflowTriggerContext{
-		Event: events.NewProjectionEvent("", events.EventType("custom.trigger"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}).WithEntityID("ent-1"),
+		Event: eventtest.WithEntityID(eventtest.Projection("", events.EventType("custom.trigger"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}), "ent-1"),
 		State: WorkflowState{Stage: WorkflowStateID("queued"), Metadata: map[string]any{}},
 	}, false)
 	if err != nil {
@@ -209,7 +210,7 @@ func TestExecuteNodeContractHandlerUsesTypedEnvelopeIdentityOverPayload(t *testi
 	result, err := pc.executeNodeContractHandler(testPipelineCoordinatorRunContext(t, pc), "node-a", runtimecontracts.SystemNodeEventHandler{
 		Emit: runtimecontracts.EmitSpec{Event: "custom.emitted"},
 	}, workflowTriggerContext{
-		Event: (events.NewProjectionEvent("", events.EventType("custom.trigger"), "", "", []byte(`{"entity_id":"payload-ent"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())).WithEnvelope(events.EventEnvelope{EntityID: "env-ent"}),
+		Event: eventtest.WithEnvelope((eventtest.Projection("", events.EventType("custom.trigger"), "", "", []byte(`{"entity_id":"payload-ent"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())), events.EventEnvelope{EntityID: "env-ent"}),
 		State: WorkflowState{Stage: WorkflowStateID("queued"), Metadata: map[string]any{}},
 	}, false)
 	if err != nil {
@@ -283,7 +284,7 @@ node-a:
 		},
 		Emit: runtimecontracts.EmitSpec{Event: "custom.emitted"},
 	}, workflowTriggerContext{
-		Event: events.NewProjectionEvent("", events.EventType("custom.trigger"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}),
+		Event: eventtest.Projection("", events.EventType("custom.trigger"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}),
 		State: WorkflowState{Stage: WorkflowStateID(""), Metadata: map[string]any{}},
 	}, false)
 	if err != nil {
@@ -327,8 +328,9 @@ func TestExecuteNodeContractHandlerRejectsEmitWhenPersistencePrerequisiteFieldIs
 		Emit:       runtimecontracts.EmitSpec{Event: "spec.requested"},
 		AdvancesTo: "mvp_speccing",
 	}, workflowTriggerContext{
-		Event: events.NewProjectionEvent("", events.EventType("research.completed"), "", "", mustJSON(map[string]any{}), 0, "", "", events.EventEnvelope{}, time.Time{}).
-			WithEntityID(entityID),
+		Event: eventtest.WithEntityID(eventtest.Projection("", events.EventType("research.completed"), "", "", mustJSON(map[string]any{}), 0, "", "", events.EventEnvelope{}, time.Time{}),
+			entityID),
+
 		State: WorkflowState{
 			EntityID: entityID,
 			Stage:    WorkflowStateID("researching"),
@@ -384,10 +386,11 @@ func TestExecuteNodeContractHandlerPublishesAfterPersistencePrerequisiteFieldSuc
 		Emit:       runtimecontracts.EmitSpec{Event: "spec.requested"},
 		AdvancesTo: "mvp_speccing",
 	}, workflowTriggerContext{
-		Event: events.NewProjectionEvent("", events.EventType("research.completed"), "", "", mustJSON(map[string]any{
+		Event: eventtest.WithEntityID(eventtest.Projection("", events.EventType("research.completed"), "", "", mustJSON(map[string]any{
 			"business_brief": map[string]any{"summary": "validated"},
-		}), 0, "", "", events.EventEnvelope{}, time.Time{}).
-			WithEntityID(entityID),
+		}), 0, "", "", events.EventEnvelope{}, time.Time{}),
+			entityID),
+
 		State: WorkflowState{
 			EntityID: entityID,
 			Stage:    WorkflowStateID("researching"),
@@ -461,8 +464,9 @@ func TestExecuteNodeContractHandlerLogsAccumulatorCompletionCommittedOutcome(t *
 			payload["business_brief"] = map[string]any{"summary": "validated"}
 		}
 		result, err := pc.executeNodeContractHandler(testPipelineCoordinatorRunContext(t, pc), "node-a", handler, workflowTriggerContext{
-			Event: events.NewProjectionEvent("", events.EventType("research.completed"), "", "", mustJSON(payload), 0, "", "", events.EventEnvelope{}, time.Time{}).
-				WithEntityID(entityID),
+			Event: eventtest.WithEntityID(eventtest.Projection("", events.EventType("research.completed"), "", "", mustJSON(payload), 0, "", "", events.EventEnvelope{}, time.Time{}),
+				entityID),
+
 			State: pc.currentWorkflowState(testPipelineCoordinatorRunContext(t, pc), entityID),
 		}, false)
 		if err != nil {
@@ -532,8 +536,9 @@ func TestExecuteNodeContractHandlerLogsAccumulatorCompletionEvaluationFailure(t 
 			{ID: "bad", Condition: `entity.branch_target == "go"`, AdvancesTo: "mvp_speccing"},
 		},
 	}, workflowTriggerContext{
-		Event: events.NewProjectionEvent("", events.EventType("research.completed"), "", "", mustJSON(map[string]any{"item_id": 1}), 0, "", "", events.EventEnvelope{}, time.Time{}).
-			WithEntityID(entityID),
+		Event: eventtest.WithEntityID(eventtest.Projection("", events.EventType("research.completed"), "", "", mustJSON(map[string]any{"item_id": 1}), 0, "", "", events.EventEnvelope{}, time.Time{}),
+			entityID),
+
 		State: pc.currentWorkflowState(testPipelineCoordinatorRunContext(t, pc), entityID),
 	}, false)
 	if err == nil {
@@ -595,8 +600,9 @@ func TestExecuteNodeContractHandlerLogsAccumulatorCompletionCommitFailure(t *tes
 			{ID: "complete", Condition: "true", AdvancesTo: "mvp_speccing", Emit: runtimecontracts.EmitSpec{Event: "spec.requested"}},
 		},
 	}, workflowTriggerContext{
-		Event: events.NewProjectionEvent("", events.EventType("research.completed"), "", "", mustJSON(map[string]any{"item_id": 1}), 0, "", "", events.EventEnvelope{}, time.Time{}).
-			WithEntityID(entityID),
+		Event: eventtest.WithEntityID(eventtest.Projection("", events.EventType("research.completed"), "", "", mustJSON(map[string]any{"item_id": 1}), 0, "", "", events.EventEnvelope{}, time.Time{}),
+			entityID),
+
 		State: pc.currentWorkflowState(testPipelineCoordinatorRunContext(t, pc), entityID),
 	}, false)
 	if !errors.Is(err, runtimeengine.ErrEmitPersistencePrerequisite) {
@@ -670,7 +676,7 @@ func TestExecuteNodeContractHandlerPersistsArithmeticDataAccumulationExpression(
 			},
 		},
 	}, workflowTriggerContext{
-		Event: events.NewProjectionEvent("", events.EventType("validation.spec_requested"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}).WithEntityID(entityID),
+		Event: eventtest.WithEntityID(eventtest.Projection("", events.EventType("validation.spec_requested"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}), entityID),
 		State: pc.currentWorkflowState(testPipelineCoordinatorRunContext(t, pc), entityID),
 	}, false)
 	if err != nil {
@@ -739,7 +745,7 @@ func TestExecuteNodeContractHandlerFailsClosedOnDataAccumulationCELRuntimeError(
 			},
 		},
 	}, workflowTriggerContext{
-		Event: events.NewProjectionEvent("", events.EventType("validation.spec_requested"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}).WithEntityID(entityID),
+		Event: eventtest.WithEntityID(eventtest.Projection("", events.EventType("validation.spec_requested"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}), entityID),
 		State: pc.currentWorkflowState(testPipelineCoordinatorRunContext(t, pc), entityID),
 	}, false)
 	if err == nil {
@@ -803,7 +809,7 @@ func TestExecuteNodeContractHandlerPersistsNullPresenceCheckDataAccumulationExpr
 			},
 		},
 	}, workflowTriggerContext{
-		Event: events.NewProjectionEvent("", events.EventType("validation.spec_requested"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}).WithEntityID(entityID),
+		Event: eventtest.WithEntityID(eventtest.Projection("", events.EventType("validation.spec_requested"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}), entityID),
 		State: pc.currentWorkflowState(testPipelineCoordinatorRunContext(t, pc), entityID),
 	}, false)
 	if err != nil {
@@ -847,8 +853,9 @@ func TestResolveHandlerEntityIDForFlowKeepsSameFlowEntity(t *testing.T) {
 	const entityID = "ent-1"
 	state := WorkflowState{EntityID: entityID}
 
-	gotID, gotEvt := resolveHandlerEntityIDForFlow(source, "scoring", handler, entityID, events.NewProjectionEvent("", events.EventType("vertical.discovered"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}).
-		WithEntityID(entityID), &state)
+	gotID, gotEvt := resolveHandlerEntityIDForFlow(source, "scoring", handler, entityID, eventtest.WithEntityID(eventtest.Projection("", events.EventType("vertical.discovered"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}),
+		entityID),
+		&state)
 
 	if gotID != entityID {
 		t.Fatalf("entityID = %q, want %q", gotID, entityID)
@@ -985,8 +992,9 @@ func TestResolveHandlerEntityIDForFlowPreservesCrossFlowEntityWithoutCreateEntit
 	const incomingEntityID = "ent-discovery"
 	state := WorkflowState{EntityID: incomingEntityID}
 
-	gotID, gotEvt := resolveHandlerEntityIDForFlow(source, "scoring", handler, incomingEntityID, events.NewProjectionEvent("", events.EventType("vertical.discovered"), "", "", mustJSON(map[string]any{"entity_id": incomingEntityID}), 0, "", "", events.EventEnvelope{}, time.Time{}).
-		WithEnvelope(events.EventEnvelope{EntityID: incomingEntityID}), &state)
+	gotID, gotEvt := resolveHandlerEntityIDForFlow(source, "scoring", handler, incomingEntityID, eventtest.WithEnvelope(eventtest.Projection("", events.EventType("vertical.discovered"), "", "", mustJSON(map[string]any{"entity_id": incomingEntityID}), 0, "", "", events.EventEnvelope{}, time.Time{}),
+		events.EventEnvelope{EntityID: incomingEntityID}),
+		&state)
 
 	if gotID != incomingEntityID {
 		t.Fatalf("entityID = %q, want preserved %q", gotID, incomingEntityID)
@@ -1009,8 +1017,9 @@ func TestResolveHandlerEntityIDForRootKeepsFlowScopedInboundEntity(t *testing.T)
 		Metadata: map[string]any{},
 	}
 
-	gotID, gotEvt := resolveHandlerEntityIDForFlow(nil, "", handler, inboundEntityID, events.NewProjectionEvent("", events.EventType("child/grandchild/task.done"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}).
-		WithEntityID(inboundEntityID), &state)
+	gotID, gotEvt := resolveHandlerEntityIDForFlow(nil, "", handler, inboundEntityID, eventtest.WithEntityID(eventtest.Projection("", events.EventType("child/grandchild/task.done"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}),
+		inboundEntityID),
+		&state)
 
 	if gotID != inboundEntityID {
 		t.Fatalf("entityID = %q, want inbound %q", gotID, inboundEntityID)
@@ -1037,8 +1046,9 @@ func TestResolveHandlerEntityIDForFlowKeepsInboundEntityForDescendantScopedInbou
 		},
 	}
 
-	gotID, gotEvt := resolveHandlerEntityIDForFlow(nil, "child", handler, inboundEntityID, events.NewProjectionEvent("", events.EventType("child/grandchild/micro.done"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}).
-		WithEntityID(inboundEntityID), &state)
+	gotID, gotEvt := resolveHandlerEntityIDForFlow(nil, "child", handler, inboundEntityID, eventtest.WithEntityID(eventtest.Projection("", events.EventType("child/grandchild/micro.done"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}),
+		inboundEntityID),
+		&state)
 
 	if gotID != inboundEntityID {
 		t.Fatalf("entityID = %q, want inbound %q", gotID, inboundEntityID)
@@ -1067,8 +1077,9 @@ func TestResolveHandlerEntityIDForFlowDoesNotRetargetSameFlowInstancePath(t *tes
 		},
 	}
 
-	gotID, gotEvt := resolveHandlerEntityIDForFlow(nil, "child", handler, entityID, events.NewProjectionEvent("", events.EventType("child/grandchild/micro.done"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}).
-		WithEntityID(entityID), &state)
+	gotID, gotEvt := resolveHandlerEntityIDForFlow(nil, "child", handler, entityID, eventtest.WithEntityID(eventtest.Projection("", events.EventType("child/grandchild/micro.done"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}),
+		entityID),
+		&state)
 
 	if gotID != entityID {
 		t.Fatalf("entityID = %q, want %q", gotID, entityID)
@@ -1117,8 +1128,8 @@ vertical:
 		Status:   "active",
 		Metadata: map[string]any{"name": "Parent"},
 	}
-	inbound := events.NewProjectionEvent("", events.EventType("vertical.discovered"), "", "", mustJSON(map[string]any{"entity_id": inboundEntityID, "name": "Parent"}), 0, "", "", events.EventEnvelope{}, time.Time{}).
-		WithEnvelope(events.EventEnvelope{EntityID: inboundEntityID})
+	inbound := eventtest.WithEnvelope(eventtest.Projection("", events.EventType("vertical.discovered"), "", "", mustJSON(map[string]any{"entity_id": inboundEntityID, "name": "Parent"}), 0, "", "", events.EventEnvelope{}, time.Time{}),
+		events.EventEnvelope{EntityID: inboundEntityID})
 
 	gotID, gotEvt := resolveHandlerEntityIDForFlow(source, "scoring", handler, inboundEntityID, inbound, &state)
 
@@ -1214,7 +1225,7 @@ func TestExecuteNodeContractHandlerRejectsMalformedPersistedGateShape(t *testing
 	}
 
 	_, err := pc.executeNodeContractHandler(testPipelineCoordinatorRunContext(t, pc), "node-a", runtimecontracts.SystemNodeEventHandler{}, workflowTriggerContext{
-		Event: events.NewProjectionEvent("", events.EventType("custom.trigger"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}).WithEntityID("ent-1"),
+		Event: eventtest.WithEntityID(eventtest.Projection("", events.EventType("custom.trigger"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}), "ent-1"),
 		State: WorkflowState{
 			Stage:    WorkflowStateID("queued"),
 			Metadata: map[string]any{"gates": "invalid"},
@@ -1232,7 +1243,7 @@ func TestResolveHandlerEntityIDForFlowCreateEntityDoesNotSeedSubjectID(t *testin
 	handler := runtimecontracts.SystemNodeEventHandler{CreateEntity: true}
 	state := WorkflowState{}
 
-	gotID, _ := resolveHandlerEntityIDForFlow(nil, "scoring", handler, "", events.NewProjectionEvent("", events.EventType("vertical.discovered"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}), &state)
+	gotID, _ := resolveHandlerEntityIDForFlow(nil, "scoring", handler, "", eventtest.Projection("", events.EventType("vertical.discovered"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}), &state)
 
 	if gotID == "" {
 		t.Fatal("expected fresh entity id")
@@ -1308,7 +1319,7 @@ node-a:
 			},
 		},
 	}, workflowTriggerContext{
-		Event: events.NewProjectionEvent("", events.EventType("candidate.discovered"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}),
+		Event: eventtest.Projection("", events.EventType("candidate.discovered"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}),
 		State: WorkflowState{},
 	}, false)
 	if err != nil {
@@ -1450,9 +1461,10 @@ node-a:
 	}
 	runHandler := func(entityID, requestID string) error {
 		_, err := pc.executeNodeContractHandler(ctx, "node-a", handler, workflowTriggerContext{
-			Event: events.NewProjectionEvent("evt-"+requestID,
-				events.EventType("request.received"), "", "", mustJSON(map[string]any{"request_id": requestID}), 0, testPipelineRunID, "", events.EventEnvelope{}, time.Time{}).
-				WithEntityID(entityID),
+			Event: eventtest.WithEntityID(eventtest.Projection("evt-"+requestID,
+				events.EventType("request.received"), "", "", mustJSON(map[string]any{"request_id": requestID}), 0, testPipelineRunID, "", events.EventEnvelope{}, time.Time{}),
+				entityID),
+
 			State: WorkflowState{EntityID: entityID, Stage: WorkflowStateID("queued"), Metadata: map[string]any{}},
 		}, false)
 		return err
@@ -1554,7 +1566,7 @@ node-a:
 			},
 		},
 	}, workflowTriggerContext{
-		Event: events.NewProjectionEvent("", events.EventType("candidate.ready"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}),
+		Event: eventtest.Projection("", events.EventType("candidate.ready"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}),
 		State: WorkflowState{},
 	}, false)
 	if err != nil {
@@ -1676,7 +1688,7 @@ node-a:
 		Clear:        &runtimecontracts.ClearSpec{Target: "entity.revision_count"},
 		Emit:         runtimecontracts.EmitSpec{Event: "entity.created"},
 	}, workflowTriggerContext{
-		Event: events.NewProjectionEvent("", events.EventType("candidate.discovered"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}),
+		Event: eventtest.Projection("", events.EventType("candidate.discovered"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}),
 		State: WorkflowState{},
 	}, false)
 	if err != nil {
@@ -1777,7 +1789,7 @@ node-a:
 		t.Fatal("expected temp workflow bundle")
 	}
 
-	preview, err := PreviewContractHandlerExecution(context.Background(), bundle, "node-a", events.NewProjectionEvent("", events.EventType("candidate.discovered"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}), WorkflowState{}, nil)
+	preview, err := PreviewContractHandlerExecution(context.Background(), bundle, "node-a", eventtest.Projection("", events.EventType("candidate.discovered"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}), WorkflowState{}, nil)
 	if err != nil {
 		t.Fatalf("PreviewContractHandlerExecution: %v", err)
 	}
@@ -1834,7 +1846,7 @@ func TestExecuteNodeContractHandlerReturnsTerminalRejectForTerminalEntity(t *tes
 	}
 
 	result, err := pc.executeNodeContractHandler(testPipelineCoordinatorRunContext(t, pc), "node-a", runtimecontracts.SystemNodeEventHandler{}, workflowTriggerContext{
-		Event: events.NewProjectionEvent("", events.EventType("custom.trigger"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}).WithEntityID("ent-1"),
+		Event: eventtest.WithEntityID(eventtest.Projection("", events.EventType("custom.trigger"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}), "ent-1"),
 		State: WorkflowState{Stage: WorkflowStateID("done"), Metadata: map[string]any{}},
 	}, false)
 	if err != nil {
@@ -1867,8 +1879,9 @@ func TestExecuteNodeContractHandlerAppliesEmitFieldsToEmittedEvent(t *testing.T)
 			},
 		},
 	}, workflowTriggerContext{
-		Event: events.NewProjectionEvent("", events.EventType("custom.trigger"), "", "", mustJSON(map[string]any{"entity_id": "ent-1"}), 0, "", "", events.EventEnvelope{}, time.Time{}).
-			WithEntityID("ent-1"),
+		Event: eventtest.WithEntityID(eventtest.Projection("", events.EventType("custom.trigger"), "", "", mustJSON(map[string]any{"entity_id": "ent-1"}), 0, "", "", events.EventEnvelope{}, time.Time{}),
+			"ent-1"),
+
 		State: WorkflowState{Stage: WorkflowStateID("queued"), Metadata: map[string]any{"stage": "queued"}},
 	}, false)
 	if err != nil {
@@ -1916,8 +1929,9 @@ func TestExecuteNodeContractHandlerAppliesEmitFieldsSparseFieldPresenceCheck(t *
 			},
 		},
 	}, workflowTriggerContext{
-		Event: events.NewProjectionEvent("", events.EventType("custom.trigger"), "", "", mustJSON(map[string]any{"entity_id": "ent-1"}), 0, "", "", events.EventEnvelope{}, time.Time{}).
-			WithEntityID("ent-1"),
+		Event: eventtest.WithEntityID(eventtest.Projection("", events.EventType("custom.trigger"), "", "", mustJSON(map[string]any{"entity_id": "ent-1"}), 0, "", "", events.EventEnvelope{}, time.Time{}),
+			"ent-1"),
+
 		State: WorkflowState{Stage: WorkflowStateID("queued"), Metadata: map[string]any{}},
 	}, false)
 	if err != nil {
@@ -1987,7 +2001,7 @@ node-a:
 			},
 		},
 	}, workflowTriggerContext{
-		Event: events.NewProjectionEvent("", events.EventType("custom.trigger"), "", "", mustJSON(map[string]any{"reason": "active"}), 0, "", "", events.EventEnvelope{}, time.Time{}),
+		Event: eventtest.Projection("", events.EventType("custom.trigger"), "", "", mustJSON(map[string]any{"reason": "active"}), 0, "", "", events.EventEnvelope{}, time.Time{}),
 
 		State: WorkflowState{Stage: WorkflowStateID("queued"), Metadata: map[string]any{}},
 	}, false)
@@ -2067,13 +2081,14 @@ func TestExecuteNodeHandlerPlanResult_NestedDescendantCompletionDoesNotBackPropa
 	}); err != nil {
 		t.Fatalf("seed grandchild instance: %v", err)
 	}
-	if consume, handled := pc.workflowNodeInterceptPolicy("child/grandchild/micro.done", (events.NewProjectionEvent("", events.EventType("child/grandchild/micro.done"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{})).WithEntityID(grandchildEntityID)); !handled {
+	if consume, handled := pc.workflowNodeInterceptPolicy("child/grandchild/micro.done", eventtest.WithEntityID((eventtest.Projection("", events.EventType("child/grandchild/micro.done"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{})), grandchildEntityID)); !handled {
 		t.Fatalf("workflowNodeInterceptPolicy handled = %v, consume = %v, want handled", handled, consume)
 	}
 
-	evt := events.NewProjectionEvent(uuid.NewString(),
-		events.EventType("child/grandchild/micro.done"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}).
-		WithEntityID(grandchildEntityID)
+	evt := eventtest.WithEntityID(eventtest.Projection(uuid.NewString(),
+		events.EventType("child/grandchild/micro.done"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}),
+		grandchildEntityID)
+
 	seedPipelineNodeDeliveryAuthority(t, db, evt, "root-collector")
 	handled, err := pc.dispatchWorkflowNodeEventResult(testWorkflowStoreRunContext(t, store), evt)
 	if err != nil {
@@ -2111,8 +2126,9 @@ func TestExecuteNodeContractHandlerRejectsAmbiguousHandlerTopLevelEmitWithRules(
 			{ID: "pick-rule", Condition: "true", Emit: runtimecontracts.EmitSpec{Event: "rule.emitted"}},
 		},
 	}, workflowTriggerContext{
-		Event: events.NewProjectionEvent("", events.EventType("custom.trigger"), "", "", mustJSON(map[string]any{"entity_id": "ent-1"}), 0, "", "", events.EventEnvelope{}, time.Time{}).
-			WithEntityID("ent-1"),
+		Event: eventtest.WithEntityID(eventtest.Projection("", events.EventType("custom.trigger"), "", "", mustJSON(map[string]any{"entity_id": "ent-1"}), 0, "", "", events.EventEnvelope{}, time.Time{}),
+			"ent-1"),
+
 		State: WorkflowState{Stage: WorkflowStateID("queued"), Metadata: map[string]any{}},
 	}, false)
 	if err == nil {
@@ -2137,8 +2153,9 @@ func TestExecuteNodeContractHandlerRejectsAmbiguousHandlerTopLevelEmitWithRulesW
 			{ID: "pick-rule", Condition: "true", AdvancesTo: "done"},
 		},
 	}, workflowTriggerContext{
-		Event: events.NewProjectionEvent("", events.EventType("custom.trigger"), "", "", mustJSON(map[string]any{"entity_id": "ent-1"}), 0, "", "", events.EventEnvelope{}, time.Time{}).
-			WithEntityID("ent-1"),
+		Event: eventtest.WithEntityID(eventtest.Projection("", events.EventType("custom.trigger"), "", "", mustJSON(map[string]any{"entity_id": "ent-1"}), 0, "", "", events.EventEnvelope{}, time.Time{}),
+			"ent-1"),
+
 		State: WorkflowState{Stage: WorkflowStateID("queued"), Metadata: map[string]any{}},
 	}, false)
 	if err == nil {
@@ -2167,8 +2184,9 @@ func TestExecuteNodeContractHandlerOnCompleteDoesNotSeeCurrentHandlerTopLevelWri
 			{ID: "too-early", Condition: `"branch_target" in entity && entity.branch_target == "handler"`, Emit: runtimecontracts.EmitSpec{Event: "branch.selected"}},
 		},
 	}, workflowTriggerContext{
-		Event: events.NewProjectionEvent("", events.EventType("custom.trigger"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}).
-			WithEntityID("ent-1"),
+		Event: eventtest.WithEntityID(eventtest.Projection("", events.EventType("custom.trigger"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}),
+			"ent-1"),
+
 		State: WorkflowState{EntityID: "ent-1", Stage: WorkflowStateID("queued"), Metadata: map[string]any{}},
 	}, false)
 	if err == nil {
@@ -2189,7 +2207,7 @@ func TestExecuteNodeContractHandlerExecutesEmitInsideEngine(t *testing.T) {
 	result, err := pc.executeNodeContractHandler(testPipelineCoordinatorRunContext(t, pc), "node-a", runtimecontracts.SystemNodeEventHandler{
 		Emit: runtimecontracts.EmitSpec{Event: "custom.emitted"},
 	}, workflowTriggerContext{
-		Event: events.NewProjectionEvent("", events.EventType("custom.trigger"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}).WithEntityID(entityID),
+		Event: eventtest.WithEntityID(eventtest.Projection("", events.EventType("custom.trigger"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}), entityID),
 		State: WorkflowState{Stage: WorkflowStateID("queued"), Metadata: map[string]any{}},
 	}, false)
 	if err != nil {
@@ -2254,8 +2272,9 @@ func TestExecuteNodeContractHandler_UsesEmitFieldsAsOnlyBusinessPayloadSource(t 
 			},
 		},
 	}, workflowTriggerContext{
-		Event: events.NewProjectionEvent("", events.EventType("custom.trigger"), "", "", mustJSON(map[string]any{"entity_id": "ent-1", "legacy": "should-not-pass"}), 0, "", "", events.EventEnvelope{}, time.Time{}).
-			WithEntityID("ent-1"),
+		Event: eventtest.WithEntityID(eventtest.Projection("", events.EventType("custom.trigger"), "", "", mustJSON(map[string]any{"entity_id": "ent-1", "legacy": "should-not-pass"}), 0, "", "", events.EventEnvelope{}, time.Time{}),
+			"ent-1"),
+
 		State: WorkflowState{EntityID: "ent-1", Stage: WorkflowStateID("queued"), Metadata: map[string]any{"legacy_entity": "should-not-pass"}},
 	}, false)
 	if err != nil {
@@ -2305,8 +2324,9 @@ func TestExecuteNodeContractHandler_GuardEscalateUsesOnlyRuntimeOwnedEnvelope(t 
 			OnFail: "escalate:guard.failed",
 		},
 	}, workflowTriggerContext{
-		Event: events.NewProjectionEvent("", events.EventType("custom.trigger"), "", "", mustJSON(map[string]any{"entity_id": "ent-1", "score": 50, "legacy": "should-not-pass"}), 0, "", "", events.EventEnvelope{}, time.Time{}).
-			WithEntityID("ent-1"),
+		Event: eventtest.WithEntityID(eventtest.Projection("", events.EventType("custom.trigger"), "", "", mustJSON(map[string]any{"entity_id": "ent-1", "score": 50, "legacy": "should-not-pass"}), 0, "", "", events.EventEnvelope{}, time.Time{}),
+			"ent-1"),
+
 		State: WorkflowState{EntityID: "ent-1", Stage: WorkflowStateID("queued"), Metadata: map[string]any{"legacy_entity": "should-not-pass"}},
 	}, false)
 	if err != nil {
@@ -2351,7 +2371,7 @@ func TestExecuteNodeContractHandler_RejectsUndeclaredBusinessPayloadAcrossSuppor
 	}{
 		{
 			name:  "handler top level",
-			event: events.NewProjectionEvent("", events.EventType("custom.trigger"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}).WithEntityID("ent-1"),
+			event: eventtest.WithEntityID(eventtest.Projection("", events.EventType("custom.trigger"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}), "ent-1"),
 			state: WorkflowState{EntityID: "ent-1", Stage: WorkflowStateID("queued"), Metadata: map[string]any{}},
 			handler: runtimecontracts.SystemNodeEventHandler{
 				Emit: runtimecontracts.EmitSpec{
@@ -2365,7 +2385,7 @@ func TestExecuteNodeContractHandler_RejectsUndeclaredBusinessPayloadAcrossSuppor
 		},
 		{
 			name:  "rules",
-			event: events.NewProjectionEvent("", events.EventType("custom.trigger"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}).WithEntityID("ent-1"),
+			event: eventtest.WithEntityID(eventtest.Projection("", events.EventType("custom.trigger"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}), "ent-1"),
 			state: WorkflowState{EntityID: "ent-1", Stage: WorkflowStateID("queued"), Metadata: map[string]any{}},
 			handler: runtimecontracts.SystemNodeEventHandler{
 				Rules: []runtimecontracts.HandlerRuleEntry{{
@@ -2383,7 +2403,7 @@ func TestExecuteNodeContractHandler_RejectsUndeclaredBusinessPayloadAcrossSuppor
 		},
 		{
 			name:  "on_complete",
-			event: events.NewProjectionEvent("", events.EventType("custom.trigger"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}).WithEntityID("ent-1"),
+			event: eventtest.WithEntityID(eventtest.Projection("", events.EventType("custom.trigger"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}), "ent-1"),
 			state: WorkflowState{EntityID: "ent-1", Stage: WorkflowStateID("queued"), Metadata: map[string]any{}},
 			handler: runtimecontracts.SystemNodeEventHandler{
 				OnComplete: []runtimecontracts.HandlerRuleEntry{{
@@ -2401,7 +2421,7 @@ func TestExecuteNodeContractHandler_RejectsUndeclaredBusinessPayloadAcrossSuppor
 		},
 		{
 			name: "accumulate.on_timeout",
-			event: events.NewProjectionEvent("", events.EventType("accumulate.timeout"), "", "", mustJSON(map[string]any{
+			event: eventtest.WithEntityID(eventtest.Projection("", events.EventType("accumulate.timeout"), "", "", mustJSON(map[string]any{
 				"timer_handle": map[string]any{
 					"kind": "accumulation_timeout",
 					"bucket": map[string]any{
@@ -2409,8 +2429,9 @@ func TestExecuteNodeContractHandler_RejectsUndeclaredBusinessPayloadAcrossSuppor
 						"event_type": "item.arrived",
 					},
 				},
-			}), 0, "", "", events.EventEnvelope{}, time.Time{}).
-				WithEntityID("ent-1"),
+			}), 0, "", "", events.EventEnvelope{}, time.Time{}),
+				"ent-1"),
+
 			state: WorkflowState{EntityID: "ent-1", Stage: WorkflowStateID("collecting"), Metadata: map[string]any{"expected_count": 2}},
 			handler: runtimecontracts.SystemNodeEventHandler{
 				Accumulate: &runtimecontracts.AccumulateSpec{
@@ -2432,8 +2453,9 @@ func TestExecuteNodeContractHandler_RejectsUndeclaredBusinessPayloadAcrossSuppor
 		},
 		{
 			name: "fan_out",
-			event: events.NewProjectionEvent("", events.EventType("batch.submitted"), "", "", mustJSON(map[string]any{"items": []any{map[string]any{"label": "x"}}}), 0, "", "", events.EventEnvelope{}, time.Time{}).
-				WithEntityID("ent-1"),
+			event: eventtest.WithEntityID(eventtest.Projection("", events.EventType("batch.submitted"), "", "", mustJSON(map[string]any{"items": []any{map[string]any{"label": "x"}}}), 0, "", "", events.EventEnvelope{}, time.Time{}),
+				"ent-1"),
+
 			state: WorkflowState{EntityID: "ent-1", Stage: WorkflowStateID("queued"), Metadata: map[string]any{}},
 			handler: runtimecontracts.SystemNodeEventHandler{
 				FanOut: &runtimecontracts.FanOutSpec{

--- a/internal/runtime/pipeline/node_system_runner_completion_test.go
+++ b/internal/runtime/pipeline/node_system_runner_completion_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/division-sh/swarm/internal/events"
+	"github.com/division-sh/swarm/internal/events/eventtest"
 	runtimelifecycleprobe "github.com/division-sh/swarm/internal/runtime/lifecycleprobe"
 	"github.com/division-sh/swarm/internal/testutil"
 	"github.com/google/uuid"
@@ -64,8 +65,8 @@ func TestSystemNodeRunner_MarkProcessedSettlesNodeDeliveryAndTriggersNormalRunCo
 		return nil
 	}, func(context.Context) (bool, error) { return true, nil })
 
-	runner.ProcessEventForTest(ctx, (events.NewProjectionEvent(eventID,
-		"example.started", "", "", []byte(`{}`), 0, runID, "", events.EventEnvelope{}, time.Now().UTC())).WithEntityID(entityID))
+	runner.ProcessEventForTest(ctx, eventtest.WithEntityID((eventtest.Projection(eventID,
+		"example.started", "", "", []byte(`{}`), 0, runID, "", events.EventEnvelope{}, time.Now().UTC())), entityID))
 
 	if !handlerCalled {
 		t.Fatal("handler was not called")
@@ -133,9 +134,10 @@ func TestSystemNodeRunner_TargetSetSameNodeSettlesEachTargetDelivery(t *testing.
 		return nil
 	}, func(context.Context) (bool, error) { return true, nil })
 
-	base := events.NewProjectionEvent(eventID,
+	base := eventtest.Projection(eventID,
 		"worker/work.assign", "", "", []byte(`{}`), 0, runID, "", events.EventEnvelope{}, time.Now().UTC())
-	runner.ProcessEventForTest(ctx, base.WithTargetRoute(targetOne))
+
+	runner.ProcessEventForTest(ctx, eventtest.WithTargetRoute(base, targetOne))
 	if got := loadSystemNodeCompletionTargetDeliveryStatus(t, db, eventID, "task-handler", targetOne); got != "delivered" {
 		t.Fatalf("target one status = %q, want delivered", got)
 	}
@@ -143,7 +145,7 @@ func TestSystemNodeRunner_TargetSetSameNodeSettlesEachTargetDelivery(t *testing.
 		t.Fatalf("target two status after first delivery = %q, want pending", got)
 	}
 
-	runner.ProcessEventForTest(ctx, base.WithTargetRoute(targetTwo))
+	runner.ProcessEventForTest(ctx, eventtest.WithTargetRoute(base, targetTwo))
 	if got := loadSystemNodeCompletionTargetDeliveryStatus(t, db, eventID, "task-handler", targetTwo); got != "delivered" {
 		t.Fatalf("target two status = %q, want delivered", got)
 	}
@@ -200,9 +202,10 @@ func TestSystemNodeRunner_TargetSetSameNodeFailureKeepsSiblingPending(t *testing
 		return 0
 	})
 
-	base := events.NewProjectionEvent(eventID,
+	base := eventtest.Projection(eventID,
 		"worker/work.assign", "", "", []byte(`{}`), 0, runID, "", events.EventEnvelope{}, time.Now().UTC())
-	runner.ProcessEventForTest(ctx, base.WithTargetRoute(targetOne))
+
+	runner.ProcessEventForTest(ctx, eventtest.WithTargetRoute(base, targetOne))
 
 	if attempts != 2 {
 		t.Fatalf("attempts = %d, want 2", attempts)
@@ -234,9 +237,10 @@ func TestSystemNodeRunner_TargetSetSameNodeDeadLetterKeepsSiblingExecutable(t *t
 	}, func(context.Context) (bool, error) { return true, nil })
 	failingRunner.SetRetryPolicyForTest(1, func(int) time.Duration { return 0 })
 
-	base := events.NewProjectionEvent(eventID,
+	base := eventtest.Projection(eventID,
 		"worker/work.assign", "", "", []byte(`{}`), 0, runID, "", events.EventEnvelope{}, time.Now().UTC())
-	failingRunner.ProcessEventForTest(ctx, base.WithTargetRoute(targetOne))
+
+	failingRunner.ProcessEventForTest(ctx, eventtest.WithTargetRoute(base, targetOne))
 
 	targetOneDelivery := loadSystemNodeCompletionTargetDelivery(t, db, eventID, "task-handler", targetOne)
 	if targetOneDelivery.Status != "dead_letter" || targetOneDelivery.Reason != "retry_exhausted" || targetOneDelivery.RetryCount != 1 || targetOneDelivery.LastError == "" {
@@ -251,7 +255,7 @@ func TestSystemNodeRunner_TargetSetSameNodeDeadLetterKeepsSiblingExecutable(t *t
 	}, func(context.Context, events.Event) error {
 		return nil
 	}, func(context.Context) (bool, error) { return true, nil })
-	successRunner.ProcessEventForTest(ctx, base.WithTargetRoute(targetTwo))
+	successRunner.ProcessEventForTest(ctx, eventtest.WithTargetRoute(base, targetTwo))
 	if got := loadSystemNodeCompletionTargetDeliveryStatus(t, db, eventID, "task-handler", targetTwo); got != "delivered" {
 		t.Fatalf("target two status after target one dead-letter = %q, want delivered", got)
 	}
@@ -364,8 +368,8 @@ func TestSystemNodeRunnerLifecycleProbeEmitsHandlerBoundaries(t *testing.T) {
 	}, func(context.Context) (bool, error) { return true, nil })
 	runner.SetTestLifecycleProbe(probe)
 
-	runner.ProcessEventForTest(ctx, (events.NewProjectionEvent(eventID,
-		"example.started", "", "", []byte(`{}`), 0, runID, "", events.EventEnvelope{}, time.Now().UTC())).WithEntityID(entityID))
+	runner.ProcessEventForTest(ctx, eventtest.WithEntityID((eventtest.Projection(eventID,
+		"example.started", "", "", []byte(`{}`), 0, runID, "", events.EventEnvelope{}, time.Now().UTC())), entityID))
 
 	waitCtx, cancelWait := context.WithTimeout(ctx, time.Second)
 	defer cancelWait()
@@ -450,8 +454,8 @@ func TestSystemNodeRunner_RetryableFailureWritesFailedBeforeRetry(t *testing.T) 
 		return 0
 	})
 
-	runner.ProcessEventForTest(ctx, (events.NewProjectionEvent(eventID,
-		"example.started", "", "", []byte(`{}`), 0, runID, "", events.EventEnvelope{}, time.Now().UTC())).WithEntityID(entityID))
+	runner.ProcessEventForTest(ctx, eventtest.WithEntityID((eventtest.Projection(eventID,
+		"example.started", "", "", []byte(`{}`), 0, runID, "", events.EventEnvelope{}, time.Now().UTC())), entityID))
 
 	if attempts != 2 {
 		t.Fatalf("attempts = %d, want 2", attempts)
@@ -491,8 +495,8 @@ func TestSystemNodeRunner_RetryableFailureExhaustsConfiguredRetryLimit(t *testin
 	}, func(context.Context) (bool, error) { return true, nil })
 	runner.SetRetryPolicyForTest(DefaultSystemNodeRetryLimit, func(int) time.Duration { return 0 })
 
-	runner.ProcessEventForTest(ctx, (events.NewProjectionEvent(eventID,
-		"example.started", "", "", []byte(`{}`), 0, runID, "", events.EventEnvelope{}, time.Now().UTC())).WithEntityID(entityID))
+	runner.ProcessEventForTest(ctx, eventtest.WithEntityID((eventtest.Projection(eventID,
+		"example.started", "", "", []byte(`{}`), 0, runID, "", events.EventEnvelope{}, time.Now().UTC())), entityID))
 
 	if attempts != DefaultSystemNodeRetryLimit {
 		t.Fatalf("attempts = %d, want configured retry limit %d", attempts, DefaultSystemNodeRetryLimit)

--- a/internal/runtime/pipeline/node_system_runner_completion_test.go
+++ b/internal/runtime/pipeline/node_system_runner_completion_test.go
@@ -65,8 +65,18 @@ func TestSystemNodeRunner_MarkProcessedSettlesNodeDeliveryAndTriggersNormalRunCo
 		return nil
 	}, func(context.Context) (bool, error) { return true, nil })
 
-	runner.ProcessEventForTest(ctx, eventtest.WithEntityID((eventtest.Projection(eventID,
-		"example.started", "", "", []byte(`{}`), 0, runID, "", events.EventEnvelope{}, time.Now().UTC())), entityID))
+	runner.ProcessEventForTest(ctx, eventtest.RootIngress(
+		eventID,
+		"example.started",
+		"",
+		"",
+		[]byte(`{}`),
+		0,
+		runID,
+		"",
+		events.EnvelopeForEntityID(events.EventEnvelope{}, entityID),
+		time.Now().UTC(),
+	))
 
 	if !handlerCalled {
 		t.Fatal("handler was not called")
@@ -134,10 +144,12 @@ func TestSystemNodeRunner_TargetSetSameNodeSettlesEachTargetDelivery(t *testing.
 		return nil
 	}, func(context.Context) (bool, error) { return true, nil })
 
-	base := eventtest.Projection(eventID,
-		"worker/work.assign", "", "", []byte(`{}`), 0, runID, "", events.EventEnvelope{}, time.Now().UTC())
+	eventForTarget := func(target events.RouteIdentity) events.Event {
+		return eventtest.RootIngress(eventID,
+			"worker/work.assign", "", "", []byte(`{}`), 0, runID, "", events.EnvelopeForTargetRoute(events.EventEnvelope{}, target), time.Now().UTC())
+	}
 
-	runner.ProcessEventForTest(ctx, eventtest.WithTargetRoute(base, targetOne))
+	runner.ProcessEventForTest(ctx, eventForTarget(targetOne))
 	if got := loadSystemNodeCompletionTargetDeliveryStatus(t, db, eventID, "task-handler", targetOne); got != "delivered" {
 		t.Fatalf("target one status = %q, want delivered", got)
 	}
@@ -145,7 +157,7 @@ func TestSystemNodeRunner_TargetSetSameNodeSettlesEachTargetDelivery(t *testing.
 		t.Fatalf("target two status after first delivery = %q, want pending", got)
 	}
 
-	runner.ProcessEventForTest(ctx, eventtest.WithTargetRoute(base, targetTwo))
+	runner.ProcessEventForTest(ctx, eventForTarget(targetTwo))
 	if got := loadSystemNodeCompletionTargetDeliveryStatus(t, db, eventID, "task-handler", targetTwo); got != "delivered" {
 		t.Fatalf("target two status = %q, want delivered", got)
 	}
@@ -202,10 +214,12 @@ func TestSystemNodeRunner_TargetSetSameNodeFailureKeepsSiblingPending(t *testing
 		return 0
 	})
 
-	base := eventtest.Projection(eventID,
-		"worker/work.assign", "", "", []byte(`{}`), 0, runID, "", events.EventEnvelope{}, time.Now().UTC())
+	eventForTarget := func(target events.RouteIdentity) events.Event {
+		return eventtest.RootIngress(eventID,
+			"worker/work.assign", "", "", []byte(`{}`), 0, runID, "", events.EnvelopeForTargetRoute(events.EventEnvelope{}, target), time.Now().UTC())
+	}
 
-	runner.ProcessEventForTest(ctx, eventtest.WithTargetRoute(base, targetOne))
+	runner.ProcessEventForTest(ctx, eventForTarget(targetOne))
 
 	if attempts != 2 {
 		t.Fatalf("attempts = %d, want 2", attempts)
@@ -237,10 +251,12 @@ func TestSystemNodeRunner_TargetSetSameNodeDeadLetterKeepsSiblingExecutable(t *t
 	}, func(context.Context) (bool, error) { return true, nil })
 	failingRunner.SetRetryPolicyForTest(1, func(int) time.Duration { return 0 })
 
-	base := eventtest.Projection(eventID,
-		"worker/work.assign", "", "", []byte(`{}`), 0, runID, "", events.EventEnvelope{}, time.Now().UTC())
+	eventForTarget := func(target events.RouteIdentity) events.Event {
+		return eventtest.RootIngress(eventID,
+			"worker/work.assign", "", "", []byte(`{}`), 0, runID, "", events.EnvelopeForTargetRoute(events.EventEnvelope{}, target), time.Now().UTC())
+	}
 
-	failingRunner.ProcessEventForTest(ctx, eventtest.WithTargetRoute(base, targetOne))
+	failingRunner.ProcessEventForTest(ctx, eventForTarget(targetOne))
 
 	targetOneDelivery := loadSystemNodeCompletionTargetDelivery(t, db, eventID, "task-handler", targetOne)
 	if targetOneDelivery.Status != "dead_letter" || targetOneDelivery.Reason != "retry_exhausted" || targetOneDelivery.RetryCount != 1 || targetOneDelivery.LastError == "" {
@@ -255,7 +271,7 @@ func TestSystemNodeRunner_TargetSetSameNodeDeadLetterKeepsSiblingExecutable(t *t
 	}, func(context.Context, events.Event) error {
 		return nil
 	}, func(context.Context) (bool, error) { return true, nil })
-	successRunner.ProcessEventForTest(ctx, eventtest.WithTargetRoute(base, targetTwo))
+	successRunner.ProcessEventForTest(ctx, eventForTarget(targetTwo))
 	if got := loadSystemNodeCompletionTargetDeliveryStatus(t, db, eventID, "task-handler", targetTwo); got != "delivered" {
 		t.Fatalf("target two status after target one dead-letter = %q, want delivered", got)
 	}
@@ -368,8 +384,18 @@ func TestSystemNodeRunnerLifecycleProbeEmitsHandlerBoundaries(t *testing.T) {
 	}, func(context.Context) (bool, error) { return true, nil })
 	runner.SetTestLifecycleProbe(probe)
 
-	runner.ProcessEventForTest(ctx, eventtest.WithEntityID((eventtest.Projection(eventID,
-		"example.started", "", "", []byte(`{}`), 0, runID, "", events.EventEnvelope{}, time.Now().UTC())), entityID))
+	runner.ProcessEventForTest(ctx, eventtest.RootIngress(
+		eventID,
+		"example.started",
+		"",
+		"",
+		[]byte(`{}`),
+		0,
+		runID,
+		"",
+		events.EnvelopeForEntityID(events.EventEnvelope{}, entityID),
+		time.Now().UTC(),
+	))
 
 	waitCtx, cancelWait := context.WithTimeout(ctx, time.Second)
 	defer cancelWait()
@@ -454,8 +480,18 @@ func TestSystemNodeRunner_RetryableFailureWritesFailedBeforeRetry(t *testing.T) 
 		return 0
 	})
 
-	runner.ProcessEventForTest(ctx, eventtest.WithEntityID((eventtest.Projection(eventID,
-		"example.started", "", "", []byte(`{}`), 0, runID, "", events.EventEnvelope{}, time.Now().UTC())), entityID))
+	runner.ProcessEventForTest(ctx, eventtest.RootIngress(
+		eventID,
+		"example.started",
+		"",
+		"",
+		[]byte(`{}`),
+		0,
+		runID,
+		"",
+		events.EnvelopeForEntityID(events.EventEnvelope{}, entityID),
+		time.Now().UTC(),
+	))
 
 	if attempts != 2 {
 		t.Fatalf("attempts = %d, want 2", attempts)
@@ -495,8 +531,18 @@ func TestSystemNodeRunner_RetryableFailureExhaustsConfiguredRetryLimit(t *testin
 	}, func(context.Context) (bool, error) { return true, nil })
 	runner.SetRetryPolicyForTest(DefaultSystemNodeRetryLimit, func(int) time.Duration { return 0 })
 
-	runner.ProcessEventForTest(ctx, eventtest.WithEntityID((eventtest.Projection(eventID,
-		"example.started", "", "", []byte(`{}`), 0, runID, "", events.EventEnvelope{}, time.Now().UTC())), entityID))
+	runner.ProcessEventForTest(ctx, eventtest.RootIngress(
+		eventID,
+		"example.started",
+		"",
+		"",
+		[]byte(`{}`),
+		0,
+		runID,
+		"",
+		events.EnvelopeForEntityID(events.EventEnvelope{}, entityID),
+		time.Now().UTC(),
+	))
 
 	if attempts != DefaultSystemNodeRetryLimit {
 		t.Fatalf("attempts = %d, want configured retry limit %d", attempts, DefaultSystemNodeRetryLimit)

--- a/internal/runtime/pipeline/on_timeout_pipeline_test.go
+++ b/internal/runtime/pipeline/on_timeout_pipeline_test.go
@@ -72,8 +72,12 @@ func TestExecuteAuthoritativeNodeHandler_OnTimeoutAdvancesPartial(t *testing.T) 
 		t.Fatalf("seed workflow instance: %v", err)
 	}
 
-	timeoutEvt := eventtest.WithEntityID(eventtest.Projection("timeout-1",
-		events.EventType("accumulate.timeout"), "", "", mustJSON(map[string]any{
+	timeoutEvt := eventtest.RootIngress(
+		"timeout-1",
+		events.EventType("accumulate.timeout"),
+		"",
+		"",
+		mustJSON(map[string]any{
 			"timer_handle": map[string]any{
 				"kind": "accumulation_timeout",
 				"bucket": map[string]any{
@@ -81,8 +85,13 @@ func TestExecuteAuthoritativeNodeHandler_OnTimeoutAdvancesPartial(t *testing.T) 
 					"event_type": "item.arrived",
 				},
 			},
-		}), 0, "", "", events.EventEnvelope{}, time.Now().UTC()),
-		"ent-001")
+		}),
+		0,
+		"",
+		"",
+		events.EnvelopeForEntityID(events.EventEnvelope{}, "ent-001"),
+		time.Now().UTC(),
+	)
 
 	result, err := pc.executeAuthoritativeNodeHandler(testPipelineCoordinatorRunContext(t, pc), timeoutEvt, workflowTriggerContext{
 		Event: timeoutEvt,

--- a/internal/runtime/pipeline/on_timeout_pipeline_test.go
+++ b/internal/runtime/pipeline/on_timeout_pipeline_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/division-sh/swarm/internal/events"
+	"github.com/division-sh/swarm/internal/events/eventtest"
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
 	"github.com/division-sh/swarm/internal/runtime/core/timeridentity"
 	runtimeengine "github.com/division-sh/swarm/internal/runtime/engine"
@@ -71,7 +72,7 @@ func TestExecuteAuthoritativeNodeHandler_OnTimeoutAdvancesPartial(t *testing.T) 
 		t.Fatalf("seed workflow instance: %v", err)
 	}
 
-	timeoutEvt := events.NewProjectionEvent("timeout-1",
+	timeoutEvt := eventtest.WithEntityID(eventtest.Projection("timeout-1",
 		events.EventType("accumulate.timeout"), "", "", mustJSON(map[string]any{
 			"timer_handle": map[string]any{
 				"kind": "accumulation_timeout",
@@ -80,8 +81,9 @@ func TestExecuteAuthoritativeNodeHandler_OnTimeoutAdvancesPartial(t *testing.T) 
 					"event_type": "item.arrived",
 				},
 			},
-		}), 0, "", "", events.EventEnvelope{}, time.Now().UTC()).
-		WithEntityID("ent-001")
+		}), 0, "", "", events.EventEnvelope{}, time.Now().UTC()),
+		"ent-001")
+
 	result, err := pc.executeAuthoritativeNodeHandler(testPipelineCoordinatorRunContext(t, pc), timeoutEvt, workflowTriggerContext{
 		Event: timeoutEvt,
 		State: pc.currentWorkflowState(testPipelineCoordinatorRunContext(t, pc), "ent-001"),

--- a/internal/runtime/pipeline/select_entity_test.go
+++ b/internal/runtime/pipeline/select_entity_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/division-sh/swarm/internal/events"
+	"github.com/division-sh/swarm/internal/events/eventtest"
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
 	"github.com/division-sh/swarm/internal/runtime/semanticview"
 	storerunlifecycle "github.com/division-sh/swarm/internal/store/runlifecycle"
@@ -27,8 +28,9 @@ func TestExecuteNodeContractHandlerSelectEntityUpdatesTargetOwnedEntity(t *testi
 	budgetEntityID := seedSelectEntityBudget(t, pc.workflowStore, ctx, source, "vertical-1", 0)
 
 	result, err := pc.executeNodeContractHandler(ctx, "treasury-orchestrator", selectEntitySpendHandler(), workflowTriggerContext{
-		Event: events.NewProjectionEvent("", events.EventType("opco.spend_recorded"), "", "", mustJSON(map[string]any{"vertical_id": "vertical-1", "amount_usd": 42}), 0, "", "", events.EventEnvelope{}, time.Time{}).
-			WithEntityID("22222222-2222-2222-2222-222222222222"),
+		Event: eventtest.WithEntityID(eventtest.Projection("", events.EventType("opco.spend_recorded"), "", "", mustJSON(map[string]any{"vertical_id": "vertical-1", "amount_usd": 42}), 0, "", "", events.EventEnvelope{}, time.Time{}),
+			"22222222-2222-2222-2222-222222222222"),
+
 		State: WorkflowState{},
 	}, false)
 	if err != nil {
@@ -64,8 +66,9 @@ func TestExecuteNodeContractHandlerSelectEntityReplayUsesSameTargetEntity(t *tes
 
 	for _, amount := range []int{42, 99} {
 		result, err := pc.executeNodeContractHandler(ctx, "treasury-orchestrator", selectEntitySpendHandler(), workflowTriggerContext{
-			Event: events.NewProjectionEvent("", events.EventType("opco.spend_recorded"), "", "", mustJSON(map[string]any{"vertical_id": "vertical-1", "amount_usd": amount}), 0, "", "", events.EventEnvelope{}, time.Time{}).
-				WithEntityID("22222222-2222-2222-2222-222222222222"),
+			Event: eventtest.WithEntityID(eventtest.Projection("", events.EventType("opco.spend_recorded"), "", "", mustJSON(map[string]any{"vertical_id": "vertical-1", "amount_usd": amount}), 0, "", "", events.EventEnvelope{}, time.Time{}),
+				"22222222-2222-2222-2222-222222222222"),
+
 			State: WorkflowState{},
 		}, false)
 		if err != nil {
@@ -129,8 +132,9 @@ func TestExecuteNodeContractHandlerSelectEntityMatchesTypedStatusField(t *testin
 			}},
 		},
 	}, workflowTriggerContext{
-		Event: events.NewProjectionEvent("", events.EventType("opco.spend_recorded"), "", "", mustJSON(map[string]any{"vertical_id": "vertical-1", "status": "pending", "amount_usd": 42}), 0, "", "", events.EventEnvelope{}, time.Time{}).
-			WithEntityID("22222222-2222-2222-2222-222222222222"),
+		Event: eventtest.WithEntityID(eventtest.Projection("", events.EventType("opco.spend_recorded"), "", "", mustJSON(map[string]any{"vertical_id": "vertical-1", "status": "pending", "amount_usd": 42}), 0, "", "", events.EventEnvelope{}, time.Time{}),
+			"22222222-2222-2222-2222-222222222222"),
+
 		State: WorkflowState{},
 	}, false)
 	if err != nil {
@@ -165,7 +169,7 @@ func TestExecuteNodeContractHandlerSelectOrCreateEntityCreatesTargetOwnedEntity(
 	ctx := testPipelineCoordinatorRunContext(t, pc)
 
 	result, err := pc.executeNodeContractHandler(ctx, "treasury-orchestrator", selectOrCreateEntitySpendHandler(), workflowTriggerContext{
-		Event: events.NewProjectionEvent("", events.EventType("opco.spend_recorded"), "", "", mustJSON(map[string]any{"vertical_id": "vertical-1", "amount_usd": 42}), 0, "", "", events.EventEnvelope{}, time.Time{}),
+		Event: eventtest.Projection("", events.EventType("opco.spend_recorded"), "", "", mustJSON(map[string]any{"vertical_id": "vertical-1", "amount_usd": 42}), 0, "", "", events.EventEnvelope{}, time.Time{}),
 
 		State: WorkflowState{},
 	}, false)
@@ -331,7 +335,7 @@ func TestExecuteNodeContractHandlerSelectOrCreateEntityReplayUsesSameDeclaredKey
 
 	for _, amount := range []int{42, 99} {
 		result, err := pc.executeNodeContractHandler(ctx, "treasury-orchestrator", selectOrCreateEntitySpendHandler(), workflowTriggerContext{
-			Event: events.NewProjectionEvent("", events.EventType("opco.spend_recorded"), "", "", mustJSON(map[string]any{"vertical_id": "vertical-1", "amount_usd": amount}), 0, "", "", events.EventEnvelope{}, time.Time{}),
+			Event: eventtest.Projection("", events.EventType("opco.spend_recorded"), "", "", mustJSON(map[string]any{"vertical_id": "vertical-1", "amount_usd": amount}), 0, "", "", events.EventEnvelope{}, time.Time{}),
 
 			State: WorkflowState{},
 		}, false)
@@ -360,7 +364,7 @@ func TestExecuteNodeContractHandlerSelectOrCreateEntityFailsClosedOnAmbiguousMat
 	seedSelectEntityBudgetWithInstance(t, pc.workflowStore, ctx, source, "budget-2", "vertical-1", 0)
 
 	_, err := pc.executeNodeContractHandler(ctx, "treasury-orchestrator", selectOrCreateEntitySpendHandler(), workflowTriggerContext{
-		Event: events.NewProjectionEvent("", events.EventType("opco.spend_recorded"), "", "", mustJSON(map[string]any{"vertical_id": "vertical-1", "amount_usd": 42}), 0, "", "", events.EventEnvelope{}, time.Time{}),
+		Event: eventtest.Projection("", events.EventType("opco.spend_recorded"), "", "", mustJSON(map[string]any{"vertical_id": "vertical-1", "amount_usd": 42}), 0, "", "", events.EventEnvelope{}, time.Time{}),
 	}, false)
 	if err == nil || !strings.Contains(err.Error(), "select_or_create_entity_ambiguous") {
 		t.Fatalf("executeNodeContractHandler error = %v, want select_or_create_entity_ambiguous", err)
@@ -396,7 +400,7 @@ func TestExecuteNodeContractHandlerSelectOrCreateEntityFailsClosedOnDeterministi
 	}
 
 	_, err = pc.executeNodeContractHandler(ctx, "treasury-orchestrator", selectOrCreateEntitySpendHandler(), workflowTriggerContext{
-		Event: events.NewProjectionEvent("", events.EventType("opco.spend_recorded"), "", "", mustJSON(map[string]any{"vertical_id": "vertical-1", "amount_usd": 42}), 0, "", "", events.EventEnvelope{}, time.Time{}),
+		Event: eventtest.Projection("", events.EventType("opco.spend_recorded"), "", "", mustJSON(map[string]any{"vertical_id": "vertical-1", "amount_usd": 42}), 0, "", "", events.EventEnvelope{}, time.Time{}),
 	}, false)
 	if err == nil || !strings.Contains(err.Error(), "select_or_create_entity_conflict") {
 		t.Fatalf("executeNodeContractHandler error = %v, want select_or_create_entity_conflict", err)
@@ -416,7 +420,7 @@ func TestExecuteNodeContractHandlerSelectOrCreateEntityConcurrentDuplicateCreate
 		go func() {
 			defer wg.Done()
 			result, err := pc.executeNodeContractHandler(ctx, "treasury-orchestrator", selectOrCreateEntitySpendHandler(), workflowTriggerContext{
-				Event: events.NewProjectionEvent("", events.EventType("opco.spend_recorded"), "", "", mustJSON(map[string]any{"vertical_id": "vertical-1", "amount_usd": 42}), 0, "", "", events.EventEnvelope{}, time.Time{}),
+				Event: eventtest.Projection("", events.EventType("opco.spend_recorded"), "", "", mustJSON(map[string]any{"vertical_id": "vertical-1", "amount_usd": 42}), 0, "", "", events.EventEnvelope{}, time.Time{}),
 
 				State: WorkflowState{},
 			}, false)
@@ -491,7 +495,7 @@ func TestExecuteNodeContractHandlerSelectOrCreateEntityFeedsEntityIDToArtifactRe
 	}
 
 	result, err := pc.executeNodeContractHandler(ctx, "treasury-orchestrator", selectOrCreateArtifactRepoCommitHandler(), workflowTriggerContext{
-		Event: events.NewProjectionEvent(sourceEventID,
+		Event: eventtest.Projection(sourceEventID,
 			events.EventType("spec_repo.commit_requested"), "", "", mustJSON(payload), 0, testPipelineRunID, "", events.EventEnvelope{}, time.Unix(1_700_000_000, 0).UTC()),
 
 		State: WorkflowState{},
@@ -582,7 +586,7 @@ func TestExecuteNodeContractHandlerSelectEntityIgnoresTerminalAndTerminatedMatch
 	}
 
 	result, err := pc.executeNodeContractHandler(ctx, "treasury-orchestrator", selectEntitySpendHandler(), workflowTriggerContext{
-		Event: events.NewProjectionEvent("", events.EventType("opco.spend_recorded"), "", "", mustJSON(map[string]any{"vertical_id": "vertical-1", "amount_usd": 42}), 0, "", "", events.EventEnvelope{}, time.Time{}),
+		Event: eventtest.Projection("", events.EventType("opco.spend_recorded"), "", "", mustJSON(map[string]any{"vertical_id": "vertical-1", "amount_usd": 42}), 0, "", "", events.EventEnvelope{}, time.Time{}),
 
 		State: WorkflowState{},
 	}, false)
@@ -635,7 +639,7 @@ func TestExecuteNodeContractHandlerSelectEntityFailsClosedOnNoMatch(t *testing.T
 	seedSelectEntityBudget(t, pc.workflowStore, ctx, source, "vertical-1", 0)
 
 	_, err := pc.executeNodeContractHandler(ctx, "treasury-orchestrator", selectEntitySpendHandler(), workflowTriggerContext{
-		Event: events.NewProjectionEvent("", events.EventType("opco.spend_recorded"), "", "", mustJSON(map[string]any{"vertical_id": "missing", "amount_usd": 42}), 0, "", "", events.EventEnvelope{}, time.Time{}),
+		Event: eventtest.Projection("", events.EventType("opco.spend_recorded"), "", "", mustJSON(map[string]any{"vertical_id": "missing", "amount_usd": 42}), 0, "", "", events.EventEnvelope{}, time.Time{}),
 	}, false)
 	if err == nil || !strings.Contains(err.Error(), "select_entity_no_match") {
 		t.Fatalf("executeNodeContractHandler error = %v, want select_entity_no_match", err)
@@ -651,7 +655,7 @@ func TestExecuteNodeContractHandlerSelectEntityFailsClosedOnMissingPayloadRef(t 
 	seedSelectEntityBudget(t, pc.workflowStore, ctx, source, "vertical-1", 0)
 
 	_, err := pc.executeNodeContractHandler(ctx, "treasury-orchestrator", selectEntitySpendHandler(), workflowTriggerContext{
-		Event: events.NewProjectionEvent("", events.EventType("opco.spend_recorded"), "", "", mustJSON(map[string]any{"amount_usd": 42}), 0, "", "", events.EventEnvelope{}, time.Time{}),
+		Event: eventtest.Projection("", events.EventType("opco.spend_recorded"), "", "", mustJSON(map[string]any{"amount_usd": 42}), 0, "", "", events.EventEnvelope{}, time.Time{}),
 	}, false)
 	if err == nil || !strings.Contains(err.Error(), "missing required payload ref") {
 		t.Fatalf("executeNodeContractHandler error = %v, want missing payload ref", err)
@@ -668,7 +672,7 @@ func TestExecuteNodeContractHandlerSelectEntityFailsClosedOnAmbiguousMatch(t *te
 	seedSelectEntityBudgetWithInstance(t, pc.workflowStore, ctx, source, "budget-2", "vertical-1", 0)
 
 	_, err := pc.executeNodeContractHandler(ctx, "treasury-orchestrator", selectEntitySpendHandler(), workflowTriggerContext{
-		Event: events.NewProjectionEvent("", events.EventType("opco.spend_recorded"), "", "", mustJSON(map[string]any{"vertical_id": "vertical-1", "amount_usd": 42}), 0, "", "", events.EventEnvelope{}, time.Time{}),
+		Event: eventtest.Projection("", events.EventType("opco.spend_recorded"), "", "", mustJSON(map[string]any{"vertical_id": "vertical-1", "amount_usd": 42}), 0, "", "", events.EventEnvelope{}, time.Time{}),
 	}, false)
 	if err == nil || !strings.Contains(err.Error(), "select_entity_ambiguous") {
 		t.Fatalf("executeNodeContractHandler error = %v, want select_entity_ambiguous", err)
@@ -913,9 +917,10 @@ func loadSelectOrCreateBudgetByKey(t *testing.T, store *WorkflowInstanceStore, c
 func seedSelectEntitySpendEvent(t *testing.T, db *sql.DB, ctx context.Context, payload map[string]any) events.Event {
 	t.Helper()
 	entityID := uuid.NewString()
-	evt := (events.NewProjectionEvent(uuid.NewString(),
+	evt := eventtest.WithEntityID((eventtest.Projection(uuid.NewString(),
 		events.EventType("opco.spend_recorded"),
-		"opco", "", mustJSON(payload), 0, "", "", events.EventEnvelope{}, time.Now().UTC())).WithEntityID(entityID)
+		"opco", "", mustJSON(payload), 0, "", "", events.EventEnvelope{}, time.Now().UTC())), entityID)
+
 	if _, err := db.ExecContext(ctx, `
 		INSERT INTO events (event_id, event_name, entity_id, flow_instance, scope, payload, produced_by, produced_by_type, created_at)
 		VALUES ($1::uuid, $2, $3::uuid, 'opco/vertical-1', 'entity', $4::jsonb, 'opco', 'node', now())

--- a/internal/runtime/pipeline/select_entity_test.go
+++ b/internal/runtime/pipeline/select_entity_test.go
@@ -28,8 +28,18 @@ func TestExecuteNodeContractHandlerSelectEntityUpdatesTargetOwnedEntity(t *testi
 	budgetEntityID := seedSelectEntityBudget(t, pc.workflowStore, ctx, source, "vertical-1", 0)
 
 	result, err := pc.executeNodeContractHandler(ctx, "treasury-orchestrator", selectEntitySpendHandler(), workflowTriggerContext{
-		Event: eventtest.WithEntityID(eventtest.Projection("", events.EventType("opco.spend_recorded"), "", "", mustJSON(map[string]any{"vertical_id": "vertical-1", "amount_usd": 42}), 0, "", "", events.EventEnvelope{}, time.Time{}),
-			"22222222-2222-2222-2222-222222222222"),
+		Event: eventtest.RootIngress(
+			"",
+			events.EventType("opco.spend_recorded"),
+			"",
+			"",
+			mustJSON(map[string]any{"vertical_id": "vertical-1", "amount_usd": 42}),
+			0,
+			"",
+			"",
+			events.EnvelopeForEntityID(events.EventEnvelope{}, "22222222-2222-2222-2222-222222222222"),
+			time.Time{},
+		),
 
 		State: WorkflowState{},
 	}, false)
@@ -66,8 +76,18 @@ func TestExecuteNodeContractHandlerSelectEntityReplayUsesSameTargetEntity(t *tes
 
 	for _, amount := range []int{42, 99} {
 		result, err := pc.executeNodeContractHandler(ctx, "treasury-orchestrator", selectEntitySpendHandler(), workflowTriggerContext{
-			Event: eventtest.WithEntityID(eventtest.Projection("", events.EventType("opco.spend_recorded"), "", "", mustJSON(map[string]any{"vertical_id": "vertical-1", "amount_usd": amount}), 0, "", "", events.EventEnvelope{}, time.Time{}),
-				"22222222-2222-2222-2222-222222222222"),
+			Event: eventtest.RootIngress(
+				"",
+				events.EventType("opco.spend_recorded"),
+				"",
+				"",
+				mustJSON(map[string]any{"vertical_id": "vertical-1", "amount_usd": amount}),
+				0,
+				"",
+				"",
+				events.EnvelopeForEntityID(events.EventEnvelope{}, "22222222-2222-2222-2222-222222222222"),
+				time.Time{},
+			),
 
 			State: WorkflowState{},
 		}, false)
@@ -132,8 +152,18 @@ func TestExecuteNodeContractHandlerSelectEntityMatchesTypedStatusField(t *testin
 			}},
 		},
 	}, workflowTriggerContext{
-		Event: eventtest.WithEntityID(eventtest.Projection("", events.EventType("opco.spend_recorded"), "", "", mustJSON(map[string]any{"vertical_id": "vertical-1", "status": "pending", "amount_usd": 42}), 0, "", "", events.EventEnvelope{}, time.Time{}),
-			"22222222-2222-2222-2222-222222222222"),
+		Event: eventtest.RootIngress(
+			"",
+			events.EventType("opco.spend_recorded"),
+			"",
+			"",
+			mustJSON(map[string]any{"vertical_id": "vertical-1", "status": "pending", "amount_usd": 42}),
+			0,
+			"",
+			"",
+			events.EnvelopeForEntityID(events.EventEnvelope{}, "22222222-2222-2222-2222-222222222222"),
+			time.Time{},
+		),
 
 		State: WorkflowState{},
 	}, false)
@@ -169,7 +199,7 @@ func TestExecuteNodeContractHandlerSelectOrCreateEntityCreatesTargetOwnedEntity(
 	ctx := testPipelineCoordinatorRunContext(t, pc)
 
 	result, err := pc.executeNodeContractHandler(ctx, "treasury-orchestrator", selectOrCreateEntitySpendHandler(), workflowTriggerContext{
-		Event: eventtest.Projection("", events.EventType("opco.spend_recorded"), "", "", mustJSON(map[string]any{"vertical_id": "vertical-1", "amount_usd": 42}), 0, "", "", events.EventEnvelope{}, time.Time{}),
+		Event: eventtest.RootIngress("", events.EventType("opco.spend_recorded"), "", "", mustJSON(map[string]any{"vertical_id": "vertical-1", "amount_usd": 42}), 0, "", "", events.EventEnvelope{}, time.Time{}),
 
 		State: WorkflowState{},
 	}, false)
@@ -335,7 +365,7 @@ func TestExecuteNodeContractHandlerSelectOrCreateEntityReplayUsesSameDeclaredKey
 
 	for _, amount := range []int{42, 99} {
 		result, err := pc.executeNodeContractHandler(ctx, "treasury-orchestrator", selectOrCreateEntitySpendHandler(), workflowTriggerContext{
-			Event: eventtest.Projection("", events.EventType("opco.spend_recorded"), "", "", mustJSON(map[string]any{"vertical_id": "vertical-1", "amount_usd": amount}), 0, "", "", events.EventEnvelope{}, time.Time{}),
+			Event: eventtest.RootIngress("", events.EventType("opco.spend_recorded"), "", "", mustJSON(map[string]any{"vertical_id": "vertical-1", "amount_usd": amount}), 0, "", "", events.EventEnvelope{}, time.Time{}),
 
 			State: WorkflowState{},
 		}, false)
@@ -364,7 +394,7 @@ func TestExecuteNodeContractHandlerSelectOrCreateEntityFailsClosedOnAmbiguousMat
 	seedSelectEntityBudgetWithInstance(t, pc.workflowStore, ctx, source, "budget-2", "vertical-1", 0)
 
 	_, err := pc.executeNodeContractHandler(ctx, "treasury-orchestrator", selectOrCreateEntitySpendHandler(), workflowTriggerContext{
-		Event: eventtest.Projection("", events.EventType("opco.spend_recorded"), "", "", mustJSON(map[string]any{"vertical_id": "vertical-1", "amount_usd": 42}), 0, "", "", events.EventEnvelope{}, time.Time{}),
+		Event: eventtest.RootIngress("", events.EventType("opco.spend_recorded"), "", "", mustJSON(map[string]any{"vertical_id": "vertical-1", "amount_usd": 42}), 0, "", "", events.EventEnvelope{}, time.Time{}),
 	}, false)
 	if err == nil || !strings.Contains(err.Error(), "select_or_create_entity_ambiguous") {
 		t.Fatalf("executeNodeContractHandler error = %v, want select_or_create_entity_ambiguous", err)
@@ -400,7 +430,7 @@ func TestExecuteNodeContractHandlerSelectOrCreateEntityFailsClosedOnDeterministi
 	}
 
 	_, err = pc.executeNodeContractHandler(ctx, "treasury-orchestrator", selectOrCreateEntitySpendHandler(), workflowTriggerContext{
-		Event: eventtest.Projection("", events.EventType("opco.spend_recorded"), "", "", mustJSON(map[string]any{"vertical_id": "vertical-1", "amount_usd": 42}), 0, "", "", events.EventEnvelope{}, time.Time{}),
+		Event: eventtest.RootIngress("", events.EventType("opco.spend_recorded"), "", "", mustJSON(map[string]any{"vertical_id": "vertical-1", "amount_usd": 42}), 0, "", "", events.EventEnvelope{}, time.Time{}),
 	}, false)
 	if err == nil || !strings.Contains(err.Error(), "select_or_create_entity_conflict") {
 		t.Fatalf("executeNodeContractHandler error = %v, want select_or_create_entity_conflict", err)
@@ -420,7 +450,7 @@ func TestExecuteNodeContractHandlerSelectOrCreateEntityConcurrentDuplicateCreate
 		go func() {
 			defer wg.Done()
 			result, err := pc.executeNodeContractHandler(ctx, "treasury-orchestrator", selectOrCreateEntitySpendHandler(), workflowTriggerContext{
-				Event: eventtest.Projection("", events.EventType("opco.spend_recorded"), "", "", mustJSON(map[string]any{"vertical_id": "vertical-1", "amount_usd": 42}), 0, "", "", events.EventEnvelope{}, time.Time{}),
+				Event: eventtest.RootIngress("", events.EventType("opco.spend_recorded"), "", "", mustJSON(map[string]any{"vertical_id": "vertical-1", "amount_usd": 42}), 0, "", "", events.EventEnvelope{}, time.Time{}),
 
 				State: WorkflowState{},
 			}, false)
@@ -495,7 +525,7 @@ func TestExecuteNodeContractHandlerSelectOrCreateEntityFeedsEntityIDToArtifactRe
 	}
 
 	result, err := pc.executeNodeContractHandler(ctx, "treasury-orchestrator", selectOrCreateArtifactRepoCommitHandler(), workflowTriggerContext{
-		Event: eventtest.Projection(sourceEventID,
+		Event: eventtest.RootIngress(sourceEventID,
 			events.EventType("spec_repo.commit_requested"), "", "", mustJSON(payload), 0, testPipelineRunID, "", events.EventEnvelope{}, time.Unix(1_700_000_000, 0).UTC()),
 
 		State: WorkflowState{},
@@ -586,7 +616,7 @@ func TestExecuteNodeContractHandlerSelectEntityIgnoresTerminalAndTerminatedMatch
 	}
 
 	result, err := pc.executeNodeContractHandler(ctx, "treasury-orchestrator", selectEntitySpendHandler(), workflowTriggerContext{
-		Event: eventtest.Projection("", events.EventType("opco.spend_recorded"), "", "", mustJSON(map[string]any{"vertical_id": "vertical-1", "amount_usd": 42}), 0, "", "", events.EventEnvelope{}, time.Time{}),
+		Event: eventtest.RootIngress("", events.EventType("opco.spend_recorded"), "", "", mustJSON(map[string]any{"vertical_id": "vertical-1", "amount_usd": 42}), 0, "", "", events.EventEnvelope{}, time.Time{}),
 
 		State: WorkflowState{},
 	}, false)
@@ -639,7 +669,7 @@ func TestExecuteNodeContractHandlerSelectEntityFailsClosedOnNoMatch(t *testing.T
 	seedSelectEntityBudget(t, pc.workflowStore, ctx, source, "vertical-1", 0)
 
 	_, err := pc.executeNodeContractHandler(ctx, "treasury-orchestrator", selectEntitySpendHandler(), workflowTriggerContext{
-		Event: eventtest.Projection("", events.EventType("opco.spend_recorded"), "", "", mustJSON(map[string]any{"vertical_id": "missing", "amount_usd": 42}), 0, "", "", events.EventEnvelope{}, time.Time{}),
+		Event: eventtest.RootIngress("", events.EventType("opco.spend_recorded"), "", "", mustJSON(map[string]any{"vertical_id": "missing", "amount_usd": 42}), 0, "", "", events.EventEnvelope{}, time.Time{}),
 	}, false)
 	if err == nil || !strings.Contains(err.Error(), "select_entity_no_match") {
 		t.Fatalf("executeNodeContractHandler error = %v, want select_entity_no_match", err)
@@ -655,7 +685,7 @@ func TestExecuteNodeContractHandlerSelectEntityFailsClosedOnMissingPayloadRef(t 
 	seedSelectEntityBudget(t, pc.workflowStore, ctx, source, "vertical-1", 0)
 
 	_, err := pc.executeNodeContractHandler(ctx, "treasury-orchestrator", selectEntitySpendHandler(), workflowTriggerContext{
-		Event: eventtest.Projection("", events.EventType("opco.spend_recorded"), "", "", mustJSON(map[string]any{"amount_usd": 42}), 0, "", "", events.EventEnvelope{}, time.Time{}),
+		Event: eventtest.RootIngress("", events.EventType("opco.spend_recorded"), "", "", mustJSON(map[string]any{"amount_usd": 42}), 0, "", "", events.EventEnvelope{}, time.Time{}),
 	}, false)
 	if err == nil || !strings.Contains(err.Error(), "missing required payload ref") {
 		t.Fatalf("executeNodeContractHandler error = %v, want missing payload ref", err)
@@ -672,7 +702,7 @@ func TestExecuteNodeContractHandlerSelectEntityFailsClosedOnAmbiguousMatch(t *te
 	seedSelectEntityBudgetWithInstance(t, pc.workflowStore, ctx, source, "budget-2", "vertical-1", 0)
 
 	_, err := pc.executeNodeContractHandler(ctx, "treasury-orchestrator", selectEntitySpendHandler(), workflowTriggerContext{
-		Event: eventtest.Projection("", events.EventType("opco.spend_recorded"), "", "", mustJSON(map[string]any{"vertical_id": "vertical-1", "amount_usd": 42}), 0, "", "", events.EventEnvelope{}, time.Time{}),
+		Event: eventtest.RootIngress("", events.EventType("opco.spend_recorded"), "", "", mustJSON(map[string]any{"vertical_id": "vertical-1", "amount_usd": 42}), 0, "", "", events.EventEnvelope{}, time.Time{}),
 	}, false)
 	if err == nil || !strings.Contains(err.Error(), "select_entity_ambiguous") {
 		t.Fatalf("executeNodeContractHandler error = %v, want select_entity_ambiguous", err)
@@ -917,9 +947,18 @@ func loadSelectOrCreateBudgetByKey(t *testing.T, store *WorkflowInstanceStore, c
 func seedSelectEntitySpendEvent(t *testing.T, db *sql.DB, ctx context.Context, payload map[string]any) events.Event {
 	t.Helper()
 	entityID := uuid.NewString()
-	evt := eventtest.WithEntityID((eventtest.Projection(uuid.NewString(),
+	evt := eventtest.RootIngress(
+		uuid.NewString(),
 		events.EventType("opco.spend_recorded"),
-		"opco", "", mustJSON(payload), 0, "", "", events.EventEnvelope{}, time.Now().UTC())), entityID)
+		"opco",
+		"",
+		mustJSON(payload),
+		0,
+		"",
+		"",
+		events.EnvelopeForEntityID(events.EventEnvelope{}, entityID),
+		time.Now().UTC(),
+	)
 
 	if _, err := db.ExecContext(ctx, `
 		INSERT INTO events (event_id, event_name, entity_id, flow_instance, scope, payload, produced_by, produced_by_type, created_at)

--- a/internal/runtime/pipeline/sqlite_dynamic_activation_test.go
+++ b/internal/runtime/pipeline/sqlite_dynamic_activation_test.go
@@ -20,15 +20,23 @@ func TestSQLiteFanOutCreateFlowInstanceDeliveriesPersistWithoutDeadLetter(t *tes
 	ctx := sqliteExactOnceRunContext(t, db)
 	pc, bus := newSQLiteDynamicActivationCoordinator(t, db, workflowStore)
 
-	parent := eventtest.WithFlowInstance(eventtest.WithEntityID(eventtest.Projection(uuid.NewString(),
-		events.EventType("component_scaffold.batch_requested"), "", "", mustJSON(map[string]any{
+	parent := eventtest.RootIngress(
+		uuid.NewString(),
+		events.EventType("component_scaffold.batch_requested"),
+		"",
+		"",
+		mustJSON(map[string]any{
 			"components": []any{
 				map[string]any{"component_id": "component-a"},
 				map[string]any{"component_id": "component-b"},
 			},
-		}), 0, runtimecorrelation.RunIDFromContext(ctx), "", events.EventEnvelope{}, time.Now().UTC()),
-		"parent-ent"),
-		"root/parent")
+		}),
+		0,
+		runtimecorrelation.RunIDFromContext(ctx),
+		"",
+		events.EnvelopeForFlowInstance(events.EnvelopeForEntityID(events.EventEnvelope{}, "parent-ent"), "root/parent"),
+		time.Now().UTC(),
+	)
 
 	if err := workflowStore.Create(ctx, WorkflowInstance{
 		InstanceID:      "parent-ent",
@@ -69,7 +77,7 @@ func TestSQLiteFanOutCreateFlowInstanceDeliveriesPersistWithoutDeadLetter(t *tes
 		if childRunID == "" {
 			childRunID = runtimecorrelation.RunIDFromContext(ctx)
 		}
-		child = eventtest.Projection(
+		child = eventtest.RootIngress(
 			childID,
 			child.Type(),
 			child.SourceAgent(),

--- a/internal/runtime/pipeline/sqlite_dynamic_activation_test.go
+++ b/internal/runtime/pipeline/sqlite_dynamic_activation_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/division-sh/swarm/internal/events"
+	"github.com/division-sh/swarm/internal/events/eventtest"
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
 	runtimecorrelation "github.com/division-sh/swarm/internal/runtime/correlation"
 	"github.com/google/uuid"
@@ -19,14 +20,16 @@ func TestSQLiteFanOutCreateFlowInstanceDeliveriesPersistWithoutDeadLetter(t *tes
 	ctx := sqliteExactOnceRunContext(t, db)
 	pc, bus := newSQLiteDynamicActivationCoordinator(t, db, workflowStore)
 
-	parent := events.NewProjectionEvent(uuid.NewString(),
+	parent := eventtest.WithFlowInstance(eventtest.WithEntityID(eventtest.Projection(uuid.NewString(),
 		events.EventType("component_scaffold.batch_requested"), "", "", mustJSON(map[string]any{
 			"components": []any{
 				map[string]any{"component_id": "component-a"},
 				map[string]any{"component_id": "component-b"},
 			},
-		}), 0, runtimecorrelation.RunIDFromContext(ctx), "", events.EventEnvelope{}, time.Now().UTC()).
-		WithEntityID("parent-ent").WithFlowInstance("root/parent")
+		}), 0, runtimecorrelation.RunIDFromContext(ctx), "", events.EventEnvelope{}, time.Now().UTC()),
+		"parent-ent"),
+		"root/parent")
+
 	if err := workflowStore.Create(ctx, WorkflowInstance{
 		InstanceID:      "parent-ent",
 		StorageRef:      "parent-ent",
@@ -66,7 +69,7 @@ func TestSQLiteFanOutCreateFlowInstanceDeliveriesPersistWithoutDeadLetter(t *tes
 		if childRunID == "" {
 			childRunID = runtimecorrelation.RunIDFromContext(ctx)
 		}
-		child = events.NewProjectionEvent(
+		child = eventtest.Projection(
 			childID,
 			child.Type(),
 			child.SourceAgent(),
@@ -76,8 +79,8 @@ func TestSQLiteFanOutCreateFlowInstanceDeliveriesPersistWithoutDeadLetter(t *tes
 			childRunID,
 			child.ParentEventID(),
 			child.Envelope(),
-			child.CreatedAt(),
-		)
+			child.CreatedAt())
+
 		children[idx] = child
 		seedExactOnceEventDelivery(t, workflowStore, ctx, child, "spawn-node")
 	}

--- a/internal/runtime/pipeline/timeout_selection_test.go
+++ b/internal/runtime/pipeline/timeout_selection_test.go
@@ -60,7 +60,7 @@ func TestDeclarativeNodeHandleEvent_SelectsOnTimeoutAccumulatorHandler(t *testin
 	entry := bundle.NodeEntries()["test-node"]
 	engine := &recordingExecutionEngine{}
 	node := NewNode(entry, semanticview.Wrap(bundle), engine, nil)
-	handled := node.Handle(context.Background(), eventtest.Projection("", "accumulate.timeout", "", "", mustJSON(map[string]any{
+	handled := node.Handle(context.Background(), eventtest.RootIngress("", "accumulate.timeout", "", "", mustJSON(map[string]any{
 		"timer_handle": map[string]any{
 			"kind": "accumulation_timeout",
 			"bucket": map[string]any{
@@ -91,7 +91,7 @@ func TestDeclarativeNodeHandleEvent_MatchesWildcardHandler(t *testing.T) {
 	entry := bundle.NodeEntries()["test-node"]
 	engine := &recordingExecutionEngine{}
 	node := NewNode(entry, semanticview.Wrap(bundle), engine, nil)
-	handled := node.Handle(context.Background(), eventtest.WithEntityID(eventtest.Projection("", "task.completed", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}), "ent-1"))
+	handled := node.Handle(context.Background(), eventtest.RootIngress("", "task.completed", "", "", nil, 0, "", "", events.EnvelopeForEntityID(events.EventEnvelope{}, "ent-1"), time.Time{}))
 	if !handled {
 		t.Fatal("expected wildcard event to be handled")
 	}
@@ -168,7 +168,7 @@ func TestDeclarativeNodeHandleEvent_MatchesDeepWildcardChildFlowHandler(t *testi
 	entry := bundle.NodeEntries()["collector"]
 	engine := &recordingExecutionEngine{}
 	node := NewNode(entry, semanticview.Wrap(bundle), engine, nil)
-	handled := node.Handle(context.Background(), eventtest.WithEntityID(eventtest.Projection("", "child/grandchild/task.done", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}), "ent-1"))
+	handled := node.Handle(context.Background(), eventtest.RootIngress("", "child/grandchild/task.done", "", "", nil, 0, "", "", events.EnvelopeForEntityID(events.EventEnvelope{}, "ent-1"), time.Time{}))
 	if !handled {
 		t.Fatal("expected deep wildcard event to be handled")
 	}

--- a/internal/runtime/pipeline/timeout_selection_test.go
+++ b/internal/runtime/pipeline/timeout_selection_test.go
@@ -109,7 +109,7 @@ func TestDeclarativeNodeHandleEvent_DeniesImportBoundaryWildcardRawFallback(t *t
 	engine := &recordingExecutionEngine{}
 	node := NewNode(entry, source, engine, nil)
 
-	handled := node.Handle(context.Background(), events.NewProjectionEvent("", "producer/task.done", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}))
+	handled := node.Handle(context.Background(), eventtest.RootIngress("", "producer/task.done", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}))
 	if handled {
 		t.Fatal("expected ungranted sibling event not to be handled")
 	}
@@ -124,7 +124,7 @@ func TestDeclarativeNodeHandleEvent_AllowsGrantedImportBoundaryWildcard(t *testi
 	engine := &recordingExecutionEngine{}
 	node := NewNode(entry, source, engine, nil)
 
-	handled := node.Handle(context.Background(), events.NewProjectionEvent("", "producer/task.done", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}))
+	handled := node.Handle(context.Background(), eventtest.RootIngress("", "producer/task.done", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}))
 	if !handled {
 		t.Fatal("expected granted sibling event to be handled")
 	}

--- a/internal/runtime/pipeline/timeout_selection_test.go
+++ b/internal/runtime/pipeline/timeout_selection_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/division-sh/swarm/internal/events"
+	"github.com/division-sh/swarm/internal/events/eventtest"
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
 	"github.com/division-sh/swarm/internal/runtime/core/timeridentity"
 	"github.com/division-sh/swarm/internal/runtime/semanticview"
@@ -59,7 +60,7 @@ func TestDeclarativeNodeHandleEvent_SelectsOnTimeoutAccumulatorHandler(t *testin
 	entry := bundle.NodeEntries()["test-node"]
 	engine := &recordingExecutionEngine{}
 	node := NewNode(entry, semanticview.Wrap(bundle), engine, nil)
-	handled := node.Handle(context.Background(), events.NewProjectionEvent("", "accumulate.timeout", "", "", mustJSON(map[string]any{
+	handled := node.Handle(context.Background(), eventtest.Projection("", "accumulate.timeout", "", "", mustJSON(map[string]any{
 		"timer_handle": map[string]any{
 			"kind": "accumulation_timeout",
 			"bucket": map[string]any{
@@ -67,8 +68,7 @@ func TestDeclarativeNodeHandleEvent_SelectsOnTimeoutAccumulatorHandler(t *testin
 				"event_type": "item.arrived",
 			},
 		},
-	}), 0, "", "", events.EventEnvelope{}, time.Time{}),
-	)
+	}), 0, "", "", events.EventEnvelope{}, time.Time{}))
 	if !handled {
 		t.Fatal("expected timeout event to be handled")
 	}
@@ -91,7 +91,7 @@ func TestDeclarativeNodeHandleEvent_MatchesWildcardHandler(t *testing.T) {
 	entry := bundle.NodeEntries()["test-node"]
 	engine := &recordingExecutionEngine{}
 	node := NewNode(entry, semanticview.Wrap(bundle), engine, nil)
-	handled := node.Handle(context.Background(), events.NewProjectionEvent("", "task.completed", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}).WithEntityID("ent-1"))
+	handled := node.Handle(context.Background(), eventtest.WithEntityID(eventtest.Projection("", "task.completed", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}), "ent-1"))
 	if !handled {
 		t.Fatal("expected wildcard event to be handled")
 	}
@@ -168,7 +168,7 @@ func TestDeclarativeNodeHandleEvent_MatchesDeepWildcardChildFlowHandler(t *testi
 	entry := bundle.NodeEntries()["collector"]
 	engine := &recordingExecutionEngine{}
 	node := NewNode(entry, semanticview.Wrap(bundle), engine, nil)
-	handled := node.Handle(context.Background(), events.NewProjectionEvent("", "child/grandchild/task.done", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}).WithEntityID("ent-1"))
+	handled := node.Handle(context.Background(), eventtest.WithEntityID(eventtest.Projection("", "child/grandchild/task.done", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}), "ent-1"))
 	if !handled {
 		t.Fatal("expected deep wildcard event to be handled")
 	}

--- a/internal/runtime/pipeline/workflow_handler_preview_test.go
+++ b/internal/runtime/pipeline/workflow_handler_preview_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/division-sh/swarm/internal/events"
+	"github.com/division-sh/swarm/internal/events/eventtest"
 )
 
 func TestPreviewContractHandlerExecution_DeniesImportBoundaryWildcardRawFallback(t *testing.T) {
@@ -15,7 +16,7 @@ func TestPreviewContractHandlerExecution_DeniesImportBoundaryWildcardRawFallback
 		context.Background(),
 		bundle,
 		"worker-listener",
-		events.NewProjectionEvent("", "producer/task.done", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}),
+		eventtest.RootIngress("", "producer/task.done", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}),
 		WorkflowState{},
 		nil,
 	)
@@ -33,7 +34,7 @@ func TestPreviewContractHandlerExecution_AllowsGrantedImportBoundaryWildcard(t *
 		context.Background(),
 		bundle,
 		"worker-listener",
-		events.NewProjectionEvent("", "producer/task.done", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}),
+		eventtest.RootIngress("", "producer/task.done", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}),
 		WorkflowState{},
 		nil,
 	)

--- a/internal/runtime/pipeline/workflow_instance_activation_test.go
+++ b/internal/runtime/pipeline/workflow_instance_activation_test.go
@@ -36,7 +36,18 @@ func TestCreateFlowInstanceResolvesInstanceIDFromPayloadPath(t *testing.T) {
 			return nil
 		},
 	}
-	trigger := eventtest.WithEntityID((eventtest.Projection("", events.EventType("custom.triggered"), "", "", []byte(`{"entity_id":"ent-1","desired_instance_id":"inst-42","name":"alpha"}`), 0, "", "", events.EventEnvelope{}, time.Time{})), "ent-1")
+	trigger := eventtest.RootIngress(
+		"",
+		events.EventType("custom.triggered"),
+		"",
+		"",
+		[]byte(`{"entity_id":"ent-1","desired_instance_id":"inst-42","name":"alpha"}`),
+		0,
+		"",
+		"",
+		events.EnvelopeForEntityID(events.EventEnvelope{}, "ent-1"),
+		time.Time{},
+	)
 	triggerCtx := workflowTriggerContext{Event: trigger}
 
 	ok := pc.createFlowInstance(context.Background(), triggerCtx, handlerExecutionPlan{
@@ -71,7 +82,18 @@ func TestCreateFlowInstanceResolvesConfigFromBindings(t *testing.T) {
 			return nil
 		},
 	}
-	trigger := eventtest.WithEntityID((eventtest.Projection("", events.EventType("spawn.requested"), "", "", []byte(`{"entity_id":"ent-1","instance_id":"inst-42","name":"alpha","priority":1}`), 0, "", "", events.EventEnvelope{}, time.Time{})), "ent-1")
+	trigger := eventtest.RootIngress(
+		"",
+		events.EventType("spawn.requested"),
+		"",
+		"",
+		[]byte(`{"entity_id":"ent-1","instance_id":"inst-42","name":"alpha","priority":1}`),
+		0,
+		"",
+		"",
+		events.EnvelopeForEntityID(events.EventEnvelope{}, "ent-1"),
+		time.Time{},
+	)
 	triggerCtx := workflowTriggerContext{Event: trigger}
 
 	err := pc.createFlowInstance(context.Background(), triggerCtx, handlerExecutionPlan{
@@ -107,7 +129,18 @@ func TestCreateFlowInstancePreservesNullConfigFromValues(t *testing.T) {
 			return nil
 		},
 	}
-	trigger := eventtest.WithEntityID((eventtest.Projection("", events.EventType("spawn.requested"), "", "", []byte(`{"entity_id":"ent-1","instance_id":"inst-42","optional_setting":null}`), 0, "", "", events.EventEnvelope{}, time.Time{})), "ent-1")
+	trigger := eventtest.RootIngress(
+		"",
+		events.EventType("spawn.requested"),
+		"",
+		"",
+		[]byte(`{"entity_id":"ent-1","instance_id":"inst-42","optional_setting":null}`),
+		0,
+		"",
+		"",
+		events.EnvelopeForEntityID(events.EventEnvelope{}, "ent-1"),
+		time.Time{},
+	)
 	triggerCtx := workflowTriggerContext{Event: trigger}
 
 	err := pc.createFlowInstance(context.Background(), triggerCtx, handlerExecutionPlan{
@@ -143,15 +176,25 @@ func TestCreateFlowInstanceResolvesConfigFromHandlerEventContext(t *testing.T) {
 			return nil
 		},
 	}
-	trigger := eventtest.WithEnvelope((eventtest.Projection("evt-123",
-		events.EventType("spawn.requested"), "", "", []byte(`{"entity_id":"ent-1","instance_id":"inst-42","name":"alpha"}`), 0, "", "source-evt-1", events.EventEnvelope{}, time.Time{})), events.EventEnvelope{
-		EntityID: "ent-1",
-		Source: events.RouteIdentity{
-			FlowID:       "parent-flow",
-			FlowInstance: "parent-flow/source-1",
-			EntityID:     "ent-parent",
+	trigger := eventtest.RootIngress(
+		"evt-123",
+		events.EventType("spawn.requested"),
+		"",
+		"",
+		[]byte(`{"entity_id":"ent-1","instance_id":"inst-42","name":"alpha"}`),
+		0,
+		"",
+		"source-evt-1",
+		events.EventEnvelope{
+			EntityID: "ent-1",
+			Source: events.RouteIdentity{
+				FlowID:       "parent-flow",
+				FlowInstance: "parent-flow/source-1",
+				EntityID:     "ent-parent",
+			},
 		},
-	})
+		time.Time{},
+	)
 
 	triggerCtx := workflowTriggerContext{Event: trigger}
 
@@ -194,8 +237,18 @@ func TestCreateFlowInstanceRejectsUnknownEventConfigRef(t *testing.T) {
 			return nil
 		},
 	}
-	trigger := eventtest.WithEntityID((eventtest.Projection("evt-123",
-		events.EventType("spawn.requested"), "", "", []byte(`{"entity_id":"ent-1","instance_id":"inst-42"}`), 0, "", "", events.EventEnvelope{}, time.Time{})), "ent-1")
+	trigger := eventtest.RootIngress(
+		"evt-123",
+		events.EventType("spawn.requested"),
+		"",
+		"",
+		[]byte(`{"entity_id":"ent-1","instance_id":"inst-42"}`),
+		0,
+		"",
+		"",
+		events.EnvelopeForEntityID(events.EventEnvelope{}, "ent-1"),
+		time.Time{},
+	)
 
 	triggerCtx := workflowTriggerContext{Event: trigger}
 
@@ -227,8 +280,18 @@ func TestCreateFlowInstanceRejectsUnsupportedConfigRefRoot(t *testing.T) {
 			return nil
 		},
 	}
-	trigger := eventtest.WithEntityID((eventtest.Projection("evt-123",
-		events.EventType("spawn.requested"), "", "", []byte(`{"entity_id":"ent-1","instance_id":"inst-42"}`), 0, "", "", events.EventEnvelope{}, time.Time{})), "ent-1")
+	trigger := eventtest.RootIngress(
+		"evt-123",
+		events.EventType("spawn.requested"),
+		"",
+		"",
+		[]byte(`{"entity_id":"ent-1","instance_id":"inst-42"}`),
+		0,
+		"",
+		"",
+		events.EnvelopeForEntityID(events.EventEnvelope{}, "ent-1"),
+		time.Time{},
+	)
 
 	triggerCtx := workflowTriggerContext{Event: trigger}
 
@@ -260,8 +323,18 @@ func TestCreateFlowInstanceDoesNotResolveInstanceIDFromEventRef(t *testing.T) {
 			return nil
 		},
 	}
-	trigger := eventtest.WithEntityID((eventtest.Projection("evt-123",
-		events.EventType("spawn.requested"), "", "", []byte(`{"entity_id":"ent-1","name":"alpha"}`), 0, "", "", events.EventEnvelope{}, time.Time{})), "ent-1")
+	trigger := eventtest.RootIngress(
+		"evt-123",
+		events.EventType("spawn.requested"),
+		"",
+		"",
+		[]byte(`{"entity_id":"ent-1","name":"alpha"}`),
+		0,
+		"",
+		"",
+		events.EnvelopeForEntityID(events.EventEnvelope{}, "ent-1"),
+		time.Time{},
+	)
 
 	triggerCtx := workflowTriggerContext{Event: trigger}
 
@@ -287,7 +360,18 @@ func TestCreateFlowInstanceRejectsMissingRequiredSiblingFields(t *testing.T) {
 			return nil
 		},
 	}
-	trigger := eventtest.WithEntityID((eventtest.Projection("", events.EventType("spawn.requested"), "", "", []byte(`{"entity_id":"ent-1","instance_id":"inst-42","name":"alpha"}`), 0, "", "", events.EventEnvelope{}, time.Time{})), "ent-1")
+	trigger := eventtest.RootIngress(
+		"",
+		events.EventType("spawn.requested"),
+		"",
+		"",
+		[]byte(`{"entity_id":"ent-1","instance_id":"inst-42","name":"alpha"}`),
+		0,
+		"",
+		"",
+		events.EnvelopeForEntityID(events.EventEnvelope{}, "ent-1"),
+		time.Time{},
+	)
 	triggerCtx := workflowTriggerContext{Event: trigger}
 
 	err := pc.createFlowInstance(context.Background(), triggerCtx, handlerExecutionPlan{
@@ -305,7 +389,18 @@ func TestCreateFlowInstanceRejectsGeneratedFallbackWithoutInstanceIDFrom(t *test
 			return nil
 		},
 	}
-	trigger := eventtest.WithEntityID((eventtest.Projection("", events.EventType("spawn.requested"), "", "", []byte(`{"entity_id":"ent-1","instance_id":"inst-42","name":"alpha"}`), 0, "", "", events.EventEnvelope{}, time.Time{})), "ent-1")
+	trigger := eventtest.RootIngress(
+		"",
+		events.EventType("spawn.requested"),
+		"",
+		"",
+		[]byte(`{"entity_id":"ent-1","instance_id":"inst-42","name":"alpha"}`),
+		0,
+		"",
+		"",
+		events.EnvelopeForEntityID(events.EventEnvelope{}, "ent-1"),
+		time.Time{},
+	)
 	triggerCtx := workflowTriggerContext{Event: trigger}
 
 	err := pc.createFlowInstance(context.Background(), triggerCtx, handlerExecutionPlan{
@@ -328,7 +423,18 @@ func TestCreateFlowInstanceRejectsEmptyConfigFromBindings(t *testing.T) {
 			return nil
 		},
 	}
-	trigger := eventtest.WithEntityID((eventtest.Projection("", events.EventType("spawn.requested"), "", "", []byte(`{"entity_id":"ent-1","desired_instance_id":"inst-42"}`), 0, "", "", events.EventEnvelope{}, time.Time{})), "ent-1")
+	trigger := eventtest.RootIngress(
+		"",
+		events.EventType("spawn.requested"),
+		"",
+		"",
+		[]byte(`{"entity_id":"ent-1","desired_instance_id":"inst-42"}`),
+		0,
+		"",
+		"",
+		events.EnvelopeForEntityID(events.EventEnvelope{}, "ent-1"),
+		time.Time{},
+	)
 	triggerCtx := workflowTriggerContext{Event: trigger}
 
 	err := pc.createFlowInstance(context.Background(), triggerCtx, handlerExecutionPlan{
@@ -351,7 +457,18 @@ func TestCreateFlowInstanceRejectsEmptyResolvedConfig(t *testing.T) {
 			return nil
 		},
 	}
-	trigger := eventtest.WithEntityID((eventtest.Projection("", events.EventType("spawn.requested"), "", "", []byte(`{"entity_id":"ent-1","desired_instance_id":"inst-42"}`), 0, "", "", events.EventEnvelope{}, time.Time{})), "ent-1")
+	trigger := eventtest.RootIngress(
+		"",
+		events.EventType("spawn.requested"),
+		"",
+		"",
+		[]byte(`{"entity_id":"ent-1","desired_instance_id":"inst-42"}`),
+		0,
+		"",
+		"",
+		events.EnvelopeForEntityID(events.EventEnvelope{}, "ent-1"),
+		time.Time{},
+	)
 	triggerCtx := workflowTriggerContext{Event: trigger}
 
 	err := pc.createFlowInstance(context.Background(), triggerCtx, handlerExecutionPlan{
@@ -377,8 +494,18 @@ func TestHandlerEmitEnvelope_KeepsLocalEntityAcrossOutputBoundaries(t *testing.T
 	}
 	pc := &PipelineCoordinator{module: module}
 	trigger := workflowTriggerContext{
-		Event: eventtest.WithEntityID(eventtest.Projection("", events.EventType("child/child.start"), "", "", []byte(`{"entity_id":"ent-child"}`), 0, "", "", events.EventEnvelope{}, time.Time{}),
-			"ent-child"),
+		Event: eventtest.RootIngress(
+			"",
+			events.EventType("child/child.start"),
+			"",
+			"",
+			[]byte(`{"entity_id":"ent-child"}`),
+			0,
+			"",
+			"",
+			events.EnvelopeForEntityID(events.EventEnvelope{}, "ent-child"),
+			time.Time{},
+		),
 
 		State: WorkflowState{
 			EntityID: "ent-child",
@@ -434,8 +561,18 @@ pins:
 	})
 	pc := &PipelineCoordinator{module: staticSemanticWorkflowModule{source: source}}
 	trigger := workflowTriggerContext{
-		Event: eventtest.WithEntityID(eventtest.Projection("", events.EventType("vertical.discovered"), "", "", []byte(`{"entity_id":"ent-root"}`), 0, "", "", events.EventEnvelope{}, time.Time{}),
-			"ent-root"),
+		Event: eventtest.RootIngress(
+			"",
+			events.EventType("vertical.discovered"),
+			"",
+			"",
+			[]byte(`{"entity_id":"ent-root"}`),
+			0,
+			"",
+			"",
+			events.EnvelopeForEntityID(events.EventEnvelope{}, "ent-root"),
+			time.Time{},
+		),
 
 		State: WorkflowState{
 			EntityID: "ent-child",
@@ -482,9 +619,18 @@ opco.ceo_ready:
       emit: opco.ceo_ready
 `,
 	})
-	evt := eventtest.WithFlowInstance(eventtest.WithEntityID((eventtest.Projection(uuid.NewString(),
-		events.EventType("operating/inst-1/opco.product_initialization_requested"), "", "", []byte(`{"entity_id":"ent-operating"}`), 0, "", "", events.EventEnvelope{}, time.Time{})), "ent-operating"),
-		"operating/inst-1")
+	evt := eventtest.RootIngress(
+		uuid.NewString(),
+		events.EventType("operating/inst-1/opco.product_initialization_requested"),
+		"",
+		"",
+		[]byte(`{"entity_id":"ent-operating"}`),
+		0,
+		"",
+		"",
+		events.EnvelopeForFlowInstance(events.EnvelopeForEntityID(events.EventEnvelope{}, "ent-operating"), "operating/inst-1"),
+		time.Time{},
+	)
 
 	if _, ok := source.NodeEventHandler("lifecycle-orchestrator", string(evt.Type())); ok {
 		t.Fatal("raw bundle handler lookup unexpectedly matched concrete instance event without delivery localization")
@@ -553,10 +699,18 @@ states: [initializing, ready]
 `,
 	})
 	const entityID = "11111111-1111-1111-1111-111111111111"
-	evt := eventtest.WithFlowInstance(eventtest.WithEntityID(eventtest.Projection(uuid.NewString(),
-		events.EventType("operating/inst-1/build_progress"), "", "", mustJSON(map[string]any{"entity_id": entityID, "summary": "compile complete"}), 0, "", "", events.EventEnvelope{}, time.Time{}),
-		entityID),
-		"operating/inst-1")
+	evt := eventtest.RootIngress(
+		uuid.NewString(),
+		events.EventType("operating/inst-1/build_progress"),
+		"",
+		"",
+		mustJSON(map[string]any{"entity_id": entityID, "summary": "compile complete"}),
+		0,
+		"",
+		"",
+		events.EnvelopeForFlowInstance(events.EnvelopeForEntityID(events.EventEnvelope{}, entityID), "operating/inst-1"),
+		time.Time{},
+	)
 
 	if _, ok := source.NodeEventHandler("build-orchestrator", string(evt.Type())); ok {
 		t.Fatal("raw bundle handler lookup unexpectedly matched concrete instance event without delivery localization")

--- a/internal/runtime/pipeline/workflow_instance_activation_test.go
+++ b/internal/runtime/pipeline/workflow_instance_activation_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/division-sh/swarm/internal/events"
+	"github.com/division-sh/swarm/internal/events/eventtest"
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
 	"github.com/division-sh/swarm/internal/runtime/core/paths"
 	"github.com/division-sh/swarm/internal/runtime/core/values"
@@ -35,7 +36,7 @@ func TestCreateFlowInstanceResolvesInstanceIDFromPayloadPath(t *testing.T) {
 			return nil
 		},
 	}
-	trigger := (events.NewProjectionEvent("", events.EventType("custom.triggered"), "", "", []byte(`{"entity_id":"ent-1","desired_instance_id":"inst-42","name":"alpha"}`), 0, "", "", events.EventEnvelope{}, time.Time{})).WithEntityID("ent-1")
+	trigger := eventtest.WithEntityID((eventtest.Projection("", events.EventType("custom.triggered"), "", "", []byte(`{"entity_id":"ent-1","desired_instance_id":"inst-42","name":"alpha"}`), 0, "", "", events.EventEnvelope{}, time.Time{})), "ent-1")
 	triggerCtx := workflowTriggerContext{Event: trigger}
 
 	ok := pc.createFlowInstance(context.Background(), triggerCtx, handlerExecutionPlan{
@@ -70,7 +71,7 @@ func TestCreateFlowInstanceResolvesConfigFromBindings(t *testing.T) {
 			return nil
 		},
 	}
-	trigger := (events.NewProjectionEvent("", events.EventType("spawn.requested"), "", "", []byte(`{"entity_id":"ent-1","instance_id":"inst-42","name":"alpha","priority":1}`), 0, "", "", events.EventEnvelope{}, time.Time{})).WithEntityID("ent-1")
+	trigger := eventtest.WithEntityID((eventtest.Projection("", events.EventType("spawn.requested"), "", "", []byte(`{"entity_id":"ent-1","instance_id":"inst-42","name":"alpha","priority":1}`), 0, "", "", events.EventEnvelope{}, time.Time{})), "ent-1")
 	triggerCtx := workflowTriggerContext{Event: trigger}
 
 	err := pc.createFlowInstance(context.Background(), triggerCtx, handlerExecutionPlan{
@@ -106,7 +107,7 @@ func TestCreateFlowInstancePreservesNullConfigFromValues(t *testing.T) {
 			return nil
 		},
 	}
-	trigger := (events.NewProjectionEvent("", events.EventType("spawn.requested"), "", "", []byte(`{"entity_id":"ent-1","instance_id":"inst-42","optional_setting":null}`), 0, "", "", events.EventEnvelope{}, time.Time{})).WithEntityID("ent-1")
+	trigger := eventtest.WithEntityID((eventtest.Projection("", events.EventType("spawn.requested"), "", "", []byte(`{"entity_id":"ent-1","instance_id":"inst-42","optional_setting":null}`), 0, "", "", events.EventEnvelope{}, time.Time{})), "ent-1")
 	triggerCtx := workflowTriggerContext{Event: trigger}
 
 	err := pc.createFlowInstance(context.Background(), triggerCtx, handlerExecutionPlan{
@@ -142,8 +143,8 @@ func TestCreateFlowInstanceResolvesConfigFromHandlerEventContext(t *testing.T) {
 			return nil
 		},
 	}
-	trigger := (events.NewProjectionEvent("evt-123",
-		events.EventType("spawn.requested"), "", "", []byte(`{"entity_id":"ent-1","instance_id":"inst-42","name":"alpha"}`), 0, "", "source-evt-1", events.EventEnvelope{}, time.Time{})).WithEnvelope(events.EventEnvelope{
+	trigger := eventtest.WithEnvelope((eventtest.Projection("evt-123",
+		events.EventType("spawn.requested"), "", "", []byte(`{"entity_id":"ent-1","instance_id":"inst-42","name":"alpha"}`), 0, "", "source-evt-1", events.EventEnvelope{}, time.Time{})), events.EventEnvelope{
 		EntityID: "ent-1",
 		Source: events.RouteIdentity{
 			FlowID:       "parent-flow",
@@ -151,6 +152,7 @@ func TestCreateFlowInstanceResolvesConfigFromHandlerEventContext(t *testing.T) {
 			EntityID:     "ent-parent",
 		},
 	})
+
 	triggerCtx := workflowTriggerContext{Event: trigger}
 
 	err := pc.createFlowInstance(context.Background(), triggerCtx, handlerExecutionPlan{
@@ -192,8 +194,9 @@ func TestCreateFlowInstanceRejectsUnknownEventConfigRef(t *testing.T) {
 			return nil
 		},
 	}
-	trigger := (events.NewProjectionEvent("evt-123",
-		events.EventType("spawn.requested"), "", "", []byte(`{"entity_id":"ent-1","instance_id":"inst-42"}`), 0, "", "", events.EventEnvelope{}, time.Time{})).WithEntityID("ent-1")
+	trigger := eventtest.WithEntityID((eventtest.Projection("evt-123",
+		events.EventType("spawn.requested"), "", "", []byte(`{"entity_id":"ent-1","instance_id":"inst-42"}`), 0, "", "", events.EventEnvelope{}, time.Time{})), "ent-1")
+
 	triggerCtx := workflowTriggerContext{Event: trigger}
 
 	err := pc.createFlowInstance(context.Background(), triggerCtx, handlerExecutionPlan{
@@ -224,8 +227,9 @@ func TestCreateFlowInstanceRejectsUnsupportedConfigRefRoot(t *testing.T) {
 			return nil
 		},
 	}
-	trigger := (events.NewProjectionEvent("evt-123",
-		events.EventType("spawn.requested"), "", "", []byte(`{"entity_id":"ent-1","instance_id":"inst-42"}`), 0, "", "", events.EventEnvelope{}, time.Time{})).WithEntityID("ent-1")
+	trigger := eventtest.WithEntityID((eventtest.Projection("evt-123",
+		events.EventType("spawn.requested"), "", "", []byte(`{"entity_id":"ent-1","instance_id":"inst-42"}`), 0, "", "", events.EventEnvelope{}, time.Time{})), "ent-1")
+
 	triggerCtx := workflowTriggerContext{Event: trigger}
 
 	err := pc.createFlowInstance(context.Background(), triggerCtx, handlerExecutionPlan{
@@ -256,8 +260,9 @@ func TestCreateFlowInstanceDoesNotResolveInstanceIDFromEventRef(t *testing.T) {
 			return nil
 		},
 	}
-	trigger := (events.NewProjectionEvent("evt-123",
-		events.EventType("spawn.requested"), "", "", []byte(`{"entity_id":"ent-1","name":"alpha"}`), 0, "", "", events.EventEnvelope{}, time.Time{})).WithEntityID("ent-1")
+	trigger := eventtest.WithEntityID((eventtest.Projection("evt-123",
+		events.EventType("spawn.requested"), "", "", []byte(`{"entity_id":"ent-1","name":"alpha"}`), 0, "", "", events.EventEnvelope{}, time.Time{})), "ent-1")
+
 	triggerCtx := workflowTriggerContext{Event: trigger}
 
 	err := pc.createFlowInstance(context.Background(), triggerCtx, handlerExecutionPlan{
@@ -282,7 +287,7 @@ func TestCreateFlowInstanceRejectsMissingRequiredSiblingFields(t *testing.T) {
 			return nil
 		},
 	}
-	trigger := (events.NewProjectionEvent("", events.EventType("spawn.requested"), "", "", []byte(`{"entity_id":"ent-1","instance_id":"inst-42","name":"alpha"}`), 0, "", "", events.EventEnvelope{}, time.Time{})).WithEntityID("ent-1")
+	trigger := eventtest.WithEntityID((eventtest.Projection("", events.EventType("spawn.requested"), "", "", []byte(`{"entity_id":"ent-1","instance_id":"inst-42","name":"alpha"}`), 0, "", "", events.EventEnvelope{}, time.Time{})), "ent-1")
 	triggerCtx := workflowTriggerContext{Event: trigger}
 
 	err := pc.createFlowInstance(context.Background(), triggerCtx, handlerExecutionPlan{
@@ -300,7 +305,7 @@ func TestCreateFlowInstanceRejectsGeneratedFallbackWithoutInstanceIDFrom(t *test
 			return nil
 		},
 	}
-	trigger := (events.NewProjectionEvent("", events.EventType("spawn.requested"), "", "", []byte(`{"entity_id":"ent-1","instance_id":"inst-42","name":"alpha"}`), 0, "", "", events.EventEnvelope{}, time.Time{})).WithEntityID("ent-1")
+	trigger := eventtest.WithEntityID((eventtest.Projection("", events.EventType("spawn.requested"), "", "", []byte(`{"entity_id":"ent-1","instance_id":"inst-42","name":"alpha"}`), 0, "", "", events.EventEnvelope{}, time.Time{})), "ent-1")
 	triggerCtx := workflowTriggerContext{Event: trigger}
 
 	err := pc.createFlowInstance(context.Background(), triggerCtx, handlerExecutionPlan{
@@ -323,7 +328,7 @@ func TestCreateFlowInstanceRejectsEmptyConfigFromBindings(t *testing.T) {
 			return nil
 		},
 	}
-	trigger := (events.NewProjectionEvent("", events.EventType("spawn.requested"), "", "", []byte(`{"entity_id":"ent-1","desired_instance_id":"inst-42"}`), 0, "", "", events.EventEnvelope{}, time.Time{})).WithEntityID("ent-1")
+	trigger := eventtest.WithEntityID((eventtest.Projection("", events.EventType("spawn.requested"), "", "", []byte(`{"entity_id":"ent-1","desired_instance_id":"inst-42"}`), 0, "", "", events.EventEnvelope{}, time.Time{})), "ent-1")
 	triggerCtx := workflowTriggerContext{Event: trigger}
 
 	err := pc.createFlowInstance(context.Background(), triggerCtx, handlerExecutionPlan{
@@ -346,7 +351,7 @@ func TestCreateFlowInstanceRejectsEmptyResolvedConfig(t *testing.T) {
 			return nil
 		},
 	}
-	trigger := (events.NewProjectionEvent("", events.EventType("spawn.requested"), "", "", []byte(`{"entity_id":"ent-1","desired_instance_id":"inst-42"}`), 0, "", "", events.EventEnvelope{}, time.Time{})).WithEntityID("ent-1")
+	trigger := eventtest.WithEntityID((eventtest.Projection("", events.EventType("spawn.requested"), "", "", []byte(`{"entity_id":"ent-1","desired_instance_id":"inst-42"}`), 0, "", "", events.EventEnvelope{}, time.Time{})), "ent-1")
 	triggerCtx := workflowTriggerContext{Event: trigger}
 
 	err := pc.createFlowInstance(context.Background(), triggerCtx, handlerExecutionPlan{
@@ -372,8 +377,9 @@ func TestHandlerEmitEnvelope_KeepsLocalEntityAcrossOutputBoundaries(t *testing.T
 	}
 	pc := &PipelineCoordinator{module: module}
 	trigger := workflowTriggerContext{
-		Event: events.NewProjectionEvent("", events.EventType("child/child.start"), "", "", []byte(`{"entity_id":"ent-child"}`), 0, "", "", events.EventEnvelope{}, time.Time{}).
-			WithEntityID("ent-child"),
+		Event: eventtest.WithEntityID(eventtest.Projection("", events.EventType("child/child.start"), "", "", []byte(`{"entity_id":"ent-child"}`), 0, "", "", events.EventEnvelope{}, time.Time{}),
+			"ent-child"),
+
 		State: WorkflowState{
 			EntityID: "ent-child",
 			Metadata: map[string]any{
@@ -428,8 +434,9 @@ pins:
 	})
 	pc := &PipelineCoordinator{module: staticSemanticWorkflowModule{source: source}}
 	trigger := workflowTriggerContext{
-		Event: events.NewProjectionEvent("", events.EventType("vertical.discovered"), "", "", []byte(`{"entity_id":"ent-root"}`), 0, "", "", events.EventEnvelope{}, time.Time{}).
-			WithEntityID("ent-root"),
+		Event: eventtest.WithEntityID(eventtest.Projection("", events.EventType("vertical.discovered"), "", "", []byte(`{"entity_id":"ent-root"}`), 0, "", "", events.EventEnvelope{}, time.Time{}),
+			"ent-root"),
+
 		State: WorkflowState{
 			EntityID: "ent-child",
 			Metadata: map[string]any{
@@ -475,8 +482,10 @@ opco.ceo_ready:
       emit: opco.ceo_ready
 `,
 	})
-	evt := (events.NewProjectionEvent(uuid.NewString(),
-		events.EventType("operating/inst-1/opco.product_initialization_requested"), "", "", []byte(`{"entity_id":"ent-operating"}`), 0, "", "", events.EventEnvelope{}, time.Time{})).WithEntityID("ent-operating").WithFlowInstance("operating/inst-1")
+	evt := eventtest.WithFlowInstance(eventtest.WithEntityID((eventtest.Projection(uuid.NewString(),
+		events.EventType("operating/inst-1/opco.product_initialization_requested"), "", "", []byte(`{"entity_id":"ent-operating"}`), 0, "", "", events.EventEnvelope{}, time.Time{})), "ent-operating"),
+		"operating/inst-1")
+
 	if _, ok := source.NodeEventHandler("lifecycle-orchestrator", string(evt.Type())); ok {
 		t.Fatal("raw bundle handler lookup unexpectedly matched concrete instance event without delivery localization")
 	}
@@ -544,10 +553,11 @@ states: [initializing, ready]
 `,
 	})
 	const entityID = "11111111-1111-1111-1111-111111111111"
-	evt := events.NewProjectionEvent(uuid.NewString(),
-		events.EventType("operating/inst-1/build_progress"), "", "", mustJSON(map[string]any{"entity_id": entityID, "summary": "compile complete"}), 0, "", "", events.EventEnvelope{}, time.Time{}).
-		WithEntityID(entityID).
-		WithFlowInstance("operating/inst-1")
+	evt := eventtest.WithFlowInstance(eventtest.WithEntityID(eventtest.Projection(uuid.NewString(),
+		events.EventType("operating/inst-1/build_progress"), "", "", mustJSON(map[string]any{"entity_id": entityID, "summary": "compile complete"}), 0, "", "", events.EventEnvelope{}, time.Time{}),
+		entityID),
+		"operating/inst-1")
+
 	if _, ok := source.NodeEventHandler("build-orchestrator", string(evt.Type())); ok {
 		t.Fatal("raw bundle handler lookup unexpectedly matched concrete instance event without delivery localization")
 	}

--- a/internal/runtime/pipeline/workflow_node_delivery_authority_test.go
+++ b/internal/runtime/pipeline/workflow_node_delivery_authority_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/division-sh/swarm/internal/events"
+	"github.com/division-sh/swarm/internal/events/eventtest"
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
 	"github.com/division-sh/swarm/internal/testutil"
 	"github.com/google/uuid"
@@ -217,10 +218,11 @@ func newDeliveryAuthorityCoordinatorWithReceipts(t *testing.T, db *sql.DB, recei
 func seedDeliveryAuthorityEvent(t *testing.T, db *sql.DB, ctx context.Context) events.Event {
 	t.Helper()
 	entityID := uuid.NewString()
-	evt := (events.NewProjectionEvent(uuid.NewString(),
+	evt := eventtest.WithEntityID((eventtest.Projection(uuid.NewString(),
 
 		events.EventType("source.evt"),
-		"src", "", []byte(`{"entity_id":"`+entityID+`"}`), 0, testPipelineRunID, "", events.EventEnvelope{}, time.Now().UTC())).WithEntityID(entityID)
+		"src", "", []byte(`{"entity_id":"`+entityID+`"}`), 0, testPipelineRunID, "", events.EventEnvelope{}, time.Now().UTC())), entityID)
+
 	if _, err := db.ExecContext(ctx, `
 		INSERT INTO events (
 			event_id, run_id, event_name, entity_id, flow_instance, scope, payload,

--- a/internal/runtime/pipeline/workflow_node_delivery_authority_test.go
+++ b/internal/runtime/pipeline/workflow_node_delivery_authority_test.go
@@ -218,10 +218,18 @@ func newDeliveryAuthorityCoordinatorWithReceipts(t *testing.T, db *sql.DB, recei
 func seedDeliveryAuthorityEvent(t *testing.T, db *sql.DB, ctx context.Context) events.Event {
 	t.Helper()
 	entityID := uuid.NewString()
-	evt := eventtest.WithEntityID((eventtest.Projection(uuid.NewString(),
-
+	evt := eventtest.RootIngress(
+		uuid.NewString(),
 		events.EventType("source.evt"),
-		"src", "", []byte(`{"entity_id":"`+entityID+`"}`), 0, testPipelineRunID, "", events.EventEnvelope{}, time.Now().UTC())), entityID)
+		"src",
+		"",
+		[]byte(`{"entity_id":"`+entityID+`"}`),
+		0,
+		testPipelineRunID,
+		"",
+		events.EnvelopeForEntityID(events.EventEnvelope{}, entityID),
+		time.Now().UTC(),
+	)
 
 	if _, err := db.ExecContext(ctx, `
 		INSERT INTO events (

--- a/internal/runtime/pipeline/workflow_nodes_test.go
+++ b/internal/runtime/pipeline/workflow_nodes_test.go
@@ -263,7 +263,7 @@ func TestLoadWorkflowNodes_UsesImportBoundaryOutputAliasForWildcardParentSubscri
 
 func TestWorkflowNodeHandlerResolution_DeniesImportBoundaryWildcardRawFallback(t *testing.T) {
 	source := loadPipelineImportBoundaryWildcardSource(t, "")
-	evt := events.NewProjectionEvent("", "producer/task.done", "", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Unix(1, 0).UTC())
+	evt := eventtest.RootIngress("", "producer/task.done", "", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Unix(1, 0).UTC())
 	resolved := workflowNodeEventHandlerResolutionForDelivery(source, "worker-listener", evt)
 	if resolved.Matched {
 		t.Fatalf("worker-listener matched ungranted sibling event through raw wildcard fallback: %#v", resolved)
@@ -275,7 +275,7 @@ func TestWorkflowNodeHandlerResolution_DeniesImportBoundaryWildcardRawFallback(t
 
 func TestWorkflowNodeHandlerResolution_AllowsGrantedImportBoundaryWildcard(t *testing.T) {
 	source := loadPipelineImportBoundaryWildcardSource(t, "      observe:\n        - source: producer\n          events: [task.done]\n")
-	evt := events.NewProjectionEvent("", "producer/task.done", "", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Unix(1, 0).UTC())
+	evt := eventtest.RootIngress("", "producer/task.done", "", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Unix(1, 0).UTC())
 	resolved := workflowNodeEventHandlerResolutionForDelivery(source, "worker-listener", evt)
 	if !resolved.Matched {
 		t.Fatal("worker-listener did not match granted sibling event")

--- a/internal/runtime/pipeline/workflow_nodes_test.go
+++ b/internal/runtime/pipeline/workflow_nodes_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/division-sh/swarm/internal/events"
+	"github.com/division-sh/swarm/internal/events/eventtest"
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
 	"github.com/division-sh/swarm/internal/runtime/flowmodel"
 	"github.com/division-sh/swarm/internal/runtime/semanticview"
@@ -204,7 +205,7 @@ func TestLoadWorkflowNodes_UsesImportBoundaryInputAlias(t *testing.T) {
 	if workflowNodeHasSubscriptionForTest(*worker, "work.requested") || workflowNodeHasSubscriptionForTest(*worker, "worker/work.requested") {
 		t.Fatalf("worker-node subscriptions = %#v, should not preserve raw required-import input fallback", worker.Subscriptions)
 	}
-	evt := events.NewProjectionEvent("", "parent.lead_captured", "", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Unix(1, 0).UTC())
+	evt := eventtest.Projection("", "parent.lead_captured", "", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Unix(1, 0).UTC())
 	resolved := workflowNodeEventHandlerResolutionForDelivery(source, "worker-node", evt)
 	if !resolved.Matched {
 		t.Fatal("expected worker-node handler to resolve through input alias")
@@ -227,7 +228,7 @@ func TestLoadWorkflowNodes_UsesImportBoundaryOutputAliasForParentHandler(t *test
 	if !workflowNodeHasSubscriptionForTest(*parent, "worker/work.completed") {
 		t.Fatalf("parent-listener subscriptions = %#v, want worker/work.completed output alias", parent.Subscriptions)
 	}
-	evt := events.NewProjectionEvent("", "worker/work.completed", "", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Unix(1, 0).UTC())
+	evt := eventtest.Projection("", "worker/work.completed", "", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Unix(1, 0).UTC())
 	resolved := workflowNodeEventHandlerResolutionForDelivery(source, "parent-listener", evt)
 	if !resolved.Matched {
 		t.Fatal("expected parent-listener handler to resolve through output alias")
@@ -250,7 +251,7 @@ func TestLoadWorkflowNodes_UsesImportBoundaryOutputAliasForWildcardParentSubscri
 	if !workflowNodeHasSubscriptionForTest(*parent, "worker/work.completed") {
 		t.Fatalf("parent-listener subscriptions = %#v, want worker/work.completed output alias for wildcard parent subscription", parent.Subscriptions)
 	}
-	evt := events.NewProjectionEvent("", "worker/work.completed", "", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Unix(1, 0).UTC())
+	evt := eventtest.Projection("", "worker/work.completed", "", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Unix(1, 0).UTC())
 	resolved := workflowNodeEventHandlerResolutionForDelivery(source, "parent-listener", evt)
 	if !resolved.Matched {
 		t.Fatal("expected parent-listener handler to resolve through output alias")

--- a/internal/runtime/pipeline/workflow_nodes_test.go
+++ b/internal/runtime/pipeline/workflow_nodes_test.go
@@ -205,7 +205,7 @@ func TestLoadWorkflowNodes_UsesImportBoundaryInputAlias(t *testing.T) {
 	if workflowNodeHasSubscriptionForTest(*worker, "work.requested") || workflowNodeHasSubscriptionForTest(*worker, "worker/work.requested") {
 		t.Fatalf("worker-node subscriptions = %#v, should not preserve raw required-import input fallback", worker.Subscriptions)
 	}
-	evt := eventtest.Projection("", "parent.lead_captured", "", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Unix(1, 0).UTC())
+	evt := eventtest.RootIngress("", "parent.lead_captured", "", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Unix(1, 0).UTC())
 	resolved := workflowNodeEventHandlerResolutionForDelivery(source, "worker-node", evt)
 	if !resolved.Matched {
 		t.Fatal("expected worker-node handler to resolve through input alias")
@@ -228,7 +228,7 @@ func TestLoadWorkflowNodes_UsesImportBoundaryOutputAliasForParentHandler(t *test
 	if !workflowNodeHasSubscriptionForTest(*parent, "worker/work.completed") {
 		t.Fatalf("parent-listener subscriptions = %#v, want worker/work.completed output alias", parent.Subscriptions)
 	}
-	evt := eventtest.Projection("", "worker/work.completed", "", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Unix(1, 0).UTC())
+	evt := eventtest.RootIngress("", "worker/work.completed", "", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Unix(1, 0).UTC())
 	resolved := workflowNodeEventHandlerResolutionForDelivery(source, "parent-listener", evt)
 	if !resolved.Matched {
 		t.Fatal("expected parent-listener handler to resolve through output alias")
@@ -251,7 +251,7 @@ func TestLoadWorkflowNodes_UsesImportBoundaryOutputAliasForWildcardParentSubscri
 	if !workflowNodeHasSubscriptionForTest(*parent, "worker/work.completed") {
 		t.Fatalf("parent-listener subscriptions = %#v, want worker/work.completed output alias for wildcard parent subscription", parent.Subscriptions)
 	}
-	evt := eventtest.Projection("", "worker/work.completed", "", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Unix(1, 0).UTC())
+	evt := eventtest.RootIngress("", "worker/work.completed", "", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Unix(1, 0).UTC())
 	resolved := workflowNodeEventHandlerResolutionForDelivery(source, "parent-listener", evt)
 	if !resolved.Matched {
 		t.Fatal("expected parent-listener handler to resolve through output alias")

--- a/internal/runtime/pipeline/workflow_timer_lifecycle_test.go
+++ b/internal/runtime/pipeline/workflow_timer_lifecycle_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/division-sh/swarm/internal/events"
+	"github.com/division-sh/swarm/internal/events/eventtest"
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
 	"github.com/division-sh/swarm/internal/runtime/core/timeridentity"
 	"github.com/division-sh/swarm/internal/runtime/semanticview"
@@ -131,10 +132,11 @@ func TestExecuteNodeHandlerPlan_EventTimerStartOnRegistersSchedule(t *testing.T)
 		t.Fatalf("seed workflow instance: %v", err)
 	}
 
-	evt := events.NewProjectionEvent(uuid.NewString(),
+	evt := eventtest.WithEntityID(eventtest.Projection(uuid.NewString(),
 		events.EventType("timer.scheduled"),
-		"cataloge2e", "", []byte(`{"entity_id":"ent-001"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC()).
-		WithEntityID("ent-001")
+		"cataloge2e", "", []byte(`{"entity_id":"ent-001"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC()),
+		"ent-001")
+
 	seedPipelineNodeDeliveryAuthority(t, db, evt, "test-node")
 
 	txctx := testActivePipelineSQLTxContext(t, db, ctx)
@@ -194,10 +196,11 @@ func TestPipelineIntercept_EventTimerStartOnRegistersSchedule(t *testing.T) {
 		t.Fatalf("seed workflow instance: %v", err)
 	}
 
-	evt := events.NewProjectionEvent(uuid.NewString(),
+	evt := eventtest.WithEntityID(eventtest.Projection(uuid.NewString(),
 		events.EventType("timer.scheduled"),
-		"cataloge2e", "", []byte(`{"entity_id":"ent-001"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC()).
-		WithEntityID("ent-001")
+		"cataloge2e", "", []byte(`{"entity_id":"ent-001"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC()),
+		"ent-001")
+
 	seedPipelineNodeDeliveryAuthority(t, db, evt, "test-node")
 
 	_, handled := pc.interceptPolicy("timer.scheduled", evt)
@@ -422,10 +425,11 @@ func TestExecuteNodeHandlerPlan_DoesNotRunOtherNodeHandler(t *testing.T) {
 		t.Fatalf("seed workflow instance: %v", err)
 	}
 
-	evt := events.NewProjectionEvent(uuid.NewString(),
+	evt := eventtest.WithEntityID(eventtest.Projection(uuid.NewString(),
 		events.EventType("child/task.done"),
-		"cataloge2e", "", []byte(`{"entity_id":"ent-001"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC()).
-		WithEntityID("ent-001")
+		"cataloge2e", "", []byte(`{"entity_id":"ent-001"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC()),
+		"ent-001")
+
 	seedPipelineNodeDeliveryAuthority(t, db, evt, "listener")
 
 	if handled := pc.executeNodeHandlerPlan(testPipelineCoordinatorRunContext(t, pc), "dispatcher", evt); handled {
@@ -490,10 +494,11 @@ func TestExecuteNodeHandlerPlan_AccumulateTimeoutRegistersSchedule(t *testing.T)
 	}
 
 	start := time.Now().UTC()
-	evt := events.NewProjectionEvent(uuid.NewString(),
+	evt := eventtest.WithEntityID(eventtest.Projection(uuid.NewString(),
 		events.EventType("item.arrived"),
-		"cataloge2e", "", []byte(`{"entity_id":"ent-001","item_id":"a"}`), 0, "", "", events.EventEnvelope{}, start).
-		WithEntityID("ent-001")
+		"cataloge2e", "", []byte(`{"entity_id":"ent-001","item_id":"a"}`), 0, "", "", events.EventEnvelope{}, start),
+		"ent-001")
+
 	seedPipelineNodeDeliveryAuthority(t, db, evt, "test-node")
 
 	txctx := testActivePipelineSQLTxContext(t, db, ctx)
@@ -570,10 +575,11 @@ func TestReconcileAccumulationTimeoutScheduleUsesMatchedHandlerEventKey(t *testi
 			},
 		},
 	}
-	evt := events.NewProjectionEvent("evt-item-a",
+	evt := eventtest.WithFlowInstance(eventtest.WithEntityID(eventtest.Projection("evt-item-a",
 		events.EventType("component-scaffold/a/item.arrived"),
-		"cataloge2e", "", []byte(`{"entity_id":"ent-001","item_id":"a"}`), 0, "", "", events.EventEnvelope{}, start).
-		WithEntityID("ent-001").WithFlowInstance("component-scaffold/a")
+		"cataloge2e", "", []byte(`{"entity_id":"ent-001","item_id":"a"}`), 0, "", "", events.EventEnvelope{}, start),
+		"ent-001"),
+		"component-scaffold/a")
 
 	if err := pc.reconcileAccumulationTimeoutSchedule(context.Background(), "ent-001", "test-node", handler, evt, "item.arrived", stateBuckets, true); err != nil {
 		t.Fatalf("reconcileAccumulationTimeoutSchedule: %v", err)
@@ -634,16 +640,17 @@ func TestExecuteNodeHandlerPlan_AccumulateTimeoutCancelsScheduleOnTimeout(t *tes
 		t.Fatalf("seed workflow instance: %v", err)
 	}
 
-	evt := events.NewProjectionEvent(uuid.NewString(),
+	evt := eventtest.WithEntityID(eventtest.Projection(uuid.NewString(),
 		events.EventType("item.arrived"),
-		"cataloge2e", "", []byte(`{"entity_id":"ent-001","item_id":"a"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC()).
-		WithEntityID("ent-001")
+		"cataloge2e", "", []byte(`{"entity_id":"ent-001","item_id":"a"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC()),
+		"ent-001")
+
 	seedPipelineNodeDeliveryAuthority(t, db, evt, "test-node")
 	if handled := pc.executeNodeHandlerPlan(ctx, "test-node", evt); !handled {
 		t.Fatal("expected item.arrived handler to be handled")
 	}
 
-	timeoutEvt := events.NewProjectionEvent(uuid.NewString(),
+	timeoutEvt := eventtest.WithEntityID(eventtest.Projection(uuid.NewString(),
 		events.EventType("accumulate.timeout"),
 		runtimeWorkflowID, "", mustJSON(map[string]any{
 			"entity_id": "ent-001",
@@ -654,8 +661,9 @@ func TestExecuteNodeHandlerPlan_AccumulateTimeoutCancelsScheduleOnTimeout(t *tes
 					"event_type": "item.arrived",
 				},
 			},
-		}), 0, "", "", events.EventEnvelope{}, time.Now().UTC()).
-		WithEntityID("ent-001")
+		}), 0, "", "", events.EventEnvelope{}, time.Now().UTC()),
+		"ent-001")
+
 	seedPipelineNodeDeliveryAuthority(t, db, timeoutEvt, "test-node")
 	txctx := testActivePipelineSQLTxContext(t, db, ctx)
 	if handled := pc.executeNodeHandlerPlan(txctx, "test-node", timeoutEvt); !handled {
@@ -706,10 +714,11 @@ func TestExecuteNodeHandlerPlan_PreservesRootStateForChildFlowTransitions(t *tes
 		t.Fatalf("seed workflow instance: %v", err)
 	}
 
-	trigger := events.NewProjectionEvent(uuid.NewString(),
+	trigger := eventtest.WithEntityID(eventtest.Projection(uuid.NewString(),
 		events.EventType("work.requested"),
-		"cataloge2e", "", []byte(`{"entity_id":"ent-001"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC()).
-		WithEntityID("ent-001")
+		"cataloge2e", "", []byte(`{"entity_id":"ent-001"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC()),
+		"ent-001")
+
 	seedPipelineNodeDeliveryAuthority(t, db, trigger, "child-worker")
 
 	if handled := pc.executeNodeHandlerPlan(testPipelineCoordinatorRunContext(t, pc), "child-worker", trigger); !handled {
@@ -727,10 +736,11 @@ func TestExecuteNodeHandlerPlan_PreservesRootStateForChildFlowTransitions(t *tes
 	}
 
 	listenerCtx := withPipelineFlowScope(testPipelineCoordinatorRunContext(t, pc), "child")
-	completion := events.NewProjectionEvent(uuid.NewString(),
+	completion := eventtest.WithEntityID(eventtest.Projection(uuid.NewString(),
 		events.EventType("child/work.completed"),
-		"cataloge2e", "", []byte(`{"entity_id":"ent-001"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC()).
-		WithEntityID("ent-001")
+		"cataloge2e", "", []byte(`{"entity_id":"ent-001"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC()),
+		"ent-001")
+
 	seedPipelineNodeDeliveryAuthority(t, db, completion, "parent-listener")
 	handler, ok := pc.SemanticSource().NodeEventHandler("parent-listener", "child/work.completed")
 	if !ok {
@@ -795,10 +805,11 @@ func TestPipelineIntercept_HandlesChildFlowOutputForRootListener(t *testing.T) {
 		t.Fatalf("seed workflow instance: %v", err)
 	}
 
-	completion := events.NewProjectionEvent(uuid.NewString(),
+	completion := eventtest.WithEntityID(eventtest.Projection(uuid.NewString(),
 		events.EventType("child/work.completed"),
-		"cataloge2e", "", []byte(`{"entity_id":"ent-001"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC()).
-		WithEntityID("ent-001")
+		"cataloge2e", "", []byte(`{"entity_id":"ent-001"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC()),
+		"ent-001")
+
 	seedPipelineNodeDeliveryAuthority(t, db, completion, "parent-listener")
 	passThrough, emitted, err := pc.Intercept(testPipelineCoordinatorRunContext(t, pc), completion)
 	if err != nil {
@@ -867,9 +878,10 @@ func TestPipelineCoordinatorIntercept_NestedDescendantCompletionDoesNotEmitChild
 		t.Fatalf("seed grandchild instance: %v", err)
 	}
 
-	completion := (events.NewProjectionEvent(uuid.NewString(),
+	completion := eventtest.WithEntityID((eventtest.Projection(uuid.NewString(),
 		events.EventType("child/grandchild/micro.done"),
-		"cataloge2e", "", []byte(`{"entity_id":"`+grandchildEntityID+`"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())).WithEntityID(grandchildEntityID)
+		"cataloge2e", "", []byte(`{"entity_id":"`+grandchildEntityID+`"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())), grandchildEntityID)
+
 	seedPipelineNodeDeliveryAuthority(t, db, completion, "root-collector")
 	passThrough, emitted, err := pc.Intercept(testPipelineCoordinatorRunContext(t, pc), completion)
 	if err != nil {
@@ -944,13 +956,14 @@ func TestPipelineCoordinatorIntercept_NestedDescendantCompletionAlreadyTargetedT
 	}); err != nil {
 		t.Fatalf("seed child instance: %v", err)
 	}
-	if consume, handled := pc.workflowNodeInterceptPolicy("child/grandchild/micro.done", (events.NewProjectionEvent("", events.EventType("child/grandchild/micro.done"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{})).WithEntityID(childRowID)); !handled {
+	if consume, handled := pc.workflowNodeInterceptPolicy("child/grandchild/micro.done", eventtest.WithEntityID((eventtest.Projection("", events.EventType("child/grandchild/micro.done"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{})), childRowID)); !handled {
 		t.Fatalf("workflowNodeInterceptPolicy handled = %v, consume = %v, want handled", handled, consume)
 	}
 
-	completion := (events.NewProjectionEvent(uuid.NewString(),
+	completion := eventtest.WithEntityID((eventtest.Projection(uuid.NewString(),
 		events.EventType("child/grandchild/micro.done"),
-		"cataloge2e", "", []byte(`{"entity_id":"`+childRowID+`"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())).WithEntityID(childRowID)
+		"cataloge2e", "", []byte(`{"entity_id":"`+childRowID+`"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())), childRowID)
+
 	seedPipelineNodeDeliveryAuthority(t, db, completion, "root-collector")
 	passThrough, emitted, err := pc.Intercept(testPipelineCoordinatorRunContext(t, pc), completion)
 	if err != nil {
@@ -1024,9 +1037,10 @@ func TestPipelineCoordinatorIntercept_NestedDescendantCompletionInsideOuterSQLTx
 	t.Cleanup(func() { _ = tx.Rollback() })
 	ctx := WithPipelineSQLTxContext(testPipelineCoordinatorRunContext(t, pc), tx)
 
-	completion := (events.NewProjectionEvent(uuid.NewString(),
+	completion := eventtest.WithEntityID((eventtest.Projection(uuid.NewString(),
 		events.EventType("child/grandchild/micro.done"),
-		"cataloge2e", "", []byte(`{"entity_id":"`+childRowID+`"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())).WithEntityID(childRowID)
+		"cataloge2e", "", []byte(`{"entity_id":"`+childRowID+`"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())), childRowID)
+
 	seedPipelineNodeDeliveryAuthority(t, db, completion, "root-collector")
 	passThrough, emitted, err := pc.Intercept(ctx, completion)
 	if err != nil {

--- a/internal/runtime/pipeline/workflow_timer_lifecycle_test.go
+++ b/internal/runtime/pipeline/workflow_timer_lifecycle_test.go
@@ -132,10 +132,18 @@ func TestExecuteNodeHandlerPlan_EventTimerStartOnRegistersSchedule(t *testing.T)
 		t.Fatalf("seed workflow instance: %v", err)
 	}
 
-	evt := eventtest.WithEntityID(eventtest.Projection(uuid.NewString(),
+	evt := eventtest.RootIngress(
+		uuid.NewString(),
 		events.EventType("timer.scheduled"),
-		"cataloge2e", "", []byte(`{"entity_id":"ent-001"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC()),
-		"ent-001")
+		"cataloge2e",
+		"",
+		[]byte(`{"entity_id":"ent-001"}`),
+		0,
+		"",
+		"",
+		events.EnvelopeForEntityID(events.EventEnvelope{}, "ent-001"),
+		time.Now().UTC(),
+	)
 
 	seedPipelineNodeDeliveryAuthority(t, db, evt, "test-node")
 
@@ -196,10 +204,18 @@ func TestPipelineIntercept_EventTimerStartOnRegistersSchedule(t *testing.T) {
 		t.Fatalf("seed workflow instance: %v", err)
 	}
 
-	evt := eventtest.WithEntityID(eventtest.Projection(uuid.NewString(),
+	evt := eventtest.RootIngress(
+		uuid.NewString(),
 		events.EventType("timer.scheduled"),
-		"cataloge2e", "", []byte(`{"entity_id":"ent-001"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC()),
-		"ent-001")
+		"cataloge2e",
+		"",
+		[]byte(`{"entity_id":"ent-001"}`),
+		0,
+		"",
+		"",
+		events.EnvelopeForEntityID(events.EventEnvelope{}, "ent-001"),
+		time.Now().UTC(),
+	)
 
 	seedPipelineNodeDeliveryAuthority(t, db, evt, "test-node")
 
@@ -425,10 +441,18 @@ func TestExecuteNodeHandlerPlan_DoesNotRunOtherNodeHandler(t *testing.T) {
 		t.Fatalf("seed workflow instance: %v", err)
 	}
 
-	evt := eventtest.WithEntityID(eventtest.Projection(uuid.NewString(),
+	evt := eventtest.RootIngress(
+		uuid.NewString(),
 		events.EventType("child/task.done"),
-		"cataloge2e", "", []byte(`{"entity_id":"ent-001"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC()),
-		"ent-001")
+		"cataloge2e",
+		"",
+		[]byte(`{"entity_id":"ent-001"}`),
+		0,
+		"",
+		"",
+		events.EnvelopeForEntityID(events.EventEnvelope{}, "ent-001"),
+		time.Now().UTC(),
+	)
 
 	seedPipelineNodeDeliveryAuthority(t, db, evt, "listener")
 
@@ -494,10 +518,18 @@ func TestExecuteNodeHandlerPlan_AccumulateTimeoutRegistersSchedule(t *testing.T)
 	}
 
 	start := time.Now().UTC()
-	evt := eventtest.WithEntityID(eventtest.Projection(uuid.NewString(),
+	evt := eventtest.RootIngress(
+		uuid.NewString(),
 		events.EventType("item.arrived"),
-		"cataloge2e", "", []byte(`{"entity_id":"ent-001","item_id":"a"}`), 0, "", "", events.EventEnvelope{}, start),
-		"ent-001")
+		"cataloge2e",
+		"",
+		[]byte(`{"entity_id":"ent-001","item_id":"a"}`),
+		0,
+		"",
+		"",
+		events.EnvelopeForEntityID(events.EventEnvelope{}, "ent-001"),
+		start,
+	)
 
 	seedPipelineNodeDeliveryAuthority(t, db, evt, "test-node")
 
@@ -575,11 +607,18 @@ func TestReconcileAccumulationTimeoutScheduleUsesMatchedHandlerEventKey(t *testi
 			},
 		},
 	}
-	evt := eventtest.WithFlowInstance(eventtest.WithEntityID(eventtest.Projection("evt-item-a",
+	evt := eventtest.RootIngress(
+		"evt-item-a",
 		events.EventType("component-scaffold/a/item.arrived"),
-		"cataloge2e", "", []byte(`{"entity_id":"ent-001","item_id":"a"}`), 0, "", "", events.EventEnvelope{}, start),
-		"ent-001"),
-		"component-scaffold/a")
+		"cataloge2e",
+		"",
+		[]byte(`{"entity_id":"ent-001","item_id":"a"}`),
+		0,
+		"",
+		"",
+		events.EnvelopeForFlowInstance(events.EnvelopeForEntityID(events.EventEnvelope{}, "ent-001"), "component-scaffold/a"),
+		start,
+	)
 
 	if err := pc.reconcileAccumulationTimeoutSchedule(context.Background(), "ent-001", "test-node", handler, evt, "item.arrived", stateBuckets, true); err != nil {
 		t.Fatalf("reconcileAccumulationTimeoutSchedule: %v", err)
@@ -640,19 +679,30 @@ func TestExecuteNodeHandlerPlan_AccumulateTimeoutCancelsScheduleOnTimeout(t *tes
 		t.Fatalf("seed workflow instance: %v", err)
 	}
 
-	evt := eventtest.WithEntityID(eventtest.Projection(uuid.NewString(),
+	evt := eventtest.RootIngress(
+		uuid.NewString(),
 		events.EventType("item.arrived"),
-		"cataloge2e", "", []byte(`{"entity_id":"ent-001","item_id":"a"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC()),
-		"ent-001")
+		"cataloge2e",
+		"",
+		[]byte(`{"entity_id":"ent-001","item_id":"a"}`),
+		0,
+		"",
+		"",
+		events.EnvelopeForEntityID(events.EventEnvelope{}, "ent-001"),
+		time.Now().UTC(),
+	)
 
 	seedPipelineNodeDeliveryAuthority(t, db, evt, "test-node")
 	if handled := pc.executeNodeHandlerPlan(ctx, "test-node", evt); !handled {
 		t.Fatal("expected item.arrived handler to be handled")
 	}
 
-	timeoutEvt := eventtest.WithEntityID(eventtest.Projection(uuid.NewString(),
+	timeoutEvt := eventtest.RootIngress(
+		uuid.NewString(),
 		events.EventType("accumulate.timeout"),
-		runtimeWorkflowID, "", mustJSON(map[string]any{
+		runtimeWorkflowID,
+		"",
+		mustJSON(map[string]any{
 			"entity_id": "ent-001",
 			"timer_handle": map[string]any{
 				"kind": "accumulation_timeout",
@@ -661,8 +711,13 @@ func TestExecuteNodeHandlerPlan_AccumulateTimeoutCancelsScheduleOnTimeout(t *tes
 					"event_type": "item.arrived",
 				},
 			},
-		}), 0, "", "", events.EventEnvelope{}, time.Now().UTC()),
-		"ent-001")
+		}),
+		0,
+		"",
+		"",
+		events.EnvelopeForEntityID(events.EventEnvelope{}, "ent-001"),
+		time.Now().UTC(),
+	)
 
 	seedPipelineNodeDeliveryAuthority(t, db, timeoutEvt, "test-node")
 	txctx := testActivePipelineSQLTxContext(t, db, ctx)
@@ -714,10 +769,18 @@ func TestExecuteNodeHandlerPlan_PreservesRootStateForChildFlowTransitions(t *tes
 		t.Fatalf("seed workflow instance: %v", err)
 	}
 
-	trigger := eventtest.WithEntityID(eventtest.Projection(uuid.NewString(),
+	trigger := eventtest.RootIngress(
+		uuid.NewString(),
 		events.EventType("work.requested"),
-		"cataloge2e", "", []byte(`{"entity_id":"ent-001"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC()),
-		"ent-001")
+		"cataloge2e",
+		"",
+		[]byte(`{"entity_id":"ent-001"}`),
+		0,
+		"",
+		"",
+		events.EnvelopeForEntityID(events.EventEnvelope{}, "ent-001"),
+		time.Now().UTC(),
+	)
 
 	seedPipelineNodeDeliveryAuthority(t, db, trigger, "child-worker")
 
@@ -736,10 +799,18 @@ func TestExecuteNodeHandlerPlan_PreservesRootStateForChildFlowTransitions(t *tes
 	}
 
 	listenerCtx := withPipelineFlowScope(testPipelineCoordinatorRunContext(t, pc), "child")
-	completion := eventtest.WithEntityID(eventtest.Projection(uuid.NewString(),
+	completion := eventtest.RootIngress(
+		uuid.NewString(),
 		events.EventType("child/work.completed"),
-		"cataloge2e", "", []byte(`{"entity_id":"ent-001"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC()),
-		"ent-001")
+		"cataloge2e",
+		"",
+		[]byte(`{"entity_id":"ent-001"}`),
+		0,
+		"",
+		"",
+		events.EnvelopeForEntityID(events.EventEnvelope{}, "ent-001"),
+		time.Now().UTC(),
+	)
 
 	seedPipelineNodeDeliveryAuthority(t, db, completion, "parent-listener")
 	handler, ok := pc.SemanticSource().NodeEventHandler("parent-listener", "child/work.completed")
@@ -805,10 +876,18 @@ func TestPipelineIntercept_HandlesChildFlowOutputForRootListener(t *testing.T) {
 		t.Fatalf("seed workflow instance: %v", err)
 	}
 
-	completion := eventtest.WithEntityID(eventtest.Projection(uuid.NewString(),
+	completion := eventtest.RootIngress(
+		uuid.NewString(),
 		events.EventType("child/work.completed"),
-		"cataloge2e", "", []byte(`{"entity_id":"ent-001"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC()),
-		"ent-001")
+		"cataloge2e",
+		"",
+		[]byte(`{"entity_id":"ent-001"}`),
+		0,
+		"",
+		"",
+		events.EnvelopeForEntityID(events.EventEnvelope{}, "ent-001"),
+		time.Now().UTC(),
+	)
 
 	seedPipelineNodeDeliveryAuthority(t, db, completion, "parent-listener")
 	passThrough, emitted, err := pc.Intercept(testPipelineCoordinatorRunContext(t, pc), completion)
@@ -878,9 +957,18 @@ func TestPipelineCoordinatorIntercept_NestedDescendantCompletionDoesNotEmitChild
 		t.Fatalf("seed grandchild instance: %v", err)
 	}
 
-	completion := eventtest.WithEntityID((eventtest.Projection(uuid.NewString(),
+	completion := eventtest.RootIngress(
+		uuid.NewString(),
 		events.EventType("child/grandchild/micro.done"),
-		"cataloge2e", "", []byte(`{"entity_id":"`+grandchildEntityID+`"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())), grandchildEntityID)
+		"cataloge2e",
+		"",
+		[]byte(`{"entity_id":"`+grandchildEntityID+`"}`),
+		0,
+		"",
+		"",
+		events.EnvelopeForEntityID(events.EventEnvelope{}, grandchildEntityID),
+		time.Now().UTC(),
+	)
 
 	seedPipelineNodeDeliveryAuthority(t, db, completion, "root-collector")
 	passThrough, emitted, err := pc.Intercept(testPipelineCoordinatorRunContext(t, pc), completion)
@@ -956,13 +1044,33 @@ func TestPipelineCoordinatorIntercept_NestedDescendantCompletionAlreadyTargetedT
 	}); err != nil {
 		t.Fatalf("seed child instance: %v", err)
 	}
-	if consume, handled := pc.workflowNodeInterceptPolicy("child/grandchild/micro.done", eventtest.WithEntityID((eventtest.Projection("", events.EventType("child/grandchild/micro.done"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{})), childRowID)); !handled {
+	if consume, handled := pc.workflowNodeInterceptPolicy("child/grandchild/micro.done", eventtest.RootIngress(
+		"",
+		events.EventType("child/grandchild/micro.done"),
+		"",
+		"",
+		nil,
+		0,
+		"",
+		"",
+		events.EnvelopeForEntityID(events.EventEnvelope{}, childRowID),
+		time.Time{},
+	)); !handled {
 		t.Fatalf("workflowNodeInterceptPolicy handled = %v, consume = %v, want handled", handled, consume)
 	}
 
-	completion := eventtest.WithEntityID((eventtest.Projection(uuid.NewString(),
+	completion := eventtest.RootIngress(
+		uuid.NewString(),
 		events.EventType("child/grandchild/micro.done"),
-		"cataloge2e", "", []byte(`{"entity_id":"`+childRowID+`"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())), childRowID)
+		"cataloge2e",
+		"",
+		[]byte(`{"entity_id":"`+childRowID+`"}`),
+		0,
+		"",
+		"",
+		events.EnvelopeForEntityID(events.EventEnvelope{}, childRowID),
+		time.Now().UTC(),
+	)
 
 	seedPipelineNodeDeliveryAuthority(t, db, completion, "root-collector")
 	passThrough, emitted, err := pc.Intercept(testPipelineCoordinatorRunContext(t, pc), completion)
@@ -1037,9 +1145,18 @@ func TestPipelineCoordinatorIntercept_NestedDescendantCompletionInsideOuterSQLTx
 	t.Cleanup(func() { _ = tx.Rollback() })
 	ctx := WithPipelineSQLTxContext(testPipelineCoordinatorRunContext(t, pc), tx)
 
-	completion := eventtest.WithEntityID((eventtest.Projection(uuid.NewString(),
+	completion := eventtest.RootIngress(
+		uuid.NewString(),
 		events.EventType("child/grandchild/micro.done"),
-		"cataloge2e", "", []byte(`{"entity_id":"`+childRowID+`"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())), childRowID)
+		"cataloge2e",
+		"",
+		[]byte(`{"entity_id":"`+childRowID+`"}`),
+		0,
+		"",
+		"",
+		events.EnvelopeForEntityID(events.EventEnvelope{}, childRowID),
+		time.Now().UTC(),
+	)
 
 	seedPipelineNodeDeliveryAuthority(t, db, completion, "root-collector")
 	passThrough, emitted, err := pc.Intercept(ctx, completion)

--- a/internal/runtime/runforkexecution/execution_test.go
+++ b/internal/runtime/runforkexecution/execution_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/division-sh/swarm/internal/config"
 	"github.com/division-sh/swarm/internal/events"
+	"github.com/division-sh/swarm/internal/events/eventtest"
 	"github.com/division-sh/swarm/internal/runtime/bus"
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
 	runtimeactors "github.com/division-sh/swarm/internal/runtime/core/actors"
@@ -1672,24 +1673,25 @@ func TestSelectedContractRecipientPlanPublishGuardAuthorizesCanonicalPlan(t *tes
 	}
 	guard.ExpectForkEvent("fork-event", sourceEventID)
 
-	err = guard.AuthorizeEvent(context.Background(), events.NewProjectionEvent("fork-event",
+	err = guard.AuthorizeEvent(context.Background(), eventtest.Projection("fork-event",
 		"work.begin",
-		store.RunForkSelectedContractExecutionOwner, "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}),
-	)
+		store.RunForkSelectedContractExecutionOwner, "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}))
 	if err != nil {
 		t.Fatalf("AuthorizeEvent canonical recipient plan: %v", err)
 	}
 
-	err = guard.Authorize(context.Background(), events.NewProjectionEvent("fork-event",
+	err = guard.Authorize(context.Background(), eventtest.Projection("fork-event",
 		"work.begin",
-		store.RunForkSelectedContractExecutionOwner, "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}), bus.PublishRecipientPlan{
-		RoutedRecipients: []bus.PublishDiagnosticRecipient{{
-			Type:        "node",
-			ID:          "alpha-intake",
-			Path:        "flow-a/alpha-intake",
-			RouteSource: "selected_contracts",
-		}},
-	})
+		store.RunForkSelectedContractExecutionOwner, "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}),
+
+		bus.PublishRecipientPlan{
+			RoutedRecipients: []bus.PublishDiagnosticRecipient{{
+				Type:        "node",
+				ID:          "alpha-intake",
+				Path:        "flow-a/alpha-intake",
+				RouteSource: "selected_contracts",
+			}},
+		})
 	if err != nil {
 		t.Fatalf("Authorize canonical recipient plan: %v", err)
 	}
@@ -1726,22 +1728,24 @@ func TestSelectedContractRecipientPlanPublishGuardMaterializesTargetNodeDelivery
 	}
 	guard.ExpectForkEvent("fork-event", "source-event")
 
-	routes, err := guard.MaterializeNodeDeliveryRoutes(context.Background(), events.NewProjectionEvent("fork-event",
+	routes, err := guard.MaterializeNodeDeliveryRoutes(context.Background(), eventtest.Projection("fork-event",
 		"item.received",
-		store.RunForkSelectedContractExecutionOwner, "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}), bus.PublishRecipientPlan{
-		RoutedRecipients: []bus.PublishDiagnosticRecipient{
-			{
-				Type:        "agent",
-				ID:          "target-agent",
-				RouteSource: "selected_contracts",
+		store.RunForkSelectedContractExecutionOwner, "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}),
+
+		bus.PublishRecipientPlan{
+			RoutedRecipients: []bus.PublishDiagnosticRecipient{
+				{
+					Type:        "agent",
+					ID:          "target-agent",
+					RouteSource: "selected_contracts",
+				},
+				{
+					Type:        "node",
+					ID:          "test-node",
+					RouteSource: "selected_contracts",
+				},
 			},
-			{
-				Type:        "node",
-				ID:          "test-node",
-				RouteSource: "selected_contracts",
-			},
-		},
-	})
+		})
 	if err != nil {
 		t.Fatalf("MaterializeNodeDeliveryRoutes: %v", err)
 	}
@@ -1772,16 +1776,18 @@ func TestSelectedContractRecipientPlanPublishGuardAuthorizesContractSwapOwner(t 
 	}
 	guard.ExpectForkEvent("fork-event", sourceEventID)
 
-	err = guard.Authorize(context.Background(), events.NewProjectionEvent("fork-event",
+	err = guard.Authorize(context.Background(), eventtest.Projection("fork-event",
 		"work.begin",
-		store.RunForkHistoricalReplayContractSwapBootResumeOwner, "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}), bus.PublishRecipientPlan{
-		RoutedRecipients: []bus.PublishDiagnosticRecipient{{
-			Type:        "node",
-			ID:          "alpha-intake",
-			Path:        "flow-a/alpha-intake",
-			RouteSource: "selected_contracts",
-		}},
-	})
+		store.RunForkHistoricalReplayContractSwapBootResumeOwner, "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}),
+
+		bus.PublishRecipientPlan{
+			RoutedRecipients: []bus.PublishDiagnosticRecipient{{
+				Type:        "node",
+				ID:          "alpha-intake",
+				Path:        "flow-a/alpha-intake",
+				RouteSource: "selected_contracts",
+			}},
+		})
 	if err != nil {
 		t.Fatalf("Authorize contract-swap owner recipient plan: %v", err)
 	}
@@ -1805,47 +1811,53 @@ func TestSelectedContractRecipientPlanPublishGuardRejectsBypassAndSubscriptions(
 		t.Fatalf("newSelectedContractRecipientPlanPublishGuard: %v", err)
 	}
 
-	err = guard.Authorize(context.Background(), events.NewProjectionEvent("fork-event",
+	err = guard.Authorize(context.Background(), eventtest.Projection("fork-event",
 		"work.begin",
-		store.RunForkSelectedContractExecutionOwner, "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}), bus.PublishRecipientPlan{
-		RoutedRecipients: []bus.PublishDiagnosticRecipient{{
-			Type:        "node",
-			ID:          "alpha-intake",
-			Path:        "flow-a/alpha-intake",
-			RouteSource: "selected_contracts",
-		}},
-	})
+		store.RunForkSelectedContractExecutionOwner, "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}),
+
+		bus.PublishRecipientPlan{
+			RoutedRecipients: []bus.PublishDiagnosticRecipient{{
+				Type:        "node",
+				ID:          "alpha-intake",
+				Path:        "flow-a/alpha-intake",
+				RouteSource: "selected_contracts",
+			}},
+		})
 	if err == nil || !strings.Contains(err.Error(), store.RunForkSelectedContractRecipientPlanningOwner) {
 		t.Fatalf("Authorize without expectation error = %v, want recipient-planning evidence failure", err)
 	}
 
 	guard.ExpectForkEvent("fork-event-subscription", sourceEventID)
-	err = guard.Authorize(context.Background(), events.NewProjectionEvent("fork-event-subscription",
+	err = guard.Authorize(context.Background(), eventtest.Projection("fork-event-subscription",
 		"work.begin",
-		store.RunForkSelectedContractExecutionOwner, "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}), bus.PublishRecipientPlan{
-		RoutedRecipients: []bus.PublishDiagnosticRecipient{{
-			Type:        "node",
-			ID:          "alpha-intake",
-			Path:        "flow-a/alpha-intake",
-			RouteSource: "selected_contracts",
-		}},
-		SubscriptionRecipients: []string{"legacy-subscription"},
-	})
+		store.RunForkSelectedContractExecutionOwner, "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}),
+
+		bus.PublishRecipientPlan{
+			RoutedRecipients: []bus.PublishDiagnosticRecipient{{
+				Type:        "node",
+				ID:          "alpha-intake",
+				Path:        "flow-a/alpha-intake",
+				RouteSource: "selected_contracts",
+			}},
+			SubscriptionRecipients: []string{"legacy-subscription"},
+		})
 	if err == nil || !strings.Contains(err.Error(), "live subscription") {
 		t.Fatalf("Authorize subscription recipient error = %v, want live subscription rejection", err)
 	}
 
 	guard.ExpectForkEvent("fork-event-wrong-recipient", sourceEventID)
-	err = guard.Authorize(context.Background(), events.NewProjectionEvent("fork-event-wrong-recipient",
+	err = guard.Authorize(context.Background(), eventtest.Projection("fork-event-wrong-recipient",
 		"work.begin",
-		store.RunForkSelectedContractExecutionOwner, "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}), bus.PublishRecipientPlan{
-		RoutedRecipients: []bus.PublishDiagnosticRecipient{{
-			Type:        "node",
-			ID:          "other-node",
-			Path:        "flow-a/other-node",
-			RouteSource: "selected_contracts",
-		}},
-	})
+		store.RunForkSelectedContractExecutionOwner, "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}),
+
+		bus.PublishRecipientPlan{
+			RoutedRecipients: []bus.PublishDiagnosticRecipient{{
+				Type:        "node",
+				ID:          "other-node",
+				Path:        "flow-a/other-node",
+				RouteSource: "selected_contracts",
+			}},
+		})
 	if err == nil || !strings.Contains(err.Error(), "routed recipients do not match") {
 		t.Fatalf("Authorize wrong recipient error = %v, want recipient-plan mismatch", err)
 	}
@@ -1982,7 +1994,7 @@ func (a *selectedContractForkTestAgent) OnEvent(ctx context.Context, evt events.
 	a.mu.Unlock()
 
 	return []events.Event{
-		events.NewProjectionEvent("", events.EventType("task.completed"), agentID, "", json.RawMessage(`{}`), 0, evt.RunID(), evt.ID(), evt.NormalizedEnvelope(), time.Now().UTC()),
+		eventtest.Projection("", events.EventType("task.completed"), agentID, "", json.RawMessage(`{}`), 0, evt.RunID(), evt.ID(), evt.NormalizedEnvelope(), time.Now().UTC()),
 	}, nil
 }
 

--- a/internal/runtime/runforkexecution/execution_test.go
+++ b/internal/runtime/runforkexecution/execution_test.go
@@ -1673,14 +1673,14 @@ func TestSelectedContractRecipientPlanPublishGuardAuthorizesCanonicalPlan(t *tes
 	}
 	guard.ExpectForkEvent("fork-event", sourceEventID)
 
-	err = guard.AuthorizeEvent(context.Background(), eventtest.Projection("fork-event",
+	err = guard.AuthorizeEvent(context.Background(), eventtest.RootIngress("fork-event",
 		"work.begin",
 		store.RunForkSelectedContractExecutionOwner, "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}))
 	if err != nil {
 		t.Fatalf("AuthorizeEvent canonical recipient plan: %v", err)
 	}
 
-	err = guard.Authorize(context.Background(), eventtest.Projection("fork-event",
+	err = guard.Authorize(context.Background(), eventtest.RootIngress("fork-event",
 		"work.begin",
 		store.RunForkSelectedContractExecutionOwner, "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}),
 
@@ -1728,7 +1728,7 @@ func TestSelectedContractRecipientPlanPublishGuardMaterializesTargetNodeDelivery
 	}
 	guard.ExpectForkEvent("fork-event", "source-event")
 
-	routes, err := guard.MaterializeNodeDeliveryRoutes(context.Background(), eventtest.Projection("fork-event",
+	routes, err := guard.MaterializeNodeDeliveryRoutes(context.Background(), eventtest.RootIngress("fork-event",
 		"item.received",
 		store.RunForkSelectedContractExecutionOwner, "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}),
 
@@ -1776,7 +1776,7 @@ func TestSelectedContractRecipientPlanPublishGuardAuthorizesContractSwapOwner(t 
 	}
 	guard.ExpectForkEvent("fork-event", sourceEventID)
 
-	err = guard.Authorize(context.Background(), eventtest.Projection("fork-event",
+	err = guard.Authorize(context.Background(), eventtest.RootIngress("fork-event",
 		"work.begin",
 		store.RunForkHistoricalReplayContractSwapBootResumeOwner, "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}),
 
@@ -1811,7 +1811,7 @@ func TestSelectedContractRecipientPlanPublishGuardRejectsBypassAndSubscriptions(
 		t.Fatalf("newSelectedContractRecipientPlanPublishGuard: %v", err)
 	}
 
-	err = guard.Authorize(context.Background(), eventtest.Projection("fork-event",
+	err = guard.Authorize(context.Background(), eventtest.RootIngress("fork-event",
 		"work.begin",
 		store.RunForkSelectedContractExecutionOwner, "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}),
 
@@ -1828,7 +1828,7 @@ func TestSelectedContractRecipientPlanPublishGuardRejectsBypassAndSubscriptions(
 	}
 
 	guard.ExpectForkEvent("fork-event-subscription", sourceEventID)
-	err = guard.Authorize(context.Background(), eventtest.Projection("fork-event-subscription",
+	err = guard.Authorize(context.Background(), eventtest.RootIngress("fork-event-subscription",
 		"work.begin",
 		store.RunForkSelectedContractExecutionOwner, "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}),
 
@@ -1846,7 +1846,7 @@ func TestSelectedContractRecipientPlanPublishGuardRejectsBypassAndSubscriptions(
 	}
 
 	guard.ExpectForkEvent("fork-event-wrong-recipient", sourceEventID)
-	err = guard.Authorize(context.Background(), eventtest.Projection("fork-event-wrong-recipient",
+	err = guard.Authorize(context.Background(), eventtest.RootIngress("fork-event-wrong-recipient",
 		"work.begin",
 		store.RunForkSelectedContractExecutionOwner, "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}),
 
@@ -1994,7 +1994,7 @@ func (a *selectedContractForkTestAgent) OnEvent(ctx context.Context, evt events.
 	a.mu.Unlock()
 
 	return []events.Event{
-		eventtest.Projection("", events.EventType("task.completed"), agentID, "", json.RawMessage(`{}`), 0, evt.RunID(), evt.ID(), evt.NormalizedEnvelope(), time.Now().UTC()),
+		eventtest.RootIngress("", events.EventType("task.completed"), agentID, "", json.RawMessage(`{}`), 0, evt.RunID(), evt.ID(), evt.NormalizedEnvelope(), time.Now().UTC()),
 	}, nil
 }
 

--- a/internal/runtime/runtime_operational_config_test.go
+++ b/internal/runtime/runtime_operational_config_test.go
@@ -167,7 +167,7 @@ func TestRuntimeStart_AllowsRecoveryDisabledWithManagerSnapshotWork(t *testing.T
 	module := loadRuntimeOwnershipWorkflowModule(t)
 	eventStore := &recoveryGuardEventStore{
 		missing: []events.PersistedReplayEvent{{
-			Event: eventtest.Projection("evt-1",
+			Event: eventtest.RootIngress("evt-1",
 				"support.item_created", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}),
 		}},
 		routes: []runtimeflowidentity.Route{

--- a/internal/runtime/runtime_operational_config_test.go
+++ b/internal/runtime/runtime_operational_config_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/division-sh/swarm/internal/config"
 	"github.com/division-sh/swarm/internal/events"
+	"github.com/division-sh/swarm/internal/events/eventtest"
 	runtimebus "github.com/division-sh/swarm/internal/runtime/bus"
 	runtimeactors "github.com/division-sh/swarm/internal/runtime/core/actors"
 	runtimeflowidentity "github.com/division-sh/swarm/internal/runtime/core/flowidentity"
@@ -166,7 +167,7 @@ func TestRuntimeStart_AllowsRecoveryDisabledWithManagerSnapshotWork(t *testing.T
 	module := loadRuntimeOwnershipWorkflowModule(t)
 	eventStore := &recoveryGuardEventStore{
 		missing: []events.PersistedReplayEvent{{
-			Event: events.NewProjectionEvent("evt-1",
+			Event: eventtest.Projection("evt-1",
 				"support.item_created", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}),
 		}},
 		routes: []runtimeflowidentity.Route{

--- a/internal/runtime/runtime_recovery_diagnostics_test.go
+++ b/internal/runtime/runtime_recovery_diagnostics_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/division-sh/swarm/internal/config"
 	"github.com/division-sh/swarm/internal/events"
+	"github.com/division-sh/swarm/internal/events/eventtest"
 	runtimebus "github.com/division-sh/swarm/internal/runtime/bus"
 	runtimeactors "github.com/division-sh/swarm/internal/runtime/core/actors"
 	runtimeflowidentity "github.com/division-sh/swarm/internal/runtime/core/flowidentity"
@@ -412,7 +413,7 @@ func TestRuntimeStart_RecoveryDisabledAllowsAndLogsManagerSnapshotWork(t *testin
 	module := loadRuntimeOwnershipWorkflowModule(t)
 	eventStore := &startupRecoveryEventStore{
 		missing: []events.PersistedReplayEvent{{
-			Event: events.NewProjectionEvent("evt-1", "support.item_created", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}),
+			Event: eventtest.Projection("evt-1", "support.item_created", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}),
 		}},
 		routes: []runtimeflowidentity.Route{
 			runtimeflowidentity.DeriveRoute("child", "inst-1"),
@@ -702,10 +703,10 @@ func TestRuntimeStart_RecoveryEnabledEmitsManagerReplayAftermathAndSummary(t *te
 		}},
 		pending: map[string][]events.Event{
 			"agent-a": {
-				events.NewProjectionEvent("evt-replay", events.EventType("support.replay.ok"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Now().Add(-4*time.Minute).UTC()),
-				events.NewProjectionEvent("evt-skip", events.EventType("support.replay.skip"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Now().Add(-3*time.Minute).UTC()),
-				events.NewProjectionEvent("evt-leased", events.EventType("support.replay.leased"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Now().Add(-2*time.Minute).UTC()),
-				events.NewProjectionEvent("evt-drop", events.EventType("support.replay.drop"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Now().Add(-time.Minute).UTC()),
+				eventtest.Projection("evt-replay", events.EventType("support.replay.ok"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Now().Add(-4*time.Minute).UTC()),
+				eventtest.Projection("evt-skip", events.EventType("support.replay.skip"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Now().Add(-3*time.Minute).UTC()),
+				eventtest.Projection("evt-leased", events.EventType("support.replay.leased"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Now().Add(-2*time.Minute).UTC()),
+				eventtest.Projection("evt-drop", events.EventType("support.replay.drop"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Now().Add(-time.Minute).UTC()),
 			},
 		},
 		receipts: map[string]runtimemanager.EventReceipt{
@@ -813,7 +814,7 @@ func TestRuntimeStart_RecoveryFailureEmitsDegradedDecisionSummary(t *testing.T) 
 	module := loadRuntimeOwnershipWorkflowModule(t)
 	eventStore := &startupRecoveryEventStore{
 		missing: []events.PersistedReplayEvent{{
-			Event: events.NewProjectionEvent("evt-1", "support.item_created", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}),
+			Event: eventtest.Projection("evt-1", "support.item_created", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}),
 		}},
 		claimErr: errors.New("claim failed"),
 	}

--- a/internal/runtime/runtime_recovery_diagnostics_test.go
+++ b/internal/runtime/runtime_recovery_diagnostics_test.go
@@ -413,7 +413,7 @@ func TestRuntimeStart_RecoveryDisabledAllowsAndLogsManagerSnapshotWork(t *testin
 	module := loadRuntimeOwnershipWorkflowModule(t)
 	eventStore := &startupRecoveryEventStore{
 		missing: []events.PersistedReplayEvent{{
-			Event: eventtest.Projection("evt-1", "support.item_created", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}),
+			Event: eventtest.RootIngress("evt-1", "support.item_created", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}),
 		}},
 		routes: []runtimeflowidentity.Route{
 			runtimeflowidentity.DeriveRoute("child", "inst-1"),
@@ -703,10 +703,10 @@ func TestRuntimeStart_RecoveryEnabledEmitsManagerReplayAftermathAndSummary(t *te
 		}},
 		pending: map[string][]events.Event{
 			"agent-a": {
-				eventtest.Projection("evt-replay", events.EventType("support.replay.ok"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Now().Add(-4*time.Minute).UTC()),
-				eventtest.Projection("evt-skip", events.EventType("support.replay.skip"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Now().Add(-3*time.Minute).UTC()),
-				eventtest.Projection("evt-leased", events.EventType("support.replay.leased"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Now().Add(-2*time.Minute).UTC()),
-				eventtest.Projection("evt-drop", events.EventType("support.replay.drop"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Now().Add(-time.Minute).UTC()),
+				eventtest.RootIngress("evt-replay", events.EventType("support.replay.ok"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Now().Add(-4*time.Minute).UTC()),
+				eventtest.RootIngress("evt-skip", events.EventType("support.replay.skip"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Now().Add(-3*time.Minute).UTC()),
+				eventtest.RootIngress("evt-leased", events.EventType("support.replay.leased"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Now().Add(-2*time.Minute).UTC()),
+				eventtest.RootIngress("evt-drop", events.EventType("support.replay.drop"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Now().Add(-time.Minute).UTC()),
 			},
 		},
 		receipts: map[string]runtimemanager.EventReceipt{
@@ -814,7 +814,7 @@ func TestRuntimeStart_RecoveryFailureEmitsDegradedDecisionSummary(t *testing.T) 
 	module := loadRuntimeOwnershipWorkflowModule(t)
 	eventStore := &startupRecoveryEventStore{
 		missing: []events.PersistedReplayEvent{{
-			Event: eventtest.Projection("evt-1", "support.item_created", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}),
+			Event: eventtest.RootIngress("evt-1", "support.item_created", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}),
 		}},
 		claimErr: errors.New("claim failed"),
 	}

--- a/internal/runtime/runtime_shutdown_admission_test.go
+++ b/internal/runtime/runtime_shutdown_admission_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/division-sh/swarm/internal/events"
+	"github.com/division-sh/swarm/internal/events/eventtest"
 	runtimebus "github.com/division-sh/swarm/internal/runtime/bus"
 	runtimeactors "github.com/division-sh/swarm/internal/runtime/core/actors"
 	runtimemanager "github.com/division-sh/swarm/internal/runtime/manager"
@@ -124,10 +125,9 @@ func TestRuntimeShutdown_ClosesAdmissionBeforeManagerDrainAndInboundIngress(t *t
 		t.Fatalf("SpawnAgent: %v", err)
 	}
 	am.Run(context.Background())
-	if err := bus.Publish(context.Background(), events.NewProjectionEvent("evt-in-1",
+	if err := bus.Publish(context.Background(), eventtest.Projection("evt-in-1",
 		events.EventType("test.in"),
-		"tester", "", nil, 0, "", "", events.EventEnvelope{}, time.Now().UTC()),
-	); err != nil {
+		"tester", "", nil, 0, "", "", events.EventEnvelope{}, time.Now().UTC())); err != nil {
 		t.Fatalf("Publish: %v", err)
 	}
 
@@ -215,10 +215,9 @@ func TestRuntimeShutdownWithOptions_PropagatesConfiguredGraceToManagerDrain(t *t
 		t.Fatalf("SpawnAgent: %v", err)
 	}
 	am.Run(context.Background())
-	if err := bus.Publish(context.Background(), events.NewProjectionEvent("evt-in-1",
+	if err := bus.Publish(context.Background(), eventtest.Projection("evt-in-1",
 		events.EventType("test.in"),
-		"tester", "", nil, 0, "", "", events.EventEnvelope{}, time.Now().UTC()),
-	); err != nil {
+		"tester", "", nil, 0, "", "", events.EventEnvelope{}, time.Now().UTC())); err != nil {
 		t.Fatalf("Publish: %v", err)
 	}
 

--- a/internal/runtime/runtime_shutdown_admission_test.go
+++ b/internal/runtime/runtime_shutdown_admission_test.go
@@ -125,7 +125,7 @@ func TestRuntimeShutdown_ClosesAdmissionBeforeManagerDrainAndInboundIngress(t *t
 		t.Fatalf("SpawnAgent: %v", err)
 	}
 	am.Run(context.Background())
-	if err := bus.Publish(context.Background(), eventtest.Projection("evt-in-1",
+	if err := bus.Publish(context.Background(), eventtest.RootIngress("evt-in-1",
 		events.EventType("test.in"),
 		"tester", "", nil, 0, "", "", events.EventEnvelope{}, time.Now().UTC())); err != nil {
 		t.Fatalf("Publish: %v", err)
@@ -215,7 +215,7 @@ func TestRuntimeShutdownWithOptions_PropagatesConfiguredGraceToManagerDrain(t *t
 		t.Fatalf("SpawnAgent: %v", err)
 	}
 	am.Run(context.Background())
-	if err := bus.Publish(context.Background(), eventtest.Projection("evt-in-1",
+	if err := bus.Publish(context.Background(), eventtest.RootIngress("evt-in-1",
 		events.EventType("test.in"),
 		"tester", "", nil, 0, "", "", events.EventEnvelope{}, time.Now().UTC())); err != nil {
 		t.Fatalf("Publish: %v", err)

--- a/internal/runtime/template_instance_delivery_test.go
+++ b/internal/runtime/template_instance_delivery_test.go
@@ -59,10 +59,18 @@ func TestTemplateInstanceNoTargetSystemNodeDeliveryPersistsReceiptAndReplayScope
 		t.Fatalf("AddFlowInstanceRoute: %v", err)
 	}
 	eventID := "99999999-9999-4999-8999-999999999902"
-	evt := eventtest.WithFlowInstance(eventtest.WithEntityID((eventtest.Projection(eventID,
-
-		events.EventType("operating/inst-1/opco.product_initialization_requested"), "", "", []byte(`{"entity_id":"11111111-1111-4111-8111-111111111111"}`), 0, templateInstanceDeliveryRunID, "", events.EventEnvelope{}, time.Now().UTC())), "11111111-1111-4111-8111-111111111111"),
-		"operating/inst-1")
+	evt := eventtest.RootIngress(
+		eventID,
+		events.EventType("operating/inst-1/opco.product_initialization_requested"),
+		"",
+		"",
+		[]byte(`{"entity_id":"11111111-1111-4111-8111-111111111111"}`),
+		0,
+		templateInstanceDeliveryRunID,
+		"",
+		events.EnvelopeForFlowInstance(events.EnvelopeForEntityID(events.EventEnvelope{}, "11111111-1111-4111-8111-111111111111"), "operating/inst-1"),
+		time.Now().UTC(),
+	)
 
 	if err := bus.Publish(ctx, evt); err != nil {
 		t.Fatalf("Publish: %v", err)
@@ -106,10 +114,18 @@ func TestTemplateInstanceNoTargetSystemNodeDeliveryPersistsAuthorityBeforeHandle
 	}
 	ch := bus.SubscribeInternal("workflow-runtime", events.EventType("operating/opco.product_initialization_requested"))
 	eventID := "99999999-9999-4999-8999-999999999903"
-	evt := eventtest.WithFlowInstance(eventtest.WithEntityID((eventtest.Projection(eventID,
-
-		events.EventType("operating/inst-1/opco.product_initialization_requested"), "", "", []byte(`{"entity_id":"11111111-1111-4111-8111-111111111111"}`), 0, templateInstanceDeliveryRunID, "", events.EventEnvelope{}, time.Now().UTC())), "11111111-1111-4111-8111-111111111111"),
-		"operating/inst-1")
+	evt := eventtest.RootIngress(
+		eventID,
+		events.EventType("operating/inst-1/opco.product_initialization_requested"),
+		"",
+		"",
+		[]byte(`{"entity_id":"11111111-1111-4111-8111-111111111111"}`),
+		0,
+		templateInstanceDeliveryRunID,
+		"",
+		events.EnvelopeForFlowInstance(events.EnvelopeForEntityID(events.EventEnvelope{}, "11111111-1111-4111-8111-111111111111"), "operating/inst-1"),
+		time.Now().UTC(),
+	)
 
 	if err := bus.Publish(ctx, evt); err != nil {
 		t.Fatalf("Publish: %v", err)
@@ -162,9 +178,18 @@ func TestTemplateInstanceAutoEmitDispatchesLocalHandlerAndEmpireStyleSideEffect(
 	})
 	bus.SetInterceptors(pc)
 
-	spinup := eventtest.WithEntityID((eventtest.Projection("99999999-9999-4999-8999-999999999910",
-
-		events.EventType("opco.spinup_requested"), "", "", []byte(`{"entity_id":"22222222-2222-4222-8222-222222222222","instance_id":"11111111-1111-4111-8111-111111111111","product_id":"product-1"}`), 0, templateInstanceDeliveryRunID, "", events.EventEnvelope{}, time.Now().UTC())), "22222222-2222-4222-8222-222222222222")
+	spinup := eventtest.RootIngress(
+		"99999999-9999-4999-8999-999999999910",
+		events.EventType("opco.spinup_requested"),
+		"",
+		"",
+		[]byte(`{"entity_id":"22222222-2222-4222-8222-222222222222","instance_id":"11111111-1111-4111-8111-111111111111","product_id":"product-1"}`),
+		0,
+		templateInstanceDeliveryRunID,
+		"",
+		events.EnvelopeForEntityID(events.EventEnvelope{}, "22222222-2222-4222-8222-222222222222"),
+		time.Now().UTC(),
+	)
 
 	if err := bus.Publish(ctx, spinup); err != nil {
 		t.Fatalf("Publish spinup: %v", err)
@@ -245,9 +270,18 @@ func TestTemplateInstanceActivationConfigSubscriberPersistsRenderedRouteAndDeliv
 	})
 	bus.SetInterceptors(pc)
 
-	spinup := eventtest.WithEntityID((eventtest.Projection("99999999-9999-4999-8999-999999999930",
-
-		events.EventType("opco.spinup_requested"), "", "", []byte(`{"entity_id":"22222222-2222-4222-8222-222222222222","instance_id":"11111111-1111-4111-8111-111111111111","product_id":"product-1"}`), 0, templateInstanceDeliveryRunID, "", events.EventEnvelope{}, time.Now().UTC())), "22222222-2222-4222-8222-222222222222")
+	spinup := eventtest.RootIngress(
+		"99999999-9999-4999-8999-999999999930",
+		events.EventType("opco.spinup_requested"),
+		"",
+		"",
+		[]byte(`{"entity_id":"22222222-2222-4222-8222-222222222222","instance_id":"11111111-1111-4111-8111-111111111111","product_id":"product-1"}`),
+		0,
+		templateInstanceDeliveryRunID,
+		"",
+		events.EnvelopeForEntityID(events.EventEnvelope{}, "22222222-2222-4222-8222-222222222222"),
+		time.Now().UTC(),
+	)
 
 	if err := bus.Publish(ctx, spinup); err != nil {
 		t.Fatalf("Publish spinup: %v", err)
@@ -317,7 +351,7 @@ func TestTemplateInstanceAcknowledgedPublishDispatchesRoutedSystemNodeWithoutInt
 		},
 	})
 
-	mailbox := eventtest.Projection(
+	mailbox := eventtest.RootIngress(
 		"99999999-9999-4999-8999-999999999913",
 		events.EventType("mailbox.item_decided"),
 		"",
@@ -436,9 +470,18 @@ func TestTemplateInstanceRootOutboxEventDispatchesRoutedSystemNodeAndEmpireStyle
 		t.Fatal("workflow runtime did not subscribe")
 	}
 
-	mailbox := eventtest.WithEntityID((eventtest.Projection("99999999-9999-4999-8999-999999999912",
-
-		events.EventType("mailbox.item_decided"), "", "", []byte(`{"entity_id":"22222222-2222-4222-8222-222222222222","instance_id":"11111111-1111-4111-8111-111111111111","product_id":"product-1"}`), 0, templateInstanceDeliveryRunID, "", events.EventEnvelope{}, time.Now().UTC())), "22222222-2222-4222-8222-222222222222")
+	mailbox := eventtest.RootIngress(
+		"99999999-9999-4999-8999-999999999912",
+		events.EventType("mailbox.item_decided"),
+		"",
+		"",
+		[]byte(`{"entity_id":"22222222-2222-4222-8222-222222222222","instance_id":"11111111-1111-4111-8111-111111111111","product_id":"product-1"}`),
+		0,
+		templateInstanceDeliveryRunID,
+		"",
+		events.EnvelopeForEntityID(events.EventEnvelope{}, "22222222-2222-4222-8222-222222222222"),
+		time.Now().UTC(),
+	)
 
 	if err := bus.Publish(ctx, mailbox); err != nil {
 		t.Fatalf("Publish mailbox: %v", err)

--- a/internal/runtime/template_instance_delivery_test.go
+++ b/internal/runtime/template_instance_delivery_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/division-sh/swarm/internal/events"
+	"github.com/division-sh/swarm/internal/events/eventtest"
 	runtimebus "github.com/division-sh/swarm/internal/runtime/bus"
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
 	runtimeflowidentity "github.com/division-sh/swarm/internal/runtime/core/flowidentity"
@@ -58,9 +59,11 @@ func TestTemplateInstanceNoTargetSystemNodeDeliveryPersistsReceiptAndReplayScope
 		t.Fatalf("AddFlowInstanceRoute: %v", err)
 	}
 	eventID := "99999999-9999-4999-8999-999999999902"
-	evt := (events.NewProjectionEvent(eventID,
+	evt := eventtest.WithFlowInstance(eventtest.WithEntityID((eventtest.Projection(eventID,
 
-		events.EventType("operating/inst-1/opco.product_initialization_requested"), "", "", []byte(`{"entity_id":"11111111-1111-4111-8111-111111111111"}`), 0, templateInstanceDeliveryRunID, "", events.EventEnvelope{}, time.Now().UTC())).WithEntityID("11111111-1111-4111-8111-111111111111").WithFlowInstance("operating/inst-1")
+		events.EventType("operating/inst-1/opco.product_initialization_requested"), "", "", []byte(`{"entity_id":"11111111-1111-4111-8111-111111111111"}`), 0, templateInstanceDeliveryRunID, "", events.EventEnvelope{}, time.Now().UTC())), "11111111-1111-4111-8111-111111111111"),
+		"operating/inst-1")
+
 	if err := bus.Publish(ctx, evt); err != nil {
 		t.Fatalf("Publish: %v", err)
 	}
@@ -103,9 +106,11 @@ func TestTemplateInstanceNoTargetSystemNodeDeliveryPersistsAuthorityBeforeHandle
 	}
 	ch := bus.SubscribeInternal("workflow-runtime", events.EventType("operating/opco.product_initialization_requested"))
 	eventID := "99999999-9999-4999-8999-999999999903"
-	evt := (events.NewProjectionEvent(eventID,
+	evt := eventtest.WithFlowInstance(eventtest.WithEntityID((eventtest.Projection(eventID,
 
-		events.EventType("operating/inst-1/opco.product_initialization_requested"), "", "", []byte(`{"entity_id":"11111111-1111-4111-8111-111111111111"}`), 0, templateInstanceDeliveryRunID, "", events.EventEnvelope{}, time.Now().UTC())).WithEntityID("11111111-1111-4111-8111-111111111111").WithFlowInstance("operating/inst-1")
+		events.EventType("operating/inst-1/opco.product_initialization_requested"), "", "", []byte(`{"entity_id":"11111111-1111-4111-8111-111111111111"}`), 0, templateInstanceDeliveryRunID, "", events.EventEnvelope{}, time.Now().UTC())), "11111111-1111-4111-8111-111111111111"),
+		"operating/inst-1")
+
 	if err := bus.Publish(ctx, evt); err != nil {
 		t.Fatalf("Publish: %v", err)
 	}
@@ -157,9 +162,10 @@ func TestTemplateInstanceAutoEmitDispatchesLocalHandlerAndEmpireStyleSideEffect(
 	})
 	bus.SetInterceptors(pc)
 
-	spinup := (events.NewProjectionEvent("99999999-9999-4999-8999-999999999910",
+	spinup := eventtest.WithEntityID((eventtest.Projection("99999999-9999-4999-8999-999999999910",
 
-		events.EventType("opco.spinup_requested"), "", "", []byte(`{"entity_id":"22222222-2222-4222-8222-222222222222","instance_id":"11111111-1111-4111-8111-111111111111","product_id":"product-1"}`), 0, templateInstanceDeliveryRunID, "", events.EventEnvelope{}, time.Now().UTC())).WithEntityID("22222222-2222-4222-8222-222222222222")
+		events.EventType("opco.spinup_requested"), "", "", []byte(`{"entity_id":"22222222-2222-4222-8222-222222222222","instance_id":"11111111-1111-4111-8111-111111111111","product_id":"product-1"}`), 0, templateInstanceDeliveryRunID, "", events.EventEnvelope{}, time.Now().UTC())), "22222222-2222-4222-8222-222222222222")
+
 	if err := bus.Publish(ctx, spinup); err != nil {
 		t.Fatalf("Publish spinup: %v", err)
 	}
@@ -239,9 +245,10 @@ func TestTemplateInstanceActivationConfigSubscriberPersistsRenderedRouteAndDeliv
 	})
 	bus.SetInterceptors(pc)
 
-	spinup := (events.NewProjectionEvent("99999999-9999-4999-8999-999999999930",
+	spinup := eventtest.WithEntityID((eventtest.Projection("99999999-9999-4999-8999-999999999930",
 
-		events.EventType("opco.spinup_requested"), "", "", []byte(`{"entity_id":"22222222-2222-4222-8222-222222222222","instance_id":"11111111-1111-4111-8111-111111111111","product_id":"product-1"}`), 0, templateInstanceDeliveryRunID, "", events.EventEnvelope{}, time.Now().UTC())).WithEntityID("22222222-2222-4222-8222-222222222222")
+		events.EventType("opco.spinup_requested"), "", "", []byte(`{"entity_id":"22222222-2222-4222-8222-222222222222","instance_id":"11111111-1111-4111-8111-111111111111","product_id":"product-1"}`), 0, templateInstanceDeliveryRunID, "", events.EventEnvelope{}, time.Now().UTC())), "22222222-2222-4222-8222-222222222222")
+
 	if err := bus.Publish(ctx, spinup); err != nil {
 		t.Fatalf("Publish spinup: %v", err)
 	}
@@ -310,7 +317,7 @@ func TestTemplateInstanceAcknowledgedPublishDispatchesRoutedSystemNodeWithoutInt
 		},
 	})
 
-	mailbox := events.NewProjectionEvent(
+	mailbox := eventtest.Projection(
 		"99999999-9999-4999-8999-999999999913",
 		events.EventType("mailbox.item_decided"),
 		"",
@@ -320,8 +327,8 @@ func TestTemplateInstanceAcknowledgedPublishDispatchesRoutedSystemNodeWithoutInt
 		templateInstanceDeliveryRunID,
 		"",
 		events.EventEnvelope{EntityID: "22222222-2222-4222-8222-222222222222"},
-		time.Now().UTC(),
-	)
+		time.Now().UTC())
+
 	if err := bus.PublishAcknowledged(ctx, mailbox); err != nil {
 		t.Fatalf("PublishAcknowledged mailbox: %v", err)
 	}
@@ -429,9 +436,10 @@ func TestTemplateInstanceRootOutboxEventDispatchesRoutedSystemNodeAndEmpireStyle
 		t.Fatal("workflow runtime did not subscribe")
 	}
 
-	mailbox := (events.NewProjectionEvent("99999999-9999-4999-8999-999999999912",
+	mailbox := eventtest.WithEntityID((eventtest.Projection("99999999-9999-4999-8999-999999999912",
 
-		events.EventType("mailbox.item_decided"), "", "", []byte(`{"entity_id":"22222222-2222-4222-8222-222222222222","instance_id":"11111111-1111-4111-8111-111111111111","product_id":"product-1"}`), 0, templateInstanceDeliveryRunID, "", events.EventEnvelope{}, time.Now().UTC())).WithEntityID("22222222-2222-4222-8222-222222222222")
+		events.EventType("mailbox.item_decided"), "", "", []byte(`{"entity_id":"22222222-2222-4222-8222-222222222222","instance_id":"11111111-1111-4111-8111-111111111111","product_id":"product-1"}`), 0, templateInstanceDeliveryRunID, "", events.EventEnvelope{}, time.Now().UTC())), "22222222-2222-4222-8222-222222222222")
+
 	if err := bus.Publish(ctx, mailbox); err != nil {
 		t.Fatalf("Publish mailbox: %v", err)
 	}

--- a/internal/runtime/testcases/helpers_test.go
+++ b/internal/runtime/testcases/helpers_test.go
@@ -89,9 +89,18 @@ func previewHandler(t testing.TB, bundle *runtimecontracts.WorkflowContractBundl
 	if err != nil {
 		t.Fatalf("marshal payload: %v", err)
 	}
-	preview, err := runtimepipeline.PreviewContractHandlerExecution(context.Background(), bundle, nodeID, eventtest.WithEntityID((eventtest.Projection("evt-"+strings.ReplaceAll(eventType, ".", "-"),
+	preview, err := runtimepipeline.PreviewContractHandlerExecution(context.Background(), bundle, nodeID, eventtest.RootIngress(
+		"evt-"+strings.ReplaceAll(eventType, ".", "-"),
 		events.EventType(eventType),
-		"test-driver", "", rawPayload, 0, "", "", events.EventEnvelope{}, time.Now().UTC())), "item-123"),
+		"test-driver",
+		"",
+		rawPayload,
+		0,
+		"",
+		"",
+		events.EnvelopeForEntityID(events.EventEnvelope{}, "item-123"),
+		time.Now().UTC(),
+	),
 
 		state, policyOverrides)
 	if err != nil {

--- a/internal/runtime/testcases/helpers_test.go
+++ b/internal/runtime/testcases/helpers_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/division-sh/swarm/internal/events"
+	"github.com/division-sh/swarm/internal/events/eventtest"
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
 	models "github.com/division-sh/swarm/internal/runtime/core/actors"
 	runtimepipeline "github.com/division-sh/swarm/internal/runtime/pipeline"
@@ -88,9 +89,11 @@ func previewHandler(t testing.TB, bundle *runtimecontracts.WorkflowContractBundl
 	if err != nil {
 		t.Fatalf("marshal payload: %v", err)
 	}
-	preview, err := runtimepipeline.PreviewContractHandlerExecution(context.Background(), bundle, nodeID, (events.NewProjectionEvent("evt-"+strings.ReplaceAll(eventType, ".", "-"),
+	preview, err := runtimepipeline.PreviewContractHandlerExecution(context.Background(), bundle, nodeID, eventtest.WithEntityID((eventtest.Projection("evt-"+strings.ReplaceAll(eventType, ".", "-"),
 		events.EventType(eventType),
-		"test-driver", "", rawPayload, 0, "", "", events.EventEnvelope{}, time.Now().UTC())).WithEntityID("item-123"), state, policyOverrides)
+		"test-driver", "", rawPayload, 0, "", "", events.EventEnvelope{}, time.Now().UTC())), "item-123"),
+
+		state, policyOverrides)
 	if err != nil {
 		t.Fatalf("preview handler %s/%s: %v", nodeID, eventType, err)
 	}

--- a/internal/runtime/tools/executor_emit_test.go
+++ b/internal/runtime/tools/executor_emit_test.go
@@ -216,7 +216,18 @@ func TestHandleEmitTool_PreservesInboundChildFlowOwnerWithinActorScope(t *testin
 		FlowPath:   "validation",
 		EmitEvents: []string{"research.completed"},
 	}
-	inbound := eventtest.WithFlowInstance(eventtest.WithEntityID((eventtest.Projection("", events.EventType("validation/validation.started"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{})), "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"), "validation/inst-1")
+	inbound := eventtest.RootIngress(
+		"",
+		events.EventType("validation/validation.started"),
+		"",
+		"",
+		nil,
+		0,
+		"",
+		"",
+		events.EnvelopeForFlowInstance(events.EnvelopeForEntityID(events.EventEnvelope{}, "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"), "validation/inst-1"),
+		time.Time{},
+	)
 	ctx := runtimebus.WithInboundEvent(context.Background(), inbound)
 
 	_, err := exec.handleEmitTool(ctx, actor, "emit_research_completed", map[string]any{
@@ -273,7 +284,18 @@ func TestHandleEmitTool_DoesNotAdoptForeignInboundFlowOwner(t *testing.T) {
 		FlowPath:   "validation",
 		EmitEvents: []string{"research.completed"},
 	}
-	inbound := eventtest.WithFlowInstance(eventtest.WithEntityID((eventtest.Projection("", events.EventType("scoring/vertical.shortlisted"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{})), "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"), "scoring/inst-1")
+	inbound := eventtest.RootIngress(
+		"",
+		events.EventType("scoring/vertical.shortlisted"),
+		"",
+		"",
+		nil,
+		0,
+		"",
+		"",
+		events.EnvelopeForFlowInstance(events.EnvelopeForEntityID(events.EventEnvelope{}, "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"), "scoring/inst-1"),
+		time.Time{},
+	)
 	ctx := runtimebus.WithInboundEvent(context.Background(), inbound)
 
 	_, err := exec.handleEmitTool(ctx, actor, "emit_research_completed", map[string]any{
@@ -423,7 +445,18 @@ func TestHandleEmitTool_TargetsParentRouteForChildPinOutput(t *testing.T) {
 		FlowInstance: "wrong-root",
 		EntityID:     "33333333-3333-3333-3333-333333333333",
 	}
-	inbound := eventtest.WithTargetRoute(eventtest.WithSourceRoute((eventtest.Projection("", events.EventType("analyzer-flow/analysis.requested"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{})), wrongInboundParent), childRoute)
+	inbound := eventtest.RootIngress(
+		"",
+		events.EventType("analyzer-flow/analysis.requested"),
+		"",
+		"",
+		nil,
+		0,
+		"",
+		"",
+		events.EnvelopeForTargetRoute(events.EnvelopeForSourceRoute(events.EventEnvelope{}, wrongInboundParent), childRoute),
+		time.Time{},
+	)
 	ctx := runtimebus.WithInboundEvent(context.Background(), inbound)
 
 	_, err := exec.handleEmitTool(ctx, actor, "emit_analysis_done", map[string]any{})
@@ -495,7 +528,7 @@ func TestHandleEmitTool_FailsClosedOnIncompleteStoredParentRoute(t *testing.T) {
 		EntityID:   "22222222-2222-2222-2222-222222222222",
 		EmitEvents: []string{"analyzer-flow/analysis.done"},
 	}
-	ctx := runtimebus.WithInboundEvent(context.Background(), eventtest.Projection("", events.EventType("analyzer-flow/analysis.requested"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}))
+	ctx := runtimebus.WithInboundEvent(context.Background(), eventtest.RootIngress("", events.EventType("analyzer-flow/analysis.requested"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}))
 
 	_, err := exec.handleEmitTool(ctx, actor, "emit_analysis_done", map[string]any{})
 	if err == nil {
@@ -554,11 +587,22 @@ func TestHandleEmitTool_StaticChildPinOutputTargetsDeliveryEntity(t *testing.T) 
 		FlowPath:   "root/analyzer-flow",
 		EmitEvents: []string{"analyzer-flow/analysis.done"},
 	}
-	inbound := eventtest.WithSourceRoute(eventtest.WithEntityID((eventtest.Projection("", events.EventType("analyzer-flow/analysis.requested"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{})), "11111111-1111-1111-1111-111111111111"), events.RouteIdentity{
-		FlowID:       "wrong-root",
-		FlowInstance: "wrong-root",
-		EntityID:     "33333333-3333-3333-3333-333333333333",
-	})
+	inbound := eventtest.RootIngress(
+		"",
+		events.EventType("analyzer-flow/analysis.requested"),
+		"",
+		"",
+		nil,
+		0,
+		"",
+		"",
+		events.EnvelopeForSourceRoute(events.EnvelopeForEntityID(events.EventEnvelope{}, "11111111-1111-1111-1111-111111111111"), events.RouteIdentity{
+			FlowID:       "wrong-root",
+			FlowInstance: "wrong-root",
+			EntityID:     "33333333-3333-3333-3333-333333333333",
+		}),
+		time.Time{},
+	)
 
 	ctx := runtimebus.WithInboundEvent(context.Background(), inbound)
 
@@ -617,7 +661,18 @@ func TestHandleEmitTool_RootStaticPinOutputStillRequiresTarget(t *testing.T) {
 		FlowPath:   "analyzer-flow",
 		EmitEvents: []string{"analyzer-flow/analysis.done"},
 	}
-	inbound := eventtest.WithEntityID((eventtest.Projection("", events.EventType("analyzer-flow/analysis.requested"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{})), "11111111-1111-1111-1111-111111111111")
+	inbound := eventtest.RootIngress(
+		"",
+		events.EventType("analyzer-flow/analysis.requested"),
+		"",
+		"",
+		nil,
+		0,
+		"",
+		"",
+		events.EnvelopeForEntityID(events.EventEnvelope{}, "11111111-1111-1111-1111-111111111111"),
+		time.Time{},
+	)
 	ctx := runtimebus.WithInboundEvent(context.Background(), inbound)
 
 	_, err := exec.handleEmitTool(ctx, actor, "emit_analysis_done", map[string]any{})
@@ -695,7 +750,7 @@ func TestHandleEmitTool_RoutesConnectedOutputPinThroughCanonicalRouteAuthority(t
 	}
 	exec := NewExecutorWithOptions(eb, nil, ExecutorOptions{WorkflowSource: source, EmitRegistry: emitRegistry})
 
-	ctx := runtimebus.WithInboundEvent(context.Background(), eventtest.Projection(
+	ctx := runtimebus.WithInboundEvent(context.Background(), eventtest.RootIngress(
 		"evt-parent",
 		events.EventType("producer/deploy.requested"),
 		"runtime",
@@ -757,7 +812,7 @@ func TestHandleEmitTool_FailsClosedForConnectedOutputWithoutCanonicalRouteAuthor
 	}
 	exec := NewExecutorWithOptions(eb, nil, ExecutorOptions{WorkflowSource: source, EmitRegistry: emitRegistry})
 
-	ctx := runtimebus.WithInboundEvent(context.Background(), eventtest.Projection(
+	ctx := runtimebus.WithInboundEvent(context.Background(), eventtest.RootIngress(
 		"evt-parent",
 		events.EventType("producer/deploy.requested"),
 		"runtime",

--- a/internal/runtime/tools/executor_emit_test.go
+++ b/internal/runtime/tools/executor_emit_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/division-sh/swarm/internal/events"
+	"github.com/division-sh/swarm/internal/events/eventtest"
 	runtimebus "github.com/division-sh/swarm/internal/runtime/bus"
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
 	models "github.com/division-sh/swarm/internal/runtime/core/actors"
@@ -215,7 +216,7 @@ func TestHandleEmitTool_PreservesInboundChildFlowOwnerWithinActorScope(t *testin
 		FlowPath:   "validation",
 		EmitEvents: []string{"research.completed"},
 	}
-	inbound := (events.NewProjectionEvent("", events.EventType("validation/validation.started"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{})).WithEntityID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa").WithFlowInstance("validation/inst-1")
+	inbound := eventtest.WithFlowInstance(eventtest.WithEntityID((eventtest.Projection("", events.EventType("validation/validation.started"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{})), "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"), "validation/inst-1")
 	ctx := runtimebus.WithInboundEvent(context.Background(), inbound)
 
 	_, err := exec.handleEmitTool(ctx, actor, "emit_research_completed", map[string]any{
@@ -272,7 +273,7 @@ func TestHandleEmitTool_DoesNotAdoptForeignInboundFlowOwner(t *testing.T) {
 		FlowPath:   "validation",
 		EmitEvents: []string{"research.completed"},
 	}
-	inbound := (events.NewProjectionEvent("", events.EventType("scoring/vertical.shortlisted"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{})).WithEntityID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa").WithFlowInstance("scoring/inst-1")
+	inbound := eventtest.WithFlowInstance(eventtest.WithEntityID((eventtest.Projection("", events.EventType("scoring/vertical.shortlisted"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{})), "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"), "scoring/inst-1")
 	ctx := runtimebus.WithInboundEvent(context.Background(), inbound)
 
 	_, err := exec.handleEmitTool(ctx, actor, "emit_research_completed", map[string]any{
@@ -422,7 +423,7 @@ func TestHandleEmitTool_TargetsParentRouteForChildPinOutput(t *testing.T) {
 		FlowInstance: "wrong-root",
 		EntityID:     "33333333-3333-3333-3333-333333333333",
 	}
-	inbound := (events.NewProjectionEvent("", events.EventType("analyzer-flow/analysis.requested"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{})).WithSourceRoute(wrongInboundParent).WithTargetRoute(childRoute)
+	inbound := eventtest.WithTargetRoute(eventtest.WithSourceRoute((eventtest.Projection("", events.EventType("analyzer-flow/analysis.requested"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{})), wrongInboundParent), childRoute)
 	ctx := runtimebus.WithInboundEvent(context.Background(), inbound)
 
 	_, err := exec.handleEmitTool(ctx, actor, "emit_analysis_done", map[string]any{})
@@ -494,7 +495,7 @@ func TestHandleEmitTool_FailsClosedOnIncompleteStoredParentRoute(t *testing.T) {
 		EntityID:   "22222222-2222-2222-2222-222222222222",
 		EmitEvents: []string{"analyzer-flow/analysis.done"},
 	}
-	ctx := runtimebus.WithInboundEvent(context.Background(), events.NewProjectionEvent("", events.EventType("analyzer-flow/analysis.requested"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}))
+	ctx := runtimebus.WithInboundEvent(context.Background(), eventtest.Projection("", events.EventType("analyzer-flow/analysis.requested"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}))
 
 	_, err := exec.handleEmitTool(ctx, actor, "emit_analysis_done", map[string]any{})
 	if err == nil {
@@ -553,11 +554,12 @@ func TestHandleEmitTool_StaticChildPinOutputTargetsDeliveryEntity(t *testing.T) 
 		FlowPath:   "root/analyzer-flow",
 		EmitEvents: []string{"analyzer-flow/analysis.done"},
 	}
-	inbound := (events.NewProjectionEvent("", events.EventType("analyzer-flow/analysis.requested"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{})).WithEntityID("11111111-1111-1111-1111-111111111111").WithSourceRoute(events.RouteIdentity{
+	inbound := eventtest.WithSourceRoute(eventtest.WithEntityID((eventtest.Projection("", events.EventType("analyzer-flow/analysis.requested"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{})), "11111111-1111-1111-1111-111111111111"), events.RouteIdentity{
 		FlowID:       "wrong-root",
 		FlowInstance: "wrong-root",
 		EntityID:     "33333333-3333-3333-3333-333333333333",
 	})
+
 	ctx := runtimebus.WithInboundEvent(context.Background(), inbound)
 
 	_, err := exec.handleEmitTool(ctx, actor, "emit_analysis_done", map[string]any{})
@@ -615,7 +617,7 @@ func TestHandleEmitTool_RootStaticPinOutputStillRequiresTarget(t *testing.T) {
 		FlowPath:   "analyzer-flow",
 		EmitEvents: []string{"analyzer-flow/analysis.done"},
 	}
-	inbound := (events.NewProjectionEvent("", events.EventType("analyzer-flow/analysis.requested"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{})).WithEntityID("11111111-1111-1111-1111-111111111111")
+	inbound := eventtest.WithEntityID((eventtest.Projection("", events.EventType("analyzer-flow/analysis.requested"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{})), "11111111-1111-1111-1111-111111111111")
 	ctx := runtimebus.WithInboundEvent(context.Background(), inbound)
 
 	_, err := exec.handleEmitTool(ctx, actor, "emit_analysis_done", map[string]any{})
@@ -693,7 +695,7 @@ func TestHandleEmitTool_RoutesConnectedOutputPinThroughCanonicalRouteAuthority(t
 	}
 	exec := NewExecutorWithOptions(eb, nil, ExecutorOptions{WorkflowSource: source, EmitRegistry: emitRegistry})
 
-	ctx := runtimebus.WithInboundEvent(context.Background(), events.NewProjectionEvent(
+	ctx := runtimebus.WithInboundEvent(context.Background(), eventtest.Projection(
 		"evt-parent",
 		events.EventType("producer/deploy.requested"),
 		"runtime",
@@ -703,8 +705,7 @@ func TestHandleEmitTool_RoutesConnectedOutputPinThroughCanonicalRouteAuthority(t
 		"run-1474",
 		"",
 		events.EventEnvelope{},
-		time.Now().UTC(),
-	))
+		time.Now().UTC()))
 	out, err := exec.handleEmitTool(ctx, actor, "emit_deploy_done", map[string]any{})
 	if err != nil {
 		t.Fatalf("handleEmitTool: %v", err)
@@ -756,7 +757,7 @@ func TestHandleEmitTool_FailsClosedForConnectedOutputWithoutCanonicalRouteAuthor
 	}
 	exec := NewExecutorWithOptions(eb, nil, ExecutorOptions{WorkflowSource: source, EmitRegistry: emitRegistry})
 
-	ctx := runtimebus.WithInboundEvent(context.Background(), events.NewProjectionEvent(
+	ctx := runtimebus.WithInboundEvent(context.Background(), eventtest.Projection(
 		"evt-parent",
 		events.EventType("producer/deploy.requested"),
 		"runtime",
@@ -766,8 +767,7 @@ func TestHandleEmitTool_FailsClosedForConnectedOutputWithoutCanonicalRouteAuthor
 		"run-1474",
 		"",
 		events.EventEnvelope{},
-		time.Now().UTC(),
-	))
+		time.Now().UTC()))
 	_, err = exec.handleEmitTool(ctx, actor, "emit_deploy_done", map[string]any{})
 	if err == nil {
 		t.Fatal("handleEmitTool error = nil, want target_required_missing")

--- a/internal/runtime/tools/executor_entity_test.go
+++ b/internal/runtime/tools/executor_entity_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/division-sh/swarm/internal/events"
+	"github.com/division-sh/swarm/internal/events/eventtest"
 	runtimebus "github.com/division-sh/swarm/internal/runtime/bus"
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
 	models "github.com/division-sh/swarm/internal/runtime/core/actors"
@@ -66,9 +67,9 @@ func selectedForkEntityToolRuntimeContext(actor models.AgentConfig) context.Cont
 		Classification:      runtimecorrelation.RuntimeLineageClassificationForkLocal,
 		SelectedForkContext: true,
 	})
-	return runtimebus.WithInboundEvent(ctx, events.NewProjectionEvent(eventID,
-		events.EventType("validation/validation.package_ready"), "", "", []byte(`{"entity_id":"entity-typed-lineage"}`), 0, entityToolTestRunID, "", events.EventEnvelope{}, time.Unix(1700000000, 0).UTC()).
-		WithEntityID("entity-typed-lineage"))
+	return runtimebus.WithInboundEvent(ctx, eventtest.WithEntityID(eventtest.Projection(eventID,
+		events.EventType("validation/validation.package_ready"), "", "", []byte(`{"entity_id":"entity-typed-lineage"}`), 0, entityToolTestRunID, "", events.EventEnvelope{}, time.Unix(1700000000, 0).UTC()),
+		"entity-typed-lineage"))
 }
 
 func assertEntityToolDiagnosticLineage(t *testing.T, bus *entityToolRuntimeLogBus, index int) {
@@ -417,12 +418,14 @@ func TestRoleScopedEntityTools_CurrentEntityEligibilityFiltersTurnSurface(t *tes
 		"status": "root",
 	}, time.Now().UTC())
 
-	validCtx := runtimebus.WithInboundEvent(ctx, events.NewProjectionEvent("evt-current",
-		events.EventType("validation.started"), "", "", nil, 0, entityToolTestRunID, "", events.EventEnvelope{}, time.Time{}).
-		WithEntityID(currentID).WithFlowInstance("validation/inst-1"))
-	invalidCtx := runtimebus.WithInboundEvent(ctx, events.NewProjectionEvent("evt-root",
-		events.EventType("validation.started"), "", "", nil, 0, entityToolTestRunID, "", events.EventEnvelope{}, time.Time{}).
-		WithEntityID(foreignID).WithFlowInstance("run-root"))
+	validCtx := runtimebus.WithInboundEvent(ctx, eventtest.WithFlowInstance(eventtest.WithEntityID(eventtest.Projection("evt-current",
+		events.EventType("validation.started"), "", "", nil, 0, entityToolTestRunID, "", events.EventEnvelope{}, time.Time{}),
+		currentID),
+		"validation/inst-1"))
+	invalidCtx := runtimebus.WithInboundEvent(ctx, eventtest.WithFlowInstance(eventtest.WithEntityID(eventtest.Projection("evt-root",
+		events.EventType("validation.started"), "", "", nil, 0, entityToolTestRunID, "", events.EventEnvelope{}, time.Time{}),
+		foreignID),
+		"run-root"))
 
 	validNames := roleScopedToolDefinitionMap(exec.ToolDefinitionsForActorInContext(validCtx, actor))
 	for _, name := range []string{"read_validation_case", "read_validation_case_status", "save_validation_case_business_brief", "update_validation_case_business_brief_summary"} {
@@ -476,9 +479,10 @@ func TestRoleScopedEntityTools_GeneratedSchemasAreClosedAndRuntimeRejectsExtras(
 		"status":         "open",
 		"business_brief": map[string]any{"summary": "before", "confidence": 1},
 	}, time.Now().UTC())
-	currentCtx := runtimebus.WithInboundEvent(ctx, events.NewProjectionEvent("evt-current",
-		events.EventType("validation.started"), "", "", nil, 0, entityToolTestRunID, "", events.EventEnvelope{}, time.Time{}).
-		WithEntityID(entityID).WithFlowInstance("validation/inst-1"))
+	currentCtx := runtimebus.WithInboundEvent(ctx, eventtest.WithFlowInstance(eventtest.WithEntityID(eventtest.Projection("evt-current",
+		events.EventType("validation.started"), "", "", nil, 0, entityToolTestRunID, "", events.EventEnvelope{}, time.Time{}),
+		entityID),
+		"validation/inst-1"))
 	if _, err := exec.Execute(currentCtx, "save_validation_case_business_brief", map[string]any{
 		"value": map[string]any{
 			"summary":    "after",
@@ -532,9 +536,10 @@ func TestRoleScopedEntityTools_CurrentEntityBindingAndBypassRejection(t *testing
 	seedEntityStateRow(t, db, foreignID, "", "other/inst-1", "other_case", "queued", map[string]any{
 		"status": "foreign",
 	}, time.Now().UTC())
-	currentCtx := runtimebus.WithInboundEvent(ctx, events.NewProjectionEvent("evt-current",
-		events.EventType("validation.started"), "", "", nil, 0, entityToolTestRunID, "", events.EventEnvelope{}, time.Time{}).
-		WithEntityID(currentID).WithFlowInstance("validation/inst-1"))
+	currentCtx := runtimebus.WithInboundEvent(ctx, eventtest.WithFlowInstance(eventtest.WithEntityID(eventtest.Projection("evt-current",
+		events.EventType("validation.started"), "", "", nil, 0, entityToolTestRunID, "", events.EventEnvelope{}, time.Time{}),
+		currentID),
+		"validation/inst-1"))
 
 	if _, err := exec.Execute(currentCtx, "save_validation_case_business_brief", map[string]any{
 		"value": map[string]any{"summary": "after", "confidence": 9},
@@ -559,9 +564,10 @@ func TestRoleScopedEntityTools_CurrentEntityBindingAndBypassRejection(t *testing
 	if _, err := exec.Execute(ctx, "read_validation_case", map[string]any{}); err == nil {
 		t.Fatalf("read_validation_case succeeded without current inbound entity")
 	}
-	foreignCtx := runtimebus.WithInboundEvent(ctx, events.NewProjectionEvent("evt-foreign",
-		events.EventType("other.started"), "", "", nil, 0, entityToolTestRunID, "", events.EventEnvelope{}, time.Time{}).
-		WithEntityID(foreignID).WithFlowInstance("other/inst-1"))
+	foreignCtx := runtimebus.WithInboundEvent(ctx, eventtest.WithFlowInstance(eventtest.WithEntityID(eventtest.Projection("evt-foreign",
+		events.EventType("other.started"), "", "", nil, 0, entityToolTestRunID, "", events.EventEnvelope{}, time.Time{}),
+		foreignID),
+		"other/inst-1"))
 	if _, err := exec.Execute(foreignCtx, "read_validation_case", map[string]any{}); err == nil {
 		t.Fatalf("read_validation_case accepted foreign current entity")
 	}
@@ -591,9 +597,10 @@ func TestRoleScopedEntityTools_ReadsLargeValidationCaseWithoutLoss(t *testing.T)
 			"technical_approach": specApproach,
 		},
 	}, time.Now().UTC())
-	currentCtx := runtimebus.WithInboundEvent(ctx, events.NewProjectionEvent("evt-current",
-		events.EventType("validation.started"), "", "", nil, 0, entityToolTestRunID, "", events.EventEnvelope{}, time.Time{}).
-		WithEntityID(entityID).WithFlowInstance("validation/inst-1"))
+	currentCtx := runtimebus.WithInboundEvent(ctx, eventtest.WithFlowInstance(eventtest.WithEntityID(eventtest.Projection("evt-current",
+		events.EventType("validation.started"), "", "", nil, 0, entityToolTestRunID, "", events.EventEnvelope{}, time.Time{}),
+		entityID),
+		"validation/inst-1"))
 
 	whole, err := exec.Execute(currentCtx, "read_validation_case", map[string]any{})
 	if err != nil {

--- a/internal/runtime/tools/executor_entity_test.go
+++ b/internal/runtime/tools/executor_entity_test.go
@@ -67,9 +67,18 @@ func selectedForkEntityToolRuntimeContext(actor models.AgentConfig) context.Cont
 		Classification:      runtimecorrelation.RuntimeLineageClassificationForkLocal,
 		SelectedForkContext: true,
 	})
-	return runtimebus.WithInboundEvent(ctx, eventtest.WithEntityID(eventtest.Projection(eventID,
-		events.EventType("validation/validation.package_ready"), "", "", []byte(`{"entity_id":"entity-typed-lineage"}`), 0, entityToolTestRunID, "", events.EventEnvelope{}, time.Unix(1700000000, 0).UTC()),
-		"entity-typed-lineage"))
+	return runtimebus.WithInboundEvent(ctx, eventtest.RootIngress(
+		eventID,
+		events.EventType("validation/validation.package_ready"),
+		"",
+		"",
+		[]byte(`{"entity_id":"entity-typed-lineage"}`),
+		0,
+		entityToolTestRunID,
+		"",
+		events.EnvelopeForEntityID(events.EventEnvelope{}, "entity-typed-lineage"),
+		time.Unix(1700000000, 0).UTC(),
+	))
 }
 
 func assertEntityToolDiagnosticLineage(t *testing.T, bus *entityToolRuntimeLogBus, index int) {
@@ -418,14 +427,30 @@ func TestRoleScopedEntityTools_CurrentEntityEligibilityFiltersTurnSurface(t *tes
 		"status": "root",
 	}, time.Now().UTC())
 
-	validCtx := runtimebus.WithInboundEvent(ctx, eventtest.WithFlowInstance(eventtest.WithEntityID(eventtest.Projection("evt-current",
-		events.EventType("validation.started"), "", "", nil, 0, entityToolTestRunID, "", events.EventEnvelope{}, time.Time{}),
-		currentID),
-		"validation/inst-1"))
-	invalidCtx := runtimebus.WithInboundEvent(ctx, eventtest.WithFlowInstance(eventtest.WithEntityID(eventtest.Projection("evt-root",
-		events.EventType("validation.started"), "", "", nil, 0, entityToolTestRunID, "", events.EventEnvelope{}, time.Time{}),
-		foreignID),
-		"run-root"))
+	validCtx := runtimebus.WithInboundEvent(ctx, eventtest.RootIngress(
+		"evt-current",
+		events.EventType("validation.started"),
+		"",
+		"",
+		nil,
+		0,
+		entityToolTestRunID,
+		"",
+		events.EnvelopeForFlowInstance(events.EnvelopeForEntityID(events.EventEnvelope{}, currentID), "validation/inst-1"),
+		time.Time{},
+	))
+	invalidCtx := runtimebus.WithInboundEvent(ctx, eventtest.RootIngress(
+		"evt-root",
+		events.EventType("validation.started"),
+		"",
+		"",
+		nil,
+		0,
+		entityToolTestRunID,
+		"",
+		events.EnvelopeForFlowInstance(events.EnvelopeForEntityID(events.EventEnvelope{}, foreignID), "run-root"),
+		time.Time{},
+	))
 
 	validNames := roleScopedToolDefinitionMap(exec.ToolDefinitionsForActorInContext(validCtx, actor))
 	for _, name := range []string{"read_validation_case", "read_validation_case_status", "save_validation_case_business_brief", "update_validation_case_business_brief_summary"} {
@@ -479,10 +504,18 @@ func TestRoleScopedEntityTools_GeneratedSchemasAreClosedAndRuntimeRejectsExtras(
 		"status":         "open",
 		"business_brief": map[string]any{"summary": "before", "confidence": 1},
 	}, time.Now().UTC())
-	currentCtx := runtimebus.WithInboundEvent(ctx, eventtest.WithFlowInstance(eventtest.WithEntityID(eventtest.Projection("evt-current",
-		events.EventType("validation.started"), "", "", nil, 0, entityToolTestRunID, "", events.EventEnvelope{}, time.Time{}),
-		entityID),
-		"validation/inst-1"))
+	currentCtx := runtimebus.WithInboundEvent(ctx, eventtest.RootIngress(
+		"evt-current",
+		events.EventType("validation.started"),
+		"",
+		"",
+		nil,
+		0,
+		entityToolTestRunID,
+		"",
+		events.EnvelopeForFlowInstance(events.EnvelopeForEntityID(events.EventEnvelope{}, entityID), "validation/inst-1"),
+		time.Time{},
+	))
 	if _, err := exec.Execute(currentCtx, "save_validation_case_business_brief", map[string]any{
 		"value": map[string]any{
 			"summary":    "after",
@@ -536,10 +569,18 @@ func TestRoleScopedEntityTools_CurrentEntityBindingAndBypassRejection(t *testing
 	seedEntityStateRow(t, db, foreignID, "", "other/inst-1", "other_case", "queued", map[string]any{
 		"status": "foreign",
 	}, time.Now().UTC())
-	currentCtx := runtimebus.WithInboundEvent(ctx, eventtest.WithFlowInstance(eventtest.WithEntityID(eventtest.Projection("evt-current",
-		events.EventType("validation.started"), "", "", nil, 0, entityToolTestRunID, "", events.EventEnvelope{}, time.Time{}),
-		currentID),
-		"validation/inst-1"))
+	currentCtx := runtimebus.WithInboundEvent(ctx, eventtest.RootIngress(
+		"evt-current",
+		events.EventType("validation.started"),
+		"",
+		"",
+		nil,
+		0,
+		entityToolTestRunID,
+		"",
+		events.EnvelopeForFlowInstance(events.EnvelopeForEntityID(events.EventEnvelope{}, currentID), "validation/inst-1"),
+		time.Time{},
+	))
 
 	if _, err := exec.Execute(currentCtx, "save_validation_case_business_brief", map[string]any{
 		"value": map[string]any{"summary": "after", "confidence": 9},
@@ -564,10 +605,18 @@ func TestRoleScopedEntityTools_CurrentEntityBindingAndBypassRejection(t *testing
 	if _, err := exec.Execute(ctx, "read_validation_case", map[string]any{}); err == nil {
 		t.Fatalf("read_validation_case succeeded without current inbound entity")
 	}
-	foreignCtx := runtimebus.WithInboundEvent(ctx, eventtest.WithFlowInstance(eventtest.WithEntityID(eventtest.Projection("evt-foreign",
-		events.EventType("other.started"), "", "", nil, 0, entityToolTestRunID, "", events.EventEnvelope{}, time.Time{}),
-		foreignID),
-		"other/inst-1"))
+	foreignCtx := runtimebus.WithInboundEvent(ctx, eventtest.RootIngress(
+		"evt-foreign",
+		events.EventType("other.started"),
+		"",
+		"",
+		nil,
+		0,
+		entityToolTestRunID,
+		"",
+		events.EnvelopeForFlowInstance(events.EnvelopeForEntityID(events.EventEnvelope{}, foreignID), "other/inst-1"),
+		time.Time{},
+	))
 	if _, err := exec.Execute(foreignCtx, "read_validation_case", map[string]any{}); err == nil {
 		t.Fatalf("read_validation_case accepted foreign current entity")
 	}
@@ -597,10 +646,18 @@ func TestRoleScopedEntityTools_ReadsLargeValidationCaseWithoutLoss(t *testing.T)
 			"technical_approach": specApproach,
 		},
 	}, time.Now().UTC())
-	currentCtx := runtimebus.WithInboundEvent(ctx, eventtest.WithFlowInstance(eventtest.WithEntityID(eventtest.Projection("evt-current",
-		events.EventType("validation.started"), "", "", nil, 0, entityToolTestRunID, "", events.EventEnvelope{}, time.Time{}),
-		entityID),
-		"validation/inst-1"))
+	currentCtx := runtimebus.WithInboundEvent(ctx, eventtest.RootIngress(
+		"evt-current",
+		events.EventType("validation.started"),
+		"",
+		"",
+		nil,
+		0,
+		entityToolTestRunID,
+		"",
+		events.EnvelopeForFlowInstance(events.EnvelopeForEntityID(events.EventEnvelope{}, entityID), "validation/inst-1"),
+		time.Time{},
+	))
 
 	whole, err := exec.Execute(currentCtx, "read_validation_case", map[string]any{})
 	if err != nil {

--- a/internal/runtime/tools/executor_sqlite_persistence_test.go
+++ b/internal/runtime/tools/executor_sqlite_persistence_test.go
@@ -204,10 +204,18 @@ func TestRoleScopedEntityTools_SQLiteCurrentEntityPersistence(t *testing.T) {
 		WorkflowSource:    semanticview.Wrap(bundle),
 		AuthorityProvider: allowHumanTaskAuthority{},
 	})
-	currentCtx := runtimetools.WithActor(runtimebus.WithInboundEvent(ctx, eventtest.WithFlowInstance(eventtest.WithEntityID(eventtest.Projection("evt-current",
-		events.EventType("validation.started"), "", "", nil, 0, entityToolTestRunID, "", events.EventEnvelope{}, time.Time{}),
-		entityID),
-		"validation/inst-1")), actor)
+	currentCtx := runtimetools.WithActor(runtimebus.WithInboundEvent(ctx, eventtest.RootIngress(
+		"evt-current",
+		events.EventType("validation.started"),
+		"",
+		"",
+		nil,
+		0,
+		entityToolTestRunID,
+		"",
+		events.EnvelopeForFlowInstance(events.EnvelopeForEntityID(events.EventEnvelope{}, entityID), "validation/inst-1"),
+		time.Time{},
+	)), actor)
 
 	names := roleScopedToolDefinitionMap(exec.ToolDefinitionsForActorInContext(currentCtx, actor))
 	if _, ok := names["read_validation_case"]; !ok {

--- a/internal/runtime/tools/executor_sqlite_persistence_test.go
+++ b/internal/runtime/tools/executor_sqlite_persistence_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/division-sh/swarm/internal/config"
 	"github.com/division-sh/swarm/internal/events"
+	"github.com/division-sh/swarm/internal/events/eventtest"
 	runtimebus "github.com/division-sh/swarm/internal/runtime/bus"
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
 	models "github.com/division-sh/swarm/internal/runtime/core/actors"
@@ -203,9 +204,10 @@ func TestRoleScopedEntityTools_SQLiteCurrentEntityPersistence(t *testing.T) {
 		WorkflowSource:    semanticview.Wrap(bundle),
 		AuthorityProvider: allowHumanTaskAuthority{},
 	})
-	currentCtx := runtimetools.WithActor(runtimebus.WithInboundEvent(ctx, events.NewProjectionEvent("evt-current",
-		events.EventType("validation.started"), "", "", nil, 0, entityToolTestRunID, "", events.EventEnvelope{}, time.Time{}).
-		WithEntityID(entityID).WithFlowInstance("validation/inst-1")), actor)
+	currentCtx := runtimetools.WithActor(runtimebus.WithInboundEvent(ctx, eventtest.WithFlowInstance(eventtest.WithEntityID(eventtest.Projection("evt-current",
+		events.EventType("validation.started"), "", "", nil, 0, entityToolTestRunID, "", events.EventEnvelope{}, time.Time{}),
+		entityID),
+		"validation/inst-1")), actor)
 
 	names := roleScopedToolDefinitionMap(exec.ToolDefinitionsForActorInContext(currentCtx, actor))
 	if _, ok := names["read_validation_case"]; !ok {

--- a/internal/runtime/tools/executor_telemetry_test.go
+++ b/internal/runtime/tools/executor_telemetry_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/division-sh/swarm/internal/events"
+	"github.com/division-sh/swarm/internal/events/eventtest"
 	runtimebus "github.com/division-sh/swarm/internal/runtime/bus"
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
 	models "github.com/division-sh/swarm/internal/runtime/core/actors"
@@ -60,9 +61,9 @@ func selectedForkToolContext(actor models.AgentConfig) context.Context {
 		Classification:      runtimecorrelation.RuntimeLineageClassificationForkLocal,
 		SelectedForkContext: true,
 	})
-	return runtimebus.WithInboundEvent(ctx, events.NewProjectionEvent(eventID,
-		events.EventType("validation/validation.package_ready"), "", "", []byte(`{"entity_id":"entity-typed-lineage"}`), 0, runID, "", events.EventEnvelope{}, testTime()).
-		WithEntityID("entity-typed-lineage"))
+	return runtimebus.WithInboundEvent(ctx, eventtest.WithEntityID(eventtest.Projection(eventID,
+		events.EventType("validation/validation.package_ready"), "", "", []byte(`{"entity_id":"entity-typed-lineage"}`), 0, runID, "", events.EventEnvelope{}, testTime()),
+		"entity-typed-lineage"))
 }
 
 func assertToolExecutorDiagnosticLineage(t *testing.T, bus *telemetryBusStub, index int) {
@@ -358,10 +359,10 @@ func TestExecutorTelemetry_EmitToolLogsStructuredPublishedOutcome(t *testing.T) 
 			"category.assessed",
 		},
 	})
-	ctx = runtimebus.WithInboundEvent(ctx, events.NewProjectionEvent("evt-inbound",
+	ctx = runtimebus.WithInboundEvent(ctx, eventtest.WithEntityID(eventtest.Projection("evt-inbound",
 		events.EventType("trigger.input"), "", "task-inbound",
-		[]byte(`{"entity_id":"entity-inbound"}`), 0, "", "", events.EventEnvelope{}, testTime()).
-		WithEntityID("entity-inbound"))
+		[]byte(`{"entity_id":"entity-inbound"}`), 0, "", "", events.EventEnvelope{}, testTime()),
+		"entity-inbound"))
 
 	if _, err := exec.Execute(ctx, "emit_category_assessed", map[string]any{"category": "AP automation"}); err != nil {
 		t.Fatalf("Execute(emit): %v", err)
@@ -504,10 +505,10 @@ func TestExecutorTelemetry_EmitToolLogsUndeclaredFieldSchemaValidationFailure(t 
 			"category.assessed",
 		},
 	})
-	ctx = runtimebus.WithInboundEvent(ctx, events.NewProjectionEvent("evt-inbound",
+	ctx = runtimebus.WithInboundEvent(ctx, eventtest.WithEntityID(eventtest.Projection("evt-inbound",
 		events.EventType("trigger.input"), "", "task-inbound",
-		[]byte(`{"entity_id":"entity-inbound"}`), 0, "", "", events.EventEnvelope{}, testTime()).
-		WithEntityID("entity-inbound"))
+		[]byte(`{"entity_id":"entity-inbound"}`), 0, "", "", events.EventEnvelope{}, testTime()),
+		"entity-inbound"))
 
 	if _, err := exec.Execute(ctx, "emit_category_assessed", map[string]any{
 		"category":   "AP automation",

--- a/internal/runtime/tools/executor_telemetry_test.go
+++ b/internal/runtime/tools/executor_telemetry_test.go
@@ -61,9 +61,18 @@ func selectedForkToolContext(actor models.AgentConfig) context.Context {
 		Classification:      runtimecorrelation.RuntimeLineageClassificationForkLocal,
 		SelectedForkContext: true,
 	})
-	return runtimebus.WithInboundEvent(ctx, eventtest.WithEntityID(eventtest.Projection(eventID,
-		events.EventType("validation/validation.package_ready"), "", "", []byte(`{"entity_id":"entity-typed-lineage"}`), 0, runID, "", events.EventEnvelope{}, testTime()),
-		"entity-typed-lineage"))
+	return runtimebus.WithInboundEvent(ctx, eventtest.RootIngress(
+		eventID,
+		events.EventType("validation/validation.package_ready"),
+		"",
+		"",
+		[]byte(`{"entity_id":"entity-typed-lineage"}`),
+		0,
+		runID,
+		"",
+		events.EnvelopeForEntityID(events.EventEnvelope{}, "entity-typed-lineage"),
+		testTime(),
+	))
 }
 
 func assertToolExecutorDiagnosticLineage(t *testing.T, bus *telemetryBusStub, index int) {
@@ -359,10 +368,18 @@ func TestExecutorTelemetry_EmitToolLogsStructuredPublishedOutcome(t *testing.T) 
 			"category.assessed",
 		},
 	})
-	ctx = runtimebus.WithInboundEvent(ctx, eventtest.WithEntityID(eventtest.Projection("evt-inbound",
-		events.EventType("trigger.input"), "", "task-inbound",
-		[]byte(`{"entity_id":"entity-inbound"}`), 0, "", "", events.EventEnvelope{}, testTime()),
-		"entity-inbound"))
+	ctx = runtimebus.WithInboundEvent(ctx, eventtest.RootIngress(
+		"evt-inbound",
+		events.EventType("trigger.input"),
+		"",
+		"task-inbound",
+		[]byte(`{"entity_id":"entity-inbound"}`),
+		0,
+		"",
+		"",
+		events.EnvelopeForEntityID(events.EventEnvelope{}, "entity-inbound"),
+		testTime(),
+	))
 
 	if _, err := exec.Execute(ctx, "emit_category_assessed", map[string]any{"category": "AP automation"}); err != nil {
 		t.Fatalf("Execute(emit): %v", err)
@@ -505,10 +522,18 @@ func TestExecutorTelemetry_EmitToolLogsUndeclaredFieldSchemaValidationFailure(t 
 			"category.assessed",
 		},
 	})
-	ctx = runtimebus.WithInboundEvent(ctx, eventtest.WithEntityID(eventtest.Projection("evt-inbound",
-		events.EventType("trigger.input"), "", "task-inbound",
-		[]byte(`{"entity_id":"entity-inbound"}`), 0, "", "", events.EventEnvelope{}, testTime()),
-		"entity-inbound"))
+	ctx = runtimebus.WithInboundEvent(ctx, eventtest.RootIngress(
+		"evt-inbound",
+		events.EventType("trigger.input"),
+		"",
+		"task-inbound",
+		[]byte(`{"entity_id":"entity-inbound"}`),
+		0,
+		"",
+		"",
+		events.EnvelopeForEntityID(events.EventEnvelope{}, "entity-inbound"),
+		testTime(),
+	))
 
 	if _, err := exec.Execute(ctx, "emit_category_assessed", map[string]any{
 		"category":   "AP automation",

--- a/internal/store/bundle_delete_test.go
+++ b/internal/store/bundle_delete_test.go
@@ -285,7 +285,7 @@ func TestPostgresStore_BundleDeleteFinalMutationBlocksPostDeletePersistedSourceR
 		BundleSource:      storerunlifecycle.BundleSourcePersisted,
 		BundleFingerprint: testBootBundleFingerprint,
 	})
-	err = pg.AppendEvent(publishCtx, eventtest.Projection(eventID,
+	err = pg.AppendEvent(publishCtx, eventtest.PersistedProjection(eventID,
 
 		"scan.requested",
 		"api.v1", "", []byte(`{"topic":"medicine"}`), 0, runID, "", events.EventEnvelope{}, time.Date(2026, 5, 31, 12, 1, 0, 0, time.UTC)))

--- a/internal/store/bundle_delete_test.go
+++ b/internal/store/bundle_delete_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/division-sh/swarm/internal/events"
+	"github.com/division-sh/swarm/internal/events/eventtest"
 	"github.com/division-sh/swarm/internal/runtime/bundledelete"
 	runtimecorrelation "github.com/division-sh/swarm/internal/runtime/correlation"
 	"github.com/division-sh/swarm/internal/runtime/preservationcleanup"
@@ -284,11 +285,10 @@ func TestPostgresStore_BundleDeleteFinalMutationBlocksPostDeletePersistedSourceR
 		BundleSource:      storerunlifecycle.BundleSourcePersisted,
 		BundleFingerprint: testBootBundleFingerprint,
 	})
-	err = pg.AppendEvent(publishCtx, events.NewProjectionEvent(eventID,
+	err = pg.AppendEvent(publishCtx, eventtest.Projection(eventID,
 
 		"scan.requested",
-		"api.v1", "", []byte(`{"topic":"medicine"}`), 0, runID, "", events.EventEnvelope{}, time.Date(2026, 5, 31, 12, 1, 0, 0, time.UTC)),
-	)
+		"api.v1", "", []byte(`{"topic":"medicine"}`), 0, runID, "", events.EventEnvelope{}, time.Date(2026, 5, 31, 12, 1, 0, 0, time.UTC)))
 	if !errors.Is(err, storerunlifecycle.ErrPersistedBundleUnavailable) {
 		t.Fatalf("AppendEvent after delete error = %v, want ErrPersistedBundleUnavailable", err)
 	}

--- a/internal/store/dead_letters_test.go
+++ b/internal/store/dead_letters_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/division-sh/swarm/internal/events"
+	"github.com/division-sh/swarm/internal/events/eventtest"
 	runtimedeadletters "github.com/division-sh/swarm/internal/runtime/deadletters"
 	"github.com/division-sh/swarm/internal/testutil"
 	"github.com/google/uuid"
@@ -18,9 +19,10 @@ func TestRecordDeadLetter_PersistsAndDedupes(t *testing.T) {
 	ctx := context.Background()
 
 	entityID := uuid.NewString()
-	evt := (events.NewProjectionEvent(uuid.NewString(),
+	evt := eventtest.WithEntityID((eventtest.Projection(uuid.NewString(),
 		"deadletter.test",
-		"runtime", "", []byte(`{"x":1}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())).WithEntityID(entityID)
+		"runtime", "", []byte(`{"x":1}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())), entityID)
+
 	if err := pg.AppendEvent(ctx, evt); err != nil {
 		t.Fatalf("AppendEvent: %v", err)
 	}
@@ -63,7 +65,7 @@ func TestRecordDeadLetter_AllowsNonUUIDEntityIDViaSourceEventPayload(t *testing.
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 
-	evt := events.NewProjectionEvent(uuid.NewString(),
+	evt := eventtest.Projection(uuid.NewString(),
 		"deadletter.test",
 		"runtime", "", []byte(`{"entity_id":"ent-001","x":1}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())
 
@@ -105,9 +107,10 @@ func TestRecordDeadLetter_PersistsTargetResolutionFailureContext(t *testing.T) {
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 
-	evt := (events.NewProjectionEvent(uuid.NewString(),
+	evt := eventtest.WithTargetRoute((eventtest.Projection(uuid.NewString(),
 		"pin.output",
-		"runtime", "", []byte(`{"x":1}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())).WithTargetRoute(events.RouteIdentity{EntityID: uuid.NewString(), FlowInstance: "flow/target"})
+		"runtime", "", []byte(`{"x":1}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())), events.RouteIdentity{EntityID: uuid.NewString(), FlowInstance: "flow/target"})
+
 	if err := pg.AppendEvent(ctx, evt); err != nil {
 		t.Fatalf("AppendEvent: %v", err)
 	}

--- a/internal/store/dead_letters_test.go
+++ b/internal/store/dead_letters_test.go
@@ -19,9 +19,18 @@ func TestRecordDeadLetter_PersistsAndDedupes(t *testing.T) {
 	ctx := context.Background()
 
 	entityID := uuid.NewString()
-	evt := eventtest.WithEntityID((eventtest.Projection(uuid.NewString(),
+	evt := eventtest.PersistedProjection(
+		uuid.NewString(),
 		"deadletter.test",
-		"runtime", "", []byte(`{"x":1}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())), entityID)
+		"runtime",
+		"",
+		[]byte(`{"x":1}`),
+		0,
+		"",
+		"",
+		events.EnvelopeForEntityID(events.EventEnvelope{}, entityID),
+		time.Now().UTC(),
+	)
 
 	if err := pg.AppendEvent(ctx, evt); err != nil {
 		t.Fatalf("AppendEvent: %v", err)
@@ -65,7 +74,7 @@ func TestRecordDeadLetter_AllowsNonUUIDEntityIDViaSourceEventPayload(t *testing.
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 
-	evt := eventtest.Projection(uuid.NewString(),
+	evt := eventtest.PersistedProjection(uuid.NewString(),
 		"deadletter.test",
 		"runtime", "", []byte(`{"entity_id":"ent-001","x":1}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())
 
@@ -107,9 +116,18 @@ func TestRecordDeadLetter_PersistsTargetResolutionFailureContext(t *testing.T) {
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 
-	evt := eventtest.WithTargetRoute((eventtest.Projection(uuid.NewString(),
+	evt := eventtest.PersistedProjection(
+		uuid.NewString(),
 		"pin.output",
-		"runtime", "", []byte(`{"x":1}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())), events.RouteIdentity{EntityID: uuid.NewString(), FlowInstance: "flow/target"})
+		"runtime",
+		"",
+		[]byte(`{"x":1}`),
+		0,
+		"",
+		"",
+		events.EnvelopeForTargetRoute(events.EventEnvelope{}, events.RouteIdentity{EntityID: uuid.NewString(), FlowInstance: "flow/target"}),
+		time.Now().UTC(),
+	)
 
 	if err := pg.AppendEvent(ctx, evt); err != nil {
 		t.Fatalf("AppendEvent: %v", err)

--- a/internal/store/diagnostic_direct_replay_test.go
+++ b/internal/store/diagnostic_direct_replay_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/division-sh/swarm/internal/events"
+	"github.com/division-sh/swarm/internal/events/eventtest"
 	runtimepkg "github.com/division-sh/swarm/internal/runtime"
 	runtimebus "github.com/division-sh/swarm/internal/runtime/bus"
 	runtimecorrelation "github.com/division-sh/swarm/internal/runtime/correlation"
@@ -27,24 +28,22 @@ func TestSQLiteRuntimeStoreListEventsMissingPipelineReceiptExcludesDiagnosticDir
 	agentDirectiveID := uuid.NewString()
 	executableID := uuid.NewString()
 
-	appendSQLiteReplayTestEvent(t, ctx, store, events.NewProjectionEvent(inboundID,
+	appendSQLiteReplayTestEvent(t, ctx, store, eventtest.WithEntityID(eventtest.Projection(inboundID,
 
 		events.EventType("platform.inbound_recorded"),
-		"github", "", json.RawMessage(`{"provider":"github","provider_event_id":"provider-event-1","entity_id":"`+entityID+`"}`), 0, runID, "", events.EventEnvelope{}, now.Add(time.Second)).
-		WithEntityID(entityID))
-	appendSQLiteReplayTestEvent(t, ctx, store, events.NewProjectionEvent(agentDirectiveID,
+		"github", "", json.RawMessage(`{"provider":"github","provider_event_id":"provider-event-1","entity_id":"`+entityID+`"}`), 0, runID, "", events.EventEnvelope{}, now.Add(time.Second)),
+		entityID))
+	appendSQLiteReplayTestEvent(t, ctx, store, eventtest.Projection(agentDirectiveID,
 
 		events.EventType("platform.agent_directive"),
-		"runtime", "", json.RawMessage(`{"agent_id":"agent-1","directive":"resume"}`), 0, runID, "", events.EventEnvelope{}, now.Add(2*time.Second)),
-	)
+		"runtime", "", json.RawMessage(`{"agent_id":"agent-1","directive":"resume"}`), 0, runID, "", events.EventEnvelope{}, now.Add(2*time.Second)))
 	if err := store.UpsertCommittedReplayScope(ctx, agentDirectiveID, runtimereplayclaim.CommittedReplayScopeDirect); err != nil {
 		t.Fatalf("UpsertCommittedReplayScope(agent directive): %v", err)
 	}
-	appendSQLiteReplayTestEvent(t, ctx, store, events.NewProjectionEvent(executableID,
+	appendSQLiteReplayTestEvent(t, ctx, store, eventtest.Projection(executableID,
 
 		events.EventType("workflow.executable"),
-		"runtime", "", json.RawMessage(`{"ok":true}`), 0, runID, "", events.EventEnvelope{}, now.Add(3*time.Second)),
-	)
+		"runtime", "", json.RawMessage(`{"ok":true}`), 0, runID, "", events.EventEnvelope{}, now.Add(3*time.Second)))
 
 	globalMissing, err := store.ListEventsMissingPipelineReceipt(ctx, now.Add(-time.Hour), 20)
 	if err != nil {
@@ -102,19 +101,17 @@ func TestPostgresStoreListEventsMissingPipelineReceiptExcludesDiagnosticDirectEv
 	agentDirectiveID := uuid.NewString()
 	executableID := uuid.NewString()
 
-	appendPostgresReplayTestEvent(t, ctx, pg, events.NewProjectionEvent(agentDirectiveID,
+	appendPostgresReplayTestEvent(t, ctx, pg, eventtest.Projection(agentDirectiveID,
 
 		events.EventType("platform.agent_directive"),
-		"runtime", "", json.RawMessage(`{"agent_id":"agent-1","directive":"resume"}`), 0, runID, "", events.EventEnvelope{}, now.Add(2*time.Second)),
-	)
+		"runtime", "", json.RawMessage(`{"agent_id":"agent-1","directive":"resume"}`), 0, runID, "", events.EventEnvelope{}, now.Add(2*time.Second)))
 	if err := pg.UpsertCommittedReplayScope(ctx, agentDirectiveID, runtimereplayclaim.CommittedReplayScopeDirect); err != nil {
 		t.Fatalf("UpsertCommittedReplayScope(agent directive): %v", err)
 	}
-	appendPostgresReplayTestEvent(t, ctx, pg, events.NewProjectionEvent(executableID,
+	appendPostgresReplayTestEvent(t, ctx, pg, eventtest.Projection(executableID,
 
 		events.EventType("workflow.executable"),
-		"runtime", "", json.RawMessage(`{"ok":true}`), 0, runID, "", events.EventEnvelope{}, now.Add(3*time.Second)),
-	)
+		"runtime", "", json.RawMessage(`{"ok":true}`), 0, runID, "", events.EventEnvelope{}, now.Add(3*time.Second)))
 
 	globalMissing, err := pg.ListEventsMissingPipelineReceipt(ctx, now.Add(-time.Hour), 20)
 	if err != nil {

--- a/internal/store/diagnostic_direct_replay_test.go
+++ b/internal/store/diagnostic_direct_replay_test.go
@@ -28,19 +28,26 @@ func TestSQLiteRuntimeStoreListEventsMissingPipelineReceiptExcludesDiagnosticDir
 	agentDirectiveID := uuid.NewString()
 	executableID := uuid.NewString()
 
-	appendSQLiteReplayTestEvent(t, ctx, store, eventtest.WithEntityID(eventtest.Projection(inboundID,
-
+	appendSQLiteReplayTestEvent(t, ctx, store, eventtest.PersistedProjection(
+		inboundID,
 		events.EventType("platform.inbound_recorded"),
-		"github", "", json.RawMessage(`{"provider":"github","provider_event_id":"provider-event-1","entity_id":"`+entityID+`"}`), 0, runID, "", events.EventEnvelope{}, now.Add(time.Second)),
-		entityID))
-	appendSQLiteReplayTestEvent(t, ctx, store, eventtest.Projection(agentDirectiveID,
+		"github",
+		"",
+		json.RawMessage(`{"provider":"github","provider_event_id":"provider-event-1","entity_id":"`+entityID+`"}`),
+		0,
+		runID,
+		"",
+		events.EnvelopeForEntityID(events.EventEnvelope{}, entityID),
+		now.Add(time.Second),
+	))
+	appendSQLiteReplayTestEvent(t, ctx, store, eventtest.PersistedProjection(agentDirectiveID,
 
 		events.EventType("platform.agent_directive"),
 		"runtime", "", json.RawMessage(`{"agent_id":"agent-1","directive":"resume"}`), 0, runID, "", events.EventEnvelope{}, now.Add(2*time.Second)))
 	if err := store.UpsertCommittedReplayScope(ctx, agentDirectiveID, runtimereplayclaim.CommittedReplayScopeDirect); err != nil {
 		t.Fatalf("UpsertCommittedReplayScope(agent directive): %v", err)
 	}
-	appendSQLiteReplayTestEvent(t, ctx, store, eventtest.Projection(executableID,
+	appendSQLiteReplayTestEvent(t, ctx, store, eventtest.PersistedProjection(executableID,
 
 		events.EventType("workflow.executable"),
 		"runtime", "", json.RawMessage(`{"ok":true}`), 0, runID, "", events.EventEnvelope{}, now.Add(3*time.Second)))
@@ -101,14 +108,14 @@ func TestPostgresStoreListEventsMissingPipelineReceiptExcludesDiagnosticDirectEv
 	agentDirectiveID := uuid.NewString()
 	executableID := uuid.NewString()
 
-	appendPostgresReplayTestEvent(t, ctx, pg, eventtest.Projection(agentDirectiveID,
+	appendPostgresReplayTestEvent(t, ctx, pg, eventtest.PersistedProjection(agentDirectiveID,
 
 		events.EventType("platform.agent_directive"),
 		"runtime", "", json.RawMessage(`{"agent_id":"agent-1","directive":"resume"}`), 0, runID, "", events.EventEnvelope{}, now.Add(2*time.Second)))
 	if err := pg.UpsertCommittedReplayScope(ctx, agentDirectiveID, runtimereplayclaim.CommittedReplayScopeDirect); err != nil {
 		t.Fatalf("UpsertCommittedReplayScope(agent directive): %v", err)
 	}
-	appendPostgresReplayTestEvent(t, ctx, pg, eventtest.Projection(executableID,
+	appendPostgresReplayTestEvent(t, ctx, pg, eventtest.PersistedProjection(executableID,
 
 		events.EventType("workflow.executable"),
 		"runtime", "", json.RawMessage(`{"ok":true}`), 0, runID, "", events.EventEnvelope{}, now.Add(3*time.Second)))

--- a/internal/store/event_admission_persistence_test.go
+++ b/internal/store/event_admission_persistence_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/division-sh/swarm/internal/events"
+	"github.com/division-sh/swarm/internal/events/eventtest"
 	runtimepkg "github.com/division-sh/swarm/internal/runtime"
 	runtimecorrelation "github.com/division-sh/swarm/internal/runtime/correlation"
 	"github.com/division-sh/swarm/internal/runtime/diaglog"
@@ -52,7 +53,7 @@ func TestPostgresEventAdmissionRejectsProjectionDirectAppendWithoutAuthoritative
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 
-	err := pg.AppendEvent(ctx, events.NewProjectionEvent(
+	err := pg.AppendEvent(ctx, eventtest.Projection(
 		"",
 		events.EventType("task.completed"),
 		"agent-1",
@@ -62,8 +63,7 @@ func TestPostgresEventAdmissionRejectsProjectionDirectAppendWithoutAuthoritative
 		"",
 		"",
 		events.EventEnvelope{},
-		time.Time{},
-	))
+		time.Time{}))
 	if err == nil {
 		t.Fatal("expected malformed projection event to fail admission")
 	}
@@ -73,7 +73,7 @@ func TestPostgresEventAdmissionRejectsProjectionDirectAppendWithoutAuthoritative
 
 	err = pg.AppendEvent(runtimecorrelation.WithRuntimeLineage(ctx, runtimecorrelation.RuntimeLineage{
 		RunID: uuid.NewString(),
-	}), events.NewProjectionEvent(
+	}), eventtest.Projection(
 		uuid.NewString(),
 		events.EventType("task.completed"),
 		"agent-1",
@@ -83,8 +83,8 @@ func TestPostgresEventAdmissionRejectsProjectionDirectAppendWithoutAuthoritative
 		"",
 		"",
 		events.EventEnvelope{},
-		time.Date(2026, 6, 6, 10, 11, 12, 0, time.UTC),
-	))
+		time.Date(2026, 6, 6, 10, 11, 12, 0, time.UTC)),
+	)
 	if err == nil {
 		t.Fatal("expected projection event missing own run_id to fail admission")
 	}
@@ -136,7 +136,7 @@ func TestSQLiteEventAdmissionRejectsProjectionDirectAppendWithoutAuthoritativeFa
 	sqliteStore := newBootstrappedSQLiteRuntimeStoreForTest(t)
 	ctx := context.Background()
 
-	err := sqliteStore.AppendEvent(ctx, events.NewProjectionEvent(
+	err := sqliteStore.AppendEvent(ctx, eventtest.Projection(
 		"",
 		events.EventType("task.completed"),
 		"agent-1",
@@ -146,8 +146,7 @@ func TestSQLiteEventAdmissionRejectsProjectionDirectAppendWithoutAuthoritativeFa
 		"",
 		"",
 		events.EventEnvelope{},
-		time.Time{},
-	))
+		time.Time{}))
 	if err == nil {
 		t.Fatal("expected malformed projection event to fail admission")
 	}
@@ -157,7 +156,7 @@ func TestSQLiteEventAdmissionRejectsProjectionDirectAppendWithoutAuthoritativeFa
 
 	err = sqliteStore.AppendEvent(runtimecorrelation.WithRuntimeLineage(ctx, runtimecorrelation.RuntimeLineage{
 		RunID: uuid.NewString(),
-	}), events.NewProjectionEvent(
+	}), eventtest.Projection(
 		uuid.NewString(),
 		events.EventType("task.completed"),
 		"agent-1",
@@ -167,8 +166,8 @@ func TestSQLiteEventAdmissionRejectsProjectionDirectAppendWithoutAuthoritativeFa
 		"",
 		"",
 		events.EventEnvelope{},
-		time.Date(2026, 6, 6, 10, 11, 12, 0, time.UTC),
-	))
+		time.Date(2026, 6, 6, 10, 11, 12, 0, time.UTC)),
+	)
 	if err == nil {
 		t.Fatal("expected projection event missing own run_id to fail admission")
 	}

--- a/internal/store/event_admission_persistence_test.go
+++ b/internal/store/event_admission_persistence_test.go
@@ -21,16 +21,10 @@ func TestPostgresEventAdmissionRejectsMalformedChildDirectAppend(t *testing.T) {
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 
-	err := pg.AppendEvent(ctx, events.NewChildEventWithLineage(
-		"",
+	err := pg.AppendEvent(ctx, eventtest.MalformedChildWithoutLineage(
 		events.EventType("task.completed"),
 		"agent-1",
-		"",
 		json.RawMessage(`{"ok":true}`),
-		0,
-		events.EventLineage{},
-		events.EventEnvelope{},
-		time.Time{},
 	))
 	if err == nil {
 		t.Fatal("expected malformed child event to fail admission")
@@ -53,17 +47,11 @@ func TestPostgresEventAdmissionRejectsProjectionDirectAppendWithoutAuthoritative
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 
-	err := pg.AppendEvent(ctx, eventtest.Projection(
-		"",
+	err := pg.AppendEvent(ctx, eventtest.MalformedProjectionWithoutAuthoritativeFacts(
 		events.EventType("task.completed"),
 		"agent-1",
-		"",
 		json.RawMessage(`{"ok":true}`),
-		0,
-		"",
-		"",
-		events.EventEnvelope{},
-		time.Time{}))
+	))
 	if err == nil {
 		t.Fatal("expected malformed projection event to fail admission")
 	}
@@ -73,16 +61,11 @@ func TestPostgresEventAdmissionRejectsProjectionDirectAppendWithoutAuthoritative
 
 	err = pg.AppendEvent(runtimecorrelation.WithRuntimeLineage(ctx, runtimecorrelation.RuntimeLineage{
 		RunID: uuid.NewString(),
-	}), eventtest.Projection(
+	}), eventtest.MalformedProjectionWithoutAuthoritativeRun(
 		uuid.NewString(),
 		events.EventType("task.completed"),
 		"agent-1",
-		"",
 		json.RawMessage(`{"ok":true}`),
-		0,
-		"",
-		"",
-		events.EventEnvelope{},
 		time.Date(2026, 6, 6, 10, 11, 12, 0, time.UTC)),
 	)
 	if err == nil {
@@ -105,16 +88,10 @@ func TestSQLiteEventAdmissionRejectsMalformedChildDirectAppend(t *testing.T) {
 	sqliteStore := newBootstrappedSQLiteRuntimeStoreForTest(t)
 	ctx := context.Background()
 
-	err := sqliteStore.AppendEvent(ctx, events.NewChildEventWithLineage(
-		"",
+	err := sqliteStore.AppendEvent(ctx, eventtest.MalformedChildWithoutLineage(
 		events.EventType("task.completed"),
 		"agent-1",
-		"",
 		json.RawMessage(`{"ok":true}`),
-		0,
-		events.EventLineage{},
-		events.EventEnvelope{},
-		time.Time{},
 	))
 	if err == nil {
 		t.Fatal("expected malformed child event to fail admission")
@@ -136,17 +113,11 @@ func TestSQLiteEventAdmissionRejectsProjectionDirectAppendWithoutAuthoritativeFa
 	sqliteStore := newBootstrappedSQLiteRuntimeStoreForTest(t)
 	ctx := context.Background()
 
-	err := sqliteStore.AppendEvent(ctx, eventtest.Projection(
-		"",
+	err := sqliteStore.AppendEvent(ctx, eventtest.MalformedProjectionWithoutAuthoritativeFacts(
 		events.EventType("task.completed"),
 		"agent-1",
-		"",
 		json.RawMessage(`{"ok":true}`),
-		0,
-		"",
-		"",
-		events.EventEnvelope{},
-		time.Time{}))
+	))
 	if err == nil {
 		t.Fatal("expected malformed projection event to fail admission")
 	}
@@ -156,16 +127,11 @@ func TestSQLiteEventAdmissionRejectsProjectionDirectAppendWithoutAuthoritativeFa
 
 	err = sqliteStore.AppendEvent(runtimecorrelation.WithRuntimeLineage(ctx, runtimecorrelation.RuntimeLineage{
 		RunID: uuid.NewString(),
-	}), eventtest.Projection(
+	}), eventtest.MalformedProjectionWithoutAuthoritativeRun(
 		uuid.NewString(),
 		events.EventType("task.completed"),
 		"agent-1",
-		"",
 		json.RawMessage(`{"ok":true}`),
-		0,
-		"",
-		"",
-		events.EventEnvelope{},
 		time.Date(2026, 6, 6, 10, 11, 12, 0, time.UTC)),
 	)
 	if err == nil {

--- a/internal/store/event_delivery_routes_test.go
+++ b/internal/store/event_delivery_routes_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/division-sh/swarm/internal/events"
+	"github.com/division-sh/swarm/internal/events/eventtest"
 	"github.com/division-sh/swarm/internal/testutil"
 	"github.com/google/uuid"
 )
@@ -16,12 +17,13 @@ func TestPostgresStore_EventDeliveryRoutesPersistNodeTargetRows(t *testing.T) {
 
 	ctx := context.Background()
 	pg := &PostgresStore{DB: db}
-	evt := events.NewProjectionEvent(uuid.NewString(),
-		events.EventType("child/output.done"), "", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC()).
-		WithTargetSet([]events.RouteIdentity{
+	evt := eventtest.WithTargetSet(eventtest.Projection(uuid.NewString(),
+		events.EventType("child/output.done"), "", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC()),
+		[]events.RouteIdentity{
 			{EntityID: "ent-a", FlowInstance: "child-a/inst-1"},
 			{EntityID: "ent-b", FlowInstance: "child-b/inst-1"},
 		})
+
 	if err := pg.AppendEvent(ctx, evt); err != nil {
 		t.Fatalf("AppendEvent: %v", err)
 	}

--- a/internal/store/event_delivery_routes_test.go
+++ b/internal/store/event_delivery_routes_test.go
@@ -17,12 +17,21 @@ func TestPostgresStore_EventDeliveryRoutesPersistNodeTargetRows(t *testing.T) {
 
 	ctx := context.Background()
 	pg := &PostgresStore{DB: db}
-	evt := eventtest.WithTargetSet(eventtest.Projection(uuid.NewString(),
-		events.EventType("child/output.done"), "", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC()),
-		[]events.RouteIdentity{
+	evt := eventtest.PersistedProjection(
+		uuid.NewString(),
+		events.EventType("child/output.done"),
+		"",
+		"",
+		[]byte(`{}`),
+		0,
+		"",
+		"",
+		events.EnvelopeForTargetSet(events.EventEnvelope{}, []events.RouteIdentity{
 			{EntityID: "ent-a", FlowInstance: "child-a/inst-1"},
 			{EntityID: "ent-b", FlowInstance: "child-b/inst-1"},
-		})
+		}),
+		time.Now().UTC(),
+	)
 
 	if err := pg.AppendEvent(ctx, evt); err != nil {
 		t.Fatalf("AppendEvent: %v", err)

--- a/internal/store/mailbox_materialization_test.go
+++ b/internal/store/mailbox_materialization_test.go
@@ -24,10 +24,18 @@ func TestPostgresStore_MaterializeMailboxWriteUsesTransactionAndV1ReadOwner(t *t
 	runID := uuid.NewString()
 	eventID := uuid.NewString()
 	entityID := uuid.NewString()
-	if err := store.AppendEvent(ctx, eventtest.WithFlowInstance(eventtest.WithEntityID((eventtest.Projection(eventID,
-
-		"mailbox.review_requested", "", "", json.RawMessage(`{"kind":"review"}`), 0, runID, "", events.EventEnvelope{}, time.Now().UTC())), entityID),
-		"validation/case-1")); err != nil {
+	if err := store.AppendEvent(ctx, eventtest.PersistedProjection(
+		eventID,
+		"mailbox.review_requested",
+		"",
+		"",
+		json.RawMessage(`{"kind":"review"}`),
+		0,
+		runID,
+		"",
+		events.EnvelopeForFlowInstance(events.EnvelopeForEntityID(events.EventEnvelope{}, entityID), "validation/case-1"),
+		time.Now().UTC(),
+	)); err != nil {
 		t.Fatalf("AppendEvent: %v", err)
 	}
 	item := runtimepipeline.MailboxWriteMaterialization{
@@ -79,10 +87,18 @@ func TestSQLiteRuntimeStore_MaterializeMailboxWriteUsesTransactionAndV1ReadOwner
 	runID := uuid.NewString()
 	eventID := uuid.NewString()
 	entityID := uuid.NewString()
-	if err := store.AppendEvent(ctx, eventtest.WithFlowInstance(eventtest.WithEntityID((eventtest.Projection(eventID,
-
-		"mailbox.review_requested", "", "", json.RawMessage(`{"kind":"review"}`), 0, runID, "", events.EventEnvelope{}, time.Now().UTC())), entityID),
-		"validation/case-1")); err != nil {
+	if err := store.AppendEvent(ctx, eventtest.PersistedProjection(
+		eventID,
+		"mailbox.review_requested",
+		"",
+		"",
+		json.RawMessage(`{"kind":"review"}`),
+		0,
+		runID,
+		"",
+		events.EnvelopeForFlowInstance(events.EnvelopeForEntityID(events.EventEnvelope{}, entityID), "validation/case-1"),
+		time.Now().UTC(),
+	)); err != nil {
 		t.Fatalf("AppendEvent: %v", err)
 	}
 	item := runtimepipeline.MailboxWriteMaterialization{

--- a/internal/store/mailbox_materialization_test.go
+++ b/internal/store/mailbox_materialization_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/division-sh/swarm/internal/events"
+	"github.com/division-sh/swarm/internal/events/eventtest"
 	runtimepipeline "github.com/division-sh/swarm/internal/runtime/pipeline"
 	"github.com/division-sh/swarm/internal/testutil"
 	"github.com/google/uuid"
@@ -23,9 +24,10 @@ func TestPostgresStore_MaterializeMailboxWriteUsesTransactionAndV1ReadOwner(t *t
 	runID := uuid.NewString()
 	eventID := uuid.NewString()
 	entityID := uuid.NewString()
-	if err := store.AppendEvent(ctx, (events.NewProjectionEvent(eventID,
+	if err := store.AppendEvent(ctx, eventtest.WithFlowInstance(eventtest.WithEntityID((eventtest.Projection(eventID,
 
-		"mailbox.review_requested", "", "", json.RawMessage(`{"kind":"review"}`), 0, runID, "", events.EventEnvelope{}, time.Now().UTC())).WithEntityID(entityID).WithFlowInstance("validation/case-1")); err != nil {
+		"mailbox.review_requested", "", "", json.RawMessage(`{"kind":"review"}`), 0, runID, "", events.EventEnvelope{}, time.Now().UTC())), entityID),
+		"validation/case-1")); err != nil {
 		t.Fatalf("AppendEvent: %v", err)
 	}
 	item := runtimepipeline.MailboxWriteMaterialization{
@@ -77,9 +79,10 @@ func TestSQLiteRuntimeStore_MaterializeMailboxWriteUsesTransactionAndV1ReadOwner
 	runID := uuid.NewString()
 	eventID := uuid.NewString()
 	entityID := uuid.NewString()
-	if err := store.AppendEvent(ctx, (events.NewProjectionEvent(eventID,
+	if err := store.AppendEvent(ctx, eventtest.WithFlowInstance(eventtest.WithEntityID((eventtest.Projection(eventID,
 
-		"mailbox.review_requested", "", "", json.RawMessage(`{"kind":"review"}`), 0, runID, "", events.EventEnvelope{}, time.Now().UTC())).WithEntityID(entityID).WithFlowInstance("validation/case-1")); err != nil {
+		"mailbox.review_requested", "", "", json.RawMessage(`{"kind":"review"}`), 0, runID, "", events.EventEnvelope{}, time.Now().UTC())), entityID),
+		"validation/case-1")); err != nil {
 		t.Fatalf("AppendEvent: %v", err)
 	}
 	item := runtimepipeline.MailboxWriteMaterialization{

--- a/internal/store/mailbox_v1_test.go
+++ b/internal/store/mailbox_v1_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/division-sh/swarm/internal/events"
+	"github.com/division-sh/swarm/internal/events/eventtest"
 	runtimetools "github.com/division-sh/swarm/internal/runtime/tools"
 	"github.com/division-sh/swarm/internal/testutil"
 	"github.com/google/uuid"
@@ -22,9 +23,10 @@ func TestPostgresStore_V1MailboxReadDecisionAndIdempotencyOwners(t *testing.T) {
 	entityID := uuid.NewString()
 	sourceEventID := uuid.NewString()
 	runID := uuid.NewString()
-	if err := s.AppendEvent(ctx, events.NewRootIngressEvent(sourceEventID,
-		"review.requested", "", "", json.RawMessage(`{"request":true}`), 0, runID, "", events.EventEnvelope{}, time.Time{}).
-		WithEntityID(entityID).WithFlowInstance("main/review")); err != nil {
+	if err := s.AppendEvent(ctx, eventtest.WithFlowInstance(eventtest.WithEntityID(events.NewRootIngressEvent(sourceEventID,
+		"review.requested", "", "", json.RawMessage(`{"request":true}`), 0, runID, "", events.EventEnvelope{}, time.Time{}),
+		entityID),
+		"main/review")); err != nil {
 		t.Fatalf("append source event: %v", err)
 	}
 

--- a/internal/store/mailbox_v1_test.go
+++ b/internal/store/mailbox_v1_test.go
@@ -23,10 +23,18 @@ func TestPostgresStore_V1MailboxReadDecisionAndIdempotencyOwners(t *testing.T) {
 	entityID := uuid.NewString()
 	sourceEventID := uuid.NewString()
 	runID := uuid.NewString()
-	if err := s.AppendEvent(ctx, eventtest.WithFlowInstance(eventtest.WithEntityID(events.NewRootIngressEvent(sourceEventID,
-		"review.requested", "", "", json.RawMessage(`{"request":true}`), 0, runID, "", events.EventEnvelope{}, time.Time{}),
-		entityID),
-		"main/review")); err != nil {
+	if err := s.AppendEvent(ctx, eventtest.RootIngress(
+		sourceEventID,
+		"review.requested",
+		"",
+		"",
+		json.RawMessage(`{"request":true}`),
+		0,
+		runID,
+		"",
+		events.EnvelopeForFlowInstance(events.EnvelopeForEntityID(events.EventEnvelope{}, entityID), "main/review"),
+		time.Time{},
+	)); err != nil {
 		t.Fatalf("append source event: %v", err)
 	}
 

--- a/internal/store/manager_error_branches_test.go
+++ b/internal/store/manager_error_branches_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/division-sh/swarm/internal/events"
+	"github.com/division-sh/swarm/internal/events/eventtest"
 	runtimeactors "github.com/division-sh/swarm/internal/runtime/core/actors"
 	runtimecorrelation "github.com/division-sh/swarm/internal/runtime/correlation"
 	runtimemanager "github.com/division-sh/swarm/internal/runtime/manager"
@@ -77,10 +78,9 @@ func TestPostgresStore_Manager_ErrorBranches(t *testing.T) {
 		Status: "active", HiredBy: "t", StartedAt: time.Now(),
 	})
 	evtID := uuid.NewString()
-	if err := pg.AppendEvent(ctx, events.NewProjectionEvent(evtID,
+	if err := pg.AppendEvent(ctx, eventtest.Projection(evtID,
 		"test.event",
-		"tester", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Now()),
-	); err != nil {
+		"tester", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Now())); err != nil {
 		t.Fatalf("AppendEvent: %v", err)
 	}
 	if err := pg.InsertEventDeliveries(ctx, evtID, []string{aid}); err != nil {

--- a/internal/store/manager_error_branches_test.go
+++ b/internal/store/manager_error_branches_test.go
@@ -78,7 +78,7 @@ func TestPostgresStore_Manager_ErrorBranches(t *testing.T) {
 		Status: "active", HiredBy: "t", StartedAt: time.Now(),
 	})
 	evtID := uuid.NewString()
-	if err := pg.AppendEvent(ctx, eventtest.Projection(evtID,
+	if err := pg.AppendEvent(ctx, eventtest.PersistedProjection(evtID,
 		"test.event",
 		"tester", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Now())); err != nil {
 		t.Fatalf("AppendEvent: %v", err)

--- a/internal/store/manager_retry_policy_test.go
+++ b/internal/store/manager_retry_policy_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/division-sh/swarm/internal/events"
+	"github.com/division-sh/swarm/internal/events/eventtest"
 	runtimebus "github.com/division-sh/swarm/internal/runtime/bus"
 	runtimeactors "github.com/division-sh/swarm/internal/runtime/core/actors"
 	runtimemanager "github.com/division-sh/swarm/internal/runtime/manager"
@@ -1139,9 +1140,10 @@ func seedEvent(t *testing.T, ctx context.Context, pg *store.PostgresStore, entit
 	t.Helper()
 
 	payload, _ := json.Marshal(map[string]any{"k": "v"})
-	evt := (events.NewProjectionEvent(uuid.NewString(),
+	evt := eventtest.WithEntityID((eventtest.Projection(uuid.NewString(),
 		events.EventType(eventType),
-		"store-test", "", payload, 0, "", "", events.EventEnvelope{}, time.Now().Add(-1*time.Hour))).WithEntityID(entityID)
+		"store-test", "", payload, 0, "", "", events.EventEnvelope{}, time.Now().Add(-1*time.Hour))), entityID)
+
 	if err := pg.AppendEvent(ctx, evt); err != nil {
 		t.Fatalf("append event: %v", err)
 	}

--- a/internal/store/manager_retry_policy_test.go
+++ b/internal/store/manager_retry_policy_test.go
@@ -345,7 +345,7 @@ func TestUpsertEventReceipt_ConcurrentTerminalReceiptsConvergeStandaloneRuntimeR
 		t.Fatalf("seed second agent: %v", err)
 	}
 	payload, _ := json.Marshal(map[string]any{"k": "v"})
-	evt := events.NewRuntimeControlEvent(
+	evt := eventtest.RuntimeControl(
 		uuid.NewString(),
 		events.EventType("platform.paused"),
 		"runtime",
@@ -1140,9 +1140,18 @@ func seedEvent(t *testing.T, ctx context.Context, pg *store.PostgresStore, entit
 	t.Helper()
 
 	payload, _ := json.Marshal(map[string]any{"k": "v"})
-	evt := eventtest.WithEntityID((eventtest.Projection(uuid.NewString(),
+	evt := eventtest.PersistedProjection(
+		uuid.NewString(),
 		events.EventType(eventType),
-		"store-test", "", payload, 0, "", "", events.EventEnvelope{}, time.Now().Add(-1*time.Hour))), entityID)
+		"store-test",
+		"",
+		payload,
+		0,
+		"",
+		"",
+		events.EnvelopeForEntityID(events.EventEnvelope{}, entityID),
+		time.Now().Add(-1*time.Hour),
+	)
 
 	if err := pg.AppendEvent(ctx, evt); err != nil {
 		t.Fatalf("append event: %v", err)

--- a/internal/store/postgres_smoke_test.go
+++ b/internal/store/postgres_smoke_test.go
@@ -113,9 +113,18 @@ func TestPostgresStore_Smoke_ManagerEventsMailboxInboundScanCampaigns(t *testing
 	}
 
 	// Events + deliveries + receipts.
-	evt := eventtest.WithEntityID((eventtest.Projection(uuid.NewString(),
+	evt := eventtest.PersistedProjection(
+		uuid.NewString(),
 		events.EventType("review.requested"),
-		"dashboard", "", json.RawMessage(`{"message":"hi"}`), 0, "", "", events.EventEnvelope{}, time.Now())), entityID)
+		"dashboard",
+		"",
+		json.RawMessage(`{"message":"hi"}`),
+		0,
+		"",
+		"",
+		events.EnvelopeForEntityID(events.EventEnvelope{}, entityID),
+		time.Now(),
+	)
 
 	if err := pg.AppendEvent(ctx, evt); err != nil {
 		t.Fatalf("append event: %v", err)

--- a/internal/store/postgres_smoke_test.go
+++ b/internal/store/postgres_smoke_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/division-sh/swarm/internal/events"
+	"github.com/division-sh/swarm/internal/events/eventtest"
 	runtimeactors "github.com/division-sh/swarm/internal/runtime/core/actors"
 	runtimecorrelation "github.com/division-sh/swarm/internal/runtime/correlation"
 	runtimemanager "github.com/division-sh/swarm/internal/runtime/manager"
@@ -112,9 +113,10 @@ func TestPostgresStore_Smoke_ManagerEventsMailboxInboundScanCampaigns(t *testing
 	}
 
 	// Events + deliveries + receipts.
-	evt := (events.NewProjectionEvent(uuid.NewString(),
+	evt := eventtest.WithEntityID((eventtest.Projection(uuid.NewString(),
 		events.EventType("review.requested"),
-		"dashboard", "", json.RawMessage(`{"message":"hi"}`), 0, "", "", events.EventEnvelope{}, time.Now())).WithEntityID(entityID)
+		"dashboard", "", json.RawMessage(`{"message":"hi"}`), 0, "", "", events.EventEnvelope{}, time.Now())), entityID)
+
 	if err := pg.AppendEvent(ctx, evt); err != nil {
 		t.Fatalf("append event: %v", err)
 	}

--- a/internal/store/postgres_store_additional_test.go
+++ b/internal/store/postgres_store_additional_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/division-sh/swarm/internal/events"
+	"github.com/division-sh/swarm/internal/events/eventtest"
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
 	runtimeactors "github.com/division-sh/swarm/internal/runtime/core/actors"
 	"github.com/division-sh/swarm/internal/runtime/core/eventidentity"
@@ -300,11 +301,12 @@ func TestPostgresRunLifecycleFailsClosedWhenEntityStateCountSourceUnavailable(t 
 		t.Fatalf("seed run: %v", err)
 	}
 
-	evt := events.NewProjectionEvent(uuid.NewString(),
+	evt := eventtest.WithEntityID(eventtest.Projection(uuid.NewString(),
 
 		events.EventType("scan.requested"),
-		"agent-1", "", []byte(`{}`), 0, runID, "", events.EventEnvelope{}, time.Now().UTC()).
-		WithEntityID(entityID)
+		"agent-1", "", []byte(`{}`), 0, runID, "", events.EventEnvelope{}, time.Now().UTC()),
+		entityID)
+
 	if err := pg.AppendEvent(ctx, evt); err != nil {
 		t.Fatalf("AppendEvent: %v", err)
 	}
@@ -342,11 +344,12 @@ func TestPostgresStore_AppendEvent_ReopensPrematureCompletedRunAndSyncsCounters(
 	}
 	seedPostgresEntityStateRows(t, db, ctx, runID, entityID)
 
-	evt := events.NewProjectionEvent(uuid.NewString(),
+	evt := eventtest.WithEntityID(eventtest.Projection(uuid.NewString(),
 
 		events.EventType("scan.completed"),
-		"agent-1", "", []byte(`{}`), 0, runID, "", events.EventEnvelope{}, time.Now().UTC()).
-		WithEntityID(entityID)
+		"agent-1", "", []byte(`{}`), 0, runID, "", events.EventEnvelope{}, time.Now().UTC()),
+		entityID)
+
 	if err := pg.AppendEvent(ctx, evt); err != nil {
 		t.Fatalf("AppendEvent: %v", err)
 	}
@@ -404,11 +407,12 @@ func TestPostgresStore_AppendEvent_DuplicateDoesNotReopenCompletedRun(t *testing
 	}
 	seedPostgresEntityStateRows(t, db, ctx, runID, entityID)
 
-	evt := events.NewProjectionEvent(eventID,
+	evt := eventtest.WithEntityID(eventtest.Projection(eventID,
 
 		events.EventType("scan.completed"),
-		"agent-1", "", []byte(`{}`), 0, runID, "", events.EventEnvelope{}, time.Now().UTC()).
-		WithEntityID(entityID)
+		"agent-1", "", []byte(`{}`), 0, runID, "", events.EventEnvelope{}, time.Now().UTC()),
+		entityID)
+
 	if err := pg.AppendEvent(ctx, evt); err != nil {
 		t.Fatalf("AppendEvent(duplicate): %v", err)
 	}
@@ -480,11 +484,12 @@ func TestPostgresStore_AppendEvent_AllowsRunsWithoutTriggerColumns(t *testing.T)
 
 	runID := uuid.NewString()
 	entityID := uuid.NewString()
-	evt := events.NewProjectionEvent(uuid.NewString(),
+	evt := eventtest.WithEntityID(eventtest.Projection(uuid.NewString(),
 
 		events.EventType("scan.requested"),
-		"builder", "", []byte(`{}`), 0, runID, "", events.EventEnvelope{}, time.Now().UTC()).
-		WithEntityID(entityID)
+		"builder", "", []byte(`{}`), 0, runID, "", events.EventEnvelope{}, time.Now().UTC()),
+		entityID)
+
 	if err := pg.AppendEvent(ctx, evt); err != nil {
 		t.Fatalf("AppendEvent: %v", err)
 	}
@@ -1512,11 +1517,11 @@ func TestPostgresStore_AppendEvent_EntityIDBoundaryContract(t *testing.T) {
 
 	validEntityID := uuid.NewString()
 	validEventID := uuid.NewString()
-	if err := pg.AppendEvent(ctx, (events.NewProjectionEvent(validEventID,
+	if err := pg.AppendEvent(ctx, eventtest.WithEntityID((eventtest.Projection(validEventID,
 		events.EventType("review.requested"),
 		"control-plane",
 		"legacy-task-key",
-		[]byte(`{"name":"Telemedicine Platform"}`), 0, "", "", events.EventEnvelope{}, time.Now())).WithEntityID(validEntityID)); err != nil {
+		[]byte(`{"name":"Telemedicine Platform"}`), 0, "", "", events.EventEnvelope{}, time.Now())), validEntityID)); err != nil {
 		t.Fatalf("AppendEvent(valid entity_id): %v", err)
 	}
 
@@ -1539,10 +1544,9 @@ func TestPostgresStore_AppendEvent_EntityIDBoundaryContract(t *testing.T) {
 	}
 
 	emptyEventID := uuid.NewString()
-	if err := pg.AppendEvent(ctx, events.NewProjectionEvent(emptyEventID,
+	if err := pg.AppendEvent(ctx, eventtest.Projection(emptyEventID,
 		events.EventType("review.requested"),
-		"control-plane", "", []byte(`{"name":"Telemedicine Platform"}`), 0, "", "", events.EventEnvelope{}, time.Now()),
-	); err != nil {
+		"control-plane", "", []byte(`{"name":"Telemedicine Platform"}`), 0, "", "", events.EventEnvelope{}, time.Now())); err != nil {
 		t.Fatalf("AppendEvent(empty entity_id): %v", err)
 	}
 	if err := db.QueryRowContext(ctx, `
@@ -1560,9 +1564,9 @@ func TestPostgresStore_AppendEvent_EntityIDBoundaryContract(t *testing.T) {
 	}
 
 	invalidEventID := uuid.NewString()
-	err := pg.AppendEvent(ctx, (events.NewProjectionEvent(invalidEventID,
+	err := pg.AppendEvent(ctx, eventtest.WithEntityID((eventtest.Projection(invalidEventID,
 		events.EventType("review.requested"),
-		"control-plane", "", []byte(`{"name":"Telemedicine Platform"}`), 0, "", "", events.EventEnvelope{}, time.Now())).WithEntityID("pry_hc_telemedicine_001"))
+		"control-plane", "", []byte(`{"name":"Telemedicine Platform"}`), 0, "", "", events.EventEnvelope{}, time.Now())), "pry_hc_telemedicine_001"))
 	if err == nil {
 		t.Fatal("expected AppendEvent to fail on non-UUID entity_id")
 	}
@@ -1589,9 +1593,11 @@ func TestPostgresStore_PersistEventWithDeliveries_RejectsInvalidEntityID(t *test
 	ctx := context.Background()
 
 	eventID := uuid.NewString()
-	err := pg.PersistEventWithDeliveries(ctx, (events.NewProjectionEvent(eventID,
+	err := pg.PersistEventWithDeliveries(ctx, eventtest.WithEntityID((eventtest.Projection(eventID,
 		events.EventType("review.requested"),
-		"human", "", []byte(`{"directive":"Telemedicine Platform"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())).WithEntityID("pry_hc_telemedicine_001"), []string{"control-plane"})
+		"human", "", []byte(`{"directive":"Telemedicine Platform"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())), "pry_hc_telemedicine_001"),
+
+		[]string{"control-plane"})
 	if err == nil {
 		t.Fatal("expected PersistEventWithDeliveries to fail on non-UUID entity_id")
 	}
@@ -1633,10 +1639,9 @@ func TestPostgresStore_AppendEvent_RejectsPayloadValidatorFailureBeforePersisten
 	ctx := context.Background()
 	eventID := uuid.NewString()
 
-	err := pg.AppendEvent(ctx, events.NewProjectionEvent(eventID,
+	err := pg.AppendEvent(ctx, eventtest.Projection(eventID,
 		events.EventType("task.completed"),
-		"control-plane", "", []byte(`{"ok":"bad"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC()),
-	)
+		"control-plane", "", []byte(`{"ok":"bad"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC()))
 	if err == nil {
 		t.Fatal("expected AppendEvent to fail on payload validator rejection")
 	}
@@ -1756,9 +1761,9 @@ func TestPostgresStore_GetEventReceipt_FallsBackToPersistedReceiptForNonTerminal
 	entityID := uuid.NewString()
 	seedSpecAgent(t, ctx, pg, "a1", "", "*")
 	eventID := uuid.NewString()
-	if err := pg.AppendEvent(ctx, (events.NewProjectionEvent(eventID,
+	if err := pg.AppendEvent(ctx, eventtest.WithEntityID((eventtest.Projection(eventID,
 		"system.started",
-		"runtime", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Now())).WithEntityID(entityID)); err != nil {
+		"runtime", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Now())), entityID)); err != nil {
 		t.Fatalf("seed event: %v", err)
 	}
 	if err := pg.InsertEventDeliveries(ctx, eventID, []string{"a1"}); err != nil {
@@ -1839,11 +1844,10 @@ func TestPostgresStore_AppendEvent_InheritsParentRunID(t *testing.T) {
 
 	parentID := uuid.NewString()
 	childID := uuid.NewString()
-	if err := pg.AppendEvent(ctx, events.NewProjectionEvent(parentID,
+	if err := pg.AppendEvent(ctx, eventtest.Projection(parentID,
 
 		events.EventType("parent.event"),
-		"root", "", []byte(`{}`), 0, runID, "", events.EventEnvelope{}, time.Now().UTC()),
-	); err != nil {
+		"root", "", []byte(`{}`), 0, runID, "", events.EventEnvelope{}, time.Now().UTC())); err != nil {
 		t.Fatalf("AppendEvent(parent): %v", err)
 	}
 	if err := pg.AppendEvent(context.Background(), events.NewChildEventWithLineage(childID,
@@ -2347,13 +2351,14 @@ func TestPostgresStore_ListPendingEventsForAgent_UsesTypedEnvelopeMetadata(t *te
 	seedSpecAgent(t, ctx, pg, "analysis-agent", "", "scoring.requested")
 
 	eventID := uuid.NewString()
-	evt := events.NewProjectionEvent(eventID,
+	evt := eventtest.WithEnvelope(eventtest.Projection(eventID,
 		events.EventType("scoring.requested"),
-		"runtime", "", []byte(`{"entity_id":"payload-ent","flow_instance":"payload-flow"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC()).
-		WithEnvelope(events.EventEnvelope{
+		"runtime", "", []byte(`{"entity_id":"payload-ent","flow_instance":"payload-flow"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC()),
+		events.EventEnvelope{
 			EntityID:     entityID,
 			FlowInstance: flowInstance,
 		})
+
 	if err := pg.AppendEvent(ctx, evt); err != nil {
 		t.Fatalf("AppendEvent: %v", err)
 	}
@@ -2386,11 +2391,11 @@ func TestPostgresStore_PipelineReceipts_MissingEventsQuery(t *testing.T) {
 
 	runID := uuid.NewString()
 	parentID := uuid.NewString()
-	eventProcessed := events.NewProjectionEvent(uuid.NewString(),
+	eventProcessed := eventtest.Projection(uuid.NewString(),
 		events.EventType("system.started"),
 		"runtime", "", []byte(`{"ok":true}`), 0, "", "", events.EventEnvelope{}, time.Now().Add(-2*time.Minute))
 
-	eventMissing := events.NewProjectionEvent(uuid.NewString(),
+	eventMissing := eventtest.Projection(uuid.NewString(),
 		events.EventType("system.directive"),
 		"human", "", []byte(`{"directive":"x"}`), 0, runID,
 		parentID, events.EventEnvelope{}, time.Now().Add(-1*time.Minute))
@@ -2398,10 +2403,9 @@ func TestPostgresStore_PipelineReceipts_MissingEventsQuery(t *testing.T) {
 	if _, err := db.ExecContext(ctx, `INSERT INTO runs (run_id, status) VALUES ($1::uuid, 'running') ON CONFLICT (run_id) DO NOTHING`, runID); err != nil {
 		t.Fatalf("seed run: %v", err)
 	}
-	if err := pg.AppendEvent(ctx, events.NewProjectionEvent(parentID,
+	if err := pg.AppendEvent(ctx, eventtest.Projection(parentID,
 		events.EventType("system.parent"),
-		"runtime", "", []byte(`{"ok":true}`), 0, runID, "", events.EventEnvelope{}, time.Now().Add(-3*time.Minute)),
-	); err != nil {
+		"runtime", "", []byte(`{"ok":true}`), 0, runID, "", events.EventEnvelope{}, time.Now().Add(-3*time.Minute))); err != nil {
 		t.Fatalf("append parent event: %v", err)
 	}
 	if err := pg.AppendEvent(ctx, eventProcessed); err != nil {
@@ -2449,7 +2453,7 @@ func TestPostgresStore_PipelineReceipts_MissingEventsQuery_QuarantinesNoRunIDCap
 	pg := &PostgresStore{DB: db}
 	eventID := uuid.NewString()
 	parentID := uuid.NewString()
-	evt := events.NewProjectionEvent(eventID,
+	evt := eventtest.Projection(eventID,
 		events.EventType("system.directive"),
 		"runtime", "", []byte(`{"directive":"x"}`), 0, "", parentID, events.EventEnvelope{}, time.Now().Add(-time.Minute).UTC())
 
@@ -2489,7 +2493,7 @@ func TestPostgresStore_BeginEventTx_AppendAndDeliveriesTx(t *testing.T) {
 	}
 
 	eventID := uuid.NewString()
-	evt := events.NewProjectionEvent(eventID,
+	evt := eventtest.Projection(eventID,
 		events.EventType("system.started"),
 		"runtime", "", []byte(`{"ok":true}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())
 
@@ -2523,9 +2527,11 @@ func TestPostgresStore_PersistEventWithDeliveries_SuccessAndRollbackOnFailure(t 
 	ctx := context.Background()
 
 	eventID := uuid.NewString()
-	if err := pg.PersistEventWithDeliveries(ctx, events.NewProjectionEvent(eventID,
+	if err := pg.PersistEventWithDeliveries(ctx, eventtest.Projection(eventID,
 		events.EventType("system.directive"),
-		"human", "", []byte(`{"directive":"SaaS in Argentina"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC()), []string{" control-plane ", "", "control-plane"}); err != nil {
+		"human", "", []byte(`{"directive":"SaaS in Argentina"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC()),
+
+		[]string{" control-plane ", "", "control-plane"}); err != nil {
 		t.Fatalf("PersistEventWithDeliveries success path: %v", err)
 	}
 
@@ -2541,9 +2547,11 @@ func TestPostgresStore_PersistEventWithDeliveries_SuccessAndRollbackOnFailure(t 
 	}
 
 	failedEventID := uuid.NewString()
-	err := pg.PersistEventWithDeliveries(ctx, events.NewProjectionEvent(failedEventID,
+	err := pg.PersistEventWithDeliveries(ctx, eventtest.Projection(failedEventID,
 		events.EventType("system.directive"),
-		"human", "", []byte(`{"directive":"fail path"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC()), []string{"missing-agent"})
+		"human", "", []byte(`{"directive":"fail path"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC()),
+
+		[]string{"missing-agent"})
 	if err != nil {
 		t.Fatalf("PersistEventWithDeliveries unknown subscriber should still persist: %v", err)
 	}
@@ -3590,9 +3598,9 @@ func TestEventReceipts_RetryToDeadLetter_AndPendingQueries(t *testing.T) {
 	entityID := uuid.NewString()
 	seedSpecAgent(t, ctx, pg, "a1", "", "inbound.*")
 	eventID := uuid.NewString()
-	if err := pg.AppendEvent(ctx, (events.NewProjectionEvent(eventID,
+	if err := pg.AppendEvent(ctx, eventtest.WithEntityID((eventtest.Projection(eventID,
 		"inbound.test",
-		"inbound", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Now())).WithEntityID(entityID)); err != nil {
+		"inbound", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Now())), entityID)); err != nil {
 		t.Fatalf("seed event: %v", err)
 	}
 	if err := pg.InsertEventDeliveries(ctx, eventID, []string{"a1"}); err != nil {
@@ -3650,10 +3658,9 @@ func TestListPendingSubscribedEvents_RespectsDirectDeliveryScope(t *testing.T) {
 	directSelfID := uuid.NewString()
 	noDeliveryID := uuid.NewString()
 	for idx, id := range []string{broadcastID, directOtherID, directSelfID, noDeliveryID} {
-		if err := pg.AppendEvent(ctx, events.NewProjectionEvent(id,
+		if err := pg.AppendEvent(ctx, eventtest.Projection(id,
 			"inbound.alert",
-			"runtime", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Now().Add(time.Duration(-3+idx)*time.Minute)),
-		); err != nil {
+			"runtime", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Now().Add(time.Duration(-3+idx)*time.Minute))); err != nil {
 			t.Fatalf("seed events: %v", err)
 		}
 	}
@@ -3704,18 +3711,16 @@ func TestPendingEventQueries_PreserveParentCorrelation(t *testing.T) {
 	seedSpecAgent(t, ctx, pg, "a1", "", "inbound.*")
 
 	parentID := uuid.NewString()
-	if err := pg.AppendEvent(ctx, events.NewProjectionEvent(parentID,
+	if err := pg.AppendEvent(ctx, eventtest.Projection(parentID,
 		"inbound.root",
-		"runtime", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Now().Add(-2*time.Minute)),
-	); err != nil {
+		"runtime", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Now().Add(-2*time.Minute))); err != nil {
 		t.Fatalf("AppendEvent(parent): %v", err)
 	}
 
 	childID := uuid.NewString()
-	if err := pg.AppendEvent(ctx, events.NewProjectionEvent(childID,
+	if err := pg.AppendEvent(ctx, eventtest.Projection(childID,
 		"inbound.child",
-		"runtime", "", []byte(`{}`), 0, "", parentID, events.EventEnvelope{}, time.Now().Add(-1*time.Minute)),
-	); err != nil {
+		"runtime", "", []byte(`{}`), 0, "", parentID, events.EventEnvelope{}, time.Now().Add(-1*time.Minute))); err != nil {
 		t.Fatalf("AppendEvent(child): %v", err)
 	}
 	if err := pg.InsertEventDeliveries(ctx, childID, []string{"a1"}); err != nil {
@@ -3762,9 +3767,9 @@ func TestManagerStore_EventReceiptBranches(t *testing.T) {
 	entityID := uuid.NewString()
 	seedSpecAgent(t, ctx, pg, "a1", "", "*")
 	eventID := uuid.NewString()
-	if err := pg.AppendEvent(ctx, (events.NewProjectionEvent(eventID,
+	if err := pg.AppendEvent(ctx, eventtest.WithEntityID((eventtest.Projection(eventID,
 		"system.started",
-		"runtime", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Now())).WithEntityID(entityID)); err != nil {
+		"runtime", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Now())), entityID)); err != nil {
 		t.Fatalf("seed event: %v", err)
 	}
 
@@ -3799,9 +3804,9 @@ func TestManagerStore_GetEventReceipt_FailsClosedOnMalformedSideEffects(t *testi
 	entityID := uuid.NewString()
 	seedSpecAgent(t, ctx, pg, "a1", "", "*")
 	eventID := uuid.NewString()
-	if err := pg.AppendEvent(ctx, (events.NewProjectionEvent(eventID,
+	if err := pg.AppendEvent(ctx, eventtest.WithEntityID((eventtest.Projection(eventID,
 		"system.started",
-		"runtime", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Now())).WithEntityID(entityID)); err != nil {
+		"runtime", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Now())), entityID)); err != nil {
 		t.Fatalf("seed event: %v", err)
 	}
 
@@ -6209,9 +6214,10 @@ func TestPostgresStore_Manager_MoreCoverage(t *testing.T) {
 		t.Fatalf("DeactivateRoutingRulesByEntity: %v", err)
 	}
 
-	evt := (events.NewProjectionEvent(uuid.NewString(),
+	evt := eventtest.WithEntityID((eventtest.Projection(uuid.NewString(),
 		"review.requested",
-		"human", "", json.RawMessage(`{"x":1}`), 0, "", "", events.EventEnvelope{}, time.Now().Add(-2*time.Hour))).WithEntityID(entityID)
+		"human", "", json.RawMessage(`{"x":1}`), 0, "", "", events.EventEnvelope{}, time.Now().Add(-2*time.Hour))), entityID)
+
 	if err := pg.AppendEvent(ctx, evt); err != nil {
 		t.Fatalf("AppendEvent: %v", err)
 	}

--- a/internal/store/postgres_store_additional_test.go
+++ b/internal/store/postgres_store_additional_test.go
@@ -301,11 +301,18 @@ func TestPostgresRunLifecycleFailsClosedWhenEntityStateCountSourceUnavailable(t 
 		t.Fatalf("seed run: %v", err)
 	}
 
-	evt := eventtest.WithEntityID(eventtest.Projection(uuid.NewString(),
-
+	evt := eventtest.PersistedProjection(
+		uuid.NewString(),
 		events.EventType("scan.requested"),
-		"agent-1", "", []byte(`{}`), 0, runID, "", events.EventEnvelope{}, time.Now().UTC()),
-		entityID)
+		"agent-1",
+		"",
+		[]byte(`{}`),
+		0,
+		runID,
+		"",
+		events.EnvelopeForEntityID(events.EventEnvelope{}, entityID),
+		time.Now().UTC(),
+	)
 
 	if err := pg.AppendEvent(ctx, evt); err != nil {
 		t.Fatalf("AppendEvent: %v", err)
@@ -344,11 +351,18 @@ func TestPostgresStore_AppendEvent_ReopensPrematureCompletedRunAndSyncsCounters(
 	}
 	seedPostgresEntityStateRows(t, db, ctx, runID, entityID)
 
-	evt := eventtest.WithEntityID(eventtest.Projection(uuid.NewString(),
-
+	evt := eventtest.PersistedProjection(
+		uuid.NewString(),
 		events.EventType("scan.completed"),
-		"agent-1", "", []byte(`{}`), 0, runID, "", events.EventEnvelope{}, time.Now().UTC()),
-		entityID)
+		"agent-1",
+		"",
+		[]byte(`{}`),
+		0,
+		runID,
+		"",
+		events.EnvelopeForEntityID(events.EventEnvelope{}, entityID),
+		time.Now().UTC(),
+	)
 
 	if err := pg.AppendEvent(ctx, evt); err != nil {
 		t.Fatalf("AppendEvent: %v", err)
@@ -407,11 +421,18 @@ func TestPostgresStore_AppendEvent_DuplicateDoesNotReopenCompletedRun(t *testing
 	}
 	seedPostgresEntityStateRows(t, db, ctx, runID, entityID)
 
-	evt := eventtest.WithEntityID(eventtest.Projection(eventID,
-
+	evt := eventtest.PersistedProjection(
+		eventID,
 		events.EventType("scan.completed"),
-		"agent-1", "", []byte(`{}`), 0, runID, "", events.EventEnvelope{}, time.Now().UTC()),
-		entityID)
+		"agent-1",
+		"",
+		[]byte(`{}`),
+		0,
+		runID,
+		"",
+		events.EnvelopeForEntityID(events.EventEnvelope{}, entityID),
+		time.Now().UTC(),
+	)
 
 	if err := pg.AppendEvent(ctx, evt); err != nil {
 		t.Fatalf("AppendEvent(duplicate): %v", err)
@@ -484,11 +505,18 @@ func TestPostgresStore_AppendEvent_AllowsRunsWithoutTriggerColumns(t *testing.T)
 
 	runID := uuid.NewString()
 	entityID := uuid.NewString()
-	evt := eventtest.WithEntityID(eventtest.Projection(uuid.NewString(),
-
+	evt := eventtest.PersistedProjection(
+		uuid.NewString(),
 		events.EventType("scan.requested"),
-		"builder", "", []byte(`{}`), 0, runID, "", events.EventEnvelope{}, time.Now().UTC()),
-		entityID)
+		"builder",
+		"",
+		[]byte(`{}`),
+		0,
+		runID,
+		"",
+		events.EnvelopeForEntityID(events.EventEnvelope{}, entityID),
+		time.Now().UTC(),
+	)
 
 	if err := pg.AppendEvent(ctx, evt); err != nil {
 		t.Fatalf("AppendEvent: %v", err)
@@ -1517,11 +1545,18 @@ func TestPostgresStore_AppendEvent_EntityIDBoundaryContract(t *testing.T) {
 
 	validEntityID := uuid.NewString()
 	validEventID := uuid.NewString()
-	if err := pg.AppendEvent(ctx, eventtest.WithEntityID((eventtest.Projection(validEventID,
+	if err := pg.AppendEvent(ctx, eventtest.PersistedProjection(
+		validEventID,
 		events.EventType("review.requested"),
 		"control-plane",
 		"legacy-task-key",
-		[]byte(`{"name":"Telemedicine Platform"}`), 0, "", "", events.EventEnvelope{}, time.Now())), validEntityID)); err != nil {
+		[]byte(`{"name":"Telemedicine Platform"}`),
+		0,
+		"",
+		"",
+		events.EnvelopeForEntityID(events.EventEnvelope{}, validEntityID),
+		time.Now(),
+	)); err != nil {
 		t.Fatalf("AppendEvent(valid entity_id): %v", err)
 	}
 
@@ -1544,7 +1579,7 @@ func TestPostgresStore_AppendEvent_EntityIDBoundaryContract(t *testing.T) {
 	}
 
 	emptyEventID := uuid.NewString()
-	if err := pg.AppendEvent(ctx, eventtest.Projection(emptyEventID,
+	if err := pg.AppendEvent(ctx, eventtest.PersistedProjection(emptyEventID,
 		events.EventType("review.requested"),
 		"control-plane", "", []byte(`{"name":"Telemedicine Platform"}`), 0, "", "", events.EventEnvelope{}, time.Now())); err != nil {
 		t.Fatalf("AppendEvent(empty entity_id): %v", err)
@@ -1564,9 +1599,18 @@ func TestPostgresStore_AppendEvent_EntityIDBoundaryContract(t *testing.T) {
 	}
 
 	invalidEventID := uuid.NewString()
-	err := pg.AppendEvent(ctx, eventtest.WithEntityID((eventtest.Projection(invalidEventID,
+	err := pg.AppendEvent(ctx, eventtest.PersistedProjection(
+		invalidEventID,
 		events.EventType("review.requested"),
-		"control-plane", "", []byte(`{"name":"Telemedicine Platform"}`), 0, "", "", events.EventEnvelope{}, time.Now())), "pry_hc_telemedicine_001"))
+		"control-plane",
+		"",
+		[]byte(`{"name":"Telemedicine Platform"}`),
+		0,
+		"",
+		"",
+		events.EnvelopeForEntityID(events.EventEnvelope{}, "pry_hc_telemedicine_001"),
+		time.Now(),
+	))
 	if err == nil {
 		t.Fatal("expected AppendEvent to fail on non-UUID entity_id")
 	}
@@ -1593,9 +1637,18 @@ func TestPostgresStore_PersistEventWithDeliveries_RejectsInvalidEntityID(t *test
 	ctx := context.Background()
 
 	eventID := uuid.NewString()
-	err := pg.PersistEventWithDeliveries(ctx, eventtest.WithEntityID((eventtest.Projection(eventID,
+	err := pg.PersistEventWithDeliveries(ctx, eventtest.PersistedProjection(
+		eventID,
 		events.EventType("review.requested"),
-		"human", "", []byte(`{"directive":"Telemedicine Platform"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())), "pry_hc_telemedicine_001"),
+		"human",
+		"",
+		[]byte(`{"directive":"Telemedicine Platform"}`),
+		0,
+		"",
+		"",
+		events.EnvelopeForEntityID(events.EventEnvelope{}, "pry_hc_telemedicine_001"),
+		time.Now().UTC(),
+	),
 
 		[]string{"control-plane"})
 	if err == nil {
@@ -1639,7 +1692,7 @@ func TestPostgresStore_AppendEvent_RejectsPayloadValidatorFailureBeforePersisten
 	ctx := context.Background()
 	eventID := uuid.NewString()
 
-	err := pg.AppendEvent(ctx, eventtest.Projection(eventID,
+	err := pg.AppendEvent(ctx, eventtest.PersistedProjection(eventID,
 		events.EventType("task.completed"),
 		"control-plane", "", []byte(`{"ok":"bad"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC()))
 	if err == nil {
@@ -1761,9 +1814,7 @@ func TestPostgresStore_GetEventReceipt_FallsBackToPersistedReceiptForNonTerminal
 	entityID := uuid.NewString()
 	seedSpecAgent(t, ctx, pg, "a1", "", "*")
 	eventID := uuid.NewString()
-	if err := pg.AppendEvent(ctx, eventtest.WithEntityID((eventtest.Projection(eventID,
-		"system.started",
-		"runtime", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Now())), entityID)); err != nil {
+	if err := pg.AppendEvent(ctx, eventtest.PersistedProjection(eventID, "system.started", "runtime", "", []byte(`{}`), 0, "", "", events.EnvelopeForEntityID(events.EventEnvelope{}, entityID), time.Now())); err != nil {
 		t.Fatalf("seed event: %v", err)
 	}
 	if err := pg.InsertEventDeliveries(ctx, eventID, []string{"a1"}); err != nil {
@@ -1844,13 +1895,13 @@ func TestPostgresStore_AppendEvent_InheritsParentRunID(t *testing.T) {
 
 	parentID := uuid.NewString()
 	childID := uuid.NewString()
-	if err := pg.AppendEvent(ctx, eventtest.Projection(parentID,
+	if err := pg.AppendEvent(ctx, eventtest.PersistedProjection(parentID,
 
 		events.EventType("parent.event"),
 		"root", "", []byte(`{}`), 0, runID, "", events.EventEnvelope{}, time.Now().UTC())); err != nil {
 		t.Fatalf("AppendEvent(parent): %v", err)
 	}
-	if err := pg.AppendEvent(context.Background(), events.NewChildEventWithLineage(childID,
+	if err := pg.AppendEvent(context.Background(), eventtest.ChildWithLineage(childID,
 		events.EventType("child.event"),
 		"child", "", []byte(`{}`), 0, events.EventLineage{ParentEventID: parentID}, events.EventEnvelope{}, time.Now().UTC()),
 	); err != nil {
@@ -2351,13 +2402,21 @@ func TestPostgresStore_ListPendingEventsForAgent_UsesTypedEnvelopeMetadata(t *te
 	seedSpecAgent(t, ctx, pg, "analysis-agent", "", "scoring.requested")
 
 	eventID := uuid.NewString()
-	evt := eventtest.WithEnvelope(eventtest.Projection(eventID,
+	evt := eventtest.PersistedProjection(
+		eventID,
 		events.EventType("scoring.requested"),
-		"runtime", "", []byte(`{"entity_id":"payload-ent","flow_instance":"payload-flow"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC()),
+		"runtime",
+		"",
+		[]byte(`{"entity_id":"payload-ent","flow_instance":"payload-flow"}`),
+		0,
+		"",
+		"",
 		events.EventEnvelope{
 			EntityID:     entityID,
 			FlowInstance: flowInstance,
-		})
+		},
+		time.Now().UTC(),
+	)
 
 	if err := pg.AppendEvent(ctx, evt); err != nil {
 		t.Fatalf("AppendEvent: %v", err)
@@ -2391,11 +2450,11 @@ func TestPostgresStore_PipelineReceipts_MissingEventsQuery(t *testing.T) {
 
 	runID := uuid.NewString()
 	parentID := uuid.NewString()
-	eventProcessed := eventtest.Projection(uuid.NewString(),
+	eventProcessed := eventtest.PersistedProjection(uuid.NewString(),
 		events.EventType("system.started"),
 		"runtime", "", []byte(`{"ok":true}`), 0, "", "", events.EventEnvelope{}, time.Now().Add(-2*time.Minute))
 
-	eventMissing := eventtest.Projection(uuid.NewString(),
+	eventMissing := eventtest.PersistedProjection(uuid.NewString(),
 		events.EventType("system.directive"),
 		"human", "", []byte(`{"directive":"x"}`), 0, runID,
 		parentID, events.EventEnvelope{}, time.Now().Add(-1*time.Minute))
@@ -2403,7 +2462,7 @@ func TestPostgresStore_PipelineReceipts_MissingEventsQuery(t *testing.T) {
 	if _, err := db.ExecContext(ctx, `INSERT INTO runs (run_id, status) VALUES ($1::uuid, 'running') ON CONFLICT (run_id) DO NOTHING`, runID); err != nil {
 		t.Fatalf("seed run: %v", err)
 	}
-	if err := pg.AppendEvent(ctx, eventtest.Projection(parentID,
+	if err := pg.AppendEvent(ctx, eventtest.PersistedProjection(parentID,
 		events.EventType("system.parent"),
 		"runtime", "", []byte(`{"ok":true}`), 0, runID, "", events.EventEnvelope{}, time.Now().Add(-3*time.Minute))); err != nil {
 		t.Fatalf("append parent event: %v", err)
@@ -2453,7 +2512,7 @@ func TestPostgresStore_PipelineReceipts_MissingEventsQuery_QuarantinesNoRunIDCap
 	pg := &PostgresStore{DB: db}
 	eventID := uuid.NewString()
 	parentID := uuid.NewString()
-	evt := eventtest.Projection(eventID,
+	evt := eventtest.PersistedProjection(eventID,
 		events.EventType("system.directive"),
 		"runtime", "", []byte(`{"directive":"x"}`), 0, "", parentID, events.EventEnvelope{}, time.Now().Add(-time.Minute).UTC())
 
@@ -2493,7 +2552,7 @@ func TestPostgresStore_BeginEventTx_AppendAndDeliveriesTx(t *testing.T) {
 	}
 
 	eventID := uuid.NewString()
-	evt := eventtest.Projection(eventID,
+	evt := eventtest.PersistedProjection(eventID,
 		events.EventType("system.started"),
 		"runtime", "", []byte(`{"ok":true}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())
 
@@ -2527,7 +2586,7 @@ func TestPostgresStore_PersistEventWithDeliveries_SuccessAndRollbackOnFailure(t 
 	ctx := context.Background()
 
 	eventID := uuid.NewString()
-	if err := pg.PersistEventWithDeliveries(ctx, eventtest.Projection(eventID,
+	if err := pg.PersistEventWithDeliveries(ctx, eventtest.PersistedProjection(eventID,
 		events.EventType("system.directive"),
 		"human", "", []byte(`{"directive":"SaaS in Argentina"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC()),
 
@@ -2547,7 +2606,7 @@ func TestPostgresStore_PersistEventWithDeliveries_SuccessAndRollbackOnFailure(t 
 	}
 
 	failedEventID := uuid.NewString()
-	err := pg.PersistEventWithDeliveries(ctx, eventtest.Projection(failedEventID,
+	err := pg.PersistEventWithDeliveries(ctx, eventtest.PersistedProjection(failedEventID,
 		events.EventType("system.directive"),
 		"human", "", []byte(`{"directive":"fail path"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC()),
 
@@ -3598,9 +3657,7 @@ func TestEventReceipts_RetryToDeadLetter_AndPendingQueries(t *testing.T) {
 	entityID := uuid.NewString()
 	seedSpecAgent(t, ctx, pg, "a1", "", "inbound.*")
 	eventID := uuid.NewString()
-	if err := pg.AppendEvent(ctx, eventtest.WithEntityID((eventtest.Projection(eventID,
-		"inbound.test",
-		"inbound", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Now())), entityID)); err != nil {
+	if err := pg.AppendEvent(ctx, eventtest.PersistedProjection(eventID, "inbound.test", "inbound", "", []byte(`{}`), 0, "", "", events.EnvelopeForEntityID(events.EventEnvelope{}, entityID), time.Now())); err != nil {
 		t.Fatalf("seed event: %v", err)
 	}
 	if err := pg.InsertEventDeliveries(ctx, eventID, []string{"a1"}); err != nil {
@@ -3658,7 +3715,7 @@ func TestListPendingSubscribedEvents_RespectsDirectDeliveryScope(t *testing.T) {
 	directSelfID := uuid.NewString()
 	noDeliveryID := uuid.NewString()
 	for idx, id := range []string{broadcastID, directOtherID, directSelfID, noDeliveryID} {
-		if err := pg.AppendEvent(ctx, eventtest.Projection(id,
+		if err := pg.AppendEvent(ctx, eventtest.PersistedProjection(id,
 			"inbound.alert",
 			"runtime", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Now().Add(time.Duration(-3+idx)*time.Minute))); err != nil {
 			t.Fatalf("seed events: %v", err)
@@ -3711,14 +3768,14 @@ func TestPendingEventQueries_PreserveParentCorrelation(t *testing.T) {
 	seedSpecAgent(t, ctx, pg, "a1", "", "inbound.*")
 
 	parentID := uuid.NewString()
-	if err := pg.AppendEvent(ctx, eventtest.Projection(parentID,
+	if err := pg.AppendEvent(ctx, eventtest.PersistedProjection(parentID,
 		"inbound.root",
 		"runtime", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Now().Add(-2*time.Minute))); err != nil {
 		t.Fatalf("AppendEvent(parent): %v", err)
 	}
 
 	childID := uuid.NewString()
-	if err := pg.AppendEvent(ctx, eventtest.Projection(childID,
+	if err := pg.AppendEvent(ctx, eventtest.PersistedProjection(childID,
 		"inbound.child",
 		"runtime", "", []byte(`{}`), 0, "", parentID, events.EventEnvelope{}, time.Now().Add(-1*time.Minute))); err != nil {
 		t.Fatalf("AppendEvent(child): %v", err)
@@ -3767,9 +3824,7 @@ func TestManagerStore_EventReceiptBranches(t *testing.T) {
 	entityID := uuid.NewString()
 	seedSpecAgent(t, ctx, pg, "a1", "", "*")
 	eventID := uuid.NewString()
-	if err := pg.AppendEvent(ctx, eventtest.WithEntityID((eventtest.Projection(eventID,
-		"system.started",
-		"runtime", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Now())), entityID)); err != nil {
+	if err := pg.AppendEvent(ctx, eventtest.PersistedProjection(eventID, "system.started", "runtime", "", []byte(`{}`), 0, "", "", events.EnvelopeForEntityID(events.EventEnvelope{}, entityID), time.Now())); err != nil {
 		t.Fatalf("seed event: %v", err)
 	}
 
@@ -3804,9 +3859,7 @@ func TestManagerStore_GetEventReceipt_FailsClosedOnMalformedSideEffects(t *testi
 	entityID := uuid.NewString()
 	seedSpecAgent(t, ctx, pg, "a1", "", "*")
 	eventID := uuid.NewString()
-	if err := pg.AppendEvent(ctx, eventtest.WithEntityID((eventtest.Projection(eventID,
-		"system.started",
-		"runtime", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Now())), entityID)); err != nil {
+	if err := pg.AppendEvent(ctx, eventtest.PersistedProjection(eventID, "system.started", "runtime", "", []byte(`{}`), 0, "", "", events.EnvelopeForEntityID(events.EventEnvelope{}, entityID), time.Now())); err != nil {
 		t.Fatalf("seed event: %v", err)
 	}
 
@@ -6214,9 +6267,18 @@ func TestPostgresStore_Manager_MoreCoverage(t *testing.T) {
 		t.Fatalf("DeactivateRoutingRulesByEntity: %v", err)
 	}
 
-	evt := eventtest.WithEntityID((eventtest.Projection(uuid.NewString(),
+	evt := eventtest.PersistedProjection(
+		uuid.NewString(),
 		"review.requested",
-		"human", "", json.RawMessage(`{"x":1}`), 0, "", "", events.EventEnvelope{}, time.Now().Add(-2*time.Hour))), entityID)
+		"human",
+		"",
+		json.RawMessage(`{"x":1}`),
+		0,
+		"",
+		"",
+		events.EnvelopeForEntityID(events.EventEnvelope{}, entityID),
+		time.Now().Add(-2*time.Hour),
+	)
 
 	if err := pg.AppendEvent(ctx, evt); err != nil {
 		t.Fatalf("AppendEvent: %v", err)

--- a/internal/store/run_bundle_fingerprint_test.go
+++ b/internal/store/run_bundle_fingerprint_test.go
@@ -28,7 +28,7 @@ func TestPostgresStore_RunBundleSourceClassifiesCurrentWritersAsLegacyAndKeepsSe
 	ctx := runtimecorrelation.WithBundleFingerprint(context.Background(), testBootBundleFingerprint)
 	runID := uuid.NewString()
 
-	if err := pg.AppendEvent(ctx, eventtest.Projection(uuid.NewString(),
+	if err := pg.AppendEvent(ctx, eventtest.PersistedProjection(uuid.NewString(),
 
 		"scan.requested",
 		"test", "", []byte(`{}`), 0, runID, "", events.EventEnvelope{}, time.Now().UTC())); err != nil {
@@ -37,7 +37,7 @@ func TestPostgresStore_RunBundleSourceClassifiesCurrentWritersAsLegacyAndKeepsSe
 	assertRunBundleIdentity(t, db, runID, "", storerunlifecycle.BundleSourceLegacy, testBootBundleFingerprint)
 
 	changedCtx := runtimecorrelation.WithBundleFingerprint(context.Background(), testOtherBundleFingerprint)
-	if err := pg.AppendEvent(changedCtx, eventtest.Projection(uuid.NewString(),
+	if err := pg.AppendEvent(changedCtx, eventtest.PersistedProjection(uuid.NewString(),
 
 		"scan.followup",
 		"test", "", []byte(`{}`), 0, runID, "", events.EventEnvelope{}, time.Now().UTC())); err != nil {
@@ -62,7 +62,7 @@ func TestPostgresStore_RunBundleSourceConsumesCanonicalSourceFact(t *testing.T) 
 		BundleFingerprint: testBootBundleFingerprint,
 	})
 
-	if err := pg.AppendEvent(ctx, eventtest.Projection(uuid.NewString(),
+	if err := pg.AppendEvent(ctx, eventtest.PersistedProjection(uuid.NewString(),
 
 		"scan.requested",
 		"test", "", []byte(`{}`), 0, runID, "", events.EventEnvelope{}, time.Now().UTC())); err != nil {
@@ -77,7 +77,7 @@ func TestPostgresStore_RunBundleSourceConsumesCanonicalSourceFact(t *testing.T) 
 		BundleSource:      storerunlifecycle.BundleSourceEphemeral,
 		BundleFingerprint: testOtherBundleFingerprint,
 	})
-	if err := pg.AppendEvent(ephemeralCtx, eventtest.Projection(uuid.NewString(),
+	if err := pg.AppendEvent(ephemeralCtx, eventtest.PersistedProjection(uuid.NewString(),
 
 		"scan.dev",
 		"test", "", []byte(`{}`), 0, ephemeralRunID, "", events.EventEnvelope{}, time.Now().UTC())); err != nil {
@@ -91,7 +91,7 @@ func TestPostgresStore_RunBundleSourceAllowsUnknownLegacyRows(t *testing.T) {
 	pg := &PostgresStore{DB: db}
 	runID := uuid.NewString()
 
-	if err := pg.AppendEvent(context.Background(), eventtest.Projection(uuid.NewString(),
+	if err := pg.AppendEvent(context.Background(), eventtest.PersistedProjection(uuid.NewString(),
 
 		"legacy.requested",
 		"test", "", []byte(`{}`), 0, runID, "", events.EventEnvelope{}, time.Now().UTC())); err != nil {
@@ -114,7 +114,7 @@ func TestPostgresStore_RunBundleSourceDoesNotPromoteLegacyFingerprintIntoBundleH
 	}
 
 	bootCtx := runtimecorrelation.WithBundleFingerprint(ctx, testBootBundleFingerprint)
-	if err := pg.AppendEvent(bootCtx, eventtest.Projection(uuid.NewString(),
+	if err := pg.AppendEvent(bootCtx, eventtest.PersistedProjection(uuid.NewString(),
 
 		"legacy.filled",
 		"test", "", []byte(`{}`), 0, runID, "", events.EventEnvelope{}, time.Now().UTC())); err != nil {
@@ -123,7 +123,7 @@ func TestPostgresStore_RunBundleSourceDoesNotPromoteLegacyFingerprintIntoBundleH
 	assertRunBundleIdentity(t, db, runID, "", storerunlifecycle.BundleSourceLegacy, testBootBundleFingerprint)
 
 	changedCtx := runtimecorrelation.WithBundleFingerprint(ctx, testOtherBundleFingerprint)
-	if err := pg.AppendEvent(changedCtx, eventtest.Projection(uuid.NewString(),
+	if err := pg.AppendEvent(changedCtx, eventtest.PersistedProjection(uuid.NewString(),
 
 		"legacy.followup",
 		"test", "", []byte(`{}`), 0, runID, "", events.EventEnvelope{}, time.Now().UTC())); err != nil {

--- a/internal/store/run_bundle_fingerprint_test.go
+++ b/internal/store/run_bundle_fingerprint_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/division-sh/swarm/internal/events"
+	"github.com/division-sh/swarm/internal/events/eventtest"
 	runtimecorrelation "github.com/division-sh/swarm/internal/runtime/correlation"
 	"github.com/division-sh/swarm/internal/store/runbundle"
 	storerunlifecycle "github.com/division-sh/swarm/internal/store/runlifecycle"
@@ -27,21 +28,19 @@ func TestPostgresStore_RunBundleSourceClassifiesCurrentWritersAsLegacyAndKeepsSe
 	ctx := runtimecorrelation.WithBundleFingerprint(context.Background(), testBootBundleFingerprint)
 	runID := uuid.NewString()
 
-	if err := pg.AppendEvent(ctx, events.NewProjectionEvent(uuid.NewString(),
+	if err := pg.AppendEvent(ctx, eventtest.Projection(uuid.NewString(),
 
 		"scan.requested",
-		"test", "", []byte(`{}`), 0, runID, "", events.EventEnvelope{}, time.Now().UTC()),
-	); err != nil {
+		"test", "", []byte(`{}`), 0, runID, "", events.EventEnvelope{}, time.Now().UTC())); err != nil {
 		t.Fatalf("AppendEvent(first): %v", err)
 	}
 	assertRunBundleIdentity(t, db, runID, "", storerunlifecycle.BundleSourceLegacy, testBootBundleFingerprint)
 
 	changedCtx := runtimecorrelation.WithBundleFingerprint(context.Background(), testOtherBundleFingerprint)
-	if err := pg.AppendEvent(changedCtx, events.NewProjectionEvent(uuid.NewString(),
+	if err := pg.AppendEvent(changedCtx, eventtest.Projection(uuid.NewString(),
 
 		"scan.followup",
-		"test", "", []byte(`{}`), 0, runID, "", events.EventEnvelope{}, time.Now().UTC()),
-	); err != nil {
+		"test", "", []byte(`{}`), 0, runID, "", events.EventEnvelope{}, time.Now().UTC())); err != nil {
 		t.Fatalf("AppendEvent(second): %v", err)
 	}
 	assertRunBundleIdentity(t, db, runID, "", storerunlifecycle.BundleSourceLegacy, testBootBundleFingerprint)
@@ -63,11 +62,10 @@ func TestPostgresStore_RunBundleSourceConsumesCanonicalSourceFact(t *testing.T) 
 		BundleFingerprint: testBootBundleFingerprint,
 	})
 
-	if err := pg.AppendEvent(ctx, events.NewProjectionEvent(uuid.NewString(),
+	if err := pg.AppendEvent(ctx, eventtest.Projection(uuid.NewString(),
 
 		"scan.requested",
-		"test", "", []byte(`{}`), 0, runID, "", events.EventEnvelope{}, time.Now().UTC()),
-	); err != nil {
+		"test", "", []byte(`{}`), 0, runID, "", events.EventEnvelope{}, time.Now().UTC())); err != nil {
 		t.Fatalf("AppendEvent(persisted): %v", err)
 	}
 	assertRunBundleIdentity(t, db, runID, testCanonicalBundleHash, storerunlifecycle.BundleSourcePersisted, testBootBundleFingerprint)
@@ -79,11 +77,10 @@ func TestPostgresStore_RunBundleSourceConsumesCanonicalSourceFact(t *testing.T) 
 		BundleSource:      storerunlifecycle.BundleSourceEphemeral,
 		BundleFingerprint: testOtherBundleFingerprint,
 	})
-	if err := pg.AppendEvent(ephemeralCtx, events.NewProjectionEvent(uuid.NewString(),
+	if err := pg.AppendEvent(ephemeralCtx, eventtest.Projection(uuid.NewString(),
 
 		"scan.dev",
-		"test", "", []byte(`{}`), 0, ephemeralRunID, "", events.EventEnvelope{}, time.Now().UTC()),
-	); err != nil {
+		"test", "", []byte(`{}`), 0, ephemeralRunID, "", events.EventEnvelope{}, time.Now().UTC())); err != nil {
 		t.Fatalf("AppendEvent(ephemeral): %v", err)
 	}
 	assertRunBundleIdentity(t, db, ephemeralRunID, ephemeralHash, storerunlifecycle.BundleSourceEphemeral, testOtherBundleFingerprint)
@@ -94,11 +91,10 @@ func TestPostgresStore_RunBundleSourceAllowsUnknownLegacyRows(t *testing.T) {
 	pg := &PostgresStore{DB: db}
 	runID := uuid.NewString()
 
-	if err := pg.AppendEvent(context.Background(), events.NewProjectionEvent(uuid.NewString(),
+	if err := pg.AppendEvent(context.Background(), eventtest.Projection(uuid.NewString(),
 
 		"legacy.requested",
-		"test", "", []byte(`{}`), 0, runID, "", events.EventEnvelope{}, time.Now().UTC()),
-	); err != nil {
+		"test", "", []byte(`{}`), 0, runID, "", events.EventEnvelope{}, time.Now().UTC())); err != nil {
 		t.Fatalf("AppendEvent: %v", err)
 	}
 	assertRunBundleIdentity(t, db, runID, "", storerunlifecycle.BundleSourceLegacy, "")
@@ -118,21 +114,19 @@ func TestPostgresStore_RunBundleSourceDoesNotPromoteLegacyFingerprintIntoBundleH
 	}
 
 	bootCtx := runtimecorrelation.WithBundleFingerprint(ctx, testBootBundleFingerprint)
-	if err := pg.AppendEvent(bootCtx, events.NewProjectionEvent(uuid.NewString(),
+	if err := pg.AppendEvent(bootCtx, eventtest.Projection(uuid.NewString(),
 
 		"legacy.filled",
-		"test", "", []byte(`{}`), 0, runID, "", events.EventEnvelope{}, time.Now().UTC()),
-	); err != nil {
+		"test", "", []byte(`{}`), 0, runID, "", events.EventEnvelope{}, time.Now().UTC())); err != nil {
 		t.Fatalf("AppendEvent(fill): %v", err)
 	}
 	assertRunBundleIdentity(t, db, runID, "", storerunlifecycle.BundleSourceLegacy, testBootBundleFingerprint)
 
 	changedCtx := runtimecorrelation.WithBundleFingerprint(ctx, testOtherBundleFingerprint)
-	if err := pg.AppendEvent(changedCtx, events.NewProjectionEvent(uuid.NewString(),
+	if err := pg.AppendEvent(changedCtx, eventtest.Projection(uuid.NewString(),
 
 		"legacy.followup",
-		"test", "", []byte(`{}`), 0, runID, "", events.EventEnvelope{}, time.Now().UTC()),
-	); err != nil {
+		"test", "", []byte(`{}`), 0, runID, "", events.EventEnvelope{}, time.Now().UTC())); err != nil {
 		t.Fatalf("AppendEvent(followup): %v", err)
 	}
 	assertRunBundleIdentity(t, db, runID, "", storerunlifecycle.BundleSourceLegacy, testBootBundleFingerprint)

--- a/internal/store/run_fork_selected_contract_route_recovery_test.go
+++ b/internal/store/run_fork_selected_contract_route_recovery_test.go
@@ -210,7 +210,7 @@ func TestRecordRunForkSelectedContractRouteRecoveryFeedsManagerRecoveryThroughJS
 		t.Fatalf("missing recovered recipient guard for fork %s", forkRunID)
 	}
 	guard.ExpectForkEvent("00000000-0000-0000-0000-000000000991", eventID)
-	evt := eventtest.Projection("00000000-0000-0000-0000-000000000991",
+	evt := eventtest.PersistedProjection("00000000-0000-0000-0000-000000000991",
 		events.EventType("item.received"),
 		RunForkSelectedContractExecutionOwner, "", nil, 0, "", "", events.EventEnvelope{}, time.Time{})
 
@@ -277,7 +277,7 @@ func TestRecordRunForkSelectedContractRouteRecoveryFeedsManagerRecoveryThroughBu
 		t.Fatalf("missing recovered recipient guard for fork %s", forkRunID)
 	}
 	guard.ExpectForkEvent("00000000-0000-0000-0000-000000000992", eventID)
-	evt := eventtest.Projection("00000000-0000-0000-0000-000000000992",
+	evt := eventtest.PersistedProjection("00000000-0000-0000-0000-000000000992",
 		events.EventType("item.received"),
 		RunForkSelectedContractExecutionOwner, "", nil, 0, "", "", events.EventEnvelope{}, time.Time{})
 

--- a/internal/store/run_fork_selected_contract_route_recovery_test.go
+++ b/internal/store/run_fork_selected_contract_route_recovery_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/division-sh/swarm/internal/events"
+	"github.com/division-sh/swarm/internal/events/eventtest"
 	runtimebus "github.com/division-sh/swarm/internal/runtime/bus"
 	runtimeactors "github.com/division-sh/swarm/internal/runtime/core/actors"
 	runtimemanager "github.com/division-sh/swarm/internal/runtime/manager"
@@ -209,7 +210,7 @@ func TestRecordRunForkSelectedContractRouteRecoveryFeedsManagerRecoveryThroughJS
 		t.Fatalf("missing recovered recipient guard for fork %s", forkRunID)
 	}
 	guard.ExpectForkEvent("00000000-0000-0000-0000-000000000991", eventID)
-	evt := events.NewProjectionEvent("00000000-0000-0000-0000-000000000991",
+	evt := eventtest.Projection("00000000-0000-0000-0000-000000000991",
 		events.EventType("item.received"),
 		RunForkSelectedContractExecutionOwner, "", nil, 0, "", "", events.EventEnvelope{}, time.Time{})
 
@@ -276,7 +277,7 @@ func TestRecordRunForkSelectedContractRouteRecoveryFeedsManagerRecoveryThroughBu
 		t.Fatalf("missing recovered recipient guard for fork %s", forkRunID)
 	}
 	guard.ExpectForkEvent("00000000-0000-0000-0000-000000000992", eventID)
-	evt := events.NewProjectionEvent("00000000-0000-0000-0000-000000000992",
+	evt := eventtest.Projection("00000000-0000-0000-0000-000000000992",
 		events.EventType("item.received"),
 		RunForkSelectedContractExecutionOwner, "", nil, 0, "", "", events.EventEnvelope{}, time.Time{})
 

--- a/internal/store/runtime_ingress_state_test.go
+++ b/internal/store/runtime_ingress_state_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/division-sh/swarm/internal/events"
+	"github.com/division-sh/swarm/internal/events/eventtest"
 	runtimeingress "github.com/division-sh/swarm/internal/runtime/ingress"
 	"github.com/division-sh/swarm/internal/testutil"
 )
@@ -34,10 +35,9 @@ func TestRuntimeIngressStatePersistsTypedTransitions(t *testing.T) {
 	}
 	pausedAt := state.UpdatedAt
 	pausedEventID := "11111111-1111-1111-1111-111111111111"
-	if err := pg.AppendEvent(ctx, events.NewProjectionEvent(pausedEventID,
+	if err := pg.AppendEvent(ctx, eventtest.Projection(pausedEventID,
 		events.EventType("platform.paused"),
-		"runtime", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, pausedAt),
-	); err != nil {
+		"runtime", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, pausedAt)); err != nil {
 		t.Fatalf("AppendEvent(paused): %v", err)
 	}
 	if ok, err := pg.SetRuntimeIngressTransitionEvent(ctx, runtimeingress.StatusPaused, pausedEventID, pausedAt); err != nil {
@@ -79,10 +79,9 @@ func TestRuntimeIngressStatePersistsTypedTransitions(t *testing.T) {
 		t.Fatalf("state after stale event update = %#v", state)
 	}
 	runningEventID := "33333333-3333-3333-3333-333333333333"
-	if err := pg.AppendEvent(ctx, events.NewProjectionEvent(runningEventID,
+	if err := pg.AppendEvent(ctx, eventtest.Projection(runningEventID,
 		events.EventType("platform.resumed"),
-		"runtime", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, runningAt),
-	); err != nil {
+		"runtime", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, runningAt)); err != nil {
 		t.Fatalf("AppendEvent(running): %v", err)
 	}
 	if ok, err := pg.SetRuntimeIngressTransitionEvent(ctx, runtimeingress.StatusRunning, runningEventID, runningAt); err != nil {

--- a/internal/store/runtime_ingress_state_test.go
+++ b/internal/store/runtime_ingress_state_test.go
@@ -35,7 +35,7 @@ func TestRuntimeIngressStatePersistsTypedTransitions(t *testing.T) {
 	}
 	pausedAt := state.UpdatedAt
 	pausedEventID := "11111111-1111-1111-1111-111111111111"
-	if err := pg.AppendEvent(ctx, eventtest.Projection(pausedEventID,
+	if err := pg.AppendEvent(ctx, eventtest.PersistedProjection(pausedEventID,
 		events.EventType("platform.paused"),
 		"runtime", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, pausedAt)); err != nil {
 		t.Fatalf("AppendEvent(paused): %v", err)
@@ -79,7 +79,7 @@ func TestRuntimeIngressStatePersistsTypedTransitions(t *testing.T) {
 		t.Fatalf("state after stale event update = %#v", state)
 	}
 	runningEventID := "33333333-3333-3333-3333-333333333333"
-	if err := pg.AppendEvent(ctx, eventtest.Projection(runningEventID,
+	if err := pg.AppendEvent(ctx, eventtest.PersistedProjection(runningEventID,
 		events.EventType("platform.resumed"),
 		"runtime", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, runningAt)); err != nil {
 		t.Fatalf("AppendEvent(running): %v", err)

--- a/internal/store/runtime_log_persistence_test.go
+++ b/internal/store/runtime_log_persistence_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/division-sh/swarm/internal/events"
+	"github.com/division-sh/swarm/internal/events/eventtest"
 	runtimepkg "github.com/division-sh/swarm/internal/runtime"
 	runtimecorrelation "github.com/division-sh/swarm/internal/runtime/correlation"
 	storerunlifecycle "github.com/division-sh/swarm/internal/store/runlifecycle"
@@ -21,11 +22,10 @@ func TestSQLiteRuntimeLogPersistenceWritesLoggerRowsForObservability(t *testing.
 	runID := uuid.NewString()
 	subjectEventID := uuid.NewString()
 	ctx = runtimecorrelation.WithRunID(ctx, runID)
-	if err := store.AppendEvent(ctx, events.NewProjectionEvent(subjectEventID,
+	if err := store.AppendEvent(ctx, eventtest.Projection(subjectEventID,
 
 		events.EventType("validation/validation.package_ready"),
-		"agent-1", "", json.RawMessage(`{"ready":true}`), 0, runID, "", events.EventEnvelope{}, time.Now().UTC()),
-	); err != nil {
+		"agent-1", "", json.RawMessage(`{"ready":true}`), 0, runID, "", events.EventEnvelope{}, time.Now().UTC())); err != nil {
 		t.Fatalf("seed sqlite subject event: %v", err)
 	}
 
@@ -206,11 +206,10 @@ func TestPostgresRuntimeLogPersistencePreservesRunSourceAndLineage(t *testing.T)
 	}
 	ctx = runtimecorrelation.WithRunID(ctx, runID)
 	ctx = runtimecorrelation.WithBundleSourceFact(ctx, sourceFact)
-	if err := pg.AppendEvent(ctx, events.NewProjectionEvent(subjectEventID,
+	if err := pg.AppendEvent(ctx, eventtest.Projection(subjectEventID,
 
 		events.EventType("validation/validation.package_ready"),
-		"agent-1", "", json.RawMessage(`{"ready":true}`), 0, runID, "", events.EventEnvelope{}, time.Now().UTC()),
-	); err != nil {
+		"agent-1", "", json.RawMessage(`{"ready":true}`), 0, runID, "", events.EventEnvelope{}, time.Now().UTC())); err != nil {
 		t.Fatalf("seed postgres subject event: %v", err)
 	}
 

--- a/internal/store/runtime_log_persistence_test.go
+++ b/internal/store/runtime_log_persistence_test.go
@@ -22,7 +22,7 @@ func TestSQLiteRuntimeLogPersistenceWritesLoggerRowsForObservability(t *testing.
 	runID := uuid.NewString()
 	subjectEventID := uuid.NewString()
 	ctx = runtimecorrelation.WithRunID(ctx, runID)
-	if err := store.AppendEvent(ctx, eventtest.Projection(subjectEventID,
+	if err := store.AppendEvent(ctx, eventtest.PersistedProjection(subjectEventID,
 
 		events.EventType("validation/validation.package_ready"),
 		"agent-1", "", json.RawMessage(`{"ready":true}`), 0, runID, "", events.EventEnvelope{}, time.Now().UTC())); err != nil {
@@ -206,7 +206,7 @@ func TestPostgresRuntimeLogPersistencePreservesRunSourceAndLineage(t *testing.T)
 	}
 	ctx = runtimecorrelation.WithRunID(ctx, runID)
 	ctx = runtimecorrelation.WithBundleSourceFact(ctx, sourceFact)
-	if err := pg.AppendEvent(ctx, eventtest.Projection(subjectEventID,
+	if err := pg.AppendEvent(ctx, eventtest.PersistedProjection(subjectEventID,
 
 		events.EventType("validation/validation.package_ready"),
 		"agent-1", "", json.RawMessage(`{"ready":true}`), 0, runID, "", events.EventEnvelope{}, time.Now().UTC())); err != nil {

--- a/internal/store/sqlite_run_completion_test.go
+++ b/internal/store/sqlite_run_completion_test.go
@@ -25,11 +25,18 @@ func seedSQLiteNormalRunCompletionFixture(t *testing.T, store *SQLiteRuntimeStor
 	runID := uuid.NewString()
 	eventID := uuid.NewString()
 	entityID := uuid.NewString()
-	if err := store.AppendEvent(ctx, eventtest.WithEntityID(eventtest.Projection(eventID,
-
+	if err := store.AppendEvent(ctx, eventtest.PersistedProjection(
+		eventID,
 		events.EventType("example.started"),
-		"test", "", json.RawMessage(`{"example":true}`), 0, runID, "", events.EventEnvelope{}, now),
-		entityID)); err != nil {
+		"test",
+		"",
+		json.RawMessage(`{"example":true}`),
+		0,
+		runID,
+		"",
+		events.EnvelopeForEntityID(events.EventEnvelope{}, entityID),
+		now,
+	)); err != nil {
 		t.Fatalf("AppendEvent: %v", err)
 	}
 	if _, err := store.DB.ExecContext(ctx, `

--- a/internal/store/sqlite_run_completion_test.go
+++ b/internal/store/sqlite_run_completion_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/division-sh/swarm/internal/events"
+	"github.com/division-sh/swarm/internal/events/eventtest"
 	"github.com/google/uuid"
 )
 
@@ -24,11 +25,11 @@ func seedSQLiteNormalRunCompletionFixture(t *testing.T, store *SQLiteRuntimeStor
 	runID := uuid.NewString()
 	eventID := uuid.NewString()
 	entityID := uuid.NewString()
-	if err := store.AppendEvent(ctx, events.NewProjectionEvent(eventID,
+	if err := store.AppendEvent(ctx, eventtest.WithEntityID(eventtest.Projection(eventID,
 
 		events.EventType("example.started"),
-		"test", "", json.RawMessage(`{"example":true}`), 0, runID, "", events.EventEnvelope{}, now).
-		WithEntityID(entityID)); err != nil {
+		"test", "", json.RawMessage(`{"example":true}`), 0, runID, "", events.EventEnvelope{}, now),
+		entityID)); err != nil {
 		t.Fatalf("AppendEvent: %v", err)
 	}
 	if _, err := store.DB.ExecContext(ctx, `

--- a/internal/store/sqlite_runtime_test.go
+++ b/internal/store/sqlite_runtime_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/division-sh/swarm/internal/events"
+	"github.com/division-sh/swarm/internal/events/eventtest"
 	runtimebus "github.com/division-sh/swarm/internal/runtime/bus"
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
 	runtimeactors "github.com/division-sh/swarm/internal/runtime/core/actors"
@@ -37,7 +38,7 @@ func TestSQLiteRuntimeStoreSelectedCoreContracts(t *testing.T) {
 	ctx = runtimecorrelation.WithRunID(ctx, runID)
 
 	evtID := uuid.NewString()
-	evt := events.NewProjectionEvent(evtID,
+	evt := eventtest.Projection(evtID,
 
 		events.EventType("test.started"),
 		"agent-1", "", json.RawMessage(`{"ok":true}`), 0, runID, "", events.EventEnvelope{}, time.Now().UTC())
@@ -584,10 +585,10 @@ func TestSQLiteRuntimeStoreAPIIdempotencyAllowsNestedEventBusPublish(t *testing.
 	publishCalls := 0
 	publish := func(ctx context.Context) (APIIdempotencyCompletion, error) {
 		publishCalls++
-		if err := bus.Publish(ctx, (events.NewProjectionEvent(eventID,
+		if err := bus.Publish(ctx, eventtest.WithEntityID((eventtest.Projection(eventID,
 
 			events.EventType("item.received"),
-			"api.v1", "", json.RawMessage(`{"entity_id":"11111111-1111-1111-1111-111111111111","topic":"medicine"}`), 0, runID, "", events.EventEnvelope{}, time.Now().UTC())).WithEntityID(entityID)); err != nil {
+			"api.v1", "", json.RawMessage(`{"entity_id":"11111111-1111-1111-1111-111111111111","topic":"medicine"}`), 0, runID, "", events.EventEnvelope{}, time.Now().UTC())), entityID)); err != nil {
 			return APIIdempotencyCompletion{}, err
 		}
 		response, err := json.Marshal(map[string]string{"event_id": eventID, "run_id": runID})
@@ -652,10 +653,10 @@ func TestSQLiteRuntimeStoreAPIIdempotencyFailedNestedPublishLeavesNoCompletionOr
 		Now:            time.Now().UTC(),
 	}
 	completion, replayed, err := store.WithAPIIdempotency(ctx, req, func(ctx context.Context) (APIIdempotencyCompletion, error) {
-		err := bus.Publish(ctx, (events.NewProjectionEvent(eventID,
+		err := bus.Publish(ctx, eventtest.WithEntityID((eventtest.Projection(eventID,
 
 			events.EventType("item.failed"),
-			"api.v1", "", json.RawMessage(`{"entity_id":"22222222-2222-2222-2222-222222222222"}`), 0, runID, "", events.EventEnvelope{}, time.Now().UTC())).WithEntityID("22222222-2222-2222-2222-222222222222"))
+			"api.v1", "", json.RawMessage(`{"entity_id":"22222222-2222-2222-2222-222222222222"}`), 0, runID, "", events.EventEnvelope{}, time.Now().UTC())), "22222222-2222-2222-2222-222222222222"))
 		if err != nil {
 			return APIIdempotencyCompletion{}, err
 		}
@@ -774,10 +775,10 @@ func TestSQLiteRuntimeStoreAppendEventTxEnsuresFreshRunRow(t *testing.T) {
 
 	runID := uuid.NewString()
 	eventID := uuid.NewString()
-	if err := store.AppendEventTx(ctx, tx, (events.NewProjectionEvent(eventID,
+	if err := store.AppendEventTx(ctx, tx, eventtest.WithEntityID((eventtest.Projection(eventID,
 
 		events.EventType("item.received"),
-		"api.v1", "", json.RawMessage(`{"entity_id":"33333333-3333-3333-3333-333333333333"}`), 0, runID, "", events.EventEnvelope{}, time.Now().UTC())).WithEntityID("33333333-3333-3333-3333-333333333333")); err != nil {
+		"api.v1", "", json.RawMessage(`{"entity_id":"33333333-3333-3333-3333-333333333333"}`), 0, runID, "", events.EventEnvelope{}, time.Now().UTC())), "33333333-3333-3333-3333-333333333333")); err != nil {
 		t.Fatalf("AppendEventTx: %v", err)
 	}
 	if err := tx.Commit(); err != nil {
@@ -810,10 +811,10 @@ func TestSQLiteRuntimeStoreRuntimeIngressReadDuringPublishDoesNotReenterWrite(t 
 	bus.SetRuntimeIngressDispatchGate(controller)
 
 	eventID := uuid.NewString()
-	err = bus.Publish(ctx, (events.NewProjectionEvent(eventID,
+	err = bus.Publish(ctx, eventtest.WithEntityID((eventtest.Projection(eventID,
 
 		events.EventType("item.received"),
-		"api.v1", "", []byte(`{"entity_id":"11111111-1111-1111-1111-111111111111"}`), 0, runID, "", events.EventEnvelope{}, time.Now().UTC())).WithEntityID("11111111-1111-1111-1111-111111111111"))
+		"api.v1", "", []byte(`{"entity_id":"11111111-1111-1111-1111-111111111111"}`), 0, runID, "", events.EventEnvelope{}, time.Now().UTC())), "11111111-1111-1111-1111-111111111111"))
 	if err != nil {
 		t.Fatalf("Publish with runtime ingress gate: %v", err)
 	}
@@ -896,7 +897,7 @@ func TestSQLiteRuntimeStoreSystemNodeReceiptOwnerSettlesDelivery(t *testing.T) {
 	runID := uuid.NewString()
 	ctx = runtimecorrelation.WithRunID(ctx, runID)
 	eventID := uuid.NewString()
-	evt := events.NewProjectionEvent(eventID,
+	evt := eventtest.Projection(eventID,
 
 		events.EventType("company.scanned"),
 		"agent-1", "", json.RawMessage(`{"ok":true}`), 0, runID, "", events.EventEnvelope{}, time.Now().UTC())
@@ -960,7 +961,7 @@ func TestSQLiteRuntimeStoreSystemNodeReceiptOwnerDeadLettersDelivery(t *testing.
 	runID := uuid.NewString()
 	ctx = runtimecorrelation.WithRunID(ctx, runID)
 	eventID := uuid.NewString()
-	evt := events.NewProjectionEvent(eventID,
+	evt := eventtest.Projection(eventID,
 		events.EventType("company.scanned"),
 		"agent-1", "", json.RawMessage(`{"ok":true}`), 0, runID, "", events.EventEnvelope{}, time.Now().UTC())
 
@@ -1010,7 +1011,7 @@ func TestSQLiteRuntimeStoreSystemNodeReceiptOwnerFailsWithoutDeliveryAuthority(t
 	runID := uuid.NewString()
 	ctx = runtimecorrelation.WithRunID(ctx, runID)
 	eventID := uuid.NewString()
-	evt := events.NewProjectionEvent(eventID,
+	evt := eventtest.Projection(eventID,
 
 		events.EventType("company.scanned"),
 		"agent-1", "", json.RawMessage(`{"ok":true}`), 0, runID, "", events.EventEnvelope{}, time.Now().UTC())
@@ -1061,7 +1062,7 @@ func TestSQLiteRuntimeStoreSystemNodeReceiptOwnerFailsWithTerminalDeliveryAuthor
 			runID := uuid.NewString()
 			ctx = runtimecorrelation.WithRunID(ctx, runID)
 			eventID := uuid.NewString()
-			evt := events.NewProjectionEvent(eventID,
+			evt := eventtest.Projection(eventID,
 
 				events.EventType("company.scanned"),
 				"agent-1", "", json.RawMessage(`{"ok":true}`), 0, runID, "", events.EventEnvelope{}, time.Now().UTC())
@@ -1119,7 +1120,7 @@ func TestSQLiteRuntimeStoreDeliveryReplayAndReceiptSemantics(t *testing.T) {
 	store.SetNowFnForTest(func() time.Time { return now })
 
 	eventID := uuid.NewString()
-	evt := events.NewProjectionEvent(eventID,
+	evt := eventtest.Projection(eventID,
 
 		events.EventType("test.delivery_requested"),
 		"runtime", "", json.RawMessage(`{"delivery":true}`), 0, runID, "", events.EventEnvelope{}, now)
@@ -1209,7 +1210,7 @@ func TestSQLiteRuntimeStoreDeliveryReplayAndReceiptSemantics(t *testing.T) {
 	subOtherID := uuid.NewString()
 	subNoDeliveryID := uuid.NewString()
 	subEvt := func(id string, offset time.Duration) events.Event {
-		return events.NewProjectionEvent(id,
+		return eventtest.Projection(id,
 
 			events.EventType("subscription.visible"),
 			"runtime", "", json.RawMessage(`{"subscription":true}`), 0, runID, "", events.EventEnvelope{}, now.Add(offset))
@@ -1321,10 +1322,12 @@ func TestSQLiteRuntimeStoreSessionStartupConversationAndTraceVisibility(t *testi
 	runID := uuid.NewString()
 	ctx = runtimecorrelation.WithRunID(ctx, runID)
 	eventID := uuid.NewString()
-	if err := store.PersistEventWithDeliveries(ctx, events.NewProjectionEvent(eventID,
+	if err := store.PersistEventWithDeliveries(ctx, eventtest.Projection(eventID,
 
 		events.EventType("trace.visible"),
-		"agent-1", "", json.RawMessage(`{"trace":true}`), 0, runID, "", events.EventEnvelope{}, now), []string{"agent-1"}); err != nil {
+		"agent-1", "", json.RawMessage(`{"trace":true}`), 0, runID, "", events.EventEnvelope{}, now),
+
+		[]string{"agent-1"}); err != nil {
 		t.Fatalf("PersistEventWithDeliveries trace event: %v", err)
 	}
 	if err := store.MarkEventDeliveryInProgress(ctx, eventID, "agent-1", lease.SessionID); err != nil {
@@ -1360,11 +1363,10 @@ func TestSQLiteRuntimeStoreSessionStartupConversationAndTraceVisibility(t *testi
 	}
 
 	logID := uuid.NewString()
-	if err := store.AppendEvent(ctx, events.NewProjectionEvent(logID,
+	if err := store.AppendEvent(ctx, eventtest.Projection(logID,
 
 		events.EventType("platform.runtime_log"),
-		"runtime", "", json.RawMessage(`{"log_level":"warn","message":"runtime warning","details":{"component":"scheduler","action":"session_warning","session_id":"`+lease.SessionID+`"}}`), 0, runID, "", events.EventEnvelope{}, now.Add(time.Second)),
-	); err != nil {
+		"runtime", "", json.RawMessage(`{"log_level":"warn","message":"runtime warning","details":{"component":"scheduler","action":"session_warning","session_id":"`+lease.SessionID+`"}}`), 0, runID, "", events.EventEnvelope{}, now.Add(time.Second))); err != nil {
 		t.Fatalf("AppendEvent runtime log: %v", err)
 	}
 	logs, err := store.ListOperatorRuntimeLogs(ctx, OperatorRuntimeLogListOptions{RunID: runID, Level: "warn", Component: "scheduler", Limit: 10})
@@ -1504,11 +1506,10 @@ func TestSQLiteRuntimeStoreV1MailboxAPISelectedOwner(t *testing.T) {
 	runID := uuid.NewString()
 	ctx = runtimecorrelation.WithRunID(ctx, runID)
 	eventID := uuid.NewString()
-	if err := store.AppendEvent(ctx, events.NewProjectionEvent(eventID,
+	if err := store.AppendEvent(ctx, eventtest.Projection(eventID,
 
 		events.EventType("mailbox.requested"),
-		"agent-1", "", json.RawMessage(`{"request":true}`), 0, runID, "", events.EventEnvelope{}, time.Now().UTC()),
-	); err != nil {
+		"agent-1", "", json.RawMessage(`{"request":true}`), 0, runID, "", events.EventEnvelope{}, time.Now().UTC())); err != nil {
 		t.Fatalf("AppendEvent source: %v", err)
 	}
 	entityID := uuid.NewString()

--- a/internal/store/sqlite_runtime_test.go
+++ b/internal/store/sqlite_runtime_test.go
@@ -38,7 +38,7 @@ func TestSQLiteRuntimeStoreSelectedCoreContracts(t *testing.T) {
 	ctx = runtimecorrelation.WithRunID(ctx, runID)
 
 	evtID := uuid.NewString()
-	evt := eventtest.Projection(evtID,
+	evt := eventtest.PersistedProjection(evtID,
 
 		events.EventType("test.started"),
 		"agent-1", "", json.RawMessage(`{"ok":true}`), 0, runID, "", events.EventEnvelope{}, time.Now().UTC())
@@ -585,10 +585,18 @@ func TestSQLiteRuntimeStoreAPIIdempotencyAllowsNestedEventBusPublish(t *testing.
 	publishCalls := 0
 	publish := func(ctx context.Context) (APIIdempotencyCompletion, error) {
 		publishCalls++
-		if err := bus.Publish(ctx, eventtest.WithEntityID((eventtest.Projection(eventID,
-
+		if err := bus.Publish(ctx, eventtest.PersistedProjection(
+			eventID,
 			events.EventType("item.received"),
-			"api.v1", "", json.RawMessage(`{"entity_id":"11111111-1111-1111-1111-111111111111","topic":"medicine"}`), 0, runID, "", events.EventEnvelope{}, time.Now().UTC())), entityID)); err != nil {
+			"api.v1",
+			"",
+			json.RawMessage(`{"entity_id":"11111111-1111-1111-1111-111111111111","topic":"medicine"}`),
+			0,
+			runID,
+			"",
+			events.EnvelopeForEntityID(events.EventEnvelope{}, entityID),
+			time.Now().UTC(),
+		)); err != nil {
 			return APIIdempotencyCompletion{}, err
 		}
 		response, err := json.Marshal(map[string]string{"event_id": eventID, "run_id": runID})
@@ -653,10 +661,18 @@ func TestSQLiteRuntimeStoreAPIIdempotencyFailedNestedPublishLeavesNoCompletionOr
 		Now:            time.Now().UTC(),
 	}
 	completion, replayed, err := store.WithAPIIdempotency(ctx, req, func(ctx context.Context) (APIIdempotencyCompletion, error) {
-		err := bus.Publish(ctx, eventtest.WithEntityID((eventtest.Projection(eventID,
-
+		err := bus.Publish(ctx, eventtest.PersistedProjection(
+			eventID,
 			events.EventType("item.failed"),
-			"api.v1", "", json.RawMessage(`{"entity_id":"22222222-2222-2222-2222-222222222222"}`), 0, runID, "", events.EventEnvelope{}, time.Now().UTC())), "22222222-2222-2222-2222-222222222222"))
+			"api.v1",
+			"",
+			json.RawMessage(`{"entity_id":"22222222-2222-2222-2222-222222222222"}`),
+			0,
+			runID,
+			"",
+			events.EnvelopeForEntityID(events.EventEnvelope{}, "22222222-2222-2222-2222-222222222222"),
+			time.Now().UTC(),
+		))
 		if err != nil {
 			return APIIdempotencyCompletion{}, err
 		}
@@ -775,10 +791,18 @@ func TestSQLiteRuntimeStoreAppendEventTxEnsuresFreshRunRow(t *testing.T) {
 
 	runID := uuid.NewString()
 	eventID := uuid.NewString()
-	if err := store.AppendEventTx(ctx, tx, eventtest.WithEntityID((eventtest.Projection(eventID,
-
+	if err := store.AppendEventTx(ctx, tx, eventtest.PersistedProjection(
+		eventID,
 		events.EventType("item.received"),
-		"api.v1", "", json.RawMessage(`{"entity_id":"33333333-3333-3333-3333-333333333333"}`), 0, runID, "", events.EventEnvelope{}, time.Now().UTC())), "33333333-3333-3333-3333-333333333333")); err != nil {
+		"api.v1",
+		"",
+		json.RawMessage(`{"entity_id":"33333333-3333-3333-3333-333333333333"}`),
+		0,
+		runID,
+		"",
+		events.EnvelopeForEntityID(events.EventEnvelope{}, "33333333-3333-3333-3333-333333333333"),
+		time.Now().UTC(),
+	)); err != nil {
 		t.Fatalf("AppendEventTx: %v", err)
 	}
 	if err := tx.Commit(); err != nil {
@@ -811,10 +835,18 @@ func TestSQLiteRuntimeStoreRuntimeIngressReadDuringPublishDoesNotReenterWrite(t 
 	bus.SetRuntimeIngressDispatchGate(controller)
 
 	eventID := uuid.NewString()
-	err = bus.Publish(ctx, eventtest.WithEntityID((eventtest.Projection(eventID,
-
+	err = bus.Publish(ctx, eventtest.PersistedProjection(
+		eventID,
 		events.EventType("item.received"),
-		"api.v1", "", []byte(`{"entity_id":"11111111-1111-1111-1111-111111111111"}`), 0, runID, "", events.EventEnvelope{}, time.Now().UTC())), "11111111-1111-1111-1111-111111111111"))
+		"api.v1",
+		"",
+		[]byte(`{"entity_id":"11111111-1111-1111-1111-111111111111"}`),
+		0,
+		runID,
+		"",
+		events.EnvelopeForEntityID(events.EventEnvelope{}, "11111111-1111-1111-1111-111111111111"),
+		time.Now().UTC(),
+	))
 	if err != nil {
 		t.Fatalf("Publish with runtime ingress gate: %v", err)
 	}
@@ -897,7 +929,7 @@ func TestSQLiteRuntimeStoreSystemNodeReceiptOwnerSettlesDelivery(t *testing.T) {
 	runID := uuid.NewString()
 	ctx = runtimecorrelation.WithRunID(ctx, runID)
 	eventID := uuid.NewString()
-	evt := eventtest.Projection(eventID,
+	evt := eventtest.PersistedProjection(eventID,
 
 		events.EventType("company.scanned"),
 		"agent-1", "", json.RawMessage(`{"ok":true}`), 0, runID, "", events.EventEnvelope{}, time.Now().UTC())
@@ -961,7 +993,7 @@ func TestSQLiteRuntimeStoreSystemNodeReceiptOwnerDeadLettersDelivery(t *testing.
 	runID := uuid.NewString()
 	ctx = runtimecorrelation.WithRunID(ctx, runID)
 	eventID := uuid.NewString()
-	evt := eventtest.Projection(eventID,
+	evt := eventtest.PersistedProjection(eventID,
 		events.EventType("company.scanned"),
 		"agent-1", "", json.RawMessage(`{"ok":true}`), 0, runID, "", events.EventEnvelope{}, time.Now().UTC())
 
@@ -1011,7 +1043,7 @@ func TestSQLiteRuntimeStoreSystemNodeReceiptOwnerFailsWithoutDeliveryAuthority(t
 	runID := uuid.NewString()
 	ctx = runtimecorrelation.WithRunID(ctx, runID)
 	eventID := uuid.NewString()
-	evt := eventtest.Projection(eventID,
+	evt := eventtest.PersistedProjection(eventID,
 
 		events.EventType("company.scanned"),
 		"agent-1", "", json.RawMessage(`{"ok":true}`), 0, runID, "", events.EventEnvelope{}, time.Now().UTC())
@@ -1062,7 +1094,7 @@ func TestSQLiteRuntimeStoreSystemNodeReceiptOwnerFailsWithTerminalDeliveryAuthor
 			runID := uuid.NewString()
 			ctx = runtimecorrelation.WithRunID(ctx, runID)
 			eventID := uuid.NewString()
-			evt := eventtest.Projection(eventID,
+			evt := eventtest.PersistedProjection(eventID,
 
 				events.EventType("company.scanned"),
 				"agent-1", "", json.RawMessage(`{"ok":true}`), 0, runID, "", events.EventEnvelope{}, time.Now().UTC())
@@ -1120,7 +1152,7 @@ func TestSQLiteRuntimeStoreDeliveryReplayAndReceiptSemantics(t *testing.T) {
 	store.SetNowFnForTest(func() time.Time { return now })
 
 	eventID := uuid.NewString()
-	evt := eventtest.Projection(eventID,
+	evt := eventtest.PersistedProjection(eventID,
 
 		events.EventType("test.delivery_requested"),
 		"runtime", "", json.RawMessage(`{"delivery":true}`), 0, runID, "", events.EventEnvelope{}, now)
@@ -1210,7 +1242,7 @@ func TestSQLiteRuntimeStoreDeliveryReplayAndReceiptSemantics(t *testing.T) {
 	subOtherID := uuid.NewString()
 	subNoDeliveryID := uuid.NewString()
 	subEvt := func(id string, offset time.Duration) events.Event {
-		return eventtest.Projection(id,
+		return eventtest.PersistedProjection(id,
 
 			events.EventType("subscription.visible"),
 			"runtime", "", json.RawMessage(`{"subscription":true}`), 0, runID, "", events.EventEnvelope{}, now.Add(offset))
@@ -1322,7 +1354,7 @@ func TestSQLiteRuntimeStoreSessionStartupConversationAndTraceVisibility(t *testi
 	runID := uuid.NewString()
 	ctx = runtimecorrelation.WithRunID(ctx, runID)
 	eventID := uuid.NewString()
-	if err := store.PersistEventWithDeliveries(ctx, eventtest.Projection(eventID,
+	if err := store.PersistEventWithDeliveries(ctx, eventtest.PersistedProjection(eventID,
 
 		events.EventType("trace.visible"),
 		"agent-1", "", json.RawMessage(`{"trace":true}`), 0, runID, "", events.EventEnvelope{}, now),
@@ -1363,7 +1395,7 @@ func TestSQLiteRuntimeStoreSessionStartupConversationAndTraceVisibility(t *testi
 	}
 
 	logID := uuid.NewString()
-	if err := store.AppendEvent(ctx, eventtest.Projection(logID,
+	if err := store.AppendEvent(ctx, eventtest.PersistedProjection(logID,
 
 		events.EventType("platform.runtime_log"),
 		"runtime", "", json.RawMessage(`{"log_level":"warn","message":"runtime warning","details":{"component":"scheduler","action":"session_warning","session_id":"`+lease.SessionID+`"}}`), 0, runID, "", events.EventEnvelope{}, now.Add(time.Second))); err != nil {
@@ -1506,7 +1538,7 @@ func TestSQLiteRuntimeStoreV1MailboxAPISelectedOwner(t *testing.T) {
 	runID := uuid.NewString()
 	ctx = runtimecorrelation.WithRunID(ctx, runID)
 	eventID := uuid.NewString()
-	if err := store.AppendEvent(ctx, eventtest.Projection(eventID,
+	if err := store.AppendEvent(ctx, eventtest.PersistedProjection(eventID,
 
 		events.EventType("mailbox.requested"),
 		"agent-1", "", json.RawMessage(`{"request":true}`), 0, runID, "", events.EventEnvelope{}, time.Now().UTC())); err != nil {

--- a/internal/store/sqlite_runtime_test.go
+++ b/internal/store/sqlite_runtime_test.go
@@ -585,7 +585,7 @@ func TestSQLiteRuntimeStoreAPIIdempotencyAllowsNestedEventBusPublish(t *testing.
 	publishCalls := 0
 	publish := func(ctx context.Context) (APIIdempotencyCompletion, error) {
 		publishCalls++
-		if err := bus.Publish(ctx, eventtest.PersistedProjection(
+		if err := bus.Publish(ctx, eventtest.RootIngress(
 			eventID,
 			events.EventType("item.received"),
 			"api.v1",
@@ -661,7 +661,7 @@ func TestSQLiteRuntimeStoreAPIIdempotencyFailedNestedPublishLeavesNoCompletionOr
 		Now:            time.Now().UTC(),
 	}
 	completion, replayed, err := store.WithAPIIdempotency(ctx, req, func(ctx context.Context) (APIIdempotencyCompletion, error) {
-		err := bus.Publish(ctx, eventtest.PersistedProjection(
+		err := bus.Publish(ctx, eventtest.RootIngress(
 			eventID,
 			events.EventType("item.failed"),
 			"api.v1",
@@ -835,7 +835,7 @@ func TestSQLiteRuntimeStoreRuntimeIngressReadDuringPublishDoesNotReenterWrite(t 
 	bus.SetRuntimeIngressDispatchGate(controller)
 
 	eventID := uuid.NewString()
-	err = bus.Publish(ctx, eventtest.PersistedProjection(
+	err = bus.Publish(ctx, eventtest.RootIngress(
 		eventID,
 		events.EventType("item.received"),
 		"api.v1",


### PR DESCRIPTION
Closes #1511
Part of #1370

## Summary
- Add `internal/events/eventtest` as the shared test-only semantic owner for event fixture construction.
- Migrate repo-wide `_test.go` direct `events.NewProjectionEvent`, `events.NewRouteProbeEvent`, and event `With*` fixture patching behind `eventtest` helpers.
- Extend `internal/events` construction conformance with a test-fixture guard that blocks new unclassified test projection/patching drift and blocks production imports of the test fixture owner.

## Governing refs / context
Exact governing spec sections:
- `platform-spec.yaml#contract_formats.event_schema.strict_payload_contract.envelope_split`
- `platform-spec.yaml#contract_formats.event_schema.strict_payload_contract.envelope_identity`
- `platform-spec.yaml#contract_formats.event_schema.runtime_event_construction`
- `platform-spec.yaml#contract_formats.event_schema.projection_boundary`
- `platform-spec.yaml#run_model.lineage`

Binding gate/context:
- #1511 pre-audit and lead gate outcome approved `test_fixture_event_builder_boundary` as the first slice under #1370.
- Required boundary: full repo-wide `_test.go` fixture migration, static guard, no production runtime semantics change.

## Semantic migration
- New canonical owner: `internal/events/eventtest` for test-only event fixture construction.
- Old non-authoritative test paths now invalid: direct `_test.go` `events.NewProjectionEvent`, direct `_test.go` `events.NewRouteProbeEvent`, and direct event `WithEnvelope` / `WithEntityID` / `WithFlowInstance` / `WithSourceRoute` / `WithTargetRoute` / `WithTargetSet`.
- Production paths checked for surviving old behavior: production guard still owns direct constructor allowlists; new guard blocks production import of `internal/events/eventtest`.
- Migration completeness: complete for the approved class outside `internal/events` constructor/helper unit tests.

## Proof
- `go test ./internal/events -run 'TestProductionEventConstructionUsesPublicAPI|TestTestEventFixturesUseFixtureBuilders' -count=1`\n- `rg -n "events\\.NewProjectionEvent|events\\.NewRouteProbeEvent" internal cmd --glob '**/*_test.go' | rg -v '^internal/events/' || true` returned no matches.\n- `rg -n "\\.WithEnvelope|\\.WithEntityID|\\.WithFlowInstance|\\.WithSourceRoute|\\.WithTargetRoute|\\.WithTargetSet" internal cmd --glob '**/*_test.go' | rg -v 'eventtest\\.(WithEnvelope|WithEntityID|WithFlowInstance|WithSourceRoute|WithTargetRoute|WithTargetSet)' | rg -v '^internal/events/' || true` returned no matches.\n- `rg -n '"github.com/division-sh/swarm/internal/events/eventtest"' internal cmd --glob '!**/*_test.go' || true` returned no matches.\n- `git diff --check`\n- `go test ./internal/runtime/bus ./internal/runtime/pipeline ./internal/store ./internal/runtime/engine ./internal/apiv1 ./internal/dashboard/server ./cmd/swarm`\n- `go test ./...`\n\n## Runtime semantics\nNo production route planning, delivery, replay, admission, readback, or publish semantics were changed. This PR only moves test fixtures behind a shared test-only owner and adds conformance coverage.