### PR TITLE
[agent-e][issue #1456] Add external tool dispatch rate limits

### DIFF
--- a/internal/runtime/bootverify/checks.go
+++ b/internal/runtime/bootverify/checks.go
@@ -616,6 +616,14 @@ func (c *checkerContext) invalidFieldDetection() []Finding {
 		return c.invalidFindings
 	}
 	c.invalidLoaded = true
+	for _, err := range runtimetools.ValidateExternalDispatchRateLimitDeclarations(c.source) {
+		c.invalidFindings = append(c.invalidFindings, Finding{
+			CheckID:  "invalid_field_detection",
+			Severity: "error",
+			Message:  err.Error(),
+			Location: "rate_limit",
+		})
+	}
 	for _, scope := range c.source.ProjectScopes() {
 		scopeLabel := projectScopeLabel(scope.Key, scope.Manifest.Name)
 		if strings.TrimSpace(scope.Manifest.Name) == "" {

--- a/internal/runtime/bootverify/report_test.go
+++ b/internal/runtime/bootverify/report_test.go
@@ -51,6 +51,23 @@ func TestRun_DoesNotWarnForBuiltinRuntimeToolReference(t *testing.T) {
 	}
 }
 
+func TestRun_FailsClosedForInvalidExternalDispatchRateLimit(t *testing.T) {
+	source := semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
+		Tools: map[string]runtimecontracts.ToolSchemaEntry{
+			"bad_http": {
+				HandlerType: "http",
+				HTTP:        &runtimecontracts.HTTPToolSpec{Method: "GET", URL: "https://example.test"},
+				RateLimit:   "1/s",
+			},
+		},
+	})
+
+	report := Run(context.Background(), source, Options{})
+	if !reportContains(report.Errors(), "invalid_field_detection", "rate_limit requires rate_limit_max_wait") {
+		t.Fatalf("expected invalid rate_limit hard invalidity, got %#v", report.Errors())
+	}
+}
+
 func TestRun_MapsMissingDiscoveredMCPToolToToolResolutionWarning(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var req map[string]any

--- a/internal/runtime/contracts/workflow_contract_types.go
+++ b/internal/runtime/contracts/workflow_contract_types.go
@@ -1174,6 +1174,8 @@ type ToolSchemaEntry struct {
 	HandlerType        string          `yaml:"handler_type"`
 	Permission         string          `yaml:"permission"`
 	RequiredPermission string          `yaml:"required_permission"`
+	RateLimit          string          `yaml:"rate_limit"`
+	RateLimitMaxWait   string          `yaml:"rate_limit_max_wait"`
 	InputSchema        ToolInputSchema `yaml:"input_schema"`
 	OutputSchema       ToolInputSchema `yaml:"output_schema"`
 	HTTP               *HTTPToolSpec   `yaml:"http"`

--- a/internal/runtime/mcp/client.go
+++ b/internal/runtime/mcp/client.go
@@ -21,14 +21,16 @@ import (
 )
 
 type ServerConfig struct {
-	Name           string
-	Description    string
-	Transport      string
-	URL            string
-	Command        string
-	Args           []string
-	Prefix         string
-	CredentialsKey string
+	Name             string
+	Description      string
+	Transport        string
+	URL              string
+	Command          string
+	Args             []string
+	Prefix           string
+	CredentialsKey   string
+	RateLimit        string
+	RateLimitMaxWait string
 }
 
 type DiscoveredTool struct {
@@ -132,6 +134,23 @@ func (c *Client) DiscoveredTools() map[string]DiscoveredTool {
 		out[key] = value
 	}
 	return out
+}
+
+func (c *Client) ServerConfig(name string) (ServerConfig, bool) {
+	if c == nil {
+		return ServerConfig{}, false
+	}
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return ServerConfig{}, false
+	}
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	server := c.servers[name]
+	if server == nil {
+		return ServerConfig{}, false
+	}
+	return server.cfg, true
 }
 
 func (c *Client) Call(ctx context.Context, prefixedName string, arguments any) (any, error) {
@@ -436,14 +455,16 @@ func parseServerConfigs(source semanticview.Source) ([]ServerConfig, error) {
 			return nil, fmt.Errorf("mcp_servers.%s must be a mapping", name)
 		}
 		cfg := ServerConfig{
-			Name:           name,
-			Description:    strings.TrimSpace(anyString(item["description"])),
-			Transport:      strings.ToLower(strings.TrimSpace(anyString(item["transport"]))),
-			URL:            strings.TrimSpace(renderPolicyTemplate(anyString(item["url"]), policyVars)),
-			Command:        strings.TrimSpace(renderPolicyTemplate(anyString(item["command"]), policyVars)),
-			Prefix:         strings.TrimSpace(anyString(item["prefix"])),
-			CredentialsKey: strings.TrimSpace(anyString(item["credentials_key"])),
-			Args:           renderPolicyStringSlice(stringSlice(item["args"]), policyVars),
+			Name:             name,
+			Description:      strings.TrimSpace(anyString(item["description"])),
+			Transport:        strings.ToLower(strings.TrimSpace(anyString(item["transport"]))),
+			URL:              strings.TrimSpace(renderPolicyTemplate(anyString(item["url"]), policyVars)),
+			Command:          strings.TrimSpace(renderPolicyTemplate(anyString(item["command"]), policyVars)),
+			Prefix:           strings.TrimSpace(anyString(item["prefix"])),
+			CredentialsKey:   strings.TrimSpace(anyString(item["credentials_key"])),
+			RateLimit:        anyString(item["rate_limit"]),
+			RateLimitMaxWait: anyString(item["rate_limit_max_wait"]),
+			Args:             renderPolicyStringSlice(stringSlice(item["args"]), policyVars),
 		}
 		if cfg.Transport == "" {
 			cfg.Transport = "http"

--- a/internal/runtime/mcp/gateway.go
+++ b/internal/runtime/mcp/gateway.go
@@ -288,7 +288,11 @@ func (g *Gateway) handleMCP(w http.ResponseWriter, r *http.Request) {
 					retryable = rv
 				}
 			}
-			err = g.newRuntimeError(ErrCodeToolExecFailed, "mcp.tools.call.execute", retryable, execErr, "tool execution failed: %s", toolName)
+			if runtimeErr, ok := runtimerterr.AsRuntimeError(execErr); ok && strings.TrimSpace(runtimeErr.Code) == "rate_limited" {
+				err = execErr
+			} else {
+				err = g.newRuntimeError(ErrCodeToolExecFailed, "mcp.tools.call.execute", retryable, execErr, "tool execution failed: %s", toolName)
+			}
 			g.logMCP(r, "warn", "mcp.tools.call.exec_error", err, map[string]any{
 				"method":    "tools/call",
 				"tool_name": toolName,

--- a/internal/runtime/semanticview/helpers.go
+++ b/internal/runtime/semanticview/helpers.go
@@ -6,6 +6,11 @@ import (
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
 )
 
+type PolicyValueResolution struct {
+	Value    runtimecontracts.PolicyValue
+	OwnerKey string
+}
+
 func PolicyValueForFlow(source Source, flowID, key string) (runtimecontracts.PolicyValue, bool) {
 	if source == nil {
 		return runtimecontracts.PolicyValue{}, false
@@ -28,6 +33,129 @@ func PolicyValueForFlow(source Source, flowID, key string) (runtimecontracts.Pol
 		return runtimecontracts.PolicyValue{}, false
 	}
 	return runtimecontracts.PolicyValue{Value: descended}, true
+}
+
+func PolicyValueForFlowWithOwner(source Source, flowID, key string) (PolicyValueResolution, bool) {
+	return policyValueForFlowWithOwner(source, flowID, key, map[string]struct{}{})
+}
+
+func policyValueForFlowWithOwner(source Source, flowID, key string, seen map[string]struct{}) (PolicyValueResolution, bool) {
+	if source == nil {
+		return PolicyValueResolution{}, false
+	}
+	flowID = strings.TrimSpace(flowID)
+	key = strings.TrimSpace(key)
+	if key == "" {
+		return PolicyValueResolution{}, false
+	}
+	seenKey := flowID + "\x00" + key
+	if _, ok := seen[seenKey]; ok {
+		return PolicyValueResolution{}, false
+	}
+	seen[seenKey] = struct{}{}
+	if deps, ok := importBoundaryDependencyContext(source, flowID); ok {
+		return importBoundaryPolicyValueWithOwner(source, deps, flowID, key, seen)
+	}
+	return rawPolicyValueForFlowWithOwner(source, flowID, key)
+}
+
+func rawPolicyValueForFlowWithOwner(source Source, flowID, key string) (PolicyValueResolution, bool) {
+	flowID = strings.TrimSpace(flowID)
+	for _, scope := range policyScopesForFlow(source, flowID) {
+		if value, ok := policyValueAtPath(scope.Policy, key); ok {
+			return PolicyValueResolution{Value: value, OwnerKey: policyOwnerFlowKey(scope.ID)}, true
+		}
+	}
+	if value, ok := policyValueAtPath(source.ResolvedPolicyForFlow(flowID), key); ok {
+		return PolicyValueResolution{Value: value, OwnerKey: policyOwnerRootKey()}, true
+	}
+	return PolicyValueResolution{}, false
+}
+
+func importBoundaryPolicyValueWithOwner(source Source, deps importBoundaryDependencyCtx, flowID, key string, seen map[string]struct{}) (PolicyValueResolution, bool) {
+	required := normalizeDependencySet(deps.child.Manifest.Requires.Policy)
+	if _, ok := required[key]; ok {
+		if ref := strings.TrimSpace(deps.site.Bind.Policy[key]); ref != "" {
+			path, ok := importBoundaryParentPolicyPath(ref)
+			if !ok {
+				return PolicyValueResolution{}, false
+			}
+			return policyValueForFlowWithOwner(source, strings.TrimSpace(deps.parent.OwningFlowID), path, seen)
+		}
+		if value, ok := deps.child.Manifest.Requires.PolicyDefaults[key]; ok {
+			return PolicyValueResolution{Value: clonePolicyValue(value), OwnerKey: policyOwnerPackageKey(deps.child.Key)}, true
+		}
+		return PolicyValueResolution{}, false
+	}
+	if flow, ok := source.FlowScopeByID(strings.TrimSpace(flowID)); ok {
+		if value, ok := policyValueAtPath(flow.Policy, key); ok {
+			return PolicyValueResolution{Value: value, OwnerKey: policyOwnerFlowKey(flow.ID)}, true
+		}
+	}
+	if value, ok := policyValueAtPath(deps.child.Policy, key); ok {
+		return PolicyValueResolution{Value: value, OwnerKey: policyOwnerPackageKey(deps.child.Key)}, true
+	}
+	return PolicyValueResolution{}, false
+}
+
+func policyScopesForFlow(source Source, flowID string) []FlowScope {
+	if source == nil {
+		return nil
+	}
+	flowID = strings.TrimSpace(flowID)
+	if flowID == "" {
+		return nil
+	}
+	target, ok := source.FlowScopeByID(flowID)
+	if !ok {
+		return nil
+	}
+	targetPath := strings.Trim(strings.TrimSpace(target.Path), "/")
+	if targetPath == "" {
+		return []FlowScope{target}
+	}
+	scopes := source.FlowScopes()
+	out := make([]FlowScope, 0, len(scopes))
+	for _, scope := range scopes {
+		path := strings.Trim(strings.TrimSpace(scope.Path), "/")
+		if path == "" {
+			continue
+		}
+		if targetPath == path || strings.HasPrefix(targetPath, path+"/") {
+			out = append(out, scope)
+		}
+	}
+	for i := 0; i < len(out); i++ {
+		for j := i + 1; j < len(out); j++ {
+			if len(strings.Trim(strings.TrimSpace(out[i].Path), "/")) > len(strings.Trim(strings.TrimSpace(out[j].Path), "/")) {
+				out[i], out[j] = out[j], out[i]
+			}
+		}
+	}
+	for i, j := 0, len(out)-1; i < j; i, j = i+1, j-1 {
+		out[i], out[j] = out[j], out[i]
+	}
+	return out
+}
+
+func policyOwnerRootKey() string {
+	return "root"
+}
+
+func policyOwnerFlowKey(flowID string) string {
+	flowID = strings.TrimSpace(flowID)
+	if flowID == "" {
+		return policyOwnerRootKey()
+	}
+	return "flow:" + flowID
+}
+
+func policyOwnerPackageKey(packageKey string) string {
+	packageKey = normalizeImportPackageKey(packageKey)
+	if packageKey == "" {
+		return "package:."
+	}
+	return "package:" + packageKey
 }
 
 func FindAgentEntry(source Source, agentID, role string) (runtimecontracts.AgentRegistryEntry, bool) {

--- a/internal/runtime/semanticview/import_boundary_dependencies_test.go
+++ b/internal/runtime/semanticview/import_boundary_dependencies_test.go
@@ -34,6 +34,26 @@ func TestImportBoundaryPolicyResolutionUsesBindingThenPackageDefault(t *testing.
 	}
 }
 
+func TestImportBoundaryPolicyResolutionReportsOwnerForBindingAndPackageDefault(t *testing.T) {
+	source := loadImportBoundaryDependencyFixture(t, importBoundaryDependencyFixtureOptions{
+		policyBind: "        provider.threshold: parent.policy.provider.threshold\n",
+		policyRequires: `  policy:
+    provider.threshold: {}
+    provider.mode:
+      default: strict
+`,
+		credentialRequires: "  credentials: [provider_key]\n",
+		credentialBind:     "        provider_key: tenant_provider_key\n",
+	})
+
+	if got, ok := PolicyValueForFlowWithOwner(source, "worker", "provider.threshold"); !ok || got.Value.Value != 0.91 || got.OwnerKey != "root" {
+		t.Fatalf("provider.threshold resolution = (%#v, %v), want root-owned bound value 0.91", got, ok)
+	}
+	if got, ok := PolicyValueForFlowWithOwner(source, "worker", "provider.mode"); !ok || got.Value.Value != "strict" || got.OwnerKey != "package:flows/worker" {
+		t.Fatalf("provider.mode resolution = (%#v, %v), want package-owned default strict", got, ok)
+	}
+}
+
 func TestImportBoundaryPolicyResolutionUsesResolvedParentPolicyForNestedBinding(t *testing.T) {
 	source := loadNestedImportBoundaryPolicyFixture(t)
 

--- a/internal/runtime/tools/executor.go
+++ b/internal/runtime/tools/executor.go
@@ -47,6 +47,7 @@ type Executor struct {
 	authorizer                     *ToolAuthorizer
 	validator                      *ToolInputValidator
 	dispatcher                     *ToolDispatcher
+	externalDispatchAdmission      *externalDispatchAdmissionController
 	allowInternalLegacyEntityTools bool
 	execWorkspaceFn                func(ctx context.Context, target workspace.ExecutionTarget, timeout time.Duration, stdin string, args ...string) ([]byte, []byte, int, error)
 	oneShotMu                      sync.Mutex
@@ -83,6 +84,7 @@ func NewExecutorWithOptions(bus EventPublisher, scheduler Scheduler, opts Execut
 		workflowSource:                 opts.WorkflowSource,
 		workspaces:                     opts.WorkspaceResolver,
 		authority:                      runtimeauthority.ProviderOrNoop(opts.AuthorityProvider),
+		externalDispatchAdmission:      newExternalDispatchAdmissionController(),
 		allowInternalLegacyEntityTools: opts.AllowInternalLegacyEntityTools,
 		oneShotEmits:                   make(map[string]struct{}),
 	}
@@ -374,11 +376,12 @@ func (e *Executor) Execute(ctx context.Context, name string, input any) (any, er
 	}
 	input = normalizeRuntimeToolInput(name, input)
 	start := time.Now()
-	out, err := e.dispatchTool(ctx, actor, name, input)
+	dispatchCtx := withExternalDispatchAdmissionCollector(ctx)
+	out, err := e.dispatchTool(dispatchCtx, actor, name, input)
 	if isEmitToolName(name) {
 		return out, err
 	}
-	e.emitToolExecutionEvent(ctx, actor, name, input, out, err, time.Since(start), "dispatch")
+	e.emitToolExecutionEvent(dispatchCtx, actor, name, input, out, err, time.Since(start), "dispatch")
 	return out, err
 }
 
@@ -574,6 +577,11 @@ func toolExecutionDiagnosticDetail(ctx context.Context, toolName string, input a
 			detail["runtime_error_component"] = v
 		}
 		detail["retryable"] = runtimeErr.Retryable
+	}
+	if rateLimitDetail, ok := externalDispatchAdmissionDiagnosticDetail(ctx); ok {
+		for key, value := range rateLimitDetail {
+			detail[key] = value
+		}
 	}
 	return detail
 }

--- a/internal/runtime/tools/executor_http.go
+++ b/internal/runtime/tools/executor_http.go
@@ -94,6 +94,9 @@ func (e *Executor) execHTTPTool(ctx context.Context, actor models.AgentConfig, t
 			return result, nil
 		}
 		lastErr = err
+		if isExternalDispatchRateLimited(err) {
+			break
+		}
 		if attempt == maxRetries {
 			break
 		}
@@ -110,6 +113,9 @@ func (e *Executor) execHTTPTool(ctx context.Context, actor models.AgentConfig, t
 }
 
 func (e *Executor) execHTTPRequestOnce(ctx context.Context, method, url string, headers http.Header, body io.Reader, timeout time.Duration, tool RegisteredTool) (any, error) {
+	if err := e.admitExternalDispatch(ctx, e.httpToolExternalDispatchPolicy(tool)); err != nil {
+		return nil, err
+	}
 	reqCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 	req, err := http.NewRequestWithContext(reqCtx, method, url, body)
@@ -120,9 +126,6 @@ func (e *Executor) execHTTPRequestOnce(ctx context.Context, method, url string, 
 		for _, value := range values {
 			req.Header.Add(key, value)
 		}
-	}
-	if err := e.admitExternalDispatch(ctx, e.httpToolExternalDispatchPolicy(tool)); err != nil {
-		return nil, err
 	}
 	resp, err := e.httpClient.Do(req)
 	if err != nil {

--- a/internal/runtime/tools/executor_http.go
+++ b/internal/runtime/tools/executor_http.go
@@ -121,6 +121,9 @@ func (e *Executor) execHTTPRequestOnce(ctx context.Context, method, url string, 
 			req.Header.Add(key, value)
 		}
 	}
+	if err := e.admitExternalDispatch(ctx, e.httpToolExternalDispatchPolicy(tool)); err != nil {
+		return nil, err
+	}
 	resp, err := e.httpClient.Do(req)
 	if err != nil {
 		return nil, err
@@ -150,6 +153,13 @@ func (e *Executor) execHTTPRequestOnce(ctx context.Context, method, url string, 
 func (e *Executor) execMCPTool(ctx context.Context, actor models.AgentConfig, tool RegisteredTool, input any) (any, error) {
 	if e.mcpClient == nil {
 		return nil, fmt.Errorf("mcp client is not configured")
+	}
+	policy, err := e.mcpToolExternalDispatchPolicy(tool)
+	if err != nil {
+		return nil, err
+	}
+	if err := e.admitExternalDispatch(ctx, policy); err != nil {
+		return nil, err
 	}
 	e.mu.RLock()
 	source := e.workflowSource

--- a/internal/runtime/tools/executor_native.go
+++ b/internal/runtime/tools/executor_native.go
@@ -46,7 +46,7 @@ type webSearchProviderConfig struct {
 	HTTP              *runtimecontracts.HTTPToolSpec
 	ResponsePath      string
 	FieldMapping      map[string]string
-	FlowID            string
+	PolicyOwnerKey    string
 	RateLimit         externalDispatchRateLimitConfig
 }
 
@@ -458,10 +458,11 @@ func resolveWebSearchProviderConfigFromSourceForFlow(source semanticview.Source,
 	if source == nil {
 		return webSearchProviderConfig{}, fmt.Errorf("web_search provider is unavailable without a workflow source")
 	}
-	value, ok := semanticview.PolicyValueForFlow(source, strings.TrimSpace(flowID), "web_search_provider")
+	resolution, ok := semanticview.PolicyValueForFlowWithOwner(source, strings.TrimSpace(flowID), "web_search_provider")
 	if !ok {
 		return webSearchProviderConfig{}, fmt.Errorf("policy.web_search_provider is not configured")
 	}
+	value := resolution.Value
 	root, ok := normalizeAnyMap(value.Value)
 	if !ok {
 		return webSearchProviderConfig{}, fmt.Errorf("policy.web_search_provider must be a mapping")
@@ -472,7 +473,7 @@ func resolveWebSearchProviderConfigFromSourceForFlow(source semanticview.Source,
 		MaxResultsDefault: asInt(root["max_results_default"]),
 		ResponsePath:      strings.TrimSpace(asString(root["response_path"])),
 		FieldMapping:      map[string]string{},
-		FlowID:            strings.TrimSpace(flowID),
+		PolicyOwnerKey:    strings.TrimSpace(resolution.OwnerKey),
 	}
 	rateLimit, _, err := parseExternalDispatchRateLimit(asString(root["rate_limit"]), asString(root["rate_limit_max_wait"]))
 	if err != nil {

--- a/internal/runtime/tools/executor_native.go
+++ b/internal/runtime/tools/executor_native.go
@@ -46,6 +46,8 @@ type webSearchProviderConfig struct {
 	HTTP              *runtimecontracts.HTTPToolSpec
 	ResponsePath      string
 	FieldMapping      map[string]string
+	FlowID            string
+	RateLimit         externalDispatchRateLimitConfig
 }
 
 func (e *Executor) execNativeBash(ctx context.Context, actor models.AgentConfig, input any) (any, error) {
@@ -185,7 +187,7 @@ func (e *Executor) executeWebSearch(ctx context.Context, cfg webSearchProviderCo
 		}
 		req.Header.Set("Accept", "application/json")
 		req.Header.Set("X-Subscription-Token", credentialValue)
-		return e.doNormalizedSearch(ctx, req, "web.results", map[string]string{"title": "title", "url": "url", "snippet": "description"})
+		return e.doNormalizedSearch(ctx, req, "web.results", map[string]string{"title": "title", "url": "url", "snippet": "description"}, e.webSearchExternalDispatchPolicy(cfg))
 	case "serper":
 		body, _ := json.Marshal(map[string]any{"q": query, "num": maxResults})
 		req, err := http.NewRequestWithContext(ctx, http.MethodPost, "https://google.serper.dev/search", bytes.NewReader(body))
@@ -194,7 +196,7 @@ func (e *Executor) executeWebSearch(ctx context.Context, cfg webSearchProviderCo
 		}
 		req.Header.Set("Content-Type", "application/json")
 		req.Header.Set("X-API-KEY", credentialValue)
-		return e.doNormalizedSearch(ctx, req, "organic", map[string]string{"title": "title", "url": "link", "snippet": "snippet"})
+		return e.doNormalizedSearch(ctx, req, "organic", map[string]string{"title": "title", "url": "link", "snippet": "snippet"}, e.webSearchExternalDispatchPolicy(cfg))
 	case "tavily":
 		body, _ := json.Marshal(map[string]any{"api_key": credentialValue, "query": query, "max_results": maxResults})
 		req, err := http.NewRequestWithContext(ctx, http.MethodPost, "https://api.tavily.com/search", bytes.NewReader(body))
@@ -202,7 +204,7 @@ func (e *Executor) executeWebSearch(ctx context.Context, cfg webSearchProviderCo
 			return nil, err
 		}
 		req.Header.Set("Content-Type", "application/json")
-		return e.doNormalizedSearch(ctx, req, "results", map[string]string{"title": "title", "url": "url", "snippet": "content"})
+		return e.doNormalizedSearch(ctx, req, "results", map[string]string{"title": "title", "url": "url", "snippet": "content"}, e.webSearchExternalDispatchPolicy(cfg))
 	case "custom":
 		return e.executeCustomWebSearch(ctx, cfg, query, maxResults, credentialValue)
 	default:
@@ -262,10 +264,13 @@ func (e *Executor) executeCustomWebSearch(ctx context.Context, cfg webSearchProv
 		return nil, err
 	}
 	req.Header = headers
-	return e.doNormalizedSearch(ctx, req, cfg.ResponsePath, cfg.FieldMapping)
+	return e.doNormalizedSearch(ctx, req, cfg.ResponsePath, cfg.FieldMapping, e.webSearchExternalDispatchPolicy(cfg))
 }
 
-func (e *Executor) doNormalizedSearch(ctx context.Context, req *http.Request, responsePath string, fieldMapping map[string]string) ([]map[string]any, error) {
+func (e *Executor) doNormalizedSearch(ctx context.Context, req *http.Request, responsePath string, fieldMapping map[string]string, policy externalDispatchAdmissionPolicy) ([]map[string]any, error) {
+	if err := e.admitExternalDispatch(ctx, policy); err != nil {
+		return nil, err
+	}
 	resp, err := e.httpClient.Do(req)
 	if err != nil {
 		return nil, err
@@ -467,7 +472,13 @@ func resolveWebSearchProviderConfigFromSourceForFlow(source semanticview.Source,
 		MaxResultsDefault: asInt(root["max_results_default"]),
 		ResponsePath:      strings.TrimSpace(asString(root["response_path"])),
 		FieldMapping:      map[string]string{},
+		FlowID:            strings.TrimSpace(flowID),
 	}
+	rateLimit, _, err := parseExternalDispatchRateLimit(asString(root["rate_limit"]), asString(root["rate_limit_max_wait"]))
+	if err != nil {
+		return webSearchProviderConfig{}, fmt.Errorf("policy.web_search_provider: %w", err)
+	}
+	cfg.RateLimit = rateLimit
 	if cfg.MaxResultsDefault <= 0 {
 		cfg.MaxResultsDefault = 10
 	}

--- a/internal/runtime/tools/external_dispatch_admission.go
+++ b/internal/runtime/tools/external_dispatch_admission.go
@@ -1,0 +1,652 @@
+package tools
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+	"unicode"
+
+	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
+	"github.com/division-sh/swarm/internal/runtime/semanticview"
+)
+
+const (
+	externalDispatchRateLimitedCode = "rate_limited"
+
+	externalDispatchScopeHTTPTool        = "http_tool"
+	externalDispatchScopeMCPServer       = "mcp_server"
+	externalDispatchScopeNativeWebSearch = "native_web_search"
+
+	externalDispatchOutcomeImmediate = "admitted_immediate"
+	externalDispatchOutcomeWaited    = "admitted_after_wait"
+	externalDispatchOutcomeTimedOut  = "timed_out"
+)
+
+type externalDispatchRateLimitConfig struct {
+	Enabled bool
+	Limit   int
+	Period  time.Duration
+	MaxWait time.Duration
+}
+
+type externalDispatchAdmissionPolicy struct {
+	Scope      string
+	BucketName string
+	BucketKey  string
+	Config     externalDispatchRateLimitConfig
+}
+
+type externalDispatchAdmissionResult struct {
+	Enabled    bool
+	Scope      string
+	BucketHash string
+	Limit      int
+	Period     time.Duration
+	MaxWait    time.Duration
+	Wait       time.Duration
+	Outcome    string
+	ErrorCode  string
+	Retryable  bool
+}
+
+type externalDispatchAdmissionSummary struct {
+	Enabled    bool
+	Scope      string
+	BucketHash string
+	Limit      int
+	Period     time.Duration
+	MaxWait    time.Duration
+	Wait       time.Duration
+	Outcome    string
+	ErrorCode  string
+	Retryable  bool
+	Attempts   int
+}
+
+type externalDispatchAdmissionCollector struct {
+	mu      sync.Mutex
+	summary externalDispatchAdmissionSummary
+}
+
+type externalDispatchAdmissionCollectorKey struct{}
+
+func withExternalDispatchAdmissionCollector(ctx context.Context) context.Context {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if _, ok := ctx.Value(externalDispatchAdmissionCollectorKey{}).(*externalDispatchAdmissionCollector); ok {
+		return ctx
+	}
+	return context.WithValue(ctx, externalDispatchAdmissionCollectorKey{}, &externalDispatchAdmissionCollector{})
+}
+
+func recordExternalDispatchAdmission(ctx context.Context, result externalDispatchAdmissionResult) {
+	if !result.Enabled {
+		return
+	}
+	collector, ok := ctx.Value(externalDispatchAdmissionCollectorKey{}).(*externalDispatchAdmissionCollector)
+	if !ok || collector == nil {
+		return
+	}
+	collector.record(result)
+}
+
+func externalDispatchAdmissionDiagnosticDetail(ctx context.Context) (map[string]any, bool) {
+	collector, ok := ctx.Value(externalDispatchAdmissionCollectorKey{}).(*externalDispatchAdmissionCollector)
+	if !ok || collector == nil {
+		return nil, false
+	}
+	summary, ok := collector.snapshot()
+	if !ok {
+		return nil, false
+	}
+	detail := map[string]any{
+		"rate_limit_scope":       summary.Scope,
+		"rate_limit_bucket_hash": summary.BucketHash,
+		"rate_limit_limit":       summary.Limit,
+		"rate_limit_period_ms":   summary.Period.Milliseconds(),
+		"rate_limit_max_wait_ms": summary.MaxWait.Milliseconds(),
+		"rate_limit_wait_ms":     summary.Wait.Milliseconds(),
+		"rate_limit_outcome":     summary.Outcome,
+		"rate_limit_attempts":    summary.Attempts,
+	}
+	if summary.ErrorCode != "" {
+		detail["error_code"] = summary.ErrorCode
+		detail["retryable"] = summary.Retryable
+	}
+	return detail, true
+}
+
+func (c *externalDispatchAdmissionCollector) record(result externalDispatchAdmissionResult) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if !c.summary.Enabled {
+		c.summary = externalDispatchAdmissionSummary{
+			Enabled:    true,
+			Scope:      result.Scope,
+			BucketHash: result.BucketHash,
+			Limit:      result.Limit,
+			Period:     result.Period,
+			MaxWait:    result.MaxWait,
+			Outcome:    result.Outcome,
+		}
+	}
+	c.summary.Attempts++
+	c.summary.Wait += result.Wait
+	switch result.Outcome {
+	case externalDispatchOutcomeTimedOut:
+		c.summary.Outcome = result.Outcome
+		c.summary.ErrorCode = result.ErrorCode
+		c.summary.Retryable = result.Retryable
+	case externalDispatchOutcomeWaited:
+		if c.summary.Outcome != externalDispatchOutcomeTimedOut {
+			c.summary.Outcome = result.Outcome
+		}
+	case externalDispatchOutcomeImmediate:
+		if c.summary.Outcome == "" {
+			c.summary.Outcome = result.Outcome
+		}
+	}
+}
+
+func (c *externalDispatchAdmissionCollector) snapshot() (externalDispatchAdmissionSummary, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if !c.summary.Enabled {
+		return externalDispatchAdmissionSummary{}, false
+	}
+	return c.summary, true
+}
+
+type externalDispatchAdmissionController struct {
+	mu      sync.Mutex
+	buckets map[string]*externalDispatchAdmissionBucket
+}
+
+type externalDispatchAdmissionBucket struct {
+	mu        sync.Mutex
+	scheduled []time.Time
+}
+
+func newExternalDispatchAdmissionController() *externalDispatchAdmissionController {
+	return &externalDispatchAdmissionController{buckets: map[string]*externalDispatchAdmissionBucket{}}
+}
+
+func (e *Executor) admitExternalDispatch(ctx context.Context, policy externalDispatchAdmissionPolicy) error {
+	if e == nil || e.externalDispatchAdmission == nil || !policy.Config.Enabled {
+		return nil
+	}
+	result, err := e.externalDispatchAdmission.Admit(ctx, policy)
+	recordExternalDispatchAdmission(ctx, result)
+	return err
+}
+
+func (e *Executor) httpToolExternalDispatchPolicy(tool RegisteredTool) externalDispatchAdmissionPolicy {
+	if !tool.RateLimit.Enabled {
+		return externalDispatchAdmissionPolicy{}
+	}
+	source := e.workflowSourceForAdmission()
+	toolName := strings.TrimSpace(tool.Name)
+	bucketKey := strings.Join([]string{
+		externalDispatchScopeHTTPTool,
+		externalDispatchSourceKey(source),
+		toolName,
+	}, ":")
+	return externalDispatchAdmissionPolicy{
+		Scope:      externalDispatchScopeHTTPTool,
+		BucketName: "http tool " + toolName,
+		BucketKey:  bucketKey,
+		Config:     tool.RateLimit,
+	}
+}
+
+func (e *Executor) mcpToolExternalDispatchPolicy(tool RegisteredTool) (externalDispatchAdmissionPolicy, error) {
+	if e == nil || e.mcpClient == nil {
+		return externalDispatchAdmissionPolicy{}, nil
+	}
+	serverName := strings.TrimSpace(tool.MCPServerName)
+	if serverName == "" {
+		return externalDispatchAdmissionPolicy{}, nil
+	}
+	cfg, ok := e.mcpClient.ServerConfig(serverName)
+	if !ok {
+		return externalDispatchAdmissionPolicy{}, nil
+	}
+	rateLimit, _, err := parseExternalDispatchRateLimit(cfg.RateLimit, cfg.RateLimitMaxWait)
+	if err != nil {
+		return externalDispatchAdmissionPolicy{}, fmt.Errorf("mcp_servers.%s: %w", serverName, err)
+	}
+	if !rateLimit.Enabled {
+		return externalDispatchAdmissionPolicy{}, nil
+	}
+	source := e.workflowSourceForAdmission()
+	bucketKey := strings.Join([]string{
+		externalDispatchScopeMCPServer,
+		externalDispatchSourceKey(source),
+		serverName,
+	}, ":")
+	return externalDispatchAdmissionPolicy{
+		Scope:      externalDispatchScopeMCPServer,
+		BucketName: "mcp server " + serverName,
+		BucketKey:  bucketKey,
+		Config:     rateLimit,
+	}, nil
+}
+
+func (e *Executor) webSearchExternalDispatchPolicy(cfg webSearchProviderConfig) externalDispatchAdmissionPolicy {
+	if !cfg.RateLimit.Enabled {
+		return externalDispatchAdmissionPolicy{}
+	}
+	source := e.workflowSourceForAdmission()
+	flowID := strings.TrimSpace(cfg.FlowID)
+	if flowID == "" {
+		flowID = "root"
+	}
+	provider := strings.TrimSpace(cfg.Provider)
+	bucketKey := strings.Join([]string{
+		externalDispatchScopeNativeWebSearch,
+		externalDispatchSourceKey(source),
+		flowID,
+		provider,
+	}, ":")
+	return externalDispatchAdmissionPolicy{
+		Scope:      externalDispatchScopeNativeWebSearch,
+		BucketName: "native web_search provider " + provider,
+		BucketKey:  bucketKey,
+		Config:     cfg.RateLimit,
+	}
+}
+
+func (e *Executor) workflowSourceForAdmission() semanticview.Source {
+	if e == nil {
+		return nil
+	}
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+	return e.workflowSource
+}
+
+func (c *externalDispatchAdmissionController) Admit(ctx context.Context, policy externalDispatchAdmissionPolicy) (externalDispatchAdmissionResult, error) {
+	cfg := policy.Config
+	if !cfg.Enabled {
+		return externalDispatchAdmissionResult{}, nil
+	}
+	bucketKey := strings.TrimSpace(policy.BucketKey)
+	if bucketKey == "" {
+		return externalDispatchAdmissionResult{}, fmt.Errorf("external dispatch admission bucket key is required")
+	}
+	result := externalDispatchAdmissionResult{
+		Enabled:    true,
+		Scope:      strings.TrimSpace(policy.Scope),
+		BucketHash: externalDispatchBucketHash(bucketKey),
+		Limit:      cfg.Limit,
+		Period:     cfg.Period,
+		MaxWait:    cfg.MaxWait,
+		Outcome:    externalDispatchOutcomeImmediate,
+	}
+	bucket := c.bucket(bucketKey)
+	wait, scheduled, timedOut := bucket.reserve(cfg.Limit, cfg.Period, cfg.MaxWait)
+	result.Wait = wait
+	if timedOut {
+		result.Outcome = externalDispatchOutcomeTimedOut
+		result.ErrorCode = externalDispatchRateLimitedCode
+		result.Retryable = true
+		return result, NewRuntimeError(
+			externalDispatchRateLimitedCode,
+			"tool-executor",
+			"external_dispatch_admission",
+			true,
+			"external dispatch rate limit exceeded for %s",
+			strings.TrimSpace(policy.BucketName),
+		)
+	}
+	if wait > 0 {
+		result.Outcome = externalDispatchOutcomeWaited
+		timer := time.NewTimer(wait)
+		defer timer.Stop()
+		select {
+		case <-ctx.Done():
+			bucket.cancelReservation(scheduled)
+			return result, ctx.Err()
+		case <-timer.C:
+		}
+	}
+	return result, nil
+}
+
+func (c *externalDispatchAdmissionController) bucket(key string) *externalDispatchAdmissionBucket {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.buckets == nil {
+		c.buckets = map[string]*externalDispatchAdmissionBucket{}
+	}
+	bucket := c.buckets[key]
+	if bucket == nil {
+		bucket = &externalDispatchAdmissionBucket{}
+		c.buckets[key] = bucket
+	}
+	return bucket
+}
+
+func (b *externalDispatchAdmissionBucket) reserve(limit int, period, maxWait time.Duration) (time.Duration, time.Time, bool) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	now := time.Now()
+	cutoff := now.Add(-period)
+	kept := b.scheduled[:0]
+	for _, scheduled := range b.scheduled {
+		if scheduled.After(cutoff) {
+			kept = append(kept, scheduled)
+		}
+	}
+	b.scheduled = kept
+	scheduled := now
+	if len(b.scheduled) >= limit {
+		next := b.scheduled[len(b.scheduled)-limit].Add(period)
+		if next.After(scheduled) {
+			scheduled = next
+		}
+	}
+	wait := scheduled.Sub(now)
+	if wait < 0 {
+		wait = 0
+	}
+	if wait > maxWait {
+		return wait, scheduled, true
+	}
+	b.scheduled = append(b.scheduled, scheduled)
+	return wait, scheduled, false
+}
+
+func (b *externalDispatchAdmissionBucket) cancelReservation(scheduled time.Time) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	for i, item := range b.scheduled {
+		if item.Equal(scheduled) {
+			b.scheduled = append(b.scheduled[:i], b.scheduled[i+1:]...)
+			return
+		}
+	}
+}
+
+func externalDispatchBucketHash(bucketKey string) string {
+	sum := sha256.Sum256([]byte(strings.TrimSpace(bucketKey)))
+	return "sha256:" + hex.EncodeToString(sum[:])
+}
+
+func parseExternalDispatchRateLimit(rateLimit, maxWait string) (externalDispatchRateLimitConfig, bool, error) {
+	rateLimitSet := rateLimit != ""
+	maxWaitSet := maxWait != ""
+	if !rateLimitSet && !maxWaitSet {
+		return externalDispatchRateLimitConfig{}, false, nil
+	}
+	if !rateLimitSet {
+		return externalDispatchRateLimitConfig{}, false, fmt.Errorf("rate_limit_max_wait requires rate_limit")
+	}
+	if !maxWaitSet {
+		return externalDispatchRateLimitConfig{}, false, fmt.Errorf("rate_limit requires rate_limit_max_wait")
+	}
+	limit, period, err := parseExternalDispatchRate(rateLimit)
+	if err != nil {
+		return externalDispatchRateLimitConfig{}, false, fmt.Errorf("rate_limit: %w", err)
+	}
+	wait, err := parseExternalDispatchDuration(maxWait, true)
+	if err != nil {
+		return externalDispatchRateLimitConfig{}, false, fmt.Errorf("rate_limit_max_wait: %w", err)
+	}
+	return externalDispatchRateLimitConfig{
+		Enabled: true,
+		Limit:   limit,
+		Period:  period,
+		MaxWait: wait,
+	}, true, nil
+}
+
+func ValidateExternalDispatchRateLimitDeclarations(source semanticview.Source) []error {
+	if source == nil {
+		return nil
+	}
+	errs := make([]error, 0)
+	for name, entry := range source.ToolEntries() {
+		location := fmt.Sprintf("tool %s", strings.TrimSpace(name))
+		_, enabled, err := parseExternalDispatchRateLimit(entry.RateLimit, entry.RateLimitMaxWait)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("%s: %w", location, err))
+			continue
+		}
+		if enabled && normalizeImplementationClass(name, entry) != implementationHTTP {
+			errs = append(errs, fmt.Errorf("%s: rate_limit is only supported for handler_type http", location))
+		}
+	}
+	errs = appendExternalDispatchPolicyValidationErrors(errs, "root policy", source.ResolvedPolicyForFlow("").Values)
+	for _, scope := range source.ProjectScopes() {
+		label := strings.TrimSpace(scope.Key)
+		if label == "" {
+			label = strings.TrimSpace(scope.Manifest.Name)
+		}
+		if label == "" {
+			label = "project"
+		}
+		errs = appendExternalDispatchPolicyValidationErrors(errs, "project policy "+label, scope.Policy.Values)
+	}
+	for _, scope := range source.FlowScopes() {
+		label := strings.TrimSpace(scope.ID)
+		if label == "" {
+			label = strings.TrimSpace(scope.Path)
+		}
+		if label == "" {
+			label = "flow"
+		}
+		errs = appendExternalDispatchPolicyValidationErrors(errs, "flow policy "+label, scope.Policy.Values)
+	}
+	return dedupeExternalDispatchValidationErrors(errs)
+}
+
+func appendExternalDispatchPolicyValidationErrors(errs []error, location string, values map[string]runtimecontracts.PolicyValue) []error {
+	if len(values) == 0 {
+		return errs
+	}
+	if item, ok := values["mcp_servers"]; ok {
+		errs = appendExternalDispatchMCPServerValidationErrors(errs, location+".mcp_servers", item.Value)
+	}
+	if item, ok := values["web_search_provider"]; ok {
+		errs = appendExternalDispatchWebSearchValidationErrors(errs, location+".web_search_provider", item.Value)
+	}
+	return errs
+}
+
+func appendExternalDispatchMCPServerValidationErrors(errs []error, location string, raw any) []error {
+	servers, ok := raw.(map[string]any)
+	if !ok {
+		return errs
+	}
+	names := make([]string, 0, len(servers))
+	for name := range servers {
+		if strings.TrimSpace(name) != "" {
+			names = append(names, strings.TrimSpace(name))
+		}
+	}
+	sort.Strings(names)
+	for _, name := range names {
+		item, ok := servers[name].(map[string]any)
+		if !ok {
+			continue
+		}
+		rateLimit, maxWait, err := externalDispatchRateLimitPairFromMap(item)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("%s.%s: %w", location, name, err))
+			continue
+		}
+		if _, _, err := parseExternalDispatchRateLimit(rateLimit, maxWait); err != nil {
+			errs = append(errs, fmt.Errorf("%s.%s: %w", location, name, err))
+		}
+	}
+	return errs
+}
+
+func appendExternalDispatchWebSearchValidationErrors(errs []error, location string, raw any) []error {
+	item, ok := raw.(map[string]any)
+	if !ok {
+		return errs
+	}
+	rateLimit, maxWait, err := externalDispatchRateLimitPairFromMap(item)
+	if err != nil {
+		return append(errs, fmt.Errorf("%s: %w", location, err))
+	}
+	if _, _, err := parseExternalDispatchRateLimit(rateLimit, maxWait); err != nil {
+		errs = append(errs, fmt.Errorf("%s: %w", location, err))
+	}
+	return errs
+}
+
+func externalDispatchRateLimitPairFromMap(item map[string]any) (string, string, error) {
+	rateLimit, _, err := externalDispatchOptionalString(item, "rate_limit")
+	if err != nil {
+		return "", "", err
+	}
+	maxWait, _, err := externalDispatchOptionalString(item, "rate_limit_max_wait")
+	if err != nil {
+		return "", "", err
+	}
+	return rateLimit, maxWait, nil
+}
+
+func externalDispatchOptionalString(item map[string]any, field string) (string, bool, error) {
+	value, ok := item[field]
+	if !ok || value == nil {
+		return "", false, nil
+	}
+	text, ok := value.(string)
+	if !ok {
+		return "", true, fmt.Errorf("%s must be a string", field)
+	}
+	return text, true, nil
+}
+
+func dedupeExternalDispatchValidationErrors(errs []error) []error {
+	if len(errs) < 2 {
+		return errs
+	}
+	out := make([]error, 0, len(errs))
+	seen := make(map[string]struct{}, len(errs))
+	for _, err := range errs {
+		if err == nil {
+			continue
+		}
+		key := err.Error()
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		out = append(out, err)
+	}
+	return out
+}
+
+func parseExternalDispatchRate(raw string) (int, time.Duration, error) {
+	if err := rejectRateLimitWhitespace(raw); err != nil {
+		return 0, 0, err
+	}
+	countRaw, periodRaw, ok := strings.Cut(raw, "/")
+	if !ok || countRaw == "" || periodRaw == "" || strings.Contains(periodRaw, "/") {
+		return 0, 0, fmt.Errorf("must be <positive integer>/<period>")
+	}
+	count, err := strconv.Atoi(countRaw)
+	if err != nil || count <= 0 {
+		return 0, 0, fmt.Errorf("count must be a positive integer")
+	}
+	period, err := parseExternalDispatchDuration(periodRaw, false)
+	if err != nil {
+		return 0, 0, err
+	}
+	return count, period, nil
+}
+
+func parseExternalDispatchDuration(raw string, allowZero bool) (time.Duration, error) {
+	if err := rejectRateLimitWhitespace(raw); err != nil {
+		return 0, err
+	}
+	if raw == "" {
+		return 0, fmt.Errorf("duration is required")
+	}
+	unit := ""
+	numberRaw := raw
+	for _, candidate := range []string{"ms", "s", "m", "h", "d"} {
+		if strings.HasSuffix(raw, candidate) {
+			unit = candidate
+			numberRaw = strings.TrimSuffix(raw, candidate)
+			break
+		}
+	}
+	if unit == "" {
+		return 0, fmt.Errorf("duration unit must be one of ms, s, m, h, d")
+	}
+	if numberRaw == "" {
+		numberRaw = "1"
+	}
+	n, err := strconv.Atoi(numberRaw)
+	if err != nil {
+		return 0, fmt.Errorf("duration amount must be an integer")
+	}
+	if n < 0 || (!allowZero && n == 0) {
+		return 0, fmt.Errorf("duration must be positive")
+	}
+	var unitDuration time.Duration
+	switch unit {
+	case "ms":
+		unitDuration = time.Millisecond
+	case "s":
+		unitDuration = time.Second
+	case "m":
+		unitDuration = time.Minute
+	case "h":
+		unitDuration = time.Hour
+	case "d":
+		unitDuration = 24 * time.Hour
+	}
+	return time.Duration(n) * unitDuration, nil
+}
+
+func rejectRateLimitWhitespace(raw string) error {
+	if raw == "" {
+		return nil
+	}
+	if strings.ContainsFunc(raw, unicode.IsSpace) {
+		return fmt.Errorf("must not contain whitespace")
+	}
+	return nil
+}
+
+func externalDispatchSourceKey(source semanticview.Source) string {
+	if source == nil {
+		return "source:unknown"
+	}
+	parts := []string{}
+	if name := strings.TrimSpace(source.WorkflowName()); name != "" {
+		parts = append(parts, name)
+	}
+	if version := strings.TrimSpace(source.WorkflowVersion()); version != "" {
+		parts = append(parts, version)
+	}
+	if len(parts) == 0 {
+		scopes := source.ProjectScopes()
+		labels := make([]string, 0, len(scopes))
+		for _, scope := range scopes {
+			if key := strings.TrimSpace(scope.Key); key != "" {
+				labels = append(labels, key)
+			}
+		}
+		sort.Strings(labels)
+		parts = labels
+	}
+	if len(parts) == 0 {
+		return "source:unknown"
+	}
+	return "source:" + strings.Join(parts, "@")
+}

--- a/internal/runtime/tools/external_dispatch_admission.go
+++ b/internal/runtime/tools/external_dispatch_admission.go
@@ -249,15 +249,15 @@ func (e *Executor) webSearchExternalDispatchPolicy(cfg webSearchProviderConfig) 
 		return externalDispatchAdmissionPolicy{}
 	}
 	source := e.workflowSourceForAdmission()
-	flowID := strings.TrimSpace(cfg.FlowID)
-	if flowID == "" {
-		flowID = "root"
+	ownerKey := strings.TrimSpace(cfg.PolicyOwnerKey)
+	if ownerKey == "" {
+		ownerKey = "root"
 	}
 	provider := strings.TrimSpace(cfg.Provider)
 	bucketKey := strings.Join([]string{
 		externalDispatchScopeNativeWebSearch,
 		externalDispatchSourceKey(source),
-		flowID,
+		ownerKey,
 		provider,
 	}, ":")
 	return externalDispatchAdmissionPolicy{

--- a/internal/runtime/tools/external_dispatch_admission.go
+++ b/internal/runtime/tools/external_dispatch_admission.go
@@ -187,6 +187,11 @@ func (e *Executor) admitExternalDispatch(ctx context.Context, policy externalDis
 	return err
 }
 
+func isExternalDispatchRateLimited(err error) bool {
+	runtimeErr, ok := AsRuntimeError(err)
+	return ok && runtimeErr != nil && runtimeErr.Code == externalDispatchRateLimitedCode
+}
+
 func (e *Executor) httpToolExternalDispatchPolicy(tool RegisteredTool) externalDispatchAdmissionPolicy {
 	if !tool.RateLimit.Enabled {
 		return externalDispatchAdmissionPolicy{}

--- a/internal/runtime/tools/external_dispatch_admission_test.go
+++ b/internal/runtime/tools/external_dispatch_admission_test.go
@@ -159,6 +159,61 @@ func TestExecutor_HTTPRetryAttemptsTraverseSameRateLimitBucket(t *testing.T) {
 	recorder.requireGapAtLeast(t, 1050*time.Millisecond)
 }
 
+func TestExecutor_HTTPTimeoutStartsAfterAdmissionWait(t *testing.T) {
+	var recorder dispatchTimeRecorder
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		recorder.record()
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"ok": true})
+	}))
+	defer server.Close()
+
+	exec := NewExecutorWithOptions(nil, nil, ExecutorOptions{})
+	tool := RegisteredTool{
+		Name: "check_domain",
+		HTTP: &runtimecontracts.HTTPToolSpec{Method: "GET", URL: server.URL},
+		RateLimit: externalDispatchRateLimitConfig{
+			Enabled: true,
+			Limit:   1,
+			Period:  60 * time.Millisecond,
+			MaxWait: 500 * time.Millisecond,
+		},
+	}
+	if _, err := exec.execHTTPRequestOnce(context.Background(), http.MethodGet, server.URL, http.Header{}, nil, 20*time.Millisecond, tool); err != nil {
+		t.Fatalf("initial execHTTPRequestOnce: %v", err)
+	}
+	if _, err := exec.execHTTPRequestOnce(context.Background(), http.MethodGet, server.URL, http.Header{}, nil, 20*time.Millisecond, tool); err != nil {
+		t.Fatalf("second execHTTPRequestOnce after admission wait: %v", err)
+	}
+	recorder.requireGapAtLeast(t, 45*time.Millisecond)
+}
+
+func TestExecutor_HTTPRateLimitTimeoutDoesNotRetry(t *testing.T) {
+	var recorder dispatchTimeRecorder
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		recorder.record()
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"ok": true})
+	}))
+	defer server.Close()
+
+	exec := NewExecutorWithOptions(nil, nil, ExecutorOptions{
+		WorkflowSource: rateLimitedHTTPToolSource(server.URL, "1/s", "0s", 1),
+	})
+	ctx := models.WithActor(context.Background(), models.AgentConfig{ID: "agent-1", Tools: []string{"check_domain"}})
+	if _, err := exec.Execute(ctx, "check_domain", map[string]any{}); err != nil {
+		t.Fatalf("initial Execute: %v", err)
+	}
+	_, err := exec.Execute(ctx, "check_domain", map[string]any{})
+	runtimeErr, ok := AsRuntimeError(err)
+	if !ok || runtimeErr == nil || runtimeErr.Code != externalDispatchRateLimitedCode {
+		t.Fatalf("second Execute err = %v, want rate_limited runtime error", err)
+	}
+	if got := len(recorder.timesSnapshot()); got != 1 {
+		t.Fatalf("outbound requests = %d, want no retry dispatch after admission timeout", got)
+	}
+}
+
 func TestExecutor_MCPServerRateLimitIsSharedAcrossTools(t *testing.T) {
 	var recorder dispatchTimeRecorder
 	server := newRateLimitedMCPTestServer(t, &recorder, []string{"ping", "pong"})

--- a/internal/runtime/tools/external_dispatch_admission_test.go
+++ b/internal/runtime/tools/external_dispatch_admission_test.go
@@ -467,6 +467,43 @@ func TestExecutor_NativeWebSearchCustomProviderUsesRateLimit(t *testing.T) {
 	recorder.requireGapAtLeast(t, 25*time.Millisecond)
 }
 
+func TestExecutor_NativeWebSearchInheritedProviderPolicySharesBucketAcrossFlows(t *testing.T) {
+	var recorder dispatchTimeRecorder
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		recorder.record()
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"items": []map[string]any{{"title": "T", "link": "https://example.test", "summary": "S"}},
+		})
+	}))
+	defer server.Close()
+
+	exec := NewExecutorWithOptions(nil, nil, ExecutorOptions{
+		WorkflowSource: rateLimitedNativeWebSearchSiblingFlowSource(server.URL),
+	})
+	first := models.WithActor(context.Background(), models.AgentConfig{
+		ID:          "alpha-agent",
+		FlowPath:    "alpha/instance-1",
+		NativeTools: models.NativeToolConfig{WebSearch: true},
+	})
+	if _, err := exec.Execute(first, "web_search", map[string]any{"query": "alpha"}); err != nil {
+		t.Fatalf("first sibling Execute(web_search): %v", err)
+	}
+	second := models.WithActor(context.Background(), models.AgentConfig{
+		ID:          "beta-agent",
+		FlowPath:    "beta/instance-1",
+		NativeTools: models.NativeToolConfig{WebSearch: true},
+	})
+	_, err := exec.Execute(second, "web_search", map[string]any{"query": "beta"})
+	runtimeErr, ok := AsRuntimeError(err)
+	if !ok || runtimeErr == nil || runtimeErr.Code != externalDispatchRateLimitedCode {
+		t.Fatalf("second sibling Execute(web_search) err = %v, want rate_limited runtime error", err)
+	}
+	if got := len(recorder.timesSnapshot()); got != 1 {
+		t.Fatalf("outbound web_search requests = %d, want shared inherited-policy bucket to block second dispatch", got)
+	}
+}
+
 type dispatchTimeRecorder struct {
 	mu    sync.Mutex
 	times []time.Time
@@ -553,6 +590,44 @@ func rateLimitedNativeWebSearchSource(provider, rateLimit, maxWait string, custo
 		Policy: runtimecontracts.PolicyDocument{Values: map[string]runtimecontracts.PolicyValue{
 			"web_search_provider": {Value: root},
 		}},
+	})
+}
+
+func rateLimitedNativeWebSearchSiblingFlowSource(serverURL string) semanticview.Source {
+	rootPolicy := runtimecontracts.PolicyDocument{Values: map[string]runtimecontracts.PolicyValue{
+		"web_search_provider": {Value: map[string]any{
+			"provider":            "custom",
+			"max_results_default": 2,
+			"rate_limit":          "1/s",
+			"rate_limit_max_wait": "0s",
+			"response_path":       "items",
+			"field_mapping":       map[string]any{"title": "title", "url": "link", "snippet": "summary"},
+			"http": map[string]any{
+				"method": "GET",
+				"url":    serverURL + "?q={{input.query}}&count={{input.max_results}}",
+			},
+		}},
+	}}
+	root := runtimecontracts.FlowContractView{
+		Policy: rootPolicy,
+		Children: []runtimecontracts.FlowContractView{
+			{Paths: runtimecontracts.FlowContractPaths{ID: "alpha", Flow: "alpha"}, Path: "alpha"},
+			{Paths: runtimecontracts.FlowContractPaths{ID: "beta", Flow: "beta"}, Path: "beta"},
+		},
+	}
+	return semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
+		Policy: rootPolicy,
+		FlowTree: runtimecontracts.FlowTree{
+			Root: &root,
+			ByID: map[string]*runtimecontracts.FlowContractView{
+				"alpha": &root.Children[0],
+				"beta":  &root.Children[1],
+			},
+			ByPath: map[string]*runtimecontracts.FlowContractView{
+				"alpha": &root.Children[0],
+				"beta":  &root.Children[1],
+			},
+		},
 	})
 }
 

--- a/internal/runtime/tools/external_dispatch_admission_test.go
+++ b/internal/runtime/tools/external_dispatch_admission_test.go
@@ -1,0 +1,599 @@
+package tools
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
+	models "github.com/division-sh/swarm/internal/runtime/core/actors"
+	runtimemcp "github.com/division-sh/swarm/internal/runtime/mcp"
+	"github.com/division-sh/swarm/internal/runtime/semanticview"
+)
+
+func TestParseExternalDispatchRateLimitGrammar(t *testing.T) {
+	tests := []struct {
+		name    string
+		limit   string
+		wait    string
+		wantErr string
+	}{
+		{name: "per second", limit: "5/s", wait: "2s"},
+		{name: "explicit seconds", limit: "5/1s", wait: "100ms"},
+		{name: "minutes", limit: "300/15m", wait: "1m"},
+		{name: "days", limit: "1000/1d", wait: "0s"},
+		{name: "missing wait", limit: "1/s", wantErr: "rate_limit requires rate_limit_max_wait"},
+		{name: "missing limit", wait: "1s", wantErr: "rate_limit_max_wait requires rate_limit"},
+		{name: "zero count", limit: "0/s", wait: "1s", wantErr: "count must be a positive integer"},
+		{name: "unknown unit", limit: "1/week", wait: "1s", wantErr: "duration unit"},
+		{name: "whitespace rejected", limit: "1 /s", wait: "1s", wantErr: "must not contain whitespace"},
+		{name: "negative wait rejected", limit: "1/s", wait: "-1s", wantErr: "duration must be positive"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, _, err := parseExternalDispatchRateLimit(tc.limit, tc.wait)
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Fatalf("parseExternalDispatchRateLimit(%q,%q): %v", tc.limit, tc.wait, err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("parseExternalDispatchRateLimit(%q,%q) err = %v, want %q", tc.limit, tc.wait, err, tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestValidateExternalDispatchRateLimitDeclarations(t *testing.T) {
+	source := semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
+		Tools: map[string]runtimecontracts.ToolSchemaEntry{
+			"bad_builtin": {
+				HandlerType:      "platform_builtin",
+				RateLimit:        "1/s",
+				RateLimitMaxWait: "1s",
+			},
+			"bad_http": {
+				HandlerType: "http",
+				HTTP:        &runtimecontracts.HTTPToolSpec{Method: "GET", URL: "https://example.test"},
+				RateLimit:   "1/s",
+			},
+		},
+		Policy: runtimecontracts.PolicyDocument{Values: map[string]runtimecontracts.PolicyValue{
+			"mcp_servers": {Value: map[string]any{
+				"infra": map[string]any{
+					"transport":           "stdio",
+					"command":             "infra",
+					"rate_limit":          "1 /s",
+					"rate_limit_max_wait": "1s",
+				},
+			}},
+			"web_search_provider": {Value: map[string]any{
+				"provider":            "custom",
+				"rate_limit":          "1/s",
+				"rate_limit_max_wait": 250,
+			}},
+		}},
+	})
+
+	errs := ValidateExternalDispatchRateLimitDeclarations(source)
+	joined := externalDispatchJoinedErrors(errs)
+	for _, want := range []string{
+		"tool bad_builtin: rate_limit is only supported for handler_type http",
+		"tool bad_http: rate_limit requires rate_limit_max_wait",
+		"root policy.mcp_servers.infra: rate_limit: must not contain whitespace",
+		"root policy.web_search_provider: rate_limit_max_wait must be a string",
+	} {
+		if !strings.Contains(joined, want) {
+			t.Fatalf("validation errors:\n%s\nmissing %q", joined, want)
+		}
+	}
+}
+
+func TestExecutor_HTTPToolRateLimitAdmitsDirectCallsAndLogsWait(t *testing.T) {
+	var recorder dispatchTimeRecorder
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		recorder.record()
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"ok": true})
+	}))
+	defer server.Close()
+
+	bus := &telemetryBusStub{}
+	exec := NewExecutorWithOptions(bus, nil, ExecutorOptions{
+		WorkflowSource: rateLimitedHTTPToolSource(server.URL, "1/40ms", "500ms", 0),
+	})
+	ctx := models.WithActor(context.Background(), models.AgentConfig{ID: "agent-1", Tools: []string{"check_domain"}})
+	for i := 0; i < 2; i++ {
+		if _, err := exec.Execute(ctx, "check_domain", map[string]any{}); err != nil {
+			t.Fatalf("Execute #%d: %v", i+1, err)
+		}
+	}
+	recorder.requireGapAtLeast(t, 25*time.Millisecond)
+	if len(bus.logs) != 2 {
+		t.Fatalf("runtime logs = %d, want 2", len(bus.logs))
+	}
+	detail, _ := bus.logs[1].Detail.(map[string]any)
+	if got := detail["rate_limit_scope"]; got != externalDispatchScopeHTTPTool {
+		t.Fatalf("rate_limit_scope = %#v, want %q", got, externalDispatchScopeHTTPTool)
+	}
+	if got := detail["rate_limit_outcome"]; got != externalDispatchOutcomeWaited {
+		t.Fatalf("rate_limit_outcome = %#v, want %q", got, externalDispatchOutcomeWaited)
+	}
+	if wait := int64FromAny(detail["rate_limit_wait_ms"]); wait <= 0 {
+		t.Fatalf("rate_limit_wait_ms = %#v, want positive", detail["rate_limit_wait_ms"])
+	}
+}
+
+func TestExecutor_HTTPRetryAttemptsTraverseSameRateLimitBucket(t *testing.T) {
+	var recorder dispatchTimeRecorder
+	var attempts int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		recorder.record()
+		attempts++
+		if attempts == 1 {
+			http.Error(w, "upstream unavailable", http.StatusTooManyRequests)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"ok": true})
+	}))
+	defer server.Close()
+
+	exec := NewExecutorWithOptions(nil, nil, ExecutorOptions{
+		WorkflowSource: rateLimitedHTTPToolSource(server.URL, "1/1100ms", "500ms", 1),
+	})
+	ctx := models.WithActor(context.Background(), models.AgentConfig{ID: "agent-1", Tools: []string{"check_domain"}})
+	if _, err := exec.Execute(ctx, "check_domain", map[string]any{}); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	recorder.requireGapAtLeast(t, 1050*time.Millisecond)
+}
+
+func TestExecutor_MCPServerRateLimitIsSharedAcrossTools(t *testing.T) {
+	var recorder dispatchTimeRecorder
+	server := newRateLimitedMCPTestServer(t, &recorder, []string{"ping", "pong"})
+	defer server.Close()
+
+	exec := NewExecutorWithOptions(nil, nil, ExecutorOptions{
+		WorkflowSource: rateLimitedMCPSource(server.URL, "1/40ms", "500ms"),
+	})
+	ctx := models.WithActor(context.Background(), models.AgentConfig{ID: "agent-1", Tools: []string{"infra.ping", "infra.pong"}})
+	if _, err := exec.Execute(ctx, "infra.ping", map[string]any{}); err != nil {
+		t.Fatalf("Execute(infra.ping): %v", err)
+	}
+	if _, err := exec.Execute(ctx, "infra.pong", map[string]any{}); err != nil {
+		t.Fatalf("Execute(infra.pong): %v", err)
+	}
+	recorder.requireGapAtLeast(t, 25*time.Millisecond)
+}
+
+func TestExecutor_MCPStdioRuntimeCallUsesRateLimit(t *testing.T) {
+	t.Setenv("SWARM_TEST_MCP_STDIO_HELPER", "1")
+	source := semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
+		Policy: runtimecontracts.PolicyDocument{Values: map[string]runtimecontracts.PolicyValue{
+			"mcp_servers": {Value: map[string]any{
+				"infra": map[string]any{
+					"transport":           "stdio",
+					"command":             os.Args[0],
+					"args":                []string{"-test.run=TestExternalDispatchMCPStdioHelperProcess", "--"},
+					"prefix":              "infra",
+					"rate_limit":          "1/s",
+					"rate_limit_max_wait": "0s",
+				},
+			}},
+		}},
+	})
+
+	exec := NewExecutorWithOptions(nil, nil, ExecutorOptions{WorkflowSource: source})
+	ctx := models.WithActor(context.Background(), models.AgentConfig{ID: "agent-1", Tools: []string{"infra.ping"}})
+	if _, err := exec.Execute(ctx, "infra.ping", map[string]any{}); err != nil {
+		t.Fatalf("initial Execute(infra.ping): %v", err)
+	}
+	_, err := exec.Execute(ctx, "infra.ping", map[string]any{})
+	runtimeErr, ok := AsRuntimeError(err)
+	if !ok || runtimeErr == nil || runtimeErr.Code != externalDispatchRateLimitedCode {
+		t.Fatalf("second Execute err = %v, want runtime rate_limited", err)
+	}
+}
+
+func TestExternalDispatchMCPStdioHelperProcess(t *testing.T) {
+	if os.Getenv("SWARM_TEST_MCP_STDIO_HELPER") != "1" {
+		return
+	}
+	scanner := bufio.NewScanner(os.Stdin)
+	encoder := json.NewEncoder(os.Stdout)
+	for scanner.Scan() {
+		var req map[string]any
+		if err := json.Unmarshal(scanner.Bytes(), &req); err != nil {
+			continue
+		}
+		id := req["id"]
+		method, _ := req["method"].(string)
+		if id == nil {
+			continue
+		}
+		switch method {
+		case "initialize":
+			_ = encoder.Encode(map[string]any{
+				"jsonrpc": "2.0",
+				"id":      id,
+				"result": map[string]any{
+					"protocolVersion": "2025-03-26",
+					"capabilities":    map[string]any{"tools": map[string]any{}},
+					"serverInfo":      map[string]any{"name": "infra", "version": "1.0.0"},
+				},
+			})
+		case "tools/list":
+			_ = encoder.Encode(map[string]any{
+				"jsonrpc": "2.0",
+				"id":      id,
+				"result": map[string]any{
+					"tools": []map[string]any{{
+						"name":        "ping",
+						"description": "ping",
+						"inputSchema": map[string]any{"type": "object", "additionalProperties": false},
+					}},
+				},
+			})
+		case "tools/call":
+			_ = encoder.Encode(map[string]any{
+				"jsonrpc": "2.0",
+				"id":      id,
+				"result":  map[string]any{"structuredContent": map[string]any{"ok": true}},
+			})
+		default:
+			_ = encoder.Encode(map[string]any{
+				"jsonrpc": "2.0",
+				"id":      id,
+				"error":   map[string]any{"code": -32601, "message": "method not found"},
+			})
+		}
+	}
+	os.Exit(0)
+}
+
+func TestGatewayToolPathProjectsHTTPRateLimitTimeout(t *testing.T) {
+	var recorder dispatchTimeRecorder
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		recorder.record()
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"ok": true})
+	}))
+	defer server.Close()
+
+	exec := NewExecutorWithOptions(nil, nil, ExecutorOptions{
+		WorkflowSource: rateLimitedHTTPToolSource(server.URL, "1/s", "0s", 0),
+	})
+	actor := models.AgentConfig{ID: "agent-1", Tools: []string{"check_domain"}}
+	ctx := models.WithActor(context.Background(), actor)
+	if _, err := exec.Execute(ctx, "check_domain", map[string]any{}); err != nil {
+		t.Fatalf("initial Execute: %v", err)
+	}
+
+	gateway := runtimemcp.NewGateway(exec, "gateway-token", runtimemcp.GatewayHooks{
+		WithActor:          models.WithActor,
+		ResolveTurnContext: fixedTurnContextResolver(actor),
+	})
+	body, _ := json.Marshal(runtimemcp.ToolGatewayRequest{Input: map[string]any{}})
+	req := httptest.NewRequest(http.MethodPost, "/tools/check_domain", bytes.NewReader(body))
+	authorizeRateLimitGatewayRequest(req, "ctx-rate-limit")
+	rec := httptest.NewRecorder()
+	gateway.Handler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("gateway status = %d body=%s, want 400", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), externalDispatchRateLimitedCode) {
+		t.Fatalf("gateway body = %s, want rate_limited", rec.Body.String())
+	}
+	if got := len(recorder.timesSnapshot()); got != 1 {
+		t.Fatalf("outbound requests = %d, want second call blocked before dispatch", got)
+	}
+}
+
+func TestGatewayMCPToolsCallProjectsRateLimitedRuntimeError(t *testing.T) {
+	var recorder dispatchTimeRecorder
+	server := newRateLimitedMCPTestServer(t, &recorder, []string{"ping"})
+	defer server.Close()
+
+	exec := NewExecutorWithOptions(nil, nil, ExecutorOptions{
+		WorkflowSource: rateLimitedMCPSource(server.URL, "1/s", "0s"),
+	})
+	actor := models.AgentConfig{ID: "agent-1", Tools: []string{"infra.ping"}}
+	ctx := models.WithActor(context.Background(), actor)
+	if _, err := exec.Execute(ctx, "infra.ping", map[string]any{}); err != nil {
+		t.Fatalf("initial Execute: %v", err)
+	}
+
+	gateway := runtimemcp.NewGateway(exec, "gateway-token", runtimemcp.GatewayHooks{
+		WithActor:          models.WithActor,
+		ResolveTurnContext: fixedTurnContextResolver(actor),
+	})
+	body, _ := json.Marshal(map[string]any{
+		"id":     "req-1",
+		"method": "tools/call",
+		"params": map[string]any{
+			"name":      "infra.ping",
+			"arguments": map[string]any{},
+		},
+	})
+	req := httptest.NewRequest(http.MethodPost, "/mcp", bytes.NewReader(body))
+	authorizeRateLimitGatewayRequest(req, "ctx-rate-limit")
+	rec := httptest.NewRecorder()
+	gateway.Handler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("gateway status = %d body=%s, want 200", rec.Code, rec.Body.String())
+	}
+	var resp runtimemcp.RPCResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	result, ok := resp.Result.(map[string]any)
+	if !ok {
+		t.Fatalf("result = %#v, want map", resp.Result)
+	}
+	runtimeErr, err := runtimemcp.DecodeRuntimeErrorPayload(result["runtimeError"])
+	if err != nil {
+		t.Fatalf("DecodeRuntimeErrorPayload: %v", err)
+	}
+	if runtimeErr.Code != externalDispatchRateLimitedCode {
+		t.Fatalf("runtimeError.code = %q, want %q", runtimeErr.Code, externalDispatchRateLimitedCode)
+	}
+	if !runtimeErr.Retryable {
+		t.Fatalf("runtimeError.retryable = false, want true")
+	}
+	if got := len(recorder.timesSnapshot()); got != 1 {
+		t.Fatalf("outbound mcp tools/call count = %d, want second call blocked before dispatch", got)
+	}
+}
+
+func TestExecutor_NativeWebSearchHardcodedProviderUsesRateLimit(t *testing.T) {
+	var recorder dispatchTimeRecorder
+	exec := NewExecutorWithOptions(nil, nil, ExecutorOptions{
+		WorkflowSource: rateLimitedNativeWebSearchSource("brave", "1/40ms", "500ms", nil),
+	})
+	exec.httpClient.Transport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		recorder.record()
+		if !strings.Contains(req.URL.Host, "brave.com") {
+			t.Fatalf("host = %s, want brave provider", req.URL.Host)
+		}
+		return jsonHTTPResponse(http.StatusOK, `{"web":{"results":[{"title":"T","url":"https://example.test","description":"S"}]}}`), nil
+	})
+	ctx := models.WithActor(context.Background(), models.AgentConfig{
+		ID:          "agent-1",
+		NativeTools: models.NativeToolConfig{WebSearch: true},
+	})
+	for i := 0; i < 2; i++ {
+		if _, err := exec.Execute(ctx, "web_search", map[string]any{"query": "swarm"}); err != nil {
+			t.Fatalf("Execute web_search #%d: %v", i+1, err)
+		}
+	}
+	recorder.requireGapAtLeast(t, 25*time.Millisecond)
+}
+
+func TestExecutor_NativeWebSearchCustomProviderUsesRateLimit(t *testing.T) {
+	var recorder dispatchTimeRecorder
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		recorder.record()
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"items": []map[string]any{{"title": "T", "link": "https://example.test", "summary": "S"}},
+		})
+	}))
+	defer server.Close()
+
+	customHTTP := &runtimecontracts.HTTPToolSpec{
+		Method: "GET",
+		URL:    server.URL + "?q={{input.query}}&count={{input.max_results}}",
+	}
+	exec := NewExecutorWithOptions(nil, nil, ExecutorOptions{
+		WorkflowSource: rateLimitedNativeWebSearchSource("custom", "1/40ms", "500ms", customHTTP),
+	})
+	ctx := models.WithActor(context.Background(), models.AgentConfig{
+		ID:          "agent-1",
+		NativeTools: models.NativeToolConfig{WebSearch: true},
+	})
+	for i := 0; i < 2; i++ {
+		if _, err := exec.Execute(ctx, "web_search", map[string]any{"query": "swarm"}); err != nil {
+			t.Fatalf("Execute custom web_search #%d: %v", i+1, err)
+		}
+	}
+	recorder.requireGapAtLeast(t, 25*time.Millisecond)
+}
+
+type dispatchTimeRecorder struct {
+	mu    sync.Mutex
+	times []time.Time
+}
+
+func (r *dispatchTimeRecorder) record() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.times = append(r.times, time.Now())
+}
+
+func (r *dispatchTimeRecorder) timesSnapshot() []time.Time {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([]time.Time(nil), r.times...)
+}
+
+func (r *dispatchTimeRecorder) requireGapAtLeast(t *testing.T, min time.Duration) {
+	t.Helper()
+	times := r.timesSnapshot()
+	if len(times) < 2 {
+		t.Fatalf("dispatch timestamps = %d, want at least 2", len(times))
+	}
+	gap := times[1].Sub(times[0])
+	if gap < min {
+		t.Fatalf("dispatch gap = %s, want at least %s", gap, min)
+	}
+}
+
+func rateLimitedHTTPToolSource(serverURL, rateLimit, maxWait string, maxRetries int) semanticview.Source {
+	return semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
+		Tools: map[string]runtimecontracts.ToolSchemaEntry{
+			"check_domain": {
+				Description:      "Check domain availability",
+				HandlerType:      "http",
+				RateLimit:        rateLimit,
+				RateLimitMaxWait: maxWait,
+				InputSchema: runtimecontracts.ToolInputSchema{
+					Type:                 "object",
+					AdditionalProperties: runtimecontracts.ToolAdditionalProperties{Allowed: boolPtr(false)},
+				},
+				HTTP: &runtimecontracts.HTTPToolSpec{
+					Method: "GET",
+					URL:    serverURL,
+					Retry:  runtimecontracts.HTTPToolRetrySpec{MaxRetries: maxRetries},
+				},
+			},
+		},
+	})
+}
+
+func rateLimitedMCPSource(serverURL, rateLimit, maxWait string) semanticview.Source {
+	return semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
+		Policy: runtimecontracts.PolicyDocument{Values: map[string]runtimecontracts.PolicyValue{
+			"mcp_servers": {Value: map[string]any{
+				"infra": map[string]any{
+					"transport":           "http",
+					"url":                 serverURL,
+					"prefix":              "infra",
+					"rate_limit":          rateLimit,
+					"rate_limit_max_wait": maxWait,
+				},
+			}},
+		}},
+	})
+}
+
+func rateLimitedNativeWebSearchSource(provider, rateLimit, maxWait string, customHTTP *runtimecontracts.HTTPToolSpec) semanticview.Source {
+	root := map[string]any{
+		"provider":            provider,
+		"max_results_default": 2,
+		"rate_limit":          rateLimit,
+		"rate_limit_max_wait": maxWait,
+		"response_path":       "items",
+		"field_mapping":       map[string]any{"title": "title", "url": "link", "snippet": "summary"},
+	}
+	if customHTTP != nil {
+		rawHTTP, _ := json.Marshal(customHTTP)
+		var httpMap map[string]any
+		_ = json.Unmarshal(rawHTTP, &httpMap)
+		root["http"] = httpMap
+	}
+	return semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
+		Policy: runtimecontracts.PolicyDocument{Values: map[string]runtimecontracts.PolicyValue{
+			"web_search_provider": {Value: root},
+		}},
+	})
+}
+
+func newRateLimitedMCPTestServer(t *testing.T, recorder *dispatchTimeRecorder, toolNames []string) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatalf("Decode request: %v", err)
+		}
+		method, _ := req["method"].(string)
+		switch method {
+		case "initialize":
+			writeMCPResult(t, w, req["id"], map[string]any{
+				"protocolVersion": "2025-03-26",
+				"capabilities":    map[string]any{"tools": map[string]any{}},
+				"serverInfo":      map[string]any{"name": "infra", "version": "1.0.0"},
+			})
+		case "notifications/initialized":
+			writeMCPResult(t, w, nil, map[string]any{})
+		case "tools/list":
+			tools := make([]map[string]any, 0, len(toolNames))
+			for _, name := range toolNames {
+				tools = append(tools, map[string]any{
+					"name":        name,
+					"description": name,
+					"inputSchema": map[string]any{"type": "object", "additionalProperties": false},
+				})
+			}
+			writeMCPResult(t, w, req["id"], map[string]any{"tools": tools})
+		case "tools/call":
+			recorder.record()
+			writeMCPResult(t, w, req["id"], map[string]any{
+				"structuredContent": map[string]any{"ok": true},
+			})
+		default:
+			t.Fatalf("unexpected mcp method %q", method)
+		}
+	}))
+}
+
+func fixedTurnContextResolver(actor models.AgentConfig) func(string) (runtimemcp.TurnContext, bool) {
+	return func(token string) (runtimemcp.TurnContext, bool) {
+		if strings.TrimSpace(token) != "ctx-rate-limit" {
+			return runtimemcp.TurnContext{}, false
+		}
+		return runtimemcp.TurnContext{
+			Actor:     actor,
+			CreatedAt: time.Now().UTC(),
+			ExpiresAt: time.Now().UTC().Add(time.Hour),
+		}, true
+	}
+}
+
+func authorizeRateLimitGatewayRequest(req *http.Request, contextToken string) {
+	req.Header.Set("Authorization", "Bearer gateway-token")
+	req.Header.Set("X-SWARM-Context-Token", contextToken)
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+func jsonHTTPResponse(status int, body string) *http.Response {
+	return &http.Response{
+		StatusCode: status,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       io.NopCloser(strings.NewReader(body)),
+	}
+}
+
+func externalDispatchJoinedErrors(errs []error) string {
+	parts := make([]string, 0, len(errs))
+	for _, err := range errs {
+		if err != nil {
+			parts = append(parts, err.Error())
+		}
+	}
+	return strings.Join(parts, "\n")
+}
+
+func int64FromAny(value any) int64 {
+	switch typed := value.(type) {
+	case int64:
+		return typed
+	case int:
+		return int64(typed)
+	case float64:
+		return int64(typed)
+	default:
+		return 0
+	}
+}
+
+func boolPtr(v bool) *bool {
+	return &v
+}

--- a/internal/runtime/tools/registry.go
+++ b/internal/runtime/tools/registry.go
@@ -1,6 +1,7 @@
 package tools
 
 import (
+	"fmt"
 	"sort"
 	"strings"
 
@@ -32,6 +33,7 @@ type RegisteredTool struct {
 	HTTP               *runtimecontracts.HTTPToolSpec
 	ResponseMapping    map[string]any
 	Credentials        []string
+	RateLimit          externalDispatchRateLimitConfig
 	MCPServerName      string
 	MCPRemoteName      string
 }
@@ -207,6 +209,13 @@ func registeredToolFromContract(name string, entry runtimecontracts.ToolSchemaEn
 	if handlerType == "" {
 		return RegisteredTool{}, false, nil
 	}
+	rateLimit, enabled, err := parseExternalDispatchRateLimit(entry.RateLimit, entry.RateLimitMaxWait)
+	if err != nil {
+		return RegisteredTool{}, false, err
+	}
+	if enabled && handlerType != implementationHTTP {
+		return RegisteredTool{}, false, fmt.Errorf("tool %s rate_limit is only supported for handler_type http", strings.TrimSpace(name))
+	}
 	inputSchema, err := schemaToMap(entry.InputSchema)
 	if err != nil {
 		return RegisteredTool{}, false, err
@@ -227,6 +236,7 @@ func registeredToolFromContract(name string, entry runtimecontracts.ToolSchemaEn
 		HTTP:               entry.HTTP,
 		ResponseMapping:    deepCloneMap(entry.ResponseMapping),
 		Credentials:        append([]string{}, entry.Credentials...),
+		RateLimit:          rateLimit,
 	}, true, nil
 }
 

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -3817,7 +3817,10 @@ engine:
               external tool-provider dispatch admission model and apply only to platform-owned HTTP
               provider requests for hardcoded Brave/Serper/Tavily providers and custom provider.http
               requests. Provider-native CLI web_search and LLM-provider API calls do not consume this
-              bucket.
+              bucket. Bucket identity is keyed by workflow source, the effective policy owner/provenance
+              that supplied the `policy.web_search_provider` declaration, and provider. Inherited root or
+              ancestor provider declarations therefore share one provider bucket across child flows; caller
+              flow becomes a bucket dimension only when that flow owns or overrides the provider declaration.
         file_io:
           description: Read and write files within workspace mounts. On the shipped CLI runtime, file_io is provider-native
             and maps to callable read_file/write_file operations on the same turn. /workspace is read-write, /data is read-only,

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -3811,6 +3811,13 @@ engine:
               unlock, or downgrade native_tools.web_search. If the configured CLI runtime cannot expose provider-native web_search,
               startup/runtime validation must fail closed. Non-CLI runtimes may still use fallback-aware validation outside
               this CLI-specific rule.
+            platform_provider_rate_limit: >
+              Non-CLI platform-executed web_search_provider dispatch may declare `rate_limit` and
+              `rate_limit_max_wait` alongside the provider configuration. These fields are owned by the
+              external tool-provider dispatch admission model and apply only to platform-owned HTTP
+              provider requests for hardcoded Brave/Serper/Tavily providers and custom provider.http
+              requests. Provider-native CLI web_search and LLM-provider API calls do not consume this
+              bucket.
         file_io:
           description: Read and write files within workspace mounts. On the shipped CLI runtime, file_io is provider-native
             and maps to callable read_file/write_file operations on the same turn. /workspace is read-write, /data is read-only,
@@ -3893,6 +3900,8 @@ engine:
         - If any enabled native capability is unsupported by a CLI-native-strict runtime's provider-native capability set, startup/runtime
           validation fails closed. policy.web_search_provider is not part of CLI native_tools validation or authorization. Non-CLI
           runtimes may still use fallback-aware validation outside this CLI-specific rule.
+        - policy.web_search_provider `rate_limit` and `rate_limit_max_wait`, when present for a platform-executed provider,
+          must satisfy the external tool-provider dispatch grammar. They do not make CLI native_tools.web_search valid.
   timer_model:
     description: Timers are durable delayed events. The platform schedules them and fires them as regular events entering
       the event loop. Timers are declared in nodes.yaml.
@@ -4125,9 +4134,11 @@ engine:
       when: boot-only
     - id: invalid_field_detection
       severity: error
-      scope: per-node
-      trigger: A node declaration uses a top-level field not in the defined node_fields set (id, execution_type, description,
-        subscribes_to, event_handlers, state_schema, state_table, timers, gate_state, permissions, produces).
+      scope: contract
+      trigger: A declaration uses an unsupported or malformed field in a fail-closed contract surface. This includes node
+        top-level fields outside the defined node_fields set (id, execution_type, description, subscribes_to, event_handlers,
+        state_schema, state_table, timers, gate_state, permissions, produces) and malformed external tool-provider dispatch
+        rate-limit declarations on HTTP tools, MCP servers, or policy.web_search_provider.
       when: boot-only
     - id: policy_conflict_detection
       severity: warning
@@ -4669,6 +4680,10 @@ tool_model:
             args: list — command arguments (for stdio transport)
             prefix: string — namespace prefix for this server's tools. Required. Must be unique across all registered servers.
             credentials_key: string — optional reference to credential store entry for server authentication
+            rate_limit: string — optional external dispatch rate limit, format N/period, shared by all runtime tools/call
+              dispatches to this MCP server.
+            rate_limit_max_wait: string — required when rate_limit is present; maximum per-call admission wait before
+              returning typed rate_limited.
       example: "mcp_servers:\n  postgres:\n    description: PostgreSQL database access\n    transport: http\n    url: \"{{postgres_mcp_url}}\"\
         \n    prefix: pg\n    credentials_key: postgres_mcp\n  sendgrid:\n    description: Email delivery via SendGrid\n   \
         \ transport: stdio\n    command: npx\n    args: [\"@sendgrid/mcp-server\"]\n    prefix: email"
@@ -4688,6 +4703,26 @@ tool_model:
     lifecycle:
       http: Connection maintained for platform lifetime. Reconnect on failure with exponential backoff (1s, 2s, 4s, max 30s).
       stdio: Process spawned at boot, killed on platform shutdown. If process exits unexpectedly, respawn with backoff.
+    external_provider_dispatch_rate_limit:
+      description: >
+        `rate_limit` on an MCP server declares process-local admission for runtime `tools/call` dispatches to that server.
+        The bucket is shared by all discovered tools from the server, across direct Executor.Execute, /tools/{name}, and
+        /mcp tools/call entry points. It applies to both HTTP and stdio MCP transports after discovery. MCP boot discovery
+        (`tools/list`, initialize, startup probes) is not part of this admission bucket.
+      grammar:
+        rate_limit: >
+          `N/period`, where N is a positive integer and period is an integer duration with unit ms, s, m, h, or d.
+          The short form `N/s` means `N/1s`. Whitespace is invalid.
+        rate_limit_max_wait: >
+          Integer duration with unit ms, s, m, h, or d. `0s` is valid and means fail immediately rather than queue.
+          This field is required when rate_limit is present; no hidden default wait is applied.
+      behavior:
+      - Absence of both fields means no admission limit.
+      - Providing only one field is a boot/runtime validation error.
+      - Excess calls wait FIFO within the process-local bucket until they can be admitted or until rate_limit_max_wait is exceeded.
+      - On max-wait timeout the tool call fails with typed runtime error code `rate_limited`, component `tool-executor`,
+        operation `external_dispatch_admission`, retryable true, before any outbound provider dispatch occurs.
+      - Durable cross-process/fleet-wide admission, global priority, and deadline policy remain outside this owner.
   http_tool_definition:
     description: Tools defined as HTTP request templates in tools.yaml. The platform ships a generic HTTP executor that reads
       the template, resolves variables, makes the HTTP call, and maps the response. This is the primary mechanism for products
@@ -4719,6 +4754,9 @@ tool_model:
           returned as the tool result.
         credentials: list of strings — credential store key names this tool needs. The platform resolves them from the credential
           store at call time and makes them available as {{credentials.key}} in templates.
+        rate_limit: string — optional external dispatch rate limit, format N/period.
+        rate_limit_max_wait: string — required when rate_limit is present; maximum per-call admission wait before
+          returning typed rate_limited.
     template_resolution:
       description: Template variables in url, headers, body, and response_mapping are resolved at tool call time. URL
         template resolution is context-aware and performs URL-component percent-encoding for embedded substitutions;
@@ -4730,6 +4768,27 @@ tool_model:
           {{response.headers.header_name}}.
       missing_variable: If a required template variable cannot be resolved (missing input field, missing credential), the tool
         call fails with an error returned to the agent. The platform does not make the HTTP request.
+    external_provider_dispatch_rate_limit:
+      description: >
+        `rate_limit` on an HTTP tool declares process-local admission for outbound HTTP provider dispatch by that tool.
+        The bucket is per workflow source and tool name, and it is consumed by direct Executor.Execute, /tools/{name},
+        and /mcp tools/call entry points. Every retry attempt consumes the same bucket before making another outbound
+        HTTP request; retry/backoff cannot bypass admission.
+      grammar:
+        rate_limit: >
+          `N/period`, where N is a positive integer and period is an integer duration with unit ms, s, m, h, or d.
+          The short form `N/s` means `N/1s`. Whitespace is invalid.
+        rate_limit_max_wait: >
+          Integer duration with unit ms, s, m, h, or d. `0s` is valid and means fail immediately rather than queue.
+          This field is required when rate_limit is present; no hidden default wait is applied.
+      behavior:
+      - Absence of both fields means no admission limit.
+      - Providing only one field, malformed grammar, zero/non-positive count, or use on non-HTTP tool handler declarations
+        is a fail-closed validation error.
+      - Excess calls wait FIFO within the process-local bucket until they can be admitted or until rate_limit_max_wait is exceeded.
+      - On max-wait timeout the tool call fails with typed runtime error code `rate_limited`, component `tool-executor`,
+        operation `external_dispatch_admission`, retryable true, before any outbound provider dispatch occurs.
+      - Successful or waited admissions and timeouts are reflected in platform.runtime_log tool-execution details.
     example: "check_domain:\n  description: Check if a domain name is available for registration\n  handler_type: http\n  input_schema:\n\
       \    type: object\n    required: [domain]\n    properties:\n      domain:\n        type: string\n        description:\
       \ Domain to check (e.g., example.com)\n  http:\n    method: GET\n    url: \"https://api.domainr.com/v2/status?domain={{input.domain}}\"\
@@ -4830,6 +4889,8 @@ tool_model:
       http: object — HTTP request template (see http_tool_definition.schema.http_block)
       response_mapping: object — maps response fields to output fields
       credentials: list of strings — credential store keys
+      rate_limit: string — optional external dispatch admission rate, supported only when handler_type resolves to http.
+      rate_limit_max_wait: string — required when rate_limit is present.
     not_accepted:
       endpoint: NOT a valid field. Use http.url instead.
       type: NOT a valid field. Use handler_type instead.
@@ -6242,6 +6303,11 @@ platform_tables:
       - component and action live in details, not as top-level runtime_log fields
       - error text lives in details.error; message may summarize the failure but is not the raw error string
       - readers and debug UIs should filter and render structured runtime diagnostics from details
+      - >
+        Tool-execution entries that consume external tool-provider dispatch admission include machine-readable
+        details fields `rate_limit_scope`, `rate_limit_bucket_hash`, `rate_limit_limit`, `rate_limit_period_ms`,
+        `rate_limit_max_wait_ms`, `rate_limit_wait_ms`, `rate_limit_outcome`, and `rate_limit_attempts`. If admission
+        times out, details also include `error_code: rate_limited` and `retryable: true`.
       note: 'Queryable via: SELECT * FROM events WHERE event_name = "platform.runtime_log" AND payload->>log_level = "error"'
     pipeline_transition_encoding:
       table: event_receipts


### PR DESCRIPTION
## Summary

- Adds declarative process-local external dispatch admission for supported platform-owned external tool providers.
- Wires the shared owner into HTTP tools, HTTP retry attempts, MCP runtime `tools/call` over HTTP/stdio, `/tools/{name}`, `/mcp tools/call`, and native `web_search` hardcoded/custom provider requests.
- Updates root `platform-spec.yaml` with `rate_limit`, `rate_limit_max_wait`, bucket keying, typed `rate_limited` behavior, retryability, and runtime-log proof fields.

Closes #1456

## Governing refs/context

Exact governing spec sections updated in this PR:

- `platform-spec.yaml` `tool_model.mcp_client.external_provider_dispatch_rate_limit`
- `platform-spec.yaml` `tool_model.http_tool_definition.external_provider_dispatch_rate_limit`
- `platform-spec.yaml` `engine.native_tools.web_search.configuration.platform_provider_rate_limit`
- `platform-spec.yaml` `engine.boot_validation.invalid_field_detection`
- `platform-spec.yaml` `platform_tables.diagnostics_encoding.runtime_log_encoding`

Binding context re-read before implementation: approved #1456 Pre-Implementation Coverage Audit and gate outcome, issue #1456 body/thread, #1449/#1457/#107 split context, `/Users/youmew/dev/swarm-docs/docs/IMPLEMENTER_GUIDELINES.md`, and `/Users/youmew/dev/swarm-docs/docs/SEMANTIC_DRIFT.md`.

## Semantic migration

- New canonical owner: root `platform-spec.yaml` plus shared `internal/runtime/tools` external dispatch admission owner.
- Old non-authoritative paths now invalid: direct HTTP tool `httpClient.Do`, HTTP retry attempts, MCP runtime `CallWithCredentialKeyResolver`, and native `web_search` provider HTTP calls without admission when a rate limit is configured.
- Production paths checked for surviving old behavior: HTTP first attempts/retries, MCP HTTP/stdio runtime calls, direct `Executor.Execute`, `/tools/{name}`, `/mcp tools/call`, hardcoded Brave/Serper/Tavily web search, and custom HTTP `web_search_provider`.
- Migration status: complete for the approved #1456 first-slice class. Explicitly split siblings remain LLM provider throttling (#1457), provider-native CLI `web_search`, public API/CLI clients, mailbox notifications, MCP boot discovery, and durable/fleet-wide admission (#107).

## Verification

- `go test ./internal/runtime/tools ./internal/runtime/mcp ./internal/runtime/contracts ./internal/runtime/bootverify -count=1`
- `go test ./...`
- `git diff --check`