### PR TITLE
[agent-a][issue #1518] Validate platform event schema authority refs

### DIFF
--- a/internal/apispec/platform_spec_source_refs_test.go
+++ b/internal/apispec/platform_spec_source_refs_test.go
@@ -78,6 +78,101 @@ func TestPlatformSpecHandlerSpecificationHierarchy(t *testing.T) {
 	}
 }
 
+func TestPlatformEventsCatalogSchemaAuthorityRefsResolve(t *testing.T) {
+	root := loadPlatformSpecYAMLNode(t)
+	catalog := mustMappingValue(t, mustMappingValue(t, root, "platform_events"), "catalog")
+
+	const prefix = "platform-spec.yaml#"
+	expectedSimpleRefs := map[string]string{
+		"platform.dead_letter": "platform-spec.yaml#engine.error_model.dead_letter_schema",
+		"platform.runtime_log": "platform-spec.yaml#platform_tables.diagnostics_encoding",
+		"mailbox.item_decided": "platform-spec.yaml#api_specification.conventions.mailbox.approval_event_payload_contract",
+	}
+
+	var checked []string
+	for i := 0; i+1 < len(catalog.Content); i += 2 {
+		eventName := catalog.Content[i].Value
+		entry := catalog.Content[i+1]
+		ref := scalarValue(mappingValue(entry, "schema_authority"))
+		if ref == "" {
+			t.Fatalf("%s missing schema_authority", eventName)
+		}
+		if !strings.HasPrefix(ref, prefix) {
+			t.Fatalf("%s schema_authority = %q, want %s-prefixed ref", eventName, ref, prefix)
+		}
+		if !yamlPathExists(root, strings.TrimPrefix(ref, prefix)) {
+			t.Fatalf("%s schema_authority does not resolve to parsed platform-spec.yaml owner: %s", eventName, ref)
+		}
+		if expected, ok := expectedSimpleRefs[eventName]; ok && ref != expected {
+			t.Fatalf("%s schema_authority = %q, want existing simple owner guard %q", eventName, ref, expected)
+		}
+		checked = append(checked, eventName)
+	}
+	if len(checked) != len(mappingKeys(catalog)) {
+		t.Fatalf("checked %d schema_authority refs, catalog has %d entries", len(checked), len(mappingKeys(catalog)))
+	}
+	if len(checked) < 18 {
+		t.Fatalf("checked %d schema_authority refs, want at least the 18 refs present when #1518 was gated", len(checked))
+	}
+}
+
+func TestPlatformSpecRefPathLiteralSegments(t *testing.T) {
+	root := loadPlatformSpecYAMLNode(t)
+
+	for _, tc := range []struct {
+		name string
+		path string
+		want bool
+	}{
+		{
+			name: "simple dot path",
+			path: "engine.error_model.dead_letter_schema",
+			want: true,
+		},
+		{
+			name: "bracketed dotted event key",
+			path: `platform_events.catalog["platform.boot"].payload`,
+			want: true,
+		},
+		{
+			name: "old unbracketed dotted event key remains invalid",
+			path: "platform_events.catalog.platform.boot.payload",
+			want: false,
+		},
+		{
+			name: "missing bracket quotes fail closed",
+			path: "platform_events.catalog[platform.boot].payload",
+			want: false,
+		},
+		{
+			name: "unterminated bracket fails closed",
+			path: `platform_events.catalog["platform.boot".payload`,
+			want: false,
+		},
+		{
+			name: "empty segment fails closed",
+			path: "platform_events.catalog..payload",
+			want: false,
+		},
+		{
+			name: "empty literal segment fails closed",
+			path: `platform_events.catalog[""].payload`,
+			want: false,
+		},
+		{
+			name: "missing dot after bracketed literal fails closed",
+			path: `platform_events.catalog["platform.boot"]payload`,
+			want: false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := yamlPathExists(root, tc.path); got != tc.want {
+				t.Fatalf("yamlPathExists(%q) = %v, want %v", tc.path, got, tc.want)
+			}
+		})
+	}
+}
+
 func collectMissingSpecBasisRefs(root, node *yaml.Node, path []string) []string {
 	if node == nil {
 		return nil
@@ -127,14 +222,98 @@ func unresolvedSpecBasisRefs(root, node *yaml.Node, path []string) []string {
 }
 
 func yamlPathExists(root *yaml.Node, path string) bool {
+	segments, ok := parseYAMLPathSegments(path)
+	if !ok {
+		return false
+	}
 	current := root
-	for _, key := range strings.Split(path, ".") {
+	for _, key := range segments {
 		current = mappingValue(current, key)
 		if current == nil {
 			return false
 		}
 	}
 	return true
+}
+
+func parseYAMLPathSegments(path string) ([]string, bool) {
+	if path == "" {
+		return nil, false
+	}
+	var segments []string
+	expectSegment := true
+	for i := 0; i < len(path); {
+		switch path[i] {
+		case '.':
+			if expectSegment {
+				return nil, false
+			}
+			expectSegment = true
+			i++
+			if i == len(path) {
+				return nil, false
+			}
+		case '[':
+			segment, next, ok := parseBracketedLiteralSegment(path, i)
+			if !ok {
+				return nil, false
+			}
+			segments = append(segments, segment)
+			i = next
+			expectSegment = false
+			if i < len(path) && path[i] != '.' && path[i] != '[' {
+				return nil, false
+			}
+		default:
+			start := i
+			for i < len(path) && path[i] != '.' && path[i] != '[' && path[i] != ']' {
+				i++
+			}
+			if start == i {
+				return nil, false
+			}
+			segments = append(segments, path[start:i])
+			expectSegment = false
+		}
+	}
+	if expectSegment {
+		return nil, false
+	}
+	return segments, true
+}
+
+func parseBracketedLiteralSegment(path string, start int) (string, int, bool) {
+	if start+3 >= len(path) || path[start] != '[' || path[start+1] != '"' {
+		return "", 0, false
+	}
+	var b strings.Builder
+	for i := start + 2; i < len(path); {
+		switch path[i] {
+		case '\\':
+			if i+1 >= len(path) {
+				return "", 0, false
+			}
+			next := path[i+1]
+			if next != '\\' && next != '"' {
+				return "", 0, false
+			}
+			b.WriteByte(next)
+			i += 2
+		case '"':
+			if i+1 >= len(path) || path[i+1] != ']' || b.Len() == 0 {
+				return "", 0, false
+			}
+			return b.String(), i + 2, true
+		case '[':
+			return "", 0, false
+		case ']':
+			return "", 0, false
+		default:
+			b.WriteByte(path[i])
+			i++
+		}
+	}
+	return "", 0, false
 }
 
 func mappingKeys(node *yaml.Node) []string {

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -7970,6 +7970,20 @@ platform_events:
     - Wildcard subscriptions that match platform.* events (e.g., platform.* subscription pattern)
     - Flow schema.yaml pins.inputs.events listing platform.* events (flows MAY declare them as inputs to receive routing)
     - Product subscriptions, handlers, or input pins that reference non-platform.* catalog-owned events such as mailbox.item_decided
+  schema_authority_ref_syntax:
+    description: >-
+      platform_events.catalog entries use schema_authority refs to identify the parsed platform-spec.yaml owner for each
+      payload schema. A schema_authority ref with prefix platform-spec.yaml# is parsed as explicit path syntax, not as prose.
+      Dot segments select normal YAML mapping keys. Bracketed literal segments select an exact YAML mapping key and MUST be
+      used when the key itself contains dots, such as platform event names.
+    grammar:
+      simple_segment: Normal YAML mapping key segment separated by dots, for example engine.error_model.dead_letter_schema.
+      bracketed_literal_segment: '["literal.key"] selects the exact YAML mapping key literal.key without splitting on dots.'
+      fail_closed: Invalid syntax, empty segments, unterminated brackets, unquoted bracket literals, and missing owners are
+        parsed-invalid. Implementations and conformance tests MUST NOT recover by joining dot segments heuristically.
+    examples:
+      dotted_event_key: 'platform-spec.yaml#platform_events.catalog["platform.boot"].payload'
+      simple_owner: platform-spec.yaml#engine.error_model.dead_letter_schema
   catalog:
     platform.dead_letter:
       description: Failed event after retry exhaustion or chain depth overflow.
@@ -7994,7 +8008,7 @@ platform_events:
       note: Full payload schema defined in platform_tables. Not duplicated here.
     platform.agent_failed:
       description: Agent session failed after retry.
-      schema_authority: platform-spec.yaml#platform_events.catalog.platform.agent_failed.payload
+      schema_authority: 'platform-spec.yaml#platform_events.catalog["platform.agent_failed"].payload'
       producer_evidence:
         produced_by_type: platform
         locations:
@@ -8012,7 +8026,7 @@ platform_events:
       produced_by_type: platform
     platform.agent_panic:
       description: Agent session panicked with unrecoverable error.
-      schema_authority: platform-spec.yaml#platform_events.catalog.platform.agent_panic.payload
+      schema_authority: 'platform-spec.yaml#platform_events.catalog["platform.agent_panic"].payload'
       producer_evidence:
         produced_by_type: platform
         locations:
@@ -8030,7 +8044,7 @@ platform_events:
       produced_by_type: platform
     platform.event_quarantined:
       description: Poison event quarantined after repeated handler failures on different entities.
-      schema_authority: platform-spec.yaml#platform_events.catalog.platform.event_quarantined.payload
+      schema_authority: 'platform-spec.yaml#platform_events.catalog["platform.event_quarantined"].payload'
       producer_evidence:
         produced_by_type: platform
         locations:
@@ -8046,7 +8060,7 @@ platform_events:
       produced_by_type: platform
     platform.dead_letter_escalation:
       description: Dead letter volume or pattern crossed escalation threshold.
-      schema_authority: platform-spec.yaml#platform_events.catalog.platform.dead_letter_escalation.payload
+      schema_authority: 'platform-spec.yaml#platform_events.catalog["platform.dead_letter_escalation"].payload'
       producer_evidence:
         produced_by_type: platform
         locations:
@@ -8062,7 +8076,7 @@ platform_events:
       produced_by_type: platform
     platform.run_stalled:
       description: Runtime detected a running run that has crossed the stalled-run escalation threshold according to the canonical run diagnosis projection.
-      schema_authority: platform-spec.yaml#platform_events.catalog.platform.run_stalled.payload
+      schema_authority: 'platform-spec.yaml#platform_events.catalog["platform.run_stalled"].payload'
       producer_evidence:
         produced_by_type: platform
         locations:
@@ -8095,7 +8109,7 @@ platform_events:
         via the internal admin reset source. Builder/dashboard reset_state is retired and MUST NOT emit this event. NOT
         emitted on crash recovery or automatic recovery fallback — those use platform.recovery_failed if they fail, or normal
         boot if they succeed.
-      schema_authority: platform-spec.yaml#platform_events.catalog.platform.reset.payload
+      schema_authority: 'platform-spec.yaml#platform_events.catalog["platform.reset"].payload'
       producer_evidence:
         produced_by_type: platform
         locations:
@@ -8113,7 +8127,7 @@ platform_events:
         source: external (platform admin CLI)
     platform.auth_required:
       description: Agent or tool call blocked pending authorization.
-      schema_authority: platform-spec.yaml#platform_events.catalog.platform.auth_required.payload
+      schema_authority: 'platform-spec.yaml#platform_events.catalog["platform.auth_required"].payload'
       producer_evidence:
         produced_by_type: platform
         locations:
@@ -8140,7 +8154,7 @@ platform_events:
     platform.budget_threshold_crossed:
       description: LLM spend crossed a configured threshold. The platform monitors spend_ledger against policy-defined thresholds
         and emits this event when a boundary is crossed. One event with a level field — no separate events per level.
-      schema_authority: platform-spec.yaml#platform_events.catalog.platform.budget_threshold_crossed.payload
+      schema_authority: 'platform-spec.yaml#platform_events.catalog["platform.budget_threshold_crossed"].payload'
       producer_evidence:
         produced_by_type: platform
         locations:
@@ -8168,7 +8182,7 @@ platform_events:
         such as MCP/tool execution is rejected fail-closed while paused. In-flight events already dispatched complete their handler
         execution and commit. Agent sessions in progress complete their current turn; new agent invocations for queued work are
         deferred until resume.
-      schema_authority: platform-spec.yaml#platform_events.catalog.platform.paused.payload
+      schema_authority: 'platform-spec.yaml#platform_events.catalog["platform.paused"].payload'
       producer_evidence:
         produced_by_type: platform
         locations:
@@ -8184,7 +8198,7 @@ platform_events:
       description: Runtime ingress left paused state. Queued event-producing ingress is eligible for normal EventBus dispatch
         exactly once through the canonical delivery/idempotency owners. Synchronous request/response ingress may execute again
         after resume.
-      schema_authority: platform-spec.yaml#platform_events.catalog.platform.resumed.payload
+      schema_authority: 'platform-spec.yaml#platform_events.catalog["platform.resumed"].payload'
       producer_evidence:
         produced_by_type: platform
         locations:
@@ -8200,7 +8214,7 @@ platform_events:
       description: Operator-issued directive accepted by the runtime for an agent. This is the authoritative persisted root
         event for directive-started or directive-targeted work; BoardStep and all child emissions inherit this event's run_id
         and source_event_id. It is persisted before agent execution and is not defined by the legacy board.directive helper.
-      schema_authority: platform-spec.yaml#platform_events.catalog.platform.agent_directive.payload
+      schema_authority: 'platform-spec.yaml#platform_events.catalog["platform.agent_directive"].payload'
       producer_evidence:
         produced_by_type: platform
         locations:
@@ -8228,7 +8242,7 @@ platform_events:
       produced_by_type: platform
     platform.agent_started:
       description: Agent session created and ready to process events.
-      schema_authority: platform-spec.yaml#platform_events.catalog.platform.agent_started.payload
+      schema_authority: 'platform-spec.yaml#platform_events.catalog["platform.agent_started"].payload'
       producer_evidence:
         produced_by_type: platform
         locations:
@@ -8250,7 +8264,7 @@ platform_events:
     platform.boot:
       description: Platform boot completed successfully. Emitted after validation passes, runtime boot/recovery decisions are made,
         nodes/agents are started, and the boot event is published before the runtime becomes ready.
-      schema_authority: platform-spec.yaml#platform_events.catalog.platform.boot.payload
+      schema_authority: 'platform-spec.yaml#platform_events.catalog["platform.boot"].payload'
       producer_evidence:
         produced_by_type: platform
         locations:
@@ -8289,7 +8303,7 @@ platform_events:
     platform.inbound_recorded:
       description: External event received and persisted. Emitted when an event enters the system from an external source
         (API, webhook, admin CLI).
-      schema_authority: platform-spec.yaml#platform_events.catalog.platform.inbound_recorded.payload
+      schema_authority: 'platform-spec.yaml#platform_events.catalog["platform.inbound_recorded"].payload'
       producer_evidence:
         produced_by_type: platform
         locations:
@@ -8307,7 +8321,7 @@ platform_events:
       produced_by_type: platform
     platform.recovery_failed:
       description: Crash recovery failed during event replay. Unrecoverable state.
-      schema_authority: platform-spec.yaml#platform_events.catalog.platform.recovery_failed.payload
+      schema_authority: 'platform-spec.yaml#platform_events.catalog["platform.recovery_failed"].payload'
       producer_evidence:
         produced_by_type: platform
         locations:


### PR DESCRIPTION
## Summary

Closes #1518.

This PR closes the approved first-slice class `platform_events_schema_authority_dotted_key_source_ref_integrity`.

It updates authoritative `platform-spec.yaml` and `internal/apispec` proof so every current `platform_events.catalog.*.schema_authority` ref resolves to a parsed `platform-spec.yaml` owner. The 15 catalog-local payload refs that target dotted event-name keys now use explicit bracketed literal-key syntax, for example `platform_events.catalog["platform.boot"].payload`.

## Governing Refs / Context

Exact governing spec refs:

- `platform-spec.yaml#platform_events.catalog`
- `platform-spec.yaml#platform_events.schema_authority_ref_syntax`

Binding issue/gate context:

- #1518 issue body
- #1518 Pre-Implementation Coverage Audit
- #1518 Independent Gate Review, approved as first slice
- #1470 Gate B context that split this `schema_authority` sibling from `static_analyzer.*.spec_basis`

## Semantic Migration

New canonical owner:

- `platform-spec.yaml#platform_events.schema_authority_ref_syntax` defines the explicit parsed-ref grammar for platform event `schema_authority` refs.
- `platform-spec.yaml#platform_events.catalog` remains the owner for platform event catalog entries and payload schema ownership metadata.

Old producer / reader / writer path now invalid:

- Bare dot-path refs that intend literal dotted event keys, such as `platform_events.catalog.platform.boot.payload`, are invalid for catalog-local event payload owners.
- Presence-only `schema_authority` validation is no longer sufficient proof.
- Heuristic segment joining is explicitly invalid; dotted YAML keys must use bracketed literal segments.

Production paths checked for surviving old behavior:

- `rg -n "schema_authority:.*platform_events\.catalog\.platform\." platform-spec.yaml` returned no remaining old unbracketed schema-authority refs.
- Runtime event publication/routing/admission/delivery/store paths were intentionally not changed because the approved class is spec source-reference integrity only.
- The adjacent non-`schema_authority` `event_owner` seam remains outside this PR's closure claim per the approved gate.

Migration completeness:

- Complete for all 18 current `platform_events.catalog.*.schema_authority` refs.
- Not a claim of broad `platform-spec.yaml#...` ref grammar closure outside the approved `schema_authority` field family.

## Proof

- `go test ./internal/apispec -run 'TestPlatformEventsCatalogSchemaAuthorityRefsResolve|TestPlatformSpecRefPathLiteralSegments|TestPlatformSpecStaticAnalyzerSpecBasisRefsResolve|TestPlatformSpecHandlerSpecificationHierarchy|TestPlatformEventsCatalogOwnsPlatformEmittedEvents' -count=1`
- `go test ./internal/apispec -count=1`
- `rg -n "schema_authority:.*platform_events\.catalog\.platform\." platform-spec.yaml || true`
- `go test ./...`
