### PR TITLE
[agent-a][issue #1543] Verify template instance contracts

### DIFF
--- a/cmd/swarm/main_test.go
+++ b/cmd/swarm/main_test.go
@@ -4169,6 +4169,10 @@ portfolio-node:
 	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "flows", "operating", "schema.yaml"), `
 name: operating
 mode: template
+instance:
+  by: product_id
+  on_missing: create
+  on_conflict: reject
 initial_state: initializing
 terminal_states: [ready]
 states: [initializing, waiting, ready]
@@ -4328,11 +4332,20 @@ portfolio-node:
 	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "flows", "portfolio", "agents.yaml"), `{}`)
 	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "flows", "operating", "schema.yaml"), `
 name: operating
+mode: template
+instance:
+  by: product_id
+  on_missing: create
+  on_conflict: reject
 initial_state: initializing
 terminal_states: [ready]
 states: [initializing, spawning, ready]
 auto_emit_on_create:
   event: opco.product_initialization_requested
+`)
+	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "flows", "operating", "entities.yaml"), `
+product:
+  product_id: text
 `)
 	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "flows", "operating", "events.yaml"), `
 opco.product_initialization_requested:
@@ -4348,6 +4361,11 @@ lifecycle-orchestrator:
   produces: [component_scaffold.spawn_requested]
   event_handlers:
     opco.product_initialization_requested:
+      data_accumulation:
+        source_event: opco.product_initialization_requested
+        writes:
+          - source_field: product_id
+            target_field: product_id
       emit:
         event: component_scaffold.spawn_requested
         fields:

--- a/internal/apispec/platform_spec_flow_instance_authoring_test.go
+++ b/internal/apispec/platform_spec_flow_instance_authoring_test.go
@@ -99,10 +99,20 @@ func TestPlatformSpecFlowInstanceAuthoringSourceAuthority(t *testing.T) {
 	}
 
 	templateModel := mustMappingValue(t, authoring, "template_instance_model")
-	assertScalarValue(t, mustMappingValue(t, templateModel, "status"), "spec_vocabulary_only")
+	assertScalarValue(t, mustMappingValue(t, templateModel, "status"), "merge_bearing_contract_behavior")
 	assertScalarValue(t, mustMappingValue(t, templateModel, "implementation_tracker"), "#1543")
+	assertScalarValue(t, mustMappingValue(t, templateModel, "canonical_code_owner"), "internal/runtime/contracts.WorkflowContractBundle.ResolveFlowTemplateInstance")
 	assertScalarContains(t, mustMappingValue(t, templateModel, "rule"), "process/case/job state")
 	assertScalarContains(t, mustMappingValue(t, templateModel, "rule"), "independent lifecycle")
+	assertScalarContains(t, mustMappingValue(t, templateModel, "rule"), "`mode: template` flows MUST declare `instance.by`")
+	assertScalarContains(t, mustMappingValue(t, templateModel, "primary_entity_dependency"), "ResolveFlowPrimaryEntity")
+	assertScalarContains(t, mustMappingValue(t, templateModel, "primary_entity_dependency"), "`schema.yaml entity`")
+	assertScalarContains(t, mustMappingValue(t, templateModel, "key_rule"), "top-level scalar or enum field")
+	assertScalarContains(t, mustMappingValue(t, templateModel, "key_rule"), "Composite key material is ordered exactly as declared")
+	assertScalarContains(t, mustMappingValue(t, templateModel, "policy_rule"), "`on_missing` is required")
+	assertScalarContains(t, mustMappingValue(t, templateModel, "policy_rule"), "`on_conflict` is required")
+	assertScalarContains(t, mustMappingValue(t, templateModel, "non_authoritative_paths"), "Flow input-pin `address`")
+	assertScalarContains(t, mustMappingValue(t, templateModel, "non_authoritative_paths"), "`create_flow_instance.instance_id_from`")
 
 	primaryEntity := mustMappingValue(t, authoring, "primary_entity_model")
 	assertScalarValue(t, mustMappingValue(t, primaryEntity, "status"), "merge_bearing_contract_behavior")

--- a/internal/runtime/bootverify/checks.go
+++ b/internal/runtime/bootverify/checks.go
@@ -239,6 +239,7 @@ var bootCheckRegistry = []Check{
 	{ID: "expression_field_reference_validation", Severity: "warning", Run: checkExpressionFieldReferenceValidation},
 	{ID: "entity_reader_coverage", Severity: SeverityLintEvidence, Run: checkEntityReaderCoverage},
 	{ID: "primary_entity_validation", Severity: "error", Run: checkPrimaryEntityValidation},
+	{ID: "template_instance_validation", Severity: "error", Run: checkTemplateInstanceValidation},
 	{ID: "cross_surface_named_type_use", Severity: SeverityLintEvidence, Run: checkCrossSurfaceNamedTypeUse},
 	{ID: "transition_ownership_validation", Severity: "error", Run: checkTransitionOwnershipValidation},
 	{ID: "event_runtime_wiring_validation", Severity: "error", Run: checkEventRuntimeWiringValidation},

--- a/internal/runtime/bootverify/flow_data_access_test.go
+++ b/internal/runtime/bootverify/flow_data_access_test.go
@@ -66,8 +66,8 @@ func TestRun_ValidatesFlowDataAccessDeclarations(t *testing.T) {
 }
 
 func TestBootCheckRegistry_HasFlowDataAccessCheckCount(t *testing.T) {
-	if got := len(bootCheckRegistry); got != 60 {
-		t.Fatalf("bootCheckRegistry count = %d, want 60", got)
+	if got := len(bootCheckRegistry); got != 61 {
+		t.Fatalf("bootCheckRegistry count = %d, want 61", got)
 	}
 }
 

--- a/internal/runtime/bootverify/report_test.go
+++ b/internal/runtime/bootverify/report_test.go
@@ -4747,8 +4747,8 @@ func TestRun_ReportsMissingRuntimeExecutorForOwnedRuntimeEvent(t *testing.T) {
 }
 
 func TestBootCheckRegistry_HasSpecCheckCount(t *testing.T) {
-	if got := len(bootCheckRegistry); got != 60 {
-		t.Fatalf("bootCheckRegistry count = %d, want 60", got)
+	if got := len(bootCheckRegistry); got != 61 {
+		t.Fatalf("bootCheckRegistry count = %d, want 61", got)
 	}
 	if got := len(supplementalChecks); got != 3 {
 		t.Fatalf("supplementalChecks count = %d, want 3", got)

--- a/internal/runtime/bootverify/workflow_template_instance_checks.go
+++ b/internal/runtime/bootverify/workflow_template_instance_checks.go
@@ -1,0 +1,70 @@
+package bootverify
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/division-sh/swarm/internal/runtime/entityruntime"
+	"github.com/division-sh/swarm/internal/runtime/semanticview"
+)
+
+func checkTemplateInstanceValidation(c *checkerContext) []Finding {
+	if c == nil || c.source == nil {
+		return nil
+	}
+	bundle, ok := semanticview.Bundle(c.source)
+	if !ok || bundle == nil {
+		return nil
+	}
+	findings := []Finding{}
+	if bundle.RootSchema != nil && !bundle.RootSchema.Instance.Empty() {
+		findings = append(findings, Finding{
+			CheckID:  "template_instance_validation",
+			Severity: "error",
+			Message:  "flow <root> template instance invalid: root schema must not declare instance; template instance keys belong to child flow contracts",
+			Location: "<root>",
+		})
+	}
+	for flowID, schema := range c.source.FlowSchemaEntries() {
+		flowID = strings.TrimSpace(flowID)
+		if flowID == "" {
+			continue
+		}
+		isTemplate := strings.TrimSpace(schema.Mode) == "template"
+		hasInstance := !schema.Instance.Empty()
+		if !isTemplate && !hasInstance {
+			continue
+		}
+		resolved, err := bundle.ResolveFlowTemplateInstance(flowID)
+		if err != nil {
+			findings = append(findings, Finding{
+				CheckID:  "template_instance_validation",
+				Severity: "error",
+				Message:  fmt.Sprintf("flow %s template instance invalid: %v", flowID, err),
+				Location: flowID,
+			})
+			continue
+		}
+		entityContract, ok := entityruntime.ResolveForFlow(c.source, flowID)
+		if !ok {
+			findings = append(findings, Finding{
+				CheckID:  "template_instance_validation",
+				Severity: "error",
+				Message:  fmt.Sprintf("flow %s template instance invalid: primary entity %s is unavailable for type checking", flowID, resolved.PrimaryEntity.EntityType),
+				Location: flowID,
+			})
+			continue
+		}
+		for _, field := range resolved.By {
+			if _, err := entityruntime.ResolveLeafField(entityContract, field); err != nil {
+				findings = append(findings, Finding{
+					CheckID:  "template_instance_validation",
+					Severity: "error",
+					Message:  fmt.Sprintf("flow %s template instance invalid: instance.by field %q must resolve to a scalar or enum primary-entity field: %v", flowID, field, err),
+					Location: flowID,
+				})
+			}
+		}
+	}
+	return findings
+}

--- a/internal/runtime/bootverify/workflow_template_instance_checks_test.go
+++ b/internal/runtime/bootverify/workflow_template_instance_checks_test.go
@@ -1,0 +1,235 @@
+package bootverify
+
+import (
+	"context"
+	"testing"
+
+	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
+	"github.com/division-sh/swarm/internal/runtime/semanticview"
+)
+
+func TestRun_ValidatesTemplateInstanceSingleAndCompositeKeys(t *testing.T) {
+	tests := []struct {
+		name       string
+		instanceBy string
+	}{
+		{
+			name:       "single key",
+			instanceBy: "account_id",
+		},
+		{
+			name:       "composite key",
+			instanceBy: "[tenant_id, account_id]",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			bundle := loadPrimaryEntityFixtureBundle(t, `
+name: scoring
+mode: template
+instance:
+  by: `+tc.instanceBy+`
+  on_missing: create
+  on_conflict: reject
+pins:
+  inputs:
+    events: []
+  outputs:
+    events: []
+`, `
+account:
+  tenant_id: text
+  account_id: uuid
+`)
+
+			report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+
+			if reportContains(report.Errors(), "template_instance_validation", "") {
+				t.Fatalf("unexpected template_instance_validation error: %#v", report.Errors())
+			}
+		})
+	}
+}
+
+func TestRun_RejectsRootTemplateInstanceDeclaration(t *testing.T) {
+	bundle := &runtimecontracts.WorkflowContractBundle{
+		RootSchema: &runtimecontracts.FlowSchemaDocument{
+			Name: "root",
+			Instance: runtimecontracts.FlowTemplateInstanceDeclaration{
+				By:         []string{"account_id"},
+				OnMissing:  "create",
+				OnConflict: "reject",
+			},
+		},
+		FlowSchemas: map[string]runtimecontracts.FlowSchemaDocument{},
+	}
+
+	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+
+	if !reportContains(report.Errors(), "template_instance_validation", "root schema must not declare instance") {
+		t.Fatalf("expected root template_instance_validation error, got %#v", report.Errors())
+	}
+}
+
+func TestRun_RejectsInvalidTemplateInstanceDeclarations(t *testing.T) {
+	tests := []struct {
+		name         string
+		flowSchema   string
+		flowEntities string
+		want         string
+	}{
+		{
+			name: "missing instance declaration",
+			flowSchema: `
+name: scoring
+mode: template
+pins:
+  inputs:
+    events: []
+  outputs:
+    events: []
+`,
+			flowEntities: `
+account:
+  account_id: uuid
+`,
+			want: "must declare instance.by",
+		},
+		{
+			name: "duplicate composite key field",
+			flowSchema: `
+name: scoring
+mode: template
+instance:
+  by: [account_id, account_id]
+  on_missing: create
+  on_conflict: reject
+pins:
+  inputs:
+    events: []
+  outputs:
+    events: []
+`,
+			flowEntities: `
+account:
+  account_id: uuid
+`,
+			want: "duplicated",
+		},
+		{
+			name: "undeclared key field",
+			flowSchema: `
+name: scoring
+mode: template
+instance:
+  by: missing_id
+  on_missing: create
+  on_conflict: reject
+pins:
+  inputs:
+    events: []
+  outputs:
+    events: []
+`,
+			flowEntities: `
+account:
+  account_id: uuid
+`,
+			want: "not declared",
+		},
+		{
+			name: "unsupported key field type",
+			flowSchema: `
+name: scoring
+mode: template
+instance:
+  by: tags
+  on_missing: create
+  on_conflict: reject
+pins:
+  inputs:
+    events: []
+  outputs:
+    events: []
+`,
+			flowEntities: `
+account:
+  tags: [text]
+`,
+			want: "scalar or enum",
+		},
+		{
+			name: "invalid on_missing policy",
+			flowSchema: `
+name: scoring
+mode: template
+instance:
+  by: account_id
+  on_missing: ignore
+  on_conflict: reject
+pins:
+  inputs:
+    events: []
+  outputs:
+    events: []
+`,
+			flowEntities: `
+account:
+  account_id: uuid
+`,
+			want: "on_missing",
+		},
+		{
+			name: "missing on_conflict policy",
+			flowSchema: `
+name: scoring
+mode: template
+instance:
+  by: account_id
+  on_missing: create
+pins:
+  inputs:
+    events: []
+  outputs:
+    events: []
+`,
+			flowEntities: `
+account:
+  account_id: uuid
+`,
+			want: "on_conflict",
+		},
+		{
+			name: "non template declares instance",
+			flowSchema: `
+name: scoring
+mode: static
+instance:
+  by: account_id
+  on_missing: create
+  on_conflict: reject
+pins:
+  inputs:
+    events: []
+  outputs:
+    events: []
+`,
+			flowEntities: `
+account:
+  account_id: uuid
+`,
+			want: "not mode: template",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			bundle := loadPrimaryEntityFixtureBundle(t, tc.flowSchema, tc.flowEntities)
+
+			report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+
+			if !reportContains(report.Errors(), "template_instance_validation", tc.want) {
+				t.Fatalf("expected template_instance_validation containing %q, got %#v", tc.want, report.Errors())
+			}
+		})
+	}
+}

--- a/internal/runtime/bootverify/workflow_template_instance_checks_test.go
+++ b/internal/runtime/bootverify/workflow_template_instance_checks_test.go
@@ -220,6 +220,21 @@ account:
 `,
 			want: "not mode: template",
 		},
+		{
+			name: "non template declares empty instance",
+			flowSchema: `
+name: scoring
+mode: static
+instance: {}
+pins:
+  inputs:
+    events: []
+  outputs:
+    events: []
+`,
+			flowEntities: "",
+			want:         "not mode: template",
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/runtime/contracts/workflow_contract_types.go
+++ b/internal/runtime/contracts/workflow_contract_types.go
@@ -2,11 +2,11 @@ package contracts
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/division-sh/swarm/internal/runtime/core/paths"
 	flowmodel "github.com/division-sh/swarm/internal/runtime/flowmodel"
 	"gopkg.in/yaml.v3"
-	"strings"
 )
 
 type ContractPaths struct {
@@ -703,23 +703,71 @@ type ContractItemSource struct {
 	File       string
 }
 type FlowSchemaDocument struct {
-	Name              string                   `yaml:"name"`
-	Mode              string                   `yaml:"mode"`
-	Entity            string                   `yaml:"entity"`
-	InitialState      string                   `yaml:"initial_state"`
-	NamespacePrefix   string                   `yaml:"namespace_prefix"`
-	NamespaceRule     string                   `yaml:"namespace_rule"`
-	TerminalStates    []string                 `yaml:"terminal_states"`
-	States            []string                 `yaml:"states"`
-	Pins              FlowPins                 `yaml:"pins"`
-	ToolSurface       FlowToolSurfaceContract  `yaml:"tool_surface"`
-	RequiredAgents    []FlowRequiredAgent      `yaml:"required_agents"`
-	InstanceVariables FlowInstanceVariables    `yaml:"instance_variables"`
-	AutoEmitOnCreate  AutoEmitOnCreateContract `yaml:"auto_emit_on_create"`
+	Name              string                          `yaml:"name"`
+	Mode              string                          `yaml:"mode"`
+	Entity            string                          `yaml:"entity"`
+	Instance          FlowTemplateInstanceDeclaration `yaml:"instance"`
+	InitialState      string                          `yaml:"initial_state"`
+	NamespacePrefix   string                          `yaml:"namespace_prefix"`
+	NamespaceRule     string                          `yaml:"namespace_rule"`
+	TerminalStates    []string                        `yaml:"terminal_states"`
+	States            []string                        `yaml:"states"`
+	Pins              FlowPins                        `yaml:"pins"`
+	ToolSurface       FlowToolSurfaceContract         `yaml:"tool_surface"`
+	RequiredAgents    []FlowRequiredAgent             `yaml:"required_agents"`
+	InstanceVariables FlowInstanceVariables           `yaml:"instance_variables"`
+	AutoEmitOnCreate  AutoEmitOnCreateContract        `yaml:"auto_emit_on_create"`
 }
 type FlowToolSurfaceContract struct {
 	RoleScopedEntityTools bool `yaml:"role_scoped_entity_tools"`
 }
+
+type FlowTemplateInstanceDeclaration struct {
+	By         []string `yaml:"by"`
+	OnMissing  string   `yaml:"on_missing"`
+	OnConflict string   `yaml:"on_conflict"`
+}
+
+func (i FlowTemplateInstanceDeclaration) Empty() bool {
+	return len(i.By) == 0 && strings.TrimSpace(i.OnMissing) == "" && strings.TrimSpace(i.OnConflict) == ""
+}
+
+type TemplateInstanceContract struct {
+	FlowID        string
+	By            []string
+	OnMissing     string
+	OnConflict    string
+	PrimaryEntity PrimaryEntityContract
+}
+
+type TemplateInstanceKeyValue struct {
+	Field string
+	Value string
+}
+
+func (c TemplateInstanceContract) CanonicalKeyMaterial(values map[string]any) ([]TemplateInstanceKeyValue, error) {
+	if len(c.By) == 0 {
+		return nil, fmt.Errorf("INVALID-TEMPLATE-INSTANCE: flow %s instance.by is required", defaultPrimaryEntityFlowLabel(c.FlowID))
+	}
+	out := make([]TemplateInstanceKeyValue, 0, len(c.By))
+	for _, field := range c.By {
+		field = strings.TrimSpace(field)
+		if field == "" {
+			return nil, fmt.Errorf("INVALID-TEMPLATE-INSTANCE: flow %s instance.by contains an empty field", defaultPrimaryEntityFlowLabel(c.FlowID))
+		}
+		value, ok := values[field]
+		if !ok || value == nil {
+			return nil, fmt.Errorf("INVALID-TEMPLATE-INSTANCE: flow %s instance key field %q is missing", defaultPrimaryEntityFlowLabel(c.FlowID), field)
+		}
+		valueText := strings.TrimSpace(fmt.Sprint(value))
+		if valueText == "" {
+			return nil, fmt.Errorf("INVALID-TEMPLATE-INSTANCE: flow %s instance key field %q is empty", defaultPrimaryEntityFlowLabel(c.FlowID), field)
+		}
+		out = append(out, TemplateInstanceKeyValue{Field: field, Value: valueText})
+	}
+	return out, nil
+}
+
 type FlowInstanceVariables struct {
 	Description string                  `yaml:"description"`
 	Variables   map[string]FlowVariable `yaml:"variables"`

--- a/internal/runtime/contracts/workflow_contract_types.go
+++ b/internal/runtime/contracts/workflow_contract_types.go
@@ -723,13 +723,14 @@ type FlowToolSurfaceContract struct {
 }
 
 type FlowTemplateInstanceDeclaration struct {
+	Declared   bool     `yaml:"-"`
 	By         []string `yaml:"by"`
 	OnMissing  string   `yaml:"on_missing"`
 	OnConflict string   `yaml:"on_conflict"`
 }
 
 func (i FlowTemplateInstanceDeclaration) Empty() bool {
-	return len(i.By) == 0 && strings.TrimSpace(i.OnMissing) == "" && strings.TrimSpace(i.OnConflict) == ""
+	return !i.Declared && len(i.By) == 0 && strings.TrimSpace(i.OnMissing) == "" && strings.TrimSpace(i.OnConflict) == ""
 }
 
 type TemplateInstanceContract struct {

--- a/internal/runtime/contracts/workflow_contract_wave1_accessors.go
+++ b/internal/runtime/contracts/workflow_contract_wave1_accessors.go
@@ -80,13 +80,108 @@ func validateTemplateInstanceBy(flowID string, fields []string, primary PrimaryE
 		if _, ok := seen[field]; ok {
 			return nil, fmt.Errorf("INVALID-TEMPLATE-INSTANCE: flow %s instance.by field %q is duplicated; composite keys must be unambiguous", flowID, field)
 		}
-		if _, ok := primary.Contract.Fields[field]; !ok {
+		decl, ok := primary.Contract.Fields[field]
+		if !ok {
 			return nil, fmt.Errorf("INVALID-TEMPLATE-INSTANCE: flow %s instance.by field %q is not declared on primary entity %s", flowID, field, primary.EntityType)
+		}
+		kind := templateInstanceFieldLeafKind(primary, decl.Type)
+		if kind != "scalar" && kind != "enum" {
+			return nil, fmt.Errorf("INVALID-TEMPLATE-INSTANCE: flow %s instance.by field %q must resolve to a scalar or enum primary-entity field", flowID, field)
 		}
 		seen[field] = struct{}{}
 		out = append(out, field)
 	}
 	return out, nil
+}
+
+func templateInstanceFieldLeafKind(primary PrimaryEntityContract, typeRef string) string {
+	switch {
+	case templateInstanceIsTextType(typeRef):
+		return "scalar"
+	case templateInstanceIsIntegerType(primary.Types, typeRef):
+		return "scalar"
+	case templateInstanceIsNumericType(primary.Types, typeRef):
+		return "scalar"
+	case templateInstanceIsBooleanType(primary.Types, typeRef):
+		return "scalar"
+	case templateInstanceIsJSONObjectType(primary.Types, typeRef):
+		return "object"
+	case templateInstanceIsJSONArrayType(primary.Types, typeRef):
+		return "list"
+	case templateInstanceIsTimestampType(primary.Types, typeRef):
+		return "scalar"
+	case templateInstanceIsUUIDType(primary.Types, typeRef):
+		return "scalar"
+	case templateInstanceIsEnumType(primary.Types, typeRef):
+		return "enum"
+	case templateInstanceIsNamedType(primary.Types, typeRef):
+		return "object"
+	case templateInstanceIsListType(typeRef):
+		return "list"
+	default:
+		return ""
+	}
+}
+
+func templateInstanceTypeName(types TypeCatalogDocument, typeRef string) string {
+	typeRef = strings.TrimSpace(typeRef)
+	if scalar, ok := types.Scalars[typeRef]; ok {
+		return strings.TrimSpace(scalar.Base)
+	}
+	return typeRef
+}
+
+func templateInstanceIsNamedType(types TypeCatalogDocument, typeRef string) bool {
+	_, ok := types.Types[templateInstanceTypeName(types, typeRef)]
+	return ok
+}
+
+func templateInstanceIsEnumType(types TypeCatalogDocument, typeRef string) bool {
+	_, ok := types.Enums[templateInstanceTypeName(types, typeRef)]
+	return ok
+}
+
+func templateInstanceIsTextType(typeRef string) bool {
+	typeRef = strings.ToLower(strings.TrimSpace(typeRef))
+	return typeRef == "text" || typeRef == "string"
+}
+
+func templateInstanceIsIntegerType(types TypeCatalogDocument, typeRef string) bool {
+	return strings.EqualFold(templateInstanceTypeName(types, typeRef), "integer")
+}
+
+func templateInstanceIsNumericType(types TypeCatalogDocument, typeRef string) bool {
+	raw := strings.ToLower(strings.TrimSpace(templateInstanceTypeName(types, typeRef)))
+	return raw == "numeric" || raw == "number" || raw == "float" || raw == "double" || raw == "real" || strings.HasPrefix(raw, "numeric(")
+}
+
+func templateInstanceIsBooleanType(types TypeCatalogDocument, typeRef string) bool {
+	return strings.EqualFold(templateInstanceTypeName(types, typeRef), "boolean")
+}
+
+func templateInstanceIsJSONObjectType(types TypeCatalogDocument, typeRef string) bool {
+	raw := strings.ToLower(strings.TrimSpace(templateInstanceTypeName(types, typeRef)))
+	return raw == "json" || raw == "object"
+}
+
+func templateInstanceIsJSONArrayType(types TypeCatalogDocument, typeRef string) bool {
+	return strings.EqualFold(templateInstanceTypeName(types, typeRef), "array")
+}
+
+func templateInstanceIsTimestampType(types TypeCatalogDocument, typeRef string) bool {
+	return strings.EqualFold(templateInstanceTypeName(types, typeRef), "timestamp")
+}
+
+func templateInstanceIsUUIDType(types TypeCatalogDocument, typeRef string) bool {
+	return strings.EqualFold(templateInstanceTypeName(types, typeRef), "uuid")
+}
+
+func templateInstanceIsListType(typeRef string) bool {
+	typeRef = strings.TrimSpace(typeRef)
+	return strings.HasPrefix(typeRef, "list<") && strings.HasSuffix(typeRef, ">") ||
+		strings.HasPrefix(typeRef, "[") && strings.HasSuffix(typeRef, "]") ||
+		strings.HasSuffix(typeRef, "[]") ||
+		strings.HasPrefix(typeRef, "[]")
 }
 
 func validateTemplateInstancePolicy(flowID, field, value string, allowed ...string) (string, error) {

--- a/internal/runtime/contracts/workflow_contract_wave1_accessors.go
+++ b/internal/runtime/contracts/workflow_contract_wave1_accessors.go
@@ -14,6 +14,94 @@ type PrimaryEntityContract struct {
 	Types      TypeCatalogDocument
 }
 
+func (b *WorkflowContractBundle) ResolveFlowTemplateInstance(flowID string) (TemplateInstanceContract, error) {
+	flowID = strings.TrimSpace(flowID)
+	label := defaultPrimaryEntityFlowLabel(flowID)
+	if b == nil {
+		return TemplateInstanceContract{}, fmt.Errorf("INVALID-TEMPLATE-INSTANCE: flow %s template instance is unavailable: bundle is nil", label)
+	}
+	if flowID == "" {
+		return TemplateInstanceContract{}, fmt.Errorf("INVALID-TEMPLATE-INSTANCE: flow <root> cannot declare a template instance key; template instances are child flow contracts")
+	}
+	schema, ok := b.FlowSchemas[flowID]
+	if !ok {
+		return TemplateInstanceContract{}, fmt.Errorf("INVALID-TEMPLATE-INSTANCE: flow %s template instance is unavailable: schema not found", flowID)
+	}
+	mode := strings.TrimSpace(schema.Mode)
+	if mode != "template" {
+		if !schema.Instance.Empty() {
+			return TemplateInstanceContract{}, fmt.Errorf("INVALID-TEMPLATE-INSTANCE: flow %s declares instance but is not mode: template", flowID)
+		}
+		return TemplateInstanceContract{}, fmt.Errorf("INVALID-TEMPLATE-INSTANCE: flow %s is not mode: template", flowID)
+	}
+	if schema.Instance.Empty() {
+		return TemplateInstanceContract{}, fmt.Errorf("INVALID-TEMPLATE-INSTANCE: flow %s mode: template must declare instance.by, instance.on_missing, and instance.on_conflict", flowID)
+	}
+	primary, err := b.ResolveFlowPrimaryEntity(flowID)
+	if err != nil {
+		return TemplateInstanceContract{}, fmt.Errorf("INVALID-TEMPLATE-INSTANCE: flow %s primary entity required for instance.by: %w", flowID, err)
+	}
+	by, err := validateTemplateInstanceBy(flowID, schema.Instance.By, primary)
+	if err != nil {
+		return TemplateInstanceContract{}, err
+	}
+	onMissing, err := validateTemplateInstancePolicy(flowID, "on_missing", schema.Instance.OnMissing, "create", "reject")
+	if err != nil {
+		return TemplateInstanceContract{}, err
+	}
+	onConflict, err := validateTemplateInstancePolicy(flowID, "on_conflict", schema.Instance.OnConflict, "reject", "reuse")
+	if err != nil {
+		return TemplateInstanceContract{}, err
+	}
+	return TemplateInstanceContract{
+		FlowID:        flowID,
+		By:            by,
+		OnMissing:     onMissing,
+		OnConflict:    onConflict,
+		PrimaryEntity: primary,
+	}, nil
+}
+
+func validateTemplateInstanceBy(flowID string, fields []string, primary PrimaryEntityContract) ([]string, error) {
+	flowID = strings.TrimSpace(flowID)
+	if len(fields) == 0 {
+		return nil, fmt.Errorf("INVALID-TEMPLATE-INSTANCE: flow %s instance.by is required", defaultPrimaryEntityFlowLabel(flowID))
+	}
+	out := make([]string, 0, len(fields))
+	seen := map[string]struct{}{}
+	for _, rawField := range fields {
+		field := strings.TrimSpace(rawField)
+		switch {
+		case field == "":
+			return nil, fmt.Errorf("INVALID-TEMPLATE-INSTANCE: flow %s instance.by contains an empty field", flowID)
+		case strings.Contains(field, "."):
+			return nil, fmt.Errorf("INVALID-TEMPLATE-INSTANCE: flow %s instance.by field %q must be a top-level primary-entity field", flowID, field)
+		}
+		if _, ok := seen[field]; ok {
+			return nil, fmt.Errorf("INVALID-TEMPLATE-INSTANCE: flow %s instance.by field %q is duplicated; composite keys must be unambiguous", flowID, field)
+		}
+		if _, ok := primary.Contract.Fields[field]; !ok {
+			return nil, fmt.Errorf("INVALID-TEMPLATE-INSTANCE: flow %s instance.by field %q is not declared on primary entity %s", flowID, field, primary.EntityType)
+		}
+		seen[field] = struct{}{}
+		out = append(out, field)
+	}
+	return out, nil
+}
+
+func validateTemplateInstancePolicy(flowID, field, value string, allowed ...string) (string, error) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return "", fmt.Errorf("INVALID-TEMPLATE-INSTANCE: flow %s instance.%s is required", defaultPrimaryEntityFlowLabel(flowID), field)
+	}
+	for _, option := range allowed {
+		if value == option {
+			return value, nil
+		}
+	}
+	return "", fmt.Errorf("INVALID-TEMPLATE-INSTANCE: flow %s instance.%s value %q is unsupported; allowed values: %s", defaultPrimaryEntityFlowLabel(flowID), field, value, strings.Join(allowed, ", "))
+}
+
 func validateWave1ContractsLoadBoundary(bundle *WorkflowContractBundle) error {
 	if bundle == nil {
 		return nil
@@ -23,19 +111,24 @@ func validateWave1ContractsLoadBoundary(bundle *WorkflowContractBundle) error {
 			errString("RETIRED: package.yaml entity_schema is no longer supported; migrate to entities.yaml (legacy scope: " + legacyScope + ")"),
 		}}
 	}
+	flowScopedTypesFiles, flowScopedEntityFiles := flowScopedContractFiles(bundle)
 	for _, pkg := range bundle.PackageTree {
 		if strings.TrimSpace(pkg.Key) == "." {
 			continue
 		}
 		if path := existingFile(filepath.Join(pkg.Paths.Dir, "types.yaml")); path != "" {
-			return &LoadValidationError{Items: []error{
-				errString("RETIRED: package-scoped types.yaml is not supported in Wave 1; move declarations to bundle root or flow scope (" + path + ")"),
-			}}
+			if _, ok := flowScopedTypesFiles[filepath.Clean(path)]; !ok {
+				return &LoadValidationError{Items: []error{
+					errString("RETIRED: package-scoped types.yaml is not supported in Wave 1; move declarations to bundle root or flow scope (" + path + ")"),
+				}}
+			}
 		}
 		if path := existingFile(filepath.Join(pkg.Paths.Dir, "entities.yaml")); path != "" {
-			return &LoadValidationError{Items: []error{
-				errString("RETIRED: package-scoped entities.yaml is not supported in Wave 1; move declarations to bundle root or flow scope (" + path + ")"),
-			}}
+			if _, ok := flowScopedEntityFiles[filepath.Clean(path)]; !ok {
+				return &LoadValidationError{Items: []error{
+					errString("RETIRED: package-scoped entities.yaml is not supported in Wave 1; move declarations to bundle root or flow scope (" + path + ")"),
+				}}
+			}
 		}
 	}
 	for entityType, contract := range bundle.RootEntities {
@@ -63,6 +156,25 @@ func validateWave1ContractsLoadBoundary(bundle *WorkflowContractBundle) error {
 		}
 	}
 	return nil
+}
+
+func flowScopedContractFiles(bundle *WorkflowContractBundle) (map[string]struct{}, map[string]struct{}) {
+	typesFiles := map[string]struct{}{}
+	entityFiles := map[string]struct{}{}
+	if bundle == nil {
+		return typesFiles, entityFiles
+	}
+	for _, pkg := range bundle.PackageTree {
+		for _, flow := range pkg.Paths.Flows {
+			if path := strings.TrimSpace(flow.TypesFile); path != "" {
+				typesFiles[filepath.Clean(path)] = struct{}{}
+			}
+			if path := strings.TrimSpace(flow.EntitiesFile); path != "" {
+				entityFiles[filepath.Clean(path)] = struct{}{}
+			}
+		}
+	}
+	return typesFiles, entityFiles
 }
 
 func validateRootPrimaryEntityLoadBoundary(bundle *WorkflowContractBundle) error {

--- a/internal/runtime/contracts/workflow_contract_wave1_test.go
+++ b/internal/runtime/contracts/workflow_contract_wave1_test.go
@@ -211,6 +211,19 @@ func TestWorkflowContractBundleResolveFlowTemplateInstance_RejectsInvalidDeclara
 			wantErr:  "on_missing",
 		},
 		{
+			name: "non scalar key field",
+			schema: FlowSchemaDocument{
+				Mode: "template",
+				Instance: FlowTemplateInstanceDeclaration{
+					By:         []string{"tags"},
+					OnMissing:  "create",
+					OnConflict: "reject",
+				},
+			},
+			entities: EntityContractsDocument{"tenant": {Fields: map[string]EntityFieldDecl{"tags": {Type: "[text]"}}}},
+			wantErr:  "scalar or enum",
+		},
+		{
 			name: "non template",
 			schema: FlowSchemaDocument{
 				Mode: "static",

--- a/internal/runtime/contracts/workflow_contract_wave1_test.go
+++ b/internal/runtime/contracts/workflow_contract_wave1_test.go
@@ -106,6 +106,147 @@ vertical.shortlisted:
 	}
 }
 
+func TestWorkflowContractBundleResolveFlowTemplateInstance_PreservesOrderedCompositeKey(t *testing.T) {
+	bundle := &WorkflowContractBundle{
+		FlowSchemas: map[string]FlowSchemaDocument{
+			"spec_repo": {
+				Name: "spec_repo",
+				Mode: "template",
+				Instance: FlowTemplateInstanceDeclaration{
+					By:         []string{"scope", "scope_id", "artifact_type"},
+					OnMissing:  "create",
+					OnConflict: "reject",
+				},
+			},
+		},
+		flowEntities: map[string]EntityContractsDocument{
+			"spec_repo": {
+				"artifact_repo": {
+					Fields: map[string]EntityFieldDecl{
+						"artifact_type": {Type: "text"},
+						"scope":         {Type: "text"},
+						"scope_id":      {Type: "uuid"},
+					},
+				},
+			},
+		},
+	}
+
+	resolved, err := bundle.ResolveFlowTemplateInstance("spec_repo")
+	if err != nil {
+		t.Fatalf("ResolveFlowTemplateInstance: %v", err)
+	}
+	if got, want := strings.Join(resolved.By, ","), "scope,scope_id,artifact_type"; got != want {
+		t.Fatalf("resolved By = %q, want %q", got, want)
+	}
+	key, err := resolved.CanonicalKeyMaterial(map[string]any{
+		"artifact_type": "contract",
+		"scope_id":      "vertical-1",
+		"scope":         "project",
+	})
+	if err != nil {
+		t.Fatalf("CanonicalKeyMaterial: %v", err)
+	}
+	if got, want := keyMaterialString(key), "scope=project,scope_id=vertical-1,artifact_type=contract"; got != want {
+		t.Fatalf("CanonicalKeyMaterial = %q, want %q", got, want)
+	}
+}
+
+func TestWorkflowContractBundleResolveFlowTemplateInstance_RejectsInvalidDeclarations(t *testing.T) {
+	tests := []struct {
+		name     string
+		schema   FlowSchemaDocument
+		entities EntityContractsDocument
+		wantErr  string
+	}{
+		{
+			name: "duplicate key",
+			schema: FlowSchemaDocument{
+				Mode: "template",
+				Instance: FlowTemplateInstanceDeclaration{
+					By:         []string{"tenant_id", "tenant_id"},
+					OnMissing:  "create",
+					OnConflict: "reject",
+				},
+			},
+			entities: EntityContractsDocument{"tenant": {Fields: map[string]EntityFieldDecl{"tenant_id": {Type: "text"}}}},
+			wantErr:  "duplicated",
+		},
+		{
+			name: "missing field",
+			schema: FlowSchemaDocument{
+				Mode: "template",
+				Instance: FlowTemplateInstanceDeclaration{
+					By:         []string{"account_id"},
+					OnMissing:  "create",
+					OnConflict: "reject",
+				},
+			},
+			entities: EntityContractsDocument{"tenant": {Fields: map[string]EntityFieldDecl{"tenant_id": {Type: "text"}}}},
+			wantErr:  "not declared",
+		},
+		{
+			name: "nested field",
+			schema: FlowSchemaDocument{
+				Mode: "template",
+				Instance: FlowTemplateInstanceDeclaration{
+					By:         []string{"tenant.id"},
+					OnMissing:  "create",
+					OnConflict: "reject",
+				},
+			},
+			entities: EntityContractsDocument{"tenant": {Fields: map[string]EntityFieldDecl{"tenant": {Type: "Tenant"}}}},
+			wantErr:  "top-level",
+		},
+		{
+			name: "missing policy",
+			schema: FlowSchemaDocument{
+				Mode: "template",
+				Instance: FlowTemplateInstanceDeclaration{
+					By:         []string{"tenant_id"},
+					OnConflict: "reject",
+				},
+			},
+			entities: EntityContractsDocument{"tenant": {Fields: map[string]EntityFieldDecl{"tenant_id": {Type: "text"}}}},
+			wantErr:  "on_missing",
+		},
+		{
+			name: "non template",
+			schema: FlowSchemaDocument{
+				Mode: "static",
+				Instance: FlowTemplateInstanceDeclaration{
+					By:         []string{"tenant_id"},
+					OnMissing:  "create",
+					OnConflict: "reject",
+				},
+			},
+			entities: EntityContractsDocument{"tenant": {Fields: map[string]EntityFieldDecl{"tenant_id": {Type: "text"}}}},
+			wantErr:  "not mode: template",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			bundle := &WorkflowContractBundle{
+				FlowSchemas:  map[string]FlowSchemaDocument{"worker": tc.schema},
+				flowEntities: map[string]EntityContractsDocument{"worker": tc.entities},
+			}
+			_, err := bundle.ResolveFlowTemplateInstance("worker")
+			if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("ResolveFlowTemplateInstance error = %v, want %q", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+func keyMaterialString(values []TemplateInstanceKeyValue) string {
+	parts := make([]string, 0, len(values))
+	for _, value := range values {
+		parts = append(parts, value.Field+"="+value.Value)
+	}
+	return strings.Join(parts, ",")
+}
+
 func TestLoadWorkflowContractBundle_RejectsLegacyPackageEntitySchema(t *testing.T) {
 	repoRoot := repoRootForContractsTest(t)
 	root := t.TempDir()

--- a/internal/runtime/contracts/workflow_contract_yaml_flow.go
+++ b/internal/runtime/contracts/workflow_contract_yaml_flow.go
@@ -111,6 +111,68 @@ func (p *FlowOutputPins) UnmarshalYAML(node *yaml.Node) error {
 	return nil
 }
 
+func (i *FlowTemplateInstanceDeclaration) UnmarshalYAML(node *yaml.Node) error {
+	if i == nil {
+		return nil
+	}
+	if node == nil || node.Kind == 0 {
+		return nil
+	}
+	if node.Kind != yaml.MappingNode {
+		return fmt.Errorf("template instance must be a mapping")
+	}
+	var out FlowTemplateInstanceDeclaration
+	for idx := 0; idx+1 < len(node.Content); idx += 2 {
+		key := strings.TrimSpace(node.Content[idx].Value)
+		value := node.Content[idx+1]
+		switch key {
+		case "":
+			continue
+		case "by":
+			by, err := decodeTemplateInstanceByNode(value)
+			if err != nil {
+				return err
+			}
+			out.By = by
+		case "on_missing":
+			if err := value.Decode(&out.OnMissing); err != nil {
+				return fmt.Errorf("template instance on_missing: %w", err)
+			}
+			out.OnMissing = strings.TrimSpace(out.OnMissing)
+		case "on_conflict":
+			if err := value.Decode(&out.OnConflict); err != nil {
+				return fmt.Errorf("template instance on_conflict: %w", err)
+			}
+			out.OnConflict = strings.TrimSpace(out.OnConflict)
+		default:
+			return fmt.Errorf("UNDEFINED-FIELD: template instance field %q not in platform spec", key)
+		}
+	}
+	*i = out
+	return nil
+}
+
+func decodeTemplateInstanceByNode(node *yaml.Node) ([]string, error) {
+	if node == nil || node.Kind == 0 {
+		return nil, nil
+	}
+	switch node.Kind {
+	case yaml.ScalarNode:
+		return []string{strings.TrimSpace(node.Value)}, nil
+	case yaml.SequenceNode:
+		out := make([]string, 0, len(node.Content))
+		for _, item := range node.Content {
+			if item == nil || item.Kind != yaml.ScalarNode {
+				return nil, fmt.Errorf("template instance by entries must be strings")
+			}
+			out = append(out, strings.TrimSpace(item.Value))
+		}
+		return out, nil
+	default:
+		return nil, fmt.Errorf("template instance by must be a string or sequence")
+	}
+}
+
 func decodeFlowInputPinEventsNode(node *yaml.Node) ([]string, []FlowInputEventPin, error) {
 	if node == nil || node.Kind == 0 {
 		return nil, nil, nil

--- a/internal/runtime/contracts/workflow_contract_yaml_flow.go
+++ b/internal/runtime/contracts/workflow_contract_yaml_flow.go
@@ -121,7 +121,7 @@ func (i *FlowTemplateInstanceDeclaration) UnmarshalYAML(node *yaml.Node) error {
 	if node.Kind != yaml.MappingNode {
 		return fmt.Errorf("template instance must be a mapping")
 	}
-	var out FlowTemplateInstanceDeclaration
+	out := FlowTemplateInstanceDeclaration{Declared: true}
 	for idx := 0; idx+1 < len(node.Content); idx += 2 {
 		key := strings.TrimSpace(node.Content[idx].Value)
 		value := node.Content[idx+1]

--- a/internal/runtime/contracts/workflow_contract_yaml_test.go
+++ b/internal/runtime/contracts/workflow_contract_yaml_test.go
@@ -334,6 +334,23 @@ instance:
 	}
 }
 
+func TestFlowSchemaDocumentDecode_PreservesEmptyTemplateInstancePresence(t *testing.T) {
+	var doc FlowSchemaDocument
+	if err := yaml.Unmarshal([]byte(`
+name: template-flow
+mode: static
+instance: {}
+`), &doc); err != nil {
+		t.Fatalf("yaml.Unmarshal: %v", err)
+	}
+	if !doc.Instance.Declared {
+		t.Fatal("Instance.Declared = false, want explicit empty declaration preserved")
+	}
+	if doc.Instance.Empty() {
+		t.Fatal("Instance.Empty() = true for explicit empty declaration, want false")
+	}
+}
+
 func TestFlowSchemaDocumentDecode_RejectsUnsupportedTemplateInstanceFields(t *testing.T) {
 	var doc FlowSchemaDocument
 	err := yaml.Unmarshal([]byte(`

--- a/internal/runtime/contracts/workflow_contract_yaml_test.go
+++ b/internal/runtime/contracts/workflow_contract_yaml_test.go
@@ -291,6 +291,65 @@ pins:
 	}
 }
 
+func TestFlowSchemaDocumentDecode_PreservesTemplateInstanceDeclaration(t *testing.T) {
+	var doc FlowSchemaDocument
+	if err := yaml.Unmarshal([]byte(`
+name: template-flow
+mode: template
+instance:
+  by: [scope, scope_id, artifact_type]
+  on_missing: create
+  on_conflict: reject
+`), &doc); err != nil {
+		t.Fatalf("yaml.Unmarshal: %v", err)
+	}
+	if got, want := doc.Mode, "template"; got != want {
+		t.Fatalf("Mode = %q, want %q", got, want)
+	}
+	if got, want := strings.Join(doc.Instance.By, ","), "scope,scope_id,artifact_type"; got != want {
+		t.Fatalf("Instance.By = %q, want %q", got, want)
+	}
+	if got, want := doc.Instance.OnMissing, "create"; got != want {
+		t.Fatalf("Instance.OnMissing = %q, want %q", got, want)
+	}
+	if got, want := doc.Instance.OnConflict, "reject"; got != want {
+		t.Fatalf("Instance.OnConflict = %q, want %q", got, want)
+	}
+}
+
+func TestFlowSchemaDocumentDecode_PreservesTemplateInstanceDuplicateKeysForResolver(t *testing.T) {
+	var doc FlowSchemaDocument
+	if err := yaml.Unmarshal([]byte(`
+name: template-flow
+mode: template
+instance:
+  by: [tenant_id, tenant_id]
+  on_missing: reject
+  on_conflict: reuse
+`), &doc); err != nil {
+		t.Fatalf("yaml.Unmarshal: %v", err)
+	}
+	if got, want := strings.Join(doc.Instance.By, ","), "tenant_id,tenant_id"; got != want {
+		t.Fatalf("Instance.By = %q, want duplicate-preserving %q", got, want)
+	}
+}
+
+func TestFlowSchemaDocumentDecode_RejectsUnsupportedTemplateInstanceFields(t *testing.T) {
+	var doc FlowSchemaDocument
+	err := yaml.Unmarshal([]byte(`
+name: invalid-template
+mode: template
+instance:
+  by: account_id
+  on_missing: create
+  on_conflict: reject
+  fallback: legacy
+`), &doc)
+	if err == nil || !strings.Contains(err.Error(), "UNDEFINED-FIELD") {
+		t.Fatalf("yaml.Unmarshal error = %v, want UNDEFINED-FIELD", err)
+	}
+}
+
 func TestHandlerRuleEntryDecode_RejectsLegacyComputeExpressionShorthand(t *testing.T) {
 	var rule HandlerRuleEntry
 	err := yaml.Unmarshal([]byte(`

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -5057,8 +5057,9 @@ flow_model:
         when: A map/list item starts behaving like a routable recipient.
         use: promote it to a child/template flow instance
     template_instance_model:
-      status: spec_vocabulary_only
+      status: merge_bearing_contract_behavior
       implementation_tracker: '#1543'
+      canonical_code_owner: internal/runtime/contracts.WorkflowContractBundle.ResolveFlowTemplateInstance
       declaration_surface:
       - 'mode: template'
       - 'instance.by'
@@ -5067,8 +5068,32 @@ flow_model:
       rule: >
         Template flow instances are the common shape for process/case/job state
         that needs independent lifecycle, routing, timers, retries, agents, or
-        audit. Instance-key verification and runtime semantics are tracked by
-        #1543 and are not implemented by #1538.
+        audit. #1543 owns the receiver template-instance declaration and verifier
+        contract: `mode: template` flows MUST declare `instance.by`,
+        `on_missing`, and `on_conflict`; runtime route-plan lowering remains
+        tracked by #1545.
+      primary_entity_dependency: >
+        `instance.by` is checked against the flow primary entity resolved by
+        internal/runtime/contracts.WorkflowContractBundle.ResolveFlowPrimaryEntity.
+        `schema.yaml entity` is not a secondary entity selector and remains
+        invalid for normal flow authoring.
+      key_rule: >
+        Each `instance.by` entry names a top-level scalar or enum field on the
+        primary entity. Empty fields, duplicate fields, nested paths, undeclared
+        fields, and non-scalar/non-enum fields fail verification. Composite key
+        material is ordered exactly as declared in `instance.by` so identity is
+        deterministic and unambiguous.
+      policy_rule: >
+        `on_missing` is required and MUST be `create` or `reject`. `on_conflict`
+        is required and MUST be `reject` or `reuse`. Missing or unsupported
+        policy values fail closed during verification.
+      non_authoritative_paths: >
+        Flow input-pin `address`, receiver `select_entity` /
+        `select_or_create_entity`, producer `target`, producer `broadcast:true`,
+        direct delivery, and `create_flow_instance.instance_id_from` are not the
+        normal template instance-key authority for #1537 composition. They may
+        survive only as explicit sibling/escape-hatch surfaces owned by their
+        tracked issues.
     primary_entity_model:
       status: merge_bearing_contract_behavior
       implementation_tracker: '#1539'

--- a/tests/tier11-flow-composition/test-dynamic-flow-instance/flows/worker/entities.yaml
+++ b/tests/tier11-flow-composition/test-dynamic-flow-instance/flows/worker/entities.yaml
@@ -1,0 +1,7 @@
+worker:
+  worker_id:
+    type: text
+    _unused_reason: lifecycle fixture key supplied by create_flow_instance
+  task_label:
+    type: text
+    _unused_reason: lifecycle fixture payload proof field

--- a/tests/tier11-flow-composition/test-dynamic-flow-instance/flows/worker/schema.yaml
+++ b/tests/tier11-flow-composition/test-dynamic-flow-instance/flows/worker/schema.yaml
@@ -1,5 +1,10 @@
 name: worker
 namespace: worker
+mode: template
+instance:
+  by: worker_id
+  on_missing: create
+  on_conflict: reject
 initial_state: idle
 terminal_states: [complete]
 states: [idle, working, complete]

--- a/tests/tier5-flow-lifecycle/test-create-flow-instance-config/flows/worker-flow/entities.yaml
+++ b/tests/tier5-flow-lifecycle/test-create-flow-instance-config/flows/worker-flow/entities.yaml
@@ -1,0 +1,7 @@
+worker:
+  max_retries:
+    type: integer
+    _unused_reason: lifecycle config fixture proof field
+  timeout_ms:
+    type: integer
+    _unused_reason: lifecycle config fixture proof field

--- a/tests/tier5-flow-lifecycle/test-create-flow-instance-config/flows/worker-flow/schema.yaml
+++ b/tests/tier5-flow-lifecycle/test-create-flow-instance-config/flows/worker-flow/schema.yaml
@@ -1,5 +1,10 @@
 name: worker-flow
 namespace: worker-flow
+mode: template
+instance:
+  by: max_retries
+  on_missing: create
+  on_conflict: reject
 initial_state: idle
 terminal_states: [complete]
 states: [idle, complete]

--- a/tests/tier5-flow-lifecycle/test-create-flow-instance-duplicate/flows/worker-flow/entities.yaml
+++ b/tests/tier5-flow-lifecycle/test-create-flow-instance-duplicate/flows/worker-flow/entities.yaml
@@ -1,0 +1,4 @@
+worker:
+  entity_id:
+    type: text
+    _unused_reason: lifecycle fixture key supplied by create_flow_instance

--- a/tests/tier5-flow-lifecycle/test-create-flow-instance-duplicate/flows/worker-flow/schema.yaml
+++ b/tests/tier5-flow-lifecycle/test-create-flow-instance-duplicate/flows/worker-flow/schema.yaml
@@ -1,5 +1,10 @@
 name: worker-flow
 namespace: worker-flow
+mode: template
+instance:
+  by: entity_id
+  on_missing: create
+  on_conflict: reject
 initial_state: idle
 terminal_states: [complete]
 states: [idle, complete]

--- a/tests/tier5-flow-lifecycle/test-create-flow-instance/flows/worker-flow/entities.yaml
+++ b/tests/tier5-flow-lifecycle/test-create-flow-instance/flows/worker-flow/entities.yaml
@@ -1,0 +1,4 @@
+worker:
+  entity_id:
+    type: text
+    _unused_reason: lifecycle fixture key supplied by create_flow_instance

--- a/tests/tier5-flow-lifecycle/test-create-flow-instance/flows/worker-flow/schema.yaml
+++ b/tests/tier5-flow-lifecycle/test-create-flow-instance/flows/worker-flow/schema.yaml
@@ -1,5 +1,10 @@
 name: worker-flow
 namespace: worker-flow
+mode: template
+instance:
+  by: entity_id
+  on_missing: create
+  on_conflict: reject
 initial_state: idle
 terminal_states: [complete]
 states: [idle, complete]

--- a/tests/tier9-composition-patterns/test-compose-create-instance-config/flows/worker/entities.yaml
+++ b/tests/tier9-composition-patterns/test-compose-create-instance-config/flows/worker/entities.yaml
@@ -1,0 +1,10 @@
+worker:
+  name:
+    type: text
+    _unused_reason: lifecycle config fixture proof field
+  priority:
+    type: integer
+    _unused_reason: lifecycle config fixture proof field
+  owner:
+    type: text
+    _unused_reason: lifecycle config fixture proof field

--- a/tests/tier9-composition-patterns/test-compose-create-instance-config/flows/worker/schema.yaml
+++ b/tests/tier9-composition-patterns/test-compose-create-instance-config/flows/worker/schema.yaml
@@ -1,5 +1,10 @@
 name: worker
 namespace: worker
+mode: template
+instance:
+  by: name
+  on_missing: create
+  on_conflict: reject
 initial_state: ready
 terminal_states: [done]
 states: [ready, done]


### PR DESCRIPTION
Closes #1543

## Governing refs/context
- `platform-spec.yaml#flow_model.flow_instance_authoring`
- `platform-spec.yaml#flow_model.flow_instance_authoring.template_instance_model`
- `platform-spec.yaml#flow_model.flow_instance_authoring.primary_entity_model`
- `platform-spec.yaml#flow_model.flow_instance_authoring.analyzer_obligations`
- #1476 locked design and #1543 pre-audit/gate comments

## Scope
- Promotes `template_instance_model` from vocabulary-only to merge-bearing contract/verifier behavior.
- Adds canonical owner `internal/runtime/contracts.WorkflowContractBundle.ResolveFlowTemplateInstance` plus `FlowSchemaDocument.Instance` YAML support.
- Adds bootverify `template_instance_validation` fail-closed checks for missing/invalid `instance.by`, duplicate keys, non-scalar key fields, invalid/missing policies, root/incompatible usage, and primary-entity dependency.
- Repairs template fixtures to declare explicit instance keys without changing route-plan/runtime lowering semantics.

## Semantic migration
- New canonical owner: `WorkflowContractBundle.ResolveFlowTemplateInstance` and `FlowSchemaDocument.Instance`.
- Old non-authoritative paths: input-pin `address`, `select_entity`, producer `target`, `broadcast:true`, direct delivery, and `create_flow_instance.instance_id_from` are not normal template instance-key authority.
- Checked surviving production paths: contracts YAML decode/load, bootverify registry, catalog fixtures, served-runtime fixtures, apispec spec assertions, and flow package/flow-scope entity loading.
- Migration completeness: complete for #1543 contract/spec/verifier surface only. Runtime route-plan lowering, producer key/carries, adapters, select_entity demotion, and static multi-entity policy remain split to #1544/#1545/#1546/#1547/#1554.

## Proof
- `go test ./internal/runtime/contracts ./internal/runtime/bootverify ./internal/apispec -run 'TemplateInstance|FlowInstanceAuthoring|FlowSchemaDocumentDecode|PrimaryEntity' -count=1`
- `go test ./cmd/swarm ./internal/runtime/cataloge2e ./internal/runtime/bootverify`
- `go test ./...`