### PR TITLE
[agent-a][issue #1544] Verify output pin key/carries evidence

### DIFF
--- a/internal/apispec/platform_spec_composition_routing_test.go
+++ b/internal/apispec/platform_spec_composition_routing_test.go
@@ -200,6 +200,7 @@ func TestPlatformSpecCompositionRoutingCatalogSurfacesConsumeConnectAuthority(t 
 	assertScalarContains(t, mustMappingValue(t, outputPinKeyCarries, "trigger"), "missing key/carries evidence")
 	assertScalarContains(t, mustMappingValue(t, outputPinKeyCarries, "trigger"), "Agent emit_events")
 	assertScalarContains(t, mustMappingValue(t, outputPinKeyCarries, "trigger"), "auto_emit_on_create")
+	assertScalarContains(t, mustMappingValue(t, outputPinKeyCarries, "trigger"), "workflow timers")
 
 	bootSteps := mustYAMLPath(t, root, "engine", "boot_sequence", "steps")
 	validatePins := mustSequenceMappingByScalarField(t, bootSteps, "name", "validate_pins")

--- a/internal/apispec/platform_spec_composition_routing_test.go
+++ b/internal/apispec/platform_spec_composition_routing_test.go
@@ -199,6 +199,7 @@ func TestPlatformSpecCompositionRoutingCatalogSurfacesConsumeConnectAuthority(t 
 	outputPinKeyCarries := mustSequenceMappingByScalarField(t, checks, "id", "output_pin_key_carries_validation")
 	assertScalarContains(t, mustMappingValue(t, outputPinKeyCarries, "trigger"), "missing key/carries evidence")
 	assertScalarContains(t, mustMappingValue(t, outputPinKeyCarries, "trigger"), "Agent emit_events")
+	assertScalarContains(t, mustMappingValue(t, outputPinKeyCarries, "trigger"), "auto_emit_on_create")
 
 	bootSteps := mustYAMLPath(t, root, "engine", "boot_sequence", "steps")
 	validatePins := mustSequenceMappingByScalarField(t, bootSteps, "name", "validate_pins")

--- a/internal/apispec/platform_spec_composition_routing_test.go
+++ b/internal/apispec/platform_spec_composition_routing_test.go
@@ -21,6 +21,10 @@ func TestPlatformSpecCompositionRoutingSourceAuthority(t *testing.T) {
 	assertScalarContains(t, mustMappingValue(t, composition, "rule"), "Producer emit sites MUST NOT own consumer routing")
 
 	authored := mustMappingValue(t, composition, "authored_shapes")
+	outputPin := mustMappingValue(t, authored, "output_event_pin")
+	assertScalarContains(t, mustMappingValue(t, outputPin, "canonical_form"), "{name, event, key, carries}")
+	assertScalarContains(t, mustMappingValue(t, outputPin, "canonical_form"), "MUST include `key`")
+	assertScalarContains(t, mustMappingValue(t, outputPin, "scalar_form"), "fails closed")
 	addressed := mustMappingValue(t, authored, "addressed_input_pin")
 	assertScalarContains(t, mustMappingValue(t, addressed, "canonical_form"), "{name, event, address}")
 	assertScalarContains(t, mustYAMLPath(t, addressed, "address_fields", "cardinality"), "one and many")
@@ -33,6 +37,7 @@ func TestPlatformSpecCompositionRoutingSourceAuthority(t *testing.T) {
 
 	ownership := mustMappingValue(t, composition, "ownership_split")
 	assertScalarContains(t, mustMappingValue(t, ownership, "parent_connect"), "owns inter-flow delivery topology")
+	assertScalarContains(t, mustMappingValue(t, ownership, "output_pins"), "key/carries evidence")
 	assertScalarContains(t, mustMappingValue(t, ownership, "input_pins"), "receiver address resolution")
 	assertScalarContains(t, mustMappingValue(t, ownership, "producer_emit_target"), "exceptional dynamic routing")
 
@@ -60,6 +65,7 @@ func TestPlatformSpecCompositionRoutingSourceAuthority(t *testing.T) {
 	assertScalarValue(t, mustMappingValue(t, lowering, "owner"), "platform-spec.yaml#flow_model.flow_package.composition_routing.route_plan_lowering")
 	for _, want := range []string{
 		"parent package.yaml connect entries",
+		"producer output pin event identity and verified key/carries evidence, including explicit package-root `.pin_name` output endpoints",
 		"receiver addressed input pin rules",
 		"import-boundary pin alias bindings",
 	} {
@@ -189,6 +195,10 @@ func TestPlatformSpecCompositionRoutingCatalogSurfacesConsumeConnectAuthority(t 
 	assertScalarContains(t, mustMappingValue(t, pinTargetResolution, "trigger"), "explicit target escape hatch")
 	assertScalarContains(t, mustMappingValue(t, pinTargetResolution, "trigger"), "eligible static child delivery-entity route")
 	assertScalarContains(t, mustMappingValue(t, pinTargetResolution, "trigger"), "producer target/broadcast")
+
+	outputPinKeyCarries := mustSequenceMappingByScalarField(t, checks, "id", "output_pin_key_carries_validation")
+	assertScalarContains(t, mustMappingValue(t, outputPinKeyCarries, "trigger"), "missing key/carries evidence")
+	assertScalarContains(t, mustMappingValue(t, outputPinKeyCarries, "trigger"), "Agent emit_events")
 
 	bootSteps := mustYAMLPath(t, root, "engine", "boot_sequence", "steps")
 	validatePins := mustSequenceMappingByScalarField(t, bootSteps, "name", "validate_pins")

--- a/internal/apispec/platform_spec_flow_instance_authoring_test.go
+++ b/internal/apispec/platform_spec_flow_instance_authoring_test.go
@@ -132,6 +132,12 @@ func TestPlatformSpecFlowInstanceAuthoringSourceAuthority(t *testing.T) {
 	assertScalarValue(t, mustYAMLPath(t, composition, "split_children", "output_pin_key_carries"), "#1544")
 	assertScalarValue(t, mustYAMLPath(t, composition, "split_children", "connect_to_instance_route_planning"), "#1545")
 	assertScalarValue(t, mustYAMLPath(t, composition, "split_children", "connect_key_adapters"), "#1546")
+	outputContract := mustMappingValue(t, composition, "output_pin_key_carries_contract")
+	assertScalarValue(t, mustMappingValue(t, outputContract, "implementation_tracker"), "#1544")
+	assertScalarContains(t, mustMappingValue(t, outputContract, "canonical_code_owner"), "FlowOutputEventPin")
+	assertScalarContains(t, mustMappingValue(t, outputContract, "canonical_code_owner"), "checkOutputPinKeyCarriesValidation")
+	assertScalarContains(t, mustMappingValue(t, outputContract, "rule"), "MUST declare `key` and `carries`")
+	assertScalarContains(t, mustMappingValue(t, outputContract, "non_authoritative_paths"), "connect.map")
 
 	contained := mustMappingValue(t, authoring, "contained_state_model")
 	assertScalarValue(t, mustMappingValue(t, contained, "implementation_tracker"), "#1548")

--- a/internal/runtime/bootverify/checks.go
+++ b/internal/runtime/bootverify/checks.go
@@ -250,6 +250,7 @@ var bootCheckRegistry = []Check{
 	{ID: "flow_package_dependency_binding", Severity: SeverityHardInvalidity, Run: checkFlowPackageDependencyBinding},
 	{ID: "flow_package_pin_bind_alias_validation", Severity: SeverityHardInvalidity, Run: checkFlowPackagePinBindAliasValidation},
 	{ID: "flow_package_wildcard_observe_grant", Severity: SeverityHardInvalidity, Run: checkFlowPackageWildcardObserveGrant},
+	{ID: "output_pin_key_carries_validation", Severity: "error", Run: checkOutputPinKeyCarriesValidation},
 	{ID: "composition_connect_validation", Severity: "error", Run: checkCompositionConnectValidation},
 	{ID: "input_pin_wiring", Severity: "warning", Run: checkInputPinWiring},
 	{ID: "pin_target_resolution", Severity: "error", Run: checkPinTargetResolution},

--- a/internal/runtime/bootverify/flow_data_access_test.go
+++ b/internal/runtime/bootverify/flow_data_access_test.go
@@ -66,8 +66,8 @@ func TestRun_ValidatesFlowDataAccessDeclarations(t *testing.T) {
 }
 
 func TestBootCheckRegistry_HasFlowDataAccessCheckCount(t *testing.T) {
-	if got := len(bootCheckRegistry); got != 61 {
-		t.Fatalf("bootCheckRegistry count = %d, want 61", got)
+	if got := len(bootCheckRegistry); got != 62 {
+		t.Fatalf("bootCheckRegistry count = %d, want 62", got)
 	}
 }
 

--- a/internal/runtime/bootverify/report_test.go
+++ b/internal/runtime/bootverify/report_test.go
@@ -4747,8 +4747,8 @@ func TestRun_ReportsMissingRuntimeExecutorForOwnedRuntimeEvent(t *testing.T) {
 }
 
 func TestBootCheckRegistry_HasSpecCheckCount(t *testing.T) {
-	if got := len(bootCheckRegistry); got != 61 {
-		t.Fatalf("bootCheckRegistry count = %d, want 61", got)
+	if got := len(bootCheckRegistry); got != 62 {
+		t.Fatalf("bootCheckRegistry count = %d, want 62", got)
 	}
 	if got := len(supplementalChecks); got != 3 {
 		t.Fatalf("supplementalChecks count = %d, want 3", got)

--- a/internal/runtime/bootverify/workflow_composition_connect_checks.go
+++ b/internal/runtime/bootverify/workflow_composition_connect_checks.go
@@ -224,7 +224,7 @@ func validateCompositionConnectAddress(source semanticview.Source, connect runti
 	if targetExpr == "" {
 		targetExpr = "entity." + address.By
 	}
-	sourceType, err := compositionConnectSourceType(source, producerFlowID, outputPin.EventType(), sourceExpr)
+	sourceType, err := outputPinKeyCarriesSourceType(source, producerFlowID, outputPin, sourceExpr)
 	if err != nil {
 		return []Finding{compositionConnectFinding(connect, "output_carries_address_key", err.Error(), producerFlowID)}
 	}
@@ -239,39 +239,6 @@ func validateCompositionConnectAddress(source semanticview.Source, connect runti
 		return []Finding{compositionConnectFinding(connect, "key_types_incompatible", fmt.Sprintf("source %s type %s is incompatible with target %s type %s", sourceExpr, sourceType, targetExpr, targetType), receiverFlowID)}
 	}
 	return nil
-}
-
-func compositionConnectSourceType(source semanticview.Source, flowID, eventType, expr string) (string, error) {
-	expr = strings.TrimSpace(expr)
-	if expr == "" {
-		return "", fmt.Errorf("source expression is required")
-	}
-	if strings.HasPrefix(expr, "event.source.") {
-		return "string", nil
-	}
-	if !strings.HasPrefix(expr, "payload.") {
-		return "", fmt.Errorf("source expression %q must be payload.* or event.source.*", expr)
-	}
-	fieldPath := strings.TrimPrefix(expr, "payload.")
-	if fieldPath == "" || strings.Contains(fieldPath, ".") {
-		return "", fmt.Errorf("source expression %q must reference a single payload field", expr)
-	}
-	resolution := semanticview.ResolveEventSchema(source, flowID, eventType)
-	if !resolution.HasSchema {
-		return "", fmt.Errorf("producer output event %s has no payload schema", eventType)
-	}
-	props, _ := resolution.Schema.Schema["properties"].(map[string]any)
-	raw, ok := props[fieldPath]
-	if !ok {
-		return "", fmt.Errorf("producer output event %s does not carry payload field %s", eventType, fieldPath)
-	}
-	prop, _ := raw.(map[string]any)
-	typ, _ := prop["type"].(string)
-	typ = strings.TrimSpace(typ)
-	if typ == "" {
-		return "", fmt.Errorf("producer output event %s payload field %s has no scalar type", eventType, fieldPath)
-	}
-	return typ, nil
 }
 
 func compositionConnectTargetType(source semanticview.Source, flowID, expr string) (string, error) {

--- a/internal/runtime/bootverify/workflow_composition_connect_checks_test.go
+++ b/internal/runtime/bootverify/workflow_composition_connect_checks_test.go
@@ -230,6 +230,11 @@ func TestRun_FailsClosedForInvalidOutputPinKeyCarriesEvidence(t *testing.T) {
 			opts: compositionConnectFixtureOptions{producerAutoEmit: true},
 			want: "auto_emit_payload_unproven",
 		},
+		{
+			name: "workflow timer cannot prove carried field",
+			opts: compositionConnectFixtureOptions{producerTimer: true},
+			want: "timer_payload_unproven",
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -242,6 +247,17 @@ func TestRun_FailsClosedForInvalidOutputPinKeyCarriesEvidence(t *testing.T) {
 				t.Fatalf("expected output_pin_key_carries_validation %q, got %#v", tc.want, report.Errors())
 			}
 		})
+	}
+}
+
+func TestRun_FailsClosedForRootAutoEmitOutputPinKeyCarriesEvidence(t *testing.T) {
+	root := writeRootAutoEmitOutputPinKeyCarriesFixture(t)
+	bundle := loadFixtureBundleAt(t, repoRootForBootverifyTest(t), root, runtimecontracts.DefaultPlatformSpecFile(repoRootForBootverifyTest(t)))
+
+	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+
+	if !reportContains(report.Errors(), "output_pin_key_carries_validation", "auto_emit_payload_unproven") {
+		t.Fatalf("expected root auto_emit output_pin_key_carries_validation error, got %#v", report.Errors())
 	}
 }
 
@@ -353,6 +369,7 @@ type compositionConnectFixtureOptions struct {
 	producerVerticalIDType     string
 	producerAgentEmit          bool
 	producerAutoEmit           bool
+	producerTimer              bool
 	duplicateProducerOutputKey bool
 }
 
@@ -486,6 +503,77 @@ root.ready:
   entity_id: text
 `)
 	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "consumer", "entities.yaml"), "{}\n")
+	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "consumer", "nodes.yaml"), "{}\n")
+	return root
+}
+
+func writeRootAutoEmitOutputPinKeyCarriesFixture(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	writeBootverifyFixtureFile(t, filepath.Join(root, "package.yaml"), `
+name: root-auto-emit-key-carries
+version: "1.0.0"
+platform_version: ">=1.6.0"
+flows:
+  - id: consumer
+    flow: consumer
+    mode: static
+connect:
+  - from: .root_ready
+    to: consumer.ready
+    delivery: one
+    map:
+      entity_id:
+        source: payload.entity_id
+        target: entity.entity_id
+`)
+	writeBootverifyFixtureFile(t, filepath.Join(root, "schema.yaml"), `
+name: root-auto-emit-key-carries
+auto_emit_on_create:
+  event: root.ready
+pins:
+  outputs:
+    events:
+      - name: root_ready
+        event: root.ready
+        key: entity_id
+        carries: [entity_id]
+`)
+	writeBootverifyFixtureFile(t, filepath.Join(root, "policy.yaml"), "{}\n")
+	writeBootverifyFixtureFile(t, filepath.Join(root, "tools.yaml"), "{}\n")
+	writeBootverifyFixtureFile(t, filepath.Join(root, "agents.yaml"), "{}\n")
+	writeBootverifyFixtureFile(t, filepath.Join(root, "events.yaml"), `
+root.ready:
+  entity_id: string
+`)
+	writeBootverifyFixtureFile(t, filepath.Join(root, "nodes.yaml"), "{}\n")
+	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "consumer", "schema.yaml"), `
+name: consumer
+mode: static
+pins:
+  inputs:
+    events:
+      - name: ready
+        event: root.ready
+        address:
+          by: entity_id
+          source: payload.entity_id
+          target: entity.entity_id
+          cardinality: one
+`)
+	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "consumer", "policy.yaml"), "{}\n")
+	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "consumer", "agents.yaml"), "{}\n")
+	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "consumer", "events.yaml"), `
+root.ready:
+  entity_id: string
+`)
+	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "consumer", "entities.yaml"), `
+deployment:
+  entity_id:
+    type: string
+    indexed: true
+    _unused_reason: root output pin key/carries receiver address proof field
+`)
 	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "consumer", "nodes.yaml"), "{}\n")
 	return root
 }
@@ -722,6 +810,7 @@ producer-node:
   id: producer-node
   execution_type: system_node
   subscribes_to: [deploy.requested]
+`+producerWorkflowTimerBlock(opts)+`
   event_handlers:
     deploy.requested:
       emit:
@@ -729,6 +818,19 @@ producer-node:
         fields:
 `+emitField+`
 `)
+}
+
+func producerWorkflowTimerBlock(opts compositionConnectFixtureOptions) string {
+	if !opts.producerTimer {
+		return ""
+	}
+	return `  timers:
+    - id: deploy_done_timer
+      owner: producer-node
+      event: deploy.done
+      delay: 1m
+      start_on: event:deploy.requested
+`
 }
 
 func producerAutoEmitOnCreateBlock(opts compositionConnectFixtureOptions) string {

--- a/internal/runtime/bootverify/workflow_composition_connect_checks_test.go
+++ b/internal/runtime/bootverify/workflow_composition_connect_checks_test.go
@@ -170,6 +170,76 @@ func TestRun_FailsClosedForInvalidParentCompositionConnect(t *testing.T) {
 	}
 }
 
+func TestRun_FailsClosedForInvalidOutputPinKeyCarriesEvidence(t *testing.T) {
+	tests := []struct {
+		name string
+		opts compositionConnectFixtureOptions
+		want string
+	}{
+		{
+			name: "connected output missing key",
+			opts: compositionConnectFixtureOptions{omitProducerOutputKey: true},
+			want: "missing_key",
+		},
+		{
+			name: "connected output missing carries",
+			opts: compositionConnectFixtureOptions{omitProducerOutputCarries: true},
+			want: "missing_carries",
+		},
+		{
+			name: "key not listed in carries",
+			opts: compositionConnectFixtureOptions{producerOutputCarries: "[component_id]"},
+			want: "key_not_carried",
+		},
+		{
+			name: "duplicate carried field",
+			opts: compositionConnectFixtureOptions{producerOutputCarries: "[vertical_id, vertical_id]"},
+			want: "duplicate_carry_field",
+		},
+		{
+			name: "ambiguous output key",
+			opts: compositionConnectFixtureOptions{duplicateProducerOutputKey: true},
+			want: "ambiguous_output_key",
+		},
+		{
+			name: "declared key missing from event payload schema",
+			opts: compositionConnectFixtureOptions{
+				producerOutputKey:     "component_id",
+				producerOutputCarries: "[component_id]",
+				mapSource:             "payload.component_id",
+			},
+			want: "does not declare payload field component_id",
+		},
+		{
+			name: "declared key is not scalar",
+			opts: compositionConnectFixtureOptions{producerVerticalIDType: "[string]"},
+			want: "not a scalar key type",
+		},
+		{
+			name: "node emit does not prove carried field",
+			opts: compositionConnectFixtureOptions{omitProducerEmitField: true},
+			want: "emit_payload_missing_key",
+		},
+		{
+			name: "agent emit_events cannot prove carried field",
+			opts: compositionConnectFixtureOptions{producerAgentEmit: true},
+			want: "agent_emit_payload_unproven",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			root := writeCompositionConnectBootverifyFixture(t, tc.opts)
+			bundle := loadFixtureBundleAt(t, repoRootForBootverifyTest(t), root, runtimecontracts.DefaultPlatformSpecFile(repoRootForBootverifyTest(t)))
+
+			report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+
+			if !reportContains(report.Errors(), "output_pin_key_carries_validation", tc.want) {
+				t.Fatalf("expected output_pin_key_carries_validation %q, got %#v", tc.want, report.Errors())
+			}
+		})
+	}
+}
+
 func TestRun_AllowsImportBoundaryAliasAsConnectEventAdapter(t *testing.T) {
 	root := writeCompositionConnectBootverifyFixture(t, compositionConnectFixtureOptions{
 		consumerRequiresInput: true,
@@ -242,21 +312,29 @@ func TestRun_TreatsParentCompositionConnectAsEventTopologyProof(t *testing.T) {
 }
 
 type compositionConnectFixtureOptions struct {
-	connectFrom             string
-	connectTo               string
-	delivery                string
-	noAdapter               bool
-	mapSource               string
-	mapTarget               string
-	omitMap                 bool
-	consumerMode            string
-	consumerScalarInput     bool
-	consumerEntityType      string
-	consumerEntityUnindexed bool
-	consumerRequiresInput   bool
-	consumerInputBind       string
-	producerRequiresOutput  bool
-	producerOutputBind      string
+	connectFrom                string
+	connectTo                  string
+	delivery                   string
+	noAdapter                  bool
+	mapSource                  string
+	mapTarget                  string
+	omitMap                    bool
+	consumerMode               string
+	consumerScalarInput        bool
+	consumerEntityType         string
+	consumerEntityUnindexed    bool
+	consumerRequiresInput      bool
+	consumerInputBind          string
+	producerRequiresOutput     bool
+	producerOutputBind         string
+	producerOutputKey          string
+	producerOutputCarries      string
+	omitProducerOutputKey      bool
+	omitProducerOutputCarries  bool
+	omitProducerEmitField      bool
+	producerVerticalIDType     string
+	producerAgentEmit          bool
+	duplicateProducerOutputKey bool
 }
 
 func writeCompositionConnectBootverifyFixture(t *testing.T, opts compositionConnectFixtureOptions) string {
@@ -509,6 +587,8 @@ pins:
     events:
       - name: deploy_done
         event: deploy.done
+        key: vertical_id
+        carries: [vertical_id]
 `)
 	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "producer", "policy.yaml"), "{}\n")
 	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "producer", "agents.yaml"), "{}\n")
@@ -563,6 +643,26 @@ requires:
   outputs: [deploy.done]
 `)
 	}
+	outputKeyBlock := ""
+	if !opts.omitProducerOutputKey {
+		outputKeyBlock += "\n        key: " + firstTestValue(opts.producerOutputKey, "vertical_id")
+	}
+	if !opts.omitProducerOutputCarries {
+		outputKeyBlock += "\n        carries: " + firstTestValue(opts.producerOutputCarries, "[vertical_id]")
+	}
+	duplicateOutputPinBlock := ""
+	if opts.duplicateProducerOutputKey {
+		duplicateOutputPinBlock = `
+      - name: deploy_done_alias
+        event: deploy.done
+        key: vertical_id
+        carries: [vertical_id]
+`
+	}
+	emitField := "          vertical_id: payload.vertical_id\n"
+	if opts.omitProducerEmitField {
+		emitField = ""
+	}
 	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "producer", "schema.yaml"), `
 name: producer
 mode: static
@@ -571,18 +671,32 @@ pins:
     events:
       - name: deploy_done
         event: deploy.done
+`+outputKeyBlock+`
+`+duplicateOutputPinBlock+`
 `)
 	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "producer", "policy.yaml"), "{}\n")
-	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "producer", "agents.yaml"), "{}\n")
 	if !opts.producerRequiresOutput {
 		writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "producer", "entities.yaml"), "{}\n")
 	}
+	verticalIDType := firstTestValue(opts.producerVerticalIDType, "string")
+	verticalIDSchema := "  vertical_id: " + verticalIDType + "\n"
 	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "producer", "events.yaml"), `
 deploy.requested:
   vertical_id: string
 deploy.done:
-  vertical_id: string
+`+verticalIDSchema+`
 `)
+	producerAgents := "{}\n"
+	if opts.producerAgentEmit {
+		producerAgents = `
+producer-agent:
+  id: producer-agent
+  type: claude
+  role: producer
+  emit_events: [deploy.done]
+`
+	}
+	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "producer", "agents.yaml"), producerAgents)
 	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "producer", "nodes.yaml"), `
 producer-node:
   id: producer-node
@@ -593,7 +707,7 @@ producer-node:
       emit:
         event: deploy.done
         fields:
-          vertical_id: payload.vertical_id
+`+emitField+`
 `)
 }
 

--- a/internal/runtime/bootverify/workflow_composition_connect_checks_test.go
+++ b/internal/runtime/bootverify/workflow_composition_connect_checks_test.go
@@ -225,6 +225,11 @@ func TestRun_FailsClosedForInvalidOutputPinKeyCarriesEvidence(t *testing.T) {
 			opts: compositionConnectFixtureOptions{producerAgentEmit: true},
 			want: "agent_emit_payload_unproven",
 		},
+		{
+			name: "auto_emit_on_create cannot prove carried field",
+			opts: compositionConnectFixtureOptions{producerAutoEmit: true},
+			want: "auto_emit_payload_unproven",
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -347,6 +352,7 @@ type compositionConnectFixtureOptions struct {
 	omitProducerEmitField      bool
 	producerVerticalIDType     string
 	producerAgentEmit          bool
+	producerAutoEmit           bool
 	duplicateProducerOutputKey bool
 }
 
@@ -679,6 +685,7 @@ requires:
 	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "producer", "schema.yaml"), `
 name: producer
 mode: static
+`+producerAutoEmitOnCreateBlock(opts)+`
 pins:
   outputs:
     events:
@@ -722,6 +729,15 @@ producer-node:
         fields:
 `+emitField+`
 `)
+}
+
+func producerAutoEmitOnCreateBlock(opts compositionConnectFixtureOptions) string {
+	if !opts.producerAutoEmit {
+		return ""
+	}
+	return `auto_emit_on_create:
+  event: deploy.done
+`
 }
 
 func writeCompositionConnectConsumerFlow(t *testing.T, root string, opts compositionConnectFixtureOptions) {

--- a/internal/runtime/bootverify/workflow_composition_connect_checks_test.go
+++ b/internal/runtime/bootverify/workflow_composition_connect_checks_test.go
@@ -240,6 +240,19 @@ func TestRun_FailsClosedForInvalidOutputPinKeyCarriesEvidence(t *testing.T) {
 	}
 }
 
+func TestOutputPinKeyCarriesPinsForEventIgnoresPublicPinName(t *testing.T) {
+	root := writeCompositionConnectBootverifyFixture(t, compositionConnectFixtureOptions{})
+	bundle := loadFixtureBundleAt(t, repoRootForBootverifyTest(t), root, runtimecontracts.DefaultPlatformSpecFile(repoRootForBootverifyTest(t)))
+	source := semanticview.Wrap(bundle)
+
+	if got := outputPinKeyCarriesPinsForEvent(source, "producer", "deploy_done"); len(got) != 0 {
+		t.Fatalf("output pins for public pin name deploy_done = %#v, want none", got)
+	}
+	if got := outputPinKeyCarriesPinsForEvent(source, "producer", "deploy.done"); len(got) != 1 || got[0].PinName() != "deploy_done" {
+		t.Fatalf("output pins for emitted event deploy.done = %#v, want deploy_done pin", got)
+	}
+}
+
 func TestRun_AllowsImportBoundaryAliasAsConnectEventAdapter(t *testing.T) {
 	root := writeCompositionConnectBootverifyFixture(t, compositionConnectFixtureOptions{
 		consumerRequiresInput: true,

--- a/internal/runtime/bootverify/workflow_output_pin_key_carries_checks.go
+++ b/internal/runtime/bootverify/workflow_output_pin_key_carries_checks.go
@@ -1,0 +1,325 @@
+package bootverify
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
+	"github.com/division-sh/swarm/internal/runtime/core/eventidentity"
+	"github.com/division-sh/swarm/internal/runtime/semanticview"
+)
+
+const outputPinKeyCarriesCheckID = "output_pin_key_carries_validation"
+
+type outputPinKeyCarriesIdentity struct {
+	FlowID  string
+	PinName string
+}
+
+func checkOutputPinKeyCarriesValidation(c *checkerContext) []Finding {
+	if c == nil || c.source == nil {
+		return nil
+	}
+	source := c.source
+	addressedConnects := outputPinKeyCarriesAddressedConnects(source)
+	var findings []Finding
+	for _, flowID := range outputPinKeyCarriesFlowIDs(source) {
+		findings = append(findings, validateOutputPinKeyCarriesForFlow(source, flowID, addressedConnects)...)
+	}
+	findings = append(findings, validateOutputPinKeyCarriesNodeEmitSites(source)...)
+	findings = append(findings, validateOutputPinKeyCarriesAgentEmitSites(source)...)
+	sort.SliceStable(findings, func(i, j int) bool {
+		if findings[i].Location != findings[j].Location {
+			return findings[i].Location < findings[j].Location
+		}
+		return findings[i].Message < findings[j].Message
+	})
+	return findings
+}
+
+func validateOutputPinKeyCarriesForFlow(source semanticview.Source, flowID string, addressedConnects map[outputPinKeyCarriesIdentity]struct{}) []Finding {
+	var findings []Finding
+	seenEventKeys := map[string]string{}
+	for _, pin := range source.FlowOutputEventPins(flowID) {
+		identity := outputPinKeyCarriesIdentity{FlowID: strings.TrimSpace(flowID), PinName: pin.PinName()}
+		_, requiredByAddressedConnect := addressedConnects[identity]
+		if requiredByAddressedConnect || outputPinHasKeyCarries(pin) {
+			findings = append(findings, validateOutputPinKeyCarriesDeclaration(source, flowID, pin, requiredByAddressedConnect)...)
+		}
+		if strings.TrimSpace(pin.Key) == "" {
+			continue
+		}
+		eventKey := eventidentity.Normalize(source.ResolveFlowEventReference(flowID, pin.EventType()))
+		if eventKey == "" {
+			eventKey = eventidentity.Normalize(pin.EventType())
+		}
+		ambiguityKey := eventKey + "\x00" + strings.TrimSpace(pin.Key)
+		if previous := seenEventKeys[ambiguityKey]; previous != "" {
+			findings = append(findings, outputPinKeyCarriesFinding(flowID, pin, "ambiguous_output_key", fmt.Sprintf("output pins %s and %s both declare key %s for event %s", previous, pin.PinName(), strings.TrimSpace(pin.Key), pin.EventType())))
+			continue
+		}
+		seenEventKeys[ambiguityKey] = pin.PinName()
+	}
+	return findings
+}
+
+func validateOutputPinKeyCarriesDeclaration(source semanticview.Source, flowID string, pin runtimecontracts.FlowOutputEventPin, required bool) []Finding {
+	var findings []Finding
+	key := strings.TrimSpace(pin.Key)
+	carries := outputPinCarries(pin)
+	if required && key == "" {
+		findings = append(findings, outputPinKeyCarriesFinding(flowID, pin, "missing_key", "connected output pin must declare key before it can provide instance-key producer evidence"))
+	}
+	if required && len(carries) == 0 {
+		findings = append(findings, outputPinKeyCarriesFinding(flowID, pin, "missing_carries", "connected output pin must declare carries before it can provide instance-key producer evidence"))
+	}
+	if key == "" && len(carries) > 0 {
+		findings = append(findings, outputPinKeyCarriesFinding(flowID, pin, "missing_key", "output pin declares carries without a key"))
+	}
+	if key != "" && !outputPinStringSetContains(carries, key) {
+		findings = append(findings, outputPinKeyCarriesFinding(flowID, pin, "key_not_carried", fmt.Sprintf("output pin key %s must also appear in carries", key)))
+	}
+	seen := map[string]struct{}{}
+	for _, field := range carries {
+		if strings.TrimSpace(field) == "" {
+			findings = append(findings, outputPinKeyCarriesFinding(flowID, pin, "empty_carry_field", "output pin carries includes an empty field"))
+			continue
+		}
+		if strings.Contains(field, ".") {
+			findings = append(findings, outputPinKeyCarriesFinding(flowID, pin, "nested_carry_field", fmt.Sprintf("output pin carry %s must be a top-level payload field in this slice", field)))
+			continue
+		}
+		if _, ok := seen[field]; ok {
+			findings = append(findings, outputPinKeyCarriesFinding(flowID, pin, "duplicate_carry_field", fmt.Sprintf("output pin carries declares %s more than once", field)))
+			continue
+		}
+		seen[field] = struct{}{}
+	}
+	for _, field := range outputPinRequiredFields(pin) {
+		typ, err := outputPinPayloadFieldType(source, flowID, pin.EventType(), field)
+		if err != nil {
+			findings = append(findings, outputPinKeyCarriesFinding(flowID, pin, "payload_field_unproven", err.Error()))
+			continue
+		}
+		if !outputPinScalarType(typ) {
+			findings = append(findings, outputPinKeyCarriesFinding(flowID, pin, "payload_field_not_scalar", fmt.Sprintf("producer output event %s payload field %s type %s is not a scalar key type", pin.EventType(), field, typ)))
+		}
+	}
+	return findings
+}
+
+func validateOutputPinKeyCarriesNodeEmitSites(source semanticview.Source) []Finding {
+	var findings []Finding
+	seen := map[string]struct{}{}
+	for _, site := range pinRoutingEmitSites(source) {
+		for _, pin := range outputPinKeyCarriesPinsForEvent(source, site.FlowID, site.Spec.EventType()) {
+			for _, field := range outputPinRequiredFields(pin) {
+				if _, ok := site.Spec.Fields[field]; ok {
+					continue
+				}
+				key := site.ID + "\x00" + pin.PinName() + "\x00" + field
+				if _, ok := seen[key]; ok {
+					continue
+				}
+				seen[key] = struct{}{}
+				findings = append(findings, outputPinKeyCarriesFinding(site.FlowID, pin, "emit_payload_missing_key", fmt.Sprintf("node %s emit site %s emits output pin %s event %s but emit.fields does not statically prove carried field %s", site.NodeID, site.Site, pin.PinName(), pin.EventType(), field)))
+			}
+		}
+	}
+	return findings
+}
+
+func validateOutputPinKeyCarriesAgentEmitSites(source semanticview.Source) []Finding {
+	var findings []Finding
+	for _, site := range pinRoutingAgentEmitSites(source) {
+		for _, pin := range outputPinKeyCarriesPinsForEvent(source, site.FlowID, site.EventType) {
+			if len(outputPinRequiredFields(pin)) == 0 {
+				continue
+			}
+			findings = append(findings, outputPinKeyCarriesFinding(site.FlowID, pin, "agent_emit_payload_unproven", fmt.Sprintf("agent %s emit_events declares output pin %s event %s, but agent emit_events has no static payload construction surface for key/carries fields %s", site.AgentID, pin.PinName(), pin.EventType(), strings.Join(outputPinRequiredFields(pin), ", "))))
+		}
+	}
+	return findings
+}
+
+func outputPinKeyCarriesSourceType(source semanticview.Source, flowID string, pin runtimecontracts.FlowOutputEventPin, expr string) (string, error) {
+	expr = strings.TrimSpace(expr)
+	if expr == "" {
+		return "", fmt.Errorf("source expression is required")
+	}
+	if !strings.HasPrefix(expr, "payload.") {
+		return "", fmt.Errorf("source expression %q must reference the producer output pin key as payload.<key>", expr)
+	}
+	field := strings.TrimSpace(strings.TrimPrefix(expr, "payload."))
+	if field == "" || strings.Contains(field, ".") {
+		return "", fmt.Errorf("source expression %q must reference a single top-level payload field", expr)
+	}
+	key := strings.TrimSpace(pin.Key)
+	if key == "" {
+		return "", fmt.Errorf("producer output pin %s must declare key before it can supply %s", pin.PinName(), expr)
+	}
+	if field != key {
+		return "", fmt.Errorf("source expression %s does not match producer output pin key %s; renamed-key adapters are tracked by #1546", expr, key)
+	}
+	carries := outputPinCarries(pin)
+	if !outputPinStringSetContains(carries, key) {
+		return "", fmt.Errorf("producer output pin %s must include key %s in carries", pin.PinName(), key)
+	}
+	typ, err := outputPinPayloadFieldType(source, flowID, pin.EventType(), field)
+	if err != nil {
+		return "", err
+	}
+	if !outputPinScalarType(typ) {
+		return "", fmt.Errorf("producer output event %s payload field %s type %s is not a scalar key type", pin.EventType(), field, typ)
+	}
+	return typ, nil
+}
+
+func outputPinPayloadFieldType(source semanticview.Source, flowID, eventType, field string) (string, error) {
+	field = strings.TrimSpace(field)
+	if field == "" {
+		return "", fmt.Errorf("producer output event %s key/carries field is empty", eventType)
+	}
+	resolution := semanticview.ResolveEventSchema(source, flowID, eventType)
+	if !resolution.HasSchema {
+		return "", fmt.Errorf("producer output event %s has no payload schema", eventType)
+	}
+	props, _ := resolution.Schema.Schema["properties"].(map[string]any)
+	raw, ok := props[field]
+	if !ok {
+		return "", fmt.Errorf("producer output event %s does not declare payload field %s required by output pin key/carries", eventType, field)
+	}
+	prop, _ := raw.(map[string]any)
+	typ, _ := prop["type"].(string)
+	typ = strings.TrimSpace(typ)
+	if typ == "" {
+		return "", fmt.Errorf("producer output event %s payload field %s has no scalar type", eventType, field)
+	}
+	return typ, nil
+}
+
+func outputPinKeyCarriesAddressedConnects(source semanticview.Source) map[outputPinKeyCarriesIdentity]struct{} {
+	out := map[outputPinKeyCarriesIdentity]struct{}{}
+	if source == nil {
+		return out
+	}
+	for _, connect := range source.CompositionConnects() {
+		from, fromErr := connect.FromRef()
+		to, toErr := connect.ToRef()
+		if fromErr != nil || toErr != nil || to.Root {
+			continue
+		}
+		inputPin, ok := source.FlowInputEventPin(to.FlowID, to.Pin)
+		if !ok || inputPin.Address == nil {
+			continue
+		}
+		out[outputPinKeyCarriesIdentity{FlowID: strings.TrimSpace(from.FlowID), PinName: strings.TrimSpace(from.Pin)}] = struct{}{}
+	}
+	return out
+}
+
+func outputPinKeyCarriesFlowIDs(source semanticview.Source) []string {
+	seen := map[string]struct{}{"": {}}
+	for flowID := range source.FlowSchemaEntries() {
+		flowID = strings.TrimSpace(flowID)
+		if flowID == "" {
+			continue
+		}
+		seen[flowID] = struct{}{}
+	}
+	out := make([]string, 0, len(seen))
+	for flowID := range seen {
+		out = append(out, flowID)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func outputPinKeyCarriesPinsForEvent(source semanticview.Source, flowID, eventType string) []runtimecontracts.FlowOutputEventPin {
+	if source == nil {
+		return nil
+	}
+	eventType = strings.TrimSpace(eventType)
+	if eventType == "" {
+		return nil
+	}
+	normalizedEvent := eventidentity.Normalize(eventType)
+	resolvedEvent := eventidentity.Normalize(source.ResolveFlowEventReference(flowID, eventType))
+	var out []runtimecontracts.FlowOutputEventPin
+	for _, pin := range source.FlowOutputEventPins(flowID) {
+		pinName := eventidentity.Normalize(pin.PinName())
+		pinEvent := eventidentity.Normalize(pin.EventType())
+		pinResolved := eventidentity.Normalize(source.ResolveFlowEventReference(flowID, pin.EventType()))
+		if normalizedEvent == pinName || normalizedEvent == pinEvent || (resolvedEvent != "" && resolvedEvent == pinResolved) {
+			out = append(out, pin)
+		}
+	}
+	return out
+}
+
+func outputPinHasKeyCarries(pin runtimecontracts.FlowOutputEventPin) bool {
+	return strings.TrimSpace(pin.Key) != "" || len(outputPinCarries(pin)) > 0
+}
+
+func outputPinCarries(pin runtimecontracts.FlowOutputEventPin) []string {
+	out := make([]string, 0, len(pin.Carries))
+	for _, field := range pin.Carries {
+		out = append(out, strings.TrimSpace(field))
+	}
+	return out
+}
+
+func outputPinRequiredFields(pin runtimecontracts.FlowOutputEventPin) []string {
+	seen := map[string]struct{}{}
+	var out []string
+	for _, field := range append([]string{strings.TrimSpace(pin.Key)}, outputPinCarries(pin)...) {
+		field = strings.TrimSpace(field)
+		if field == "" {
+			continue
+		}
+		if _, ok := seen[field]; ok {
+			continue
+		}
+		seen[field] = struct{}{}
+		out = append(out, field)
+	}
+	return out
+}
+
+func outputPinScalarType(typ string) bool {
+	switch compositionConnectTypeFamily(typ) {
+	case "string", "number", "boolean":
+		return true
+	default:
+		return false
+	}
+}
+
+func outputPinStringSetContains(values []string, want string) bool {
+	want = strings.TrimSpace(want)
+	if want == "" {
+		return false
+	}
+	for _, value := range values {
+		if strings.TrimSpace(value) == want {
+			return true
+		}
+	}
+	return false
+}
+
+func outputPinKeyCarriesFinding(flowID string, pin runtimecontracts.FlowOutputEventPin, reason, detail string) Finding {
+	location := strings.TrimSpace(flowID)
+	label := "flow " + location
+	if location == "" {
+		location = "root"
+		label = "root"
+	}
+	return Finding{
+		CheckID:  outputPinKeyCarriesCheckID,
+		Severity: "error",
+		Message:  fmt.Sprintf("%s output pin %s is invalid: %s: %s", label, pin.PinName(), reason, detail),
+		Location: location,
+	}
+}

--- a/internal/runtime/bootverify/workflow_output_pin_key_carries_checks.go
+++ b/internal/runtime/bootverify/workflow_output_pin_key_carries_checks.go
@@ -29,6 +29,7 @@ func checkOutputPinKeyCarriesValidation(c *checkerContext) []Finding {
 	}
 	findings = append(findings, validateOutputPinKeyCarriesNodeEmitSites(source)...)
 	findings = append(findings, validateOutputPinKeyCarriesAgentEmitSites(source)...)
+	findings = append(findings, validateOutputPinKeyCarriesAutoEmitSites(source)...)
 	sort.SliceStable(findings, func(i, j int) bool {
 		if findings[i].Location != findings[j].Location {
 			return findings[i].Location < findings[j].Location
@@ -104,6 +105,27 @@ func validateOutputPinKeyCarriesDeclaration(source semanticview.Source, flowID s
 		}
 		if !outputPinScalarType(typ) {
 			findings = append(findings, outputPinKeyCarriesFinding(flowID, pin, "payload_field_not_scalar", fmt.Sprintf("producer output event %s payload field %s type %s is not a scalar key type", pin.EventType(), field, typ)))
+		}
+	}
+	return findings
+}
+
+func validateOutputPinKeyCarriesAutoEmitSites(source semanticview.Source) []Finding {
+	if source == nil {
+		return nil
+	}
+	var findings []Finding
+	for _, scope := range source.FlowScopes() {
+		flowID := strings.TrimSpace(scope.ID)
+		eventType := strings.TrimSpace(scope.AutoEmitEvent)
+		if flowID == "" || eventType == "" {
+			continue
+		}
+		for _, pin := range outputPinKeyCarriesPinsForEvent(source, flowID, eventType) {
+			if len(outputPinRequiredFields(pin)) == 0 {
+				continue
+			}
+			findings = append(findings, outputPinKeyCarriesFinding(flowID, pin, "auto_emit_payload_unproven", fmt.Sprintf("auto_emit_on_create declares output pin %s event %s, but activation config payload cannot be statically proven for key/carries fields %s", pin.PinName(), pin.EventType(), strings.Join(outputPinRequiredFields(pin), ", "))))
 		}
 	}
 	return findings

--- a/internal/runtime/bootverify/workflow_output_pin_key_carries_checks.go
+++ b/internal/runtime/bootverify/workflow_output_pin_key_carries_checks.go
@@ -30,6 +30,7 @@ func checkOutputPinKeyCarriesValidation(c *checkerContext) []Finding {
 	findings = append(findings, validateOutputPinKeyCarriesNodeEmitSites(source)...)
 	findings = append(findings, validateOutputPinKeyCarriesAgentEmitSites(source)...)
 	findings = append(findings, validateOutputPinKeyCarriesAutoEmitSites(source)...)
+	findings = append(findings, validateOutputPinKeyCarriesTimerSites(source)...)
 	sort.SliceStable(findings, func(i, j int) bool {
 		if findings[i].Location != findings[j].Location {
 			return findings[i].Location < findings[j].Location
@@ -115,6 +116,15 @@ func validateOutputPinKeyCarriesAutoEmitSites(source semanticview.Source) []Find
 		return nil
 	}
 	var findings []Finding
+	if bundle, ok := semanticview.Bundle(source); ok && bundle != nil && bundle.RootSchema != nil {
+		eventType := strings.TrimSpace(bundle.RootSchema.AutoEmitOnCreate.Event)
+		for _, pin := range outputPinKeyCarriesPinsForEvent(source, "", eventType) {
+			if len(outputPinRequiredFields(pin)) == 0 {
+				continue
+			}
+			findings = append(findings, outputPinKeyCarriesFinding("", pin, "auto_emit_payload_unproven", fmt.Sprintf("root auto_emit_on_create declares output pin %s event %s, but activation config payload cannot be statically proven for key/carries fields %s", pin.PinName(), pin.EventType(), strings.Join(outputPinRequiredFields(pin), ", "))))
+		}
+	}
 	for _, scope := range source.FlowScopes() {
 		flowID := strings.TrimSpace(scope.ID)
 		eventType := strings.TrimSpace(scope.AutoEmitEvent)
@@ -126,6 +136,27 @@ func validateOutputPinKeyCarriesAutoEmitSites(source semanticview.Source) []Find
 				continue
 			}
 			findings = append(findings, outputPinKeyCarriesFinding(flowID, pin, "auto_emit_payload_unproven", fmt.Sprintf("auto_emit_on_create declares output pin %s event %s, but activation config payload cannot be statically proven for key/carries fields %s", pin.PinName(), pin.EventType(), strings.Join(outputPinRequiredFields(pin), ", "))))
+		}
+	}
+	return findings
+}
+
+func validateOutputPinKeyCarriesTimerSites(source semanticview.Source) []Finding {
+	if source == nil {
+		return nil
+	}
+	var findings []Finding
+	for _, timer := range source.WorkflowTimers() {
+		flowID := strings.TrimSpace(timer.FlowID)
+		eventType := strings.TrimSpace(timer.Event)
+		if eventType == "" {
+			continue
+		}
+		for _, pin := range outputPinKeyCarriesPinsForEvent(source, flowID, eventType) {
+			if len(outputPinRequiredFields(pin)) == 0 {
+				continue
+			}
+			findings = append(findings, outputPinKeyCarriesFinding(flowID, pin, "timer_payload_unproven", fmt.Sprintf("workflow timer %s declares output pin %s event %s, but timer payload construction cannot be statically proven for key/carries fields %s", strings.TrimSpace(timer.ID), pin.PinName(), pin.EventType(), strings.Join(outputPinRequiredFields(pin), ", "))))
 		}
 	}
 	return findings

--- a/internal/runtime/bootverify/workflow_output_pin_key_carries_checks.go
+++ b/internal/runtime/bootverify/workflow_output_pin_key_carries_checks.go
@@ -248,10 +248,9 @@ func outputPinKeyCarriesPinsForEvent(source semanticview.Source, flowID, eventTy
 	resolvedEvent := eventidentity.Normalize(source.ResolveFlowEventReference(flowID, eventType))
 	var out []runtimecontracts.FlowOutputEventPin
 	for _, pin := range source.FlowOutputEventPins(flowID) {
-		pinName := eventidentity.Normalize(pin.PinName())
 		pinEvent := eventidentity.Normalize(pin.EventType())
 		pinResolved := eventidentity.Normalize(source.ResolveFlowEventReference(flowID, pin.EventType()))
-		if normalizedEvent == pinName || normalizedEvent == pinEvent || (resolvedEvent != "" && resolvedEvent == pinResolved) {
+		if normalizedEvent == pinEvent || (resolvedEvent != "" && resolvedEvent == pinResolved) {
 			out = append(out, pin)
 		}
 	}

--- a/internal/runtime/contracts/workflow_contract_connect.go
+++ b/internal/runtime/contracts/workflow_contract_connect.go
@@ -45,8 +45,10 @@ func (p FlowOutputEventPin) EventType() string {
 
 func (p FlowOutputEventPin) normalized() FlowOutputEventPin {
 	out := FlowOutputEventPin{
-		Name:  strings.TrimSpace(p.Name),
-		Event: strings.TrimSpace(p.Event),
+		Name:    strings.TrimSpace(p.Name),
+		Event:   strings.TrimSpace(p.Event),
+		Key:     strings.TrimSpace(p.Key),
+		Carries: normalizeOutputPinCarries(p.Carries),
 	}
 	if out.Event == "" {
 		out.Event = out.Name
@@ -163,6 +165,17 @@ func cloneFlowOutputEventPins(in []FlowOutputEventPin) []FlowOutputEventPin {
 			continue
 		}
 		out = append(out, normalized)
+	}
+	return out
+}
+
+func normalizeOutputPinCarries(in []string) []string {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(in))
+	for _, item := range in {
+		out = append(out, strings.TrimSpace(item))
 	}
 	return out
 }

--- a/internal/runtime/contracts/workflow_contract_types.go
+++ b/internal/runtime/contracts/workflow_contract_types.go
@@ -797,8 +797,10 @@ type FlowInputEventPin struct {
 	Address *FlowInputPinAddress `yaml:"address"`
 }
 type FlowOutputEventPin struct {
-	Name  string `yaml:"name"`
-	Event string `yaml:"event"`
+	Name    string   `yaml:"name"`
+	Event   string   `yaml:"event"`
+	Key     string   `yaml:"key"`
+	Carries []string `yaml:"carries"`
 }
 type FlowInputPinAddress struct {
 	By          string `yaml:"by"`

--- a/internal/runtime/contracts/workflow_contract_yaml_flow.go
+++ b/internal/runtime/contracts/workflow_contract_yaml_flow.go
@@ -290,6 +290,16 @@ func decodeFlowOutputPinEventNode(node *yaml.Node) (FlowOutputEventPin, error) {
 			if err := value.Decode(&out.Event); err != nil {
 				return FlowOutputEventPin{}, fmt.Errorf("output event pin event: %w", err)
 			}
+		case "key":
+			if err := value.Decode(&out.Key); err != nil {
+				return FlowOutputEventPin{}, fmt.Errorf("output event pin key: %w", err)
+			}
+		case "carries":
+			carries, err := decodeFlowOutputPinCarriesNode(value)
+			if err != nil {
+				return FlowOutputEventPin{}, fmt.Errorf("output event pin carries: %w", err)
+			}
+			out.Carries = carries
 		default:
 			return FlowOutputEventPin{}, fmt.Errorf("UNDEFINED-FIELD: output event pin field %q not in platform spec", key)
 		}
@@ -299,6 +309,30 @@ func decodeFlowOutputPinEventNode(node *yaml.Node) (FlowOutputEventPin, error) {
 		return FlowOutputEventPin{}, fmt.Errorf("output event pin name is required")
 	}
 	return out, nil
+}
+
+func decodeFlowOutputPinCarriesNode(node *yaml.Node) ([]string, error) {
+	if node == nil || node.Kind == 0 {
+		return nil, nil
+	}
+	switch node.Kind {
+	case yaml.ScalarNode:
+		if strings.EqualFold(strings.TrimSpace(node.Tag), "!!null") || strings.TrimSpace(node.Value) == "" {
+			return nil, nil
+		}
+		return []string{strings.TrimSpace(node.Value)}, nil
+	case yaml.SequenceNode:
+		out := make([]string, 0, len(node.Content))
+		for _, item := range node.Content {
+			if item == nil || item.Kind != yaml.ScalarNode {
+				return nil, fmt.Errorf("carries entries must be strings")
+			}
+			out = append(out, strings.TrimSpace(item.Value))
+		}
+		return out, nil
+	default:
+		return nil, fmt.Errorf("carries must be a string or sequence")
+	}
 }
 
 func (a *FlowInputPinAddress) UnmarshalYAML(node *yaml.Node) error {

--- a/internal/runtime/contracts/workflow_contract_yaml_test.go
+++ b/internal/runtime/contracts/workflow_contract_yaml_test.go
@@ -243,6 +243,8 @@ pins:
     events:
       - name: deploy_done
         event: deploy.done
+        key: vertical_id
+        carries: [vertical_id, component_id]
 `), &doc); err != nil {
 		t.Fatalf("yaml.Unmarshal: %v", err)
 	}
@@ -271,6 +273,12 @@ pins:
 	if got, want := doc.Pins.Outputs.EventPins[0].PinName(), "deploy_done"; got != want {
 		t.Fatalf("output PinName = %q, want %q", got, want)
 	}
+	if got, want := doc.Pins.Outputs.EventPins[0].Key, "vertical_id"; got != want {
+		t.Fatalf("output Key = %q, want %q", got, want)
+	}
+	if got, want := strings.Join(doc.Pins.Outputs.EventPins[0].Carries, ","), "vertical_id,component_id"; got != want {
+		t.Fatalf("output Carries = %q, want %q", got, want)
+	}
 }
 
 func TestFlowSchemaDocumentDecode_RejectsUnsupportedAddressedPinFields(t *testing.T) {
@@ -285,6 +293,22 @@ pins:
         address:
           by: vertical_id
           unsupported: nope
+`), &doc)
+	if err == nil || !strings.Contains(err.Error(), "UNDEFINED-FIELD") {
+		t.Fatalf("yaml.Unmarshal error = %v, want UNDEFINED-FIELD", err)
+	}
+}
+
+func TestFlowSchemaDocumentDecode_RejectsUnsupportedOutputPinFields(t *testing.T) {
+	var doc FlowSchemaDocument
+	err := yaml.Unmarshal([]byte(`
+name: invalid-output-pins
+pins:
+  outputs:
+    events:
+      - name: deploy_done
+        event: deploy.done
+        unknown: nope
 `), &doc)
 	if err == nil || !strings.Contains(err.Error(), "UNDEFINED-FIELD") {
 		t.Fatalf("yaml.Unmarshal error = %v, want UNDEFINED-FIELD", err)

--- a/internal/runtime/semanticview/composition_connect_test.go
+++ b/internal/runtime/semanticview/composition_connect_test.go
@@ -42,6 +42,12 @@ func TestCompositionConnectFactsExposeTypedPinsAndParentConnect(t *testing.T) {
 	if got, want := outputPins[0].PinName(), "deploy_done"; got != want {
 		t.Fatalf("output pin name = %q, want %q", got, want)
 	}
+	if got, want := outputPins[0].Key, "vertical_id"; got != want {
+		t.Fatalf("output pin key = %q, want %q", got, want)
+	}
+	if got, want := len(outputPins[0].Carries), 1; got != want || outputPins[0].Carries[0] != "vertical_id" {
+		t.Fatalf("output pin carries = %#v, want [vertical_id]", outputPins[0].Carries)
+	}
 
 	connects := source.CompositionConnects()
 	if len(connects) != 1 {
@@ -133,7 +139,9 @@ pins:
     events:
       - name: deploy_done
         event: deploy.done
-`, "deploy.done: {}\n", "{}\n")
+        key: vertical_id
+        carries: [vertical_id]
+`, "deploy.done:\n  vertical_id: string\n", "{}\n")
 	writeCompositionConnectFlow(t, root, "consumer", `
 pins:
   inputs:

--- a/internal/runtime/testfixtures/sealedpackage/fixture.go
+++ b/internal/runtime/testfixtures/sealedpackage/fixture.go
@@ -151,6 +151,8 @@ pins:
     events:
       - name: shared_done
         event: shared.done
+        key: flow_instance
+        carries: [flow_instance]
 `)
 	writeFile(t, filepath.Join(root, "flows", "producer", "policy.yaml"), `
 runtime:

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -4268,6 +4268,14 @@ engine:
       scope: per-node
       trigger: A handler's sets_gate references a gate name not declared in the node's gate_state schema.
       when: boot-only
+    - id: output_pin_key_carries_validation
+      severity: error
+      scope: per-output-pin-and-emit-site
+      trigger: A connected producer output pin that participates in instance-key composition is missing key/carries evidence,
+        declares ambiguous, duplicate, undeclared, or non-scalar carried fields, or an authored producer emit site cannot
+        statically prove every declared key/carries payload field. Agent emit_events declarations for key/carries output
+        pins fail closed until a static payload construction surface exists.
+      when: boot-only
     - id: input_pin_wiring
       severity: warning
       scope: per-flow
@@ -5141,6 +5149,26 @@ flow_model:
         output_pin_key_carries: '#1544'
         connect_to_instance_route_planning: '#1545'
         connect_key_adapters: '#1546'
+      output_pin_key_carries_contract:
+        status: merge_bearing_contract_behavior
+        implementation_tracker: '#1544'
+        canonical_code_owner: internal/runtime/contracts.FlowOutputEventPin + internal/runtime/bootverify.checkOutputPinKeyCarriesValidation
+        rule: >
+          Producer output event pins used for downstream instance-key composition
+          MUST declare `key` and `carries`. `key` names the top-level payload
+          field that supplies the producer's route identity evidence. `carries`
+          names every top-level payload field the output pin promises as
+          producer interface evidence and MUST include the key. The verifier
+          type-checks those fields against the producer event schema and
+          requires supported node emit sites to statically construct them.
+          Agent `emit_events` declarations that name key/carries output pins
+          fail closed until an explicit static payload construction surface is
+          available.
+        non_authoritative_paths: >
+          Event payload schema fields, connect.map source expressions, receiver
+          address rules, producer target.match, broadcast:true, raw/direct
+          subscribers, and RouteTable/live subscription lookup are not the
+          canonical producer evidence owner for this class.
     contained_state_model:
       status: spec_vocabulary_only
       implementation_tracker: '#1548'
@@ -5415,6 +5443,29 @@ flow_model:
         fail-closed, and lowers each accepted connection into concrete route-plan facts consumed by runtime RoutePlan.
         Producer emit sites MUST NOT own consumer routing on the common composed path.
       authored_shapes:
+        output_event_pin:
+          location: schema.yaml pins.outputs.events
+          canonical_form: >
+            An output event pin MAY be authored as an object `{name, event, key, carries}`.
+            `name` is the local public output pin name. `event` is the local event identity
+            emitted by the producer. `key` names the top-level payload field that carries
+            instance-key producer evidence for normal parent-composed delivery. `carries`
+            is the top-level payload field inventory promised by the producer output pin
+            and MUST include `key` when `key` is present.
+          scalar_form: >
+            A scalar output event pin remains valid for outputs that do not participate in
+            instance-key composition. A scalar output pin consumed by an addressed parent
+            connect cannot prove producer key evidence and fails closed.
+          example: |
+            pins:
+              outputs:
+                events:
+                  - name: deploy_completed
+                    event: deploy.completed
+                    key: vertical_id
+                    carries:
+                      - vertical_id
+                      - component_id
         addressed_input_pin:
           location: schema.yaml pins.inputs.events
           canonical_form: >
@@ -5469,7 +5520,7 @@ flow_model:
                 to: operating.root_ready
                 delivery: one
       ownership_split:
-        output_pins: Output pins own producer event identity and public producer interface only.
+        output_pins: Output pins own producer event identity and public producer key/carries evidence for instance-key composition.
         input_pins: Input pins own receiver interface and receiver address resolution requirements.
         parent_connect: Parent connect owns inter-flow delivery topology, including point-to-point, broadcast/fan-out, and reply/sender routing.
         analyzer: Analyzer owns validation, safe inference, alias/adapter expansion, and lowering to concrete route-plan facts.
@@ -5484,7 +5535,9 @@ flow_model:
         receiver_root_unsupported: Root receiver endpoints are not supported by #1508; `to` must name a loaded receiver flow input pin.
         receiver_input_pin_exists: The `to` pin must exist in the receiver schema input event pins.
         event_alias_or_adapter_valid: Differing local event names or payload keys require an explicit alias/adapter or unambiguous bind-derived alias; raw same-name fallback is not valid for declared imported package pins.
-        output_carries_address_key: The producer output event payload or envelope must carry every receiver address key required by the target input pin, or the connect entry must map it explicitly.
+        output_carries_address_key: The producer output pin key/carries declaration must prove the top-level payload key used
+          by the receiver address or explicit connect.map source. Event payload schema and connect.map are validation inputs,
+          not the canonical producer evidence owner; renamed-key adapters are explicit sibling work.
         receiver_address_rule_present: Stateful or instance-addressed receivers must declare or inherit an input-pin address rule unless the connection lowers to a statically unique receiver.
         key_types_compatible: Source and target key types must be compatible before route-plan lowering.
         delivery_topology_valid: The declared delivery topology must match addressed input cardinality and available receiver instances.
@@ -5495,7 +5548,7 @@ flow_model:
         owner: platform-spec.yaml#flow_model.flow_package.composition_routing.route_plan_lowering
         consumes:
         - parent package.yaml connect entries
-        - producer output pin event identity, including explicit package-root `.pin_name` output endpoints
+        - producer output pin event identity and verified key/carries evidence, including explicit package-root `.pin_name` output endpoints
         - receiver addressed input pin rules
         - import-boundary pin alias bindings
         - explicit adapter/map entries
@@ -5846,7 +5899,9 @@ flow_model:
       description: Events the flow emits across its public interface. Optional, but when an emit site emits one of these
         events, pin routing is active and routing must be supplied by parent connect lowering, explicit dynamic target escape
         hatch, structural ParentRoute fallback when no lowered connect route applies, an eligible static child delivery-entity
-        route, or explicit broadcast escape hatch.
+        route, or explicit broadcast escape hatch. Structured output pins may declare `key` and `carries`; for connected
+        instance-key composition these fields are the canonical producer-side evidence that the output event carries the
+        payload key material consumed by parent `connect`.
       required: false
     input_data_pins:
       description: Entity fields the flow reads. Required pins must be written by a prior flow or initial data.
@@ -9457,6 +9512,53 @@ static_analyzer:
       - broad #1466 composition-first parent closure
       - #1474 runtime generated-agent EventBus RoutePlan admission, already closed separately
       - marketplace/address-key or other final turnkey composition behavior outside static verify coverage
+  slice_3a0_output_pin_key_carries_validation:
+    id: output_pin_key_carries_validation
+    domain: semantic_validity
+    authority: hard_invalidity
+    severity: error
+    canonical_owner: internal/runtime/bootverify.checkOutputPinKeyCarriesValidation
+    supported_surface: cmd/swarm verify
+    implementation_tracker: '#1544'
+    spec_basis:
+    - flow_model.flow_instance_authoring.composition_model.output_pin_key_carries_contract
+    - flow_model.flow_package.composition_routing
+    - contract_formats.event_schema
+    scope:
+      description: >
+        For producer output event pins used by addressed parent connect /
+        instance-key composition, verify that the output pin declares canonical
+        key/carries evidence and that supported producer emit sites statically
+        construct every declared key/carries payload field.
+      applies_to:
+      - schema.yaml pins.outputs.events structured output pin objects
+      - connected output pins consumed by addressed parent connect entries
+      - handler top-level single-emit
+      - rules entries
+      - on_complete branches
+      - accumulate.on_timeout and accumulate.on_complete branches
+      - fan_out per-item emit
+      - guard on_fail: escalate
+      - agent emit_events declarations
+      excludes:
+      - RoutePlan runtime lowering and EventBus dispatch, tracked by #1545
+      - renamed-key adapters, tracked by #1546
+      - receiver select_entity demotion, tracked by #1547
+      - producer target/broadcast compatibility
+    validation_requirements:
+      connected_output_declares_key: Addressed parent connect outputs must declare key.
+      connected_output_declares_carries: Addressed parent connect outputs must declare carries.
+      key_is_carried: The declared key must also appear in carries.
+      carries_are_unique: Duplicate carried fields fail closed.
+      carries_are_top_level_payload_fields: Key/carries fields are top-level payload fields in this slice.
+      event_schema_declares_fields: The producer event schema must declare every key/carries field.
+      carried_fields_are_scalar: Key/carries fields must be scalar key material, not list/object payloads.
+      node_emit_payload_proves_fields: Supported node emit sites must include every key/carries field in emit.fields.
+      agent_emit_payload_fails_closed: Agent emit_events for key/carries output pins fail closed until static payload construction exists.
+    old_non_authoritative_paths: >
+      Event payload schema alone, connect.map source, receiver input-pin address
+      rules, target.match, broadcast:true, direct/raw subscribers, RouteTable, or
+      live subscription lookup cannot satisfy producer key/carries evidence.
   slice_3a1_composition_connect_validation:
     id: composition_connect_validation
     domain: semantic_validity
@@ -9491,8 +9593,9 @@ static_analyzer:
       event_alias_or_adapter_valid: Differing producer and receiver event identities require an explicit adapter or an
         import-boundary alias from requires/bind on either the producer output side or receiver input side; alias/bind
         adapts names only and does not own topology.
-      output_carries_address_key: The producer output event payload or explicit connect.map source must carry every receiver
-        address key needed by the input pin.
+      output_carries_address_key: The producer output pin key/carries declaration must prove the top-level payload key
+        consumed by the receiver address or explicit connect.map source; event payload schema and connect.map are
+        validation inputs, not the producer evidence owner.
       receiver_address_rule_present: Template or instance-addressed receivers must declare an addressed input pin unless
         delivery is an explicit broadcast.
       key_types_compatible: Payload/config/entity/instance source and target key types must be compatible before lowering.

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -4274,7 +4274,8 @@ engine:
       trigger: A connected producer output pin that participates in instance-key composition is missing key/carries evidence,
         declares ambiguous, duplicate, undeclared, or non-scalar carried fields, or an authored producer emit site cannot
         statically prove every declared key/carries payload field. Agent emit_events declarations for key/carries output
-        pins fail closed until a static payload construction surface exists.
+        pins and auto_emit_on_create declarations for key/carries output pins fail closed until a static payload construction
+        surface exists.
       when: boot-only
     - id: input_pin_wiring
       severity: warning
@@ -5161,9 +5162,9 @@ flow_model:
           producer interface evidence and MUST include the key. The verifier
           type-checks those fields against the producer event schema and
           requires supported node emit sites to statically construct them.
-          Agent `emit_events` declarations that name key/carries output pins
-          fail closed until an explicit static payload construction surface is
-          available.
+          Agent `emit_events` and `auto_emit_on_create` declarations that name
+          key/carries output pins fail closed until an explicit static payload
+          construction surface is available.
         non_authoritative_paths: >
           Event payload schema fields, connect.map source expressions, receiver
           address rules, producer target.match, broadcast:true, raw/direct
@@ -9529,7 +9530,9 @@ static_analyzer:
         For producer output event pins used by addressed parent connect /
         instance-key composition, verify that the output pin declares canonical
         key/carries evidence and that supported producer emit sites statically
-        construct every declared key/carries payload field.
+        construct every declared key/carries payload field. Runtime/config
+        constructed producer surfaces must either consume an explicit static
+        payload proof owner or fail closed.
       applies_to:
       - schema.yaml pins.outputs.events structured output pin objects
       - connected output pins consumed by addressed parent connect entries
@@ -9540,6 +9543,7 @@ static_analyzer:
       - fan_out per-item emit
       - guard on_fail: escalate
       - agent emit_events declarations
+      - auto_emit_on_create declarations
       excludes:
       - RoutePlan runtime lowering and EventBus dispatch, tracked by #1545
       - renamed-key adapters, tracked by #1546
@@ -9555,6 +9559,7 @@ static_analyzer:
       carried_fields_are_scalar: Key/carries fields must be scalar key material, not list/object payloads.
       node_emit_payload_proves_fields: Supported node emit sites must include every key/carries field in emit.fields.
       agent_emit_payload_fails_closed: Agent emit_events for key/carries output pins fail closed until static payload construction exists.
+      auto_emit_payload_fails_closed: auto_emit_on_create for key/carries output pins fails closed until activation config payload proof exists.
     old_non_authoritative_paths: >
       Event payload schema alone, connect.map source, receiver input-pin address
       rules, target.match, broadcast:true, direct/raw subscribers, RouteTable, or

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -4273,9 +4273,9 @@ engine:
       scope: per-output-pin-and-emit-site
       trigger: A connected producer output pin that participates in instance-key composition is missing key/carries evidence,
         declares ambiguous, duplicate, undeclared, or non-scalar carried fields, or an authored producer emit site cannot
-        statically prove every declared key/carries payload field. Agent emit_events declarations for key/carries output
-        pins and auto_emit_on_create declarations for key/carries output pins fail closed until a static payload construction
-        surface exists.
+        statically prove every declared key/carries payload field. Agent emit_events declarations, root or flow
+        auto_emit_on_create declarations, and workflow timers for key/carries output pins fail closed until a static payload
+        construction surface exists.
       when: boot-only
     - id: input_pin_wiring
       severity: warning
@@ -5162,9 +5162,9 @@ flow_model:
           producer interface evidence and MUST include the key. The verifier
           type-checks those fields against the producer event schema and
           requires supported node emit sites to statically construct them.
-          Agent `emit_events` and `auto_emit_on_create` declarations that name
-          key/carries output pins fail closed until an explicit static payload
-          construction surface is available.
+          Agent `emit_events`, root or flow `auto_emit_on_create`, and workflow
+          timer declarations that name key/carries output pins fail closed until
+          an explicit static payload construction surface is available.
         non_authoritative_paths: >
           Event payload schema fields, connect.map source expressions, receiver
           address rules, producer target.match, broadcast:true, raw/direct
@@ -9543,7 +9543,8 @@ static_analyzer:
       - fan_out per-item emit
       - guard on_fail: escalate
       - agent emit_events declarations
-      - auto_emit_on_create declarations
+      - root and flow auto_emit_on_create declarations
+      - workflow timer declarations
       excludes:
       - RoutePlan runtime lowering and EventBus dispatch, tracked by #1545
       - renamed-key adapters, tracked by #1546
@@ -9559,7 +9560,8 @@ static_analyzer:
       carried_fields_are_scalar: Key/carries fields must be scalar key material, not list/object payloads.
       node_emit_payload_proves_fields: Supported node emit sites must include every key/carries field in emit.fields.
       agent_emit_payload_fails_closed: Agent emit_events for key/carries output pins fail closed until static payload construction exists.
-      auto_emit_payload_fails_closed: auto_emit_on_create for key/carries output pins fails closed until activation config payload proof exists.
+      auto_emit_payload_fails_closed: Root and flow auto_emit_on_create for key/carries output pins fails closed until activation config payload proof exists.
+      timer_payload_fails_closed: Workflow timers for key/carries output pins fail closed until timer payload construction proof exists.
     old_non_authoritative_paths: >
       Event payload schema alone, connect.map source, receiver input-pin address
       rules, target.match, broadcast:true, direct/raw subscribers, RouteTable, or


### PR DESCRIPTION
## Summary

Closes #1544.

This PR implements the approved #1544 first slice: producer output pins used for downstream instance-key composition now own canonical `key` / `carries` evidence, and verifier consumers no longer accept event-schema/connect/address inspection as the producer evidence owner.

Changes:
- Add `key` and `carries` to `FlowOutputEventPin`, YAML decode, normalization/clone, semantic view preservation, and fixture coverage.
- Add `output_pin_key_carries_validation` as a hard bootverify check for missing, ambiguous, duplicate, undeclared, non-scalar, or unproven output-pin evidence.
- Move producer-side composition-connect validation to consume output pin key/carries instead of the old payload-schema/connect-map heuristic.
- Fail closed for agent `emit_events` on key/carries output pins until a static payload construction surface exists.
- Update `platform-spec.yaml` and API spec assertions for the merge-bearing contract.

## Governing refs / context

Exact governing spec references updated in this PR:
- `platform-spec.yaml#flow_model.flow_instance_authoring.composition_model.output_pin_key_carries_contract`
- `platform-spec.yaml#flow_model.flow_package.composition_routing`
- `platform-spec.yaml#engine.boot_verification.checks.output_pin_key_carries_validation`
- `platform-spec.yaml#static_analyzer.slice_3a0_output_pin_key_carries_validation`
- `platform-spec.yaml#static_analyzer.slice_3a1_composition_connect_validation`

Binding issue/gate context:
- #1544 issue body
- #1544 `Pre-Implementation Coverage Audit`
- #1544 gate outcome: approved as first slice
- Parent tracker #1537

## Semantic migration

New canonical owner:
- `internal/runtime/contracts.FlowOutputEventPin` owns producer output pin `key` / `carries` contract data.
- `internal/runtime/bootverify.checkOutputPinKeyCarriesValidation` owns fail-closed validation and supported emitted-payload proof for that producer evidence.

Old producer / reader / writer path now invalid:
- `composition_connect_validation` can no longer prove producer instance-key evidence from event payload schema, `connect.map.source`, or receiver input-pin address alone.
- The old `compositionConnectSourceType` helper was removed; composition connect validation now calls the output-pin key/carries owner.

Production paths checked for surviving old behavior:
- Contract YAML/model/normalization/semantic-view consumers.
- Composition connect validation.
- Supported authored node emit-site inventory through `pinRoutingEmitSites`.
- Agent `emit_events` route producer declarations.
- Route authority bypass sweep for old payload/connect/address-only producer evidence strings.

Migration completeness:
- Complete for the #1544 contracts/verify producer-evidence slice.
- Runtime RoutePlan consumption remains split to #1545.
- Renamed-key adapters remain split to #1546.
- Receiver select_entity demotion remains split to #1547.
- Legacy/static multi-entity policy remains split to #1554.

## Validation

- `go test ./internal/apispec ./internal/runtime/contracts ./internal/runtime/semanticview ./internal/runtime/bootverify`
- `go test ./internal/runtime/core/pinrouting ./internal/runtime/bus ./internal/runtime/tools ./internal/runtime/conformance`
- `go test ./...`
- `rg -n "compositionConnectSourceType\(|output_carries_address_key: The producer output event payload|payload or explicit connect.map source must carry|event payload schema alone|Event payload schema alone|source expression .*payload\.\* or event\.source\.\*" internal platform-spec.yaml -g'*.go' -g'*.yaml'`