### PR TITLE
[agent-b][issue #1530] Fail closed required MCP tool availability

### DIFF
--- a/internal/runtime/bootverify/checks.go
+++ b/internal/runtime/bootverify/checks.go
@@ -55,6 +55,9 @@ type checkerContext struct {
 	toolLoaded   bool
 	toolFindings []Finding
 
+	requiredMCPLoaded   bool
+	requiredMCPFindings []Finding
+
 	toolUsageLoaded   bool
 	toolUsageFindings []Finding
 
@@ -215,6 +218,7 @@ var bootCheckRegistry = []Check{
 	{ID: "required_agents_match", Severity: "error", Run: checkRequiredAgentsMatch},
 	{ID: "handler_field_compliance", Severity: "error", Run: checkHandlerFieldCompliance},
 	{ID: "tool_resolution", Severity: "warning", Run: checkToolResolution},
+	{ID: "required_mcp_tool_availability", Severity: SeverityHardInvalidity, Run: checkRequiredMCPToolAvailability},
 	{ID: "platform_tool_usage_hints", Severity: SeverityHardInvalidity, Run: checkPlatformToolUsageHints},
 	{ID: "generated_tool_schema_closure", Severity: SeverityHardInvalidity, Run: checkGeneratedToolSchemaClosure},
 	{ID: "prompt_exists", Severity: "warning", Run: checkPromptExists},

--- a/internal/runtime/bootverify/flow_data_access_test.go
+++ b/internal/runtime/bootverify/flow_data_access_test.go
@@ -66,8 +66,8 @@ func TestRun_ValidatesFlowDataAccessDeclarations(t *testing.T) {
 }
 
 func TestBootCheckRegistry_HasFlowDataAccessCheckCount(t *testing.T) {
-	if got := len(bootCheckRegistry); got != 61 {
-		t.Fatalf("bootCheckRegistry count = %d, want 61", got)
+	if got := len(bootCheckRegistry); got != 62 {
+		t.Fatalf("bootCheckRegistry count = %d, want 62", got)
 	}
 }
 

--- a/internal/runtime/bootverify/report_test.go
+++ b/internal/runtime/bootverify/report_test.go
@@ -68,7 +68,7 @@ func TestRun_FailsClosedForInvalidExternalDispatchRateLimit(t *testing.T) {
 	}
 }
 
-func TestRun_MapsMissingDiscoveredMCPToolToToolResolutionWarning(t *testing.T) {
+func TestRun_FailsClosedForMissingDiscoveredMCPTool(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var req map[string]any
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
@@ -127,12 +127,15 @@ func TestRun_MapsMissingDiscoveredMCPToolToToolResolutionWarning(t *testing.T) {
 
 	report := Run(context.Background(), source, Options{CheckMCPReachable: true})
 
-	if !reportContains(report.Warnings(), "tool_resolution", "infra.missing") {
-		t.Fatalf("expected tool_resolution warning for undiscovered mcp tool, got %#v", report.Warnings())
+	if !reportContains(report.Errors(), "required_mcp_tool_availability", "infra.missing") {
+		t.Fatalf("expected required_mcp_tool_availability hard invalidity for undiscovered mcp tool, got %#v", report.Errors())
+	}
+	if reportContains(report.Warnings(), "tool_resolution", "infra.missing") {
+		t.Fatalf("did not expect required mcp tool to fall back to tool_resolution warning, got %#v", report.Warnings())
 	}
 }
 
-func TestRun_MapsMissingContractMCPToolToToolResolutionWarning(t *testing.T) {
+func TestRun_FailsClosedForMissingContractMCPTool(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var req map[string]any
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
@@ -189,8 +192,105 @@ func TestRun_MapsMissingContractMCPToolToToolResolutionWarning(t *testing.T) {
 
 	report := Run(context.Background(), source, Options{CheckMCPReachable: true})
 
-	if !reportContains(report.Warnings(), "tool_resolution", "infra.missing") {
-		t.Fatalf("expected tool_resolution warning for undiscovered contract mcp tool, got %#v", report.Warnings())
+	if !reportContains(report.Errors(), "required_mcp_tool_availability", "infra.missing") {
+		t.Fatalf("expected required_mcp_tool_availability hard invalidity for undiscovered contract mcp tool, got %#v", report.Errors())
+	}
+	if reportContains(report.Warnings(), "tool_resolution", "infra.missing") {
+		t.Fatalf("did not expect required contract mcp tool to fall back to tool_resolution warning, got %#v", report.Warnings())
+	}
+}
+
+func TestRun_FailsClosedForRequiredMCPToolWhenDiscoveryFails(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatalf("Decode request: %v", err)
+		}
+		switch req["method"] {
+		case "initialize":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"jsonrpc": "2.0",
+				"id":      req["id"],
+				"result": map[string]any{
+					"protocolVersion": "2025-03-26",
+					"capabilities":    map[string]any{"tools": map[string]any{}},
+					"serverInfo":      map[string]any{"name": "infra", "version": "1.0.0"},
+				},
+			})
+		case "notifications/initialized":
+			_ = json.NewEncoder(w).Encode(map[string]any{"jsonrpc": "2.0", "result": map[string]any{}})
+		case "tools/list":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"jsonrpc": "2.0",
+				"id":      req["id"],
+				"error": map[string]any{
+					"code":    -32000,
+					"message": "catalog unavailable",
+				},
+			})
+		default:
+			t.Fatalf("unexpected mcp method %v", req["method"])
+		}
+	}))
+	defer server.Close()
+
+	source := semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
+		Agents: map[string]runtimecontracts.AgentRegistryEntry{
+			"agent-1": {Tools: []string{"infra.ping"}},
+		},
+		Policy: runtimecontracts.PolicyDocument{Values: map[string]runtimecontracts.PolicyValue{
+			"mcp_servers": {
+				Value: map[string]any{
+					"infra": map[string]any{
+						"transport": "http",
+						"url":       server.URL,
+						"prefix":    "infra",
+					},
+				},
+			},
+		}},
+	})
+
+	report := Run(context.Background(), source, Options{CheckMCPReachable: true})
+
+	if !reportContains(report.Errors(), "required_mcp_tool_availability", "infra.ping") {
+		t.Fatalf("expected required_mcp_tool_availability hard invalidity for failed required mcp discovery, got %#v", report.Errors())
+	}
+	if !reportContains(report.Warnings(), "mcp_server_reachable", "catalog unavailable") {
+		t.Fatalf("expected optional inventory reachability warning to remain visible, got %#v", report.Warnings())
+	}
+}
+
+func TestRun_FailsClosedForPrefixOnlyRequiredMCPToolWhenDiscoveryDisabled(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatalf("MCP server should not be contacted when CheckMCPReachable is false")
+	}))
+	defer server.Close()
+
+	source := semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
+		Agents: map[string]runtimecontracts.AgentRegistryEntry{
+			"agent-1": {Tools: []string{"infra.ping"}},
+		},
+		Policy: runtimecontracts.PolicyDocument{Values: map[string]runtimecontracts.PolicyValue{
+			"mcp_servers": {
+				Value: map[string]any{
+					"infra": map[string]any{
+						"transport": "http",
+						"url":       server.URL,
+						"prefix":    "infra",
+					},
+				},
+			},
+		}},
+	})
+
+	report := Run(context.Background(), source, Options{})
+
+	if !reportContains(report.Errors(), "required_mcp_tool_availability", "infra.ping") {
+		t.Fatalf("expected required_mcp_tool_availability hard invalidity without catalog proof, got %#v", report.Errors())
+	}
+	if reportContains(report.Warnings(), "tool_resolution", "infra.ping") {
+		t.Fatalf("did not expect prefix-only required mcp tool to fall back to tool_resolution warning, got %#v", report.Warnings())
 	}
 }
 
@@ -4764,8 +4864,8 @@ func TestRun_ReportsMissingRuntimeExecutorForOwnedRuntimeEvent(t *testing.T) {
 }
 
 func TestBootCheckRegistry_HasSpecCheckCount(t *testing.T) {
-	if got := len(bootCheckRegistry); got != 61 {
-		t.Fatalf("bootCheckRegistry count = %d, want 61", got)
+	if got := len(bootCheckRegistry); got != 62 {
+		t.Fatalf("bootCheckRegistry count = %d, want 62", got)
 	}
 	if got := len(supplementalChecks); got != 3 {
 		t.Fatalf("supplementalChecks count = %d, want 3", got)

--- a/internal/runtime/bootverify/runtime_tool_surface_checks.go
+++ b/internal/runtime/bootverify/runtime_tool_surface_checks.go
@@ -4,13 +4,13 @@ import (
 	"fmt"
 	"strings"
 
-	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
-	runtimemcp "github.com/division-sh/swarm/internal/runtime/mcp"
-	"github.com/division-sh/swarm/internal/runtime/semanticview"
 	runtimetools "github.com/division-sh/swarm/internal/runtime/tools"
 )
 
 func checkToolResolution(c *checkerContext) []Finding { return c.toolResolution() }
+func checkRequiredMCPToolAvailability(c *checkerContext) []Finding {
+	return c.requiredMCPToolAvailability()
+}
 func checkPlatformToolUsageHints(c *checkerContext) []Finding {
 	return c.platformToolUsageHints()
 }
@@ -23,7 +23,6 @@ func (c *checkerContext) toolResolution() []Finding {
 		return c.toolFindings
 	}
 	c.toolLoaded = true
-	mcpPrefixes := declaredMCPPrefixes(c.source)
 	discoveredTools := c.mcpDiscovered()
 	// Boot tool warnings must consume the same runtime inventory truth that the
 	// generic runtime ships, then layer MCP discovery on top of it.
@@ -35,18 +34,13 @@ func (c *checkerContext) toolResolution() []Finding {
 			if toolID == "" {
 				continue
 			}
-			if entry, ok := c.source.ToolEntryForAgent(agentID, toolID); ok {
-				if mcpToolEntryRequiresDiscovery(entry) && !toolReferenceAllowedByMCPCatalog(toolID, discoveredTools, mcpPrefixes) {
-					c.toolFindings = append(c.toolFindings, Finding{
-						CheckID:  "tool_resolution",
-						Severity: "warning",
-						Message:  fmt.Sprintf("agent %s references missing tool %s", agentID, toolID),
-						Location: agentID,
-					})
-				}
+			if runtimetools.IsAgentRequiredMCPToolReference(c.source, agentID, toolID) {
 				continue
 			}
-			if toolReferenceAllowedByMCPCatalog(toolID, discoveredTools, mcpPrefixes) {
+			if _, ok := c.source.ToolEntryForAgent(agentID, toolID); ok {
+				continue
+			}
+			if runtimetools.MCPToolDiscovered(toolID, discoveredTools) {
 				continue
 			}
 			if _, ok := runtimeToolNames[toolID]; ok {
@@ -61,6 +55,22 @@ func (c *checkerContext) toolResolution() []Finding {
 		}
 	}
 	return c.toolFindings
+}
+
+func (c *checkerContext) requiredMCPToolAvailability() []Finding {
+	if c.requiredMCPLoaded {
+		return c.requiredMCPFindings
+	}
+	c.requiredMCPLoaded = true
+	for _, item := range runtimetools.RequiredMCPToolAvailabilityFindings(c.source, c.mcpDiscovered()) {
+		c.requiredMCPFindings = append(c.requiredMCPFindings, Finding{
+			CheckID:  "required_mcp_tool_availability",
+			Severity: SeverityHardInvalidity,
+			Message:  fmt.Sprintf("agent %s requires MCP tool %s but %s", item.AgentID, item.ToolName, item.Reason),
+			Location: item.AgentID,
+		})
+	}
+	return c.requiredMCPFindings
 }
 
 func (c *checkerContext) platformToolUsageHints() []Finding {
@@ -113,58 +123,4 @@ func (c *checkerContext) runtimeAvailableToolNames() map[string]struct{} {
 		c.runtimeToolNames[strings.TrimSpace(name)] = struct{}{}
 	}
 	return c.runtimeToolNames
-}
-
-func declaredMCPPrefixes(source semanticview.Source) map[string]struct{} {
-	if source == nil {
-		return nil
-	}
-	value, ok := semanticview.PolicyValueForFlow(source, "", "mcp_servers")
-	if !ok {
-		return nil
-	}
-	root, ok := anyMap(value.Value)
-	if !ok || len(root) == 0 {
-		return nil
-	}
-	out := make(map[string]struct{}, len(root))
-	for _, raw := range root {
-		server, ok := anyMap(raw)
-		if !ok {
-			continue
-		}
-		prefix := strings.TrimSpace(anyString(server["prefix"]))
-		if prefix != "" {
-			out[prefix] = struct{}{}
-		}
-	}
-	return out
-}
-
-func toolReferenceAllowedByMCPPrefix(toolID string, prefixes map[string]struct{}) bool {
-	if len(prefixes) == 0 {
-		return false
-	}
-	prefix, _, ok := strings.Cut(strings.TrimSpace(toolID), ".")
-	if !ok || strings.TrimSpace(prefix) == "" {
-		return false
-	}
-	_, exists := prefixes[strings.TrimSpace(prefix)]
-	return exists
-}
-
-func toolReferenceAllowedByMCPCatalog(toolID string, discovered map[string]runtimemcp.DiscoveredTool, prefixes map[string]struct{}) bool {
-	toolID = strings.TrimSpace(toolID)
-	if toolID == "" {
-		return false
-	}
-	if len(discovered) > 0 {
-		_, ok := discovered[toolID]
-		return ok
-	}
-	return toolReferenceAllowedByMCPPrefix(toolID, prefixes)
-}
-
-func mcpToolEntryRequiresDiscovery(entry runtimecontracts.ToolSchemaEntry) bool {
-	return strings.EqualFold(strings.TrimSpace(entry.HandlerType), "mcp")
 }

--- a/internal/runtime/tools/mcp_availability.go
+++ b/internal/runtime/tools/mcp_availability.go
@@ -1,0 +1,123 @@
+package tools
+
+import (
+	"sort"
+	"strings"
+
+	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
+	runtimemcp "github.com/division-sh/swarm/internal/runtime/mcp"
+	"github.com/division-sh/swarm/internal/runtime/semanticview"
+)
+
+type RequiredMCPToolAvailabilityFinding struct {
+	AgentID  string
+	ToolName string
+	Reason   string
+}
+
+func RequiredMCPToolAvailabilityFindings(source semanticview.Source, discovered map[string]runtimemcp.DiscoveredTool) []RequiredMCPToolAvailabilityFinding {
+	if source == nil {
+		return nil
+	}
+	findings := make([]RequiredMCPToolAvailabilityFinding, 0)
+	for agentID, agent := range source.AgentEntries() {
+		agentID = strings.TrimSpace(agentID)
+		for _, toolName := range agent.ConfiguredTools() {
+			toolName = strings.TrimSpace(toolName)
+			if toolName == "" || !IsAgentRequiredMCPToolReference(source, agentID, toolName) {
+				continue
+			}
+			if MCPToolDiscovered(toolName, discovered) {
+				continue
+			}
+			findings = append(findings, RequiredMCPToolAvailabilityFinding{
+				AgentID:  agentID,
+				ToolName: toolName,
+				Reason:   "no exact discovered MCP catalog entry exists for required agent tool",
+			})
+		}
+	}
+	sort.Slice(findings, func(i, j int) bool {
+		if findings[i].AgentID == findings[j].AgentID {
+			return findings[i].ToolName < findings[j].ToolName
+		}
+		return findings[i].AgentID < findings[j].AgentID
+	})
+	return findings
+}
+
+func IsAgentRequiredMCPToolReference(source semanticview.Source, agentID, toolName string) bool {
+	if source == nil {
+		return false
+	}
+	toolName = strings.TrimSpace(toolName)
+	if toolName == "" {
+		return false
+	}
+	if entry, ok := source.ToolEntryForAgent(strings.TrimSpace(agentID), toolName); ok {
+		return toolEntryRequiresMCPDiscovery(entry)
+	}
+	prefix, _, ok := strings.Cut(toolName, ".")
+	if !ok || strings.TrimSpace(prefix) == "" {
+		return false
+	}
+	_, exists := declaredMCPServerPrefixes(source)[strings.TrimSpace(prefix)]
+	return exists
+}
+
+func MCPToolDiscovered(toolName string, discovered map[string]runtimemcp.DiscoveredTool) bool {
+	toolName = strings.TrimSpace(toolName)
+	if toolName == "" || len(discovered) == 0 {
+		return false
+	}
+	_, ok := discovered[toolName]
+	return ok
+}
+
+func toolEntryRequiresMCPDiscovery(entry runtimecontracts.ToolSchemaEntry) bool {
+	return strings.EqualFold(strings.TrimSpace(entry.HandlerType), string(implementationMCP))
+}
+
+func declaredMCPServerPrefixes(source semanticview.Source) map[string]struct{} {
+	if source == nil {
+		return nil
+	}
+	value, ok := semanticview.PolicyValueForFlow(source, "", "mcp_servers")
+	if !ok {
+		return nil
+	}
+	root, ok := mcpPolicyMap(value.Value)
+	if !ok || len(root) == 0 {
+		return nil
+	}
+	out := make(map[string]struct{}, len(root))
+	for _, raw := range root {
+		server, ok := mcpPolicyMap(raw)
+		if !ok {
+			continue
+		}
+		prefix := strings.TrimSpace(mcpPolicyString(server["prefix"]))
+		if prefix != "" {
+			out[prefix] = struct{}{}
+		}
+	}
+	return out
+}
+
+func mcpPolicyMap(value any) (map[string]any, bool) {
+	switch typed := value.(type) {
+	case map[string]any:
+		return typed, true
+	default:
+		return nil, false
+	}
+}
+
+func mcpPolicyString(value any) string {
+	switch typed := value.(type) {
+	case string:
+		return typed
+	default:
+		return ""
+	}
+}

--- a/internal/runtime/tools/registry.go
+++ b/internal/runtime/tools/registry.go
@@ -216,6 +216,9 @@ func registeredToolFromContract(name string, entry runtimecontracts.ToolSchemaEn
 	if enabled && handlerType != implementationHTTP {
 		return RegisteredTool{}, false, fmt.Errorf("tool %s rate_limit is only supported for handler_type http", strings.TrimSpace(name))
 	}
+	if handlerType == implementationMCP {
+		return RegisteredTool{}, false, nil
+	}
 	inputSchema, err := schemaToMap(entry.InputSchema)
 	if err != nil {
 		return RegisteredTool{}, false, err

--- a/internal/runtime/tools/tool_model_test.go
+++ b/internal/runtime/tools/tool_model_test.go
@@ -498,6 +498,34 @@ func TestExecutor_MCPToolExecutesDiscoveredServerTool(t *testing.T) {
 	}
 }
 
+func TestExecutor_ToolDefinitionsForActor_ExcludesContractMCPWithoutDiscovery(t *testing.T) {
+	source := semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
+		Agents: map[string]runtimecontracts.AgentRegistryEntry{
+			"agent-1": {ID: "agent-1", Tools: []string{"infra.ping"}},
+		},
+		Tools: map[string]runtimecontracts.ToolSchemaEntry{
+			"infra.ping": {
+				Description: "Authored MCP tool should not create runtime availability",
+				HandlerType: "mcp",
+				InputSchema: runtimecontracts.ToolInputSchema{
+					Type: "object",
+				},
+			},
+		},
+	})
+
+	exec := NewExecutorWithOptions(nil, nil, ExecutorOptions{WorkflowSource: source})
+	defs := exec.ToolDefinitionsForActor(models.AgentConfig{ID: "agent-1", Tools: []string{"infra.ping"}})
+
+	names := make([]string, 0, len(defs))
+	for _, def := range defs {
+		names = append(names, def.Name)
+	}
+	if containsToolName(names, "infra.ping") {
+		t.Fatalf("did not expect authored handler_type mcp entry without discovery proof to be delivered, got %v", names)
+	}
+}
+
 func TestExecutor_ToolDefinitionsForActor_UsesSharedActorRegistry(t *testing.T) {
 	source := semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
 		Tools: map[string]runtimecontracts.ToolSchemaEntry{

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -4122,8 +4122,18 @@ engine:
     - id: tool_resolution
       severity: warning
       scope: per-agent
-      trigger: An agent's tools list references a tool name that does not exist in the merged runtime tool registry
-        (platform builtin tools, authored tools.yaml/http tools, and MCP server catalogs).
+      trigger: An agent's tools list references a non-MCP tool name that does not exist in the merged runtime tool
+        registry (platform builtin tools, authored tools.yaml/http tools, and MCP server catalogs). Required MCP-backed
+        tools are governed by required_mcp_tool_availability instead of this warning path.
+      when: boot-only
+    - id: required_mcp_tool_availability
+      severity: hard_invalidity
+      scope: per-agent
+      trigger: An MCP-backed tool that can become visible or callable for an agent turn lacks exact concrete
+        tools/list catalog proof from the runtime MCP discovery owner. This includes explicit agent tools entries,
+        authored tools.yaml handler_type:mcp entries selected for an actor, and runtime actor tool definitions or
+        gateway catalog entries. Declared MCP prefixes, authored handler_type:mcp schemas, and later mcp tools/call
+        unavailable errors are not sufficient proof.
       when: boot-only
     - id: platform_tool_usage_hints
       severity: hard_invalidity
@@ -4510,9 +4520,12 @@ tool_model:
       description: Tools provided by external MCP servers. The platform connects as an MCP client, discovers tools via tools/list,
         and forwards agent calls via tools/call. The platform ships one generic MCP client executor — no per-tool handler code.
       handler_type_value: mcp
-      boot_rule: If an MCP server is unreachable at boot, log warning. Tools from that server are marked unavailable. Agents
-        with those tools in tools get a boot warning (not error — the agent may not be invoked in this run). If the agent
-        IS invoked and calls the tool, the platform returns a tool error to the agent.
+      boot_rule: If an MCP server is unreachable at boot, log warning only for optional or unreferenced external inventory.
+        Any MCP-backed tool that can become visible or callable for an agent turn MUST have an exact discovered tools/list
+        catalog entry before the agent turn. Missing reachability, missing catalog, missing concrete tool, prefix-only
+        evidence, and authored tools.yaml handler_type:mcp entries without discovered catalog proof are hard invalidity
+        under required_mcp_tool_availability. Later mcp tools/call unavailable errors are defense-in-depth only and MUST
+        NOT be the first failure point for a required MCP tool.
       portability: Works anywhere the MCP server is reachable. Pre-built MCP servers exist for common services (databases,
         APIs, cloud providers). Products can ship custom MCP servers as sidecars for infrastructure-specific tools.
     http:
@@ -4663,8 +4676,10 @@ tool_model:
     description: Agents only see tools listed in their tools contract field. The platform never injects the full tool
       catalog from any source into an agent session. This controls LLM context cost.
     rule: When constructing an agent session, the platform resolves tools entries against the merged tool registry
-      (platform_builtin + mcp + http). Only resolved tools are included in the LLM tool definitions. Unresolvable entries
-      log a warning per the tool_resolution boot check.
+      (platform_builtin + mcp + http). Only resolved tools are included in the LLM tool definitions. Unresolvable non-MCP
+      entries log a warning per the tool_resolution boot check. Unresolvable MCP-backed entries that can become visible
+      or callable for an agent turn fail closed per required_mcp_tool_availability and MUST NOT be delivered from a
+      declared prefix or authored handler_type:mcp schema without exact discovered catalog proof.
     usage_hints: Provider-facing tool definitions for platform-owned delivered tools and generated emit tools MUST include
       the shared platform usage guidance. Generated emit tool usage guidance MUST describe concrete JSON payload arguments,
       not CEL or workflow expression arguments. Boot verification reports this through platform_tool_usage_hints.
@@ -4720,7 +4735,9 @@ tool_model:
     - 2. Call tools/list. Cache the response as the server's tool catalog.
     - 3. For each tool in the catalog, register in the platform tool registry with the prefixed name.
     - 4. Log server name, tool count, and tool names at info level.
-    - 5. If connection fails, log warning with server name and error. Skip this server. Do not abort boot.
+    - 5. If connection fails, log warning with server name and error for optional or unreferenced inventory. Skip this
+      server for optional inventory, but abort boot/startup through required_mcp_tool_availability when any agent-required
+      MCP tool depends on exact catalog proof from that server.
     lifecycle:
       http: Connection maintained for platform lifetime. Reconnect on failure with exponential backoff (1s, 2s, 4s, max 30s).
       stdio: Process spawned at boot, killed on platform shutdown. If process exits unexpectedly, respawn with backoff.


### PR DESCRIPTION
## Summary
- adds `required_mcp_tool_availability` as the hard boot/runtime check for agent-required MCP tools without exact discovered catalog proof
- moves required MCP detection into a shared runtime tools owner consumed by bootverify and actor tool delivery
- stops authored `tools.yaml handler_type:mcp` entries from independently producing delivered runtime tools without discovered catalog evidence
- updates `platform-spec.yaml` to split required MCP fail-closed behavior from optional/unreferenced MCP inventory warnings

Closes #1530
Part of #1462

## Governing refs / context
- #1530 Pre-Implementation Coverage Audit: https://github.com/division-sh/swarm/issues/1530#issuecomment-4835373171
- #1530 independent gate: https://github.com/division-sh/swarm/issues/1530#issuecomment-4835493296
- `platform-spec.yaml` `engine.boot_verification.checks.tool_resolution`
- `platform-spec.yaml` `engine.boot_verification.checks.required_mcp_tool_availability`
- `platform-spec.yaml` `tool_model.tool_implementation_classes.mcp.boot_rule`
- `platform-spec.yaml` `tool_model.agent_tool_filtering.rule`
- `platform-spec.yaml` `tool_model.mcp_client.boot_sequence`
- Prior boundary: #1100 / PR #1103 preserved warning-only MCP reachability for optional runtime-external inventory

## Semantic migration
- New canonical required-MCP availability owner: `internal/runtime/tools.RequiredMCPToolAvailabilityFindings`, consuming `internal/runtime/mcp.Client.Refresh` / `DiscoveredTools` catalog truth plus agent/tool requirements.
- Old producer / reader / writer paths now invalid: prefix-only MCP acceptance in bootverify, warning-only `tool_resolution` for required MCP tools, and authored `handler_type:mcp` registry delivery without discovered catalog evidence.
- Production paths checked for surviving old behavior: bootverify `tool_resolution`, new hard `required_mcp_tool_availability`, workflow validation error path, runtime actor tool definitions, executor registry resolution, discovered MCP execution, MCP client defense-in-depth, and selected-runtime startup tests.
- Migration complete for #1530. Optional/unreferenced MCP inventory still uses `mcp_server_reachable` warning behavior by spec.

## Tests
- `go test ./internal/runtime/bootverify ./internal/runtime/tools -count=1`
- `go test ./internal/runtime/bootverify ./internal/runtime/tools ./internal/runtime/mcp ./internal/runtime -run 'MCP|RequiredMCP|ToolResolution|ValidateClaude' -count=1`
- `go test ./...`
