### PR TITLE
[agent-a][issue #1545] Route connect plans through instance keys

### DIFF
--- a/internal/apispec/platform_spec_composition_routing_test.go
+++ b/internal/apispec/platform_spec_composition_routing_test.go
@@ -38,7 +38,7 @@ func TestPlatformSpecCompositionRoutingSourceAuthority(t *testing.T) {
 	ownership := mustMappingValue(t, composition, "ownership_split")
 	assertScalarContains(t, mustMappingValue(t, ownership, "parent_connect"), "owns inter-flow delivery topology")
 	assertScalarContains(t, mustMappingValue(t, ownership, "output_pins"), "key/carries evidence")
-	assertScalarContains(t, mustMappingValue(t, ownership, "input_pins"), "receiver address resolution")
+	assertScalarContains(t, mustMappingValue(t, ownership, "input_pins"), "receiver interface")
 	assertScalarContains(t, mustMappingValue(t, ownership, "producer_emit_target"), "exceptional dynamic routing")
 
 	verify := mustMappingValue(t, composition, "analyzer_verify_requirements")
@@ -49,7 +49,7 @@ func TestPlatformSpecCompositionRoutingSourceAuthority(t *testing.T) {
 		"receiver_input_pin_exists",
 		"event_alias_or_adapter_valid",
 		"output_carries_address_key",
-		"receiver_address_rule_present",
+		"receiver_route_key_present",
 		"key_types_compatible",
 		"delivery_topology_valid",
 		"reply_lineage_usable",
@@ -66,6 +66,7 @@ func TestPlatformSpecCompositionRoutingSourceAuthority(t *testing.T) {
 	for _, want := range []string{
 		"parent package.yaml connect entries",
 		"producer output pin event identity and verified key/carries evidence, including explicit package-root `.pin_name` output endpoints",
+		"receiver template instance.by / on_missing / on_conflict contracts from WorkflowContractBundle.ResolveFlowTemplateInstance",
 		"receiver addressed input pin rules",
 		"import-boundary pin alias bindings",
 	} {
@@ -91,6 +92,15 @@ func TestPlatformSpecCompositionRoutingSourceAuthority(t *testing.T) {
 	assertScalarValue(t, mustMappingValue(t, slice1473, "status"), "merge_bearing_runtime_behavior")
 	assertScalarContains(t, mustMappingValue(t, slice1473, "canonical_code_owner"), "internal/runtime/bus.RoutePlan")
 	assertScalarContains(t, mustMappingValue(t, slice1473, "rule"), "Supported EventBus publish/preflight/outbox dispatch consumes lowered ConnectRoutePlan")
+
+	slice1545 := mustYAMLPath(t, composition, "route_plan_lowering", "implementation_slice_1545")
+	assertScalarValue(t, mustMappingValue(t, slice1545, "status"), "merge_bearing_runtime_behavior")
+	assertScalarContains(t, mustMappingValue(t, slice1545, "canonical_code_owner"), "ConnectRoutePlan.InstanceKey")
+	assertScalarContains(t, mustMappingValue(t, slice1545, "rule"), "WorkflowContractBundle.ResolveFlowTemplateInstance")
+	assertScalarContains(t, mustMappingValue(t, slice1545, "rule"), "TemplateInstanceContract.CanonicalKeyMaterial")
+	if !sequenceContainsScalar(mustMappingValue(t, slice1545, "non_authoritative_for_this_slice"), "receiver input-pin address") {
+		t.Fatal("implementation_slice_1545 must classify receiver input-pin address as non-authoritative for normal instance-key routing")
+	}
 
 	slice1475 := mustYAMLPath(t, composition, "route_plan_lowering", "implementation_slice_1475")
 	assertScalarValue(t, mustMappingValue(t, slice1475, "status"), "merge_bearing_runtime_behavior")

--- a/internal/apispec/platform_spec_composition_routing_test.go
+++ b/internal/apispec/platform_spec_composition_routing_test.go
@@ -95,11 +95,14 @@ func TestPlatformSpecCompositionRoutingSourceAuthority(t *testing.T) {
 
 	slice1545 := mustYAMLPath(t, composition, "route_plan_lowering", "implementation_slice_1545")
 	assertScalarValue(t, mustMappingValue(t, slice1545, "status"), "merge_bearing_runtime_behavior")
+	assertScalarContains(t, mustMappingValue(t, slice1545, "canonical_code_owner"), "ConnectRoutePlan.ResolutionKind")
 	assertScalarContains(t, mustMappingValue(t, slice1545, "canonical_code_owner"), "ConnectRoutePlan.InstanceKey")
+	assertScalarContains(t, mustMappingValue(t, slice1545, "rule"), "ResolutionKind: instance_key")
+	assertScalarContains(t, mustMappingValue(t, slice1545, "rule"), "ResolutionKind: address")
 	assertScalarContains(t, mustMappingValue(t, slice1545, "rule"), "WorkflowContractBundle.ResolveFlowTemplateInstance")
 	assertScalarContains(t, mustMappingValue(t, slice1545, "rule"), "TemplateInstanceContract.CanonicalKeyMaterial")
-	if !sequenceContainsScalar(mustMappingValue(t, slice1545, "non_authoritative_for_this_slice"), "receiver input-pin address") {
-		t.Fatal("implementation_slice_1545 must classify receiver input-pin address as non-authoritative for normal instance-key routing")
+	if !sequenceContainsScalar(mustMappingValue(t, slice1545, "non_authoritative_for_this_slice"), "receiver input-pin address for the addressless normal instance-key path") {
+		t.Fatal("implementation_slice_1545 must classify receiver input-pin address as non-authoritative only for normal instance-key routing")
 	}
 
 	slice1475 := mustYAMLPath(t, composition, "route_plan_lowering", "implementation_slice_1475")

--- a/internal/apispec/platform_spec_composition_routing_test.go
+++ b/internal/apispec/platform_spec_composition_routing_test.go
@@ -99,10 +99,14 @@ func TestPlatformSpecCompositionRoutingSourceAuthority(t *testing.T) {
 	assertScalarContains(t, mustMappingValue(t, slice1545, "canonical_code_owner"), "ConnectRoutePlan.InstanceKey")
 	assertScalarContains(t, mustMappingValue(t, slice1545, "rule"), "ResolutionKind: instance_key")
 	assertScalarContains(t, mustMappingValue(t, slice1545, "rule"), "ResolutionKind: address")
+	assertScalarContains(t, mustMappingValue(t, slice1545, "rule"), "ResolutionKind: broadcast")
 	assertScalarContains(t, mustMappingValue(t, slice1545, "rule"), "WorkflowContractBundle.ResolveFlowTemplateInstance")
 	assertScalarContains(t, mustMappingValue(t, slice1545, "rule"), "TemplateInstanceContract.CanonicalKeyMaterial")
 	if !sequenceContainsScalar(mustMappingValue(t, slice1545, "non_authoritative_for_this_slice"), "receiver input-pin address for the addressless normal instance-key path") {
 		t.Fatal("implementation_slice_1545 must classify receiver input-pin address as non-authoritative only for normal instance-key routing")
+	}
+	if !sequenceContainsScalar(mustMappingValue(t, slice1545, "non_authoritative_for_this_slice"), "receiver instance-key materialization for explicit parent-authored broadcast fan-out") {
+		t.Fatal("implementation_slice_1545 must classify instance-key materialization as non-authoritative for explicit parent broadcast")
 	}
 
 	slice1475 := mustYAMLPath(t, composition, "route_plan_lowering", "implementation_slice_1475")

--- a/internal/runtime/bootverify/flow_data_access_test.go
+++ b/internal/runtime/bootverify/flow_data_access_test.go
@@ -66,8 +66,8 @@ func TestRun_ValidatesFlowDataAccessDeclarations(t *testing.T) {
 }
 
 func TestBootCheckRegistry_HasFlowDataAccessCheckCount(t *testing.T) {
-	if got := len(bootCheckRegistry); got != 62 {
-		t.Fatalf("bootCheckRegistry count = %d, want 62", got)
+	if got := len(bootCheckRegistry); got != 63 {
+		t.Fatalf("bootCheckRegistry count = %d, want 63", got)
 	}
 }
 

--- a/internal/runtime/bootverify/report_test.go
+++ b/internal/runtime/bootverify/report_test.go
@@ -4864,8 +4864,8 @@ func TestRun_ReportsMissingRuntimeExecutorForOwnedRuntimeEvent(t *testing.T) {
 }
 
 func TestBootCheckRegistry_HasSpecCheckCount(t *testing.T) {
-	if got := len(bootCheckRegistry); got != 62 {
-		t.Fatalf("bootCheckRegistry count = %d, want 62", got)
+	if got := len(bootCheckRegistry); got != 63 {
+		t.Fatalf("bootCheckRegistry count = %d, want 63", got)
 	}
 	if got := len(supplementalChecks); got != 3 {
 		t.Fatalf("supplementalChecks count = %d, want 3", got)

--- a/internal/runtime/bootverify/workflow_composition_connect_checks.go
+++ b/internal/runtime/bootverify/workflow_composition_connect_checks.go
@@ -77,8 +77,13 @@ func validateCompositionConnect(source semanticview.Source, connect runtimecontr
 		))
 	}
 
-	findings = append(findings, validateCompositionConnectDelivery(connect, inputPin, receiverSchema, to.FlowID)...)
-	findings = append(findings, validateCompositionConnectAddress(source, connect, outputPin, inputPin, from.FlowID, to.FlowID)...)
+	instanceKeyFindings := validateCompositionConnectInstanceKey(source, connect, outputPin, inputPin, from.FlowID, to.FlowID)
+	findings = append(findings, validateCompositionConnectDelivery(connect, inputPin, receiverSchema, to.FlowID, len(instanceKeyFindings) == 0)...)
+	if len(instanceKeyFindings) > 0 {
+		findings = append(findings, instanceKeyFindings...)
+	} else {
+		findings = append(findings, validateCompositionConnectAddress(source, connect, outputPin, inputPin, from.FlowID, to.FlowID)...)
+	}
 	return findings
 }
 
@@ -145,7 +150,7 @@ func compositionConnectEventCompatible(source semanticview.Source, connect runti
 	return false
 }
 
-func validateCompositionConnectDelivery(connect runtimecontracts.FlowPackageConnect, inputPin runtimecontracts.FlowInputEventPin, receiverSchema runtimecontracts.FlowSchemaDocument, receiverFlowID string) []Finding {
+func validateCompositionConnectDelivery(connect runtimecontracts.FlowPackageConnect, inputPin runtimecontracts.FlowInputEventPin, receiverSchema runtimecontracts.FlowSchemaDocument, receiverFlowID string, hasInstanceKeyRoute bool) []Finding {
 	var findings []Finding
 	delivery := strings.TrimSpace(connect.Delivery)
 	if delivery == "" && inputPin.Address != nil {
@@ -160,8 +165,8 @@ func validateCompositionConnectDelivery(connect runtimecontracts.FlowPackageConn
 		findings = append(findings, compositionConnectFinding(connect, "reply_lineage_missing", "reply delivery requires a reply lineage declaration", receiverFlowID))
 	}
 	if inputPin.Address == nil {
-		if compositionReceiverAddressRequired(receiverSchema) && delivery != "broadcast" {
-			findings = append(findings, compositionConnectFinding(connect, "receiver_address_rule_missing", fmt.Sprintf("receiver flow %s requires an addressed input pin", receiverFlowID), receiverFlowID))
+		if compositionReceiverAddressRequired(receiverSchema) && !hasInstanceKeyRoute && delivery != "broadcast" {
+			findings = append(findings, compositionConnectFinding(connect, "receiver_route_key_missing", fmt.Sprintf("receiver flow %s requires a matching instance key route or an explicit addressed input pin", receiverFlowID), receiverFlowID))
 		}
 		return findings
 	}
@@ -191,6 +196,61 @@ func validateCompositionConnectDelivery(connect runtimecontracts.FlowPackageConn
 
 func compositionReceiverAddressRequired(schema runtimecontracts.FlowSchemaDocument) bool {
 	return strings.EqualFold(strings.TrimSpace(schema.Mode), "template")
+}
+
+func validateCompositionConnectInstanceKey(source semanticview.Source, connect runtimecontracts.FlowPackageConnect, outputPin runtimecontracts.FlowOutputEventPin, inputPin runtimecontracts.FlowInputEventPin, producerFlowID, receiverFlowID string) []Finding {
+	if inputPin.Address != nil {
+		return nil
+	}
+	if strings.TrimSpace(connect.Delivery) == "broadcast" {
+		return nil
+	}
+	receiverSchema, ok := source.FlowSchemaByID(receiverFlowID)
+	if !ok || !compositionReceiverAddressRequired(receiverSchema) {
+		return nil
+	}
+	if len(connect.Map) > 0 {
+		for key := range connect.Map {
+			return []Finding{compositionConnectFinding(connect, "connect_key_adapter_unsupported", fmt.Sprintf("connect map key %s is a renamed-key adapter surface and is tracked separately from same-name instance-key routing", key), receiverFlowID)}
+		}
+	}
+	bundle, ok := semanticview.Bundle(source)
+	if !ok {
+		return []Finding{compositionConnectFinding(connect, "receiver_instance_key_unavailable", "receiver instance key owner is unavailable for this semantic source", receiverFlowID)}
+	}
+	instance, err := bundle.ResolveFlowTemplateInstance(receiverFlowID)
+	if err != nil {
+		return []Finding{compositionConnectFinding(connect, "receiver_instance_key_invalid", err.Error(), receiverFlowID)}
+	}
+	outputKey := strings.TrimSpace(outputPin.Key)
+	if outputKey == "" {
+		return []Finding{compositionConnectFinding(connect, "output_key_missing", "producer output pin must declare key before it can route to a receiver instance key", producerFlowID)}
+	}
+	carries := outputPinCarries(outputPin)
+	if !stringSliceContains(carries, outputKey) {
+		return []Finding{compositionConnectFinding(connect, "output_carries_instance_key", fmt.Sprintf("producer output pin key %s must also be listed in carries", outputKey), producerFlowID)}
+	}
+	if !stringSliceContains(instance.By, outputKey) {
+		return []Finding{compositionConnectFinding(connect, "instance_key_mismatch", fmt.Sprintf("producer output key %s does not match receiver instance.by %v", outputKey, instance.By), receiverFlowID)}
+	}
+	for _, field := range instance.By {
+		field = strings.TrimSpace(field)
+		if !stringSliceContains(carries, field) {
+			return []Finding{compositionConnectFinding(connect, "output_carries_instance_key", fmt.Sprintf("producer output pin carries must include receiver instance.by field %s", field), producerFlowID)}
+		}
+		sourceType, err := outputPinKeyCarriesSourceType(source, producerFlowID, outputPin, "payload."+field)
+		if err != nil {
+			return []Finding{compositionConnectFinding(connect, "output_carries_instance_key", err.Error(), producerFlowID)}
+		}
+		targetType, err := compositionConnectTargetType(source, receiverFlowID, "entity."+field)
+		if err != nil {
+			return []Finding{compositionConnectFinding(connect, "receiver_instance_key_invalid", err.Error(), receiverFlowID)}
+		}
+		if !compositionConnectTypesCompatible(sourceType, targetType) {
+			return []Finding{compositionConnectFinding(connect, "key_types_incompatible", fmt.Sprintf("source payload.%s type %s is incompatible with receiver instance.by field entity.%s type %s", field, sourceType, field, targetType), receiverFlowID)}
+		}
+	}
+	return nil
 }
 
 func validateCompositionConnectAddress(source semanticview.Source, connect runtimecontracts.FlowPackageConnect, outputPin runtimecontracts.FlowOutputEventPin, inputPin runtimecontracts.FlowInputEventPin, producerFlowID, receiverFlowID string) []Finding {
@@ -383,4 +443,17 @@ func firstNonEmpty(values ...string) string {
 		}
 	}
 	return ""
+}
+
+func stringSliceContains(values []string, needle string) bool {
+	needle = strings.TrimSpace(needle)
+	if needle == "" {
+		return false
+	}
+	for _, value := range values {
+		if strings.TrimSpace(value) == needle {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/runtime/bootverify/workflow_composition_connect_checks.go
+++ b/internal/runtime/bootverify/workflow_composition_connect_checks.go
@@ -238,7 +238,7 @@ func validateCompositionConnectInstanceKey(source semanticview.Source, connect r
 		if !stringSliceContains(carries, field) {
 			return []Finding{compositionConnectFinding(connect, "output_carries_instance_key", fmt.Sprintf("producer output pin carries must include receiver instance.by field %s", field), producerFlowID)}
 		}
-		sourceType, err := outputPinKeyCarriesSourceType(source, producerFlowID, outputPin, "payload."+field)
+		sourceType, err := outputPinCarriedPayloadFieldType(source, producerFlowID, outputPin, field)
 		if err != nil {
 			return []Finding{compositionConnectFinding(connect, "output_carries_instance_key", err.Error(), producerFlowID)}
 		}

--- a/internal/runtime/bootverify/workflow_composition_connect_checks_test.go
+++ b/internal/runtime/bootverify/workflow_composition_connect_checks_test.go
@@ -41,6 +41,26 @@ func TestRun_AllowsRootProducerCompositionConnectAsRouteProof(t *testing.T) {
 	}
 }
 
+func TestRun_AllowsTemplateInstanceKeyCompositionConnectWithoutAddress(t *testing.T) {
+	root := writeCompositionConnectBootverifyFixture(t, compositionConnectFixtureOptions{
+		consumerMode:             "template",
+		consumerScalarInput:      true,
+		consumerTemplateInstance: true,
+		connectTo:                "consumer.deploy.completed",
+		omitMap:                  true,
+	})
+	bundle := loadFixtureBundleAt(t, repoRootForBootverifyTest(t), root, runtimecontracts.DefaultPlatformSpecFile(repoRootForBootverifyTest(t)))
+
+	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+
+	if reportContains(report.Errors(), "composition_connect_validation", "") {
+		t.Fatalf("unexpected composition_connect_validation error: %#v", report.Errors())
+	}
+	if reportContains(report.Errors(), "template_instance_validation", "") {
+		t.Fatalf("unexpected template_instance_validation error: %#v", report.Errors())
+	}
+}
+
 func TestRun_FailsClosedForInvalidParentCompositionConnect(t *testing.T) {
 	tests := []struct {
 		name      string
@@ -149,8 +169,19 @@ func TestRun_FailsClosedForInvalidParentCompositionConnect(t *testing.T) {
 				consumerMode:        "template",
 				consumerScalarInput: true,
 				connectTo:           "consumer.deploy.completed",
+				omitMap:             true,
 			},
-			want: "receiver_address_rule_missing",
+			want: "receiver_instance_key_invalid",
+		},
+		{
+			name: "template instance key route rejects renamed connect map",
+			opts: compositionConnectFixtureOptions{
+				consumerMode:             "template",
+				consumerScalarInput:      true,
+				consumerTemplateInstance: true,
+				connectTo:                "consumer.deploy.completed",
+			},
+			want: "connect_key_adapter_unsupported",
 		},
 	}
 	for _, tc := range tests {
@@ -371,6 +402,7 @@ type compositionConnectFixtureOptions struct {
 	producerAutoEmit           bool
 	producerTimer              bool
 	duplicateProducerOutputKey bool
+	consumerTemplateInstance   bool
 }
 
 func writeCompositionConnectBootverifyFixture(t *testing.T, opts compositionConnectFixtureOptions) string {
@@ -867,9 +899,18 @@ requires:
       - deploy.completed
 `
 	}
+	instanceBlock := ""
+	if opts.consumerTemplateInstance {
+		instanceBlock = `instance:
+  by: vertical_id
+  on_missing: reject
+  on_conflict: reject
+`
+	}
 	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "consumer", "schema.yaml"), `
 name: consumer
 mode: `+firstTestValue(opts.consumerMode, "static")+`
+`+instanceBlock+`
 initial_state: idle
 terminal_states: [done]
 states: [idle, done]
@@ -882,7 +923,7 @@ pins:
 deploy.completed:
   vertical_id: string
 `)
-	if !opts.consumerScalarInput {
+	if !opts.consumerScalarInput || opts.consumerTemplateInstance {
 		entityType := firstTestValue(opts.consumerEntityType, "string")
 		indexed := "\n    indexed: true"
 		if opts.consumerEntityUnindexed {
@@ -893,6 +934,7 @@ deployment:
   vertical_id:
     type: `+entityType+`
 `+indexed+`
+    _unused_reason: composition connect route-key proof field
 `)
 	}
 	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "consumer", "nodes.yaml"), `

--- a/internal/runtime/bootverify/workflow_composition_connect_checks_test.go
+++ b/internal/runtime/bootverify/workflow_composition_connect_checks_test.go
@@ -61,6 +61,32 @@ func TestRun_AllowsTemplateInstanceKeyCompositionConnectWithoutAddress(t *testin
 	}
 }
 
+func TestRun_AllowsCompositeTemplateInstanceKeyCompositionConnectWithoutAddress(t *testing.T) {
+	root := writeCompositionConnectBootverifyFixture(t, compositionConnectFixtureOptions{
+		consumerMode:                   "template",
+		consumerScalarInput:            true,
+		consumerTemplateInstance:       true,
+		consumerTemplateInstanceBy:     "[vertical_id, region]",
+		consumerTemplateInstanceRegion: true,
+		producerOutputCarries:          "[vertical_id, region]",
+		connectTo:                      "consumer.deploy.completed",
+		omitMap:                        true,
+	})
+	bundle := loadFixtureBundleAt(t, repoRootForBootverifyTest(t), root, runtimecontracts.DefaultPlatformSpecFile(repoRootForBootverifyTest(t)))
+
+	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+
+	if reportContains(report.Errors(), "composition_connect_validation", "") {
+		t.Fatalf("unexpected composition_connect_validation error: %#v", report.Errors())
+	}
+	if reportContains(report.Errors(), "output_pin_key_carries_validation", "") {
+		t.Fatalf("unexpected output_pin_key_carries_validation error: %#v", report.Errors())
+	}
+	if reportContains(report.Errors(), "template_instance_validation", "") {
+		t.Fatalf("unexpected template_instance_validation error: %#v", report.Errors())
+	}
+}
+
 func TestRun_FailsClosedForInvalidParentCompositionConnect(t *testing.T) {
 	tests := []struct {
 		name      string
@@ -377,32 +403,34 @@ func TestRun_TreatsParentCompositionConnectAsEventTopologyProof(t *testing.T) {
 }
 
 type compositionConnectFixtureOptions struct {
-	connectFrom                string
-	connectTo                  string
-	delivery                   string
-	noAdapter                  bool
-	mapSource                  string
-	mapTarget                  string
-	omitMap                    bool
-	consumerMode               string
-	consumerScalarInput        bool
-	consumerEntityType         string
-	consumerEntityUnindexed    bool
-	consumerRequiresInput      bool
-	consumerInputBind          string
-	producerRequiresOutput     bool
-	producerOutputBind         string
-	producerOutputKey          string
-	producerOutputCarries      string
-	omitProducerOutputKey      bool
-	omitProducerOutputCarries  bool
-	omitProducerEmitField      bool
-	producerVerticalIDType     string
-	producerAgentEmit          bool
-	producerAutoEmit           bool
-	producerTimer              bool
-	duplicateProducerOutputKey bool
-	consumerTemplateInstance   bool
+	connectFrom                    string
+	connectTo                      string
+	delivery                       string
+	noAdapter                      bool
+	mapSource                      string
+	mapTarget                      string
+	omitMap                        bool
+	consumerMode                   string
+	consumerScalarInput            bool
+	consumerEntityType             string
+	consumerEntityUnindexed        bool
+	consumerRequiresInput          bool
+	consumerInputBind              string
+	producerRequiresOutput         bool
+	producerOutputBind             string
+	producerOutputKey              string
+	producerOutputCarries          string
+	omitProducerOutputKey          bool
+	omitProducerOutputCarries      bool
+	omitProducerEmitField          bool
+	producerVerticalIDType         string
+	producerAgentEmit              bool
+	producerAutoEmit               bool
+	producerTimer                  bool
+	duplicateProducerOutputKey     bool
+	consumerTemplateInstance       bool
+	consumerTemplateInstanceBy     string
+	consumerTemplateInstanceRegion bool
 }
 
 func writeCompositionConnectBootverifyFixture(t *testing.T, opts compositionConnectFixtureOptions) string {
@@ -801,6 +829,8 @@ requires:
 	emitField := "          vertical_id: payload.vertical_id\n"
 	if opts.omitProducerEmitField {
 		emitField = ""
+	} else if opts.consumerTemplateInstanceRegion {
+		emitField += "          region: payload.region\n"
 	}
 	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "producer", "schema.yaml"), `
 name: producer
@@ -820,6 +850,9 @@ pins:
 	}
 	verticalIDType := firstTestValue(opts.producerVerticalIDType, "string")
 	verticalIDSchema := "  vertical_id: " + verticalIDType + "\n"
+	if opts.consumerTemplateInstanceRegion {
+		verticalIDSchema += "  region: string\n"
+	}
 	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "producer", "events.yaml"), `
 deploy.requested:
   vertical_id: string
@@ -901,8 +934,9 @@ requires:
 	}
 	instanceBlock := ""
 	if opts.consumerTemplateInstance {
+		instanceBy := firstTestValue(opts.consumerTemplateInstanceBy, "vertical_id")
 		instanceBlock = `instance:
-  by: vertical_id
+  by: ` + instanceBy + `
   on_missing: reject
   on_conflict: reject
 `
@@ -922,7 +956,7 @@ pins:
 	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "consumer", "events.yaml"), `
 deploy.completed:
   vertical_id: string
-`)
+`+compositionConnectConsumerRegionEventSchema(opts))
 	if !opts.consumerScalarInput || opts.consumerTemplateInstance {
 		entityType := firstTestValue(opts.consumerEntityType, "string")
 		indexed := "\n    indexed: true"
@@ -935,6 +969,7 @@ deployment:
     type: `+entityType+`
 `+indexed+`
     _unused_reason: composition connect route-key proof field
+`+compositionConnectConsumerRegionEntitySchema(opts)+`
 `)
 	}
 	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "consumer", "nodes.yaml"), `
@@ -947,6 +982,23 @@ consumer-node:
       create_entity: true
       advances_to: done
 `)
+}
+
+func compositionConnectConsumerRegionEventSchema(opts compositionConnectFixtureOptions) string {
+	if !opts.consumerTemplateInstanceRegion {
+		return ""
+	}
+	return "  region: string\n"
+}
+
+func compositionConnectConsumerRegionEntitySchema(opts compositionConnectFixtureOptions) string {
+	if !opts.consumerTemplateInstanceRegion {
+		return ""
+	}
+	return `  region:
+    type: string
+    _unused_reason: composite template instance key proof field
+`
 }
 
 func firstTestValue(values ...string) string {

--- a/internal/runtime/bootverify/workflow_output_pin_key_carries_checks.go
+++ b/internal/runtime/bootverify/workflow_output_pin_key_carries_checks.go
@@ -229,6 +229,32 @@ func outputPinKeyCarriesSourceType(source semanticview.Source, flowID string, pi
 	return typ, nil
 }
 
+func outputPinCarriedPayloadFieldType(source semanticview.Source, flowID string, pin runtimecontracts.FlowOutputEventPin, field string) (string, error) {
+	field = strings.TrimSpace(field)
+	if field == "" || strings.Contains(field, ".") {
+		return "", fmt.Errorf("producer output pin %s carried instance-key field %q must be a single top-level payload field", pin.PinName(), field)
+	}
+	key := strings.TrimSpace(pin.Key)
+	if key == "" {
+		return "", fmt.Errorf("producer output pin %s must declare key before it can supply payload.%s", pin.PinName(), field)
+	}
+	carries := outputPinCarries(pin)
+	if !outputPinStringSetContains(carries, key) {
+		return "", fmt.Errorf("producer output pin %s must include key %s in carries", pin.PinName(), key)
+	}
+	if !outputPinStringSetContains(carries, field) {
+		return "", fmt.Errorf("producer output pin %s must include receiver instance.by field %s in carries", pin.PinName(), field)
+	}
+	typ, err := outputPinPayloadFieldType(source, flowID, pin.EventType(), field)
+	if err != nil {
+		return "", err
+	}
+	if !outputPinScalarType(typ) {
+		return "", fmt.Errorf("producer output event %s payload field %s type %s is not a scalar key type", pin.EventType(), field, typ)
+	}
+	return typ, nil
+}
+
 func outputPinPayloadFieldType(source semanticview.Source, flowID, eventType, field string) (string, error) {
 	field = strings.TrimSpace(field)
 	if field == "" {

--- a/internal/runtime/bus/connect_route_plan_dispatch_test.go
+++ b/internal/runtime/bus/connect_route_plan_dispatch_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -661,6 +663,169 @@ func TestEventBusPublish_ConnectRoutePlanPersistsIndexedBusinessFieldTarget(t *t
 	}
 }
 
+func TestEventBusPublish_ConnectRoutePlanPersistsTemplateInstanceKeyTarget(t *testing.T) {
+	source := connectRoutePlanInstanceKeySource(t)
+	store := &connectRoutePlanDescriptorStore{
+		targetRouteMemoryStore: newTargetRouteMemoryStore(),
+		flowInstances: []ActiveFlowInstanceDescriptor{{
+			InstanceID:    "one",
+			EntityID:      "ent-1",
+			FlowInstance:  "consumer/one",
+			AddressFields: map[string]string{"entity.vertical_id": "v-1"},
+		}},
+	}
+	eb, err := NewEventBusWithOptions(store, EventBusOptions{ContractBundle: source})
+	if err != nil {
+		t.Fatalf("NewEventBusWithOptions: %v", err)
+	}
+	if err := eb.AddFlowInstanceRoute(FlowInstanceRouteMaterializationRequest{Identity: runtimeflowidentity.DeriveRoute("consumer", "one")}); err != nil {
+		t.Fatalf("AddFlowInstanceRoute: %v", err)
+	}
+	eventID := uuid.NewString()
+	evt := eventtest.RootIngress(eventID,
+		events.EventType("producer/deploy.done"), "", "", json.RawMessage(`{"vertical_id":"v-1"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())
+
+	want := events.DeliveryRoute{SubscriberType: "node", SubscriberID: "consumer-node-one", Target: events.RouteIdentity{FlowID: "consumer", FlowInstance: "consumer/one", EntityID: "ent-1"}}
+
+	routePlan, err := eb.planSubscribedRoutePlan(context.Background(), evt, false)
+	if err != nil {
+		t.Fatalf("planSubscribedRoutePlan: %v", err)
+	}
+	if routePlan.AuthorityState != RoutePlanAuthorityCanonicalMatched || routePlan.AuthorityOwner != routePlanSourceConnectRoutePlan {
+		t.Fatalf("route plan authority = %q/%q, want matched connect route plan", routePlan.AuthorityState, routePlan.AuthorityOwner)
+	}
+	if !deliveryRoutesContain(routePlan.DeliveryRoutes(), want) || len(routePlan.DeliveryRoutes()) != 1 {
+		t.Fatalf("route plan delivery routes = %#v, want instance-key route %#v", routePlan.DeliveryRoutes(), want)
+	}
+
+	plan, err := eb.CheckPublishRecipientPlan(context.Background(), evt)
+	if err != nil {
+		t.Fatalf("CheckPublishRecipientPlan: %v", err)
+	}
+	if plan.TargetFailure != "" {
+		t.Fatalf("target failure = %q, want none", plan.TargetFailure)
+	}
+	if !deliveryRoutesContain(plan.DeliveryRoutes, want) || len(plan.DeliveryRoutes) != 1 {
+		t.Fatalf("preflight delivery routes = %#v, want instance-key route %#v", plan.DeliveryRoutes, want)
+	}
+
+	if err := eb.Publish(context.Background(), evt); err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+	if !deliveryRoutesContain(store.routes[eventID], want) || len(store.routes[eventID]) != 1 {
+		t.Fatalf("persisted delivery routes = %#v, want instance-key route %#v", store.routes[eventID], want)
+	}
+	live, internal, replayRoutes, err := eb.replayRecipientsForCommittedEvent(context.Background(), evt, nil, runtimereplayclaim.CommittedReplayScopeSubscribed)
+	if err != nil {
+		t.Fatalf("replayRecipientsForCommittedEvent: %v", err)
+	}
+	if !containsString(live, "consumer-node-one") || !containsString(internal, "consumer-node-one") {
+		t.Fatalf("replay live=%#v internal=%#v, want consumer-node-one from persisted connect route", live, internal)
+	}
+	if !deliveryRoutesContain(replayRoutes, want) {
+		t.Fatalf("replay delivery routes = %#v, want %#v", replayRoutes, want)
+	}
+}
+
+func TestEventBusPublish_ConnectRoutePlanFailsClosedForTemplateInstanceKeyGaps(t *testing.T) {
+	tests := []struct {
+		name          string
+		payload       string
+		flowInstances []ActiveFlowInstanceDescriptor
+		addRoutes     []string
+		wantFailure   runtimepinrouting.TargetFailure
+	}{
+		{
+			name:        "missing source key value",
+			payload:     `{}`,
+			wantFailure: runtimepinrouting.TargetFailure(runtimepinrouting.ConnectFailureAddressValueMissing),
+		},
+		{
+			name:    "no receiver instance under rejecting policy",
+			payload: `{"vertical_id":"v-1"}`,
+			flowInstances: []ActiveFlowInstanceDescriptor{{
+				InstanceID:    "two",
+				EntityID:      "ent-2",
+				FlowInstance:  "consumer/two",
+				AddressFields: map[string]string{"entity.vertical_id": "v-2"},
+			}},
+			addRoutes:   []string{"two"},
+			wantFailure: runtimepinrouting.TargetFailure(runtimepinrouting.ConnectFailureTargetUnresolved),
+		},
+		{
+			name:    "ambiguous receiver instance key",
+			payload: `{"vertical_id":"v-1"}`,
+			flowInstances: []ActiveFlowInstanceDescriptor{
+				{InstanceID: "one", EntityID: "ent-1", FlowInstance: "consumer/one", AddressFields: map[string]string{"entity.vertical_id": "v-1"}},
+				{InstanceID: "two", EntityID: "ent-2", FlowInstance: "consumer/two", AddressFields: map[string]string{"entity.vertical_id": "v-1"}},
+			},
+			addRoutes:   []string{"one", "two"},
+			wantFailure: runtimepinrouting.TargetFailure(runtimepinrouting.ConnectFailureTargetAmbiguous),
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			source := connectRoutePlanInstanceKeySource(t)
+			store := &connectRoutePlanDescriptorStore{
+				targetRouteMemoryStore: newTargetRouteMemoryStore(),
+				flowInstances:          tc.flowInstances,
+			}
+			eb, err := NewEventBusWithOptions(store, EventBusOptions{ContractBundle: source})
+			if err != nil {
+				t.Fatalf("NewEventBusWithOptions: %v", err)
+			}
+			for _, instanceID := range tc.addRoutes {
+				if err := eb.AddFlowInstanceRoute(FlowInstanceRouteMaterializationRequest{Identity: runtimeflowidentity.DeriveRoute("consumer", instanceID)}); err != nil {
+					t.Fatalf("AddFlowInstanceRoute(%s): %v", instanceID, err)
+				}
+			}
+			raw := eb.Subscribe("raw-source-listener", events.EventType("producer/deploy.done"), events.EventType("deploy.done"))
+			defer eb.Unsubscribe("raw-source-listener")
+			eventID := uuid.NewString()
+			evt := eventtest.RootIngress(eventID,
+				events.EventType("producer/deploy.done"), "", "", json.RawMessage(tc.payload), 0, "", "", events.EventEnvelope{}, time.Now().UTC())
+
+			routePlan, err := eb.planSubscribedRoutePlan(context.Background(), evt, false)
+			if err != nil {
+				t.Fatalf("planSubscribedRoutePlan: %v", err)
+			}
+			if routePlan.AuthorityState != RoutePlanAuthorityCanonicalFailedClosed || routePlan.AuthorityOwner != routePlanSourceConnectRoutePlan {
+				t.Fatalf("route plan authority = %q/%q, want fail-closed connect route plan", routePlan.AuthorityState, routePlan.AuthorityOwner)
+			}
+			if routePlan.TargetFailure != tc.wantFailure {
+				t.Fatalf("target failure = %q, want %q", routePlan.TargetFailure, tc.wantFailure)
+			}
+			if len(routePlan.LiveRecipients) != 0 || len(routePlan.DeliveryIntents) != 0 || len(routePlan.RoutedRecipients) != 0 ||
+				len(routePlan.SubscribedRecipients) != 0 || len(routePlan.RecipientIDs()) != 0 ||
+				len(routePlan.PersistedRecipientIDs()) != 0 || len(routePlan.DeliveryRoutes()) != 0 {
+				t.Fatalf("fail-closed instance-key route exposed lower-precedence fallback: live=%#v intents=%#v routed=%#v subscriptions=%#v recipients=%#v persisted=%#v routes=%#v",
+					routePlan.LiveRecipients, routePlan.DeliveryIntents, routePlan.RoutedRecipients, routePlan.SubscribedRecipients,
+					routePlan.RecipientIDs(), routePlan.PersistedRecipientIDs(), routePlan.DeliveryRoutes())
+			}
+
+			plan, err := eb.CheckPublishRecipientPlan(context.Background(), evt)
+			if err != nil {
+				t.Fatalf("CheckPublishRecipientPlan: %v", err)
+			}
+			if got, want := plan.TargetFailure, string(tc.wantFailure); got != want {
+				t.Fatalf("preflight target failure = %q, want %q", got, want)
+			}
+			if len(plan.Recipients) != 0 || len(plan.PersistedRecipients) != 0 || len(plan.RoutedRecipients) != 0 ||
+				len(plan.SubscriptionRecipients) != 0 || len(plan.DeliveryRoutes) != 0 {
+				t.Fatalf("preflight exposed lower-precedence fallback: recipients=%#v persisted=%#v routed=%#v subscriptions=%#v routes=%#v",
+					plan.Recipients, plan.PersistedRecipients, plan.RoutedRecipients, plan.SubscriptionRecipients, plan.DeliveryRoutes)
+			}
+			if err := eb.Publish(context.Background(), evt); err != nil {
+				t.Fatalf("Publish: %v", err)
+			}
+			if routes := store.routes[eventID]; len(routes) != 0 {
+				t.Fatalf("persisted delivery routes = %#v, want none for fail-closed instance-key route", routes)
+			}
+			requireNoConnectRoutePlanBusEvent(t, raw, "source/raw subscriber fallback")
+		})
+	}
+}
+
 func TestEventBusPublish_ConnectRoutePlanPersistsIndexedBusinessFieldTargetSet(t *testing.T) {
 	source := connectRoutePlanBusinessFieldSource("many", true)
 	store := &connectRoutePlanDescriptorStore{
@@ -1137,6 +1302,103 @@ func TestRoutePlanNormalizationPreservesAuthorityState(t *testing.T) {
 	}
 	if !deliveryRoutesContain(got.DeliveryRoutes(), connectRoutePlanStaticDeliveryRoute()) {
 		t.Fatalf("normalized route plan delivery routes = %#v, want static connect route", got.DeliveryRoutes())
+	}
+}
+
+func connectRoutePlanInstanceKeySource(t testing.TB) semanticview.Source {
+	t.Helper()
+	repoRoot, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd: %v", err)
+	}
+	repoRoot = filepath.Clean(filepath.Join(repoRoot, "..", "..", ".."))
+	root := writeConnectRoutePlanInstanceKeyFixture(t)
+	bundle, err := runtimecontracts.LoadWorkflowContractBundleWithOverrides(repoRoot, root, runtimecontracts.DefaultPlatformSpecFile(repoRoot))
+	if err != nil {
+		t.Fatalf("LoadWorkflowContractBundleWithOverrides: %v", err)
+	}
+	return semanticview.Wrap(bundle)
+}
+
+func writeConnectRoutePlanInstanceKeyFixture(t testing.TB) string {
+	t.Helper()
+	root := t.TempDir()
+	writeConnectRoutePlanBusFixtureFile(t, filepath.Join(root, "package.yaml"), `
+name: instance-key-connect-route-plan-bus
+version: "1.0.0"
+platform_version: ">=1.6.0"
+flows:
+  - id: producer
+    flow: producer
+    mode: static
+  - id: consumer
+    flow: consumer
+    mode: template
+connect:
+  - from: producer.deploy_done
+    to: consumer.deploy_completed
+    delivery: one
+`)
+	writeConnectRoutePlanBusFixtureFile(t, filepath.Join(root, "schema.yaml"), "name: instance-key-connect-route-plan-bus\n")
+	writeConnectRoutePlanBusFixtureFile(t, filepath.Join(root, "policy.yaml"), "{}\n")
+	writeConnectRoutePlanBusFixtureFile(t, filepath.Join(root, "tools.yaml"), "{}\n")
+	writeConnectRoutePlanBusFixtureFile(t, filepath.Join(root, "agents.yaml"), "{}\n")
+	writeConnectRoutePlanBusFixtureFile(t, filepath.Join(root, "events.yaml"), "{}\n")
+	writeConnectRoutePlanBusFixtureFile(t, filepath.Join(root, "nodes.yaml"), "{}\n")
+	writeConnectRoutePlanBusFixtureFile(t, filepath.Join(root, "flows", "producer", "schema.yaml"), `
+name: producer
+mode: static
+pins:
+  outputs:
+    events:
+      - name: deploy_done
+        event: deploy.done
+        key: vertical_id
+        carries: [vertical_id]
+`)
+	writeConnectRoutePlanBusFixtureFile(t, filepath.Join(root, "flows", "producer", "policy.yaml"), "{}\n")
+	writeConnectRoutePlanBusFixtureFile(t, filepath.Join(root, "flows", "producer", "agents.yaml"), "{}\n")
+	writeConnectRoutePlanBusFixtureFile(t, filepath.Join(root, "flows", "producer", "events.yaml"), "deploy.done:\n  vertical_id: string\n")
+	writeConnectRoutePlanBusFixtureFile(t, filepath.Join(root, "flows", "producer", "entities.yaml"), "{}\n")
+	writeConnectRoutePlanBusFixtureFile(t, filepath.Join(root, "flows", "producer", "nodes.yaml"), "{}\n")
+	writeConnectRoutePlanBusFixtureFile(t, filepath.Join(root, "flows", "consumer", "schema.yaml"), `
+name: consumer
+mode: template
+instance:
+  by: vertical_id
+  on_missing: reject
+  on_conflict: reject
+pins:
+  inputs:
+    events:
+      - name: deploy_completed
+        event: deploy.done
+`)
+	writeConnectRoutePlanBusFixtureFile(t, filepath.Join(root, "flows", "consumer", "policy.yaml"), "{}\n")
+	writeConnectRoutePlanBusFixtureFile(t, filepath.Join(root, "flows", "consumer", "agents.yaml"), "{}\n")
+	writeConnectRoutePlanBusFixtureFile(t, filepath.Join(root, "flows", "consumer", "events.yaml"), "deploy.done:\n  vertical_id: string\n")
+	writeConnectRoutePlanBusFixtureFile(t, filepath.Join(root, "flows", "consumer", "entities.yaml"), `
+deployment:
+  vertical_id:
+    type: string
+`)
+	writeConnectRoutePlanBusFixtureFile(t, filepath.Join(root, "flows", "consumer", "nodes.yaml"), `
+consumer-node:
+  id: consumer-node-{instance_id}
+  execution_type: system_node
+  event_handlers:
+    deploy.done: {}
+`)
+	return root
+}
+
+func writeConnectRoutePlanBusFixtureFile(t testing.TB, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("MkdirAll(%s): %v", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("WriteFile(%s): %v", path, err)
 	}
 }
 

--- a/internal/runtime/bus/connect_route_plan_dispatch_test.go
+++ b/internal/runtime/bus/connect_route_plan_dispatch_test.go
@@ -727,6 +727,62 @@ func TestEventBusPublish_ConnectRoutePlanPersistsTemplateInstanceKeyTarget(t *te
 	}
 }
 
+func TestEventBusPublish_ConnectRoutePlanBroadcastIgnoresInstanceKeyFiltering(t *testing.T) {
+	source := connectRoutePlanInstanceKeyBroadcastSource(t)
+	store := &connectRoutePlanDescriptorStore{
+		targetRouteMemoryStore: newTargetRouteMemoryStore(),
+		flowInstances: []ActiveFlowInstanceDescriptor{
+			{InstanceID: "one", EntityID: "ent-1", FlowInstance: "consumer/one", AddressFields: map[string]string{"entity.vertical_id": "v-1"}},
+			{InstanceID: "two", EntityID: "ent-2", FlowInstance: "consumer/two", AddressFields: map[string]string{"entity.vertical_id": "v-2"}},
+			{InstanceID: "other", EntityID: "ent-3", FlowInstance: "other/three", AddressFields: map[string]string{"entity.vertical_id": "v-1"}},
+		},
+	}
+	eb, err := NewEventBusWithOptions(store, EventBusOptions{ContractBundle: source})
+	if err != nil {
+		t.Fatalf("NewEventBusWithOptions: %v", err)
+	}
+	for _, instanceID := range []string{"one", "two"} {
+		if err := eb.AddFlowInstanceRoute(FlowInstanceRouteMaterializationRequest{Identity: runtimeflowidentity.DeriveRoute("consumer", instanceID)}); err != nil {
+			t.Fatalf("AddFlowInstanceRoute(%s): %v", instanceID, err)
+		}
+	}
+	eventID := uuid.NewString()
+	evt := eventtest.RootIngress(eventID,
+		events.EventType("producer/deploy.done"), "", "", json.RawMessage(`{"vertical_id":"v-1"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())
+
+	wantOne := events.DeliveryRoute{SubscriberType: "node", SubscriberID: "consumer-node-one", Target: events.RouteIdentity{FlowID: "consumer", FlowInstance: "consumer/one", EntityID: "ent-1"}}
+	wantTwo := events.DeliveryRoute{SubscriberType: "node", SubscriberID: "consumer-node-two", Target: events.RouteIdentity{FlowID: "consumer", FlowInstance: "consumer/two", EntityID: "ent-2"}}
+
+	routePlan, err := eb.planSubscribedRoutePlan(context.Background(), evt, false)
+	if err != nil {
+		t.Fatalf("planSubscribedRoutePlan: %v", err)
+	}
+	if routePlan.AuthorityState != RoutePlanAuthorityCanonicalMatched || routePlan.AuthorityOwner != routePlanSourceConnectRoutePlan {
+		t.Fatalf("route plan authority = %q/%q, want matched connect route plan", routePlan.AuthorityState, routePlan.AuthorityOwner)
+	}
+	if !deliveryRoutesContain(routePlan.DeliveryRoutes(), wantOne) || !deliveryRoutesContain(routePlan.DeliveryRoutes(), wantTwo) || len(routePlan.DeliveryRoutes()) != 2 {
+		t.Fatalf("route plan delivery routes = %#v, want broadcast routes %#v and %#v", routePlan.DeliveryRoutes(), wantOne, wantTwo)
+	}
+
+	plan, err := eb.CheckPublishRecipientPlan(context.Background(), evt)
+	if err != nil {
+		t.Fatalf("CheckPublishRecipientPlan: %v", err)
+	}
+	if plan.TargetFailure != "" {
+		t.Fatalf("target failure = %q, want none", plan.TargetFailure)
+	}
+	if !deliveryRoutesContain(plan.DeliveryRoutes, wantOne) || !deliveryRoutesContain(plan.DeliveryRoutes, wantTwo) || len(plan.DeliveryRoutes) != 2 {
+		t.Fatalf("preflight delivery routes = %#v, want broadcast routes %#v and %#v", plan.DeliveryRoutes, wantOne, wantTwo)
+	}
+
+	if err := eb.Publish(context.Background(), evt); err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+	if !deliveryRoutesContain(store.routes[eventID], wantOne) || !deliveryRoutesContain(store.routes[eventID], wantTwo) || len(store.routes[eventID]) != 2 {
+		t.Fatalf("persisted delivery routes = %#v, want broadcast routes %#v and %#v", store.routes[eventID], wantOne, wantTwo)
+	}
+}
+
 func TestEventBusPublish_ConnectRoutePlanFailsClosedForTemplateInstanceKeyGaps(t *testing.T) {
 	tests := []struct {
 		name          string
@@ -1320,7 +1376,26 @@ func connectRoutePlanInstanceKeySource(t testing.TB) semanticview.Source {
 	return semanticview.Wrap(bundle)
 }
 
+func connectRoutePlanInstanceKeyBroadcastSource(t testing.TB) semanticview.Source {
+	t.Helper()
+	repoRoot, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd: %v", err)
+	}
+	repoRoot = filepath.Clean(filepath.Join(repoRoot, "..", "..", ".."))
+	root := writeConnectRoutePlanInstanceKeyFixtureWithDelivery(t, "broadcast")
+	bundle, err := runtimecontracts.LoadWorkflowContractBundleWithOverrides(repoRoot, root, runtimecontracts.DefaultPlatformSpecFile(repoRoot))
+	if err != nil {
+		t.Fatalf("LoadWorkflowContractBundleWithOverrides: %v", err)
+	}
+	return semanticview.Wrap(bundle)
+}
+
 func writeConnectRoutePlanInstanceKeyFixture(t testing.TB) string {
+	return writeConnectRoutePlanInstanceKeyFixtureWithDelivery(t, "one")
+}
+
+func writeConnectRoutePlanInstanceKeyFixtureWithDelivery(t testing.TB, delivery string) string {
 	t.Helper()
 	root := t.TempDir()
 	writeConnectRoutePlanBusFixtureFile(t, filepath.Join(root, "package.yaml"), `
@@ -1337,7 +1412,7 @@ flows:
 connect:
   - from: producer.deploy_done
     to: consumer.deploy_completed
-    delivery: one
+    delivery: `+delivery+`
 `)
 	writeConnectRoutePlanBusFixtureFile(t, filepath.Join(root, "schema.yaml"), "name: instance-key-connect-route-plan-bus\n")
 	writeConnectRoutePlanBusFixtureFile(t, filepath.Join(root, "policy.yaml"), "{}\n")

--- a/internal/runtime/conformance/testdata/route_authority_drift_inventory.yaml
+++ b/internal/runtime/conformance/testdata/route_authority_drift_inventory.yaml
@@ -370,7 +370,9 @@ seam_families:
     notes: >
       Lowered ConnectRoutePlan is the typed route-intent artifact consumed by
       EventBus planning. #1494 classifies it as route authority input and guard
-      surface; #1495 owns broader producer migration.
+      surface; #1495 owns broader producer migration. #1545 adds an explicit
+      ResolutionKind discriminant so addressed-input, instance-key, broadcast,
+      and static route authority are not selected by nil-field ordering.
   - id: route_table_resolve_role_separation
     layer: route_topology
     classification: valid_consumer

--- a/internal/runtime/conformance/testdata/route_authority_drift_inventory.yaml
+++ b/internal/runtime/conformance/testdata/route_authority_drift_inventory.yaml
@@ -372,7 +372,8 @@ seam_families:
       EventBus planning. #1494 classifies it as route authority input and guard
       surface; #1495 owns broader producer migration. #1545 adds an explicit
       ResolutionKind discriminant so addressed-input, instance-key, broadcast,
-      and static route authority are not selected by nil-field ordering.
+      and static route authority are not selected by nil-field ordering, and
+      keyed instance evidence cannot shadow explicit parent broadcast fan-out.
   - id: route_table_resolve_role_separation
     layer: route_topology
     classification: valid_consumer

--- a/internal/runtime/conformance/testdata/route_authority_drift_inventory.yaml
+++ b/internal/runtime/conformance/testdata/route_authority_drift_inventory.yaml
@@ -1,7 +1,7 @@
 version: 1
 kind: route_authority_drift_inventory
 issue: 1364
-implementation_issues: [1364, 1494, 1495, 1496]
+implementation_issues: [1364, 1494, 1495, 1496, 1545]
 parent_issues: [1340, 1353, 1481, 1493]
 watchlist: runtime_operations.delivery_and_replay_ownership
 policy:

--- a/internal/runtime/conformance/testdata/route_authority_matrix.yaml
+++ b/internal/runtime/conformance/testdata/route_authority_matrix.yaml
@@ -321,8 +321,12 @@ rows:
       - {kind: issue, issue: 1472}
       - {kind: issue, issue: 1473}
       - {kind: issue, issue: 1494}
+      - {kind: issue, issue: 1545}
+      - {kind: go_test, name: TestLowerCompositionConnectRoutePlansUsesTemplateInstanceKey}
       - {kind: go_test, name: TestLowerCompositionConnectRoutePlanDoesNotDependOnRawPinNamesOrProducerTargets}
       - {kind: go_test, name: TestEventBusPublish_ConnectRoutePlanPersistsSingularTargetWithoutLiveSubscriber}
+      - {kind: go_test, name: TestEventBusPublish_ConnectRoutePlanPersistsTemplateInstanceKeyTarget}
+      - {kind: go_test, name: TestEventBusPublish_ConnectRoutePlanFailsClosedForTemplateInstanceKeyGaps}
       - {kind: go_test, name: TestEventBusPublish_ConnectRoutePlanFailsClosedForUnsupportedBusinessFieldTarget}
     notes: >
       ConnectRoutePlan is a typed route-intent input, not an untracked string
@@ -394,7 +398,10 @@ rows:
     proof_refs:
       - {kind: issue, issue: 1479}
       - {kind: issue, issue: 1494}
+      - {kind: issue, issue: 1545}
       - {kind: go_test, name: TestConnectRoutePlanDescriptorsLoadOnlyForRuntimeResolution}
+      - {kind: go_test, name: TestEventBusPublish_ConnectRoutePlanPersistsTemplateInstanceKeyTarget}
+      - {kind: go_test, name: TestEventBusPublish_ConnectRoutePlanFailsClosedForTemplateInstanceKeyGaps}
       - {kind: go_test, name: TestEventBusPublish_ConnectRoutePlanPersistsIndexedBusinessFieldTarget}
       - {kind: go_test, name: TestEventBusPublish_ConnectRoutePlanPersistsIndexedBusinessFieldTargetSet}
       - {kind: go_test, name: TestEventBusPublish_ConnectRoutePlanFailsClosedForBusinessFieldDescriptorGaps}

--- a/internal/runtime/conformance/testdata/route_authority_matrix.yaml
+++ b/internal/runtime/conformance/testdata/route_authority_matrix.yaml
@@ -324,9 +324,11 @@ rows:
       - {kind: issue, issue: 1545}
       - {kind: go_test, name: TestLowerCompositionConnectRoutePlansUsesTemplateInstanceKey}
       - {kind: go_test, name: TestLowerCompositionConnectRoutePlansPreservesAddressedTemplateRoute}
+      - {kind: go_test, name: TestLowerCompositionConnectRoutePlansBroadcastBeatsInstanceKey}
       - {kind: go_test, name: TestLowerCompositionConnectRoutePlanDoesNotDependOnRawPinNamesOrProducerTargets}
       - {kind: go_test, name: TestEventBusPublish_ConnectRoutePlanPersistsSingularTargetWithoutLiveSubscriber}
       - {kind: go_test, name: TestEventBusPublish_ConnectRoutePlanPersistsTemplateInstanceKeyTarget}
+      - {kind: go_test, name: TestEventBusPublish_ConnectRoutePlanBroadcastIgnoresInstanceKeyFiltering}
       - {kind: go_test, name: TestEventBusPublish_ConnectRoutePlanFailsClosedForTemplateInstanceKeyGaps}
       - {kind: go_test, name: TestEventBusPublish_ConnectRoutePlanFailsClosedForUnsupportedBusinessFieldTarget}
     notes: >
@@ -404,7 +406,9 @@ rows:
       - {kind: issue, issue: 1545}
       - {kind: go_test, name: TestConnectRoutePlanDescriptorsLoadOnlyForRuntimeResolution}
       - {kind: go_test, name: TestLowerCompositionConnectRoutePlansPreservesAddressedTemplateRoute}
+      - {kind: go_test, name: TestLowerCompositionConnectRoutePlansBroadcastBeatsInstanceKey}
       - {kind: go_test, name: TestEventBusPublish_ConnectRoutePlanPersistsTemplateInstanceKeyTarget}
+      - {kind: go_test, name: TestEventBusPublish_ConnectRoutePlanBroadcastIgnoresInstanceKeyFiltering}
       - {kind: go_test, name: TestEventBusPublish_ConnectRoutePlanFailsClosedForTemplateInstanceKeyGaps}
       - {kind: go_test, name: TestEventBusPublish_ConnectRoutePlanPersistsIndexedBusinessFieldTarget}
       - {kind: go_test, name: TestEventBusPublish_ConnectRoutePlanPersistsIndexedBusinessFieldTargetSet}

--- a/internal/runtime/conformance/testdata/route_authority_matrix.yaml
+++ b/internal/runtime/conformance/testdata/route_authority_matrix.yaml
@@ -323,6 +323,7 @@ rows:
       - {kind: issue, issue: 1494}
       - {kind: issue, issue: 1545}
       - {kind: go_test, name: TestLowerCompositionConnectRoutePlansUsesTemplateInstanceKey}
+      - {kind: go_test, name: TestLowerCompositionConnectRoutePlansPreservesAddressedTemplateRoute}
       - {kind: go_test, name: TestLowerCompositionConnectRoutePlanDoesNotDependOnRawPinNamesOrProducerTargets}
       - {kind: go_test, name: TestEventBusPublish_ConnectRoutePlanPersistsSingularTargetWithoutLiveSubscriber}
       - {kind: go_test, name: TestEventBusPublish_ConnectRoutePlanPersistsTemplateInstanceKeyTarget}
@@ -330,8 +331,10 @@ rows:
       - {kind: go_test, name: TestEventBusPublish_ConnectRoutePlanFailsClosedForUnsupportedBusinessFieldTarget}
     notes: >
       ConnectRoutePlan is a typed route-intent input, not an untracked string
-      fallback. #1495 owns additional typed producer migration after this
-      guardrail is in place.
+      fallback. #1545 records the selected route authority in ResolutionKind so
+      explicit addressed-input routing cannot be shadowed by addressless
+      instance-key materialization. #1495 owns additional typed producer
+      migration after this guardrail is in place.
 
   - id: route_table_resolve_role_separation
     concept: RouteTable.Resolve usages must be classified by role instead of treated as generic route authority.
@@ -400,6 +403,7 @@ rows:
       - {kind: issue, issue: 1494}
       - {kind: issue, issue: 1545}
       - {kind: go_test, name: TestConnectRoutePlanDescriptorsLoadOnlyForRuntimeResolution}
+      - {kind: go_test, name: TestLowerCompositionConnectRoutePlansPreservesAddressedTemplateRoute}
       - {kind: go_test, name: TestEventBusPublish_ConnectRoutePlanPersistsTemplateInstanceKeyTarget}
       - {kind: go_test, name: TestEventBusPublish_ConnectRoutePlanFailsClosedForTemplateInstanceKeyGaps}
       - {kind: go_test, name: TestEventBusPublish_ConnectRoutePlanPersistsIndexedBusinessFieldTarget}

--- a/internal/runtime/core/pinrouting/connect_route_plan.go
+++ b/internal/runtime/core/pinrouting/connect_route_plan.go
@@ -56,6 +56,8 @@ type ConnectRoutePlanEndpoint struct {
 	Pin           string
 	Event         string
 	ResolvedEvent string
+	Key           string
+	Carries       []string
 }
 
 type ConnectRoutePlanAddress struct {
@@ -72,6 +74,12 @@ type ConnectRoutePlanMapEntry struct {
 	Target string
 }
 
+type ConnectRoutePlanInstanceKey struct {
+	Fields     []string
+	OnMissing  string
+	OnConflict string
+}
+
 type ConnectRoutePlan struct {
 	PackageKey                string
 	Source                    ConnectRoutePlanEndpoint
@@ -80,6 +88,7 @@ type ConnectRoutePlan struct {
 	Delivery                  ConnectRoutePlanDelivery
 	TargetKind                ConnectRoutePlanTargetKind
 	Address                   *ConnectRoutePlanAddress
+	InstanceKey               *ConnectRoutePlanInstanceKey
 	Map                       []ConnectRoutePlanMapEntry
 	Reply                     map[string]string
 	Target                    events.RouteIdentity
@@ -146,7 +155,7 @@ func LowerCompositionConnectRoutePlan(source semanticview.Source, connect runtim
 	if err != nil {
 		return ConnectRoutePlan{}, ConnectRoutePlanIssue{Connect: connect, Failure: ConnectFailurePinRefInvalid, Detail: err.Error()}
 	}
-	sourceEndpoint, _, sourceIssue := connectRoutePlanSourceEndpoint(source, from, connect)
+	sourceEndpoint, outputPin, sourceIssue := connectRoutePlanSourceEndpoint(source, from, connect)
 	if sourceIssue.Failure != "" {
 		return ConnectRoutePlan{}, sourceIssue
 	}
@@ -166,7 +175,8 @@ func LowerCompositionConnectRoutePlan(source semanticview.Source, connect runtim
 		return ConnectRoutePlan{}, ConnectRoutePlanIssue{Connect: connect, Failure: failure, Detail: strings.TrimSpace(connect.Delivery)}
 	}
 	address := connectAddress(connect, inputPin)
-	if receiverRequiresRuntimeResolution(receiverScope) && address == nil && delivery != ConnectDeliveryBroadcast {
+	instanceKey := connectInstanceKey(source, connect, outputPin, to.FlowID)
+	if receiverRequiresRuntimeResolution(receiverScope) && address == nil && instanceKey == nil && delivery != ConnectDeliveryBroadcast {
 		return ConnectRoutePlan{}, ConnectRoutePlanIssue{Connect: connect, Failure: ConnectFailureReceiverAddressRuleMissing, Detail: to.FlowID}
 	}
 	targetKind := connectTargetKind(delivery)
@@ -181,12 +191,13 @@ func LowerCompositionConnectRoutePlan(source semanticview.Source, connect runtim
 			Event:         eventidentity.Normalize(inputPin.EventType()),
 			ResolvedEvent: eventidentity.Normalize(source.ResolveFlowEventReference(to.FlowID, inputPin.EventType())),
 		},
-		Adapter:    strings.TrimSpace(connect.Adapter),
-		Delivery:   delivery,
-		TargetKind: targetKind,
-		Address:    address,
-		Map:        connectMapEntries(connect.Map),
-		Reply:      cloneStringMap(connect.Reply),
+		Adapter:     strings.TrimSpace(connect.Adapter),
+		Delivery:    delivery,
+		TargetKind:  targetKind,
+		Address:     address,
+		InstanceKey: instanceKey,
+		Map:         connectMapEntries(connect.Map),
+		Reply:       cloneStringMap(connect.Reply),
 	}
 	if !receiverRequiresRuntimeResolution(receiverScope) {
 		route := staticConnectRoute(source, to.FlowID)
@@ -216,6 +227,8 @@ func connectRoutePlanSourceEndpoint(source semanticview.Source, from runtimecont
 			Event:         eventidentity.Normalize(outputPin.EventType()),
 			ResolvedEvent: eventidentity.Normalize(source.ResolveFlowEventReference("", outputPin.EventType())),
 			Mode:          "root",
+			Key:           strings.TrimSpace(outputPin.Key),
+			Carries:       normalizedPinCarries(outputPin.Carries),
 		}, outputPin, ConnectRoutePlanIssue{}
 	}
 	sourceScope, ok := source.FlowScopeByID(from.FlowID)
@@ -233,6 +246,8 @@ func connectRoutePlanSourceEndpoint(source semanticview.Source, from runtimecont
 		Pin:           strings.TrimSpace(from.Pin),
 		Event:         eventidentity.Normalize(outputPin.EventType()),
 		ResolvedEvent: eventidentity.Normalize(source.ResolveFlowEventReference(from.FlowID, outputPin.EventType())),
+		Key:           strings.TrimSpace(outputPin.Key),
+		Carries:       normalizedPinCarries(outputPin.Carries),
 	}, outputPin, ConnectRoutePlanIssue{}
 }
 
@@ -245,6 +260,9 @@ func MaterializeConnectRoutePlan(plan ConnectRoutePlan, input ConnectRoutePlanMa
 	}
 	if plan.TargetKind == ConnectTargetKindTargetSet && plan.Delivery == ConnectDeliveryBroadcast && plan.Address == nil {
 		return materializeBroadcastConnectRoutePlan(plan, input.Descriptors)
+	}
+	if plan.InstanceKey != nil {
+		return materializeInstanceKeyConnectRoutePlan(plan, input)
 	}
 	if plan.Address == nil {
 		return ConnectRoutePlanMaterialization{Failure: ConnectFailureReceiverAddressRuleMissing}
@@ -292,6 +310,57 @@ func materializeBroadcastConnectRoutePlan(plan ConnectRoutePlan, descriptors []D
 		return ConnectRoutePlanMaterialization{Failure: ConnectFailureTargetUnresolved}
 	}
 	return ConnectRoutePlanMaterialization{TargetSet: routes}
+}
+
+func materializeInstanceKeyConnectRoutePlan(plan ConnectRoutePlan, input ConnectRoutePlanMaterializationInput) ConnectRoutePlanMaterialization {
+	instanceKey := plan.InstanceKey
+	if instanceKey == nil || len(instanceKey.Fields) == 0 {
+		return ConnectRoutePlanMaterialization{Failure: ConnectFailureReceiverAddressRuleMissing}
+	}
+	values := make(map[string]any, len(instanceKey.Fields))
+	for _, field := range instanceKey.Fields {
+		field = strings.TrimSpace(field)
+		if field == "" {
+			return ConnectRoutePlanMaterialization{Failure: ConnectFailureReceiverAddressRuleMissing}
+		}
+		value := firstMatchValue(input.MatchValues, field, "payload."+field)
+		if value == "" {
+			return ConnectRoutePlanMaterialization{Failure: ConnectFailureAddressValueMissing}
+		}
+		values[field] = value
+	}
+	keyMaterial, err := (runtimecontracts.TemplateInstanceContract{
+		FlowID: plan.Receiver.FlowID,
+		By:     append([]string{}, instanceKey.Fields...),
+	}).CanonicalKeyMaterial(values)
+	if err != nil {
+		return ConnectRoutePlanMaterialization{Failure: ConnectFailureAddressValueMissing}
+	}
+	routes := make([]events.RouteIdentity, 0, len(input.Descriptors))
+	for _, descriptor := range input.Descriptors {
+		route := descriptorRouteForReceiver(plan, descriptor)
+		if route.Empty() {
+			continue
+		}
+		if connectInstanceKeyDescriptorMatches(keyMaterial, descriptor) {
+			routes = append(routes, route)
+		}
+	}
+	routes = uniqueRoutes(routes)
+	if len(routes) == 0 {
+		return ConnectRoutePlanMaterialization{Failure: ConnectFailureTargetUnresolved}
+	}
+	switch plan.TargetKind {
+	case ConnectTargetKindTarget, ConnectTargetKindReply:
+		if len(routes) > 1 {
+			return ConnectRoutePlanMaterialization{Failure: ConnectFailureTargetAmbiguous}
+		}
+		return ConnectRoutePlanMaterialization{Target: routes[0]}
+	case ConnectTargetKindTargetSet:
+		return ConnectRoutePlanMaterialization{TargetSet: routes}
+	default:
+		return ConnectRoutePlanMaterialization{Failure: ConnectFailureDeliveryTopologyInvalid}
+	}
 }
 
 func connectDelivery(connect runtimecontracts.FlowPackageConnect, inputPin runtimecontracts.FlowInputEventPin) (ConnectRoutePlanDelivery, ConnectRoutePlanFailure) {
@@ -355,6 +424,38 @@ func connectAddress(connect runtimecontracts.FlowPackageConnect, inputPin runtim
 		}
 	}
 	return &out
+}
+
+func connectInstanceKey(source semanticview.Source, connect runtimecontracts.FlowPackageConnect, outputPin runtimecontracts.FlowOutputEventPin, receiverFlowID string) *ConnectRoutePlanInstanceKey {
+	if source == nil || len(connect.Map) > 0 {
+		return nil
+	}
+	bundle, ok := semanticview.Bundle(source)
+	if !ok {
+		return nil
+	}
+	instance, err := bundle.ResolveFlowTemplateInstance(receiverFlowID)
+	if err != nil {
+		return nil
+	}
+	outputKey := strings.TrimSpace(outputPin.Key)
+	if outputKey == "" {
+		return nil
+	}
+	carries := normalizedPinCarries(outputPin.Carries)
+	if !stringListContains(carries, outputKey) || !stringListContains(instance.By, outputKey) {
+		return nil
+	}
+	for _, field := range instance.By {
+		if !stringListContains(carries, field) {
+			return nil
+		}
+	}
+	return &ConnectRoutePlanInstanceKey{
+		Fields:     normalizedStringList(instance.By),
+		OnMissing:  strings.TrimSpace(instance.OnMissing),
+		OnConflict: strings.TrimSpace(instance.OnConflict),
+	}
 }
 
 func connectMapEntries(in map[string]runtimecontracts.FlowPackageConnectMap) []ConnectRoutePlanMapEntry {
@@ -468,6 +569,27 @@ func connectDescriptorMatches(targetExpr, value string, descriptor Descriptor, r
 	}
 }
 
+func connectInstanceKeyDescriptorMatches(keyMaterial []runtimecontracts.TemplateInstanceKeyValue, descriptor Descriptor) bool {
+	if len(keyMaterial) == 0 {
+		return false
+	}
+	for _, key := range keyMaterial {
+		field := strings.TrimSpace(key.Field)
+		value := strings.Trim(strings.TrimSpace(key.Value), "/")
+		if field == "" || value == "" {
+			return false
+		}
+		actual, ok := descriptor.AddressFields["entity."+field]
+		if !ok {
+			actual, ok = descriptor.AddressFields[field]
+		}
+		if !ok || strings.Trim(strings.TrimSpace(actual), "/") != value {
+			return false
+		}
+	}
+	return true
+}
+
 func descriptorRouteForReceiver(plan ConnectRoutePlan, descriptor Descriptor) events.RouteIdentity {
 	if !descriptorBelongsToReceiver(plan, descriptor) {
 		return events.RouteIdentity{}
@@ -572,6 +694,62 @@ func expressionLeaf(expr string) string {
 		return strings.TrimSpace(expr[idx+1:])
 	}
 	return expr
+}
+
+func firstMatchValue(values map[string]string, keys ...string) string {
+	if len(values) == 0 {
+		return ""
+	}
+	for _, key := range keys {
+		key = strings.TrimSpace(key)
+		if key == "" {
+			continue
+		}
+		if value := strings.TrimSpace(values[key]); value != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func normalizedPinCarries(in []string) []string {
+	return normalizedStringList(in)
+}
+
+func normalizedStringList(in []string) []string {
+	if len(in) == 0 {
+		return nil
+	}
+	seen := map[string]struct{}{}
+	out := make([]string, 0, len(in))
+	for _, value := range in {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		out = append(out, value)
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+func stringListContains(values []string, needle string) bool {
+	needle = strings.TrimSpace(needle)
+	if needle == "" {
+		return false
+	}
+	for _, value := range values {
+		if strings.TrimSpace(value) == needle {
+			return true
+		}
+	}
+	return false
 }
 
 func cloneStringMap(in map[string]string) map[string]string {

--- a/internal/runtime/core/pinrouting/connect_route_plan.go
+++ b/internal/runtime/core/pinrouting/connect_route_plan.go
@@ -185,7 +185,7 @@ func LowerCompositionConnectRoutePlan(source semanticview.Source, connect runtim
 		return ConnectRoutePlan{}, ConnectRoutePlanIssue{Connect: connect, Failure: failure, Detail: strings.TrimSpace(connect.Delivery)}
 	}
 	address := connectAddress(connect, inputPin)
-	instanceKey := connectInstanceKey(source, connect, outputPin, inputPin, to.FlowID)
+	instanceKey := connectInstanceKey(source, connect, outputPin, inputPin, delivery, to.FlowID)
 	if receiverRequiresRuntimeResolution(receiverScope) && address == nil && instanceKey == nil && delivery != ConnectDeliveryBroadcast {
 		return ConnectRoutePlan{}, ConnectRoutePlanIssue{Connect: connect, Failure: ConnectFailureReceiverAddressRuleMissing, Detail: to.FlowID}
 	}
@@ -449,8 +449,8 @@ func connectAddress(connect runtimecontracts.FlowPackageConnect, inputPin runtim
 	return &out
 }
 
-func connectInstanceKey(source semanticview.Source, connect runtimecontracts.FlowPackageConnect, outputPin runtimecontracts.FlowOutputEventPin, inputPin runtimecontracts.FlowInputEventPin, receiverFlowID string) *ConnectRoutePlanInstanceKey {
-	if source == nil || len(connect.Map) > 0 || inputPin.Address != nil {
+func connectInstanceKey(source semanticview.Source, connect runtimecontracts.FlowPackageConnect, outputPin runtimecontracts.FlowOutputEventPin, inputPin runtimecontracts.FlowInputEventPin, delivery ConnectRoutePlanDelivery, receiverFlowID string) *ConnectRoutePlanInstanceKey {
+	if source == nil || len(connect.Map) > 0 || inputPin.Address != nil || delivery == ConnectDeliveryBroadcast {
 		return nil
 	}
 	bundle, ok := semanticview.Bundle(source)
@@ -488,11 +488,11 @@ func connectResolutionKind(scope semanticview.FlowScope, delivery ConnectRoutePl
 	if address != nil {
 		return ConnectResolutionAddress
 	}
-	if instanceKey != nil {
-		return ConnectResolutionInstanceKey
-	}
 	if delivery == ConnectDeliveryBroadcast {
 		return ConnectResolutionBroadcast
+	}
+	if instanceKey != nil {
+		return ConnectResolutionInstanceKey
 	}
 	return ""
 }

--- a/internal/runtime/core/pinrouting/connect_route_plan.go
+++ b/internal/runtime/core/pinrouting/connect_route_plan.go
@@ -29,6 +29,15 @@ const (
 	ConnectTargetKindReply     ConnectRoutePlanTargetKind = "reply"
 )
 
+type ConnectRoutePlanResolutionKind string
+
+const (
+	ConnectResolutionStatic      ConnectRoutePlanResolutionKind = "static"
+	ConnectResolutionAddress     ConnectRoutePlanResolutionKind = "address"
+	ConnectResolutionInstanceKey ConnectRoutePlanResolutionKind = "instance_key"
+	ConnectResolutionBroadcast   ConnectRoutePlanResolutionKind = "broadcast"
+)
+
 type ConnectRoutePlanFailure string
 
 const (
@@ -87,6 +96,7 @@ type ConnectRoutePlan struct {
 	Adapter                   string
 	Delivery                  ConnectRoutePlanDelivery
 	TargetKind                ConnectRoutePlanTargetKind
+	ResolutionKind            ConnectRoutePlanResolutionKind
 	Address                   *ConnectRoutePlanAddress
 	InstanceKey               *ConnectRoutePlanInstanceKey
 	Map                       []ConnectRoutePlanMapEntry
@@ -175,7 +185,7 @@ func LowerCompositionConnectRoutePlan(source semanticview.Source, connect runtim
 		return ConnectRoutePlan{}, ConnectRoutePlanIssue{Connect: connect, Failure: failure, Detail: strings.TrimSpace(connect.Delivery)}
 	}
 	address := connectAddress(connect, inputPin)
-	instanceKey := connectInstanceKey(source, connect, outputPin, to.FlowID)
+	instanceKey := connectInstanceKey(source, connect, outputPin, inputPin, to.FlowID)
 	if receiverRequiresRuntimeResolution(receiverScope) && address == nil && instanceKey == nil && delivery != ConnectDeliveryBroadcast {
 		return ConnectRoutePlan{}, ConnectRoutePlanIssue{Connect: connect, Failure: ConnectFailureReceiverAddressRuleMissing, Detail: to.FlowID}
 	}
@@ -191,9 +201,15 @@ func LowerCompositionConnectRoutePlan(source semanticview.Source, connect runtim
 			Event:         eventidentity.Normalize(inputPin.EventType()),
 			ResolvedEvent: eventidentity.Normalize(source.ResolveFlowEventReference(to.FlowID, inputPin.EventType())),
 		},
-		Adapter:     strings.TrimSpace(connect.Adapter),
-		Delivery:    delivery,
-		TargetKind:  targetKind,
+		Adapter:    strings.TrimSpace(connect.Adapter),
+		Delivery:   delivery,
+		TargetKind: targetKind,
+		ResolutionKind: connectResolutionKind(
+			receiverScope,
+			delivery,
+			address,
+			instanceKey,
+		),
 		Address:     address,
 		InstanceKey: instanceKey,
 		Map:         connectMapEntries(connect.Map),
@@ -258,12 +274,19 @@ func MaterializeConnectRoutePlan(plan ConnectRoutePlan, input ConnectRoutePlanMa
 	if len(plan.TargetSet) > 0 {
 		return ConnectRoutePlanMaterialization{TargetSet: append([]events.RouteIdentity{}, plan.TargetSet...)}
 	}
-	if plan.TargetKind == ConnectTargetKindTargetSet && plan.Delivery == ConnectDeliveryBroadcast && plan.Address == nil {
+	switch connectRoutePlanResolutionKind(plan) {
+	case ConnectResolutionBroadcast:
 		return materializeBroadcastConnectRoutePlan(plan, input.Descriptors)
-	}
-	if plan.InstanceKey != nil {
+	case ConnectResolutionAddress:
+		return materializeAddressConnectRoutePlan(plan, input)
+	case ConnectResolutionInstanceKey:
 		return materializeInstanceKeyConnectRoutePlan(plan, input)
+	default:
+		return ConnectRoutePlanMaterialization{Failure: ConnectFailureReceiverAddressRuleMissing}
 	}
+}
+
+func materializeAddressConnectRoutePlan(plan ConnectRoutePlan, input ConnectRoutePlanMaterializationInput) ConnectRoutePlanMaterialization {
 	if plan.Address == nil {
 		return ConnectRoutePlanMaterialization{Failure: ConnectFailureReceiverAddressRuleMissing}
 	}
@@ -426,8 +449,8 @@ func connectAddress(connect runtimecontracts.FlowPackageConnect, inputPin runtim
 	return &out
 }
 
-func connectInstanceKey(source semanticview.Source, connect runtimecontracts.FlowPackageConnect, outputPin runtimecontracts.FlowOutputEventPin, receiverFlowID string) *ConnectRoutePlanInstanceKey {
-	if source == nil || len(connect.Map) > 0 {
+func connectInstanceKey(source semanticview.Source, connect runtimecontracts.FlowPackageConnect, outputPin runtimecontracts.FlowOutputEventPin, inputPin runtimecontracts.FlowInputEventPin, receiverFlowID string) *ConnectRoutePlanInstanceKey {
+	if source == nil || len(connect.Map) > 0 || inputPin.Address != nil {
 		return nil
 	}
 	bundle, ok := semanticview.Bundle(source)
@@ -456,6 +479,41 @@ func connectInstanceKey(source semanticview.Source, connect runtimecontracts.Flo
 		OnMissing:  strings.TrimSpace(instance.OnMissing),
 		OnConflict: strings.TrimSpace(instance.OnConflict),
 	}
+}
+
+func connectResolutionKind(scope semanticview.FlowScope, delivery ConnectRoutePlanDelivery, address *ConnectRoutePlanAddress, instanceKey *ConnectRoutePlanInstanceKey) ConnectRoutePlanResolutionKind {
+	if !receiverRequiresRuntimeResolution(scope) {
+		return ConnectResolutionStatic
+	}
+	if address != nil {
+		return ConnectResolutionAddress
+	}
+	if instanceKey != nil {
+		return ConnectResolutionInstanceKey
+	}
+	if delivery == ConnectDeliveryBroadcast {
+		return ConnectResolutionBroadcast
+	}
+	return ""
+}
+
+func connectRoutePlanResolutionKind(plan ConnectRoutePlan) ConnectRoutePlanResolutionKind {
+	if plan.ResolutionKind != "" {
+		return plan.ResolutionKind
+	}
+	if !plan.Target.Empty() || len(plan.TargetSet) > 0 {
+		return ConnectResolutionStatic
+	}
+	if plan.Address != nil {
+		return ConnectResolutionAddress
+	}
+	if plan.InstanceKey != nil {
+		return ConnectResolutionInstanceKey
+	}
+	if plan.TargetKind == ConnectTargetKindTargetSet && plan.Delivery == ConnectDeliveryBroadcast {
+		return ConnectResolutionBroadcast
+	}
+	return ""
 }
 
 func connectMapEntries(in map[string]runtimecontracts.FlowPackageConnectMap) []ConnectRoutePlanMapEntry {

--- a/internal/runtime/core/pinrouting/connect_route_plan_test.go
+++ b/internal/runtime/core/pinrouting/connect_route_plan_test.go
@@ -190,6 +190,55 @@ func TestLowerCompositionConnectRoutePlansPreservesAddressedTemplateRoute(t *tes
 	}
 }
 
+func TestLowerCompositionConnectRoutePlansBroadcastBeatsInstanceKey(t *testing.T) {
+	repoRoot, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd: %v", err)
+	}
+	repoRoot = filepath.Clean(filepath.Join(repoRoot, "..", "..", "..", ".."))
+	root := writeInstanceKeyConnectRoutePlanPackageFixtureWithDelivery(t, "broadcast")
+	bundle, err := runtimecontracts.LoadWorkflowContractBundleWithOverrides(repoRoot, root, runtimecontracts.DefaultPlatformSpecFile(repoRoot))
+	if err != nil {
+		t.Fatalf("LoadWorkflowContractBundleWithOverrides: %v", err)
+	}
+
+	plans, issues := LowerCompositionConnectRoutePlans(semanticview.Wrap(bundle))
+	if len(issues) != 0 {
+		t.Fatalf("issues = %#v, want none", issues)
+	}
+	if len(plans) != 1 {
+		t.Fatalf("plans = %#v, want one", plans)
+	}
+	plan := plans[0]
+	if got, want := plan.ResolutionKind, ConnectResolutionBroadcast; got != want {
+		t.Fatalf("ResolutionKind = %q, want %q", got, want)
+	}
+	if plan.InstanceKey != nil {
+		t.Fatalf("InstanceKey = %#v, want nil for explicit parent broadcast", plan.InstanceKey)
+	}
+	if got, want := plan.Source.Key, "vertical_id"; got != want {
+		t.Fatalf("Source.Key = %q, want retained producer key evidence", got)
+	}
+
+	materialized := MaterializeConnectRoutePlan(plan, ConnectRoutePlanMaterializationInput{
+		MatchValues: map[string]string{"vertical_id": "v-1"},
+		Descriptors: []Descriptor{
+			{EntityID: "ent-1", FlowInstance: "consumer/one", AddressFields: map[string]string{"entity.vertical_id": "v-1"}},
+			{EntityID: "ent-2", FlowInstance: "consumer/two", AddressFields: map[string]string{"entity.vertical_id": "v-2"}},
+			{EntityID: "ent-3", FlowInstance: "other/three", AddressFields: map[string]string{"entity.vertical_id": "v-1"}},
+		},
+	})
+	if materialized.Failure != "" {
+		t.Fatalf("Failure = %q, want empty", materialized.Failure)
+	}
+	if len(materialized.TargetSet) != 2 {
+		t.Fatalf("TargetSet = %#v, want both receiver-scoped descriptors", materialized.TargetSet)
+	}
+	if materialized.TargetSet[0].FlowInstance != "consumer/one" || materialized.TargetSet[1].FlowInstance != "consumer/two" {
+		t.Fatalf("TargetSet = %#v, want consumer/one and consumer/two without payload-key filtering", materialized.TargetSet)
+	}
+}
+
 func TestLowerCompositionConnectRoutePlansOneToOneStatic(t *testing.T) {
 	source := testConnectRoutePlanSource([]connectRoutePlanFlow{
 		{
@@ -803,6 +852,10 @@ deployment:
 }
 
 func writeInstanceKeyConnectRoutePlanPackageFixture(t *testing.T) string {
+	return writeInstanceKeyConnectRoutePlanPackageFixtureWithDelivery(t, "one")
+}
+
+func writeInstanceKeyConnectRoutePlanPackageFixtureWithDelivery(t *testing.T, delivery string) string {
 	t.Helper()
 	root := t.TempDir()
 	writeConnectRoutePlanFixtureFile(t, filepath.Join(root, "package.yaml"), `
@@ -819,7 +872,7 @@ flows:
 connect:
   - from: producer.deploy_done
     to: consumer.deploy_completed
-    delivery: one
+    delivery: `+delivery+`
 `)
 	writeConnectRoutePlanFixtureFile(t, filepath.Join(root, "schema.yaml"), "name: instance-key-connect-route-plan-package\n")
 	writeConnectRoutePlanFixtureFile(t, filepath.Join(root, "policy.yaml"), "{}\n")

--- a/internal/runtime/core/pinrouting/connect_route_plan_test.go
+++ b/internal/runtime/core/pinrouting/connect_route_plan_test.go
@@ -40,6 +40,9 @@ func TestLowerCompositionConnectRoutePlansFromLoadedPackageFixture(t *testing.T)
 	if plan.Address == nil || plan.Address.By != "vertical_id" {
 		t.Fatalf("Address = %#v, want loaded vertical_id address", plan.Address)
 	}
+	if got, want := plan.ResolutionKind, ConnectResolutionStatic; got != want {
+		t.Fatalf("ResolutionKind = %q, want %q", got, want)
+	}
 	if plan.Target.FlowInstance != "consumer" {
 		t.Fatalf("Target = %#v, want concrete static consumer route", plan.Target)
 	}
@@ -70,6 +73,9 @@ func TestLowerCompositionConnectRoutePlansUsesTemplateInstanceKey(t *testing.T) 
 	}
 	if plan.InstanceKey == nil {
 		t.Fatal("InstanceKey = nil, want canonical receiver instance key evidence")
+	}
+	if got, want := plan.ResolutionKind, ConnectResolutionInstanceKey; got != want {
+		t.Fatalf("ResolutionKind = %q, want %q", got, want)
 	}
 	if got, want := plan.Source.Key, "vertical_id"; got != want {
 		t.Fatalf("Source.Key = %q, want %q", got, want)
@@ -118,6 +124,69 @@ func TestLowerCompositionConnectRoutePlansUsesTemplateInstanceKey(t *testing.T) 
 	})
 	if ambiguous.Failure != ConnectFailureTargetAmbiguous {
 		t.Fatalf("ambiguous Failure = %q, want %q", ambiguous.Failure, ConnectFailureTargetAmbiguous)
+	}
+}
+
+func TestLowerCompositionConnectRoutePlansPreservesAddressedTemplateRoute(t *testing.T) {
+	repoRoot, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd: %v", err)
+	}
+	repoRoot = filepath.Clean(filepath.Join(repoRoot, "..", "..", "..", ".."))
+	root := writeAddressedTemplateConnectRoutePlanPackageFixture(t)
+	bundle, err := runtimecontracts.LoadWorkflowContractBundleWithOverrides(repoRoot, root, runtimecontracts.DefaultPlatformSpecFile(repoRoot))
+	if err != nil {
+		t.Fatalf("LoadWorkflowContractBundleWithOverrides: %v", err)
+	}
+
+	plans, issues := LowerCompositionConnectRoutePlans(semanticview.Wrap(bundle))
+	if len(issues) != 0 {
+		t.Fatalf("issues = %#v, want none", issues)
+	}
+	if len(plans) != 1 {
+		t.Fatalf("plans = %#v, want one", plans)
+	}
+	plan := plans[0]
+	if plan.Address == nil {
+		t.Fatal("Address = nil, want addressed-input route evidence")
+	}
+	if plan.InstanceKey != nil {
+		t.Fatalf("InstanceKey = %#v, want nil when receiver input declares address", plan.InstanceKey)
+	}
+	if got, want := plan.ResolutionKind, ConnectResolutionAddress; got != want {
+		t.Fatalf("ResolutionKind = %q, want %q", got, want)
+	}
+
+	materialized := MaterializeConnectRoutePlan(plan, ConnectRoutePlanMaterializationInput{
+		MatchValues: map[string]string{
+			"customer_id": "cust-1",
+			"vertical_id": "v-wrong",
+		},
+		Descriptors: []Descriptor{
+			{
+				EntityID:     "ent-address",
+				FlowInstance: "consumer/addressed",
+				AddressFields: map[string]string{
+					"entity.customer_id": "cust-1",
+					"entity.vertical_id": "v-other",
+				},
+			},
+			{
+				EntityID:     "ent-instance",
+				FlowInstance: "consumer/instance-key",
+				AddressFields: map[string]string{
+					"entity.customer_id": "cust-other",
+					"entity.vertical_id": "v-wrong",
+				},
+			},
+		},
+		SupportedAddressTargets: []string{"entity.customer_id"},
+	})
+	if materialized.Failure != "" {
+		t.Fatalf("Failure = %q, want empty", materialized.Failure)
+	}
+	if got, want := materialized.Target.FlowInstance, "consumer/addressed"; got != want {
+		t.Fatalf("Target.FlowInstance = %q, want %q", got, want)
 	}
 }
 
@@ -186,6 +255,9 @@ func TestLowerCompositionConnectRoutePlansOneToOneStatic(t *testing.T) {
 	}
 	if got, want := plan.TargetKind, ConnectTargetKindTarget; got != want {
 		t.Fatalf("TargetKind = %q, want %q", got, want)
+	}
+	if got, want := plan.ResolutionKind, ConnectResolutionStatic; got != want {
+		t.Fatalf("ResolutionKind = %q, want %q", got, want)
 	}
 	if plan.Address == nil || plan.Address.By != "vertical_id" || plan.Address.Source != "payload.vertical_id" || plan.Address.Target != "entity.vertical_id" {
 		t.Fatalf("Address = %#v, want vertical_id payload/entity mapping", plan.Address)
@@ -785,6 +857,73 @@ pins:
 deployment:
   vertical_id:
     type: string
+`)
+	return root
+}
+
+func writeAddressedTemplateConnectRoutePlanPackageFixture(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	writeConnectRoutePlanFixtureFile(t, filepath.Join(root, "package.yaml"), `
+name: addressed-template-connect-route-plan-package
+version: "1.0.0"
+platform_version: ">=1.6.0"
+flows:
+  - id: producer
+    flow: producer
+    mode: static
+  - id: consumer
+    flow: consumer
+    mode: template
+connect:
+  - from: producer.deploy_done
+    to: consumer.deploy_completed
+    delivery: one
+`)
+	writeConnectRoutePlanFixtureFile(t, filepath.Join(root, "schema.yaml"), "name: addressed-template-connect-route-plan-package\n")
+	writeConnectRoutePlanFixtureFile(t, filepath.Join(root, "policy.yaml"), "{}\n")
+	writeConnectRoutePlanFixtureFile(t, filepath.Join(root, "tools.yaml"), "{}\n")
+	writeConnectRoutePlanFixtureFile(t, filepath.Join(root, "agents.yaml"), "{}\n")
+	writeConnectRoutePlanFixtureFile(t, filepath.Join(root, "events.yaml"), "{}\n")
+	writeConnectRoutePlanFixtureFile(t, filepath.Join(root, "nodes.yaml"), "{}\n")
+	writeConnectRoutePlanFlowFixture(t, root, "producer", `
+pins:
+  outputs:
+    events:
+      - name: deploy_done
+        event: deploy.done
+        key: vertical_id
+        carries: [vertical_id, customer_id]
+`, "deploy.done:\n  vertical_id: string\n  customer_id: string\n", "{}\n")
+	writeConnectRoutePlanFixtureFile(t, filepath.Join(root, "flows", "consumer", "schema.yaml"), `
+name: consumer
+mode: template
+instance:
+  by: vertical_id
+  on_missing: reject
+  on_conflict: reject
+pins:
+  inputs:
+    events:
+      - name: deploy_completed
+        event: deploy.done
+        address:
+          by: customer_id
+          source: payload.customer_id
+          target: entity.customer_id
+          cardinality: one
+`)
+	writeConnectRoutePlanFixtureFile(t, filepath.Join(root, "flows", "consumer", "policy.yaml"), "{}\n")
+	writeConnectRoutePlanFixtureFile(t, filepath.Join(root, "flows", "consumer", "agents.yaml"), "{}\n")
+	writeConnectRoutePlanFixtureFile(t, filepath.Join(root, "flows", "consumer", "nodes.yaml"), "{}\n")
+	writeConnectRoutePlanFixtureFile(t, filepath.Join(root, "flows", "consumer", "events.yaml"), "deploy.done:\n  vertical_id: string\n  customer_id: string\n")
+	writeConnectRoutePlanFixtureFile(t, filepath.Join(root, "flows", "consumer", "entities.yaml"), `
+deployment:
+  vertical_id:
+    type: string
+  customer_id:
+    type: string
+    indexed: true
 `)
 	return root
 }

--- a/internal/runtime/core/pinrouting/connect_route_plan_test.go
+++ b/internal/runtime/core/pinrouting/connect_route_plan_test.go
@@ -45,6 +45,82 @@ func TestLowerCompositionConnectRoutePlansFromLoadedPackageFixture(t *testing.T)
 	}
 }
 
+func TestLowerCompositionConnectRoutePlansUsesTemplateInstanceKey(t *testing.T) {
+	repoRoot, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd: %v", err)
+	}
+	repoRoot = filepath.Clean(filepath.Join(repoRoot, "..", "..", "..", ".."))
+	root := writeInstanceKeyConnectRoutePlanPackageFixture(t)
+	bundle, err := runtimecontracts.LoadWorkflowContractBundleWithOverrides(repoRoot, root, runtimecontracts.DefaultPlatformSpecFile(repoRoot))
+	if err != nil {
+		t.Fatalf("LoadWorkflowContractBundleWithOverrides: %v", err)
+	}
+
+	plans, issues := LowerCompositionConnectRoutePlans(semanticview.Wrap(bundle))
+	if len(issues) != 0 {
+		t.Fatalf("issues = %#v, want none", issues)
+	}
+	if len(plans) != 1 {
+		t.Fatalf("plans = %#v, want one", plans)
+	}
+	plan := plans[0]
+	if plan.Address != nil {
+		t.Fatalf("Address = %#v, want nil for canonical instance-key plan", plan.Address)
+	}
+	if plan.InstanceKey == nil {
+		t.Fatal("InstanceKey = nil, want canonical receiver instance key evidence")
+	}
+	if got, want := plan.Source.Key, "vertical_id"; got != want {
+		t.Fatalf("Source.Key = %q, want %q", got, want)
+	}
+	if len(plan.Source.Carries) != 1 || plan.Source.Carries[0] != "vertical_id" {
+		t.Fatalf("Source.Carries = %#v, want [vertical_id]", plan.Source.Carries)
+	}
+	if len(plan.InstanceKey.Fields) != 1 || plan.InstanceKey.Fields[0] != "vertical_id" {
+		t.Fatalf("InstanceKey.Fields = %#v, want [vertical_id]", plan.InstanceKey.Fields)
+	}
+	if got, want := plan.InstanceKey.OnMissing, "reject"; got != want {
+		t.Fatalf("InstanceKey.OnMissing = %q, want %q", got, want)
+	}
+	if !plan.RequiresRuntimeResolution {
+		t.Fatal("template instance-key receiver should require runtime resolution")
+	}
+
+	materialized := MaterializeConnectRoutePlan(plan, ConnectRoutePlanMaterializationInput{
+		MatchValues: map[string]string{"vertical_id": "v-1"},
+		Descriptors: []Descriptor{{
+			EntityID:      "ent-1",
+			FlowInstance:  "consumer/one",
+			AddressFields: map[string]string{"entity.vertical_id": "v-1"},
+		}},
+	})
+	if materialized.Failure != "" {
+		t.Fatalf("Failure = %q, want empty", materialized.Failure)
+	}
+	if got, want := materialized.Target.FlowInstance, "consumer/one"; got != want {
+		t.Fatalf("Target.FlowInstance = %q, want %q", got, want)
+	}
+
+	missing := MaterializeConnectRoutePlan(plan, ConnectRoutePlanMaterializationInput{
+		MatchValues: map[string]string{},
+	})
+	if missing.Failure != ConnectFailureAddressValueMissing {
+		t.Fatalf("missing Failure = %q, want %q", missing.Failure, ConnectFailureAddressValueMissing)
+	}
+
+	ambiguous := MaterializeConnectRoutePlan(plan, ConnectRoutePlanMaterializationInput{
+		MatchValues: map[string]string{"payload.vertical_id": "v-1"},
+		Descriptors: []Descriptor{
+			{EntityID: "ent-1", FlowInstance: "consumer/one", AddressFields: map[string]string{"entity.vertical_id": "v-1"}},
+			{EntityID: "ent-2", FlowInstance: "consumer/two", AddressFields: map[string]string{"entity.vertical_id": "v-1"}},
+		},
+	})
+	if ambiguous.Failure != ConnectFailureTargetAmbiguous {
+		t.Fatalf("ambiguous Failure = %q, want %q", ambiguous.Failure, ConnectFailureTargetAmbiguous)
+	}
+}
+
 func TestLowerCompositionConnectRoutePlansOneToOneStatic(t *testing.T) {
 	source := testConnectRoutePlanSource([]connectRoutePlanFlow{
 		{
@@ -647,6 +723,65 @@ pins:
           target: entity.vertical_id
           cardinality: one
 `, "deploy.completed: {}\n", `
+deployment:
+  vertical_id:
+    type: string
+`)
+	return root
+}
+
+func writeInstanceKeyConnectRoutePlanPackageFixture(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	writeConnectRoutePlanFixtureFile(t, filepath.Join(root, "package.yaml"), `
+name: instance-key-connect-route-plan-package
+version: "1.0.0"
+platform_version: ">=1.6.0"
+flows:
+  - id: producer
+    flow: producer
+    mode: static
+  - id: consumer
+    flow: consumer
+    mode: template
+connect:
+  - from: producer.deploy_done
+    to: consumer.deploy_completed
+    delivery: one
+`)
+	writeConnectRoutePlanFixtureFile(t, filepath.Join(root, "schema.yaml"), "name: instance-key-connect-route-plan-package\n")
+	writeConnectRoutePlanFixtureFile(t, filepath.Join(root, "policy.yaml"), "{}\n")
+	writeConnectRoutePlanFixtureFile(t, filepath.Join(root, "tools.yaml"), "{}\n")
+	writeConnectRoutePlanFixtureFile(t, filepath.Join(root, "agents.yaml"), "{}\n")
+	writeConnectRoutePlanFixtureFile(t, filepath.Join(root, "events.yaml"), "{}\n")
+	writeConnectRoutePlanFixtureFile(t, filepath.Join(root, "nodes.yaml"), "{}\n")
+	writeConnectRoutePlanFlowFixture(t, root, "producer", `
+pins:
+  outputs:
+    events:
+      - name: deploy_done
+        event: deploy.done
+        key: vertical_id
+        carries: [vertical_id]
+`, "deploy.done:\n  vertical_id: string\n", "{}\n")
+	writeConnectRoutePlanFixtureFile(t, filepath.Join(root, "flows", "consumer", "schema.yaml"), `
+name: consumer
+mode: template
+instance:
+  by: vertical_id
+  on_missing: reject
+  on_conflict: reject
+pins:
+  inputs:
+    events:
+      - name: deploy_completed
+        event: deploy.done
+`)
+	writeConnectRoutePlanFixtureFile(t, filepath.Join(root, "flows", "consumer", "policy.yaml"), "{}\n")
+	writeConnectRoutePlanFixtureFile(t, filepath.Join(root, "flows", "consumer", "agents.yaml"), "{}\n")
+	writeConnectRoutePlanFixtureFile(t, filepath.Join(root, "flows", "consumer", "nodes.yaml"), "{}\n")
+	writeConnectRoutePlanFixtureFile(t, filepath.Join(root, "flows", "consumer", "events.yaml"), "deploy.done:\n  vertical_id: string\n")
+	writeConnectRoutePlanFixtureFile(t, filepath.Join(root, "flows", "consumer", "entities.yaml"), `
 deployment:
   vertical_id:
     type: string

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -5693,7 +5693,13 @@ flow_model:
             adapter_and_map: Explicit adapter plus sorted address-key map entries used for alias/key adaptation.
             delivery: one, many, broadcast, or reply after analyzer/default inference.
             target_kind: target for singular delivery, target_set for fanout/broadcast, reply for reply-lineage delivery.
-            resolution_kind: static, address, instance_key, or broadcast; materialization MUST consume this discriminant and MUST NOT select route authority from nil-field ordering.
+            resolution_kind: |
+              static, address, instance_key, or broadcast; materialization MUST
+              consume this discriminant and MUST NOT select route authority from
+              nil-field ordering. Explicit addressed-input routes remain
+              `address`; explicit parent-authored `delivery: broadcast` remains
+              `broadcast` for addressless fan-out and MUST NOT be shadowed by
+              producer key/carries or receiver instance.by evidence.
             address_rule: Receiver-owned address key, source expression, target expression, cardinality, and mode when runtime descriptor materialization is required.
             instance_key_rule: Receiver-owned template instance fields, on_missing, and on_conflict when an addressless template receiver is selected by producer key/carries plus receiver instance.by.
             reply_lineage: 'The explicit reply lineage map for delivery: reply.'
@@ -5724,7 +5730,11 @@ flow_model:
             pin declares `address`, lowering MUST keep `ResolutionKind: address`
             and MUST NOT also select the addressless instance-key route; the
             addressed-input descriptor model remains the canonical owner for
-            that explicit addressed surface.
+            that explicit addressed surface. If the parent connect declares
+            `delivery: broadcast`, lowering MUST keep `ResolutionKind: broadcast`
+            for addressless template fan-out and MUST NOT select instance-key
+            materialization even when producer key/carries and receiver
+            instance.by evidence are present.
 
             Runtime materialization MUST derive key material from the inbound
             event payload using TemplateInstanceContract.CanonicalKeyMaterial,
@@ -5737,6 +5747,7 @@ flow_model:
             MUST fail closed with zero executable routes.
           non_authoritative_for_this_slice:
           - receiver input-pin address for the addressless normal instance-key path
+          - receiver instance-key materialization for explicit parent-authored broadcast fan-out
           - receiver select_entity/select_or_create_entity
           - producer target.match
           - producer broadcast:true

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -462,8 +462,9 @@ contract_formats:
         nodes.yaml subscribes_to, and event_handlers keys. The platform matches local event names
         against local subscriber declarations.'
       cross_flow: 'Between flows, authored topology derives from parent package connect entries
-        over output and input pins. Output pins declare event identity, input pins declare receiver
-        address resolution, and parent connect lowers into concrete route-plan facts. See
+        over output and input pins. Output pins declare event identity and producer key/carries
+        evidence, template receivers declare instance.by route keys, input pins declare receiver
+        interface and explicit addressed-input routing when needed, and parent connect lowers into concrete route-plan facts. See
         flow_model.flow_package.composition_routing and engine.cross_flow_routing for details.
         Explicit scoped subscriptions (e.g., scoring/vertical.shortlisted) remain an escape hatch for
         cases outside the pin/connect interface.'
@@ -588,14 +589,15 @@ contract_formats:
             routing from replay/readback evidence.
         lowered_connect_route_plan_consumption:
           status: merge_bearing_runtime_behavior
-          implementation_slice: '#1473'
+          implementation_slice: '#1473/#1545'
           canonical_code_owner: internal/runtime/bus.RoutePlan via deliveryPlanner.Plan and connectRoutePlanResolver
           consumes:
           - internal/runtime/core/pinrouting.ConnectRoutePlan
           - lowered connect-route failure issues from route_plan_lowering
           - EventBus semantic source selected for the publish operation
+          - producer output key/carries evidence and receiver instance-key evidence carried by ConnectRoutePlan.InstanceKey
           - RouteTable concrete receiver subscribers only after a lowered plan selects the receiver route identity
-          - active flow-instance descriptors for supported identity-style addressed template targets
+          - active flow-instance descriptors for supported receiver instance-key and addressed template targets
           produces:
           - typed RoutePlanDeliveryIntent rows with source=connect_route_plan and reason=lowered_connect_route_plan
           - concrete delivery_target_route values for supported singular event.target delivery
@@ -609,6 +611,10 @@ contract_formats:
             Publish, PublishInMutation, CheckPublishRecipientPlan, and engineOutbox MUST share this RoutePlan authority path.
             Static lowered ConnectRoutePlan matches MUST NOT require or be blocked by legacy active-agent descriptor lookup;
             descriptor loading is limited to lowered plans whose supported target form requires runtime resolution.
+            Same-name template receiver plans MUST materialize from producer output key/carries plus receiver instance.by
+            evidence carried on ConnectRoutePlan.InstanceKey; input-pin address, connect.map, select_entity, producer target,
+            broadcast:true, direct delivery, raw subscribers, handler lookup, delivery rows, replay rows, and readback rows
+            MUST NOT route or rescue that normal instance-key path.
             When a lowered plan matches but cannot materialize or resolve to supported concrete receiver routes, planning MUST
             fail closed and MUST NOT preserve previously inferred live-subscriber fallback recipients. RouteTable may be used
             only as a consumer that locates the concrete receiver handler/carrier for the already-selected target route identity.
@@ -2163,9 +2169,10 @@ engine:
         unless the parent connect, alias/adapter, scoped subscription escape hatch, or explicit target escape hatch
         disambiguates the route.'
       static_pairs: Static-to-static pairs may resolve to a single instance pair at boot.
-      template_pairs: Template or dynamic-instance pairs require lowered parent connect route facts from the addressed input
-        pin, or an explicit dynamic target escape hatch at emit/publish time. Structural ParentRoute binding is only a
-        child-to-parent fallback when no lowered connect target applies.
+      template_pairs: Template or dynamic-instance pairs require lowered parent connect route facts from producer output
+        key/carries plus receiver instance.by for normal same-name instance-key routing, explicit addressed input-pin
+        descriptor routing for approved addressed surfaces, or an explicit dynamic target escape hatch at emit/publish
+        time. Structural ParentRoute binding is only a child-to-parent fallback when no lowered connect target applies.
     target_resolution:
       precedence:
       - lowered parent connect route plan
@@ -5231,6 +5238,19 @@ flow_model:
         output_pin_key_carries: '#1544'
         connect_to_instance_route_planning: '#1545'
         connect_key_adapters: '#1546'
+      connect_to_instance_route_planning:
+        status: merge_bearing_runtime_behavior
+        implementation_tracker: '#1545'
+        canonical_code_owner: internal/runtime/core/pinrouting.ConnectRoutePlan.InstanceKey + internal/runtime/bus.connectRoutePlanResolver
+        rule: >
+          For same-name normal composition into a template receiver, parent
+          `connect` MUST lower the producer output pin `key/carries` evidence
+          and the receiver `instance.by` contract into an explicit
+          instance-key ConnectRoutePlan. The normal path MUST NOT use receiver
+          input-pin `address`, receiver `select_entity`, producer
+          target/broadcast, direct delivery, raw subscribers, RouteTable lookup,
+          handler lookup, delivery rows, or replay/readback rows as the route
+          selector. Renamed key adapters remain #1546.
       output_pin_key_carries_contract:
         status: merge_bearing_contract_behavior
         implementation_tracker: '#1544'
@@ -5519,8 +5539,9 @@ flow_model:
       owner: platform-spec.yaml#flow_model.flow_package.composition_routing
       rule: >
         Parent-authored composition routing is the canonical source authority for common cross-flow pin delivery.
-        Output pins declare the event identity and producer interface; input pins declare the receiver interface and
-        any receiver address resolution; parent package.yaml `connect` entries declare inter-flow delivery topology.
+        Output pins declare the event identity and producer interface/key evidence; input pins declare the receiver interface;
+        template receiver `instance.by` declares the normal receiver instance key; explicit input-pin `address` declares
+        separately approved addressed-input descriptor routing. Parent package.yaml `connect` entries declare inter-flow delivery topology.
         The analyzer verifies those authored facts, infers only safe and unambiguous defaults, rejects ambiguity
         fail-closed, and lowers each accepted connection into concrete route-plan facts consumed by runtime RoutePlan.
         Producer emit sites MUST NOT own consumer routing on the common composed path.
@@ -5556,8 +5577,10 @@ flow_model:
             identity accepted by the receiver handler. `address` declares how the receiver entity or flow instance
             is selected for in-topology delivery.
           scalar_form: >
-            A scalar input event pin remains valid only for receivers that need no receiver address resolution or where
-            the parent connect/lowering rule supplies a complete receiver route without receiver-side key selection.
+            A scalar input event pin remains valid only for receivers that need no explicit addressed-input descriptor
+            routing or where the parent connect/lowering rule supplies a complete receiver route from static topology or
+            producer output key/carries plus receiver instance.by. A scalar input pin on a template receiver is not a
+            receiver-side selector by itself.
           address_fields:
             by: Required receiver address key name when address is present.
             source: Optional source expression such as payload.vertical_id or event.source.entity_id. If omitted, the analyzer may infer it only when the output payload exposes exactly one compatible field for `by`.
@@ -5618,9 +5641,11 @@ flow_model:
         receiver_input_pin_exists: The `to` pin must exist in the receiver schema input event pins.
         event_alias_or_adapter_valid: Differing local event names or payload keys require an explicit alias/adapter or unambiguous bind-derived alias; raw same-name fallback is not valid for declared imported package pins.
         output_carries_address_key: The producer output pin key/carries declaration must prove the top-level payload key used
-          by the receiver address or explicit connect.map source. Event payload schema and connect.map are validation inputs,
+          by the receiver instance.by route key, receiver address, or explicit connect.map source. Event payload schema and connect.map are validation inputs,
           not the canonical producer evidence owner; renamed-key adapters are explicit sibling work.
-        receiver_address_rule_present: Stateful or instance-addressed receivers must declare or inherit an input-pin address rule unless the connection lowers to a statically unique receiver.
+        receiver_route_key_present: Template receivers must resolve a valid instance.by contract for normal same-name
+          instance-key routing, or declare an explicit addressed input-pin route surface. Stateful/static receivers that
+          need no runtime selection may lower to a statically unique receiver.
         key_types_compatible: Source and target key types must be compatible before route-plan lowering.
         delivery_topology_valid: The declared delivery topology must match addressed input cardinality and available receiver instances.
         reply_lineage_usable: Reply delivery must prove usable request lineage; missing or ambiguous lineage fails closed.
@@ -5631,12 +5656,15 @@ flow_model:
         consumes:
         - parent package.yaml connect entries
         - producer output pin event identity and verified key/carries evidence, including explicit package-root `.pin_name` output endpoints
+        - receiver template instance.by / on_missing / on_conflict contracts from WorkflowContractBundle.ResolveFlowTemplateInstance
         - receiver addressed input pin rules
         - import-boundary pin alias bindings
         - explicit adapter/map entries
         produces:
         - semantic producer scope and local output pin identity
+        - producer output key/carries evidence on instance-key connect plans
         - semantic receiver scope and local input pin identity
+        - receiver instance-key evidence on same-name template receiver connect plans
         - external persisted event identity
         - receiver-local handler event identity
         - 'concrete target route for delivery: one'
@@ -5671,7 +5699,7 @@ flow_model:
             runtime_resolution_flag: Template or dynamic receivers keep an explicit runtime-resolution requirement instead of fabricating concrete delivery rows.
           materialization_boundary:
             static_receivers: Static receivers can materialize target route facts during lowering because the receiver flow path is concrete.
-            template_receivers: Template/dynamic receivers may materialize route facts only from explicit addressed-input keys and runtime descriptors, or for delivery:broadcast by enumerating receiver-scope descriptors; descriptor materialization remains pre-dispatch route evidence, not delivery execution.
+            template_receivers: Template/dynamic receivers may materialize route facts from receiver instance keys plus runtime descriptors, from explicit addressed-input keys and runtime descriptors, or for delivery:broadcast by enumerating receiver-scope descriptors; descriptor materialization remains pre-dispatch route evidence, not delivery execution.
             descriptor_scope: Descriptor materialization MUST reject descriptors whose flow_instance is not the receiver semantic flow path or a child instance under that path before stamping the receiver flow id onto the route.
             supported_descriptor_targets:
             - entity_id / entity.entity_id
@@ -5679,6 +5707,42 @@ flow_model:
             - instance_id / instance.instance_id
             - entity.<field> when the receiver entity contract declares that top-level field with indexed: true
             unsupported_descriptor_targets: Nested entity paths, undeclared or unindexed entity fields, config.<field>, instance.<field>, and other arbitrary business fields remain fail-closed unless a later approved spec+runtime child promotes a typed descriptor/index owner for those forms.
+        implementation_slice_1545:
+          status: merge_bearing_runtime_behavior
+          canonical_code_owner: internal/runtime/core/pinrouting.ConnectRoutePlan.InstanceKey + internal/runtime/bus.connectRoutePlanResolver
+          rule: |
+            Same-name parent connect into a template receiver MUST lower to an
+            explicit ConnectRoutePlan instance-key decision when the producer
+            output pin declares `key/carries` and the receiver resolves
+            `instance.by` through WorkflowContractBundle.ResolveFlowTemplateInstance.
+            The lowered plan MUST carry producer key/carries evidence and
+            receiver instance-key fields separately from the legacy/advanced
+            addressed-input `Address` descriptor model.
+
+            Runtime materialization MUST derive key material from the inbound
+            event payload using TemplateInstanceContract.CanonicalKeyMaterial,
+            match only receiver-scoped active flow-instance descriptors whose
+            entity.<field> address fields equal that key material, and then use
+            RouteTable only to locate the concrete receiver carrier for the
+            already-selected route identity. Missing key value, no matching
+            receiver instance under rejecting policy, ambiguous matching
+            descriptors, unsupported evidence shape, or missing receiver carrier
+            MUST fail closed with zero executable routes.
+          non_authoritative_for_this_slice:
+          - receiver input-pin address
+          - receiver select_entity/select_or_create_entity
+          - producer target.match
+          - producer broadcast:true
+          - direct delivery
+          - connect.map renamed-key adapter
+          - raw/live subscribers before selected target identity
+          - handler lookup before selected target identity
+          - delivery rows, replay rows, or readback rows as route producers
+          split_or_adjacent:
+            renamed_key_adapters: '#1546'
+            select_entity_demote_warn_error: '#1547'
+            replay_fork_idempotency_beyond_delivery_row_readback: '#1550'
+            explicit_addressed_input_descriptor_routing: '#1479'
           failure_reasons:
           - source_missing
           - connect_pin_ref_invalid

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -5693,7 +5693,9 @@ flow_model:
             adapter_and_map: Explicit adapter plus sorted address-key map entries used for alias/key adaptation.
             delivery: one, many, broadcast, or reply after analyzer/default inference.
             target_kind: target for singular delivery, target_set for fanout/broadcast, reply for reply-lineage delivery.
+            resolution_kind: static, address, instance_key, or broadcast; materialization MUST consume this discriminant and MUST NOT select route authority from nil-field ordering.
             address_rule: Receiver-owned address key, source expression, target expression, cardinality, and mode when runtime descriptor materialization is required.
+            instance_key_rule: Receiver-owned template instance fields, on_missing, and on_conflict when an addressless template receiver is selected by producer key/carries plus receiver instance.by.
             reply_lineage: 'The explicit reply lineage map for delivery: reply.'
             static_target_route: Static receiver flows may lower immediately to a concrete target or single target_set member using the receiver flow path and canonical flow-instance entity id.
             runtime_resolution_flag: Template or dynamic receivers keep an explicit runtime-resolution requirement instead of fabricating concrete delivery rows.
@@ -5709,15 +5711,20 @@ flow_model:
             unsupported_descriptor_targets: Nested entity paths, undeclared or unindexed entity fields, config.<field>, instance.<field>, and other arbitrary business fields remain fail-closed unless a later approved spec+runtime child promotes a typed descriptor/index owner for those forms.
         implementation_slice_1545:
           status: merge_bearing_runtime_behavior
-          canonical_code_owner: internal/runtime/core/pinrouting.ConnectRoutePlan.InstanceKey + internal/runtime/bus.connectRoutePlanResolver
+          canonical_code_owner: internal/runtime/core/pinrouting.ConnectRoutePlan.ResolutionKind + ConnectRoutePlan.InstanceKey + internal/runtime/bus.connectRoutePlanResolver
           rule: |
             Same-name parent connect into a template receiver MUST lower to an
-            explicit ConnectRoutePlan instance-key decision when the producer
-            output pin declares `key/carries` and the receiver resolves
-            `instance.by` through WorkflowContractBundle.ResolveFlowTemplateInstance.
+            explicit ConnectRoutePlan `ResolutionKind: instance_key` decision
+            when the receiver input pin is addressless, the producer output pin
+            declares `key/carries`, and the receiver resolves `instance.by`
+            through WorkflowContractBundle.ResolveFlowTemplateInstance.
             The lowered plan MUST carry producer key/carries evidence and
-            receiver instance-key fields separately from the legacy/advanced
-            addressed-input `Address` descriptor model.
+            receiver instance-key fields separately from the explicit
+            addressed-input `Address` descriptor model. If the receiver input
+            pin declares `address`, lowering MUST keep `ResolutionKind: address`
+            and MUST NOT also select the addressless instance-key route; the
+            addressed-input descriptor model remains the canonical owner for
+            that explicit addressed surface.
 
             Runtime materialization MUST derive key material from the inbound
             event payload using TemplateInstanceContract.CanonicalKeyMaterial,
@@ -5729,7 +5736,7 @@ flow_model:
             descriptors, unsupported evidence shape, or missing receiver carrier
             MUST fail closed with zero executable routes.
           non_authoritative_for_this_slice:
-          - receiver input-pin address
+          - receiver input-pin address for the addressless normal instance-key path
           - receiver select_entity/select_or_create_entity
           - producer target.match
           - producer broadcast:true


### PR DESCRIPTION
## Summary

- Add explicit `ConnectRoutePlan.ResolutionKind` plus `ConnectRoutePlan.InstanceKey` evidence for same-name parent connect to addressless template receiver routing.
- Lower producer output `key/carries` plus receiver `instance.by` into canonical route-plan instance-key evidence when the receiver input has no explicit `address` and parent delivery is not broadcast.
- Preserve explicit addressed-input routing as `ResolutionKind: address`, so `address.target` remains authoritative for addressed receiver inputs and cannot be shadowed by instance-key evidence.
- Preserve explicit parent `delivery: broadcast` as `ResolutionKind: broadcast`, so keyed addressless template receivers fan out across receiver-scope descriptors instead of filtering by instance key.
- Materialize instance-key plans through `TemplateInstanceContract.CanonicalKeyMaterial`, receiver-scoped active flow-instance descriptors, and post-target RouteTable carrier lookup.
- Fail closed with zero executable routes for missing key value, unresolved receiver instance, ambiguous receiver instance evidence, or unsupported same-concept fallback.
- Update `platform-spec.yaml`, the composition-routing spec assertion, and the route-authority matrix/inventory proof references.

Closes #1545

## Governing Refs / Context

Exact governing refs:

- `platform-spec.yaml#flow_model.flow_instance_authoring`
- `platform-spec.yaml#flow_model.flow_instance_authoring.template_instance_model`
- `platform-spec.yaml#flow_model.flow_instance_authoring.composition_model`
- `platform-spec.yaml#flow_model.flow_instance_authoring.composition_model.output_pin_key_carries_contract`
- `platform-spec.yaml#flow_model.flow_package.composition_routing`
- `platform-spec.yaml#flow_model.flow_package.composition_routing.route_plan_lowering`
- `platform-spec.yaml#contract_formats.event_schema.routing_derivation.route_plan_authority.lowered_connect_route_plan_consumption`
- Discussion #1476 locked design
- Approved #1545 pre-audit and independent gate outcome

Process note: `docs/IMPLEMENTER_GUIDELINES.md` and `docs/SEMANTIC_DRIFT.md` are absent from current `master`; I followed the issue/gate instructions and route-authority guardrails as binding context.

## Semantic Migration

- New canonical owner for this slice: `internal/runtime/core/pinrouting.ConnectRoutePlan.ResolutionKind`, `ConnectRoutePlan.InstanceKey`, and `internal/runtime/bus.connectRoutePlanResolver` consuming EventBus `RoutePlan` authority.
- Upstream canonical owners consumed: `FlowOutputEventPin` `key/carries` / `checkOutputPinKeyCarriesValidation`, and `WorkflowContractBundle.ResolveFlowTemplateInstance` / `TemplateInstanceContract.CanonicalKeyMaterial`.
- Old normal-path producers/interpreters now invalid for the addressless instance-key class: receiver input-pin `address` as a repair/override path, `connect.Map`, receiver `select_entity`, producer `target.match`, `broadcast:true`, direct delivery, raw/live subscriber lookup, handler lookup, recipient materializer repair, delivery rows, replay rows, and readback rows as route producers.
- Explicit addressed-input routing remains valid and authoritative as the separate #1479 surface; addressed receiver inputs lower as `ResolutionKind: address`, not `instance_key`.
- Explicit parent-authored `delivery: broadcast` remains valid and authoritative as broadcast fan-out; broadcast receiver inputs lower as `ResolutionKind: broadcast`, not `instance_key`, even when producer key/carries and receiver instance.by evidence exist.
- Production paths checked: pinrouting lower/materialize, bootverify composition validation, EventBus plan/preflight/publish, delivery-row persistence/readback replay recipient loading, RouteTable carrier lookup, descriptor evidence loading, route-authority matrix/inventory.
- Migration complete for the approved same-name addressless instance-key class. Renamed key adapters remain #1546; `select_entity` demotion remains #1547; replay/fork/idempotency beyond delivery-row/readback proof remains #1550.

## Proof

Focused proof run:

- `go test ./internal/runtime/core/pinrouting ./internal/runtime/bootverify ./internal/runtime/bus ./internal/apispec ./internal/runtime/conformance -run 'TestLowerCompositionConnectRoutePlansUsesTemplateInstanceKey|TestLowerCompositionConnectRoutePlansPreservesAddressedTemplateRoute|TestLowerCompositionConnectRoutePlansBroadcastBeatsInstanceKey|TestRun_AllowsTemplateInstanceKeyCompositionConnectWithoutAddress|TestRun_AllowsCompositeTemplateInstanceKeyCompositionConnectWithoutAddress|TestRun_FailsClosedForInvalidParentCompositionConnect|TestEventBusPublish_ConnectRoutePlanPersistsTemplateInstanceKeyTarget|TestEventBusPublish_ConnectRoutePlanBroadcastIgnoresInstanceKeyFiltering|TestEventBusPublish_ConnectRoutePlanFailsClosedForTemplateInstanceKeyGaps|TestPlatformSpecCompositionRoutingSourceAuthority|TestRouteAuthorityDriftInventoryCoversRepoWideSearchDimensions|TestRouteAuthorityMatrixCoversApprovedRows' -count=1`

Required full suite:

- `go test ./...`