### PR TITLE
[agent-a][issue #1546] Add connect key adapters

### DIFF
--- a/internal/apispec/platform_spec_composition_routing_test.go
+++ b/internal/apispec/platform_spec_composition_routing_test.go
@@ -109,6 +109,24 @@ func TestPlatformSpecCompositionRoutingSourceAuthority(t *testing.T) {
 		t.Fatal("implementation_slice_1545 must classify instance-key materialization as non-authoritative for explicit parent broadcast")
 	}
 
+	slice1546 := mustYAMLPath(t, composition, "route_plan_lowering", "implementation_slice_1546")
+	assertScalarValue(t, mustMappingValue(t, slice1546, "status"), "merge_bearing_runtime_behavior")
+	assertScalarContains(t, mustMappingValue(t, slice1546, "canonical_code_owner"), "ConnectRoutePlan.InstanceKey.Mappings")
+	assertScalarContains(t, mustMappingValue(t, slice1546, "canonical_code_owner"), "connectRoutePlanResolver")
+	assertScalarContains(t, mustMappingValue(t, slice1546, "rule"), "connect.using.instance.source")
+	assertScalarContains(t, mustMappingValue(t, slice1546, "rule"), "connect.using.instance.target")
+	assertScalarContains(t, mustMappingValue(t, slice1546, "rule"), "Same-name key/carries")
+	assertScalarContains(t, mustMappingValue(t, slice1546, "rule"), "`connect.map` remains the explicit addressed-input map concept")
+	if !sequenceContainsScalar(mustMappingValue(t, slice1546, "consumes"), "FlowPackageConnect.Using.Instance source/target adapter evidence") {
+		t.Fatal("implementation_slice_1546 must consume parsed using.instance adapter evidence")
+	}
+	if !sequenceContainsScalar(mustMappingValue(t, slice1546, "produces"), "ConnectRoutePlan.InstanceKey.Mappings for scalar and composite renamed keys") {
+		t.Fatal("implementation_slice_1546 must produce explicit instance-key mappings")
+	}
+	if !sequenceContainsScalar(mustMappingValue(t, slice1546, "non_authoritative_for_this_slice"), "connect.map as addressless template instance-key adapter authority") {
+		t.Fatal("implementation_slice_1546 must mark connect.map non-authoritative for addressless template instance-key adapters")
+	}
+
 	slice1475 := mustYAMLPath(t, composition, "route_plan_lowering", "implementation_slice_1475")
 	assertScalarValue(t, mustMappingValue(t, slice1475, "status"), "merge_bearing_runtime_behavior")
 	assertScalarContains(t, mustMappingValue(t, slice1475, "canonical_code_owner"), "ProducerRouteCommonPathFailure")

--- a/internal/apispec/platform_spec_flow_instance_authoring_test.go
+++ b/internal/apispec/platform_spec_flow_instance_authoring_test.go
@@ -132,6 +132,20 @@ func TestPlatformSpecFlowInstanceAuthoringSourceAuthority(t *testing.T) {
 	assertScalarValue(t, mustYAMLPath(t, composition, "split_children", "output_pin_key_carries"), "#1544")
 	assertScalarValue(t, mustYAMLPath(t, composition, "split_children", "connect_to_instance_route_planning"), "#1545")
 	assertScalarValue(t, mustYAMLPath(t, composition, "split_children", "connect_key_adapters"), "#1546")
+	keyAdapters := mustMappingValue(t, composition, "connect_key_adapters")
+	assertScalarValue(t, mustMappingValue(t, keyAdapters, "implementation_tracker"), "#1546")
+	assertScalarContains(t, mustMappingValue(t, keyAdapters, "canonical_code_owner"), "FlowPackageConnect.Using.Instance")
+	assertScalarContains(t, mustMappingValue(t, keyAdapters, "canonical_code_owner"), "validateCompositionConnectInstanceKeyAdapter")
+	assertScalarContains(t, mustMappingValue(t, keyAdapters, "canonical_code_owner"), "ConnectRoutePlan.InstanceKey.Mappings")
+	assertScalarValue(t, mustMappingValue(t, keyAdapters, "syntax"), "connect.using.instance.source / connect.using.instance.target")
+	assertScalarContains(t, mustMappingValue(t, keyAdapters, "rule"), "Same-name")
+	assertScalarContains(t, mustMappingValue(t, keyAdapters, "rule"), "`connect.map` is not adapter authority")
+	if !sequenceContainsScalar(mustMappingValue(t, keyAdapters, "fail_closed"), "using.instance declared on addressed-input, broadcast, or non-template receiver routes") {
+		t.Fatal("connect_key_adapters must fail closed for unsupported declaration surfaces")
+	}
+	if !sequenceContainsScalar(mustMappingValue(t, keyAdapters, "non_authoritative_paths"), "connect.map for addressless template instance-key adapters") {
+		t.Fatal("connect_key_adapters must mark connect.map non-authoritative for addressless template instance-key adapters")
+	}
 	outputContract := mustMappingValue(t, composition, "output_pin_key_carries_contract")
 	assertScalarValue(t, mustMappingValue(t, outputContract, "implementation_tracker"), "#1544")
 	assertScalarContains(t, mustMappingValue(t, outputContract, "canonical_code_owner"), "FlowOutputEventPin")

--- a/internal/runtime/bootverify/workflow_composition_connect_checks.go
+++ b/internal/runtime/bootverify/workflow_composition_connect_checks.go
@@ -199,14 +199,24 @@ func compositionReceiverAddressRequired(schema runtimecontracts.FlowSchemaDocume
 }
 
 func validateCompositionConnectInstanceKey(source semanticview.Source, connect runtimecontracts.FlowPackageConnect, outputPin runtimecontracts.FlowOutputEventPin, inputPin runtimecontracts.FlowInputEventPin, producerFlowID, receiverFlowID string) []Finding {
+	adapter := connect.Using.Instance
 	if inputPin.Address != nil {
+		if adapter.Declared {
+			return []Finding{compositionConnectFinding(connect, "connect_key_adapter_invalid", "connect.using.instance is valid only for addressless template receiver instance-key routes", receiverFlowID)}
+		}
 		return nil
 	}
 	if strings.TrimSpace(connect.Delivery) == "broadcast" {
+		if adapter.Declared {
+			return []Finding{compositionConnectFinding(connect, "connect_key_adapter_invalid", "connect.using.instance is incompatible with delivery broadcast", receiverFlowID)}
+		}
 		return nil
 	}
 	receiverSchema, ok := source.FlowSchemaByID(receiverFlowID)
 	if !ok || !compositionReceiverAddressRequired(receiverSchema) {
+		if adapter.Declared {
+			return []Finding{compositionConnectFinding(connect, "connect_key_adapter_invalid", "connect.using.instance requires a template receiver", receiverFlowID)}
+		}
 		return nil
 	}
 	if len(connect.Map) > 0 {
@@ -230,6 +240,9 @@ func validateCompositionConnectInstanceKey(source semanticview.Source, connect r
 	if !stringSliceContains(carries, outputKey) {
 		return []Finding{compositionConnectFinding(connect, "output_carries_instance_key", fmt.Sprintf("producer output pin key %s must also be listed in carries", outputKey), producerFlowID)}
 	}
+	if adapter.Declared {
+		return validateCompositionConnectInstanceKeyAdapter(source, connect, adapter, carries, instance.By, outputPin, producerFlowID, receiverFlowID)
+	}
 	if !stringSliceContains(instance.By, outputKey) {
 		return []Finding{compositionConnectFinding(connect, "instance_key_mismatch", fmt.Sprintf("producer output key %s does not match receiver instance.by %v", outputKey, instance.By), receiverFlowID)}
 	}
@@ -248,6 +261,53 @@ func validateCompositionConnectInstanceKey(source semanticview.Source, connect r
 		}
 		if !compositionConnectTypesCompatible(sourceType, targetType) {
 			return []Finding{compositionConnectFinding(connect, "key_types_incompatible", fmt.Sprintf("source payload.%s type %s is incompatible with receiver instance.by field entity.%s type %s", field, sourceType, field, targetType), receiverFlowID)}
+		}
+	}
+	return nil
+}
+
+func validateCompositionConnectInstanceKeyAdapter(source semanticview.Source, connect runtimecontracts.FlowPackageConnect, adapter runtimecontracts.FlowPackageConnectInstanceAdapter, carries, receiverFields []string, outputPin runtimecontracts.FlowOutputEventPin, producerFlowID, receiverFlowID string) []Finding {
+	sources := normalizedConnectAdapterFields(adapter.Source)
+	targets := normalizedConnectAdapterFields(adapter.Target)
+	if len(sources) == 0 {
+		return []Finding{compositionConnectFinding(connect, "connect_key_adapter_missing_source", "connect.using.instance.source is required", receiverFlowID)}
+	}
+	if len(targets) == 0 {
+		return []Finding{compositionConnectFinding(connect, "connect_key_adapter_missing_target", "connect.using.instance.target is required", receiverFlowID)}
+	}
+	if len(sources) != len(targets) {
+		return []Finding{compositionConnectFinding(connect, "connect_key_adapter_cardinality", fmt.Sprintf("connect.using.instance source count %d must equal target count %d", len(sources), len(targets)), receiverFlowID)}
+	}
+	if duplicate := duplicateString(sources); duplicate != "" {
+		return []Finding{compositionConnectFinding(connect, "connect_key_adapter_duplicate_source", fmt.Sprintf("connect.using.instance.source contains duplicate field %s", duplicate), producerFlowID)}
+	}
+	if duplicate := duplicateString(targets); duplicate != "" {
+		return []Finding{compositionConnectFinding(connect, "connect_key_adapter_duplicate_target", fmt.Sprintf("connect.using.instance.target contains duplicate field %s", duplicate), receiverFlowID)}
+	}
+	receiverFields = normalizedConnectAdapterFields(receiverFields)
+	for _, targetField := range targets {
+		if !stringSliceContains(receiverFields, targetField) {
+			return []Finding{compositionConnectFinding(connect, "connect_key_adapter_target_missing", fmt.Sprintf("adapter target field %s is not declared in receiver instance.by %v", targetField, receiverFields), receiverFlowID)}
+		}
+	}
+	if len(targets) != len(receiverFields) || !sameStringSet(targets, receiverFields) {
+		return []Finding{compositionConnectFinding(connect, "connect_key_adapter_partial", fmt.Sprintf("connect.using.instance.target must map every receiver instance.by field %v", receiverFields), receiverFlowID)}
+	}
+	for idx, sourceField := range sources {
+		targetField := targets[idx]
+		if !stringSliceContains(carries, sourceField) {
+			return []Finding{compositionConnectFinding(connect, "connect_key_adapter_source_missing", fmt.Sprintf("adapter source field %s is not declared in producer output carries %v", sourceField, carries), producerFlowID)}
+		}
+		sourceType, err := outputPinCarriedPayloadFieldType(source, producerFlowID, outputPin, sourceField)
+		if err != nil {
+			return []Finding{compositionConnectFinding(connect, "connect_key_adapter_source_missing", err.Error(), producerFlowID)}
+		}
+		targetType, err := compositionConnectTargetType(source, receiverFlowID, "entity."+targetField)
+		if err != nil {
+			return []Finding{compositionConnectFinding(connect, "connect_key_adapter_target_missing", err.Error(), receiverFlowID)}
+		}
+		if !compositionConnectTypesCompatible(sourceType, targetType) {
+			return []Finding{compositionConnectFinding(connect, "key_types_incompatible", fmt.Sprintf("adapter source payload.%s type %s is incompatible with receiver instance.by field entity.%s type %s", sourceField, sourceType, targetField, targetType), receiverFlowID)}
 		}
 	}
 	return nil
@@ -382,6 +442,59 @@ func compositionConnectTypesCompatible(sourceType, targetType string) bool {
 	sourceType = compositionConnectTypeFamily(sourceType)
 	targetType = compositionConnectTypeFamily(targetType)
 	return sourceType != "" && targetType != "" && sourceType == targetType
+}
+
+func normalizedConnectAdapterFields(in []string) []string {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(in))
+	for _, field := range in {
+		field = strings.TrimSpace(field)
+		if field != "" {
+			out = append(out, field)
+		}
+	}
+	return out
+}
+
+func duplicateString(in []string) string {
+	seen := map[string]struct{}{}
+	for _, item := range in {
+		item = strings.TrimSpace(item)
+		if item == "" {
+			continue
+		}
+		if _, ok := seen[item]; ok {
+			return item
+		}
+		seen[item] = struct{}{}
+	}
+	return ""
+}
+
+func sameStringSet(left, right []string) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	seen := map[string]struct{}{}
+	for _, item := range left {
+		item = strings.TrimSpace(item)
+		if item == "" {
+			return false
+		}
+		seen[item] = struct{}{}
+	}
+	for _, item := range right {
+		item = strings.TrimSpace(item)
+		if item == "" {
+			return false
+		}
+		if _, ok := seen[item]; !ok {
+			return false
+		}
+	}
+	return true
 }
 
 func compositionConnectTypeFamily(raw string) string {

--- a/internal/runtime/bootverify/workflow_composition_connect_checks_test.go
+++ b/internal/runtime/bootverify/workflow_composition_connect_checks_test.go
@@ -87,6 +87,186 @@ func TestRun_AllowsCompositeTemplateInstanceKeyCompositionConnectWithoutAddress(
 	}
 }
 
+func TestRun_AllowsRenamedTemplateInstanceKeyCompositionConnectWithUsingInstance(t *testing.T) {
+	tests := []struct {
+		name string
+		opts compositionConnectAdapterFixtureOptions
+	}{
+		{
+			name: "scalar renamed key",
+			opts: compositionConnectAdapterFixtureOptions{
+				sourceFields:       []compositionConnectAdapterField{{Name: "source_vertical_id", Type: "string"}},
+				outputKey:          "source_vertical_id",
+				outputCarries:      "[source_vertical_id]",
+				receiverInstanceBy: "vertical_id",
+				receiverFields:     []compositionConnectAdapterField{{Name: "vertical_id", Type: "string"}},
+				usingSource:        "source_vertical_id",
+				usingTarget:        "vertical_id",
+			},
+		},
+		{
+			name: "complete composite renamed key",
+			opts: compositionConnectAdapterFixtureOptions{
+				sourceFields: []compositionConnectAdapterField{
+					{Name: "source_vertical_id", Type: "string"},
+					{Name: "region_code", Type: "string"},
+				},
+				outputKey:          "source_vertical_id",
+				outputCarries:      "[source_vertical_id, region_code]",
+				receiverInstanceBy: "[vertical_id, region]",
+				receiverFields: []compositionConnectAdapterField{
+					{Name: "vertical_id", Type: "string"},
+					{Name: "region", Type: "string"},
+				},
+				usingSource: "[source_vertical_id, region_code]",
+				usingTarget: "[vertical_id, region]",
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			root := writeCompositionConnectAdapterBootverifyFixture(t, tc.opts)
+			bundle := loadFixtureBundleAt(t, repoRootForBootverifyTest(t), root, runtimecontracts.DefaultPlatformSpecFile(repoRootForBootverifyTest(t)))
+
+			report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+
+			if reportContains(report.Errors(), "composition_connect_validation", "") {
+				t.Fatalf("unexpected composition_connect_validation error: %#v", report.Errors())
+			}
+			if reportContains(report.Errors(), "template_instance_validation", "") {
+				t.Fatalf("unexpected template_instance_validation error: %#v", report.Errors())
+			}
+			if reportContains(report.Errors(), "output_pin_key_carries_validation", "") {
+				t.Fatalf("unexpected output_pin_key_carries_validation error: %#v", report.Errors())
+			}
+		})
+	}
+}
+
+func TestRun_FailsClosedForInvalidRenamedTemplateInstanceKeyAdapters(t *testing.T) {
+	base := compositionConnectAdapterFixtureOptions{
+		sourceFields: []compositionConnectAdapterField{
+			{Name: "source_vertical_id", Type: "string"},
+			{Name: "region_code", Type: "string"},
+		},
+		outputKey:          "source_vertical_id",
+		outputCarries:      "[source_vertical_id, region_code]",
+		receiverInstanceBy: "[vertical_id, region]",
+		receiverFields: []compositionConnectAdapterField{
+			{Name: "vertical_id", Type: "string"},
+			{Name: "region", Type: "string"},
+		},
+		usingSource: "[source_vertical_id, region_code]",
+		usingTarget: "[vertical_id, region]",
+	}
+	tests := []struct {
+		name      string
+		mutate    func(*compositionConnectAdapterFixtureOptions)
+		want      string
+		wantExtra string
+	}{
+		{
+			name: "missing adapter for renamed key",
+			mutate: func(o *compositionConnectAdapterFixtureOptions) {
+				o.omitUsing = true
+			},
+			want: "instance_key_mismatch",
+		},
+		{
+			name: "missing source",
+			mutate: func(o *compositionConnectAdapterFixtureOptions) {
+				o.usingSource = ""
+			},
+			want: "connect_key_adapter_missing_source",
+		},
+		{
+			name: "missing target",
+			mutate: func(o *compositionConnectAdapterFixtureOptions) {
+				o.usingTarget = ""
+			},
+			want: "connect_key_adapter_missing_target",
+		},
+		{
+			name: "source not carried",
+			mutate: func(o *compositionConnectAdapterFixtureOptions) {
+				o.usingSource = "[source_vertical_id, missing_region]"
+			},
+			want:      "connect_key_adapter_source_missing",
+			wantExtra: "missing_region",
+		},
+		{
+			name: "target not instance key",
+			mutate: func(o *compositionConnectAdapterFixtureOptions) {
+				o.usingTarget = "[vertical_id, missing_region]"
+			},
+			want:      "connect_key_adapter_target_missing",
+			wantExtra: "missing_region",
+		},
+		{
+			name: "partial composite mapping",
+			mutate: func(o *compositionConnectAdapterFixtureOptions) {
+				o.usingSource = "source_vertical_id"
+				o.usingTarget = "vertical_id"
+			},
+			want: "connect_key_adapter_partial",
+		},
+		{
+			name: "source target cardinality mismatch",
+			mutate: func(o *compositionConnectAdapterFixtureOptions) {
+				o.usingSource = "[source_vertical_id, region_code]"
+				o.usingTarget = "vertical_id"
+			},
+			want: "connect_key_adapter_cardinality",
+		},
+		{
+			name: "duplicate source mapping",
+			mutate: func(o *compositionConnectAdapterFixtureOptions) {
+				o.usingSource = "[source_vertical_id, source_vertical_id]"
+			},
+			want: "connect_key_adapter_duplicate_source",
+		},
+		{
+			name: "duplicate target mapping",
+			mutate: func(o *compositionConnectAdapterFixtureOptions) {
+				o.usingTarget = "[vertical_id, vertical_id]"
+			},
+			want: "connect_key_adapter_duplicate_target",
+		},
+		{
+			name: "incompatible adapter types",
+			mutate: func(o *compositionConnectAdapterFixtureOptions) {
+				o.sourceFields[0].Type = "integer"
+			},
+			want: "key_types_incompatible",
+		},
+		{
+			name: "old connect map remains invalid for addressless template receiver",
+			mutate: func(o *compositionConnectAdapterFixtureOptions) {
+				o.omitUsing = true
+				o.includeLegacyMap = true
+			},
+			want: "connect_key_adapter_unsupported",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			opts := base.clone()
+			tc.mutate(&opts)
+			root := writeCompositionConnectAdapterBootverifyFixture(t, opts)
+			bundle := loadFixtureBundleAt(t, repoRootForBootverifyTest(t), root, runtimecontracts.DefaultPlatformSpecFile(repoRootForBootverifyTest(t)))
+
+			report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+
+			if !reportContains(report.Errors(), "composition_connect_validation", tc.want) {
+				t.Fatalf("expected composition_connect_validation %q, got %#v", tc.want, report.Errors())
+			}
+			if tc.wantExtra != "" && !reportContains(report.Errors(), "composition_connect_validation", tc.wantExtra) {
+				t.Fatalf("expected composition_connect_validation detail %q, got %#v", tc.wantExtra, report.Errors())
+			}
+		})
+	}
+}
+
 func TestRun_FailsClosedForInvalidParentCompositionConnect(t *testing.T) {
 	tests := []struct {
 		name      string
@@ -431,6 +611,30 @@ type compositionConnectFixtureOptions struct {
 	consumerTemplateInstance       bool
 	consumerTemplateInstanceBy     string
 	consumerTemplateInstanceRegion bool
+}
+
+type compositionConnectAdapterField struct {
+	Name string
+	Type string
+}
+
+type compositionConnectAdapterFixtureOptions struct {
+	sourceFields       []compositionConnectAdapterField
+	outputKey          string
+	outputCarries      string
+	receiverInstanceBy string
+	receiverFields     []compositionConnectAdapterField
+	usingSource        string
+	usingTarget        string
+	omitUsing          bool
+	includeLegacyMap   bool
+}
+
+func (o compositionConnectAdapterFixtureOptions) clone() compositionConnectAdapterFixtureOptions {
+	out := o
+	out.sourceFields = append([]compositionConnectAdapterField(nil), o.sourceFields...)
+	out.receiverFields = append([]compositionConnectAdapterField(nil), o.receiverFields...)
+	return out
 }
 
 func writeCompositionConnectBootverifyFixture(t *testing.T, opts compositionConnectFixtureOptions) string {
@@ -995,10 +1199,145 @@ func compositionConnectConsumerRegionEntitySchema(opts compositionConnectFixture
 	if !opts.consumerTemplateInstanceRegion {
 		return ""
 	}
-	return `  region:
-    type: string
-    _unused_reason: composite template instance key proof field
-`
+	return "  region:\n" +
+		"    type: string\n" +
+		"    _unused_reason: composite template instance key proof field\n"
+}
+
+func writeCompositionConnectAdapterBootverifyFixture(t *testing.T, opts compositionConnectAdapterFixtureOptions) string {
+	t.Helper()
+	root := t.TempDir()
+	outputKey := firstTestValue(opts.outputKey, "source_vertical_id")
+	outputCarries := firstTestValue(opts.outputCarries, "["+outputKey+"]")
+	receiverInstanceBy := firstTestValue(opts.receiverInstanceBy, "vertical_id")
+	usingBlock := ""
+	if !opts.omitUsing {
+		usingBlock = "\n" +
+			"    using:\n" +
+			"      instance:\n" +
+			"        source: " + opts.usingSource + "\n" +
+			"        target: " + opts.usingTarget
+	}
+	legacyMapBlock := ""
+	if opts.includeLegacyMap {
+		legacyMapBlock = "\n" +
+			"    map:\n" +
+			"      vertical_id:\n" +
+			"        source: payload." + outputKey + "\n" +
+			"        target: entity.vertical_id"
+	}
+	writeBootverifyFixtureFile(t, filepath.Join(root, "package.yaml"), `
+name: composition-connect-adapter-bootverify
+version: "1.0.0"
+platform_version: ">=1.6.0"
+flows:
+  - id: producer
+    flow: producer
+    mode: static
+  - id: consumer
+    flow: consumer
+    mode: template
+connect:
+  - from: producer.deploy_done
+    to: consumer.deploy_completed
+    delivery: one`+usingBlock+legacyMapBlock+`
+`)
+	writeBootverifyFixtureFile(t, filepath.Join(root, "schema.yaml"), "name: composition-connect-adapter-bootverify\n")
+	writeBootverifyFixtureFile(t, filepath.Join(root, "policy.yaml"), "{}\n")
+	writeBootverifyFixtureFile(t, filepath.Join(root, "tools.yaml"), "{}\n")
+	writeBootverifyFixtureFile(t, filepath.Join(root, "agents.yaml"), "{}\n")
+	writeBootverifyFixtureFile(t, filepath.Join(root, "events.yaml"), "{}\n")
+	writeBootverifyFixtureFile(t, filepath.Join(root, "nodes.yaml"), "{}\n")
+	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "producer", "schema.yaml"), `
+name: producer
+mode: static
+pins:
+  outputs:
+    events:
+      - name: deploy_done
+        event: deploy.done
+        key: `+outputKey+`
+        carries: `+outputCarries+`
+`)
+	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "producer", "policy.yaml"), "{}\n")
+	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "producer", "agents.yaml"), "{}\n")
+	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "producer", "entities.yaml"), "{}\n")
+	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "producer", "events.yaml"), `
+deploy.requested:
+`+compositionConnectAdapterFieldsSchema(opts.sourceFields)+`deploy.done:
+`+compositionConnectAdapterFieldsSchema(opts.sourceFields))
+	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "producer", "nodes.yaml"), `
+producer-node:
+  id: producer-node
+  execution_type: system_node
+  subscribes_to: [deploy.requested]
+  event_handlers:
+    deploy.requested:
+      emit:
+        event: deploy.done
+        fields:
+`+compositionConnectAdapterEmitFields(opts.sourceFields))
+	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "consumer", "schema.yaml"), `
+name: consumer
+mode: template
+instance:
+  by: `+receiverInstanceBy+`
+  on_missing: reject
+  on_conflict: reject
+pins:
+  inputs:
+    events:
+      - name: deploy_completed
+        event: deploy.done
+`)
+	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "consumer", "policy.yaml"), "{}\n")
+	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "consumer", "agents.yaml"), "{}\n")
+	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "consumer", "events.yaml"), `
+deploy.done:
+`+compositionConnectAdapterFieldsSchema(opts.sourceFields))
+	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "consumer", "entities.yaml"), `
+deployment:
+`+compositionConnectAdapterEntityFields(opts.receiverFields))
+	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "consumer", "nodes.yaml"), "{}\n")
+	return root
+}
+
+func compositionConnectAdapterFieldsSchema(fields []compositionConnectAdapterField) string {
+	if len(fields) == 0 {
+		return "  source_vertical_id: string\n"
+	}
+	var out strings.Builder
+	for _, field := range fields {
+		name := firstTestValue(field.Name, "source_vertical_id")
+		typ := firstTestValue(field.Type, "string")
+		out.WriteString("  " + name + ": " + typ + "\n")
+	}
+	return out.String()
+}
+
+func compositionConnectAdapterEmitFields(fields []compositionConnectAdapterField) string {
+	if len(fields) == 0 {
+		return "          source_vertical_id: payload.source_vertical_id\n"
+	}
+	var out strings.Builder
+	for _, field := range fields {
+		name := firstTestValue(field.Name, "source_vertical_id")
+		out.WriteString("          " + name + ": payload." + name + "\n")
+	}
+	return out.String()
+}
+
+func compositionConnectAdapterEntityFields(fields []compositionConnectAdapterField) string {
+	if len(fields) == 0 {
+		return "  vertical_id:\n    type: string\n    _unused_reason: connect adapter receiver instance-key proof field\n"
+	}
+	var out strings.Builder
+	for _, field := range fields {
+		name := firstTestValue(field.Name, "vertical_id")
+		typ := firstTestValue(field.Type, "string")
+		out.WriteString("  " + name + ":\n    type: " + typ + "\n    _unused_reason: connect adapter receiver instance-key proof field\n")
+	}
+	return out.String()
 }
 
 func firstTestValue(values ...string) string {

--- a/internal/runtime/bus/connect_route_plan_dispatch_test.go
+++ b/internal/runtime/bus/connect_route_plan_dispatch_test.go
@@ -813,7 +813,7 @@ func TestEventBusPublish_ConnectRoutePlanFailsClosedForRenamedTemplateInstanceKe
 	defer eb.Unsubscribe("raw-source-listener")
 	eventID := uuid.NewString()
 	evt := eventtest.RootIngress(eventID,
-		events.EventType("producer/deploy.done"), "", "", json.RawMessage(`{"vertical_id":"v-1"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())
+		events.EventType("producer/deploy.done"), "", "", json.RawMessage(`{"nested":{"source_vertical_id":"v-1"}}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())
 
 	routePlan, err := eb.planSubscribedRoutePlan(context.Background(), evt, false)
 	if err != nil {

--- a/internal/runtime/bus/connect_route_plan_dispatch_test.go
+++ b/internal/runtime/bus/connect_route_plan_dispatch_test.go
@@ -727,6 +727,133 @@ func TestEventBusPublish_ConnectRoutePlanPersistsTemplateInstanceKeyTarget(t *te
 	}
 }
 
+func TestEventBusPublish_ConnectRoutePlanPersistsRenamedTemplateInstanceKeyTarget(t *testing.T) {
+	source := connectRoutePlanRenamedInstanceKeySource(t)
+	store := &connectRoutePlanDescriptorStore{
+		targetRouteMemoryStore: newTargetRouteMemoryStore(),
+		flowInstances: []ActiveFlowInstanceDescriptor{{
+			InstanceID:    "one",
+			EntityID:      "ent-1",
+			FlowInstance:  "consumer/one",
+			AddressFields: map[string]string{"entity.vertical_id": "v-1"},
+		}},
+	}
+	eb, err := NewEventBusWithOptions(store, EventBusOptions{ContractBundle: source})
+	if err != nil {
+		t.Fatalf("NewEventBusWithOptions: %v", err)
+	}
+	if err := eb.AddFlowInstanceRoute(FlowInstanceRouteMaterializationRequest{Identity: runtimeflowidentity.DeriveRoute("consumer", "one")}); err != nil {
+		t.Fatalf("AddFlowInstanceRoute: %v", err)
+	}
+	eventID := uuid.NewString()
+	evt := eventtest.RootIngress(eventID,
+		events.EventType("producer/deploy.done"), "", "", json.RawMessage(`{"source_vertical_id":"v-1"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())
+
+	want := events.DeliveryRoute{SubscriberType: "node", SubscriberID: "consumer-node-one", Target: events.RouteIdentity{FlowID: "consumer", FlowInstance: "consumer/one", EntityID: "ent-1"}}
+
+	routePlan, err := eb.planSubscribedRoutePlan(context.Background(), evt, false)
+	if err != nil {
+		t.Fatalf("planSubscribedRoutePlan: %v", err)
+	}
+	if routePlan.AuthorityState != RoutePlanAuthorityCanonicalMatched || routePlan.AuthorityOwner != routePlanSourceConnectRoutePlan {
+		t.Fatalf("route plan authority = %q/%q, want matched connect route plan", routePlan.AuthorityState, routePlan.AuthorityOwner)
+	}
+	if !deliveryRoutesContain(routePlan.DeliveryRoutes(), want) || len(routePlan.DeliveryRoutes()) != 1 {
+		t.Fatalf("route plan delivery routes = %#v, want renamed instance-key route %#v", routePlan.DeliveryRoutes(), want)
+	}
+
+	plan, err := eb.CheckPublishRecipientPlan(context.Background(), evt)
+	if err != nil {
+		t.Fatalf("CheckPublishRecipientPlan: %v", err)
+	}
+	if plan.TargetFailure != "" {
+		t.Fatalf("target failure = %q, want none", plan.TargetFailure)
+	}
+	if !deliveryRoutesContain(plan.DeliveryRoutes, want) || len(plan.DeliveryRoutes) != 1 {
+		t.Fatalf("preflight delivery routes = %#v, want renamed instance-key route %#v", plan.DeliveryRoutes, want)
+	}
+
+	if err := eb.Publish(context.Background(), evt); err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+	if !deliveryRoutesContain(store.routes[eventID], want) || len(store.routes[eventID]) != 1 {
+		t.Fatalf("persisted delivery routes = %#v, want renamed instance-key route %#v", store.routes[eventID], want)
+	}
+	live, internal, replayRoutes, err := eb.replayRecipientsForCommittedEvent(context.Background(), evt, nil, runtimereplayclaim.CommittedReplayScopeSubscribed)
+	if err != nil {
+		t.Fatalf("replayRecipientsForCommittedEvent: %v", err)
+	}
+	if !containsString(live, "consumer-node-one") || !containsString(internal, "consumer-node-one") {
+		t.Fatalf("replay live=%#v internal=%#v, want consumer-node-one from persisted connect route", live, internal)
+	}
+	if !deliveryRoutesContain(replayRoutes, want) {
+		t.Fatalf("replay delivery routes = %#v, want %#v", replayRoutes, want)
+	}
+}
+
+func TestEventBusPublish_ConnectRoutePlanFailsClosedForRenamedTemplateInstanceKeySourceGap(t *testing.T) {
+	source := connectRoutePlanRenamedInstanceKeySource(t)
+	store := &connectRoutePlanDescriptorStore{
+		targetRouteMemoryStore: newTargetRouteMemoryStore(),
+		flowInstances: []ActiveFlowInstanceDescriptor{{
+			InstanceID:    "one",
+			EntityID:      "ent-1",
+			FlowInstance:  "consumer/one",
+			AddressFields: map[string]string{"entity.vertical_id": "v-1"},
+		}},
+	}
+	eb, err := NewEventBusWithOptions(store, EventBusOptions{ContractBundle: source})
+	if err != nil {
+		t.Fatalf("NewEventBusWithOptions: %v", err)
+	}
+	if err := eb.AddFlowInstanceRoute(FlowInstanceRouteMaterializationRequest{Identity: runtimeflowidentity.DeriveRoute("consumer", "one")}); err != nil {
+		t.Fatalf("AddFlowInstanceRoute: %v", err)
+	}
+	raw := eb.Subscribe("raw-source-listener", events.EventType("producer/deploy.done"), events.EventType("deploy.done"))
+	defer eb.Unsubscribe("raw-source-listener")
+	eventID := uuid.NewString()
+	evt := eventtest.RootIngress(eventID,
+		events.EventType("producer/deploy.done"), "", "", json.RawMessage(`{"vertical_id":"v-1"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())
+
+	routePlan, err := eb.planSubscribedRoutePlan(context.Background(), evt, false)
+	if err != nil {
+		t.Fatalf("planSubscribedRoutePlan: %v", err)
+	}
+	if routePlan.AuthorityState != RoutePlanAuthorityCanonicalFailedClosed || routePlan.AuthorityOwner != routePlanSourceConnectRoutePlan {
+		t.Fatalf("route plan authority = %q/%q, want fail-closed connect route plan", routePlan.AuthorityState, routePlan.AuthorityOwner)
+	}
+	if routePlan.TargetFailure != runtimepinrouting.TargetFailure(runtimepinrouting.ConnectFailureAddressValueMissing) {
+		t.Fatalf("target failure = %q, want %q", routePlan.TargetFailure, runtimepinrouting.ConnectFailureAddressValueMissing)
+	}
+	if len(routePlan.LiveRecipients) != 0 || len(routePlan.DeliveryIntents) != 0 || len(routePlan.RoutedRecipients) != 0 ||
+		len(routePlan.SubscribedRecipients) != 0 || len(routePlan.RecipientIDs()) != 0 ||
+		len(routePlan.PersistedRecipientIDs()) != 0 || len(routePlan.DeliveryRoutes()) != 0 {
+		t.Fatalf("fail-closed renamed instance-key route exposed lower-precedence fallback: live=%#v intents=%#v routed=%#v subscriptions=%#v recipients=%#v persisted=%#v routes=%#v",
+			routePlan.LiveRecipients, routePlan.DeliveryIntents, routePlan.RoutedRecipients, routePlan.SubscribedRecipients,
+			routePlan.RecipientIDs(), routePlan.PersistedRecipientIDs(), routePlan.DeliveryRoutes())
+	}
+
+	plan, err := eb.CheckPublishRecipientPlan(context.Background(), evt)
+	if err != nil {
+		t.Fatalf("CheckPublishRecipientPlan: %v", err)
+	}
+	if got, want := plan.TargetFailure, string(runtimepinrouting.ConnectFailureAddressValueMissing); got != want {
+		t.Fatalf("preflight target failure = %q, want %q", got, want)
+	}
+	if len(plan.Recipients) != 0 || len(plan.PersistedRecipients) != 0 || len(plan.RoutedRecipients) != 0 ||
+		len(plan.SubscriptionRecipients) != 0 || len(plan.DeliveryRoutes) != 0 {
+		t.Fatalf("preflight exposed lower-precedence fallback: recipients=%#v persisted=%#v routed=%#v subscriptions=%#v routes=%#v",
+			plan.Recipients, plan.PersistedRecipients, plan.RoutedRecipients, plan.SubscriptionRecipients, plan.DeliveryRoutes)
+	}
+	if err := eb.Publish(context.Background(), evt); err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+	if routes := store.routes[eventID]; len(routes) != 0 {
+		t.Fatalf("persisted delivery routes = %#v, want none for fail-closed renamed instance-key route", routes)
+	}
+	requireNoConnectRoutePlanBusEvent(t, raw, "source/raw subscriber fallback")
+}
+
 func TestEventBusPublish_ConnectRoutePlanBroadcastIgnoresInstanceKeyFiltering(t *testing.T) {
 	source := connectRoutePlanInstanceKeyBroadcastSource(t)
 	store := &connectRoutePlanDescriptorStore{
@@ -1376,6 +1503,21 @@ func connectRoutePlanInstanceKeySource(t testing.TB) semanticview.Source {
 	return semanticview.Wrap(bundle)
 }
 
+func connectRoutePlanRenamedInstanceKeySource(t testing.TB) semanticview.Source {
+	t.Helper()
+	repoRoot, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd: %v", err)
+	}
+	repoRoot = filepath.Clean(filepath.Join(repoRoot, "..", "..", ".."))
+	root := writeConnectRoutePlanRenamedInstanceKeyFixture(t)
+	bundle, err := runtimecontracts.LoadWorkflowContractBundleWithOverrides(repoRoot, root, runtimecontracts.DefaultPlatformSpecFile(repoRoot))
+	if err != nil {
+		t.Fatalf("LoadWorkflowContractBundleWithOverrides: %v", err)
+	}
+	return semanticview.Wrap(bundle)
+}
+
 func connectRoutePlanInstanceKeyBroadcastSource(t testing.TB) semanticview.Source {
 	t.Helper()
 	repoRoot, err := os.Getwd()
@@ -1393,6 +1535,82 @@ func connectRoutePlanInstanceKeyBroadcastSource(t testing.TB) semanticview.Sourc
 
 func writeConnectRoutePlanInstanceKeyFixture(t testing.TB) string {
 	return writeConnectRoutePlanInstanceKeyFixtureWithDelivery(t, "one")
+}
+
+func writeConnectRoutePlanRenamedInstanceKeyFixture(t testing.TB) string {
+	t.Helper()
+	root := t.TempDir()
+	writeConnectRoutePlanBusFixtureFile(t, filepath.Join(root, "package.yaml"), `
+name: renamed-instance-key-connect-route-plan-bus
+version: "1.0.0"
+platform_version: ">=1.6.0"
+flows:
+  - id: producer
+    flow: producer
+    mode: static
+  - id: consumer
+    flow: consumer
+    mode: template
+connect:
+  - from: producer.deploy_done
+    to: consumer.deploy_completed
+    delivery: one
+    using:
+      instance:
+        source: source_vertical_id
+        target: vertical_id
+`)
+	writeConnectRoutePlanBusFixtureFile(t, filepath.Join(root, "schema.yaml"), "name: renamed-instance-key-connect-route-plan-bus\n")
+	writeConnectRoutePlanBusFixtureFile(t, filepath.Join(root, "policy.yaml"), "{}\n")
+	writeConnectRoutePlanBusFixtureFile(t, filepath.Join(root, "tools.yaml"), "{}\n")
+	writeConnectRoutePlanBusFixtureFile(t, filepath.Join(root, "agents.yaml"), "{}\n")
+	writeConnectRoutePlanBusFixtureFile(t, filepath.Join(root, "events.yaml"), "{}\n")
+	writeConnectRoutePlanBusFixtureFile(t, filepath.Join(root, "nodes.yaml"), "{}\n")
+	writeConnectRoutePlanBusFixtureFile(t, filepath.Join(root, "flows", "producer", "schema.yaml"), `
+name: producer
+mode: static
+pins:
+  outputs:
+    events:
+      - name: deploy_done
+        event: deploy.done
+        key: source_vertical_id
+        carries: [source_vertical_id]
+`)
+	writeConnectRoutePlanBusFixtureFile(t, filepath.Join(root, "flows", "producer", "policy.yaml"), "{}\n")
+	writeConnectRoutePlanBusFixtureFile(t, filepath.Join(root, "flows", "producer", "agents.yaml"), "{}\n")
+	writeConnectRoutePlanBusFixtureFile(t, filepath.Join(root, "flows", "producer", "events.yaml"), "deploy.done:\n  source_vertical_id: string\n")
+	writeConnectRoutePlanBusFixtureFile(t, filepath.Join(root, "flows", "producer", "entities.yaml"), "{}\n")
+	writeConnectRoutePlanBusFixtureFile(t, filepath.Join(root, "flows", "producer", "nodes.yaml"), "{}\n")
+	writeConnectRoutePlanBusFixtureFile(t, filepath.Join(root, "flows", "consumer", "schema.yaml"), `
+name: consumer
+mode: template
+instance:
+  by: vertical_id
+  on_missing: reject
+  on_conflict: reject
+pins:
+  inputs:
+    events:
+      - name: deploy_completed
+        event: deploy.done
+`)
+	writeConnectRoutePlanBusFixtureFile(t, filepath.Join(root, "flows", "consumer", "policy.yaml"), "{}\n")
+	writeConnectRoutePlanBusFixtureFile(t, filepath.Join(root, "flows", "consumer", "agents.yaml"), "{}\n")
+	writeConnectRoutePlanBusFixtureFile(t, filepath.Join(root, "flows", "consumer", "events.yaml"), "deploy.done:\n  source_vertical_id: string\n")
+	writeConnectRoutePlanBusFixtureFile(t, filepath.Join(root, "flows", "consumer", "entities.yaml"), `
+deployment:
+  vertical_id:
+    type: string
+`)
+	writeConnectRoutePlanBusFixtureFile(t, filepath.Join(root, "flows", "consumer", "nodes.yaml"), `
+consumer-node:
+  id: consumer-node-{instance_id}
+  execution_type: system_node
+  event_handlers:
+    deploy.done: {}
+`)
+	return root
 }
 
 func writeConnectRoutePlanInstanceKeyFixtureWithDelivery(t testing.TB, delivery string) string {

--- a/internal/runtime/conformance/route_authority_drift_inventory_test.go
+++ b/internal/runtime/conformance/route_authority_drift_inventory_test.go
@@ -152,6 +152,20 @@ func TestRouteAuthorityDriftInventoryRejectsNarrowOrStaleAudit(t *testing.T) {
 			},
 			want: "inventory implementation_issues missing #1495",
 		},
+		{
+			name: "route plan discriminant child issue must stay visible",
+			mutate: func(inventory *routeAuthorityDriftInventory) {
+				inventory.ImplementationIssues = []int{1364, 1494, 1495, 1496}
+			},
+			want: "inventory implementation_issues missing #1545",
+		},
+		{
+			name: "connect key adapter child issue must stay visible",
+			mutate: func(inventory *routeAuthorityDriftInventory) {
+				inventory.ImplementationIssues = []int{1364, 1494, 1495, 1496, 1545}
+			},
+			want: "inventory implementation_issues missing #1546",
+		},
 	}
 
 	for _, tc := range tests {
@@ -249,7 +263,7 @@ func validateRouteAuthorityDriftInventoryWithCorpus(root string, corpus *routeAu
 	if inventory.Issue != 1364 {
 		problems = append(problems, fmt.Sprintf("inventory issue = #%d, want #1364", inventory.Issue))
 	}
-	for _, issue := range []int{1364, 1494, 1495, 1496} {
+	for _, issue := range []int{1364, 1494, 1495, 1496, 1545, 1546} {
 		if !routeAuthorityDriftHasInt(inventory.ImplementationIssues, issue) {
 			problems = append(problems, fmt.Sprintf("inventory implementation_issues missing #%d", issue))
 		}

--- a/internal/runtime/conformance/testdata/route_authority_drift_inventory.yaml
+++ b/internal/runtime/conformance/testdata/route_authority_drift_inventory.yaml
@@ -359,6 +359,7 @@ seam_families:
     classification: canonical_owner
     paths:
       - platform-spec.yaml
+      - internal/apispec/platform_spec_flow_instance_authoring_test.go
       - internal/apispec/platform_spec_composition_routing_test.go
       - internal/runtime/core/pinrouting/connect_route_plan.go
       - internal/runtime/core/pinrouting/connect_route_plan_test.go
@@ -374,6 +375,9 @@ seam_families:
       ResolutionKind discriminant so addressed-input, instance-key, broadcast,
       and static route authority are not selected by nil-field ordering, and
       keyed instance evidence cannot shadow explicit parent broadcast fan-out.
+      #1546 adds ConnectRoutePlan.InstanceKey.Mappings as the only runtime
+      adapter authority for renamed addressless template instance-key routes;
+      connect.map remains non-authoritative for that class.
   - id: route_table_resolve_role_separation
     layer: route_topology
     classification: valid_consumer

--- a/internal/runtime/conformance/testdata/route_authority_drift_inventory.yaml
+++ b/internal/runtime/conformance/testdata/route_authority_drift_inventory.yaml
@@ -1,7 +1,7 @@
 version: 1
 kind: route_authority_drift_inventory
 issue: 1364
-implementation_issues: [1364, 1494, 1495, 1496, 1545]
+implementation_issues: [1364, 1494, 1495, 1496, 1545, 1546]
 parent_issues: [1340, 1353, 1481, 1493]
 watchlist: runtime_operations.delivery_and_replay_ownership
 policy:

--- a/internal/runtime/conformance/testdata/route_authority_matrix.yaml
+++ b/internal/runtime/conformance/testdata/route_authority_matrix.yaml
@@ -322,14 +322,19 @@ rows:
       - {kind: issue, issue: 1473}
       - {kind: issue, issue: 1494}
       - {kind: issue, issue: 1545}
+      - {kind: issue, issue: 1546}
       - {kind: go_test, name: TestLowerCompositionConnectRoutePlansUsesTemplateInstanceKey}
       - {kind: go_test, name: TestLowerCompositionConnectRoutePlansPreservesAddressedTemplateRoute}
       - {kind: go_test, name: TestLowerCompositionConnectRoutePlansBroadcastBeatsInstanceKey}
+      - {kind: go_test, name: TestLowerCompositionConnectRoutePlansUsesRenamedInstanceKeyAdapter}
+      - {kind: go_test, name: TestLowerCompositionConnectRoutePlansFailsClosedForInvalidRenamedInstanceKeyAdapter}
       - {kind: go_test, name: TestLowerCompositionConnectRoutePlanDoesNotDependOnRawPinNamesOrProducerTargets}
       - {kind: go_test, name: TestEventBusPublish_ConnectRoutePlanPersistsSingularTargetWithoutLiveSubscriber}
       - {kind: go_test, name: TestEventBusPublish_ConnectRoutePlanPersistsTemplateInstanceKeyTarget}
+      - {kind: go_test, name: TestEventBusPublish_ConnectRoutePlanPersistsRenamedTemplateInstanceKeyTarget}
       - {kind: go_test, name: TestEventBusPublish_ConnectRoutePlanBroadcastIgnoresInstanceKeyFiltering}
       - {kind: go_test, name: TestEventBusPublish_ConnectRoutePlanFailsClosedForTemplateInstanceKeyGaps}
+      - {kind: go_test, name: TestEventBusPublish_ConnectRoutePlanFailsClosedForRenamedTemplateInstanceKeySourceGap}
       - {kind: go_test, name: TestEventBusPublish_ConnectRoutePlanFailsClosedForUnsupportedBusinessFieldTarget}
     notes: >
       ConnectRoutePlan is a typed route-intent input, not an untracked string

--- a/internal/runtime/contracts/workflow_contract_connect.go
+++ b/internal/runtime/contracts/workflow_contract_connect.go
@@ -86,10 +86,38 @@ func (c FlowPackageConnect) normalized() FlowPackageConnect {
 		From:       strings.TrimSpace(c.From),
 		To:         strings.TrimSpace(c.To),
 		Adapter:    strings.TrimSpace(c.Adapter),
+		Using:      c.Using.normalized(),
 		Map:        cloneFlowPackageConnectMap(c.Map),
 		Delivery:   strings.TrimSpace(c.Delivery),
 		Reply:      normalizeStringMap(c.Reply),
 	}
+}
+
+func (u FlowPackageConnectUsing) normalized() FlowPackageConnectUsing {
+	return FlowPackageConnectUsing{
+		Instance: u.Instance.normalized(),
+	}
+}
+
+func (a FlowPackageConnectInstanceAdapter) normalized() FlowPackageConnectInstanceAdapter {
+	return FlowPackageConnectInstanceAdapter{
+		Declared: a.Declared,
+		Source:   normalizeStringListPreserveOrder(a.Source),
+		Target:   normalizeStringListPreserveOrder(a.Target),
+	}
+}
+
+func normalizeStringListPreserveOrder(values []string) []string {
+	if len(values) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		if value = strings.TrimSpace(value); value != "" {
+			out = append(out, value)
+		}
+	}
+	return out
 }
 
 func parseFlowPackagePinRef(raw string) (FlowPackagePinRef, error) {

--- a/internal/runtime/contracts/workflow_contract_types.go
+++ b/internal/runtime/contracts/workflow_contract_types.go
@@ -814,9 +814,18 @@ type FlowPackageConnect struct {
 	From       string                           `yaml:"from"`
 	To         string                           `yaml:"to"`
 	Adapter    string                           `yaml:"adapter"`
+	Using      FlowPackageConnectUsing          `yaml:"using"`
 	Map        map[string]FlowPackageConnectMap `yaml:"map"`
 	Delivery   string                           `yaml:"delivery"`
 	Reply      map[string]string                `yaml:"reply"`
+}
+type FlowPackageConnectUsing struct {
+	Instance FlowPackageConnectInstanceAdapter `yaml:"instance"`
+}
+type FlowPackageConnectInstanceAdapter struct {
+	Declared bool     `yaml:"-"`
+	Source   []string `yaml:"source"`
+	Target   []string `yaml:"target"`
 }
 type FlowPackageConnectMap struct {
 	Source string `yaml:"source"`

--- a/internal/runtime/contracts/workflow_contract_yaml_wave1.go
+++ b/internal/runtime/contracts/workflow_contract_yaml_wave1.go
@@ -315,6 +315,10 @@ func (c *FlowPackageConnect) UnmarshalYAML(node *yaml.Node) error {
 			if err := value.Decode(&out.Adapter); err != nil {
 				return fmt.Errorf("connect.adapter: %w", err)
 			}
+		case "using":
+			if err := value.Decode(&out.Using); err != nil {
+				return fmt.Errorf("connect.using: %w", err)
+			}
 		case "map":
 			if err := value.Decode(&out.Map); err != nil {
 				return fmt.Errorf("connect.map: %w", err)
@@ -333,6 +337,101 @@ func (c *FlowPackageConnect) UnmarshalYAML(node *yaml.Node) error {
 	}
 	*c = out.normalized()
 	return nil
+}
+
+func (u *FlowPackageConnectUsing) UnmarshalYAML(node *yaml.Node) error {
+	if u == nil {
+		return nil
+	}
+	if node == nil || node.Kind == 0 {
+		*u = FlowPackageConnectUsing{}
+		return nil
+	}
+	if node.Kind != yaml.MappingNode {
+		return fmt.Errorf("connect using must be a mapping")
+	}
+	var out FlowPackageConnectUsing
+	for i := 0; i+1 < len(node.Content); i += 2 {
+		key := strings.TrimSpace(node.Content[i].Value)
+		value := node.Content[i+1]
+		switch key {
+		case "":
+			continue
+		case "instance":
+			if err := value.Decode(&out.Instance); err != nil {
+				return fmt.Errorf("connect.using.instance: %w", err)
+			}
+		default:
+			return fmt.Errorf("UNDEFINED-FIELD: connect using field %q not in platform spec", key)
+		}
+	}
+	*u = out.normalized()
+	return nil
+}
+
+func (a *FlowPackageConnectInstanceAdapter) UnmarshalYAML(node *yaml.Node) error {
+	if a == nil {
+		return nil
+	}
+	if node == nil || node.Kind == 0 {
+		*a = FlowPackageConnectInstanceAdapter{}
+		return nil
+	}
+	if node.Kind != yaml.MappingNode {
+		return fmt.Errorf("connect.using.instance must be a mapping")
+	}
+	out := FlowPackageConnectInstanceAdapter{Declared: true}
+	for i := 0; i+1 < len(node.Content); i += 2 {
+		key := strings.TrimSpace(node.Content[i].Value)
+		value := node.Content[i+1]
+		switch key {
+		case "":
+			continue
+		case "source":
+			source, err := decodeStringListNodePreserveOrder(value)
+			if err != nil {
+				return fmt.Errorf("connect.using.instance.source: %w", err)
+			}
+			out.Source = source
+		case "target":
+			target, err := decodeStringListNodePreserveOrder(value)
+			if err != nil {
+				return fmt.Errorf("connect.using.instance.target: %w", err)
+			}
+			out.Target = target
+		default:
+			return fmt.Errorf("UNDEFINED-FIELD: connect using instance field %q not in platform spec", key)
+		}
+	}
+	*a = out.normalized()
+	return nil
+}
+
+func decodeStringListNodePreserveOrder(node *yaml.Node) ([]string, error) {
+	if node == nil || node.Kind == 0 {
+		return nil, nil
+	}
+	switch node.Kind {
+	case yaml.ScalarNode:
+		if strings.EqualFold(strings.TrimSpace(node.Tag), "!!null") || strings.TrimSpace(node.Value) == "" {
+			return nil, nil
+		}
+		return []string{strings.TrimSpace(node.Value)}, nil
+	case yaml.SequenceNode:
+		var values []string
+		if err := node.Decode(&values); err != nil {
+			return nil, err
+		}
+		out := make([]string, 0, len(values))
+		for _, value := range values {
+			if value = strings.TrimSpace(value); value != "" {
+				out = append(out, value)
+			}
+		}
+		return out, nil
+	default:
+		return nil, fmt.Errorf("unsupported string list yaml node kind %d", node.Kind)
+	}
 }
 
 func (m *FlowPackageConnectMap) UnmarshalYAML(node *yaml.Node) error {

--- a/internal/runtime/core/pinrouting/connect_route_plan.go
+++ b/internal/runtime/core/pinrouting/connect_route_plan.go
@@ -92,8 +92,9 @@ type ConnectRoutePlanInstanceKey struct {
 }
 
 type ConnectRoutePlanInstanceKeyMapping struct {
-	Source string
-	Target string
+	Source   string
+	Target   string
+	Explicit bool
 }
 
 type ConnectRoutePlan struct {
@@ -358,7 +359,12 @@ func materializeInstanceKeyConnectRoutePlan(plan ConnectRoutePlan, input Connect
 		if source == "" || target == "" {
 			return ConnectRoutePlanMaterialization{Failure: ConnectFailureReceiverAddressRuleMissing}
 		}
-		value := firstMatchValue(input.MatchValues, source, "payload."+source)
+		value := ""
+		if mapping.Explicit {
+			value = firstMatchValue(input.MatchValues, "payload."+source)
+		} else {
+			value = firstMatchValue(input.MatchValues, source, "payload."+source)
+		}
 		if value == "" {
 			return ConnectRoutePlanMaterialization{Failure: ConnectFailureAddressValueMissing}
 		}
@@ -534,7 +540,7 @@ func connectInstanceKeyMaterializationMappings(instanceKey *ConnectRoutePlanInst
 			if source == "" || target == "" {
 				continue
 			}
-			out = append(out, ConnectRoutePlanInstanceKeyMapping{Source: source, Target: target})
+			out = append(out, ConnectRoutePlanInstanceKeyMapping{Source: source, Target: target, Explicit: mapping.Explicit})
 		}
 		return out
 	}
@@ -564,7 +570,7 @@ func connectInstanceKeyMappings(adapter runtimecontracts.FlowPackageConnectInsta
 			if !stringListContains(carries, source) || !stringListContains(receiverFields, target) {
 				return nil, false
 			}
-			mappings = append(mappings, ConnectRoutePlanInstanceKeyMapping{Source: source, Target: target})
+			mappings = append(mappings, ConnectRoutePlanInstanceKeyMapping{Source: source, Target: target, Explicit: true})
 		}
 		return mappings, true
 	}

--- a/internal/runtime/core/pinrouting/connect_route_plan.go
+++ b/internal/runtime/core/pinrouting/connect_route_plan.go
@@ -55,6 +55,7 @@ const (
 	ConnectFailureTargetUnsupported          ConnectRoutePlanFailure = "route_plan_target_unsupported"
 	ConnectFailureTargetUnresolved           ConnectRoutePlanFailure = "route_plan_target_unresolved"
 	ConnectFailureTargetAmbiguous            ConnectRoutePlanFailure = "route_plan_target_ambiguous"
+	ConnectFailureInstanceKeyAdapterInvalid  ConnectRoutePlanFailure = "route_plan_instance_key_adapter_invalid"
 )
 
 type ConnectRoutePlanEndpoint struct {
@@ -85,8 +86,14 @@ type ConnectRoutePlanMapEntry struct {
 
 type ConnectRoutePlanInstanceKey struct {
 	Fields     []string
+	Mappings   []ConnectRoutePlanInstanceKeyMapping
 	OnMissing  string
 	OnConflict string
+}
+
+type ConnectRoutePlanInstanceKeyMapping struct {
+	Source string
+	Target string
 }
 
 type ConnectRoutePlan struct {
@@ -185,7 +192,10 @@ func LowerCompositionConnectRoutePlan(source semanticview.Source, connect runtim
 		return ConnectRoutePlan{}, ConnectRoutePlanIssue{Connect: connect, Failure: failure, Detail: strings.TrimSpace(connect.Delivery)}
 	}
 	address := connectAddress(connect, inputPin)
-	instanceKey := connectInstanceKey(source, connect, outputPin, inputPin, delivery, to.FlowID)
+	instanceKey, instanceKeyIssue := connectInstanceKey(source, connect, outputPin, inputPin, delivery, to.FlowID)
+	if instanceKeyIssue.Failure != "" {
+		return ConnectRoutePlan{}, instanceKeyIssue
+	}
 	if receiverRequiresRuntimeResolution(receiverScope) && address == nil && instanceKey == nil && delivery != ConnectDeliveryBroadcast {
 		return ConnectRoutePlan{}, ConnectRoutePlanIssue{Connect: connect, Failure: ConnectFailureReceiverAddressRuleMissing, Detail: to.FlowID}
 	}
@@ -341,16 +351,18 @@ func materializeInstanceKeyConnectRoutePlan(plan ConnectRoutePlan, input Connect
 		return ConnectRoutePlanMaterialization{Failure: ConnectFailureReceiverAddressRuleMissing}
 	}
 	values := make(map[string]any, len(instanceKey.Fields))
-	for _, field := range instanceKey.Fields {
-		field = strings.TrimSpace(field)
-		if field == "" {
+	mappings := connectInstanceKeyMaterializationMappings(instanceKey)
+	for _, mapping := range mappings {
+		source := strings.TrimSpace(mapping.Source)
+		target := strings.TrimSpace(mapping.Target)
+		if source == "" || target == "" {
 			return ConnectRoutePlanMaterialization{Failure: ConnectFailureReceiverAddressRuleMissing}
 		}
-		value := firstMatchValue(input.MatchValues, field, "payload."+field)
+		value := firstMatchValue(input.MatchValues, source, "payload."+source)
 		if value == "" {
 			return ConnectRoutePlanMaterialization{Failure: ConnectFailureAddressValueMissing}
 		}
-		values[field] = value
+		values[target] = value
 	}
 	keyMaterial, err := (runtimecontracts.TemplateInstanceContract{
 		FlowID: plan.Receiver.FlowID,
@@ -449,36 +461,141 @@ func connectAddress(connect runtimecontracts.FlowPackageConnect, inputPin runtim
 	return &out
 }
 
-func connectInstanceKey(source semanticview.Source, connect runtimecontracts.FlowPackageConnect, outputPin runtimecontracts.FlowOutputEventPin, inputPin runtimecontracts.FlowInputEventPin, delivery ConnectRoutePlanDelivery, receiverFlowID string) *ConnectRoutePlanInstanceKey {
-	if source == nil || len(connect.Map) > 0 || inputPin.Address != nil || delivery == ConnectDeliveryBroadcast {
-		return nil
+func connectInstanceKey(source semanticview.Source, connect runtimecontracts.FlowPackageConnect, outputPin runtimecontracts.FlowOutputEventPin, inputPin runtimecontracts.FlowInputEventPin, delivery ConnectRoutePlanDelivery, receiverFlowID string) (*ConnectRoutePlanInstanceKey, ConnectRoutePlanIssue) {
+	adapter := connect.Using.Instance
+	if source == nil {
+		return nil, ConnectRoutePlanIssue{}
+	}
+	if inputPin.Address != nil {
+		if adapter.Declared {
+			return nil, ConnectRoutePlanIssue{Connect: connect, Failure: ConnectFailureInstanceKeyAdapterInvalid, Detail: "connect.using.instance requires an addressless receiver input"}
+		}
+		return nil, ConnectRoutePlanIssue{}
+	}
+	if delivery == ConnectDeliveryBroadcast {
+		if adapter.Declared {
+			return nil, ConnectRoutePlanIssue{Connect: connect, Failure: ConnectFailureInstanceKeyAdapterInvalid, Detail: "connect.using.instance is incompatible with delivery broadcast"}
+		}
+		return nil, ConnectRoutePlanIssue{}
+	}
+	if len(connect.Map) > 0 {
+		return nil, ConnectRoutePlanIssue{Connect: connect, Failure: ConnectFailureInstanceKeyAdapterInvalid, Detail: "connect.map is not instance-key adapter authority; use connect.using.instance"}
 	}
 	bundle, ok := semanticview.Bundle(source)
 	if !ok {
-		return nil
+		return nil, ConnectRoutePlanIssue{}
 	}
 	instance, err := bundle.ResolveFlowTemplateInstance(receiverFlowID)
 	if err != nil {
-		return nil
+		if adapter.Declared {
+			return nil, ConnectRoutePlanIssue{Connect: connect, Failure: ConnectFailureInstanceKeyAdapterInvalid, Detail: err.Error()}
+		}
+		return nil, ConnectRoutePlanIssue{}
 	}
 	outputKey := strings.TrimSpace(outputPin.Key)
 	if outputKey == "" {
-		return nil
+		if adapter.Declared {
+			return nil, ConnectRoutePlanIssue{Connect: connect, Failure: ConnectFailureInstanceKeyAdapterInvalid, Detail: "producer output pin key is required for connect.using.instance"}
+		}
+		return nil, ConnectRoutePlanIssue{}
 	}
 	carries := normalizedPinCarries(outputPin.Carries)
-	if !stringListContains(carries, outputKey) || !stringListContains(instance.By, outputKey) {
-		return nil
-	}
-	for _, field := range instance.By {
-		if !stringListContains(carries, field) {
-			return nil
+	if !stringListContains(carries, outputKey) {
+		if adapter.Declared {
+			return nil, ConnectRoutePlanIssue{Connect: connect, Failure: ConnectFailureInstanceKeyAdapterInvalid, Detail: "producer output pin carries must include key before connect.using.instance can route"}
 		}
+		return nil, ConnectRoutePlanIssue{}
+	}
+	fields := normalizedStringList(instance.By)
+	mappings, ok := connectInstanceKeyMappings(adapter, fields, carries, outputKey)
+	if !ok {
+		if adapter.Declared {
+			return nil, ConnectRoutePlanIssue{Connect: connect, Failure: ConnectFailureInstanceKeyAdapterInvalid, Detail: "connect.using.instance must completely map producer carries to receiver instance.by"}
+		}
+		return nil, ConnectRoutePlanIssue{}
 	}
 	return &ConnectRoutePlanInstanceKey{
-		Fields:     normalizedStringList(instance.By),
+		Fields:     fields,
+		Mappings:   mappings,
 		OnMissing:  strings.TrimSpace(instance.OnMissing),
 		OnConflict: strings.TrimSpace(instance.OnConflict),
+	}, ConnectRoutePlanIssue{}
+}
+
+func connectInstanceKeyMaterializationMappings(instanceKey *ConnectRoutePlanInstanceKey) []ConnectRoutePlanInstanceKeyMapping {
+	if instanceKey == nil {
+		return nil
 	}
+	if len(instanceKey.Mappings) > 0 {
+		out := make([]ConnectRoutePlanInstanceKeyMapping, 0, len(instanceKey.Mappings))
+		for _, mapping := range instanceKey.Mappings {
+			source := strings.TrimSpace(mapping.Source)
+			target := strings.TrimSpace(mapping.Target)
+			if source == "" || target == "" {
+				continue
+			}
+			out = append(out, ConnectRoutePlanInstanceKeyMapping{Source: source, Target: target})
+		}
+		return out
+	}
+	out := make([]ConnectRoutePlanInstanceKeyMapping, 0, len(instanceKey.Fields))
+	for _, field := range instanceKey.Fields {
+		field = strings.TrimSpace(field)
+		if field != "" {
+			out = append(out, ConnectRoutePlanInstanceKeyMapping{Source: field, Target: field})
+		}
+	}
+	return out
+}
+
+func connectInstanceKeyMappings(adapter runtimecontracts.FlowPackageConnectInstanceAdapter, receiverFields, carries []string, outputKey string) ([]ConnectRoutePlanInstanceKeyMapping, bool) {
+	if adapter.Declared {
+		sources := normalizedAdapterFields(adapter.Source)
+		targets := normalizedAdapterFields(adapter.Target)
+		if len(sources) == 0 || len(sources) != len(targets) || len(targets) != len(receiverFields) || duplicateString(sources) != "" || duplicateString(targets) != "" {
+			return nil, false
+		}
+		if !sameStringSet(targets, receiverFields) {
+			return nil, false
+		}
+		mappings := make([]ConnectRoutePlanInstanceKeyMapping, 0, len(targets))
+		for idx, source := range sources {
+			target := strings.TrimSpace(targets[idx])
+			if !stringListContains(carries, source) || !stringListContains(receiverFields, target) {
+				return nil, false
+			}
+			mappings = append(mappings, ConnectRoutePlanInstanceKeyMapping{Source: source, Target: target})
+		}
+		return mappings, true
+	}
+	if !stringListContains(receiverFields, outputKey) {
+		return nil, false
+	}
+	mappings := make([]ConnectRoutePlanInstanceKeyMapping, 0, len(receiverFields))
+	for _, field := range receiverFields {
+		if !stringListContains(carries, field) {
+			return nil, false
+		}
+		mappings = append(mappings, ConnectRoutePlanInstanceKeyMapping{Source: field, Target: field})
+	}
+	return mappings, true
+}
+
+func normalizedAdapterFields(in []string) []string {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(in))
+	for _, value := range in {
+		value = strings.TrimSpace(value)
+		if value != "" {
+			out = append(out, value)
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
 }
 
 func connectResolutionKind(scope semanticview.FlowScope, delivery ConnectRoutePlanDelivery, address *ConnectRoutePlanAddress, instanceKey *ConnectRoutePlanInstanceKey) ConnectRoutePlanResolutionKind {
@@ -808,6 +925,45 @@ func stringListContains(values []string, needle string) bool {
 		}
 	}
 	return false
+}
+
+func duplicateString(values []string) string {
+	seen := map[string]struct{}{}
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		if _, ok := seen[value]; ok {
+			return value
+		}
+		seen[value] = struct{}{}
+	}
+	return ""
+}
+
+func sameStringSet(left, right []string) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	seen := map[string]struct{}{}
+	for _, value := range left {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			return false
+		}
+		seen[value] = struct{}{}
+	}
+	for _, value := range right {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			return false
+		}
+		if _, ok := seen[value]; !ok {
+			return false
+		}
+	}
+	return true
 }
 
 func cloneStringMap(in map[string]string) map[string]string {

--- a/internal/runtime/core/pinrouting/connect_route_plan_test.go
+++ b/internal/runtime/core/pinrouting/connect_route_plan_test.go
@@ -127,6 +127,98 @@ func TestLowerCompositionConnectRoutePlansUsesTemplateInstanceKey(t *testing.T) 
 	}
 }
 
+func TestLowerCompositionConnectRoutePlansUsesRenamedInstanceKeyAdapter(t *testing.T) {
+	repoRoot, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd: %v", err)
+	}
+	repoRoot = filepath.Clean(filepath.Join(repoRoot, "..", "..", "..", ".."))
+	root := writeInstanceKeyAdapterConnectRoutePlanPackageFixture(t, `
+    using:
+      instance:
+        source: source_vertical_id
+        target: vertical_id
+`, "source_vertical_id", "[source_vertical_id]", "vertical_id")
+	bundle, err := runtimecontracts.LoadWorkflowContractBundleWithOverrides(repoRoot, root, runtimecontracts.DefaultPlatformSpecFile(repoRoot))
+	if err != nil {
+		t.Fatalf("LoadWorkflowContractBundleWithOverrides: %v", err)
+	}
+
+	plans, issues := LowerCompositionConnectRoutePlans(semanticview.Wrap(bundle))
+	if len(issues) != 0 {
+		t.Fatalf("issues = %#v, want none", issues)
+	}
+	if len(plans) != 1 {
+		t.Fatalf("plans = %#v, want one", plans)
+	}
+	plan := plans[0]
+	if got, want := plan.ResolutionKind, ConnectResolutionInstanceKey; got != want {
+		t.Fatalf("ResolutionKind = %q, want %q", got, want)
+	}
+	if plan.InstanceKey == nil {
+		t.Fatal("InstanceKey = nil, want adapter-backed instance key")
+	}
+	if len(plan.InstanceKey.Fields) != 1 || plan.InstanceKey.Fields[0] != "vertical_id" {
+		t.Fatalf("InstanceKey.Fields = %#v, want receiver target field vertical_id", plan.InstanceKey.Fields)
+	}
+	if len(plan.InstanceKey.Mappings) != 1 || plan.InstanceKey.Mappings[0].Source != "source_vertical_id" || plan.InstanceKey.Mappings[0].Target != "vertical_id" {
+		t.Fatalf("InstanceKey.Mappings = %#v, want source_vertical_id -> vertical_id", plan.InstanceKey.Mappings)
+	}
+
+	materialized := MaterializeConnectRoutePlan(plan, ConnectRoutePlanMaterializationInput{
+		MatchValues: map[string]string{"source_vertical_id": "v-1"},
+		Descriptors: []Descriptor{{
+			EntityID:      "ent-1",
+			FlowInstance:  "consumer/one",
+			AddressFields: map[string]string{"entity.vertical_id": "v-1"},
+		}},
+	})
+	if materialized.Failure != "" {
+		t.Fatalf("Failure = %q, want empty", materialized.Failure)
+	}
+	if got, want := materialized.Target.FlowInstance, "consumer/one"; got != want {
+		t.Fatalf("Target.FlowInstance = %q, want %q", got, want)
+	}
+
+	missing := MaterializeConnectRoutePlan(plan, ConnectRoutePlanMaterializationInput{
+		MatchValues: map[string]string{"vertical_id": "v-1"},
+		Descriptors: []Descriptor{{
+			EntityID:      "ent-1",
+			FlowInstance:  "consumer/one",
+			AddressFields: map[string]string{"entity.vertical_id": "v-1"},
+		}},
+	})
+	if missing.Failure != ConnectFailureAddressValueMissing {
+		t.Fatalf("missing Failure = %q, want %q", missing.Failure, ConnectFailureAddressValueMissing)
+	}
+}
+
+func TestLowerCompositionConnectRoutePlansFailsClosedForInvalidRenamedInstanceKeyAdapter(t *testing.T) {
+	repoRoot, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd: %v", err)
+	}
+	repoRoot = filepath.Clean(filepath.Join(repoRoot, "..", "..", "..", ".."))
+	root := writeInstanceKeyAdapterConnectRoutePlanPackageFixture(t, `
+    using:
+      instance:
+        source: source_vertical_id
+        target: missing_vertical_id
+`, "source_vertical_id", "[source_vertical_id]", "vertical_id")
+	bundle, err := runtimecontracts.LoadWorkflowContractBundleWithOverrides(repoRoot, root, runtimecontracts.DefaultPlatformSpecFile(repoRoot))
+	if err != nil {
+		t.Fatalf("LoadWorkflowContractBundleWithOverrides: %v", err)
+	}
+
+	plans, issues := LowerCompositionConnectRoutePlans(semanticview.Wrap(bundle))
+	if len(plans) != 0 {
+		t.Fatalf("plans = %#v, want none for invalid adapter", plans)
+	}
+	if len(issues) != 1 || issues[0].Failure != ConnectFailureInstanceKeyAdapterInvalid {
+		t.Fatalf("issues = %#v, want %q", issues, ConnectFailureInstanceKeyAdapterInvalid)
+	}
+}
+
 func TestLowerCompositionConnectRoutePlansPreservesAddressedTemplateRoute(t *testing.T) {
 	repoRoot, err := os.Getwd()
 	if err != nil {
@@ -906,6 +998,65 @@ pins:
 	writeConnectRoutePlanFixtureFile(t, filepath.Join(root, "flows", "consumer", "agents.yaml"), "{}\n")
 	writeConnectRoutePlanFixtureFile(t, filepath.Join(root, "flows", "consumer", "nodes.yaml"), "{}\n")
 	writeConnectRoutePlanFixtureFile(t, filepath.Join(root, "flows", "consumer", "events.yaml"), "deploy.done:\n  vertical_id: string\n")
+	writeConnectRoutePlanFixtureFile(t, filepath.Join(root, "flows", "consumer", "entities.yaml"), `
+deployment:
+  vertical_id:
+    type: string
+`)
+	return root
+}
+
+func writeInstanceKeyAdapterConnectRoutePlanPackageFixture(t *testing.T, usingBlock, outputKey, outputCarries, instanceBy string) string {
+	t.Helper()
+	root := t.TempDir()
+	writeConnectRoutePlanFixtureFile(t, filepath.Join(root, "package.yaml"), `
+name: instance-key-adapter-connect-route-plan-package
+version: "1.0.0"
+platform_version: ">=1.6.0"
+flows:
+  - id: producer
+    flow: producer
+    mode: static
+  - id: consumer
+    flow: consumer
+    mode: template
+connect:
+  - from: producer.deploy_done
+    to: consumer.deploy_completed
+    delivery: one`+usingBlock+`
+`)
+	writeConnectRoutePlanFixtureFile(t, filepath.Join(root, "schema.yaml"), "name: instance-key-adapter-connect-route-plan-package\n")
+	writeConnectRoutePlanFixtureFile(t, filepath.Join(root, "policy.yaml"), "{}\n")
+	writeConnectRoutePlanFixtureFile(t, filepath.Join(root, "tools.yaml"), "{}\n")
+	writeConnectRoutePlanFixtureFile(t, filepath.Join(root, "agents.yaml"), "{}\n")
+	writeConnectRoutePlanFixtureFile(t, filepath.Join(root, "events.yaml"), "{}\n")
+	writeConnectRoutePlanFixtureFile(t, filepath.Join(root, "nodes.yaml"), "{}\n")
+	writeConnectRoutePlanFlowFixture(t, root, "producer", `
+pins:
+  outputs:
+    events:
+      - name: deploy_done
+        event: deploy.done
+        key: `+outputKey+`
+        carries: `+outputCarries+`
+`, "deploy.done:\n  source_vertical_id: string\n", "{}\n")
+	writeConnectRoutePlanFixtureFile(t, filepath.Join(root, "flows", "consumer", "schema.yaml"), `
+name: consumer
+mode: template
+instance:
+  by: `+instanceBy+`
+  on_missing: reject
+  on_conflict: reject
+pins:
+  inputs:
+    events:
+      - name: deploy_completed
+        event: deploy.done
+`)
+	writeConnectRoutePlanFixtureFile(t, filepath.Join(root, "flows", "consumer", "policy.yaml"), "{}\n")
+	writeConnectRoutePlanFixtureFile(t, filepath.Join(root, "flows", "consumer", "agents.yaml"), "{}\n")
+	writeConnectRoutePlanFixtureFile(t, filepath.Join(root, "flows", "consumer", "nodes.yaml"), "{}\n")
+	writeConnectRoutePlanFixtureFile(t, filepath.Join(root, "flows", "consumer", "events.yaml"), "deploy.done:\n  source_vertical_id: string\n")
 	writeConnectRoutePlanFixtureFile(t, filepath.Join(root, "flows", "consumer", "entities.yaml"), `
 deployment:
   vertical_id:

--- a/internal/runtime/core/pinrouting/connect_route_plan_test.go
+++ b/internal/runtime/core/pinrouting/connect_route_plan_test.go
@@ -161,12 +161,12 @@ func TestLowerCompositionConnectRoutePlansUsesRenamedInstanceKeyAdapter(t *testi
 	if len(plan.InstanceKey.Fields) != 1 || plan.InstanceKey.Fields[0] != "vertical_id" {
 		t.Fatalf("InstanceKey.Fields = %#v, want receiver target field vertical_id", plan.InstanceKey.Fields)
 	}
-	if len(plan.InstanceKey.Mappings) != 1 || plan.InstanceKey.Mappings[0].Source != "source_vertical_id" || plan.InstanceKey.Mappings[0].Target != "vertical_id" {
+	if len(plan.InstanceKey.Mappings) != 1 || plan.InstanceKey.Mappings[0].Source != "source_vertical_id" || plan.InstanceKey.Mappings[0].Target != "vertical_id" || !plan.InstanceKey.Mappings[0].Explicit {
 		t.Fatalf("InstanceKey.Mappings = %#v, want source_vertical_id -> vertical_id", plan.InstanceKey.Mappings)
 	}
 
 	materialized := MaterializeConnectRoutePlan(plan, ConnectRoutePlanMaterializationInput{
-		MatchValues: map[string]string{"source_vertical_id": "v-1"},
+		MatchValues: map[string]string{"payload.source_vertical_id": "v-1", "source_vertical_id": "wrong-alias"},
 		Descriptors: []Descriptor{{
 			EntityID:      "ent-1",
 			FlowInstance:  "consumer/one",
@@ -180,7 +180,19 @@ func TestLowerCompositionConnectRoutePlansUsesRenamedInstanceKeyAdapter(t *testi
 		t.Fatalf("Target.FlowInstance = %q, want %q", got, want)
 	}
 
-	missing := MaterializeConnectRoutePlan(plan, ConnectRoutePlanMaterializationInput{
+	unqualifiedAlias := MaterializeConnectRoutePlan(plan, ConnectRoutePlanMaterializationInput{
+		MatchValues: map[string]string{"source_vertical_id": "v-1"},
+		Descriptors: []Descriptor{{
+			EntityID:      "ent-1",
+			FlowInstance:  "consumer/one",
+			AddressFields: map[string]string{"entity.vertical_id": "v-1"},
+		}},
+	})
+	if unqualifiedAlias.Failure != ConnectFailureAddressValueMissing {
+		t.Fatalf("unqualified alias Failure = %q, want %q", unqualifiedAlias.Failure, ConnectFailureAddressValueMissing)
+	}
+
+	wrongCanonicalField := MaterializeConnectRoutePlan(plan, ConnectRoutePlanMaterializationInput{
 		MatchValues: map[string]string{"vertical_id": "v-1"},
 		Descriptors: []Descriptor{{
 			EntityID:      "ent-1",
@@ -188,8 +200,8 @@ func TestLowerCompositionConnectRoutePlansUsesRenamedInstanceKeyAdapter(t *testi
 			AddressFields: map[string]string{"entity.vertical_id": "v-1"},
 		}},
 	})
-	if missing.Failure != ConnectFailureAddressValueMissing {
-		t.Fatalf("missing Failure = %q, want %q", missing.Failure, ConnectFailureAddressValueMissing)
+	if wrongCanonicalField.Failure != ConnectFailureAddressValueMissing {
+		t.Fatalf("wrong canonical field Failure = %q, want %q", wrongCanonicalField.Failure, ConnectFailureAddressValueMissing)
 	}
 }
 

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -5251,6 +5251,48 @@ flow_model:
           target/broadcast, direct delivery, raw subscribers, RouteTable lookup,
           handler lookup, delivery rows, or replay/readback rows as the route
           selector. Renamed key adapters remain #1546.
+      connect_key_adapters:
+        status: merge_bearing_contract_runtime_behavior
+        implementation_tracker: '#1546'
+        canonical_code_owner: internal/runtime/contracts.FlowPackageConnect.Using.Instance + internal/runtime/bootverify.validateCompositionConnectInstanceKeyAdapter + internal/runtime/core/pinrouting.ConnectRoutePlan.InstanceKey.Mappings
+        syntax: connect.using.instance.source / connect.using.instance.target
+        rule: >
+          Parent `connect` MAY adapt renamed producer output key evidence to a
+          receiver template `instance.by` key only through
+          `connect.using.instance`. The adapter is parent-owned route
+          evidence: `source` names top-level producer payload fields declared by
+          the output pin `carries`, `target` names the receiver template
+          `instance.by` fields, and the ordered mapping becomes the lowered
+          ConnectRoutePlan instance-key materialization rule. Same-name
+          producer/receiver key fields remain valid without adapter syntax.
+          Renamed key routes without explicit adapter evidence fail closed.
+          `connect.map` is not adapter authority for addressless template
+          instance-key routing and MUST NOT repair this class.
+        supported_shapes:
+          scalar: >
+            A scalar adapter maps exactly one producer source field to exactly
+            one receiver target field. Both fields must exist, be unique in the
+            mapping, and have compatible schema types.
+          composite: >
+            Composite adapters map the full ordered receiver `instance.by`
+            field set. `source` and `target` lists must have equal cardinality,
+            every target must appear in receiver `instance.by`, every receiver
+            key target must be covered exactly once, and every source must be
+            carried by the producer output pin.
+        fail_closed:
+        - missing source or target adapter side
+        - source/target cardinality mismatch
+        - duplicate source or target fields
+        - source field missing from producer carries or event schema
+        - target field missing from receiver entity schema or instance.by
+        - producer/receiver key type incompatibility
+        - using.instance declared on addressed-input, broadcast, or non-template receiver routes
+        non_authoritative_paths:
+        - connect.map for addressless template instance-key adapters
+        - receiver input-pin address rules for this addressless instance-key class
+        - producer target.match or broadcast:true
+        - raw/live subscriber lookup before lowered route identity
+        - delivery rows, replay rows, or readback rows as route producers
       output_pin_key_carries_contract:
         status: merge_bearing_contract_behavior
         implementation_tracker: '#1544'
@@ -5713,7 +5755,7 @@ flow_model:
             - entity_id / entity.entity_id
             - flow_instance / instance.flow_instance
             - instance_id / instance.instance_id
-            - entity.<field> when the receiver entity contract declares that top-level field with indexed: true
+            - 'entity.<field> when the receiver entity contract declares that top-level field with indexed: true'
             unsupported_descriptor_targets: Nested entity paths, undeclared or unindexed entity fields, config.<field>, instance.<field>, and other arbitrary business fields remain fail-closed unless a later approved spec+runtime child promotes a typed descriptor/index owner for those forms.
         implementation_slice_1545:
           status: merge_bearing_runtime_behavior
@@ -5787,6 +5829,64 @@ flow_model:
             - recovery or retry work
             - agent/node delivery parity
             - producer target/broadcast retirement
+        implementation_slice_1546:
+          status: merge_bearing_runtime_behavior
+          canonical_code_owner: internal/runtime/core/pinrouting.ConnectRoutePlan.InstanceKey.Mappings + internal/runtime/bus.connectRoutePlanResolver
+          rule: |
+            Renamed parent connect into an addressless template receiver MUST
+            lower `connect.using.instance.source` /
+            `connect.using.instance.target` adapter evidence
+            into explicit ConnectRoutePlan instance-key mappings. Runtime
+            materialization MUST read key values from the mapped producer source
+            payload fields and stamp them under the receiver canonical
+            `instance.by` target fields before matching receiver-scoped
+            descriptors and producing delivery routes. Same-name key/carries
+            routes remain valid without adapter noise. Renamed routes without
+            adapter evidence, incomplete/ambiguous adapter shapes, unsupported
+            declaration surfaces, or missing source payload values fail closed
+            with zero executable routes and no raw subscriber fallback.
+
+            `connect.map` remains the explicit addressed-input map concept and
+            is not instance-key adapter authority for addressless template
+            receivers. No legacy map, receiver address rule, producer target,
+            broadcast:true, RouteTable lookup, delivery row, replay row, or
+            readback row may repair a missing or invalid instance-key adapter.
+          consumes:
+          - FlowPackageConnect.Using.Instance source/target adapter evidence
+          - producer output pin key/carries evidence
+          - receiver template instance.by fields
+          - matched inbound event payload source fields
+          - receiver-scoped active flow-instance descriptors
+          produces:
+          - ConnectRoutePlan.InstanceKey.Mappings for scalar and composite renamed keys
+          - route_plan_instance_key_adapter_invalid for unsupported adapter declarations
+          - route_plan_address_value_missing when mapped source payload values are missing
+          non_authoritative_for_this_slice:
+          - connect.map as addressless template instance-key adapter authority
+          - receiver input-pin address rules for this addressless instance-key adapter class
+          - receiver select_entity/select_or_create_entity
+          - producer target.match
+          - producer broadcast:true
+          - direct delivery
+          - raw/live subscribers before selected target identity
+          - handler lookup before selected target identity
+          - delivery rows, replay rows, or readback rows as route producers
+          split_or_adjacent:
+            same_name_instance_key_route_planning: '#1545'
+            select_entity_demote_warn_error: '#1547'
+            explicit_addressed_input_descriptor_routing: '#1479'
+          failure_reasons:
+          - connect_key_adapter_missing_source
+          - connect_key_adapter_missing_target
+          - connect_key_adapter_cardinality
+          - connect_key_adapter_duplicate_source
+          - connect_key_adapter_duplicate_target
+          - connect_key_adapter_source_missing
+          - connect_key_adapter_target_missing
+          - connect_key_adapter_partial
+          - key_types_incompatible
+          - route_plan_instance_key_adapter_invalid
+          - route_plan_address_value_missing
         implementation_slice_1473:
           status: merge_bearing_runtime_behavior
           canonical_code_owner: internal/runtime/bus.RoutePlan via deliveryPlanner.Plan and connectRoutePlanResolver


### PR DESCRIPTION
## Summary
- Adds `connect.using.instance.source` / `connect.using.instance.target` parsing for parent-owned renamed instance-key adapters.
- Validates scalar and composite adapter shape fail-closed in bootverify and lowers accepted mappings into `ConnectRoutePlan.InstanceKey.Mappings`.
- Materializes runtime delivery from mapped producer source payload fields to receiver canonical `instance.by` fields, with no raw subscriber or `connect.map` fallback.
- Promotes the #1546 contract/runtime behavior into `platform-spec.yaml` and route-authority conformance proof refs.

Closes #1546

## Governing Refs / Context
- `platform-spec.yaml#flow_model.flow_instance_authoring.composition_model.connect_key_adapters`
- `platform-spec.yaml#flow_model.flow_package.composition_routing.route_plan_lowering.implementation_slice_1546`
- Binding issue/gate context: #1546 pre-implementation audit and approved gate comment.

## Semantic Migration
- New canonical owner: `FlowPackageConnect.Using.Instance` parsed from package `connect`, verified by `validateCompositionConnectInstanceKeyAdapter`, and consumed by `ConnectRoutePlan.InstanceKey.Mappings` plus EventBus `connectRoutePlanResolver` materialization.
- Old path now invalid for this class: `connect.map` is not instance-key adapter authority for addressless template receiver routes.
- Production paths checked for surviving old behavior: bootverify connect validation, contract parsing/normalization, route-plan lowering, EventBus publish/preflight/persistence/readback, route-authority conformance inventory.
- Migration complete for approved #1546 class: renamed parent connect instance-key adapters for addressless template receivers.

## Proof
- `go test ./internal/runtime/contracts ./internal/runtime/bootverify ./internal/runtime/core/pinrouting ./internal/runtime/bus ./internal/apispec ./internal/runtime/conformance -run 'TestRun_AllowsRenamedTemplateInstanceKeyCompositionConnectWithUsingInstance|TestRun_FailsClosedForInvalidRenamedTemplateInstanceKeyAdapters|TestLowerCompositionConnectRoutePlansUsesRenamedInstanceKeyAdapter|TestLowerCompositionConnectRoutePlansFailsClosedForInvalidRenamedInstanceKeyAdapter|TestEventBusPublish_ConnectRoutePlanPersistsRenamedTemplateInstanceKeyTarget|TestEventBusPublish_ConnectRoutePlanFailsClosedForRenamedTemplateInstanceKeySourceGap|TestPlatformSpecCompositionRoutingSourceAuthority|TestPlatformSpecFlowInstanceAuthoringSourceAuthority|TestRouteAuthorityMatrixCoversApprovedRows|TestRouteAuthorityDriftInventoryCoversRepoWideSearchDimensions' -count=1`
- `go test ./internal/runtime/bootverify ./internal/runtime/core/pinrouting ./internal/runtime/bus -run 'TestRun_FailsClosedForInvalidRenamedTemplateInstanceKeyAdapters|TestLowerCompositionConnectRoutePlansUsesRenamedInstanceKeyAdapter|TestLowerCompositionConnectRoutePlansFailsClosedForInvalidRenamedInstanceKeyAdapter|TestEventBusPublish_ConnectRoutePlanPersistsRenamedTemplateInstanceKeyTarget|TestEventBusPublish_ConnectRoutePlanFailsClosedForRenamedTemplateInstanceKeySourceGap' -count=1`
- `go test ./internal/runtime -count=1`
- `go test ./...`