### PR TITLE
[agent-a][issue #1547] Hard-fail in-topology select entity

### DIFF
--- a/internal/runtime/bootverify/checks.go
+++ b/internal/runtime/bootverify/checks.go
@@ -258,7 +258,7 @@ var bootCheckRegistry = []Check{
 	{ID: "composition_connect_validation", Severity: "error", Run: checkCompositionConnectValidation},
 	{ID: "input_pin_wiring", Severity: "warning", Run: checkInputPinWiring},
 	{ID: "pin_target_resolution", Severity: "error", Run: checkPinTargetResolution},
-	{ID: "redundant_in_topology_select_entity", Severity: "warning", Run: checkRedundantInTopologySelectEntity},
+	{ID: "redundant_in_topology_select_entity", Severity: SeverityHardInvalidity, Run: checkRedundantInTopologySelectEntity},
 	{ID: "missing_external_select_entity", Severity: "error", Run: checkMissingExternalSelectEntity},
 	{ID: "cross_flow_pin_ambiguity_validation", Severity: "error", Run: checkCrossFlowPinAmbiguityValidation},
 	{ID: "select_entity_validation", Severity: "error", Run: checkSelectEntityValidation},

--- a/internal/runtime/bootverify/workflow_pin_routing_checks.go
+++ b/internal/runtime/bootverify/workflow_pin_routing_checks.go
@@ -308,16 +308,17 @@ func pinRoutingAllKnownProducersTargeted(source semanticview.Source, flowID, eve
 	producers := 0
 	targeted := 0
 	for _, site := range pinRoutingEmitSites(source) {
-		if !pinRoutingEmitSiteProducesReceiverEvent(source, site, flowID, eventType, canonical) {
+		sameCanonical := pinRoutingEmitSiteMatchesReceiverCanonical(source, site, canonical)
+		connectedToReceiver := pinRoutingEmitSiteConnectsToReceiverEvent(source, site, flowID, eventType)
+		if !sameCanonical && !connectedToReceiver {
 			continue
 		}
 		if !runtimepinrouting.PinDeclaredOutput(source, site.FlowID, site.Spec.EventType()) {
 			continue
 		}
 		producers++
-		connectedOutput := compositionConnectsFromOutputEvent(source, site.FlowID, site.Spec.EventType())
 		structuralParent := pinRoutingStructuralParentRouteEligible(source, site.FlowID)
-		if connectedOutput {
+		if connectedToReceiver {
 			structuralParent = true
 		}
 		if (site.Spec.HasTarget() && runtimepinrouting.ProducerRouteCommonPathFailure(source, site.FlowID, site.Spec.EventType(), site.Spec) == "") ||
@@ -328,14 +329,11 @@ func pinRoutingAllKnownProducersTargeted(source semanticview.Source, flowID, eve
 	return producers > 0 && targeted == producers
 }
 
-func pinRoutingEmitSiteProducesReceiverEvent(source semanticview.Source, site semanticview.AuthoredEmitSite, receiverFlowID, receiverEventType, receiverCanonical string) bool {
+func pinRoutingEmitSiteMatchesReceiverCanonical(source semanticview.Source, site semanticview.AuthoredEmitSite, receiverCanonical string) bool {
 	if source == nil {
 		return false
 	}
-	if receiverCanonical != "" && strings.TrimSpace(source.ResolveFlowEventReference(site.FlowID, site.Spec.EventType())) == receiverCanonical {
-		return true
-	}
-	return pinRoutingEmitSiteConnectsToReceiverEvent(source, site, receiverFlowID, receiverEventType)
+	return receiverCanonical != "" && strings.TrimSpace(source.ResolveFlowEventReference(site.FlowID, site.Spec.EventType())) == receiverCanonical
 }
 
 func pinRoutingEmitSiteConnectsToReceiverEvent(source semanticview.Source, site semanticview.AuthoredEmitSite, receiverFlowID, receiverEventType string) bool {

--- a/internal/runtime/bootverify/workflow_pin_routing_checks.go
+++ b/internal/runtime/bootverify/workflow_pin_routing_checks.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
+	"github.com/division-sh/swarm/internal/runtime/core/eventidentity"
 	runtimepinrouting "github.com/division-sh/swarm/internal/runtime/core/pinrouting"
 	"github.com/division-sh/swarm/internal/runtime/semanticview"
 )
@@ -71,13 +72,20 @@ func checkRedundantInTopologySelectEntity(c *checkerContext) []Finding {
 				if !hasSelect && !hasSelectOrCreate {
 					continue
 				}
+				if pinRoutingEventExternalSource(c.source, flowID, eventType) {
+					continue
+				}
 				if !pinRoutingAllKnownProducersTargeted(c.source, flowID, eventType) {
 					continue
 				}
+				label := "select_entity"
+				if hasSelectOrCreate && !hasSelect {
+					label = "select_or_create_entity"
+				}
 				findings = append(findings, Finding{
 					CheckID:  "redundant_in_topology_select_entity",
-					Severity: "warning",
-					Message:  fmt.Sprintf("flow %s handler %s on node %s declares receiver-side entity acquisition for in-topology pin-routed event", flowID, eventType, nodeID),
+					Severity: SeverityHardInvalidity,
+					Message:  fmt.Sprintf("flow %s handler %s on node %s declares %s for normal in-topology composition; use receiver instance.by plus parent connect routing instead", flowID, eventType, nodeID, label),
 					Location: flowID,
 				})
 			}
@@ -261,12 +269,35 @@ func pinRoutingStructuralParentRouteEligible(source semanticview.Source, flowID 
 }
 
 func pinRoutingEventExternalSource(source semanticview.Source, flowID, eventType string) bool {
+	if source == nil {
+		return false
+	}
+	eventType = eventidentity.Normalize(eventType)
+	if eventType == "" {
+		return false
+	}
+	if scope, ok := source.FlowScopeByID(flowID); ok {
+		if entry, ok := scope.Events[eventType]; ok && pinRoutingEventEntryExternalSource(entry) {
+			return true
+		}
+		if canonical := eventidentity.Normalize(source.ResolveFlowEventReference(flowID, eventType)); canonical != "" {
+			for local, entry := range scope.Events {
+				if eventidentity.Normalize(source.ResolveFlowEventReference(flowID, local)) == canonical && pinRoutingEventEntryExternalSource(entry) {
+					return true
+				}
+			}
+		}
+	}
 	proof := semanticview.ResolveFlowEventProof(source, flowID, eventType)
-	if strings.HasPrefix(strings.ToLower(strings.TrimSpace(proof.Entry.SwarmSource())), "external") {
+	if pinRoutingEventEntryExternalSource(proof.Entry) {
 		return true
 	}
 	entry, _, ok := source.ResolveFlowEventCatalogEntry(flowID, eventType)
-	return ok && strings.HasPrefix(strings.ToLower(strings.TrimSpace(entry.SwarmSource())), "external")
+	return ok && pinRoutingEventEntryExternalSource(entry)
+}
+
+func pinRoutingEventEntryExternalSource(entry runtimecontracts.EventCatalogEntry) bool {
+	return strings.HasPrefix(strings.ToLower(strings.TrimSpace(entry.SwarmSource())), "external")
 }
 
 func pinRoutingAllKnownProducersTargeted(source semanticview.Source, flowID, eventType string) bool {
@@ -277,18 +308,87 @@ func pinRoutingAllKnownProducersTargeted(source semanticview.Source, flowID, eve
 	producers := 0
 	targeted := 0
 	for _, site := range pinRoutingEmitSites(source) {
-		if strings.TrimSpace(source.ResolveFlowEventReference(site.FlowID, site.Spec.EventType())) != canonical {
+		if !pinRoutingEmitSiteProducesReceiverEvent(source, site, flowID, eventType, canonical) {
 			continue
 		}
 		if !runtimepinrouting.PinDeclaredOutput(source, site.FlowID, site.Spec.EventType()) {
 			continue
 		}
 		producers++
+		connectedOutput := compositionConnectsFromOutputEvent(source, site.FlowID, site.Spec.EventType())
 		structuralParent := pinRoutingStructuralParentRouteEligible(source, site.FlowID)
+		if connectedOutput {
+			structuralParent = true
+		}
 		if (site.Spec.HasTarget() && runtimepinrouting.ProducerRouteCommonPathFailure(source, site.FlowID, site.Spec.EventType(), site.Spec) == "") ||
 			(structuralParent && !site.Spec.Broadcast) {
 			targeted++
 		}
 	}
 	return producers > 0 && targeted == producers
+}
+
+func pinRoutingEmitSiteProducesReceiverEvent(source semanticview.Source, site semanticview.AuthoredEmitSite, receiverFlowID, receiverEventType, receiverCanonical string) bool {
+	if source == nil {
+		return false
+	}
+	if receiverCanonical != "" && strings.TrimSpace(source.ResolveFlowEventReference(site.FlowID, site.Spec.EventType())) == receiverCanonical {
+		return true
+	}
+	return pinRoutingEmitSiteConnectsToReceiverEvent(source, site, receiverFlowID, receiverEventType)
+}
+
+func pinRoutingEmitSiteConnectsToReceiverEvent(source semanticview.Source, site semanticview.AuthoredEmitSite, receiverFlowID, receiverEventType string) bool {
+	if source == nil {
+		return false
+	}
+	for _, inputPin := range source.FlowInputEventPins(receiverFlowID) {
+		if !pinRoutingInputPinMatchesReceiverEvent(source, receiverFlowID, inputPin, receiverEventType) {
+			continue
+		}
+		for _, connect := range source.CompositionConnectsTo(receiverFlowID, inputPin.PinName()) {
+			from, err := connect.FromRef()
+			if err != nil {
+				continue
+			}
+			if pinRoutingConnectSourceMatchesEmitSite(source, from, site) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func pinRoutingInputPinMatchesReceiverEvent(source semanticview.Source, flowID string, inputPin runtimecontracts.FlowInputEventPin, eventType string) bool {
+	eventType = eventidentity.Normalize(eventType)
+	if eventType == "" {
+		return false
+	}
+	if eventidentity.Normalize(inputPin.PinName()) == eventType || eventidentity.Normalize(inputPin.EventType()) == eventType {
+		return true
+	}
+	resolved := eventidentity.Normalize(source.ResolveFlowEventReference(flowID, eventType))
+	pinResolved := eventidentity.Normalize(source.ResolveFlowEventReference(flowID, inputPin.EventType()))
+	return resolved != "" && resolved == pinResolved
+}
+
+func pinRoutingConnectSourceMatchesEmitSite(source semanticview.Source, from runtimecontracts.FlowPackagePinRef, site semanticview.AuthoredEmitSite) bool {
+	siteFlowID := strings.TrimSpace(site.FlowID)
+	if from.Root {
+		if siteFlowID != "" {
+			return false
+		}
+	} else if strings.TrimSpace(from.FlowID) != siteFlowID {
+		return false
+	}
+	for _, outputPin := range source.FlowOutputEventPins(siteFlowID) {
+		if strings.TrimSpace(outputPin.PinName()) != strings.TrimSpace(from.Pin) {
+			continue
+		}
+		if eventidentity.Normalize(outputPin.PinName()) == eventidentity.Normalize(site.Spec.EventType()) ||
+			eventidentity.Normalize(outputPin.EventType()) == eventidentity.Normalize(site.Spec.EventType()) {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/runtime/bootverify/workflow_pin_routing_checks_test.go
+++ b/internal/runtime/bootverify/workflow_pin_routing_checks_test.go
@@ -141,6 +141,22 @@ func TestRedundantInTopologySelectEntityAllowsExternalAndMixedProvenanceAcquisit
 	}
 }
 
+func TestRedundantInTopologySelectEntityIgnoresProducerConnectedOnlyToOtherReceiver(t *testing.T) {
+	bundle := loadSelectEntityDemotionBundle(t, selectEntityDemotionFixtureOptions{
+		consumerMode:           "static",
+		acquisition:            "select_entity",
+		withProducer:           true,
+		connectProducerToOther: true,
+	})
+
+	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+
+	if reportContains(report.Errors(), "redundant_in_topology_select_entity", "") ||
+		reportContains(report.Warnings(), "redundant_in_topology_select_entity", "") {
+		t.Fatalf("producer connected only to another receiver must not prove in-topology authority for this receiver, got errors=%#v warnings=%#v", report.Errors(), report.Warnings())
+	}
+}
+
 func TestPinTargetResolution_FailsClosedForProducerTargetAdaptedConnectCommonPath(t *testing.T) {
 	bundle := loadPinRoutingProducerRouteBundleForEvents(t, "shared.ready", "consumer.ready", `
       emit:
@@ -743,10 +759,11 @@ connect:
 }
 
 type selectEntityDemotionFixtureOptions struct {
-	consumerMode string
-	acquisition  string
-	external     bool
-	withProducer bool
+	consumerMode           string
+	acquisition            string
+	external               bool
+	withProducer           bool
+	connectProducerToOther bool
 }
 
 func loadSelectEntityDemotionBundle(t *testing.T, opts selectEntityDemotionFixtureOptions) *runtimecontracts.WorkflowContractBundle {
@@ -765,13 +782,23 @@ func loadSelectEntityDemotionBundle(t *testing.T, opts selectEntityDemotionFixtu
   - id: producer
     flow: producer
     mode: static` + flows
+		if opts.connectProducerToOther {
+			flows += `
+  - id: other_consumer
+    flow: other_consumer
+    mode: static`
+		}
 	}
 	connectBlock := ""
 	if opts.withProducer {
+		targetFlow := "consumer"
+		if opts.connectProducerToOther {
+			targetFlow = "other_consumer"
+		}
 		connectBlock = `
 connect:
   - from: producer.deploy_done
-    to: consumer.deploy_done
+    to: ` + targetFlow + `.deploy_done
     delivery: one`
 		if consumerMode == "static" {
 			connectBlock += `
@@ -795,6 +822,9 @@ flows:`+flows+connectBlock+`
 	writePinRoutingVerifyFile(t, filepath.Join(root, "entities.yaml"), "{}\n")
 	if opts.withProducer {
 		writeSelectEntityDemotionProducerFlow(t, root)
+		if opts.connectProducerToOther {
+			writeSelectEntityDemotionOtherConsumerFlow(t, root)
+		}
 	}
 	writeSelectEntityDemotionConsumerFlow(t, root, opts)
 	repoRoot := filepath.Clean(filepath.Join("..", "..", ".."))
@@ -848,6 +878,51 @@ producer-node:
         event: deploy.done
         fields:
           vertical_id: payload.vertical_id
+      advances_to: done
+`)
+}
+
+func writeSelectEntityDemotionOtherConsumerFlow(t *testing.T, root string) {
+	t.Helper()
+	writePinRoutingVerifyFile(t, filepath.Join(root, "flows", "other_consumer", "schema.yaml"), `
+name: other-consumer
+mode: static
+initial_state: pending
+states: [pending, done]
+terminal_states: [done]
+pins:
+  inputs:
+    events:
+      - name: deploy_done
+        event: deploy.done
+        address:
+          by: vertical_id
+          source: payload.vertical_id
+          target: entity.vertical_id
+          cardinality: one
+  outputs:
+    events: []
+`)
+	writePinRoutingVerifyFile(t, filepath.Join(root, "flows", "other_consumer", "policy.yaml"), "{}\n")
+	writePinRoutingVerifyFile(t, filepath.Join(root, "flows", "other_consumer", "agents.yaml"), "{}\n")
+	writePinRoutingVerifyFile(t, filepath.Join(root, "flows", "other_consumer", "events.yaml"), `
+deploy.done:
+  vertical_id: string
+`)
+	writePinRoutingVerifyFile(t, filepath.Join(root, "flows", "other_consumer", "entities.yaml"), `
+deployment:
+  vertical_id:
+    type: string
+    indexed: true
+    _unused_reason: select_entity demotion other receiver route-key proof field
+`)
+	writePinRoutingVerifyFile(t, filepath.Join(root, "flows", "other_consumer", "nodes.yaml"), `
+other-consumer-node:
+  id: other-consumer-node
+  execution_type: system_node
+  subscribes_to: [deploy.done]
+  event_handlers:
+    deploy.done:
       advances_to: done
 `)
 }

--- a/internal/runtime/bootverify/workflow_pin_routing_checks_test.go
+++ b/internal/runtime/bootverify/workflow_pin_routing_checks_test.go
@@ -60,6 +60,87 @@ func TestPinTargetResolution_FailsClosedForProducerBroadcastCommonCompositionPat
 	}
 }
 
+func TestRedundantInTopologySelectEntityFailsClosedForParentConnect(t *testing.T) {
+	bundle := loadSelectEntityDemotionBundle(t, selectEntityDemotionFixtureOptions{
+		consumerMode: "static",
+		acquisition:  "select_entity",
+		withProducer: true,
+	})
+
+	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+
+	if !reportContains(report.Errors(), "redundant_in_topology_select_entity", "instance.by plus parent connect") {
+		t.Fatalf("expected redundant_in_topology_select_entity hard invalidity, got errors=%#v warnings=%#v", report.Errors(), report.Warnings())
+	}
+	if reportContains(report.Warnings(), "redundant_in_topology_select_entity", "") {
+		t.Fatalf("redundant_in_topology_select_entity must not remain warning-only, got %#v", report.Warnings())
+	}
+}
+
+func TestRedundantInTopologySelectOrCreateEntityFailsClosedForParentConnect(t *testing.T) {
+	bundle := loadSelectEntityDemotionBundle(t, selectEntityDemotionFixtureOptions{
+		consumerMode: "static",
+		acquisition:  "select_or_create_entity",
+		withProducer: true,
+	})
+
+	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+
+	if !reportContains(report.Errors(), "redundant_in_topology_select_entity", "select_or_create_entity") ||
+		!reportContains(report.Errors(), "redundant_in_topology_select_entity", "instance.by plus parent connect") {
+		t.Fatalf("expected redundant_in_topology_select_entity hard invalidity for select_or_create_entity, got errors=%#v warnings=%#v", report.Errors(), report.Warnings())
+	}
+}
+
+func TestRedundantInTopologySelectEntityAllowsTemplateInstanceConnectReplacement(t *testing.T) {
+	bundle := loadSelectEntityDemotionBundle(t, selectEntityDemotionFixtureOptions{
+		consumerMode: "template",
+		withProducer: true,
+	})
+
+	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+
+	if report.HasErrors() {
+		t.Fatalf("template instance.by plus parent connect should verify without receiver acquisition, got %#v", report.Errors())
+	}
+	if reportContains(report.Warnings(), "redundant_in_topology_select_entity", "") {
+		t.Fatalf("connect-routed replacement should not report select_entity warning, got %#v", report.Warnings())
+	}
+}
+
+func TestRedundantInTopologySelectEntityAllowsExternalAndMixedProvenanceAcquisition(t *testing.T) {
+	tests := []struct {
+		name         string
+		acquisition  string
+		withProducer bool
+	}{
+		{name: "external select_entity", acquisition: "select_entity"},
+		{name: "external select_or_create_entity", acquisition: "select_or_create_entity"},
+		{name: "mixed select_entity", acquisition: "select_entity", withProducer: true},
+		{name: "mixed select_or_create_entity", acquisition: "select_or_create_entity", withProducer: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			bundle := loadSelectEntityDemotionBundle(t, selectEntityDemotionFixtureOptions{
+				consumerMode: "static",
+				acquisition:  tc.acquisition,
+				external:     true,
+				withProducer: tc.withProducer,
+			})
+
+			report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+
+			if reportContains(report.Errors(), "redundant_in_topology_select_entity", "") ||
+				reportContains(report.Warnings(), "redundant_in_topology_select_entity", "") {
+				t.Fatalf("external/mixed provenance acquisition must remain allowed, got errors=%#v warnings=%#v", report.Errors(), report.Warnings())
+			}
+			if reportContains(report.Errors(), "select_entity_validation", "") {
+				t.Fatalf("external/mixed provenance acquisition should keep valid binding semantics, got %#v", report.Errors())
+			}
+		})
+	}
+}
+
 func TestPinTargetResolution_FailsClosedForProducerTargetAdaptedConnectCommonPath(t *testing.T) {
 	bundle := loadPinRoutingProducerRouteBundleForEvents(t, "shared.ready", "consumer.ready", `
       emit:
@@ -658,6 +739,202 @@ connect:
   - from: producer.shared.ready
     to: consumer.consumer.ready
     adapter: producer-shared-to-consumer-ready
+`
+}
+
+type selectEntityDemotionFixtureOptions struct {
+	consumerMode string
+	acquisition  string
+	external     bool
+	withProducer bool
+}
+
+func loadSelectEntityDemotionBundle(t *testing.T, opts selectEntityDemotionFixtureOptions) *runtimecontracts.WorkflowContractBundle {
+	t.Helper()
+	root := t.TempDir()
+	consumerMode := opts.consumerMode
+	if strings.TrimSpace(consumerMode) == "" {
+		consumerMode = "static"
+	}
+	flows := `
+  - id: consumer
+    flow: consumer
+    mode: ` + consumerMode
+	if opts.withProducer {
+		flows = `
+  - id: producer
+    flow: producer
+    mode: static` + flows
+	}
+	connectBlock := ""
+	if opts.withProducer {
+		connectBlock = `
+connect:
+  - from: producer.deploy_done
+    to: consumer.deploy_done
+    delivery: one`
+		if consumerMode == "static" {
+			connectBlock += `
+    map:
+      vertical_id:
+        source: payload.vertical_id
+        target: entity.vertical_id`
+		}
+	}
+	writePinRoutingVerifyFile(t, filepath.Join(root, "package.yaml"), `
+name: select-entity-demotion
+version: "1.0.0"
+platform_version: ">=1.6.0"
+flows:`+flows+connectBlock+`
+`)
+	writePinRoutingVerifyFile(t, filepath.Join(root, "schema.yaml"), "name: select-entity-demotion\n")
+	writePinRoutingVerifyFile(t, filepath.Join(root, "policy.yaml"), "{}\n")
+	writePinRoutingVerifyFile(t, filepath.Join(root, "tools.yaml"), "{}\n")
+	writePinRoutingVerifyFile(t, filepath.Join(root, "agents.yaml"), "{}\n")
+	writePinRoutingVerifyFile(t, filepath.Join(root, "events.yaml"), "{}\n")
+	writePinRoutingVerifyFile(t, filepath.Join(root, "entities.yaml"), "{}\n")
+	if opts.withProducer {
+		writeSelectEntityDemotionProducerFlow(t, root)
+	}
+	writeSelectEntityDemotionConsumerFlow(t, root, opts)
+	repoRoot := filepath.Clean(filepath.Join("..", "..", ".."))
+	bundle, err := runtimecontracts.LoadWorkflowContractBundleWithOverrides(repoRoot, root, runtimecontracts.DefaultPlatformSpecFile(repoRoot))
+	if err != nil {
+		t.Fatalf("LoadWorkflowContractBundleWithOverrides: %v", err)
+	}
+	return bundle
+}
+
+func writeSelectEntityDemotionProducerFlow(t *testing.T, root string) {
+	t.Helper()
+	writePinRoutingVerifyFile(t, filepath.Join(root, "flows", "producer", "schema.yaml"), `
+name: producer
+mode: static
+initial_state: pending
+states: [pending, done]
+terminal_states: [done]
+pins:
+  inputs:
+    events: [deploy.requested]
+  outputs:
+    events:
+      - name: deploy_done
+        event: deploy.done
+        key: vertical_id
+        carries: [vertical_id]
+`)
+	writePinRoutingVerifyFile(t, filepath.Join(root, "flows", "producer", "policy.yaml"), "{}\n")
+	writePinRoutingVerifyFile(t, filepath.Join(root, "flows", "producer", "agents.yaml"), "{}\n")
+	writePinRoutingVerifyFile(t, filepath.Join(root, "flows", "producer", "entities.yaml"), `
+producer_request:
+  vertical_id:
+    type: string
+    _unused_reason: select_entity demotion producer proof field
+`)
+	writePinRoutingVerifyFile(t, filepath.Join(root, "flows", "producer", "events.yaml"), `
+deploy.requested:
+  vertical_id: string
+deploy.done:
+  vertical_id: string
+`)
+	writePinRoutingVerifyFile(t, filepath.Join(root, "flows", "producer", "nodes.yaml"), `
+producer-node:
+  id: producer-node
+  execution_type: system_node
+  event_handlers:
+    deploy.requested:
+      create_entity: true
+      emit:
+        event: deploy.done
+        fields:
+          vertical_id: payload.vertical_id
+      advances_to: done
+`)
+}
+
+func writeSelectEntityDemotionConsumerFlow(t *testing.T, root string, opts selectEntityDemotionFixtureOptions) {
+	t.Helper()
+	consumerMode := opts.consumerMode
+	if strings.TrimSpace(consumerMode) == "" {
+		consumerMode = "static"
+	}
+	instanceBlock := ""
+	inputPin := `
+      - name: deploy_done
+        event: deploy.done
+        address:
+          by: vertical_id
+          source: payload.vertical_id
+          target: entity.vertical_id
+          cardinality: one
+`
+	if consumerMode == "template" {
+		instanceBlock = `instance:
+  by: vertical_id
+  on_missing: reject
+  on_conflict: reject
+`
+		inputPin = `
+      - name: deploy_done
+        event: deploy.done
+`
+	}
+	writePinRoutingVerifyFile(t, filepath.Join(root, "flows", "consumer", "schema.yaml"), `
+name: consumer
+mode: `+consumerMode+`
+`+instanceBlock+`initial_state: pending
+states: [pending, done]
+terminal_states: [done]
+pins:
+  inputs:
+    events:`+inputPin+`  outputs:
+    events: []
+`)
+	writePinRoutingVerifyFile(t, filepath.Join(root, "flows", "consumer", "policy.yaml"), "{}\n")
+	writePinRoutingVerifyFile(t, filepath.Join(root, "flows", "consumer", "agents.yaml"), "{}\n")
+	externalSource := ""
+	if opts.external {
+		externalSource = `  swarm:
+    source: external (operator webhook)
+`
+	}
+	writePinRoutingVerifyFile(t, filepath.Join(root, "flows", "consumer", "events.yaml"), `
+deploy.done:
+`+externalSource+`  vertical_id: string
+`)
+	writePinRoutingVerifyFile(t, filepath.Join(root, "flows", "consumer", "entities.yaml"), `
+deployment:
+  vertical_id:
+    type: string
+    indexed: true
+    _unused_reason: select_entity demotion route-key proof field
+`)
+	writePinRoutingVerifyFile(t, filepath.Join(root, "flows", "consumer", "nodes.yaml"), selectEntityDemotionConsumerNodes(opts.acquisition))
+}
+
+func selectEntityDemotionConsumerNodes(acquisition string) string {
+	acquisition = strings.TrimSpace(acquisition)
+	acquisitionBlock := ""
+	switch acquisition {
+	case "select_entity":
+		acquisitionBlock = `      select_entity:
+        by:
+          vertical_id: payload.vertical_id
+`
+	case "select_or_create_entity":
+		acquisitionBlock = `      select_or_create_entity:
+        by:
+          vertical_id: payload.vertical_id
+`
+	}
+	return `
+consumer-node:
+  id: consumer-node
+  execution_type: system_node
+  subscribes_to: [deploy.done]
+  event_handlers:
+    deploy.done:
+` + acquisitionBlock + `      advances_to: done
 `
 }
 

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -1428,9 +1428,10 @@ handler_specification:
         canonical_uses: External webhook ingress, events declared with swarm.source beginning with external, and rare mixed-provenance
           event types where in-topology producers set event.target but external producers arrive without target.
         non_canonical_use: In-topology receivers for pin-declared events whose producers are also in the pin topology. Pin routing
-          already supplies event.target; select_entity is redundant and should be removed by the contract migration.
-        boot_verify: Redundant in-topology select_entity is a warning. Missing select_entity on external/no-target stateful
-          handlers is an error because the handler would otherwise run against the wrong entity context.
+          already supplies event.target; select_entity is a hard invalidity under the normal composition model and should
+          be replaced with receiver instance.by plus parent connect routing.
+        boot_verify: Redundant normal in-topology select_entity is a hard invalidity. Missing select_entity on external/no-target
+          stateful handlers is an error because the handler would otherwise run against the wrong entity context.
       restrictions:
         lifecycle_scope: Valid only on stateful static-flow input-pin handlers. Stateless flows do not have stateful entity
           acquisition. Template flows acquire entities through create_flow_instance.
@@ -1483,6 +1484,8 @@ handler_specification:
           to mint the entity on zero-match.
         non_canonical_use: In-topology pin routing where lowered parent connect, the explicit target escape hatch, structural
           fallback, or target_set delivery already supplies the receiver route context.
+        boot_verify: Redundant normal in-topology select_or_create_entity is a hard invalidity. External or mixed-provenance
+          acquisition remains valid when event.target may be absent.
       restrictions:
         lifecycle_scope: Valid only on stateful static-flow input-pin handlers. Stateless flows do not have stateful entity
           acquisition. Template flows acquire entities through create_flow_instance.
@@ -2307,12 +2310,13 @@ engine:
     select_entity_coexistence:
       canonical: External webhook ingress, events declared with swarm.source beginning with external, and mixed-provenance no-target events.
       non_canonical: In-topology parent-connect pin routing. Receivers should declare addressed input pin resolution rather
-        than depend on select_entity to repair broadcast to the right entity.
+        than depend on select_entity to repair broadcast or connected delivery to the right entity.
       receiver_context_order:
       - event.target
       - select_entity_or_select_or_create_entity
       - event.source
-      boot_verify: Redundant in-topology select_entity is a warning. Missing select_entity on external/no-target stateful handlers is an error.
+      boot_verify: Redundant normal in-topology select_entity/select_or_create_entity is hard invalidity. Missing select_entity
+        on external/no-target stateful handlers is an error.
     auth_boundary:
       v1_rule: Existing emit authorization plus pin topology are the v1 authorization boundary.
       no_separate_acl: No separate per-target ACL layer exists in v1.
@@ -4328,11 +4332,12 @@ engine:
         receiver input where parent connect is required.
       when: boot-only
     - id: redundant_in_topology_select_entity
-      severity: warning
+      severity: hard_invalidity
       scope: per-handler
       trigger: A handler declares select_entity or select_or_create_entity for an event whose only producers are in-topology
-        pin-routed producers that set event.target. The receiver-side acquisition is redundant and should be removed unless
-        the event is external or mixed-provenance.
+        connected/pin-routed producers that set event.target through parent connect, structural routing, or a valid explicit
+        target. The receiver-side acquisition is invalid normal composition authority and must be replaced with receiver
+        instance.by plus parent connect routing unless the event is external or mixed-provenance.
       when: boot-only
     - id: missing_external_select_entity
       severity: error
@@ -5349,7 +5354,8 @@ flow_model:
           primitives for external ingress, legacy migration, and explicit
           advanced database-like flows. Normal in-topology composition should
           route to the receiving flow instance through parent `connect` and
-          instance keys instead.
+          instance keys instead; normal in-topology receiver acquisition fails
+          boot verification rather than remaining a warning.
       producer_emit_target:
         status: exotic_dynamic_routing_escape_hatch
         implementation_tracker: '#1545'
@@ -9885,8 +9891,8 @@ static_analyzer:
   slice_3b_select_entity_pin_coexistence:
     id: select_entity_pin_coexistence
     domain: semantic_drift
-    authority: semantic_drift_warning
-    severity: warning
+    authority: hard_invalidity
+    severity: error
     canonical_owner: internal/runtime/bootverify
     supported_surface: cmd/swarm verify
     spec_basis:
@@ -9904,8 +9910,9 @@ static_analyzer:
       - runtime target resolution
     verdicts:
       redundant_in_topology:
-        severity: warning
-        rule: select_entity/select_or_create_entity on an event whose only producers are in-topology pin-routed producers is redundant.
+        severity: error
+        rule: select_entity/select_or_create_entity on an event whose only producers are normal in-topology connected/pin-routed
+          producers is hard invalidity; use receiver instance.by plus parent connect routing instead.
       external_or_mixed_provenance:
         severity: ok
         rule: External or mixed-provenance events may use receiver-side acquisition as late binding when event.target is absent.


### PR DESCRIPTION
## Summary
- Promote `redundant_in_topology_select_entity` from warning to hard invalidity for normal in-topology connected/pin-routed receiver acquisition.
- Keep external and mixed-provenance receiver acquisition valid by preferring receiver flow-local `swarm.source: external` metadata before generic catalog resolution.
- Add bootverify coverage for normal `select_entity` / `select_or_create_entity` failure, the `instance.by` + parent `connect` replacement path, and external/mixed allowed cases.
- Update `platform-spec.yaml` so spec/watchlist rows no longer describe this class as warning-only.

Closes #1547

## Governing Refs / Context
- `platform-spec.yaml#handler_specification.handler_fields.select_entity`
- `platform-spec.yaml#handler_specification.handler_fields.select_or_create_entity`
- `platform-spec.yaml#engine.cross_flow_routing.select_entity_coexistence`
- `platform-spec.yaml#flow_model.flow_instance_authoring.escape_hatches.select_entity`
- `platform-spec.yaml#static_analyzer.slice_3b_select_entity_pin_coexistence`
- Binding issue/gate context: #1547 Pre-Implementation Coverage Audit and approved lead gate comment.

## Semantic Migration
- New canonical owner: normal in-topology route/state authority is parent `connect` plus receiver `instance.by` / addressed input pin resolution; boot verification owns rejecting receiver acquisition in that normal path.
- Old producer/reader/writer path now invalid: receiver-side `select_entity` / `select_or_create_entity` on connected/pin-routed normal in-topology events is no longer warning-only and is non-authoritative for routing.
- Production paths checked for surviving old behavior: bootverify check registry, receiver acquisition classification, parent-connect emit-site matching, receiver-local external metadata, EventBus/route authority adjacent tests, conformance/bus/pipeline focused packages.
- Migration complete for #1547 child class. Parent #1537 remains open for its remaining schema-authority family.

## Proof Run
- `go test ./internal/runtime/bootverify -run 'TestRedundantInTopologySelectEntity|TestPinTargetResolution_FailsClosedForProducerTargetCommonCompositionPath|TestPinTargetResolution_AllowsFlowScopedAgentEmitEventsThroughParentConnect|TestRun_AllowsTemplateInstanceKeyCompositionConnectWithoutAddress' -count=1`
- `go test ./internal/runtime/bootverify ./internal/runtime/conformance ./internal/runtime/bus ./internal/runtime/pipeline -count=1`
- `go test ./...`

## Note
- `docs/IMPLEMENTER_GUIDELINES.md` and `docs/SEMANTIC_DRIFT.md` were requested by the gate but are absent from this worktree's `docs/` directory; implementation followed the approved gate and authoritative spec sections above.