### PR TITLE
[agent-a][issue #1548] Add typed contained state operations

### DIFF
--- a/internal/runtime/bootverify/checks.go
+++ b/internal/runtime/bootverify/checks.go
@@ -208,6 +208,7 @@ var bootCheckRegistry = []Check{
 	{ID: "entity_writer_coverage", Severity: SeverityHardInvalidity, Run: checkEntityWriterCoverage},
 	{ID: "payload_field_coverage", Severity: "error", Run: checkPayloadFieldCoverage},
 	{ID: "entity_write_target_compliance", Severity: SeverityHardInvalidity, Run: checkEntityWriteTargetCompliance},
+	{ID: "contained_state_operation_compliance", Severity: SeverityHardInvalidity, Run: checkContainedStateOperationCompliance},
 	{ID: "semantic_drift_payload_completeness", Severity: "error", Run: checkSemanticDriftPayloadCompleteness},
 	{ID: "condition_payload_alignment", Severity: "error", Run: checkConditionPayloadAlignment},
 	{ID: "condition_policy_alignment", Severity: "warning", Run: checkConditionPolicyAlignment},

--- a/internal/runtime/bootverify/flow_data_access_test.go
+++ b/internal/runtime/bootverify/flow_data_access_test.go
@@ -66,8 +66,8 @@ func TestRun_ValidatesFlowDataAccessDeclarations(t *testing.T) {
 }
 
 func TestBootCheckRegistry_HasFlowDataAccessCheckCount(t *testing.T) {
-	if got := len(bootCheckRegistry); got != 63 {
-		t.Fatalf("bootCheckRegistry count = %d, want 63", got)
+	if got := len(bootCheckRegistry); got != 64 {
+		t.Fatalf("bootCheckRegistry count = %d, want 64", got)
 	}
 }
 

--- a/internal/runtime/bootverify/report_test.go
+++ b/internal/runtime/bootverify/report_test.go
@@ -4864,8 +4864,8 @@ func TestRun_ReportsMissingRuntimeExecutorForOwnedRuntimeEvent(t *testing.T) {
 }
 
 func TestBootCheckRegistry_HasSpecCheckCount(t *testing.T) {
-	if got := len(bootCheckRegistry); got != 63 {
-		t.Fatalf("bootCheckRegistry count = %d, want 63", got)
+	if got := len(bootCheckRegistry); got != 64 {
+		t.Fatalf("bootCheckRegistry count = %d, want 64", got)
 	}
 	if got := len(supplementalChecks); got != 3 {
 		t.Fatalf("supplementalChecks count = %d, want 3", got)

--- a/internal/runtime/bootverify/workflow_contained_state_operation_checks.go
+++ b/internal/runtime/bootverify/workflow_contained_state_operation_checks.go
@@ -1,0 +1,134 @@
+package bootverify
+
+import (
+	"fmt"
+	"strings"
+
+	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
+	"github.com/division-sh/swarm/internal/runtime/entityruntime"
+	"github.com/division-sh/swarm/internal/runtime/semanticview"
+)
+
+func checkContainedStateOperationCompliance(c *checkerContext) []Finding {
+	findings := make([]Finding, 0)
+	for _, ref := range wave1ContainedStateOperations(c.source) {
+		contract, ok := entityruntime.ResolveForFlow(c.source, ref.FlowID)
+		if !ok {
+			findings = append(findings, containedStateOperationFinding(ref, fmt.Sprintf("flow %s has no declared entity contract", defaultFlowLabel(ref.FlowID))))
+			continue
+		}
+		target, err := entityruntime.ResolveContainedOperationTarget(contract, ref.Write.Target(), string(ref.Write.Operation), !ref.Write.Key.IsZero(), !ref.Write.Index.IsZero())
+		if err != nil {
+			findings = append(findings, containedStateOperationFinding(ref, err.Error()))
+			continue
+		}
+		if ref.Write.Key.HasLiteralValue() {
+			if _, err := entityruntime.NormalizeContainedOperationKey(contract, target.MapKeyType, ref.Write.Key.Literal); err != nil {
+				findings = append(findings, containedStateOperationFinding(ref, fmt.Sprintf("key: %v", err)))
+			}
+		}
+		if ref.Write.Index.HasLiteralValue() {
+			if _, err := entityruntime.NormalizeContainedOperationIndex(ref.Write.Index.Literal); err != nil {
+				findings = append(findings, containedStateOperationFinding(ref, fmt.Sprintf("index: %v", err)))
+			}
+		}
+		if ref.Write.Operation != runtimecontracts.WorkflowDataOperationDelete && ref.Write.Value.HasLiteralValue() {
+			if _, err := entityruntime.NormalizeContainedOperationValue(contract, target, string(ref.Write.Operation), ref.Write.Value.Literal); err != nil {
+				findings = append(findings, containedStateOperationFinding(ref, fmt.Sprintf("value: %v", err)))
+			}
+		}
+	}
+	return findings
+}
+
+type wave1ContainedStateOperationRef struct {
+	FlowID    string
+	NodeID    string
+	EventType string
+	Kind      string
+	Write     runtimecontracts.WorkflowDataWrite
+}
+
+func wave1ContainedStateOperations(source semanticview.Source) []wave1ContainedStateOperationRef {
+	out := make([]wave1ContainedStateOperationRef, 0)
+	nodes := source.NodeEntries()
+	for _, nodeID := range sortedNodeIDs(source) {
+		node, ok := nodes[nodeID]
+		if !ok {
+			continue
+		}
+		flowID := ""
+		if sourceRef, ok := source.NodeContractSource(nodeID); ok {
+			flowID = strings.TrimSpace(sourceRef.FlowID)
+		}
+		for eventType, handler := range node.EventHandlers {
+			eventType = strings.TrimSpace(eventType)
+			out = append(out, wave1HandlerContainedStateOperations(flowID, strings.TrimSpace(nodeID), eventType, "handler", handler.DataAccumulation.Writes)...)
+			for idx, rule := range handler.Rules {
+				scope := fmt.Sprintf("handler.rules[%d]", idx)
+				if id := strings.TrimSpace(rule.ID); id != "" {
+					scope = "handler.rules[" + id + "]"
+				}
+				out = append(out, wave1HandlerContainedStateOperations(flowID, strings.TrimSpace(nodeID), eventType, scope, rule.DataAccumulation.Writes)...)
+			}
+			for idx, rule := range handler.OnComplete {
+				scope := fmt.Sprintf("handler.on_complete[%d]", idx)
+				if id := strings.TrimSpace(rule.ID); id != "" {
+					scope = "handler.on_complete[" + id + "]"
+				}
+				out = append(out, wave1HandlerContainedStateOperations(flowID, strings.TrimSpace(nodeID), eventType, scope, rule.DataAccumulation.Writes)...)
+			}
+			if handler.Accumulate != nil {
+				for idx, rule := range handler.Accumulate.OnComplete {
+					scope := fmt.Sprintf("handler.accumulate.on_complete[%d]", idx)
+					if id := strings.TrimSpace(rule.ID); id != "" {
+						scope = "handler.accumulate.on_complete[" + id + "]"
+					}
+					out = append(out, wave1HandlerContainedStateOperations(flowID, strings.TrimSpace(nodeID), eventType, scope, rule.DataAccumulation.Writes)...)
+				}
+				if handler.Accumulate.OnTimeout != nil {
+					scope := "handler.accumulate.on_timeout"
+					if id := strings.TrimSpace(handler.Accumulate.OnTimeout.ID); id != "" {
+						scope = "handler.accumulate.on_timeout[" + id + "]"
+					}
+					out = append(out, wave1HandlerContainedStateOperations(flowID, strings.TrimSpace(nodeID), eventType, scope, handler.Accumulate.OnTimeout.DataAccumulation.Writes)...)
+				}
+			}
+			for idx, branch := range handler.Branch {
+				if branch.Then != nil {
+					out = append(out, wave1HandlerContainedStateOperations(flowID, strings.TrimSpace(nodeID), eventType, fmt.Sprintf("handler.branch[%d].then", idx), branch.Then.DataAccumulation.Writes)...)
+				}
+				if branch.Else != nil {
+					out = append(out, wave1HandlerContainedStateOperations(flowID, strings.TrimSpace(nodeID), eventType, fmt.Sprintf("handler.branch[%d].else", idx), branch.Else.DataAccumulation.Writes)...)
+				}
+			}
+		}
+	}
+	return out
+}
+
+func wave1HandlerContainedStateOperations(flowID, nodeID, eventType, kind string, writes []runtimecontracts.WorkflowDataWrite) []wave1ContainedStateOperationRef {
+	out := make([]wave1ContainedStateOperationRef, 0)
+	for _, write := range writes {
+		if !write.IsContainedOperation() {
+			continue
+		}
+		out = append(out, wave1ContainedStateOperationRef{
+			FlowID:    flowID,
+			NodeID:    nodeID,
+			EventType: eventType,
+			Kind:      kind + ".data_accumulation",
+			Write:     write,
+		})
+	}
+	return out
+}
+
+func containedStateOperationFinding(ref wave1ContainedStateOperationRef, detail string) Finding {
+	return Finding{
+		CheckID:  "contained_state_operation_compliance",
+		Severity: SeverityHardInvalidity,
+		Message:  fmt.Sprintf("flow %s node %s handler %s %s op %q target %q invalid: %s", defaultFlowLabel(ref.FlowID), ref.NodeID, ref.EventType, ref.Kind, ref.Write.Operation, ref.Write.Target(), strings.TrimSpace(detail)),
+		Location: ref.NodeID,
+	}
+}

--- a/internal/runtime/bootverify/workflow_contained_state_operation_checks_test.go
+++ b/internal/runtime/bootverify/workflow_contained_state_operation_checks_test.go
@@ -1,0 +1,109 @@
+package bootverify
+
+import (
+	"context"
+	"testing"
+
+	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
+	"github.com/division-sh/swarm/internal/runtime/semanticview"
+)
+
+func TestRun_ValidatesTypedContainedStateOperations(t *testing.T) {
+	source := semanticview.Wrap(containedStateOperationBundle(runtimecontracts.WorkflowDataWrite{
+		Operation: runtimecontracts.WorkflowDataOperationAppend,
+		TargetRef: "entity.verticals.active_jobs",
+		Key:       runtimecontracts.RefExpression("payload.vertical_id"),
+		Value:     runtimecontracts.RefExpression("payload.job"),
+	}))
+
+	report := Run(context.Background(), source, Options{})
+
+	if reportContains(report.Errors(), "contained_state_operation_compliance", "") {
+		t.Fatalf("unexpected contained_state_operation_compliance error: %#v", report.Errors())
+	}
+}
+
+func TestRun_FailsClosedOnInvalidContainedStateOperationValue(t *testing.T) {
+	source := semanticview.Wrap(containedStateOperationBundle(runtimecontracts.WorkflowDataWrite{
+		Operation: runtimecontracts.WorkflowDataOperationSet,
+		TargetRef: "entity.verticals",
+		Key:       runtimecontracts.LiteralExpression("north"),
+		Value: runtimecontracts.LiteralExpression(map[string]any{
+			"undeclared": "field",
+		}),
+	}))
+
+	report := Run(context.Background(), source, Options{})
+
+	if !reportContains(report.Errors(), "contained_state_operation_compliance", "is undeclared") {
+		t.Fatalf("expected contained_state_operation_compliance undeclared field error, got %#v", report.Errors())
+	}
+}
+
+func TestRun_FailsClosedOnDynamicContainedStateOperationTargetPath(t *testing.T) {
+	source := semanticview.Wrap(containedStateOperationBundle(runtimecontracts.WorkflowDataWrite{
+		Operation: runtimecontracts.WorkflowDataOperationSet,
+		TargetRef: "entity.verticals[payload.vertical_id]",
+		Key:       runtimecontracts.LiteralExpression("north"),
+		Value: runtimecontracts.LiteralExpression(map[string]any{
+			"status":      "active",
+			"active_jobs": []any{},
+		}),
+	}))
+
+	report := Run(context.Background(), source, Options{})
+
+	if !reportContains(report.Errors(), "contained_state_operation_compliance", "dynamic bracket path syntax") {
+		t.Fatalf("expected contained_state_operation_compliance dynamic path error, got %#v", report.Errors())
+	}
+}
+
+func containedStateOperationBundle(write runtimecontracts.WorkflowDataWrite) *runtimecontracts.WorkflowContractBundle {
+	return &runtimecontracts.WorkflowContractBundle{
+		Events: map[string]runtimecontracts.EventCatalogEntry{
+			"job.received": {
+				Payload: runtimecontracts.EventPayloadSpec{
+					Properties: map[string]runtimecontracts.EventFieldSpec{
+						"vertical_id": {Type: "text"},
+						"job":         {Type: "json"},
+					},
+				},
+			},
+		},
+		RootTypes: runtimecontracts.TypeCatalogDocument{
+			Types: map[string]runtimecontracts.NamedTypeDecl{
+				"VerticalState": {
+					Fields: map[string]runtimecontracts.TypeFieldSpec{
+						"status":      {Type: "text"},
+						"active_jobs": {Type: "[Job]"},
+					},
+				},
+				"Job": {
+					Fields: map[string]runtimecontracts.TypeFieldSpec{
+						"id":    {Type: "text"},
+						"title": {Type: "text"},
+					},
+				},
+			},
+		},
+		RootEntities: runtimecontracts.EntityContractsDocument{
+			"subject": {
+				Fields: map[string]runtimecontracts.EntityFieldDecl{
+					"verticals": {Type: "map[text]VerticalState"},
+				},
+			},
+		},
+		Nodes: map[string]runtimecontracts.SystemNodeContract{
+			"node-1": {
+				ID: "node-1",
+				EventHandlers: map[string]runtimecontracts.SystemNodeEventHandler{
+					"job.received": {
+						DataAccumulation: runtimecontracts.WorkflowDataAccumulation{
+							Writes: []runtimecontracts.WorkflowDataWrite{write},
+						},
+					},
+				},
+			},
+		},
+	}
+}

--- a/internal/runtime/bootverify/workflow_contained_state_operation_checks_test.go
+++ b/internal/runtime/bootverify/workflow_contained_state_operation_checks_test.go
@@ -58,6 +58,46 @@ func TestRun_FailsClosedOnDynamicContainedStateOperationTargetPath(t *testing.T)
 	}
 }
 
+func TestRun_FailsClosedOnContainedStateOperationRefOperandsToUnknownEntityField(t *testing.T) {
+	tests := []struct {
+		name  string
+		write runtimecontracts.WorkflowDataWrite
+		want  string
+	}{
+		{
+			name: "key ref",
+			write: runtimecontracts.WorkflowDataWrite{
+				Operation: runtimecontracts.WorkflowDataOperationSet,
+				TargetRef: "entity.verticals",
+				Key:       runtimecontracts.RefExpression("entity.bad_key"),
+				Value: runtimecontracts.LiteralExpression(map[string]any{
+					"status":      "active",
+					"active_jobs": []any{},
+				}),
+			},
+			want: "entity.bad_key",
+		},
+		{
+			name: "value ref",
+			write: runtimecontracts.WorkflowDataWrite{
+				Operation: runtimecontracts.WorkflowDataOperationAppend,
+				TargetRef: "entity.verticals.active_jobs",
+				Key:       runtimecontracts.LiteralExpression("north"),
+				Value:     runtimecontracts.RefExpression("entity.missing"),
+			},
+			want: "entity.missing",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			report := Run(context.Background(), semanticview.Wrap(containedStateOperationBundle(tc.write)), Options{})
+			if !reportContains(report.Errors(), "expression_field_reference_validation", tc.want) {
+				t.Fatalf("expected expression_field_reference_validation containing %q, got %#v", tc.want, report.Errors())
+			}
+		})
+	}
+}
+
 func containedStateOperationBundle(write runtimecontracts.WorkflowDataWrite) *runtimecontracts.WorkflowContractBundle {
 	return &runtimecontracts.WorkflowContractBundle{
 		Events: map[string]runtimecontracts.EventCatalogEntry{

--- a/internal/runtime/bootverify/workflow_contained_state_operation_checks_test.go
+++ b/internal/runtime/bootverify/workflow_contained_state_operation_checks_test.go
@@ -58,6 +58,35 @@ func TestRun_FailsClosedOnDynamicContainedStateOperationTargetPath(t *testing.T)
 	}
 }
 
+func TestRun_FailsClosedOnContainedSetOrMergeIndex(t *testing.T) {
+	tests := []struct {
+		name string
+		op   runtimecontracts.WorkflowDataOperation
+	}{
+		{name: "set", op: runtimecontracts.WorkflowDataOperationSet},
+		{name: "merge", op: runtimecontracts.WorkflowDataOperationMerge},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			source := semanticview.Wrap(containedStateOperationBundle(runtimecontracts.WorkflowDataWrite{
+				Operation: tc.op,
+				TargetRef: "entity.verticals",
+				Key:       runtimecontracts.LiteralExpression("north"),
+				Index:     runtimecontracts.LiteralExpression(0),
+				Value: runtimecontracts.LiteralExpression(map[string]any{
+					"status": "active",
+				}),
+			}))
+
+			report := Run(context.Background(), source, Options{})
+
+			if !reportContains(report.Errors(), "contained_state_operation_compliance", "must not declare index") {
+				t.Fatalf("expected contained_state_operation_compliance index rejection, got %#v", report.Errors())
+			}
+		})
+	}
+}
+
 func TestRun_FailsClosedOnContainedStateOperationRefOperandsToUnknownEntityField(t *testing.T) {
 	tests := []struct {
 		name  string

--- a/internal/runtime/bootverify/workflow_entity_contract_coverage_checks.go
+++ b/internal/runtime/bootverify/workflow_entity_contract_coverage_checks.go
@@ -279,6 +279,21 @@ func wave1AgentExplicitEntityWriteCoverageByFlow(source semanticview.Source) map
 			}
 		}
 	}
+	for _, ref := range wave1ContainedStateOperations(source) {
+		contract, ok := entityruntime.ResolveForFlow(source, ref.FlowID)
+		if !ok {
+			continue
+		}
+		target, err := entityruntime.ResolveContainedOperationTarget(contract, ref.Write.Target(), string(ref.Write.Operation), !ref.Write.Key.IsZero(), !ref.Write.Index.IsZero())
+		if err != nil {
+			continue
+		}
+		ownerFlowID := strings.TrimSpace(ref.FlowID)
+		if out[ownerFlowID] == nil {
+			out[ownerFlowID] = map[string]struct{}{}
+		}
+		out[ownerFlowID][target.RootField] = struct{}{}
+	}
 	return out
 }
 
@@ -499,6 +514,9 @@ func wave1HandlerWriteTargets(flowID, nodeID, eventType string, handler runtimec
 	}
 	addRuleTargets := func(scope string, rule runtimecontracts.HandlerRuleEntry) {
 		for _, write := range rule.DataAccumulation.Writes {
+			if write.IsContainedOperation() {
+				continue
+			}
 			add(scope+".data_accumulation", write.Target())
 		}
 		if rule.Compute != nil {
@@ -518,6 +536,9 @@ func wave1HandlerWriteTargets(flowID, nodeID, eventType string, handler runtimec
 
 	addQueryTargets("handler", handler.Query)
 	for _, write := range handler.DataAccumulation.Writes {
+		if write.IsContainedOperation() {
+			continue
+		}
 		add("handler.data_accumulation", write.Target())
 	}
 	if handler.Compute != nil {

--- a/internal/runtime/bootverify/workflow_expression_checks.go
+++ b/internal/runtime/bootverify/workflow_expression_checks.go
@@ -336,6 +336,15 @@ func handlerEntityExpressions(handler runtimecontracts.SystemNodeEventHandler) [
 		out = append(out, expressionReference{Kind: "condition", Expression: condition, Phase: runtimepipeline.WorkflowEntityFieldLifecycleRule})
 	}
 	appendWriteExpressions := func(kind string, writes []runtimecontracts.WorkflowDataWrite) {
+		appendOperandExpression := func(operandKind string, exprValue runtimecontracts.ExpressionValue) {
+			expr := strings.TrimSpace(exprValue.CEL)
+			if expr == "" && exprValue.Kind == runtimecontracts.ExpressionKindRef {
+				expr = strings.TrimSpace(exprValue.Ref)
+			}
+			if expr != "" {
+				out = append(out, expressionReference{Kind: kind + " " + operandKind, Expression: expr, Phase: runtimepipeline.WorkflowEntityFieldLifecycleDataAccumulation})
+			}
+		}
 		for _, write := range writes {
 			if expr := strings.TrimSpace(write.Value.CEL); expr != "" {
 				selfTarget, _ := runtimepipeline.WorkflowEntityFieldNameFromTarget(write.Target())
@@ -347,11 +356,10 @@ func handlerEntityExpressions(handler runtimecontracts.SystemNodeEventHandler) [
 				})
 			}
 			if write.IsContainedOperation() {
-				if expr := strings.TrimSpace(write.Key.CEL); expr != "" {
-					out = append(out, expressionReference{Kind: kind + " key", Expression: expr, Phase: runtimepipeline.WorkflowEntityFieldLifecycleDataAccumulation})
-				}
-				if expr := strings.TrimSpace(write.Index.CEL); expr != "" {
-					out = append(out, expressionReference{Kind: kind + " index", Expression: expr, Phase: runtimepipeline.WorkflowEntityFieldLifecycleDataAccumulation})
+				appendOperandExpression("key", write.Key)
+				appendOperandExpression("index", write.Index)
+				if strings.TrimSpace(write.Value.CEL) == "" {
+					appendOperandExpression("value", write.Value)
 				}
 			}
 		}

--- a/internal/runtime/bootverify/workflow_expression_checks.go
+++ b/internal/runtime/bootverify/workflow_expression_checks.go
@@ -346,6 +346,14 @@ func handlerEntityExpressions(handler runtimecontracts.SystemNodeEventHandler) [
 					SelfTargetField: selfTarget,
 				})
 			}
+			if write.IsContainedOperation() {
+				if expr := strings.TrimSpace(write.Key.CEL); expr != "" {
+					out = append(out, expressionReference{Kind: kind + " key", Expression: expr, Phase: runtimepipeline.WorkflowEntityFieldLifecycleDataAccumulation})
+				}
+				if expr := strings.TrimSpace(write.Index.CEL); expr != "" {
+					out = append(out, expressionReference{Kind: kind + " index", Expression: expr, Phase: runtimepipeline.WorkflowEntityFieldLifecycleDataAccumulation})
+				}
+			}
 		}
 	}
 	appendRuleExpressions := func(kindPrefix string, rule runtimecontracts.HandlerRuleEntry) {

--- a/internal/runtime/bootverify/workflow_input_alignment_checks.go
+++ b/internal/runtime/bootverify/workflow_input_alignment_checks.go
@@ -208,6 +208,13 @@ type dataAccumulationPayloadSourceRef struct {
 }
 
 func dataAccumulationPayloadSourceRefs(write runtimecontracts.WorkflowDataWrite) []dataAccumulationPayloadSourceRef {
+	if write.IsContainedOperation() {
+		out := make([]dataAccumulationPayloadSourceRef, 0)
+		out = append(out, expressionPayloadSourceRefs(write.Key, "key")...)
+		out = append(out, expressionPayloadSourceRefs(write.Index, "index")...)
+		out = append(out, expressionPayloadSourceRefs(write.Value, "value")...)
+		return out
+	}
 	if write.Value.HasLiteralValue() {
 		return nil
 	}
@@ -240,6 +247,31 @@ func dataAccumulationPayloadSourceRefs(write runtimecontracts.WorkflowDataWrite)
 		return []dataAccumulationPayloadSourceRef{{
 			Field:       source,
 			Description: description,
+		}}
+	}
+	return nil
+}
+
+func expressionPayloadSourceRefs(expr runtimecontracts.ExpressionValue, label string) []dataAccumulationPayloadSourceRef {
+	if expr.IsZero() || expr.HasLiteralValue() {
+		return nil
+	}
+	if cel := strings.TrimSpace(expr.CEL); cel != "" {
+		refs := payloadReferences(cel)
+		out := make([]dataAccumulationPayloadSourceRef, 0, len(refs))
+		for _, ref := range refs {
+			out = append(out, dataAccumulationPayloadSourceRef{
+				Field:       ref,
+				Description: strings.TrimSpace(label) + " payload." + ref,
+			})
+		}
+		return out
+	}
+	if ref := strings.TrimSpace(expr.Ref); strings.HasPrefix(ref, "payload.") {
+		field := strings.TrimPrefix(ref, "payload.")
+		return []dataAccumulationPayloadSourceRef{{
+			Field:       field,
+			Description: strings.TrimSpace(label) + " " + ref,
 		}}
 	}
 	return nil

--- a/internal/runtime/contracts/workflow_contract_types.go
+++ b/internal/runtime/contracts/workflow_contract_types.go
@@ -447,6 +447,16 @@ const (
 	ExpressionKindCEL     ExpressionKind = "cel"
 )
 
+type WorkflowDataOperation string
+
+const (
+	WorkflowDataOperationSet    WorkflowDataOperation = "set"
+	WorkflowDataOperationMerge  WorkflowDataOperation = "merge"
+	WorkflowDataOperationDelete WorkflowDataOperation = "delete"
+	WorkflowDataOperationAppend WorkflowDataOperation = "append"
+	WorkflowDataOperationUpdate WorkflowDataOperation = "update"
+)
+
 type ExpressionValue struct {
 	Kind    ExpressionKind `yaml:"kind,omitempty"`
 	Literal any            `yaml:"literal,omitempty"`
@@ -863,13 +873,17 @@ type WorkflowDataAccumulation struct {
 	SourceEvent string              `yaml:"source_event"`
 }
 type WorkflowDataWrite struct {
-	Field         string          `yaml:"-" json:"field,omitempty"`
-	SourceField   string          `yaml:"source_field,omitempty" json:"source_field,omitempty"`
-	SourcePath    paths.Path      `yaml:"-" json:"-"`
-	TargetField   string          `yaml:"target_field,omitempty" json:"target_field,omitempty"`
-	TargetPathRef string          `yaml:"target_path,omitempty" json:"target_path,omitempty"`
-	TargetPath    paths.Path      `yaml:"-" json:"-"`
-	Value         ExpressionValue `yaml:"value,omitempty" json:"value,omitempty"`
+	Field         string                `yaml:"-" json:"field,omitempty"`
+	SourceField   string                `yaml:"source_field,omitempty" json:"source_field,omitempty"`
+	SourcePath    paths.Path            `yaml:"-" json:"-"`
+	Operation     WorkflowDataOperation `yaml:"op,omitempty" json:"op,omitempty"`
+	TargetRef     string                `yaml:"target,omitempty" json:"target,omitempty"`
+	TargetField   string                `yaml:"target_field,omitempty" json:"target_field,omitempty"`
+	TargetPathRef string                `yaml:"target_path,omitempty" json:"target_path,omitempty"`
+	TargetPath    paths.Path            `yaml:"-" json:"-"`
+	Value         ExpressionValue       `yaml:"value,omitempty" json:"value,omitempty"`
+	Key           ExpressionValue       `yaml:"key,omitempty" json:"key,omitempty"`
+	Index         ExpressionValue       `yaml:"index,omitempty" json:"index,omitempty"`
 }
 
 func (w WorkflowDataWrite) Source() string {
@@ -884,6 +898,8 @@ func (w WorkflowDataWrite) Source() string {
 }
 func (w WorkflowDataWrite) Target() string {
 	switch {
+	case strings.TrimSpace(w.TargetRef) != "":
+		return strings.TrimSpace(w.TargetRef)
 	case strings.TrimSpace(w.TargetPathRef) != "":
 		return strings.TrimSpace(w.TargetPathRef)
 	case strings.TrimSpace(w.TargetField) != "":
@@ -896,6 +912,10 @@ func (w WorkflowDataWrite) Target() string {
 }
 func (w WorkflowDataWrite) HasLiteralValue() bool {
 	return w.Value.HasLiteralValue()
+}
+
+func (w WorkflowDataWrite) IsContainedOperation() bool {
+	return strings.TrimSpace(string(w.Operation)) != ""
 }
 
 func (w WorkflowDataWrite) SourceExpression() ExpressionValue {

--- a/internal/runtime/contracts/workflow_contract_yaml_rules.go
+++ b/internal/runtime/contracts/workflow_contract_yaml_rules.go
@@ -630,6 +630,9 @@ func hydrateWorkflowDataOperation(w *WorkflowDataWrite) error {
 		if w.Key.IsZero() {
 			return fmt.Errorf("workflow data write op %q requires key", w.Operation)
 		}
+		if !w.Index.IsZero() {
+			return fmt.Errorf("workflow data write op %q must not declare index", w.Operation)
+		}
 	case WorkflowDataOperationAppend:
 		if !w.Index.IsZero() {
 			return fmt.Errorf("workflow data write op append must not declare index")

--- a/internal/runtime/contracts/workflow_contract_yaml_rules.go
+++ b/internal/runtime/contracts/workflow_contract_yaml_rules.go
@@ -222,18 +222,22 @@ func (w *WorkflowDataWrite) UnmarshalYAML(node *yaml.Node) error {
 	}
 	for i := 0; i+1 < len(node.Content); i += 2 {
 		switch strings.TrimSpace(node.Content[i].Value) {
-		case "", "field", "source_field", "target_field", "target_path", "expression", "value":
+		case "", "field", "source_field", "target_field", "target_path", "target", "op", "key", "index", "expression", "value":
 		default:
 			return fmt.Errorf("unsupported workflow data write field %q", strings.TrimSpace(node.Content[i].Value))
 		}
 	}
 	var aux struct {
-		Field       string    `yaml:"field"`
-		SourceField string    `yaml:"source_field"`
-		TargetField string    `yaml:"target_field"`
-		TargetPath  string    `yaml:"target_path"`
-		Expression  string    `yaml:"expression"`
-		Value       yaml.Node `yaml:"value"`
+		Field       string                `yaml:"field"`
+		SourceField string                `yaml:"source_field"`
+		Operation   WorkflowDataOperation `yaml:"op"`
+		Target      string                `yaml:"target"`
+		TargetField string                `yaml:"target_field"`
+		TargetPath  string                `yaml:"target_path"`
+		Key         ExpressionValue       `yaml:"key"`
+		Index       ExpressionValue       `yaml:"index"`
+		Expression  string                `yaml:"expression"`
+		Value       yaml.Node             `yaml:"value"`
 	}
 	if err := node.Decode(&aux); err != nil {
 		return err
@@ -241,8 +245,12 @@ func (w *WorkflowDataWrite) UnmarshalYAML(node *yaml.Node) error {
 	*w = WorkflowDataWrite{
 		Field:         strings.TrimSpace(aux.Field),
 		SourceField:   strings.TrimSpace(aux.SourceField),
+		Operation:     WorkflowDataOperation(strings.TrimSpace(string(aux.Operation))),
+		TargetRef:     strings.TrimSpace(aux.Target),
 		TargetField:   strings.TrimSpace(aux.TargetField),
 		TargetPathRef: strings.TrimSpace(aux.TargetPath),
+		Key:           aux.Key,
+		Index:         aux.Index,
 	}
 	switch aux.Value.Kind {
 	case 0:
@@ -254,11 +262,19 @@ func (w *WorkflowDataWrite) UnmarshalYAML(node *yaml.Node) error {
 		if strings.TrimSpace(aux.Expression) != "" {
 			return fmt.Errorf("workflow data write cannot declare both value and expression")
 		}
-		expr, err := decodeWorkflowDataWriteValueNode(&aux.Value)
-		if err != nil {
-			return err
+		if strings.TrimSpace(string(w.Operation)) != "" {
+			var expr ExpressionValue
+			if err := aux.Value.Decode(&expr); err != nil {
+				return err
+			}
+			w.Value = expr
+		} else {
+			expr, err := decodeWorkflowDataWriteValueNode(&aux.Value)
+			if err != nil {
+				return err
+			}
+			w.Value = expr
 		}
-		w.Value = expr
 	}
 	return hydrateWorkflowDataWrite(w)
 }
@@ -520,11 +536,32 @@ func hydrateWorkflowDataWrite(w *WorkflowDataWrite) error {
 	}
 	w.Field = strings.TrimSpace(w.Field)
 	w.SourceField = strings.TrimSpace(w.SourceField)
+	w.Operation = WorkflowDataOperation(strings.TrimSpace(string(w.Operation)))
+	w.TargetRef = strings.TrimSpace(w.TargetRef)
 	w.TargetField = strings.TrimSpace(w.TargetField)
 	w.TargetPathRef = strings.TrimSpace(w.TargetPathRef)
 	w.Value.hydrate()
+	w.Key.hydrate()
+	w.Index.hydrate()
 	if err := validateExpressionValue(w.Value); err != nil {
 		return err
+	}
+	if err := validateExpressionValue(w.Key); err != nil {
+		return err
+	}
+	if err := validateExpressionValue(w.Index); err != nil {
+		return err
+	}
+	if w.Operation != "" {
+		if err := hydrateWorkflowDataOperation(w); err != nil {
+			return err
+		}
+		w.SourcePath = paths.Parse(w.Source())
+		w.TargetPath = paths.Parse(w.Target())
+		return nil
+	}
+	if w.TargetRef != "" || !w.Key.IsZero() || !w.Index.IsZero() {
+		return fmt.Errorf("workflow data write target/key/index forms require op")
 	}
 	if w.TargetField != "" && w.TargetPathRef != "" {
 		return fmt.Errorf("workflow data write must not declare both target_field and target_path")
@@ -553,6 +590,51 @@ func hydrateWorkflowDataWrite(w *WorkflowDataWrite) error {
 	}
 	w.SourcePath = paths.Parse(w.Source())
 	w.TargetPath = paths.Parse(w.Target())
+	return nil
+}
+
+func hydrateWorkflowDataOperation(w *WorkflowDataWrite) error {
+	switch w.Operation {
+	case WorkflowDataOperationSet, WorkflowDataOperationMerge, WorkflowDataOperationDelete, WorkflowDataOperationAppend, WorkflowDataOperationUpdate:
+	default:
+		return fmt.Errorf("unsupported workflow data write op %q", strings.TrimSpace(string(w.Operation)))
+	}
+	if w.TargetRef == "" {
+		return fmt.Errorf("workflow data write op %q requires target", w.Operation)
+	}
+	if w.Field != "" || w.SourceField != "" || w.TargetField != "" || w.TargetPathRef != "" {
+		return fmt.Errorf("workflow data write op %q must use target, not field/source_field/target_field/target_path", w.Operation)
+	}
+	if strings.TrimSpace(w.TargetRef) != "" && paths.Parse(w.TargetRef).Root != paths.RootEntity {
+		return fmt.Errorf("workflow data write op %q target %q must use entity scope", w.Operation, w.TargetRef)
+	}
+	switch w.Operation {
+	case WorkflowDataOperationSet, WorkflowDataOperationMerge, WorkflowDataOperationAppend:
+		if w.Value.IsZero() {
+			return fmt.Errorf("workflow data write op %q requires value", w.Operation)
+		}
+	case WorkflowDataOperationDelete:
+		if w.Key.IsZero() {
+			return fmt.Errorf("workflow data write op delete requires key")
+		}
+		if !w.Value.IsZero() || !w.Index.IsZero() {
+			return fmt.Errorf("workflow data write op delete must not declare value or index")
+		}
+	case WorkflowDataOperationUpdate:
+		if w.Value.IsZero() || w.Index.IsZero() {
+			return fmt.Errorf("workflow data write op update requires value and index")
+		}
+	}
+	switch w.Operation {
+	case WorkflowDataOperationSet, WorkflowDataOperationMerge:
+		if w.Key.IsZero() {
+			return fmt.Errorf("workflow data write op %q requires key", w.Operation)
+		}
+	case WorkflowDataOperationAppend:
+		if !w.Index.IsZero() {
+			return fmt.Errorf("workflow data write op append must not declare index")
+		}
+	}
 	return nil
 }
 

--- a/internal/runtime/contracts/workflow_contract_yaml_test.go
+++ b/internal/runtime/contracts/workflow_contract_yaml_test.go
@@ -765,6 +765,69 @@ writes:
 	}
 }
 
+func TestWorkflowDataWriteDecode_PreservesContainedOperationForms(t *testing.T) {
+	var spec WorkflowDataAccumulation
+	if err := yaml.Unmarshal([]byte(`
+writes:
+  - op: append
+    target: entity.verticals.active_jobs
+    key:
+      ref: payload.vertical_id
+    value:
+      ref: payload.job
+  - op: update
+    target: entity.queue
+    index: 0
+    value: reviewed
+`), &spec); err != nil {
+		t.Fatalf("yaml.Unmarshal: %v", err)
+	}
+	if got := len(spec.Writes); got != 2 {
+		t.Fatalf("len(Writes) = %d, want 2", got)
+	}
+	appendWrite := spec.Writes[0]
+	if !appendWrite.IsContainedOperation() {
+		t.Fatal("append write did not decode as contained operation")
+	}
+	if got := appendWrite.Operation; got != WorkflowDataOperationAppend {
+		t.Fatalf("Operation = %q, want append", got)
+	}
+	if got := appendWrite.Target(); got != "entity.verticals.active_jobs" {
+		t.Fatalf("Target() = %q", got)
+	}
+	if got := appendWrite.Key.Ref; got != "payload.vertical_id" {
+		t.Fatalf("Key.Ref = %q", got)
+	}
+	if got := appendWrite.Value.Ref; got != "payload.job" {
+		t.Fatalf("Value.Ref = %q", got)
+	}
+	updateWrite := spec.Writes[1]
+	if got := updateWrite.Index.Literal; got != 0 {
+		t.Fatalf("Index.Literal = %#v, want 0", got)
+	}
+	if got := updateWrite.Value.Literal; got != "reviewed" {
+		t.Fatalf("Value.Literal = %#v, want reviewed", got)
+	}
+}
+
+func TestWorkflowDataWriteDecode_RejectsAmbiguousContainedOperationShape(t *testing.T) {
+	var spec WorkflowDataAccumulation
+	err := yaml.Unmarshal([]byte(`
+writes:
+  - op: append
+    target_path: entity.verticals.active_jobs
+    target: entity.verticals.active_jobs
+    key: north
+    value: job-1
+`), &spec)
+	if err == nil {
+		t.Fatal("expected contained operation target_path ambiguity error")
+	}
+	if !strings.Contains(err.Error(), "must use target") {
+		t.Fatalf("error = %v, want target-only rejection", err)
+	}
+}
+
 func TestWorkflowDataWriteDecode_PreservesTargetPathAuthoring(t *testing.T) {
 	var write WorkflowDataWrite
 	if err := yaml.Unmarshal([]byte(`

--- a/internal/runtime/contracts/workflow_contract_yaml_test.go
+++ b/internal/runtime/contracts/workflow_contract_yaml_test.go
@@ -828,6 +828,36 @@ writes:
 	}
 }
 
+func TestWorkflowDataWriteDecode_RejectsContainedSetOrMergeIndex(t *testing.T) {
+	tests := []struct {
+		name string
+		op   string
+	}{
+		{name: "set", op: "set"},
+		{name: "merge", op: "merge"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var spec WorkflowDataAccumulation
+			err := yaml.Unmarshal([]byte(fmt.Sprintf(`
+writes:
+  - op: %s
+    target: entity.verticals
+    key: north
+    index: 0
+    value:
+      status: active
+`, tc.op)), &spec)
+			if err == nil {
+				t.Fatalf("expected op %s index rejection", tc.op)
+			}
+			if !strings.Contains(err.Error(), "must not declare index") {
+				t.Fatalf("error = %v, want index rejection", err)
+			}
+		})
+	}
+}
+
 func TestWorkflowDataWriteDecode_PreservesTargetPathAuthoring(t *testing.T) {
 	var write WorkflowDataWrite
 	if err := yaml.Unmarshal([]byte(`

--- a/internal/runtime/contracts/workflow_contract_yaml_wave1.go
+++ b/internal/runtime/contracts/workflow_contract_yaml_wave1.go
@@ -945,6 +945,21 @@ func validateWave1TypeRef(raw, context string) error {
 	if strings.HasPrefix(raw, "Optional<") {
 		return fmt.Errorf("RETIRED: %s type %q is not part of the Wave 1 type system", context, raw)
 	}
+	if keyType, valueType, ok := parseWave1MapTypeRef(raw); ok {
+		if keyType == "" || valueType == "" {
+			return fmt.Errorf("%s map type requires key and value types", context)
+		}
+		if strings.HasPrefix(keyType, "[") || strings.HasPrefix(strings.ToLower(keyType), "map[") {
+			return fmt.Errorf("%s map key type %q must be scalar or enum", context, keyType)
+		}
+		if strings.EqualFold(keyType, "object") || strings.EqualFold(keyType, "jsonb") {
+			return fmt.Errorf("RETIRED: %s map key type %q is retired", context, keyType)
+		}
+		if strings.EqualFold(valueType, "object") || strings.EqualFold(valueType, "jsonb") {
+			return fmt.Errorf("RETIRED: %s map value type %q is retired; declare a named type in types.yaml", context, valueType)
+		}
+		return nil
+	}
 	if strings.HasPrefix(raw, "[") && strings.HasSuffix(raw, "]") {
 		inner := strings.TrimSpace(strings.TrimSuffix(strings.TrimPrefix(raw, "["), "]"))
 		if inner == "" {
@@ -956,6 +971,20 @@ func validateWave1TypeRef(raw, context string) error {
 		return nil
 	}
 	return nil
+}
+
+func parseWave1MapTypeRef(raw string) (string, string, bool) {
+	raw = strings.TrimSpace(raw)
+	if !strings.HasPrefix(strings.ToLower(raw), "map[") {
+		return "", "", false
+	}
+	closeIdx := strings.Index(raw, "]")
+	if closeIdx < len("map[]")-1 {
+		return "", "", true
+	}
+	keyType := strings.TrimSpace(raw[len("map["):closeIdx])
+	valueType := strings.TrimSpace(raw[closeIdx+1:])
+	return keyType, valueType, true
 }
 
 func isBuiltinWave1Scalar(raw string) bool {

--- a/internal/runtime/engine/contained_data_operations.go
+++ b/internal/runtime/engine/contained_data_operations.go
@@ -1,0 +1,266 @@
+package engine
+
+import (
+	"fmt"
+	"strings"
+
+	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
+	"github.com/division-sh/swarm/internal/runtime/entityruntime"
+	"github.com/division-sh/swarm/internal/runtime/workflowexpr"
+)
+
+func (e *Executor) applyContainedDataOperation(frame *executionFrame, current BaseContext, write runtimecontracts.WorkflowDataWrite) error {
+	contract, ok := entityruntime.ResolveForFlow(e.deps.Source, frame.req.FlowID.String())
+	if !ok {
+		return fmt.Errorf("flow %s has no declared entity contract", strings.TrimSpace(frame.req.FlowID.String()))
+	}
+	op := strings.TrimSpace(string(write.Operation))
+	target, err := entityruntime.ResolveContainedOperationTarget(contract, write.Target(), op, !write.Key.IsZero(), !write.Index.IsZero())
+	if err != nil {
+		return err
+	}
+
+	key := ""
+	if !write.Key.IsZero() {
+		rawKey, err := evalRequiredDataOperationExpression(current, frame.state, write.Key, "key")
+		if err != nil {
+			return err
+		}
+		key, err = entityruntime.NormalizeContainedOperationKey(contract, target.MapKeyType, rawKey)
+		if err != nil {
+			return err
+		}
+	}
+
+	hasIndex := !write.Index.IsZero()
+	index := 0
+	if hasIndex {
+		rawIndex, err := evalRequiredDataOperationExpression(current, frame.state, write.Index, "index")
+		if err != nil {
+			return err
+		}
+		index, err = entityruntime.NormalizeContainedOperationIndex(rawIndex)
+		if err != nil {
+			return err
+		}
+	}
+
+	var value any
+	if write.Operation != runtimecontracts.WorkflowDataOperationDelete {
+		rawValue, err := evalRequiredDataOperationExpression(current, frame.state, write.Value, "value")
+		if err != nil {
+			return err
+		}
+		value, err = entityruntime.NormalizeContainedOperationValue(contract, target, op, rawValue)
+		if err != nil {
+			return err
+		}
+	}
+
+	if frame.state.State.StateCarrier.Metadata == nil {
+		frame.state.State.StateCarrier.Metadata = map[string]any{}
+	}
+	if err := applyContainedOperationToMetadata(frame.state.State.StateCarrier.Metadata, target, op, key, hasIndex, index, value); err != nil {
+		return err
+	}
+	frame.result.StateMutation.StateCarrier.Metadata = cloneStringAnyMap(frame.state.State.StateCarrier.Metadata)
+	return nil
+}
+
+func evalRequiredDataOperationExpression(base BaseContext, state ExecutionState, expr runtimecontracts.ExpressionValue, label string) (any, error) {
+	value, ok, err := evalExpressionValue(base, state, expr, workflowexpr.ValueExpressionOptions{})
+	if err != nil {
+		return nil, err
+	}
+	if !ok {
+		return nil, fmt.Errorf("%s expression did not resolve", strings.TrimSpace(label))
+	}
+	return value, nil
+}
+
+func applyContainedOperationToMetadata(metadata map[string]any, target entityruntime.ContainedOperationTarget, op, key string, hasIndex bool, index int, value any) error {
+	if target.MapScoped {
+		return applyMapScopedOperation(metadata, target, op, key, hasIndex, index, value)
+	}
+	return applyListScopedOperation(metadata, target, op, hasIndex, index, value)
+}
+
+func applyMapScopedOperation(metadata map[string]any, target entityruntime.ContainedOperationTarget, op, key string, hasIndex bool, index int, value any) error {
+	root, ok := metadata[target.RootField].(map[string]any)
+	if !ok || root == nil {
+		if op != entityruntime.ContainedOperationSet || len(target.MapValuePath) != 0 {
+			return fmt.Errorf("map field %s is missing or not a map", target.RootField)
+		}
+		root = map[string]any{}
+		metadata[target.RootField] = root
+	}
+
+	switch op {
+	case entityruntime.ContainedOperationSet:
+		if len(target.MapValuePath) == 0 {
+			root[key] = value
+			return nil
+		}
+		entry, ok := root[key].(map[string]any)
+		if !ok || entry == nil {
+			return fmt.Errorf("map key %q does not exist", key)
+		}
+		setNestedMapValue(entry, target.MapValuePath, value)
+		return nil
+	case entityruntime.ContainedOperationMerge:
+		targetMap, err := mapScopedObjectTarget(root, key, target.MapValuePath)
+		if err != nil {
+			return err
+		}
+		for mergeKey, mergeValue := range value.(map[string]any) {
+			targetMap[mergeKey] = mergeValue
+		}
+		return nil
+	case entityruntime.ContainedOperationDelete:
+		if _, exists := root[key]; !exists {
+			return fmt.Errorf("map key %q does not exist", key)
+		}
+		delete(root, key)
+		return nil
+	case entityruntime.ContainedOperationAppend, entityruntime.ContainedOperationUpdate:
+		list, setter, err := mapScopedListTarget(root, key, target.MapValuePath)
+		if err != nil {
+			return err
+		}
+		next, err := applyListMutation(list, op, hasIndex, index, value)
+		if err != nil {
+			return err
+		}
+		setter(next)
+		return nil
+	default:
+		return fmt.Errorf("unsupported contained operation %q", op)
+	}
+}
+
+func applyListScopedOperation(metadata map[string]any, target entityruntime.ContainedOperationTarget, op string, hasIndex bool, index int, value any) error {
+	path := strings.Split(target.Path, ".")
+	list, setter, err := metadataListTarget(metadata, path, op == entityruntime.ContainedOperationAppend)
+	if err != nil {
+		return err
+	}
+	next, err := applyListMutation(list, op, hasIndex, index, value)
+	if err != nil {
+		return err
+	}
+	setter(next)
+	return nil
+}
+
+func applyListMutation(list []any, op string, hasIndex bool, index int, value any) ([]any, error) {
+	switch op {
+	case entityruntime.ContainedOperationAppend:
+		return append(list, value), nil
+	case entityruntime.ContainedOperationUpdate:
+		if !hasIndex {
+			return nil, fmt.Errorf("op update requires index")
+		}
+		if index >= len(list) {
+			return nil, fmt.Errorf("list index %d is missing", index)
+		}
+		next := append([]any(nil), list...)
+		next[index] = value
+		return next, nil
+	default:
+		return nil, fmt.Errorf("op %s is not a list operation", op)
+	}
+}
+
+func mapScopedObjectTarget(root map[string]any, key string, path []string) (map[string]any, error) {
+	entry, ok := root[key].(map[string]any)
+	if !ok || entry == nil {
+		return nil, fmt.Errorf("map key %q does not exist", key)
+	}
+	if len(path) == 0 {
+		return entry, nil
+	}
+	current := entry
+	for _, segment := range path {
+		segment = strings.TrimSpace(segment)
+		next, ok := current[segment].(map[string]any)
+		if !ok || next == nil {
+			return nil, fmt.Errorf("map key %q path %s is missing or not an object", key, strings.Join(path, "."))
+		}
+		current = next
+	}
+	return current, nil
+}
+
+func mapScopedListTarget(root map[string]any, key string, path []string) ([]any, func([]any), error) {
+	if len(path) == 0 {
+		list, ok := root[key].([]any)
+		if !ok {
+			return nil, nil, fmt.Errorf("map key %q is missing or not a list", key)
+		}
+		return list, func(next []any) { root[key] = next }, nil
+	}
+	entry, ok := root[key].(map[string]any)
+	if !ok || entry == nil {
+		return nil, nil, fmt.Errorf("map key %q does not exist", key)
+	}
+	return nestedListTarget(entry, path, false)
+}
+
+func metadataListTarget(metadata map[string]any, path []string, createLeaf bool) ([]any, func([]any), error) {
+	return nestedListTarget(metadata, path, createLeaf)
+}
+
+func nestedListTarget(root map[string]any, path []string, createLeaf bool) ([]any, func([]any), error) {
+	if len(path) == 0 {
+		return nil, nil, fmt.Errorf("list path is required")
+	}
+	if len(path) == 1 {
+		leaf := strings.TrimSpace(path[0])
+		raw, ok := root[leaf]
+		if !ok && createLeaf {
+			list := []any{}
+			root[leaf] = list
+			return list, func(next []any) { root[leaf] = next }, nil
+		}
+		list, ok := raw.([]any)
+		if !ok {
+			return nil, nil, fmt.Errorf("path %s is missing or not a list", strings.Join(path, "."))
+		}
+		return list, func(next []any) { root[leaf] = next }, nil
+	}
+	current := root
+	for _, segment := range path[:len(path)-1] {
+		segment = strings.TrimSpace(segment)
+		next, ok := current[segment].(map[string]any)
+		if !ok || next == nil {
+			return nil, nil, fmt.Errorf("path %s is missing or not an object", strings.Join(path, "."))
+		}
+		current = next
+	}
+	leaf := strings.TrimSpace(path[len(path)-1])
+	raw, ok := current[leaf]
+	if !ok && createLeaf {
+		list := []any{}
+		current[leaf] = list
+		return list, func(next []any) { current[leaf] = next }, nil
+	}
+	list, ok := raw.([]any)
+	if !ok {
+		return nil, nil, fmt.Errorf("path %s is missing or not a list", strings.Join(path, "."))
+	}
+	return list, func(next []any) { current[leaf] = next }, nil
+}
+
+func setNestedMapValue(root map[string]any, path []string, value any) {
+	current := root
+	for _, segment := range path[:len(path)-1] {
+		segment = strings.TrimSpace(segment)
+		next, _ := current[segment].(map[string]any)
+		if next == nil {
+			next = map[string]any{}
+			current[segment] = next
+		}
+		current = next
+	}
+	current[strings.TrimSpace(path[len(path)-1])] = value
+}

--- a/internal/runtime/engine/executor.go
+++ b/internal/runtime/engine/executor.go
@@ -241,6 +241,16 @@ func validateHandlerEntityWriteTargets(source semanticview.Source, flowID string
 	}
 	validateWrites := func(kind string, writes []runtimecontracts.WorkflowDataWrite) error {
 		for _, write := range writes {
+			if write.IsContainedOperation() {
+				contract, ok := entityruntime.ResolveForFlow(source, flowID)
+				if !ok {
+					return fmt.Errorf("%s target %q: flow %s has no declared entity contract", kind, write.Target(), strings.TrimSpace(flowID))
+				}
+				if _, err := entityruntime.ResolveContainedOperationTarget(contract, write.Target(), string(write.Operation), !write.Key.IsZero(), !write.Index.IsZero()); err != nil {
+					return fmt.Errorf("%s target %q: %w", kind, write.Target(), err)
+				}
+				continue
+			}
 			if err := validateTarget(kind, write.Target()); err != nil {
 				return err
 			}
@@ -1598,14 +1608,29 @@ func (e *Executor) emitPersistencePrerequisites(frame executionFrame) EmitPersis
 		seen[field] = len(fields)
 		fields = append(fields, prerequisite)
 	}
+	appendWrite := func(write runtimecontracts.WorkflowDataWrite) {
+		if write.IsContainedOperation() {
+			contract, ok := entityruntime.ResolveForFlow(e.deps.Source, frame.req.FlowID.String())
+			if !ok {
+				return
+			}
+			target, err := entityruntime.ResolveContainedOperationTarget(contract, write.Target(), string(write.Operation), !write.Key.IsZero(), !write.Index.IsZero())
+			if err != nil {
+				return
+			}
+			appendField("entity." + target.RootField)
+			return
+		}
+		appendField(write.Target())
+	}
 	if frame.topLevelDataWritesApplied {
 		for _, write := range frame.topLevelDataAccumulation.Writes {
-			appendField(write.Target())
+			appendWrite(write)
 		}
 	}
 	if frame.rule != nil {
 		for _, write := range frame.rule.DataAccumulation.Writes {
-			appendField(write.Target())
+			appendWrite(write)
 		}
 	}
 	if spec := e.selectedCompute(&frame); spec != nil {
@@ -1923,6 +1948,12 @@ func (e *Executor) applyRule(frame *executionFrame, rule *runtimecontracts.Handl
 func (e *Executor) applyDataAccumulation(frame *executionFrame, spec runtimecontracts.WorkflowDataAccumulation) error {
 	current := e.currentContext(frame)
 	for _, write := range spec.Writes {
+		if write.IsContainedOperation() {
+			if err := e.applyContainedDataOperation(frame, current, write); err != nil {
+				return fmt.Errorf("data_accumulation target %s: %w", strings.TrimSpace(write.Target()), err)
+			}
+			continue
+		}
 		target := strings.TrimSpace(write.Target())
 		if target == "" {
 			continue

--- a/internal/runtime/engine/executor_test.go
+++ b/internal/runtime/engine/executor_test.go
@@ -90,12 +90,26 @@ func stubSourceWithRootEntityContract() semanticview.Source {
 						"report_count": {Type: "integer"},
 					},
 				},
+				"VerticalState": {
+					Fields: map[string]runtimecontracts.TypeFieldSpec{
+						"status":      {Type: "text"},
+						"active_jobs": {Type: "[Job]"},
+					},
+				},
+				"Job": {
+					Fields: map[string]runtimecontracts.TypeFieldSpec{
+						"id":    {Type: "text"},
+						"title": {Type: "text"},
+					},
+				},
 			},
 		},
 		RootEntities: runtimecontracts.EntityContractsDocument{
 			"subject": {
 				Fields: map[string]runtimecontracts.EntityFieldDecl{
-					"analysis": {Type: "Analysis"},
+					"analysis":  {Type: "Analysis"},
+					"verticals": {Type: "map[text]VerticalState"},
+					"tags":      {Type: "[text]"},
 				},
 			},
 		},
@@ -2347,6 +2361,153 @@ func TestExecutor_DataAccumulationTargetPathWritesNestedEntityLeaf(t *testing.T)
 	}
 	if got := analysis["report_count"]; got != 2 {
 		t.Fatalf("analysis.report_count = %#v, want 2", got)
+	}
+}
+
+func TestExecutor_DataAccumulationAppliesTypedContainedOperations(t *testing.T) {
+	exec, err := NewExecutor(RuntimeDependencies{
+		Source:     stubSourceWithRootEntityContract(),
+		StateRepo:  stubStateRepo{},
+		TxRunner:   stubRunner{},
+		Locker:     stubLocker{},
+		Outbox:     stubOutbox{},
+		Dispatcher: stubDispatcher{},
+	}, nil)
+	if err != nil {
+		t.Fatalf("NewExecutor error: %v", err)
+	}
+	result, err := exec.Execute(context.Background(), ExecutionRequest{
+		EntityID: "entity-1",
+		NodeID:   "node-1",
+		Event: eventtest.RootIngress(
+			"evt-1",
+			"job.received",
+			"",
+			"",
+			json.RawMessage(`{"vertical_id":"north","job":{"id":"job-1","title":"Build"}}`),
+			0,
+			"",
+			"",
+			events.EventEnvelope{},
+			time.Time{},
+		),
+		Handler: runtimecontracts.SystemNodeEventHandler{
+			DataAccumulation: runtimecontracts.WorkflowDataAccumulation{
+				Writes: []runtimecontracts.WorkflowDataWrite{
+					{
+						Operation: runtimecontracts.WorkflowDataOperationSet,
+						TargetRef: "entity.verticals",
+						Key:       runtimecontracts.LiteralExpression("north"),
+						Value: runtimecontracts.LiteralExpression(map[string]any{
+							"status":      "active",
+							"active_jobs": []any{},
+						}),
+					},
+					{
+						Operation: runtimecontracts.WorkflowDataOperationMerge,
+						TargetRef: "entity.verticals",
+						Key:       runtimecontracts.LiteralExpression("north"),
+						Value: runtimecontracts.LiteralExpression(map[string]any{
+							"status": "busy",
+						}),
+					},
+					{
+						Operation: runtimecontracts.WorkflowDataOperationAppend,
+						TargetRef: "entity.verticals.active_jobs",
+						Key:       runtimecontracts.RefExpression("payload.vertical_id"),
+						Value:     runtimecontracts.RefExpression("payload.job"),
+					},
+					{
+						Operation: runtimecontracts.WorkflowDataOperationUpdate,
+						TargetRef: "entity.tags",
+						Index:     runtimecontracts.LiteralExpression(1),
+						Value:     runtimecontracts.LiteralExpression("gold"),
+					},
+					{
+						Operation: runtimecontracts.WorkflowDataOperationAppend,
+						TargetRef: "entity.tags",
+						Value:     runtimecontracts.LiteralExpression("vip"),
+					},
+					{
+						Operation: runtimecontracts.WorkflowDataOperationDelete,
+						TargetRef: "entity.verticals",
+						Key:       runtimecontracts.LiteralExpression("obsolete"),
+					},
+				},
+			},
+		},
+		State: testStateSnapshot("pending", map[string]any{
+			"verticals": map[string]any{
+				"obsolete": map[string]any{"status": "old", "active_jobs": []any{}},
+			},
+			"tags": []any{"new", "silver"},
+		}, nil, map[string]map[string]any{}),
+	})
+	if err != nil {
+		t.Fatalf("Execute error: %v", err)
+	}
+
+	verticals, ok := result.StateMutation.Metadata["verticals"].(map[string]any)
+	if !ok {
+		t.Fatalf("verticals = %#v", result.StateMutation.Metadata["verticals"])
+	}
+	if _, exists := verticals["obsolete"]; exists {
+		t.Fatalf("obsolete key survived delete: %#v", verticals)
+	}
+	north, ok := verticals["north"].(map[string]any)
+	if !ok {
+		t.Fatalf("verticals.north = %#v", verticals["north"])
+	}
+	if got := north["status"]; got != "busy" {
+		t.Fatalf("verticals.north.status = %#v, want busy", got)
+	}
+	jobs, ok := north["active_jobs"].([]any)
+	if !ok || len(jobs) != 1 {
+		t.Fatalf("verticals.north.active_jobs = %#v", north["active_jobs"])
+	}
+	job, ok := jobs[0].(map[string]any)
+	if !ok || job["id"] != "job-1" || job["title"] != "Build" {
+		t.Fatalf("active job = %#v", jobs[0])
+	}
+	if !reflect.DeepEqual(result.StateMutation.Metadata["tags"], []any{"new", "gold", "vip"}) {
+		t.Fatalf("tags = %#v", result.StateMutation.Metadata["tags"])
+	}
+}
+
+func TestExecutor_DataAccumulationContainedOperationRejectsMissingMapKey(t *testing.T) {
+	exec, err := NewExecutor(RuntimeDependencies{
+		Source:     stubSourceWithRootEntityContract(),
+		StateRepo:  stubStateRepo{},
+		TxRunner:   stubRunner{},
+		Locker:     stubLocker{},
+		Outbox:     stubOutbox{},
+		Dispatcher: stubDispatcher{},
+	}, nil)
+	if err != nil {
+		t.Fatalf("NewExecutor error: %v", err)
+	}
+	_, err = exec.Execute(context.Background(), ExecutionRequest{
+		EntityID: "entity-1",
+		NodeID:   "node-1",
+		Event:    eventtest.RootIngress("evt-1", "job.received", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}),
+		Handler: runtimecontracts.SystemNodeEventHandler{
+			DataAccumulation: runtimecontracts.WorkflowDataAccumulation{
+				Writes: []runtimecontracts.WorkflowDataWrite{{
+					Operation: runtimecontracts.WorkflowDataOperationDelete,
+					TargetRef: "entity.verticals",
+					Key:       runtimecontracts.LiteralExpression("missing"),
+				}},
+			},
+		},
+		State: testStateSnapshot("pending", map[string]any{
+			"verticals": map[string]any{},
+		}, nil, map[string]map[string]any{}),
+	})
+	if err == nil {
+		t.Fatal("expected missing map key failure")
+	}
+	if !strings.Contains(err.Error(), `map key "missing" does not exist`) {
+		t.Fatalf("error = %v, want missing-key context", err)
 	}
 }
 

--- a/internal/runtime/engine/executor_test.go
+++ b/internal/runtime/engine/executor_test.go
@@ -2511,6 +2511,58 @@ func TestExecutor_DataAccumulationContainedOperationRejectsMissingMapKey(t *test
 	}
 }
 
+func TestExecutor_DataAccumulationRejectsContainedSetOrMergeIndex(t *testing.T) {
+	exec, err := NewExecutor(RuntimeDependencies{
+		Source:     stubSourceWithRootEntityContract(),
+		StateRepo:  stubStateRepo{},
+		TxRunner:   stubRunner{},
+		Locker:     stubLocker{},
+		Outbox:     stubOutbox{},
+		Dispatcher: stubDispatcher{},
+	}, nil)
+	if err != nil {
+		t.Fatalf("NewExecutor error: %v", err)
+	}
+	tests := []struct {
+		name string
+		op   runtimecontracts.WorkflowDataOperation
+	}{
+		{name: "set", op: runtimecontracts.WorkflowDataOperationSet},
+		{name: "merge", op: runtimecontracts.WorkflowDataOperationMerge},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := exec.Execute(context.Background(), ExecutionRequest{
+				EntityID: "entity-1",
+				NodeID:   "node-1",
+				Event:    eventtest.RootIngress("evt-1", "job.received", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}),
+				Handler: runtimecontracts.SystemNodeEventHandler{
+					DataAccumulation: runtimecontracts.WorkflowDataAccumulation{
+						Writes: []runtimecontracts.WorkflowDataWrite{{
+							Operation: tc.op,
+							TargetRef: "entity.verticals",
+							Key:       runtimecontracts.LiteralExpression("north"),
+							Index:     runtimecontracts.LiteralExpression(0),
+							Value: runtimecontracts.LiteralExpression(map[string]any{
+								"status": "active",
+							}),
+						}},
+					},
+				},
+				State: testStateSnapshot("pending", map[string]any{
+					"verticals": map[string]any{},
+				}, nil, map[string]map[string]any{}),
+			})
+			if err == nil {
+				t.Fatal("expected contained operation index rejection")
+			}
+			if !strings.Contains(err.Error(), "must not declare index") {
+				t.Fatalf("error = %v, want index rejection", err)
+			}
+		})
+	}
+}
+
 func TestExecutor_RejectsUndeclaredNestedEntityWriteBeforeExecution(t *testing.T) {
 	exec, err := NewExecutor(RuntimeDependencies{
 		Source:     stubSourceWithRootEntityContract(),

--- a/internal/runtime/engine/helpers.go
+++ b/internal/runtime/engine/helpers.go
@@ -188,6 +188,9 @@ func applyDataAccumulationToState(base BaseContext, state ExecutionState, snapsh
 		snapshot.StateCarrier.Metadata = map[string]any{}
 	}
 	for _, write := range spec.Writes {
+		if write.IsContainedOperation() {
+			return fmt.Errorf("data_accumulation target %s: contained operations require semantic source validation", strings.TrimSpace(write.Target()))
+		}
 		target := strings.TrimSpace(write.Target())
 		if target == "" {
 			continue

--- a/internal/runtime/entityruntime/contained_operations.go
+++ b/internal/runtime/entityruntime/contained_operations.go
@@ -180,9 +180,15 @@ func validateOperationTargetKind(contract Contract, target ContainedOperationTar
 		if !target.MapScoped {
 			return "", fmt.Errorf("op set requires a map key")
 		}
+		if hasIndex {
+			return "", fmt.Errorf("op set must not declare index")
+		}
 	case ContainedOperationMerge:
 		if !target.MapScoped {
 			return "", fmt.Errorf("op merge requires a map key")
+		}
+		if hasIndex {
+			return "", fmt.Errorf("op merge must not declare index")
 		}
 		if !isNamedType(contract, target.TargetType) && !isJSONObjectType(contract, target.TargetType) {
 			return "", fmt.Errorf("op merge target %s must resolve to an object type", target.Path)

--- a/internal/runtime/entityruntime/contained_operations.go
+++ b/internal/runtime/entityruntime/contained_operations.go
@@ -1,0 +1,278 @@
+package entityruntime
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/division-sh/swarm/internal/runtime/core/paths"
+)
+
+const (
+	ContainedOperationSet    = "set"
+	ContainedOperationMerge  = "merge"
+	ContainedOperationDelete = "delete"
+	ContainedOperationAppend = "append"
+	ContainedOperationUpdate = "update"
+)
+
+type ContainedOperationTarget struct {
+	Raw          string
+	Path         string
+	RootField    string
+	MapKeyType   string
+	MapValueType string
+	MapValuePath []string
+	TargetType   string
+	ListItemType string
+	MapScoped    bool
+}
+
+func ResolveContainedOperationTarget(contract Contract, target, op string, hasKey, hasIndex bool) (ContainedOperationTarget, error) {
+	op = strings.TrimSpace(op)
+	target = strings.TrimSpace(target)
+	if target == "" {
+		return ContainedOperationTarget{}, fmt.Errorf("target is required")
+	}
+	if strings.Contains(target, "[") || strings.Contains(target, "]") {
+		return ContainedOperationTarget{}, fmt.Errorf("dynamic bracket path syntax is not supported for contained operation targets")
+	}
+	parsed := paths.Parse(target)
+	if parsed.Root != paths.RootEntity {
+		return ContainedOperationTarget{}, fmt.Errorf("target %q must use entity scope", target)
+	}
+	if len(parsed.Segments) == 0 {
+		return ContainedOperationTarget{}, fmt.Errorf("target field is required")
+	}
+	rootField := strings.TrimSpace(parsed.Segments[0])
+	if rootField == "" {
+		return ContainedOperationTarget{}, fmt.Errorf("target field is required")
+	}
+
+	if hasKey {
+		return resolveMapScopedOperationTarget(contract, target, op, parsed.Segments, hasIndex)
+	}
+	return resolveListScopedOperationTarget(contract, target, op, parsed.Segments, hasIndex)
+}
+
+func NormalizeContainedOperationValue(contract Contract, target ContainedOperationTarget, op string, value any) (any, error) {
+	op = strings.TrimSpace(op)
+	switch op {
+	case ContainedOperationSet:
+		return normalizeValueForType(contract, target.Path, target.TargetType, value)
+	case ContainedOperationMerge:
+		return normalizePartialObjectValue(contract, target.Path, target.TargetType, value)
+	case ContainedOperationAppend, ContainedOperationUpdate:
+		return normalizeValueForType(contract, target.Path, target.ListItemType, value)
+	default:
+		return nil, fmt.Errorf("unsupported contained operation %q", op)
+	}
+}
+
+func NormalizeContainedOperationKey(contract Contract, keyType string, value any) (string, error) {
+	keyType = strings.TrimSpace(typeName(contract, keyType))
+	switch {
+	case isTextType(keyType), isUUIDType(contract, keyType), isEnumType(contract, keyType):
+		normalized, err := normalizeValueForType(contract, "", keyType, value)
+		if err != nil {
+			return "", err
+		}
+		key := strings.TrimSpace(fmt.Sprint(normalized))
+		if key == "" {
+			return "", fmt.Errorf("map key cannot be empty")
+		}
+		return key, nil
+	default:
+		return "", fmt.Errorf("map key type %s is unsupported; use text, uuid, or enum", keyType)
+	}
+}
+
+func NormalizeContainedOperationIndex(value any) (int, error) {
+	switch typed := value.(type) {
+	case int:
+		if typed < 0 {
+			return 0, fmt.Errorf("list index cannot be negative")
+		}
+		return typed, nil
+	case int64:
+		if typed < 0 {
+			return 0, fmt.Errorf("list index cannot be negative")
+		}
+		return int(typed), nil
+	case float64:
+		if typed < 0 || typed != float64(int(typed)) {
+			return 0, fmt.Errorf("list index must be a non-negative integer")
+		}
+		return int(typed), nil
+	case string:
+		raw := strings.TrimSpace(typed)
+		if raw == "" {
+			return 0, fmt.Errorf("list index is required")
+		}
+		parsed, err := strconv.Atoi(raw)
+		if err != nil || parsed < 0 {
+			return 0, fmt.Errorf("list index must be a non-negative integer")
+		}
+		return parsed, nil
+	default:
+		return 0, fmt.Errorf("list index must be a non-negative integer")
+	}
+}
+
+func resolveMapScopedOperationTarget(contract Contract, rawTarget, op string, segments []string, hasIndex bool) (ContainedOperationTarget, error) {
+	rootField := strings.TrimSpace(segments[0])
+	rootDecl, err := FieldDecl(contract, rootField)
+	if err != nil {
+		return ContainedOperationTarget{}, err
+	}
+	keyType, valueType, ok := MapTypeParts(rootDecl.Type)
+	if !ok || strings.TrimSpace(keyType) == "" || strings.TrimSpace(valueType) == "" {
+		return ContainedOperationTarget{}, fmt.Errorf("target %s is not a declared map field", rootField)
+	}
+	out := ContainedOperationTarget{
+		Raw:          strings.TrimSpace(rawTarget),
+		Path:         strings.Join(segments, "."),
+		RootField:    rootField,
+		MapKeyType:   keyType,
+		MapValueType: valueType,
+		MapValuePath: append([]string(nil), segments[1:]...),
+		TargetType:   valueType,
+		MapScoped:    true,
+	}
+	if len(out.MapValuePath) > 0 {
+		resolvedType, err := resolveTypePath(contract, valueType, out.MapValuePath)
+		if err != nil {
+			return ContainedOperationTarget{}, err
+		}
+		out.TargetType = resolvedType
+	}
+	itemType, err := validateOperationTargetKind(contract, out, op, hasIndex)
+	if err != nil {
+		return ContainedOperationTarget{}, err
+	}
+	out.ListItemType = itemType
+	return out, nil
+}
+
+func resolveListScopedOperationTarget(contract Contract, rawTarget, op string, segments []string, hasIndex bool) (ContainedOperationTarget, error) {
+	path := strings.Join(segments, ".")
+	field, err := ResolveFieldPath(contract, path)
+	if err != nil {
+		return ContainedOperationTarget{}, err
+	}
+	out := ContainedOperationTarget{
+		Raw:        strings.TrimSpace(rawTarget),
+		Path:       path,
+		RootField:  strings.TrimSpace(segments[0]),
+		TargetType: field.Type,
+	}
+	itemType, err := validateOperationTargetKind(contract, out, op, hasIndex)
+	if err != nil {
+		return ContainedOperationTarget{}, err
+	}
+	out.ListItemType = itemType
+	return out, nil
+}
+
+func validateOperationTargetKind(contract Contract, target ContainedOperationTarget, op string, hasIndex bool) (string, error) {
+	switch strings.TrimSpace(op) {
+	case ContainedOperationSet:
+		if !target.MapScoped {
+			return "", fmt.Errorf("op set requires a map key")
+		}
+	case ContainedOperationMerge:
+		if !target.MapScoped {
+			return "", fmt.Errorf("op merge requires a map key")
+		}
+		if !isNamedType(contract, target.TargetType) && !isJSONObjectType(contract, target.TargetType) {
+			return "", fmt.Errorf("op merge target %s must resolve to an object type", target.Path)
+		}
+	case ContainedOperationDelete:
+		if !target.MapScoped {
+			return "", fmt.Errorf("op delete requires a map key")
+		}
+		if len(target.MapValuePath) > 0 {
+			return "", fmt.Errorf("op delete removes map entries only; target %s must be the map field", target.Path)
+		}
+	case ContainedOperationAppend, ContainedOperationUpdate:
+		if !isListType(target.TargetType) && !isJSONArrayType(contract, target.TargetType) {
+			return "", fmt.Errorf("op %s target %s must resolve to a list", op, target.Path)
+		}
+		if strings.TrimSpace(op) == ContainedOperationUpdate && !hasIndex {
+			return "", fmt.Errorf("op update requires index")
+		}
+		_, itemType, err := listElementType(contract, target.TargetType)
+		if err != nil {
+			return "", err
+		}
+		return itemType, nil
+	default:
+		return "", fmt.Errorf("unsupported contained operation %q", op)
+	}
+	return "", nil
+}
+
+func resolveTypePath(contract Contract, typeRef string, segments []string) (string, error) {
+	currentType := strings.TrimSpace(typeRef)
+	for _, segment := range segments {
+		segment = strings.TrimSpace(segment)
+		if segment == "" {
+			return "", fmt.Errorf("field is required")
+		}
+		named, ok := contract.Types.Types[typeName(contract, currentType)]
+		if !ok {
+			return "", fmt.Errorf("path does not resolve through a named type")
+		}
+		spec, ok := named.Fields[segment]
+		if !ok {
+			return "", fmt.Errorf("undeclared path segment %s", segment)
+		}
+		currentType = strings.TrimSpace(spec.Type)
+	}
+	return currentType, nil
+}
+
+func normalizePartialObjectValue(contract Contract, fieldName, typeRef string, value any) (map[string]any, error) {
+	object, ok := value.(map[string]any)
+	if !ok {
+		return nil, fieldTypeError(fieldName, "must be object")
+	}
+	if isJSONObjectType(contract, typeRef) {
+		return cloneMap(object), nil
+	}
+	named, ok := contract.Types.Types[typeName(contract, typeRef)]
+	if !ok {
+		return nil, fieldTypeError(fieldName, "must be object")
+	}
+	out := make(map[string]any, len(object))
+	for key, raw := range object {
+		key = strings.TrimSpace(key)
+		if key == "" {
+			continue
+		}
+		spec, ok := named.Fields[key]
+		if !ok {
+			return nil, fieldTypeError(joinFieldName(fieldName, key), "is undeclared")
+		}
+		normalized, err := normalizeValueForType(contract, joinFieldName(fieldName, key), spec.Type, raw)
+		if err != nil {
+			return nil, err
+		}
+		out[key] = normalized
+	}
+	return out, nil
+}
+
+func listElementType(contract Contract, typeRef string) (bool, string, error) {
+	if isJSONArrayType(contract, typeRef) {
+		return true, "json", nil
+	}
+	if !isListType(typeRef) {
+		return false, "", fmt.Errorf("type %s is not a list", typeRef)
+	}
+	itemType := listItemType(typeRef)
+	if strings.TrimSpace(itemType) == "" {
+		return false, "", fmt.Errorf("list item type is required")
+	}
+	return true, itemType, nil
+}

--- a/internal/runtime/entityruntime/contracts.go
+++ b/internal/runtime/entityruntime/contracts.go
@@ -496,6 +496,8 @@ func defaultValue(contract Contract, typeRef string, explicit any) (any, error) 
 	}
 	typeRef = strings.TrimSpace(typeRef)
 	switch {
+	case isMapType(typeRef):
+		return map[string]any{}, nil
 	case isListType(typeRef):
 		return []any{}, nil
 	case isTextType(typeRef):
@@ -548,6 +550,28 @@ func normalizeValueForType(contract Contract, fieldName, typeRef string, value a
 		}
 	}
 	switch {
+	case isMapType(typeRef):
+		object, ok := value.(map[string]any)
+		if !ok {
+			return nil, fieldTypeError(fieldName, "must be map")
+		}
+		_, valueType, ok := MapTypeParts(typeRef)
+		if !ok {
+			return nil, fieldTypeError(fieldName, "has unsupported map type "+typeRef)
+		}
+		out := make(map[string]any, len(object))
+		for key, raw := range object {
+			key = strings.TrimSpace(key)
+			if key == "" {
+				return nil, fieldTypeError(fieldName, "map key cannot be empty")
+			}
+			normalized, err := normalizeValueForType(contract, joinFieldName(fieldName, key), valueType, raw)
+			if err != nil {
+				return nil, err
+			}
+			out[key] = normalized
+		}
+		return out, nil
 	case isListType(typeRef):
 		items, ok := listValues(value)
 		if !ok {
@@ -701,6 +725,8 @@ func pathKind(contract Contract, typeRef string) string {
 		return "enum"
 	case isNamedType(contract, typeRef):
 		return "object"
+	case isMapType(typeRef):
+		return "map"
 	case isListType(typeRef):
 		return "list"
 	default:
@@ -771,6 +797,28 @@ func isJSONObjectType(contract Contract, typeRef string) bool {
 
 func isJSONArrayType(contract Contract, typeRef string) bool {
 	return strings.EqualFold(typeName(contract, typeRef), "array")
+}
+
+func isMapType(typeRef string) bool {
+	_, _, ok := MapTypeParts(typeRef)
+	return ok
+}
+
+func MapTypeParts(typeRef string) (string, string, bool) {
+	typeRef = strings.TrimSpace(typeRef)
+	if !strings.HasPrefix(strings.ToLower(typeRef), "map[") {
+		return "", "", false
+	}
+	closeIdx := strings.Index(typeRef, "]")
+	if closeIdx <= len("map[") {
+		return "", "", false
+	}
+	keyType := strings.TrimSpace(typeRef[len("map["):closeIdx])
+	valueType := strings.TrimSpace(typeRef[closeIdx+1:])
+	if keyType == "" || valueType == "" {
+		return "", "", false
+	}
+	return keyType, valueType, true
 }
 
 func isTimestampType(contract Contract, typeRef string) bool {

--- a/internal/runtime/entityruntime/contracts_test.go
+++ b/internal/runtime/entityruntime/contracts_test.go
@@ -111,3 +111,83 @@ func TestMaterialize_AcceptsBracketFormListRefs(t *testing.T) {
 		t.Fatalf("NormalizeFieldValue(spec.features undeclared field) = nil, want named-type field error")
 	}
 }
+
+func TestContainedOperationTarget_ResolvesTypedMapAndListOperations(t *testing.T) {
+	contract := Contract{
+		Entity: runtimecontracts.EntityContract{
+			Fields: map[string]runtimecontracts.EntityFieldDecl{
+				"verticals": {Type: "map[text]VerticalState"},
+				"queue":     {Type: "[Job]"},
+			},
+		},
+		Types: runtimecontracts.TypeCatalogDocument{
+			Types: map[string]runtimecontracts.NamedTypeDecl{
+				"VerticalState": {
+					Fields: map[string]runtimecontracts.TypeFieldSpec{
+						"status":      {Type: "text"},
+						"active_jobs": {Type: "[Job]"},
+					},
+				},
+				"Job": {
+					Fields: map[string]runtimecontracts.TypeFieldSpec{
+						"id":    {Type: "text"},
+						"title": {Type: "text"},
+					},
+				},
+			},
+		},
+	}
+
+	target, err := ResolveContainedOperationTarget(contract, "entity.verticals.active_jobs", string(ContainedOperationAppend), true, false)
+	if err != nil {
+		t.Fatalf("ResolveContainedOperationTarget(map append): %v", err)
+	}
+	if !target.MapScoped || target.RootField != "verticals" || target.ListItemType != "Job" {
+		t.Fatalf("target = %+v, want map-scoped verticals active_jobs list", target)
+	}
+	value, err := NormalizeContainedOperationValue(contract, target, string(ContainedOperationAppend), map[string]any{"id": "job-1", "title": "Build"})
+	if err != nil {
+		t.Fatalf("NormalizeContainedOperationValue(append): %v", err)
+	}
+	if !reflect.DeepEqual(value, map[string]any{"id": "job-1", "title": "Build"}) {
+		t.Fatalf("value = %#v", value)
+	}
+
+	listTarget, err := ResolveContainedOperationTarget(contract, "entity.queue", string(ContainedOperationUpdate), false, true)
+	if err != nil {
+		t.Fatalf("ResolveContainedOperationTarget(list update): %v", err)
+	}
+	if listTarget.MapScoped || listTarget.ListItemType != "Job" {
+		t.Fatalf("list target = %+v, want direct Job list", listTarget)
+	}
+}
+
+func TestContainedOperationTarget_FailsClosedForDynamicPathAndWrongShape(t *testing.T) {
+	contract := Contract{
+		Entity: runtimecontracts.EntityContract{
+			Fields: map[string]runtimecontracts.EntityFieldDecl{
+				"verticals": {Type: "map[text]VerticalState"},
+			},
+		},
+		Types: runtimecontracts.TypeCatalogDocument{
+			Types: map[string]runtimecontracts.NamedTypeDecl{
+				"VerticalState": {
+					Fields: map[string]runtimecontracts.TypeFieldSpec{
+						"status": {Type: "text"},
+					},
+				},
+			},
+		},
+	}
+
+	if _, err := ResolveContainedOperationTarget(contract, "entity.verticals[payload.vertical_id]", string(ContainedOperationSet), true, false); err == nil {
+		t.Fatal("dynamic bracket target resolved; want fail-closed rejection")
+	}
+	target, err := ResolveContainedOperationTarget(contract, "entity.verticals", string(ContainedOperationSet), true, false)
+	if err != nil {
+		t.Fatalf("ResolveContainedOperationTarget(map set): %v", err)
+	}
+	if _, err := NormalizeContainedOperationValue(contract, target, string(ContainedOperationSet), map[string]any{"missing": "field"}); err == nil {
+		t.Fatal("undeclared map value field normalized; want fail-closed rejection")
+	}
+}

--- a/internal/runtime/entityruntime/contracts_test.go
+++ b/internal/runtime/entityruntime/contracts_test.go
@@ -2,6 +2,7 @@ package entityruntime
 
 import (
 	"reflect"
+	"strings"
 	"testing"
 
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
@@ -189,5 +190,36 @@ func TestContainedOperationTarget_FailsClosedForDynamicPathAndWrongShape(t *test
 	}
 	if _, err := NormalizeContainedOperationValue(contract, target, string(ContainedOperationSet), map[string]any{"missing": "field"}); err == nil {
 		t.Fatal("undeclared map value field normalized; want fail-closed rejection")
+	}
+}
+
+func TestContainedOperationTarget_RejectsSetOrMergeIndex(t *testing.T) {
+	contract := Contract{
+		Entity: runtimecontracts.EntityContract{
+			Fields: map[string]runtimecontracts.EntityFieldDecl{
+				"verticals": {Type: "map[text]VerticalState"},
+			},
+		},
+		Types: runtimecontracts.TypeCatalogDocument{
+			Types: map[string]runtimecontracts.NamedTypeDecl{
+				"VerticalState": {
+					Fields: map[string]runtimecontracts.TypeFieldSpec{
+						"status": {Type: "text"},
+					},
+				},
+			},
+		},
+	}
+
+	for _, op := range []string{ContainedOperationSet, ContainedOperationMerge} {
+		t.Run(op, func(t *testing.T) {
+			_, err := ResolveContainedOperationTarget(contract, "entity.verticals", op, true, true)
+			if err == nil {
+				t.Fatalf("ResolveContainedOperationTarget(%s with index) = nil, want fail-closed rejection", op)
+			}
+			if !strings.Contains(err.Error(), "must not declare index") {
+				t.Fatalf("error = %v, want index rejection", err)
+			}
+		})
 	}
 }

--- a/internal/runtime/pipeline/mutation_logging_test.go
+++ b/internal/runtime/pipeline/mutation_logging_test.go
@@ -147,6 +147,77 @@ func TestWorkflowInstanceStore_UpsertTracksFieldsGatesAndAccumulatorInMutationLo
 	}
 }
 
+func TestWorkflowInstanceStore_ReplaysContainedStateMapListProjection(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	store := NewWorkflowInstanceStore(db)
+	entityID := uuid.NewString()
+
+	if err := store.Upsert(testWorkflowStoreRunContext(t, store), WorkflowInstance{
+		InstanceID:      entityID,
+		StorageRef:      entityID,
+		WorkflowName:    "contained-state-flow",
+		WorkflowVersion: "1.0.0",
+		CurrentState:    "queued",
+		Metadata: map[string]any{
+			"verticals": map[string]any{
+				"north": map[string]any{
+					"status":      "active",
+					"active_jobs": []any{},
+				},
+			},
+			"tags": []any{"new"},
+		},
+	}); err != nil {
+		t.Fatalf("seed workflow instance: %v", err)
+	}
+
+	contained := map[string]any{
+		"north": map[string]any{
+			"status": "busy",
+			"active_jobs": []any{
+				map[string]any{"id": "job-1", "title": "Build"},
+			},
+		},
+	}
+	if err := store.Upsert(testWorkflowStoreRunContext(t, store), WorkflowInstance{
+		InstanceID:      entityID,
+		StorageRef:      entityID,
+		WorkflowName:    "contained-state-flow",
+		WorkflowVersion: "1.0.0",
+		CurrentState:    "queued",
+		Metadata: map[string]any{
+			"verticals": contained,
+			"tags":      []any{"new", "vip"},
+		},
+	}); err != nil {
+		t.Fatalf("update workflow instance: %v", err)
+	}
+
+	loaded, ok, err := store.Load(testWorkflowStoreRunContext(t, store), entityID)
+	if err != nil {
+		t.Fatalf("load workflow instance: %v", err)
+	}
+	if !ok {
+		t.Fatal("workflow instance missing after contained state update")
+	}
+	if got := mustCanonicalJSON(t, loaded.Metadata["verticals"]); got != mustCanonicalJSON(t, contained) {
+		t.Fatalf("loaded verticals = %s, want %s", got, mustCanonicalJSON(t, contained))
+	}
+	if got := mustCanonicalJSON(t, loaded.Metadata["tags"]); got != `["new","vip"]` {
+		t.Fatalf("loaded tags = %s, want [new,vip]", got)
+	}
+
+	fields := mutationFieldsForEntity(t, db, entityID)
+	for _, want := range []string{"verticals", "tags"} {
+		if !containsMutationField(fields, want) {
+			t.Fatalf("mutation fields missing %q: %v", want, fields)
+		}
+	}
+	if err := trackedMutationStateMatchesEntityState(t, db, entityID); err != nil {
+		t.Fatalf("trackedMutationStateMatchesEntityState(contained state): %v", err)
+	}
+}
+
 func TestApplyWorkflowGateMutation_LogsMutationRow(t *testing.T) {
 	_, db, _ := testutil.StartPostgres(t)
 	entityID := uuid.NewString()

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -1595,7 +1595,7 @@ handler_specification:
         source_event: 'string — which event the payload comes from (default: current trigger event).
           CANONICAL field name — use source_event, not "source".'
       write_item_forms:
-        description: 'Each item in writes is one of four forms. No other forms are accepted.'
+        description: 'Each item in writes is one of five forms. No other forms are accepted.'
         direct:
           shape: 'field_name (bare string)'
           meaning: 'payload.field_name → entity.field_name. Direct name match.'
@@ -1619,14 +1619,76 @@ handler_specification:
           example: "- target_field: revision_count\n  expression: entity.revision_count + 1"
           note: 'value and expression are mutually exclusive. Use value for constants, expression
             for dynamic computation. Do not use expression for simple constants — use value instead.'
+        contained_operation:
+          promoted_by: '#1548'
+          canonical_code_owner: internal/runtime/contracts.WorkflowDataWrite.Operation + internal/runtime/entityruntime.ResolveContainedOperationTarget
+          shape: '{op: set|merge|delete|append|update, target: entity.<map_or_list_field>[.<declared_nested_field>], key?: expression, index?: expression, value?: expression}'
+          meaning: >
+            Apply a deterministic typed update to a list/map contained inside the
+            current primary entity. `target` is a declared entity field path and
+            MUST use `entity.` scope. For map-scoped operations, `key` is the
+            explicit map key expression; dynamic bracket targets such as
+            `entity.map[payload.key]` are not valid operation syntax. `value`,
+            `key`, and `index` use the expression-value grammar: scalars/maps/lists
+            are literals, `{ref: payload.field}` reads a scoped value, and
+            `{cel: expression}` evaluates a CEL expression.
+          map_operations:
+            set: >
+              Requires `target`, `key`, and `value`. The target root must be
+              `map[...]T`. The value is type-checked as `T` or as the declared
+              nested target type when `target` names a declared field under the
+              map value type.
+            merge: >
+              Requires `target`, `key`, and `value`. The map entry or declared
+              nested target must already exist and resolve to an object/named
+              type. The value is a typed partial object merged deterministically
+              into that object. Unknown fields fail closed.
+            delete: >
+              Requires `target` and `key`; forbids `value` and `index`. The
+              target must be the map root. Missing keys fail closed.
+            append: >
+              With `key`, appends `value` to a list stored as the map value or
+              under a declared nested list field of the map value type. The list
+              item is type-checked against the declared list element type.
+          list_operations:
+            append: >
+              Without `key`, `target` must resolve to a declared list field on
+              the primary entity. Appends a value type-checked against the list
+              item type.
+            update: >
+              Requires `target`, `index`, and `value`. `target` must resolve to
+              a declared list field, either directly on the primary entity or
+              under an explicit map `key`. The index must be non-negative and
+              existing at runtime; out-of-range update fails closed.
+          fail_closed:
+          - missing target
+          - target outside entity scope
+          - target_path/field/source_field/target_field mixed with op syntax
+          - unsupported operation name
+          - missing required key/index/value for the operation
+          - index declared on append or delete
+          - value declared on delete
+          - dynamic bracket/index path syntax in target
+          - target root not declared on the primary entity schema
+          - map operation on a non-map field
+          - list operation on a non-list field
+          - nested target path that does not resolve through declared named types
+          - wrong key type, wrong value shape, missing map key, or out-of-range list update
+          non_authoritative_paths:
+          - target_path bracket syntax
+          - paths.Parse dynamic segments
+          - whole-map/list CEL rebuilds used as keyed operation proof
+          - connect/direct delivery/RouteTable/descriptor lookup for contained items
+          example: "data_accumulation:\n  writes:\n  - op: append\n    target: entity.verticals.active_jobs\n    key:\n      ref: payload.vertical_id\n    value:\n      ref: payload.job\n  - op: update\n    target: entity.review_queue\n    index: 0\n    value: reviewed"
       rules:
       - writes is always a list
-      - each item is exactly one of the four forms above
+      - each item is exactly one of the five forms above
       - value and expression are mutually exclusive on the same write item (boot error if both present)
       - source_event is optional — if omitted, the trigger event is the source
       - source_event payload must contain all fields referenced by direct and mapped writes (verified at boot)
       - literal writes do not reference source_event or handler context — the value is used as-is
       - computed writes do not reference source_event — they use the handler context directly
+      - contained operations are validated against the current flow primary entity contract and remain local state updates, not routing declarations
       example: "data_accumulation:\n  writes:\n  - geography                              # direct\n\
         \  - source_field: vertical_name             # mapped\n    target_field: name\n  - target_field:\
         \ revision_count                # literal\n    value: 0\n  - target_field: expected_count\
@@ -5319,8 +5381,9 @@ flow_model:
           subscribers, and RouteTable/live subscription lookup are not the
           canonical producer evidence owner for this class.
     contained_state_model:
-      status: spec_vocabulary_only
+      status: merge_bearing_contract_runtime_behavior
       implementation_tracker: '#1548'
+      canonical_code_owner: internal/runtime/contracts.WorkflowDataWrite.Operation + internal/runtime/entityruntime.ResolveContainedOperationTarget + internal/runtime/engine.Executor.applyContainedDataOperation
       rule: >
         Typed lists and maps are contained state inside the primary entity.
         They are not cross-flow route targets and MUST NOT be addressed through
@@ -5328,6 +5391,28 @@ flow_model:
         routing, timers, retries, agents, audit, callbacks, terminality, or
         durable idempotency identity, it must be promoted to a child/template
         flow instance instead of remaining only a list/map item.
+      operation_surface:
+        host: platform-spec.yaml#handler.data_accumulation.write_item_forms.contained_operation
+        supported_operations:
+        - map set
+        - map merge
+        - map delete
+        - map append-to-contained-list
+        - list append
+        - list update
+        variable_key_rule: >
+          Variable map keys are expressed only through the operation `key`
+          expression. Dynamic/bracket target paths are not a compatibility
+          surface and must fail verification/runtime validation.
+        persistence_rule: >
+          Contained operations mutate the owning primary entity field. Store
+          persistence, mutation-log rows, replay reconstruction, and readback
+          remain keyed by the primary entity field; contained map/list items do
+          not gain independent runtime identity or route rows.
+        non_routing_rule: >
+          A contained operation does not create a receiver, route descriptor,
+          RouteTable row, direct delivery target, or live subscription. Parent
+          `connect` remains cross-flow-instance topology only.
     singleton_coordinator_model:
       status: spec_vocabulary_only
       implementation_tracker: '#1549'


### PR DESCRIPTION
Closes #1548

## Summary
- Adds a canonical typed contained-state operation owner for `data_accumulation.writes`: `op`, `target`, `key`, `index`, and `value` on `WorkflowDataWrite`.
- Adds entityruntime target/type validation and normalization for map set/merge/delete, map append-to-list, list append, and list update.
- Wires the same owner through bootverify, runtime execution, emit persistence prerequisites, mutation-log/readback proof, and authoritative spec text.

## Governing Refs
- `platform-spec.yaml#handler_specification.data_accumulation.write_item_forms.contained_operation`
- `platform-spec.yaml#flow_model.flow_instance_authoring.contained_state_model`
- Binding issue/gate context: #1548 Pre-Implementation Coverage Audit and approved gate outcome.
- Adjacent parent context: #1537 locked #1476 flow-instance-centered authoring model.

## Semantic Migration
- New canonical owner: `internal/runtime/contracts.WorkflowDataWrite.Operation` plus `internal/runtime/entityruntime.ResolveContainedOperationTarget` and `internal/runtime/engine.Executor.applyContainedDataOperation`.
- Old producer/reader/writer paths now invalid for this class: bracket/dynamic `target_path` syntax such as `entity.map[payload.key]`, `paths.Parse` string heuristics, whole-map/list CEL rebuilds used as keyed-operation proof, `connect`/direct delivery/RouteTable/descriptor lookup as contained-item addressability.
- Production paths checked for surviving old behavior: YAML decode/hydration, bootverify write target coverage, expression/payload alignment checks, runtime data accumulation, emit persistence prerequisites, store mutation-log projection/readback.
- Migration completeness: complete for #1548 typed contained map/list operations; broader #1537 siblings remain separate.

## Proof
- `go test ./internal/runtime/contracts ./internal/runtime/entityruntime ./internal/runtime/engine ./internal/runtime/bootverify ./internal/runtime/pipeline`
- `go test ./...`

Note: `docs/IMPLEMENTER_GUIDELINES.md` and `docs/SEMANTIC_DRIFT.md` are absent in this worktree, so they could not be re-read locally.