### PR TITLE
[agent-b][issue #1565] Add claude_cli doctor preflight

### DIFF
--- a/cmd/swarm/cli.go
+++ b/cmd/swarm/cli.go
@@ -76,6 +76,7 @@ func newRootCommandWithOptions(ctx context.Context, repo string, out, errOut io.
 	cmd.AddCommand(
 		newServeCommand(ctx, repo, opts.runServe),
 		newRunCommand(repo, opts),
+		newDoctorCommand(ctx, repo),
 		newVerifyCommand(ctx, repo),
 		newSecretsCommand(ctx, repo),
 		newVersionCommand(opts),

--- a/cmd/swarm/doctor.go
+++ b/cmd/swarm/doctor.go
@@ -1,0 +1,127 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+type doctorOptions struct {
+	configPath          string
+	backend             string
+	contractsPath       string
+	dataSource          string
+	workspaceBackend    string
+	workspaceBackendSet bool
+	platformSpecPath    string
+	apiListenAddr       string
+	mcpListenAddr       string
+	asJSON              bool
+}
+
+func newDoctorCommand(ctx context.Context, repo string) *cobra.Command {
+	opts := doctorOptions{
+		apiListenAddr: defaultAPIListenAddr,
+		mcpListenAddr: defaultMCPListenAddr,
+	}
+	cmd := &cobra.Command{
+		Use:   "doctor",
+		Short: "Diagnose local Swarm runtime prerequisites.",
+		Args:  cobra.NoArgs,
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			if cmd.Flags().Changed("data") {
+				opts.dataSource = strings.TrimSpace(opts.dataSource)
+				if opts.dataSource == "" {
+					return fmt.Errorf("--data must be non-empty")
+				}
+			}
+			if cmd.Flags().Changed("workspace-backend") {
+				backend, err := normalizeWorkspaceBackend(opts.workspaceBackend, "--workspace-backend")
+				if err != nil {
+					return err
+				}
+				opts.workspaceBackend = backend
+			}
+			opts.workspaceBackendSet = cmd.Flags().Changed("workspace-backend")
+			apiListenAddr, mcpListenAddr, err := resolveCLIServeListenerAddresses(cliServeListenerAddressOptions{
+				APIListenAddr:        opts.apiListenAddr,
+				MCPListenAddr:        opts.mcpListenAddr,
+				APIListenAddrFlagSet: cmd.Flags().Changed("api-listen-addr"),
+				MCPListenAddrFlagSet: cmd.Flags().Changed("mcp-listen-addr"),
+			})
+			if err != nil {
+				return err
+			}
+			opts.apiListenAddr = apiListenAddr
+			opts.mcpListenAddr = mcpListenAddr
+			if err := validateServeListenAddr("--api-listen-addr", opts.apiListenAddr); err != nil {
+				return err
+			}
+			if err := validateServeListenAddr("--mcp-listen-addr", opts.mcpListenAddr); err != nil {
+				return err
+			}
+			return nil
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runDoctorCommand(ctx, assetCommandRepoRoot(repo), cmd, opts)
+		},
+	}
+	cmd.Flags().StringVar(&opts.configPath, "config", opts.configPath, "Optional path to Swarm runtime config")
+	cmd.Flags().StringVar(&opts.backend, "backend", opts.backend, "LLM backend profile to diagnose: anthropic, claude_cli, openai_compatible, or openai_responses")
+	cmd.Flags().StringVar(&opts.contractsPath, "contracts", opts.contractsPath, "Path to Swarm contract bundle root")
+	cmd.Flags().StringVar(&opts.dataSource, "data", opts.dataSource, "Path to agent-visible read-only /data reference directory")
+	cmd.Flags().StringVar(&opts.workspaceBackend, "workspace-backend", opts.workspaceBackend, "Workspace backend for local diagnostics: docker or host")
+	cmd.Flags().StringVar(&opts.platformSpecPath, "platform-spec", opts.platformSpecPath, "Path to platform spec yaml")
+	cmd.Flags().StringVar(&opts.apiListenAddr, "api-listen-addr", opts.apiListenAddr, "HTTP bind address to preflight for API, WebSocket, health, and readiness routes")
+	cmd.Flags().StringVar(&opts.mcpListenAddr, "mcp-listen-addr", opts.mcpListenAddr, "HTTP bind address to preflight for MCP and tools routes")
+	cmd.Flags().BoolVar(&opts.asJSON, "json", false, "Render the diagnostic report as JSON")
+	return cmd
+}
+
+func runDoctorCommand(ctx context.Context, repo string, cmd *cobra.Command, opts doctorOptions) error {
+	if err := loadRepoDotEnv(repo); err != nil {
+		return returnCLIValidationError(cmd.ErrOrStderr(), fmt.Errorf("load .env: %w", err))
+	}
+	resolvedPaths, err := resolveCLIContractPlatformSpecPaths(repo, cliContractPlatformSpecPathOptions{
+		ContractsPath:    opts.contractsPath,
+		PlatformSpecPath: opts.platformSpecPath,
+	})
+	if err != nil {
+		report := localPreflightReport{Owner: localPreflightOwner, Mode: "doctor"}
+		report.add(localPreflightBackendPrerequisite, "path_resolution_failed", localPreflightSeverityBlocker, localPreflightStatusFailed, err.Error(), "fix --contracts or --platform-spec")
+		return returnLocalPreflightResult(cmd, report.finalize(), opts.asJSON)
+	}
+	cfgResult, err := loadRuntimeConfigWithOptions(runtimeConfigLoadOptions{
+		RepoRoot:        repo,
+		ExplicitPath:    opts.configPath,
+		BackendOverride: opts.backend,
+	})
+	if err != nil {
+		report := localPreflightReport{Owner: localPreflightOwner, Mode: "doctor"}
+		report.add(localPreflightBackendPrerequisite, "config_load_failed", localPreflightSeverityBlocker, localPreflightStatusFailed, err.Error(), "fix --config, --backend, retired env vars, or llm.backend")
+		return returnLocalPreflightResult(cmd, report.finalize(), opts.asJSON)
+	}
+	workspaceBackend, err := resolveWorkspaceBackend(opts.workspaceBackend, opts.workspaceBackendSet, cfgResult.Config)
+	if err != nil {
+		report := localPreflightReport{Owner: localPreflightOwner, Mode: "doctor"}
+		report.add(localPreflightWorkspacePrerequisite, "workspace_backend_invalid", localPreflightSeverityBlocker, localPreflightStatusFailed, err.Error(), "fix --workspace-backend, workspace.backend, or SWARM_WORKSPACE_BACKEND")
+		return returnLocalPreflightResult(cmd, report.finalize(), opts.asJSON)
+	}
+	report := runLocalClaudeCLIPreflight(ctx, localPreflightRequest{
+		Mode:                   "doctor",
+		RepoRoot:               repo,
+		Config:                 cfgResult.Config,
+		ResolvedPaths:          resolvedPaths,
+		DataSource:             opts.dataSource,
+		WorkspaceBackend:       workspaceBackend,
+		APIListenAddr:          opts.apiListenAddr,
+		MCPListenAddr:          opts.mcpListenAddr,
+		CheckListeners:         true,
+		CheckGatewayEnv:        true,
+		CheckContractSecrets:   cmd.Flags().Changed("contracts"),
+		ContractSecretSeverity: localPreflightCommandSeverityForContractSecrets("doctor"),
+	})
+	return returnLocalPreflightResult(cmd, report, opts.asJSON)
+}

--- a/cmd/swarm/doctor_test.go
+++ b/cmd/swarm/doctor_test.go
@@ -95,6 +95,42 @@ func TestDoctorClaudeCLIPreflightJSONReportsOKWithoutDB(t *testing.T) {
 	}
 }
 
+func TestDoctorClaudeCLIPreflightSkipsCredentialForAgentFreeContracts(t *testing.T) {
+	t.Setenv("CLAUDE_CODE_OAUTH_TOKEN", "")
+	t.Setenv("SWARM_TOOL_GATEWAY_URL", "")
+	t.Setenv("SWARM_TOOL_GATEWAY_CONTAINER_URL", "")
+	t.Setenv("SWARM_TOOL_GATEWAY_TOKEN", "")
+
+	args := doctorClaudeArgs(t, writeDoctorClaudeConfig(t), false)
+	for i := 0; i+1 < len(args); i++ {
+		if args[i] == "--contracts" {
+			args[i+1] = writeDoctorAgentFreeContractsFixture(t)
+			break
+		}
+	}
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), repoRoot(), args, &stdout, &stderr, defaultRootCommandOptions())
+	if code != 0 {
+		t.Fatalf("code = %d stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	for _, want := range []string{
+		"backend_prerequisite/backend_credential_skipped_agent_free",
+		"workspace_prerequisite/agent_free_source",
+	} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("doctor output missing %q:\n%s", want, stdout.String())
+		}
+	}
+	for _, forbidden := range []string{
+		"missing_backend_credential",
+		"workspace_claude_cli_unavailable",
+	} {
+		if strings.Contains(stdout.String(), forbidden) {
+			t.Fatalf("doctor output contains %q for agent-free source:\n%s", forbidden, stdout.String())
+		}
+	}
+}
+
 func TestDoctorClaudeCLIPreflightReportsMissingWorkspaceCLI(t *testing.T) {
 	configureDoctorDockerStub(t)
 	t.Setenv("CLAUDE_CODE_OAUTH_TOKEN", "oauth-token")
@@ -331,6 +367,30 @@ func writeDoctorClaudeConfig(t *testing.T) string {
 		"    no_session_persistence: false",
 	}, "\n")+"\n")
 	return path
+}
+
+func writeDoctorAgentFreeContractsFixture(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "package.yaml"), `
+name: agent-free-doctor
+version: "1.0.0"
+platform_version: ">=1.0.0"
+flows: []
+`)
+	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "schema.yaml"), `
+name: agent-free-doctor
+initial_state: idle
+states:
+  - idle
+terminal_states:
+  - idle
+`)
+	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "nodes.yaml"), "{}\n")
+	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "events.yaml"), "{}\n")
+	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "policy.yaml"), "{}\n")
+	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "tools.yaml"), "{}\n")
+	return root
 }
 
 func configureDoctorDockerStub(t *testing.T) {

--- a/cmd/swarm/doctor_test.go
+++ b/cmd/swarm/doctor_test.go
@@ -1,0 +1,396 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	storebackend "github.com/division-sh/swarm/internal/store/backendselection"
+	"gopkg.in/yaml.v3"
+)
+
+func TestDoctorClaudeCLIPreflightReportsMissingPrerequisites(t *testing.T) {
+	configureDoctorDockerStub(t)
+	t.Setenv("CLAUDE_CODE_OAUTH_TOKEN", "")
+	t.Setenv("SWARM_TEST_DOCKER_IMAGE_MISSING", "1")
+	t.Setenv("SWARM_TOOL_GATEWAY_URL", "")
+	t.Setenv("SWARM_TOOL_GATEWAY_CONTAINER_URL", "")
+	t.Setenv("SWARM_TOOL_GATEWAY_TOKEN", "")
+
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), repoRoot(), doctorClaudeArgs(t, writeDoctorClaudeConfig(t), false), &stdout, &stderr, defaultRootCommandOptions())
+	if code != cliExitRuntime {
+		t.Fatalf("code = %d, want %d stdout=%s stderr=%s", code, cliExitRuntime, stdout.String(), stderr.String())
+	}
+	for _, want := range []string{
+		"claude_cli preflight: failed",
+		"backend_prerequisite/missing_backend_credential",
+		"workspace_prerequisite/workspace_image_unavailable",
+		"set CLAUDE_CODE_OAUTH_TOKEN",
+		"set SWARM_WORKSPACE_IMAGE",
+	} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("doctor output missing %q:\n%s", want, stdout.String())
+		}
+	}
+	if stderr.String() != "" {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+}
+
+func TestDoctorClaudeCLIPreflightReportsMissingDocker(t *testing.T) {
+	configureDoctorDockerStub(t)
+	t.Setenv("CLAUDE_CODE_OAUTH_TOKEN", "oauth-token")
+	t.Setenv("SWARM_TEST_DOCKER_UNAVAILABLE", "1")
+	t.Setenv("SWARM_TOOL_GATEWAY_URL", "")
+	t.Setenv("SWARM_TOOL_GATEWAY_CONTAINER_URL", "")
+	t.Setenv("SWARM_TOOL_GATEWAY_TOKEN", "")
+
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), repoRoot(), doctorClaudeArgs(t, writeDoctorClaudeConfig(t), false), &stdout, &stderr, defaultRootCommandOptions())
+	if code != cliExitRuntime {
+		t.Fatalf("code = %d, want %d stdout=%s stderr=%s", code, cliExitRuntime, stdout.String(), stderr.String())
+	}
+	for _, want := range []string{
+		"workspace_prerequisite/docker_unavailable",
+		"docker is not available",
+		"start Docker or set SWARM_DOCKER_BIN",
+	} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("doctor output missing %q:\n%s", want, stdout.String())
+		}
+	}
+}
+
+func TestDoctorClaudeCLIPreflightJSONReportsOKWithoutDB(t *testing.T) {
+	configureDoctorDockerStub(t)
+	t.Setenv("CLAUDE_CODE_OAUTH_TOKEN", "oauth-token")
+	t.Setenv("SWARM_TOOL_GATEWAY_URL", "")
+	t.Setenv("SWARM_TOOL_GATEWAY_CONTAINER_URL", "")
+	t.Setenv("SWARM_TOOL_GATEWAY_TOKEN", "")
+	t.Setenv(storebackend.EnvSQLitePath, filepath.Join(t.TempDir(), "must-not-be-used.db"))
+
+	args := doctorClaudeArgs(t, writeDoctorClaudeConfig(t), true)
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), repoRoot(), args, &stdout, &stderr, defaultRootCommandOptions())
+	if code != 0 {
+		t.Fatalf("code = %d stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	var report localPreflightReport
+	if err := json.Unmarshal(stdout.Bytes(), &report); err != nil {
+		t.Fatalf("parse doctor json: %v\n%s", err, stdout.String())
+	}
+	if !report.OK || report.Owner != localPreflightOwner || report.Mode != "doctor" || report.Backend != "claude_cli" {
+		t.Fatalf("report = %#v", report)
+	}
+	for _, want := range []string{"backend_credential_present", "docker_available", "workspace_image_available", "workspace_claude_cli_available"} {
+		if !localPreflightReportHasCode(report, want) {
+			t.Fatalf("report missing finding %q: %#v", want, report.Findings)
+		}
+	}
+}
+
+func TestDoctorClaudeCLIPreflightReportsMissingWorkspaceCLI(t *testing.T) {
+	configureDoctorDockerStub(t)
+	t.Setenv("CLAUDE_CODE_OAUTH_TOKEN", "oauth-token")
+	t.Setenv("SWARM_TEST_DOCKER_CLI_MISSING", "1")
+	t.Setenv("SWARM_TOOL_GATEWAY_URL", "")
+	t.Setenv("SWARM_TOOL_GATEWAY_CONTAINER_URL", "")
+	t.Setenv("SWARM_TOOL_GATEWAY_TOKEN", "")
+
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), repoRoot(), doctorClaudeArgs(t, writeDoctorClaudeConfig(t), false), &stdout, &stderr, defaultRootCommandOptions())
+	if code != cliExitRuntime {
+		t.Fatalf("code = %d, want %d stdout=%s stderr=%s", code, cliExitRuntime, stdout.String(), stderr.String())
+	}
+	for _, want := range []string{
+		"workspace_prerequisite/workspace_claude_cli_unavailable",
+		"configured Claude CLI command",
+		"workspace image",
+		"contains the configured Claude CLI command",
+	} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("doctor output missing %q:\n%s", want, stdout.String())
+		}
+	}
+}
+
+func TestDoctorClaudeCLIPreflightUsesCredentialStoreForContractSecrets(t *testing.T) {
+	t.Setenv("CLAUDE_CODE_OAUTH_TOKEN", "oauth-token")
+	t.Setenv("SWARM_CREDENTIALS_FILE", filepath.Join(t.TempDir(), "credentials.json"))
+	t.Setenv("SWARM_TOOL_GATEWAY_URL", "")
+	t.Setenv("SWARM_TOOL_GATEWAY_CONTAINER_URL", "")
+	t.Setenv("SWARM_TOOL_GATEWAY_TOKEN", "")
+
+	args := doctorClaudeArgs(t, writeDoctorClaudeConfig(t), false)
+	for i := 0; i+1 < len(args); i++ {
+		if args[i] == "--contracts" {
+			args[i+1] = writeSecretsCommandContractsFixture(t)
+			break
+		}
+	}
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), repoRoot(), args, &stdout, &stderr, defaultRootCommandOptions())
+	if code != cliExitRuntime {
+		t.Fatalf("code = %d, want %d stdout=%s stderr=%s", code, cliExitRuntime, stdout.String(), stderr.String())
+	}
+	for _, want := range []string{
+		"contract_secret_prerequisite/missing_contract_secret",
+		"sendgrid_api_key",
+		"tool:email_api",
+		"swarm secrets set sendgrid_api_key",
+	} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("doctor output missing %q:\n%s", want, stdout.String())
+		}
+	}
+}
+
+func TestDoctorClaudeCLIPreflightReportsRetiredBackendEnv(t *testing.T) {
+	t.Setenv("SWARM_LLM_BACKEND", "cli_test")
+	t.Setenv("CLAUDE_CODE_OAUTH_TOKEN", "oauth-token")
+
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), repoRoot(), doctorClaudeArgs(t, writeDoctorClaudeConfig(t), false), &stdout, &stderr, defaultRootCommandOptions())
+	if code != cliExitRuntime {
+		t.Fatalf("code = %d, want %d stdout=%s stderr=%s", code, cliExitRuntime, stdout.String(), stderr.String())
+	}
+	for _, want := range []string{
+		"backend_prerequisite/config_load_failed",
+		"SWARM_LLM_BACKEND is retired",
+		"use --backend or llm.backend",
+	} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("doctor output missing %q:\n%s", want, stdout.String())
+		}
+	}
+}
+
+func TestDoctorClaudeCLIPreflightReportsStaleGatewayEnv(t *testing.T) {
+	configureDoctorDockerStub(t)
+	t.Setenv("CLAUDE_CODE_OAUTH_TOKEN", "oauth-token")
+	t.Setenv("SWARM_TOOL_GATEWAY_TOKEN", "operator-token")
+
+	mcpPort := freeDoctorTCPPort(t)
+	oldPort := freeDoctorTCPPort(t)
+	if oldPort == mcpPort {
+		oldPort = freeDoctorTCPPort(t)
+	}
+	t.Setenv("SWARM_TOOL_GATEWAY_URL", "http://127.0.0.1:"+oldPort)
+	t.Setenv("SWARM_TOOL_GATEWAY_CONTAINER_URL", "http://host.docker.internal:"+oldPort)
+
+	args := doctorClaudeArgs(t, writeDoctorClaudeConfig(t), false)
+	args = append(args[:len(args)-4], "--api-listen-addr", "127.0.0.1:0", "--mcp-listen-addr", "127.0.0.1:"+mcpPort)
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), repoRoot(), args, &stdout, &stderr, defaultRootCommandOptions())
+	if code != cliExitRuntime {
+		t.Fatalf("code = %d, want %d stdout=%s stderr=%s", code, cliExitRuntime, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "gateway_prerequisite/swarm_tool_gateway_url_stale") || !strings.Contains(stdout.String(), "must target the MCP listener port "+mcpPort) {
+		t.Fatalf("stale gateway env not reported:\n%s", stdout.String())
+	}
+}
+
+func TestRunServeRuntimeConsumesLocalClaudePreflightBeforeStoreSelection(t *testing.T) {
+	configureDoctorDockerStub(t)
+	t.Setenv("CLAUDE_CODE_OAUTH_TOKEN", "")
+	t.Setenv("SWARM_TOOL_GATEWAY_URL", "")
+	t.Setenv("SWARM_TOOL_GATEWAY_CONTAINER_URL", "")
+	t.Setenv("SWARM_TOOL_GATEWAY_TOKEN", "")
+
+	var out bytes.Buffer
+	code := runServeRuntime(context.Background(), repoRoot(), serveOptions{
+		ConfigPath:         writeDoctorClaudeConfig(t),
+		ContractsPath:      doctorAgentContractsPath,
+		DataSource:         t.TempDir(),
+		PlatformSpecPath:   defaultPlatformSpecPath,
+		StoreMode:          "not-a-store",
+		APIListenAddr:      "127.0.0.1:0",
+		MCPListenAddr:      "127.0.0.1:0",
+		SelfCheck:          true,
+		RequireBundleMatch: false,
+		Verbose:            true,
+		Output:             &out,
+		Dev:                true,
+	})
+	if code != cliExitRuntime {
+		t.Fatalf("runServeRuntime code = %d, want %d\noutput:\n%s", code, cliExitRuntime, out.String())
+	}
+	if !strings.Contains(out.String(), "local_preflight") || !strings.Contains(out.String(), "missing_backend_credential") {
+		t.Fatalf("serve output missing shared local preflight failure:\n%s", out.String())
+	}
+	if strings.Contains(out.String(), "not-a-store") || strings.Contains(out.String(), "db_connection") {
+		t.Fatalf("serve reached store selection instead of failing preflight first:\n%s", out.String())
+	}
+}
+
+func TestPlatformSpecLocalClaudeCLIPreflightAdmissionPromoted(t *testing.T) {
+	var spec struct {
+		CLISpecification struct {
+			Foundations struct {
+				Preflight struct {
+					PromotedBy           string   `yaml:"promoted_by"`
+					ImplementationStatus string   `yaml:"implementation_status"`
+					CanonicalOwner       string   `yaml:"canonical_owner"`
+					ImplementationOwner  string   `yaml:"implementation_owner"`
+					Scope                string   `yaml:"scope"`
+					FindingCategories    []string `yaml:"finding_categories"`
+					CommandModeRule      string   `yaml:"command_mode_rule"`
+					OwnerConsumptionRule string   `yaml:"owner_consumption_rule"`
+					SplitTail            []string `yaml:"split_tail"`
+				} `yaml:"local_claude_cli_preflight_admission"`
+			} `yaml:"foundations"`
+			CommandCatalog struct {
+				Doctor struct {
+					Command              string   `yaml:"command"`
+					ImplementationStatus string   `yaml:"implementation_status"`
+					Owner                string   `yaml:"owner"`
+					Behavior             string   `yaml:"behavior"`
+					SplitScope           []string `yaml:"split_scope"`
+				} `yaml:"doctor"`
+			} `yaml:"command_catalog"`
+		} `yaml:"cli_specification"`
+	}
+	data, err := os.ReadFile(filepath.Join(repoRoot(), defaultPlatformSpecPath))
+	if err != nil {
+		t.Fatalf("read platform spec: %v", err)
+	}
+	if err := yaml.Unmarshal(data, &spec); err != nil {
+		t.Fatalf("parse platform spec: %v", err)
+	}
+	preflight := spec.CLISpecification.Foundations.Preflight
+	if preflight.PromotedBy != "#1565" || preflight.ImplementationStatus != "implemented" || !strings.Contains(preflight.CanonicalOwner, "local_claude_cli_preflight_admission") {
+		t.Fatalf("preflight spec = %#v", preflight)
+	}
+	for _, want := range []string{"backend_prerequisite", "workspace_prerequisite", "serve_listener_prerequisite", "gateway_prerequisite", "contract_secret_prerequisite"} {
+		if !stringSliceContains(preflight.FindingCategories, want) {
+			t.Fatalf("preflight categories missing %q: %#v", want, preflight.FindingCategories)
+		}
+	}
+	for _, want := range []string{"swarm doctor", "swarm serve --dev", "swarm run --backend claude_cli"} {
+		if !strings.Contains(preflight.CommandModeRule, want) && !strings.Contains(preflight.Scope, want) {
+			t.Fatalf("preflight spec missing consumer %q:\n%#v", want, preflight)
+		}
+	}
+	for _, want := range []string{"llm_provider_selection_config_authority", "tool_model.credential_store", "workspace lifecycle", "serve startup/listener"} {
+		if !strings.Contains(preflight.OwnerConsumptionRule, want) {
+			t.Fatalf("owner consumption rule missing %q:\n%s", want, preflight.OwnerConsumptionRule)
+		}
+	}
+	doctor := spec.CLISpecification.CommandCatalog.Doctor
+	if doctor.Command != "swarm doctor --backend claude_cli [--contracts <path>] [--json]" || doctor.ImplementationStatus != "implemented" || doctor.Owner != "cli_specification.foundations.local_claude_cli_preflight_admission" {
+		t.Fatalf("doctor command catalog = %#v", doctor)
+	}
+	if !strings.Contains(doctor.Behavior, "without starting runtime") || !strings.Contains(doctor.Behavior, "DB state") {
+		t.Fatalf("doctor behavior missing runtime/DB boundary: %s", doctor.Behavior)
+	}
+}
+
+func doctorClaudeArgs(t *testing.T, configPath string, asJSON bool) []string {
+	t.Helper()
+	args := []string{
+		"doctor",
+		"--backend", "claude_cli",
+		"--config", configPath,
+		"--contracts", doctorAgentContractsPath,
+		"--platform-spec", defaultPlatformSpecPath,
+		"--data", t.TempDir(),
+		"--api-listen-addr", "127.0.0.1:0",
+		"--mcp-listen-addr", "127.0.0.1:0",
+	}
+	if asJSON {
+		args = append(args, "--json")
+	}
+	return args
+}
+
+const doctorAgentContractsPath = "tests/tier8-boot-verification/test-boot-prompt-stub"
+
+func writeDoctorClaudeConfig(t *testing.T) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "claude.yaml")
+	writeRuntimeConfigText(t, path, strings.Join([]string{
+		"runtime:",
+		"  recovery_on_startup: false",
+		"llm:",
+		"  backend: claude_cli",
+		"  session:",
+		"    lock_ttl: 10s",
+		"    rotate_after_turns: 40",
+		"    rotate_on_parse_failures: 3",
+		"  claude_cli:",
+		"    command: claude",
+		"    timeout: 2s",
+		"    output_format: json",
+		"    retries: 1",
+		"    no_session_persistence: false",
+	}, "\n")+"\n")
+	return path
+}
+
+func configureDoctorDockerStub(t *testing.T) {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "docker")
+	script := `#!/bin/sh
+case "$1:$2" in
+  version:--format)
+    if [ "${SWARM_TEST_DOCKER_UNAVAILABLE:-}" = "1" ]; then
+      echo "docker unavailable" >&2
+      exit 1
+    fi
+    exit 0
+    ;;
+  image:inspect)
+    if [ "${SWARM_TEST_DOCKER_IMAGE_MISSING:-}" = "1" ]; then
+      echo "no such image" >&2
+      exit 1
+    fi
+    exit 0
+    ;;
+  run:--rm)
+    if [ "${SWARM_TEST_DOCKER_CLI_MISSING:-}" = "1" ]; then
+      echo "claude: not found" >&2
+      exit 127
+    fi
+    exit 0
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+`
+	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
+		t.Fatalf("write docker stub: %v", err)
+	}
+	t.Setenv("SWARM_DOCKER_BIN", path)
+	t.Setenv("SWARM_WORKSPACE_IMAGE", "doctor-test-image:latest")
+	t.Setenv("SWARM_WORKSPACE_VOLUMES_FROM", "")
+}
+
+func freeDoctorTCPPort(t *testing.T) string {
+	t.Helper()
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen for free port: %v", err)
+	}
+	defer listener.Close()
+	_, port, err := net.SplitHostPort(listener.Addr().String())
+	if err != nil {
+		t.Fatalf("split free port: %v", err)
+	}
+	return port
+}
+
+func localPreflightReportHasCode(report localPreflightReport, code string) bool {
+	for _, finding := range report.Findings {
+		if finding.Code == code {
+			return true
+		}
+	}
+	return false
+}

--- a/cmd/swarm/doctor_test.go
+++ b/cmd/swarm/doctor_test.go
@@ -156,6 +156,31 @@ func TestDoctorClaudeCLIPreflightReportsMissingWorkspaceCLI(t *testing.T) {
 	}
 }
 
+func TestDoctorClaudeCLIPreflightReportsBrokenWorkspaceCLI(t *testing.T) {
+	configureDoctorDockerStub(t)
+	t.Setenv("CLAUDE_CODE_OAUTH_TOKEN", "oauth-token")
+	t.Setenv("SWARM_TEST_DOCKER_CLI_BROKEN", "1")
+	t.Setenv("SWARM_TOOL_GATEWAY_URL", "")
+	t.Setenv("SWARM_TOOL_GATEWAY_CONTAINER_URL", "")
+	t.Setenv("SWARM_TOOL_GATEWAY_TOKEN", "")
+
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), repoRoot(), doctorClaudeArgs(t, writeDoctorClaudeConfig(t), false), &stdout, &stderr, defaultRootCommandOptions())
+	if code != cliExitRuntime {
+		t.Fatalf("code = %d, want %d stdout=%s stderr=%s", code, cliExitRuntime, stdout.String(), stderr.String())
+	}
+	for _, want := range []string{
+		"workspace_prerequisite/workspace_claude_cli_unavailable",
+		"cannot execute in workspace image",
+		"claude launcher failed after command lookup",
+		"runnable Claude CLI",
+	} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("doctor output missing %q:\n%s", want, stdout.String())
+		}
+	}
+}
+
 func TestDoctorClaudeCLIPreflightUsesCredentialStoreForContractSecrets(t *testing.T) {
 	t.Setenv("CLAUDE_CODE_OAUTH_TOKEN", "oauth-token")
 	t.Setenv("SWARM_CREDENTIALS_FILE", filepath.Join(t.TempDir(), "credentials.json"))
@@ -416,6 +441,14 @@ case "$1:$2" in
     if [ "${SWARM_TEST_DOCKER_CLI_MISSING:-}" = "1" ]; then
       echo "claude: not found" >&2
       exit 127
+    fi
+    if [ "${SWARM_TEST_DOCKER_CLI_BROKEN:-}" = "1" ]; then
+      case "$*" in
+        *"command -v"*"--version"*)
+          echo "claude launcher failed after command lookup" >&2
+          exit 126
+          ;;
+      esac
     fi
     exit 0
     ;;

--- a/cmd/swarm/local_preflight.go
+++ b/cmd/swarm/local_preflight.go
@@ -104,12 +104,6 @@ func runLocalClaudeCLIPreflight(ctx context.Context, req localPreflightRequest) 
 		return report.finalize()
 	}
 
-	if err := llmselection.RequireCredential(profile, os.LookupEnv); err != nil {
-		report.add(localPreflightBackendPrerequisite, "missing_backend_credential", localPreflightSeverityBlocker, localPreflightStatusFailed, err.Error(), fmt.Sprintf("set %s for claude_cli backend authentication", strings.TrimSpace(profile.Credential.EnvVar)))
-	} else {
-		report.add(localPreflightBackendPrerequisite, "backend_credential_present", localPreflightSeverityInfo, localPreflightStatusOK, fmt.Sprintf("%s is present", strings.TrimSpace(profile.Credential.EnvVar)), "")
-	}
-
 	if req.CheckListeners {
 		report.checkListener("api_listener", "api", req.APIListenAddr)
 		report.checkListener("mcp_listener", "mcp", req.MCPListenAddr)
@@ -127,8 +121,14 @@ func runLocalClaudeCLIPreflight(ctx context.Context, req localPreflightRequest) 
 		report.checkContractSecrets(ctx, source, req.ContractSecretSeverity)
 	}
 	if !sourceDeclaresAgents(source) {
+		report.add(localPreflightBackendPrerequisite, "backend_credential_skipped_agent_free", localPreflightSeverityInfo, localPreflightStatusSkipped, "selected contract source declares no agents; claude_cli backend credential is not required", "")
 		report.add(localPreflightWorkspacePrerequisite, "agent_free_source", localPreflightSeverityInfo, localPreflightStatusSkipped, "selected contract source declares no agents; claude_cli workspace proof is not required", "")
 		return report.finalize()
+	}
+	if err := llmselection.RequireCredential(profile, os.LookupEnv); err != nil {
+		report.add(localPreflightBackendPrerequisite, "missing_backend_credential", localPreflightSeverityBlocker, localPreflightStatusFailed, err.Error(), fmt.Sprintf("set %s for claude_cli backend authentication", strings.TrimSpace(profile.Credential.EnvVar)))
+	} else {
+		report.add(localPreflightBackendPrerequisite, "backend_credential_present", localPreflightSeverityInfo, localPreflightStatusOK, fmt.Sprintf("%s is present", strings.TrimSpace(profile.Credential.EnvVar)), "")
 	}
 	report.checkWorkspace(ctx, req.RepoRoot, req.Config, source, contractsRoot, req.DataSource, req.WorkspaceBackend)
 	return report.finalize()

--- a/cmd/swarm/local_preflight.go
+++ b/cmd/swarm/local_preflight.go
@@ -1,0 +1,424 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"sort"
+	"strings"
+
+	"github.com/division-sh/swarm/internal/config"
+	runtimecredentials "github.com/division-sh/swarm/internal/runtime/credentials"
+	llmselection "github.com/division-sh/swarm/internal/runtime/llm/selection"
+	"github.com/division-sh/swarm/internal/runtime/semanticview"
+	workspace "github.com/division-sh/swarm/internal/runtime/workspace"
+	"github.com/spf13/cobra"
+)
+
+const localPreflightOwner = "cmd/swarm local claude_cli preflight/admission owner"
+
+type localPreflightCategory string
+
+const (
+	localPreflightBackendPrerequisite        localPreflightCategory = "backend_prerequisite"
+	localPreflightWorkspacePrerequisite      localPreflightCategory = "workspace_prerequisite"
+	localPreflightServeListenerPrerequisite  localPreflightCategory = "serve_listener_prerequisite"
+	localPreflightGatewayPrerequisite        localPreflightCategory = "gateway_prerequisite"
+	localPreflightContractSecretPrerequisite localPreflightCategory = "contract_secret_prerequisite"
+	localPreflightDevConveniencePrerequisite localPreflightCategory = "dev_convenience_prerequisite"
+)
+
+type localPreflightSeverity string
+
+const (
+	localPreflightSeverityInfo    localPreflightSeverity = "info"
+	localPreflightSeverityWarning localPreflightSeverity = "warning"
+	localPreflightSeverityBlocker localPreflightSeverity = "blocker"
+)
+
+type localPreflightFindingStatus string
+
+const (
+	localPreflightStatusOK      localPreflightFindingStatus = "ok"
+	localPreflightStatusFailed  localPreflightFindingStatus = "failed"
+	localPreflightStatusSkipped localPreflightFindingStatus = "skipped"
+)
+
+type localPreflightFinding struct {
+	Category    localPreflightCategory      `json:"category"`
+	Code        string                      `json:"code"`
+	Status      localPreflightFindingStatus `json:"status"`
+	Severity    localPreflightSeverity      `json:"severity"`
+	Message     string                      `json:"message"`
+	Remediation string                      `json:"remediation,omitempty"`
+	Owner       string                      `json:"owner"`
+}
+
+type localPreflightReport struct {
+	OK       bool                    `json:"ok"`
+	Owner    string                  `json:"owner"`
+	Mode     string                  `json:"mode"`
+	Backend  string                  `json:"backend"`
+	Findings []localPreflightFinding `json:"findings"`
+}
+
+type localPreflightRequest struct {
+	Mode                   string
+	RepoRoot               string
+	Config                 *config.Config
+	ResolvedPaths          cliContractPlatformSpecPaths
+	DataSource             string
+	WorkspaceBackend       workspaceBackendSelection
+	APIListenAddr          string
+	MCPListenAddr          string
+	CheckListeners         bool
+	CheckGatewayEnv        bool
+	CheckContractSecrets   bool
+	ContractSecretSeverity localPreflightSeverity
+}
+
+func runLocalClaudeCLIPreflight(ctx context.Context, req localPreflightRequest) localPreflightReport {
+	report := localPreflightReport{
+		OK:    true,
+		Owner: localPreflightOwner,
+		Mode:  strings.TrimSpace(req.Mode),
+	}
+	if report.Mode == "" {
+		report.Mode = "unknown"
+	}
+	if req.Config == nil {
+		report.add(localPreflightBackendPrerequisite, "config_missing", localPreflightSeverityBlocker, localPreflightStatusFailed, "runtime config is required", "load runtime config through the serve/run config owner")
+		return report.finalize()
+	}
+	profile, err := req.Config.LLMBackendProfile()
+	if err != nil {
+		report.add(localPreflightBackendPrerequisite, "backend_profile_invalid", localPreflightSeverityBlocker, localPreflightStatusFailed, err.Error(), "set a supported backend with --backend or llm.backend")
+		return report.finalize()
+	}
+	report.Backend = strings.TrimSpace(profile.ID)
+	if profile.ID != llmselection.BackendClaudeCLI {
+		report.add(localPreflightBackendPrerequisite, "backend_not_claude_cli", localPreflightSeverityInfo, localPreflightStatusSkipped, fmt.Sprintf("backend %q does not require claude_cli local proof prerequisites", profile.ID), "")
+		return report.finalize()
+	}
+
+	if err := llmselection.RequireCredential(profile, os.LookupEnv); err != nil {
+		report.add(localPreflightBackendPrerequisite, "missing_backend_credential", localPreflightSeverityBlocker, localPreflightStatusFailed, err.Error(), fmt.Sprintf("set %s for claude_cli backend authentication", strings.TrimSpace(profile.Credential.EnvVar)))
+	} else {
+		report.add(localPreflightBackendPrerequisite, "backend_credential_present", localPreflightSeverityInfo, localPreflightStatusOK, fmt.Sprintf("%s is present", strings.TrimSpace(profile.Credential.EnvVar)), "")
+	}
+
+	if req.CheckListeners {
+		report.checkListener("api_listener", "api", req.APIListenAddr)
+		report.checkListener("mcp_listener", "mcp", req.MCPListenAddr)
+	}
+	if req.CheckGatewayEnv {
+		report.checkGatewayEnv(req.MCPListenAddr)
+	}
+
+	source, contractsRoot, err := loadLocalPreflightSource(req.RepoRoot, req.ResolvedPaths)
+	if err != nil {
+		report.add(localPreflightWorkspacePrerequisite, "contract_source_load_failed", localPreflightSeverityBlocker, localPreflightStatusFailed, err.Error(), "fix the selected --contracts and --platform-spec paths")
+		return report.finalize()
+	}
+	if req.CheckContractSecrets {
+		report.checkContractSecrets(ctx, source, req.ContractSecretSeverity)
+	}
+	if !sourceDeclaresAgents(source) {
+		report.add(localPreflightWorkspacePrerequisite, "agent_free_source", localPreflightSeverityInfo, localPreflightStatusSkipped, "selected contract source declares no agents; claude_cli workspace proof is not required", "")
+		return report.finalize()
+	}
+	report.checkWorkspace(ctx, req.RepoRoot, req.Config, source, contractsRoot, req.DataSource, req.WorkspaceBackend)
+	return report.finalize()
+}
+
+func (r *localPreflightReport) add(category localPreflightCategory, code string, severity localPreflightSeverity, status localPreflightFindingStatus, message, remediation string) {
+	if r == nil {
+		return
+	}
+	code = strings.TrimSpace(code)
+	message = strings.TrimSpace(message)
+	if severity == "" {
+		severity = localPreflightSeverityInfo
+	}
+	if status == "" {
+		status = localPreflightStatusOK
+	}
+	r.Findings = append(r.Findings, localPreflightFinding{
+		Category:    category,
+		Code:        code,
+		Status:      status,
+		Severity:    severity,
+		Message:     message,
+		Remediation: strings.TrimSpace(remediation),
+		Owner:       localPreflightOwner,
+	})
+}
+
+func (r localPreflightReport) finalize() localPreflightReport {
+	r.OK = !r.HasBlockers()
+	sort.SliceStable(r.Findings, func(i, j int) bool {
+		if r.Findings[i].Severity != r.Findings[j].Severity {
+			return localPreflightSeverityRank(r.Findings[i].Severity) > localPreflightSeverityRank(r.Findings[j].Severity)
+		}
+		if r.Findings[i].Category != r.Findings[j].Category {
+			return r.Findings[i].Category < r.Findings[j].Category
+		}
+		return r.Findings[i].Code < r.Findings[j].Code
+	})
+	return r
+}
+
+func localPreflightSeverityRank(severity localPreflightSeverity) int {
+	switch severity {
+	case localPreflightSeverityBlocker:
+		return 3
+	case localPreflightSeverityWarning:
+		return 2
+	default:
+		return 1
+	}
+}
+
+func (r localPreflightReport) HasBlockers() bool {
+	for _, finding := range r.Findings {
+		if finding.Severity == localPreflightSeverityBlocker && finding.Status == localPreflightStatusFailed {
+			return true
+		}
+	}
+	return false
+}
+
+func (r localPreflightReport) BlockerSummary() string {
+	parts := []string{}
+	for _, finding := range r.Findings {
+		if finding.Severity == localPreflightSeverityBlocker && finding.Status == localPreflightStatusFailed {
+			parts = append(parts, strings.TrimSpace(finding.Code)+": "+strings.TrimSpace(finding.Message))
+		}
+	}
+	if len(parts) == 0 {
+		return ""
+	}
+	return strings.Join(parts, "; ")
+}
+
+func (r *localPreflightReport) checkListener(code, name, addr string) {
+	listener, err := listenServeHTTPListener(name, addr)
+	if err != nil {
+		r.add(localPreflightServeListenerPrerequisite, code, localPreflightSeverityBlocker, localPreflightStatusFailed, err.Error(), fmt.Sprintf("free the %s listener address or choose a different --%s-listen-addr", name, name))
+		return
+	}
+	_ = listener.Close()
+	r.add(localPreflightServeListenerPrerequisite, code, localPreflightSeverityInfo, localPreflightStatusOK, fmt.Sprintf("%s listener address %s is available", name, strings.TrimSpace(addr)), "")
+}
+
+func (r *localPreflightReport) checkGatewayEnv(mcpListenAddr string) {
+	addr, ok, err := resolvedGatewayCheckAddr(mcpListenAddr)
+	if err != nil {
+		r.add(localPreflightGatewayPrerequisite, "mcp_listener_unavailable", localPreflightSeverityBlocker, localPreflightStatusFailed, err.Error(), "set a valid --mcp-listen-addr")
+		return
+	}
+	if !ok {
+		r.add(localPreflightGatewayPrerequisite, "gateway_env_port_deferred", localPreflightSeverityInfo, localPreflightStatusSkipped, "MCP listener uses port 0; gateway env validation is deferred until serve binds the actual listener", "")
+		return
+	}
+	for _, name := range []string{"SWARM_TOOL_GATEWAY_URL", "SWARM_TOOL_GATEWAY_CONTAINER_URL"} {
+		if err := validateExistingServeGatewayURL(name, lookupEnvValue(name), addr); err != nil {
+			r.add(localPreflightGatewayPrerequisite, strings.ToLower(name)+"_stale", localPreflightSeverityBlocker, localPreflightStatusFailed, err.Error(), fmt.Sprintf("unset %s or point it at the selected MCP listener port", name))
+		} else {
+			r.add(localPreflightGatewayPrerequisite, strings.ToLower(name)+"_valid", localPreflightSeverityInfo, localPreflightStatusOK, fmt.Sprintf("%s is empty or targets the selected MCP listener", name), "")
+		}
+	}
+}
+
+func (r *localPreflightReport) checkContractSecrets(ctx context.Context, source semanticview.Source, severity localPreflightSeverity) {
+	if severity == "" {
+		severity = localPreflightSeverityWarning
+	}
+	store, err := buildCredentialStore()
+	if err != nil {
+		r.add(localPreflightContractSecretPrerequisite, "credential_store_unavailable", localPreflightSeverityBlocker, localPreflightStatusFailed, err.Error(), "fix the local credential store or SWARM_CREDENTIALS_FILE")
+		return
+	}
+	missing, err := runtimecredentials.MissingRequired(ctx, store, source)
+	if err != nil {
+		r.add(localPreflightContractSecretPrerequisite, "contract_secret_check_failed", localPreflightSeverityBlocker, localPreflightStatusFailed, err.Error(), "fix contract credential references or credential store access")
+		return
+	}
+	if len(missing) == 0 {
+		r.add(localPreflightContractSecretPrerequisite, "contract_secrets_present", localPreflightSeverityInfo, localPreflightStatusOK, "all contract-required secrets are present", "")
+		return
+	}
+	for _, desc := range missing {
+		record := secretRecordFromDescriptor(desc)
+		message := fmt.Sprintf("required secret %q is missing", record.Key)
+		if requiredBy := formatSecretRequirements(record.RequiredBy); requiredBy != "" {
+			message += " for " + requiredBy
+		}
+		r.add(localPreflightContractSecretPrerequisite, "missing_contract_secret", severity, localPreflightStatusFailed, message, fmt.Sprintf("run `swarm secrets set %s` or provide the matching environment variable", record.Key))
+	}
+}
+
+func (r *localPreflightReport) checkWorkspace(ctx context.Context, repo string, cfg *config.Config, source semanticview.Source, contractsRoot, dataSource string, backend workspaceBackendSelection) {
+	mountSources, err := resolveWorkspaceMountSources(repo, dataSource, cfg)
+	if err != nil {
+		r.add(localPreflightWorkspacePrerequisite, "workspace_data_source_invalid", localPreflightSeverityBlocker, localPreflightStatusFailed, err.Error(), "fix --data, workspace.data_source, or SWARM_WORKSPACE_DATA_SOURCE")
+		return
+	}
+	workspaces, err := configuredWorkspaceLifecycleForServe(nil, contractsRoot, source, mountSources, backend)
+	if err != nil {
+		r.add(localPreflightWorkspacePrerequisite, "workspace_config_invalid", localPreflightSeverityBlocker, localPreflightStatusFailed, err.Error(), "fix workspace backend or mount configuration")
+		return
+	}
+	if workspaces == nil {
+		r.add(localPreflightWorkspacePrerequisite, "workspace_lifecycle_missing", localPreflightSeverityBlocker, localPreflightStatusFailed, "workspace lifecycle is not configured", "select a supported workspace backend")
+		return
+	}
+	if err := workspaces.ValidateSource(ctx, source); err != nil {
+		r.add(localPreflightWorkspacePrerequisite, "workspace_source_invalid", localPreflightSeverityBlocker, localPreflightStatusFailed, err.Error(), "fix workspace_class declarations in the selected contracts")
+		return
+	}
+	dockerManager, ok := workspaces.(*workspace.DockerManager)
+	if !ok {
+		r.add(localPreflightWorkspacePrerequisite, "workspace_backend_unsupported", localPreflightSeverityBlocker, localPreflightStatusFailed, fmt.Sprintf("workspace backend %q does not support claude_cli local proof", strings.TrimSpace(backend.Backend)), "use --workspace-backend docker for claude_cli local proof; host claude_cli support is split separately")
+		return
+	}
+	if err := dockerManager.CheckDockerAvailable(ctx); err != nil {
+		r.add(localPreflightWorkspacePrerequisite, "docker_unavailable", localPreflightSeverityBlocker, localPreflightStatusFailed, err.Error(), "start Docker or set SWARM_DOCKER_BIN to a working Docker-compatible CLI")
+	} else {
+		r.add(localPreflightWorkspacePrerequisite, "docker_available", localPreflightSeverityInfo, localPreflightStatusOK, "Docker is reachable", "")
+	}
+	if err := dockerManager.CheckWorkspaceImageAvailable(ctx); err != nil {
+		r.add(localPreflightWorkspacePrerequisite, "workspace_image_unavailable", localPreflightSeverityBlocker, localPreflightStatusFailed, err.Error(), "build or pull the configured workspace image, or set SWARM_WORKSPACE_IMAGE")
+	} else {
+		r.add(localPreflightWorkspacePrerequisite, "workspace_image_available", localPreflightSeverityInfo, localPreflightStatusOK, "workspace image is available", "")
+	}
+	if err := dockerManager.CheckWorkspaceCLICommandAvailable(ctx, cfg.LLM.ClaudeCLI.Command); err != nil {
+		r.add(localPreflightWorkspacePrerequisite, "workspace_claude_cli_unavailable", localPreflightSeverityBlocker, localPreflightStatusFailed, err.Error(), "build or pull a workspace image that contains the configured Claude CLI command")
+	} else {
+		r.add(localPreflightWorkspacePrerequisite, "workspace_claude_cli_available", localPreflightSeverityInfo, localPreflightStatusOK, "workspace image can execute the configured Claude CLI command", "")
+	}
+}
+
+func loadLocalPreflightSource(repo string, paths cliContractPlatformSpecPaths) (semanticview.Source, string, error) {
+	contractsRoot, err := normalizeContractsRoot(paths.ContractsPath)
+	if err != nil {
+		return nil, "", fmt.Errorf("resolve contracts: %w", err)
+	}
+	_, bundle, err := newSwarmWorkflowModule(assetCommandRepoRoot(repo), contractsRoot, paths.PlatformSpecPath)
+	if err != nil {
+		return nil, "", fmt.Errorf("load Swarm contracts: %w", err)
+	}
+	return semanticview.Wrap(bundle), contractsRoot, nil
+}
+
+func sourceDeclaresAgents(source semanticview.Source) bool {
+	return source != nil && len(source.AgentEntries()) > 0
+}
+
+func resolvedGatewayCheckAddr(mcpListenAddr string) (net.Addr, bool, error) {
+	addr := strings.TrimSpace(mcpListenAddr)
+	if err := validateServeListenAddr("--mcp-listen-addr", addr); err != nil {
+		return nil, false, err
+	}
+	host, port, err := net.SplitHostPort(addr)
+	if err != nil {
+		return nil, false, err
+	}
+	if strings.TrimSpace(port) == "" || strings.TrimSpace(port) == "0" {
+		return nil, false, nil
+	}
+	resolved, err := net.ResolveTCPAddr("tcp", net.JoinHostPort(host, port))
+	if err != nil {
+		return nil, false, err
+	}
+	return resolved, true, nil
+}
+
+func lookupEnvValue(name string) string {
+	return os.Getenv(name)
+}
+
+func writeLocalPreflightText(out io.Writer, report localPreflightReport) {
+	if out == nil {
+		return
+	}
+	status := "ok"
+	if !report.OK {
+		status = "failed"
+	}
+	fmt.Fprintf(out, "claude_cli preflight: %s\n", status)
+	for _, finding := range report.Findings {
+		fmt.Fprintf(out, "[%s] %s/%s: %s\n", strings.ToUpper(string(finding.Severity)), finding.Category, finding.Code, finding.Message)
+		if finding.Remediation != "" {
+			fmt.Fprintf(out, "  remediation: %s\n", finding.Remediation)
+		}
+	}
+}
+
+func writeLocalPreflightJSON(out io.Writer, report localPreflightReport) error {
+	if out == nil {
+		return nil
+	}
+	encoder := json.NewEncoder(out)
+	encoder.SetIndent("", "  ")
+	return encoder.Encode(report)
+}
+
+func returnLocalPreflightResult(cmd *cobra.Command, report localPreflightReport, asJSON bool) error {
+	if asJSON {
+		if err := writeLocalPreflightJSON(cmd.OutOrStdout(), report); err != nil {
+			return err
+		}
+	} else {
+		writeLocalPreflightText(cmd.OutOrStdout(), report)
+	}
+	if !report.OK {
+		return commandExitError{code: cliExitRuntime}
+	}
+	return nil
+}
+
+func localPreflightCommandSeverityForContractSecrets(mode string) localPreflightSeverity {
+	if strings.EqualFold(strings.TrimSpace(mode), "doctor") {
+		return localPreflightSeverityBlocker
+	}
+	return localPreflightSeverityWarning
+}
+
+func shouldRunServeLocalClaudeCLIPreflight(opts serveOptions) bool {
+	if strings.TrimSpace(opts.BundleHash) != "" || len(opts.BundleHashes) > 0 {
+		return false
+	}
+	return true
+}
+
+func serveLocalPreflightMode(opts serveOptions) string {
+	if opts.LocalRun {
+		return "run_local"
+	}
+	if opts.Dev {
+		return "serve_dev"
+	}
+	return "serve"
+}
+
+func runServeLocalClaudeCLIPreflight(ctx context.Context, repo string, opts serveOptions, cfg *config.Config, resolvedPaths cliContractPlatformSpecPaths, workspaceBackend workspaceBackendSelection) localPreflightReport {
+	mode := serveLocalPreflightMode(opts)
+	return runLocalClaudeCLIPreflight(ctx, localPreflightRequest{
+		Mode:                   mode,
+		RepoRoot:               repo,
+		Config:                 cfg,
+		ResolvedPaths:          resolvedPaths,
+		DataSource:             opts.DataSource,
+		WorkspaceBackend:       workspaceBackend,
+		APIListenAddr:          opts.APIListenAddr,
+		MCPListenAddr:          opts.MCPListenAddr,
+		CheckListeners:         true,
+		CheckGatewayEnv:        true,
+		CheckContractSecrets:   true,
+		ContractSecretSeverity: localPreflightCommandSeverityForContractSecrets(mode),
+	})
+}

--- a/cmd/swarm/main.go
+++ b/cmd/swarm/main.go
@@ -348,6 +348,7 @@ type serveOptions struct {
 	AbandonActiveRuns                bool
 	Verbose                          bool
 	Output                           io.Writer
+	LocalRun                         bool
 	TestEntityStateHook              func(entityID, state string)
 	TestWorkflowNodeHandlerStartHook runtimepipeline.WorkflowNodeHandlerStartHook
 	TestLifecycleProbe               runtimelifecycleprobe.Observer
@@ -789,6 +790,18 @@ func runServeRuntime(ctx context.Context, repo string, opts serveOptions) int {
 		reporter.emit(2, "config_load", "FAILED", err.Error())
 		log.Printf("resolve workspace backend: %v", err)
 		return 1
+	}
+	if shouldRunServeLocalClaudeCLIPreflight(opts) {
+		preflight := runServeLocalClaudeCLIPreflight(ctx, repo, opts, cfg, resolvedPaths, workspaceBackend)
+		if preflight.HasBlockers() {
+			detail := preflight.BlockerSummary()
+			reporter.emit(2, "local_preflight", "FAILED", detail)
+			if opts.Output != nil {
+				writeLocalPreflightText(opts.Output, preflight)
+			}
+			log.Printf("local claude_cli preflight failed: %s", detail)
+			return 3
+		}
 	}
 	storeSelection, err := resolveRuntimeStoreSelection(repo, opts.StoreMode, opts.StoreModeSet, cfg)
 	if err != nil {

--- a/cmd/swarm/run_command.go
+++ b/cmd/swarm/run_command.go
@@ -368,6 +368,7 @@ func startLocalRunServe(ctx context.Context, repo string, opts runCommandOptions
 	serveOpts.ContractsPath = resolvedPaths.ContractsPath
 	serveOpts.DataSource = opts.dataSource
 	serveOpts.PlatformSpecPath = resolvedPaths.PlatformSpecPath
+	serveOpts.LocalRun = true
 	if opts.apiPort > 0 {
 		serveOpts.APIListenAddr = net.JoinHostPort("127.0.0.1", strconv.Itoa(opts.apiPort))
 	}

--- a/cmd/swarm/run_command_test.go
+++ b/cmd/swarm/run_command_test.go
@@ -66,6 +66,9 @@ func TestRunCommandLocalForegroundConsumesServeOwnerAndV1API(t *testing.T) {
 		if serveOpts.Verbose {
 			t.Errorf("local run serve opts Verbose = true, want default non-verbose schema summary owner")
 		}
+		if !serveOpts.LocalRun {
+			t.Errorf("local run serve opts LocalRun = false, want shared local preflight consumer marker")
+		}
 		<-ctx.Done()
 		close(serveCanceled)
 		return 0

--- a/internal/runtime/workspace/manager.go
+++ b/internal/runtime/workspace/manager.go
@@ -266,14 +266,46 @@ func (m *DockerManager) EnsurePrereqs(ctx context.Context) error {
 	if m == nil {
 		return fmt.Errorf("workspace manager is required")
 	}
-	if err := m.ensureDockerAvailable(ctx); err != nil {
+	if err := m.CheckDockerAvailable(ctx); err != nil {
 		return err
 	}
 	if err := m.ensureWorkspaceNetwork(ctx); err != nil {
 		return err
 	}
-	if err := m.ensureWorkspaceImage(ctx); err != nil {
+	if err := m.CheckWorkspaceImageAvailable(ctx); err != nil {
 		return err
+	}
+	return nil
+}
+
+func (m *DockerManager) CheckDockerAvailable(ctx context.Context) error {
+	if m == nil {
+		return fmt.Errorf("workspace manager is required")
+	}
+	return m.ensureDockerAvailable(ctx)
+}
+
+func (m *DockerManager) CheckWorkspaceImageAvailable(ctx context.Context) error {
+	if m == nil {
+		return fmt.Errorf("workspace manager is required")
+	}
+	return m.ensureWorkspaceImage(ctx)
+}
+
+func (m *DockerManager) CheckWorkspaceCLICommandAvailable(ctx context.Context, command string) error {
+	if m == nil {
+		return fmt.Errorf("workspace manager is required")
+	}
+	image := strings.TrimSpace(m.cfg.WorkspaceImage)
+	if image == "" {
+		return fmt.Errorf("workspace prerequisite failed: workspace image is required")
+	}
+	command = strings.TrimSpace(command)
+	if command == "" {
+		command = "claude"
+	}
+	if _, err := m.RunDocker(ctx, "run", "--rm", "--entrypoint", "sh", image, "-lc", `command -v -- "$1" >/dev/null`, "swarm-cli-proof", command); err != nil {
+		return fmt.Errorf("workspace prerequisite failed: configured Claude CLI command %q is not available in workspace image %q; build or pull a workspace image that includes the Claude CLI, remove stale workspace containers, or set SWARM_WORKSPACE_IMAGE to a compatible image: %w", command, image, err)
 	}
 	return nil
 }

--- a/internal/runtime/workspace/manager.go
+++ b/internal/runtime/workspace/manager.go
@@ -304,8 +304,8 @@ func (m *DockerManager) CheckWorkspaceCLICommandAvailable(ctx context.Context, c
 	if command == "" {
 		command = "claude"
 	}
-	if _, err := m.RunDocker(ctx, "run", "--rm", "--entrypoint", "sh", image, "-lc", `command -v -- "$1" >/dev/null`, "swarm-cli-proof", command); err != nil {
-		return fmt.Errorf("workspace prerequisite failed: configured Claude CLI command %q is not available in workspace image %q; build or pull a workspace image that includes the Claude CLI, remove stale workspace containers, or set SWARM_WORKSPACE_IMAGE to a compatible image: %w", command, image, err)
+	if _, err := m.RunDocker(ctx, "run", "--rm", "--entrypoint", "sh", image, "-lc", `command -v -- "$1" >/dev/null && "$1" --version >/dev/null`, "swarm-cli-proof", command); err != nil {
+		return fmt.Errorf("workspace prerequisite failed: configured Claude CLI command %q cannot execute in workspace image %q; build or pull a workspace image that includes a runnable Claude CLI, remove stale workspace containers, or set SWARM_WORKSPACE_IMAGE to a compatible image: %w", command, image, err)
 	}
 	return nil
 }

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -10746,10 +10746,11 @@ cli_specification:
         prerequisites; dev-only conveniences must not leak into deployment-mode serve.
       owner_consumption_rule: >
         The preflight owner MUST delegate subordinate facts to existing owners: backend profile/credential and retired
-        selector checks consume `llm_provider_selection_config_authority`; contract-required secrets consume
-        `tool_model.credential_store` / `swarm secrets check`; Docker/image/workspace CLI capability consumes the workspace
-        lifecycle owner; listener and gateway validation consume the serve startup/listener owners. Doctor-only or run-only
-        duplicate interpreters are non-authoritative.
+        selector checks consume `llm_provider_selection_config_authority`; the selected backend credential is required only
+        when the selected contract source declares agents, matching runtime's declared-agent credential gate;
+        contract-required secrets consume `tool_model.credential_store` / `swarm secrets check`; Docker/image/workspace CLI
+        capability consumes the workspace lifecycle owner; listener and gateway validation consume the serve startup/listener
+        owners. Doctor-only or run-only duplicate interpreters are non-authoritative.
       split_tail:
       - '#1566 workspace image build/validation path remains split; this owner may report a missing/unusable image but must not build one.'
       - '#1567 API connection discovery and .swarm/connection.* remain split.'
@@ -11496,10 +11497,11 @@ cli_specification:
       owner: cli_specification.foundations.local_claude_cli_preflight_admission
       behavior: >
         Reports typed local prerequisite findings for the selected backend without starting runtime or reading/writing runtime
-        DB state. For `claude_cli`, the command checks backend credential/env selector authority, selected contract source
-        when provided, contract-required secrets through the credential store, Docker/workspace image/Claude CLI availability
-        through the workspace lifecycle owner, API/MCP listener availability, and stale MCP gateway env values through the
-        serve startup owner. JSON output is supported for scripts.
+        DB state. For `claude_cli`, the command checks backend selector authority, applies backend credential authority only
+        when the selected source declares agents, checks selected contract source when provided, contract-required secrets
+        through the credential store, Docker/workspace image/Claude CLI availability through the workspace lifecycle owner,
+        API/MCP listener availability, and stale MCP gateway env values through the serve startup owner. JSON output is
+        supported for scripts.
       split_scope:
       - workspace image build
       - local API connection discovery files

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -10720,6 +10720,42 @@ cli_specification:
       - '#995 schema migration startup diagnostics remain split.'
       - '#979/#1012 selected-contract and multi-bundle gateway materialization remains split.'
       - '#1002 runtime workspace source-root image packaging is closed by PR #1034 and is not reopened.'
+    local_claude_cli_preflight_admission:
+      promoted_by: '#1565'
+      implementation_status: implemented
+      canonical_owner: platform-spec.yaml#cli_specification.foundations.local_claude_cli_preflight_admission
+      implementation_owner: cmd/swarm local claude_cli preflight/admission owner
+      scope: >
+        Merge-bearing authority for local `claude_cli` prerequisite diagnostics and admission. The owner materializes typed
+        prerequisite findings for the selected backend and local runtime path, reports them through `swarm doctor`, and feeds
+        the relevant fail-closed subset into `swarm serve --dev --backend claude_cli` and local foreground
+        `swarm run --backend claude_cli` through the serve startup owner. It is not a deployment profile system and does not
+        build workspace images, write local connection files, or change stale gateway env precedence.
+      finding_categories:
+      - backend_prerequisite
+      - workspace_prerequisite
+      - serve_listener_prerequisite
+      - gateway_prerequisite
+      - contract_secret_prerequisite
+      - dev_convenience_prerequisite
+      command_mode_rule: >
+        `swarm doctor --backend claude_cli` renders the shared findings without starting runtime. `swarm serve --dev
+        --backend claude_cli` and local foreground `swarm run --backend claude_cli` consume the same owner as admission
+        evidence and fail closed before readiness when a blocking prerequisite is missing. Non-dev `swarm serve
+        --backend claude_cli` consumes the runtime-safety subset where the selected disk-contract startup path needs the same
+        prerequisites; dev-only conveniences must not leak into deployment-mode serve.
+      owner_consumption_rule: >
+        The preflight owner MUST delegate subordinate facts to existing owners: backend profile/credential and retired
+        selector checks consume `llm_provider_selection_config_authority`; contract-required secrets consume
+        `tool_model.credential_store` / `swarm secrets check`; Docker/image/workspace CLI capability consumes the workspace
+        lifecycle owner; listener and gateway validation consume the serve startup/listener owners. Doctor-only or run-only
+        duplicate interpreters are non-authoritative.
+      split_tail:
+      - '#1566 workspace image build/validation path remains split; this owner may report a missing/unusable image but must not build one.'
+      - '#1567 API connection discovery and .swarm/connection.* remain split.'
+      - '#1568 stale MCP gateway env precedence/auto-fix policy remains split; this owner may detect/report/fail closed on stale values.'
+      - '#1138/#1213 host workspace claude_cli execution support remains split.'
+      - '#1441 parent local proof setup remains open after this child unless all sibling tails are closed separately.'
     no_args_behavior: '`swarm` with no arguments prints root help and exits 0. Bare `swarm` MUST NOT start the runtime.'
     daemon_startup: '`swarm serve` owns runtime/API/health/MCP startup. `swarm run` may consume the serve startup owner for local foreground start, but MUST NOT fork a second runtime boot owner.'
     cli_consumes_api_rule: 'All CLI commands that read or mutate runtime state consume the canonical API at /v1/rpc or /v1/ws. The only local file-contract carve-out is `swarm verify`, which validates contract files on disk and does not require runtime DB/API state.'
@@ -11453,6 +11489,22 @@ cli_specification:
           - remote server commit
           - remote server build date
           - server-local bundle path
+    doctor:
+      command: swarm doctor --backend claude_cli [--contracts <path>] [--json]
+      tier: should_have
+      implementation_status: implemented
+      owner: cli_specification.foundations.local_claude_cli_preflight_admission
+      behavior: >
+        Reports typed local prerequisite findings for the selected backend without starting runtime or reading/writing runtime
+        DB state. For `claude_cli`, the command checks backend credential/env selector authority, selected contract source
+        when provided, contract-required secrets through the credential store, Docker/workspace image/Claude CLI availability
+        through the workspace lifecycle owner, API/MCP listener availability, and stale MCP gateway env values through the
+        serve startup owner. JSON output is supported for scripts.
+      split_scope:
+      - workspace image build
+      - local API connection discovery files
+      - stale gateway env precedence or auto-fix policy
+      - deployment-mode profile management
     secrets:
       command: swarm secrets set|list|check|rm
       tier: must_have


### PR DESCRIPTION
Closes #1565

## Summary

Adds a spec-backed local `claude_cli` preflight/admission owner and exposes it through `swarm doctor --backend claude_cli`. The same owner now feeds the relevant fail-closed startup path for `swarm serve --dev --backend claude_cli` and local foreground `swarm run --backend claude_cli` through the serve startup owner.

The preflight reports typed findings for backend credentials, contract-required secrets, Docker/workspace image availability, Claude CLI availability inside the workspace image, listener availability, and stale MCP gateway env values. `doctor` renders text or JSON and does not start runtime or read/write runtime DB state.

## Governing refs/context

Exact governing spec sections:

- `platform-spec.yaml` `cli_specification.foundations.local_claude_cli_preflight_admission`
- `platform-spec.yaml` `command_catalog.doctor`
- `platform-spec.yaml` `engine.agent_session_management.llm_provider_selection_config_authority`
- `platform-spec.yaml` `tool_model.credential_store`
- `platform-spec.yaml` `cli_specification.foundations.local_cli_test_gateway_startup`
- `platform-spec.yaml` `cli_specification.foundations.local_cli_test_workspace_cli_availability`
- `platform-spec.yaml` `cli_specification.foundations.api_connection_auth_config_precedence`
- `platform-spec.yaml` `command_catalog.serve`

Binding issue/gate context:

- #1565 issue body and locked design comment
- #1565 Pre-Implementation Coverage Audit
- #1565 independent gate outcome: approved as first slice
- Parent tracker: #1441

## Semantic migration

New canonical owner: `platform-spec.yaml#cli_specification.foundations.local_claude_cli_preflight_admission`, implemented by `cmd/swarm local claude_cli preflight/admission owner`.

Old producer/reader/writer paths now invalid: doctor-only prerequisite helpers, run-only prerequisite helpers, direct contract-secret lookup outside the credential store, direct backend credential interpretation outside backend profile authority, direct Docker/image/CLI probes outside the workspace lifecycle owner, and stale gateway checks that do not consume the serve startup rule.

Production paths checked for surviving old behavior: `swarm doctor`, `swarm serve --dev`, local foreground `swarm run`, non-dev disk-contract `swarm serve --backend claude_cli` runtime-safety subset, `swarm secrets check`, workspace manager prerequisites, backend selection/config loading, serve listener binding, and serve MCP gateway env validation.

Migration completeness: complete for the #1565 chosen working failure class. Parent #1441 remains open for #1566 workspace image build/validation, #1567 API connection discovery, #1568 stale gateway env policy, and documentation/local proof tails.

## Verification

- `go test ./cmd/swarm ./internal/runtime/workspace`
- `go test ./internal/store` after an initial unrelated SQLite lock timing failure in the first whole-suite attempt
- `go test ./...`
