### PR TITLE
[agent-a][issue #1549] Add singleton coordinator mode

### DIFF
--- a/internal/apispec/platform_spec_flow_instance_authoring_test.go
+++ b/internal/apispec/platform_spec_flow_instance_authoring_test.go
@@ -174,6 +174,7 @@ func TestPlatformSpecFlowInstanceAuthoringSourceAuthority(t *testing.T) {
 		"bare mode: static used as singleton/coordinator proof",
 		"mode: singleton declares template instance fields",
 		"singleton flow primary entity lacks typed contained map/list state",
+		"singleton flow contained map/list value or item types do not resolve",
 		"agent conversation/session memory is used as coordinator state authority",
 		"contained map/list items are targeted as route recipients",
 	} {

--- a/internal/apispec/platform_spec_flow_instance_authoring_test.go
+++ b/internal/apispec/platform_spec_flow_instance_authoring_test.go
@@ -160,8 +160,35 @@ func TestPlatformSpecFlowInstanceAuthoringSourceAuthority(t *testing.T) {
 	assertScalarContains(t, mustMappingValue(t, contained, "rule"), "promoted to a child/template")
 
 	coordinator := mustMappingValue(t, authoring, "singleton_coordinator_model")
+	assertScalarValue(t, mustMappingValue(t, coordinator, "status"), "merge_bearing_contract_runtime_behavior")
 	assertScalarValue(t, mustMappingValue(t, coordinator, "implementation_tracker"), "#1549")
+	assertScalarValue(t, mustMappingValue(t, coordinator, "declaration_surface"), "mode: singleton")
+	assertScalarContains(t, mustMappingValue(t, coordinator, "canonical_code_owner"), "ResolveFlowSingletonCoordinator")
+	assertScalarContains(t, mustMappingValue(t, coordinator, "canonical_code_owner"), "checkSingletonCoordinatorValidation")
+	assertScalarContains(t, mustMappingValue(t, coordinator, "canonical_code_owner"), "applyContainedDataOperation")
 	assertScalarContains(t, mustMappingValue(t, coordinator, "rule"), "shared policy, aggregate state, or cross-instance learning")
+	assertScalarContains(t, mustMappingValue(t, coordinator, "rule"), "Bare `mode: static` is")
+	assertScalarContains(t, mustMappingValue(t, coordinator, "lifecycle_policy"), "archive, roll up, clean up, or promote")
+	assertScalarContains(t, mustMappingValue(t, coordinator, "promotion_rule"), "#1553")
+	for _, want := range []string{
+		"bare mode: static used as singleton/coordinator proof",
+		"mode: singleton declares template instance fields",
+		"singleton flow primary entity lacks typed contained map/list state",
+		"agent conversation/session memory is used as coordinator state authority",
+		"contained map/list items are targeted as route recipients",
+	} {
+		if !sequenceContainsScalar(mustMappingValue(t, coordinator, "fail_closed"), want) {
+			t.Fatalf("singleton_coordinator_model.fail_closed missing %q", want)
+		}
+	}
+	for _, want := range []string{
+		"mode: static as implicit coordinator declaration",
+		"agent conversation_mode or session_scope memory",
+	} {
+		if !sequenceContainsScalar(mustMappingValue(t, coordinator, "non_authoritative_paths"), want) {
+			t.Fatalf("singleton_coordinator_model.non_authoritative_paths missing %q", want)
+		}
+	}
 
 	escapeHatches := mustMappingValue(t, authoring, "escape_hatches")
 	staticMulti := mustMappingValue(t, escapeHatches, "static_multi_entity_flows")
@@ -210,6 +237,7 @@ func TestPlatformSpecFlowInstanceAuthoringSourceAuthority(t *testing.T) {
 		{"ambiguous_key_rejection", "#1545"},
 		{"select_entity_demotion", "#1547"},
 		{"typed_map_list_update_verification", "#1548"},
+		{"singleton_coordinator_contract", "#1549"},
 		{"expand_minimize_tooling", "#1551"},
 	} {
 		assertScalarValue(t, mustYAMLPath(t, analyzer, "children", tc.key), tc.want)

--- a/internal/runtime/bootverify/checks.go
+++ b/internal/runtime/bootverify/checks.go
@@ -245,6 +245,7 @@ var bootCheckRegistry = []Check{
 	{ID: "entity_reader_coverage", Severity: SeverityLintEvidence, Run: checkEntityReaderCoverage},
 	{ID: "primary_entity_validation", Severity: "error", Run: checkPrimaryEntityValidation},
 	{ID: "template_instance_validation", Severity: "error", Run: checkTemplateInstanceValidation},
+	{ID: "singleton_coordinator_validation", Severity: "error", Run: checkSingletonCoordinatorValidation},
 	{ID: "cross_surface_named_type_use", Severity: SeverityLintEvidence, Run: checkCrossSurfaceNamedTypeUse},
 	{ID: "transition_ownership_validation", Severity: "error", Run: checkTransitionOwnershipValidation},
 	{ID: "event_runtime_wiring_validation", Severity: "error", Run: checkEventRuntimeWiringValidation},

--- a/internal/runtime/bootverify/flow_data_access_test.go
+++ b/internal/runtime/bootverify/flow_data_access_test.go
@@ -66,8 +66,8 @@ func TestRun_ValidatesFlowDataAccessDeclarations(t *testing.T) {
 }
 
 func TestBootCheckRegistry_HasFlowDataAccessCheckCount(t *testing.T) {
-	if got := len(bootCheckRegistry); got != 64 {
-		t.Fatalf("bootCheckRegistry count = %d, want 64", got)
+	if got := len(bootCheckRegistry); got != 65 {
+		t.Fatalf("bootCheckRegistry count = %d, want 65", got)
 	}
 }
 

--- a/internal/runtime/bootverify/report_test.go
+++ b/internal/runtime/bootverify/report_test.go
@@ -4864,8 +4864,8 @@ func TestRun_ReportsMissingRuntimeExecutorForOwnedRuntimeEvent(t *testing.T) {
 }
 
 func TestBootCheckRegistry_HasSpecCheckCount(t *testing.T) {
-	if got := len(bootCheckRegistry); got != 64 {
-		t.Fatalf("bootCheckRegistry count = %d, want 64", got)
+	if got := len(bootCheckRegistry); got != 65 {
+		t.Fatalf("bootCheckRegistry count = %d, want 65", got)
 	}
 	if got := len(supplementalChecks); got != 3 {
 		t.Fatalf("supplementalChecks count = %d, want 3", got)

--- a/internal/runtime/bootverify/workflow_singleton_coordinator_checks.go
+++ b/internal/runtime/bootverify/workflow_singleton_coordinator_checks.go
@@ -1,0 +1,43 @@
+package bootverify
+
+import (
+	"fmt"
+	"strings"
+
+	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
+	"github.com/division-sh/swarm/internal/runtime/semanticview"
+)
+
+func checkSingletonCoordinatorValidation(c *checkerContext) []Finding {
+	if c == nil || c.source == nil {
+		return nil
+	}
+	bundle, ok := semanticview.Bundle(c.source)
+	if !ok || bundle == nil {
+		return nil
+	}
+	findings := []Finding{}
+	if bundle.RootSchema != nil && strings.TrimSpace(bundle.RootSchema.Mode) == runtimecontracts.FlowModeSingleton {
+		findings = append(findings, Finding{
+			CheckID:  "singleton_coordinator_validation",
+			Severity: "error",
+			Message:  "flow <root> singleton coordinator invalid: root schema must not declare mode: singleton; singleton coordinators are child flow contracts",
+			Location: "<root>",
+		})
+	}
+	for flowID, schema := range c.source.FlowSchemaEntries() {
+		flowID = strings.TrimSpace(flowID)
+		if flowID == "" || strings.TrimSpace(schema.Mode) != runtimecontracts.FlowModeSingleton {
+			continue
+		}
+		if _, err := bundle.ResolveFlowSingletonCoordinator(flowID); err != nil {
+			findings = append(findings, Finding{
+				CheckID:  "singleton_coordinator_validation",
+				Severity: "error",
+				Message:  fmt.Sprintf("flow %s singleton coordinator invalid: %v", flowID, err),
+				Location: flowID,
+			})
+		}
+	}
+	return findings
+}

--- a/internal/runtime/bootverify/workflow_singleton_coordinator_checks_test.go
+++ b/internal/runtime/bootverify/workflow_singleton_coordinator_checks_test.go
@@ -79,6 +79,27 @@ pins:
 	}
 }
 
+func TestRun_RejectsSingletonCoordinatorUnresolvedContainedType(t *testing.T) {
+	bundle := loadSingletonCoordinatorFixtureBundle(t, `
+name: coordinator
+mode: singleton
+pins:
+  inputs:
+    events: [job.received]
+  outputs:
+    events: []
+`, `
+coordinator_state:
+  verticals: map[text]MissingType
+`, "", "{}\n")
+
+	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+
+	if !reportContains(report.Errors(), "singleton_coordinator_validation", "MissingType") {
+		t.Fatalf("expected singleton_coordinator_validation unresolved contained type error, got %#v", report.Errors())
+	}
+}
+
 func TestRun_DoesNotTreatBareStaticFlowAsSingletonCoordinator(t *testing.T) {
 	bundle := loadSingletonCoordinatorFixtureBundle(t, `
 name: coordinator

--- a/internal/runtime/bootverify/workflow_singleton_coordinator_checks_test.go
+++ b/internal/runtime/bootverify/workflow_singleton_coordinator_checks_test.go
@@ -1,0 +1,192 @@
+package bootverify
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
+	"github.com/division-sh/swarm/internal/runtime/semanticview"
+)
+
+func TestRun_ValidatesSingletonCoordinatorWithContainedState(t *testing.T) {
+	bundle := loadSingletonCoordinatorFixtureBundle(t, `
+name: coordinator
+mode: singleton
+pins:
+  inputs:
+    events: [job.received]
+  outputs:
+    events: []
+`, singletonCoordinatorEntitiesYAML(), "", "{}\n")
+
+	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+
+	if reportContains(report.Errors(), "singleton_coordinator_validation", "") {
+		t.Fatalf("unexpected singleton_coordinator_validation error: %#v", report.Errors())
+	}
+}
+
+func TestRun_RejectsSingletonCoordinatorBackedOnlyByAgentMemory(t *testing.T) {
+	bundle := loadSingletonCoordinatorFixtureBundle(t, `
+name: coordinator
+mode: singleton
+pins:
+  inputs:
+    events: [job.received]
+  outputs:
+    events: []
+`, `
+coordinator_state:
+  status: text
+`, `
+memory-agent:
+  id: memory-agent
+  role: analyst
+  model: regular
+  conversation_mode: session
+  session_scope: flow
+  subscriptions: [job.received]
+`, "{}\n")
+
+	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+
+	if !reportContains(report.Errors(), "singleton_coordinator_validation", "agent conversation memory is not coordinator state authority") {
+		t.Fatalf("expected singleton_coordinator_validation agent-memory authority error, got %#v", report.Errors())
+	}
+}
+
+func TestRun_RejectsSingletonCoordinatorTemplateInstanceMix(t *testing.T) {
+	bundle := loadSingletonCoordinatorFixtureBundle(t, `
+name: coordinator
+mode: singleton
+instance:
+  by: vertical_id
+  on_missing: create
+  on_conflict: reject
+pins:
+  inputs:
+    events: [job.received]
+  outputs:
+    events: []
+`, singletonCoordinatorEntitiesYAML(), "", "{}\n")
+
+	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+
+	if !reportContains(report.Errors(), "singleton_coordinator_validation", "must not declare template instance") {
+		t.Fatalf("expected singleton_coordinator_validation template instance error, got %#v", report.Errors())
+	}
+}
+
+func TestRun_DoesNotTreatBareStaticFlowAsSingletonCoordinator(t *testing.T) {
+	bundle := loadSingletonCoordinatorFixtureBundle(t, `
+name: coordinator
+mode: static
+pins:
+  inputs:
+    events: [job.received]
+  outputs:
+    events: []
+`, `
+coordinator_state:
+  status: text
+`, "", "{}\n")
+
+	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+
+	if reportContains(report.Errors(), "singleton_coordinator_validation", "") {
+		t.Fatalf("bare mode: static must not be interpreted as singleton coordinator, got %#v", report.Errors())
+	}
+}
+
+func TestRun_SingletonCoordinatorRejectsDynamicContainedTargetPath(t *testing.T) {
+	bundle := loadSingletonCoordinatorFixtureBundle(t, `
+name: coordinator
+mode: singleton
+pins:
+  inputs:
+    events: [job.received]
+  outputs:
+    events: []
+`, singletonCoordinatorEntitiesYAML(), "", `
+coordinator-node:
+  id: coordinator-node
+  execution_type: system_node
+  subscribes_to: [job.received]
+  event_handlers:
+    job.received:
+      data_accumulation:
+        writes:
+          - op: set
+            target: entity.verticals[payload.vertical_id]
+            key:
+              ref: payload.vertical_id
+            value:
+              status: active
+              active_jobs: []
+`)
+
+	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+
+	if !reportContains(report.Errors(), "contained_state_operation_compliance", "dynamic bracket path syntax") {
+		t.Fatalf("expected contained_state_operation_compliance dynamic target rejection, got %#v", report.Errors())
+	}
+}
+
+func loadSingletonCoordinatorFixtureBundle(t *testing.T, flowSchema, flowEntities, flowAgents, flowNodes string) *runtimecontracts.WorkflowContractBundle {
+	t.Helper()
+	repoRoot := repoRootForBootverifyTest(t)
+	root := t.TempDir()
+	writeBootverifyFixtureFile(t, filepath.Join(root, "package.yaml"), `
+name: singleton-coordinator-fixture
+version: "1.0.0"
+platform_version: ">=1.0.0"
+flows:
+  - id: coordinator
+    flow: coordinator
+`)
+	writeBootverifyFixtureFile(t, filepath.Join(root, "schema.yaml"), "name: singleton-coordinator-fixture\n")
+	writeBootverifyFixtureFile(t, filepath.Join(root, "policy.yaml"), "{}\n")
+	writeBootverifyFixtureFile(t, filepath.Join(root, "tools.yaml"), "{}\n")
+	writeBootverifyFixtureFile(t, filepath.Join(root, "agents.yaml"), "{}\n")
+	writeBootverifyFixtureFile(t, filepath.Join(root, "events.yaml"), "{}\n")
+	writeBootverifyFixtureFile(t, filepath.Join(root, "nodes.yaml"), "{}\n")
+	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "coordinator", "schema.yaml"), strings.TrimSpace(flowSchema)+"\n")
+	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "coordinator", "types.yaml"), singletonCoordinatorTypesYAML())
+	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "coordinator", "entities.yaml"), strings.TrimSpace(flowEntities)+"\n")
+	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "coordinator", "events.yaml"), `
+job.received:
+  vertical_id: text
+  job: Job
+`)
+	if strings.TrimSpace(flowAgents) == "" {
+		flowAgents = "{}\n"
+	}
+	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "coordinator", "agents.yaml"), strings.TrimSpace(flowAgents)+"\n")
+	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "coordinator", "nodes.yaml"), strings.TrimSpace(flowNodes)+"\n")
+	bundle, err := runtimecontracts.LoadWorkflowContractBundleWithOverrides(repoRoot, root, runtimecontracts.DefaultPlatformSpecFile(repoRoot))
+	if err != nil {
+		t.Fatalf("LoadWorkflowContractBundleWithOverrides: %v", err)
+	}
+	return bundle
+}
+
+func singletonCoordinatorTypesYAML() string {
+	return `
+types:
+  VerticalState:
+    status: text
+    active_jobs: "[Job]"
+  Job:
+    id: text
+    title: text
+`
+}
+
+func singletonCoordinatorEntitiesYAML() string {
+	return `
+coordinator_state:
+  verticals: map[text]VerticalState
+`
+}

--- a/internal/runtime/contracts/workflow_contract_types.go
+++ b/internal/runtime/contracts/workflow_contract_types.go
@@ -728,6 +728,13 @@ type FlowSchemaDocument struct {
 	InstanceVariables FlowInstanceVariables           `yaml:"instance_variables"`
 	AutoEmitOnCreate  AutoEmitOnCreateContract        `yaml:"auto_emit_on_create"`
 }
+
+const (
+	FlowModeStatic    = "static"
+	FlowModeTemplate  = "template"
+	FlowModeSingleton = "singleton"
+)
+
 type FlowToolSurfaceContract struct {
 	RoleScopedEntityTools bool `yaml:"role_scoped_entity_tools"`
 }
@@ -749,6 +756,18 @@ type TemplateInstanceContract struct {
 	OnMissing     string
 	OnConflict    string
 	PrimaryEntity PrimaryEntityContract
+}
+
+type SingletonCoordinatorContract struct {
+	FlowID         string
+	PrimaryEntity  PrimaryEntityContract
+	ContainedState []SingletonCoordinatorContainedField
+}
+
+type SingletonCoordinatorContainedField struct {
+	Name string
+	Type string
+	Kind string
 }
 
 type TemplateInstanceKeyValue struct {

--- a/internal/runtime/contracts/workflow_contract_wave1_accessors.go
+++ b/internal/runtime/contracts/workflow_contract_wave1_accessors.go
@@ -28,7 +28,7 @@ func (b *WorkflowContractBundle) ResolveFlowTemplateInstance(flowID string) (Tem
 		return TemplateInstanceContract{}, fmt.Errorf("INVALID-TEMPLATE-INSTANCE: flow %s template instance is unavailable: schema not found", flowID)
 	}
 	mode := strings.TrimSpace(schema.Mode)
-	if mode != "template" {
+	if mode != FlowModeTemplate {
 		if !schema.Instance.Empty() {
 			return TemplateInstanceContract{}, fmt.Errorf("INVALID-TEMPLATE-INSTANCE: flow %s declares instance but is not mode: template", flowID)
 		}
@@ -60,6 +60,70 @@ func (b *WorkflowContractBundle) ResolveFlowTemplateInstance(flowID string) (Tem
 		OnConflict:    onConflict,
 		PrimaryEntity: primary,
 	}, nil
+}
+
+func (b *WorkflowContractBundle) ResolveFlowSingletonCoordinator(flowID string) (SingletonCoordinatorContract, error) {
+	flowID = strings.TrimSpace(flowID)
+	label := defaultPrimaryEntityFlowLabel(flowID)
+	if b == nil {
+		return SingletonCoordinatorContract{}, fmt.Errorf("INVALID-SINGLETON-COORDINATOR: flow %s singleton coordinator is unavailable: bundle is nil", label)
+	}
+	if flowID == "" {
+		return SingletonCoordinatorContract{}, fmt.Errorf("INVALID-SINGLETON-COORDINATOR: flow <root> cannot declare singleton coordinator ownership; singleton coordinators are child flow contracts")
+	}
+	schema, ok := b.FlowSchemas[flowID]
+	if !ok {
+		return SingletonCoordinatorContract{}, fmt.Errorf("INVALID-SINGLETON-COORDINATOR: flow %s singleton coordinator is unavailable: schema not found", flowID)
+	}
+	if mode := strings.TrimSpace(schema.Mode); mode != FlowModeSingleton {
+		return SingletonCoordinatorContract{}, fmt.Errorf("INVALID-SINGLETON-COORDINATOR: flow %s is not mode: singleton", flowID)
+	}
+	if !schema.Instance.Empty() {
+		return SingletonCoordinatorContract{}, fmt.Errorf("INVALID-SINGLETON-COORDINATOR: flow %s mode: singleton must not declare template instance", flowID)
+	}
+	primary, err := b.ResolveFlowPrimaryEntity(flowID)
+	if err != nil {
+		return SingletonCoordinatorContract{}, fmt.Errorf("INVALID-SINGLETON-COORDINATOR: flow %s primary entity required for singleton coordinator state: %w", flowID, err)
+	}
+	contained := singletonCoordinatorContainedFields(primary)
+	if len(contained) == 0 {
+		return SingletonCoordinatorContract{}, fmt.Errorf("INVALID-SINGLETON-COORDINATOR: flow %s mode: singleton must declare at least one typed contained map/list field on primary entity %s; agent conversation memory is not coordinator state authority", flowID, primary.EntityType)
+	}
+	return SingletonCoordinatorContract{
+		FlowID:         flowID,
+		PrimaryEntity:  primary,
+		ContainedState: contained,
+	}, nil
+}
+
+func singletonCoordinatorContainedFields(primary PrimaryEntityContract) []SingletonCoordinatorContainedField {
+	fields := sortedEntityFieldKeys(primary.Contract.Fields)
+	out := make([]SingletonCoordinatorContainedField, 0, len(fields))
+	for _, field := range fields {
+		decl := primary.Contract.Fields[field]
+		kind := singletonCoordinatorContainedKind(decl.Type)
+		if kind == "" {
+			continue
+		}
+		out = append(out, SingletonCoordinatorContainedField{
+			Name: field,
+			Type: strings.TrimSpace(decl.Type),
+			Kind: kind,
+		})
+	}
+	return out
+}
+
+func singletonCoordinatorContainedKind(typeRef string) string {
+	typeRef = strings.TrimSpace(typeRef)
+	switch {
+	case strings.HasPrefix(typeRef, "map["):
+		return "map"
+	case templateInstanceIsListType(typeRef):
+		return "list"
+	default:
+		return ""
+	}
 }
 
 func validateTemplateInstanceBy(flowID string, fields []string, primary PrimaryEntityContract) ([]string, error) {
@@ -445,6 +509,18 @@ func resolvePrimaryEntityContract(flowID, declared string, entities EntityContra
 func sortedEntityContractKeys(entities EntityContractsDocument) []string {
 	keys := make([]string, 0, len(entities))
 	for key := range entities {
+		key = strings.TrimSpace(key)
+		if key != "" {
+			keys = append(keys, key)
+		}
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func sortedEntityFieldKeys(fields map[string]EntityFieldDecl) []string {
+	keys := make([]string, 0, len(fields))
+	for key := range fields {
 		key = strings.TrimSpace(key)
 		if key != "" {
 			keys = append(keys, key)

--- a/internal/runtime/contracts/workflow_contract_wave1_accessors.go
+++ b/internal/runtime/contracts/workflow_contract_wave1_accessors.go
@@ -85,7 +85,10 @@ func (b *WorkflowContractBundle) ResolveFlowSingletonCoordinator(flowID string) 
 	if err != nil {
 		return SingletonCoordinatorContract{}, fmt.Errorf("INVALID-SINGLETON-COORDINATOR: flow %s primary entity required for singleton coordinator state: %w", flowID, err)
 	}
-	contained := singletonCoordinatorContainedFields(primary)
+	contained, err := singletonCoordinatorContainedFields(primary)
+	if err != nil {
+		return SingletonCoordinatorContract{}, fmt.Errorf("INVALID-SINGLETON-COORDINATOR: flow %s invalid contained coordinator state: %w", flowID, err)
+	}
 	if len(contained) == 0 {
 		return SingletonCoordinatorContract{}, fmt.Errorf("INVALID-SINGLETON-COORDINATOR: flow %s mode: singleton must declare at least one typed contained map/list field on primary entity %s; agent conversation memory is not coordinator state authority", flowID, primary.EntityType)
 	}
@@ -96,12 +99,15 @@ func (b *WorkflowContractBundle) ResolveFlowSingletonCoordinator(flowID string) 
 	}, nil
 }
 
-func singletonCoordinatorContainedFields(primary PrimaryEntityContract) []SingletonCoordinatorContainedField {
+func singletonCoordinatorContainedFields(primary PrimaryEntityContract) ([]SingletonCoordinatorContainedField, error) {
 	fields := sortedEntityFieldKeys(primary.Contract.Fields)
 	out := make([]SingletonCoordinatorContainedField, 0, len(fields))
 	for _, field := range fields {
 		decl := primary.Contract.Fields[field]
-		kind := singletonCoordinatorContainedKind(decl.Type)
+		kind, err := singletonCoordinatorContainedKind(primary, decl.Type)
+		if err != nil {
+			return nil, fmt.Errorf("field %s: %w", field, err)
+		}
 		if kind == "" {
 			continue
 		}
@@ -111,18 +117,127 @@ func singletonCoordinatorContainedFields(primary PrimaryEntityContract) []Single
 			Kind: kind,
 		})
 	}
-	return out
+	return out, nil
 }
 
-func singletonCoordinatorContainedKind(typeRef string) string {
+func singletonCoordinatorContainedKind(primary PrimaryEntityContract, typeRef string) (string, error) {
+	typeRef = strings.TrimSpace(typeRef)
+	if keyType, valueType, ok := singletonCoordinatorMapTypeParts(typeRef); ok {
+		if err := singletonCoordinatorValidateMapKeyType(primary.Types, keyType); err != nil {
+			return "", err
+		}
+		if err := singletonCoordinatorValidateTypeRef(primary.Types, valueType); err != nil {
+			return "", fmt.Errorf("map value type %q does not resolve: %w", valueType, err)
+		}
+		return "map", nil
+	}
+	if templateInstanceIsListType(typeRef) {
+		itemType := singletonCoordinatorListItemType(typeRef)
+		if strings.TrimSpace(itemType) == "" {
+			return "", fmt.Errorf("list item type is required")
+		}
+		if err := singletonCoordinatorValidateTypeRef(primary.Types, itemType); err != nil {
+			return "", fmt.Errorf("list item type %q does not resolve: %w", itemType, err)
+		}
+		return "list", nil
+	}
+	return "", nil
+}
+
+func singletonCoordinatorValidateTypeRef(types TypeCatalogDocument, typeRef string) error {
+	return singletonCoordinatorValidateTypeRefSeen(types, typeRef, map[string]struct{}{})
+}
+
+func singletonCoordinatorValidateTypeRefSeen(types TypeCatalogDocument, typeRef string, seen map[string]struct{}) error {
+	typeRef = strings.TrimSpace(typeRef)
+	if typeRef == "" {
+		return fmt.Errorf("type is required")
+	}
+	if keyType, valueType, ok := singletonCoordinatorMapTypeParts(typeRef); ok {
+		if err := singletonCoordinatorValidateMapKeyType(types, keyType); err != nil {
+			return err
+		}
+		if err := singletonCoordinatorValidateTypeRefSeen(types, valueType, seen); err != nil {
+			return fmt.Errorf("map value type %q does not resolve: %w", valueType, err)
+		}
+		return nil
+	}
+	if templateInstanceIsListType(typeRef) {
+		itemType := singletonCoordinatorListItemType(typeRef)
+		if strings.TrimSpace(itemType) == "" {
+			return fmt.Errorf("list item type is required")
+		}
+		if err := singletonCoordinatorValidateTypeRefSeen(types, itemType, seen); err != nil {
+			return fmt.Errorf("list item type %q does not resolve: %w", itemType, err)
+		}
+		return nil
+	}
+	if templateInstanceIsTextType(typeRef) ||
+		templateInstanceIsIntegerType(types, typeRef) ||
+		templateInstanceIsNumericType(types, typeRef) ||
+		templateInstanceIsBooleanType(types, typeRef) ||
+		templateInstanceIsJSONObjectType(types, typeRef) ||
+		templateInstanceIsJSONArrayType(types, typeRef) ||
+		templateInstanceIsTimestampType(types, typeRef) ||
+		templateInstanceIsUUIDType(types, typeRef) ||
+		templateInstanceIsEnumType(types, typeRef) {
+		return nil
+	}
+	typeName := templateInstanceTypeName(types, typeRef)
+	named, ok := types.Types[typeName]
+	if !ok {
+		return fmt.Errorf("unsupported contract type %s", typeRef)
+	}
+	if _, ok := seen[typeName]; ok {
+		return nil
+	}
+	seen[typeName] = struct{}{}
+	for field, spec := range named.Fields {
+		if err := singletonCoordinatorValidateTypeRefSeen(types, spec.Type, seen); err != nil {
+			return fmt.Errorf("field %s: %w", strings.TrimSpace(field), err)
+		}
+	}
+	delete(seen, typeName)
+	return nil
+}
+
+func singletonCoordinatorValidateMapKeyType(types TypeCatalogDocument, keyType string) error {
+	if templateInstanceIsTextType(keyType) || templateInstanceIsUUIDType(types, keyType) || templateInstanceIsEnumType(types, keyType) {
+		return nil
+	}
+	return fmt.Errorf("map key type %q is unsupported; use text, uuid, or enum", strings.TrimSpace(keyType))
+}
+
+func singletonCoordinatorMapTypeParts(typeRef string) (string, string, bool) {
+	typeRef = strings.TrimSpace(typeRef)
+	if !strings.HasPrefix(strings.ToLower(typeRef), "map[") {
+		return "", "", false
+	}
+	closeIdx := strings.Index(typeRef, "]")
+	if closeIdx <= len("map[") {
+		return "", "", false
+	}
+	keyType := strings.TrimSpace(typeRef[len("map["):closeIdx])
+	valueType := strings.TrimSpace(typeRef[closeIdx+1:])
+	if keyType == "" || valueType == "" {
+		return "", "", false
+	}
+	return keyType, valueType, true
+}
+
+func singletonCoordinatorListItemType(typeRef string) string {
 	typeRef = strings.TrimSpace(typeRef)
 	switch {
-	case strings.HasPrefix(typeRef, "map["):
-		return "map"
-	case templateInstanceIsListType(typeRef):
-		return "list"
+	case strings.HasPrefix(typeRef, "list<") && strings.HasSuffix(typeRef, ">"):
+		return strings.TrimSpace(typeRef[len("list<") : len(typeRef)-1])
+	case strings.HasSuffix(typeRef, "[]"):
+		return strings.TrimSpace(typeRef[:len(typeRef)-2])
+	case strings.HasPrefix(typeRef, "[]"):
+		return strings.TrimSpace(typeRef[2:])
+	case strings.HasPrefix(typeRef, "[") && strings.HasSuffix(typeRef, "]"):
+		return strings.TrimSpace(typeRef[1 : len(typeRef)-1])
 	default:
-		return ""
+		return typeRef
 	}
 }
 

--- a/internal/runtime/contracts/workflow_contract_wave1_test.go
+++ b/internal/runtime/contracts/workflow_contract_wave1_test.go
@@ -271,6 +271,24 @@ func TestWorkflowContractBundleResolveFlowSingletonCoordinator_UsesPrimaryEntity
 				},
 			},
 		},
+		flowTypes: map[string]TypeCatalogDocument{
+			"coordinator": {
+				Types: map[string]NamedTypeDecl{
+					"VerticalState": {
+						Fields: map[string]TypeFieldSpec{
+							"status":      {Type: "text"},
+							"active_jobs": {Type: "[Job]"},
+						},
+					},
+					"Job": {
+						Fields: map[string]TypeFieldSpec{
+							"id":    {Type: "text"},
+							"title": {Type: "text"},
+						},
+					},
+				},
+			},
+		},
 	}
 
 	resolved, err := bundle.ResolveFlowSingletonCoordinator("coordinator")
@@ -326,6 +344,22 @@ func TestWorkflowContractBundleResolveFlowSingletonCoordinator_RejectsInvalidDec
 			},
 			entities: EntityContractsDocument{"coordinator_state": {Fields: map[string]EntityFieldDecl{"status": {Type: "text"}}}},
 			wantErr:  "agent conversation memory is not coordinator state authority",
+		},
+		{
+			name: "unresolved map value type",
+			schema: FlowSchemaDocument{
+				Mode: FlowModeSingleton,
+			},
+			entities: EntityContractsDocument{"coordinator_state": {Fields: map[string]EntityFieldDecl{"verticals": {Type: "map[text]MissingType"}}}},
+			wantErr:  "MissingType",
+		},
+		{
+			name: "unresolved list item type",
+			schema: FlowSchemaDocument{
+				Mode: FlowModeSingleton,
+			},
+			entities: EntityContractsDocument{"coordinator_state": {Fields: map[string]EntityFieldDecl{"jobs": {Type: "[MissingType]"}}}},
+			wantErr:  "MissingType",
 		},
 		{
 			name: "schema entity restatement",

--- a/internal/runtime/contracts/workflow_contract_wave1_test.go
+++ b/internal/runtime/contracts/workflow_contract_wave1_test.go
@@ -252,6 +252,117 @@ func TestWorkflowContractBundleResolveFlowTemplateInstance_RejectsInvalidDeclara
 	}
 }
 
+func TestWorkflowContractBundleResolveFlowSingletonCoordinator_UsesPrimaryEntityContainedState(t *testing.T) {
+	bundle := &WorkflowContractBundle{
+		FlowSchemas: map[string]FlowSchemaDocument{
+			"coordinator": {
+				Name: "coordinator",
+				Mode: FlowModeSingleton,
+			},
+		},
+		flowEntities: map[string]EntityContractsDocument{
+			"coordinator": {
+				"coordinator_state": {
+					Fields: map[string]EntityFieldDecl{
+						"status":    {Type: "text"},
+						"verticals": {Type: "map[text]VerticalState"},
+						"jobs":      {Type: "[Job]"},
+					},
+				},
+			},
+		},
+	}
+
+	resolved, err := bundle.ResolveFlowSingletonCoordinator("coordinator")
+	if err != nil {
+		t.Fatalf("ResolveFlowSingletonCoordinator: %v", err)
+	}
+	if got := resolved.PrimaryEntity.EntityType; got != "coordinator_state" {
+		t.Fatalf("PrimaryEntity.EntityType = %q, want coordinator_state", got)
+	}
+	if len(resolved.ContainedState) != 2 {
+		t.Fatalf("ContainedState = %#v, want verticals/jobs", resolved.ContainedState)
+	}
+	if got := resolved.ContainedState[0].Name + ":" + resolved.ContainedState[0].Kind; got != "jobs:list" {
+		t.Fatalf("ContainedState[0] = %q, want jobs:list", got)
+	}
+	if got := resolved.ContainedState[1].Name + ":" + resolved.ContainedState[1].Kind; got != "verticals:map" {
+		t.Fatalf("ContainedState[1] = %q, want verticals:map", got)
+	}
+}
+
+func TestWorkflowContractBundleResolveFlowSingletonCoordinator_RejectsInvalidDeclarations(t *testing.T) {
+	tests := []struct {
+		name     string
+		schema   FlowSchemaDocument
+		entities EntityContractsDocument
+		wantErr  string
+	}{
+		{
+			name: "bare static is not singleton",
+			schema: FlowSchemaDocument{
+				Mode: FlowModeStatic,
+			},
+			entities: EntityContractsDocument{"coordinator_state": {Fields: map[string]EntityFieldDecl{"verticals": {Type: "map[text]VerticalState"}}}},
+			wantErr:  "not mode: singleton",
+		},
+		{
+			name: "template instance mix",
+			schema: FlowSchemaDocument{
+				Mode: FlowModeSingleton,
+				Instance: FlowTemplateInstanceDeclaration{
+					By:         []string{"vertical_id"},
+					OnMissing:  "create",
+					OnConflict: "reject",
+				},
+			},
+			entities: EntityContractsDocument{"coordinator_state": {Fields: map[string]EntityFieldDecl{"verticals": {Type: "map[text]VerticalState"}}}},
+			wantErr:  "must not declare template instance",
+		},
+		{
+			name: "agent memory only no contained state",
+			schema: FlowSchemaDocument{
+				Mode: FlowModeSingleton,
+			},
+			entities: EntityContractsDocument{"coordinator_state": {Fields: map[string]EntityFieldDecl{"status": {Type: "text"}}}},
+			wantErr:  "agent conversation memory is not coordinator state authority",
+		},
+		{
+			name: "schema entity restatement",
+			schema: FlowSchemaDocument{
+				Mode:   FlowModeSingleton,
+				Entity: "coordinator_state",
+			},
+			entities: EntityContractsDocument{"coordinator_state": {Fields: map[string]EntityFieldDecl{"verticals": {Type: "map[text]VerticalState"}}}},
+			wantErr:  "schema.yaml entity",
+		},
+		{
+			name: "multiple entity contracts",
+			schema: FlowSchemaDocument{
+				Mode: FlowModeSingleton,
+			},
+			entities: EntityContractsDocument{
+				"coordinator_state": {Fields: map[string]EntityFieldDecl{"verticals": {Type: "map[text]VerticalState"}}},
+				"legacy_state":      {Fields: map[string]EntityFieldDecl{"status": {Type: "text"}}},
+			},
+			wantErr: "multiple entity types",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			bundle := &WorkflowContractBundle{
+				FlowSchemas:  map[string]FlowSchemaDocument{"coordinator": tc.schema},
+				flowEntities: map[string]EntityContractsDocument{"coordinator": tc.entities},
+			}
+			_, err := bundle.ResolveFlowSingletonCoordinator("coordinator")
+			if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("ResolveFlowSingletonCoordinator error = %v, want %q", err, tc.wantErr)
+			}
+		})
+	}
+}
+
 func keyMaterialString(values []TemplateInstanceKeyValue) string {
 	parts := make([]string, 0, len(values))
 	for _, value := range values {

--- a/internal/runtime/contracts/workflow_contract_yaml_test.go
+++ b/internal/runtime/contracts/workflow_contract_yaml_test.go
@@ -341,6 +341,19 @@ instance:
 	}
 }
 
+func TestFlowSchemaDocumentDecode_PreservesSingletonMode(t *testing.T) {
+	var doc FlowSchemaDocument
+	if err := yaml.Unmarshal([]byte(`
+name: coordinator-flow
+mode: singleton
+`), &doc); err != nil {
+		t.Fatalf("yaml.Unmarshal: %v", err)
+	}
+	if got, want := doc.Mode, "singleton"; got != want {
+		t.Fatalf("Mode = %q, want %q", got, want)
+	}
+}
+
 func TestFlowSchemaDocumentDecode_PreservesTemplateInstanceDuplicateKeysForResolver(t *testing.T) {
 	var doc FlowSchemaDocument
 	if err := yaml.Unmarshal([]byte(`

--- a/internal/runtime/engine/executor_test.go
+++ b/internal/runtime/engine/executor_test.go
@@ -2474,6 +2474,89 @@ func TestExecutor_DataAccumulationAppliesTypedContainedOperations(t *testing.T) 
 	}
 }
 
+func TestExecutor_SingletonCoordinatorAppliesContainedStateThroughLoadedContract(t *testing.T) {
+	bundle := loadEngineSingletonCoordinatorFlowBundle(t)
+	if _, err := bundle.ResolveFlowSingletonCoordinator("coordinator"); err != nil {
+		t.Fatalf("ResolveFlowSingletonCoordinator: %v", err)
+	}
+	exec, err := NewExecutor(RuntimeDependencies{
+		Source:     semanticview.Wrap(bundle),
+		StateRepo:  stubStateRepo{},
+		TxRunner:   stubRunner{},
+		Locker:     stubLocker{},
+		Outbox:     stubOutbox{},
+		Dispatcher: stubDispatcher{},
+	}, nil)
+	if err != nil {
+		t.Fatalf("NewExecutor error: %v", err)
+	}
+
+	result, err := exec.Execute(context.Background(), ExecutionRequest{
+		EntityID: "coordinator-1",
+		NodeID:   "coordinator-node",
+		FlowID:   "coordinator",
+		Event: eventtest.RootIngress(
+			"evt-1",
+			"job.received",
+			"",
+			"",
+			json.RawMessage(`{"vertical_id":"north","job":{"id":"job-1","title":"Build"}}`),
+			0,
+			"",
+			"",
+			events.EventEnvelope{},
+			time.Time{},
+		),
+		Handler: runtimecontracts.SystemNodeEventHandler{
+			DataAccumulation: runtimecontracts.WorkflowDataAccumulation{
+				Writes: []runtimecontracts.WorkflowDataWrite{
+					{
+						Operation: runtimecontracts.WorkflowDataOperationSet,
+						TargetRef: "entity.verticals",
+						Key:       runtimecontracts.RefExpression("payload.vertical_id"),
+						Value: runtimecontracts.LiteralExpression(map[string]any{
+							"status":      "active",
+							"active_jobs": []any{},
+						}),
+					},
+					{
+						Operation: runtimecontracts.WorkflowDataOperationAppend,
+						TargetRef: "entity.verticals.active_jobs",
+						Key:       runtimecontracts.RefExpression("payload.vertical_id"),
+						Value:     runtimecontracts.RefExpression("payload.job"),
+					},
+				},
+			},
+		},
+		State: testStateSnapshot("active", map[string]any{
+			"verticals": map[string]any{},
+		}, nil, map[string]map[string]any{}),
+	})
+	if err != nil {
+		t.Fatalf("Execute error: %v", err)
+	}
+
+	verticals, ok := result.StateMutation.Metadata["verticals"].(map[string]any)
+	if !ok {
+		t.Fatalf("verticals = %#v", result.StateMutation.Metadata["verticals"])
+	}
+	north, ok := verticals["north"].(map[string]any)
+	if !ok {
+		t.Fatalf("verticals.north = %#v", verticals["north"])
+	}
+	if got := north["status"]; got != "active" {
+		t.Fatalf("verticals.north.status = %#v, want active", got)
+	}
+	jobs, ok := north["active_jobs"].([]any)
+	if !ok || len(jobs) != 1 {
+		t.Fatalf("verticals.north.active_jobs = %#v", north["active_jobs"])
+	}
+	job, ok := jobs[0].(map[string]any)
+	if !ok || job["id"] != "job-1" || job["title"] != "Build" {
+		t.Fatalf("active job = %#v", jobs[0])
+	}
+}
+
 func TestExecutor_DataAccumulationContainedOperationRejectsMissingMapKey(t *testing.T) {
 	exec, err := NewExecutor(RuntimeDependencies{
 		Source:     stubSourceWithRootEntityContract(),
@@ -3530,6 +3613,69 @@ scoring-node:
   state_schema:
     fields:
       dimensions_received: "[DimensionScore]"
+`)
+
+	repoRoot := repoRootForEngineProjectionTest(t)
+	bundle, err := runtimecontracts.LoadWorkflowContractBundleWithOverrides(repoRoot, root, runtimecontracts.DefaultPlatformSpecFile(repoRoot))
+	if err != nil {
+		t.Fatalf("LoadWorkflowContractBundleWithOverrides: %v", err)
+	}
+	return bundle
+}
+
+func loadEngineSingletonCoordinatorFlowBundle(t *testing.T) *runtimecontracts.WorkflowContractBundle {
+	t.Helper()
+	root := t.TempDir()
+	writeEngineProjectionFixtureFile(t, filepath.Join(root, "package.yaml"), `
+name: singleton-coordinator-runtime
+version: "1.0.0"
+platform_version: ">=1.6.0"
+flows:
+  - id: coordinator
+    flow: coordinator
+    mode: singleton
+`)
+	writeEngineProjectionFixtureFile(t, filepath.Join(root, "schema.yaml"), "name: singleton-coordinator-runtime\n")
+	writeEngineProjectionFixtureFile(t, filepath.Join(root, "policy.yaml"), "{}\n")
+	writeEngineProjectionFixtureFile(t, filepath.Join(root, "tools.yaml"), "{}\n")
+	writeEngineProjectionFixtureFile(t, filepath.Join(root, "agents.yaml"), "{}\n")
+	writeEngineProjectionFixtureFile(t, filepath.Join(root, "events.yaml"), "{}\n")
+	writeEngineProjectionFixtureFile(t, filepath.Join(root, "entities.yaml"), "{}\n")
+	writeEngineProjectionFixtureFile(t, filepath.Join(root, "flows", "coordinator", "schema.yaml"), `
+name: coordinator
+mode: singleton
+initial_state: active
+states: [active]
+pins:
+  inputs:
+    events:
+      - job.received
+  outputs:
+    events: []
+`)
+	writeEngineProjectionFixtureFile(t, filepath.Join(root, "flows", "coordinator", "types.yaml"), `
+types:
+  VerticalState:
+    status: text
+    active_jobs: "[Job]"
+  Job:
+    id: text
+    title: text
+`)
+	writeEngineProjectionFixtureFile(t, filepath.Join(root, "flows", "coordinator", "entities.yaml"), `
+coordinator_state:
+  verticals: map[text]VerticalState
+`)
+	writeEngineProjectionFixtureFile(t, filepath.Join(root, "flows", "coordinator", "events.yaml"), `
+job.received:
+  vertical_id: text
+  job: Job
+`)
+	writeEngineProjectionFixtureFile(t, filepath.Join(root, "flows", "coordinator", "nodes.yaml"), `
+coordinator-node:
+  id: coordinator-node
+  execution_type: system_node
+  event_handlers: {}
 `)
 
 	repoRoot := repoRootForEngineProjectionTest(t)

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -5148,6 +5148,7 @@ flow_model:
         - '#1545'
         - '#1546'
         - '#1548'
+        - '#1549'
       - id: empire_migration_framing
         locked_design_section: Empire migration framing
         coverage: split_to_child
@@ -5168,6 +5169,7 @@ flow_model:
         - '#1546'
         - '#1547'
         - '#1548'
+        - '#1549'
         - '#1551'
       - id: first_pilots
         locked_design_section: First pilots
@@ -5414,13 +5416,53 @@ flow_model:
           RouteTable row, direct delivery target, or live subscription. Parent
           `connect` remains cross-flow-instance topology only.
     singleton_coordinator_model:
-      status: spec_vocabulary_only
+      status: merge_bearing_contract_runtime_behavior
       implementation_tracker: '#1549'
+      declaration_surface: 'mode: singleton'
+      canonical_code_owner: internal/runtime/contracts.WorkflowContractBundle.ResolveFlowSingletonCoordinator + internal/runtime/bootverify.checkSingletonCoordinatorValidation + internal/runtime/engine.Executor.applyContainedDataOperation
       rule: >
-        Singleton/coordinator flows are valid when the flow owns real shared
-        policy, aggregate state, or cross-instance learning. They are not a
-        backdoor for accidental shared agent memory or arbitrary multi-entity
-        routing inside a static flow.
+        Singleton/coordinator flows are explicit `mode: singleton` child flows
+        that own real shared policy, aggregate state, or cross-instance
+        learning for many normal/template instances. Bare `mode: static` is
+        not coordinator authority. A singleton coordinator still has exactly
+        one primary entity and must express coordinator state as typed
+        contained map/list fields on that entity. Agent conversation/session
+        memory, static multi-entity ownership, route-to-contained-item
+        semantics, producer target/broadcast, direct delivery, and route-plan
+        fallbacks are not singleton coordinator authority.
+      lifecycle_policy: >
+        Singleton coordinator state is persisted on the coordinator primary
+        entity until handlers explicitly archive, roll up, clean up, or promote
+        the state. Contained map/list items do not gain independent lifecycle,
+        retry, timer, audit, callback, terminality, idempotency, or route
+        identity. If a contained item needs those behaviors it must be promoted
+        to a child/template flow instance instead of remaining singleton
+        contained state.
+      fail_closed:
+      - 'root schema declares mode: singleton'
+      - 'bare mode: static used as singleton/coordinator proof'
+      - 'mode: singleton declares template instance fields'
+      - singleton flow lacks exactly one primary entity
+      - singleton flow primary entity lacks typed contained map/list state
+      - singleton flow uses schema.yaml entity restatement
+      - singleton flow declares multiple entity contracts
+      - agent conversation/session memory is used as coordinator state authority
+      - contained map/list items are targeted as route recipients
+      - 'producer target, broadcast:true, direct delivery, RouteTable, live subscriptions, handler lookup, delivery rows, or replay rows are used as coordinator authority'
+      promotion_rule: >
+        Promote a singleton contained map/list item when it becomes an
+        independently routable recipient or needs lifecycle, timers, retries,
+        agents, audit, callbacks, terminality, durable idempotency, or separate
+        route identity. Promotion behavior and pilots remain tracked by #1553
+        and do not widen #1549.
+      non_authoritative_paths:
+      - 'mode: static as implicit coordinator declaration'
+      - schema.yaml entity as a singleton entity selector
+      - template instance.by / on_missing / on_conflict for singleton ownership
+      - static multi-entity flow ownership
+      - agent conversation_mode or session_scope memory
+      - parent connect to contained map/list items
+      - producer target, broadcast:true, direct delivery, RouteTable, raw subscribers, delivery rows, replay rows
     escape_hatches:
       static_multi_entity_flows:
         status: advanced_legacy_escape_hatch
@@ -5497,6 +5539,7 @@ flow_model:
         ambiguous_key_rejection: '#1545'
         select_entity_demotion: '#1547'
         typed_map_list_update_verification: '#1548'
+        singleton_coordinator_contract: '#1549'
         expand_minimize_tooling: '#1551'
     non_goals:
     - '#1538 does not implement verifier/runtime behavior.'

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -5444,6 +5444,7 @@ flow_model:
       - 'mode: singleton declares template instance fields'
       - singleton flow lacks exactly one primary entity
       - singleton flow primary entity lacks typed contained map/list state
+      - singleton flow contained map/list value or item types do not resolve
       - singleton flow uses schema.yaml entity restatement
       - singleton flow declares multiple entity contracts
       - agent conversation/session memory is used as coordinator state authority


### PR DESCRIPTION
## Summary
- Adds explicit `mode: singleton` flow authority through `WorkflowContractBundle.ResolveFlowSingletonCoordinator`.
- Adds boot verification for singleton coordinator declarations and fail-closed invalid shapes.
- Promotes `platform-spec.yaml#flow_model.flow_instance_authoring.singleton_coordinator_model` to merge-bearing behavior and covers it with API/spec tests.
- Adds runtime proof that a loaded singleton coordinator flow mutates typed contained map/list state through the existing contained-state executor path.

Closes #1549.

## Governing refs / context
- `platform-spec.yaml#flow_model.flow_instance_authoring.singleton_coordinator_model`
- `platform-spec.yaml#flow_model.flow_instance_authoring.primary_entity_model`
- `platform-spec.yaml#flow_model.flow_instance_authoring.contained_state_model`
- `platform-spec.yaml#handler.data_accumulation.write_item_forms.contained_operation`
- Binding issue/gate context: #1549 and parent #1537 / locked design #1476.

## Semantic migration
- New canonical owner: `internal/runtime/contracts.WorkflowContractBundle.ResolveFlowSingletonCoordinator`, consumed by `internal/runtime/bootverify.checkSingletonCoordinatorValidation` and runtime proof via `internal/runtime/engine.Executor.applyContainedDataOperation`.
- Old invalid/non-authoritative paths: bare `mode: static`, schema-level entity restatement, template `instance.*`, static multi-entity ownership, agent conversation/session memory, parent connect to contained items, producer target/broadcast/direct/RouteTable/raw delivery surfaces.
- Production paths checked for surviving old behavior: primary entity resolver, template instance resolver, bootverify singleton/template/primary/contained checks, and executor contained-state mutation path.
- Migration complete for #1549's singleton coordinator child class. Parent #1537 and sibling/pilot tails remain tracked separately.

## Proof
- `go test ./internal/runtime/contracts ./internal/runtime/bootverify ./internal/runtime/engine ./internal/apispec`
- `go test ./...`