### PR TITLE
[agent-c][issue #1536] Clarify rules condition read scope

### DIFF
--- a/internal/runtime/bootverify/report_test.go
+++ b/internal/runtime/bootverify/report_test.go
@@ -4080,6 +4080,65 @@ func TestRun_AllowsOnCompleteReferenceToPersistedFieldEvenWhenHandlerWritesField
 	}
 }
 
+func TestRun_AllowsRuleConditionReferenceToDeclaredEntityAndEventContext(t *testing.T) {
+	bundle := loadWave1ExpressionFixtureBundle(t)
+	flowID, nodeID, eventType, handler := firstFlowHandlerInFlowView(t, bundle)
+	clearWave1ExpressionFeedbackEmit(t, bundle, flowID, nodeID)
+	handler.CreateEntity = true
+	handler.Rules = []runtimecontracts.HandlerRuleEntry{{
+		ID:        "ready",
+		Condition: `entity.revision_count == 0 && payload.score >= 0 && event.entity_id != ""`,
+	}}
+	writeFlowHandler(t, bundle, flowID, nodeID, eventType, handler)
+
+	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+
+	if report.HasErrors() {
+		t.Fatalf("unexpected rule-condition errors, got %#v", report.Errors())
+	}
+	if reportContains(report.Errors(), "expression_field_reference_validation", "entity.revision_count") {
+		t.Fatalf("unexpected rule-condition entity reference error, got %#v", report.Errors())
+	}
+	if reportContains(report.Errors(), "condition_expression_validation", "event.entity_id") {
+		t.Fatalf("unexpected rule-condition event context validation error, got %#v", report.Errors())
+	}
+	if reportContains(report.Errors(), "condition_payload_alignment", "payload.score") {
+		t.Fatalf("unexpected rule-condition payload alignment error, got %#v", report.Errors())
+	}
+}
+
+func TestRun_RejectsRuleConditionReferenceToUndeclaredEntityField(t *testing.T) {
+	bundle := loadWave1ExpressionFixtureBundle(t)
+	flowID, nodeID, eventType, handler := firstFlowHandlerInFlowView(t, bundle)
+	clearWave1ExpressionFeedbackEmit(t, bundle, flowID, nodeID)
+	handler.Rules = []runtimecontracts.HandlerRuleEntry{{
+		ID:        "missing",
+		Condition: "entity.missing_rule_score > 0",
+	}}
+	writeFlowHandler(t, bundle, flowID, nodeID, eventType, handler)
+
+	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+
+	if !reportContains(report.Errors(), "expression_field_reference_validation", "entity.missing_rule_score") {
+		t.Fatalf("expected undeclared rule-condition entity reference error, got %#v", report.Errors())
+	}
+}
+
+func clearWave1ExpressionFeedbackEmit(t *testing.T, bundle *runtimecontracts.WorkflowContractBundle, flowID, nodeID string) {
+	t.Helper()
+	flowView, ok := bundle.FlowViewByID(flowID)
+	if !ok || flowView == nil {
+		t.Fatalf("flow view %s missing", flowID)
+	}
+	node := flowView.Nodes[nodeID]
+	feedbackHandler, ok := node.EventHandlers["task.feedback"]
+	if !ok {
+		t.Fatalf("expected wave1 fixture feedback handler on node %s", nodeID)
+	}
+	feedbackHandler.Emit = runtimecontracts.EmitSpec{}
+	writeFlowHandler(t, bundle, flowID, nodeID, "task.feedback", feedbackHandler)
+}
+
 func TestRun_AllowsCreateEntityGuardReferenceToSchemaInitializedField(t *testing.T) {
 	bundle := loadWave1ExpressionFixtureBundle(t)
 	flowID, nodeID, eventType, handler := firstFlowHandlerInFlowView(t, bundle)

--- a/internal/runtime/pipeline/workflow_expression_evaluator_test.go
+++ b/internal/runtime/pipeline/workflow_expression_evaluator_test.go
@@ -46,6 +46,53 @@ func TestValidateConditionCEL_AllowsItemOnlyInFilterLikeContexts(t *testing.T) {
 	}
 }
 
+func TestValidateConditionCEL_AllowsRuleConditionCanonicalRoots(t *testing.T) {
+	tests := []struct {
+		name       string
+		expression string
+		wantErr    bool
+	}{
+		{
+			name:       "payload entity policy event",
+			expression: `entity.entity_id != "" && payload.score >= policy.threshold && event.entity_id != ""`,
+		},
+		{
+			name:       "query entities",
+			expression: `query_entities(name == payload.name).count == 0`,
+		},
+		{
+			name:       "accumulated unavailable",
+			expression: `accumulated.size() > 0`,
+			wantErr:    true,
+		},
+		{
+			name:       "fan out unavailable",
+			expression: `fan_out.count > 0`,
+			wantErr:    true,
+		},
+		{
+			name:       "item unavailable",
+			expression: `item.score > 50`,
+			wantErr:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateConditionCEL(tt.expression, WorkflowConditionContextRule)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected rule condition %q to fail validation", tt.expression)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("expected rule condition %q to validate, got %v", tt.expression, err)
+			}
+		})
+	}
+}
+
 func TestNormalizeWorkflowExpression_RewritesQueryEntitiesCount(t *testing.T) {
 	got, _, err := normalizeWorkflowExpression(
 		`query_entities(name == payload.name).count == 0`,

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -1347,7 +1347,8 @@ handler_specification:
   on_complete_vs_rules:
     description: Mutually exclusive. A handler uses on_complete OR rules, never both.
     on_complete: Ordered list of {condition, advances_to, emit} — first match wins. Used after accumulation/computation.
-    rules: Map of {condition, emit/advances_to/data_accumulation} — payload-based routing. Used for type dispatching.
+    rules: Map of {condition, emit/advances_to/data_accumulation} — condition-based routing over the rule
+      condition context. Used for type dispatching without changing branch precedence.
   short_circuits:
     guard_fail: If guard fails, handler stops. on_fail action executes (reject/kill/discard/escalate). No further steps.
     accumulate_incomplete: If accumulation is not yet complete, handler stops after recording the arrival. No further steps
@@ -1755,9 +1756,13 @@ handler_specification:
     rules:
       field: rules
       type: map of rule_name → rule
-      purpose: Type-based routing. Match payload field against conditions.
+      purpose: Type-based routing. Match rule conditions over the rule-condition handler context; common dispatch
+        reads payload fields, but rule conditions are not payload-only.
       rule_fields:
-        condition: string — expression evaluated against payload
+        condition: string — CEL expression evaluated against the rule-condition handler context. Allowed roots
+          are payload.*, entity.*, policy.*, event.*, and query_entities(...). accumulated.*, fan_out.*, and
+          item.* are unavailable in rules.condition. entity.* reads use the pre-rule entity state and the same
+          declared-field validation as other rule-phase handler conditions.
         emit: string or object — rule-local event to emit
         advances_to: string — optional state change
         data_accumulation: object — optional data write (same format as handler-level)
@@ -2010,6 +2015,12 @@ handler_specification:
       payload:
         resolves_to: 'The inbound event payload. payload.X reads the X field from the triggering event''s
           JSONB payload.'
+      event:
+        resolves_to: 'The runtime-owned triggering event envelope/context. event.X reads event context fields
+          such as event.id, event.type, event.entity_id, event.flow_instance, and platform-owned routing
+          envelope values supplied by the runtime.'
+        available_in: 'rules.condition and other handler expression surfaces when the runtime supplies current
+          event context. event.* is read-only handler context, not payload.'
       policy:
         resolves_to: 'The merged policy context. policy.X reads the X key from the flow''s policy.yaml
           (or root policy.yaml if not overridden at flow level).'
@@ -4039,6 +4050,7 @@ engine:
     context_variables:
       entity: Current entity state (all declared entity fields at type-valid values + envelope + gates)
       payload: Current event payload fields
+      event: Current runtime-owned event envelope/context fields
       policy: Policy values from flow policy.yaml merged with root policy.yaml
       fan_out: Available after fan_out step (e.g., fan_out.count)
       accumulated: Available inside on_complete after accumulation (list of received items)


### PR DESCRIPTION
## Summary

Closes #1536.

This PR clarifies the authoritative `rules.condition` read scope and adds direct supported proof for the roots already accepted by runtime/verify behavior.

Changes:
- Updates `platform-spec.yaml` so `rules.condition` is no longer described as payload-only routing.
- Explicitly documents the allowed rule-condition roots: `payload.*`, `entity.*`, `policy.*`, `event.*`, and `query_entities(...)`.
- Explicitly documents unavailable rule-condition roots: `accumulated.*`, `fan_out.*`, and `item.*`.
- Adds bootverify proof that a rule condition can read a declared initialized `entity.*` field plus `event.*` context.
- Adds bootverify proof that an undeclared `entity.*` read in `rules.condition` still fails through `expression_field_reference_validation`.
- Adds pipeline validation proof that rule conditions accept the canonical root set.

No runtime execution or branch precedence behavior changes are included.

## Governing Refs / Context

Exact governing spec sections updated or used:
- `platform-spec.yaml#handler_specification.on_complete_vs_rules.rules`
- `platform-spec.yaml#handler_specification.handler_fields.rules`
- `platform-spec.yaml#handler_specification.expression_context`
- `platform-spec.yaml#expression_language.context_variables`
- `platform-spec.yaml#runtime_verification.semantic_validity.slice_7_entity_reader_compliance`

Binding issue context:
- #1536 body and approved pre-audit/gate outcome.
- #1462 as the parent tracker for the spec-clarity split.
- #1524 remains separate and untouched for rule branch precedence.

## Semantic Migration / Ownership

New canonical owner after this PR:
- `platform-spec.yaml#handler_specification.expression_context` plus the local `rules` field prose for `rules.condition` root-set authority.

Old non-authoritative path now invalid:
- The old local wording that rules are payload-based and that `rules.condition` is evaluated only against payload.

Production paths checked:
- `internal/runtime/pipeline/workflow_condition_validation.go` already accepts `payload`, `entity`, `policy`, `event`, and `query_entities` for rule conditions.
- `internal/runtime/bootverify/workflow_expression_checks.go` already routes `rules.condition` entity reads through rule-phase entity reference validation.
- `internal/runtime/engine.Executor.selectRule` already evaluates rule conditions with `currentContext`, which supplies the runtime event context.

Migration completeness:
- Complete for #1536's chosen class. This PR does not migrate or change runtime behavior.

## Validation

- `go test ./internal/runtime/pipeline -run 'TestValidateConditionCEL_AllowsRuleConditionCanonicalRoots|TestValidateConditionCEL_AllowsItemOnlyInFilterLikeContexts|TestWorkflowEntityFieldsAvailableBeforeCondition|TestWorkflowEntityReadsPersistedStateBeforeHandlerWrites' -count=1`
- `go test ./internal/runtime/bootverify -run 'TestRun_AllowsRuleConditionReferenceToDeclaredEntityAndEventContext|TestRun_RejectsRuleConditionReferenceToUndeclaredEntityField|TestRun_MapsBareConditionToConditionExpressionValidation|TestRun_RejectsItemNamespaceOutsideFilterConditions' -count=1`
- `go test ./internal/apispec -count=1`
- `go test ./...`