### PR TITLE
[agent-a][issue #1550] Preserve instance-key replay routes

### DIFF
--- a/internal/runtime/bus/committed_replay_scope.go
+++ b/internal/runtime/bus/committed_replay_scope.go
@@ -50,6 +50,11 @@ func (eb *EventBus) replayRecipientsForCommittedEvent(
 		}
 	}
 	if scope == runtimereplayclaim.CommittedReplayScopeSubscribed && hasDeliveryRouteSubscriberType(persistedRoutes, "node") {
+		if hasFlowInstanceNodeDeliveryRoute(persistedRoutes) {
+			internal := deliveryRouteRecipientIDsByType(persistedRoutes, "node")
+			live := uniqueStrings(append(deliveryRouteRecipientIDsByType(persistedRoutes, "agent"), internal...))
+			return live, internal, persistedRoutes, nil
+		}
 		internal, err := eb.currentInternalRecipientsForCommittedEvent(ctx, evt)
 		if err != nil {
 			return nil, nil, nil, err
@@ -93,6 +98,19 @@ func hasDeliveryRouteSubscriberType(routes []events.DeliveryRoute, subscriberTyp
 	subscriberType = strings.TrimSpace(subscriberType)
 	for _, route := range events.NormalizeDeliveryRoutes(routes) {
 		if route.SubscriberType == subscriberType {
+			return true
+		}
+	}
+	return false
+}
+
+func hasFlowInstanceNodeDeliveryRoute(routes []events.DeliveryRoute) bool {
+	for _, route := range events.NormalizeDeliveryRoutes(routes) {
+		if route.SubscriberType != "node" {
+			continue
+		}
+		target := route.Target.Normalized()
+		if target.FlowID != "" && target.FlowInstance != "" {
 			return true
 		}
 	}

--- a/internal/runtime/bus/connect_route_plan_dispatch_test.go
+++ b/internal/runtime/bus/connect_route_plan_dispatch_test.go
@@ -727,6 +727,71 @@ func TestEventBusPublish_ConnectRoutePlanPersistsTemplateInstanceKeyTarget(t *te
 	}
 }
 
+func TestEventBusReplay_ConnectRoutePlanUsesPersistedInstanceKeyRouteAfterDescriptorDrift(t *testing.T) {
+	source := connectRoutePlanInstanceKeySource(t)
+	store := &connectRoutePlanDescriptorStore{
+		targetRouteMemoryStore: newTargetRouteMemoryStore(),
+		flowInstances: []ActiveFlowInstanceDescriptor{{
+			InstanceID:    "one",
+			EntityID:      "ent-1",
+			FlowInstance:  "consumer/one",
+			AddressFields: map[string]string{"entity.vertical_id": "v-1"},
+		}},
+	}
+	eb, err := NewEventBusWithOptions(store, EventBusOptions{ContractBundle: source})
+	if err != nil {
+		t.Fatalf("NewEventBusWithOptions: %v", err)
+	}
+	if err := eb.AddFlowInstanceRoute(FlowInstanceRouteMaterializationRequest{Identity: runtimeflowidentity.DeriveRoute("consumer", "one")}); err != nil {
+		t.Fatalf("AddFlowInstanceRoute(one): %v", err)
+	}
+	consumerOne := eb.SubscribeInternal("consumer-node-one")
+	consumerTwo := eb.SubscribeInternal("consumer-node-two")
+	eventID := uuid.NewString()
+	evt := eventtest.RootIngress(eventID,
+		events.EventType("producer/deploy.done"), "", "", json.RawMessage(`{"vertical_id":"v-1"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())
+
+	wantOne := events.DeliveryRoute{SubscriberType: "node", SubscriberID: "consumer-node-one", Target: events.RouteIdentity{FlowID: "consumer", FlowInstance: "consumer/one", EntityID: "ent-1"}}
+
+	if err := eb.Publish(context.Background(), evt); err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+	got := requireBusEvent(t, consumerOne, "initial instance-key publish")
+	if got.FlowInstance() != "consumer/one" || got.EntityID() != "ent-1" {
+		t.Fatalf("initial delivery target = flow_instance:%q entity:%q, want consumer/one ent-1", got.FlowInstance(), got.EntityID())
+	}
+	if !deliveryRoutesContain(store.routes[eventID], wantOne) || len(store.routes[eventID]) != 1 {
+		t.Fatalf("persisted delivery routes = %#v, want instance-key route %#v", store.routes[eventID], wantOne)
+	}
+
+	store.flowInstances = []ActiveFlowInstanceDescriptor{{
+		InstanceID:    "two",
+		EntityID:      "ent-2",
+		FlowInstance:  "consumer/two",
+		AddressFields: map[string]string{"entity.vertical_id": "v-1"},
+	}}
+	store.flowInstanceDescriptorCalls = 0
+	if err := eb.AddFlowInstanceRoute(FlowInstanceRouteMaterializationRequest{Identity: runtimeflowidentity.DeriveRoute("consumer", "two")}); err != nil {
+		t.Fatalf("AddFlowInstanceRoute(two): %v", err)
+	}
+
+	if err := eb.PublishPersistedRecipients(context.Background(), evt, nil); err != nil {
+		t.Fatalf("PublishPersistedRecipients: %v", err)
+	}
+	got = requireBusEvent(t, consumerOne, "persisted replay after descriptor drift")
+	if got.FlowInstance() != "consumer/one" || got.EntityID() != "ent-1" {
+		t.Fatalf("replayed delivery target = flow_instance:%q entity:%q, want persisted consumer/one ent-1", got.FlowInstance(), got.EntityID())
+	}
+	select {
+	case evt := <-consumerTwo:
+		t.Fatalf("descriptor drift recipient received replay: flow_instance:%q entity:%q", evt.FlowInstance(), evt.EntityID())
+	default:
+	}
+	if got := store.flowInstanceDescriptorCalls; got != 0 {
+		t.Fatalf("replay descriptor calls = %d, want 0 because persisted route/scope is authoritative", got)
+	}
+}
+
 func TestEventBusPublish_ConnectRoutePlanPersistsRenamedTemplateInstanceKeyTarget(t *testing.T) {
 	source := connectRoutePlanRenamedInstanceKeySource(t)
 	store := &connectRoutePlanDescriptorStore{


### PR DESCRIPTION
## Summary

Closes #1550.
Part of #1537. Automatic connect-time `on_missing:create` / `on_conflict:reuse` lifecycle ownership remains split to #1577 per the approved gate.

This PR fixes the subscribed replay seam called out in Gate A: when a persisted typed node delivery route already carries concrete flow-instance route evidence (`Target.FlowID` + `Target.FlowInstance`), replay now consumes that persisted route/scope owner directly instead of recomputing internal recipients from current descriptors/RouteTable. Semantic node routes without flow-instance route evidence keep the existing carrier lookup behavior.

## Governing refs/context

- Pre-audit: #1550 comment `Pre-Implementation Coverage Audit`.
- Gate: #1550 comment `Gate A review: failure-class boundary`, outcome `approved as first slice`.
- `platform-spec.yaml#flow_model.flow_instance_authoring`
- `platform-spec.yaml#flow_model.flow_instance_authoring.template_instance_model`
- `platform-spec.yaml#flow_model.flow_instance_authoring.composition_model.connect_to_instance_route_planning`
- `platform-spec.yaml#contract_formats.event_schema.routing_derivation.route_plan_authority.lowered_connect_route_plan_consumption`
- `platform-spec.yaml#contract_formats.event_schema.routing_derivation.route_plan_authority.outputs.replay_scope_expectations`
- `platform-spec.yaml#contract_formats.event_schema.routing_derivation.route_plan_authority.persistence_requirements`
- `platform-spec.yaml#contract_formats.event_schema.routing_derivation.route_plan_authority.authority_boundaries.replay_recovery`
- `platform-spec.yaml#storage.sqlite_explicit_store_parity.event_delivery_receipt_and_replay_rows`

Requested docs note: `docs/IMPLEMENTER_GUIDELINES.md` and `docs/SEMANTIC_DRIFT.md` are not present in this worktree, matching the pre-audit record.

## Semantic migration / owner context

- New canonical owner: unchanged; persisted typed `event_deliveries.delivery_target_route` plus committed replay scope remain the durable replay owner for instance-key route decisions.
- Old producer/reader/writer path now invalid: `replayRecipientsForCommittedEvent` must not call live `deliveryPlanner.Plan` / descriptor-backed RouteTable rematerialization for persisted flow-instance node routes.
- Production paths checked for surviving old behavior: publish/preflight route persistence, `PublishPersistedRecipients`, sweeper/recovery replay claim paths, run-fork delivery-event replay lineage, selected-contract timer reconstruction, and lower-precedence route rescue tests.
- Migration completeness: complete for #1550 first-slice instance-key post-route replay drift. Automatic create/reuse lifecycle remains intentionally split to #1577.

## Tests

- `go test ./internal/runtime/bus -run 'TestEventBusReplay_ConnectRoutePlanUsesPersistedInstanceKeyRouteAfterDescriptorDrift|TestEventBusPublish_ConnectRoutePlanPersistsTemplateInstanceKeyTarget|TestEventBusPublish_NoTargetRootRoutedNodeUsesSemanticNodeDeliveryRoute'`
- `go test ./internal/runtime/bus ./internal/runtime/pipeline ./internal/store -run 'TestEventBusReplay_ConnectRoutePlanUsesPersistedInstanceKeyRouteAfterDescriptorDrift|TestSweepUndispatched_ClaimsReplayOwnershipBeforeDispatch|TestSelectedContractExecutionMaterializationReconstructsActiveTimer|TestRecoveryManager_ReplaysHistoricalForkDeliveryEventReplayRows|TestRunForkActivation_ReplaysSafePendingDeliveryWithForkLocalLineage|TestRunForkDeliveryEventReplayValidationRejectsUnsafeCurrentEvidence|TestSelectedContractExecutionMaterializationTreatsSourceReplayScopeMarkersAsLineage'`
- `go test ./...`