### PR TITLE
[agent-b][issue #1566] Add claude_cli workspace image build

### DIFF
--- a/cmd/swarm/cli.go
+++ b/cmd/swarm/cli.go
@@ -79,6 +79,7 @@ func newRootCommandWithOptions(ctx context.Context, repo string, out, errOut io.
 		newDoctorCommand(ctx, repo),
 		newVerifyCommand(ctx, repo),
 		newSecretsCommand(ctx, repo),
+		newWorkspaceCommand(ctx),
 		newVersionCommand(opts),
 		newCompletionCommand(),
 		newRunsCommand(opts),

--- a/cmd/swarm/local_preflight.go
+++ b/cmd/swarm/local_preflight.go
@@ -291,12 +291,12 @@ func (r *localPreflightReport) checkWorkspace(ctx context.Context, repo string, 
 		r.add(localPreflightWorkspacePrerequisite, "docker_available", localPreflightSeverityInfo, localPreflightStatusOK, "Docker is reachable", "")
 	}
 	if err := dockerManager.CheckWorkspaceImageAvailable(ctx); err != nil {
-		r.add(localPreflightWorkspacePrerequisite, "workspace_image_unavailable", localPreflightSeverityBlocker, localPreflightStatusFailed, err.Error(), "build or pull the configured workspace image, or set SWARM_WORKSPACE_IMAGE")
+		r.add(localPreflightWorkspacePrerequisite, "workspace_image_unavailable", localPreflightSeverityBlocker, localPreflightStatusFailed, err.Error(), "run `swarm workspace build --backend claude_cli`, pull the configured workspace image, or set SWARM_WORKSPACE_IMAGE")
 	} else {
 		r.add(localPreflightWorkspacePrerequisite, "workspace_image_available", localPreflightSeverityInfo, localPreflightStatusOK, "workspace image is available", "")
 	}
 	if err := dockerManager.CheckWorkspaceCLICommandAvailable(ctx, cfg.LLM.ClaudeCLI.Command); err != nil {
-		r.add(localPreflightWorkspacePrerequisite, "workspace_claude_cli_unavailable", localPreflightSeverityBlocker, localPreflightStatusFailed, err.Error(), "build or pull a workspace image that contains the configured Claude CLI command")
+		r.add(localPreflightWorkspacePrerequisite, "workspace_claude_cli_unavailable", localPreflightSeverityBlocker, localPreflightStatusFailed, err.Error(), "run `swarm workspace build --backend claude_cli` or pull a workspace image that contains the configured Claude CLI command")
 	} else {
 		r.add(localPreflightWorkspacePrerequisite, "workspace_claude_cli_available", localPreflightSeverityInfo, localPreflightStatusOK, "workspace image can execute the configured Claude CLI command", "")
 	}

--- a/cmd/swarm/workspace_build.go
+++ b/cmd/swarm/workspace_build.go
@@ -9,6 +9,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/division-sh/swarm/internal/platform"
 	workspace "github.com/division-sh/swarm/internal/runtime/workspace"
@@ -95,9 +96,10 @@ func runWorkspaceBuildCommand(ctx context.Context, out io.Writer, opts workspace
 	if out != nil {
 		fmt.Fprintf(out, "Building workspace image %s for backend claude_cli\n", image)
 	}
+	tempImage := temporaryWorkspaceBuildImageTag()
 	if _, err := runWorkspaceBuildDocker(ctx, dockerBin,
 		"build",
-		"-t", image,
+		"-t", tempImage,
 		"-f", dockerfile,
 		"--build-arg", "INSTALL_CLAUDE_CLI=true",
 		"--build-arg", "INSTALL_CODEX_CLI=false",
@@ -105,21 +107,31 @@ func runWorkspaceBuildCommand(ctx context.Context, out io.Writer, opts workspace
 	); err != nil {
 		return fmt.Errorf("workspace image build failed for image %q: %w", image, err)
 	}
+	defer func() {
+		_, _ = runWorkspaceBuildDocker(ctx, dockerBin, "image", "rm", tempImage)
+	}()
 
 	if out != nil {
 		fmt.Fprintf(out, "Validating workspace image %s can execute %s\n", image, workspaceBuildClaudeCommand)
 	}
 	if _, err := runWorkspaceBuildDocker(ctx, dockerBin,
-		"run", "--rm", "--entrypoint", "sh", image,
+		"run", "--rm", "--entrypoint", "sh", tempImage,
 		"-lc", `command -v -- "$1" >/dev/null && "$1" --version >/dev/null`,
 		"swarm-cli-proof", workspaceBuildClaudeCommand,
 	); err != nil {
 		return fmt.Errorf("workspace image validation failed: configured Claude CLI command %q cannot execute in workspace image %q; build or pull a workspace image that includes a runnable Claude CLI, or set SWARM_WORKSPACE_IMAGE/--image to a compatible image: %w", workspaceBuildClaudeCommand, image, err)
 	}
+	if _, err := runWorkspaceBuildDocker(ctx, dockerBin, "tag", tempImage, image); err != nil {
+		return fmt.Errorf("workspace image build failed to publish validated image %q: %w", image, err)
+	}
 	if out != nil {
 		fmt.Fprintf(out, "Workspace image %s is ready for claude_cli\n", image)
 	}
 	return nil
+}
+
+func temporaryWorkspaceBuildImageTag() string {
+	return fmt.Sprintf("swarm-workspace-build-%d:%d", os.Getpid(), time.Now().UnixNano())
 }
 
 func normalizeWorkspaceBuildImage(raw, source string) (string, error) {

--- a/cmd/swarm/workspace_build.go
+++ b/cmd/swarm/workspace_build.go
@@ -1,0 +1,169 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/division-sh/swarm/internal/platform"
+	workspace "github.com/division-sh/swarm/internal/runtime/workspace"
+	"github.com/spf13/cobra"
+)
+
+const workspaceBuildClaudeCommand = "claude"
+
+type workspaceBuildOptions struct {
+	backend string
+	image   string
+}
+
+func newWorkspaceCommand(ctx context.Context) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "workspace",
+		Short: "Manage local workspace setup surfaces.",
+	}
+	cmd.AddCommand(newWorkspaceBuildCommand(ctx))
+	return cmd
+}
+
+func newWorkspaceBuildCommand(ctx context.Context) *cobra.Command {
+	opts := workspaceBuildOptions{}
+	cmd := &cobra.Command{
+		Use:   "build --backend claude_cli [--image <tag>]",
+		Short: "Build and validate a local workspace image.",
+		Args:  cobra.NoArgs,
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			backend := strings.ToLower(strings.TrimSpace(opts.backend))
+			if backend == "" {
+				return fmt.Errorf("swarm workspace build requires --backend claude_cli")
+			}
+			if backend != "claude_cli" {
+				return fmt.Errorf("unsupported workspace build backend %q; only claude_cli is supported", strings.TrimSpace(opts.backend))
+			}
+			opts.backend = backend
+			if cmd.Flags().Changed("image") {
+				image, err := normalizeWorkspaceBuildImage(opts.image, "--image")
+				if err != nil {
+					return err
+				}
+				opts.image = image
+			}
+			return nil
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := runWorkspaceBuildCommand(ctx, cmd.OutOrStdout(), opts); err != nil {
+				fmt.Fprintln(cmd.ErrOrStderr(), err)
+				return commandExitError{code: cliExitRuntime}
+			}
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&opts.backend, "backend", opts.backend, "Workspace image build backend to materialize: claude_cli")
+	cmd.Flags().StringVar(&opts.image, "image", opts.image, "Workspace image tag to build; defaults to SWARM_WORKSPACE_IMAGE or swarm-workspace:latest")
+	return cmd
+}
+
+func runWorkspaceBuildCommand(ctx context.Context, out io.Writer, opts workspaceBuildOptions) error {
+	image := strings.TrimSpace(opts.image)
+	if image == "" {
+		var err error
+		image, err = normalizeWorkspaceBuildImage(workspace.ConfiguredWorkspaceImageFromEnv(), "SWARM_WORKSPACE_IMAGE")
+		if err != nil {
+			return err
+		}
+	}
+	dockerfile, err := platform.MaterializeWorkspaceDockerfile()
+	if err != nil {
+		return fmt.Errorf("workspace image build failed: %w", err)
+	}
+	contextDir, cleanup, err := materializeWorkspaceBuildContext(dockerfile)
+	if err != nil {
+		return fmt.Errorf("workspace image build failed: %w", err)
+	}
+	defer cleanup()
+
+	dockerBin := workspace.EnvOrDefault("SWARM_DOCKER_BIN", "docker")
+	if _, err := runWorkspaceBuildDocker(ctx, dockerBin, "version", "--format", "{{.Server.Version}}"); err != nil {
+		return fmt.Errorf("workspace image build failed: Docker is not available via %q; start Docker or set SWARM_DOCKER_BIN to a working Docker-compatible CLI: %w", dockerBin, err)
+	}
+
+	if out != nil {
+		fmt.Fprintf(out, "Building workspace image %s for backend claude_cli\n", image)
+	}
+	if _, err := runWorkspaceBuildDocker(ctx, dockerBin,
+		"build",
+		"-t", image,
+		"-f", dockerfile,
+		"--build-arg", "INSTALL_CLAUDE_CLI=true",
+		"--build-arg", "INSTALL_CODEX_CLI=false",
+		contextDir,
+	); err != nil {
+		return fmt.Errorf("workspace image build failed for image %q: %w", image, err)
+	}
+
+	if out != nil {
+		fmt.Fprintf(out, "Validating workspace image %s can execute %s\n", image, workspaceBuildClaudeCommand)
+	}
+	if _, err := runWorkspaceBuildDocker(ctx, dockerBin,
+		"run", "--rm", "--entrypoint", "sh", image,
+		"-lc", `command -v -- "$1" >/dev/null && "$1" --version >/dev/null`,
+		"swarm-cli-proof", workspaceBuildClaudeCommand,
+	); err != nil {
+		return fmt.Errorf("workspace image validation failed: configured Claude CLI command %q cannot execute in workspace image %q; build or pull a workspace image that includes a runnable Claude CLI, or set SWARM_WORKSPACE_IMAGE/--image to a compatible image: %w", workspaceBuildClaudeCommand, image, err)
+	}
+	if out != nil {
+		fmt.Fprintf(out, "Workspace image %s is ready for claude_cli\n", image)
+	}
+	return nil
+}
+
+func normalizeWorkspaceBuildImage(raw, source string) (string, error) {
+	image := strings.TrimSpace(raw)
+	if image == "" {
+		return "", fmt.Errorf("workspace image from %s must be non-empty", source)
+	}
+	if strings.ContainsAny(image, " \t\r\n") {
+		return "", fmt.Errorf("workspace image from %s must not contain whitespace", source)
+	}
+	return image, nil
+}
+
+func materializeWorkspaceBuildContext(dockerfile string) (string, func(), error) {
+	dir, err := os.MkdirTemp("", "swarm-workspace-build-context-*")
+	if err != nil {
+		return "", func() {}, err
+	}
+	cleanup := func() {
+		_ = os.RemoveAll(dir)
+	}
+	data, err := os.ReadFile(dockerfile)
+	if err != nil {
+		cleanup()
+		return "", func() {}, err
+	}
+	if err := os.WriteFile(filepath.Join(dir, platform.DefaultWorkspaceDockerfilePath), data, 0o644); err != nil {
+		cleanup()
+		return "", func() {}, err
+	}
+	return dir, cleanup, nil
+}
+
+func runWorkspaceBuildDocker(ctx context.Context, dockerBin string, args ...string) (string, error) {
+	cmd := exec.CommandContext(ctx, dockerBin, args...)
+	var raw bytes.Buffer
+	cmd.Stdout = &raw
+	cmd.Stderr = &raw
+	if err := cmd.Run(); err != nil {
+		out := strings.TrimSpace(raw.String())
+		if out == "" {
+			return "", err
+		}
+		return "", fmt.Errorf("%w: %s", err, out)
+	}
+	return strings.TrimSpace(raw.String()), nil
+}

--- a/cmd/swarm/workspace_build_test.go
+++ b/cmd/swarm/workspace_build_test.go
@@ -1,0 +1,294 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestWorkspaceBuildClaudeCLIUsesEmbeddedBuildPlanFromTempCWD(t *testing.T) {
+	sourceRoot := repoRoot()
+	tempCWD := t.TempDir()
+	chdirForTest(t, tempCWD)
+	callsPath := configureWorkspaceBuildDockerStub(t)
+	t.Setenv("SWARM_WORKSPACE_IMAGE", "")
+
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), tempCWD, []string{"workspace", "build", "--backend", "claude_cli"}, &stdout, &stderr, defaultRootCommandOptions())
+	if code != cliExitOK {
+		t.Fatalf("code = %d stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if stderr.String() != "" {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+	for _, want := range []string{
+		"Building workspace image swarm-workspace:latest for backend claude_cli",
+		"Validating workspace image swarm-workspace:latest can execute claude",
+		"Workspace image swarm-workspace:latest is ready for claude_cli",
+	} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("stdout missing %q:\n%s", want, stdout.String())
+		}
+	}
+
+	calls := readWorkspaceBuildDockerCalls(t, callsPath)
+	if len(calls) != 3 {
+		t.Fatalf("docker call count = %d, want 3:\n%s", len(calls), strings.Join(calls, "\n"))
+	}
+	if calls[0] != "version --format {{.Server.Version}}" {
+		t.Fatalf("docker version call = %q", calls[0])
+	}
+	build := calls[1]
+	for _, want := range []string{
+		"build -t swarm-workspace:latest",
+		"--build-arg INSTALL_CLAUDE_CLI=true",
+		"--build-arg INSTALL_CODEX_CLI=false",
+		"swarm-workspace-build-context-",
+	} {
+		if !strings.Contains(build, want) {
+			t.Fatalf("docker build call missing %q:\n%s", want, build)
+		}
+	}
+	if strings.Contains(build, sourceRoot) || strings.Contains(build, tempCWD) {
+		t.Fatalf("docker build call used source checkout or current directory:\n%s", build)
+	}
+	if !strings.Contains(build, "Dockerfile.workspace-") {
+		t.Fatalf("docker build call did not use materialized embedded Dockerfile:\n%s", build)
+	}
+	validate := calls[2]
+	for _, want := range []string{
+		"run --rm --entrypoint sh swarm-workspace:latest",
+		"command -v -- \"$1\" >/dev/null && \"$1\" --version >/dev/null",
+		"swarm-cli-proof claude",
+	} {
+		if !strings.Contains(validate, want) {
+			t.Fatalf("docker validation call missing %q:\n%s", want, validate)
+		}
+	}
+}
+
+func TestWorkspaceBuildClaudeCLIImageOverride(t *testing.T) {
+	callsPath := configureWorkspaceBuildDockerStub(t)
+	t.Setenv("SWARM_WORKSPACE_IMAGE", "env-image:latest")
+
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"workspace", "build", "--backend", "claude_cli", "--image", "custom/image:test"}, &stdout, &stderr, defaultRootCommandOptions())
+	if code != cliExitOK {
+		t.Fatalf("code = %d stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	calls := strings.Join(readWorkspaceBuildDockerCalls(t, callsPath), "\n")
+	if !strings.Contains(calls, "build -t custom/image:test") || !strings.Contains(calls, "run --rm --entrypoint sh custom/image:test") {
+		t.Fatalf("docker calls did not use --image override:\n%s", calls)
+	}
+	if strings.Contains(calls, "env-image:latest") {
+		t.Fatalf("docker calls used env image despite --image override:\n%s", calls)
+	}
+}
+
+func TestWorkspaceBuildClaudeCLIFailsOnDockerBuildError(t *testing.T) {
+	configureWorkspaceBuildDockerStub(t)
+	t.Setenv("SWARM_TEST_DOCKER_FAIL_BUILD", "1")
+
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"workspace", "build", "--backend", "claude_cli"}, &stdout, &stderr, defaultRootCommandOptions())
+	if code != cliExitRuntime {
+		t.Fatalf("code = %d, want %d stdout=%s stderr=%s", code, cliExitRuntime, stdout.String(), stderr.String())
+	}
+	for _, want := range []string{"workspace image build failed for image", "docker build failed"} {
+		if !strings.Contains(stderr.String(), want) {
+			t.Fatalf("stderr missing %q:\n%s", want, stderr.String())
+		}
+	}
+}
+
+func TestWorkspaceBuildClaudeCLIFailsOnValidationError(t *testing.T) {
+	configureWorkspaceBuildDockerStub(t)
+	t.Setenv("SWARM_TEST_DOCKER_FAIL_VALIDATE", "1")
+
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"workspace", "build", "--backend", "claude_cli"}, &stdout, &stderr, defaultRootCommandOptions())
+	if code != cliExitRuntime {
+		t.Fatalf("code = %d, want %d stdout=%s stderr=%s", code, cliExitRuntime, stdout.String(), stderr.String())
+	}
+	for _, want := range []string{"workspace image validation failed", "configured Claude CLI command \"claude\" cannot execute", "claude missing"} {
+		if !strings.Contains(stderr.String(), want) {
+			t.Fatalf("stderr missing %q:\n%s", want, stderr.String())
+		}
+	}
+}
+
+func TestWorkspaceBuildClaudeCLIFailsOnUnavailableDocker(t *testing.T) {
+	t.Setenv("SWARM_DOCKER_BIN", filepath.Join(t.TempDir(), "missing-docker"))
+
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"workspace", "build", "--backend", "claude_cli"}, &stdout, &stderr, defaultRootCommandOptions())
+	if code != cliExitRuntime {
+		t.Fatalf("code = %d, want %d stdout=%s stderr=%s", code, cliExitRuntime, stdout.String(), stderr.String())
+	}
+	for _, want := range []string{"Docker is not available", "SWARM_DOCKER_BIN"} {
+		if !strings.Contains(stderr.String(), want) {
+			t.Fatalf("stderr missing %q:\n%s", want, stderr.String())
+		}
+	}
+}
+
+func TestWorkspaceBuildClaudeCLIValidationErrors(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{name: "missing backend", args: []string{"workspace", "build"}, want: "requires --backend claude_cli"},
+		{name: "unsupported backend", args: []string{"workspace", "build", "--backend", "host"}, want: "unsupported workspace build backend"},
+		{name: "empty image", args: []string{"workspace", "build", "--backend", "claude_cli", "--image", " "}, want: "workspace image from --image must be non-empty"},
+		{name: "image whitespace", args: []string{"workspace", "build", "--backend", "claude_cli", "--image", "bad image"}, want: "must not contain whitespace"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var stdout, stderr bytes.Buffer
+			code := executeRootCommandWithOptions(context.Background(), t.TempDir(), tc.args, &stdout, &stderr, defaultRootCommandOptions())
+			if code != cliExitValidation {
+				t.Fatalf("code = %d, want %d stdout=%s stderr=%s", code, cliExitValidation, stdout.String(), stderr.String())
+			}
+			if !strings.Contains(stderr.String(), tc.want) {
+				t.Fatalf("stderr missing %q:\n%s", tc.want, stderr.String())
+			}
+		})
+	}
+}
+
+func TestWorkspaceBuildSpecAuthorityPromoted(t *testing.T) {
+	var spec struct {
+		WorkspaceModel struct {
+			BuildAuthority struct {
+				PromotedBy           string         `yaml:"promoted_by"`
+				ImplementationStatus string         `yaml:"implementation_status"`
+				CanonicalOwner       string         `yaml:"canonical_owner"`
+				BuildPlanRule        string         `yaml:"build_plan_rule"`
+				BuildProfile         map[string]any `yaml:"claude_cli_build_profile"`
+				ImageTargetRule      string         `yaml:"image_target_rule"`
+				ValidationRule       string         `yaml:"validation_rule"`
+				ConsumerBoundaries   []string       `yaml:"consumer_boundaries"`
+			} `yaml:"local_workspace_image_build_authority"`
+		} `yaml:"workspace_model"`
+		CLISpecification struct {
+			CommandCatalog struct {
+				WorkspaceBuild struct {
+					Command              string   `yaml:"command"`
+					ImplementationStatus string   `yaml:"implementation_status"`
+					Owner                string   `yaml:"owner"`
+					Behavior             string   `yaml:"behavior"`
+					Boundaries           []string `yaml:"boundaries"`
+				} `yaml:"workspace_build"`
+			} `yaml:"command_catalog"`
+		} `yaml:"cli_specification"`
+	}
+	data, err := os.ReadFile(filepath.Join(repoRoot(), defaultPlatformSpecPath))
+	if err != nil {
+		t.Fatalf("read platform spec: %v", err)
+	}
+	if err := yaml.Unmarshal(data, &spec); err != nil {
+		t.Fatalf("parse platform spec: %v", err)
+	}
+	owner := spec.WorkspaceModel.BuildAuthority
+	if owner.PromotedBy != "#1566" || owner.ImplementationStatus != "implemented_first_slice" || owner.CanonicalOwner != "platform-spec.yaml#workspace_model.local_workspace_image_build_authority" {
+		t.Fatalf("workspace image build authority = %#v", owner)
+	}
+	for _, want := range []string{"embedded/materialized", "source checkout", "Dockerfile.workspace", "go.mod"} {
+		if !strings.Contains(owner.BuildPlanRule, want) {
+			t.Fatalf("build plan rule missing %q:\n%s", want, owner.BuildPlanRule)
+		}
+	}
+	for _, want := range []string{"SWARM_WORKSPACE_IMAGE", "swarm-workspace:latest", "--image"} {
+		if !strings.Contains(owner.ImageTargetRule, want) {
+			t.Fatalf("image target rule missing %q:\n%s", want, owner.ImageTargetRule)
+		}
+	}
+	for _, want := range []string{"command -v", "--version", "lookup alone are insufficient"} {
+		if !strings.Contains(owner.ValidationRule, want) {
+			t.Fatalf("validation rule missing %q:\n%s", want, owner.ValidationRule)
+		}
+	}
+	buildArgs, ok := owner.BuildProfile["docker_build_args"].(map[string]any)
+	if !ok || buildArgs["INSTALL_CLAUDE_CLI"] != "true" || buildArgs["INSTALL_CODEX_CLI"] != "false" {
+		t.Fatalf("build args = %#v", owner.BuildProfile["docker_build_args"])
+	}
+	for _, want := range []string{"MUST NOT build images", "MUST NOT auto-build images", "Host workspace backend"} {
+		if !stringSliceContains(owner.ConsumerBoundaries, want) {
+			t.Fatalf("consumer boundaries missing %q: %#v", want, owner.ConsumerBoundaries)
+		}
+	}
+	row := spec.CLISpecification.CommandCatalog.WorkspaceBuild
+	if row.Command != "swarm workspace build --backend claude_cli [--image <tag>]" || row.ImplementationStatus != "implemented_first_slice" || row.Owner != "workspace_model.local_workspace_image_build_authority" {
+		t.Fatalf("workspace_build command catalog row = %#v", row)
+	}
+	for _, want := range []string{"embedded/materialized", "SWARM_DOCKER_BIN", "SWARM_WORKSPACE_IMAGE", "claude --version"} {
+		if !strings.Contains(row.Behavior, want) {
+			t.Fatalf("workspace_build behavior missing %q:\n%s", want, row.Behavior)
+		}
+	}
+	if !stringSliceContains(row.Boundaries, "no runtime startup auto-build") || !stringSliceContains(row.Boundaries, "no source-checkout Dockerfile lookup or go.mod walk") {
+		t.Fatalf("workspace_build boundaries incomplete: %#v", row.Boundaries)
+	}
+}
+
+func configureWorkspaceBuildDockerStub(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	callsPath := filepath.Join(dir, "docker.calls")
+	dockerPath := filepath.Join(dir, "docker")
+	script := `#!/bin/sh
+printf '%s\n' "$*" >> "$SWARM_TEST_DOCKER_CALLS"
+case "$1" in
+  version)
+    exit 0
+    ;;
+  build)
+    if [ "$SWARM_TEST_DOCKER_FAIL_BUILD" = "1" ]; then
+      echo "docker build failed" >&2
+      exit 42
+    fi
+    exit 0
+    ;;
+  run)
+    if [ "$SWARM_TEST_DOCKER_FAIL_VALIDATE" = "1" ]; then
+      echo "claude missing" >&2
+      exit 43
+    fi
+    exit 0
+    ;;
+  *)
+    echo "unexpected docker command: $*" >&2
+    exit 44
+    ;;
+esac
+`
+	if err := os.WriteFile(dockerPath, []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake docker: %v", err)
+	}
+	t.Setenv("SWARM_DOCKER_BIN", dockerPath)
+	t.Setenv("SWARM_TEST_DOCKER_CALLS", callsPath)
+	t.Setenv("SWARM_TEST_DOCKER_FAIL_BUILD", "")
+	t.Setenv("SWARM_TEST_DOCKER_FAIL_VALIDATE", "")
+	return callsPath
+}
+
+func readWorkspaceBuildDockerCalls(t *testing.T, callsPath string) []string {
+	t.Helper()
+	data, err := os.ReadFile(callsPath)
+	if err != nil {
+		t.Fatalf("read docker calls: %v", err)
+	}
+	var out []string
+	for _, line := range strings.Split(strings.TrimSpace(string(data)), "\n") {
+		if strings.TrimSpace(line) != "" {
+			out = append(out, line)
+		}
+	}
+	return out
+}

--- a/cmd/swarm/workspace_build_test.go
+++ b/cmd/swarm/workspace_build_test.go
@@ -37,15 +37,15 @@ func TestWorkspaceBuildClaudeCLIUsesEmbeddedBuildPlanFromTempCWD(t *testing.T) {
 	}
 
 	calls := readWorkspaceBuildDockerCalls(t, callsPath)
-	if len(calls) != 3 {
-		t.Fatalf("docker call count = %d, want 3:\n%s", len(calls), strings.Join(calls, "\n"))
+	if len(calls) != 5 {
+		t.Fatalf("docker call count = %d, want 5:\n%s", len(calls), strings.Join(calls, "\n"))
 	}
 	if calls[0] != "version --format {{.Server.Version}}" {
 		t.Fatalf("docker version call = %q", calls[0])
 	}
 	build := calls[1]
 	for _, want := range []string{
-		"build -t swarm-workspace:latest",
+		"build -t swarm-workspace-build-",
 		"--build-arg INSTALL_CLAUDE_CLI=true",
 		"--build-arg INSTALL_CODEX_CLI=false",
 		"swarm-workspace-build-context-",
@@ -54,6 +54,10 @@ func TestWorkspaceBuildClaudeCLIUsesEmbeddedBuildPlanFromTempCWD(t *testing.T) {
 			t.Fatalf("docker build call missing %q:\n%s", want, build)
 		}
 	}
+	if strings.Contains(build, "build -t swarm-workspace:latest") {
+		t.Fatalf("docker build call published directly to runtime image tag:\n%s", build)
+	}
+	tempImage := workspaceBuildTaggedImageFromCall(t, build)
 	if strings.Contains(build, sourceRoot) || strings.Contains(build, tempCWD) {
 		t.Fatalf("docker build call used source checkout or current directory:\n%s", build)
 	}
@@ -62,13 +66,19 @@ func TestWorkspaceBuildClaudeCLIUsesEmbeddedBuildPlanFromTempCWD(t *testing.T) {
 	}
 	validate := calls[2]
 	for _, want := range []string{
-		"run --rm --entrypoint sh swarm-workspace:latest",
+		"run --rm --entrypoint sh " + tempImage,
 		"command -v -- \"$1\" >/dev/null && \"$1\" --version >/dev/null",
 		"swarm-cli-proof claude",
 	} {
 		if !strings.Contains(validate, want) {
 			t.Fatalf("docker validation call missing %q:\n%s", want, validate)
 		}
+	}
+	if calls[3] != "tag "+tempImage+" swarm-workspace:latest" {
+		t.Fatalf("docker publish call = %q, want tag from temp image to runtime image", calls[3])
+	}
+	if calls[4] != "image rm "+tempImage {
+		t.Fatalf("docker temp cleanup call = %q, want image rm %s", calls[4], tempImage)
 	}
 }
 
@@ -82,8 +92,11 @@ func TestWorkspaceBuildClaudeCLIImageOverride(t *testing.T) {
 		t.Fatalf("code = %d stdout=%s stderr=%s", code, stdout.String(), stderr.String())
 	}
 	calls := strings.Join(readWorkspaceBuildDockerCalls(t, callsPath), "\n")
-	if !strings.Contains(calls, "build -t custom/image:test") || !strings.Contains(calls, "run --rm --entrypoint sh custom/image:test") {
+	if !strings.Contains(calls, "tag swarm-workspace-build-") || !strings.Contains(calls, " custom/image:test") {
 		t.Fatalf("docker calls did not use --image override:\n%s", calls)
+	}
+	if strings.Contains(calls, "build -t custom/image:test") || strings.Contains(calls, "run --rm --entrypoint sh custom/image:test") {
+		t.Fatalf("docker calls published or validated final image before validation completed:\n%s", calls)
 	}
 	if strings.Contains(calls, "env-image:latest") {
 		t.Fatalf("docker calls used env image despite --image override:\n%s", calls)
@@ -107,7 +120,7 @@ func TestWorkspaceBuildClaudeCLIFailsOnDockerBuildError(t *testing.T) {
 }
 
 func TestWorkspaceBuildClaudeCLIFailsOnValidationError(t *testing.T) {
-	configureWorkspaceBuildDockerStub(t)
+	callsPath := configureWorkspaceBuildDockerStub(t)
 	t.Setenv("SWARM_TEST_DOCKER_FAIL_VALIDATE", "1")
 
 	var stdout, stderr bytes.Buffer
@@ -119,6 +132,13 @@ func TestWorkspaceBuildClaudeCLIFailsOnValidationError(t *testing.T) {
 		if !strings.Contains(stderr.String(), want) {
 			t.Fatalf("stderr missing %q:\n%s", want, stderr.String())
 		}
+	}
+	calls := strings.Join(readWorkspaceBuildDockerCalls(t, callsPath), "\n")
+	if strings.Contains(calls, "\ntag ") || strings.HasPrefix(calls, "tag ") {
+		t.Fatalf("docker calls published final image after validation failure:\n%s", calls)
+	}
+	if !strings.Contains(calls, "\nimage rm swarm-workspace-build-") {
+		t.Fatalf("docker calls did not clean up temp validation image:\n%s", calls)
 	}
 }
 
@@ -209,7 +229,7 @@ func TestWorkspaceBuildSpecAuthorityPromoted(t *testing.T) {
 			t.Fatalf("image target rule missing %q:\n%s", want, owner.ImageTargetRule)
 		}
 	}
-	for _, want := range []string{"command -v", "--version", "lookup alone are insufficient"} {
+	for _, want := range []string{"temporary image tag", "command -v", "--version", "lookup alone are insufficient"} {
 		if !strings.Contains(owner.ValidationRule, want) {
 			t.Fatalf("validation rule missing %q:\n%s", want, owner.ValidationRule)
 		}
@@ -227,7 +247,7 @@ func TestWorkspaceBuildSpecAuthorityPromoted(t *testing.T) {
 	if row.Command != "swarm workspace build --backend claude_cli [--image <tag>]" || row.ImplementationStatus != "implemented_first_slice" || row.Owner != "workspace_model.local_workspace_image_build_authority" {
 		t.Fatalf("workspace_build command catalog row = %#v", row)
 	}
-	for _, want := range []string{"embedded/materialized", "SWARM_DOCKER_BIN", "SWARM_WORKSPACE_IMAGE", "claude --version"} {
+	for _, want := range []string{"embedded/materialized", "temporary image tag", "SWARM_DOCKER_BIN", "SWARM_WORKSPACE_IMAGE", "claude --version"} {
 		if !strings.Contains(row.Behavior, want) {
 			t.Fatalf("workspace_build behavior missing %q:\n%s", want, row.Behavior)
 		}
@@ -262,6 +282,16 @@ case "$1" in
     fi
     exit 0
     ;;
+  tag)
+    exit 0
+    ;;
+  image)
+    if [ "$2" = "rm" ]; then
+      exit 0
+    fi
+    echo "unexpected docker image command: $*" >&2
+    exit 45
+    ;;
   *)
     echo "unexpected docker command: $*" >&2
     exit 44
@@ -276,6 +306,18 @@ esac
 	t.Setenv("SWARM_TEST_DOCKER_FAIL_BUILD", "")
 	t.Setenv("SWARM_TEST_DOCKER_FAIL_VALIDATE", "")
 	return callsPath
+}
+
+func workspaceBuildTaggedImageFromCall(t *testing.T, call string) string {
+	t.Helper()
+	fields := strings.Fields(call)
+	for i := 0; i < len(fields)-1; i++ {
+		if fields[i] == "-t" {
+			return fields[i+1]
+		}
+	}
+	t.Fatalf("docker call missing -t image: %s", call)
+	return ""
 }
 
 func readWorkspaceBuildDockerCalls(t *testing.T, callsPath string) []string {

--- a/internal/platform/artifacts.go
+++ b/internal/platform/artifacts.go
@@ -13,11 +13,13 @@ import (
 )
 
 const (
-	DefaultPlatformSpecPath = "platform-spec.yaml"
-	DefaultOpenRPCPath      = "openrpc.json"
+	DefaultPlatformSpecPath        = "platform-spec.yaml"
+	DefaultOpenRPCPath             = "openrpc.json"
+	DefaultWorkspaceDockerfilePath = "Dockerfile.workspace"
 )
 
 const PlatformSpecDisplayPath = "embedded://swarm/platform-spec.yaml"
+const WorkspaceDockerfileDisplayPath = "embedded://swarm/Dockerfile.workspace"
 
 func DefaultPlatformSpecFile(repoRoot string) string {
 	return filepath.Join(repoRoot, DefaultPlatformSpecPath)
@@ -31,19 +33,32 @@ func PlatformSpecYAML() []byte {
 	return rootartifacts.EmbeddedPlatformSpecYAML()
 }
 
+func WorkspaceDockerfile() []byte {
+	return rootartifacts.EmbeddedWorkspaceDockerfile()
+}
+
 func MaterializePlatformSpecFile() (string, error) {
 	spec := PlatformSpecYAML()
-	digest := sha256.Sum256(spec)
-	name := "platform-spec-" + hex.EncodeToString(digest[:8]) + ".yaml"
+	return materializeEmbeddedAsset("platform spec", "platform-spec-", ".yaml", spec)
+}
+
+func MaterializeWorkspaceDockerfile() (string, error) {
+	dockerfile := WorkspaceDockerfile()
+	return materializeEmbeddedAsset("workspace Dockerfile", "Dockerfile.workspace-", "", dockerfile)
+}
+
+func materializeEmbeddedAsset(label, prefix, suffix string, data []byte) (string, error) {
+	digest := sha256.Sum256(data)
+	name := prefix + hex.EncodeToString(digest[:8]) + suffix
 	var attempts []string
 	for _, base := range platformSpecCacheBases() {
-		path, err := materializePlatformSpecFile(base, name, spec)
+		path, err := materializeEmbeddedAssetFile(base, name, data)
 		if err == nil {
 			return path, nil
 		}
 		attempts = append(attempts, fmt.Sprintf("%s: %v", base, err))
 	}
-	return "", fmt.Errorf("materialize embedded platform spec: %s", strings.Join(attempts, "; "))
+	return "", fmt.Errorf("materialize embedded %s: %s", label, strings.Join(attempts, "; "))
 }
 
 func platformSpecCacheBases() []string {
@@ -55,12 +70,12 @@ func platformSpecCacheBases() []string {
 	return bases
 }
 
-func materializePlatformSpecFile(dir, name string, spec []byte) (string, error) {
+func materializeEmbeddedAssetFile(dir, name string, data []byte) (string, error) {
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return "", err
 	}
 	path := filepath.Join(dir, name)
-	if existing, err := os.ReadFile(path); err == nil && bytes.Equal(existing, spec) {
+	if existing, err := os.ReadFile(path); err == nil && bytes.Equal(existing, data) {
 		return path, nil
 	}
 	tmp, err := os.CreateTemp(dir, name+".tmp-*")
@@ -69,7 +84,7 @@ func materializePlatformSpecFile(dir, name string, spec []byte) (string, error) 
 	}
 	tmpPath := tmp.Name()
 	defer os.Remove(tmpPath)
-	if _, err := tmp.Write(spec); err != nil {
+	if _, err := tmp.Write(data); err != nil {
 		tmp.Close()
 		return "", err
 	}
@@ -81,7 +96,7 @@ func materializePlatformSpecFile(dir, name string, spec []byte) (string, error) 
 		return "", err
 	}
 	if err := os.Rename(tmpPath, path); err != nil {
-		if existing, readErr := os.ReadFile(path); readErr == nil && bytes.Equal(existing, spec) {
+		if existing, readErr := os.ReadFile(path); readErr == nil && bytes.Equal(existing, data) {
 			return path, nil
 		}
 		return "", err

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -9382,9 +9382,10 @@ workspace_model:
       setup-only override and MUST fail closed when empty or syntactically invalid. The override does not change runtime
       configuration by itself; operators must still run serve with the matching configured image when overriding.
     validation_rule: >
-      After build, the command MUST validate the resulting image by running a harmless executable Claude CLI proof inside
-      the image, equivalent to `command -v -- "$1" >/dev/null && "$1" --version >/dev/null` with `$1=claude`. Image
-      inspection alone and command lookup alone are insufficient.
+      The command MUST build into a temporary image tag first and MUST NOT publish/replace the configured runtime image
+      tag until validation passes. After build, the command MUST validate the temporary image by running a harmless
+      executable Claude CLI proof inside the image, equivalent to `command -v -- "$1" >/dev/null && "$1" --version
+      >/dev/null` with `$1=claude`. Image inspection alone and command lookup alone are insufficient.
     consumer_boundaries:
       - '`swarm workspace build` is the setup producer for this first slice.'
       - '`swarm doctor --backend claude_cli` may report or recommend the build command, but MUST NOT build images.'
@@ -11608,9 +11609,10 @@ cli_specification:
       owner: workspace_model.local_workspace_image_build_authority
       behavior: >
         Builds and validates the local Docker workspace image for `claude_cli` proof flows using the embedded/materialized
-        workspace build plan. The command uses `SWARM_DOCKER_BIN` when set, targets `SWARM_WORKSPACE_IMAGE` or
-        `swarm-workspace:latest` by default, accepts explicit `--image <tag>` for setup-only override, passes the approved
-        `claude_cli` build args, and validates that the resulting image can execute `claude --version`.
+        workspace build plan. The command uses `SWARM_DOCKER_BIN` when set, builds into a temporary image tag, targets
+        `SWARM_WORKSPACE_IMAGE` or `swarm-workspace:latest` by default, accepts explicit `--image <tag>` for setup-only
+        override, passes the approved `claude_cli` build args, validates that the temporary image can execute
+        `claude --version`, and only then tags the validated image as the configured target.
       boundaries:
       - no runtime startup auto-build
       - no source-checkout Dockerfile lookup or go.mod walk

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -9352,6 +9352,44 @@ workspace_model:
     split_scope: >
       Docker Compose setup and workspace image contents/default agent CLI availability remain tracked separately by #996 and
       #997 unless a future gate explicitly widens them.
+  local_workspace_image_build_authority:
+    promoted_by: '#1566'
+    implementation_status: implemented_first_slice
+    canonical_owner: platform-spec.yaml#workspace_model.local_workspace_image_build_authority
+    implementation_owner: cmd/swarm workspace build command plus embedded workspace Dockerfile materializer
+    scope: >
+      Merge-bearing local setup authority for building and validating the Docker workspace image needed by local
+      `claude_cli` proof flows. This owner is an explicit operator setup surface. It is separate from runtime startup:
+      runtime startup consumes `workspace_model.runtime_image_packaging` and MUST remain fail-closed inspect-only when the
+      configured image is missing or unusable.
+    command_surface: swarm workspace build --backend claude_cli [--image <tag>]
+    build_plan_rule: >
+      The command MUST use an embedded/materialized workspace Dockerfile or equivalent embedded build plan. It MUST NOT
+      locate build material by walking for a source checkout, reading repo-root `Dockerfile.workspace`, using
+      `runtime.Caller`, or requiring a `go.mod` path. The materialized plan is internal implementation detail, not a
+      user-facing configuration source.
+    claude_cli_build_profile:
+      backend: claude_cli
+      docker_build_args:
+        INSTALL_CLAUDE_CLI: 'true'
+        INSTALL_CODEX_CLI: 'false'
+      version_policy: >
+        Claude CLI package/version selection is owned by the embedded workspace Dockerfile defaults unless a later gated
+        source-authority change promotes explicit version flags.
+    image_target_rule: >
+      Without `--image`, the command MUST target the same configured workspace image consumed by `swarm serve` Docker
+      startup: `SWARM_WORKSPACE_IMAGE` when set, otherwise `swarm-workspace:latest`. `--image <tag>` is an explicit
+      setup-only override and MUST fail closed when empty or syntactically invalid. The override does not change runtime
+      configuration by itself; operators must still run serve with the matching configured image when overriding.
+    validation_rule: >
+      After build, the command MUST validate the resulting image by running a harmless executable Claude CLI proof inside
+      the image, equivalent to `command -v -- "$1" >/dev/null && "$1" --version >/dev/null` with `$1=claude`. Image
+      inspection alone and command lookup alone are insufficient.
+    consumer_boundaries:
+      - '`swarm workspace build` is the setup producer for this first slice.'
+      - '`swarm doctor --backend claude_cli` may report or recommend the build command, but MUST NOT build images.'
+      - '`swarm serve --dev --backend claude_cli` and local foreground `swarm run --backend claude_cli` MUST NOT auto-build images.'
+      - 'Host workspace backend execution, local API connection discovery, stale MCP gateway env policy, Compose setup, and docs rollout remain split.'
   data_source_authority:
     promoted_by: '#1139/#1223'
     implementation_status: implemented
@@ -11563,6 +11601,22 @@ cli_specification:
       - local API connection discovery files
       - stale gateway env precedence or auto-fix policy
       - deployment-mode profile management
+    workspace_build:
+      command: swarm workspace build --backend claude_cli [--image <tag>]
+      tier: should_have
+      implementation_status: implemented_first_slice
+      owner: workspace_model.local_workspace_image_build_authority
+      behavior: >
+        Builds and validates the local Docker workspace image for `claude_cli` proof flows using the embedded/materialized
+        workspace build plan. The command uses `SWARM_DOCKER_BIN` when set, targets `SWARM_WORKSPACE_IMAGE` or
+        `swarm-workspace:latest` by default, accepts explicit `--image <tag>` for setup-only override, passes the approved
+        `claude_cli` build args, and validates that the resulting image can execute `claude --version`.
+      boundaries:
+      - no runtime startup auto-build
+      - no source-checkout Dockerfile lookup or go.mod walk
+      - no host workspace execution changes
+      - no local API connection discovery
+      - no stale MCP gateway env policy change
     secrets:
       command: swarm secrets set|list|check|rm
       tier: must_have

--- a/platform_artifacts.go
+++ b/platform_artifacts.go
@@ -5,8 +5,17 @@ import _ "embed"
 //go:embed platform-spec.yaml
 var platformSpecYAML []byte
 
+//go:embed Dockerfile.workspace
+var workspaceDockerfile []byte
+
 func EmbeddedPlatformSpecYAML() []byte {
 	out := make([]byte, len(platformSpecYAML))
 	copy(out, platformSpecYAML)
+	return out
+}
+
+func EmbeddedWorkspaceDockerfile() []byte {
+	out := make([]byte, len(workspaceDockerfile))
+	copy(out, workspaceDockerfile)
 	return out
 }


### PR DESCRIPTION
## Summary

Adds the approved explicit local workspace image setup path:

- `swarm workspace build --backend claude_cli [--image <tag>]`
- embedded/materialized `Dockerfile.workspace` build plan for installed-binary-safe setup
- Docker build args for the `claude_cli` profile: `INSTALL_CLAUDE_CLI=true`, `INSTALL_CODEX_CLI=false`
- post-build validation that executes `claude --version` inside the image
- doctor/preflight remediation text pointing to the new command without building images

Closes #1566.

## Governing refs / context

Exact spec refs promoted or consumed:

- `platform-spec.yaml#workspace_model.local_workspace_image_build_authority` added by this PR
- `platform-spec.yaml#cli_specification.command_catalog.workspace_build` added by this PR
- `platform-spec.yaml#workspace_model.runtime_image_packaging`
- `platform-spec.yaml#cli_specification.foundations.installed_binary_portability`
- `platform-spec.yaml#cli_specification.foundations.local_cli_test_workspace_cli_availability`
- `platform-spec.yaml#cli_specification.foundations.local_claude_cli_preflight_admission`
- `platform-spec.yaml#workspace_model.workspace_backend_selection`

Issue/gate context:

- #1566 Pre-Implementation Coverage Audit
- #1566 gate outcome: approved as first slice
- Parent #1441 remains open for local proof UX tails
- Siblings #1567 and #1568 remain split

## Semantic migration

New canonical owner:

- `workspace_model.local_workspace_image_build_authority`
- `cli_specification.command_catalog.workspace_build`

Old non-authoritative path now invalid:

- manual operator knowledge of `docker build -f Dockerfile.workspace --build-arg ... .` as the only happy path
- source-checkout Dockerfile lookup for installed CLI setup
- runtime startup image auto-build or any `serve`/`run`/`doctor` build side effect

Production paths checked for surviving old behavior:

- runtime `EnsurePrereqs` remains inspect/network/image-check only
- `swarm doctor` remains report/remediation only
- local `swarm serve --dev --backend claude_cli` and foreground `swarm run --backend claude_cli` continue consuming preflight/runtime image availability and do not build

Migration completeness:

- complete for the #1566 chosen class: one supported CLI setup producer exists and the runtime/doctor consumers remain non-builders
- not full #1441 closure; connection discovery, stale gateway policy, and docs cleanup remain tracked separately

## Validation

- `go test ./cmd/swarm ./internal/platform ./internal/runtime/workspace`
- `go test ./cmd/swarm -run 'TestWorkspaceBuild' -count=1 -v`
- `go test ./...`
