### PR TITLE
[agent-c][issue #1535] Add guard escalation payload fields

### DIFF
--- a/internal/runtime/bootverify/report_test.go
+++ b/internal/runtime/bootverify/report_test.go
@@ -2770,6 +2770,33 @@ func TestRun_RejectsUnsupportedGuardOnFail(t *testing.T) {
 	}
 }
 
+func TestRun_RejectsGuardEscalateObjectMissingEvent(t *testing.T) {
+	source := semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
+		Nodes: map[string]runtimecontracts.SystemNodeContract{
+			"test-node": {
+				ID: "test-node",
+				EventHandlers: map[string]runtimecontracts.SystemNodeEventHandler{
+					"item.received": {
+						Guard: &runtimecontracts.GuardSpec{
+							Check: "entity.entity_id != null",
+							OnFailSpec: runtimecontracts.GuardFailureSpec{
+								Action:          runtimecontracts.GuardFailureActionEscalate,
+								AuthoredMapping: true,
+							},
+						},
+					},
+				},
+			},
+		},
+	})
+
+	report := Run(context.Background(), source, Options{})
+
+	if !reportContains(report.Errors(), "condition_expression_validation", "guard on_fail escalate requires event type") {
+		t.Fatalf("expected missing guard escalation event error, got %#v", report.Errors())
+	}
+}
+
 func TestRun_RejectsMalformedConditionCELAfterRecognizedPrefix(t *testing.T) {
 	source := semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
 		Nodes: map[string]runtimecontracts.SystemNodeContract{
@@ -3485,6 +3512,74 @@ func TestRun_ErrorsForGuardEscalatePayloadDrift(t *testing.T) {
 	}
 }
 
+func TestRun_DoesNotWarnWhenGuardEscalateObjectFieldsCoverRequiredPayload(t *testing.T) {
+	bundle := loadFixtureBundle(t, filepath.Join("tests", "tier1-primitives", "test-guard-escalate"))
+	entry := bundle.Events["check.escalated"]
+	entry.Payload.Properties["score"] = runtimecontracts.EventFieldSpec{Type: "integer"}
+	entry.Payload.Properties["reason"] = runtimecontracts.EventFieldSpec{Type: "string"}
+	entry.Required = []string{"score", "reason"}
+	bundle.Events["check.escalated"] = entry
+	setGuardEscalationForBootverifyTest(bundle, runtimecontracts.EmitSpec{
+		Event: "check.escalated",
+		Fields: map[string]runtimecontracts.ExpressionValue{
+			"score":  runtimecontracts.RefExpression("payload.score"),
+			"reason": runtimecontracts.LiteralExpression("score_below_threshold"),
+		},
+	})
+
+	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+
+	if reportContains(report.Errors(), "semantic_drift_payload_completeness", "guard.on_fail.escalate") {
+		t.Fatalf("unexpected guard escalation payload completeness error, got %#v", report.Errors())
+	}
+}
+
+func TestRun_ErrorsWhenGuardEscalateObjectFieldsMissRequiredPayload(t *testing.T) {
+	bundle := loadFixtureBundle(t, filepath.Join("tests", "tier1-primitives", "test-guard-escalate"))
+	entry := bundle.Events["check.escalated"]
+	entry.Payload.Properties["score"] = runtimecontracts.EventFieldSpec{Type: "integer"}
+	entry.Payload.Properties["reason"] = runtimecontracts.EventFieldSpec{Type: "string"}
+	entry.Required = []string{"score", "reason"}
+	bundle.Events["check.escalated"] = entry
+	setGuardEscalationForBootverifyTest(bundle, runtimecontracts.EmitSpec{
+		Event: "check.escalated",
+		Fields: map[string]runtimecontracts.ExpressionValue{
+			"score": runtimecontracts.RefExpression("payload.score"),
+		},
+	})
+
+	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+
+	if !reportContains(report.Errors(), "semantic_drift_payload_completeness", "guard.on_fail.escalate") {
+		t.Fatalf("expected guard escalation payload completeness error, got %#v", report.Errors())
+	}
+	if !reportContains(report.Errors(), "semantic_drift_payload_completeness", "reason is not statically provable") {
+		t.Fatalf("expected missing reason error for guard escalation object fields, got %#v", report.Errors())
+	}
+}
+
+func TestRun_ErrorsWhenGuardEscalateObjectFieldsAuthorEnvelopeOwnedField(t *testing.T) {
+	bundle := loadFixtureBundle(t, filepath.Join("tests", "tier1-primitives", "test-guard-escalate"))
+	entry := bundle.Events["check.escalated"]
+	entry.Required = nil
+	bundle.Events["check.escalated"] = entry
+	setGuardEscalationForBootverifyTest(bundle, runtimecontracts.EmitSpec{
+		Event: "check.escalated",
+		Fields: map[string]runtimecontracts.ExpressionValue{
+			"entity_id": runtimecontracts.RefExpression("event.entity_id"),
+		},
+	})
+
+	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+
+	if !reportContains(report.Errors(), "semantic_drift_payload_completeness", "guard.on_fail.escalate") {
+		t.Fatalf("expected guard escalation envelope-owned field error, got %#v", report.Errors())
+	}
+	if !reportContains(report.Errors(), "semantic_drift_payload_completeness", "authors envelope-owned field entity_id in emit.fields") {
+		t.Fatalf("expected authored envelope field error for guard escalation, got %#v", report.Errors())
+	}
+}
+
 func TestRun_ErrorsForGuardEscalateWhenRequiredPayloadContainsEnvelopeOwnedFields(t *testing.T) {
 	bundle := loadFixtureBundle(t, filepath.Join("tests", "tier1-primitives", "test-guard-escalate"))
 	entry := bundle.Events["check.escalated"]
@@ -3499,6 +3594,19 @@ func TestRun_ErrorsForGuardEscalateWhenRequiredPayloadContainsEnvelopeOwnedField
 	if !reportContains(report.Errors(), "semantic_drift_payload_completeness", "entity_id is not statically provable") {
 		t.Fatalf("expected envelope-owned entity_id drift for guard escalation, got %#v", report.Errors())
 	}
+}
+
+func setGuardEscalationForBootverifyTest(bundle *runtimecontracts.WorkflowContractBundle, emit runtimecontracts.EmitSpec) {
+	node := bundle.Nodes["test-node"]
+	handler := node.EventHandlers["check.requested"]
+	handler.Guard.OnFail = "escalate:" + emit.Event
+	handler.Guard.OnFailSpec = runtimecontracts.GuardFailureSpec{
+		Action:     runtimecontracts.GuardFailureActionEscalate,
+		Escalation: emit,
+	}
+	node.EventHandlers["check.requested"] = handler
+	bundle.Nodes["test-node"] = node
+	bundle.Semantics.NodeHandlers["test-node"]["check.requested"] = handler
 }
 
 func TestRun_ReportsInputPinWiringWarning(t *testing.T) {

--- a/internal/runtime/bootverify/workflow_expression_checks.go
+++ b/internal/runtime/bootverify/workflow_expression_checks.go
@@ -31,8 +31,8 @@ func (c *checkerContext) conditionExpressions() []Finding {
 		nodeID = strings.TrimSpace(nodeID)
 		for eventType, handler := range node.EventHandlers {
 			eventType = strings.TrimSpace(eventType)
-			if onFail := handlerGuardOnFailLocal(handler.Guard); onFail != "" {
-				if err := validateGuardOnFailLocal(onFail); err != nil {
+			if handler.Guard != nil {
+				if err := validateGuardOnFailLocal(handler.Guard); err != nil {
 					c.conditionExprFindings = append(c.conditionExprFindings, Finding{
 						CheckID:  "condition_expression_validation",
 						Severity: "error",
@@ -102,7 +102,8 @@ func (c *checkerContext) emitFieldExpressions() []Finding {
 		for eventType, handler := range node.EventHandlers {
 			eventType = strings.TrimSpace(eventType)
 			for _, expr := range handlerEntityExpressions(handler) {
-				if expr.Phase != runtimepipeline.WorkflowEntityFieldLifecycleEmitFields {
+				if expr.Phase != runtimepipeline.WorkflowEntityFieldLifecycleEmitFields &&
+					expr.Phase != runtimepipeline.WorkflowEntityFieldLifecycleGuardEscalation {
 					continue
 				}
 				if err := workflowexpr.ValidateValueExpressionWithOptions(expr.Expression, workflowexpr.ValueExpressionOptions{AllowBareItem: expr.AllowBareItem}); err != nil {
@@ -423,6 +424,18 @@ func handlerEntityExpressions(handler runtimecontracts.SystemNodeEventHandler) [
 		}
 	}
 	appendEmitExpressions("handler", handler.Emit, false)
+	if handler.Guard != nil {
+		if failureSpec, err := handler.Guard.FailureSpec(); err == nil {
+			appendEmitExpressions("guard escalation", failureSpec.EscalationEmitSpec(), false)
+			if len(out) > 0 {
+				for i := range out {
+					if strings.HasPrefix(out[i].Kind, "guard escalation emit field ") {
+						out[i].Phase = runtimepipeline.WorkflowEntityFieldLifecycleGuardEscalation
+					}
+				}
+			}
+		}
+	}
 	if handler.FanOut != nil {
 		appendEmitExpressions("fan_out", handler.FanOut.Emit, true)
 	}
@@ -489,7 +502,8 @@ func availableEntityFieldsForExpression(handler runtimecontracts.SystemNodeEvent
 	switch expr.Phase {
 	case runtimepipeline.WorkflowEntityFieldLifecycleDataAccumulation:
 		return runtimepipeline.WorkflowEntityFieldsAvailableBeforeDataAccumulation(handler)
-	case runtimepipeline.WorkflowEntityFieldLifecycleGuard:
+	case runtimepipeline.WorkflowEntityFieldLifecycleGuard,
+		runtimepipeline.WorkflowEntityFieldLifecycleGuardEscalation:
 		return runtimepipeline.WorkflowEntityFieldsAvailableBeforeCondition(handler, runtimepipeline.WorkflowConditionContextGuard)
 	case runtimepipeline.WorkflowEntityFieldLifecycleFilter:
 		return runtimepipeline.WorkflowEntityFieldsAvailableBeforeCondition(handler, runtimepipeline.WorkflowConditionContextFilter)
@@ -599,8 +613,12 @@ func handlerEntityFieldWriters(handler runtimecontracts.SystemNodeEventHandler) 
 	return out
 }
 
-func validateGuardOnFailLocal(onFail string) error {
-	parsed, err := runtimeengine.ParseGuardFailure(onFail)
+func validateGuardOnFailLocal(spec *runtimecontracts.GuardSpec) error {
+	failureSpec, err := spec.FailureSpec()
+	if err != nil {
+		return err
+	}
+	parsed, err := runtimeengine.GuardFailureFromSpec(failureSpec)
 	if err != nil {
 		return err
 	}
@@ -615,15 +633,8 @@ func validateGuardOnFailLocal(onFail string) error {
 		}
 		return nil
 	default:
-		return fmt.Errorf("on_fail %q is not supported", onFail)
+		return fmt.Errorf("on_fail %q is not supported", failureSpec.Action)
 	}
-}
-
-func handlerGuardOnFailLocal(spec *runtimecontracts.GuardSpec) string {
-	if spec == nil {
-		return ""
-	}
-	return strings.TrimSpace(spec.OnFail)
 }
 
 func conditionMissingRecognizedPrefixLocal(expression string, context runtimepipeline.WorkflowConditionContext) bool {

--- a/internal/runtime/bootverify/workflow_payload_completeness_checks.go
+++ b/internal/runtime/bootverify/workflow_payload_completeness_checks.go
@@ -161,10 +161,9 @@ func payloadCompletenessEmitSites(handler runtimecontracts.SystemNodeEventHandle
 		}
 	}
 	if handler.Guard != nil {
-		onFail := strings.TrimSpace(handler.Guard.OnFail)
-		if onFail != "" {
-			if parsed, err := runtimeengine.ParseGuardFailure(onFail); err == nil && parsed.Action == runtimeengine.GuardFailureEscalate {
-				add("guard.on_fail.escalate", runtimecontracts.EmitSpec{Event: strings.TrimSpace(parsed.EventType)})
+		if failureSpec, err := handler.Guard.FailureSpec(); err == nil {
+			if parsed, err := runtimeengine.GuardFailureFromSpec(failureSpec); err == nil && parsed.Action == runtimeengine.GuardFailureEscalate {
+				add("guard.on_fail.escalate", failureSpec.EscalationEmitSpec())
 			}
 		}
 	}

--- a/internal/runtime/contracts/workflow_contract_types.go
+++ b/internal/runtime/contracts/workflow_contract_types.go
@@ -147,16 +147,77 @@ type HandlerRuleEntry struct {
 	FanOut           *FanOutSpec              `yaml:"fan_out"`
 }
 type GuardSpec struct {
-	ID        string       `yaml:"id"`
-	Check     string       `yaml:"check"`
-	OnFail    string       `yaml:"on_fail"`
-	Checks    []GuardCheck `yaml:"checks"`
-	PolicyRef string       `yaml:"policy_ref"`
+	ID         string           `yaml:"id"`
+	Check      string           `yaml:"check"`
+	OnFail     string           `yaml:"on_fail"`
+	OnFailSpec GuardFailureSpec `yaml:"-"`
+	Checks     []GuardCheck     `yaml:"checks"`
+	PolicyRef  string           `yaml:"policy_ref"`
 }
 type GuardCheck struct {
 	ID    string `yaml:"id"`
 	Check string `yaml:"check"`
 }
+
+type GuardFailureAction string
+
+const (
+	GuardFailureActionReject   GuardFailureAction = "reject"
+	GuardFailureActionDiscard  GuardFailureAction = "discard"
+	GuardFailureActionKill     GuardFailureAction = "kill"
+	GuardFailureActionEscalate GuardFailureAction = "escalate"
+)
+
+type GuardFailureSpec struct {
+	Action          GuardFailureAction `yaml:"action"`
+	Escalation      EmitSpec           `yaml:"escalate"`
+	AuthoredMapping bool               `yaml:"-"`
+}
+
+func (s GuardFailureSpec) Empty() bool {
+	return strings.TrimSpace(string(s.Action)) == "" && s.Escalation.Empty() && len(s.Escalation.Fields) == 0
+}
+
+func (s GuardFailureSpec) EscalationEmitSpec() EmitSpec {
+	if s.Action != GuardFailureActionEscalate {
+		return EmitSpec{}
+	}
+	return cloneEmitSpec(s.Escalation)
+}
+
+func (g *GuardSpec) FailureSpec() (GuardFailureSpec, error) {
+	if g == nil {
+		return ParseGuardFailureSpec("")
+	}
+	if !g.OnFailSpec.Empty() || g.OnFailSpec.AuthoredMapping {
+		return g.OnFailSpec, nil
+	}
+	return ParseGuardFailureSpec(g.OnFail)
+}
+
+func ParseGuardFailureSpec(action string) (GuardFailureSpec, error) {
+	normalized := strings.TrimSpace(strings.ToLower(action))
+	switch normalized {
+	case "", "reject":
+		return GuardFailureSpec{Action: GuardFailureActionReject}, nil
+	case "discard":
+		return GuardFailureSpec{Action: GuardFailureActionDiscard}, nil
+	case "kill":
+		return GuardFailureSpec{Action: GuardFailureActionKill}, nil
+	}
+	if strings.HasPrefix(normalized, "escalate:") {
+		eventType := strings.TrimSpace(strings.TrimPrefix(normalized, "escalate:"))
+		if eventType == "" {
+			return GuardFailureSpec{}, fmt.Errorf("guard on_fail escalate requires event type")
+		}
+		return GuardFailureSpec{
+			Action:     GuardFailureActionEscalate,
+			Escalation: EmitSpec{Event: eventType},
+		}, nil
+	}
+	return GuardFailureSpec{}, fmt.Errorf("unsupported guard on_fail action %q", action)
+}
+
 type AccumulateSpec struct {
 	Into         string               `yaml:"into"`
 	ExpectedFrom string               `yaml:"expected_from"`

--- a/internal/runtime/contracts/workflow_contract_yaml_rules.go
+++ b/internal/runtime/contracts/workflow_contract_yaml_rules.go
@@ -62,7 +62,7 @@ func decodeGuardOnFailNode(node *yaml.Node) (string, GuardFailureSpec, error) {
 		return value, GuardFailureSpec{}, nil
 	case yaml.MappingNode:
 		if len(node.Content) == 0 {
-			return "", GuardFailureSpec{}, nil
+			return "", GuardFailureSpec{}, fmt.Errorf("guard.on_fail object form requires escalate")
 		}
 		var escalation *EmitSpec
 		for i := 0; i+1 < len(node.Content); i += 2 {
@@ -79,7 +79,7 @@ func decodeGuardOnFailNode(node *yaml.Node) (string, GuardFailureSpec, error) {
 			}
 		}
 		if escalation == nil {
-			return "", GuardFailureSpec{}, nil
+			return "", GuardFailureSpec{}, fmt.Errorf("guard.on_fail object form requires escalate")
 		}
 		spec := GuardFailureSpec{
 			Action:          GuardFailureActionEscalate,

--- a/internal/runtime/contracts/workflow_contract_yaml_rules.go
+++ b/internal/runtime/contracts/workflow_contract_yaml_rules.go
@@ -21,15 +21,107 @@ func (g *GuardSpec) UnmarshalYAML(node *yaml.Node) error {
 		*g = GuardSpec{ID: strings.TrimSpace(node.Value)}
 		return nil
 	case yaml.MappingNode:
-		type alias GuardSpec
-		var aux alias
+		var aux struct {
+			ID        string       `yaml:"id"`
+			Check     string       `yaml:"check"`
+			OnFail    yaml.Node    `yaml:"on_fail"`
+			Checks    []GuardCheck `yaml:"checks"`
+			PolicyRef string       `yaml:"policy_ref"`
+		}
 		if err := node.Decode(&aux); err != nil {
 			return err
 		}
-		*g = GuardSpec(aux)
+		*g = GuardSpec{
+			ID:        strings.TrimSpace(aux.ID),
+			Check:     strings.TrimSpace(aux.Check),
+			Checks:    aux.Checks,
+			PolicyRef: strings.TrimSpace(aux.PolicyRef),
+		}
+		onFail, spec, err := decodeGuardOnFailNode(&aux.OnFail)
+		if err != nil {
+			return err
+		}
+		g.OnFail = onFail
+		g.OnFailSpec = spec
 		return nil
 	default:
 		return fmt.Errorf("unsupported guard yaml node kind %d", node.Kind)
+	}
+}
+
+func decodeGuardOnFailNode(node *yaml.Node) (string, GuardFailureSpec, error) {
+	if node == nil || node.Kind == 0 || strings.EqualFold(strings.TrimSpace(node.Tag), "!!null") {
+		return "", GuardFailureSpec{}, nil
+	}
+	switch node.Kind {
+	case yaml.ScalarNode:
+		value := strings.TrimSpace(node.Value)
+		if value == "" {
+			return "", GuardFailureSpec{}, nil
+		}
+		return value, GuardFailureSpec{}, nil
+	case yaml.MappingNode:
+		if len(node.Content) == 0 {
+			return "", GuardFailureSpec{}, nil
+		}
+		var escalation *EmitSpec
+		for i := 0; i+1 < len(node.Content); i += 2 {
+			key := strings.TrimSpace(node.Content[i].Value)
+			switch key {
+			case "escalate":
+				decoded, err := decodeGuardEscalationNode(node.Content[i+1])
+				if err != nil {
+					return "", GuardFailureSpec{}, err
+				}
+				escalation = &decoded
+			default:
+				return "", GuardFailureSpec{}, fmt.Errorf("UNDEFINED-FIELD: guard.on_fail field %q not in platform spec", key)
+			}
+		}
+		if escalation == nil {
+			return "", GuardFailureSpec{}, nil
+		}
+		spec := GuardFailureSpec{
+			Action:          GuardFailureActionEscalate,
+			Escalation:      cloneEmitSpec(*escalation),
+			AuthoredMapping: true,
+		}
+		onFail := "escalate:" + strings.TrimSpace(escalation.Event)
+		return onFail, spec, nil
+	default:
+		return "", GuardFailureSpec{}, fmt.Errorf("unsupported guard.on_fail yaml node kind %d", node.Kind)
+	}
+}
+
+func decodeGuardEscalationNode(node *yaml.Node) (EmitSpec, error) {
+	if node == nil || node.Kind == 0 || strings.EqualFold(strings.TrimSpace(node.Tag), "!!null") {
+		return EmitSpec{}, nil
+	}
+	switch node.Kind {
+	case yaml.MappingNode:
+		var event string
+		var fields map[string]ExpressionValue
+		for i := 0; i+1 < len(node.Content); i += 2 {
+			key := strings.TrimSpace(node.Content[i].Value)
+			value := node.Content[i+1]
+			switch key {
+			case "event":
+				if err := value.Decode(&event); err != nil {
+					return EmitSpec{}, err
+				}
+			case "fields":
+				decoded, err := decodeEmitFieldsNode(value)
+				if err != nil {
+					return EmitSpec{}, err
+				}
+				fields = decoded
+			default:
+				return EmitSpec{}, fmt.Errorf("UNDEFINED-FIELD: guard.on_fail.escalate field %q not in platform spec", key)
+			}
+		}
+		return EmitSpec{Event: strings.TrimSpace(event), Fields: fields}, nil
+	default:
+		return EmitSpec{}, fmt.Errorf("guard.on_fail.escalate must be a mapping with event and optional fields")
 	}
 }
 

--- a/internal/runtime/contracts/workflow_contract_yaml_test.go
+++ b/internal/runtime/contracts/workflow_contract_yaml_test.go
@@ -1161,6 +1161,63 @@ fields:
 	}
 }
 
+func TestGuardSpecDecode_OnFailEscalateObjectFields(t *testing.T) {
+	var spec GuardSpec
+	if err := yaml.Unmarshal([]byte(`
+id: score_check
+check: payload.score >= policy.threshold
+on_fail:
+  escalate:
+    event: check.escalated
+    fields:
+      score: payload.score
+      threshold: policy.threshold
+      reason:
+        literal: score_below_threshold
+`), &spec); err != nil {
+		t.Fatalf("yaml.Unmarshal: %v", err)
+	}
+	if got := strings.TrimSpace(spec.OnFail); got != "escalate:check.escalated" {
+		t.Fatalf("OnFail = %q, want scalar shorthand mirror", got)
+	}
+	failure, err := spec.FailureSpec()
+	if err != nil {
+		t.Fatalf("FailureSpec error: %v", err)
+	}
+	if failure.Action != GuardFailureActionEscalate {
+		t.Fatalf("failure action = %q, want %q", failure.Action, GuardFailureActionEscalate)
+	}
+	emit := failure.EscalationEmitSpec()
+	if got := emit.Event; got != "check.escalated" {
+		t.Fatalf("escalation event = %q, want check.escalated", got)
+	}
+	if expr := emit.Fields["score"]; expr.Kind != ExpressionKindCEL || expr.CEL != "payload.score" {
+		t.Fatalf("score field = %#v, want CEL payload.score", expr)
+	}
+	if expr := emit.Fields["threshold"]; expr.Kind != ExpressionKindCEL || expr.CEL != "policy.threshold" {
+		t.Fatalf("threshold field = %#v, want CEL policy.threshold", expr)
+	}
+	if expr := emit.Fields["reason"]; expr.Kind != ExpressionKindLiteral || expr.Literal != "score_below_threshold" {
+		t.Fatalf("reason field = %#v, want literal score_below_threshold", expr)
+	}
+}
+
+func TestGuardSpecDecode_RejectsNestedScalarEscalateShortcut(t *testing.T) {
+	var spec GuardSpec
+	err := yaml.Unmarshal([]byte(`
+id: score_check
+check: payload.score >= policy.threshold
+on_fail:
+  escalate: check.escalated
+`), &spec)
+	if err == nil {
+		t.Fatal("expected nested scalar guard escalation shortcut to be rejected")
+	}
+	if !strings.Contains(err.Error(), "guard.on_fail.escalate must be a mapping") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func TestEmitSpecDecode_RejectsUnstructuredObjectFieldMappings(t *testing.T) {
 	var spec EmitSpec
 	err := yaml.Unmarshal([]byte(`

--- a/internal/runtime/contracts/workflow_contract_yaml_test.go
+++ b/internal/runtime/contracts/workflow_contract_yaml_test.go
@@ -1218,6 +1218,43 @@ on_fail:
 	}
 }
 
+func TestGuardSpecDecode_RejectsMalformedOnFailObjectForms(t *testing.T) {
+	tests := []struct {
+		name    string
+		body    string
+		wantErr string
+	}{
+		{
+			name: "empty object",
+			body: `
+id: score_check
+check: payload.score >= policy.threshold
+on_fail: {}
+`,
+			wantErr: "guard.on_fail object form requires escalate",
+		},
+		{
+			name: "missing escalate key",
+			body: `
+id: score_check
+check: payload.score >= policy.threshold
+on_fail:
+  reject: true
+`,
+			wantErr: "UNDEFINED-FIELD",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var spec GuardSpec
+			err := yaml.Unmarshal([]byte(tc.body), &spec)
+			if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("yaml.Unmarshal error = %v, want %q", err, tc.wantErr)
+			}
+		})
+	}
+}
+
 func TestEmitSpecDecode_RejectsUnstructuredObjectFieldMappings(t *testing.T) {
 	var spec EmitSpec
 	err := yaml.Unmarshal([]byte(`

--- a/internal/runtime/engine/enums.go
+++ b/internal/runtime/engine/enums.go
@@ -3,6 +3,8 @@ package engine
 import (
 	"fmt"
 	"strings"
+
+	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
 )
 
 type OutcomeStatus uint8
@@ -114,21 +116,28 @@ type GuardFailure struct {
 }
 
 func ParseGuardFailure(action string) (GuardFailure, error) {
-	normalized := strings.TrimSpace(strings.ToLower(action))
-	switch normalized {
-	case "", "reject":
-		return GuardFailure{Action: GuardFailureReject}, nil
-	case "discard":
-		return GuardFailure{Action: GuardFailureDiscard}, nil
-	case "kill":
-		return GuardFailure{Action: GuardFailureKill}, nil
+	spec, err := runtimecontracts.ParseGuardFailureSpec(action)
+	if err != nil {
+		return GuardFailure{}, err
 	}
-	if strings.HasPrefix(normalized, "escalate:") {
-		eventType := strings.TrimSpace(strings.TrimPrefix(normalized, "escalate:"))
+	return GuardFailureFromSpec(spec)
+}
+
+func GuardFailureFromSpec(spec runtimecontracts.GuardFailureSpec) (GuardFailure, error) {
+	switch spec.Action {
+	case runtimecontracts.GuardFailureActionReject:
+		return GuardFailure{Action: GuardFailureReject}, nil
+	case runtimecontracts.GuardFailureActionDiscard:
+		return GuardFailure{Action: GuardFailureDiscard}, nil
+	case runtimecontracts.GuardFailureActionKill:
+		return GuardFailure{Action: GuardFailureKill}, nil
+	case runtimecontracts.GuardFailureActionEscalate:
+		eventType := strings.TrimSpace(spec.Escalation.Event)
 		if eventType == "" {
 			return GuardFailure{}, fmt.Errorf("guard on_fail escalate requires event type")
 		}
 		return GuardFailure{Action: GuardFailureEscalate, EventType: eventType}, nil
+	default:
+		return GuardFailure{}, fmt.Errorf("unsupported guard on_fail action %q", spec.Action)
 	}
-	return GuardFailure{}, fmt.Errorf("unsupported guard on_fail action %q", action)
 }

--- a/internal/runtime/engine/executor.go
+++ b/internal/runtime/engine/executor.go
@@ -752,7 +752,7 @@ func (e *Executor) stepGuard(frame *executionFrame) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	if err := e.applyGuardFailure(frame, spec.OnFail); err != nil {
+	if err := e.applyGuardFailure(frame, spec); err != nil {
 		return false, err
 	}
 	return true, nil
@@ -2285,8 +2285,12 @@ func (e *Executor) resolveClearGates(frame *executionFrame) []string {
 	return normalizeStrings(stringSliceFromAny(mapsKeys(boolMapToAnyMap(frame.state.State.StateCarrier.Gates))))
 }
 
-func (e *Executor) applyGuardFailure(frame *executionFrame, action string) error {
-	parsed, err := ParseGuardFailure(action)
+func (e *Executor) applyGuardFailure(frame *executionFrame, spec *runtimecontracts.GuardSpec) error {
+	failureSpec, err := spec.FailureSpec()
+	if err != nil {
+		return err
+	}
+	parsed, err := GuardFailureFromSpec(failureSpec)
 	if err != nil {
 		return err
 	}
@@ -2317,11 +2321,17 @@ func (e *Executor) applyGuardFailure(frame *executionFrame, action string) error
 		eventType := parsed.EventType
 		frame.result.Status = OutcomeEscalated
 		frame.result.ActionsExecuted = append(frame.result.ActionsExecuted, "escalate:"+eventType)
-		// Guard escalation is a supported declarative emit outcome, but it has no
-		// business-payload authoring surface. It therefore uses the same runtime
-		// envelope-only path as an empty emit.fields payload, not the inbound
-		// trigger payload.
-		shaped, err := e.shapeEmitPayload(frame, eventType, map[string]any{})
+		emitSpec := failureSpec.EscalationEmitSpec()
+		emitSpec.Event = eventType
+		payload := map[string]any{}
+		transformed, err := emitFieldsPayload(e.currentContext(frame), frame.state, emitSpec, workflowexpr.ValueExpressionOptions{})
+		if err != nil {
+			return err
+		}
+		if len(transformed) > 0 {
+			payload = transformed
+		}
+		shaped, err := e.shapeEmitPayload(frame, eventType, payload)
 		if err != nil {
 			return err
 		}
@@ -2330,7 +2340,7 @@ func (e *Executor) applyGuardFailure(frame *executionFrame, action string) error
 		}
 		return nil
 	default:
-		return fmt.Errorf("unsupported guard on_fail action %q", action)
+		return fmt.Errorf("unsupported guard on_fail action %q", failureSpec.Action)
 	}
 }
 

--- a/internal/runtime/engine/executor_test.go
+++ b/internal/runtime/engine/executor_test.go
@@ -3542,6 +3542,66 @@ func TestExecutor_GuardOnFailEscalateCreatesEmitIntent(t *testing.T) {
 	}
 }
 
+func TestExecutor_GuardOnFailEscalateObjectFieldsShapeExplicitPayload(t *testing.T) {
+	shaper := &recordingPayloadShaper{}
+	exec, err := NewExecutor(RuntimeDependencies{
+		Source:        stubSource(),
+		StateRepo:     stubStateRepo{},
+		TxRunner:      stubRunner{},
+		Locker:        stubLocker{},
+		Outbox:        stubOutbox{},
+		Dispatcher:    stubDispatcher{},
+		PayloadShaper: shaper,
+		MaxChainDepth: 5,
+	}, stubEvaluator{bools: map[string]bool{
+		"payload.ok == true": false,
+	}})
+	if err != nil {
+		t.Fatalf("NewExecutor error: %v", err)
+	}
+	result, err := exec.Execute(context.Background(), ExecutionRequest{
+		EntityID:   "entity-1",
+		NodeID:     "node-1",
+		FlowID:     "flow-1",
+		ChainDepth: 1,
+		Event:      eventtest.RootIngress("evt-1", "task.completed", "", "", json.RawMessage(`{"ok":false,"score":42,"legacy":"should-not-pass"}`), 0, "", "", events.EventEnvelope{}, time.Time{}),
+		Handler: runtimecontracts.SystemNodeEventHandler{
+			Guard: &runtimecontracts.GuardSpec{
+				Check: "payload.ok == true",
+				OnFailSpec: runtimecontracts.GuardFailureSpec{
+					Action: runtimecontracts.GuardFailureActionEscalate,
+					Escalation: runtimecontracts.EmitSpec{
+						Event: "guard.failed",
+						Fields: map[string]runtimecontracts.ExpressionValue{
+							"score":  runtimecontracts.CELExpression("payload.score"),
+							"reason": runtimecontracts.CELExpression(`"score_below_threshold"`),
+						},
+					},
+				},
+			},
+		},
+		State: testStateSnapshot("", map[string]any{}, nil, map[string]map[string]any{}),
+	})
+	if err != nil {
+		t.Fatalf("Execute error: %v", err)
+	}
+	if result.Status != OutcomeEscalated {
+		t.Fatalf("Status = %q", result.Status)
+	}
+	if len(result.EmitIntents) != 1 || string(result.EmitIntents[0].Event.Type()) != "guard.failed" {
+		t.Fatalf("unexpected escalation intents: %#v", result.EmitIntents)
+	}
+	if got := asInt(shaper.lastPayload["score"]); got != 42 {
+		t.Fatalf("guard escalation score payload = %#v, want 42", shaper.lastPayload["score"])
+	}
+	if got := shaper.lastPayload["reason"]; got != "score_below_threshold" {
+		t.Fatalf("guard escalation reason payload = %#v, want score_below_threshold", got)
+	}
+	if _, ok := shaper.lastPayload["legacy"]; ok {
+		t.Fatalf("guard escalation leaked unmapped trigger payload: %#v", shaper.lastPayload)
+	}
+}
+
 func loadEngineProjectionFlowBundle(t *testing.T) *runtimecontracts.WorkflowContractBundle {
 	t.Helper()
 	root := t.TempDir()

--- a/internal/runtime/pipeline/handler_engine_transaction_test.go
+++ b/internal/runtime/pipeline/handler_engine_transaction_test.go
@@ -2604,6 +2604,73 @@ func TestExecuteNodeContractHandler_GuardEscalateUsesOnlyRuntimeOwnedEnvelope(t 
 	}
 }
 
+func TestExecuteNodeContractHandler_GuardEscalateObjectFieldsUseExplicitPayloadOnly(t *testing.T) {
+	pc, bus := newDeclarativeEmitContractCoordinatorWithBundle(declarativeEmitContractTestBundleWithEntry("guard.failed", runtimecontracts.EventCatalogEntry{
+		Payload: runtimecontracts.EventPayloadSpec{
+			Properties: map[string]runtimecontracts.EventFieldSpec{
+				"score":  {Type: "number"},
+				"reason": {Type: "string"},
+			},
+			Required: []string{"score", "reason"},
+		},
+	}))
+
+	_, err := pc.executeNodeContractHandler(testPipelineCoordinatorRunContext(t, pc), "node-a", runtimecontracts.SystemNodeEventHandler{
+		Guard: &runtimecontracts.GuardSpec{
+			Check: "payload.score >= 70",
+			OnFailSpec: runtimecontracts.GuardFailureSpec{
+				Action: runtimecontracts.GuardFailureActionEscalate,
+				Escalation: runtimecontracts.EmitSpec{
+					Event: "guard.failed",
+					Fields: map[string]runtimecontracts.ExpressionValue{
+						"score":  runtimecontracts.CELExpression("payload.score"),
+						"reason": runtimecontracts.CELExpression(`"score_below_threshold"`),
+					},
+				},
+			},
+		},
+	}, workflowTriggerContext{
+		Event: eventtest.RootIngress(
+			"",
+			events.EventType("custom.trigger"),
+			"",
+			"",
+			mustJSON(map[string]any{"entity_id": "ent-1", "score": 50, "legacy": "should-not-pass"}),
+			0,
+			"",
+			"",
+			events.EnvelopeForEntityID(events.EventEnvelope{}, "ent-1"),
+			time.Time{},
+		),
+		State: WorkflowState{EntityID: "ent-1", Stage: WorkflowStateID("queued"), Metadata: map[string]any{"legacy_entity": "should-not-pass"}},
+	}, false)
+	if err != nil {
+		t.Fatalf("executeNodeContractHandler: %v", err)
+	}
+	if got := bus.publishedCount(); got != 1 {
+		t.Fatalf("bus published count = %d, want 1", got)
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(bus.publishedEvent(0).Payload(), &payload); err != nil {
+		t.Fatalf("decode payload: %v", err)
+	}
+	if got := payload["score"]; got != float64(50) {
+		t.Fatalf("guard escalation score payload = %#v, want 50", got)
+	}
+	if got := payload["reason"]; got != "score_below_threshold" {
+		t.Fatalf("guard escalation reason payload = %#v, want score_below_threshold", got)
+	}
+	if _, ok := payload["entity_id"]; ok {
+		t.Fatalf("payload must not carry envelope entity_id: %#v", payload["entity_id"])
+	}
+	if _, ok := payload["legacy"]; ok {
+		t.Fatalf("guard escalation leaked unmapped trigger payload: %#v", payload["legacy"])
+	}
+	if _, ok := payload["legacy_entity"]; ok {
+		t.Fatalf("guard escalation leaked entity metadata: %#v", payload["legacy_entity"])
+	}
+}
+
 func TestExecuteNodeContractHandler_RejectsUndeclaredBusinessPayloadAcrossSupportedEmitSites(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/internal/runtime/pipeline/workflow_entity_field_lifecycle.go
+++ b/internal/runtime/pipeline/workflow_entity_field_lifecycle.go
@@ -12,6 +12,7 @@ type WorkflowEntityFieldLifecyclePhase string
 
 const (
 	WorkflowEntityFieldLifecycleGuard            WorkflowEntityFieldLifecyclePhase = "guard"
+	WorkflowEntityFieldLifecycleGuardEscalation  WorkflowEntityFieldLifecyclePhase = "guard_escalation_fields"
 	WorkflowEntityFieldLifecycleAccumulate       WorkflowEntityFieldLifecyclePhase = "accumulate"
 	WorkflowEntityFieldLifecycleFilter           WorkflowEntityFieldLifecyclePhase = "filter"
 	WorkflowEntityFieldLifecycleGroupBy          WorkflowEntityFieldLifecyclePhase = "group_by"
@@ -118,6 +119,7 @@ func WorkflowEntityFieldsAvailableBeforeEmitFields(handler runtimecontracts.Syst
 func WorkflowEntityReadsPersistedStateBeforeHandlerWrites(phase WorkflowEntityFieldLifecyclePhase) bool {
 	switch phase {
 	case WorkflowEntityFieldLifecycleGuard,
+		WorkflowEntityFieldLifecycleGuardEscalation,
 		WorkflowEntityFieldLifecycleFilter,
 		WorkflowEntityFieldLifecycleCount,
 		WorkflowEntityFieldLifecycleOnComplete,
@@ -250,6 +252,8 @@ func phaseAfter(current, threshold WorkflowEntityFieldLifecyclePhase) bool {
 func workflowEntityFieldLifecycleOrder(phase WorkflowEntityFieldLifecyclePhase) int {
 	switch phase {
 	case WorkflowEntityFieldLifecycleGuard:
+		return 1
+	case WorkflowEntityFieldLifecycleGuardEscalation:
 		return 1
 	case WorkflowEntityFieldLifecycleAccumulate:
 		return 2

--- a/internal/runtime/pipeline/workflow_entity_field_lifecycle_test.go
+++ b/internal/runtime/pipeline/workflow_entity_field_lifecycle_test.go
@@ -87,6 +87,35 @@ func TestWorkflowEntityFieldsAvailableBeforeEmitFields_IncludesCreateEntityTopLe
 	}
 }
 
+func TestWorkflowEntityFieldsAvailableBeforeGuardEscalation_UsesGuardTimeVisibility(t *testing.T) {
+	handler := runtimecontracts.SystemNodeEventHandler{
+		Query: &runtimecontracts.QuerySpec{
+			StoreAs: "entity.query_score",
+		},
+		Compute: &runtimecontracts.ComputeSpec{
+			Operation: runtimecontracts.ComputeOpCount,
+			StoreAs:   "entity.computed_score",
+		},
+		CreateEntity: true,
+		DataAccumulation: runtimecontracts.WorkflowDataAccumulation{
+			Writes: []runtimecontracts.WorkflowDataWrite{
+				{TargetField: "revision_count", Value: runtimecontracts.LiteralExpression(0)},
+			},
+		},
+	}
+
+	available := workflowEntityFieldsAvailableBeforePhase(handler, WorkflowEntityFieldLifecycleGuardEscalation)
+	if _, ok := available["query_score"]; !ok {
+		t.Fatalf("query_score missing from guard escalation availability: %#v", available)
+	}
+	if _, ok := available["computed_score"]; ok {
+		t.Fatalf("computed_score unexpectedly available before guard escalation: %#v", available)
+	}
+	if _, ok := available["revision_count"]; ok {
+		t.Fatalf("revision_count unexpectedly available before guard escalation: %#v", available)
+	}
+}
+
 func TestWorkflowEntityFieldsAvailableBeforeEmitFields_ExcludesRuleOnlyWrites(t *testing.T) {
 	handler := runtimecontracts.SystemNodeEventHandler{
 		Rules: []runtimecontracts.HandlerRuleEntry{{
@@ -168,6 +197,7 @@ func TestWorkflowEntityReadsPersistedStateBeforeHandlerWrites(t *testing.T) {
 		want  bool
 	}{
 		{name: "guard", phase: WorkflowEntityFieldLifecycleGuard, want: true},
+		{name: "guard escalation", phase: WorkflowEntityFieldLifecycleGuardEscalation, want: true},
 		{name: "filter", phase: WorkflowEntityFieldLifecycleFilter, want: true},
 		{name: "count", phase: WorkflowEntityFieldLifecycleCount, want: true},
 		{name: "rule", phase: WorkflowEntityFieldLifecycleRule, want: true},

--- a/internal/runtime/semanticview/authored_emit_sites.go
+++ b/internal/runtime/semanticview/authored_emit_sites.go
@@ -122,8 +122,8 @@ func (b *authoredEmitSiteBuilder) appendHandlerSites(kind AuthoredEmitSiteSource
 	}
 	add("handler.emit", "handler.emit", "", handler.Emit)
 	if handler.Guard != nil {
-		if eventType := authoredGuardEscalationEvent(handler.Guard.OnFail); eventType != "" {
-			add("handler.guard.on_fail.escalate", "handler.guard.on_fail.escalate", handler.Guard.ID, runtimecontracts.EmitSpec{Event: eventType})
+		if emitSpec := authoredGuardEscalationEmitSpec(handler.Guard); !emitSpec.Empty() {
+			add("handler.guard.on_fail.escalate", "handler.guard.on_fail.escalate", handler.Guard.ID, emitSpec)
 		}
 	}
 	for idx, rule := range handler.Rules {
@@ -313,10 +313,13 @@ func indexedAuthoredEmitSiteKey(prefix string, index int, suffix string) string 
 	return prefix + "[" + strconv.Itoa(index) + "]." + suffix
 }
 
-func authoredGuardEscalationEvent(onFail string) string {
-	normalized := strings.TrimSpace(strings.ToLower(onFail))
-	if !strings.HasPrefix(normalized, "escalate:") {
-		return ""
+func authoredGuardEscalationEmitSpec(guard *runtimecontracts.GuardSpec) runtimecontracts.EmitSpec {
+	if guard == nil {
+		return runtimecontracts.EmitSpec{}
 	}
-	return strings.TrimSpace(strings.TrimPrefix(normalized, "escalate:"))
+	failureSpec, err := guard.FailureSpec()
+	if err != nil || failureSpec.Action != runtimecontracts.GuardFailureActionEscalate {
+		return runtimecontracts.EmitSpec{}
+	}
+	return failureSpec.EscalationEmitSpec()
 }

--- a/internal/runtime/semanticview/authored_emit_sites_test.go
+++ b/internal/runtime/semanticview/authored_emit_sites_test.go
@@ -36,6 +36,30 @@ func TestAuthoredEmitSites_EnumeratesRootAndFlowOwnedScopes(t *testing.T) {
 	}
 }
 
+func TestAuthoredEmitSites_GuardEscalationObjectCarriesFields(t *testing.T) {
+	source := loadAuthoredEmitSiteFixture(t, authoredEmitSiteFixture{
+		rootNodeID:      "root-node",
+		rootEmit:        "root.ready",
+		rootGuardEmit:   "root.escalated",
+		rootGuardObject: true,
+	})
+
+	sites := AuthoredEmitSites(source)
+	matches := authoredEmitSitesByFlowNodeEvent(sites, "", "root-node", "root.escalated")
+	if len(matches) != 1 {
+		t.Fatalf("expected one guard escalation authored emit site, got %d: %#v", len(matches), authoredEmitSiteSummaries(sites))
+	}
+	if matches[0].Site != "handler.guard.on_fail.escalate" {
+		t.Fatalf("site = %q, want handler.guard.on_fail.escalate", matches[0].Site)
+	}
+	if expr := matches[0].Spec.Fields["score"]; expr.Kind != runtimecontracts.ExpressionKindCEL || expr.CEL != "payload.score" {
+		t.Fatalf("score field = %#v, want CEL payload.score", expr)
+	}
+	if expr := matches[0].Spec.Fields["reason"]; expr.Kind != runtimecontracts.ExpressionKindLiteral || expr.Literal != "score_below_threshold" {
+		t.Fatalf("reason field = %#v, want literal score_below_threshold", expr)
+	}
+}
+
 func TestAuthoredEmitSites_DeduplicatesPackageProjectionWithoutCollapsingDistinctSources(t *testing.T) {
 	source := loadAuthoredEmitSiteFixture(t, authoredEmitSiteFixture{
 		rootNodeID:      "root-node",
@@ -109,6 +133,7 @@ type authoredEmitSiteFixture struct {
 	omitFlowPackage     bool
 	nestedPackageNodeID string
 	nestedPackageEmit   string
+	rootGuardObject     bool
 }
 
 func loadAuthoredEmitSiteFixture(t *testing.T, opts authoredEmitSiteFixture) Source {
@@ -150,7 +175,11 @@ root.escalated: {}
 	writeSemanticviewFixtureFile(t, filepath.Join(root, "tools.yaml"), "{}\n")
 	writeSemanticviewFixtureFile(t, filepath.Join(root, "agents.yaml"), "{}\n")
 	writeSemanticviewFixtureFile(t, filepath.Join(root, "entities.yaml"), "{}\n")
-	writeSemanticviewFixtureFile(t, filepath.Join(root, "nodes.yaml"), authoredEmitSiteNodeYAML(opts.rootNodeID, "root.start", opts.rootEmit, opts.rootGuardEmit, opts.rootBroadcast))
+	rootNodeYAML := authoredEmitSiteNodeYAML(opts.rootNodeID, "root.start", opts.rootEmit, opts.rootGuardEmit, opts.rootBroadcast)
+	if opts.rootGuardObject {
+		rootNodeYAML = authoredEmitSiteNodeYAMLWithGuardObject(opts.rootNodeID, "root.start", opts.rootEmit, opts.rootGuardEmit, opts.rootBroadcast)
+	}
+	writeSemanticviewFixtureFile(t, filepath.Join(root, "nodes.yaml"), rootNodeYAML)
 	if !opts.omitFlowPackage {
 		writeSemanticviewFixtureFile(t, filepath.Join(root, "flows", "support", "package.yaml"), `
 name: support
@@ -221,6 +250,36 @@ func authoredEmitSiteNodeYAML(nodeID, trigger, eventType, guardEventType string,
   event_handlers:
     ` + trigger + `:
 ` + guardYAML + `
+      emit:
+        event: ` + eventType + `
+` + broadcastLine
+}
+
+func authoredEmitSiteNodeYAMLWithGuardObject(nodeID, trigger, eventType, guardEventType string, broadcast bool) string {
+	if strings.TrimSpace(nodeID) == "" || strings.TrimSpace(eventType) == "" {
+		return "{}\n"
+	}
+	broadcastLine := ""
+	if broadcast {
+		broadcastLine = "        broadcast: true\n"
+	}
+	return `
+` + nodeID + `:
+  id: ` + nodeID + `
+  execution_type: system_node
+  event_handlers:
+    ` + trigger + `:
+      guard:
+        id: guard-escalate
+        check: "false"
+        on_fail:
+          escalate:
+            event: ` + guardEventType + `
+            fields:
+              score: payload.score
+              reason:
+                literal: score_below_threshold
+
       emit:
         event: ` + eventType + `
 ` + broadcastLine

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -1518,7 +1518,12 @@ handler_specification:
         platform_builtin: string — optional reference to a platform-provided guard (e.g., authorization checks)
       list_form:
         checks: list of {id, check} objects — ALL must pass
-        on_fail: 'reject | kill | discard | escalate:{event_name} — what to do when any check fails. Default: reject.'
+        on_fail: 'reject | kill | discard | escalate:{event_name} | {escalate: {event, fields}} — what to do when
+          any check fails. Default: reject. The scalar escalate:{event_name} shorthand emits an escalation event with
+          no explicit business payload. The object form authors explicit escalation business payload fields using the
+          same expression-value forms as emit.fields, evaluated at guard-failure time before later handler transforms
+          or data writes. Guard escalation never implicitly passes through trigger payload/entity metadata and cannot
+          author runtime-owned envelope fields as business payload.'
     accumulate:
       field: accumulate
       type: object
@@ -9290,10 +9295,11 @@ observation_model:
       reject: 'Guard failed with on_fail: reject. No side effects. Entity unchanged.'
       discard: 'Guard failed with on_fail: discard. No side effects. No record.'
       kill: 'Guard failed with on_fail: kill. Entity advanced to terminal state.'
-      escalate: 'Guard failed with on_fail: escalate:{event}. Escalation event emitted instead, using the same emit payload
-        construction rules as a declarative system-node emit with no business fields: no implicit trigger/entity passthrough,
-        payload stays empty unless authored fields exist, runtime-owned envelope remains on the event carrier, and fail-closed
-        contract validation still applies.'
+      escalate: 'Guard failed with on_fail: escalate:{event} or on_fail: {escalate: {event, fields}}. Escalation event
+        emitted instead. Scalar shorthand emits no explicit business payload. Object form fields use the same explicit
+        expression-value forms as declarative emit.fields, but they are evaluated at guard-failure time before later handler
+        transforms/data writes. No implicit trigger/entity passthrough occurs, runtime-owned envelope remains on the event
+        carrier, envelope-owned fields cannot be authored into business payload, and fail-closed contract validation applies.'
       dead_letter: Handler failed after retry exhaustion OR chain depth exceeded. Event moved to dead_letters.
       terminal_reject: Event targeted an entity in terminal state. Rejected before handler execution.
       waiting: Accumulation incomplete. Handler recorded the arrival but completion condition not yet met. No further steps


### PR DESCRIPTION
## Summary

- Add a normalized guard failure/escalation model that preserves scalar `on_fail: "escalate:event"` as envelope-only and adds structured `on_fail.escalate.event/fields` for explicit business payload authoring.
- Wire the same canonical guard escalation `EmitSpec` through runtime execution, bootverify expression/payload checks, semanticview authored emit sites, and served pipeline proof.
- Update `platform-spec.yaml` to define object-form guard escalation payload semantics and guard-time field evaluation.

Closes #1535

## Governing Refs / Context

- `platform-spec.yaml` handler guard `on_fail` schema.
- `platform-spec.yaml` `handler_outcome.escalate` semantics.
- #1535 issue body and approved `Pre-Implementation Coverage Audit`.
- #1462 Point 14 split/tracker context.
- Gate outcome on #1535: `approved as first slice` for `guard_escalation_explicit_payload_authoring_gap`.

Requested `docs/IMPLEMENTER_GUIDELINES.md` and `docs/SEMANTIC_DRIFT.md` are not present on current `origin/master`; the issue/spec/code contracts above are the binding context.

## Semantic Migration

- New canonical owner: `runtimecontracts.GuardFailureSpec` / `GuardEscalationSpec`-equivalent normalized model via `GuardSpec.FailureSpec()`, carrying a guard escalation `EmitSpec` with `event` and `fields`.
- Old producer/reader/writer path now invalid: treating `GuardSpec.OnFail string` plus local `ParseGuardFailure` as the complete guard escalation model. Scalar `OnFail` remains a shorthand carrier only.
- Production paths checked/moved: YAML contract decode, runtime `Executor.applyGuardFailure`, bootverify guard action validation, bootverify payload completeness, bootverify expression/entity lifecycle checks, semanticview authored emit sites, served pipeline execution.
- Migration completeness: complete for #1535 object-form explicit payload authoring. `guard.*` failure-detail roots remain intentionally split unless a later gate widens scope.

## Proof

- `go test ./internal/runtime/contracts ./internal/runtime/engine ./internal/runtime/bootverify ./internal/runtime/semanticview ./internal/runtime/pipeline -run 'Guard|OnFail|Escalate|AuthoredEmitSites|PayloadCompleteness|EntityFieldsAvailableBeforeGuardEscalation' -count=1`
- `go test ./internal/runtime/bootverify -run 'Guard|PayloadCompleteness' -count=1`
- `go test ./...`