### PR TITLE
[agent-a][issue #1577] Add connect-time template lifecycle owner

### DIFF
--- a/internal/runtime/bus/connect_route_plan_dispatch.go
+++ b/internal/runtime/bus/connect_route_plan_dispatch.go
@@ -105,6 +105,13 @@ func (r connectRoutePlanResolver) Plan(ctx context.Context, evt events.Event) (c
 		if cleanupPreview != nil {
 			cleanupPreview()
 		}
+		if strings.TrimSpace(decision.Action) == templateInstanceLifecycleActionCreated {
+			refreshed, err := r.descriptorsForPlans(ctx, matched)
+			if err != nil {
+				return connectRoutePlanDispatch{}, err
+			}
+			descriptors = refreshed
+		}
 		if len(routes) == 0 {
 			out.Failure = runtimepinrouting.FailureTargetNotSubscribed
 			out.ExtraDetail["connect_route_plan_failure"] = string(runtimepinrouting.FailureTargetNotSubscribed)

--- a/internal/runtime/bus/connect_route_plan_dispatch.go
+++ b/internal/runtime/bus/connect_route_plan_dispatch.go
@@ -10,6 +10,7 @@ import (
 	runtimeflowidentity "github.com/division-sh/swarm/internal/runtime/core/flowidentity"
 	runtimepinrouting "github.com/division-sh/swarm/internal/runtime/core/pinrouting"
 	runtimecorrelation "github.com/division-sh/swarm/internal/runtime/correlation"
+	runtimepipeline "github.com/division-sh/swarm/internal/runtime/pipeline"
 	"github.com/division-sh/swarm/internal/runtime/semanticview"
 )
 
@@ -21,6 +22,7 @@ type connectRoutePlanResolver struct {
 	plans           []runtimepinrouting.ConnectRoutePlan
 	issues          []runtimepinrouting.ConnectRoutePlanIssue
 	loadDescriptors connectRoutePlanDescriptorLoader
+	lifecycle       templateInstanceLifecycleOwner
 }
 
 type connectRoutePlanDispatch struct {
@@ -32,7 +34,7 @@ type connectRoutePlanDispatch struct {
 	ExtraDetail      map[string]any
 }
 
-func newConnectRoutePlanResolver(source semanticview.Source, routeTable *RouteTable, loadDescriptors connectRoutePlanDescriptorLoader) connectRoutePlanResolver {
+func newConnectRoutePlanResolver(source semanticview.Source, routeTable *RouteTable, loadDescriptors connectRoutePlanDescriptorLoader, activator runtimepipeline.FlowInstanceActivator) connectRoutePlanResolver {
 	if source == nil {
 		return connectRoutePlanResolver{routeTable: routeTable, loadDescriptors: loadDescriptors}
 	}
@@ -43,6 +45,7 @@ func newConnectRoutePlanResolver(source semanticview.Source, routeTable *RouteTa
 		plans:           append([]runtimepinrouting.ConnectRoutePlan(nil), plans...),
 		issues:          append([]runtimepinrouting.ConnectRoutePlanIssue(nil), issues...),
 		loadDescriptors: loadDescriptors,
+		lifecycle:       newTemplateInstanceLifecycleOwner(source, loadDescriptors, activator),
 	}
 }
 
@@ -80,11 +83,10 @@ func (r connectRoutePlanResolver) Plan(ctx context.Context, evt events.Event) (c
 		},
 	}
 	for _, plan := range matched {
-		materialized := runtimepinrouting.MaterializeConnectRoutePlan(plan, runtimepinrouting.ConnectRoutePlanMaterializationInput{
-			MatchValues:             values,
-			Descriptors:             descriptors,
-			SupportedAddressTargets: runtimepinrouting.SupportedConnectAddressTargets(r.source, plan),
-		})
+		materialized, decision, err := r.materializeConnectRoutePlan(ctx, evt, plan, values, descriptors)
+		if err != nil {
+			return connectRoutePlanDispatch{}, err
+		}
 		if materialized.Failure != "" {
 			out.Failure = connectRoutePlanTargetFailure(materialized.Failure)
 			out.ExtraDetail["connect_route_plan_failure"] = string(materialized.Failure)
@@ -92,7 +94,17 @@ func (r connectRoutePlanResolver) Plan(ctx context.Context, evt events.Event) (c
 			out.ExtraDetail["connect_route_plan_receiver_event"] = plan.Receiver.ResolvedEvent
 			return out, nil
 		}
+		if !decision.Empty() {
+			out.ExtraDetail["connect_route_plan_template_instance_lifecycle"] = decision.Detail()
+		}
+		cleanupPreview, err := r.installTemplateInstanceLifecyclePreview(decision)
+		if err != nil {
+			return connectRoutePlanDispatch{}, err
+		}
 		routes, subscribers := r.deliveryRoutesForMaterialization(plan, materialized)
+		if cleanupPreview != nil {
+			cleanupPreview()
+		}
 		if len(routes) == 0 {
 			out.Failure = runtimepinrouting.FailureTargetNotSubscribed
 			out.ExtraDetail["connect_route_plan_failure"] = string(runtimepinrouting.FailureTargetNotSubscribed)
@@ -111,6 +123,42 @@ func (r connectRoutePlanResolver) Plan(ctx context.Context, evt events.Event) (c
 	out.DeliveryIntents = normalizeRoutePlanDeliveryIntents(out.DeliveryIntents)
 	out.RoutedRecipients = dedupeSubscribers(out.RoutedRecipients)
 	return out, nil
+}
+
+func (r connectRoutePlanResolver) materializeConnectRoutePlan(ctx context.Context, evt events.Event, plan runtimepinrouting.ConnectRoutePlan, values map[string]string, descriptors []runtimepinrouting.Descriptor) (runtimepinrouting.ConnectRoutePlanMaterialization, TemplateInstanceLifecycleDecision, error) {
+	if materialized, decision, handled, err := r.lifecycle.Materialize(ctx, evt, plan, values, descriptors); handled || err != nil {
+		return materialized, decision, err
+	}
+	return runtimepinrouting.MaterializeConnectRoutePlan(plan, runtimepinrouting.ConnectRoutePlanMaterializationInput{
+		MatchValues:             values,
+		Descriptors:             descriptors,
+		SupportedAddressTargets: runtimepinrouting.SupportedConnectAddressTargets(r.source, plan),
+	}), TemplateInstanceLifecycleDecision{}, nil
+}
+
+func (r connectRoutePlanResolver) installTemplateInstanceLifecyclePreview(decision TemplateInstanceLifecycleDecision) (func(), error) {
+	if strings.TrimSpace(decision.Action) != templateInstanceLifecycleActionPreviewCreate {
+		return nil, nil
+	}
+	if r.routeTable == nil {
+		return nil, nil
+	}
+	identity := decision.Route()
+	if !identity.Valid() {
+		return nil, nil
+	}
+	if len(r.routeTable.MaterializedRoutes(identity)) > 0 {
+		return nil, nil
+	}
+	if err := r.routeTable.AddFlowInstanceRoute(FlowInstanceRouteMaterializationRequest{
+		Identity:            identity,
+		ActivationVariables: decision.ActivationVariables(),
+	}); err != nil {
+		return nil, err
+	}
+	return func() {
+		r.routeTable.RemoveFlowInstanceRoute(identity)
+	}, nil
 }
 
 func (r connectRoutePlanResolver) matchedPlans(evt events.Event) []runtimepinrouting.ConnectRoutePlan {

--- a/internal/runtime/bus/connect_route_plan_dispatch_test.go
+++ b/internal/runtime/bus/connect_route_plan_dispatch_test.go
@@ -109,6 +109,12 @@ func (s *connectRoutePlanDescriptorStore) ListActiveFlowInstanceDescriptors(cont
 }
 
 func (s *connectRoutePlanLifecycleStore) Activate(ctx context.Context, req runtimepipeline.FlowInstanceActivationRequest) error {
+	for _, descriptor := range s.flowInstances {
+		descriptor = descriptor.Normalized()
+		if descriptor.InstanceID == req.Instance.InstanceID || descriptor.FlowInstance == req.Instance.InstancePath {
+			return errors.New("flow instance already exists")
+		}
+	}
 	s.activations = append(s.activations, req)
 	verticalID, _ := req.Metadata["vertical_id"].(string)
 	s.flowInstances = append(s.flowInstances, ActiveFlowInstanceDescriptor{
@@ -847,6 +853,89 @@ func TestEventBusPublish_ConnectRoutePlanCreatesTemplateInstanceOnMissingCreate(
 	}
 	if got := store.flowInstanceDescriptorCalls; got != 0 {
 		t.Fatalf("replay descriptor calls = %d, want 0 because lifecycle-created persisted route/scope is authoritative", got)
+	}
+}
+
+func TestEventBusPublish_ConnectRoutePlanLifecycleCreateRefreshesDescriptorsForLaterPlans(t *testing.T) {
+	source := connectRoutePlanInstanceKeyMultiInputSourceWithPolicy(t, "create", "reuse")
+	store := &connectRoutePlanLifecycleStore{
+		connectRoutePlanDescriptorStore: &connectRoutePlanDescriptorStore{
+			targetRouteMemoryStore: newTargetRouteMemoryStore(),
+		},
+	}
+	eb, err := NewEventBusWithOptions(store, EventBusOptions{
+		ContractBundle:            source,
+		TemplateInstanceActivator: store.Activate,
+	})
+	if err != nil {
+		t.Fatalf("NewEventBusWithOptions: %v", err)
+	}
+	store.bus = eb
+	evt := eventtest.RootIngress(uuid.NewString(),
+		events.EventType("producer/deploy.done"), "", "", json.RawMessage(`{"vertical_id":"v-1"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())
+
+	if err := eb.Publish(context.Background(), evt); err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+	if len(store.activations) != 1 {
+		t.Fatalf("activations = %d, want exactly one lifecycle create for both connect plans", len(store.activations))
+	}
+	activation := store.activations[0]
+	want := events.DeliveryRoute{
+		SubscriberType: "node",
+		SubscriberID:   "consumer-node-" + activation.Instance.InstanceID,
+		Target: events.RouteIdentity{
+			FlowID:       "consumer",
+			FlowInstance: activation.Instance.InstancePath,
+			EntityID:     activation.Instance.EntityID,
+		},
+	}
+	if !deliveryRoutesContain(store.routes[evt.ID()], want) || len(store.routes[evt.ID()]) != 1 {
+		t.Fatalf("persisted delivery routes = %#v, want one deduplicated route %#v", store.routes[evt.ID()], want)
+	}
+}
+
+func TestEventBusPublish_ConnectRoutePlanCreateRejectSameEventRetryUsesCommittedReplay(t *testing.T) {
+	source := connectRoutePlanInstanceKeySourceWithPolicy(t, "create", "reject")
+	store := &connectRoutePlanLifecycleStore{
+		connectRoutePlanDescriptorStore: &connectRoutePlanDescriptorStore{
+			targetRouteMemoryStore: newTargetRouteMemoryStore(),
+		},
+	}
+	eb, err := NewEventBusWithOptions(store, EventBusOptions{
+		ContractBundle:            source,
+		TemplateInstanceActivator: store.Activate,
+	})
+	if err != nil {
+		t.Fatalf("NewEventBusWithOptions: %v", err)
+	}
+	store.bus = eb
+	evt := eventtest.RootIngress(uuid.NewString(),
+		events.EventType("producer/deploy.done"), "", "", json.RawMessage(`{"vertical_id":"v-1"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())
+
+	if err := eb.Publish(context.Background(), evt); err != nil {
+		t.Fatalf("Publish initial: %v", err)
+	}
+	if len(store.activations) != 1 {
+		t.Fatalf("initial activations = %d, want 1", len(store.activations))
+	}
+	activation := store.activations[0]
+	replayTarget := eb.SubscribeInternal("consumer-node-" + activation.Instance.InstanceID)
+	store.flowInstanceDescriptorCalls = 0
+
+	if err := eb.Publish(context.Background(), evt); err != nil {
+		t.Fatalf("Publish retry: %v", err)
+	}
+	if len(store.activations) != 1 {
+		t.Fatalf("retry activations = %d, want committed replay without a second activation", len(store.activations))
+	}
+	if got := store.flowInstanceDescriptorCalls; got != 0 {
+		t.Fatalf("retry descriptor calls = %d, want 0 because committed replay is authoritative", got)
+	}
+	replayed := requireBusEvent(t, replayTarget, "same-event retry committed replay")
+	if replayed.FlowInstance() != activation.Instance.InstancePath || replayed.EntityID() != activation.Instance.EntityID {
+		t.Fatalf("retry delivery target = flow_instance:%q entity:%q, want persisted %q/%q",
+			replayed.FlowInstance(), replayed.EntityID(), activation.Instance.InstancePath, activation.Instance.EntityID)
 	}
 }
 
@@ -1827,6 +1916,21 @@ func connectRoutePlanInstanceKeySourceWithPolicy(t testing.TB, onMissing, onConf
 	return semanticview.Wrap(bundle)
 }
 
+func connectRoutePlanInstanceKeyMultiInputSourceWithPolicy(t testing.TB, onMissing, onConflict string) semanticview.Source {
+	t.Helper()
+	repoRoot, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd: %v", err)
+	}
+	repoRoot = filepath.Clean(filepath.Join(repoRoot, "..", "..", ".."))
+	root := writeConnectRoutePlanInstanceKeyMultiInputFixtureWithPolicy(t, onMissing, onConflict)
+	bundle, err := runtimecontracts.LoadWorkflowContractBundleWithOverrides(repoRoot, root, runtimecontracts.DefaultPlatformSpecFile(repoRoot))
+	if err != nil {
+		t.Fatalf("LoadWorkflowContractBundleWithOverrides: %v", err)
+	}
+	return semanticview.Wrap(bundle)
+}
+
 func connectRoutePlanRenamedInstanceKeySource(t testing.TB) semanticview.Source {
 	t.Helper()
 	return connectRoutePlanRenamedInstanceKeySourceWithPolicy(t, "reject", "reject")
@@ -2002,6 +2106,83 @@ pins:
   inputs:
     events:
       - name: deploy_completed
+        event: deploy.done
+`)
+	writeConnectRoutePlanBusFixtureFile(t, filepath.Join(root, "flows", "consumer", "policy.yaml"), "{}\n")
+	writeConnectRoutePlanBusFixtureFile(t, filepath.Join(root, "flows", "consumer", "agents.yaml"), "{}\n")
+	writeConnectRoutePlanBusFixtureFile(t, filepath.Join(root, "flows", "consumer", "events.yaml"), "deploy.done:\n  vertical_id: string\n")
+	writeConnectRoutePlanBusFixtureFile(t, filepath.Join(root, "flows", "consumer", "entities.yaml"), `
+deployment:
+  vertical_id:
+    type: string
+`)
+	writeConnectRoutePlanBusFixtureFile(t, filepath.Join(root, "flows", "consumer", "nodes.yaml"), `
+consumer-node:
+  id: consumer-node-{instance_id}
+  execution_type: system_node
+  event_handlers:
+    deploy.done: {}
+`)
+	return root
+}
+
+func writeConnectRoutePlanInstanceKeyMultiInputFixtureWithPolicy(t testing.TB, onMissing, onConflict string) string {
+	t.Helper()
+	root := t.TempDir()
+	writeConnectRoutePlanBusFixtureFile(t, filepath.Join(root, "package.yaml"), `
+name: instance-key-connect-route-plan-bus
+version: "1.0.0"
+platform_version: ">=1.6.0"
+flows:
+  - id: producer
+    flow: producer
+    mode: static
+  - id: consumer
+    flow: consumer
+    mode: template
+connect:
+  - from: producer.deploy_done
+    to: consumer.deploy_completed
+    delivery: one
+  - from: producer.deploy_done
+    to: consumer.deploy_audited
+    delivery: one
+`)
+	writeConnectRoutePlanBusFixtureFile(t, filepath.Join(root, "schema.yaml"), "name: instance-key-connect-route-plan-bus\n")
+	writeConnectRoutePlanBusFixtureFile(t, filepath.Join(root, "policy.yaml"), "{}\n")
+	writeConnectRoutePlanBusFixtureFile(t, filepath.Join(root, "tools.yaml"), "{}\n")
+	writeConnectRoutePlanBusFixtureFile(t, filepath.Join(root, "agents.yaml"), "{}\n")
+	writeConnectRoutePlanBusFixtureFile(t, filepath.Join(root, "events.yaml"), "{}\n")
+	writeConnectRoutePlanBusFixtureFile(t, filepath.Join(root, "nodes.yaml"), "{}\n")
+	writeConnectRoutePlanBusFixtureFile(t, filepath.Join(root, "flows", "producer", "schema.yaml"), `
+name: producer
+mode: static
+pins:
+  outputs:
+    events:
+      - name: deploy_done
+        event: deploy.done
+        key: vertical_id
+        carries: [vertical_id]
+`)
+	writeConnectRoutePlanBusFixtureFile(t, filepath.Join(root, "flows", "producer", "policy.yaml"), "{}\n")
+	writeConnectRoutePlanBusFixtureFile(t, filepath.Join(root, "flows", "producer", "agents.yaml"), "{}\n")
+	writeConnectRoutePlanBusFixtureFile(t, filepath.Join(root, "flows", "producer", "events.yaml"), "deploy.done:\n  vertical_id: string\n")
+	writeConnectRoutePlanBusFixtureFile(t, filepath.Join(root, "flows", "producer", "entities.yaml"), "{}\n")
+	writeConnectRoutePlanBusFixtureFile(t, filepath.Join(root, "flows", "producer", "nodes.yaml"), "{}\n")
+	writeConnectRoutePlanBusFixtureFile(t, filepath.Join(root, "flows", "consumer", "schema.yaml"), `
+name: consumer
+mode: template
+instance:
+  by: vertical_id
+  on_missing: `+onMissing+`
+  on_conflict: `+onConflict+`
+pins:
+  inputs:
+    events:
+      - name: deploy_completed
+        event: deploy.done
+      - name: deploy_audited
         event: deploy.done
 `)
 	writeConnectRoutePlanBusFixtureFile(t, filepath.Join(root, "flows", "consumer", "policy.yaml"), "{}\n")

--- a/internal/runtime/bus/connect_route_plan_dispatch_test.go
+++ b/internal/runtime/bus/connect_route_plan_dispatch_test.go
@@ -46,6 +46,12 @@ type connectRoutePlanMutationStore struct {
 	*targetRouteMemoryStore
 }
 
+type connectRoutePlanLifecycleStore struct {
+	*connectRoutePlanDescriptorStore
+	bus         *EventBus
+	activations []runtimepipeline.FlowInstanceActivationRequest
+}
+
 type targetRouteMemoryEventMutation struct {
 	ctx   context.Context
 	store *connectRoutePlanMutationStore
@@ -100,6 +106,24 @@ func (*targetRouteMemoryEventMutation) RecordDeadLetter(context.Context, runtime
 func (s *connectRoutePlanDescriptorStore) ListActiveFlowInstanceDescriptors(context.Context) ([]ActiveFlowInstanceDescriptor, error) {
 	s.flowInstanceDescriptorCalls++
 	return append([]ActiveFlowInstanceDescriptor(nil), s.flowInstances...), nil
+}
+
+func (s *connectRoutePlanLifecycleStore) Activate(ctx context.Context, req runtimepipeline.FlowInstanceActivationRequest) error {
+	s.activations = append(s.activations, req)
+	verticalID, _ := req.Metadata["vertical_id"].(string)
+	s.flowInstances = append(s.flowInstances, ActiveFlowInstanceDescriptor{
+		InstanceID:    req.Instance.InstanceID,
+		EntityID:      req.Instance.EntityID,
+		FlowInstance:  req.Instance.InstancePath,
+		FlowTemplate:  req.Instance.TemplateID,
+		AddressFields: map[string]string{"entity.vertical_id": verticalID},
+	})
+	if s.bus == nil {
+		return nil
+	}
+	return s.bus.AddFlowInstanceRouteContext(ctx, FlowInstanceRouteMaterializationRequest{
+		Identity: req.Instance.Route(),
+	})
 }
 
 func (s *targetRouteMemoryStore) UpsertCommittedReplayScope(_ context.Context, eventID string, scope runtimereplayclaim.CommittedReplayScope) error {
@@ -725,6 +749,236 @@ func TestEventBusPublish_ConnectRoutePlanPersistsTemplateInstanceKeyTarget(t *te
 	if !deliveryRoutesContain(replayRoutes, want) {
 		t.Fatalf("replay delivery routes = %#v, want %#v", replayRoutes, want)
 	}
+}
+
+func TestEventBusPublish_ConnectRoutePlanCreatesTemplateInstanceOnMissingCreate(t *testing.T) {
+	source := connectRoutePlanInstanceKeySourceWithPolicy(t, "create", "reuse")
+	store := &connectRoutePlanLifecycleStore{
+		connectRoutePlanDescriptorStore: &connectRoutePlanDescriptorStore{
+			targetRouteMemoryStore: newTargetRouteMemoryStore(),
+		},
+	}
+	eb, err := NewEventBusWithOptions(store, EventBusOptions{
+		ContractBundle:            source,
+		TemplateInstanceActivator: store.Activate,
+	})
+	if err != nil {
+		t.Fatalf("NewEventBusWithOptions: %v", err)
+	}
+	store.bus = eb
+	evt := eventtest.RootIngress(uuid.NewString(),
+		events.EventType("producer/deploy.done"), "", "", json.RawMessage(`{"vertical_id":"v-1"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())
+
+	preflight, err := eb.CheckPublishRecipientPlan(context.Background(), evt)
+	if err != nil {
+		t.Fatalf("CheckPublishRecipientPlan: %v", err)
+	}
+	if len(store.activations) != 0 {
+		t.Fatalf("preflight activations = %d, want 0", len(store.activations))
+	}
+	if preflight.TargetFailure != "" || len(preflight.DeliveryRoutes) != 1 {
+		t.Fatalf("preflight failure/routes = %q/%#v, want one preview route", preflight.TargetFailure, preflight.DeliveryRoutes)
+	}
+	previewTarget := preflight.DeliveryRoutes[0].Target
+	if previewTarget.FlowID != "consumer" || previewTarget.FlowInstance == "" || previewTarget.EntityID == "" {
+		t.Fatalf("preview target = %#v, want deterministic consumer flow instance", previewTarget)
+	}
+	previewIdentity := runtimeflowidentity.StoredRoute("consumer", runtimeflowidentity.LogicalInstanceID(previewTarget.FlowInstance), previewTarget.FlowInstance)
+	if routes := eb.RouteTable().MaterializedRoutes(previewIdentity); len(routes) != 0 {
+		t.Fatalf("preview route table state leaked after preflight: %#v", routes)
+	}
+
+	if err := eb.Publish(context.Background(), evt); err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+	if len(store.activations) != 1 {
+		t.Fatalf("activations = %d, want 1", len(store.activations))
+	}
+	activation := store.activations[0]
+	if activation.Config["vertical_id"] != "v-1" || activation.Metadata["vertical_id"] != "v-1" {
+		t.Fatalf("activation config/metadata = %#v/%#v, want vertical_id v-1", activation.Config, activation.Metadata)
+	}
+	if activation.Metadata["entity_type"] != "deployment" || activation.Metadata["instance_kind"] != "template" || activation.Metadata["last_source_event"] != evt.ID() {
+		t.Fatalf("activation metadata = %#v, want entity_type/instance_kind/last_source_event proof", activation.Metadata)
+	}
+	want := events.DeliveryRoute{
+		SubscriberType: "node",
+		SubscriberID:   "consumer-node-" + activation.Instance.InstanceID,
+		Target: events.RouteIdentity{
+			FlowID:       "consumer",
+			FlowInstance: activation.Instance.InstancePath,
+			EntityID:     activation.Instance.EntityID,
+		},
+	}
+	if !deliveryRoutesContain(store.routes[evt.ID()], want) || len(store.routes[evt.ID()]) != 1 {
+		t.Fatalf("persisted delivery routes = %#v, want created instance route %#v", store.routes[evt.ID()], want)
+	}
+
+	retry := eventtest.RootIngress(uuid.NewString(),
+		events.EventType("producer/deploy.done"), "", "", json.RawMessage(`{"vertical_id":"v-1"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())
+	if err := eb.Publish(context.Background(), retry); err != nil {
+		t.Fatalf("Publish retry: %v", err)
+	}
+	if len(store.activations) != 1 {
+		t.Fatalf("retry activations = %d, want idempotent reuse without a second activation", len(store.activations))
+	}
+	if !deliveryRoutesContain(store.routes[retry.ID()], want) || len(store.routes[retry.ID()]) != 1 {
+		t.Fatalf("retry delivery routes = %#v, want reused instance route %#v", store.routes[retry.ID()], want)
+	}
+
+	replayTarget := eb.SubscribeInternal(want.SubscriberID)
+	store.flowInstances = []ActiveFlowInstanceDescriptor{{
+		InstanceID:    "drift",
+		EntityID:      "ent-drift",
+		FlowInstance:  "consumer/drift",
+		AddressFields: map[string]string{"entity.vertical_id": "v-1"},
+	}}
+	store.flowInstanceDescriptorCalls = 0
+	if err := eb.AddFlowInstanceRoute(FlowInstanceRouteMaterializationRequest{Identity: runtimeflowidentity.DeriveRoute("consumer", "drift")}); err != nil {
+		t.Fatalf("AddFlowInstanceRoute(drift): %v", err)
+	}
+	if err := eb.PublishPersistedRecipients(context.Background(), evt, nil); err != nil {
+		t.Fatalf("PublishPersistedRecipients: %v", err)
+	}
+	replayed := requireBusEvent(t, replayTarget, "persisted replay after lifecycle-created descriptor drift")
+	if replayed.FlowInstance() != activation.Instance.InstancePath || replayed.EntityID() != activation.Instance.EntityID {
+		t.Fatalf("replayed delivery target = flow_instance:%q entity:%q, want persisted lifecycle-created %q/%q",
+			replayed.FlowInstance(), replayed.EntityID(), activation.Instance.InstancePath, activation.Instance.EntityID)
+	}
+	if got := store.flowInstanceDescriptorCalls; got != 0 {
+		t.Fatalf("replay descriptor calls = %d, want 0 because lifecycle-created persisted route/scope is authoritative", got)
+	}
+}
+
+func TestEventBusPublish_ConnectRoutePlanCreatesRenamedTemplateInstanceKeyTarget(t *testing.T) {
+	source := connectRoutePlanRenamedInstanceKeySourceWithPolicy(t, "create", "reuse")
+	store := &connectRoutePlanLifecycleStore{
+		connectRoutePlanDescriptorStore: &connectRoutePlanDescriptorStore{
+			targetRouteMemoryStore: newTargetRouteMemoryStore(),
+		},
+	}
+	eb, err := NewEventBusWithOptions(store, EventBusOptions{
+		ContractBundle:            source,
+		TemplateInstanceActivator: store.Activate,
+	})
+	if err != nil {
+		t.Fatalf("NewEventBusWithOptions: %v", err)
+	}
+	store.bus = eb
+	evt := eventtest.RootIngress(uuid.NewString(),
+		events.EventType("producer/deploy.done"), "", "", json.RawMessage(`{"source_vertical_id":"v-1"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())
+
+	if err := eb.Publish(context.Background(), evt); err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+	if len(store.activations) != 1 {
+		t.Fatalf("activations = %d, want 1", len(store.activations))
+	}
+	activation := store.activations[0]
+	if activation.Config["vertical_id"] != "v-1" || activation.Metadata["vertical_id"] != "v-1" {
+		t.Fatalf("renamed activation config/metadata = %#v/%#v, want receiver vertical_id from adapter source_vertical_id", activation.Config, activation.Metadata)
+	}
+	want := events.DeliveryRoute{
+		SubscriberType: "node",
+		SubscriberID:   "consumer-node-" + activation.Instance.InstanceID,
+		Target: events.RouteIdentity{
+			FlowID:       "consumer",
+			FlowInstance: activation.Instance.InstancePath,
+			EntityID:     activation.Instance.EntityID,
+		},
+	}
+	if !deliveryRoutesContain(store.routes[evt.ID()], want) || len(store.routes[evt.ID()]) != 1 {
+		t.Fatalf("persisted delivery routes = %#v, want renamed-key created route %#v", store.routes[evt.ID()], want)
+	}
+}
+
+func TestEventBusPublish_ConnectRoutePlanRejectsCreateConflict(t *testing.T) {
+	source := connectRoutePlanInstanceKeySourceWithPolicy(t, "create", "reject")
+	store := &connectRoutePlanLifecycleStore{
+		connectRoutePlanDescriptorStore: &connectRoutePlanDescriptorStore{
+			targetRouteMemoryStore: newTargetRouteMemoryStore(),
+			flowInstances: []ActiveFlowInstanceDescriptor{{
+				InstanceID:    "one",
+				EntityID:      "ent-1",
+				FlowInstance:  "consumer/one",
+				AddressFields: map[string]string{"entity.vertical_id": "v-1"},
+			}},
+		},
+	}
+	eb, err := NewEventBusWithOptions(store, EventBusOptions{
+		ContractBundle:            source,
+		TemplateInstanceActivator: store.Activate,
+	})
+	if err != nil {
+		t.Fatalf("NewEventBusWithOptions: %v", err)
+	}
+	store.bus = eb
+	if err := eb.AddFlowInstanceRoute(FlowInstanceRouteMaterializationRequest{Identity: runtimeflowidentity.DeriveRoute("consumer", "one")}); err != nil {
+		t.Fatalf("AddFlowInstanceRoute: %v", err)
+	}
+	evt := eventtest.RootIngress(uuid.NewString(),
+		events.EventType("producer/deploy.done"), "", "", json.RawMessage(`{"vertical_id":"v-1"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())
+
+	routePlan, err := eb.planSubscribedRoutePlan(context.Background(), evt, false)
+	if err != nil {
+		t.Fatalf("planSubscribedRoutePlan: %v", err)
+	}
+	if got, want := routePlan.TargetFailure, runtimepinrouting.TargetFailure(runtimepinrouting.ConnectFailureInstanceConflict); got != want {
+		t.Fatalf("target failure = %q, want %q", got, want)
+	}
+	if len(routePlan.DeliveryRoutes()) != 0 {
+		t.Fatalf("delivery routes = %#v, want none on create conflict", routePlan.DeliveryRoutes())
+	}
+	if len(store.activations) != 0 {
+		t.Fatalf("activations = %d, want 0 on conflict", len(store.activations))
+	}
+}
+
+func TestEventBusPublish_ConnectRoutePlanLifecycleUnavailableBlocksLowerPrecedenceRescue(t *testing.T) {
+	source := connectRoutePlanInstanceKeySourceWithPolicy(t, "create", "reuse")
+	store := &connectRoutePlanDescriptorStore{
+		targetRouteMemoryStore: newTargetRouteMemoryStore(),
+	}
+	materializerCalled := false
+	eb, err := NewEventBusWithOptions(store, EventBusOptions{
+		ContractBundle: source,
+		RecipientPlanMaterializer: func(context.Context, events.Event, PublishRecipientPlan) ([]events.DeliveryRoute, error) {
+			materializerCalled = true
+			return []events.DeliveryRoute{{
+				SubscriberType: "node",
+				SubscriberID:   "bogus-node",
+				Target:         events.RouteIdentity{FlowID: "bogus", FlowInstance: "bogus/one", EntityID: "bogus"},
+			}}, nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewEventBusWithOptions: %v", err)
+	}
+	raw := eb.Subscribe("raw-source-listener", events.EventType("producer/deploy.done"), events.EventType("deploy.done"))
+	defer eb.Unsubscribe("raw-source-listener")
+	evt := eventtest.RootIngress(uuid.NewString(),
+		events.EventType("producer/deploy.done"), "", "", json.RawMessage(`{"vertical_id":"v-1"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())
+
+	routePlan, err := eb.planSubscribedRoutePlan(context.Background(), evt, false)
+	if err != nil {
+		t.Fatalf("planSubscribedRoutePlan: %v", err)
+	}
+	if materializerCalled {
+		t.Fatalf("recipient plan materializer was called for lifecycle-unavailable canonical failure")
+	}
+	if got, want := routePlan.TargetFailure, runtimepinrouting.TargetFailure(runtimepinrouting.ConnectFailureLifecycleUnavailable); got != want {
+		t.Fatalf("target failure = %q, want %q", got, want)
+	}
+	if len(routePlan.DeliveryRoutes()) != 0 {
+		t.Fatalf("delivery routes = %#v, want none on lifecycle-unavailable failure", routePlan.DeliveryRoutes())
+	}
+	if err := eb.Publish(context.Background(), evt); err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+	if materializerCalled {
+		t.Fatalf("recipient plan materializer was called during publish for lifecycle-unavailable canonical failure")
+	}
+	requireNoConnectRoutePlanBusEvent(t, raw, "source/raw subscriber fallback")
 }
 
 func TestEventBusReplay_ConnectRoutePlanUsesPersistedInstanceKeyRouteAfterDescriptorDrift(t *testing.T) {
@@ -1555,12 +1809,17 @@ func TestRoutePlanNormalizationPreservesAuthorityState(t *testing.T) {
 
 func connectRoutePlanInstanceKeySource(t testing.TB) semanticview.Source {
 	t.Helper()
+	return connectRoutePlanInstanceKeySourceWithPolicy(t, "reject", "reject")
+}
+
+func connectRoutePlanInstanceKeySourceWithPolicy(t testing.TB, onMissing, onConflict string) semanticview.Source {
+	t.Helper()
 	repoRoot, err := os.Getwd()
 	if err != nil {
 		t.Fatalf("Getwd: %v", err)
 	}
 	repoRoot = filepath.Clean(filepath.Join(repoRoot, "..", "..", ".."))
-	root := writeConnectRoutePlanInstanceKeyFixture(t)
+	root := writeConnectRoutePlanInstanceKeyFixtureWithPolicy(t, "one", onMissing, onConflict)
 	bundle, err := runtimecontracts.LoadWorkflowContractBundleWithOverrides(repoRoot, root, runtimecontracts.DefaultPlatformSpecFile(repoRoot))
 	if err != nil {
 		t.Fatalf("LoadWorkflowContractBundleWithOverrides: %v", err)
@@ -1570,12 +1829,17 @@ func connectRoutePlanInstanceKeySource(t testing.TB) semanticview.Source {
 
 func connectRoutePlanRenamedInstanceKeySource(t testing.TB) semanticview.Source {
 	t.Helper()
+	return connectRoutePlanRenamedInstanceKeySourceWithPolicy(t, "reject", "reject")
+}
+
+func connectRoutePlanRenamedInstanceKeySourceWithPolicy(t testing.TB, onMissing, onConflict string) semanticview.Source {
+	t.Helper()
 	repoRoot, err := os.Getwd()
 	if err != nil {
 		t.Fatalf("Getwd: %v", err)
 	}
 	repoRoot = filepath.Clean(filepath.Join(repoRoot, "..", "..", ".."))
-	root := writeConnectRoutePlanRenamedInstanceKeyFixture(t)
+	root := writeConnectRoutePlanRenamedInstanceKeyFixtureWithPolicy(t, onMissing, onConflict)
 	bundle, err := runtimecontracts.LoadWorkflowContractBundleWithOverrides(repoRoot, root, runtimecontracts.DefaultPlatformSpecFile(repoRoot))
 	if err != nil {
 		t.Fatalf("LoadWorkflowContractBundleWithOverrides: %v", err)
@@ -1603,6 +1867,10 @@ func writeConnectRoutePlanInstanceKeyFixture(t testing.TB) string {
 }
 
 func writeConnectRoutePlanRenamedInstanceKeyFixture(t testing.TB) string {
+	return writeConnectRoutePlanRenamedInstanceKeyFixtureWithPolicy(t, "reject", "reject")
+}
+
+func writeConnectRoutePlanRenamedInstanceKeyFixtureWithPolicy(t testing.TB, onMissing, onConflict string) string {
 	t.Helper()
 	root := t.TempDir()
 	writeConnectRoutePlanBusFixtureFile(t, filepath.Join(root, "package.yaml"), `
@@ -1652,8 +1920,8 @@ name: consumer
 mode: template
 instance:
   by: vertical_id
-  on_missing: reject
-  on_conflict: reject
+  on_missing: `+onMissing+`
+  on_conflict: `+onConflict+`
 pins:
   inputs:
     events:
@@ -1679,6 +1947,10 @@ consumer-node:
 }
 
 func writeConnectRoutePlanInstanceKeyFixtureWithDelivery(t testing.TB, delivery string) string {
+	return writeConnectRoutePlanInstanceKeyFixtureWithPolicy(t, delivery, "reject", "reject")
+}
+
+func writeConnectRoutePlanInstanceKeyFixtureWithPolicy(t testing.TB, delivery, onMissing, onConflict string) string {
 	t.Helper()
 	root := t.TempDir()
 	writeConnectRoutePlanBusFixtureFile(t, filepath.Join(root, "package.yaml"), `
@@ -1724,8 +1996,8 @@ name: consumer
 mode: template
 instance:
   by: vertical_id
-  on_missing: reject
-  on_conflict: reject
+  on_missing: `+onMissing+`
+  on_conflict: `+onConflict+`
 pins:
   inputs:
     events:

--- a/internal/runtime/bus/eventbus.go
+++ b/internal/runtime/bus/eventbus.go
@@ -247,8 +247,20 @@ func (eb *EventBus) AddFlowInstanceRouteContext(ctx context.Context, req FlowIns
 		return errors.New("route table is not initialized")
 	}
 	req = req.Normalized()
+	hadRoute := table.HasFlowInstanceRoute(req.Identity)
 	if err := table.AddFlowInstanceRoute(req); err != nil {
 		return err
+	}
+	addedRoute := !hadRoute && table.HasFlowInstanceRoute(req.Identity)
+	if addedRoute {
+		if _, ok := runtimepipeline.PipelineSQLTxFromContext(ctx); ok {
+			if !runtimepipeline.QueuePipelineRollbackAction(ctx, func() {
+				table.RemoveFlowInstanceRoute(req.Identity)
+			}) {
+				table.RemoveFlowInstanceRoute(req.Identity)
+				return errors.New("flow-instance route rollback action is required in pipeline transaction")
+			}
+		}
 	}
 	persister, ok := eb.store.(FlowInstanceRoutePersistence)
 	if !ok {
@@ -260,10 +272,12 @@ func (eb *EventBus) AddFlowInstanceRouteContext(ctx context.Context, req FlowIns
 	}
 	for _, route := range routes {
 		if err := persister.UpsertFlowInstanceRoute(ctx, route); err != nil {
-			if rollback, ok := eb.store.(FlowInstanceRouteRollbackPersistence); ok && rollback != nil {
-				_ = rollback.RollbackFlowInstanceRoute(ctx, route.Identity)
+			if addedRoute {
+				if rollback, ok := eb.store.(FlowInstanceRouteRollbackPersistence); ok && rollback != nil {
+					_ = rollback.RollbackFlowInstanceRoute(ctx, route.Identity)
+				}
+				table.RemoveFlowInstanceRoute(route.Identity)
 			}
-			table.RemoveFlowInstanceRoute(route.Identity)
 			return err
 		}
 	}

--- a/internal/runtime/bus/eventbus.go
+++ b/internal/runtime/bus/eventbus.go
@@ -12,6 +12,7 @@ import (
 	runtimeflowidentity "github.com/division-sh/swarm/internal/runtime/core/flowidentity"
 	runtimecorrelation "github.com/division-sh/swarm/internal/runtime/correlation"
 	runtimelifecycleprobe "github.com/division-sh/swarm/internal/runtime/lifecycleprobe"
+	runtimepipeline "github.com/division-sh/swarm/internal/runtime/pipeline"
 	"github.com/division-sh/swarm/internal/runtime/semanticview"
 )
 
@@ -42,6 +43,7 @@ type EventBus struct {
 	store                       EventStore
 	logger                      LoggerHook
 	semanticSource              semanticview.Source
+	templateInstanceActivator   runtimepipeline.FlowInstanceActivator
 	payloadValidator            PayloadValidator
 	recipientPlanAdmissionGuard PublishRecipientPlanAdmissionGuard
 	recipientPlanMaterializer   PublishRecipientPlanMaterializer
@@ -90,6 +92,7 @@ type EventBusOptions struct {
 	InterceptorProvider         func() []EventInterceptor
 	ContractBundle              semanticview.Source
 	RouteTable                  *RouteTable
+	TemplateInstanceActivator   runtimepipeline.FlowInstanceActivator
 	PayloadValidator            PayloadValidator
 	RecipientPlanAdmissionGuard PublishRecipientPlanAdmissionGuard
 	RecipientPlanMaterializer   PublishRecipientPlanMaterializer
@@ -148,6 +151,7 @@ func NewEventBusWithOptions(store EventStore, opts EventBusOptions) (*EventBus, 
 		interceptors:                filtered,
 		interceptorProvider:         opts.InterceptorProvider,
 		semanticSource:              semanticSource,
+		templateInstanceActivator:   opts.TemplateInstanceActivator,
 		payloadValidator:            opts.PayloadValidator,
 		recipientPlanAdmissionGuard: opts.RecipientPlanAdmissionGuard,
 		recipientPlanMaterializer:   opts.RecipientPlanMaterializer,
@@ -166,7 +170,7 @@ func (eb *EventBus) rebuildRoutePlanners() {
 	if eb == nil {
 		return
 	}
-	eb.connectRoutePlanner = newConnectRoutePlanResolver(eb.semanticSource, eb.routeTable, eb.PinRoutingDescriptors)
+	eb.connectRoutePlanner = newConnectRoutePlanResolver(eb.semanticSource, eb.routeTable, eb.PinRoutingDescriptors, eb.templateInstanceActivator)
 	eb.deliveryPlanner = eb.newEventBusDeliveryPlanner()
 }
 
@@ -226,8 +230,15 @@ func (eb *EventBus) RouteTable() *RouteTable {
 }
 
 func (eb *EventBus) AddFlowInstanceRoute(req FlowInstanceRouteMaterializationRequest) error {
+	return eb.AddFlowInstanceRouteContext(context.Background(), req)
+}
+
+func (eb *EventBus) AddFlowInstanceRouteContext(ctx context.Context, req FlowInstanceRouteMaterializationRequest) error {
 	if eb == nil {
 		return errors.New("event bus is required")
+	}
+	if ctx == nil {
+		ctx = context.Background()
 	}
 	eb.mu.RLock()
 	table := eb.routeTable
@@ -248,9 +259,9 @@ func (eb *EventBus) AddFlowInstanceRoute(req FlowInstanceRouteMaterializationReq
 		return nil
 	}
 	for _, route := range routes {
-		if err := persister.UpsertFlowInstanceRoute(context.Background(), route); err != nil {
+		if err := persister.UpsertFlowInstanceRoute(ctx, route); err != nil {
 			if rollback, ok := eb.store.(FlowInstanceRouteRollbackPersistence); ok && rollback != nil {
-				_ = rollback.RollbackFlowInstanceRoute(context.Background(), route.Identity)
+				_ = rollback.RollbackFlowInstanceRoute(ctx, route.Identity)
 			}
 			table.RemoveFlowInstanceRoute(route.Identity)
 			return err

--- a/internal/runtime/bus/eventbus_publish.go
+++ b/internal/runtime/bus/eventbus_publish.go
@@ -1479,7 +1479,7 @@ func (eb *EventBus) CheckPublishRecipientPlan(ctx context.Context, evt events.Ev
 			return PublishRecipientPlan{}, fmt.Errorf("%w for %s: %v", ErrPayloadValidation, strings.TrimSpace(string(evt.Type())), err)
 		}
 	}
-	plan, err := eb.planSubscribedRoutePlan(ctx, evt, false)
+	plan, err := eb.planSubscribedRoutePlan(withTemplateInstanceLifecyclePreview(ctx), evt, false)
 	if err != nil {
 		return PublishRecipientPlan{}, err
 	}

--- a/internal/runtime/bus/eventbus_publish.go
+++ b/internal/runtime/bus/eventbus_publish.go
@@ -171,6 +171,9 @@ func (eb *EventBus) Publish(ctx context.Context, evt events.Event) (err error) {
 	if err != nil {
 		return err
 	}
+	if replayed, err := eb.publishCommittedReplayIfPresent(ictx, evt); replayed || err != nil {
+		return err
+	}
 
 	deferredTransitions := make([]runtimepipeline.DeferredPipelineTransition, 0, 8)
 	postCommitActions := make([]func(), 0, 8)
@@ -256,6 +259,19 @@ func (eb *EventBus) Publish(ctx context.Context, evt events.Event) (err error) {
 		}
 	}
 	return eb.convergeStandaloneRuntimePlatformRun(ictx, evt)
+}
+
+func (eb *EventBus) publishCommittedReplayIfPresent(ctx context.Context, evt events.Event) (bool, error) {
+	if eb == nil || strings.TrimSpace(evt.ID()) == "" {
+		return false, nil
+	}
+	if _, err := eb.authoritativeReplayScopeForEvent(ctx, evt.ID()); err != nil {
+		if errors.Is(err, runtimereplayclaim.ErrMissingCommittedReplayScope) {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, eb.publishPersistedRecipients(ctx, evt, nil, false)
 }
 
 // PublishAcknowledged persists the event, recipient manifest, and replay scope

--- a/internal/runtime/bus/routing_derivation.go
+++ b/internal/runtime/bus/routing_derivation.go
@@ -267,6 +267,20 @@ func (rt *RouteTable) AddFlowInstanceRoute(req FlowInstanceRouteMaterializationR
 	return nil
 }
 
+func (rt *RouteTable) HasFlowInstanceRoute(identity runtimeflowidentity.Route) bool {
+	if rt == nil {
+		return false
+	}
+	identity = runtimeflowidentity.StoredRoute(identity.ScopeKey, identity.InstanceID, identity.InstancePath)
+	if !identity.Valid() {
+		return false
+	}
+	rt.mu.RLock()
+	defer rt.mu.RUnlock()
+	_, exists := rt.instances[identity.InstancePath]
+	return exists
+}
+
 func (rt *RouteTable) RemoveFlowInstanceRoute(identity runtimeflowidentity.Route) {
 	if rt == nil {
 		return

--- a/internal/runtime/bus/template_instance_lifecycle.go
+++ b/internal/runtime/bus/template_instance_lifecycle.go
@@ -1,0 +1,389 @@
+package bus
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"strings"
+
+	"github.com/division-sh/swarm/internal/events"
+	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
+	runtimeflowidentity "github.com/division-sh/swarm/internal/runtime/core/flowidentity"
+	runtimepinrouting "github.com/division-sh/swarm/internal/runtime/core/pinrouting"
+	runtimepipeline "github.com/division-sh/swarm/internal/runtime/pipeline"
+	"github.com/division-sh/swarm/internal/runtime/semanticview"
+)
+
+const (
+	templateInstanceLifecycleActionCreated          = "created"
+	templateInstanceLifecycleActionPreviewCreate    = "would_create"
+	templateInstanceLifecycleActionReused           = "reused"
+	templateInstanceLifecycleActionSelectedExisting = "selected_existing"
+)
+
+type templateInstanceLifecyclePreviewKey struct{}
+
+type templateInstanceLifecycleOwner struct {
+	source          semanticview.Source
+	loadDescriptors connectRoutePlanDescriptorLoader
+	activate        runtimepipeline.FlowInstanceActivator
+}
+
+type TemplateInstanceLifecycleDecision struct {
+	Action        string
+	ReceiverFlow  string
+	InstanceID    string
+	InstancePath  string
+	EntityID      string
+	KeyDigest     string
+	KeyMaterial   []runtimecontracts.TemplateInstanceKeyValue
+	OnMissing     string
+	OnConflict    string
+	SourceEventID string
+}
+
+func newTemplateInstanceLifecycleOwner(source semanticview.Source, loadDescriptors connectRoutePlanDescriptorLoader, activate runtimepipeline.FlowInstanceActivator) templateInstanceLifecycleOwner {
+	return templateInstanceLifecycleOwner{
+		source:          source,
+		loadDescriptors: loadDescriptors,
+		activate:        activate,
+	}
+}
+
+func (d TemplateInstanceLifecycleDecision) Empty() bool {
+	return strings.TrimSpace(d.Action) == ""
+}
+
+func (d TemplateInstanceLifecycleDecision) Detail() map[string]any {
+	if d.Empty() {
+		return nil
+	}
+	return map[string]any{
+		"action":          strings.TrimSpace(d.Action),
+		"receiver_flow":   strings.TrimSpace(d.ReceiverFlow),
+		"instance_id":     strings.TrimSpace(d.InstanceID),
+		"instance_path":   strings.Trim(strings.TrimSpace(d.InstancePath), "/"),
+		"entity_id":       strings.TrimSpace(d.EntityID),
+		"key_digest":      strings.TrimSpace(d.KeyDigest),
+		"key_material":    templateInstanceLifecycleKeyMaterialDetail(d.KeyMaterial),
+		"on_missing":      strings.TrimSpace(d.OnMissing),
+		"on_conflict":     strings.TrimSpace(d.OnConflict),
+		"source_event_id": strings.TrimSpace(d.SourceEventID),
+	}
+}
+
+func (d TemplateInstanceLifecycleDecision) Route() runtimeflowidentity.Route {
+	scope := runtimeflowidentity.SemanticScopeFromInstancePath(d.InstancePath)
+	if scope == "" {
+		scope = strings.TrimSpace(d.ReceiverFlow)
+	}
+	return runtimeflowidentity.StoredRoute(scope, d.InstanceID, d.InstancePath)
+}
+
+func (d TemplateInstanceLifecycleDecision) ActivationVariables() map[string]string {
+	out := map[string]string{}
+	for _, key := range d.KeyMaterial {
+		field := strings.TrimSpace(key.Field)
+		value := strings.TrimSpace(key.Value)
+		if field != "" && value != "" {
+			out[field] = value
+		}
+	}
+	setTemplateInstanceLifecycleVariable(out, "entity_id", d.EntityID)
+	setTemplateInstanceLifecycleVariable(out, "instance_id", d.InstanceID)
+	setTemplateInstanceLifecycleVariable(out, "template_id", d.ReceiverFlow)
+	if route := d.Route(); route.Valid() {
+		setTemplateInstanceLifecycleVariable(out, "flow_scope_key", route.ScopeKey)
+		setTemplateInstanceLifecycleVariable(out, "flow_instance_path", route.InstancePath)
+	}
+	return out
+}
+
+func setTemplateInstanceLifecycleVariable(vars map[string]string, key, value string) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return
+	}
+	vars[key] = value
+}
+
+func withTemplateInstanceLifecyclePreview(ctx context.Context) context.Context {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	return context.WithValue(ctx, templateInstanceLifecyclePreviewKey{}, true)
+}
+
+func templateInstanceLifecyclePreview(ctx context.Context) bool {
+	enabled, _ := ctx.Value(templateInstanceLifecyclePreviewKey{}).(bool)
+	return enabled
+}
+
+func (o templateInstanceLifecycleOwner) Materialize(ctx context.Context, evt events.Event, plan runtimepinrouting.ConnectRoutePlan, values map[string]string, descriptors []runtimepinrouting.Descriptor) (runtimepinrouting.ConnectRoutePlanMaterialization, TemplateInstanceLifecycleDecision, bool, error) {
+	if plan.ResolutionKind != runtimepinrouting.ConnectResolutionInstanceKey || plan.InstanceKey == nil {
+		return runtimepinrouting.ConnectRoutePlanMaterialization{}, TemplateInstanceLifecycleDecision{}, false, nil
+	}
+	material, failure := runtimepinrouting.InstanceKeyMaterialForConnectRoutePlan(plan, values)
+	if failure != "" {
+		return runtimepinrouting.ConnectRoutePlanMaterialization{Failure: failure}, TemplateInstanceLifecycleDecision{}, true, nil
+	}
+	instanceContract, failure := o.resolveInstanceContract(plan, material)
+	if failure != "" {
+		return runtimepinrouting.ConnectRoutePlanMaterialization{Failure: failure}, TemplateInstanceLifecycleDecision{}, true, nil
+	}
+	keyMaterial := append([]runtimecontracts.TemplateInstanceKeyValue{}, material.Keys...)
+	if canonical, err := instanceContract.CanonicalKeyMaterial(material.Values); err == nil {
+		keyMaterial = canonical
+	} else {
+		return runtimepinrouting.ConnectRoutePlanMaterialization{Failure: runtimepinrouting.ConnectFailureAddressValueMissing}, TemplateInstanceLifecycleDecision{}, true, nil
+	}
+	onMissing := strings.TrimSpace(instanceContract.OnMissing)
+	onConflict := strings.TrimSpace(instanceContract.OnConflict)
+	matches := runtimepinrouting.InstanceKeyDescriptorRoutesForConnectRoutePlan(plan, keyMaterial, descriptors)
+	if len(matches) > 1 {
+		return runtimepinrouting.ConnectRoutePlanMaterialization{Failure: runtimepinrouting.ConnectFailureTargetAmbiguous}, TemplateInstanceLifecycleDecision{}, true, nil
+	}
+	if len(matches) == 1 {
+		if onMissing == "create" && onConflict == "reject" {
+			return runtimepinrouting.ConnectRoutePlanMaterialization{Failure: runtimepinrouting.ConnectFailureInstanceConflict}, TemplateInstanceLifecycleDecision{}, true, nil
+		}
+		return templateInstanceLifecycleMaterialization(plan, matches), o.decision(plan, evt, keyMaterial, onMissing, onConflict, matches[0], templateInstanceLifecycleExistingAction(onMissing, onConflict)), true, nil
+	}
+	if onMissing != "create" {
+		return runtimepinrouting.ConnectRoutePlanMaterialization{Failure: runtimepinrouting.ConnectFailureTargetUnresolved}, TemplateInstanceLifecycleDecision{}, true, nil
+	}
+	if o.activate == nil {
+		return runtimepinrouting.ConnectRoutePlanMaterialization{Failure: runtimepinrouting.ConnectFailureLifecycleUnavailable}, TemplateInstanceLifecycleDecision{}, true, nil
+	}
+	if templateInstanceLifecyclePreview(ctx) {
+		req, decision, failure := o.activationRequest(evt, plan, instanceContract, keyMaterial, onMissing, onConflict)
+		if failure != "" {
+			return runtimepinrouting.ConnectRoutePlanMaterialization{Failure: failure}, TemplateInstanceLifecycleDecision{}, true, nil
+		}
+		decision.Action = templateInstanceLifecycleActionPreviewCreate
+		route := events.RouteIdentity{FlowID: plan.Receiver.FlowID, FlowInstance: req.Instance.InstancePath, EntityID: req.Instance.EntityID}.Normalized()
+		return templateInstanceLifecycleMaterialization(plan, []events.RouteIdentity{route}), decision, true, nil
+	}
+	req, decision, failure := o.activationRequest(evt, plan, instanceContract, keyMaterial, onMissing, onConflict)
+	if failure != "" {
+		return runtimepinrouting.ConnectRoutePlanMaterialization{Failure: failure}, TemplateInstanceLifecycleDecision{}, true, nil
+	}
+	if err := o.activate(ctx, req); err != nil {
+		return runtimepinrouting.ConnectRoutePlanMaterialization{}, TemplateInstanceLifecycleDecision{}, true, fmt.Errorf("activate connect-time template instance %s: %w", req.Instance.InstancePath, err)
+	}
+	refreshed, err := o.reloadDescriptors(ctx)
+	if err != nil {
+		return runtimepinrouting.ConnectRoutePlanMaterialization{}, TemplateInstanceLifecycleDecision{}, true, err
+	}
+	matches = runtimepinrouting.InstanceKeyDescriptorRoutesForConnectRoutePlan(plan, keyMaterial, refreshed)
+	if len(matches) == 0 {
+		return runtimepinrouting.ConnectRoutePlanMaterialization{Failure: runtimepinrouting.ConnectFailureTargetUnresolved}, decision, true, nil
+	}
+	if len(matches) > 1 {
+		return runtimepinrouting.ConnectRoutePlanMaterialization{Failure: runtimepinrouting.ConnectFailureTargetAmbiguous}, decision, true, nil
+	}
+	decision.InstancePath = matches[0].FlowInstance
+	decision.EntityID = matches[0].EntityID
+	return templateInstanceLifecycleMaterialization(plan, matches), decision, true, nil
+}
+
+func (o templateInstanceLifecycleOwner) resolveInstanceContract(plan runtimepinrouting.ConnectRoutePlan, material runtimepinrouting.ConnectRoutePlanInstanceKeyMaterial) (runtimecontracts.TemplateInstanceContract, runtimepinrouting.ConnectRoutePlanFailure) {
+	bundle, ok := semanticview.Bundle(o.source)
+	if !ok || bundle == nil {
+		return runtimecontracts.TemplateInstanceContract{}, runtimepinrouting.ConnectFailureLifecycleUnavailable
+	}
+	instance, err := bundle.ResolveFlowTemplateInstance(plan.Receiver.FlowID)
+	if err != nil {
+		return runtimecontracts.TemplateInstanceContract{}, runtimepinrouting.ConnectFailureLifecycleUnavailable
+	}
+	if _, err := instance.CanonicalKeyMaterial(material.Values); err != nil {
+		return runtimecontracts.TemplateInstanceContract{}, runtimepinrouting.ConnectFailureAddressValueMissing
+	}
+	return instance, ""
+}
+
+func (o templateInstanceLifecycleOwner) activationRequest(evt events.Event, plan runtimepinrouting.ConnectRoutePlan, instanceContract runtimecontracts.TemplateInstanceContract, keyMaterial []runtimecontracts.TemplateInstanceKeyValue, onMissing, onConflict string) (runtimepipeline.FlowInstanceActivationRequest, TemplateInstanceLifecycleDecision, runtimepinrouting.ConnectRoutePlanFailure) {
+	instanceID := templateInstanceLifecycleInstanceID(plan.Receiver.FlowID, keyMaterial)
+	if instanceID == "" {
+		return runtimepipeline.FlowInstanceActivationRequest{}, TemplateInstanceLifecycleDecision{}, runtimepinrouting.ConnectFailureAddressValueMissing
+	}
+	instance := runtimeflowidentity.Derive(o.source, plan.Receiver.FlowID, instanceID)
+	instance.ParentRoute = templateInstanceLifecycleParentRoute(evt, plan)
+	instance.ParentEntityID = instance.ParentRoute.EntityID
+	config := templateInstanceLifecycleKeyMap(keyMaterial)
+	metadata := templateInstanceLifecycleKeyMap(keyMaterial)
+	metadata["entity_type"] = strings.TrimSpace(instanceContract.PrimaryEntity.EntityType)
+	metadata["instance_kind"] = "template"
+	metadata["last_source_event"] = strings.TrimSpace(evt.ID())
+	config["template_instance_key"] = templateInstanceLifecycleKeyDigest(plan.Receiver.FlowID, keyMaterial)
+	config["template_instance_source_event"] = strings.TrimSpace(evt.ID())
+	config["template_instance_on_missing"] = onMissing
+	config["template_instance_on_conflict"] = onConflict
+	decision := TemplateInstanceLifecycleDecision{
+		Action:        templateInstanceLifecycleActionCreated,
+		ReceiverFlow:  strings.TrimSpace(plan.Receiver.FlowID),
+		InstanceID:    instance.InstanceID,
+		InstancePath:  instance.InstancePath,
+		EntityID:      instance.EntityID,
+		KeyDigest:     templateInstanceLifecycleKeyDigest(plan.Receiver.FlowID, keyMaterial),
+		KeyMaterial:   append([]runtimecontracts.TemplateInstanceKeyValue{}, keyMaterial...),
+		OnMissing:     onMissing,
+		OnConflict:    onConflict,
+		SourceEventID: strings.TrimSpace(evt.ID()),
+	}
+	return runtimepipeline.FlowInstanceActivationRequest{
+		ContractBundle: o.source,
+		Instance:       instance,
+		Config:         config,
+		Metadata:       metadata,
+		TriggerEvent:   evt,
+	}, decision, ""
+}
+
+func (o templateInstanceLifecycleOwner) reloadDescriptors(ctx context.Context) ([]runtimepinrouting.Descriptor, error) {
+	if o.loadDescriptors == nil {
+		return nil, nil
+	}
+	return o.loadDescriptors(ctx)
+}
+
+func templateInstanceLifecycleMaterialization(plan runtimepinrouting.ConnectRoutePlan, routes []events.RouteIdentity) runtimepinrouting.ConnectRoutePlanMaterialization {
+	routes = templateInstanceLifecycleRoutes(routes)
+	if len(routes) == 0 {
+		return runtimepinrouting.ConnectRoutePlanMaterialization{Failure: runtimepinrouting.ConnectFailureTargetUnresolved}
+	}
+	if len(routes) > 1 {
+		return runtimepinrouting.ConnectRoutePlanMaterialization{Failure: runtimepinrouting.ConnectFailureTargetAmbiguous}
+	}
+	switch plan.TargetKind {
+	case runtimepinrouting.ConnectTargetKindTarget, runtimepinrouting.ConnectTargetKindReply:
+		return runtimepinrouting.ConnectRoutePlanMaterialization{Target: routes[0]}
+	case runtimepinrouting.ConnectTargetKindTargetSet:
+		return runtimepinrouting.ConnectRoutePlanMaterialization{TargetSet: routes}
+	default:
+		return runtimepinrouting.ConnectRoutePlanMaterialization{Failure: runtimepinrouting.ConnectFailureDeliveryTopologyInvalid}
+	}
+}
+
+func templateInstanceLifecycleRoutes(in []events.RouteIdentity) []events.RouteIdentity {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]events.RouteIdentity, 0, len(in))
+	seen := map[string]struct{}{}
+	for _, route := range in {
+		route = route.Normalized()
+		if route.Empty() {
+			continue
+		}
+		key := strings.TrimSpace(route.FlowID) + "\x00" + strings.Trim(route.FlowInstance, "/") + "\x00" + strings.TrimSpace(route.EntityID)
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		out = append(out, route)
+	}
+	return out
+}
+
+func (o templateInstanceLifecycleOwner) decision(plan runtimepinrouting.ConnectRoutePlan, evt events.Event, keyMaterial []runtimecontracts.TemplateInstanceKeyValue, onMissing, onConflict string, route events.RouteIdentity, action string) TemplateInstanceLifecycleDecision {
+	return TemplateInstanceLifecycleDecision{
+		Action:        action,
+		ReceiverFlow:  strings.TrimSpace(plan.Receiver.FlowID),
+		InstanceID:    runtimeflowidentity.LogicalInstanceID(route.FlowInstance),
+		InstancePath:  strings.Trim(strings.TrimSpace(route.FlowInstance), "/"),
+		EntityID:      strings.TrimSpace(route.EntityID),
+		KeyDigest:     templateInstanceLifecycleKeyDigest(plan.Receiver.FlowID, keyMaterial),
+		KeyMaterial:   append([]runtimecontracts.TemplateInstanceKeyValue{}, keyMaterial...),
+		OnMissing:     strings.TrimSpace(onMissing),
+		OnConflict:    strings.TrimSpace(onConflict),
+		SourceEventID: strings.TrimSpace(evt.ID()),
+	}
+}
+
+func templateInstanceLifecycleExistingAction(onMissing, onConflict string) string {
+	if strings.TrimSpace(onMissing) == "create" && strings.TrimSpace(onConflict) == "reuse" {
+		return templateInstanceLifecycleActionReused
+	}
+	return templateInstanceLifecycleActionSelectedExisting
+}
+
+func templateInstanceLifecycleParentRoute(evt events.Event, plan runtimepinrouting.ConnectRoutePlan) runtimeflowidentity.ParentRoute {
+	envelope := evt.NormalizedEnvelope()
+	parent := runtimeflowidentity.ParentRoute{
+		FlowID:       strings.TrimSpace(plan.Source.FlowID),
+		FlowInstance: strings.Trim(strings.TrimSpace(evt.FlowInstance()), "/"),
+		EntityID:     strings.TrimSpace(evt.EntityID()),
+	}
+	if parent.FlowInstance == "" {
+		parent.FlowInstance = strings.Trim(strings.TrimSpace(envelope.Source.FlowInstance), "/")
+	}
+	if parent.EntityID == "" {
+		parent.EntityID = strings.TrimSpace(envelope.Source.EntityID)
+	}
+	if parent.FlowID == "" {
+		parent.FlowID = strings.TrimSpace(envelope.Source.FlowID)
+	}
+	if parent.FlowInstance == "" {
+		parent.FlowInstance = strings.Trim(strings.TrimSpace(plan.Source.FlowPath), "/")
+	}
+	return parent.Normalized()
+}
+
+func templateInstanceLifecycleInstanceID(receiverFlow string, keyMaterial []runtimecontracts.TemplateInstanceKeyValue) string {
+	digest := templateInstanceLifecycleKeyDigest(receiverFlow, keyMaterial)
+	if digest == "" {
+		return ""
+	}
+	if len(digest) > 24 {
+		digest = digest[:24]
+	}
+	return "ti-" + digest
+}
+
+func templateInstanceLifecycleKeyDigest(receiverFlow string, keyMaterial []runtimecontracts.TemplateInstanceKeyValue) string {
+	receiverFlow = strings.TrimSpace(receiverFlow)
+	if receiverFlow == "" || len(keyMaterial) == 0 {
+		return ""
+	}
+	h := sha256.New()
+	_, _ = h.Write([]byte(receiverFlow))
+	_, _ = h.Write([]byte{0})
+	for _, key := range keyMaterial {
+		_, _ = h.Write([]byte(strings.TrimSpace(key.Field)))
+		_, _ = h.Write([]byte{0})
+		_, _ = h.Write([]byte(strings.TrimSpace(key.Value)))
+		_, _ = h.Write([]byte{0})
+	}
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+func templateInstanceLifecycleKeyMap(keyMaterial []runtimecontracts.TemplateInstanceKeyValue) map[string]any {
+	out := make(map[string]any, len(keyMaterial))
+	for _, key := range keyMaterial {
+		field := strings.TrimSpace(key.Field)
+		value := strings.TrimSpace(key.Value)
+		if field == "" || value == "" {
+			continue
+		}
+		out[field] = value
+	}
+	return out
+}
+
+func templateInstanceLifecycleKeyMaterialDetail(keyMaterial []runtimecontracts.TemplateInstanceKeyValue) []map[string]string {
+	if len(keyMaterial) == 0 {
+		return nil
+	}
+	out := make([]map[string]string, 0, len(keyMaterial))
+	for _, key := range keyMaterial {
+		field := strings.TrimSpace(key.Field)
+		value := strings.TrimSpace(key.Value)
+		if field == "" || value == "" {
+			continue
+		}
+		out = append(out, map[string]string{"field": field, "value": value})
+	}
+	return out
+}

--- a/internal/runtime/conformance/testdata/route_authority_drift_inventory.yaml
+++ b/internal/runtime/conformance/testdata/route_authority_drift_inventory.yaml
@@ -1,7 +1,7 @@
 version: 1
 kind: route_authority_drift_inventory
 issue: 1364
-implementation_issues: [1364, 1494, 1495, 1496, 1545, 1546]
+implementation_issues: [1364, 1494, 1495, 1496, 1545, 1546, 1577]
 parent_issues: [1340, 1353, 1481, 1493]
 watchlist: runtime_operations.delivery_and_replay_ownership
 policy:
@@ -364,6 +364,7 @@ seam_families:
       - internal/runtime/core/pinrouting/connect_route_plan.go
       - internal/runtime/core/pinrouting/connect_route_plan_test.go
       - internal/runtime/bus/connect_route_plan_dispatch.go
+      - internal/runtime/bus/template_instance_lifecycle.go
       - internal/runtime/bus/connect_route_plan_dispatch_test.go
       - internal/runtime/bus/route_plan.go
       - internal/runtime/conformance/testdata/route_authority_matrix.yaml
@@ -377,7 +378,9 @@ seam_families:
       keyed instance evidence cannot shadow explicit parent broadcast fan-out.
       #1546 adds ConnectRoutePlan.InstanceKey.Mappings as the only runtime
       adapter authority for renamed addressless template instance-key routes;
-      connect.map remains non-authoritative for that class.
+      connect.map remains non-authoritative for that class. #1577 adds the
+      connect-time template lifecycle owner that consumes the lowered instance
+      key plan and creates, reuses, or fails closed before delivery rows commit.
   - id: route_table_resolve_role_separation
     layer: route_topology
     classification: valid_consumer

--- a/internal/runtime/core/pinrouting/connect_route_plan.go
+++ b/internal/runtime/core/pinrouting/connect_route_plan.go
@@ -56,6 +56,8 @@ const (
 	ConnectFailureTargetUnresolved           ConnectRoutePlanFailure = "route_plan_target_unresolved"
 	ConnectFailureTargetAmbiguous            ConnectRoutePlanFailure = "route_plan_target_ambiguous"
 	ConnectFailureInstanceKeyAdapterInvalid  ConnectRoutePlanFailure = "route_plan_instance_key_adapter_invalid"
+	ConnectFailureInstanceConflict           ConnectRoutePlanFailure = "route_plan_instance_conflict"
+	ConnectFailureLifecycleUnavailable       ConnectRoutePlanFailure = "route_plan_lifecycle_unavailable"
 )
 
 type ConnectRoutePlanEndpoint struct {
@@ -130,6 +132,11 @@ type ConnectRoutePlanMaterialization struct {
 	Target    events.RouteIdentity
 	TargetSet []events.RouteIdentity
 	Failure   ConnectRoutePlanFailure
+}
+
+type ConnectRoutePlanInstanceKeyMaterial struct {
+	Values map[string]any
+	Keys   []runtimecontracts.TemplateInstanceKeyValue
 }
 
 func LowerCompositionConnectRoutePlans(source semanticview.Source) ([]ConnectRoutePlan, []ConnectRoutePlanIssue) {
@@ -347,35 +354,9 @@ func materializeBroadcastConnectRoutePlan(plan ConnectRoutePlan, descriptors []D
 }
 
 func materializeInstanceKeyConnectRoutePlan(plan ConnectRoutePlan, input ConnectRoutePlanMaterializationInput) ConnectRoutePlanMaterialization {
-	instanceKey := plan.InstanceKey
-	if instanceKey == nil || len(instanceKey.Fields) == 0 {
-		return ConnectRoutePlanMaterialization{Failure: ConnectFailureReceiverAddressRuleMissing}
-	}
-	values := make(map[string]any, len(instanceKey.Fields))
-	mappings := connectInstanceKeyMaterializationMappings(instanceKey)
-	for _, mapping := range mappings {
-		source := strings.TrimSpace(mapping.Source)
-		target := strings.TrimSpace(mapping.Target)
-		if source == "" || target == "" {
-			return ConnectRoutePlanMaterialization{Failure: ConnectFailureReceiverAddressRuleMissing}
-		}
-		value := ""
-		if mapping.Explicit {
-			value = firstMatchValue(input.MatchValues, "payload."+source)
-		} else {
-			value = firstMatchValue(input.MatchValues, source, "payload."+source)
-		}
-		if value == "" {
-			return ConnectRoutePlanMaterialization{Failure: ConnectFailureAddressValueMissing}
-		}
-		values[target] = value
-	}
-	keyMaterial, err := (runtimecontracts.TemplateInstanceContract{
-		FlowID: plan.Receiver.FlowID,
-		By:     append([]string{}, instanceKey.Fields...),
-	}).CanonicalKeyMaterial(values)
-	if err != nil {
-		return ConnectRoutePlanMaterialization{Failure: ConnectFailureAddressValueMissing}
+	keyMaterial, failure := InstanceKeyMaterialForConnectRoutePlan(plan, input.MatchValues)
+	if failure != "" {
+		return ConnectRoutePlanMaterialization{Failure: failure}
 	}
 	routes := make([]events.RouteIdentity, 0, len(input.Descriptors))
 	for _, descriptor := range input.Descriptors {
@@ -383,7 +364,7 @@ func materializeInstanceKeyConnectRoutePlan(plan ConnectRoutePlan, input Connect
 		if route.Empty() {
 			continue
 		}
-		if connectInstanceKeyDescriptorMatches(keyMaterial, descriptor) {
+		if ConnectInstanceKeyDescriptorMatches(keyMaterial.Keys, descriptor) {
 			routes = append(routes, route)
 		}
 	}
@@ -402,6 +383,60 @@ func materializeInstanceKeyConnectRoutePlan(plan ConnectRoutePlan, input Connect
 	default:
 		return ConnectRoutePlanMaterialization{Failure: ConnectFailureDeliveryTopologyInvalid}
 	}
+}
+
+func InstanceKeyMaterialForConnectRoutePlan(plan ConnectRoutePlan, matchValues map[string]string) (ConnectRoutePlanInstanceKeyMaterial, ConnectRoutePlanFailure) {
+	instanceKey := plan.InstanceKey
+	if instanceKey == nil || len(instanceKey.Fields) == 0 {
+		return ConnectRoutePlanInstanceKeyMaterial{}, ConnectFailureReceiverAddressRuleMissing
+	}
+	values := make(map[string]any, len(instanceKey.Fields))
+	mappings := connectInstanceKeyMaterializationMappings(instanceKey)
+	for _, mapping := range mappings {
+		source := strings.TrimSpace(mapping.Source)
+		target := strings.TrimSpace(mapping.Target)
+		if source == "" || target == "" {
+			return ConnectRoutePlanInstanceKeyMaterial{}, ConnectFailureReceiverAddressRuleMissing
+		}
+		value := ""
+		if mapping.Explicit {
+			value = firstMatchValue(matchValues, "payload."+source)
+		} else {
+			value = firstMatchValue(matchValues, source, "payload."+source)
+		}
+		if value == "" {
+			return ConnectRoutePlanInstanceKeyMaterial{}, ConnectFailureAddressValueMissing
+		}
+		values[target] = value
+	}
+	keys, err := (runtimecontracts.TemplateInstanceContract{
+		FlowID: plan.Receiver.FlowID,
+		By:     append([]string{}, instanceKey.Fields...),
+	}).CanonicalKeyMaterial(values)
+	if err != nil {
+		return ConnectRoutePlanInstanceKeyMaterial{}, ConnectFailureAddressValueMissing
+	}
+	return ConnectRoutePlanInstanceKeyMaterial{
+		Values: values,
+		Keys:   append([]runtimecontracts.TemplateInstanceKeyValue{}, keys...),
+	}, ""
+}
+
+func InstanceKeyDescriptorRoutesForConnectRoutePlan(plan ConnectRoutePlan, keyMaterial []runtimecontracts.TemplateInstanceKeyValue, descriptors []Descriptor) []events.RouteIdentity {
+	if len(keyMaterial) == 0 {
+		return nil
+	}
+	routes := make([]events.RouteIdentity, 0, len(descriptors))
+	for _, descriptor := range descriptors {
+		route := descriptorRouteForReceiver(plan, descriptor)
+		if route.Empty() {
+			continue
+		}
+		if ConnectInstanceKeyDescriptorMatches(keyMaterial, descriptor) {
+			routes = append(routes, route)
+		}
+	}
+	return uniqueRoutes(routes)
 }
 
 func connectDelivery(connect runtimecontracts.FlowPackageConnect, inputPin runtimecontracts.FlowInputEventPin) (ConnectRoutePlanDelivery, ConnectRoutePlanFailure) {
@@ -750,7 +785,7 @@ func connectDescriptorMatches(targetExpr, value string, descriptor Descriptor, r
 	}
 }
 
-func connectInstanceKeyDescriptorMatches(keyMaterial []runtimecontracts.TemplateInstanceKeyValue, descriptor Descriptor) bool {
+func ConnectInstanceKeyDescriptorMatches(keyMaterial []runtimecontracts.TemplateInstanceKeyValue, descriptor Descriptor) bool {
 	if len(keyMaterial) == 0 {
 		return false
 	}

--- a/internal/runtime/eventbus_logger.go
+++ b/internal/runtime/eventbus_logger.go
@@ -11,24 +11,26 @@ import (
 	"github.com/division-sh/swarm/internal/runtime/diaglog"
 	runtimeeventpayload "github.com/division-sh/swarm/internal/runtime/eventpayload"
 	runtimelifecycleprobe "github.com/division-sh/swarm/internal/runtime/lifecycleprobe"
+	runtimepipeline "github.com/division-sh/swarm/internal/runtime/pipeline"
 	"github.com/division-sh/swarm/internal/runtime/semanticview"
 	runtimesharedjson "github.com/division-sh/swarm/internal/runtime/sharedjson"
 	runtimetools "github.com/division-sh/swarm/internal/runtime/tools"
 )
 
-func newRuntimeEventBus(store runtimebus.EventStore, logger *RuntimeLogger, source semanticview.Source, bundleFingerprint string, bundleSourceFact runtimecorrelation.BundleSourceFact, interceptorProvider func() []runtimebus.EventInterceptor, payloadValidator runtimebus.PayloadValidator, testLifecycleProbe runtimelifecycleprobe.Observer) (*runtimebus.EventBus, error) {
+func newRuntimeEventBus(store runtimebus.EventStore, logger *RuntimeLogger, source semanticview.Source, bundleFingerprint string, bundleSourceFact runtimecorrelation.BundleSourceFact, interceptorProvider func() []runtimebus.EventInterceptor, payloadValidator runtimebus.PayloadValidator, templateInstanceActivator runtimepipeline.FlowInstanceActivator, testLifecycleProbe runtimelifecycleprobe.Observer) (*runtimebus.EventBus, error) {
 	var hook runtimebus.LoggerHook
 	if logger != nil {
 		hook = runtimeLoggerHook{logger: logger}
 	}
 	return runtimebus.NewEventBusWithOptions(store, runtimebus.EventBusOptions{
-		Logger:              hook,
-		InterceptorProvider: interceptorProvider,
-		ContractBundle:      source,
-		PayloadValidator:    payloadValidator,
-		BundleFingerprint:   bundleFingerprint,
-		BundleSourceFact:    bundleSourceFact,
-		TestLifecycleProbe:  testLifecycleProbe,
+		Logger:                    hook,
+		InterceptorProvider:       interceptorProvider,
+		ContractBundle:            source,
+		TemplateInstanceActivator: templateInstanceActivator,
+		PayloadValidator:          payloadValidator,
+		BundleFingerprint:         bundleFingerprint,
+		BundleSourceFact:          bundleSourceFact,
+		TestLifecycleProbe:        testLifecycleProbe,
 	})
 }
 

--- a/internal/runtime/manager/flow_activation.go
+++ b/internal/runtime/manager/flow_activation.go
@@ -34,6 +34,10 @@ type flowInstanceRouteInstaller interface {
 	AddFlowInstanceRoute(runtimebus.FlowInstanceRouteMaterializationRequest) error
 }
 
+type flowInstanceRouteContextInstaller interface {
+	AddFlowInstanceRouteContext(context.Context, runtimebus.FlowInstanceRouteMaterializationRequest) error
+}
+
 type flowInstanceRouteRemover interface {
 	RemoveFlowInstanceRoute(identity runtimeflowidentity.Route) error
 }
@@ -92,6 +96,10 @@ func (am *AgentManager) ActivateFlowInstance(ctx context.Context, req runtimepip
 	if err != nil {
 		return err
 	}
+	metadata := cloneFlowConfig(req.Metadata)
+	for key, value := range flowInstanceActivationMetadata(instance, flowEntityID, instanceID, flowPath, parentEntityID) {
+		metadata[key] = value
+	}
 	if err := am.workflowInstances.Create(ctx, runtimepipeline.WorkflowInstance{
 		InstanceID:      instanceID,
 		StorageRef:      flowPath,
@@ -99,7 +107,7 @@ func (am *AgentManager) ActivateFlowInstance(ctx context.Context, req runtimepip
 		WorkflowVersion: strings.TrimSpace(req.ContractBundle.WorkflowVersion()),
 		CurrentState:    initialState,
 		Config:          cloneFlowConfig(req.Config),
-		Metadata:        flowInstanceActivationMetadata(instance, flowEntityID, instanceID, flowPath, parentEntityID),
+		Metadata:        metadata,
 	}); err != nil {
 		return fmt.Errorf("persist flow instance %s: %w", flowPath, err)
 	}
@@ -131,7 +139,14 @@ func (am *AgentManager) ActivateFlowInstance(ctx context.Context, req runtimepip
 			return err
 		}
 	}
-	if installer, ok := am.bus.(flowInstanceRouteInstaller); ok && installer != nil {
+	if installer, ok := am.bus.(flowInstanceRouteContextInstaller); ok && installer != nil {
+		if err := installer.AddFlowInstanceRouteContext(ctx, runtimebus.FlowInstanceRouteMaterializationRequest{
+			Identity:            instance.Route(),
+			ActivationVariables: vars,
+		}); err != nil {
+			return err
+		}
+	} else if installer, ok := am.bus.(flowInstanceRouteInstaller); ok && installer != nil {
 		if err := installer.AddFlowInstanceRoute(runtimebus.FlowInstanceRouteMaterializationRequest{
 			Identity:            instance.Route(),
 			ActivationVariables: vars,

--- a/internal/runtime/pipeline/runtime_support.go
+++ b/internal/runtime/pipeline/runtime_support.go
@@ -273,6 +273,7 @@ func asObject(v any) (map[string]any, bool) {
 
 type sqlTxContextKey struct{}
 type pipelinePostCommitActionsKey struct{}
+type pipelineRollbackActionsKey struct{}
 type pipelineAfterPublishActionsKey struct{}
 type pipelineReceiptOverrideKey struct{}
 
@@ -352,6 +353,45 @@ func flushPipelinePostCommitActions(actions []func()) {
 
 func FlushPipelinePostCommitActions(actions []func()) {
 	flushPipelinePostCommitActions(actions)
+}
+
+func withPipelineRollbackActions(ctx context.Context, actions *[]func()) context.Context {
+	if actions == nil {
+		return ctx
+	}
+	return context.WithValue(ctx, pipelineRollbackActionsKey{}, actions)
+}
+
+func WithPipelineRollbackActions(ctx context.Context, actions *[]func()) context.Context {
+	return withPipelineRollbackActions(ctx, actions)
+}
+
+func queuePipelineRollbackAction(ctx context.Context, fn func()) bool {
+	if ctx == nil || fn == nil {
+		return false
+	}
+	actions, ok := ctx.Value(pipelineRollbackActionsKey{}).(*[]func())
+	if !ok || actions == nil {
+		return false
+	}
+	*actions = append(*actions, fn)
+	return true
+}
+
+func QueuePipelineRollbackAction(ctx context.Context, fn func()) bool {
+	return queuePipelineRollbackAction(ctx, fn)
+}
+
+func flushPipelineRollbackActions(actions []func()) {
+	for i := len(actions) - 1; i >= 0; i-- {
+		if actions[i] != nil {
+			actions[i]()
+		}
+	}
+}
+
+func FlushPipelineRollbackActions(actions []func()) {
+	flushPipelineRollbackActions(actions)
 }
 
 func withPipelineAfterPublishActions(ctx context.Context, actions *[]func()) context.Context {

--- a/internal/runtime/pipeline/workflow_instance_activation.go
+++ b/internal/runtime/pipeline/workflow_instance_activation.go
@@ -18,6 +18,7 @@ type FlowInstanceActivationRequest struct {
 	Instance       runtimeflowidentity.Instance
 	InitialState   string
 	Config         map[string]any
+	Metadata       map[string]any
 	TriggerEvent   events.Event
 }
 

--- a/internal/runtime/pipeline/workflow_instance_store.go
+++ b/internal/runtime/pipeline/workflow_instance_store.go
@@ -437,12 +437,17 @@ func (s *WorkflowInstanceStore) runInPipelineTransactionOnce(ctx context.Context
 		return err
 	}
 	postCommit := make([]func(), 0, 4)
-	txctx := withPipelinePostCommitActions(withSQLTxContext(ctx, tx), &postCommit)
+	rollbackActions := make([]func(), 0, 4)
+	txctx := withSQLTxContext(ctx, tx)
+	txctx = withPipelinePostCommitActions(txctx, &postCommit)
+	txctx = withPipelineRollbackActions(txctx, &rollbackActions)
 	if err := fn(txctx, tx); err != nil {
 		_ = tx.Rollback()
+		flushPipelineRollbackActions(rollbackActions)
 		return err
 	}
 	if err := tx.Commit(); err != nil {
+		flushPipelineRollbackActions(rollbackActions)
 		return err
 	}
 	flushPipelinePostCommitActions(postCommit)

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -394,12 +394,18 @@ func NewRuntime(ctx context.Context, deps RuntimeDeps) (*Runtime, error) {
 	}
 	payloadValidator := boot.payloadValidator(rt.Logger)
 	boot.bindPayloadValidator(payloadValidator)
+	var managerRef *runtimemanager.AgentManager
 	bus, err := newRuntimeEventBus(stores.EventStore, rt.Logger, source, boot.TrimmedBundleFingerprint, boot.BundleSourceFact, func() []runtimebus.EventInterceptor {
 		if rt.Pipeline == nil {
 			return nil
 		}
 		return []runtimebus.EventInterceptor{rt.Pipeline}
-	}, payloadValidator, opts.TestLifecycleProbe)
+	}, payloadValidator, func(ctx context.Context, req runtimepipeline.FlowInstanceActivationRequest) error {
+		if managerRef == nil {
+			return fmt.Errorf("flow instance activator is required")
+		}
+		return managerRef.ActivateFlowInstance(ctx, req)
+	}, opts.TestLifecycleProbe)
 	if err != nil {
 		return nil, fmt.Errorf("build event bus: %w", err)
 	}
@@ -413,8 +419,6 @@ func NewRuntime(ctx context.Context, deps RuntimeDeps) (*Runtime, error) {
 		rt.RunControl = runtimeruncontrol.NewController(runControlStore, rt.Bus, runtimeruncontrol.Options{})
 		rt.Bus.SetRunDispatchGate(rt.RunControl)
 	}
-
-	var managerRef *runtimemanager.AgentManager
 	rt.Scheduler = runtimepipeline.NewScheduler(func(sc runtimepipeline.Schedule) {
 		callbackCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
 		defer cancel()

--- a/internal/runtime/template_instance_delivery_test.go
+++ b/internal/runtime/template_instance_delivery_test.go
@@ -317,6 +317,82 @@ func TestTemplateInstanceActivationConfigSubscriberPersistsRenderedRouteAndDeliv
 	`, 0, autoEventID)
 }
 
+func TestTemplateInstanceConnectLifecyclePublishRollbackDoesNotLeakInstanceOrRoute(t *testing.T) {
+	bundle := loadRuntimeTempBundle(t, templateInstanceConnectLifecycleRollbackFixtureFiles())
+	source := semanticview.Wrap(bundle)
+	_, db, cleanup := testutil.StartPostgres(t)
+	t.Cleanup(cleanup)
+	ctx := seedRuntimeTestRun(t, db)
+	pg := &store.PostgresStore{DB: db}
+	proofStore := &failingDeliveryRouteStore{PostgresStore: pg}
+	workflowStore := runtimepipeline.NewWorkflowInstanceStore(db)
+	var manager *runtimemanager.AgentManager
+	bus, err := runtimebus.NewEventBusWithOptions(proofStore, runtimebus.EventBusOptions{
+		ContractBundle: source,
+		TemplateInstanceActivator: func(ctx context.Context, req runtimepipeline.FlowInstanceActivationRequest) error {
+			if manager == nil {
+				return errors.New("agent manager is required")
+			}
+			return manager.ActivateFlowInstance(ctx, req)
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewEventBusWithOptions: %v", err)
+	}
+	manager = runtimemanager.NewAgentManagerWithOptions(bus, nil, runtimemanager.AgentManagerOptions{
+		WorkflowInstances: workflowStore,
+	})
+	proofStore.failDeliveryRoutes = true
+	evt := eventtest.RootIngress(
+		"99999999-9999-4999-8999-999999999940",
+		events.EventType("producer/deploy.done"),
+		"",
+		"",
+		[]byte(`{"vertical_id":"v-1"}`),
+		0,
+		templateInstanceDeliveryRunID,
+		"",
+		events.EventEnvelope{},
+		time.Now().UTC(),
+	)
+
+	err = bus.Publish(ctx, evt)
+	if err == nil || !strings.Contains(err.Error(), "injected delivery route persistence failure") {
+		t.Fatalf("Publish error = %v, want injected delivery route persistence failure", err)
+	}
+	if len(proofStore.descriptorsSeenDuringDelivery) != 1 {
+		t.Fatalf("descriptors seen during delivery failure = %#v, want one lifecycle-created descriptor", proofStore.descriptorsSeenDuringDelivery)
+	}
+	descriptor := proofStore.descriptorsSeenDuringDelivery[0]
+	if descriptor.FlowTemplate != "consumer" || descriptor.FlowInstance == "" {
+		t.Fatalf("descriptor seen during delivery failure = %#v, want consumer flow instance", descriptor)
+	}
+	if descriptor.AddressFields["entity.vertical_id"] != "v-1" {
+		t.Fatalf("descriptor address fields = %#v, want entity.vertical_id v-1", descriptor.AddressFields)
+	}
+
+	assertRuntimeDBCount(t, ctx, db, `
+		SELECT COUNT(*) FROM events
+		WHERE event_id = $1::uuid
+	`, 0, evt.ID())
+	assertRuntimeDBCount(t, ctx, db, `
+		SELECT COUNT(*) FROM event_deliveries
+		WHERE event_id = $1::uuid
+	`, 0, evt.ID())
+	assertRuntimeDBCount(t, ctx, db, `
+		SELECT COUNT(*) FROM flow_instances
+		WHERE instance_id = $1
+	`, 0, descriptor.FlowInstance)
+	assertRuntimeDBCount(t, ctx, db, `
+		SELECT COUNT(*) FROM entity_state
+		WHERE flow_instance = $1
+	`, 0, descriptor.FlowInstance)
+	assertRuntimeDBCount(t, ctx, db, `
+		SELECT COUNT(*) FROM routing_rules
+		WHERE flow_instance = $1
+	`, 0, descriptor.FlowInstance)
+}
+
 func TestTemplateInstanceAcknowledgedPublishDispatchesRoutedSystemNodeWithoutInternalCarrierAndEmpireStyleSideEffect(t *testing.T) {
 	bundle := loadRuntimeTempBundle(t, templateInstanceEmpireOutboxFixtureFiles())
 	source := semanticview.Wrap(bundle)
@@ -736,6 +812,142 @@ auto_emit_on_create:
   subscriptions: [opco.product_initialization_requested]
 `,
 	}
+}
+
+func templateInstanceConnectLifecycleRollbackFixtureFiles() map[string]string {
+	return map[string]string{
+		"package.yaml": `name: test
+version: "1.0.0"
+platform_version: ">=1.6.0"
+flows:
+  - id: producer
+    flow: producer
+    mode: static
+  - id: consumer
+    flow: consumer
+    mode: template
+connect:
+  - from: producer.deploy_done
+    to: consumer.deploy_completed
+    delivery: one
+  - from: producer.deploy_done
+    to: consumer.deploy_audited
+    delivery: one
+`,
+		"schema.yaml": "name: test\n",
+		"policy.yaml": "{}\n",
+		"tools.yaml":  "{}\n",
+		"agents.yaml": "{}\n",
+		"events.yaml": "{}\n",
+		"nodes.yaml":  "{}\n",
+		"flows/producer/schema.yaml": `name: producer
+mode: static
+pins:
+  outputs:
+    events:
+      - name: deploy_done
+        event: deploy.done
+        key: vertical_id
+        carries: [vertical_id]
+`,
+		"flows/producer/policy.yaml":   "{}\n",
+		"flows/producer/agents.yaml":   "{}\n",
+		"flows/producer/events.yaml":   "deploy.done:\n  vertical_id: string\n",
+		"flows/producer/entities.yaml": "{}\n",
+		"flows/producer/nodes.yaml":    "{}\n",
+		"flows/consumer/schema.yaml": `name: consumer
+mode: template
+instance:
+  by: vertical_id
+  on_missing: create
+  on_conflict: reuse
+pins:
+  inputs:
+    events:
+      - name: deploy_completed
+        event: deploy.done
+      - name: deploy_audited
+        event: deploy.done
+`,
+		"flows/consumer/policy.yaml": "{}\n",
+		"flows/consumer/agents.yaml": "{}\n",
+		"flows/consumer/events.yaml": "deploy.done:\n  vertical_id: string\n",
+		"flows/consumer/entities.yaml": `deployment:
+  vertical_id:
+    type: string
+`,
+		"flows/consumer/nodes.yaml": `consumer-node:
+  id: consumer-node-{instance_id}
+  execution_type: system_node
+  event_handlers:
+    deploy.done: {}
+`,
+	}
+}
+
+type failingDeliveryRouteStore struct {
+	*store.PostgresStore
+	failDeliveryRoutes            bool
+	descriptorsSeenDuringDelivery []runtimebus.ActiveFlowInstanceDescriptor
+}
+
+func (s *failingDeliveryRouteStore) RunEventMutation(ctx context.Context, fn func(runtimebus.EventMutation) error) error {
+	if s == nil || s.PostgresStore == nil {
+		return errors.New("postgres store is required")
+	}
+	return s.PostgresStore.RunEventMutation(ctx, func(mutation runtimebus.EventMutation) error {
+		return fn(&failingDeliveryRouteMutation{
+			EventMutation: mutation,
+			store:         s,
+		})
+	})
+}
+
+type failingDeliveryRouteMutation struct {
+	runtimebus.EventMutation
+	store *failingDeliveryRouteStore
+}
+
+func (m *failingDeliveryRouteMutation) InsertEventDeliveries(ctx context.Context, eventID string, agentIDs []string) error {
+	if err := m.captureDescriptorReadback(ctx); err != nil {
+		return err
+	}
+	if m.store.failDeliveryRoutes {
+		return errors.New("injected delivery route persistence failure")
+	}
+	return m.EventMutation.InsertEventDeliveries(ctx, eventID, agentIDs)
+}
+
+func (m *failingDeliveryRouteMutation) InsertEventDeliveriesWithTargets(ctx context.Context, eventID string, agentIDs []string, deliveryTargets map[string]events.RouteIdentity) error {
+	if err := m.captureDescriptorReadback(ctx); err != nil {
+		return err
+	}
+	if m.store.failDeliveryRoutes {
+		return errors.New("injected delivery route persistence failure")
+	}
+	return m.EventMutation.InsertEventDeliveriesWithTargets(ctx, eventID, agentIDs, deliveryTargets)
+}
+
+func (m *failingDeliveryRouteMutation) InsertEventDeliveryRoutes(ctx context.Context, eventID string, routes []events.DeliveryRoute) error {
+	if err := m.captureDescriptorReadback(ctx); err != nil {
+		return err
+	}
+	if m.store.failDeliveryRoutes {
+		return errors.New("injected delivery route persistence failure")
+	}
+	return m.EventMutation.InsertEventDeliveryRoutes(ctx, eventID, routes)
+}
+
+func (m *failingDeliveryRouteMutation) captureDescriptorReadback(ctx context.Context) error {
+	if m == nil || m.store == nil {
+		return errors.New("delivery route mutation store is required")
+	}
+	descriptors, err := m.store.ListActiveFlowInstanceDescriptors(ctx)
+	if err != nil {
+		return err
+	}
+	m.store.descriptorsSeenDuringDelivery = descriptors
+	return nil
 }
 
 type routeMaterializationDBProofStore struct {

--- a/internal/runtime/template_instance_delivery_test.go
+++ b/internal/runtime/template_instance_delivery_test.go
@@ -391,6 +391,10 @@ func TestTemplateInstanceConnectLifecyclePublishRollbackDoesNotLeakInstanceOrRou
 		SELECT COUNT(*) FROM routing_rules
 		WHERE flow_instance = $1
 	`, 0, descriptor.FlowInstance)
+	route := runtimeflowidentity.StoredRoute("", "", descriptor.FlowInstance)
+	if got := bus.RouteTable().MaterializedRoutes(route); len(got) != 0 {
+		t.Fatalf("route table materialized routes after rollback = %#v, want none", got)
+	}
 }
 
 func TestTemplateInstanceAcknowledgedPublishDispatchesRoutedSystemNodeWithoutInternalCarrierAndEmpireStyleSideEffect(t *testing.T) {

--- a/internal/store/flow_instance_routes.go
+++ b/internal/store/flow_instance_routes.go
@@ -19,10 +19,23 @@ type flowInstanceDescriptorQueryer interface {
 	QueryContext(ctx context.Context, query string, args ...any) (*sql.Rows, error)
 }
 
+type flowInstanceRouteExecutor interface {
+	ExecContext(ctx context.Context, query string, args ...any) (sql.Result, error)
+	QueryRowContext(ctx context.Context, query string, args ...any) *sql.Row
+}
+
+func flowInstanceRouteExecutorFromContext(ctx context.Context, db *sql.DB) flowInstanceRouteExecutor {
+	if tx, ok := runtimepipeline.PipelineSQLTxFromContext(ctx); ok && tx != nil {
+		return tx
+	}
+	return db
+}
+
 func (s *PostgresStore) UpsertFlowInstanceRoute(ctx context.Context, route runtimebus.FlowInstanceRouteRecord) error {
 	if s == nil || s.DB == nil {
 		return fmt.Errorf("postgres store is required for flow instance routes")
 	}
+	exec := flowInstanceRouteExecutorFromContext(ctx, s.DB)
 	route.Identity = runtimeflowidentity.StoredRoute(route.Identity.ScopeKey, route.Identity.InstanceID, route.Identity.InstancePath)
 	if !route.Identity.Valid() {
 		return fmt.Errorf("scope_key, instance_id, and instance_path are required")
@@ -33,7 +46,7 @@ func (s *PostgresStore) UpsertFlowInstanceRoute(ctx context.Context, route runti
 	}
 	var materializedFrom any
 	if strings.TrimSpace(route.EventPattern) != "" && strings.TrimSpace(route.SubscriberType) != "" && strings.TrimSpace(route.SubscriberID) != "" {
-		_ = s.DB.QueryRowContext(ctx, `
+		_ = exec.QueryRowContext(ctx, `
 			SELECT rule_id
 			FROM routing_rules
 			WHERE event_pattern = $1
@@ -47,7 +60,7 @@ func (s *PostgresStore) UpsertFlowInstanceRoute(ctx context.Context, route runti
 				LIMIT 1
 			`, route.EventPattern, route.SubscriberType, route.SubscriberID, sourceFlow).Scan(&materializedFrom)
 	}
-	_, err := s.DB.ExecContext(ctx, `
+	_, err := exec.ExecContext(ctx, `
 		WITH updated AS (
 			UPDATE routing_rules
 			SET source_flow = NULLIF($5,''),
@@ -95,12 +108,13 @@ func (s *PostgresStore) DeleteFlowInstanceRoute(ctx context.Context, identity ru
 	if s == nil || s.DB == nil {
 		return fmt.Errorf("postgres store is required for flow instance routes")
 	}
+	exec := flowInstanceRouteExecutorFromContext(ctx, s.DB)
 	identity = runtimeflowidentity.StoredRoute(identity.ScopeKey, identity.InstanceID, identity.InstancePath)
 	if !identity.Valid() {
 		return fmt.Errorf("scope_key, instance_id, and instance_path are required")
 	}
 	var status string
-	err := s.DB.QueryRowContext(ctx, `
+	err := exec.QueryRowContext(ctx, `
 		SELECT status
 		FROM flow_instances
 		WHERE instance_id = $1
@@ -114,7 +128,7 @@ func (s *PostgresStore) DeleteFlowInstanceRoute(ctx context.Context, identity ru
 	if strings.TrimSpace(status) != "terminated" {
 		return fmt.Errorf("flow instance route removal requires terminal flow_instances status for %s", identity.InstancePath)
 	}
-	if _, err := s.DB.ExecContext(ctx, `
+	if _, err := exec.ExecContext(ctx, `
 			UPDATE routing_rules
 			SET status = 'inactive'
 			WHERE flow_instance = $1
@@ -130,11 +144,12 @@ func (s *PostgresStore) RollbackFlowInstanceRoute(ctx context.Context, identity 
 	if s == nil || s.DB == nil {
 		return fmt.Errorf("postgres store is required for flow instance routes")
 	}
+	exec := flowInstanceRouteExecutorFromContext(ctx, s.DB)
 	identity = runtimeflowidentity.StoredRoute(identity.ScopeKey, identity.InstanceID, identity.InstancePath)
 	if !identity.Valid() {
 		return fmt.Errorf("scope_key, instance_id, and instance_path are required")
 	}
-	if _, err := s.DB.ExecContext(ctx, `
+	if _, err := exec.ExecContext(ctx, `
 			UPDATE routing_rules
 			SET status = 'inactive'
 			WHERE flow_instance = $1
@@ -150,7 +165,11 @@ func (s *PostgresStore) ListFlowInstanceRoutes(ctx context.Context) ([]runtimefl
 	if s == nil || s.DB == nil {
 		return nil, fmt.Errorf("postgres store is required for flow instance routes")
 	}
-	rows, err := s.DB.QueryContext(ctx, `
+	q := flowInstanceDescriptorQueryer(s.DB)
+	if tx, ok := runtimepipeline.PipelineSQLTxFromContext(ctx); ok && tx != nil {
+		q = tx
+	}
+	rows, err := q.QueryContext(ctx, `
 			SELECT
 				COALESCE(NULLIF(source_flow, ''), ''),
 				flow_instance

--- a/internal/store/flow_instance_routes_test.go
+++ b/internal/store/flow_instance_routes_test.go
@@ -111,6 +111,180 @@ func TestPostgresStoreFlowInstanceRoutes(t *testing.T) {
 	}
 }
 
+func TestPostgresStoreUpsertFlowInstanceRouteUsesPipelineTransaction(t *testing.T) {
+	ctx := context.Background()
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &PostgresStore{DB: db}
+	ensureFlowInstanceRouteTables(t, ctx, db)
+
+	route := runtimebus.FlowInstanceRouteRecord{
+		Identity:       runtimeflowidentity.DeriveRoute("review", "inst-1"),
+		EventPattern:   "review/inst-1/task.started",
+		SubscriberType: "node",
+		SubscriberID:   "reviewer-inst-1",
+		SourceFlow:     "review",
+	}
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		t.Fatalf("BeginTx: %v", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	if _, err := tx.ExecContext(ctx, `
+		INSERT INTO flow_instances (instance_id, flow_template, mode, config, status, created_at)
+		VALUES ($1, 'review', 'template', '{}'::jsonb, 'active', NOW())
+	`, route.Identity.InstancePath); err != nil {
+		t.Fatalf("seed flow_instances in tx: %v", err)
+	}
+	txctx := runtimepipeline.WithPipelineSQLTxContext(ctx, tx)
+	if err := pg.UpsertFlowInstanceRoute(txctx, route); err != nil {
+		t.Fatalf("UpsertFlowInstanceRoute in tx: %v", err)
+	}
+	var inTx int
+	if err := tx.QueryRowContext(ctx, `
+		SELECT COUNT(*)
+		FROM routing_rules
+		WHERE flow_instance = $1
+		  AND is_materialized = true
+		  AND status = 'active'
+	`, route.Identity.InstancePath).Scan(&inTx); err != nil {
+		t.Fatalf("count routing_rules in tx: %v", err)
+	}
+	if inTx != 1 {
+		t.Fatalf("routing_rules in tx = %d, want 1", inTx)
+	}
+	if err := tx.Rollback(); err != nil {
+		t.Fatalf("Rollback: %v", err)
+	}
+	var leaked int
+	if err := db.QueryRowContext(ctx, `
+		SELECT COUNT(*)
+		FROM routing_rules
+		WHERE flow_instance = $1
+		  AND is_materialized = true
+	`, route.Identity.InstancePath).Scan(&leaked); err != nil {
+		t.Fatalf("count routing_rules after rollback: %v", err)
+	}
+	if leaked != 0 {
+		t.Fatalf("routing_rules leaked after rollback = %d, want 0", leaked)
+	}
+}
+
+func TestPostgresStoreDeleteFlowInstanceRouteUsesPipelineTransaction(t *testing.T) {
+	ctx := context.Background()
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &PostgresStore{DB: db}
+	ensureFlowInstanceRouteTables(t, ctx, db)
+
+	route := runtimebus.FlowInstanceRouteRecord{
+		Identity:       runtimeflowidentity.DeriveRoute("review", "inst-1"),
+		EventPattern:   "review/inst-1/task.started",
+		SubscriberType: "node",
+		SubscriberID:   "reviewer-inst-1",
+		SourceFlow:     "review",
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO flow_instances (instance_id, flow_template, mode, config, status, terminated_at, created_at)
+		VALUES ($1, 'review', 'template', '{}'::jsonb, 'terminated', NOW(), NOW())
+	`, route.Identity.InstancePath); err != nil {
+		t.Fatalf("seed flow_instances: %v", err)
+	}
+	if err := pg.UpsertFlowInstanceRoute(ctx, route); err != nil {
+		t.Fatalf("UpsertFlowInstanceRoute: %v", err)
+	}
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		t.Fatalf("BeginTx: %v", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	txctx := runtimepipeline.WithPipelineSQLTxContext(ctx, tx)
+	if err := pg.DeleteFlowInstanceRoute(txctx, route.Identity); err != nil {
+		t.Fatalf("DeleteFlowInstanceRoute in tx: %v", err)
+	}
+	var inTxStatus string
+	if err := tx.QueryRowContext(ctx, `
+		SELECT status
+		FROM routing_rules
+		WHERE flow_instance = $1
+	`, route.Identity.InstancePath).Scan(&inTxStatus); err != nil {
+		t.Fatalf("query routing_rules in tx: %v", err)
+	}
+	if strings.TrimSpace(inTxStatus) != "inactive" {
+		t.Fatalf("routing_rules status in tx = %q, want inactive", inTxStatus)
+	}
+	if err := tx.Rollback(); err != nil {
+		t.Fatalf("Rollback: %v", err)
+	}
+	var status string
+	if err := db.QueryRowContext(ctx, `
+		SELECT status
+		FROM routing_rules
+		WHERE flow_instance = $1
+	`, route.Identity.InstancePath).Scan(&status); err != nil {
+		t.Fatalf("query routing_rules after rollback: %v", err)
+	}
+	if strings.TrimSpace(status) != "active" {
+		t.Fatalf("routing_rules status after rollback = %q, want active", status)
+	}
+}
+
+func TestPostgresStoreRollbackFlowInstanceRouteUsesPipelineTransaction(t *testing.T) {
+	ctx := context.Background()
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &PostgresStore{DB: db}
+	ensureFlowInstanceRouteTables(t, ctx, db)
+
+	route := runtimebus.FlowInstanceRouteRecord{
+		Identity:       runtimeflowidentity.DeriveRoute("review", "inst-1"),
+		EventPattern:   "review/inst-1/task.started",
+		SubscriberType: "node",
+		SubscriberID:   "reviewer-inst-1",
+		SourceFlow:     "review",
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO flow_instances (instance_id, flow_template, mode, config, status, created_at)
+		VALUES ($1, 'review', 'template', '{}'::jsonb, 'active', NOW())
+	`, route.Identity.InstancePath); err != nil {
+		t.Fatalf("seed flow_instances: %v", err)
+	}
+	if err := pg.UpsertFlowInstanceRoute(ctx, route); err != nil {
+		t.Fatalf("UpsertFlowInstanceRoute: %v", err)
+	}
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		t.Fatalf("BeginTx: %v", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	txctx := runtimepipeline.WithPipelineSQLTxContext(ctx, tx)
+	if err := pg.RollbackFlowInstanceRoute(txctx, route.Identity); err != nil {
+		t.Fatalf("RollbackFlowInstanceRoute in tx: %v", err)
+	}
+	var inTxStatus string
+	if err := tx.QueryRowContext(ctx, `
+		SELECT status
+		FROM routing_rules
+		WHERE flow_instance = $1
+	`, route.Identity.InstancePath).Scan(&inTxStatus); err != nil {
+		t.Fatalf("query routing_rules in tx: %v", err)
+	}
+	if strings.TrimSpace(inTxStatus) != "inactive" {
+		t.Fatalf("routing_rules status in tx = %q, want inactive", inTxStatus)
+	}
+	if err := tx.Rollback(); err != nil {
+		t.Fatalf("Rollback: %v", err)
+	}
+	var status string
+	if err := db.QueryRowContext(ctx, `
+		SELECT status
+		FROM routing_rules
+		WHERE flow_instance = $1
+	`, route.Identity.InstancePath).Scan(&status); err != nil {
+		t.Fatalf("query routing_rules after rollback: %v", err)
+	}
+	if strings.TrimSpace(status) != "active" {
+		t.Fatalf("routing_rules status after rollback = %q, want active", status)
+	}
+}
+
 func TestPostgresStoreFlowInstanceRoutes_NestedTemplateScope(t *testing.T) {
 	ctx := context.Background()
 	_, db, _ := testutil.StartPostgres(t)

--- a/internal/store/runtime_mutation.go
+++ b/internal/store/runtime_mutation.go
@@ -52,13 +52,17 @@ func (s *PostgresStore) RunEventTransaction(ctx context.Context, fn func(context
 		return err
 	}
 	postCommit := make([]func(), 0, 4)
+	rollbackActions := make([]func(), 0, 4)
 	txctx := runtimepipeline.WithPipelineSQLTxContext(ctx, tx)
 	txctx = runtimepipeline.WithPipelinePostCommitActions(txctx, &postCommit)
+	txctx = runtimepipeline.WithPipelineRollbackActions(txctx, &rollbackActions)
 	if err := fn(txctx, tx); err != nil {
 		_ = tx.Rollback()
+		runtimepipeline.FlushPipelineRollbackActions(rollbackActions)
 		return err
 	}
 	if err := tx.Commit(); err != nil {
+		runtimepipeline.FlushPipelineRollbackActions(rollbackActions)
 		return err
 	}
 	runtimepipeline.FlushPipelinePostCommitActions(postCommit)
@@ -157,13 +161,17 @@ func (s *SQLiteRuntimeStore) runRuntimeMutationOnceLocked(ctx context.Context, f
 		return nil, err
 	}
 	postCommit := make([]func(), 0, 4)
+	rollbackActions := make([]func(), 0, 4)
 	txctx := runtimepipeline.WithPipelineSQLTxContext(ctx, tx)
 	txctx = runtimepipeline.WithPipelinePostCommitActions(txctx, &postCommit)
+	txctx = runtimepipeline.WithPipelineRollbackActions(txctx, &rollbackActions)
 	if err := fn(txctx, tx); err != nil {
 		_ = tx.Rollback()
+		runtimepipeline.FlushPipelineRollbackActions(rollbackActions)
 		return nil, err
 	}
 	if err := tx.Commit(); err != nil {
+		runtimepipeline.FlushPipelineRollbackActions(rollbackActions)
 		return nil, err
 	}
 	return postCommit, nil

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -5265,6 +5265,27 @@ flow_model:
         `on_missing` is required and MUST be `create` or `reject`. `on_conflict`
         is required and MUST be `reject` or `reuse`. Missing or unsupported
         policy values fail closed during verification.
+      connect_time_lifecycle_rule: >
+        For normal parent `connect` into an addressless template receiver, the
+        runtime owner is the EventBus connect-time template instance lifecycle
+        decision. That owner consumes
+        WorkflowContractBundle.ResolveFlowTemplateInstance, ordered
+        TemplateInstanceContract.CanonicalKeyMaterial, the lowered
+        ConnectRoutePlan.InstanceKey including #1546 adapter mappings, and the
+        producer output key/carries evidence. If the receiver policy is
+        `on_missing: create`, the owner derives a deterministic instance id from
+        receiver flow id plus ordered key material, seeds the receiver primary
+        entity/config with those key fields, and invokes the configured flow
+        instance activator before delivery routes are committed. If
+        `on_missing: reject`, missing instances fail closed. If create is
+        enabled and an exact matching active descriptor already exists,
+        `on_conflict: reuse` routes to that exact instance and `on_conflict:
+        reject` fails closed as `route_plan_instance_conflict`; ambiguous
+        matches always fail closed. Preflight may only preview the deterministic
+        route when the real lifecycle activator is configured and MUST NOT
+        persist lifecycle state. Publish-time creation, route installation,
+        event row, delivery rows, and committed replay scope share the active
+        publish mutation boundary when the store provides one.
       non_authoritative_paths: >
         Flow input-pin `address`, receiver `select_entity` /
         `select_or_create_entity`, producer `target`, producer `broadcast:true`,
@@ -5319,6 +5340,7 @@ flow_model:
         output_pin_key_carries: '#1544'
         connect_to_instance_route_planning: '#1545'
         connect_key_adapters: '#1546'
+        connect_time_template_lifecycle: '#1577'
       connect_to_instance_route_planning:
         status: merge_bearing_runtime_behavior
         implementation_tracker: '#1545'
@@ -5976,6 +5998,42 @@ flow_model:
             - recovery or retry work
             - agent/node delivery parity
             - producer target/broadcast retirement
+        implementation_slice_1577:
+          status: merge_bearing_runtime_behavior
+          canonical_code_owner: internal/runtime/bus.TemplateInstanceLifecycleDecision + internal/runtime/bus.templateInstanceLifecycleOwner
+          rule: |
+            `on_missing` and `on_conflict` on addressless template receivers are
+            consumed by the connect-time template lifecycle owner, not by
+            descriptor lookup alone. The owner first derives ordered key
+            material with TemplateInstanceContract.CanonicalKeyMaterial from
+            ConnectRoutePlan.InstanceKey and producer key/carries evidence. It
+            then selects exactly one receiver-scoped active descriptor, creates
+            one deterministic receiver flow instance, or fails closed.
+
+            Created instance identity is deterministic: receiver semantic flow
+            id plus ordered field/value key material is hashed into the stored
+            template instance id. The created flow instance persists the key
+            fields as receiver primary-entity fields and config variables, with
+            entity_type, instance_kind, last_source_event, and parent-route
+            control metadata carried by activation. Route installation must use
+            the same activation context so stores that expose a publish mutation
+            persist the instance row, entity_state row, route row, event row,
+            delivery rows, and committed replay scope in one semantic mutation.
+
+            `on_missing: reject` means no create attempt and no lower-precedence
+            rescue. `on_missing: create` with `on_conflict: reuse` reuses the
+            exact existing matching receiver instance and treats duplicate
+            retry of the same key decision as reuse after the descriptor exists.
+            `on_missing: create` with `on_conflict: reject` rejects an exact
+            pre-existing match as `route_plan_instance_conflict`; event-id and
+            store idempotency remain responsible for retrying the same already
+            committed publish. Ambiguous matches, non-matching descriptors,
+            missing activator, missing key values, missing receiver carrier,
+            unsupported adapter evidence, delivery rows, replay/readback rows,
+            RouteTable lookup before selected identity, live subscribers,
+            handler lookup, direct delivery, producer target, producer
+            broadcast:true, receiver select_entity/select_or_create_entity, and
+            explicit create_flow_instance are not lifecycle authority.
         implementation_slice_1546:
           status: merge_bearing_runtime_behavior
           canonical_code_owner: internal/runtime/core/pinrouting.ConnectRoutePlan.InstanceKey.Mappings + internal/runtime/bus.connectRoutePlanResolver


### PR DESCRIPTION
## Summary
- Adds the connect-time template instance lifecycle owner for normal parent `connect` into addressless `mode: template` receivers using `instance.by`, `on_missing`, and `on_conflict`.
- Defines #1577 lifecycle semantics in `platform-spec.yaml`, including deterministic instance identity, key-field seeding, conflict/reuse behavior, preflight preview, and mutation-boundary expectations.
- Adds runtime proof for create, reject, reuse, renamed-key adapter routes, duplicate retry/idempotency, lower-precedence rescue rejection, persisted replay after lifecycle creation, and route-authority inventory classification.

Closes #1577

## Governing Context
- `platform-spec.yaml#flow_model.flow_instance_authoring.template_instance_model`
- `platform-spec.yaml#flow_model.flow_instance_authoring.composition_model.connect_to_instance_route_planning`
- `platform-spec.yaml#flow_model.flow_package.composition_routing.route_plan_lowering`
- Issue #1577 body, approved pre-implementation gate, and locked discussion #1476.
- Requested `docs/IMPLEMENTER_GUIDELINES.md` and `docs/SEMANTIC_DRIFT.md` are not present in this worktree; the issue/thread/spec gate were used as binding context.

## Semantic Migration
New canonical owner: `internal/runtime/bus.TemplateInstanceLifecycleDecision` plus `templateInstanceLifecycleOwner`, consumed by `connectRoutePlanResolver` before delivery routes are committed.

Old non-authoritative paths now invalid for normal parent-connect template lifecycle: descriptor lookup alone as a complete implementation, delivery/replay rows, RouteTable lookup before selected identity, live subscribers, handler lookup, producer `target`, `broadcast:true`, direct delivery, receiver `select_entity` / `select_or_create_entity`, and explicit `create_flow_instance`.

Production paths checked: pinrouting lowering/materialization, EventBus preflight/publish, flow activation, workflow instance metadata/config seeding, route persistence, delivery persistence, committed replay, route-authority inventory guard, and #1546 renamed-key mappings.

Migration complete for the #1577 chosen class. Parent #1537 remains open for downstream tooling, pilots, migration policy, and final fixture work.

## Validation
- `python3` YAML parse of `platform-spec.yaml`
- `go test ./internal/runtime/core/pinrouting ./internal/runtime/bus ./internal/runtime/manager ./internal/runtime ./internal/runtime/contracts ./internal/runtime/pipeline -run 'TemplateInstance|ConnectRoutePlan|FlowInstance|Lifecycle|select' -count=1`
- `go test ./internal/runtime/conformance -run 'RouteAuthorityDriftInventory|RouteAuthorityMatrix' -count=1`
- Post-rebase focused proof: `go test ./internal/runtime/core/pinrouting ./internal/runtime/bus ./internal/runtime/manager ./internal/runtime ./internal/runtime/contracts ./internal/runtime/pipeline ./internal/runtime/conformance -run 'TemplateInstance|ConnectRoutePlan|FlowInstance|Lifecycle|select|RouteAuthorityDriftInventory|RouteAuthorityMatrix' -count=1`
- Post-rebase full suite: `go test ./...`