### PR TITLE
[agent-b][issue #1568] Add local tool gateway binding

### DIFF
--- a/cmd/swarm/doctor_test.go
+++ b/cmd/swarm/doctor_test.go
@@ -232,7 +232,7 @@ func TestDoctorClaudeCLIPreflightReportsRetiredBackendEnv(t *testing.T) {
 	}
 }
 
-func TestDoctorClaudeCLIPreflightReportsStaleGatewayEnv(t *testing.T) {
+func TestDoctorClaudeCLIPreflightWarnsOnStaleGatewayEnv(t *testing.T) {
 	configureDoctorDockerStub(t)
 	t.Setenv("CLAUDE_CODE_OAUTH_TOKEN", "oauth-token")
 	t.Setenv("SWARM_TOOL_GATEWAY_TOKEN", "operator-token")
@@ -249,11 +249,14 @@ func TestDoctorClaudeCLIPreflightReportsStaleGatewayEnv(t *testing.T) {
 	args = append(args[:len(args)-4], "--api-listen-addr", "127.0.0.1:0", "--mcp-listen-addr", "127.0.0.1:"+mcpPort)
 	var stdout, stderr bytes.Buffer
 	code := executeRootCommandWithOptions(context.Background(), repoRoot(), args, &stdout, &stderr, defaultRootCommandOptions())
-	if code != cliExitRuntime {
-		t.Fatalf("code = %d, want %d stdout=%s stderr=%s", code, cliExitRuntime, stdout.String(), stderr.String())
+	if code != cliExitOK {
+		t.Fatalf("code = %d, want %d stdout=%s stderr=%s", code, cliExitOK, stdout.String(), stderr.String())
 	}
-	if !strings.Contains(stdout.String(), "gateway_prerequisite/swarm_tool_gateway_url_stale") || !strings.Contains(stdout.String(), "must target the MCP listener port "+mcpPort) {
+	if !strings.Contains(stdout.String(), "[WARNING] gateway_prerequisite/swarm_tool_gateway_url_stale") || !strings.Contains(stdout.String(), "must target the MCP listener port "+mcpPort) {
 		t.Fatalf("stale gateway env not reported:\n%s", stdout.String())
+	}
+	if !strings.Contains(stdout.String(), "local serve/run derives the gateway binding from the bound MCP listener and ignores this URL") {
+		t.Fatalf("stale gateway env remediation missing binding authority:\n%s", stdout.String())
 	}
 }
 

--- a/cmd/swarm/local_preflight.go
+++ b/cmd/swarm/local_preflight.go
@@ -226,9 +226,15 @@ func (r *localPreflightReport) checkGatewayEnv(mcpListenAddr string) {
 	}
 	for _, name := range []string{"SWARM_TOOL_GATEWAY_URL", "SWARM_TOOL_GATEWAY_CONTAINER_URL"} {
 		if err := validateExistingServeGatewayURL(name, lookupEnvValue(name), addr); err != nil {
-			r.add(localPreflightGatewayPrerequisite, strings.ToLower(name)+"_stale", localPreflightSeverityBlocker, localPreflightStatusFailed, err.Error(), fmt.Sprintf("unset %s or point it at the selected MCP listener port", name))
+			severity := localPreflightSeverityWarning
+			remediation := fmt.Sprintf("unset %s; local serve/run derives the gateway binding from the bound MCP listener and ignores this URL", name)
+			if r.Mode == "serve" {
+				severity = localPreflightSeverityBlocker
+				remediation = fmt.Sprintf("unset %s or point it at the selected MCP listener port; public URL-env retirement remains split", name)
+			}
+			r.add(localPreflightGatewayPrerequisite, strings.ToLower(name)+"_stale", severity, localPreflightStatusFailed, err.Error(), remediation)
 		} else {
-			r.add(localPreflightGatewayPrerequisite, strings.ToLower(name)+"_valid", localPreflightSeverityInfo, localPreflightStatusOK, fmt.Sprintf("%s is empty or targets the selected MCP listener", name), "")
+			r.add(localPreflightGatewayPrerequisite, strings.ToLower(name)+"_shadowed_or_empty", localPreflightSeverityInfo, localPreflightStatusOK, fmt.Sprintf("%s is empty or non-authoritative for local gateway binding", name), "")
 		}
 	}
 }

--- a/cmd/swarm/main.go
+++ b/cmd/swarm/main.go
@@ -52,6 +52,7 @@ import (
 	"github.com/division-sh/swarm/internal/runtime/sessions"
 	runtimestartupownership "github.com/division-sh/swarm/internal/runtime/startupownership"
 	runtimestartuprecovery "github.com/division-sh/swarm/internal/runtime/startuprecovery"
+	"github.com/division-sh/swarm/internal/runtime/toolgateway"
 	runtimetools "github.com/division-sh/swarm/internal/runtime/tools"
 	workspace "github.com/division-sh/swarm/internal/runtime/workspace"
 	"github.com/division-sh/swarm/internal/store"
@@ -117,11 +118,6 @@ func (s serveStartupRecoveryContainers) StopManagedContainer(ctx context.Context
 		return fmt.Errorf("workspace lifecycle is not configured")
 	}
 	return s.lifecycle.StopManagedContainer(ctx, name)
-}
-
-type previousEnv struct {
-	value string
-	set   bool
 }
 
 type storeBundle struct {
@@ -392,6 +388,7 @@ type serveRuntimeBundleContextRequest struct {
 	BootStartedAt          time.Time
 	BootProgress           func(runtime.BootProgressEvent)
 	EnableToolGateway      bool
+	ToolGatewayBinding     toolgateway.Binding
 	UseStartupOwnership    bool
 	UseStartupRecovery     bool
 	RequireBundleScopeName bool
@@ -698,7 +695,8 @@ func buildServeRuntimeBundleContext(req serveRuntimeBundleContextRequest) (serve
 			WorkflowModule:                   loaded.module,
 			WorkspaceLifecycle:               workspaces,
 			EnableToolGateway:                req.EnableToolGateway,
-			ToolGatewayToken:                 strings.TrimSpace(os.Getenv("SWARM_TOOL_GATEWAY_TOKEN")),
+			ToolGatewayToken:                 req.ToolGatewayBinding.AuthToken(),
+			ToolGatewayBinding:               req.ToolGatewayBinding,
 			BundleFingerprint:                bootIdentity.Fingerprint,
 			BundleSourceFact:                 bundleSourceFact,
 			Credentials:                      req.Credentials,
@@ -919,8 +917,46 @@ func runServeRuntime(ctx context.Context, repo string, opts serveOptions) int {
 		slog.Error("configure credentials", "error", err)
 		return 1
 	}
+
+	apiListener, err := listenServeHTTPListener("api", opts.APIListenAddr)
+	if err != nil {
+		reporter.emit(20, "http_listener_bind", "FAILED", err.Error())
+		log.Printf("bind api listener: %v", err)
+		return 3
+	}
+	defer apiListener.Close()
+	mcpListener, err := listenServeHTTPListener("mcp", opts.MCPListenAddr)
+	if err != nil {
+		_ = apiListener.Close()
+		reporter.emit(20, "http_listener_bind", "FAILED", err.Error())
+		log.Printf("bind mcp listener: %v", err)
+		return 3
+	}
+	defer mcpListener.Close()
+	toolGatewayBinding, err := createServeToolGatewayBinding(mcpListener.Addr())
+	if err != nil {
+		_ = mcpListener.Close()
+		_ = apiListener.Close()
+		reporter.emit(20, "http_listener_bind", "FAILED", err.Error())
+		log.Printf("configure mcp gateway binding: %v", err)
+		return 3
+	}
+	if !opts.Dev && !opts.LocalRun {
+		if err := validateServeGatewayURLEnvForNonDev(mcpListener.Addr()); err != nil {
+			_ = mcpListener.Close()
+			_ = apiListener.Close()
+			reporter.emit(20, "http_listener_bind", "FAILED", err.Error())
+			log.Printf("validate non-dev mcp gateway env: %v", err)
+			return 3
+		}
+	}
+
 	runtimeContexts := make([]serveRuntimeBundleContext, 0, len(loadedBundles))
 	for i, loaded := range loadedBundles {
+		contextToolGatewayBinding := toolgateway.Binding{}
+		if i == 0 {
+			contextToolGatewayBinding = toolGatewayBinding
+		}
 		contextDef, err := buildServeRuntimeBundleContext(serveRuntimeBundleContextRequest{
 			Ctx:                    ctx,
 			Stores:                 stores,
@@ -934,6 +970,7 @@ func runServeRuntime(ctx context.Context, repo string, opts serveOptions) int {
 			BootStartedAt:          bootStartedAt,
 			BootProgress:           reporter.runtimeSink(),
 			EnableToolGateway:      i == 0,
+			ToolGatewayBinding:     contextToolGatewayBinding,
 			UseStartupOwnership:    len(loadedBundles) == 1 && i == 0,
 			UseStartupRecovery:     len(loadedBundles) == 1,
 			RequireBundleScopeName: len(loadedBundles) > 1,
@@ -954,31 +991,6 @@ func runServeRuntime(ctx context.Context, repo string, opts serveOptions) int {
 	rt := primaryContext.runtime
 	bootReport := primaryContext.validation.BootReport
 	stateStoreSummary := serveRuntimeStateStoreSummary(runtimeContexts)
-
-	apiListener, err := listenServeHTTPListener("api", opts.APIListenAddr)
-	if err != nil {
-		reporter.emit(20, "http_listener_bind", "FAILED", err.Error())
-		log.Printf("bind api listener: %v", err)
-		return 3
-	}
-	defer apiListener.Close()
-	mcpListener, err := listenServeHTTPListener("mcp", opts.MCPListenAddr)
-	if err != nil {
-		_ = apiListener.Close()
-		reporter.emit(20, "http_listener_bind", "FAILED", err.Error())
-		log.Printf("bind mcp listener: %v", err)
-		return 3
-	}
-	defer mcpListener.Close()
-	restoreGatewayEnv, err := configureServeMCPGatewayEnv(mcpListener.Addr())
-	if err != nil {
-		_ = mcpListener.Close()
-		_ = apiListener.Close()
-		reporter.emit(20, "http_listener_bind", "FAILED", err.Error())
-		log.Printf("configure mcp gateway env: %v", err)
-		return 3
-	}
-	defer restoreGatewayEnv()
 
 	forkChatLLM, err := buildForkChatSandboxLLMRuntime(cfg, workspaces)
 	if err != nil {
@@ -3142,36 +3154,37 @@ func addrString(addr net.Addr) string {
 	return addr.String()
 }
 
-func configureServeMCPGatewayEnv(mcpAddr net.Addr) (func(), error) {
+func createServeToolGatewayBinding(mcpAddr net.Addr) (toolgateway.Binding, error) {
 	if mcpAddr == nil {
-		return func() {}, errors.New("mcp listener address is unavailable")
+		return toolgateway.Binding{}, errors.New("mcp listener address is unavailable")
 	}
 	mcpHostURL, err := serveListenerHTTPURL(mcpAddr, "127.0.0.1")
 	if err != nil {
-		return func() {}, err
+		return toolgateway.Binding{}, err
 	}
 	mcpContainerURL, err := serveMCPContainerGatewayURL(mcpAddr)
 	if err != nil {
-		return func() {}, err
-	}
-	if err := validateExistingServeGatewayURL("SWARM_TOOL_GATEWAY_URL", os.Getenv("SWARM_TOOL_GATEWAY_URL"), mcpAddr); err != nil {
-		return func() {}, err
-	}
-	if err := validateExistingServeGatewayURL("SWARM_TOOL_GATEWAY_CONTAINER_URL", os.Getenv("SWARM_TOOL_GATEWAY_CONTAINER_URL"), mcpAddr); err != nil {
-		return func() {}, err
+		return toolgateway.Binding{}, err
 	}
 	gatewayToken := strings.TrimSpace(os.Getenv("SWARM_TOOL_GATEWAY_TOKEN"))
 	if gatewayToken == "" {
 		gatewayToken, err = generateServeMCPGatewayToken()
 		if err != nil {
-			return func() {}, err
+			return toolgateway.Binding{}, err
 		}
 	}
-	return setServeGatewayEnv(map[string]string{
-		"SWARM_TOOL_GATEWAY_URL":           mcpHostURL,
-		"SWARM_TOOL_GATEWAY_CONTAINER_URL": mcpContainerURL,
-		"SWARM_TOOL_GATEWAY_TOKEN":         gatewayToken,
-	})
+	binding := toolgateway.Binding{
+		Transport:         toolgateway.TransportHTTP,
+		HostEndpoint:      mcpHostURL,
+		WorkspaceEndpoint: mcpContainerURL,
+		Token:             gatewayToken,
+		LifecycleOwner:    toolgateway.LifecycleOwnerServeBoot,
+		Source:            toolgateway.SourceBoundMCPListener,
+	}
+	if err := binding.Validate(); err != nil {
+		return toolgateway.Binding{}, err
+	}
+	return binding, nil
 }
 
 func generateServeMCPGatewayToken() (string, error) {
@@ -3201,29 +3214,14 @@ func validateExistingServeGatewayURL(name, raw string, mcpAddr net.Addr) error {
 	return nil
 }
 
-func setServeGatewayEnv(values map[string]string) (func(), error) {
-	previous := make(map[string]previousEnv, len(values))
-	for name, value := range values {
-		prevValue, prevSet := os.LookupEnv(name)
-		previous[name] = previousEnv{value: prevValue, set: prevSet}
-		if err := os.Setenv(name, value); err != nil {
-			restoreServeGatewayEnv(previous)
-			return func() {}, err
-		}
+func validateServeGatewayURLEnvForNonDev(mcpAddr net.Addr) error {
+	if err := validateExistingServeGatewayURL("SWARM_TOOL_GATEWAY_URL", os.Getenv("SWARM_TOOL_GATEWAY_URL"), mcpAddr); err != nil {
+		return err
 	}
-	return func() {
-		restoreServeGatewayEnv(previous)
-	}, nil
-}
-
-func restoreServeGatewayEnv(previous map[string]previousEnv) {
-	for name, prev := range previous {
-		if prev.set {
-			_ = os.Setenv(name, prev.value)
-		} else {
-			_ = os.Unsetenv(name)
-		}
+	if err := validateExistingServeGatewayURL("SWARM_TOOL_GATEWAY_CONTAINER_URL", os.Getenv("SWARM_TOOL_GATEWAY_CONTAINER_URL"), mcpAddr); err != nil {
+		return err
 	}
+	return nil
 }
 
 type parsedHTTPHostPort struct {

--- a/cmd/swarm/main.go
+++ b/cmd/swarm/main.go
@@ -3,9 +3,7 @@ package main
 import (
 	"bufio"
 	"context"
-	"crypto/rand"
 	"database/sql"
-	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"flag"
@@ -70,7 +68,6 @@ const (
 	serveAPIRoutes          = "/healthz /readyz /v1/rpc /v1/ws"
 	serveMCPRoutes          = "/mcp /tools/"
 	serveReadinessRoutes    = "/healthz /readyz"
-	serveGatewayTokenBytes  = 32
 	serveExitDataIntegrity  = 78
 	runtimeStoreBackendHelp = "Runtime store backend: sqlite (local/dev default) or postgres (explicit opt-in production/external backend)"
 )
@@ -725,15 +722,16 @@ func buildServeRuntimeBundleContext(req serveRuntimeBundleContextRequest) (serve
 	}, nil
 }
 
-func buildForkChatSandboxLLMRuntime(cfg *config.Config, workspaces workspace.Resolver) (runtimellm.Runtime, error) {
+func buildForkChatSandboxLLMRuntime(cfg *config.Config, workspaces workspace.Resolver, binding toolgateway.Binding) (runtimellm.Runtime, error) {
 	if cfg == nil {
 		return nil, fmt.Errorf("runtime config is required")
 	}
 	return runtimellm.RuntimeFactory{
-		Cfg:        cfg,
-		Sessions:   sessions.NewInMemoryRegistry(cfg.LLM.Session.LockTTL),
-		LockOwner:  "forkchat-sandbox",
-		Workspaces: workspaces,
+		Cfg:         cfg,
+		Sessions:    sessions.NewInMemoryRegistry(cfg.LLM.Session.LockTTL),
+		LockOwner:   "forkchat-sandbox",
+		Workspaces:  workspaces,
+		ToolGateway: binding,
 	}.Build()
 }
 
@@ -992,7 +990,7 @@ func runServeRuntime(ctx context.Context, repo string, opts serveOptions) int {
 	bootReport := primaryContext.validation.BootReport
 	stateStoreSummary := serveRuntimeStateStoreSummary(runtimeContexts)
 
-	forkChatLLM, err := buildForkChatSandboxLLMRuntime(cfg, workspaces)
+	forkChatLLM, err := buildForkChatSandboxLLMRuntime(cfg, workspaces, toolGatewayBinding)
 	if err != nil {
 		log.Printf("init forkchat sandbox runtime: %v", err)
 		return 1
@@ -3168,9 +3166,9 @@ func createServeToolGatewayBinding(mcpAddr net.Addr) (toolgateway.Binding, error
 	}
 	gatewayToken := strings.TrimSpace(os.Getenv("SWARM_TOOL_GATEWAY_TOKEN"))
 	if gatewayToken == "" {
-		gatewayToken, err = generateServeMCPGatewayToken()
+		gatewayToken, err = toolgateway.GenerateAuthToken()
 		if err != nil {
-			return toolgateway.Binding{}, err
+			return toolgateway.Binding{}, fmt.Errorf("generate mcp gateway token: %w", err)
 		}
 	}
 	binding := toolgateway.Binding{
@@ -3185,14 +3183,6 @@ func createServeToolGatewayBinding(mcpAddr net.Addr) (toolgateway.Binding, error
 		return toolgateway.Binding{}, err
 	}
 	return binding, nil
-}
-
-func generateServeMCPGatewayToken() (string, error) {
-	raw := make([]byte, serveGatewayTokenBytes)
-	if _, err := rand.Read(raw); err != nil {
-		return "", fmt.Errorf("generate mcp gateway token: %w", err)
-	}
-	return base64.RawURLEncoding.EncodeToString(raw), nil
 }
 
 func validateExistingServeGatewayURL(name, raw string, mcpAddr net.Addr) error {

--- a/cmd/swarm/main_test.go
+++ b/cmd/swarm/main_test.go
@@ -2464,7 +2464,7 @@ func TestPlatformSpecLocalCLITestGatewayStartupPromoted(t *testing.T) {
 			t.Fatalf("startup probe rule missing %q:\n%s", want, startup.StartupProbeRule)
 		}
 	}
-	for _, want := range []string{"#997 local cli_test workspace image contents", "#996 Docker Compose", "#979/#1012", "#1002 runtime workspace source-root image packaging is closed"} {
+	for _, want := range []string{"#997 local cli_test workspace image contents", "#996 Docker Compose", "#1568 selected-contract", "#979/#1012 are completed historical source-authority slices", "#1002 runtime workspace source-root image packaging is closed"} {
 		if !stringSliceContains(startup.SplitTail, want) {
 			t.Fatalf("local cli_test gateway startup split_tail missing %q: %#v", want, startup.SplitTail)
 		}
@@ -2537,7 +2537,7 @@ func TestPlatformSpecLocalToolGatewayBindingPromoted(t *testing.T) {
 			t.Fatalf("binding consumers missing %q: %#v", want, binding.Consumers)
 		}
 	}
-	for _, want := range []string{"#1568 public/operator URL-env retirement", "#979/#1012 broader selected-contract", "ephemeral gateway to pass its own typed binding", "#1138/#1213", "#1567", "IPC/unix socket"} {
+	for _, want := range []string{"#1568 public/operator URL-env retirement", "#1568 broader selected-contract", "ephemeral gateway to pass its own typed binding", "#979/#1012 are completed historical source-authority slices", "#1138/#1213", "#1567", "IPC/unix socket"} {
 		if !stringSliceContains(binding.SplitTail, want) {
 			t.Fatalf("binding split_tail missing %q: %#v", want, binding.SplitTail)
 		}
@@ -2592,7 +2592,7 @@ func TestPlatformSpecLocalCLITestWorkspaceCLIAvailabilityPromoted(t *testing.T) 
 			t.Fatalf("local cli_test workspace cli availability consumers missing %q: %#v", want, availability.Consumers)
 		}
 	}
-	for _, want := range []string{"#996 Docker Compose", "#995 schema migration", "#979/#1012", "#1002 runtime workspace source-root image packaging is closed"} {
+	for _, want := range []string{"#996 Docker Compose", "#995 schema migration", "#1568 selected-contract", "#979/#1012 are completed historical source-authority slices", "#1002 runtime workspace source-root image packaging is closed"} {
 		if !stringSliceContains(availability.SplitTail, want) {
 			t.Fatalf("local cli_test workspace cli availability split_tail missing %q: %#v", want, availability.SplitTail)
 		}
@@ -10329,6 +10329,103 @@ func TestCreateServeToolGatewayBindingPreservesExplicitGatewayToken(t *testing.T
 	}
 }
 
+func TestRunServeRuntimeDevClaudeCLIStaleGatewayEnvUsesTypedBinding(t *testing.T) {
+	isolateCLIAPIConfigEnv(t)
+	mcpPort := freeDoctorTCPPort(t)
+	mcpAddr := "127.0.0.1:" + mcpPort
+	stalePort := staleGatewayTestPort(mcpPort)
+	t.Setenv("SWARM_TOOL_GATEWAY_URL", "http://127.0.0.1:"+stalePort)
+	t.Setenv("SWARM_TOOL_GATEWAY_CONTAINER_URL", "http://host.docker.internal:"+stalePort)
+	t.Setenv("SWARM_TOOL_GATEWAY_TOKEN", "")
+
+	bindingCh := make(chan toolgateway.Binding, 1)
+	opts := serveOptions{
+		ConfigPath:         writeDoctorClaudeConfig(t),
+		Backend:            "claude_cli",
+		ContractsPath:      filepath.Join("tests", "tier8-boot-verification", "test-boot-success"),
+		DataSource:         t.TempDir(),
+		PlatformSpecPath:   defaultPlatformSpecPath,
+		StoreMode:          "sqlite",
+		APIListenAddr:      "127.0.0.1:0",
+		MCPListenAddr:      mcpAddr,
+		SelfCheck:          true,
+		RequireBundleMatch: false,
+		Verbose:            true,
+		Dev:                true,
+		TestRuntimeReadyHook: func(rt *runtimepkg.Runtime) {
+			bindingCh <- rt.Options.ToolGatewayBinding
+		},
+	}
+	assertServePreflightStaleGatewayWarning(t, opts, "serve_dev")
+
+	process := startServeRuntimeTestProcess(t, opts)
+	process.waitForReadyLine()
+	binding := receiveToolGatewayBinding(t, bindingCh, process.outputString())
+	assertToolGatewayBindingUsesMCPPort(t, binding, mcpPort, stalePort)
+	if code := process.stop(); code != 0 {
+		t.Fatalf("serve exited with code %d, want 0\noutput:\n%s", code, process.outputString())
+	}
+}
+
+func TestStartLocalRunServeClaudeCLIStaleGatewayEnvUsesTypedBinding(t *testing.T) {
+	isolateCLIAPIConfigEnv(t)
+	apiPortText := freeDoctorTCPPort(t)
+	apiPort, err := strconv.Atoi(apiPortText)
+	if err != nil {
+		t.Fatalf("parse api port %q: %v", apiPortText, err)
+	}
+	mcpPort := freeDoctorTCPPort(t)
+	mcpAddr := "127.0.0.1:" + mcpPort
+	stalePort := staleGatewayTestPort(mcpPort)
+	t.Setenv("SWARM_TOOL_GATEWAY_URL", "http://127.0.0.1:"+stalePort)
+	t.Setenv("SWARM_TOOL_GATEWAY_CONTAINER_URL", "http://host.docker.internal:"+stalePort)
+	t.Setenv("SWARM_TOOL_GATEWAY_TOKEN", "")
+
+	bindingCh := make(chan toolgateway.Binding, 1)
+	serveStarted := make(chan serveOptions, 1)
+	apiOpts := defaultRootCommandOptions()
+	apiOpts.apiRPCEndpointOverride = "http://127.0.0.1:" + apiPortText + "/v1/rpc"
+	apiOpts.runReadyTimeout = serveRuntimeReadyTimeout
+	apiOpts.runReadyPoll = 10 * time.Millisecond
+	apiOpts.runServe = func(ctx context.Context, repo string, serveOpts serveOptions) int {
+		if !serveOpts.LocalRun {
+			t.Errorf("startLocalRunServe produced LocalRun = false, want shared run_local preflight consumer")
+		}
+		if serveOpts.APIListenAddr != "127.0.0.1:"+apiPortText {
+			t.Errorf("startLocalRunServe APIListenAddr = %q, want 127.0.0.1:%s", serveOpts.APIListenAddr, apiPortText)
+		}
+		serveOpts.MCPListenAddr = mcpAddr
+		serveOpts.Verbose = true
+		serveOpts.TestRuntimeReadyHook = func(rt *runtimepkg.Runtime) {
+			bindingCh <- rt.Options.ToolGatewayBinding
+		}
+		assertServePreflightStaleGatewayWarning(t, serveOpts, "run_local")
+		serveStarted <- serveOpts
+		return runServeRuntime(ctx, repo, serveOpts)
+	}
+
+	stop, err := startLocalRunServe(context.Background(), repoRoot(), runCommandOptions{
+		apiOptions:       apiOpts,
+		configPath:       writeDoctorClaudeConfig(t),
+		backend:          "claude_cli",
+		contractsPath:    filepath.Join("tests", "tier8-boot-verification", "test-boot-success"),
+		dataSource:       t.TempDir(),
+		platformSpecPath: defaultPlatformSpecPath,
+		apiPort:          apiPort,
+	})
+	if err != nil {
+		t.Fatalf("startLocalRunServe: %v", err)
+	}
+	defer stop()
+	select {
+	case <-serveStarted:
+	case <-time.After(serveRuntimeReadyTimeout):
+		t.Fatal("startLocalRunServe did not invoke the serve owner")
+	}
+	binding := receiveToolGatewayBinding(t, bindingCh, "")
+	assertToolGatewayBindingUsesMCPPort(t, binding, mcpPort, stalePort)
+}
+
 func TestCreateServeToolGatewayBindingIgnoresStaleLocalURLEnv(t *testing.T) {
 	listener, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
@@ -10353,6 +10450,87 @@ func TestCreateServeToolGatewayBindingIgnoresStaleLocalURLEnv(t *testing.T) {
 	if strings.Contains(binding.HostEndpoint, oldUnifiedPort) || strings.Contains(binding.WorkspaceEndpoint, oldUnifiedPort) {
 		t.Fatalf("binding = %#v, stale URL env leaked into binding", binding)
 	}
+}
+
+func assertServePreflightStaleGatewayWarning(t *testing.T, opts serveOptions, wantMode string) {
+	t.Helper()
+	cfgResult, err := loadRuntimeConfigWithOptions(runtimeConfigLoadOptions{
+		RepoRoot:        repoRoot(),
+		ExplicitPath:    opts.ConfigPath,
+		BackendOverride: opts.Backend,
+	})
+	if err != nil {
+		t.Fatalf("load config for preflight proof: %v", err)
+	}
+	resolvedPaths, err := resolveCLIContractPlatformSpecPaths(repoRoot(), cliContractPlatformSpecPathOptions{
+		ContractsPath:    opts.ContractsPath,
+		PlatformSpecPath: opts.PlatformSpecPath,
+	})
+	if err != nil {
+		t.Fatalf("resolve preflight paths: %v", err)
+	}
+	workspaceBackend, err := resolveWorkspaceBackend(opts.WorkspaceBackend, opts.WorkspaceBackendSet, cfgResult.Config)
+	if err != nil {
+		t.Fatalf("resolve workspace backend for preflight proof: %v", err)
+	}
+	report := runServeLocalClaudeCLIPreflight(context.Background(), repoRoot(), opts, cfgResult.Config, resolvedPaths, workspaceBackend)
+	if report.Mode != wantMode {
+		t.Fatalf("preflight mode = %q, want %q", report.Mode, wantMode)
+	}
+	for _, code := range []string{"swarm_tool_gateway_url_stale", "swarm_tool_gateway_container_url_stale"} {
+		if !localPreflightReportHasFinding(report, code, localPreflightSeverityWarning, localPreflightStatusFailed) {
+			t.Fatalf("preflight report missing warning %q:\n%#v", code, report)
+		}
+	}
+	if report.HasBlockers() {
+		t.Fatalf("stale local gateway URL env produced blockers, want warnings only:\n%#v", report)
+	}
+}
+
+func localPreflightReportHasFinding(report localPreflightReport, code string, severity localPreflightSeverity, status localPreflightFindingStatus) bool {
+	for _, finding := range report.Findings {
+		if finding.Code == code && finding.Severity == severity && finding.Status == status {
+			return true
+		}
+	}
+	return false
+}
+
+func receiveToolGatewayBinding(t *testing.T, ch <-chan toolgateway.Binding, output string) toolgateway.Binding {
+	t.Helper()
+	select {
+	case binding := <-ch:
+		return binding
+	case <-time.After(serveRuntimeReadyTimeout):
+		t.Fatalf("timed out waiting for runtime tool gateway binding\noutput:\n%s", output)
+		return toolgateway.Binding{}
+	}
+}
+
+func assertToolGatewayBindingUsesMCPPort(t *testing.T, binding toolgateway.Binding, mcpPort, stalePort string) {
+	t.Helper()
+	if err := binding.Validate(); err != nil {
+		t.Fatalf("runtime tool gateway binding is invalid: %v\nbinding=%#v", err, binding)
+	}
+	if got, want := binding.HostEndpoint, "http://127.0.0.1:"+mcpPort; got != want {
+		t.Fatalf("binding HostEndpoint = %q, want %q", got, want)
+	}
+	if got, want := binding.WorkspaceEndpoint, "http://host.docker.internal:"+mcpPort; got != want {
+		t.Fatalf("binding WorkspaceEndpoint = %q, want %q", got, want)
+	}
+	if strings.Contains(binding.HostEndpoint, stalePort) || strings.Contains(binding.WorkspaceEndpoint, stalePort) {
+		t.Fatalf("runtime binding leaked stale URL env port %s: %#v", stalePort, binding)
+	}
+	if strings.TrimSpace(binding.Token) == "" {
+		t.Fatalf("runtime binding token is empty: %#v", binding)
+	}
+}
+
+func staleGatewayTestPort(mcpPort string) string {
+	if strings.TrimSpace(mcpPort) == "8081" {
+		return "8080"
+	}
+	return "8081"
 }
 
 func TestValidateServeGatewayURLEnvForNonDevRejectsOldUnifiedPort(t *testing.T) {

--- a/cmd/swarm/main_test.go
+++ b/cmd/swarm/main_test.go
@@ -2443,17 +2443,17 @@ func TestPlatformSpecLocalCLITestGatewayStartupPromoted(t *testing.T) {
 	if !strings.Contains(startup.CanonicalOwner, "cli_specification.foundations.local_cli_test_gateway_startup") {
 		t.Fatalf("canonical owner does not point at local_cli_test_gateway_startup: %s", startup.CanonicalOwner)
 	}
-	for _, want := range []string{"narrowed #997", "MCP gateway token derivation", "MCP-only managed-agent startup proof", "does not close full #997"} {
+	for _, want := range []string{"narrowed #997", "MCP gateway token derivation", "MCP-only managed-agent startup proof", "does not close full #997", "local_tool_gateway_binding"} {
 		if !strings.Contains(startup.Scope, want) {
 			t.Fatalf("local cli_test gateway startup scope missing %q:\n%s", want, startup.Scope)
 		}
 	}
-	for _, want := range []string{"SWARM_TOOL_GATEWAY_TOKEN", "per-boot", "operator-provided", "Local foreground `swarm run`"} {
+	for _, want := range []string{"SWARM_TOOL_GATEWAY_TOKEN", "token-only source", "per-boot", "SWARM_TOOL_GATEWAY_URL", "not source authority", "Local foreground `swarm run`"} {
 		if !strings.Contains(startup.GatewayTokenRule, want) {
 			t.Fatalf("gateway token rule missing %q:\n%s", want, startup.GatewayTokenRule)
 		}
 	}
-	for _, want := range []string{"RuntimeOptions.ToolGatewayToken", "runtime MCP gateway auth", "ValidateClaudeCLIRuntimeConfig", "docker exec", "MCP HTTP binding"} {
+	for _, want := range []string{"RuntimeOptions.ToolGatewayBinding", "runtime MCP gateway auth", "ValidateClaudeCLIRuntimeConfig", "docker exec", "MCP HTTP binding"} {
 		if !stringSliceContains(startup.GatewayTokenConsumers, want) {
 			t.Fatalf("gateway token consumers missing %q: %#v", want, startup.GatewayTokenConsumers)
 		}
@@ -2466,6 +2466,79 @@ func TestPlatformSpecLocalCLITestGatewayStartupPromoted(t *testing.T) {
 	for _, want := range []string{"#997 local cli_test workspace image contents", "#996 Docker Compose", "#979/#1012", "#1002 runtime workspace source-root image packaging is closed"} {
 		if !stringSliceContains(startup.SplitTail, want) {
 			t.Fatalf("local cli_test gateway startup split_tail missing %q: %#v", want, startup.SplitTail)
+		}
+	}
+}
+
+func TestPlatformSpecLocalToolGatewayBindingPromoted(t *testing.T) {
+	var spec struct {
+		CLISpecification struct {
+			Foundations struct {
+				LocalToolGatewayBinding struct {
+					PromotedBy           string   `yaml:"promoted_by"`
+					ImplementationStatus string   `yaml:"implementation_status"`
+					CanonicalOwner       string   `yaml:"canonical_owner"`
+					Scope                string   `yaml:"scope"`
+					BindingFields        []string `yaml:"binding_fields"`
+					SourceRule           string   `yaml:"source_rule"`
+					EndpointEnvRule      string   `yaml:"endpoint_env_rule"`
+					AuthRule             string   `yaml:"auth_rule"`
+					Consumers            []string `yaml:"consumers"`
+					SplitTail            []string `yaml:"split_tail"`
+				} `yaml:"local_tool_gateway_binding"`
+			} `yaml:"foundations"`
+		} `yaml:"cli_specification"`
+	}
+	data, err := os.ReadFile(filepath.Join(repoRoot(), defaultPlatformSpecPath))
+	if err != nil {
+		t.Fatalf("read platform spec: %v", err)
+	}
+	if err := yaml.Unmarshal(data, &spec); err != nil {
+		t.Fatalf("parse platform spec: %v", err)
+	}
+	binding := spec.CLISpecification.Foundations.LocalToolGatewayBinding
+	if strings.TrimSpace(binding.PromotedBy) != "#1568" {
+		t.Fatalf("local tool gateway binding promoted_by = %q, want #1568", binding.PromotedBy)
+	}
+	if strings.TrimSpace(binding.ImplementationStatus) != "implemented_first_slice" {
+		t.Fatalf("local tool gateway binding implementation_status = %q, want implemented_first_slice", binding.ImplementationStatus)
+	}
+	if !strings.Contains(binding.CanonicalOwner, "cli_specification.foundations.local_tool_gateway_binding") {
+		t.Fatalf("canonical owner does not point at local_tool_gateway_binding: %s", binding.CanonicalOwner)
+	}
+	for _, want := range []string{"local `serve`", "foreground `run`", "actual bound MCP listener", "stale URL-env", "first slice"} {
+		if !strings.Contains(binding.Scope, want) {
+			t.Fatalf("local tool gateway binding scope missing %q:\n%s", want, binding.Scope)
+		}
+	}
+	for _, want := range []string{"transport", "host_endpoint", "workspace_endpoint", "auth_token", "lifecycle_owner", "source"} {
+		if !stringSliceContains(binding.BindingFields, want) {
+			t.Fatalf("binding fields missing %q: %#v", want, binding.BindingFields)
+		}
+	}
+	for _, want := range []string{"bind the MCP/tool listener first", "ToolGatewayBinding", "workspace-backend projection", "serve boot"} {
+		if !strings.Contains(binding.SourceRule, want) {
+			t.Fatalf("source rule missing %q:\n%s", want, binding.SourceRule)
+		}
+	}
+	for _, want := range []string{"SWARM_TOOL_GATEWAY_URL", "SWARM_TOOL_GATEWAY_CONTAINER_URL", "not public/operator source", "generated final-boundary compatibility", "derived from `ToolGatewayBinding`"} {
+		if !strings.Contains(binding.EndpointEnvRule, want) {
+			t.Fatalf("endpoint env rule missing %q:\n%s", want, binding.EndpointEnvRule)
+		}
+	}
+	for _, want := range []string{"SWARM_TOOL_GATEWAY_TOKEN", "token-only source authority", "per-boot token", "binding token"} {
+		if !strings.Contains(binding.AuthRule, want) {
+			t.Fatalf("auth rule missing %q:\n%s", want, binding.AuthRule)
+		}
+	}
+	for _, want := range []string{"serve listener binding", "RuntimeOptions.ToolGatewayBinding", "runtime MCP gateway auth", "ValidateClaudeCLIRuntimeConfig", "MCP HTTP config", "Docker exec"} {
+		if !stringSliceContains(binding.Consumers, want) {
+			t.Fatalf("binding consumers missing %q: %#v", want, binding.Consumers)
+		}
+	}
+	for _, want := range []string{"#1568 public/operator URL-env retirement", "#979/#1012", "#1138/#1213", "#1567", "IPC/unix socket"} {
+		if !stringSliceContains(binding.SplitTail, want) {
+			t.Fatalf("binding split_tail missing %q: %#v", want, binding.SplitTail)
 		}
 	}
 }
@@ -10195,7 +10268,7 @@ func TestRunServeRuntimeListenerBindFailuresExitBeforeReadiness(t *testing.T) {
 	}
 }
 
-func TestConfigureServeMCPGatewayEnvAlignsToMCPListener(t *testing.T) {
+func TestCreateServeToolGatewayBindingAlignsToMCPListenerWithoutMutatingURLEnv(t *testing.T) {
 	t.Setenv("SWARM_TOOL_GATEWAY_URL", "")
 	t.Setenv("SWARM_TOOL_GATEWAY_CONTAINER_URL", "")
 	t.Setenv("SWARM_TOOL_GATEWAY_TOKEN", "")
@@ -10209,36 +10282,34 @@ func TestConfigureServeMCPGatewayEnvAlignsToMCPListener(t *testing.T) {
 		t.Fatalf("split listener addr: %v", err)
 	}
 
-	restore, err := configureServeMCPGatewayEnv(listener.Addr())
+	binding, err := createServeToolGatewayBinding(listener.Addr())
 	if err != nil {
-		t.Fatalf("configure gateway env: %v", err)
+		t.Fatalf("create gateway binding: %v", err)
 	}
-	if got, want := os.Getenv("SWARM_TOOL_GATEWAY_URL"), "http://127.0.0.1:"+port; got != want {
-		t.Fatalf("SWARM_TOOL_GATEWAY_URL = %q, want %q", got, want)
+	if got, want := binding.HostEndpoint, "http://127.0.0.1:"+port; got != want {
+		t.Fatalf("HostEndpoint = %q, want %q", got, want)
 	}
-	if got, want := os.Getenv("SWARM_TOOL_GATEWAY_CONTAINER_URL"), "http://host.docker.internal:"+port; got != want {
-		t.Fatalf("SWARM_TOOL_GATEWAY_CONTAINER_URL = %q, want %q", got, want)
+	if got, want := binding.WorkspaceEndpoint, "http://host.docker.internal:"+port; got != want {
+		t.Fatalf("WorkspaceEndpoint = %q, want %q", got, want)
 	}
-	gatewayToken := os.Getenv("SWARM_TOOL_GATEWAY_TOKEN")
-	if strings.TrimSpace(gatewayToken) == "" {
-		t.Fatal("SWARM_TOOL_GATEWAY_TOKEN was not generated")
+	if strings.TrimSpace(binding.Token) == "" {
+		t.Fatal("binding token was not generated")
 	}
-	if got, want := len(gatewayToken), base64.RawURLEncoding.EncodedLen(serveGatewayTokenBytes); got != want {
-		t.Fatalf("SWARM_TOOL_GATEWAY_TOKEN length = %d, want %d", got, want)
+	if got, want := len(binding.Token), base64.RawURLEncoding.EncodedLen(serveGatewayTokenBytes); got != want {
+		t.Fatalf("binding token length = %d, want %d", got, want)
 	}
-	restore()
 	if got := os.Getenv("SWARM_TOOL_GATEWAY_URL"); got != "" {
-		t.Fatalf("SWARM_TOOL_GATEWAY_URL after restore = %q, want empty", got)
+		t.Fatalf("SWARM_TOOL_GATEWAY_URL = %q, want empty", got)
 	}
 	if got := os.Getenv("SWARM_TOOL_GATEWAY_CONTAINER_URL"); got != "" {
-		t.Fatalf("SWARM_TOOL_GATEWAY_CONTAINER_URL after restore = %q, want empty", got)
+		t.Fatalf("SWARM_TOOL_GATEWAY_CONTAINER_URL = %q, want empty", got)
 	}
 	if got := os.Getenv("SWARM_TOOL_GATEWAY_TOKEN"); got != "" {
-		t.Fatalf("SWARM_TOOL_GATEWAY_TOKEN after restore = %q, want empty", got)
+		t.Fatalf("SWARM_TOOL_GATEWAY_TOKEN = %q, want empty", got)
 	}
 }
 
-func TestConfigureServeMCPGatewayEnvPreservesExplicitGatewayToken(t *testing.T) {
+func TestCreateServeToolGatewayBindingPreservesExplicitGatewayToken(t *testing.T) {
 	t.Setenv("SWARM_TOOL_GATEWAY_URL", "")
 	t.Setenv("SWARM_TOOL_GATEWAY_CONTAINER_URL", "")
 	t.Setenv("SWARM_TOOL_GATEWAY_TOKEN", "operator-token")
@@ -10248,20 +10319,16 @@ func TestConfigureServeMCPGatewayEnvPreservesExplicitGatewayToken(t *testing.T) 
 	}
 	defer listener.Close()
 
-	restore, err := configureServeMCPGatewayEnv(listener.Addr())
+	binding, err := createServeToolGatewayBinding(listener.Addr())
 	if err != nil {
-		t.Fatalf("configure gateway env: %v", err)
+		t.Fatalf("create gateway binding: %v", err)
 	}
-	if got := os.Getenv("SWARM_TOOL_GATEWAY_TOKEN"); got != "operator-token" {
-		t.Fatalf("SWARM_TOOL_GATEWAY_TOKEN = %q, want explicit operator token", got)
-	}
-	restore()
-	if got := os.Getenv("SWARM_TOOL_GATEWAY_TOKEN"); got != "operator-token" {
-		t.Fatalf("SWARM_TOOL_GATEWAY_TOKEN after restore = %q, want explicit operator token", got)
+	if got := binding.Token; got != "operator-token" {
+		t.Fatalf("binding token = %q, want explicit operator token", got)
 	}
 }
 
-func TestConfigureServeMCPGatewayEnvRejectsOldUnifiedPort(t *testing.T) {
+func TestCreateServeToolGatewayBindingIgnoresStaleLocalURLEnv(t *testing.T) {
 	listener, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		t.Fatalf("listen mcp: %v", err)
@@ -10278,10 +10345,35 @@ func TestConfigureServeMCPGatewayEnvRejectsOldUnifiedPort(t *testing.T) {
 	t.Setenv("SWARM_TOOL_GATEWAY_URL", "http://127.0.0.1:"+oldUnifiedPort)
 	t.Setenv("SWARM_TOOL_GATEWAY_CONTAINER_URL", "http://host.docker.internal:"+oldUnifiedPort)
 
-	restore, err := configureServeMCPGatewayEnv(listener.Addr())
+	binding, err := createServeToolGatewayBinding(listener.Addr())
+	if err != nil {
+		t.Fatalf("create gateway binding: %v", err)
+	}
+	if strings.Contains(binding.HostEndpoint, oldUnifiedPort) || strings.Contains(binding.WorkspaceEndpoint, oldUnifiedPort) {
+		t.Fatalf("binding = %#v, stale URL env leaked into binding", binding)
+	}
+}
+
+func TestValidateServeGatewayURLEnvForNonDevRejectsOldUnifiedPort(t *testing.T) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen mcp: %v", err)
+	}
+	defer listener.Close()
+	_, mcpPort, err := net.SplitHostPort(listener.Addr().String())
+	if err != nil {
+		t.Fatalf("split listener addr: %v", err)
+	}
+	oldUnifiedPort := "8081"
+	if mcpPort == oldUnifiedPort {
+		oldUnifiedPort = "8080"
+	}
+	t.Setenv("SWARM_TOOL_GATEWAY_URL", "http://127.0.0.1:"+oldUnifiedPort)
+	t.Setenv("SWARM_TOOL_GATEWAY_CONTAINER_URL", "http://host.docker.internal:"+oldUnifiedPort)
+
+	err = validateServeGatewayURLEnvForNonDev(listener.Addr())
 	if err == nil {
-		restore()
-		t.Fatalf("configure gateway env unexpectedly accepted old unified API port")
+		t.Fatal("non-dev gateway env validation unexpectedly accepted old unified API port")
 	}
 	if !strings.Contains(err.Error(), "must target the MCP listener port") {
 		t.Fatalf("error = %v, want MCP listener port mismatch", err)

--- a/cmd/swarm/main_test.go
+++ b/cmd/swarm/main_test.go
@@ -10331,6 +10331,7 @@ func TestCreateServeToolGatewayBindingPreservesExplicitGatewayToken(t *testing.T
 
 func TestRunServeRuntimeDevClaudeCLIStaleGatewayEnvUsesTypedBinding(t *testing.T) {
 	isolateCLIAPIConfigEnv(t)
+	stubServeWorkspaceLifecycleForTest(t)
 	mcpPort := freeDoctorTCPPort(t)
 	mcpAddr := "127.0.0.1:" + mcpPort
 	stalePort := staleGatewayTestPort(mcpPort)
@@ -10369,6 +10370,7 @@ func TestRunServeRuntimeDevClaudeCLIStaleGatewayEnvUsesTypedBinding(t *testing.T
 
 func TestStartLocalRunServeClaudeCLIStaleGatewayEnvUsesTypedBinding(t *testing.T) {
 	isolateCLIAPIConfigEnv(t)
+	stubServeWorkspaceLifecycleForTest(t)
 	apiPortText := freeDoctorTCPPort(t)
 	apiPort, err := strconv.Atoi(apiPortText)
 	if err != nil {
@@ -10494,6 +10496,17 @@ func localPreflightReportHasFinding(report localPreflightReport, code string, se
 		}
 	}
 	return false
+}
+
+func stubServeWorkspaceLifecycleForTest(t *testing.T) {
+	t.Helper()
+	oldWorkspaceLifecycle := configuredWorkspaceLifecycleForServe
+	configuredWorkspaceLifecycleForServe = func(*sql.DB, string, semanticview.Source, workspaceMountSources, workspaceBackendSelection) (serveWorkspaceLifecycle, error) {
+		return serveRuntimeWorkspaceStub{}, nil
+	}
+	t.Cleanup(func() {
+		configuredWorkspaceLifecycleForServe = oldWorkspaceLifecycle
+	})
 }
 
 func receiveToolGatewayBinding(t *testing.T, ch <-chan toolgateway.Binding, output string) toolgateway.Binding {

--- a/cmd/swarm/main_test.go
+++ b/cmd/swarm/main_test.go
@@ -42,6 +42,7 @@ import (
 	runtimerunforkexecution "github.com/division-sh/swarm/internal/runtime/runforkexecution"
 	runtimerunquiescence "github.com/division-sh/swarm/internal/runtime/runquiescence"
 	"github.com/division-sh/swarm/internal/runtime/semanticview"
+	"github.com/division-sh/swarm/internal/runtime/toolgateway"
 	runtimetools "github.com/division-sh/swarm/internal/runtime/tools"
 	workspace "github.com/division-sh/swarm/internal/runtime/workspace"
 	"github.com/division-sh/swarm/internal/store"
@@ -2506,7 +2507,7 @@ func TestPlatformSpecLocalToolGatewayBindingPromoted(t *testing.T) {
 	if !strings.Contains(binding.CanonicalOwner, "cli_specification.foundations.local_tool_gateway_binding") {
 		t.Fatalf("canonical owner does not point at local_tool_gateway_binding: %s", binding.CanonicalOwner)
 	}
-	for _, want := range []string{"local `serve`", "foreground `run`", "actual bound MCP listener", "stale URL-env", "first slice"} {
+	for _, want := range []string{"local `serve`", "foreground `run`", "actual bound MCP listener", "stale URL-env", "first slice", "production Claude runtime factory"} {
 		if !strings.Contains(binding.Scope, want) {
 			t.Fatalf("local tool gateway binding scope missing %q:\n%s", want, binding.Scope)
 		}
@@ -2531,12 +2532,12 @@ func TestPlatformSpecLocalToolGatewayBindingPromoted(t *testing.T) {
 			t.Fatalf("auth rule missing %q:\n%s", want, binding.AuthRule)
 		}
 	}
-	for _, want := range []string{"serve listener binding", "RuntimeOptions.ToolGatewayBinding", "runtime MCP gateway auth", "ValidateClaudeCLIRuntimeConfig", "MCP HTTP config", "Docker exec"} {
+	for _, want := range []string{"serve listener binding", "RuntimeOptions.ToolGatewayBinding", "runtime MCP gateway auth", "ValidateClaudeCLIRuntimeConfig", "MCP HTTP config", "Docker exec", "fork-chat sandbox", "selected-fork ephemeral gateway"} {
 		if !stringSliceContains(binding.Consumers, want) {
 			t.Fatalf("binding consumers missing %q: %#v", want, binding.Consumers)
 		}
 	}
-	for _, want := range []string{"#1568 public/operator URL-env retirement", "#979/#1012", "#1138/#1213", "#1567", "IPC/unix socket"} {
+	for _, want := range []string{"#1568 public/operator URL-env retirement", "#979/#1012 broader selected-contract", "ephemeral gateway to pass its own typed binding", "#1138/#1213", "#1567", "IPC/unix socket"} {
 		if !stringSliceContains(binding.SplitTail, want) {
 			t.Fatalf("binding split_tail missing %q: %#v", want, binding.SplitTail)
 		}
@@ -10295,7 +10296,7 @@ func TestCreateServeToolGatewayBindingAlignsToMCPListenerWithoutMutatingURLEnv(t
 	if strings.TrimSpace(binding.Token) == "" {
 		t.Fatal("binding token was not generated")
 	}
-	if got, want := len(binding.Token), base64.RawURLEncoding.EncodedLen(serveGatewayTokenBytes); got != want {
+	if got, want := len(binding.Token), base64.RawURLEncoding.EncodedLen(toolgateway.AuthTokenBytes); got != want {
 		t.Fatalf("binding token length = %d, want %d", got, want)
 	}
 	if got := os.Getenv("SWARM_TOOL_GATEWAY_URL"); got != "" {

--- a/internal/runtime/llm/cli_runtime.go
+++ b/internal/runtime/llm/cli_runtime.go
@@ -13,6 +13,7 @@ import (
 	runtimecorrelation "github.com/division-sh/swarm/internal/runtime/correlation"
 	llmselection "github.com/division-sh/swarm/internal/runtime/llm/selection"
 	"github.com/division-sh/swarm/internal/runtime/sessions"
+	"github.com/division-sh/swarm/internal/runtime/toolgateway"
 	workspace "github.com/division-sh/swarm/internal/runtime/workspace"
 )
 
@@ -27,6 +28,7 @@ type ClaudeCLIRuntime struct {
 	monitor         MonitorSink
 	events          EventPublisher
 	mcpTurns        MCPTurnContextStore
+	toolGateway     toolgateway.Binding
 	execWorkspaceFn func(ctx context.Context, target *workspace.Target, stdin string, args ...string) ([]byte, []byte, int, error)
 }
 
@@ -42,6 +44,7 @@ type promptTransportFallback struct {
 type ClaudeCLIRuntimeOptions struct {
 	MonitorSink         MonitorSink
 	MCPTurnContextStore MCPTurnContextStore
+	ToolGateway         toolgateway.Binding
 }
 
 func NewClaudeCLIRuntime(
@@ -83,6 +86,7 @@ func NewClaudeCLIRuntimeWithOptions(
 		monitor:       monitor,
 		events:        publisher,
 		mcpTurns:      opts.MCPTurnContextStore,
+		toolGateway:   opts.ToolGateway,
 	}
 }
 

--- a/internal/runtime/llm/cli_runtime_boot.go
+++ b/internal/runtime/llm/cli_runtime_boot.go
@@ -2,15 +2,14 @@ package llm
 
 import (
 	"fmt"
-	"net/url"
 	"os"
-	"strings"
 
 	"github.com/division-sh/swarm/internal/config"
 	llmselection "github.com/division-sh/swarm/internal/runtime/llm/selection"
+	"github.com/division-sh/swarm/internal/runtime/toolgateway"
 )
 
-func ValidateClaudeCLIRuntimeConfig(cfg *config.Config) error {
+func ValidateClaudeCLIRuntimeConfig(cfg *config.Config, binding toolgateway.Binding) error {
 	if cfg == nil {
 		return nil
 	}
@@ -24,32 +23,8 @@ func ValidateClaudeCLIRuntimeConfig(cfg *config.Config) error {
 	if !shouldUseMCPBridge() {
 		return fmt.Errorf("SWARM_CLAUDE_USE_MCP must remain enabled for claude cli runtime")
 	}
-	hostGatewayURL := strings.TrimSpace(os.Getenv("SWARM_TOOL_GATEWAY_URL"))
-	if hostGatewayURL == "" {
-		return fmt.Errorf("SWARM_TOOL_GATEWAY_URL is required for claude cli runtime")
-	}
-	normalized := normalizeMCPServerURL(hostGatewayURL)
-	if normalized == "" {
-		return fmt.Errorf("SWARM_TOOL_GATEWAY_URL must be a valid http(s) MCP gateway URL: %s", hostGatewayURL)
-	}
-	parsed, err := url.Parse(normalized)
-	if err != nil || strings.TrimSpace(parsed.Host) == "" {
-		return fmt.Errorf("SWARM_TOOL_GATEWAY_URL must be a valid http(s) MCP gateway URL: %s", hostGatewayURL)
-	}
-	containerGatewayURL := strings.TrimSpace(os.Getenv("SWARM_TOOL_GATEWAY_CONTAINER_URL"))
-	if containerGatewayURL == "" {
-		return fmt.Errorf("SWARM_TOOL_GATEWAY_CONTAINER_URL is required for claude cli runtime")
-	}
-	containerNormalized := normalizeMCPServerURL(containerGatewayURL)
-	if containerNormalized == "" {
-		return fmt.Errorf("SWARM_TOOL_GATEWAY_CONTAINER_URL must be a valid http(s) MCP gateway URL: %s", containerGatewayURL)
-	}
-	containerParsed, err := url.Parse(containerNormalized)
-	if err != nil || strings.TrimSpace(containerParsed.Host) == "" {
-		return fmt.Errorf("SWARM_TOOL_GATEWAY_CONTAINER_URL must be a valid http(s) MCP gateway URL: %s", containerGatewayURL)
-	}
-	if strings.TrimSpace(os.Getenv("SWARM_TOOL_GATEWAY_TOKEN")) == "" {
-		return fmt.Errorf("SWARM_TOOL_GATEWAY_TOKEN is required for claude cli runtime")
+	if err := binding.Validate(); err != nil {
+		return fmt.Errorf("claude cli tool gateway binding invalid: %w", err)
 	}
 	if err := llmselection.RequireCredential(profile, os.LookupEnv); err != nil {
 		return err

--- a/internal/runtime/llm/cli_runtime_boot_test.go
+++ b/internal/runtime/llm/cli_runtime_boot_test.go
@@ -5,9 +5,10 @@ import (
 	"testing"
 
 	"github.com/division-sh/swarm/internal/config"
+	"github.com/division-sh/swarm/internal/runtime/toolgateway"
 )
 
-func TestValidateClaudeCLIRuntimeConfig_RequiresExplicitBridgeEnv(t *testing.T) {
+func TestValidateClaudeCLIRuntimeConfig_RequiresToolGatewayBinding(t *testing.T) {
 	cfg := &config.Config{}
 	cfg.LLM.Backend = "claude_cli"
 
@@ -17,9 +18,9 @@ func TestValidateClaudeCLIRuntimeConfig_RequiresExplicitBridgeEnv(t *testing.T) 
 	t.Setenv("SWARM_TOOL_GATEWAY_TOKEN", "")
 	t.Setenv("CLAUDE_CODE_OAUTH_TOKEN", "")
 
-	err := ValidateClaudeCLIRuntimeConfig(cfg)
-	if err == nil || !strings.Contains(err.Error(), "SWARM_TOOL_GATEWAY_URL") {
-		t.Fatalf("expected missing gateway URL error, got %v", err)
+	err := ValidateClaudeCLIRuntimeConfig(cfg, testToolGatewayBinding("", "", ""))
+	if err == nil || !strings.Contains(err.Error(), "tool gateway binding") {
+		t.Fatalf("expected missing gateway binding error, got %v", err)
 	}
 }
 
@@ -27,7 +28,7 @@ func TestValidateClaudeCLIRuntimeConfig_RejectsRetiredRuntimeMode(t *testing.T) 
 	cfg := &config.Config{}
 	cfg.LLM.RuntimeMode = "cli_test"
 
-	if err := ValidateClaudeCLIRuntimeConfig(cfg); err == nil || !strings.Contains(err.Error(), "llm.runtime_mode is retired") {
+	if err := ValidateClaudeCLIRuntimeConfig(cfg, toolgateway.Binding{}); err == nil || !strings.Contains(err.Error(), "llm.runtime_mode is retired") {
 		t.Fatalf("ValidateClaudeCLIRuntimeConfig error = %v, want retired runtime mode rejection", err)
 	}
 }
@@ -42,7 +43,7 @@ func TestValidateClaudeCLIRuntimeConfig_RequiresMCPBridgeEnabled(t *testing.T) {
 	t.Setenv("SWARM_TOOL_GATEWAY_TOKEN", "gateway-token")
 	t.Setenv("CLAUDE_CODE_OAUTH_TOKEN", "oauth-token")
 
-	err := ValidateClaudeCLIRuntimeConfig(cfg)
+	err := ValidateClaudeCLIRuntimeConfig(cfg, testToolGatewayBinding("http://127.0.0.1:8081", "http://host.docker.internal:8081", "gateway-token"))
 	if err == nil || !strings.Contains(err.Error(), "SWARM_CLAUDE_USE_MCP") {
 		t.Fatalf("expected MCP enabled error, got %v", err)
 	}
@@ -58,12 +59,12 @@ func TestValidateClaudeCLIRuntimeConfig_AcceptsExplicitConfig(t *testing.T) {
 	t.Setenv("SWARM_TOOL_GATEWAY_TOKEN", "gateway-token")
 	t.Setenv("CLAUDE_CODE_OAUTH_TOKEN", "oauth-token")
 
-	if err := ValidateClaudeCLIRuntimeConfig(cfg); err != nil {
+	if err := ValidateClaudeCLIRuntimeConfig(cfg, testToolGatewayBinding("http://127.0.0.1:8081", "http://host.docker.internal:8081", "gateway-token")); err != nil {
 		t.Fatalf("ValidateClaudeCLIRuntimeConfig: %v", err)
 	}
 }
 
-func TestValidateClaudeCLIRuntimeConfig_RequiresExplicitContainerGatewayEnv(t *testing.T) {
+func TestValidateClaudeCLIRuntimeConfig_RequiresWorkspaceGatewayEndpoint(t *testing.T) {
 	cfg := &config.Config{}
 	cfg.LLM.Backend = "claude_cli"
 
@@ -73,8 +74,8 @@ func TestValidateClaudeCLIRuntimeConfig_RequiresExplicitContainerGatewayEnv(t *t
 	t.Setenv("SWARM_TOOL_GATEWAY_TOKEN", "gateway-token")
 	t.Setenv("CLAUDE_CODE_OAUTH_TOKEN", "oauth-token")
 
-	err := ValidateClaudeCLIRuntimeConfig(cfg)
-	if err == nil || !strings.Contains(err.Error(), "SWARM_TOOL_GATEWAY_CONTAINER_URL") {
-		t.Fatalf("expected missing container gateway URL error, got %v", err)
+	err := ValidateClaudeCLIRuntimeConfig(cfg, testToolGatewayBinding("http://127.0.0.1:8081", "", "gateway-token"))
+	if err == nil || !strings.Contains(err.Error(), "workspace endpoint") {
+		t.Fatalf("expected missing workspace endpoint error, got %v", err)
 	}
 }

--- a/internal/runtime/llm/cli_runtime_process.go
+++ b/internal/runtime/llm/cli_runtime_process.go
@@ -296,11 +296,11 @@ func (r *ClaudeCLIRuntime) buildCommand(ctx context.Context, args []string, targ
 			dockerBin = "docker"
 		}
 		dockerArgs := []string{"exec", "-i"}
-		gatewayURL := runtimeMCPGatewayURLForContainerExecution()
+		gatewayURL := r.toolGateway.WorkspaceMCPURL()
 		if gatewayURL != "" {
 			dockerArgs = append(dockerArgs, "-e", "SWARM_TOOL_GATEWAY_URL="+gatewayURL)
 		}
-		if gatewayToken := strings.TrimSpace(os.Getenv("SWARM_TOOL_GATEWAY_TOKEN")); gatewayToken != "" {
+		if gatewayToken := r.toolGateway.AuthToken(); gatewayToken != "" {
 			dockerArgs = append(dockerArgs, "-e", "SWARM_TOOL_GATEWAY_TOKEN="+gatewayToken)
 		}
 		profile, _ := llmselection.ResolveActiveBackend(llmselection.BackendClaudeCLI)

--- a/internal/runtime/llm/cli_runtime_process_test.go
+++ b/internal/runtime/llm/cli_runtime_process_test.go
@@ -101,12 +101,13 @@ func TestClaudeCLIRuntimeWorkspaceCommandRejectsHostWorkspaceBackend(t *testing.
 }
 
 func TestClaudeCLIRuntimeBuildCommand_UsesContainerReachableMCPGatewayURL(t *testing.T) {
-	t.Setenv("SWARM_TOOL_GATEWAY_CONTAINER_URL", "http://host.docker.internal:8081")
-	t.Setenv("SWARM_TOOL_GATEWAY_TOKEN", "gateway-token")
+	t.Setenv("SWARM_TOOL_GATEWAY_CONTAINER_URL", "http://stale.example.invalid:8081")
+	t.Setenv("SWARM_TOOL_GATEWAY_TOKEN", "stale-token")
 	t.Setenv("CLAUDE_CODE_OAUTH_TOKEN", "oauth-token")
 
 	runtime := NewClaudeCLIRuntime(&config.Config{}, sessions.NewInMemoryRegistry(0), "worker-1", nil, nil, nil, nil, nil)
 	runtime.cfg.LLM.ClaudeCLI.Command = "claude"
+	runtime.toolGateway = testToolGatewayBinding("http://127.0.0.1:8082", "http://host.docker.internal:8082", "gateway-token")
 
 	cmd, err := runtime.buildCommand(context.Background(), []string{"--print", "hello"}, &workspace.Target{
 		Backend:   workspace.BackendDocker,
@@ -117,11 +118,14 @@ func TestClaudeCLIRuntimeBuildCommand_UsesContainerReachableMCPGatewayURL(t *tes
 		t.Fatalf("buildCommand: %v", err)
 	}
 	got := strings.Join(cmd.Args, " ")
-	if !strings.Contains(got, "SWARM_TOOL_GATEWAY_URL=http://host.docker.internal:8081/mcp") {
+	if !strings.Contains(got, "SWARM_TOOL_GATEWAY_URL=http://host.docker.internal:8082/mcp") {
 		t.Fatalf("docker args = %q, want explicit container MCP gateway URL", got)
 	}
 	if !strings.Contains(got, "SWARM_TOOL_GATEWAY_TOKEN=gateway-token") {
 		t.Fatalf("docker args = %q, want MCP gateway token propagated into cli_test container exec", got)
+	}
+	if strings.Contains(got, "stale.example.invalid") || strings.Contains(got, "stale-token") {
+		t.Fatalf("docker args = %q, stale operator gateway env leaked into launch", got)
 	}
 }
 

--- a/internal/runtime/llm/cli_runtime_supported_path_test.go
+++ b/internal/runtime/llm/cli_runtime_supported_path_test.go
@@ -97,6 +97,7 @@ func TestConversationStep_ClaudeCLIFirstTurnPreservesSupportedReadFileSurface(t 
 		nil,
 		nil,
 		ClaudeCLIRuntimeOptions{
+			ToolGateway: testToolGatewayBinding("http://127.0.0.1:8081", "http://host.docker.internal:8081", "gateway-token"),
 			MCPTurnContextStore: mcpTurnContextStoreStub{
 				register: func(_ context.Context, _ time.Duration, got []string) string {
 					allowedTools = append([]string(nil), got...)

--- a/internal/runtime/llm/cli_runtime_transport.go
+++ b/internal/runtime/llm/cli_runtime_transport.go
@@ -4,13 +4,13 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"net/url"
 	"os"
 	"strings"
 	"time"
 
 	"github.com/division-sh/swarm/internal/config"
 	models "github.com/division-sh/swarm/internal/runtime/core/actors"
+	"github.com/division-sh/swarm/internal/runtime/toolgateway"
 	workspace "github.com/division-sh/swarm/internal/runtime/workspace"
 )
 
@@ -51,7 +51,7 @@ func BuildMCPHTTPBinding(ctx context.Context, cfg *config.Config, turns MCPTurnC
 	if len(allowedTools) == 0 {
 		return MCPHTTPBinding{}, false, nil
 	}
-	serverURL := normalizeMCPServerURL(gatewayURL)
+	serverURL := toolgateway.NormalizeMCPServerURL(gatewayURL)
 	if serverURL == "" {
 		return MCPHTTPBinding{}, false, nil
 	}
@@ -71,8 +71,7 @@ func BuildMCPHTTPBinding(ctx context.Context, cfg *config.Config, turns MCPTurnC
 }
 
 func (r *ClaudeCLIRuntime) buildMCPConfigArg(ctx context.Context, s *Session) (configJSON string, contextToken string, enabled bool, err error) {
-	gatewayURL := runtimeMCPGatewayURLForContainerExecution()
-	binding, enabled, err := BuildMCPHTTPBinding(ctx, r.cfg, r.mcpTurns, s, gatewayURL, strings.TrimSpace(os.Getenv("SWARM_TOOL_GATEWAY_TOKEN")))
+	binding, enabled, err := BuildMCPHTTPBinding(ctx, r.cfg, r.mcpTurns, s, r.toolGateway.WorkspaceMCPURL(), r.toolGateway.AuthToken())
 	if err != nil || !enabled {
 		return "", "", enabled, err
 	}
@@ -129,36 +128,6 @@ func shouldUseMCPBridge() bool {
 		return false
 	}
 	return v == "1" || v == "true" || v == "yes"
-}
-
-func normalizeMCPServerURL(raw string) string {
-	raw = strings.TrimSpace(raw)
-	if raw == "" {
-		return ""
-	}
-	u, err := url.Parse(raw)
-	if err != nil || strings.TrimSpace(u.Scheme) == "" || strings.TrimSpace(u.Host) == "" {
-		return ""
-	}
-	path := strings.TrimSpace(u.Path)
-	switch path {
-	case "", "/":
-		u.Path = "/mcp"
-	case "/mcp":
-	default:
-		// Respect explicit path when operator already targets a specific endpoint.
-	}
-	return strings.TrimSpace(u.String())
-}
-
-func runtimeMCPGatewayURLForContainerExecution() string {
-	raw := strings.TrimSpace(os.Getenv("SWARM_TOOL_GATEWAY_CONTAINER_URL"))
-	return normalizeMCPServerURL(raw)
-}
-
-func RuntimeMCPGatewayURLForHostExecution() string {
-	raw := strings.TrimSpace(os.Getenv("SWARM_TOOL_GATEWAY_URL"))
-	return normalizeMCPServerURL(raw)
 }
 
 func (r *ClaudeCLIRuntime) runWithPromptTransportFallback(ctx context.Context, args []string, target *workspace.Target, prompt string, meta MonitorTurnMeta) (*Response, promptTransportFallback, error) {

--- a/internal/runtime/llm/cli_runtime_transport_test.go
+++ b/internal/runtime/llm/cli_runtime_transport_test.go
@@ -300,11 +300,10 @@ func TestCLIExecutionToolSurface_FileIONativeSurfaceRemovesFallbackRuntimeTools(
 
 func TestBuildMCPConfigArg_UsesContextTokenWithoutLegacyCorrelationPropagation(t *testing.T) {
 	t.Setenv("SWARM_CLAUDE_USE_MCP", "1")
-	t.Setenv("SWARM_TOOL_GATEWAY_CONTAINER_URL", "http://host.docker.internal:18082")
-	t.Setenv("SWARM_TOOL_GATEWAY_TOKEN", "gateway-token")
 
 	r := &ClaudeCLIRuntime{
-		cfg: &config.Config{},
+		cfg:         &config.Config{},
+		toolGateway: testToolGatewayBinding("http://127.0.0.1:18082", "http://host.docker.internal:18082", "gateway-token"),
 		mcpTurns: mcpTurnContextStoreStub{
 			register: func(_ context.Context, _ time.Duration, allowedTools []string) string {
 				if !slices.Equal(allowedTools, []string{"emit_category_assessed", "query_entities"}) {
@@ -409,11 +408,10 @@ func TestBuildMCPHTTPBinding_DisablesBridgeForNativeBuiltinOnlySurface(t *testin
 
 func TestBuildMCPConfigArg_PreservesNonLoopbackGatewayURLForContainerExecution(t *testing.T) {
 	t.Setenv("SWARM_CLAUDE_USE_MCP", "1")
-	t.Setenv("SWARM_TOOL_GATEWAY_CONTAINER_URL", "http://orchestrator:8090")
-	t.Setenv("SWARM_TOOL_GATEWAY_TOKEN", "gateway-token")
 
 	r := &ClaudeCLIRuntime{
-		cfg: &config.Config{},
+		cfg:         &config.Config{},
+		toolGateway: testToolGatewayBinding("http://127.0.0.1:8090", "http://orchestrator:8090", "gateway-token"),
 		mcpTurns: mcpTurnContextStoreStub{
 			register:   func(_ context.Context, _ time.Duration, _ []string) string { return "ctx-token-456" },
 			unregister: func(string) {},
@@ -448,29 +446,13 @@ func TestBuildMCPConfigArg_PreservesNonLoopbackGatewayURLForContainerExecution(t
 	}
 }
 
-func TestRuntimeMCPGatewayURLForHostExecution_UsesExplicitHostGatewayURL(t *testing.T) {
-	t.Setenv("SWARM_TOOL_GATEWAY_URL", "http://127.0.0.1:18082")
-
-	got := RuntimeMCPGatewayURLForHostExecution()
-	if got != "http://127.0.0.1:18082/mcp" {
-		t.Fatalf("gateway url = %q, want explicit host MCP endpoint", got)
-	}
-}
-
-func TestRuntimeMCPGatewayURLForContainerExecution_UsesExplicitContainerGatewayURL(t *testing.T) {
-	t.Setenv("SWARM_TOOL_GATEWAY_CONTAINER_URL", "http://host.docker.internal:18082")
-
-	got := runtimeMCPGatewayURLForContainerExecution()
-	if got != "http://host.docker.internal:18082/mcp" {
-		t.Fatalf("gateway url = %q, want explicit container MCP endpoint", got)
-	}
-}
-
 func TestBuildMCPConfigArg_FailsClosedWithoutTurnContextStore(t *testing.T) {
 	t.Setenv("SWARM_CLAUDE_USE_MCP", "1")
-	t.Setenv("SWARM_TOOL_GATEWAY_CONTAINER_URL", "http://host.docker.internal:18082")
 
-	r := &ClaudeCLIRuntime{cfg: &config.Config{}}
+	r := &ClaudeCLIRuntime{
+		cfg:         &config.Config{},
+		toolGateway: testToolGatewayBinding("http://127.0.0.1:18082", "http://host.docker.internal:18082", "gateway-token"),
+	}
 	ctx := models.WithActor(context.Background(), models.AgentConfig{
 		ID:   "market-research-agent",
 		Role: "market_research",

--- a/internal/runtime/llm/factory.go
+++ b/internal/runtime/llm/factory.go
@@ -10,6 +10,7 @@ import (
 	"github.com/division-sh/swarm/internal/events"
 	llmselection "github.com/division-sh/swarm/internal/runtime/llm/selection"
 	"github.com/division-sh/swarm/internal/runtime/sessions"
+	"github.com/division-sh/swarm/internal/runtime/toolgateway"
 	workspace "github.com/division-sh/swarm/internal/runtime/workspace"
 )
 
@@ -23,6 +24,7 @@ type RuntimeFactory struct {
 	Workspaces    workspace.Resolver
 	Events        EventPublisher
 	MCPTurns      MCPTurnContextStore
+	ToolGateway   toolgateway.Binding
 }
 
 func (f RuntimeFactory) Build() (Runtime, error) {
@@ -48,6 +50,7 @@ func (f RuntimeFactory) Build() (Runtime, error) {
 	case llmselection.BackendClaudeCLI:
 		runtime = NewClaudeCLIRuntimeWithOptions(f.Cfg, f.Sessions, f.LockOwner, f.Turns, f.Budget, f.Workspaces, f.Conversations, f.Events, ClaudeCLIRuntimeOptions{
 			MCPTurnContextStore: f.MCPTurns,
+			ToolGateway:         f.ToolGateway,
 		})
 	case llmselection.BackendOpenAICompatible:
 		runtime = NewOpenAICompatibleRuntime(f.Cfg, f.Sessions, f.LockOwner, f.Turns, f.Conversations, f.Budget, f.Events)

--- a/internal/runtime/llm/tool_gateway_test.go
+++ b/internal/runtime/llm/tool_gateway_test.go
@@ -1,0 +1,14 @@
+package llm
+
+import "github.com/division-sh/swarm/internal/runtime/toolgateway"
+
+func testToolGatewayBinding(hostURL, workspaceURL, token string) toolgateway.Binding {
+	return toolgateway.Binding{
+		Transport:         toolgateway.TransportHTTP,
+		HostEndpoint:      hostURL,
+		WorkspaceEndpoint: workspaceURL,
+		Token:             token,
+		LifecycleOwner:    toolgateway.LifecycleOwnerServeBoot,
+		Source:            toolgateway.SourceBoundMCPListener,
+	}
+}

--- a/internal/runtime/runforkexecution/agent_runtime_materialization.go
+++ b/internal/runtime/runforkexecution/agent_runtime_materialization.go
@@ -25,6 +25,7 @@ import (
 	runtimepipeline "github.com/division-sh/swarm/internal/runtime/pipeline"
 	"github.com/division-sh/swarm/internal/runtime/semanticview"
 	runtimesessions "github.com/division-sh/swarm/internal/runtime/sessions"
+	"github.com/division-sh/swarm/internal/runtime/toolgateway"
 	runtimetools "github.com/division-sh/swarm/internal/runtime/tools"
 	workspace "github.com/division-sh/swarm/internal/runtime/workspace"
 	"github.com/division-sh/swarm/internal/store"
@@ -251,21 +252,6 @@ func buildSelectedContractAgentRuntimeFactory(req publishSelectedContractForkEve
 	if credentials == nil {
 		credentials = runtimecredentials.NewEnvStore()
 	}
-	modelRuntime := options.LLMRuntime
-	if modelRuntime == nil {
-		modelRuntime, err = runtimellm.RuntimeFactory{
-			Cfg:           options.Config,
-			Sessions:      options.SessionRegistry,
-			Turns:         options.TurnStore,
-			Conversations: options.ConversationStore,
-			Workspaces:    options.Workspace,
-			Events:        bus,
-			MCPTurns:      mcpTurns,
-		}.Build()
-		if err != nil {
-			return selectedContractAgentRuntimeFactory{}, fmt.Errorf("build selected-fork agent runtime: %w", err)
-		}
-	}
 	var managerRef runtimetools.Manager
 	exec := runtimetools.NewExecutorWithOptions(bus, nil, runtimetools.ExecutorOptions{
 		Config:            options.Config,
@@ -282,7 +268,7 @@ func buildSelectedContractAgentRuntimeFactory(req publishSelectedContractForkEve
 			return managerRef
 		},
 	}, options.ScheduleStore)
-	cleanup, err := startSelectedContractAgentRuntimeGateway(exec, emitRegistry, mcpTurns, func(agentID string) (runtimeactors.AgentConfig, bool) {
+	binding, cleanup, err := startSelectedContractAgentRuntimeGateway(exec, emitRegistry, mcpTurns, func(agentID string) (runtimeactors.AgentConfig, bool) {
 		if managerRef == nil {
 			return runtimeactors.AgentConfig{}, false
 		}
@@ -290,6 +276,25 @@ func buildSelectedContractAgentRuntimeFactory(req publishSelectedContractForkEve
 	})
 	if err != nil {
 		return selectedContractAgentRuntimeFactory{}, fmt.Errorf("start selected-fork tool gateway: %w", err)
+	}
+	modelRuntime := options.LLMRuntime
+	if modelRuntime == nil {
+		modelRuntime, err = runtimellm.RuntimeFactory{
+			Cfg:           options.Config,
+			Sessions:      options.SessionRegistry,
+			Turns:         options.TurnStore,
+			Conversations: options.ConversationStore,
+			Workspaces:    options.Workspace,
+			Events:        bus,
+			MCPTurns:      mcpTurns,
+			ToolGateway:   binding,
+		}.Build()
+		if err != nil {
+			if cleanup != nil {
+				cleanup()
+			}
+			return selectedContractAgentRuntimeFactory{}, fmt.Errorf("build selected-fork agent runtime: %w", err)
+		}
 	}
 	factory := runtimeagents.NewLLMAgentFactory(modelRuntime, exec, exec.ToolDefinitions(), runtimeagents.LLMAgentOptions{
 		PromptResolver:    promptResolver,
@@ -306,9 +311,9 @@ func buildSelectedContractAgentRuntimeFactory(req publishSelectedContractForkEve
 	}, nil
 }
 
-func startSelectedContractAgentRuntimeGateway(exec *runtimetools.Executor, emitRegistry *runtimetools.EmitRegistry, mcpTurns *runtimemcp.TurnContextRegistry, resolveActorConfig func(string) (runtimeactors.AgentConfig, bool)) (func(), error) {
+func startSelectedContractAgentRuntimeGateway(exec *runtimetools.Executor, emitRegistry *runtimetools.EmitRegistry, mcpTurns *runtimemcp.TurnContextRegistry, resolveActorConfig func(string) (runtimeactors.AgentConfig, bool)) (toolgateway.Binding, func(), error) {
 	if exec == nil {
-		return nil, nil
+		return toolgateway.Binding{}, nil, nil
 	}
 	selectedContractAgentRuntimeGatewayEnvMu.Lock()
 	unlock := true
@@ -320,24 +325,44 @@ func startSelectedContractAgentRuntimeGateway(exec *runtimetools.Executor, emitR
 
 	ln, err := net.Listen("tcp", "0.0.0.0:0")
 	if err != nil {
-		return nil, err
+		return toolgateway.Binding{}, nil, err
 	}
 	port := ln.Addr().(*net.TCPAddr).Port
 	hostURL := fmt.Sprintf("http://127.0.0.1:%d", port)
 	containerURL := fmt.Sprintf("http://host.docker.internal:%d", port)
+	gatewayToken := strings.TrimSpace(os.Getenv("SWARM_TOOL_GATEWAY_TOKEN"))
+	if gatewayToken == "" {
+		gatewayToken, err = toolgateway.GenerateAuthToken()
+		if err != nil {
+			_ = ln.Close()
+			return toolgateway.Binding{}, nil, fmt.Errorf("generate selected-fork tool gateway token: %w", err)
+		}
+	}
+	binding := toolgateway.Binding{
+		Transport:         toolgateway.TransportHTTP,
+		HostEndpoint:      hostURL,
+		WorkspaceEndpoint: containerURL,
+		Token:             gatewayToken,
+		LifecycleOwner:    toolgateway.LifecycleOwnerSelectedForkRuntime,
+		Source:            toolgateway.SourceSelectedForkEphemeralGateway,
+	}
+	if err := binding.Validate(); err != nil {
+		_ = ln.Close()
+		return toolgateway.Binding{}, nil, err
+	}
 	prevHostURL, prevHostSet := os.LookupEnv("SWARM_TOOL_GATEWAY_URL")
 	prevContainerURL, prevContainerSet := os.LookupEnv("SWARM_TOOL_GATEWAY_CONTAINER_URL")
 	if err := os.Setenv("SWARM_TOOL_GATEWAY_URL", hostURL); err != nil {
 		_ = ln.Close()
-		return nil, err
+		return toolgateway.Binding{}, nil, err
 	}
 	if err := os.Setenv("SWARM_TOOL_GATEWAY_CONTAINER_URL", containerURL); err != nil {
 		restoreEnv("SWARM_TOOL_GATEWAY_URL", prevHostURL, prevHostSet)
 		_ = ln.Close()
-		return nil, err
+		return toolgateway.Binding{}, nil, err
 	}
 
-	gateway := runtimemcp.NewGateway(exec, strings.TrimSpace(os.Getenv("SWARM_TOOL_GATEWAY_TOKEN")), swaruntime.RuntimeMCPGatewayHooks(nil, nil, resolveActorConfig, nil, emitRegistry, mcpTurns))
+	gateway := runtimemcp.NewGateway(exec, binding.AuthToken(), swaruntime.RuntimeMCPGatewayHooks(nil, nil, resolveActorConfig, nil, emitRegistry, mcpTurns))
 	server := &http.Server{Handler: gateway.Handler()}
 	go func() {
 		if err := server.Serve(ln); err != nil && err != http.ErrServerClosed {
@@ -345,7 +370,7 @@ func startSelectedContractAgentRuntimeGateway(exec *runtimetools.Executor, emitR
 		}
 	}()
 	unlock = false
-	return func() {
+	return binding, func() {
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		_ = server.Shutdown(ctx)
 		cancel()

--- a/internal/runtime/runforkexecution/execution_test.go
+++ b/internal/runtime/runforkexecution/execution_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
@@ -21,8 +22,10 @@ import (
 	runtimeactors "github.com/division-sh/swarm/internal/runtime/core/actors"
 	runtimellm "github.com/division-sh/swarm/internal/runtime/llm"
 	runtimemanager "github.com/division-sh/swarm/internal/runtime/manager"
+	runtimemcp "github.com/division-sh/swarm/internal/runtime/mcp"
 	"github.com/division-sh/swarm/internal/runtime/runforkadmission"
 	"github.com/division-sh/swarm/internal/runtime/semanticview"
+	runtimetools "github.com/division-sh/swarm/internal/runtime/tools"
 	"github.com/division-sh/swarm/internal/store"
 	storerunlifecycle "github.com/division-sh/swarm/internal/store/runlifecycle"
 	"github.com/division-sh/swarm/internal/testutil"
@@ -527,6 +530,49 @@ func TestExecuteSelectedContractRunForkMaterializesAndExecutesForkLocalAgentRunt
 	}
 	if typedRuntimeDiagnostics == 0 {
 		t.Fatalf("typed runtime diagnostics parented to fork event = %d, want > 0", typedRuntimeDiagnostics)
+	}
+}
+
+func TestStartSelectedContractAgentRuntimeGatewayReturnsGeneratedBinding(t *testing.T) {
+	t.Setenv("SWARM_TOOL_GATEWAY_URL", "http://127.0.0.1:9998")
+	t.Setenv("SWARM_TOOL_GATEWAY_CONTAINER_URL", "http://host.docker.internal:9998")
+	t.Setenv("SWARM_TOOL_GATEWAY_TOKEN", "")
+
+	exec := runtimetools.NewExecutorWithOptions(nil, nil, runtimetools.ExecutorOptions{})
+	turns := runtimemcp.NewTurnContextRegistry(runtimeactors.ActorFromContext)
+	binding, cleanup, err := startSelectedContractAgentRuntimeGateway(exec, nil, turns, nil)
+	if err != nil {
+		t.Fatalf("startSelectedContractAgentRuntimeGateway: %v", err)
+	}
+	if cleanup == nil {
+		t.Fatal("cleanup is nil")
+	}
+	defer cleanup()
+	if binding.HostMCPURL() == "" || binding.WorkspaceMCPURL() == "" {
+		t.Fatalf("binding endpoints were not populated: %#v", binding)
+	}
+	if binding.AuthToken() == "" {
+		t.Fatalf("binding token was not generated: %#v", binding)
+	}
+	if got := strings.TrimSpace(os.Getenv("SWARM_TOOL_GATEWAY_URL")); got != strings.TrimSuffix(binding.HostEndpoint, "/") {
+		t.Fatalf("SWARM_TOOL_GATEWAY_URL = %q, want selected-fork host endpoint %q", got, binding.HostEndpoint)
+	}
+	if got := strings.TrimSpace(os.Getenv("SWARM_TOOL_GATEWAY_TOKEN")); got != "" {
+		t.Fatalf("SWARM_TOOL_GATEWAY_TOKEN = %q, want generated binding token to remain typed-only", got)
+	}
+
+	req, err := http.NewRequest(http.MethodPost, binding.HostMCPURL(), strings.NewReader(`{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}`))
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+binding.AuthToken())
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("post selected-fork gateway initialize: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("selected-fork gateway status = %d, want 200", resp.StatusCode)
 	}
 }
 

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -34,6 +34,7 @@ import (
 	"github.com/division-sh/swarm/internal/runtime/semanticview"
 	"github.com/division-sh/swarm/internal/runtime/sessions"
 	runtimestartupownership "github.com/division-sh/swarm/internal/runtime/startupownership"
+	"github.com/division-sh/swarm/internal/runtime/toolgateway"
 	runtimetools "github.com/division-sh/swarm/internal/runtime/tools"
 	workspace "github.com/division-sh/swarm/internal/runtime/workspace"
 	"github.com/google/uuid"
@@ -69,6 +70,7 @@ type RuntimeOptions struct {
 	WorkspaceLifecycle               workspace.Lifecycle
 	EnableToolGateway                bool
 	ToolGatewayToken                 string
+	ToolGatewayBinding               toolgateway.Binding
 	BundleFingerprint                string
 	BundleSourceFact                 runtimecorrelation.BundleSourceFact
 	WorkflowModule                   runtimepipeline.WorkflowModule
@@ -499,6 +501,7 @@ func NewRuntime(ctx context.Context, deps RuntimeDeps) (*Runtime, error) {
 			Workspaces:    rt.Workspace,
 			Events:        rt.Bus,
 			MCPTurns:      rt.MCPTurns,
+			ToolGateway:   opts.ToolGatewayBinding,
 		}.Build()
 		if err != nil {
 			return nil, fmt.Errorf("build runtime: %w", err)
@@ -602,7 +605,11 @@ func NewRuntime(ctx context.Context, deps RuntimeDeps) (*Runtime, error) {
 		rt.InboundGateway.SetRuntimeIngress(rt.RuntimeIngress)
 	}
 	if opts.EnableToolGateway {
-		rt.ToolGateway = runtimemcp.NewGateway(rt.ToolExecutor, strings.TrimSpace(opts.ToolGatewayToken), RuntimeMCPGatewayHooks(rt.Logger, rt.RuntimeIngress, func(agentID string) (runtimeactors.AgentConfig, bool) {
+		toolGatewayToken := opts.ToolGatewayBinding.AuthToken()
+		if toolGatewayToken == "" {
+			toolGatewayToken = strings.TrimSpace(opts.ToolGatewayToken)
+		}
+		rt.ToolGateway = runtimemcp.NewGateway(rt.ToolExecutor, toolGatewayToken, RuntimeMCPGatewayHooks(rt.Logger, rt.RuntimeIngress, func(agentID string) (runtimeactors.AgentConfig, bool) {
 			if rt.Manager == nil {
 				return runtimeactors.AgentConfig{}, false
 			}
@@ -950,7 +957,7 @@ func (rt *Runtime) Start(ctx context.Context) error {
 	}
 	rt.emitBootProgress(15, "workspace_validation_and_system_containers", "ok", fmt.Sprintf("%d system containers", len(rt.Options.SystemContainers)))
 	startupProbe, _ := llm.StartupVisibleToolSurfaceProberForRuntime(rt.LLM)
-	if err := validateClaudeMCPToolsForManagedAgents(ctx, rt.Config, source, startupProbe, rt.MCPTurns, rt.ToolExecutor, rt.Manager); err != nil {
+	if err := validateClaudeMCPToolsForManagedAgents(ctx, rt.Config, source, rt.Options.ToolGatewayBinding, startupProbe, rt.MCPTurns, rt.ToolExecutor, rt.Manager); err != nil {
 		rt.emitBootProgress(16, "mcp_tool_validation", "FAILED", err.Error())
 		return fmt.Errorf("claude runtime mcp validation failed: %w", err)
 	}

--- a/internal/runtime/runtime_agent_free_claude_boot_test.go
+++ b/internal/runtime/runtime_agent_free_claude_boot_test.go
@@ -103,13 +103,10 @@ func TestNewRuntime_AgentPresentCLITestStillRequiresClaudeStartupEnv(t *testing.
 	}
 }
 
-func TestRuntimeStart_ActiveManagerAgentRequiresFullClaudeStartupEnv(t *testing.T) {
+func TestRuntimeStart_ActiveManagerAgentRequiresFullClaudeStartupBinding(t *testing.T) {
 	cfg := &config.Config{}
 	cfg.LLM.Backend = "claude_cli"
 	t.Setenv("SWARM_CLAUDE_USE_MCP", "1")
-	t.Setenv("SWARM_TOOL_GATEWAY_URL", "http://127.0.0.1:8081")
-	t.Setenv("SWARM_TOOL_GATEWAY_CONTAINER_URL", "")
-	t.Setenv("SWARM_TOOL_GATEWAY_TOKEN", "gateway-token")
 	t.Setenv("CLAUDE_CODE_OAUTH_TOKEN", "")
 
 	rt, err := NewRuntime(context.Background(), RuntimeDeps{Config: cfg, Stores: Stores{}, Options: RuntimeOptions{
@@ -119,8 +116,9 @@ func TestRuntimeStart_ActiveManagerAgentRequiresFullClaudeStartupEnv(t *testing.
 		WorkspaceLifecycle: claudeStartupWorkspaceStub{
 			target: &workspace.Target{Container: "swarm-agent-recovered-agent", Workdir: "/workspace"},
 		},
-		EnableToolGateway: true,
-		ToolGatewayToken:  "gateway-token",
+		EnableToolGateway:  true,
+		ToolGatewayToken:   "gateway-token",
+		ToolGatewayBinding: testToolGatewayBinding("http://127.0.0.1:8081", "", "gateway-token"),
 	}})
 
 	if err != nil {
@@ -132,8 +130,8 @@ func TestRuntimeStart_ActiveManagerAgentRequiresFullClaudeStartupEnv(t *testing.
 	}
 
 	err = rt.Start(context.Background())
-	if err == nil || !strings.Contains(err.Error(), "claude runtime startup validation failed") || !strings.Contains(err.Error(), "SWARM_TOOL_GATEWAY_CONTAINER_URL") {
-		t.Fatalf("Start error = %v, want startup validation failure for missing container gateway URL", err)
+	if err == nil || !strings.Contains(err.Error(), "claude runtime startup validation failed") || !strings.Contains(err.Error(), "tool gateway binding workspace endpoint") {
+		t.Fatalf("Start error = %v, want startup validation failure for missing workspace gateway binding", err)
 	}
 }
 

--- a/internal/runtime/runtime_claude_startup.go
+++ b/internal/runtime/runtime_claude_startup.go
@@ -19,6 +19,7 @@ import (
 	runtimemanager "github.com/division-sh/swarm/internal/runtime/manager"
 	runtimemcp "github.com/division-sh/swarm/internal/runtime/mcp"
 	"github.com/division-sh/swarm/internal/runtime/semanticview"
+	"github.com/division-sh/swarm/internal/runtime/toolgateway"
 	workspace "github.com/division-sh/swarm/internal/runtime/workspace"
 )
 
@@ -114,7 +115,7 @@ func validateSelectedBackendCredential(cfg *config.Config) error {
 }
 
 func validateClaudeStartupRequirements(cfg *config.Config, opts RuntimeOptions) error {
-	if err := llm.ValidateClaudeCLIRuntimeConfig(cfg); err != nil {
+	if err := llm.ValidateClaudeCLIRuntimeConfig(cfg, opts.ToolGatewayBinding); err != nil {
 		return err
 	}
 	if opts.WorkspaceLifecycle == nil {
@@ -122,9 +123,6 @@ func validateClaudeStartupRequirements(cfg *config.Config, opts RuntimeOptions) 
 	}
 	if !opts.EnableToolGateway {
 		return fmt.Errorf("tool gateway must be enabled for claude cli runtime")
-	}
-	if strings.TrimSpace(opts.ToolGatewayToken) == "" {
-		return fmt.Errorf("tool gateway token must be configured for claude cli runtime")
 	}
 	return nil
 }
@@ -194,7 +192,7 @@ type claudeStartupContextAwareToolSource interface {
 	ToolCapabilitiesForActorInContext(context.Context, runtimeactors.AgentConfig, []string, map[string]struct{}) toolcapabilities.Set
 }
 
-func validateClaudeMCPToolsForManagedAgents(ctx context.Context, cfg *config.Config, source semanticview.Source, startupProbe llm.StartupVisibleToolSurfaceProber, turnStore llm.MCPTurnContextStore, tools claudeStartupToolSource, manager *runtimemanager.AgentManager) error {
+func validateClaudeMCPToolsForManagedAgents(ctx context.Context, cfg *config.Config, source semanticview.Source, binding toolgateway.Binding, startupProbe llm.StartupVisibleToolSurfaceProber, turnStore llm.MCPTurnContextStore, tools claudeStartupToolSource, manager *runtimemanager.AgentManager) error {
 	enabled, err := isClaudeCLIBackend(cfg)
 	if err != nil {
 		return err
@@ -218,13 +216,13 @@ func validateClaudeMCPToolsForManagedAgents(ctx context.Context, cfg *config.Con
 	if manager == nil {
 		return fmt.Errorf("agent manager is required for claude cli runtime")
 	}
-	gatewayURL := strings.TrimSpace(runtimeConfiguredMCPGatewayURL())
+	gatewayURL := strings.TrimSpace(binding.HostMCPURL())
 	if gatewayURL == "" {
-		return fmt.Errorf("SWARM_TOOL_GATEWAY_URL is required for claude cli runtime")
+		return fmt.Errorf("tool gateway binding host endpoint is required for claude cli runtime")
 	}
-	gatewayToken := strings.TrimSpace(runtimeConfiguredMCPGatewayToken())
+	gatewayToken := strings.TrimSpace(binding.AuthToken())
 	if gatewayToken == "" {
-		return fmt.Errorf("SWARM_TOOL_GATEWAY_TOKEN is required for claude cli runtime")
+		return fmt.Errorf("tool gateway binding token is required for claude cli runtime")
 	}
 	client := &http.Client{Timeout: 10 * time.Second}
 	for _, agentCfg := range manager.ListAgentConfigs() {
@@ -316,14 +314,6 @@ func isClaudeCLIBackend(cfg *config.Config) (bool, error) {
 		return false, err
 	}
 	return profile.ID == llmselection.BackendClaudeCLI, nil
-}
-
-func runtimeConfiguredMCPGatewayURL() string {
-	return strings.TrimSpace(llm.RuntimeMCPGatewayURLForHostExecution())
-}
-
-func runtimeConfiguredMCPGatewayToken() string {
-	return strings.TrimSpace(os.Getenv("SWARM_TOOL_GATEWAY_TOKEN"))
 }
 
 func expectedStartupMCPTools(ctx context.Context, agentCfg runtimeactors.AgentConfig, tools claudeStartupToolSource, sessionTools []llm.ToolDefinition) ([]string, toolcapabilities.Set, error) {

--- a/internal/runtime/runtime_claude_startup_test.go
+++ b/internal/runtime/runtime_claude_startup_test.go
@@ -17,8 +17,20 @@ import (
 	runtimemanager "github.com/division-sh/swarm/internal/runtime/manager"
 	runtimemcp "github.com/division-sh/swarm/internal/runtime/mcp"
 	"github.com/division-sh/swarm/internal/runtime/semanticview"
+	"github.com/division-sh/swarm/internal/runtime/toolgateway"
 	workspace "github.com/division-sh/swarm/internal/runtime/workspace"
 )
+
+func testToolGatewayBinding(hostURL, workspaceURL, token string) toolgateway.Binding {
+	return toolgateway.Binding{
+		Transport:         toolgateway.TransportHTTP,
+		HostEndpoint:      hostURL,
+		WorkspaceEndpoint: workspaceURL,
+		Token:             token,
+		LifecycleOwner:    toolgateway.LifecycleOwnerServeBoot,
+		Source:            toolgateway.SourceBoundMCPListener,
+	}
+}
 
 type claudeStartupWorkspaceStub struct {
 	target *workspace.Target
@@ -63,12 +75,11 @@ func TestValidateClaudeStartupConfig_RequiresWorkspaceAndGateway(t *testing.T) {
 	cfg := &config.Config{}
 	cfg.LLM.Backend = "claude_cli"
 	t.Setenv("SWARM_CLAUDE_USE_MCP", "1")
-	t.Setenv("SWARM_TOOL_GATEWAY_URL", "http://127.0.0.1:8081")
-	t.Setenv("SWARM_TOOL_GATEWAY_CONTAINER_URL", "http://host.docker.internal:8081")
-	t.Setenv("SWARM_TOOL_GATEWAY_TOKEN", "gateway-token")
 	t.Setenv("CLAUDE_CODE_OAUTH_TOKEN", "oauth-token")
 
-	err := validateClaudeStartupConfig(cfg, RuntimeOptions{}, claudeStartupAgentSource())
+	err := validateClaudeStartupConfig(cfg, RuntimeOptions{
+		ToolGatewayBinding: testToolGatewayBinding("http://127.0.0.1:8081", "http://host.docker.internal:8081", "gateway-token"),
+	}, claudeStartupAgentSource())
 	if err == nil || !strings.Contains(err.Error(), "workspace lifecycle") {
 		t.Fatalf("expected workspace lifecycle error, got %v", err)
 	}
@@ -88,7 +99,7 @@ func TestValidateClaudeStartupConfig_SkipsClaudeEnvForAgentFreeSource(t *testing
 	}
 }
 
-func TestValidateClaudeStartupConfigForActiveAgents_RequiresFullCLIEnvForRecoveredManagerAgent(t *testing.T) {
+func TestValidateClaudeStartupConfigForActiveAgents_RequiresFullCLIBindingForRecoveredManagerAgent(t *testing.T) {
 	cfg := &config.Config{}
 	cfg.LLM.Backend = "claude_cli"
 	manager := runtimemanager.NewAgentManager(nil, nil)
@@ -103,17 +114,15 @@ func TestValidateClaudeStartupConfigForActiveAgents_RequiresFullCLIEnvForRecover
 		ToolGatewayToken:  "gateway-token",
 	}
 	t.Setenv("SWARM_CLAUDE_USE_MCP", "1")
-	t.Setenv("SWARM_TOOL_GATEWAY_URL", "http://127.0.0.1:8081")
-	t.Setenv("SWARM_TOOL_GATEWAY_CONTAINER_URL", "")
-	t.Setenv("SWARM_TOOL_GATEWAY_TOKEN", "gateway-token")
 	t.Setenv("CLAUDE_CODE_OAUTH_TOKEN", "")
 
+	opts.ToolGatewayBinding = testToolGatewayBinding("http://127.0.0.1:8081", "", "gateway-token")
 	err := validateClaudeStartupConfigForActiveAgents(cfg, opts, claudeStartupAgentFreeSource(), manager)
-	if err == nil || !strings.Contains(err.Error(), "SWARM_TOOL_GATEWAY_CONTAINER_URL") {
-		t.Fatalf("expected container gateway URL error, got %v", err)
+	if err == nil || !strings.Contains(err.Error(), "tool gateway binding workspace endpoint") {
+		t.Fatalf("expected workspace gateway binding error, got %v", err)
 	}
 
-	t.Setenv("SWARM_TOOL_GATEWAY_CONTAINER_URL", "http://host.docker.internal:8081")
+	opts.ToolGatewayBinding = testToolGatewayBinding("http://127.0.0.1:8081", "http://host.docker.internal:8081", "gateway-token")
 	err = validateClaudeStartupConfigForActiveAgents(cfg, opts, claudeStartupAgentFreeSource(), manager)
 	if err == nil || !strings.Contains(err.Error(), "CLAUDE_CODE_OAUTH_TOKEN") {
 		t.Fatalf("expected oauth token error, got %v", err)
@@ -324,30 +333,28 @@ func startupProbeCaps() map[string]toolcapabilities.Capability {
 	}
 }
 
-func setupStartupProbeTransport(t *testing.T, manager *runtimemanager.AgentManager, exec *startupProbeToolExecutor, gatewayToken string) *runtimemcp.TurnContextRegistry {
+func setupStartupProbeTransport(t *testing.T, manager *runtimemanager.AgentManager, exec *startupProbeToolExecutor, gatewayToken string) (*runtimemcp.TurnContextRegistry, toolgateway.Binding) {
 	t.Helper()
 	turns := runtimemcp.NewTurnContextRegistry(runtimeactors.ActorFromContext)
 	gateway := runtimemcp.NewGateway(exec, gatewayToken, RuntimeMCPGatewayHooks(nil, nil, manager.GetAgentConfig, nil, nil, turns))
 	server := httptest.NewServer(gateway.Handler())
 	t.Cleanup(server.Close)
 	t.Setenv("SWARM_CLAUDE_USE_MCP", "1")
-	t.Setenv("SWARM_TOOL_GATEWAY_URL", server.URL)
-	t.Setenv("SWARM_TOOL_GATEWAY_TOKEN", gatewayToken)
-	return turns
+	return turns, testToolGatewayBinding(server.URL, "http://host.docker.internal:8081", gatewayToken)
 }
 
-func TestValidateClaudeMCPToolsForManagedAgents_SkipsGatewayEnvForAgentFreeSource(t *testing.T) {
+func TestValidateClaudeMCPToolsForManagedAgents_SkipsGatewayBindingForAgentFreeSource(t *testing.T) {
 	cfg := &config.Config{}
 	cfg.LLM.Backend = "claude_cli"
 	t.Setenv("SWARM_TOOL_GATEWAY_URL", "")
 	t.Setenv("SWARM_TOOL_GATEWAY_TOKEN", "")
 
-	if err := validateClaudeMCPToolsForManagedAgents(context.Background(), cfg, claudeStartupAgentFreeSource(), nil, nil, nil, nil); err != nil {
+	if err := validateClaudeMCPToolsForManagedAgents(context.Background(), cfg, claudeStartupAgentFreeSource(), toolgateway.Binding{}, nil, nil, nil, nil); err != nil {
 		t.Fatalf("validateClaudeMCPToolsForManagedAgents: %v", err)
 	}
 }
 
-func TestValidateClaudeMCPToolsForManagedAgents_RequiresGatewayEnvForAgentSource(t *testing.T) {
+func TestValidateClaudeMCPToolsForManagedAgents_RequiresGatewayBindingForAgentSource(t *testing.T) {
 	cfg := &config.Config{}
 	cfg.LLM.Backend = "claude_cli"
 	manager := runtimemanager.NewAgentManager(nil, nil)
@@ -366,13 +373,13 @@ func TestValidateClaudeMCPToolsForManagedAgents_RequiresGatewayEnvForAgentSource
 	t.Setenv("SWARM_TOOL_GATEWAY_URL", "")
 	t.Setenv("SWARM_TOOL_GATEWAY_TOKEN", "")
 
-	err := validateClaudeMCPToolsForManagedAgents(context.Background(), cfg, claudeStartupAgentSource("campaign-coordinator"), nil, turns, exec, manager)
-	if err == nil || !strings.Contains(err.Error(), "SWARM_TOOL_GATEWAY_URL") {
-		t.Fatalf("expected gateway URL error, got %v", err)
+	err := validateClaudeMCPToolsForManagedAgents(context.Background(), cfg, claudeStartupAgentSource("campaign-coordinator"), toolgateway.Binding{}, nil, turns, exec, manager)
+	if err == nil || !strings.Contains(err.Error(), "tool gateway binding host endpoint") {
+		t.Fatalf("expected gateway binding error, got %v", err)
 	}
 }
 
-func TestValidateClaudeMCPToolsForManagedAgents_RequiresGatewayEnvForRecoveredManagerAgent(t *testing.T) {
+func TestValidateClaudeMCPToolsForManagedAgents_RequiresGatewayBindingForRecoveredManagerAgent(t *testing.T) {
 	cfg := &config.Config{}
 	cfg.LLM.Backend = "claude_cli"
 	manager := runtimemanager.NewAgentManager(nil, nil)
@@ -391,9 +398,9 @@ func TestValidateClaudeMCPToolsForManagedAgents_RequiresGatewayEnvForRecoveredMa
 	t.Setenv("SWARM_TOOL_GATEWAY_URL", "")
 	t.Setenv("SWARM_TOOL_GATEWAY_TOKEN", "")
 
-	err := validateClaudeMCPToolsForManagedAgents(context.Background(), cfg, claudeStartupAgentFreeSource(), nil, turns, exec, manager)
-	if err == nil || !strings.Contains(err.Error(), "SWARM_TOOL_GATEWAY_URL") {
-		t.Fatalf("expected gateway URL error, got %v", err)
+	err := validateClaudeMCPToolsForManagedAgents(context.Background(), cfg, claudeStartupAgentFreeSource(), toolgateway.Binding{}, nil, turns, exec, manager)
+	if err == nil || !strings.Contains(err.Error(), "tool gateway binding host endpoint") {
+		t.Fatalf("expected gateway binding error, got %v", err)
 	}
 }
 
@@ -412,10 +419,10 @@ func TestValidateClaudeMCPToolsForManagedAgents_UsesRealFilteredTransport(t *tes
 		defs: startupProbeDefs(),
 		caps: startupProbeCaps(),
 	}
-	turns := setupStartupProbeTransport(t, manager, exec, "gateway-token")
+	turns, binding := setupStartupProbeTransport(t, manager, exec, "gateway-token")
 	probe := &startupVisibleSurfaceProbeStub{}
 
-	if err := validateClaudeMCPToolsForManagedAgents(context.Background(), cfg, claudeStartupAgentSource(), probe, turns, exec, manager); err != nil {
+	if err := validateClaudeMCPToolsForManagedAgents(context.Background(), cfg, claudeStartupAgentSource(), binding, probe, turns, exec, manager); err != nil {
 		t.Fatalf("validateClaudeMCPToolsForManagedAgents: %v", err)
 	}
 	if !slices.Equal(probe.calls, []string{"campaign-coordinator"}) {
@@ -441,9 +448,9 @@ func TestValidateClaudeMCPToolsForManagedAgents_RequiresCLIStartupProbeForMCPOnl
 		defs: startupProbeDefs(),
 		caps: startupProbeCaps(),
 	}
-	turns := setupStartupProbeTransport(t, manager, exec, "gateway-token")
+	turns, binding := setupStartupProbeTransport(t, manager, exec, "gateway-token")
 
-	err := validateClaudeMCPToolsForManagedAgents(context.Background(), cfg, claudeStartupAgentSource(), nil, turns, exec, manager)
+	err := validateClaudeMCPToolsForManagedAgents(context.Background(), cfg, claudeStartupAgentSource(), binding, nil, turns, exec, manager)
 	if err == nil || !strings.Contains(err.Error(), "claude cli startup probe is required") {
 		t.Fatalf("expected required CLI startup probe error, got %v", err)
 	}
@@ -467,10 +474,10 @@ func TestValidateClaudeMCPToolsForManagedAgents_FailsClosedWhenMCPOnlyCLIStartup
 		defs: startupProbeDefs(),
 		caps: startupProbeCaps(),
 	}
-	turns := setupStartupProbeTransport(t, manager, exec, "gateway-token")
+	turns, binding := setupStartupProbeTransport(t, manager, exec, "gateway-token")
 	probe := &startupVisibleSurfaceProbeStub{err: errors.New("claude: command not found")}
 
-	err := validateClaudeMCPToolsForManagedAgents(context.Background(), cfg, claudeStartupAgentSource(), probe, turns, exec, manager)
+	err := validateClaudeMCPToolsForManagedAgents(context.Background(), cfg, claudeStartupAgentSource(), binding, probe, turns, exec, manager)
 	if err == nil || !strings.Contains(err.Error(), "claude cli startup probe failed") || !strings.Contains(err.Error(), "claude: command not found") {
 		t.Fatalf("expected CLI startup probe failure, got %v", err)
 	}
@@ -513,10 +520,10 @@ func TestValidateClaudeMCPToolsForManagedAgents_SeparatesStaticInventoryFromNoCu
 			"emit_vertical_derived": {Name: "emit_vertical_derived", Kind: toolcapabilities.KindEmit, Visible: true, Callable: true},
 		},
 	}
-	turns := setupStartupProbeTransport(t, manager, exec, "gateway-token")
+	turns, binding := setupStartupProbeTransport(t, manager, exec, "gateway-token")
 	probe := &startupVisibleSurfaceProbeStub{}
 
-	if err := validateClaudeMCPToolsForManagedAgents(context.Background(), cfg, claudeStartupAgentSource(), probe, turns, exec, manager); err != nil {
+	if err := validateClaudeMCPToolsForManagedAgents(context.Background(), cfg, claudeStartupAgentSource(), binding, probe, turns, exec, manager); err != nil {
 		t.Fatalf("validateClaudeMCPToolsForManagedAgents: %v", err)
 	}
 	if !slices.Equal(probe.calls, []string{"analysis-agent"}) {
@@ -554,10 +561,10 @@ func TestValidateClaudeMCPToolsForManagedAgents_AllowsEmptyConcreteSurfaceWhenSt
 		},
 		contextCaps: map[string]toolcapabilities.Capability{},
 	}
-	turns := setupStartupProbeTransport(t, manager, exec, "gateway-token")
+	turns, binding := setupStartupProbeTransport(t, manager, exec, "gateway-token")
 	probe := &startupVisibleSurfaceProbeStub{}
 
-	if err := validateClaudeMCPToolsForManagedAgents(context.Background(), cfg, claudeStartupAgentSource(), probe, turns, exec, manager); err != nil {
+	if err := validateClaudeMCPToolsForManagedAgents(context.Background(), cfg, claudeStartupAgentSource(), binding, probe, turns, exec, manager); err != nil {
 		t.Fatalf("validateClaudeMCPToolsForManagedAgents: %v", err)
 	}
 	if !slices.Equal(probe.calls, []string{"validation-agent"}) {
@@ -586,10 +593,10 @@ func TestValidateClaudeMCPToolsForManagedAgents_AcceptsExplicitValidationOnlyPro
 			"health_check": WrapRuntimeError("invalid_tool_input", "tool-executor", "exec_health_check.input", false, nil, "probe input is invalid"),
 		},
 	}
-	turns := setupStartupProbeTransport(t, manager, exec, "gateway-token")
+	turns, binding := setupStartupProbeTransport(t, manager, exec, "gateway-token")
 	probe := &startupVisibleSurfaceProbeStub{}
 
-	if err := validateClaudeMCPToolsForManagedAgents(context.Background(), cfg, claudeStartupAgentSource(), probe, turns, exec, manager); err != nil {
+	if err := validateClaudeMCPToolsForManagedAgents(context.Background(), cfg, claudeStartupAgentSource(), binding, probe, turns, exec, manager); err != nil {
 		t.Fatalf("validateClaudeMCPToolsForManagedAgents: %v", err)
 	}
 	if !slices.Equal(probe.calls, []string{"campaign-coordinator"}) {
@@ -614,11 +621,11 @@ func TestValidateClaudeMCPToolsForManagedAgents_FailsClosedOnConfiguredGatewayTo
 		defs: startupProbeDefs(),
 		caps: startupProbeCaps(),
 	}
-	turns := setupStartupProbeTransport(t, manager, exec, "gateway-token")
-	t.Setenv("SWARM_TOOL_GATEWAY_TOKEN", "wrong-token")
+	turns, binding := setupStartupProbeTransport(t, manager, exec, "gateway-token")
+	binding.Token = "wrong-token"
 	probe := &startupVisibleSurfaceProbeStub{}
 
-	err := validateClaudeMCPToolsForManagedAgents(context.Background(), cfg, claudeStartupAgentSource(), probe, turns, exec, manager)
+	err := validateClaudeMCPToolsForManagedAgents(context.Background(), cfg, claudeStartupAgentSource(), binding, probe, turns, exec, manager)
 	if err == nil || !strings.Contains(err.Error(), "invalid token") {
 		t.Fatalf("expected invalid token error, got %v", err)
 	}
@@ -648,10 +655,10 @@ func TestValidateClaudeMCPToolsForManagedAgents_FailsOnEmptyVisibleToolSurface(t
 			},
 		},
 	}
-	turns := setupStartupProbeTransport(t, manager, exec, "gateway-token")
+	turns, binding := setupStartupProbeTransport(t, manager, exec, "gateway-token")
 	probe := &startupVisibleSurfaceProbeStub{}
 
-	err := validateClaudeMCPToolsForManagedAgents(context.Background(), cfg, claudeStartupAgentSource(), probe, turns, exec, manager)
+	err := validateClaudeMCPToolsForManagedAgents(context.Background(), cfg, claudeStartupAgentSource(), binding, probe, turns, exec, manager)
 	if err == nil || !strings.Contains(err.Error(), "found no visible tools") {
 		t.Fatalf("expected empty visible tools error, got %v", err)
 	}
@@ -689,14 +696,14 @@ func TestValidateClaudeMCPToolsForManagedAgents_UsesLiveVisibleSurfaceForNativeB
 			"web_search": {Name: "web_search", Visible: true, Callable: true},
 		},
 	}
-	turns := setupStartupProbeTransport(t, manager, exec, "gateway-token")
+	turns, binding := setupStartupProbeTransport(t, manager, exec, "gateway-token")
 	probe := &startupVisibleSurfaceProbeStub{
 		resp: &llm.Response{
 			VisibleTools: []string{"Bash", "Read", "Write", "Edit", "WebFetch", "WebSearch"},
 		},
 	}
 
-	if err := validateClaudeMCPToolsForManagedAgents(context.Background(), cfg, claudeStartupAgentSource(), probe, turns, exec, manager); err != nil {
+	if err := validateClaudeMCPToolsForManagedAgents(context.Background(), cfg, claudeStartupAgentSource(), binding, probe, turns, exec, manager); err != nil {
 		t.Fatalf("validateClaudeMCPToolsForManagedAgents: %v", err)
 	}
 	if !slices.Equal(probe.calls, []string{"campaign-coordinator"}) {
@@ -731,14 +738,14 @@ func TestValidateClaudeMCPToolsForManagedAgents_ComparesProviderNativeSurfaceOnl
 			"emit_trend_identified": {Name: "emit_trend_identified", Kind: toolcapabilities.KindEmit, Visible: true, Callable: true},
 		},
 	}
-	turns := setupStartupProbeTransport(t, manager, exec, "gateway-token")
+	turns, binding := setupStartupProbeTransport(t, manager, exec, "gateway-token")
 	probe := &startupVisibleSurfaceProbeStub{
 		resp: &llm.Response{
 			VisibleTools: []string{"WebSearch"},
 		},
 	}
 
-	if err := validateClaudeMCPToolsForManagedAgents(context.Background(), cfg, claudeStartupAgentSource(), probe, turns, exec, manager); err != nil {
+	if err := validateClaudeMCPToolsForManagedAgents(context.Background(), cfg, claudeStartupAgentSource(), binding, probe, turns, exec, manager); err != nil {
 		t.Fatalf("validateClaudeMCPToolsForManagedAgents: %v", err)
 	}
 	if !slices.Equal(probe.calls, []string{"trend-research-agent"}) {
@@ -773,14 +780,14 @@ func TestValidateClaudeMCPToolsForManagedAgents_FailsClosedOnUnexpectedProviderN
 			"emit_trend_identified": {Name: "emit_trend_identified", Kind: toolcapabilities.KindEmit, Visible: true, Callable: true},
 		},
 	}
-	turns := setupStartupProbeTransport(t, manager, exec, "gateway-token")
+	turns, binding := setupStartupProbeTransport(t, manager, exec, "gateway-token")
 	probe := &startupVisibleSurfaceProbeStub{
 		resp: &llm.Response{
 			VisibleTools: []string{"WebSearch", "Bash"},
 		},
 	}
 
-	err := validateClaudeMCPToolsForManagedAgents(context.Background(), cfg, claudeStartupAgentSource(), probe, turns, exec, manager)
+	err := validateClaudeMCPToolsForManagedAgents(context.Background(), cfg, claudeStartupAgentSource(), binding, probe, turns, exec, manager)
 	if err == nil || !strings.Contains(err.Error(), "unexpected visible tool surface") {
 		t.Fatalf("expected provider-native visible-surface mismatch, got %v", err)
 	}
@@ -815,14 +822,14 @@ func TestValidateClaudeMCPToolsForManagedAgents_FailsClosedWhenNativeBuiltinVisi
 			"write_file": {Name: "write_file", Visible: true, Callable: true},
 		},
 	}
-	turns := setupStartupProbeTransport(t, manager, exec, "gateway-token")
+	turns, binding := setupStartupProbeTransport(t, manager, exec, "gateway-token")
 	probe := &startupVisibleSurfaceProbeStub{
 		resp: &llm.Response{
 			VisibleTools: []string{"Read"},
 		},
 	}
 
-	err := validateClaudeMCPToolsForManagedAgents(context.Background(), cfg, claudeStartupAgentSource(), probe, turns, exec, manager)
+	err := validateClaudeMCPToolsForManagedAgents(context.Background(), cfg, claudeStartupAgentSource(), binding, probe, turns, exec, manager)
 	if err == nil || !strings.Contains(err.Error(), "unexpected visible tool surface") {
 		t.Fatalf("expected visible tool surface mismatch, got %v", err)
 	}
@@ -863,10 +870,10 @@ func TestValidateClaudeMCPToolsForManagedAgents_UsesVisibilityOnlyWhenNoExplicit
 					},
 				},
 			}
-			turns := setupStartupProbeTransport(t, manager, exec, "gateway-token")
+			turns, binding := setupStartupProbeTransport(t, manager, exec, "gateway-token")
 			probe := &startupVisibleSurfaceProbeStub{}
 
-			if err := validateClaudeMCPToolsForManagedAgents(context.Background(), cfg, claudeStartupAgentSource(), probe, turns, exec, manager); err != nil {
+			if err := validateClaudeMCPToolsForManagedAgents(context.Background(), cfg, claudeStartupAgentSource(), binding, probe, turns, exec, manager); err != nil {
 				t.Fatalf("validateClaudeMCPToolsForManagedAgents: %v", err)
 			}
 			if !slices.Equal(probe.calls, []string{"campaign-coordinator"}) {
@@ -903,10 +910,10 @@ func TestValidateClaudeMCPToolsForManagedAgents_DoesNotCallSchemaOnlyEmptyObject
 			"query_entities": errors.New("flow-owned entity contract is not available for actor lifecycle-coordinator"),
 		},
 	}
-	turns := setupStartupProbeTransport(t, manager, exec, "gateway-token")
+	turns, binding := setupStartupProbeTransport(t, manager, exec, "gateway-token")
 	probe := &startupVisibleSurfaceProbeStub{}
 
-	if err := validateClaudeMCPToolsForManagedAgents(context.Background(), cfg, claudeStartupAgentSource(), probe, turns, exec, manager); err != nil {
+	if err := validateClaudeMCPToolsForManagedAgents(context.Background(), cfg, claudeStartupAgentSource(), binding, probe, turns, exec, manager); err != nil {
 		t.Fatalf("validateClaudeMCPToolsForManagedAgents: %v", err)
 	}
 	if !slices.Equal(probe.calls, []string{"lifecycle-coordinator"}) {
@@ -939,10 +946,10 @@ func TestValidateClaudeMCPToolsForManagedAgents_UsesVisibilityOnlyWhenVisibleToo
 			},
 		},
 	}
-	turns := setupStartupProbeTransport(t, manager, exec, "gateway-token")
+	turns, binding := setupStartupProbeTransport(t, manager, exec, "gateway-token")
 	probe := &startupVisibleSurfaceProbeStub{}
 
-	if err := validateClaudeMCPToolsForManagedAgents(context.Background(), cfg, claudeStartupAgentSource(), probe, turns, exec, manager); err != nil {
+	if err := validateClaudeMCPToolsForManagedAgents(context.Background(), cfg, claudeStartupAgentSource(), binding, probe, turns, exec, manager); err != nil {
 		t.Fatalf("validateClaudeMCPToolsForManagedAgents: %v", err)
 	}
 	if !slices.Equal(probe.calls, []string{"campaign-coordinator"}) {
@@ -974,10 +981,10 @@ func TestValidateClaudeMCPToolsForManagedAgents_FailsClosedWhenExplicitProbeSafe
 			},
 		},
 	}
-	turns := setupStartupProbeTransport(t, manager, exec, "gateway-token")
+	turns, binding := setupStartupProbeTransport(t, manager, exec, "gateway-token")
 	probe := &startupVisibleSurfaceProbeStub{}
 
-	err := validateClaudeMCPToolsForManagedAgents(context.Background(), cfg, claudeStartupAgentSource(), probe, turns, exec, manager)
+	err := validateClaudeMCPToolsForManagedAgents(context.Background(), cfg, claudeStartupAgentSource(), binding, probe, turns, exec, manager)
 	if err == nil || !strings.Contains(err.Error(), "call_empty_object") {
 		t.Fatalf("expected explicit probe-safe schema mismatch error, got %v", err)
 	}
@@ -1003,10 +1010,10 @@ func TestValidateClaudeMCPToolsForManagedAgents_FailsClosedOnUnexpectedCallableP
 			"health_check": errors.New("unexpected tool failure"),
 		},
 	}
-	turns := setupStartupProbeTransport(t, manager, exec, "gateway-token")
+	turns, binding := setupStartupProbeTransport(t, manager, exec, "gateway-token")
 	probe := &startupVisibleSurfaceProbeStub{}
 
-	err := validateClaudeMCPToolsForManagedAgents(context.Background(), cfg, claudeStartupAgentSource(), probe, turns, exec, manager)
+	err := validateClaudeMCPToolsForManagedAgents(context.Background(), cfg, claudeStartupAgentSource(), binding, probe, turns, exec, manager)
 	if err == nil || !strings.Contains(err.Error(), "unexpected tool failure") {
 		t.Fatalf("expected unexpected callable probe error, got %v", err)
 	}
@@ -1029,10 +1036,10 @@ func TestValidateClaudeMCPToolsForManagedAgents_FailsClosedOnGenericPhraseNonVal
 			"health_check": errors.New("schema validation failed: execution path must be enabled before use"),
 		},
 	}
-	turns := setupStartupProbeTransport(t, manager, exec, "gateway-token")
+	turns, binding := setupStartupProbeTransport(t, manager, exec, "gateway-token")
 	probe := &startupVisibleSurfaceProbeStub{}
 
-	err := validateClaudeMCPToolsForManagedAgents(context.Background(), cfg, claudeStartupAgentSource(), probe, turns, exec, manager)
+	err := validateClaudeMCPToolsForManagedAgents(context.Background(), cfg, claudeStartupAgentSource(), binding, probe, turns, exec, manager)
 	if err == nil || !strings.Contains(err.Error(), "execution path must be enabled before use") {
 		t.Fatalf("expected generic phrase non-validation probe error, got %v", err)
 	}

--- a/internal/runtime/toolgateway/binding.go
+++ b/internal/runtime/toolgateway/binding.go
@@ -1,0 +1,86 @@
+package toolgateway
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+)
+
+type Transport string
+
+const (
+	TransportHTTP Transport = "http"
+
+	LifecycleOwnerServeBoot = "serve_boot"
+	SourceBoundMCPListener  = "bound_mcp_listener"
+)
+
+type Binding struct {
+	Transport         Transport
+	HostEndpoint      string
+	WorkspaceEndpoint string
+	Token             string
+	LifecycleOwner    string
+	Source            string
+}
+
+func (b Binding) Empty() bool {
+	return strings.TrimSpace(string(b.Transport)) == "" &&
+		strings.TrimSpace(b.HostEndpoint) == "" &&
+		strings.TrimSpace(b.WorkspaceEndpoint) == "" &&
+		strings.TrimSpace(b.Token) == ""
+}
+
+func (b Binding) Validate() error {
+	if b.Empty() {
+		return fmt.Errorf("tool gateway binding is required")
+	}
+	if b.Transport != TransportHTTP {
+		return fmt.Errorf("tool gateway binding transport must be %q", TransportHTTP)
+	}
+	if NormalizeMCPServerURL(b.HostEndpoint) == "" {
+		return fmt.Errorf("tool gateway binding host endpoint must be a valid http(s) MCP URL")
+	}
+	if NormalizeMCPServerURL(b.WorkspaceEndpoint) == "" {
+		return fmt.Errorf("tool gateway binding workspace endpoint must be a valid http(s) MCP URL")
+	}
+	if strings.TrimSpace(b.Token) == "" {
+		return fmt.Errorf("tool gateway binding token is required")
+	}
+	return nil
+}
+
+func (b Binding) HostMCPURL() string {
+	return NormalizeMCPServerURL(b.HostEndpoint)
+}
+
+func (b Binding) WorkspaceMCPURL() string {
+	return NormalizeMCPServerURL(b.WorkspaceEndpoint)
+}
+
+func (b Binding) AuthToken() string {
+	return strings.TrimSpace(b.Token)
+}
+
+func NormalizeMCPServerURL(raw string) string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return ""
+	}
+	u, err := url.Parse(raw)
+	if err != nil || strings.TrimSpace(u.Scheme) == "" || strings.TrimSpace(u.Host) == "" {
+		return ""
+	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return ""
+	}
+	path := strings.TrimSpace(u.Path)
+	switch path {
+	case "", "/":
+		u.Path = "/mcp"
+	case "/mcp":
+	default:
+		// Preserve explicit MCP-compatible paths for non-default gateway projections.
+	}
+	return strings.TrimSpace(u.String())
+}

--- a/internal/runtime/toolgateway/binding.go
+++ b/internal/runtime/toolgateway/binding.go
@@ -1,6 +1,8 @@
 package toolgateway
 
 import (
+	"crypto/rand"
+	"encoding/base64"
 	"fmt"
 	"net/url"
 	"strings"
@@ -11,8 +13,12 @@ type Transport string
 const (
 	TransportHTTP Transport = "http"
 
-	LifecycleOwnerServeBoot = "serve_boot"
-	SourceBoundMCPListener  = "bound_mcp_listener"
+	AuthTokenBytes = 32
+
+	LifecycleOwnerServeBoot            = "serve_boot"
+	LifecycleOwnerSelectedForkRuntime  = "selected_fork_agent_runtime"
+	SourceBoundMCPListener             = "bound_mcp_listener"
+	SourceSelectedForkEphemeralGateway = "selected_fork_ephemeral_gateway"
 )
 
 type Binding struct {
@@ -60,6 +66,14 @@ func (b Binding) WorkspaceMCPURL() string {
 
 func (b Binding) AuthToken() string {
 	return strings.TrimSpace(b.Token)
+}
+
+func GenerateAuthToken() (string, error) {
+	raw := make([]byte, AuthTokenBytes)
+	if _, err := rand.Read(raw); err != nil {
+		return "", err
+	}
+	return base64.RawURLEncoding.EncodeToString(raw), nil
 }
 
 func NormalizeMCPServerURL(raw string) string {

--- a/internal/runtime/toolgateway/binding_test.go
+++ b/internal/runtime/toolgateway/binding_test.go
@@ -1,6 +1,9 @@
 package toolgateway
 
-import "testing"
+import (
+	"encoding/base64"
+	"testing"
+)
 
 func TestBindingNormalizesHostAndWorkspaceMCPURLs(t *testing.T) {
 	binding := Binding{
@@ -29,5 +32,18 @@ func TestBindingValidateRequiresWorkspaceEndpoint(t *testing.T) {
 
 	if err := binding.Validate(); err == nil {
 		t.Fatal("expected missing workspace endpoint to fail validation")
+	}
+}
+
+func TestGenerateAuthTokenReturnsURLSafeToken(t *testing.T) {
+	token, err := GenerateAuthToken()
+	if err != nil {
+		t.Fatalf("GenerateAuthToken: %v", err)
+	}
+	if got, want := len(token), base64.RawURLEncoding.EncodedLen(AuthTokenBytes); got != want {
+		t.Fatalf("token length = %d, want %d", got, want)
+	}
+	if _, err := base64.RawURLEncoding.DecodeString(token); err != nil {
+		t.Fatalf("token is not raw URL-safe base64: %v", err)
 	}
 }

--- a/internal/runtime/toolgateway/binding_test.go
+++ b/internal/runtime/toolgateway/binding_test.go
@@ -1,0 +1,33 @@
+package toolgateway
+
+import "testing"
+
+func TestBindingNormalizesHostAndWorkspaceMCPURLs(t *testing.T) {
+	binding := Binding{
+		Transport:         TransportHTTP,
+		HostEndpoint:      "http://127.0.0.1:18082",
+		WorkspaceEndpoint: "http://host.docker.internal:18082",
+		Token:             "gateway-token",
+		LifecycleOwner:    LifecycleOwnerServeBoot,
+		Source:            SourceBoundMCPListener,
+	}
+
+	if got := binding.HostMCPURL(); got != "http://127.0.0.1:18082/mcp" {
+		t.Fatalf("host MCP URL = %q", got)
+	}
+	if got := binding.WorkspaceMCPURL(); got != "http://host.docker.internal:18082/mcp" {
+		t.Fatalf("workspace MCP URL = %q", got)
+	}
+}
+
+func TestBindingValidateRequiresWorkspaceEndpoint(t *testing.T) {
+	binding := Binding{
+		Transport:    TransportHTTP,
+		HostEndpoint: "http://127.0.0.1:18082",
+		Token:        "gateway-token",
+	}
+
+	if err := binding.Validate(); err == nil {
+		t.Fatal("expected missing workspace endpoint to fail validation")
+	}
+}

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -10800,8 +10800,11 @@ cli_specification:
         tool gateway reachability in the approved #1568 first slice. The binding is a typed runtime value
         produced from the actual bound MCP listener before local runtime construction. It closes the local
         stale URL-env endpoint authority class only for local serve/run. It does not close public URL-env
-        retirement outside local serve/run, selected-contract/multi-bundle materialization, host workspace
-        execution, API connection discovery, IPC/unix socket transports, or remote/Kubernetes routing.
+        retirement outside local serve/run, broader selected-contract/multi-bundle materialization,
+        host workspace execution, API connection discovery, IPC/unix socket transports, or remote/Kubernetes
+        routing. It also records the regression-guard requirement that any production Claude runtime factory
+        constructed for a live ephemeral gateway must receive that gateway's typed binding instead of depending
+        on ambient URL env.
       binding_fields:
       - transport
       - host_endpoint
@@ -10834,11 +10837,13 @@ cli_specification:
       - Claude CLI startup MCP probes
       - Claude CLI MCP HTTP config generation
       - Claude CLI Docker exec final-boundary env injection
+      - fork-chat sandbox Claude runtime factory as a local serve consumer
+      - selected-fork ephemeral gateway Claude runtime factory as regression-guard consumer
       - local `claude_cli` preflight diagnostics as consumer-only stale-env reporter
       split_tail:
       - '#1568 public/operator URL-env retirement outside local serve/run remains split.'
       - '#1568 token-source migration beyond token-only env remains split.'
-      - '#979/#1012 selected-contract and multi-bundle gateway materialization remains split.'
+      - '#979/#1012 broader selected-contract and multi-bundle gateway materialization remains split; this first slice only requires a selected-fork ephemeral gateway to pass its own typed binding to its internal Claude runtime factory.'
       - '#1138/#1213 host workspace `claude_cli` execution remains split.'
       - '#1567 API connection discovery and connection-file authority remain split.'
       - 'IPC/unix socket transports and remote/Kubernetes routing remain split.'

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -10759,18 +10759,22 @@ cli_specification:
       scope: >
         Merge-bearing CLI/runtime authority for the narrowed #997 local `cli_test` first slice:
         local serve/run MCP gateway token derivation and MCP-only managed-agent startup proof.
-        This owner does not close full #997, local workspace image contents/default-agent CLI
+        Endpoint/source-authority for local tool gateway reachability is now owned by
+        `cli_specification.foundations.local_tool_gateway_binding`; this owner remains the
+        token-source and startup-proof history for the #997 first slice. This owner does not close full #997,
+        local workspace image contents/default-agent CLI
         availability, Docker Compose setup, selected-contract/multi-bundle gateway materialization,
         or public one-secret quickstart polish.
       gateway_token_rule: >
-        `swarm serve` MUST derive `SWARM_TOOL_GATEWAY_URL` and `SWARM_TOOL_GATEWAY_CONTAINER_URL`
-        from the bound MCP listener and MUST derive a per-boot `SWARM_TOOL_GATEWAY_TOKEN` when
-        the operator did not provide one. An explicit non-empty operator-provided
-        `SWARM_TOOL_GATEWAY_TOKEN` remains authoritative for that process. Local foreground
-        `swarm run` consumes the same serve startup owner and MUST NOT fork an independent
+        `SWARM_TOOL_GATEWAY_TOKEN` remains a token-only source for the #1568 first slice:
+        when present and non-empty it supplies the local tool gateway binding auth token; when absent,
+        local serve/run MUST derive a per-boot token and store it on the typed binding. The token env var
+        MUST NOT own endpoint reachability. `SWARM_TOOL_GATEWAY_URL` and
+        `SWARM_TOOL_GATEWAY_CONTAINER_URL` are not source authority for local serve/run endpoint binding.
+        Local foreground `swarm run` consumes the same serve startup owner and MUST NOT fork an independent
         gateway-token owner.
       gateway_token_consumers:
-      - 'runtime `RuntimeOptions.ToolGatewayToken`'
+      - 'runtime `RuntimeOptions.ToolGatewayBinding`'
       - runtime MCP gateway auth
       - '`llm.ValidateClaudeCLIRuntimeConfig`'
       - Claude CLI docker exec environment
@@ -10786,6 +10790,58 @@ cli_specification:
       - '#996 Docker Compose setup remains split.'
       - '#979/#1012 selected-contract and multi-bundle gateway materialization remains split.'
       - '#1002 runtime workspace source-root image packaging is closed by PR #1034 and is not an open tail.'
+      - '#1568 broader public URL-env retirement, selected-fork/multi-bundle materialization, and remote transport policy remain split.'
+    local_tool_gateway_binding:
+      promoted_by: '#1568'
+      implementation_status: implemented_first_slice
+      canonical_owner: platform-spec.yaml#cli_specification.foundations.local_tool_gateway_binding
+      scope: >
+        Merge-bearing source authority for local `serve` / foreground `run` `claude_cli`
+        tool gateway reachability in the approved #1568 first slice. The binding is a typed runtime value
+        produced from the actual bound MCP listener before local runtime construction. It closes the local
+        stale URL-env endpoint authority class only for local serve/run. It does not close public URL-env
+        retirement outside local serve/run, selected-contract/multi-bundle materialization, host workspace
+        execution, API connection discovery, IPC/unix socket transports, or remote/Kubernetes routing.
+      binding_fields:
+      - transport
+      - host_endpoint
+      - workspace_endpoint
+      - auth_token
+      - lifecycle_owner
+      - source
+      source_rule: >
+        `swarm serve` MUST bind the MCP/tool listener first, then create `ToolGatewayBinding` from that bound
+        address. The host endpoint is the listener URL reachable by the serve process. The workspace endpoint
+        is the workspace-backend projection for containers or workspace processes. The binding source records
+        the bound MCP listener, and the lifecycle owner is serve boot. Local foreground `swarm run` consumes
+        the same binding path through the serve startup owner.
+      endpoint_env_rule: >
+        `SWARM_TOOL_GATEWAY_URL` and `SWARM_TOOL_GATEWAY_CONTAINER_URL` are not public/operator source
+        authority for local serve/run endpoint binding. Stale values MUST NOT override the typed binding.
+        These variables may survive only as generated final-boundary compatibility for launched host/container
+        processes, and only when their values are derived from `ToolGatewayBinding`.
+      auth_rule: >
+        `SWARM_TOOL_GATEWAY_TOKEN` remains token-only source authority for this first slice. If it is empty,
+        serve boot MUST generate a per-boot token and place it on `ToolGatewayBinding`. Runtime gateway auth,
+        startup probes, MCP HTTP config generation, and Docker exec env injection MUST consume the binding token,
+        not a later ambient env read.
+      consumers:
+      - '`cmd/swarm` serve listener binding'
+      - 'local foreground `swarm run` through the serve startup owner'
+      - 'runtime `RuntimeOptions.ToolGatewayBinding`'
+      - runtime MCP gateway auth
+      - '`internal/runtime/llm.ValidateClaudeCLIRuntimeConfig`'
+      - Claude CLI startup MCP probes
+      - Claude CLI MCP HTTP config generation
+      - Claude CLI Docker exec final-boundary env injection
+      - local `claude_cli` preflight diagnostics as consumer-only stale-env reporter
+      split_tail:
+      - '#1568 public/operator URL-env retirement outside local serve/run remains split.'
+      - '#1568 token-source migration beyond token-only env remains split.'
+      - '#979/#1012 selected-contract and multi-bundle gateway materialization remains split.'
+      - '#1138/#1213 host workspace `claude_cli` execution remains split.'
+      - '#1567 API connection discovery and connection-file authority remain split.'
+      - 'IPC/unix socket transports and remote/Kubernetes routing remain split.'
     local_cli_test_workspace_cli_availability:
       promoted_by: '#997'
       implementation_status: implemented

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -10788,7 +10788,7 @@ cli_specification:
       split_tail:
       - '#997 local cli_test workspace image contents/default-agent Claude CLI availability is closed by cli_specification.foundations.local_cli_test_workspace_cli_availability.'
       - '#996 Docker Compose setup remains split.'
-      - '#979/#1012 selected-contract and multi-bundle gateway materialization remains split.'
+      - '#1568 selected-contract and multi-bundle gateway materialization remains split; #979/#1012 are completed historical source-authority slices and are not active trackers for this open gateway tail.'
       - '#1002 runtime workspace source-root image packaging is closed by PR #1034 and is not an open tail.'
       - '#1568 broader public URL-env retirement, selected-fork/multi-bundle materialization, and remote transport policy remain split.'
     local_tool_gateway_binding:
@@ -10843,7 +10843,7 @@ cli_specification:
       split_tail:
       - '#1568 public/operator URL-env retirement outside local serve/run remains split.'
       - '#1568 token-source migration beyond token-only env remains split.'
-      - '#979/#1012 broader selected-contract and multi-bundle gateway materialization remains split; this first slice only requires a selected-fork ephemeral gateway to pass its own typed binding to its internal Claude runtime factory.'
+      - '#1568 broader selected-contract and multi-bundle gateway materialization remains split; this first slice only requires a selected-fork ephemeral gateway to pass its own typed binding to its internal Claude runtime factory. #979/#1012 are completed historical source-authority slices and are not active trackers for this open gateway tail.'
       - '#1138/#1213 host workspace `claude_cli` execution remains split.'
       - '#1567 API connection discovery and connection-file authority remain split.'
       - 'IPC/unix socket transports and remote/Kubernetes routing remain split.'
@@ -10880,7 +10880,7 @@ cli_specification:
       split_tail:
       - '#996 Docker Compose setup remains split.'
       - '#995 schema migration startup diagnostics remain split.'
-      - '#979/#1012 selected-contract and multi-bundle gateway materialization remains split.'
+      - '#1568 selected-contract and multi-bundle gateway materialization remains split; #979/#1012 are completed historical source-authority slices and are not active trackers for this open gateway tail.'
       - '#1002 runtime workspace source-root image packaging is closed by PR #1034 and is not reopened.'
     local_claude_cli_preflight_admission:
       promoted_by: '#1565'


### PR DESCRIPTION
Part of #1568

## Summary
- Adds a typed `ToolGatewayBinding` for the approved local `serve` / foreground `run` `claude_cli` first slice.
- Derives local tool gateway host/workspace endpoints from the actual bound MCP listener instead of public URL env.
- Moves runtime startup validation, MCP startup probes, MCP HTTP config generation, and Docker exec final-boundary env injection to consume the binding.
- Updates `platform-spec.yaml` with `cli_specification.foundations.local_tool_gateway_binding` as the merge-bearing source-authority owner.

## Governing refs / context
- Approved pre-audit gate on #1568: local `serve` / foreground `run` stale URL-env endpoint authority first slice only.
- New authoritative spec section: `platform-spec.yaml#cli_specification.foundations.local_tool_gateway_binding`.
- Adjacent existing spec sections: `cli_specification.foundations.local_cli_test_gateway_startup`, `cli_specification.foundations.local_claude_cli_preflight_admission`, and `cli_specification.command_catalog.serve.listener_topology_v2_1`.
- Followed `docs/IMPLEMENTER_GUIDELINES.md` and `docs/SEMANTIC_DRIFT.md`.

## Semantic migration
- New canonical owner: typed `ToolGatewayBinding` produced from the bound MCP/tool listener during serve boot.
- Old invalid endpoint authority: `SWARM_TOOL_GATEWAY_URL` / `SWARM_TOOL_GATEWAY_CONTAINER_URL` as local serve/run operator source authority.
- Remaining token source: `SWARM_TOOL_GATEWAY_TOKEN` remains token-only source for this first slice; absent token generates a per-boot binding token.
- Production paths checked: local serve listener bind, foreground run via serve startup owner, runtime MCP gateway auth, Claude CLI startup validation/probes, MCP HTTP config generation, Docker exec env injection, and local preflight/doctor stale-env diagnostics.
- Surviving split path: selected-contract/multi-bundle fork materialization still uses env projection and remains split under #979/#1012 / #1568 tail.
- Migration completeness: complete for the approved local serve/run endpoint-authority class, not complete for the broader #1568 parent.

## Verification
- `go test ./internal/runtime/toolgateway ./internal/runtime/llm ./internal/runtime ./cmd/swarm`
- `go test ./cmd/swarm`
- `go test ./...`
