### PR TITLE
[agent-c][issue #1534] Harden timer lifecycle validation

### DIFF
--- a/internal/runtime/bootverify/report_test.go
+++ b/internal/runtime/bootverify/report_test.go
@@ -5233,6 +5233,80 @@ func TestRun_ReportsErrorForTimerStartEventWithoutProducerPath(t *testing.T) {
 	}
 }
 
+func TestRun_AllowsTimerStartEventProducedByArtifactRepoCommitResult(t *testing.T) {
+	artifactHandler := runtimecontracts.SystemNodeEventHandler{
+		Action: runtimecontracts.ActionSpec{
+			ID: "artifact_repo_commit",
+			ArtifactRepo: &runtimecontracts.ArtifactRepoSpec{
+				Provider:     "local_git",
+				RepoID:       runtimecontracts.RefExpression("entity.repo_id"),
+				Namespace:    runtimecontracts.RefExpression("event.run_id"),
+				RequestID:    runtimecontracts.RefExpression("payload.request_id"),
+				AllowedPaths: []string{"readme.md"},
+				Files: []runtimecontracts.ArtifactRepoFileSpec{{
+					Path:        runtimecontracts.LiteralExpression("readme.md"),
+					Content:     runtimecontracts.RefExpression("payload.readme"),
+					ContentType: "markdown",
+				}},
+				Output: runtimecontracts.ArtifactRepoOutputSpec{
+					RepoURL:           "repo_url",
+					CurrentRef:        "current_ref",
+					FileManifest:      "file_manifest",
+					Status:            "status",
+					FailureReason:     "failure_reason",
+					LastRequestID:     "last_request_id",
+					LastSourceEventID: "last_source_event_id",
+				},
+				SuccessEvent: "artifact_repo.commit_completed",
+				FailureEvent: "artifact_repo.commit_failed",
+			},
+		},
+	}
+	timerHandler := runtimecontracts.SystemNodeEventHandler{AdvancesTo: "done"}
+	source := semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
+		Events: map[string]runtimecontracts.EventCatalogEntry{
+			"artifact.commit_requested":      {},
+			"artifact_repo.commit_completed": artifactRepoTimerResultEventEntry(true),
+			"artifact_repo.commit_failed":    artifactRepoTimerResultEventEntry(false),
+			"timer.reminder":                 {},
+		},
+		Nodes: map[string]runtimecontracts.SystemNodeContract{
+			"artifact-node": {
+				ID: "artifact-node",
+				EventHandlers: map[string]runtimecontracts.SystemNodeEventHandler{
+					"artifact.commit_requested": artifactHandler,
+					"timer.reminder":            timerHandler,
+				},
+			},
+		},
+		Semantics: runtimecontracts.WorkflowSemanticView{
+			Timers: []runtimecontracts.WorkflowTimerContract{{
+				ID:      "reminder",
+				Owner:   "artifact-node",
+				Event:   "timer.reminder",
+				Delay:   "1m",
+				StartOn: "event:artifact_repo.commit_completed",
+			}},
+			NodeHandlers: map[string]map[string]runtimecontracts.SystemNodeEventHandler{
+				"artifact-node": {
+					"artifact.commit_requested": artifactHandler,
+					"timer.reminder":            timerHandler,
+				},
+			},
+			EventOwners: map[string][]string{
+				"artifact.commit_requested": {"artifact-node"},
+				"timer.reminder":            {"artifact-node"},
+			},
+		},
+	})
+
+	report := Run(context.Background(), source, Options{})
+
+	if reportContains(report.Errors(), "timer_validation", "start_on event artifact_repo.commit_completed has no producer path") {
+		t.Fatalf("unexpected timer_validation producer error for artifact result event, got %#v", report.Errors())
+	}
+}
+
 func TestRun_ReportsErrorForTimerCancelEventWithoutProducerPath(t *testing.T) {
 	root := writeTimerValidationFixtureWithOptions(t, timerValidationFixtureOptions{
 		startOn:              "event:ticket.opened",
@@ -5573,6 +5647,30 @@ func timerValidationHasExternalSource(events []string, eventType string) bool {
 		}
 	}
 	return false
+}
+
+func artifactRepoTimerResultEventEntry(success bool) runtimecontracts.EventCatalogEntry {
+	properties := map[string]runtimecontracts.EventFieldSpec{
+		"repo_id":         {Type: "string"},
+		"namespace":       {Type: "string"},
+		"request_id":      {Type: "string"},
+		"source_event_id": {Type: "string"},
+		"provenance":      {Type: "object"},
+	}
+	required := []string{"repo_id", "namespace", "request_id", "source_event_id", "provenance"}
+	if success {
+		properties["repo_url"] = runtimecontracts.EventFieldSpec{Type: "string"}
+		properties["current_ref"] = runtimecontracts.EventFieldSpec{Type: "string"}
+		properties["file_manifest"] = runtimecontracts.EventFieldSpec{Type: "object"}
+		required = append(required, "repo_url", "current_ref", "file_manifest")
+	} else {
+		properties["failure_reason"] = runtimecontracts.EventFieldSpec{Type: "string"}
+		required = append(required, "failure_reason")
+	}
+	return runtimecontracts.EventCatalogEntry{
+		Payload:  runtimecontracts.EventPayloadSpec{Properties: properties},
+		Required: required,
+	}
 }
 
 func writeCrossFlowPinAmbiguityFixture(t *testing.T, scoped bool) string {

--- a/internal/runtime/bootverify/report_test.go
+++ b/internal/runtime/bootverify/report_test.go
@@ -5069,13 +5069,13 @@ func TestRun_ReportsErrorForUnknownTimerTriggerState(t *testing.T) {
 	}
 }
 
-func TestRun_ReportsWarningForUnknownTimerTriggerEvent(t *testing.T) {
+func TestRun_ReportsErrorForUnknownTimerTriggerEvent(t *testing.T) {
 	root := writeTimerValidationFixture(t, "event:ticket.unknown", "")
 	repoRoot := repoRootForBootverifyTest(t)
 	platformSpec := runtimecontracts.DefaultPlatformSpecFile(repoRoot)
 	report := Run(context.Background(), semanticview.Wrap(loadFixtureBundleAt(t, repoRoot, root, platformSpec)), Options{})
-	if !reportContains(report.Warnings(), "timer_validation", "unknown event") {
-		t.Fatalf("expected timer_validation unknown event warning, got %#v", report.Warnings())
+	if !reportContains(report.Errors(), "timer_validation", "unknown event") {
+		t.Fatalf("expected timer_validation unknown event error, got %#v", report.Errors())
 	}
 }
 
@@ -5112,6 +5112,151 @@ func TestRun_ReportsErrorForTimerEventMissingFromCatalog(t *testing.T) {
 	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
 	if !reportContains(report.Errors(), "timer_validation", "event timer.missing missing from event catalog") {
 		t.Fatalf("expected timer_validation missing timer event error, got %#v", report.Errors())
+	}
+}
+
+func TestRun_ReportsErrorForTimerFireEventWithoutExecutableConsumer(t *testing.T) {
+	root := writeTimerValidationFixtureWithOptions(t, timerValidationFixtureOptions{
+		startOn:           "event:ticket.opened",
+		owner:             "support-node",
+		event:             "timer.reminder",
+		includeTimerEvent: true,
+		omitTimerHandler:  true,
+	})
+	repoRoot := repoRootForBootverifyTest(t)
+	platformSpec := runtimecontracts.DefaultPlatformSpecFile(repoRoot)
+	report := Run(context.Background(), semanticview.Wrap(loadFixtureBundleAt(t, repoRoot, root, platformSpec)), Options{})
+	if !reportContains(report.Errors(), "timer_validation", "has no executable consumer") {
+		t.Fatalf("expected timer_validation no-consumer error, got %#v", report.Errors())
+	}
+	if reportContains(report.Warnings(), "semantic_drift_dead_event_schema", "support/timer.reminder") {
+		t.Fatalf("timer reference should still satisfy dead-event accounting; timer_validation owns consumer proof, got %#v", report.Warnings())
+	}
+}
+
+func TestRun_AllowsTimerFireEventWithHandlerConsumer(t *testing.T) {
+	root := writeTimerValidationFixture(t, "event:ticket.opened", "")
+	repoRoot := repoRootForBootverifyTest(t)
+	platformSpec := runtimecontracts.DefaultPlatformSpecFile(repoRoot)
+	report := Run(context.Background(), semanticview.Wrap(loadFixtureBundleAt(t, repoRoot, root, platformSpec)), Options{})
+	if reportContains(report.Errors(), "timer_validation", "timer reminder") {
+		t.Fatalf("unexpected timer_validation error for handler consumer, got %#v", report.Errors())
+	}
+}
+
+func TestRun_AllowsTimerFireEventWithAgentConsumer(t *testing.T) {
+	root := writeTimerValidationFixtureWithOptions(t, timerValidationFixtureOptions{
+		startOn:           "event:ticket.opened",
+		owner:             "support-node",
+		event:             "timer.reminder",
+		includeTimerEvent: true,
+		omitTimerHandler:  true,
+		flowAgents: `
+reminder-agent:
+  model: regular
+  conversation_mode: stateless
+  subscriptions: [timer.reminder]
+  emit_events: []
+`,
+	})
+	repoRoot := repoRootForBootverifyTest(t)
+	platformSpec := runtimecontracts.DefaultPlatformSpecFile(repoRoot)
+	report := Run(context.Background(), semanticview.Wrap(loadFixtureBundleAt(t, repoRoot, root, platformSpec)), Options{})
+	if reportContains(report.Errors(), "timer_validation", "has no executable consumer") {
+		t.Fatalf("unexpected timer_validation no-consumer error for agent subscriber, got %#v", report.Errors())
+	}
+}
+
+func TestRun_AllowsTimerFireEventWithWildcardConsumer(t *testing.T) {
+	root := writeTimerValidationFixtureWithOptions(t, timerValidationFixtureOptions{
+		startOn:           "event:ticket.opened",
+		owner:             "support-node",
+		event:             "timer.reminder",
+		includeTimerEvent: true,
+		timerHandlerKey:   "timer.*",
+	})
+	repoRoot := repoRootForBootverifyTest(t)
+	platformSpec := runtimecontracts.DefaultPlatformSpecFile(repoRoot)
+	report := Run(context.Background(), semanticview.Wrap(loadFixtureBundleAt(t, repoRoot, root, platformSpec)), Options{})
+	if reportContains(report.Errors(), "timer_validation", "has no executable consumer") {
+		t.Fatalf("unexpected timer_validation no-consumer error for wildcard handler, got %#v", report.Errors())
+	}
+}
+
+func TestRun_AllowsTimerFireEventWithExternalConsumer(t *testing.T) {
+	root := writeTimerValidationFixtureWithOptions(t, timerValidationFixtureOptions{
+		startOn:           "event:ticket.opened",
+		owner:             "support-node",
+		event:             "timer.reminder",
+		includeTimerEvent: true,
+		omitTimerHandler:  true,
+		timerEventSwarm:   "consumer: mailbox_system",
+	})
+	repoRoot := repoRootForBootverifyTest(t)
+	platformSpec := runtimecontracts.DefaultPlatformSpecFile(repoRoot)
+	report := Run(context.Background(), semanticview.Wrap(loadFixtureBundleAt(t, repoRoot, root, platformSpec)), Options{})
+	if reportContains(report.Errors(), "timer_validation", "has no executable consumer") {
+		t.Fatalf("unexpected timer_validation no-consumer error for external consumer, got %#v", report.Errors())
+	}
+}
+
+func TestRun_AllowsTimerFireEventWithOutputBoundary(t *testing.T) {
+	root := writeTimerValidationFixtureWithOptions(t, timerValidationFixtureOptions{
+		startOn:           "event:ticket.opened",
+		owner:             "support-node",
+		event:             "timer.reminder",
+		includeTimerEvent: true,
+		omitTimerHandler:  true,
+		flowOutputs:       []string{"timer.reminder"},
+	})
+	repoRoot := repoRootForBootverifyTest(t)
+	platformSpec := runtimecontracts.DefaultPlatformSpecFile(repoRoot)
+	report := Run(context.Background(), semanticview.Wrap(loadFixtureBundleAt(t, repoRoot, root, platformSpec)), Options{})
+	if reportContains(report.Errors(), "timer_validation", "has no executable consumer") {
+		t.Fatalf("unexpected timer_validation no-consumer error for output boundary, got %#v", report.Errors())
+	}
+}
+
+func TestRun_ReportsErrorForTimerStartEventWithoutProducerPath(t *testing.T) {
+	root := writeTimerValidationFixtureWithOptions(t, timerValidationFixtureOptions{
+		startOn:              "event:ticket.closed",
+		owner:                "support-node",
+		event:                "timer.reminder",
+		includeTimerEvent:    true,
+		externalSourceEvents: []string{"ticket.opened"},
+	})
+	repoRoot := repoRootForBootverifyTest(t)
+	platformSpec := runtimecontracts.DefaultPlatformSpecFile(repoRoot)
+	report := Run(context.Background(), semanticview.Wrap(loadFixtureBundleAt(t, repoRoot, root, platformSpec)), Options{})
+	if !reportContains(report.Errors(), "timer_validation", "start_on event support/ticket.closed has no producer path") {
+		t.Fatalf("expected timer_validation start_on producer error, got %#v", report.Errors())
+	}
+}
+
+func TestRun_ReportsErrorForTimerCancelEventWithoutProducerPath(t *testing.T) {
+	root := writeTimerValidationFixtureWithOptions(t, timerValidationFixtureOptions{
+		startOn:              "event:ticket.opened",
+		cancelOn:             "event:ticket.closed",
+		owner:                "support-node",
+		event:                "timer.reminder",
+		includeTimerEvent:    true,
+		externalSourceEvents: []string{"ticket.opened"},
+	})
+	repoRoot := repoRootForBootverifyTest(t)
+	platformSpec := runtimecontracts.DefaultPlatformSpecFile(repoRoot)
+	report := Run(context.Background(), semanticview.Wrap(loadFixtureBundleAt(t, repoRoot, root, platformSpec)), Options{})
+	if !reportContains(report.Errors(), "timer_validation", "cancel_on event support/ticket.closed has no producer path") {
+		t.Fatalf("expected timer_validation cancel_on producer error, got %#v", report.Errors())
+	}
+}
+
+func TestRun_ReportsErrorForUnknownTimerCancelEvent(t *testing.T) {
+	root := writeTimerValidationFixture(t, "event:ticket.opened", "event:ticket.unknown")
+	repoRoot := repoRootForBootverifyTest(t)
+	platformSpec := runtimecontracts.DefaultPlatformSpecFile(repoRoot)
+	report := Run(context.Background(), semanticview.Wrap(loadFixtureBundleAt(t, repoRoot, root, platformSpec)), Options{})
+	if !reportContains(report.Errors(), "timer_validation", "cancel_on references unknown event ticket.unknown") {
+		t.Fatalf("expected timer_validation unknown cancel event error, got %#v", report.Errors())
 	}
 }
 
@@ -5278,11 +5423,17 @@ support/item.created:
 }
 
 type timerValidationFixtureOptions struct {
-	startOn           string
-	cancelOn          string
-	owner             string
-	event             string
-	includeTimerEvent bool
+	startOn              string
+	cancelOn             string
+	owner                string
+	event                string
+	includeTimerEvent    bool
+	omitTimerHandler     bool
+	timerHandlerKey      string
+	timerEventSwarm      string
+	flowOutputs          []string
+	flowAgents           string
+	externalSourceEvents []string
 }
 
 func writeTimerValidationFixture(t *testing.T, startOn, cancelOn string) string {
@@ -5300,6 +5451,18 @@ func writeTimerValidationFixtureWithOptions(t *testing.T, opts timerValidationFi
 	root := t.TempDir()
 	if strings.TrimSpace(opts.event) == "" {
 		opts.event = "timer.reminder"
+	}
+	externalSourceEvents := opts.externalSourceEvents
+	if externalSourceEvents == nil {
+		externalSourceEvents = []string{"ticket.opened", "ticket.closed"}
+	}
+	flowAgents := opts.flowAgents
+	if strings.TrimSpace(flowAgents) == "" {
+		flowAgents = "{}\n"
+	}
+	timerHandlerKey := strings.TrimSpace(opts.timerHandlerKey)
+	if timerHandlerKey == "" {
+		timerHandlerKey = opts.event
 	}
 
 	writeBootverifyFixtureFile(t, filepath.Join(root, "package.yaml"), `
@@ -5320,27 +5483,33 @@ ticket:
 	writeBootverifyFixtureFile(t, filepath.Join(root, "tools.yaml"), "{}\n")
 	writeBootverifyFixtureFile(t, filepath.Join(root, "agents.yaml"), "{}\n")
 	writeBootverifyFixtureFile(t, filepath.Join(root, "events.yaml"), "{}\n")
-	timerEventBlock := ""
-	if opts.includeTimerEvent {
-		timerEventBlock = strings.TrimSpace(`
-` + opts.event + `:
-  entity_id: string
-`)
+	flowPinsBlock := ""
+	if len(opts.flowOutputs) > 0 {
+		flowPinsBlock = `
+pins:
+  inputs:
+    events: []
+  outputs:
+    events:
+`
+		for _, output := range opts.flowOutputs {
+			flowPinsBlock += "      - " + output + "\n"
+		}
 	}
 	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "support", "schema.yaml"), `
 name: support
 initial_state: waiting
 terminal_states: [done]
 states: [waiting, active, done]
-`)
+`+flowPinsBlock)
 	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "support", "policy.yaml"), "{}\n")
-	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "support", "events.yaml"), `
-ticket.opened:
-  entity_id: string
-ticket.closed:
-  entity_id: string
-`+timerEventBlock+`
-`)
+	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "support", "agents.yaml"), flowAgents)
+	eventsYAML := timerValidationEventEntry("ticket.opened", timerValidationHasExternalSource(externalSourceEvents, "ticket.opened"), "")
+	eventsYAML += timerValidationEventEntry("ticket.closed", timerValidationHasExternalSource(externalSourceEvents, "ticket.closed"), "")
+	if opts.includeTimerEvent {
+		eventsYAML += timerValidationEventEntry(opts.event, false, opts.timerEventSwarm)
+	}
+	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "support", "events.yaml"), eventsYAML)
 	timerBlock := `
     - id: reminder
       owner: ` + opts.owner + `
@@ -5349,6 +5518,10 @@ ticket.closed:
       start_on: ` + opts.startOn + "\n"
 	if strings.TrimSpace(opts.cancelOn) != "" {
 		timerBlock += "      cancel_on: " + opts.cancelOn + "\n"
+	}
+	timerHandlerBlock := ""
+	if !opts.omitTimerHandler {
+		timerHandlerBlock = "    " + timerHandlerKey + ":\n      advances_to: done\n"
 	}
 	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "support", "nodes.yaml"), `
 support-node:
@@ -5365,10 +5538,41 @@ support-node:
       advances_to: active
     ticket.closed:
       advances_to: done
-    timer.reminder:
-      advances_to: done
-`)
+`+timerHandlerBlock)
 	return root
+}
+
+func timerValidationEventEntry(eventType string, externalSource bool, swarmLines string) string {
+	eventType = strings.TrimSpace(eventType)
+	if eventType == "" {
+		return ""
+	}
+	out := eventType + ":\n  entity_id: string\n"
+	swarmLines = strings.TrimSpace(swarmLines)
+	if externalSource || swarmLines != "" {
+		out += "  swarm:\n"
+		if externalSource {
+			out += "    source: external\n"
+		}
+		for _, line := range strings.Split(swarmLines, "\n") {
+			line = strings.TrimSpace(line)
+			if line == "" {
+				continue
+			}
+			out += "    " + line + "\n"
+		}
+	}
+	return out
+}
+
+func timerValidationHasExternalSource(events []string, eventType string) bool {
+	eventType = strings.TrimSpace(eventType)
+	for _, candidate := range events {
+		if strings.TrimSpace(candidate) == eventType {
+			return true
+		}
+	}
+	return false
 }
 
 func writeCrossFlowPinAmbiguityFixture(t *testing.T, scoped bool) string {

--- a/internal/runtime/bootverify/workflow_timer_checks.go
+++ b/internal/runtime/bootverify/workflow_timer_checks.go
@@ -39,13 +39,16 @@ func (c *checkerContext) timerValidation() []Finding {
 				}
 			}
 		}
-		if !eventExists(c.source, strings.TrimSpace(timer.Event)) {
+		fireEvent := semanticview.ResolveFlowEventProof(c.source, timer.FlowID, timer.Event)
+		if !fireEvent.HasSchema {
 			c.timerFindings = append(c.timerFindings, Finding{
 				CheckID:  "timer_validation",
 				Severity: "error",
 				Message:  fmt.Sprintf("timer %s event %s missing from event catalog", timer.ID, timer.Event),
 				Location: strings.TrimSpace(timer.ID),
 			})
+		} else {
+			c.validateTimerFireEventConsumer(timer, fireEvent)
 		}
 		startTrigger, err := timeridentity.ParseStartTrigger(timer.StartOn)
 		if err != nil {
@@ -88,15 +91,167 @@ func (c *checkerContext) validateTimerTrigger(timer runtimecontracts.WorkflowTim
 			})
 		}
 	case timeridentity.TriggerKindEvent:
-		if !eventExists(c.source, trigger.Name) {
+		ref := semanticview.ResolveFlowEventProof(c.source, timer.FlowID, trigger.Name)
+		if !ref.HasSchema {
 			c.timerFindings = append(c.timerFindings, Finding{
 				CheckID:  "timer_validation",
-				Severity: "warning",
+				Severity: "error",
 				Message:  fmt.Sprintf("timer %s %s references unknown event %s", timer.ID, field, trigger.Name),
+				Location: strings.TrimSpace(timer.ID),
+			})
+			return
+		}
+		if !c.timerTriggerEventProduced(timer, ref) {
+			c.timerFindings = append(c.timerFindings, Finding{
+				CheckID:  "timer_validation",
+				Severity: "error",
+				Message:  fmt.Sprintf("timer %s %s event %s has no producer path", timer.ID, field, ref.DisplayName()),
 				Location: strings.TrimSpace(timer.ID),
 			})
 		}
 	}
+}
+
+func (c *checkerContext) validateTimerFireEventConsumer(timer runtimecontracts.WorkflowTimerContract, ref semanticview.FlowEventProof) {
+	if timerFireEventHasConsumer(c.source, ref) {
+		return
+	}
+	c.timerFindings = append(c.timerFindings, Finding{
+		CheckID:  "timer_validation",
+		Severity: "error",
+		Message:  fmt.Sprintf("timer %s event %s has no executable consumer or explicit external/exported role", timer.ID, ref.DisplayName()),
+		Location: strings.TrimSpace(timer.ID),
+	})
+}
+
+func timerFireEventHasConsumer(source semanticview.Source, ref semanticview.FlowEventProof) bool {
+	if source == nil {
+		return false
+	}
+	if len(source.RuntimeEventOwners(ref.Canonical)) > 0 {
+		return true
+	}
+	if timerFireEventHasAgentConsumer(source, ref) {
+		return true
+	}
+	if eventHasExternalConsumerLocal(ref.Entry) {
+		return true
+	}
+	return ref.CrossesDeclaredOutputBoundary(source)
+}
+
+func timerFireEventHasAgentConsumer(source semanticview.Source, ref semanticview.FlowEventProof) bool {
+	subscribedRefs := map[string]semanticview.FlowEventProof{}
+	subscriptionPatterns := map[string]eventPatternLocal{}
+	for _, required := range source.RequiredAgents() {
+		for _, eventType := range required.SubscribesTo {
+			addTimerAgentSubscriptionProof(source, subscribedRefs, subscriptionPatterns, "", "", eventType)
+		}
+	}
+	for _, scope := range source.FlowScopes() {
+		flowID := strings.TrimSpace(scope.ID)
+		for _, required := range source.FlowRequiredAgents(flowID) {
+			for _, eventType := range required.SubscribesTo {
+				addTimerAgentSubscriptionProof(source, subscribedRefs, subscriptionPatterns, scope.PackageKey, flowID, eventType)
+			}
+		}
+	}
+	for agentID, agent := range source.AgentEntries() {
+		agentSource, _ := source.AgentContractSource(agentID)
+		flowID := strings.TrimSpace(agentSource.FlowID)
+		for _, eventType := range append(append([]string{}, agent.Subscriptions...), agent.SubscribesTo...) {
+			addTimerAgentSubscriptionProof(source, subscribedRefs, subscriptionPatterns, agentSource.PackageKey, flowID, eventType)
+		}
+	}
+	return eventRefConsumedLocal(source, ref.Canonical, subscribedRefs, subscriptionPatterns)
+}
+
+func addTimerAgentSubscriptionProof(source semanticview.Source, subscribedRefs map[string]semanticview.FlowEventProof, patterns map[string]eventPatternLocal, packageKey, flowID, eventType string) {
+	eventType = strings.TrimSpace(eventType)
+	if eventType == "" {
+		return
+	}
+	if strings.Contains(eventType, "*") {
+		addEventPatternLocal(patterns, packageKey, flowID, eventType)
+		return
+	}
+	addEventProofLocal(subscribedRefs, source, flowID, eventType)
+}
+
+func (c *checkerContext) timerTriggerEventProduced(timer runtimecontracts.WorkflowTimerContract, ref semanticview.FlowEventProof) bool {
+	if c.source == nil {
+		return false
+	}
+	if timerEventProducedByPlatform(c.source, ref) || eventProducedExternallyLocal(ref.Entry) {
+		return true
+	}
+	emittedRefs := timerLifecycleEmittedEventRefs(c.source, strings.TrimSpace(timer.ID))
+	return eventRefProducedLocal(c.source, ref, emittedRefs)
+}
+
+func timerEventProducedByPlatform(source semanticview.Source, ref semanticview.FlowEventProof) bool {
+	if source == nil {
+		return false
+	}
+	for _, candidate := range []string{ref.Canonical, ref.CatalogKey, ref.Authored, ref.Local} {
+		if runtimecontracts.PlatformEventCatalogContains(source.PlatformSpec(), strings.TrimSpace(candidate)) {
+			return true
+		}
+	}
+	return false
+}
+
+func timerLifecycleEmittedEventRefs(source semanticview.Source, excludeTimerID string) map[string]semanticview.FlowEventProof {
+	emittedRefs := map[string]semanticview.FlowEventProof{}
+	if source == nil {
+		return emittedRefs
+	}
+	if bundle, ok := semanticview.Bundle(source); ok && bundle != nil && bundle.RootSchema != nil {
+		addEventProofLocal(emittedRefs, source, "", bundle.RootSchema.AutoEmitOnCreate.Event)
+	}
+	for _, scope := range source.FlowScopes() {
+		if eventType := strings.TrimSpace(scope.AutoEmitEvent); eventType != "" {
+			addEventProofLocal(emittedRefs, source, scope.ID, eventType)
+		}
+		for _, required := range source.FlowRequiredAgents(scope.ID) {
+			for _, eventType := range required.Emits {
+				addEventProofLocal(emittedRefs, source, scope.ID, eventType)
+			}
+		}
+	}
+	for _, required := range source.RequiredAgents() {
+		for _, eventType := range required.Emits {
+			addEventProofLocal(emittedRefs, source, "", eventType)
+		}
+	}
+	for nodeID := range source.NodeEntries() {
+		nodeSource, _ := source.NodeContractSource(nodeID)
+		flowID := strings.TrimSpace(nodeSource.FlowID)
+		for _, eventType := range source.NodeHandlerSubscriptions(nodeID) {
+			handler, ok := source.NodeEventHandler(nodeID, eventType)
+			if !ok {
+				continue
+			}
+			for _, emitted := range handlerEmits(handler) {
+				addEventProofLocal(emittedRefs, source, flowID, emitted)
+			}
+		}
+	}
+	for _, timer := range source.WorkflowTimers() {
+		if strings.TrimSpace(timer.ID) == excludeTimerID {
+			continue
+		}
+		addEventProofLocal(emittedRefs, source, timer.FlowID, timer.Event)
+	}
+	for agentID, agent := range source.AgentEntries() {
+		agentSource, _ := source.AgentContractSource(agentID)
+		flowID := strings.TrimSpace(agentSource.FlowID)
+		for _, eventType := range agent.EmitEvents {
+			addEventProofLocal(emittedRefs, source, flowID, eventType)
+		}
+	}
+	addCompositionConnectEventProofsLocal(source, emittedRefs, map[string]semanticview.FlowEventProof{})
+	return emittedRefs
 }
 
 func flowStatesForTimer(source semanticview.Source, flowID string) []string {

--- a/internal/runtime/contracts/workflow_contract_emit.go
+++ b/internal/runtime/contracts/workflow_contract_emit.go
@@ -7,6 +7,7 @@ func HandlerEmitEvents(handler SystemNodeEventHandler) []string {
 	if eventType := handler.Emit.EventType(); eventType != "" {
 		out = append(out, eventType)
 	}
+	out = append(out, actionResultEvents(handler.Action)...)
 	for _, rule := range handler.Rules {
 		out = append(out, ruleEmitEvents(rule)...)
 	}
@@ -38,12 +39,23 @@ func ruleEmitEvents(rule HandlerRuleEntry) []string {
 	if eventType := rule.Emit.EventType(); eventType != "" {
 		out = append(out, eventType)
 	}
+	out = append(out, actionResultEvents(rule.Action)...)
 	if rule.FanOut != nil {
 		if eventType := rule.FanOut.Emit.EventType(); eventType != "" {
 			out = append(out, eventType)
 		}
 	}
 	return uniqueOrderedStrings(out)
+}
+
+func actionResultEvents(action ActionSpec) []string {
+	if strings.TrimSpace(action.ID) != "artifact_repo_commit" || action.ArtifactRepo == nil {
+		return nil
+	}
+	return []string{
+		action.ArtifactRepo.SuccessEvent,
+		action.ArtifactRepo.FailureEvent,
+	}
 }
 
 func HandlerHasNestedEmitSites(handler SystemNodeEventHandler) bool {

--- a/internal/runtime/contracts/workflow_contract_emit_test.go
+++ b/internal/runtime/contracts/workflow_contract_emit_test.go
@@ -1,0 +1,42 @@
+package contracts
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestHandlerEmitEventsIncludesArtifactRepoCommitResults(t *testing.T) {
+	handler := SystemNodeEventHandler{
+		Emit: EmitSpec{Event: "handler.emitted"},
+		Action: ActionSpec{
+			ID: "artifact_repo_commit",
+			ArtifactRepo: &ArtifactRepoSpec{
+				SuccessEvent: "artifact_repo.commit_completed",
+				FailureEvent: "artifact_repo.commit_failed",
+			},
+		},
+		Rules: []HandlerRuleEntry{{
+			Emit: EmitSpec{Event: "rule.emitted"},
+			Action: ActionSpec{
+				ID: "artifact_repo_commit",
+				ArtifactRepo: &ArtifactRepoSpec{
+					SuccessEvent: "artifact_repo.rule_completed",
+					FailureEvent: "artifact_repo.rule_failed",
+				},
+			},
+		}},
+	}
+
+	got := HandlerEmitEvents(handler)
+	want := []string{
+		"handler.emitted",
+		"artifact_repo.commit_completed",
+		"artifact_repo.commit_failed",
+		"rule.emitted",
+		"artifact_repo.rule_completed",
+		"artifact_repo.rule_failed",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("HandlerEmitEvents() = %#v, want %#v", got, want)
+	}
+}

--- a/internal/runtime/pipeline/workflow_timer_lifecycle_test.go
+++ b/internal/runtime/pipeline/workflow_timer_lifecycle_test.go
@@ -101,6 +101,33 @@ func testActivePipelineSQLTxContext(t *testing.T, db *sql.DB, ctx context.Contex
 	return WithPipelineSQLTxContext(ctx, tx)
 }
 
+func TestWorkflowTimerFireAtSnapshotsPolicyDelayAtStart(t *testing.T) {
+	now := time.Date(2026, time.July, 1, 12, 0, 0, 0, time.UTC)
+	timer := runtimecontracts.WorkflowTimerContract{
+		ID:    "sla_timeout",
+		Owner: "support-node",
+		Event: "timer.sla_timeout",
+		Delay: "{{sla_timeout_hours}}h",
+	}
+
+	fireAt, ok := workflowTimerFireAt(timer, now, map[string]any{
+		"sla_timeout_hours": 2,
+	})
+	if !ok {
+		t.Fatal("expected policy-backed timer delay to render")
+	}
+	if want := now.Add(2 * time.Hour); !fireAt.Equal(want) {
+		t.Fatalf("fireAt = %s, want %s", fireAt, want)
+	}
+
+	schedule := workflowTimerSchedule(timer, "ent-001", "support", fireAt, map[string]any{
+		"sla_timeout_hours": 8,
+	})
+	if !schedule.At.Equal(fireAt) {
+		t.Fatalf("schedule At = %s, want persisted fireAt %s", schedule.At, fireAt)
+	}
+}
+
 func TestExecuteNodeHandlerPlan_EventTimerStartOnRegistersSchedule(t *testing.T) {
 	repoRoot := filepath.Clean(filepath.Join("..", "..", ".."))
 	fixtureRoot := filepath.Join(repoRoot, "tests", "tier5-flow-lifecycle", "test-timer-fire")

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -4033,7 +4033,9 @@ engine:
       - "Prefixes other than state: and event: are boot errors."
     lifecycle:
     - 1. Timer starts when the entity enters the start_on state, the start_on event fires, or start_on is boot and platform startup schedules it.
-    - 2. Platform persists the timer (entity_id, timer_id, fire_at timestamp).
+    - 2. Platform renders the timer delay at start time and persists the timer (entity_id, timer_id, fire_at timestamp).
+      Active timers keep the persisted fire_at value; later policy/config changes do not rewrite already scheduled timers unless
+      a separate explicit reschedule primitive is defined.
     - 3. When fire_at is reached, platform emits the timer event into the event loop.
     - 4. Timer event is a regular event — routed to subscribers, processed by handlers.
     - 5. If cancel_on state is reached or cancel_on event fires before fire_at, timer is cancelled.
@@ -4043,7 +4045,10 @@ engine:
       start_on: start_on must match state:<name>, event:<name>, or boot. Any other form is a boot error.
       cancel_on: cancel_on must match state:<name> or event:<name>. boot is not valid.
       state_reference: state:<name> must reference a declared flow state. Unknown state is a boot error.
-      event_reference: event:<name> should reference an event in the flow or platform catalog. Unknown event is a boot warning.
+      event_reference: event:<name> must reference an event in the flow or platform catalog and must have an authored producer
+        path, platform producer, or explicit external source. Unknown or inert event triggers are boot errors.
+      fire_event_consumer: The timer fire event must have an executable handler/agent consumer, a declared output boundary, or
+        explicit external consumer metadata. Catalog membership alone is not sufficient proof that a timer can do useful work.
     example: "timers:\n  - id: sla_timeout\n    event: timer.sla_breach\n    delay: \"{{sla_timeout_hours}}h\"\
       \n    start_on: state:assigned\n    cancel_on: state:resolved\n    recurring: false\n  - id: daily_report\n\
       \    event: timer.daily_report\n    delay: \"{{report_interval_hours}}h\"\n    start_on: boot\n    recurring: true"

--- a/tests/tier5-flow-lifecycle/test-timer-cancel/events.yaml
+++ b/tests/tier5-flow-lifecycle/test-timer-cancel/events.yaml
@@ -1,7 +1,11 @@
 timer.scheduled:
   entity_id: string
+  swarm:
+    source: external
 timer.cancel_requested:
   entity_id: string
+  swarm:
+    source: external
 timer.check:
   entity_id: string
 timer.cancelled:

--- a/tests/tier5-flow-lifecycle/test-timer-cancel/nodes.yaml
+++ b/tests/tier5-flow-lifecycle/test-timer-cancel/nodes.yaml
@@ -2,7 +2,6 @@ timer-node:
   id: timer-node
   execution_type: system_node
   subscribes_to: [timer.scheduled, timer.check]
-  produces: [timer.check]
   timers:
     - id: check_timer
       event: timer.check

--- a/tests/tier5-flow-lifecycle/test-timer-fire/events.yaml
+++ b/tests/tier5-flow-lifecycle/test-timer-fire/events.yaml
@@ -1,4 +1,6 @@
 timer.scheduled:
   entity_id: string
+  swarm:
+    source: external
 timer.check:
   entity_id: string

--- a/tests/tier5-flow-lifecycle/test-timer-fire/nodes.yaml
+++ b/tests/tier5-flow-lifecycle/test-timer-fire/nodes.yaml
@@ -2,7 +2,6 @@ test-node:
   id: test-node
   execution_type: system_node
   subscribes_to: [timer.scheduled, timer.check]
-  produces: [timer.check]
   timers:
     - id: check_timer
       event: timer.check

--- a/tests/tier5-flow-lifecycle/test-timer-recurring/events.yaml
+++ b/tests/tier5-flow-lifecycle/test-timer-recurring/events.yaml
@@ -1,4 +1,6 @@
 monitor.started:
   entity_id: string
+  swarm:
+    source: external
 timer.tick:
   entity_id: string

--- a/tests/tier5-flow-lifecycle/test-timer-recurring/nodes.yaml
+++ b/tests/tier5-flow-lifecycle/test-timer-recurring/nodes.yaml
@@ -2,7 +2,6 @@ test-node:
   id: test-node
   execution_type: system_node
   subscribes_to: [monitor.started, timer.tick]
-  produces: [timer.tick]
   timers:
     - id: tick_timer
       event: timer.tick

--- a/tests/tier5-flow-lifecycle/test-timer-start-on/events.yaml
+++ b/tests/tier5-flow-lifecycle/test-timer-start-on/events.yaml
@@ -1,5 +1,7 @@
 task.started:
   entity_id: string
+  swarm:
+    source: external
 timer.task_timeout:
   entity_id: string
 task.timed_out:


### PR DESCRIPTION
## Summary

Part of #1534.

This PR closes the approved first-slice class `workflow_timer_event_lifecycle_static_proof`:

- hardens `timer_validation` so timer fire events must have an executable handler/agent consumer, declared output boundary, or explicit external consumer metadata
- promotes `start_on event:*` / `cancel_on event:*` from warning-only unknown-event handling to fail-closed catalog + producer-path validation
- counts `artifact_repo_commit` `success_event` / `failure_event` result events in the shared handler-produced event inventory, so artifact result events can start or cancel timers
- updates `platform-spec.yaml` to make active timer `fire_at` snapshot semantics and timer lifecycle proof authoritative
- updates timer lifecycle fixtures so root ingress timer triggers are explicit external sources and timer fire events are not incorrectly listed as handler `produces`

## Governing refs / context

Exact spec references exist and are updated in this PR:

- `platform-spec.yaml#engine.timer_model.lifecycle`
- `platform-spec.yaml#engine.timer_model.boot_validation`
- adjacent unchanged context: `platform-spec.yaml#engine.error_model.timer_failure`
- adjacent unchanged context: `platform-spec.yaml#semantic_validity.slice_4_state_machine_reachability`
- adjacent unchanged context: `platform-spec.yaml#semantic_validity.slice_5_dead_declared_event_schema_surface`

Binding issue/gate context:

- #1534 issue body
- #1534 `Pre-Implementation Coverage Audit`
- #1534 lead gate outcome: approved as first slice for `workflow_timer_event_lifecycle_static_proof`

## Canonical owner / semantic migration

New canonical owner for this first slice:

- `platform-spec.yaml#engine.timer_model.boot_validation` defines timer lifecycle validation authority
- `internal/runtime/bootverify.timer_validation` enforces the supported verify/boot surface
- `runtimecontracts.HandlerEmitEvents` owns authored handler-produced event inventory consumed by timer trigger producer proof and sibling diagnostics
- `semanticview.ResolveFlowEventProof` remains the shared event identity/catalog helper consumed by that owner

Old paths now invalid as closure-bearing proof:

- unknown timer trigger events as warning-only validation
- timer fire event catalog membership as proof of useful work
- generic `event_consumer_exists` warning as the only timer fire lifecycle proof
- `semantic_drift_dead_event_schema` timer reference count as executable-consumer proof
- `input_pin_wiring` same-flow timer producer proof as fire-event consumer proof
- node `produces` entries claiming timer fire events that are actually produced by timer declarations
- handler emit inventory that omits runtime-queued artifact repo result events

Production paths checked for surviving old behavior:

- `workflow_timer_checks.go`
- `workflow_event_topology_checks.go`
- `workflow_dead_event_schema_checks.go`
- `workflow_flow_boundary_checks.go`
- `workflow_state_machine_reachability_checks.go`
- `workflow_timer_lifecycle.go`
- `runtime.go` lifecycle schedule rehydration
- `workflow_contract_emit.go`
- artifact repo result validation / runtime queuing context

Migration completeness:

- Complete for approved first-slice `workflow_timer_event_lifecycle_static_proof`.
- Not claiming closure of timer-context `cancel_on state:*` reachability or explicit active-timer reschedule/refresh semantics; those remain split siblings per the gate.

## Tests / proof

- `go test ./internal/runtime/contracts ./internal/runtime/bootverify -run 'HandlerEmitEvents|Timer|ArtifactRepo|DeadEvent|InputPin|UnreachableState|EventConsumer|EventProducer' -count=1`
- `go test ./internal/runtime/bootverify -run 'Timer|DeadEvent|InputPin|UnreachableState|EventConsumer|EventProducer' -count=1`
- `go test ./internal/runtime/pipeline -run 'Timer|WorkflowTimer' -count=1`
- `go run ./cmd/swarm verify --contracts tests/tier5-flow-lifecycle/test-timer-fire`
- `go run ./cmd/swarm verify --contracts tests/tier5-flow-lifecycle/test-timer-start-on`
- `go run ./cmd/swarm verify --contracts tests/tier5-flow-lifecycle/test-timer-cancel`
- `go run ./cmd/swarm verify --contracts tests/tier5-flow-lifecycle/test-timer-recurring`
- `go test ./...`