### PR TITLE
[agent-x][issue #1552] Add template-flow pilot conformance

### DIFF
--- a/internal/runtime/conformance/template_flow_pilot_conformance_test.go
+++ b/internal/runtime/conformance/template_flow_pilot_conformance_test.go
@@ -1,0 +1,127 @@
+package conformance
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	runtimebootverify "github.com/division-sh/swarm/internal/runtime/bootverify"
+	runtimepinrouting "github.com/division-sh/swarm/internal/runtime/core/pinrouting"
+	"github.com/division-sh/swarm/internal/runtime/semanticview"
+	"github.com/division-sh/swarm/internal/runtime/testfixtures/templateflowpilot"
+)
+
+func TestTemplateFlowPilotConformance_CoversInstanceCenteredAuthoringOwners(t *testing.T) {
+	source := templateflowpilot.LoadSource(t, templateflowpilot.Options{})
+	report := runtimebootverify.Run(context.Background(), source, runtimebootverify.Options{})
+	if got := report.HardInvalidities(); len(got) != 0 {
+		t.Fatalf("template-flow pilot hard invalidities = %#v, want none", got)
+	}
+	bundle, ok := semanticview.Bundle(source)
+	if !ok {
+		t.Fatal("template-flow pilot source did not expose bundle")
+	}
+	primary, err := bundle.ResolveFlowPrimaryEntity("scoring")
+	if err != nil {
+		t.Fatalf("ResolveFlowPrimaryEntity(scoring): %v", err)
+	}
+	if primary.EntityType != "validation" {
+		t.Fatalf("scoring primary entity = %q, want validation", primary.EntityType)
+	}
+	instance, err := bundle.ResolveFlowTemplateInstance("scoring")
+	if err != nil {
+		t.Fatalf("ResolveFlowTemplateInstance(scoring): %v", err)
+	}
+	if got := strings.Join(instance.By, ","); got != "account_id" {
+		t.Fatalf("scoring instance fields = %q, want account_id", got)
+	}
+	if instance.OnMissing != "create" || instance.OnConflict != "reuse" {
+		t.Fatalf("scoring lifecycle policy = %s/%s, want create/reuse", instance.OnMissing, instance.OnConflict)
+	}
+	output, ok := bundle.FlowOutputEventPin("producer", "validation_requested")
+	if !ok {
+		t.Fatal("producer validation_requested output pin missing")
+	}
+	if output.Key != "account_id" || strings.Join(output.Carries, ",") != "account_id,score,decision" {
+		t.Fatalf("producer output pin key/carries = %q/%#v, want account_id/[account_id score decision]", output.Key, output.Carries)
+	}
+
+	plans, issues := runtimepinrouting.LowerCompositionConnectRoutePlans(source)
+	if len(issues) != 0 {
+		t.Fatalf("LowerCompositionConnectRoutePlans issues = %#v, want none", issues)
+	}
+	if len(plans) != 1 {
+		t.Fatalf("LowerCompositionConnectRoutePlans = %#v, want one template route plan", plans)
+	}
+	plan := plans[0]
+	if plan.ResolutionKind != runtimepinrouting.ConnectResolutionInstanceKey || !plan.RequiresRuntimeResolution {
+		t.Fatalf("route plan resolution = %s runtime=%v, want instance_key runtime resolution", plan.ResolutionKind, plan.RequiresRuntimeResolution)
+	}
+	if plan.Source.FlowID != "producer" || plan.Source.Pin != "validation_requested" || plan.Source.Key != "account_id" {
+		t.Fatalf("route plan source = %#v, want producer.validation_requested keyed by account_id", plan.Source)
+	}
+	if plan.Receiver.FlowID != "scoring" || plan.Receiver.Pin != "validation_requested" || plan.Receiver.Mode != "template" {
+		t.Fatalf("route plan receiver = %#v, want template scoring.validation_requested", plan.Receiver)
+	}
+	if plan.InstanceKey == nil || strings.Join(plan.InstanceKey.Fields, ",") != "account_id" {
+		t.Fatalf("route plan instance key = %#v, want account_id", plan.InstanceKey)
+	}
+	if len(plan.InstanceKey.Mappings) != 1 || plan.InstanceKey.Mappings[0].Source != "account_id" || plan.InstanceKey.Mappings[0].Target != "account_id" || plan.InstanceKey.Mappings[0].Explicit {
+		t.Fatalf("route plan instance key mappings = %#v, want implicit account_id -> account_id", plan.InstanceKey.Mappings)
+	}
+}
+
+func TestTemplateFlowPilotConformance_FailClosedMatrix(t *testing.T) {
+	tests := []struct {
+		name        string
+		opts        templateflowpilot.Options
+		checkID     string
+		wantMessage string
+	}{
+		{
+			name:        "unsupported receiver select_entity on connected normal path",
+			opts:        templateflowpilot.Options{UnsupportedReceiverSelection: true},
+			checkID:     "redundant_in_topology_select_entity",
+			wantMessage: "instance.by plus parent connect",
+		},
+		{
+			name:        "bad connect instance key mapping",
+			opts:        templateflowpilot.Options{BadConnectMapping: true},
+			checkID:     "composition_connect_validation",
+			wantMessage: "connect_key_adapter_source_missing",
+		},
+		{
+			name:        "producer target cannot rescue common composition",
+			opts:        templateflowpilot.Options{ProducerTarget: true},
+			checkID:     "pin_target_resolution",
+			wantMessage: "producer_target_common_path_forbidden",
+		},
+		{
+			name:        "producer broadcast cannot replace parent connect authority",
+			opts:        templateflowpilot.Options{ProducerBroadcast: true},
+			checkID:     "pin_target_resolution",
+			wantMessage: "producer_broadcast_common_path_forbidden",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			source := templateflowpilot.LoadSource(t, tc.opts)
+			report := runtimebootverify.Run(context.Background(), source, runtimebootverify.Options{})
+			if !templateFlowPilotConformanceFindingContains(report.HardInvalidities(), tc.checkID, tc.wantMessage) {
+				t.Fatalf("expected hard invalidity %s containing %q, got %#v", tc.checkID, tc.wantMessage, report.HardInvalidities())
+			}
+		})
+	}
+}
+
+func templateFlowPilotConformanceFindingContains(findings []runtimebootverify.Finding, checkID, substr string) bool {
+	for _, finding := range findings {
+		if strings.TrimSpace(finding.CheckID) != checkID {
+			continue
+		}
+		if substr == "" || strings.Contains(finding.Message, substr) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/runtime/conformance/testdata/route_authority_drift_inventory.yaml
+++ b/internal/runtime/conformance/testdata/route_authority_drift_inventory.yaml
@@ -1,7 +1,7 @@
 version: 1
 kind: route_authority_drift_inventory
 issue: 1364
-implementation_issues: [1364, 1494, 1495, 1496, 1545, 1546, 1577]
+implementation_issues: [1364, 1494, 1495, 1496, 1545, 1546, 1552, 1577]
 parent_issues: [1340, 1353, 1481, 1493]
 watchlist: runtime_operations.delivery_and_replay_ownership
 policy:
@@ -658,6 +658,7 @@ seam_families:
       - internal/runtime/cataloge2e/tier12_runtime_fork_e2e_test.go
       - internal/runtime/bus/sealed_flow_package_fixture_test.go
       - internal/runtime/conformance/sealed_flow_package_conformance_test.go
+      - internal/runtime/conformance/template_flow_pilot_conformance_test.go
       - internal/runtime/swarmflowtest/catalog_runner_test.go
       - tests/tier11-flow-composition/test-dynamic-flow-instance/expected.yaml
       - tests/tier5-flow-lifecycle/test-create-flow-instance/expected.yaml
@@ -667,7 +668,9 @@ seam_families:
       smoke must cite focused rows; full route behavior stays in named full
       conformance/catalog tiers. The sealed package fixture and conformance
       tests consume lowered connect route plans and receiver-carrier evidence
-      as runtime proof; they do not introduce or replace route authority.
+      as runtime proof; they do not introduce or replace route authority. #1552
+      adds the template-flow pilot conformance fixture as an integrated
+      package-boundary proof consumer for the existing route-authority owners.
   - id: route_authority_conformance_artifacts
     layer: conformance_guardrails
     classification: canonical_owner

--- a/internal/runtime/pipeline/template_flow_pilot_delivery_test.go
+++ b/internal/runtime/pipeline/template_flow_pilot_delivery_test.go
@@ -1,0 +1,162 @@
+package pipeline
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/division-sh/swarm/internal/events"
+	"github.com/division-sh/swarm/internal/events/eventtest"
+	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
+	"github.com/division-sh/swarm/internal/runtime/semanticview"
+	"github.com/division-sh/swarm/internal/runtime/testfixtures/templateflowpilot"
+	"github.com/division-sh/swarm/internal/testutil"
+	"github.com/google/uuid"
+)
+
+func TestTemplateFlowPilotPipelineDispatchUpdatesSelectedTemplateInstance(t *testing.T) {
+	bundle := templateflowpilot.LoadBundle(t, templateflowpilot.Options{})
+	source := semanticview.Wrap(bundle)
+	_, db, cleanup := testutil.StartPostgres(t)
+	t.Cleanup(cleanup)
+	pc, workflowStore := newTemplateFlowPilotPipelineCoordinator(t, db, bundle, source)
+	ctx := testPipelineCoordinatorRunContext(t, pc)
+	entityID := uuid.NewString()
+	instanceID := "ti-template-flow-pilot"
+	flowInstance := "scoring/" + instanceID
+	if err := workflowStore.Create(ctx, WorkflowInstance{
+		InstanceID:      instanceID,
+		StorageRef:      flowInstance,
+		WorkflowName:    "scoring",
+		WorkflowVersion: bundle.WorkflowVersion(),
+		CurrentState:    "pending",
+		Config: map[string]any{
+			"account_id": "acct-1",
+		},
+		Metadata: map[string]any{
+			"entity_id":   entityID,
+			"flow_path":   flowInstance,
+			"instance_id": instanceID,
+		},
+	}); err != nil {
+		t.Fatalf("seed scoring workflow instance: %v", err)
+	}
+
+	target := events.RouteIdentity{FlowID: "scoring", FlowInstance: flowInstance, EntityID: entityID}
+	evt := eventtest.RootIngress(
+		uuid.NewString(),
+		events.EventType("producer/validation.requested"),
+		"producer",
+		"",
+		json.RawMessage(`{"account_id":"acct-1","score":"91","decision":"approved"}`),
+		0,
+		testPipelineRunID,
+		"",
+		events.EnvelopeForTargetRoute(events.EventEnvelope{}, target),
+		time.Now().UTC(),
+	)
+	seedTemplateFlowPilotPipelineEvent(t, db, ctx, evt)
+	seedTemplateFlowPilotPipelineNodeDelivery(t, db, ctx, evt.ID(), "scoring-handler", target)
+
+	handled, err := pc.dispatchWorkflowNodeEventResult(ctx, evt)
+	if err != nil {
+		t.Fatalf("dispatchWorkflowNodeEventResult: %v", err)
+	}
+	if !handled {
+		t.Fatal("dispatchWorkflowNodeEventResult handled = false, want scoring handler delivery")
+	}
+	loaded, ok, err := workflowStore.Load(ctx, entityID)
+	if err != nil {
+		t.Fatalf("workflowStore.Load(%s): %v", entityID, err)
+	}
+	if !ok {
+		t.Fatalf("workflowStore.Load(%s) ok=false", entityID)
+	}
+	if loaded.WorkflowName != "scoring" || loaded.CurrentState != "done" {
+		t.Fatalf("loaded scoring instance = storage:%q workflow:%q state:%q, want scoring/done", loaded.StorageRef, loaded.WorkflowName, loaded.CurrentState)
+	}
+	if loaded.Metadata["account_id"] != "acct-1" || loaded.Metadata["score"] != "91" || loaded.Metadata["decision"] != "approved" {
+		t.Fatalf("loaded scoring metadata = %#v, want account_id/score/decision from routed payload", loaded.Metadata)
+	}
+	assertTemplateFlowPilotPipelineDeliveryStatus(t, db, evt.ID(), "scoring-handler", "delivered")
+}
+
+func newTemplateFlowPilotPipelineCoordinator(t *testing.T, db *sql.DB, bundle *runtimecontracts.WorkflowContractBundle, source semanticview.Source) (*PipelineCoordinator, *WorkflowInstanceStore) {
+	t.Helper()
+	workflow, err := LoadWorkflowDefinition(source)
+	if err != nil {
+		t.Fatalf("LoadWorkflowDefinition: %v", err)
+	}
+	nodes, err := LoadWorkflowNodes(source)
+	if err != nil {
+		t.Fatalf("LoadWorkflowNodes: %v", err)
+	}
+	workflowStore := NewWorkflowInstanceStore(db)
+	pc := NewPipelineCoordinatorWithOptions(&recordingPipelineBus{}, db, PipelineCoordinatorOptions{
+		Module: &previewWorkflowModule{
+			bundle:         bundle,
+			workflow:       workflow,
+			workflowNodes:  nodes,
+			guardRegistry:  NewContractGuardRegistry(source),
+			actionRegistry: NewContractActionRegistry(source),
+		},
+		WorkflowStore:           workflowStore,
+		EventReceiptsCapability: eventReceiptsCapabilityStub{enabled: true}.resolve,
+	})
+	return pc, workflowStore
+}
+
+func seedTemplateFlowPilotPipelineEvent(t *testing.T, db *sql.DB, ctx context.Context, evt events.Event) {
+	t.Helper()
+	targetRaw, err := json.Marshal(evt.TargetRoute())
+	if err != nil {
+		t.Fatalf("marshal target route: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO events (
+			event_id, run_id, event_name, entity_id, flow_instance, scope, payload,
+			produced_by, produced_by_type, target_route, created_at
+		) VALUES (
+			$1::uuid, $2::uuid, $3, $4::uuid, $5, 'entity', $6::jsonb,
+			$7, 'agent', $8::jsonb, now()
+		)
+	`, evt.ID(), evt.RunID(), string(evt.Type()), evt.EntityID(), evt.FlowInstance(), string(evt.Payload()), evt.SourceAgent(), string(targetRaw)); err != nil {
+		t.Fatalf("seed template-flow pilot event: %v", err)
+	}
+}
+
+func seedTemplateFlowPilotPipelineNodeDelivery(t *testing.T, db *sql.DB, ctx context.Context, eventID, nodeID string, target events.RouteIdentity) {
+	t.Helper()
+	targetRaw, err := json.Marshal(target.Normalized())
+	if err != nil {
+		t.Fatalf("marshal delivery target route: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO event_deliveries (
+			run_id, event_id, subscriber_type, subscriber_id, delivery_target_route, status, retry_count, created_at
+		) VALUES (
+			$1::uuid, $2::uuid, 'node', $3, $4::jsonb, 'pending', 0, now()
+		)
+	`, testPipelineRunID, eventID, nodeID, string(targetRaw)); err != nil {
+		t.Fatalf("seed template-flow pilot node delivery: %v", err)
+	}
+}
+
+func assertTemplateFlowPilotPipelineDeliveryStatus(t *testing.T, db *sql.DB, eventID, nodeID, want string) {
+	t.Helper()
+	var got string
+	if err := db.QueryRowContext(context.Background(), `
+		SELECT COALESCE(status, '')
+		FROM event_deliveries
+		WHERE event_id = $1::uuid
+		  AND subscriber_type = 'node'
+		  AND subscriber_id = $2
+	`, eventID, nodeID).Scan(&got); err != nil {
+		t.Fatalf("load template-flow pilot node delivery: %v", err)
+	}
+	if got != want {
+		t.Fatalf("template-flow pilot delivery status = %q, want %q", got, want)
+	}
+}

--- a/internal/runtime/template_flow_pilot_runtime_test.go
+++ b/internal/runtime/template_flow_pilot_runtime_test.go
@@ -1,0 +1,221 @@
+package runtime_test
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/division-sh/swarm/internal/events"
+	"github.com/division-sh/swarm/internal/events/eventtest"
+	runtimebootverify "github.com/division-sh/swarm/internal/runtime/bootverify"
+	runtimebus "github.com/division-sh/swarm/internal/runtime/bus"
+	runtimepinrouting "github.com/division-sh/swarm/internal/runtime/core/pinrouting"
+	runtimemanager "github.com/division-sh/swarm/internal/runtime/manager"
+	runtimepipeline "github.com/division-sh/swarm/internal/runtime/pipeline"
+	"github.com/division-sh/swarm/internal/runtime/semanticview"
+	"github.com/division-sh/swarm/internal/runtime/testfixtures/templateflowpilot"
+	"github.com/division-sh/swarm/internal/store"
+	"github.com/division-sh/swarm/internal/testutil"
+)
+
+func TestTemplateFlowPilotRuntime_ParentConnectCreatesTemplateInstanceAndPersistedDeliveryRoute(t *testing.T) {
+	bundle := templateflowpilot.LoadBundle(t, templateflowpilot.Options{})
+	source := semanticview.Wrap(bundle)
+	report := runtimebootverify.Run(context.Background(), source, runtimebootverify.Options{})
+	if got := report.HardInvalidities(); len(got) != 0 {
+		t.Fatalf("template-flow pilot hard invalidities = %#v, want none", got)
+	}
+
+	_, db, cleanup := testutil.StartPostgres(t)
+	t.Cleanup(cleanup)
+	ctx := seedRuntimeTestRun(t, db)
+	pg := &store.PostgresStore{DB: db}
+	workflowStore := runtimepipeline.NewWorkflowInstanceStore(db)
+	var manager *runtimemanager.AgentManager
+	bus, err := runtimebus.NewEventBusWithOptions(pg, runtimebus.EventBusOptions{
+		ContractBundle: source,
+		TemplateInstanceActivator: func(ctx context.Context, req runtimepipeline.FlowInstanceActivationRequest) error {
+			if manager == nil {
+				t.Fatal("agent manager not initialized")
+			}
+			return manager.ActivateFlowInstance(ctx, req)
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewEventBusWithOptions: %v", err)
+	}
+	manager = runtimemanager.NewAgentManagerWithOptions(bus, nil, runtimemanager.AgentManagerOptions{
+		WorkflowInstances: workflowStore,
+	})
+
+	evt := eventtest.RootIngress(
+		"99999999-9999-4999-8999-999999999952",
+		events.EventType("producer/validation.requested"),
+		"",
+		"",
+		json.RawMessage(`{"account_id":"acct-1","score":"91","decision":"approved"}`),
+		0,
+		templateInstanceDeliveryRunID,
+		"",
+		events.EventEnvelope{},
+		time.Now().UTC(),
+	)
+	preflight, err := bus.CheckPublishRecipientPlan(ctx, evt)
+	if err != nil {
+		t.Fatalf("CheckPublishRecipientPlan: %v", err)
+	}
+	if preflight.TargetFailure != "" || len(preflight.DeliveryRoutes) != 1 {
+		t.Fatalf("preflight failure/routes = %q/%#v, want one deterministic template route", preflight.TargetFailure, preflight.DeliveryRoutes)
+	}
+	if target := preflight.DeliveryRoutes[0].Target; target.FlowID != "scoring" || !strings.HasPrefix(target.FlowInstance, "scoring/") || target.EntityID == "" {
+		t.Fatalf("preflight target = %#v, want scoring template flow instance", target)
+	}
+	assertRuntimeDBCount(t, ctx, db, `
+		SELECT COUNT(*) FROM flow_instances
+		WHERE flow_template = 'scoring'
+	`, 0)
+
+	if err := bus.Publish(ctx, evt); err != nil {
+		t.Fatalf("Publish validation request: %v", err)
+	}
+	waitRuntimeDBCount(t, ctx, db, `
+		SELECT COUNT(*) FROM event_deliveries
+		WHERE event_id = $1::uuid
+		  AND subscriber_type = 'node'
+		  AND subscriber_id = 'scoring-handler'
+	`, 1, evt.ID())
+	assertRuntimeDBCount(t, ctx, db, `
+		SELECT COUNT(*) FROM event_deliveries
+		WHERE event_id = $1::uuid
+		  AND subscriber_id IN ('workflow-runtime', 'raw-source-listener')
+	`, 0, evt.ID())
+
+	flowInstance, entityID := loadTemplateFlowPilotInstanceIdentity(t, ctx, db)
+	loaded, ok, err := workflowStore.Load(ctx, entityID)
+	if err != nil {
+		t.Fatalf("workflowStore.Load(%s): %v", entityID, err)
+	}
+	if !ok {
+		t.Fatalf("workflowStore.Load(%s) ok=false", entityID)
+	}
+	if loaded.StorageRef != flowInstance || loaded.WorkflowName != "scoring" || loaded.CurrentState != "pending" {
+		t.Fatalf("loaded scoring instance = storage:%q workflow:%q state:%q, want %s/scoring/pending", loaded.StorageRef, loaded.WorkflowName, loaded.CurrentState, flowInstance)
+	}
+	if loaded.Metadata["account_id"] != "acct-1" {
+		t.Fatalf("loaded scoring metadata = %#v, want account_id from route activation", loaded.Metadata)
+	}
+}
+
+func TestTemplateFlowPilotRuntime_FailsClosedForMissingAndAmbiguousKeys(t *testing.T) {
+	source := templateflowpilot.LoadSource(t, templateflowpilot.Options{})
+	tests := []struct {
+		name          string
+		payload       json.RawMessage
+		flowInstances []runtimebus.ActiveFlowInstanceDescriptor
+		wantFailure   string
+	}{
+		{
+			name:        "missing producer key",
+			payload:     json.RawMessage(`{"score":"91","decision":"approved"}`),
+			wantFailure: string(runtimepinrouting.ConnectFailureAddressValueMissing),
+		},
+		{
+			name:    "ambiguous receiver key",
+			payload: json.RawMessage(`{"account_id":"acct-1","score":"91","decision":"approved"}`),
+			flowInstances: []runtimebus.ActiveFlowInstanceDescriptor{
+				{InstanceID: "one", EntityID: "11111111-1111-4111-8111-111111111111", FlowInstance: "scoring/one", FlowTemplate: "scoring", AddressFields: map[string]string{"entity.account_id": "acct-1"}},
+				{InstanceID: "two", EntityID: "22222222-2222-4222-8222-222222222222", FlowInstance: "scoring/two", FlowTemplate: "scoring", AddressFields: map[string]string{"entity.account_id": "acct-1"}},
+			},
+			wantFailure: string(runtimepinrouting.ConnectFailureTargetAmbiguous),
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			store := &templateFlowPilotMemoryStore{flowInstances: tc.flowInstances}
+			bus, err := runtimebus.NewEventBusWithOptions(store, runtimebus.EventBusOptions{
+				ContractBundle: source,
+				TemplateInstanceActivator: func(context.Context, runtimepipeline.FlowInstanceActivationRequest) error {
+					t.Fatal("fail-closed route must not activate a template instance")
+					return nil
+				},
+			})
+			if err != nil {
+				t.Fatalf("NewEventBusWithOptions: %v", err)
+			}
+			raw := bus.Subscribe("raw-source-listener", events.EventType("producer/validation.requested"), events.EventType("validation.requested"))
+			defer bus.Unsubscribe("raw-source-listener")
+			evt := eventtest.RootIngress(
+				"99999999-9999-4999-8999-999999999953",
+				events.EventType("producer/validation.requested"),
+				"",
+				"",
+				tc.payload,
+				0,
+				templateInstanceDeliveryRunID,
+				"",
+				events.EventEnvelope{},
+				time.Now().UTC(),
+			)
+			plan, err := bus.CheckPublishRecipientPlan(context.Background(), evt)
+			if err != nil {
+				t.Fatalf("CheckPublishRecipientPlan: %v", err)
+			}
+			if plan.TargetFailure != tc.wantFailure {
+				t.Fatalf("target failure = %q, want %q", plan.TargetFailure, tc.wantFailure)
+			}
+			if len(plan.Recipients) != 0 || len(plan.PersistedRecipients) != 0 || len(plan.RoutedRecipients) != 0 ||
+				len(plan.SubscriptionRecipients) != 0 || len(plan.DeliveryRoutes) != 0 {
+				t.Fatalf("fail-closed route exposed executable plan: recipients=%#v persisted=%#v routed=%#v subscriptions=%#v routes=%#v",
+					plan.Recipients, plan.PersistedRecipients, plan.RoutedRecipients, plan.SubscriptionRecipients, plan.DeliveryRoutes)
+			}
+			if err := bus.Publish(context.Background(), evt); err != nil {
+				t.Fatalf("Publish: %v", err)
+			}
+			if routes := store.deliveryRoutes[evt.ID()]; len(routes) != 0 {
+				t.Fatalf("persisted delivery routes = %#v, want none", routes)
+			}
+			select {
+			case got := <-raw:
+				t.Fatalf("raw subscriber received fail-closed event with flow_instance=%q entity=%q", got.FlowInstance(), got.EntityID())
+			default:
+			}
+		})
+	}
+}
+
+type templateFlowPilotMemoryStore struct {
+	runtimebus.InMemoryEventStore
+	flowInstances  []runtimebus.ActiveFlowInstanceDescriptor
+	deliveryRoutes map[string][]events.DeliveryRoute
+}
+
+func (s *templateFlowPilotMemoryStore) ListActiveFlowInstanceDescriptors(context.Context) ([]runtimebus.ActiveFlowInstanceDescriptor, error) {
+	return append([]runtimebus.ActiveFlowInstanceDescriptor(nil), s.flowInstances...), nil
+}
+
+func (s *templateFlowPilotMemoryStore) InsertEventDeliveryRoutes(_ context.Context, eventID string, routes []events.DeliveryRoute) error {
+	if s.deliveryRoutes == nil {
+		s.deliveryRoutes = map[string][]events.DeliveryRoute{}
+	}
+	s.deliveryRoutes[eventID] = events.NormalizeDeliveryRoutes(routes)
+	return nil
+}
+
+func loadTemplateFlowPilotInstanceIdentity(t *testing.T, ctx context.Context, db *sql.DB) (string, string) {
+	t.Helper()
+	var flowInstance string
+	var entityID string
+	if err := db.QueryRowContext(ctx, `
+		SELECT flow_instance, entity_id::text
+		FROM entity_state
+		WHERE flow_instance LIKE 'scoring/%'
+		ORDER BY created_at DESC
+		LIMIT 1
+	`).Scan(&flowInstance, &entityID); err != nil {
+		t.Fatalf("load scoring instance identity: %v", err)
+	}
+	return flowInstance, entityID
+}

--- a/internal/runtime/template_flow_pilot_runtime_test.go
+++ b/internal/runtime/template_flow_pilot_runtime_test.go
@@ -94,6 +94,17 @@ func TestTemplateFlowPilotRuntime_ParentConnectCreatesTemplateInstanceAndPersist
 	`, 0, evt.ID())
 
 	flowInstance, entityID := loadTemplateFlowPilotInstanceIdentity(t, ctx, db)
+	assertRuntimeDBCount(t, ctx, db, `
+		SELECT COUNT(*) FROM event_deliveries
+		WHERE event_id = $1::uuid
+		  AND subscriber_type = 'node'
+		  AND subscriber_id = 'scoring-handler'
+		  AND delivery_target_route @> $2::jsonb
+	`, 1, evt.ID(), templateFlowPilotDeliveryTargetRouteJSON(t, events.RouteIdentity{
+		FlowID:       "scoring",
+		FlowInstance: flowInstance,
+		EntityID:     entityID,
+	}))
 	loaded, ok, err := workflowStore.Load(ctx, entityID)
 	if err != nil {
 		t.Fatalf("workflowStore.Load(%s): %v", entityID, err)
@@ -218,4 +229,13 @@ func loadTemplateFlowPilotInstanceIdentity(t *testing.T, ctx context.Context, db
 		t.Fatalf("load scoring instance identity: %v", err)
 	}
 	return flowInstance, entityID
+}
+
+func templateFlowPilotDeliveryTargetRouteJSON(t *testing.T, target events.RouteIdentity) string {
+	t.Helper()
+	encoded, err := json.Marshal(target.Normalized())
+	if err != nil {
+		t.Fatalf("marshal template-flow pilot delivery target: %v", err)
+	}
+	return string(encoded)
 }

--- a/internal/runtime/testfixtures/templateflowpilot/fixture.go
+++ b/internal/runtime/testfixtures/templateflowpilot/fixture.go
@@ -1,0 +1,225 @@
+package templateflowpilot
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
+	"github.com/division-sh/swarm/internal/runtime/semanticview"
+)
+
+// Options toggles the template-flow pilot variants used by conformance and
+// runtime tests.
+type Options struct {
+	BadConnectMapping            bool
+	UnsupportedReceiverSelection bool
+	ProducerTarget               bool
+	ProducerBroadcast            bool
+}
+
+func LoadBundle(t testing.TB, opts Options) *runtimecontracts.WorkflowContractBundle {
+	t.Helper()
+	root := Write(t, opts)
+	bundle, err := runtimecontracts.LoadWorkflowContractBundleWithOverrides(repoRoot(t), root, runtimecontracts.DefaultPlatformSpecFile(repoRoot(t)))
+	if err != nil {
+		t.Fatalf("LoadWorkflowContractBundleWithOverrides: %v", err)
+	}
+	return bundle
+}
+
+func LoadSource(t testing.TB, opts Options) semanticview.Source {
+	t.Helper()
+	return semanticview.Wrap(LoadBundle(t, opts))
+}
+
+func Write(t testing.TB, opts Options) string {
+	t.Helper()
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "package.yaml"), `
+name: template-flow-pilot
+version: "1.0.0"
+platform_version: ">=1.6.0"
+flows:
+  - id: producer
+    flow: producer
+    mode: static
+  - id: scoring
+    flow: scoring
+    mode: template
+connect:
+  - from: producer.validation_requested
+    to: scoring.validation_requested
+    delivery: one
+`+connectAdapterYAML(opts))
+	writeFile(t, filepath.Join(root, "schema.yaml"), "name: template-flow-pilot\n")
+	writeFile(t, filepath.Join(root, "policy.yaml"), "{}\n")
+	writeFile(t, filepath.Join(root, "tools.yaml"), "{}\n")
+	writeFile(t, filepath.Join(root, "agents.yaml"), "{}\n")
+	writeFile(t, filepath.Join(root, "events.yaml"), "{}\n")
+	writeFile(t, filepath.Join(root, "nodes.yaml"), "{}\n")
+	writeProducer(t, root, opts)
+	writeScoring(t, root, opts)
+	return root
+}
+
+func connectAdapterYAML(opts Options) string {
+	if !opts.BadConnectMapping {
+		return ""
+	}
+	return `    using:
+      instance:
+        source: missing_account_id
+        target: account_id
+`
+}
+
+func writeProducer(t testing.TB, root string, opts Options) {
+	t.Helper()
+	writeFile(t, filepath.Join(root, "flows", "producer", "schema.yaml"), `
+name: producer
+mode: static
+pins:
+  inputs:
+    events:
+      - name: intake_received
+        event: intake.received
+  outputs:
+    events:
+      - name: validation_requested
+        event: validation.requested
+        key: account_id
+        carries: [account_id, score, decision]
+`)
+	writeFile(t, filepath.Join(root, "flows", "producer", "policy.yaml"), "{}\n")
+	writeFile(t, filepath.Join(root, "flows", "producer", "tools.yaml"), "{}\n")
+	writeFile(t, filepath.Join(root, "flows", "producer", "agents.yaml"), "{}\n")
+	writeFile(t, filepath.Join(root, "flows", "producer", "events.yaml"), `
+intake.received:
+  account_id: string
+  score: string
+  decision: string
+validation.requested:
+  account_id: string
+  score: string
+  decision: string
+`)
+	writeFile(t, filepath.Join(root, "flows", "producer", "entities.yaml"), "{}\n")
+	writeFile(t, filepath.Join(root, "flows", "producer", "nodes.yaml"), `
+intake-validator:
+  id: intake-validator
+  execution_type: system_node
+  subscribes_to: [intake.received]
+  produces: [validation.requested]
+  event_handlers:
+    intake.received:
+      emit:
+        event: validation.requested
+`+producerEmitRouteYAML(opts)+`        fields:
+          account_id: payload.account_id
+          score: payload.score
+          decision: payload.decision
+`)
+}
+
+func producerEmitRouteYAML(opts Options) string {
+	if opts.ProducerTarget {
+		return `        target:
+          flow: scoring
+          match:
+            account_id: payload.account_id
+`
+	}
+	if opts.ProducerBroadcast {
+		return "        broadcast: true\n"
+	}
+	return ""
+}
+
+func writeScoring(t testing.TB, root string, opts Options) {
+	t.Helper()
+	writeFile(t, filepath.Join(root, "flows", "scoring", "schema.yaml"), `
+name: scoring
+mode: template
+initial_state: pending
+terminal_states: [done]
+states: [pending, done]
+instance:
+  by: account_id
+  on_missing: create
+  on_conflict: reuse
+pins:
+  inputs:
+    events:
+      - name: validation_requested
+        event: validation.requested
+  outputs:
+    events: []
+`)
+	writeFile(t, filepath.Join(root, "flows", "scoring", "policy.yaml"), "{}\n")
+	writeFile(t, filepath.Join(root, "flows", "scoring", "tools.yaml"), "{}\n")
+	writeFile(t, filepath.Join(root, "flows", "scoring", "agents.yaml"), "{}\n")
+	writeFile(t, filepath.Join(root, "flows", "scoring", "events.yaml"), `
+validation.requested:
+  account_id: string
+  score: string
+  decision: string
+`)
+	writeFile(t, filepath.Join(root, "flows", "scoring", "entities.yaml"), `
+validation:
+  account_id:
+    type: string
+  score:
+    type: string
+  decision:
+    type: string
+`)
+	writeFile(t, filepath.Join(root, "flows", "scoring", "nodes.yaml"), `
+scoring-handler:
+  id: scoring-handler
+  execution_type: system_node
+  subscribes_to: [validation.requested]
+  event_handlers:
+    validation.requested:
+`+receiverSelectionYAML(opts)+`      data_accumulation:
+        writes:
+          - source_field: account_id
+            target_field: account_id
+          - source_field: score
+            target_field: score
+          - source_field: decision
+            target_field: decision
+      advances_to: done
+`)
+}
+
+func receiverSelectionYAML(opts Options) string {
+	if !opts.UnsupportedReceiverSelection {
+		return ""
+	}
+	return `      select_entity:
+        by:
+          account_id: payload.account_id
+`
+}
+
+func repoRoot(t testing.TB) string {
+	t.Helper()
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("resolve repo root")
+	}
+	return filepath.Clean(filepath.Join(filepath.Dir(file), "..", "..", "..", ".."))
+}
+
+func writeFile(t testing.TB, path, contents string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, []byte(strings.TrimLeft(contents, "\n")), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}


### PR DESCRIPTION
## Summary
Adds the #1552 template-flow pilot fixture and proof coverage without changing production semantics.

Closes #1552
Part of #1537

## Governing Refs
- Discussion #1476 locked composition/instance-centered flow-package design.
- `platform-spec.yaml`: `flow_model.flow_instance_authoring`, `flow_model.template_instance_model`, `flow_model.composition_model`, `flow_model.pilot_model`, `flow_model.flow_package.composition_routing`, `route_plan_lowering`, `static_analyzer.slice_3a0_output_pin_key_carries_validation`.
- Binding issue context: #1552 is a conformance/runtime pilot fixture child under #1537, proving existing owners together rather than introducing new semantics.

## Semantic Migration
- New canonical owner: none introduced; this PR consumes the existing owners.
- Existing canonical owners exercised: primary entity resolver, template instance resolver, output pin key/carries validation, lowered `ConnectRoutePlan` instance-key authority, EventBus template lifecycle/route materialization, persisted delivery authority, and pipeline node delivery settlement.
- Old producer/reader/writer paths now invalid: receiver `select_entity` on the connected normal path, bad connect key mapping, producer `target`, producer `broadcast:true`, raw subscriber fallback, direct delivery, and relay/compat shims.
- Production paths checked for surviving old behavior: bootverify fail-closed matrix, EventBus missing/ambiguous key route planning, persisted route materialization, and pipeline delivery-authority dispatch.
- Migration complete: not applicable; test/fixture proof only, no production semantic migration.

## Validation
- `go test ./internal/runtime/conformance ./internal/runtime ./internal/runtime/pipeline -run 'TemplateFlowPilot' -count=1 -v`
- `go test ./internal/runtime/contracts ./internal/runtime/bootverify ./internal/runtime/core/pinrouting ./internal/runtime/bus ./internal/runtime/conformance ./internal/runtime ./internal/runtime/pipeline -run 'PrimaryEntity|TemplateInstance|KeyCarries|ConnectRoutePlan|RouteAuthority|SealedFlow|select_entity|SelectEntity|TemplateFlowPilot' -count=1`
- `go test ./...`