### PR TITLE
[agent-e][issue #1521] Add accumulator static safety checks

### DIFF
--- a/cmd/swarm/main_test.go
+++ b/cmd/swarm/main_test.go
@@ -9318,6 +9318,8 @@ accumulator:
 }
 
 func TestRunVerifyCommand_AllowsAccumulatorEntityProjection(t *testing.T) {
+	t.Setenv("SWARM_BOOT_WARNINGS_FATAL", "false")
+
 	root := t.TempDir()
 	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "package.yaml"), `
 name: verify-accumulator-entity-projection
@@ -9400,6 +9402,119 @@ scorer:
 	if out := buf.String(); !strings.Contains(out, "verify ok: contracts=") {
 		t.Fatalf("verify output missing success marker:\n%s", out)
 	}
+}
+
+func TestRunVerifyCommand_WarnsForAccumulateAllWithoutBoundedEscape(t *testing.T) {
+	t.Setenv("SWARM_BOOT_WARNINGS_FATAL", "false")
+
+	root := writeVerifyAccumulatorSafetyCommandFixture(t, verifyAccumulatorSafetyCommandFixtureOptions{
+		eventSource: "external (verify accumulator safety proof)",
+		completion:  "all",
+	})
+
+	var stdout, stderr bytes.Buffer
+	code := runVerifyCommandWithContractsOutputForTest(context.Background(), repoRoot(), root, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("runVerifyCommand exit code = %d, stdout = %q stderr = %q", code, stdout.String(), stderr.String())
+	}
+	if out := stdout.String(); !strings.Contains(out, "verify ok: contracts=") {
+		t.Fatalf("verify stdout missing success marker:\n%s", out)
+	}
+	errText := stderr.String()
+	if !strings.Contains(errText, "WARN: accumulate_all_bounded_escape") ||
+		!strings.Contains(errText, "without a bounded timeout escape") {
+		t.Fatalf("verify stderr missing accumulator bounded-escape warning:\n%s", errText)
+	}
+	if strings.Contains(errText, "accumulator_input_producer_path") {
+		t.Fatalf("verify stderr reported no-producer error despite external source:\n%s", errText)
+	}
+}
+
+func TestRunVerifyCommand_FailsForAccumulatorInputWithoutProducerPath(t *testing.T) {
+	root := writeVerifyAccumulatorSafetyCommandFixture(t, verifyAccumulatorSafetyCommandFixtureOptions{
+		completion: "timeout",
+		timeoutMS:  5000,
+	})
+
+	var stdout, stderr bytes.Buffer
+	code := runVerifyCommandWithContractsOutputForTest(context.Background(), repoRoot(), root, &stdout, &stderr)
+	if code == 0 {
+		t.Fatalf("expected non-zero exit code, stdout = %q stderr = %q", stdout.String(), stderr.String())
+	}
+	if strings.TrimSpace(stdout.String()) != "" {
+		t.Fatalf("verify stdout = %q, want empty for hard invalidity", stdout.String())
+	}
+	errText := stderr.String()
+	for _, want := range []string{
+		"verify failed: boot verification failed:",
+		"ERROR: accumulator_input_producer_path",
+		"no accepted producer/source path",
+	} {
+		if !strings.Contains(errText, want) {
+			t.Fatalf("verify stderr missing %q:\n%s", want, errText)
+		}
+	}
+}
+
+type verifyAccumulatorSafetyCommandFixtureOptions struct {
+	eventSource string
+	completion  string
+	timeoutMS   int
+}
+
+func writeVerifyAccumulatorSafetyCommandFixture(t *testing.T, opts verifyAccumulatorSafetyCommandFixtureOptions) string {
+	t.Helper()
+	root := t.TempDir()
+	completion := strings.TrimSpace(opts.completion)
+	if completion == "" {
+		completion = "all"
+	}
+	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "package.yaml"), `
+name: verify-accumulator-safety
+version: "1.0.0"
+platform: ">=1.6.0"
+flows: []
+`)
+	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "schema.yaml"), `
+name: verify-accumulator-safety
+initial_state: collecting
+terminal_states: [done]
+states: [collecting, done]
+pins:
+  inputs:
+    events: [item.arrived]
+`)
+	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "policy.yaml"), `{}`)
+	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "tools.yaml"), `{}`)
+	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "agents.yaml"), `{}`)
+	sourceBlock := ""
+	if strings.TrimSpace(opts.eventSource) != "" {
+		sourceBlock = "\n  swarm:\n    source: " + opts.eventSource
+	}
+	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "events.yaml"), `
+item.arrived:`+sourceBlock+`
+  expected_count: integer
+`)
+	timeoutLine := ""
+	if opts.timeoutMS > 0 {
+		timeoutLine = fmt.Sprintf("        timeout_ms: %d\n", opts.timeoutMS)
+	}
+	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "nodes.yaml"), `
+accumulator:
+  id: accumulator
+  execution_type: system_node
+  subscribes_to: [item.arrived]
+  event_handlers:
+    item.arrived:
+      accumulate:
+        expected_from: entity.expected_count
+        completion: `+completion+`
+`+timeoutLine+`      advances_to: done
+  state_schema:
+    fields:
+      expected_count: integer
+`)
+	return root
 }
 
 func testWorkflowValidationBundle() *runtimecontracts.WorkflowContractBundle {

--- a/cmd/swarm/main_test.go
+++ b/cmd/swarm/main_test.go
@@ -9430,6 +9430,35 @@ func TestRunVerifyCommand_WarnsForAccumulateAllWithoutBoundedEscape(t *testing.T
 	}
 }
 
+func TestRunVerifyCommand_FailsForAccumulateTimeoutWithoutTimeoutMS(t *testing.T) {
+	root := writeVerifyAccumulatorSafetyCommandFixture(t, verifyAccumulatorSafetyCommandFixtureOptions{
+		eventSource: "external (verify accumulator safety proof)",
+		completion:  "timeout",
+	})
+
+	var stdout, stderr bytes.Buffer
+	code := runVerifyCommandWithContractsOutputForTest(context.Background(), repoRoot(), root, &stdout, &stderr)
+	if code == 0 {
+		t.Fatalf("expected non-zero exit code, stdout = %q stderr = %q", stdout.String(), stderr.String())
+	}
+	if strings.TrimSpace(stdout.String()) != "" {
+		t.Fatalf("verify stdout = %q, want empty for hard invalidity", stdout.String())
+	}
+	errText := stderr.String()
+	for _, want := range []string{
+		"verify failed: boot verification failed:",
+		"ERROR: accumulator_timeout_requires_timeout_ms",
+		"without positive timeout_ms",
+	} {
+		if !strings.Contains(errText, want) {
+			t.Fatalf("verify stderr missing %q:\n%s", want, errText)
+		}
+	}
+	if strings.Contains(errText, "accumulator_input_producer_path") {
+		t.Fatalf("verify stderr reported no-producer error despite external source:\n%s", errText)
+	}
+}
+
 func TestRunVerifyCommand_FailsForAccumulatorInputWithoutProducerPath(t *testing.T) {
 	root := writeVerifyAccumulatorSafetyCommandFixture(t, verifyAccumulatorSafetyCommandFixtureOptions{
 		completion: "timeout",

--- a/internal/runtime/bootverify/checks.go
+++ b/internal/runtime/bootverify/checks.go
@@ -132,6 +132,8 @@ type checkerContext struct {
 
 	accumulatorProjectionLoaded   bool
 	accumulatorProjectionFindings []Finding
+	accumulatorSafetyLoaded       bool
+	accumulatorSafetyFindings     []Finding
 
 	producesDriftLoaded   bool
 	producesDriftFindings []Finding
@@ -216,6 +218,8 @@ var bootCheckRegistry = []Check{
 	{ID: "semantic_drift_unreachable_state", Severity: "warning", Run: checkSemanticDriftUnreachableState},
 	{ID: "node_state_schema_typed_counterpart", Severity: SeverityHardInvalidity, Run: checkNodeStateSchemaTypedCounterpart},
 	{ID: "accumulator_entity_projection", Severity: SeverityHardInvalidity, Run: checkAccumulatorEntityProjection},
+	{ID: "accumulate_all_bounded_escape", Severity: "warning", Run: checkAccumulateAllBoundedEscape},
+	{ID: "accumulator_input_producer_path", Severity: SeverityHardInvalidity, Run: checkAccumulatorInputProducerPath},
 	{ID: "required_agents_match", Severity: "error", Run: checkRequiredAgentsMatch},
 	{ID: "handler_field_compliance", Severity: "error", Run: checkHandlerFieldCompliance},
 	{ID: "tool_resolution", Severity: "warning", Run: checkToolResolution},

--- a/internal/runtime/bootverify/checks.go
+++ b/internal/runtime/bootverify/checks.go
@@ -219,6 +219,7 @@ var bootCheckRegistry = []Check{
 	{ID: "node_state_schema_typed_counterpart", Severity: SeverityHardInvalidity, Run: checkNodeStateSchemaTypedCounterpart},
 	{ID: "accumulator_entity_projection", Severity: SeverityHardInvalidity, Run: checkAccumulatorEntityProjection},
 	{ID: "accumulate_all_bounded_escape", Severity: "warning", Run: checkAccumulateAllBoundedEscape},
+	{ID: "accumulator_timeout_requires_timeout_ms", Severity: SeverityHardInvalidity, Run: checkAccumulatorTimeoutRequiresTimeout},
 	{ID: "accumulator_input_producer_path", Severity: SeverityHardInvalidity, Run: checkAccumulatorInputProducerPath},
 	{ID: "required_agents_match", Severity: "error", Run: checkRequiredAgentsMatch},
 	{ID: "handler_field_compliance", Severity: "error", Run: checkHandlerFieldCompliance},

--- a/internal/runtime/bootverify/flow_data_access_test.go
+++ b/internal/runtime/bootverify/flow_data_access_test.go
@@ -66,8 +66,8 @@ func TestRun_ValidatesFlowDataAccessDeclarations(t *testing.T) {
 }
 
 func TestBootCheckRegistry_HasFlowDataAccessCheckCount(t *testing.T) {
-	if got := len(bootCheckRegistry); got != 65 {
-		t.Fatalf("bootCheckRegistry count = %d, want 65", got)
+	if got := len(bootCheckRegistry); got != 67 {
+		t.Fatalf("bootCheckRegistry count = %d, want 67", got)
 	}
 }
 

--- a/internal/runtime/bootverify/flow_data_access_test.go
+++ b/internal/runtime/bootverify/flow_data_access_test.go
@@ -66,8 +66,8 @@ func TestRun_ValidatesFlowDataAccessDeclarations(t *testing.T) {
 }
 
 func TestBootCheckRegistry_HasFlowDataAccessCheckCount(t *testing.T) {
-	if got := len(bootCheckRegistry); got != 67 {
-		t.Fatalf("bootCheckRegistry count = %d, want 67", got)
+	if got := len(bootCheckRegistry); got != 68 {
+		t.Fatalf("bootCheckRegistry count = %d, want 68", got)
 	}
 }
 

--- a/internal/runtime/bootverify/report_test.go
+++ b/internal/runtime/bootverify/report_test.go
@@ -5031,8 +5031,8 @@ func TestRun_ReportsMissingRuntimeExecutorForOwnedRuntimeEvent(t *testing.T) {
 }
 
 func TestBootCheckRegistry_HasSpecCheckCount(t *testing.T) {
-	if got := len(bootCheckRegistry); got != 67 {
-		t.Fatalf("bootCheckRegistry count = %d, want 67", got)
+	if got := len(bootCheckRegistry); got != 68 {
+		t.Fatalf("bootCheckRegistry count = %d, want 68", got)
 	}
 	if got := len(supplementalChecks); got != 3 {
 		t.Fatalf("supplementalChecks count = %d, want 3", got)

--- a/internal/runtime/bootverify/report_test.go
+++ b/internal/runtime/bootverify/report_test.go
@@ -5031,8 +5031,8 @@ func TestRun_ReportsMissingRuntimeExecutorForOwnedRuntimeEvent(t *testing.T) {
 }
 
 func TestBootCheckRegistry_HasSpecCheckCount(t *testing.T) {
-	if got := len(bootCheckRegistry); got != 65 {
-		t.Fatalf("bootCheckRegistry count = %d, want 65", got)
+	if got := len(bootCheckRegistry); got != 67 {
+		t.Fatalf("bootCheckRegistry count = %d, want 67", got)
 	}
 	if got := len(supplementalChecks); got != 3 {
 		t.Fatalf("supplementalChecks count = %d, want 3", got)

--- a/internal/runtime/bootverify/workflow_accumulator_safety_checks.go
+++ b/internal/runtime/bootverify/workflow_accumulator_safety_checks.go
@@ -1,0 +1,257 @@
+package bootverify
+
+import (
+	"fmt"
+	"strings"
+
+	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
+	"github.com/division-sh/swarm/internal/runtime/core/eventidentity"
+)
+
+const (
+	checkIDAccumulateAllBoundedEscape = "accumulate_all_bounded_escape"
+	checkIDAccumulatorInputProducer   = "accumulator_input_producer_path"
+)
+
+func checkAccumulateAllBoundedEscape(c *checkerContext) []Finding {
+	return c.accumulatorSafetyByCheck(checkIDAccumulateAllBoundedEscape)
+}
+
+func checkAccumulatorInputProducerPath(c *checkerContext) []Finding {
+	return c.accumulatorSafetyByCheck(checkIDAccumulatorInputProducer)
+}
+
+func (c *checkerContext) accumulatorSafetyByCheck(checkID string) []Finding {
+	findings := c.accumulatorSafety()
+	out := make([]Finding, 0, len(findings))
+	for _, finding := range findings {
+		if finding.CheckID == checkID {
+			out = append(out, finding)
+		}
+	}
+	return out
+}
+
+func (c *checkerContext) accumulatorSafety() []Finding {
+	if c == nil || c.source == nil {
+		return nil
+	}
+	if c.accumulatorSafetyLoaded {
+		return c.accumulatorSafetyFindings
+	}
+	c.accumulatorSafetyLoaded = true
+
+	flowScopedNodes, flowScopedAgents := inputPinRootParticipants(c.source)
+	for nodeID := range c.source.NodeEntries() {
+		nodeID = strings.TrimSpace(nodeID)
+		if nodeID == "" {
+			continue
+		}
+		nodeSource, _ := c.source.NodeContractSource(nodeID)
+		flowID := strings.TrimSpace(nodeSource.FlowID)
+		for _, eventType := range c.source.NodeHandlerSubscriptions(nodeID) {
+			eventType = strings.TrimSpace(eventType)
+			if eventType == "" {
+				continue
+			}
+			handler, ok := c.source.NodeEventHandler(nodeID, eventType)
+			if !ok || handler.Accumulate == nil {
+				continue
+			}
+			location := accumulatorHandlerLocation(flowID, nodeID, eventType)
+			spec := handler.Accumulate
+			if accumulatorCompletionAllFamily(spec) && !accumulatorHasBoundedEscape(spec) {
+				c.accumulatorSafetyFindings = append(c.accumulatorSafetyFindings, Finding{
+					CheckID:  checkIDAccumulateAllBoundedEscape,
+					Severity: "warning",
+					Location: location,
+					Message: fmt.Sprintf(
+						"flow %s node %s handler %s uses accumulate completion %q without a bounded timeout escape; if an expected arrival never appears this handler can wait indefinitely. Add a schedulable timeout escape such as completion: timeout with timeout_ms, or an on_timeout branch with timeout_ms.",
+						accumulatorFlowLabel(flowID),
+						nodeID,
+						eventType,
+						accumulatorCompletionLabel(spec),
+					),
+				})
+			}
+			producerPaths := c.accumulatorProducerPaths(flowID, eventType, flowScopedNodes, flowScopedAgents)
+			if producerPaths.hasAny() {
+				continue
+			}
+			c.accumulatorSafetyFindings = append(c.accumulatorSafetyFindings, Finding{
+				CheckID:  checkIDAccumulatorInputProducer,
+				Severity: SeverityHardInvalidity,
+				Location: location,
+				Message:  producerPaths.message(flowID, nodeID, eventType),
+			})
+		}
+	}
+	return c.accumulatorSafetyFindings
+}
+
+func accumulatorCompletionAllFamily(spec *runtimecontracts.AccumulateSpec) bool {
+	if spec == nil {
+		return false
+	}
+	return spec.Completion.Mode == runtimecontracts.AccumulateModeDefault ||
+		spec.Completion.Mode == runtimecontracts.AccumulateModeAll
+}
+
+func accumulatorHasBoundedEscape(spec *runtimecontracts.AccumulateSpec) bool {
+	if spec == nil || spec.TimeoutMS <= 0 {
+		return false
+	}
+	if spec.Completion.Mode == runtimecontracts.AccumulateModeTimeout {
+		return true
+	}
+	return spec.OnTimeout != nil
+}
+
+func accumulatorCompletionLabel(spec *runtimecontracts.AccumulateSpec) string {
+	if spec == nil {
+		return ""
+	}
+	if text := strings.TrimSpace(spec.Completion.String()); text != "" {
+		return text
+	}
+	return "default/all"
+}
+
+func accumulatorHandlerLocation(flowID, nodeID, eventType string) string {
+	nodeID = strings.TrimSpace(nodeID)
+	eventType = strings.TrimSpace(eventType)
+	flowID = accumulatorFlowLabel(flowID)
+	return strings.Trim(flowID+"/"+nodeID+":"+eventType, "/:")
+}
+
+func accumulatorFlowLabel(flowID string) string {
+	flowID = strings.TrimSpace(flowID)
+	if flowID == "" {
+		return "root"
+	}
+	return flowID
+}
+
+type accumulatorProducerPaths struct {
+	inputPaths        inputPinProducerPaths
+	sameFlowNodeEmit  string
+	sameFlowAgentEmit string
+}
+
+func (p accumulatorProducerPaths) hasAny() bool {
+	if p.inputPaths.hasAny() {
+		return true
+	}
+	for _, detail := range []string{
+		p.sameFlowNodeEmit,
+		p.sameFlowAgentEmit,
+	} {
+		if !strings.HasPrefix(strings.TrimSpace(detail), "not ") {
+			return true
+		}
+	}
+	return false
+}
+
+func (p accumulatorProducerPaths) message(flowID, nodeID, eventType string) string {
+	return fmt.Sprintf(
+		"Flow %s node %s handler %s accumulates event %s but no accepted producer/source path was found in the authored bundle.\n\nChecked producer paths:\n- Parent connect: %s\n- Sibling flow output pin: %s\n- Root agent emit_events: %s\n- Root node handler emits: %s\n- Platform event catalog: %s\n- External source metadata (swarm.source): %s\n- Same-flow timer declaration: %s\n- Same-flow node handler emits: %s\n- Same-flow agent emit_events: %s\n\nFix one of:\n- Add an accepted producer path for %s\n- Add swarm.source: external to %s's events.yaml entry if produced externally\n- Remove the accumulator if the event is not produced",
+		accumulatorFlowLabel(flowID),
+		strings.TrimSpace(nodeID),
+		strings.TrimSpace(eventType),
+		strings.TrimSpace(eventType),
+		p.inputPaths.parentConnect,
+		p.inputPaths.siblingFlowOutputPin,
+		p.inputPaths.rootAgentEmit,
+		p.inputPaths.rootNodeHandlerEmit,
+		p.inputPaths.platformEventCatalog,
+		p.inputPaths.externalSource,
+		p.inputPaths.sameFlowTimer,
+		p.sameFlowNodeEmit,
+		p.sameFlowAgentEmit,
+		strings.TrimSpace(eventType),
+		strings.TrimSpace(eventType),
+	)
+}
+
+func (c *checkerContext) accumulatorProducerPaths(flowID, eventType string, flowScopedNodes, flowScopedAgents map[string]struct{}) accumulatorProducerPaths {
+	inputPaths := c.inputPinProducerPaths(flowID, eventType, flowScopedNodes, flowScopedAgents)
+	return accumulatorProducerPaths{
+		inputPaths:        inputPaths,
+		sameFlowNodeEmit:  c.accumulatorSameFlowNodeEmitPath(flowID, eventType),
+		sameFlowAgentEmit: c.accumulatorSameFlowAgentEmitPath(flowID, eventType),
+	}
+}
+
+func (c *checkerContext) accumulatorSameFlowNodeEmitPath(flowID, eventType string) string {
+	matches := map[string]struct{}{}
+	for nodeID := range c.source.NodeEntries() {
+		nodeID = strings.TrimSpace(nodeID)
+		nodeSource, _ := c.source.NodeContractSource(nodeID)
+		if strings.TrimSpace(nodeSource.FlowID) != strings.TrimSpace(flowID) {
+			continue
+		}
+		for handlerEvent, handler := range c.source.NodeEventHandlers(nodeID) {
+			for _, emitted := range handlerEmits(handler) {
+				if accumulatorEventMatches(c.source, flowID, eventType, emitted) {
+					matches[fmt.Sprintf("%s handler %s", nodeID, strings.TrimSpace(handlerEvent))] = struct{}{}
+				}
+			}
+		}
+	}
+	if len(matches) == 0 {
+		return "not found"
+	}
+	labels := sortedSetKeysLocal(matches)
+	if len(labels) == 1 {
+		return fmt.Sprintf("found on %s", labels[0])
+	}
+	return fmt.Sprintf("found on %s", strings.Join(labels, ", "))
+}
+
+func (c *checkerContext) accumulatorSameFlowAgentEmitPath(flowID, eventType string) string {
+	matches := map[string]struct{}{}
+	for agentID, agent := range c.source.AgentEntries() {
+		agentID = strings.TrimSpace(agentID)
+		agentSource, _ := c.source.AgentContractSource(agentID)
+		if strings.TrimSpace(agentSource.FlowID) != strings.TrimSpace(flowID) {
+			continue
+		}
+		for _, emitted := range agent.EmitEvents {
+			if accumulatorEventMatches(c.source, flowID, eventType, emitted) {
+				matches[agentID] = struct{}{}
+			}
+		}
+	}
+	if len(matches) == 0 {
+		return "not found"
+	}
+	labels := sortedSetKeysLocal(matches)
+	if len(labels) == 1 {
+		return fmt.Sprintf("found on agent %s", labels[0])
+	}
+	return fmt.Sprintf("found on agents %s", strings.Join(labels, ", "))
+}
+
+func accumulatorEventMatches(source interface {
+	ResolveFlowEventReference(flowID, eventType string) string
+	FlowEventMatches(flowID, subscription, eventType string) bool
+}, flowID, eventType, candidate string) bool {
+	eventType = eventidentity.Normalize(eventType)
+	candidate = eventidentity.Normalize(candidate)
+	if eventType == "" || candidate == "" {
+		return false
+	}
+	if eventType == candidate {
+		return true
+	}
+	if source == nil {
+		return false
+	}
+	canonicalEvent := eventidentity.Normalize(source.ResolveFlowEventReference(flowID, eventType))
+	canonicalCandidate := eventidentity.Normalize(source.ResolveFlowEventReference(flowID, candidate))
+	if canonicalEvent != "" && canonicalCandidate == canonicalEvent {
+		return true
+	}
+	return source.FlowEventMatches(flowID, candidate, canonicalEvent)
+}

--- a/internal/runtime/bootverify/workflow_accumulator_safety_checks.go
+++ b/internal/runtime/bootverify/workflow_accumulator_safety_checks.go
@@ -9,8 +9,9 @@ import (
 )
 
 const (
-	checkIDAccumulateAllBoundedEscape = "accumulate_all_bounded_escape"
-	checkIDAccumulatorInputProducer   = "accumulator_input_producer_path"
+	checkIDAccumulateAllBoundedEscape        = "accumulate_all_bounded_escape"
+	checkIDAccumulatorTimeoutRequiresTimeout = "accumulator_timeout_requires_timeout_ms"
+	checkIDAccumulatorInputProducer          = "accumulator_input_producer_path"
 )
 
 func checkAccumulateAllBoundedEscape(c *checkerContext) []Finding {
@@ -19,6 +20,10 @@ func checkAccumulateAllBoundedEscape(c *checkerContext) []Finding {
 
 func checkAccumulatorInputProducerPath(c *checkerContext) []Finding {
 	return c.accumulatorSafetyByCheck(checkIDAccumulatorInputProducer)
+}
+
+func checkAccumulatorTimeoutRequiresTimeout(c *checkerContext) []Finding {
+	return c.accumulatorSafetyByCheck(checkIDAccumulatorTimeoutRequiresTimeout)
 }
 
 func (c *checkerContext) accumulatorSafetyByCheck(checkID string) []Finding {
@@ -74,6 +79,20 @@ func (c *checkerContext) accumulatorSafety() []Finding {
 					),
 				})
 			}
+			if accumulatorTimeoutCompletionWithoutSchedulableTimeout(spec) {
+				c.accumulatorSafetyFindings = append(c.accumulatorSafetyFindings, Finding{
+					CheckID:  checkIDAccumulatorTimeoutRequiresTimeout,
+					Severity: SeverityHardInvalidity,
+					Location: location,
+					Message: fmt.Sprintf(
+						"flow %s node %s handler %s uses accumulate completion %q without positive timeout_ms; runtime cannot schedule the accumulate.timeout event, so the handler can wait indefinitely. Add timeout_ms > 0 or choose a completion mode with a schedulable bounded escape.",
+						accumulatorFlowLabel(flowID),
+						nodeID,
+						eventType,
+						accumulatorCompletionLabel(spec),
+					),
+				})
+			}
 			producerPaths := c.accumulatorProducerPaths(flowID, eventType, flowScopedNodes, flowScopedAgents)
 			if producerPaths.hasAny() {
 				continue
@@ -105,6 +124,12 @@ func accumulatorHasBoundedEscape(spec *runtimecontracts.AccumulateSpec) bool {
 		return true
 	}
 	return spec.OnTimeout != nil
+}
+
+func accumulatorTimeoutCompletionWithoutSchedulableTimeout(spec *runtimecontracts.AccumulateSpec) bool {
+	return spec != nil &&
+		spec.Completion.Mode == runtimecontracts.AccumulateModeTimeout &&
+		spec.TimeoutMS <= 0
 }
 
 func accumulatorCompletionLabel(spec *runtimecontracts.AccumulateSpec) string {

--- a/internal/runtime/bootverify/workflow_accumulator_safety_checks.go
+++ b/internal/runtime/bootverify/workflow_accumulator_safety_checks.go
@@ -253,5 +253,11 @@ func accumulatorEventMatches(source interface {
 	if canonicalEvent != "" && canonicalCandidate == canonicalEvent {
 		return true
 	}
-	return source.FlowEventMatches(flowID, candidate, canonicalEvent)
+	if source.FlowEventMatches(flowID, eventType, candidate) {
+		return true
+	}
+	if canonicalCandidate != "" && canonicalCandidate != candidate {
+		return source.FlowEventMatches(flowID, eventType, canonicalCandidate)
+	}
+	return false
 }

--- a/internal/runtime/bootverify/workflow_accumulator_safety_checks_test.go
+++ b/internal/runtime/bootverify/workflow_accumulator_safety_checks_test.go
@@ -28,6 +28,23 @@ func TestRun_WarnsForAccumulateAllWithoutBoundedEscape(t *testing.T) {
 	}
 }
 
+func TestRun_WarnsForDefaultAccumulateWithoutBoundedEscape(t *testing.T) {
+	root := writeAccumulatorSafetyFixture(t, accumulatorSafetyFixtureOptions{
+		eventSource:    "external",
+		omitCompletion: true,
+	})
+	bundle := loadFixtureBundleAt(t, repoRootForBootverifyTest(t), root, runtimecontracts.DefaultPlatformSpecFile(repoRootForBootverifyTest(t)))
+
+	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+
+	if report.HasErrors() {
+		t.Fatalf("expected warning-only report, got errors: %#v", report.Errors())
+	}
+	if !reportContains(report.Warnings(), checkIDAccumulateAllBoundedEscape, "default/all") {
+		t.Fatalf("expected %s warning for omitted completion, got %#v", checkIDAccumulateAllBoundedEscape, report.Warnings())
+	}
+}
+
 func TestRun_WarnsForAccumulateAllOnTimeoutWithoutSchedulableTimeout(t *testing.T) {
 	root := writeAccumulatorSafetyFixture(t, accumulatorSafetyFixtureOptions{
 		eventSource: "external",
@@ -59,6 +76,26 @@ func TestRun_DoesNotWarnForAccumulateAllWithSchedulableOnTimeout(t *testing.T) {
 
 	if reportContains(report.Warnings(), checkIDAccumulateAllBoundedEscape, "") {
 		t.Fatalf("unexpected %s warning with schedulable on_timeout: %#v", checkIDAccumulateAllBoundedEscape, report.Warnings())
+	}
+	if reportContains(report.Errors(), checkIDAccumulatorInputProducer, "") {
+		t.Fatalf("unexpected %s error with external source: %#v", checkIDAccumulatorInputProducer, report.Errors())
+	}
+}
+
+func TestRun_FailsClosedForAccumulateTimeoutWithoutTimeoutMS(t *testing.T) {
+	root := writeAccumulatorSafetyFixture(t, accumulatorSafetyFixtureOptions{
+		eventSource: "external",
+		completion:  "timeout",
+	})
+	bundle := loadFixtureBundleAt(t, repoRootForBootverifyTest(t), root, runtimecontracts.DefaultPlatformSpecFile(repoRootForBootverifyTest(t)))
+
+	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+
+	if !reportContains(report.Errors(), checkIDAccumulatorTimeoutRequiresTimeout, "without positive timeout_ms") {
+		t.Fatalf("expected %s hard invalidity, got %#v", checkIDAccumulatorTimeoutRequiresTimeout, report.Errors())
+	}
+	if reportContains(report.Warnings(), checkIDAccumulateAllBoundedEscape, "") {
+		t.Fatalf("unexpected %s warning for timeout completion: %#v", checkIDAccumulateAllBoundedEscape, report.Warnings())
 	}
 	if reportContains(report.Errors(), checkIDAccumulatorInputProducer, "") {
 		t.Fatalf("unexpected %s error with external source: %#v", checkIDAccumulatorInputProducer, report.Errors())
@@ -227,6 +264,7 @@ type accumulatorSafetyFixtureOptions struct {
 	eventSource           string
 	eventStatusPlan       bool
 	completion            string
+	omitCompletion        bool
 	timeoutMS             int
 	onTimeout             bool
 	sameFlowNodeProducer  bool
@@ -245,6 +283,10 @@ func writeAccumulatorSafetyFixture(t *testing.T, opts accumulatorSafetyFixtureOp
 	completion := strings.TrimSpace(opts.completion)
 	if completion == "" {
 		completion = "all"
+	}
+	completionLine := ""
+	if !opts.omitCompletion {
+		completionLine = "        completion: " + completion + "\n"
 	}
 	producesLine := ""
 	if opts.nodeProduces {
@@ -315,8 +357,7 @@ accumulator-node:
     `+eventType+`:
       accumulate:
         expected_from: entity.expected_count
-        completion: `+completion+`
-`+timeoutLine+onTimeoutBlock+`      advances_to: done
+`+completionLine+timeoutLine+onTimeoutBlock+`      advances_to: done
   state_schema:
     fields:
       expected_count: integer

--- a/internal/runtime/bootverify/workflow_accumulator_safety_checks_test.go
+++ b/internal/runtime/bootverify/workflow_accumulator_safety_checks_test.go
@@ -1,0 +1,462 @@
+package bootverify
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
+	"github.com/division-sh/swarm/internal/runtime/semanticview"
+)
+
+func TestRun_WarnsForAccumulateAllWithoutBoundedEscape(t *testing.T) {
+	root := writeAccumulatorSafetyFixture(t, accumulatorSafetyFixtureOptions{
+		eventSource: "external",
+		completion:  "all",
+	})
+	bundle := loadFixtureBundleAt(t, repoRootForBootverifyTest(t), root, runtimecontracts.DefaultPlatformSpecFile(repoRootForBootverifyTest(t)))
+
+	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+
+	if report.HasErrors() {
+		t.Fatalf("expected warning-only report, got errors: %#v", report.Errors())
+	}
+	if !reportContains(report.Warnings(), checkIDAccumulateAllBoundedEscape, "without a bounded timeout escape") {
+		t.Fatalf("expected %s warning, got %#v", checkIDAccumulateAllBoundedEscape, report.Warnings())
+	}
+}
+
+func TestRun_WarnsForAccumulateAllOnTimeoutWithoutSchedulableTimeout(t *testing.T) {
+	root := writeAccumulatorSafetyFixture(t, accumulatorSafetyFixtureOptions{
+		eventSource: "external",
+		completion:  "all",
+		onTimeout:   true,
+	})
+	bundle := loadFixtureBundleAt(t, repoRootForBootverifyTest(t), root, runtimecontracts.DefaultPlatformSpecFile(repoRootForBootverifyTest(t)))
+
+	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+
+	if report.HasErrors() {
+		t.Fatalf("expected warning-only report, got errors: %#v", report.Errors())
+	}
+	if !reportContains(report.Warnings(), checkIDAccumulateAllBoundedEscape, "without a bounded timeout escape") {
+		t.Fatalf("expected %s warning for bare on_timeout, got %#v", checkIDAccumulateAllBoundedEscape, report.Warnings())
+	}
+}
+
+func TestRun_DoesNotWarnForAccumulateAllWithSchedulableOnTimeout(t *testing.T) {
+	root := writeAccumulatorSafetyFixture(t, accumulatorSafetyFixtureOptions{
+		eventSource: "external",
+		completion:  "all",
+		onTimeout:   true,
+		timeoutMS:   5000,
+	})
+	bundle := loadFixtureBundleAt(t, repoRootForBootverifyTest(t), root, runtimecontracts.DefaultPlatformSpecFile(repoRootForBootverifyTest(t)))
+
+	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+
+	if reportContains(report.Warnings(), checkIDAccumulateAllBoundedEscape, "") {
+		t.Fatalf("unexpected %s warning with schedulable on_timeout: %#v", checkIDAccumulateAllBoundedEscape, report.Warnings())
+	}
+	if reportContains(report.Errors(), checkIDAccumulatorInputProducer, "") {
+		t.Fatalf("unexpected %s error with external source: %#v", checkIDAccumulatorInputProducer, report.Errors())
+	}
+}
+
+func TestRun_DoesNotWarnForAccumulateTimeoutWithSchedulableTimeout(t *testing.T) {
+	root := writeAccumulatorSafetyFixture(t, accumulatorSafetyFixtureOptions{
+		eventSource: "external",
+		completion:  "timeout",
+		timeoutMS:   5000,
+	})
+	bundle := loadFixtureBundleAt(t, repoRootForBootverifyTest(t), root, runtimecontracts.DefaultPlatformSpecFile(repoRootForBootverifyTest(t)))
+
+	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+
+	if reportContains(report.Warnings(), checkIDAccumulateAllBoundedEscape, "") {
+		t.Fatalf("unexpected %s warning for timeout completion: %#v", checkIDAccumulateAllBoundedEscape, report.Warnings())
+	}
+	if reportContains(report.Errors(), checkIDAccumulatorInputProducer, "") {
+		t.Fatalf("unexpected %s error with external source: %#v", checkIDAccumulatorInputProducer, report.Errors())
+	}
+}
+
+func TestRun_FailsClosedForAccumulatorInputWithoutProducerPath(t *testing.T) {
+	root := writeAccumulatorSafetyFixture(t, accumulatorSafetyFixtureOptions{
+		completion: "timeout",
+		timeoutMS:  5000,
+	})
+	bundle := loadFixtureBundleAt(t, repoRootForBootverifyTest(t), root, runtimecontracts.DefaultPlatformSpecFile(repoRootForBootverifyTest(t)))
+
+	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+
+	if !reportContains(report.Errors(), checkIDAccumulatorInputProducer, "no accepted producer/source path") {
+		t.Fatalf("expected %s error, got %#v", checkIDAccumulatorInputProducer, report.Errors())
+	}
+	if !reportContains(report.Errors(), checkIDAccumulatorInputProducer, "Parent connect: not found") ||
+		!reportContains(report.Errors(), checkIDAccumulatorInputProducer, "Same-flow node handler emits: not found") {
+		t.Fatalf("expected producer path audit details, got %#v", report.Errors())
+	}
+}
+
+func TestRun_DoesNotErrorForAccumulatorAcceptedProducerPaths(t *testing.T) {
+	cases := []struct {
+		name string
+		root func(*testing.T) string
+	}{
+		{
+			name: "external source metadata",
+			root: func(t *testing.T) string {
+				return writeAccumulatorSafetyFixture(t, accumulatorSafetyFixtureOptions{
+					eventSource: "external",
+					completion:  "timeout",
+					timeoutMS:   5000,
+				})
+			},
+		},
+		{
+			name: "same-flow node handler emit",
+			root: func(t *testing.T) string {
+				return writeAccumulatorSafetyFixture(t, accumulatorSafetyFixtureOptions{
+					sameFlowNodeProducer: true,
+					completion:           "timeout",
+					timeoutMS:            5000,
+				})
+			},
+		},
+		{
+			name: "same-flow agent emit_events",
+			root: func(t *testing.T) string {
+				return writeAccumulatorSafetyFixture(t, accumulatorSafetyFixtureOptions{
+					sameFlowAgentProducer: true,
+					completion:            "timeout",
+					timeoutMS:             5000,
+				})
+			},
+		},
+		{
+			name: "same-flow timer declaration",
+			root: func(t *testing.T) string {
+				return writeAccumulatorSafetyFixture(t, accumulatorSafetyFixtureOptions{
+					sameFlowTimer: true,
+					completion:    "timeout",
+					timeoutMS:     5000,
+				})
+			},
+		},
+		{
+			name: "platform event catalog",
+			root: func(t *testing.T) string {
+				return writeAccumulatorSafetyFixture(t, accumulatorSafetyFixtureOptions{
+					eventType:  "platform.runtime_log",
+					completion: "timeout",
+					timeoutMS:  5000,
+				})
+			},
+		},
+		{
+			name: "root agent emit_events",
+			root: func(t *testing.T) string {
+				return writeAccumulatorRootAgentFixture(t)
+			},
+		},
+		{
+			name: "root node handler emit",
+			root: func(t *testing.T) string {
+				return writeAccumulatorRootNodeFixture(t)
+			},
+		},
+		{
+			name: "sibling output pin",
+			root: func(t *testing.T) string {
+				return writeAccumulatorCrossFlowFixture(t, false)
+			},
+		},
+		{
+			name: "parent connect",
+			root: func(t *testing.T) string {
+				return writeAccumulatorCrossFlowFixture(t, true)
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			bundle := loadFixtureBundleAt(t, repoRootForBootverifyTest(t), tc.root(t), runtimecontracts.DefaultPlatformSpecFile(repoRootForBootverifyTest(t)))
+
+			report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+
+			if reportContains(report.Errors(), checkIDAccumulatorInputProducer, "") {
+				t.Fatalf("unexpected %s error: %#v", checkIDAccumulatorInputProducer, report.Errors())
+			}
+		})
+	}
+}
+
+func TestRun_AccumulatorProducerProofRejectsProducesAndPlannedStatus(t *testing.T) {
+	root := writeAccumulatorSafetyFixture(t, accumulatorSafetyFixtureOptions{
+		completion:      "timeout",
+		timeoutMS:       5000,
+		nodeProduces:    true,
+		eventStatusPlan: true,
+	})
+	bundle := loadFixtureBundleAt(t, repoRootForBootverifyTest(t), root, runtimecontracts.DefaultPlatformSpecFile(repoRootForBootverifyTest(t)))
+
+	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+
+	if !reportContains(report.Errors(), checkIDAccumulatorInputProducer, "no accepted producer/source path") {
+		t.Fatalf("expected %s error despite produces/planned status, got %#v", checkIDAccumulatorInputProducer, report.Errors())
+	}
+}
+
+type accumulatorSafetyFixtureOptions struct {
+	eventType             string
+	eventSource           string
+	eventStatusPlan       bool
+	completion            string
+	timeoutMS             int
+	onTimeout             bool
+	sameFlowNodeProducer  bool
+	sameFlowAgentProducer bool
+	sameFlowTimer         bool
+	nodeProduces          bool
+}
+
+func writeAccumulatorSafetyFixture(t *testing.T, opts accumulatorSafetyFixtureOptions) string {
+	t.Helper()
+	root := t.TempDir()
+	eventType := strings.TrimSpace(opts.eventType)
+	if eventType == "" {
+		eventType = "item.arrived"
+	}
+	completion := strings.TrimSpace(opts.completion)
+	if completion == "" {
+		completion = "all"
+	}
+	producesLine := ""
+	if opts.nodeProduces {
+		producesLine = "  produces: [" + eventType + "]\n"
+	}
+	writeBootverifyFixtureFile(t, filepath.Join(root, "package.yaml"), `
+name: accumulator-safety
+version: "1.0.0"
+platform: ">=1.6.0"
+`)
+	writeBootverifyFixtureFile(t, filepath.Join(root, "schema.yaml"), `
+name: accumulator-safety
+initial_state: collecting
+terminal_states: [done, partial]
+states: [collecting, done, partial]
+pins:
+  inputs:
+    events: [`+eventType+`]
+`)
+	writeBootverifyFixtureFile(t, filepath.Join(root, "policy.yaml"), "{}\n")
+	writeBootverifyFixtureFile(t, filepath.Join(root, "tools.yaml"), "{}\n")
+	writeAccumulatorEventsFile(t, filepath.Join(root, "events.yaml"), eventType, opts.eventSource, opts.eventStatusPlan)
+	writeAccumulatorAgentsFile(t, filepath.Join(root, "agents.yaml"), eventType, opts.sameFlowAgentProducer)
+
+	timeoutLine := ""
+	if opts.timeoutMS > 0 {
+		timeoutLine = fmt.Sprintf("        timeout_ms: %d\n", opts.timeoutMS)
+	}
+	onTimeoutBlock := ""
+	if opts.onTimeout {
+		onTimeoutBlock = `
+        on_timeout:
+          advances_to: partial
+          emit:
+            event: collection.partial
+`
+	}
+	producerBlock := ""
+	if opts.sameFlowNodeProducer {
+		producerBlock = `
+producer-node:
+  id: producer-node
+  execution_type: system_node
+  subscribes_to: [producer.start]
+  event_handlers:
+    producer.start:
+      emit:
+        event: ` + eventType + `
+`
+	}
+	timerBlock := ""
+	if opts.sameFlowTimer {
+		timerBlock = `
+  timers:
+    - id: accumulation
+      owner: accumulator-node
+      event: ` + eventType + `
+      delay: 1m
+      start_on: boot
+`
+	}
+	writeBootverifyFixtureFile(t, filepath.Join(root, "nodes.yaml"), producerBlock+`
+accumulator-node:
+  id: accumulator-node
+  execution_type: system_node
+  subscribes_to: [`+eventType+`]
+`+producesLine+timerBlock+`  event_handlers:
+    `+eventType+`:
+      accumulate:
+        expected_from: entity.expected_count
+        completion: `+completion+`
+`+timeoutLine+onTimeoutBlock+`      advances_to: done
+  state_schema:
+    fields:
+      expected_count: integer
+`)
+	return root
+}
+
+func writeAccumulatorEventsFile(t *testing.T, path, eventType, source string, planned bool) {
+	t.Helper()
+	sourceBlock := ""
+	if strings.TrimSpace(source) != "" || planned {
+		sourceBlock += "  swarm:\n"
+		if strings.TrimSpace(source) != "" {
+			sourceBlock += "    source: " + source + "\n"
+		}
+		if planned {
+			sourceBlock += "    status: planned\n"
+		}
+	}
+	writeBootverifyFixtureFile(t, path, eventType+`:
+`+sourceBlock+`  expected_count: integer
+producer.start:
+  {}
+accumulate.timeout:
+  {}
+collection.done:
+  {}
+collection.partial:
+  {}
+`)
+}
+
+func writeAccumulatorAgentsFile(t *testing.T, path, eventType string, includeProducer bool) {
+	t.Helper()
+	if !includeProducer {
+		writeBootverifyFixtureFile(t, path, "{}\n")
+		return
+	}
+	writeBootverifyFixtureFile(t, path, `
+producer-agent:
+  id: producer-agent
+  role: producer
+  emit_events:
+    - `+eventType+`
+`)
+}
+
+func writeAccumulatorRootAgentFixture(t *testing.T) string {
+	t.Helper()
+	root := writeAccumulatorSafetyFixture(t, accumulatorSafetyFixtureOptions{
+		completion: "timeout",
+		timeoutMS:  5000,
+	})
+	writeBootverifyFixtureFile(t, filepath.Join(root, "agents.yaml"), `
+producer-agent:
+  id: producer-agent
+  role: producer
+  emit_events:
+    - item.arrived
+`)
+	return root
+}
+
+func writeAccumulatorRootNodeFixture(t *testing.T) string {
+	t.Helper()
+	return writeAccumulatorSafetyFixture(t, accumulatorSafetyFixtureOptions{
+		sameFlowNodeProducer: true,
+		completion:           "timeout",
+		timeoutMS:            5000,
+	})
+}
+
+func writeAccumulatorCrossFlowFixture(t *testing.T, withConnect bool) string {
+	t.Helper()
+	root := t.TempDir()
+	connectBlock := ""
+	if withConnect {
+		connectBlock = `
+connect:
+  - from: producer.item.arrived
+    to: consumer.item.arrived
+`
+	}
+	writeBootverifyFixtureFile(t, filepath.Join(root, "package.yaml"), `
+name: accumulator-cross-flow
+version: "1.0.0"
+platform: ">=1.6.0"
+flows:
+  - id: producer
+    flow: producer
+    mode: static
+  - id: consumer
+    flow: consumer
+    mode: static
+`+connectBlock)
+	writeBootverifyFixtureFile(t, filepath.Join(root, "schema.yaml"), "name: accumulator-cross-flow\n")
+	writeBootverifyFixtureFile(t, filepath.Join(root, "policy.yaml"), "{}\n")
+	writeBootverifyFixtureFile(t, filepath.Join(root, "tools.yaml"), "{}\n")
+	writeBootverifyFixtureFile(t, filepath.Join(root, "events.yaml"), "{}\n")
+	writeBootverifyFixtureFile(t, filepath.Join(root, "agents.yaml"), "{}\n")
+	writeBootverifyFixtureFile(t, filepath.Join(root, "nodes.yaml"), "{}\n")
+	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "producer", "schema.yaml"), `
+name: producer
+pins:
+  outputs:
+    events: [item.arrived]
+`)
+	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "producer", "events.yaml"), `
+item.arrived:
+  expected_count: integer
+producer.start:
+  {}
+`)
+	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "producer", "agents.yaml"), "{}\n")
+	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "producer", "entities.yaml"), "{}\n")
+	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "producer", "nodes.yaml"), `
+producer-node:
+  id: producer-node
+  execution_type: system_node
+  subscribes_to: [producer.start]
+  event_handlers:
+    producer.start:
+      emit:
+        event: item.arrived
+`)
+	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "consumer", "schema.yaml"), `
+name: consumer
+initial_state: collecting
+terminal_states: [done]
+states: [collecting, done]
+pins:
+  inputs:
+    events: [item.arrived]
+`)
+	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "consumer", "events.yaml"), `
+item.arrived:
+  expected_count: integer
+`)
+	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "consumer", "agents.yaml"), "{}\n")
+	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "consumer", "entities.yaml"), "{}\n")
+	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "consumer", "nodes.yaml"), `
+consumer-node:
+  id: consumer-node
+  execution_type: system_node
+  subscribes_to: [item.arrived]
+  event_handlers:
+    item.arrived:
+      accumulate:
+        expected_from: entity.expected_count
+        completion: timeout
+        timeout_ms: 5000
+      advances_to: done
+`)
+	return root
+}

--- a/internal/runtime/bootverify/workflow_accumulator_safety_checks_test.go
+++ b/internal/runtime/bootverify/workflow_accumulator_safety_checks_test.go
@@ -127,6 +127,12 @@ func TestRun_DoesNotErrorForAccumulatorAcceptedProducerPaths(t *testing.T) {
 			},
 		},
 		{
+			name: "same-flow node handler wildcard emit",
+			root: func(t *testing.T) string {
+				return writeAccumulatorWildcardSameFlowNodeFixture(t)
+			},
+		},
+		{
 			name: "same-flow agent emit_events",
 			root: func(t *testing.T) string {
 				return writeAccumulatorSafetyFixture(t, accumulatorSafetyFixtureOptions{
@@ -134,6 +140,12 @@ func TestRun_DoesNotErrorForAccumulatorAcceptedProducerPaths(t *testing.T) {
 					completion:            "timeout",
 					timeoutMS:             5000,
 				})
+			},
+		},
+		{
+			name: "same-flow agent wildcard emit_events",
+			root: func(t *testing.T) string {
+				return writeAccumulatorWildcardSameFlowAgentFixture(t)
 			},
 		},
 		{
@@ -375,6 +387,94 @@ func writeAccumulatorRootNodeFixture(t *testing.T) string {
 		completion:           "timeout",
 		timeoutMS:            5000,
 	})
+}
+
+func writeAccumulatorWildcardSameFlowNodeFixture(t *testing.T) string {
+	t.Helper()
+	root := writeAccumulatorWildcardSameFlowFixture(t)
+	writeBootverifyFixtureFile(t, filepath.Join(root, "nodes.yaml"), `
+producer-node:
+  id: producer-node
+  execution_type: system_node
+  subscribes_to: [producer.start]
+  event_handlers:
+    producer.start:
+      emit:
+        event: task.done
+accumulator-node:
+  id: accumulator-node
+  execution_type: system_node
+  subscribes_to: [task.*]
+  event_handlers:
+    task.*:
+      accumulate:
+        expected_from: entity.expected_count
+        completion: timeout
+        timeout_ms: 5000
+      advances_to: done
+  state_schema:
+    fields:
+      expected_count: integer
+`)
+	return root
+}
+
+func writeAccumulatorWildcardSameFlowAgentFixture(t *testing.T) string {
+	t.Helper()
+	root := writeAccumulatorWildcardSameFlowFixture(t)
+	writeBootverifyFixtureFile(t, filepath.Join(root, "agents.yaml"), `
+producer-agent:
+  id: producer-agent
+  role: producer
+  emit_events:
+    - task.done
+`)
+	writeBootverifyFixtureFile(t, filepath.Join(root, "nodes.yaml"), `
+accumulator-node:
+  id: accumulator-node
+  execution_type: system_node
+  subscribes_to: [task.*]
+  event_handlers:
+    task.*:
+      accumulate:
+        expected_from: entity.expected_count
+        completion: timeout
+        timeout_ms: 5000
+      advances_to: done
+  state_schema:
+    fields:
+      expected_count: integer
+`)
+	return root
+}
+
+func writeAccumulatorWildcardSameFlowFixture(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	writeBootverifyFixtureFile(t, filepath.Join(root, "package.yaml"), `
+name: accumulator-wildcard-safety
+version: "1.0.0"
+platform: ">=1.6.0"
+`)
+	writeBootverifyFixtureFile(t, filepath.Join(root, "schema.yaml"), `
+name: accumulator-wildcard-safety
+initial_state: collecting
+terminal_states: [done]
+states: [collecting, done]
+pins:
+  inputs:
+    events: [task.done]
+`)
+	writeBootverifyFixtureFile(t, filepath.Join(root, "policy.yaml"), "{}\n")
+	writeBootverifyFixtureFile(t, filepath.Join(root, "tools.yaml"), "{}\n")
+	writeBootverifyFixtureFile(t, filepath.Join(root, "agents.yaml"), "{}\n")
+	writeBootverifyFixtureFile(t, filepath.Join(root, "events.yaml"), `
+task.done:
+  expected_count: integer
+producer.start:
+  {}
+`)
+	return root
 }
 
 func writeAccumulatorCrossFlowFixture(t *testing.T, withConnect bool) string {

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -4400,6 +4400,21 @@ engine:
         swarm.source values starting with external, and same-flow timer declarations. It does not use produces or swarm.status:
         planned as input-pin proof.'
       when: boot-only
+    - id: accumulate_all_bounded_escape
+      severity: warning
+      scope: per-handler
+      trigger: A handler declares an accumulator in completion all/default mode without a schedulable bounded timeout escape.
+        This is a static safety-net lint only; it does not prove the accumulator will stall.
+      when: boot-only
+    - id: accumulator_input_producer_path
+      severity: hard_invalidity
+      scope: per-handler
+      trigger: A handler declares an accumulator over an input event but the authored bundle has no accepted static producer
+        or source path for that event. Accepted paths are parent connect, safe sibling output pin inference, root agent
+        emit_events, root node handler emits, exact platform event catalog matches, swarm.source external metadata, same-flow
+        timers, same-flow node handler emits, and same-flow agent emit_events. produces declarations and swarm.status planned
+        do not satisfy this proof.
+      when: boot-only
     - id: pin_target_resolution
       severity: error
       scope: per-emit-site
@@ -10323,6 +10338,45 @@ static_analyzer:
       execution fails closed as a runtime invariant violation rather than
       silently skipping the projection. Projection does not run for timeout,
       incomplete accumulation, or no-match completion.
+  slice_6c_accumulator_static_safety:
+    ids:
+    - accumulate_all_bounded_escape
+    - accumulator_input_producer_path
+    domain: semantic_validity
+    authority: mixed_warning_and_hard_invalidity
+    canonical_owner: internal/runtime/bootverify
+    supported_surface: cmd/swarm verify
+    spec_basis:
+    - handler_specification.handler_fields.accumulate
+    - engine.event_identity
+    - flow_model.flow_package.composition_routing
+    - static_analyzer.slice_3_input_pin_producer_path_satisfaction
+    scope:
+      description: Verify static accumulator safety properties that are decidable from the authored bundle without claiming
+        runtime liveness. The check is structural and source/producer-path based only.
+      applies_to:
+      - system-node handlers with accumulate declarations
+      excludes:
+      - runtime progress detection
+      - watchdog stalled-entity signaling
+      - implicit timeout insertion
+      - changing accumulator completion semantics
+      - treating produces declarations as producer proof
+      - treating swarm.status planned as producer proof
+    bounded_escape_warning:
+      id: accumulate_all_bounded_escape
+      severity: warning
+      rule: Emit a warning when an accumulator uses completion all/default and has no schedulable bounded timeout escape.
+        A schedulable timeout escape requires positive timeout_ms plus either completion timeout or an on_timeout branch.
+        A bare on_timeout without positive timeout_ms remains unbounded. This warning is not proof that runtime execution
+        will stall; it says the authored handler has no static escape if an expected arrival never appears.
+    input_producer_dead_end:
+      id: accumulator_input_producer_path
+      severity: hard_invalidity
+      rule: Emit hard invalidity when an accumulator input event has no accepted static producer/source path in the authored
+        bundle. Accepted paths are the same producer/source categories used by input_pin_wiring where applicable, plus same-flow
+        node handler emits and same-flow agent emit_events for accumulator-local consumption. produces declarations and
+        swarm.status planned do not count as proof.
   slice_7_entity_reader_compliance:
     id: expression_field_reference_validation
     domain: semantic_validity

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -4406,6 +4406,12 @@ engine:
       trigger: A handler declares an accumulator in completion all/default mode without a schedulable bounded timeout escape.
         This is a static safety-net lint only; it does not prove the accumulator will stall.
       when: boot-only
+    - id: accumulator_timeout_requires_timeout_ms
+      severity: hard_invalidity
+      scope: per-handler
+      trigger: A handler declares accumulator completion timeout without positive timeout_ms, so runtime cannot schedule the
+        accumulate.timeout event required to complete that mode.
+      when: boot-only
     - id: accumulator_input_producer_path
       severity: hard_invalidity
       scope: per-handler
@@ -10341,6 +10347,7 @@ static_analyzer:
   slice_6c_accumulator_static_safety:
     ids:
     - accumulate_all_bounded_escape
+    - accumulator_timeout_requires_timeout_ms
     - accumulator_input_producer_path
     domain: semantic_validity
     authority: mixed_warning_and_hard_invalidity
@@ -10370,6 +10377,11 @@ static_analyzer:
         A schedulable timeout escape requires positive timeout_ms plus either completion timeout or an on_timeout branch.
         A bare on_timeout without positive timeout_ms remains unbounded. This warning is not proof that runtime execution
         will stall; it says the authored handler has no static escape if an expected arrival never appears.
+    timeout_completion_requires_timeout:
+      id: accumulator_timeout_requires_timeout_ms
+      severity: hard_invalidity
+      rule: Emit hard invalidity when an accumulator uses completion timeout without positive timeout_ms. Runtime schedules
+        accumulate.timeout only from a positive timeout_ms, and timeout completion depends on that event.
     input_producer_dead_end:
       id: accumulator_input_producer_path
       severity: hard_invalidity

--- a/tests/tier2-accumulation/test-accumulate-all/events.yaml
+++ b/tests/tier2-accumulation/test-accumulate-all/events.yaml
@@ -1,4 +1,6 @@
 item.arrived:
+  swarm:
+    source: external
   entity_id: string
   item_id: string
 collection.done:

--- a/tests/tier2-accumulation/test-accumulate-crash-recovery/events.yaml
+++ b/tests/tier2-accumulation/test-accumulate-crash-recovery/events.yaml
@@ -1,4 +1,6 @@
 item.arrived:
+  swarm:
+    source: external
   entity_id: string
   item_id: string
 collection.done:

--- a/tests/tier2-accumulation/test-accumulate-expected-from-entity/events.yaml
+++ b/tests/tier2-accumulation/test-accumulate-expected-from-entity/events.yaml
@@ -1,4 +1,6 @@
 item.arrived:
+  swarm:
+    source: external
   entity_id: string
   item_id: string
 collection.done:

--- a/tests/tier2-accumulation/test-accumulate-from-filter/events.yaml
+++ b/tests/tier2-accumulation/test-accumulate-from-filter/events.yaml
@@ -1,4 +1,6 @@
 score.received:
+  swarm:
+    source: external
   entity_id: string
   score: float
 scores.collected:

--- a/tests/tier2-accumulation/test-accumulate-idempotent/events.yaml
+++ b/tests/tier2-accumulation/test-accumulate-idempotent/events.yaml
@@ -1,4 +1,6 @@
 item.arrived:
+  swarm:
+    source: external
   entity_id: string
   item_id: string
 collection.done:

--- a/tests/tier2-accumulation/test-accumulate-on-complete-rollback/events.yaml
+++ b/tests/tier2-accumulation/test-accumulate-on-complete-rollback/events.yaml
@@ -1,4 +1,6 @@
 score.received:
+  swarm:
+    source: external
   entity_id: string
   score: integer
 batch.scored:

--- a/tests/tier2-accumulation/test-accumulate-on-timeout/events.yaml
+++ b/tests/tier2-accumulation/test-accumulate-on-timeout/events.yaml
@@ -1,4 +1,6 @@
 item.arrived:
+  swarm:
+    source: external
   entity_id: string
   item_id: string
 accumulate.timeout:

--- a/tests/tier2-accumulation/test-accumulate-partial/events.yaml
+++ b/tests/tier2-accumulation/test-accumulate-partial/events.yaml
@@ -1,4 +1,6 @@
 item.arrived:
+  swarm:
+    source: external
   entity_id: string
   item_id: string
 collection.done:

--- a/tests/tier2-accumulation/test-accumulate-threshold/events.yaml
+++ b/tests/tier2-accumulation/test-accumulate-threshold/events.yaml
@@ -1,4 +1,6 @@
 item.arrived:
+  swarm:
+    source: external
   entity_id: string
   item_id: string
 collection.done:

--- a/tests/tier2-accumulation/test-accumulate-timeout/events.yaml
+++ b/tests/tier2-accumulation/test-accumulate-timeout/events.yaml
@@ -1,4 +1,6 @@
 item.arrived:
+  swarm:
+    source: external
   entity_id: string
   item_id: string
 accumulate.timeout:

--- a/tests/tier2-accumulation/test-accumulate-with-compute/events.yaml
+++ b/tests/tier2-accumulation/test-accumulate-with-compute/events.yaml
@@ -1,4 +1,6 @@
 score.received:
+  swarm:
+    source: external
   entity_id: string
   dimension: string
   score: float


### PR DESCRIPTION
Closes #1521

## Governing refs / context
- Issue #1521 pre-audit and approved gate outcome: first slice for static/verify accumulator safety only.
- `platform-spec.yaml` now records `static_analyzer.slice_6c_accumulator_static_safety`.
- Adjacent binding refs: `handler_specification.handler_fields.accumulate`, `engine.event_identity`, `flow_model.flow_package.composition_routing`, and `static_analyzer.slice_3_input_pin_producer_path_satisfaction`.

## Summary
- Adds `accumulate_all_bounded_escape` as a warning for `completion: all` / default accumulators without a schedulable timeout escape.
- Adds `accumulator_input_producer_path` as hard invalidity when an accumulator input event has no accepted authored producer/source path.
- Reuses the accepted input-pin producer/source model and adds accumulator-local same-flow node/agent emit proof.
- Updates accumulator catalog fixtures to declare externally published accumulator input events as `swarm.source: external`.

## Semantic migration
- New canonical owner for this static safety class: `internal/runtime/bootverify`, surfaced through `cmd/swarm verify`.
- Old non-authoritative proof paths now invalid for this class: `produces` declarations and `swarm.status: planned` do not satisfy accumulator producer/source proof.
- Runtime liveness/watchdog behavior remains out of scope; this PR does not add implicit timeouts or change accumulator execution semantics.
- Migration is complete for the approved static verify slice.

## Validation
- `go test ./internal/runtime/bootverify -run 'TestRun_(WarnsForAccumulateAll|DoesNotWarnForAccumulate|FailsClosedForAccumulator|AccumulatorProducer)' -count=1`
- `go test ./cmd/swarm -run 'TestRunVerifyCommand_(WarnsForAccumulateAllWithoutBoundedEscape|FailsForAccumulatorInputWithoutProducerPath)' -count=1`
- `go test ./internal/runtime/bootverify -count=1`
- `go test ./cmd/swarm -count=1`
- `go test ./internal/apispec -run TestPlatformSpecStaticAnalyzerSpecBasisRefsResolve -count=1`
- `go test ./internal/runtime/cataloge2e -run TestTier2AccumulationCatalogFixtures_RealRuntime -count=1`
- `go test ./internal/runtime/conformance -run TestAccumulatorCompletionOutcomeSurface_RoundTripsThroughObservabilityReader -count=1`
- `go test ./...`