### PR TITLE
[agent-b][issue #1568] Remove selected-fork gateway env side channel

### DIFF
--- a/cmd/swarm/main_test.go
+++ b/cmd/swarm/main_test.go
@@ -2507,7 +2507,7 @@ func TestPlatformSpecLocalToolGatewayBindingPromoted(t *testing.T) {
 	if !strings.Contains(binding.CanonicalOwner, "cli_specification.foundations.local_tool_gateway_binding") {
 		t.Fatalf("canonical owner does not point at local_tool_gateway_binding: %s", binding.CanonicalOwner)
 	}
-	for _, want := range []string{"local `serve`", "foreground `run`", "actual bound MCP listener", "stale URL-env", "first slice", "production Claude runtime factory"} {
+	for _, want := range []string{"local `serve`", "foreground `run`", "actual bound MCP listener", "stale URL-env", "first slice", "production Claude runtime factory", "MUST NOT mutate process-global"} {
 		if !strings.Contains(binding.Scope, want) {
 			t.Fatalf("local tool gateway binding scope missing %q:\n%s", want, binding.Scope)
 		}
@@ -2517,17 +2517,17 @@ func TestPlatformSpecLocalToolGatewayBindingPromoted(t *testing.T) {
 			t.Fatalf("binding fields missing %q: %#v", want, binding.BindingFields)
 		}
 	}
-	for _, want := range []string{"bind the MCP/tool listener first", "ToolGatewayBinding", "workspace-backend projection", "serve boot"} {
+	for _, want := range []string{"bind the MCP/tool listener first", "ToolGatewayBinding", "workspace-backend projection", "serve boot", "Selected-fork ephemeral gateways", "actual ephemeral gateway listener"} {
 		if !strings.Contains(binding.SourceRule, want) {
 			t.Fatalf("source rule missing %q:\n%s", want, binding.SourceRule)
 		}
 	}
-	for _, want := range []string{"SWARM_TOOL_GATEWAY_URL", "SWARM_TOOL_GATEWAY_CONTAINER_URL", "not public/operator source", "generated final-boundary compatibility", "derived from `ToolGatewayBinding`"} {
+	for _, want := range []string{"SWARM_TOOL_GATEWAY_URL", "SWARM_TOOL_GATEWAY_CONTAINER_URL", "not public/operator source", "generated final-boundary compatibility", "derived from `ToolGatewayBinding`", "Selected-fork ephemeral gateway startup MUST NOT set"} {
 		if !strings.Contains(binding.EndpointEnvRule, want) {
 			t.Fatalf("endpoint env rule missing %q:\n%s", want, binding.EndpointEnvRule)
 		}
 	}
-	for _, want := range []string{"SWARM_TOOL_GATEWAY_TOKEN", "token-only source authority", "per-boot token", "binding token"} {
+	for _, want := range []string{"SWARM_TOOL_GATEWAY_TOKEN", "token-only source authority", "per-boot token", "binding token", "Selected-fork ephemeral gateways follow the same token-only rule"} {
 		if !strings.Contains(binding.AuthRule, want) {
 			t.Fatalf("auth rule missing %q:\n%s", want, binding.AuthRule)
 		}
@@ -2537,7 +2537,7 @@ func TestPlatformSpecLocalToolGatewayBindingPromoted(t *testing.T) {
 			t.Fatalf("binding consumers missing %q: %#v", want, binding.Consumers)
 		}
 	}
-	for _, want := range []string{"#1568 public/operator URL-env retirement", "#1568 broader selected-contract", "ephemeral gateway to pass its own typed binding", "#979/#1012 are completed historical source-authority slices", "#1138/#1213", "#1567", "IPC/unix socket"} {
+	for _, want := range []string{"#1568 public/operator URL-env retirement", "#1568 broader selected-contract", "no longer uses process-global URL env", "#979/#1012 are completed historical source-authority slices", "#1138/#1213", "#1567", "IPC/unix socket"} {
 		if !stringSliceContains(binding.SplitTail, want) {
 			t.Fatalf("binding split_tail missing %q: %#v", want, binding.SplitTail)
 		}

--- a/internal/runtime/runforkexecution/agent_runtime_materialization.go
+++ b/internal/runtime/runforkexecution/agent_runtime_materialization.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"sort"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/division-sh/swarm/internal/config"
@@ -32,8 +31,6 @@ import (
 )
 
 const selectedContractAgentRuntimeDefaultQuiescenceTimeout = 2 * time.Minute
-
-var selectedContractAgentRuntimeGatewayEnvMu sync.Mutex
 
 type SelectedContractAgentRuntimeOptions struct {
 	Config            *config.Config
@@ -315,13 +312,6 @@ func startSelectedContractAgentRuntimeGateway(exec *runtimetools.Executor, emitR
 	if exec == nil {
 		return toolgateway.Binding{}, nil, nil
 	}
-	selectedContractAgentRuntimeGatewayEnvMu.Lock()
-	unlock := true
-	defer func() {
-		if unlock {
-			selectedContractAgentRuntimeGatewayEnvMu.Unlock()
-		}
-	}()
 
 	ln, err := net.Listen("tcp", "0.0.0.0:0")
 	if err != nil {
@@ -350,17 +340,6 @@ func startSelectedContractAgentRuntimeGateway(exec *runtimetools.Executor, emitR
 		_ = ln.Close()
 		return toolgateway.Binding{}, nil, err
 	}
-	prevHostURL, prevHostSet := os.LookupEnv("SWARM_TOOL_GATEWAY_URL")
-	prevContainerURL, prevContainerSet := os.LookupEnv("SWARM_TOOL_GATEWAY_CONTAINER_URL")
-	if err := os.Setenv("SWARM_TOOL_GATEWAY_URL", hostURL); err != nil {
-		_ = ln.Close()
-		return toolgateway.Binding{}, nil, err
-	}
-	if err := os.Setenv("SWARM_TOOL_GATEWAY_CONTAINER_URL", containerURL); err != nil {
-		restoreEnv("SWARM_TOOL_GATEWAY_URL", prevHostURL, prevHostSet)
-		_ = ln.Close()
-		return toolgateway.Binding{}, nil, err
-	}
 
 	gateway := runtimemcp.NewGateway(exec, binding.AuthToken(), swaruntime.RuntimeMCPGatewayHooks(nil, nil, resolveActorConfig, nil, emitRegistry, mcpTurns))
 	server := &http.Server{Handler: gateway.Handler()}
@@ -369,23 +348,11 @@ func startSelectedContractAgentRuntimeGateway(exec *runtimetools.Executor, emitR
 			_ = server.Close()
 		}
 	}()
-	unlock = false
 	return binding, func() {
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		_ = server.Shutdown(ctx)
 		cancel()
-		restoreEnv("SWARM_TOOL_GATEWAY_CONTAINER_URL", prevContainerURL, prevContainerSet)
-		restoreEnv("SWARM_TOOL_GATEWAY_URL", prevHostURL, prevHostSet)
-		selectedContractAgentRuntimeGatewayEnvMu.Unlock()
 	}, nil
-}
-
-func restoreEnv(key, value string, existed bool) {
-	if existed {
-		_ = os.Setenv(key, value)
-		return
-	}
-	_ = os.Unsetenv(key)
 }
 
 func selectedContractPromptResolver(source semanticview.Source) (runtimecontracts.PromptResolver, error) {

--- a/internal/runtime/runforkexecution/execution_test.go
+++ b/internal/runtime/runforkexecution/execution_test.go
@@ -534,8 +534,10 @@ func TestExecuteSelectedContractRunForkMaterializesAndExecutesForkLocalAgentRunt
 }
 
 func TestStartSelectedContractAgentRuntimeGatewayReturnsGeneratedBinding(t *testing.T) {
-	t.Setenv("SWARM_TOOL_GATEWAY_URL", "http://127.0.0.1:9998")
-	t.Setenv("SWARM_TOOL_GATEWAY_CONTAINER_URL", "http://host.docker.internal:9998")
+	const staleHostURL = "http://127.0.0.1:9998"
+	const staleContainerURL = "http://host.docker.internal:9998"
+	t.Setenv("SWARM_TOOL_GATEWAY_URL", staleHostURL)
+	t.Setenv("SWARM_TOOL_GATEWAY_CONTAINER_URL", staleContainerURL)
 	t.Setenv("SWARM_TOOL_GATEWAY_TOKEN", "")
 
 	exec := runtimetools.NewExecutorWithOptions(nil, nil, runtimetools.ExecutorOptions{})
@@ -554,8 +556,14 @@ func TestStartSelectedContractAgentRuntimeGatewayReturnsGeneratedBinding(t *test
 	if binding.AuthToken() == "" {
 		t.Fatalf("binding token was not generated: %#v", binding)
 	}
-	if got := strings.TrimSpace(os.Getenv("SWARM_TOOL_GATEWAY_URL")); got != strings.TrimSuffix(binding.HostEndpoint, "/") {
-		t.Fatalf("SWARM_TOOL_GATEWAY_URL = %q, want selected-fork host endpoint %q", got, binding.HostEndpoint)
+	if strings.Contains(binding.HostEndpoint, ":9998") || strings.Contains(binding.WorkspaceEndpoint, ":9998") {
+		t.Fatalf("binding endpoints used stale env: %#v", binding)
+	}
+	if got := strings.TrimSpace(os.Getenv("SWARM_TOOL_GATEWAY_URL")); got != staleHostURL {
+		t.Fatalf("SWARM_TOOL_GATEWAY_URL = %q, want stale operator value unchanged %q", got, staleHostURL)
+	}
+	if got := strings.TrimSpace(os.Getenv("SWARM_TOOL_GATEWAY_CONTAINER_URL")); got != staleContainerURL {
+		t.Fatalf("SWARM_TOOL_GATEWAY_CONTAINER_URL = %q, want stale operator value unchanged %q", got, staleContainerURL)
 	}
 	if got := strings.TrimSpace(os.Getenv("SWARM_TOOL_GATEWAY_TOKEN")); got != "" {
 		t.Fatalf("SWARM_TOOL_GATEWAY_TOKEN = %q, want generated binding token to remain typed-only", got)
@@ -576,9 +584,42 @@ func TestStartSelectedContractAgentRuntimeGatewayReturnsGeneratedBinding(t *test
 	}
 }
 
+func TestStartSelectedContractAgentRuntimeGatewayUsesExplicitTokenWithoutURLMutation(t *testing.T) {
+	const staleHostURL = "http://127.0.0.1:9998"
+	const staleContainerURL = "http://host.docker.internal:9998"
+	t.Setenv("SWARM_TOOL_GATEWAY_URL", staleHostURL)
+	t.Setenv("SWARM_TOOL_GATEWAY_CONTAINER_URL", staleContainerURL)
+	t.Setenv("SWARM_TOOL_GATEWAY_TOKEN", "operator-token")
+
+	exec := runtimetools.NewExecutorWithOptions(nil, nil, runtimetools.ExecutorOptions{})
+	turns := runtimemcp.NewTurnContextRegistry(runtimeactors.ActorFromContext)
+	binding, cleanup, err := startSelectedContractAgentRuntimeGateway(exec, nil, turns, nil)
+	if err != nil {
+		t.Fatalf("startSelectedContractAgentRuntimeGateway: %v", err)
+	}
+	if cleanup == nil {
+		t.Fatal("cleanup is nil")
+	}
+	defer cleanup()
+	if got := binding.AuthToken(); got != "operator-token" {
+		t.Fatalf("binding token = %q, want explicit token", got)
+	}
+	if got := strings.TrimSpace(os.Getenv("SWARM_TOOL_GATEWAY_URL")); got != staleHostURL {
+		t.Fatalf("SWARM_TOOL_GATEWAY_URL = %q, want unchanged %q", got, staleHostURL)
+	}
+	if got := strings.TrimSpace(os.Getenv("SWARM_TOOL_GATEWAY_CONTAINER_URL")); got != staleContainerURL {
+		t.Fatalf("SWARM_TOOL_GATEWAY_CONTAINER_URL = %q, want unchanged %q", got, staleContainerURL)
+	}
+	if got := strings.TrimSpace(os.Getenv("SWARM_TOOL_GATEWAY_TOKEN")); got != "operator-token" {
+		t.Fatalf("SWARM_TOOL_GATEWAY_TOKEN = %q, want explicit token env preserved", got)
+	}
+}
+
 func TestStartSelectedContractAgentRuntimeCleansGatewayOnRegistrationFailure(t *testing.T) {
-	t.Setenv("SWARM_TOOL_GATEWAY_URL", "http://127.0.0.1:9998")
-	t.Setenv("SWARM_TOOL_GATEWAY_CONTAINER_URL", "http://host.docker.internal:9998")
+	const staleHostURL = "http://127.0.0.1:9998"
+	const staleContainerURL = "http://host.docker.internal:9998"
+	t.Setenv("SWARM_TOOL_GATEWAY_URL", staleHostURL)
+	t.Setenv("SWARM_TOOL_GATEWAY_CONTAINER_URL", staleContainerURL)
 	t.Setenv("SWARM_CLAUDE_USE_MCP", "1")
 	eventBus, err := bus.NewEventBus(nil)
 	if err != nil {
@@ -608,23 +649,11 @@ func TestStartSelectedContractAgentRuntimeCleansGatewayOnRegistrationFailure(t *
 	if err == nil || !strings.Contains(err.Error(), "missing required system_prompt") {
 		t.Fatalf("startSelectedContractAgentRuntime error = %v, want registration failure", err)
 	}
-	if got := strings.TrimSpace(os.Getenv("SWARM_TOOL_GATEWAY_URL")); got != "http://127.0.0.1:9998" {
-		t.Fatalf("SWARM_TOOL_GATEWAY_URL = %q, want restored original", got)
+	if got := strings.TrimSpace(os.Getenv("SWARM_TOOL_GATEWAY_URL")); got != staleHostURL {
+		t.Fatalf("SWARM_TOOL_GATEWAY_URL = %q, want unchanged %q", got, staleHostURL)
 	}
-	if got := strings.TrimSpace(os.Getenv("SWARM_TOOL_GATEWAY_CONTAINER_URL")); got != "http://host.docker.internal:9998" {
-		t.Fatalf("SWARM_TOOL_GATEWAY_CONTAINER_URL = %q, want restored original", got)
-	}
-
-	unlocked := make(chan struct{})
-	go func() {
-		selectedContractAgentRuntimeGatewayEnvMu.Lock()
-		defer selectedContractAgentRuntimeGatewayEnvMu.Unlock()
-		close(unlocked)
-	}()
-	select {
-	case <-unlocked:
-	case <-time.After(time.Second):
-		t.Fatal("selected-fork runtime gateway mutex remained locked after registration failure")
+	if got := strings.TrimSpace(os.Getenv("SWARM_TOOL_GATEWAY_CONTAINER_URL")); got != staleContainerURL {
+		t.Fatalf("SWARM_TOOL_GATEWAY_CONTAINER_URL = %q, want unchanged %q", got, staleContainerURL)
 	}
 }
 

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -10865,9 +10865,10 @@ cli_specification:
         stale URL-env endpoint authority class only for local serve/run. It does not close public URL-env
         retirement outside local serve/run, broader selected-contract/multi-bundle materialization,
         host workspace execution, API connection discovery, IPC/unix socket transports, or remote/Kubernetes
-        routing. It also records the regression-guard requirement that any production Claude runtime factory
-        constructed for a live ephemeral gateway must receive that gateway's typed binding instead of depending
-        on ambient URL env.
+        routing. It also closes the selected-fork ephemeral gateway URL-env side-channel child: any production
+        Claude runtime factory constructed for a live ephemeral gateway MUST receive that gateway's typed binding
+        instead of depending on ambient URL env, and selected-fork gateway startup MUST NOT mutate process-global
+        `SWARM_TOOL_GATEWAY_URL` or `SWARM_TOOL_GATEWAY_CONTAINER_URL`.
       binding_fields:
       - transport
       - host_endpoint
@@ -10880,17 +10881,22 @@ cli_specification:
         address. The host endpoint is the listener URL reachable by the serve process. The workspace endpoint
         is the workspace-backend projection for containers or workspace processes. The binding source records
         the bound MCP listener, and the lifecycle owner is serve boot. Local foreground `swarm run` consumes
-        the same binding path through the serve startup owner.
+        the same binding path through the serve startup owner. Selected-fork ephemeral gateways MUST create their
+        own typed binding from the actual ephemeral gateway listener, with selected-fork lifecycle/source metadata,
+        and pass that binding directly to selected-fork runtime consumers.
       endpoint_env_rule: >
         `SWARM_TOOL_GATEWAY_URL` and `SWARM_TOOL_GATEWAY_CONTAINER_URL` are not public/operator source
         authority for local serve/run endpoint binding. Stale values MUST NOT override the typed binding.
         These variables may survive only as generated final-boundary compatibility for launched host/container
-        processes, and only when their values are derived from `ToolGatewayBinding`.
+        processes, and only when their values are derived from `ToolGatewayBinding`. Selected-fork ephemeral
+        gateway startup MUST NOT set, restore, or otherwise use process-global URL env as a propagation channel;
+        stale shell URL env must remain unchanged and non-authoritative.
       auth_rule: >
         `SWARM_TOOL_GATEWAY_TOKEN` remains token-only source authority for this first slice. If it is empty,
         serve boot MUST generate a per-boot token and place it on `ToolGatewayBinding`. Runtime gateway auth,
         startup probes, MCP HTTP config generation, and Docker exec env injection MUST consume the binding token,
-        not a later ambient env read.
+        not a later ambient env read. Selected-fork ephemeral gateways follow the same token-only rule: explicit
+        `SWARM_TOOL_GATEWAY_TOKEN` may supply the binding token, and absent token generates a typed binding token.
       consumers:
       - '`cmd/swarm` serve listener binding'
       - 'local foreground `swarm run` through the serve startup owner'
@@ -10906,7 +10912,7 @@ cli_specification:
       split_tail:
       - '#1568 public/operator URL-env retirement outside local serve/run remains split.'
       - '#1568 token-source migration beyond token-only env remains split.'
-      - '#1568 broader selected-contract and multi-bundle gateway materialization remains split; this first slice only requires a selected-fork ephemeral gateway to pass its own typed binding to its internal Claude runtime factory. #979/#1012 are completed historical source-authority slices and are not active trackers for this open gateway tail.'
+      - '#1568 broader selected-contract and multi-bundle gateway materialization remains split; selected-fork ephemeral gateway startup no longer uses process-global URL env as a propagation side channel, but broader multi-bundle materialization remains open. #979/#1012 are completed historical source-authority slices and are not active trackers for this open gateway tail.'
       - '#1138/#1213 host workspace `claude_cli` execution remains split.'
       - '#1567 API connection discovery and connection-file authority remain split.'
       - 'IPC/unix socket transports and remote/Kubernetes routing remain split.'


### PR DESCRIPTION
Part of #1568

## Summary

This PR closes the approved selected-fork child slice of #1568: selected-contract fork-local ephemeral gateway startup no longer uses process-global `SWARM_TOOL_GATEWAY_URL` or `SWARM_TOOL_GATEWAY_CONTAINER_URL` as a propagation side channel.

The selected-fork gateway still creates a `toolgateway.Binding` from the actual ephemeral listener and passes that binding to the selected-fork Claude runtime factory. Stale shell URL env remains unchanged and non-authoritative. `SWARM_TOOL_GATEWAY_TOKEN` remains token-only source authority for this slice; absent token still generates a typed binding token.

## Governing Refs / Context

- #1568 Pre-Implementation Coverage Audit: https://github.com/division-sh/swarm/issues/1568#issuecomment-4857863053
- #1568 gate outcome: https://github.com/division-sh/swarm/issues/1568#issuecomment-4857949283
- `platform-spec.yaml#cli_specification.foundations.local_tool_gateway_binding`
- `platform-spec.yaml#cli_specification.foundations.local_cli_test_gateway_startup`
- `platform-spec.yaml#cli_specification.command_catalog.serve.listener_topology_v2_1`

## Semantic Migration

- New canonical owner: `toolgateway.Binding` under `local_tool_gateway_binding` for selected-fork ephemeral gateway endpoint truth.
- Old producer path now invalid: selected-fork production `os.Setenv("SWARM_TOOL_GATEWAY_URL"...)`, `os.Setenv("SWARM_TOOL_GATEWAY_CONTAINER_URL"...)`, restore-env cleanup, and the env mutex.
- Production paths checked: selected-fork ephemeral gateway startup, selected-fork `RuntimeFactory.ToolGateway` consumption, Claude CLI final-boundary Docker env injection derived from binding, and token-only behavior.
- Migration completeness: complete for the selected-fork ambient URL-env side-channel child. Full #1568 remains open for public URL-env retirement, token-source migration, multi-bundle materialization tails, #1567 API discovery, IPC/unix socket transport, host workspace execution, and remote/Kubernetes routing.

## Verification

- `go test ./internal/runtime/runforkexecution -run 'TestStartSelectedContractAgentRuntimeGatewayReturnsGeneratedBinding|TestStartSelectedContractAgentRuntimeGatewayUsesExplicitTokenWithoutURLMutation|TestStartSelectedContractAgentRuntimeCleansGatewayOnRegistrationFailure' -count=1`
- `go test ./internal/runtime/llm -run 'TestClaudeCLIRuntimeBuildCommand_UsesContainerReachableMCPGatewayURL|TestValidateClaudeCLIRuntimeConfig_RequiresToolGatewayBinding' -count=1`
- `go test ./cmd/swarm -run TestPlatformSpecLocalToolGatewayBindingPromoted -count=1`
- `go test ./internal/runtime/runforkexecution`
- `go test ./internal/runtime/llm`
- `go test ./cmd/swarm`
- `go test ./...`