### PR TITLE
[agent-c][issue #1534] Validate timer cancel state reachability

### DIFF
--- a/internal/runtime/bootverify/report_test.go
+++ b/internal/runtime/bootverify/report_test.go
@@ -5069,6 +5069,16 @@ func TestRun_ReportsErrorForUnknownTimerTriggerState(t *testing.T) {
 	}
 }
 
+func TestRun_ReportsErrorForUnknownTimerCancelState(t *testing.T) {
+	root := writeTimerValidationFixture(t, "event:ticket.opened", "state:missing_state")
+	repoRoot := repoRootForBootverifyTest(t)
+	platformSpec := runtimecontracts.DefaultPlatformSpecFile(repoRoot)
+	report := Run(context.Background(), semanticview.Wrap(loadFixtureBundleAt(t, repoRoot, root, platformSpec)), Options{})
+	if !reportContains(report.Errors(), "timer_validation", "cancel_on references unknown state missing_state") {
+		t.Fatalf("expected timer_validation unknown cancel state error, got %#v", report.Errors())
+	}
+}
+
 func TestRun_ReportsErrorForUnknownTimerTriggerEvent(t *testing.T) {
 	root := writeTimerValidationFixture(t, "event:ticket.unknown", "")
 	repoRoot := repoRootForBootverifyTest(t)
@@ -5331,6 +5341,118 @@ func TestRun_ReportsErrorForUnknownTimerCancelEvent(t *testing.T) {
 	report := Run(context.Background(), semanticview.Wrap(loadFixtureBundleAt(t, repoRoot, root, platformSpec)), Options{})
 	if !reportContains(report.Errors(), "timer_validation", "cancel_on references unknown event ticket.unknown") {
 		t.Fatalf("expected timer_validation unknown cancel event error, got %#v", report.Errors())
+	}
+}
+
+func TestRun_AllowsTimerCancelStateReachableFromStartStateContext(t *testing.T) {
+	root := writeTimerStateCancelReachabilityFixture(t, timerStateCancelReachabilityFixtureOptions{
+		startOn:          "state:active",
+		cancelOn:         "state:done",
+		includeClosePath: true,
+	})
+	repoRoot := repoRootForBootverifyTest(t)
+	platformSpec := runtimecontracts.DefaultPlatformSpecFile(repoRoot)
+	report := Run(context.Background(), semanticview.Wrap(loadFixtureBundleAt(t, repoRoot, root, platformSpec)), Options{})
+	if reportContains(report.Errors(), "timer_validation", "cancel_on state done is not reachable") {
+		t.Fatalf("unexpected timer_validation cancel-state reachability error, got %#v", report.Errors())
+	}
+}
+
+func TestRun_ReportsErrorForTimerCancelStateUnreachableFromStartStateContext(t *testing.T) {
+	root := writeTimerStateCancelReachabilityFixture(t, timerStateCancelReachabilityFixtureOptions{
+		startOn:                 "state:active",
+		cancelOn:                "state:done",
+		includeGlobalDonePath:   true,
+		includeGlobalReviewPath: true,
+	})
+	repoRoot := repoRootForBootverifyTest(t)
+	platformSpec := runtimecontracts.DefaultPlatformSpecFile(repoRoot)
+	report := Run(context.Background(), semanticview.Wrap(loadFixtureBundleAt(t, repoRoot, root, platformSpec)), Options{})
+	if !reportContains(report.Errors(), "timer_validation", "cancel_on state done is not reachable after start_on state:active") {
+		t.Fatalf("expected timer_validation cancel-state reachability error, got %#v", report.Errors())
+	}
+	if reportContains(report.Warnings(), "semantic_drift_unreachable_state", "done") {
+		t.Fatalf("done should be globally reachable so the timer-specific owner proves the failure, got %#v", report.Warnings())
+	}
+}
+
+func TestRun_ReportsErrorForTimerCancelStateGloballyUnreachableFromStartContext(t *testing.T) {
+	root := writeTimerStateCancelReachabilityFixture(t, timerStateCancelReachabilityFixtureOptions{
+		startOn:               "state:active",
+		cancelOn:              "state:review",
+		includeGlobalDonePath: true,
+	})
+	repoRoot := repoRootForBootverifyTest(t)
+	platformSpec := runtimecontracts.DefaultPlatformSpecFile(repoRoot)
+	report := Run(context.Background(), semanticview.Wrap(loadFixtureBundleAt(t, repoRoot, root, platformSpec)), Options{})
+	if !reportContains(report.Errors(), "timer_validation", "cancel_on state review is not reachable after start_on state:active") {
+		t.Fatalf("expected timer_validation globally-unreachable cancel-state error, got %#v", report.Errors())
+	}
+	if !reportContains(report.Warnings(), "semantic_drift_unreachable_state", "declares state review") {
+		t.Fatalf("expected generic unreachable-state warning to survive as diagnostic, got %#v", report.Warnings())
+	}
+}
+
+func TestRun_AllowsTimerCancelStateReachableFromEventStartContext(t *testing.T) {
+	root := writeTimerStateCancelReachabilityFixture(t, timerStateCancelReachabilityFixtureOptions{
+		startOn:          "event:ticket.opened",
+		cancelOn:         "state:done",
+		includeClosePath: true,
+	})
+	repoRoot := repoRootForBootverifyTest(t)
+	platformSpec := runtimecontracts.DefaultPlatformSpecFile(repoRoot)
+	report := Run(context.Background(), semanticview.Wrap(loadFixtureBundleAt(t, repoRoot, root, platformSpec)), Options{})
+	if reportContains(report.Errors(), "timer_validation", "cancel_on state done is not reachable") {
+		t.Fatalf("unexpected timer_validation event-start cancel-state reachability error, got %#v", report.Errors())
+	}
+}
+
+func TestRun_ReportsErrorForTimerCancelStateUnreachableFromOneEventActivationState(t *testing.T) {
+	root := writeTimerStateCancelReachabilityFixture(t, timerStateCancelReachabilityFixtureOptions{
+		startOn:                         "event:ticket.opened",
+		cancelOn:                        "state:done",
+		includeClosePath:                true,
+		includeEventStartReviewBranch:   true,
+		treatReviewAsTerminalActivation: true,
+	})
+	repoRoot := repoRootForBootverifyTest(t)
+	platformSpec := runtimecontracts.DefaultPlatformSpecFile(repoRoot)
+	report := Run(context.Background(), semanticview.Wrap(loadFixtureBundleAt(t, repoRoot, root, platformSpec)), Options{})
+	if !reportContains(report.Errors(), "timer_validation", "unreachable activation states: review") {
+		t.Fatalf("expected timer_validation to reject one unreachable event activation state, got %#v", report.Errors())
+	}
+}
+
+func TestRun_ReportsErrorForTimerCancelStateUnreachableFromEventStartContext(t *testing.T) {
+	root := writeTimerStateCancelReachabilityFixture(t, timerStateCancelReachabilityFixtureOptions{
+		startOn:                 "event:ticket.opened",
+		cancelOn:                "state:review",
+		includeGlobalDonePath:   true,
+		includeGlobalReviewPath: true,
+	})
+	repoRoot := repoRootForBootverifyTest(t)
+	platformSpec := runtimecontracts.DefaultPlatformSpecFile(repoRoot)
+	report := Run(context.Background(), semanticview.Wrap(loadFixtureBundleAt(t, repoRoot, root, platformSpec)), Options{})
+	if !reportContains(report.Errors(), "timer_validation", "cancel_on state review is not reachable after start_on event:ticket.opened") {
+		t.Fatalf("expected timer_validation event-start cancel-state reachability error, got %#v", report.Errors())
+	}
+	if reportContains(report.Warnings(), "semantic_drift_unreachable_state", "review") {
+		t.Fatalf("review should be globally reachable so the timer-specific owner proves the failure, got %#v", report.Warnings())
+	}
+}
+
+func TestRun_ReportsErrorForTimerCancelStateReachedOnlyByTimerFireEvent(t *testing.T) {
+	root := writeTimerStateCancelReachabilityFixture(t, timerStateCancelReachabilityFixtureOptions{
+		startOn:                 "state:active",
+		cancelOn:                "state:done",
+		includeTimerFireHandler: true,
+		includeGlobalDonePath:   true,
+	})
+	repoRoot := repoRootForBootverifyTest(t)
+	platformSpec := runtimecontracts.DefaultPlatformSpecFile(repoRoot)
+	report := Run(context.Background(), semanticview.Wrap(loadFixtureBundleAt(t, repoRoot, root, platformSpec)), Options{})
+	if !reportContains(report.Errors(), "timer_validation", "cancel_on state done is not reachable after start_on state:active") {
+		t.Fatalf("expected timer fire handler not to prove pre-fire cancellation, got %#v", report.Errors())
 	}
 }
 
@@ -5613,6 +5735,136 @@ support-node:
     ticket.closed:
       advances_to: done
 `+timerHandlerBlock)
+	return root
+}
+
+type timerStateCancelReachabilityFixtureOptions struct {
+	startOn                         string
+	cancelOn                        string
+	includeClosePath                bool
+	includeGlobalDonePath           bool
+	includeGlobalReviewPath         bool
+	includeTimerFireHandler         bool
+	includeEventStartReviewBranch   bool
+	treatReviewAsTerminalActivation bool
+}
+
+func writeTimerStateCancelReachabilityFixture(t *testing.T, opts timerStateCancelReachabilityFixtureOptions) string {
+	t.Helper()
+	root := t.TempDir()
+	writeBootverifyFixtureFile(t, filepath.Join(root, "package.yaml"), `
+name: timer-state-cancel-reachability
+version: "1.0.0"
+platform: ">=1.6.0"
+flows:
+  - id: support
+    flow: support
+    mode: static
+`)
+	writeBootverifyFixtureFile(t, filepath.Join(root, "entities.yaml"), `
+ticket:
+  ticket_id: string
+`)
+	writeBootverifyFixtureFile(t, filepath.Join(root, "schema.yaml"), "name: timer-state-cancel-reachability\n")
+	writeBootverifyFixtureFile(t, filepath.Join(root, "policy.yaml"), "{}\n")
+	writeBootverifyFixtureFile(t, filepath.Join(root, "tools.yaml"), "{}\n")
+	writeBootverifyFixtureFile(t, filepath.Join(root, "agents.yaml"), "{}\n")
+	writeBootverifyFixtureFile(t, filepath.Join(root, "events.yaml"), "{}\n")
+	terminalStates := "[done]"
+	if opts.treatReviewAsTerminalActivation {
+		terminalStates = "[review, done]"
+	}
+	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "support", "schema.yaml"), `
+name: support
+initial_state: waiting
+terminal_states: `+terminalStates+`
+states: [waiting, active, review, done]
+`)
+	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "support", "policy.yaml"), "{}\n")
+	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "support", "agents.yaml"), "{}\n")
+	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "support", "events.yaml"), `
+ticket.opened:
+  swarm:
+    source: external (test)
+ticket.closed:
+  entity_id: string
+admin.done:
+  swarm:
+    source: external (test)
+admin.review:
+  swarm:
+    source: external (test)
+timer.reminder:
+  swarm:
+    consumer: mailbox_system
+`)
+	timerBlock := `
+    - id: reminder
+      owner: support-node
+      event: timer.reminder
+      delay: 1m
+      start_on: ` + opts.startOn + "\n"
+	if strings.TrimSpace(opts.cancelOn) != "" {
+		timerBlock += "      cancel_on: " + opts.cancelOn + "\n"
+	}
+	handlerBlock := ""
+	if opts.includeEventStartReviewBranch {
+		handlerBlock += `
+    ticket.opened:
+      rules:
+        - id: active_path
+          condition: "true"
+          advances_to: active
+        - id: review_path
+          condition: "true"
+          advances_to: review
+`
+	} else {
+		handlerBlock += `
+    ticket.opened:
+      create_entity: true
+      advances_to: active
+`
+	}
+	if opts.includeClosePath {
+		handlerBlock += `
+    ticket.closed:
+      advances_to: done
+`
+	}
+	if opts.includeGlobalDonePath {
+		handlerBlock += `
+    admin.done:
+      create_entity: true
+      advances_to: done
+`
+	}
+	if opts.includeGlobalReviewPath {
+		handlerBlock += `
+    admin.review:
+      create_entity: true
+      advances_to: review
+`
+	}
+	if opts.includeTimerFireHandler {
+		handlerBlock += `
+    timer.reminder:
+      advances_to: done
+`
+	}
+	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "support", "nodes.yaml"), `
+support-node:
+  id: support-node
+  execution_type: system_node
+  subscribes_to:
+    - ticket.opened
+    - ticket.closed
+    - admin.done
+    - admin.review
+    - timer.reminder
+  timers:
+`+timerBlock+`  event_handlers:
+`+handlerBlock)
 	return root
 }
 

--- a/internal/runtime/bootverify/workflow_state_machine_reachability_checks.go
+++ b/internal/runtime/bootverify/workflow_state_machine_reachability_checks.go
@@ -95,6 +95,15 @@ func authoredReachableStates(source semanticview.Source, flowID, initial string,
 }
 
 func authoredStateGraphEdges(source semanticview.Source, flowID, initial string, declaredStates map[string]struct{}) map[string]map[string]struct{} {
+	return authoredStateGraphEdgesFiltered(source, flowID, initial, declaredStates, nil)
+}
+
+func authoredStateGraphEdgesFiltered(
+	source semanticview.Source,
+	flowID, initial string,
+	declaredStates map[string]struct{},
+	includeHandler func(nodeID, eventType string, handler runtimecontracts.SystemNodeEventHandler) bool,
+) map[string]map[string]struct{} {
 	edges := make(map[string]map[string]struct{}, len(declaredStates))
 	nonTerminalStates := authoredNonTerminalStates(source, flowID, declaredStates)
 	for nodeID, node := range source.NodeEntries() {
@@ -102,7 +111,11 @@ func authoredStateGraphEdges(source semanticview.Source, flowID, initial string,
 		if nodeID == "" || strings.TrimSpace(nodeFlowID(source, nodeID)) != flowID {
 			continue
 		}
-		for _, handler := range node.EventHandlers {
+		for eventType, handler := range node.EventHandlers {
+			eventType = strings.TrimSpace(eventType)
+			if includeHandler != nil && !includeHandler(nodeID, eventType, handler) {
+				continue
+			}
 			sources := authoredHandlerSourceStates(initial, nonTerminalStates, handler)
 			for _, target := range authoredReachabilityTargets(handler) {
 				target = strings.TrimSpace(target)

--- a/internal/runtime/bootverify/workflow_timer_checks.go
+++ b/internal/runtime/bootverify/workflow_timer_checks.go
@@ -72,6 +72,7 @@ func (c *checkerContext) timerValidation() []Finding {
 		} else {
 			c.validateTimerTrigger(timer, "cancel_on", cancelTrigger)
 		}
+		c.validateTimerCancelStateReachability(timer, startTrigger, cancelTrigger)
 	}
 	return c.timerFindings
 }
@@ -122,6 +123,201 @@ func (c *checkerContext) validateTimerFireEventConsumer(timer runtimecontracts.W
 		Message:  fmt.Sprintf("timer %s event %s has no executable consumer or explicit external/exported role", timer.ID, ref.DisplayName()),
 		Location: strings.TrimSpace(timer.ID),
 	})
+}
+
+func (c *checkerContext) validateTimerCancelStateReachability(timer runtimecontracts.WorkflowTimerContract, startTrigger, cancelTrigger timeridentity.Trigger) {
+	if c.source == nil || !startTrigger.Valid() || !cancelTrigger.Valid() || cancelTrigger.Kind != timeridentity.TriggerKindState {
+		return
+	}
+	if startTrigger.Kind == timeridentity.TriggerKindBoot {
+		return
+	}
+	flowID := strings.TrimSpace(timer.FlowID)
+	declaredStates := declaredStatesForFlow(c.source, flowID)
+	cancelState := strings.TrimSpace(cancelTrigger.Name)
+	if cancelState == "" {
+		return
+	}
+	if _, ok := declaredStates[cancelState]; !ok {
+		return
+	}
+	initial := timerFlowInitialState(c.source, flowID)
+	if strings.TrimSpace(initial) == "" {
+		return
+	}
+	activationStates := timerActivationStates(c.source, timer, startTrigger, initial, declaredStates)
+	if len(activationStates) == 0 {
+		c.timerFindings = append(c.timerFindings, Finding{
+			CheckID:  "timer_validation",
+			Severity: "error",
+			Message:  fmt.Sprintf("timer %s cancel_on state %s has no derived activation state from start_on %s", timer.ID, cancelState, startTrigger.String()),
+			Location: strings.TrimSpace(timer.ID),
+		})
+		return
+	}
+	edges := timerCancelStateGraphEdges(c.source, timer, initial, declaredStates)
+	unreachableActivationStates := timerActivationStatesWithoutPostActivationReachability(edges, activationStates, cancelState)
+	if len(unreachableActivationStates) == 0 {
+		return
+	}
+	c.timerFindings = append(c.timerFindings, Finding{
+		CheckID:  "timer_validation",
+		Severity: "error",
+		Message: fmt.Sprintf(
+			"timer %s cancel_on state %s is not reachable after start_on %s in flow %s; activation states: %s; unreachable activation states: %s",
+			timer.ID,
+			cancelState,
+			startTrigger.String(),
+			timerValidationFlowLabel(flowID),
+			strings.Join(sortedSetKeys(activationStates), ", "),
+			strings.Join(unreachableActivationStates, ", "),
+		),
+		Location: strings.TrimSpace(timer.ID),
+	})
+}
+
+func timerActivationStates(source semanticview.Source, timer runtimecontracts.WorkflowTimerContract, startTrigger timeridentity.Trigger, initial string, declaredStates map[string]struct{}) map[string]struct{} {
+	out := map[string]struct{}{}
+	if source == nil || !startTrigger.Valid() {
+		return out
+	}
+	switch startTrigger.Kind {
+	case timeridentity.TriggerKindState:
+		state := strings.TrimSpace(startTrigger.Name)
+		if _, ok := declaredStates[state]; ok {
+			out[state] = struct{}{}
+		}
+	case timeridentity.TriggerKindEvent:
+		flowID := strings.TrimSpace(timer.FlowID)
+		ref := semanticview.ResolveFlowEventProof(source, flowID, startTrigger.Name)
+		nonTerminalStates := authoredNonTerminalStates(source, flowID, declaredStates)
+		for nodeID, node := range source.NodeEntries() {
+			nodeID = strings.TrimSpace(nodeID)
+			if nodeID == "" || strings.TrimSpace(nodeFlowID(source, nodeID)) != flowID {
+				continue
+			}
+			for eventType, handler := range node.EventHandlers {
+				if !timerHandlerMatchesEvent(source, flowID, eventType, ref) {
+					continue
+				}
+				targets := authoredReachabilityTargets(handler)
+				if len(targets) == 0 {
+					addTimerActivationStates(out, declaredStates, authoredHandlerSourceStates(initial, nonTerminalStates, handler))
+					continue
+				}
+				addTimerActivationStates(out, declaredStates, targets)
+			}
+		}
+	}
+	return out
+}
+
+func addTimerActivationStates(out map[string]struct{}, declaredStates map[string]struct{}, states []string) {
+	for _, state := range states {
+		state = strings.TrimSpace(state)
+		if state == "" {
+			continue
+		}
+		if _, ok := declaredStates[state]; !ok {
+			continue
+		}
+		out[state] = struct{}{}
+	}
+}
+
+func timerCancelStateGraphEdges(source semanticview.Source, timer runtimecontracts.WorkflowTimerContract, initial string, declaredStates map[string]struct{}) map[string]map[string]struct{} {
+	flowID := strings.TrimSpace(timer.FlowID)
+	fireRef := semanticview.ResolveFlowEventProof(source, flowID, timer.Event)
+	return authoredStateGraphEdgesFiltered(source, flowID, initial, declaredStates, func(_ string, eventType string, _ runtimecontracts.SystemNodeEventHandler) bool {
+		return !timerHandlerMatchesEvent(source, flowID, eventType, fireRef)
+	})
+}
+
+func timerActivationStatesWithoutPostActivationReachability(edges map[string]map[string]struct{}, activationStates map[string]struct{}, target string) []string {
+	missing := []string{}
+	for _, state := range sortedSetKeys(activationStates) {
+		if timerStateReachableAfterActivation(edges, state, target) {
+			continue
+		}
+		missing = append(missing, state)
+	}
+	return missing
+}
+
+func timerStateReachableAfterActivation(edges map[string]map[string]struct{}, activationState string, target string) bool {
+	activationState = strings.TrimSpace(activationState)
+	target = strings.TrimSpace(target)
+	if activationState == "" || target == "" {
+		return false
+	}
+	seen := map[string]struct{}{}
+	queue := make([]string, 0)
+	for next := range edges[activationState] {
+		next = strings.TrimSpace(next)
+		if next == "" {
+			continue
+		}
+		queue = append(queue, next)
+	}
+	for len(queue) > 0 {
+		state := strings.TrimSpace(queue[0])
+		queue = queue[1:]
+		if state == "" {
+			continue
+		}
+		if state == target {
+			return true
+		}
+		if _, ok := seen[state]; ok {
+			continue
+		}
+		seen[state] = struct{}{}
+		for next := range edges[state] {
+			if _, ok := seen[next]; ok {
+				continue
+			}
+			queue = append(queue, next)
+		}
+	}
+	return false
+}
+
+func timerHandlerMatchesEvent(source semanticview.Source, flowID, eventType string, ref semanticview.FlowEventProof) bool {
+	if source == nil {
+		return false
+	}
+	eventType = strings.TrimSpace(eventType)
+	if eventType == "" {
+		return false
+	}
+	for _, candidate := range []string{ref.Canonical, ref.Authored, ref.Local, ref.CatalogKey} {
+		candidate = strings.TrimSpace(candidate)
+		if candidate == "" {
+			continue
+		}
+		if source.FlowEventMatches(flowID, eventType, candidate) {
+			return true
+		}
+	}
+	return false
+}
+
+func timerFlowInitialState(source semanticview.Source, flowID string) string {
+	if source == nil {
+		return ""
+	}
+	flowID = strings.TrimSpace(flowID)
+	if flowID == "" {
+		return strings.TrimSpace(source.WorkflowInitialStage())
+	}
+	return strings.TrimSpace(source.FlowInitialStage(flowID))
+}
+
+func timerValidationFlowLabel(flowID string) string {
+	if flowID = strings.TrimSpace(flowID); flowID != "" {
+		return flowID
+	}
+	return "root"
 }
 
 func timerFireEventHasConsumer(source semanticview.Source, ref semanticview.FlowEventProof) bool {

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -4049,6 +4049,16 @@ engine:
         path, platform producer, or explicit external source. Unknown or inert event triggers are boot errors.
       fire_event_consumer: The timer fire event must have an executable handler/agent consumer, a declared output boundary, or
         explicit external consumer metadata. Catalog membership alone is not sufficient proof that a timer can do useful work.
+      cancel_state_reachability: >
+        For timers started by state:<name> or event:<name>, cancel_on state:<name> must be reachable after every possible
+        timer activation context in the authored transition graph. start_on state:<name> uses that state as the activation
+        context. start_on event:<name> derives activation states from same-flow handlers for that event: explicit advances_to,
+        on_complete advances_to, and rules advances_to targets are post-handler activation states; a handler with no authored
+        state target uses its authored source states. The timer's own fire event is not valid proof of a pre-fire cancellation
+        path. The activation state itself is not sufficient proof unless an authored post-activation transition reaches the
+        cancel state from that activation state. Missing activation proof or any derived activation state with no
+        post-activation path is a boot error. start_on boot state-cancel reachability is left to explicit boot-start
+        scheduling semantics and is not closed by this rule.
     example: "timers:\n  - id: sla_timeout\n    event: timer.sla_breach\n    delay: \"{{sla_timeout_hours}}h\"\
       \n    start_on: state:assigned\n    cancel_on: state:resolved\n    recurring: false\n  - id: daily_report\n\
       \    event: timer.daily_report\n    delay: \"{{report_interval_hours}}h\"\n    start_on: boot\n    recurring: true"
@@ -10190,6 +10200,7 @@ static_analyzer:
       - structural invalid target validation
       - missing terminal-path reasoning
       - runtime liveness or temporal behavior claims
+      - timer cancel_on state:<name> reachability from timer activation context
     transition_carriers:
       handler_advances_to:
         rule: Handler-level advances_to contributes a possible edge.


### PR DESCRIPTION
## Summary

Part of #1534.

This PR closes the approved first-slice class `workflow_timer_cancel_state_context_reachability_static_proof`.

It makes `timer_validation` fail closed when `cancel_on state:<name>` is only declared-state-valid but cannot be reached after the timer activation context in the authored transition graph.

## Governing refs / context

Exact governing spec refs updated in this PR:

- `platform-spec.yaml` `engine.timer_model.boot_validation.cancel_state_reachability`
- `platform-spec.yaml` `static_analyzer.slice_4_state_machine_reachability.scope.excludes`

Binding issue/gate context:

- #1534 issue body/thread
- `Pre-Implementation Coverage Audit` comment on #1534
- Gate outcome: approved first slice for `workflow_timer_cancel_state_context_reachability_static_proof`

## Semantic migration

New canonical owner:

- `internal/runtime/bootverify.timer_validation` owns timer-specific `cancel_on state:*` lifecycle-context reachability.

Old producer / reader / interpreter path now invalid:

- `cancel_on state:<name>` declared-state existence is no longer sufficient proof.
- Generic `semantic_drift_unreachable_state` global reachability warning is not authoritative proof for timer cancellation.
- The timer's own fire event handler cannot prove a pre-fire cancellation path.

Production paths checked for surviving old behavior:

- `internal/runtime/pipeline/workflow_timer_lifecycle.go` remains runtime behavior proof once state/event triggers occur.
- `internal/runtime/runtime.go#ensureRecurringWorkflowSchedules` remains explicitly split boot-start residual under #1534.

Migration complete for chosen class: yes.

Parent #1534 remains open for boot-start support/scheduling semantics and active timer reschedule/refresh.

## Tests

- `go test ./internal/runtime/bootverify -run 'Timer|StateMachine|Reachability' -count=1`
- `go test ./internal/runtime/pipeline -run 'Timer|WorkflowTimer' -count=1`
- `go test ./internal/runtime/core/timeridentity -count=1`
- `go test ./internal/runtime -run 'RecurringWorkflow|LifecycleWorkflow|Schedule' -count=1`
- `go test ./cmd/swarm -run 'RunVerifyCommand' -count=1`
- `go test ./...`