### PR TITLE
[agent-a][issue #1553] Add singleton coordinator pilot fixture

### DIFF
--- a/internal/runtime/conformance/singleton_coordinator_pilot_conformance_test.go
+++ b/internal/runtime/conformance/singleton_coordinator_pilot_conformance_test.go
@@ -1,0 +1,191 @@
+package conformance
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	runtimebootverify "github.com/division-sh/swarm/internal/runtime/bootverify"
+	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
+	"github.com/division-sh/swarm/internal/runtime/core/pinrouting"
+	"github.com/division-sh/swarm/internal/runtime/entityruntime"
+	"github.com/division-sh/swarm/internal/runtime/semanticview"
+	"github.com/division-sh/swarm/internal/runtime/testfixtures/singletoncoordinatorpilot"
+)
+
+func TestSingletonCoordinatorPilotConformance_CoversSingletonMapCoordinatorOwners(t *testing.T) {
+	source := singletoncoordinatorpilot.LoadSource(t, singletoncoordinatorpilot.Options{})
+	report := runtimebootverify.Run(context.Background(), source, runtimebootverify.Options{})
+	if got := report.HardInvalidities(); len(got) != 0 {
+		t.Fatalf("singleton coordinator pilot hard invalidities = %#v, want none", got)
+	}
+	bundle, ok := semanticview.Bundle(source)
+	if !ok {
+		t.Fatal("singleton coordinator pilot source did not expose bundle")
+	}
+
+	primary, err := bundle.ResolveFlowPrimaryEntity(singletoncoordinatorpilot.FlowID)
+	if err != nil {
+		t.Fatalf("ResolveFlowPrimaryEntity(%s): %v", singletoncoordinatorpilot.FlowID, err)
+	}
+	if primary.EntityType != singletoncoordinatorpilot.EntityType {
+		t.Fatalf("primary entity = %q, want %s", primary.EntityType, singletoncoordinatorpilot.EntityType)
+	}
+	if got := primary.Contract.Fields["lead_index"].Type; got != "map[text]LeadScore" {
+		t.Fatalf("lead_index type = %q, want map[text]LeadScore", got)
+	}
+	if got := primary.Contract.Fields["audit_log"].Type; got != "[AuditEntry]" {
+		t.Fatalf("audit_log type = %q, want [AuditEntry]", got)
+	}
+
+	coordinator, err := bundle.ResolveFlowSingletonCoordinator(singletoncoordinatorpilot.FlowID)
+	if err != nil {
+		t.Fatalf("ResolveFlowSingletonCoordinator(%s): %v", singletoncoordinatorpilot.FlowID, err)
+	}
+	if coordinator.PrimaryEntity.EntityType != singletoncoordinatorpilot.EntityType {
+		t.Fatalf("singleton primary entity = %q, want %s", coordinator.PrimaryEntity.EntityType, singletoncoordinatorpilot.EntityType)
+	}
+	if !singletonCoordinatorContains(coordinator.ContainedState, "lead_index", "map") {
+		t.Fatalf("singleton contained fields = %#v, want lead_index map", coordinator.ContainedState)
+	}
+	if !singletonCoordinatorContains(coordinator.ContainedState, "audit_log", "list") {
+		t.Fatalf("singleton contained fields = %#v, want audit_log list", coordinator.ContainedState)
+	}
+
+	handler, ok := source.NodeEventHandler(singletoncoordinatorpilot.NodeID, singletoncoordinatorpilot.InputEvent)
+	if !ok {
+		t.Fatalf("handler %s/%s missing", singletoncoordinatorpilot.NodeID, singletoncoordinatorpilot.InputEvent)
+	}
+	containedWrites := make([]runtimecontracts.WorkflowDataWrite, 0, len(handler.DataAccumulation.Writes))
+	for _, write := range handler.DataAccumulation.Writes {
+		if write.IsContainedOperation() {
+			containedWrites = append(containedWrites, write)
+		}
+	}
+	if got := len(containedWrites); got != 6 {
+		t.Fatalf("contained handler writes = %d, want 6 in %#v", got, handler.DataAccumulation.Writes)
+	}
+	wantOps := []runtimecontracts.WorkflowDataOperation{
+		runtimecontracts.WorkflowDataOperationSet,
+		runtimecontracts.WorkflowDataOperationMerge,
+		runtimecontracts.WorkflowDataOperationAppend,
+		runtimecontracts.WorkflowDataOperationAppend,
+		runtimecontracts.WorkflowDataOperationAppend,
+		runtimecontracts.WorkflowDataOperationUpdate,
+	}
+	contract, ok := entityruntime.ResolveForFlow(source, singletoncoordinatorpilot.FlowID)
+	if !ok {
+		t.Fatalf("entityruntime.ResolveForFlow(%s) missing", singletoncoordinatorpilot.FlowID)
+	}
+	for idx, write := range containedWrites {
+		if write.Operation != wantOps[idx] {
+			t.Fatalf("write[%d] op = %q, want %q", idx, write.Operation, wantOps[idx])
+		}
+		if !write.IsContainedOperation() {
+			t.Fatalf("write[%d] is not a contained operation: %#v", idx, write)
+		}
+		if _, err := entityruntime.ResolveContainedOperationTarget(contract, write.Target(), string(write.Operation), !write.Key.IsZero(), !write.Index.IsZero()); err != nil {
+			t.Fatalf("ResolveContainedOperationTarget(write[%d]): %v", idx, err)
+		}
+	}
+	if containedWrites[0].Key.Ref != "payload.lead_id" {
+		t.Fatalf("map set key = %#v, want explicit payload.lead_id ref", containedWrites[0].Key)
+	}
+	if containedWrites[2].Key.Ref != "payload.lead_id" {
+		t.Fatalf("map append key = %#v, want explicit payload.lead_id ref", containedWrites[2].Key)
+	}
+
+	plans, issues := pinrouting.LowerCompositionConnectRoutePlans(source)
+	if len(issues) != 0 {
+		t.Fatalf("LowerCompositionConnectRoutePlans issues = %#v, want none", issues)
+	}
+	if len(plans) != 0 {
+		t.Fatalf("singleton coordinator contained state produced route plans = %#v, want none", plans)
+	}
+}
+
+func TestSingletonCoordinatorPilotConformance_FailClosedMatrix(t *testing.T) {
+	tests := []struct {
+		name        string
+		opts        singletoncoordinatorpilot.Options
+		checkID     string
+		wantMessage string
+	}{
+		{
+			name:        "dynamic bracket target path",
+			opts:        singletoncoordinatorpilot.Options{DynamicBracketTarget: true},
+			checkID:     "contained_state_operation_compliance",
+			wantMessage: "dynamic bracket path syntax",
+		},
+		{
+			name:        "missing map key",
+			opts:        singletoncoordinatorpilot.Options{MissingMapKey: true},
+			checkID:     "load",
+			wantMessage: "requires key",
+		},
+		{
+			name:        "wrong value shape",
+			opts:        singletoncoordinatorpilot.Options{WrongValueShape: true},
+			checkID:     "contained_state_operation_compliance",
+			wantMessage: "undeclared",
+		},
+		{
+			name:        "undeclared target",
+			opts:        singletoncoordinatorpilot.Options{UndeclaredTarget: true},
+			checkID:     "contained_state_operation_compliance",
+			wantMessage: "missing_index",
+		},
+		{
+			name:        "unsupported operation",
+			opts:        singletoncoordinatorpilot.Options{UnsupportedOperation: true},
+			checkID:     "load",
+			wantMessage: "unsupported workflow data write op",
+		},
+		{
+			name:        "bad list index",
+			opts:        singletoncoordinatorpilot.Options{BadListIndex: true},
+			checkID:     "contained_state_operation_compliance",
+			wantMessage: "list index cannot be negative",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			bundle, err := singletoncoordinatorpilot.LoadBundleResult(t, tc.opts)
+			if tc.checkID == "load" {
+				if err == nil || !strings.Contains(err.Error(), tc.wantMessage) {
+					t.Fatalf("LoadWorkflowContractBundleWithOverrides error = %v, want %q", err, tc.wantMessage)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("LoadWorkflowContractBundleWithOverrides: %v", err)
+			}
+			source := semanticview.Wrap(bundle)
+			report := runtimebootverify.Run(context.Background(), source, runtimebootverify.Options{})
+			if !singletonCoordinatorPilotFindingContains(report.HardInvalidities(), tc.checkID, tc.wantMessage) {
+				t.Fatalf("expected hard invalidity %s containing %q, got %#v", tc.checkID, tc.wantMessage, report.HardInvalidities())
+			}
+		})
+	}
+}
+
+func singletonCoordinatorContains(fields []runtimecontracts.SingletonCoordinatorContainedField, name, kind string) bool {
+	for _, field := range fields {
+		if strings.TrimSpace(field.Name) == name && strings.TrimSpace(field.Kind) == kind {
+			return true
+		}
+	}
+	return false
+}
+
+func singletonCoordinatorPilotFindingContains(findings []runtimebootverify.Finding, checkID, substr string) bool {
+	for _, finding := range findings {
+		if strings.TrimSpace(finding.CheckID) != checkID {
+			continue
+		}
+		if substr == "" || strings.Contains(finding.Message, substr) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/runtime/conformance/testdata/route_authority_drift_inventory.yaml
+++ b/internal/runtime/conformance/testdata/route_authority_drift_inventory.yaml
@@ -658,6 +658,7 @@ seam_families:
       - internal/runtime/cataloge2e/tier12_runtime_fork_e2e_test.go
       - internal/runtime/bus/sealed_flow_package_fixture_test.go
       - internal/runtime/conformance/sealed_flow_package_conformance_test.go
+      - internal/runtime/conformance/singleton_coordinator_pilot_conformance_test.go
       - internal/runtime/conformance/template_flow_pilot_conformance_test.go
       - internal/runtime/swarmflowtest/catalog_runner_test.go
       - tests/tier11-flow-composition/test-dynamic-flow-instance/expected.yaml
@@ -671,6 +672,9 @@ seam_families:
       as runtime proof; they do not introduce or replace route authority. #1552
       adds the template-flow pilot conformance fixture as an integrated
       package-boundary proof consumer for the existing route-authority owners.
+      #1553 adds the singleton coordinator pilot conformance fixture as a
+      consumer that proves contained map/list state does not produce lowered
+      connect route authority.
   - id: route_authority_conformance_artifacts
     layer: conformance_guardrails
     classification: canonical_owner

--- a/internal/runtime/pipeline/singleton_coordinator_pilot_delivery_test.go
+++ b/internal/runtime/pipeline/singleton_coordinator_pilot_delivery_test.go
@@ -1,0 +1,241 @@
+package pipeline
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/division-sh/swarm/internal/events"
+	"github.com/division-sh/swarm/internal/events/eventtest"
+	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
+	"github.com/division-sh/swarm/internal/runtime/semanticview"
+	"github.com/division-sh/swarm/internal/runtime/testfixtures/singletoncoordinatorpilot"
+	"github.com/division-sh/swarm/internal/testutil"
+	"github.com/google/uuid"
+)
+
+func TestSingletonCoordinatorPilotPipelineDispatchPersistsContainedStateReadback(t *testing.T) {
+	bundle := singletoncoordinatorpilot.LoadBundle(t, singletoncoordinatorpilot.Options{})
+	source := semanticview.Wrap(bundle)
+	_, db, cleanup := testutil.StartPostgres(t)
+	t.Cleanup(cleanup)
+	pc, workflowStore := newSingletonCoordinatorPilotPipelineCoordinator(t, db, bundle, source)
+	ctx := testPipelineCoordinatorRunContext(t, pc)
+	entityID := FlowInstanceEntityID(singletoncoordinatorpilot.FlowInstance)
+	seedSingletonCoordinatorPilotInstance(t, workflowStore, ctx, bundle, entityID)
+
+	target := events.RouteIdentity{
+		FlowID:       singletoncoordinatorpilot.FlowID,
+		FlowInstance: singletoncoordinatorpilot.FlowInstance,
+		EntityID:     entityID,
+	}
+	evt := eventtest.RootIngress(
+		uuid.NewString(),
+		events.EventType(singletoncoordinatorpilot.InputEvent),
+		singletoncoordinatorpilot.FlowID,
+		"",
+		json.RawMessage(`{"coordinator_id":"global","lead_id":"lead-42","observation":{"source":"feed","note":"first seen"},"audit":{"ref":"lead-42","action":"observed"},"followup_audit":{"ref":"lead-42","action":"queued"},"corrected_audit":{"ref":"bootstrap","action":"corrected"}}`),
+		0,
+		testPipelineRunID,
+		"",
+		events.EnvelopeForTargetRoute(events.EventEnvelope{}, target),
+		time.Now().UTC(),
+	)
+	seedSingletonCoordinatorPilotEvent(t, db, ctx, evt)
+	seedSingletonCoordinatorPilotNodeDelivery(t, db, ctx, evt.ID(), singletoncoordinatorpilot.NodeID, target)
+
+	handled, err := pc.dispatchWorkflowNodeEventResult(ctx, evt)
+	if err != nil {
+		t.Fatalf("dispatchWorkflowNodeEventResult: %v", err)
+	}
+	if !handled {
+		t.Fatal("dispatchWorkflowNodeEventResult handled = false, want coordinator handler delivery")
+	}
+	loaded, ok, err := workflowStore.Load(ctx, entityID)
+	if err != nil {
+		t.Fatalf("workflowStore.Load(%s): %v", entityID, err)
+	}
+	if !ok {
+		t.Fatalf("workflowStore.Load(%s) ok=false", entityID)
+	}
+	if loaded.WorkflowName != singletoncoordinatorpilot.FlowID || loaded.CurrentState != "active" {
+		t.Fatalf("loaded singleton coordinator = storage:%q workflow:%q state:%q, want coordinator/active", loaded.StorageRef, loaded.WorkflowName, loaded.CurrentState)
+	}
+	leadIndex, ok := loaded.Metadata["lead_index"].(map[string]any)
+	if !ok {
+		t.Fatalf("lead_index = %#v, want map", loaded.Metadata["lead_index"])
+	}
+	lead, ok := leadIndex["lead-42"].(map[string]any)
+	if !ok {
+		t.Fatalf("lead_index[lead-42] = %#v, want map", leadIndex["lead-42"])
+	}
+	if lead["status"] != "active" || lead["score"] != float64(1) {
+		t.Fatalf("lead_index[lead-42] = %#v, want status active score 1", lead)
+	}
+	observations, ok := lead["observations"].([]any)
+	if !ok || len(observations) != 1 {
+		t.Fatalf("lead observations = %#v, want one observation", lead["observations"])
+	}
+	observation, ok := observations[0].(map[string]any)
+	if !ok || observation["source"] != "feed" || observation["note"] != "first seen" {
+		t.Fatalf("observation = %#v, want feed/first seen", observations[0])
+	}
+	auditLog, ok := loaded.Metadata["audit_log"].([]any)
+	if !ok || len(auditLog) != 3 {
+		t.Fatalf("audit_log = %#v, want three entries", loaded.Metadata["audit_log"])
+	}
+	firstAudit, ok := auditLog[0].(map[string]any)
+	if !ok || firstAudit["ref"] != "bootstrap" || firstAudit["action"] != "corrected" {
+		t.Fatalf("audit_log[0] = %#v, want corrected bootstrap entry", auditLog[0])
+	}
+	secondAudit, ok := auditLog[1].(map[string]any)
+	if !ok || secondAudit["ref"] != "lead-42" || secondAudit["action"] != "observed" {
+		t.Fatalf("audit_log[1] = %#v, want observed lead-42 entry", auditLog[1])
+	}
+	thirdAudit, ok := auditLog[2].(map[string]any)
+	if !ok || thirdAudit["ref"] != "lead-42" || thirdAudit["action"] != "queued" {
+		t.Fatalf("audit_log[2] = %#v, want queued lead-42 entry", auditLog[2])
+	}
+	assertSingletonCoordinatorPilotDeliveryStatus(t, db, evt.ID(), singletoncoordinatorpilot.NodeID, "delivered")
+	assertNoSingletonCoordinatorPilotContainedRouteRows(t, db, "coordinator/lead-42")
+	if _, ok, err := workflowStore.Load(ctx, "lead-42"); err != nil {
+		t.Fatalf("workflowStore.Load(lead-42): %v", err)
+	} else if ok {
+		t.Fatal("contained map key lead-42 materialized as a workflow instance")
+	}
+}
+
+func TestSingletonCoordinatorPilotPipelineRejectsContainedItemDeliveryTarget(t *testing.T) {
+	bundle := singletoncoordinatorpilot.LoadBundle(t, singletoncoordinatorpilot.Options{})
+	source := semanticview.Wrap(bundle)
+	_, db, cleanup := testutil.StartPostgres(t)
+	t.Cleanup(cleanup)
+	pc, _ := newSingletonCoordinatorPilotPipelineCoordinator(t, db, bundle, source)
+
+	containedTarget := events.RouteIdentity{
+		FlowID:       singletoncoordinatorpilot.FlowID,
+		FlowInstance: singletoncoordinatorpilot.FlowInstance + "/lead-42",
+		EntityID:     uuid.NewString(),
+	}
+	if pc.workflowNodeMatchesDeliveryTarget(singletoncoordinatorpilot.NodeID, containedTarget) {
+		t.Fatalf("contained item target %#v matched singleton coordinator node; contained map entries must not be route recipients", containedTarget)
+	}
+}
+
+func newSingletonCoordinatorPilotPipelineCoordinator(t *testing.T, db *sql.DB, bundle *runtimecontracts.WorkflowContractBundle, source semanticview.Source) (*PipelineCoordinator, *WorkflowInstanceStore) {
+	t.Helper()
+	workflow, err := LoadWorkflowDefinition(source)
+	if err != nil {
+		t.Fatalf("LoadWorkflowDefinition: %v", err)
+	}
+	nodes, err := LoadWorkflowNodes(source)
+	if err != nil {
+		t.Fatalf("LoadWorkflowNodes: %v", err)
+	}
+	workflowStore := NewWorkflowInstanceStore(db)
+	pc := NewPipelineCoordinatorWithOptions(&recordingPipelineBus{}, db, PipelineCoordinatorOptions{
+		Module: &previewWorkflowModule{
+			bundle:         bundle,
+			workflow:       workflow,
+			workflowNodes:  nodes,
+			guardRegistry:  NewContractGuardRegistry(source),
+			actionRegistry: NewContractActionRegistry(source),
+		},
+		WorkflowStore:           workflowStore,
+		EventReceiptsCapability: eventReceiptsCapabilityStub{enabled: true}.resolve,
+	})
+	return pc, workflowStore
+}
+
+func seedSingletonCoordinatorPilotInstance(t *testing.T, store *WorkflowInstanceStore, ctx context.Context, bundle *runtimecontracts.WorkflowContractBundle, entityID string) {
+	t.Helper()
+	if err := store.Create(ctx, WorkflowInstance{
+		InstanceID:      entityID,
+		StorageRef:      singletoncoordinatorpilot.FlowInstance,
+		WorkflowName:    singletoncoordinatorpilot.FlowID,
+		WorkflowVersion: bundle.WorkflowVersion(),
+		CurrentState:    "active",
+		Metadata: map[string]any{
+			"entity_id":      entityID,
+			"flow_path":      singletoncoordinatorpilot.FlowInstance,
+			"instance_id":    entityID,
+			"coordinator_id": "global",
+			"lead_index":     map[string]any{},
+			"audit_log": []any{
+				map[string]any{"ref": "seed", "action": "seed"},
+			},
+		},
+	}); err != nil {
+		t.Fatalf("seed singleton coordinator workflow instance: %v", err)
+	}
+}
+
+func seedSingletonCoordinatorPilotEvent(t *testing.T, db *sql.DB, ctx context.Context, evt events.Event) {
+	t.Helper()
+	targetRaw, err := json.Marshal(evt.TargetRoute())
+	if err != nil {
+		t.Fatalf("marshal target route: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO events (
+			event_id, run_id, event_name, entity_id, flow_instance, scope, payload,
+			produced_by, produced_by_type, target_route, created_at
+		) VALUES (
+			$1::uuid, $2::uuid, $3, $4::uuid, $5, 'entity', $6::jsonb,
+			$7, 'agent', $8::jsonb, now()
+		)
+	`, evt.ID(), evt.RunID(), string(evt.Type()), evt.EntityID(), evt.FlowInstance(), string(evt.Payload()), evt.SourceAgent(), string(targetRaw)); err != nil {
+		t.Fatalf("seed singleton coordinator pilot event: %v", err)
+	}
+}
+
+func seedSingletonCoordinatorPilotNodeDelivery(t *testing.T, db *sql.DB, ctx context.Context, eventID, nodeID string, target events.RouteIdentity) {
+	t.Helper()
+	targetRaw, err := json.Marshal(target.Normalized())
+	if err != nil {
+		t.Fatalf("marshal delivery target route: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO event_deliveries (
+			run_id, event_id, subscriber_type, subscriber_id, delivery_target_route, status, retry_count, created_at
+		) VALUES (
+			$1::uuid, $2::uuid, 'node', $3, $4::jsonb, 'pending', 0, now()
+		)
+	`, testPipelineRunID, eventID, nodeID, string(targetRaw)); err != nil {
+		t.Fatalf("seed singleton coordinator pilot node delivery: %v", err)
+	}
+}
+
+func assertSingletonCoordinatorPilotDeliveryStatus(t *testing.T, db *sql.DB, eventID, nodeID, want string) {
+	t.Helper()
+	var got string
+	if err := db.QueryRowContext(context.Background(), `
+		SELECT COALESCE(status, '')
+		FROM event_deliveries
+		WHERE event_id = $1::uuid
+		  AND subscriber_type = 'node'
+		  AND subscriber_id = $2
+	`, eventID, nodeID).Scan(&got); err != nil {
+		t.Fatalf("load singleton coordinator pilot node delivery: %v", err)
+	}
+	if got != want {
+		t.Fatalf("singleton coordinator pilot delivery status = %q, want %q", got, want)
+	}
+}
+
+func assertNoSingletonCoordinatorPilotContainedRouteRows(t *testing.T, db *sql.DB, flowInstance string) {
+	t.Helper()
+	var count int
+	if err := db.QueryRowContext(context.Background(), `
+		SELECT COUNT(*)
+		FROM event_deliveries
+		WHERE delivery_target_route->>'flow_instance' = $1
+	`, flowInstance).Scan(&count); err != nil {
+		t.Fatalf("count contained route delivery rows: %v", err)
+	}
+	if count != 0 {
+		t.Fatalf("contained flow_instance %q has %d delivery row(s), want none", flowInstance, count)
+	}
+}

--- a/internal/runtime/pipeline/singleton_coordinator_pilot_delivery_test.go
+++ b/internal/runtime/pipeline/singleton_coordinator_pilot_delivery_test.go
@@ -100,11 +100,7 @@ func TestSingletonCoordinatorPilotPipelineDispatchPersistsContainedStateReadback
 	}
 	assertSingletonCoordinatorPilotDeliveryStatus(t, db, evt.ID(), singletoncoordinatorpilot.NodeID, "delivered")
 	assertNoSingletonCoordinatorPilotContainedRouteRows(t, db, "coordinator/lead-42")
-	if _, ok, err := workflowStore.Load(ctx, "lead-42"); err != nil {
-		t.Fatalf("workflowStore.Load(lead-42): %v", err)
-	} else if ok {
-		t.Fatal("contained map key lead-42 materialized as a workflow instance")
-	}
+	assertNoSingletonCoordinatorPilotContainedWorkflowInstance(t, db, workflowStore, ctx, "coordinator/lead-42")
 }
 
 func TestSingletonCoordinatorPilotPipelineRejectsContainedItemDeliveryTarget(t *testing.T) {
@@ -237,5 +233,49 @@ func assertNoSingletonCoordinatorPilotContainedRouteRows(t *testing.T, db *sql.D
 	}
 	if count != 0 {
 		t.Fatalf("contained flow_instance %q has %d delivery row(s), want none", flowInstance, count)
+	}
+}
+
+func assertNoSingletonCoordinatorPilotContainedWorkflowInstance(t *testing.T, db *sql.DB, store *WorkflowInstanceStore, ctx context.Context, flowInstance string) {
+	t.Helper()
+	entityID := FlowInstanceEntityID(flowInstance)
+	if _, ok, err := store.Load(ctx, entityID); err != nil {
+		t.Fatalf("workflowStore.Load(%s): %v", entityID, err)
+	} else if ok {
+		t.Fatalf("contained flow_instance %q materialized with canonical entity id %s", flowInstance, entityID)
+	}
+	if _, ok, err := store.Load(ctx, flowInstance); err != nil {
+		t.Fatalf("workflowStore.Load(%s): %v", flowInstance, err)
+	} else if ok {
+		t.Fatalf("contained flow_instance %q materialized through storage-ref lookup", flowInstance)
+	}
+
+	assertNoSingletonCoordinatorPilotRow(t, db, `
+		SELECT COUNT(*)
+		FROM entity_state
+		WHERE run_id = $1::uuid
+		  AND entity_id = $2::uuid
+	`, testPipelineRunID, entityID)
+	assertNoSingletonCoordinatorPilotRow(t, db, `
+		SELECT COUNT(*)
+		FROM entity_state
+		WHERE run_id = $1::uuid
+		  AND flow_instance = $2
+	`, testPipelineRunID, flowInstance)
+	assertNoSingletonCoordinatorPilotRow(t, db, `
+		SELECT COUNT(*)
+		FROM flow_instances
+		WHERE instance_id = $1
+	`, flowInstance)
+}
+
+func assertNoSingletonCoordinatorPilotRow(t *testing.T, db *sql.DB, query string, args ...any) {
+	t.Helper()
+	var count int
+	if err := db.QueryRowContext(context.Background(), query, args...).Scan(&count); err != nil {
+		t.Fatalf("count singleton coordinator pilot rows: %v", err)
+	}
+	if count != 0 {
+		t.Fatalf("singleton coordinator pilot absence query returned %d row(s), want none", count)
 	}
 }

--- a/internal/runtime/pipeline/workflow_nodes.go
+++ b/internal/runtime/pipeline/workflow_nodes.go
@@ -1157,14 +1157,42 @@ func (pc *PipelineCoordinator) workflowNodeMatchesDeliveryTarget(nodeID string, 
 		return false
 	}
 	if target.FlowID != "" {
-		return target.FlowID == flowID
+		return target.FlowID == flowID && workflowNodeDeliveryTargetFlowInstanceMatches(source, flowID, target.FlowInstance)
 	}
 	flowPath := strings.Trim(strings.TrimSpace(source.FlowPath(flowID)), "/")
 	if flowPath == "" {
 		flowPath = flowID
 	}
 	targetPath := strings.Trim(strings.TrimSpace(target.FlowInstance), "/")
+	if workflowFlowMode(source, flowID) == runtimecontracts.FlowModeSingleton {
+		return targetPath == flowPath || targetPath == flowID
+	}
 	return targetPath == flowPath || strings.HasPrefix(targetPath, flowPath+"/")
+}
+
+func workflowNodeDeliveryTargetFlowInstanceMatches(source semanticview.Source, flowID, flowInstance string) bool {
+	flowInstance = strings.Trim(strings.TrimSpace(flowInstance), "/")
+	if flowInstance == "" {
+		return true
+	}
+	flowPath := strings.Trim(strings.TrimSpace(source.FlowPath(flowID)), "/")
+	if flowPath == "" {
+		flowPath = strings.Trim(strings.TrimSpace(flowID), "/")
+	}
+	if workflowFlowMode(source, flowID) == runtimecontracts.FlowModeSingleton {
+		return flowInstance == flowPath || flowInstance == strings.Trim(strings.TrimSpace(flowID), "/")
+	}
+	return true
+}
+
+func workflowFlowMode(source semanticview.Source, flowID string) string {
+	if source == nil {
+		return ""
+	}
+	if schema, ok := source.FlowSchemaByID(strings.TrimSpace(flowID)); ok {
+		return strings.TrimSpace(schema.Mode)
+	}
+	return ""
 }
 
 func deriveWorkflowEventDelivery(entry runtimecontracts.EventCatalogEntry) (consume bool, visible bool) {

--- a/internal/runtime/testfixtures/singletoncoordinatorpilot/fixture.go
+++ b/internal/runtime/testfixtures/singletoncoordinatorpilot/fixture.go
@@ -1,0 +1,261 @@
+package singletoncoordinatorpilot
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
+	"github.com/division-sh/swarm/internal/runtime/semanticview"
+)
+
+const (
+	FlowID       = "coordinator"
+	NodeID       = "coordinator-indexer"
+	EntityType   = "coordinator_state"
+	InputEvent   = "lead.observed"
+	FlowInstance = "coordinator"
+)
+
+// Options toggles the singleton coordinator pilot variants used by
+// conformance and runtime tests.
+type Options struct {
+	DynamicBracketTarget bool
+	MissingMapKey        bool
+	WrongValueShape      bool
+	UndeclaredTarget     bool
+	UnsupportedOperation bool
+	BadListIndex         bool
+}
+
+func LoadBundle(t testing.TB, opts Options) *runtimecontracts.WorkflowContractBundle {
+	t.Helper()
+	bundle, err := LoadBundleResult(t, opts)
+	if err != nil {
+		t.Fatalf("LoadWorkflowContractBundleWithOverrides: %v", err)
+	}
+	return bundle
+}
+
+func LoadBundleResult(t testing.TB, opts Options) (*runtimecontracts.WorkflowContractBundle, error) {
+	t.Helper()
+	root := Write(t, opts)
+	return runtimecontracts.LoadWorkflowContractBundleWithOverrides(repoRoot(t), root, runtimecontracts.DefaultPlatformSpecFile(repoRoot(t)))
+}
+
+func LoadSource(t testing.TB, opts Options) semanticview.Source {
+	t.Helper()
+	return semanticview.Wrap(LoadBundle(t, opts))
+}
+
+func Write(t testing.TB, opts Options) string {
+	t.Helper()
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "package.yaml"), `
+name: singleton-coordinator-pilot
+version: "1.0.0"
+platform_version: ">=1.6.0"
+flows:
+  - id: coordinator
+    flow: coordinator
+    mode: singleton
+`)
+	writeFile(t, filepath.Join(root, "schema.yaml"), "name: singleton-coordinator-pilot\n")
+	writeFile(t, filepath.Join(root, "policy.yaml"), "{}\n")
+	writeFile(t, filepath.Join(root, "tools.yaml"), "{}\n")
+	writeFile(t, filepath.Join(root, "agents.yaml"), "{}\n")
+	writeFile(t, filepath.Join(root, "events.yaml"), "{}\n")
+	writeFile(t, filepath.Join(root, "nodes.yaml"), "{}\n")
+	writeCoordinator(t, root, opts)
+	return root
+}
+
+func writeCoordinator(t testing.TB, root string, opts Options) {
+	t.Helper()
+	writeFile(t, filepath.Join(root, "flows", "coordinator", "schema.yaml"), `
+name: coordinator
+mode: singleton
+initial_state: active
+states: [active]
+pins:
+  inputs:
+    events:
+      - name: lead_observed
+        event: lead.observed
+  outputs:
+    events: []
+`)
+	writeFile(t, filepath.Join(root, "flows", "coordinator", "policy.yaml"), "{}\n")
+	writeFile(t, filepath.Join(root, "flows", "coordinator", "tools.yaml"), "{}\n")
+	writeFile(t, filepath.Join(root, "flows", "coordinator", "agents.yaml"), "{}\n")
+	writeFile(t, filepath.Join(root, "flows", "coordinator", "types.yaml"), `
+types:
+  LeadScore:
+    status: text
+    score: integer
+    observations: "[Observation]"
+  Observation:
+    source: text
+    note: text
+  AuditEntry:
+    ref: text
+    action: text
+`)
+	writeFile(t, filepath.Join(root, "flows", "coordinator", "entities.yaml"), `
+coordinator_state:
+  coordinator_id: text
+  lead_index: map[text]LeadScore
+  audit_log: "[AuditEntry]"
+`)
+	writeFile(t, filepath.Join(root, "flows", "coordinator", "events.yaml"), `
+lead.observed:
+  coordinator_id: text
+  lead_id: text
+  observation: Observation
+  audit: AuditEntry
+  followup_audit: AuditEntry
+  corrected_audit: AuditEntry
+`)
+	writeFile(t, filepath.Join(root, "flows", "coordinator", "nodes.yaml"), `
+coordinator-indexer:
+  id: coordinator-indexer
+  execution_type: system_node
+  subscribes_to: [lead.observed]
+  event_handlers:
+    lead.observed:
+      select_entity:
+        by:
+          coordinator_id: payload.coordinator_id
+      data_accumulation:
+        writes:
+`+writesYAML(opts))
+}
+
+func writesYAML(opts Options) string {
+	if opts.DynamicBracketTarget {
+		return firstMapWriteYAML("set", "entity.lead_index[payload.lead_id]", "key:\n              ref: payload.lead_id", `
+            value:
+              status: active
+              score: 0
+              observations: []
+`)
+	}
+	if opts.MissingMapKey {
+		return firstMapWriteYAML("set", "entity.lead_index", "", `
+            value:
+              status: active
+              score: 0
+              observations: []
+`)
+	}
+	if opts.WrongValueShape {
+		return firstMapWriteYAML("set", "entity.lead_index", "key:\n              ref: payload.lead_id", `
+            value:
+              undeclared: true
+`)
+	}
+	if opts.UndeclaredTarget {
+		return firstMapWriteYAML("set", "entity.missing_index", "key:\n              ref: payload.lead_id", `
+            value:
+              status: active
+              score: 0
+              observations: []
+`)
+	}
+	if opts.UnsupportedOperation {
+		return firstMapWriteYAML("replace", "entity.lead_index", "key:\n              ref: payload.lead_id", `
+            value:
+              status: active
+              score: 0
+              observations: []
+`)
+	}
+	if opts.BadListIndex {
+		return directCoordinatorWriteYAML() + validWritesPrefixYAML() + `          - op: update
+            target: entity.audit_log
+            index: -1
+            value:
+              ref: payload.corrected_audit
+`
+	}
+	return validWritesYAML()
+}
+
+func validWritesYAML() string {
+	return directCoordinatorWriteYAML() + validWritesPrefixYAML() + `          - op: update
+            target: entity.audit_log
+            index: 0
+            value:
+              ref: payload.corrected_audit
+`
+}
+
+func validWritesPrefixYAML() string {
+	return `          - op: set
+            target: entity.lead_index
+            key:
+              ref: payload.lead_id
+            value:
+              status: active
+              score: 0
+              observations: []
+          - op: merge
+            target: entity.lead_index
+            key:
+              ref: payload.lead_id
+            value:
+              score: 1
+          - op: append
+            target: entity.lead_index.observations
+            key:
+              ref: payload.lead_id
+            value:
+              ref: payload.observation
+          - op: append
+            target: entity.audit_log
+            value:
+              ref: payload.audit
+          - op: append
+            target: entity.audit_log
+            value:
+              ref: payload.followup_audit
+`
+}
+
+func directCoordinatorWriteYAML() string {
+	return `          - source_field: coordinator_id
+            target_field: coordinator_id
+`
+}
+
+func firstMapWriteYAML(op, target, keyBlock, valueBlock string) string {
+	out := directCoordinatorWriteYAML() + `          - op: ` + op + `
+            target: ` + target + `
+`
+	if strings.TrimSpace(keyBlock) != "" {
+		out += "            " + strings.ReplaceAll(strings.TrimRight(keyBlock, "\n"), "\n", "\n            ") + "\n"
+	}
+	out += strings.TrimLeft(valueBlock, "\n")
+	return out
+}
+
+func repoRoot(t testing.TB) string {
+	t.Helper()
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("resolve repo root")
+	}
+	return filepath.Clean(filepath.Join(filepath.Dir(file), "..", "..", "..", ".."))
+}
+
+func writeFile(t testing.TB, path, contents string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, []byte(strings.TrimLeft(contents, "\n")), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}


### PR DESCRIPTION
## Summary
- Add a reusable singleton coordinator pilot fixture with `mode: singleton`, one primary coordinator entity, typed contained map/list state, and explicit variable-key contained operations.
- Add conformance coverage for canonical owners and fail-closed invalid operation shapes.
- Add pipeline runtime proof for handler dispatch through the existing contained-operation owner, persisted readback, and contained-key non-routability.
- Add a singleton-only delivery target guard so contained-key subpaths do not match singleton workflow node delivery targets, and classify the new conformance route-plan proof in the drift inventory.

## Governing refs / binding context
- Closes #1553.
- Parent: #1537.
- Locked design: discussion #1476.
- Approved issue gate: #1553 `Pre-Implementation Coverage Audit` and `Gate A review`.
- Spec refs: `platform-spec.yaml#flow_model.flow_instance_authoring.contained_state_model`, `platform-spec.yaml#flow_model.flow_instance_authoring.singleton_coordinator_model`, `platform-spec.yaml#handler_specification.data_accumulation.write_item_forms.contained_operation`.

## Semantic migration / ownership
- New canonical owner: none. This PR consumes existing owners: `ResolveFlowSingletonCoordinator`, `ResolveFlowPrimaryEntity`, `WorkflowDataWrite.Operation`, `entityruntime.ResolveContainedOperationTarget`, bootverify `contained_state_operation_compliance`, `Executor.applyContainedDataOperation`, and workflow-store primary-entity readback.
- Old invalid paths now covered: dynamic bracket contained targets, missing map key, wrong value shape, undeclared target, unsupported op, bad list index, and contained item delivery identity such as `coordinator/lead-42`.
- Production paths checked: contract loading, bootverify, route-plan lowering, pipeline workflow-node dispatch, store readback, and workflow-node delivery target matching.
- Migration complete: yes for #1553 child proof. #1537 remains open for sibling/final children.

## Tests
- `go test ./internal/runtime/conformance ./internal/runtime/pipeline -run 'SingletonCoordinatorPilot|RouteAuthorityDriftInventoryCoversRepoWideSearchDimensions' -count=1`
- `go test ./...`