### PR TITLE
[agent-e][issue #1522] Project accumulator materialize_from without on_complete

### DIFF
--- a/internal/runtime/engine/executor.go
+++ b/internal/runtime/engine/executor.go
@@ -88,6 +88,8 @@ type executionFrame struct {
 	payload                   map[string]any
 	topLevelDataAccumulation  runtimecontracts.WorkflowDataAccumulation
 	topLevelDataWritesApplied bool
+	ruleDataWritesApplied     bool
+	projectionApplied         bool
 }
 
 type handlerRuleSource string
@@ -1002,6 +1004,9 @@ func (e *Executor) stepFanOut(frame *executionFrame) (bool, error) {
 	if len(items) == 0 {
 		return false, nil
 	}
+	if err := e.stepDataWrites(frame); err != nil {
+		return false, err
+	}
 	if err := e.stepProjection(frame); err != nil {
 		return false, err
 	}
@@ -1189,12 +1194,13 @@ func (e *Executor) stepSetsGate(frame *executionFrame) error {
 
 func (e *Executor) stepDataWrites(frame *executionFrame) error {
 	ruleHasWrites := frame.rule != nil && (frame.rule.DataAccumulation.HasWrites() || strings.TrimSpace(frame.rule.DataAccumulation.SourceEvent) != "")
-	if ruleHasWrites {
+	if ruleHasWrites && !frame.ruleDataWritesApplied {
 		if err := e.applyDataAccumulation(frame, frame.rule.DataAccumulation); err != nil {
 			return err
 		}
+		frame.ruleDataWritesApplied = true
 	}
-	if (frame.topLevelDataAccumulation.HasWrites() || strings.TrimSpace(frame.topLevelDataAccumulation.SourceEvent) != "") && (!frame.topLevelDataWritesApplied || ruleHasWrites) {
+	if (frame.topLevelDataAccumulation.HasWrites() || strings.TrimSpace(frame.topLevelDataAccumulation.SourceEvent) != "") && !frame.topLevelDataWritesApplied {
 		if err := e.applyDataAccumulation(frame, frame.topLevelDataAccumulation); err != nil {
 			return err
 		}
@@ -1204,6 +1210,9 @@ func (e *Executor) stepDataWrites(frame *executionFrame) error {
 }
 
 func (e *Executor) stepProjection(frame *executionFrame) error {
+	if frame.projectionApplied {
+		return nil
+	}
 	if !accumulatorProjectionEligible(frame) {
 		return nil
 	}
@@ -1231,6 +1240,7 @@ func (e *Executor) stepProjection(frame *executionFrame) error {
 			return fmt.Errorf("materialize_from %s.%s: %w", binding.SourceNodeID, binding.AccumulatorName, err)
 		}
 	}
+	frame.projectionApplied = true
 	return nil
 }
 

--- a/internal/runtime/engine/executor.go
+++ b/internal/runtime/engine/executor.go
@@ -78,17 +78,16 @@ type Executor struct {
 }
 
 type executionFrame struct {
-	tx                            Tx
-	req                           ExecutionRequest
-	base                          BaseContext
-	state                         ExecutionState
-	result                        ExecutionResult
-	rule                          *runtimecontracts.HandlerRuleEntry
-	ruleSource                    handlerRuleSource
-	payload                       map[string]any
-	topLevelDataAccumulation      runtimecontracts.WorkflowDataAccumulation
-	topLevelDataWritesApplied     bool
-	accumulatorProjectionEligible bool
+	tx                        Tx
+	req                       ExecutionRequest
+	base                      BaseContext
+	state                     ExecutionState
+	result                    ExecutionResult
+	rule                      *runtimecontracts.HandlerRuleEntry
+	ruleSource                handlerRuleSource
+	payload                   map[string]any
+	topLevelDataAccumulation  runtimecontracts.WorkflowDataAccumulation
+	topLevelDataWritesApplied bool
 }
 
 type handlerRuleSource string
@@ -1095,11 +1094,6 @@ func (e *Executor) stepOnComplete(frame *executionFrame) error {
 	if rule != nil {
 		frame.rule = rule
 		frame.ruleSource = ruleSource
-		if frame.result.AccumulatorCompletionDiagnostics.Relevant &&
-			frame.result.AccumulatorCompletionDiagnostics.CompletionReached &&
-			frame.req.Handler.Accumulate != nil {
-			frame.accumulatorProjectionEligible = true
-		}
 		e.applyRule(frame, rule)
 		if rule.FanOut != nil {
 			if _, err := e.stepFanOut(frame); err != nil {
@@ -1207,7 +1201,7 @@ func (e *Executor) stepDataWrites(frame *executionFrame) error {
 }
 
 func (e *Executor) stepProjection(frame *executionFrame) error {
-	if !frame.accumulatorProjectionEligible {
+	if !accumulatorProjectionEligible(frame) {
 		return nil
 	}
 	handlerEventType := handlerAccumulatorEventType(frame.req)
@@ -1242,6 +1236,25 @@ func activeAccumulatorName(handler runtimecontracts.SystemNodeEventHandler) stri
 		return ""
 	}
 	return strings.TrimSpace(handler.Accumulate.Into)
+}
+
+func accumulatorProjectionEligible(frame *executionFrame) bool {
+	if frame == nil || frame.req.Handler.Accumulate == nil {
+		return false
+	}
+	diagnostics := frame.result.AccumulatorCompletionDiagnostics
+	if !diagnostics.Relevant || !diagnostics.CompletionReached {
+		return false
+	}
+	if isAccumulationTimeoutEvent(frame.req.Event.Type()) || frame.ruleSource == handlerRuleSourceAccumulateOnTimeout {
+		return false
+	}
+	onCompleteDeclared := len(frame.req.Handler.OnComplete) > 0 || len(frame.req.Handler.Accumulate.OnComplete) > 0
+	if !onCompleteDeclared {
+		return true
+	}
+	return frame.rule != nil &&
+		(frame.ruleSource == handlerRuleSourceOnComplete || frame.ruleSource == handlerRuleSourceAccumulateOnComplete)
 }
 
 func (e *Executor) projectAccumulatorItems(frame *executionFrame, binding accprojection.Binding, items []map[string]any) ([]any, error) {

--- a/internal/runtime/engine/executor.go
+++ b/internal/runtime/engine/executor.go
@@ -1002,6 +1002,9 @@ func (e *Executor) stepFanOut(frame *executionFrame) (bool, error) {
 	if len(items) == 0 {
 		return false, nil
 	}
+	if err := e.stepProjection(frame); err != nil {
+		return false, err
+	}
 	for _, item := range items {
 		eventType := fanOutEventType(spec)
 		if eventType == "" {

--- a/internal/runtime/engine/executor_test.go
+++ b/internal/runtime/engine/executor_test.go
@@ -663,8 +663,8 @@ func TestExecutor_ShapeEmitPayloadUsesUpdatedState(t *testing.T) {
 	}
 }
 
-func TestExecutor_AccumulatorProjectionMaterializesTypedEntityFieldBeforeEmit(t *testing.T) {
-	source := semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
+func accumulatorProjectionTestSource() semanticview.Source {
+	return semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
 		RootTypes: runtimecontracts.TypeCatalogDocument{
 			Types: map[string]runtimecontracts.NamedTypeDecl{
 				"DimensionScore": {
@@ -748,6 +748,10 @@ func TestExecutor_AccumulatorProjectionMaterializesTypedEntityFieldBeforeEmit(t 
 			},
 		},
 	})
+}
+
+func TestExecutor_AccumulatorProjectionMaterializesTypedEntityFieldBeforeEmit(t *testing.T) {
+	source := accumulatorProjectionTestSource()
 	exec, err := NewExecutor(RuntimeDependencies{
 		Source:     source,
 		StateRepo:  stubStateRepo{},
@@ -828,6 +832,283 @@ func TestExecutor_AccumulatorProjectionMaterializesTypedEntityFieldBeforeEmit(t 
 	emittedScores, ok := emitted["scores"].([]any)
 	if !ok || len(emittedScores) != 1 {
 		t.Fatalf("emit payload scores = %#v", emitted["scores"])
+	}
+}
+
+func TestExecutor_AccumulatorProjectionMaterializesWithoutOnComplete(t *testing.T) {
+	exec := newAccumulatorProjectionTestExecutor(t, nil)
+	handler := runtimecontracts.SystemNodeEventHandler{
+		Accumulate: &runtimecontracts.AccumulateSpec{
+			Into:      "dimensions_received",
+			DedupBy:   "payload.dimension",
+			DedupPath: runtimecontracts.RefExpression("payload.dimension").RefPath,
+		},
+		Emit: runtimecontracts.EmitSpec{
+			Event: "vertical.scored",
+			Fields: map[string]runtimecontracts.ExpressionValue{
+				"scores": runtimecontracts.RefExpression("entity.scores"),
+			},
+		},
+	}
+	result := executeAccumulatorProjectionTestEvent(t, exec, handler, testStateSnapshot("pending", map[string]any{}, nil, map[string]map[string]any{}))
+	score := requireProjectedScore(t, result, "scores")
+	if got := score["dimension"]; got != "market" {
+		t.Fatalf("projected dimension = %#v", got)
+	}
+	if len(result.EmitIntents) != 1 {
+		t.Fatalf("EmitIntents count = %d, want 1", len(result.EmitIntents))
+	}
+	var emitted map[string]any
+	if err := json.Unmarshal(result.EmitIntents[0].Event.Payload(), &emitted); err != nil {
+		t.Fatalf("emit payload json: %v", err)
+	}
+	emittedScores, ok := emitted["scores"].([]any)
+	if !ok || len(emittedScores) != 1 {
+		t.Fatalf("emit payload scores = %#v", emitted["scores"])
+	}
+}
+
+func TestExecutor_AccumulatorProjectionMaterializesWithRulesBeforeEmitFields(t *testing.T) {
+	exec := newAccumulatorProjectionTestExecutor(t, nil)
+	handler := runtimecontracts.SystemNodeEventHandler{
+		Accumulate: &runtimecontracts.AccumulateSpec{
+			Into:      "dimensions_received",
+			DedupBy:   "payload.dimension",
+			DedupPath: runtimecontracts.RefExpression("payload.dimension").RefPath,
+		},
+		DataAccumulation: runtimecontracts.WorkflowDataAccumulation{
+			Writes: []runtimecontracts.WorkflowDataWrite{{
+				TargetField: "metadata.handler_marker",
+				Value:       runtimecontracts.LiteralExpression("top-level"),
+			}},
+		},
+		Rules: []runtimecontracts.HandlerRuleEntry{{
+			ID:        "matched",
+			Condition: "else",
+			DataAccumulation: runtimecontracts.WorkflowDataAccumulation{
+				Writes: []runtimecontracts.WorkflowDataWrite{{
+					TargetField: "metadata.rule_marker",
+					Value:       runtimecontracts.LiteralExpression("rule"),
+				}},
+			},
+			Emit: runtimecontracts.EmitSpec{
+				Event: "vertical.scored",
+				Fields: map[string]runtimecontracts.ExpressionValue{
+					"scores":         runtimecontracts.RefExpression("entity.scores"),
+					"handler_marker": runtimecontracts.RefExpression("metadata.handler_marker"),
+					"rule_marker":    runtimecontracts.RefExpression("metadata.rule_marker"),
+				},
+			},
+		}},
+	}
+	result := executeAccumulatorProjectionTestEvent(t, exec, handler, testStateSnapshot("pending", map[string]any{}, nil, map[string]map[string]any{}))
+	requireProjectedScore(t, result, "scores")
+	if got := result.RuleID; got != "matched" {
+		t.Fatalf("RuleID = %q, want matched", got)
+	}
+	if got := result.StateMutation.Metadata["handler_marker"]; got != "top-level" {
+		t.Fatalf("handler_marker = %#v, want top-level", got)
+	}
+	if got := result.StateMutation.Metadata["rule_marker"]; got != "rule" {
+		t.Fatalf("rule_marker = %#v, want rule", got)
+	}
+	if len(result.EmitIntents) != 1 {
+		t.Fatalf("EmitIntents count = %d, want 1", len(result.EmitIntents))
+	}
+	var emitted map[string]any
+	if err := json.Unmarshal(result.EmitIntents[0].Event.Payload(), &emitted); err != nil {
+		t.Fatalf("emit payload json: %v", err)
+	}
+	if emittedScores, ok := emitted["scores"].([]any); !ok || len(emittedScores) != 1 {
+		t.Fatalf("emit payload scores = %#v", emitted["scores"])
+	}
+	if got := emitted["handler_marker"]; got != "top-level" {
+		t.Fatalf("emit handler_marker = %#v, want top-level", got)
+	}
+	if got := emitted["rule_marker"]; got != "rule" {
+		t.Fatalf("emit rule_marker = %#v, want rule", got)
+	}
+}
+
+func TestExecutor_AccumulatorProjectionMaterializesWhenRulesDoNotMatch(t *testing.T) {
+	exec := newAccumulatorProjectionTestExecutor(t, stubEvaluator{bools: map[string]bool{
+		"payload.score > 100": false,
+	}})
+	handler := runtimecontracts.SystemNodeEventHandler{
+		Accumulate: &runtimecontracts.AccumulateSpec{
+			Into:      "dimensions_received",
+			DedupBy:   "payload.dimension",
+			DedupPath: runtimecontracts.RefExpression("payload.dimension").RefPath,
+		},
+		Rules: []runtimecontracts.HandlerRuleEntry{{
+			ID:        "too-high",
+			Condition: "payload.score > 100",
+			DataAccumulation: runtimecontracts.WorkflowDataAccumulation{
+				Writes: []runtimecontracts.WorkflowDataWrite{{
+					TargetField: "metadata.rule_marker",
+					Value:       runtimecontracts.LiteralExpression("unexpected"),
+				}},
+			},
+		}},
+	}
+	result := executeAccumulatorProjectionTestEvent(t, exec, handler, testStateSnapshot("pending", map[string]any{}, nil, map[string]map[string]any{}))
+	requireProjectedScore(t, result, "scores")
+	if got := strings.TrimSpace(result.RuleID); got != "" {
+		t.Fatalf("RuleID = %q, want empty when rules do not match", got)
+	}
+	if _, ok := result.StateMutation.Metadata["rule_marker"]; ok {
+		t.Fatalf("rule_marker unexpectedly written: %#v", result.StateMutation.Metadata)
+	}
+}
+
+func TestExecutor_AccumulatorProjectionSkipsDeclaredOnCompleteNoMatch(t *testing.T) {
+	exec := newAccumulatorProjectionTestExecutor(t, stubEvaluator{bools: map[string]bool{
+		"payload.score > 100": false,
+	}})
+	handler := runtimecontracts.SystemNodeEventHandler{
+		Accumulate: &runtimecontracts.AccumulateSpec{
+			Into:      "dimensions_received",
+			DedupBy:   "payload.dimension",
+			DedupPath: runtimecontracts.RefExpression("payload.dimension").RefPath,
+			OnComplete: []runtimecontracts.HandlerRuleEntry{{
+				ID:        "too-high",
+				Condition: "payload.score > 100",
+				Emit:      runtimecontracts.EmitSpec{Event: "vertical.scored"},
+			}},
+		},
+	}
+	result := executeAccumulatorProjectionTestEvent(t, exec, handler, testStateSnapshot("pending", map[string]any{}, nil, map[string]map[string]any{}))
+	requireNoProjectedScores(t, result)
+	if got := strings.TrimSpace(result.RuleID); got != "" {
+		t.Fatalf("RuleID = %q, want empty when on_complete does not match", got)
+	}
+	if len(result.EmitIntents) != 0 {
+		t.Fatalf("EmitIntents count = %d, want 0", len(result.EmitIntents))
+	}
+}
+
+func TestExecutor_AccumulatorProjectionSkipsIncompleteAccumulation(t *testing.T) {
+	exec := newAccumulatorProjectionTestExecutor(t, nil)
+	handler := runtimecontracts.SystemNodeEventHandler{
+		Accumulate: &runtimecontracts.AccumulateSpec{
+			Into:         "dimensions_received",
+			ExpectedFrom: "entity.expected_dimensions",
+			ExpectedPath: runtimecontracts.RefExpression("entity.expected_dimensions").RefPath,
+			Completion:   runtimecontracts.ParseAccumulateCompletion("all"),
+			DedupBy:      "payload.dimension",
+			DedupPath:    runtimecontracts.RefExpression("payload.dimension").RefPath,
+		},
+	}
+	state := testStateSnapshot("pending", map[string]any{"expected_dimensions": []any{"market", "risk"}}, nil, map[string]map[string]any{})
+	result := executeAccumulatorProjectionTestEvent(t, exec, handler, state)
+	if result.Status != OutcomeWaiting {
+		t.Fatalf("Status = %q, want %q", result.Status, OutcomeWaiting)
+	}
+	requireNoProjectedScores(t, result)
+}
+
+func TestExecutor_AccumulatorProjectionSkipsTimeoutBranch(t *testing.T) {
+	exec := newAccumulatorProjectionTestExecutor(t, nil)
+	handler := runtimecontracts.SystemNodeEventHandler{
+		Accumulate: &runtimecontracts.AccumulateSpec{
+			Into:       "dimensions_received",
+			Completion: runtimecontracts.ParseAccumulateCompletion("all"),
+			OnTimeout: &runtimecontracts.HandlerRuleEntry{
+				ID: "timeout",
+				DataAccumulation: runtimecontracts.WorkflowDataAccumulation{
+					Writes: []runtimecontracts.WorkflowDataWrite{{
+						TargetField: "metadata.timeout_seen",
+						Value:       runtimecontracts.LiteralExpression(true),
+					}},
+				},
+			},
+		},
+	}
+	state := testStateSnapshot("pending", map[string]any{}, nil, map[string]map[string]any{})
+	storeAccumulatorForBucket(&state, accumulatorBucketRef("scoring-node", "score.dimension_complete"), &Accumulator{
+		ExpectedCount: 2,
+		Received:      map[string]bool{"market": true},
+		Items: []map[string]any{{
+			"dimension":  "market",
+			"tier":       2,
+			"score":      87,
+			"evidence":   "strong",
+			"confidence": "high",
+		}},
+	})
+	result, err := exec.Execute(context.Background(), ExecutionRequest{
+		EntityID: "entity-1",
+		NodeID:   "scoring-node",
+		Event: eventtest.RootIngress("timeout-1",
+			"accumulate.timeout", "", "", json.RawMessage(`{"timer_handle":{"kind":"accumulation_timeout","bucket":{"node_id":"scoring-node","event_type":"score.dimension_complete"}}}`), 0, "", "", events.EventEnvelope{}, time.Time{}),
+		HandlerEventKey: "score.dimension_complete",
+		Handler:         handler,
+		State:           state,
+	})
+	if err != nil {
+		t.Fatalf("Execute error: %v", err)
+	}
+	if got := result.StateMutation.Metadata["timeout_seen"]; got != true {
+		t.Fatalf("timeout_seen = %#v, want true", got)
+	}
+	requireNoProjectedScores(t, result)
+}
+
+func newAccumulatorProjectionTestExecutor(t *testing.T, evaluator Evaluator) *Executor {
+	t.Helper()
+	exec, err := NewExecutor(RuntimeDependencies{
+		Source:     accumulatorProjectionTestSource(),
+		StateRepo:  stubStateRepo{},
+		TxRunner:   stubRunner{},
+		Locker:     stubLocker{},
+		Outbox:     stubOutbox{},
+		Dispatcher: stubDispatcher{},
+	}, evaluator)
+	if err != nil {
+		t.Fatalf("NewExecutor error: %v", err)
+	}
+	return exec
+}
+
+func executeAccumulatorProjectionTestEvent(t *testing.T, exec *Executor, handler runtimecontracts.SystemNodeEventHandler, state StateSnapshot) ExecutionResult {
+	t.Helper()
+	result, err := exec.Execute(context.Background(), ExecutionRequest{
+		EntityID: "entity-1",
+		NodeID:   "scoring-node",
+		Event: eventtest.RootIngress("evt-1",
+			"score.dimension_complete", "", "", json.RawMessage(`{"vertical_id":"11111111-1111-1111-1111-111111111111","dimension":"market","tier":2,"score":87,"evidence":"strong","confidence":"high"}`), 0, "", "", events.EventEnvelope{}, time.Time{}),
+		Handler: handler,
+		State:   state,
+	})
+	if err != nil {
+		t.Fatalf("Execute error: %v", err)
+	}
+	return result
+}
+
+func requireProjectedScore(t *testing.T, result ExecutionResult, field string) map[string]any {
+	t.Helper()
+	scores, ok := result.StateMutation.Metadata[field].([]any)
+	if !ok || len(scores) != 1 {
+		t.Fatalf("projected %s = %#v", field, result.StateMutation.Metadata[field])
+	}
+	score, ok := scores[0].(map[string]any)
+	if !ok {
+		t.Fatalf("projected %s item = %#v", field, scores[0])
+	}
+	if _, exists := score["event_id"]; exists {
+		t.Fatalf("projected score leaked accumulator metadata: %#v", score)
+	}
+	if _, exists := score["vertical_id"]; exists {
+		t.Fatalf("projected score leaked payload extra field: %#v", score)
+	}
+	return score
+}
+
+func requireNoProjectedScores(t *testing.T, result ExecutionResult) {
+	t.Helper()
+	if _, exists := result.StateMutation.Metadata["scores"]; exists {
+		t.Fatalf("projected scores unexpectedly present: %#v", result.StateMutation.Metadata["scores"])
 	}
 }
 

--- a/internal/runtime/engine/executor_test.go
+++ b/internal/runtime/engine/executor_test.go
@@ -1054,6 +1054,56 @@ func TestExecutor_AccumulatorProjectionSkipsTimeoutBranch(t *testing.T) {
 	requireNoProjectedScores(t, result)
 }
 
+func TestExecutor_AccumulatorProjectionMaterializesBeforeTopLevelFanOutEmitFields(t *testing.T) {
+	exec := newAccumulatorProjectionTestExecutor(t, nil)
+	handler := runtimecontracts.SystemNodeEventHandler{
+		Accumulate: &runtimecontracts.AccumulateSpec{
+			Into:      "dimensions_received",
+			DedupBy:   "payload.dimension",
+			DedupPath: runtimecontracts.RefExpression("payload.dimension").RefPath,
+		},
+		FanOut: &runtimecontracts.FanOutSpec{
+			ItemsFrom: "payload.targets",
+			Emit: runtimecontracts.EmitSpec{
+				Event: "vertical.scored",
+				Fields: map[string]runtimecontracts.ExpressionValue{
+					"scores": runtimecontracts.RefExpression("entity.scores"),
+					"target": runtimecontracts.RefExpression("fan_out.item"),
+				},
+			},
+		},
+	}
+	result, err := exec.Execute(context.Background(), ExecutionRequest{
+		EntityID: "entity-1",
+		NodeID:   "scoring-node",
+		Event: eventtest.RootIngress("evt-1",
+			"score.dimension_complete", "", "", json.RawMessage(`{"vertical_id":"11111111-1111-1111-1111-111111111111","dimension":"market","tier":2,"score":87,"evidence":"strong","confidence":"high","targets":["agent-a"]}`), 0, "", "", events.EventEnvelope{}, time.Time{}),
+		Handler: handler,
+		State:   testStateSnapshot("pending", map[string]any{}, nil, map[string]map[string]any{}),
+	})
+	if err != nil {
+		t.Fatalf("Execute error: %v", err)
+	}
+	requireProjectedScore(t, result, "scores")
+	if result.Status != OutcomeFannedOut {
+		t.Fatalf("Status = %q, want %q", result.Status, OutcomeFannedOut)
+	}
+	if len(result.EmitIntents) != 1 {
+		t.Fatalf("EmitIntents count = %d, want 1", len(result.EmitIntents))
+	}
+	var emitted map[string]any
+	if err := json.Unmarshal(result.EmitIntents[0].Event.Payload(), &emitted); err != nil {
+		t.Fatalf("emit payload json: %v", err)
+	}
+	emittedScores, ok := emitted["scores"].([]any)
+	if !ok || len(emittedScores) != 1 {
+		t.Fatalf("fan_out emit payload scores = %#v", emitted["scores"])
+	}
+	if got := emitted["target"]; got != "agent-a" {
+		t.Fatalf("fan_out emit target = %#v, want agent-a", got)
+	}
+}
+
 func newAccumulatorProjectionTestExecutor(t *testing.T, evaluator Evaluator) *Executor {
 	t.Helper()
 	exec, err := NewExecutor(RuntimeDependencies{

--- a/internal/runtime/engine/executor_test.go
+++ b/internal/runtime/engine/executor_test.go
@@ -1062,13 +1062,20 @@ func TestExecutor_AccumulatorProjectionMaterializesBeforeTopLevelFanOutEmitField
 			DedupBy:   "payload.dimension",
 			DedupPath: runtimecontracts.RefExpression("payload.dimension").RefPath,
 		},
+		DataAccumulation: runtimecontracts.WorkflowDataAccumulation{
+			Writes: []runtimecontracts.WorkflowDataWrite{{
+				TargetField: "metadata.handler_marker",
+				Value:       runtimecontracts.LiteralExpression("top-level"),
+			}},
+		},
 		FanOut: &runtimecontracts.FanOutSpec{
 			ItemsFrom: "payload.targets",
 			Emit: runtimecontracts.EmitSpec{
 				Event: "vertical.scored",
 				Fields: map[string]runtimecontracts.ExpressionValue{
-					"scores": runtimecontracts.RefExpression("entity.scores"),
-					"target": runtimecontracts.RefExpression("fan_out.item"),
+					"handler_marker": runtimecontracts.RefExpression("metadata.handler_marker"),
+					"scores":         runtimecontracts.RefExpression("entity.scores"),
+					"target":         runtimecontracts.RefExpression("fan_out.item"),
 				},
 			},
 		},
@@ -1088,6 +1095,9 @@ func TestExecutor_AccumulatorProjectionMaterializesBeforeTopLevelFanOutEmitField
 	if result.Status != OutcomeFannedOut {
 		t.Fatalf("Status = %q, want %q", result.Status, OutcomeFannedOut)
 	}
+	if got := result.StateMutation.Metadata["handler_marker"]; got != "top-level" {
+		t.Fatalf("handler_marker state mutation = %#v, want top-level", got)
+	}
 	if len(result.EmitIntents) != 1 {
 		t.Fatalf("EmitIntents count = %d, want 1", len(result.EmitIntents))
 	}
@@ -1098,6 +1108,9 @@ func TestExecutor_AccumulatorProjectionMaterializesBeforeTopLevelFanOutEmitField
 	emittedScores, ok := emitted["scores"].([]any)
 	if !ok || len(emittedScores) != 1 {
 		t.Fatalf("fan_out emit payload scores = %#v", emitted["scores"])
+	}
+	if got := emitted["handler_marker"]; got != "top-level" {
+		t.Fatalf("fan_out emit handler_marker = %#v, want top-level", got)
 	}
 	if got := emitted["target"]; got != "agent-a" {
 		t.Fatalf("fan_out emit target = %#v, want agent-a", got)

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -1331,7 +1331,7 @@ handler_specification:
       \           └→ emit-site selection (handler emit OR active branch/rule/timeout/fan_out emit)\n                    \
       \                      └→ advances_to ─┐\n                                             sets_gate ────┤ (independent\
       \ of each other)\n                                             data_accumulation ┘\n                         \
-      \                         └→ projection (materialize_from, if accumulator on_complete matched)\n                  \
+      \                         └→ projection (materialize_from, if accumulator projection eligible)\n                  \
       \                                └→ emit.fields\n                                                       └→ emit.event\n  \
       \                                                          └→ action\n                                            \
       \                     └→ clear (optional — reset accumulator/state buckets)\n    "
@@ -1544,12 +1544,15 @@ handler_specification:
       concept: Track multiple events arriving for the same entity. Fire on_complete when completion condition is met. Expected
         count read from entity state (written by initiating handler).
       projection_hook: |
-        When a handler accumulator completes and an on_complete branch matches
-        successfully, any same-flow entity field declaring `materialize_from`
-        for this handler's `accumulate.into` buffer is written as a full
-        replacement list after data_accumulation and before emit.fields. No
-        projection occurs for incomplete accumulation, timeout branches, or
-        completion with no matching on_complete rule.
+        When a handler accumulator reaches successful completion, any same-flow
+        entity field declaring `materialize_from` for this handler's
+        `accumulate.into` buffer is written as a full replacement list after
+        data_accumulation and before emit.fields if either no `on_complete`
+        block is declared or an `on_complete` branch matches successfully.
+        `rules` remain branch-selection/data-write/emit/action semantics and do
+        not guard accumulator projection eligibility. No projection occurs for
+        incomplete accumulation, timeout branches, or declared `on_complete`
+        completion with no matching branch.
     compute:
       field: compute
       type: object
@@ -10352,14 +10355,17 @@ static_analyzer:
       also declares `_unused_reason`, or any other authored writer targets the
       same field.
     runtime_rule: |
-      On a successful matching accumulator on_complete branch, runtime writes
-      the projection as a full replacement before emit.fields and validates the
-      result through entity named-type normalization. Failure rolls back the
-      whole handler transaction. If a verify-clean declaration exists for the
-      active handler accumulator but runtime resolves zero projection bindings,
-      execution fails closed as a runtime invariant violation rather than
-      silently skipping the projection. Projection does not run for timeout,
-      incomplete accumulation, or no-match completion.
+      On successful accumulator completion, runtime writes the projection as a
+      full replacement before emit.fields when no `on_complete` block is
+      declared or when a declared `on_complete` branch matches successfully.
+      Handler `rules` do not guard projection eligibility. The projected result
+      is validated through entity named-type normalization. Failure rolls back
+      the whole handler transaction. If a verify-clean declaration exists for
+      the active handler accumulator but runtime resolves zero projection
+      bindings, execution fails closed as a runtime invariant violation rather
+      than silently skipping the projection. Projection does not run for
+      timeout, incomplete accumulation, or declared `on_complete` no-match
+      completion.
   slice_6c_accumulator_static_safety:
     ids:
     - accumulate_all_bounded_escape


### PR DESCRIPTION
## Summary

- Makes accumulator `materialize_from` projection eligibility an explicit engine decision based on successful completion, timeout status, and `on_complete` declaration/match policy.
- Allows successful completion with no `on_complete` to project, including handlers with `rules`, while preserving negative boundaries for incomplete, timeout, and declared `on_complete` no-match cases.
- Ensures fan-out emit fields cannot bypass projection when fan-out stops the ordered loop.
- Updates authoritative root `platform-spec.yaml` to match the runtime semantics.

Closes #1522
Part of #1462

## Governing Refs / Context

Exact governing spec references updated in this PR:
- `platform-spec.yaml` `entity_contracts.accumulator_entity_projection`
- `platform-spec.yaml` `handler_specification.dependency_graph`
- `platform-spec.yaml` `handler_fields.accumulate.projection_hook`
- `platform-spec.yaml` `accumulation_engine.completion_modes`
- `platform-spec.yaml` `static_analyzer.slice_6b_accumulator_entity_projection`

Binding issue/gate context:
- #1522 issue body
- #1522 `Pre-Implementation Coverage Audit`
- #1522 gate comment: `approved as first slice`, with `rules` as proof-bearing scope
- #1462 Point 2 parent context
- #1521 / PR #1586 explicitly split static accumulator safety from this projection semantics work

## Semantic Migration

- New canonical owner for runtime eligibility: `internal/runtime/engine` explicit `accumulatorProjectionEligible` decision.
- Existing canonical owner retained for binding shape: `internal/runtime/accprojection` resolver consumed by runtime and bootverify.
- Old producer/interpreter now invalid: `stepOnComplete` implicitly being the only place that made accumulator projection eligible.
- Checked production paths for surviving old behavior: `stepAccumulate`, `stepOnComplete`, `stepRules`, `stepProjection`, `stepFanOut`, `accprojection.ForHandlerWithAccumulator`, and bootverify projection checks.
- Migration completeness: complete for the #1522 child class. Broader #1462 remains parent context outside this PR.

## Tests

- `go test ./internal/runtime/engine -run 'TestExecutor_.*AccumulatorProjection|TestExecutor_StepOrderIsStable' -count=1`
- `go test ./internal/runtime/accprojection -count=1`
- `go test ./internal/runtime/bootverify -run 'TestRun_(AcceptsAccumulator|RejectsAccumulatorProjection)' -count=1`
- `go test ./internal/runtime -run 'TestArtifactRepoCommitResultEventsFlowThroughStaticServiceCallbackDelivery|TestTemplateInstanceAcknowledgedPublishDispatchesRoutedSystemNodeWithoutInternalCarrierAndEmpireStyleSideEffect' -count=1` (reran after first full-suite concurrency failure)
- `go test ./internal/runtime/cataloge2e -run 'TestTier11FlowCompositionCatalogFixtures_RealRuntime/test-nested-three-levels' -count=1` (reran after first full-suite concurrency failure)
- `go test ./...` (clean rerun passed before review follow-up; rerun after fan-out follow-up also passed)