### PR TITLE
[agent-b][issue #1568] Retire public gateway URL env

### DIFF
--- a/cmd/swarm/doctor_test.go
+++ b/cmd/swarm/doctor_test.go
@@ -232,18 +232,14 @@ func TestDoctorClaudeCLIPreflightReportsRetiredBackendEnv(t *testing.T) {
 	}
 }
 
-func TestDoctorClaudeCLIPreflightWarnsOnStaleGatewayEnv(t *testing.T) {
+func TestDoctorClaudeCLIPreflightWarnsOnRetiredGatewayEnv(t *testing.T) {
 	configureDoctorDockerStub(t)
 	t.Setenv("CLAUDE_CODE_OAUTH_TOKEN", "oauth-token")
 	t.Setenv("SWARM_TOOL_GATEWAY_TOKEN", "operator-token")
 
 	mcpPort := freeDoctorTCPPort(t)
-	oldPort := freeDoctorTCPPort(t)
-	if oldPort == mcpPort {
-		oldPort = freeDoctorTCPPort(t)
-	}
-	t.Setenv("SWARM_TOOL_GATEWAY_URL", "http://127.0.0.1:"+oldPort)
-	t.Setenv("SWARM_TOOL_GATEWAY_CONTAINER_URL", "http://host.docker.internal:"+oldPort)
+	t.Setenv("SWARM_TOOL_GATEWAY_URL", "http://127.0.0.1:"+mcpPort)
+	t.Setenv("SWARM_TOOL_GATEWAY_CONTAINER_URL", "http://host.docker.internal:"+mcpPort)
 
 	args := doctorClaudeArgs(t, writeDoctorClaudeConfig(t), false)
 	args = append(args[:len(args)-4], "--api-listen-addr", "127.0.0.1:0", "--mcp-listen-addr", "127.0.0.1:"+mcpPort)
@@ -252,11 +248,18 @@ func TestDoctorClaudeCLIPreflightWarnsOnStaleGatewayEnv(t *testing.T) {
 	if code != cliExitOK {
 		t.Fatalf("code = %d, want %d stdout=%s stderr=%s", code, cliExitOK, stdout.String(), stderr.String())
 	}
-	if !strings.Contains(stdout.String(), "[WARNING] gateway_prerequisite/swarm_tool_gateway_url_stale") || !strings.Contains(stdout.String(), "must target the MCP listener port "+mcpPort) {
-		t.Fatalf("stale gateway env not reported:\n%s", stdout.String())
+	for _, want := range []string{
+		"[WARNING] gateway_prerequisite/swarm_tool_gateway_url_retired",
+		"[WARNING] gateway_prerequisite/swarm_tool_gateway_container_url_retired",
+		"SWARM_TOOL_GATEWAY_URL is retired and not accepted as gateway endpoint configuration",
+		"unset SWARM_TOOL_GATEWAY_URL; local serve/run derives the gateway binding from the bound MCP listener and ignores this retired URL",
+	} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("doctor output missing %q:\n%s", want, stdout.String())
+		}
 	}
-	if !strings.Contains(stdout.String(), "local serve/run derives the gateway binding from the bound MCP listener and ignores this URL") {
-		t.Fatalf("stale gateway env remediation missing binding authority:\n%s", stdout.String())
+	if strings.Contains(stdout.String(), "shadowed_or_empty") || strings.Contains(stdout.String(), "must target the MCP listener port") {
+		t.Fatalf("doctor output still renders retired URL env through old acceptance model:\n%s", stdout.String())
 	}
 }
 

--- a/cmd/swarm/local_preflight.go
+++ b/cmd/swarm/local_preflight.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"net"
 	"os"
 	"sort"
 	"strings"
@@ -109,7 +108,7 @@ func runLocalClaudeCLIPreflight(ctx context.Context, req localPreflightRequest) 
 		report.checkListener("mcp_listener", "mcp", req.MCPListenAddr)
 	}
 	if req.CheckGatewayEnv {
-		report.checkGatewayEnv(req.MCPListenAddr)
+		report.checkGatewayEnv()
 	}
 
 	source, contractsRoot, err := loadLocalPreflightSource(req.RepoRoot, req.ResolvedPaths)
@@ -214,28 +213,20 @@ func (r *localPreflightReport) checkListener(code, name, addr string) {
 	r.add(localPreflightServeListenerPrerequisite, code, localPreflightSeverityInfo, localPreflightStatusOK, fmt.Sprintf("%s listener address %s is available", name, strings.TrimSpace(addr)), "")
 }
 
-func (r *localPreflightReport) checkGatewayEnv(mcpListenAddr string) {
-	addr, ok, err := resolvedGatewayCheckAddr(mcpListenAddr)
-	if err != nil {
-		r.add(localPreflightGatewayPrerequisite, "mcp_listener_unavailable", localPreflightSeverityBlocker, localPreflightStatusFailed, err.Error(), "set a valid --mcp-listen-addr")
-		return
-	}
-	if !ok {
-		r.add(localPreflightGatewayPrerequisite, "gateway_env_port_deferred", localPreflightSeverityInfo, localPreflightStatusSkipped, "MCP listener uses port 0; gateway env validation is deferred until serve binds the actual listener", "")
-		return
-	}
-	for _, name := range []string{"SWARM_TOOL_GATEWAY_URL", "SWARM_TOOL_GATEWAY_CONTAINER_URL"} {
-		if err := validateExistingServeGatewayURL(name, lookupEnvValue(name), addr); err != nil {
-			severity := localPreflightSeverityWarning
-			remediation := fmt.Sprintf("unset %s; local serve/run derives the gateway binding from the bound MCP listener and ignores this URL", name)
-			if r.Mode == "serve" {
-				severity = localPreflightSeverityBlocker
-				remediation = fmt.Sprintf("unset %s or point it at the selected MCP listener port; public URL-env retirement remains split", name)
-			}
-			r.add(localPreflightGatewayPrerequisite, strings.ToLower(name)+"_stale", severity, localPreflightStatusFailed, err.Error(), remediation)
-		} else {
-			r.add(localPreflightGatewayPrerequisite, strings.ToLower(name)+"_shadowed_or_empty", localPreflightSeverityInfo, localPreflightStatusOK, fmt.Sprintf("%s is empty or non-authoritative for local gateway binding", name), "")
+func (r *localPreflightReport) checkGatewayEnv() {
+	for _, name := range retiredToolGatewayURLEnvNames {
+		raw := strings.TrimSpace(lookupEnvValue(name))
+		if raw == "" {
+			r.add(localPreflightGatewayPrerequisite, strings.ToLower(name)+"_empty", localPreflightSeverityInfo, localPreflightStatusOK, fmt.Sprintf("%s is empty; gateway endpoints are derived from ToolGatewayBinding", name), "")
+			continue
 		}
+		severity := localPreflightSeverityWarning
+		remediation := fmt.Sprintf("unset %s; local serve/run derives the gateway binding from the bound MCP listener and ignores this retired URL", name)
+		if r.Mode == "serve" {
+			severity = localPreflightSeverityBlocker
+			remediation = fmt.Sprintf("unset %s; non-dev serve rejects retired gateway URL env because ToolGatewayBinding owns endpoint configuration", name)
+		}
+		r.add(localPreflightGatewayPrerequisite, strings.ToLower(name)+"_retired", severity, localPreflightStatusFailed, validateRetiredToolGatewayURLEnv(name, raw).Error(), remediation)
 	}
 }
 
@@ -322,25 +313,6 @@ func loadLocalPreflightSource(repo string, paths cliContractPlatformSpecPaths) (
 
 func sourceDeclaresAgents(source semanticview.Source) bool {
 	return source != nil && len(source.AgentEntries()) > 0
-}
-
-func resolvedGatewayCheckAddr(mcpListenAddr string) (net.Addr, bool, error) {
-	addr := strings.TrimSpace(mcpListenAddr)
-	if err := validateServeListenAddr("--mcp-listen-addr", addr); err != nil {
-		return nil, false, err
-	}
-	host, port, err := net.SplitHostPort(addr)
-	if err != nil {
-		return nil, false, err
-	}
-	if strings.TrimSpace(port) == "" || strings.TrimSpace(port) == "0" {
-		return nil, false, nil
-	}
-	resolved, err := net.ResolveTCPAddr("tcp", net.JoinHostPort(host, port))
-	if err != nil {
-		return nil, false, err
-	}
-	return resolved, true, nil
 }
 
 func lookupEnvValue(name string) string {

--- a/cmd/swarm/main.go
+++ b/cmd/swarm/main.go
@@ -774,6 +774,13 @@ func runServeRuntime(ctx context.Context, repo string, opts serveOptions) int {
 	}
 	cfg := cfgResult.Config
 	reporter.emit(2, "config_load", "ok", serveConfigLoadDetail(cfgResult.Detail(), resolvedPaths, opts))
+	if !opts.Dev && !opts.LocalRun {
+		if err := validateServeGatewayURLEnvForNonDev(); err != nil {
+			reporter.emit(2, "serve_admission", "FAILED", err.Error())
+			log.Printf("validate non-dev mcp gateway env: %v", err)
+			return 3
+		}
+	}
 	mountSources, err := resolveWorkspaceMountSources(repo, opts.DataSource, cfg)
 	if err != nil {
 		reporter.emit(2, "config_load", "FAILED", err.Error())
@@ -937,15 +944,6 @@ func runServeRuntime(ctx context.Context, repo string, opts serveOptions) int {
 		reporter.emit(20, "http_listener_bind", "FAILED", err.Error())
 		log.Printf("configure mcp gateway binding: %v", err)
 		return 3
-	}
-	if !opts.Dev && !opts.LocalRun {
-		if err := validateServeGatewayURLEnvForNonDev(); err != nil {
-			_ = mcpListener.Close()
-			_ = apiListener.Close()
-			reporter.emit(20, "http_listener_bind", "FAILED", err.Error())
-			log.Printf("validate non-dev mcp gateway env: %v", err)
-			return 3
-		}
 	}
 
 	runtimeContexts := make([]serveRuntimeBundleContext, 0, len(loadedBundles))
@@ -3196,7 +3194,7 @@ func validateRetiredToolGatewayURLEnv(name, raw string) error {
 func validateServeGatewayURLEnvForNonDev() error {
 	for _, name := range retiredToolGatewayURLEnvNames {
 		if err := validateRetiredToolGatewayURLEnv(name, os.Getenv(name)); err != nil {
-			return err
+			return fmt.Errorf("non-dev serve rejects retired gateway URL env: %w", err)
 		}
 	}
 	return nil

--- a/cmd/swarm/main.go
+++ b/cmd/swarm/main.go
@@ -13,7 +13,6 @@ import (
 	"log/slog"
 	"net"
 	"net/http"
-	"net/url"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -940,7 +939,7 @@ func runServeRuntime(ctx context.Context, repo string, opts serveOptions) int {
 		return 3
 	}
 	if !opts.Dev && !opts.LocalRun {
-		if err := validateServeGatewayURLEnvForNonDev(mcpListener.Addr()); err != nil {
+		if err := validateServeGatewayURLEnvForNonDev(); err != nil {
 			_ = mcpListener.Close()
 			_ = apiListener.Close()
 			reporter.emit(20, "http_listener_bind", "FAILED", err.Error())
@@ -3185,54 +3184,22 @@ func createServeToolGatewayBinding(mcpAddr net.Addr) (toolgateway.Binding, error
 	return binding, nil
 }
 
-func validateExistingServeGatewayURL(name, raw string, mcpAddr net.Addr) error {
-	raw = strings.TrimSpace(raw)
-	if raw == "" {
+var retiredToolGatewayURLEnvNames = []string{"SWARM_TOOL_GATEWAY_URL", "SWARM_TOOL_GATEWAY_CONTAINER_URL"}
+
+func validateRetiredToolGatewayURLEnv(name, raw string) error {
+	if strings.TrimSpace(raw) == "" {
 		return nil
 	}
-	_, mcpPort, err := splitListenerHostPort(mcpAddr)
-	if err != nil {
-		return err
-	}
-	parsed, err := httpURLHostPort(raw)
-	if err != nil {
-		return fmt.Errorf("%s must be a valid http(s) URL for the MCP listener: %w", name, err)
-	}
-	if parsed.port != mcpPort {
-		return fmt.Errorf("%s must target the MCP listener port %s, got %s", name, mcpPort, parsed.port)
+	return fmt.Errorf("%s is retired and not accepted as gateway endpoint configuration; unset %s because swarm derives the tool gateway endpoint from ToolGatewayBinding", name, name)
+}
+
+func validateServeGatewayURLEnvForNonDev() error {
+	for _, name := range retiredToolGatewayURLEnvNames {
+		if err := validateRetiredToolGatewayURLEnv(name, os.Getenv(name)); err != nil {
+			return err
+		}
 	}
 	return nil
-}
-
-func validateServeGatewayURLEnvForNonDev(mcpAddr net.Addr) error {
-	if err := validateExistingServeGatewayURL("SWARM_TOOL_GATEWAY_URL", os.Getenv("SWARM_TOOL_GATEWAY_URL"), mcpAddr); err != nil {
-		return err
-	}
-	if err := validateExistingServeGatewayURL("SWARM_TOOL_GATEWAY_CONTAINER_URL", os.Getenv("SWARM_TOOL_GATEWAY_CONTAINER_URL"), mcpAddr); err != nil {
-		return err
-	}
-	return nil
-}
-
-type parsedHTTPHostPort struct {
-	host string
-	port string
-}
-
-func httpURLHostPort(raw string) (parsedHTTPHostPort, error) {
-	parsed, err := url.Parse(strings.TrimSpace(raw))
-	if err != nil {
-		return parsedHTTPHostPort{}, err
-	}
-	if parsed.Scheme != "http" && parsed.Scheme != "https" {
-		return parsedHTTPHostPort{}, fmt.Errorf("scheme must be http or https")
-	}
-	host := strings.TrimSpace(parsed.Hostname())
-	port := strings.TrimSpace(parsed.Port())
-	if host == "" || port == "" {
-		return parsedHTTPHostPort{}, fmt.Errorf("host and port are required")
-	}
-	return parsedHTTPHostPort{host: host, port: port}, nil
 }
 
 func serveMCPContainerGatewayURL(addr net.Addr) (string, error) {

--- a/cmd/swarm/main_test.go
+++ b/cmd/swarm/main_test.go
@@ -2507,7 +2507,7 @@ func TestPlatformSpecLocalToolGatewayBindingPromoted(t *testing.T) {
 	if !strings.Contains(binding.CanonicalOwner, "cli_specification.foundations.local_tool_gateway_binding") {
 		t.Fatalf("canonical owner does not point at local_tool_gateway_binding: %s", binding.CanonicalOwner)
 	}
-	for _, want := range []string{"local `serve`", "foreground `run`", "actual bound MCP listener", "stale URL-env", "first slice", "production Claude runtime factory", "MUST NOT mutate process-global"} {
+	for _, want := range []string{"local `serve`", "foreground `run`", "actual bound MCP listener", "stale URL-env", "public/operator", "non-dev serve", "production Claude runtime factory", "MUST NOT mutate process-global"} {
 		if !strings.Contains(binding.Scope, want) {
 			t.Fatalf("local tool gateway binding scope missing %q:\n%s", want, binding.Scope)
 		}
@@ -2522,7 +2522,7 @@ func TestPlatformSpecLocalToolGatewayBindingPromoted(t *testing.T) {
 			t.Fatalf("source rule missing %q:\n%s", want, binding.SourceRule)
 		}
 	}
-	for _, want := range []string{"SWARM_TOOL_GATEWAY_URL", "SWARM_TOOL_GATEWAY_CONTAINER_URL", "not public/operator source", "generated final-boundary compatibility", "derived from `ToolGatewayBinding`", "Selected-fork ephemeral gateway startup MUST NOT set"} {
+	for _, want := range []string{"SWARM_TOOL_GATEWAY_URL", "SWARM_TOOL_GATEWAY_CONTAINER_URL", "not public/operator source", "generated final-boundary compatibility", "derived from `ToolGatewayBinding`", "Selected-fork ephemeral gateway startup MUST NOT set", "retired public input", "MUST fail closed", "unset it", "MUST NOT be rendered as accepted configuration"} {
 		if !strings.Contains(binding.EndpointEnvRule, want) {
 			t.Fatalf("endpoint env rule missing %q:\n%s", want, binding.EndpointEnvRule)
 		}
@@ -2532,12 +2532,12 @@ func TestPlatformSpecLocalToolGatewayBindingPromoted(t *testing.T) {
 			t.Fatalf("auth rule missing %q:\n%s", want, binding.AuthRule)
 		}
 	}
-	for _, want := range []string{"serve listener binding", "RuntimeOptions.ToolGatewayBinding", "runtime MCP gateway auth", "ValidateClaudeCLIRuntimeConfig", "MCP HTTP config", "Docker exec", "fork-chat sandbox", "selected-fork ephemeral gateway"} {
+	for _, want := range []string{"serve listener binding", "RuntimeOptions.ToolGatewayBinding", "runtime MCP gateway auth", "ValidateClaudeCLIRuntimeConfig", "MCP HTTP config", "Docker exec", "fork-chat sandbox", "selected-fork ephemeral gateway", "non-dev serve retired URL-env admission"} {
 		if !stringSliceContains(binding.Consumers, want) {
 			t.Fatalf("binding consumers missing %q: %#v", want, binding.Consumers)
 		}
 	}
-	for _, want := range []string{"#1568 public/operator URL-env retirement", "#1568 broader selected-contract", "no longer uses process-global URL env", "#979/#1012 are completed historical source-authority slices", "#1138/#1213", "#1567", "IPC/unix socket"} {
+	for _, want := range []string{"#1568 token-source migration", "#1568 broader selected-contract", "no longer uses process-global URL env", "#979/#1012 are completed historical source-authority slices", "#1138/#1213", "#1567", "IPC/unix socket"} {
 		if !stringSliceContains(binding.SplitTail, want) {
 			t.Fatalf("binding split_tail missing %q: %#v", want, binding.SplitTail)
 		}
@@ -10598,6 +10598,47 @@ func TestCreateServeToolGatewayBindingIgnoresStaleLocalURLEnv(t *testing.T) {
 	}
 }
 
+func TestRunServeRuntimeNonDevClaudeCLIRetiredGatewayURLEnvFailsClosed(t *testing.T) {
+	isolateCLIAPIConfigEnv(t)
+	mcpPort := freeDoctorTCPPort(t)
+	t.Setenv("SWARM_TOOL_GATEWAY_URL", "http://127.0.0.1:"+mcpPort)
+	t.Setenv("SWARM_TOOL_GATEWAY_CONTAINER_URL", "http://host.docker.internal:"+mcpPort)
+	t.Setenv("SWARM_TOOL_GATEWAY_TOKEN", "")
+
+	var out lockedBuffer
+	code := runServeRuntime(context.Background(), repoRoot(), serveOptions{
+		ConfigPath:         writeDoctorClaudeConfig(t),
+		Backend:            "claude_cli",
+		ContractsPath:      filepath.Join("tests", "tier8-boot-verification", "test-boot-success"),
+		DataSource:         t.TempDir(),
+		PlatformSpecPath:   defaultPlatformSpecPath,
+		StoreMode:          "not-a-store",
+		APIListenAddr:      "127.0.0.1:0",
+		MCPListenAddr:      "127.0.0.1:" + mcpPort,
+		SelfCheck:          true,
+		RequireBundleMatch: false,
+		Verbose:            true,
+		Output:             &out,
+	})
+	if code != cliExitRuntime {
+		t.Fatalf("runServeRuntime code = %d, want %d\noutput:\n%s", code, cliExitRuntime, out.String())
+	}
+	for _, want := range []string{
+		"local_preflight",
+		"swarm_tool_gateway_url_retired",
+		"swarm_tool_gateway_container_url_retired",
+		"non-dev serve rejects retired gateway URL env",
+		"ToolGatewayBinding owns endpoint configuration",
+	} {
+		if !strings.Contains(out.String(), want) {
+			t.Fatalf("serve output missing %q:\n%s", want, out.String())
+		}
+	}
+	if strings.Contains(out.String(), "not-a-store") || strings.Contains(out.String(), "db_connection") || strings.Contains(out.String(), "ready") {
+		t.Fatalf("serve reached later startup after retired gateway URL env failure:\n%s", out.String())
+	}
+}
+
 func assertServePreflightStaleGatewayWarning(t *testing.T, opts serveOptions, wantMode string) {
 	t.Helper()
 	cfgResult, err := loadRuntimeConfigWithOptions(runtimeConfigLoadOptions{
@@ -10623,7 +10664,7 @@ func assertServePreflightStaleGatewayWarning(t *testing.T, opts serveOptions, wa
 	if report.Mode != wantMode {
 		t.Fatalf("preflight mode = %q, want %q", report.Mode, wantMode)
 	}
-	for _, code := range []string{"swarm_tool_gateway_url_stale", "swarm_tool_gateway_container_url_stale"} {
+	for _, code := range []string{"swarm_tool_gateway_url_retired", "swarm_tool_gateway_container_url_retired"} {
 		if !localPreflightReportHasFinding(report, code, localPreflightSeverityWarning, localPreflightStatusFailed) {
 			t.Fatalf("preflight report missing warning %q:\n%#v", code, report)
 		}
@@ -10690,29 +10731,31 @@ func staleGatewayTestPort(mcpPort string) string {
 	return "8081"
 }
 
-func TestValidateServeGatewayURLEnvForNonDevRejectsOldUnifiedPort(t *testing.T) {
-	listener, err := net.Listen("tcp", "127.0.0.1:0")
-	if err != nil {
-		t.Fatalf("listen mcp: %v", err)
-	}
-	defer listener.Close()
-	_, mcpPort, err := net.SplitHostPort(listener.Addr().String())
-	if err != nil {
-		t.Fatalf("split listener addr: %v", err)
-	}
-	oldUnifiedPort := "8081"
-	if mcpPort == oldUnifiedPort {
-		oldUnifiedPort = "8080"
-	}
-	t.Setenv("SWARM_TOOL_GATEWAY_URL", "http://127.0.0.1:"+oldUnifiedPort)
-	t.Setenv("SWARM_TOOL_GATEWAY_CONTAINER_URL", "http://host.docker.internal:"+oldUnifiedPort)
-
-	err = validateServeGatewayURLEnvForNonDev(listener.Addr())
-	if err == nil {
-		t.Fatal("non-dev gateway env validation unexpectedly accepted old unified API port")
-	}
-	if !strings.Contains(err.Error(), "must target the MCP listener port") {
-		t.Fatalf("error = %v, want MCP listener port mismatch", err)
+func TestValidateServeGatewayURLEnvForNonDevRejectsAnyRetiredURLEnv(t *testing.T) {
+	for _, tt := range []struct {
+		name  string
+		value string
+	}{
+		{name: "SWARM_TOOL_GATEWAY_URL", value: "http://127.0.0.1:8082"},
+		{name: "SWARM_TOOL_GATEWAY_CONTAINER_URL", value: "http://host.docker.internal:8082"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("SWARM_TOOL_GATEWAY_URL", "")
+			t.Setenv("SWARM_TOOL_GATEWAY_CONTAINER_URL", "")
+			t.Setenv(tt.name, tt.value)
+			err := validateServeGatewayURLEnvForNonDev()
+			if err == nil {
+				t.Fatal("non-dev gateway env validation unexpectedly accepted retired URL env")
+			}
+			for _, want := range []string{tt.name, "retired", "unset " + tt.name, "ToolGatewayBinding"} {
+				if !strings.Contains(err.Error(), want) {
+					t.Fatalf("error = %v, want %q", err, want)
+				}
+			}
+			if strings.Contains(err.Error(), "MCP listener port") {
+				t.Fatalf("error still suggests port-matching URL env is valid: %v", err)
+			}
+		})
 	}
 }
 

--- a/cmd/swarm/main_test.go
+++ b/cmd/swarm/main_test.go
@@ -10599,14 +10599,44 @@ func TestCreateServeToolGatewayBindingIgnoresStaleLocalURLEnv(t *testing.T) {
 }
 
 func TestRunServeRuntimeNonDevClaudeCLIRetiredGatewayURLEnvFailsClosed(t *testing.T) {
+	for _, tt := range []struct {
+		name  string
+		env   string
+		value string
+	}{
+		{name: "host-url", env: "SWARM_TOOL_GATEWAY_URL", value: "http://127.0.0.1:" + freeDoctorTCPPort(t)},
+		{name: "container-url", env: "SWARM_TOOL_GATEWAY_CONTAINER_URL", value: "http://host.docker.internal:" + freeDoctorTCPPort(t)},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			isolateCLIAPIConfigEnv(t)
+			t.Setenv("SWARM_TOOL_GATEWAY_URL", "")
+			t.Setenv("SWARM_TOOL_GATEWAY_CONTAINER_URL", "")
+			t.Setenv("SWARM_TOOL_GATEWAY_TOKEN", "")
+			t.Setenv(tt.env, tt.value)
+
+			assertRunServeRuntimeRetiredGatewayURLAdmissionFailure(t, tt.env, serveOptions{
+				ConfigPath:         writeDoctorClaudeConfig(t),
+				Backend:            "claude_cli",
+				ContractsPath:      filepath.Join("tests", "tier8-boot-verification", "test-boot-success"),
+				DataSource:         t.TempDir(),
+				PlatformSpecPath:   defaultPlatformSpecPath,
+				StoreMode:          "not-a-store",
+				APIListenAddr:      "127.0.0.1:0",
+				MCPListenAddr:      "127.0.0.1:0",
+				SelfCheck:          true,
+				RequireBundleMatch: false,
+			})
+		})
+	}
+}
+
+func TestRunServeRuntimeBundleHashRetiredGatewayURLEnvFailsBeforeStartupSideEffects(t *testing.T) {
 	isolateCLIAPIConfigEnv(t)
-	mcpPort := freeDoctorTCPPort(t)
-	t.Setenv("SWARM_TOOL_GATEWAY_URL", "http://127.0.0.1:"+mcpPort)
-	t.Setenv("SWARM_TOOL_GATEWAY_CONTAINER_URL", "http://host.docker.internal:"+mcpPort)
+	t.Setenv("SWARM_TOOL_GATEWAY_URL", "http://127.0.0.1:"+freeDoctorTCPPort(t))
+	t.Setenv("SWARM_TOOL_GATEWAY_CONTAINER_URL", "")
 	t.Setenv("SWARM_TOOL_GATEWAY_TOKEN", "")
 
-	var out lockedBuffer
-	code := runServeRuntime(context.Background(), repoRoot(), serveOptions{
+	assertRunServeRuntimeRetiredGatewayURLAdmissionFailure(t, "SWARM_TOOL_GATEWAY_URL", serveOptions{
 		ConfigPath:         writeDoctorClaudeConfig(t),
 		Backend:            "claude_cli",
 		ContractsPath:      filepath.Join("tests", "tier8-boot-verification", "test-boot-success"),
@@ -10614,28 +10644,59 @@ func TestRunServeRuntimeNonDevClaudeCLIRetiredGatewayURLEnvFailsClosed(t *testin
 		PlatformSpecPath:   defaultPlatformSpecPath,
 		StoreMode:          "not-a-store",
 		APIListenAddr:      "127.0.0.1:0",
-		MCPListenAddr:      "127.0.0.1:" + mcpPort,
+		MCPListenAddr:      "127.0.0.1:0",
 		SelfCheck:          true,
 		RequireBundleMatch: false,
-		Verbose:            true,
-		Output:             &out,
+		BundleHash:         "bundle-v1:sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
 	})
+}
+
+func TestRunServeRuntimeNonClaudeRetiredGatewayURLEnvFailsBeforeStartupSideEffects(t *testing.T) {
+	isolateCLIAPIConfigEnv(t)
+	t.Setenv("SWARM_TOOL_GATEWAY_URL", "")
+	t.Setenv("SWARM_TOOL_GATEWAY_CONTAINER_URL", "http://host.docker.internal:"+freeDoctorTCPPort(t))
+	t.Setenv("SWARM_TOOL_GATEWAY_TOKEN", "")
+
+	assertRunServeRuntimeRetiredGatewayURLAdmissionFailure(t, "SWARM_TOOL_GATEWAY_CONTAINER_URL", serveOptions{
+		ConfigPath:         writeServeRuntimeTestConfig(t),
+		Backend:            "anthropic",
+		ContractsPath:      filepath.Join("tests", "tier8-boot-verification", "test-boot-success"),
+		DataSource:         t.TempDir(),
+		PlatformSpecPath:   defaultPlatformSpecPath,
+		StoreMode:          "not-a-store",
+		APIListenAddr:      "127.0.0.1:0",
+		MCPListenAddr:      "127.0.0.1:0",
+		SelfCheck:          true,
+		RequireBundleMatch: false,
+	})
+}
+
+func assertRunServeRuntimeRetiredGatewayURLAdmissionFailure(t *testing.T, envName string, opts serveOptions) {
+	t.Helper()
+	var out lockedBuffer
+	opts.Verbose = true
+	opts.Output = &out
+	code := runServeRuntime(context.Background(), repoRoot(), opts)
 	if code != cliExitRuntime {
 		t.Fatalf("runServeRuntime code = %d, want %d\noutput:\n%s", code, cliExitRuntime, out.String())
 	}
 	for _, want := range []string{
-		"local_preflight",
-		"swarm_tool_gateway_url_retired",
-		"swarm_tool_gateway_container_url_retired",
+		"config_load",
+		"serve_admission",
+		envName,
+		"retired",
+		"unset " + envName,
+		"ToolGatewayBinding",
 		"non-dev serve rejects retired gateway URL env",
-		"ToolGatewayBinding owns endpoint configuration",
 	} {
 		if !strings.Contains(out.String(), want) {
 			t.Fatalf("serve output missing %q:\n%s", want, out.String())
 		}
 	}
-	if strings.Contains(out.String(), "not-a-store") || strings.Contains(out.String(), "db_connection") || strings.Contains(out.String(), "ready") {
-		t.Fatalf("serve reached later startup after retired gateway URL env failure:\n%s", out.String())
+	for _, notWant := range []string{"local_preflight", "not-a-store", "db_connection", "bundle_load", "http_listener_bind", "ready"} {
+		if strings.Contains(out.String(), notWant) {
+			t.Fatalf("serve reached %q after retired gateway URL env failure:\n%s", notWant, out.String())
+		}
 	}
 }
 

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -10930,7 +10930,7 @@ cli_specification:
       - '#996 Docker Compose setup remains split.'
       - '#1568 selected-contract and multi-bundle gateway materialization remains split; #979/#1012 are completed historical source-authority slices and are not active trackers for this open gateway tail.'
       - '#1002 runtime workspace source-root image packaging is closed by PR #1034 and is not an open tail.'
-      - '#1568 broader public URL-env retirement, selected-fork/multi-bundle materialization, and remote transport policy remain split.'
+      - '#1568 selected-fork URL-env side-channel and current public URL-env retirement/admission are closed by local_tool_gateway_binding; broader multi-bundle materialization and remote transport policy remain split.'
     local_tool_gateway_binding:
       promoted_by: '#1568'
       implementation_status: implemented_first_slice
@@ -10939,10 +10939,11 @@ cli_specification:
         Merge-bearing source authority for local `serve` / foreground `run` `claude_cli`
         tool gateway reachability in the approved #1568 first slice. The binding is a typed runtime value
         produced from the actual bound MCP listener before local runtime construction. It closes the local
-        stale URL-env endpoint authority class only for local serve/run. It does not close public URL-env
-        retirement outside local serve/run, broader selected-contract/multi-bundle materialization,
-        host workspace execution, API connection discovery, IPC/unix socket transports, or remote/Kubernetes
-        routing. It also closes the selected-fork ephemeral gateway URL-env side-channel child: any production
+        stale URL-env endpoint authority class for local serve/run. It also closes current public/operator
+        URL-env retirement/admission for non-dev serve and doctor/preflight diagnostics. It does not close
+        broader selected-contract/multi-bundle materialization, host workspace execution, API connection
+        discovery, IPC/unix socket transports, or remote/Kubernetes routing. It also closes the selected-fork
+        ephemeral gateway URL-env side-channel child: any production
         Claude runtime factory constructed for a live ephemeral gateway MUST receive that gateway's typed binding
         instead of depending on ambient URL env, and selected-fork gateway startup MUST NOT mutate process-global
         `SWARM_TOOL_GATEWAY_URL` or `SWARM_TOOL_GATEWAY_CONTAINER_URL`.
@@ -10967,7 +10968,11 @@ cli_specification:
         These variables may survive only as generated final-boundary compatibility for launched host/container
         processes, and only when their values are derived from `ToolGatewayBinding`. Selected-fork ephemeral
         gateway startup MUST NOT set, restore, or otherwise use process-global URL env as a propagation channel;
-        stale shell URL env must remain unchanged and non-authoritative.
+        stale shell URL env must remain unchanged and non-authoritative. For current non-dev `swarm serve`,
+        any non-empty `SWARM_TOOL_GATEWAY_URL` or `SWARM_TOOL_GATEWAY_CONTAINER_URL` is a retired public input
+        and MUST fail closed with remediation to unset it, not repoint it at the MCP listener. `swarm doctor`
+        and local preflight may read these variables only to report retired/shadowed diagnostic evidence; matching
+        non-empty URL env MUST NOT be rendered as accepted configuration.
       auth_rule: >
         `SWARM_TOOL_GATEWAY_TOKEN` remains token-only source authority for this first slice. If it is empty,
         serve boot MUST generate a per-boot token and place it on `ToolGatewayBinding`. Runtime gateway auth,
@@ -10986,8 +10991,8 @@ cli_specification:
       - fork-chat sandbox Claude runtime factory as a local serve consumer
       - selected-fork ephemeral gateway Claude runtime factory as regression-guard consumer
       - local `claude_cli` preflight diagnostics as consumer-only stale-env reporter
+      - non-dev serve retired URL-env admission
       split_tail:
-      - '#1568 public/operator URL-env retirement outside local serve/run remains split.'
       - '#1568 token-source migration beyond token-only env remains split.'
       - '#1568 broader selected-contract and multi-bundle gateway materialization remains split; selected-fork ephemeral gateway startup no longer uses process-global URL env as a propagation side channel, but broader multi-bundle materialization remains open. #979/#1012 are completed historical source-authority slices and are not active trackers for this open gateway tail.'
       - '#1138/#1213 host workspace `claude_cli` execution remains split.'


### PR DESCRIPTION
Part of #1568

## Summary

This PR closes the approved #1568 child slice for public/operator gateway URL env retirement:

- `SWARM_TOOL_GATEWAY_URL` and `SWARM_TOOL_GATEWAY_CONTAINER_URL` are no longer accepted as valid non-dev serve endpoint configuration, even when they match the MCP port.
- `swarm doctor` / local preflight now reports any non-empty URL env as retired/shadowed diagnostic evidence instead of rendering matching values as OK.
- Local `serve --dev`, foreground `run`, selected-fork gateway startup, token-only behavior, and binding-derived Docker/process env injection remain unchanged.

## Governing Refs / Context

- #1568 Pre-Implementation Coverage Audit: https://github.com/division-sh/swarm/issues/1568#issuecomment-4858461609
- #1568 independent gate: https://github.com/division-sh/swarm/issues/1568#issuecomment-4858484837
- `platform-spec.yaml#cli_specification.foundations.local_tool_gateway_binding`
- `platform-spec.yaml#cli_specification.foundations.local_cli_test_gateway_startup`
- `platform-spec.yaml#cli_specification.foundations.local_claude_cli_preflight_admission`
- `platform-spec.yaml#cli_specification.command_catalog.serve.listener_topology_v2_1`

Current master does not contain `docs/IMPLEMENTER_GUIDELINES.md` or `docs/SEMANTIC_DRIFT.md`; I used the latest available sibling-worktree copies as process guidance and treated the issue gate plus `platform-spec.yaml` as binding authority.

## Semantic Migration

- New canonical owner: `platform-spec.yaml#cli_specification.foundations.local_tool_gateway_binding` owns URL-env retirement/admission semantics for current serve/preflight surfaces.
- Old producer / reader / writer path now invalid: `validateExistingServeGatewayURL`, the URL host/port parser, and preflight `*_shadowed_or_empty` OK rendering for matching non-empty URL env.
- Production paths checked for surviving old behavior: non-dev `swarm serve` admission, local preflight/doctor diagnostics, local dev/run typed binding proof, selected-fork typed binding proof, and `internal/runtime/llm` binding-derived final-boundary env injection.
- Migration completeness: complete for current public/operator URL-env admission and diagnostics. Full #1568 remains open for token-source migration, broader multi-bundle materialization, #1567 API discovery, #1576 IPC/unix-socket transport, #1138/#1213 host execution, and remote/Kubernetes routing.

## Verification

Focused/touched proof:

- `go test ./cmd/swarm -run 'TestRunServeRuntimeNonDevClaudeCLIRetiredGatewayURLEnvFailsClosed|TestValidateServeGatewayURLEnvForNonDevRejectsAnyRetiredURLEnv|TestDoctorClaudeCLIPreflightWarnsOnRetiredGatewayEnv|TestRunServeRuntimeDevClaudeCLIStaleGatewayEnvUsesTypedBinding|TestStartLocalRunServeClaudeCLIStaleGatewayEnvUsesTypedBinding|TestPlatformSpecLocalToolGatewayBindingPromoted|TestPlatformSpecLocalCLITestGatewayStartupPromoted|TestPlatformSpecLocalClaudeCLIPreflightAdmissionPromoted' -count=1`
- `go test ./internal/runtime/llm -run 'TestClaudeCLIRuntimeBuildCommand_UsesContainerReachableMCPGatewayURL|TestValidateClaudeCLIRuntimeConfig_RequiresToolGatewayBinding' -count=1`
- `go test ./internal/runtime/runforkexecution -run 'TestStartSelectedContractAgentRuntimeGatewayReturnsGeneratedBinding|TestStartSelectedContractAgentRuntimeGatewayUsesExplicitTokenWithoutURLMutation|TestStartSelectedContractAgentRuntimeCleansGatewayOnRegistrationFailure' -count=1`
- `go test ./cmd/swarm`
- `go test ./internal/runtime/llm`
- `go test ./internal/runtime/runforkexecution`

Full-suite proof:

- Initial `go test ./...` failed under concurrent machine-wide test load with timeout/convergence failures in unrelated packages.
- Reran failed packages individually: `go test ./internal/apiv1`, `go test ./internal/runtime`, `go test ./internal/runtime/cataloge2e`, `go test ./internal/testutil` all passed.
- Clean rerun with no other Go test processes active: `go test ./...` passed.