### PR TITLE
[agent-c][issue #1534] Align boot timer startup semantics

### DIFF
--- a/cmd/swarm/main_test.go
+++ b/cmd/swarm/main_test.go
@@ -9057,6 +9057,42 @@ reader:
 	}
 }
 
+func TestRunVerifyCommand_AllowsBootTimerWithoutCancelOn(t *testing.T) {
+	root := writeVerifyBootTimerCommandFixture(t, "")
+
+	var stdout, stderr bytes.Buffer
+	code := runVerifyCommandWithContractsOutputForTest(context.Background(), repoRoot(), root, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("runVerifyCommand exit code = %d, stdout = %q stderr = %q", code, stdout.String(), stderr.String())
+	}
+	if out := stdout.String(); !strings.Contains(out, "verify ok: contracts=") {
+		t.Fatalf("verify stdout missing success marker:\n%s", out)
+	}
+}
+
+func TestRunVerifyCommand_RejectsBootTimerWithCancelOn(t *testing.T) {
+	root := writeVerifyBootTimerCommandFixture(t, "state:done")
+
+	var stdout, stderr bytes.Buffer
+	code := runVerifyCommandWithContractsOutputForTest(context.Background(), repoRoot(), root, &stdout, &stderr)
+	if code == 0 {
+		t.Fatalf("runVerifyCommand exit code = 0, stdout = %q stderr = %q", stdout.String(), stderr.String())
+	}
+	if strings.TrimSpace(stdout.String()) != "" {
+		t.Fatalf("verify stdout = %q, want empty for hard invalidity", stdout.String())
+	}
+	errText := stderr.String()
+	for _, want := range []string{
+		"verify failed: boot verification failed:",
+		"ERROR: timer_validation",
+		"start_on boot does not support cancel_on state:done",
+	} {
+		if !strings.Contains(errText, want) {
+			t.Fatalf("verify stderr missing %q:\n%s", want, errText)
+		}
+	}
+}
+
 func TestRunVerifyCommand_EscalatedWarningUsesBlockingAnalyzerOutput(t *testing.T) {
 	t.Setenv("SWARM_BOOT_WARNINGS_FATAL", "true")
 
@@ -9087,6 +9123,57 @@ func TestRunVerifyCommand_EscalatedWarningUsesBlockingAnalyzerOutput(t *testing.
 	if strings.Contains(errText, "boot verification warnings:") {
 		t.Fatalf("verify stderr used legacy fatal warning banner:\n%s", errText)
 	}
+}
+
+func writeVerifyBootTimerCommandFixture(t *testing.T, cancelOn string) string {
+	t.Helper()
+	root := t.TempDir()
+	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "package.yaml"), `
+name: verify-boot-timer
+version: "1.0.0"
+platform: ">=1.6.0"
+flows: []
+`)
+	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "schema.yaml"), `
+name: verify-boot-timer
+initial_state: waiting
+terminal_states: [done]
+states: [waiting, done]
+`)
+	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "policy.yaml"), `{}`)
+	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "tools.yaml"), `{}`)
+	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "agents.yaml"), `{}`)
+	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "entities.yaml"), `
+ticket:
+  ticket_id:
+    type: string
+    initial: ""
+`)
+	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "events.yaml"), `
+timer.reminder:
+  entity_id: string
+`)
+	timerBlock := `
+    - id: reminder
+      owner: support-node
+      event: timer.reminder
+      delay: 1m
+      start_on: boot
+`
+	if strings.TrimSpace(cancelOn) != "" {
+		timerBlock += "      cancel_on: " + cancelOn + "\n"
+	}
+	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "nodes.yaml"), `
+support-node:
+  id: support-node
+  execution_type: system_node
+  subscribes_to: [timer.reminder]
+  timers:
+`+timerBlock+`  event_handlers:
+    timer.reminder:
+      advances_to: done
+`)
+	return root
 }
 
 func TestRunVerifyCommand_FirstFlowEquivalentSuppressesTutorialLintEvidence(t *testing.T) {

--- a/internal/runtime/bootverify/report_test.go
+++ b/internal/runtime/bootverify/report_test.go
@@ -5344,6 +5344,36 @@ func TestRun_ReportsErrorForUnknownTimerCancelEvent(t *testing.T) {
 	}
 }
 
+func TestRun_AllowsBootTimerWithoutCancelOn(t *testing.T) {
+	root := writeTimerValidationFixture(t, "boot", "")
+	repoRoot := repoRootForBootverifyTest(t)
+	platformSpec := runtimecontracts.DefaultPlatformSpecFile(repoRoot)
+	report := Run(context.Background(), semanticview.Wrap(loadFixtureBundleAt(t, repoRoot, root, platformSpec)), Options{})
+	if reportContains(report.Errors(), "timer_validation", "timer reminder") {
+		t.Fatalf("unexpected timer_validation error for boot timer without cancel_on, got %#v", report.Errors())
+	}
+}
+
+func TestRun_ReportsErrorForBootTimerCancelOnState(t *testing.T) {
+	root := writeTimerValidationFixture(t, "boot", "state:done")
+	repoRoot := repoRootForBootverifyTest(t)
+	platformSpec := runtimecontracts.DefaultPlatformSpecFile(repoRoot)
+	report := Run(context.Background(), semanticview.Wrap(loadFixtureBundleAt(t, repoRoot, root, platformSpec)), Options{})
+	if !reportContains(report.Errors(), "timer_validation", "start_on boot does not support cancel_on state:done") {
+		t.Fatalf("expected timer_validation boot cancel_on state error, got %#v", report.Errors())
+	}
+}
+
+func TestRun_ReportsErrorForBootTimerCancelOnEvent(t *testing.T) {
+	root := writeTimerValidationFixture(t, "boot", "event:ticket.closed")
+	repoRoot := repoRootForBootverifyTest(t)
+	platformSpec := runtimecontracts.DefaultPlatformSpecFile(repoRoot)
+	report := Run(context.Background(), semanticview.Wrap(loadFixtureBundleAt(t, repoRoot, root, platformSpec)), Options{})
+	if !reportContains(report.Errors(), "timer_validation", "start_on boot does not support cancel_on event:ticket.closed") {
+		t.Fatalf("expected timer_validation boot cancel_on event error, got %#v", report.Errors())
+	}
+}
+
 func TestRun_AllowsTimerCancelStateReachableFromStartStateContext(t *testing.T) {
 	root := writeTimerStateCancelReachabilityFixture(t, timerStateCancelReachabilityFixtureOptions{
 		startOn:          "state:active",

--- a/internal/runtime/bootverify/workflow_timer_checks.go
+++ b/internal/runtime/bootverify/workflow_timer_checks.go
@@ -69,6 +69,13 @@ func (c *checkerContext) timerValidation() []Finding {
 				Message:  fmt.Sprintf("timer %s cancel_on %q is invalid: %v", timer.ID, timer.CancelOn, err),
 				Location: strings.TrimSpace(timer.ID),
 			})
+		} else if startTrigger.IsBoot() && cancelTrigger.Valid() {
+			c.timerFindings = append(c.timerFindings, Finding{
+				CheckID:  "timer_validation",
+				Severity: "error",
+				Message:  fmt.Sprintf("timer %s start_on boot does not support cancel_on %s", timer.ID, cancelTrigger.String()),
+				Location: strings.TrimSpace(timer.ID),
+			})
 		} else {
 			c.validateTimerTrigger(timer, "cancel_on", cancelTrigger)
 		}

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"log/slog"
 	"os"
+	"regexp"
 	"sort"
 	"strings"
 	"sync"
@@ -807,9 +808,9 @@ func (rt *Runtime) Start(ctx context.Context) error {
 				handleRuntimeLogPersistenceError("scheduler", "ensure_lifecycle_failed", rt.Logger.Error(ctx, "scheduler", "ensure_lifecycle_failed", nil, err))
 			}
 		}
-		if err := ensureRecurringWorkflowSchedules(ctx, rt.Stores.ScheduleStore, rt.Scheduler, rt.Pipeline); err != nil {
+		if err := ensureBootWorkflowSchedules(ctx, rt.Stores.ScheduleStore, rt.Scheduler, rt.Pipeline); err != nil {
 			if rt.Logger != nil {
-				handleRuntimeLogPersistenceError("scheduler", "ensure_recurring_failed", rt.Logger.Error(ctx, "scheduler", "ensure_recurring_failed", nil, err))
+				handleRuntimeLogPersistenceError("scheduler", "ensure_boot_timers_failed", rt.Logger.Error(ctx, "scheduler", "ensure_boot_timers_failed", nil, err))
 			}
 		}
 		if startupRecoveryDecision.Outcome != startupRecoveryOutcomeDegraded && startupRecoveryDecision.ScheduleDropCount > 0 {
@@ -1258,7 +1259,9 @@ func (rt *Runtime) verifyBootPublished(ch <-chan events.Event) error {
 	return nil
 }
 
-func ensureRecurringWorkflowSchedules(ctx context.Context, store runtimepipeline.SchedulePersistence, scheduler *runtimepipeline.Scheduler, workflow runtimepipeline.WorkflowRuntime) error {
+var bootWorkflowTimerPolicyPlaceholder = regexp.MustCompile(`\{\{\s*([a-zA-Z0-9_.-]+)\s*\}\}`)
+
+func ensureBootWorkflowSchedules(ctx context.Context, store runtimepipeline.SchedulePersistence, scheduler *runtimepipeline.Scheduler, workflow runtimepipeline.WorkflowRuntime) error {
 	if store == nil || workflow == nil {
 		return nil
 	}
@@ -1266,34 +1269,11 @@ func ensureRecurringWorkflowSchedules(ctx context.Context, store runtimepipeline
 	if source == nil {
 		return nil
 	}
+	now := time.Now().UTC()
 	for _, timer := range source.WorkflowTimers() {
-		if !timer.Recurring {
-			continue
-		}
-		startTrigger, err := timeridentity.ParseStartTrigger(timer.StartOn)
-		if err != nil || !startTrigger.IsBoot() {
-			continue
-		}
-		cancelTrigger, err := timeridentity.ParseCancelTrigger(timer.CancelOn)
-		if err != nil || cancelTrigger.Valid() {
-			continue
-		}
-		owner := strings.TrimSpace(timer.Owner)
-		eventType := strings.TrimSpace(timer.Event)
-		if owner == "" || eventType == "" {
-			continue
-		}
-		cron, ok := recurringWorkflowTimerSpec(timer)
+		sc, ok := bootWorkflowTimerSchedule(source, timer, now)
 		if !ok {
 			continue
-		}
-		sc := runtimepipeline.Schedule{
-			RunID:     runtimecorrelation.RunIDFromContext(ctx),
-			AgentID:   owner,
-			EventType: eventType,
-			Mode:      "cron",
-			Cron:      cron,
-			Payload:   recurringWorkflowTimerPayload(timer),
 		}
 		if err := store.UpsertSchedule(ctx, sc); err != nil {
 			return err
@@ -1303,6 +1283,41 @@ func ensureRecurringWorkflowSchedules(ctx context.Context, store runtimepipeline
 		}
 	}
 	return nil
+}
+
+func bootWorkflowTimerSchedule(source semanticview.Source, timer runtimecontracts.WorkflowTimerContract, now time.Time) (runtimepipeline.Schedule, bool) {
+	startTrigger, err := timeridentity.ParseStartTrigger(timer.StartOn)
+	if err != nil || !startTrigger.IsBoot() {
+		return runtimepipeline.Schedule{}, false
+	}
+	cancelTrigger, err := timeridentity.ParseCancelTrigger(timer.CancelOn)
+	if err != nil || cancelTrigger.Valid() {
+		return runtimepipeline.Schedule{}, false
+	}
+	owner := strings.TrimSpace(timer.Owner)
+	eventType := strings.TrimSpace(timer.Event)
+	if owner == "" || eventType == "" {
+		return runtimepipeline.Schedule{}, false
+	}
+	interval := bootWorkflowTimerDuration(source, timer)
+	if interval <= 0 {
+		return runtimepipeline.Schedule{}, false
+	}
+	handle := timeridentity.WorkflowTimerHandle(timer.ID)
+	sc := runtimepipeline.Schedule{
+		AgentID:   owner,
+		EventType: eventType,
+		Mode:      "once",
+		At:        now.Add(interval),
+		TaskID:    handle.TaskID(),
+		Payload:   workflowTimerPayload(timer),
+	}
+	if timer.Recurring {
+		sc.Mode = "cron"
+		sc.Cron = "@every " + interval.String()
+		sc.At = time.Time{}
+	}
+	return sc, true
 }
 
 func ensureLifecycleWorkflowSchedules(ctx context.Context, store runtimepipeline.SchedulePersistence, scheduler *runtimepipeline.Scheduler, workflow runtimepipeline.WorkflowRuntime) error {
@@ -1356,7 +1371,7 @@ func ensureLifecycleWorkflowSchedules(ctx context.Context, store runtimepipeline
 				EntityID:     entityID,
 				FlowInstance: strings.TrimSpace(instance.StorageRef),
 				TaskID:       timeridentity.WorkflowTimerHandle(timerID).TaskID(),
-				Payload:      recurringWorkflowTimerPayload(timer),
+				Payload:      workflowTimerPayload(timer),
 			}
 			if err := store.UpsertSchedule(ctx, sc); err != nil {
 				return err
@@ -1371,9 +1386,9 @@ func ensureLifecycleWorkflowSchedules(ctx context.Context, store runtimepipeline
 	return nil
 }
 
-func recurringWorkflowTimerSpec(timer runtimecontracts.WorkflowTimerContract) (string, bool) {
+func bootWorkflowTimerDuration(source semanticview.Source, timer runtimecontracts.WorkflowTimerContract) time.Duration {
 	var interval time.Duration
-	if delay := strings.TrimSpace(timer.Delay); delay != "" && !strings.Contains(delay, "{") {
+	if delay := bootWorkflowTimerRenderedDelay(source, timer, timer.Delay); delay != "" && !strings.Contains(delay, "{") {
 		if parsed, err := time.ParseDuration(delay); err == nil && parsed > 0 {
 			interval += parsed
 		}
@@ -1382,13 +1397,29 @@ func recurringWorkflowTimerSpec(timer runtimecontracts.WorkflowTimerContract) (s
 	interval += time.Duration(timer.DelayMinutes) * time.Minute
 	interval += time.Duration(timer.DelayHours) * time.Hour
 	interval += time.Duration(timer.DelayDays) * 24 * time.Hour
-	if interval <= 0 {
-		return "", false
-	}
-	return "@every " + interval.String(), true
+	return interval
 }
 
-func recurringWorkflowTimerPayload(timer runtimecontracts.WorkflowTimerContract) []byte {
+func bootWorkflowTimerRenderedDelay(source semanticview.Source, timer runtimecontracts.WorkflowTimerContract, delay string) string {
+	delay = strings.TrimSpace(delay)
+	if delay == "" || !strings.Contains(delay, "{{") {
+		return delay
+	}
+	flowID := strings.TrimSpace(timer.FlowID)
+	return bootWorkflowTimerPolicyPlaceholder.ReplaceAllStringFunc(delay, func(token string) string {
+		match := bootWorkflowTimerPolicyPlaceholder.FindStringSubmatch(token)
+		if len(match) != 2 {
+			return token
+		}
+		value, ok := semanticview.PolicyValueForFlow(source, flowID, match[1])
+		if !ok || value.Value == nil {
+			return token
+		}
+		return fmt.Sprint(value.Value)
+	})
+}
+
+func workflowTimerPayload(timer runtimecontracts.WorkflowTimerContract) []byte {
 	handle := timeridentity.WorkflowTimerHandle(timer.ID)
 	if !handle.Valid() {
 		return mustJSON(map[string]any{})

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -808,7 +808,7 @@ func (rt *Runtime) Start(ctx context.Context) error {
 				handleRuntimeLogPersistenceError("scheduler", "ensure_lifecycle_failed", rt.Logger.Error(ctx, "scheduler", "ensure_lifecycle_failed", nil, err))
 			}
 		}
-		if err := ensureBootWorkflowSchedules(ctx, rt.Stores.ScheduleStore, rt.Scheduler, rt.Pipeline); err != nil {
+		if err := ensureBootWorkflowSchedules(ctx, rt.Stores.ScheduleStore, rt.Scheduler, rt.Pipeline, schedules); err != nil {
 			if rt.Logger != nil {
 				handleRuntimeLogPersistenceError("scheduler", "ensure_boot_timers_failed", rt.Logger.Error(ctx, "scheduler", "ensure_boot_timers_failed", nil, err))
 			}
@@ -1261,7 +1261,7 @@ func (rt *Runtime) verifyBootPublished(ch <-chan events.Event) error {
 
 var bootWorkflowTimerPolicyPlaceholder = regexp.MustCompile(`\{\{\s*([a-zA-Z0-9_.-]+)\s*\}\}`)
 
-func ensureBootWorkflowSchedules(ctx context.Context, store runtimepipeline.SchedulePersistence, scheduler *runtimepipeline.Scheduler, workflow runtimepipeline.WorkflowRuntime) error {
+func ensureBootWorkflowSchedules(ctx context.Context, store runtimepipeline.SchedulePersistence, scheduler *runtimepipeline.Scheduler, workflow runtimepipeline.WorkflowRuntime, activeSnapshots ...[]runtimepipeline.Schedule) error {
 	if store == nil || workflow == nil {
 		return nil
 	}
@@ -1269,10 +1269,20 @@ func ensureBootWorkflowSchedules(ctx context.Context, store runtimepipeline.Sche
 	if source == nil {
 		return nil
 	}
+	activeSchedules, err := activeScheduleSnapshot(ctx, store, activeSnapshots...)
+	if err != nil {
+		return err
+	}
 	now := time.Now().UTC()
 	for _, timer := range source.WorkflowTimers() {
 		sc, ok := bootWorkflowTimerSchedule(source, timer, now)
 		if !ok {
+			continue
+		}
+		if active, ok := activeScheduleExactMatch(activeSchedules, sc); ok {
+			if _, err := runtimepipeline.ClaimAndRegisterSchedule(ctx, store, scheduler, active); err != nil {
+				return err
+			}
 			continue
 		}
 		if err := store.UpsertSchedule(ctx, sc); err != nil {
@@ -1283,6 +1293,52 @@ func ensureBootWorkflowSchedules(ctx context.Context, store runtimepipeline.Sche
 		}
 	}
 	return nil
+}
+
+func activeScheduleSnapshot(ctx context.Context, store runtimepipeline.SchedulePersistence, snapshots ...[]runtimepipeline.Schedule) ([]runtimepipeline.Schedule, error) {
+	if len(snapshots) > 0 {
+		return append([]runtimepipeline.Schedule(nil), snapshots[0]...), nil
+	}
+	if store == nil {
+		return nil, nil
+	}
+	return store.LoadActiveSchedules(ctx)
+}
+
+func activeScheduleExactMatch(active []runtimepipeline.Schedule, target runtimepipeline.Schedule) (runtimepipeline.Schedule, bool) {
+	normalizeScheduleIdentity(&target)
+	for _, candidate := range active {
+		normalizeScheduleIdentity(&candidate)
+		if strings.TrimSpace(candidate.AgentID) != strings.TrimSpace(target.AgentID) {
+			continue
+		}
+		if strings.TrimSpace(candidate.EventType) != strings.TrimSpace(target.EventType) {
+			continue
+		}
+		if strings.TrimSpace(candidate.TaskID) != strings.TrimSpace(target.TaskID) {
+			continue
+		}
+		if candidate.RunID != target.RunID {
+			continue
+		}
+		if candidate.EntityID != target.EntityID {
+			continue
+		}
+		if candidate.FlowInstance != target.FlowInstance {
+			continue
+		}
+		return candidate, true
+	}
+	return runtimepipeline.Schedule{}, false
+}
+
+func normalizeScheduleIdentity(sc *runtimepipeline.Schedule) {
+	if sc == nil {
+		return
+	}
+	sc.NormalizeRunID()
+	sc.NormalizeEntityID()
+	sc.NormalizeFlowInstance()
 }
 
 func bootWorkflowTimerSchedule(source semanticview.Source, timer runtimecontracts.WorkflowTimerContract, now time.Time) (runtimepipeline.Schedule, bool) {

--- a/internal/runtime/runtime_schedule_test.go
+++ b/internal/runtime/runtime_schedule_test.go
@@ -304,6 +304,70 @@ func TestEnsureBootWorkflowSchedulesRegistersGlobalBootOneShotTimers(t *testing.
 	}
 }
 
+func TestEnsureBootWorkflowSchedulesPreservesActiveExactBootSchedule(t *testing.T) {
+	activeAt := time.Now().UTC().Add(-1 * time.Minute)
+	store := &recordingRuntimeScheduleStore{
+		active: []runtimepipeline.Schedule{{
+			AgentID:   "runtime",
+			EventType: "timer.boot_once",
+			Mode:      "once",
+			At:        activeAt,
+			TaskID:    "boot_once",
+			Payload:   []byte(`{"timer_id":"boot_once"}`),
+		}},
+	}
+	bundle := &runtimecontracts.WorkflowContractBundle{
+		Semantics: runtimecontracts.WorkflowSemanticView{
+			Timers: []runtimecontracts.WorkflowTimerContract{{
+				ID:      "boot_once",
+				Owner:   "runtime",
+				Event:   "timer.boot_once",
+				Delay:   "5s",
+				StartOn: "boot",
+			}},
+		},
+	}
+	if err := ensureBootWorkflowSchedules(context.Background(), store, nil, semanticOnlyWorkflowRuntime{
+		source: semanticview.Wrap(bundle),
+	}); err != nil {
+		t.Fatalf("ensureBootWorkflowSchedules: %v", err)
+	}
+	if len(store.schedules) != 0 {
+		t.Fatalf("startup boot schedule upserts = %#v, want none when active exact schedule already exists", store.schedules)
+	}
+}
+
+func TestEnsureBootWorkflowSchedulesUsesRestoredSnapshotToAvoidRecreatingBootSchedule(t *testing.T) {
+	restored := runtimepipeline.Schedule{
+		AgentID:   "runtime",
+		EventType: "timer.boot_once",
+		Mode:      "once",
+		At:        time.Now().UTC().Add(-1 * time.Minute),
+		TaskID:    "boot_once",
+		Payload:   []byte(`{"timer_id":"boot_once"}`),
+	}
+	store := &recordingRuntimeScheduleStore{}
+	bundle := &runtimecontracts.WorkflowContractBundle{
+		Semantics: runtimecontracts.WorkflowSemanticView{
+			Timers: []runtimecontracts.WorkflowTimerContract{{
+				ID:      "boot_once",
+				Owner:   "runtime",
+				Event:   "timer.boot_once",
+				Delay:   "5s",
+				StartOn: "boot",
+			}},
+		},
+	}
+	if err := ensureBootWorkflowSchedules(context.Background(), store, nil, semanticOnlyWorkflowRuntime{
+		source: semanticview.Wrap(bundle),
+	}, []runtimepipeline.Schedule{restored}); err != nil {
+		t.Fatalf("ensureBootWorkflowSchedules: %v", err)
+	}
+	if len(store.schedules) != 0 {
+		t.Fatalf("startup boot schedule upserts = %#v, want none when restored startup snapshot had exact schedule", store.schedules)
+	}
+}
+
 func TestEnsureBootWorkflowSchedulesRendersPolicyDelayAtStartup(t *testing.T) {
 	store := &recordingRuntimeScheduleStore{}
 	bundle := &runtimecontracts.WorkflowContractBundle{

--- a/internal/runtime/runtime_schedule_test.go
+++ b/internal/runtime/runtime_schedule_test.go
@@ -202,7 +202,7 @@ func (noopLLMRuntime) ContinueSession(context.Context, *llm.Session, llm.Message
 	return &llm.Response{}, nil
 }
 
-func TestEnsureRecurringWorkflowSchedulesSkipsLifecycleScopedRecurringTimers(t *testing.T) {
+func TestEnsureBootWorkflowSchedulesSkipsLifecycleScopedRecurringTimers(t *testing.T) {
 	repoRoot := filepath.Clean(filepath.Join("..", ".."))
 	fixtureRoot := filepath.Join(repoRoot, "tests", "tier5-flow-lifecycle", "test-timer-recurring")
 	platformSpec := runtimecontracts.DefaultPlatformSpecFile(repoRoot)
@@ -211,18 +211,18 @@ func TestEnsureRecurringWorkflowSchedulesSkipsLifecycleScopedRecurringTimers(t *
 		t.Fatalf("load bundle: %v", err)
 	}
 	store := &recordingRuntimeScheduleStore{}
-	err = ensureRecurringWorkflowSchedules(context.Background(), store, nil, semanticOnlyWorkflowRuntime{
+	err = ensureBootWorkflowSchedules(context.Background(), store, nil, semanticOnlyWorkflowRuntime{
 		source: semanticview.Wrap(bundle),
 	})
 	if err != nil {
-		t.Fatalf("ensureRecurringWorkflowSchedules: %v", err)
+		t.Fatalf("ensureBootWorkflowSchedules: %v", err)
 	}
 	if len(store.schedules) != 0 {
 		t.Fatalf("startup recurring schedules = %#v, want none for start_on recurring timers", store.schedules)
 	}
 }
 
-func TestEnsureRecurringWorkflowSchedulesRegistersBootRecurringTimers(t *testing.T) {
+func TestEnsureBootWorkflowSchedulesRegistersGlobalBootRecurringTimers(t *testing.T) {
 	store := &recordingRuntimeScheduleStore{}
 	bundle := &runtimecontracts.WorkflowContractBundle{
 		Semantics: runtimecontracts.WorkflowSemanticView{
@@ -236,17 +236,135 @@ func TestEnsureRecurringWorkflowSchedulesRegistersBootRecurringTimers(t *testing
 			}},
 		},
 	}
-	err := ensureRecurringWorkflowSchedules(context.Background(), store, nil, semanticOnlyWorkflowRuntime{
+	err := ensureBootWorkflowSchedules(context.Background(), store, nil, semanticOnlyWorkflowRuntime{
 		source: semanticview.Wrap(bundle),
 	})
 	if err != nil {
-		t.Fatalf("ensureRecurringWorkflowSchedules: %v", err)
+		t.Fatalf("ensureBootWorkflowSchedules: %v", err)
 	}
 	if len(store.schedules) != 1 {
 		t.Fatalf("startup recurring schedules = %#v, want 1 boot schedule", store.schedules)
 	}
-	if got := store.schedules[0].EventType; got != "timer.daily_report" {
+	sc := store.schedules[0]
+	if got := sc.EventType; got != "timer.daily_report" {
 		t.Fatalf("scheduled event = %q, want timer.daily_report", got)
+	}
+	if got := sc.Mode; got != "cron" {
+		t.Fatalf("schedule mode = %q, want cron", got)
+	}
+	if got := sc.Cron; got != "@every 24h0m0s" {
+		t.Fatalf("schedule cron = %q, want @every 24h0m0s", got)
+	}
+	if !sc.At.IsZero() {
+		t.Fatalf("recurring boot schedule At = %v, want zero", sc.At)
+	}
+	if sc.RunID != "" || sc.EntityID != "" || sc.FlowInstance != "" {
+		t.Fatalf("boot recurring schedule scope = run:%q entity:%q flow:%q, want global", sc.RunID, sc.EntityID, sc.FlowInstance)
+	}
+	if got := sc.TaskID; got != "daily_report" {
+		t.Fatalf("schedule task_id = %q, want daily_report", got)
+	}
+}
+
+func TestEnsureBootWorkflowSchedulesRegistersGlobalBootOneShotTimers(t *testing.T) {
+	store := &recordingRuntimeScheduleStore{}
+	bundle := &runtimecontracts.WorkflowContractBundle{
+		Semantics: runtimecontracts.WorkflowSemanticView{
+			Timers: []runtimecontracts.WorkflowTimerContract{{
+				ID:      "boot_once",
+				Owner:   "runtime",
+				Event:   "timer.boot_once",
+				Delay:   "5s",
+				StartOn: "boot",
+			}},
+		},
+	}
+	before := time.Now().UTC()
+	err := ensureBootWorkflowSchedules(context.Background(), store, nil, semanticOnlyWorkflowRuntime{
+		source: semanticview.Wrap(bundle),
+	})
+	if err != nil {
+		t.Fatalf("ensureBootWorkflowSchedules: %v", err)
+	}
+	if len(store.schedules) != 1 {
+		t.Fatalf("startup boot schedules = %#v, want 1 one-shot boot schedule", store.schedules)
+	}
+	sc := store.schedules[0]
+	if got := sc.Mode; got != "once" {
+		t.Fatalf("schedule mode = %q, want once", got)
+	}
+	if sc.At.Before(before.Add(5*time.Second)) || sc.At.After(time.Now().UTC().Add(6*time.Second)) {
+		t.Fatalf("schedule At = %v, want roughly 5s after startup", sc.At)
+	}
+	if sc.RunID != "" || sc.EntityID != "" || sc.FlowInstance != "" {
+		t.Fatalf("boot one-shot schedule scope = run:%q entity:%q flow:%q, want global", sc.RunID, sc.EntityID, sc.FlowInstance)
+	}
+	if got := sc.TaskID; got != "boot_once" {
+		t.Fatalf("schedule task_id = %q, want boot_once", got)
+	}
+}
+
+func TestEnsureBootWorkflowSchedulesRendersPolicyDelayAtStartup(t *testing.T) {
+	store := &recordingRuntimeScheduleStore{}
+	bundle := &runtimecontracts.WorkflowContractBundle{
+		Policy: runtimecontracts.PolicyDocument{Values: map[string]runtimecontracts.PolicyValue{
+			"boot_delay": {Value: "7s"},
+		}},
+		Semantics: runtimecontracts.WorkflowSemanticView{
+			Timers: []runtimecontracts.WorkflowTimerContract{{
+				ID:      "policy_boot",
+				Owner:   "runtime",
+				Event:   "timer.policy_boot",
+				Delay:   "{{boot_delay}}",
+				StartOn: "boot",
+			}},
+		},
+	}
+	before := time.Now().UTC()
+	if err := ensureBootWorkflowSchedules(context.Background(), store, nil, semanticOnlyWorkflowRuntime{
+		source: semanticview.Wrap(bundle),
+	}); err != nil {
+		t.Fatalf("ensureBootWorkflowSchedules: %v", err)
+	}
+	if len(store.schedules) != 1 {
+		t.Fatalf("startup boot schedules = %#v, want 1 policy-backed boot schedule", store.schedules)
+	}
+	if got := store.schedules[0].At; got.Before(before.Add(7*time.Second)) || got.After(time.Now().UTC().Add(8*time.Second)) {
+		t.Fatalf("policy-backed boot schedule At = %v, want roughly 7s after startup", got)
+	}
+}
+
+func TestEnsureBootWorkflowSchedulesSkipsUnsupportedBootCancelTimers(t *testing.T) {
+	store := &recordingRuntimeScheduleStore{}
+	bundle := &runtimecontracts.WorkflowContractBundle{
+		Semantics: runtimecontracts.WorkflowSemanticView{
+			Timers: []runtimecontracts.WorkflowTimerContract{
+				{
+					ID:       "boot_cancel_state",
+					Owner:    "runtime",
+					Event:    "timer.boot_cancel_state",
+					Delay:    "5s",
+					StartOn:  "boot",
+					CancelOn: "state:done",
+				},
+				{
+					ID:       "boot_cancel_event",
+					Owner:    "runtime",
+					Event:    "timer.boot_cancel_event",
+					Delay:    "5s",
+					StartOn:  "boot",
+					CancelOn: "event:cancel.boot",
+				},
+			},
+		},
+	}
+	if err := ensureBootWorkflowSchedules(context.Background(), store, nil, semanticOnlyWorkflowRuntime{
+		source: semanticview.Wrap(bundle),
+	}); err != nil {
+		t.Fatalf("ensureBootWorkflowSchedules: %v", err)
+	}
+	if len(store.schedules) != 0 {
+		t.Fatalf("unsupported boot-cancel schedules = %#v, want none", store.schedules)
 	}
 }
 

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -4024,26 +4024,34 @@ engine:
         recurring: Boolean — if true, timer re-fires at the interval until cancelled
         start_on: Trigger that starts the timer. Canonical forms are state:<name>, event:<name>, or boot.
         cancel_on: Trigger that cancels the timer. Canonical forms are state:<name> or event:<name>. boot is invalid.
+          cancel_on is invalid when start_on is boot until the platform defines an explicit global boot-timer cancellation
+          primitive.
       trigger_forms:
         state: "state:<name> starts or cancels when the entity enters the named state"
         event: "event:<name> starts or cancels when the named event fires for the entity"
-        boot: "start_on: boot starts a timer at platform boot. This form is only valid on start_on."
+        boot: "start_on: boot starts a global schedule at platform boot. This form is only valid on start_on."
       invalid_forms:
       - "Unprefixed trigger values are boot errors. The platform does not infer state-vs-event intent from bare strings."
       - "Prefixes other than state: and event: are boot errors."
     lifecycle:
     - 1. Timer starts when the entity enters the start_on state, the start_on event fires, or start_on is boot and platform startup schedules it.
-    - 2. Platform renders the timer delay at start time and persists the timer (entity_id, timer_id, fire_at timestamp).
-      Active timers keep the persisted fire_at value; later policy/config changes do not rewrite already scheduled timers unless
-      a separate explicit reschedule primitive is defined.
+    - 2. Platform renders the timer delay at start time and persists the timer. State/event timers persist run/entity or
+      flow scope plus fire_at. Boot-start timers persist as global schedules with entity_id, flow_instance, and run_id NULL.
+      Non-recurring boot timers persist a one-shot fire_at. Recurring boot timers persist the recurring schedule interval.
+      Active timers keep the persisted fire_at or recurrence value; later policy/config changes do not rewrite already scheduled
+      timers unless a separate explicit reschedule primitive is defined.
     - 3. When fire_at is reached, platform emits the timer event into the event loop.
     - 4. Timer event is a regular event — routed to subscribers, processed by handlers.
-    - 5. If cancel_on state is reached or cancel_on event fires before fire_at, timer is cancelled.
+    - 5. If cancel_on state is reached or cancel_on event fires before fire_at, timer is cancelled. cancel_on is invalid
+      for start_on boot timers until an explicit global cancellation primitive is specified.
     - 6. Recurring timers restart after firing unless cancelled.
     crash_recovery: Timers are persisted. On restart, platform checks for expired timers and fires them.
     boot_validation:
       start_on: start_on must match state:<name>, event:<name>, or boot. Any other form is a boot error.
       cancel_on: cancel_on must match state:<name> or event:<name>. boot is not valid.
+      boot_start: start_on boot creates a global startup schedule. Recurring and non-recurring boot timers are valid only
+        when cancel_on is absent. A boot-start timer with cancel_on is a boot error because no entity/run-scoped cancellation
+        context exists for that global schedule.
       state_reference: state:<name> must reference a declared flow state. Unknown state is a boot error.
       event_reference: event:<name> must reference an event in the flow or platform catalog and must have an authored producer
         path, platform producer, or explicit external source. Unknown or inert event triggers are boot errors.
@@ -7016,13 +7024,15 @@ platform_tables:
       description: 'Durable timer and scheduled task store. Persisted across restarts. Run-scoped timers carry run_id and
         are claimed, fired, cancelled, and recovered under that run identity. Entity-scoped timers: entity_id and
         flow_instance set, tied to a specific entity lifecycle inside run_id. Global timers: entity_id, flow_instance,
-        and run_id NULL, used for recurring platform-level work (periodic scans, health checks, digest compilation).
+        and run_id NULL, used for boot-start workflow timers and platform-level work (periodic scans, health checks,
+        digest compilation).
         fire_payload carries context when the timer fires. owner_node OR owner_agent identifies who declared the timer
         (mutually exclusive). source_timer_id, forked_from_run_id, forked_from_event_id, and reconstruction_owner are
         lineage-only fields for fork-local reconstructed timers and must not make the source timer executable fork truth.
         recurrence_cron supports cron expressions for global recurring schedules. recurrence_interval supports duration
-        strings (e.g., "24h") for entity-scoped recurring timers. task_type: timer (one-shot entity), scheduled_task
-        (recurring entity), deadline (hard cutoff), global_recurring (platform-level periodic work).'
+        strings (e.g., "24h") for entity-scoped recurring timers. task_type: timer (one-shot schedule, including global
+        non-recurring boot timers), scheduled_task (recurring entity), deadline (hard cutoff), global_recurring
+        (global recurring work).'
       ddl: "CREATE TABLE timers (\n    timer_id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),\n    timer_name     \
         \   TEXT NOT NULL,\n    run_id            UUID REFERENCES runs(run_id),\n    source_timer_id   UUID REFERENCES timers(timer_id),\n\
         \    forked_from_run_id UUID REFERENCES runs(run_id),\n    forked_from_event_id UUID REFERENCES events(event_id),\n\


### PR DESCRIPTION
## Summary

- Defines the `start_on: boot` workflow timer contract in `platform-spec.yaml`: boot timers create global startup schedules, recurring and non-recurring boot timers are valid only without `cancel_on`, and boot `cancel_on` is fail-closed until an explicit global cancellation primitive exists.
- Updates `timer_validation` to reject boot-start timers that declare `cancel_on`.
- Generalizes runtime startup scheduling from recurring-only boot timers to all spec-valid boot timers, including one-shot global schedules and policy-rendered startup delays.

Part of #1534

## Governing Refs / Context

Exact governing spec sections updated in this PR:

- `platform-spec.yaml#engine.timer_model.lifecycle`
- `platform-spec.yaml#engine.timer_model.boot_validation`
- `platform-spec.yaml#platform_tables.timers.scope_rules`

Binding issue/gate context:

- #1534 issue body/thread
- Pre-Implementation Coverage Audit: https://github.com/division-sh/swarm/issues/1534#issuecomment-4858652605
- Gate outcome: https://github.com/division-sh/swarm/issues/1534#issuecomment-4860380152

## Semantic Migration

- New canonical contract owner: `platform-spec.yaml#engine.timer_model.boot_validation`, consumed by `internal/runtime/bootverify.timer_validation` and runtime startup boot scheduling.
- Runtime startup owner: `internal/runtime/runtime.go#ensureBootWorkflowSchedules`.
- Old path now invalid: treating `ensureRecurringWorkflowSchedules` / `timer.Recurring == true` as the authored boot-timer contract boundary.
- Old reader/writer behavior now invalid: silently skipping spec-valid non-recurring boot timers at runtime startup.
- Old validation behavior now invalid: accepting `start_on: boot` with `cancel_on` and leaving runtime to skip it.
- Production paths checked for surviving old behavior: bootverify timer validation, runtime startup schedule registration, state/event workflow timer lifecycle, persisted schedule restoration, generic schedule store/scheduler surfaces.
- Migration complete for the approved chosen class `workflow_timer_boot_start_global_schedule_semantics`; active timer reschedule/refresh remains split under #1534.

## Tests

- `go test ./internal/runtime -run 'EnsureBootWorkflowSchedules|NewRuntime_SchedulerMarksSchedulesFiredThroughCanonicalTerminalHelper|Runtime_StartRestoresExactSchedulesDistinctByFlowInstance' -count=1`
- `go test ./internal/runtime/bootverify -run 'Timer|BootTimer|StateMachine|Reachability' -count=1`
- `go test ./internal/runtime/pipeline -run 'Timer|WorkflowTimer' -count=1`
- `go test ./cmd/swarm -run 'RunVerifyCommand_.*BootTimer' -count=1`
- `go test ./...`