### PR TITLE
[agent-b][issue #1568] Fail closed multi-context Claude gateway serve

### DIFF
--- a/cmd/swarm/main.go
+++ b/cmd/swarm/main.go
@@ -856,6 +856,11 @@ func runServeRuntime(ctx context.Context, repo string, opts serveOptions) int {
 	source := loadedBundle.source
 	resolvedPlatformSpecPath := loadedBundle.platformSpecPath
 	reporter.emit(4, "bundle_load", "ok", serveBootBundleLoadDetail(serveRuntimeBundleIdentitiesDetail(loadedBundles), source))
+	if err := validateServeMultiContextToolGatewayAdmission(cfg, loadedBundles); err != nil {
+		reporter.emit(5, "runtime_context", "FAILED", err.Error())
+		log.Printf("validate multi-context tool gateway admission: %v", err)
+		return 3
+	}
 	stateStoreSummaries := make([]string, len(loadedBundles))
 	if stores.SchemaBootstrapper != nil {
 		summaries, err := initializeLoadedServeRuntimeStateStores(ctx, stores, loadedBundles, opts.Verbose)
@@ -3180,6 +3185,23 @@ func createServeToolGatewayBinding(mcpAddr net.Addr) (toolgateway.Binding, error
 		return toolgateway.Binding{}, err
 	}
 	return binding, nil
+}
+
+func validateServeMultiContextToolGatewayAdmission(cfg *config.Config, loadedBundles []serveRuntimeBundle) error {
+	if len(loadedBundles) <= 1 {
+		return nil
+	}
+	if cfg == nil {
+		return fmt.Errorf("runtime config is required for multi-context tool gateway admission")
+	}
+	profile, err := cfg.LLMBackendProfile()
+	if err != nil {
+		return fmt.Errorf("resolve llm backend for multi-context tool gateway admission: %w", err)
+	}
+	if profile.ID != llmselection.BackendClaudeCLI {
+		return nil
+	}
+	return fmt.Errorf("multi-context swarm serve --bundle-hash with llm.backend=claude_cli is unsupported by #1568 first-slice source authority: ToolGatewayBinding, MCP /mcp and /tools routes, and forkchat sandbox runtime are single-context until a separately gated context-aware gateway router exists; use one --bundle-hash or a non-claude_cli backend")
 }
 
 var retiredToolGatewayURLEnvNames = []string{"SWARM_TOOL_GATEWAY_URL", "SWARM_TOOL_GATEWAY_CONTAINER_URL"}

--- a/cmd/swarm/main_test.go
+++ b/cmd/swarm/main_test.go
@@ -2484,6 +2484,7 @@ func TestPlatformSpecLocalToolGatewayBindingPromoted(t *testing.T) {
 					SourceRule           string   `yaml:"source_rule"`
 					EndpointEnvRule      string   `yaml:"endpoint_env_rule"`
 					AuthRule             string   `yaml:"auth_rule"`
+					MultiContextRule     string   `yaml:"multi_context_rule"`
 					Consumers            []string `yaml:"consumers"`
 					SplitTail            []string `yaml:"split_tail"`
 				} `yaml:"local_tool_gateway_binding"`
@@ -2530,6 +2531,11 @@ func TestPlatformSpecLocalToolGatewayBindingPromoted(t *testing.T) {
 	for _, want := range []string{"SWARM_TOOL_GATEWAY_TOKEN", "token-only source authority", "per-boot token", "binding token", "Selected-fork ephemeral gateways follow the same token-only rule"} {
 		if !strings.Contains(binding.AuthRule, want) {
 			t.Fatalf("auth rule missing %q:\n%s", want, binding.AuthRule)
+		}
+	}
+	for _, want := range []string{"multi-context", "claude_cli", "ToolGatewayBinding", "MCP `/mcp` and `/tools/`", "forkchat sandbox", "MUST fail closed before readiness", "MUST NOT rely on primary"} {
+		if !strings.Contains(binding.MultiContextRule, want) {
+			t.Fatalf("multi context rule missing %q:\n%s", want, binding.MultiContextRule)
 		}
 	}
 	for _, want := range []string{"serve listener binding", "RuntimeOptions.ToolGatewayBinding", "runtime MCP gateway auth", "ValidateClaudeCLIRuntimeConfig", "MCP HTTP config", "Docker exec", "fork-chat sandbox", "selected-fork ephemeral gateway", "non-dev serve retired URL-env admission"} {
@@ -6348,6 +6354,128 @@ func TestRunServeRuntimeBundleHashMissingFailsBeforeReadiness(t *testing.T) {
 	}
 }
 
+func TestValidateServeMultiContextToolGatewayAdmission(t *testing.T) {
+	claudeCfg := &config.Config{}
+	claudeCfg.LLM.Backend = "claude_cli"
+	anthropicCfg := &config.Config{}
+	anthropicCfg.LLM.Backend = "anthropic"
+	twoContexts := []serveRuntimeBundle{{}, {}}
+
+	tests := []struct {
+		name        string
+		cfg         *config.Config
+		loaded      []serveRuntimeBundle
+		wantErr     string
+		wantDetails bool
+	}{
+		{
+			name:   "single claude context allowed",
+			cfg:    claudeCfg,
+			loaded: []serveRuntimeBundle{{}},
+		},
+		{
+			name:   "multi context non claude backend allowed",
+			cfg:    anthropicCfg,
+			loaded: twoContexts,
+		},
+		{
+			name:        "multi context claude backend fails closed",
+			cfg:         claudeCfg,
+			loaded:      twoContexts,
+			wantErr:     "multi-context swarm serve --bundle-hash with llm.backend=claude_cli is unsupported",
+			wantDetails: true,
+		},
+		{
+			name:    "multi context needs config",
+			cfg:     nil,
+			loaded:  twoContexts,
+			wantErr: "runtime config is required",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateServeMultiContextToolGatewayAdmission(tt.cfg, tt.loaded)
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("validateServeMultiContextToolGatewayAdmission: %v", err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("validateServeMultiContextToolGatewayAdmission err = %v, want %q", err, tt.wantErr)
+			}
+			if tt.wantDetails {
+				for _, want := range []string{"ToolGatewayBinding", "MCP /mcp and /tools routes", "forkchat sandbox runtime", "context-aware gateway router"} {
+					if !strings.Contains(err.Error(), want) {
+						t.Fatalf("admission error missing %q:\n%s", want, err.Error())
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestRunServeRuntimeMultiContextClaudeCLIFailsClosedBeforePrimaryGatewayOrForkchat(t *testing.T) {
+	isolateCLIAPIConfigEnv(t)
+	t.Setenv("SWARM_TOOL_GATEWAY_URL", "")
+	t.Setenv("SWARM_TOOL_GATEWAY_CONTAINER_URL", "")
+	t.Setenv("SWARM_TOOL_GATEWAY_TOKEN", "")
+
+	var workspaceConfigured atomic.Bool
+	_, _, pg := installServeRuntimePostgresTestStores(t, func() serveWorkspaceLifecycle {
+		workspaceConfigured.Store(true)
+		return serveRuntimeWorkspaceStub{}
+	})
+	ctx := context.Background()
+	firstHash := seedServeRuntimeBundleCatalog(t, ctx, pg, filepath.Join("tests", "tier8-boot-verification", "test-boot-success"))
+	secondHash := seedServeRuntimeBundleCatalog(t, ctx, pg, filepath.Join("tests", "tier1-primitives", "test-emits-single"))
+	if firstHash == secondHash {
+		t.Fatalf("test fixtures produced duplicate bundle hash %s", firstHash)
+	}
+
+	var out lockedBuffer
+	code := runServeRuntime(ctx, repoRoot(), serveOptions{
+		ConfigPath:         writeDoctorClaudeConfig(t),
+		Backend:            "claude_cli",
+		BundleHash:         firstHash,
+		BundleHashes:       []string{secondHash},
+		PlatformSpecPath:   defaultPlatformSpecPath,
+		StoreMode:          "postgres",
+		APIListenAddr:      "127.0.0.1:0",
+		MCPListenAddr:      "127.0.0.1:0",
+		SelfCheck:          true,
+		RequireBundleMatch: false,
+		Verbose:            true,
+		Output:             &out,
+	})
+	if code != 3 {
+		t.Fatalf("runServeRuntime code = %d, want 3\noutput:\n%s", code, out.String())
+	}
+	for _, want := range []string{
+		"[4/22] bundle_load",
+		"[5/22] runtime_context",
+		"multi-context swarm serve --bundle-hash",
+		"llm.backend=claude_cli",
+		"ToolGatewayBinding",
+		"MCP /mcp and /tools routes",
+		"forkchat sandbox runtime",
+		"context-aware gateway router",
+	} {
+		if !strings.Contains(out.String(), want) {
+			t.Fatalf("serve output missing %q:\n%s", want, out.String())
+		}
+	}
+	for _, notWant := range []string{"http_listener_bind", "[20/22]", "[22/22]", "ready                      ok", "init forkchat sandbox runtime"} {
+		if strings.Contains(out.String(), notWant) {
+			t.Fatalf("serve reached %q after multi-context claude_cli admission failure:\n%s", notWant, out.String())
+		}
+	}
+	if workspaceConfigured.Load() {
+		t.Fatalf("workspace lifecycle was configured despite fail-closed admission:\n%s", out.String())
+	}
+}
+
 func TestRunServeRuntimeUnavailableBundleStartupRecoveryFailsPersistedMissingBeforeCleanup(t *testing.T) {
 	_, db, _ := installServeRuntimePostgresTestStores(t, func() serveWorkspaceLifecycle {
 		return serveRuntimeWorkspaceStub{}
@@ -9724,6 +9852,31 @@ func loadWorkflowValidationFixtureBundle(t *testing.T, relativeRoot string) *run
 		t.Fatalf("LoadWorkflowContractBundleWithOverrides(%s): %v", fixtureRoot, err)
 	}
 	return bundle
+}
+
+func seedServeRuntimeBundleCatalog(t *testing.T, ctx context.Context, pg *store.PostgresStore, relativeRoot string) string {
+	t.Helper()
+	if pg == nil {
+		t.Fatal("postgres store is required")
+	}
+	if _, err := pg.BindSchemaCapabilities(ctx); err != nil {
+		t.Fatalf("BindSchemaCapabilities: %v", err)
+	}
+	bundle := loadWorkflowValidationFixtureBundle(t, relativeRoot)
+	projection, err := runtimecontracts.BuildBundleCatalogProjection(bundle)
+	if err != nil {
+		t.Fatalf("BuildBundleCatalogProjection(%s): %v", relativeRoot, err)
+	}
+	if _, err := pg.UpsertBundleCatalog(ctx, store.BundleCatalogUpsert{
+		BundleHash:  projection.BundleHash,
+		ContentYAML: projection.ContentYAML,
+		ParsedJSON:  projection.ParsedJSON,
+		DataBlob:    projection.DataBlob,
+		Metadata:    projection.Metadata,
+	}); err != nil {
+		t.Fatalf("UpsertBundleCatalog(%s): %v", relativeRoot, err)
+	}
+	return projection.BundleHash
 }
 
 func loadWorkflowValidationBundleAt(t *testing.T, fixtureRoot string) *runtimecontracts.WorkflowContractBundle {

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -10970,7 +10970,10 @@ cli_specification:
         ephemeral gateway URL-env side-channel child: any production
         Claude runtime factory constructed for a live ephemeral gateway MUST receive that gateway's typed binding
         instead of depending on ambient URL env, and selected-fork gateway startup MUST NOT mutate process-global
-        `SWARM_TOOL_GATEWAY_URL` or `SWARM_TOOL_GATEWAY_CONTAINER_URL`.
+        `SWARM_TOOL_GATEWAY_URL` or `SWARM_TOOL_GATEWAY_CONTAINER_URL`. This owner also closes the #1568
+        fail-closed first slice for DB-loaded multi-context `claude_cli` serve: until a separately gated
+        context-aware gateway router exists, Swarm must not expose hidden primary-only MCP or forkchat gateway
+        behavior in a process with multiple loaded BundleContexts.
       binding_fields:
       - transport
       - host_endpoint
@@ -11003,6 +11006,15 @@ cli_specification:
         startup probes, MCP HTTP config generation, and Docker exec env injection MUST consume the binding token,
         not a later ambient env read. Selected-fork ephemeral gateways follow the same token-only rule: explicit
         `SWARM_TOOL_GATEWAY_TOKEN` may supply the binding token, and absent token generates a typed binding token.
+      multi_context_rule: >
+        In DB-loaded multi-context serve, `claude_cli` tool-gateway and forkchat sandbox materialization are
+        unsupported until a separately gated context-aware gateway router and forkchat runtime selector exist.
+        If more than one BundleContext is boot-pinned and the selected LLM backend is `claude_cli`, serve MUST
+        fail closed before readiness, before MCP `/mcp` and `/tools/` routes are exposed, and before the forkchat
+        sandbox Claude runtime can be exposed through the API. The implementation MUST NOT rely on primary
+        context `ToolGatewayBinding`, primary `rt.ToolGateway`, primary workspace resolver, or primary forkchat
+        sandbox runtime construction as implicit semantic policy. RuntimeContextManager API routing remains
+        adjacent and does not prove MCP/tool-gateway/forkchat routing is context-aware.
       consumers:
       - '`cmd/swarm` serve listener binding'
       - 'local foreground `swarm run` through the serve startup owner'
@@ -11013,12 +11025,13 @@ cli_specification:
       - Claude CLI MCP HTTP config generation
       - Claude CLI Docker exec final-boundary env injection
       - fork-chat sandbox Claude runtime factory as a local serve consumer
+      - multi-context serve admission for unsupported `claude_cli` tool-gateway and forkchat materialization
       - selected-fork ephemeral gateway Claude runtime factory as regression-guard consumer
       - local `claude_cli` preflight diagnostics as consumer-only stale-env reporter
       - non-dev serve retired URL-env admission
       split_tail:
       - '#1568 token-source migration beyond token-only env remains split.'
-      - '#1568 broader selected-contract and multi-bundle gateway materialization remains split; selected-fork ephemeral gateway startup no longer uses process-global URL env as a propagation side channel, but broader multi-bundle materialization remains open. #979/#1012 are completed historical source-authority slices and are not active trackers for this open gateway tail.'
+      - '#1568 broader selected-contract and multi-bundle gateway materialization remains split; selected-fork ephemeral gateway startup no longer uses process-global URL env as a propagation side channel, and DB-loaded multi-context claude_cli gateway/forkchat ambiguity now fails closed, but full context-aware MCP/forkchat routing remains open. #979/#1012 are completed historical source-authority slices and are not active trackers for this open gateway tail.'
       - '#1138/#1213 host workspace `claude_cli` execution remains split.'
       - '#1567 API connection discovery and connection-file authority remain split.'
       - 'IPC/unix socket transports and remote/Kubernetes routing remain split.'


### PR DESCRIPTION
## Summary

Part of #1568.

This PR implements the approved first slice from the #1568 gate: DB-loaded multi-context `swarm serve --bundle-hash ... --bundle-hash ...` with `llm.backend=claude_cli` now fails closed before readiness instead of silently exposing primary-only tool-gateway and forkchat materialization.

The change adds a source-backed admission check after bundle loading and before state-store bootstrap, runtime-context construction, MCP `/mcp` and `/tools/` route exposure, and forkchat sandbox runtime construction. It also promotes the unsupported multi-context policy into `platform-spec.yaml`.

## Governing Refs / Context

- `platform-spec.yaml#cli_specification.foundations.local_tool_gateway_binding`
- `platform-spec.yaml#cli_specification.foundations.local_cli_test_gateway_startup`
- `platform-spec.yaml#cli_specification.foundations.serve_db_loaded_runtime_source`
- `platform-spec.yaml#cli_specification.command_catalog.serve.listener_topology_v2_1`
- Gate: https://github.com/division-sh/swarm/issues/1568#issuecomment-4861589752
- Repaired pre-audit: https://github.com/division-sh/swarm/issues/1568#issuecomment-4861566537

## Semantic Migration

New canonical owner: `platform-spec.yaml#cli_specification.foundations.local_tool_gateway_binding.multi_context_rule`.

Old non-authoritative paths now invalid for this slice:

- implicit `i == 0` runtime-context policy as the semantic owner for multi-context `claude_cli` gateway support
- primary `rt.ToolGateway` as proof that secondary BundleContexts can use `/mcp` or `/tools/`
- primary `buildForkChatSandboxLLMRuntime(...)` as proof that forkchat sandbox Claude runtime selection is context-aware

Production paths checked:

- serve bundle-load admission before runtime-context/state/listener/forkchat exposure
- runtime context construction and `EnableToolGateway: i == 0` remains unreachable for unsupported multi-context `claude_cli`
- MCP `/mcp` and `/tools/` route ownership remains primary-only but is no longer exposed in unsupported multi-context `claude_cli`
- forkchat sandbox runtime construction is not reached for unsupported multi-context `claude_cli`
- RuntimeContextManager API routing remains adjacent, not proof of MCP/tool-gateway/forkchat routing

Migration is complete for the approved fail-closed first slice only. Full context-aware MCP routing, context-aware forkchat runtime selection, token-source migration, IPC transport, host execution, API discovery, and full #1568 closure remain explicitly out of scope.

## Validation

- `go test ./cmd/swarm -run 'TestValidateServeMultiContextToolGatewayAdmission|TestRunServeRuntimeMultiContextClaudeCLIFailsClosedBeforePrimaryGatewayOrForkchat|TestPlatformSpecLocalToolGatewayBindingPromoted|TestRunServeRuntimeDevClaudeCLIStaleGatewayEnvUsesTypedBinding|TestStartLocalRunServeClaudeCLIStaleGatewayEnvUsesTypedBinding|TestRunServeRuntimeNonDevClaudeCLIRetiredGatewayURLEnvFailsClosed|TestRunServeRuntimeBundleHashRetiredGatewayURLEnvFailsBeforeStartupSideEffects|TestCreateServeToolGatewayBinding' -count=1`
- `go test ./internal/runtime -run 'TestRuntimeContextManager|TestValidateClaude|Test.*ToolGateway|Test.*Claude.*Startup' -count=1`
- `go test ./internal/runtime/llm -run 'Test.*ToolGateway|Test.*MCP|Test.*Docker|TestValidateClaudeCLIRuntimeConfig|TestClaude.*Startup|Test.*Final' -count=1`
- `go test ./internal/runtime/runforkexecution -run 'Test.*ToolGateway|Test.*Selected.*Gateway|Test.*Fork.*Gateway|Test.*URL' -count=1`
- `go test ./cmd/swarm -run 'TestValidateServeMultiContextToolGatewayAdmission|TestRunServeRuntimeMultiContextClaudeCLIFailsClosedBeforePrimaryGatewayOrForkchat|TestPlatformSpecLocalToolGatewayBindingPromoted' -count=1`
- `git diff --check`
- `go test ./...`