### PR TITLE
[agent-a][issue #1447] Add batch agent coordinator pilot

### DIFF
--- a/internal/runtime/batch_agent_runner.go
+++ b/internal/runtime/batch_agent_runner.go
@@ -1,0 +1,137 @@
+package runtime
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
+	runtimeactors "github.com/division-sh/swarm/internal/runtime/core/actors"
+	runtimeengine "github.com/division-sh/swarm/internal/runtime/engine"
+	runtimellm "github.com/division-sh/swarm/internal/runtime/llm"
+	"github.com/division-sh/swarm/internal/runtime/semanticview"
+)
+
+type llmBatchAgentRunner struct {
+	modelRuntime   runtimellm.Runtime
+	source         semanticview.Source
+	promptResolver runtimecontracts.PromptResolver
+}
+
+func newLLMBatchAgentRunner(modelRuntime runtimellm.Runtime, source semanticview.Source, promptResolver runtimecontracts.PromptResolver) runtimeengine.BatchAgentRunner {
+	return llmBatchAgentRunner{
+		modelRuntime:   modelRuntime,
+		source:         source,
+		promptResolver: promptResolver,
+	}
+}
+
+func (r llmBatchAgentRunner) InvokeBatchAgent(ctx context.Context, req runtimeengine.BatchAgentRequest) (runtimeengine.BatchAgentResponse, error) {
+	if r.modelRuntime == nil {
+		return runtimeengine.BatchAgentResponse{}, fmt.Errorf("batch_agent runner requires an llm runtime")
+	}
+	agentID := strings.TrimSpace(req.Agent)
+	if agentID == "" {
+		return runtimeengine.BatchAgentResponse{}, fmt.Errorf("batch_agent.agent is required")
+	}
+	entry, ok := semanticview.FindAgentEntry(r.source, agentID, agentID)
+	if !ok {
+		return runtimeengine.BatchAgentResponse{}, fmt.Errorf("batch_agent agent %q not found", agentID)
+	}
+	cfg := batchAgentConfig(agentID, entry)
+	prompt, found, err := batchAgentPrompt(r.promptResolver, cfg)
+	if err != nil {
+		return runtimeengine.BatchAgentResponse{}, err
+	}
+	if !found {
+		prompt = defaultBatchAgentPrompt()
+	}
+	maxTurns := cfg.MaxTurnsPerTask
+	if maxTurns <= 0 {
+		maxTurns = 1
+	}
+	taskID := strings.Join(nonEmptyBatchAgentStrings("batch_agent", req.FlowID, req.NodeID, agentID), ":")
+	conv := runtimellm.NewConversation(cfg.ID, taskID, prompt, nil, runtimellm.TaskScoped, maxTurns, r.modelRuntime)
+	requestPayload := map[string]any{
+		"operation": "batch_agent",
+		"flow_id":   strings.TrimSpace(req.FlowID),
+		"node_id":   strings.TrimSpace(req.NodeID),
+		"agent":     agentID,
+		"items":     req.Items,
+		"input":     req.Input,
+		"result_contract": map[string]any{
+			"items_from":      req.ResultItemsFrom,
+			"correlation_key": req.CorrelationKey,
+			"required_fields": req.RequiredFields,
+		},
+	}
+	encoded, err := json.Marshal(requestPayload)
+	if err != nil {
+		return runtimeengine.BatchAgentResponse{}, err
+	}
+	resp, err := conv.Step(ctx, string(encoded))
+	if err != nil {
+		return runtimeengine.BatchAgentResponse{}, err
+	}
+	var decoded any
+	if err := json.Unmarshal([]byte(strings.TrimSpace(resp.Message.Content)), &decoded); err != nil {
+		return runtimeengine.BatchAgentResponse{}, fmt.Errorf("batch_agent agent %q returned non-json output: %w", agentID, err)
+	}
+	if _, ok := decoded.(map[string]any); !ok {
+		return runtimeengine.BatchAgentResponse{}, fmt.Errorf("batch_agent agent %q must return a JSON object", agentID)
+	}
+	return runtimeengine.BatchAgentResponse{Output: decoded}, nil
+}
+
+func batchAgentConfig(agentID string, entry runtimecontracts.AgentRegistryEntry) runtimeactors.AgentConfig {
+	cfg := runtimeactors.AgentConfig{
+		ID:              firstBatchAgentNonEmptyString(strings.TrimSpace(entry.ID), agentID),
+		Type:            strings.TrimSpace(entry.Type),
+		Role:            firstBatchAgentNonEmptyString(strings.TrimSpace(entry.Role), agentID),
+		Mode:            strings.TrimSpace(entry.Mode),
+		Model:           strings.TrimSpace(entry.Model),
+		MaxTurnsPerTask: entry.MaxTurnsPerTask,
+		Tools:           append([]string(nil), entry.Tools...),
+		Permissions:     append([]string(nil), entry.Permissions...),
+		FlowDataAccess:  append([]string(nil), entry.FlowDataAccess...),
+		EmitEvents:      append([]string(nil), entry.EmitEvents...),
+	}
+	cfg.NormalizeRuntimeDescriptor()
+	return cfg
+}
+
+func batchAgentPrompt(resolver runtimecontracts.PromptResolver, cfg runtimeactors.AgentConfig) (string, bool, error) {
+	if resolver == nil {
+		return "", false, nil
+	}
+	return resolver.LoadPromptForAgent(cfg, "")
+}
+
+func defaultBatchAgentPrompt() string {
+	return strings.TrimSpace(`You are executing a swarm batch_agent operation.
+Return one strict JSON object and no markdown.
+The object must contain the result list at the requested result_contract.items_from path.
+Each result row must include the requested result_contract.correlation_key and every requested required field.`)
+}
+
+func nonEmptyBatchAgentStrings(values ...string) []string {
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value != "" {
+			out = append(out, value)
+		}
+	}
+	return out
+}
+
+func firstBatchAgentNonEmptyString(values ...string) string {
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value != "" {
+			return value
+		}
+	}
+	return ""
+}

--- a/internal/runtime/bootverify/workflow_dead_event_schema_checks.go
+++ b/internal/runtime/bootverify/workflow_dead_event_schema_checks.go
@@ -298,9 +298,19 @@ func deadEventHandlerFanOutEmits(handler runtimecontracts.SystemNodeEventHandler
 			out = append(out, emitted)
 		}
 	}
+	if handler.BatchAgent != nil {
+		if emitted := handler.BatchAgent.Emit.EventType(); emitted != "" {
+			out = append(out, emitted)
+		}
+	}
 	for _, rule := range handler.Rules {
 		if rule.FanOut != nil {
 			if emitted := rule.FanOut.Emit.EventType(); emitted != "" {
+				out = append(out, emitted)
+			}
+		}
+		if rule.BatchAgent != nil {
+			if emitted := rule.BatchAgent.Emit.EventType(); emitted != "" {
 				out = append(out, emitted)
 			}
 		}
@@ -308,6 +318,11 @@ func deadEventHandlerFanOutEmits(handler runtimecontracts.SystemNodeEventHandler
 	for _, rule := range handler.OnComplete {
 		if rule.FanOut != nil {
 			if emitted := rule.FanOut.Emit.EventType(); emitted != "" {
+				out = append(out, emitted)
+			}
+		}
+		if rule.BatchAgent != nil {
+			if emitted := rule.BatchAgent.Emit.EventType(); emitted != "" {
 				out = append(out, emitted)
 			}
 		}
@@ -319,9 +334,19 @@ func deadEventHandlerFanOutEmits(handler runtimecontracts.SystemNodeEventHandler
 					out = append(out, emitted)
 				}
 			}
+			if rule.BatchAgent != nil {
+				if emitted := rule.BatchAgent.Emit.EventType(); emitted != "" {
+					out = append(out, emitted)
+				}
+			}
 		}
 		if handler.Accumulate.OnTimeout != nil && handler.Accumulate.OnTimeout.FanOut != nil {
 			if emitted := handler.Accumulate.OnTimeout.FanOut.Emit.EventType(); emitted != "" {
+				out = append(out, emitted)
+			}
+		}
+		if handler.Accumulate.OnTimeout != nil && handler.Accumulate.OnTimeout.BatchAgent != nil {
+			if emitted := handler.Accumulate.OnTimeout.BatchAgent.Emit.EventType(); emitted != "" {
 				out = append(out, emitted)
 			}
 		}

--- a/internal/runtime/bootverify/workflow_expression_checks.go
+++ b/internal/runtime/bootverify/workflow_expression_checks.go
@@ -377,6 +377,13 @@ func handlerEntityExpressions(handler runtimecontracts.SystemNodeEventHandler) [
 		if rule.FanOut != nil {
 			// Fan-out has no CEL-bearing fields today.
 		}
+		if rule.BatchAgent != nil {
+			for key, value := range rule.BatchAgent.Input {
+				if expr := strings.TrimSpace(value.CEL); expr != "" {
+					out = append(out, expressionReference{Kind: kindPrefix + " batch_agent input " + strings.TrimSpace(key), Expression: expr, Phase: runtimepipeline.WorkflowEntityFieldLifecycleEmitFields})
+				}
+			}
+		}
 	}
 
 	appendWriteExpressions("expression", handler.DataAccumulation.Writes)
@@ -439,16 +446,30 @@ func handlerEntityExpressions(handler runtimecontracts.SystemNodeEventHandler) [
 	if handler.FanOut != nil {
 		appendEmitExpressions("fan_out", handler.FanOut.Emit, true)
 	}
+	if handler.BatchAgent != nil {
+		appendEmitExpressions("batch_agent", handler.BatchAgent.Emit, false)
+		for key, value := range handler.BatchAgent.Input {
+			if expr := strings.TrimSpace(value.CEL); expr != "" {
+				out = append(out, expressionReference{Kind: "batch_agent input " + strings.TrimSpace(key), Expression: expr, Phase: runtimepipeline.WorkflowEntityFieldLifecycleEmitFields})
+			}
+		}
+	}
 	for _, rule := range handler.Rules {
 		appendEmitExpressions("rule", rule.Emit, false)
 		if rule.FanOut != nil {
 			appendEmitExpressions("rule fan_out", rule.FanOut.Emit, true)
+		}
+		if rule.BatchAgent != nil {
+			appendEmitExpressions("rule batch_agent", rule.BatchAgent.Emit, false)
 		}
 	}
 	for _, rule := range handler.OnComplete {
 		appendEmitExpressions("on_complete", rule.Emit, false)
 		if rule.FanOut != nil {
 			appendEmitExpressions("on_complete fan_out", rule.FanOut.Emit, true)
+		}
+		if rule.BatchAgent != nil {
+			appendEmitExpressions("on_complete batch_agent", rule.BatchAgent.Emit, false)
 		}
 	}
 	if handler.Accumulate != nil {
@@ -457,11 +478,17 @@ func handlerEntityExpressions(handler runtimecontracts.SystemNodeEventHandler) [
 			if rule.FanOut != nil {
 				appendEmitExpressions("accumulate.on_complete fan_out", rule.FanOut.Emit, true)
 			}
+			if rule.BatchAgent != nil {
+				appendEmitExpressions("accumulate.on_complete batch_agent", rule.BatchAgent.Emit, false)
+			}
 		}
 		if handler.Accumulate.OnTimeout != nil {
 			appendEmitExpressions("accumulate.on_timeout", handler.Accumulate.OnTimeout.Emit, false)
 			if handler.Accumulate.OnTimeout.FanOut != nil {
 				appendEmitExpressions("accumulate.on_timeout fan_out", handler.Accumulate.OnTimeout.FanOut.Emit, true)
+			}
+			if handler.Accumulate.OnTimeout.BatchAgent != nil {
+				appendEmitExpressions("accumulate.on_timeout batch_agent", handler.Accumulate.OnTimeout.BatchAgent.Emit, false)
 			}
 		}
 	}

--- a/internal/runtime/bootverify/workflow_payload_completeness_checks.go
+++ b/internal/runtime/bootverify/workflow_payload_completeness_checks.go
@@ -134,16 +134,25 @@ func payloadCompletenessEmitSites(handler runtimecontracts.SystemNodeEventHandle
 	if handler.FanOut != nil {
 		add("handler.fan_out.emit", handler.FanOut.Emit)
 	}
+	if handler.BatchAgent != nil {
+		add("handler.batch_agent.emit", handler.BatchAgent.Emit)
+	}
 	for i, rule := range handler.Rules {
 		add(payloadCompletenessRuleLabel("rules", i, rule.ID, "emit"), rule.Emit)
 		if rule.FanOut != nil {
 			add(payloadCompletenessRuleLabel("rules", i, rule.ID, "fan_out.emit"), rule.FanOut.Emit)
+		}
+		if rule.BatchAgent != nil {
+			add(payloadCompletenessRuleLabel("rules", i, rule.ID, "batch_agent.emit"), rule.BatchAgent.Emit)
 		}
 	}
 	for i, rule := range handler.OnComplete {
 		add(payloadCompletenessRuleLabel("on_complete", i, rule.ID, "emit"), rule.Emit)
 		if rule.FanOut != nil {
 			add(payloadCompletenessRuleLabel("on_complete", i, rule.ID, "fan_out.emit"), rule.FanOut.Emit)
+		}
+		if rule.BatchAgent != nil {
+			add(payloadCompletenessRuleLabel("on_complete", i, rule.ID, "batch_agent.emit"), rule.BatchAgent.Emit)
 		}
 	}
 	if handler.Accumulate != nil {
@@ -152,11 +161,17 @@ func payloadCompletenessEmitSites(handler runtimecontracts.SystemNodeEventHandle
 			if rule.FanOut != nil {
 				add(payloadCompletenessRuleLabel("accumulate.on_complete", i, rule.ID, "fan_out.emit"), rule.FanOut.Emit)
 			}
+			if rule.BatchAgent != nil {
+				add(payloadCompletenessRuleLabel("accumulate.on_complete", i, rule.ID, "batch_agent.emit"), rule.BatchAgent.Emit)
+			}
 		}
 		if handler.Accumulate.OnTimeout != nil {
 			add(payloadCompletenessRuleLabel("accumulate.on_timeout", 0, handler.Accumulate.OnTimeout.ID, "emit"), handler.Accumulate.OnTimeout.Emit)
 			if handler.Accumulate.OnTimeout.FanOut != nil {
 				add(payloadCompletenessRuleLabel("accumulate.on_timeout", 0, handler.Accumulate.OnTimeout.ID, "fan_out.emit"), handler.Accumulate.OnTimeout.FanOut.Emit)
+			}
+			if handler.Accumulate.OnTimeout.BatchAgent != nil {
+				add(payloadCompletenessRuleLabel("accumulate.on_timeout", 0, handler.Accumulate.OnTimeout.ID, "batch_agent.emit"), handler.Accumulate.OnTimeout.BatchAgent.Emit)
 			}
 		}
 	}

--- a/internal/runtime/conformance/batch_agent_coordinator_pilot_conformance_test.go
+++ b/internal/runtime/conformance/batch_agent_coordinator_pilot_conformance_test.go
@@ -1,0 +1,126 @@
+package conformance
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	runtimebootverify "github.com/division-sh/swarm/internal/runtime/bootverify"
+	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
+	runtimepinrouting "github.com/division-sh/swarm/internal/runtime/core/pinrouting"
+	"github.com/division-sh/swarm/internal/runtime/semanticview"
+	"github.com/division-sh/swarm/internal/runtime/testfixtures/batchagentcoordinatorpilot"
+)
+
+func TestBatchAgentCoordinatorPilotConformance_CoversBatchAgentConnectScatter(t *testing.T) {
+	source := batchagentcoordinatorpilot.LoadSource(t)
+	report := runtimebootverify.Run(context.Background(), source, runtimebootverify.Options{})
+	if got := report.HardInvalidities(); len(got) != 0 {
+		t.Fatalf("batch-agent coordinator pilot hard invalidities = %#v, want none", got)
+	}
+
+	handler, ok := source.NodeEventHandler(batchagentcoordinatorpilot.NodeID, batchagentcoordinatorpilot.InputEvent)
+	if !ok {
+		t.Fatalf("handler %s/%s missing", batchagentcoordinatorpilot.NodeID, batchagentcoordinatorpilot.InputEvent)
+	}
+	if handler.Accumulate == nil || len(handler.Accumulate.OnComplete) != 1 {
+		t.Fatalf("accumulate.on_complete = %#v, want one batch rule", handler.Accumulate)
+	}
+	rule := handler.Accumulate.OnComplete[0]
+	if rule.BatchAgent == nil {
+		t.Fatalf("accumulate.on_complete rule = %#v, want batch_agent", rule)
+	}
+	assertBatchAgentCoordinatorPilotSpec(t, rule.BatchAgent)
+	if rule.BatchAgent.Emit.Target.Kind != "" || rule.BatchAgent.Emit.Broadcast {
+		t.Fatalf("batch_agent emit target/broadcast = %#v/%v, want parent connect authority only", rule.BatchAgent.Emit.Target, rule.BatchAgent.Emit.Broadcast)
+	}
+
+	emits := runtimecontracts.HandlerEmitEvents(handler)
+	wantResolvedOutput := batchagentcoordinatorpilot.CoordinatorFlowID + "/" + batchagentcoordinatorpilot.OutputEvent
+	if len(emits) != 1 || emits[0] != wantResolvedOutput {
+		t.Fatalf("HandlerEmitEvents = %#v, want %s from batch_agent emit", emits, wantResolvedOutput)
+	}
+	if !batchAgentCoordinatorPilotAuthoredSite(source) {
+		t.Fatalf("AuthoredEmitSites missing accumulate.on_complete.batch_agent emit for %s; sites=%s", batchagentcoordinatorpilot.OutputEvent, batchAgentCoordinatorPilotSiteSummary(source))
+	}
+
+	plans, issues := runtimepinrouting.LowerCompositionConnectRoutePlans(source)
+	if len(issues) != 0 {
+		t.Fatalf("LowerCompositionConnectRoutePlans issues = %#v, want none", issues)
+	}
+	if len(plans) != 1 {
+		t.Fatalf("LowerCompositionConnectRoutePlans = %#v, want one parent connect route plan", plans)
+	}
+	plan := plans[0]
+	if plan.Source.FlowID != batchagentcoordinatorpilot.CoordinatorFlowID || plan.Source.Pin != batchagentcoordinatorpilot.OutputPin || plan.Source.Key != "account_id" {
+		t.Fatalf("route plan source = %#v, want coordinator.account_classified keyed by account_id", plan.Source)
+	}
+	if plan.Receiver.FlowID != batchagentcoordinatorpilot.AccountFlowID || plan.Receiver.Pin != batchagentcoordinatorpilot.OutputPin || plan.Receiver.Mode != "template" {
+		t.Fatalf("route plan receiver = %#v, want accounts.account_classified template input", plan.Receiver)
+	}
+	if plan.ResolutionKind != runtimepinrouting.ConnectResolutionInstanceKey || !plan.RequiresRuntimeResolution {
+		t.Fatalf("route plan resolution = %s runtime=%v, want instance-key runtime resolution", plan.ResolutionKind, plan.RequiresRuntimeResolution)
+	}
+	if plan.InstanceKey == nil || strings.Join(plan.InstanceKey.Fields, ",") != "account_id" {
+		t.Fatalf("route plan instance key = %#v, want account_id", plan.InstanceKey)
+	}
+	if len(plan.InstanceKey.Mappings) != 1 || plan.InstanceKey.Mappings[0].Source != "account_id" || plan.InstanceKey.Mappings[0].Target != "account_id" || plan.InstanceKey.Mappings[0].Explicit {
+		t.Fatalf("route plan instance key mappings = %#v, want implicit account_id -> account_id", plan.InstanceKey.Mappings)
+	}
+}
+
+func assertBatchAgentCoordinatorPilotSpec(t *testing.T, spec *runtimecontracts.BatchAgentSpec) {
+	t.Helper()
+	if spec.Agent != batchagentcoordinatorpilot.AgentID {
+		t.Fatalf("batch_agent.agent = %q, want %s", spec.Agent, batchagentcoordinatorpilot.AgentID)
+	}
+	if spec.ItemsFrom != "accumulated.items" {
+		t.Fatalf("batch_agent.items_from = %q, want accumulated.items", spec.ItemsFrom)
+	}
+	if spec.Result.ItemsFrom != "results" || spec.Result.CorrelationKey != "account_id" {
+		t.Fatalf("batch_agent.result = %#v, want results/account_id", spec.Result)
+	}
+	if strings.Join(spec.Result.RequiredFields, ",") != "account_id,bucket,score" {
+		t.Fatalf("batch_agent.required_fields = %#v, want account_id/bucket/score", spec.Result.RequiredFields)
+	}
+	wantFields := map[string]string{
+		"account_id": "batch_agent.result.account_id",
+		"bucket":     "batch_agent.result.bucket",
+		"score":      "batch_agent.result.score",
+		"handle":     "batch_agent.source_item.handle",
+	}
+	for field, ref := range wantFields {
+		got, ok := spec.Emit.Fields[field]
+		if !ok || batchAgentCoordinatorPilotExpression(got) != ref {
+			t.Fatalf("batch_agent.emit.fields[%s] = %#v, want %s", field, got, ref)
+		}
+	}
+}
+
+func batchAgentCoordinatorPilotExpression(value runtimecontracts.ExpressionValue) string {
+	if value.Ref != "" {
+		return value.Ref
+	}
+	return value.CEL
+}
+
+func batchAgentCoordinatorPilotAuthoredSite(source semanticview.Source) bool {
+	for _, site := range semanticview.AuthoredEmitSites(source) {
+		if site.FlowID == batchagentcoordinatorpilot.CoordinatorFlowID &&
+			site.NodeID == batchagentcoordinatorpilot.NodeID &&
+			site.HandlerEvent == batchagentcoordinatorpilot.InputEvent &&
+			site.Site == "handler.accumulate.on_complete.batch_agent.emit" &&
+			site.Spec.EventType() == batchagentcoordinatorpilot.OutputEvent {
+			return true
+		}
+	}
+	return false
+}
+
+func batchAgentCoordinatorPilotSiteSummary(source semanticview.Source) string {
+	var out []string
+	for _, site := range semanticview.AuthoredEmitSites(source) {
+		out = append(out, strings.Join([]string{site.FlowID, site.NodeID, site.HandlerEvent, site.Site, site.Spec.EventType()}, "|"))
+	}
+	return strings.Join(out, ";")
+}

--- a/internal/runtime/conformance/testdata/route_authority_drift_inventory.yaml
+++ b/internal/runtime/conformance/testdata/route_authority_drift_inventory.yaml
@@ -1,7 +1,7 @@
 version: 1
 kind: route_authority_drift_inventory
 issue: 1364
-implementation_issues: [1364, 1494, 1495, 1496, 1545, 1546, 1552, 1577]
+implementation_issues: [1364, 1447, 1494, 1495, 1496, 1545, 1546, 1552, 1577]
 parent_issues: [1340, 1353, 1481, 1493]
 watchlist: runtime_operations.delivery_and_replay_ownership
 policy:
@@ -658,6 +658,7 @@ seam_families:
       - internal/runtime/cataloge2e/tier12_runtime_fork_e2e_test.go
       - internal/runtime/bus/sealed_flow_package_fixture_test.go
       - internal/runtime/conformance/sealed_flow_package_conformance_test.go
+      - internal/runtime/conformance/batch_agent_coordinator_pilot_conformance_test.go
       - internal/runtime/conformance/singleton_coordinator_pilot_conformance_test.go
       - internal/runtime/conformance/template_flow_pilot_conformance_test.go
       - internal/runtime/swarmflowtest/catalog_runner_test.go
@@ -674,7 +675,10 @@ seam_families:
       package-boundary proof consumer for the existing route-authority owners.
       #1553 adds the singleton coordinator pilot conformance fixture as a
       consumer that proves contained map/list state does not produce lowered
-      connect route authority.
+      connect route authority. #1447 adds the batch-agent coordinator pilot
+      conformance fixture as a proof consumer that batch scatter emits consume
+      lowered parent connect authority instead of introducing row-level route
+      authority.
   - id: route_authority_conformance_artifacts
     layer: conformance_guardrails
     classification: canonical_owner

--- a/internal/runtime/contracts/workflow_contract_accessors.go
+++ b/internal/runtime/contracts/workflow_contract_accessors.go
@@ -1081,6 +1081,11 @@ func (b *WorkflowContractBundle) externalizeNodeHandler(nodeID string, handler S
 		clone.Emit = b.externalizeEmitSpec(nodeID, clone.Emit)
 		handler.FanOut = &clone
 	}
+	if handler.BatchAgent != nil {
+		clone := *handler.BatchAgent
+		clone.Emit = b.externalizeEmitSpec(nodeID, clone.Emit)
+		handler.BatchAgent = &clone
+	}
 	if len(handler.Rules) > 0 {
 		rules := make([]HandlerRuleEntry, 0, len(handler.Rules))
 		for _, rule := range handler.Rules {
@@ -1089,6 +1094,11 @@ func (b *WorkflowContractBundle) externalizeNodeHandler(nodeID string, handler S
 				clone := *rule.FanOut
 				clone.Emit = b.externalizeEmitSpec(nodeID, clone.Emit)
 				rule.FanOut = &clone
+			}
+			if rule.BatchAgent != nil {
+				clone := *rule.BatchAgent
+				clone.Emit = b.externalizeEmitSpec(nodeID, clone.Emit)
+				rule.BatchAgent = &clone
 			}
 			rules = append(rules, rule)
 		}
@@ -1102,6 +1112,11 @@ func (b *WorkflowContractBundle) externalizeNodeHandler(nodeID string, handler S
 				clone := *rule.FanOut
 				clone.Emit = b.externalizeEmitSpec(nodeID, clone.Emit)
 				rule.FanOut = &clone
+			}
+			if rule.BatchAgent != nil {
+				clone := *rule.BatchAgent
+				clone.Emit = b.externalizeEmitSpec(nodeID, clone.Emit)
+				rule.BatchAgent = &clone
 			}
 			rules = append(rules, rule)
 		}
@@ -1118,6 +1133,11 @@ func (b *WorkflowContractBundle) externalizeNodeHandler(nodeID string, handler S
 					fanOut.Emit = b.externalizeEmitSpec(nodeID, fanOut.Emit)
 					rule.FanOut = &fanOut
 				}
+				if rule.BatchAgent != nil {
+					batchAgent := *rule.BatchAgent
+					batchAgent.Emit = b.externalizeEmitSpec(nodeID, batchAgent.Emit)
+					rule.BatchAgent = &batchAgent
+				}
 				rules = append(rules, rule)
 			}
 			clone.OnComplete = rules
@@ -1129,6 +1149,11 @@ func (b *WorkflowContractBundle) externalizeNodeHandler(nodeID string, handler S
 				fanOut := *onTimeout.FanOut
 				fanOut.Emit = b.externalizeEmitSpec(nodeID, fanOut.Emit)
 				onTimeout.FanOut = &fanOut
+			}
+			if onTimeout.BatchAgent != nil {
+				batchAgent := *onTimeout.BatchAgent
+				batchAgent.Emit = b.externalizeEmitSpec(nodeID, batchAgent.Emit)
+				onTimeout.BatchAgent = &batchAgent
 			}
 			clone.OnTimeout = &onTimeout
 		}

--- a/internal/runtime/contracts/workflow_contract_emit.go
+++ b/internal/runtime/contracts/workflow_contract_emit.go
@@ -27,6 +27,11 @@ func HandlerEmitEvents(handler SystemNodeEventHandler) []string {
 			out = append(out, eventType)
 		}
 	}
+	if handler.BatchAgent != nil {
+		if eventType := handler.BatchAgent.Emit.EventType(); eventType != "" {
+			out = append(out, eventType)
+		}
+	}
 	return uniqueOrderedStrings(out)
 }
 
@@ -45,6 +50,11 @@ func ruleEmitEvents(rule HandlerRuleEntry) []string {
 			out = append(out, eventType)
 		}
 	}
+	if rule.BatchAgent != nil {
+		if eventType := rule.BatchAgent.Emit.EventType(); eventType != "" {
+			out = append(out, eventType)
+		}
+	}
 	return uniqueOrderedStrings(out)
 }
 
@@ -59,7 +69,7 @@ func actionResultEvents(action ActionSpec) []string {
 }
 
 func HandlerHasNestedEmitSites(handler SystemNodeEventHandler) bool {
-	if handler.FanOut != nil {
+	if handler.FanOut != nil || handler.BatchAgent != nil {
 		return true
 	}
 	if len(handler.Rules) > 0 {

--- a/internal/runtime/contracts/workflow_contract_semantics.go
+++ b/internal/runtime/contracts/workflow_contract_semantics.go
@@ -132,6 +132,7 @@ func populateWorkflowSemantics(bundle *WorkflowContractBundle) {
 				Compute:              handler.Compute,
 				Query:                handler.Query,
 				FanOut:               handler.FanOut,
+				BatchAgent:           handler.BatchAgent,
 				GroupBy:              handler.GroupBy,
 				Filter:               handler.Filter,
 				Reduce:               handler.Reduce,

--- a/internal/runtime/contracts/workflow_contract_types.go
+++ b/internal/runtime/contracts/workflow_contract_types.go
@@ -129,6 +129,7 @@ type HandlerTransitionSemantic struct {
 	Compute              *ComputeSpec
 	Query                *QuerySpec
 	FanOut               *FanOutSpec
+	BatchAgent           *BatchAgentSpec
 	GroupBy              *GroupBySpec
 	Filter               *FilterSpec
 	Reduce               *ReduceSpec
@@ -146,6 +147,7 @@ type HandlerRuleEntry struct {
 	DataAccumulation WorkflowDataAccumulation `yaml:"data_accumulation"`
 	Compute          *ComputeSpec             `yaml:"compute"`
 	FanOut           *FanOutSpec              `yaml:"fan_out"`
+	BatchAgent       *BatchAgentSpec          `yaml:"batch_agent"`
 }
 type GuardSpec struct {
 	ID         string           `yaml:"id"`
@@ -257,6 +259,20 @@ type FanOutSpec struct {
 	ItemsPath paths.Path `yaml:"-"`
 	Target    string     `yaml:"target"`
 	Emit      EmitSpec   `yaml:"emit"`
+}
+type BatchAgentSpec struct {
+	Agent     string                     `yaml:"agent"`
+	ItemsFrom string                     `yaml:"items_from"`
+	ItemsPath paths.Path                 `yaml:"-"`
+	Input     map[string]ExpressionValue `yaml:"input"`
+	Result    BatchAgentResultSpec       `yaml:"result"`
+	Emit      EmitSpec                   `yaml:"emit"`
+}
+type BatchAgentResultSpec struct {
+	ItemsFrom      string     `yaml:"items_from"`
+	ItemsPath      paths.Path `yaml:"-"`
+	CorrelationKey string     `yaml:"correlation_key"`
+	RequiredFields []string   `yaml:"required_fields"`
 }
 type GroupBySpec struct {
 	ItemsFrom string     `yaml:"items_from"`
@@ -1222,6 +1238,7 @@ type SystemNodeEventHandler struct {
 	Compute              *ComputeSpec              `yaml:"compute"`
 	Query                *QuerySpec                `yaml:"query"`
 	FanOut               *FanOutSpec               `yaml:"fan_out"`
+	BatchAgent           *BatchAgentSpec           `yaml:"batch_agent"`
 	GroupBy              *GroupBySpec              `yaml:"group_by"`
 	Filter               *FilterSpec               `yaml:"filter"`
 	Reduce               *ReduceSpec               `yaml:"reduce"`

--- a/internal/runtime/contracts/workflow_contract_yaml_flow.go
+++ b/internal/runtime/contracts/workflow_contract_yaml_flow.go
@@ -38,6 +38,7 @@ func validateRuleFieldNodes(node *yaml.Node) error {
 		"data_accumulation": {},
 		"compute":           {},
 		"fan_out":           {},
+		"batch_agent":       {},
 	}
 	for i := 0; i+1 < len(node.Content); i += 2 {
 		key := strings.TrimSpace(node.Content[i].Value)

--- a/internal/runtime/contracts/workflow_contract_yaml_handlers.go
+++ b/internal/runtime/contracts/workflow_contract_yaml_handlers.go
@@ -578,6 +578,7 @@ func (h *SystemNodeEventHandler) UnmarshalYAML(node *yaml.Node) error {
 		Compute              *ComputeSpec             `yaml:"compute"`
 		Query                yaml.Node                `yaml:"query"`
 		FanOut               *FanOutSpec              `yaml:"fan_out"`
+		BatchAgent           *BatchAgentSpec          `yaml:"batch_agent"`
 		GroupBy              *GroupBySpec             `yaml:"group_by"`
 		Filter               *FilterSpec              `yaml:"filter"`
 		Reduce               *ReduceSpec              `yaml:"reduce"`
@@ -601,6 +602,7 @@ func (h *SystemNodeEventHandler) UnmarshalYAML(node *yaml.Node) error {
 		Accumulate:       aux.Accumulate,
 		Compute:          aux.Compute,
 		FanOut:           aux.FanOut,
+		BatchAgent:       aux.BatchAgent,
 		GroupBy:          aux.GroupBy,
 		Filter:           aux.Filter,
 		Reduce:           aux.Reduce,
@@ -913,6 +915,7 @@ func validateHandlerFieldNodes(node *yaml.Node) error {
 		"compute":                 {},
 		"query":                   {},
 		"fan_out":                 {},
+		"batch_agent":             {},
 		"group_by":                {},
 		"filter":                  {},
 		"reduce":                  {},
@@ -1014,7 +1017,7 @@ func decodeHandlerRuleEntryNode(node *yaml.Node, context handlerRuleDecodeContex
 	if err := rejectRuleActionOutsideRules(rule, context); err != nil {
 		return nil, err
 	}
-	if strings.TrimSpace(rule.ID) == "" && strings.TrimSpace(rule.Description) == "" && strings.TrimSpace(rule.Condition) == "" && strings.TrimSpace(rule.AdvancesTo) == "" && rule.Emit.Empty() && strings.TrimSpace(rule.Action.ID) == "" && !rule.DataAccumulation.HasWrites() && rule.Compute == nil && rule.FanOut == nil {
+	if strings.TrimSpace(rule.ID) == "" && strings.TrimSpace(rule.Description) == "" && strings.TrimSpace(rule.Condition) == "" && strings.TrimSpace(rule.AdvancesTo) == "" && rule.Emit.Empty() && strings.TrimSpace(rule.Action.ID) == "" && !rule.DataAccumulation.HasWrites() && rule.Compute == nil && rule.FanOut == nil && rule.BatchAgent == nil {
 		return nil, nil
 	}
 	return &rule, nil
@@ -1037,7 +1040,7 @@ func decodeHandlerRuleEntriesNode(node *yaml.Node, context handlerRuleDecodeCont
 		}
 		return rules, nil
 	case yaml.MappingNode:
-		if hasAnyYAMLMappingKey(node, "condition", "advances_to", "emit", "emits", "action", "data_accumulation", "compute", "fan_out") {
+		if hasAnyYAMLMappingKey(node, "condition", "advances_to", "emit", "emits", "action", "data_accumulation", "compute", "fan_out", "batch_agent") {
 			rule, err := decodeHandlerRuleEntryNode(node, context)
 			if err != nil || rule == nil {
 				return nil, err

--- a/internal/runtime/contracts/workflow_contract_yaml_rules.go
+++ b/internal/runtime/contracts/workflow_contract_yaml_rules.go
@@ -223,6 +223,125 @@ func (f *FanOutSpec) UnmarshalYAML(node *yaml.Node) error {
 	return nil
 }
 
+func (s *BatchAgentSpec) UnmarshalYAML(node *yaml.Node) error {
+	if s == nil {
+		return nil
+	}
+	if err := validateBatchAgentFieldNodes(node); err != nil {
+		return err
+	}
+	var aux struct {
+		Agent     string                     `yaml:"agent"`
+		ItemsFrom string                     `yaml:"items_from"`
+		Input     map[string]ExpressionValue `yaml:"input"`
+		Result    BatchAgentResultSpec       `yaml:"result"`
+		Emit      EmitSpec                   `yaml:"emit"`
+	}
+	if err := node.Decode(&aux); err != nil {
+		return err
+	}
+	*s = BatchAgentSpec{
+		Agent:     strings.TrimSpace(aux.Agent),
+		ItemsFrom: strings.TrimSpace(aux.ItemsFrom),
+		ItemsPath: paths.Parse(aux.ItemsFrom),
+		Input:     cloneExpressionValueMap(aux.Input),
+		Result:    aux.Result.normalized(),
+		Emit:      aux.Emit,
+	}
+	if s.Agent == "" {
+		return fmt.Errorf("batch_agent.agent is required")
+	}
+	if s.ItemsFrom == "" {
+		return fmt.Errorf("batch_agent.items_from is required")
+	}
+	if s.Result.ItemsFrom == "" {
+		return fmt.Errorf("batch_agent.result.items_from is required")
+	}
+	if s.Result.CorrelationKey == "" {
+		return fmt.Errorf("batch_agent.result.correlation_key is required")
+	}
+	if s.Emit.EventType() == "" {
+		return fmt.Errorf("batch_agent.emit.event is required")
+	}
+	return nil
+}
+
+func validateBatchAgentFieldNodes(node *yaml.Node) error {
+	if node == nil || node.Kind != yaml.MappingNode {
+		return nil
+	}
+	allowed := map[string]struct{}{
+		"agent":      {},
+		"items_from": {},
+		"input":      {},
+		"result":     {},
+		"emit":       {},
+	}
+	for i := 0; i+1 < len(node.Content); i += 2 {
+		key := strings.TrimSpace(node.Content[i].Value)
+		if key == "" {
+			continue
+		}
+		if _, ok := allowed[key]; !ok {
+			return fmt.Errorf("UNDEFINED-FIELD: batch_agent field %q not in platform spec", key)
+		}
+	}
+	return nil
+}
+
+func (s *BatchAgentResultSpec) UnmarshalYAML(node *yaml.Node) error {
+	if s == nil {
+		return nil
+	}
+	if err := validateBatchAgentResultFieldNodes(node); err != nil {
+		return err
+	}
+	var aux struct {
+		ItemsFrom      string   `yaml:"items_from"`
+		CorrelationKey string   `yaml:"correlation_key"`
+		RequiredFields []string `yaml:"required_fields"`
+	}
+	if err := node.Decode(&aux); err != nil {
+		return err
+	}
+	*s = BatchAgentResultSpec{
+		ItemsFrom:      strings.TrimSpace(aux.ItemsFrom),
+		ItemsPath:      paths.Parse(aux.ItemsFrom),
+		CorrelationKey: strings.TrimSpace(aux.CorrelationKey),
+		RequiredFields: normalizeStrings(append(aux.RequiredFields, aux.CorrelationKey)),
+	}
+	return nil
+}
+
+func validateBatchAgentResultFieldNodes(node *yaml.Node) error {
+	if node == nil || node.Kind != yaml.MappingNode {
+		return nil
+	}
+	allowed := map[string]struct{}{
+		"items_from":      {},
+		"correlation_key": {},
+		"required_fields": {},
+	}
+	for i := 0; i+1 < len(node.Content); i += 2 {
+		key := strings.TrimSpace(node.Content[i].Value)
+		if key == "" {
+			continue
+		}
+		if _, ok := allowed[key]; !ok {
+			return fmt.Errorf("UNDEFINED-FIELD: batch_agent.result field %q not in platform spec", key)
+		}
+	}
+	return nil
+}
+
+func (s BatchAgentResultSpec) normalized() BatchAgentResultSpec {
+	s.ItemsFrom = strings.TrimSpace(s.ItemsFrom)
+	s.ItemsPath = paths.Parse(s.ItemsFrom)
+	s.CorrelationKey = strings.TrimSpace(s.CorrelationKey)
+	s.RequiredFields = normalizeStrings(append(s.RequiredFields, s.CorrelationKey))
+	return s
+}
+
 func validateFanOutFieldNodes(node *yaml.Node) error {
 	if node == nil || node.Kind != yaml.MappingNode {
 		return nil

--- a/internal/runtime/core/paths/path.go
+++ b/internal/runtime/core/paths/path.go
@@ -14,6 +14,7 @@ const (
 	RootGates
 	RootAccumulated
 	RootFanOut
+	RootBatchAgent
 	RootComputed
 )
 
@@ -35,6 +36,8 @@ func (r PathRoot) String() string {
 		return "accumulated"
 	case RootFanOut:
 		return "fan_out"
+	case RootBatchAgent:
+		return "batch_agent"
 	case RootComputed:
 		return "computed"
 	default:
@@ -90,6 +93,8 @@ func parseRoot(text string) PathRoot {
 		return RootAccumulated
 	case "fan_out":
 		return RootFanOut
+	case "batch_agent":
+		return RootBatchAgent
 	case "computed":
 		return RootComputed
 	default:

--- a/internal/runtime/core/values/context.go
+++ b/internal/runtime/core/values/context.go
@@ -11,6 +11,7 @@ type Context struct {
 	Payload     Bucket
 	Accumulated Bucket
 	FanOut      Bucket
+	BatchAgent  Bucket
 	Computed    Bucket
 }
 
@@ -24,6 +25,7 @@ func NewContext() Context {
 		Payload:     Wrap(map[string]any{}),
 		Accumulated: Wrap(map[string]any{}),
 		FanOut:      Wrap(map[string]any{}),
+		BatchAgent:  Wrap(map[string]any{}),
 		Computed:    Wrap(map[string]any{}),
 	}
 }
@@ -38,6 +40,7 @@ func (c Context) Clone() Context {
 		Payload:     c.Payload.Clone(),
 		Accumulated: c.Accumulated.Clone(),
 		FanOut:      c.FanOut.Clone(),
+		BatchAgent:  c.BatchAgent.Clone(),
 		Computed:    c.Computed.Clone(),
 	}
 }
@@ -62,6 +65,11 @@ func (c Context) WithFanOut(fanOut map[string]any) Context {
 	return c
 }
 
+func (c Context) WithBatchAgent(batchAgent map[string]any) Context {
+	c.BatchAgent = Wrap(batchAgent).Clone()
+	return c
+}
+
 func (c Context) Bucket(root paths.PathRoot) Bucket {
 	switch root {
 	case paths.RootEntity:
@@ -80,6 +88,8 @@ func (c Context) Bucket(root paths.PathRoot) Bucket {
 		return c.Accumulated
 	case paths.RootFanOut:
 		return c.FanOut
+	case paths.RootBatchAgent:
+		return c.BatchAgent
 	case paths.RootComputed:
 		return c.Computed
 	default:

--- a/internal/runtime/engine/batch_agent.go
+++ b/internal/runtime/engine/batch_agent.go
@@ -1,0 +1,350 @@
+package engine
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+
+	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
+	"github.com/division-sh/swarm/internal/runtime/core/paths"
+	"github.com/division-sh/swarm/internal/runtime/workflowexpr"
+)
+
+type validatedBatchAgentRow struct {
+	key        string
+	sourceItem any
+	result     map[string]any
+}
+
+func validateHandlerBatchAgentSpecs(handler runtimecontracts.SystemNodeEventHandler) error {
+	validate := func(context string, spec *runtimecontracts.BatchAgentSpec) error {
+		if spec == nil {
+			return nil
+		}
+		if strings.TrimSpace(spec.Agent) == "" {
+			return fmt.Errorf("%s.agent is required", context)
+		}
+		if strings.TrimSpace(spec.ItemsFrom) == "" {
+			return fmt.Errorf("%s.items_from is required", context)
+		}
+		if strings.TrimSpace(spec.Result.ItemsFrom) == "" {
+			return fmt.Errorf("%s.result.items_from is required", context)
+		}
+		if strings.TrimSpace(spec.Result.CorrelationKey) == "" {
+			return fmt.Errorf("%s.result.correlation_key is required", context)
+		}
+		if spec.Emit.EventType() == "" {
+			return fmt.Errorf("%s.emit.event is required", context)
+		}
+		return nil
+	}
+	validateRule := func(context string, rule runtimecontracts.HandlerRuleEntry) error {
+		if rule.BatchAgent == nil {
+			return nil
+		}
+		if !rule.Emit.Empty() {
+			return fmt.Errorf("%s declares both emit and batch_agent; batch_agent.emit owns the scatter payload", context)
+		}
+		if rule.FanOut != nil {
+			return fmt.Errorf("%s declares both fan_out and batch_agent", context)
+		}
+		return validate(context+".batch_agent", rule.BatchAgent)
+	}
+	if err := validate("handler.batch_agent", handler.BatchAgent); err != nil {
+		return err
+	}
+	if handler.BatchAgent != nil && handler.FanOut != nil {
+		return fmt.Errorf("handler declares both fan_out and batch_agent")
+	}
+	for idx, rule := range handler.Rules {
+		if err := validateRule(handlerRuleContext("handler.rules", idx, rule.ID), rule); err != nil {
+			return err
+		}
+	}
+	for idx, rule := range handler.OnComplete {
+		if err := validateRule(handlerRuleContext("handler.on_complete", idx, rule.ID), rule); err != nil {
+			return err
+		}
+	}
+	if handler.Accumulate != nil {
+		for idx, rule := range handler.Accumulate.OnComplete {
+			if err := validateRule(handlerRuleContext("handler.accumulate.on_complete", idx, rule.ID), rule); err != nil {
+				return err
+			}
+		}
+		if handler.Accumulate.OnTimeout != nil {
+			if err := validateRule(handlerRuleContext("handler.accumulate.on_timeout", 0, handler.Accumulate.OnTimeout.ID), *handler.Accumulate.OnTimeout); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func (e *Executor) stepBatchAgent(frame *executionFrame) (bool, error) {
+	spec := e.selectedBatchAgent(frame)
+	if spec == nil {
+		return false, nil
+	}
+	current := e.currentContext(frame)
+	itemsValue, _ := resolveContractPath(current, frame.state, spec.ItemsPath, spec.ItemsFrom)
+	items := sliceFromAny(itemsValue)
+	frame.result.BatchAgentCount = len(items)
+	frame.state.BatchAgent = map[string]any{}
+	frame.state.SetBatchAgent("agent", strings.TrimSpace(spec.Agent))
+	frame.state.SetBatchAgent("count", len(items))
+	if len(items) == 0 {
+		return false, nil
+	}
+	if e.deps.BatchAgentRunner == nil {
+		return false, fmt.Errorf("batch_agent runner is required")
+	}
+	input, err := e.batchAgentInput(frame, spec)
+	if err != nil {
+		return false, err
+	}
+	if _, err := expectedBatchAgentKeys(items, spec.Result.CorrelationKey); err != nil {
+		return false, err
+	}
+	resp, err := e.deps.BatchAgentRunner.InvokeBatchAgent(frame.tx.Context(), BatchAgentRequest{
+		FlowID:          strings.TrimSpace(frame.req.FlowID.String()),
+		NodeID:          strings.TrimSpace(frame.req.NodeID.String()),
+		Agent:           strings.TrimSpace(spec.Agent),
+		Items:           cloneAnySlice(items),
+		Input:           cloneStringAnyMap(input),
+		ResultItemsFrom: strings.TrimSpace(spec.Result.ItemsFrom),
+		CorrelationKey:  strings.TrimSpace(spec.Result.CorrelationKey),
+		RequiredFields:  append([]string(nil), spec.Result.RequiredFields...),
+	})
+	if err != nil {
+		return false, err
+	}
+	rows, err := batchAgentRowsFromOutput(resp.Output, spec.Result)
+	if err != nil {
+		return false, err
+	}
+	ordered, err := validateBatchAgentRows(items, rows, spec.Result)
+	if err != nil {
+		return false, err
+	}
+	frame.result.BatchAgentCount = len(ordered)
+	frame.state.SetBatchAgent("count", len(ordered))
+	for _, row := range ordered {
+		if err := e.emitBatchAgentRow(frame, spec, row); err != nil {
+			return false, err
+		}
+	}
+	if len(frame.result.EmitIntents) == 0 && len(frame.result.DeadLetterIntents) == 0 {
+		return false, nil
+	}
+	if err := e.stepAdvancesTo(frame); err != nil {
+		return false, err
+	}
+	frame.result.Status = OutcomeFannedOut
+	return true, nil
+}
+
+func (e *Executor) batchAgentInput(frame *executionFrame, spec *runtimecontracts.BatchAgentSpec) (map[string]any, error) {
+	out := map[string]any{}
+	base := e.currentContext(frame)
+	for key, expr := range spec.Input {
+		key = strings.TrimSpace(key)
+		if key == "" {
+			continue
+		}
+		value, ok, err := evalExpressionValue(base, frame.state, expr, workflowexpr.ValueExpressionOptions{})
+		if err != nil {
+			return nil, fmt.Errorf("batch_agent.input.%s: %w", key, err)
+		}
+		if !ok {
+			continue
+		}
+		setParsedValuePath(out, paths.Parse(key), value)
+	}
+	return out, nil
+}
+
+func (e *Executor) emitBatchAgentRow(frame *executionFrame, spec *runtimecontracts.BatchAgentSpec, row validatedBatchAgentRow) error {
+	frame.state.SetBatchAgent("source_item", cloneBatchAgentValue(row.sourceItem))
+	frame.state.SetBatchAgent("result", cloneStringAnyMap(row.result))
+	frame.state.SetBatchAgent("key", row.key)
+	eventType := spec.Emit.EventType()
+	if eventType == "" {
+		return nil
+	}
+	eventType = e.resolveDeclarativeEmitEventType(frame, eventType)
+	emitSpec := spec.Emit
+	emitSpec.Event = eventType
+	payload := map[string]any{}
+	transformed, err := emitFieldsPayload(e.currentContext(frame), frame.state, emitSpec, workflowexpr.ValueExpressionOptions{})
+	if err != nil {
+		return err
+	}
+	if len(transformed) > 0 {
+		payload = transformed
+	}
+	shaped, err := e.shapeEmitPayload(frame, eventType, payload)
+	if err != nil {
+		return err
+	}
+	_, err = e.queueEmitIntentForSpec(frame, emitSpec, eventType, shaped)
+	return err
+}
+
+func batchAgentRowsFromOutput(output any, spec runtimecontracts.BatchAgentResultSpec) ([]any, error) {
+	rowsPath := spec.ItemsPath
+	if rowsPath.IsZero() {
+		rowsPath = paths.Parse(spec.ItemsFrom)
+	}
+	if rowsPath.IsZero() {
+		return nil, fmt.Errorf("batch_agent.result.items_from is required")
+	}
+	if rowsPath.HasExplicitRoot() {
+		return nil, fmt.Errorf("batch_agent.result.items_from must address the agent output object, got %q", rowsPath.String())
+	}
+	object, ok := asObject(output)
+	if !ok {
+		return nil, fmt.Errorf("batch_agent output must be an object containing %q", rowsPath.String())
+	}
+	rowsValue, ok := lookupParsedPath(object, rowsPath)
+	if !ok {
+		return nil, fmt.Errorf("batch_agent output missing result rows at %q", rowsPath.String())
+	}
+	rows := sliceFromAny(rowsValue)
+	if rows == nil {
+		return nil, fmt.Errorf("batch_agent result rows at %q must be a list", rowsPath.String())
+	}
+	return rows, nil
+}
+
+func validateBatchAgentRows(items []any, rows []any, spec runtimecontracts.BatchAgentResultSpec) ([]validatedBatchAgentRow, error) {
+	expected, err := expectedBatchAgentKeys(items, spec.CorrelationKey)
+	if err != nil {
+		return nil, err
+	}
+	if len(rows) == 0 && len(expected.order) > 0 {
+		return nil, fmt.Errorf("batch_agent result missing rows for %d input item(s)", len(expected.order))
+	}
+	byKey := make(map[string]map[string]any, len(rows))
+	for idx, row := range rows {
+		rowObj, ok := asObject(row)
+		if !ok {
+			return nil, fmt.Errorf("batch_agent result row %d is malformed: row must be an object", idx)
+		}
+		key, err := batchAgentObjectKey(rowObj, spec.CorrelationKey)
+		if err != nil {
+			return nil, fmt.Errorf("batch_agent result row %d: %w", idx, err)
+		}
+		if _, ok := expected.byKey[key]; !ok {
+			return nil, fmt.Errorf("batch_agent result row %d has unknown correlation key %q", idx, key)
+		}
+		if _, exists := byKey[key]; exists {
+			return nil, fmt.Errorf("batch_agent result has duplicate correlation key %q", key)
+		}
+		for _, field := range spec.RequiredFields {
+			if _, ok := batchAgentLookup(rowObj, field); !ok {
+				return nil, fmt.Errorf("batch_agent result row %d for key %q missing required field %q", idx, key, strings.TrimSpace(field))
+			}
+		}
+		byKey[key] = cloneStringAnyMap(rowObj)
+	}
+	out := make([]validatedBatchAgentRow, 0, len(expected.order))
+	for _, key := range expected.order {
+		row, ok := byKey[key]
+		if !ok {
+			return nil, fmt.Errorf("batch_agent result missing row for correlation key %q", key)
+		}
+		out = append(out, validatedBatchAgentRow{
+			key:        key,
+			sourceItem: expected.byKey[key],
+			result:     row,
+		})
+	}
+	return out, nil
+}
+
+type expectedBatchAgentKeySet struct {
+	order []string
+	byKey map[string]any
+}
+
+func expectedBatchAgentKeys(items []any, keyPath string) (expectedBatchAgentKeySet, error) {
+	out := expectedBatchAgentKeySet{
+		order: make([]string, 0, len(items)),
+		byKey: make(map[string]any, len(items)),
+	}
+	for idx, item := range items {
+		itemObj, ok := asObject(item)
+		if !ok {
+			return expectedBatchAgentKeySet{}, fmt.Errorf("batch_agent input item %d is malformed: item must be an object", idx)
+		}
+		key, err := batchAgentObjectKey(itemObj, keyPath)
+		if err != nil {
+			return expectedBatchAgentKeySet{}, fmt.Errorf("batch_agent input item %d: %w", idx, err)
+		}
+		if _, exists := out.byKey[key]; exists {
+			return expectedBatchAgentKeySet{}, fmt.Errorf("batch_agent input has duplicate correlation key %q", key)
+		}
+		out.order = append(out.order, key)
+		out.byKey[key] = cloneStringAnyMap(itemObj)
+	}
+	return out, nil
+}
+
+func batchAgentObjectKey(object map[string]any, keyPath string) (string, error) {
+	value, ok := batchAgentLookup(object, keyPath)
+	if !ok {
+		return "", fmt.Errorf("missing correlation key %q", strings.TrimSpace(keyPath))
+	}
+	key := strings.TrimSpace(asString(value))
+	if key == "" {
+		key = strings.TrimSpace(fmt.Sprint(value))
+	}
+	if key == "" || key == "<nil>" {
+		return "", fmt.Errorf("correlation key %q is empty", strings.TrimSpace(keyPath))
+	}
+	return key, nil
+}
+
+func batchAgentLookup(object map[string]any, rawPath string) (any, bool) {
+	rawPath = strings.TrimSpace(rawPath)
+	if rawPath == "" {
+		return nil, false
+	}
+	parsed := paths.Parse(rawPath)
+	if parsed.HasExplicitRoot() {
+		parsed = paths.Path{Segments: parsed.Segments, Raw: strings.Join(parsed.Segments, ".")}
+	}
+	return lookupParsedPath(object, parsed)
+}
+
+func cloneAnySlice(in []any) []any {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]any, 0, len(in))
+	for _, item := range in {
+		out = append(out, cloneBatchAgentValue(item))
+	}
+	return out
+}
+
+func cloneBatchAgentValue(value any) any {
+	switch typed := value.(type) {
+	case map[string]any:
+		return cloneStringAnyMap(typed)
+	case []any:
+		return cloneAnySlice(typed)
+	case []map[string]any:
+		out := make([]any, 0, len(typed))
+		for _, item := range typed {
+			out = append(out, cloneStringAnyMap(item))
+		}
+		return out
+	default:
+		if reflect.TypeOf(value) == nil {
+			return nil
+		}
+		return value
+	}
+}

--- a/internal/runtime/engine/context_builder.go
+++ b/internal/runtime/engine/context_builder.go
@@ -14,6 +14,7 @@ type ContextOverlay struct {
 	Payload     map[string]any
 	Accumulated map[string]any
 	FanOut      map[string]any
+	BatchAgent  map[string]any
 }
 
 type ContextBuilderInput struct {
@@ -57,6 +58,11 @@ func WithAccumulated(base BaseContext, accumulated map[string]any) BaseContext {
 
 func WithFanOutItem(base BaseContext, fanOut map[string]any) BaseContext {
 	base.FanOut = values.Wrap(cloneStringAnyMap(fanOut))
+	return base
+}
+
+func WithBatchAgent(base BaseContext, batchAgent map[string]any) BaseContext {
+	base.BatchAgent = values.Wrap(cloneStringAnyMap(batchAgent))
 	return base
 }
 

--- a/internal/runtime/engine/executor.go
+++ b/internal/runtime/engine/executor.go
@@ -37,6 +37,7 @@ const (
 	StepCount      Step = "count"
 	StepCompute    Step = "compute"
 	StepFanOut     Step = "fan_out"
+	StepBatchAgent Step = "batch_agent"
 	StepOnComplete Step = "on_complete"
 	StepRules      Step = "rules"
 	StepAdvancesTo Step = "advances_to"
@@ -60,6 +61,7 @@ var OrderedSteps = []Step{
 	StepCount,
 	StepCompute,
 	StepFanOut,
+	StepBatchAgent,
 	StepOnComplete,
 	StepRules,
 	StepAdvancesTo,
@@ -176,6 +178,9 @@ func (e *Executor) ValidateRequest(req ExecutionRequest) error {
 		return fmt.Errorf("%w: handler declares both select_entity and select_or_create_entity", ErrInvalidConfig)
 	}
 	if err := validateHandlerComputeSpecs(req.Handler); err != nil {
+		return fmt.Errorf("%w: %v", ErrInvalidConfig, err)
+	}
+	if err := validateHandlerBatchAgentSpecs(req.Handler); err != nil {
 		return fmt.Errorf("%w: %v", ErrInvalidConfig, err)
 	}
 	if err := validateHandlerEntityWriteTargets(e.deps.Source, req.FlowID.String(), req.Handler); err != nil {
@@ -577,6 +582,7 @@ func (e *Executor) newExecutionFrame(tx Tx, req ExecutionRequest) executionFrame
 			Computed:    map[string]any{},
 			Accumulated: map[string]any{},
 			FanOut:      map[string]any{},
+			BatchAgent:  map[string]any{},
 			Transformed: map[string]any{},
 		},
 		result: ExecutionResult{
@@ -624,6 +630,8 @@ func (e *Executor) runStep(frame *executionFrame, step Step) (bool, error) {
 		return false, e.stepCompute(frame)
 	case StepFanOut:
 		return e.stepFanOut(frame)
+	case StepBatchAgent:
+		return e.stepBatchAgent(frame)
 	case StepOnComplete:
 		return false, e.stepOnComplete(frame)
 	case StepRules:
@@ -1108,6 +1116,11 @@ func (e *Executor) stepOnComplete(frame *executionFrame) error {
 				return err
 			}
 		}
+		if rule.BatchAgent != nil {
+			if _, err := e.stepBatchAgent(frame); err != nil {
+				return err
+			}
+		}
 		if rule.Compute != nil {
 			return e.stepCompute(frame)
 		}
@@ -1129,6 +1142,11 @@ func (e *Executor) stepRules(frame *executionFrame) error {
 		e.applyRule(frame, rule)
 		if rule.FanOut != nil {
 			if _, err := e.stepFanOut(frame); err != nil {
+				return err
+			}
+		}
+		if rule.BatchAgent != nil {
+			if _, err := e.stepBatchAgent(frame); err != nil {
 				return err
 			}
 		}
@@ -1768,6 +1786,7 @@ func (e *Executor) currentContext(frame *executionFrame) BaseContext {
 	ctx = WithEvent(ctx, frame.req.Event.ContextMap(frame.state.State.CurrentState))
 	ctx = WithAccumulated(ctx, frame.state.Accumulated)
 	ctx = WithFanOutItem(ctx, frame.state.FanOut)
+	ctx = WithBatchAgent(ctx, frame.state.BatchAgent)
 	ctx.Metadata = values.Wrap(cloneStringAnyMap(frame.state.State.StateCarrier.Metadata))
 	ctx.Gates = values.Wrap(boolMapToAnyMap(frame.state.State.StateCarrier.Gates))
 	ctx.Entity = values.Wrap(frame.state.State.EntityContext())
@@ -1792,6 +1811,8 @@ func (e *Executor) writeStepValue(frame *executionFrame, target string, value an
 	case paths.RootFanOut:
 		frame.state.SetFanOut(strings.Join(parsed.Segments, "."), value)
 		return nil
+	case paths.RootBatchAgent:
+		return fmt.Errorf("target %s: unsupported target scope", target)
 	}
 	if frame.state.State.StateCarrier.Metadata == nil {
 		frame.state.State.StateCarrier.Metadata = map[string]any{}
@@ -1844,6 +1865,8 @@ func (e *Executor) clearStepValue(frame *executionFrame, target string) error {
 		delete(frame.state.Accumulated, strings.Join(parsed.Segments, "."))
 	case paths.RootFanOut:
 		delete(frame.state.FanOut, strings.Join(parsed.Segments, "."))
+	case paths.RootBatchAgent:
+		return fmt.Errorf("clear target %s: unsupported target scope", target)
 	case paths.RootEntity, paths.RootMetadata:
 		if parsed.Root == paths.RootEntity {
 			if _, resolved, _, err := resolveHandlerEntityWriteTarget(e.deps.Source, frame.req.FlowID.String(), target); err != nil {
@@ -1985,7 +2008,7 @@ func (e *Executor) applyDataAccumulation(frame *executionFrame, spec runtimecont
 			continue
 		}
 		switch parsed := paths.Parse(target); parsed.Root {
-		case paths.RootComputed, paths.RootAccumulated, paths.RootFanOut, paths.RootGates, paths.RootEvent, paths.RootPayload, paths.RootPolicy:
+		case paths.RootComputed, paths.RootAccumulated, paths.RootFanOut, paths.RootBatchAgent, paths.RootGates, paths.RootEvent, paths.RootPayload, paths.RootPolicy:
 			return fmt.Errorf("data_accumulation target %s: unsupported target scope", target)
 		}
 		if write.Value.HasLiteralValue() {
@@ -2032,6 +2055,13 @@ func (e *Executor) selectedFanOut(frame *executionFrame) *runtimecontracts.FanOu
 		return frame.rule.FanOut
 	}
 	return frame.req.Handler.FanOut
+}
+
+func (e *Executor) selectedBatchAgent(frame *executionFrame) *runtimecontracts.BatchAgentSpec {
+	if frame.rule != nil && frame.rule.BatchAgent != nil {
+		return frame.rule.BatchAgent
+	}
+	return frame.req.Handler.BatchAgent
 }
 
 func selectedEmitSpec(handler runtimecontracts.SystemNodeEventHandler, rule *runtimecontracts.HandlerRuleEntry) runtimecontracts.EmitSpec {

--- a/internal/runtime/engine/executor_test.go
+++ b/internal/runtime/engine/executor_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/division-sh/swarm/internal/events/eventtest"
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
 	"github.com/division-sh/swarm/internal/runtime/core/identity"
+	"github.com/division-sh/swarm/internal/runtime/core/paths"
 	runtimeregistry "github.com/division-sh/swarm/internal/runtime/core/registry"
 	"github.com/division-sh/swarm/internal/runtime/flowmodel"
 	"github.com/division-sh/swarm/internal/runtime/semanticview"
@@ -160,6 +161,11 @@ type stubGuardRegistry struct {
 	entries map[identity.GuardKey]runtimeregistry.GuardInstruction
 }
 type stubPayloadShaper struct{}
+type stubBatchAgentRunner struct {
+	output   any
+	err      error
+	requests []BatchAgentRequest
+}
 type recordingPayloadShaper struct {
 	lastReq     ExecutionRequest
 	lastPayload map[string]any
@@ -201,6 +207,13 @@ func (stubTimerApplier) ApplyTimerIntents(context.Context, identity.EntityID, []
 	return nil
 }
 func (stubDispatcher) DispatchPostCommit(context.Context, []EmitIntent) error { return nil }
+func (r *stubBatchAgentRunner) InvokeBatchAgent(_ context.Context, req BatchAgentRequest) (BatchAgentResponse, error) {
+	r.requests = append(r.requests, req)
+	if r.err != nil {
+		return BatchAgentResponse{}, r.err
+	}
+	return BatchAgentResponse{Output: r.output}, nil
+}
 func (s stubEvaluator) EvalBool(expression string, _ BaseContext) (bool, error) {
 	if err := s.errs[expression]; err != nil {
 		return false, err
@@ -575,8 +588,8 @@ func TestExecutor_StepOrderIsStable(t *testing.T) {
 		t.Fatalf("NewExecutor error: %v", err)
 	}
 	steps := exec.Steps()
-	if len(steps) != 20 {
-		t.Fatalf("step count = %d, want 20", len(steps))
+	if len(steps) != 21 {
+		t.Fatalf("step count = %d, want 21", len(steps))
 	}
 	if steps[0] != StepQuery || steps[len(steps)-1] != StepClear {
 		t.Fatalf("unexpected step order: %v", steps)
@@ -584,8 +597,11 @@ func TestExecutor_StepOrderIsStable(t *testing.T) {
 	if steps[5] != StepGroupBy {
 		t.Fatalf("expected group_by at index 5, got order %v", steps)
 	}
-	if steps[15] != StepProjection {
-		t.Fatalf("expected projection after data_writes at index 15, got order %v", steps)
+	if steps[10] != StepBatchAgent {
+		t.Fatalf("expected batch_agent after fan_out at index 10, got order %v", steps)
+	}
+	if steps[16] != StepProjection {
+		t.Fatalf("expected projection after data_writes at index 16, got order %v", steps)
 	}
 }
 
@@ -3264,6 +3280,217 @@ func TestExecutor_FanOutUsesExplicitEmitEvent(t *testing.T) {
 	if !result.EmitIntents[1].Event.CreatedAt().After(result.EmitIntents[0].Event.CreatedAt()) {
 		t.Fatalf("emit CreatedAt ordering = [%s, %s]", result.EmitIntents[0].Event.CreatedAt(), result.EmitIntents[1].Event.CreatedAt())
 	}
+}
+
+func TestExecutor_BatchAgentValidatesOutOfOrderRowsAndEmitsInInputOrder(t *testing.T) {
+	runner := &stubBatchAgentRunner{output: map[string]any{
+		"results": []any{
+			map[string]any{"account_id": "b", "bucket": "review", "score": 0.7},
+			map[string]any{"account_id": "a", "bucket": "accept", "score": 0.9},
+		},
+	}}
+	exec, err := NewExecutor(RuntimeDependencies{
+		Source:           stubSource(),
+		StateRepo:        stubStateRepo{},
+		TxRunner:         stubRunner{},
+		Locker:           stubLocker{},
+		Outbox:           stubOutbox{},
+		Dispatcher:       stubDispatcher{},
+		BatchAgentRunner: runner,
+		MaxChainDepth:    5,
+	}, nil)
+	if err != nil {
+		t.Fatalf("NewExecutor error: %v", err)
+	}
+	result, err := exec.Execute(context.Background(), ExecutionRequest{
+		EntityID:   "coordinator-1",
+		NodeID:     "coordinator",
+		FlowID:     "classifier",
+		ChainDepth: 1,
+		Event:      eventtest.RootIngress("evt-1", "classify.ready", "", "", json.RawMessage(`{"items":[{"account_id":"a","profile":"A"},{"account_id":"b","profile":"B"}]}`), 0, "", "", events.EventEnvelope{}, time.Time{}),
+		Handler: runtimecontracts.SystemNodeEventHandler{
+			BatchAgent: batchAgentTestSpec(),
+			AdvancesTo: "classified",
+		},
+		State: testStateSnapshot("ready", map[string]any{}, nil, map[string]map[string]any{}),
+	})
+	if err != nil {
+		t.Fatalf("Execute error: %v", err)
+	}
+	if result.Status != OutcomeFannedOut {
+		t.Fatalf("Status = %q", result.Status)
+	}
+	if result.BatchAgentCount != 2 || len(result.EmitIntents) != 2 {
+		t.Fatalf("batch_agent results wrong: count=%d intents=%d", result.BatchAgentCount, len(result.EmitIntents))
+	}
+	if len(runner.requests) != 1 || len(runner.requests[0].Items) != 2 {
+		t.Fatalf("runner requests = %#v", runner.requests)
+	}
+	firstPayload := decodeTestPayload(t, result.EmitIntents[0].Event.Payload())
+	secondPayload := decodeTestPayload(t, result.EmitIntents[1].Event.Payload())
+	if firstPayload["account_id"] != "a" || firstPayload["bucket"] != "accept" || firstPayload["source_profile"] != "A" {
+		t.Fatalf("first payload = %#v", firstPayload)
+	}
+	if secondPayload["account_id"] != "b" || secondPayload["bucket"] != "review" || secondPayload["source_profile"] != "B" {
+		t.Fatalf("second payload = %#v", secondPayload)
+	}
+	if result.NextState != "classified" {
+		t.Fatalf("NextState = %q", result.NextState)
+	}
+}
+
+func TestExecutor_BatchAgentValidationFailuresFailClosedBeforeEmit(t *testing.T) {
+	tests := []struct {
+		name        string
+		output      any
+		wantMessage string
+	}{
+		{
+			name: "missing_result_row",
+			output: map[string]any{"results": []any{
+				map[string]any{"account_id": "a", "bucket": "accept", "score": 0.9},
+			}},
+			wantMessage: `missing row for correlation key "b"`,
+		},
+		{
+			name: "duplicate_result_row",
+			output: map[string]any{"results": []any{
+				map[string]any{"account_id": "a", "bucket": "accept", "score": 0.9},
+				map[string]any{"account_id": "a", "bucket": "review", "score": 0.5},
+			}},
+			wantMessage: `duplicate correlation key "a"`,
+		},
+		{
+			name: "unknown_result_row",
+			output: map[string]any{"results": []any{
+				map[string]any{"account_id": "a", "bucket": "accept", "score": 0.9},
+				map[string]any{"account_id": "x", "bucket": "review", "score": 0.5},
+				map[string]any{"account_id": "b", "bucket": "reject", "score": 0.1},
+			}},
+			wantMessage: `unknown correlation key "x"`,
+		},
+		{
+			name: "malformed_result_row",
+			output: map[string]any{"results": []any{
+				"not-an-object",
+				map[string]any{"account_id": "b", "bucket": "reject", "score": 0.1},
+			}},
+			wantMessage: `row 0 is malformed`,
+		},
+		{
+			name: "partial_result_row",
+			output: map[string]any{"results": []any{
+				map[string]any{"account_id": "a", "bucket": "accept", "score": 0.9},
+				map[string]any{"account_id": "b", "bucket": "reject"},
+			}},
+			wantMessage: `missing required field "score"`,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			runner := &stubBatchAgentRunner{output: tc.output}
+			exec, err := NewExecutor(RuntimeDependencies{
+				Source:           stubSource(),
+				StateRepo:        stubStateRepo{},
+				TxRunner:         stubRunner{},
+				Locker:           stubLocker{},
+				Outbox:           stubOutbox{},
+				Dispatcher:       stubDispatcher{},
+				BatchAgentRunner: runner,
+				MaxChainDepth:    5,
+			}, nil)
+			if err != nil {
+				t.Fatalf("NewExecutor error: %v", err)
+			}
+			result, err := exec.Execute(context.Background(), ExecutionRequest{
+				EntityID:   "coordinator-1",
+				NodeID:     "coordinator",
+				FlowID:     "classifier",
+				ChainDepth: 1,
+				Event:      eventtest.RootIngress("evt-1", "classify.ready", "", "", json.RawMessage(`{"items":[{"account_id":"a","profile":"A"},{"account_id":"b","profile":"B"}]}`), 0, "", "", events.EventEnvelope{}, time.Time{}),
+				Handler: runtimecontracts.SystemNodeEventHandler{
+					BatchAgent: batchAgentTestSpec(),
+				},
+				State: testStateSnapshot("ready", map[string]any{}, nil, map[string]map[string]any{}),
+			})
+			if err == nil {
+				t.Fatal("expected batch_agent validation error")
+			}
+			if !strings.Contains(err.Error(), tc.wantMessage) {
+				t.Fatalf("error = %q, want substring %q", err.Error(), tc.wantMessage)
+			}
+			if len(result.EmitIntents) != 0 || len(result.DeadLetterIntents) != 0 {
+				t.Fatalf("expected no emits on validation failure, got emits=%d dead_letters=%d", len(result.EmitIntents), len(result.DeadLetterIntents))
+			}
+		})
+	}
+}
+
+func TestExecutor_BatchAgentNamespaceRejectsAuthoredStoreAs(t *testing.T) {
+	exec, err := NewExecutor(RuntimeDependencies{
+		Source:        stubSource(),
+		StateRepo:     stubStateRepo{},
+		TxRunner:      stubRunner{},
+		Locker:        stubLocker{},
+		Outbox:        stubOutbox{},
+		Dispatcher:    stubDispatcher{},
+		MaxChainDepth: 5,
+	}, nil)
+	if err != nil {
+		t.Fatalf("NewExecutor error: %v", err)
+	}
+	_, err = exec.Execute(context.Background(), ExecutionRequest{
+		EntityID:   "coordinator-1",
+		NodeID:     "coordinator",
+		FlowID:     "classifier",
+		ChainDepth: 1,
+		Event:      eventtest.RootIngress("evt-1", "classify.ready", "", "", json.RawMessage(`{"items":[{"account_id":"a"}]}`), 0, "", "", events.EventEnvelope{}, time.Time{}),
+		Handler: runtimecontracts.SystemNodeEventHandler{
+			Count: &runtimecontracts.CountSpec{
+				ItemsFrom: "payload.items",
+				StoreAs:   "batch_agent.count",
+			},
+		},
+		State: testStateSnapshot("ready", map[string]any{}, nil, map[string]map[string]any{}),
+	})
+	if err == nil {
+		t.Fatal("expected batch_agent authored store_as rejection")
+	}
+	if !strings.Contains(err.Error(), "unsupported target scope") {
+		t.Fatalf("error = %q, want unsupported target scope", err.Error())
+	}
+}
+
+func batchAgentTestSpec() *runtimecontracts.BatchAgentSpec {
+	return &runtimecontracts.BatchAgentSpec{
+		Agent:     "classifier",
+		ItemsFrom: "payload.items",
+		ItemsPath: paths.Parse("payload.items"),
+		Result: runtimecontracts.BatchAgentResultSpec{
+			ItemsFrom:      "results",
+			ItemsPath:      paths.Parse("results"),
+			CorrelationKey: "account_id",
+			RequiredFields: []string{"account_id", "bucket", "score"},
+		},
+		Emit: runtimecontracts.EmitSpec{
+			Event: "account.classified",
+			Fields: map[string]runtimecontracts.ExpressionValue{
+				"account_id":     runtimecontracts.RefExpression("batch_agent.result.account_id"),
+				"bucket":         runtimecontracts.RefExpression("batch_agent.result.bucket"),
+				"score":          runtimecontracts.RefExpression("batch_agent.result.score"),
+				"source_profile": runtimecontracts.RefExpression("batch_agent.source_item.profile"),
+			},
+		},
+	}
+}
+
+func decodeTestPayload(t *testing.T, raw json.RawMessage) map[string]any {
+	t.Helper()
+	var payload map[string]any
+	if err := json.Unmarshal(raw, &payload); err != nil {
+		t.Fatalf("unmarshal payload: %v", err)
+	}
+	return payload
 }
 
 func TestExecutor_GuardKillTransitionsToKilledStateWhenDeclared(t *testing.T) {

--- a/internal/runtime/engine/helpers.go
+++ b/internal/runtime/engine/helpers.go
@@ -107,6 +107,9 @@ func resolveParsedRef(base BaseContext, state ExecutionState, ref paths.Path) (a
 		if ref.Root == paths.RootFanOut {
 			return state.FanOutBucket().Lookup(ref)
 		}
+		if ref.Root == paths.RootBatchAgent {
+			return state.BatchAgentBucket().Lookup(ref)
+		}
 		if ref.Root == paths.RootComputed {
 			return state.ComputedBucket().Lookup(ref)
 		}
@@ -230,11 +233,12 @@ func applyDataAccumulationToState(base BaseContext, state ExecutionState, snapsh
 
 func evalWorkflowValueExpression(base BaseContext, state ExecutionState, expression string, opts workflowexpr.ValueExpressionOptions) (any, error) {
 	return workflowexpr.EvalValueExpressionWithOptions(expression, workflowexpr.ValueContext{
-		Entity:  base.Entity.Raw(),
-		Event:   base.Event.Raw(),
-		Payload: base.Payload.Raw(),
-		Policy:  base.Policy.Raw(),
-		FanOut:  state.FanOut,
+		Entity:     base.Entity.Raw(),
+		Event:      base.Event.Raw(),
+		Payload:    base.Payload.Raw(),
+		Policy:     base.Policy.Raw(),
+		FanOut:     state.FanOut,
+		BatchAgent: state.BatchAgent,
 	}, opts)
 }
 

--- a/internal/runtime/engine/interfaces.go
+++ b/internal/runtime/engine/interfaces.go
@@ -104,6 +104,25 @@ type PayloadShaper interface {
 	ShapeEmitPayload(ctx context.Context, req ExecutionRequest, eventType string, payload map[string]any) (map[string]any, error)
 }
 
+type BatchAgentRunner interface {
+	InvokeBatchAgent(ctx context.Context, req BatchAgentRequest) (BatchAgentResponse, error)
+}
+
+type BatchAgentRequest struct {
+	FlowID          string
+	NodeID          string
+	Agent           string
+	Items           []any
+	Input           map[string]any
+	ResultItemsFrom string
+	CorrelationKey  string
+	RequiredFields  []string
+}
+
+type BatchAgentResponse struct {
+	Output any
+}
+
 type TargetDescriptorLoader func(context.Context) ([]runtimepinrouting.Descriptor, error)
 
 type TransitionValidator interface {
@@ -123,6 +142,7 @@ type RuntimeDependencies struct {
 	GuardRunner         GuardRunner
 	ActionRegistry      ActionRegistry
 	ActionRunner        ActionRunner
+	BatchAgentRunner    BatchAgentRunner
 	PayloadShaper       PayloadShaper
 	TargetDescriptors   TargetDescriptorLoader
 	TransitionValidator TransitionValidator

--- a/internal/runtime/engine/types.go
+++ b/internal/runtime/engine/types.go
@@ -238,6 +238,7 @@ type ExecutionState struct {
 	Computed    map[string]any
 	Accumulated map[string]any
 	FanOut      map[string]any
+	BatchAgent  map[string]any
 	Transformed map[string]any
 }
 
@@ -251,6 +252,10 @@ func (s ExecutionState) AccumulatedBucket() values.Bucket {
 
 func (s ExecutionState) FanOutBucket() values.Bucket {
 	return values.Wrap(s.FanOut)
+}
+
+func (s ExecutionState) BatchAgentBucket() values.Bucket {
+	return values.Wrap(s.BatchAgent)
 }
 
 func (s *ExecutionState) SetComputed(key string, value any) {
@@ -272,6 +277,13 @@ func (s *ExecutionState) SetFanOut(key string, value any) {
 		s.FanOut = map[string]any{}
 	}
 	values.Wrap(s.FanOut).Set(key, value)
+}
+
+func (s *ExecutionState) SetBatchAgent(key string, value any) {
+	if s.BatchAgent == nil {
+		s.BatchAgent = map[string]any{}
+	}
+	values.Wrap(s.BatchAgent).Set(key, value)
 }
 
 type EmitIntent struct {
@@ -377,6 +389,7 @@ type ExecutionResult struct {
 	SetsGate                         string
 	RuleID                           string
 	FanOutCount                      int
+	BatchAgentCount                  int
 	Computed                         map[string]any
 	StateMutation                    StateMutation
 	TimerIntents                     []TimerIntent

--- a/internal/runtime/pipeline/coordinator.go
+++ b/internal/runtime/pipeline/coordinator.go
@@ -57,6 +57,7 @@ type PipelineCoordinator struct {
 	timerScheduler          *Scheduler
 	timerScheduleStore      SchedulePersistence
 	mailboxMaterializer     MailboxWriteMaterializationStore
+	batchAgentRunner        runtimeengine.BatchAgentRunner
 	eventReceiptsCapability func(context.Context) (bool, error)
 	artifactRoot            string
 	bundleFingerprint       string
@@ -78,6 +79,7 @@ type PipelineCoordinatorOptions struct {
 	TimerScheduler                   *Scheduler
 	TimerScheduleStore               SchedulePersistence
 	MailboxMaterializer              MailboxWriteMaterializationStore
+	BatchAgentRunner                 runtimeengine.BatchAgentRunner
 	EventReceiptsCapability          func(context.Context) (bool, error)
 	ArtifactRoot                     string
 	BundleFingerprint                string
@@ -109,6 +111,7 @@ func NewPipelineCoordinatorWithOptions(bus Bus, db *sql.DB, opts PipelineCoordin
 		timerScheduler:                   opts.TimerScheduler,
 		timerScheduleStore:               opts.TimerScheduleStore,
 		mailboxMaterializer:              opts.MailboxMaterializer,
+		batchAgentRunner:                 opts.BatchAgentRunner,
 		eventReceiptsCapability:          opts.EventReceiptsCapability,
 		artifactRoot:                     strings.TrimSpace(opts.ArtifactRoot),
 		bundleFingerprint:                strings.TrimSpace(opts.BundleFingerprint),
@@ -117,6 +120,15 @@ func NewPipelineCoordinatorWithOptions(bus Bus, db *sql.DB, opts PipelineCoordin
 		testLifecycleProbe:               opts.TestLifecycleProbe,
 		entityLocks:                      make(map[string]*sync.Mutex),
 	}
+}
+
+func (pc *PipelineCoordinator) SetBatchAgentRunner(runner runtimeengine.BatchAgentRunner) {
+	if pc == nil {
+		return
+	}
+	pc.mu.Lock()
+	pc.batchAgentRunner = runner
+	pc.mu.Unlock()
 }
 
 func NewPipelineCoordinator(bus Bus, db *sql.DB) *PipelineCoordinator {

--- a/internal/runtime/pipeline/engine_adapter.go
+++ b/internal/runtime/pipeline/engine_adapter.go
@@ -40,6 +40,7 @@ func (e pipelineEngineEvaluator) EvalBool(expression string, ctx runtimeengine.B
 		Policy:      cloneStringAnyMap(ctx.Policy.Raw()),
 		Accumulated: accumulatedItemsForCEL(ctx.Accumulated.Raw()),
 		FanOut:      cloneStringAnyMap(ctx.FanOut.Raw()),
+		BatchAgent:  cloneStringAnyMap(ctx.BatchAgent.Raw()),
 	}
 	queryCtx.QueryEntityCount = func(predicate string) (int, error) {
 		return e.queryEntityCount(queryCtx, predicate)
@@ -505,6 +506,7 @@ func coordinatorEngineDependencies(pc *PipelineCoordinator) runtimeengine.Runtim
 		GuardRunner:         pipelineEngineGuardRunner{coordinator: pc},
 		ActionRegistry:      pipelineEngineActionRegistry{registry: pc.ActionRegistry()},
 		ActionRunner:        pipelineEngineActionRunner{coordinator: pc},
+		BatchAgentRunner:    pc.batchAgentRunner,
 		PayloadShaper:       pipelineEnginePayloadShaper{coordinator: pc},
 		TargetDescriptors:   pipelineEngineTargetDescriptorLoader(pc),
 		TransitionValidator: pipelineEngineTransitionValidator{coordinator: pc},

--- a/internal/runtime/pipeline/engine_bridge.go
+++ b/internal/runtime/pipeline/engine_bridge.go
@@ -40,6 +40,7 @@ type handlerExecutionOutcome struct {
 	Emits            []string
 	RuleID           string
 	FanOutCount      int
+	BatchAgentCount  int
 	Computed         map[string]any
 	InterceptedEmits []runtimeengine.EmitIntent
 }
@@ -379,6 +380,7 @@ func handlerOutcomeFromExecutionResult(result runtimeengine.ExecutionResult) *ha
 		DataAccumulation: result.StateMutation.DataAccumulation,
 		RuleID:           strings.TrimSpace(result.RuleID),
 		FanOutCount:      result.FanOutCount,
+		BatchAgentCount:  result.BatchAgentCount,
 		Computed:         cloneStringAnyMap(result.Computed),
 		InterceptedEmits: append([]runtimeengine.EmitIntent(nil), result.DeadLetterIntents...),
 	}

--- a/internal/runtime/pipeline/node_declarative.go
+++ b/internal/runtime/pipeline/node_declarative.go
@@ -538,11 +538,17 @@ func emitSitesReferenceEntity(handler SystemNodeEventHandler) bool {
 	if handler.FanOut != nil && emitReferencesEntity(handler.FanOut.Emit) {
 		return true
 	}
+	if handler.BatchAgent != nil && emitReferencesEntity(handler.BatchAgent.Emit) {
+		return true
+	}
 	for _, rule := range handler.Rules {
 		if emitReferencesEntity(rule.Emit) {
 			return true
 		}
 		if rule.FanOut != nil && emitReferencesEntity(rule.FanOut.Emit) {
+			return true
+		}
+		if rule.BatchAgent != nil && emitReferencesEntity(rule.BatchAgent.Emit) {
 			return true
 		}
 	}
@@ -551,6 +557,9 @@ func emitSitesReferenceEntity(handler SystemNodeEventHandler) bool {
 			return true
 		}
 		if rule.FanOut != nil && emitReferencesEntity(rule.FanOut.Emit) {
+			return true
+		}
+		if rule.BatchAgent != nil && emitReferencesEntity(rule.BatchAgent.Emit) {
 			return true
 		}
 	}
@@ -562,6 +571,9 @@ func emitSitesReferenceEntity(handler SystemNodeEventHandler) bool {
 			if rule.FanOut != nil && emitReferencesEntity(rule.FanOut.Emit) {
 				return true
 			}
+			if rule.BatchAgent != nil && emitReferencesEntity(rule.BatchAgent.Emit) {
+				return true
+			}
 		}
 		if handler.Accumulate.OnTimeout != nil {
 			rule := handler.Accumulate.OnTimeout
@@ -569,6 +581,9 @@ func emitSitesReferenceEntity(handler SystemNodeEventHandler) bool {
 				return true
 			}
 			if rule.FanOut != nil && emitReferencesEntity(rule.FanOut.Emit) {
+				return true
+			}
+			if rule.BatchAgent != nil && emitReferencesEntity(rule.BatchAgent.Emit) {
 				return true
 			}
 		}

--- a/internal/runtime/pipeline/workflow_execution_plan.go
+++ b/internal/runtime/pipeline/workflow_execution_plan.go
@@ -29,6 +29,7 @@ type handlerExecutionPlan struct {
 	Accumulate       *runtimecontracts.AccumulateSpec
 	Compute          *runtimecontracts.ComputeSpec
 	FanOut           *runtimecontracts.FanOutSpec
+	BatchAgent       *runtimecontracts.BatchAgentSpec
 	AdvancesTo       string
 	SetsGate         string
 	ClearGates       bool
@@ -78,6 +79,7 @@ func handlerExecutionPlanFromNodeHandler(nodeID, eventType string, handler runti
 		Accumulate:       handler.Accumulate,
 		Compute:          handler.Compute,
 		FanOut:           handler.FanOut,
+		BatchAgent:       handler.BatchAgent,
 		AdvancesTo:       strings.TrimSpace(handler.AdvancesTo),
 		SetsGate:         gateSpecString(handler.SetsGate),
 		ClearGates:       len(handler.ClearGates) > 0,
@@ -107,6 +109,9 @@ func handlerExecutionOrderForPlan(plan handlerExecutionPlan) []string {
 	}
 	if plan.FanOut != nil {
 		steps = append(steps, "fan_out")
+	}
+	if plan.BatchAgent != nil {
+		steps = append(steps, "batch_agent")
 	}
 	if len(plan.OnComplete) > 0 {
 		steps = append(steps, "on_complete")
@@ -151,11 +156,17 @@ func handlerPlanHasEmitFields(plan handlerExecutionPlan) bool {
 	if plan.FanOut != nil && plan.FanOut.Emit.HasFields() {
 		return true
 	}
+	if plan.BatchAgent != nil && plan.BatchAgent.Emit.HasFields() {
+		return true
+	}
 	for _, rule := range plan.Rules {
 		if rule.Emit.HasFields() {
 			return true
 		}
 		if rule.FanOut != nil && rule.FanOut.Emit.HasFields() {
+			return true
+		}
+		if rule.BatchAgent != nil && rule.BatchAgent.Emit.HasFields() {
 			return true
 		}
 	}
@@ -164,6 +175,9 @@ func handlerPlanHasEmitFields(plan handlerExecutionPlan) bool {
 			return true
 		}
 		if rule.FanOut != nil && rule.FanOut.Emit.HasFields() {
+			return true
+		}
+		if rule.BatchAgent != nil && rule.BatchAgent.Emit.HasFields() {
 			return true
 		}
 	}
@@ -175,12 +189,18 @@ func handlerPlanHasEmitFields(plan handlerExecutionPlan) bool {
 			if rule.FanOut != nil && rule.FanOut.Emit.HasFields() {
 				return true
 			}
+			if rule.BatchAgent != nil && rule.BatchAgent.Emit.HasFields() {
+				return true
+			}
 		}
 		if plan.Accumulate.OnTimeout != nil {
 			if plan.Accumulate.OnTimeout.Emit.HasFields() {
 				return true
 			}
 			if plan.Accumulate.OnTimeout.FanOut != nil && plan.Accumulate.OnTimeout.FanOut.Emit.HasFields() {
+				return true
+			}
+			if plan.Accumulate.OnTimeout.BatchAgent != nil && plan.Accumulate.OnTimeout.BatchAgent.Emit.HasFields() {
 				return true
 			}
 		}

--- a/internal/runtime/pipeline/workflow_expression_evaluator.go
+++ b/internal/runtime/pipeline/workflow_expression_evaluator.go
@@ -28,6 +28,7 @@ type workflowExpressionContext struct {
 	Policy                       map[string]any
 	Accumulated                  any
 	FanOut                       map[string]any
+	BatchAgent                   map[string]any
 	QueryEntityCount             func(string) (int, error)
 	AllowUnresolvedQueryOperands bool
 }
@@ -46,6 +47,7 @@ func newWorkflowExpressionEvaluator() *workflowExpressionEvaluator {
 		cel.Variable("policy", cel.DynType),
 		cel.Variable("accumulated", cel.DynType),
 		cel.Variable("fan_out", cel.DynType),
+		cel.Variable("batch_agent", cel.DynType),
 		cel.Function("count_ge",
 			cel.Overload(
 				"count_ge_dyn_dyn",
@@ -89,6 +91,7 @@ func (e *workflowExpressionEvaluator) EvalBool(expression string, ctx workflowEx
 		"policy":      workflowNormalizeCELInput(cloneStringAnyMap(normalizedCtx.Policy)),
 		"accumulated": normalizedCtx.Accumulated,
 		"fan_out":     workflowNormalizeCELInput(cloneStringAnyMap(normalizedCtx.FanOut)),
+		"batch_agent": workflowNormalizeCELInput(cloneStringAnyMap(normalizedCtx.BatchAgent)),
 	})
 	if err != nil {
 		return false, err
@@ -156,6 +159,7 @@ func normalizeWorkflowExpression(expression string, ctx workflowExpressionContex
 			Policy:                       cloneStringAnyMap(ctx.Policy),
 			Accumulated:                  cloneAccumulatedItems(ctx.Accumulated),
 			FanOut:                       cloneStringAnyMap(ctx.FanOut),
+			BatchAgent:                   cloneStringAnyMap(ctx.BatchAgent),
 			QueryEntityCount:             ctx.QueryEntityCount,
 			AllowUnresolvedQueryOperands: ctx.AllowUnresolvedQueryOperands,
 		}, nil
@@ -188,6 +192,7 @@ func normalizeWorkflowExpression(expression string, ctx workflowExpressionContex
 		Policy:                       cloneStringAnyMap(ctx.Policy),
 		Accumulated:                  cloneAccumulatedItems(ctx.Accumulated),
 		FanOut:                       cloneStringAnyMap(ctx.FanOut),
+		BatchAgent:                   cloneStringAnyMap(ctx.BatchAgent),
 		QueryEntityCount:             ctx.QueryEntityCount,
 		AllowUnresolvedQueryOperands: ctx.AllowUnresolvedQueryOperands,
 	}
@@ -296,7 +301,7 @@ func workflowExpressionResolveQueryOperand(raw string, ctx workflowExpressionCon
 	}
 	if root, scoped := workflowExpressionQueryOperandScope(raw); scoped {
 		switch root {
-		case "entity", "event", "payload", "policy", "fan_out":
+		case "entity", "event", "payload", "policy", "fan_out", "batch_agent":
 			if ctx.AllowUnresolvedQueryOperands {
 				return raw, nil
 			}
@@ -339,6 +344,8 @@ func workflowExpressionLookupContextValue(ref string, ctx workflowExpressionCont
 		return workflowExpressionLookupPath(ctx.Policy, strings.TrimPrefix(ref, "policy."))
 	case strings.HasPrefix(ref, "fan_out."):
 		return workflowExpressionLookupPath(ctx.FanOut, strings.TrimPrefix(ref, "fan_out."))
+	case strings.HasPrefix(ref, "batch_agent."):
+		return workflowExpressionLookupPath(ctx.BatchAgent, strings.TrimPrefix(ref, "batch_agent."))
 	default:
 		return nil, false
 	}

--- a/internal/runtime/pipeline/workflow_handler_preview.go
+++ b/internal/runtime/pipeline/workflow_handler_preview.go
@@ -25,6 +25,7 @@ type HandlerPreview struct {
 	SetsGate        string
 	ClearGates      []string
 	FanOutCount     int
+	BatchAgentCount int
 	Computed        map[string]any
 }
 
@@ -148,6 +149,7 @@ func PreviewContractHandlerExecution(ctx context.Context, bundle *runtimecontrac
 	setsGate := ""
 	clearGates := []string(nil)
 	fanOutCount := 0
+	batchAgentCount := 0
 	computed := map[string]any(nil)
 	status := HandlerOutcomeCompleted
 	if result.Outcome != nil {
@@ -158,6 +160,7 @@ func PreviewContractHandlerExecution(ctx context.Context, bundle *runtimecontrac
 		setsGate = strings.TrimSpace(result.Outcome.SetsGate)
 		clearGates = append(clearGates, result.Outcome.ClearGates...)
 		fanOutCount = result.Outcome.FanOutCount
+		batchAgentCount = result.Outcome.BatchAgentCount
 		computed = cloneStringAnyMap(result.Outcome.Computed)
 	}
 	return HandlerPreview{
@@ -173,6 +176,7 @@ func PreviewContractHandlerExecution(ctx context.Context, bundle *runtimecontrac
 		SetsGate:        setsGate,
 		ClearGates:      clearGates,
 		FanOutCount:     fanOutCount,
+		BatchAgentCount: batchAgentCount,
 		Computed:        computed,
 	}, nil
 }

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -513,6 +513,9 @@ func NewRuntime(ctx context.Context, deps RuntimeDeps) (*Runtime, error) {
 		}
 	}
 	rt.LLM = modelRuntime
+	if rt.Pipeline != nil {
+		rt.Pipeline.SetBatchAgentRunner(newLLMBatchAgentRunner(rt.LLM, source, rt.PromptResolver))
+	}
 	if warnings, err := runtimetools.ValidateNativeToolBootConfig(ctx, source, rt.Credentials, modelRuntime); err != nil {
 		return nil, fmt.Errorf("native tool validation failed: %w", err)
 	} else {

--- a/internal/runtime/semanticview/authored_emit_sites.go
+++ b/internal/runtime/semanticview/authored_emit_sites.go
@@ -131,11 +131,17 @@ func (b *authoredEmitSiteBuilder) appendHandlerSites(kind AuthoredEmitSiteSource
 		if rule.FanOut != nil {
 			add("handler.rules.fan_out.emit", indexedAuthoredEmitSiteKey("handler.rules", idx, "fan_out.emit"), rule.ID, rule.FanOut.Emit)
 		}
+		if rule.BatchAgent != nil {
+			add("handler.rules.batch_agent.emit", indexedAuthoredEmitSiteKey("handler.rules", idx, "batch_agent.emit"), rule.ID, rule.BatchAgent.Emit)
+		}
 	}
 	for idx, rule := range handler.OnComplete {
 		add("handler.on_complete.emit", indexedAuthoredEmitSiteKey("handler.on_complete", idx, "emit"), rule.ID, rule.Emit)
 		if rule.FanOut != nil {
 			add("handler.on_complete.fan_out.emit", indexedAuthoredEmitSiteKey("handler.on_complete", idx, "fan_out.emit"), rule.ID, rule.FanOut.Emit)
+		}
+		if rule.BatchAgent != nil {
+			add("handler.on_complete.batch_agent.emit", indexedAuthoredEmitSiteKey("handler.on_complete", idx, "batch_agent.emit"), rule.ID, rule.BatchAgent.Emit)
 		}
 	}
 	if handler.Accumulate != nil {
@@ -144,16 +150,25 @@ func (b *authoredEmitSiteBuilder) appendHandlerSites(kind AuthoredEmitSiteSource
 			if rule.FanOut != nil {
 				add("handler.accumulate.on_complete.fan_out.emit", indexedAuthoredEmitSiteKey("handler.accumulate.on_complete", idx, "fan_out.emit"), rule.ID, rule.FanOut.Emit)
 			}
+			if rule.BatchAgent != nil {
+				add("handler.accumulate.on_complete.batch_agent.emit", indexedAuthoredEmitSiteKey("handler.accumulate.on_complete", idx, "batch_agent.emit"), rule.ID, rule.BatchAgent.Emit)
+			}
 		}
 		if handler.Accumulate.OnTimeout != nil {
 			add("handler.accumulate.on_timeout.emit", "handler.accumulate.on_timeout.emit", handler.Accumulate.OnTimeout.ID, handler.Accumulate.OnTimeout.Emit)
 			if handler.Accumulate.OnTimeout.FanOut != nil {
 				add("handler.accumulate.on_timeout.fan_out.emit", "handler.accumulate.on_timeout.fan_out.emit", handler.Accumulate.OnTimeout.ID, handler.Accumulate.OnTimeout.FanOut.Emit)
 			}
+			if handler.Accumulate.OnTimeout.BatchAgent != nil {
+				add("handler.accumulate.on_timeout.batch_agent.emit", "handler.accumulate.on_timeout.batch_agent.emit", handler.Accumulate.OnTimeout.ID, handler.Accumulate.OnTimeout.BatchAgent.Emit)
+			}
 		}
 	}
 	if handler.FanOut != nil {
 		add("handler.fan_out.emit", "handler.fan_out.emit", "", handler.FanOut.Emit)
+	}
+	if handler.BatchAgent != nil {
+		add("handler.batch_agent.emit", "handler.batch_agent.emit", "", handler.BatchAgent.Emit)
 	}
 }
 

--- a/internal/runtime/testfixtures/batchagentcoordinatorpilot/fixture.go
+++ b/internal/runtime/testfixtures/batchagentcoordinatorpilot/fixture.go
@@ -1,0 +1,277 @@
+package batchagentcoordinatorpilot
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
+	"github.com/division-sh/swarm/internal/runtime/semanticview"
+)
+
+const (
+	CoordinatorFlowID = "coordinator"
+	AccountFlowID     = "accounts"
+	NodeID            = "batch-classifier"
+	InputEvent        = "account.profile_observed"
+	OutputEvent       = "account.classified"
+	OutputPin         = "account_classified"
+	AgentID           = "profile-classifier"
+)
+
+func LoadBundle(t testing.TB) *runtimecontracts.WorkflowContractBundle {
+	t.Helper()
+	bundle, err := LoadBundleResult(t)
+	if err != nil {
+		t.Fatalf("LoadWorkflowContractBundleWithOverrides: %v", err)
+	}
+	return bundle
+}
+
+func LoadBundleResult(t testing.TB) (*runtimecontracts.WorkflowContractBundle, error) {
+	t.Helper()
+	root := Write(t)
+	return runtimecontracts.LoadWorkflowContractBundleWithOverrides(repoRoot(t), root, runtimecontracts.DefaultPlatformSpecFile(repoRoot(t)))
+}
+
+func LoadSource(t testing.TB) semanticview.Source {
+	t.Helper()
+	return semanticview.Wrap(LoadBundle(t))
+}
+
+func Write(t testing.TB) string {
+	t.Helper()
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "package.yaml"), `
+name: batch-agent-coordinator-pilot
+version: "1.0.0"
+platform_version: ">=1.6.0"
+flows:
+  - id: coordinator
+    flow: coordinator
+    mode: singleton
+  - id: accounts
+    flow: accounts
+    mode: template
+connect:
+  - from: coordinator.account_classified
+    to: accounts.account_classified
+    delivery: one
+`)
+	writeRootFiles(t, root)
+	writeCoordinator(t, root)
+	writeAccounts(t, root)
+	return root
+}
+
+func writeRootFiles(t testing.TB, root string) {
+	t.Helper()
+	writeFile(t, filepath.Join(root, "schema.yaml"), "name: batch-agent-coordinator-pilot\n")
+	writeFile(t, filepath.Join(root, "policy.yaml"), "{}\n")
+	writeFile(t, filepath.Join(root, "tools.yaml"), "{}\n")
+	writeFile(t, filepath.Join(root, "agents.yaml"), "{}\n")
+	writeFile(t, filepath.Join(root, "events.yaml"), "{}\n")
+	writeFile(t, filepath.Join(root, "nodes.yaml"), "{}\n")
+}
+
+func writeCoordinator(t testing.TB, root string) {
+	t.Helper()
+	writeFile(t, filepath.Join(root, "flows", "coordinator", "schema.yaml"), `
+name: coordinator
+mode: singleton
+initial_state: collecting
+states: [collecting, classified]
+required_agents:
+  - role: profile-classifier
+    subscribes_to: []
+    emits: []
+pins:
+  inputs:
+    events:
+      - name: profile_observed
+        event: account.profile_observed
+  outputs:
+    events:
+      - name: account_classified
+        event: account.classified
+        key: account_id
+        carries: [account_id, bucket, score, handle]
+`)
+	writeFile(t, filepath.Join(root, "flows", "coordinator", "policy.yaml"), "{}\n")
+	writeFile(t, filepath.Join(root, "flows", "coordinator", "tools.yaml"), "{}\n")
+	writeFile(t, filepath.Join(root, "flows", "coordinator", "agents.yaml"), `
+profile-classifier:
+  id: profile-classifier
+  role: profile-classifier
+  model: cheap
+  mode: task
+  subscriptions: [account.profile_observed]
+  max_turns_per_task: 1
+  prompt_ref: prompts/profile_classifier.md
+`)
+	writeFile(t, filepath.Join(root, "flows", "coordinator", "prompts", "profile_classifier.md"), `
+Classify each profile row and return strict JSON:
+{"results":[{"account_id":"...","bucket":"...","score":0}]}
+`)
+	writeFile(t, filepath.Join(root, "flows", "coordinator", "types.yaml"), `
+types:
+  ProfileObservation:
+    account_id: text
+    handle: text
+    followers: integer
+`)
+	writeFile(t, filepath.Join(root, "flows", "coordinator", "entities.yaml"), `
+coordinator_state:
+  coordinator_id: text
+  pending_profiles:
+    type: "[ProfileObservation]"
+    initial: []
+`)
+	writeFile(t, filepath.Join(root, "flows", "coordinator", "events.yaml"), `
+account.profile_observed:
+  swarm:
+    source: external (batch-agent coordinator pilot ingress)
+  coordinator_id: text
+  expected_count: integer
+  account_id: text
+  handle: text
+  followers: integer
+account.classified:
+  account_id: text
+  bucket: text
+  score: integer
+  handle: text
+`)
+	writeFile(t, filepath.Join(root, "flows", "coordinator", "nodes.yaml"), `
+batch-classifier:
+  id: batch-classifier
+  execution_type: system_node
+  subscribes_to: [account.profile_observed]
+  produces: [account.classified]
+  event_handlers:
+    account.profile_observed:
+      select_entity:
+        by:
+          coordinator_id: payload.coordinator_id
+      data_accumulation:
+        writes:
+          - source_field: coordinator_id
+            target_field: coordinator_id
+          - op: append
+            target: entity.pending_profiles
+            value:
+              account_id: fixture-account
+              handle: fixture-handle
+              followers: 0
+      accumulate:
+        into: pending_profiles
+        expected_from: payload.expected_count
+        completion: all
+        dedup_by: payload.account_id
+        on_complete:
+          - id: classify-ready
+            condition: else
+            advances_to: classified
+            batch_agent:
+              agent: profile-classifier
+              items_from: accumulated.items
+              input:
+                instruction: Classify each account profile by sales fit.
+                coordinator_id:
+                  ref: entity.coordinator_id
+              result:
+                items_from: results
+                correlation_key: account_id
+                required_fields: [account_id, bucket, score]
+              emit:
+                event: account.classified
+                fields:
+                  account_id: batch_agent.result.account_id
+                  bucket: batch_agent.result.bucket
+                  score: batch_agent.result.score
+                  handle: batch_agent.source_item.handle
+  state_schema:
+    fields:
+      pending_profiles: "[ProfileObservation]"
+`)
+}
+
+func writeAccounts(t testing.TB, root string) {
+	t.Helper()
+	writeFile(t, filepath.Join(root, "flows", "accounts", "schema.yaml"), `
+name: accounts
+mode: template
+initial_state: pending
+states: [pending, classified]
+terminal_states: [classified]
+instance:
+  by: account_id
+  on_missing: create
+  on_conflict: reuse
+pins:
+  inputs:
+    events:
+      - name: account_classified
+        event: account.classified
+  outputs:
+    events: []
+`)
+	writeFile(t, filepath.Join(root, "flows", "accounts", "policy.yaml"), "{}\n")
+	writeFile(t, filepath.Join(root, "flows", "accounts", "tools.yaml"), "{}\n")
+	writeFile(t, filepath.Join(root, "flows", "accounts", "agents.yaml"), "{}\n")
+	writeFile(t, filepath.Join(root, "flows", "accounts", "types.yaml"), "{}\n")
+	writeFile(t, filepath.Join(root, "flows", "accounts", "entities.yaml"), `
+account:
+  account_id: text
+  bucket: text
+  score: integer
+  handle: text
+`)
+	writeFile(t, filepath.Join(root, "flows", "accounts", "events.yaml"), `
+account.classified:
+  account_id: text
+  bucket: text
+  score: integer
+  handle: text
+`)
+	writeFile(t, filepath.Join(root, "flows", "accounts", "nodes.yaml"), `
+classification-recorder:
+  id: classification-recorder
+  execution_type: system_node
+  subscribes_to: [account.classified]
+  event_handlers:
+    account.classified:
+      data_accumulation:
+        writes:
+          - source_field: account_id
+            target_field: account_id
+          - source_field: bucket
+            target_field: bucket
+          - source_field: score
+            target_field: score
+          - source_field: handle
+            target_field: handle
+      advances_to: classified
+`)
+}
+
+func repoRoot(t testing.TB) string {
+	t.Helper()
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("resolve repo root")
+	}
+	return filepath.Clean(filepath.Join(filepath.Dir(file), "..", "..", "..", ".."))
+}
+
+func writeFile(t testing.TB, path, contents string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, []byte(strings.TrimLeft(contents, "\n")), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}

--- a/internal/runtime/workflowexpr/data_expression.go
+++ b/internal/runtime/workflowexpr/data_expression.go
@@ -34,11 +34,12 @@ var (
 )
 
 type ValueContext struct {
-	Entity  map[string]any
-	Event   map[string]any
-	Payload map[string]any
-	Policy  map[string]any
-	FanOut  map[string]any
+	Entity     map[string]any
+	Event      map[string]any
+	Payload    map[string]any
+	Policy     map[string]any
+	FanOut     map[string]any
+	BatchAgent map[string]any
 }
 
 type ValueExpressionOptions struct {
@@ -90,11 +91,12 @@ func EvalValueExpressionWithOptions(expression string, ctx ValueContext, opts Va
 		return nil, err
 	}
 	activation := map[string]any{
-		"entity":  NormalizeCELInputMap(ctx.Entity),
-		"event":   NormalizeCELInputMap(ctx.Event),
-		"payload": NormalizeCELInputMap(ctx.Payload),
-		"policy":  NormalizeCELInputMap(ctx.Policy),
-		"fan_out": NormalizeCELInputMap(ctx.FanOut),
+		"entity":      NormalizeCELInputMap(ctx.Entity),
+		"event":       NormalizeCELInputMap(ctx.Event),
+		"payload":     NormalizeCELInputMap(ctx.Payload),
+		"policy":      NormalizeCELInputMap(ctx.Policy),
+		"fan_out":     NormalizeCELInputMap(ctx.FanOut),
+		"batch_agent": NormalizeCELInputMap(ctx.BatchAgent),
 	}
 	if opts.AllowBareItem {
 		activation["item"] = NormalizeCELValue(ctx.FanOut["item"])
@@ -352,6 +354,7 @@ func newDataExpressionEnv(allowBareItem bool) (*cel.Env, error) {
 		cel.Variable("payload", cel.DynType),
 		cel.Variable("policy", cel.DynType),
 		cel.Variable("fan_out", cel.DynType),
+		cel.Variable("batch_agent", cel.DynType),
 	}
 	if allowBareItem {
 		variables = append(variables, cel.Variable("item", cel.DynType))

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -959,7 +959,7 @@ contract_formats:
   produces_derivation: >-
     The produces field on system nodes is OPTIONAL. If omitted, the platform derives it from every supported declarative
     emit site at boot: handler top-level emit, rule-local emit, on_complete branch emit, accumulate.on_timeout emit, and
-    fan_out emit. If present, the verifier checks it matches actual emits (PRODUCES-DRIFT warning). Authors should omit
+    fan_out emit, and batch_agent emit. If present, the verifier checks it matches actual emits (PRODUCES-DRIFT warning). Authors should omit
     produces and let the platform derive it.
   underscore_prefix_convention:
     description: Fields starting with _ in contract YAML files.
@@ -1328,7 +1328,7 @@ handler_specification:
       \ data into handler context)\n       └→ clear_gates (optional — reset gates before guard)\n            └→ guard\n            └→ accumulate\n                 └→ filter (optional — prune accumulated\
       \ items)\n                      └→ reduce (optional — aggregate filtered items to single value)\n                  \
       \         └→ count (optional — count items)\n                                └→ compute\n                          \
-      \           └→ emit-site selection (handler emit OR active branch/rule/timeout/fan_out emit)\n                    \
+      \           └→ emit-site selection (handler emit OR active branch/rule/timeout/fan_out/batch_agent emit)\n                    \
       \                      └→ advances_to ─┐\n                                             sets_gate ────┤ (independent\
       \ of each other)\n                                             data_accumulation ┘\n                         \
       \                         └→ projection (materialize_from, if accumulator projection eligible)\n                  \
@@ -1577,14 +1577,75 @@ handler_specification:
           example: "compute:\n  operation: weighted_average\n  keys:\n    dimension_key: dimension\n    score_keys: [score]\n\
             \  tiers:\n  - dimensions: [build_complexity, automation_completeness]\n    weight: 0.6\n  - dimensions: [pain_severity]\n\
             \    weight: 0.4\n  store_as: entity.composite_score"
+    batch_agent:
+      field: batch_agent
+      promoted_by: '#1447'
+      canonical_code_owner: internal/runtime/engine.BatchAgentRunner + internal/runtime/engine.stepBatchAgent
+      type: object
+      purpose: >
+        Invoke one configured agent turn over a typed list of items and scatter
+        one validated result row per input item through a normal declarative
+        emit site. `batch_agent` is a supported emit site, not a routing
+        primitive; routing authority remains the emitted event's output pin,
+        parent `connect` lowering, structural binding, or explicit escape hatch.
+      valid_locations:
+      - handler.batch_agent
+      - handler.rules[*].batch_agent
+      - handler.on_complete[*].batch_agent
+      - handler.accumulate.on_complete[*].batch_agent
+      - handler.accumulate.on_timeout.batch_agent
+      sub_fields:
+        agent: string — required agent id/role to invoke for the batch operation.
+        items_from: string — required expression/path resolving to the input item list in handler context.
+        input: map — optional expression-value map sent once with the batch request.
+        result: object — required result contract for validating the agent output rows.
+        emit: object — required declarative emit spec used once per accepted row.
+      result:
+        items_from: string — required path inside the agent output object resolving to the result row list.
+        correlation_key: string — required field/path present on every input item and every result row.
+        required_fields: list — required result-row fields. The correlation key is always required even if omitted here.
+      runtime_semantics: >
+        The runtime reads the input item list, evaluates `input`, invokes the
+        agent once, extracts `result.items_from` from the returned JSON object,
+        validates the complete row set atomically, reorders accepted rows to
+        input order by `correlation_key`, and evaluates `emit.fields` for each
+        row with `batch_agent.result`, `batch_agent.source_item`,
+        `batch_agent.key`, `batch_agent.count`, and `batch_agent.agent`
+        available in expression context.
+      fail_closed:
+      - missing batch_agent.agent
+      - missing batch_agent.items_from
+      - missing batch_agent.result.items_from
+      - missing batch_agent.result.correlation_key
+      - missing batch_agent.emit.event
+      - input item is not an object
+      - input item is missing the correlation key
+      - duplicate input correlation key
+      - agent runner unavailable or agent output is not a JSON object
+      - result.items_from missing or not a list
+      - result row is not an object
+      - result row missing, duplicate, unknown, or empty correlation key
+      - result row missing any required field
+      routing_rules:
+      - batch_agent.emit produces ordinary declarative emit intents.
+      - Pin-declared batch_agent emits MUST consume the same pin/connect route authority as handler, rule, on_complete, and fan_out emits.
+      - batch_agent MUST NOT use select_entity, producer target, broadcast:true, direct delivery, RouteTable, raw subscribers, replay/readback, or relay nodes as scatter authority.
+      - Agent output is untrusted operation output. It never authorizes routing; only validated emit payload fields can feed the existing emitted event route plan.
+      non_authoritative_paths:
+      - producer target/broadcast as common-path scatter routing
+      - direct delivery or RouteTable lookup from the batch result rows
+      - raw subscriber fan-out from returned result rows
+      - dynamic bracket/path writes into batch_agent state
+      example: "accumulate:\n  into: pending_profiles\n  expected_from: payload.expected_count\n  completion: all\n  dedup_by: payload.account_id\n  on_complete:\n    - condition: else\n      batch_agent:\n        agent: profile-classifier\n        items_from: accumulated.items\n        input:\n          instruction: Classify each account profile by sales fit.\n        result:\n          items_from: results\n          correlation_key: account_id\n          required_fields: [account_id, bucket, score]\n        emit:\n          event: account.classified\n          fields:\n            account_id: batch_agent.result.account_id\n            bucket: batch_agent.result.bucket\n            score: batch_agent.result.score\n            handle: batch_agent.source_item.handle"
     on_complete:
       field: on_complete
-      type: list of {condition, advances_to, emit} objects — evaluated top-to-bottom, first match wins
+      type: list of {condition, advances_to, emit, fan_out, batch_agent} objects — evaluated top-to-bottom, first match wins
       purpose: Conditional branching after accumulation or computation.
       branch_fields:
         condition: string — expression evaluated against entity state and policy
         advances_to: string — target state
         emit: string or object — event to emit, optionally with local fields payload construction
+        batch_agent: object — batch agent operation and row-scatter emit site
       _note: MUST be a YAML list (ordered), not a map (unordered). Each entry has a condition evaluated as CEL. First matching
         condition executes.
     advances_to:
@@ -1708,7 +1769,7 @@ handler_specification:
       type: 'scalar event name OR object: {event, fields, target, broadcast}'
       purpose: Publish the selected follow-up event for this emit site. Handler top-level emit is allowed only when the handler
         has no nested emit sites. Nested emit sites are branch-local on_complete emit, rules emit, accumulate.on_timeout emit,
-        and fan_out emit.
+        fan_out emit, and batch_agent emit.
       sub_fields:
         event: string — event to emit
         fields: map of output_field_name → CEL expression evaluated against handler context. Optional. If omitted, the emitted
@@ -1759,7 +1820,7 @@ handler_specification:
           delivery to receiver input pins for the same pin-declared output or connected output pin; parent connect
           broadcast/fan-out is the required route owner.
       single_emit_handler_rule: 'A handler top-level emit is valid only when the handler has exactly one possible emit site.
-        If the handler also declares rules, on_complete, accumulate.on_timeout, or fan_out emit, boot fails with ambiguity.
+        If the handler also declares rules, on_complete, accumulate.on_timeout, fan_out emit, or batch_agent emit, boot fails with ambiguity.
         Payload ownership must move to the active emit site.'
     rules:
       field: rules


### PR DESCRIPTION
## Summary
- Add `batch_agent` as a supported declarative batch operation and emit site for handler, rule, on_complete, accumulate.on_complete, and accumulate.on_timeout contexts.
- Validate agent result rows fail-closed by correlation key, required fields, unknown/duplicate/missing/malformed rows, and reorder accepted rows to input order before emitting.
- Add the batch-agent coordinator conformance fixture proving accumulated typed input, contained state operation use, batch result scatter, and parent `connect` route-plan authority.

Closes #1447.

## Governing refs / context
- `platform-spec.yaml` `handler_specification.handler_fields.batch_agent` promoted by #1447.
- `platform-spec.yaml` emit/pin-routing authority: pin-declared emits must consume parent `connect` lowering, structural binding, or explicit escape hatch; no target/broadcast/direct/RouteTable scatter authority.
- Binding issue context: #1447 pre-audit and lead approval for the first slice: coordinator-owned batch-agent operation over typed pending coordinator state, one configured agent turn, typed result rows by declared correlation key, scatter via existing output pin/parent `connect` route authority.

## Semantic migration
- New canonical owner: `internal/runtime/engine.BatchAgentRunner` plus `internal/runtime/engine.stepBatchAgent`, with parser/spec owner `contracts.BatchAgentSpec` and spec owner `platform-spec.yaml`.
- Old producer/reader/writer paths now invalid or non-authoritative: producer `target`, `broadcast:true`, direct delivery, RouteTable/raw subscriber routing, replay/readback repair, relay nodes, and authored writes into `batch_agent.*` do not own batch scatter routing.
- Production paths checked for surviving old behavior: bootverify expression/payload/dead-event checks, `HandlerEmitEvents`, semanticview authored emit sites, pipeline plan/preview/engine adapter, runtime runner wiring, route-authority drift inventory, and parent connect route-plan lowering.
- Migration status: complete for the approved #1447 first-slice class. No legacy compatibility shim added.

## Proof
- `go test ./...` passed before rebase.
- Rebased onto current `origin/master` and reran `go test ./...`; passed.
- Focused proofs included `go test ./internal/runtime/engine -run 'BatchAgent|StepOrder' -count=1` and `go test ./internal/runtime/conformance -count=1`.