### PR TITLE
[agent-e][issue #1523] Add rules on_success emit site

### DIFF
--- a/internal/runtime/bootverify/report_test.go
+++ b/internal/runtime/bootverify/report_test.go
@@ -3418,6 +3418,46 @@ func TestRun_ErrorsPerEmitSiteWhenSameEventIsUnderspecifiedOnOneRuleOnly(t *test
 	}
 }
 
+func TestRun_ErrorsForOnSuccessEmitSitePayloadDrift(t *testing.T) {
+	bundle := bootverifyPayloadCompletenessBundle()
+	bundle.Events["market_research.audit_logged"] = runtimecontracts.EventCatalogEntry{
+		Payload: runtimecontracts.EventPayloadSpec{
+			Properties: map[string]runtimecontracts.EventFieldSpec{
+				"audit_id": {Type: "string"},
+			},
+		},
+		Required: []string{"audit_id"},
+	}
+	node := bundle.Nodes["dispatcher"]
+	handler := node.EventHandlers["scan.corpus_dispatch"]
+	handler.Emit = runtimecontracts.EmitSpec{}
+	handler.OnSuccess = runtimecontracts.HandlerOnSuccessSpec{
+		Emit: runtimecontracts.EmitSpec{Event: "market_research.audit_logged"},
+	}
+	handler.Rules = []runtimecontracts.HandlerRuleEntry{{
+		ID:        "complete",
+		Condition: "else",
+		Emit: runtimecontracts.EmitSpec{
+			Event: "market_research.scan_assigned",
+			Fields: map[string]runtimecontracts.ExpressionValue{
+				"scan_id": runtimecontracts.RefExpression("payload.scan_id"),
+			},
+		},
+	}}
+	node.EventHandlers["scan.corpus_dispatch"] = handler
+	bundle.Nodes["dispatcher"] = node
+	bundle.Semantics.NodeHandlers["dispatcher"]["scan.corpus_dispatch"] = handler
+
+	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+
+	if !reportContains(report.Errors(), "semantic_drift_payload_completeness", "handler.on_success.emit") {
+		t.Fatalf("expected payload completeness error for on_success emit site, got %#v", report.Errors())
+	}
+	if !reportContains(report.Errors(), "semantic_drift_payload_completeness", "audit_id is not statically provable") {
+		t.Fatalf("expected missing audit_id error, got %#v", report.Errors())
+	}
+}
+
 func TestRun_ErrorsForOnCompleteEmitSitePayloadDrift(t *testing.T) {
 	bundle := bootverifyPayloadCompletenessBundle()
 	node := bundle.Nodes["dispatcher"]

--- a/internal/runtime/bootverify/workflow_payload_completeness_checks.go
+++ b/internal/runtime/bootverify/workflow_payload_completeness_checks.go
@@ -131,6 +131,7 @@ func payloadCompletenessEmitSites(handler runtimecontracts.SystemNodeEventHandle
 		})
 	}
 	add("handler.emit", handler.Emit)
+	add("handler.on_success.emit", handler.OnSuccess.Emit)
 	if handler.FanOut != nil {
 		add("handler.fan_out.emit", handler.FanOut.Emit)
 	}

--- a/internal/runtime/contracts/workflow_contract_accessors.go
+++ b/internal/runtime/contracts/workflow_contract_accessors.go
@@ -1096,6 +1096,7 @@ func (b *WorkflowContractBundle) nodeEventScope(nodeID string) eventidentity.Sco
 
 func (b *WorkflowContractBundle) externalizeNodeHandler(nodeID string, handler SystemNodeEventHandler) SystemNodeEventHandler {
 	handler.Emit = b.externalizeEmitSpec(nodeID, handler.Emit)
+	handler.OnSuccess.Emit = b.externalizeEmitSpec(nodeID, handler.OnSuccess.Emit)
 	if handler.FanOut != nil {
 		clone := *handler.FanOut
 		clone.Emit = b.externalizeEmitSpec(nodeID, clone.Emit)

--- a/internal/runtime/contracts/workflow_contract_emit.go
+++ b/internal/runtime/contracts/workflow_contract_emit.go
@@ -122,6 +122,11 @@ func HandlerEmitSiteOwnershipError(handler SystemNodeEventHandler) error {
 	if handler.FanOut != nil {
 		return fmt.Errorf("UNSUPPORTED-EMIT: handler on_success.emit is not supported with fan_out")
 	}
+	for idx, rule := range handler.Rules {
+		if rule.FanOut != nil {
+			return fmt.Errorf("UNSUPPORTED-EMIT: handler on_success.emit is not supported with rules[%d].fan_out", idx)
+		}
+	}
 	if handler.Accumulate != nil {
 		if len(handler.Accumulate.OnComplete) > 0 {
 			return fmt.Errorf("UNSUPPORTED-EMIT: handler on_success.emit is not supported with accumulate.on_complete")

--- a/internal/runtime/contracts/workflow_contract_emit.go
+++ b/internal/runtime/contracts/workflow_contract_emit.go
@@ -1,6 +1,9 @@
 package contracts
 
-import "strings"
+import (
+	"fmt"
+	"strings"
+)
 
 func HandlerEmitEvents(handler SystemNodeEventHandler) []string {
 	out := make([]string, 0, 8)
@@ -10,6 +13,9 @@ func HandlerEmitEvents(handler SystemNodeEventHandler) []string {
 	out = append(out, actionResultEvents(handler.Action)...)
 	for _, rule := range handler.Rules {
 		out = append(out, ruleEmitEvents(rule)...)
+	}
+	if eventType := handler.OnSuccess.Emit.EventType(); eventType != "" {
+		out = append(out, eventType)
 	}
 	for _, rule := range handler.OnComplete {
 		out = append(out, ruleEmitEvents(rule)...)
@@ -95,6 +101,36 @@ func HandlerHasNestedEmitSites(handler SystemNodeEventHandler) bool {
 
 func HandlerHasAmbiguousTopLevelEmit(handler SystemNodeEventHandler) bool {
 	return !handler.Emit.Empty() && HandlerHasNestedEmitSites(handler)
+}
+
+func HandlerEmitSiteOwnershipError(handler SystemNodeEventHandler) error {
+	if HandlerHasAmbiguousTopLevelEmit(handler) {
+		return fmt.Errorf("AMBIGUOUS-EMIT: handler-top-level emit is only allowed on single-emit handlers; move emit ownership to the active branch, rule, timeout, or fan_out site")
+	}
+	if handler.OnSuccess.Empty() {
+		return nil
+	}
+	if !handler.Emit.Empty() {
+		return fmt.Errorf("AMBIGUOUS-EMIT: handler on_success.emit cannot be combined with handler-level emit")
+	}
+	if len(handler.Rules) == 0 {
+		return fmt.Errorf("UNSUPPORTED-EMIT: handler on_success.emit is only supported on handlers with rules")
+	}
+	if len(handler.OnComplete) > 0 {
+		return fmt.Errorf("UNSUPPORTED-EMIT: handler on_success.emit is not supported with on_complete")
+	}
+	if handler.FanOut != nil {
+		return fmt.Errorf("UNSUPPORTED-EMIT: handler on_success.emit is not supported with fan_out")
+	}
+	if handler.Accumulate != nil {
+		if len(handler.Accumulate.OnComplete) > 0 {
+			return fmt.Errorf("UNSUPPORTED-EMIT: handler on_success.emit is not supported with accumulate.on_complete")
+		}
+		if handler.Accumulate.OnTimeout != nil {
+			return fmt.Errorf("UNSUPPORTED-EMIT: handler on_success.emit is not supported with accumulate.on_timeout")
+		}
+	}
+	return nil
 }
 
 func HandlerHasAmbiguousTopLevelAction(handler SystemNodeEventHandler) bool {

--- a/internal/runtime/contracts/workflow_contract_emit_test.go
+++ b/internal/runtime/contracts/workflow_contract_emit_test.go
@@ -68,3 +68,18 @@ func TestHandlerHasNestedEmitSitesIncludesBranch(t *testing.T) {
 		t.Fatal("HandlerHasNestedEmitSites() = false, want true for branch emit sites")
 	}
 }
+
+func TestHandlerEmitEventsIncludesOnSuccessAfterRules(t *testing.T) {
+	handler := SystemNodeEventHandler{
+		OnSuccess: HandlerOnSuccessSpec{Emit: EmitSpec{Event: "handler.succeeded"}},
+		Rules: []HandlerRuleEntry{{
+			Emit: EmitSpec{Event: "rule.emitted"},
+		}},
+	}
+
+	got := HandlerEmitEvents(handler)
+	want := []string{"rule.emitted", "handler.succeeded"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("HandlerEmitEvents() = %#v, want %#v", got, want)
+	}
+}

--- a/internal/runtime/contracts/workflow_contract_semantics.go
+++ b/internal/runtime/contracts/workflow_contract_semantics.go
@@ -141,6 +141,7 @@ func populateWorkflowSemantics(bundle *WorkflowContractBundle) {
 				ClearGates:           handler.ClearGates,
 				DataAccumulation:     handler.DataAccumulation,
 				Emit:                 cloneEmitSpec(handler.Emit),
+				OnSuccess:            HandlerOnSuccessSpec{Emit: cloneEmitSpec(handler.OnSuccess.Emit)},
 				Condition:            strings.TrimSpace(handler.Condition),
 				CompletionRule:       strings.TrimSpace(handler.CompletionRule),
 				OnComplete:           handler.OnComplete,

--- a/internal/runtime/contracts/workflow_contract_types.go
+++ b/internal/runtime/contracts/workflow_contract_types.go
@@ -129,6 +129,7 @@ type HandlerTransitionSemantic struct {
 	ClearGates           []string
 	DataAccumulation     WorkflowDataAccumulation
 	Emit                 EmitSpec
+	OnSuccess            HandlerOnSuccessSpec
 	Condition            string
 	CompletionRule       string
 	OnComplete           []HandlerRuleEntry
@@ -266,6 +267,14 @@ type FanOutSpec struct {
 	Target    string     `yaml:"target"`
 	Emit      EmitSpec   `yaml:"emit"`
 }
+type HandlerOnSuccessSpec struct {
+	Emit EmitSpec `yaml:"emit"`
+}
+
+func (s HandlerOnSuccessSpec) Empty() bool {
+	return s.Emit.Empty()
+}
+
 type GroupBySpec struct {
 	ItemsFrom string     `yaml:"items_from"`
 	ItemsPath paths.Path `yaml:"-"`
@@ -1215,6 +1224,7 @@ type SystemNodeEventHandler struct {
 	Description          string                    `yaml:"description"`
 	EvidenceTarget       string                    `yaml:"evidence_target"`
 	Emit                 EmitSpec                  `yaml:"emit"`
+	OnSuccess            HandlerOnSuccessSpec      `yaml:"on_success"`
 	Guard                *GuardSpec                `yaml:"guard"`
 	AdvancesTo           string                    `yaml:"advances_to"`
 	SetsGate             *GateSpec                 `yaml:"sets_gate"`

--- a/internal/runtime/contracts/workflow_contract_yaml_handlers.go
+++ b/internal/runtime/contracts/workflow_contract_yaml_handlers.go
@@ -126,6 +126,38 @@ func (e *EmitSpec) UnmarshalYAML(node *yaml.Node) error {
 	}
 }
 
+func (s *HandlerOnSuccessSpec) UnmarshalYAML(node *yaml.Node) error {
+	if s == nil {
+		return nil
+	}
+	if node == nil || strings.EqualFold(strings.TrimSpace(node.Tag), "!!null") {
+		*s = HandlerOnSuccessSpec{}
+		return nil
+	}
+	if node.Kind != yaml.MappingNode {
+		return fmt.Errorf("unsupported on_success yaml node kind %d", node.Kind)
+	}
+	for i := 0; i+1 < len(node.Content); i += 2 {
+		key := strings.TrimSpace(node.Content[i].Value)
+		switch key {
+		case "", "emit":
+		default:
+			return fmt.Errorf("UNDEFINED-FIELD: on_success field %q not in platform spec", key)
+		}
+	}
+	var aux struct {
+		Emit EmitSpec `yaml:"emit"`
+	}
+	if err := node.Decode(&aux); err != nil {
+		return err
+	}
+	*s = HandlerOnSuccessSpec{Emit: aux.Emit}
+	if !s.Empty() && s.Emit.EventType() == "" {
+		return fmt.Errorf("INVALID-EMIT: on_success.emit.event is required")
+	}
+	return nil
+}
+
 func decodeEmitTargetNode(node *yaml.Node) (EmitTargetSpec, error) {
 	if node == nil || strings.EqualFold(strings.TrimSpace(node.Tag), "!!null") {
 		return EmitTargetSpec{}, nil
@@ -563,6 +595,7 @@ func (h *SystemNodeEventHandler) UnmarshalYAML(node *yaml.Node) error {
 		EvidenceTarget       string                   `yaml:"evidence_target"`
 		Description          string                   `yaml:"description"`
 		Emit                 EmitSpec                 `yaml:"emit"`
+		OnSuccess            HandlerOnSuccessSpec     `yaml:"on_success"`
 		Guard                yaml.Node                `yaml:"guard"`
 		AdvancesTo           yaml.Node                `yaml:"advances_to"`
 		SetsGate             yaml.Node                `yaml:"sets_gate"`
@@ -593,6 +626,7 @@ func (h *SystemNodeEventHandler) UnmarshalYAML(node *yaml.Node) error {
 		EvidenceTarget:   strings.TrimSpace(aux.EvidenceTarget),
 		Description:      strings.TrimSpace(aux.Description),
 		Emit:             aux.Emit,
+		OnSuccess:        aux.OnSuccess,
 		DataAccumulation: aux.DataAccumulation,
 		Condition:        strings.TrimSpace(aux.Condition),
 		CompletionRule:   strings.TrimSpace(aux.CompletionRule),
@@ -657,8 +691,8 @@ func (h *SystemNodeEventHandler) UnmarshalYAML(node *yaml.Node) error {
 	if h.Branch, err = decodeBranchSpecsNode(&aux.Branch); err != nil {
 		return err
 	}
-	if HandlerHasAmbiguousTopLevelEmit(*h) {
-		return fmt.Errorf("AMBIGUOUS-EMIT: handler-top-level emit is only allowed on single-emit handlers; move emit ownership to the active branch, rule, timeout, or fan_out site")
+	if err := HandlerEmitSiteOwnershipError(*h); err != nil {
+		return err
 	}
 	if HandlerHasAmbiguousTopLevelAction(*h) {
 		return fmt.Errorf("AMBIGUOUS-ACTION: handler-top-level action is only allowed on handlers without rules; move action ownership to the active rule")
@@ -898,6 +932,7 @@ func validateHandlerFieldNodes(node *yaml.Node) error {
 		"select_entity":           {},
 		"select_or_create_entity": {},
 		"emit":                    {},
+		"on_success":              {},
 		"guard":                   {},
 		"advances_to":             {},
 		"sets_gate":               {},

--- a/internal/runtime/contracts/workflow_contract_yaml_test.go
+++ b/internal/runtime/contracts/workflow_contract_yaml_test.go
@@ -2,6 +2,7 @@ package contracts
 
 import (
 	"fmt"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -1341,6 +1342,117 @@ rules:
 `), &handler)
 	if err == nil || !strings.Contains(err.Error(), "AMBIGUOUS-ACTION") {
 		t.Fatalf("yaml.Unmarshal error = %v, want AMBIGUOUS-ACTION", err)
+	}
+}
+
+func TestSystemNodeEventHandlerDecode_AllowsOnSuccessEmitWithRules(t *testing.T) {
+	var handler SystemNodeEventHandler
+	if err := yaml.Unmarshal([]byte(`
+on_success:
+  emit:
+    event: handler.succeeded
+    fields:
+      audit:
+        literal: ok
+rules:
+  needs_human:
+    condition: "payload.amount >= 100"
+    emit:
+      event: rule.needs_human
+      fields:
+        amount: payload.amount
+`), &handler); err != nil {
+		t.Fatalf("yaml.Unmarshal: %v", err)
+	}
+	if got := handler.OnSuccess.Emit.EventType(); got != "handler.succeeded" {
+		t.Fatalf("OnSuccess.Emit.EventType = %q, want handler.succeeded", got)
+	}
+	if got := len(handler.Rules); got != 1 {
+		t.Fatalf("Rules len = %d, want 1", got)
+	}
+	if got := HandlerEmitEvents(handler); !reflect.DeepEqual(got, []string{"rule.needs_human", "handler.succeeded"}) {
+		t.Fatalf("HandlerEmitEvents = %#v", got)
+	}
+}
+
+func TestSystemNodeEventHandlerDecode_RejectsUnsupportedOnSuccessEmitShapes(t *testing.T) {
+	cases := []struct {
+		name     string
+		raw      string
+		contains string
+	}{
+		{
+			name: "without_rules",
+			raw: `
+on_success:
+  emit: handler.succeeded
+`,
+			contains: "only supported on handlers with rules",
+		},
+		{
+			name: "with_bare_emit",
+			raw: `
+emit: handler.default
+on_success:
+  emit: handler.succeeded
+rules:
+  done:
+    condition: "else"
+    emit: rule.done
+`,
+			contains: "handler-top-level emit is only allowed on single-emit handlers",
+		},
+		{
+			name: "with_on_complete",
+			raw: `
+on_success:
+  emit: handler.succeeded
+rules:
+  done:
+    condition: "else"
+    emit: rule.done
+on_complete:
+  - id: complete
+    emit: flow.complete
+`,
+			contains: "not supported with on_complete",
+		},
+		{
+			name: "with_fan_out",
+			raw: `
+on_success:
+  emit: handler.succeeded
+rules:
+  done:
+    condition: "else"
+    emit: rule.done
+fan_out:
+  items_from: payload.items
+  emit: item.done
+`,
+			contains: "not supported with fan_out",
+		},
+		{
+			name: "unknown_on_success_field",
+			raw: `
+on_success:
+  action: notify
+rules:
+  done:
+    condition: "else"
+    emit: rule.done
+`,
+			contains: "on_success field",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var handler SystemNodeEventHandler
+			err := yaml.Unmarshal([]byte(tc.raw), &handler)
+			if err == nil || !strings.Contains(err.Error(), tc.contains) {
+				t.Fatalf("yaml.Unmarshal error = %v, want containing %q", err, tc.contains)
+			}
+		})
 	}
 }
 

--- a/internal/runtime/contracts/workflow_contract_yaml_test.go
+++ b/internal/runtime/contracts/workflow_contract_yaml_test.go
@@ -1433,6 +1433,20 @@ fan_out:
 			contains: "not supported with fan_out",
 		},
 		{
+			name: "with_rule_fan_out",
+			raw: `
+on_success:
+  emit: handler.succeeded
+rules:
+  done:
+    condition: "else"
+    fan_out:
+      items_from: payload.items
+      emit: item.done
+`,
+			contains: "not supported with rules[0].fan_out",
+		},
+		{
 			name: "unknown_on_success_field",
 			raw: `
 on_success:

--- a/internal/runtime/contracts/workflow_contracts_tree_test.go
+++ b/internal/runtime/contracts/workflow_contracts_tree_test.go
@@ -200,6 +200,119 @@ validation-orchestrator:
 	}
 }
 
+func TestNodeEventHandler_ExternalizesOnSuccessEmitWithRules(t *testing.T) {
+	repoRoot := repoRootForContractsTest(t)
+	root := t.TempDir()
+
+	writeFixtureFile(t, filepath.Join(root, "package.yaml"), `
+name: cross-flow-on-success
+version: "1.0.0"
+platform_version: ">=1.6.0"
+flows:
+  - id: scoring
+    flow: scoring
+    mode: static
+  - id: validation
+    flow: validation
+    mode: static
+`)
+	writeFixtureFile(t, filepath.Join(root, "entities.yaml"), `
+item:
+  item_id: string
+`)
+	writeFixtureFile(t, filepath.Join(root, "schema.yaml"), "name: cross-flow-on-success\n")
+	writeFixtureFile(t, filepath.Join(root, "policy.yaml"), "{}\n")
+	writeFixtureFile(t, filepath.Join(root, "tools.yaml"), "{}\n")
+	writeFixtureFile(t, filepath.Join(root, "agents.yaml"), "{}\n")
+	writeFixtureFile(t, filepath.Join(root, "events.yaml"), "{}\n")
+
+	writeFixtureFile(t, filepath.Join(root, "flows", "scoring", "schema.yaml"), `
+name: scoring
+initial_state: discovered
+terminal_states: [done]
+states: [discovered, done]
+pins:
+  inputs:
+    events: []
+  outputs:
+    events:
+      - vertical.shortlisted
+`)
+	writeFixtureFile(t, filepath.Join(root, "flows", "scoring", "policy.yaml"), "{}\n")
+	writeFixtureFile(t, filepath.Join(root, "flows", "scoring", "events.yaml"), `
+vertical.shortlisted:
+  entity_id: string
+`)
+	writeFixtureFile(t, filepath.Join(root, "flows", "scoring", "nodes.yaml"), `
+scoring-node:
+  id: scoring-node
+  execution_type: system_node
+  subscribes_to:
+    - score.ready
+  produces:
+    - vertical.shortlisted
+  event_handlers:
+    score.ready:
+      emit: vertical.shortlisted
+`)
+
+	writeFixtureFile(t, filepath.Join(root, "flows", "validation", "schema.yaml"), `
+name: validation
+initial_state: researching
+terminal_states: [done]
+states: [researching, done]
+pins:
+  inputs:
+    events:
+      - vertical.shortlisted
+  outputs:
+    events:
+      - validation.rule
+      - validation.started
+`)
+	writeFixtureFile(t, filepath.Join(root, "flows", "validation", "policy.yaml"), "{}\n")
+	writeFixtureFile(t, filepath.Join(root, "flows", "validation", "events.yaml"), `
+validation.rule:
+  entity_id: string
+validation.started:
+  entity_id: string
+`)
+	writeFixtureFile(t, filepath.Join(root, "flows", "validation", "nodes.yaml"), `
+validation-orchestrator:
+  id: validation-orchestrator
+  execution_type: system_node
+  produces:
+    - validation.rule
+    - validation.started
+  event_handlers:
+    vertical.shortlisted:
+      rules:
+        accepted:
+          condition: "else"
+          emit: validation.rule
+      on_success:
+        emit: validation.started
+`)
+
+	bundle, err := LoadWorkflowContractBundleWithOverrides(repoRoot, root, "")
+	if err != nil {
+		t.Fatalf("LoadWorkflowContractBundleWithOverrides: %v", err)
+	}
+	handler, ok := bundle.NodeEventHandler("validation-orchestrator", "scoring/vertical.shortlisted")
+	if !ok {
+		t.Fatal("expected cross-flow qualified input event to resolve to local handler")
+	}
+	if got := len(handler.Rules); got != 1 {
+		t.Fatalf("handler rules len = %d, want 1", got)
+	}
+	if got := strings.TrimSpace(handler.Rules[0].Emit.EventType()); got != "validation/validation.rule" {
+		t.Fatalf("handler rule emit = %q, want %q", got, "validation/validation.rule")
+	}
+	if got := strings.TrimSpace(handler.OnSuccess.Emit.EventType()); got != "validation/validation.started" {
+		t.Fatalf("handler on_success emit = %q, want %q", got, "validation/validation.started")
+	}
+}
+
 func repoRootForContractsTest(t *testing.T) string {
 	t.Helper()
 	wd, err := os.Getwd()

--- a/internal/runtime/engine/executor.go
+++ b/internal/runtime/engine/executor.go
@@ -154,8 +154,8 @@ func (e *Executor) ValidateRequest(req ExecutionRequest) error {
 	if handlerDeclaresConflictingCompletion(req.Handler) {
 		return fmt.Errorf("%w: handler declares both on_complete and rules", ErrInvalidConfig)
 	}
-	if runtimecontracts.HandlerHasAmbiguousTopLevelEmit(req.Handler) {
-		return fmt.Errorf("%w: handler-top-level emit is only allowed on single-emit handlers", ErrInvalidConfig)
+	if err := runtimecontracts.HandlerEmitSiteOwnershipError(req.Handler); err != nil {
+		return fmt.Errorf("%w: %v", ErrInvalidConfig, err)
 	}
 	if runtimecontracts.HandlerHasAmbiguousTopLevelAction(req.Handler) {
 		return fmt.Errorf("%w: handler-top-level action is only allowed on handlers without rules", ErrInvalidConfig)
@@ -1389,7 +1389,11 @@ func lookupProjectionPath(raw map[string]any, path string) (any, bool) {
 }
 
 func (e *Executor) stepTransform(frame *executionFrame) error {
-	emitSpec := selectedEmitSpec(frame.req.Handler, frame.rule)
+	activeEmits := selectedDeclarativeEmitSpecs(frame.req.Handler, frame.rule)
+	if len(activeEmits) != 1 {
+		return nil
+	}
+	emitSpec := activeEmits[0].Spec
 	if emitSpec.Empty() || !emitSpec.HasFields() {
 		return nil
 	}
@@ -1407,23 +1411,44 @@ func (e *Executor) stepTransform(frame *executionFrame) error {
 }
 
 func (e *Executor) stepEmits(frame *executionFrame) error {
-	emitSpec := selectedEmitSpec(frame.req.Handler, frame.rule)
-	eventType := emitSpec.EventType()
-	if eventType == "" {
+	activeEmits := selectedDeclarativeEmitSpecs(frame.req.Handler, frame.rule)
+	if len(activeEmits) == 0 {
 		return nil
 	}
-	eventType = e.resolveDeclarativeEmitEventType(frame, eventType)
-	emitSpec.Event = eventType
-	payload := map[string]any{}
-	if len(frame.state.Transformed) > 0 {
-		payload = frame.state.Transformed
+	seen := map[string]string{}
+	for _, activeEmit := range activeEmits {
+		emitSpec := activeEmit.Spec
+		eventType := emitSpec.EventType()
+		if eventType == "" {
+			continue
+		}
+		eventType = e.resolveDeclarativeEmitEventType(frame, eventType)
+		if previousSource := seen[eventType]; previousSource != "" {
+			return fmt.Errorf("duplicate declarative emit event %q from %s and %s; additive on_success emits must be distinct from the selected rule emit", eventType, previousSource, activeEmit.Source)
+		}
+		seen[eventType] = activeEmit.Source
+		emitSpec.Event = eventType
+		payload := map[string]any{}
+		if emitSpec.HasFields() && len(activeEmits) == 1 && len(frame.state.Transformed) > 0 {
+			payload = frame.state.Transformed
+		} else if emitSpec.HasFields() {
+			transformed, err := emitFieldsPayload(e.currentContext(frame), frame.state, emitSpec, workflowexpr.ValueExpressionOptions{})
+			if err != nil {
+				return err
+			}
+			payload = transformed
+		} else if len(activeEmits) == 1 && len(frame.state.Transformed) > 0 {
+			payload = frame.state.Transformed
+		}
+		shaped, err := e.shapeEmitPayload(frame, eventType, payload)
+		if err != nil {
+			return err
+		}
+		if _, err = e.queueEmitIntentForSpec(frame, emitSpec, eventType, shaped); err != nil {
+			return err
+		}
 	}
-	shaped, err := e.shapeEmitPayload(frame, eventType, payload)
-	if err != nil {
-		return err
-	}
-	_, err = e.queueEmitIntentForSpec(frame, emitSpec, eventType, shaped)
-	return err
+	return nil
 }
 
 func (e *Executor) stepAction(frame *executionFrame) error {
@@ -2034,11 +2059,36 @@ func (e *Executor) selectedFanOut(frame *executionFrame) *runtimecontracts.FanOu
 	return frame.req.Handler.FanOut
 }
 
-func selectedEmitSpec(handler runtimecontracts.SystemNodeEventHandler, rule *runtimecontracts.HandlerRuleEntry) runtimecontracts.EmitSpec {
-	if rule != nil {
-		return rule.Emit
+type activeDeclarativeEmitSpec struct {
+	Source string
+	Spec   runtimecontracts.EmitSpec
+}
+
+func selectedDeclarativeEmitSpecs(handler runtimecontracts.SystemNodeEventHandler, rule *runtimecontracts.HandlerRuleEntry) []activeDeclarativeEmitSpec {
+	out := make([]activeDeclarativeEmitSpec, 0, 2)
+	if rule != nil && !rule.Emit.Empty() {
+		out = append(out, activeDeclarativeEmitSpec{
+			Source: "handler.rules.emit",
+			Spec:   rule.Emit,
+		})
 	}
-	return handler.Emit
+	if !handler.OnSuccess.Empty() {
+		out = append(out, activeDeclarativeEmitSpec{
+			Source: "handler.on_success.emit",
+			Spec:   handler.OnSuccess.Emit,
+		})
+		return out
+	}
+	if rule != nil {
+		return out
+	}
+	if !handler.Emit.Empty() {
+		out = append(out, activeDeclarativeEmitSpec{
+			Source: "handler.emit",
+			Spec:   handler.Emit,
+		})
+	}
+	return out
 }
 
 func selectedActionSpec(handler runtimecontracts.SystemNodeEventHandler, rule *runtimecontracts.HandlerRuleEntry, source handlerRuleSource) runtimecontracts.ActionSpec {

--- a/internal/runtime/engine/executor_test.go
+++ b/internal/runtime/engine/executor_test.go
@@ -2073,6 +2073,39 @@ func TestExecutor_OnSuccessEmitFailsClosedWhenRuleEventMatchesSuccessEvent(t *te
 	}
 }
 
+func TestExecutor_RejectsOnSuccessEmitWithRuleFanOut(t *testing.T) {
+	exec, err := NewExecutor(RuntimeDependencies{
+		Source:        stubSource(),
+		StateRepo:     stubStateRepo{},
+		TxRunner:      stubRunner{},
+		Locker:        stubLocker{},
+		Outbox:        stubOutbox{},
+		Dispatcher:    stubDispatcher{},
+		PayloadShaper: stubPayloadShaper{},
+		MaxChainDepth: 5,
+	}, stubEvaluator{})
+	if err != nil {
+		t.Fatalf("NewExecutor error: %v", err)
+	}
+
+	err = exec.ValidateRequest(ExecutionRequest{
+		Handler: runtimecontracts.SystemNodeEventHandler{
+			OnSuccess: runtimecontracts.HandlerOnSuccessSpec{Emit: runtimecontracts.EmitSpec{Event: "handler.succeeded"}},
+			Rules: []runtimecontracts.HandlerRuleEntry{{
+				ID:        "rule-1",
+				Condition: "else",
+				FanOut: &runtimecontracts.FanOutSpec{
+					ItemsFrom: "payload.items",
+					Emit:      runtimecontracts.EmitSpec{Event: "item.done"},
+				},
+			}},
+		},
+	})
+	if err == nil || !strings.Contains(err.Error(), "rules[0].fan_out") {
+		t.Fatalf("ValidateRequest error = %v, want rules[0].fan_out rejection", err)
+	}
+}
+
 func TestExecutor_OnSuccessSecondEmitFailureDoesNotCommitFirstEmitOrState(t *testing.T) {
 	stateRepo := &recordingStateRepo{}
 	outbox := &recordingEmitOutbox{}

--- a/internal/runtime/engine/executor_test.go
+++ b/internal/runtime/engine/executor_test.go
@@ -129,12 +129,19 @@ func sourceWithKilledState() semanticview.Source {
 }
 
 type stubStateRepo struct{}
+type recordingStateRepo struct {
+	saves int
+}
 type actionMergeStateRepo struct {
 	snapshot StateSnapshot
 }
 type stubRunner struct{}
 type stubLocker struct{}
 type stubOutbox struct{}
+type recordingEmitOutbox struct {
+	intents []EmitIntent
+	err     error
+}
 type stubTimerApplier struct{}
 type stubDispatcher struct{}
 type stubActionRegistry struct {
@@ -166,11 +173,22 @@ type recordingPayloadShaper struct {
 	lastSurface EmitSurface
 	err         error
 }
+type eventErrPayloadShaper struct {
+	failEvent string
+	shaped    []string
+}
 
 func (stubStateRepo) LoadState(context.Context, identity.EntityID) (StateSnapshot, bool, error) {
 	return StateSnapshot{}, false, nil
 }
 func (stubStateRepo) SaveState(context.Context, identity.EntityID, StateMutation) error { return nil }
+func (r *recordingStateRepo) LoadState(context.Context, identity.EntityID) (StateSnapshot, bool, error) {
+	return StateSnapshot{}, false, nil
+}
+func (r *recordingStateRepo) SaveState(context.Context, identity.EntityID, StateMutation) error {
+	r.saves++
+	return nil
+}
 func (r actionMergeStateRepo) LoadState(context.Context, identity.EntityID) (StateSnapshot, bool, error) {
 	return r.snapshot, true, nil
 }
@@ -197,6 +215,13 @@ func (l lockOrderLocker) WithEntityLock(ctx context.Context, _ identity.EntityID
 	return fn(ctx)
 }
 func (stubOutbox) WriteOutbox(context.Context, []EmitIntent) error { return nil }
+func (o *recordingEmitOutbox) WriteOutbox(_ context.Context, intents []EmitIntent) error {
+	if o.err != nil {
+		return o.err
+	}
+	o.intents = append(o.intents, intents...)
+	return nil
+}
 func (stubTimerApplier) ApplyTimerIntents(context.Context, identity.EntityID, []TimerIntent) error {
 	return nil
 }
@@ -252,6 +277,15 @@ func (s *recordingPayloadShaper) ShapeEmitPayload(ctx context.Context, req Execu
 	out["shaped_for"] = eventType
 	return out, nil
 }
+func (s *eventErrPayloadShaper) ShapeEmitPayload(_ context.Context, _ ExecutionRequest, eventType string, payload map[string]any) (map[string]any, error) {
+	s.shaped = append(s.shaped, eventType)
+	if eventType == s.failEvent {
+		return nil, errors.New("payload shape failed")
+	}
+	out := cloneStringAnyMap(payload)
+	out["shaped_for"] = eventType
+	return out, nil
+}
 
 type stubTx struct{ ctx context.Context }
 
@@ -262,6 +296,15 @@ func testStateSnapshot(currentState string, metadata map[string]any, gates map[s
 		CurrentState: currentState,
 		StateCarrier: NewStateCarrier(metadata, gates, buckets),
 	}
+}
+
+func eventPayloadMap(t *testing.T, evt events.Event) map[string]any {
+	t.Helper()
+	var out map[string]any
+	if err := json.Unmarshal(evt.Payload(), &out); err != nil {
+		t.Fatalf("json.Unmarshal payload: %v", err)
+	}
+	return out
 }
 
 func TestNewExecutor_DefaultsMaxChainDepth(t *testing.T) {
@@ -1871,6 +1914,211 @@ func TestExecutor_RejectsAmbiguousHandlerTopLevelEmitWithRulesWithoutRuleEmit(t 
 	}
 	if !strings.Contains(err.Error(), "handler-top-level emit is only allowed on single-emit handlers") {
 		t.Fatalf("error = %v", err)
+	}
+}
+
+func TestExecutor_OnSuccessEmitWithMatchedRuleQueuesRuleThenSuccess(t *testing.T) {
+	outbox := &recordingEmitOutbox{}
+	exec, err := NewExecutor(RuntimeDependencies{
+		Source:        stubSource(),
+		StateRepo:     stubStateRepo{},
+		TxRunner:      stubRunner{},
+		Locker:        stubLocker{},
+		Outbox:        outbox,
+		Dispatcher:    stubDispatcher{},
+		PayloadShaper: stubPayloadShaper{},
+		MaxChainDepth: 5,
+	}, stubEvaluator{bools: map[string]bool{"payload.score > 5": true}})
+	if err != nil {
+		t.Fatalf("NewExecutor error: %v", err)
+	}
+
+	result, err := exec.Execute(context.Background(), ExecutionRequest{
+		EntityID:   "entity-1",
+		NodeID:     "node-1",
+		FlowID:     "flow-1",
+		ChainDepth: 1,
+		Event:      eventtest.RootIngress("evt-1", "task.completed", "", "", json.RawMessage(`{"score":9}`), 0, "", "", events.EventEnvelope{}, time.Time{}),
+		Handler: runtimecontracts.SystemNodeEventHandler{
+			OnSuccess: runtimecontracts.HandlerOnSuccessSpec{Emit: runtimecontracts.EmitSpec{
+				Event: "handler.succeeded",
+				Fields: map[string]runtimecontracts.ExpressionValue{
+					"audit": runtimecontracts.LiteralExpression("ok"),
+				},
+			}},
+			Rules: []runtimecontracts.HandlerRuleEntry{{
+				ID:        "rule-1",
+				Condition: "payload.score > 5",
+				Emit: runtimecontracts.EmitSpec{
+					Event: "rule.emitted",
+					Fields: map[string]runtimecontracts.ExpressionValue{
+						"score": runtimecontracts.RefExpression("payload.score"),
+					},
+				},
+			}},
+		},
+		State: testStateSnapshot("pending", map[string]any{}, nil, map[string]map[string]any{}),
+	})
+	if err != nil {
+		t.Fatalf("Execute error: %v", err)
+	}
+	if got := result.RuleID; got != "rule-1" {
+		t.Fatalf("RuleID = %q, want rule-1", got)
+	}
+	if got := len(result.EmitIntents); got != 2 {
+		t.Fatalf("EmitIntents len = %d, want 2", got)
+	}
+	if got := []string{string(result.EmitIntents[0].Event.Type()), string(result.EmitIntents[1].Event.Type())}; !reflect.DeepEqual(got, []string{"rule.emitted", "handler.succeeded"}) {
+		t.Fatalf("emit order = %#v", got)
+	}
+	if got := len(outbox.intents); got != 2 {
+		t.Fatalf("outbox intents len = %d, want 2", got)
+	}
+	rulePayload := eventPayloadMap(t, result.EmitIntents[0].Event)
+	if got := rulePayload["score"]; got != float64(9) {
+		t.Fatalf("rule payload score = %#v, want 9", got)
+	}
+	successPayload := eventPayloadMap(t, result.EmitIntents[1].Event)
+	if got := successPayload["audit"]; got != "ok" {
+		t.Fatalf("success payload audit = %#v, want ok", got)
+	}
+}
+
+func TestExecutor_OnSuccessEmitFiresWhenRulesDoNotMatch(t *testing.T) {
+	outbox := &recordingEmitOutbox{}
+	exec, err := NewExecutor(RuntimeDependencies{
+		Source:        stubSource(),
+		StateRepo:     stubStateRepo{},
+		TxRunner:      stubRunner{},
+		Locker:        stubLocker{},
+		Outbox:        outbox,
+		Dispatcher:    stubDispatcher{},
+		PayloadShaper: stubPayloadShaper{},
+		MaxChainDepth: 5,
+	}, stubEvaluator{bools: map[string]bool{"payload.score > 5": false}})
+	if err != nil {
+		t.Fatalf("NewExecutor error: %v", err)
+	}
+
+	result, err := exec.Execute(context.Background(), ExecutionRequest{
+		EntityID:   "entity-1",
+		NodeID:     "node-1",
+		FlowID:     "flow-1",
+		ChainDepth: 1,
+		Event:      eventtest.RootIngress("evt-1", "task.completed", "", "", json.RawMessage(`{"score":3}`), 0, "", "", events.EventEnvelope{}, time.Time{}),
+		Handler: runtimecontracts.SystemNodeEventHandler{
+			OnSuccess: runtimecontracts.HandlerOnSuccessSpec{Emit: runtimecontracts.EmitSpec{Event: "handler.succeeded"}},
+			Rules: []runtimecontracts.HandlerRuleEntry{{
+				ID:        "rule-1",
+				Condition: "payload.score > 5",
+				Emit:      runtimecontracts.EmitSpec{Event: "rule.emitted"},
+			}},
+		},
+		State: testStateSnapshot("pending", map[string]any{}, nil, map[string]map[string]any{}),
+	})
+	if err != nil {
+		t.Fatalf("Execute error: %v", err)
+	}
+	if got := result.RuleID; got != "" {
+		t.Fatalf("RuleID = %q, want empty on no-match success", got)
+	}
+	if got := len(result.EmitIntents); got != 1 {
+		t.Fatalf("EmitIntents len = %d, want 1", got)
+	}
+	if got := string(result.EmitIntents[0].Event.Type()); got != "handler.succeeded" {
+		t.Fatalf("emit event = %q, want handler.succeeded", got)
+	}
+	if got := len(outbox.intents); got != 1 {
+		t.Fatalf("outbox intents len = %d, want 1", got)
+	}
+}
+
+func TestExecutor_OnSuccessEmitFailsClosedWhenRuleEventMatchesSuccessEvent(t *testing.T) {
+	outbox := &recordingEmitOutbox{}
+	exec, err := NewExecutor(RuntimeDependencies{
+		Source:        stubSource(),
+		StateRepo:     stubStateRepo{},
+		TxRunner:      stubRunner{},
+		Locker:        stubLocker{},
+		Outbox:        outbox,
+		Dispatcher:    stubDispatcher{},
+		PayloadShaper: stubPayloadShaper{},
+		MaxChainDepth: 5,
+	}, stubEvaluator{bools: map[string]bool{"payload.score > 5": true}})
+	if err != nil {
+		t.Fatalf("NewExecutor error: %v", err)
+	}
+
+	_, err = exec.Execute(context.Background(), ExecutionRequest{
+		EntityID:   "entity-1",
+		NodeID:     "node-1",
+		FlowID:     "flow-1",
+		ChainDepth: 1,
+		Event:      eventtest.RootIngress("evt-1", "task.completed", "", "", json.RawMessage(`{"score":9}`), 0, "", "", events.EventEnvelope{}, time.Time{}),
+		Handler: runtimecontracts.SystemNodeEventHandler{
+			OnSuccess: runtimecontracts.HandlerOnSuccessSpec{Emit: runtimecontracts.EmitSpec{Event: "shared.event"}},
+			Rules: []runtimecontracts.HandlerRuleEntry{{
+				ID:        "rule-1",
+				Condition: "payload.score > 5",
+				Emit:      runtimecontracts.EmitSpec{Event: "shared.event"},
+			}},
+		},
+		State: testStateSnapshot("pending", map[string]any{}, nil, map[string]map[string]any{}),
+	})
+	if err == nil || !strings.Contains(err.Error(), "duplicate declarative emit event") {
+		t.Fatalf("Execute error = %v, want duplicate declarative emit event", err)
+	}
+	if got := len(outbox.intents); got != 0 {
+		t.Fatalf("outbox intents len = %d, want 0 after duplicate failure", got)
+	}
+}
+
+func TestExecutor_OnSuccessSecondEmitFailureDoesNotCommitFirstEmitOrState(t *testing.T) {
+	stateRepo := &recordingStateRepo{}
+	outbox := &recordingEmitOutbox{}
+	shaper := &eventErrPayloadShaper{failEvent: "handler.succeeded"}
+	exec, err := NewExecutor(RuntimeDependencies{
+		Source:        stubSource(),
+		StateRepo:     stateRepo,
+		TxRunner:      stubRunner{},
+		Locker:        stubLocker{},
+		Outbox:        outbox,
+		Dispatcher:    stubDispatcher{},
+		PayloadShaper: shaper,
+		MaxChainDepth: 5,
+	}, stubEvaluator{bools: map[string]bool{"payload.score > 5": true}})
+	if err != nil {
+		t.Fatalf("NewExecutor error: %v", err)
+	}
+
+	_, err = exec.Execute(context.Background(), ExecutionRequest{
+		EntityID:   "entity-1",
+		NodeID:     "node-1",
+		FlowID:     "flow-1",
+		ChainDepth: 1,
+		Event:      eventtest.RootIngress("evt-1", "task.completed", "", "", json.RawMessage(`{"score":9}`), 0, "", "", events.EventEnvelope{}, time.Time{}),
+		Handler: runtimecontracts.SystemNodeEventHandler{
+			AdvancesTo: "done",
+			OnSuccess:  runtimecontracts.HandlerOnSuccessSpec{Emit: runtimecontracts.EmitSpec{Event: "handler.succeeded"}},
+			Rules: []runtimecontracts.HandlerRuleEntry{{
+				ID:        "rule-1",
+				Condition: "payload.score > 5",
+				Emit:      runtimecontracts.EmitSpec{Event: "rule.emitted"},
+			}},
+		},
+		State: testStateSnapshot("pending", map[string]any{}, nil, map[string]map[string]any{}),
+	})
+	if err == nil || !strings.Contains(err.Error(), "payload shape failed") {
+		t.Fatalf("Execute error = %v, want payload shape failed", err)
+	}
+	if got := shaper.shaped; !reflect.DeepEqual(got, []string{"rule.emitted", "handler.succeeded"}) {
+		t.Fatalf("payload shaper order = %#v", got)
+	}
+	if got := len(outbox.intents); got != 0 {
+		t.Fatalf("outbox intents len = %d, want 0 after second emit failure", got)
+	}
+	if got := stateRepo.saves; got != 0 {
+		t.Fatalf("state saves = %d, want 0 after second emit failure", got)
 	}
 }
 

--- a/internal/runtime/pipeline/handler_engine_transaction_test.go
+++ b/internal/runtime/pipeline/handler_engine_transaction_test.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"errors"
+	"reflect"
 	"strings"
 	"sync"
 	"testing"
@@ -2443,6 +2444,63 @@ func TestExecuteNodeContractHandlerExecutesEmitInsideEngine(t *testing.T) {
 	}
 }
 
+func TestExecuteNodeContractHandlerOnSuccessRulesEmitsBothInOrder(t *testing.T) {
+	bus := &recordingPipelineBus{}
+	pc := NewPipelineCoordinatorWithOptions(bus, nil, PipelineCoordinatorOptions{
+		Module: &previewWorkflowModule{bundle: additiveOnSuccessContractBundle()},
+	})
+	entityID := "ent-1"
+
+	result, err := pc.executeNodeContractHandler(testPipelineCoordinatorRunContext(t, pc), "node-a", runtimecontracts.SystemNodeEventHandler{
+		OnSuccess: runtimecontracts.HandlerOnSuccessSpec{Emit: runtimecontracts.EmitSpec{Event: "handler.succeeded"}},
+		Rules: []runtimecontracts.HandlerRuleEntry{
+			{ID: "pick-rule", Condition: "true", Emit: runtimecontracts.EmitSpec{Event: "rule.emitted"}},
+		},
+	}, workflowTriggerContext{
+		Event: eventtest.RootIngress("", events.EventType("custom.trigger"), "", "", nil, 0, "", "", events.EnvelopeForEntityID(events.EventEnvelope{}, entityID), time.Time{}),
+		State: WorkflowState{Stage: WorkflowStateID("queued"), Metadata: map[string]any{}},
+	}, false)
+	if err != nil {
+		t.Fatalf("executeNodeContractHandler: %v", err)
+	}
+	if !result.Handled {
+		t.Fatal("expected handled result")
+	}
+	if got := bus.publishedCount(); got != 2 {
+		t.Fatalf("bus published count = %d, want 2", got)
+	}
+	if got := []events.EventType{bus.publishes[0].Type(), bus.publishes[1].Type()}; !reflect.DeepEqual(got, []events.EventType{"rule.emitted", "handler.succeeded"}) {
+		t.Fatalf("published order = %#v", got)
+	}
+}
+
+func TestExecuteNodeContractHandlerOnSuccessOutboxFailureDoesNotPartiallyPublish(t *testing.T) {
+	bus := &recordingPipelineBus{outboxErr: errors.New("outbox failed")}
+	pc := NewPipelineCoordinatorWithOptions(bus, nil, PipelineCoordinatorOptions{
+		Module: &previewWorkflowModule{bundle: additiveOnSuccessContractBundle()},
+	})
+
+	_, err := pc.executeNodeContractHandler(testPipelineCoordinatorRunContext(t, pc), "node-a", runtimecontracts.SystemNodeEventHandler{
+		AdvancesTo: "done",
+		OnSuccess:  runtimecontracts.HandlerOnSuccessSpec{Emit: runtimecontracts.EmitSpec{Event: "handler.succeeded"}},
+		Rules: []runtimecontracts.HandlerRuleEntry{
+			{ID: "pick-rule", Condition: "true", Emit: runtimecontracts.EmitSpec{Event: "rule.emitted"}},
+		},
+	}, workflowTriggerContext{
+		Event: eventtest.RootIngress("", events.EventType("custom.trigger"), "", "", nil, 0, "", "", events.EnvelopeForEntityID(events.EventEnvelope{}, "ent-1"), time.Time{}),
+		State: WorkflowState{Stage: WorkflowStateID("queued"), Metadata: map[string]any{}},
+	}, false)
+	if err == nil || !strings.Contains(err.Error(), "outbox failed") {
+		t.Fatalf("executeNodeContractHandler error = %v, want outbox failed", err)
+	}
+	if got := len(bus.outboxIntents); got != 0 {
+		t.Fatalf("outbox intents len = %d, want 0 after outbox failure", got)
+	}
+	if got := bus.publishedCount(); got != 0 {
+		t.Fatalf("bus published count = %d, want 0 after outbox failure", got)
+	}
+}
+
 func declarativeEmitContractTestBundle(eventType string) *runtimecontracts.WorkflowContractBundle {
 	return declarativeEmitContractTestBundleWithEntry(eventType, runtimecontracts.EventCatalogEntry{
 		Payload: runtimecontracts.EventPayloadSpec{
@@ -2452,6 +2510,19 @@ func declarativeEmitContractTestBundle(eventType string) *runtimecontracts.Workf
 		},
 		Required: []string{"label"},
 	})
+}
+
+func additiveOnSuccessContractBundle() *runtimecontracts.WorkflowContractBundle {
+	return &runtimecontracts.WorkflowContractBundle{
+		Semantics: runtimecontracts.WorkflowSemanticView{
+			Name:    "test",
+			Version: "v-test",
+		},
+		Events: map[string]runtimecontracts.EventCatalogEntry{
+			"rule.emitted":      {},
+			"handler.succeeded": {},
+		},
+	}
 }
 
 func declarativeEmitContractTestBundleWithEntry(eventType string, entry runtimecontracts.EventCatalogEntry) *runtimecontracts.WorkflowContractBundle {

--- a/internal/runtime/pipeline/workflow_execution_plan.go
+++ b/internal/runtime/pipeline/workflow_execution_plan.go
@@ -34,6 +34,7 @@ type handlerExecutionPlan struct {
 	ClearGates       bool
 	DataAccumulation runtimecontracts.WorkflowDataAccumulation
 	Emit             runtimecontracts.EmitSpec
+	OnSuccess        runtimecontracts.HandlerOnSuccessSpec
 	EmitEvents       []string
 	Rules            []runtimecontracts.HandlerRuleEntry
 	OnComplete       []runtimecontracts.HandlerRuleEntry
@@ -83,6 +84,7 @@ func handlerExecutionPlanFromNodeHandler(nodeID, eventType string, handler runti
 		ClearGates:       len(handler.ClearGates) > 0,
 		DataAccumulation: handler.DataAccumulation,
 		Emit:             handler.Emit,
+		OnSuccess:        handler.OnSuccess,
 		EmitEvents:       runtimecontracts.HandlerEmitEvents(handler),
 		Rules:            append([]runtimecontracts.HandlerRuleEntry(nil), handler.Rules...),
 		OnComplete:       append([]runtimecontracts.HandlerRuleEntry(nil), handler.OnComplete...),
@@ -146,6 +148,9 @@ func handlerPlanHasRuleActions(plan handlerExecutionPlan) bool {
 
 func handlerPlanHasEmitFields(plan handlerExecutionPlan) bool {
 	if plan.Emit.HasFields() {
+		return true
+	}
+	if plan.OnSuccess.Emit.HasFields() {
 		return true
 	}
 	if plan.FanOut != nil && plan.FanOut.Emit.HasFields() {

--- a/internal/runtime/semanticview/authored_emit_sites.go
+++ b/internal/runtime/semanticview/authored_emit_sites.go
@@ -121,6 +121,7 @@ func (b *authoredEmitSiteBuilder) appendHandlerSites(kind AuthoredEmitSiteSource
 		})
 	}
 	add("handler.emit", "handler.emit", "", handler.Emit)
+	add("handler.on_success.emit", "handler.on_success.emit", "", handler.OnSuccess.Emit)
 	if handler.Guard != nil {
 		if emitSpec := authoredGuardEscalationEmitSpec(handler.Guard); !emitSpec.Empty() {
 			add("handler.guard.on_fail.escalate", "handler.guard.on_fail.escalate", handler.Guard.ID, emitSpec)

--- a/internal/runtime/semanticview/authored_emit_sites_test.go
+++ b/internal/runtime/semanticview/authored_emit_sites_test.go
@@ -60,6 +60,30 @@ func TestAuthoredEmitSites_GuardEscalationObjectCarriesFields(t *testing.T) {
 	}
 }
 
+func TestAuthoredEmitSites_EnumeratesOnSuccessEmitWithRules(t *testing.T) {
+	source := loadAuthoredEmitSiteFixture(t, authoredEmitSiteFixture{
+		rootNodeID:    "root-node",
+		rootRuleEmit:  "root.routed",
+		rootOnSuccess: "root.audit",
+	})
+
+	sites := AuthoredEmitSites(source)
+	ruleMatches := authoredEmitSitesByFlowNodeEvent(sites, "", "root-node", "root.routed")
+	if len(ruleMatches) != 1 {
+		t.Fatalf("expected one rules authored emit site, got %d: %#v", len(ruleMatches), authoredEmitSiteSummaries(sites))
+	}
+	if got := ruleMatches[0].Site; got != "handler.rules.emit" {
+		t.Fatalf("rule site = %q, want handler.rules.emit", got)
+	}
+	successMatches := authoredEmitSitesByFlowNodeEvent(sites, "", "root-node", "root.audit")
+	if len(successMatches) != 1 {
+		t.Fatalf("expected one on_success authored emit site, got %d: %#v", len(successMatches), authoredEmitSiteSummaries(sites))
+	}
+	if got := successMatches[0].Site; got != "handler.on_success.emit" {
+		t.Fatalf("success site = %q, want handler.on_success.emit", got)
+	}
+}
+
 func TestAuthoredEmitSites_DeduplicatesPackageProjectionWithoutCollapsingDistinctSources(t *testing.T) {
 	source := loadAuthoredEmitSiteFixture(t, authoredEmitSiteFixture{
 		rootNodeID:      "root-node",
@@ -122,6 +146,8 @@ func TestAuthoredEmitSites_NestedFlowPackageDoesNotSuppressMainFlowScope(t *test
 type authoredEmitSiteFixture struct {
 	rootNodeID          string
 	rootEmit            string
+	rootRuleEmit        string
+	rootOnSuccess       string
 	rootGuardEmit       string
 	rootBroadcast       bool
 	flowNodeID          string
@@ -170,12 +196,17 @@ pins:
 root.start: {}
 root.ready: {}
 root.escalated: {}
+root.routed: {}
+root.audit: {}
 `)
 	writeSemanticviewFixtureFile(t, filepath.Join(root, "policy.yaml"), "{}\n")
 	writeSemanticviewFixtureFile(t, filepath.Join(root, "tools.yaml"), "{}\n")
 	writeSemanticviewFixtureFile(t, filepath.Join(root, "agents.yaml"), "{}\n")
 	writeSemanticviewFixtureFile(t, filepath.Join(root, "entities.yaml"), "{}\n")
 	rootNodeYAML := authoredEmitSiteNodeYAML(opts.rootNodeID, "root.start", opts.rootEmit, opts.rootGuardEmit, opts.rootBroadcast)
+	if strings.TrimSpace(opts.rootRuleEmit) != "" || strings.TrimSpace(opts.rootOnSuccess) != "" {
+		rootNodeYAML = authoredEmitSiteRulesSuccessNodeYAML(opts.rootNodeID, "root.start", opts.rootRuleEmit, opts.rootOnSuccess)
+	}
 	if opts.rootGuardObject {
 		rootNodeYAML = authoredEmitSiteNodeYAMLWithGuardObject(opts.rootNodeID, "root.start", opts.rootEmit, opts.rootGuardEmit, opts.rootBroadcast)
 	}
@@ -283,6 +314,25 @@ func authoredEmitSiteNodeYAMLWithGuardObject(nodeID, trigger, eventType, guardEv
       emit:
         event: ` + eventType + `
 ` + broadcastLine
+}
+
+func authoredEmitSiteRulesSuccessNodeYAML(nodeID, trigger, ruleEventType, successEventType string) string {
+	if strings.TrimSpace(nodeID) == "" {
+		return "{}\n"
+	}
+	return `
+` + nodeID + `:
+  id: ` + nodeID + `
+  execution_type: system_node
+  event_handlers:
+    ` + trigger + `:
+      on_success:
+        emit: ` + successEventType + `
+      rules:
+        routed:
+          condition: "else"
+          emit: ` + ruleEventType + `
+`
 }
 
 func countAuthoredEmitSites(sites []AuthoredEmitSite, flowID, nodeID, eventType string) int {

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -1771,7 +1771,7 @@ handler_specification:
         sub_fields:
           emit: emit spec — additive success/audit/lifecycle event emitted after the selected rules emit.
         rules_only: on_success.emit is supported only on handlers with rules in this slice. It is not supported with on_complete,
-          accumulate.on_timeout, fan_out, handler-level action, or bare handler-level emit.
+          accumulate.on_timeout, handler-level fan_out, rule-level fan_out, handler-level action, or bare handler-level emit.
         ordering: When a rule matches and has emit, the rule emit is materialized first and on_success.emit second. Both events
           are emitted after rule selection, state/gate/data/projection side effects, and emit.fields evaluation for their own
           active emit site, before the handler transaction commits.

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -1329,7 +1329,7 @@ handler_specification:
       \ data into handler context)\n       └→ clear_gates (optional — reset gates before guard)\n            └→ guard\n            └→ accumulate\n                 └→ filter (optional — prune accumulated\
       \ items)\n                      └→ reduce (optional — aggregate filtered items to single value)\n                  \
       \         └→ count (optional — count items)\n                                └→ compute\n                          \
-      \           └→ emit-site selection (handler emit OR active branch/rule/timeout/fan_out emit)\n                    \
+      \           └→ emit-site selection (handler emit OR active emit set: selected rule emit then on_success.emit, or active branch/timeout/fan_out emit)\n                    \
       \                      └→ advances_to ─┐\n                                             sets_gate ────┤ (independent\
       \ of each other)\n                                             data_accumulation ┘\n                         \
       \                         └→ projection (materialize_from, if accumulator projection eligible)\n                  \
@@ -1762,7 +1762,25 @@ handler_specification:
           broadcast/fan-out is the required route owner.
       single_emit_handler_rule: 'A handler top-level emit is valid only when the handler has exactly one possible emit site.
         If the handler also declares rules, on_complete, accumulate.on_timeout, or fan_out emit, boot fails with ambiguity.
-        Payload ownership must move to the active emit site.'
+        Payload ownership must move to the active emit site. The only approved additive rules success surface is explicit
+        on_success.emit, which is not a handler-level emit overload.'
+      on_success:
+        field: on_success
+        type: object
+        purpose: Explicit success-side effects that run after a handler execution succeeds.
+        sub_fields:
+          emit: emit spec — additive success/audit/lifecycle event emitted after the selected rules emit.
+        rules_only: on_success.emit is supported only on handlers with rules in this slice. It is not supported with on_complete,
+          accumulate.on_timeout, fan_out, handler-level action, or bare handler-level emit.
+        ordering: When a rule matches and has emit, the rule emit is materialized first and on_success.emit second. Both events
+          are emitted after rule selection, state/gate/data/projection side effects, and emit.fields evaluation for their own
+          active emit site, before the handler transaction commits.
+        no_match: If no rule matches and no else branch exists, the handler still succeeds when no validation or runtime failure
+          occurs. on_success.emit fires, and no rule emit fires.
+        distinct_event_requirement: If on_success.emit and the selected rules emit resolve to the same event identity, runtime
+          fails closed. Same-event template specialization is outside this surface.
+        atomicity: Any payload, route, validation, persistence-prerequisite, outbox, or delivery-plan creation failure for either
+          event rolls back both emitted events and all same-handler state changes.
     rules:
       field: rules
       type: map of rule_name → rule
@@ -2125,18 +2143,22 @@ handler_specification:
     SHOULD order fields to match the dependency graph for readability, but the engine does not require it.
   rules_handler_interaction:
     description: When a handler has rules, the active rule owns conditional emit and action selection for that execution.
-    execution_order: 1. rules execute first — the matching rule determines the active condition-specific side effects (rule-level
+    execution_order: |
+      1. rules execute first — the matching rule determines the active condition-specific side effects (rule-level
       emit, action, data_accumulation, advances_to). 2. Handler-level data_accumulation executes AFTER rules when present and
-      supplements rule-level writes in the same atomic transaction. 3. Handler-level emit and handler-level action do NOT supplement
-      rules. If rules are present, handler-level emit or handler-level action is invalid and boot fails as ambiguous. 4. The
-      selected rule action executes at the normal action step after active state/gate/data updates and selected emit queuing, and
-      remains in the same system-node handler transaction as those side effects.
+      supplements rule-level writes in the same atomic transaction. 3. Bare handler-level emit and handler-level action do NOT
+      supplement rules. If rules are present, bare handler-level emit or handler-level action is invalid and boot fails as
+      ambiguous. 4. Explicit on_success.emit supplements rules as a distinct additive success emit: the selected rule emit is
+      queued first and on_success.emit second; if no rule matches, only on_success.emit is queued. 5. The selected rule action
+      executes at the normal action step after active state/gate/data updates and selected emit queuing, and remains in the same
+      system-node handler transaction as those side effects.
     example: 'order.received may have handler-level data_accumulation (3 fields) + rules with per-rule data_accumulation (category_data).
       Result: all 3 handler-level fields are written, PLUS the matching rule writes category_data. Event emission, however,
       and action must be owned by the matching rule.'
     precedence: Handler-level advances_to, sets_gate, and data_accumulation are defaults. If the matched rule specifies any
-      of these, the rule value OVERRIDES the handler-level value for that field only. emit and action never fall through from
-      a handler into a rules-based multi-emit/action handler.
+      of these, the rule value OVERRIDES the handler-level value for that field only. Bare emit and action never fall through from
+      a handler into a rules-based multi-emit/action handler; only explicit on_success.emit is additive, and only as a second
+      distinct success event.
 engine:
   description: Specification for the platform engine — how it loads, validates, and executes flows.
   flow_tree_walker:
@@ -9338,6 +9360,7 @@ observation_model:
     includes:
     - Events from handler top-level emit on single-emit handlers
     - Events from handler rules emit
+    - Events from handler on_success.emit
     - Events from handler on_complete emit
     - Events from handler accumulate.on_timeout emit
     - Events from handler fan_out emit


### PR DESCRIPTION
## Summary

- Adds explicit `on_success.emit` for rules handlers as the approved additive success/audit emit site.
- Keeps bare handler-level `emit` with `rules` invalid and keeps non-rules nested additive combinations out of scope.
- Replaces the runtime singleton selected-emit path with an ordered active declarative emit set for the approved rules class.
- Updates semantic-view, bootverify payload completeness, handler emit enumeration, pipeline execution-plan, and root `platform-spec.yaml` consumers.

Closes #1523

## Governing Refs / Context

Authoritative spec updated in this PR:

- `platform-spec.yaml` `handler_specification.handler_execution_order`
- `platform-spec.yaml` `handler_fields.emit.single_emit_handler_rule`
- `platform-spec.yaml` `handler_fields.on_success`
- `platform-spec.yaml` `rules_handler_interaction`
- `platform-spec.yaml` `engine.atomicity` / `engine.emit_payload_default`
- `platform-spec.yaml` `observation_model.emitted_events`

Issue/gate context:

- #1523 Pre-Implementation Coverage Audit and Independent Gate E approved first-slice scope.
- Parent/tail remain tracked by #1462, #1463, and #1525; this PR does not close one-event template specialization or non-rules nested additive emit cases.

## Semantic Migration

- New canonical owner: explicit `on_success.emit` in `platform-spec.yaml`, `runtime/contracts.HandlerOnSuccessSpec`, and runtime `selectedDeclarativeEmitSpecs` ordered active emit-set selection.
- Old invalid path: bare handler-level `emit` plus `rules` remains fail-closed; the old singleton `selectedEmitSpec` runtime owner was removed.
- Production paths checked/moved: YAML decode, runtime `ValidateRequest`, `HandlerEmitEvents`, `semanticview.AuthoredEmitSites`, bootverify `payloadCompletenessEmitSites`, pipeline execution plan, executor emit queueing, and pipeline outbox transaction bridge.
- Migration completeness: complete for `rules_handler_additive_success_emit_two_distinct_events`; #1525 and non-rules nested emit combinations remain split.

## Proof

- `go test ./internal/runtime/contracts ./internal/runtime/semanticview ./internal/runtime/bootverify ./internal/runtime/engine ./internal/runtime/pipeline -run 'OnSuccess|Ambiguous|HandlerEmitEvents|AuthoredEmitSites|PayloadCompleteness|ErrorsForOnSuccess|ExecuteNodeContractHandlerOnSuccess|RejectsAmbiguousHandlerTopLevelEmitWithRules' -count=1`
- `go test ./...`