### PR TITLE
[agent-f][issue #1594] Derive system-node effective facts

### DIFF
--- a/internal/runtime/authority/source_provider.go
+++ b/internal/runtime/authority/source_provider.go
@@ -236,12 +236,12 @@ func buildProducerRegistry(source semanticview.Source) map[string][]string {
 			agentEvents[role] = appendUniqueSortedEvent(agentEvents[role], eventType)
 		}
 	}
-	for nodeID, node := range source.NodeEntries() {
+	for nodeID := range source.NodeEntries() {
 		role := canonicalRole(nodeID)
 		if role == "" {
 			continue
 		}
-		for _, eventType := range node.Produces {
+		for _, eventType := range semanticview.NodeEffectiveProduces(source, nodeID) {
 			agentEvents[role] = appendUniqueSortedEvent(agentEvents[role], eventType)
 		}
 	}

--- a/internal/runtime/authority/source_provider_test.go
+++ b/internal/runtime/authority/source_provider_test.go
@@ -53,6 +53,24 @@ func TestNewSourceProvider_UsesDeclaredRoleForProducerEvents(t *testing.T) {
 	}
 }
 
+func TestNewSourceProvider_UsesEffectiveSystemNodeProduces(t *testing.T) {
+	bundle := &runtimecontracts.WorkflowContractBundle{
+		Nodes: map[string]runtimecontracts.SystemNodeContract{
+			"worker": {
+				EventHandlers: map[string]runtimecontracts.SystemNodeEventHandler{
+					"work.started": {Emit: runtimecontracts.EmitSpec{Event: "work.completed"}},
+				},
+			},
+		},
+	}
+
+	provider := NewSourceProvider(semanticview.Wrap(bundle))
+	got := provider.ProducerEventsForRole("worker")
+	if len(got) != 1 || got[0] != "work.completed" {
+		t.Fatalf("ProducerEventsForRole(worker) = %#v, want [work.completed]", got)
+	}
+}
+
 func TestNewSourceProvider_AuthorityMatrix(t *testing.T) {
 	provider := NewSourceProvider(semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
 		Agents: map[string]runtimecontracts.AgentRegistryEntry{

--- a/internal/runtime/bootverify/checks.go
+++ b/internal/runtime/bootverify/checks.go
@@ -668,20 +668,23 @@ func (c *checkerContext) invalidFieldDetection() []Finding {
 				})
 				continue
 			}
-			if strings.TrimSpace(node.ExecutionType) == "" {
+			if authoredID := strings.TrimSpace(node.ID); !runtimecontracts.SystemNodeIDMatchesKey(nodeID, authoredID) {
 				c.invalidFindings = append(c.invalidFindings, Finding{
 					CheckID:  "invalid_field_detection",
 					Severity: "error",
-					Message:  fmt.Sprintf("node %s missing required field execution_type", nodeLabel),
+					Message:  fmt.Sprintf("node %s id %q must match map key", nodeLabel, authoredID),
 					Location: nodeLabel,
 				})
-			} else if err := runtimecontracts.ValidateSystemNodeExecutionType(node.ExecutionType); err != nil {
-				c.invalidFindings = append(c.invalidFindings, Finding{
-					CheckID:  "invalid_field_detection",
-					Severity: "error",
-					Message:  fmt.Sprintf("node %s execution_type must be %s", nodeLabel, runtimecontracts.SystemNodeExecutionType),
-					Location: nodeLabel,
-				})
+			}
+			if strings.TrimSpace(node.ExecutionType) != "" {
+				if err := runtimecontracts.ValidateSystemNodeExecutionType(node.ExecutionType); err != nil {
+					c.invalidFindings = append(c.invalidFindings, Finding{
+						CheckID:  "invalid_field_detection",
+						Severity: "error",
+						Message:  fmt.Sprintf("node %s execution_type must be %s", nodeLabel, runtimecontracts.SystemNodeExecutionType),
+						Location: nodeLabel,
+					})
+				}
 			}
 			if len(c.source.NodeRuntimeSubscriptions(nodeID)) == 0 {
 				c.invalidFindings = append(c.invalidFindings, Finding{
@@ -775,20 +778,23 @@ func (c *checkerContext) invalidFieldDetection() []Finding {
 				})
 				continue
 			}
-			if strings.TrimSpace(node.ExecutionType) == "" {
+			if authoredID := strings.TrimSpace(node.ID); !runtimecontracts.SystemNodeIDMatchesKey(nodeID, authoredID) {
 				c.invalidFindings = append(c.invalidFindings, Finding{
 					CheckID:  "invalid_field_detection",
 					Severity: "error",
-					Message:  fmt.Sprintf("node %s missing required field execution_type", nodeLabel),
+					Message:  fmt.Sprintf("node %s id %q must match map key", nodeLabel, authoredID),
 					Location: nodeLabel,
 				})
-			} else if err := runtimecontracts.ValidateSystemNodeExecutionType(node.ExecutionType); err != nil {
-				c.invalidFindings = append(c.invalidFindings, Finding{
-					CheckID:  "invalid_field_detection",
-					Severity: "error",
-					Message:  fmt.Sprintf("node %s execution_type must be %s", nodeLabel, runtimecontracts.SystemNodeExecutionType),
-					Location: nodeLabel,
-				})
+			}
+			if strings.TrimSpace(node.ExecutionType) != "" {
+				if err := runtimecontracts.ValidateSystemNodeExecutionType(node.ExecutionType); err != nil {
+					c.invalidFindings = append(c.invalidFindings, Finding{
+						CheckID:  "invalid_field_detection",
+						Severity: "error",
+						Message:  fmt.Sprintf("node %s execution_type must be %s", nodeLabel, runtimecontracts.SystemNodeExecutionType),
+						Location: nodeLabel,
+					})
+				}
 			}
 			if len(c.source.NodeRuntimeSubscriptions(nodeID)) == 0 {
 				c.invalidFindings = append(c.invalidFindings, Finding{

--- a/internal/runtime/bootverify/report_test.go
+++ b/internal/runtime/bootverify/report_test.go
@@ -3159,6 +3159,35 @@ func TestRun_DoesNotWarnForProducesDriftWhenDeclaredEventsMatchEmits(t *testing.
 	}
 }
 
+func TestRun_DoesNotWarnForProducesDriftWhenProducesOmitted(t *testing.T) {
+	bundle := bootverifyDeclarationDriftBundle()
+	node := bundle.Nodes["producer"]
+	node.Produces = nil
+	bundle.Nodes["producer"] = node
+
+	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+
+	if reportContains(report.Warnings(), "produces_drift", "outside produces list") {
+		t.Fatalf("unexpected produces_drift warning for omitted produces, got %#v", report.Warnings())
+	}
+	if reportContains(report.Warnings(), "phantom_produces", "no handler emits") {
+		t.Fatalf("unexpected phantom_produces warning for omitted produces, got %#v", report.Warnings())
+	}
+}
+
+func TestRun_ExplicitEmptyProducesRemainsAssertion(t *testing.T) {
+	bundle := bootverifyDeclarationDriftBundle()
+	node := bundle.Nodes["producer"]
+	node.Produces = []string{}
+	bundle.Nodes["producer"] = node
+
+	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+
+	if !reportContains(report.Warnings(), "produces_drift", "outside produces list") {
+		t.Fatalf("expected produces_drift warning for explicit empty produces assertion, got %#v", report.Warnings())
+	}
+}
+
 func TestRun_MapsPhantomProducesToNamedWarning(t *testing.T) {
 	bundle := bootverifyDeclarationDriftBundle()
 	bundle.Nodes["producer"] = runtimecontracts.SystemNodeContract{

--- a/internal/runtime/bootverify/workflow_dead_event_schema_checks.go
+++ b/internal/runtime/bootverify/workflow_dead_event_schema_checks.go
@@ -190,7 +190,7 @@ func (c *checkerContext) deadEventSchemaUsageFor(decl deadEventDeclaration) dead
 			}
 		}
 		for _, node := range scope.Nodes {
-			for _, eventType := range node.SubscribesTo {
+			for _, eventType := range runtimecontracts.EffectiveSystemNodeSubscriptions(node) {
 				if deadEventRoleMatches(c.source, decl, flowID, eventType) {
 					usage.handlerSubscribes++
 				}
@@ -236,7 +236,7 @@ func (c *checkerContext) deadEventSchemaUsageFor(decl deadEventDeclaration) dead
 	for nodeID, node := range c.source.NodeEntries() {
 		nodeSource, _ := c.source.NodeContractSource(nodeID)
 		flowID := strings.TrimSpace(nodeSource.FlowID)
-		for _, eventType := range node.SubscribesTo {
+		for _, eventType := range semanticview.NodeEffectiveSubscriptions(c.source, nodeID) {
 			if deadEventRoleMatches(c.source, decl, flowID, eventType) {
 				usage.handlerSubscribes++
 			}

--- a/internal/runtime/bootverify/workflow_event_declaration_drift_checks.go
+++ b/internal/runtime/bootverify/workflow_event_declaration_drift_checks.go
@@ -14,6 +14,9 @@ func (c *checkerContext) producesDrift() []Finding {
 	}
 	c.producesDriftLoaded = true
 	for nodeID, node := range c.source.NodeEntries() {
+		if node.Produces == nil {
+			continue
+		}
 		produces := stringSet(node.Produces)
 		for eventType, handler := range node.EventHandlers {
 			eventType = strings.TrimSpace(eventType)
@@ -43,6 +46,9 @@ func (c *checkerContext) phantomProduces() []Finding {
 	}
 	c.phantomLoaded = true
 	for nodeID, node := range c.source.NodeEntries() {
+		if node.Produces == nil {
+			continue
+		}
 		emitted := map[string]struct{}{}
 		for _, handler := range node.EventHandlers {
 			for _, eventType := range handlerEmits(handler) {

--- a/internal/runtime/bootverify/workflow_event_topology_checks.go
+++ b/internal/runtime/bootverify/workflow_event_topology_checks.go
@@ -92,18 +92,7 @@ func (c *checkerContext) eventWarnings() []Finding {
 	for nodeID, node := range c.source.NodeEntries() {
 		nodeSource, _ := c.source.NodeContractSource(nodeID)
 		flowID := strings.TrimSpace(nodeSource.FlowID)
-		for _, eventType := range node.SubscribesTo {
-			eventType = strings.TrimSpace(eventType)
-			if eventType == "" {
-				continue
-			}
-			if strings.Contains(eventType, "*") {
-				addEventPatternLocal(subscriptionPatterns, nodeSource.PackageKey, flowID, eventType)
-			} else {
-				addEventProofLocal(subscribedRefs, c.source, flowID, eventType)
-			}
-		}
-		for _, eventType := range c.source.NodeHandlerSubscriptions(nodeID) {
+		for _, eventType := range semanticview.NodeEffectiveSubscriptions(c.source, nodeID) {
 			eventType = strings.TrimSpace(eventType)
 			if eventType == "" {
 				continue

--- a/internal/runtime/bootverify/workflow_flow_boundary_checks.go
+++ b/internal/runtime/bootverify/workflow_flow_boundary_checks.go
@@ -447,7 +447,7 @@ func flowHasScopedInputEscapeHatch(source semanticview.Source, flowID, eventType
 		return false
 	}
 	for _, node := range scope.Nodes {
-		for _, sub := range eventidentity.NormalizeList(node.SubscribesTo) {
+		for _, sub := range eventidentity.NormalizeList(runtimecontracts.EffectiveSystemNodeSubscriptions(node)) {
 			if strings.Contains(sub, "/") && strings.HasSuffix(sub, "/"+eventType) {
 				return true
 			}

--- a/internal/runtime/bootverify/workflow_transition_runtime_checks.go
+++ b/internal/runtime/bootverify/workflow_transition_runtime_checks.go
@@ -123,7 +123,7 @@ func (c *checkerContext) transitionOwnership() []Finding {
 			continue
 		}
 		subs := stringSet(c.source.NodeRuntimeSubscriptions(nodeID))
-		produces := stringSet(node.Produces)
+		produces := stringSet(semanticview.NodeEffectiveProduces(c.source, nodeID))
 		for _, transitionID := range node.OwnedTransitions {
 			transitionID = strings.TrimSpace(transitionID)
 			if transitionID == "" {

--- a/internal/runtime/bus/routing_derivation.go
+++ b/internal/runtime/bus/routing_derivation.go
@@ -250,7 +250,7 @@ func (rt *RouteTable) AddFlowInstanceRoute(req FlowInstanceRouteMaterializationR
 		Type: "node",
 		Path: instancePath,
 	}
-	for _, rawPattern := range normalizeStringList(req.Template.SubscribesTo) {
+	for _, rawPattern := range runtimecontracts.EffectiveSystemNodeSubscriptions(req.Template) {
 		for _, resolved := range routeResolveSubscriberPatterns(rt.source, "", templateID, nil, instancePath, localEvents, rawPattern) {
 			if strings.TrimSpace(resolved.EventPattern) == "" {
 				continue
@@ -387,18 +387,19 @@ func (rt *RouteTable) addTopLevelRootInputNodeRoutesLocked(source semanticview.S
 	for _, eventType := range sortedStringKeys(rootInputs) {
 		for _, key := range sortedStringKeys(bundle.Nodes) {
 			entry := bundle.Nodes[key]
-			nodeID := strings.TrimSpace(entry.ID)
-			if nodeID == "" {
-				nodeID = strings.TrimSpace(key)
+			semanticNodeID := strings.TrimSpace(key)
+			subscriberID := strings.TrimSpace(entry.ID)
+			if subscriberID == "" {
+				subscriberID = semanticNodeID
 			}
-			if nodeID == "" || !normalizedStringListContains(source.NodeRuntimeSubscriptions(nodeID), eventType) {
+			if semanticNodeID == "" || !normalizedStringListContains(source.NodeRuntimeSubscriptions(semanticNodeID), eventType) {
 				continue
 			}
-			if rootInputFlowOwnsNodeRoute(source, nodeID, eventType) {
+			if rootInputFlowOwnsNodeRoute(source, semanticNodeID, eventType) {
 				continue
 			}
 			rt.rootInputRoutes[eventType] = appendUniqueRootInputSubscriber(rt.rootInputRoutes[eventType], Subscriber{
-				ID:           nodeID,
+				ID:           subscriberID,
 				Type:         "node",
 				MatchPattern: eventType,
 				RouteSource:  "root_input_project",
@@ -413,11 +414,7 @@ func rootInputFlowOwnsNodeRoute(source semanticview.Source, nodeID string, event
 			continue
 		}
 		for _, key := range sortedStringKeys(scope.Nodes) {
-			entry := scope.Nodes[key]
-			scopedNodeID := strings.TrimSpace(entry.ID)
-			if scopedNodeID == "" {
-				scopedNodeID = strings.TrimSpace(key)
-			}
+			scopedNodeID := strings.TrimSpace(key)
 			if scopedNodeID == nodeID {
 				return true
 			}
@@ -449,15 +446,16 @@ func (rt *RouteTable) addRootInputFlowNodeRoutesLocked(source semanticview.Sourc
 			}
 			for _, key := range sortedStringKeys(scope.Nodes) {
 				entry := scope.Nodes[key]
-				nodeID := strings.TrimSpace(entry.ID)
-				if nodeID == "" {
-					nodeID = strings.TrimSpace(key)
+				semanticNodeID := strings.TrimSpace(key)
+				subscriberID := strings.TrimSpace(entry.ID)
+				if subscriberID == "" {
+					subscriberID = semanticNodeID
 				}
-				if nodeID == "" || !normalizedStringListContains(source.NodeRuntimeSubscriptions(nodeID), eventType) {
+				if semanticNodeID == "" || !normalizedStringListContains(source.NodeRuntimeSubscriptions(semanticNodeID), eventType) {
 					continue
 				}
 				rt.rootInputRoutes[eventType] = appendUniqueSubscriber(rt.rootInputRoutes[eventType], Subscriber{
-					ID:           nodeID,
+					ID:           subscriberID,
 					Type:         "node",
 					Path:         flowPath,
 					MatchPattern: eventType,
@@ -523,18 +521,19 @@ func (rt *RouteTable) addAgentPatternsLocked(source semanticview.Source, package
 func (rt *RouteTable) addNodePatternsLocked(source semanticview.Source, packageKey, flowID string, inputEvents []string, basePath string, localEvents map[string]struct{}, nodes map[string]runtimecontracts.SystemNodeContract) {
 	for _, key := range sortedStringKeys(nodes) {
 		entry := nodes[key]
-		nodeID := strings.TrimSpace(entry.ID)
-		if nodeID == "" {
-			nodeID = strings.TrimSpace(key)
+		semanticNodeID := strings.TrimSpace(key)
+		subscriberID := strings.TrimSpace(entry.ID)
+		if subscriberID == "" {
+			subscriberID = semanticNodeID
 		}
 		subscriber := Subscriber{
-			ID:   nodeID,
+			ID:   subscriberID,
 			Type: "node",
 			Path: strings.Trim(strings.TrimSpace(basePath), "/"),
 		}
-		patterns := normalizeStringList(entry.SubscribesTo)
+		patterns := runtimecontracts.EffectiveSystemNodeSubscriptions(entry)
 		if source != nil {
-			patterns = source.NodeRuntimeSubscriptions(nodeID)
+			patterns = source.NodeRuntimeSubscriptions(semanticNodeID)
 		}
 		for _, rawPattern := range patterns {
 			if routeFlowInputHasLoweredConnectReceiver(source, flowID, rawPattern) && !routeInputAliasRequiresExclusivePatterns(source, flowID, rawPattern) {
@@ -553,7 +552,7 @@ func (rt *RouteTable) addNodePatternsLocked(source semanticview.Source, packageK
 			if routeInputAliasRequiresExclusivePatterns(source, flowID, rawPattern) {
 				continue
 			}
-			if resolved := routeResolveNodeCanonicalPattern(source, basePath, nodeID, rawPattern); strings.TrimSpace(resolved.EventPattern) != "" {
+			if resolved := routeResolveNodeCanonicalPattern(source, basePath, semanticNodeID, rawPattern); strings.TrimSpace(resolved.EventPattern) != "" {
 				resolvedSubscriber := routeApplyResolvedPattern(subscriber, resolved)
 				rt.patterns = append(rt.patterns, routePattern{
 					EventPattern: resolved.EventPattern,
@@ -721,8 +720,13 @@ func routeInputAliasRequiresExclusivePatterns(source semanticview.Source, flowID
 
 func routeNodeLocalEventSet(node runtimecontracts.SystemNodeContract) map[string]struct{} {
 	out := make(map[string]struct{})
-	for _, eventType := range normalizeStringList(node.Produces) {
+	for _, eventType := range runtimecontracts.EffectiveSystemNodeProduces(node) {
 		out[eventType] = struct{}{}
+	}
+	if len(node.EventHandlers) == 0 {
+		for _, eventType := range normalizeStringList(node.Produces) {
+			out[eventType] = struct{}{}
+		}
 	}
 	for _, timer := range node.Timers {
 		if eventType := strings.TrimSpace(timer.Event); eventType != "" {
@@ -758,19 +762,20 @@ func routeSubscriberTemplates(source semanticview.Source, scope semanticview.Flo
 	}
 	for _, key := range sortedStringKeys(scope.Nodes) {
 		entry := scope.Nodes[key]
-		nodeID := strings.TrimSpace(entry.ID)
-		if nodeID == "" {
-			nodeID = strings.TrimSpace(key)
+		semanticNodeID := strings.TrimSpace(key)
+		subscriberID := strings.TrimSpace(entry.ID)
+		if subscriberID == "" {
+			subscriberID = semanticNodeID
 		}
-		patterns := normalizeStringList(entry.SubscribesTo)
+		patterns := runtimecontracts.EffectiveSystemNodeSubscriptions(entry)
 		if source != nil {
-			patterns = source.NodeRuntimeSubscriptions(nodeID)
+			patterns = source.NodeRuntimeSubscriptions(semanticNodeID)
 		}
 		if len(patterns) == 0 {
 			continue
 		}
 		out = append(out, routeSubscriberTemplate{
-			IDTemplate:  nodeID,
+			IDTemplate:  subscriberID,
 			Type:        "node",
 			RawPatterns: append([]string{}, patterns...),
 		})

--- a/internal/runtime/bus/routing_derivation_internal_test.go
+++ b/internal/runtime/bus/routing_derivation_internal_test.go
@@ -6,8 +6,21 @@ import (
 
 	"github.com/division-sh/swarm/internal/events"
 	"github.com/division-sh/swarm/internal/events/eventtest"
+	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
 	"time"
 )
+
+func TestRouteNodeLocalEventSetDerivesProducesFromHandlerEmits(t *testing.T) {
+	events := routeNodeLocalEventSet(runtimecontracts.SystemNodeContract{
+		EventHandlers: map[string]runtimecontracts.SystemNodeEventHandler{
+			"task.start": {Emit: runtimecontracts.EmitSpec{Event: "task.done"}},
+		},
+	})
+
+	if _, ok := events["task.done"]; !ok {
+		t.Fatalf("local events = %#v, want task.done derived from handler emit", events)
+	}
+}
 
 func TestRouteTableResolve_WildcardSubscriberMatchesActiveConcreteChildEventWithoutMaterializedKey(t *testing.T) {
 	const pattern = "component-scaffold/*/component.scaffolded"

--- a/internal/runtime/bus/routing_derivation_test.go
+++ b/internal/runtime/bus/routing_derivation_test.go
@@ -41,6 +41,27 @@ func TestEventBusRemoveFlowInstanceDropsDerivedRoutes(t *testing.T) {
 	}
 }
 
+func TestEventBusFlowInstanceTemplateDerivesSubscriptionsFromHandlerKeys(t *testing.T) {
+	eb, err := runtimebus.NewEventBus(runtimebus.InMemoryEventStore{})
+	if err != nil {
+		t.Fatalf("NewEventBus: %v", err)
+	}
+	if err := eb.AddFlowInstanceRoute(runtimebus.FlowInstanceRouteMaterializationRequest{
+		Template: runtimecontracts.SystemNodeContract{
+			ID: "reviewer-{instance_id}",
+			EventHandlers: map[string]runtimecontracts.SystemNodeEventHandler{
+				"task.started": {Emit: runtimecontracts.EmitSpec{Event: "task.started"}},
+			},
+		},
+		Identity: runtimeflowidentity.DeriveRoute("review", "inst-1"),
+	}); err != nil {
+		t.Fatalf("AddFlowInstance: %v", err)
+	}
+	if got := eb.RouteTable().Resolve("review/inst-1/task.started"); len(got) != 1 || got[0].ID != "reviewer-inst-1" {
+		t.Fatalf("resolved subscribers = %#v, want reviewer-inst-1", got)
+	}
+}
+
 type routePersistenceTestStore struct {
 	routes           map[string]runtimebus.FlowInstanceRouteRecord
 	deliveries       map[string][]string

--- a/internal/runtime/contracts/load_validation_test.go
+++ b/internal/runtime/contracts/load_validation_test.go
@@ -72,6 +72,56 @@ func TestValidateWorkflowContractBundleLoadConstraintsRejectsInvalidExecutionTyp
 	}
 }
 
+func TestValidateWorkflowContractBundleLoadConstraintsAllowsMissingExecutionType(t *testing.T) {
+	bundle := loadCurrentWorkflowBundleForTest(t)
+
+	for nodeID, node := range bundle.Nodes {
+		node.ExecutionType = ""
+		bundle.Nodes[nodeID] = node
+		break
+	}
+
+	err := validateWorkflowContractBundleLoadConstraints(bundle)
+	if err != nil {
+		t.Fatalf("unexpected load validation error for missing execution_type: %v", err)
+	}
+}
+
+func TestValidateWorkflowContractBundleLoadConstraintsRejectsNodeIDMismatch(t *testing.T) {
+	bundle := loadCurrentWorkflowBundleForTest(t)
+
+	var expected string
+	for nodeID, node := range bundle.Nodes {
+		node.ID = nodeID + "-alias"
+		bundle.Nodes[nodeID] = node
+		expected = nodeID
+		break
+	}
+	if expected == "" {
+		t.Fatal("expected at least one node")
+	}
+
+	err := validateWorkflowContractBundleLoadConstraints(bundle)
+	if err == nil || !contractErrorContains(err, "node id") || !contractErrorContains(err, "must match map key") {
+		t.Fatalf("unexpected load validation error: %v", err)
+	}
+}
+
+func TestValidateWorkflowContractBundleLoadConstraintsAllowsRenderedNodeIDTemplate(t *testing.T) {
+	bundle := loadCurrentWorkflowBundleForTest(t)
+
+	for nodeID, node := range bundle.Nodes {
+		node.ID = nodeID + "-{instance_id}"
+		bundle.Nodes[nodeID] = node
+		break
+	}
+
+	err := validateWorkflowContractBundleLoadConstraints(bundle)
+	if err != nil {
+		t.Fatalf("unexpected load validation error for rendered node id template: %v", err)
+	}
+}
+
 func TestValidateWorkflowContractBundleLoadConstraintsRejectsUnsupportedHandlerAction(t *testing.T) {
 	bundle := loadCurrentWorkflowBundleForTest(t)
 

--- a/internal/runtime/contracts/workflow_contract_accessors.go
+++ b/internal/runtime/contracts/workflow_contract_accessors.go
@@ -638,8 +638,8 @@ func (b *WorkflowContractBundle) NodeContractSource(nodeID string) (ContractItem
 		return source, true
 	}
 	for _, view := range b.ProjectViews() {
-		for key, entry := range view.Nodes {
-			if strings.TrimSpace(key) != nodeID && strings.TrimSpace(entry.ID) != nodeID {
+		for key := range view.Nodes {
+			if strings.TrimSpace(key) != nodeID {
 				continue
 			}
 			return ContractItemSource{
@@ -649,8 +649,8 @@ func (b *WorkflowContractBundle) NodeContractSource(nodeID string) (ContractItem
 		}
 	}
 	for _, view := range b.FlowViews() {
-		for key, entry := range view.Nodes {
-			if strings.TrimSpace(key) != nodeID && strings.TrimSpace(entry.ID) != nodeID {
+		for key := range view.Nodes {
+			if strings.TrimSpace(key) != nodeID {
 				continue
 			}
 			return ContractItemSource{
@@ -687,31 +687,66 @@ func (b *WorkflowContractBundle) NodeRuntimeSubscriptions(nodeID string) []strin
 	if b == nil || nodeID == "" {
 		return nil
 	}
+	if effective, ok := b.Semantics.EffectiveNodes[nodeID]; ok {
+		return append([]string{}, effective.RuntimeSubscriptions...)
+	}
 	entry, ok := b.nodeContract(nodeID)
 	if !ok {
 		return nil
 	}
-	seen := make(map[string]struct{})
-	out := make([]string, 0, len(entry.SubscribesTo)+len(entry.EventHandlers))
-	appendSubscription := func(value string) {
-		value = eventidentity.Normalize(value)
-		if value == "" {
-			return
-		}
-		if _, ok := seen[value]; ok {
-			return
-		}
-		seen[value] = struct{}{}
-		out = append(out, value)
+	return EffectiveSystemNodeSubscriptions(entry)
+}
+
+func (b *WorkflowContractBundle) NodeEffectiveProduces(nodeID string) []string {
+	nodeID = strings.TrimSpace(nodeID)
+	if b == nil || nodeID == "" {
+		return nil
 	}
-	for _, eventType := range entry.SubscribesTo {
-		appendSubscription(eventType)
+	if effective, ok := b.Semantics.EffectiveNodes[nodeID]; ok {
+		return append([]string{}, effective.Produces...)
 	}
-	for _, eventType := range b.NodeHandlerSubscriptions(nodeID) {
-		appendSubscription(eventType)
+	entry, ok := b.nodeContract(nodeID)
+	if !ok {
+		return nil
 	}
-	sort.Strings(out)
-	return out
+	return EffectiveSystemNodeProduces(entry)
+}
+
+func (b *WorkflowContractBundle) NodeEffectiveExecutionType(nodeID string) string {
+	nodeID = strings.TrimSpace(nodeID)
+	if b == nil || nodeID == "" {
+		return ""
+	}
+	if effective, ok := b.Semantics.EffectiveNodes[nodeID]; ok {
+		return strings.TrimSpace(effective.ExecutionType)
+	}
+	entry, ok := b.nodeContract(nodeID)
+	if !ok {
+		return ""
+	}
+	return EffectiveSystemNodeExecutionType(entry)
+}
+
+func (b *WorkflowContractBundle) NodeEffectiveSemantics(nodeID string) (SystemNodeEffectiveSemantics, bool) {
+	nodeID = strings.TrimSpace(nodeID)
+	if b == nil || nodeID == "" {
+		return SystemNodeEffectiveSemantics{}, false
+	}
+	if effective, ok := b.Semantics.EffectiveNodes[nodeID]; ok {
+		effective.RuntimeSubscriptions = append([]string{}, effective.RuntimeSubscriptions...)
+		effective.Produces = append([]string{}, effective.Produces...)
+		return effective, true
+	}
+	entry, ok := b.nodeContract(nodeID)
+	if !ok {
+		return SystemNodeEffectiveSemantics{}, false
+	}
+	return SystemNodeEffectiveSemantics{
+		ID:                   EffectiveSystemNodeID(nodeID, entry),
+		ExecutionType:        EffectiveSystemNodeExecutionType(entry),
+		RuntimeSubscriptions: EffectiveSystemNodeSubscriptions(entry),
+		Produces:             EffectiveSystemNodeProduces(entry),
+	}, true
 }
 func (b *WorkflowContractBundle) ScopedAgentEntries() map[string]AgentRegistryEntry {
 	if b == nil {
@@ -778,29 +813,14 @@ func (b *WorkflowContractBundle) nodeContract(nodeID string) (SystemNodeContract
 	if entry, ok := b.Nodes[nodeID]; ok {
 		return entry, true
 	}
-	for _, entry := range b.Nodes {
-		if strings.TrimSpace(entry.ID) == nodeID {
-			return entry, true
-		}
-	}
 	for _, view := range b.ProjectViews() {
 		if entry, ok := view.Nodes[nodeID]; ok {
 			return entry, true
-		}
-		for _, entry := range view.Nodes {
-			if strings.TrimSpace(entry.ID) == nodeID {
-				return entry, true
-			}
 		}
 	}
 	for _, view := range b.FlowViews() {
 		if entry, ok := view.Nodes[nodeID]; ok {
 			return entry, true
-		}
-		for _, entry := range view.Nodes {
-			if strings.TrimSpace(entry.ID) == nodeID {
-				return entry, true
-			}
 		}
 	}
 	return SystemNodeContract{}, false

--- a/internal/runtime/contracts/workflow_contract_effective.go
+++ b/internal/runtime/contracts/workflow_contract_effective.go
@@ -1,0 +1,142 @@
+package contracts
+
+import (
+	"sort"
+	"strings"
+
+	"github.com/division-sh/swarm/internal/runtime/core/eventidentity"
+)
+
+func EffectiveSystemNodeID(nodeKey string, node SystemNodeContract) string {
+	if nodeKey := strings.TrimSpace(nodeKey); nodeKey != "" {
+		return nodeKey
+	}
+	return strings.TrimSpace(node.ID)
+}
+
+func SystemNodeIDMatchesKey(nodeKey, authoredID string) bool {
+	nodeKey = strings.TrimSpace(nodeKey)
+	authoredID = strings.TrimSpace(authoredID)
+	if authoredID == "" || authoredID == nodeKey {
+		return true
+	}
+	return systemNodeRenderedIDTemplateMatchesKey(nodeKey, authoredID)
+}
+
+func systemNodeRenderedIDTemplateMatchesKey(nodeKey, authoredID string) bool {
+	if nodeKey == "" || !strings.Contains(authoredID, "{") || !strings.Contains(authoredID, "}") {
+		return false
+	}
+	prefix, _, _ := strings.Cut(authoredID, "{")
+	prefix = strings.TrimSuffix(strings.TrimSpace(prefix), "-")
+	return prefix == nodeKey
+}
+
+func EffectiveSystemNodeExecutionType(node SystemNodeContract) string {
+	if executionType := strings.TrimSpace(node.ExecutionType); executionType != "" {
+		return executionType
+	}
+	return SystemNodeExecutionType
+}
+
+func EffectiveSystemNodeSubscriptions(node SystemNodeContract) []string {
+	seen := make(map[string]struct{})
+	out := make([]string, 0, len(node.SubscribesTo)+len(node.EventHandlers))
+	appendSubscription := func(value string) {
+		value = eventidentity.Normalize(value)
+		if value == "" {
+			return
+		}
+		if _, ok := seen[value]; ok {
+			return
+		}
+		seen[value] = struct{}{}
+		out = append(out, value)
+	}
+	for _, eventType := range node.SubscribesTo {
+		appendSubscription(eventType)
+	}
+	for eventType := range node.EventHandlers {
+		appendSubscription(eventType)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func EffectiveSystemNodeProduces(node SystemNodeContract) []string {
+	seen := make(map[string]struct{})
+	out := make([]string, 0, len(node.EventHandlers))
+	for _, eventType := range sortedContractKeys(node.EventHandlers) {
+		for _, emitted := range HandlerEmitEvents(node.EventHandlers[eventType]) {
+			emitted = strings.TrimSpace(emitted)
+			if emitted == "" {
+				continue
+			}
+			if _, ok := seen[emitted]; ok {
+				continue
+			}
+			seen[emitted] = struct{}{}
+			out = append(out, emitted)
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+func DefaultSystemNodeHandlerSourceEvent(handler SystemNodeEventHandler, triggerEvent string) SystemNodeEventHandler {
+	triggerEvent = strings.TrimSpace(triggerEvent)
+	if triggerEvent == "" {
+		return handler
+	}
+	handler.DataAccumulation = defaultWorkflowDataAccumulationSourceEvent(handler.DataAccumulation, triggerEvent)
+	if len(handler.Rules) > 0 {
+		handler.Rules = append([]HandlerRuleEntry(nil), handler.Rules...)
+		for i := range handler.Rules {
+			handler.Rules[i].DataAccumulation = defaultWorkflowDataAccumulationSourceEvent(handler.Rules[i].DataAccumulation, triggerEvent)
+		}
+	}
+	if len(handler.OnComplete) > 0 {
+		handler.OnComplete = append([]HandlerRuleEntry(nil), handler.OnComplete...)
+		for i := range handler.OnComplete {
+			handler.OnComplete[i].DataAccumulation = defaultWorkflowDataAccumulationSourceEvent(handler.OnComplete[i].DataAccumulation, triggerEvent)
+		}
+	}
+	if handler.Accumulate != nil {
+		accumulate := *handler.Accumulate
+		if len(accumulate.OnComplete) > 0 {
+			accumulate.OnComplete = append([]HandlerRuleEntry(nil), accumulate.OnComplete...)
+			for i := range accumulate.OnComplete {
+				accumulate.OnComplete[i].DataAccumulation = defaultWorkflowDataAccumulationSourceEvent(accumulate.OnComplete[i].DataAccumulation, triggerEvent)
+			}
+		}
+		if accumulate.OnTimeout != nil {
+			timeout := *accumulate.OnTimeout
+			timeout.DataAccumulation = defaultWorkflowDataAccumulationSourceEvent(timeout.DataAccumulation, triggerEvent)
+			accumulate.OnTimeout = &timeout
+		}
+		handler.Accumulate = &accumulate
+	}
+	if len(handler.Branch) > 0 {
+		handler.Branch = append([]BranchSpec(nil), handler.Branch...)
+		for i := range handler.Branch {
+			if handler.Branch[i].Then != nil {
+				then := *handler.Branch[i].Then
+				then.DataAccumulation = defaultWorkflowDataAccumulationSourceEvent(then.DataAccumulation, triggerEvent)
+				handler.Branch[i].Then = &then
+			}
+			if handler.Branch[i].Else != nil {
+				otherwise := *handler.Branch[i].Else
+				otherwise.DataAccumulation = defaultWorkflowDataAccumulationSourceEvent(otherwise.DataAccumulation, triggerEvent)
+				handler.Branch[i].Else = &otherwise
+			}
+		}
+	}
+	return handler
+}
+
+func defaultWorkflowDataAccumulationSourceEvent(accumulation WorkflowDataAccumulation, triggerEvent string) WorkflowDataAccumulation {
+	if accumulation.HasWrites() && strings.TrimSpace(accumulation.SourceEvent) == "" {
+		accumulation.SourceEvent = triggerEvent
+	}
+	return accumulation
+}

--- a/internal/runtime/contracts/workflow_contract_emit.go
+++ b/internal/runtime/contracts/workflow_contract_emit.go
@@ -22,6 +22,9 @@ func HandlerEmitEvents(handler SystemNodeEventHandler) []string {
 			out = append(out, ruleEmitEvents(*handler.Accumulate.OnTimeout)...)
 		}
 	}
+	for _, branch := range handler.Branch {
+		out = append(out, branchEmitEvents(branch)...)
+	}
 	if handler.FanOut != nil {
 		if eventType := handler.FanOut.Emit.EventType(); eventType != "" {
 			out = append(out, eventType)
@@ -48,6 +51,17 @@ func ruleEmitEvents(rule HandlerRuleEntry) []string {
 	return uniqueOrderedStrings(out)
 }
 
+func branchEmitEvents(branch BranchSpec) []string {
+	out := make([]string, 0, 4)
+	if branch.Then != nil {
+		out = append(out, ruleEmitEvents(*branch.Then)...)
+	}
+	if branch.Else != nil {
+		out = append(out, ruleEmitEvents(*branch.Else)...)
+	}
+	return uniqueOrderedStrings(out)
+}
+
 func actionResultEvents(action ActionSpec) []string {
 	if strings.TrimSpace(action.ID) != "artifact_repo_commit" || action.ArtifactRepo == nil {
 		return nil
@@ -66,6 +80,9 @@ func HandlerHasNestedEmitSites(handler SystemNodeEventHandler) bool {
 		return true
 	}
 	if len(handler.OnComplete) > 0 {
+		return true
+	}
+	if len(handler.Branch) > 0 {
 		return true
 	}
 	if handler.Accumulate != nil {

--- a/internal/runtime/contracts/workflow_contract_emit_test.go
+++ b/internal/runtime/contracts/workflow_contract_emit_test.go
@@ -25,6 +25,19 @@ func TestHandlerEmitEventsIncludesArtifactRepoCommitResults(t *testing.T) {
 				},
 			},
 		}},
+		Branch: []BranchSpec{{
+			Then: &HandlerRuleEntry{Emit: EmitSpec{Event: "branch.then.emitted"}},
+			Else: &HandlerRuleEntry{
+				Emit: EmitSpec{Event: "branch.else.emitted"},
+				Action: ActionSpec{
+					ID: "artifact_repo_commit",
+					ArtifactRepo: &ArtifactRepoSpec{
+						SuccessEvent: "artifact_repo.branch_completed",
+						FailureEvent: "artifact_repo.branch_failed",
+					},
+				},
+			},
+		}},
 	}
 
 	got := HandlerEmitEvents(handler)
@@ -35,8 +48,23 @@ func TestHandlerEmitEventsIncludesArtifactRepoCommitResults(t *testing.T) {
 		"rule.emitted",
 		"artifact_repo.rule_completed",
 		"artifact_repo.rule_failed",
+		"branch.then.emitted",
+		"branch.else.emitted",
+		"artifact_repo.branch_completed",
+		"artifact_repo.branch_failed",
 	}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("HandlerEmitEvents() = %#v, want %#v", got, want)
+	}
+}
+
+func TestHandlerHasNestedEmitSitesIncludesBranch(t *testing.T) {
+	handler := SystemNodeEventHandler{
+		Branch: []BranchSpec{{
+			Then: &HandlerRuleEntry{Emit: EmitSpec{Event: "branch.then.emitted"}},
+		}},
+	}
+	if !HandlerHasNestedEmitSites(handler) {
+		t.Fatal("HandlerHasNestedEmitSites() = false, want true for branch emit sites")
 	}
 }

--- a/internal/runtime/contracts/workflow_contract_loading.go
+++ b/internal/runtime/contracts/workflow_contract_loading.go
@@ -153,8 +153,13 @@ func validateWorkflowContractBundleLoadConstraints(bundle *WorkflowContractBundl
 	errs := make([]error, 0, 8)
 	for nodeID, node := range bundle.Nodes {
 		nodeID = strings.TrimSpace(nodeID)
-		if err := ValidateSystemNodeExecutionType(node.ExecutionType); err != nil {
-			errs = append(errs, fmt.Errorf("%w: node %s %v", ErrInvalidField, nodeID, err))
+		if authoredID := strings.TrimSpace(node.ID); !SystemNodeIDMatchesKey(nodeID, authoredID) {
+			errs = append(errs, fmt.Errorf("%w: node %s id %q must match map key", ErrInvalidField, nodeID, authoredID))
+		}
+		if strings.TrimSpace(node.ExecutionType) != "" {
+			if err := ValidateSystemNodeExecutionType(node.ExecutionType); err != nil {
+				errs = append(errs, fmt.Errorf("%w: node %s %v", ErrInvalidField, nodeID, err))
+			}
 		}
 		for eventType, handler := range node.EventHandlers {
 			eventType = strings.TrimSpace(eventType)

--- a/internal/runtime/contracts/workflow_contract_semantics.go
+++ b/internal/runtime/contracts/workflow_contract_semantics.go
@@ -41,6 +41,7 @@ func populateWorkflowSemantics(bundle *WorkflowContractBundle) {
 		CompositionConnects:    nil,
 		FlowAgents:             map[string][]FlowRequiredAgent{},
 		WritePinOwners:         map[string][]string{},
+		EffectiveNodes:         map[string]SystemNodeEffectiveSemantics{},
 		NodeHandlers:           map[string]map[string]SystemNodeEventHandler{},
 		EventOwners:            map[string][]string{},
 		HandlerTransitionIndex: map[string]map[string]HandlerTransitionSemantic{},
@@ -94,7 +95,22 @@ func populateWorkflowSemantics(bundle *WorkflowContractBundle) {
 	}
 	for nodeID, node := range bundle.Nodes {
 		nodeID = strings.TrimSpace(nodeID)
-		if nodeID == "" || len(node.EventHandlers) == 0 {
+		if nodeID == "" {
+			continue
+		}
+		effective := SystemNodeEffectiveSemantics{
+			ID:                   EffectiveSystemNodeID(nodeID, node),
+			ExecutionType:        EffectiveSystemNodeExecutionType(node),
+			RuntimeSubscriptions: EffectiveSystemNodeSubscriptions(node),
+			Produces:             EffectiveSystemNodeProduces(node),
+		}
+		semantics.EffectiveNodes[nodeID] = effective
+		if strings.TrimSpace(node.ID) == "" || strings.TrimSpace(node.ExecutionType) == "" {
+			node.ID = effective.ID
+			node.ExecutionType = effective.ExecutionType
+			bundle.Nodes[nodeID] = node
+		}
+		if len(node.EventHandlers) == 0 {
 			continue
 		}
 		handlers := make(map[string]SystemNodeEventHandler, len(node.EventHandlers))
@@ -104,6 +120,7 @@ func populateWorkflowSemantics(bundle *WorkflowContractBundle) {
 			if rawEventType == "" {
 				continue
 			}
+			handler = DefaultSystemNodeHandlerSourceEvent(handler, rawEventType)
 			handlers[rawEventType] = handler
 			ownerEventType := strings.TrimSpace(bundle.resolveNodeEventOwnerPattern(nodeID, rawEventType))
 			if ownerEventType == "" {
@@ -555,7 +572,7 @@ func inferWorkflowTimerEvent(bundle *WorkflowContractBundle, node SystemNodeCont
 			return candidate
 		}
 	}
-	for _, subscribed := range node.SubscribesTo {
+	for _, subscribed := range EffectiveSystemNodeSubscriptions(node) {
 		subscribed = strings.TrimSpace(subscribed)
 		if subscribed == "" {
 			continue

--- a/internal/runtime/contracts/workflow_contract_semantics_test.go
+++ b/internal/runtime/contracts/workflow_contract_semantics_test.go
@@ -1,6 +1,9 @@
 package contracts
 
-import "testing"
+import (
+	"reflect"
+	"testing"
+)
 
 func TestWorkflowSemanticsRuleActionUsesHandlerAdvancesToFallback(t *testing.T) {
 	bundle := &WorkflowContractBundle{
@@ -49,5 +52,77 @@ func TestWorkflowSemanticsRuleActionUsesHandlerAdvancesToFallback(t *testing.T) 
 		if transition.ID == "auto-approve" {
 			t.Fatalf("derived fallback transition for rule without action: %#v", transition)
 		}
+	}
+}
+
+func TestWorkflowSemanticsDerivesEffectiveSystemNodeFacts(t *testing.T) {
+	bundle := &WorkflowContractBundle{
+		Nodes: map[string]SystemNodeContract{
+			"worker": {
+				EventHandlers: map[string]SystemNodeEventHandler{
+					"task.start": {
+						DataAccumulation: WorkflowDataAccumulation{
+							Writes: []WorkflowDataWrite{{Field: "status"}},
+						},
+						Emit: EmitSpec{Event: "task.done"},
+					},
+					"task.review": {
+						Rules: []HandlerRuleEntry{{Emit: EmitSpec{Event: "task.approved"}}},
+					},
+					"task.timeout": {
+						Accumulate: &AccumulateSpec{
+							OnTimeout: &HandlerRuleEntry{Emit: EmitSpec{Event: "task.expired"}},
+						},
+					},
+					"task.branch": {
+						Branch: []BranchSpec{{
+							Then: &HandlerRuleEntry{Emit: EmitSpec{Event: "task.branch.then"}},
+							Else: &HandlerRuleEntry{Emit: EmitSpec{Event: "task.branch.else"}},
+						}},
+						FanOut: &FanOutSpec{Emit: EmitSpec{Event: "task.child"}},
+					},
+				},
+			},
+		},
+	}
+
+	populateWorkflowSemantics(bundle)
+
+	node := bundle.Nodes["worker"]
+	if node.ID != "worker" {
+		t.Fatalf("normalized node ID = %q, want worker", node.ID)
+	}
+	if node.ExecutionType != SystemNodeExecutionType {
+		t.Fatalf("normalized execution_type = %q, want %q", node.ExecutionType, SystemNodeExecutionType)
+	}
+	effective, ok := bundle.NodeEffectiveSemantics("worker")
+	if !ok {
+		t.Fatal("missing effective node semantics")
+	}
+	if got, want := effective.ID, "worker"; got != want {
+		t.Fatalf("effective ID = %q, want %q", got, want)
+	}
+	if got, want := effective.ExecutionType, SystemNodeExecutionType; got != want {
+		t.Fatalf("effective execution type = %q, want %q", got, want)
+	}
+	if got, want := effective.RuntimeSubscriptions, []string{"task.branch", "task.review", "task.start", "task.timeout"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("effective subscriptions = %#v, want %#v", got, want)
+	}
+	if got, want := effective.Produces, []string{"task.approved", "task.branch.else", "task.branch.then", "task.child", "task.done", "task.expired"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("effective produces = %#v, want %#v", got, want)
+	}
+	handler, ok := bundle.NodeEventHandler("worker", "task.start")
+	if !ok {
+		t.Fatal("missing task.start handler")
+	}
+	if got, want := handler.DataAccumulation.SourceEvent, "task.start"; got != want {
+		t.Fatalf("effective source_event = %q, want %q", got, want)
+	}
+	transition, ok := bundle.DerivedHandlerTransition("worker", "task.start")
+	if !ok {
+		t.Fatal("missing task.start transition")
+	}
+	if got, want := transition.DataAccumulation.SourceEvent, "task.start"; got != want {
+		t.Fatalf("transition source_event = %q, want %q", got, want)
 	}
 }

--- a/internal/runtime/contracts/workflow_contract_types.go
+++ b/internal/runtime/contracts/workflow_contract_types.go
@@ -96,10 +96,18 @@ type WorkflowSemanticView struct {
 	CompositionConnects    []FlowPackageConnect
 	FlowAgents             map[string][]FlowRequiredAgent
 	WritePinOwners         map[string][]string
+	EffectiveNodes         map[string]SystemNodeEffectiveSemantics
 	NodeHandlers           map[string]map[string]SystemNodeEventHandler
 	EventOwners            map[string][]string
 	HandlerTransitions     []HandlerTransitionSemantic
 	HandlerTransitionIndex map[string]map[string]HandlerTransitionSemantic
+}
+
+type SystemNodeEffectiveSemantics struct {
+	ID                   string
+	ExecutionType        string
+	RuntimeSubscriptions []string
+	Produces             []string
 }
 
 type FlowInputAutoWireResolution struct {

--- a/internal/runtime/pipeline/engine_bridge.go
+++ b/internal/runtime/pipeline/engine_bridge.go
@@ -113,14 +113,14 @@ func isAccumulationTimeoutEvent(eventType events.EventType) bool {
 
 func findAccumulationTimeoutHandlerForBucket(source interface {
 	NodeEntries() map[string]runtimecontracts.SystemNodeContract
+	NodeRuntimeSubscriptions(nodeID string) []string
 	NodeEventHandlers(nodeID string) map[string]runtimecontracts.SystemNodeEventHandler
 }, bucket timeridentity.AccumulatorBucketRef) (runtimecontracts.SystemNodeEventHandler, bool) {
 	bucket = bucket.Normalize()
 	if source == nil || !bucket.Valid() {
 		return runtimecontracts.SystemNodeEventHandler{}, false
 	}
-	node, ok := source.NodeEntries()[bucket.NodeID]
-	if !ok || !containsString(node.SubscribesTo, "accumulate.timeout") {
+	if _, ok := source.NodeEntries()[bucket.NodeID]; !ok || !containsString(source.NodeRuntimeSubscriptions(bucket.NodeID), "accumulate.timeout") {
 		return runtimecontracts.SystemNodeEventHandler{}, false
 	}
 	for eventType, candidate := range source.NodeEventHandlers(bucket.NodeID) {

--- a/internal/runtime/pipeline/node_declarative.go
+++ b/internal/runtime/pipeline/node_declarative.go
@@ -54,8 +54,9 @@ type ProductHookRegistry struct {
 
 func NewNode(contract SystemNodeContract, source semanticview.Source, engine HandlerExecutionEngine, hooks *ProductHookRegistry) NodeExecutor {
 	nodeID := strings.TrimSpace(contract.ID)
-	subscriptions := make([]events.EventType, 0, len(contract.SubscribesTo))
-	for _, evt := range contract.SubscribesTo {
+	effectiveSubscriptions := runtimecontracts.EffectiveSystemNodeSubscriptions(contract)
+	subscriptions := make([]events.EventType, 0, len(effectiveSubscriptions))
+	for _, evt := range effectiveSubscriptions {
 		evt = strings.TrimSpace(evt)
 		if evt == "" {
 			continue
@@ -130,8 +131,9 @@ func (n *DeclarativeNode) Subscriptions() []events.EventType {
 	if n == nil {
 		return nil
 	}
-	out := make([]events.EventType, 0, len(n.contract.SubscribesTo))
-	for _, evt := range n.contract.SubscribesTo {
+	effectiveSubscriptions := runtimecontracts.EffectiveSystemNodeSubscriptions(n.contract)
+	out := make([]events.EventType, 0, len(effectiveSubscriptions))
+	for _, evt := range effectiveSubscriptions {
 		evt = strings.TrimSpace(evt)
 		if evt == "" {
 			continue
@@ -198,7 +200,7 @@ func (n *DeclarativeNode) HandleEvent(ctx context.Context, evt Event) (*HandlerO
 			}
 		}
 	}
-	if !ok && isAccumulationTimeoutEvent(events.EventType(eventType)) && containsString(n.contract.SubscribesTo, eventType) {
+	if !ok && isAccumulationTimeoutEvent(events.EventType(eventType)) && containsEventType(n.Subscriptions(), events.EventType(eventType)) {
 		if bucket, bucketOK := timeridentity.ParseAccumulatorBucketRef(parsePayloadMap(evt.Payload())); bucketOK && bucket.NodeID == n.NodeID() {
 			for candidateEventType, candidate := range n.contract.EventHandlers {
 				if strings.TrimSpace(candidateEventType) != bucket.EventType {
@@ -233,6 +235,19 @@ func (n *DeclarativeNode) resolvedHandlerForDelivery(evt Event) (SystemNodeEvent
 	}
 	resolved := workflowNodeEventHandlerResolutionForDelivery(n.source, n.NodeID(), evt)
 	return resolved.Handler, resolved.Matched
+}
+
+func containsEventType(values []events.EventType, want events.EventType) bool {
+	want = events.EventType(strings.TrimSpace(string(want)))
+	if want == "" {
+		return false
+	}
+	for _, value := range values {
+		if events.EventType(strings.TrimSpace(string(value))) == want {
+			return true
+		}
+	}
+	return false
 }
 
 func (r *ProductHookRegistry) Register(actionID string, handler ActionHandler) {

--- a/internal/runtime/pipeline/workflow_nodes.go
+++ b/internal/runtime/pipeline/workflow_nodes.go
@@ -383,8 +383,9 @@ func LoadWorkflowNodes(source semanticview.Source) ([]WorkflowNode, error) {
 				subscriptions = append(subscriptions, events.EventType(resolved))
 			}
 		}
-		produces := make([]events.EventType, 0, len(entry.Produces))
-		for _, evt := range entry.Produces {
+		effectiveProduces := semanticview.NodeEffectiveProduces(source, nodeID)
+		produces := make([]events.EventType, 0, len(effectiveProduces))
+		for _, evt := range effectiveProduces {
 			evt = workflowNodeExternalEventType(source, nodeID, evt)
 			if evt == "" {
 				continue
@@ -397,7 +398,7 @@ func LoadWorkflowNodes(source semanticview.Source) ([]WorkflowNode, error) {
 			Produces:         produces,
 			OwnedTransitions: append([]string{}, entry.OwnedTransitions...),
 			Timers:           workflowNodeTimerIDs(entry.Timers),
-			ExecutionType:    strings.TrimSpace(entry.ExecutionType),
+			ExecutionType:    runtimecontracts.EffectiveSystemNodeExecutionType(entry),
 			Implementation:   strings.TrimSpace(entry.Implementation),
 			StateTable:       strings.TrimSpace(entry.StateTable),
 			IdempotencyTable: strings.TrimSpace(entry.IdempotencyTable),
@@ -563,7 +564,7 @@ func workflowRuntimeNodeIDs(source semanticview.Source) []string {
 		if _, ok := seen[nodeID]; ok {
 			continue
 		}
-		if len(node.SubscribesTo) == 0 && len(node.OwnedTransitions) == 0 && len(node.Timers) == 0 {
+		if len(source.NodeRuntimeSubscriptions(nodeID)) == 0 && len(node.OwnedTransitions) == 0 && len(node.Timers) == 0 {
 			continue
 		}
 		seen[nodeID] = struct{}{}

--- a/internal/runtime/pipeline/workflow_nodes_test.go
+++ b/internal/runtime/pipeline/workflow_nodes_test.go
@@ -189,6 +189,38 @@ func TestLoadWorkflowNodes_UsesHandlerKeysForCrossFlowPinAutoWire(t *testing.T) 
 	t.Fatalf("Subscriptions = %#v, want producer/scan.requested", nodes[0].Subscriptions)
 }
 
+func TestLoadWorkflowNodes_UsesEffectiveFactsForMinimizedSystemNode(t *testing.T) {
+	bundle := &runtimecontracts.WorkflowContractBundle{
+		Nodes: map[string]runtimecontracts.SystemNodeContract{
+			"worker": {
+				EventHandlers: map[string]runtimecontracts.SystemNodeEventHandler{
+					"task.start": {
+						Emit: runtimecontracts.EmitSpec{Event: "task.done"},
+					},
+				},
+			},
+		},
+	}
+
+	nodes, err := LoadWorkflowNodes(semanticview.Wrap(bundle))
+	if err != nil {
+		t.Fatalf("LoadWorkflowNodes: %v", err)
+	}
+	worker := workflowNodeByIDForTest(nodes, "worker")
+	if worker == nil {
+		t.Fatalf("worker missing from %#v", nodes)
+	}
+	if got, want := worker.ExecutionType, runtimecontracts.SystemNodeExecutionType; got != want {
+		t.Fatalf("execution type = %q, want %q", got, want)
+	}
+	if !workflowNodeHasSubscriptionForTest(*worker, "task.start") {
+		t.Fatalf("subscriptions = %#v, want task.start", worker.Subscriptions)
+	}
+	if !workflowNodeHasProducesForTest(*worker, "task.done") {
+		t.Fatalf("produces = %#v, want task.done", worker.Produces)
+	}
+}
+
 func TestLoadWorkflowNodes_UsesImportBoundaryInputAlias(t *testing.T) {
 	source := loadPipelineImportBoundaryAliasSource(t)
 	nodes, err := LoadWorkflowNodes(source)
@@ -459,6 +491,15 @@ func workflowNodeByIDForTest(nodes []WorkflowNode, id string) *WorkflowNode {
 func workflowNodeHasSubscriptionForTest(node WorkflowNode, eventType string) bool {
 	for _, subscription := range node.Subscriptions {
 		if string(subscription) == eventType {
+			return true
+		}
+	}
+	return false
+}
+
+func workflowNodeHasProducesForTest(node WorkflowNode, eventType string) bool {
+	for _, produced := range node.Produces {
+		if string(produced) == eventType {
 			return true
 		}
 	}

--- a/internal/runtime/semanticview/effective_nodes.go
+++ b/internal/runtime/semanticview/effective_nodes.go
@@ -1,0 +1,43 @@
+package semanticview
+
+import (
+	"strings"
+
+	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
+)
+
+func NodeEffectiveProduces(source Source, nodeID string) []string {
+	nodeID = strings.TrimSpace(nodeID)
+	if source == nil || nodeID == "" {
+		return nil
+	}
+	if bundle, ok := Bundle(source); ok && bundle != nil {
+		return bundle.NodeEffectiveProduces(nodeID)
+	}
+	entry, ok := source.NodeEntries()[nodeID]
+	if !ok {
+		return nil
+	}
+	if handlers := source.NodeEventHandlers(nodeID); len(handlers) > 0 {
+		entry.EventHandlers = handlers
+	}
+	return runtimecontracts.EffectiveSystemNodeProduces(entry)
+}
+
+func NodeEffectiveSubscriptions(source Source, nodeID string) []string {
+	nodeID = strings.TrimSpace(nodeID)
+	if source == nil || nodeID == "" {
+		return nil
+	}
+	if subs := source.NodeRuntimeSubscriptions(nodeID); len(subs) > 0 {
+		return append([]string{}, subs...)
+	}
+	entry, ok := source.NodeEntries()[nodeID]
+	if !ok {
+		return nil
+	}
+	if handlers := source.NodeEventHandlers(nodeID); len(handlers) > 0 {
+		entry.EventHandlers = handlers
+	}
+	return runtimecontracts.EffectiveSystemNodeSubscriptions(entry)
+}

--- a/internal/runtime/semanticview/import_boundary_wildcards.go
+++ b/internal/runtime/semanticview/import_boundary_wildcards.go
@@ -315,10 +315,7 @@ func importBoundaryProjectWildcardSubscriptions(scope ProjectScope) []string {
 		}
 	}
 	for _, entry := range scope.Nodes {
-		for _, pattern := range entry.SubscribesTo {
-			appendPattern(pattern)
-		}
-		for pattern := range entry.EventHandlers {
+		for _, pattern := range runtimecontracts.EffectiveSystemNodeSubscriptions(entry) {
 			appendPattern(pattern)
 		}
 	}
@@ -343,10 +340,7 @@ func importBoundaryFlowWildcardSubscriptions(scope FlowScope) []string {
 		}
 	}
 	for _, entry := range scope.Nodes {
-		for _, pattern := range entry.SubscribesTo {
-			appendPattern(pattern)
-		}
-		for pattern := range entry.EventHandlers {
+		for _, pattern := range runtimecontracts.EffectiveSystemNodeSubscriptions(entry) {
 			appendPattern(pattern)
 		}
 	}

--- a/internal/runtime/tools/usage_test.go
+++ b/internal/runtime/tools/usage_test.go
@@ -92,7 +92,11 @@ func TestValidateUsageHintCoverage_CoversRoleDerivedEmitTools(t *testing.T) {
 		},
 		Nodes: map[string]runtimecontracts.SystemNodeContract{
 			"reviewer": {
-				Produces: []string{"review.completed"},
+				EventHandlers: map[string]runtimecontracts.SystemNodeEventHandler{
+					"review.requested": {
+						Emit: runtimecontracts.EmitSpec{Event: "review.completed"},
+					},
+				},
 			},
 		},
 		Events: map[string]runtimecontracts.EventCatalogEntry{

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -951,16 +951,17 @@ contract_formats:
       flows: []'
     schema_yaml: "initial_state: waiting\nterminal_states: [done]\nstates: [waiting, done]\npins:\n  inputs:\n    events:\
       \ [hello.requested]\n  outputs:\n    events: [hello.completed]"
-    nodes_yaml: "hello-node:\n  id: hello-node\n  execution_type: system_node\n  subscribes_to: [hello.requested]\n  produces:\
-      \ [hello.completed]\n  event_handlers:\n    hello.requested:\n      advances_to: done\n      emit:\n        event: hello.completed\n\
+    nodes_yaml: "hello-node:\n  event_handlers:\n    hello.requested:\n      advances_to: done\n      emit:\n        event: hello.completed\n\
       \        fields:\n          result: payload.message"
     events_yaml: "hello.requested:\n  message: text\nhello.completed:\n  result: text"
     agents_yaml: '{}'
   produces_derivation: >-
-    The produces field on system nodes is OPTIONAL. If omitted, the platform derives it from every supported declarative
-    emit site at boot: handler top-level emit, rule-local emit, on_complete branch emit, accumulate.on_timeout emit, and
-    fan_out emit. If present, the verifier checks it matches actual emits (PRODUCES-DRIFT warning). Authors should omit
-    produces and let the platform derive it.
+    The produces field on system nodes is OPTIONAL. If omitted, the platform derives the effective production surface from
+    every supported declarative emit site at boot: handler top-level emit, rule-local emit, on_complete branch emit,
+    accumulate.on_timeout emit, and fan_out emit. Runtime routing, producer authority, and transition checks consume this
+    effective production surface, not raw authored produces. If present, produces is an explicit authored assertion surface:
+    the verifier checks it matches actual emits, including an explicit empty list, with a PRODUCES-DRIFT warning. Authors
+    should omit produces and let the platform derive it.
   underscore_prefix_convention:
     description: Fields starting with _ in contract YAML files.
     semantic_fields:
@@ -1693,7 +1694,8 @@ handler_specification:
       - writes is always a list
       - each item is exactly one of the five forms above
       - value and expression are mutually exclusive on the same write item (boot error if both present)
-      - source_event is optional — if omitted, the trigger event is the source
+      - source_event is optional — if omitted, the trigger event is the source; this effective default must be visible in
+        the normalized handler semantics used by boot and runtime
       - source_event payload must contain all fields referenced by direct and mapped writes (verified at boot)
       - literal writes do not reference source_event or handler context — the value is used as-is
       - computed writes do not reference source_event — they use the handler context directly
@@ -2053,17 +2055,28 @@ handler_specification:
     node_fields:
       description: Top-level fields on a system node declaration.
       required:
-        id: string — unique node identifier within the flow
-        execution_type: string — must be "system_node"
-        subscribes_to: list of event names this node receives
         event_handlers: map of event_name → handler declaration
       optional:
+        id: string — migration spelling for the node identifier; if omitted, the YAML map key is the effective node id.
+          If present as a plain value, it must exactly match the YAML map key. Existing rendered runtime-id templates such
+          as node-key-{instance_id} are subscriber naming templates, not a separate semantic node identity owner.
+        execution_type: string — if omitted, defaults to "system_node"; any explicit non-system_node value is invalid.
+        subscribes_to: list of event names this node receives. Exact handler-triggered subscriptions are derived from
+          event_handlers keys when omitted. Wildcard/import-boundary escape-hatch subscriptions remain explicit.
+        produces: list of event names this node emits. Omit for ordinary nodes; the effective production surface is derived
+          from supported declarative emit sites. If present, this is an explicit authored assertion checked against actual
+          emits.
         description: string — human-readable description
         state_schema: map — fields the node persists per entity (accumulator state)
         state_table: string — table name for node state persistence
         timers: list of timer declarations (see timer_model)
         gate_state: map — gate field definitions for this node (boolean flags on entity)
         permissions: list of platform permissions this node requires (e.g., create_flow_instance)
+      effective_semantics:
+        id: YAML map key, with same-value explicit id accepted during migration
+        execution_type: system_node
+        runtime_subscriptions: union of explicit subscribes_to entries and event_handlers keys
+        produces: events derived from supported declarative emit sites
     description: Complete specification for system nodes — the deterministic components that orchestrate state transitions.
       Every field used in nodes.yaml must be defined here.
   dependency_rules:
@@ -4584,8 +4597,10 @@ compliance:
   - Root-level nodes must not duplicate flow-level node IDs
   - All handoff events must have both an emitter (source flow) and subscriber (target flow or declarative handoff)
   node_coherence:
-  - Every event in event_handlers must appear in subscribes_to
-  - Every event in produces must have a payload schema in events.yaml
+  - The effective runtime subscription surface includes every event in event_handlers. Explicit subscribes_to is required
+    only for wildcard/import-boundary escape hatches that cannot be derived from exact handler keys.
+  - Every event in the effective production surface must have a payload schema in events.yaml. Explicit produces, when
+    authored, is an assertion checked against handler-derived emits.
   - Guards must reference fields that exist on the entity or in policy.yaml
   - advances_to states must be reachable from the current flow state space
   agent_coherence:


### PR DESCRIPTION
Closes #1594.

## Scope

Implements the approved #1594 first slice for ordinary system-node pure inference:

- derive effective node identity from the YAML map key
- default omitted `execution_type` to `system_node`
- derive exact runtime subscriptions from `event_handlers` keys
- derive effective `produces` from supported declarative emit sites
- default simple `data_accumulation.source_event` to the handler trigger event in normalized semantics

## Governing refs

- #1594 Pre-Implementation Coverage Audit and gate outcome: approved as first slice with binding consumer-sweep repair
- `platform-spec.yaml` sections updated/ratified in this PR:
  - `contract_formats.produces_derivation`
  - `handler_specification.data_accumulation`
  - `handler_specification.node_specification.node_fields`
  - `compliance.node_coherence`
- Parent/watchlist context remains #1528 / #1463.
- Split siblings remain #1595, #1596, #1597, #1599, #1551, #1523, and #1525.

`docs/IMPLEMENTER_GUIDELINES.md` and `docs/SEMANTIC_DRIFT.md` are not present in this checkout; the implementation used the issue thread, gate comment, platform spec, and local runtime/bootverify contracts as the binding context.

## Semantic migration

New canonical owner:

- `runtimecontracts` effective system-node semantics: `EffectiveSystemNodeID`, `EffectiveSystemNodeExecutionType`, `EffectiveSystemNodeSubscriptions`, `EffectiveSystemNodeProduces`, and `DefaultSystemNodeHandlerSourceEvent`
- `WorkflowSemanticView.EffectiveNodes` as the inspectable normalized projection

Old paths now invalid or non-authoritative:

- raw `node.id` as a second semantic identity owner
- missing `execution_type` as a hard error
- raw `node.SubscribesTo` as the exact runtime subscription authority for normal handler-triggered events
- raw `node.Produces` as runtime producer authority for handler-backed nodes
- empty `source_event` as an unreviewable implicit default

Production consumers checked/moved:

- bootverify required-field/topology/dead-event/flow-boundary/transition/drift checks
- bus route derivation, route templates, and node-local event sets
- pipeline workflow-node loading, declarative node subscriptions, and accumulation-timeout lookup
- authority source provider producer registry
- semantic import-boundary wildcard scans
- role-derived emit tooling fixtures

Migration is complete for the approved #1594 chosen class. Parent #1528/#1463 remains open for broader derivability work.

## Validation

- `go test ./internal/runtime/contracts ./internal/runtime/semanticview ./internal/runtime/bootverify ./internal/runtime/bus ./internal/runtime/pipeline ./internal/runtime/authority -run 'TestWorkflowSemanticsDerivesEffectiveSystemNodeFacts|TestValidateWorkflowContractBundleLoadConstraints(AllowsMissingExecutionType|RejectsNodeIDMismatch|RejectsInvalidExecutionType)|TestRun_(DoesNotWarnForProducesDriftWhenProducesOmitted|ExplicitEmptyProducesRemainsAssertion|DoesNotWarnForProducesDriftWhenDeclaredEventsMatchEmits|MapsProducesDriftToNamedWarning|MapsPhantomProducesToNamedWarning)|TestEventBusFlowInstanceTemplateDerivesSubscriptionsFromHandlerKeys|TestRouteNodeLocalEventSetDerivesProducesFromHandlerEmits|TestLoadWorkflowNodes_UsesEffectiveFactsForMinimizedSystemNode|TestNewSourceProvider_UsesEffectiveSystemNodeProduces' -count=1`
- `go test ./...`