### PR TITLE
[agent-c][issue #1531] Fail closed duplicate boot-pinned agent slugs

### DIFF
--- a/cmd/swarm/main.go
+++ b/cmd/swarm/main.go
@@ -1028,6 +1028,7 @@ func runServeRuntime(ctx context.Context, repo string, opts serveOptions) int {
 		Credentials:      credentialStore,
 	})
 	if err != nil {
+		reporter.emit(5, "runtime_context", "FAILED", err.Error())
 		log.Printf("init runtime context manager: %v", err)
 		return 1
 	}

--- a/cmd/swarm/main_test.go
+++ b/cmd/swarm/main_test.go
@@ -6422,8 +6422,8 @@ func TestRunServeRuntimeDuplicateAgentSlugFailsBeforeReadiness(t *testing.T) {
 		return serveRuntimeWorkspaceStub{}
 	})
 	ctx := context.Background()
-	firstRoot := writeServeRuntimeAgentSlugFixture(t, "duplicate-agent-slug-a", "shared-worker")
-	secondRoot := writeServeRuntimeAgentSlugFixture(t, "duplicate-agent-slug-b", "shared-worker")
+	firstRoot := writeServeRuntimeAgentSlugFixtureWithKey(t, "duplicate-agent-slug-a", "alpha", "shared-worker")
+	secondRoot := writeServeRuntimeAgentSlugFixtureWithKey(t, "duplicate-agent-slug-b", "beta", "shared-worker")
 	firstHash := seedServeRuntimeBundleCatalogRoot(t, ctx, pg, firstRoot)
 	secondHash := seedServeRuntimeBundleCatalogRoot(t, ctx, pg, secondRoot)
 	if firstHash == secondHash {
@@ -10000,6 +10000,11 @@ func writeWorkflowValidationFixtureFile(t *testing.T, path, contents string) {
 
 func writeServeRuntimeAgentSlugFixture(t *testing.T, workflowName, agentID string) string {
 	t.Helper()
+	return writeServeRuntimeAgentSlugFixtureWithKey(t, workflowName, agentID, agentID)
+}
+
+func writeServeRuntimeAgentSlugFixtureWithKey(t *testing.T, workflowName, agentKey, agentID string) string {
+	t.Helper()
 	root := t.TempDir()
 	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "package.yaml"), fmt.Sprintf(`
 name: %s
@@ -10032,7 +10037,7 @@ agent.requested:
   model: regular
   mode: task
   subscriptions: [agent.requested]
-`, agentID, agentID, agentID, agentID))
+`, agentKey, agentID, agentID, agentID))
 	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "prompts", agentID+".md"), "Handle assigned work.\n")
 	return root
 }

--- a/cmd/swarm/main_test.go
+++ b/cmd/swarm/main_test.go
@@ -6416,6 +6416,95 @@ func TestValidateServeMultiContextToolGatewayAdmission(t *testing.T) {
 	}
 }
 
+func TestRunServeRuntimeDuplicateAgentSlugFailsBeforeReadiness(t *testing.T) {
+	isolateCLIAPIConfigEnv(t)
+	_, _, pg := installServeRuntimePostgresTestStores(t, func() serveWorkspaceLifecycle {
+		return serveRuntimeWorkspaceStub{}
+	})
+	ctx := context.Background()
+	firstRoot := writeServeRuntimeAgentSlugFixture(t, "duplicate-agent-slug-a", "shared-worker")
+	secondRoot := writeServeRuntimeAgentSlugFixture(t, "duplicate-agent-slug-b", "shared-worker")
+	firstHash := seedServeRuntimeBundleCatalogRoot(t, ctx, pg, firstRoot)
+	secondHash := seedServeRuntimeBundleCatalogRoot(t, ctx, pg, secondRoot)
+	if firstHash == secondHash {
+		t.Fatalf("test fixtures produced duplicate bundle hash %s", firstHash)
+	}
+
+	var out lockedBuffer
+	code := runServeRuntime(ctx, repoRoot(), serveOptions{
+		ConfigPath:         writeServeRuntimeTestConfig(t),
+		BundleHash:         firstHash,
+		BundleHashes:       []string{secondHash},
+		PlatformSpecPath:   defaultPlatformSpecPath,
+		StoreMode:          "postgres",
+		APIListenAddr:      "127.0.0.1:0",
+		MCPListenAddr:      "127.0.0.1:0",
+		SelfCheck:          true,
+		RequireBundleMatch: false,
+		Verbose:            true,
+		Output:             &out,
+		TestLLMRuntime:     runtimellm.NoopRuntime{},
+	})
+	if code == 0 {
+		t.Fatalf("runServeRuntime code = 0, want startup failure\noutput:\n%s", out.String())
+	}
+	for _, want := range []string{
+		"[5/22] runtime_context",
+		`duplicate runtime context agent_id "shared-worker"`,
+		firstHash,
+		secondHash,
+		"bundle_source=persisted",
+	} {
+		if !strings.Contains(out.String(), want) {
+			t.Fatalf("serve output missing %q:\n%s", want, out.String())
+		}
+	}
+	for _, notWant := range []string{"[22/22]", "ready                      ok", "manager_event_loop_start", "platform_boot_event_published"} {
+		if strings.Contains(out.String(), notWant) {
+			t.Fatalf("serve reached %q after duplicate agent slug admission failure:\n%s", notWant, out.String())
+		}
+	}
+}
+
+func TestRunServeRuntimeDistinctAgentSlugsBootPinnedContextsReachReadiness(t *testing.T) {
+	isolateCLIAPIConfigEnv(t)
+	_, _, pg := installServeRuntimePostgresTestStores(t, func() serveWorkspaceLifecycle {
+		return serveRuntimeWorkspaceStub{}
+	})
+	ctx := context.Background()
+	firstRoot := writeServeRuntimeAgentSlugFixture(t, "distinct-agent-slug-a", "alpha-worker")
+	secondRoot := writeServeRuntimeAgentSlugFixture(t, "distinct-agent-slug-b", "beta-worker")
+	firstHash := seedServeRuntimeBundleCatalogRoot(t, ctx, pg, firstRoot)
+	secondHash := seedServeRuntimeBundleCatalogRoot(t, ctx, pg, secondRoot)
+	if firstHash == secondHash {
+		t.Fatalf("test fixtures produced duplicate bundle hash %s", firstHash)
+	}
+
+	serve := startServeRuntimeTestProcess(t, serveOptions{
+		ConfigPath:              writeServeRuntimeTestConfig(t),
+		BundleHash:              firstHash,
+		BundleHashes:            []string{secondHash},
+		PlatformSpecPath:        defaultPlatformSpecPath,
+		StoreMode:               "postgres",
+		APIListenAddr:           "127.0.0.1:0",
+		MCPListenAddr:           "127.0.0.1:0",
+		SelfCheck:               true,
+		RequireBundleMatch:      false,
+		Verbose:                 true,
+		TestLLMRuntime:          runtimellm.NoopRuntime{},
+		TestOutboxSweeperConfig: servedEventPublishProofOutboxSweeperConfig(),
+	})
+	serve.waitForReadyLine()
+	if code := serve.stop(); code != 0 {
+		t.Fatalf("runServeRuntime code = %d\noutput:\n%s", code, serve.outputString())
+	}
+	for _, want := range []string{firstHash, secondHash, "[22/22] ready"} {
+		if !strings.Contains(serve.outputString(), want) {
+			t.Fatalf("serve output missing %q:\n%s", want, serve.outputString())
+		}
+	}
+}
+
 func TestRunServeRuntimeMultiContextClaudeCLIFailsClosedBeforePrimaryGatewayOrForkchat(t *testing.T) {
 	isolateCLIAPIConfigEnv(t)
 	t.Setenv("SWARM_TOOL_GATEWAY_URL", "")
@@ -9856,16 +9945,25 @@ func loadWorkflowValidationFixtureBundle(t *testing.T, relativeRoot string) *run
 
 func seedServeRuntimeBundleCatalog(t *testing.T, ctx context.Context, pg *store.PostgresStore, relativeRoot string) string {
 	t.Helper()
+	return seedServeRuntimeBundleCatalogFromBundle(t, ctx, pg, relativeRoot, loadWorkflowValidationFixtureBundle(t, relativeRoot))
+}
+
+func seedServeRuntimeBundleCatalogRoot(t *testing.T, ctx context.Context, pg *store.PostgresStore, root string) string {
+	t.Helper()
+	return seedServeRuntimeBundleCatalogFromBundle(t, ctx, pg, root, loadWorkflowValidationBundleAt(t, root))
+}
+
+func seedServeRuntimeBundleCatalogFromBundle(t *testing.T, ctx context.Context, pg *store.PostgresStore, label string, bundle *runtimecontracts.WorkflowContractBundle) string {
+	t.Helper()
 	if pg == nil {
 		t.Fatal("postgres store is required")
 	}
 	if _, err := pg.BindSchemaCapabilities(ctx); err != nil {
 		t.Fatalf("BindSchemaCapabilities: %v", err)
 	}
-	bundle := loadWorkflowValidationFixtureBundle(t, relativeRoot)
 	projection, err := runtimecontracts.BuildBundleCatalogProjection(bundle)
 	if err != nil {
-		t.Fatalf("BuildBundleCatalogProjection(%s): %v", relativeRoot, err)
+		t.Fatalf("BuildBundleCatalogProjection(%s): %v", label, err)
 	}
 	if _, err := pg.UpsertBundleCatalog(ctx, store.BundleCatalogUpsert{
 		BundleHash:  projection.BundleHash,
@@ -9874,7 +9972,7 @@ func seedServeRuntimeBundleCatalog(t *testing.T, ctx context.Context, pg *store.
 		DataBlob:    projection.DataBlob,
 		Metadata:    projection.Metadata,
 	}); err != nil {
-		t.Fatalf("UpsertBundleCatalog(%s): %v", relativeRoot, err)
+		t.Fatalf("UpsertBundleCatalog(%s): %v", label, err)
 	}
 	return projection.BundleHash
 }
@@ -9898,6 +9996,45 @@ func writeWorkflowValidationFixtureFile(t *testing.T, path, contents string) {
 	if err := os.WriteFile(path, []byte(strings.TrimLeft(contents, "\n")), 0o644); err != nil {
 		t.Fatalf("write %s: %v", path, err)
 	}
+}
+
+func writeServeRuntimeAgentSlugFixture(t *testing.T, workflowName, agentID string) string {
+	t.Helper()
+	root := t.TempDir()
+	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "package.yaml"), fmt.Sprintf(`
+name: %s
+version: "1.0.0"
+platform_version: ">=1.6.0"
+flows: []
+`, workflowName))
+	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "schema.yaml"), `
+initial_state: pending
+terminal_states: [done]
+states: [pending, done]
+pins:
+  inputs:
+    events: [agent.requested]
+`)
+	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "policy.yaml"), "{}\n")
+	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "tools.yaml"), "{}\n")
+	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "events.yaml"), `
+agent.requested:
+  swarm:
+    source: external
+  entity_id: string
+`)
+	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "nodes.yaml"), "{}\n")
+	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "agents.yaml"), fmt.Sprintf(`
+%s:
+  id: %s
+  role: %s
+  prompt_ref: %s
+  model: regular
+  mode: task
+  subscriptions: [agent.requested]
+`, agentID, agentID, agentID, agentID))
+	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "prompts", agentID+".md"), "Handle assigned work.\n")
+	return root
 }
 
 func writeArtifactRepoCommitServeFixture(t *testing.T) string {

--- a/internal/apispec/spec_test.go
+++ b/internal/apispec/spec_test.go
@@ -1019,7 +1019,9 @@ func TestAgentIdentityModelRecordsCurrentSlugConstraint(t *testing.T) {
 	constraint := mustMappingValue(t, identity, "current_multi_bundle_constraint")
 	assertScalarContains(t, mappingValue(constraint, "rule"), "globally unique authored agent_id values")
 	assertScalarContains(t, mappingValue(constraint, "rule"), "Duplicate authored agent slugs across live loaded BundleContexts are unsupported")
-	assertScalarContains(t, mappingValue(constraint, "enforcement_status"), "does not add runtime/store enforcement")
+	assertScalarContains(t, mappingValue(constraint, "enforcement_status"), "RuntimeContextManager admission enforces")
+	assertScalarContains(t, mappingValue(constraint, "enforcement_status"), "fail closed before API readiness")
+	assertScalarContains(t, mappingValue(constraint, "enforcement_status"), "does not add duplicate-slug support")
 
 	migration := mustMappingValue(t, identity, "uuid_internal_migration_target")
 	assertScalarValue(t, mappingValue(migration, "tracker"), "#977")

--- a/internal/runtime/conformance/testdata/multi_bundle_option_a_matrix.yaml
+++ b/internal/runtime/conformance/testdata/multi_bundle_option_a_matrix.yaml
@@ -311,13 +311,16 @@ rows:
 
   - id: duplicate_agent_slug_posture
     category: identity
-    concept: duplicate authored agent slugs across live bundles are unsupported under current global slug posture.
+    concept: duplicate authored agent slugs across live bundles are unsupported under current global slug posture, and boot-pinned RuntimeContextManager admission fails closed for that unsupported shape.
     classification: not_current_option_a
     owner_refs:
       - {kind: spec_ref, path: platform-spec.yaml, ref: agent_identity_model}
     proof_refs:
       - {kind: issue, issue: 977}
+      - {kind: issue, issue: 1531}
       - {kind: pr, pr: 1243}
+      - {kind: go_test, name: TestRuntimeContextManagerRejectsDuplicateAgentSlugs}
+      - {kind: go_test, name: TestRunServeRuntimeDuplicateAgentSlugFailsBeforeReadiness}
       - {kind: spec_ref, path: platform-spec.yaml, ref: current_global_slug_constraint}
 
   - id: provider_native_llm_exclusion

--- a/internal/runtime/context_manager.go
+++ b/internal/runtime/context_manager.go
@@ -59,6 +59,12 @@ type runtimeContextEntry struct {
 	cause   string
 }
 
+type runtimeContextAgentSlugCollision struct {
+	agentID  string
+	existing BundleContext
+	incoming BundleContext
+}
+
 type RuntimeContextLookup struct {
 	Context *BundleContext
 	State   RuntimeContextState
@@ -132,6 +138,14 @@ func (m *RuntimeContextManager) Register(contextDef BundleContext) error {
 	if _, exists := m.contexts[contextDef.BundleHash]; exists {
 		return fmt.Errorf("duplicate runtime context bundle_hash %s", contextDef.BundleHash)
 	}
+	if collision, ok := m.duplicateLoadedAgentSlugLocked(contextDef); ok {
+		return fmt.Errorf(
+			"duplicate runtime context agent_id %q across loaded BundleContexts: existing %s; incoming %s",
+			collision.agentID,
+			runtimeContextBundleLabel(collision.existing),
+			runtimeContextBundleLabel(collision.incoming),
+		)
+	}
 	copied := contextDef
 	m.contexts[contextDef.BundleHash] = &runtimeContextEntry{
 		context: &copied,
@@ -140,6 +154,88 @@ func (m *RuntimeContextManager) Register(contextDef BundleContext) error {
 	m.order = append(m.order, contextDef.BundleHash)
 	sort.Strings(m.order)
 	return nil
+}
+
+func (m *RuntimeContextManager) duplicateLoadedAgentSlugLocked(incoming BundleContext) (runtimeContextAgentSlugCollision, bool) {
+	incomingIDs := runtimeContextAgentIDs(incoming.Source)
+	if len(incomingIDs) == 0 {
+		return runtimeContextAgentSlugCollision{}, false
+	}
+	incomingSet := make(map[string]struct{}, len(incomingIDs))
+	for _, agentID := range incomingIDs {
+		incomingSet[agentID] = struct{}{}
+	}
+	for _, bundleHash := range m.order {
+		entry := m.contexts[bundleHash]
+		if !runtimeContextEntryLoaded(entry) {
+			continue
+		}
+		for _, existingAgentID := range runtimeContextAgentIDs(entry.context.Source) {
+			if _, ok := incomingSet[existingAgentID]; !ok {
+				continue
+			}
+			return runtimeContextAgentSlugCollision{
+				agentID:  existingAgentID,
+				existing: *entry.context,
+				incoming: incoming,
+			}, true
+		}
+	}
+	return runtimeContextAgentSlugCollision{}, false
+}
+
+func runtimeContextEntryLoaded(entry *runtimeContextEntry) bool {
+	if entry == nil || entry.context == nil {
+		return false
+	}
+	state := entry.state
+	if state == "" {
+		state = RuntimeContextStateLoaded
+	}
+	return state == RuntimeContextStateLoaded
+}
+
+func runtimeContextAgentIDs(source semanticview.Source) []string {
+	if source == nil {
+		return nil
+	}
+	entries := source.AgentEntries()
+	ids := make([]string, 0, len(entries))
+	for agentID := range entries {
+		agentID = strings.TrimSpace(agentID)
+		if agentID == "" {
+			continue
+		}
+		ids = append(ids, agentID)
+	}
+	sort.Strings(ids)
+	return ids
+}
+
+func runtimeContextBundleLabel(contextDef BundleContext) string {
+	contextDef = contextDef.normalized()
+	parts := []string{}
+	if contextDef.BundleHash != "" {
+		parts = append(parts, "bundle_hash="+contextDef.BundleHash)
+	}
+	if source := strings.TrimSpace(contextDef.BundleSourceFact.BundleSource); source != "" {
+		parts = append(parts, "bundle_source="+source)
+	}
+	if fingerprint := strings.TrimSpace(contextDef.BundleSourceFact.BundleFingerprint); fingerprint != "" {
+		parts = append(parts, "bundle_fingerprint="+fingerprint)
+	}
+	workflowName := strings.TrimSpace(contextDef.BundleIdentity.WorkflowName)
+	workflowVersion := strings.TrimSpace(contextDef.BundleIdentity.WorkflowVersion)
+	switch {
+	case workflowName != "" && workflowVersion != "":
+		parts = append(parts, "workflow="+workflowName+"@"+workflowVersion)
+	case workflowName != "":
+		parts = append(parts, "workflow="+workflowName)
+	}
+	if len(parts) == 0 {
+		return "bundle_context=<unknown>"
+	}
+	return strings.Join(parts, " ")
 }
 
 func (m *RuntimeContextManager) Len() int {

--- a/internal/runtime/context_manager.go
+++ b/internal/runtime/context_manager.go
@@ -201,8 +201,11 @@ func runtimeContextAgentIDs(source semanticview.Source) []string {
 	}
 	entries := source.AgentEntries()
 	ids := make([]string, 0, len(entries))
-	for agentID := range entries {
-		agentID = strings.TrimSpace(agentID)
+	for key, entry := range entries {
+		agentID := strings.TrimSpace(entry.ID)
+		if agentID == "" {
+			agentID = strings.TrimSpace(key)
+		}
 		if agentID == "" {
 			continue
 		}

--- a/internal/runtime/context_manager_test.go
+++ b/internal/runtime/context_manager_test.go
@@ -90,6 +90,29 @@ func TestRuntimeContextManagerRejectsDuplicateAgentSlugs(t *testing.T) {
 	}
 }
 
+func TestRuntimeContextManagerRejectsDuplicateEffectiveAgentIDs(t *testing.T) {
+	_, err := NewRuntimeContextManager(nil,
+		testBundleContextWithAgentEntries(t, runtimeContextTestHashA, "alpha.requested", map[string]runtimecontracts.AgentRegistryEntry{
+			"alpha": {ID: "shared-worker", Role: "alpha"},
+		}),
+		testBundleContextWithAgentEntries(t, runtimeContextTestHashB, "beta.requested", map[string]runtimecontracts.AgentRegistryEntry{
+			"beta": {ID: "shared-worker", Role: "beta"},
+		}),
+	)
+	if err == nil {
+		t.Fatal("NewRuntimeContextManager duplicate effective agent_id error = nil")
+	}
+	for _, want := range []string{
+		`duplicate runtime context agent_id "shared-worker"`,
+		runtimeContextTestHashA,
+		runtimeContextTestHashB,
+	} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("duplicate effective agent_id error missing %q:\n%s", want, err.Error())
+		}
+	}
+}
+
 func TestRuntimeContextManagerRegisterRejectsDuplicateAgentSlugWithoutMutatingManager(t *testing.T) {
 	manager, err := NewRuntimeContextManager(nil,
 		testBundleContextWithAgents(t, runtimeContextTestHashA, "alpha.requested", "shared-worker"),
@@ -205,6 +228,11 @@ func testBundleContextWithAgents(t *testing.T, bundleHash, eventName string, age
 		}
 		agents[agentID] = runtimecontracts.AgentRegistryEntry{ID: agentID, Role: agentID}
 	}
+	return testBundleContextWithAgentEntries(t, bundleHash, eventName, agents)
+}
+
+func testBundleContextWithAgentEntries(t *testing.T, bundleHash, eventName string, agents map[string]runtimecontracts.AgentRegistryEntry) BundleContext {
+	t.Helper()
 	bundle := &runtimecontracts.WorkflowContractBundle{
 		Semantics: runtimecontracts.WorkflowSemanticView{Name: "review", Version: "1.0.0"},
 		Events: map[string]runtimecontracts.EventCatalogEntry{

--- a/internal/runtime/context_manager_test.go
+++ b/internal/runtime/context_manager_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"reflect"
+	"strings"
 	"testing"
 
 	runtimebus "github.com/division-sh/swarm/internal/runtime/bus"
@@ -68,6 +69,71 @@ func TestRuntimeContextManagerRejectsDuplicateBundleHashes(t *testing.T) {
 	}
 }
 
+func TestRuntimeContextManagerRejectsDuplicateAgentSlugs(t *testing.T) {
+	_, err := NewRuntimeContextManager(nil,
+		testBundleContextWithAgents(t, runtimeContextTestHashA, "alpha.requested", "shared-worker"),
+		testBundleContextWithAgents(t, runtimeContextTestHashB, "beta.requested", "shared-worker"),
+	)
+	if err == nil {
+		t.Fatal("NewRuntimeContextManager duplicate agent slug error = nil")
+	}
+	for _, want := range []string{
+		`duplicate runtime context agent_id "shared-worker"`,
+		runtimeContextTestHashA,
+		runtimeContextTestHashB,
+		"bundle_source=persisted",
+		"workflow=review@1.0.0",
+	} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("duplicate agent slug error missing %q:\n%s", want, err.Error())
+		}
+	}
+}
+
+func TestRuntimeContextManagerRegisterRejectsDuplicateAgentSlugWithoutMutatingManager(t *testing.T) {
+	manager, err := NewRuntimeContextManager(nil,
+		testBundleContextWithAgents(t, runtimeContextTestHashA, "alpha.requested", "shared-worker"),
+	)
+	if err != nil {
+		t.Fatalf("NewRuntimeContextManager: %v", err)
+	}
+	err = manager.Register(testBundleContextWithAgents(t, runtimeContextTestHashB, "beta.requested", "shared-worker"))
+	if err == nil {
+		t.Fatal("Register duplicate agent slug error = nil")
+	}
+	for _, want := range []string{
+		`duplicate runtime context agent_id "shared-worker"`,
+		runtimeContextTestHashA,
+		runtimeContextTestHashB,
+	} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("Register duplicate agent slug error missing %q:\n%s", want, err.Error())
+		}
+	}
+	if manager.Len() != 1 || manager.MultiContext() {
+		t.Fatalf("manager Len/MultiContext after rejected register = %d/%v, want 1/false", manager.Len(), manager.MultiContext())
+	}
+	if got, want := manager.BundleHashes(), []string{runtimeContextTestHashA}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("BundleHashes after rejected register = %#v, want %#v", got, want)
+	}
+	if _, ok := manager.LookupBundleHash(runtimeContextTestHashB); ok {
+		t.Fatal("LookupBundleHash found rejected duplicate context")
+	}
+}
+
+func TestRuntimeContextManagerAllowsDistinctAgentSlugs(t *testing.T) {
+	manager, err := NewRuntimeContextManager(nil,
+		testBundleContextWithAgents(t, runtimeContextTestHashA, "alpha.requested", "alpha-worker"),
+		testBundleContextWithAgents(t, runtimeContextTestHashB, "beta.requested", "beta-worker"),
+	)
+	if err != nil {
+		t.Fatalf("NewRuntimeContextManager distinct agent slugs: %v", err)
+	}
+	if manager.Len() != 2 || !manager.MultiContext() {
+		t.Fatalf("manager Len/MultiContext = %d/%v, want 2/true", manager.Len(), manager.MultiContext())
+	}
+}
+
 func TestRuntimeContextManagerDeactivatesPinnedContextFailClosed(t *testing.T) {
 	availability := fakeRunBundleAvailability{
 		rows: map[string]runbundle.Availability{
@@ -126,11 +192,25 @@ func TestRuntimeContextManagerDeactivatesPinnedContextFailClosed(t *testing.T) {
 
 func testBundleContext(t *testing.T, bundleHash, eventName string) BundleContext {
 	t.Helper()
+	return testBundleContextWithAgents(t, bundleHash, eventName)
+}
+
+func testBundleContextWithAgents(t *testing.T, bundleHash, eventName string, agentIDs ...string) BundleContext {
+	t.Helper()
+	agents := map[string]runtimecontracts.AgentRegistryEntry{}
+	for _, agentID := range agentIDs {
+		agentID = strings.TrimSpace(agentID)
+		if agentID == "" {
+			continue
+		}
+		agents[agentID] = runtimecontracts.AgentRegistryEntry{ID: agentID, Role: agentID}
+	}
 	bundle := &runtimecontracts.WorkflowContractBundle{
 		Semantics: runtimecontracts.WorkflowSemanticView{Name: "review", Version: "1.0.0"},
 		Events: map[string]runtimecontracts.EventCatalogEntry{
 			eventName: {},
 		},
+		Agents: agents,
 	}
 	source := semanticview.Wrap(bundle)
 	bus, err := runtimebus.NewEventBusWithOptions(nil, runtimebus.EventBusOptions{

--- a/internal/runtime/contracts/workflow_contract_wave1_test.go
+++ b/internal/runtime/contracts/workflow_contract_wave1_test.go
@@ -106,6 +106,34 @@ vertical.shortlisted:
 	}
 }
 
+func TestMergeAgentContractsRejectsDuplicateScopedAgentID(t *testing.T) {
+	bundle := &WorkflowContractBundle{
+		Agents:                map[string]AgentRegistryEntry{},
+		agentSources:          map[string]ContractItemSource{},
+		scopedAgents:          map[string]AgentRegistryEntry{},
+		scopedAgentSources:    map[string]ContractItemSource{},
+		ambiguousAgentAliases: map[string]struct{}{},
+	}
+	sourceA := ContractItemSource{FlowID: "review", Layer: "flow", File: "flows/review/agents.yaml"}
+	sourceB := ContractItemSource{FlowID: "review", Layer: "flow", File: "flows/review/agents-extra.yaml"}
+	if err := mergeAgentContracts(bundle, map[string]AgentRegistryEntry{
+		"worker": {ID: "worker", Role: "reviewer"},
+	}, sourceA); err != nil {
+		t.Fatalf("mergeAgentContracts initial: %v", err)
+	}
+	err := mergeAgentContracts(bundle, map[string]AgentRegistryEntry{
+		"worker": {ID: "worker", Role: "alternate"},
+	}, sourceB)
+	if err == nil {
+		t.Fatal("mergeAgentContracts duplicate scoped agent error = nil")
+	}
+	for _, want := range []string{`duplicate scoped agent id "review::worker"`, sourceA.File, sourceB.File} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("duplicate scoped agent error missing %q:\n%s", want, err.Error())
+		}
+	}
+}
+
 func TestWorkflowContractBundleResolveFlowTemplateInstance_PreservesOrderedCompositeKey(t *testing.T) {
 	bundle := &WorkflowContractBundle{
 		FlowSchemas: map[string]FlowSchemaDocument{

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -8154,9 +8154,11 @@ agent_identity_model:
       use globally unique authored agent_id values. Duplicate authored agent slugs across live loaded BundleContexts are
       unsupported and must not be advertised as bundle-scoped or UUID-disambiguated behavior.
     enforcement_status: >
-      This source-authority slice documents the supported contract only. It does not add runtime/store enforcement.
-      A future loader/admission/serve child that can detect duplicate live agent slugs before API readiness must fail
-      closed or receive its own gate; absent such proof, operators must avoid duplicate live slugs.
+      RuntimeContextManager admission enforces this current-model live constraint for registered loaded BundleContexts:
+      duplicate authored agent slugs fail closed before API readiness and report the duplicate slug plus conflicting
+      bundle hashes/source labels when available. This enforcement does not add duplicate-slug support, UUID identity,
+      bundle-scoped public lookup, store schema migration, API/CLI disambiguation, slug prefixing, or compatibility
+      remapping; #977 remains the parent for those behaviors.
     final_matrix_dependency: >
       #1025 must treat duplicate agent slugs across live bundles as unsupported unless a later #977 implementation child
       promotes UUID-internal identity and proves bundle-scoped lookup across all affected surfaces.
@@ -8455,6 +8457,7 @@ multi_bundle_persistence:
         - The runtime loader consumes stored bundles.content_yaml and raw bundles.data_blob bytes only; parsed_json is inspection output and is never a runtime source.
         - The loader reconstructs platform spec, contract definition files, prompts, and flow data/ raw bytes into a process-owned temporary source, then recomputes BundleHash and requires it to equal the requested bundle_hash before runtime construction.
         - Each pinned bundle is registered as a BundleContext under RuntimeContextManager. The BundleContext owns its source, BundleSourceFact, EventBus, route table, pipeline/coordinator, agent manager, subscriptions, source-bound runtime components, and manager-owned lifecycle state.
+        - Under agent_identity_model.current_supported_posture, RuntimeContextManager admission rejects duplicate authored agent_id slugs across registered loaded BundleContexts before API readiness; the unsupported shape must name the duplicate slug and conflicting bundle hashes/source labels rather than prefix, alias, remap, or otherwise disambiguate the slug.
         - event.publish and run.start select a loaded BundleContext by explicit canonical bundle_hash for create-new work or by runs.bundle_hash/runs.bundle_source for existing-run work. Missing, deleted, legacy, or unloaded contexts fail closed rather than falling back to ambient boot state.
         - RuntimeContextManager lifecycle state is fail-closed and monotonic in this slice: once a loaded persisted BundleContext is marked unavailable/unloaded by an authoritative bundle-unavailability operation, supported admission paths must reject that context with BUNDLE_UNAVAILABLE unless a later separately-approved Load/repair owner exists.
         - Successful bundle.delete, force bundle.delete partial failure after force-controlled cleanup begins, and successful or partial runtime.nuke with include_bundles=true consume RuntimeContextManager deactivation for loaded matching contexts. runtime.nuke include_bundles=false must not deactivate bundle contexts.


### PR DESCRIPTION
Closes #1531

## Summary

- Enforce the current global live runtime `agent_id` constraint in `RuntimeContextManager.Register` / `NewRuntimeContextManager`.
- Reject duplicate effective agent IDs across registered loaded `BundleContext`s, using `AgentRegistryEntry.ID` when present and the authored map key as fallback, with an error naming the duplicate ID and both conflicting bundle hashes/source labels.
- Add supported `swarm serve --bundle-hash ... --bundle-hash ...` proof for duplicate failure before readiness and distinct-ID positive boot.
- Update `platform-spec.yaml`, API spec assertions, and the multi-bundle conformance matrix proof refs for the new fail-closed enforcement status.

## Governing Refs / Context

Exact spec refs treated as binding:

- `platform-spec.yaml#contract_formats.loader_defaults.agent_id`
- `platform-spec.yaml#agent_identity_model.current_supported_posture`
- `platform-spec.yaml#agent_identity_model.current_multi_bundle_constraint`
- `platform-spec.yaml#agent_identity_model.consumer_disposition`
- `platform-spec.yaml#multi_bundle_persistence.agent_identity_boundary`
- `platform-spec.yaml#multi_bundle_persistence.serve_db_loaded_runtime_source`
- `platform-spec.yaml#api_specification.agent_identity_boundary`
- `platform-spec.yaml#cli_specification.agent_identity_boundary`
- `internal/runtime/conformance/testdata/multi_bundle_option_a_matrix.yaml#duplicate_agent_slug_posture`

Binding issue/gate context:

- #1531 issue body
- Pre-Implementation Coverage Audit on #1531
- Gate C outcome on #1531: `approved as first slice`
- Parent tracker #977 remains open for UUID-internal/display-alias identity and duplicate-display-slug support.

## Semantic Migration

- New code canonical owner: `internal/runtime.RuntimeContextManager.Register` / `NewRuntimeContextManager`, consuming loaded semantic source truth through effective `BundleContext.Source.AgentEntries()` runtime IDs.
- Merge-bearing semantic owner: `platform-spec.yaml#agent_identity_model`.
- Old invalid path: relying on operator discipline, store primary-key conflicts, URI scoping, bundle hash context, slug prefixing/mangling, aliases, or UUID/remap behavior to disambiguate duplicate live runtime `agent_id` values.
- Production paths checked for surviving old behavior: `cmd/swarm.serveRuntimeContextManager`, DB-loaded `swarm serve --bundle-hash` boot, `RuntimeContextManager.Register`, duplicate bundle-hash validation, and the single-tree contract merger duplicate/scoped-agent guard.
- Migration complete for chosen class: yes, for duplicate effective agent IDs across registered loaded boot-pinned runtime contexts. The broader #977 parent remains open.

## Proof

Focused proof:

- `go test ./internal/runtime -run 'TestRuntimeContextManager'`
- `go test ./internal/apispec -run 'TestAgentIdentityModelRecordsCurrentSlugConstraint'`
- `go test ./internal/runtime/conformance -run 'TestMultiBundleOptionAMatrix'`
- `go test ./cmd/swarm -run 'TestCLI_ServeBundleHashValidationAndSerialScope|TestRunServeRuntimeDuplicateAgentSlugFailsBeforeReadiness|TestRunServeRuntimeDistinctAgentSlugsBootPinnedContextsReachReadiness' -count=1`
- `go test ./internal/runtime/contracts -run 'TestMergeAgentContractsRejectsDuplicateScopedAgentID'`

Review-fix proof after `372074d3`:

- `go test ./internal/runtime -run 'TestRuntimeContextManager'`
- `go test ./cmd/swarm -run 'TestRunServeRuntimeDuplicateAgentSlugFailsBeforeReadiness|TestRunServeRuntimeDistinctAgentSlugsBootPinnedContextsReachReadiness' -count=1`

Full suite:

- `go test ./...`