### PR TITLE
[agent-a][issue #1605] Route fan-out emits through pin authority

### DIFF
--- a/internal/runtime/bootverify/report_test.go
+++ b/internal/runtime/bootverify/report_test.go
@@ -2972,7 +2972,6 @@ func TestRun_AcceptsYAMLScalarFanOutEmitItemExpressions(t *testing.T) {
 	if err := yaml.Unmarshal([]byte(`
 fan_out:
   items_from: payload.industries
-  target: market-research-agent
   emit:
     event: market_research.industry_assigned
     fields:

--- a/internal/runtime/bootverify/report_test.go
+++ b/internal/runtime/bootverify/report_test.go
@@ -2887,6 +2887,32 @@ func TestRun_RejectsAccumulatedNamespaceInDataAccumulationExpressions(t *testing
 	}
 }
 
+func TestRun_RejectsRetiredFanOutTargetInDataAccumulationExpressions(t *testing.T) {
+	source := semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
+		Nodes: map[string]runtimecontracts.SystemNodeContract{
+			"test-node": {
+				ID: "test-node",
+				EventHandlers: map[string]runtimecontracts.SystemNodeEventHandler{
+					"item.received": {
+						DataAccumulation: runtimecontracts.WorkflowDataAccumulation{
+							Writes: []runtimecontracts.WorkflowDataWrite{
+								{TargetField: "last_target", Value: runtimecontracts.CELExpression("fan_out.target")},
+							},
+						},
+					},
+				},
+			},
+		},
+	})
+
+	report := Run(context.Background(), source, Options{})
+
+	if !reportContains(report.Errors(), "data_accumulation_expression_validation", "fan_out.target") ||
+		!reportContains(report.Errors(), "data_accumulation_expression_validation", "retired") {
+		t.Fatalf("expected retired fan_out.target in data_accumulation expression to fail validation, got %#v", report.Errors())
+	}
+}
+
 func TestRun_RejectsAccumulatedNamespaceInEmitFieldExpressions(t *testing.T) {
 	source := semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
 		Nodes: map[string]runtimecontracts.SystemNodeContract{
@@ -2910,6 +2936,36 @@ func TestRun_RejectsAccumulatedNamespaceInEmitFieldExpressions(t *testing.T) {
 
 	if !reportContains(report.Errors(), "emit_field_expression_validation", "accumulated.size()") {
 		t.Fatalf("expected accumulated namespace in emit.fields expression to fail validation, got %#v", report.Errors())
+	}
+}
+
+func TestRun_RejectsRetiredFanOutTargetInFanOutEmitFieldExpressions(t *testing.T) {
+	source := semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
+		Nodes: map[string]runtimecontracts.SystemNodeContract{
+			"test-node": {
+				ID: "test-node",
+				EventHandlers: map[string]runtimecontracts.SystemNodeEventHandler{
+					"item.received": {
+						FanOut: &runtimecontracts.FanOutSpec{
+							ItemsFrom: "payload.items",
+							Emit: runtimecontracts.EmitSpec{
+								Event: "item.scored",
+								Fields: map[string]runtimecontracts.ExpressionValue{
+									"bad": runtimecontracts.CELExpression(`fan_out["target"]`),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	})
+
+	report := Run(context.Background(), source, Options{})
+
+	if !reportContains(report.Errors(), "emit_field_expression_validation", "fan_out.target") ||
+		!reportContains(report.Errors(), "emit_field_expression_validation", "retired") {
+		t.Fatalf("expected retired fan_out.target in fan_out.emit.fields to fail validation, got %#v", report.Errors())
 	}
 }
 

--- a/internal/runtime/bootverify/workflow_pin_routing_checks_test.go
+++ b/internal/runtime/bootverify/workflow_pin_routing_checks_test.go
@@ -9,6 +9,7 @@ import (
 
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
 	"github.com/division-sh/swarm/internal/runtime/semanticview"
+	"github.com/division-sh/swarm/internal/runtime/testfixtures/fanoutpinroute"
 )
 
 func TestPinTargetResolution_FailsClosedForPinOutputWithoutTargetMechanism(t *testing.T) {
@@ -57,6 +58,78 @@ func TestPinTargetResolution_FailsClosedForProducerBroadcastCommonCompositionPat
 	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
 	if !reportContains(report.Errors(), "pin_target_resolution", "producer_broadcast_common_path_forbidden") {
 		t.Fatalf("expected producer_broadcast_common_path_forbidden, got %#v", report.Errors())
+	}
+}
+
+func TestPinTargetResolution_AllowsTargetlessFanOutEmitThroughParentConnect(t *testing.T) {
+	source := fanoutpinroute.LoadSource(t, fanoutpinroute.Options{})
+	report := Run(context.Background(), source, Options{})
+	if reportContains(report.Errors(), "pin_target_resolution", "") ||
+		reportContains(report.Errors(), "composition_connect_validation", "") ||
+		reportContains(report.Errors(), "output_pin_key_carries_validation", "") {
+		t.Fatalf("targetless fan_out.emit should verify through parent connect authority, got %#v", report.Errors())
+	}
+}
+
+func TestPinTargetResolution_FanOutEmitFailsClosedWithoutRouteAuthority(t *testing.T) {
+	source := fanoutpinroute.LoadSource(t, fanoutpinroute.Options{OmitConnect: true})
+	report := Run(context.Background(), source, Options{})
+	if !reportContains(report.Errors(), "pin_target_resolution", "handler.fan_out.emit") ||
+		!reportContains(report.Errors(), "pin_target_resolution", "target_required_missing") {
+		t.Fatalf("expected targetless fan_out.emit target_required_missing, got %#v", report.Errors())
+	}
+}
+
+func TestPinTargetResolution_FanOutEmitFailsClosedWithoutOutputPin(t *testing.T) {
+	source := fanoutpinroute.LoadSource(t, fanoutpinroute.Options{OmitOutputPin: true})
+	report := Run(context.Background(), source, Options{})
+	if !reportContains(report.Errors(), "composition_connect_validation", "producer_output_pin_missing") {
+		t.Fatalf("expected missing output pin to fail connect validation, got %#v", report.Errors())
+	}
+}
+
+func TestPinTargetResolution_FanOutEmitFailsClosedForMissingConnectKeyMaterial(t *testing.T) {
+	source := fanoutpinroute.LoadSource(t, fanoutpinroute.Options{BadConnectMapping: true})
+	report := Run(context.Background(), source, Options{})
+	if !reportContains(report.Errors(), "composition_connect_validation", "connect_key_adapter_source_missing") {
+		t.Fatalf("expected bad connect key adapter to fail closed, got %#v", report.Errors())
+	}
+}
+
+func TestPinTargetResolution_FanOutEmitFailsClosedForMissingCarriesPayload(t *testing.T) {
+	source := fanoutpinroute.LoadSource(t, fanoutpinroute.Options{MissingEmitCarry: true})
+	report := Run(context.Background(), source, Options{})
+	if !reportContains(report.Errors(), "output_pin_key_carries_validation", "emit_payload_missing_key") ||
+		!reportContains(report.Errors(), "output_pin_key_carries_validation", "handler.fan_out.emit") {
+		t.Fatalf("expected fan_out.emit missing carried fields to fail closed, got %#v", report.Errors())
+	}
+}
+
+func TestPinTargetResolution_FanOutEmitRejectsProducerTargetAndBroadcastCommonPath(t *testing.T) {
+	tests := []struct {
+		name string
+		opts fanoutpinroute.Options
+		want string
+	}{
+		{
+			name: "producer target",
+			opts: fanoutpinroute.Options{ProducerTarget: true},
+			want: "producer_target_common_path_forbidden",
+		},
+		{
+			name: "producer broadcast",
+			opts: fanoutpinroute.Options{ProducerBroadcast: true},
+			want: "producer_broadcast_common_path_forbidden",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			source := fanoutpinroute.LoadSource(t, tc.opts)
+			report := Run(context.Background(), source, Options{})
+			if !reportContains(report.Errors(), "pin_target_resolution", tc.want) {
+				t.Fatalf("expected %s, got %#v", tc.want, report.Errors())
+			}
+		})
 	}
 }
 

--- a/internal/runtime/conformance/template_flow_pilot_conformance_test.go
+++ b/internal/runtime/conformance/template_flow_pilot_conformance_test.go
@@ -2,12 +2,22 @@ package conformance
 
 import (
 	"context"
+	"encoding/json"
 	"strings"
 	"testing"
+	"time"
 
+	"github.com/division-sh/swarm/internal/events"
+	"github.com/division-sh/swarm/internal/events/eventtest"
 	runtimebootverify "github.com/division-sh/swarm/internal/runtime/bootverify"
+	runtimebus "github.com/division-sh/swarm/internal/runtime/bus"
+	runtimeflowidentity "github.com/division-sh/swarm/internal/runtime/core/flowidentity"
+	runtimeidentity "github.com/division-sh/swarm/internal/runtime/core/identity"
 	runtimepinrouting "github.com/division-sh/swarm/internal/runtime/core/pinrouting"
+	runtimeengine "github.com/division-sh/swarm/internal/runtime/engine"
+	runtimepipeline "github.com/division-sh/swarm/internal/runtime/pipeline"
 	"github.com/division-sh/swarm/internal/runtime/semanticview"
+	"github.com/division-sh/swarm/internal/runtime/testfixtures/fanoutpinroute"
 	"github.com/division-sh/swarm/internal/runtime/testfixtures/templateflowpilot"
 )
 
@@ -114,12 +124,297 @@ func TestTemplateFlowPilotConformance_FailClosedMatrix(t *testing.T) {
 	}
 }
 
+func TestFanOutPinRouteConformance_CoversTargetlessFanOutEmitRouteAuthority(t *testing.T) {
+	source := fanoutpinroute.LoadSource(t, fanoutpinroute.Options{})
+	report := runtimebootverify.Run(context.Background(), source, runtimebootverify.Options{})
+	if got := report.HardInvalidities(); len(got) != 0 {
+		t.Fatalf("fanout pin-route hard invalidities = %#v, want none", got)
+	}
+
+	plans, issues := runtimepinrouting.LowerCompositionConnectRoutePlans(source)
+	if len(issues) != 0 {
+		t.Fatalf("LowerCompositionConnectRoutePlans issues = %#v, want none", issues)
+	}
+	if len(plans) != 1 {
+		t.Fatalf("LowerCompositionConnectRoutePlans = %#v, want one instance-key plan", plans)
+	}
+	plan := plans[0]
+	if plan.Source.FlowID != "coordinator" || plan.Source.Pin != "account_classified" || plan.Source.Key != "account_id" {
+		t.Fatalf("route plan source = %#v, want coordinator.account_classified keyed by account_id", plan.Source)
+	}
+	if plan.Receiver.FlowID != "account" || plan.Receiver.Pin != "account_classified" || plan.Receiver.Mode != "template" {
+		t.Fatalf("route plan receiver = %#v, want account.account_classified template", plan.Receiver)
+	}
+	if plan.InstanceKey == nil || strings.Join(plan.InstanceKey.Fields, ",") != "account_id" {
+		t.Fatalf("route plan instance key = %#v, want account_id", plan.InstanceKey)
+	}
+
+	handler, ok := source.NodeEventHandler("classifier-coordinator", "batch.classify.completed")
+	if !ok {
+		t.Fatal("classifier-coordinator batch.classify.completed handler missing")
+	}
+	exec, err := runtimeengine.NewExecutor(runtimeengine.RuntimeDependencies{
+		Source:     source,
+		StateRepo:  fanOutPinRouteStateRepo{},
+		TxRunner:   fanOutPinRouteTxRunner{},
+		Locker:     fanOutPinRouteLocker{},
+		Outbox:     fanOutPinRouteOutbox{},
+		Dispatcher: fanOutPinRouteDispatcher{},
+	}, nil)
+	if err != nil {
+		t.Fatalf("NewExecutor: %v", err)
+	}
+	parent := eventtest.RootIngress(
+		"evt-fanout-pin-route-parent",
+		events.EventType("coordinator/batch.classify.completed"),
+		"",
+		"",
+		json.RawMessage(`{"coordinator_id":"singleton","results":[{"account_id":"acct-a","bucket":"priority","score":91},{"account_id":"acct-b","bucket":"nurture","score":72}]}`),
+		0,
+		"run-fanout-pin-route",
+		"",
+		events.EnvelopeForSourceRoute(events.EventEnvelope{}, events.RouteIdentity{
+			FlowID:       "coordinator",
+			FlowInstance: "coordinator",
+			EntityID:     "coordinator",
+		}),
+		time.Now().UTC(),
+	)
+	result, err := exec.Execute(context.Background(), runtimeengine.ExecutionRequest{
+		EntityID: "coordinator",
+		NodeID:   "classifier-coordinator",
+		FlowID:   "coordinator",
+		Event:    parent,
+		Handler:  handler,
+		State: runtimeengine.StateSnapshot{
+			EntityID:     "coordinator",
+			CurrentState: "active",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Execute fan_out: %v", err)
+	}
+	if result.Status != runtimeengine.OutcomeFannedOut || result.FanOutCount != 2 || len(result.EmitIntents) != 2 {
+		t.Fatalf("fan_out result = status:%s count:%d intents:%d", result.Status, result.FanOutCount, len(result.EmitIntents))
+	}
+
+	store := &fanOutPinRouteMemoryStore{
+		flowInstances: []runtimebus.ActiveFlowInstanceDescriptor{
+			{InstanceID: "acct-a", EntityID: "ent-a", FlowInstance: "account/acct-a", FlowTemplate: "account", AddressFields: map[string]string{"entity.account_id": "acct-a"}},
+			{InstanceID: "acct-b", EntityID: "ent-b", FlowInstance: "account/acct-b", FlowTemplate: "account", AddressFields: map[string]string{"entity.account_id": "acct-b"}},
+		},
+	}
+	eb, err := runtimebus.NewEventBusWithOptions(store, runtimebus.EventBusOptions{
+		ContractBundle: source,
+		TemplateInstanceActivator: func(context.Context, runtimepipeline.FlowInstanceActivationRequest) error {
+			t.Fatal("existing account route descriptors should satisfy fan-out delivery")
+			return nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewEventBusWithOptions: %v", err)
+	}
+	for _, instanceID := range []string{"acct-a", "acct-b"} {
+		if err := eb.AddFlowInstanceRoute(runtimebus.FlowInstanceRouteMaterializationRequest{
+			Identity: runtimeflowidentity.StoredRoute("account", instanceID, "account/"+instanceID),
+		}); err != nil {
+			t.Fatalf("AddFlowInstanceRoute(%s): %v", instanceID, err)
+		}
+	}
+
+	want := map[string]events.RouteIdentity{
+		"acct-a": {FlowID: "account", FlowInstance: "account/acct-a", EntityID: "ent-a"},
+		"acct-b": {FlowID: "account", FlowInstance: "account/acct-b", EntityID: "ent-b"},
+	}
+	for idx, intent := range result.EmitIntents {
+		evt := eventtest.Child(
+			"evt-fanout-pin-route-child-"+string(rune('a'+idx)),
+			intent.Event.Type(),
+			intent.Event.SourceAgent(),
+			intent.Event.TaskID(),
+			intent.Event.Payload(),
+			intent.Event.ChainDepth(),
+			parent,
+			intent.Event.Envelope(),
+			intent.Event.CreatedAt(),
+		)
+		if got, wantType := string(evt.Type()), "coordinator/account.classified"; got != wantType {
+			t.Fatalf("fan_out emitted event type = %q, want %q", got, wantType)
+		}
+		if target := evt.TargetRoute(); !target.Empty() {
+			t.Fatalf("engine fan_out emit pre-populated target = %#v, want EventBus RoutePlan ownership", target)
+		}
+		payload := map[string]any{}
+		if err := json.Unmarshal(evt.Payload(), &payload); err != nil {
+			t.Fatalf("fan_out payload json: %v", err)
+		}
+		accountID, _ := payload["account_id"].(string)
+		expected, ok := want[accountID]
+		if !ok {
+			t.Fatalf("unexpected account_id in fan_out payload: %#v", payload)
+		}
+		preflight, err := eb.CheckPublishRecipientPlan(context.Background(), evt)
+		if err != nil {
+			t.Fatalf("CheckPublishRecipientPlan(%s): %v", accountID, err)
+		}
+		if preflight.TargetFailure != "" || len(preflight.DeliveryRoutes) != 1 ||
+			!fanOutPinRouteDeliveryRoutesContain(preflight.DeliveryRoutes, expected) {
+			t.Fatalf("preflight for %s = failure:%q routes:%#v, want only %#v", accountID, preflight.TargetFailure, preflight.DeliveryRoutes, expected)
+		}
+		if err := eb.Publish(context.Background(), evt); err != nil {
+			t.Fatalf("Publish fan_out event for %s: %v", accountID, err)
+		}
+		if routes := store.deliveryRoutes[evt.ID()]; len(routes) != 1 ||
+			!fanOutPinRouteDeliveryRoutesContain(routes, expected) {
+			t.Fatalf("persisted routes for %s = %#v, want only %#v", accountID, routes, expected)
+		}
+	}
+}
+
+func TestFanOutPinRouteConformance_FailsClosedForRouteKeyGaps(t *testing.T) {
+	source := fanoutpinroute.LoadSource(t, fanoutpinroute.Options{})
+	tests := []struct {
+		name          string
+		payload       json.RawMessage
+		flowInstances []runtimebus.ActiveFlowInstanceDescriptor
+		wantFailure   string
+	}{
+		{
+			name:        "missing account key",
+			payload:     json.RawMessage(`{"bucket":"priority","score":91}`),
+			wantFailure: string(runtimepinrouting.ConnectFailureAddressValueMissing),
+		},
+		{
+			name:    "ambiguous account key",
+			payload: json.RawMessage(`{"account_id":"acct-a","bucket":"priority","score":91}`),
+			flowInstances: []runtimebus.ActiveFlowInstanceDescriptor{
+				{InstanceID: "acct-a-one", EntityID: "ent-a1", FlowInstance: "account/acct-a-one", FlowTemplate: "account", AddressFields: map[string]string{"entity.account_id": "acct-a"}},
+				{InstanceID: "acct-a-two", EntityID: "ent-a2", FlowInstance: "account/acct-a-two", FlowTemplate: "account", AddressFields: map[string]string{"entity.account_id": "acct-a"}},
+			},
+			wantFailure: string(runtimepinrouting.ConnectFailureTargetAmbiguous),
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			store := &fanOutPinRouteMemoryStore{flowInstances: tc.flowInstances}
+			eb, err := runtimebus.NewEventBusWithOptions(store, runtimebus.EventBusOptions{
+				ContractBundle: source,
+				TemplateInstanceActivator: func(context.Context, runtimepipeline.FlowInstanceActivationRequest) error {
+					t.Fatal("fail-closed fan-out route should not activate an account instance")
+					return nil
+				},
+			})
+			if err != nil {
+				t.Fatalf("NewEventBusWithOptions: %v", err)
+			}
+			evt := eventtest.RootIngress(
+				"evt-fanout-pin-route-negative",
+				events.EventType("coordinator/account.classified"),
+				"",
+				"",
+				tc.payload,
+				0,
+				"run-fanout-pin-route",
+				"",
+				events.EnvelopeForSourceRoute(events.EventEnvelope{}, events.RouteIdentity{
+					FlowID:       "coordinator",
+					FlowInstance: "coordinator",
+					EntityID:     "coordinator",
+				}),
+				time.Now().UTC(),
+			)
+			preflight, err := eb.CheckPublishRecipientPlan(context.Background(), evt)
+			if err != nil {
+				t.Fatalf("CheckPublishRecipientPlan: %v", err)
+			}
+			if preflight.TargetFailure != tc.wantFailure {
+				t.Fatalf("target failure = %q, want %q", preflight.TargetFailure, tc.wantFailure)
+			}
+			if len(preflight.DeliveryRoutes) != 0 || len(preflight.Recipients) != 0 ||
+				len(preflight.RoutedRecipients) != 0 || len(preflight.SubscriptionRecipients) != 0 {
+				t.Fatalf("fail-closed fan-out route exposed executable recipients: routes=%#v recipients=%#v routed=%#v subscriptions=%#v",
+					preflight.DeliveryRoutes, preflight.Recipients, preflight.RoutedRecipients, preflight.SubscriptionRecipients)
+			}
+		})
+	}
+}
+
 func templateFlowPilotConformanceFindingContains(findings []runtimebootverify.Finding, checkID, substr string) bool {
 	for _, finding := range findings {
 		if strings.TrimSpace(finding.CheckID) != checkID {
 			continue
 		}
 		if substr == "" || strings.Contains(finding.Message, substr) {
+			return true
+		}
+	}
+	return false
+}
+
+type fanOutPinRouteStateRepo struct{}
+
+func (fanOutPinRouteStateRepo) LoadState(context.Context, runtimeidentity.EntityID) (runtimeengine.StateSnapshot, bool, error) {
+	return runtimeengine.StateSnapshot{}, false, nil
+}
+
+func (fanOutPinRouteStateRepo) SaveState(context.Context, runtimeidentity.EntityID, runtimeengine.StateMutation) error {
+	return nil
+}
+
+type fanOutPinRouteTxRunner struct{}
+type fanOutPinRouteTx struct{ ctx context.Context }
+
+func (fanOutPinRouteTxRunner) Run(ctx context.Context, fn func(runtimeengine.Tx) error) error {
+	return fn(fanOutPinRouteTx{ctx: ctx})
+}
+
+func (t fanOutPinRouteTx) Context() context.Context {
+	if t.ctx == nil {
+		return context.Background()
+	}
+	return t.ctx
+}
+
+type fanOutPinRouteLocker struct{}
+
+func (fanOutPinRouteLocker) WithEntityLock(ctx context.Context, _ runtimeidentity.EntityID, fn func(context.Context) error) error {
+	return fn(ctx)
+}
+
+type fanOutPinRouteOutbox struct{}
+
+func (fanOutPinRouteOutbox) WriteOutbox(context.Context, []runtimeengine.EmitIntent) error {
+	return nil
+}
+
+type fanOutPinRouteDispatcher struct{}
+
+func (fanOutPinRouteDispatcher) DispatchPostCommit(context.Context, []runtimeengine.EmitIntent) error {
+	return nil
+}
+
+type fanOutPinRouteMemoryStore struct {
+	runtimebus.InMemoryEventStore
+	flowInstances  []runtimebus.ActiveFlowInstanceDescriptor
+	deliveryRoutes map[string][]events.DeliveryRoute
+}
+
+func (s *fanOutPinRouteMemoryStore) ListActiveFlowInstanceDescriptors(context.Context) ([]runtimebus.ActiveFlowInstanceDescriptor, error) {
+	return append([]runtimebus.ActiveFlowInstanceDescriptor(nil), s.flowInstances...), nil
+}
+
+func (s *fanOutPinRouteMemoryStore) InsertEventDeliveryRoutes(_ context.Context, eventID string, routes []events.DeliveryRoute) error {
+	if s.deliveryRoutes == nil {
+		s.deliveryRoutes = map[string][]events.DeliveryRoute{}
+	}
+	s.deliveryRoutes[eventID] = events.NormalizeDeliveryRoutes(routes)
+	return nil
+}
+
+func fanOutPinRouteDeliveryRoutesContain(routes []events.DeliveryRoute, target events.RouteIdentity) bool {
+	target = target.Normalized()
+	for _, route := range events.NormalizeDeliveryRoutes(routes) {
+		if route.SubscriberType == "node" && route.SubscriberID == "account-classifier" && route.Target == target {
 			return true
 		}
 	}

--- a/internal/runtime/contracts/workflow_contract_types.go
+++ b/internal/runtime/contracts/workflow_contract_types.go
@@ -263,7 +263,6 @@ type ComputeKeyConfig struct {
 type FanOutSpec struct {
 	ItemsFrom string     `yaml:"items_from"`
 	ItemsPath paths.Path `yaml:"-"`
-	Target    string     `yaml:"target"`
 	Emit      EmitSpec   `yaml:"emit"`
 }
 type GroupBySpec struct {

--- a/internal/runtime/contracts/workflow_contract_yaml_rules.go
+++ b/internal/runtime/contracts/workflow_contract_yaml_rules.go
@@ -206,7 +206,6 @@ func (f *FanOutSpec) UnmarshalYAML(node *yaml.Node) error {
 	}
 	var aux struct {
 		ItemsFrom string   `yaml:"items_from"`
-		Target    string   `yaml:"target"`
 		Emit      EmitSpec `yaml:"emit"`
 	}
 	if err := node.Decode(&aux); err != nil {
@@ -214,12 +213,10 @@ func (f *FanOutSpec) UnmarshalYAML(node *yaml.Node) error {
 	}
 	*f = FanOutSpec{
 		ItemsFrom: strings.TrimSpace(aux.ItemsFrom),
-		Target:    strings.TrimSpace(aux.Target),
 		Emit:      aux.Emit,
 	}
 	f.ItemsFrom = strings.TrimSpace(f.ItemsFrom)
 	f.ItemsPath = paths.Parse(f.ItemsFrom)
-	f.Target = strings.TrimSpace(f.Target)
 	return nil
 }
 
@@ -229,7 +226,6 @@ func validateFanOutFieldNodes(node *yaml.Node) error {
 	}
 	allowed := map[string]struct{}{
 		"items_from": {},
-		"target":     {},
 		"emit":       {},
 	}
 	for i := 0; i+1 < len(node.Content); i += 2 {
@@ -238,6 +234,8 @@ func validateFanOutFieldNodes(node *yaml.Node) error {
 			continue
 		}
 		switch key {
+		case "target":
+			return fmt.Errorf("RETIRED: fan_out field %q is retired; route fan_out.emit through output pins and parent connect, or use emit.target only as an explicit producer escape hatch", key)
 		case "emit_per_item":
 			return fmt.Errorf("RETIRED: fan_out field %q is retired; use emit: <event> or emit: {event, fields}", key)
 		case "emit_mapping":

--- a/internal/runtime/contracts/workflow_contract_yaml_test.go
+++ b/internal/runtime/contracts/workflow_contract_yaml_test.go
@@ -697,6 +697,19 @@ emit_per_item: routed.item
 	}
 }
 
+func TestFanOutSpecDecode_RejectsRetiredTarget(t *testing.T) {
+	var spec FanOutSpec
+	err := yaml.Unmarshal([]byte(`
+items_from: payload.items
+target: worker-a
+emit:
+  event: routed.item
+`), &spec)
+	if err == nil || !strings.Contains(err.Error(), `fan_out field "target" is retired`) {
+		t.Fatalf("yaml.Unmarshal error = %v, want retired fan_out target rejection", err)
+	}
+}
+
 func TestGroupBySpecDecode_HydratesPaths(t *testing.T) {
 	var spec GroupBySpec
 	if err := yaml.Unmarshal([]byte(`

--- a/internal/runtime/engine/executor.go
+++ b/internal/runtime/engine/executor.go
@@ -995,7 +995,6 @@ func (e *Executor) stepFanOut(frame *executionFrame) (bool, error) {
 	items := sliceFromAny(itemsValue)
 	frame.result.FanOutCount = len(items)
 	frame.state.FanOut = map[string]any{}
-	frame.state.SetFanOut("target", spec.Target)
 	frame.state.SetFanOut("count", len(items))
 	// fan_out_count is platform-populated runtime bookkeeping, not an authored
 	// entity write target.

--- a/internal/runtime/engine/executor_test.go
+++ b/internal/runtime/engine/executor_test.go
@@ -2098,7 +2098,6 @@ func TestExecutor_FanOutCreatesShapedEmitIntentsAndStopsLoop(t *testing.T) {
 			FanOut: &runtimecontracts.FanOutSpec{
 				ItemsFrom: "payload.items",
 				Emit:      runtimecontracts.EmitSpec{Event: "item.process"},
-				Target:    "agent-x",
 			},
 			AdvancesTo: "processing",
 			Action:     runtimecontracts.ActionSpec{ID: "should_not_run"},

--- a/internal/runtime/testcases/accumulation_fanout_test.go
+++ b/internal/runtime/testcases/accumulation_fanout_test.go
@@ -15,7 +15,7 @@ func TestGenericBundle_AccumulationFanoutPatterns(t *testing.T) {
 	if created.FanOut == nil {
 		t.Fatal("expected fan_out on item.created")
 	}
-	if created.FanOut.ItemsFrom != "payload.items" || created.FanOut.Target != "worker-a" || created.FanOut.Emit.EventType() != "intake/item.processed" {
+	if created.FanOut.ItemsFrom != "payload.items" || created.FanOut.Emit.EventType() != "intake/item.processed" {
 		t.Fatalf("unexpected fan_out spec: %+v", created.FanOut)
 	}
 	if len(created.Branch) != 1 || created.Branch[0].Then == nil || created.Branch[0].Else == nil {

--- a/internal/runtime/testdata/generic-swarm-bundle/flows/intake/nodes.yaml
+++ b/internal/runtime/testdata/generic-swarm-bundle/flows/intake/nodes.yaml
@@ -18,7 +18,6 @@ intake-router:
         check: payload.item_id != ''
       fan_out:
         items_from: payload.items
-        target: worker-a
         emit:
           event: item.processed
           broadcast: true

--- a/internal/runtime/testfixtures/fanoutpinroute/fixture.go
+++ b/internal/runtime/testfixtures/fanoutpinroute/fixture.go
@@ -1,0 +1,255 @@
+package fanoutpinroute
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
+	"github.com/division-sh/swarm/internal/runtime/semanticview"
+)
+
+// Options toggles the fan_out.emit pin-route fixture variants used by
+// conformance and verifier tests.
+type Options struct {
+	OmitOutputPin     bool
+	OmitConnect       bool
+	BadConnectMapping bool
+	MissingEmitCarry  bool
+	ProducerTarget    bool
+	ProducerBroadcast bool
+}
+
+func LoadBundle(t testing.TB, opts Options) *runtimecontracts.WorkflowContractBundle {
+	t.Helper()
+	root := Write(t, opts)
+	bundle, err := runtimecontracts.LoadWorkflowContractBundleWithOverrides(repoRoot(t), root, runtimecontracts.DefaultPlatformSpecFile(repoRoot(t)))
+	if err != nil {
+		t.Fatalf("LoadWorkflowContractBundleWithOverrides: %v", err)
+	}
+	return bundle
+}
+
+func LoadSource(t testing.TB, opts Options) semanticview.Source {
+	t.Helper()
+	return semanticview.Wrap(LoadBundle(t, opts))
+}
+
+func Write(t testing.TB, opts Options) string {
+	t.Helper()
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "package.yaml"), `
+name: fanout-pin-route
+version: "1.0.0"
+platform_version: ">=1.6.0"
+flows:
+  - id: coordinator
+    flow: coordinator
+    mode: singleton
+  - id: account
+    flow: account
+    mode: template
+`+connectYAML(opts))
+	writeFile(t, filepath.Join(root, "schema.yaml"), "name: fanout-pin-route\n")
+	writeFile(t, filepath.Join(root, "policy.yaml"), "{}\n")
+	writeFile(t, filepath.Join(root, "tools.yaml"), "{}\n")
+	writeFile(t, filepath.Join(root, "agents.yaml"), "{}\n")
+	writeFile(t, filepath.Join(root, "events.yaml"), "{}\n")
+	writeFile(t, filepath.Join(root, "nodes.yaml"), "{}\n")
+	writeCoordinator(t, root, opts)
+	writeAccount(t, root)
+	return root
+}
+
+func connectYAML(opts Options) string {
+	if opts.OmitConnect {
+		return ""
+	}
+	out := `
+connect:
+  - from: coordinator.account_classified
+    to: account.account_classified
+    delivery: one
+`
+	if opts.BadConnectMapping {
+		out += `    using:
+      instance:
+        source: missing_account_id
+        target: account_id
+`
+	}
+	return out
+}
+
+func writeCoordinator(t testing.TB, root string, opts Options) {
+	t.Helper()
+	writeFile(t, filepath.Join(root, "flows", "coordinator", "schema.yaml"), `
+name: coordinator
+mode: singleton
+initial_state: active
+states: [active]
+pins:
+  inputs:
+    events:
+      - name: batch_classify_completed
+        event: batch.classify.completed
+  outputs:
+`+coordinatorOutputPinYAML(opts))
+	writeFile(t, filepath.Join(root, "flows", "coordinator", "policy.yaml"), "{}\n")
+	writeFile(t, filepath.Join(root, "flows", "coordinator", "tools.yaml"), "{}\n")
+	writeFile(t, filepath.Join(root, "flows", "coordinator", "agents.yaml"), "{}\n")
+	writeFile(t, filepath.Join(root, "flows", "coordinator", "types.yaml"), `
+types:
+  ClassificationResult:
+    account_id: text
+    bucket: text
+    score: integer
+`)
+	writeFile(t, filepath.Join(root, "flows", "coordinator", "entities.yaml"), `
+coordinator_state:
+  coordinator_id: text
+  classifications:
+    type: map[text]ClassificationResult
+    _unused_reason: singleton coordinator fan-out route proof field
+`)
+	writeFile(t, filepath.Join(root, "flows", "coordinator", "events.yaml"), `
+batch.classify.completed:
+  coordinator_id: text
+  results: "[ClassificationResult]"
+account.classified:
+  account_id: text
+  bucket: text
+  score: integer
+  required: [account_id, bucket, score]
+`)
+	writeFile(t, filepath.Join(root, "flows", "coordinator", "nodes.yaml"), `
+classifier-coordinator:
+  id: classifier-coordinator
+  execution_type: system_node
+  subscribes_to: [batch.classify.completed]
+  event_handlers:
+    batch.classify.completed:
+      select_entity:
+        by:
+          coordinator_id: payload.coordinator_id
+      data_accumulation:
+        writes:
+          - source_field: coordinator_id
+            target_field: coordinator_id
+      fan_out:
+        items_from: payload.results
+        emit:
+          event: account.classified
+`+producerRouteYAML(opts)+`          fields:
+            account_id: fan_out.item.account_id
+`+emitCarryFieldsYAML(opts))
+}
+
+func coordinatorOutputPinYAML(opts Options) string {
+	if opts.OmitOutputPin {
+		return "    events: []\n"
+	}
+	return `    events:
+      - name: account_classified
+        event: account.classified
+        key: account_id
+        carries: [account_id, bucket, score]
+`
+}
+
+func producerRouteYAML(opts Options) string {
+	if opts.ProducerTarget {
+		return `          target:
+            flow: account
+            match:
+              account_id: fan_out.item.account_id
+`
+	}
+	if opts.ProducerBroadcast {
+		return "          broadcast: true\n"
+	}
+	return ""
+}
+
+func emitCarryFieldsYAML(opts Options) string {
+	if opts.MissingEmitCarry {
+		return ""
+	}
+	return `            bucket: fan_out.item.bucket
+            score: fan_out.item.score
+`
+}
+
+func writeAccount(t testing.TB, root string) {
+	t.Helper()
+	writeFile(t, filepath.Join(root, "flows", "account", "schema.yaml"), `
+name: account
+mode: template
+initial_state: awaiting_classification
+terminal_states: [classified]
+states: [awaiting_classification, classified]
+instance:
+  by: account_id
+  on_missing: create
+  on_conflict: reuse
+pins:
+  inputs:
+    events:
+      - name: account_classified
+        event: account.classified
+  outputs:
+    events: []
+`)
+	writeFile(t, filepath.Join(root, "flows", "account", "policy.yaml"), "{}\n")
+	writeFile(t, filepath.Join(root, "flows", "account", "tools.yaml"), "{}\n")
+	writeFile(t, filepath.Join(root, "flows", "account", "agents.yaml"), "{}\n")
+	writeFile(t, filepath.Join(root, "flows", "account", "events.yaml"), `
+account.classified:
+  account_id: text
+  bucket: text
+  score: integer
+`)
+	writeFile(t, filepath.Join(root, "flows", "account", "entities.yaml"), `
+account_state:
+  account_id: text
+  bucket: text
+  score: integer
+`)
+	writeFile(t, filepath.Join(root, "flows", "account", "nodes.yaml"), `
+account-classifier:
+  id: account-classifier
+  execution_type: system_node
+  subscribes_to: [account.classified]
+  event_handlers:
+    account.classified:
+      data_accumulation:
+        writes:
+          - source_field: account_id
+            target_field: account_id
+          - source_field: bucket
+            target_field: bucket
+          - source_field: score
+            target_field: score
+      advances_to: classified
+`)
+}
+
+func repoRoot(t testing.TB) string {
+	t.Helper()
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("resolve repo root")
+	}
+	return filepath.Clean(filepath.Join(filepath.Dir(file), "..", "..", "..", ".."))
+}
+
+func writeFile(t testing.TB, path, contents string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, []byte(contents), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}

--- a/internal/runtime/workflowexpr/data_expression.go
+++ b/internal/runtime/workflowexpr/data_expression.go
@@ -58,6 +58,9 @@ func ValidateValueExpressionWithOptions(expression string, opts ValueExpressionO
 	if expression == "" {
 		return fmt.Errorf("workflow data expression is empty")
 	}
+	if expressionReferencesRetiredFanOutTarget(expression) {
+		return fmt.Errorf("fan_out.target is retired; use fan_out.item for per-item values or fan_out.count for fan-out count")
+	}
 	_, issues := env.Compile(expression)
 	if issues != nil && issues.Err() != nil {
 		return issues.Err()
@@ -77,6 +80,9 @@ func EvalValueExpressionWithOptions(expression string, ctx ValueContext, opts Va
 	normalized := strings.TrimSpace(RewriteEntityNullPresenceChecks(expression))
 	if normalized == "" {
 		return nil, fmt.Errorf("workflow data expression is empty")
+	}
+	if expressionReferencesRetiredFanOutTarget(normalized) {
+		return nil, fmt.Errorf("fan_out.target is retired; use fan_out.item for per-item values or fan_out.count for fan-out count")
 	}
 	if missing := MissingEntityReferences(normalized, ctx.Entity); len(missing) > 0 {
 		return nil, fmt.Errorf("entity field(s) unavailable in expression context: %s", strings.Join(missing, ", "))
@@ -108,6 +114,58 @@ func EvalValueExpressionWithOptions(expression string, ctx ValueContext, opts Va
 
 func ExpressionReferencesEntity(expression string) bool {
 	return len(EntityReferences(expression)) > 0
+}
+
+func expressionReferencesRetiredFanOutTarget(expression string) bool {
+	expression = strings.TrimSpace(expression)
+	if expression == "" {
+		return false
+	}
+	for i := 0; i < len(expression); i++ {
+		switch expression[i] {
+		case '\'', '"':
+			next, ok := skipQuotedString(expression, i)
+			if ok {
+				i = next - 1
+				continue
+			}
+		}
+		if !strings.HasPrefix(expression[i:], "fan_out") {
+			continue
+		}
+		if i > 0 && isIdentifierPart(expression[i-1]) {
+			continue
+		}
+		pos := i + len("fan_out")
+		if pos < len(expression) && isIdentifierPart(expression[pos]) {
+			continue
+		}
+		pos = skipExpressionWhitespace(expression, pos)
+		if pos >= len(expression) {
+			continue
+		}
+		switch expression[pos] {
+		case '.':
+			pos = skipExpressionWhitespace(expression, pos+1)
+			if strings.HasPrefix(expression[pos:], "target") {
+				end := pos + len("target")
+				if end >= len(expression) || !isIdentifierPart(expression[end]) {
+					return true
+				}
+			}
+		case '[':
+			pos = skipExpressionWhitespace(expression, pos+1)
+			value, next, ok := readQuotedString(expression, pos)
+			if !ok {
+				continue
+			}
+			next = skipExpressionWhitespace(expression, next)
+			if next < len(expression) && expression[next] == ']' && value == "target" {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func RewriteEntityNullPresenceChecks(expression string) string {
@@ -166,6 +224,59 @@ func StripStringLiterals(expression string) string {
 		out.WriteByte(ch)
 	}
 	return out.String()
+}
+
+func skipQuotedString(expression string, start int) (int, bool) {
+	_, next, ok := readQuotedString(expression, start)
+	return next, ok
+}
+
+func readQuotedString(expression string, start int) (string, int, bool) {
+	if start < 0 || start >= len(expression) {
+		return "", start, false
+	}
+	quote := expression[start]
+	if quote != '\'' && quote != '"' {
+		return "", start, false
+	}
+	var out strings.Builder
+	escaped := false
+	for i := start + 1; i < len(expression); i++ {
+		ch := expression[i]
+		if escaped {
+			out.WriteByte(ch)
+			escaped = false
+			continue
+		}
+		if ch == '\\' {
+			escaped = true
+			continue
+		}
+		if ch == quote {
+			return out.String(), i + 1, true
+		}
+		out.WriteByte(ch)
+	}
+	return "", len(expression), false
+}
+
+func skipExpressionWhitespace(expression string, pos int) int {
+	for pos < len(expression) {
+		switch expression[pos] {
+		case ' ', '\t', '\n', '\r':
+			pos++
+		default:
+			return pos
+		}
+	}
+	return pos
+}
+
+func isIdentifierPart(ch byte) bool {
+	return (ch >= 'a' && ch <= 'z') ||
+		(ch >= 'A' && ch <= 'Z') ||
+		(ch >= '0' && ch <= '9') ||
+		ch == '_'
 }
 
 func EntityReferences(expression string) []string {

--- a/internal/runtime/workflowexpr/data_expression_test.go
+++ b/internal/runtime/workflowexpr/data_expression_test.go
@@ -1,6 +1,9 @@
 package workflowexpr
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func TestEvalValueExpression_AllowsNullPresenceCheckOnMissingField(t *testing.T) {
 	value, err := EvalValueExpression(`entity.kill_reason == null`, ValueContext{
@@ -62,6 +65,42 @@ func TestValidateValueExpression_RejectsAccumulatedNamespace(t *testing.T) {
 	}
 }
 
+func TestValidateValueExpression_RejectsRetiredFanOutTarget(t *testing.T) {
+	tests := []string{
+		`fan_out.target`,
+		`fan_out.target.flow_instance`,
+		`fan_out["target"]`,
+		`fan_out['target']`,
+	}
+	for _, expression := range tests {
+		t.Run(expression, func(t *testing.T) {
+			err := ValidateValueExpressionWithOptions(expression, ValueExpressionOptions{AllowBareItem: true})
+			if err == nil {
+				t.Fatalf("expected %q to reject retired fan_out.target", expression)
+			}
+			if got := err.Error(); got == "" || !containsAll(got, "fan_out.target", "retired") {
+				t.Fatalf("ValidateValueExpressionWithOptions(%q) error = %q, want retired fan_out.target", expression, got)
+			}
+		})
+	}
+}
+
+func TestValidateValueExpression_AllowsFanOutItemAndStringLiteralTargetText(t *testing.T) {
+	tests := []string{
+		`fan_out.item.target`,
+		`item.target`,
+		`"fan_out.target"`,
+		`payload.note == "fan_out.target"`,
+	}
+	for _, expression := range tests {
+		t.Run(expression, func(t *testing.T) {
+			if err := ValidateValueExpressionWithOptions(expression, ValueExpressionOptions{AllowBareItem: true}); err != nil {
+				t.Fatalf("ValidateValueExpressionWithOptions(%q) error = %v", expression, err)
+			}
+		})
+	}
+}
+
 func TestExpressionReferencesEntity_IgnoresStringLiterals(t *testing.T) {
 	if ExpressionReferencesEntity(`payload.reason == "entity.kill_reason"`) {
 		t.Fatal("expected quoted entity reference text to be ignored")
@@ -69,4 +108,13 @@ func TestExpressionReferencesEntity_IgnoresStringLiterals(t *testing.T) {
 	if !ExpressionReferencesEntity(`has(entity.kill_reason) ? entity.kill_reason : payload.reason`) {
 		t.Fatal("expected real entity reference to be detected")
 	}
+}
+
+func containsAll(value string, parts ...string) bool {
+	for _, part := range parts {
+		if !strings.Contains(value, part) {
+			return false
+		}
+	}
+	return true
 }

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -1780,11 +1780,35 @@ handler_specification:
     fan_out:
       field: fan_out
       type: object
-      purpose: For each item in a list, emit an event.
+      purpose: For each item in a list, emit one ordinary event through the normal emit pipeline.
       sub_fields:
         items_from: string — source list (payload field or entity field)
-        target: string — agent path to receive events
         emit: string or object — per-item event to emit, optionally with local fields payload construction
+      route_authority: >
+        `fan_out.emit` is a normal authored emit site. When it emits a
+        pin-declared output event, routing is owned by the same output pin,
+        parent connect / ConnectRoutePlan, and EventBus RoutePlan authority as
+        handler-level emit, rule emit, on_complete emit, and accumulate timeout
+        emit. The runtime must not route target-less fan_out output through
+        direct delivery, raw subscriber lookup, RouteTable fallback, relay,
+        replay/readback repair, receiver select_entity repair, or event-type
+        broadcast compatibility.
+      retired_target_field: >
+        `fan_out.target` is retired and invalid. It is not a route owner and
+        must not be implemented as an agent-dispatch mode. Authors that need a
+        genuine producer escape hatch use `fan_out.emit.target` with the same
+        restrictions as any other explicit emit target; common composed flow
+        delivery uses output pins and parent connect.
+      batching_scatter_pattern: >
+        The supported batched-agent scatter pattern is asynchronous and
+        event-driven: a coordinator emits a batch request event to a normal
+        authored agent, that agent emits a batch-completed event, and the
+        coordinator fans out result rows with target-less `fan_out.emit` to
+        pin-declared outputs. Each row must construct the output pin key/carries
+        payload fields from the current `fan_out.item`, and parent connect
+        routes each emitted event to the intended flow instance by correlation
+        key. No `batch_agent`, `map_agent`, inline runtime LLM invocation, or
+        runtime-owned JSON result contract is part of this pattern.
       side_effect: Writes fan_out.count to handler context (available for data_accumulation).
     query:
       field: query
@@ -1963,6 +1987,7 @@ handler_specification:
       - "`payload_transform` — retired; move payload ownership into `emit.fields` at the active emit site"
       - "`fan_out.emit_per_item` — retired; use `fan_out.emit`"
       - "`fan_out.emit_mapping` — retired; no direct replacement in the current fan_out model. Use a single `fan_out.emit` and route before or after fan-out if per-item event-name branching is required."
+      - "`fan_out.target` — retired; `fan_out.emit` routes through ordinary emit target semantics or, for composed pin-declared outputs, through output pin plus parent connect route authority."
     clear_gates:
       field: clear_gates
       type: boolean

--- a/tests/tier3-list-processing/test-fan-out-basic/nodes.yaml
+++ b/tests/tier3-list-processing/test-fan-out-basic/nodes.yaml
@@ -7,7 +7,6 @@ fan-out-node:
     batch.submitted:
       fan_out:
         items_from: payload.items
-        target: fan-out-node
         emit:
           event: item.assigned
           broadcast: true

--- a/tests/tier3-list-processing/test-fan-out-count/nodes.yaml
+++ b/tests/tier3-list-processing/test-fan-out-count/nodes.yaml
@@ -7,7 +7,6 @@ fan-out-node:
     batch.received:
       fan_out:
         items_from: payload.items
-        target: fan-out-node
         emit:
           event: task.dispatched
           broadcast: true

--- a/tests/tier3-list-processing/test-fan-out-empty/nodes.yaml
+++ b/tests/tier3-list-processing/test-fan-out-empty/nodes.yaml
@@ -7,7 +7,6 @@ fan-out-node:
     batch.submitted:
       fan_out:
         items_from: payload.items
-        target: fan-out-node
         emit:
           event: item.assigned
           broadcast: true


### PR DESCRIPTION
## Summary

- Retires stale `fan_out.target` parsing/runtime context and rejects it as invalid authoring syntax.
- Documents `fan_out.emit` as the normal per-item emit site routed by output pins, parent `connect` / `ConnectRoutePlan`, and EventBus `RoutePlan` authority.
- Adds bootverify and conformance coverage for target-less fan-out scatter to distinct template flow instances by correlation key, plus fail-closed negative cases.

Closes #1605
Part of #1447
Part of #1537

## Governing Refs / Context

Exact spec refs updated/consumed:

- `platform-spec.yaml#handler_specification.handler_fields.fan_out`
- `platform-spec.yaml#handler_specification.handler_fields.emit`
- `platform-spec.yaml#handler_specification.legacy_surface_retirement`
- `platform-spec.yaml#engine.cross_flow_routing`
- `platform-spec.yaml#flow_model.flow_instance_authoring.composition_model.output_pin_key_carries_contract`
- `platform-spec.yaml#static_analyzer.slice_2_emitted_event_payload_completeness`
- `platform-spec.yaml#static_analyzer.slice_3a_pin_target_resolution`
- `platform-spec.yaml#static_analyzer.slice_3a0_output_pin_key_carries_validation`

Binding issue/gate context:

- #1605 issue body/thread
- #1605 `Pre-Implementation Coverage Audit`
- #1605 independent gate comment approving the corrected boundary
- #1447 parent batching/scatter issue
- #1537 parent flow-instance-centered composition epic
- #1602 closed unmerged and superseded

`docs/IMPLEMENTER_GUIDELINES.md` and `docs/SEMANTIC_DRIFT.md` are not present on this branch, matching the pre-audit note; this PR uses the merge-bearing spec and issue/gate thread as binding context.

## Semantic Migration

- New canonical owner: `fan_out.emit` consumes ordinary `EmitSpec`; pin-declared fan-out output routing is owned by output pin -> parent `connect` / `ConnectRoutePlan` -> EventBus `RoutePlan`.
- Old producer/reader/writer path now invalid: `fan_out.target` is removed from `FanOutSpec`, no longer decoded, no longer written into `fan_out.target` handler context, and parser rejects it as retired syntax.
- Production paths checked for surviving old behavior: contract decode, engine `stepFanOut`, authored emit-site bootverify consumers, pin target resolution, output-pin key/carries validation, payload completeness, EventBus route planning, generic/test catalog fixtures.
- Migration complete for the chosen #1605 class. Explicit `emit.target` / `broadcast:true` remain existing producer escape hatches under their existing restrictions; `fan_out.target` itself is not preserved.

## Tests

- `go test ./internal/runtime/contracts ./internal/runtime/engine ./internal/runtime/bootverify -run 'FanOut|PinTarget|OutputPin|Payload' -count=1`
- `go test ./internal/runtime/conformance -run 'FanOutPinRouteConformance|RouteAuthorityDriftInventory' -count=1 -timeout=90s`
- `go test ./internal/runtime/contracts ./internal/runtime/engine ./internal/runtime/bootverify ./internal/runtime/core/pinrouting ./internal/runtime/bus ./internal/runtime/conformance -count=1`
- `go test ./internal/runtime/cataloge2e -run 'TestTier3ListProcessingCatalogFixtures_RealRuntime' -count=1`
- `go test ./...`