### PR TITLE
[agent-f][issue #1599] Reconcile public node/schema YAML fields

### DIFF
--- a/cmd/swarm/main_test.go
+++ b/cmd/swarm/main_test.go
@@ -4240,8 +4240,6 @@ portfolio-node:
       config_from:
         product_id: payload.product_id
       advances_to: done
-  permissions:
-    - create_flow_instance
 `)
 	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "flows", "portfolio", "policy.yaml"), `{}`)
 	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "flows", "portfolio", "tools.yaml"), `{}`)
@@ -4404,8 +4402,6 @@ portfolio-node:
       config_from:
         product_id: payload.product_id
       advances_to: done
-  permissions:
-    - create_flow_instance
 `)
 	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "flows", "portfolio", "policy.yaml"), `{}`)
 	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "flows", "portfolio", "tools.yaml"), `{}`)

--- a/internal/runtime/bootverify/report_test.go
+++ b/internal/runtime/bootverify/report_test.go
@@ -6377,7 +6377,6 @@ flows:
 
 	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "child", "schema.yaml"), `
 name: child
-namespace: child
 initial_state: idle
 terminal_states: [done]
 states: [idle, working, done]

--- a/internal/runtime/contracts/bundle_hash_test.go
+++ b/internal/runtime/contracts/bundle_hash_test.go
@@ -491,7 +491,7 @@ func writeEquivalentBundleHashFixture(t *testing.T, lineEnding, packageYAML stri
 	platform := DefaultPlatformSpecFile(t.TempDir())
 	writeBundleHashText(t, platform, strings.ReplaceAll("api_specification:\n  alpha: true\n  number: 1\n", "\n", lineEnding))
 	writeBundleHashText(t, filepath.Join(root, "package.yaml"), packageYAML)
-	writeBundleHashText(t, filepath.Join(root, "schema.yaml"), strings.ReplaceAll("name: equivalent\nfields:\n  topic: string\n", "\n", lineEnding))
+	writeBundleHashText(t, filepath.Join(root, "schema.yaml"), strings.ReplaceAll("name: equivalent\n", "\n", lineEnding))
 	writeBundleHashText(t, filepath.Join(root, "prompts", "guide.md"), strings.ReplaceAll("hello\nworld", "\n", lineEnding))
 	return root, platform
 }

--- a/internal/runtime/contracts/load_validation_test.go
+++ b/internal/runtime/contracts/load_validation_test.go
@@ -156,6 +156,87 @@ func TestLoadWorkflowContractBundle_PreservesEvidenceTarget(t *testing.T) {
 	t.Fatal("expected at least one record_evidence handler")
 }
 
+func TestLoadWorkflowContractBundleRejectsRetiredPublicNodeAndSchemaFields(t *testing.T) {
+	repoRoot := contractRepoRoot(t)
+	platformSpec := DefaultPlatformSpecFile(repoRoot)
+	tests := []struct {
+		name        string
+		schemaExtra string
+		nodes       string
+		wantErr     string
+	}{
+		{
+			name:        "schema namespace is not public schema YAML",
+			schemaExtra: "namespace: legacy\n",
+			nodes:       "{}\n",
+			wantErr:     "UNDEFINED-FIELD",
+		},
+		{
+			name:        "node idempotency table is retired public YAML",
+			schemaExtra: "",
+			nodes: `
+worker:
+  id: worker
+  idempotency_table: worker_idempotency
+  event_handlers: {}
+`,
+			wantErr: "RETIRED",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			root := t.TempDir()
+			writeFieldReconciliationBundle(t, root, tc.schemaExtra, tc.nodes)
+			_, err := LoadWorkflowContractBundleWithOverrides(repoRoot, root, platformSpec)
+			if err == nil || !contractErrorContains(err, tc.wantErr) {
+				t.Fatalf("LoadWorkflowContractBundleWithOverrides error = %v, want %q", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestLoadWorkflowContractBundleAllowsPublicNodeStateTable(t *testing.T) {
+	repoRoot := contractRepoRoot(t)
+	root := t.TempDir()
+	writeFieldReconciliationBundle(t, root, "", `
+worker:
+  id: worker
+  state_table: worker_state
+  state_schema:
+    fields:
+      count:
+        type: integer
+  event_handlers: {}
+`)
+	bundle, err := LoadWorkflowContractBundleWithOverrides(repoRoot, root, DefaultPlatformSpecFile(repoRoot))
+	if err != nil {
+		t.Fatalf("LoadWorkflowContractBundleWithOverrides: %v", err)
+	}
+	node, ok := bundle.Nodes["worker"]
+	if !ok {
+		t.Fatalf("worker node missing: %#v", bundle.Nodes)
+	}
+	if got, want := strings.TrimSpace(node.StateTable), "worker_state"; got != want {
+		t.Fatalf("StateTable = %q, want %q", got, want)
+	}
+}
+
+func writeFieldReconciliationBundle(t *testing.T, root, schemaExtra, nodes string) {
+	t.Helper()
+	writeFixtureFile(t, filepath.Join(root, "package.yaml"), `
+name: field-reconciliation
+version: "1.0.0"
+platform_version: ">=1.0.0"
+flows: []
+`)
+	writeFixtureFile(t, filepath.Join(root, "schema.yaml"), "name: field-reconciliation\n"+schemaExtra)
+	writeFixtureFile(t, filepath.Join(root, "policy.yaml"), "{}\n")
+	writeFixtureFile(t, filepath.Join(root, "tools.yaml"), "{}\n")
+	writeFixtureFile(t, filepath.Join(root, "agents.yaml"), "{}\n")
+	writeFixtureFile(t, filepath.Join(root, "events.yaml"), "{}\n")
+	writeFixtureFile(t, filepath.Join(root, "nodes.yaml"), nodes)
+}
+
 func TestAgentRegistryEntryRejectsRetiredModelTierField(t *testing.T) {
 	var entry AgentRegistryEntry
 	err := yaml.Unmarshal([]byte(`

--- a/internal/runtime/contracts/workflow_contract_types.go
+++ b/internal/runtime/contracts/workflow_contract_types.go
@@ -796,8 +796,8 @@ type FlowSchemaDocument struct {
 	Entity            string                          `yaml:"entity"`
 	Instance          FlowTemplateInstanceDeclaration `yaml:"instance"`
 	InitialState      string                          `yaml:"initial_state"`
-	NamespacePrefix   string                          `yaml:"namespace_prefix"`
-	NamespaceRule     string                          `yaml:"namespace_rule"`
+	NamespacePrefix   string                          `yaml:"-"`
+	NamespaceRule     string                          `yaml:"-"`
 	TerminalStates    []string                        `yaml:"terminal_states"`
 	States            []string                        `yaml:"states"`
 	Pins              FlowPins                        `yaml:"pins"`
@@ -1204,12 +1204,12 @@ type SystemNodeContract struct {
 	ID               string                            `yaml:"id"`
 	Description      string                            `yaml:"description"`
 	ExecutionType    string                            `yaml:"execution_type"`
-	Implementation   string                            `yaml:"implementation"`
+	Implementation   string                            `yaml:"-"`
 	SubscribesTo     []string                          `yaml:"subscribes_to"`
 	Produces         []string                          `yaml:"produces"`
-	OwnedTransitions []string                          `yaml:"owned_transitions"`
+	OwnedTransitions []string                          `yaml:"-"`
 	StateTable       string                            `yaml:"state_table"`
-	IdempotencyTable string                            `yaml:"idempotency_table"`
+	IdempotencyTable string                            `yaml:"-"`
 	Timers           []WorkflowTimerContract           `yaml:"timers"`
 	EventHandlers    map[string]SystemNodeEventHandler `yaml:"event_handlers"`
 	StateSchema      NodeStateSchema                   `yaml:"state_schema"`

--- a/internal/runtime/contracts/workflow_contract_yaml.go
+++ b/internal/runtime/contracts/workflow_contract_yaml.go
@@ -28,6 +28,120 @@ func hasAnyYAMLMappingKey(node *yaml.Node, keys ...string) bool {
 	return false
 }
 
+func (d *FlowSchemaDocument) UnmarshalYAML(node *yaml.Node) error {
+	if d == nil {
+		return nil
+	}
+	if node == nil || node.Kind == 0 {
+		*d = FlowSchemaDocument{}
+		return nil
+	}
+	if node.Kind != yaml.MappingNode {
+		return fmt.Errorf("flow schema document must be a mapping")
+	}
+	if err := validateFlowSchemaDocumentFields(node); err != nil {
+		return err
+	}
+	type alias FlowSchemaDocument
+	var aux alias
+	if err := node.Decode(&aux); err != nil {
+		return err
+	}
+	*d = FlowSchemaDocument(aux)
+	return nil
+}
+
+func validateFlowSchemaDocumentFields(node *yaml.Node) error {
+	allowed := map[string]struct{}{
+		"name":                {},
+		"mode":                {},
+		"entity":              {},
+		"instance":            {},
+		"initial_state":       {},
+		"terminal_states":     {},
+		"states":              {},
+		"pins":                {},
+		"tool_surface":        {},
+		"required_agents":     {},
+		"instance_variables":  {},
+		"auto_emit_on_create": {},
+	}
+	retired := map[string]string{
+		"namespace_prefix": "schema namespace_prefix is retired; flow namespace is derived from the package tree",
+		"namespace_rule":   "schema namespace_rule is retired; namespace override semantics require a separate spec owner",
+	}
+	for i := 0; i+1 < len(node.Content); i += 2 {
+		key := strings.TrimSpace(node.Content[i].Value)
+		if key == "" {
+			continue
+		}
+		if reason, ok := retired[key]; ok {
+			return fmt.Errorf("RETIRED: schema field %q is retired; %s", key, reason)
+		}
+		if _, ok := allowed[key]; !ok {
+			return fmt.Errorf("UNDEFINED-FIELD: schema field %q not in platform spec", key)
+		}
+	}
+	return nil
+}
+
+func (n *SystemNodeContract) UnmarshalYAML(node *yaml.Node) error {
+	if n == nil {
+		return nil
+	}
+	if node == nil || node.Kind == 0 {
+		*n = SystemNodeContract{}
+		return nil
+	}
+	if node.Kind != yaml.MappingNode {
+		return fmt.Errorf("system node contract must be a mapping")
+	}
+	if err := validateSystemNodeContractFields(node); err != nil {
+		return err
+	}
+	type alias SystemNodeContract
+	var aux alias
+	if err := node.Decode(&aux); err != nil {
+		return err
+	}
+	*n = SystemNodeContract(aux)
+	return nil
+}
+
+func validateSystemNodeContractFields(node *yaml.Node) error {
+	allowed := map[string]struct{}{
+		"id":             {},
+		"description":    {},
+		"execution_type": {},
+		"subscribes_to":  {},
+		"produces":       {},
+		"state_table":    {},
+		"timers":         {},
+		"event_handlers": {},
+		"state_schema":   {},
+		"gate_state":     {},
+	}
+	retired := map[string]string{
+		"permissions":       "node permissions are not public node YAML authority",
+		"implementation":    "executor binding is not public node YAML authority",
+		"owned_transitions": "transition ownership is expressed through event owning_node and event_handlers",
+		"idempotency_table": "node idempotency table semantics are not public node YAML authority",
+	}
+	for i := 0; i+1 < len(node.Content); i += 2 {
+		key := strings.TrimSpace(node.Content[i].Value)
+		if key == "" {
+			continue
+		}
+		if reason, ok := retired[key]; ok {
+			return fmt.Errorf("RETIRED: node field %q is retired; %s", key, reason)
+		}
+		if _, ok := allowed[key]; !ok {
+			return fmt.Errorf("UNDEFINED-FIELD: node field %q not in platform spec", key)
+		}
+	}
+	return nil
+}
+
 func decodeStringListNode(node *yaml.Node) ([]string, error) {
 	if node == nil || node.Kind == 0 {
 		return nil, nil

--- a/internal/runtime/contracts/workflow_contract_yaml_test.go
+++ b/internal/runtime/contracts/workflow_contract_yaml_test.go
@@ -316,6 +316,28 @@ pins:
 	}
 }
 
+func TestFlowSchemaDocumentDecode_RejectsRetiredAndUnsupportedTopLevelFields(t *testing.T) {
+	tests := []struct {
+		name    string
+		field   string
+		wantErr string
+	}{
+		{name: "namespace_prefix", field: "namespace_prefix: worker", wantErr: "RETIRED"},
+		{name: "namespace_rule", field: "namespace_rule: path", wantErr: "RETIRED"},
+		{name: "namespace", field: "namespace: worker", wantErr: "UNDEFINED-FIELD"},
+		{name: "unknown", field: "legacy_owner: worker", wantErr: "UNDEFINED-FIELD"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var doc FlowSchemaDocument
+			err := yaml.Unmarshal([]byte("name: invalid-schema\n"+tc.field+"\n"), &doc)
+			if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("yaml.Unmarshal error = %v, want %q", err, tc.wantErr)
+			}
+		})
+	}
+}
+
 func TestFlowSchemaDocumentDecode_PreservesTemplateInstanceDeclaration(t *testing.T) {
 	var doc FlowSchemaDocument
 	if err := yaml.Unmarshal([]byte(`
@@ -618,6 +640,65 @@ pins:
 	}
 	if got := schema.Pins.Outputs.Events[0]; got != "check.passed" {
 		t.Fatalf("Outputs.Events[0] = %q", got)
+	}
+}
+
+func TestSystemNodeContractDecode_PreservesSupportedTopLevelFields(t *testing.T) {
+	var node SystemNodeContract
+	if err := yaml.Unmarshal([]byte(`
+id: worker
+description: Worker node
+execution_type: system_node
+subscribes_to: [task.requested]
+produces: [task.completed]
+state_table: worker_state
+state_schema:
+  fields:
+    count:
+      type: integer
+timers:
+  - id: task_timeout
+    event: timer.task.timeout
+    delay: 1m
+gate_state:
+  ready: Worker is ready
+event_handlers:
+  task.requested:
+    advances_to: done
+`), &node); err != nil {
+		t.Fatalf("yaml.Unmarshal: %v", err)
+	}
+	if got, want := strings.TrimSpace(node.StateTable), "worker_state"; got != want {
+		t.Fatalf("StateTable = %q, want %q", got, want)
+	}
+	if _, ok := node.EventHandlers["task.requested"]; !ok {
+		t.Fatalf("task.requested handler missing: %#v", node.EventHandlers)
+	}
+	if len(node.StateSchema.Fields) != 1 {
+		t.Fatalf("StateSchema fields = %#v, want one field", node.StateSchema.Fields)
+	}
+}
+
+func TestSystemNodeContractDecode_RejectsRetiredAndUnsupportedTopLevelFields(t *testing.T) {
+	tests := []struct {
+		name    string
+		field   string
+		wantErr string
+	}{
+		{name: "permissions", field: "permissions: [create_flow_instance]", wantErr: "RETIRED"},
+		{name: "implementation", field: "implementation: builtin", wantErr: "RETIRED"},
+		{name: "owned_transitions", field: "owned_transitions: [ticket-open]", wantErr: "RETIRED"},
+		{name: "idempotency_table", field: "idempotency_table: worker_idempotency", wantErr: "RETIRED"},
+		{name: "unknown", field: "legacy_owner: worker", wantErr: "UNDEFINED-FIELD"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var node SystemNodeContract
+			err := yaml.Unmarshal([]byte("id: worker\n"+tc.field+"\n"), &node)
+			if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("yaml.Unmarshal error = %v, want %q", err, tc.wantErr)
+			}
+		})
 	}
 }
 

--- a/internal/runtime/testcases/system_node_reliability_test.go
+++ b/internal/runtime/testcases/system_node_reliability_test.go
@@ -6,9 +6,6 @@ func TestGenericBundle_SystemNodeReliabilityPatterns(t *testing.T) {
 	bundle := loadGenericSwarmBundle(t)
 	for _, nodeID := range []string{"intake-router", "processing-node", "delivery-node"} {
 		node := bundle.Nodes[nodeID]
-		if node.IdempotencyTable == "" {
-			t.Fatalf("expected idempotency table for %s", nodeID)
-		}
 		if node.StateTable == "" {
 			t.Fatalf("expected state table for %s", nodeID)
 		}

--- a/internal/runtime/testdata/generic-swarm-bundle/flows/delivery/nodes.yaml
+++ b/internal/runtime/testdata/generic-swarm-bundle/flows/delivery/nodes.yaml
@@ -1,7 +1,6 @@
 delivery-node:
   id: delivery-node
   execution_type: system_node
-  idempotency_table: delivery_node_idempotency
   state_table: delivery_node_state
   subscribes_to:
     - item.completed

--- a/internal/runtime/testdata/generic-swarm-bundle/flows/intake/nodes.yaml
+++ b/internal/runtime/testdata/generic-swarm-bundle/flows/intake/nodes.yaml
@@ -1,7 +1,6 @@
 intake-router:
   id: intake-router
   execution_type: system_node
-  idempotency_table: intake_router_idempotency
   state_table: intake_router_state
   subscribes_to:
     - item.created

--- a/internal/runtime/testdata/generic-swarm-bundle/flows/processing/nodes.yaml
+++ b/internal/runtime/testdata/generic-swarm-bundle/flows/processing/nodes.yaml
@@ -1,7 +1,6 @@
 processing-node:
   id: processing-node
   execution_type: system_node
-  idempotency_table: processing_node_idempotency
   state_table: processing_node_state
   subscribes_to:
     - item.review_requested

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -153,11 +153,13 @@ vocabulary:
 contract_formats:
   description: Canonical format for all flow contract files.
   loader_defaults:
-    description: Fields that are optional in contract YAML because the loader derives them from context.
+    description: Fields and identifiers that the loader derives from context. Entries marked non-authorable are not accepted
+      as public YAML fields.
     schema_name: Optional. If omitted, derived from the directory name of the flow package. A flow at flows/intake/ gets
       name "intake" automatically.
-    schema_namespace: Optional. If omitted, derived from the flow path relative to root. A flow at flows/intake/ gets namespace
-      "intake". Root flow gets empty namespace.
+    flow_namespace: Non-authorable. Derived from the flow path relative to root. A flow at flows/intake/ gets namespace "intake".
+      Root flow gets empty namespace. Public schema.yaml namespace override fields, including namespace, namespace_prefix,
+      and namespace_rule, are not accepted.
     agent_id: 'Optional. If omitted, the YAML map key IS the agent ID. agents.yaml uses map keys as canonical identifiers:
       {"classifier-agent": {model: regular, ...}} means agent_id = "classifier-agent". Explicit id field overrides the
       map key if present, but this is discouraged. Under agent_identity_model.current_supported_posture this authored
@@ -2114,7 +2116,6 @@ handler_specification:
         state_table: string — table name for node state persistence
         timers: list of timer declarations (see timer_model)
         gate_state: map — gate field definitions for this node (boolean flags on entity)
-        permissions: list of platform permissions this node requires (e.g., create_flow_instance)
       effective_semantics:
         id: YAML map key, with same-value explicit id accepted during migration
         execution_type: system_node
@@ -4352,7 +4353,7 @@ engine:
       scope: contract
       trigger: A declaration uses an unsupported or malformed field in a fail-closed contract surface. This includes node
         top-level fields outside the defined node_fields set (id, execution_type, description, subscribes_to, event_handlers,
-        state_schema, state_table, timers, gate_state, permissions, produces) and malformed external tool-provider dispatch
+        state_schema, state_table, timers, gate_state, produces) and malformed external tool-provider dispatch
         rate-limit declarations on HTTP tools, MCP servers, or policy.web_search_provider.
       when: boot-only
     - id: policy_conflict_detection

--- a/tests/tier11-flow-composition/test-data-pin-wiring/flows/processor/schema.yaml
+++ b/tests/tier11-flow-composition/test-data-pin-wiring/flows/processor/schema.yaml
@@ -1,5 +1,4 @@
 name: processor
-namespace: processor
 initial_state: waiting
 terminal_states: [finished]
 states: [waiting, finished]

--- a/tests/tier11-flow-composition/test-data-pin-wiring/schema.yaml
+++ b/tests/tier11-flow-composition/test-data-pin-wiring/schema.yaml
@@ -1,5 +1,4 @@
 name: test-data-pin-wiring
-namespace: test-data-pin-wiring
 initial_state: idle
 terminal_states: [done]
 states: [idle, configured, done]

--- a/tests/tier11-flow-composition/test-data-pin-write-conflict/flows/flow-a/schema.yaml
+++ b/tests/tier11-flow-composition/test-data-pin-write-conflict/flows/flow-a/schema.yaml
@@ -1,5 +1,4 @@
 name: flow-a
-namespace: flow-a
 initial_state: idle
 terminal_states: [done]
 states: [idle, done]

--- a/tests/tier11-flow-composition/test-data-pin-write-conflict/flows/flow-b/schema.yaml
+++ b/tests/tier11-flow-composition/test-data-pin-write-conflict/flows/flow-b/schema.yaml
@@ -1,5 +1,4 @@
 name: flow-b
-namespace: flow-b
 initial_state: idle
 terminal_states: [done]
 states: [idle, done]

--- a/tests/tier11-flow-composition/test-data-pin-write-conflict/schema.yaml
+++ b/tests/tier11-flow-composition/test-data-pin-write-conflict/schema.yaml
@@ -1,5 +1,4 @@
 name: test-data-pin-write-conflict
-namespace: test-data-pin-write-conflict
 initial_state: idle
 terminal_states: [done]
 states: [idle, done]

--- a/tests/tier11-flow-composition/test-dynamic-flow-instance/flows/worker/schema.yaml
+++ b/tests/tier11-flow-composition/test-dynamic-flow-instance/flows/worker/schema.yaml
@@ -1,5 +1,4 @@
 name: worker
-namespace: worker
 mode: template
 instance:
   by: worker_id

--- a/tests/tier11-flow-composition/test-dynamic-flow-instance/nodes.yaml
+++ b/tests/tier11-flow-composition/test-dynamic-flow-instance/nodes.yaml
@@ -17,8 +17,6 @@ orchestrator:
         fields:
           worker_id: payload.worker_id
       advances_to: spawned
-  permissions:
-  - create_flow_instance
 
 assigner:
   id: assigner

--- a/tests/tier11-flow-composition/test-dynamic-flow-instance/schema.yaml
+++ b/tests/tier11-flow-composition/test-dynamic-flow-instance/schema.yaml
@@ -1,5 +1,4 @@
 name: test-dynamic-flow-instance
-namespace: test-dynamic-flow-instance
 initial_state: pending
 terminal_states: [done]
 states: [pending, spawned, done]

--- a/tests/tier11-flow-composition/test-tool-override/flows/child/schema.yaml
+++ b/tests/tier11-flow-composition/test-tool-override/flows/child/schema.yaml
@@ -1,5 +1,4 @@
 name: child
-namespace: child
 initial_state: idle
 terminal_states: [done]
 states: [idle, done]

--- a/tests/tier11-flow-composition/test-tool-override/schema.yaml
+++ b/tests/tier11-flow-composition/test-tool-override/schema.yaml
@@ -1,5 +1,4 @@
 name: test-tool-override
-namespace: test-tool-override
 initial_state: pending
 terminal_states: [done]
 states: [pending, done]

--- a/tests/tier12-runtime-fork/test-non-agent-replay-fail-closed/schema.yaml
+++ b/tests/tier12-runtime-fork/test-non-agent-replay-fail-closed/schema.yaml
@@ -1,5 +1,4 @@
 name: test-non-agent-replay-fail-closed
-namespace: test-non-agent-replay-fail-closed
 initial_state: pending
 terminal_states: [done]
 states: [pending, done]

--- a/tests/tier12-runtime-fork/test-selected-contract-fork-execution/schema.yaml
+++ b/tests/tier12-runtime-fork/test-selected-contract-fork-execution/schema.yaml
@@ -1,5 +1,4 @@
 name: test-selected-contract-fork-execution
-namespace: test-selected-contract-fork-execution
 initial_state: pending
 terminal_states: [done]
 states: [pending, done]

--- a/tests/tier12-runtime-tools/test-flow-data-access/schema.yaml
+++ b/tests/tier12-runtime-tools/test-flow-data-access/schema.yaml
@@ -1,5 +1,4 @@
 name: test-flow-data-access
-namespace: test-flow-data-access
 initial_state: pending
 terminal_states: [done]
 states: [pending, done]

--- a/tests/tier5-flow-lifecycle/test-create-flow-instance-config/flows/worker-flow/schema.yaml
+++ b/tests/tier5-flow-lifecycle/test-create-flow-instance-config/flows/worker-flow/schema.yaml
@@ -1,5 +1,4 @@
 name: worker-flow
-namespace: worker-flow
 mode: template
 instance:
   by: max_retries

--- a/tests/tier5-flow-lifecycle/test-create-flow-instance-duplicate/flows/worker-flow/schema.yaml
+++ b/tests/tier5-flow-lifecycle/test-create-flow-instance-duplicate/flows/worker-flow/schema.yaml
@@ -1,5 +1,4 @@
 name: worker-flow
-namespace: worker-flow
 mode: template
 instance:
   by: entity_id

--- a/tests/tier5-flow-lifecycle/test-create-flow-instance/flows/worker-flow/schema.yaml
+++ b/tests/tier5-flow-lifecycle/test-create-flow-instance/flows/worker-flow/schema.yaml
@@ -1,5 +1,4 @@
 name: worker-flow
-namespace: worker-flow
 mode: template
 instance:
   by: entity_id

--- a/tests/tier5-flow-lifecycle/test-terminal-state-preserves/schema.yaml
+++ b/tests/tier5-flow-lifecycle/test-terminal-state-preserves/schema.yaml
@@ -1,5 +1,4 @@
 name: test-terminal-state-preserves
-namespace: test-terminal-state-preserves
 initial_state: pending
 terminal_states: [done]
 states: [pending, done]

--- a/tests/tier5-flow-lifecycle/test-terminal-state-rejects/schema.yaml
+++ b/tests/tier5-flow-lifecycle/test-terminal-state-rejects/schema.yaml
@@ -1,5 +1,4 @@
 name: test-terminal-state-rejects
-namespace: test-terminal-state-rejects
 initial_state: pending
 terminal_states: [done]
 states: [pending, processing, done]

--- a/tests/tier5-flow-lifecycle/test-timer-cancel/schema.yaml
+++ b/tests/tier5-flow-lifecycle/test-timer-cancel/schema.yaml
@@ -1,5 +1,4 @@
 name: test-timer-cancel
-namespace: test-timer-cancel
 initial_state: waiting
 terminal_states: [done]
 states: [waiting, cancelled, done]

--- a/tests/tier6-event-loop/test-atomicity-guard-rollback/schema.yaml
+++ b/tests/tier6-event-loop/test-atomicity-guard-rollback/schema.yaml
@@ -1,5 +1,4 @@
 name: test-atomicity-guard-rollback
-namespace: test-atomicity-guard-rollback
 initial_state: pending
 terminal_states: [processed]
 states: [pending, processed]

--- a/tests/tier6-event-loop/test-chain-depth-limit/schema.yaml
+++ b/tests/tier6-event-loop/test-chain-depth-limit/schema.yaml
@@ -1,5 +1,4 @@
 name: test-chain-depth-limit
-namespace: test-chain-depth-limit
 initial_state: pending
 terminal_states: [done]
 states: [pending, processing, done]

--- a/tests/tier6-event-loop/test-dead-letter/schema.yaml
+++ b/tests/tier6-event-loop/test-dead-letter/schema.yaml
@@ -1,5 +1,4 @@
 name: test-dead-letter
-namespace: test-dead-letter
 initial_state: pending
 terminal_states: [done]
 states: [pending, done]

--- a/tests/tier6-event-loop/test-guards-pre-handler-state/schema.yaml
+++ b/tests/tier6-event-loop/test-guards-pre-handler-state/schema.yaml
@@ -1,5 +1,4 @@
 name: test-guards-pre-handler-state
-namespace: test-guards-pre-handler-state
 initial_state: active
 terminal_states: [processing]
 states: [active, processing]

--- a/tests/tier7-composition/test-agent-emits-to-node/schema.yaml
+++ b/tests/tier7-composition/test-agent-emits-to-node/schema.yaml
@@ -1,5 +1,4 @@
 name: test-agent-emits-to-node
-namespace: test-agent-emits-to-node
 initial_state: pending
 terminal_states: [done]
 states: [pending, assigned, done]

--- a/tests/tier7-composition/test-cross-flow-subscription/flows/flow-a/schema.yaml
+++ b/tests/tier7-composition/test-cross-flow-subscription/flows/flow-a/schema.yaml
@@ -1,5 +1,4 @@
 name: flow-a
-namespace: flow-a
 initial_state: pending
 terminal_states: [done]
 states: [pending, done]

--- a/tests/tier7-composition/test-cross-flow-subscription/flows/flow-b/schema.yaml
+++ b/tests/tier7-composition/test-cross-flow-subscription/flows/flow-b/schema.yaml
@@ -1,5 +1,4 @@
 name: flow-b
-namespace: flow-b
 initial_state: pending
 terminal_states: [done]
 states: [pending, done]

--- a/tests/tier7-composition/test-cross-flow-subscription/schema.yaml
+++ b/tests/tier7-composition/test-cross-flow-subscription/schema.yaml
@@ -1,5 +1,4 @@
 name: test-cross-flow-subscription
-namespace: test-cross-flow-subscription
 initial_state: pending
 terminal_states: [done]
 states: [pending, done]

--- a/tests/tier7-composition/test-dual-delivery/schema.yaml
+++ b/tests/tier7-composition/test-dual-delivery/schema.yaml
@@ -1,5 +1,4 @@
 name: test-dual-delivery
-namespace: test-dual-delivery
 initial_state: pending
 terminal_states: [done]
 states: [pending, done]

--- a/tests/tier7-composition/test-multi-gate-pipeline/schema.yaml
+++ b/tests/tier7-composition/test-multi-gate-pipeline/schema.yaml
@@ -1,5 +1,4 @@
 name: test-multi-gate-pipeline
-namespace: test-multi-gate-pipeline
 initial_state: pending
 terminal_states: [approved]
 states: [pending, approved]

--- a/tests/tier7-composition/test-wildcard-cross-flow/flows/flow-alpha/schema.yaml
+++ b/tests/tier7-composition/test-wildcard-cross-flow/flows/flow-alpha/schema.yaml
@@ -1,5 +1,4 @@
 name: flow-alpha
-namespace: flow-alpha
 initial_state: pending
 terminal_states: [done]
 states: [pending, done]

--- a/tests/tier7-composition/test-wildcard-cross-flow/flows/flow-beta/schema.yaml
+++ b/tests/tier7-composition/test-wildcard-cross-flow/flows/flow-beta/schema.yaml
@@ -1,5 +1,4 @@
 name: flow-beta
-namespace: flow-beta
 initial_state: pending
 terminal_states: [done]
 states: [pending, done]

--- a/tests/tier7-composition/test-wildcard-cross-flow/schema.yaml
+++ b/tests/tier7-composition/test-wildcard-cross-flow/schema.yaml
@@ -1,5 +1,4 @@
 name: test-wildcard-cross-flow
-namespace: test-wildcard-cross-flow
 initial_state: pending
 terminal_states: [done]
 states: [pending, done]

--- a/tests/tier8-boot-verification/test-boot-emit-mismatch/nodes.yaml
+++ b/tests/tier8-boot-verification/test-boot-emit-mismatch/nodes.yaml
@@ -3,7 +3,6 @@ worker-node:
   execution_type: system_node
   subscribes_to: [task.requested]
   produces: [task.completed]
-  agent: worker
   event_handlers:
     task.requested:
       advances_to: done

--- a/tests/tier8-boot-verification/test-boot-missing-pin/flows/child/schema.yaml
+++ b/tests/tier8-boot-verification/test-boot-missing-pin/flows/child/schema.yaml
@@ -1,5 +1,4 @@
 name: child
-namespace: child
 initial_state: idle
 terminal_states: [done]
 states: [idle, working, done]

--- a/tests/tier8-boot-verification/test-boot-missing-pin/schema.yaml
+++ b/tests/tier8-boot-verification/test-boot-missing-pin/schema.yaml
@@ -1,5 +1,4 @@
 name: test-boot-missing-pin
-namespace: test-boot-missing-pin
 initial_state: pending
 terminal_states: [done]
 states: [pending, done]

--- a/tests/tier8-boot-verification/test-boot-permission-tool-mismatch/schema.yaml
+++ b/tests/tier8-boot-verification/test-boot-permission-tool-mismatch/schema.yaml
@@ -1,5 +1,4 @@
 name: test-boot-permission-tool-mismatch
-namespace: test-boot-permission-tool-mismatch
 initial_state: pending
 terminal_states: [done]
 states: [pending, done]

--- a/tests/tier8-boot-verification/test-boot-prompt-stub/nodes.yaml
+++ b/tests/tier8-boot-verification/test-boot-prompt-stub/nodes.yaml
@@ -3,7 +3,6 @@ stub-agent-node:
   execution_type: system_node
   subscribes_to: [task.requested]
   produces: [task.completed]
-  agent: stub-agent
   event_handlers:
     task.requested:
       advances_to: done

--- a/tests/tier8-boot-verification/test-boot-state-machine-unreachable/schema.yaml
+++ b/tests/tier8-boot-verification/test-boot-state-machine-unreachable/schema.yaml
@@ -1,2 +1,1 @@
 name: test-boot-state-machine-unreachable
-namespace: test-boot-state-machine-unreachable

--- a/tests/tier9-composition-patterns/test-compose-accumulate-compute-branch/schema.yaml
+++ b/tests/tier9-composition-patterns/test-compose-accumulate-compute-branch/schema.yaml
@@ -1,5 +1,4 @@
 name: test-compose-accumulate-compute-branch
-namespace: test-compose-accumulate-compute-branch
 initial_state: collecting
 terminal_states: [high, mid, low]
 states: [collecting, high, mid, low]

--- a/tests/tier9-composition-patterns/test-compose-clear-gates-reenter/schema.yaml
+++ b/tests/tier9-composition-patterns/test-compose-clear-gates-reenter/schema.yaml
@@ -1,5 +1,4 @@
 name: test-compose-clear-gates-reenter
-namespace: test-compose-clear-gates-reenter
 initial_state: reviewing
 terminal_states: [approved, done]
 states: [reviewing, approved, done]

--- a/tests/tier9-composition-patterns/test-compose-create-instance-config/flows/worker/schema.yaml
+++ b/tests/tier9-composition-patterns/test-compose-create-instance-config/flows/worker/schema.yaml
@@ -1,5 +1,4 @@
 name: worker
-namespace: worker
 mode: template
 instance:
   by: name

--- a/tests/tier9-composition-patterns/test-compose-create-instance-config/nodes.yaml
+++ b/tests/tier9-composition-patterns/test-compose-create-instance-config/nodes.yaml
@@ -16,5 +16,3 @@ spawner:
       emit:
         event: spawn.done
         broadcast: true
-  permissions:
-  - create_flow_instance

--- a/tests/tier9-composition-patterns/test-compose-create-instance-config/schema.yaml
+++ b/tests/tier9-composition-patterns/test-compose-create-instance-config/schema.yaml
@@ -1,5 +1,4 @@
 name: test-compose-create-instance-config
-namespace: test-compose-create-instance-config
 initial_state: idle
 terminal_states: [spawned]
 states: [idle, spawned]

--- a/tests/tier9-composition-patterns/test-compose-gate-data-advance-emit/schema.yaml
+++ b/tests/tier9-composition-patterns/test-compose-gate-data-advance-emit/schema.yaml
@@ -1,5 +1,4 @@
 name: test-compose-gate-data-advance-emit
-namespace: test-compose-gate-data-advance-emit
 initial_state: stage_one
 terminal_states: [complete]
 states: [stage_one, stage_two, complete]

--- a/tests/tier9-composition-patterns/test-compose-multi-emit-cross-flow/flows/tracker/schema.yaml
+++ b/tests/tier9-composition-patterns/test-compose-multi-emit-cross-flow/flows/tracker/schema.yaml
@@ -1,5 +1,4 @@
 name: tracker
-namespace: tracker
 initial_state: idle
 terminal_states: [recorded]
 states: [idle, recorded]

--- a/tests/tier9-composition-patterns/test-compose-multi-emit-cross-flow/schema.yaml
+++ b/tests/tier9-composition-patterns/test-compose-multi-emit-cross-flow/schema.yaml
@@ -1,5 +1,4 @@
 name: test-compose-multi-emit-cross-flow
-namespace: test-compose-multi-emit-cross-flow
 initial_state: pending
 terminal_states: [done]
 states: [pending, done]


### PR DESCRIPTION
## Summary
- Make `SystemNodeContract` and `FlowSchemaDocument` enforce strict public top-level YAML allowlists.
- Retire/reject public node fields `permissions`, `implementation`, `owned_transitions`, and `idempotency_table`, and public schema fields `namespace`, `namespace_prefix`, and `namespace_rule`.
- Reconcile `platform-spec.yaml`, including loader-default namespace wording, and migrate checked-in fixtures while preserving supported `state_table` behavior.

Closes #1599

## Governing Refs / Context
- Approved gate: #1599 lead gate decision, approved as the first public field-reconciliation slice.
- `platform-spec.yaml#contract_formats.node_specification.node_fields`
- `platform-spec.yaml#workflow_semantics.validation.invalid_field_detection`
- `platform-spec.yaml#contract_formats.loader_defaults.flow_namespace` records flow namespace as derived and non-authorable.
- `platform-spec.yaml#permissions_model` for agent/tool permissions; this PR does not move those semantics into node YAML.
- Parent/watchlist: #1528 / #1463 remain broader schema-authority trackers.

## Semantic Migration
- New canonical owner: `platform-spec.yaml` public node/schema field allowlists plus strict `SystemNodeContract` and `FlowSchemaDocument` YAML decoders.
- Old public producer/reader/writer paths now invalid: node `permissions`, `implementation`, `owned_transitions`, `idempotency_table`; schema `namespace`, `namespace_prefix`, `namespace_rule`; arbitrary unknown top-level public node/schema fields.
- Production paths checked: root/project/flow `nodes.yaml` loads, root/flow `schema.yaml` loads, runtime `NodeEntries` / `LoadWorkflowNodes` carry-through, bootverify checks, node `state_table` DDL path, and current checked-in fixtures.
- Migration is complete for the #1599 first-slice field reconciliation. Broader generated-schema/spec-vs-struct authority remains tracked by #1528/#1463.

## Proof
- `go test ./internal/runtime/contracts -run 'Test(FlowSchemaDocumentDecode_RejectsRetiredAndUnsupportedTopLevelFields|SystemNodeContractDecode_|LoadWorkflowContractBundleRejectsRetiredPublicNodeAndSchemaFields|LoadWorkflowContractBundleAllowsPublicNodeStateTable)' -count=1 -v`
- `go test ./internal/runtime/contracts ./internal/runtime/testcases ./internal/runtime/bootverify ./cmd/swarm -count=1`
- `go test ./...`

Review-fix rerun after repairing stale `loader_defaults.schema_namespace` wording:
- `go test ./internal/runtime/contracts -run 'Test(FlowSchemaDocumentDecode_RejectsRetiredAndUnsupportedTopLevelFields|SystemNodeContractDecode_|LoadWorkflowContractBundleRejectsRetiredPublicNodeAndSchemaFields|LoadWorkflowContractBundleAllowsPublicNodeStateTable)' -count=1 -v`
- `go test ./...`