### PR TITLE
[agent-f][issue #1596] Retire tool schema aliases

### DIFF
--- a/internal/runtime/contracts/workflow_contract_yaml_schema.go
+++ b/internal/runtime/contracts/workflow_contract_yaml_schema.go
@@ -245,22 +245,18 @@ func (t *ToolSchemaEntry) UnmarshalYAML(node *yaml.Node) error {
 	if t == nil {
 		return nil
 	}
-	type alias ToolSchemaEntry
-	var aux struct {
-		alias      `yaml:",inline"`
-		Parameters *ToolInputSchema `yaml:"parameters"`
-		Returns    *ToolInputSchema `yaml:"returns"`
+	if hasYAMLMappingKey(node, "parameters") {
+		return fmt.Errorf("RETIRED: tool field %q is retired; use input_schema", "parameters")
 	}
+	if hasYAMLMappingKey(node, "returns") {
+		return fmt.Errorf("RETIRED: tool field %q is retired; use output_schema", "returns")
+	}
+	type alias ToolSchemaEntry
+	var aux alias
 	if err := node.Decode(&aux); err != nil {
 		return err
 	}
-	*t = ToolSchemaEntry(aux.alias)
-	if aux.Parameters != nil && t.InputSchema.Type == "" && len(t.InputSchema.Properties) == 0 && len(t.InputSchema.Required) == 0 {
-		t.InputSchema = *aux.Parameters
-	}
-	if aux.Returns != nil && t.OutputSchema.Type == "" && len(t.OutputSchema.Properties) == 0 && len(t.OutputSchema.Required) == 0 {
-		t.OutputSchema = *aux.Returns
-	}
+	*t = ToolSchemaEntry(aux)
 	t.HandlerType = strings.TrimSpace(t.HandlerType)
 	t.Permission = strings.TrimSpace(t.Permission)
 	t.RequiredPermission = strings.TrimSpace(t.RequiredPermission)

--- a/internal/runtime/contracts/workflow_contracts_tree_test.go
+++ b/internal/runtime/contracts/workflow_contracts_tree_test.go
@@ -180,6 +180,38 @@ flow_lookup:
 	}
 }
 
+func TestMigratedToolFixturesPreserveQueryInputSchema(t *testing.T) {
+	repoRoot := repoRootForContractsTest(t)
+	paths := []string{
+		filepath.Join("tests", "tier8-boot-verification", "test-boot-permission-tool-mismatch", "tools.yaml"),
+		filepath.Join("tests", "tier11-flow-composition", "test-child-flow-tool-inherit", "tools.yaml"),
+		filepath.Join("tests", "tier11-flow-composition", "test-tool-override", "tools.yaml"),
+		filepath.Join("tests", "tier11-flow-composition", "test-tool-override", "flows", "child", "tools.yaml"),
+	}
+	for _, rel := range paths {
+		t.Run(rel, func(t *testing.T) {
+			var tools map[string]ToolSchemaEntry
+			if err := loadYAMLFile(filepath.Join(repoRoot, rel), &tools); err != nil {
+				t.Fatalf("load %s: %v", rel, err)
+			}
+			entry, ok := tools["lookup_data"]
+			if !ok {
+				t.Fatalf("lookup_data missing from %s: %#v", rel, tools)
+			}
+			if got := strings.TrimSpace(entry.InputSchema.Type); got != "object" {
+				t.Fatalf("%s input_schema.type = %q, want object", rel, got)
+			}
+			query, ok := entry.InputSchema.Properties["query"]
+			if !ok {
+				t.Fatalf("%s input_schema properties = %#v, want query", rel, entry.InputSchema.Properties)
+			}
+			if got := strings.TrimSpace(query.Type); got != "string" {
+				t.Fatalf("%s query.type = %q, want string", rel, got)
+			}
+		})
+	}
+}
+
 func TestNodeEventHandler_LocalizesCrossFlowQualifiedInputEventToLocalHandler(t *testing.T) {
 	repoRoot := repoRootForContractsTest(t)
 	root := t.TempDir()

--- a/internal/runtime/contracts/workflow_contracts_tree_test.go
+++ b/internal/runtime/contracts/workflow_contracts_tree_test.go
@@ -101,6 +101,85 @@ func TestLoadWorkflowContractBundleBuildsRecursiveFlowTree(t *testing.T) {
 	}
 }
 
+func TestLoadWorkflowContractBundleLoadsCanonicalToolSchemasFromRootAndFlowTools(t *testing.T) {
+	repoRoot := repoRootForContractsTest(t)
+	root := t.TempDir()
+
+	writeFixtureFile(t, filepath.Join(root, "package.yaml"), `
+name: canonical-tool-schema
+version: "1.0.0"
+flows:
+  - id: worker
+    flow: worker
+    mode: static
+`)
+	writeFixtureFile(t, filepath.Join(root, "schema.yaml"), "name: canonical-tool-schema\n")
+	writeFixtureFile(t, filepath.Join(root, "tools.yaml"), `
+root_lookup:
+  description: Root-level lookup tool.
+  handler_type: http
+  input_schema:
+    type: object
+    required: [query]
+    properties:
+      query:
+        type: string
+  output_schema:
+    type: object
+    properties:
+      result:
+        type: string
+`)
+	writeFixtureFile(t, filepath.Join(root, "flows", "worker", "schema.yaml"), `
+name: worker
+mode: static
+`)
+	writeFixtureFile(t, filepath.Join(root, "flows", "worker", "tools.yaml"), `
+flow_lookup:
+  description: Flow-level lookup tool.
+  handler_type: http
+  input_schema:
+    type: object
+    required: [flow_id]
+    properties:
+      flow_id:
+        type: string
+  output_schema:
+    type: object
+    properties:
+      accepted:
+        type: boolean
+`)
+
+	bundle, err := LoadWorkflowContractBundleWithOverrides(repoRoot, root, "")
+	if err != nil {
+		t.Fatalf("LoadWorkflowContractBundleWithOverrides: %v", err)
+	}
+	rootTool, ok := bundle.Tools["root_lookup"]
+	if !ok {
+		t.Fatalf("expected root tool to load, got keys %#v", sortedContractKeys(bundle.Tools))
+	}
+	if got := strings.TrimSpace(rootTool.InputSchema.Type); got != "object" {
+		t.Fatalf("root input schema type = %q, want object", got)
+	}
+	if _, ok := rootTool.InputSchema.Properties["query"]; !ok {
+		t.Fatalf("root input schema properties = %#v, want query", rootTool.InputSchema.Properties)
+	}
+	if _, ok := rootTool.OutputSchema.Properties["result"]; !ok {
+		t.Fatalf("root output schema properties = %#v, want result", rootTool.OutputSchema.Properties)
+	}
+	flowTool, ok := bundle.Tools["flow_lookup"]
+	if !ok {
+		t.Fatalf("expected flow tool to load, got keys %#v", sortedContractKeys(bundle.Tools))
+	}
+	if _, ok := flowTool.InputSchema.Properties["flow_id"]; !ok {
+		t.Fatalf("flow input schema properties = %#v, want flow_id", flowTool.InputSchema.Properties)
+	}
+	if _, ok := flowTool.OutputSchema.Properties["accepted"]; !ok {
+		t.Fatalf("flow output schema properties = %#v, want accepted", flowTool.OutputSchema.Properties)
+	}
+}
+
 func TestNodeEventHandler_LocalizesCrossFlowQualifiedInputEventToLocalHandler(t *testing.T) {
 	repoRoot := repoRootForContractsTest(t)
 	root := t.TempDir()
@@ -507,6 +586,63 @@ additionalProperties: false
 	}
 	if got := strings.TrimSpace(schema.Properties["metadata"].AdditionalProperties.Schema.Type); got != "string" {
 		t.Fatalf("expected nested additionalProperties schema type string, got %q", got)
+	}
+}
+
+func TestToolSchemaEntryDecode_RejectsRetiredSchemaAliases(t *testing.T) {
+	tests := []struct {
+		name     string
+		body     string
+		want     string
+		wantNext string
+	}{
+		{
+			name: "parameters",
+			body: `
+lookup:
+  description: Lookup data.
+  parameters:
+    type: object
+`,
+			want:     "parameters",
+			wantNext: "input_schema",
+		},
+		{
+			name: "returns",
+			body: `
+lookup:
+  description: Lookup data.
+  returns:
+    type: object
+`,
+			want:     "returns",
+			wantNext: "output_schema",
+		},
+		{
+			name: "canonical plus alias",
+			body: `
+lookup:
+  description: Lookup data.
+  input_schema:
+    type: object
+  parameters:
+    type: object
+`,
+			want:     "parameters",
+			wantNext: "input_schema",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var tools map[string]ToolSchemaEntry
+			err := loadYAMLBytes([]byte(tc.body), &tools)
+			if err == nil ||
+				!strings.Contains(err.Error(), "RETIRED") ||
+				!strings.Contains(err.Error(), tc.want) ||
+				!strings.Contains(err.Error(), tc.wantNext) {
+				t.Fatalf("load tool schema error = %v, want RETIRED %s -> %s", err, tc.want, tc.wantNext)
+			}
+		})
 	}
 }
 

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -5139,8 +5139,9 @@ tool_model:
       handler_type: string — platform_builtin | mcp | http. Default http.
       input_schema: object — parameter names and types the tool accepts
       output_schema: object — field names and types the tool returns
-      parameters: object — alias for input_schema (accepted by loader)
-      returns: object — alias for output_schema (accepted by loader)
+    retired_fields:
+      parameters: RETIRED — use input_schema
+      returns: RETIRED — use output_schema
     http_fields:
       http: object — HTTP request template (see http_tool_definition.schema.http_block)
       response_mapping: object — maps response fields to output fields

--- a/tests/tier11-flow-composition/test-child-flow-tool-inherit/tools.yaml
+++ b/tests/tier11-flow-composition/test-child-flow-tool-inherit/tools.yaml
@@ -1,9 +1,11 @@
 lookup_data:
   description: Looks up data from the knowledge base.
   input_schema:
-    query:
-      type: string
-      description: The search query.
+    type: object
+    properties:
+      query:
+        type: string
+        description: The search query.
   output_schema:
     type: string
     description: The search result.

--- a/tests/tier11-flow-composition/test-child-flow-tool-inherit/tools.yaml
+++ b/tests/tier11-flow-composition/test-child-flow-tool-inherit/tools.yaml
@@ -1,9 +1,9 @@
 lookup_data:
   description: Looks up data from the knowledge base.
-  parameters:
+  input_schema:
     query:
       type: string
       description: The search query.
-  returns:
+  output_schema:
     type: string
     description: The search result.

--- a/tests/tier11-flow-composition/test-tool-override/flows/child/tools.yaml
+++ b/tests/tier11-flow-composition/test-tool-override/flows/child/tools.yaml
@@ -1,10 +1,10 @@
 lookup_data:
   description: Looks up data from the knowledge base (child v2 override).
   endpoint: /api/v2/lookup
-  parameters:
+  input_schema:
     query:
       type: string
       description: The search query.
-  returns:
+  output_schema:
     type: string
     description: The search result.

--- a/tests/tier11-flow-composition/test-tool-override/flows/child/tools.yaml
+++ b/tests/tier11-flow-composition/test-tool-override/flows/child/tools.yaml
@@ -2,9 +2,11 @@ lookup_data:
   description: Looks up data from the knowledge base (child v2 override).
   endpoint: /api/v2/lookup
   input_schema:
-    query:
-      type: string
-      description: The search query.
+    type: object
+    properties:
+      query:
+        type: string
+        description: The search query.
   output_schema:
     type: string
     description: The search result.

--- a/tests/tier11-flow-composition/test-tool-override/tools.yaml
+++ b/tests/tier11-flow-composition/test-tool-override/tools.yaml
@@ -2,9 +2,11 @@ lookup_data:
   description: Looks up data from the knowledge base (root v1).
   endpoint: /api/v1/lookup
   input_schema:
-    query:
-      type: string
-      description: The search query.
+    type: object
+    properties:
+      query:
+        type: string
+        description: The search query.
   output_schema:
     type: string
     description: The search result.

--- a/tests/tier11-flow-composition/test-tool-override/tools.yaml
+++ b/tests/tier11-flow-composition/test-tool-override/tools.yaml
@@ -1,10 +1,10 @@
 lookup_data:
   description: Looks up data from the knowledge base (root v1).
   endpoint: /api/v1/lookup
-  parameters:
+  input_schema:
     query:
       type: string
       description: The search query.
-  returns:
+  output_schema:
     type: string
     description: The search result.

--- a/tests/tier8-boot-verification/test-boot-permission-tool-mismatch/tools.yaml
+++ b/tests/tier8-boot-verification/test-boot-permission-tool-mismatch/tools.yaml
@@ -2,7 +2,7 @@ lookup_data:
   description: Looks up external data
   type: custom
   permission: external_api_access
-  parameters:
+  input_schema:
     query:
       type: string
       description: Search query

--- a/tests/tier8-boot-verification/test-boot-permission-tool-mismatch/tools.yaml
+++ b/tests/tier8-boot-verification/test-boot-permission-tool-mismatch/tools.yaml
@@ -3,6 +3,8 @@ lookup_data:
   type: custom
   permission: external_api_access
   input_schema:
-    query:
-      type: string
-      description: Search query
+    type: object
+    properties:
+      query:
+        type: string
+        description: Search query


### PR DESCRIPTION
Part of #1596

## Summary
- Hard-reject retired `tools.yaml` tool schema aliases `parameters` and `returns` in `ToolSchemaEntry.UnmarshalYAML`.
- Keep `input_schema` and `output_schema` as the only accepted authored fields for custom tool argument/result schemas.
- Reconcile `platform-spec.yaml` and migrate checked-in `tools.yaml` fixtures away from the retired aliases.
- Add positive root/flow loader proof for canonical fields and negative decoder proof for `parameters`, `returns`, and canonical+alias dual spelling.

## Governing Refs / Context
- Pre-audit: #1596 comment https://github.com/division-sh/swarm/issues/1596#issuecomment-4867739061
- Gate: #1596 comment https://github.com/division-sh/swarm/issues/1596#issuecomment-4867809228
- Exact spec references: `platform-spec.yaml#tool_model.custom_tool_schema.common_optional_fields`, `platform-spec.yaml#tool_model.http_tool_definition`, `platform-spec.yaml#tool_model.agent_tool_filtering`.
- Parent trackers: #1528 / #1463.

## Semantic Migration
- New canonical owner: `platform-spec.yaml#tool_model.custom_tool_schema.common_optional_fields.input_schema` and `.output_schema`, implemented by `internal/runtime/contracts.ToolSchemaEntry.UnmarshalYAML` into `InputSchema` / `OutputSchema`.
- Old reader path now invalid: public `tools.yaml` aliases `parameters` and `returns` are retired and fail closed with a `RETIRED` error.
- Production paths checked for surviving old behavior: root/project `tools.yaml` loader, flow `tools.yaml` loader, downstream tool registry/schema consumers, bootverify, generated-schema closure, and checked-in tier fixtures.
- Migration completeness: complete for the selected tool-schema alias class. #1596 remains open for separate alias/legacy syntax siblings.

## Validation
- `go test ./internal/runtime/contracts -run 'TestLoadWorkflowContractBundleLoadsCanonicalToolSchemasFromRootAndFlowTools|TestToolSchemaEntryDecode_RejectsRetiredSchemaAliases' -count=1 -v`
- `go test ./internal/runtime/contracts ./internal/runtime/tools ./internal/runtime/bootverify ./cmd/swarm -count=1`
- `go test ./...`