### PR TITLE
[agent-b][issue #1612] Add local target doctor diagnostics

### DIFF
--- a/cmd/swarm/cli.go
+++ b/cmd/swarm/cli.go
@@ -73,6 +73,7 @@ func newRootCommandWithOptions(ctx context.Context, repo string, out, errOut io.
 	}
 	cmd.SetOut(out)
 	cmd.SetErr(errOut)
+	cmd.PersistentFlags().StringVar(&opts.swarmDir, "swarm-dir", opts.swarmDir, "Path to the Swarm user/global state directory")
 	cmd.AddCommand(
 		newServeCommand(ctx, repo, opts.runServe),
 		newRunCommand(repo, opts),

--- a/cmd/swarm/cli_api.go
+++ b/cmd/swarm/cli_api.go
@@ -36,6 +36,7 @@ type rootCommandOptions struct {
 	// those paths have already resolved their own API endpoint semantics.
 	apiRPCEndpointOverride string
 	apiTokenFile           string
+	swarmDir               string
 	httpClient             *http.Client
 	input                  io.Reader
 	stdinIsTerminal        func() bool
@@ -90,6 +91,7 @@ type cliAPISettings struct {
 type cliAPIConfigFile struct {
 	APIServer          string `yaml:"api_server"`
 	APITokenFile       string `yaml:"api_token_file"`
+	SwarmDir           string `yaml:"swarm_dir"`
 	ContractsPath      string `yaml:"contracts_path"`
 	PlatformSpecPath   string `yaml:"platform_spec_path"`
 	ServeAPIListenAddr string `yaml:"serve_api_listen_addr"`
@@ -293,7 +295,7 @@ func parseCLIAPIConfigFile(configPath string, raw []byte) (cliAPIConfigFile, err
 	}
 	for key, value := range decoded {
 		switch key {
-		case "api_server", "api_token_file", "contracts_path", "platform_spec_path", "serve_api_listen_addr", "serve_mcp_listen_addr":
+		case "api_server", "api_token_file", "swarm_dir", "contracts_path", "platform_spec_path", "serve_api_listen_addr", "serve_mcp_listen_addr":
 			if value == nil {
 				continue
 			}

--- a/cmd/swarm/cli_api.go
+++ b/cmd/swarm/cli_api.go
@@ -92,6 +92,7 @@ type cliAPIConfigFile struct {
 	APIServer          string `yaml:"api_server"`
 	APITokenFile       string `yaml:"api_token_file"`
 	SwarmDir           string `yaml:"swarm_dir"`
+	SwarmDirSet        bool   `yaml:"-"`
 	ContractsPath      string `yaml:"contracts_path"`
 	PlatformSpecPath   string `yaml:"platform_spec_path"`
 	ServeAPIListenAddr string `yaml:"serve_api_listen_addr"`
@@ -310,6 +311,7 @@ func parseCLIAPIConfigFile(configPath string, raw []byte) (cliAPIConfigFile, err
 	if err := yaml.Unmarshal(raw, &cfg); err != nil {
 		return cliAPIConfigFile{}, &cliAPIValidationError{message: fmt.Sprintf("decode CLI config %s: %v", configPath, err)}
 	}
+	_, cfg.SwarmDirSet = decoded["swarm_dir"]
 	return cfg, nil
 }
 

--- a/cmd/swarm/cli_api_flags.go
+++ b/cmd/swarm/cli_api_flags.go
@@ -74,6 +74,7 @@ func cliAPIConnectionFlagAfterLeafCommand(prefix []string) bool {
 		{"control", "stop"},
 		{"control", "nuke"},
 		{"fork"},
+		{"doctor"},
 	}
 	for _, command := range leafCommands {
 		if argsHaveCommandPrefix(prefix, command) {

--- a/cmd/swarm/cli_api_flags.go
+++ b/cmd/swarm/cli_api_flags.go
@@ -38,6 +38,7 @@ func firstCLIAPIConnectionFlagIndex(args []string) (int, string) {
 }
 
 func cliAPIConnectionFlagAfterLeafCommand(prefix []string) bool {
+	prefix = stripRootPersistentFlagsForCLIAPIPlacement(prefix)
 	leafCommands := [][]string{
 		{"runs"},
 		{"status"},
@@ -82,6 +83,26 @@ func cliAPIConnectionFlagAfterLeafCommand(prefix []string) bool {
 		}
 	}
 	return false
+}
+
+func stripRootPersistentFlagsForCLIAPIPlacement(args []string) []string {
+	if len(args) == 0 {
+		return args
+	}
+	stripped := make([]string, 0, len(args))
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+		switch {
+		case arg == "--swarm-dir" && i+1 < len(args):
+			i++
+			continue
+		case strings.HasPrefix(arg, "--swarm-dir="):
+			continue
+		default:
+			stripped = append(stripped, arg)
+		}
+	}
+	return stripped
 }
 
 func argsHaveCommandPrefix(args, command []string) bool {

--- a/cmd/swarm/cli_api_resolver_test.go
+++ b/cmd/swarm/cli_api_resolver_test.go
@@ -263,6 +263,19 @@ func TestCLISwarmDirConfigValidation(t *testing.T) {
 	}
 }
 
+func TestCLISwarmDirBlankConfigFailsClosed(t *testing.T) {
+	isolateCLIAPIConfigEnv(t)
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	if err := os.WriteFile(path, []byte("swarm_dir: \"  \"\n"), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	t.Setenv("SWARM_CONFIG", path)
+
+	if _, err := resolveCLISwarmDir(cliSwarmDirOptions{}); err == nil || !strings.Contains(err.Error(), "config swarm_dir must be non-empty") {
+		t.Fatalf("resolveCLISwarmDir err = %v, want blank config swarm_dir validation", err)
+	}
+}
+
 func TestCLIAPIResolverIgnoresServeListenerConfigKeys(t *testing.T) {
 	isolateCLIAPIConfigEnv(t)
 	tokenFile := writeCLIAPITokenFile(t, "config-token")

--- a/cmd/swarm/cli_api_resolver_test.go
+++ b/cmd/swarm/cli_api_resolver_test.go
@@ -194,6 +194,7 @@ func TestCLIAPIResolverToleratesContractPathConfigKeys(t *testing.T) {
 	t.Setenv("SWARM_CONFIG", writeCLIAPIConfigFile(t, map[string]string{
 		"api_server":         "http://127.0.0.1:4444",
 		"api_token_file":     tokenFile,
+		"swarm_dir":          filepath.Join(t.TempDir(), "state"),
 		"contracts_path":     "contracts-from-config",
 		"platform_spec_path": "platform-from-config.yaml",
 	}))
@@ -207,6 +208,58 @@ func TestCLIAPIResolverToleratesContractPathConfigKeys(t *testing.T) {
 	}
 	if client.token != "config-token" {
 		t.Fatalf("token = %q", client.token)
+	}
+}
+
+func TestCLISwarmDirResolutionPrecedence(t *testing.T) {
+	isolateCLIAPIConfigEnv(t)
+	configDir := filepath.Join(t.TempDir(), "config-state")
+	flagDir := filepath.Join(t.TempDir(), "flag-state")
+	t.Setenv("SWARM_CONFIG", writeCLIAPIConfigFile(t, map[string]string{
+		"swarm_dir": configDir,
+	}))
+	t.Setenv("SWARM_DIR", filepath.Join(t.TempDir(), "must-not-use"))
+	t.Setenv("SWARM_HOME", filepath.Join(t.TempDir(), "must-not-use"))
+
+	got, err := resolveCLISwarmDir(cliSwarmDirOptions{SwarmDir: flagDir, SwarmDirFlagSet: true})
+	if err != nil {
+		t.Fatalf("resolve flag swarm dir: %v", err)
+	}
+	if got.Path != flagDir || got.Source != "--swarm-dir" {
+		t.Fatalf("flag swarm dir = %#v, want %q from --swarm-dir", got, flagDir)
+	}
+
+	got, err = resolveCLISwarmDir(cliSwarmDirOptions{})
+	if err != nil {
+		t.Fatalf("resolve config swarm dir: %v", err)
+	}
+	if got.Path != configDir || got.Source != "config swarm_dir" {
+		t.Fatalf("config swarm dir = %#v, want %q from config swarm_dir", got, configDir)
+	}
+
+	t.Setenv("SWARM_CONFIG", "")
+	got, err = resolveCLISwarmDir(cliSwarmDirOptions{})
+	if err != nil {
+		t.Fatalf("resolve default swarm dir: %v", err)
+	}
+	if !strings.HasSuffix(got.Path, filepath.Join(".swarm")) || got.Source != "default ~/.swarm" {
+		t.Fatalf("default swarm dir = %#v, want ~/.swarm default", got)
+	}
+	if strings.Contains(got.Path, "must-not-use") {
+		t.Fatalf("default swarm dir consumed retired env source: %#v", got)
+	}
+}
+
+func TestCLISwarmDirConfigValidation(t *testing.T) {
+	isolateCLIAPIConfigEnv(t)
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	if err := os.WriteFile(path, []byte("swarm_dir: [bad]\n"), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	t.Setenv("SWARM_CONFIG", path)
+
+	if _, err := resolveCLISwarmDir(cliSwarmDirOptions{}); err == nil || !strings.Contains(err.Error(), "CLI config swarm_dir must be a string") {
+		t.Fatalf("resolveCLISwarmDir err = %v, want non-string swarm_dir validation", err)
 	}
 }
 
@@ -706,7 +759,7 @@ func writeCLIAPITokenFile(t *testing.T, token string) string {
 func writeCLIAPIConfigFile(t *testing.T, values map[string]string) string {
 	t.Helper()
 	var body strings.Builder
-	for _, key := range []string{"api_server", "api_token_file", "contracts_path", "platform_spec_path", "serve_api_listen_addr", "serve_mcp_listen_addr"} {
+	for _, key := range []string{"api_server", "api_token_file", "swarm_dir", "contracts_path", "platform_spec_path", "serve_api_listen_addr", "serve_mcp_listen_addr"} {
 		if value, ok := values[key]; ok {
 			body.WriteString(key)
 			body.WriteString(": ")

--- a/cmd/swarm/doctor.go
+++ b/cmd/swarm/doctor.go
@@ -13,12 +13,15 @@ type doctorOptions struct {
 	backend             string
 	contractsPath       string
 	dataSource          string
+	dataSourceSet       bool
 	workspaceBackend    string
 	workspaceBackendSet bool
 	platformSpecPath    string
 	apiListenAddr       string
 	mcpListenAddr       string
+	target              bool
 	asJSON              bool
+	apiOptions          rootCommandOptions
 }
 
 func newDoctorCommand(ctx context.Context, repo string) *cobra.Command {
@@ -31,11 +34,18 @@ func newDoctorCommand(ctx context.Context, repo string) *cobra.Command {
 		Short: "Diagnose local Swarm runtime prerequisites.",
 		Args:  cobra.NoArgs,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
+			if cliAPIConnectionFlagsChanged(cmd) && !opts.target {
+				return fmt.Errorf("--api-server and --api-token-file require --target")
+			}
 			if cmd.Flags().Changed("data") {
 				opts.dataSource = strings.TrimSpace(opts.dataSource)
 				if opts.dataSource == "" {
 					return fmt.Errorf("--data must be non-empty")
 				}
+			}
+			opts.dataSourceSet = cmd.Flags().Changed("data")
+			if opts.target {
+				return nil
 			}
 			if cmd.Flags().Changed("workspace-backend") {
 				backend, err := normalizeWorkspaceBackend(opts.workspaceBackend, "--workspace-backend")
@@ -76,11 +86,16 @@ func newDoctorCommand(ctx context.Context, repo string) *cobra.Command {
 	cmd.Flags().StringVar(&opts.platformSpecPath, "platform-spec", opts.platformSpecPath, "Path to platform spec yaml")
 	cmd.Flags().StringVar(&opts.apiListenAddr, "api-listen-addr", opts.apiListenAddr, "HTTP bind address to preflight for API, WebSocket, health, and readiness routes")
 	cmd.Flags().StringVar(&opts.mcpListenAddr, "mcp-listen-addr", opts.mcpListenAddr, "HTTP bind address to preflight for MCP and tools routes")
+	cmd.Flags().BoolVar(&opts.target, "target", false, "Explain local target, state directory, project, and context resolution without runtime preflight")
 	cmd.Flags().BoolVar(&opts.asJSON, "json", false, "Render the diagnostic report as JSON")
+	bindCLIAPIConnectionFlags(cmd, &opts.apiOptions)
 	return cmd
 }
 
 func runDoctorCommand(ctx context.Context, repo string, cmd *cobra.Command, opts doctorOptions) error {
+	if opts.target {
+		return runDoctorTargetCommand(repo, cmd, opts)
+	}
 	if err := loadRepoDotEnv(repo); err != nil {
 		return returnCLIValidationError(cmd.ErrOrStderr(), fmt.Errorf("load .env: %w", err))
 	}

--- a/cmd/swarm/doctor_test.go
+++ b/cmd/swarm/doctor_test.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -263,6 +264,116 @@ func TestDoctorClaudeCLIPreflightWarnsOnRetiredGatewayEnv(t *testing.T) {
 	}
 }
 
+func TestDoctorTargetHumanExplainsResolutionWithoutPreflight(t *testing.T) {
+	isolateCLIAPIConfigEnv(t)
+	repo := writeDoctorTargetRepo(t)
+	flagSwarmDir := filepath.Join(t.TempDir(), "flag-state")
+	configSwarmDir := filepath.Join(t.TempDir(), "config-state")
+	t.Setenv("SWARM_CONFIG", writeCLIAPIConfigFile(t, map[string]string{
+		"swarm_dir":  configSwarmDir,
+		"api_server": "http://127.0.0.1:19001",
+	}))
+
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), repo, []string{
+		"--swarm-dir", flagSwarmDir,
+		"doctor", "--target",
+		"--contracts", filepath.Join(repo, "contracts"),
+		"--config", filepath.Join(t.TempDir(), "missing-runtime-config.yaml"),
+		"--backend", "not-a-backend",
+	}, &stdout, &stderr, defaultRootCommandOptions())
+	if code != cliExitOK {
+		t.Fatalf("code = %d, want %d stdout=%s stderr=%s", code, cliExitOK, stdout.String(), stderr.String())
+	}
+	for _, want := range []string{
+		"swarm target diagnostics: ok",
+		"swarm_dir: " + flagSwarmDir + " (source: --swarm-dir)",
+		"project_root: " + repo,
+		"api_server: http://127.0.0.1:19001 (source: config api_server)",
+		"descriptor_registry: pending (#1613)",
+		"runtime_identity: pending (#1613)",
+		"store_path: " + filepath.Join(repo, ".swarm", "dev.db"),
+		"data_dir: " + filepath.Join(repo, ".swarm", "data"),
+		"command_classes:",
+		"#1614",
+		"#1615",
+	} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("doctor target output missing %q:\n%s", want, stdout.String())
+		}
+	}
+	if strings.Contains(stdout.String(), "claude_cli preflight") {
+		t.Fatalf("doctor target ran backend preflight:\n%s", stdout.String())
+	}
+	if stderr.String() != "" {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+}
+
+func TestDoctorTargetJSONPreservesScriptableOutput(t *testing.T) {
+	isolateCLIAPIConfigEnv(t)
+	repo := writeDoctorTargetRepo(t)
+	tokenFile := writeCLIAPITokenFile(t, "target-token")
+	apiServer := "http://127.0.0.1:19002"
+
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), repo, []string{
+		"doctor", "--target", "--json",
+		"--api-server", apiServer,
+		"--api-token-file", tokenFile,
+		"--contracts", filepath.Join(repo, "contracts"),
+	}, &stdout, &stderr, defaultRootCommandOptions())
+	if code != cliExitOK {
+		t.Fatalf("code = %d, want %d stdout=%s stderr=%s", code, cliExitOK, stdout.String(), stderr.String())
+	}
+	if stderr.String() != "" {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+	var report doctorTargetReport
+	if err := json.Unmarshal(stdout.Bytes(), &report); err != nil {
+		t.Fatalf("parse target json: %v\n%s", err, stdout.String())
+	}
+	if !report.OK || report.Owner != localTargetOwner || report.Mode != "target" {
+		t.Fatalf("report identity = %#v", report)
+	}
+	if report.API.Server != apiServer || report.API.Source != "--api-server" || report.API.Auth.Source != "--api-token-file" {
+		t.Fatalf("api resolution = %#v", report.API)
+	}
+	if report.Context.Registry.Status != "pending" || report.RuntimeIdentity.Status != "pending" {
+		t.Fatalf("registry/identity should be pending, report = %#v", report)
+	}
+	if len(report.CommandClasses) == 0 || len(report.SplitSiblings) == 0 {
+		t.Fatalf("report missing command classes or split siblings: %#v", report)
+	}
+}
+
+func TestDoctorTargetQuietRemainsUnsupported(t *testing.T) {
+	isolateCLIAPIConfigEnv(t)
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"doctor", "--target", "--quiet"}, &stdout, &stderr, defaultRootCommandOptions())
+	if code != cliExitValidation {
+		t.Fatalf("code = %d, want %d stdout=%s stderr=%s", code, cliExitValidation, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "unknown flag: --quiet") {
+		t.Fatalf("stderr = %q, want unsupported quiet flag", stderr.String())
+	}
+	if stdout.String() != "" {
+		t.Fatalf("stdout = %q, want empty", stdout.String())
+	}
+}
+
+func TestDoctorAPIFlagsRequireTargetMode(t *testing.T) {
+	isolateCLIAPIConfigEnv(t)
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"doctor", "--api-server", "http://127.0.0.1:19003"}, &stdout, &stderr, defaultRootCommandOptions())
+	if code != cliExitValidation {
+		t.Fatalf("code = %d, want %d stdout=%s stderr=%s", code, cliExitValidation, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "--api-server and --api-token-file require --target") {
+		t.Fatalf("stderr = %q, want target-only API flag validation", stderr.String())
+	}
+}
+
 func TestRunServeRuntimeConsumesLocalClaudePreflightBeforeStoreSelection(t *testing.T) {
 	configureDoctorDockerStub(t)
 	t.Setenv("CLAUDE_CODE_OAUTH_TOKEN", "")
@@ -350,11 +461,85 @@ func TestPlatformSpecLocalClaudeCLIPreflightAdmissionPromoted(t *testing.T) {
 		}
 	}
 	doctor := spec.CLISpecification.CommandCatalog.Doctor
-	if doctor.Command != "swarm doctor --backend claude_cli [--contracts <path>] [--json]" || doctor.ImplementationStatus != "implemented" || doctor.Owner != "cli_specification.foundations.local_claude_cli_preflight_admission" {
+	if doctor.Command != "swarm doctor [--backend claude_cli] [--target] [--contracts <path>] [--json]" || doctor.ImplementationStatus != "implemented" || !strings.Contains(doctor.Owner, "local_claude_cli_preflight_admission") {
 		t.Fatalf("doctor command catalog = %#v", doctor)
 	}
-	if !strings.Contains(doctor.Behavior, "without starting runtime") || !strings.Contains(doctor.Behavior, "DB state") {
+	if !strings.Contains(doctor.Owner, "local_target_resolution_authority") {
+		t.Fatalf("doctor command catalog missing target owner: %#v", doctor)
+	}
+	if !strings.Contains(doctor.Behavior, "without starting runtime") || !strings.Contains(doctor.Behavior, "DB state") || !strings.Contains(doctor.Behavior, "--target") {
 		t.Fatalf("doctor behavior missing runtime/DB boundary: %s", doctor.Behavior)
+	}
+}
+
+func TestPlatformSpecLocalTargetResolutionAuthorityPromoted(t *testing.T) {
+	var spec struct {
+		CLISpecification struct {
+			Foundations struct {
+				LocalTarget struct {
+					PromotedBy           string `yaml:"promoted_by"`
+					ImplementationStatus string `yaml:"implementation_status"`
+					CanonicalOwner       string `yaml:"canonical_owner"`
+					SwarmDir             struct {
+						SourceOrder     []string          `yaml:"source_order"`
+						RejectedSources map[string]string `yaml:"rejected_sources"`
+					} `yaml:"swarm_dir"`
+					TargetPrecedence struct {
+						SourceOrder []string `yaml:"source_order"`
+					} `yaml:"target_precedence"`
+					CommandClasses map[string]struct {
+						Status   string   `yaml:"status"`
+						Commands []string `yaml:"commands"`
+					} `yaml:"command_classes"`
+					DoctorTargetSurface struct {
+						Command  string `yaml:"command"`
+						Behavior string `yaml:"behavior"`
+					} `yaml:"doctor_target_surface"`
+					SplitSiblings []string `yaml:"split_siblings"`
+				} `yaml:"local_target_resolution_authority"`
+			} `yaml:"foundations"`
+		} `yaml:"cli_specification"`
+	}
+	data, err := os.ReadFile(filepath.Join(repoRoot(), defaultPlatformSpecPath))
+	if err != nil {
+		t.Fatalf("read platform spec: %v", err)
+	}
+	if err := yaml.Unmarshal(data, &spec); err != nil {
+		t.Fatalf("parse platform spec: %v", err)
+	}
+	target := spec.CLISpecification.Foundations.LocalTarget
+	if target.PromotedBy != "#1612" || target.ImplementationStatus != "implemented_first_slice" || target.CanonicalOwner != localTargetOwner {
+		t.Fatalf("local target owner = %#v", target)
+	}
+	wantSwarmDirOrder := []string{"--swarm-dir", "config swarm_dir", "default ~/.swarm"}
+	if !reflect.DeepEqual(target.SwarmDir.SourceOrder, wantSwarmDirOrder) {
+		t.Fatalf("swarm_dir source order = %#v, want %#v", target.SwarmDir.SourceOrder, wantSwarmDirOrder)
+	}
+	for _, rejected := range []string{"--datadir", "SWARM_DIR", "SWARM_HOME", "<swarm-dir>/config.yaml"} {
+		if _, ok := target.SwarmDir.RejectedSources[rejected]; !ok {
+			t.Fatalf("swarm_dir rejected sources missing %q: %#v", rejected, target.SwarmDir.RejectedSources)
+		}
+	}
+	for _, want := range []string{"explicit_api_flags", "live_project_scoped_context", "selected_or_default_global_context", "built_in_loopback_default"} {
+		if !stringSliceContains(target.TargetPrecedence.SourceOrder, want) {
+			t.Fatalf("target precedence missing %q: %#v", want, target.TargetPrecedence.SourceOrder)
+		}
+	}
+	for _, class := range []string{"target_diagnostic", "read_only_inspection", "mutating_runtime_state", "control_destructive", "startup_and_run"} {
+		if _, ok := target.CommandClasses[class]; !ok {
+			t.Fatalf("command classes missing %q: %#v", class, target.CommandClasses)
+		}
+	}
+	if target.CommandClasses["target_diagnostic"].Status != "implemented" || !stringSliceContains(target.CommandClasses["target_diagnostic"].Commands, "swarm doctor --target") {
+		t.Fatalf("target diagnostic class = %#v", target.CommandClasses["target_diagnostic"])
+	}
+	if !strings.Contains(target.DoctorTargetSurface.Command, "swarm doctor --target") || !strings.Contains(target.DoctorTargetSurface.Behavior, "MUST NOT require backend preflight") {
+		t.Fatalf("doctor target surface = %#v", target.DoctorTargetSurface)
+	}
+	for _, sibling := range []string{"#1613", "#1614", "#1615", "#1576"} {
+		if !stringSliceContainsPrefix(target.SplitSiblings, sibling) {
+			t.Fatalf("split siblings missing %q: %#v", sibling, target.SplitSiblings)
+		}
 	}
 }
 
@@ -398,6 +583,19 @@ func writeDoctorClaudeConfig(t *testing.T) string {
 		"    no_session_persistence: false",
 	}, "\n")+"\n")
 	return path
+}
+
+func writeDoctorTargetRepo(t *testing.T) string {
+	t.Helper()
+	repo := t.TempDir()
+	contracts := filepath.Join(repo, "contracts")
+	if err := os.MkdirAll(contracts, 0o755); err != nil {
+		t.Fatalf("mkdir contracts: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(contracts, "package.yaml"), []byte("name: target-fixture\nversion: 0.0.1\n"), 0o644); err != nil {
+		t.Fatalf("write package: %v", err)
+	}
+	return repo
 }
 
 func writeDoctorAgentFreeContractsFixture(t *testing.T) string {
@@ -488,6 +686,15 @@ func freeDoctorTCPPort(t *testing.T) string {
 func localPreflightReportHasCode(report localPreflightReport, code string) bool {
 	for _, finding := range report.Findings {
 		if finding.Code == code {
+			return true
+		}
+	}
+	return false
+}
+
+func stringSliceContainsPrefix(values []string, prefix string) bool {
+	for _, value := range values {
+		if strings.HasPrefix(value, prefix) {
 			return true
 		}
 	}

--- a/cmd/swarm/doctor_test.go
+++ b/cmd/swarm/doctor_test.go
@@ -347,6 +347,37 @@ func TestDoctorTargetJSONPreservesScriptableOutput(t *testing.T) {
 	}
 }
 
+func TestDoctorTargetAPIFlagsAfterRootSwarmDir(t *testing.T) {
+	isolateCLIAPIConfigEnv(t)
+	repo := writeDoctorTargetRepo(t)
+	swarmDir := filepath.Join(t.TempDir(), "state")
+	apiServer := "http://127.0.0.1:19004"
+
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), repo, []string{
+		"--swarm-dir", swarmDir,
+		"doctor", "--target", "--json",
+		"--api-server", apiServer,
+		"--contracts", filepath.Join(repo, "contracts"),
+	}, &stdout, &stderr, defaultRootCommandOptions())
+	if code != cliExitOK {
+		t.Fatalf("code = %d, want %d stdout=%s stderr=%s", code, cliExitOK, stdout.String(), stderr.String())
+	}
+	var report doctorTargetReport
+	if err := json.Unmarshal(stdout.Bytes(), &report); err != nil {
+		t.Fatalf("parse target json: %v\n%s", err, stdout.String())
+	}
+	if report.SwarmDir.Path != swarmDir || report.SwarmDir.Source != "--swarm-dir" {
+		t.Fatalf("swarm dir = %#v, want %q from --swarm-dir", report.SwarmDir, swarmDir)
+	}
+	if report.API.Server != apiServer || report.API.Source != "--api-server" {
+		t.Fatalf("api target = %#v, want %q from --api-server", report.API, apiServer)
+	}
+	if stderr.String() != "" {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+}
+
 func TestDoctorTargetQuietRemainsUnsupported(t *testing.T) {
 	isolateCLIAPIConfigEnv(t)
 	var stdout, stderr bytes.Buffer

--- a/cmd/swarm/target_resolution.go
+++ b/cmd/swarm/target_resolution.go
@@ -1,0 +1,503 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	storebackend "github.com/division-sh/swarm/internal/store/backendselection"
+	"github.com/spf13/cobra"
+)
+
+const (
+	localTargetOwner = "platform-spec.yaml#cli_specification.foundations.local_target_resolution_authority"
+)
+
+type cliSwarmDirOptions struct {
+	SwarmDir        string
+	SwarmDirFlagSet bool
+}
+
+type cliSwarmDirResolution struct {
+	Path   string
+	Source string
+}
+
+func resolveCLISwarmDir(opts cliSwarmDirOptions) (cliSwarmDirResolution, error) {
+	cfg, err := loadCLIAPIConfigFile()
+	if err != nil {
+		return cliSwarmDirResolution{}, err
+	}
+	return resolveCLISwarmDirFromConfig(opts, cfg)
+}
+
+func resolveCLISwarmDirFromConfig(opts cliSwarmDirOptions, cfg cliAPIConfigFile) (cliSwarmDirResolution, error) {
+	if opts.SwarmDirFlagSet {
+		path, err := normalizeCLISwarmDir(opts.SwarmDir, "--swarm-dir")
+		return cliSwarmDirResolution{Path: path, Source: "--swarm-dir"}, err
+	}
+	if strings.TrimSpace(cfg.SwarmDir) != "" {
+		path, err := normalizeCLISwarmDir(cfg.SwarmDir, "config swarm_dir")
+		return cliSwarmDirResolution{Path: path, Source: "config swarm_dir"}, err
+	}
+	path, err := defaultCLISwarmDir()
+	return cliSwarmDirResolution{Path: path, Source: "default ~/.swarm"}, err
+}
+
+func normalizeCLISwarmDir(raw, source string) (string, error) {
+	path := strings.TrimSpace(raw)
+	if path == "" {
+		return "", &cliAPIValidationError{message: fmt.Sprintf("%s must be non-empty", source)}
+	}
+	if !filepath.IsAbs(path) {
+		abs, err := filepath.Abs(path)
+		if err != nil {
+			return "", &cliAPIValidationError{message: fmt.Sprintf("resolve %s: %v", source, err)}
+		}
+		path = abs
+	}
+	return filepath.Clean(path), nil
+}
+
+func defaultCLISwarmDir() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", &cliAPIValidationError{message: fmt.Sprintf("resolve default ~/.swarm: %v", err)}
+	}
+	return filepath.Join(home, ".swarm"), nil
+}
+
+type doctorTargetReport struct {
+	Owner           string                     `json:"owner"`
+	Mode            string                     `json:"mode"`
+	OK              bool                       `json:"ok"`
+	SwarmDir        doctorTargetPath           `json:"swarm_dir"`
+	Project         doctorTargetProject        `json:"project"`
+	API             doctorTargetAPI            `json:"api"`
+	Context         doctorTargetContext        `json:"context"`
+	RuntimeIdentity doctorTargetPendingFact    `json:"runtime_identity"`
+	Store           doctorTargetPath           `json:"store"`
+	Data            doctorTargetPath           `json:"data"`
+	CommandClasses  []doctorTargetCommandClass `json:"command_classes"`
+	SplitSiblings   []string                   `json:"split_siblings"`
+}
+
+type doctorTargetPath struct {
+	Path   string `json:"path,omitempty"`
+	Source string `json:"source,omitempty"`
+	Status string `json:"status"`
+	Detail string `json:"detail,omitempty"`
+}
+
+type doctorTargetProject struct {
+	ContractsPath          string `json:"contracts_path,omitempty"`
+	ContractsSource        string `json:"contracts_source,omitempty"`
+	ProjectRoot            string `json:"project_root,omitempty"`
+	CanonicalProjectRoot   string `json:"canonical_project_root,omitempty"`
+	CanonicalizationStatus string `json:"canonicalization_status"`
+	Status                 string `json:"status"`
+	Detail                 string `json:"detail,omitempty"`
+}
+
+type doctorTargetAPI struct {
+	Server      string           `json:"server"`
+	RPCEndpoint string           `json:"rpc_endpoint"`
+	Source      string           `json:"source"`
+	Auth        doctorTargetAuth `json:"auth"`
+	Reason      string           `json:"reason"`
+}
+
+type doctorTargetAuth struct {
+	Source string `json:"source"`
+	Status string `json:"status"`
+	Detail string `json:"detail,omitempty"`
+}
+
+type doctorTargetContext struct {
+	ProjectScoped  doctorTargetPendingFact `json:"project_scoped"`
+	SelectedGlobal doctorTargetPendingFact `json:"selected_global"`
+	Registry       doctorTargetPendingFact `json:"registry"`
+}
+
+type doctorTargetPendingFact struct {
+	Status string `json:"status"`
+	Owner  string `json:"owner,omitempty"`
+	Detail string `json:"detail,omitempty"`
+}
+
+type doctorTargetCommandClass struct {
+	Name        string   `json:"name"`
+	Status      string   `json:"status"`
+	Fallthrough string   `json:"fallthrough"`
+	Commands    []string `json:"commands"`
+}
+
+func runDoctorTargetCommand(repo string, cmd *cobra.Command, opts doctorOptions) error {
+	cfg, err := loadCLIAPIConfigFile()
+	if err != nil {
+		return returnCLIValidationError(cmd.ErrOrStderr(), err)
+	}
+	swarmDirFlag, swarmDirFlagSet := rootSwarmDirFlag(cmd)
+	swarmDir, err := resolveCLISwarmDirFromConfig(cliSwarmDirOptions{SwarmDir: swarmDirFlag, SwarmDirFlagSet: swarmDirFlagSet}, cfg)
+	if err != nil {
+		return returnCLIValidationError(cmd.ErrOrStderr(), err)
+	}
+	report, err := buildDoctorTargetReport(repo, opts, cfg, swarmDir)
+	if err != nil {
+		return returnCLIValidationError(cmd.ErrOrStderr(), err)
+	}
+	if opts.asJSON {
+		return writeDoctorTargetJSON(cmd.OutOrStdout(), report)
+	}
+	writeDoctorTargetText(cmd.OutOrStdout(), report)
+	return nil
+}
+
+func buildDoctorTargetReport(repo string, opts doctorOptions, cfg cliAPIConfigFile, swarmDir cliSwarmDirResolution) (doctorTargetReport, error) {
+	api, err := resolveDoctorTargetAPI(opts, cfg)
+	if err != nil {
+		return doctorTargetReport{}, err
+	}
+	store, err := resolveDoctorTargetStore(repo)
+	if err != nil {
+		return doctorTargetReport{}, err
+	}
+	data, err := resolveDoctorTargetData(repo, opts)
+	if err != nil {
+		return doctorTargetReport{}, err
+	}
+	return doctorTargetReport{
+		Owner:    localTargetOwner,
+		Mode:     "target",
+		OK:       true,
+		SwarmDir: doctorTargetPath{Path: swarmDir.Path, Source: swarmDir.Source, Status: "resolved"},
+		Project:  resolveDoctorTargetProject(repo, opts, cfg),
+		API:      api,
+		Context: doctorTargetContext{
+			ProjectScoped: doctorTargetPendingFact{
+				Status: "pending",
+				Owner:  "#1613/#1614",
+				Detail: "project-scoped context registry and consumption are split; this diagnostic does not trust descriptor files yet",
+			},
+			SelectedGlobal: doctorTargetPendingFact{
+				Status: "pending",
+				Owner:  "#1613/#1614",
+				Detail: "selected/default global context lookup is specified here but implemented by the registry and command-consumption children",
+			},
+			Registry: doctorTargetPendingFact{
+				Status: "pending",
+				Owner:  "#1613",
+				Detail: "descriptor writes, current/list/prune, atomicity, and liveness-backed identity remain split",
+			},
+		},
+		RuntimeIdentity: doctorTargetPendingFact{
+			Status: "pending",
+			Owner:  "#1613",
+			Detail: "health/PID/port are not trusted as runtime instance identity in this slice",
+		},
+		Store:          store,
+		Data:           data,
+		CommandClasses: doctorTargetCommandClasses(),
+		SplitSiblings:  doctorTargetSplitSiblings(),
+	}, nil
+}
+
+func rootSwarmDirFlag(cmd *cobra.Command) (string, bool) {
+	if cmd == nil || cmd.Root() == nil {
+		return "", false
+	}
+	flag := cmd.Root().PersistentFlags().Lookup("swarm-dir")
+	if flag == nil {
+		return "", false
+	}
+	return flag.Value.String(), flag.Changed
+}
+
+func resolveDoctorTargetAPI(opts doctorOptions, cfg cliAPIConfigFile) (doctorTargetAPI, error) {
+	server, source := firstDoctorTargetAPIServer(opts, cfg)
+	base, err := normalizeCLIAPIServerBase(server, source)
+	if err != nil {
+		return doctorTargetAPI{}, err
+	}
+	rpcEndpoint, err := cliAPIRPCEndpointFromServer(base.String(), source)
+	if err != nil {
+		return doctorTargetAPI{}, err
+	}
+	return doctorTargetAPI{
+		Server:      base.String(),
+		RPCEndpoint: rpcEndpoint,
+		Source:      source,
+		Auth:        resolveDoctorTargetAuth(opts, cfg, rpcEndpoint),
+		Reason:      doctorTargetAPIReason(source),
+	}, nil
+}
+
+func firstDoctorTargetAPIServer(opts doctorOptions, cfg cliAPIConfigFile) (string, string) {
+	if server := strings.TrimSpace(opts.apiOptions.apiServer); server != "" {
+		return server, "--api-server"
+	}
+	if server := strings.TrimSpace(os.Getenv("SWARM_API_SERVER")); server != "" {
+		return server, "SWARM_API_SERVER"
+	}
+	if server := strings.TrimSpace(cfg.APIServer); server != "" {
+		return server, "config api_server"
+	}
+	return defaultCLIAPIServer, "built-in loopback default"
+}
+
+func resolveDoctorTargetAuth(opts doctorOptions, cfg cliAPIConfigFile, rpcEndpoint string) doctorTargetAuth {
+	if tokenFile := strings.TrimSpace(opts.apiOptions.apiTokenFile); tokenFile != "" {
+		return doctorTargetAuth{Source: "--api-token-file", Status: "configured", Detail: tokenFile}
+	}
+	if strings.TrimSpace(os.Getenv("SWARM_API_TOKEN")) != "" {
+		return doctorTargetAuth{Source: "SWARM_API_TOKEN", Status: "configured", Detail: "value redacted"}
+	}
+	if tokenFile := strings.TrimSpace(os.Getenv("SWARM_API_TOKEN_FILE")); tokenFile != "" {
+		return doctorTargetAuth{Source: "SWARM_API_TOKEN_FILE", Status: "configured", Detail: tokenFile}
+	}
+	if tokenFile := strings.TrimSpace(cfg.APITokenFile); tokenFile != "" {
+		return doctorTargetAuth{Source: "config api_token_file", Status: "configured", Detail: tokenFile}
+	}
+	if cliAPIRPCEndpointAllowsDefaultToken(rpcEndpoint) {
+		return doctorTargetAuth{Source: "built-in loopback default", Status: "available", Detail: "numeric loopback target"}
+	}
+	return doctorTargetAuth{Source: "none", Status: "missing_explicit_token", Detail: "non-loopback targets require --api-token-file, SWARM_API_TOKEN, SWARM_API_TOKEN_FILE, or config api_token_file"}
+}
+
+func doctorTargetAPIReason(source string) string {
+	switch source {
+	case "--api-server":
+		return "explicit API server flag wins target precedence for this diagnostic"
+	case "SWARM_API_SERVER":
+		return "existing explicit API environment source wins after flags"
+	case "config api_server":
+		return "existing bootstrap config API source wins after flags and environment"
+	default:
+		return "context registry consumption is pending #1613/#1614, so this first-slice diagnostic falls through to the built-in loopback default"
+	}
+}
+
+func resolveDoctorTargetProject(repo string, opts doctorOptions, cfg cliAPIConfigFile) doctorTargetProject {
+	contractsPath, source := firstDoctorTargetContractsPath(repo, opts, cfg)
+	if strings.TrimSpace(contractsPath) == "" {
+		return doctorTargetProject{
+			CanonicalizationStatus: "not_applicable",
+			Status:                 "no_contract_source",
+			Detail:                 "no --contracts, SWARM_CONTRACTS_PATH, config contracts_path, or repo-local contracts/package.yaml source was resolved",
+		}
+	}
+	projectRoot := inferProjectRootFromContractsPath(contractsPath)
+	canonical, canonicalStatus := canonicalizeDoctorTargetPath(projectRoot)
+	return doctorTargetProject{
+		ContractsPath:          filepath.Clean(contractsPath),
+		ContractsSource:        source,
+		ProjectRoot:            filepath.Clean(projectRoot),
+		CanonicalProjectRoot:   canonical,
+		CanonicalizationStatus: canonicalStatus,
+		Status:                 "resolved",
+	}
+}
+
+func firstDoctorTargetContractsPath(repo string, opts doctorOptions, cfg cliAPIConfigFile) (string, string) {
+	if path := strings.TrimSpace(opts.contractsPath); path != "" {
+		return resolvePath(repo, path), "--contracts"
+	}
+	if path := strings.TrimSpace(os.Getenv(cliContractsPathEnv)); path != "" {
+		return resolvePath(repo, path), cliContractsPathEnv
+	}
+	if path := strings.TrimSpace(cfg.ContractsPath); path != "" {
+		return resolvePath(repo, path), "config contracts_path"
+	}
+	if path := discoverRepoContractsPath(repo); path != "" {
+		return path, "repo contracts/package.yaml"
+	}
+	return "", ""
+}
+
+func inferProjectRootFromContractsPath(contractsPath string) string {
+	contractsPath = filepath.Clean(contractsPath)
+	if filepath.Base(contractsPath) == "package.yaml" {
+		contractsPath = filepath.Dir(contractsPath)
+	}
+	if filepath.Base(contractsPath) == "contracts" {
+		return filepath.Dir(contractsPath)
+	}
+	return contractsPath
+}
+
+func canonicalizeDoctorTargetPath(path string) (string, string) {
+	if strings.TrimSpace(path) == "" {
+		return "", "not_applicable"
+	}
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return filepath.Clean(path), "unavailable: " + err.Error()
+	}
+	real, err := filepath.EvalSymlinks(abs)
+	if err != nil {
+		return filepath.Clean(abs), "unavailable: " + err.Error()
+	}
+	return filepath.Clean(real), "resolved"
+}
+
+func resolveDoctorTargetStore(repo string) (doctorTargetPath, error) {
+	if raw, ok := os.LookupEnv(storebackend.EnvSQLitePath); ok {
+		path, err := normalizeDoctorTargetSQLitePath(repo, raw, storebackend.EnvSQLitePath)
+		if err != nil {
+			return doctorTargetPath{}, err
+		}
+		return doctorTargetPath{
+			Path:   path,
+			Source: storebackend.EnvSQLitePath,
+			Status: "current_behavior",
+			Detail: "runtime store migration and project-local defaults remain split to #1615",
+		}, nil
+	}
+	return doctorTargetPath{
+		Path:   filepath.Clean(resolvePath(repo, storebackend.DefaultSQLiteRelativePath)),
+		Source: "current rollout default",
+		Status: "current_behavior",
+		Detail: "runtime config store.sqlite.path is not loaded in target-only mode; store/data migration remains split to #1615",
+	}, nil
+}
+
+func normalizeDoctorTargetSQLitePath(repo, raw, source string) (string, error) {
+	path := strings.TrimSpace(raw)
+	if path == "" {
+		return "", fmt.Errorf("sqlite path from %s must be non-empty", source)
+	}
+	if filepath.IsAbs(path) {
+		return filepath.Clean(path), nil
+	}
+	root := strings.TrimSpace(repo)
+	if root == "" {
+		return filepath.Clean(path), nil
+	}
+	return filepath.Clean(filepath.Join(root, path)), nil
+}
+
+func resolveDoctorTargetData(repo string, opts doctorOptions) (doctorTargetPath, error) {
+	if opts.dataSourceSet {
+		path, err := normalizeWorkspaceDataSourcePath(repo, opts.dataSource, "--data")
+		if err != nil {
+			return doctorTargetPath{}, err
+		}
+		return doctorTargetPath{Path: path, Source: "--data", Status: "resolved"}, nil
+	}
+	if raw, ok := os.LookupEnv(envWorkspaceDataSource); ok {
+		path, err := normalizeWorkspaceDataSourcePath(repo, raw, envWorkspaceDataSource)
+		if err != nil {
+			return doctorTargetPath{}, err
+		}
+		return doctorTargetPath{Path: path, Source: envWorkspaceDataSource, Status: "current_behavior"}, nil
+	}
+	if raw, ok := os.LookupEnv(envWorkspaceVolumesFrom); ok && strings.TrimSpace(raw) != "" {
+		return doctorTargetPath{
+			Source: envWorkspaceVolumesFrom,
+			Status: "no_host_data_dir",
+			Detail: "workspace volumes_from supplies container mounts; store/data migration remains split to #1615",
+		}, nil
+	}
+	return doctorTargetPath{
+		Path:   filepath.Clean(resolvePath(repo, defaultWorkspaceDataSourceRelativePath)),
+		Source: defaultWorkspaceDataSourceSource,
+		Status: "current_behavior",
+		Detail: "directory is reported only; target mode does not create it and migration remains split to #1615",
+	}, nil
+}
+
+func doctorTargetCommandClasses() []doctorTargetCommandClass {
+	return []doctorTargetCommandClass{
+		{
+			Name:        "target_diagnostic",
+			Status:      "implemented",
+			Fallthrough: "not_applicable",
+			Commands:    []string{"swarm doctor --target"},
+		},
+		{
+			Name:        "read_only_inspection",
+			Status:      "specified_pending_#1614_consumption",
+			Fallthrough: "may use project/global/default target only after #1614 consumes the registry and fails closed on stale project contexts",
+			Commands:    []string{"swarm status", "swarm trace", "swarm logs", "swarm health", "swarm runs", "swarm agents list"},
+		},
+		{
+			Name:        "mutating_runtime_state",
+			Status:      "specified_pending_#1614_consumption",
+			Fallthrough: "requires explicit or unambiguous selected target; no command behavior changes are implemented in #1612",
+			Commands:    []string{"swarm event publish", "swarm agent restart", "swarm agent directive", "swarm mailbox approve"},
+		},
+		{
+			Name:        "control_destructive",
+			Status:      "specified_pending_#1614_consumption",
+			Fallthrough: "requires explicit or unambiguous selected target plus existing command confirmation rules",
+			Commands:    []string{"swarm control pause", "swarm control stop", "swarm control nuke"},
+		},
+		{
+			Name:        "startup_and_run",
+			Status:      "split_pending_#1614_#1615",
+			Fallthrough: "serve project registration and swarm run semantics are intentionally not implemented in #1612",
+			Commands:    []string{"swarm serve --dev", "swarm run"},
+		},
+	}
+}
+
+func doctorTargetSplitSiblings() []string {
+	return []string{
+		"#1613 runtime identity and descriptor registry",
+		"#1614 project-scoped serve/API command targeting",
+		"#1615 store/data migration and swarm run semantics",
+		"#1576 transport-aware descriptors and IPC/ephemeral-port direction",
+	}
+}
+
+func writeDoctorTargetJSON(out io.Writer, report doctorTargetReport) error {
+	if out == nil {
+		return nil
+	}
+	encoder := json.NewEncoder(out)
+	encoder.SetIndent("", "  ")
+	return encoder.Encode(report)
+}
+
+func writeDoctorTargetText(out io.Writer, report doctorTargetReport) {
+	if out == nil {
+		return
+	}
+	fmt.Fprintf(out, "swarm target diagnostics: ok\n")
+	fmt.Fprintf(out, "owner: %s\n", report.Owner)
+	fmt.Fprintf(out, "swarm_dir: %s (source: %s)\n", report.SwarmDir.Path, report.SwarmDir.Source)
+	if report.Project.Status == "resolved" {
+		fmt.Fprintf(out, "project_root: %s (source: %s; canonical: %s; canonicalization: %s)\n", report.Project.ProjectRoot, report.Project.ContractsSource, report.Project.CanonicalProjectRoot, report.Project.CanonicalizationStatus)
+	} else {
+		fmt.Fprintf(out, "project_root: %s (%s)\n", report.Project.Status, report.Project.Detail)
+	}
+	fmt.Fprintf(out, "api_server: %s (source: %s)\n", report.API.Server, report.API.Source)
+	fmt.Fprintf(out, "rpc_endpoint: %s\n", report.API.RPCEndpoint)
+	fmt.Fprintf(out, "api_auth: %s (%s", report.API.Auth.Status, report.API.Auth.Source)
+	if report.API.Auth.Detail != "" {
+		fmt.Fprintf(out, "; %s", report.API.Auth.Detail)
+	}
+	fmt.Fprintln(out, ")")
+	fmt.Fprintf(out, "target_reason: %s\n", report.API.Reason)
+	fmt.Fprintf(out, "project_context: %s (%s)\n", report.Context.ProjectScoped.Status, report.Context.ProjectScoped.Owner)
+	fmt.Fprintf(out, "selected_global_context: %s (%s)\n", report.Context.SelectedGlobal.Status, report.Context.SelectedGlobal.Owner)
+	fmt.Fprintf(out, "descriptor_registry: %s (%s)\n", report.Context.Registry.Status, report.Context.Registry.Owner)
+	fmt.Fprintf(out, "runtime_identity: %s (%s)\n", report.RuntimeIdentity.Status, report.RuntimeIdentity.Owner)
+	fmt.Fprintf(out, "store_path: %s (source: %s; status: %s)\n", report.Store.Path, report.Store.Source, report.Store.Status)
+	if report.Data.Path != "" {
+		fmt.Fprintf(out, "data_dir: %s (source: %s; status: %s)\n", report.Data.Path, report.Data.Source, report.Data.Status)
+	} else {
+		fmt.Fprintf(out, "data_dir: %s (source: %s; %s)\n", report.Data.Status, report.Data.Source, report.Data.Detail)
+	}
+	fmt.Fprintln(out, "command_classes:")
+	for _, class := range report.CommandClasses {
+		fmt.Fprintf(out, "  - %s: %s; fallthrough: %s\n", class.Name, class.Status, class.Fallthrough)
+	}
+	fmt.Fprintln(out, "split_siblings:")
+	for _, sibling := range report.SplitSiblings {
+		fmt.Fprintf(out, "  - %s\n", sibling)
+	}
+}

--- a/cmd/swarm/target_resolution.go
+++ b/cmd/swarm/target_resolution.go
@@ -39,7 +39,7 @@ func resolveCLISwarmDirFromConfig(opts cliSwarmDirOptions, cfg cliAPIConfigFile)
 		path, err := normalizeCLISwarmDir(opts.SwarmDir, "--swarm-dir")
 		return cliSwarmDirResolution{Path: path, Source: "--swarm-dir"}, err
 	}
-	if strings.TrimSpace(cfg.SwarmDir) != "" {
+	if cfg.SwarmDirSet {
 		path, err := normalizeCLISwarmDir(cfg.SwarmDir, "config swarm_dir")
 		return cliSwarmDirResolution{Path: path, Source: "config swarm_dir"}, err
 	}

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -11586,6 +11586,129 @@ cli_specification:
       Runtime-state commands use v1 bearer auth through token sources governed by
       cli_specification.foundations.api_connection_auth_config_precedence. Legacy
       `SWARM_BUILDER_AUTH_TOKEN` and `SWARM_OPERATOR_AUTH_TOKEN` fallback is invalid.
+    local_target_resolution_authority:
+      promoted_by: '#1612'
+      implementation_status: implemented_first_slice
+      canonical_owner: platform-spec.yaml#cli_specification.foundations.local_target_resolution_authority
+      implementation_owner: cmd/swarm local target diagnostic resolver
+      scope: >
+        Merge-bearing authority for local Swarm target/source explanation: the Swarm user/global state directory,
+        project-root facts derived from the existing contracts resolver, target precedence, command-class safety, and
+        the first inspection surface `swarm doctor --target`. This first slice is an authority and diagnostic surface
+        only. It does not write descriptor registries, trust runtime identity, retarget API-backed commands, register
+        project-scoped `serve --dev` contexts, migrate store/data paths, or change `swarm run` behavior.
+      invariant: >
+        You target the project you are in. If you are not in a project, or the project has no live known runtime after
+        the registry children exist, Swarm may use the selected/default context or built-in loopback target according to
+        command-class safety. Swarm MUST NOT silently guess between two live runtimes, and supported target diagnostics
+        MUST show what was selected and why.
+      swarm_dir:
+        accepted_sources:
+          flag: --swarm-dir <path>
+          config_key: swarm_dir
+          built_in_default: ~/.swarm
+        source_order:
+        - --swarm-dir
+        - config swarm_dir
+        - default ~/.swarm
+        rejected_sources:
+          --datadir: Not promoted; too easily confused with the agent-visible `--data` directory.
+          SWARM_DIR: Not promoted in this slice; adding environment state-dir authority requires a later gate.
+          SWARM_HOME: Not promoted in this slice; adding environment state-dir authority requires a later gate.
+          '<swarm-dir>/config.yaml': >
+            Not a bootstrap config owner. Static bootstrap config remains governed by `SWARM_CONFIG` and the XDG config
+            default in cli_specification.foundations.api_connection_auth_config_precedence.cli_config_file.
+        normalization_rule: >
+          Explicit relative `--swarm-dir` and config `swarm_dir` paths are resolved to clean absolute filesystem paths
+          without creating the directory. Blank explicit values fail closed before target diagnostics or runtime action.
+      project_root_resolution:
+        source_owner: cli_specification.foundations.contract_platform_spec_path_resolution
+        rule: >
+          Project-root facts are derived from the resolved contracts source. If the resolved contracts root is named
+          `contracts`, the project root is its parent; otherwise the contracts root itself is the project root. The
+          canonical project key uses the realpath of that root when available. This owner consumes project-root facts
+          for explanation only until #1614 consumes them for runtime targeting.
+        no_project_rule: >
+          If no contracts source is resolved, target diagnostics report no project source. Runtime command behavior is
+          not changed by #1612.
+      target_precedence:
+        source_order:
+        - explicit_api_flags
+        - explicit_context_flag
+        - existing_api_environment
+        - existing_api_config
+        - live_project_scoped_context
+        - known_dead_or_stale_project_context_fail_closed
+        - selected_or_default_global_context
+        - built_in_loopback_default
+        current_first_slice_behavior: >
+          `swarm doctor --target` can explain explicit API flag, environment, config, project-root, Swarm-dir, current
+          rollout store/data, and pending registry/identity facts. Context registry, liveness-backed identity, and
+          API-backed command consumption are split to #1613 and #1614; unavailable facts MUST be reported as pending or
+          unavailable rather than inferred from PID, port, or health bundle fingerprint.
+      command_classes:
+        target_diagnostic:
+          status: implemented
+          commands:
+          - swarm doctor --target
+          fallthrough: not_applicable
+        read_only_inspection:
+          status: specified_pending_#1614_consumption
+          commands:
+          - swarm status
+          - swarm trace
+          - swarm logs
+          - swarm health
+          - swarm runs
+          - swarm agents list
+          fallthrough: >
+            May use project/global/default target only after #1614 consumes the registry and fails closed on stale project
+            contexts.
+        mutating_runtime_state:
+          status: specified_pending_#1614_consumption
+          commands:
+          - swarm event publish
+          - swarm agent restart
+          - swarm agent directive
+          - swarm mailbox approve
+          fallthrough: >
+            Requires explicit or unambiguous selected target; #1612 implements no mutating command behavior changes.
+        control_destructive:
+          status: specified_pending_#1614_consumption
+          commands:
+          - swarm control pause
+          - swarm control stop
+          - swarm control nuke
+          fallthrough: >
+            Requires explicit or unambiguous selected target plus existing command confirmation rules; #1612 implements
+            no control command behavior changes.
+        startup_and_run:
+          status: split_pending_#1614_#1615
+          commands:
+          - swarm serve --dev
+          - swarm run
+          fallthrough: >
+            Project registration and run semantics are explicitly split.
+      doctor_target_surface:
+        command: swarm doctor --target [--json] [--swarm-dir <path>] [--api-server <url>] [--api-token-file <path>]
+        output_owner: cli_specification.foundations.output_contract
+        behavior: >
+          The target mode is a fast, read-only diagnostic. It MUST NOT require backend preflight, start runtime, read a
+          runtime DB, write local state, create the Swarm-dir, create `.swarm/data`, trust descriptors, or mutate other
+          command JSON payloads. Human output renders only to stdout on success. `--json` renders one structured target
+          report to stdout and emits no success stderr. `--quiet` is not supported by this first slice and remains
+          fail-closed as an unknown/unsupported flag.
+      split_siblings:
+      - '#1613 runtime identity and descriptor registry'
+      - '#1614 project-scoped serve/API command targeting'
+      - '#1615 store/data migration and swarm run semantics'
+      - '#1576 transport-aware descriptors and IPC/ephemeral-port direction'
+      implementation_boundaries:
+      - 'The shared CLI config parser may accept `swarm_dir`, but API connection/auth resolution must ignore it.'
+      - 'No `SWARM_DIR`, `SWARM_HOME`, `--datadir`, or `<swarm-dir>/config.yaml` bootstrap source is promoted.'
+      - 'No descriptor files are written or trusted in #1612.'
+      - 'No API-backed command target resolver consumes project/global contexts in #1612.'
+      - 'Store and data paths may be reported as current behavior only; migration is split to #1615.'
     api_connection_auth_config_precedence:
       promoted_by: '#844'
       loopback_default_implemented_by: '#1124'
@@ -11682,6 +11805,10 @@ cli_specification:
           api_server: API server base URL consumed by API-backed commands.
           api_token_file: Path to a file containing the bearer token.
         shared_non_api_keys:
+          swarm_dir: >
+            Accepted by the shared CLI config parser for
+            cli_specification.foundations.local_target_resolution_authority; ignored by the API connection and auth
+            resolver.
           contracts_path: >
             Accepted by the shared CLI config parser for
             cli_specification.foundations.contract_platform_spec_path_resolution; ignored by the API connection
@@ -11909,22 +12036,27 @@ cli_specification:
           - remote server build date
           - server-local bundle path
     doctor:
-      command: swarm doctor --backend claude_cli [--contracts <path>] [--json]
+      command: swarm doctor [--backend claude_cli] [--target] [--contracts <path>] [--json]
       tier: should_have
       implementation_status: implemented
-      owner: cli_specification.foundations.local_claude_cli_preflight_admission
+      owner: cli_specification.foundations.local_claude_cli_preflight_admission; target mode owner cli_specification.foundations.local_target_resolution_authority
       behavior: >
-        Reports typed local prerequisite findings for the selected backend without starting runtime or reading/writing runtime
-        DB state. For `claude_cli`, the command checks backend selector authority, applies backend credential authority only
-        when the selected source declares agents, checks selected contract source when provided, contract-required secrets
-        through the credential store, Docker/workspace image/Claude CLI availability through the workspace lifecycle owner,
-        API/MCP listener availability, and stale MCP gateway env values through the serve startup owner. JSON output is
-        supported for scripts.
+        Default mode reports typed local prerequisite findings for the selected backend without starting runtime or
+        reading/writing runtime DB state. For `claude_cli`, the command checks backend selector authority, applies backend
+        credential authority only when the selected source declares agents, checks selected contract source when provided,
+        contract-required secrets through the credential store, Docker/workspace image/Claude CLI availability through the
+        workspace lifecycle owner, API/MCP listener availability, and stale MCP gateway env values through the serve startup
+        owner. `--target` is a separate fast local-target diagnostic mode owned by
+        cli_specification.foundations.local_target_resolution_authority; it reports Swarm-dir, project-root, API target,
+        pending context/identity facts, current store/data facts, command classes, and split siblings without backend
+        preflight or local state writes. JSON output is supported for scripts.
       split_scope:
       - workspace image build
       - local API connection discovery files
       - stale gateway env precedence or auto-fix policy
       - deployment-mode profile management
+      - trusted runtime identity and context registry consumption
+      - store/data migration and swarm run behavior
     workspace_build:
       command: swarm workspace build --backend claude_cli [--image <tag>]
       tier: should_have


### PR DESCRIPTION
## Summary

- Promotes `platform-spec.yaml#cli_specification.foundations.local_target_resolution_authority` as the canonical owner for local target/source explanation, Swarm-dir source precedence, target precedence, command classes, and `doctor --target`.
- Adds `swarm_dir` to the shared CLI config parser and `--swarm-dir` as the first-slice explicit Swarm-dir source.
- Adds `swarm doctor --target` and `swarm doctor --target --json` as fast, read-only target diagnostics that report pending registry/runtime identity facts instead of trusting PID/port/health bundle fingerprints.

Closes #1612

## Governing Refs / Context

- `platform-spec.yaml#cli_specification.foundations.local_target_resolution_authority`
- `platform-spec.yaml#cli_specification.foundations.api_connection_auth_config_precedence`
- `platform-spec.yaml#cli_specification.foundations.contract_platform_spec_path_resolution`
- `platform-spec.yaml#cli_specification.foundations.output_contract`
- `platform-spec.yaml#cli_specification.foundations.local_claude_cli_preflight_admission`
- `platform-spec.yaml#cli_specification.command_catalog.doctor`
- Issue/gate context: #1612 under #1606, with #1613, #1614, and #1615 remaining split.
- `docs/IMPLEMENTER_GUIDELINES.md` and `docs/SEMANTIC_DRIFT.md` are not present in this tree, matching the pre-audit note.

## Semantic Migration

- New canonical owner: `platform-spec.yaml#cli_specification.foundations.local_target_resolution_authority`.
- Old non-authoritative paths now invalid for this slice: `SWARM_DIR`, `SWARM_HOME`, `--datadir`, `<swarm-dir>/config.yaml` bootstrap config, blind `.swarm/connection.json` discovery, and PID/port/health-fingerprint identity trust.
- Production paths checked for surviving old behavior: API config/auth resolver ignores `swarm_dir`; target diagnostics do not write descriptor files, retarget API commands, migrate store/data, or change `swarm run`.
- Migration completeness: complete for the approved #1612 child class; broader registry/identity/targeting/store/run work remains split to #1613-#1615.

## Proof

- `go test ./cmd/swarm`
- `go test ./...`