### PR TITLE
[agent-e][issue #1525] Add rules emit template specialization

### DIFF
--- a/internal/runtime/bootverify/report_test.go
+++ b/internal/runtime/bootverify/report_test.go
@@ -3483,7 +3483,7 @@ func TestRun_RulesEmitTemplateSpecializationUsesMergedBranchPayloads(t *testing.
 	handler.Emit = runtimecontracts.EmitSpec{
 		Event: "market_research.scan_assigned",
 		Fields: map[string]runtimecontracts.ExpressionValue{
-			"scan_id": runtimecontracts.RefExpression("payload.scan_id"),
+			"scan_id": runtimecontracts.CELExpression("payload.scan_id"),
 		},
 	}
 	handler.Rules = []runtimecontracts.HandlerRuleEntry{
@@ -3492,7 +3492,7 @@ func TestRun_RulesEmitTemplateSpecializationUsesMergedBranchPayloads(t *testing.
 			Condition: "payload.mode == 'full'",
 			Emit: runtimecontracts.EmitSpec{
 				Fields: map[string]runtimecontracts.ExpressionValue{
-					"geography": runtimecontracts.RefExpression("payload.geography"),
+					"geography": runtimecontracts.CELExpression("payload.geography"),
 				},
 			},
 		},
@@ -3501,7 +3501,7 @@ func TestRun_RulesEmitTemplateSpecializationUsesMergedBranchPayloads(t *testing.
 			Condition: "else",
 			Emit: runtimecontracts.EmitSpec{
 				Fields: map[string]runtimecontracts.ExpressionValue{
-					"geography": runtimecontracts.RefExpression("payload.geography"),
+					"geography": runtimecontracts.CELExpression("payload.geography"),
 				},
 			},
 		},
@@ -3528,7 +3528,7 @@ func TestRun_RulesEmitTemplateSpecializationErrorsPerMergedBranch(t *testing.T) 
 	handler.Emit = runtimecontracts.EmitSpec{
 		Event: "market_research.scan_assigned",
 		Fields: map[string]runtimecontracts.ExpressionValue{
-			"scan_id": runtimecontracts.RefExpression("payload.scan_id"),
+			"scan_id": runtimecontracts.CELExpression("payload.scan_id"),
 		},
 	}
 	handler.Rules = []runtimecontracts.HandlerRuleEntry{
@@ -3537,7 +3537,7 @@ func TestRun_RulesEmitTemplateSpecializationErrorsPerMergedBranch(t *testing.T) 
 			Condition: "payload.mode == 'full'",
 			Emit: runtimecontracts.EmitSpec{
 				Fields: map[string]runtimecontracts.ExpressionValue{
-					"geography": runtimecontracts.RefExpression("payload.geography"),
+					"geography": runtimecontracts.CELExpression("payload.geography"),
 				},
 			},
 		},
@@ -3546,7 +3546,7 @@ func TestRun_RulesEmitTemplateSpecializationErrorsPerMergedBranch(t *testing.T) 
 			Condition: "else",
 			Emit: runtimecontracts.EmitSpec{
 				Fields: map[string]runtimecontracts.ExpressionValue{
-					"bucket": runtimecontracts.LiteralExpression("partial"),
+					"bucket": runtimecontracts.CELExpression(`"partial"`),
 				},
 			},
 		},

--- a/internal/runtime/bootverify/report_test.go
+++ b/internal/runtime/bootverify/report_test.go
@@ -3473,6 +3473,101 @@ func TestRun_ErrorsPerEmitSiteWhenSameEventIsUnderspecifiedOnOneRuleOnly(t *test
 	}
 }
 
+func TestRun_RulesEmitTemplateSpecializationUsesMergedBranchPayloads(t *testing.T) {
+	bundle := bootverifyPayloadCompletenessBundle()
+	entry := bundle.Events["market_research.scan_assigned"]
+	entry.Required = []string{"scan_id", "geography"}
+	bundle.Events["market_research.scan_assigned"] = entry
+	node := bundle.Nodes["dispatcher"]
+	handler := node.EventHandlers["scan.corpus_dispatch"]
+	handler.Emit = runtimecontracts.EmitSpec{
+		Event: "market_research.scan_assigned",
+		Fields: map[string]runtimecontracts.ExpressionValue{
+			"scan_id": runtimecontracts.RefExpression("payload.scan_id"),
+		},
+	}
+	handler.Rules = []runtimecontracts.HandlerRuleEntry{
+		{
+			ID:        "full",
+			Condition: "payload.mode == 'full'",
+			Emit: runtimecontracts.EmitSpec{
+				Fields: map[string]runtimecontracts.ExpressionValue{
+					"geography": runtimecontracts.RefExpression("payload.geography"),
+				},
+			},
+		},
+		{
+			ID:        "partial",
+			Condition: "else",
+			Emit: runtimecontracts.EmitSpec{
+				Fields: map[string]runtimecontracts.ExpressionValue{
+					"geography": runtimecontracts.RefExpression("payload.geography"),
+				},
+			},
+		},
+	}
+	node.EventHandlers["scan.corpus_dispatch"] = handler
+	bundle.Nodes["dispatcher"] = node
+	bundle.Semantics.NodeHandlers["dispatcher"]["scan.corpus_dispatch"] = handler
+
+	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+
+	if reportContains(report.Errors(), "semantic_drift_payload_completeness", "scan_id is not statically provable") ||
+		reportContains(report.Errors(), "semantic_drift_payload_completeness", "geography is not statically provable") {
+		t.Fatalf("unexpected payload completeness error for merged template fields, got %#v", report.Errors())
+	}
+}
+
+func TestRun_RulesEmitTemplateSpecializationErrorsPerMergedBranch(t *testing.T) {
+	bundle := bootverifyPayloadCompletenessBundle()
+	entry := bundle.Events["market_research.scan_assigned"]
+	entry.Required = []string{"scan_id", "geography"}
+	bundle.Events["market_research.scan_assigned"] = entry
+	node := bundle.Nodes["dispatcher"]
+	handler := node.EventHandlers["scan.corpus_dispatch"]
+	handler.Emit = runtimecontracts.EmitSpec{
+		Event: "market_research.scan_assigned",
+		Fields: map[string]runtimecontracts.ExpressionValue{
+			"scan_id": runtimecontracts.RefExpression("payload.scan_id"),
+		},
+	}
+	handler.Rules = []runtimecontracts.HandlerRuleEntry{
+		{
+			ID:        "full",
+			Condition: "payload.mode == 'full'",
+			Emit: runtimecontracts.EmitSpec{
+				Fields: map[string]runtimecontracts.ExpressionValue{
+					"geography": runtimecontracts.RefExpression("payload.geography"),
+				},
+			},
+		},
+		{
+			ID:        "partial",
+			Condition: "else",
+			Emit: runtimecontracts.EmitSpec{
+				Fields: map[string]runtimecontracts.ExpressionValue{
+					"bucket": runtimecontracts.LiteralExpression("partial"),
+				},
+			},
+		},
+	}
+	node.EventHandlers["scan.corpus_dispatch"] = handler
+	bundle.Nodes["dispatcher"] = node
+	bundle.Semantics.NodeHandlers["dispatcher"]["scan.corpus_dispatch"] = handler
+
+	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+
+	if !reportContains(report.Errors(), "semantic_drift_payload_completeness", "rules[partial].emit_template") {
+		t.Fatalf("expected template branch payload completeness error for partial rule, got %#v", report.Errors())
+	}
+	if !reportContains(report.Errors(), "semantic_drift_payload_completeness", "geography is not statically provable") {
+		t.Fatalf("expected missing geography error for partial rule, got %#v", report.Errors())
+	}
+	if reportContains(report.Errors(), "semantic_drift_payload_completeness", "rules[full].emit_template") {
+		t.Fatalf("unexpected payload completeness error for full rule, got %#v", report.Errors())
+	}
+}
+
 func TestRun_ErrorsForOnSuccessEmitSitePayloadDrift(t *testing.T) {
 	bundle := bootverifyPayloadCompletenessBundle()
 	bundle.Events["market_research.audit_logged"] = runtimecontracts.EventCatalogEntry{

--- a/internal/runtime/bootverify/workflow_payload_completeness_checks.go
+++ b/internal/runtime/bootverify/workflow_payload_completeness_checks.go
@@ -130,15 +130,28 @@ func payloadCompletenessEmitSites(handler runtimecontracts.SystemNodeEventHandle
 			Fields:    targets,
 		})
 	}
-	add("handler.emit", handler.Emit)
+	templateSites := runtimecontracts.HandlerRuleEmitTemplateSites(handler)
+	if len(templateSites) == 0 {
+		add("handler.emit", handler.Emit)
+	} else {
+		for _, site := range templateSites {
+			label := site.SiteKey
+			if strings.TrimSpace(site.RuleID) != "" {
+				label = "rules[" + strings.TrimSpace(site.RuleID) + "].emit_template"
+			}
+			add(label, site.Spec)
+		}
+	}
 	add("handler.on_success.emit", handler.OnSuccess.Emit)
 	if handler.FanOut != nil {
 		add("handler.fan_out.emit", handler.FanOut.Emit)
 	}
-	for i, rule := range handler.Rules {
-		add(payloadCompletenessRuleLabel("rules", i, rule.ID, "emit"), rule.Emit)
-		if rule.FanOut != nil {
-			add(payloadCompletenessRuleLabel("rules", i, rule.ID, "fan_out.emit"), rule.FanOut.Emit)
+	if len(templateSites) == 0 {
+		for i, rule := range handler.Rules {
+			add(payloadCompletenessRuleLabel("rules", i, rule.ID, "emit"), rule.Emit)
+			if rule.FanOut != nil {
+				add(payloadCompletenessRuleLabel("rules", i, rule.ID, "fan_out.emit"), rule.FanOut.Emit)
+			}
 		}
 	}
 	for i, rule := range handler.OnComplete {

--- a/internal/runtime/contracts/workflow_contract_emit.go
+++ b/internal/runtime/contracts/workflow_contract_emit.go
@@ -152,7 +152,13 @@ func EffectiveRuleEmitTemplateSpec(handler SystemNodeEventHandler, rule HandlerR
 	if strings.TrimSpace(handler.Emit.EventType()) == "" {
 		return EmitSpec{}, false
 	}
+	if !emitFieldsAreCELExpressions(handler.Emit.Fields) {
+		return EmitSpec{}, false
+	}
 	if rule.Emit.EventType() != "" || rule.Emit.Empty() || !rule.Emit.HasFields() || !rule.Emit.Target.Empty() || rule.Emit.Broadcast {
+		return EmitSpec{}, false
+	}
+	if !emitFieldsAreCELExpressions(rule.Emit.Fields) {
 		return EmitSpec{}, false
 	}
 	spec := cloneEmitSpec(handler.Emit)
@@ -320,6 +326,9 @@ func validateHandlerRuleEmitTemplateSpecialization(handler SystemNodeEventHandle
 			return fmt.Errorf("UNSUPPORTED-EMIT: handler emit template specialization is not supported with accumulate.on_timeout")
 		}
 	}
+	if err := validateEmitTemplateCELFields("handler.emit.fields", handler.Emit.Fields); err != nil {
+		return err
+	}
 	hasElse := false
 	for idx, rule := range handler.Rules {
 		if strings.TrimSpace(rule.Condition) == "" || strings.EqualFold(strings.TrimSpace(rule.Condition), "else") {
@@ -340,6 +349,9 @@ func validateHandlerRuleEmitTemplateSpecialization(handler SystemNodeEventHandle
 		if !rule.Emit.HasFields() {
 			return fmt.Errorf("INVALID-EMIT: handler emit template specialization requires rules[%d].emit.fields", idx)
 		}
+		if err := validateEmitTemplateCELFields(fmt.Sprintf("rules[%d].emit.fields", idx), rule.Emit.Fields); err != nil {
+			return err
+		}
 		for field := range rule.Emit.Fields {
 			field = strings.TrimSpace(field)
 			if field == "" {
@@ -352,6 +364,28 @@ func validateHandlerRuleEmitTemplateSpecialization(handler SystemNodeEventHandle
 	}
 	if !hasElse {
 		return fmt.Errorf("INVALID-EMIT: handler emit template specialization requires an else rule")
+	}
+	return nil
+}
+
+func emitFieldsAreCELExpressions(fields map[string]ExpressionValue) bool {
+	for _, expr := range fields {
+		if expr.Kind != ExpressionKindCEL {
+			return false
+		}
+	}
+	return true
+}
+
+func validateEmitTemplateCELFields(prefix string, fields map[string]ExpressionValue) error {
+	for field, expr := range fields {
+		field = strings.TrimSpace(field)
+		if field == "" {
+			continue
+		}
+		if expr.Kind != ExpressionKindCEL {
+			return fmt.Errorf("INVALID-EMIT: handler emit template specialization requires %s.%s to be a CEL expression string", prefix, field)
+		}
 	}
 	return nil
 }

--- a/internal/runtime/contracts/workflow_contract_emit.go
+++ b/internal/runtime/contracts/workflow_contract_emit.go
@@ -2,17 +2,44 @@ package contracts
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 )
 
+type HandlerDeclarativeEmitSite struct {
+	Source    string
+	SiteKey   string
+	RuleID    string
+	RuleIndex int
+	Spec      EmitSpec
+}
+
 func HandlerEmitEvents(handler SystemNodeEventHandler) []string {
 	out := make([]string, 0, 8)
-	if eventType := handler.Emit.EventType(); eventType != "" {
-		out = append(out, eventType)
+	templateSites := HandlerRuleEmitTemplateSites(handler)
+	if len(templateSites) == 0 {
+		if eventType := handler.Emit.EventType(); eventType != "" {
+			out = append(out, eventType)
+		}
+	} else {
+		for _, site := range templateSites {
+			if eventType := site.Spec.EventType(); eventType != "" {
+				out = append(out, eventType)
+			}
+		}
 	}
 	out = append(out, actionResultEvents(handler.Action)...)
 	for _, rule := range handler.Rules {
-		out = append(out, ruleEmitEvents(rule)...)
+		if len(templateSites) == 0 {
+			out = append(out, ruleEmitEvents(rule)...)
+			continue
+		}
+		out = append(out, actionResultEvents(rule.Action)...)
+		if rule.FanOut != nil {
+			if eventType := rule.FanOut.Emit.EventType(); eventType != "" {
+				out = append(out, eventType)
+			}
+		}
 	}
 	if eventType := handler.OnSuccess.Emit.EventType(); eventType != "" {
 		out = append(out, eventType)
@@ -37,6 +64,113 @@ func HandlerEmitEvents(handler SystemNodeEventHandler) []string {
 		}
 	}
 	return uniqueOrderedStrings(out)
+}
+
+func HandlerDeclarativeEmitSites(handler SystemNodeEventHandler) []HandlerDeclarativeEmitSite {
+	out := make([]HandlerDeclarativeEmitSite, 0, 8)
+	add := func(source, siteKey, ruleID string, ruleIndex int, spec EmitSpec) {
+		if spec.Empty() {
+			return
+		}
+		out = append(out, HandlerDeclarativeEmitSite{
+			Source:    strings.TrimSpace(source),
+			SiteKey:   strings.TrimSpace(siteKey),
+			RuleID:    strings.TrimSpace(ruleID),
+			RuleIndex: ruleIndex,
+			Spec:      cloneEmitSpec(spec),
+		})
+	}
+	templateSites := HandlerRuleEmitTemplateSites(handler)
+	if len(templateSites) == 0 {
+		add("handler.emit", "handler.emit", "", -1, handler.Emit)
+		for idx, rule := range handler.Rules {
+			add("handler.rules.emit", indexedHandlerEmitSiteKey("handler.rules", idx, "emit"), rule.ID, idx, rule.Emit)
+			if rule.FanOut != nil {
+				add("handler.rules.fan_out.emit", indexedHandlerEmitSiteKey("handler.rules", idx, "fan_out.emit"), rule.ID, idx, rule.FanOut.Emit)
+			}
+		}
+	} else {
+		out = append(out, templateSites...)
+	}
+	add("handler.on_success.emit", "handler.on_success.emit", "", -1, handler.OnSuccess.Emit)
+	for idx, rule := range handler.OnComplete {
+		add("handler.on_complete.emit", indexedHandlerEmitSiteKey("handler.on_complete", idx, "emit"), rule.ID, idx, rule.Emit)
+		if rule.FanOut != nil {
+			add("handler.on_complete.fan_out.emit", indexedHandlerEmitSiteKey("handler.on_complete", idx, "fan_out.emit"), rule.ID, idx, rule.FanOut.Emit)
+		}
+	}
+	if handler.Accumulate != nil {
+		for idx, rule := range handler.Accumulate.OnComplete {
+			add("handler.accumulate.on_complete.emit", indexedHandlerEmitSiteKey("handler.accumulate.on_complete", idx, "emit"), rule.ID, idx, rule.Emit)
+			if rule.FanOut != nil {
+				add("handler.accumulate.on_complete.fan_out.emit", indexedHandlerEmitSiteKey("handler.accumulate.on_complete", idx, "fan_out.emit"), rule.ID, idx, rule.FanOut.Emit)
+			}
+		}
+		if handler.Accumulate.OnTimeout != nil {
+			add("handler.accumulate.on_timeout.emit", "handler.accumulate.on_timeout.emit", handler.Accumulate.OnTimeout.ID, 0, handler.Accumulate.OnTimeout.Emit)
+			if handler.Accumulate.OnTimeout.FanOut != nil {
+				add("handler.accumulate.on_timeout.fan_out.emit", "handler.accumulate.on_timeout.fan_out.emit", handler.Accumulate.OnTimeout.ID, 0, handler.Accumulate.OnTimeout.FanOut.Emit)
+			}
+		}
+	}
+	for idx, branch := range handler.Branch {
+		if branch.Then != nil {
+			add("handler.branch.then.emit", indexedHandlerEmitSiteKey("handler.branch", idx, "then.emit"), branch.Then.ID, idx, branch.Then.Emit)
+		}
+		if branch.Else != nil {
+			add("handler.branch.else.emit", indexedHandlerEmitSiteKey("handler.branch", idx, "else.emit"), branch.Else.ID, idx, branch.Else.Emit)
+		}
+	}
+	if handler.FanOut != nil {
+		add("handler.fan_out.emit", "handler.fan_out.emit", "", -1, handler.FanOut.Emit)
+	}
+	return out
+}
+
+func HandlerRuleEmitTemplateSites(handler SystemNodeEventHandler) []HandlerDeclarativeEmitSite {
+	if !handlerRulesEmitTemplateSpecializationCandidate(handler) {
+		return nil
+	}
+	out := make([]HandlerDeclarativeEmitSite, 0, len(handler.Rules))
+	for idx, rule := range handler.Rules {
+		spec, ok := EffectiveRuleEmitTemplateSpec(handler, rule)
+		if !ok {
+			return nil
+		}
+		out = append(out, HandlerDeclarativeEmitSite{
+			Source:    "handler.rules.emit_template",
+			SiteKey:   indexedHandlerEmitSiteKey("handler.rules", idx, "emit_template"),
+			RuleID:    strings.TrimSpace(rule.ID),
+			RuleIndex: idx,
+			Spec:      spec,
+		})
+	}
+	return out
+}
+
+func EffectiveRuleEmitTemplateSpec(handler SystemNodeEventHandler, rule HandlerRuleEntry) (EmitSpec, bool) {
+	if strings.TrimSpace(handler.Emit.EventType()) == "" {
+		return EmitSpec{}, false
+	}
+	if rule.Emit.EventType() != "" || rule.Emit.Empty() || !rule.Emit.HasFields() || !rule.Emit.Target.Empty() || rule.Emit.Broadcast {
+		return EmitSpec{}, false
+	}
+	spec := cloneEmitSpec(handler.Emit)
+	if spec.Fields == nil {
+		spec.Fields = map[string]ExpressionValue{}
+	}
+	for field, value := range rule.Emit.Fields {
+		field = strings.TrimSpace(field)
+		if field == "" {
+			continue
+		}
+		if _, exists := spec.Fields[field]; exists {
+			return EmitSpec{}, false
+		}
+		value.hydrate()
+		spec.Fields[field] = value
+	}
+	return spec, true
 }
 
 func RuleEmitEvents(rule HandlerRuleEntry) []string {
@@ -100,12 +234,24 @@ func HandlerHasNestedEmitSites(handler SystemNodeEventHandler) bool {
 }
 
 func HandlerHasAmbiguousTopLevelEmit(handler SystemNodeEventHandler) bool {
+	if handlerRulesEmitTemplateSpecializationCandidate(handler) {
+		return false
+	}
 	return !handler.Emit.Empty() && HandlerHasNestedEmitSites(handler)
 }
 
 func HandlerEmitSiteOwnershipError(handler SystemNodeEventHandler) error {
-	if HandlerHasAmbiguousTopLevelEmit(handler) {
-		return fmt.Errorf("AMBIGUOUS-EMIT: handler-top-level emit is only allowed on single-emit handlers; move emit ownership to the active branch, rule, timeout, or fan_out site")
+	if handlerRulesEmitTemplateSpecializationCandidate(handler) {
+		if err := validateHandlerRuleEmitTemplateSpecialization(handler); err != nil {
+			return err
+		}
+	} else {
+		if err := rejectEventlessEmitSpecs(handler); err != nil {
+			return err
+		}
+		if HandlerHasAmbiguousTopLevelEmit(handler) {
+			return fmt.Errorf("AMBIGUOUS-EMIT: handler-top-level emit is only allowed on single-emit handlers; move emit ownership to the active branch, rule, timeout, or fan_out site")
+		}
 	}
 	if handler.OnSuccess.Empty() {
 		return nil
@@ -136,6 +282,150 @@ func HandlerEmitSiteOwnershipError(handler SystemNodeEventHandler) error {
 		}
 	}
 	return nil
+}
+
+func handlerRulesEmitTemplateSpecializationCandidate(handler SystemNodeEventHandler) bool {
+	if handler.Emit.EventType() == "" || len(handler.Rules) == 0 {
+		return false
+	}
+	for _, rule := range handler.Rules {
+		if rule.Emit.EventType() == "" && !rule.Emit.Empty() {
+			return true
+		}
+	}
+	return false
+}
+
+func validateHandlerRuleEmitTemplateSpecialization(handler SystemNodeEventHandler) error {
+	if handler.Emit.EventType() == "" {
+		return fmt.Errorf("INVALID-EMIT: handler emit template specialization requires handler.emit.event")
+	}
+	if !handler.OnSuccess.Empty() {
+		return fmt.Errorf("UNSUPPORTED-EMIT: handler emit template specialization cannot be combined with on_success.emit")
+	}
+	if len(handler.OnComplete) > 0 {
+		return fmt.Errorf("UNSUPPORTED-EMIT: handler emit template specialization is only supported with handler.rules, not on_complete")
+	}
+	if handler.FanOut != nil {
+		return fmt.Errorf("UNSUPPORTED-EMIT: handler emit template specialization is only supported with handler.rules, not fan_out")
+	}
+	if len(handler.Branch) > 0 {
+		return fmt.Errorf("UNSUPPORTED-EMIT: handler emit template specialization is only supported with handler.rules, not branch")
+	}
+	if handler.Accumulate != nil {
+		if len(handler.Accumulate.OnComplete) > 0 {
+			return fmt.Errorf("UNSUPPORTED-EMIT: handler emit template specialization is not supported with accumulate.on_complete")
+		}
+		if handler.Accumulate.OnTimeout != nil {
+			return fmt.Errorf("UNSUPPORTED-EMIT: handler emit template specialization is not supported with accumulate.on_timeout")
+		}
+	}
+	hasElse := false
+	for idx, rule := range handler.Rules {
+		if strings.TrimSpace(rule.Condition) == "" || strings.EqualFold(strings.TrimSpace(rule.Condition), "else") {
+			hasElse = true
+		}
+		if rule.FanOut != nil {
+			return fmt.Errorf("UNSUPPORTED-EMIT: handler emit template specialization is not supported with rules[%d].fan_out", idx)
+		}
+		if rule.Emit.Empty() {
+			return fmt.Errorf("INVALID-EMIT: handler emit template specialization requires rules[%d].emit.fields", idx)
+		}
+		if rule.Emit.EventType() != "" {
+			return fmt.Errorf("UNSUPPORTED-EMIT: rules[%d].emit.event cannot be combined with handler emit template specialization", idx)
+		}
+		if !rule.Emit.Target.Empty() || rule.Emit.Broadcast {
+			return fmt.Errorf("UNSUPPORTED-EMIT: rules[%d].emit may only contribute fields in handler emit template specialization", idx)
+		}
+		if !rule.Emit.HasFields() {
+			return fmt.Errorf("INVALID-EMIT: handler emit template specialization requires rules[%d].emit.fields", idx)
+		}
+		for field := range rule.Emit.Fields {
+			field = strings.TrimSpace(field)
+			if field == "" {
+				continue
+			}
+			if _, exists := handler.Emit.Fields[field]; exists {
+				return fmt.Errorf("INVALID-EMIT: rules[%d].emit.fields.%s conflicts with handler emit template field", idx, field)
+			}
+		}
+	}
+	if !hasElse {
+		return fmt.Errorf("INVALID-EMIT: handler emit template specialization requires an else rule")
+	}
+	return nil
+}
+
+func rejectEventlessEmitSpecs(handler SystemNodeEventHandler) error {
+	if err := requireEmitEvent("handler.emit", handler.Emit); err != nil {
+		return err
+	}
+	if err := requireEmitEvent("handler.on_success.emit", handler.OnSuccess.Emit); err != nil {
+		return err
+	}
+	if handler.FanOut != nil {
+		if err := requireEmitEvent("handler.fan_out.emit", handler.FanOut.Emit); err != nil {
+			return err
+		}
+	}
+	for idx, rule := range handler.Rules {
+		if err := requireRuleEmitEvents("rules", idx, rule); err != nil {
+			return err
+		}
+	}
+	for idx, rule := range handler.OnComplete {
+		if err := requireRuleEmitEvents("on_complete", idx, rule); err != nil {
+			return err
+		}
+	}
+	if handler.Accumulate != nil {
+		for idx, rule := range handler.Accumulate.OnComplete {
+			if err := requireRuleEmitEvents("accumulate.on_complete", idx, rule); err != nil {
+				return err
+			}
+		}
+		if handler.Accumulate.OnTimeout != nil {
+			if err := requireRuleEmitEvents("accumulate.on_timeout", 0, *handler.Accumulate.OnTimeout); err != nil {
+				return err
+			}
+		}
+	}
+	for idx, branch := range handler.Branch {
+		if branch.Then != nil {
+			if err := requireRuleEmitEvents("branch.then", idx, *branch.Then); err != nil {
+				return err
+			}
+		}
+		if branch.Else != nil {
+			if err := requireRuleEmitEvents("branch.else", idx, *branch.Else); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func requireRuleEmitEvents(scope string, idx int, rule HandlerRuleEntry) error {
+	if err := requireEmitEvent(fmt.Sprintf("%s[%d].emit", scope, idx), rule.Emit); err != nil {
+		return err
+	}
+	if rule.FanOut != nil {
+		if err := requireEmitEvent(fmt.Sprintf("%s[%d].fan_out.emit", scope, idx), rule.FanOut.Emit); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func requireEmitEvent(label string, spec EmitSpec) error {
+	if spec.Empty() || spec.EventType() != "" {
+		return nil
+	}
+	return fmt.Errorf("INVALID-EMIT: %s.event is required", label)
+}
+
+func indexedHandlerEmitSiteKey(prefix string, index int, suffix string) string {
+	return prefix + "[" + strconv.Itoa(index) + "]." + suffix
 }
 
 func HandlerHasAmbiguousTopLevelAction(handler SystemNodeEventHandler) bool {

--- a/internal/runtime/contracts/workflow_contract_emit_test.go
+++ b/internal/runtime/contracts/workflow_contract_emit_test.go
@@ -83,3 +83,47 @@ func TestHandlerEmitEventsIncludesOnSuccessAfterRules(t *testing.T) {
 		t.Fatalf("HandlerEmitEvents() = %#v, want %#v", got, want)
 	}
 }
+
+func TestHandlerRuleEmitTemplateSitesMergeHandlerTemplateWithRuleFields(t *testing.T) {
+	handler := SystemNodeEventHandler{
+		Emit: EmitSpec{
+			Event: "account.bucketed",
+			Fields: map[string]ExpressionValue{
+				"account_id": CELExpression("payload.account_id"),
+			},
+		},
+		Rules: []HandlerRuleEntry{
+			{
+				ID:        "high",
+				Condition: "payload.score >= 80",
+				Emit: EmitSpec{Fields: map[string]ExpressionValue{
+					"bucket": CELExpression(`"high"`),
+				}},
+			},
+			{
+				ID:        "low",
+				Condition: "else",
+				Emit: EmitSpec{Fields: map[string]ExpressionValue{
+					"bucket": CELExpression(`"low"`),
+				}},
+			},
+		},
+	}
+
+	sites := HandlerRuleEmitTemplateSites(handler)
+	if got := len(sites); got != 2 {
+		t.Fatalf("HandlerRuleEmitTemplateSites len = %d, want 2", got)
+	}
+	if got := HandlerEmitEvents(handler); !reflect.DeepEqual(got, []string{"account.bucketed"}) {
+		t.Fatalf("HandlerEmitEvents = %#v, want one effective account.bucketed", got)
+	}
+	if got := sites[0].Spec.EventType(); got != "account.bucketed" {
+		t.Fatalf("merged event = %q, want account.bucketed", got)
+	}
+	if _, ok := sites[0].Spec.Fields["account_id"]; !ok {
+		t.Fatalf("merged site missing handler field: %#v", sites[0].Spec.Fields)
+	}
+	if expr := sites[0].Spec.Fields["bucket"]; expr.Kind != ExpressionKindCEL || expr.CEL != `"high"` {
+		t.Fatalf("merged bucket expr = %#v, want CEL \"high\"", expr)
+	}
+}

--- a/internal/runtime/contracts/workflow_contract_types.go
+++ b/internal/runtime/contracts/workflow_contract_types.go
@@ -1099,7 +1099,7 @@ func (e EmitSpec) EventType() string {
 }
 
 func (e EmitSpec) Empty() bool {
-	return strings.TrimSpace(e.Event) == ""
+	return strings.TrimSpace(e.Event) == "" && len(e.Fields) == 0 && e.Target.Empty() && !e.Broadcast
 }
 
 func (e EmitSpec) HasFields() bool {

--- a/internal/runtime/contracts/workflow_contract_yaml_handlers.go
+++ b/internal/runtime/contracts/workflow_contract_yaml_handlers.go
@@ -114,9 +114,6 @@ func (e *EmitSpec) UnmarshalYAML(node *yaml.Node) error {
 			Target:    target.Normalized(),
 			Broadcast: broadcast,
 		}
-		if e.EventType() == "" && len(e.Fields) > 0 {
-			return fmt.Errorf("INVALID-EMIT: emit.event is required when emit.fields is present")
-		}
 		if e.Broadcast && e.HasTarget() {
 			return fmt.Errorf("INVALID-EMIT: emit.target and emit.broadcast:true are mutually exclusive")
 		}

--- a/internal/runtime/contracts/workflow_contract_yaml_test.go
+++ b/internal/runtime/contracts/workflow_contract_yaml_test.go
@@ -1105,16 +1105,18 @@ select_or_create_entity:
 	}
 }
 
-func TestHandlerRuleEntryDecode_RejectsEmitFieldsWithoutEvent(t *testing.T) {
-	var rule HandlerRuleEntry
+func TestSystemNodeEventHandlerDecode_RejectsEventlessRuleEmitWithoutTemplate(t *testing.T) {
+	var handler SystemNodeEventHandler
 	err := yaml.Unmarshal([]byte(`
-condition: "else"
-emit:
-  fields:
-    scan_id: payload.scan_id
-`), &rule)
-	if err == nil || !strings.Contains(err.Error(), "INVALID-EMIT") {
-		t.Fatalf("yaml.Unmarshal error = %v, want INVALID-EMIT", err)
+rules:
+  done:
+    condition: "else"
+    emit:
+      fields:
+        scan_id: payload.scan_id
+`), &handler)
+	if err == nil || !strings.Contains(err.Error(), "rules[0].emit.event is required") {
+		t.Fatalf("yaml.Unmarshal error = %v, want eventless rule emit rejection", err)
 	}
 }
 
@@ -1466,6 +1468,155 @@ rules:
 	}
 	if got := HandlerEmitEvents(handler); !reflect.DeepEqual(got, []string{"rule.needs_human", "handler.succeeded"}) {
 		t.Fatalf("HandlerEmitEvents = %#v", got)
+	}
+}
+
+func TestSystemNodeEventHandlerDecode_AllowsRulesEmitTemplateSpecialization(t *testing.T) {
+	var handler SystemNodeEventHandler
+	if err := yaml.Unmarshal([]byte(`
+emit:
+  event: account.bucketed
+  fields:
+    account_id: entity.id
+    score: payload.score
+rules:
+  high:
+    condition: payload.score >= 80
+    emit:
+      fields:
+        bucket: '"high"'
+  medium:
+    condition: payload.score >= 40
+    emit:
+      fields:
+        bucket: '"medium"'
+  low:
+    condition: else
+    emit:
+      fields:
+        bucket: '"low"'
+`), &handler); err != nil {
+		t.Fatalf("yaml.Unmarshal: %v", err)
+	}
+	if got := HandlerEmitEvents(handler); !reflect.DeepEqual(got, []string{"account.bucketed"}) {
+		t.Fatalf("HandlerEmitEvents = %#v, want account.bucketed once", got)
+	}
+	sites := HandlerRuleEmitTemplateSites(handler)
+	if got := len(sites); got != 3 {
+		t.Fatalf("template sites len = %d, want 3", got)
+	}
+	if got := sites[0].Source; got != "handler.rules.emit_template" {
+		t.Fatalf("site source = %q, want handler.rules.emit_template", got)
+	}
+	if got := sites[0].Spec.EventType(); got != "account.bucketed" {
+		t.Fatalf("merged event = %q, want account.bucketed", got)
+	}
+	for _, field := range []string{"account_id", "score", "bucket"} {
+		if _, ok := sites[0].Spec.Fields[field]; !ok {
+			t.Fatalf("merged fields missing %s: %#v", field, sites[0].Spec.Fields)
+		}
+	}
+	if expr := sites[0].Spec.Fields["bucket"]; expr.Kind != ExpressionKindCEL || expr.CEL != `"high"` {
+		t.Fatalf("bucket expression = %#v, want CEL \"high\"", expr)
+	}
+}
+
+func TestSystemNodeEventHandlerDecode_RejectsInvalidRulesEmitTemplateSpecialization(t *testing.T) {
+	cases := []struct {
+		name     string
+		raw      string
+		contains string
+	}{
+		{
+			name: "missing_else",
+			raw: `
+emit:
+  event: account.bucketed
+rules:
+  high:
+    condition: payload.score >= 80
+    emit:
+      fields:
+        bucket: '"high"'
+`,
+			contains: "requires an else rule",
+		},
+		{
+			name: "field_conflict",
+			raw: `
+emit:
+  event: account.bucketed
+  fields:
+    bucket: '"base"'
+rules:
+  low:
+    condition: else
+    emit:
+      fields:
+        bucket: '"low"'
+`,
+			contains: "conflicts with handler emit template field",
+		},
+		{
+			name: "rule_own_event",
+			raw: `
+emit:
+  event: account.bucketed
+rules:
+  high:
+    condition: payload.score >= 80
+    emit:
+      fields:
+        bucket: '"high"'
+  low:
+    condition: else
+    emit:
+      event: account.dropped
+      fields:
+        bucket: '"low"'
+`,
+			contains: "rules[1].emit.event cannot be combined",
+		},
+		{
+			name: "rule_target_override",
+			raw: `
+emit:
+  event: account.bucketed
+rules:
+  low:
+    condition: else
+    emit:
+      target: sender
+      fields:
+        bucket: '"low"'
+`,
+			contains: "may only contribute fields",
+		},
+		{
+			name: "on_success_split",
+			raw: `
+emit:
+  event: account.bucketed
+on_success:
+  emit: account.audit
+rules:
+  low:
+    condition: else
+    emit:
+      fields:
+        bucket: '"low"'
+`,
+			contains: "cannot be combined with on_success.emit",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var handler SystemNodeEventHandler
+			err := yaml.Unmarshal([]byte(tc.raw), &handler)
+			if err == nil || !strings.Contains(err.Error(), tc.contains) {
+				t.Fatalf("yaml.Unmarshal error = %v, want containing %q", err, tc.contains)
+			}
+		})
 	}
 }
 

--- a/internal/runtime/contracts/workflow_contract_yaml_test.go
+++ b/internal/runtime/contracts/workflow_contract_yaml_test.go
@@ -1608,6 +1608,40 @@ rules:
 `,
 			contains: "cannot be combined with on_success.emit",
 		},
+		{
+			name: "rule_literal_field_value",
+			raw: `
+emit:
+  event: account.bucketed
+  fields:
+    account_id: entity.id
+rules:
+  low:
+    condition: else
+    emit:
+      fields:
+        bucket:
+          literal: low
+`,
+			contains: "rules[0].emit.fields.bucket to be a CEL expression string",
+		},
+		{
+			name: "handler_template_literal_field_value",
+			raw: `
+emit:
+  event: account.bucketed
+  fields:
+    account_id:
+      literal: acct-1
+rules:
+  low:
+    condition: else
+    emit:
+      fields:
+        bucket: '"low"'
+`,
+			contains: "handler.emit.fields.account_id to be a CEL expression string",
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/runtime/engine/executor.go
+++ b/internal/runtime/engine/executor.go
@@ -2065,11 +2065,18 @@ type activeDeclarativeEmitSpec struct {
 
 func selectedDeclarativeEmitSpecs(handler runtimecontracts.SystemNodeEventHandler, rule *runtimecontracts.HandlerRuleEntry) []activeDeclarativeEmitSpec {
 	out := make([]activeDeclarativeEmitSpec, 0, 2)
-	if rule != nil && !rule.Emit.Empty() {
-		out = append(out, activeDeclarativeEmitSpec{
-			Source: "handler.rules.emit",
-			Spec:   rule.Emit,
-		})
+	if rule != nil {
+		if spec, ok := runtimecontracts.EffectiveRuleEmitTemplateSpec(handler, *rule); ok {
+			out = append(out, activeDeclarativeEmitSpec{
+				Source: "handler.rules.emit_template",
+				Spec:   spec,
+			})
+		} else if !rule.Emit.Empty() {
+			out = append(out, activeDeclarativeEmitSpec{
+				Source: "handler.rules.emit",
+				Spec:   rule.Emit,
+			})
+		}
 	}
 	if !handler.OnSuccess.Empty() {
 		out = append(out, activeDeclarativeEmitSpec{

--- a/internal/runtime/engine/executor_test.go
+++ b/internal/runtime/engine/executor_test.go
@@ -1917,6 +1917,133 @@ func TestExecutor_RejectsAmbiguousHandlerTopLevelEmitWithRulesWithoutRuleEmit(t 
 	}
 }
 
+func TestExecutor_RulesEmitTemplateSpecializationQueuesOneMergedEvent(t *testing.T) {
+	cases := []struct {
+		name   string
+		score  int
+		bools  map[string]bool
+		bucket string
+		ruleID string
+	}{
+		{
+			name:   "high_first_match",
+			score:  91,
+			bools:  map[string]bool{"payload.score >= 80": true, "payload.score >= 40": true},
+			bucket: "high",
+			ruleID: "high",
+		},
+		{
+			name:   "medium_after_high_fails",
+			score:  52,
+			bools:  map[string]bool{"payload.score >= 80": false, "payload.score >= 40": true},
+			bucket: "medium",
+			ruleID: "medium",
+		},
+		{
+			name:   "else_low",
+			score:  12,
+			bools:  map[string]bool{"payload.score >= 80": false, "payload.score >= 40": false},
+			bucket: "low",
+			ruleID: "low",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			outbox := &recordingEmitOutbox{}
+			exec, err := NewExecutor(RuntimeDependencies{
+				Source:        stubSource(),
+				StateRepo:     stubStateRepo{},
+				TxRunner:      stubRunner{},
+				Locker:        stubLocker{},
+				Outbox:        outbox,
+				Dispatcher:    stubDispatcher{},
+				PayloadShaper: stubPayloadShaper{},
+				MaxChainDepth: 5,
+			}, stubEvaluator{bools: tc.bools})
+			if err != nil {
+				t.Fatalf("NewExecutor error: %v", err)
+			}
+
+			result, err := exec.Execute(context.Background(), ExecutionRequest{
+				EntityID:   "entity-1",
+				NodeID:     "node-1",
+				FlowID:     "flow-1",
+				ChainDepth: 1,
+				Event: eventtest.RootIngress(
+					"evt-1",
+					"account.scored",
+					"",
+					"",
+					mustEncodeJSON(t, map[string]any{"account_id": "acct-1", "score": tc.score}),
+					0,
+					"",
+					"",
+					events.EventEnvelope{},
+					time.Time{},
+				),
+				Handler: runtimecontracts.SystemNodeEventHandler{
+					Emit: runtimecontracts.EmitSpec{
+						Event: "account.bucketed",
+						Fields: map[string]runtimecontracts.ExpressionValue{
+							"account_id": runtimecontracts.CELExpression("payload.account_id"),
+							"score":      runtimecontracts.CELExpression("payload.score"),
+						},
+					},
+					Rules: []runtimecontracts.HandlerRuleEntry{
+						{
+							ID:        "high",
+							Condition: "payload.score >= 80",
+							Emit: runtimecontracts.EmitSpec{Fields: map[string]runtimecontracts.ExpressionValue{
+								"bucket": runtimecontracts.CELExpression(`"high"`),
+							}},
+						},
+						{
+							ID:        "medium",
+							Condition: "payload.score >= 40",
+							Emit: runtimecontracts.EmitSpec{Fields: map[string]runtimecontracts.ExpressionValue{
+								"bucket": runtimecontracts.CELExpression(`"medium"`),
+							}},
+						},
+						{
+							ID:        "low",
+							Condition: "else",
+							Emit: runtimecontracts.EmitSpec{Fields: map[string]runtimecontracts.ExpressionValue{
+								"bucket": runtimecontracts.CELExpression(`"low"`),
+							}},
+						},
+					},
+				},
+				State: testStateSnapshot("pending", map[string]any{}, nil, map[string]map[string]any{}),
+			})
+			if err != nil {
+				t.Fatalf("Execute error: %v", err)
+			}
+			if got := result.RuleID; got != tc.ruleID {
+				t.Fatalf("RuleID = %q, want %q", got, tc.ruleID)
+			}
+			if got := len(result.EmitIntents); got != 1 {
+				t.Fatalf("EmitIntents len = %d, want 1", got)
+			}
+			if got := string(result.EmitIntents[0].Event.Type()); got != "account.bucketed" {
+				t.Fatalf("emit event = %q, want account.bucketed", got)
+			}
+			payload := eventPayloadMap(t, result.EmitIntents[0].Event)
+			if got := payload["account_id"]; got != "acct-1" {
+				t.Fatalf("account_id = %#v, want acct-1", got)
+			}
+			if got := payload["bucket"]; got != tc.bucket {
+				t.Fatalf("bucket = %#v, want %s", got, tc.bucket)
+			}
+			if got := int(payload["score"].(float64)); got != tc.score {
+				t.Fatalf("score = %#v, want %d", payload["score"], tc.score)
+			}
+			if got := len(outbox.intents); got != 1 {
+				t.Fatalf("outbox intents len = %d, want 1", got)
+			}
+		})
+	}
+}
+
 func TestExecutor_OnSuccessEmitWithMatchedRuleQueuesRuleThenSuccess(t *testing.T) {
 	outbox := &recordingEmitOutbox{}
 	exec, err := NewExecutor(RuntimeDependencies{

--- a/internal/runtime/pipeline/handler_engine_transaction_test.go
+++ b/internal/runtime/pipeline/handler_engine_transaction_test.go
@@ -2474,6 +2474,87 @@ func TestExecuteNodeContractHandlerOnSuccessRulesEmitsBothInOrder(t *testing.T) 
 	}
 }
 
+func TestExecuteNodeContractHandlerRulesEmitTemplatePublishesOneMergedEvent(t *testing.T) {
+	bus := &recordingPipelineBus{}
+	pc := NewPipelineCoordinatorWithOptions(bus, nil, PipelineCoordinatorOptions{
+		Module: &previewWorkflowModule{bundle: rulesEmitTemplateContractBundle()},
+	})
+	entityID := "ent-1"
+
+	result, err := pc.executeNodeContractHandler(testPipelineCoordinatorRunContext(t, pc), "node-a", runtimecontracts.SystemNodeEventHandler{
+		Emit: runtimecontracts.EmitSpec{
+			Event: "account.bucketed",
+			Fields: map[string]runtimecontracts.ExpressionValue{
+				"account_id": runtimecontracts.CELExpression("payload.account_id"),
+				"score":      runtimecontracts.CELExpression("payload.score"),
+			},
+		},
+		Rules: []runtimecontracts.HandlerRuleEntry{
+			{
+				ID:        "high",
+				Condition: "payload.score >= 80",
+				Emit: runtimecontracts.EmitSpec{Fields: map[string]runtimecontracts.ExpressionValue{
+					"bucket": runtimecontracts.CELExpression(`"high"`),
+				}},
+			},
+			{
+				ID:        "medium",
+				Condition: "payload.score >= 40",
+				Emit: runtimecontracts.EmitSpec{Fields: map[string]runtimecontracts.ExpressionValue{
+					"bucket": runtimecontracts.CELExpression(`"medium"`),
+				}},
+			},
+			{
+				ID:        "low",
+				Condition: "else",
+				Emit: runtimecontracts.EmitSpec{Fields: map[string]runtimecontracts.ExpressionValue{
+					"bucket": runtimecontracts.CELExpression(`"low"`),
+				}},
+			},
+		},
+	}, workflowTriggerContext{
+		Event: eventtest.RootIngress(
+			"",
+			events.EventType("account.scored"),
+			"",
+			"",
+			mustJSON(map[string]any{"account_id": "acct-1", "score": 91}),
+			0,
+			"",
+			"",
+			events.EnvelopeForEntityID(events.EventEnvelope{}, entityID),
+			time.Time{},
+		),
+		State: WorkflowState{Stage: WorkflowStateID("queued"), Metadata: map[string]any{}},
+	}, false)
+	if err != nil {
+		t.Fatalf("executeNodeContractHandler: %v", err)
+	}
+	if !result.Handled {
+		t.Fatal("expected handled result")
+	}
+	if got := bus.publishedCount(); got != 1 {
+		t.Fatalf("bus published count = %d, want 1", got)
+	}
+	emitted := bus.publishedEvent(0)
+	if got := emitted.Type(); got != events.EventType("account.bucketed") {
+		t.Fatalf("published event = %q, want account.bucketed", got)
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(emitted.Payload(), &payload); err != nil {
+		t.Fatalf("json.Unmarshal payload: %v", err)
+	}
+	if got := payload["account_id"]; got != "acct-1" {
+		t.Fatalf("account_id = %#v, want acct-1", got)
+	}
+	if got := payload["bucket"]; got != "high" {
+		t.Fatalf("bucket = %#v, want high", got)
+	}
+	if got := int(payload["score"].(float64)); got != 91 {
+		t.Fatalf("score = %#v, want 91", payload["score"])
+	}
+}
+
 func TestExecuteNodeContractHandlerOnSuccessOutboxFailureDoesNotPartiallyPublish(t *testing.T) {
 	bus := &recordingPipelineBus{outboxErr: errors.New("outbox failed")}
 	pc := NewPipelineCoordinatorWithOptions(bus, nil, PipelineCoordinatorOptions{
@@ -2521,6 +2602,36 @@ func additiveOnSuccessContractBundle() *runtimecontracts.WorkflowContractBundle 
 		Events: map[string]runtimecontracts.EventCatalogEntry{
 			"rule.emitted":      {},
 			"handler.succeeded": {},
+		},
+	}
+}
+
+func rulesEmitTemplateContractBundle() *runtimecontracts.WorkflowContractBundle {
+	return &runtimecontracts.WorkflowContractBundle{
+		Semantics: runtimecontracts.WorkflowSemanticView{
+			Name:    "test",
+			Version: "v-test",
+		},
+		Events: map[string]runtimecontracts.EventCatalogEntry{
+			"account.scored": {
+				Payload: runtimecontracts.EventPayloadSpec{
+					Properties: map[string]runtimecontracts.EventFieldSpec{
+						"account_id": {Type: "string"},
+						"score":      {Type: "number"},
+					},
+				},
+				Required: []string{"account_id", "score"},
+			},
+			"account.bucketed": {
+				Payload: runtimecontracts.EventPayloadSpec{
+					Properties: map[string]runtimecontracts.EventFieldSpec{
+						"account_id": {Type: "string"},
+						"score":      {Type: "number"},
+						"bucket":     {Type: "string"},
+					},
+				},
+				Required: []string{"account_id", "score", "bucket"},
+			},
 		},
 	}
 }

--- a/internal/runtime/semanticview/authored_emit_sites.go
+++ b/internal/runtime/semanticview/authored_emit_sites.go
@@ -120,17 +120,26 @@ func (b *authoredEmitSiteBuilder) appendHandlerSites(kind AuthoredEmitSiteSource
 			Handler:        handler,
 		})
 	}
-	add("handler.emit", "handler.emit", "", handler.Emit)
+	templateSites := runtimecontracts.HandlerRuleEmitTemplateSites(handler)
+	if len(templateSites) == 0 {
+		add("handler.emit", "handler.emit", "", handler.Emit)
+	} else {
+		for _, site := range templateSites {
+			add(site.Source, site.SiteKey, site.RuleID, site.Spec)
+		}
+	}
 	add("handler.on_success.emit", "handler.on_success.emit", "", handler.OnSuccess.Emit)
 	if handler.Guard != nil {
 		if emitSpec := authoredGuardEscalationEmitSpec(handler.Guard); !emitSpec.Empty() {
 			add("handler.guard.on_fail.escalate", "handler.guard.on_fail.escalate", handler.Guard.ID, emitSpec)
 		}
 	}
-	for idx, rule := range handler.Rules {
-		add("handler.rules.emit", indexedAuthoredEmitSiteKey("handler.rules", idx, "emit"), rule.ID, rule.Emit)
-		if rule.FanOut != nil {
-			add("handler.rules.fan_out.emit", indexedAuthoredEmitSiteKey("handler.rules", idx, "fan_out.emit"), rule.ID, rule.FanOut.Emit)
+	if len(templateSites) == 0 {
+		for idx, rule := range handler.Rules {
+			add("handler.rules.emit", indexedAuthoredEmitSiteKey("handler.rules", idx, "emit"), rule.ID, rule.Emit)
+			if rule.FanOut != nil {
+				add("handler.rules.fan_out.emit", indexedAuthoredEmitSiteKey("handler.rules", idx, "fan_out.emit"), rule.ID, rule.FanOut.Emit)
+			}
 		}
 	}
 	for idx, rule := range handler.OnComplete {

--- a/internal/runtime/semanticview/authored_emit_sites_test.go
+++ b/internal/runtime/semanticview/authored_emit_sites_test.go
@@ -84,6 +84,35 @@ func TestAuthoredEmitSites_EnumeratesOnSuccessEmitWithRules(t *testing.T) {
 	}
 }
 
+func TestAuthoredEmitSites_UsesRulesEmitTemplateEffectiveSite(t *testing.T) {
+	source := loadAuthoredEmitSiteFixture(t, authoredEmitSiteFixture{
+		rootNodeID:       "root-node",
+		rootTemplateEmit: true,
+	})
+
+	sites := AuthoredEmitSites(source)
+	matches := authoredEmitSitesByFlowNodeEvent(sites, "", "root-node", "root.ready")
+	if len(matches) != 2 {
+		t.Fatalf("expected one effective template site per rule, got %d: %#v", len(matches), authoredEmitSiteSummaries(sites))
+	}
+	for _, match := range matches {
+		if got := match.Site; got != "handler.rules.emit_template" {
+			t.Fatalf("template site = %q, want handler.rules.emit_template", got)
+		}
+		for _, field := range []string{"shared", "bucket"} {
+			if _, ok := match.Spec.Fields[field]; !ok {
+				t.Fatalf("site %s missing merged field %s: %#v", match.RuleID, field, match.Spec.Fields)
+			}
+		}
+	}
+	if countAuthoredSitesWithSite(sites, "handler.emit") != 0 {
+		t.Fatalf("raw handler.emit survived for template specialization: %#v", authoredEmitSiteSummaries(sites))
+	}
+	if countAuthoredSitesWithSite(sites, "handler.rules.emit") != 0 {
+		t.Fatalf("raw handler.rules.emit survived for template specialization: %#v", authoredEmitSiteSummaries(sites))
+	}
+}
+
 func TestAuthoredEmitSites_DeduplicatesPackageProjectionWithoutCollapsingDistinctSources(t *testing.T) {
 	source := loadAuthoredEmitSiteFixture(t, authoredEmitSiteFixture{
 		rootNodeID:      "root-node",
@@ -148,6 +177,7 @@ type authoredEmitSiteFixture struct {
 	rootEmit            string
 	rootRuleEmit        string
 	rootOnSuccess       string
+	rootTemplateEmit    bool
 	rootGuardEmit       string
 	rootBroadcast       bool
 	flowNodeID          string
@@ -206,6 +236,9 @@ root.audit: {}
 	rootNodeYAML := authoredEmitSiteNodeYAML(opts.rootNodeID, "root.start", opts.rootEmit, opts.rootGuardEmit, opts.rootBroadcast)
 	if strings.TrimSpace(opts.rootRuleEmit) != "" || strings.TrimSpace(opts.rootOnSuccess) != "" {
 		rootNodeYAML = authoredEmitSiteRulesSuccessNodeYAML(opts.rootNodeID, "root.start", opts.rootRuleEmit, opts.rootOnSuccess)
+	}
+	if opts.rootTemplateEmit {
+		rootNodeYAML = authoredEmitSiteTemplateNodeYAML(opts.rootNodeID, "root.start", "root.ready")
 	}
 	if opts.rootGuardObject {
 		rootNodeYAML = authoredEmitSiteNodeYAMLWithGuardObject(opts.rootNodeID, "root.start", opts.rootEmit, opts.rootGuardEmit, opts.rootBroadcast)
@@ -274,8 +307,7 @@ func authoredEmitSiteNodeYAML(nodeID, trigger, eventType, guardEventType string,
         on_fail: "escalate:` + guardEventType + `"
 `
 	}
-	return `
-` + nodeID + `:
+	return nodeID + `:
   id: ` + nodeID + `
   execution_type: system_node
   event_handlers:
@@ -294,8 +326,7 @@ func authoredEmitSiteNodeYAMLWithGuardObject(nodeID, trigger, eventType, guardEv
 	if broadcast {
 		broadcastLine = "        broadcast: true\n"
 	}
-	return `
-` + nodeID + `:
+	return nodeID + `:
   id: ` + nodeID + `
   execution_type: system_node
   event_handlers:
@@ -320,8 +351,7 @@ func authoredEmitSiteRulesSuccessNodeYAML(nodeID, trigger, ruleEventType, succes
 	if strings.TrimSpace(nodeID) == "" {
 		return "{}\n"
 	}
-	return `
-` + nodeID + `:
+	return nodeID + `:
   id: ` + nodeID + `
   execution_type: system_node
   event_handlers:
@@ -335,8 +365,45 @@ func authoredEmitSiteRulesSuccessNodeYAML(nodeID, trigger, ruleEventType, succes
 `
 }
 
+func authoredEmitSiteTemplateNodeYAML(nodeID, trigger, eventType string) string {
+	if strings.TrimSpace(nodeID) == "" || strings.TrimSpace(eventType) == "" {
+		return "{}\n"
+	}
+	return nodeID + `:
+  id: ` + nodeID + `
+  execution_type: system_node
+  event_handlers:
+    ` + trigger + `:
+      emit:
+        event: ` + eventType + `
+        fields:
+          shared: payload.shared
+      rules:
+        high:
+          condition: "payload.score >= 80"
+          emit:
+            fields:
+              bucket: '"high"'
+        low:
+          condition: "else"
+          emit:
+            fields:
+              bucket: '"low"'
+`
+}
+
 func countAuthoredEmitSites(sites []AuthoredEmitSite, flowID, nodeID, eventType string) int {
 	return len(authoredEmitSitesByFlowNodeEvent(sites, flowID, nodeID, eventType))
+}
+
+func countAuthoredSitesWithSite(sites []AuthoredEmitSite, site string) int {
+	count := 0
+	for _, candidate := range sites {
+		if strings.TrimSpace(candidate.Site) == site {
+			count++
+		}
+	}
+	return count
 }
 
 func authoredEmitSitesByFlowNodeEvent(sites []AuthoredEmitSite, flowID, nodeID, eventType string) []AuthoredEmitSite {

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -959,11 +959,11 @@ contract_formats:
     agents_yaml: '{}'
   produces_derivation: >-
     The produces field on system nodes is OPTIONAL. If omitted, the platform derives the effective production surface from
-    every supported declarative emit site at boot: handler top-level emit, rule-local emit, on_complete branch emit,
-    accumulate.on_timeout emit, and fan_out emit. Runtime routing, producer authority, and transition checks consume this
-    effective production surface, not raw authored produces. If present, produces is an explicit authored assertion surface:
-    the verifier checks it matches actual emits, including an explicit empty list, with a PRODUCES-DRIFT warning. Authors
-    should omit produces and let the platform derive it.
+    every supported declarative emit site at boot: handler top-level emit, rule-local emit, rules emit template specialization
+    effective emits, on_complete branch emit, accumulate.on_timeout emit, and fan_out emit. Runtime routing, producer authority,
+    and transition checks consume this effective production surface, not raw authored produces. If present, produces is an
+    explicit authored assertion surface: the verifier checks it matches actual emits, including an explicit empty list, with
+    a PRODUCES-DRIFT warning. Authors should omit produces and let the platform derive it.
   underscore_prefix_convention:
     description: Fields starting with _ in contract YAML files.
     semantic_fields:
@@ -1331,7 +1331,7 @@ handler_specification:
       \ data into handler context)\n       └→ clear_gates (optional — reset gates before guard)\n            └→ guard\n            └→ accumulate\n                 └→ filter (optional — prune accumulated\
       \ items)\n                      └→ reduce (optional — aggregate filtered items to single value)\n                  \
       \         └→ count (optional — count items)\n                                └→ compute\n                          \
-      \           └→ emit-site selection (handler emit OR active emit set: selected rule emit then on_success.emit, or active branch/timeout/fan_out emit)\n                    \
+      \           └→ emit-site selection (handler emit OR active emit set: selected rule emit/template then on_success.emit, or active branch/timeout/fan_out emit)\n                    \
       \                      └→ advances_to ─┐\n                                             sets_gate ────┤ (independent\
       \ of each other)\n                                             data_accumulation ┘\n                         \
       \                         └→ projection (materialize_from, if accumulator projection eligible)\n                  \
@@ -1762,10 +1762,12 @@ handler_specification:
         producer_broadcast_common_path_forbidden: Loaded flow-scope or package-root broadcast:true is used as package-internal
           delivery to receiver input pins for the same pin-declared output or connected output pin; parent connect
           broadcast/fan-out is the required route owner.
-      single_emit_handler_rule: 'A handler top-level emit is valid only when the handler has exactly one possible emit site.
-        If the handler also declares rules, on_complete, accumulate.on_timeout, or fan_out emit, boot fails with ambiguity.
-        Payload ownership must move to the active emit site. The only approved additive rules success surface is explicit
-        on_success.emit, which is not a handler-level emit overload.'
+      single_emit_handler_rule: >-
+        A handler top-level emit is valid only when the handler has exactly one possible emit site, except for the explicit
+        rules emit template specialization described under `rules.emit_template_specialization`. If the handler also declares
+        ordinary rules emit sites, on_complete, accumulate.on_timeout, or fan_out emit, boot fails with ambiguity. Payload
+        ownership must move to the active emit site. The only approved additive rules success surface is explicit
+        on_success.emit, which is not a handler-level emit overload.
       on_success:
         field: on_success
         type: object
@@ -1793,10 +1795,33 @@ handler_specification:
           are payload.*, entity.*, policy.*, event.*, and query_entities(...). accumulated.*, fan_out.*, and
           item.* are unavailable in rules.condition. entity.* reads use the pre-rule entity state and the same
           declared-field validation as other rule-phase handler conditions.
-        emit: string or object — rule-local event to emit
+        emit: string or object — rule-local event to emit, or an eventless object with fields only when participating in
+          rules emit template specialization.
         advances_to: string — optional state change
         data_accumulation: object — optional data write (same format as handler-level)
         description: string — human-readable note
+      emit_template_specialization:
+        syntax: A rules handler may declare handler-level emit as the template, with `emit.event` and optional shared
+          `emit.fields`. Each rule then declares `emit.fields` without `emit.event` to add branch-specific fields. `emit`
+          remains one object shape everywhere, `{event?, fields?, target?, broadcast?}`.
+        field_values: All `emit.fields` values use the normal CEL expression string grammar. String constants are CEL string
+          literals, for example YAML value `'"high"'`. The platform does not support `emit_fields`, flattened rule emit
+          payload maps, `literal`, `value`, or any second field-value dialect for this specialization.
+        matching: Rules keep ordered first-match semantics. Threshold-style overlapping rules are valid when ordered from
+          most specific to least specific; the platform does not fail closed merely because multiple conditions could be true.
+        required_else: Every rules emit template specialization must include an `else` rule so every successful rules-handler
+          execution has a defined specialization branch.
+        effective_emit: The selected rule's eventless `emit.fields` fill-merge with the handler template. The result is exactly
+          one effective emit. Runtime evaluates that merged effective emit's fields, then emits its inherited `emit.event`.
+        fill_only: Rule specialization fields are fill-only. A rule field that redefines a handler template field is invalid
+          and boot fails closed.
+        unsupported_combinations: Rule-level specialization may not set `emit.event`, `emit.target`, or `emit.broadcast`;
+          those are not template refinements in this slice. Handler-level `on_success.emit` remains the separate additive
+          two-event surface and is not part of template specialization. on_complete, accumulate.on_timeout, fan_out, and
+          action-originated emits are out of this specialization slice.
+        proof_consumers: Bootverify, semantic view, produces derivation, route authority, runtime execution, and pipeline/outbox
+          proof consume the same merged effective emit, not the raw handler template and raw rule specialization as separate
+          events.
     fan_out:
       field: fan_out
       type: object
@@ -2174,17 +2199,21 @@ handler_specification:
       emit, action, data_accumulation, advances_to). 2. Handler-level data_accumulation executes AFTER rules when present and
       supplements rule-level writes in the same atomic transaction. 3. Bare handler-level emit and handler-level action do NOT
       supplement rules. If rules are present, bare handler-level emit or handler-level action is invalid and boot fails as
-      ambiguous. 4. Explicit on_success.emit supplements rules as a distinct additive success emit: the selected rule emit is
-      queued first and on_success.emit second; if no rule matches, only on_success.emit is queued. 5. The selected rule action
+      ambiguous, except for the explicit rules emit template specialization where handler-level emit supplies the event/shared
+      field template and the matched rule contributes eventless fields to one effective emit. 4. Explicit on_success.emit
+      supplements rules as a distinct additive success emit: the selected rule emit or template-specialized emit is queued first
+      and on_success.emit second; if no rule matches, only on_success.emit is queued. 5. The selected rule action
       executes at the normal action step after active state/gate/data updates and selected emit queuing, and remains in the same
       system-node handler transaction as those side effects.
     example: 'order.received may have handler-level data_accumulation (3 fields) + rules with per-rule data_accumulation (category_data).
       Result: all 3 handler-level fields are written, PLUS the matching rule writes category_data. Event emission, however,
-      and action must be owned by the matching rule.'
+      and action must be owned by the matching rule or by the explicit rules emit template specialization.'
     precedence: Handler-level advances_to, sets_gate, and data_accumulation are defaults. If the matched rule specifies any
       of these, the rule value OVERRIDES the handler-level value for that field only. Bare emit and action never fall through from
-      a handler into a rules-based multi-emit/action handler; only explicit on_success.emit is additive, and only as a second
-      distinct success event.
+      a handler into a rules-based multi-emit/action handler. The only handler-level emit exception is rules emit template
+      specialization, where handler-level `emit.event` and shared `emit.fields` are inherited by the matched rule's eventless
+      `emit.fields` and produce exactly one effective emit. Explicit on_success.emit is additive only as a second distinct
+      success event.
 engine:
   description: Specification for the platform engine — how it loads, validates, and executes flows.
   flow_tree_walker:


### PR DESCRIPTION
## Summary
- Add the locked rules emit template specialization: handler-level `emit` supplies the event/shared fields and matched rule-level eventless `emit.fields` fill-merge into one effective emit.
- Route contracts, semantic view, bootverify payload completeness, engine emit selection, and pipeline proof through the same scoped effective emit helper.
- Update root `platform-spec.yaml` with the new authoritative syntax/semantics and preserve #1523 `on_success.emit` as a separate additive two-event surface.

Closes #1525

## Governing refs / context
- Binding issue context: #1525 design lock and approved Pre-Implementation Coverage Audit.
- Updated authoritative spec: root `platform-spec.yaml` sections `produces_derivation`, `handler_specification.dependency_graph`, `emit.single_emit_handler_rule`, `rules.emit_template_specialization`, and `rules_handler_interaction`.
- Adjacent existing context: #1462 Point 3, #1463 Tier 2b, and #1523 additive `on_success.emit` split.

## Semantic migration
- New canonical owner: `internal/runtime/contracts` effective emit helpers, especially `HandlerRuleEmitTemplateSites` and `EffectiveRuleEmitTemplateSpec`.
- Old producer/reader/interpreter paths now invalid for this shape: raw handler template emit plus raw eventless rule emit interpreted as separate authoritative emit sites; blanket eventless `emit.fields` parser rejection; executor-only merge without semanticview/bootverify/produces alignment.
- Production paths checked for surviving old behavior: YAML admission/ownership validation, `HandlerEmitEvents`, semantic view authored emit sites, bootverify payload completeness, engine selected declarative emits, pipeline/outbox transaction proof, and #1523 additive regression paths.
- Migration status: complete for the approved `rules_emit_template_specialization_one_effective_event` child class.

## Proof
- `go test ./internal/runtime/contracts ./internal/runtime/semanticview ./internal/runtime/bootverify ./internal/runtime/engine ./internal/runtime/pipeline -run 'Emit|OnSuccess|Produces|PayloadCompleteness|AuthoredEmitSites|ExecutionPlan|Ambiguous' -count=1`
- `go test ./...`