### PR TITLE
[agent-f][issue #1619] Retire timer duration aliases

### DIFF
--- a/internal/runtime/contracts/load_validation_test.go
+++ b/internal/runtime/contracts/load_validation_test.go
@@ -221,6 +221,24 @@ worker:
 	}
 }
 
+func TestLoadWorkflowContractBundleRejectsRetiredTimerDurationAlias(t *testing.T) {
+	repoRoot := contractRepoRoot(t)
+	root := t.TempDir()
+	writeFieldReconciliationBundle(t, root, "", `
+worker:
+  id: worker
+  timers:
+    - id: reminder
+      event: timer.reminder
+      delay_minutes: 5
+  event_handlers: {}
+`)
+	_, err := LoadWorkflowContractBundleWithOverrides(repoRoot, root, DefaultPlatformSpecFile(repoRoot))
+	if err == nil || !contractErrorContains(err, "RETIRED") || !contractErrorContains(err, "delay_minutes") {
+		t.Fatalf("LoadWorkflowContractBundleWithOverrides error = %v, want retired delay_minutes rejection", err)
+	}
+}
+
 func writeFieldReconciliationBundle(t *testing.T, root, schemaExtra, nodes string) {
 	t.Helper()
 	writeFixtureFile(t, filepath.Join(root, "package.yaml"), `

--- a/internal/runtime/contracts/workflow_contract_semantics.go
+++ b/internal/runtime/contracts/workflow_contract_semantics.go
@@ -536,18 +536,6 @@ func mergeWorkflowSemanticTimer(existing, incoming WorkflowTimerContract) Workfl
 	if strings.TrimSpace(existing.CancelOn) == "" {
 		existing.CancelOn = incoming.CancelOn
 	}
-	if existing.DelaySeconds == 0 {
-		existing.DelaySeconds = incoming.DelaySeconds
-	}
-	if existing.DelayMinutes == 0 {
-		existing.DelayMinutes = incoming.DelayMinutes
-	}
-	if existing.DelayHours == 0 {
-		existing.DelayHours = incoming.DelayHours
-	}
-	if existing.DelayDays == 0 {
-		existing.DelayDays = incoming.DelayDays
-	}
 	existing.Recurring = existing.Recurring || incoming.Recurring
 	return existing
 }

--- a/internal/runtime/contracts/workflow_contract_types.go
+++ b/internal/runtime/contracts/workflow_contract_types.go
@@ -1053,10 +1053,6 @@ type WorkflowTimerContract struct {
 	Delay        string `yaml:"delay"`
 	StartOn      string `yaml:"start_on"`
 	CancelOn     string `yaml:"cancel_on"`
-	DelaySeconds int    `yaml:"delay_seconds"`
-	DelayMinutes int    `yaml:"delay_minutes"`
-	DelayHours   int    `yaml:"delay_hours"`
-	DelayDays    int    `yaml:"delay_days"`
 	Recurring    bool   `yaml:"recurring"`
 }
 type EventEmission struct {

--- a/internal/runtime/contracts/workflow_contract_yaml_handlers.go
+++ b/internal/runtime/contracts/workflow_contract_yaml_handlers.go
@@ -21,6 +21,9 @@ func (t *WorkflowTimerContract) UnmarshalYAML(node *yaml.Node) error {
 		t.ID = strings.TrimSpace(node.Value)
 		return nil
 	case yaml.MappingNode:
+		if err := rejectWorkflowTimerRetiredDurationAliases(node); err != nil {
+			return err
+		}
 		type alias WorkflowTimerContract
 		var aux alias
 		if err := node.Decode(&aux); err != nil {
@@ -31,6 +34,33 @@ func (t *WorkflowTimerContract) UnmarshalYAML(node *yaml.Node) error {
 	default:
 		return fmt.Errorf("unsupported workflow timer yaml node kind %d", node.Kind)
 	}
+}
+
+func rejectWorkflowTimerRetiredDurationAliases(node *yaml.Node) error {
+	if node == nil || node.Kind != yaml.MappingNode {
+		return nil
+	}
+	hasDelay := false
+	retired := []string{}
+	for i := 0; i+1 < len(node.Content); i += 2 {
+		key := strings.TrimSpace(node.Content[i].Value)
+		switch key {
+		case "delay":
+			hasDelay = true
+		case "delay_seconds", "delay_minutes", "delay_hours", "delay_days":
+			retired = append(retired, key)
+		}
+	}
+	if len(retired) == 0 {
+		return nil
+	}
+	if hasDelay {
+		return fmt.Errorf("RETIRED timer duration fields %s cannot be combined with canonical delay; use delay only", strings.Join(retired, ", "))
+	}
+	if len(retired) == 1 {
+		return fmt.Errorf("RETIRED timer duration field %s is not accepted; use delay", retired[0])
+	}
+	return fmt.Errorf("RETIRED timer duration fields %s are not accepted; use delay", strings.Join(retired, ", "))
 }
 
 func (e *EventEmission) UnmarshalYAML(node *yaml.Node) error {

--- a/internal/runtime/contracts/workflow_contract_yaml_handlers.go
+++ b/internal/runtime/contracts/workflow_contract_yaml_handlers.go
@@ -40,17 +40,7 @@ func rejectWorkflowTimerRetiredDurationAliases(node *yaml.Node) error {
 	if node == nil || node.Kind != yaml.MappingNode {
 		return nil
 	}
-	hasDelay := false
-	retired := []string{}
-	for i := 0; i+1 < len(node.Content); i += 2 {
-		key := strings.TrimSpace(node.Content[i].Value)
-		switch key {
-		case "delay":
-			hasDelay = true
-		case "delay_seconds", "delay_minutes", "delay_hours", "delay_days":
-			retired = append(retired, key)
-		}
-	}
+	hasDelay, retired := workflowTimerDurationKeys(node, map[*yaml.Node]bool{})
 	if len(retired) == 0 {
 		return nil
 	}
@@ -61,6 +51,69 @@ func rejectWorkflowTimerRetiredDurationAliases(node *yaml.Node) error {
 		return fmt.Errorf("RETIRED timer duration field %s is not accepted; use delay", retired[0])
 	}
 	return fmt.Errorf("RETIRED timer duration fields %s are not accepted; use delay", strings.Join(retired, ", "))
+}
+
+func workflowTimerDurationKeys(node *yaml.Node, seen map[*yaml.Node]bool) (bool, []string) {
+	if node == nil {
+		return false, nil
+	}
+	if seen[node] {
+		return false, nil
+	}
+	seen[node] = true
+	switch node.Kind {
+	case yaml.AliasNode:
+		return workflowTimerDurationKeys(node.Alias, seen)
+	case yaml.SequenceNode:
+		hasDelay := false
+		retired := []string{}
+		for _, child := range node.Content {
+			childHasDelay, childRetired := workflowTimerDurationKeys(child, seen)
+			hasDelay = hasDelay || childHasDelay
+			retired = appendRetiredTimerDurationFields(retired, childRetired...)
+		}
+		return hasDelay, retired
+	case yaml.MappingNode:
+		hasDelay := false
+		retired := []string{}
+		for i := 0; i+1 < len(node.Content); i += 2 {
+			key := strings.TrimSpace(node.Content[i].Value)
+			if key == "<<" || strings.TrimSpace(node.Content[i].Tag) == "!!merge" {
+				mergeHasDelay, mergeRetired := workflowTimerDurationKeys(node.Content[i+1], seen)
+				hasDelay = hasDelay || mergeHasDelay
+				retired = appendRetiredTimerDurationFields(retired, mergeRetired...)
+				continue
+			}
+			switch key {
+			case "delay":
+				hasDelay = true
+			case "delay_seconds", "delay_minutes", "delay_hours", "delay_days":
+				retired = appendRetiredTimerDurationFields(retired, key)
+			}
+		}
+		return hasDelay, retired
+	default:
+		return false, nil
+	}
+}
+
+func appendRetiredTimerDurationFields(fields []string, candidates ...string) []string {
+	for _, candidate := range candidates {
+		if candidate == "" {
+			continue
+		}
+		seen := false
+		for _, existing := range fields {
+			if existing == candidate {
+				seen = true
+				break
+			}
+		}
+		if !seen {
+			fields = append(fields, candidate)
+		}
+	}
+	return fields
 }
 
 func (e *EventEmission) UnmarshalYAML(node *yaml.Node) error {

--- a/internal/runtime/contracts/workflow_contract_yaml_test.go
+++ b/internal/runtime/contracts/workflow_contract_yaml_test.go
@@ -705,6 +705,58 @@ event_handlers:
 	}
 }
 
+func TestWorkflowTimerContractDecode_RejectsRetiredDurationAliases(t *testing.T) {
+	tests := []struct {
+		name  string
+		field string
+	}{
+		{name: "seconds", field: "delay_seconds: 30"},
+		{name: "minutes", field: "delay_minutes: 5"},
+		{name: "hours", field: "delay_hours: 2"},
+		{name: "days", field: "delay_days: 1"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var timer WorkflowTimerContract
+			err := yaml.Unmarshal([]byte(`
+id: reminder
+event: timer.reminder
+`+tc.field+`
+`), &timer)
+			if err == nil || !strings.Contains(err.Error(), "RETIRED") || !strings.Contains(err.Error(), strings.Split(tc.field, ":")[0]) || !strings.Contains(err.Error(), "delay") {
+				t.Fatalf("yaml.Unmarshal error = %v, want retired alias rejection for %s", err, tc.field)
+			}
+		})
+	}
+}
+
+func TestWorkflowTimerContractDecode_RejectsMixedCanonicalAndRetiredDurationAlias(t *testing.T) {
+	var timer WorkflowTimerContract
+	err := yaml.Unmarshal([]byte(`
+id: reminder
+event: timer.reminder
+delay: 30m
+delay_minutes: 30
+`), &timer)
+	if err == nil || !strings.Contains(err.Error(), "cannot be combined with canonical delay") {
+		t.Fatalf("yaml.Unmarshal error = %v, want mixed canonical+retired alias rejection", err)
+	}
+}
+
+func TestWorkflowTimerContractDecode_PreservesCanonicalDelay(t *testing.T) {
+	var timer WorkflowTimerContract
+	if err := yaml.Unmarshal([]byte(`
+id: reminder
+event: timer.reminder
+delay: 7d
+`), &timer); err != nil {
+		t.Fatalf("yaml.Unmarshal: %v", err)
+	}
+	if got := strings.TrimSpace(timer.Delay); got != "7d" {
+		t.Fatalf("Delay = %q, want 7d", got)
+	}
+}
+
 func TestFlowSchemaDocumentDecode_PreservesRequiredAgentSubscribesTo(t *testing.T) {
 	var schema FlowSchemaDocument
 	if err := yaml.Unmarshal([]byte(`

--- a/internal/runtime/contracts/workflow_contract_yaml_test.go
+++ b/internal/runtime/contracts/workflow_contract_yaml_test.go
@@ -743,6 +743,36 @@ delay_minutes: 30
 	}
 }
 
+func TestWorkflowTimerContractDecode_RejectsMergedRetiredDurationAliases(t *testing.T) {
+	tests := []struct {
+		name  string
+		field string
+	}{
+		{name: "seconds", field: "delay_seconds: 30"},
+		{name: "minutes", field: "delay_minutes: 5"},
+		{name: "hours", field: "delay_hours: 2"},
+		{name: "days", field: "delay_days: 1"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var doc struct {
+				Timer WorkflowTimerContract `yaml:"timer"`
+			}
+			err := yaml.Unmarshal([]byte(`
+timer_defaults: &timer_defaults
+  `+tc.field+`
+timer:
+  <<: *timer_defaults
+  id: reminder
+  event: timer.reminder
+`), &doc)
+			if err == nil || !strings.Contains(err.Error(), "RETIRED") || !strings.Contains(err.Error(), strings.Split(tc.field, ":")[0]) {
+				t.Fatalf("yaml.Unmarshal error = %v, want merged retired alias rejection for %s", err, tc.field)
+			}
+		})
+	}
+}
+
 func TestWorkflowTimerContractDecode_PreservesCanonicalDelay(t *testing.T) {
 	var timer WorkflowTimerContract
 	if err := yaml.Unmarshal([]byte(`

--- a/internal/runtime/core/timeridentity/timeridentity.go
+++ b/internal/runtime/core/timeridentity/timeridentity.go
@@ -2,7 +2,9 @@ package timeridentity
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
+	"time"
 )
 
 type TriggerKind string
@@ -44,6 +46,30 @@ func ParseStartTrigger(raw string) (Trigger, error) {
 
 func ParseCancelTrigger(raw string) (Trigger, error) {
 	return parseTrigger(raw, false)
+}
+
+func ParseDelayDuration(raw string) (time.Duration, bool) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return 0, false
+	}
+	if duration, err := time.ParseDuration(raw); err == nil && duration > 0 {
+		return duration, true
+	}
+	if !strings.HasSuffix(raw, "d") {
+		return 0, false
+	}
+	daysRaw := strings.TrimSpace(strings.TrimSuffix(raw, "d"))
+	days, err := strconv.ParseInt(daysRaw, 10, 64)
+	if err != nil || days <= 0 {
+		return 0, false
+	}
+	const day = 24 * time.Hour
+	const maxDuration = time.Duration(1<<63 - 1)
+	if days > int64(maxDuration/day) {
+		return 0, false
+	}
+	return time.Duration(days) * day, true
 }
 
 func parseTrigger(raw string, allowBoot bool) (Trigger, error) {

--- a/internal/runtime/core/timeridentity/timeridentity_test.go
+++ b/internal/runtime/core/timeridentity/timeridentity_test.go
@@ -1,6 +1,9 @@
 package timeridentity
 
-import "testing"
+import (
+	"testing"
+	"time"
+)
 
 func TestParseStartTrigger(t *testing.T) {
 	trigger, err := ParseStartTrigger("state:active")
@@ -24,6 +27,38 @@ func TestParseTriggerRejectsUnprefixedValues(t *testing.T) {
 func TestParseCancelTriggerRejectsBoot(t *testing.T) {
 	if _, err := ParseCancelTrigger("boot"); err == nil {
 		t.Fatal("expected cancel_on boot to be rejected")
+	}
+}
+
+func TestParseDelayDurationSupportsGoDurationAndDayUnit(t *testing.T) {
+	tests := []struct {
+		raw  string
+		want time.Duration
+	}{
+		{raw: "30m", want: 30 * time.Minute},
+		{raw: "1h30m", want: 90 * time.Minute},
+		{raw: "7d", want: 7 * 24 * time.Hour},
+	}
+	for _, tc := range tests {
+		t.Run(tc.raw, func(t *testing.T) {
+			got, ok := ParseDelayDuration(tc.raw)
+			if !ok {
+				t.Fatalf("ParseDelayDuration(%q) did not parse", tc.raw)
+			}
+			if got != tc.want {
+				t.Fatalf("ParseDelayDuration(%q) = %s, want %s", tc.raw, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestParseDelayDurationRejectsInvalidOrNonPositiveValues(t *testing.T) {
+	for _, raw := range []string{"", "0s", "-1s", "1.5d", "soon"} {
+		t.Run(raw, func(t *testing.T) {
+			if got, ok := ParseDelayDuration(raw); ok {
+				t.Fatalf("ParseDelayDuration(%q) = %s, want rejection", raw, got)
+			}
+		})
 	}
 }
 

--- a/internal/runtime/pipeline/workflow_timer_lifecycle.go
+++ b/internal/runtime/pipeline/workflow_timer_lifecycle.go
@@ -311,17 +311,12 @@ func workflowTimerFireAt(timer runtimecontracts.WorkflowTimerContract, now time.
 }
 
 func workflowTimerDuration(timer runtimecontracts.WorkflowTimerContract, policy map[string]any) time.Duration {
-	var interval time.Duration
 	if delay := workflowTimerRenderedDelay(timer.Delay, policy); delay != "" {
-		if parsed, err := time.ParseDuration(delay); err == nil && parsed > 0 {
-			interval += parsed
+		if parsed, ok := timeridentity.ParseDelayDuration(delay); ok {
+			return parsed
 		}
 	}
-	interval += time.Duration(timer.DelaySeconds) * time.Second
-	interval += time.Duration(timer.DelayMinutes) * time.Minute
-	interval += time.Duration(timer.DelayHours) * time.Hour
-	interval += time.Duration(timer.DelayDays) * 24 * time.Hour
-	return interval
+	return 0
 }
 
 func workflowTimerRenderedDelay(delay string, policy map[string]any) string {
@@ -383,17 +378,12 @@ func workflowTimerCancelTrigger(timer runtimecontracts.WorkflowTimerContract) (t
 }
 
 func workflowTimerRecurringSpec(timer runtimecontracts.WorkflowTimerContract, policy map[string]any) (string, bool) {
-	if delay := workflowTimerRenderedDelay(timer.Delay, policy); delay != "" && !strings.Contains(delay, "{") {
-		return "@every " + delay, true
+	if delay := workflowTimerRenderedDelay(timer.Delay, policy); delay != "" {
+		if interval, ok := timeridentity.ParseDelayDuration(delay); ok {
+			return "@every " + interval.String(), true
+		}
 	}
-	interval := time.Duration(timer.DelaySeconds) * time.Second
-	interval += time.Duration(timer.DelayMinutes) * time.Minute
-	interval += time.Duration(timer.DelayHours) * time.Hour
-	interval += time.Duration(timer.DelayDays) * 24 * time.Hour
-	if interval <= 0 {
-		return "", false
-	}
-	return "@every " + interval.String(), true
+	return "", false
 }
 
 func (pc *PipelineCoordinator) registerWorkflowTimerSchedule(ctx context.Context, sc Schedule) {

--- a/internal/runtime/pipeline/workflow_timer_lifecycle_test.go
+++ b/internal/runtime/pipeline/workflow_timer_lifecycle_test.go
@@ -128,6 +128,62 @@ func TestWorkflowTimerFireAtSnapshotsPolicyDelayAtStart(t *testing.T) {
 	}
 }
 
+func TestWorkflowTimerFireAtSupportsCanonicalDayDelay(t *testing.T) {
+	now := time.Date(2026, time.July, 1, 12, 0, 0, 0, time.UTC)
+	timer := runtimecontracts.WorkflowTimerContract{
+		ID:    "sla_timeout",
+		Owner: "support-node",
+		Event: "timer.sla_timeout",
+		Delay: "7d",
+	}
+
+	fireAt, ok := workflowTimerFireAt(timer, now, nil)
+	if !ok {
+		t.Fatal("expected canonical day delay to render")
+	}
+	if want := now.Add(7 * 24 * time.Hour); !fireAt.Equal(want) {
+		t.Fatalf("fireAt = %s, want %s", fireAt, want)
+	}
+}
+
+func TestWorkflowTimerFireAtSupportsPolicyRenderedDayDelay(t *testing.T) {
+	now := time.Date(2026, time.July, 1, 12, 0, 0, 0, time.UTC)
+	timer := runtimecontracts.WorkflowTimerContract{
+		ID:    "sla_timeout",
+		Owner: "support-node",
+		Event: "timer.sla_timeout",
+		Delay: "{{sla_timeout_days}}d",
+	}
+
+	fireAt, ok := workflowTimerFireAt(timer, now, map[string]any{
+		"sla_timeout_days": 3,
+	})
+	if !ok {
+		t.Fatal("expected policy-backed day delay to render")
+	}
+	if want := now.Add(3 * 24 * time.Hour); !fireAt.Equal(want) {
+		t.Fatalf("fireAt = %s, want %s", fireAt, want)
+	}
+}
+
+func TestWorkflowTimerRecurringSpecNormalizesCanonicalDayDelay(t *testing.T) {
+	timer := runtimecontracts.WorkflowTimerContract{
+		ID:        "daily_report",
+		Owner:     "runtime",
+		Event:     "timer.daily_report",
+		Delay:     "7d",
+		Recurring: true,
+	}
+
+	got, ok := workflowTimerRecurringSpec(timer, nil)
+	if !ok {
+		t.Fatal("expected canonical day delay recurring spec")
+	}
+	if want := "@every 168h0m0s"; got != want {
+		t.Fatalf("workflowTimerRecurringSpec = %q, want %q", got, want)
+	}
+}
+
 func TestExecuteNodeHandlerPlan_EventTimerStartOnRegistersSchedule(t *testing.T) {
 	repoRoot := filepath.Clean(filepath.Join("..", "..", ".."))
 	fixtureRoot := filepath.Join(repoRoot, "tests", "tier5-flow-lifecycle", "test-timer-fire")

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -1443,17 +1443,12 @@ func ensureLifecycleWorkflowSchedules(ctx context.Context, store runtimepipeline
 }
 
 func bootWorkflowTimerDuration(source semanticview.Source, timer runtimecontracts.WorkflowTimerContract) time.Duration {
-	var interval time.Duration
 	if delay := bootWorkflowTimerRenderedDelay(source, timer, timer.Delay); delay != "" && !strings.Contains(delay, "{") {
-		if parsed, err := time.ParseDuration(delay); err == nil && parsed > 0 {
-			interval += parsed
+		if parsed, ok := timeridentity.ParseDelayDuration(delay); ok {
+			return parsed
 		}
 	}
-	interval += time.Duration(timer.DelaySeconds) * time.Second
-	interval += time.Duration(timer.DelayMinutes) * time.Minute
-	interval += time.Duration(timer.DelayHours) * time.Hour
-	interval += time.Duration(timer.DelayDays) * 24 * time.Hour
-	return interval
+	return 0
 }
 
 func bootWorkflowTimerRenderedDelay(source semanticview.Source, timer runtimecontracts.WorkflowTimerContract, delay string) string {

--- a/internal/runtime/runtime_schedule_test.go
+++ b/internal/runtime/runtime_schedule_test.go
@@ -304,6 +304,34 @@ func TestEnsureBootWorkflowSchedulesRegistersGlobalBootOneShotTimers(t *testing.
 	}
 }
 
+func TestEnsureBootWorkflowSchedulesSupportsCanonicalDayDelay(t *testing.T) {
+	store := &recordingRuntimeScheduleStore{}
+	bundle := &runtimecontracts.WorkflowContractBundle{
+		Semantics: runtimecontracts.WorkflowSemanticView{
+			Timers: []runtimecontracts.WorkflowTimerContract{{
+				ID:      "boot_day",
+				Owner:   "runtime",
+				Event:   "timer.boot_day",
+				Delay:   "1d",
+				StartOn: "boot",
+			}},
+		},
+	}
+	before := time.Now().UTC()
+	err := ensureBootWorkflowSchedules(context.Background(), store, nil, semanticOnlyWorkflowRuntime{
+		source: semanticview.Wrap(bundle),
+	})
+	if err != nil {
+		t.Fatalf("ensureBootWorkflowSchedules: %v", err)
+	}
+	if len(store.schedules) != 1 {
+		t.Fatalf("startup boot schedules = %#v, want 1 one-shot boot schedule", store.schedules)
+	}
+	if got := store.schedules[0].At; got.Before(before.Add(24*time.Hour)) || got.After(time.Now().UTC().Add(24*time.Hour+time.Second)) {
+		t.Fatalf("schedule At = %v, want roughly 1d after startup", got)
+	}
+}
+
 func TestEnsureBootWorkflowSchedulesPreservesActiveExactBootSchedule(t *testing.T) {
 	activeAt := time.Now().UTC().Add(-1 * time.Minute)
 	store := &recordingRuntimeScheduleStore{

--- a/internal/runtime/testdata/generic-swarm-bundle/workflow.yaml
+++ b/internal/runtime/testdata/generic-swarm-bundle/workflow.yaml
@@ -82,4 +82,4 @@ workflow:
       owner: delivery-node
       start_on: state:approved
       cancel_on: state:completed
-      delay_minutes: 30
+      delay: 30m

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -69,12 +69,16 @@ vocabulary:
     - event
     - owner
     optional_fields:
+    - delay
+    - cancellation
+    - recurring
+    retired_fields:
     - delay_seconds
     - delay_minutes
     - delay_hours
     - delay_days
-    - cancellation
-    - recurring
+    retirement_rule: Numeric duration aliases are retired public YAML. Timer declarations must use canonical delay
+      and retired aliases fail closed.
   agent_role:
     description: 'An entity that owns transitions, handles events, and executes logic. Three execution types with different
       semantics.
@@ -4099,7 +4103,8 @@ engine:
       fields:
         id: Unique timer name
         event: Event name to fire when timer expires (e.g., timer.scan_timeout)
-        delay: Duration string (e.g., 72h, 30m, 7d) or policy reference (e.g., policy.sla_timeout)
+        delay: Canonical duration string or policy-rendered duration. Accepts Go duration strings (e.g., 72h,
+          30m) plus a positive integer day unit (e.g., 7d).
         recurring: Boolean — if true, timer re-fires at the interval until cancelled
         start_on: Trigger that starts the timer. Canonical forms are state:<name>, event:<name>, or boot.
         cancel_on: Trigger that cancels the timer. Canonical forms are state:<name> or event:<name>. boot is invalid.


### PR DESCRIPTION
## Summary

- Makes workflow timer declaration `delay` the sole public YAML duration field and hard-rejects `delay_seconds`, `delay_minutes`, `delay_hours`, and `delay_days`.
- Promotes a timer-owned duration parser for canonical `delay`, preserving Go duration values and adding integer day-unit support like `7d`.
- Routes boot-start, one-shot lifecycle, recurring lifecycle, and policy-rendered delay scheduling through the same parser/normalizer.
- Migrates checked-in timer fixture YAML to canonical `delay`.

Closes #1619
Part of #1596

## Governing Refs / Context

- Approved #1619 Pre-Implementation Coverage Audit: https://github.com/division-sh/swarm/issues/1619#issuecomment-4868947808
- Independent gate outcome: https://github.com/division-sh/swarm/issues/1619#issuecomment-4869013054
- Exact spec refs updated/used: `platform-spec.yaml#spec_authority`, `platform-spec.yaml#vocabulary.timer`, `platform-spec.yaml#engine.timer_model.declaration`, `platform-spec.yaml#engine.timer_model.lifecycle`, `platform-spec.yaml#engine.timer_model.boot_validation`.
- `docs/IMPLEMENTER_GUIDELINES.md` and `docs/SEMANTIC_DRIFT.md` were absent in this checkout, matching the pre-audit record.

## Semantic Migration

- New canonical owner: `platform-spec.yaml#engine.timer_model.declaration.fields.delay`, `WorkflowTimerContract.Delay`, and `timeridentity.ParseDelayDuration` for timer-owned delay grammar.
- Old producer/reader/writer path now invalid: public timer YAML aliases `delay_seconds`, `delay_minutes`, `delay_hours`, `delay_days`; numeric `WorkflowTimerContract` fields; semantic merge copying of numeric aliases; boot/lifecycle duration fallback arithmetic over numeric aliases.
- Production paths checked for surviving old behavior: YAML decode/load, semantic timer derivation/merge, boot-start scheduling, lifecycle one-shot scheduling, recurring scheduling, policy-rendered delay, checked-in timer fixtures, and scoped repo search for old alias names.
- Migration completeness: complete for #1619. Runtime tool `schedule.delay_seconds` remains intentionally valid as a different semantic concept outside the workflow timer declaration surface.

## Validation

- `go test ./internal/runtime/core/timeridentity ./internal/runtime/contracts ./internal/runtime/bootverify ./internal/runtime/pipeline ./cmd/swarm ./internal/runtime/tools -count=1`
- `go test ./cmd/swarm -run TestRunServeRuntimeEventPublishDynamicAutoEmitServedPathPostgres -count=1 -v` after an initial unrelated full-suite timing failure in that existing test
- `go test ./...`
- `git diff --check`
- `rg -n "DelaySeconds|DelayMinutes|DelayHours|DelayDays" .`
- `rg -n "delay_seconds|delay_minutes|delay_hours|delay_days" .`