### PR TITLE
[agent-b][issue #1613] Add runtime identity registry primitives

### DIFF
--- a/cmd/swarm/cli.go
+++ b/cmd/swarm/cli.go
@@ -80,6 +80,7 @@ func newRootCommandWithOptions(ctx context.Context, repo string, out, errOut io.
 		newDoctorCommand(ctx, repo),
 		newVerifyCommand(ctx, repo),
 		newSecretsCommand(ctx, repo),
+		newContextCommand(ctx, opts),
 		newWorkspaceCommand(ctx),
 		newVersionCommand(opts),
 		newCompletionCommand(),

--- a/cmd/swarm/context_command.go
+++ b/cmd/swarm/context_command.go
@@ -108,12 +108,16 @@ func inspectLocalContextRegistryForCommand(ctx context.Context, cmd *cobra.Comma
 }
 
 func resolveSwarmDirForCommand(cmd *cobra.Command) (cliSwarmDirResolution, error) {
+	swarmDirFlag, swarmDirFlagSet := rootSwarmDirFlag(cmd)
+	if swarmDirFlagSet {
+		path, err := normalizeCLISwarmDir(swarmDirFlag, "--swarm-dir")
+		return cliSwarmDirResolution{Path: path, Source: "--swarm-dir"}, err
+	}
 	cfg, err := loadCLIAPIConfigFile()
 	if err != nil {
 		return cliSwarmDirResolution{}, err
 	}
-	swarmDirFlag, swarmDirFlagSet := rootSwarmDirFlag(cmd)
-	return resolveCLISwarmDirFromConfig(cliSwarmDirOptions{SwarmDir: swarmDirFlag, SwarmDirFlagSet: swarmDirFlagSet}, cfg)
+	return resolveCLISwarmDirFromConfig(cliSwarmDirOptions{}, cfg)
 }
 
 func writeContextCurrentText(out io.Writer, report localContextRegistryReport) {

--- a/cmd/swarm/context_command.go
+++ b/cmd/swarm/context_command.go
@@ -141,6 +141,12 @@ func writeContextListText(out io.Writer, report localContextRegistryReport) {
 	}
 	if len(report.Entries) == 0 {
 		fmt.Fprintf(out, "no contexts found\n")
+		if report.Status != "" && report.Status != "empty" {
+			fmt.Fprintf(out, "registry_status: %s\n", report.Status)
+			if report.Detail != "" {
+				fmt.Fprintf(out, "detail: %s\n", report.Detail)
+			}
+		}
 		return
 	}
 	fmt.Fprintf(out, "%-24s %-22s %-9s %s\n", "NAME", "STATUS", "TRANSPORT", "TARGET")

--- a/cmd/swarm/context_command.go
+++ b/cmd/swarm/context_command.go
@@ -1,0 +1,196 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+type contextCommandOptions struct {
+	asJSON bool
+}
+
+func newContextCommand(ctx context.Context, opts rootCommandOptions) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "context",
+		Short: "Inspect local Swarm runtime context descriptors.",
+	}
+	cmd.AddCommand(
+		newContextCurrentCommand(ctx, opts),
+		newContextListCommand(ctx, opts),
+		newContextPruneCommand(ctx, opts),
+	)
+	return cmd
+}
+
+func newContextCurrentCommand(ctx context.Context, opts rootCommandOptions) *cobra.Command {
+	var commandOpts contextCommandOptions
+	cmd := &cobra.Command{
+		Use:   "current",
+		Short: "Show the selected local Swarm context.",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			report, err := inspectLocalContextRegistryForCommand(ctx, cmd, opts)
+			if err != nil {
+				return returnCLIValidationError(cmd.ErrOrStderr(), err)
+			}
+			if commandOpts.asJSON {
+				return writeJSON(cmd.OutOrStdout(), report)
+			}
+			writeContextCurrentText(cmd.OutOrStdout(), report)
+			return nil
+		},
+	}
+	cmd.Flags().BoolVar(&commandOpts.asJSON, "json", false, "Render current context details as JSON")
+	return cmd
+}
+
+func newContextListCommand(ctx context.Context, opts rootCommandOptions) *cobra.Command {
+	var commandOpts contextCommandOptions
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List local Swarm context descriptors.",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			report, err := inspectLocalContextRegistryForCommand(ctx, cmd, opts)
+			if err != nil {
+				return returnCLIValidationError(cmd.ErrOrStderr(), err)
+			}
+			if commandOpts.asJSON {
+				return writeJSON(cmd.OutOrStdout(), report)
+			}
+			writeContextListText(cmd.OutOrStdout(), report)
+			return nil
+		},
+	}
+	cmd.Flags().BoolVar(&commandOpts.asJSON, "json", false, "Render context descriptors as JSON")
+	return cmd
+}
+
+func newContextPruneCommand(ctx context.Context, opts rootCommandOptions) *cobra.Command {
+	var commandOpts contextCommandOptions
+	cmd := &cobra.Command{
+		Use:   "prune",
+		Short: "Remove stale, mismatched, corrupt, or unsupported local Swarm context descriptors.",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			swarmDir, err := resolveSwarmDirForCommand(cmd)
+			if err != nil {
+				return returnCLIValidationError(cmd.ErrOrStderr(), err)
+			}
+			registry := newLocalContextRegistry(swarmDir.Path)
+			result, err := registry.Prune(ctx, cliRuntimeIdentityCaller{httpClient: opts.httpClient})
+			if err != nil {
+				return returnCLIValidationError(cmd.ErrOrStderr(), err)
+			}
+			if commandOpts.asJSON {
+				return writeJSON(cmd.OutOrStdout(), result)
+			}
+			writeContextPruneText(cmd.OutOrStdout(), result)
+			return nil
+		},
+	}
+	cmd.Flags().BoolVar(&commandOpts.asJSON, "json", false, "Render prune result as JSON")
+	return cmd
+}
+
+func inspectLocalContextRegistryForCommand(ctx context.Context, cmd *cobra.Command, opts rootCommandOptions) (localContextRegistryReport, error) {
+	swarmDir, err := resolveSwarmDirForCommand(cmd)
+	if err != nil {
+		return localContextRegistryReport{}, err
+	}
+	registry := newLocalContextRegistry(swarmDir.Path)
+	return registry.Inspect(ctx, cliRuntimeIdentityCaller{httpClient: opts.httpClient})
+}
+
+func resolveSwarmDirForCommand(cmd *cobra.Command) (cliSwarmDirResolution, error) {
+	cfg, err := loadCLIAPIConfigFile()
+	if err != nil {
+		return cliSwarmDirResolution{}, err
+	}
+	swarmDirFlag, swarmDirFlagSet := rootSwarmDirFlag(cmd)
+	return resolveCLISwarmDirFromConfig(cliSwarmDirOptions{SwarmDir: swarmDirFlag, SwarmDirFlagSet: swarmDirFlagSet}, cfg)
+}
+
+func writeContextCurrentText(out io.Writer, report localContextRegistryReport) {
+	if out == nil {
+		return
+	}
+	if report.Current == nil {
+		fmt.Fprintf(out, "current context: none\n")
+		fmt.Fprintf(out, "registry_status: %s\n", report.Status)
+		if report.Detail != "" {
+			fmt.Fprintf(out, "detail: %s\n", report.Detail)
+		}
+		return
+	}
+	writeContextEntryText(out, "current context", *report.Current)
+}
+
+func writeContextListText(out io.Writer, report localContextRegistryReport) {
+	if out == nil {
+		return
+	}
+	if len(report.Entries) == 0 {
+		fmt.Fprintf(out, "no contexts found\n")
+		return
+	}
+	fmt.Fprintf(out, "%-24s %-22s %-9s %s\n", "NAME", "STATUS", "TRANSPORT", "TARGET")
+	for _, entry := range report.Entries {
+		target := contextEntryTarget(entry.Descriptor)
+		fmt.Fprintf(out, "%-24s %-22s %-9s %s\n", entry.Descriptor.Name, entry.Status, entry.Descriptor.Transport, target)
+	}
+}
+
+func writeContextEntryText(out io.Writer, label string, entry localContextEntry) {
+	fmt.Fprintf(out, "%s: %s\n", label, entry.Descriptor.Name)
+	fmt.Fprintf(out, "status: %s\n", entry.Status)
+	fmt.Fprintf(out, "runtime_instance_id: %s\n", entry.Descriptor.RuntimeInstanceID)
+	fmt.Fprintf(out, "transport: %s\n", entry.Descriptor.Transport)
+	fmt.Fprintf(out, "target: %s\n", contextEntryTarget(entry.Descriptor))
+	if entry.Detail != "" {
+		fmt.Fprintf(out, "detail: %s\n", entry.Detail)
+	}
+}
+
+func writeContextPruneText(out io.Writer, result localContextPruneResult) {
+	if out == nil {
+		return
+	}
+	if len(result.Removed) == 0 {
+		fmt.Fprintf(out, "removed contexts: 0\n")
+		return
+	}
+	fmt.Fprintf(out, "removed contexts: %d\n", len(result.Removed))
+	for _, entry := range result.Removed {
+		detail := strings.TrimSpace(entry.Detail)
+		if detail != "" {
+			detail = " (" + detail + ")"
+		}
+		fmt.Fprintf(out, "- %s: %s%s\n", entry.Descriptor.Name, entry.Status, detail)
+	}
+}
+
+func contextEntryTarget(desc localContextDescriptor) string {
+	switch desc.Transport {
+	case localContextTransportTCP:
+		return desc.APIServer
+	case localContextTransportUnix:
+		return desc.SocketPath
+	default:
+		return ""
+	}
+}
+
+func writeJSON(out io.Writer, value any) error {
+	if out == nil {
+		return nil
+	}
+	encoder := json.NewEncoder(out)
+	encoder.SetIndent("", "  ")
+	return encoder.Encode(value)
+}

--- a/cmd/swarm/context_command_test.go
+++ b/cmd/swarm/context_command_test.go
@@ -24,6 +24,20 @@ func TestContextListCommandUsesSwarmDirRegistry(t *testing.T) {
 	}
 }
 
+func TestContextListCommandSwarmDirFlagBypassesBrokenConfig(t *testing.T) {
+	isolateCLIAPIConfigEnv(t)
+	swarmDir := t.TempDir()
+	t.Setenv("SWARM_CONFIG", filepath.Join(t.TempDir(), "missing-config.yaml"))
+	var out, errOut bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"--swarm-dir", swarmDir, "context", "list"}, &out, &errOut, rootCommandOptions{})
+	if code != 0 {
+		t.Fatalf("exit = %d stderr=%s", code, errOut.String())
+	}
+	if !strings.Contains(out.String(), "no contexts found") {
+		t.Fatalf("output = %q, want empty registry", out.String())
+	}
+}
+
 func TestContextCurrentCommandReportsEmptyRegistry(t *testing.T) {
 	var out, errOut bytes.Buffer
 	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"--swarm-dir", filepath.Join(t.TempDir(), "state"), "context", "current"}, &out, &errOut, rootCommandOptions{})

--- a/cmd/swarm/context_command_test.go
+++ b/cmd/swarm/context_command_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"context"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -35,6 +36,24 @@ func TestContextListCommandSwarmDirFlagBypassesBrokenConfig(t *testing.T) {
 	}
 	if !strings.Contains(out.String(), "no contexts found") {
 		t.Fatalf("output = %q, want empty registry", out.String())
+	}
+}
+
+func TestContextListCommandSurfacesZeroEntryRegistryFailure(t *testing.T) {
+	swarmDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(swarmDir, "contexts"), []byte("not a registry directory"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	var out, errOut bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"--swarm-dir", swarmDir, "context", "list"}, &out, &errOut, rootCommandOptions{})
+	if code != 0 {
+		t.Fatalf("exit = %d stderr=%s", code, errOut.String())
+	}
+	if !strings.Contains(out.String(), "no contexts found") {
+		t.Fatalf("output = %q, want empty-list marker", out.String())
+	}
+	if !strings.Contains(out.String(), "registry_status: invalid_descriptor") || !strings.Contains(out.String(), "detail:") {
+		t.Fatalf("output = %q, want registry failure status and detail", out.String())
 	}
 }
 

--- a/cmd/swarm/context_command_test.go
+++ b/cmd/swarm/context_command_test.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestContextListCommandUsesSwarmDirRegistry(t *testing.T) {
+	swarmDir := t.TempDir()
+	registry := newLocalContextRegistry(swarmDir)
+	if err := registry.WriteDescriptor(testLocalContextDescriptor("local", "runtime-a")); err != nil {
+		t.Fatal(err)
+	}
+	var out, errOut bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"--swarm-dir", swarmDir, "context", "list"}, &out, &errOut, rootCommandOptions{})
+	if code != 0 {
+		t.Fatalf("exit = %d stderr=%s", code, errOut.String())
+	}
+	if !strings.Contains(out.String(), "local") || !strings.Contains(out.String(), "no_server") {
+		t.Fatalf("output = %q, want local no_server row", out.String())
+	}
+}
+
+func TestContextCurrentCommandReportsEmptyRegistry(t *testing.T) {
+	var out, errOut bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"--swarm-dir", filepath.Join(t.TempDir(), "state"), "context", "current"}, &out, &errOut, rootCommandOptions{})
+	if code != 0 {
+		t.Fatalf("exit = %d stderr=%s", code, errOut.String())
+	}
+	if !strings.Contains(out.String(), "current context: none") {
+		t.Fatalf("output = %q, want no current context", out.String())
+	}
+}

--- a/cmd/swarm/doctor_test.go
+++ b/cmd/swarm/doctor_test.go
@@ -290,8 +290,8 @@ func TestDoctorTargetHumanExplainsResolutionWithoutPreflight(t *testing.T) {
 		"swarm_dir: " + flagSwarmDir + " (source: --swarm-dir)",
 		"project_root: " + repo,
 		"api_server: http://127.0.0.1:19001 (source: config api_server)",
-		"descriptor_registry: pending (#1613)",
-		"runtime_identity: pending (#1613)",
+		"descriptor_registry: empty (" + localContextRegistryOwner,
+		"runtime_identity: unavailable (platform-spec.yaml#api_specification.method_catalog.runtime.identity)",
 		"store_path: " + filepath.Join(repo, ".swarm", "dev.db"),
 		"data_dir: " + filepath.Join(repo, ".swarm", "data"),
 		"command_classes:",
@@ -339,8 +339,8 @@ func TestDoctorTargetJSONPreservesScriptableOutput(t *testing.T) {
 	if report.API.Server != apiServer || report.API.Source != "--api-server" || report.API.Auth.Source != "--api-token-file" {
 		t.Fatalf("api resolution = %#v", report.API)
 	}
-	if report.Context.Registry.Status != "pending" || report.RuntimeIdentity.Status != "pending" {
-		t.Fatalf("registry/identity should be pending, report = %#v", report)
+	if report.Context.Registry.Status != "empty" || report.RuntimeIdentity.Status != "unavailable" {
+		t.Fatalf("registry should be empty and runtime identity unavailable, report = %#v", report)
 	}
 	if len(report.CommandClasses) == 0 || len(report.SplitSiblings) == 0 {
 		t.Fatalf("report missing command classes or split siblings: %#v", report)
@@ -528,6 +528,16 @@ func TestPlatformSpecLocalTargetResolutionAuthorityPromoted(t *testing.T) {
 					} `yaml:"doctor_target_surface"`
 					SplitSiblings []string `yaml:"split_siblings"`
 				} `yaml:"local_target_resolution_authority"`
+				LocalContextRegistry struct {
+					PromotedBy           string   `yaml:"promoted_by"`
+					ImplementationStatus string   `yaml:"implementation_status"`
+					CanonicalOwner       string   `yaml:"canonical_owner"`
+					ValidationStatuses   []string `yaml:"validation_statuses"`
+					LifecycleSurface     struct {
+						Commands []string `yaml:"commands"`
+					} `yaml:"lifecycle_surface"`
+					ImplementationBoundaries []string `yaml:"implementation_boundaries"`
+				} `yaml:"local_context_registry_authority"`
 			} `yaml:"foundations"`
 		} `yaml:"cli_specification"`
 	}
@@ -567,9 +577,28 @@ func TestPlatformSpecLocalTargetResolutionAuthorityPromoted(t *testing.T) {
 	if !strings.Contains(target.DoctorTargetSurface.Command, "swarm doctor --target") || !strings.Contains(target.DoctorTargetSurface.Behavior, "MUST NOT require backend preflight") {
 		t.Fatalf("doctor target surface = %#v", target.DoctorTargetSurface)
 	}
-	for _, sibling := range []string{"#1613", "#1614", "#1615", "#1576"} {
+	for _, sibling := range []string{"#1614", "#1615", "#1576"} {
 		if !stringSliceContainsPrefix(target.SplitSiblings, sibling) {
 			t.Fatalf("split siblings missing %q: %#v", sibling, target.SplitSiblings)
+		}
+	}
+	registry := spec.CLISpecification.Foundations.LocalContextRegistry
+	if registry.PromotedBy != "#1613" || registry.ImplementationStatus != "implemented_primitive_registry" || registry.CanonicalOwner != localContextRegistryOwner {
+		t.Fatalf("local context registry owner = %#v", registry)
+	}
+	for _, status := range []string{localContextStatusOK, localContextStatusNoServer, localContextStatusIdentityMismatch, localContextStatusUnsupportedTransport, localContextStatusAuthFailure, localContextStatusPermissionDenied, localContextStatusCorruptDescriptor} {
+		if !stringSliceContains(registry.ValidationStatuses, status) {
+			t.Fatalf("registry validation statuses missing %q: %#v", status, registry.ValidationStatuses)
+		}
+	}
+	for _, command := range []string{"swarm context current", "swarm context list", "swarm context prune"} {
+		if !stringSliceContains(registry.LifecycleSurface.Commands, command) {
+			t.Fatalf("registry lifecycle commands missing %q: %#v", command, registry.LifecycleSurface.Commands)
+		}
+	}
+	for _, sibling := range []string{"#1614", "#1615", "#1576"} {
+		if !stringSliceContainsPrefix(registry.ImplementationBoundaries, "No") || !strings.Contains(strings.Join(registry.ImplementationBoundaries, "\n"), sibling) {
+			t.Fatalf("registry boundaries missing %s: %#v", sibling, registry.ImplementationBoundaries)
 		}
 	}
 }

--- a/cmd/swarm/local_context_registry.go
+++ b/cmd/swarm/local_context_registry.go
@@ -1,0 +1,624 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/division-sh/swarm/internal/apiv1"
+)
+
+const (
+	localContextRegistryOwner = "platform-spec.yaml#cli_specification.foundations.local_context_registry_authority"
+
+	localContextDescriptorVersion = 1
+
+	localContextTransportTCP  = "tcp"
+	localContextTransportUnix = "unix"
+
+	localContextAuthBuiltinLoopback = "builtin_loopback"
+	localContextAuthTokenFile       = "token_file"
+
+	localContextStatusOK                   = "ok"
+	localContextStatusNoServer             = "no_server"
+	localContextStatusStaleDescriptor      = "stale_descriptor"
+	localContextStatusIdentityMismatch     = "identity_mismatch"
+	localContextStatusUnsupportedTransport = "unsupported_transport"
+	localContextStatusAuthFailure          = "auth_failure"
+	localContextStatusPermissionDenied     = "permission_denied"
+	localContextStatusCorruptDescriptor    = "corrupt_descriptor"
+	localContextStatusInvalidDescriptor    = "invalid_descriptor"
+)
+
+type localContextDescriptor struct {
+	Version           int                        `json:"version"`
+	Name              string                     `json:"name"`
+	RuntimeInstanceID string                     `json:"runtime_instance_id"`
+	Transport         string                     `json:"transport"`
+	APIServer         string                     `json:"api_server,omitempty"`
+	SocketPath        string                     `json:"socket_path,omitempty"`
+	Auth              localContextDescriptorAuth `json:"auth"`
+	ProjectRoot       string                     `json:"project_root,omitempty"`
+	ContractsPath     string                     `json:"contracts_path,omitempty"`
+	StorePath         string                     `json:"store_path,omitempty"`
+	DataDir           string                     `json:"data_dir,omitempty"`
+	PID               int                        `json:"pid,omitempty"`
+	CreatedAt         string                     `json:"created_at"`
+	UpdatedAt         string                     `json:"updated_at"`
+}
+
+type localContextDescriptorAuth struct {
+	Mode      string `json:"mode"`
+	TokenFile string `json:"token_file,omitempty"`
+}
+
+type localContextRegistry struct {
+	swarmDir string
+}
+
+type localContextEntry struct {
+	Descriptor localContextDescriptor `json:"descriptor"`
+	Path       string                 `json:"path"`
+	Status     string                 `json:"status"`
+	Detail     string                 `json:"detail,omitempty"`
+}
+
+type localContextRegistryReport struct {
+	Owner   string              `json:"owner"`
+	Status  string              `json:"status"`
+	Detail  string              `json:"detail,omitempty"`
+	Current *localContextEntry  `json:"current,omitempty"`
+	Entries []localContextEntry `json:"entries"`
+}
+
+type localContextPruneResult struct {
+	Removed []localContextEntry `json:"removed"`
+	Kept    []localContextEntry `json:"kept"`
+}
+
+type runtimeIdentityCaller interface {
+	callRuntimeIdentity(ctx context.Context, rpcEndpoint, token string) (apiv1.RuntimeIdentityResult, error)
+}
+
+type cliRuntimeIdentityCaller struct {
+	httpClient *http.Client
+}
+
+func (c cliRuntimeIdentityCaller) callRuntimeIdentity(ctx context.Context, rpcEndpoint, token string) (apiv1.RuntimeIdentityResult, error) {
+	client := c.httpClient
+	if client == nil {
+		client = &http.Client{Timeout: 2 * time.Second}
+	}
+	apiClient := cliAPIClient{endpoint: rpcEndpoint, token: token, httpClient: client}
+	var result apiv1.RuntimeIdentityResult
+	if err := apiClient.call(ctx, "runtime.identity", map[string]any{}, &result); err != nil {
+		return apiv1.RuntimeIdentityResult{}, err
+	}
+	return result, nil
+}
+
+func newLocalContextRegistry(swarmDir string) localContextRegistry {
+	return localContextRegistry{swarmDir: filepath.Clean(swarmDir)}
+}
+
+func (r localContextRegistry) dir() string {
+	return filepath.Join(r.swarmDir, "contexts")
+}
+
+func (r localContextRegistry) lockPath() string {
+	return filepath.Join(r.dir(), ".lock")
+}
+
+func (r localContextRegistry) currentPath() string {
+	return filepath.Join(r.dir(), "current")
+}
+
+func (r localContextRegistry) descriptorPath(name string) (string, error) {
+	name, err := normalizeLocalContextName(name)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(r.dir(), name+".json"), nil
+}
+
+func normalizeLocalContextName(raw string) (string, error) {
+	name := strings.TrimSpace(raw)
+	if name == "" {
+		return "", fmt.Errorf("context name must be non-empty")
+	}
+	if name == "." || name == ".." || strings.HasPrefix(name, ".") {
+		return "", fmt.Errorf("context name %q is reserved", name)
+	}
+	if strings.ContainsAny(name, `/\`+"\x00") || filepath.Base(name) != name {
+		return "", fmt.Errorf("context name %q must not contain path separators or NUL", name)
+	}
+	return name, nil
+}
+
+func (r localContextRegistry) WriteDescriptor(desc localContextDescriptor) error {
+	if err := validateLocalContextDescriptorShape(desc); err != nil {
+		return err
+	}
+	if err := os.MkdirAll(r.dir(), 0o700); err != nil {
+		return fmt.Errorf("create context registry: %w", err)
+	}
+	unlock, err := acquireLocalContextRegistryLock(r.lockPath())
+	if err != nil {
+		return err
+	}
+	defer unlock()
+	path, err := r.descriptorPath(desc.Name)
+	if err != nil {
+		return err
+	}
+	return atomicWriteJSON(path, desc, 0o600)
+}
+
+func (r localContextRegistry) SetCurrent(name string) error {
+	name, err := normalizeLocalContextName(name)
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(r.dir(), 0o700); err != nil {
+		return fmt.Errorf("create context registry: %w", err)
+	}
+	unlock, err := acquireLocalContextRegistryLock(r.lockPath())
+	if err != nil {
+		return err
+	}
+	defer unlock()
+	return atomicWriteFile(r.currentPath(), []byte(name+"\n"), 0o600)
+}
+
+func (r localContextRegistry) ClearCurrent() error {
+	if err := os.MkdirAll(r.dir(), 0o700); err != nil {
+		return fmt.Errorf("create context registry: %w", err)
+	}
+	unlock, err := acquireLocalContextRegistryLock(r.lockPath())
+	if err != nil {
+		return err
+	}
+	defer unlock()
+	err = os.Remove(r.currentPath())
+	if err == nil || errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	return err
+}
+
+func (r localContextRegistry) CurrentName() (string, error) {
+	raw, err := os.ReadFile(r.currentPath())
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return "", nil
+		}
+		return "", err
+	}
+	name := strings.TrimSpace(string(raw))
+	if name == "" {
+		return "", nil
+	}
+	return normalizeLocalContextName(name)
+}
+
+func (r localContextRegistry) ReadDescriptor(name string) (localContextEntry, error) {
+	path, err := r.descriptorPath(name)
+	if err != nil {
+		return localContextEntry{Status: localContextStatusInvalidDescriptor, Detail: err.Error()}, nil
+	}
+	desc, status, detail := readLocalContextDescriptorFile(path)
+	if status != localContextStatusOK {
+		if strings.TrimSpace(desc.Name) == "" {
+			desc.Name = strings.TrimSuffix(filepath.Base(path), ".json")
+		}
+		return localContextEntry{Descriptor: desc, Path: path, Status: status, Detail: detail}, nil
+	}
+	return localContextEntry{Descriptor: desc, Path: path, Status: localContextStatusOK}, nil
+}
+
+func (r localContextRegistry) ListDescriptors() ([]localContextEntry, error) {
+	entries, err := os.ReadDir(r.dir())
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return []localContextEntry{}, nil
+		}
+		return nil, err
+	}
+	out := make([]localContextEntry, 0, len(entries))
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".json") {
+			continue
+		}
+		path := filepath.Join(r.dir(), entry.Name())
+		desc, status, detail := readLocalContextDescriptorFile(path)
+		if strings.TrimSpace(desc.Name) == "" {
+			desc.Name = strings.TrimSuffix(entry.Name(), ".json")
+		}
+		out = append(out, localContextEntry{Descriptor: desc, Path: path, Status: status, Detail: detail})
+	}
+	sort.Slice(out, func(i, j int) bool {
+		return out[i].Descriptor.Name < out[j].Descriptor.Name
+	})
+	return out, nil
+}
+
+func (r localContextRegistry) Inspect(ctx context.Context, caller runtimeIdentityCaller) (localContextRegistryReport, error) {
+	entries, err := r.ListDescriptors()
+	if err != nil {
+		status := localContextStatusPermissionDenied
+		if !errors.Is(err, os.ErrPermission) {
+			status = localContextStatusInvalidDescriptor
+		}
+		return localContextRegistryReport{Owner: localContextRegistryOwner, Status: status, Detail: err.Error()}, nil
+	}
+	for i := range entries {
+		entries[i] = validateLocalContextEntry(ctx, entries[i], caller)
+	}
+	currentName, currentErr := r.CurrentName()
+	if currentErr != nil {
+		return localContextRegistryReport{
+			Owner:   localContextRegistryOwner,
+			Status:  localContextStatusCorruptDescriptor,
+			Detail:  fmt.Sprintf("current selector is invalid: %v", currentErr),
+			Entries: entries,
+		}, nil
+	}
+	report := localContextRegistryReport{
+		Owner:   localContextRegistryOwner,
+		Status:  localContextStatusOK,
+		Entries: entries,
+	}
+	if currentName == "" {
+		if len(entries) == 0 {
+			report.Status = "empty"
+			report.Detail = "no context descriptors found"
+		} else {
+			report.Status = "no_current"
+			report.Detail = "no selected current context"
+		}
+		return report, nil
+	}
+	for i := range entries {
+		if entries[i].Descriptor.Name == currentName {
+			entry := entries[i]
+			report.Current = &entry
+			report.Status = entry.Status
+			report.Detail = entry.Detail
+			return report, nil
+		}
+	}
+	entry, err := r.ReadDescriptor(currentName)
+	if err != nil {
+		return localContextRegistryReport{Owner: localContextRegistryOwner, Status: localContextStatusInvalidDescriptor, Detail: err.Error(), Entries: entries}, nil
+	}
+	entry = validateLocalContextEntry(ctx, entry, caller)
+	report.Current = &entry
+	report.Status = entry.Status
+	report.Detail = entry.Detail
+	return report, nil
+}
+
+func (r localContextRegistry) Prune(ctx context.Context, caller runtimeIdentityCaller) (localContextPruneResult, error) {
+	if err := os.MkdirAll(r.dir(), 0o700); err != nil {
+		return localContextPruneResult{}, fmt.Errorf("create context registry: %w", err)
+	}
+	unlock, err := acquireLocalContextRegistryLock(r.lockPath())
+	if err != nil {
+		return localContextPruneResult{}, err
+	}
+	defer unlock()
+	report, err := r.Inspect(ctx, caller)
+	if err != nil {
+		return localContextPruneResult{}, err
+	}
+	currentName, _ := r.CurrentName()
+	result := localContextPruneResult{}
+	prunedCurrent := false
+	for _, entry := range report.Entries {
+		if localContextStatusPruneable(entry.Status) {
+			if entry.Path != "" {
+				if err := os.Remove(entry.Path); err != nil && !errors.Is(err, os.ErrNotExist) {
+					return result, err
+				}
+			}
+			result.Removed = append(result.Removed, entry)
+			if entry.Descriptor.Name == currentName {
+				prunedCurrent = true
+			}
+			continue
+		}
+		result.Kept = append(result.Kept, entry)
+	}
+	if prunedCurrent {
+		if err := os.Remove(r.currentPath()); err != nil && !errors.Is(err, os.ErrNotExist) {
+			return result, err
+		}
+	}
+	return result, nil
+}
+
+func localContextStatusPruneable(status string) bool {
+	switch status {
+	case localContextStatusNoServer, localContextStatusStaleDescriptor, localContextStatusIdentityMismatch,
+		localContextStatusUnsupportedTransport, localContextStatusCorruptDescriptor, localContextStatusInvalidDescriptor:
+		return true
+	default:
+		return false
+	}
+}
+
+func readLocalContextDescriptorFile(path string) (localContextDescriptor, string, string) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrPermission) {
+			return localContextDescriptor{}, localContextStatusPermissionDenied, err.Error()
+		}
+		return localContextDescriptor{}, localContextStatusCorruptDescriptor, err.Error()
+	}
+	dec := json.NewDecoder(bytes.NewReader(raw))
+	dec.DisallowUnknownFields()
+	var desc localContextDescriptor
+	if err := dec.Decode(&desc); err != nil {
+		return localContextDescriptor{}, localContextStatusCorruptDescriptor, err.Error()
+	}
+	if err := ensureJSONEOF(dec); err != nil {
+		return localContextDescriptor{}, localContextStatusCorruptDescriptor, err.Error()
+	}
+	if err := validateLocalContextDescriptorShape(desc); err != nil {
+		return desc, localContextStatusInvalidDescriptor, err.Error()
+	}
+	return desc, localContextStatusOK, ""
+}
+
+func ensureJSONEOF(dec *json.Decoder) error {
+	var extra any
+	if err := dec.Decode(&extra); err == io.EOF {
+		return nil
+	} else if err != nil {
+		return err
+	}
+	return fmt.Errorf("descriptor contains trailing JSON")
+}
+
+func validateLocalContextDescriptorShape(desc localContextDescriptor) error {
+	if desc.Version != localContextDescriptorVersion {
+		return fmt.Errorf("descriptor version = %d, want %d", desc.Version, localContextDescriptorVersion)
+	}
+	name, err := normalizeLocalContextName(desc.Name)
+	if err != nil {
+		return err
+	}
+	if name != desc.Name {
+		return fmt.Errorf("context name must be canonical")
+	}
+	if strings.TrimSpace(desc.RuntimeInstanceID) == "" {
+		return fmt.Errorf("runtime_instance_id is required")
+	}
+	switch desc.Transport {
+	case localContextTransportTCP:
+		if strings.TrimSpace(desc.APIServer) == "" {
+			return fmt.Errorf("api_server is required for tcp descriptors")
+		}
+		if _, err := cliAPIRPCEndpointFromServer(desc.APIServer, "descriptor api_server"); err != nil {
+			return err
+		}
+	case localContextTransportUnix:
+		if strings.TrimSpace(desc.SocketPath) == "" {
+			return fmt.Errorf("socket_path is required for unix descriptors")
+		}
+	default:
+		return fmt.Errorf("unsupported transport %q", desc.Transport)
+	}
+	switch desc.Auth.Mode {
+	case localContextAuthBuiltinLoopback:
+		if desc.Transport != localContextTransportTCP {
+			return fmt.Errorf("builtin_loopback auth is only valid for tcp descriptors")
+		}
+		rpcEndpoint, err := cliAPIRPCEndpointFromServer(desc.APIServer, "descriptor api_server")
+		if err != nil {
+			return err
+		}
+		if !cliAPIRPCEndpointAllowsDefaultToken(rpcEndpoint) {
+			return fmt.Errorf("builtin_loopback auth requires numeric loopback api_server")
+		}
+	case localContextAuthTokenFile:
+		if strings.TrimSpace(desc.Auth.TokenFile) == "" {
+			return fmt.Errorf("token_file auth requires token_file")
+		}
+	default:
+		return fmt.Errorf("unsupported auth mode %q", desc.Auth.Mode)
+	}
+	if strings.TrimSpace(desc.CreatedAt) == "" {
+		return fmt.Errorf("created_at is required")
+	}
+	if strings.TrimSpace(desc.UpdatedAt) == "" {
+		return fmt.Errorf("updated_at is required")
+	}
+	return nil
+}
+
+func validateLocalContextEntry(ctx context.Context, entry localContextEntry, caller runtimeIdentityCaller) localContextEntry {
+	if entry.Status != localContextStatusOK {
+		return entry
+	}
+	desc := entry.Descriptor
+	if desc.Transport == localContextTransportUnix {
+		entry.Status = localContextStatusUnsupportedTransport
+		entry.Detail = "unix descriptor is schema-valid but IPC dialing is split to #1576"
+		return entry
+	}
+	rpcEndpoint, err := cliAPIRPCEndpointFromServer(desc.APIServer, "descriptor api_server")
+	if err != nil {
+		entry.Status = localContextStatusInvalidDescriptor
+		entry.Detail = err.Error()
+		return entry
+	}
+	token, err := localContextDescriptorToken(desc, rpcEndpoint)
+	if err != nil {
+		entry.Status = classifyLocalContextTokenError(err)
+		entry.Detail = err.Error()
+		return entry
+	}
+	if caller == nil {
+		caller = cliRuntimeIdentityCaller{httpClient: &http.Client{Timeout: 2 * time.Second}}
+	}
+	identity, err := caller.callRuntimeIdentity(ctx, rpcEndpoint, token)
+	if err != nil {
+		entry.Status = classifyLocalContextIdentityError(err)
+		entry.Detail = err.Error()
+		return entry
+	}
+	if strings.TrimSpace(identity.RuntimeInstanceID) == "" {
+		entry.Status = localContextStatusStaleDescriptor
+		entry.Detail = "runtime.identity returned an empty runtime_instance_id"
+		return entry
+	}
+	if identity.RuntimeInstanceID != desc.RuntimeInstanceID {
+		entry.Status = localContextStatusIdentityMismatch
+		entry.Detail = fmt.Sprintf("descriptor runtime_instance_id=%s, live runtime_instance_id=%s", desc.RuntimeInstanceID, identity.RuntimeInstanceID)
+		return entry
+	}
+	entry.Status = localContextStatusOK
+	entry.Detail = ""
+	return entry
+}
+
+func localContextDescriptorToken(desc localContextDescriptor, rpcEndpoint string) (string, error) {
+	switch desc.Auth.Mode {
+	case localContextAuthBuiltinLoopback:
+		if !cliAPIRPCEndpointAllowsDefaultToken(rpcEndpoint) {
+			return "", fmt.Errorf("builtin_loopback auth requires numeric loopback api_server")
+		}
+		return apiv1.DefaultLoopbackAPIToken, nil
+	case localContextAuthTokenFile:
+		return readCLIAPITokenFile(desc.Auth.TokenFile, "descriptor auth.token_file")
+	default:
+		return "", fmt.Errorf("unsupported auth mode %q", desc.Auth.Mode)
+	}
+}
+
+func classifyLocalContextTokenError(err error) string {
+	if errors.Is(err, os.ErrPermission) {
+		return localContextStatusPermissionDenied
+	}
+	return localContextStatusAuthFailure
+}
+
+func classifyLocalContextIdentityError(err error) string {
+	var httpErr *cliAPIHTTPError
+	if errors.As(err, &httpErr) {
+		switch httpErr.statusCode {
+		case http.StatusUnauthorized:
+			return localContextStatusAuthFailure
+		case http.StatusForbidden:
+			return localContextStatusPermissionDenied
+		default:
+			return localContextStatusStaleDescriptor
+		}
+	}
+	var netErr net.Error
+	if errors.As(err, &netErr) {
+		return localContextStatusNoServer
+	}
+	if isConnectionRefusedError(err) {
+		return localContextStatusNoServer
+	}
+	var rpcErr *jsonRPCError
+	if errors.As(err, &rpcErr) {
+		if rpcErr.Code == -32601 || applicationErrorCode(rpcErr.Data) == apiv1.MethodUnavailableCode {
+			return localContextStatusStaleDescriptor
+		}
+		return localContextStatusStaleDescriptor
+	}
+	return localContextStatusNoServer
+}
+
+func isConnectionRefusedError(err error) bool {
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "connection refused") ||
+		strings.Contains(msg, "connect: cannot assign requested address") ||
+		strings.Contains(msg, "no such host")
+}
+
+func acquireLocalContextRegistryLock(path string) (func(), error) {
+	lock, err := os.OpenFile(path, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600)
+	if err != nil {
+		if errors.Is(err, os.ErrExist) {
+			return nil, fmt.Errorf("context registry is locked: %w", err)
+		}
+		return nil, fmt.Errorf("acquire context registry lock: %w", err)
+	}
+	_, _ = fmt.Fprintf(lock, "pid=%d\n", os.Getpid())
+	_ = lock.Close()
+	return func() {
+		_ = os.Remove(path)
+	}, nil
+}
+
+func atomicWriteJSON(path string, value any, perm os.FileMode) error {
+	var buf bytes.Buffer
+	encoder := json.NewEncoder(&buf)
+	encoder.SetIndent("", "  ")
+	if err := encoder.Encode(value); err != nil {
+		return err
+	}
+	return atomicWriteFile(path, buf.Bytes(), perm)
+}
+
+func atomicWriteFile(path string, data []byte, perm os.FileMode) error {
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return err
+	}
+	tmp, err := os.CreateTemp(dir, "."+filepath.Base(path)+".tmp-*")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	cleanup := true
+	defer func() {
+		if cleanup {
+			_ = os.Remove(tmpName)
+		}
+	}()
+	if err := tmp.Chmod(perm); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	if err := os.Rename(tmpName, path); err != nil {
+		return err
+	}
+	cleanup = false
+	_ = syncLocalContextRegistryDir(dir)
+	return nil
+}
+
+func syncLocalContextRegistryDir(dir string) error {
+	handle, err := os.Open(dir)
+	if err != nil {
+		return err
+	}
+	defer handle.Close()
+	return handle.Sync()
+}

--- a/cmd/swarm/local_context_registry.go
+++ b/cmd/swarm/local_context_registry.go
@@ -324,6 +324,7 @@ func (r localContextRegistry) Prune(ctx context.Context, caller runtimeIdentityC
 	currentName, _ := r.CurrentName()
 	result := localContextPruneResult{}
 	prunedCurrent := false
+	currentSeen := false
 	for _, entry := range report.Entries {
 		if localContextStatusPruneable(entry.Status) {
 			if entry.Path != "" {
@@ -333,11 +334,24 @@ func (r localContextRegistry) Prune(ctx context.Context, caller runtimeIdentityC
 			}
 			result.Removed = append(result.Removed, entry)
 			if entry.Descriptor.Name == currentName {
+				currentSeen = true
 				prunedCurrent = true
 			}
 			continue
 		}
 		result.Kept = append(result.Kept, entry)
+		if entry.Descriptor.Name == currentName {
+			currentSeen = true
+		}
+	}
+	if !currentSeen && report.Current != nil && localContextStatusPruneable(report.Current.Status) {
+		if report.Current.Path != "" {
+			if err := os.Remove(report.Current.Path); err != nil && !errors.Is(err, os.ErrNotExist) {
+				return result, err
+			}
+		}
+		result.Removed = append(result.Removed, *report.Current)
+		prunedCurrent = true
 	}
 	if prunedCurrent {
 		if err := os.Remove(r.currentPath()); err != nil && !errors.Is(err, os.ErrNotExist) {

--- a/cmd/swarm/local_context_registry_test.go
+++ b/cmd/swarm/local_context_registry_test.go
@@ -1,0 +1,236 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/division-sh/swarm/internal/apiv1"
+)
+
+type fakeRuntimeIdentityCaller struct {
+	result apiv1.RuntimeIdentityResult
+	err    error
+	calls  int
+}
+
+func (f *fakeRuntimeIdentityCaller) callRuntimeIdentity(context.Context, string, string) (apiv1.RuntimeIdentityResult, error) {
+	f.calls++
+	if f.err != nil {
+		return apiv1.RuntimeIdentityResult{}, f.err
+	}
+	return f.result, nil
+}
+
+func TestLocalContextRegistryAtomicWriteCurrentAndIdentityValidation(t *testing.T) {
+	registry := newLocalContextRegistry(t.TempDir())
+	desc := testLocalContextDescriptor("local", "runtime-a")
+	if err := registry.WriteDescriptor(desc); err != nil {
+		t.Fatalf("WriteDescriptor() error = %v", err)
+	}
+	if err := registry.SetCurrent(desc.Name); err != nil {
+		t.Fatalf("SetCurrent() error = %v", err)
+	}
+	caller := &fakeRuntimeIdentityCaller{result: apiv1.RuntimeIdentityResult{
+		RuntimeInstanceID:   "runtime-a",
+		StartedAt:           "2026-07-02T00:00:00Z",
+		APIVersion:          "v1",
+		SupportedTransports: []string{"tcp"},
+	}}
+	report, err := registry.Inspect(context.Background(), caller)
+	if err != nil {
+		t.Fatalf("Inspect() error = %v", err)
+	}
+	if report.Status != localContextStatusOK {
+		t.Fatalf("report status = %q, want ok detail=%s", report.Status, report.Detail)
+	}
+	if report.Current == nil || report.Current.Descriptor.Name != "local" {
+		t.Fatalf("current = %#v, want local", report.Current)
+	}
+	if caller.calls != 1 {
+		t.Fatalf("runtime.identity calls = %d, want 1", caller.calls)
+	}
+}
+
+func TestLocalContextRegistryLockContentionFailsClosed(t *testing.T) {
+	registry := newLocalContextRegistry(t.TempDir())
+	if err := os.MkdirAll(registry.dir(), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(registry.lockPath(), []byte("held\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	err := registry.WriteDescriptor(testLocalContextDescriptor("local", "runtime-a"))
+	if err == nil || !strings.Contains(err.Error(), "locked") {
+		t.Fatalf("WriteDescriptor() error = %v, want lock failure", err)
+	}
+	if _, statErr := os.Stat(filepath.Join(registry.dir(), "local.json")); !errors.Is(statErr, os.ErrNotExist) {
+		t.Fatalf("descriptor stat error = %v, want not exist", statErr)
+	}
+}
+
+func TestLocalContextDescriptorRejectsInlineTokenAndCorruptJSON(t *testing.T) {
+	registry := newLocalContextRegistry(t.TempDir())
+	if err := os.MkdirAll(registry.dir(), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	inlineToken := `{"version":1,"name":"inline","runtime_instance_id":"runtime-a","transport":"tcp","api_server":"http://127.0.0.1:8081","auth":{"mode":"token_file","token":"secret"},"created_at":"2026-07-02T00:00:00Z","updated_at":"2026-07-02T00:00:00Z"}`
+	if err := os.WriteFile(filepath.Join(registry.dir(), "inline.json"), []byte(inlineToken), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(registry.dir(), "bad.json"), []byte(`{"version":`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	report, err := registry.Inspect(context.Background(), &fakeRuntimeIdentityCaller{})
+	if err != nil {
+		t.Fatalf("Inspect() error = %v", err)
+	}
+	statuses := map[string]string{}
+	for _, entry := range report.Entries {
+		statuses[entry.Descriptor.Name] = entry.Status
+	}
+	if statuses["inline"] != localContextStatusCorruptDescriptor {
+		t.Fatalf("inline status = %q, want corrupt_descriptor", statuses["inline"])
+	}
+	if statuses["bad"] != localContextStatusCorruptDescriptor {
+		t.Fatalf("bad status = %q, want corrupt_descriptor", statuses["bad"])
+	}
+}
+
+func TestLocalContextValidationTaxonomy(t *testing.T) {
+	tests := []struct {
+		name       string
+		desc       localContextDescriptor
+		caller     *fakeRuntimeIdentityCaller
+		wantStatus string
+		wantCalls  int
+	}{
+		{
+			name:       "identity mismatch",
+			desc:       testLocalContextDescriptor("mismatch", "runtime-a"),
+			caller:     &fakeRuntimeIdentityCaller{result: apiv1.RuntimeIdentityResult{RuntimeInstanceID: "runtime-b"}},
+			wantStatus: localContextStatusIdentityMismatch,
+			wantCalls:  1,
+		},
+		{
+			name:       "auth failure",
+			desc:       testLocalContextDescriptor("auth", "runtime-a"),
+			caller:     &fakeRuntimeIdentityCaller{err: &cliAPIHTTPError{statusCode: 401, message: "unauthorized"}},
+			wantStatus: localContextStatusAuthFailure,
+			wantCalls:  1,
+		},
+		{
+			name:       "no server",
+			desc:       testLocalContextDescriptor("down", "runtime-a"),
+			caller:     &fakeRuntimeIdentityCaller{err: &net.DNSError{Err: "no such host"}},
+			wantStatus: localContextStatusNoServer,
+			wantCalls:  1,
+		},
+		{
+			name: "unsupported unix",
+			desc: func() localContextDescriptor {
+				desc := testLocalContextDescriptor("unix", "runtime-a")
+				desc.Transport = localContextTransportUnix
+				desc.APIServer = ""
+				desc.SocketPath = "/tmp/swarm.sock"
+				desc.Auth = localContextDescriptorAuth{Mode: localContextAuthTokenFile, TokenFile: "/tmp/token"}
+				return desc
+			}(),
+			caller:     &fakeRuntimeIdentityCaller{},
+			wantStatus: localContextStatusUnsupportedTransport,
+			wantCalls:  0,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			entry := localContextEntry{Descriptor: tt.desc, Status: localContextStatusOK}
+			got := validateLocalContextEntry(context.Background(), entry, tt.caller)
+			if got.Status != tt.wantStatus {
+				t.Fatalf("status = %q, want %q detail=%s", got.Status, tt.wantStatus, got.Detail)
+			}
+			if tt.caller.calls != tt.wantCalls {
+				t.Fatalf("calls = %d, want %d", tt.caller.calls, tt.wantCalls)
+			}
+		})
+	}
+}
+
+func TestLocalContextPruneRemovesOnlyPruneableStatuses(t *testing.T) {
+	registry := newLocalContextRegistry(t.TempDir())
+	for _, desc := range []localContextDescriptor{
+		testLocalContextDescriptor("mismatch", "runtime-a"),
+		testLocalContextDescriptor("auth", "runtime-a"),
+	} {
+		if err := registry.WriteDescriptor(desc); err != nil {
+			t.Fatalf("WriteDescriptor(%s) error = %v", desc.Name, err)
+		}
+	}
+	if err := registry.SetCurrent("mismatch"); err != nil {
+		t.Fatal(err)
+	}
+	caller := &switchingRuntimeIdentityCaller{
+		results: map[string]apiv1.RuntimeIdentityResult{
+			"mismatch": {RuntimeInstanceID: "runtime-b"},
+		},
+		errs: map[string]error{
+			"auth": &cliAPIHTTPError{statusCode: 401, message: "unauthorized"},
+		},
+	}
+	result, err := registry.Prune(context.Background(), caller)
+	if err != nil {
+		t.Fatalf("Prune() error = %v", err)
+	}
+	if len(result.Removed) != 1 || result.Removed[0].Descriptor.Name != "mismatch" {
+		t.Fatalf("removed = %#v, want only mismatch", result.Removed)
+	}
+	if len(result.Kept) != 1 || result.Kept[0].Descriptor.Name != "auth" {
+		t.Fatalf("kept = %#v, want only auth", result.Kept)
+	}
+	if current, err := registry.CurrentName(); err != nil || current != "" {
+		t.Fatalf("current = %q err=%v, want cleared", current, err)
+	}
+}
+
+func TestLocalContextPermissionClassifier(t *testing.T) {
+	if got := classifyLocalContextTokenError(os.ErrPermission); got != localContextStatusPermissionDenied {
+		t.Fatalf("permission token error classified as %q", got)
+	}
+}
+
+type switchingRuntimeIdentityCaller struct {
+	results map[string]apiv1.RuntimeIdentityResult
+	errs    map[string]error
+}
+
+func (c *switchingRuntimeIdentityCaller) callRuntimeIdentity(_ context.Context, rpcEndpoint, _ string) (apiv1.RuntimeIdentityResult, error) {
+	for name, err := range c.errs {
+		if strings.Contains(rpcEndpoint, name) {
+			return apiv1.RuntimeIdentityResult{}, err
+		}
+	}
+	for name, result := range c.results {
+		if strings.Contains(rpcEndpoint, name) {
+			return result, nil
+		}
+	}
+	return apiv1.RuntimeIdentityResult{RuntimeInstanceID: "runtime-a"}, nil
+}
+
+func testLocalContextDescriptor(name, runtimeID string) localContextDescriptor {
+	now := time.Date(2026, 7, 2, 0, 0, 0, 0, time.UTC).Format(time.RFC3339Nano)
+	return localContextDescriptor{
+		Version:           localContextDescriptorVersion,
+		Name:              name,
+		RuntimeInstanceID: runtimeID,
+		Transport:         localContextTransportTCP,
+		APIServer:         "http://127.0.0.1:8081/" + name,
+		Auth:              localContextDescriptorAuth{Mode: localContextAuthBuiltinLoopback},
+		CreatedAt:         now,
+		UpdatedAt:         now,
+	}
+}

--- a/cmd/swarm/local_context_registry_test.go
+++ b/cmd/swarm/local_context_registry_test.go
@@ -196,6 +196,26 @@ func TestLocalContextPruneRemovesOnlyPruneableStatuses(t *testing.T) {
 	}
 }
 
+func TestLocalContextPruneClearsDanglingCurrentSelector(t *testing.T) {
+	registry := newLocalContextRegistry(t.TempDir())
+	if err := registry.SetCurrent("missing"); err != nil {
+		t.Fatal(err)
+	}
+	result, err := registry.Prune(context.Background(), &fakeRuntimeIdentityCaller{})
+	if err != nil {
+		t.Fatalf("Prune() error = %v", err)
+	}
+	if len(result.Removed) != 1 || result.Removed[0].Descriptor.Name != "missing" {
+		t.Fatalf("removed = %#v, want dangling current", result.Removed)
+	}
+	if result.Removed[0].Status != localContextStatusCorruptDescriptor {
+		t.Fatalf("removed status = %q, want corrupt_descriptor", result.Removed[0].Status)
+	}
+	if current, err := registry.CurrentName(); err != nil || current != "" {
+		t.Fatalf("current = %q err=%v, want cleared", current, err)
+	}
+}
+
 func TestLocalContextPermissionClassifier(t *testing.T) {
 	if got := classifyLocalContextTokenError(os.ErrPermission); got != localContextStatusPermissionDenied {
 		t.Fatalf("permission token error classified as %q", got)

--- a/cmd/swarm/main.go
+++ b/cmd/swarm/main.go
@@ -56,6 +56,7 @@ import (
 	storebackend "github.com/division-sh/swarm/internal/store/backendselection"
 	"github.com/division-sh/swarm/internal/store/runbundle"
 	storerunlifecycle "github.com/division-sh/swarm/internal/store/runlifecycle"
+	"github.com/google/uuid"
 
 	"gopkg.in/yaml.v3"
 )
@@ -736,6 +737,7 @@ func buildForkChatSandboxLLMRuntime(cfg *config.Config, workspaces workspace.Res
 
 func runServeRuntime(ctx context.Context, repo string, opts serveOptions) int {
 	bootStartedAt := time.Now().UTC()
+	runtimeInstanceID := uuid.NewString()
 	reporter := newServeBootReporter(opts.Verbose, opts.Output)
 	reporter.emit(1, "process_start", "ok", "")
 	if err := loadRepoDotEnv(repo); err != nil {
@@ -1066,6 +1068,12 @@ func runServeRuntime(ctx context.Context, repo string, opts serveOptions) int {
 		Source:                 source,
 		MailboxApprovalRoutes:  mailboxApprovalRoutes,
 		Bundle:                 bootBundleIdentity,
+		RuntimeIdentity: apiv1.RuntimeIdentityResult{
+			RuntimeInstanceID:   runtimeInstanceID,
+			StartedAt:           bootStartedAt.Format(time.RFC3339Nano),
+			APIVersion:          "v1",
+			SupportedTransports: []string{"tcp"},
+		},
 	}
 	apiV1Handler, err := apiv1.NewHandler(apiv1.Options{
 		PlatformSpecPath: resolvedPlatformSpecPath,

--- a/cmd/swarm/target_resolution.go
+++ b/cmd/swarm/target_resolution.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -117,9 +118,9 @@ type doctorTargetAuth struct {
 }
 
 type doctorTargetContext struct {
-	ProjectScoped  doctorTargetPendingFact `json:"project_scoped"`
-	SelectedGlobal doctorTargetPendingFact `json:"selected_global"`
-	Registry       doctorTargetPendingFact `json:"registry"`
+	ProjectScoped  doctorTargetPendingFact    `json:"project_scoped"`
+	SelectedGlobal doctorTargetPendingFact    `json:"selected_global"`
+	Registry       localContextRegistryReport `json:"registry"`
 }
 
 type doctorTargetPendingFact struct {
@@ -145,7 +146,7 @@ func runDoctorTargetCommand(repo string, cmd *cobra.Command, opts doctorOptions)
 	if err != nil {
 		return returnCLIValidationError(cmd.ErrOrStderr(), err)
 	}
-	report, err := buildDoctorTargetReport(repo, opts, cfg, swarmDir)
+	report, err := buildDoctorTargetReport(cmd.Context(), repo, opts, cfg, swarmDir)
 	if err != nil {
 		return returnCLIValidationError(cmd.ErrOrStderr(), err)
 	}
@@ -156,7 +157,7 @@ func runDoctorTargetCommand(repo string, cmd *cobra.Command, opts doctorOptions)
 	return nil
 }
 
-func buildDoctorTargetReport(repo string, opts doctorOptions, cfg cliAPIConfigFile, swarmDir cliSwarmDirResolution) (doctorTargetReport, error) {
+func buildDoctorTargetReport(ctx context.Context, repo string, opts doctorOptions, cfg cliAPIConfigFile, swarmDir cliSwarmDirResolution) (doctorTargetReport, error) {
 	api, err := resolveDoctorTargetAPI(opts, cfg)
 	if err != nil {
 		return doctorTargetReport{}, err
@@ -166,6 +167,10 @@ func buildDoctorTargetReport(repo string, opts doctorOptions, cfg cliAPIConfigFi
 		return doctorTargetReport{}, err
 	}
 	data, err := resolveDoctorTargetData(repo, opts)
+	if err != nil {
+		return doctorTargetReport{}, err
+	}
+	registryReport, err := newLocalContextRegistry(swarmDir.Path).Inspect(ctx, cliRuntimeIdentityCaller{})
 	if err != nil {
 		return doctorTargetReport{}, err
 	}
@@ -179,30 +184,37 @@ func buildDoctorTargetReport(repo string, opts doctorOptions, cfg cliAPIConfigFi
 		Context: doctorTargetContext{
 			ProjectScoped: doctorTargetPendingFact{
 				Status: "pending",
-				Owner:  "#1613/#1614",
-				Detail: "project-scoped context registry and consumption are split; this diagnostic does not trust descriptor files yet",
+				Owner:  "#1614",
+				Detail: "project-scoped serve registration and API command consumption remain split",
 			},
 			SelectedGlobal: doctorTargetPendingFact{
-				Status: "pending",
-				Owner:  "#1613/#1614",
-				Detail: "selected/default global context lookup is specified here but implemented by the registry and command-consumption children",
+				Status: registryReport.Status,
+				Owner:  localContextRegistryOwner,
+				Detail: registryReport.Detail,
 			},
-			Registry: doctorTargetPendingFact{
-				Status: "pending",
-				Owner:  "#1613",
-				Detail: "descriptor writes, current/list/prune, atomicity, and liveness-backed identity remain split",
-			},
+			Registry: registryReport,
 		},
-		RuntimeIdentity: doctorTargetPendingFact{
-			Status: "pending",
-			Owner:  "#1613",
-			Detail: "health/PID/port are not trusted as runtime instance identity in this slice",
-		},
-		Store:          store,
-		Data:           data,
-		CommandClasses: doctorTargetCommandClasses(),
-		SplitSiblings:  doctorTargetSplitSiblings(),
+		RuntimeIdentity: doctorTargetRuntimeIdentityFact(registryReport),
+		Store:           store,
+		Data:            data,
+		CommandClasses:  doctorTargetCommandClasses(),
+		SplitSiblings:   doctorTargetSplitSiblings(),
 	}, nil
+}
+
+func doctorTargetRuntimeIdentityFact(report localContextRegistryReport) doctorTargetPendingFact {
+	if report.Current == nil {
+		return doctorTargetPendingFact{
+			Status: "unavailable",
+			Owner:  "platform-spec.yaml#api_specification.method_catalog.runtime.identity",
+			Detail: "no current context descriptor is selected; explicit API flags still use existing API auth precedence",
+		}
+	}
+	return doctorTargetPendingFact{
+		Status: report.Current.Status,
+		Owner:  "platform-spec.yaml#api_specification.method_catalog.runtime.identity",
+		Detail: report.Current.Detail,
+	}
 }
 
 func rootSwarmDirFlag(cmd *cobra.Command) (string, bool) {
@@ -276,7 +288,7 @@ func doctorTargetAPIReason(source string) string {
 	case "config api_server":
 		return "existing bootstrap config API source wins after flags and environment"
 	default:
-		return "context registry consumption is pending #1613/#1614, so this first-slice diagnostic falls through to the built-in loopback default"
+		return "API-backed command context consumption is split to #1614, so this diagnostic falls through to the built-in loopback default when no explicit API source is configured"
 	}
 }
 
@@ -438,7 +450,7 @@ func doctorTargetCommandClasses() []doctorTargetCommandClass {
 		{
 			Name:        "startup_and_run",
 			Status:      "split_pending_#1614_#1615",
-			Fallthrough: "serve project registration and swarm run semantics are intentionally not implemented in #1612",
+			Fallthrough: "serve project registration and swarm run semantics are intentionally split to #1614 and #1615",
 			Commands:    []string{"swarm serve --dev", "swarm run"},
 		},
 	}
@@ -446,7 +458,6 @@ func doctorTargetCommandClasses() []doctorTargetCommandClass {
 
 func doctorTargetSplitSiblings() []string {
 	return []string{
-		"#1613 runtime identity and descriptor registry",
 		"#1614 project-scoped serve/API command targeting",
 		"#1615 store/data migration and swarm run semantics",
 		"#1576 transport-aware descriptors and IPC/ephemeral-port direction",
@@ -484,7 +495,14 @@ func writeDoctorTargetText(out io.Writer, report doctorTargetReport) {
 	fmt.Fprintf(out, "target_reason: %s\n", report.API.Reason)
 	fmt.Fprintf(out, "project_context: %s (%s)\n", report.Context.ProjectScoped.Status, report.Context.ProjectScoped.Owner)
 	fmt.Fprintf(out, "selected_global_context: %s (%s)\n", report.Context.SelectedGlobal.Status, report.Context.SelectedGlobal.Owner)
-	fmt.Fprintf(out, "descriptor_registry: %s (%s)\n", report.Context.Registry.Status, report.Context.Registry.Owner)
+	fmt.Fprintf(out, "descriptor_registry: %s (%s", report.Context.Registry.Status, report.Context.Registry.Owner)
+	if len(report.Context.Registry.Entries) > 0 {
+		fmt.Fprintf(out, "; entries=%d", len(report.Context.Registry.Entries))
+	}
+	if report.Context.Registry.Detail != "" {
+		fmt.Fprintf(out, "; %s", report.Context.Registry.Detail)
+	}
+	fmt.Fprintln(out, ")")
 	fmt.Fprintf(out, "runtime_identity: %s (%s)\n", report.RuntimeIdentity.Status, report.RuntimeIdentity.Owner)
 	fmt.Fprintf(out, "store_path: %s (source: %s; status: %s)\n", report.Store.Path, report.Store.Source, report.Store.Status)
 	if report.Data.Path != "" {

--- a/internal/apispec/spec_test.go
+++ b/internal/apispec/spec_test.go
@@ -17,11 +17,11 @@ func TestPlatformAPISpecValidationCoverage(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Validate() error = %v", err)
 	}
-	if report.MethodCount != 57 {
-		t.Fatalf("method count = %d, want 57", report.MethodCount)
+	if report.MethodCount != 58 {
+		t.Fatalf("method count = %d, want 58", report.MethodCount)
 	}
-	if report.SchemaCount != 108 {
-		t.Fatalf("schema count = %d, want 108", report.SchemaCount)
+	if report.SchemaCount != 109 {
+		t.Fatalf("schema count = %d, want 109", report.SchemaCount)
 	}
 	if report.ErrorCodeCount != 39 {
 		t.Fatalf("error code count = %d, want 39", report.ErrorCodeCount)
@@ -80,11 +80,11 @@ func TestGeneratedOpenRPCArtifactMatchesPlatformSpec(t *testing.T) {
 	if err := json.Unmarshal(artifact, &doc); err != nil {
 		t.Fatalf("unmarshal openrpc artifact: %v", err)
 	}
-	if len(doc.Methods) != 57 {
-		t.Fatalf("generated OpenRPC methods = %d, want 57", len(doc.Methods))
+	if len(doc.Methods) != 58 {
+		t.Fatalf("generated OpenRPC methods = %d, want 58", len(doc.Methods))
 	}
-	if len(doc.Components.Schemas) != 108 {
-		t.Fatalf("generated OpenRPC schemas = %d, want 108", len(doc.Components.Schemas))
+	if len(doc.Components.Schemas) != 109 {
+		t.Fatalf("generated OpenRPC schemas = %d, want 109", len(doc.Components.Schemas))
 	}
 	if len(doc.Components.Errors) != 39 {
 		t.Fatalf("generated OpenRPC errors = %d, want 39", len(doc.Components.Errors))

--- a/internal/apiv1/handler_test.go
+++ b/internal/apiv1/handler_test.go
@@ -33,8 +33,8 @@ func TestRegistryMethodNamesMatchGeneratedOpenRPC(t *testing.T) {
 	if got := registry.MethodNames(); !reflect.DeepEqual(got, openRPCNames) {
 		t.Fatalf("registry method names drifted from generated OpenRPC:\nregistry=%v\nopenrpc=%v", got, openRPCNames)
 	}
-	if len(openRPCNames) != 57 {
-		t.Fatalf("method count = %d, want 57", len(openRPCNames))
+	if len(openRPCNames) != 58 {
+		t.Fatalf("method count = %d, want 58", len(openRPCNames))
 	}
 	if _, ok := registry.Method("run.fork"); !ok {
 		t.Fatal("run.fork missing from generated registry")
@@ -397,6 +397,12 @@ func TestOperatorReadHandlersExposeHealthAndRunReadMethods(t *testing.T) {
 				WorkflowVersion: "1.2.3",
 				Fingerprint:     "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
 			},
+			RuntimeIdentity: RuntimeIdentityResult{
+				RuntimeInstanceID:   "runtime-instance-1",
+				StartedAt:           now.Format(time.RFC3339Nano),
+				APIVersion:          "v1",
+				SupportedTransports: []string{"tcp"},
+			},
 		}),
 	})
 
@@ -422,6 +428,18 @@ func TestOperatorReadHandlersExposeHealthAndRunReadMethods(t *testing.T) {
 	}
 	if raw, _ := json.Marshal(healthResult); strings.Contains(string(raw), "/") {
 		t.Fatalf("health.check leaked path-like content: %s", raw)
+	}
+
+	identity := rpcCall(t, handler, `{"jsonrpc":"2.0","id":"identity","method":"runtime.identity","params":{}}`)
+	if identity.Error != nil {
+		t.Fatalf("runtime.identity error = %#v", identity.Error)
+	}
+	identityResult := asMap(t, identity.Result)
+	if identityResult["runtime_instance_id"] != "runtime-instance-1" || identityResult["api_version"] != "v1" {
+		t.Fatalf("runtime.identity result = %#v", identityResult)
+	}
+	if identityResult["runtime_instance_id"] == bundle["fingerprint"] {
+		t.Fatalf("runtime.identity reused bundle fingerprint: %#v", identityResult)
 	}
 
 	get := rpcCall(t, handler, `{"jsonrpc":"2.0","id":"get","method":"run.get","params":{"run_id":"run-1"}}`)

--- a/internal/apiv1/openrpc_compliance_test.go
+++ b/internal/apiv1/openrpc_compliance_test.go
@@ -121,8 +121,8 @@ func TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod(t *testing.T) {
 	if matrix.IssueRole != "provenance" {
 		t.Fatalf("matrix issue_role = %q, want provenance", matrix.IssueRole)
 	}
-	if len(doc.Methods) != 57 {
-		t.Fatalf("generated OpenRPC methods = %d, want 57", len(doc.Methods))
+	if len(doc.Methods) != 58 {
+		t.Fatalf("generated OpenRPC methods = %d, want 58", len(doc.Methods))
 	}
 	if len(matrix.Methods) != len(doc.Methods) {
 		t.Fatalf("matrix rows = %d, want generated method count %d", len(matrix.Methods), len(doc.Methods))

--- a/internal/apiv1/openrpc_readonly_runtime_test.go
+++ b/internal/apiv1/openrpc_readonly_runtime_test.go
@@ -267,6 +267,7 @@ func approvedReadOnlyHTTPRuntimeMethods() []string {
 		"run.get",
 		"run.list",
 		"run.trace",
+		"runtime.identity",
 		"runtime.incidents",
 		"runtime.logs",
 	}
@@ -302,6 +303,7 @@ func readOnlyHTTPRuntimeFixtures() map[string]readOnlyHTTPRuntimeFixture {
 		"run.get":                        {Params: map[string]any{"run_id": "run-1"}, ResultKeys: []string{"run"}},
 		"run.list":                       {Params: map[string]any{}, ResultKeys: []string{"runs"}},
 		"run.trace":                      {Params: map[string]any{"run_id": "run-1"}, ResultKeys: []string{"trace"}},
+		"runtime.identity":               {Params: map[string]any{}, ResultKeys: []string{"runtime_instance_id", "started_at", "api_version", "supported_transports"}},
 		"runtime.incidents":              {Params: map[string]any{}, ResultKeys: []string{"incidents"}},
 		"runtime.logs":                   {Params: map[string]any{}, ResultKeys: []string{"logs"}},
 	}
@@ -514,6 +516,12 @@ func readOnlyRuntimeProbeOptions(t *testing.T) OperatorReadOptions {
 		Now:      func() time.Time { return now },
 		Ready:    func() bool { return true },
 		Database: fakePinger{},
+		RuntimeIdentity: RuntimeIdentityResult{
+			RuntimeInstanceID:   "runtime-1",
+			StartedAt:           now.Format(time.RFC3339Nano),
+			APIVersion:          "v1",
+			SupportedTransports: []string{"tcp"},
+		},
 		Runs: &fakeRunReadStore{
 			headers: map[string]store.RunHeader{
 				runID: {

--- a/internal/apiv1/operator_read.go
+++ b/internal/apiv1/operator_read.go
@@ -103,6 +103,7 @@ type OperatorReadOptions struct {
 	Source                 semanticview.Source
 	MailboxApprovalRoutes  map[string]string
 	Bundle                 runtimecontracts.BundleIdentity
+	RuntimeIdentity        RuntimeIdentityResult
 }
 
 type healthPingResult struct {
@@ -116,6 +117,13 @@ type healthCheckResult struct {
 	DBOK      bool                            `json:"db_ok"`
 	RuntimeOK bool                            `json:"runtime_ok"`
 	Bundle    runtimecontracts.BundleIdentity `json:"bundle"`
+}
+
+type RuntimeIdentityResult struct {
+	RuntimeInstanceID   string   `json:"runtime_instance_id"`
+	StartedAt           string   `json:"started_at"`
+	APIVersion          string   `json:"api_version"`
+	SupportedTransports []string `json:"supported_transports"`
 }
 
 type runGetResult struct {
@@ -165,6 +173,16 @@ func OperatorReadHandlers(opts OperatorReadOptions) map[string]MethodHandler {
 		},
 		"health.check": func(ctx context.Context, _ Request) (any, error) {
 			return operatorHealthSnapshot(ctx, ready, opts.Database, opts.Bundle), nil
+		},
+		"runtime.identity": func(context.Context, Request) (any, error) {
+			identity := opts.RuntimeIdentity
+			if strings.TrimSpace(identity.RuntimeInstanceID) == "" {
+				return nil, fmt.Errorf("runtime identity is not configured")
+			}
+			if identity.SupportedTransports == nil {
+				identity.SupportedTransports = []string{}
+			}
+			return identity, nil
 		},
 		"run.get": func(ctx context.Context, req Request) (any, error) {
 			runs, err := requireRunReadStore(opts.Runs)

--- a/internal/apiv1/testdata/openrpc_compliance_matrix.yaml
+++ b/internal/apiv1/testdata/openrpc_compliance_matrix.yaml
@@ -783,6 +783,21 @@ methods:
     examples: {status: policy_deferred, proof_refs: [{kind: artifact, path: platform-spec.yaml}, {kind: artifact, path: openrpc.json}, {kind: go_test, name: TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod}]}
     service_discovery_publication: {status: policy_not_published, proof_refs: [{kind: artifact, path: platform-spec.yaml}, {kind: artifact, path: openrpc.json}, {kind: go_test, name: TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod}, {kind: go_test, name: TestServiceDiscoveryPolicyDoesNotServeRPCDiscover}]}
     gap_classification: []
+  - method: runtime.identity
+    transport: http
+    required_params: []
+    declared_errors: []
+    happy_path: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCReadOnlyHTTPRuntimeProbes}]}
+    required_param_validation: {status: not_applicable}
+    unknown_top_level_param_validation: {status: shared, proof_refs: [{kind: go_test, name: TestOpenRPCReadOnlyHTTPRuntimeProbes}, {kind: go_helper, name: validateParams}]}
+    auth: {status: shared, proof_refs: [{kind: go_test, name: TestOpenRPCReadOnlyHTTPRuntimeProbes}, {kind: go_test, name: TestHandlerHTTPAuthBoundary}]}
+    declared_error_tests: {status: not_applicable}
+    idempotency: {status: not_applicable}
+    result_schema: {status: covered, proof_refs: [{kind: go_test, name: TestOpenRPCSuccessfulResultSchemas}, {kind: go_test, name: TestOpenRPCReadOnlyHTTPRuntimeProbes}]}
+    notification_schema: {status: not_applicable}
+    examples: {status: policy_deferred, proof_refs: [{kind: artifact, path: platform-spec.yaml}, {kind: artifact, path: openrpc.json}, {kind: go_test, name: TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod}]}
+    service_discovery_publication: {status: policy_not_published, proof_refs: [{kind: artifact, path: platform-spec.yaml}, {kind: artifact, path: openrpc.json}, {kind: go_test, name: TestOpenRPCComplianceMatrixCoversEveryGeneratedMethod}, {kind: go_test, name: TestServiceDiscoveryPolicyDoesNotServeRPCDiscover}]}
+    gap_classification: []
   - method: runtime.incidents
     transport: http
     required_params: []

--- a/openrpc.json
+++ b/openrpc.json
@@ -4336,7 +4336,7 @@
     },
     {
       "name": "health.check",
-      "description": "Structured health and runtime identity. Operators use this to confirm what server they are talking to and whether it is ready to handle requests.",
+      "description": "Structured health and bundle identity. Operators use this to confirm readiness and the served bundle identity; runtime-instance descriptor trust uses runtime.identity.",
       "params": [],
       "result": {
         "name": "result",
@@ -6972,6 +6972,18 @@
       ]
     },
     {
+      "name": "runtime.identity",
+      "description": "Authenticated nonsensitive identity for the live runtime process instance. Local context descriptors use this method to prove that a discovered API endpoint is the same runtime instance named by the descriptor. It is not bundle identity, PID, port, URL, /healthz, or /readyz.\n",
+      "params": [],
+      "result": {
+        "name": "result",
+        "required": true,
+        "schema": {
+          "$ref": "#/components/schemas/RuntimeIdentityResult"
+        }
+      }
+    },
+    {
       "name": "runtime.incidents",
       "description": "Aggregated runtime incidents (errors and warnings grouped by error_code/component for triage). The optional bundle_hash filter is applied to source runtime-log rows before aggregation.",
       "params": [
@@ -8190,8 +8202,8 @@
             "type": "string"
           },
           "session_scope": {
-            "description": "Present only for scoped agent modes. Omitted for mode=task because task agents have no live runtime session scope.",
-            "$ref": "#/components/schemas/SessionScope"
+            "$ref": "#/components/schemas/SessionScope",
+            "description": "Present only for scoped agent modes. Omitted for mode=task because task agents have no live runtime session scope."
           },
           "status": {
             "$ref": "#/components/schemas/AgentStatus"
@@ -8363,14 +8375,14 @@
           "agent_id": {
             "$ref": "#/components/schemas/OpaqueId"
           },
-          "mode": {
-            "type": "string"
-          },
           "flow_instance": {
             "description": "Persisted flow instance/catalog path when the definition is nested under a flow.",
             "type": "string"
           },
           "llm_backend": {
+            "type": "string"
+          },
+          "mode": {
             "type": "string"
           },
           "model": {
@@ -10857,6 +10869,39 @@
           "event_id",
           "event_name",
           "event_created_at"
+        ],
+        "type": "object"
+      },
+      "RuntimeIdentityResult": {
+        "additionalProperties": false,
+        "description": "Nonsensitive identity for one served runtime process instance. This is the canonical descriptor-trust identity: clients compare runtime_instance_id against local context descriptors after authenticating to the operator API. It is not a bundle fingerprint, PID, port, URL, or unauthenticated process probe.\n",
+        "properties": {
+          "api_version": {
+            "const": "v1",
+            "type": "string"
+          },
+          "runtime_instance_id": {
+            "$ref": "#/components/schemas/OpaqueId"
+          },
+          "started_at": {
+            "$ref": "#/components/schemas/Timestamp"
+          },
+          "supported_transports": {
+            "items": {
+              "enum": [
+                "tcp",
+                "unix"
+              ],
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "runtime_instance_id",
+          "started_at",
+          "api_version",
+          "supported_transports"
         ],
         "type": "object"
       },

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -11602,8 +11602,9 @@ cli_specification:
         Merge-bearing authority for local Swarm target/source explanation: the Swarm user/global state directory,
         project-root facts derived from the existing contracts resolver, target precedence, command-class safety, and
         the first inspection surface `swarm doctor --target`. This first slice is an authority and diagnostic surface
-        only. It does not write descriptor registries, trust runtime identity, retarget API-backed commands, register
-        project-scoped `serve --dev` contexts, migrate store/data paths, or change `swarm run` behavior.
+        only. Runtime identity and local context registry primitives are promoted separately under
+        local_context_registry_authority. This owner still does not retarget API-backed commands, register project-scoped
+        `serve --dev` contexts, migrate store/data paths, or change `swarm run` behavior.
       invariant: >
         You target the project you are in. If you are not in a project, or the project has no live known runtime after
         the registry children exist, Swarm may use the selected/default context or built-in loopback target according to
@@ -11650,9 +11651,9 @@ cli_specification:
         - built_in_loopback_default
         current_first_slice_behavior: >
           `swarm doctor --target` can explain explicit API flag, environment, config, project-root, Swarm-dir, current
-          rollout store/data, and pending registry/identity facts. Context registry, liveness-backed identity, and
-          API-backed command consumption are split to #1613 and #1614; unavailable facts MUST be reported as pending or
-          unavailable rather than inferred from PID, port, or health bundle fingerprint.
+          rollout store/data, and local context registry/identity facts when registry primitives are present. API-backed
+          command consumption remains split to #1614; unavailable facts MUST be reported as unavailable rather than
+          inferred from PID, port, URL, or health bundle fingerprint.
       command_classes:
         target_diagnostic:
           status: implemented
@@ -11706,16 +11707,95 @@ cli_specification:
           report to stdout and emits no success stderr. `--quiet` is not supported by this first slice and remains
           fail-closed as an unknown/unsupported flag.
       split_siblings:
-      - '#1613 runtime identity and descriptor registry'
       - '#1614 project-scoped serve/API command targeting'
       - '#1615 store/data migration and swarm run semantics'
       - '#1576 transport-aware descriptors and IPC/ephemeral-port direction'
       implementation_boundaries:
       - 'The shared CLI config parser may accept `swarm_dir`, but API connection/auth resolution must ignore it.'
       - 'No `SWARM_DIR`, `SWARM_HOME`, `--datadir`, or `<swarm-dir>/config.yaml` bootstrap source is promoted.'
-      - 'No descriptor files are written or trusted in #1612.'
-      - 'No API-backed command target resolver consumes project/global contexts in #1612.'
+      - 'Descriptor registry primitives are written and validated only through local_context_registry_authority.'
+      - 'No API-backed command target resolver consumes project/global contexts until #1614.'
       - 'Store and data paths may be reported as current behavior only; migration is split to #1615.'
+    local_context_registry_authority:
+      promoted_by: '#1613'
+      implementation_status: implemented_primitive_registry
+      canonical_owner: platform-spec.yaml#cli_specification.foundations.local_context_registry_authority
+      implementation_owner: cmd/swarm local context registry helpers and lifecycle commands
+      scope: >
+        Merge-bearing authority for local context descriptor storage under the resolved Swarm-dir, descriptor schema,
+        selected/current context storage, atomic registry writes, descriptor validation taxonomy, and minimal lifecycle
+        inspection/cleanup. It provides primitives that #1614 may consume for project/global command targeting, but it
+        does not itself change serve registration or API-backed command resolution.
+      registry_layout:
+        root: <swarm-dir>/contexts
+        descriptors: <swarm-dir>/contexts/<context-name>.json
+        current_selector: <swarm-dir>/contexts/current
+        lock: <swarm-dir>/contexts/.lock
+        name_rule: >
+          Context names are trimmed UTF-8 strings that cannot be empty, '.', '..', contain path separators, contain NUL,
+          or start with '.'. Names are registry keys only; project auto-naming is split to #1614.
+      descriptor_schema:
+        version: 1
+        required_fields:
+        - version
+        - name
+        - runtime_instance_id
+        - transport
+        - created_at
+        - updated_at
+        transport:
+          supported_values:
+          - tcp
+          - unix
+          tcp_required_field: api_server
+          unix_required_field: socket_path
+          current_implementation: >
+            tcp descriptors can be validated by calling /v1/rpc runtime.identity. unix descriptors are schema-valid
+            but validation classifies them as unsupported until #1576 promotes IPC dialing policy.
+        safe_auth:
+          allowed_modes:
+          - builtin_loopback
+          - token_file
+          rejected: inline bearer tokens, token strings, environment-token snapshots, or descriptor-local secret values
+          builtin_loopback_rule: >
+            builtin_loopback is accepted only for numeric loopback TCP API targets where the existing API auth owner
+            permits the built-in default token. Non-loopback targets require token_file.
+        optional_fields:
+        - project_root
+        - contracts_path
+        - store_path
+        - data_dir
+        - pid
+        path_fields: >
+          Path fields are explanatory metadata only in this child. Store/data migration and project registration are split
+          to #1615 and #1614.
+      atomicity:
+        rule: >
+          Registry mutations acquire the registry lock, write complete JSON/text to a temporary file in the registry
+          directory, fsync-or-equivalent that file, rename it over the destination, and best-effort fsync the directory.
+          Lock contention, permission denial, and partial/corrupt files fail closed.
+      validation_statuses:
+      - ok
+      - no_server
+      - stale_descriptor
+      - identity_mismatch
+      - unsupported_transport
+      - auth_failure
+      - permission_denied
+      - corrupt_descriptor
+      - invalid_descriptor
+      lifecycle_surface:
+        commands:
+        - swarm context current
+        - swarm context list
+        - swarm context prune
+        doctor_consumption: swarm doctor --target reports registry and runtime identity facts using these primitives
+        output_owner: cli_specification.foundations.output_contract
+      implementation_boundaries:
+      - 'No `serve --dev` or `serve` project-scoped descriptor registration in #1613; #1614 owns that behavior.'
+      - 'No API-backed command target resolver consumes context descriptors in #1613; #1614 owns consumption.'
+      - 'No runtime store/data path migration or `swarm run` behavior change in #1613; #1615 owns that behavior.'
+      - 'No unix socket dialing policy in #1613; #1576 owns actual IPC transport behavior.'
     api_connection_auth_config_precedence:
       promoted_by: '#844'
       loopback_default_implemented_by: '#1124'
@@ -14982,6 +15062,33 @@ api_specification:
             type: boolean
           bundle:
             $ref: '#/components/schemas/BundleIdentity'
+      RuntimeIdentityResult:
+        description: >
+          Nonsensitive identity for one served runtime process instance. This is the canonical descriptor-trust identity:
+          clients compare runtime_instance_id against local context descriptors after authenticating to the operator API.
+          It is not a bundle fingerprint, PID, port, URL, or unauthenticated process probe.
+        type: object
+        additionalProperties: false
+        required:
+        - runtime_instance_id
+        - started_at
+        - api_version
+        - supported_transports
+        properties:
+          runtime_instance_id:
+            $ref: '#/components/schemas/OpaqueId'
+          started_at:
+            $ref: '#/components/schemas/Timestamp'
+          api_version:
+            type: string
+            const: v1
+          supported_transports:
+            type: array
+            items:
+              type: string
+              enum:
+              - tcp
+              - unix
       RunStatus:
         type: string
         enum:
@@ -17895,8 +18002,8 @@ api_specification:
       errors: []
     health.check:
       tier: must_have
-      description: Structured health and runtime identity. Operators use this to confirm what server they are talking to and
-        whether it is ready to handle requests.
+      description: Structured health and bundle identity. Operators use this to confirm readiness and the served bundle
+        identity; runtime-instance descriptor trust uses runtime.identity.
       scope:
         required:
         - read:health
@@ -17906,6 +18013,22 @@ api_specification:
         required: true
         schema:
           $ref: '#/components/schemas/HealthCheckResult'
+      errors: []
+    runtime.identity:
+      tier: must_have
+      description: >
+        Authenticated nonsensitive identity for the live runtime process instance. Local context descriptors use this
+        method to prove that a discovered API endpoint is the same runtime instance named by the descriptor. It is not
+        bundle identity, PID, port, URL, /healthz, or /readyz.
+      scope:
+        required:
+        - read:runtime
+      params: []
+      result:
+        name: result
+        required: true
+        schema:
+          $ref: '#/components/schemas/RuntimeIdentityResult'
       errors: []
     bundle.list:
       tier: should_have
@@ -20161,10 +20284,10 @@ api_specification:
         is the right Phase-2 API shape and is deferred until that consumer\nis real. No verify.* method is implemented in\
         \ v1 over JSON-RPC.\n"
     runtime_identity:
-      methods:
-      - runtime.identity
-      rationale: health.check covers bundle identity in v1. Break out as runtime.identity if Phase 2/3 grows non-bundle identity
-        dimensions (region, deployment, version).
+      methods: []
+      rationale: >
+        runtime.identity is promoted in v1 as the canonical runtime-instance descriptor trust owner by #1613.
+        Future non-sensitive identity dimensions may extend RuntimeIdentityResult additively.
   migration:
     description: How the previous dual-API surface is retired in favor of v1.
     builder_api_disposition:


### PR DESCRIPTION
## Summary

Closes #1613.

This PR closes the #1613 primitive class for local context descriptor trust:

- Promotes `/v1/rpc runtime.identity` with `RuntimeIdentityResult` in `platform-spec.yaml` and generated `openrpc.json`.
- Mints one nonsensitive `runtime_instance_id` per `swarm serve` process boot and exposes it only through authenticated v1 RPC.
- Adds the merge-bearing `local_context_registry_authority` spec owner for descriptor schema, registry layout, selected/current state, safe auth references, atomic writes, validation taxonomy, and lifecycle boundaries.
- Adds shared local context registry primitives plus `swarm context current`, `swarm context list`, and `swarm context prune`.
- Updates `swarm doctor --target` to report real registry/runtime-identity facts instead of #1613 pending prose.

## Governing Refs

- `platform-spec.yaml#api_specification.method_catalog.runtime.identity`
- `platform-spec.yaml#api_specification.components.schemas.RuntimeIdentityResult`
- `platform-spec.yaml#cli_specification.foundations.local_context_registry_authority`
- Existing adjacent owner: `platform-spec.yaml#cli_specification.foundations.local_target_resolution_authority`
- Existing adjacent owner: `platform-spec.yaml#cli_specification.foundations.api_connection_auth_config_precedence`
- Existing adjacent owner: `platform-spec.yaml#cli_specification.foundations.output_contract`
- Binding issue/gate context: #1613 pre-audit and approved gate comment.

## Semantic Migration

New canonical owners:

- Runtime instance identity: `runtime.identity` + `RuntimeIdentityResult`.
- Descriptor trust and registry primitives: `local_context_registry_authority`.

Old/non-authoritative paths now invalid:

- PID, port, URL, descriptor file existence, `/healthz`, `/readyz`, and `health.check.bundle.fingerprint` are not runtime-instance identity proof.
- URL-only descriptors are non-authoritative; descriptors are transport-aware from v1.
- Inline bearer tokens or token snapshots in descriptors are invalid.
- Non-atomic descriptor/current writes and corrupt/partial best-effort parsing are invalid.

Production paths checked for surviving old behavior:

- `swarm serve` only mints/passes runtime identity; it does not register project contexts.
- API-backed command resolution still uses existing API flags/env/config/default behavior and does not consume descriptors.
- Store/data defaults and `swarm run` behavior are untouched.
- Unix descriptor shape is accepted as schema-compatible but validation remains `unsupported_transport` until #1576.

Migration completeness:

- Complete for the #1613 primitive class.
- Parent tail remains in #1614 (serve/project/API target consumption), #1615 (store/data/run), and #1576 (IPC/unix policy).

## Proof

- `go run ./cmd/swarm-openrpc-gen --check`
- `go test ./cmd/swarm`
- `go test ./internal/apiv1`
- `go test ./internal/apispec`
- `go test ./...` (first full run exposed unrelated event.publish timing failures; the exact failing tests passed independently, and the full-suite retry passed)
