### PR TITLE
[agent-e][issue #1524] Clarify rule side-effect resolution

### DIFF
--- a/internal/runtime/bootverify/report_test.go
+++ b/internal/runtime/bootverify/report_test.go
@@ -1905,6 +1905,38 @@ func TestRun_AllowsDeclaredSetsGateFromScalarAndStructuredForms(t *testing.T) {
 	}
 }
 
+func TestRun_ValidatesHandlerSetsGateWhenRulesExist(t *testing.T) {
+	cases := []struct {
+		name      string
+		setsGate  string
+		wantError bool
+	}{
+		{name: "declared", setsGate: "approved"},
+		{name: "undeclared", setsGate: "rejected", wantError: true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			bundle := gateSchemaValidationBundle(runtimecontracts.NodeGateStateSchema{
+				Gates: []runtimecontracts.NodeGateField{{Name: "approved"}},
+			}, runtimecontracts.SystemNodeEventHandler{
+				SetsGate: &runtimecontracts.GateSpec{Name: tc.setsGate, Value: true},
+				Rules: []runtimecontracts.HandlerRuleEntry{{
+					ID:        "matched",
+					Condition: "else",
+				}},
+			})
+
+			report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+
+			hasError := reportContains(report.Errors(), "gate_schema_validation", "sets_gate "+tc.setsGate)
+			if hasError != tc.wantError {
+				t.Fatalf("gate_schema_validation error = %v, want %v; errors: %#v", hasError, tc.wantError, report.Errors())
+			}
+		})
+	}
+}
+
 func TestRun_MapsEmptyEventPayloadSchemaConditionRefsToNamedError(t *testing.T) {
 	cases := []struct {
 		name    string

--- a/internal/runtime/contracts/workflow_contract_yaml_test.go
+++ b/internal/runtime/contracts/workflow_contract_yaml_test.go
@@ -481,6 +481,19 @@ rules:
 	}
 }
 
+func TestSystemNodeEventHandlerDecode_RejectsRuleLevelSetsGate(t *testing.T) {
+	var handler SystemNodeEventHandler
+	err := yaml.Unmarshal([]byte(`
+rules:
+  gated:
+    condition: "else"
+    sets_gate: approved
+`), &handler)
+	if err == nil || !strings.Contains(err.Error(), `UNDEFINED-FIELD: rule field "sets_gate"`) {
+		t.Fatalf("yaml.Unmarshal error = %v, want rule-level sets_gate rejection", err)
+	}
+}
+
 func TestSystemNodeEventHandlerDecode_RejectsRetiredPayloadTransform(t *testing.T) {
 	var handler SystemNodeEventHandler
 	err := yaml.Unmarshal([]byte(`

--- a/internal/runtime/engine/executor_test.go
+++ b/internal/runtime/engine/executor_test.go
@@ -1841,6 +1841,90 @@ func TestExecutor_RulesUseFirstMatchAndSkipLaterEntries(t *testing.T) {
 	}
 }
 
+func TestExecutor_RulesUseHandlerAdvancesToDefaultWhenRuleOmitsTarget(t *testing.T) {
+	exec, err := NewExecutor(RuntimeDependencies{
+		Source:     stubSource(),
+		StateRepo:  stubStateRepo{},
+		TxRunner:   stubRunner{},
+		Locker:     stubLocker{},
+		Outbox:     stubOutbox{},
+		Dispatcher: stubDispatcher{},
+	}, stubEvaluator{bools: map[string]bool{
+		"payload.score > 5": true,
+	}})
+	if err != nil {
+		t.Fatalf("NewExecutor error: %v", err)
+	}
+	result, err := exec.Execute(context.Background(), ExecutionRequest{
+		EntityID: "entity-1",
+		NodeID:   "node-1",
+		FlowID:   "flow-1",
+		Event:    eventtest.RootIngress("evt-1", "task.completed", "", "", json.RawMessage(`{"score":9}`), 0, "", "", events.EventEnvelope{}, time.Time{}),
+		Handler: runtimecontracts.SystemNodeEventHandler{
+			AdvancesTo: "default",
+			Rules: []runtimecontracts.HandlerRuleEntry{{
+				ID:        "rule-1",
+				Condition: "payload.score > 5",
+			}},
+		},
+		State: testStateSnapshot("pending", map[string]any{}, nil, map[string]map[string]any{}),
+	})
+	if err != nil {
+		t.Fatalf("Execute error: %v", err)
+	}
+	if result.RuleID != "rule-1" {
+		t.Fatalf("RuleID = %q", result.RuleID)
+	}
+	if result.NextState != "default" {
+		t.Fatalf("NextState = %q, want handler-level default", result.NextState)
+	}
+}
+
+func TestExecutor_HandlerSetsGateAppliesWithMatchedRule(t *testing.T) {
+	exec, err := NewExecutor(RuntimeDependencies{
+		Source:     stubSource(),
+		StateRepo:  stubStateRepo{},
+		TxRunner:   stubRunner{},
+		Locker:     stubLocker{},
+		Outbox:     stubOutbox{},
+		Dispatcher: stubDispatcher{},
+	}, stubEvaluator{bools: map[string]bool{
+		"payload.score > 5": true,
+	}})
+	if err != nil {
+		t.Fatalf("NewExecutor error: %v", err)
+	}
+	result, err := exec.Execute(context.Background(), ExecutionRequest{
+		EntityID: "entity-1",
+		NodeID:   "node-1",
+		FlowID:   "flow-1",
+		Event:    eventtest.RootIngress("evt-1", "task.completed", "", "", json.RawMessage(`{"score":9}`), 0, "", "", events.EventEnvelope{}, time.Time{}),
+		Handler: runtimecontracts.SystemNodeEventHandler{
+			SetsGate: &runtimecontracts.GateSpec{Name: "approved", Value: true},
+			Rules: []runtimecontracts.HandlerRuleEntry{{
+				ID:        "rule-1",
+				Condition: "payload.score > 5",
+			}},
+		},
+		State: testStateSnapshot("pending", map[string]any{}, nil, map[string]map[string]any{}),
+	})
+	if err != nil {
+		t.Fatalf("Execute error: %v", err)
+	}
+	if result.RuleID != "rule-1" {
+		t.Fatalf("RuleID = %q", result.RuleID)
+	}
+	if result.SetsGate != "approved" {
+		t.Fatalf("SetsGate = %q, want handler-level gate with matched rule", result.SetsGate)
+	}
+	if result.StateMutation.SetGate != "approved" {
+		t.Fatalf("StateMutation.SetGate = %q, want approved", result.StateMutation.SetGate)
+	}
+	if got := result.StateMutation.Gates["approved"]; !got {
+		t.Fatalf("StateMutation.Gates[approved] = %v, want true", got)
+	}
+}
+
 func TestExecutor_RejectsAmbiguousHandlerTopLevelEmitWithRules(t *testing.T) {
 	exec, err := NewExecutor(RuntimeDependencies{
 		Source:        stubSource(),

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -2164,7 +2164,9 @@ handler_specification:
   - 'reduce → count: aggregated result available before counting'
   - 'count → compute: all list processing complete before computation'
   - 'compute → emit-site selection: computed values written before branch/rule/timeout selection evaluates'
-  - 'emit-site selection → {advances_to, sets_gate, data_accumulation}: active branch/rule/timeout may override these fields'
+  - 'emit-site selection → advances_to: the selected rule/branch/timeout advances_to overrides handler-level advances_to when present; otherwise handler-level advances_to is the default'
+  - 'emit-site selection → sets_gate: sets_gate is handler-level only; selected rule/branch/timeout entries do not declare or override sets_gate'
+  - 'emit-site selection → data_accumulation: selected rule/branch/timeout data_accumulation supplements handler-level data_accumulation in the same transaction; selected entry writes run before handler-level writes'
   - 'advances_to, sets_gate, data_accumulation: INDEPENDENT — no causal dependency, any order valid'
   - 'data_accumulation → projection: accumulator-to-entity materialize_from writes run after selected branch writes'
   - 'projection → emit.fields: emit payload expressions observe projected entity fields'
@@ -2215,12 +2217,18 @@ handler_specification:
     example: 'order.received may have handler-level data_accumulation (3 fields) + rules with per-rule data_accumulation (category_data).
       Result: all 3 handler-level fields are written, PLUS the matching rule writes category_data. Event emission, however,
       and action must be owned by the matching rule or by the explicit rules emit template specialization.'
-    precedence: Handler-level advances_to, sets_gate, and data_accumulation are defaults. If the matched rule specifies any
-      of these, the rule value OVERRIDES the handler-level value for that field only. Bare emit and action never fall through from
-      a handler into a rules-based multi-emit/action handler. The only handler-level emit exception is rules emit template
-      specialization, where handler-level `emit.event` and shared `emit.fields` are inherited by the matched rule's eventless
-      `emit.fields` and produce exactly one effective emit. Explicit on_success.emit is additive only as a second distinct
-      success event.
+    side_effect_resolution:
+      advances_to: Handler-level advances_to is the default transition target. A matched rule with a non-empty advances_to
+        overrides the handler-level target for that execution only.
+      sets_gate: sets_gate is handler-level only in the supported handler/rule vocabulary. Rules, on_complete entries,
+        accumulate.on_timeout entries, and branch entries do not declare or override sets_gate.
+      data_accumulation: Handler-level data_accumulation supplements the selected rule/branch/timeout data_accumulation in
+        the same atomic transaction. Selected entry writes run before handler-level writes. This is additive composition,
+        not default/override precedence.
+      emit_and_action: Bare emit and action never fall through from a handler into a rules-based multi-emit/action handler.
+        The only handler-level emit exception is rules emit template specialization, where handler-level `emit.event` and
+        shared `emit.fields` are inherited by the matched rule's eventless `emit.fields` and produce exactly one effective
+        emit. Explicit on_success.emit is additive only as a second distinct success event.
 engine:
   description: Specification for the platform engine — how it loads, validates, and executes flows.
   flow_tree_walker:
@@ -4672,7 +4680,7 @@ compliance:
     - 'If handler has accumulate: track arrival, check completion, proceed only on complete.'
     - 'If handler has on_complete: evaluate conditions, execute matching branch.'
     - 'If handler has rules: match payload field, select the matching rule-local emit and action if present.'
-    - 'Apply advances_to, sets_gate, and data_accumulation from the active handler/branch/rule outcome.'
+    - 'Resolve side effects per handler_specification.rules_handler_interaction.side_effect_resolution: advances_to uses handler default with selected-entry override, sets_gate is handler-level only, and data_accumulation composes selected-entry writes before handler-level writes.'
     - 'If the active emit site has emit: publish the selected follow-up event.'
     - 'If the active handler or selected rule has action that is a platform action: call registered platform action.'
     - 'If the resolved action runtime instruction emits an event: publish it using the action-originated payload rules and fail-closed schema validation before commit.'


### PR DESCRIPTION
## Summary

Closes #1524.

This PR clarifies the authoritative handler/rule side-effect resolution contract without changing runtime behavior:

- replaces the stale generic `advances_to` / `sets_gate` / `data_accumulation` default-override prose with explicit per-field semantics
- aligns `dependency_rules`, `rules_handler_interaction`, and `engine.handler_execution` with the supported model
- adds focused proof for unsupported rule-level `sets_gate`, handler-level `sets_gate` with matched rules, `advances_to` default/override, and additive rule+handler `data_accumulation`

## Governing refs / context

Exact spec refs:

- `platform-spec.yaml#handler_specification.dependency_graph`
- `platform-spec.yaml#handler_specification.dependency_rules`
- `platform-spec.yaml#handler_specification.handler_fields.rules.rule_fields`
- `platform-spec.yaml#handler_specification.rules_handler_interaction.side_effect_resolution`
- `platform-spec.yaml#engine.handler_execution`

Binding issue/gate context:

- #1462 Point 4 split to #1524
- #1524 Pre-Implementation Coverage Audit: https://github.com/division-sh/swarm/issues/1524#issuecomment-4870703847
- #1524 independent gate: https://github.com/division-sh/swarm/issues/1524#issuecomment-4870748136

## Semantic migration statement

- New canonical owner: `platform-spec.yaml#handler_specification.rules_handler_interaction.side_effect_resolution`, backed by the existing contract/runtime/bootverify owners.
- Old invalid path: generic prose claiming `advances_to`, `sets_gate`, and `data_accumulation` all use one handler-default/rule-override rule.
- Old producer/reader/writer path now invalid: any spec interpretation that admits `rules[*].sets_gate` or treats rule `data_accumulation` as overriding handler `data_accumulation`.
- Production paths checked for surviving old behavior: `HandlerRuleEntry`, YAML rule field validation, `stepAdvancesTo`, `stepSetsGate`, `stepDataWrites`, and bootverify gate/data/state checks.
- Migration complete for #1524: yes. No runtime/store migration and no compatibility seam are introduced.

## Proof

Focused proof:

- `go test ./internal/runtime/contracts -run 'TestSystemNodeEventHandlerDecode_RejectsRuleLevelSetsGate|TestWorkflowSemanticsRuleActionUsesHandlerAdvancesToFallback' -count=1`
- `go test ./internal/runtime/engine -run 'TestExecutor_RulesUseFirstMatchAndSkipLaterEntries|TestExecutor_RulesUseHandlerAdvancesToDefaultWhenRuleOmitsTarget|TestExecutor_HandlerSetsGateAppliesWithMatchedRule|TestExecutor_RuleDataAccumulationRunsBeforeTopLevelWrites|TestExecutor_RulesDoNotSeeCurrentHandlerTopLevelWritesBeforeSelection' -count=1`
- `go test ./internal/runtime/bootverify -run 'TestRun_ValidatesHandlerSetsGateWhenRulesExist|TestRun_MapsUnknownSetsGateToGateSchemaValidationError|TestRun_AllowsDeclaredSetsGateFromScalarAndStructuredForms|TestRun_AllowsTopLevelDataAccumulationExpressionToReadRuleProducedField' -count=1`

Whole suite:

- `go test ./...`

Note: one pre-rebase full-suite run hit a transient `internal/runtime/bus` timeout in `TestEventBusPublishAcknowledgedReturnsBeforePostCommitDispatchCompletes`; the isolated test and package both passed immediately after. After rebasing onto current `origin/master`, the focused proof and `go test ./...` passed cleanly.