### PR TITLE
[agent-f][issue #1597] Enforce event metadata authority

### DIFF
--- a/cmd/swarm/main_test.go
+++ b/cmd/swarm/main_test.go
@@ -9287,9 +9287,7 @@ ticket:
     initial: ""
 `)
 	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "events.yaml"), `
-timer.reminder:
-  swarm:
-    source: internal
+timer.reminder: {}
 `)
 	timerBlock := `
     - id: reminder
@@ -12024,9 +12022,7 @@ pins:
 task.requested:
   swarm:
     source: external
-task.completed:
-  swarm:
-    source: internal
+task.completed: {}
 child/task.assigned: {}
 child/task.result: {}
 `)
@@ -12063,9 +12059,7 @@ pins:
 work_item: {}
 `)
 	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "flows", "child", "events.yaml"), `
-task.assigned:
-  swarm:
-    source: internal
+task.assigned: {}
 task.feedback:
   comment: string
 task.result: {}

--- a/internal/runtime/bootverify/checks.go
+++ b/internal/runtime/bootverify/checks.go
@@ -94,6 +94,9 @@ type checkerContext struct {
 	deadEventSchemaLoaded   bool
 	deadEventSchemaFindings []Finding
 
+	eventMetadataAuthorityLoaded   bool
+	eventMetadataAuthorityFindings []Finding
+
 	dialectLoaded   bool
 	dialectFindings []Finding
 
@@ -203,6 +206,7 @@ type checkerContext struct {
 }
 
 var bootCheckRegistry = []Check{
+	{ID: "event_metadata_authority", Severity: SeverityHardInvalidity, Run: checkEventMetadataAuthority},
 	{ID: "event_chain_integrity", Severity: "warning", Run: checkEventChainIntegrity},
 	{ID: "event_consumer_exists", Severity: "warning", Run: checkEventConsumerExists},
 	{ID: "event_producer_exists", Severity: "warning", Run: checkEventProducerExists},

--- a/internal/runtime/bootverify/flow_data_access_test.go
+++ b/internal/runtime/bootverify/flow_data_access_test.go
@@ -66,8 +66,8 @@ func TestRun_ValidatesFlowDataAccessDeclarations(t *testing.T) {
 }
 
 func TestBootCheckRegistry_HasFlowDataAccessCheckCount(t *testing.T) {
-	if got := len(bootCheckRegistry); got != 68 {
-		t.Fatalf("bootCheckRegistry count = %d, want 68", got)
+	if got := len(bootCheckRegistry); got != 69 {
+		t.Fatalf("bootCheckRegistry count = %d, want 69", got)
 	}
 }
 

--- a/internal/runtime/bootverify/report_test.go
+++ b/internal/runtime/bootverify/report_test.go
@@ -5447,8 +5447,8 @@ func TestRun_ReportsMissingRuntimeExecutorForOwnedRuntimeEvent(t *testing.T) {
 }
 
 func TestBootCheckRegistry_HasSpecCheckCount(t *testing.T) {
-	if got := len(bootCheckRegistry); got != 68 {
-		t.Fatalf("bootCheckRegistry count = %d, want 68", got)
+	if got := len(bootCheckRegistry); got != 69 {
+		t.Fatalf("bootCheckRegistry count = %d, want 69", got)
 	}
 	if got := len(supplementalChecks); got != 3 {
 		t.Fatalf("supplementalChecks count = %d, want 3", got)

--- a/internal/runtime/bootverify/workflow_dead_event_schema_checks.go
+++ b/internal/runtime/bootverify/workflow_dead_event_schema_checks.go
@@ -371,8 +371,7 @@ func deadEventSameScope(a, b string) bool {
 }
 
 func deadEventExternalSource(entry runtimecontracts.EventCatalogEntry) bool {
-	source := strings.ToLower(strings.TrimSpace(entry.SwarmSource()))
-	return strings.HasPrefix(source, "external")
+	return eventMetadataExternalOrPlatformSource(entry.SwarmSource())
 }
 
 func deadEventExternalConsumer(entry runtimecontracts.EventCatalogEntry) bool {

--- a/internal/runtime/bootverify/workflow_event_metadata_authority_checks.go
+++ b/internal/runtime/bootverify/workflow_event_metadata_authority_checks.go
@@ -1,0 +1,399 @@
+package bootverify
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
+	"github.com/division-sh/swarm/internal/runtime/core/eventidentity"
+	"github.com/division-sh/swarm/internal/runtime/semanticview"
+)
+
+func checkEventMetadataAuthority(c *checkerContext) []Finding {
+	return c.eventMetadataAuthority()
+}
+
+func (c *checkerContext) eventMetadataAuthority() []Finding {
+	if c.eventMetadataAuthorityLoaded {
+		return c.eventMetadataAuthorityFindings
+	}
+	c.eventMetadataAuthorityLoaded = true
+	if c.source == nil {
+		return nil
+	}
+	globalNames := eventMetadataInternalActorNames(c.source)
+	for _, decl := range deadEventDeclarations(c.source) {
+		producerNames, consumerNames := eventMetadataRoleNames(c.source, decl)
+		c.eventMetadataAuthorityFindings = append(c.eventMetadataAuthorityFindings, eventMetadataSourceAuthorityFindings(decl, globalNames, producerNames)...)
+		c.eventMetadataAuthorityFindings = append(c.eventMetadataAuthorityFindings, eventMetadataListAuthorityFindings(decl, "swarm.producer", decl.Entry.SwarmProducer(), globalNames, producerNames)...)
+		c.eventMetadataAuthorityFindings = append(c.eventMetadataAuthorityFindings, eventMetadataListAuthorityFindings(decl, "swarm.consumer", decl.Entry.SwarmConsumer(), globalNames, consumerNames)...)
+	}
+	return c.eventMetadataAuthorityFindings
+}
+
+type eventMetadataNameIndex map[string]string
+
+func (idx eventMetadataNameIndex) add(value, label string) {
+	value = strings.TrimSpace(value)
+	label = strings.TrimSpace(label)
+	if value == "" || label == "" {
+		return
+	}
+	for _, key := range eventMetadataNameKeys(value) {
+		if key == "" {
+			continue
+		}
+		if _, exists := idx[key]; exists {
+			continue
+		}
+		idx[key] = label
+	}
+}
+
+func (idx eventMetadataNameIndex) merge(other eventMetadataNameIndex) {
+	for key, label := range other {
+		if _, exists := idx[key]; exists {
+			continue
+		}
+		idx[key] = label
+	}
+}
+
+func (idx eventMetadataNameIndex) match(value string) (string, bool) {
+	for _, key := range eventMetadataNameKeys(value) {
+		if label, ok := idx[key]; ok {
+			return label, true
+		}
+	}
+	return "", false
+}
+
+func eventMetadataNameKeys(value string) []string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return nil
+	}
+	keys := []string{strings.ToLower(value)}
+	if normalized := eventidentity.Normalize(value); normalized != "" {
+		keys = append(keys, strings.ToLower(normalized))
+	}
+	return keys
+}
+
+func eventMetadataInternalActorNames(source semanticview.Source) eventMetadataNameIndex {
+	names := eventMetadataNameIndex{}
+	names.add("runtime", "runtime")
+	names.add("sys:runtime", "runtime")
+	for nodeKey, node := range source.NodeEntries() {
+		nodeKey = strings.TrimSpace(nodeKey)
+		names.add(nodeKey, fmt.Sprintf("system node %s", nodeKey))
+		if id := runtimecontracts.EffectiveSystemNodeID(nodeKey, node); id != "" {
+			names.add(id, fmt.Sprintf("system node %s", id))
+		}
+	}
+	for agentKey, agent := range source.AgentEntries() {
+		agentKey = strings.TrimSpace(agentKey)
+		names.add(agentKey, fmt.Sprintf("agent %s", agentKey))
+		names.add(agent.ID, fmt.Sprintf("agent %s", strings.TrimSpace(agent.ID)))
+		names.add(agent.Role, fmt.Sprintf("agent role %s", strings.TrimSpace(agent.Role)))
+	}
+	for _, required := range source.RequiredAgents() {
+		names.add(required.Role, fmt.Sprintf("required agent role %s", strings.TrimSpace(required.Role)))
+	}
+	for _, scope := range source.FlowScopes() {
+		eventMetadataAddGlobalFlowTopologyNames(source, names, strings.TrimSpace(scope.ID))
+		for _, required := range source.FlowRequiredAgents(scope.ID) {
+			names.add(required.Role, fmt.Sprintf("required agent role %s", strings.TrimSpace(required.Role)))
+		}
+	}
+	if bundle, ok := semanticview.Bundle(source); ok && bundle != nil && bundle.RootSchema != nil {
+		eventMetadataAddGlobalFlowTopologyNames(source, names, "")
+	}
+	eventMetadataAddGlobalCompositionConnectNames(source, names)
+	for _, timer := range source.WorkflowTimers() {
+		names.add(timer.ID, fmt.Sprintf("timer %s", strings.TrimSpace(timer.ID)))
+	}
+	return names
+}
+
+func eventMetadataAddGlobalFlowTopologyNames(source semanticview.Source, names eventMetadataNameIndex, flowID string) {
+	flowID = strings.TrimSpace(flowID)
+	if flowID != "" {
+		names.add(flowID, eventMetadataFlowLabel(flowID))
+	}
+	for _, pin := range source.FlowOutputEventPins(flowID) {
+		eventMetadataAddFlowRole(names, flowID, pin.PinName(), "output pin producer")
+	}
+	for _, pin := range source.FlowInputEventPins(flowID) {
+		eventMetadataAddFlowRole(names, flowID, pin.PinName(), "input pin consumer")
+	}
+}
+
+func eventMetadataAddGlobalCompositionConnectNames(source semanticview.Source, names eventMetadataNameIndex) {
+	for _, connect := range source.CompositionConnects() {
+		if from, err := connect.FromRef(); err == nil {
+			if _, ok := source.FlowOutputEventPin(from.FlowID, from.Pin); ok {
+				eventMetadataAddFlowPinRefRole(names, from, connect.From, "parent connect output producer")
+			}
+		}
+		if to, err := connect.ToRef(); err == nil {
+			if _, ok := source.FlowInputEventPin(to.FlowID, to.Pin); ok {
+				eventMetadataAddFlowPinRefRole(names, to, connect.To, "parent connect input consumer")
+			}
+		}
+	}
+}
+
+func eventMetadataRoleNames(source semanticview.Source, decl deadEventDeclaration) (eventMetadataNameIndex, eventMetadataNameIndex) {
+	producers := eventMetadataNameIndex{}
+	consumers := eventMetadataNameIndex{}
+	if source == nil {
+		return producers, consumers
+	}
+	for nodeKey, node := range source.NodeEntries() {
+		nodeSource, _ := source.NodeContractSource(nodeKey)
+		flowID := strings.TrimSpace(nodeSource.FlowID)
+		for handlerEvent, handler := range node.EventHandlers {
+			if deadEventRoleMatches(source, decl, flowID, handlerEvent) {
+				eventMetadataAddNodeRole(consumers, nodeKey, node, "handler subscribes")
+			}
+			for _, emitted := range runtimecontracts.HandlerEmitEvents(handler) {
+				if deadEventRoleMatches(source, decl, flowID, emitted) {
+					eventMetadataAddNodeRole(producers, nodeKey, node, "handler emits")
+				}
+			}
+		}
+		for _, eventType := range runtimecontracts.EffectiveSystemNodeSubscriptions(node) {
+			if deadEventRoleMatches(source, decl, flowID, eventType) {
+				eventMetadataAddNodeRole(consumers, nodeKey, node, "effective subscription")
+			}
+		}
+	}
+	for agentKey, agent := range source.AgentEntries() {
+		agentSource, _ := source.AgentContractSource(agentKey)
+		flowID := strings.TrimSpace(agentSource.FlowID)
+		for _, eventType := range agent.EmitEvents {
+			if deadEventRoleMatches(source, decl, flowID, eventType) {
+				eventMetadataAddAgentRole(producers, agentKey, agent, "emit_events")
+			}
+		}
+		for _, eventType := range agent.Subscriptions {
+			if deadEventRoleMatches(source, decl, flowID, eventType) {
+				eventMetadataAddAgentRole(consumers, agentKey, agent, "subscriptions")
+			}
+		}
+	}
+	for _, required := range source.RequiredAgents() {
+		eventMetadataAddRequiredAgentRoles(source, decl, producers, consumers, "", required)
+	}
+	for _, scope := range source.FlowScopes() {
+		flowID := strings.TrimSpace(scope.ID)
+		eventMetadataAddFlowRoles(source, decl, producers, consumers, flowID, scope.AutoEmitEvent)
+		for _, required := range source.FlowRequiredAgents(flowID) {
+			eventMetadataAddRequiredAgentRoles(source, decl, producers, consumers, flowID, required)
+		}
+	}
+	if bundle, ok := semanticview.Bundle(source); ok && bundle != nil && bundle.RootSchema != nil {
+		eventMetadataAddFlowRoles(source, decl, producers, consumers, "", bundle.RootSchema.AutoEmitOnCreate.Event)
+	}
+	eventMetadataAddCompositionConnectRoles(source, decl, producers, consumers)
+	for _, timer := range source.WorkflowTimers() {
+		flowID := strings.TrimSpace(timer.FlowID)
+		if deadEventRoleMatches(source, decl, flowID, timer.Event) {
+			producers.add(timer.ID, fmt.Sprintf("timer %s fires event", strings.TrimSpace(timer.ID)))
+			producers.add("runtime", "runtime timer producer")
+			producers.add("sys:runtime", "runtime timer producer")
+		}
+		for _, trigger := range []string{timer.StartOn, timer.CancelOn} {
+			trigger = strings.TrimSpace(trigger)
+			if !strings.HasPrefix(trigger, "event:") {
+				continue
+			}
+			eventType := strings.TrimSpace(strings.TrimPrefix(trigger, "event:"))
+			if deadEventRoleMatches(source, decl, flowID, eventType) {
+				consumers.add(timer.ID, fmt.Sprintf("timer %s trigger", strings.TrimSpace(timer.ID)))
+				consumers.add("runtime", "runtime timer consumer")
+				consumers.add("sys:runtime", "runtime timer consumer")
+			}
+		}
+	}
+	for _, owner := range source.RuntimeEventOwners(decl.Canonical) {
+		consumers.add(owner, fmt.Sprintf("runtime event owner %s", strings.TrimSpace(owner)))
+	}
+	return producers, consumers
+}
+
+func eventMetadataAddNodeRole(names eventMetadataNameIndex, nodeKey string, node runtimecontracts.SystemNodeContract, role string) {
+	nodeKey = strings.TrimSpace(nodeKey)
+	role = strings.TrimSpace(role)
+	if role == "" {
+		role = "topology"
+	}
+	names.add(nodeKey, fmt.Sprintf("system node %s %s", nodeKey, role))
+	if id := runtimecontracts.EffectiveSystemNodeID(nodeKey, node); id != "" {
+		names.add(id, fmt.Sprintf("system node %s %s", id, role))
+	}
+}
+
+func eventMetadataAddAgentRole(names eventMetadataNameIndex, agentKey string, agent runtimecontracts.AgentRegistryEntry, role string) {
+	agentKey = strings.TrimSpace(agentKey)
+	role = strings.TrimSpace(role)
+	if role == "" {
+		role = "topology"
+	}
+	names.add(agentKey, fmt.Sprintf("agent %s %s", agentKey, role))
+	names.add(agent.ID, fmt.Sprintf("agent %s %s", strings.TrimSpace(agent.ID), role))
+	names.add(agent.Role, fmt.Sprintf("agent role %s %s", strings.TrimSpace(agent.Role), role))
+}
+
+func eventMetadataAddRequiredAgentRoles(source semanticview.Source, decl deadEventDeclaration, producers, consumers eventMetadataNameIndex, flowID string, required runtimecontracts.FlowRequiredAgent) {
+	for _, eventType := range required.Emits {
+		if deadEventRoleMatches(source, decl, flowID, eventType) {
+			producers.add(required.Role, fmt.Sprintf("required agent role %s emits", strings.TrimSpace(required.Role)))
+		}
+	}
+	for _, eventType := range required.SubscribesTo {
+		if deadEventRoleMatches(source, decl, flowID, eventType) {
+			consumers.add(required.Role, fmt.Sprintf("required agent role %s subscribes", strings.TrimSpace(required.Role)))
+		}
+	}
+}
+
+func eventMetadataAddFlowRoles(source semanticview.Source, decl deadEventDeclaration, producers, consumers eventMetadataNameIndex, flowID, autoEmitEvent string) {
+	flowID = strings.TrimSpace(flowID)
+	if deadEventSameScope(decl.FlowID, flowID) && deadEventRoleMatches(source, decl, flowID, autoEmitEvent) {
+		eventMetadataAddFlowRole(producers, flowID, "", "auto_emit_on_create producer")
+	}
+	for _, pin := range source.FlowOutputEventPins(flowID) {
+		if deadEventRoleMatches(source, decl, flowID, pin.EventType()) {
+			eventMetadataAddFlowRole(producers, flowID, pin.PinName(), "output pin producer")
+		}
+	}
+	for _, pin := range source.FlowInputEventPins(flowID) {
+		if deadEventRoleMatches(source, decl, flowID, pin.EventType()) {
+			eventMetadataAddFlowRole(consumers, flowID, pin.PinName(), "input pin consumer")
+		}
+	}
+}
+
+func eventMetadataAddCompositionConnectRoles(source semanticview.Source, decl deadEventDeclaration, producers, consumers eventMetadataNameIndex) {
+	for _, connect := range source.CompositionConnects() {
+		if from, err := connect.FromRef(); err == nil {
+			if outputPin, ok := source.FlowOutputEventPin(from.FlowID, from.Pin); ok && deadEventRoleMatches(source, decl, from.FlowID, outputPin.EventType()) {
+				eventMetadataAddFlowPinRefRole(producers, from, connect.From, "parent connect output producer")
+			}
+		}
+		if to, err := connect.ToRef(); err == nil {
+			if inputPin, ok := source.FlowInputEventPin(to.FlowID, to.Pin); ok && deadEventRoleMatches(source, decl, to.FlowID, inputPin.EventType()) {
+				eventMetadataAddFlowPinRefRole(consumers, to, connect.To, "parent connect input consumer")
+			}
+		}
+	}
+}
+
+func eventMetadataAddFlowRole(names eventMetadataNameIndex, flowID, pinName, role string) {
+	flowID = strings.TrimSpace(flowID)
+	pinName = strings.TrimSpace(pinName)
+	role = strings.TrimSpace(role)
+	label := eventMetadataFlowLabel(flowID)
+	if role != "" {
+		label += " " + role
+	}
+	names.add(flowID, label)
+	if pinName != "" {
+		names.add(pinName, label)
+	}
+}
+
+func eventMetadataAddFlowPinRefRole(names eventMetadataNameIndex, ref runtimecontracts.FlowPackagePinRef, rawRef, role string) {
+	flowID := strings.TrimSpace(ref.FlowID)
+	pinName := strings.TrimSpace(ref.Pin)
+	role = strings.TrimSpace(role)
+	label := eventMetadataFlowLabel(flowID)
+	if pinName != "" {
+		label += fmt.Sprintf(" pin %s", pinName)
+	}
+	if role != "" {
+		label += " " + role
+	}
+	names.add(rawRef, label)
+	names.add(flowID, label)
+	names.add(pinName, label)
+	if ref.Root && pinName != "" {
+		names.add("."+pinName, label)
+	}
+}
+
+func eventMetadataFlowLabel(flowID string) string {
+	flowID = strings.TrimSpace(flowID)
+	if flowID == "" {
+		return "root flow"
+	}
+	return fmt.Sprintf("flow %s", flowID)
+}
+
+func eventMetadataSourceAuthorityFindings(decl deadEventDeclaration, globalNames, producerNames eventMetadataNameIndex) []Finding {
+	source := strings.TrimSpace(decl.Entry.SwarmSource())
+	if source == "" {
+		return nil
+	}
+	if eventMetadataExternalOrPlatformSource(source) {
+		return nil
+	}
+	names := eventMetadataNameIndex{}
+	names.merge(producerNames)
+	names.merge(globalNames)
+	if label, ok := names.match(source); ok {
+		return []Finding{eventMetadataAuthorityFinding(decl, "swarm.source", source, fmt.Sprintf("matches derived internal producer %s", label))}
+	}
+	return []Finding{eventMetadataAuthorityFinding(decl, "swarm.source", source, "is not external/platform source proof")}
+}
+
+func eventMetadataListAuthorityFindings(decl deadEventDeclaration, field string, values []string, globalNames, roleNames eventMetadataNameIndex) []Finding {
+	names := eventMetadataNameIndex{}
+	names.merge(roleNames)
+	names.merge(globalNames)
+	out := make([]Finding, 0)
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		if label, ok := names.match(value); ok {
+			out = append(out, eventMetadataAuthorityFinding(decl, field, value, fmt.Sprintf("matches derived internal topology role %s", label)))
+		}
+	}
+	sort.SliceStable(out, func(i, j int) bool {
+		if out[i].Location != out[j].Location {
+			return out[i].Location < out[j].Location
+		}
+		return out[i].Message < out[j].Message
+	})
+	return out
+}
+
+func eventMetadataExternalOrPlatformSource(source string) bool {
+	source = strings.ToLower(strings.TrimSpace(source))
+	return strings.HasPrefix(source, "external") || strings.HasPrefix(source, "platform")
+}
+
+func eventMetadataAuthorityFinding(decl deadEventDeclaration, field, value, reason string) Finding {
+	location := strings.TrimSpace(decl.Canonical)
+	if location == "" {
+		location = deadEventSchemaFileLabel(strings.TrimSpace(decl.File), strings.TrimSpace(decl.FlowID))
+	}
+	return Finding{
+		CheckID:  "event_metadata_authority",
+		Severity: SeverityHardInvalidity,
+		Location: location,
+		Message: fmt.Sprintf(
+			"event %s authored %s=%q as event metadata, but %s. Internal event producer/consumer/source facts must be derived from topology; use %s only for external/platform/non-derivable proof.",
+			strings.TrimSpace(decl.Canonical),
+			strings.TrimSpace(field),
+			strings.TrimSpace(value),
+			strings.TrimSpace(reason),
+			strings.TrimSpace(field),
+		),
+	}
+}

--- a/internal/runtime/bootverify/workflow_event_metadata_authority_checks_test.go
+++ b/internal/runtime/bootverify/workflow_event_metadata_authority_checks_test.go
@@ -1,0 +1,394 @@
+package bootverify
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
+	"github.com/division-sh/swarm/internal/runtime/semanticview"
+)
+
+func TestEventMetadataAuthorityRejectsInternalSwarmRestatements(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		opts    eventMetadataAuthorityFixtureOptions
+		want    string
+		wantMsg string
+	}{
+		{
+			name:    "producer names emitting node",
+			opts:    eventMetadataAuthorityFixtureOptions{taskDoneSwarm: "producer: worker"},
+			want:    "swarm.producer",
+			wantMsg: "system node worker handler emits",
+		},
+		{
+			name:    "consumer names subscribing node",
+			opts:    eventMetadataAuthorityFixtureOptions{taskDoneSwarm: "consumer: observer"},
+			want:    "swarm.consumer",
+			wantMsg: "system node observer handler subscribes",
+		},
+		{
+			name:    "source names internal producer",
+			opts:    eventMetadataAuthorityFixtureOptions{taskDoneSwarm: "source: worker"},
+			want:    "swarm.source",
+			wantMsg: "derived internal producer system node worker handler emits",
+		},
+		{
+			name: "producer names agent emit_events role",
+			opts: eventMetadataAuthorityFixtureOptions{
+				taskDoneSwarm: "producer: reviewer",
+				agents: `
+reviewer-agent:
+  id: reviewer-agent
+  role: reviewer
+  mode: task
+  emit_events: [task.done]
+`,
+			},
+			want:    "swarm.producer",
+			wantMsg: "agent role reviewer emit_events",
+		},
+		{
+			name: "consumer names agent subscription role",
+			opts: eventMetadataAuthorityFixtureOptions{
+				taskDoneSwarm: "consumer: reviewer",
+				agents: `
+reviewer-agent:
+  id: reviewer-agent
+  role: reviewer
+  mode: task
+  subscriptions: [task.done]
+`,
+			},
+			want:    "swarm.consumer",
+			wantMsg: "agent role reviewer subscriptions",
+		},
+		{
+			name: "producer names timer",
+			opts: eventMetadataAuthorityFixtureOptions{
+				taskDoneSwarm: "producer: reminder",
+				timerBlock: `
+  timers:
+    - id: reminder
+      owner: worker
+      event: task.done
+      delay: 1m
+      start_on: event:task.start
+`,
+			},
+			want:    "swarm.producer",
+			wantMsg: "timer reminder fires event",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			source := loadEventMetadataAuthorityFixture(t, tc.opts)
+
+			report := Run(context.Background(), source, Options{})
+
+			if !reportContains(report.HardInvalidities(), "event_metadata_authority", tc.want) ||
+				!reportContains(report.HardInvalidities(), "event_metadata_authority", tc.wantMsg) {
+				t.Fatalf("expected event_metadata_authority hard invalidity containing %q and %q, got %#v", tc.want, tc.wantMsg, report.HardInvalidities())
+			}
+		})
+	}
+}
+
+func TestEventMetadataAuthorityRejectsFlowSurfaceRestatements(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		opts    eventMetadataFlowAuthorityFixtureOptions
+		want    string
+		wantMsg string
+	}{
+		{
+			name:    "producer names flow auto emit",
+			opts:    eventMetadataFlowAuthorityFixtureOptions{flowStartedSwarm: "producer: producer"},
+			want:    "swarm.producer",
+			wantMsg: "flow producer auto_emit_on_create producer",
+		},
+		{
+			name:    "producer names flow output pin",
+			opts:    eventMetadataFlowAuthorityFixtureOptions{deployDoneSwarm: "producer: deploy_done"},
+			want:    "swarm.producer",
+			wantMsg: "flow producer output pin producer",
+		},
+		{
+			name:    "consumer names flow input pin",
+			opts:    eventMetadataFlowAuthorityFixtureOptions{deployCompletedSwarm: "consumer: consumer"},
+			want:    "swarm.consumer",
+			wantMsg: "flow consumer input pin consumer",
+		},
+		{
+			name:    "producer names parent connect output",
+			opts:    eventMetadataFlowAuthorityFixtureOptions{deployDoneSwarm: "producer: producer.deploy_done"},
+			want:    "swarm.producer",
+			wantMsg: "parent connect output producer",
+		},
+		{
+			name:    "consumer names parent connect input",
+			opts:    eventMetadataFlowAuthorityFixtureOptions{deployCompletedSwarm: "consumer: consumer.deploy_completed"},
+			want:    "swarm.consumer",
+			wantMsg: "parent connect input consumer",
+		},
+		{
+			name:    "producer rejects wrong-event flow output pin",
+			opts:    eventMetadataFlowAuthorityFixtureOptions{flowStartedSwarm: "producer: deploy_done"},
+			want:    "swarm.producer",
+			wantMsg: "flow producer output pin producer",
+		},
+		{
+			name:    "consumer rejects wrong-event flow input pin",
+			opts:    eventMetadataFlowAuthorityFixtureOptions{deployDoneSwarm: "consumer: deploy_completed"},
+			want:    "swarm.consumer",
+			wantMsg: "flow consumer input pin consumer",
+		},
+		{
+			name:    "producer rejects wrong-event parent connect output",
+			opts:    eventMetadataFlowAuthorityFixtureOptions{flowStartedSwarm: "producer: producer.deploy_done"},
+			want:    "swarm.producer",
+			wantMsg: "parent connect output producer",
+		},
+		{
+			name:    "consumer rejects wrong-event parent connect input",
+			opts:    eventMetadataFlowAuthorityFixtureOptions{deployDoneSwarm: "consumer: consumer.deploy_completed"},
+			want:    "swarm.consumer",
+			wantMsg: "parent connect input consumer",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			source := loadEventMetadataFlowAuthorityFixture(t, tc.opts)
+
+			report := Run(context.Background(), source, Options{})
+
+			if !reportContains(report.HardInvalidities(), "event_metadata_authority", tc.want) ||
+				!reportContains(report.HardInvalidities(), "event_metadata_authority", tc.wantMsg) {
+				t.Fatalf("expected event_metadata_authority hard invalidity containing %q and %q, got %#v", tc.want, tc.wantMsg, report.HardInvalidities())
+			}
+		})
+	}
+}
+
+func TestEventMetadataAuthorityAcceptsExternalProof(t *testing.T) {
+	source := loadEventMetadataAuthorityFixture(t, eventMetadataAuthorityFixtureOptions{
+		externalRequestedSwarm: `
+    source: external webhook
+    producer: mailbox_human
+    consumer: external_ui
+`,
+		taskDoneSwarm: `
+    source: platform timer
+    producer: mailbox_human
+    consumer: external_ui
+`,
+	})
+
+	report := Run(context.Background(), source, Options{})
+
+	if reportContains(report.HardInvalidities(), "event_metadata_authority", "") {
+		t.Fatalf("external/platform metadata proof should be accepted, got %#v", report.HardInvalidities())
+	}
+}
+
+func TestEventMetadataAuthorityNarrowReadbackExplainsDerivedAndExternalProof(t *testing.T) {
+	source := loadEventMetadataAuthorityFixture(t, eventMetadataAuthorityFixtureOptions{})
+	report := Run(context.Background(), source, Options{})
+
+	if reportContains(report.Warnings(), "event_producer_exists", "task.done") ||
+		reportContains(report.Warnings(), "event_consumer_exists", "task.done") {
+		t.Fatalf("derived handler roles should satisfy producer/consumer checks, got warnings %#v", report.Warnings())
+	}
+	if reportContains(report.Warnings(), "semantic_drift_dead_event_schema", "task.done") {
+		t.Fatalf("derived handler roles should keep event schema alive, got warnings %#v", report.Warnings())
+	}
+
+	entry, _, ok := source.ResolveFlowEventCatalogEntry("", "task.done")
+	if !ok {
+		t.Fatalf("task.done event entry missing")
+	}
+	producers, consumers := eventMetadataRoleNames(source, deadEventDeclaration{
+		Canonical: "task.done",
+		Entry:     entry,
+	})
+	if label, ok := producers.match("worker"); !ok || !strings.Contains(label, "handler emits") {
+		t.Fatalf("producer role readback = %q/%v, want worker handler emit proof", label, ok)
+	}
+	if label, ok := consumers.match("observer"); !ok || !strings.Contains(label, "handler subscribes") {
+		t.Fatalf("consumer role readback = %q/%v, want observer handler subscription proof", label, ok)
+	}
+}
+
+type eventMetadataAuthorityFixtureOptions struct {
+	externalRequestedSwarm string
+	taskDoneSwarm          string
+	agents                 string
+	timerBlock             string
+}
+
+func loadEventMetadataAuthorityFixture(t *testing.T, opts eventMetadataAuthorityFixtureOptions) semanticview.Source {
+	t.Helper()
+	root := writeEventMetadataAuthorityFixture(t, opts)
+	repoRoot := repoRootForBootverifyTest(t)
+	platformSpec := runtimecontracts.DefaultPlatformSpecFile(repoRoot)
+	return semanticview.Wrap(loadFixtureBundleAt(t, repoRoot, root, platformSpec))
+}
+
+func writeEventMetadataAuthorityFixture(t *testing.T, opts eventMetadataAuthorityFixtureOptions) string {
+	t.Helper()
+	root := t.TempDir()
+	writeBootverifyFixtureFile(t, filepath.Join(root, "package.yaml"), `
+name: event-metadata-authority
+version: "1.0.0"
+platform_version: ">=1.6.0"
+`)
+	writeBootverifyFixtureFile(t, filepath.Join(root, "schema.yaml"), "name: event-metadata-authority\n")
+	writeBootverifyFixtureFile(t, filepath.Join(root, "policy.yaml"), "{}\n")
+	writeBootverifyFixtureFile(t, filepath.Join(root, "tools.yaml"), "{}\n")
+	if strings.TrimSpace(opts.agents) == "" {
+		opts.agents = "{}\n"
+	}
+	writeBootverifyFixtureFile(t, filepath.Join(root, "agents.yaml"), opts.agents)
+	writeBootverifyFixtureFile(t, filepath.Join(root, "events.yaml"), eventMetadataAuthorityEventsYAML(opts))
+	writeBootverifyFixtureFile(t, filepath.Join(root, "nodes.yaml"), `
+worker:
+  id: worker
+  execution_type: system_node
+`+opts.timerBlock+`  event_handlers:
+    task.start:
+      emit:
+        event: task.done
+observer:
+  id: observer
+  execution_type: system_node
+  event_handlers:
+    task.done: {}
+`)
+	return root
+}
+
+type eventMetadataFlowAuthorityFixtureOptions struct {
+	flowStartedSwarm     string
+	deployDoneSwarm      string
+	deployCompletedSwarm string
+}
+
+func loadEventMetadataFlowAuthorityFixture(t *testing.T, opts eventMetadataFlowAuthorityFixtureOptions) semanticview.Source {
+	t.Helper()
+	root := writeEventMetadataFlowAuthorityFixture(t, opts)
+	repoRoot := repoRootForBootverifyTest(t)
+	platformSpec := runtimecontracts.DefaultPlatformSpecFile(repoRoot)
+	return semanticview.Wrap(loadFixtureBundleAt(t, repoRoot, root, platformSpec))
+}
+
+func writeEventMetadataFlowAuthorityFixture(t *testing.T, opts eventMetadataFlowAuthorityFixtureOptions) string {
+	t.Helper()
+	root := t.TempDir()
+	writeBootverifyFixtureFile(t, filepath.Join(root, "package.yaml"), `
+name: event-metadata-flow-authority
+version: "1.0.0"
+platform_version: ">=1.6.0"
+flows:
+  - id: producer
+    flow: producer
+    mode: template
+  - id: consumer
+    flow: consumer
+    mode: template
+connect:
+  - from: producer.deploy_done
+    to: consumer.deploy_completed
+    delivery: one
+`)
+	writeBootverifyFixtureFile(t, filepath.Join(root, "schema.yaml"), "name: event-metadata-flow-authority\n")
+	writeBootverifyFixtureFile(t, filepath.Join(root, "policy.yaml"), "{}\n")
+	writeBootverifyFixtureFile(t, filepath.Join(root, "tools.yaml"), "{}\n")
+	writeBootverifyFixtureFile(t, filepath.Join(root, "agents.yaml"), "{}\n")
+	writeBootverifyFixtureFile(t, filepath.Join(root, "events.yaml"), "{}\n")
+	writeBootverifyFixtureFile(t, filepath.Join(root, "nodes.yaml"), "{}\n")
+	writeEventMetadataFlowAuthorityFlow(t, root, "producer", `
+name: producer
+mode: template
+initial_state: idle
+terminal_states: [done]
+states: [idle, done]
+auto_emit_on_create:
+  event: flow.started
+pins:
+  inputs:
+    events: []
+  outputs:
+    events:
+      - name: deploy_done
+        event: deploy.done
+`, eventMetadataAuthorityEventEntry("flow.started", opts.flowStartedSwarm)+eventMetadataAuthorityEventEntry("deploy.done", opts.deployDoneSwarm))
+	writeEventMetadataFlowAuthorityFlow(t, root, "consumer", `
+name: consumer
+mode: template
+initial_state: idle
+terminal_states: [done]
+states: [idle, done]
+pins:
+  inputs:
+    events:
+      - name: deploy_completed
+        event: deploy.completed
+  outputs:
+    events: []
+`, eventMetadataAuthorityEventEntry("deploy.completed", opts.deployCompletedSwarm))
+	return root
+}
+
+func writeEventMetadataFlowAuthorityFlow(t *testing.T, root, flowID, schema, events string) {
+	t.Helper()
+	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", flowID, "schema.yaml"), schema)
+	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", flowID, "policy.yaml"), "{}\n")
+	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", flowID, "agents.yaml"), "{}\n")
+	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", flowID, "events.yaml"), events)
+	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", flowID, "nodes.yaml"), "{}\n")
+	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", flowID, "entities.yaml"), "{}\n")
+}
+
+func eventMetadataAuthorityEventEntry(eventName, swarm string) string {
+	eventName = strings.TrimSpace(eventName)
+	swarm = indentEventMetadataAuthoritySwarm(swarm)
+	if swarm == "" {
+		return eventName + ": {}\n"
+	}
+	return eventName + ":\n  swarm:\n" + swarm + "\n"
+}
+
+func eventMetadataAuthorityEventsYAML(opts eventMetadataAuthorityFixtureOptions) string {
+	externalSwarm := indentEventMetadataAuthoritySwarm(opts.externalRequestedSwarm)
+	if strings.TrimSpace(externalSwarm) == "" {
+		externalSwarm = "    source: external"
+	}
+	taskDoneSwarm := indentEventMetadataAuthoritySwarm(opts.taskDoneSwarm)
+	events := `external.requested:
+  swarm:
+` + externalSwarm + `
+task.start:
+  swarm:
+    source: external
+task.done:
+`
+	if strings.TrimSpace(taskDoneSwarm) != "" {
+		events += "  swarm:\n" + taskDoneSwarm + "\n"
+	}
+	return events
+}
+
+func indentEventMetadataAuthoritySwarm(raw string) string {
+	raw = strings.Trim(raw, "\n")
+	if strings.TrimSpace(raw) == "" {
+		return ""
+	}
+	lines := strings.Split(raw, "\n")
+	for idx, line := range lines {
+		if strings.TrimSpace(line) == "" || strings.HasPrefix(line, "    ") {
+			continue
+		}
+		lines[idx] = "    " + strings.TrimLeft(line, " ")
+	}
+	return strings.Join(lines, "\n")
+}

--- a/internal/runtime/contracts/workflow_contract_yaml_handlers.go
+++ b/internal/runtime/contracts/workflow_contract_yaml_handlers.go
@@ -787,6 +787,9 @@ func (e *EventCatalogEntry) UnmarshalYAML(node *yaml.Node) error {
 	if hasYAMLMappingKey(node, "payload") {
 		return fmt.Errorf("RETIRED: nested events.yaml payload blocks are no longer supported; move payload fields to the event top level")
 	}
+	if err := rejectRetiredEventMetadataFields(node); err != nil {
+		return err
+	}
 	flatPayload, err := buildFlatEventPayloadSpec(node)
 	if err != nil {
 		return err
@@ -921,6 +924,26 @@ type eventSwarmMetadataYAML struct {
 	Producer yaml.Node `yaml:"producer"`
 	Consumer yaml.Node `yaml:"consumer"`
 	Status   string    `yaml:"status"`
+}
+
+func rejectRetiredEventMetadataFields(node *yaml.Node) error {
+	retired := map[string]string{
+		"producer":  "swarm.producer",
+		"_producer": "swarm.producer",
+		"consumer":  "swarm.consumer",
+		"_consumer": "swarm.consumer",
+		"_source":   "swarm.source",
+		"_status":   "swarm.status",
+	}
+	for i := 0; node != nil && i+1 < len(node.Content); i += 2 {
+		key := strings.TrimSpace(node.Content[i].Value)
+		canonical, ok := retired[key]
+		if !ok {
+			continue
+		}
+		return fmt.Errorf("RETIRED: events.yaml metadata field %s is no longer supported; use %s for external/non-derivable proof and derive internal roles from topology", key, canonical)
+	}
+	return nil
 }
 
 func mergeCanonicalLegacyString(canonical, legacy, canonicalKey, legacyKey string) (string, error) {

--- a/internal/runtime/contracts/workflow_contracts_tree_test.go
+++ b/internal/runtime/contracts/workflow_contracts_tree_test.go
@@ -783,7 +783,7 @@ entity_id: string
 	}
 }
 
-func TestEventCatalogEntry_LegacyMetadataNormalizesIntoSwarmOwner(t *testing.T) {
+func TestEventCatalogEntry_LegacyMetadataFieldsFailClosed(t *testing.T) {
 	var entry EventCatalogEntry
 	if err := loadYAMLBytes([]byte(`
 _source: external (human board interface)
@@ -793,29 +793,41 @@ _consumer_type: external_ui
 _status: planned
 _note: Human board handoff
 source: text
-`), &entry); err != nil {
-		t.Fatalf("load event catalog entry: %v", err)
+`), &entry); err == nil || !strings.Contains(err.Error(), "RETIRED") || !strings.Contains(err.Error(), "_source") || !strings.Contains(err.Error(), "swarm.source") {
+		t.Fatalf("load event catalog entry error = %v, want retired _source failure", err)
 	}
-	if got := entry.SwarmSource(); got != "external (human board interface)" {
-		t.Fatalf("expected legacy _source to normalize into swarm.source, got %q", got)
-	}
-	if got := entry.SwarmProducer(); len(got) != 1 || got[0] != "mailbox_human" {
-		t.Fatalf("expected legacy _producer to normalize into swarm.producer, got %#v", got)
-	}
-	if got := entry.SwarmConsumer(); len(got) != 1 || got[0] == "" {
-		t.Fatalf("expected legacy _consumer to normalize into swarm.consumer, got %#v", got)
-	}
-	if got := entry.ConsumerType; len(got) != 1 || got[0] != "external_ui" {
-		t.Fatalf("expected legacy _consumer_type to normalize into sibling consumer_type, got %#v", got)
-	}
-	if got := entry.SwarmStatus(); got != "planned" {
-		t.Fatalf("expected legacy _status to normalize into swarm.status, got %q", got)
-	}
-	if got := entry.SwarmNote(); got != "Human board handoff" {
-		t.Fatalf("expected legacy _note to normalize into swarm.note, got %q", got)
-	}
-	if _, ok := entry.Payload.Properties["source"]; !ok {
-		t.Fatalf("expected bare source to remain payload field, not metadata")
+}
+
+func TestEventCatalogEntry_TopLevelProducerConsumerMetadataFailsClosed(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		yaml      string
+		wantField string
+	}{
+		{
+			name: "producer",
+			yaml: `
+producer: mailbox_human
+entity_id: string
+`,
+			wantField: "producer",
+		},
+		{
+			name: "consumer",
+			yaml: `
+consumer: dashboard
+entity_id: string
+`,
+			wantField: "consumer",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var entry EventCatalogEntry
+			err := loadYAMLBytes([]byte(tc.yaml), &entry)
+			if err == nil || !strings.Contains(err.Error(), "RETIRED") || !strings.Contains(err.Error(), tc.wantField) || !strings.Contains(err.Error(), "swarm.") {
+				t.Fatalf("load event catalog entry error = %v, want retired %s failure", err, tc.wantField)
+			}
+		})
 	}
 }
 

--- a/internal/runtime/swarmflowtest/catalog_runner_test.go
+++ b/internal/runtime/swarmflowtest/catalog_runner_test.go
@@ -1956,16 +1956,7 @@ func catalogIsSuppressedEvent(events map[string]any, ev string) bool {
 	if strings.EqualFold(strings.TrimSpace(asStringForCatalog(swarm["status"])), "planned") {
 		return true
 	}
-	if source := strings.TrimSpace(asStringForCatalog(eventDef["_source"])); strings.HasPrefix(source, "external") || strings.HasPrefix(source, "platform") {
-		return true
-	}
-	if catalogMetadataPresent(eventDef["consumer"]) || catalogMetadataPresent(eventDef["_consumer"]) {
-		return true
-	}
-	if catalogMetadataPresent(eventDef["producer"]) || catalogMetadataPresent(eventDef["_producer"]) {
-		return true
-	}
-	return strings.EqualFold(strings.TrimSpace(asStringForCatalog(eventDef["_status"])), "planned")
+	return false
 }
 
 func catalogMetadataPresent(value any) bool {

--- a/internal/runtime/testdata/generic-swarm-bundle/flows/delivery/events.yaml
+++ b/internal/runtime/testdata/generic-swarm-bundle/flows/delivery/events.yaml
@@ -1,10 +1,6 @@
 item.completed:
   emitter:
     - processing-node
-  consumer:
-    - delivery-node
 timer.item.timeout:
   emitter:
     - sys:runtime
-  consumer:
-    - delivery-node

--- a/internal/runtime/testdata/generic-swarm-bundle/flows/intake/events.yaml
+++ b/internal/runtime/testdata/generic-swarm-bundle/flows/intake/events.yaml
@@ -1,21 +1,13 @@
 item.created:
   emitter:
     - control-plane
-  consumer:
-    - intake-router
 item.processed:
   emitter:
     - worker-a
     - worker-b
-  consumer:
-    - intake-router
 item.review_requested:
   emitter:
     - intake-router
-  consumer:
-    - processing-node
 item.rejected:
   emitter:
     - processing-node
-  consumer:
-    - control-plane

--- a/internal/runtime/testdata/generic-swarm-bundle/flows/processing/events.yaml
+++ b/internal/runtime/testdata/generic-swarm-bundle/flows/processing/events.yaml
@@ -1,15 +1,9 @@
 item.review_requested:
   emitter:
     - intake-router
-  consumer:
-    - processing-node
 item.completed:
   emitter:
     - processing-node
-  consumer:
-    - delivery-node
 item.rejected:
   emitter:
     - processing-node
-  consumer:
-    - control-plane

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -257,6 +257,13 @@ contract_formats:
       Wave 1 type catalog. Runtime validators MUST NOT pass unresolved
       contract type names such as named types, scalar aliases, or enums
       to the primitive JSON schema validator as literal schema types.
+      Authored `swarm.source`, `swarm.producer`, and `swarm.consumer`
+      are external/platform/non-derivable proof only. Internal producer,
+      consumer, and source facts MUST be derived from topology owners such
+      as handlers, agents, timers, fan_out, auto_emit_on_create, pins,
+      connect routes, runtime owners, and effective system-node helpers.
+      Authored metadata that deterministically restates those internal
+      roles is a hard invalidity, not an alternate semantic owner.
       Validation ownership is layered, not competing: supported emit
       surfaces validate producer-authored payloads before publish, while
       canonical event-store admission validates every event payload that
@@ -971,10 +978,10 @@ contract_formats:
   underscore_prefix_convention:
     description: Fields starting with _ in contract YAML files.
     semantic_fields:
-      _source: 'Legacy migration input for event swarm.source. Do not author in new contracts.'
-      _consumer: 'Legacy migration input for event swarm.consumer. Do not author in new contracts.'
-      _status: 'Legacy migration input for event swarm.status. Do not author in new contracts.'
-      _producer: 'Legacy migration input for event swarm.producer for non-derivable producer proof only. Do not author for ordinary internal topology.'
+      _source: 'Retired legacy migration input for event swarm.source. Contracts MUST fail closed instead of accepting this as event metadata.'
+      _consumer: 'Retired legacy migration input for event swarm.consumer. Contracts MUST fail closed instead of accepting this as event metadata.'
+      _status: 'Retired legacy migration input for event swarm.status. Contracts MUST fail closed instead of accepting this as event metadata.'
+      _producer: 'Retired legacy migration input for event swarm.producer. Contracts MUST fail closed instead of accepting this as event metadata.'
     documentation_fields: Any other _-prefixed field (_note, _routing_note, _internal_events_note, etc.) is a human comment.
       The platform ignores them. The verifier ignores them. They are not part of the contract.
 rule:
@@ -4306,13 +4313,27 @@ engine:
       severity: warning
       scope: per-flow
       trigger: An event is emitted (by a node handler or agent emit_events) but no node or agent subscribes to it. Suppressed
-        if the event has swarm.consumer or swarm.status metadata.
+        only by accepted external/non-derivable swarm.consumer proof or swarm.status metadata. Internal consumers are derived
+        from topology owners; authored swarm.consumer values that restate internal handlers, agents, timers, pins, connect
+        routes, runtime owners, or effective system-node helpers fail closed under event_metadata_authority.
       when: boot-only
     - id: event_producer_exists
       severity: warning
       scope: per-flow
       trigger: An agent subscribes to an event that no node handler emits and no agent lists in emit_events. Suppressed if the
-        event has swarm.source, swarm.producer, swarm.status metadata, or an exact authoritative platform_events.catalog match.
+        event has accepted external/platform swarm.source proof, accepted external/non-derivable swarm.producer proof,
+        swarm.status metadata, or an exact authoritative platform_events.catalog match. Internal producers are derived from
+        topology owners; authored swarm.source or swarm.producer values that restate internal handlers, agents, timers, pins,
+        connect routes, runtime owners, or effective system-node helpers fail closed under event_metadata_authority.
+      when: boot-only
+    - id: event_metadata_authority
+      severity: hard_invalidity
+      scope: per-event
+      trigger: An events.yaml entry authors legacy event metadata fields (`producer`, `consumer`, `_source`, `_producer`,
+        `_consumer`, `_status`) or authors `swarm.source`, `swarm.producer`, or `swarm.consumer` values that deterministically
+        restate internal topology roles. `swarm.*` event metadata is external/platform/non-derivable proof only; internal roles
+        are derived from handlers, agents, timers, fan_out, auto_emit_on_create, pins, connect routes, runtime owners, and
+        effective system-node helpers.
       when: boot-only
     - id: payload_field_coverage
       severity: error
@@ -4516,7 +4537,9 @@ engine:
       severity: error
       scope: per-node
       trigger: A timer declaration is missing its owner (owner_node or owner_agent). Or the timer's owner is not a registered
-        participant in the flow. Or the timer's fire_event is not in events.yaml.
+        participant in the flow. Or the timer's fire_event is not in events.yaml. Timer fire/start/cancel references are
+        derived internal event producer/consumer roles; authors MUST NOT restate them through swarm.source, swarm.producer,
+        or swarm.consumer. External/non-derivable metadata remains only explicit proof for external producers or consumers.
       when: boot-only
     - id: write_pin_ownership_validation
       severity: error
@@ -4596,8 +4619,8 @@ engine:
       scope: per-event
       trigger: A product-declared event schema entry in `events.yaml` has no active authored role on the static verify surface.
         Active roles are limited to intra-flow local usage, explicit cross-flow qualified usage, root-local usage for root-declared
-        events only, external `swarm.source` / `swarm.consumer` metadata, same-flow timer fire/start/cancel references, same-flow
-        `fan_out.emit`, and same-flow `auto_emit_on_create`. It does not treat platform catalog membership, root-local
+        events only, accepted external/platform `swarm.source` proof, accepted external `swarm.consumer` proof, same-flow timer
+        fire/start/cancel references, same-flow `fan_out.emit`, and same-flow `auto_emit_on_create`. It does not treat platform catalog membership, root-local
         references into child-flow declarations, or coincidental same local names in other flows as proof.
       when: boot-only
     severity_behavior:
@@ -10423,7 +10446,7 @@ static_analyzer:
         rule: Another flow or root participant references the declaration via an explicitly qualified event name that resolves
           to the declaring flow.
       external_annotations:
-        rule: "`swarm.source` beginning with external or `swarm.consumer` metadata on the declared event entry counts as an active external role."
+        rule: "Accepted `swarm.source` beginning with external or platform, or accepted external `swarm.consumer` metadata on the declared event entry, counts as an active external role. Internal topology roles must be derived from topology owners and fail closed if restated through `swarm.*`."
       same_flow_timer_references:
         rule: "Timers in the same scope keep the declaration alive through `event`, `start_on: event:...`, or `cancel_on: event:...`."
       same_flow_fan_out_emit:


### PR DESCRIPTION
## Summary

Closes #1597.

This PR enforces the approved #1597 first slice for event metadata authority:

- adds `event_metadata_authority` boot verification to fail closed when authored `swarm.source`, `swarm.producer`, or `swarm.consumer` deterministically restate internal topology roles;
- rejects retired event metadata fields (`producer`, `consumer`, `_source`, `_producer`, `_consumer`, `_status`) at events.yaml decode time;
- keeps accepted external/platform/non-derivable proof through canonical `swarm.*` metadata;
- updates `platform-spec.yaml` so event topology, timer, dead-event, flow-boundary, and pin-routing wording matches external-proof-only `swarm.*` semantics;
- derives handler, agent, required-agent, timer, auto-emit, flow pin, parent connect, and runtime-owner topology roles before allowing authored proof;
- rejects stale/wrong-event deterministic topology names so metadata on one event cannot claim an internal role from another event;
- migrates checked-in fixtures/tests away from internal metadata restatements.

## Governing Context

Exact spec references updated/consumed:

- `platform-spec.yaml#contract_formats.event_schema`
- `platform-spec.yaml#contract_formats.underscore_prefix_convention`
- `platform-spec.yaml#engine.boot_validation.event_consumer_exists`
- `platform-spec.yaml#engine.boot_validation.event_producer_exists`
- `platform-spec.yaml#engine.boot_validation.timer_validation`
- `platform-spec.yaml#engine.boot_validation.semantic_drift_dead_event_schema`
- `platform-spec.yaml#static_analyzer.slice_5_dead_declared_event_schema_surface`

Binding issue/gate context:

- #1597 pre-audit: https://github.com/division-sh/swarm/issues/1597#issuecomment-4870769201
- #1597 lead gate: https://github.com/division-sh/swarm/issues/1597#issuecomment-4870843648

`docs/IMPLEMENTER_GUIDELINES.md` and `docs/SEMANTIC_DRIFT.md` are not present on this branch/master; I followed the issue thread, gate, platform spec, and surrounding contract/bootverify code as binding local context.

## Semantic Migration

New canonical owner: `EventCatalogEntry.Swarm` only for external/platform/non-derivable proof, plus `semanticview.Source` topology for internal producer/consumer/source facts.

Old paths now invalid: top-level `producer`, `consumer`, `_source`, `_producer`, `_consumer`, and `_status` in `events.yaml` now fail closed before they can become independent semantic owners.

Production paths checked for surviving old behavior: contract decode/merge, bootverify topology/dead-event/timer/flow-pin/connect consumers, verify fixtures, catalog test expectation helper, and checked-in `events.yaml` fixtures.

Migration status: complete for the #1597 child class. Runtime event envelope, store admission, delivery routing, and broad `swarm describe`/expanded tooling remain out of scope per gate (#1551 still owns general expanded tooling).

## Validation

- `go test ./internal/runtime/bootverify -run 'TestEventMetadataAuthority|TestRun_DoesNotWarnForDeadEventSchemaAcceptedActiveRoles|TestRun_DoesNotWarnForExternalInputPinWithoutEmitter|TestVerifyBundle_InputPinProducerPathReturnsWarningSurface' -count=1 -v`
- `go test ./internal/runtime/contracts -run 'TestFlowSchemaDocumentDecode_PreservesAddressedInputPins|TestResolveFlowInputAutoWire|TestEventCatalogEntry_.*Metadata|TestEventCatalogEntry_TopLevelProducerConsumerMetadataFailsClosed|TestEventCatalogEntry_ConflictingSwarmAndLegacyMetadataFailsClosed' -count=1 -v`
- `go test ./internal/runtime/bootverify -run TestEventMetadataAuthorityRejectsFlowSurfaceRestatements -count=1 -v`
- `HOME="$(mktemp -d)" go test ./cmd/swarm -run TestDoctorTargetJSONPreservesScriptableOutput -count=1 -v`
- `HOME="$(mktemp -d)" DOCKER_HOST="unix:///Users/youmew/.colima/default/docker.sock" GOCACHE="$(go env GOCACHE)" GOMODCACHE="$(go env GOMODCACHE)" go test ./...`

Plain `go test ./...` in this shared agent environment first hit stale `~/.swarm/contexts` state from another worktree. The clean full-suite proof above isolates `HOME` and uses the active Colima Docker socket for Postgres-backed packages.