### PR TITLE
[agent-a][issue #1551] Add expanded authoring describe view

### DIFF
--- a/cmd/swarm/cli.go
+++ b/cmd/swarm/cli.go
@@ -79,6 +79,7 @@ func newRootCommandWithOptions(ctx context.Context, repo string, out, errOut io.
 		newRunCommand(repo, opts),
 		newDoctorCommand(ctx, repo),
 		newVerifyCommand(ctx, repo),
+		newDescribeCommand(ctx, repo),
 		newSecretsCommand(ctx, repo),
 		newContextCommand(ctx, opts),
 		newWorkspaceCommand(ctx),

--- a/cmd/swarm/describe.go
+++ b/cmd/swarm/describe.go
@@ -123,6 +123,9 @@ func writeDescribeText(out io.Writer, view authoringview.View) {
 	}
 	fmt.Fprintf(out, "describe: contracts=%s\n", view.ContractsRoot)
 	fmt.Fprintf(out, "source authority: %s\n", view.SourceAuthority)
+	if view.Root.PrimaryEntity != nil {
+		fmt.Fprintf(out, "root primary entity: %s\n", view.Root.PrimaryEntity.Type)
+	}
 	if len(view.Flows) > 0 {
 		fmt.Fprintln(out, "flows:")
 		for _, flow := range view.Flows {

--- a/cmd/swarm/describe.go
+++ b/cmd/swarm/describe.go
@@ -1,0 +1,173 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/division-sh/swarm/internal/runtime/authoringview"
+	runtimebootverify "github.com/division-sh/swarm/internal/runtime/bootverify"
+	"github.com/division-sh/swarm/internal/runtime/semanticview"
+	"github.com/spf13/cobra"
+)
+
+type describeCommandOptions struct {
+	contractsPath    string
+	platformSpecPath string
+	output           cliOutputOptions
+	logging          cliLoggingOptions
+}
+
+func defaultDescribeCommandOptions() describeCommandOptions {
+	return describeCommandOptions{
+		logging: defaultCLILoggingOptions(),
+	}
+}
+
+func newDescribeCommand(ctx context.Context, repo string) *cobra.Command {
+	opts := defaultDescribeCommandOptions()
+	cmd := &cobra.Command{
+		Use:   "describe",
+		Short: "Render the expanded authoring view for local Swarm contracts.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := opts.logging.validate(); err != nil {
+				return returnCLIValidationError(cmd.ErrOrStderr(), err)
+			}
+			if err := opts.output.validate(); err != nil {
+				return returnCLIValidationError(cmd.ErrOrStderr(), err)
+			}
+			if len(args) > 0 {
+				return returnCLIValidationError(cmd.ErrOrStderr(), fmt.Errorf("unexpected argument %q", args[0]))
+			}
+			code := runDescribeCommandWithOutput(ctx, assetCommandRepoRoot(repo), opts, cmd.OutOrStdout(), cmd.ErrOrStderr())
+			if code != 0 {
+				return commandExitError{code: code}
+			}
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&opts.contractsPath, "contracts", opts.contractsPath, "Path to Swarm contract bundle root")
+	cmd.Flags().StringVar(&opts.platformSpecPath, "platform-spec", opts.platformSpecPath, "Path to platform spec yaml")
+	bindCLIOutputFlags(cmd, &opts.output)
+	bindCLILoggingFlags(cmd, &opts.logging)
+	return cmd
+}
+
+func runDescribeCommandWithOutput(ctx context.Context, repo string, opts describeCommandOptions, out, errOut io.Writer) int {
+	if err := opts.logging.validate(); err != nil {
+		if errOut != nil {
+			fmt.Fprintf(errOut, "describe failed: %v\n", err)
+		}
+		return 2
+	}
+	if err := opts.output.validate(); err != nil {
+		if errOut != nil {
+			fmt.Fprintf(errOut, "describe failed: %v\n", err)
+		}
+		return 2
+	}
+	if err := loadRepoDotEnv(repo); err != nil {
+		if errOut != nil {
+			fmt.Fprintf(errOut, "describe failed: load .env: %v\n", err)
+		}
+		return 1
+	}
+	resolvedPaths, err := resolveCLIContractPlatformSpecPaths(repo, cliContractPlatformSpecPathOptions{
+		ContractsPath:    opts.contractsPath,
+		PlatformSpecPath: opts.platformSpecPath,
+	})
+	if err != nil {
+		if errOut != nil {
+			fmt.Fprintf(errOut, "describe failed: resolve path config: %v\n", err)
+		}
+		return cliAPIErrorExitCode(err, cliAPIErrorClassifier{})
+	}
+	contractsRoot, err := normalizeContractsRoot(resolvedPaths.ContractsPath)
+	if err != nil {
+		if errOut != nil {
+			fmt.Fprintf(errOut, "describe failed: resolve contracts: %v\n", err)
+		}
+		return 1
+	}
+	_, bundle, err := newSwarmWorkflowModule(repo, contractsRoot, resolvedPaths.PlatformSpecPath)
+	if err != nil {
+		if errOut != nil {
+			fmt.Fprintf(errOut, "describe failed: load Swarm contracts: %v\n", err)
+		}
+		return 1
+	}
+	source := semanticview.Wrap(bundle)
+	report := runtimebootverify.Run(ctx, source, runtimebootverify.Options{})
+	view, err := authoringview.Build(ctx, source, authoringview.BuildOptions{BootReport: &report})
+	if err != nil {
+		if errOut != nil {
+			fmt.Fprintf(errOut, "describe failed: %v\n", err)
+		}
+		return 1
+	}
+	view.ContractsRoot = contractsRoot
+	if err := renderCLIOutput(out, errOut, opts.output, view, func(w io.Writer) {
+		writeDescribeText(w, view)
+	}, func() ([]string, error) {
+		return describeQuietValues(view), nil
+	}); err != nil {
+		return 2
+	}
+	return 0
+}
+
+func writeDescribeText(out io.Writer, view authoringview.View) {
+	if out == nil {
+		return
+	}
+	fmt.Fprintf(out, "describe: contracts=%s\n", view.ContractsRoot)
+	fmt.Fprintf(out, "source authority: %s\n", view.SourceAuthority)
+	if len(view.Flows) > 0 {
+		fmt.Fprintln(out, "flows:")
+		for _, flow := range view.Flows {
+			label := strings.TrimSpace(flow.ID)
+			if flow.Mode != "" {
+				label += " (" + flow.Mode + ")"
+			}
+			fmt.Fprintf(out, "  - %s\n", label)
+			if flow.PrimaryEntity != nil {
+				fmt.Fprintf(out, "    primary entity: %s\n", flow.PrimaryEntity.Type)
+			}
+			if flow.TemplateInstance != nil {
+				fmt.Fprintf(out, "    instance: by=%s on_missing=%s on_conflict=%s\n", strings.Join(flow.TemplateInstance.By, ","), flow.TemplateInstance.OnMissing, flow.TemplateInstance.OnConflict)
+			}
+			if flow.SingletonCoordinator != nil {
+				fmt.Fprintf(out, "    singleton coordinator: primary_entity=%s contained_fields=%d\n", flow.SingletonCoordinator.PrimaryEntity, len(flow.SingletonCoordinator.ContainedState))
+			}
+			if len(flow.ContainedOperations) > 0 {
+				fmt.Fprintf(out, "    contained operations: %d\n", len(flow.ContainedOperations))
+			}
+		}
+	}
+	if len(view.ConnectRoutePlans) > 0 {
+		fmt.Fprintln(out, "connect route plans:")
+		for _, plan := range view.ConnectRoutePlans {
+			fmt.Fprintf(out, "  - %s.%s -> %s.%s resolution=%s delivery=%s\n", plan.Source.FlowID, plan.Source.Pin, plan.Receiver.FlowID, plan.Receiver.Pin, plan.ResolutionKind, plan.Delivery)
+		}
+	}
+	if len(view.Diagnostics) > 0 {
+		fmt.Fprintln(out, "diagnostics:")
+		for _, diagnostic := range view.Diagnostics {
+			fmt.Fprintf(out, "  - [%s] %s %s: %s\n", diagnostic.Severity, diagnostic.CheckID, diagnostic.AuthoredLocation, diagnostic.Message)
+		}
+	}
+}
+
+func describeQuietValues(view authoringview.View) []string {
+	values := make([]string, 0, len(view.Flows)+1)
+	if strings.TrimSpace(view.ContractsRoot) != "" {
+		values = append(values, strings.TrimSpace(view.ContractsRoot))
+	}
+	for _, flow := range view.Flows {
+		if id := strings.TrimSpace(flow.ID); id != "" {
+			values = append(values, id)
+		}
+	}
+	return values
+}

--- a/cmd/swarm/describe_test.go
+++ b/cmd/swarm/describe_test.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/division-sh/swarm/internal/runtime/authoringview"
+	"github.com/division-sh/swarm/internal/runtime/testfixtures/templateflowpilot"
+)
+
+func TestDescribeCommandJSONRendersExpandedAuthoringView(t *testing.T) {
+	contractsRoot := templateflowpilot.Write(t, templateflowpilot.Options{})
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), repoRoot(), []string{
+		"describe",
+		"--contracts", contractsRoot,
+		"--json",
+	}, &stdout, &stderr, defaultRootCommandOptions())
+	if code != 0 {
+		t.Fatalf("describe --json code = %d stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if stderr.String() != "" {
+		t.Fatalf("describe --json stderr = %q, want empty", stderr.String())
+	}
+	var view authoringview.View
+	if err := json.Unmarshal(stdout.Bytes(), &view); err != nil {
+		t.Fatalf("decode describe json: %v\n%s", err, stdout.String())
+	}
+	if view.SourceAuthority != "projection_only_existing_contract_owners" {
+		t.Fatalf("source authority = %q, want projection marker", view.SourceAuthority)
+	}
+	if len(view.ConnectRoutePlans) != 1 {
+		t.Fatalf("connect route plans = %#v, want one", view.ConnectRoutePlans)
+	}
+	plan := view.ConnectRoutePlans[0]
+	if plan.ResolutionKind != "instance_key" || plan.InstanceKey == nil {
+		t.Fatalf("route plan = %#v, want instance_key plan", plan)
+	}
+	if plan.Source.Key != "account_id" || len(plan.Source.Carries) == 0 {
+		t.Fatalf("route source = %#v, want output key/carries", plan.Source)
+	}
+	if len(view.Flows) != 2 {
+		t.Fatalf("flow count = %d, want 2", len(view.Flows))
+	}
+}

--- a/cmd/swarm/describe_test.go
+++ b/cmd/swarm/describe_test.go
@@ -4,6 +4,9 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/division-sh/swarm/internal/runtime/authoringview"
@@ -43,5 +46,67 @@ func TestDescribeCommandJSONRendersExpandedAuthoringView(t *testing.T) {
 	}
 	if len(view.Flows) != 2 {
 		t.Fatalf("flow count = %d, want 2", len(view.Flows))
+	}
+}
+
+func TestDescribeCommandJSONRendersRootPrimaryEntity(t *testing.T) {
+	contractsRoot := writeDescribeRootPrimaryEntityContracts(t)
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), repoRoot(), []string{
+		"describe",
+		"--contracts", contractsRoot,
+		"--json",
+	}, &stdout, &stderr, defaultRootCommandOptions())
+	if code != 0 {
+		t.Fatalf("describe --json code = %d stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if stderr.String() != "" {
+		t.Fatalf("describe --json stderr = %q, want empty", stderr.String())
+	}
+	var view authoringview.View
+	if err := json.Unmarshal(stdout.Bytes(), &view); err != nil {
+		t.Fatalf("decode describe json: %v\n%s", err, stdout.String())
+	}
+	if view.Root.PrimaryEntity == nil {
+		t.Fatalf("root primary entity missing: %#v", view.Root)
+	}
+	if view.Root.PrimaryEntity.Type != "workspace" {
+		t.Fatalf("root primary entity type = %q, want workspace", view.Root.PrimaryEntity.Type)
+	}
+	if view.Root.PrimaryEntity.Fields["org_id"] != "text" {
+		t.Fatalf("root primary entity fields = %#v, want org_id text", view.Root.PrimaryEntity.Fields)
+	}
+}
+
+func writeDescribeRootPrimaryEntityContracts(t testing.TB) string {
+	t.Helper()
+	root := t.TempDir()
+	writeDescribeTestFile(t, filepath.Join(root, "package.yaml"), `
+name: root-primary-entity
+version: "1.0.0"
+platform_version: ">=1.6.0"
+flows: []
+`)
+	writeDescribeTestFile(t, filepath.Join(root, "schema.yaml"), "name: root-primary-entity\n")
+	writeDescribeTestFile(t, filepath.Join(root, "policy.yaml"), "{}\n")
+	writeDescribeTestFile(t, filepath.Join(root, "tools.yaml"), "{}\n")
+	writeDescribeTestFile(t, filepath.Join(root, "agents.yaml"), "{}\n")
+	writeDescribeTestFile(t, filepath.Join(root, "events.yaml"), "{}\n")
+	writeDescribeTestFile(t, filepath.Join(root, "nodes.yaml"), "{}\n")
+	writeDescribeTestFile(t, filepath.Join(root, "entities.yaml"), `
+workspace:
+  org_id: text
+  region: text
+`)
+	return root
+}
+
+func writeDescribeTestFile(t testing.TB, path, contents string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, []byte(strings.TrimLeft(contents, "\n")), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
 	}
 }

--- a/cmd/swarm/describe_test.go
+++ b/cmd/swarm/describe_test.go
@@ -34,6 +34,9 @@ func TestDescribeCommandJSONRendersExpandedAuthoringView(t *testing.T) {
 	if view.SourceAuthority != "projection_only_existing_contract_owners" {
 		t.Fatalf("source authority = %q, want projection marker", view.SourceAuthority)
 	}
+	if view.Root.PrimaryEntity != nil || view.Root.PrimaryEntityError != "" {
+		t.Fatalf("root primary entity for valid no-root fixture = entity %#v error %q, want none", view.Root.PrimaryEntity, view.Root.PrimaryEntityError)
+	}
 	if len(view.ConnectRoutePlans) != 1 {
 		t.Fatalf("connect route plans = %#v, want one", view.ConnectRoutePlans)
 	}

--- a/internal/apispec/platform_spec_flow_instance_authoring_test.go
+++ b/internal/apispec/platform_spec_flow_instance_authoring_test.go
@@ -243,4 +243,15 @@ func TestPlatformSpecFlowInstanceAuthoringSourceAuthority(t *testing.T) {
 	} {
 		assertScalarValue(t, mustYAMLPath(t, analyzer, "children", tc.key), tc.want)
 	}
+	expandMinimize := mustMappingValue(t, analyzer, "expand_minimize_tooling")
+	assertScalarValue(t, mustMappingValue(t, expandMinimize, "status"), "merge_bearing_supported_tooling")
+	assertScalarValue(t, mustMappingValue(t, expandMinimize, "implementation_tracker"), "#1551")
+	assertScalarValue(t, mustMappingValue(t, expandMinimize, "command"), "swarm describe")
+	assertScalarContains(t, mustMappingValue(t, expandMinimize, "canonical_code_owner"), "internal/runtime/authoringview.Build")
+	assertScalarContains(t, mustMappingValue(t, expandMinimize, "rule"), "projection over existing semantic owners")
+	assertScalarContains(t, mustMappingValue(t, expandMinimize, "rule"), "without becoming a new semantic owner")
+	assertScalarContains(t, mustMappingValue(t, expandMinimize, "source_location_rule"), "check_id plus authored YAML file")
+	if !sequenceContainsScalar(mustMappingValue(t, expandMinimize, "non_authoritative_paths"), "generated expanded YAML as merge authority") {
+		t.Fatal("expand_minimize_tooling must keep generated expanded YAML non-authoritative")
+	}
 }

--- a/internal/runtime/authoringview/view.go
+++ b/internal/runtime/authoringview/view.go
@@ -453,49 +453,60 @@ func containedOperationsByFlow(source semanticview.Source, bundle *runtimecontra
 	if source == nil || bundle == nil {
 		return out
 	}
-	nodes := source.NodeEntries()
-	for _, nodeID := range sortedNodeIDs(nodes) {
-		node := nodes[nodeID]
-		flowID := ""
-		sourceFile := ""
-		if sourceRef, ok := source.NodeContractSource(nodeID); ok {
-			flowID = strings.TrimSpace(sourceRef.FlowID)
-			sourceFile = authoredFileForSource(bundle, sourceRef)
+	for _, project := range bundle.ProjectViews() {
+		for _, nodeID := range sortedNodeIDs(project.Nodes) {
+			flowID := ""
+			sourceFile := strings.TrimSpace(project.Paths.ProjectNodesFile)
+			if sourceRef, ok := source.NodeContractSource(nodeID); ok {
+				flowID = strings.TrimSpace(sourceRef.FlowID)
+				sourceFile = firstNonEmpty(authoredFileForSource(bundle, sourceRef), sourceFile)
+			}
+			appendContainedOperations(out, source, flowID, nodeID, sourceFile, project.Nodes[nodeID])
 		}
-		for _, ref := range containedOperationRefs(flowID, nodeID, node) {
-			op := ContainedOperationView{
-				FlowID:     ref.FlowID,
-				NodeID:     ref.NodeID,
-				Event:      ref.EventType,
-				Scope:      ref.Scope,
-				Operation:  strings.TrimSpace(string(ref.Write.Operation)),
-				Target:     strings.TrimSpace(ref.Write.Target()),
-				HasKey:     !ref.Write.Key.IsZero(),
-				HasIndex:   !ref.Write.Index.IsZero(),
-				SourceFile: sourceFile,
-			}
-			contract, ok := entityruntime.ResolveForFlow(source, ref.FlowID)
-			if !ok {
-				op.Error = "flow has no declared entity contract"
-				out[ref.FlowID] = append(out[ref.FlowID], op)
-				continue
-			}
-			target, err := entityruntime.ResolveContainedOperationTarget(contract, ref.Write.Target(), string(ref.Write.Operation), !ref.Write.Key.IsZero(), !ref.Write.Index.IsZero())
-			if err != nil {
-				op.Error = err.Error()
-				out[ref.FlowID] = append(out[ref.FlowID], op)
-				continue
-			}
-			op.RootField = strings.TrimSpace(target.RootField)
-			op.TargetType = strings.TrimSpace(target.TargetType)
-			op.MapKeyType = strings.TrimSpace(target.MapKeyType)
-			op.MapValueType = strings.TrimSpace(target.MapValueType)
-			op.ListItemType = strings.TrimSpace(target.ListItemType)
-			op.MapScoped = target.MapScoped
-			out[ref.FlowID] = append(out[ref.FlowID], op)
+	}
+	for _, flow := range bundle.FlowViews() {
+		flowID := strings.TrimSpace(flow.Paths.ID)
+		sourceFile := strings.TrimSpace(flow.Paths.NodesFile)
+		for _, nodeID := range sortedNodeIDs(flow.Nodes) {
+			appendContainedOperations(out, source, flowID, nodeID, sourceFile, flow.Nodes[nodeID])
 		}
 	}
 	return out
+}
+
+func appendContainedOperations(out map[string][]ContainedOperationView, source semanticview.Source, flowID, nodeID, sourceFile string, node runtimecontracts.SystemNodeContract) {
+	for _, ref := range containedOperationRefs(flowID, nodeID, node) {
+		op := ContainedOperationView{
+			FlowID:     ref.FlowID,
+			NodeID:     ref.NodeID,
+			Event:      ref.EventType,
+			Scope:      ref.Scope,
+			Operation:  strings.TrimSpace(string(ref.Write.Operation)),
+			Target:     strings.TrimSpace(ref.Write.Target()),
+			HasKey:     !ref.Write.Key.IsZero(),
+			HasIndex:   !ref.Write.Index.IsZero(),
+			SourceFile: strings.TrimSpace(sourceFile),
+		}
+		contract, ok := entityruntime.ResolveForFlow(source, ref.FlowID)
+		if !ok {
+			op.Error = "flow has no declared entity contract"
+			out[ref.FlowID] = append(out[ref.FlowID], op)
+			continue
+		}
+		target, err := entityruntime.ResolveContainedOperationTarget(contract, ref.Write.Target(), string(ref.Write.Operation), !ref.Write.Key.IsZero(), !ref.Write.Index.IsZero())
+		if err != nil {
+			op.Error = err.Error()
+			out[ref.FlowID] = append(out[ref.FlowID], op)
+			continue
+		}
+		op.RootField = strings.TrimSpace(target.RootField)
+		op.TargetType = strings.TrimSpace(target.TargetType)
+		op.MapKeyType = strings.TrimSpace(target.MapKeyType)
+		op.MapValueType = strings.TrimSpace(target.MapValueType)
+		op.ListItemType = strings.TrimSpace(target.ListItemType)
+		op.MapScoped = target.MapScoped
+		out[ref.FlowID] = append(out[ref.FlowID], op)
+	}
 }
 
 func containedOperationRefs(flowID, nodeID string, node runtimecontracts.SystemNodeContract) []containedOperationRef {

--- a/internal/runtime/authoringview/view.go
+++ b/internal/runtime/authoringview/view.go
@@ -1,0 +1,692 @@
+package authoringview
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+
+	runtimebootverify "github.com/division-sh/swarm/internal/runtime/bootverify"
+	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
+	"github.com/division-sh/swarm/internal/runtime/core/pinrouting"
+	"github.com/division-sh/swarm/internal/runtime/entityruntime"
+	"github.com/division-sh/swarm/internal/runtime/semanticview"
+)
+
+type View struct {
+	WorkflowName      string                 `json:"workflow_name,omitempty"`
+	WorkflowVersion   string                 `json:"workflow_version,omitempty"`
+	ContractsRoot     string                 `json:"contracts_root,omitempty"`
+	SourceAuthority   string                 `json:"source_authority"`
+	Flows             []FlowView             `json:"flows"`
+	ConnectRoutePlans []ConnectRoutePlanView `json:"connect_route_plans"`
+	RoutePlanIssues   []RoutePlanIssueView   `json:"route_plan_issues,omitempty"`
+	Diagnostics       []DiagnosticView       `json:"diagnostics,omitempty"`
+	Equivalence       EquivalenceView        `json:"equivalence"`
+}
+
+type EquivalenceView struct {
+	ProjectionOnly  bool     `json:"projection_only"`
+	CanonicalOwners []string `json:"canonical_owners"`
+}
+
+type FlowView struct {
+	ID                   string                    `json:"id"`
+	Path                 string                    `json:"path,omitempty"`
+	Mode                 string                    `json:"mode,omitempty"`
+	SourceFiles          FlowSourceFiles           `json:"source_files"`
+	PrimaryEntity        *PrimaryEntityView        `json:"primary_entity,omitempty"`
+	PrimaryEntityError   string                    `json:"primary_entity_error,omitempty"`
+	TemplateInstance     *TemplateInstanceView     `json:"template_instance,omitempty"`
+	TemplateError        string                    `json:"template_instance_error,omitempty"`
+	SingletonCoordinator *SingletonCoordinatorView `json:"singleton_coordinator,omitempty"`
+	SingletonError       string                    `json:"singleton_coordinator_error,omitempty"`
+	InputPins            []InputPinView            `json:"input_pins,omitempty"`
+	OutputPins           []OutputPinView           `json:"output_pins,omitempty"`
+	ContainedOperations  []ContainedOperationView  `json:"contained_operations,omitempty"`
+}
+
+type FlowSourceFiles struct {
+	Package  string `json:"package,omitempty"`
+	Schema   string `json:"schema,omitempty"`
+	Entities string `json:"entities,omitempty"`
+	Nodes    string `json:"nodes,omitempty"`
+	Events   string `json:"events,omitempty"`
+}
+
+type PrimaryEntityView struct {
+	Type       string            `json:"type"`
+	Fields     map[string]string `json:"fields,omitempty"`
+	SourceFile string            `json:"source_file,omitempty"`
+}
+
+type TemplateInstanceView struct {
+	By            []string `json:"by"`
+	OnMissing     string   `json:"on_missing"`
+	OnConflict    string   `json:"on_conflict"`
+	PrimaryEntity string   `json:"primary_entity"`
+	SourceFile    string   `json:"source_file,omitempty"`
+}
+
+type SingletonCoordinatorView struct {
+	PrimaryEntity  string                        `json:"primary_entity"`
+	ContainedState []SingletonContainedFieldView `json:"contained_state,omitempty"`
+	SourceFile     string                        `json:"source_file,omitempty"`
+}
+
+type SingletonContainedFieldView struct {
+	Name string `json:"name"`
+	Type string `json:"type"`
+	Kind string `json:"kind"`
+}
+
+type InputPinView struct {
+	Name          string               `json:"name"`
+	Event         string               `json:"event"`
+	ResolvedEvent string               `json:"resolved_event"`
+	Address       *InputPinAddressView `json:"address,omitempty"`
+}
+
+type InputPinAddressView struct {
+	By          string `json:"by,omitempty"`
+	Source      string `json:"source,omitempty"`
+	Target      string `json:"target,omitempty"`
+	Cardinality string `json:"cardinality,omitempty"`
+	Mode        string `json:"mode,omitempty"`
+}
+
+type OutputPinView struct {
+	Name          string   `json:"name"`
+	Event         string   `json:"event"`
+	ResolvedEvent string   `json:"resolved_event"`
+	Key           string   `json:"key,omitempty"`
+	Carries       []string `json:"carries,omitempty"`
+}
+
+type ConnectRoutePlanView struct {
+	PackageKey                string                  `json:"package_key,omitempty"`
+	Source                    ConnectEndpointView     `json:"source"`
+	Receiver                  ConnectEndpointView     `json:"receiver"`
+	Adapter                   string                  `json:"adapter,omitempty"`
+	Delivery                  string                  `json:"delivery"`
+	TargetKind                string                  `json:"target_kind"`
+	ResolutionKind            string                  `json:"resolution_kind"`
+	Address                   *ConnectAddressView     `json:"address,omitempty"`
+	InstanceKey               *ConnectInstanceKeyView `json:"instance_key,omitempty"`
+	Map                       []ConnectMapEntryView   `json:"map,omitempty"`
+	RequiresRuntimeResolution bool                    `json:"requires_runtime_resolution"`
+	SourceFile                string                  `json:"source_file,omitempty"`
+}
+
+type ConnectEndpointView struct {
+	Root          bool     `json:"root,omitempty"`
+	FlowID        string   `json:"flow_id,omitempty"`
+	FlowPath      string   `json:"flow_path,omitempty"`
+	Mode          string   `json:"mode,omitempty"`
+	Pin           string   `json:"pin"`
+	Event         string   `json:"event"`
+	ResolvedEvent string   `json:"resolved_event"`
+	Key           string   `json:"key,omitempty"`
+	Carries       []string `json:"carries,omitempty"`
+}
+
+type ConnectAddressView struct {
+	By          string `json:"by,omitempty"`
+	Source      string `json:"source,omitempty"`
+	Target      string `json:"target,omitempty"`
+	Cardinality string `json:"cardinality,omitempty"`
+	Mode        string `json:"mode,omitempty"`
+}
+
+type ConnectInstanceKeyView struct {
+	Fields     []string                        `json:"fields,omitempty"`
+	Mappings   []ConnectInstanceKeyMappingView `json:"mappings,omitempty"`
+	OnMissing  string                          `json:"on_missing,omitempty"`
+	OnConflict string                          `json:"on_conflict,omitempty"`
+}
+
+type ConnectInstanceKeyMappingView struct {
+	Source   string `json:"source"`
+	Target   string `json:"target"`
+	Explicit bool   `json:"explicit"`
+}
+
+type ConnectMapEntryView struct {
+	Key    string `json:"key"`
+	Source string `json:"source,omitempty"`
+	Target string `json:"target,omitempty"`
+}
+
+type RoutePlanIssueView struct {
+	PackageKey       string `json:"package_key,omitempty"`
+	From             string `json:"from,omitempty"`
+	To               string `json:"to,omitempty"`
+	Failure          string `json:"failure"`
+	Detail           string `json:"detail,omitempty"`
+	AuthoredLocation string `json:"authored_location,omitempty"`
+}
+
+type ContainedOperationView struct {
+	FlowID       string `json:"flow_id"`
+	NodeID       string `json:"node_id"`
+	Event        string `json:"event"`
+	Scope        string `json:"scope"`
+	Operation    string `json:"operation"`
+	Target       string `json:"target"`
+	HasKey       bool   `json:"has_key"`
+	HasIndex     bool   `json:"has_index"`
+	RootField    string `json:"root_field,omitempty"`
+	TargetType   string `json:"target_type,omitempty"`
+	MapKeyType   string `json:"map_key_type,omitempty"`
+	MapValueType string `json:"map_value_type,omitempty"`
+	ListItemType string `json:"list_item_type,omitempty"`
+	MapScoped    bool   `json:"map_scoped,omitempty"`
+	SourceFile   string `json:"source_file,omitempty"`
+	Error        string `json:"error,omitempty"`
+}
+
+type DiagnosticView struct {
+	CheckID          string `json:"check_id"`
+	Severity         string `json:"severity"`
+	Location         string `json:"location,omitempty"`
+	AuthoredLocation string `json:"authored_location,omitempty"`
+	Message          string `json:"message"`
+}
+
+type BuildOptions struct {
+	BootReport *runtimebootverify.Report
+}
+
+func Build(_ context.Context, source semanticview.Source, opts BuildOptions) (View, error) {
+	bundle, ok := semanticview.Bundle(source)
+	if !ok || bundle == nil {
+		return View{}, fmt.Errorf("authoring view requires a workflow contract bundle source")
+	}
+	plans, routeIssues := pinrouting.LowerCompositionConnectRoutePlans(source)
+	view := View{
+		WorkflowName:      bundle.WorkflowName(),
+		WorkflowVersion:   bundle.WorkflowVersion(),
+		ContractsRoot:     strings.TrimSpace(bundle.Paths.ContractsRoot),
+		SourceAuthority:   "projection_only_existing_contract_owners",
+		Flows:             buildFlows(source, bundle),
+		ConnectRoutePlans: buildConnectRoutePlans(bundle, plans),
+		RoutePlanIssues:   buildRoutePlanIssues(bundle, routeIssues),
+		Diagnostics:       buildDiagnostics(bundle, opts.BootReport),
+		Equivalence: EquivalenceView{
+			ProjectionOnly: true,
+			CanonicalOwners: []string{
+				"runtime/contracts.WorkflowContractBundle",
+				"runtime/contracts primary entity/template/singleton accessors",
+				"runtime/core/pinrouting.LowerCompositionConnectRoutePlans",
+				"runtime/entityruntime.ResolveContainedOperationTarget",
+				"runtime/bootverify.Report",
+			},
+		},
+	}
+	return view, nil
+}
+
+func buildFlows(source semanticview.Source, bundle *runtimecontracts.WorkflowContractBundle) []FlowView {
+	opsByFlow := containedOperationsByFlow(source, bundle)
+	views := bundle.FlowViews()
+	out := make([]FlowView, 0, len(views))
+	for _, flow := range views {
+		flowID := strings.TrimSpace(flow.Paths.ID)
+		schema := flow.Schema
+		item := FlowView{
+			ID:          flowID,
+			Path:        strings.Trim(strings.TrimSpace(flow.Path), "/"),
+			Mode:        strings.TrimSpace(schema.Mode),
+			SourceFiles: flowSourceFiles(bundle, flow),
+			InputPins:   inputPinViews(source, flowID, schema.Pins.Inputs.EventPins),
+			OutputPins:  outputPinViews(source, flowID, schema.Pins.Outputs.EventPins),
+		}
+		if primary, err := bundle.ResolveFlowPrimaryEntity(flowID); err == nil {
+			item.PrimaryEntity = primaryEntityView(primary, flow.Paths.EntitiesFile)
+		} else {
+			item.PrimaryEntityError = err.Error()
+		}
+		if strings.TrimSpace(schema.Mode) == runtimecontracts.FlowModeTemplate || !schema.Instance.Empty() {
+			if instance, err := bundle.ResolveFlowTemplateInstance(flowID); err == nil {
+				item.TemplateInstance = &TemplateInstanceView{
+					By:            append([]string{}, instance.By...),
+					OnMissing:     strings.TrimSpace(instance.OnMissing),
+					OnConflict:    strings.TrimSpace(instance.OnConflict),
+					PrimaryEntity: strings.TrimSpace(instance.PrimaryEntity.EntityType),
+					SourceFile:    strings.TrimSpace(flow.Paths.SchemaFile),
+				}
+			} else {
+				item.TemplateError = err.Error()
+			}
+		}
+		if strings.TrimSpace(schema.Mode) == runtimecontracts.FlowModeSingleton {
+			if singleton, err := bundle.ResolveFlowSingletonCoordinator(flowID); err == nil {
+				item.SingletonCoordinator = singletonCoordinatorView(singleton, flow.Paths.SchemaFile)
+			} else {
+				item.SingletonError = err.Error()
+			}
+		}
+		item.ContainedOperations = opsByFlow[flowID]
+		out = append(out, item)
+	}
+	return out
+}
+
+func flowSourceFiles(bundle *runtimecontracts.WorkflowContractBundle, flow runtimecontracts.FlowContractView) FlowSourceFiles {
+	return FlowSourceFiles{
+		Package:  packageSourceFile(bundle, flow.Paths.PackageKey),
+		Schema:   strings.TrimSpace(flow.Paths.SchemaFile),
+		Entities: strings.TrimSpace(flow.Paths.EntitiesFile),
+		Nodes:    strings.TrimSpace(flow.Paths.NodesFile),
+		Events:   strings.TrimSpace(flow.Paths.EventsFile),
+	}
+}
+
+func primaryEntityView(primary runtimecontracts.PrimaryEntityContract, sourceFile string) *PrimaryEntityView {
+	fields := map[string]string{}
+	for _, field := range sortedEntityFields(primary.Contract.Fields) {
+		fields[field] = strings.TrimSpace(primary.Contract.Fields[field].Type)
+	}
+	return &PrimaryEntityView{
+		Type:       strings.TrimSpace(primary.EntityType),
+		Fields:     fields,
+		SourceFile: strings.TrimSpace(sourceFile),
+	}
+}
+
+func singletonCoordinatorView(singleton runtimecontracts.SingletonCoordinatorContract, sourceFile string) *SingletonCoordinatorView {
+	fields := make([]SingletonContainedFieldView, 0, len(singleton.ContainedState))
+	for _, field := range singleton.ContainedState {
+		fields = append(fields, SingletonContainedFieldView{
+			Name: strings.TrimSpace(field.Name),
+			Type: strings.TrimSpace(field.Type),
+			Kind: strings.TrimSpace(field.Kind),
+		})
+	}
+	sort.Slice(fields, func(i, j int) bool { return fields[i].Name < fields[j].Name })
+	return &SingletonCoordinatorView{
+		PrimaryEntity:  strings.TrimSpace(singleton.PrimaryEntity.EntityType),
+		ContainedState: fields,
+		SourceFile:     strings.TrimSpace(sourceFile),
+	}
+}
+
+func inputPinViews(source semanticview.Source, flowID string, pins []runtimecontracts.FlowInputEventPin) []InputPinView {
+	out := make([]InputPinView, 0, len(pins))
+	for _, pin := range pins {
+		item := InputPinView{
+			Name:          strings.TrimSpace(pin.PinName()),
+			Event:         strings.TrimSpace(pin.EventType()),
+			ResolvedEvent: strings.TrimSpace(source.ResolveFlowEventReference(flowID, pin.EventType())),
+		}
+		if pin.Address != nil {
+			item.Address = &InputPinAddressView{
+				By:          strings.TrimSpace(pin.Address.By),
+				Source:      strings.TrimSpace(pin.Address.Source),
+				Target:      strings.TrimSpace(pin.Address.Target),
+				Cardinality: strings.TrimSpace(pin.Address.Cardinality),
+				Mode:        strings.TrimSpace(pin.Address.Mode),
+			}
+		}
+		out = append(out, item)
+	}
+	return out
+}
+
+func outputPinViews(source semanticview.Source, flowID string, pins []runtimecontracts.FlowOutputEventPin) []OutputPinView {
+	out := make([]OutputPinView, 0, len(pins))
+	for _, pin := range pins {
+		out = append(out, OutputPinView{
+			Name:          strings.TrimSpace(pin.PinName()),
+			Event:         strings.TrimSpace(pin.EventType()),
+			ResolvedEvent: strings.TrimSpace(source.ResolveFlowEventReference(flowID, pin.EventType())),
+			Key:           strings.TrimSpace(pin.Key),
+			Carries:       normalizedStrings(pin.Carries),
+		})
+	}
+	return out
+}
+
+func buildConnectRoutePlans(bundle *runtimecontracts.WorkflowContractBundle, plans []pinrouting.ConnectRoutePlan) []ConnectRoutePlanView {
+	out := make([]ConnectRoutePlanView, 0, len(plans))
+	for _, plan := range plans {
+		item := ConnectRoutePlanView{
+			PackageKey:                strings.TrimSpace(plan.PackageKey),
+			Source:                    connectEndpointView(plan.Source),
+			Receiver:                  connectEndpointView(plan.Receiver),
+			Adapter:                   strings.TrimSpace(plan.Adapter),
+			Delivery:                  string(plan.Delivery),
+			TargetKind:                string(plan.TargetKind),
+			ResolutionKind:            string(plan.ResolutionKind),
+			Map:                       connectMapEntryViews(plan.Map),
+			RequiresRuntimeResolution: plan.RequiresRuntimeResolution,
+			SourceFile:                packageSourceFile(bundle, plan.PackageKey),
+		}
+		if plan.Address != nil {
+			item.Address = &ConnectAddressView{
+				By:          strings.TrimSpace(plan.Address.By),
+				Source:      strings.TrimSpace(plan.Address.Source),
+				Target:      strings.TrimSpace(plan.Address.Target),
+				Cardinality: strings.TrimSpace(plan.Address.Cardinality),
+				Mode:        strings.TrimSpace(plan.Address.Mode),
+			}
+		}
+		if plan.InstanceKey != nil {
+			item.InstanceKey = connectInstanceKeyView(plan.InstanceKey)
+		}
+		out = append(out, item)
+	}
+	return out
+}
+
+func connectEndpointView(endpoint pinrouting.ConnectRoutePlanEndpoint) ConnectEndpointView {
+	return ConnectEndpointView{
+		Root:          endpoint.Root,
+		FlowID:        strings.TrimSpace(endpoint.FlowID),
+		FlowPath:      strings.TrimSpace(endpoint.FlowPath),
+		Mode:          strings.TrimSpace(endpoint.Mode),
+		Pin:           strings.TrimSpace(endpoint.Pin),
+		Event:         strings.TrimSpace(endpoint.Event),
+		ResolvedEvent: strings.TrimSpace(endpoint.ResolvedEvent),
+		Key:           strings.TrimSpace(endpoint.Key),
+		Carries:       normalizedStrings(endpoint.Carries),
+	}
+}
+
+func connectInstanceKeyView(instance *pinrouting.ConnectRoutePlanInstanceKey) *ConnectInstanceKeyView {
+	if instance == nil {
+		return nil
+	}
+	mappings := make([]ConnectInstanceKeyMappingView, 0, len(instance.Mappings))
+	for _, mapping := range instance.Mappings {
+		mappings = append(mappings, ConnectInstanceKeyMappingView{
+			Source:   strings.TrimSpace(mapping.Source),
+			Target:   strings.TrimSpace(mapping.Target),
+			Explicit: mapping.Explicit,
+		})
+	}
+	return &ConnectInstanceKeyView{
+		Fields:     normalizedStrings(instance.Fields),
+		Mappings:   mappings,
+		OnMissing:  strings.TrimSpace(instance.OnMissing),
+		OnConflict: strings.TrimSpace(instance.OnConflict),
+	}
+}
+
+func connectMapEntryViews(entries []pinrouting.ConnectRoutePlanMapEntry) []ConnectMapEntryView {
+	out := make([]ConnectMapEntryView, 0, len(entries))
+	for _, entry := range entries {
+		out = append(out, ConnectMapEntryView{
+			Key:    strings.TrimSpace(entry.Key),
+			Source: strings.TrimSpace(entry.Source),
+			Target: strings.TrimSpace(entry.Target),
+		})
+	}
+	return out
+}
+
+func buildRoutePlanIssues(bundle *runtimecontracts.WorkflowContractBundle, issues []pinrouting.ConnectRoutePlanIssue) []RoutePlanIssueView {
+	out := make([]RoutePlanIssueView, 0, len(issues))
+	for _, issue := range issues {
+		out = append(out, RoutePlanIssueView{
+			PackageKey:       strings.TrimSpace(issue.Connect.PackageKey),
+			From:             strings.TrimSpace(issue.Connect.From),
+			To:               strings.TrimSpace(issue.Connect.To),
+			Failure:          string(issue.Failure),
+			Detail:           strings.TrimSpace(issue.Detail),
+			AuthoredLocation: packageSourceFile(bundle, issue.Connect.PackageKey),
+		})
+	}
+	return out
+}
+
+type containedOperationRef struct {
+	FlowID    string
+	NodeID    string
+	EventType string
+	Scope     string
+	Write     runtimecontracts.WorkflowDataWrite
+}
+
+func containedOperationsByFlow(source semanticview.Source, bundle *runtimecontracts.WorkflowContractBundle) map[string][]ContainedOperationView {
+	out := map[string][]ContainedOperationView{}
+	if source == nil || bundle == nil {
+		return out
+	}
+	nodes := source.NodeEntries()
+	for _, nodeID := range sortedNodeIDs(nodes) {
+		node := nodes[nodeID]
+		flowID := ""
+		sourceFile := ""
+		if sourceRef, ok := source.NodeContractSource(nodeID); ok {
+			flowID = strings.TrimSpace(sourceRef.FlowID)
+			sourceFile = authoredFileForSource(bundle, sourceRef)
+		}
+		for _, ref := range containedOperationRefs(flowID, nodeID, node) {
+			op := ContainedOperationView{
+				FlowID:     ref.FlowID,
+				NodeID:     ref.NodeID,
+				Event:      ref.EventType,
+				Scope:      ref.Scope,
+				Operation:  strings.TrimSpace(string(ref.Write.Operation)),
+				Target:     strings.TrimSpace(ref.Write.Target()),
+				HasKey:     !ref.Write.Key.IsZero(),
+				HasIndex:   !ref.Write.Index.IsZero(),
+				SourceFile: sourceFile,
+			}
+			contract, ok := entityruntime.ResolveForFlow(source, ref.FlowID)
+			if !ok {
+				op.Error = "flow has no declared entity contract"
+				out[ref.FlowID] = append(out[ref.FlowID], op)
+				continue
+			}
+			target, err := entityruntime.ResolveContainedOperationTarget(contract, ref.Write.Target(), string(ref.Write.Operation), !ref.Write.Key.IsZero(), !ref.Write.Index.IsZero())
+			if err != nil {
+				op.Error = err.Error()
+				out[ref.FlowID] = append(out[ref.FlowID], op)
+				continue
+			}
+			op.RootField = strings.TrimSpace(target.RootField)
+			op.TargetType = strings.TrimSpace(target.TargetType)
+			op.MapKeyType = strings.TrimSpace(target.MapKeyType)
+			op.MapValueType = strings.TrimSpace(target.MapValueType)
+			op.ListItemType = strings.TrimSpace(target.ListItemType)
+			op.MapScoped = target.MapScoped
+			out[ref.FlowID] = append(out[ref.FlowID], op)
+		}
+	}
+	return out
+}
+
+func containedOperationRefs(flowID, nodeID string, node runtimecontracts.SystemNodeContract) []containedOperationRef {
+	out := make([]containedOperationRef, 0)
+	for _, eventType := range sortedHandlerEvents(node.EventHandlers) {
+		handler := node.EventHandlers[eventType]
+		out = append(out, writeRefs(flowID, nodeID, eventType, "handler.data_accumulation", handler.DataAccumulation.Writes)...)
+		for idx, rule := range handler.Rules {
+			out = append(out, writeRefs(flowID, nodeID, eventType, ruleScope("handler.rules", idx, rule.ID)+".data_accumulation", rule.DataAccumulation.Writes)...)
+		}
+		for idx, rule := range handler.OnComplete {
+			out = append(out, writeRefs(flowID, nodeID, eventType, ruleScope("handler.on_complete", idx, rule.ID)+".data_accumulation", rule.DataAccumulation.Writes)...)
+		}
+		if handler.Accumulate != nil {
+			for idx, rule := range handler.Accumulate.OnComplete {
+				out = append(out, writeRefs(flowID, nodeID, eventType, ruleScope("handler.accumulate.on_complete", idx, rule.ID)+".data_accumulation", rule.DataAccumulation.Writes)...)
+			}
+			if handler.Accumulate.OnTimeout != nil {
+				scope := "handler.accumulate.on_timeout"
+				if id := strings.TrimSpace(handler.Accumulate.OnTimeout.ID); id != "" {
+					scope += "[" + id + "]"
+				}
+				out = append(out, writeRefs(flowID, nodeID, eventType, scope+".data_accumulation", handler.Accumulate.OnTimeout.DataAccumulation.Writes)...)
+			}
+		}
+		for idx, branch := range handler.Branch {
+			if branch.Then != nil {
+				out = append(out, writeRefs(flowID, nodeID, eventType, fmt.Sprintf("handler.branch[%d].then.data_accumulation", idx), branch.Then.DataAccumulation.Writes)...)
+			}
+			if branch.Else != nil {
+				out = append(out, writeRefs(flowID, nodeID, eventType, fmt.Sprintf("handler.branch[%d].else.data_accumulation", idx), branch.Else.DataAccumulation.Writes)...)
+			}
+		}
+	}
+	return out
+}
+
+func writeRefs(flowID, nodeID, eventType, scope string, writes []runtimecontracts.WorkflowDataWrite) []containedOperationRef {
+	out := make([]containedOperationRef, 0, len(writes))
+	for _, write := range writes {
+		if !write.IsContainedOperation() {
+			continue
+		}
+		out = append(out, containedOperationRef{
+			FlowID:    strings.TrimSpace(flowID),
+			NodeID:    strings.TrimSpace(nodeID),
+			EventType: strings.TrimSpace(eventType),
+			Scope:     strings.TrimSpace(scope),
+			Write:     write,
+		})
+	}
+	return out
+}
+
+func ruleScope(prefix string, idx int, id string) string {
+	if id = strings.TrimSpace(id); id != "" {
+		return prefix + "[" + id + "]"
+	}
+	return fmt.Sprintf("%s[%d]", prefix, idx)
+}
+
+func buildDiagnostics(bundle *runtimecontracts.WorkflowContractBundle, report *runtimebootverify.Report) []DiagnosticView {
+	if report == nil {
+		return nil
+	}
+	findings := append([]runtimebootverify.Finding{}, report.Findings...)
+	out := make([]DiagnosticView, 0, len(findings))
+	for _, finding := range findings {
+		out = append(out, DiagnosticView{
+			CheckID:          strings.TrimSpace(finding.CheckID),
+			Severity:         strings.TrimSpace(finding.Severity),
+			Location:         strings.TrimSpace(finding.Location),
+			AuthoredLocation: authoredLocationForFinding(bundle, finding),
+			Message:          strings.TrimSpace(finding.Message),
+		})
+	}
+	return out
+}
+
+func authoredLocationForFinding(bundle *runtimecontracts.WorkflowContractBundle, finding runtimebootverify.Finding) string {
+	if bundle == nil {
+		return ""
+	}
+	location := strings.TrimSpace(finding.Location)
+	if location == "" || location == "<root>" || location == "root" {
+		return firstNonEmpty(bundle.Paths.RootSchemaFile, bundle.Paths.ProjectPackageFile)
+	}
+	if source, ok := bundle.NodeContractSource(location); ok {
+		return authoredFileForSource(bundle, source)
+	}
+	if flow, ok := bundle.FlowViewByID(location); ok {
+		return strings.TrimSpace(flow.Paths.SchemaFile)
+	}
+	if project, ok := bundle.ProjectViewByKey(location); ok {
+		return strings.TrimSpace(project.Paths.PackageFile)
+	}
+	for _, flow := range bundle.FlowViews() {
+		if strings.Contains(location, strings.TrimSpace(flow.Paths.ID)) {
+			return strings.TrimSpace(flow.Paths.SchemaFile)
+		}
+	}
+	return firstNonEmpty(bundle.Paths.ProjectPackageFile, bundle.Paths.RootSchemaFile)
+}
+
+func authoredFileForSource(bundle *runtimecontracts.WorkflowContractBundle, source runtimecontracts.ContractItemSource) string {
+	if file := strings.TrimSpace(source.File); file != "" {
+		return file
+	}
+	if flowID := strings.TrimSpace(source.FlowID); flowID != "" {
+		if flow, ok := bundle.FlowViewByID(flowID); ok {
+			switch strings.TrimSpace(source.Layer) {
+			case "nodes", "node", "flow":
+				return firstNonEmpty(flow.Paths.NodesFile, flow.Paths.SchemaFile)
+			case "events", "event":
+				return firstNonEmpty(flow.Paths.EventsFile, flow.Paths.SchemaFile)
+			default:
+				return firstNonEmpty(flow.Paths.NodesFile, flow.Paths.SchemaFile)
+			}
+		}
+	}
+	if packageKey := strings.TrimSpace(source.PackageKey); packageKey != "" {
+		return packageSourceFile(bundle, packageKey)
+	}
+	return ""
+}
+
+func packageSourceFile(bundle *runtimecontracts.WorkflowContractBundle, packageKey string) string {
+	if bundle == nil {
+		return ""
+	}
+	packageKey = strings.TrimSpace(packageKey)
+	if packageKey != "" {
+		if project, ok := bundle.ProjectViewByKey(packageKey); ok {
+			return strings.TrimSpace(project.Paths.PackageFile)
+		}
+	}
+	return strings.TrimSpace(bundle.Paths.ProjectPackageFile)
+}
+
+func sortedEntityFields(fields map[string]runtimecontracts.EntityFieldDecl) []string {
+	keys := make([]string, 0, len(fields))
+	for key := range fields {
+		key = strings.TrimSpace(key)
+		if key != "" {
+			keys = append(keys, key)
+		}
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func sortedNodeIDs(nodes map[string]runtimecontracts.SystemNodeContract) []string {
+	keys := make([]string, 0, len(nodes))
+	for key := range nodes {
+		key = strings.TrimSpace(key)
+		if key != "" {
+			keys = append(keys, key)
+		}
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func sortedHandlerEvents(handlers map[string]runtimecontracts.SystemNodeEventHandler) []string {
+	keys := make([]string, 0, len(handlers))
+	for key := range handlers {
+		key = strings.TrimSpace(key)
+		if key != "" {
+			keys = append(keys, key)
+		}
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func normalizedStrings(in []string) []string {
+	out := make([]string, 0, len(in))
+	for _, value := range in {
+		value = strings.TrimSpace(value)
+		if value != "" {
+			out = append(out, value)
+		}
+	}
+	return out
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if value = strings.TrimSpace(value); value != "" {
+			return value
+		}
+	}
+	return ""
+}

--- a/internal/runtime/authoringview/view.go
+++ b/internal/runtime/authoringview/view.go
@@ -18,6 +18,7 @@ type View struct {
 	WorkflowVersion   string                 `json:"workflow_version,omitempty"`
 	ContractsRoot     string                 `json:"contracts_root,omitempty"`
 	SourceAuthority   string                 `json:"source_authority"`
+	Root              RootView               `json:"root"`
 	Flows             []FlowView             `json:"flows"`
 	ConnectRoutePlans []ConnectRoutePlanView `json:"connect_route_plans"`
 	RoutePlanIssues   []RoutePlanIssueView   `json:"route_plan_issues,omitempty"`
@@ -28,6 +29,18 @@ type View struct {
 type EquivalenceView struct {
 	ProjectionOnly  bool     `json:"projection_only"`
 	CanonicalOwners []string `json:"canonical_owners"`
+}
+
+type RootView struct {
+	SourceFiles        RootSourceFiles    `json:"source_files"`
+	PrimaryEntity      *PrimaryEntityView `json:"primary_entity,omitempty"`
+	PrimaryEntityError string             `json:"primary_entity_error,omitempty"`
+}
+
+type RootSourceFiles struct {
+	Schema   string `json:"schema,omitempty"`
+	Entities string `json:"entities,omitempty"`
+	Package  string `json:"package,omitempty"`
 }
 
 type FlowView struct {
@@ -208,6 +221,7 @@ func Build(_ context.Context, source semanticview.Source, opts BuildOptions) (Vi
 		WorkflowVersion:   bundle.WorkflowVersion(),
 		ContractsRoot:     strings.TrimSpace(bundle.Paths.ContractsRoot),
 		SourceAuthority:   "projection_only_existing_contract_owners",
+		Root:              buildRoot(bundle),
 		Flows:             buildFlows(source, bundle),
 		ConnectRoutePlans: buildConnectRoutePlans(bundle, plans),
 		RoutePlanIssues:   buildRoutePlanIssues(bundle, routeIssues),
@@ -224,6 +238,23 @@ func Build(_ context.Context, source semanticview.Source, opts BuildOptions) (Vi
 		},
 	}
 	return view, nil
+}
+
+func buildRoot(bundle *runtimecontracts.WorkflowContractBundle) RootView {
+	out := RootView{
+		SourceFiles: RootSourceFiles{
+			Schema:   strings.TrimSpace(bundle.Paths.RootSchemaFile),
+			Entities: strings.TrimSpace(bundle.Paths.RootEntitiesFile),
+			Package:  strings.TrimSpace(bundle.Paths.ProjectPackageFile),
+		},
+	}
+	primary, err := bundle.ResolveRootPrimaryEntity()
+	if err != nil {
+		out.PrimaryEntityError = err.Error()
+		return out
+	}
+	out.PrimaryEntity = primaryEntityView(primary, bundle.Paths.RootEntitiesFile)
+	return out
 }
 
 func buildFlows(source semanticview.Source, bundle *runtimecontracts.WorkflowContractBundle) []FlowView {

--- a/internal/runtime/authoringview/view.go
+++ b/internal/runtime/authoringview/view.go
@@ -248,6 +248,13 @@ func buildRoot(bundle *runtimecontracts.WorkflowContractBundle) RootView {
 			Package:  strings.TrimSpace(bundle.Paths.ProjectPackageFile),
 		},
 	}
+	declared := ""
+	if bundle.RootSchema != nil {
+		declared = strings.TrimSpace(bundle.RootSchema.Entity)
+	}
+	if declared == "" && len(bundle.RootEntities) == 0 {
+		return out
+	}
 	primary, err := bundle.ResolveRootPrimaryEntity()
 	if err != nil {
 		out.PrimaryEntityError = err.Error()

--- a/internal/runtime/authoringview/view_test.go
+++ b/internal/runtime/authoringview/view_test.go
@@ -20,6 +20,10 @@ func TestBuildShowsTemplateInstanceRouteKeysAndCarries(t *testing.T) {
 	report := runtimebootverify.Run(context.Background(), source, runtimebootverify.Options{})
 	view := mustBuild(t, source, &report)
 
+	if view.Root.PrimaryEntity != nil || view.Root.PrimaryEntityError != "" {
+		t.Fatalf("root primary entity for valid no-root fixture = entity %#v error %q, want none", view.Root.PrimaryEntity, view.Root.PrimaryEntityError)
+	}
+
 	scoring := flowByID(t, view, "scoring")
 	if scoring.PrimaryEntity == nil || scoring.PrimaryEntity.Type != "validation" {
 		t.Fatalf("scoring primary entity = %#v, want validation", scoring.PrimaryEntity)

--- a/internal/runtime/authoringview/view_test.go
+++ b/internal/runtime/authoringview/view_test.go
@@ -64,6 +64,24 @@ func TestBuildShowsTemplateInstanceRouteKeysAndCarries(t *testing.T) {
 	}
 }
 
+func TestBuildShowsRootPrimaryEntity(t *testing.T) {
+	source := loadRootPrimaryEntitySource(t)
+	view := mustBuild(t, source, nil)
+
+	if view.Root.PrimaryEntity == nil {
+		t.Fatalf("root primary entity missing: %#v", view.Root)
+	}
+	if view.Root.PrimaryEntity.Type != "workspace" {
+		t.Fatalf("root primary entity type = %q, want workspace", view.Root.PrimaryEntity.Type)
+	}
+	if view.Root.PrimaryEntity.Fields["org_id"] != "text" {
+		t.Fatalf("root primary entity fields = %#v, want org_id text", view.Root.PrimaryEntity.Fields)
+	}
+	if view.Root.PrimaryEntity.SourceFile == "" || !strings.HasSuffix(view.Root.PrimaryEntity.SourceFile, "entities.yaml") {
+		t.Fatalf("root primary entity source file = %q, want entities.yaml", view.Root.PrimaryEntity.SourceFile)
+	}
+}
+
 func TestBuildShowsRouteIssueAndAuthoredDiagnosticLocation(t *testing.T) {
 	source := templateflowpilot.LoadSource(t, templateflowpilot.Options{BadConnectMapping: true})
 	report := runtimebootverify.Run(context.Background(), source, runtimebootverify.Options{})
@@ -199,6 +217,40 @@ func containsString(values []string, want string) bool {
 		}
 	}
 	return false
+}
+
+func loadRootPrimaryEntitySource(t testing.TB) semanticview.Source {
+	t.Helper()
+	root := writeRootPrimaryEntityContracts(t)
+	repo := authoringViewRepoRoot(t)
+	bundle, err := runtimecontracts.LoadWorkflowContractBundleWithOverrides(repo, root, runtimecontracts.DefaultPlatformSpecFile(repo))
+	if err != nil {
+		t.Fatalf("LoadWorkflowContractBundleWithOverrides: %v", err)
+	}
+	return semanticview.Wrap(bundle)
+}
+
+func writeRootPrimaryEntityContracts(t testing.TB) string {
+	t.Helper()
+	root := t.TempDir()
+	writeAuthoringViewTestFile(t, filepath.Join(root, "package.yaml"), `
+name: root-primary-entity
+version: "1.0.0"
+platform_version: ">=1.6.0"
+flows: []
+`)
+	writeAuthoringViewTestFile(t, filepath.Join(root, "schema.yaml"), "name: root-primary-entity\n")
+	writeAuthoringViewTestFile(t, filepath.Join(root, "policy.yaml"), "{}\n")
+	writeAuthoringViewTestFile(t, filepath.Join(root, "tools.yaml"), "{}\n")
+	writeAuthoringViewTestFile(t, filepath.Join(root, "agents.yaml"), "{}\n")
+	writeAuthoringViewTestFile(t, filepath.Join(root, "events.yaml"), "{}\n")
+	writeAuthoringViewTestFile(t, filepath.Join(root, "nodes.yaml"), "{}\n")
+	writeAuthoringViewTestFile(t, filepath.Join(root, "entities.yaml"), `
+workspace:
+  org_id: text
+  region: text
+`)
+	return root
 }
 
 func loadDuplicateNodeIDContainedOpsSource(t testing.TB) semanticview.Source {

--- a/internal/runtime/authoringview/view_test.go
+++ b/internal/runtime/authoringview/view_test.go
@@ -2,10 +2,14 @@ package authoringview
 
 import (
 	"context"
+	"os"
+	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
 	runtimebootverify "github.com/division-sh/swarm/internal/runtime/bootverify"
+	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
 	"github.com/division-sh/swarm/internal/runtime/semanticview"
 	"github.com/division-sh/swarm/internal/runtime/testfixtures/singletoncoordinatorpilot"
 	"github.com/division-sh/swarm/internal/runtime/testfixtures/templateflowpilot"
@@ -116,6 +120,25 @@ func TestBuildShowsSingletonContainedOperations(t *testing.T) {
 	}
 }
 
+func TestBuildScansFlowLocalDuplicateNodeIDsForContainedOperations(t *testing.T) {
+	source := loadDuplicateNodeIDContainedOpsSource(t)
+	view := mustBuild(t, source, nil)
+
+	for _, flowID := range []string{"alpha", "beta"} {
+		flow := flowByID(t, view, flowID)
+		op := containedOperationByTargetAndOp(t, flow, "entity.items", "set")
+		if op.NodeID != "indexer" {
+			t.Fatalf("%s contained operation node = %q, want indexer", flowID, op.NodeID)
+		}
+		if op.MapKeyType != "text" || op.MapValueType != "Item" {
+			t.Fatalf("%s contained operation = %#v, want typed map target", flowID, op)
+		}
+		if op.SourceFile == "" || !strings.HasSuffix(op.SourceFile, filepath.Join("flows", flowID, "nodes.yaml")) {
+			t.Fatalf("%s source file = %q, want flow-local nodes.yaml", flowID, op.SourceFile)
+		}
+	}
+}
+
 func mustBuild(t testing.TB, source semanticview.Source, report *runtimebootverify.Report) View {
 	t.Helper()
 	view, err := Build(context.Background(), source, BuildOptions{BootReport: report})
@@ -176,6 +199,115 @@ func containsString(values []string, want string) bool {
 		}
 	}
 	return false
+}
+
+func loadDuplicateNodeIDContainedOpsSource(t testing.TB) semanticview.Source {
+	t.Helper()
+	root := t.TempDir()
+	writeAuthoringViewTestFile(t, filepath.Join(root, "package.yaml"), `
+name: duplicate-node-contained-ops
+version: "1.0.0"
+platform_version: ">=1.6.0"
+flows:
+  - id: alpha
+    flow: alpha
+    mode: singleton
+  - id: beta
+    flow: beta
+    mode: singleton
+`)
+	writeAuthoringViewTestFile(t, filepath.Join(root, "schema.yaml"), "name: duplicate-node-contained-ops\n")
+	writeAuthoringViewTestFile(t, filepath.Join(root, "policy.yaml"), "{}\n")
+	writeAuthoringViewTestFile(t, filepath.Join(root, "tools.yaml"), "{}\n")
+	writeAuthoringViewTestFile(t, filepath.Join(root, "agents.yaml"), "{}\n")
+	writeAuthoringViewTestFile(t, filepath.Join(root, "events.yaml"), "{}\n")
+	writeAuthoringViewTestFile(t, filepath.Join(root, "nodes.yaml"), "{}\n")
+	writeDuplicateNodeIDFlow(t, root, "alpha")
+	writeDuplicateNodeIDFlow(t, root, "beta")
+
+	repo := authoringViewRepoRoot(t)
+	bundle, err := runtimecontracts.LoadWorkflowContractBundleWithOverrides(repo, root, runtimecontracts.DefaultPlatformSpecFile(repo))
+	if err != nil {
+		t.Fatalf("LoadWorkflowContractBundleWithOverrides: %v", err)
+	}
+	return semanticview.Wrap(bundle)
+}
+
+func writeDuplicateNodeIDFlow(t testing.TB, root, flowID string) {
+	t.Helper()
+	dir := filepath.Join(root, "flows", flowID)
+	writeAuthoringViewTestFile(t, filepath.Join(dir, "schema.yaml"), `
+name: `+flowID+`
+mode: singleton
+initial_state: active
+states: [active]
+pins:
+  inputs:
+    events:
+      - name: observed
+        event: observed
+  outputs:
+    events: []
+`)
+	writeAuthoringViewTestFile(t, filepath.Join(dir, "policy.yaml"), "{}\n")
+	writeAuthoringViewTestFile(t, filepath.Join(dir, "tools.yaml"), "{}\n")
+	writeAuthoringViewTestFile(t, filepath.Join(dir, "agents.yaml"), "{}\n")
+	writeAuthoringViewTestFile(t, filepath.Join(dir, "types.yaml"), `
+types:
+  Item:
+    name: text
+`)
+	writeAuthoringViewTestFile(t, filepath.Join(dir, "entities.yaml"), `
+state:
+  id: text
+  items: map[text]Item
+`)
+	writeAuthoringViewTestFile(t, filepath.Join(dir, "events.yaml"), `
+observed:
+  id: text
+  item_id: text
+  item: Item
+`)
+	writeAuthoringViewTestFile(t, filepath.Join(dir, "nodes.yaml"), `
+indexer:
+  id: indexer
+  execution_type: system_node
+  subscribes_to: [observed]
+  event_handlers:
+    observed:
+      select_entity:
+        by:
+          id: payload.id
+      data_accumulation:
+        writes:
+          - source_field: id
+            target_field: id
+          - op: set
+            target: entity.items
+            key:
+              ref: payload.item_id
+            value:
+              name: payload.item.name
+`)
+}
+
+func writeAuthoringViewTestFile(t testing.TB, path, contents string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, []byte(strings.TrimLeft(contents, "\n")), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+func authoringViewRepoRoot(t testing.TB) string {
+	t.Helper()
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("resolve repo root")
+	}
+	return filepath.Clean(filepath.Join(filepath.Dir(file), "..", "..", ".."))
 }
 
 func containsContainedField(fields []SingletonContainedFieldView, name, kind string) bool {

--- a/internal/runtime/authoringview/view_test.go
+++ b/internal/runtime/authoringview/view_test.go
@@ -1,0 +1,188 @@
+package authoringview
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	runtimebootverify "github.com/division-sh/swarm/internal/runtime/bootverify"
+	"github.com/division-sh/swarm/internal/runtime/semanticview"
+	"github.com/division-sh/swarm/internal/runtime/testfixtures/singletoncoordinatorpilot"
+	"github.com/division-sh/swarm/internal/runtime/testfixtures/templateflowpilot"
+)
+
+func TestBuildShowsTemplateInstanceRouteKeysAndCarries(t *testing.T) {
+	source := templateflowpilot.LoadSource(t, templateflowpilot.Options{})
+	report := runtimebootverify.Run(context.Background(), source, runtimebootverify.Options{})
+	view := mustBuild(t, source, &report)
+
+	scoring := flowByID(t, view, "scoring")
+	if scoring.PrimaryEntity == nil || scoring.PrimaryEntity.Type != "validation" {
+		t.Fatalf("scoring primary entity = %#v, want validation", scoring.PrimaryEntity)
+	}
+	if scoring.TemplateInstance == nil {
+		t.Fatalf("scoring template instance missing")
+	}
+	if got := strings.Join(scoring.TemplateInstance.By, ","); got != "account_id" {
+		t.Fatalf("scoring instance.by = %q, want account_id", got)
+	}
+	if scoring.TemplateInstance.OnMissing != "create" || scoring.TemplateInstance.OnConflict != "reuse" {
+		t.Fatalf("scoring instance policy = %#v, want create/reuse", scoring.TemplateInstance)
+	}
+
+	producer := flowByID(t, view, "producer")
+	output := outputPinByName(t, producer, "validation_requested")
+	if output.Key != "account_id" || !containsString(output.Carries, "account_id") {
+		t.Fatalf("producer output key/carries = %#v, want account_id carried", output)
+	}
+
+	if len(view.ConnectRoutePlans) != 1 {
+		t.Fatalf("connect route plan count = %d, want 1: %#v", len(view.ConnectRoutePlans), view.ConnectRoutePlans)
+	}
+	plan := view.ConnectRoutePlans[0]
+	if plan.Source.FlowID != "producer" || plan.Source.Pin != "validation_requested" || plan.Source.Key != "account_id" {
+		t.Fatalf("route source = %#v, want producer.validation_requested keyed by account_id", plan.Source)
+	}
+	if plan.Receiver.FlowID != "scoring" || plan.Receiver.Pin != "validation_requested" {
+		t.Fatalf("route receiver = %#v, want scoring.validation_requested", plan.Receiver)
+	}
+	if plan.ResolutionKind != "instance_key" {
+		t.Fatalf("route resolution = %q, want instance_key", plan.ResolutionKind)
+	}
+	if plan.InstanceKey == nil {
+		t.Fatalf("route instance key missing")
+	}
+	if got := strings.Join(plan.InstanceKey.Fields, ","); got != "account_id" {
+		t.Fatalf("route instance key fields = %q, want account_id", got)
+	}
+	if len(plan.InstanceKey.Mappings) != 1 || plan.InstanceKey.Mappings[0].Source != "account_id" || plan.InstanceKey.Mappings[0].Target != "account_id" || plan.InstanceKey.Mappings[0].Explicit {
+		t.Fatalf("route implicit mapping = %#v, want account_id -> account_id explicit=false", plan.InstanceKey.Mappings)
+	}
+}
+
+func TestBuildShowsRouteIssueAndAuthoredDiagnosticLocation(t *testing.T) {
+	source := templateflowpilot.LoadSource(t, templateflowpilot.Options{BadConnectMapping: true})
+	report := runtimebootverify.Run(context.Background(), source, runtimebootverify.Options{})
+	view := mustBuild(t, source, &report)
+
+	if len(view.RoutePlanIssues) != 1 {
+		t.Fatalf("route plan issue count = %d, want 1: %#v", len(view.RoutePlanIssues), view.RoutePlanIssues)
+	}
+	issue := view.RoutePlanIssues[0]
+	if issue.Failure != "route_plan_instance_key_adapter_invalid" {
+		t.Fatalf("route issue failure = %q, want route_plan_instance_key_adapter_invalid", issue.Failure)
+	}
+	if issue.AuthoredLocation == "" || !strings.HasSuffix(issue.AuthoredLocation, "package.yaml") {
+		t.Fatalf("route issue authored location = %q, want package.yaml", issue.AuthoredLocation)
+	}
+
+	diag := diagnosticByCheckID(t, view, "composition_connect_validation")
+	if diag.AuthoredLocation == "" {
+		t.Fatalf("diagnostic authored location empty: %#v", diag)
+	}
+	if !strings.Contains(diag.Message, "connect producer.validation_requested -> scoring.validation_requested") {
+		t.Fatalf("diagnostic message = %q, want connect context", diag.Message)
+	}
+}
+
+func TestBuildShowsSingletonContainedOperations(t *testing.T) {
+	source := singletoncoordinatorpilot.LoadSource(t, singletoncoordinatorpilot.Options{})
+	report := runtimebootverify.Run(context.Background(), source, runtimebootverify.Options{})
+	view := mustBuild(t, source, &report)
+
+	flow := flowByID(t, view, singletoncoordinatorpilot.FlowID)
+	if flow.SingletonCoordinator == nil {
+		t.Fatalf("singleton coordinator view missing")
+	}
+	if flow.SingletonCoordinator.PrimaryEntity != singletoncoordinatorpilot.EntityType {
+		t.Fatalf("singleton primary entity = %q, want %s", flow.SingletonCoordinator.PrimaryEntity, singletoncoordinatorpilot.EntityType)
+	}
+	if !containsContainedField(flow.SingletonCoordinator.ContainedState, "lead_index", "map") {
+		t.Fatalf("singleton contained state = %#v, want lead_index map", flow.SingletonCoordinator.ContainedState)
+	}
+	if !containsContainedField(flow.SingletonCoordinator.ContainedState, "audit_log", "list") {
+		t.Fatalf("singleton contained state = %#v, want audit_log list", flow.SingletonCoordinator.ContainedState)
+	}
+	if len(flow.ContainedOperations) < 5 {
+		t.Fatalf("contained operation count = %d, want at least 5: %#v", len(flow.ContainedOperations), flow.ContainedOperations)
+	}
+	mapSet := containedOperationByTargetAndOp(t, flow, "entity.lead_index", "set")
+	if mapSet.MapKeyType != "text" || mapSet.MapValueType != "LeadScore" || mapSet.SourceFile == "" {
+		t.Fatalf("lead_index set view = %#v, want typed map target and source file", mapSet)
+	}
+	listAppend := containedOperationByTargetAndOp(t, flow, "entity.audit_log", "append")
+	if listAppend.ListItemType != "AuditEntry" || listAppend.SourceFile == "" {
+		t.Fatalf("audit_log append view = %#v, want typed list target and source file", listAppend)
+	}
+}
+
+func mustBuild(t testing.TB, source semanticview.Source, report *runtimebootverify.Report) View {
+	t.Helper()
+	view, err := Build(context.Background(), source, BuildOptions{BootReport: report})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	return view
+}
+
+func flowByID(t testing.TB, view View, id string) FlowView {
+	t.Helper()
+	for _, flow := range view.Flows {
+		if flow.ID == id {
+			return flow
+		}
+	}
+	t.Fatalf("flow %q not found in %#v", id, view.Flows)
+	return FlowView{}
+}
+
+func outputPinByName(t testing.TB, flow FlowView, name string) OutputPinView {
+	t.Helper()
+	for _, pin := range flow.OutputPins {
+		if pin.Name == name {
+			return pin
+		}
+	}
+	t.Fatalf("output pin %q not found in %#v", name, flow.OutputPins)
+	return OutputPinView{}
+}
+
+func diagnosticByCheckID(t testing.TB, view View, checkID string) DiagnosticView {
+	t.Helper()
+	for _, diagnostic := range view.Diagnostics {
+		if diagnostic.CheckID == checkID {
+			return diagnostic
+		}
+	}
+	t.Fatalf("diagnostic %q not found in %#v", checkID, view.Diagnostics)
+	return DiagnosticView{}
+}
+
+func containedOperationByTargetAndOp(t testing.TB, flow FlowView, target, op string) ContainedOperationView {
+	t.Helper()
+	for _, operation := range flow.ContainedOperations {
+		if operation.Target == target && operation.Operation == op {
+			return operation
+		}
+	}
+	t.Fatalf("contained operation %s %s not found in %#v", op, target, flow.ContainedOperations)
+	return ContainedOperationView{}
+}
+
+func containsString(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
+}
+
+func containsContainedField(fields []SingletonContainedFieldView, name, kind string) bool {
+	for _, field := range fields {
+		if field.Name == name && field.Kind == kind {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/runtime/conformance/testdata/route_authority_drift_inventory.yaml
+++ b/internal/runtime/conformance/testdata/route_authority_drift_inventory.yaml
@@ -367,6 +367,7 @@ seam_families:
       - internal/runtime/bus/template_instance_lifecycle.go
       - internal/runtime/bus/connect_route_plan_dispatch_test.go
       - internal/runtime/bus/route_plan.go
+      - internal/runtime/authoringview/view.go
       - internal/runtime/conformance/testdata/route_authority_matrix.yaml
     search_dimensions: [connect_route_plan, route_plan, route_plan_source_reason]
     notes: >

--- a/internal/runtime/conformance/testdata/route_authority_drift_inventory.yaml
+++ b/internal/runtime/conformance/testdata/route_authority_drift_inventory.yaml
@@ -367,7 +367,6 @@ seam_families:
       - internal/runtime/bus/template_instance_lifecycle.go
       - internal/runtime/bus/connect_route_plan_dispatch_test.go
       - internal/runtime/bus/route_plan.go
-      - internal/runtime/authoringview/view.go
       - internal/runtime/conformance/testdata/route_authority_matrix.yaml
     search_dimensions: [connect_route_plan, route_plan, route_plan_source_reason]
     notes: >
@@ -382,6 +381,21 @@ seam_families:
       connect.map remains non-authoritative for that class. #1577 adds the
       connect-time template lifecycle owner that consumes the lowered instance
       key plan and creates, reuses, or fails closed before delivery rows commit.
+  - id: authoring_describe_connect_route_plan_projection
+    layer: public_projection_non_authority
+    classification: non_authoritative_observer_projection
+    paths:
+      - internal/runtime/authoringview/view.go
+    search_dimensions: [connect_route_plan]
+    invalid_authority:
+      - route authority decisions
+      - route-plan fallback repair
+      - verifier/runtime reimplementation
+    notes: >
+      The `swarm describe` authoring view consumes
+      LowerCompositionConnectRoutePlans for author-facing readback only. It is
+      projection-only and must not become canonical connect route-plan
+      authority.
   - id: route_table_resolve_role_separation
     layer: route_topology
     classification: valid_consumer

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -5757,6 +5757,27 @@ flow_model:
         typed_map_list_update_verification: '#1548'
         singleton_coordinator_contract: '#1549'
         expand_minimize_tooling: '#1551'
+      expand_minimize_tooling:
+        status: merge_bearing_supported_tooling
+        implementation_tracker: '#1551'
+        command: swarm describe
+        canonical_code_owner: internal/runtime/authoringview.Build + cmd/swarm describe
+        rule: >
+          The supported expanded authoring view is a projection over existing
+          semantic owners. It must expose inferred primary entity, template
+          instance declaration/policy, output pin `key`/`carries`, connect
+          route plans, explicit and implicit key mappings,
+          singleton/coordinator boundaries, typed contained-state operations,
+          and retired static multi-entity diagnostics without becoming a new
+          semantic owner or reimplementing verifier/runtime decisions.
+        source_location_rule: >
+          Diagnostics in the expanded view must carry check_id plus authored
+          YAML file or other stable authored location derived from contract
+          bundle source metadata.
+        non_authoritative_paths:
+        - CLI-local verifier decisions
+        - API-local verifier decisions
+        - generated expanded YAML as merge authority
     non_goals:
     - '#1538 does not implement verifier/runtime behavior.'
     - '#1538 does not migrate Empire contracts.'


### PR DESCRIPTION
## Summary

Closes #1551.

Adds a supported `swarm describe` authoring view for the flow-instance authoring model. The view is projection-only over existing semantic owners and exposes inferred primary entities, template instance policy, output `key`/`carries`, connect route plans, explicit/implicit instance key mappings, singleton coordinator boundaries, typed contained-state operations, route-plan issues, and bootverify diagnostics with authored source locations.

## Governing Refs

- `platform-spec.yaml#flow_model.flow_instance_authoring.analyzer_obligations.expand_minimize_tooling`
- `platform-spec.yaml#flow_model.flow_instance_authoring.primary_entity_model`
- `platform-spec.yaml#flow_model.flow_instance_authoring.template_instance_model`
- `platform-spec.yaml#flow_model.flow_instance_authoring.composition_model.output_pin_key_carries_contract`
- `platform-spec.yaml#flow_model.flow_instance_authoring.composition_model.connect_to_instance_route_planning`
- `platform-spec.yaml#flow_model.flow_instance_authoring.composition_model.connect_key_adapters`
- `platform-spec.yaml#flow_model.flow_instance_authoring.contained_state_model`
- `platform-spec.yaml#flow_model.flow_instance_authoring.singleton_coordinator_model`
- `platform-spec.yaml#flow_model.flow_instance_authoring.escape_hatches.static_multi_entity_flows`

## Semantic Migration

- New canonical owner: none. `internal/runtime/authoringview.Build` is explicitly projection-only and consumes existing owners.
- Old producer / reader / writer path now invalid: CLI-local/API-local verifier reimplementation and generated expanded YAML as merge authority remain non-authoritative.
- Production paths checked for surviving old behavior: `swarm describe` uses `WorkflowContractBundle`, `pinrouting.LowerCompositionConnectRoutePlans`, `entityruntime.ResolveContainedOperationTarget`, and `bootverify.Report`; no runtime delivery, verifier, or state mutation path is replaced.
- Migration complete: yes for #1551 supported describe/projection surface; no runtime semantic migration is introduced.

## Validation

- `go test ./internal/apispec ./internal/runtime/authoringview ./cmd/swarm`
- `go test ./internal/runtime/conformance`
- `go test ./...`