### PR TITLE
[agent-b][issue #1614] Project-scoped local targeting

### DIFF
--- a/cmd/swarm/agent_directive.go
+++ b/cmd/swarm/agent_directive.go
@@ -52,7 +52,7 @@ func newAgentDirectiveCommand(opts rootCommandOptions) *cobra.Command {
 	}
 	cmd.Flags().StringVar(&directiveOpts.runID, "run-id", "", "Optional explicit nonterminal run target")
 	cmd.Flags().StringVar(&directiveOpts.idempotencyKey, "idempotency-key", "", "Optional v1 API idempotency key")
-	bindCLIAPIConnectionFlags(cmd, &directiveOpts.apiOptions)
+	bindCLIAPIConnectionFlagsWithClass(cmd, &directiveOpts.apiOptions, cliAPICommandClassMutating, "swarm agent directive")
 	return cmd
 }
 

--- a/cmd/swarm/agent_replay.go
+++ b/cmd/swarm/agent_replay.go
@@ -62,7 +62,7 @@ func newAgentReplayCommand(opts rootCommandOptions) *cobra.Command {
 	}
 	cmd.Flags().StringVar(&replayOpts.eventID, "event-id", "", "Required event ID to replay")
 	cmd.Flags().StringVar(&replayOpts.idempotencyKey, "idempotency-key", "", "Optional v1 API idempotency key")
-	bindCLIAPIConnectionFlags(cmd, &replayOpts.apiOptions)
+	bindCLIAPIConnectionFlagsWithClass(cmd, &replayOpts.apiOptions, cliAPICommandClassMutating, "swarm agent replay")
 	return cmd
 }
 

--- a/cmd/swarm/agent_replay_backlog.go
+++ b/cmd/swarm/agent_replay_backlog.go
@@ -39,7 +39,7 @@ func newAgentReplayBacklogCommand(opts rootCommandOptions) *cobra.Command {
 		},
 	}
 	cmd.Flags().StringVar(&replayOpts.idempotencyKey, "idempotency-key", "", "Optional v1 API idempotency key")
-	bindCLIAPIConnectionFlags(cmd, &replayOpts.apiOptions)
+	bindCLIAPIConnectionFlagsWithClass(cmd, &replayOpts.apiOptions, cliAPICommandClassMutating, "swarm agent replay-backlog")
 	return cmd
 }
 

--- a/cmd/swarm/agent_restart.go
+++ b/cmd/swarm/agent_restart.go
@@ -38,7 +38,7 @@ func newAgentRestartCommand(opts rootCommandOptions) *cobra.Command {
 		},
 	}
 	cmd.Flags().StringVar(&restartOpts.idempotencyKey, "idempotency-key", "", "Optional v1 API idempotency key")
-	bindCLIAPIConnectionFlags(cmd, &restartOpts.apiOptions)
+	bindCLIAPIConnectionFlagsWithClass(cmd, &restartOpts.apiOptions, cliAPICommandClassMutating, "swarm agent restart")
 	return cmd
 }
 

--- a/cmd/swarm/api_consumption_boundary_test.go
+++ b/cmd/swarm/api_consumption_boundary_test.go
@@ -165,6 +165,7 @@ func TestCLIRuntimeStateCommandsRequireSharedAPITokenBeforeRequest(t *testing.T)
 		{name: "logs follow", args: []string{"logs", "--follow"}},
 		{name: "incidents", args: []string{"incidents"}},
 		{name: "agents list", args: []string{"agents", "list"}},
+		{name: "agent deliveries", args: []string{"agent", "deliveries", "agent-1"}},
 		{name: "agent view", args: []string{"agent", "view", "agent-1"}},
 		{name: "agent diagnose", args: []string{"agent", "diagnose", "agent-1"}},
 		{name: "agent restart", args: []string{"agent", "restart", "agent-1"}},
@@ -200,6 +201,11 @@ func TestCLIRuntimeStateCommandsRequireSharedAPITokenBeforeRequest(t *testing.T)
 		{name: "run connect start", args: []string{"run", "--connect", "http://192.0.2.10:1", "--event", "scan.requested", "--payload", payloadPath, "--no-follow"}},
 		{name: "run connect reattach", args: []string{"run", "--connect", "http://192.0.2.10:1", "--reattach", "run-1"}},
 		{name: "fork", args: []string{"fork", "11111111-1111-1111-1111-111111111111"}},
+		{name: "forkchat new", args: []string{"forkchat", "new", "session-1", "--turn-index", "1"}},
+		{name: "forkchat resume", args: []string{"forkchat", "resume", "fork-1", "--message", "continue"}},
+		{name: "forkchat list", args: []string{"forkchat", "list"}},
+		{name: "forkchat view", args: []string{"forkchat", "view", "fork-1"}},
+		{name: "forkchat delete", args: []string{"forkchat", "delete", "fork-1"}},
 		{name: "version server", args: []string{"version", "--server"}},
 	} {
 		t.Run(tc.name, func(t *testing.T) {

--- a/cmd/swarm/bundle.go
+++ b/cmd/swarm/bundle.go
@@ -235,7 +235,7 @@ func newBundleRegisterCommand(repoRoot string, opts rootCommandOptions) *cobra.C
 	cmd.Flags().StringVar(&registerOpts.contractsDir, "contracts", "", "Package a local contracts directory into BundleRegistrationEnvelopeV1 before calling bundle.register")
 	cmd.Flags().StringVar(&registerOpts.idempotencyKey, "idempotency-key", "", "Optional idempotency key for bundle.register")
 	bindCLIOutputFlags(cmd, &registerOpts.output)
-	bindCLIAPIConnectionFlags(cmd, &registerOpts.apiOptions)
+	bindCLIAPIConnectionFlagsWithClass(cmd, &registerOpts.apiOptions, cliAPICommandClassMutating, "swarm bundle register")
 	return cmd
 }
 
@@ -259,7 +259,7 @@ func newBundleDeleteCommand(opts rootCommandOptions) *cobra.Command {
 	cmd.Flags().BoolVar(&deleteOpts.dryRun, "dry-run", false, "Plan bundle deletion without applying destructive changes")
 	cmd.Flags().StringVar(&deleteOpts.idempotencyKey, "idempotency-key", "", "Optional idempotency key for bundle.delete")
 	bindCLIOutputFlags(cmd, &deleteOpts.output)
-	bindCLIAPIConnectionFlags(cmd, &deleteOpts.apiOptions)
+	bindCLIAPIConnectionFlagsWithClass(cmd, &deleteOpts.apiOptions, cliAPICommandClassMutating, "swarm bundle delete")
 	return cmd
 }
 

--- a/cmd/swarm/cli.go
+++ b/cmd/swarm/cli.go
@@ -59,6 +59,8 @@ func newRootCommand(ctx context.Context, repo string, out, errOut io.Writer) *co
 }
 
 func newRootCommandWithOptions(ctx context.Context, repo string, out, errOut io.Writer, opts rootCommandOptions) *cobra.Command {
+	opts = opts.ensureRootFlagState()
+	opts.repoRoot = assetCommandRepoRoot(repo)
 	cmd := &cobra.Command{
 		Use:           "swarm",
 		Short:         "Run and inspect Swarm workflows.",
@@ -73,7 +75,7 @@ func newRootCommandWithOptions(ctx context.Context, repo string, out, errOut io.
 	}
 	cmd.SetOut(out)
 	cmd.SetErr(errOut)
-	cmd.PersistentFlags().StringVar(&opts.swarmDir, "swarm-dir", opts.swarmDir, "Path to the Swarm user/global state directory")
+	cmd.PersistentFlags().Var(&trackedRootStringFlag{value: &opts.rootFlags.swarmDir, changed: &opts.rootFlags.swarmDirSet}, "swarm-dir", "Path to the Swarm user/global state directory")
 	cmd.AddCommand(
 		newServeCommand(ctx, repo, opts.runServe),
 		newRunCommand(repo, opts),
@@ -106,6 +108,32 @@ func newRootCommandWithOptions(ctx context.Context, repo string, out, errOut io.
 		newForkCommand(opts),
 	)
 	return cmd
+}
+
+type trackedRootStringFlag struct {
+	value   *string
+	changed *bool
+}
+
+func (f *trackedRootStringFlag) Set(value string) error {
+	if f.value != nil {
+		*f.value = value
+	}
+	if f.changed != nil {
+		*f.changed = true
+	}
+	return nil
+}
+
+func (f *trackedRootStringFlag) String() string {
+	if f == nil || f.value == nil {
+		return ""
+	}
+	return *f.value
+}
+
+func (f *trackedRootStringFlag) Type() string {
+	return "string"
 }
 
 func newServeCommand(ctx context.Context, repo string, runServe func(context.Context, string, serveOptions) int) *cobra.Command {
@@ -164,6 +192,7 @@ func newServeCommand(ctx context.Context, repo string, runServe func(context.Con
 			}
 			opts.StoreModeSet = cmd.Flags().Changed("store")
 			opts.WorkspaceBackendSet = cmd.Flags().Changed("workspace-backend")
+			opts.ContextNameSet = cmd.Flags().Changed("context")
 			if opts.ShutdownGrace <= 0 {
 				return fmt.Errorf("--shutdown-grace must be a positive duration")
 			}
@@ -188,6 +217,7 @@ func newServeCommand(ctx context.Context, repo string, runServe func(context.Con
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts.Output = cmd.OutOrStdout()
+			opts.SwarmDir, opts.SwarmDirSet = rootSwarmDirFlag(cmd)
 			code := runServe(ctx, assetCommandRepoRoot(repo), opts)
 			if code != 0 {
 				return commandExitError{code: code}
@@ -203,6 +233,7 @@ func newServeCommand(ctx context.Context, repo string, runServe func(context.Con
 	cmd.Flags().StringArrayVar(&opts.BundleHashes, "bundle-hash", opts.BundleHashes, "Load a persisted bundle catalog row by canonical bundle_hash; repeat to boot multiple pinned contexts")
 	cmd.Flags().StringVar(&opts.PlatformSpecPath, "platform-spec", opts.PlatformSpecPath, "Path to platform spec yaml")
 	cmd.Flags().StringVar(&opts.StoreMode, "store", opts.StoreMode, runtimeStoreBackendHelp)
+	cmd.Flags().StringVar(&opts.ContextName, "context", opts.ContextName, "Local Swarm context name to register for --dev")
 	cmd.Flags().StringVar(&opts.APIListenAddr, "api-listen-addr", opts.APIListenAddr, "HTTP bind address for API, WebSocket, health, and readiness routes")
 	cmd.Flags().StringVar(&opts.MCPListenAddr, "mcp-listen-addr", opts.MCPListenAddr, "HTTP bind address for MCP and tools routes")
 	cmd.Flags().DurationVar(&opts.ShutdownGrace, "shutdown-grace", opts.ShutdownGrace, "Time to wait for in-flight work to drain after shutdown starts")

--- a/cmd/swarm/cli_api.go
+++ b/cmd/swarm/cli_api.go
@@ -36,7 +36,13 @@ type rootCommandOptions struct {
 	// those paths have already resolved their own API endpoint semantics.
 	apiRPCEndpointOverride string
 	apiTokenFile           string
+	contextName            string
 	swarmDir               string
+	rootFlags              *rootCommandFlagState
+	repoRoot               string
+	apiCommandClass        cliAPICommandClass
+	apiCommandName         string
+	disableLocalTargeting  bool
 	httpClient             *http.Client
 	input                  io.Reader
 	stdinIsTerminal        func() bool
@@ -58,6 +64,25 @@ func defaultRootCommandOptions() rootCommandOptions {
 	}
 }
 
+type rootCommandFlagState struct {
+	swarmDir    string
+	swarmDirSet bool
+}
+
+func (opts rootCommandOptions) ensureRootFlagState() rootCommandOptions {
+	if opts.rootFlags == nil {
+		opts.rootFlags = &rootCommandFlagState{swarmDir: opts.swarmDir}
+	}
+	return opts
+}
+
+func (opts rootCommandOptions) swarmDirResolutionOptions() cliSwarmDirOptions {
+	if opts.rootFlags != nil {
+		return cliSwarmDirOptions{SwarmDir: opts.rootFlags.swarmDir, SwarmDirFlagSet: opts.rootFlags.swarmDirSet}
+	}
+	return cliSwarmDirOptions{SwarmDir: opts.swarmDir, SwarmDirFlagSet: strings.TrimSpace(opts.swarmDir) != ""}
+}
+
 func processStdinIsTerminal() bool {
 	info, err := os.Stdin.Stat()
 	return err == nil && info.Mode()&os.ModeCharDevice != 0
@@ -66,6 +91,7 @@ func processStdinIsTerminal() bool {
 type cliAPIClient struct {
 	endpoint   string
 	token      string
+	target     cliAPITargetResolution
 	httpClient *http.Client
 }
 
@@ -78,7 +104,7 @@ func newCLIAPIClient(opts rootCommandOptions) (*cliAPIClient, error) {
 	if client == nil {
 		client = http.DefaultClient
 	}
-	return &cliAPIClient{endpoint: settings.rpcEndpoint, token: settings.token, httpClient: client}, nil
+	return &cliAPIClient{endpoint: settings.rpcEndpoint, token: settings.token, target: settings.target, httpClient: client}, nil
 }
 
 type cliAPISettings struct {
@@ -86,6 +112,7 @@ type cliAPISettings struct {
 	token         string
 	tokenSource   string
 	tokenExplicit bool
+	target        cliAPITargetResolution
 }
 
 type cliAPIConfigFile struct {
@@ -122,19 +149,20 @@ func (e *cliAPIAuthConfigError) Error() string {
 }
 
 func resolveCLIAPISettings(opts rootCommandOptions) (cliAPISettings, error) {
+	opts = opts.ensureRootFlagState()
 	cfg, err := loadCLIAPIConfigFile()
 	if err != nil {
 		return cliAPISettings{}, err
 	}
-	endpoint, err := resolveCLIAPIRPCEndpoint(opts, cfg)
+	target, err := resolveCLIAPITarget(opts, cfg)
 	if err != nil {
 		return cliAPISettings{}, err
 	}
-	token, err := resolveCLIAPIToken(opts, cfg, endpoint)
+	token, err := resolveCLIAPITokenForTarget(opts, cfg, target)
 	if err != nil {
 		return cliAPISettings{}, err
 	}
-	return cliAPISettings{rpcEndpoint: endpoint, token: token.token, tokenSource: token.source, tokenExplicit: token.explicit}, nil
+	return cliAPISettings{rpcEndpoint: target.rpcEndpoint, token: token.token, tokenSource: token.source, tokenExplicit: token.explicit, target: target}, nil
 }
 
 func resolveCLIAPIRPCEndpoint(opts rootCommandOptions, cfg cliAPIConfigFile) (string, error) {

--- a/cmd/swarm/cli_api_flags.go
+++ b/cmd/swarm/cli_api_flags.go
@@ -7,12 +7,21 @@ import (
 )
 
 func bindCLIAPIConnectionFlags(cmd *cobra.Command, opts *rootCommandOptions) {
+	bindCLIAPIConnectionFlagsWithClass(cmd, opts, cliAPICommandClassReadOnly, "")
+}
+
+func bindCLIAPIConnectionFlagsWithClass(cmd *cobra.Command, opts *rootCommandOptions, class cliAPICommandClass, commandName string) {
+	if opts != nil {
+		opts.apiCommandClass = class
+		opts.apiCommandName = strings.TrimSpace(commandName)
+	}
 	cmd.Flags().StringVar(&opts.apiServer, "api-server", "", "Swarm API server base URL")
 	cmd.Flags().StringVar(&opts.apiTokenFile, "api-token-file", "", "Path to file containing the Swarm API bearer token")
+	cmd.Flags().StringVar(&opts.contextName, "context", "", "Local Swarm context descriptor name")
 }
 
 func cliAPIConnectionFlagsChanged(cmd *cobra.Command) bool {
-	return cmd.Flags().Changed("api-server") || cmd.Flags().Changed("api-token-file")
+	return cmd.Flags().Changed("api-server") || cmd.Flags().Changed("api-token-file") || cmd.Flags().Changed("context")
 }
 
 func validateCLIAPIConnectionFlagPlacement(args []string) error {
@@ -28,10 +37,14 @@ func firstCLIAPIConnectionFlagIndex(args []string) (int, string) {
 		switch {
 		case arg == "--api-server" || arg == "--api-token-file":
 			return i, arg
+		case arg == "--context":
+			return i, arg
 		case strings.HasPrefix(arg, "--api-server="):
 			return i, "--api-server"
 		case strings.HasPrefix(arg, "--api-token-file="):
 			return i, "--api-token-file"
+		case strings.HasPrefix(arg, "--context="):
+			return i, "--context"
 		}
 	}
 	return -1, ""
@@ -56,12 +69,18 @@ func cliAPIConnectionFlagAfterLeafCommand(prefix []string) bool {
 		{"bundle", "show"},
 		{"bundle", "agents"},
 		{"bundle", "register"},
+		{"bundle", "delete"},
 		{"agents", "list"},
+		{"agent", "deliveries"},
+		{"agent", "diagnose"},
 		{"agent", "view"},
 		{"agent", "restart"},
 		{"agent", "replay"},
 		{"agent", "replay-backlog"},
 		{"agent", "directive"},
+		{"conversations", "list"},
+		{"conversation", "view"},
+		{"conversation", "turn"},
 		{"entities", "list"},
 		{"entity", "view"},
 		{"entity", "aggregate"},
@@ -75,6 +94,11 @@ func cliAPIConnectionFlagAfterLeafCommand(prefix []string) bool {
 		{"control", "stop"},
 		{"control", "nuke"},
 		{"fork"},
+		{"forkchat", "new"},
+		{"forkchat", "resume"},
+		{"forkchat", "list"},
+		{"forkchat", "view"},
+		{"forkchat", "delete"},
 		{"doctor"},
 	}
 	for _, command := range leafCommands {

--- a/cmd/swarm/cli_api_flags.go
+++ b/cmd/swarm/cli_api_flags.go
@@ -100,6 +100,7 @@ func cliAPIConnectionFlagAfterLeafCommand(prefix []string) bool {
 		{"forkchat", "view"},
 		{"forkchat", "delete"},
 		{"doctor"},
+		{"serve"},
 	}
 	for _, command := range leafCommands {
 		if argsHaveCommandPrefix(prefix, command) {

--- a/cmd/swarm/cli_api_resolver_test.go
+++ b/cmd/swarm/cli_api_resolver_test.go
@@ -453,12 +453,14 @@ func TestCLIAPIConnectionFlagsSurfaceAndIsolation(t *testing.T) {
 	withFlags := []string{
 		"runs", "status", "trace", "health", "logs", "incidents",
 		"events list", "events follow", "event view", "event publish", "event replay",
-		"bundle list", "bundle show", "bundle agents", "bundle register",
-		"agents list", "agent view", "agent diagnose", "agent restart", "agent replay", "agent replay-backlog", "agent directive",
+		"bundle list", "bundle show", "bundle agents", "bundle register", "bundle delete",
+		"agents list", "agent deliveries", "agent view", "agent diagnose", "agent restart", "agent replay", "agent replay-backlog", "agent directive",
+		"conversations list", "conversation view", "conversation turn",
 		"entities list", "entity view", "entity aggregate",
 		"mailbox list", "mailbox view", "mailbox approve", "mailbox reject", "mailbox defer",
 		"control pause", "control continue", "control stop", "control nuke",
-		"fork", "version",
+		"fork", "forkchat new", "forkchat resume", "forkchat list", "forkchat view", "forkchat delete",
+		"version",
 	}
 	for _, path := range withFlags {
 		cmd := mustFindCLICommand(t, root, path)
@@ -468,11 +470,14 @@ func TestCLIAPIConnectionFlagsSurfaceAndIsolation(t *testing.T) {
 		if cmd.Flags().Lookup("api-token-file") == nil {
 			t.Fatalf("%s missing --api-token-file", path)
 		}
+		if cmd.Flags().Lookup("context") == nil {
+			t.Fatalf("%s missing --context", path)
+		}
 	}
 
 	withoutFlags := []string{
 		"", "serve", "verify", "completion", "run",
-		"events", "event", "bundle", "agents", "agent", "entities", "entity", "mailbox", "control",
+		"events", "event", "bundle", "agents", "agent", "conversations", "conversation", "entities", "entity", "mailbox", "control", "forkchat",
 		"investigate", "investigate health",
 	}
 	for _, path := range withoutFlags {
@@ -617,6 +622,213 @@ func TestCLIAPIConfigDrivesRuntimeStateCommand(t *testing.T) {
 	}
 }
 
+func TestCLIAPIProjectContextOutranksSelectedGlobal(t *testing.T) {
+	isolateCLIAPIConfigEnv(t)
+	project := writeCLIAPIProjectFixture(t)
+	swarmDir := t.TempDir()
+	projectServer := startCLIAPIRuntimeIdentityServer(t, "runtime-project")
+	globalServer := startCLIAPIRuntimeIdentityServer(t, "runtime-global")
+	registry := newLocalContextRegistry(swarmDir)
+	writeCLIAPITestContext(t, registry, "global", "runtime-global", globalServer.URL, "")
+	writeCLIAPITestContext(t, registry, localProjectContextName(project.canonicalRoot), "runtime-project", projectServer.URL, project.canonicalRoot)
+	if err := registry.SetCurrent("global"); err != nil {
+		t.Fatalf("set current: %v", err)
+	}
+
+	client, err := newCLIAPIClient(rootCommandOptions{
+		repoRoot: project.root,
+		rootFlags: &rootCommandFlagState{
+			swarmDir:    swarmDir,
+			swarmDirSet: true,
+		},
+	})
+	if err != nil {
+		t.Fatalf("newCLIAPIClient: %v", err)
+	}
+	if want := projectServer.URL + "/v1/rpc"; client.endpoint != want {
+		t.Fatalf("endpoint = %q, want project endpoint %q", client.endpoint, want)
+	}
+	if client.target.source != "project context" || client.target.projectRoot != project.canonicalRoot {
+		t.Fatalf("target = %#v, want project context for %s", client.target, project.canonicalRoot)
+	}
+}
+
+func TestCLIAPIExplicitAPIServerAndContextPrecedence(t *testing.T) {
+	isolateCLIAPIConfigEnv(t)
+	project := writeCLIAPIProjectFixture(t)
+	swarmDir := t.TempDir()
+	projectServer := startCLIAPIRuntimeIdentityServer(t, "runtime-project")
+	explicitContextServer := startCLIAPIRuntimeIdentityServer(t, "runtime-explicit")
+	apiServer := startCLIAPIRuntimeIdentityServer(t, "runtime-api-server")
+	registry := newLocalContextRegistry(swarmDir)
+	writeCLIAPITestContext(t, registry, localProjectContextName(project.canonicalRoot), "runtime-project", projectServer.URL, project.canonicalRoot)
+	writeCLIAPITestContext(t, registry, "chosen", "runtime-explicit", explicitContextServer.URL, "")
+
+	client, err := newCLIAPIClient(rootCommandOptions{
+		repoRoot:    project.root,
+		apiServer:   apiServer.URL,
+		contextName: "chosen",
+		rootFlags: &rootCommandFlagState{
+			swarmDir:    swarmDir,
+			swarmDirSet: true,
+		},
+	})
+	if err != nil {
+		t.Fatalf("newCLIAPIClient api-server: %v", err)
+	}
+	if want := apiServer.URL + "/v1/rpc"; client.endpoint != want {
+		t.Fatalf("api-server endpoint = %q, want %q", client.endpoint, want)
+	}
+	if client.target.source != "--api-server" {
+		t.Fatalf("api-server target source = %q", client.target.source)
+	}
+
+	client, err = newCLIAPIClient(rootCommandOptions{
+		repoRoot:    project.root,
+		contextName: "chosen",
+		rootFlags: &rootCommandFlagState{
+			swarmDir:    swarmDir,
+			swarmDirSet: true,
+		},
+	})
+	if err != nil {
+		t.Fatalf("newCLIAPIClient context: %v", err)
+	}
+	if want := explicitContextServer.URL + "/v1/rpc"; client.endpoint != want {
+		t.Fatalf("context endpoint = %q, want %q", client.endpoint, want)
+	}
+	if client.target.source != "--context" || client.target.contextName != "chosen" {
+		t.Fatalf("context target = %#v", client.target)
+	}
+}
+
+func TestCLIAPIProjectContextFailureClassesFailClosed(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		setup     func(t *testing.T, registry localContextRegistry, project cliAPITestProject)
+		wantError string
+	}{
+		{
+			name: "stale descriptor",
+			setup: func(t *testing.T, registry localContextRegistry, project cliAPITestProject) {
+				writeCLIAPITestContext(t, registry, "stale", "runtime-stale", "http://127.0.0.1:1", project.canonicalRoot)
+			},
+			wantError: "project context",
+		},
+		{
+			name: "identity mismatch",
+			setup: func(t *testing.T, registry localContextRegistry, project cliAPITestProject) {
+				server := startCLIAPIRuntimeIdentityServer(t, "runtime-live")
+				writeCLIAPITestContext(t, registry, "mismatch", "runtime-descriptor", server.URL, project.canonicalRoot)
+			},
+			wantError: "identity_mismatch",
+		},
+		{
+			name: "multiple live",
+			setup: func(t *testing.T, registry localContextRegistry, project cliAPITestProject) {
+				a := startCLIAPIRuntimeIdentityServer(t, "runtime-a")
+				b := startCLIAPIRuntimeIdentityServer(t, "runtime-b")
+				writeCLIAPITestContext(t, registry, "a", "runtime-a", a.URL, project.canonicalRoot)
+				writeCLIAPITestContext(t, registry, "b", "runtime-b", b.URL, project.canonicalRoot)
+			},
+			wantError: "multiple live project contexts",
+		},
+		{
+			name: "corrupt descriptor",
+			setup: func(t *testing.T, registry localContextRegistry, project cliAPITestProject) {
+				path, err := registry.descriptorPath("corrupt")
+				if err != nil {
+					t.Fatalf("descriptor path: %v", err)
+				}
+				if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+					t.Fatalf("mkdir: %v", err)
+				}
+				if err := os.WriteFile(path, []byte(`{bad-json`), 0o600); err != nil {
+					t.Fatalf("write corrupt descriptor: %v", err)
+				}
+			},
+			wantError: "corrupt_descriptor",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			isolateCLIAPIConfigEnv(t)
+			project := writeCLIAPIProjectFixture(t)
+			swarmDir := t.TempDir()
+			registry := newLocalContextRegistry(swarmDir)
+			tc.setup(t, registry, project)
+
+			_, err := newCLIAPIClient(rootCommandOptions{
+				repoRoot: project.root,
+				rootFlags: &rootCommandFlagState{
+					swarmDir:    swarmDir,
+					swarmDirSet: true,
+				},
+			})
+			if err == nil {
+				t.Fatal("newCLIAPIClient returned nil error")
+			}
+			if !strings.Contains(err.Error(), tc.wantError) {
+				t.Fatalf("err = %q, want %q", err.Error(), tc.wantError)
+			}
+		})
+	}
+}
+
+func TestCLIAPIMutatingCommandDoesNotFallThroughFromProjectWithoutContext(t *testing.T) {
+	isolateCLIAPIConfigEnv(t)
+	project := writeCLIAPIProjectFixture(t)
+	swarmDir := t.TempDir()
+	globalServer := startCLIAPIRuntimeIdentityServer(t, "runtime-global")
+	registry := newLocalContextRegistry(swarmDir)
+	writeCLIAPITestContext(t, registry, "global", "runtime-global", globalServer.URL, "")
+	if err := registry.SetCurrent("global"); err != nil {
+		t.Fatalf("set current: %v", err)
+	}
+
+	_, err := newCLIAPIClient(rootCommandOptions{
+		repoRoot:        project.root,
+		apiCommandClass: cliAPICommandClassMutating,
+		rootFlags: &rootCommandFlagState{
+			swarmDir:    swarmDir,
+			swarmDirSet: true,
+		},
+	})
+	if err == nil {
+		t.Fatal("newCLIAPIClient returned nil error")
+	}
+	if !strings.Contains(err.Error(), "no live project context") {
+		t.Fatalf("err = %q, want no live project context", err.Error())
+	}
+}
+
+func TestCLIAPIProjectContextUsesRealpathForSymlinkedRoot(t *testing.T) {
+	isolateCLIAPIConfigEnv(t)
+	project := writeCLIAPIProjectFixture(t)
+	parent := t.TempDir()
+	link := filepath.Join(parent, "link-project")
+	if err := os.Symlink(project.root, link); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+	swarmDir := t.TempDir()
+	server := startCLIAPIRuntimeIdentityServer(t, "runtime-project")
+	registry := newLocalContextRegistry(swarmDir)
+	writeCLIAPITestContext(t, registry, localProjectContextName(project.canonicalRoot), "runtime-project", server.URL, project.canonicalRoot)
+
+	client, err := newCLIAPIClient(rootCommandOptions{
+		repoRoot: link,
+		rootFlags: &rootCommandFlagState{
+			swarmDir:    swarmDir,
+			swarmDirSet: true,
+		},
+	})
+	if err != nil {
+		t.Fatalf("newCLIAPIClient: %v", err)
+	}
+	if want := server.URL + "/v1/rpc"; client.endpoint != want {
+		t.Fatalf("endpoint = %q, want %q", client.endpoint, want)
+	}
+}
+
 func TestEndpointShapedAPIServerRejectedBeforeRequest(t *testing.T) {
 	for _, tc := range []struct {
 		name  string
@@ -747,6 +959,75 @@ func TestAPIConnectionFlagsRejectedOnNonAPISurfaces(t *testing.T) {
 	}
 }
 
+type cliAPITestProject struct {
+	root          string
+	contracts     string
+	canonicalRoot string
+}
+
+func writeCLIAPIProjectFixture(t *testing.T) cliAPITestProject {
+	t.Helper()
+	root := t.TempDir()
+	contracts := filepath.Join(root, "contracts")
+	if err := os.MkdirAll(contracts, 0o755); err != nil {
+		t.Fatalf("mkdir contracts: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(contracts, "package.yaml"), []byte("name: test\nversion: 1.0.0\n"), 0o600); err != nil {
+		t.Fatalf("write package: %v", err)
+	}
+	canonical, status := canonicalizeDoctorTargetPath(root)
+	if status != "resolved" {
+		t.Fatalf("canonicalize project root status = %q", status)
+	}
+	return cliAPITestProject{root: root, contracts: contracts, canonicalRoot: canonical}
+}
+
+func startCLIAPIRuntimeIdentityServer(t *testing.T, runtimeID string) *httptest.Server {
+	t.Helper()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req jsonRPCRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer "+apiv1.DefaultLoopbackAPIToken {
+			t.Fatalf("Authorization = %q, want built-in loopback bearer", got)
+		}
+		switch req.Method {
+		case "runtime.identity":
+			writeJSONRPCResult(t, w, req.ID, map[string]any{
+				"runtime_instance_id":  runtimeID,
+				"started_at":           "2026-07-02T00:00:00Z",
+				"api_version":          "v1",
+				"supported_transports": []string{"tcp"},
+			})
+		case "run.list":
+			writeJSONRPCResult(t, w, req.ID, map[string]any{"runs": []any{}})
+		default:
+			writeJSONRPCResult(t, w, req.ID, map[string]any{})
+		}
+	}))
+	t.Cleanup(server.Close)
+	return server
+}
+
+func writeCLIAPITestContext(t *testing.T, registry localContextRegistry, name, runtimeID, apiServer, projectRoot string) {
+	t.Helper()
+	now := localContextTimestamp()
+	if err := registry.WriteDescriptor(localContextDescriptor{
+		Version:           localContextDescriptorVersion,
+		Name:              name,
+		RuntimeInstanceID: runtimeID,
+		Transport:         localContextTransportTCP,
+		APIServer:         apiServer,
+		Auth:              localContextDescriptorAuth{Mode: localContextAuthBuiltinLoopback},
+		ProjectRoot:       projectRoot,
+		CreatedAt:         now,
+		UpdatedAt:         now,
+	}); err != nil {
+		t.Fatalf("write context %s: %v", name, err)
+	}
+}
+
 func isolateCLIAPIConfigEnv(t *testing.T) {
 	t.Helper()
 	t.Setenv("SWARM_CONFIG", "")
@@ -758,6 +1039,7 @@ func isolateCLIAPIConfigEnv(t *testing.T) {
 	t.Setenv("SWARM_CONTRACTS_PATH", "")
 	t.Setenv("SWARM_CONTRACTS_DIR", "")
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("HOME", t.TempDir())
 }
 
 func writeCLIAPITokenFile(t *testing.T, token string) string {

--- a/cmd/swarm/cli_api_resolver_test.go
+++ b/cmd/swarm/cli_api_resolver_test.go
@@ -488,6 +488,33 @@ func TestCLIAPIConnectionFlagsSurfaceAndIsolation(t *testing.T) {
 	}
 }
 
+func TestServeContextFlagPassesRootPrevalidation(t *testing.T) {
+	isolateCLIAPIConfigEnv(t)
+	var stdout, stderr bytes.Buffer
+	called := false
+	var got serveOptions
+	opts := defaultRootCommandOptions()
+	opts.runServe = func(_ context.Context, _ string, serveOpts serveOptions) int {
+		called = true
+		got = serveOpts
+		return 0
+	}
+
+	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"serve", "--dev", "--context", "named"}, &stdout, &stderr, opts)
+	if code != 0 {
+		t.Fatalf("serve code = %d, want 0 stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if !called {
+		t.Fatal("serve runner was not called")
+	}
+	if got.ContextName != "named" || !got.ContextNameSet {
+		t.Fatalf("serve context = %q set=%v, want named/set", got.ContextName, got.ContextNameSet)
+	}
+	if strings.Contains(stderr.String(), "unknown flag: --context") {
+		t.Fatalf("serve context flag was rejected by prevalidation: %s", stderr.String())
+	}
+}
+
 func TestAPIConnectionFlagsDriveRuntimeStateCommand(t *testing.T) {
 	isolateCLIAPIConfigEnv(t)
 	tokenFile := writeCLIAPITokenFile(t, "flag-token")
@@ -732,6 +759,15 @@ func TestCLIAPIProjectContextFailureClassesFailClosed(t *testing.T) {
 				writeCLIAPITestContext(t, registry, "b", "runtime-b", b.URL, project.canonicalRoot)
 			},
 			wantError: "multiple live project contexts",
+		},
+		{
+			name: "live plus stale",
+			setup: func(t *testing.T, registry localContextRegistry, project cliAPITestProject) {
+				server := startCLIAPIRuntimeIdentityServer(t, "runtime-live")
+				writeCLIAPITestContext(t, registry, "live", "runtime-live", server.URL, project.canonicalRoot)
+				writeCLIAPITestContext(t, registry, "stale", "runtime-stale", "http://127.0.0.1:1", project.canonicalRoot)
+			},
+			wantError: "no_server",
 		},
 		{
 			name: "corrupt descriptor",

--- a/cmd/swarm/cli_target_resolution.go
+++ b/cmd/swarm/cli_target_resolution.go
@@ -97,7 +97,7 @@ func resolveCLIAPIProjectTarget(opts rootCommandOptions, cfg cliAPIConfigFile, p
 		}
 	}
 	switch {
-	case len(okEntries) == 1:
+	case len(okEntries) == 1 && len(entries) == 1:
 		target, err := cliAPITargetFromDescriptor(okEntries[0], "project context")
 		if err != nil {
 			return cliAPITargetResolution{}, err

--- a/cmd/swarm/cli_target_resolution.go
+++ b/cmd/swarm/cli_target_resolution.go
@@ -1,0 +1,272 @@
+package main
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/division-sh/swarm/internal/apiv1"
+)
+
+type cliAPICommandClass string
+
+const (
+	cliAPICommandClassReadOnly         cliAPICommandClass = "read_only_inspection"
+	cliAPICommandClassMutating         cliAPICommandClass = "mutating_runtime_state"
+	cliAPICommandClassControl          cliAPICommandClass = "control_destructive"
+	cliAPICommandClassTargetDiagnostic cliAPICommandClass = "target_diagnostic"
+)
+
+type cliAPITargetResolution struct {
+	rpcEndpoint string
+	source      string
+	contextName string
+	projectRoot string
+	descriptor  *localContextDescriptor
+}
+
+type cliProjectResolution struct {
+	contractsPath        string
+	projectRoot          string
+	canonicalProjectRoot string
+}
+
+func resolveCLIAPITarget(opts rootCommandOptions, cfg cliAPIConfigFile) (cliAPITargetResolution, error) {
+	if endpoint := strings.TrimSpace(opts.apiRPCEndpointOverride); endpoint != "" {
+		rpc, err := normalizeCLIAPIRPCEndpoint(endpoint, "internal API endpoint")
+		return cliAPITargetResolution{rpcEndpoint: rpc, source: "internal API endpoint"}, err
+	}
+	if server := strings.TrimSpace(opts.apiServer); server != "" {
+		rpc, err := cliAPIRPCEndpointFromServer(server, "--api-server")
+		return cliAPITargetResolution{rpcEndpoint: rpc, source: "--api-server"}, err
+	}
+	if contextName := strings.TrimSpace(opts.contextName); contextName != "" {
+		return resolveCLIAPIExplicitContextTarget(opts, cfg, contextName)
+	}
+	if server := strings.TrimSpace(os.Getenv("SWARM_API_SERVER")); server != "" {
+		rpc, err := cliAPIRPCEndpointFromServer(server, "SWARM_API_SERVER")
+		return cliAPITargetResolution{rpcEndpoint: rpc, source: "SWARM_API_SERVER"}, err
+	}
+	if server := strings.TrimSpace(cfg.APIServer); server != "" {
+		rpc, err := cliAPIRPCEndpointFromServer(server, "config api_server")
+		return cliAPITargetResolution{rpcEndpoint: rpc, source: "config api_server"}, err
+	}
+	if !opts.disableLocalTargeting {
+		if project, ok := resolveCLIAPIProject(opts, cfg); ok {
+			return resolveCLIAPIProjectTarget(opts, cfg, project)
+		}
+	}
+	return resolveCLIAPISelectedOrDefaultTarget(opts, cfg)
+}
+
+func resolveCLIAPIExplicitContextTarget(opts rootCommandOptions, cfg cliAPIConfigFile, contextName string) (cliAPITargetResolution, error) {
+	registry, err := cliAPILocalContextRegistry(opts, cfg)
+	if err != nil {
+		return cliAPITargetResolution{}, err
+	}
+	entry, err := registry.ReadDescriptor(contextName)
+	if err != nil {
+		return cliAPITargetResolution{}, err
+	}
+	entry = validateLocalContextEntry(context.Background(), entry, cliRuntimeIdentityCaller{httpClient: opts.httpClient})
+	if entry.Status != localContextStatusOK {
+		return cliAPITargetResolution{}, cliAPIContextResolutionError("explicit context", entry)
+	}
+	return cliAPITargetFromDescriptor(entry, "--context")
+}
+
+func resolveCLIAPIProjectTarget(opts rootCommandOptions, cfg cliAPIConfigFile, project cliProjectResolution) (cliAPITargetResolution, error) {
+	registry, err := cliAPILocalContextRegistry(opts, cfg)
+	if err != nil {
+		return cliAPITargetResolution{}, err
+	}
+	entries, err := registry.ProjectEntries(context.Background(), project.canonicalProjectRoot, cliRuntimeIdentityCaller{httpClient: opts.httpClient})
+	if err != nil {
+		return cliAPITargetResolution{}, &cliAPIValidationError{message: fmt.Sprintf("inspect project contexts: %v", err)}
+	}
+	okEntries := make([]localContextEntry, 0, len(entries))
+	for _, entry := range entries {
+		if entry.Status == localContextStatusOK {
+			okEntries = append(okEntries, entry)
+		}
+	}
+	switch {
+	case len(okEntries) == 1:
+		target, err := cliAPITargetFromDescriptor(okEntries[0], "project context")
+		if err != nil {
+			return cliAPITargetResolution{}, err
+		}
+		target.projectRoot = project.canonicalProjectRoot
+		return target, nil
+	case len(okEntries) > 1:
+		return cliAPITargetResolution{}, &cliAPIValidationError{message: fmt.Sprintf("multiple live project contexts for %s; pass --context to choose one", project.canonicalProjectRoot)}
+	case len(entries) > 0:
+		return cliAPITargetResolution{}, cliAPIProjectContextError(project, entries)
+	case !cliAPICommandClassAllowsProjectlessFallthrough(opts.apiCommandClass):
+		commandClass := opts.apiCommandClass
+		if commandClass == "" {
+			commandClass = cliAPICommandClassMutating
+		}
+		return cliAPITargetResolution{}, &cliAPIValidationError{message: fmt.Sprintf("no live project context for %s; refusing %s command without explicit --context or --api-server; start `swarm serve --dev` for this project or choose a target explicitly", project.canonicalProjectRoot, commandClass)}
+	default:
+		return resolveCLIAPISelectedOrDefaultTarget(opts, cfg)
+	}
+}
+
+func resolveCLIAPISelectedOrDefaultTarget(opts rootCommandOptions, cfg cliAPIConfigFile) (cliAPITargetResolution, error) {
+	registry, err := cliAPILocalContextRegistry(opts, cfg)
+	if err != nil {
+		return cliAPITargetResolution{}, err
+	}
+	report, err := registry.Inspect(context.Background(), cliRuntimeIdentityCaller{httpClient: opts.httpClient})
+	if err != nil {
+		return cliAPITargetResolution{}, err
+	}
+	if report.Current != nil {
+		if report.Current.Status != localContextStatusOK {
+			return cliAPITargetResolution{}, cliAPIContextResolutionError("selected context", *report.Current)
+		}
+		return cliAPITargetFromDescriptor(*report.Current, "selected context")
+	}
+	if report.Status != "" && report.Status != "empty" && report.Status != "no_current" && report.Status != localContextStatusOK {
+		return cliAPITargetResolution{}, &cliAPIValidationError{message: fmt.Sprintf("local context registry is %s: %s", report.Status, report.Detail)}
+	}
+	rpc, err := cliAPIRPCEndpointFromServer(defaultCLIAPIServer, "built-in loopback default")
+	return cliAPITargetResolution{rpcEndpoint: rpc, source: "built-in loopback default"}, err
+}
+
+func cliAPILocalContextRegistry(opts rootCommandOptions, cfg cliAPIConfigFile) (localContextRegistry, error) {
+	swarmDir, err := resolveCLISwarmDirFromConfig(opts.swarmDirResolutionOptions(), cfg)
+	if err != nil {
+		return localContextRegistry{}, err
+	}
+	return newLocalContextRegistry(swarmDir.Path), nil
+}
+
+func resolveCLIAPIProject(opts rootCommandOptions, cfg cliAPIConfigFile) (cliProjectResolution, bool) {
+	contractsPath := firstNonEmpty(
+		os.Getenv(cliContractsPathEnv),
+		cfg.ContractsPath,
+		discoverRepoContractsPath(opts.repoRoot),
+	)
+	if strings.TrimSpace(contractsPath) == "" {
+		return cliProjectResolution{}, false
+	}
+	contractsPath = resolvePath(opts.repoRoot, contractsPath)
+	projectRoot := inferProjectRootFromContractsPath(contractsPath)
+	canonical, _ := canonicalizeDoctorTargetPath(projectRoot)
+	if strings.TrimSpace(canonical) == "" {
+		return cliProjectResolution{}, false
+	}
+	return cliProjectResolution{
+		contractsPath:        filepath.Clean(contractsPath),
+		projectRoot:          filepath.Clean(projectRoot),
+		canonicalProjectRoot: filepath.Clean(canonical),
+	}, true
+}
+
+func cliAPITargetFromDescriptor(entry localContextEntry, source string) (cliAPITargetResolution, error) {
+	rpc, err := cliAPIRPCEndpointFromServer(entry.Descriptor.APIServer, "descriptor api_server")
+	if err != nil {
+		return cliAPITargetResolution{}, err
+	}
+	desc := entry.Descriptor
+	return cliAPITargetResolution{
+		rpcEndpoint: rpc,
+		source:      source,
+		contextName: desc.Name,
+		projectRoot: desc.ProjectRoot,
+		descriptor:  &desc,
+	}, nil
+}
+
+func resolveCLIAPITokenForTarget(opts rootCommandOptions, cfg cliAPIConfigFile, target cliAPITargetResolution) (cliAPITokenResolution, error) {
+	if target.descriptor == nil {
+		return resolveCLIAPIToken(opts, cfg, target.rpcEndpoint)
+	}
+	if tokenFile := strings.TrimSpace(opts.apiTokenFile); tokenFile != "" {
+		return readCLIAPIExplicitTokenFile(tokenFile, "--api-token-file")
+	}
+	if token := strings.TrimSpace(os.Getenv("SWARM_API_TOKEN")); token != "" {
+		return cliAPITokenResolution{token: token, source: string(apiv1.AuthTokenSourceEnvironment), explicit: true}, nil
+	}
+	if tokenFile := strings.TrimSpace(os.Getenv("SWARM_API_TOKEN_FILE")); tokenFile != "" {
+		return readCLIAPIExplicitTokenFile(tokenFile, "SWARM_API_TOKEN_FILE")
+	}
+	if tokenFile := strings.TrimSpace(cfg.APITokenFile); tokenFile != "" {
+		return readCLIAPIExplicitTokenFile(tokenFile, "config api_token_file")
+	}
+	token, err := localContextDescriptorToken(*target.descriptor, target.rpcEndpoint)
+	if err != nil {
+		return cliAPITokenResolution{}, err
+	}
+	return cliAPITokenResolution{token: token, source: "context descriptor " + target.descriptor.Auth.Mode}, nil
+}
+
+func cliAPICommandClassAllowsProjectlessFallthrough(class cliAPICommandClass) bool {
+	switch class {
+	case "", cliAPICommandClassReadOnly, cliAPICommandClassTargetDiagnostic:
+		return true
+	default:
+		return false
+	}
+}
+
+func cliAPIContextResolutionError(prefix string, entry localContextEntry) error {
+	name := strings.TrimSpace(entry.Descriptor.Name)
+	if name == "" {
+		name = "<unknown>"
+	}
+	detail := strings.TrimSpace(entry.Detail)
+	if detail != "" {
+		detail = ": " + detail
+	}
+	return &cliAPIValidationError{message: fmt.Sprintf("%s %s is not usable (%s)%s; run `swarm context prune` or pass --context/--api-server explicitly", prefix, name, entry.Status, detail)}
+}
+
+func cliAPIProjectContextError(project cliProjectResolution, entries []localContextEntry) error {
+	parts := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		name := strings.TrimSpace(entry.Descriptor.Name)
+		if name == "" {
+			name = "<unknown>"
+		}
+		parts = append(parts, fmt.Sprintf("%s=%s", name, entry.Status))
+	}
+	return &cliAPIValidationError{message: fmt.Sprintf("project context for %s is not usable (%s); run `swarm context prune` or pass --context/--api-server explicitly", project.canonicalProjectRoot, strings.Join(parts, ", "))}
+}
+
+func localProjectContextName(canonicalProjectRoot string) string {
+	base := filepath.Base(filepath.Clean(canonicalProjectRoot))
+	base = sanitizeLocalContextNameComponent(base)
+	if base == "" || base == "." || base == string(filepath.Separator) {
+		base = "project"
+	}
+	sum := sha256.Sum256([]byte(filepath.Clean(canonicalProjectRoot)))
+	return fmt.Sprintf("%s-%s", base, hex.EncodeToString(sum[:])[:12])
+}
+
+var localContextNameComponentRe = regexp.MustCompile(`[^A-Za-z0-9._-]+`)
+
+func sanitizeLocalContextNameComponent(raw string) string {
+	out := localContextNameComponentRe.ReplaceAllString(strings.TrimSpace(raw), "-")
+	out = strings.Trim(out, "-._")
+	if out == "" {
+		return ""
+	}
+	if len(out) > 40 {
+		out = out[:40]
+		out = strings.Trim(out, "-._")
+	}
+	return out
+}
+
+func localContextTimestamp() string {
+	return time.Now().UTC().Format(time.RFC3339Nano)
+}

--- a/cmd/swarm/control_mailbox.go
+++ b/cmd/swarm/control_mailbox.go
@@ -224,7 +224,7 @@ func newMailboxApproveCommand(opts rootCommandOptions) *cobra.Command {
 	cmd.Flags().StringVar(&actionOpts.idempotencyKey, "idempotency-key", "", "Optional v1 API idempotency key")
 	cmd.Flags().StringVar(&actionOpts.decisionPayloadFile, "decision-payload", "", "Read optional approval event JSON object from file")
 	cmd.Flags().StringVar(&actionOpts.decisionPayloadJSON, "decision-payload-json", "", "Optional JSON object attached to the approval event")
-	bindCLIAPIConnectionFlags(cmd, &actionOpts.apiOptions)
+	bindCLIAPIConnectionFlagsWithClass(cmd, &actionOpts.apiOptions, cliAPICommandClassMutating, "swarm mailbox approve")
 	return cmd
 }
 
@@ -244,7 +244,7 @@ func newMailboxRejectCommand(opts rootCommandOptions) *cobra.Command {
 	}
 	cmd.Flags().StringVar(&actionOpts.reason, "reason", "", "Required rejection reason")
 	cmd.Flags().StringVar(&actionOpts.idempotencyKey, "idempotency-key", "", "Optional v1 API idempotency key")
-	bindCLIAPIConnectionFlags(cmd, &actionOpts.apiOptions)
+	bindCLIAPIConnectionFlagsWithClass(cmd, &actionOpts.apiOptions, cliAPICommandClassMutating, "swarm mailbox reject")
 	return cmd
 }
 
@@ -264,7 +264,7 @@ func newMailboxDeferCommand(opts rootCommandOptions) *cobra.Command {
 	}
 	cmd.Flags().StringVar(&actionOpts.until, "until", "", "Required RFC3339 timestamp")
 	cmd.Flags().StringVar(&actionOpts.idempotencyKey, "idempotency-key", "", "Optional v1 API idempotency key")
-	bindCLIAPIConnectionFlags(cmd, &actionOpts.apiOptions)
+	bindCLIAPIConnectionFlagsWithClass(cmd, &actionOpts.apiOptions, cliAPICommandClassMutating, "swarm mailbox defer")
 	return cmd
 }
 

--- a/cmd/swarm/control_nuke.go
+++ b/cmd/swarm/control_nuke.go
@@ -132,7 +132,7 @@ func newControlNukeCommand(opts rootCommandOptions) *cobra.Command {
 	cmd.Flags().BoolVarP(&nukeOpts.yes, "yes", "y", false, "Skip the destructive confirmation prompt")
 	cmd.Flags().BoolVar(&nukeOpts.dryRun, "dry-run", false, "Preview the destructive reset without applying it")
 	cmd.Flags().StringVar(&nukeOpts.idempotencyKey, "idempotency-key", "", "Optional v1 API idempotency key")
-	bindCLIAPIConnectionFlags(cmd, &nukeOpts.apiOptions)
+	bindCLIAPIConnectionFlagsWithClass(cmd, &nukeOpts.apiOptions, cliAPICommandClassControl, "swarm control nuke")
 	return cmd
 }
 

--- a/cmd/swarm/control_run.go
+++ b/cmd/swarm/control_run.go
@@ -91,7 +91,7 @@ func newControlRunCommand(opts controlRunCommandOptions) *cobra.Command {
 		cmd.Flags().BoolVar(&cmdOpts.yes, "yes", false, "Skip the stop-all confirmation prompt")
 	}
 	cmd.Flags().StringVar(&cmdOpts.idempotencyKey, "idempotency-key", "", "Optional v1 API idempotency key")
-	bindCLIAPIConnectionFlags(cmd, &cmdOpts.apiOptions)
+	bindCLIAPIConnectionFlagsWithClass(cmd, &cmdOpts.apiOptions, cliAPICommandClassControl, "swarm control "+opts.action)
 	return cmd
 }
 

--- a/cmd/swarm/conversations.go
+++ b/cmd/swarm/conversations.go
@@ -185,6 +185,7 @@ func newConversationsListCommand(opts rootCommandOptions) *cobra.Command {
 	cmd.Flags().StringVar(&listOpts.runID, "run-id", "", "Filter by run id")
 	cmd.Flags().IntVar(&listOpts.limit, "limit", 0, "Optional page size, 1-500")
 	cmd.Flags().StringVar(&listOpts.cursor, "cursor", "", "Pagination cursor")
+	bindCLIAPIConnectionFlags(cmd, &listOpts.apiOptions)
 	bindCLIOutputFlags(cmd, &listOpts.output)
 	bindCLILoggingFlags(cmd, &listOpts.logging)
 	return cmd
@@ -206,6 +207,7 @@ func newConversationViewCommand(opts rootCommandOptions) *cobra.Command {
 			return runConversationViewCommand(cmd.Context(), cmd.OutOrStdout(), cmd.ErrOrStderr(), viewOpts, args[0])
 		},
 	}
+	bindCLIAPIConnectionFlags(cmd, &viewOpts.apiOptions)
 	bindCLIOutputFlags(cmd, &viewOpts.output)
 	bindCLILoggingFlags(cmd, &viewOpts.logging)
 	return cmd
@@ -227,6 +229,7 @@ func newConversationTurnCommand(opts rootCommandOptions) *cobra.Command {
 			return runConversationTurnCommand(cmd.Context(), cmd.OutOrStdout(), cmd.ErrOrStderr(), turnOpts, args[0], args[1])
 		},
 	}
+	bindCLIAPIConnectionFlags(cmd, &turnOpts.apiOptions)
 	bindCLIOutputFlags(cmd, &turnOpts.output)
 	bindCLILoggingFlags(cmd, &turnOpts.logging)
 	return cmd

--- a/cmd/swarm/event_publish.go
+++ b/cmd/swarm/event_publish.go
@@ -95,7 +95,7 @@ func newEventPublishCommand(opts rootCommandOptions) *cobra.Command {
 	cmd.Flags().StringVar(&publishOpts.bundleFingerprint, "bundle-fingerprint", "", "Optional expected server bundle fingerprint")
 	cmd.Flags().StringVar(&publishOpts.emitter, "emitter", "", "Optional producer identifier")
 	cmd.Flags().StringVar(&publishOpts.idempotencyKey, "idempotency-key", "", "Optional v1 API idempotency key")
-	bindCLIAPIConnectionFlags(cmd, &publishOpts.apiOptions)
+	bindCLIAPIConnectionFlagsWithClass(cmd, &publishOpts.apiOptions, cliAPICommandClassMutating, "swarm event publish")
 	return cmd
 }
 

--- a/cmd/swarm/events.go
+++ b/cmd/swarm/events.go
@@ -270,7 +270,7 @@ func newEventReplayCommand(opts rootCommandOptions) *cobra.Command {
 	}
 	cmd.Flags().StringArrayVar(&replayOpts.subscribers, "subscriber", nil, "Original agent subscriber to replay to; repeat to select a subset")
 	cmd.Flags().StringVar(&replayOpts.idempotencyKey, "idempotency-key", "", "Optional v1 API idempotency key")
-	bindCLIAPIConnectionFlags(cmd, &replayOpts.apiOptions)
+	bindCLIAPIConnectionFlagsWithClass(cmd, &replayOpts.apiOptions, cliAPICommandClassMutating, "swarm event replay")
 	return cmd
 }
 

--- a/cmd/swarm/fork.go
+++ b/cmd/swarm/fork.go
@@ -59,7 +59,7 @@ func newForkCommand(opts rootCommandOptions) *cobra.Command {
 	cmd.Flags().StringVar(&forkOpts.atEvent, "at-event", "", "Fork at this source event id")
 	cmd.Flags().StringVar(&forkOpts.idempotencyKey, "idempotency-key", "", "Optional idempotency key for retry-safe fork creation")
 	bindCLIOutputFlags(cmd, &forkOpts.output)
-	bindCLIAPIConnectionFlags(cmd, &forkOpts.apiOptions)
+	bindCLIAPIConnectionFlagsWithClass(cmd, &forkOpts.apiOptions, cliAPICommandClassMutating, "swarm fork")
 	return cmd
 }
 

--- a/cmd/swarm/forkchat.go
+++ b/cmd/swarm/forkchat.go
@@ -221,7 +221,7 @@ func newForkChatNewCommand(opts rootCommandOptions) *cobra.Command {
 	cmd.Flags().StringVar(&newOpts.idempotencyKey, "idempotency-key", "", "Optional v1 API idempotency key")
 	bindCLIOutputFlags(cmd, &newOpts.output)
 	bindCLILoggingFlags(cmd, &newOpts.logging)
-	bindCLIAPIConnectionFlags(cmd, &newOpts.apiOptions)
+	bindCLIAPIConnectionFlagsWithClass(cmd, &newOpts.apiOptions, cliAPICommandClassMutating, "swarm forkchat new")
 	return cmd
 }
 
@@ -247,7 +247,7 @@ func newForkChatResumeCommand(opts rootCommandOptions) *cobra.Command {
 	cmd.Flags().StringVar(&resumeOpts.idempotencyKey, "idempotency-key", "", "Optional v1 API idempotency key")
 	bindCLIOutputFlags(cmd, &resumeOpts.output)
 	bindCLILoggingFlags(cmd, &resumeOpts.logging)
-	bindCLIAPIConnectionFlags(cmd, &resumeOpts.apiOptions)
+	bindCLIAPIConnectionFlagsWithClass(cmd, &resumeOpts.apiOptions, cliAPICommandClassMutating, "swarm forkchat resume")
 	return cmd
 }
 
@@ -321,7 +321,7 @@ func newForkChatDeleteCommand(opts rootCommandOptions) *cobra.Command {
 	cmd.Flags().StringVar(&deleteOpts.idempotencyKey, "idempotency-key", "", "Optional v1 API idempotency key")
 	bindCLIOutputFlags(cmd, &deleteOpts.output)
 	bindCLILoggingFlags(cmd, &deleteOpts.logging)
-	bindCLIAPIConnectionFlags(cmd, &deleteOpts.apiOptions)
+	bindCLIAPIConnectionFlagsWithClass(cmd, &deleteOpts.apiOptions, cliAPICommandClassMutating, "swarm forkchat delete")
 	return cmd
 }
 

--- a/cmd/swarm/local_context_registry.go
+++ b/cmd/swarm/local_context_registry.go
@@ -3,6 +3,8 @@ package main
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -123,6 +125,10 @@ func (r localContextRegistry) currentPath() string {
 	return filepath.Join(r.dir(), "current")
 }
 
+func (r localContextRegistry) projectClaimDir() string {
+	return filepath.Join(r.dir(), ".project-claims")
+}
+
 func (r localContextRegistry) descriptorPath(name string) (string, error) {
 	name, err := normalizeLocalContextName(name)
 	if err != nil {
@@ -194,6 +200,75 @@ func (r localContextRegistry) ClearCurrent() error {
 		return nil
 	}
 	return err
+}
+
+func (r localContextRegistry) DeleteDescriptor(name string) error {
+	name, err := normalizeLocalContextName(name)
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(r.dir(), 0o700); err != nil {
+		return fmt.Errorf("create context registry: %w", err)
+	}
+	unlock, err := acquireLocalContextRegistryLock(r.lockPath())
+	if err != nil {
+		return err
+	}
+	defer unlock()
+	path, err := r.descriptorPath(name)
+	if err != nil {
+		return err
+	}
+	if err := os.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+	current, err := r.CurrentName()
+	if err != nil {
+		return err
+	}
+	if current == name {
+		if err := os.Remove(r.currentPath()); err != nil && !errors.Is(err, os.ErrNotExist) {
+			return err
+		}
+	}
+	return nil
+}
+
+func (r localContextRegistry) AcquireProjectClaim(projectRoot, contextName string) (func(), error) {
+	projectRoot = filepath.Clean(strings.TrimSpace(projectRoot))
+	if projectRoot == "" || projectRoot == "." {
+		return nil, fmt.Errorf("project root is required for context claim")
+	}
+	contextName, err := normalizeLocalContextName(contextName)
+	if err != nil {
+		return nil, err
+	}
+	if err := os.MkdirAll(r.projectClaimDir(), 0o700); err != nil {
+		return nil, fmt.Errorf("create project context claim dir: %w", err)
+	}
+	sum := sha256.Sum256([]byte(projectRoot + "\x00" + contextName))
+	path := filepath.Join(r.projectClaimDir(), hex.EncodeToString(sum[:])[:24]+".claim")
+	file, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
+	if err != nil {
+		if errors.Is(err, os.ErrExist) {
+			return nil, fmt.Errorf("project context claim already exists for %s (%s); another `swarm serve --dev` startup may be in progress, remove the claim only after confirming no startup owns it", projectRoot, path)
+		}
+		return nil, fmt.Errorf("create project context claim: %w", err)
+	}
+	release := func() {
+		_ = os.Remove(path)
+	}
+	claim := fmt.Sprintf("pid=%d\nproject_root=%s\ncontext=%s\ncreated_at=%s\n", os.Getpid(), projectRoot, contextName, localContextTimestamp())
+	if _, err := io.WriteString(file, claim); err != nil {
+		_ = file.Close()
+		release()
+		return nil, fmt.Errorf("write project context claim: %w", err)
+	}
+	if err := file.Close(); err != nil {
+		release()
+		return nil, fmt.Errorf("close project context claim: %w", err)
+	}
+	return release, nil
 }
 
 func (r localContextRegistry) CurrentName() (string, error) {
@@ -306,6 +381,26 @@ func (r localContextRegistry) Inspect(ctx context.Context, caller runtimeIdentit
 	report.Status = entry.Status
 	report.Detail = entry.Detail
 	return report, nil
+}
+
+func (r localContextRegistry) ProjectEntries(ctx context.Context, canonicalProjectRoot string, caller runtimeIdentityCaller) ([]localContextEntry, error) {
+	entries, err := r.ListDescriptors()
+	if err != nil {
+		return nil, err
+	}
+	canonicalProjectRoot = filepath.Clean(strings.TrimSpace(canonicalProjectRoot))
+	out := make([]localContextEntry, 0, len(entries))
+	for _, entry := range entries {
+		projectRoot := filepath.Clean(strings.TrimSpace(entry.Descriptor.ProjectRoot))
+		if projectRoot != canonicalProjectRoot {
+			if projectRoot == "." && (entry.Status == localContextStatusCorruptDescriptor || entry.Status == localContextStatusPermissionDenied) {
+				out = append(out, entry)
+			}
+			continue
+		}
+		out = append(out, validateLocalContextEntry(ctx, entry, caller))
+	}
+	return out, nil
 }
 
 func (r localContextRegistry) Prune(ctx context.Context, caller runtimeIdentityCaller) (localContextPruneResult, error) {

--- a/cmd/swarm/main.go
+++ b/cmd/swarm/main.go
@@ -331,6 +331,10 @@ type serveOptions struct {
 	PlatformSpecPath                 string
 	StoreMode                        string
 	StoreModeSet                     bool
+	SwarmDir                         string
+	SwarmDirSet                      bool
+	ContextName                      string
+	ContextNameSet                   bool
 	APIListenAddr                    string
 	MCPListenAddr                    string
 	ShutdownGrace                    time.Duration
@@ -763,6 +767,13 @@ func runServeRuntime(ctx context.Context, repo string, opts serveOptions) int {
 		log.Printf("resolve CLI path config: %v", err)
 		return 1
 	}
+	projectContextRegistration, err := prepareServeProjectContextRegistration(ctx, repo, opts, resolvedPaths)
+	if err != nil {
+		reporter.emit(2, "serve_admission", "FAILED", err.Error())
+		log.Printf("prepare local project context registration: %v", err)
+		return 3
+	}
+	defer projectContextRegistration.Release()
 
 	cfgResult, err := loadRuntimeConfigWithOptions(runtimeConfigLoadOptions{
 		RepoRoot:        repo,
@@ -1087,6 +1098,12 @@ func runServeRuntime(ctx context.Context, repo string, opts serveOptions) int {
 	}
 	apiServer := newAPIServer(&ready, apiV1Handler)
 	mcpServer := newMCPServer(rt.ToolGateway)
+	if err := projectContextRegistration.WriteFinal(runtimeInstanceID, apiListener.Addr(), apiAuth, resolvedPaths, storeSelection, mountSources); err != nil {
+		reporter.emit(20, "context_registry", "FAILED", err.Error())
+		log.Printf("register local project context: %v", err)
+		return 3
+	}
+	defer projectContextRegistration.Unregister()
 	go serveHTTPServer("api", apiServer, apiListener)
 	go serveHTTPServer("mcp", mcpServer, mcpListener)
 	defer shutdownHTTPServer("mcp", mcpServer)

--- a/cmd/swarm/run_command.go
+++ b/cmd/swarm/run_command.go
@@ -131,6 +131,7 @@ func runRunCommand(ctx context.Context, repo string, out, errOut io.Writer, opts
 		fmt.Fprintln(errOut, err)
 		return commandExitError{code: 2}
 	}
+	apiOpts.disableLocalTargeting = true
 	opts.apiOptions = apiOpts
 
 	if strings.TrimSpace(opts.reattachRunID) != "" {

--- a/cmd/swarm/serve_context_registration.go
+++ b/cmd/swarm/serve_context_registration.go
@@ -1,0 +1,199 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net"
+	"os"
+	"strings"
+
+	"github.com/division-sh/swarm/internal/apiv1"
+	storebackend "github.com/division-sh/swarm/internal/store/backendselection"
+)
+
+type serveProjectContextRegistration struct {
+	registry    localContextRegistry
+	project     cliProjectResolution
+	contextName string
+	release     func()
+	registered  bool
+}
+
+func prepareServeProjectContextRegistration(ctx context.Context, repo string, opts serveOptions, resolvedPaths cliContractPlatformSpecPaths) (*serveProjectContextRegistration, error) {
+	if !opts.Dev || opts.LocalRun {
+		return nil, nil
+	}
+	swarmDir, err := resolveServeContextRegistrationSwarmDir(opts)
+	if err != nil {
+		return nil, err
+	}
+	contractsPath := strings.TrimSpace(resolvedPaths.ContractsPath)
+	if contractsPath == "" {
+		return nil, fmt.Errorf("serve --dev project context registration requires a resolved contracts path")
+	}
+	projectRoot := inferProjectRootFromContractsPath(contractsPath)
+	canonical, _ := canonicalizeDoctorTargetPath(projectRoot)
+	canonical = strings.TrimSpace(canonical)
+	if canonical == "" {
+		return nil, fmt.Errorf("serve --dev project context registration requires a canonical project root")
+	}
+	contextName := strings.TrimSpace(opts.ContextName)
+	if contextName == "" {
+		contextName = localProjectContextName(canonical)
+	}
+	contextName, err = normalizeLocalContextName(contextName)
+	if err != nil {
+		return nil, err
+	}
+	registry := newLocalContextRegistry(swarmDir.Path)
+	project := cliProjectResolution{
+		contractsPath:        contractsPath,
+		projectRoot:          projectRoot,
+		canonicalProjectRoot: canonical,
+	}
+	if err := guardServeProjectContext(ctx, registry, project, contextName, opts.ContextNameSet); err != nil {
+		return nil, err
+	}
+	release, err := registry.AcquireProjectClaim(canonical, contextName)
+	if err != nil {
+		return nil, err
+	}
+	return &serveProjectContextRegistration{
+		registry:    registry,
+		project:     project,
+		contextName: contextName,
+		release:     release,
+	}, nil
+}
+
+func resolveServeContextRegistrationSwarmDir(opts serveOptions) (cliSwarmDirResolution, error) {
+	if opts.SwarmDirSet {
+		path, err := normalizeCLISwarmDir(opts.SwarmDir, "--swarm-dir")
+		return cliSwarmDirResolution{Path: path, Source: "--swarm-dir"}, err
+	}
+	cfg, err := loadCLIAPIConfigFile()
+	if err != nil {
+		return cliSwarmDirResolution{}, err
+	}
+	return resolveCLISwarmDirFromConfig(cliSwarmDirOptions{}, cfg)
+}
+
+func guardServeProjectContext(ctx context.Context, registry localContextRegistry, project cliProjectResolution, contextName string, explicitContext bool) error {
+	entries, err := registry.ProjectEntries(ctx, project.canonicalProjectRoot, cliRuntimeIdentityCaller{})
+	if err != nil {
+		return fmt.Errorf("inspect project contexts: %w", err)
+	}
+	if explicitContext {
+		for _, entry := range entries {
+			if entry.Descriptor.Name == contextName {
+				return fmt.Errorf("context %s already exists for project %s (%s); run `swarm context prune` after confirming stale entries, or choose another --context", contextName, project.canonicalProjectRoot, entry.Status)
+			}
+		}
+		return nil
+	}
+	if len(entries) == 0 {
+		return nil
+	}
+	parts := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		name := strings.TrimSpace(entry.Descriptor.Name)
+		if name == "" {
+			name = "<unknown>"
+		}
+		parts = append(parts, fmt.Sprintf("%s=%s", name, entry.Status))
+	}
+	return fmt.Errorf("project %s already has context descriptors (%s); refusing bare `swarm serve --dev` to avoid orphaning a runtime; run `swarm context prune` for stale entries or pass --context for an intentional second runtime", project.canonicalProjectRoot, strings.Join(parts, ", "))
+}
+
+func (r *serveProjectContextRegistration) Release() {
+	if r == nil || r.release == nil {
+		return
+	}
+	r.release()
+	r.release = nil
+}
+
+func (r *serveProjectContextRegistration) Unregister() {
+	if r == nil || !r.registered {
+		return
+	}
+	if err := r.registry.DeleteDescriptor(r.contextName); err != nil {
+		log.Printf("unregister local project context %s: %v", r.contextName, err)
+	}
+	r.registered = false
+}
+
+func (r *serveProjectContextRegistration) WriteFinal(runtimeInstanceID string, apiAddr net.Addr, apiAuth apiv1.AuthTokenResolution, resolvedPaths cliContractPlatformSpecPaths, storeSelection storebackend.Selection, mountSources workspaceMountSources) error {
+	if r == nil {
+		return nil
+	}
+	if !apiAuth.UsesDefaultLoopbackToken() {
+		return fmt.Errorf("serve --dev project context registration currently supports only built-in loopback auth; explicit SWARM_API_TOKEN cannot be snapshotted into a safe context descriptor")
+	}
+	apiServer, err := serveProjectContextAPIServer(apiAddr)
+	if err != nil {
+		return err
+	}
+	rpcEndpoint, err := cliAPIRPCEndpointFromServer(apiServer, "serve api listener")
+	if err != nil {
+		return err
+	}
+	if !cliAPIRPCEndpointAllowsDefaultToken(rpcEndpoint) {
+		return fmt.Errorf("serve --dev project context registration requires a numeric loopback API listener, got %s", apiServer)
+	}
+	now := localContextTimestamp()
+	desc := localContextDescriptor{
+		Version:           localContextDescriptorVersion,
+		Name:              r.contextName,
+		RuntimeInstanceID: runtimeInstanceID,
+		Transport:         localContextTransportTCP,
+		APIServer:         apiServer,
+		Auth:              localContextDescriptorAuth{Mode: localContextAuthBuiltinLoopback},
+		ProjectRoot:       r.project.canonicalProjectRoot,
+		ContractsPath:     strings.TrimSpace(resolvedPaths.ContractsPath),
+		StorePath:         serveDescriptorStorePath(storeSelection),
+		DataDir:           strings.TrimSpace(mountSources.DataSource),
+		PID:               currentProcessID(),
+		CreatedAt:         now,
+		UpdatedAt:         now,
+	}
+	if err := r.registry.WriteDescriptor(desc); err != nil {
+		return err
+	}
+	if err := r.registry.SetCurrent(desc.Name); err != nil {
+		if path, pathErr := r.registry.descriptorPath(desc.Name); pathErr == nil {
+			_ = os.Remove(path)
+		}
+		return err
+	}
+	r.registered = true
+	return nil
+}
+
+func serveProjectContextAPIServer(addr net.Addr) (string, error) {
+	if addr == nil {
+		return "", fmt.Errorf("api listener address is required")
+	}
+	host, port, err := net.SplitHostPort(addr.String())
+	if err != nil {
+		return "", fmt.Errorf("api listener address %q is not host:port: %w", addr.String(), err)
+	}
+	host = strings.TrimSpace(strings.Trim(host, "[]"))
+	port = strings.TrimSpace(port)
+	if host == "" || port == "" {
+		return "", fmt.Errorf("api listener address %q is incomplete", addr.String())
+	}
+	return "http://" + net.JoinHostPort(host, port), nil
+}
+
+func serveDescriptorStorePath(selection storebackend.Selection) string {
+	if selection.Backend != storebackend.BackendSQLite {
+		return ""
+	}
+	return strings.TrimSpace(selection.SQLitePath)
+}
+
+func currentProcessID() int {
+	return os.Getpid()
+}

--- a/cmd/swarm/serve_context_registration.go
+++ b/cmd/swarm/serve_context_registration.go
@@ -87,12 +87,35 @@ func guardServeProjectContext(ctx context.Context, registry localContextRegistry
 	if explicitContext {
 		for _, entry := range entries {
 			if entry.Descriptor.Name == contextName {
+				if serveProjectContextEntryReclaimable(entry) {
+					if err := registry.DeleteDescriptor(entry.Descriptor.Name); err != nil {
+						return fmt.Errorf("reclaim stale project context %s: %w", contextName, err)
+					}
+					return nil
+				}
 				return fmt.Errorf("context %s already exists for project %s (%s); run `swarm context prune` after confirming stale entries, or choose another --context", contextName, project.canonicalProjectRoot, entry.Status)
 			}
 		}
 		return nil
 	}
 	if len(entries) == 0 {
+		return nil
+	}
+	blockers := make([]localContextEntry, 0, len(entries))
+	reclaimable := make([]localContextEntry, 0, len(entries))
+	for _, entry := range entries {
+		if serveProjectContextEntryReclaimable(entry) {
+			reclaimable = append(reclaimable, entry)
+			continue
+		}
+		blockers = append(blockers, entry)
+	}
+	if len(blockers) == 0 {
+		for _, entry := range reclaimable {
+			if err := registry.DeleteDescriptor(entry.Descriptor.Name); err != nil {
+				return fmt.Errorf("reclaim stale project context %s: %w", entry.Descriptor.Name, err)
+			}
+		}
 		return nil
 	}
 	parts := make([]string, 0, len(entries))
@@ -104,6 +127,18 @@ func guardServeProjectContext(ctx context.Context, registry localContextRegistry
 		parts = append(parts, fmt.Sprintf("%s=%s", name, entry.Status))
 	}
 	return fmt.Errorf("project %s already has context descriptors (%s); refusing bare `swarm serve --dev` to avoid orphaning a runtime; run `swarm context prune` for stale entries or pass --context for an intentional second runtime", project.canonicalProjectRoot, strings.Join(parts, ", "))
+}
+
+func serveProjectContextEntryReclaimable(entry localContextEntry) bool {
+	if strings.TrimSpace(entry.Descriptor.Name) == "" {
+		return false
+	}
+	switch entry.Status {
+	case localContextStatusNoServer, localContextStatusStaleDescriptor, localContextStatusIdentityMismatch:
+		return true
+	default:
+		return false
+	}
 }
 
 func (r *serveProjectContextRegistration) Release() {

--- a/cmd/swarm/serve_context_registration.go
+++ b/cmd/swarm/serve_context_registration.go
@@ -80,23 +80,33 @@ func resolveServeContextRegistrationSwarmDir(opts serveOptions) (cliSwarmDirReso
 }
 
 func guardServeProjectContext(ctx context.Context, registry localContextRegistry, project cliProjectResolution, contextName string, explicitContext bool) error {
+	allEntries, err := registry.ListDescriptors()
+	if err != nil {
+		return fmt.Errorf("inspect context registry: %w", err)
+	}
 	entries, err := registry.ProjectEntries(ctx, project.canonicalProjectRoot, cliRuntimeIdentityCaller{})
 	if err != nil {
 		return fmt.Errorf("inspect project contexts: %w", err)
 	}
 	if explicitContext {
-		for _, entry := range entries {
-			if entry.Descriptor.Name == contextName {
-				if serveProjectContextEntryReclaimable(entry) {
-					if err := registry.DeleteDescriptor(entry.Descriptor.Name); err != nil {
-						return fmt.Errorf("reclaim stale project context %s: %w", contextName, err)
-					}
-					return nil
-				}
-				return fmt.Errorf("context %s already exists for project %s (%s); run `swarm context prune` after confirming stale entries, or choose another --context", contextName, project.canonicalProjectRoot, entry.Status)
-			}
+		existing, exists := serveProjectContextEntryByName(allEntries, contextName)
+		if !exists {
+			return nil
 		}
-		return nil
+		if projectEntry, sameProject := serveProjectContextEntryByName(entries, contextName); sameProject {
+			if serveProjectContextEntryReclaimable(projectEntry) {
+				if err := registry.DeleteDescriptor(projectEntry.Descriptor.Name); err != nil {
+					return fmt.Errorf("reclaim stale project context %s: %w", contextName, err)
+				}
+				return nil
+			}
+			return fmt.Errorf("context %s already exists for project %s (%s); run `swarm context prune` after confirming stale entries, or choose another --context", contextName, project.canonicalProjectRoot, projectEntry.Status)
+		}
+		existingProject := strings.TrimSpace(existing.Descriptor.ProjectRoot)
+		if existingProject == "" {
+			existingProject = "<unknown>"
+		}
+		return fmt.Errorf("context %s already exists for project %s (%s); context names are global, choose another --context", contextName, existingProject, existing.Status)
 	}
 	if len(entries) == 0 {
 		return nil
@@ -127,6 +137,15 @@ func guardServeProjectContext(ctx context.Context, registry localContextRegistry
 		parts = append(parts, fmt.Sprintf("%s=%s", name, entry.Status))
 	}
 	return fmt.Errorf("project %s already has context descriptors (%s); refusing bare `swarm serve --dev` to avoid orphaning a runtime; run `swarm context prune` for stale entries or pass --context for an intentional second runtime", project.canonicalProjectRoot, strings.Join(parts, ", "))
+}
+
+func serveProjectContextEntryByName(entries []localContextEntry, contextName string) (localContextEntry, bool) {
+	for _, entry := range entries {
+		if entry.Descriptor.Name == contextName {
+			return entry, true
+		}
+	}
+	return localContextEntry{}, false
 }
 
 func serveProjectContextEntryReclaimable(entry localContextEntry) bool {

--- a/cmd/swarm/serve_context_registration_test.go
+++ b/cmd/swarm/serve_context_registration_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"net"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -74,6 +75,38 @@ func TestServeProjectContextRegistrationGuardsBareDoubleServe(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "already has context descriptors") {
 		t.Fatalf("err = %q, want double-serve guard", err.Error())
+	}
+}
+
+func TestServeProjectContextRegistrationReclaimsDeadProjectDescriptor(t *testing.T) {
+	isolateCLIAPIConfigEnv(t)
+	project := writeCLIAPIProjectFixture(t)
+	swarmDir := t.TempDir()
+	registry := newLocalContextRegistry(swarmDir)
+	contextName := localProjectContextName(project.canonicalRoot)
+	writeCLIAPITestContext(t, registry, contextName, "runtime-dead", "http://127.0.0.1:1", project.canonicalRoot)
+	if err := registry.SetCurrent(contextName); err != nil {
+		t.Fatalf("set current context: %v", err)
+	}
+	opts := defaultServeOptions()
+	opts.Dev = true
+	opts.SwarmDir = swarmDir
+	opts.SwarmDirSet = true
+
+	reg, err := prepareServeProjectContextRegistration(context.Background(), project.root, opts, cliContractPlatformSpecPaths{ContractsPath: project.contracts})
+	if err != nil {
+		t.Fatalf("prepare registration: %v", err)
+	}
+	defer reg.Release()
+	path, err := registry.descriptorPath(contextName)
+	if err != nil {
+		t.Fatalf("descriptor path: %v", err)
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatalf("dead descriptor stat err = %v, want removed", err)
+	}
+	if current, err := registry.CurrentName(); err != nil || current != "" {
+		t.Fatalf("current = %q err=%v, want cleared", current, err)
 	}
 }
 

--- a/cmd/swarm/serve_context_registration_test.go
+++ b/cmd/swarm/serve_context_registration_test.go
@@ -1,0 +1,140 @@
+package main
+
+import (
+	"context"
+	"net"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/division-sh/swarm/internal/apiv1"
+	storebackend "github.com/division-sh/swarm/internal/store/backendselection"
+)
+
+func TestServeProjectContextRegistrationWritesFinalDescriptor(t *testing.T) {
+	isolateCLIAPIConfigEnv(t)
+	project := writeCLIAPIProjectFixture(t)
+	swarmDir := t.TempDir()
+	opts := defaultServeOptions()
+	opts.Dev = true
+	opts.SwarmDir = swarmDir
+	opts.SwarmDirSet = true
+
+	reg, err := prepareServeProjectContextRegistration(context.Background(), project.root, opts, cliContractPlatformSpecPaths{ContractsPath: project.contracts})
+	if err != nil {
+		t.Fatalf("prepare registration: %v", err)
+	}
+	defer reg.Release()
+	listener := listenLoopbackTestListener(t)
+	defer listener.Close()
+	storePath := filepath.Join(t.TempDir(), "dev.db")
+	if err := reg.WriteFinal("runtime-1", listener.Addr(), defaultLoopbackAuthResolution(), cliContractPlatformSpecPaths{ContractsPath: project.contracts}, storebackend.Selection{
+		Backend:    storebackend.BackendSQLite,
+		SQLitePath: storePath,
+	}, workspaceMountSources{DataSource: filepath.Join(project.root, ".swarm", "data")}); err != nil {
+		t.Fatalf("write final: %v", err)
+	}
+
+	registry := newLocalContextRegistry(swarmDir)
+	entry, err := registry.ReadDescriptor(localProjectContextName(project.canonicalRoot))
+	if err != nil {
+		t.Fatalf("read descriptor: %v", err)
+	}
+	if entry.Status != localContextStatusOK {
+		t.Fatalf("descriptor status = %s detail=%s", entry.Status, entry.Detail)
+	}
+	desc := entry.Descriptor
+	if desc.RuntimeInstanceID != "runtime-1" || desc.ProjectRoot != project.canonicalRoot || desc.ContractsPath != project.contracts {
+		t.Fatalf("descriptor = %#v, want runtime/project/contracts metadata", desc)
+	}
+	if desc.StorePath != storePath || desc.DataDir == "" || desc.Auth.Mode != localContextAuthBuiltinLoopback {
+		t.Fatalf("descriptor = %#v, want store/data/builtin auth metadata", desc)
+	}
+	if current, err := registry.CurrentName(); err != nil || current != desc.Name {
+		t.Fatalf("current = %q err=%v, want %q", current, err, desc.Name)
+	}
+}
+
+func TestServeProjectContextRegistrationGuardsBareDoubleServe(t *testing.T) {
+	isolateCLIAPIConfigEnv(t)
+	project := writeCLIAPIProjectFixture(t)
+	swarmDir := t.TempDir()
+	server := startCLIAPIRuntimeIdentityServer(t, "runtime-live")
+	registry := newLocalContextRegistry(swarmDir)
+	writeCLIAPITestContext(t, registry, localProjectContextName(project.canonicalRoot), "runtime-live", server.URL, project.canonicalRoot)
+	opts := defaultServeOptions()
+	opts.Dev = true
+	opts.SwarmDir = swarmDir
+	opts.SwarmDirSet = true
+
+	reg, err := prepareServeProjectContextRegistration(context.Background(), project.root, opts, cliContractPlatformSpecPaths{ContractsPath: project.contracts})
+	if err == nil {
+		reg.Release()
+		t.Fatal("prepare registration returned nil error")
+	}
+	if !strings.Contains(err.Error(), "already has context descriptors") {
+		t.Fatalf("err = %q, want double-serve guard", err.Error())
+	}
+}
+
+func TestServeProjectContextRegistrationAllowsExplicitSecondContext(t *testing.T) {
+	isolateCLIAPIConfigEnv(t)
+	project := writeCLIAPIProjectFixture(t)
+	swarmDir := t.TempDir()
+	server := startCLIAPIRuntimeIdentityServer(t, "runtime-live")
+	registry := newLocalContextRegistry(swarmDir)
+	writeCLIAPITestContext(t, registry, localProjectContextName(project.canonicalRoot), "runtime-live", server.URL, project.canonicalRoot)
+	opts := defaultServeOptions()
+	opts.Dev = true
+	opts.SwarmDir = swarmDir
+	opts.SwarmDirSet = true
+	opts.ContextName = "second"
+	opts.ContextNameSet = true
+
+	reg, err := prepareServeProjectContextRegistration(context.Background(), project.root, opts, cliContractPlatformSpecPaths{ContractsPath: project.contracts})
+	if err != nil {
+		t.Fatalf("prepare explicit context: %v", err)
+	}
+	defer reg.Release()
+}
+
+func TestServeProjectContextRegistrationRejectsUnsafeAuthDescriptor(t *testing.T) {
+	isolateCLIAPIConfigEnv(t)
+	project := writeCLIAPIProjectFixture(t)
+	swarmDir := t.TempDir()
+	opts := defaultServeOptions()
+	opts.Dev = true
+	opts.SwarmDir = swarmDir
+	opts.SwarmDirSet = true
+	reg, err := prepareServeProjectContextRegistration(context.Background(), project.root, opts, cliContractPlatformSpecPaths{ContractsPath: project.contracts})
+	if err != nil {
+		t.Fatalf("prepare registration: %v", err)
+	}
+	defer reg.Release()
+	listener := listenLoopbackTestListener(t)
+	defer listener.Close()
+	err = reg.WriteFinal("runtime-1", listener.Addr(), apiv1.AuthTokenResolution{
+		Tokens:   []string{"secret"},
+		Source:   apiv1.AuthTokenSourceEnvironment,
+		Explicit: true,
+	}, cliContractPlatformSpecPaths{ContractsPath: project.contracts}, storebackend.Selection{Backend: storebackend.BackendSQLite}, workspaceMountSources{})
+	if err == nil || !strings.Contains(err.Error(), "cannot be snapshotted") {
+		t.Fatalf("WriteFinal err = %v, want safe-auth rejection", err)
+	}
+}
+
+func listenLoopbackTestListener(t *testing.T) net.Listener {
+	t.Helper()
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	return listener
+}
+
+func defaultLoopbackAuthResolution() apiv1.AuthTokenResolution {
+	return apiv1.AuthTokenResolution{
+		Tokens: []string{apiv1.DefaultLoopbackAPIToken},
+		Source: apiv1.AuthTokenSourceBuiltInLoopbackToken,
+	}
+}

--- a/cmd/swarm/serve_context_registration_test.go
+++ b/cmd/swarm/serve_context_registration_test.go
@@ -131,6 +131,30 @@ func TestServeProjectContextRegistrationAllowsExplicitSecondContext(t *testing.T
 	defer reg.Release()
 }
 
+func TestServeProjectContextRegistrationRejectsCrossProjectExplicitContextName(t *testing.T) {
+	isolateCLIAPIConfigEnv(t)
+	project := writeCLIAPIProjectFixture(t)
+	otherProject := writeCLIAPIProjectFixture(t)
+	swarmDir := t.TempDir()
+	registry := newLocalContextRegistry(swarmDir)
+	writeCLIAPITestContext(t, registry, "shared", "runtime-other", "http://127.0.0.1:1", otherProject.canonicalRoot)
+	opts := defaultServeOptions()
+	opts.Dev = true
+	opts.SwarmDir = swarmDir
+	opts.SwarmDirSet = true
+	opts.ContextName = "shared"
+	opts.ContextNameSet = true
+
+	reg, err := prepareServeProjectContextRegistration(context.Background(), project.root, opts, cliContractPlatformSpecPaths{ContractsPath: project.contracts})
+	if err == nil {
+		reg.Release()
+		t.Fatal("prepare explicit context returned nil error")
+	}
+	if !strings.Contains(err.Error(), "context shared already exists for project "+otherProject.canonicalRoot) || !strings.Contains(err.Error(), "context names are global") {
+		t.Fatalf("err = %q, want cross-project name collision", err.Error())
+	}
+}
+
 func TestServeProjectContextRegistrationRejectsUnsafeAuthDescriptor(t *testing.T) {
 	isolateCLIAPIConfigEnv(t)
 	project := writeCLIAPIProjectFixture(t)

--- a/cmd/swarm/target_resolution.go
+++ b/cmd/swarm/target_resolution.go
@@ -174,19 +174,16 @@ func buildDoctorTargetReport(ctx context.Context, repo string, opts doctorOption
 	if err != nil {
 		return doctorTargetReport{}, err
 	}
+	project := resolveDoctorTargetProject(repo, opts, cfg)
 	return doctorTargetReport{
 		Owner:    localTargetOwner,
 		Mode:     "target",
 		OK:       true,
 		SwarmDir: doctorTargetPath{Path: swarmDir.Path, Source: swarmDir.Source, Status: "resolved"},
-		Project:  resolveDoctorTargetProject(repo, opts, cfg),
+		Project:  project,
 		API:      api,
 		Context: doctorTargetContext{
-			ProjectScoped: doctorTargetPendingFact{
-				Status: "pending",
-				Owner:  "#1614",
-				Detail: "project-scoped serve registration and API command consumption remain split",
-			},
+			ProjectScoped: doctorTargetProjectContextFact(ctx, newLocalContextRegistry(swarmDir.Path), project),
 			SelectedGlobal: doctorTargetPendingFact{
 				Status: registryReport.Status,
 				Owner:  localContextRegistryOwner,
@@ -200,6 +197,46 @@ func buildDoctorTargetReport(ctx context.Context, repo string, opts doctorOption
 		CommandClasses:  doctorTargetCommandClasses(),
 		SplitSiblings:   doctorTargetSplitSiblings(),
 	}, nil
+}
+
+func doctorTargetProjectContextFact(ctx context.Context, registry localContextRegistry, project doctorTargetProject) doctorTargetPendingFact {
+	if project.Status != "resolved" || strings.TrimSpace(project.CanonicalProjectRoot) == "" {
+		return doctorTargetPendingFact{
+			Status: "no_project",
+			Owner:  localContextRegistryOwner,
+			Detail: "no resolved project root, so no project-scoped context lookup was attempted",
+		}
+	}
+	entries, err := registry.ProjectEntries(ctx, project.CanonicalProjectRoot, cliRuntimeIdentityCaller{})
+	if err != nil {
+		return doctorTargetPendingFact{Status: localContextStatusPermissionDenied, Owner: localContextRegistryOwner, Detail: err.Error()}
+	}
+	if len(entries) == 0 {
+		return doctorTargetPendingFact{
+			Status: "missing",
+			Owner:  localContextRegistryOwner,
+			Detail: "no context descriptor is registered for this project; read-only commands may fall through, mutating/control commands require explicit target",
+		}
+	}
+	okCount := 0
+	parts := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		if entry.Status == localContextStatusOK {
+			okCount++
+		}
+		name := strings.TrimSpace(entry.Descriptor.Name)
+		if name == "" {
+			name = "<unknown>"
+		}
+		parts = append(parts, fmt.Sprintf("%s=%s", name, entry.Status))
+	}
+	if okCount == 1 && len(entries) == 1 {
+		return doctorTargetPendingFact{Status: localContextStatusOK, Owner: localContextRegistryOwner, Detail: strings.Join(parts, ", ")}
+	}
+	if okCount > 1 {
+		return doctorTargetPendingFact{Status: "multiple_live", Owner: localContextRegistryOwner, Detail: strings.Join(parts, ", ")}
+	}
+	return doctorTargetPendingFact{Status: "blocked", Owner: localContextRegistryOwner, Detail: strings.Join(parts, ", ")}
 }
 
 func doctorTargetRuntimeIdentityFact(report localContextRegistryReport) doctorTargetPendingFact {
@@ -288,7 +325,7 @@ func doctorTargetAPIReason(source string) string {
 	case "config api_server":
 		return "existing bootstrap config API source wins after flags and environment"
 	default:
-		return "API-backed command context consumption is split to #1614, so this diagnostic falls through to the built-in loopback default when no explicit API source is configured"
+		return "when no explicit API source is configured, API-backed commands resolve project context, selected context, or built-in loopback according to command class"
 	}
 }
 
@@ -431,26 +468,70 @@ func doctorTargetCommandClasses() []doctorTargetCommandClass {
 		},
 		{
 			Name:        "read_only_inspection",
-			Status:      "specified_pending_#1614_consumption",
-			Fallthrough: "may use project/global/default target only after #1614 consumes the registry and fails closed on stale project contexts",
-			Commands:    []string{"swarm status", "swarm trace", "swarm logs", "swarm health", "swarm runs", "swarm agents list"},
+			Status:      "implemented_#1614",
+			Fallthrough: "may use selected/global/default target only outside a project or when a project has no known context; stale/mismatched/corrupt/multiple project contexts fail closed",
+			Commands: []string{
+				"swarm runs",
+				"swarm status",
+				"swarm trace",
+				"swarm health",
+				"swarm logs",
+				"swarm incidents",
+				"swarm version --server",
+				"swarm events list",
+				"swarm events follow",
+				"swarm event view",
+				"swarm bundle list",
+				"swarm bundle show",
+				"swarm bundle agents",
+				"swarm agents list",
+				"swarm agent deliveries",
+				"swarm agent diagnose",
+				"swarm agent view",
+				"swarm conversations list",
+				"swarm conversation view",
+				"swarm conversation turn",
+				"swarm entities list",
+				"swarm entity view",
+				"swarm entity aggregate",
+				"swarm mailbox list",
+				"swarm mailbox view",
+				"swarm forkchat list",
+				"swarm forkchat view",
+			},
 		},
 		{
 			Name:        "mutating_runtime_state",
-			Status:      "specified_pending_#1614_consumption",
-			Fallthrough: "requires explicit or unambiguous selected target; no command behavior changes are implemented in #1612",
-			Commands:    []string{"swarm event publish", "swarm agent restart", "swarm agent directive", "swarm mailbox approve"},
+			Status:      "implemented_#1614",
+			Fallthrough: "must not fall through to selected/global/default from inside a project with no live project context; requires explicit target or live project context",
+			Commands: []string{
+				"swarm event publish",
+				"swarm event replay",
+				"swarm agent restart",
+				"swarm agent replay",
+				"swarm agent replay-backlog",
+				"swarm agent directive",
+				"swarm bundle register",
+				"swarm bundle delete",
+				"swarm mailbox approve",
+				"swarm mailbox reject",
+				"swarm mailbox defer",
+				"swarm fork",
+				"swarm forkchat new",
+				"swarm forkchat resume",
+				"swarm forkchat delete",
+			},
 		},
 		{
 			Name:        "control_destructive",
-			Status:      "specified_pending_#1614_consumption",
+			Status:      "implemented_#1614",
 			Fallthrough: "requires explicit or unambiguous selected target plus existing command confirmation rules",
 			Commands:    []string{"swarm control pause", "swarm control stop", "swarm control nuke"},
 		},
 		{
 			Name:        "startup_and_run",
-			Status:      "split_pending_#1614_#1615",
-			Fallthrough: "serve project registration and swarm run semantics are intentionally split to #1614 and #1615",
+			Status:      "implemented_serve_split_run",
+			Fallthrough: "serve --dev registers a project context in #1614; swarm run default/foreground semantics remain split to #1615",
 			Commands:    []string{"swarm serve --dev", "swarm run"},
 		},
 	}

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -11694,7 +11694,9 @@ cli_specification:
           `swarm doctor --target` explains explicit API flag, environment, config, project-root, Swarm-dir, current
           rollout store/data, and local context registry/identity facts. API-backed commands consume the same target
           order through the shared CLI API resolver after #1614. Unavailable facts MUST be reported as unavailable
-          rather than inferred from PID, port, URL, or health bundle fingerprint.
+          rather than inferred from PID, port, URL, or health bundle fingerprint. A project context may be selected
+          implicitly only when exactly one descriptor exists for the canonical project root and that descriptor validates
+          `ok`; mixed live/stale or otherwise non-ok project descriptors fail closed.
       command_classes:
         target_diagnostic:
           status: implemented
@@ -11859,7 +11861,8 @@ cli_specification:
           releases the claim and must not leave a descriptor selected as current. `serve --dev` may reclaim an existing
           same-project descriptor only when runtime.identity validation proves it is dead, stale, or identity-mismatched;
           live, permission-denied, corrupt, invalid, or otherwise ambiguous project descriptors fail closed instead of
-          being silently overwritten.
+          being silently overwritten. Explicit `serve --dev --context <name>` MUST also reject any existing descriptor
+          with that global context name from another project.
       validation_statuses:
       - ok
       - no_server

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -11856,7 +11856,10 @@ cli_specification:
         project_claim_rule: >
           `serve --dev` acquires a project-claim file before listener binding and runtime-store side effects, then writes
           the final descriptor only after the API listener address and runtime_instance_id are known. Failed startup
-          releases the claim and must not leave a descriptor selected as current.
+          releases the claim and must not leave a descriptor selected as current. `serve --dev` may reclaim an existing
+          same-project descriptor only when runtime.identity validation proves it is dead, stale, or identity-mismatched;
+          live, permission-denied, corrupt, invalid, or otherwise ambiguous project descriptors fail closed instead of
+          being silently overwritten.
       validation_statuses:
       - ok
       - no_server

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -11643,8 +11643,9 @@ cli_specification:
         project-root facts derived from the existing contracts resolver, target precedence, command-class safety, and
         the first inspection surface `swarm doctor --target`. This first slice is an authority and diagnostic surface
         only. Runtime identity and local context registry primitives are promoted separately under
-        local_context_registry_authority. This owner still does not retarget API-backed commands, register project-scoped
-        `serve --dev` contexts, migrate store/data paths, or change `swarm run` behavior.
+        local_context_registry_authority. #1614 consumes those primitives for TCP project-scoped `serve --dev`
+        registration and current API-backed command targeting. This owner still does not migrate store/data paths,
+        change `swarm run` default/foreground behavior, or implement IPC/unix dialing policy.
       invariant: >
         You target the project you are in. If you are not in a project, or the project has no live known runtime after
         the registry children exist, Swarm may use the selected/default context or built-in loopback target according to
@@ -11674,8 +11675,8 @@ cli_specification:
         rule: >
           Project-root facts are derived from the resolved contracts source. If the resolved contracts root is named
           `contracts`, the project root is its parent; otherwise the contracts root itself is the project root. The
-          canonical project key uses the realpath of that root when available. This owner consumes project-root facts
-          for explanation only until #1614 consumes them for runtime targeting.
+          canonical project key uses the realpath of that root when available. #1614 uses this canonical project key
+          for TCP local context registration, project descriptor lookup, and project-first API command targeting.
         no_project_rule: >
           If no contracts source is resolved, target diagnostics report no project source. Runtime command behavior is
           not changed by #1612.
@@ -11689,11 +11690,11 @@ cli_specification:
         - known_dead_or_stale_project_context_fail_closed
         - selected_or_default_global_context
         - built_in_loopback_default
-        current_first_slice_behavior: >
-          `swarm doctor --target` can explain explicit API flag, environment, config, project-root, Swarm-dir, current
-          rollout store/data, and local context registry/identity facts when registry primitives are present. API-backed
-          command consumption remains split to #1614; unavailable facts MUST be reported as unavailable rather than
-          inferred from PID, port, URL, or health bundle fingerprint.
+        current_behavior: >
+          `swarm doctor --target` explains explicit API flag, environment, config, project-root, Swarm-dir, current
+          rollout store/data, and local context registry/identity facts. API-backed commands consume the same target
+          order through the shared CLI API resolver after #1614. Unavailable facts MUST be reported as unavailable
+          rather than inferred from PID, port, URL, or health bundle fingerprint.
       command_classes:
         target_diagnostic:
           status: implemented
@@ -11701,42 +11702,78 @@ cli_specification:
           - swarm doctor --target
           fallthrough: not_applicable
         read_only_inspection:
-          status: specified_pending_#1614_consumption
+          status: implemented_#1614
           commands:
+          - swarm runs
           - swarm status
           - swarm trace
           - swarm logs
           - swarm health
-          - swarm runs
+          - swarm incidents
+          - swarm version --server
+          - swarm events list
+          - swarm events follow
+          - swarm event view
+          - swarm bundle list
+          - swarm bundle show
+          - swarm bundle agents
           - swarm agents list
+          - swarm agent deliveries
+          - swarm agent diagnose
+          - swarm agent view
+          - swarm conversations list
+          - swarm conversation view
+          - swarm conversation turn
+          - swarm entities list
+          - swarm entity view
+          - swarm entity aggregate
+          - swarm mailbox list
+          - swarm mailbox view
+          - swarm forkchat list
+          - swarm forkchat view
           fallthrough: >
-            May use project/global/default target only after #1614 consumes the registry and fails closed on stale project
-            contexts.
+            May use selected/global/default target only outside a project or when a project has no known context. A
+            stale, mismatched, corrupt, permission-denied, or multiple-live project context fails closed rather than
+            silently falling through.
         mutating_runtime_state:
-          status: specified_pending_#1614_consumption
+          status: implemented_#1614
           commands:
           - swarm event publish
+          - swarm event replay
           - swarm agent restart
+          - swarm agent replay
+          - swarm agent replay-backlog
           - swarm agent directive
+          - swarm bundle register
+          - swarm bundle delete
           - swarm mailbox approve
+          - swarm mailbox reject
+          - swarm mailbox defer
+          - swarm fork
+          - swarm forkchat new
+          - swarm forkchat resume
+          - swarm forkchat delete
           fallthrough: >
-            Requires explicit or unambiguous selected target; #1612 implements no mutating command behavior changes.
+            Must not fall through to selected/global/default from inside a project with no live project context. Requires
+            an explicit target or a live project-scoped context.
         control_destructive:
-          status: specified_pending_#1614_consumption
+          status: implemented_#1614
           commands:
           - swarm control pause
+          - swarm control continue
           - swarm control stop
           - swarm control nuke
           fallthrough: >
-            Requires explicit or unambiguous selected target plus existing command confirmation rules; #1612 implements
-            no control command behavior changes.
+            Requires explicit or unambiguous selected target plus existing command confirmation rules. Must not fall
+            through to selected/global/default from inside a project with no live project context.
         startup_and_run:
-          status: split_pending_#1614_#1615
+          status: implemented_serve_split_run
           commands:
           - swarm serve --dev
           - swarm run
           fallthrough: >
-            Project registration and run semantics are explicitly split.
+            `serve --dev` registers a project-scoped TCP context after a pre-bind project claim and after the final API
+            target/runtime_instance_id are known. `swarm run` default/foreground semantics remain split to #1615.
       doctor_target_surface:
         command: swarm doctor --target [--json] [--swarm-dir <path>] [--api-server <url>] [--api-token-file <path>]
         output_owner: cli_specification.foundations.output_contract
@@ -11747,14 +11784,14 @@ cli_specification:
           report to stdout and emits no success stderr. `--quiet` is not supported by this first slice and remains
           fail-closed as an unknown/unsupported flag.
       split_siblings:
-      - '#1614 project-scoped serve/API command targeting'
+      - '#1614 project-scoped serve/API command targeting (implemented)'
       - '#1615 store/data migration and swarm run semantics'
       - '#1576 transport-aware descriptors and IPC/ephemeral-port direction'
       implementation_boundaries:
       - 'The shared CLI config parser may accept `swarm_dir`, but API connection/auth resolution must ignore it.'
       - 'No `SWARM_DIR`, `SWARM_HOME`, `--datadir`, or `<swarm-dir>/config.yaml` bootstrap source is promoted.'
       - 'Descriptor registry primitives are written and validated only through local_context_registry_authority.'
-      - 'No API-backed command target resolver consumes project/global contexts until #1614.'
+      - 'API-backed commands consume project/global contexts through the shared #1614 CLI API target resolver only.'
       - 'Store and data paths may be reported as current behavior only; migration is split to #1615.'
     local_context_registry_authority:
       promoted_by: '#1613'
@@ -11771,9 +11808,11 @@ cli_specification:
         descriptors: <swarm-dir>/contexts/<context-name>.json
         current_selector: <swarm-dir>/contexts/current
         lock: <swarm-dir>/contexts/.lock
+        project_claims: <swarm-dir>/contexts/.project-claims/<hash>.claim
         name_rule: >
           Context names are trimmed UTF-8 strings that cannot be empty, '.', '..', contain path separators, contain NUL,
-          or start with '.'. Names are registry keys only; project auto-naming is split to #1614.
+          or start with '.'. #1614 auto-generates project context names from the project basename plus a short hash of
+          the canonical project-root realpath when `serve --dev --context` is not supplied.
       descriptor_schema:
         version: 1
         required_fields:
@@ -11814,6 +11853,10 @@ cli_specification:
           Registry mutations acquire the registry lock, write complete JSON/text to a temporary file in the registry
           directory, fsync-or-equivalent that file, rename it over the destination, and best-effort fsync the directory.
           Lock contention, permission denial, and partial/corrupt files fail closed.
+        project_claim_rule: >
+          `serve --dev` acquires a project-claim file before listener binding and runtime-store side effects, then writes
+          the final descriptor only after the API listener address and runtime_instance_id are known. Failed startup
+          releases the claim and must not leave a descriptor selected as current.
       validation_statuses:
       - ok
       - no_server
@@ -11832,8 +11875,8 @@ cli_specification:
         doctor_consumption: swarm doctor --target reports registry and runtime identity facts using these primitives
         output_owner: cli_specification.foundations.output_contract
       implementation_boundaries:
-      - 'No `serve --dev` or `serve` project-scoped descriptor registration in #1613; #1614 owns that behavior.'
-      - 'No API-backed command target resolver consumes context descriptors in #1613; #1614 owns consumption.'
+      - '`serve --dev` project-scoped TCP descriptor registration is consumed by #1614; non-dev serve registration remains unpromoted.'
+      - 'API-backed command target resolver consumes context descriptors through #1614 only.'
       - 'No runtime store/data path migration or `swarm run` behavior change in #1613; #1615 owns that behavior.'
       - 'No unix socket dialing policy in #1613; #1576 owns actual IPC transport behavior.'
     api_connection_auth_config_precedence:


### PR DESCRIPTION
## Summary

Closes #1614.

Implements the approved #1614 TCP local-targeting slice:

- `serve --dev` registers a project-scoped local context descriptor after a pre-bind project claim and after the bound API target plus `runtime_instance_id` are known.
- API-backed CLI commands resolve targets through the canonical resolver: explicit API flags, explicit `--context`, API env/config, live project context, fail-closed project context errors, selected/default context, then built-in loopback default by command class.
- Mutating/control commands do not silently fall through from inside a project with no live project context.
- `doctor --target` reports real project-scoped context status instead of the previous #1614 pending placeholder.
- `platform-spec.yaml` now contains the exact current API-backed command-class matrix for this slice.

## Governing Refs

- `platform-spec.yaml#cli_specification.foundations.local_target_resolution_authority`
- `platform-spec.yaml#cli_specification.foundations.local_context_registry_authority`
- `platform-spec.yaml#cli_specification.foundations.api_connection_auth_config_precedence`
- `platform-spec.yaml#cli_specification.foundations.contract_platform_spec_path_resolution`
- `platform-spec.yaml#cli_specification.foundations.output_contract`
- `platform-spec.yaml#api_specification.method_catalog.runtime.identity`

Repository docs requested by the handoff, `docs/IMPLEMENTER_GUIDELINES.md` and `docs/SEMANTIC_DRIFT.md`, are absent in this tree; this matches the pre-audit record.

## Semantic Migration

- New canonical owner consumed by production commands: `local_target_resolution_authority` plus `local_context_registry_authority` and `runtime.identity`.
- Old path now invalid: API-backed commands using only endpoint/env/config/default loopback when a live project context exists.
- Old path still deliberately split: `swarm run` default/foreground behavior, store/data migration, legacy `.swarm/dev.db`, and IPC/unix dialing remain #1615/#1576-owned.
- Production paths checked for surviving old behavior: all current `newCLIAPIClient` consumers in `cmd/swarm`, guarded by `api_consumption_boundary_test.go` and the exact command-class spec table.
- Migration completeness: complete for #1614 TCP project-scoped `serve --dev` registration and API-backed command target resolution; broader parent remains open for #1615/#1576 tails.

## Tests

- `go test ./cmd/swarm`
- `go test ./...` initially hit a flaky unrelated `internal/runtime/bus` async timing timeout, then `go test ./internal/runtime/bus` passed, and a second `go test ./...` passed cleanly.