### PR TITLE
[agent-e][issue #1533] Add _entity platform metadata root

### DIFF
--- a/internal/runtime/bootverify/platform_entity_namespace_test.go
+++ b/internal/runtime/bootverify/platform_entity_namespace_test.go
@@ -1,0 +1,94 @@
+package bootverify
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
+	"github.com/division-sh/swarm/internal/runtime/semanticview"
+)
+
+func TestWave1EntityResolverSplitsBusinessEntityAndPlatformEntity(t *testing.T) {
+	source := semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
+		RootEntities: runtimecontracts.EntityContractsDocument{
+			"record": {
+				Fields: map[string]runtimecontracts.EntityFieldDecl{
+					"current_state": {Type: "text"},
+					"name":          {Type: "text"},
+				},
+			},
+		},
+	})
+
+	if got, _, err := wave1ResolveEntityPathWithOwner(source, "", "current_state"); err != nil {
+		t.Fatalf("entity.current_state declared business field failed to resolve: %v", err)
+	} else if got.Kind != "scalar" || got.Type != "text" {
+		t.Fatalf("entity.current_state = %#v, want scalar text", got)
+	}
+
+	for _, ref := range []string{"id", "current_state", "flow_instance", "gates.reviewed"} {
+		got, err := wave1ResolvePlatformEntityPath(ref)
+		if err != nil {
+			t.Fatalf("_entity.%s failed to resolve: %v", ref, err)
+		}
+		if got.Kind == "" || got.Type == "" {
+			t.Fatalf("_entity.%s resolved to empty type %#v", ref, got)
+		}
+	}
+}
+
+func TestWave1EntityResolverRejectsLegacyAndUnsupportedPlatformEntityFields(t *testing.T) {
+	source := semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
+		RootEntities: runtimecontracts.EntityContractsDocument{
+			"record": {
+				Fields: map[string]runtimecontracts.EntityFieldDecl{
+					"name": {Type: "text"},
+				},
+			},
+		},
+	})
+
+	if _, _, err := wave1ResolveEntityPathWithOwner(source, "", "current_state"); err == nil {
+		t.Fatal("expected undeclared entity.current_state platform metadata read to fail")
+	} else if !strings.Contains(err.Error(), "use _entity.current_state") {
+		t.Fatalf("entity.current_state error = %q, want _entity.current_state guidance", err)
+	}
+	if _, _, err := wave1ResolveEntityPathWithOwner(source, "", "entity_id"); err == nil {
+		t.Fatal("expected undeclared entity.entity_id platform metadata read to fail")
+	} else if !strings.Contains(err.Error(), "use _entity.id") {
+		t.Fatalf("entity.entity_id error = %q, want _entity.id guidance", err)
+	}
+
+	for _, ref := range []string{"entity_id", "revision", "created_at", "updated_at", "workflow_name", "name"} {
+		if _, err := wave1ResolvePlatformEntityPath(ref); err == nil {
+			t.Fatalf("expected _entity.%s to be unsupported", ref)
+		}
+	}
+}
+
+func TestRun_RejectsSelectEntityByPlatformEntitySourceAuthority(t *testing.T) {
+	for _, acquisition := range []string{"select_entity", "select_or_create_entity"} {
+		t.Run(acquisition, func(t *testing.T) {
+			root := writeSelectEntityInputPinFixture(t, `
+treasury-node:
+  id: treasury-node
+  execution_type: system_node
+  subscribes_to: [opco.spend_requested]
+  event_handlers:
+    opco.spend_requested:
+      `+acquisition+`:
+        by:
+          vertical_id: _entity.id
+`)
+			bundle := loadFixtureBundleAt(t, repoRootForBootverifyTest(t), root, runtimecontracts.DefaultPlatformSpecFile(repoRootForBootverifyTest(t)))
+
+			report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+
+			if !reportContains(report.Errors(), "select_entity_validation", "must resolve from payload.*") ||
+				!reportContains(report.Errors(), "select_entity_validation", "_entity.id") {
+				t.Fatalf("expected %s to reject _entity source authority, got %#v", acquisition, report.Errors())
+			}
+		})
+	}
+}

--- a/internal/runtime/bootverify/report_test.go
+++ b/internal/runtime/bootverify/report_test.go
@@ -5133,6 +5133,70 @@ treasury-node:
 	}
 }
 
+func TestRun_RejectsPlatformEntityDataAccumulationWriteTarget(t *testing.T) {
+	bundle := &runtimecontracts.WorkflowContractBundle{
+		RootEntities: runtimecontracts.EntityContractsDocument{
+			"subject": {
+				Fields: map[string]runtimecontracts.EntityFieldDecl{
+					"business": {Type: "text"},
+				},
+			},
+		},
+		Nodes: map[string]runtimecontracts.SystemNodeContract{
+			"node-a": {
+				EventHandlers: map[string]runtimecontracts.SystemNodeEventHandler{
+					"item.received": {
+						DataAccumulation: runtimecontracts.WorkflowDataAccumulation{
+							Writes: []runtimecontracts.WorkflowDataWrite{{
+								TargetPathRef: "_entity.current_state",
+								Value:         runtimecontracts.CELExpression(`"done"`),
+							}},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+
+	if !reportContains(report.Errors(), "entity_write_target_compliance", "_entity.current_state") ||
+		!reportContains(report.Errors(), "entity_write_target_compliance", "read-only platform entity metadata") {
+		t.Fatalf("expected platform entity data_accumulation write target error, got %#v", report.Errors())
+	}
+}
+
+func TestRun_RejectsPlatformEntityStoreAsWriteTarget(t *testing.T) {
+	bundle := &runtimecontracts.WorkflowContractBundle{
+		RootEntities: runtimecontracts.EntityContractsDocument{
+			"subject": {
+				Fields: map[string]runtimecontracts.EntityFieldDecl{
+					"business": {Type: "text"},
+				},
+			},
+		},
+		Nodes: map[string]runtimecontracts.SystemNodeContract{
+			"node-a": {
+				EventHandlers: map[string]runtimecontracts.SystemNodeEventHandler{
+					"item.received": {
+						Count: &runtimecontracts.CountSpec{
+							Source:  "payload.items",
+							StoreAs: "_entity.current_state",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+
+	if !reportContains(report.Errors(), "entity_write_target_compliance", "_entity.current_state") ||
+		!reportContains(report.Errors(), "entity_write_target_compliance", "read-only platform entity metadata") {
+		t.Fatalf("expected platform entity store_as write target error, got %#v", report.Errors())
+	}
+}
+
 func TestRun_RejectsSelectOrCreateEntityWithUndeclaredPayloadRef(t *testing.T) {
 	root := writeSelectEntityInputPinFixture(t, `
 treasury-node:

--- a/internal/runtime/bootverify/report_test.go
+++ b/internal/runtime/bootverify/report_test.go
@@ -2779,7 +2779,7 @@ func TestRun_RejectsUnsupportedGuardOnFail(t *testing.T) {
 				EventHandlers: map[string]runtimecontracts.SystemNodeEventHandler{
 					"item.received": {
 						Guard: &runtimecontracts.GuardSpec{
-							Check:  "entity.entity_id != null",
+							Check:  "_entity.id != null",
 							OnFail: "explode",
 						},
 					},
@@ -2803,7 +2803,7 @@ func TestRun_RejectsGuardEscalateObjectMissingEvent(t *testing.T) {
 				EventHandlers: map[string]runtimecontracts.SystemNodeEventHandler{
 					"item.received": {
 						Guard: &runtimecontracts.GuardSpec{
-							Check: "entity.entity_id != null",
+							Check: "_entity.id != null",
 							OnFailSpec: runtimecontracts.GuardFailureSpec{
 								Action:          runtimecontracts.GuardFailureActionEscalate,
 								AuthoredMapping: true,
@@ -2829,7 +2829,7 @@ func TestRun_RejectsMalformedConditionCELAfterRecognizedPrefix(t *testing.T) {
 				ID: "test-node",
 				EventHandlers: map[string]runtimecontracts.SystemNodeEventHandler{
 					"item.received": {
-						Guard: &runtimecontracts.GuardSpec{Check: "entity.entity_id =="},
+						Guard: &runtimecontracts.GuardSpec{Check: "_entity.id =="},
 					},
 				},
 			},
@@ -2838,7 +2838,7 @@ func TestRun_RejectsMalformedConditionCELAfterRecognizedPrefix(t *testing.T) {
 
 	report := Run(context.Background(), source, Options{})
 
-	if !reportContains(report.Errors(), "condition_expression_validation", `CEL parse failed for "entity.entity_id =="`) {
+	if !reportContains(report.Errors(), "condition_expression_validation", `CEL parse failed for "_entity.id =="`) {
 		t.Fatalf("expected CEL parse failure, got %#v", report.Errors())
 	}
 }
@@ -4604,7 +4604,7 @@ func TestRun_AllowsCreateEntityEmitFieldReadOfDeclaredFieldEvenWhenOnlyRuleWrite
 	flowID, nodeID, eventType, handler := firstFlowHandlerInFlowView(t, bundle)
 	handler.CreateEntity = true
 	handler.Rules = []runtimecontracts.HandlerRuleEntry{{
-		Condition: "entity.entity_id != null",
+		Condition: "_entity.id != null",
 		DataAccumulation: runtimecontracts.WorkflowDataAccumulation{
 			Writes: []runtimecontracts.WorkflowDataWrite{{
 				TargetField: "revision_count",
@@ -4632,7 +4632,7 @@ func TestRun_AllowsCreateEntityEmitFieldReadOfDeclaredFieldEvenWhenOnlyRuleCompu
 	flowID, nodeID, eventType, handler := firstFlowHandlerInFlowView(t, bundle)
 	handler.CreateEntity = true
 	handler.Rules = []runtimecontracts.HandlerRuleEntry{{
-		Condition: "entity.entity_id != null",
+		Condition: "_entity.id != null",
 		Compute: &runtimecontracts.ComputeSpec{
 			Operation: runtimecontracts.ComputeOpCount,
 			StoreAs:   "entity.revision_count",
@@ -4662,7 +4662,7 @@ func TestRun_AllowsCreateEntityEmitFieldReadWhenRuleAlsoWritesUnconditionallyAva
 		StoreAs:   "entity.revision_count",
 	}
 	handler.Rules = []runtimecontracts.HandlerRuleEntry{{
-		Condition: "entity.entity_id != null",
+		Condition: "_entity.id != null",
 		DataAccumulation: runtimecontracts.WorkflowDataAccumulation{
 			Writes: []runtimecontracts.WorkflowDataWrite{{
 				TargetField: "revision_count",

--- a/internal/runtime/bootverify/wave1_entity_contracts.go
+++ b/internal/runtime/bootverify/wave1_entity_contracts.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
+	"github.com/division-sh/swarm/internal/runtime/platformcontext"
 	"github.com/division-sh/swarm/internal/runtime/semanticview"
 )
 
@@ -21,17 +22,10 @@ type wave1ResolvedType struct {
 	Type string
 }
 
-var wave1EnvelopeTypes = map[string]wave1ResolvedType{
-	"entity_id":        {Kind: "scalar", Type: "uuid"},
-	"flow_instance":    {Kind: "scalar", Type: "text"},
-	"entity_type":      {Kind: "scalar", Type: "text"},
-	"name":             {Kind: "scalar", Type: "text"},
-	"current_state":    {Kind: "scalar", Type: "text"},
-	"revision":         {Kind: "scalar", Type: "integer"},
-	"created_at":       {Kind: "scalar", Type: "timestamp"},
-	"updated_at":       {Kind: "scalar", Type: "timestamp"},
-	"workflow_name":    {Kind: "scalar", Type: "text"},
-	"workflow_version": {Kind: "scalar", Type: "text"},
+var wave1PlatformEntityTypes = map[string]wave1ResolvedType{
+	"id":            {Kind: "scalar", Type: "uuid"},
+	"flow_instance": {Kind: "scalar", Type: "text"},
+	"current_state": {Kind: "scalar", Type: "text"},
 }
 
 func wave1EntityContractForFlow(source semanticview.Source, flowID string) wave1EntityContractView {
@@ -130,19 +124,6 @@ func wave1ResolveEntityPathWithOwner(source semanticview.Source, flowID, ref str
 	}
 	segments := strings.Split(ref, ".")
 	head := strings.TrimSpace(segments[0])
-	if resolved, ok := wave1EnvelopeTypes[head]; ok {
-		if len(segments) > 1 {
-			return wave1ResolvedType{}, "", fmt.Errorf("entity.%s is an envelope scalar and does not support nested path %q", head, ref)
-		}
-		return resolved, "", nil
-	}
-	if head == "gates" {
-		if len(segments) == 1 {
-			return wave1ResolvedType{Kind: "named", Type: "gates"}, "", nil
-		}
-		return wave1ResolvedType{Kind: "scalar", Type: "boolean"}, "", nil
-	}
-
 	view := wave1EntityContractForFlow(source, flowID)
 	if !view.Defined || view.Contract.Fields == nil {
 		if flowID != "" && wave1FlowReadsRootField(source, flowID, head) {
@@ -165,6 +146,9 @@ func wave1ResolveEntityPathWithOwner(source semanticview.Source, flowID, ref str
 		}
 	}
 	if !ok {
+		if platformcontext.LegacyEntityMetadataField(head) {
+			return wave1ResolvedType{}, "", fmt.Errorf("%s", legacyEntityMetadataDiagnostic(head))
+		}
 		return wave1ResolvedType{}, "", fmt.Errorf("flow %s entity_type %s does not declare field %q", defaultFlowLabel(flowID), view.EntityType, head)
 	}
 	current := strings.TrimSpace(field.Type)
@@ -203,6 +187,46 @@ func wave1ResolveEntityPathWithOwner(source semanticview.Source, flowID, ref str
 		return wave1ResolvedType{}, "", fmt.Errorf("entity path %q: %w", ref, err)
 	}
 	return wave1ResolvedType{Kind: kind, Type: current}, view.FlowID, nil
+}
+
+func wave1ResolvePlatformEntityPath(ref string) (wave1ResolvedType, error) {
+	ref = strings.TrimSpace(strings.TrimPrefix(strings.TrimSpace(ref), platformcontext.EntityRoot+"."))
+	if ref == "" {
+		return wave1ResolvedType{}, fmt.Errorf("_entity field path is required")
+	}
+	segments := strings.Split(ref, ".")
+	head := strings.TrimSpace(segments[0])
+	if head == "gates" {
+		if len(segments) == 1 {
+			return wave1ResolvedType{Kind: "named", Type: "gates"}, nil
+		}
+		if len(segments) > 2 {
+			return wave1ResolvedType{}, fmt.Errorf("_entity.gates supports one gate name segment; got %q", ref)
+		}
+		return wave1ResolvedType{Kind: "scalar", Type: "boolean"}, nil
+	}
+	if resolved, ok := wave1PlatformEntityTypes[head]; ok {
+		if len(segments) > 1 {
+			return wave1ResolvedType{}, fmt.Errorf("_entity.%s is a platform scalar and does not support nested path %q", head, ref)
+		}
+		return resolved, nil
+	}
+	if platformcontext.EntityFieldUnsupported(head) {
+		return wave1ResolvedType{}, fmt.Errorf("_entity.%s is not exposed; supported _entity fields are id, current_state, flow_instance, and gates", head)
+	}
+	return wave1ResolvedType{}, fmt.Errorf("_entity.%s is not a supported platform entity metadata field", head)
+}
+
+func legacyEntityMetadataDiagnostic(field string) string {
+	field = strings.TrimSpace(field)
+	switch field {
+	case "entity_id":
+		return "entity.entity_id is platform entity metadata; use _entity.id"
+	case "current_state", "flow_instance", "gates":
+		return fmt.Sprintf("entity.%s is platform entity metadata; use _entity.%s", field, field)
+	default:
+		return fmt.Sprintf("entity.%s is platform entity metadata and is not supported through entity.*", field)
+	}
 }
 
 func wave1ResolveNamedType(types runtimecontracts.TypeCatalogDocument, typeRef string) (string, runtimecontracts.NamedTypeDecl, error) {
@@ -270,10 +294,5 @@ func defaultFlowLabel(flowID string) string {
 }
 
 func wave1EntityEnvelopeField(field string) bool {
-	field = strings.TrimSpace(field)
-	if field == "gates" {
-		return true
-	}
-	_, ok := wave1EnvelopeTypes[field]
-	return ok
+	return platformcontext.LegacyEntityMetadataField(field)
 }

--- a/internal/runtime/bootverify/workflow_accumulator_projection_checks.go
+++ b/internal/runtime/bootverify/workflow_accumulator_projection_checks.go
@@ -35,7 +35,7 @@ func (c *checkerContext) accumulatorEntityProjection() []Finding {
 func accumulatorProjectionWriterConflictFindings(c *checkerContext, binding accprojection.Binding) []Finding {
 	out := make([]Finding, 0)
 	for _, target := range wave1AllEntityWriteTargets(c.source) {
-		if !target.Entity || wave1EntityEnvelopeField(target.Field) || wave1SpecialClearTarget(target.Field) {
+		if !target.Entity || wave1SpecialClearTarget(target.Field) {
 			continue
 		}
 		_, ownerFlowID, rootField, err := wave1ResolveWriteTargetPath(c.source, target)

--- a/internal/runtime/bootverify/workflow_composition_connect_checks.go
+++ b/internal/runtime/bootverify/workflow_composition_connect_checks.go
@@ -366,6 +366,9 @@ func compositionConnectTargetType(source semanticview.Source, flowID, expr strin
 	if expr == "" {
 		return "", fmt.Errorf("target expression is required")
 	}
+	if expr == "_entity.id" {
+		return "uuid", nil
+	}
 	if strings.HasPrefix(expr, "entity.") {
 		fieldPath := strings.TrimPrefix(expr, "entity.")
 		contract, ok := entityruntime.ResolveForFlow(source, flowID)
@@ -396,12 +399,14 @@ func compositionConnectTargetType(source semanticview.Source, flowID, expr strin
 	if strings.HasPrefix(expr, "instance.") {
 		return "string", nil
 	}
-	return "", fmt.Errorf("target expression %q must be entity.*, config.*, or instance.*", expr)
+	return "", fmt.Errorf("target expression %q must be _entity.id, entity.*, config.*, or instance.*", expr)
 }
 
 func compositionConnectTargetIndexed(source semanticview.Source, flowID, expr string) error {
 	expr = strings.TrimSpace(expr)
 	switch {
+	case expr == "_entity.id":
+		return nil
 	case strings.HasPrefix(expr, "entity."):
 		fieldPath := strings.TrimSpace(strings.TrimPrefix(expr, "entity."))
 		switch fieldPath {

--- a/internal/runtime/bootverify/workflow_composition_connect_checks_test.go
+++ b/internal/runtime/bootverify/workflow_composition_connect_checks_test.go
@@ -789,7 +789,7 @@ connect:
     map:
       entity_id:
         source: payload.entity_id
-        target: entity.entity_id
+        target: _entity.id
 `)
 	writeBootverifyFixtureFile(t, filepath.Join(root, "schema.yaml"), `
 name: root-auto-emit-key-carries
@@ -822,7 +822,7 @@ pins:
         address:
           by: entity_id
           source: payload.entity_id
-          target: entity.entity_id
+          target: _entity.id
           cardinality: one
 `)
 	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "consumer", "policy.yaml"), "{}\n")

--- a/internal/runtime/bootverify/workflow_cross_surface_named_type_checks.go
+++ b/internal/runtime/bootverify/workflow_cross_surface_named_type_checks.go
@@ -253,9 +253,6 @@ func crossSurfaceEventPayloadFields(entry runtimecontracts.EventCatalogEntry) ma
 func crossSurfaceEntityFields(contract runtimecontracts.EntityContract) map[string]string {
 	fields := make(map[string]string, len(contract.Fields))
 	for name, spec := range contract.Fields {
-		if wave1EntityEnvelopeField(name) {
-			continue
-		}
 		fields[name] = spec.Type
 	}
 	return fields

--- a/internal/runtime/bootverify/workflow_entity_contract_coverage_checks.go
+++ b/internal/runtime/bootverify/workflow_entity_contract_coverage_checks.go
@@ -606,6 +606,11 @@ func wave1ParseWriteTarget(flowID, nodeID, eventType, kind, target string) wave1
 	if strings.HasPrefix(target, "metadata.") {
 		return write
 	}
+	if target == platformcontext.EntityRoot || strings.HasPrefix(target, platformcontext.EntityRoot+".") {
+		write.Entity = true
+		write.Field = platformcontext.EntityRoot
+		return write
+	}
 	if strings.HasPrefix(target, "gates.") || target == "gates" {
 		write.Field = "gates"
 		write.Entity = false

--- a/internal/runtime/bootverify/workflow_entity_contract_coverage_checks.go
+++ b/internal/runtime/bootverify/workflow_entity_contract_coverage_checks.go
@@ -8,6 +8,7 @@ import (
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
 	"github.com/division-sh/swarm/internal/runtime/entityruntime"
 	runtimepipeline "github.com/division-sh/swarm/internal/runtime/pipeline"
+	"github.com/division-sh/swarm/internal/runtime/platformcontext"
 	"github.com/division-sh/swarm/internal/runtime/semanticview"
 )
 
@@ -38,7 +39,7 @@ func wave1SpecialClearTarget(target string) bool {
 }
 
 func wave1WriteTargetContract(source semanticview.Source, target wave1WriteTarget) (wave1EntityContractView, bool) {
-	if !target.Entity || wave1EntityEnvelopeField(target.Field) {
+	if !target.Entity {
 		return wave1EntityContractView{}, false
 	}
 	if _, ownerFlowID, _, err := wave1ResolveWriteTargetPath(source, target); err == nil {
@@ -77,7 +78,7 @@ func (c *checkerContext) entityWriterCoverage() []Finding {
 	for _, contract := range wave1DeclaredEntityContracts(c.source) {
 		for fieldName, fieldDecl := range contract.Contract.Fields {
 			fieldName = strings.TrimSpace(fieldName)
-			if fieldName == "" || wave1EntityEnvelopeField(fieldName) {
+			if fieldName == "" {
 				continue
 			}
 			if fieldDecl.Initial != nil {
@@ -134,15 +135,6 @@ func (c *checkerContext) entityWriteTargetCompliance() []Finding {
 			continue
 		}
 		_ = resolved
-		if wave1EntityEnvelopeField(rootField) {
-			c.entityWriteTargetComplianceFindings = append(c.entityWriteTargetComplianceFindings, Finding{
-				CheckID:  "entity_write_target_compliance",
-				Severity: SeverityHardInvalidity,
-				Message:  fmt.Sprintf("flow %s node %s handler %s %s targets envelope field %q; envelope fields are platform-owned", defaultFlowLabel(target.FlowID), target.NodeID, target.EventType, target.Kind, rootField),
-				Location: target.NodeID,
-			})
-			continue
-		}
 		contract, ok := wave1WriteTargetContract(c.source, target)
 		if !ok {
 			c.entityWriteTargetComplianceFindings = append(c.entityWriteTargetComplianceFindings, Finding{
@@ -178,7 +170,7 @@ func (c *checkerContext) entityReaderCoverage() []Finding {
 	for _, contract := range wave1DeclaredEntityContracts(c.source) {
 		for fieldName, fieldDecl := range contract.Contract.Fields {
 			fieldName = strings.TrimSpace(fieldName)
-			if fieldName == "" || wave1EntityEnvelopeField(fieldName) {
+			if fieldName == "" {
 				continue
 			}
 			if strings.TrimSpace(fieldDecl.UnusedReaderReason) != "" {
@@ -226,7 +218,7 @@ func wave1DeclaredEntityContracts(source semanticview.Source) []wave1EntityContr
 func wave1EntityWriterCoverageByFlow(source semanticview.Source) map[string]map[string]struct{} {
 	out := map[string]map[string]struct{}{}
 	for _, target := range wave1AllEntityWriteTargets(source) {
-		if !target.Entity || wave1EntityEnvelopeField(target.Field) || wave1SpecialClearTarget(target.Field) {
+		if !target.Entity || wave1SpecialClearTarget(target.Field) {
 			continue
 		}
 		_, ownerFlowID, rootField, err := wave1ResolveWriteTargetPath(source, target)
@@ -268,12 +260,12 @@ func wave1AgentExplicitEntityWriteCoverageByFlow(source semanticview.Source) map
 				out[contract.FlowID] = map[string]struct{}{}
 			}
 			for _, field := range decl.Create.Fields {
-				if _, declared := contract.Contract.Fields[field]; declared && !wave1EntityEnvelopeField(field) {
+				if _, declared := contract.Contract.Fields[field]; declared {
 					out[contract.FlowID][field] = struct{}{}
 				}
 			}
 			for _, field := range decl.Save.Fields {
-				if _, declared := contract.Contract.Fields[field]; declared && !wave1EntityEnvelopeField(field) {
+				if _, declared := contract.Contract.Fields[field]; declared {
 					out[contract.FlowID][field] = struct{}{}
 				}
 			}
@@ -466,9 +458,6 @@ func wave1EntityReaderCoverageByFlow(source semanticview.Source) map[string]map[
 			eventType = strings.TrimSpace(eventType)
 			for _, expr := range handlerEntityExpressions(handler) {
 				for _, ref := range wave1ResolvedExpressionRefs(source, flowID, nodeID, eventType, expr) {
-					if wave1EntityEnvelopeField(ref.Field) {
-						continue
-					}
 					ownerFlowID := strings.TrimSpace(ref.OwnerFlowID)
 					if out[ownerFlowID] == nil {
 						out[ownerFlowID] = map[string]struct{}{}
@@ -659,6 +648,9 @@ func wave1ResolveWriteTargetPath(source semanticview.Source, target wave1WriteTa
 			if root, ok := wave1RootFieldContract(source, rootField); ok {
 				return wave1ResolvedType{}, strings.TrimSpace(root.FlowID), strings.TrimSpace(rootField), nil
 			}
+		}
+		if platformcontext.LegacyEntityMetadataField(rootField) {
+			return wave1ResolvedType{}, "", "", fmt.Errorf("%s", legacyEntityMetadataDiagnostic(rootField))
 		}
 		return wave1ResolvedType{}, strings.TrimSpace(target.FlowID), strings.TrimSpace(rootField), nil
 	}

--- a/internal/runtime/bootverify/workflow_expression_checks.go
+++ b/internal/runtime/bootverify/workflow_expression_checks.go
@@ -170,6 +170,40 @@ func (c *checkerContext) expressionFieldReferences() []Finding {
 						})
 					}
 				}
+				for _, ref := range runtimepipeline.WorkflowPlatformEntityReferences(expr.Expression) {
+					ref = strings.TrimSpace(ref)
+					if ref == "" {
+						continue
+					}
+					leaf, err := wave1ResolvePlatformEntityPath(ref)
+					if err != nil {
+						key := strings.Join([]string{flowID, nodeID, eventType, expr.Kind, "_entity." + ref}, "|")
+						if _, ok := seen[key]; ok {
+							continue
+						}
+						seen[key] = struct{}{}
+						c.entityRefFindings = append(c.entityRefFindings, Finding{
+							CheckID:  "expression_field_reference_validation",
+							Severity: SeverityHardInvalidity,
+							Message:  fmt.Sprintf("flow %s node %s handler %s references _entity.%s in %s but %v", defaultFlowLabel(flowID), nodeID, eventType, ref, expr.Kind, err),
+							Location: nodeID,
+						})
+						continue
+					}
+					if expr.Kind == "query filter" && leaf.Kind != "scalar" && leaf.Kind != "enum" {
+						key := strings.Join([]string{flowID, nodeID, eventType, expr.Kind, "_entity." + ref, leaf.Kind}, "|")
+						if _, ok := seen[key]; ok {
+							continue
+						}
+						seen[key] = struct{}{}
+						c.entityRefFindings = append(c.entityRefFindings, Finding{
+							CheckID:  "expression_field_reference_validation",
+							Severity: SeverityHardInvalidity,
+							Message:  fmt.Sprintf("flow %s node %s handler %s query filter path _entity.%s must resolve to scalar or enum leaf, got %s", defaultFlowLabel(flowID), nodeID, eventType, ref, leaf.Type),
+							Location: nodeID,
+						})
+					}
+				}
 			}
 		}
 	}

--- a/internal/runtime/bootverify/workflow_node_state_schema_checks.go
+++ b/internal/runtime/bootverify/workflow_node_state_schema_checks.go
@@ -125,7 +125,7 @@ func nodeStateTypedCounterparts(source semanticview.Source, flowID string) []nod
 		}
 		sort.Strings(fieldNames)
 		for _, fieldName := range fieldNames {
-			if fieldName == "" || wave1EntityEnvelopeField(fieldName) {
+			if fieldName == "" {
 				continue
 			}
 			typeRef := strings.TrimSpace(view.Contract.Fields[fieldName].Type)

--- a/internal/runtime/bus/connect_route_plan_dispatch_test.go
+++ b/internal/runtime/bus/connect_route_plan_dispatch_test.go
@@ -2308,7 +2308,7 @@ func connectRoutePlanFanoutSource() semanticview.Source {
 				Address: &runtimecontracts.FlowInputPinAddress{
 					By:          "team_entity",
 					Source:      "payload.team_entity",
-					Target:      "entity.entity_id",
+					Target:      "_entity.id",
 					Cardinality: "many",
 				},
 			}},

--- a/internal/runtime/core/paths/path.go
+++ b/internal/runtime/core/paths/path.go
@@ -9,6 +9,7 @@ const (
 	RootPayload
 	RootEvent
 	RootEntity
+	RootPlatformEntity
 	RootPolicy
 	RootMetadata
 	RootGates
@@ -25,6 +26,8 @@ func (r PathRoot) String() string {
 		return "event"
 	case RootEntity:
 		return "entity"
+	case RootPlatformEntity:
+		return "_entity"
 	case RootPolicy:
 		return "policy"
 	case RootMetadata:
@@ -80,6 +83,8 @@ func parseRoot(text string) PathRoot {
 		return RootEvent
 	case "entity":
 		return RootEntity
+	case "_entity":
+		return RootPlatformEntity
 	case "policy":
 		return RootPolicy
 	case "metadata":

--- a/internal/runtime/core/pinrouting/connect_route_plan.go
+++ b/internal/runtime/core/pinrouting/connect_route_plan.go
@@ -842,6 +842,16 @@ func addressTargetSupported(expr string, supportedTargets []string) bool {
 
 func normalizeAddressTarget(expr string) string {
 	expr = strings.TrimSpace(expr)
+	if strings.HasPrefix(expr, "_entity.") {
+		switch value := strings.TrimSpace(strings.TrimPrefix(expr, "_entity.")); value {
+		case "id":
+			return "entity_id"
+		case "flow_instance":
+			return "flow_instance"
+		default:
+			return value
+		}
+	}
 	for _, prefix := range []string{"entity.", "instance.", "event.target.", "target."} {
 		if strings.HasPrefix(expr, prefix) {
 			return strings.TrimSpace(strings.TrimPrefix(expr, prefix))
@@ -858,6 +868,9 @@ func normalizeAddressTargetKey(expr string) string {
 	if strings.HasPrefix(expr, "entity.") {
 		return "entity." + strings.TrimSpace(strings.TrimPrefix(expr, "entity."))
 	}
+	if strings.HasPrefix(expr, "_entity.") {
+		return "_entity." + strings.TrimSpace(strings.TrimPrefix(expr, "_entity."))
+	}
 	if strings.HasPrefix(expr, "config.") {
 		return "config." + strings.TrimSpace(strings.TrimPrefix(expr, "config."))
 	}
@@ -866,7 +879,7 @@ func normalizeAddressTargetKey(expr string) string {
 	}
 	switch normalizeAddressTarget(expr) {
 	case "entity_id":
-		return "entity.entity_id"
+		return "_entity.id"
 	case "flow_instance":
 		return "instance.flow_instance"
 	case "instance_id":

--- a/internal/runtime/core/pinrouting/connect_route_plan_test.go
+++ b/internal/runtime/core/pinrouting/connect_route_plan_test.go
@@ -522,7 +522,7 @@ func TestMaterializeConnectRoutePlanFanoutForTemplateDescriptors(t *testing.T) {
 				Address: &runtimecontracts.FlowInputPinAddress{
 					By:          "team_entity",
 					Source:      "payload.team_entity",
-					Target:      "entity.entity_id",
+					Target:      "_entity.id",
 					Cardinality: "many",
 				},
 			}},

--- a/internal/runtime/core/values/context.go
+++ b/internal/runtime/core/values/context.go
@@ -3,42 +3,45 @@ package values
 import "github.com/division-sh/swarm/internal/runtime/core/paths"
 
 type Context struct {
-	Entity      Bucket
-	Event       Bucket
-	Policy      Bucket
-	Metadata    Bucket
-	Gates       Bucket
-	Payload     Bucket
-	Accumulated Bucket
-	FanOut      Bucket
-	Computed    Bucket
+	Entity         Bucket
+	PlatformEntity Bucket
+	Event          Bucket
+	Policy         Bucket
+	Metadata       Bucket
+	Gates          Bucket
+	Payload        Bucket
+	Accumulated    Bucket
+	FanOut         Bucket
+	Computed       Bucket
 }
 
 func NewContext() Context {
 	return Context{
-		Entity:      Wrap(map[string]any{}),
-		Event:       Wrap(map[string]any{}),
-		Policy:      Wrap(map[string]any{}),
-		Metadata:    Wrap(map[string]any{}),
-		Gates:       Wrap(map[string]any{}),
-		Payload:     Wrap(map[string]any{}),
-		Accumulated: Wrap(map[string]any{}),
-		FanOut:      Wrap(map[string]any{}),
-		Computed:    Wrap(map[string]any{}),
+		Entity:         Wrap(map[string]any{}),
+		PlatformEntity: Wrap(map[string]any{}),
+		Event:          Wrap(map[string]any{}),
+		Policy:         Wrap(map[string]any{}),
+		Metadata:       Wrap(map[string]any{}),
+		Gates:          Wrap(map[string]any{}),
+		Payload:        Wrap(map[string]any{}),
+		Accumulated:    Wrap(map[string]any{}),
+		FanOut:         Wrap(map[string]any{}),
+		Computed:       Wrap(map[string]any{}),
 	}
 }
 
 func (c Context) Clone() Context {
 	return Context{
-		Entity:      c.Entity.Clone(),
-		Event:       c.Event.Clone(),
-		Policy:      c.Policy.Clone(),
-		Metadata:    c.Metadata.Clone(),
-		Gates:       c.Gates.Clone(),
-		Payload:     c.Payload.Clone(),
-		Accumulated: c.Accumulated.Clone(),
-		FanOut:      c.FanOut.Clone(),
-		Computed:    c.Computed.Clone(),
+		Entity:         c.Entity.Clone(),
+		PlatformEntity: c.PlatformEntity.Clone(),
+		Event:          c.Event.Clone(),
+		Policy:         c.Policy.Clone(),
+		Metadata:       c.Metadata.Clone(),
+		Gates:          c.Gates.Clone(),
+		Payload:        c.Payload.Clone(),
+		Accumulated:    c.Accumulated.Clone(),
+		FanOut:         c.FanOut.Clone(),
+		Computed:       c.Computed.Clone(),
 	}
 }
 
@@ -66,6 +69,8 @@ func (c Context) Bucket(root paths.PathRoot) Bucket {
 	switch root {
 	case paths.RootEntity:
 		return c.Entity
+	case paths.RootPlatformEntity:
+		return c.PlatformEntity
 	case paths.RootEvent:
 		return c.Event
 	case paths.RootPolicy:

--- a/internal/runtime/core/values/context.go
+++ b/internal/runtime/core/values/context.go
@@ -5,6 +5,7 @@ import "github.com/division-sh/swarm/internal/runtime/core/paths"
 type Context struct {
 	Entity         Bucket
 	PlatformEntity Bucket
+	FlowID         string
 	Event          Bucket
 	Policy         Bucket
 	Metadata       Bucket
@@ -19,6 +20,7 @@ func NewContext() Context {
 	return Context{
 		Entity:         Wrap(map[string]any{}),
 		PlatformEntity: Wrap(map[string]any{}),
+		FlowID:         "",
 		Event:          Wrap(map[string]any{}),
 		Policy:         Wrap(map[string]any{}),
 		Metadata:       Wrap(map[string]any{}),
@@ -34,6 +36,7 @@ func (c Context) Clone() Context {
 	return Context{
 		Entity:         c.Entity.Clone(),
 		PlatformEntity: c.PlatformEntity.Clone(),
+		FlowID:         c.FlowID,
 		Event:          c.Event.Clone(),
 		Policy:         c.Policy.Clone(),
 		Metadata:       c.Metadata.Clone(),

--- a/internal/runtime/engine/context_builder.go
+++ b/internal/runtime/engine/context_builder.go
@@ -1,6 +1,8 @@
 package engine
 
 import (
+	"strings"
+
 	"github.com/division-sh/swarm/internal/events"
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
 	"github.com/division-sh/swarm/internal/runtime/core/values"
@@ -30,7 +32,8 @@ func BuildBaseContext(input ContextBuilderInput) BaseContext {
 	materializedState := input.State
 	materializedState.StateCarrier.Metadata = materializedMetadata
 	base.Entity = values.Wrap(materializedState.EntityContext())
-	base.PlatformEntity = values.Wrap(materializedState.PlatformEntityContext(input.FlowID))
+	base.PlatformEntity = values.Wrap(materializedState.PlatformEntityContext(contextFlowInstance(input.State, input.Event, input.FlowID)))
+	base.FlowID = firstNonEmpty(strings.TrimSpace(input.State.WorkflowName), strings.TrimSpace(input.FlowID))
 	base.Metadata = values.Wrap(cloneStringAnyMap(input.State.StateCarrier.Metadata))
 	base.Gates = values.Wrap(boolMapToAnyMap(input.State.StateCarrier.Gates))
 	base.Event = values.Wrap(input.Event.ContextMap(input.State.CurrentState))
@@ -39,6 +42,18 @@ func BuildBaseContext(input ContextBuilderInput) BaseContext {
 		base.Policy = values.Wrap(policyDocumentToMap(input.Source.ResolvedPolicyForFlow(input.FlowID)))
 	}
 	return base
+}
+
+func contextFlowInstance(state StateSnapshot, evt events.Event, fallbackFlowID string) string {
+	return firstNonEmpty(
+		normalizedContextFlowInstance(asString(state.StateCarrier.Metadata["flow_path"])),
+		normalizedContextFlowInstance(evt.FlowInstance()),
+		normalizedContextFlowInstance(fallbackFlowID),
+	)
+}
+
+func normalizedContextFlowInstance(value string) string {
+	return strings.Trim(strings.TrimSpace(value), "/")
 }
 
 func WithPayload(base BaseContext, payload map[string]any) BaseContext {

--- a/internal/runtime/engine/context_builder.go
+++ b/internal/runtime/engine/context_builder.go
@@ -30,6 +30,7 @@ func BuildBaseContext(input ContextBuilderInput) BaseContext {
 	materializedState := input.State
 	materializedState.StateCarrier.Metadata = materializedMetadata
 	base.Entity = values.Wrap(materializedState.EntityContext())
+	base.PlatformEntity = values.Wrap(materializedState.PlatformEntityContext(input.FlowID))
 	base.Metadata = values.Wrap(cloneStringAnyMap(input.State.StateCarrier.Metadata))
 	base.Gates = values.Wrap(boolMapToAnyMap(input.State.StateCarrier.Gates))
 	base.Event = values.Wrap(input.Event.ContextMap(input.State.CurrentState))

--- a/internal/runtime/engine/context_builder_test.go
+++ b/internal/runtime/engine/context_builder_test.go
@@ -47,6 +47,29 @@ func TestBuildBaseContext_CopiesPayloadMetadataAndPolicy(t *testing.T) {
 	}
 }
 
+func TestBuildBaseContext_UsesConcreteFlowInstanceForPlatformEntity(t *testing.T) {
+	input := ContextBuilderInput{
+		FlowID: "child",
+		State: StateSnapshot{
+			EntityID:     "entity-1",
+			WorkflowName: "child",
+			CurrentState: "waiting",
+			StateCarrier: NewStateCarrier(map[string]any{
+				"flow_path": "child/inst-1",
+			}, nil, nil),
+		},
+	}
+
+	base := BuildBaseContext(input)
+
+	if got := base.PlatformEntity.Raw()["flow_instance"]; got != "child/inst-1" {
+		t.Fatalf("_entity.flow_instance = %#v, want concrete flow path", got)
+	}
+	if got := base.FlowID; got != "child" {
+		t.Fatalf("base FlowID = %q, want executing flow id", got)
+	}
+}
+
 func TestContextOverlayHelpers_DoNotMutateOriginal(t *testing.T) {
 	base := BaseContext{
 		Payload:     values.Wrap(map[string]any{"a": 1}),

--- a/internal/runtime/engine/context_builder_test.go
+++ b/internal/runtime/engine/context_builder_test.go
@@ -22,14 +22,17 @@ func TestBuildBaseContext_CopiesPayloadMetadataAndPolicy(t *testing.T) {
 
 	base := BuildBaseContext(input)
 
-	if got := base.Entity.Raw()["entity_id"]; got != "entity-1" {
-		t.Fatalf("entity_id = %#v", got)
+	if got := base.PlatformEntity.Raw()["id"]; got != "entity-1" {
+		t.Fatalf("_entity.id = %#v", got)
 	}
 	if got := base.Entity.Raw()["k"]; got != "v" {
 		t.Fatalf("entity metadata not reflected into entity context: %#v", got)
 	}
-	if got := base.Entity.Raw()["current_state"]; got != "researching" {
-		t.Fatalf("current_state = %#v", got)
+	if got := base.PlatformEntity.Raw()["current_state"]; got != "researching" {
+		t.Fatalf("_entity.current_state = %#v", got)
+	}
+	if _, ok := base.Entity.Raw()["current_state"]; ok {
+		t.Fatalf("platform current_state leaked into entity context: %#v", base.Entity.Raw())
 	}
 	if got := base.Gates.Bool("review"); !got {
 		t.Fatalf("gates bucket missing review: %#v", base.Gates.Raw())

--- a/internal/runtime/engine/executor.go
+++ b/internal/runtime/engine/executor.go
@@ -665,7 +665,7 @@ func (e *Executor) stepQuery(frame *executionFrame) error {
 		}
 		filtered := make([]any, 0, len(items))
 		for _, item := range items {
-			scope := newExecutionScope(item, frame.payload, frame.base.Event.Raw(), frame.state.State.EntityContext(), current.Policy.Raw())
+			scope := newExecutionScope(item, frame.payload, frame.base.Event.Raw(), current.Entity.Raw(), current.PlatformEntity.Raw(), current.Policy.Raw())
 			passed, err := compiled.Eval(scope)
 			if err != nil {
 				return err
@@ -681,7 +681,7 @@ func (e *Executor) stepQuery(frame *executionFrame) error {
 	case strings.TrimSpace(spec.GroupBy) != "":
 		grouped := map[string]any{}
 		for _, item := range items {
-			scope := newExecutionScope(item, frame.payload, frame.base.Event.Raw(), frame.state.State.EntityContext(), current.Policy.Raw())
+			scope := newExecutionScope(item, frame.payload, frame.base.Event.Raw(), current.Entity.Raw(), current.PlatformEntity.Raw(), current.Policy.Raw())
 			resolved, err := scope.resolveOperand(strings.TrimSpace(spec.GroupBy), executionOperandDefaultItem)
 			if err != nil {
 				return err
@@ -859,7 +859,7 @@ func (e *Executor) stepFilter(frame *executionFrame) error {
 	}
 	filtered := make([]any, 0, len(items))
 	for _, item := range items {
-		scope := newExecutionScope(item, frame.payload, frame.base.Event.Raw(), frame.state.State.EntityContext(), current.Policy.Raw())
+		scope := newExecutionScope(item, frame.payload, frame.base.Event.Raw(), current.Entity.Raw(), current.PlatformEntity.Raw(), current.Policy.Raw())
 		passed, err := compiled.Eval(scope)
 		if err != nil {
 			return err
@@ -907,7 +907,7 @@ func (e *Executor) stepCount(frame *executionFrame) error {
 			count++
 			continue
 		}
-		scope := newExecutionScope(item, frame.payload, frame.base.Event.Raw(), frame.state.State.EntityContext(), current.Policy.Raw())
+		scope := newExecutionScope(item, frame.payload, frame.base.Event.Raw(), current.Entity.Raw(), current.PlatformEntity.Raw(), current.Policy.Raw())
 		passed, err := compiled.Eval(scope)
 		if err != nil {
 			return err
@@ -1051,7 +1051,7 @@ func (e *Executor) stepGroupBy(frame *executionFrame) error {
 	current := e.currentContext(frame)
 	grouped := make(map[string]any)
 	for _, item := range items {
-		scope := newExecutionScope(item, frame.payload, frame.base.Event.Raw(), frame.state.State.EntityContext(), current.Policy.Raw())
+		scope := newExecutionScope(item, frame.payload, frame.base.Event.Raw(), current.Entity.Raw(), current.PlatformEntity.Raw(), current.Policy.Raw())
 		resolved, err := scope.resolveOperand(strings.TrimSpace(spec.Key), executionOperandDefaultItem)
 		if err != nil {
 			return err
@@ -1788,6 +1788,7 @@ func (e *Executor) currentContext(frame *executionFrame) BaseContext {
 	ctx.Metadata = values.Wrap(cloneStringAnyMap(frame.state.State.StateCarrier.Metadata))
 	ctx.Gates = values.Wrap(boolMapToAnyMap(frame.state.State.StateCarrier.Gates))
 	ctx.Entity = values.Wrap(frame.state.State.EntityContext())
+	ctx.PlatformEntity = values.Wrap(frame.state.State.PlatformEntityContext(frame.req.FlowID.String()))
 	ctx.Computed = values.Wrap(cloneStringAnyMap(frame.state.Computed))
 	return ctx
 }

--- a/internal/runtime/engine/executor.go
+++ b/internal/runtime/engine/executor.go
@@ -1788,7 +1788,8 @@ func (e *Executor) currentContext(frame *executionFrame) BaseContext {
 	ctx.Metadata = values.Wrap(cloneStringAnyMap(frame.state.State.StateCarrier.Metadata))
 	ctx.Gates = values.Wrap(boolMapToAnyMap(frame.state.State.StateCarrier.Gates))
 	ctx.Entity = values.Wrap(frame.state.State.EntityContext())
-	ctx.PlatformEntity = values.Wrap(frame.state.State.PlatformEntityContext(frame.req.FlowID.String()))
+	ctx.PlatformEntity = values.Wrap(frame.state.State.PlatformEntityContext(contextFlowInstance(frame.state.State, frame.req.Event, frame.req.FlowID.String())))
+	ctx.FlowID = firstNonEmpty(strings.TrimSpace(frame.state.State.WorkflowName), strings.TrimSpace(frame.req.FlowID.String()))
 	ctx.Computed = values.Wrap(cloneStringAnyMap(frame.state.Computed))
 	return ctx
 }

--- a/internal/runtime/engine/executor_test.go
+++ b/internal/runtime/engine/executor_test.go
@@ -367,6 +367,45 @@ func TestExecutor_ValidateRequestRejectsConflictingCompletionDialect(t *testing.
 	}
 }
 
+func TestExecutor_ValidateRequestRejectsPlatformEntityWriteTargets(t *testing.T) {
+	exec, err := NewExecutor(RuntimeDependencies{
+		Source:     stubSource(),
+		StateRepo:  stubStateRepo{},
+		TxRunner:   stubRunner{},
+		Locker:     stubLocker{},
+		Outbox:     stubOutbox{},
+		Dispatcher: stubDispatcher{},
+	}, nil)
+	if err != nil {
+		t.Fatalf("NewExecutor error: %v", err)
+	}
+
+	cases := map[string]runtimecontracts.SystemNodeEventHandler{
+		"data accumulation": {
+			DataAccumulation: runtimecontracts.WorkflowDataAccumulation{
+				Writes: []runtimecontracts.WorkflowDataWrite{{
+					TargetPathRef: "_entity.current_state",
+					Value:         runtimecontracts.CELExpression(`"done"`),
+				}},
+			},
+		},
+		"shared store_as": {
+			Count: &runtimecontracts.CountSpec{
+				Source:  "payload.items",
+				StoreAs: "_entity.current_state",
+			},
+		},
+	}
+	for name, handler := range cases {
+		t.Run(name, func(t *testing.T) {
+			err := exec.ValidateRequest(ExecutionRequest{Handler: handler})
+			if err == nil || !strings.Contains(err.Error(), "_entity is read-only platform entity metadata") {
+				t.Fatalf("ValidateRequest error = %v, want _entity read-only write-target rejection", err)
+			}
+		})
+	}
+}
+
 func TestExecutionScopeResolveOperand_AllowsEventRoot(t *testing.T) {
 	scope := newExecutionScope(
 		nil,

--- a/internal/runtime/engine/executor_test.go
+++ b/internal/runtime/engine/executor_test.go
@@ -374,6 +374,7 @@ func TestExecutionScopeResolveOperand_AllowsEventRoot(t *testing.T) {
 		map[string]any{"entity_id": "event-entity"},
 		nil,
 		nil,
+		nil,
 	)
 
 	got, err := scope.resolveOperand("event.entity_id", executionOperandDefaultNone)
@@ -397,6 +398,7 @@ func TestCompiledExecutionCondition_AllowsEventRoot(t *testing.T) {
 		map[string]any{"entity_id": "event-entity"},
 		nil,
 		nil,
+		nil,
 	)
 
 	ok, err := compiled.Eval(scope)
@@ -405,6 +407,25 @@ func TestCompiledExecutionCondition_AllowsEventRoot(t *testing.T) {
 	}
 	if !ok {
 		t.Fatal("compiled condition evaluated false, want true")
+	}
+}
+
+func TestExecutionScopeResolveOperand_AllowsPlatformEntityRoot(t *testing.T) {
+	scope := newExecutionScope(
+		nil,
+		nil,
+		nil,
+		map[string]any{"id": "business-id"},
+		map[string]any{"id": "platform-id"},
+		nil,
+	)
+
+	got, err := scope.resolveOperand("_entity.id", executionOperandDefaultNone)
+	if err != nil {
+		t.Fatalf("resolveOperand(_entity.id) error: %v", err)
+	}
+	if got != "platform-id" {
+		t.Fatalf("resolveOperand(_entity.id) = %#v, want platform-id", got)
 	}
 }
 
@@ -3942,7 +3963,7 @@ func TestExecutor_ClearGatesRunsBeforeGuardEvaluation(t *testing.T) {
 		Outbox:     stubOutbox{},
 		Dispatcher: stubDispatcher{},
 	}, stubEvaluator{bools: map[string]bool{
-		"entity.gates.review == false": true,
+		"_entity.gates.review == false": true,
 	}})
 	if err != nil {
 		t.Fatalf("NewExecutor error: %v", err)
@@ -3955,7 +3976,7 @@ func TestExecutor_ClearGatesRunsBeforeGuardEvaluation(t *testing.T) {
 		Handler: runtimecontracts.SystemNodeEventHandler{
 			ClearGates: []string{"review"},
 			Guard: &runtimecontracts.GuardSpec{
-				Check: "entity.gates.review == false",
+				Check: "_entity.gates.review == false",
 			},
 		},
 		State: StateSnapshot{StateCarrier: NewStateCarrier(nil, map[string]bool{"review": true}, nil)},

--- a/internal/runtime/engine/helpers.go
+++ b/internal/runtime/engine/helpers.go
@@ -230,11 +230,12 @@ func applyDataAccumulationToState(base BaseContext, state ExecutionState, snapsh
 
 func evalWorkflowValueExpression(base BaseContext, state ExecutionState, expression string, opts workflowexpr.ValueExpressionOptions) (any, error) {
 	return workflowexpr.EvalValueExpressionWithOptions(expression, workflowexpr.ValueContext{
-		Entity:  base.Entity.Raw(),
-		Event:   base.Event.Raw(),
-		Payload: base.Payload.Raw(),
-		Policy:  base.Policy.Raw(),
-		FanOut:  state.FanOut,
+		Entity:         base.Entity.Raw(),
+		PlatformEntity: base.PlatformEntity.Raw(),
+		Event:          base.Event.Raw(),
+		Payload:        base.Payload.Raw(),
+		Policy:         base.Policy.Raw(),
+		FanOut:         state.FanOut,
 	}, opts)
 }
 
@@ -505,11 +506,12 @@ func executionItems(value any) []any {
 }
 
 type executionScope struct {
-	Item    any
-	Payload map[string]any
-	Event   map[string]any
-	Entity  map[string]any
-	Policy  map[string]any
+	Item           any
+	Payload        map[string]any
+	Event          map[string]any
+	Entity         map[string]any
+	PlatformEntity map[string]any
+	Policy         map[string]any
 }
 
 type executionOperandDefaultScope string
@@ -524,13 +526,14 @@ type compiledExecutionCondition struct {
 	program    cel.Program
 }
 
-func newExecutionScope(item any, payload, event, entity, policy map[string]any) executionScope {
+func newExecutionScope(item any, payload, event, entity, platformEntity, policy map[string]any) executionScope {
 	return executionScope{
-		Item:    normalizeCELValue(item),
-		Payload: normalizedCELInputMap(payload),
-		Event:   normalizedCELInputMap(event),
-		Entity:  normalizedCELInputMap(entity),
-		Policy:  normalizedCELInputMap(policy),
+		Item:           normalizeCELValue(item),
+		Payload:        normalizedCELInputMap(payload),
+		Event:          normalizedCELInputMap(event),
+		Entity:         normalizedCELInputMap(entity),
+		PlatformEntity: normalizedCELInputMap(platformEntity),
+		Policy:         normalizedCELInputMap(policy),
 	}
 }
 
@@ -540,6 +543,7 @@ func (s executionScope) activation() map[string]any {
 		"payload": s.Payload,
 		"event":   s.Event,
 		"entity":  s.Entity,
+		"_entity": s.PlatformEntity,
 		"policy":  s.Policy,
 	}
 }
@@ -551,6 +555,7 @@ func executionConditionEnv() (*cel.Env, error) {
 			cel.Variable("payload", cel.DynType),
 			cel.Variable("event", cel.DynType),
 			cel.Variable("entity", cel.DynType),
+			cel.Variable("_entity", cel.DynType),
 			cel.Variable("policy", cel.DynType),
 		)
 	})
@@ -663,6 +668,8 @@ func (s executionScope) lookupExplicitRoot(root paths.PathRoot, segments []strin
 		return lookupExecutionOperandPath(s.Event, segments)
 	case paths.RootEntity:
 		return lookupExecutionOperandPath(s.Entity, segments)
+	case paths.RootPlatformEntity:
+		return lookupExecutionOperandPath(s.PlatformEntity, segments)
 	case paths.RootPolicy:
 		return lookupExecutionOperandPath(s.Policy, segments)
 	default:

--- a/internal/runtime/engine/helpers_test.go
+++ b/internal/runtime/engine/helpers_test.go
@@ -74,10 +74,11 @@ func TestDedupIdentifier_DefaultsToEventIdentityBeforeSource(t *testing.T) {
 
 func TestResolveRefRequiresExplicitScope(t *testing.T) {
 	base := BaseContext{
-		Entity:   values.Wrap(map[string]any{"status": "ready"}),
-		Metadata: values.Wrap(map[string]any{"status": "ready"}),
-		Payload:  values.Wrap(map[string]any{"score": 7, "nested": map[string]any{"value": "x"}}),
-		Policy:   values.Wrap(map[string]any{"mode": "strict"}),
+		Entity:         values.Wrap(map[string]any{"status": "ready"}),
+		PlatformEntity: values.Wrap(map[string]any{"current_state": "reviewing"}),
+		Metadata:       values.Wrap(map[string]any{"status": "ready"}),
+		Payload:        values.Wrap(map[string]any{"score": 7, "nested": map[string]any{"value": "x"}}),
+		Policy:         values.Wrap(map[string]any{"mode": "strict"}),
 	}
 	state := ExecutionState{
 		Accumulated: map[string]any{"count": 2},
@@ -86,14 +87,15 @@ func TestResolveRefRequiresExplicitScope(t *testing.T) {
 	}
 
 	cases := map[string]any{
-		"payload.score":        7,
-		"payload.nested.value": "x",
-		"metadata.status":      "ready",
-		"entity.status":        "ready",
-		"policy.mode":          "strict",
-		"accumulated.count":    2,
-		"fan_out.item":         "fan",
-		"computed.grade":       "A",
+		"payload.score":         7,
+		"payload.nested.value":  "x",
+		"metadata.status":       "ready",
+		"entity.status":         "ready",
+		"_entity.current_state": "reviewing",
+		"policy.mode":           "strict",
+		"accumulated.count":     2,
+		"fan_out.item":          "fan",
+		"computed.grade":        "A",
 	}
 	for ref, want := range cases {
 		if got := resolveRef(base, state, ref); got != want {
@@ -107,14 +109,14 @@ func TestResolveRefRequiresExplicitScope(t *testing.T) {
 
 func TestSetValuePathAndEmitFieldsPayload(t *testing.T) {
 	base := BaseContext{
-		Entity:  values.Wrap(map[string]any{"current_state": "researching"}),
-		Payload: values.Wrap(map[string]any{"score": 9}),
+		PlatformEntity: values.Wrap(map[string]any{"current_state": "researching"}),
+		Payload:        values.Wrap(map[string]any{"score": 9}),
 	}
 	state := ExecutionState{}
 	transformed, err := emitFieldsPayload(base, state, runtimecontracts.EmitSpec{
 		Fields: map[string]runtimecontracts.ExpressionValue{
 			"nested.score":   runtimecontracts.CELExpression("payload.score"),
-			"nested.state":   runtimecontracts.CELExpression("entity.current_state"),
+			"nested.state":   runtimecontracts.CELExpression("_entity.current_state"),
 			"literal.string": runtimecontracts.CELExpression(`"hello"`),
 			"explicit.ref":   runtimecontracts.RefExpression("payload.score"),
 			"explicit.value": runtimecontracts.LiteralExpression("ready"),

--- a/internal/runtime/engine/types.go
+++ b/internal/runtime/engine/types.go
@@ -9,6 +9,7 @@ import (
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
 	"github.com/division-sh/swarm/internal/runtime/core/identity"
 	"github.com/division-sh/swarm/internal/runtime/core/values"
+	"github.com/division-sh/swarm/internal/runtime/platformcontext"
 )
 
 const DefaultMaxChainDepth = 50
@@ -63,11 +64,6 @@ func (c StateCarrier) EntityContext(entityID identity.EntityID, currentState, wo
 		out = map[string]any{}
 	}
 	delete(out, "subject_id")
-	out["entity_id"] = entityID.String()
-	out["current_state"] = strings.TrimSpace(currentState)
-	out["workflow_name"] = strings.TrimSpace(workflowName)
-	out["workflow_version"] = strings.TrimSpace(workflowVersion)
-	out["gates"] = boolMapToAnyMap(c.Gates)
 	return out
 }
 
@@ -171,6 +167,10 @@ func (s StateSnapshot) StateBucketsBucket() values.Bucket {
 
 func (s StateSnapshot) EntityContext() map[string]any {
 	return s.StateCarrier.EntityContext(s.EntityID, s.CurrentState, s.WorkflowName, s.WorkflowVersion)
+}
+
+func (s StateSnapshot) PlatformEntityContext(flowInstance string) map[string]any {
+	return platformcontext.EntityMetadata(s.EntityID.String(), s.CurrentState, flowInstance, s.StateCarrier.Gates)
 }
 
 func (s *StateSnapshot) SetGate(name string, value bool) {

--- a/internal/runtime/entityruntime/contracts.go
+++ b/internal/runtime/entityruntime/contracts.go
@@ -394,6 +394,8 @@ func EntityWritePath(target string) (string, bool, error) {
 			return strings.Join(parsed.Segments, "."), true, nil
 		case paths.RootMetadata:
 			return "", false, nil
+		case paths.RootPlatformEntity:
+			return "", false, fmt.Errorf("%s is read-only platform entity metadata and cannot be used as a write target", paths.RootPlatformEntity.String())
 		default:
 			return "", false, nil
 		}

--- a/internal/runtime/pipeline/engine_adapter.go
+++ b/internal/runtime/pipeline/engine_adapter.go
@@ -41,7 +41,7 @@ func (e pipelineEngineEvaluator) EvalBool(expression string, ctx runtimeengine.B
 		Policy:         cloneStringAnyMap(ctx.Policy.Raw()),
 		Accumulated:    accumulatedItemsForCEL(ctx.Accumulated.Raw()),
 		FanOut:         cloneStringAnyMap(ctx.FanOut.Raw()),
-		WorkflowName:   e.workflowName(),
+		WorkflowName:   firstNonEmptyString(strings.TrimSpace(ctx.FlowID), e.workflowName()),
 	}
 	queryCtx.QueryEntityCount = func(predicate string) (int, error) {
 		return e.queryEntityCount(queryCtx, predicate)

--- a/internal/runtime/pipeline/engine_adapter.go
+++ b/internal/runtime/pipeline/engine_adapter.go
@@ -34,17 +34,26 @@ func (e pipelineEngineEvaluator) EvalBool(expression string, ctx runtimeengine.B
 		return false, runtimeengine.ErrNotImplemented
 	}
 	queryCtx := workflowExpressionContext{
-		Entity:      cloneStringAnyMap(ctx.Entity.Raw()),
-		Event:       cloneStringAnyMap(ctx.Event.Raw()),
-		Payload:     cloneStringAnyMap(ctx.Payload.Raw()),
-		Policy:      cloneStringAnyMap(ctx.Policy.Raw()),
-		Accumulated: accumulatedItemsForCEL(ctx.Accumulated.Raw()),
-		FanOut:      cloneStringAnyMap(ctx.FanOut.Raw()),
+		Entity:         cloneStringAnyMap(ctx.Entity.Raw()),
+		PlatformEntity: cloneStringAnyMap(ctx.PlatformEntity.Raw()),
+		Event:          cloneStringAnyMap(ctx.Event.Raw()),
+		Payload:        cloneStringAnyMap(ctx.Payload.Raw()),
+		Policy:         cloneStringAnyMap(ctx.Policy.Raw()),
+		Accumulated:    accumulatedItemsForCEL(ctx.Accumulated.Raw()),
+		FanOut:         cloneStringAnyMap(ctx.FanOut.Raw()),
+		WorkflowName:   e.workflowName(),
 	}
 	queryCtx.QueryEntityCount = func(predicate string) (int, error) {
 		return e.queryEntityCount(queryCtx, predicate)
 	}
 	return e.evaluator.EvalBool(expression, queryCtx)
+}
+
+func (e pipelineEngineEvaluator) workflowName() string {
+	if e.coordinator == nil || e.coordinator.module == nil || e.coordinator.module.WorkflowDefinition() == nil {
+		return ""
+	}
+	return strings.TrimSpace(e.coordinator.module.WorkflowDefinition().Name)
 }
 
 func accumulatedItemsForCEL(raw map[string]any) any {
@@ -325,7 +334,7 @@ func (e pipelineEngineEvaluator) queryEntityCount(ctx workflowExpressionContext,
 	if runID == "" {
 		return 0, fmt.Errorf("query_entities requires event.run_id in expression context")
 	}
-	flowID := strings.TrimSpace(asString(ctx.Entity["workflow_name"]))
+	flowID := strings.TrimSpace(ctx.WorkflowName)
 	contract, ok := entityruntime.ResolveForFlow(e.coordinator.SemanticSource(), flowID)
 	if !ok {
 		flowLabel := flowID

--- a/internal/runtime/pipeline/engine_adapter_test.go
+++ b/internal/runtime/pipeline/engine_adapter_test.go
@@ -882,7 +882,7 @@ func TestPipelineEngineActionRunner_CreateFlowInstanceUsesExecutionBaseContextFo
 	base := values.NewContext()
 	base.Event = values.Wrap(evt.ContextMap("ready"))
 	base.Payload = values.Wrap(parsePayloadMap(evt.Payload()))
-	base.Entity = values.Wrap(map[string]any{"entity_id": "ent-1"})
+	base.PlatformEntity = values.Wrap(map[string]any{"id": "ent-1"})
 	action := runtimecontracts.ActionSpec{
 		ID:             "create_flow_instance",
 		Template:       "review",
@@ -895,7 +895,7 @@ func TestPipelineEngineActionRunner_CreateFlowInstanceUsesExecutionBaseContextFo
 				"correlation_id":  "event.source_event_id",
 				"name":            "payload.name",
 				"template_id":     "payload.template_id",
-				"parent_entity":   "entity.entity_id",
+				"parent_entity":   "_entity.id",
 			},
 		},
 	}

--- a/internal/runtime/pipeline/engine_adapter_test.go
+++ b/internal/runtime/pipeline/engine_adapter_test.go
@@ -117,6 +117,73 @@ func TestApplyEngineStateMutationScopesChildFlowGates(t *testing.T) {
 	}
 }
 
+func TestPipelineEngineEvaluatorQueryEntitiesUsesExecutingFlowID(t *testing.T) {
+	_, db, cleanup := testutil.StartPostgres(t)
+	t.Cleanup(cleanup)
+
+	source := loadWorkflowTempSource(t, map[string]string{
+		"package.yaml": `
+name: runtime-test
+version: "1.0.0"
+platform_version: ">=1.0.0"
+flows:
+  - id: child
+    flow: child
+    mode: static
+`,
+		"schema.yaml": `
+name: runtime-test
+initial_state: ready
+states: [ready]
+`,
+		"flows/child/schema.yaml": `
+name: child
+mode: static
+initial_state: queued
+states: [queued]
+`,
+		"flows/child/entities.yaml": `
+child_entity:
+  request_id: text
+`,
+		"flows/child/nodes.yaml": "{}\n",
+	})
+	pc := NewPipelineCoordinatorWithOptions(noopPipelineBus{}, db, PipelineCoordinatorOptions{
+		Module: &pipelineFixtureWorkflowModule{
+			source:   source,
+			workflow: NewWorkflowDefinition("runtime-test", []WorkflowStage{{Name: "ready"}}, nil),
+		},
+	})
+	const entityID = "11111111-1111-1111-1111-111111111111"
+	if err := pc.workflowStore.Upsert(testPipelineCoordinatorRunContext(t, pc), WorkflowInstance{
+		InstanceID:      entityID,
+		StorageRef:      "child/existing",
+		WorkflowName:    "child",
+		WorkflowVersion: "1.0.0",
+		CurrentState:    "queued",
+		Metadata: map[string]any{
+			"entity_id":  entityID,
+			"request_id": "req-existing",
+			"flow_path":  "child/existing",
+		},
+	}); err != nil {
+		t.Fatalf("seed child workflow instance: %v", err)
+	}
+
+	eval := pipelineEngineEvaluator{evaluator: pc.expressionEval, coordinator: pc}
+	ok, err := eval.EvalBool(`query_entities(request_id == payload.request_id).count == 1`, runtimeengine.BaseContext{
+		FlowID:  "child",
+		Event:   values.Wrap(map[string]any{"run_id": testPipelineRunID}),
+		Payload: values.Wrap(map[string]any{"request_id": "req-existing"}),
+	})
+	if err != nil {
+		t.Fatalf("EvalBool query_entities: %v", err)
+	}
+	if !ok {
+		t.Fatal("query_entities did not count the child-flow entity")
+	}
+}
+
 func TestApplyEngineStateMutationPreservesExistingMetadataOnGateOnlyMutation(t *testing.T) {
 	instance := &WorkflowInstance{
 		Metadata: map[string]any{

--- a/internal/runtime/pipeline/handler_engine_transaction_test.go
+++ b/internal/runtime/pipeline/handler_engine_transaction_test.go
@@ -2037,7 +2037,7 @@ func TestExecuteNodeContractHandlerAppliesEmitFieldsToEmittedEvent(t *testing.T)
 			Event: "custom.emitted",
 			Fields: map[string]runtimecontracts.ExpressionValue{
 				"summary.entity_id": runtimecontracts.CELExpression("event.entity_id"),
-				"summary.stage":     runtimecontracts.CELExpression("entity.current_state"),
+				"summary.stage":     runtimecontracts.CELExpression("_entity.current_state"),
 				"flags.ready":       runtimecontracts.CELExpression("true"),
 				"label":             runtimecontracts.CELExpression(`"done"`),
 			},

--- a/internal/runtime/pipeline/select_entity_test.go
+++ b/internal/runtime/pipeline/select_entity_test.go
@@ -888,7 +888,7 @@ func selectOrCreateArtifactRepoCommitHandler() runtimecontracts.SystemNodeEventH
 			ID: "artifact_repo_commit",
 			ArtifactRepo: &runtimecontracts.ArtifactRepoSpec{
 				Provider:     "local_git",
-				RepoID:       runtimecontracts.RefExpression("entity.entity_id"),
+				RepoID:       runtimecontracts.RefExpression("_entity.id"),
 				Namespace:    runtimecontracts.RefExpression("payload.namespace"),
 				PartitionKey: runtimecontracts.RefExpression("payload.partition_key"),
 				DisplaySlug:  runtimecontracts.RefExpression("payload.display_slug"),

--- a/internal/runtime/pipeline/workflow_condition_validation.go
+++ b/internal/runtime/pipeline/workflow_condition_validation.go
@@ -43,6 +43,7 @@ func ValidateConditionCEL(expression string, context WorkflowConditionContext) e
 func celValidationEnv(context WorkflowConditionContext) (*cel.Env, error) {
 	options := []cel.EnvOption{
 		cel.Variable("entity", cel.DynType),
+		cel.Variable("_entity", cel.DynType),
 		cel.Variable("event", cel.DynType),
 		cel.Variable("payload", cel.DynType),
 		cel.Variable("policy", cel.DynType),
@@ -89,6 +90,7 @@ func workflowConditionRecognizedPrefixes(context WorkflowConditionContext) []str
 		"payload.",
 		"event.",
 		"entity.",
+		"_entity.",
 		"policy.",
 		"query_entities(",
 	}

--- a/internal/runtime/pipeline/workflow_entity_field_lifecycle.go
+++ b/internal/runtime/pipeline/workflow_entity_field_lifecycle.go
@@ -30,6 +30,10 @@ func WorkflowEntityReferences(expression string) []string {
 	return workflowexpr.EntityReferences(expression)
 }
 
+func WorkflowPlatformEntityReferences(expression string) []string {
+	return workflowexpr.PlatformEntityReferences(expression)
+}
+
 func stripWorkflowExpressionStringLiterals(expression string) string {
 	return workflowexpr.StripStringLiterals(expression)
 }
@@ -39,12 +43,7 @@ func WorkflowEntityReferenceField(ref string) string {
 }
 
 func WorkflowBuiltinEntityField(field string) bool {
-	switch strings.TrimSpace(field) {
-	case "entity_id", "current_state", "workflow_name", "workflow_version", "gates":
-		return true
-	default:
-		return false
-	}
+	return false
 }
 
 func WorkflowPresenceGuardedEntityFields(expression string) map[string]struct{} {
@@ -223,13 +222,7 @@ func workflowEntityFieldsAvailableBeforePhase(handler runtimecontracts.SystemNod
 }
 
 func workflowBuiltinEntityFields() map[string]struct{} {
-	return map[string]struct{}{
-		"entity_id":        {},
-		"current_state":    {},
-		"workflow_name":    {},
-		"workflow_version": {},
-		"gates":            {},
-	}
+	return map[string]struct{}{}
 }
 
 func workflowEntityFieldNameFromTarget(target string) (string, bool) {

--- a/internal/runtime/pipeline/workflow_entity_field_lifecycle_test.go
+++ b/internal/runtime/pipeline/workflow_entity_field_lifecycle_test.go
@@ -119,7 +119,7 @@ func TestWorkflowEntityFieldsAvailableBeforeGuardEscalation_UsesGuardTimeVisibil
 func TestWorkflowEntityFieldsAvailableBeforeEmitFields_ExcludesRuleOnlyWrites(t *testing.T) {
 	handler := runtimecontracts.SystemNodeEventHandler{
 		Rules: []runtimecontracts.HandlerRuleEntry{{
-			Condition: "entity.entity_id != null",
+			Condition: "_entity.id != null",
 			DataAccumulation: runtimecontracts.WorkflowDataAccumulation{
 				Writes: []runtimecontracts.WorkflowDataWrite{
 					{TargetField: "revision_count", Value: runtimecontracts.LiteralExpression(0)},
@@ -137,7 +137,7 @@ func TestWorkflowEntityFieldsAvailableBeforeEmitFields_ExcludesRuleOnlyWrites(t 
 func TestWorkflowEntityFieldsAvailableBeforeEmitFields_ExcludesRuleOnlyComputeOutputs(t *testing.T) {
 	handler := runtimecontracts.SystemNodeEventHandler{
 		Rules: []runtimecontracts.HandlerRuleEntry{{
-			Condition: "entity.entity_id != null",
+			Condition: "_entity.id != null",
 			Compute: &runtimecontracts.ComputeSpec{
 				Operation: runtimecontracts.ComputeOpCount,
 				StoreAs:   "entity.revision_count",
@@ -159,7 +159,7 @@ func TestWorkflowEntityFieldsAvailableBeforeEmitFields_PreservesUnconditionalWri
 			StoreAs:   "entity.revision_count",
 		},
 		Rules: []runtimecontracts.HandlerRuleEntry{{
-			Condition: "entity.entity_id != null",
+			Condition: "_entity.id != null",
 			DataAccumulation: runtimecontracts.WorkflowDataAccumulation{
 				Writes: []runtimecontracts.WorkflowDataWrite{
 					{TargetField: "revision_count", Value: runtimecontracts.LiteralExpression(0)},

--- a/internal/runtime/pipeline/workflow_expression_evaluator.go
+++ b/internal/runtime/pipeline/workflow_expression_evaluator.go
@@ -23,11 +23,13 @@ var workflowExpressionQueryPredicatePattern = regexp.MustCompile(`^\s*([a-zA-Z_]
 
 type workflowExpressionContext struct {
 	Entity                       map[string]any
+	PlatformEntity               map[string]any
 	Event                        map[string]any
 	Payload                      map[string]any
 	Policy                       map[string]any
 	Accumulated                  any
 	FanOut                       map[string]any
+	WorkflowName                 string
 	QueryEntityCount             func(string) (int, error)
 	AllowUnresolvedQueryOperands bool
 }
@@ -41,6 +43,7 @@ type workflowExpressionEvaluator struct {
 func newWorkflowExpressionEvaluator() *workflowExpressionEvaluator {
 	env, err := cel.NewEnv(
 		cel.Variable("entity", cel.DynType),
+		cel.Variable("_entity", cel.DynType),
 		cel.Variable("event", cel.DynType),
 		cel.Variable("payload", cel.DynType),
 		cel.Variable("policy", cel.DynType),
@@ -84,6 +87,7 @@ func (e *workflowExpressionEvaluator) EvalBool(expression string, ctx workflowEx
 	}
 	out, _, err := program.Eval(map[string]any{
 		"entity":      workflowNormalizeCELInput(cloneStringAnyMap(normalizedCtx.Entity)),
+		"_entity":     workflowNormalizeCELInput(cloneStringAnyMap(normalizedCtx.PlatformEntity)),
 		"event":       workflowNormalizeCELInput(cloneStringAnyMap(normalizedCtx.Event)),
 		"payload":     workflowNormalizeCELInput(cloneStringAnyMap(normalizedCtx.Payload)),
 		"policy":      workflowNormalizeCELInput(cloneStringAnyMap(normalizedCtx.Policy)),
@@ -151,11 +155,13 @@ func normalizeWorkflowExpression(expression string, ctx workflowExpressionContex
 	if expression == "" {
 		return "", workflowExpressionContext{
 			Entity:                       cloneStringAnyMap(ctx.Entity),
+			PlatformEntity:               cloneStringAnyMap(ctx.PlatformEntity),
 			Event:                        cloneStringAnyMap(ctx.Event),
 			Payload:                      cloneStringAnyMap(ctx.Payload),
 			Policy:                       cloneStringAnyMap(ctx.Policy),
 			Accumulated:                  cloneAccumulatedItems(ctx.Accumulated),
 			FanOut:                       cloneStringAnyMap(ctx.FanOut),
+			WorkflowName:                 strings.TrimSpace(ctx.WorkflowName),
 			QueryEntityCount:             ctx.QueryEntityCount,
 			AllowUnresolvedQueryOperands: ctx.AllowUnresolvedQueryOperands,
 		}, nil
@@ -183,11 +189,13 @@ func normalizeWorkflowExpression(expression string, ctx workflowExpressionContex
 	normalized = rewriteWorkflowExpressionEntityNullPresenceChecks(normalized)
 	normalizedCtx := workflowExpressionContext{
 		Entity:                       cloneStringAnyMap(ctx.Entity),
+		PlatformEntity:               cloneStringAnyMap(ctx.PlatformEntity),
 		Event:                        cloneStringAnyMap(ctx.Event),
 		Payload:                      cloneStringAnyMap(ctx.Payload),
 		Policy:                       cloneStringAnyMap(ctx.Policy),
 		Accumulated:                  cloneAccumulatedItems(ctx.Accumulated),
 		FanOut:                       cloneStringAnyMap(ctx.FanOut),
+		WorkflowName:                 strings.TrimSpace(ctx.WorkflowName),
 		QueryEntityCount:             ctx.QueryEntityCount,
 		AllowUnresolvedQueryOperands: ctx.AllowUnresolvedQueryOperands,
 	}
@@ -296,7 +304,7 @@ func workflowExpressionResolveQueryOperand(raw string, ctx workflowExpressionCon
 	}
 	if root, scoped := workflowExpressionQueryOperandScope(raw); scoped {
 		switch root {
-		case "entity", "event", "payload", "policy", "fan_out":
+		case "entity", "_entity", "event", "payload", "policy", "fan_out":
 			if ctx.AllowUnresolvedQueryOperands {
 				return raw, nil
 			}
@@ -331,6 +339,8 @@ func workflowExpressionLookupContextValue(ref string, ctx workflowExpressionCont
 	switch {
 	case strings.HasPrefix(ref, "entity."):
 		return workflowExpressionLookupPath(ctx.Entity, strings.TrimPrefix(ref, "entity."))
+	case strings.HasPrefix(ref, "_entity."):
+		return workflowExpressionLookupPath(ctx.PlatformEntity, strings.TrimPrefix(ref, "_entity."))
 	case strings.HasPrefix(ref, "event."):
 		return workflowExpressionLookupPath(ctx.Event, strings.TrimPrefix(ref, "event."))
 	case strings.HasPrefix(ref, "payload."):

--- a/internal/runtime/pipeline/workflow_expression_evaluator_test.go
+++ b/internal/runtime/pipeline/workflow_expression_evaluator_test.go
@@ -54,7 +54,7 @@ func TestValidateConditionCEL_AllowsRuleConditionCanonicalRoots(t *testing.T) {
 	}{
 		{
 			name:       "payload entity policy event",
-			expression: `entity.entity_id != "" && payload.score >= policy.threshold && event.entity_id != ""`,
+			expression: `_entity.id != "" && payload.score >= policy.threshold && event.entity_id != ""`,
 		},
 		{
 			name:       "query entities",
@@ -169,6 +169,33 @@ func TestWorkflowExpressionEvaluator_EvalBoolFailsClosedOnMissingEntityField(t *
 	}
 	if got := err.Error(); got == "" || got == "no such key: score" {
 		t.Fatalf("expected explicit lifecycle-safe missing-field error, got %q", got)
+	}
+}
+
+func TestWorkflowExpressionEvaluator_EvalBoolSplitsBusinessEntityAndPlatformEntity(t *testing.T) {
+	eval := newWorkflowExpressionEvaluator()
+	ok, err := eval.EvalBool(
+		`entity.current_state == "business-current-state" && _entity.current_state == "platform-current-state" && _entity.id == "ent-1" && _entity.gates.reviewed`,
+		workflowExpressionContext{
+			Entity: map[string]any{
+				"current_state": "business-current-state",
+			},
+			PlatformEntity: map[string]any{
+				"id":            "ent-1",
+				"current_state": "platform-current-state",
+				"gates": map[string]any{
+					"reviewed": true,
+				},
+			},
+			Payload: map[string]any{},
+			Policy:  map[string]any{},
+		},
+	)
+	if err != nil {
+		t.Fatalf("EvalBool error = %v", err)
+	}
+	if !ok {
+		t.Fatal("expected entity.* to read business fields and _entity.* to read platform metadata")
 	}
 }
 

--- a/internal/runtime/pipeline/workflow_instance_activation.go
+++ b/internal/runtime/pipeline/workflow_instance_activation.go
@@ -142,7 +142,7 @@ func resolveFlowInstanceConfigValue(entry runtimecontracts.ConfigBinding, handle
 	}
 	if entry.RefPath.HasExplicitRoot() {
 		switch entry.RefPath.Root {
-		case paths.RootPayload, paths.RootEntity, paths.RootEvent:
+		case paths.RootPayload, paths.RootEntity, paths.RootPlatformEntity, paths.RootEvent:
 			value, ok := lookupFlowInstanceConfigPath(handlerContext, entry.RefPath)
 			if !ok {
 				return nil, flowInstanceConfigRefError{Key: key, Ref: ref, Reason: "resolved empty"}
@@ -166,7 +166,7 @@ func resolveFlowInstanceConfigValue(entry runtimecontracts.ConfigBinding, handle
 		}
 		return ref, nil
 	}
-	return nil, flowInstanceConfigRefError{Key: key, Ref: ref, Reason: "requires supported root payload, entity, or event"}
+	return nil, flowInstanceConfigRefError{Key: key, Ref: ref, Reason: "requires supported root payload, entity, _entity, or event"}
 }
 
 func lookupFlowInstanceConfigPath(handlerContext values.Context, path paths.Path) (any, bool) {

--- a/internal/runtime/pipeline/workflow_instance_activation_test.go
+++ b/internal/runtime/pipeline/workflow_instance_activation_test.go
@@ -25,7 +25,9 @@ func testCreateFlowInstanceContext(trigger workflowTriggerContext) values.Contex
 	entity := map[string]any{
 		"entity_id": workflowEventEntityID(trigger.Event),
 	}
-	return createFlowInstanceHandlerContext(trigger, payload, entity)
+	ctx := createFlowInstanceHandlerContext(trigger, payload, entity)
+	ctx.PlatformEntity = values.Wrap(map[string]any{"id": workflowEventEntityID(trigger.Event)})
+	return ctx
 }
 
 func TestCreateFlowInstanceResolvesInstanceIDFromPayloadPath(t *testing.T) {
@@ -209,7 +211,7 @@ func TestCreateFlowInstanceResolvesConfigFromHandlerEventContext(t *testing.T) {
 				"source_flow":     "event.source.flow_id",
 				"correlation_id":  "event.source_event_id",
 				"name":            "payload.name",
-				"parent_entity":   "entity.entity_id",
+				"parent_entity":   "_entity.id",
 			},
 		},
 	}, testCreateFlowInstanceContext(triggerCtx))

--- a/internal/runtime/platformcontext/entity.go
+++ b/internal/runtime/platformcontext/entity.go
@@ -1,0 +1,65 @@
+package platformcontext
+
+import "strings"
+
+const EntityRoot = "_entity"
+
+func EntityMetadata(entityID, currentState, flowInstance string, gates map[string]bool) map[string]any {
+	out := map[string]any{
+		"id":            strings.TrimSpace(entityID),
+		"current_state": strings.TrimSpace(currentState),
+		"flow_instance": strings.TrimSpace(flowInstance),
+		"gates":         boolMapToAnyMap(gates),
+	}
+	return out
+}
+
+func EntityMetadataFromRaw(row map[string]any) map[string]any {
+	return map[string]any{
+		"id":            row["entity_id"],
+		"current_state": row["current_state"],
+		"flow_instance": row["flow_instance"],
+		"gates":         row["gates"],
+	}
+}
+
+func EntityFieldSupported(field string) bool {
+	switch strings.TrimSpace(field) {
+	case "id", "current_state", "flow_instance", "gates":
+		return true
+	default:
+		return false
+	}
+}
+
+func EntityFieldUnsupported(field string) bool {
+	switch strings.TrimSpace(field) {
+	case "entity_id", "entity_type", "workflow_name", "workflow_version", "run_id", "fields", "accumulator", "entered_state_at", "revision", "created_at", "updated_at", "name":
+		return true
+	default:
+		return false
+	}
+}
+
+func LegacyEntityMetadataField(field string) bool {
+	switch strings.TrimSpace(field) {
+	case "entity_id", "flow_instance", "current_state", "gates", "revision", "created_at", "updated_at", "entity_type", "workflow_name", "workflow_version":
+		return true
+	default:
+		return false
+	}
+}
+
+func boolMapToAnyMap(in map[string]bool) map[string]any {
+	if len(in) == 0 {
+		return map[string]any{}
+	}
+	out := make(map[string]any, len(in))
+	for key, value := range in {
+		key = strings.TrimSpace(key)
+		if key != "" {
+			out[key] = value
+		}
+	}
+	return out
+}

--- a/internal/runtime/swarmflowtest/catalog_runner_guardrails_test.go
+++ b/internal/runtime/swarmflowtest/catalog_runner_guardrails_test.go
@@ -96,7 +96,7 @@ func TestCatalogGuardPasses_SupportsStrictComparisonOperators(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			if got := catalogGuardPasses(tc.spec, payload, entity, policy); got != tc.want {
+			if got := catalogGuardPasses(tc.spec, payload, entity, policy, ""); got != tc.want {
 				t.Fatalf("catalogGuardPasses() = %v, want %v", got, tc.want)
 			}
 		})

--- a/internal/runtime/swarmflowtest/catalog_runner_harness_semantics_test.go
+++ b/internal/runtime/swarmflowtest/catalog_runner_harness_semantics_test.go
@@ -223,7 +223,7 @@ func TestCatalogGuardPasses_ComparisonAndReferenceSemantics(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			if got := catalogGuardPasses(tc.spec, payload, entity, policy); got != tc.want {
+			if got := catalogGuardPasses(tc.spec, payload, entity, policy, ""); got != tc.want {
 				t.Fatalf("catalogGuardPasses() = %v, want %v", got, tc.want)
 			}
 		})

--- a/internal/runtime/swarmflowtest/catalog_runner_test.go
+++ b/internal/runtime/swarmflowtest/catalog_runner_test.go
@@ -2085,7 +2085,7 @@ func executeCatalogHandlerStep(t testing.TB, handler catalogSystemNodeEventHandl
 	t.Helper()
 	payload := cloneStringAnyMapCatalog(step.Payload)
 	result.handlerOutcome = "success"
-	if !catalogGuardPasses(handler.Guard, payload, entity, policy) {
+	if !catalogGuardPasses(handler.Guard, payload, entity, policy, result.entityState) {
 		result.handlerOutcome = guardFailOutcome(handler.Guard)
 		if result.handlerOutcome == "" {
 			result.handlerOutcome = "reject"
@@ -2107,7 +2107,7 @@ func executeCatalogHandlerStep(t testing.TB, handler catalogSystemNodeEventHandl
 	}
 	if len(handler.OnComplete) > 0 {
 		for _, rule := range handler.OnComplete {
-			if catalogRuleMatches(rule, payload, entity, policy) {
+			if catalogRuleMatches(rule, payload, entity, policy, result.entityState) {
 				result = applyCatalogRule(rule, payload, entity, result)
 				break
 			}
@@ -2115,7 +2115,7 @@ func executeCatalogHandlerStep(t testing.TB, handler catalogSystemNodeEventHandl
 	}
 	if len(handler.Rules) > 0 {
 		for _, rule := range handler.Rules {
-			if catalogRuleMatches(rule, payload, entity, policy) {
+			if catalogRuleMatches(rule, payload, entity, policy, result.entityState) {
 				result = applyCatalogRule(rule, payload, entity, result)
 				break
 			}
@@ -2150,9 +2150,9 @@ func executeCatalogHandlerStep(t testing.TB, handler catalogSystemNodeEventHandl
 	applyCatalogDataAccumulation(handler.DataAccumulation, payload, entity)
 	applyCatalogCompute(handler.Compute, entity)
 	applyCatalogFanOut(handler.FanOut, payload, entity, &result)
-	applyCatalogFilter(handler.Filter, payload, entity, policy)
+	applyCatalogFilter(handler.Filter, payload, entity, policy, result.entityState)
 	applyCatalogReduce(handler.Reduce, payload, entity)
-	applyCatalogCount(handler.Count, payload, entity, policy)
+	applyCatalogCount(handler.Count, payload, entity, policy, result.entityState)
 	applyCatalogGroupBy(handler.GroupBy, payload, entity)
 	result.entityFields = cloneStringAnyMapCatalog(entity)
 	if emit := strings.TrimSpace(handler.Emit.EventType()); emit != "" {
@@ -2161,13 +2161,13 @@ func executeCatalogHandlerStep(t testing.TB, handler catalogSystemNodeEventHandl
 	return result
 }
 
-func catalogRuleMatches(rule catalogRule, payload, entity, policy map[string]any) bool {
+func catalogRuleMatches(rule catalogRule, payload, entity, policy map[string]any, state string) bool {
 	condition := strings.TrimSpace(rule.Condition)
 	switch strings.ToLower(condition) {
 	case "", "else":
 		return true
 	default:
-		return catalogEvalCondition(condition, map[string]any{"payload": payload, "entity": entity, "policy": policy})
+		return catalogEvalCondition(condition, catalogExpressionRoots(payload, entity, policy, state))
 	}
 }
 
@@ -2200,10 +2200,11 @@ func catalogAccumulationComplete(mode string, received, expected, threshold int)
 	}
 }
 
-func catalogGuardPasses(spec any, payload, entity, policy map[string]any) bool {
+func catalogGuardPasses(spec any, payload, entity, policy map[string]any, state string) bool {
 	if spec == nil {
 		return true
 	}
+	roots := catalogExpressionRoots(payload, entity, policy, state)
 	switch typed := spec.(type) {
 	case *runtimecontracts.GuardSpec:
 		if typed == nil {
@@ -2211,7 +2212,7 @@ func catalogGuardPasses(spec any, payload, entity, policy map[string]any) bool {
 		}
 		if len(typed.Checks) > 0 {
 			for _, check := range typed.Checks {
-				if !catalogEvalCondition(check.Check, map[string]any{"payload": payload, "entity": entity, "policy": policy}) {
+				if !catalogEvalCondition(check.Check, roots) {
 					return false
 				}
 			}
@@ -2220,17 +2221,40 @@ func catalogGuardPasses(spec any, payload, entity, policy map[string]any) bool {
 		if strings.TrimSpace(typed.Check) == "" {
 			return true
 		}
-		return catalogEvalCondition(typed.Check, map[string]any{"payload": payload, "entity": entity, "policy": policy})
+		return catalogEvalCondition(typed.Check, roots)
 	case runtimecontracts.GuardSpec:
-		return catalogGuardPasses(&typed, payload, entity, policy)
+		return catalogGuardPasses(&typed, payload, entity, policy, state)
 	case map[string]any:
 		if len(typed) == 0 {
 			return true
 		}
-		return catalogEvalCondition(asStringForCatalog(typed["check"]), map[string]any{"payload": payload, "entity": entity, "policy": policy})
+		return catalogEvalCondition(asStringForCatalog(typed["check"]), roots)
 	default:
 		return true
 	}
+}
+
+func catalogExpressionRoots(payload, entity, policy map[string]any, state string) map[string]any {
+	return map[string]any{
+		"payload": payload,
+		"entity":  entity,
+		"_entity": catalogPlatformEntity(entity, state),
+		"policy":  policy,
+	}
+}
+
+func catalogPlatformEntity(entity map[string]any, state string) map[string]any {
+	out := map[string]any{
+		"id":            entity["entity_id"],
+		"flow_instance": entity["flow_instance"],
+		"gates":         ensureCatalogGates(entity),
+	}
+	if strings.TrimSpace(state) != "" {
+		out["current_state"] = strings.TrimSpace(state)
+	} else {
+		out["current_state"] = entity["current_state"]
+	}
+	return out
 }
 
 func guardFailOutcome(spec any) string {
@@ -2442,14 +2466,17 @@ func applyCatalogAction(handler catalogSystemNodeEventHandler, payload, entity m
 	return "success", true
 }
 
-func applyCatalogFilter(spec *runtimecontracts.FilterSpec, payload, entity, policy map[string]any) {
+func applyCatalogFilter(spec *runtimecontracts.FilterSpec, payload, entity, policy map[string]any, state string) {
 	if spec == nil {
 		return
 	}
-	items := catalogSlice(resolveCatalogPath(spec.ItemsPath, strings.TrimSpace(spec.ItemsFrom), entity, map[string]any{"payload": payload, "entity": entity}))
+	roots := catalogExpressionRoots(payload, entity, policy, state)
+	items := catalogSlice(resolveCatalogPath(spec.ItemsPath, strings.TrimSpace(spec.ItemsFrom), entity, roots))
 	filtered := make([]any, 0, len(items))
 	for _, item := range items {
-		if catalogEvalCondition(spec.Condition, map[string]any{"item": item, "payload": payload, "entity": entity, "policy": policy}) {
+		itemRoots := catalogExpressionRoots(payload, entity, policy, state)
+		itemRoots["item"] = item
+		if catalogEvalCondition(spec.Condition, itemRoots) {
 			filtered = append(filtered, item)
 		}
 	}
@@ -2468,14 +2495,17 @@ func applyCatalogReduce(spec *runtimecontracts.ReduceSpec, payload, entity map[s
 	}
 }
 
-func applyCatalogCount(spec *runtimecontracts.CountSpec, payload, entity, policy map[string]any) {
+func applyCatalogCount(spec *runtimecontracts.CountSpec, payload, entity, policy map[string]any, state string) {
 	if spec == nil {
 		return
 	}
-	items := catalogSlice(resolveCatalogPath(spec.ItemsPath, strings.TrimSpace(spec.ItemsFrom), entity, map[string]any{"payload": payload, "entity": entity}))
+	roots := catalogExpressionRoots(payload, entity, policy, state)
+	items := catalogSlice(resolveCatalogPath(spec.ItemsPath, strings.TrimSpace(spec.ItemsFrom), entity, roots))
 	count := 0
 	for _, item := range items {
-		if strings.TrimSpace(spec.Condition) == "" || catalogEvalCondition(spec.Condition, map[string]any{"item": item, "payload": payload, "entity": entity, "policy": policy}) {
+		itemRoots := catalogExpressionRoots(payload, entity, policy, state)
+		itemRoots["item"] = item
+		if strings.TrimSpace(spec.Condition) == "" || catalogEvalCondition(spec.Condition, itemRoots) {
 			count++
 		}
 	}
@@ -2568,6 +2598,14 @@ func splitCatalogTopLevel(expr, sep string) []string {
 				depth++
 			}
 		case ')':
+			if quote == 0 && depth > 0 {
+				depth--
+			}
+		case '[':
+			if quote == 0 {
+				depth++
+			}
+		case ']':
 			if quote == 0 && depth > 0 {
 				depth--
 			}
@@ -3089,6 +3127,7 @@ func resolveCatalogRef(expr string, entity map[string]any, roots map[string]any)
 	if expr == "" {
 		return nil
 	}
+	expr = normalizeCatalogBracketRef(expr)
 	if n, err := strconv.Atoi(expr); err == nil {
 		return n
 	}
@@ -3120,6 +3159,27 @@ func resolveCatalogRef(expr string, entity map[string]any, roots map[string]any)
 		current = obj[strings.TrimSpace(segment)]
 	}
 	return current
+}
+
+func normalizeCatalogBracketRef(expr string) string {
+	expr = strings.TrimSpace(expr)
+	for {
+		start := strings.IndexByte(expr, '[')
+		if start < 0 {
+			return expr
+		}
+		end := strings.IndexByte(expr[start:], ']')
+		if end < 0 {
+			return expr
+		}
+		end += start
+		key := strings.TrimSpace(expr[start+1 : end])
+		key = strings.Trim(key, `"'`)
+		if key == "" {
+			return expr
+		}
+		expr = strings.TrimSpace(expr[:start]) + "." + key + strings.TrimSpace(expr[end+1:])
+	}
 }
 
 func resolveCatalogPath(parsed paths.Path, raw string, entity map[string]any, roots map[string]any) any {

--- a/internal/runtime/workflowexpr/data_expression.go
+++ b/internal/runtime/workflowexpr/data_expression.go
@@ -20,25 +20,27 @@ var (
 	dataExpressionWithBareItemEnv     *cel.Env
 	dataExpressionWithBareItemEnvErr  error
 
-	workflowExpressionEntityReferencePattern        = regexp.MustCompile(`entity\.([a-zA-Z_][a-zA-Z0-9_.]*)`)
-	workflowExpressionEntityPresencePattern         = regexp.MustCompile(`["']([a-zA-Z_][a-zA-Z0-9_]*)["']\s+in\s+entity\b`)
-	workflowExpressionEntityHasPattern              = regexp.MustCompile(`\bhas\s*\(\s*entity\.([a-zA-Z_][a-zA-Z0-9_.]*)\s*\)`)
-	workflowExpressionEntityHasTernaryTruePattern   = regexp.MustCompile(`\bhas\s*\(\s*entity\.([a-zA-Z_][a-zA-Z0-9_.]*)\s*\)\s*\?\s*entity\.([a-zA-Z_][a-zA-Z0-9_.]*)`)
-	workflowExpressionEntityHasTernaryFalsePattern  = regexp.MustCompile(`!\s*has\s*\(\s*entity\.([a-zA-Z_][a-zA-Z0-9_.]*)\s*\)\s*\?\s*[^:]+:\s*entity\.([a-zA-Z_][a-zA-Z0-9_.]*)`)
-	workflowExpressionEntityNullCompareLeftPattern  = regexp.MustCompile(`\bentity\.([a-zA-Z_][a-zA-Z0-9_.]*)\s*(==|!=)\s*null\b`)
-	workflowExpressionEntityNullCompareRightPattern = regexp.MustCompile(`\bnull\s*(==|!=)\s*entity\.([a-zA-Z_][a-zA-Z0-9_.]*)\b`)
-	workflowExpressionEntityNullNotEqualPattern     = regexp.MustCompile(`\bentity\.([a-zA-Z_][a-zA-Z0-9_.]*)\s*!=\s*null\b`)
-	workflowExpressionEntityNullEqualPattern        = regexp.MustCompile(`\bentity\.([a-zA-Z_][a-zA-Z0-9_.]*)\s*==\s*null\b`)
-	workflowExpressionNullEntityNotEqualPattern     = regexp.MustCompile(`\bnull\s*!=\s*entity\.([a-zA-Z_][a-zA-Z0-9_.]*)\b`)
-	workflowExpressionNullEntityEqualPattern        = regexp.MustCompile(`\bnull\s*==\s*entity\.([a-zA-Z_][a-zA-Z0-9_.]*)\b`)
+	workflowExpressionEntityReferencePattern         = regexp.MustCompile(`(^|[^a-zA-Z0-9_])entity\.([a-zA-Z_][a-zA-Z0-9_.]*)`)
+	workflowExpressionPlatformEntityReferencePattern = regexp.MustCompile(`(^|[^a-zA-Z0-9_])_entity\.([a-zA-Z_][a-zA-Z0-9_.]*)`)
+	workflowExpressionEntityPresencePattern          = regexp.MustCompile(`["']([a-zA-Z_][a-zA-Z0-9_]*)["']\s+in\s+entity\b`)
+	workflowExpressionEntityHasPattern               = regexp.MustCompile(`\bhas\s*\(\s*entity\.([a-zA-Z_][a-zA-Z0-9_.]*)\s*\)`)
+	workflowExpressionEntityHasTernaryTruePattern    = regexp.MustCompile(`\bhas\s*\(\s*entity\.([a-zA-Z_][a-zA-Z0-9_.]*)\s*\)\s*\?\s*entity\.([a-zA-Z_][a-zA-Z0-9_.]*)`)
+	workflowExpressionEntityHasTernaryFalsePattern   = regexp.MustCompile(`!\s*has\s*\(\s*entity\.([a-zA-Z_][a-zA-Z0-9_.]*)\s*\)\s*\?\s*[^:]+:\s*entity\.([a-zA-Z_][a-zA-Z0-9_.]*)`)
+	workflowExpressionEntityNullCompareLeftPattern   = regexp.MustCompile(`\bentity\.([a-zA-Z_][a-zA-Z0-9_.]*)\s*(==|!=)\s*null\b`)
+	workflowExpressionEntityNullCompareRightPattern  = regexp.MustCompile(`\bnull\s*(==|!=)\s*entity\.([a-zA-Z_][a-zA-Z0-9_.]*)\b`)
+	workflowExpressionEntityNullNotEqualPattern      = regexp.MustCompile(`\bentity\.([a-zA-Z_][a-zA-Z0-9_.]*)\s*!=\s*null\b`)
+	workflowExpressionEntityNullEqualPattern         = regexp.MustCompile(`\bentity\.([a-zA-Z_][a-zA-Z0-9_.]*)\s*==\s*null\b`)
+	workflowExpressionNullEntityNotEqualPattern      = regexp.MustCompile(`\bnull\s*!=\s*entity\.([a-zA-Z_][a-zA-Z0-9_.]*)\b`)
+	workflowExpressionNullEntityEqualPattern         = regexp.MustCompile(`\bnull\s*==\s*entity\.([a-zA-Z_][a-zA-Z0-9_.]*)\b`)
 )
 
 type ValueContext struct {
-	Entity  map[string]any
-	Event   map[string]any
-	Payload map[string]any
-	Policy  map[string]any
-	FanOut  map[string]any
+	Entity         map[string]any
+	PlatformEntity map[string]any
+	Event          map[string]any
+	Payload        map[string]any
+	Policy         map[string]any
+	FanOut         map[string]any
 }
 
 type ValueExpressionOptions struct {
@@ -97,6 +99,7 @@ func EvalValueExpressionWithOptions(expression string, ctx ValueContext, opts Va
 	}
 	activation := map[string]any{
 		"entity":  NormalizeCELInputMap(ctx.Entity),
+		"_entity": NormalizeCELInputMap(ctx.PlatformEntity),
 		"event":   NormalizeCELInputMap(ctx.Event),
 		"payload": NormalizeCELInputMap(ctx.Payload),
 		"policy":  NormalizeCELInputMap(ctx.Policy),
@@ -288,10 +291,35 @@ func EntityReferences(expression string) []string {
 	out := make([]string, 0, len(matches))
 	seen := map[string]struct{}{}
 	for _, match := range matches {
-		if len(match) < 2 {
+		if len(match) < 3 {
 			continue
 		}
-		ref := strings.TrimSpace(match[1])
+		ref := strings.TrimSpace(match[2])
+		if ref == "" {
+			continue
+		}
+		if _, ok := seen[ref]; ok {
+			continue
+		}
+		seen[ref] = struct{}{}
+		out = append(out, ref)
+	}
+	return out
+}
+
+func PlatformEntityReferences(expression string) []string {
+	expression = strings.TrimSpace(StripStringLiterals(expression))
+	if expression == "" {
+		return nil
+	}
+	matches := workflowExpressionPlatformEntityReferencePattern.FindAllStringSubmatch(expression, -1)
+	out := make([]string, 0, len(matches))
+	seen := map[string]struct{}{}
+	for _, match := range matches {
+		if len(match) < 3 {
+			continue
+		}
+		ref := strings.TrimSpace(match[2])
 		if ref == "" {
 			continue
 		}
@@ -459,6 +487,7 @@ func dataExpressionEnvForContext(opts ValueExpressionOptions) (*cel.Env, error) 
 func newDataExpressionEnv(allowBareItem bool) (*cel.Env, error) {
 	variables := []cel.EnvOption{
 		cel.Variable("entity", cel.DynType),
+		cel.Variable("_entity", cel.DynType),
 		cel.Variable("event", cel.DynType),
 		cel.Variable("payload", cel.DynType),
 		cel.Variable("policy", cel.DynType),

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -1206,7 +1206,7 @@ entity_contracts:
   state_machine_link:
     description: |
       State is flow-scoped and declared in schema.yaml. The entity
-      envelope field entity.current_state is populated from that flow
+      envelope field exposed to expressions as _entity.current_state is populated from that flow
       state machine. Authors do not declare a state field or state model
       inside entities.yaml.
 event_payload_migration:
@@ -1259,9 +1259,11 @@ runtime_enforcement:
     rule: |
       query_entities validates filter paths against the inferred entity
       contract. Filter paths, metric selectors, and grouped/projected
-      entity selectors must resolve either to an envelope field or to a
-      declared scalar or enum leaf. Composite whole-value comparison is
-      not part of Wave 1.
+      entity selectors are projection-specific row selectors: bare top-level
+      row fields such as current_state remain valid on that tool surface, and
+      declared field paths must resolve to declared scalar or enum leaves.
+      `entity.*` is not accepted as a filter selector root on this projection
+      surface. Composite whole-value comparison is not part of Wave 1.
     handler_expression_rule: |
       `query_entities(...).count` used inside handler boolean expressions
       (guards, rules/on_complete conditions, and accumulator completion
@@ -1282,12 +1284,14 @@ state_machine_authority:
     and Wave 1 assumes one entity type per flow.
   rules:
     state_field_is_implicit: |
-      Authors do not declare a state_field anywhere. entity.current_state
-      is the implicit envelope carrier. Any state_field declaration is a
-      contract error.
+      Authors do not declare a state_field anywhere. _entity.current_state is
+      the platform entity metadata read for the current lifecycle state. Any
+      state_field declaration is a contract error. A declared business field
+      named current_state remains ordinary business data and is read as
+      entity.current_state; it is not the lifecycle state carrier.
     stateless_flows: |
       Stateless flows declare initial_state: null, states: [], and
-      terminal_states: []. For them, entity.current_state is null.
+      terminal_states: []. For them, _entity.current_state is null.
     not_field_presence_authority: |
       The state machine answers lifecycle questions, not field-write
       status questions.
@@ -1455,7 +1459,8 @@ handler_specification:
           create_entity or select an existing target-flow-owned entity with select_entity, never both.
         source_authority: PROHIBITED. select_entity keys must not target platform envelope/control fields such as entity_id,
           entity_type, flow_instance, current_state, workflow_name, or workflow_version. Payload refs must not be
-          payload.entity_id, payload.entity_type, or payload.flow_instance.
+          payload.entity_id, payload.entity_type, or payload.flow_instance. `_entity.*` and `event.*` refs are readable
+          elsewhere only where explicitly supported; they are not selector source authority.
         compatibility: PROHIBITED. select_entity does not restore generic existing-entity cross-flow continuation and does
           not allow a source flow to directly name or mutate another flow's entity row.
       interactions:
@@ -1510,7 +1515,8 @@ handler_specification:
         with_select_entity: PROHIBITED. select_entity and select_or_create_entity cannot appear on the same handler.
         source_authority: PROHIBITED. select_or_create_entity keys must not target platform envelope/control fields such as
           entity_id, entity_type, flow_instance, current_state, workflow_name, or workflow_version. Payload refs must not be
-          payload.entity_id, payload.entity_type, or payload.flow_instance.
+          payload.entity_id, payload.entity_type, or payload.flow_instance. `_entity.*` and `event.*` refs are readable
+          elsewhere only where explicitly supported; they are not selector source authority.
         compatibility: PROHIBITED. select_or_create_entity does not restore generic existing-entity cross-flow continuation
           and does not allow a source flow to directly name or mutate another flow's entity row.
       interactions:
@@ -1520,7 +1526,7 @@ handler_specification:
           subject to same-flow ownership enforcement.
         with_advances_to: ALLOWED. State transitions advance only the acquired receiving-flow entity.
         with_action: ALLOWED. Actions execute with the acquired entity context. Built-ins such as artifact_repo_commit may
-          use entity.entity_id as a service-owned opaque repo_id without exposing product-specific target identity to Swarm.
+          use _entity.id as a service-owned opaque repo_id without exposing product-specific target identity to Swarm.
         with_query: ALLOWED. Query runs after acquisition and cannot replace select_or_create_entity ownership checks.
     guard:
       field: guard
@@ -1605,11 +1611,11 @@ handler_specification:
     advances_to:
       field: advances_to
       type: string
-      purpose: Set entity.current_state to the target state. Skipped if on_complete already advanced.
+      purpose: Set the platform lifecycle state exposed as _entity.current_state to the target state. Skipped if on_complete already advanced.
     sets_gate:
       field: sets_gate
       type: string
-      purpose: Set entity.gates.{name} = true.
+      purpose: Set the platform gate exposed as _entity.gates.{name} = true.
     data_accumulation:
       field: data_accumulation
       type: object
@@ -2068,19 +2074,29 @@ handler_specification:
       are contract errors.'
     namespaces:
       entity:
-        resolves_to: 'entity_state row for the current entity. entity.X reads entity_state.fields->>X.
-          entity.current_state reads entity_state.current_state. entity.gates.X reads entity_state.gates->>X.'
+        resolves_to: 'Declared business fields for the current entity. entity.X reads entity_state.fields->>X
+          only when X is declared by the active entity contract.'
         populated_by: 'data_accumulation writes, compute.store_as, sets_gate, advances_to, save_entity_field
           (agent tool), and create_entity (initial field population).'
         read_model:
           declared_fields: Every declared entity field is readable with either an explicit initial value or the field's type default.
-          undeclared_fields: Referencing an undeclared entity field is a contract error.
+          undeclared_fields: Referencing an undeclared entity field is a contract error. Legacy platform metadata reads such as entity.current_state, entity.gates, entity.entity_id, entity.flow_instance, entity.revision, entity.created_at, entity.updated_at, entity.entity_type, entity.workflow_name, and entity.workflow_version are invalid unless the field name is declared as business data; use _entity for supported platform metadata.
           presence_checks: has(entity.X) and == null / != null comparisons are valid, but they are not required for declared fields.
         does_NOT_include: 'Accumulated items. Dimension scores, fan-out results, and other per-item data
           collected by the accumulate handler step are NOT promoted to entity fields automatically. They exist
           only in the accumulator. To reference them in post-accumulation conditions, use the accumulated namespace.
           To persist a strict typed downstream copy, declare an entity field materialize_from; the runtime projection
           step owns that write.'
+      _entity:
+        resolves_to: 'Read-only platform metadata/control for the current entity. Supported fields are _entity.id,
+          _entity.current_state, _entity.flow_instance, _entity.gates, and _entity.gates.<name>.'
+        read_model:
+          id: Canonical current entity id. This replaces legacy platform reads through entity.entity_id.
+          current_state: Current lifecycle state owned by the flow state machine.
+          flow_instance: Current flow-instance path for the entity context.
+          gates: Read-only map of platform gate booleans; dot access is supported for simple gate names and bracket access is used for gate names containing separators.
+          unsupported_fields: '_entity.entity_id, _entity.entity_type, _entity.workflow_name, _entity.workflow_version, _entity.run_id, _entity.fields, _entity.accumulator, _entity.entered_state_at, _entity.revision, _entity.created_at, _entity.updated_at, and _entity.name are not exposed. revision, created_at, and updated_at must not remain readable through undeclared entity.* platform fallback.'
+        write_model: Read-only. Handler writes and entity tools may not target _entity. Emit payload construction may read _entity; select_entity/select_or_create_entity keys may not use _entity as a source-authority bypass.
       accumulated:
         resolves_to: 'The items array from the current handler''s accumulate step. Each item is a JSONB object
           representing one accumulated event payload. Available only in on_complete conditions and filter
@@ -2845,8 +2861,8 @@ engine:
         and similar patterns are valid.
     entity_field_resolution:
       description: 'In CEL expressions, entity.X resolves against a unified namespace that includes: entity_state.fields (from
-        declared entity fields, entity_state.current_state (as entity.current_state), entity_state.gates (as entity.gates.X), and
-        node-local state_schema fields (from accumulate/compute writes). Entity contract fields come from entities.yaml, not
+        declared entity fields) and node-local state_schema fields (from accumulate/compute writes). Platform current-entity
+        metadata/control is read only through _entity.*. Entity contract fields come from entities.yaml, not
         package.yaml.entity_schema. Declared entity fields are universally readable at type-valid values; node state remains
         a separate local concept merged into the CEL namespace by the runtime.'
     state_schema_scoping: state_schema fields are node-scoped in storage. In CEL, entity.X reads the current handler node
@@ -6125,7 +6141,7 @@ flow_model:
             template_receivers: Template/dynamic receivers may materialize route facts from receiver instance keys plus runtime descriptors, from explicit addressed-input keys and runtime descriptors, or for delivery:broadcast by enumerating receiver-scope descriptors; descriptor materialization remains pre-dispatch route evidence, not delivery execution.
             descriptor_scope: Descriptor materialization MUST reject descriptors whose flow_instance is not the receiver semantic flow path or a child instance under that path before stamping the receiver flow id onto the route.
             supported_descriptor_targets:
-            - entity_id / entity.entity_id
+            - entity_id / _entity.id
             - flow_instance / instance.flow_instance
             - instance_id / instance.instance_id
             - 'entity.<field> when the receiver entity contract declares that top-level field with indexed: true'

--- a/tests/tier1-primitives/test-payload-transform-multi-source/entities.yaml
+++ b/tests/tier1-primitives/test-payload-transform-multi-source/entities.yaml
@@ -1,2 +1,4 @@
 core:
-  name: text
+  name:
+    type: text
+    initial: ""

--- a/tests/tier1-primitives/test-payload-transform-multi-source/nodes.yaml
+++ b/tests/tier1-primitives/test-payload-transform-multi-source/nodes.yaml
@@ -12,7 +12,7 @@ test-node:
         fields:
           id: event.entity_id
           name: entity.name
-          status: entity.current_state
+          status: _entity.current_state
   state_schema:
     fields:
       name: string

--- a/tests/tier11-flow-composition/test-gates-in-child-flow/nodes.yaml
+++ b/tests/tier11-flow-composition/test-gates-in-child-flow/nodes.yaml
@@ -12,7 +12,7 @@ router:
     child/validation.done:
       guard:
         id: check_child_gate
-        check: entity.gates['child/g_validated'] == true
+        check: _entity.gates['child/g_validated'] == true
       advances_to: done
       emit:
         event: validate.passed

--- a/tests/tier2-accumulation/test-accumulate-on-complete-rollback/nodes.yaml
+++ b/tests/tier2-accumulation/test-accumulate-on-complete-rollback/nodes.yaml
@@ -22,7 +22,7 @@ verifier:
     batch.scored:
       guard:
         id: confirm_scored_state
-        check: "entity.current_state == \"scored\""
+        check: "_entity.current_state == \"scored\""
         on_fail: reject
       advances_to: verified
       emit:

--- a/tests/tier6-event-loop/test-entity-serialization/nodes.yaml
+++ b/tests/tier6-event-loop/test-entity-serialization/nodes.yaml
@@ -12,7 +12,7 @@ test-node:
     step.second:
       guard:
         id: state_check
-        check: "entity.current_state == 'processing'"
+        check: "_entity.current_state == 'processing'"
       advances_to: complete
       emit:
         event: step.second_done

--- a/tests/tier7-composition/test-full-lifecycle/nodes.yaml
+++ b/tests/tier7-composition/test-full-lifecycle/nodes.yaml
@@ -23,7 +23,7 @@ completion-node:
     order.validated:
       guard:
         id: gate_check
-        check: "entity.gates.validation_passed == true"
+        check: "_entity.gates.validation_passed == true"
       advances_to: complete
       emit:
         event: order.finalized

--- a/tests/tier7-composition/test-multi-gate-pipeline/nodes.yaml
+++ b/tests/tier7-composition/test-multi-gate-pipeline/nodes.yaml
@@ -49,7 +49,7 @@ approval-node:
     approval.requested:
       guard:
         id: all_gates_check
-        check: "entity.gates.g1 == true && entity.gates.g2 == true && entity.gates.g3 == true"
+        check: "_entity.gates.g1 == true && _entity.gates.g2 == true && _entity.gates.g3 == true"
       advances_to: approved
       emit:
         event: approval.granted

--- a/tests/tier9-composition-patterns/test-compose-gate-chain-three/nodes.yaml
+++ b/tests/tier9-composition-patterns/test-compose-gate-chain-three/nodes.yaml
@@ -14,13 +14,13 @@ pipeline:
     step.b_done:
       guard:
         id: requires_a
-        check: "entity.gates.g_a == true"
+        check: "_entity.gates.g_a == true"
       sets_gate: g_b
       advances_to: stage_b
     step.c_done:
       guard:
         id: requires_b
-        check: "entity.gates.g_b == true"
+        check: "_entity.gates.g_b == true"
       sets_gate: g_c
       advances_to: released
       emit:

--- a/tests/tier9-composition-patterns/test-compose-lifecycle-seven-states/nodes.yaml
+++ b/tests/tier9-composition-patterns/test-compose-lifecycle-seven-states/nodes.yaml
@@ -9,7 +9,7 @@ lifecycle:
     phase.activate:
       guard:
         id: must_be_setup
-        check: "entity.current_state == 'setup'"
+        check: "_entity.current_state == 'setup'"
       advances_to: active
     phase.start:
       advances_to: running
@@ -20,7 +20,7 @@ lifecycle:
     phase.close:
       guard:
         id: must_be_winding
-        check: "entity.current_state == 'winding_down'"
+        check: "_entity.current_state == 'winding_down'"
       advances_to: closed
       emit:
         event: lifecycle.complete


### PR DESCRIPTION
## Summary

Closes #1533.

Adds `_entity` as the canonical expression root for current entity platform metadata/control, while preserving `entity.*` for declared business fields only. Legacy platform metadata reads through undeclared `entity.*` now fail closed with targeted diagnostics.

## Governing Refs

- `platform-spec.yaml` `contract_semantics.state_field_is_implicit`: platform lifecycle state is `_entity.current_state`; declared business `current_state` remains ordinary `entity.current_state`.
- `platform-spec.yaml` `expression_context.namespaces.entity`: `entity.*` resolves only declared business fields.
- `platform-spec.yaml` `expression_context.namespaces._entity`: supported `_entity` fields are `id`, `current_state`, `flow_instance`, `gates`, and `gates.<name>`; unsupported fields are explicit.
- `platform-spec.yaml` `handler_semantics.select_entity.source_authority` and `select_or_create_entity.source_authority`: selector/acquisition keys cannot use `_entity.*` as a source-authority bypass.
- `platform-spec.yaml` `connect.route_descriptor_target`: route identity descriptor targets may use `entity_id / _entity.id`.
- Binding issue context: #1533 refreshed pre-audit and gate approval, with `_event` split left to #1627.

## Semantic Migration

- New canonical owner: `internal/runtime/platformcontext.EntityMetadata`, `EntityFieldSupported`, `EntityFieldUnsupported`, and `LegacyEntityMetadataField`, reflected in `platform-spec.yaml` `expression_context.namespaces._entity`.
- Old producer/reader/writer path now invalid: undeclared `entity.current_state`, `entity.gates`, `entity.entity_id`, `entity.flow_instance`, `entity.revision`, `entity.created_at`, `entity.updated_at`, `entity.entity_type`, `entity.workflow_name`, and `entity.workflow_version` are not platform metadata reads anymore. Same-name declared business fields remain valid business `entity.*` reads.
- Unsupported `_entity.*` fields remain invalid: `_entity.entity_id`, `_entity.entity_type`, `_entity.workflow_name`, `_entity.workflow_version`, `_entity.run_id`, `_entity.fields`, `_entity.accumulator`, `_entity.entered_state_at`, `_entity.revision`, `_entity.created_at`, `_entity.updated_at`, and `_entity.name`.
- Production paths checked and migrated: bootverify field-reference validation, lifecycle/coverage checks, pipeline expression evaluator and query operand handling, engine base/execution scope, workflow value expressions, create-flow-instance `config_from`, connect route descriptor normalization, catalog harness, and affected catalog fixtures.
- Migration completion: complete for the approved `_entity` current-entity platform metadata/control class. `_event` is intentionally not implemented here and remains split to #1627.

## Validation

- `go test ./internal/runtime/bootverify`
- `go test ./internal/runtime/pipeline`
- `go test ./internal/runtime/bootverify ./internal/runtime/pipeline ./internal/runtime/engine ./internal/runtime/workflowexpr ./internal/runtime/core/pinrouting ./internal/runtime/bus ./internal/runtime/swarmflowtest`
- `go test ./internal/runtime/cataloge2e`
- `go test ./...`