### PR TITLE
[agent-a][issue #1555] Final sealed authoring proof

### DIFF
--- a/internal/events/construction_test.go
+++ b/internal/events/construction_test.go
@@ -25,6 +25,7 @@ var productionProjectionEventAllowlist = map[eventConstructorCallsite]int{
 	{Path: "internal/store/sqlite_runtime_delivery_replay.go", Scope: "SQLiteRuntimeStore.listSQLiteEventsMissingPipelineReceipt"}: 1,
 	{Path: "internal/store/sqlite_runtime_delivery_replay.go", Scope: "SQLiteRuntimeStore.listSQLitePendingAgentDeliveryRecords"}:  1,
 	{Path: "internal/runtime/bus/eventbus_routing.go", Scope: "EventBus.deliverToRecipientsWithRoutes"}:                            1,
+	{Path: "internal/runtime/bus/eventbus_publish.go", Scope: "EventBus.runTargetedInternalDeliveryInterceptors"}:                  1,
 	{Path: "internal/runtime/bus/outbox.go", Scope: "clonePostCommitEvent"}:                                                        1,
 	{Path: "internal/runtime/core/pinrouting/pinrouting.go", Scope: "Resolve"}:                                                     1,
 	{Path: "internal/runtime/correlation/context.go", Scope: "CorrelateEvent"}:                                                     1,

--- a/internal/events/construction_test.go
+++ b/internal/events/construction_test.go
@@ -25,7 +25,7 @@ var productionProjectionEventAllowlist = map[eventConstructorCallsite]int{
 	{Path: "internal/store/sqlite_runtime_delivery_replay.go", Scope: "SQLiteRuntimeStore.listSQLiteEventsMissingPipelineReceipt"}: 1,
 	{Path: "internal/store/sqlite_runtime_delivery_replay.go", Scope: "SQLiteRuntimeStore.listSQLitePendingAgentDeliveryRecords"}:  1,
 	{Path: "internal/runtime/bus/eventbus_routing.go", Scope: "EventBus.deliverToRecipientsWithRoutes"}:                            1,
-	{Path: "internal/runtime/bus/eventbus_publish.go", Scope: "EventBus.runTargetedInternalDeliveryInterceptors"}:                  1,
+	{Path: "internal/runtime/bus/eventbus_publish.go", Scope: "projectEventForDeliveryRoute"}:                                      1,
 	{Path: "internal/runtime/bus/outbox.go", Scope: "clonePostCommitEvent"}:                                                        1,
 	{Path: "internal/runtime/core/pinrouting/pinrouting.go", Scope: "Resolve"}:                                                     1,
 	{Path: "internal/runtime/correlation/context.go", Scope: "CorrelateEvent"}:                                                     1,

--- a/internal/events/eventtest/eventtest.go
+++ b/internal/events/eventtest/eventtest.go
@@ -61,6 +61,12 @@ func RouteProbe(eventType events.EventType) events.Event {
 	return events.NewRouteProbeEvent(eventType)
 }
 
+// TargetRouted returns a fixture event projected onto a concrete delivery
+// target route.
+func TargetRouted(evt events.Event, target events.RouteIdentity) events.Event {
+	return evt.WithTargetRoute(target)
+}
+
 // MalformedChildWithoutLineage builds the explicit negative fixture for
 // admission tests that assert child events without lineage are rejected.
 func MalformedChildWithoutLineage(eventType events.EventType, sourceAgent string, payload json.RawMessage) events.Event {

--- a/internal/runtime/authoringview/view_test.go
+++ b/internal/runtime/authoringview/view_test.go
@@ -11,6 +11,7 @@ import (
 	runtimebootverify "github.com/division-sh/swarm/internal/runtime/bootverify"
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
 	"github.com/division-sh/swarm/internal/runtime/semanticview"
+	"github.com/division-sh/swarm/internal/runtime/testfixtures/finalflowinstanceauthoring"
 	"github.com/division-sh/swarm/internal/runtime/testfixtures/singletoncoordinatorpilot"
 	"github.com/division-sh/swarm/internal/runtime/testfixtures/templateflowpilot"
 )
@@ -139,6 +140,63 @@ func TestBuildShowsSingletonContainedOperations(t *testing.T) {
 	listAppend := containedOperationByTargetAndOp(t, flow, "entity.audit_log", "append")
 	if listAppend.ListItemType != "AuditEntry" || listAppend.SourceFile == "" {
 		t.Fatalf("audit_log append view = %#v, want typed list target and source file", listAppend)
+	}
+}
+
+func TestBuildShowsFinalFlowInstanceAuthoringFixture(t *testing.T) {
+	source := finalflowinstanceauthoring.LoadSource(t, finalflowinstanceauthoring.Options{})
+	report := runtimebootverify.Run(context.Background(), source, runtimebootverify.Options{})
+	view := mustBuild(t, source, &report)
+
+	if !view.Equivalence.ProjectionOnly {
+		t.Fatalf("equivalence projection_only = false, want true")
+	}
+	if !containsString(view.Equivalence.CanonicalOwners, "runtime/core/pinrouting.LowerCompositionConnectRoutePlans") {
+		t.Fatalf("canonical owners = %#v, want pinrouting owner", view.Equivalence.CanonicalOwners)
+	}
+
+	account := flowByID(t, view, finalflowinstanceauthoring.TemplateFlowID)
+	if account.PrimaryEntity == nil || account.PrimaryEntity.Type != finalflowinstanceauthoring.TemplateEntityType {
+		t.Fatalf("account primary entity = %#v, want %s", account.PrimaryEntity, finalflowinstanceauthoring.TemplateEntityType)
+	}
+	if account.TemplateInstance == nil || strings.Join(account.TemplateInstance.By, ",") != finalflowinstanceauthoring.TemplateInstanceBy {
+		t.Fatalf("account template instance = %#v, want %s", account.TemplateInstance, finalflowinstanceauthoring.TemplateInstanceBy)
+	}
+
+	producer := flowByID(t, view, finalflowinstanceauthoring.ProducerFlowID)
+	output := outputPinByName(t, producer, finalflowinstanceauthoring.ProducerOutputPin)
+	if output.Key != finalflowinstanceauthoring.TemplatePayloadKey || !containsString(output.Carries, finalflowinstanceauthoring.TemplatePayloadKey) {
+		t.Fatalf("producer output = %#v, want %s key/carry", output, finalflowinstanceauthoring.TemplatePayloadKey)
+	}
+	if len(view.ConnectRoutePlans) != 1 {
+		t.Fatalf("connect route plan count = %d, want 1: %#v", len(view.ConnectRoutePlans), view.ConnectRoutePlans)
+	}
+	plan := view.ConnectRoutePlans[0]
+	if plan.Source.FlowID != finalflowinstanceauthoring.ProducerFlowID || plan.Receiver.FlowID != finalflowinstanceauthoring.TemplateFlowID {
+		t.Fatalf("route endpoints = %#v -> %#v, want final fixture producer to template", plan.Source, plan.Receiver)
+	}
+	if plan.InstanceKey == nil || len(plan.InstanceKey.Mappings) != 1 ||
+		plan.InstanceKey.Mappings[0].Source != finalflowinstanceauthoring.TemplatePayloadKey ||
+		plan.InstanceKey.Mappings[0].Target != finalflowinstanceauthoring.TemplateInstanceBy ||
+		!plan.InstanceKey.Mappings[0].Explicit {
+		t.Fatalf("route instance key = %#v, want explicit renamed mapping", plan.InstanceKey)
+	}
+
+	coordinator := flowByID(t, view, finalflowinstanceauthoring.CoordinatorFlowID)
+	if coordinator.SingletonCoordinator == nil || coordinator.SingletonCoordinator.PrimaryEntity != finalflowinstanceauthoring.CoordinatorEntityType {
+		t.Fatalf("coordinator singleton view = %#v, want primary %s", coordinator.SingletonCoordinator, finalflowinstanceauthoring.CoordinatorEntityType)
+	}
+	if !containsContainedField(coordinator.SingletonCoordinator.ContainedState, "lead_index", "map") ||
+		!containsContainedField(coordinator.SingletonCoordinator.ContainedState, "audit_log", "list") {
+		t.Fatalf("coordinator contained state = %#v, want lead_index map and audit_log list", coordinator.SingletonCoordinator.ContainedState)
+	}
+	mapSet := containedOperationByTargetAndOp(t, coordinator, "entity.lead_index", "set")
+	if mapSet.MapKeyType != "text" || mapSet.MapValueType != "LeadScore" {
+		t.Fatalf("lead_index set view = %#v, want typed map target", mapSet)
+	}
+	listAppend := containedOperationByTargetAndOp(t, coordinator, "entity.audit_log", "append")
+	if listAppend.ListItemType != "AuditEntry" {
+		t.Fatalf("audit_log append view = %#v, want typed list target", listAppend)
 	}
 }
 

--- a/internal/runtime/bus/eventbus.go
+++ b/internal/runtime/bus/eventbus.go
@@ -22,6 +22,14 @@ type EventInterceptor interface {
 	Intercept(ctx context.Context, evt events.Event) (passthrough bool, deferred []events.Event, err error)
 }
 
+// DeliveryRouteInterceptor runs deterministic coordination for one
+// authoritative delivery route. EventBus uses this for workflow-node delivery
+// routes so Pipeline receives "execute this node for this route" semantics
+// instead of inferring route authority from an event-wide context.
+type DeliveryRouteInterceptor interface {
+	InterceptDeliveryRoute(ctx context.Context, evt events.Event, route events.DeliveryRoute) (passthrough bool, deferred []events.Event, err error)
+}
+
 // PayloadValidator validates canonical event-store admission before an event is
 // persisted or direct-recipient eligibility is reported. It does not own
 // producer-surface shaping or routing/delivery/source-target semantics.

--- a/internal/runtime/bus/eventbus_publish.go
+++ b/internal/runtime/bus/eventbus_publish.go
@@ -482,25 +482,42 @@ func (eb *EventBus) completeCommittedPublishDispatch(ctx context.Context, evt ev
 }
 
 func (eb *EventBus) runInterceptorsForDeliveryRoutes(ctx context.Context, evt events.Event, deliveryRoutes []events.DeliveryRoute) (bool, []events.Event, error) {
-	passthrough, deferred, err := eb.runInterceptors(ctx, evt)
+	genericCtx := ctx
+	if hasTargetedNodeDeliveryRoute(deliveryRoutes) {
+		genericCtx = runtimepipeline.WithSuppressedUntargetedWorkflowNodeInterception(ctx)
+	}
+	passthrough, deferred, err := eb.runInterceptors(genericCtx, evt)
 	if err != nil {
 		return passthrough, nil, err
 	}
-	targetedDeferred, err := eb.runTargetedInternalDeliveryInterceptors(ctx, evt, deliveryRoutes)
+	targetedPassthrough, targetedDeferred, err := eb.runTargetedInternalDeliveryInterceptors(ctx, evt, deliveryRoutes)
 	if err != nil {
 		return passthrough, nil, err
 	}
 	if len(targetedDeferred) > 0 {
 		deferred = append(deferred, targetedDeferred...)
 	}
-	return passthrough, deferred, nil
+	return passthrough && targetedPassthrough, deferred, nil
 }
 
-func (eb *EventBus) runTargetedInternalDeliveryInterceptors(ctx context.Context, evt events.Event, deliveryRoutes []events.DeliveryRoute) ([]events.Event, error) {
+func hasTargetedNodeDeliveryRoute(deliveryRoutes []events.DeliveryRoute) bool {
+	for _, route := range events.NormalizeDeliveryRoutes(deliveryRoutes) {
+		if strings.TrimSpace(route.SubscriberType) != "node" {
+			continue
+		}
+		if !route.Target.Normalized().Empty() {
+			return true
+		}
+	}
+	return false
+}
+
+func (eb *EventBus) runTargetedInternalDeliveryInterceptors(ctx context.Context, evt events.Event, deliveryRoutes []events.DeliveryRoute) (bool, []events.Event, error) {
 	deliveryRoutes = events.NormalizeDeliveryRoutes(deliveryRoutes)
 	if len(deliveryRoutes) == 0 {
-		return nil, nil
+		return true, nil, nil
 	}
+	passthrough := true
 	deferred := make([]events.Event, 0)
 	seen := map[string]struct{}{}
 	for _, route := range deliveryRoutes {
@@ -532,13 +549,16 @@ func (eb *EventBus) runTargetedInternalDeliveryInterceptors(ctx context.Context,
 			events.EnvelopeForTargetRoute(evt.NormalizedEnvelope(), target),
 			evt.CreatedAt(),
 		)
-		_, out, err := eb.runInterceptors(ctx, projected)
+		pass, out, err := eb.runInterceptors(ctx, projected)
 		if err != nil {
-			return nil, err
+			return passthrough, nil, err
+		}
+		if !pass {
+			passthrough = false
 		}
 		deferred = append(deferred, out...)
 	}
-	return deferred, nil
+	return passthrough, deferred, nil
 }
 
 func (eb *EventBus) withBundleFingerprint(ctx context.Context) context.Context {

--- a/internal/runtime/bus/eventbus_publish.go
+++ b/internal/runtime/bus/eventbus_publish.go
@@ -234,7 +234,7 @@ func (eb *EventBus) Publish(ctx context.Context, evt events.Event) (err error) {
 		eb.logPublished(ictx, evt, int(time.Since(start)/time.Microsecond))
 		return eb.convergeStandaloneRuntimePlatformRun(ictx, evt)
 	}
-	if pass, out, ierr := eb.runInterceptors(ictx, evt); ierr != nil {
+	if pass, out, ierr := eb.runInterceptorsForDeliveryRoutes(ictx, evt, plan.DeliveryRoutes()); ierr != nil {
 		return ierr
 	} else {
 		passthrough = pass
@@ -441,7 +441,7 @@ func (eb *EventBus) completeCommittedPublishDispatch(ctx context.Context, evt ev
 	ctx = runtimepipeline.WithPipelineReceiptOverride(ctx, receiptOverride)
 	defer runtimepipeline.FlushPipelineAfterPublishActions(afterPublishActions)
 
-	passthrough, deferred, err := eb.runInterceptors(ctx, evt)
+	passthrough, deferred, err := eb.runInterceptorsForDeliveryRoutes(ctx, evt, inboundPlan.DeliveryRoutes())
 	if err != nil {
 		eb.recordCommittedPublishReceipt(ctx, evt, err)
 		return
@@ -479,6 +479,66 @@ func (eb *EventBus) completeCommittedPublishDispatch(ctx context.Context, evt ev
 	}
 	eb.recordCommittedPublishReceipt(ctx, evt, nil)
 	eb.recordCommittedPublishConvergence(ctx, evt)
+}
+
+func (eb *EventBus) runInterceptorsForDeliveryRoutes(ctx context.Context, evt events.Event, deliveryRoutes []events.DeliveryRoute) (bool, []events.Event, error) {
+	passthrough, deferred, err := eb.runInterceptors(ctx, evt)
+	if err != nil {
+		return passthrough, nil, err
+	}
+	targetedDeferred, err := eb.runTargetedInternalDeliveryInterceptors(ctx, evt, deliveryRoutes)
+	if err != nil {
+		return passthrough, nil, err
+	}
+	if len(targetedDeferred) > 0 {
+		deferred = append(deferred, targetedDeferred...)
+	}
+	return passthrough, deferred, nil
+}
+
+func (eb *EventBus) runTargetedInternalDeliveryInterceptors(ctx context.Context, evt events.Event, deliveryRoutes []events.DeliveryRoute) ([]events.Event, error) {
+	deliveryRoutes = events.NormalizeDeliveryRoutes(deliveryRoutes)
+	if len(deliveryRoutes) == 0 {
+		return nil, nil
+	}
+	deferred := make([]events.Event, 0)
+	seen := map[string]struct{}{}
+	for _, route := range deliveryRoutes {
+		if strings.TrimSpace(route.SubscriberType) != "node" {
+			continue
+		}
+		target := route.Target.Normalized()
+		if target.Empty() {
+			continue
+		}
+		key := strings.Join([]string{
+			target.FlowID,
+			target.FlowInstance,
+			target.EntityID,
+		}, "\x00")
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		projected := events.NewProjectionEvent(
+			evt.ID(),
+			evt.Type(),
+			evt.SourceAgent(),
+			evt.TaskID(),
+			evt.Payload(),
+			evt.ChainDepth(),
+			evt.RunID(),
+			evt.ParentEventID(),
+			events.EnvelopeForTargetRoute(evt.NormalizedEnvelope(), target),
+			evt.CreatedAt(),
+		)
+		_, out, err := eb.runInterceptors(ctx, projected)
+		if err != nil {
+			return nil, err
+		}
+		deferred = append(deferred, out...)
+	}
+	return deferred, nil
 }
 
 func (eb *EventBus) withBundleFingerprint(ctx context.Context) context.Context {
@@ -602,7 +662,7 @@ func (eb *EventBus) publishTransactional(
 	dispatchCtx := runtimepipeline.WithoutPipelineSQLTxContext(ctx)
 	dispatchCtx = runtimepipeline.WithPipelinePostCommitActions(dispatchCtx, &postCommitActions)
 	dispatchCtx = runtimepipeline.WithPipelineReceiptOverride(dispatchCtx, receiptOverride)
-	passthrough, deferred, err := eb.runInterceptors(dispatchCtx, evt)
+	passthrough, deferred, err := eb.runInterceptorsForDeliveryRoutes(dispatchCtx, evt, inboundPlan.DeliveryRoutes())
 	if err != nil {
 		eb.recordCommittedPublishReceipt(dispatchCtx, evt, err)
 		return err
@@ -885,7 +945,7 @@ func (eb *EventBus) publishDeferred(ctx context.Context, evt events.Event) (err 
 		eb.logPublished(ctx, evt, 0)
 		return nil
 	}
-	passthrough, deferred, err := eb.runInterceptors(ctx, evt)
+	passthrough, deferred, err := eb.runInterceptorsForDeliveryRoutes(ctx, evt, plan.DeliveryRoutes())
 	if err != nil {
 		return err
 	}

--- a/internal/runtime/bus/eventbus_publish.go
+++ b/internal/runtime/bus/eventbus_publish.go
@@ -482,53 +482,65 @@ func (eb *EventBus) completeCommittedPublishDispatch(ctx context.Context, evt ev
 }
 
 func (eb *EventBus) runInterceptorsForDeliveryRoutes(ctx context.Context, evt events.Event, deliveryRoutes []events.DeliveryRoute) (bool, []events.Event, error) {
-	genericCtx := ctx
-	if hasTargetedNodeDeliveryRoute(deliveryRoutes) {
-		genericCtx = runtimepipeline.WithSuppressedUntargetedWorkflowNodeInterception(ctx)
+	interceptors := eb.interceptorsSnapshot()
+	nodeRoutes := nodeDeliveryRoutes(deliveryRoutes)
+	if len(nodeRoutes) == 0 {
+		return eb.runInterceptorSet(ctx, evt, interceptors)
 	}
-	passthrough, deferred, err := eb.runInterceptors(genericCtx, evt)
+	eventInterceptors, routeInterceptors := splitDeliveryRouteInterceptors(interceptors)
+	passthrough, deferred, err := eb.runInterceptorSet(ctx, evt, eventInterceptors)
 	if err != nil {
 		return passthrough, nil, err
 	}
-	targetedPassthrough, targetedDeferred, err := eb.runTargetedInternalDeliveryInterceptors(ctx, evt, deliveryRoutes)
+	routePassthrough, routeDeferred, err := eb.runNodeDeliveryRouteInterceptors(ctx, evt, nodeRoutes, routeInterceptors)
 	if err != nil {
 		return passthrough, nil, err
 	}
-	if len(targetedDeferred) > 0 {
-		deferred = append(deferred, targetedDeferred...)
+	if len(routeDeferred) > 0 {
+		deferred = append(deferred, routeDeferred...)
 	}
-	return passthrough && targetedPassthrough, deferred, nil
+	return passthrough && routePassthrough, deferred, nil
 }
 
-func hasTargetedNodeDeliveryRoute(deliveryRoutes []events.DeliveryRoute) bool {
+func nodeDeliveryRoutes(deliveryRoutes []events.DeliveryRoute) []events.DeliveryRoute {
+	routes := make([]events.DeliveryRoute, 0)
 	for _, route := range events.NormalizeDeliveryRoutes(deliveryRoutes) {
 		if strings.TrimSpace(route.SubscriberType) != "node" {
 			continue
 		}
-		if !route.Target.Normalized().Empty() {
-			return true
-		}
+		routes = append(routes, route)
 	}
-	return false
+	return routes
 }
 
-func (eb *EventBus) runTargetedInternalDeliveryInterceptors(ctx context.Context, evt events.Event, deliveryRoutes []events.DeliveryRoute) (bool, []events.Event, error) {
-	deliveryRoutes = events.NormalizeDeliveryRoutes(deliveryRoutes)
-	if len(deliveryRoutes) == 0 {
+func splitDeliveryRouteInterceptors(interceptors []EventInterceptor) ([]EventInterceptor, []DeliveryRouteInterceptor) {
+	eventInterceptors := make([]EventInterceptor, 0, len(interceptors))
+	routeInterceptors := make([]DeliveryRouteInterceptor, 0, len(interceptors))
+	for _, it := range interceptors {
+		if it == nil {
+			continue
+		}
+		if routeInterceptor, ok := it.(DeliveryRouteInterceptor); ok {
+			routeInterceptors = append(routeInterceptors, routeInterceptor)
+			continue
+		}
+		eventInterceptors = append(eventInterceptors, it)
+	}
+	return eventInterceptors, routeInterceptors
+}
+
+func (eb *EventBus) runNodeDeliveryRouteInterceptors(ctx context.Context, evt events.Event, deliveryRoutes []events.DeliveryRoute, interceptors []DeliveryRouteInterceptor) (bool, []events.Event, error) {
+	deliveryRoutes = nodeDeliveryRoutes(deliveryRoutes)
+	if len(deliveryRoutes) == 0 || len(interceptors) == 0 {
 		return true, nil, nil
 	}
 	passthrough := true
 	deferred := make([]events.Event, 0)
 	seen := map[string]struct{}{}
 	for _, route := range deliveryRoutes {
-		if strings.TrimSpace(route.SubscriberType) != "node" {
-			continue
-		}
 		target := route.Target.Normalized()
-		if target.Empty() {
-			continue
-		}
 		key := strings.Join([]string{
+			route.SubscriberID,
 			target.FlowID,
 			target.FlowInstance,
 			target.EntityID,
@@ -537,28 +549,47 @@ func (eb *EventBus) runTargetedInternalDeliveryInterceptors(ctx context.Context,
 			continue
 		}
 		seen[key] = struct{}{}
-		projected := events.NewProjectionEvent(
-			evt.ID(),
-			evt.Type(),
-			evt.SourceAgent(),
-			evt.TaskID(),
-			evt.Payload(),
-			evt.ChainDepth(),
-			evt.RunID(),
-			evt.ParentEventID(),
-			events.EnvelopeForTargetRoute(evt.NormalizedEnvelope(), target),
-			evt.CreatedAt(),
-		)
-		pass, out, err := eb.runInterceptors(ctx, projected)
-		if err != nil {
-			return passthrough, nil, err
+		projected := projectEventForDeliveryRoute(evt, route)
+		for _, it := range interceptors {
+			pass, out, err := it.InterceptDeliveryRoute(ctx, projected, route)
+			if err != nil {
+				return passthrough, nil, err
+			}
+			if !pass {
+				passthrough = false
+			}
+			admitted, err := admitDeferredEvents(ctx, out)
+			if err != nil {
+				return passthrough, nil, err
+			}
+			deferred = append(deferred, admitted...)
 		}
-		if !pass {
-			passthrough = false
-		}
-		deferred = append(deferred, out...)
 	}
 	return passthrough, deferred, nil
+}
+
+func projectEventForDeliveryRoute(evt events.Event, route events.DeliveryRoute) events.Event {
+	envelope := evt.NormalizedEnvelope()
+	target := route.Target.Normalized()
+	if target.Empty() {
+		envelope.Target = events.RouteIdentity{}
+		envelope.TargetSet = nil
+		envelope = envelope.Normalized()
+	} else {
+		envelope = events.EnvelopeForTargetRoute(envelope, target)
+	}
+	return events.NewProjectionEvent(
+		evt.ID(),
+		evt.Type(),
+		evt.SourceAgent(),
+		evt.TaskID(),
+		evt.Payload(),
+		evt.ChainDepth(),
+		evt.RunID(),
+		evt.ParentEventID(),
+		envelope,
+		evt.CreatedAt(),
+	)
 }
 
 func (eb *EventBus) withBundleFingerprint(ctx context.Context) context.Context {
@@ -811,6 +842,10 @@ func (eb *EventBus) recordCommittedPublishConvergence(ctx context.Context, evt e
 }
 
 func (eb *EventBus) runInterceptors(ctx context.Context, evt events.Event) (bool, []events.Event, error) {
+	return eb.runInterceptorSet(ctx, evt, eb.interceptorsSnapshot())
+}
+
+func (eb *EventBus) interceptorsSnapshot() []EventInterceptor {
 	eb.mu.RLock()
 	interceptors := append([]EventInterceptor(nil), eb.interceptors...)
 	provider := eb.interceptorProvider
@@ -822,6 +857,10 @@ func (eb *EventBus) runInterceptors(ctx context.Context, evt events.Event) (bool
 			}
 		}
 	}
+	return interceptors
+}
+
+func (eb *EventBus) runInterceptorSet(ctx context.Context, evt events.Event, interceptors []EventInterceptor) (bool, []events.Event, error) {
 	if len(interceptors) == 0 {
 		return true, nil, nil
 	}
@@ -835,15 +874,28 @@ func (eb *EventBus) runInterceptors(ctx context.Context, evt events.Event) (bool
 		if !pass {
 			passthrough = false
 		}
-		for _, d := range out {
-			_, admitted, err := admitEventForPublish(ctx, d, time.Now(), "")
-			if err != nil {
-				return true, nil, err
-			}
-			deferred = append(deferred, admitted)
+		admitted, err := admitDeferredEvents(ctx, out)
+		if err != nil {
+			return true, nil, err
 		}
+		deferred = append(deferred, admitted...)
 	}
 	return passthrough, deferred, nil
+}
+
+func admitDeferredEvents(ctx context.Context, out []events.Event) ([]events.Event, error) {
+	if len(out) == 0 {
+		return nil, nil
+	}
+	deferred := make([]events.Event, 0, len(out))
+	for _, d := range out {
+		_, admitted, err := admitEventForPublish(ctx, d, time.Now(), "")
+		if err != nil {
+			return nil, err
+		}
+		deferred = append(deferred, admitted)
+	}
+	return deferred, nil
 }
 
 func admitEventForPublish(ctx context.Context, evt events.Event, now time.Time, sourceAgentDefault string) (context.Context, events.Event, error) {
@@ -1624,6 +1676,10 @@ func (eb *EventBus) publishPersistedRecipients(ctx context.Context, evt events.E
 	if err != nil {
 		return err
 	}
+	liveRecipients, internalRecipients, deliveryRoutes, err := eb.replayRecipientsForCommittedEvent(ctx, evt, recipients, scope)
+	if err != nil {
+		return err
+	}
 	passthrough := true
 	deferred := []events.Event(nil)
 	if replayInterceptors && scope == runtimereplayclaim.CommittedReplayScopeSubscribed {
@@ -1634,16 +1690,12 @@ func (eb *EventBus) publishPersistedRecipients(ctx context.Context, evt events.E
 		ctx = runtimepipeline.WithPipelinePostCommitActions(ctx, &postCommitActions)
 		ctx = runtimepipeline.WithPipelineReceiptOverride(ctx, receiptOverride)
 		var err error
-		passthrough, deferred, err = eb.runInterceptors(ctx, evt)
+		passthrough, deferred, err = eb.runInterceptorsForDeliveryRoutes(ctx, evt, deliveryRoutes)
 		if err != nil {
 			return err
 		}
 		runtimepipeline.FlushPipelinePostCommitActions(postCommitActions)
 		runtimepipeline.FlushDeferredPipelineTransitions(ctx, deferredTransitions)
-	}
-	liveRecipients, internalRecipients, deliveryRoutes, err := eb.replayRecipientsForCommittedEvent(ctx, evt, recipients, scope)
-	if err != nil {
-		return err
 	}
 	if passthrough && len(liveRecipients) > 0 {
 		if err := eb.deliverToRecipientsWithRoutes(ctx, evt, liveRecipients, deliveryRoutes); err != nil {

--- a/internal/runtime/bus/eventbus_publish_test.go
+++ b/internal/runtime/bus/eventbus_publish_test.go
@@ -2393,6 +2393,265 @@ func contains(items []string, want string) bool {
 	return false
 }
 
+func TestEventBusPublish_MixedEmptyAndTargetedNodeRoutesExecuteAndSettle(t *testing.T) {
+	_, db, cleanup := testutil.StartPostgres(t)
+	t.Cleanup(cleanup)
+	ctx := eventBusTestRunContext(t, db)
+	pg := &store.PostgresStore{DB: db}
+	module, bundle := mixedNodeRouteWorkflowModule(t)
+	const eventType = "child/child.start"
+	const rootEntityID = "11111111-1111-1111-1111-222222222222"
+	const childEntityID = "11111111-1111-1111-1111-333333333333"
+	emptyRoute := events.DeliveryRoute{
+		SubscriberType: "node",
+		SubscriberID:   "project-observer",
+	}
+	targetRoute := events.DeliveryRoute{
+		SubscriberType: "node",
+		SubscriberID:   "child-intake",
+		Target: events.RouteIdentity{
+			FlowInstance: "child",
+			EntityID:     childEntityID,
+		},
+	}
+
+	var pc *runtimepipeline.PipelineCoordinator
+	eb, err := runtimebus.NewEventBusWithOptions(pg, runtimebus.EventBusOptions{
+		ContractBundle: semanticview.Wrap(bundle),
+		RecipientPlanMaterializer: func(context.Context, events.Event, runtimebus.PublishRecipientPlan) ([]events.DeliveryRoute, error) {
+			return []events.DeliveryRoute{emptyRoute, targetRoute}, nil
+		},
+		InterceptorProvider: func() []runtimebus.EventInterceptor {
+			if pc == nil {
+				return nil
+			}
+			return []runtimebus.EventInterceptor{pc}
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewEventBusWithOptions: %v", err)
+	}
+	pc = runtimepipeline.NewPipelineCoordinatorWithOptions(eb, db, runtimepipeline.PipelineCoordinatorOptions{
+		Module:                  module,
+		EventReceiptsCapability: pg.CanonicalEventReceiptsCapability,
+	})
+	if _, ok := any(pc).(runtimebus.DeliveryRouteInterceptor); !ok {
+		t.Fatal("PipelineCoordinator does not implement DeliveryRouteInterceptor")
+	}
+	workflowStore := runtimepipeline.NewWorkflowInstanceStore(db)
+	for _, instance := range []runtimepipeline.WorkflowInstance{
+		{
+			InstanceID:      rootEntityID,
+			StorageRef:      rootEntityID,
+			WorkflowName:    "mixed-route",
+			WorkflowVersion: "v-test",
+			CurrentState:    "active",
+		},
+		{
+			InstanceID:      childEntityID,
+			StorageRef:      "child",
+			WorkflowName:    "child",
+			WorkflowVersion: "v-test",
+			CurrentState:    "active",
+		},
+	} {
+		if err := workflowStore.Upsert(ctx, instance); err != nil {
+			t.Fatalf("seed workflow instance %s: %v", instance.InstanceID, err)
+		}
+	}
+
+	live := eb.SubscribeInternal("workflow-runtime", events.EventType(eventType))
+	defer eb.Unsubscribe("workflow-runtime")
+	evt := eventtest.RootIngress(
+		uuid.NewString(),
+		events.EventType(eventType),
+		"source",
+		"",
+		[]byte(`{"entity_id":"`+rootEntityID+`"}`),
+		0,
+		eventBusTestRunID,
+		"",
+		events.EnvelopeForEntityID(events.EventEnvelope{}, rootEntityID),
+		time.Now().UTC(),
+	)
+	plan, err := eb.CheckPublishRecipientPlan(ctx, evt)
+	if err != nil {
+		t.Fatalf("CheckPublishRecipientPlan: %v", err)
+	}
+	if !deliveryRoutesContain(plan.DeliveryRoutes, emptyRoute) || !deliveryRoutesContain(plan.DeliveryRoutes, targetRoute) {
+		t.Fatalf("delivery routes = %#v, want empty route %#v and target route %#v", plan.DeliveryRoutes, emptyRoute, targetRoute)
+	}
+	if err := eb.Publish(ctx, evt); err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+	if err := eb.WaitForQuiescence(ctx); err != nil {
+		t.Fatalf("WaitForQuiescence: %v", err)
+	}
+	assertNodeDeliveryStatus(t, db, evt.ID(), emptyRoute.SubscriberID, "delivered")
+	assertNodeDeliveryStatus(t, db, evt.ID(), targetRoute.SubscriberID, "delivered")
+	select {
+	case got := <-live:
+		t.Fatalf("consumed mixed node route event leaked to workflow-runtime carrier: %#v", got)
+	default:
+	}
+}
+
+func mixedNodeRouteWorkflowModule(t *testing.T) (runtimepipeline.WorkflowModule, *runtimecontracts.WorkflowContractBundle) {
+	t.Helper()
+	handler := runtimecontracts.SystemNodeEventHandler{
+		Rules: []runtimecontracts.HandlerRuleEntry{{
+			ID:        "accept",
+			Condition: "true",
+		}},
+	}
+	child := runtimecontracts.FlowContractView{
+		Path:  "child",
+		Paths: runtimecontracts.FlowContractPaths{ID: "child", Flow: "child"},
+		Events: map[string]runtimecontracts.EventCatalogEntry{
+			"child.start": {},
+		},
+		Nodes: map[string]runtimecontracts.SystemNodeContract{
+			"child-intake": {
+				ID:            "child-intake",
+				ExecutionType: "system_node",
+				EventHandlers: map[string]runtimecontracts.SystemNodeEventHandler{
+					"child.start": handler,
+				},
+			},
+		},
+	}
+	root := runtimecontracts.FlowContractView{
+		Path:  "",
+		Paths: runtimecontracts.FlowContractPaths{ID: "mixed-route"},
+		Events: map[string]runtimecontracts.EventCatalogEntry{
+			"child/child.start": {},
+		},
+		Nodes: map[string]runtimecontracts.SystemNodeContract{
+			"project-observer": {
+				ID:            "project-observer",
+				ExecutionType: "system_node",
+				EventHandlers: map[string]runtimecontracts.SystemNodeEventHandler{
+					"child/child.start": handler,
+				},
+			},
+		},
+		Children: []runtimecontracts.FlowContractView{child},
+	}
+	bundle := &runtimecontracts.WorkflowContractBundle{
+		Semantics: runtimecontracts.WorkflowSemanticView{
+			Name:    "mixed-route",
+			Version: "v-test",
+			EffectiveNodes: map[string]runtimecontracts.SystemNodeEffectiveSemantics{
+				"project-observer": {ID: "project-observer", ExecutionType: "system_node"},
+				"child-intake":     {ID: "child-intake", ExecutionType: "system_node"},
+			},
+			NodeHandlers: map[string]map[string]runtimecontracts.SystemNodeEventHandler{
+				"project-observer": {
+					"child/child.start": handler,
+				},
+				"child-intake": {
+					"child.start": handler,
+				},
+			},
+		},
+		FlowTree: flowmodel.Tree[runtimecontracts.FlowContractView]{
+			Root: &root,
+			ByID: map[string]*runtimecontracts.FlowContractView{
+				"mixed-route": &root,
+				"child":       &root.Children[0],
+			},
+		},
+		FlowSchemas: map[string]runtimecontracts.FlowSchemaDocument{
+			"mixed-route": {},
+			"child":       {},
+		},
+	}
+	source := semanticview.Wrap(bundle)
+	return &fixtureWorkflowModule{
+		source: source,
+		workflow: runtimepipeline.NewWorkflowDefinition("mixed-route", []runtimepipeline.WorkflowStage{
+			{Name: "active"},
+		}, nil),
+		workflowNodes: []runtimepipeline.WorkflowNode{
+			{
+				ID:            "project-observer",
+				Subscriptions: []events.EventType{"child/child.start"},
+				Policies: map[string]runtimepipeline.WorkflowEventPolicy{
+					"child/child.start": {Consume: true},
+				},
+			},
+			{
+				ID:            "child-intake",
+				Subscriptions: []events.EventType{"child/child.start"},
+				Policies: map[string]runtimepipeline.WorkflowEventPolicy{
+					"child/child.start": {Consume: true},
+				},
+			},
+		},
+		guardRegistry:  runtimepipeline.NewContractGuardRegistry(source),
+		actionRegistry: runtimepipeline.NewContractActionRegistry(source),
+	}, bundle
+}
+
+func assertNodeDeliveryStatus(t *testing.T, db *sql.DB, eventID, nodeID, want string) {
+	t.Helper()
+	var count int
+	if err := db.QueryRowContext(context.Background(), `
+		SELECT COUNT(*)
+		FROM event_deliveries
+		WHERE event_id = $1::uuid
+		  AND subscriber_type = 'node'
+		  AND subscriber_id = $2
+		  AND status = $3
+	`, eventID, nodeID, want).Scan(&count); err != nil {
+		t.Fatalf("query delivery status for %s: %v", nodeID, err)
+	}
+	if count != 1 {
+		rows, err := db.QueryContext(context.Background(), `
+			SELECT subscriber_id, COALESCE(status, ''), COALESCE(reason_code, ''), COALESCE(delivery_target_route::text, '')
+			FROM event_deliveries
+			WHERE event_id = $1::uuid
+			ORDER BY subscriber_id, delivery_target_route::text
+		`, eventID)
+		if err != nil {
+			t.Fatalf("delivery rows for %s status %q = %d, want 1; dump query failed: %v", nodeID, want, count, err)
+		}
+		defer rows.Close()
+		dump := make([]string, 0)
+		for rows.Next() {
+			var subscriber, status, reason, target string
+			if err := rows.Scan(&subscriber, &status, &reason, &target); err != nil {
+				t.Fatalf("scan delivery dump: %v", err)
+			}
+			dump = append(dump, subscriber+" status="+status+" reason="+reason+" target="+target)
+		}
+		if err := rows.Err(); err != nil {
+			t.Fatalf("iterate delivery dump: %v", err)
+		}
+		deadLetters := make([]string, 0)
+		deadRows, err := db.QueryContext(context.Background(), `
+			SELECT COALESCE(handler_node, ''), COALESCE(failure_type, ''), COALESCE(error_message, '')
+			FROM dead_letters
+			WHERE original_event_id = $1::uuid
+			ORDER BY created_at ASC
+		`, eventID)
+		if err == nil {
+			defer deadRows.Close()
+			for deadRows.Next() {
+				var node, failure, message string
+				if err := deadRows.Scan(&node, &failure, &message); err != nil {
+					t.Fatalf("scan dead letter dump: %v", err)
+				}
+				deadLetters = append(deadLetters, node+" failure="+failure+" error="+message)
+			}
+			if err := deadRows.Err(); err != nil {
+				t.Fatalf("iterate dead letter dump: %v", err)
+			}
+		}
+		t.Fatalf("delivery rows for %s status %q = %d, want 1; rows=%v dead_letters=%v", nodeID, want, count, dump, deadLetters)
+	}
+}
+
 func TestEventBusPublish_NestedThreeLevelChain_FromRootStartCompletesWithoutChildContinuation(t *testing.T) {
 	repoRoot := filepath.Clean(filepath.Join("..", "..", ".."))
 	fixtureRoot := filepath.Join(repoRoot, "tests", "tier11-flow-composition", "test-nested-three-levels")

--- a/internal/runtime/bus/eventbus_routing.go
+++ b/internal/runtime/bus/eventbus_routing.go
@@ -265,6 +265,9 @@ func (eb *EventBus) deliverToRecipientsWithRoutes(ctx context.Context, evt event
 	timedOut := make([]string, 0, len(recipients))
 	for _, recipient := range recipients {
 		targets := targetsByRecipient[recipient.deliveryRouteTargetKey()]
+		if len(targets) == 0 && recipient.isWorkflowRuntimeInternalCarrier() {
+			targets = workflowRuntimeInternalCarrierTargets(deliveryRoutes)
+		}
 		if len(targets) == 0 {
 			targets = []events.RouteIdentity{{}}
 		}
@@ -385,6 +388,8 @@ type agentRecipient struct {
 	kind    inMemorySubscriberKind
 }
 
+const workflowRuntimeInternalCarrierID = "workflow-runtime"
+
 func (r agentRecipient) deliveryRouteTargetKey() deliveryRouteTargetKey {
 	subscriberType := "agent"
 	if r.kind == inMemorySubscriberInternal {
@@ -394,6 +399,35 @@ func (r agentRecipient) deliveryRouteTargetKey() deliveryRouteTargetKey {
 		subscriberType: subscriberType,
 		subscriberID:   strings.TrimSpace(r.agentID),
 	}
+}
+
+func (r agentRecipient) isWorkflowRuntimeInternalCarrier() bool {
+	return r.kind == inMemorySubscriberInternal && strings.TrimSpace(r.agentID) == workflowRuntimeInternalCarrierID
+}
+
+func workflowRuntimeInternalCarrierTargets(deliveryRoutes []events.DeliveryRoute) []events.RouteIdentity {
+	deliveryRoutes = events.NormalizeDeliveryRoutes(deliveryRoutes)
+	if len(deliveryRoutes) == 0 {
+		return nil
+	}
+	out := make([]events.RouteIdentity, 0, len(deliveryRoutes))
+	seen := map[string]struct{}{}
+	for _, route := range deliveryRoutes {
+		if strings.TrimSpace(route.SubscriberType) != "node" {
+			continue
+		}
+		target := route.Target.Normalized()
+		if target.Empty() {
+			continue
+		}
+		key := strings.Join([]string{target.FlowID, target.FlowInstance, target.EntityID}, "\x00")
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		out = append(out, target)
+	}
+	return out
 }
 
 func (eb *EventBus) snapshotRecipientChans(agentIDs []string) []agentRecipient {

--- a/internal/runtime/bus/eventbus_target_routes_test.go
+++ b/internal/runtime/bus/eventbus_target_routes_test.go
@@ -131,6 +131,18 @@ func (i materializedRoutePersistedBeforeInterceptor) Intercept(ctx context.Conte
 	return true, nil, nil
 }
 
+type targetRouteConsumingInterceptor struct {
+	targetCalls int
+}
+
+func (i *targetRouteConsumingInterceptor) Intercept(_ context.Context, evt events.Event) (bool, []events.Event, error) {
+	if evt.TargetRoute().Empty() {
+		return true, nil, nil
+	}
+	i.targetCalls++
+	return false, nil, nil
+}
+
 func TestEventBusRecipientPlanMaterializerPersistsRoutesBeforeInterceptors(t *testing.T) {
 	store := newTargetRouteMemoryStore()
 	eventID := uuid.NewString()
@@ -181,6 +193,75 @@ func TestEventBusRecipientPlanMaterializerPersistsRoutesBeforeInterceptors(t *te
 	}
 	if !guardSawMaterializedRoute {
 		t.Fatal("recipient plan guard did not see materialized route")
+	}
+}
+
+func TestEventBusPublish_TargetedNodeConsumeSuppressesLiveRecipientDelivery(t *testing.T) {
+	const eventType = "worker/work.started"
+	eventID := uuid.NewString()
+	target := events.RouteIdentity{
+		FlowID:       "worker",
+		FlowInstance: "worker/inst-1",
+		EntityID:     "ent-1",
+	}
+	targetRoute := events.DeliveryRoute{
+		SubscriberType: "node",
+		SubscriberID:   "target-node",
+		Target:         target,
+	}
+	rt := newRouteTable(nil)
+	rt.eventPath[eventType] = struct{}{}
+	rt.routes[eventType] = []Subscriber{{
+		ID:          "target-node",
+		Type:        "node",
+		Path:        "worker",
+		RouteSource: "subscription",
+	}}
+	interceptor := &targetRouteConsumingInterceptor{}
+	eb, err := NewEventBusWithOptions(newTargetRouteMemoryStore(), EventBusOptions{
+		RouteTable: rt,
+		RecipientPlanMaterializer: func(context.Context, events.Event, PublishRecipientPlan) ([]events.DeliveryRoute, error) {
+			return []events.DeliveryRoute{targetRoute}, nil
+		},
+		Interceptors: []EventInterceptor{interceptor},
+	})
+	if err != nil {
+		t.Fatalf("NewEventBusWithOptions: %v", err)
+	}
+	live := eb.Subscribe("target-node", events.EventType(eventType))
+	defer eb.Unsubscribe("target-node")
+	evt := eventtest.RootIngress(
+		eventID,
+		events.EventType(eventType),
+		"",
+		"",
+		[]byte(`{}`),
+		0,
+		"",
+		"",
+		events.EnvelopeForEntityID(events.EventEnvelope{}, "ent-1"),
+		time.Now().UTC(),
+	)
+	plan, err := eb.CheckPublishRecipientPlan(context.Background(), evt)
+	if err != nil {
+		t.Fatalf("CheckPublishRecipientPlan: %v", err)
+	}
+	if len(plan.Recipients) != 1 || plan.Recipients[0] != "target-node" {
+		t.Fatalf("recipients = %#v, want target-node live recipient", plan.Recipients)
+	}
+	if !deliveryRoutesContain(plan.DeliveryRoutes, targetRoute) {
+		t.Fatalf("delivery routes = %#v, want target route %#v", plan.DeliveryRoutes, targetRoute)
+	}
+	if err := eb.Publish(context.Background(), evt); err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+	if interceptor.targetCalls != 1 {
+		t.Fatalf("target interceptor calls = %d, want 1", interceptor.targetCalls)
+	}
+	select {
+	case got := <-live:
+		t.Fatalf("target-consuming node event leaked to live recipient: %#v", got)
+	default:
 	}
 }
 

--- a/internal/runtime/bus/eventbus_target_routes_test.go
+++ b/internal/runtime/bus/eventbus_target_routes_test.go
@@ -143,6 +143,17 @@ func (i *targetRouteConsumingInterceptor) Intercept(_ context.Context, evt event
 	return false, nil, nil
 }
 
+func (i *targetRouteConsumingInterceptor) InterceptDeliveryRoute(_ context.Context, evt events.Event, route events.DeliveryRoute) (bool, []events.Event, error) {
+	if route.Target.Normalized().Empty() {
+		return true, nil, nil
+	}
+	if evt.TargetRoute().Normalized() != route.Target.Normalized() {
+		return true, nil, nil
+	}
+	i.targetCalls++
+	return false, nil, nil
+}
+
 func TestEventBusRecipientPlanMaterializerPersistsRoutesBeforeInterceptors(t *testing.T) {
 	store := newTargetRouteMemoryStore()
 	eventID := uuid.NewString()

--- a/internal/runtime/bus/eventbus_target_routes_test.go
+++ b/internal/runtime/bus/eventbus_target_routes_test.go
@@ -1130,8 +1130,8 @@ func TestEventBusPublish_NoTargetScopedRoutedNodePersistsSemanticRouteBeforeInte
 		t.Fatalf("Publish: %v", err)
 	}
 	got := requireBusEvent(t, ch, "static scoped workflow-runtime carrier delivery")
-	if got.FlowInstance() != "" || got.EntityID() != "ent-child" {
-		t.Fatalf("delivered identity flow=%q entity=%q, want root projection ent-child", got.FlowInstance(), got.EntityID())
+	if got.FlowInstance() != "child" || got.EntityID() != "ent-child" {
+		t.Fatalf("delivered identity flow=%q entity=%q, want child target ent-child", got.FlowInstance(), got.EntityID())
 	}
 	routes := store.routes[evt.ID()]
 	if len(routes) != 1 || !deliveryRoutesContain(routes, want) {

--- a/internal/runtime/bus/final_flow_instance_authoring_route_test.go
+++ b/internal/runtime/bus/final_flow_instance_authoring_route_test.go
@@ -1,0 +1,253 @@
+package bus
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/division-sh/swarm/internal/events"
+	"github.com/division-sh/swarm/internal/events/eventtest"
+	runtimeflowidentity "github.com/division-sh/swarm/internal/runtime/core/flowidentity"
+	runtimepinrouting "github.com/division-sh/swarm/internal/runtime/core/pinrouting"
+	runtimepipeline "github.com/division-sh/swarm/internal/runtime/pipeline"
+	runtimereplayclaim "github.com/division-sh/swarm/internal/runtime/replayclaim"
+	"github.com/division-sh/swarm/internal/runtime/testfixtures/finalflowinstanceauthoring"
+	"github.com/google/uuid"
+)
+
+type finalFlowInstanceAuthoringLifecycleStore struct {
+	*targetRouteMemoryStore
+	bus                         *EventBus
+	flowInstances               []ActiveFlowInstanceDescriptor
+	flowInstanceDescriptorCalls int
+	activations                 []runtimepipeline.FlowInstanceActivationRequest
+}
+
+func (s *finalFlowInstanceAuthoringLifecycleStore) ListActiveFlowInstanceDescriptors(context.Context) ([]ActiveFlowInstanceDescriptor, error) {
+	s.flowInstanceDescriptorCalls++
+	return append([]ActiveFlowInstanceDescriptor(nil), s.flowInstances...), nil
+}
+
+func (s *finalFlowInstanceAuthoringLifecycleStore) Activate(ctx context.Context, req runtimepipeline.FlowInstanceActivationRequest) error {
+	s.activations = append(s.activations, req)
+	accountID, _ := req.Metadata[finalflowinstanceauthoring.TemplateInstanceBy].(string)
+	s.flowInstances = append(s.flowInstances, ActiveFlowInstanceDescriptor{
+		InstanceID:    req.Instance.InstanceID,
+		EntityID:      req.Instance.EntityID,
+		FlowInstance:  req.Instance.InstancePath,
+		FlowTemplate:  req.Instance.TemplateID,
+		AddressFields: map[string]string{"entity.account_id": accountID},
+	})
+	if s.bus == nil {
+		return nil
+	}
+	return s.bus.AddFlowInstanceRouteContext(ctx, FlowInstanceRouteMaterializationRequest{
+		Identity: req.Instance.Route(),
+	})
+}
+
+func TestEventBusFinalFlowInstanceAuthoringFixture_RenamedConnectRoutePersistsReplayableTemplateTarget(t *testing.T) {
+	source := finalflowinstanceauthoring.LoadSource(t, finalflowinstanceauthoring.Options{})
+	store := &finalFlowInstanceAuthoringLifecycleStore{targetRouteMemoryStore: newTargetRouteMemoryStore()}
+	eb, err := NewEventBusWithOptions(store, EventBusOptions{
+		ContractBundle:            source,
+		TemplateInstanceActivator: store.Activate,
+	})
+	if err != nil {
+		t.Fatalf("NewEventBusWithOptions: %v", err)
+	}
+	store.bus = eb
+
+	evt := finalFlowInstanceAuthoringAccountReadyEvent(uuid.NewString(), "acct-42")
+	preflight, err := eb.CheckPublishRecipientPlan(context.Background(), evt)
+	if err != nil {
+		t.Fatalf("CheckPublishRecipientPlan: %v", err)
+	}
+	if len(store.activations) != 0 {
+		t.Fatalf("preflight activations = %d, want none", len(store.activations))
+	}
+	if preflight.TargetFailure != "" || len(preflight.DeliveryRoutes) != 1 {
+		t.Fatalf("preflight failure/routes = %q/%#v, want one deterministic template route", preflight.TargetFailure, preflight.DeliveryRoutes)
+	}
+	preview := preflight.DeliveryRoutes[0].Target
+	if preview.FlowID != finalflowinstanceauthoring.TemplateFlowID || preview.FlowInstance == "" || preview.EntityID == "" {
+		t.Fatalf("preflight target = %#v, want %s template route", preview, finalflowinstanceauthoring.TemplateFlowID)
+	}
+	if routes := eb.RouteTable().MaterializedRoutes(runtimeflowidentity.StoredRoute(finalflowinstanceauthoring.TemplateFlowID, runtimeflowidentity.LogicalInstanceID(preview.FlowInstance), preview.FlowInstance)); len(routes) != 0 {
+		t.Fatalf("preflight leaked materialized route table state: %#v", routes)
+	}
+
+	routePlan, err := eb.planSubscribedRoutePlan(context.Background(), evt, false)
+	if err != nil {
+		t.Fatalf("planSubscribedRoutePlan: %v", err)
+	}
+	if routePlan.AuthorityState != RoutePlanAuthorityCanonicalMatched || routePlan.AuthorityOwner != routePlanSourceConnectRoutePlan {
+		t.Fatalf("route plan authority = %q/%q, want matched connect route plan", routePlan.AuthorityState, routePlan.AuthorityOwner)
+	}
+
+	if err := eb.Publish(context.Background(), evt); err != nil {
+		t.Fatalf("Publish account ready: %v", err)
+	}
+	if len(store.activations) != 1 {
+		t.Fatalf("activations = %d, want 1", len(store.activations))
+	}
+	activation := store.activations[0]
+	if activation.Config[finalflowinstanceauthoring.TemplateInstanceBy] != "acct-42" ||
+		activation.Metadata[finalflowinstanceauthoring.TemplateInstanceBy] != "acct-42" {
+		t.Fatalf("activation config/metadata = %#v/%#v, want account_id from renamed source_account_id adapter", activation.Config, activation.Metadata)
+	}
+	if activation.Metadata["entity_type"] != finalflowinstanceauthoring.TemplateEntityType ||
+		activation.Metadata["instance_kind"] != "template" ||
+		activation.Metadata["last_source_event"] != evt.ID() {
+		t.Fatalf("activation metadata = %#v, want entity_type/instance_kind/last_source_event", activation.Metadata)
+	}
+	want := events.DeliveryRoute{
+		SubscriberType: "node",
+		SubscriberID:   finalflowinstanceauthoring.TemplateNodeID,
+		Target: events.RouteIdentity{
+			FlowID:       finalflowinstanceauthoring.TemplateFlowID,
+			FlowInstance: activation.Instance.InstancePath,
+			EntityID:     activation.Instance.EntityID,
+		},
+	}
+	if !deliveryRoutesContain(store.routes[evt.ID()], want) || len(store.routes[evt.ID()]) != 1 {
+		t.Fatalf("persisted delivery routes = %#v, want lifecycle-created template route %#v", store.routes[evt.ID()], want)
+	}
+	if got := store.scopes[evt.ID()]; got != runtimereplayclaim.CommittedReplayScopeSubscribed {
+		t.Fatalf("committed replay scope = %q, want subscribed", got)
+	}
+
+	retryTarget := eb.SubscribeInternal(finalflowinstanceauthoring.TemplateNodeID)
+	if err := eb.Publish(context.Background(), evt); err != nil {
+		t.Fatalf("Publish same-event retry: %v", err)
+	}
+	if len(store.activations) != 1 {
+		t.Fatalf("same-event retry activations = %d, want committed replay without second activation", len(store.activations))
+	}
+	replayed := requireBusEvent(t, retryTarget, "same-event committed replay")
+	if replayed.FlowInstance() != activation.Instance.InstancePath || replayed.EntityID() != activation.Instance.EntityID {
+		t.Fatalf("same-event replay target = flow_instance:%q entity:%q, want persisted %q/%q",
+			replayed.FlowInstance(), replayed.EntityID(), activation.Instance.InstancePath, activation.Instance.EntityID)
+	}
+
+	store.flowInstances = []ActiveFlowInstanceDescriptor{{
+		InstanceID:    "drift",
+		EntityID:      "ent-drift",
+		FlowInstance:  finalflowinstanceauthoring.TemplateFlowID + "/drift",
+		FlowTemplate:  finalflowinstanceauthoring.TemplateFlowID,
+		AddressFields: map[string]string{"entity.account_id": "acct-42"},
+	}}
+	store.flowInstanceDescriptorCalls = 0
+	if err := eb.AddFlowInstanceRoute(FlowInstanceRouteMaterializationRequest{
+		Identity: runtimeflowidentity.DeriveRoute(finalflowinstanceauthoring.TemplateFlowID, "drift"),
+	}); err != nil {
+		t.Fatalf("AddFlowInstanceRoute(drift): %v", err)
+	}
+	if err := eb.PublishPersistedRecipients(context.Background(), evt, nil); err != nil {
+		t.Fatalf("PublishPersistedRecipients: %v", err)
+	}
+	replayed = requireBusEvent(t, retryTarget, "persisted replay after descriptor drift")
+	if replayed.FlowInstance() != activation.Instance.InstancePath || replayed.EntityID() != activation.Instance.EntityID {
+		t.Fatalf("drift replay target = flow_instance:%q entity:%q, want persisted %q/%q",
+			replayed.FlowInstance(), replayed.EntityID(), activation.Instance.InstancePath, activation.Instance.EntityID)
+	}
+	if got := store.flowInstanceDescriptorCalls; got != 0 {
+		t.Fatalf("replay descriptor calls = %d, want 0 because persisted delivery target route is authoritative", got)
+	}
+}
+
+func TestEventBusFinalFlowInstanceAuthoringFixture_FailsClosedForMissingAndAmbiguousKeys(t *testing.T) {
+	source := finalflowinstanceauthoring.LoadSource(t, finalflowinstanceauthoring.Options{})
+	tests := []struct {
+		name          string
+		payload       json.RawMessage
+		flowInstances []ActiveFlowInstanceDescriptor
+		wantFailure   string
+	}{
+		{
+			name:        "missing renamed producer key",
+			payload:     json.RawMessage(`{"score":"91","decision":"approved"}`),
+			wantFailure: string(runtimepinrouting.ConnectFailureAddressValueMissing),
+		},
+		{
+			name:    "ambiguous receiver key",
+			payload: json.RawMessage(`{"source_account_id":"acct-42","score":"91","decision":"approved"}`),
+			flowInstances: []ActiveFlowInstanceDescriptor{
+				{InstanceID: "one", EntityID: "ent-1", FlowInstance: finalflowinstanceauthoring.TemplateFlowID + "/one", FlowTemplate: finalflowinstanceauthoring.TemplateFlowID, AddressFields: map[string]string{"entity.account_id": "acct-42"}},
+				{InstanceID: "two", EntityID: "ent-2", FlowInstance: finalflowinstanceauthoring.TemplateFlowID + "/two", FlowTemplate: finalflowinstanceauthoring.TemplateFlowID, AddressFields: map[string]string{"entity.account_id": "acct-42"}},
+			},
+			wantFailure: string(runtimepinrouting.ConnectFailureTargetAmbiguous),
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			store := &finalFlowInstanceAuthoringLifecycleStore{
+				targetRouteMemoryStore: newTargetRouteMemoryStore(),
+				flowInstances:          tc.flowInstances,
+			}
+			eb, err := NewEventBusWithOptions(store, EventBusOptions{
+				ContractBundle: source,
+				TemplateInstanceActivator: func(context.Context, runtimepipeline.FlowInstanceActivationRequest) error {
+					t.Fatal("fail-closed route must not activate a template instance")
+					return nil
+				},
+			})
+			if err != nil {
+				t.Fatalf("NewEventBusWithOptions: %v", err)
+			}
+			raw := eb.Subscribe("raw-source-listener", events.EventType("intake/account.ready"), events.EventType("account.ready"))
+			defer eb.Unsubscribe("raw-source-listener")
+			evt := eventtest.RootIngress(uuid.NewString(),
+				events.EventType("intake/account.ready"),
+				"",
+				"",
+				tc.payload,
+				0,
+				"",
+				"",
+				events.EventEnvelope{},
+				time.Now().UTC(),
+			)
+
+			plan, err := eb.CheckPublishRecipientPlan(context.Background(), evt)
+			if err != nil {
+				t.Fatalf("CheckPublishRecipientPlan: %v", err)
+			}
+			if plan.TargetFailure != tc.wantFailure {
+				t.Fatalf("target failure = %q, want %q", plan.TargetFailure, tc.wantFailure)
+			}
+			if len(plan.Recipients) != 0 || len(plan.PersistedRecipients) != 0 || len(plan.RoutedRecipients) != 0 ||
+				len(plan.SubscriptionRecipients) != 0 || len(plan.DeliveryRoutes) != 0 {
+				t.Fatalf("fail-closed route exposed executable plan: recipients=%#v persisted=%#v routed=%#v subscriptions=%#v routes=%#v",
+					plan.Recipients, plan.PersistedRecipients, plan.RoutedRecipients, plan.SubscriptionRecipients, plan.DeliveryRoutes)
+			}
+			if err := eb.Publish(context.Background(), evt); err != nil {
+				t.Fatalf("Publish fail-closed event: %v", err)
+			}
+			if routes := store.routes[evt.ID()]; len(routes) != 0 {
+				t.Fatalf("persisted delivery routes = %#v, want none", routes)
+			}
+			select {
+			case got := <-raw:
+				t.Fatalf("raw subscriber received fail-closed event with flow_instance=%q entity=%q", got.FlowInstance(), got.EntityID())
+			default:
+			}
+		})
+	}
+}
+
+func finalFlowInstanceAuthoringAccountReadyEvent(eventID, accountID string) events.Event {
+	return eventtest.RootIngress(
+		eventID,
+		events.EventType("intake/account.ready"),
+		"",
+		"",
+		json.RawMessage(`{"source_account_id":"`+accountID+`","score":"91","decision":"approved"}`),
+		0,
+		"",
+		"",
+		events.EventEnvelope{},
+		time.Now().UTC(),
+	)
+}

--- a/internal/runtime/bus/final_flow_instance_authoring_route_test.go
+++ b/internal/runtime/bus/final_flow_instance_authoring_route_test.go
@@ -70,20 +70,15 @@ func TestEventBusFinalFlowInstanceAuthoringFixture_RenamedConnectRoutePersistsRe
 	if preflight.TargetFailure != "" || len(preflight.DeliveryRoutes) != 1 {
 		t.Fatalf("preflight failure/routes = %q/%#v, want one deterministic template route", preflight.TargetFailure, preflight.DeliveryRoutes)
 	}
+	if !preflight.UsesCanonicalRouteAuthority() {
+		t.Fatalf("preflight route authority is not canonical connect-route authority")
+	}
 	preview := preflight.DeliveryRoutes[0].Target
 	if preview.FlowID != finalflowinstanceauthoring.TemplateFlowID || preview.FlowInstance == "" || preview.EntityID == "" {
 		t.Fatalf("preflight target = %#v, want %s template route", preview, finalflowinstanceauthoring.TemplateFlowID)
 	}
 	if routes := eb.RouteTable().MaterializedRoutes(runtimeflowidentity.StoredRoute(finalflowinstanceauthoring.TemplateFlowID, runtimeflowidentity.LogicalInstanceID(preview.FlowInstance), preview.FlowInstance)); len(routes) != 0 {
 		t.Fatalf("preflight leaked materialized route table state: %#v", routes)
-	}
-
-	routePlan, err := eb.planSubscribedRoutePlan(context.Background(), evt, false)
-	if err != nil {
-		t.Fatalf("planSubscribedRoutePlan: %v", err)
-	}
-	if routePlan.AuthorityState != RoutePlanAuthorityCanonicalMatched || routePlan.AuthorityOwner != routePlanSourceConnectRoutePlan {
-		t.Fatalf("route plan authority = %q/%q, want matched connect route plan", routePlan.AuthorityState, routePlan.AuthorityOwner)
 	}
 
 	if err := eb.Publish(context.Background(), evt); err != nil {
@@ -116,6 +111,13 @@ func TestEventBusFinalFlowInstanceAuthoringFixture_RenamedConnectRoutePersistsRe
 	}
 	if got := store.scopes[evt.ID()]; got != runtimereplayclaim.CommittedReplayScopeSubscribed {
 		t.Fatalf("committed replay scope = %q, want subscribed", got)
+	}
+	routePlan, err := eb.planSubscribedRoutePlan(context.Background(), evt, false)
+	if err != nil {
+		t.Fatalf("post-publish planSubscribedRoutePlan: %v", err)
+	}
+	if routePlan.AuthorityState != RoutePlanAuthorityCanonicalMatched || routePlan.AuthorityOwner != routePlanSourceConnectRoutePlan {
+		t.Fatalf("post-publish route plan authority = %q/%q, want matched connect route plan", routePlan.AuthorityState, routePlan.AuthorityOwner)
 	}
 
 	retryTarget := eb.SubscribeInternal(finalflowinstanceauthoring.TemplateNodeID)

--- a/internal/runtime/bus/outbox.go
+++ b/internal/runtime/bus/outbox.go
@@ -192,7 +192,7 @@ func (d engineDispatcher) dispatchIntent(ctx context.Context, intent runtimeengi
 		return true, nil
 	}
 	if intent.Recipients == nil {
-		passthrough, deferred, err := d.bus.runInterceptors(ctx, intent.Event)
+		passthrough, deferred, err := d.bus.runInterceptorsForDeliveryRoutes(ctx, intent.Event, d.bus.deliveryRoutesForEvent(ctx, intent.Event.ID()))
 		if err != nil {
 			return false, err
 		}

--- a/internal/runtime/conformance/final_flow_instance_authoring_conformance_test.go
+++ b/internal/runtime/conformance/final_flow_instance_authoring_conformance_test.go
@@ -1,0 +1,304 @@
+package conformance
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	runtimebootverify "github.com/division-sh/swarm/internal/runtime/bootverify"
+	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
+	"github.com/division-sh/swarm/internal/runtime/core/pinrouting"
+	"github.com/division-sh/swarm/internal/runtime/entityruntime"
+	"github.com/division-sh/swarm/internal/runtime/semanticview"
+	"github.com/division-sh/swarm/internal/runtime/testfixtures/finalflowinstanceauthoring"
+)
+
+func TestFinalFlowInstanceAuthoringFixture_CoversSealedContractOwners(t *testing.T) {
+	source := finalflowinstanceauthoring.LoadSource(t, finalflowinstanceauthoring.Options{})
+	report := runtimebootverify.Run(context.Background(), source, runtimebootverify.Options{})
+	if got := report.HardInvalidities(); len(got) != 0 {
+		t.Fatalf("final sealed fixture hard invalidities = %#v, want none", got)
+	}
+	bundle, ok := semanticview.Bundle(source)
+	if !ok {
+		t.Fatal("final sealed fixture source did not expose bundle")
+	}
+
+	accountPrimary, err := bundle.ResolveFlowPrimaryEntity(finalflowinstanceauthoring.TemplateFlowID)
+	if err != nil {
+		t.Fatalf("ResolveFlowPrimaryEntity(%s): %v", finalflowinstanceauthoring.TemplateFlowID, err)
+	}
+	if accountPrimary.EntityType != finalflowinstanceauthoring.TemplateEntityType {
+		t.Fatalf("template primary entity = %q, want %s", accountPrimary.EntityType, finalflowinstanceauthoring.TemplateEntityType)
+	}
+	if got := accountPrimary.Contract.Fields[finalflowinstanceauthoring.TemplateInstanceBy].Type; got != "string" {
+		t.Fatalf("template primary entity key field type = %q, want string", got)
+	}
+
+	instance, err := bundle.ResolveFlowTemplateInstance(finalflowinstanceauthoring.TemplateFlowID)
+	if err != nil {
+		t.Fatalf("ResolveFlowTemplateInstance(%s): %v", finalflowinstanceauthoring.TemplateFlowID, err)
+	}
+	if got := strings.Join(instance.By, ","); got != finalflowinstanceauthoring.TemplateInstanceBy {
+		t.Fatalf("template instance.by = %q, want %s", got, finalflowinstanceauthoring.TemplateInstanceBy)
+	}
+	if instance.OnMissing != "create" || instance.OnConflict != "reuse" {
+		t.Fatalf("template lifecycle policy = %s/%s, want create/reuse", instance.OnMissing, instance.OnConflict)
+	}
+
+	output, ok := bundle.FlowOutputEventPin(finalflowinstanceauthoring.ProducerFlowID, finalflowinstanceauthoring.ProducerOutputPin)
+	if !ok {
+		t.Fatalf("producer output pin %s missing", finalflowinstanceauthoring.ProducerOutputPin)
+	}
+	if output.Key != finalflowinstanceauthoring.TemplatePayloadKey || !finalFixtureContainsString(output.Carries, finalflowinstanceauthoring.TemplatePayloadKey) {
+		t.Fatalf("producer output key/carries = %q/%#v, want %s carried", output.Key, output.Carries, finalflowinstanceauthoring.TemplatePayloadKey)
+	}
+
+	plans, issues := pinrouting.LowerCompositionConnectRoutePlans(source)
+	if len(issues) != 0 {
+		t.Fatalf("LowerCompositionConnectRoutePlans issues = %#v, want none", issues)
+	}
+	if len(plans) != 1 {
+		t.Fatalf("LowerCompositionConnectRoutePlans = %#v, want one template instance-key route plan", plans)
+	}
+	plan := plans[0]
+	if plan.ResolutionKind != pinrouting.ConnectResolutionInstanceKey || !plan.RequiresRuntimeResolution {
+		t.Fatalf("route plan resolution = %s runtime=%v, want instance_key runtime resolution", plan.ResolutionKind, plan.RequiresRuntimeResolution)
+	}
+	if plan.Source.FlowID != finalflowinstanceauthoring.ProducerFlowID || plan.Source.Pin != finalflowinstanceauthoring.ProducerOutputPin || plan.Source.Key != finalflowinstanceauthoring.TemplatePayloadKey {
+		t.Fatalf("route plan source = %#v, want %s.%s keyed by %s", plan.Source, finalflowinstanceauthoring.ProducerFlowID, finalflowinstanceauthoring.ProducerOutputPin, finalflowinstanceauthoring.TemplatePayloadKey)
+	}
+	if plan.Receiver.FlowID != finalflowinstanceauthoring.TemplateFlowID || plan.Receiver.Pin != finalflowinstanceauthoring.TemplateInputPin || plan.Receiver.Mode != "template" {
+		t.Fatalf("route plan receiver = %#v, want template %s.%s", plan.Receiver, finalflowinstanceauthoring.TemplateFlowID, finalflowinstanceauthoring.TemplateInputPin)
+	}
+	if plan.InstanceKey == nil || strings.Join(plan.InstanceKey.Fields, ",") != finalflowinstanceauthoring.TemplateInstanceBy {
+		t.Fatalf("route plan instance key = %#v, want %s", plan.InstanceKey, finalflowinstanceauthoring.TemplateInstanceBy)
+	}
+	if len(plan.InstanceKey.Mappings) != 1 ||
+		plan.InstanceKey.Mappings[0].Source != finalflowinstanceauthoring.TemplatePayloadKey ||
+		plan.InstanceKey.Mappings[0].Target != finalflowinstanceauthoring.TemplateInstanceBy ||
+		!plan.InstanceKey.Mappings[0].Explicit {
+		t.Fatalf("route plan mappings = %#v, want explicit %s -> %s", plan.InstanceKey.Mappings, finalflowinstanceauthoring.TemplatePayloadKey, finalflowinstanceauthoring.TemplateInstanceBy)
+	}
+
+	coordinatorPrimary, err := bundle.ResolveFlowPrimaryEntity(finalflowinstanceauthoring.CoordinatorFlowID)
+	if err != nil {
+		t.Fatalf("ResolveFlowPrimaryEntity(%s): %v", finalflowinstanceauthoring.CoordinatorFlowID, err)
+	}
+	if coordinatorPrimary.EntityType != finalflowinstanceauthoring.CoordinatorEntityType {
+		t.Fatalf("coordinator primary entity = %q, want %s", coordinatorPrimary.EntityType, finalflowinstanceauthoring.CoordinatorEntityType)
+	}
+	if got := coordinatorPrimary.Contract.Fields["lead_index"].Type; got != "map[text]LeadScore" {
+		t.Fatalf("lead_index type = %q, want map[text]LeadScore", got)
+	}
+	if got := coordinatorPrimary.Contract.Fields["audit_log"].Type; got != "[AuditEntry]" {
+		t.Fatalf("audit_log type = %q, want [AuditEntry]", got)
+	}
+	coordinator, err := bundle.ResolveFlowSingletonCoordinator(finalflowinstanceauthoring.CoordinatorFlowID)
+	if err != nil {
+		t.Fatalf("ResolveFlowSingletonCoordinator(%s): %v", finalflowinstanceauthoring.CoordinatorFlowID, err)
+	}
+	if coordinator.PrimaryEntity.EntityType != finalflowinstanceauthoring.CoordinatorEntityType {
+		t.Fatalf("singleton primary entity = %q, want %s", coordinator.PrimaryEntity.EntityType, finalflowinstanceauthoring.CoordinatorEntityType)
+	}
+	if !finalFixtureContainedField(coordinator.ContainedState, "lead_index", "map") || !finalFixtureContainedField(coordinator.ContainedState, "audit_log", "list") {
+		t.Fatalf("singleton contained state = %#v, want lead_index map and audit_log list", coordinator.ContainedState)
+	}
+
+	handler, ok := source.NodeEventHandler(finalflowinstanceauthoring.CoordinatorNodeID, finalflowinstanceauthoring.CoordinatorInput)
+	if !ok {
+		t.Fatalf("handler %s/%s missing", finalflowinstanceauthoring.CoordinatorNodeID, finalflowinstanceauthoring.CoordinatorInput)
+	}
+	containedWrites := make([]runtimecontracts.WorkflowDataWrite, 0, len(handler.DataAccumulation.Writes))
+	for _, write := range handler.DataAccumulation.Writes {
+		if write.IsContainedOperation() {
+			containedWrites = append(containedWrites, write)
+		}
+	}
+	if got := len(containedWrites); got != 6 {
+		t.Fatalf("contained writes = %d, want 6: %#v", got, handler.DataAccumulation.Writes)
+	}
+	contract, ok := entityruntime.ResolveForFlow(source, finalflowinstanceauthoring.CoordinatorFlowID)
+	if !ok {
+		t.Fatalf("entityruntime.ResolveForFlow(%s) missing", finalflowinstanceauthoring.CoordinatorFlowID)
+	}
+	for idx, write := range containedWrites {
+		if _, err := entityruntime.ResolveContainedOperationTarget(contract, write.Target(), string(write.Operation), !write.Key.IsZero(), !write.Index.IsZero()); err != nil {
+			t.Fatalf("ResolveContainedOperationTarget(write[%d]): %v", idx, err)
+		}
+	}
+}
+
+func TestFinalFlowInstanceAuthoringFixture_FailClosedMatrix(t *testing.T) {
+	tests := []struct {
+		name        string
+		opts        finalflowinstanceauthoring.Options
+		checkID     string
+		wantMessage string
+		loadError   bool
+	}{
+		{
+			name:        "missing output key evidence",
+			opts:        finalflowinstanceauthoring.Options{MissingOutputKey: true},
+			checkID:     "composition_connect_validation",
+			wantMessage: "output_key_missing",
+		},
+		{
+			name:        "missing output carries evidence",
+			opts:        finalflowinstanceauthoring.Options{MissingOutputCarries: true},
+			checkID:     "output_pin_key_carries_validation",
+			wantMessage: "carries",
+		},
+		{
+			name:        "renamed key adapter references missing producer evidence",
+			opts:        finalflowinstanceauthoring.Options{BadConnectMapping: true},
+			checkID:     "composition_connect_validation",
+			wantMessage: "connect_key_adapter_source_missing",
+		},
+		{
+			name:        "duplicate adapter mapping is ambiguous",
+			opts:        finalflowinstanceauthoring.Options{DuplicateConnectMapping: true},
+			checkID:     "composition_connect_validation",
+			wantMessage: "connect_key_adapter_duplicate_source",
+		},
+		{
+			name:        "normal connected receiver select_entity is illegal",
+			opts:        finalflowinstanceauthoring.Options{UnsupportedReceiverSelector: true},
+			checkID:     "redundant_in_topology_select_entity",
+			wantMessage: "instance.by plus parent connect",
+		},
+		{
+			name:        "producer target cannot rescue common composition",
+			opts:        finalflowinstanceauthoring.Options{ProducerTarget: true},
+			checkID:     "pin_target_resolution",
+			wantMessage: "producer_target_common_path_forbidden",
+		},
+		{
+			name:        "producer broadcast cannot replace parent connect authority",
+			opts:        finalflowinstanceauthoring.Options{ProducerBroadcast: true},
+			checkID:     "pin_target_resolution",
+			wantMessage: "producer_broadcast_common_path_forbidden",
+		},
+		{
+			name:        "bad map write dynamic bracket target",
+			opts:        finalflowinstanceauthoring.Options{DynamicBracketTarget: true},
+			checkID:     "contained_state_operation_compliance",
+			wantMessage: "dynamic bracket path syntax",
+		},
+		{
+			name:        "bad map write missing key",
+			opts:        finalflowinstanceauthoring.Options{MissingMapKey: true},
+			wantMessage: "requires key",
+			loadError:   true,
+		},
+		{
+			name:        "retired static create_entity",
+			opts:        finalflowinstanceauthoring.Options{StaticCreateEntity: true},
+			checkID:     "flow_boundary_create_entity_validation",
+			wantMessage: "static multi-row entity ownership is retired",
+		},
+		{
+			name:        "retired static select_entity",
+			opts:        finalflowinstanceauthoring.Options{StaticSelectEntity: true},
+			checkID:     "select_entity_validation",
+			wantMessage: "static multi-row entity ownership is retired",
+		},
+		{
+			name:        "retired static select_or_create_entity",
+			opts:        finalflowinstanceauthoring.Options{StaticSelectOrCreate: true},
+			checkID:     "select_entity_validation",
+			wantMessage: "static multi-row entity ownership is retired",
+		},
+		{
+			name:        "retired static missing acquisition",
+			opts:        finalflowinstanceauthoring.Options{StaticMissingAcquisition: true},
+			checkID:     "flow_boundary_create_entity_validation",
+			wantMessage: "static multi-row entity ownership is retired",
+		},
+		{
+			name:        "retired root default caller-selected entity id",
+			opts:        finalflowinstanceauthoring.Options{RootDefaultEntityIDSource: true},
+			checkID:     "flow_boundary_create_entity_validation",
+			wantMessage: "caller-selected entity_id",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			bundle, err := finalflowinstanceauthoring.LoadBundleResult(t, tc.opts)
+			if tc.loadError {
+				if err == nil || !strings.Contains(err.Error(), tc.wantMessage) {
+					t.Fatalf("LoadWorkflowContractBundleWithOverrides error = %v, want containing %q", err, tc.wantMessage)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("LoadWorkflowContractBundleWithOverrides: %v", err)
+			}
+			report := runtimebootverify.Run(context.Background(), semanticview.Wrap(bundle), runtimebootverify.Options{})
+			if !finalFixtureFindingContains(report.Errors(), tc.checkID, tc.wantMessage) {
+				t.Fatalf("expected bootverify error %s containing %q, got %#v", tc.checkID, tc.wantMessage, report.Errors())
+			}
+		})
+	}
+}
+
+func TestFinalFlowInstanceAuthoringFixture_RouteAuthorityBypassInventoryStaysClassified(t *testing.T) {
+	root := conformanceRepoRoot(t)
+	inventory := loadRouteAuthorityDriftInventory(t, root)
+	for _, id := range []string{
+		"direct_delivery_path",
+		"event_delivery_plan_compatibility",
+		"route_table_resolve",
+		"receiver_carrier",
+	} {
+		dimension := routeAuthorityDriftSearchDimensionByID(t, &inventory, id)
+		if !dimension.ClassifiedPathsRequired {
+			t.Fatalf("search_dimension %s classified_paths_required = false, want true for final bypass guard", id)
+		}
+	}
+	for _, id := range []string{
+		"direct_delivery_path_classification",
+		"event_delivery_plan_compatibility_adapter",
+		"route_table_resolve_role_separation",
+		"receiver_carrier_evidence",
+		"live_carriers_internal_subscriptions",
+	} {
+		family := routeAuthorityDriftSeamFamilyByID(t, &inventory, id)
+		if len(family.InvalidAuthority) == 0 && strings.Contains(family.Layer, "non_authority") {
+			t.Fatalf("seam_family %s invalid_authority missing", id)
+		}
+	}
+	if problems := validateRouteAuthorityDriftInventory(root, inventory); len(problems) != 0 {
+		t.Fatalf("route authority inventory validation failed:\n- %s", strings.Join(problems, "\n- "))
+	}
+}
+
+func finalFixtureContainedField(fields []runtimecontracts.SingletonCoordinatorContainedField, name, kind string) bool {
+	for _, field := range fields {
+		if strings.TrimSpace(field.Name) == name && strings.TrimSpace(field.Kind) == kind {
+			return true
+		}
+	}
+	return false
+}
+
+func finalFixtureContainsString(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
+}
+
+func finalFixtureFindingContains(findings []runtimebootverify.Finding, checkID, substr string) bool {
+	for _, finding := range findings {
+		if strings.TrimSpace(finding.CheckID) != checkID {
+			continue
+		}
+		if substr == "" || strings.Contains(finding.Message, substr) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/runtime/conformance/final_flow_instance_authoring_conformance_test.go
+++ b/internal/runtime/conformance/final_flow_instance_authoring_conformance_test.go
@@ -192,6 +192,30 @@ func TestFinalFlowInstanceAuthoringFixture_FailClosedMatrix(t *testing.T) {
 			loadError:   true,
 		},
 		{
+			name:        "bad map write wrong value shape",
+			opts:        finalflowinstanceauthoring.Options{WrongMapValueShape: true},
+			checkID:     "contained_state_operation_compliance",
+			wantMessage: "undeclared",
+		},
+		{
+			name:        "bad map write undeclared target",
+			opts:        finalflowinstanceauthoring.Options{UndeclaredMapTarget: true},
+			checkID:     "contained_state_operation_compliance",
+			wantMessage: "missing_index",
+		},
+		{
+			name:        "bad map write unsupported operation",
+			opts:        finalflowinstanceauthoring.Options{UnsupportedMapOp: true},
+			wantMessage: "unsupported workflow data write op",
+			loadError:   true,
+		},
+		{
+			name:        "bad list write negative index",
+			opts:        finalflowinstanceauthoring.Options{BadListIndex: true},
+			checkID:     "contained_state_operation_compliance",
+			wantMessage: "list index cannot be negative",
+		},
+		{
 			name:        "retired static create_entity",
 			opts:        finalflowinstanceauthoring.Options{StaticCreateEntity: true},
 			checkID:     "flow_boundary_create_entity_validation",

--- a/internal/runtime/conformance/testdata/route_authority_drift_inventory.yaml
+++ b/internal/runtime/conformance/testdata/route_authority_drift_inventory.yaml
@@ -366,6 +366,7 @@ seam_families:
       - internal/runtime/bus/connect_route_plan_dispatch.go
       - internal/runtime/bus/template_instance_lifecycle.go
       - internal/runtime/bus/connect_route_plan_dispatch_test.go
+      - internal/runtime/bus/final_flow_instance_authoring_route_test.go
       - internal/runtime/bus/route_plan.go
       - internal/runtime/conformance/testdata/route_authority_matrix.yaml
     search_dimensions: [connect_route_plan, route_plan, route_plan_source_reason]
@@ -386,6 +387,7 @@ seam_families:
     classification: non_authoritative_observer_projection
     paths:
       - internal/runtime/authoringview/view.go
+      - internal/runtime/authoringview/view_test.go
     search_dimensions: [connect_route_plan]
     invalid_authority:
       - route authority decisions
@@ -673,6 +675,7 @@ seam_families:
       - internal/runtime/cataloge2e/tier12_runtime_fork_e2e_test.go
       - internal/runtime/bus/sealed_flow_package_fixture_test.go
       - internal/runtime/conformance/sealed_flow_package_conformance_test.go
+      - internal/runtime/conformance/final_flow_instance_authoring_conformance_test.go
       - internal/runtime/conformance/singleton_coordinator_pilot_conformance_test.go
       - internal/runtime/conformance/template_flow_pilot_conformance_test.go
       - internal/runtime/swarmflowtest/catalog_runner_test.go

--- a/internal/runtime/final_flow_instance_authoring_runtime_test.go
+++ b/internal/runtime/final_flow_instance_authoring_runtime_test.go
@@ -1,0 +1,248 @@
+package runtime_test
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/division-sh/swarm/internal/events"
+	"github.com/division-sh/swarm/internal/events/eventtest"
+	runtimebootverify "github.com/division-sh/swarm/internal/runtime/bootverify"
+	runtimebus "github.com/division-sh/swarm/internal/runtime/bus"
+	runtimemanager "github.com/division-sh/swarm/internal/runtime/manager"
+	runtimepipeline "github.com/division-sh/swarm/internal/runtime/pipeline"
+	"github.com/division-sh/swarm/internal/runtime/semanticview"
+	"github.com/division-sh/swarm/internal/runtime/testfixtures/finalflowinstanceauthoring"
+	"github.com/division-sh/swarm/internal/store"
+	"github.com/division-sh/swarm/internal/testutil"
+)
+
+func TestFinalFlowInstanceAuthoringRuntime_PublishActivatesAndExecutesSelectedTemplateInstance(t *testing.T) {
+	bundle := finalflowinstanceauthoring.LoadBundle(t, finalflowinstanceauthoring.Options{})
+	source := semanticview.Wrap(bundle)
+	report := runtimebootverify.Run(context.Background(), source, runtimebootverify.Options{})
+	if got := report.HardInvalidities(); len(got) != 0 {
+		t.Fatalf("final flow-instance authoring hard invalidities = %#v, want none", got)
+	}
+
+	_, db, cleanup := testutil.StartPostgres(t)
+	t.Cleanup(cleanup)
+	ctx := seedRuntimeTestRun(t, db)
+	pg := &store.PostgresStore{DB: db}
+	workflowStore := runtimepipeline.NewWorkflowInstanceStore(db)
+	var manager *runtimemanager.AgentManager
+	var pc *runtimepipeline.PipelineCoordinator
+	bus, err := runtimebus.NewEventBusWithOptions(pg, runtimebus.EventBusOptions{
+		ContractBundle: source,
+		InterceptorProvider: func() []runtimebus.EventInterceptor {
+			if pc == nil {
+				return nil
+			}
+			return []runtimebus.EventInterceptor{pc}
+		},
+		TemplateInstanceActivator: func(ctx context.Context, req runtimepipeline.FlowInstanceActivationRequest) error {
+			if manager == nil {
+				return errors.New("agent manager not initialized")
+			}
+			return manager.ActivateFlowInstance(ctx, req)
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewEventBusWithOptions: %v", err)
+	}
+	manager = runtimemanager.NewAgentManagerWithOptions(bus, nil, runtimemanager.AgentManagerOptions{
+		WorkflowInstances: workflowStore,
+	})
+	module := newRuntimeTestWorkflowModule(t, source)
+	pc = runtimepipeline.NewPipelineCoordinatorWithOptions(bus, db, runtimepipeline.PipelineCoordinatorOptions{
+		Module:            module,
+		InstanceActivator: manager.ActivateFlowInstance,
+		WorkflowStore:     workflowStore,
+		EventReceiptsCapability: func(context.Context) (bool, error) {
+			return true, nil
+		},
+	})
+
+	evt := eventtest.RootIngress(
+		"99999999-9999-4999-8999-999999999955",
+		events.EventType(finalflowinstanceauthoring.ProducerFlowID+"/"+finalflowinstanceauthoring.ProducerOutput),
+		"",
+		"",
+		json.RawMessage(`{"source_account_id":"acct-42","score":"91","decision":"approved"}`),
+		0,
+		templateInstanceDeliveryRunID,
+		"",
+		events.EventEnvelope{},
+		time.Now().UTC(),
+	)
+	preflight, err := bus.CheckPublishRecipientPlan(ctx, evt)
+	if err != nil {
+		t.Fatalf("CheckPublishRecipientPlan: %v", err)
+	}
+	if preflight.TargetFailure != "" || len(preflight.DeliveryRoutes) != 1 || !preflight.UsesCanonicalRouteAuthority() {
+		t.Fatalf("preflight failure/routes/canonical = %q/%#v/%v, want one canonical template route", preflight.TargetFailure, preflight.DeliveryRoutes, preflight.UsesCanonicalRouteAuthority())
+	}
+	assertRuntimeDBCount(t, ctx, db, `
+		SELECT COUNT(*) FROM entity_state
+		WHERE flow_instance LIKE 'account_case/%'
+	`, 0)
+
+	if err := bus.PublishAcknowledged(ctx, evt); err != nil {
+		t.Fatalf("PublishAcknowledged final account.ready: %v", err)
+	}
+	t.Cleanup(func() {
+		if !t.Failed() {
+			return
+		}
+		dumpFinalFlowInstanceAuthoringRuntimeProofState(t, ctx, db, evt.ID())
+	})
+	waitRuntimeDBCount(t, ctx, db, `
+		SELECT COUNT(*) FROM event_receipts
+		WHERE event_id = $1::uuid
+		  AND subscriber_type = 'node'
+		  AND subscriber_id = $2
+		  AND outcome = 'no_op'
+	`, 1, evt.ID(), finalflowinstanceauthoring.TemplateNodeID)
+	waitRuntimeDBCount(t, ctx, db, `
+		SELECT COUNT(*) FROM entity_state
+		WHERE flow_instance LIKE 'account_case/%'
+		  AND current_state = 'reviewed'
+		  AND fields @> $1::jsonb
+	`, 1, `{"account_id":"acct-42","score":"91","decision":"approved"}`)
+	assertRuntimeDBCount(t, ctx, db, `
+		SELECT COUNT(*) FROM entity_state
+		WHERE flow_instance LIKE 'account_case/%'
+	`, 1)
+
+	flowInstance, entityID := loadFinalFlowInstanceAuthoringTemplateIdentity(t, ctx, db)
+	assertRuntimeDBCount(t, ctx, db, `
+		SELECT COUNT(*) FROM event_deliveries
+		WHERE event_id = $1::uuid
+		  AND subscriber_type = 'node'
+		  AND subscriber_id = $2
+		  AND status = 'delivered'
+		  AND delivery_target_route @> $3::jsonb
+	`, 1, evt.ID(), finalflowinstanceauthoring.TemplateNodeID, finalFlowInstanceAuthoringDeliveryTargetRouteJSON(t, events.RouteIdentity{
+		FlowID:       finalflowinstanceauthoring.TemplateFlowID,
+		FlowInstance: flowInstance,
+		EntityID:     entityID,
+	}))
+
+	loaded, ok, err := workflowStore.Load(ctx, entityID)
+	if err != nil {
+		t.Fatalf("workflowStore.Load(%s): %v", entityID, err)
+	}
+	if !ok {
+		t.Fatalf("workflowStore.Load(%s) ok=false", entityID)
+	}
+	if loaded.StorageRef != flowInstance || loaded.WorkflowName != finalflowinstanceauthoring.TemplateFlowID || loaded.CurrentState != "reviewed" {
+		t.Fatalf("loaded account_case instance = storage:%q workflow:%q state:%q, want %s/%s/reviewed", loaded.StorageRef, loaded.WorkflowName, loaded.CurrentState, flowInstance, finalflowinstanceauthoring.TemplateFlowID)
+	}
+	if loaded.Metadata[finalflowinstanceauthoring.TemplateInstanceBy] != "acct-42" ||
+		loaded.Metadata["score"] != "91" ||
+		loaded.Metadata["decision"] != "approved" {
+		t.Fatalf("loaded account_case metadata = %#v, want account_id/score/decision from selected routed payload", loaded.Metadata)
+	}
+}
+
+func loadFinalFlowInstanceAuthoringTemplateIdentity(t *testing.T, ctx context.Context, db *sql.DB) (string, string) {
+	t.Helper()
+	var flowInstance string
+	var entityID string
+	if err := db.QueryRowContext(ctx, `
+		SELECT flow_instance, entity_id::text
+		FROM entity_state
+		WHERE flow_instance LIKE 'account_case%'
+		ORDER BY created_at DESC
+		LIMIT 1
+	`).Scan(&flowInstance, &entityID); err != nil {
+		t.Fatalf("load account_case instance identity: %v", err)
+	}
+	return flowInstance, entityID
+}
+
+func finalFlowInstanceAuthoringDeliveryTargetRouteJSON(t *testing.T, target events.RouteIdentity) string {
+	t.Helper()
+	encoded, err := json.Marshal(target.Normalized())
+	if err != nil {
+		t.Fatalf("marshal final flow-instance authoring delivery target: %v", err)
+	}
+	return strings.TrimSpace(string(encoded))
+}
+
+func dumpFinalFlowInstanceAuthoringRuntimeProofState(t *testing.T, ctx context.Context, db *sql.DB, eventID string) {
+	t.Helper()
+	rows, err := db.QueryContext(ctx, `
+		SELECT subscriber_type, subscriber_id, status, COALESCE(reason_code, ''), COALESCE(last_error, ''),
+		       COALESCE(delivery_target_route::text, '')
+		FROM event_deliveries
+		WHERE event_id = $1::uuid
+		ORDER BY subscriber_type, subscriber_id
+	`, eventID)
+	if err != nil {
+		t.Logf("event_deliveries diagnostic query failed: %v", err)
+		return
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var subscriberType, subscriberID, status, reason, lastError, target string
+		if err := rows.Scan(&subscriberType, &subscriberID, &status, &reason, &lastError, &target); err != nil {
+			t.Logf("event_deliveries diagnostic scan failed: %v", err)
+			return
+		}
+		t.Logf("event_delivery: type=%s id=%s status=%s reason=%s error=%s target=%s", subscriberType, subscriberID, status, reason, lastError, target)
+	}
+	if err := rows.Err(); err != nil {
+		t.Logf("event_deliveries diagnostic rows failed: %v", err)
+	}
+
+	receiptRows, err := db.QueryContext(ctx, `
+		SELECT subscriber_type, subscriber_id, outcome, COALESCE(idempotency_key, ''), COALESCE(side_effects::text, '')
+		FROM event_receipts
+		WHERE event_id = $1::uuid
+		ORDER BY subscriber_type, subscriber_id, idempotency_key
+	`, eventID)
+	if err != nil {
+		t.Logf("event_receipts diagnostic query failed: %v", err)
+		return
+	}
+	defer receiptRows.Close()
+	for receiptRows.Next() {
+		var subscriberType, subscriberID, outcome, idempotencyKey, sideEffects string
+		if err := receiptRows.Scan(&subscriberType, &subscriberID, &outcome, &idempotencyKey, &sideEffects); err != nil {
+			t.Logf("event_receipts diagnostic scan failed: %v", err)
+			return
+		}
+		t.Logf("event_receipt: type=%s id=%s outcome=%s key=%s side_effects=%s", subscriberType, subscriberID, outcome, idempotencyKey, sideEffects)
+	}
+	if err := receiptRows.Err(); err != nil {
+		t.Logf("event_receipts diagnostic rows failed: %v", err)
+	}
+
+	stateRows, err := db.QueryContext(ctx, `
+		SELECT entity_id::text, flow_instance, current_state, fields::text
+		FROM entity_state
+		WHERE flow_instance LIKE 'account_case/%'
+		ORDER BY created_at
+	`)
+	if err != nil {
+		t.Logf("entity_state diagnostic query failed: %v", err)
+		return
+	}
+	defer stateRows.Close()
+	for stateRows.Next() {
+		var entityID, flowInstance, currentState, fields string
+		if err := stateRows.Scan(&entityID, &flowInstance, &currentState, &fields); err != nil {
+			t.Logf("entity_state diagnostic scan failed: %v", err)
+			return
+		}
+		t.Logf("entity_state: entity=%s flow_instance=%s state=%s fields=%s", entityID, flowInstance, currentState, fields)
+	}
+	if err := stateRows.Err(); err != nil {
+		t.Logf("entity_state diagnostic rows failed: %v", err)
+	}
+}

--- a/internal/runtime/pipeline/coordinator.go
+++ b/internal/runtime/pipeline/coordinator.go
@@ -220,6 +220,17 @@ func (pc *PipelineCoordinator) Intercept(ctx context.Context, evt events.Event) 
 	return !consume, emitted, nil
 }
 
+func (pc *PipelineCoordinator) InterceptDeliveryRoute(ctx context.Context, evt events.Event, route events.DeliveryRoute) (bool, []events.Event, error) {
+	route = route.Normalized()
+	if route.SubscriberType != "node" || route.SubscriberID == "" {
+		return true, nil, nil
+	}
+	if route.Target.Normalized() != evt.TargetRoute().Normalized() {
+		return true, nil, fmt.Errorf("workflow node delivery route target mismatch for %s: route=%#v event=%#v", route.SubscriberID, route.Target.Normalized(), evt.TargetRoute().Normalized())
+	}
+	return pc.Intercept(withWorkflowNodeDeliveryRoute(ctx, route), evt)
+}
+
 func (pc *PipelineCoordinator) interceptPolicy(ctx context.Context, eventType string, evt events.Event) (consume bool, handled bool) {
 	if strings.TrimSpace(eventType) == "" {
 		return false, false

--- a/internal/runtime/pipeline/coordinator.go
+++ b/internal/runtime/pipeline/coordinator.go
@@ -201,7 +201,7 @@ func (pc *PipelineCoordinator) Intercept(ctx context.Context, evt events.Event) 
 	if eventType == "" {
 		return true, nil, nil
 	}
-	consume, handled := pc.interceptPolicy(eventType, evt)
+	consume, handled := pc.interceptPolicy(ctx, eventType, evt)
 	if !handled {
 		return true, nil, nil
 	}
@@ -220,11 +220,11 @@ func (pc *PipelineCoordinator) Intercept(ctx context.Context, evt events.Event) 
 	return !consume, emitted, nil
 }
 
-func (pc *PipelineCoordinator) interceptPolicy(eventType string, evt events.Event) (consume bool, handled bool) {
+func (pc *PipelineCoordinator) interceptPolicy(ctx context.Context, eventType string, evt events.Event) (consume bool, handled bool) {
 	if strings.TrimSpace(eventType) == "" {
 		return false, false
 	}
-	return pc.workflowNodeInterceptPolicy(eventType, evt)
+	return pc.workflowNodeInterceptPolicy(ctx, eventType, evt)
 }
 
 func (pc *PipelineCoordinator) subscribe() <-chan events.Event {

--- a/internal/runtime/pipeline/final_flow_instance_authoring_delivery_test.go
+++ b/internal/runtime/pipeline/final_flow_instance_authoring_delivery_test.go
@@ -1,0 +1,281 @@
+package pipeline
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/division-sh/swarm/internal/events"
+	"github.com/division-sh/swarm/internal/events/eventtest"
+	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
+	"github.com/division-sh/swarm/internal/runtime/semanticview"
+	"github.com/division-sh/swarm/internal/runtime/testfixtures/finalflowinstanceauthoring"
+	"github.com/division-sh/swarm/internal/testutil"
+	"github.com/google/uuid"
+)
+
+func TestFinalFlowInstanceAuthoringFixturePipelineDispatchPersistsSingletonContainedStateReadback(t *testing.T) {
+	bundle := finalflowinstanceauthoring.LoadBundle(t, finalflowinstanceauthoring.Options{})
+	source := semanticview.Wrap(bundle)
+	_, db, cleanup := testutil.StartPostgres(t)
+	t.Cleanup(cleanup)
+	pc, workflowStore := newFinalFlowInstanceAuthoringPipelineCoordinator(t, db, bundle, source)
+	ctx := testPipelineCoordinatorRunContext(t, pc)
+	entityID := FlowInstanceEntityID(finalflowinstanceauthoring.CoordinatorInstance)
+	seedFinalFlowInstanceAuthoringCoordinatorInstance(t, workflowStore, ctx, bundle, entityID)
+
+	target := events.RouteIdentity{
+		FlowID:       finalflowinstanceauthoring.CoordinatorFlowID,
+		FlowInstance: finalflowinstanceauthoring.CoordinatorInstance,
+		EntityID:     entityID,
+	}
+	evt := eventtest.RootIngress(
+		uuid.NewString(),
+		events.EventType(finalflowinstanceauthoring.CoordinatorInput),
+		finalflowinstanceauthoring.CoordinatorFlowID,
+		"",
+		json.RawMessage(`{"coordinator_id":"global","lead_id":"lead-42","observation":{"source":"feed","note":"first seen"},"audit":{"ref":"lead-42","action":"observed"},"followup_audit":{"ref":"lead-42","action":"queued"},"corrected_audit":{"ref":"bootstrap","action":"corrected"}}`),
+		0,
+		testPipelineRunID,
+		"",
+		events.EnvelopeForTargetRoute(events.EventEnvelope{}, target),
+		time.Now().UTC(),
+	)
+	seedFinalFlowInstanceAuthoringEvent(t, db, ctx, evt)
+	seedFinalFlowInstanceAuthoringNodeDelivery(t, db, ctx, evt.ID(), finalflowinstanceauthoring.CoordinatorNodeID, target)
+
+	handled, err := pc.dispatchWorkflowNodeEventResult(ctx, evt)
+	if err != nil {
+		t.Fatalf("dispatchWorkflowNodeEventResult: %v", err)
+	}
+	if !handled {
+		t.Fatal("dispatchWorkflowNodeEventResult handled = false, want coordinator handler delivery")
+	}
+	loaded, ok, err := workflowStore.Load(ctx, entityID)
+	if err != nil {
+		t.Fatalf("workflowStore.Load(%s): %v", entityID, err)
+	}
+	if !ok {
+		t.Fatalf("workflowStore.Load(%s) ok=false", entityID)
+	}
+	if loaded.WorkflowName != finalflowinstanceauthoring.CoordinatorFlowID || loaded.CurrentState != "active" {
+		t.Fatalf("loaded coordinator = storage:%q workflow:%q state:%q, want coordinator/active", loaded.StorageRef, loaded.WorkflowName, loaded.CurrentState)
+	}
+	leadIndex, ok := loaded.Metadata["lead_index"].(map[string]any)
+	if !ok {
+		t.Fatalf("lead_index = %#v, want map", loaded.Metadata["lead_index"])
+	}
+	lead, ok := leadIndex["lead-42"].(map[string]any)
+	if !ok {
+		t.Fatalf("lead_index[lead-42] = %#v, want map", leadIndex["lead-42"])
+	}
+	if lead["status"] != "active" || lead["score"] != float64(1) {
+		t.Fatalf("lead_index[lead-42] = %#v, want status active score 1", lead)
+	}
+	observations, ok := lead["observations"].([]any)
+	if !ok || len(observations) != 1 {
+		t.Fatalf("lead observations = %#v, want one observation", lead["observations"])
+	}
+	observation, ok := observations[0].(map[string]any)
+	if !ok || observation["source"] != "feed" || observation["note"] != "first seen" {
+		t.Fatalf("observation = %#v, want feed/first seen", observations[0])
+	}
+	auditLog, ok := loaded.Metadata["audit_log"].([]any)
+	if !ok || len(auditLog) != 3 {
+		t.Fatalf("audit_log = %#v, want three entries", loaded.Metadata["audit_log"])
+	}
+	firstAudit, ok := auditLog[0].(map[string]any)
+	if !ok || firstAudit["ref"] != "bootstrap" || firstAudit["action"] != "corrected" {
+		t.Fatalf("audit_log[0] = %#v, want corrected bootstrap entry", auditLog[0])
+	}
+	secondAudit, ok := auditLog[1].(map[string]any)
+	if !ok || secondAudit["ref"] != "lead-42" || secondAudit["action"] != "observed" {
+		t.Fatalf("audit_log[1] = %#v, want observed lead-42 entry", auditLog[1])
+	}
+	thirdAudit, ok := auditLog[2].(map[string]any)
+	if !ok || thirdAudit["ref"] != "lead-42" || thirdAudit["action"] != "queued" {
+		t.Fatalf("audit_log[2] = %#v, want queued lead-42 entry", auditLog[2])
+	}
+	assertFinalFlowInstanceAuthoringDeliveryStatus(t, db, evt.ID(), finalflowinstanceauthoring.CoordinatorNodeID, "delivered")
+	assertNoFinalFlowInstanceAuthoringContainedRouteRows(t, db, "coordinator/lead-42")
+	assertNoFinalFlowInstanceAuthoringContainedWorkflowInstance(t, db, workflowStore, ctx, "coordinator/lead-42")
+}
+
+func TestFinalFlowInstanceAuthoringFixturePipelineRejectsContainedItemDeliveryTarget(t *testing.T) {
+	bundle := finalflowinstanceauthoring.LoadBundle(t, finalflowinstanceauthoring.Options{})
+	source := semanticview.Wrap(bundle)
+	_, db, cleanup := testutil.StartPostgres(t)
+	t.Cleanup(cleanup)
+	pc, _ := newFinalFlowInstanceAuthoringPipelineCoordinator(t, db, bundle, source)
+
+	containedTarget := events.RouteIdentity{
+		FlowID:       finalflowinstanceauthoring.CoordinatorFlowID,
+		FlowInstance: finalflowinstanceauthoring.CoordinatorInstance + "/lead-42",
+		EntityID:     uuid.NewString(),
+	}
+	if pc.workflowNodeMatchesDeliveryTarget(finalflowinstanceauthoring.CoordinatorNodeID, containedTarget) {
+		t.Fatalf("contained item target %#v matched singleton coordinator node; contained map entries must not be route recipients", containedTarget)
+	}
+}
+
+func newFinalFlowInstanceAuthoringPipelineCoordinator(t *testing.T, db *sql.DB, bundle *runtimecontracts.WorkflowContractBundle, source semanticview.Source) (*PipelineCoordinator, *WorkflowInstanceStore) {
+	t.Helper()
+	workflow, err := LoadWorkflowDefinition(source)
+	if err != nil {
+		t.Fatalf("LoadWorkflowDefinition: %v", err)
+	}
+	nodes, err := LoadWorkflowNodes(source)
+	if err != nil {
+		t.Fatalf("LoadWorkflowNodes: %v", err)
+	}
+	workflowStore := NewWorkflowInstanceStore(db)
+	pc := NewPipelineCoordinatorWithOptions(&recordingPipelineBus{}, db, PipelineCoordinatorOptions{
+		Module: &previewWorkflowModule{
+			bundle:         bundle,
+			workflow:       workflow,
+			workflowNodes:  nodes,
+			guardRegistry:  NewContractGuardRegistry(source),
+			actionRegistry: NewContractActionRegistry(source),
+		},
+		WorkflowStore:           workflowStore,
+		EventReceiptsCapability: eventReceiptsCapabilityStub{enabled: true}.resolve,
+	})
+	return pc, workflowStore
+}
+
+func seedFinalFlowInstanceAuthoringCoordinatorInstance(t *testing.T, store *WorkflowInstanceStore, ctx context.Context, bundle *runtimecontracts.WorkflowContractBundle, entityID string) {
+	t.Helper()
+	if err := store.Create(ctx, WorkflowInstance{
+		InstanceID:      entityID,
+		StorageRef:      finalflowinstanceauthoring.CoordinatorInstance,
+		WorkflowName:    finalflowinstanceauthoring.CoordinatorFlowID,
+		WorkflowVersion: bundle.WorkflowVersion(),
+		CurrentState:    "active",
+		Metadata: map[string]any{
+			"entity_id":      entityID,
+			"flow_path":      finalflowinstanceauthoring.CoordinatorInstance,
+			"instance_id":    entityID,
+			"coordinator_id": "global",
+			"lead_index":     map[string]any{},
+			"audit_log": []any{
+				map[string]any{"ref": "seed", "action": "seed"},
+			},
+		},
+	}); err != nil {
+		t.Fatalf("seed final flow-instance authoring coordinator instance: %v", err)
+	}
+}
+
+func seedFinalFlowInstanceAuthoringEvent(t *testing.T, db *sql.DB, ctx context.Context, evt events.Event) {
+	t.Helper()
+	targetRaw, err := json.Marshal(evt.TargetRoute())
+	if err != nil {
+		t.Fatalf("marshal target route: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO events (
+			event_id, run_id, event_name, entity_id, flow_instance, scope, payload,
+			produced_by, produced_by_type, target_route, created_at
+		) VALUES (
+			$1::uuid, $2::uuid, $3, $4::uuid, $5, 'entity', $6::jsonb,
+			$7, 'agent', $8::jsonb, now()
+		)
+	`, evt.ID(), evt.RunID(), string(evt.Type()), evt.EntityID(), evt.FlowInstance(), string(evt.Payload()), evt.SourceAgent(), string(targetRaw)); err != nil {
+		t.Fatalf("seed final flow-instance authoring event: %v", err)
+	}
+}
+
+func seedFinalFlowInstanceAuthoringNodeDelivery(t *testing.T, db *sql.DB, ctx context.Context, eventID, nodeID string, target events.RouteIdentity) {
+	t.Helper()
+	targetRaw, err := json.Marshal(target.Normalized())
+	if err != nil {
+		t.Fatalf("marshal delivery target route: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO event_deliveries (
+			run_id, event_id, subscriber_type, subscriber_id, delivery_target_route, status, retry_count, created_at
+		) VALUES (
+			$1::uuid, $2::uuid, 'node', $3, $4::jsonb, 'pending', 0, now()
+		)
+	`, testPipelineRunID, eventID, nodeID, string(targetRaw)); err != nil {
+		t.Fatalf("seed final flow-instance authoring node delivery: %v", err)
+	}
+}
+
+func assertFinalFlowInstanceAuthoringDeliveryStatus(t *testing.T, db *sql.DB, eventID, nodeID, want string) {
+	t.Helper()
+	var got string
+	if err := db.QueryRowContext(context.Background(), `
+		SELECT COALESCE(status, '')
+		FROM event_deliveries
+		WHERE event_id = $1::uuid
+		  AND subscriber_type = 'node'
+		  AND subscriber_id = $2
+	`, eventID, nodeID).Scan(&got); err != nil {
+		t.Fatalf("load final flow-instance authoring node delivery: %v", err)
+	}
+	if got != want {
+		t.Fatalf("final flow-instance authoring delivery status = %q, want %q", got, want)
+	}
+}
+
+func assertNoFinalFlowInstanceAuthoringContainedRouteRows(t *testing.T, db *sql.DB, flowInstance string) {
+	t.Helper()
+	var count int
+	if err := db.QueryRowContext(context.Background(), `
+		SELECT COUNT(*)
+		FROM event_deliveries
+		WHERE delivery_target_route->>'flow_instance' = $1
+	`, flowInstance).Scan(&count); err != nil {
+		t.Fatalf("count contained route delivery rows: %v", err)
+	}
+	if count != 0 {
+		t.Fatalf("contained flow_instance %q has %d delivery row(s), want none", flowInstance, count)
+	}
+}
+
+func assertNoFinalFlowInstanceAuthoringContainedWorkflowInstance(t *testing.T, db *sql.DB, store *WorkflowInstanceStore, ctx context.Context, flowInstance string) {
+	t.Helper()
+	entityID := FlowInstanceEntityID(flowInstance)
+	if _, ok, err := store.Load(ctx, entityID); err != nil {
+		t.Fatalf("workflowStore.Load(%s): %v", entityID, err)
+	} else if ok {
+		t.Fatalf("contained flow_instance %q materialized with canonical entity id %s", flowInstance, entityID)
+	}
+	if _, ok, err := store.Load(ctx, flowInstance); err != nil {
+		t.Fatalf("workflowStore.Load(%s): %v", flowInstance, err)
+	} else if ok {
+		t.Fatalf("contained flow_instance %q materialized through storage-ref lookup", flowInstance)
+	}
+
+	assertNoFinalFlowInstanceAuthoringRow(t, db, `
+		SELECT COUNT(*)
+		FROM entity_state
+		WHERE run_id = $1::uuid
+		  AND entity_id = $2::uuid
+	`, testPipelineRunID, entityID)
+	assertNoFinalFlowInstanceAuthoringRow(t, db, `
+		SELECT COUNT(*)
+		FROM entity_state
+		WHERE run_id = $1::uuid
+		  AND flow_instance = $2
+	`, testPipelineRunID, flowInstance)
+	assertNoFinalFlowInstanceAuthoringRow(t, db, `
+		SELECT COUNT(*)
+		FROM flow_instances
+		WHERE instance_id = $1
+	`, flowInstance)
+}
+
+func assertNoFinalFlowInstanceAuthoringRow(t *testing.T, db *sql.DB, query string, args ...any) {
+	t.Helper()
+	var count int
+	if err := db.QueryRowContext(context.Background(), query, args...).Scan(&count); err != nil {
+		t.Fatalf("count final flow-instance authoring rows: %v", err)
+	}
+	if count != 0 {
+		t.Fatalf("final flow-instance authoring absence query returned %d row(s), want none", count)
+	}
+}

--- a/internal/runtime/pipeline/handler_engine_transaction_test.go
+++ b/internal/runtime/pipeline/handler_engine_transaction_test.go
@@ -2265,7 +2265,7 @@ func TestExecuteNodeHandlerPlanResult_NestedDescendantCompletionDoesNotBackPropa
 	}); err != nil {
 		t.Fatalf("seed grandchild instance: %v", err)
 	}
-	if consume, handled := pc.workflowNodeInterceptPolicy("child/grandchild/micro.done", eventtest.RootIngress(
+	if consume, handled := pc.workflowNodeInterceptPolicy(context.Background(), "child/grandchild/micro.done", eventtest.RootIngress(
 		"",
 		events.EventType("child/grandchild/micro.done"),
 		"",

--- a/internal/runtime/pipeline/node_system_runner.go
+++ b/internal/runtime/pipeline/node_system_runner.go
@@ -794,6 +794,7 @@ func persistSystemNodeProcessedReceiptAndSettleDeliveryTx(ctx context.Context, t
 		WHERE event_id = $1::uuid
 		  AND subscriber_type = 'node'
 			  AND subscriber_id = $2
+			  AND COALESCE(delivery_target_route, '{}'::jsonb) = '{}'::jsonb
 			  AND (
 				status IN ('pending', 'in_progress')
 				OR (status = 'failed' AND COALESCE(retry_count, 0) < $3)
@@ -961,6 +962,7 @@ func markPostgresSystemNodeDeliveryInProgressTx(ctx context.Context, tx *sql.Tx,
 		WHERE event_id = $1::uuid
 		  AND subscriber_type = 'node'
 			  AND subscriber_id = $2
+			  AND COALESCE(delivery_target_route, '{}'::jsonb) = '{}'::jsonb
 			  AND (
 				status IN ('pending', 'in_progress')
 				OR (status = 'failed' AND COALESCE(retry_count, 0) < $3)
@@ -1108,11 +1110,12 @@ func markPostgresSystemNodeDeliveryFailedTx(ctx context.Context, tx *sql.Tx, nod
 			active_session_id = NULL,
 			started_at = COALESCE(started_at, created_at),
 			delivered_at = now()
-		WHERE event_id = $1::uuid
-		  AND subscriber_type = 'node'
-		  AND subscriber_id = $2
-		  AND status IN ('pending', 'in_progress', 'failed')
-		  AND COALESCE(retry_count, 0) < $6
+	WHERE event_id = $1::uuid
+	  AND subscriber_type = 'node'
+	  AND subscriber_id = $2
+	  AND COALESCE(delivery_target_route, '{}'::jsonb) = '{}'::jsonb
+	  AND status IN ('pending', 'in_progress', 'failed')
+	  AND COALESCE(retry_count, 0) < $6
 	`, eventID, nodeID, sanitizedSystemNodeRetryCount(retryCount), sanitizeSystemNodeReasonCode(reasonCode, "handler_error"), strings.TrimSpace(errText), retryLimit)
 	if err != nil {
 		return fmt.Errorf("mark system node delivery failed: %w", err)
@@ -1257,6 +1260,7 @@ func markPostgresSystemNodeDeliveryDeadLetterTx(ctx context.Context, tx *sql.Tx,
 		WHERE event_id = $1::uuid
 		  AND subscriber_type = 'node'
 		  AND subscriber_id = $2
+		  AND COALESCE(delivery_target_route, '{}'::jsonb) = '{}'::jsonb
 		  AND status IN ('pending', 'in_progress', 'failed')
 	`, eventID, nodeID, sanitizedSystemNodeRetryCount(retryCount), reasonCode, errText)
 	if err != nil {
@@ -1371,12 +1375,13 @@ func postgresSystemNodeDeliveryAuthorizedTx(ctx context.Context, tx *sql.Tx, nod
 		SELECT EXISTS (
 			SELECT 1
 			FROM event_deliveries
-			WHERE event_id = $1::uuid
-			  AND subscriber_type = 'node'
-				  AND subscriber_id = $2
-				  AND (
-					status IN ('pending', 'in_progress')
-					OR (status = 'failed' AND COALESCE(retry_count, 0) < $3)
+	WHERE event_id = $1::uuid
+	  AND subscriber_type = 'node'
+		  AND subscriber_id = $2
+		  AND COALESCE(delivery_target_route, '{}'::jsonb) = '{}'::jsonb
+		  AND (
+			status IN ('pending', 'in_progress')
+			OR (status = 'failed' AND COALESCE(retry_count, 0) < $3)
 				  )
 			)
 	`, strings.TrimSpace(eventID), strings.TrimSpace(nodeID), retryLimit).Scan(&ok)
@@ -1424,6 +1429,7 @@ func postgresSystemNodeDeliveryRowExistsTx(ctx context.Context, tx *sql.Tx, node
 			WHERE event_id = $1::uuid
 			  AND subscriber_type = 'node'
 			  AND subscriber_id = $2
+			  AND COALESCE(delivery_target_route, '{}'::jsonb) = '{}'::jsonb
 		)
 	`, strings.TrimSpace(eventID), strings.TrimSpace(nodeID)).Scan(&ok)
 	return ok, err

--- a/internal/runtime/pipeline/runtime_support.go
+++ b/internal/runtime/pipeline/runtime_support.go
@@ -39,24 +39,26 @@ func (noOpEngineDispatcher) DispatchPostCommit(context.Context, []runtimeengine.
 }
 
 type pipelineFlowScopeKey struct{}
-type suppressUntargetedWorkflowNodeInterceptionKey struct{}
+type workflowNodeDeliveryRouteKey struct{}
 
-// WithSuppressedUntargetedWorkflowNodeInterception tells PipelineCoordinator that
-// EventBus has authoritative target-specific node delivery routes for this
-// publish, so the untargeted workflow-node interceptor pass is not authoritative.
-func WithSuppressedUntargetedWorkflowNodeInterception(ctx context.Context) context.Context {
+func withWorkflowNodeDeliveryRoute(ctx context.Context, route events.DeliveryRoute) context.Context {
 	if ctx == nil {
 		return nil
 	}
-	return context.WithValue(ctx, suppressUntargetedWorkflowNodeInterceptionKey{}, true)
+	route = route.Normalized()
+	return context.WithValue(ctx, workflowNodeDeliveryRouteKey{}, route)
 }
 
-func suppressUntargetedWorkflowNodeInterception(ctx context.Context) bool {
+func workflowNodeDeliveryRoute(ctx context.Context) (events.DeliveryRoute, bool) {
 	if ctx == nil {
-		return false
+		return events.DeliveryRoute{}, false
 	}
-	v, _ := ctx.Value(suppressUntargetedWorkflowNodeInterceptionKey{}).(bool)
-	return v
+	route, ok := ctx.Value(workflowNodeDeliveryRouteKey{}).(events.DeliveryRoute)
+	if !ok {
+		return events.DeliveryRoute{}, false
+	}
+	route = route.Normalized()
+	return route, route.SubscriberType == "node" && route.SubscriberID != ""
 }
 
 func withPipelineFlowScope(ctx context.Context, flowID string) context.Context {

--- a/internal/runtime/pipeline/runtime_support.go
+++ b/internal/runtime/pipeline/runtime_support.go
@@ -39,6 +39,25 @@ func (noOpEngineDispatcher) DispatchPostCommit(context.Context, []runtimeengine.
 }
 
 type pipelineFlowScopeKey struct{}
+type suppressUntargetedWorkflowNodeInterceptionKey struct{}
+
+// WithSuppressedUntargetedWorkflowNodeInterception tells PipelineCoordinator that
+// EventBus has authoritative target-specific node delivery routes for this
+// publish, so the untargeted workflow-node interceptor pass is not authoritative.
+func WithSuppressedUntargetedWorkflowNodeInterception(ctx context.Context) context.Context {
+	if ctx == nil {
+		return nil
+	}
+	return context.WithValue(ctx, suppressUntargetedWorkflowNodeInterceptionKey{}, true)
+}
+
+func suppressUntargetedWorkflowNodeInterception(ctx context.Context) bool {
+	if ctx == nil {
+		return false
+	}
+	v, _ := ctx.Value(suppressUntargetedWorkflowNodeInterceptionKey{}).(bool)
+	return v
+}
 
 func withPipelineFlowScope(ctx context.Context, flowID string) context.Context {
 	if ctx == nil {

--- a/internal/runtime/pipeline/system_node_receipt_store.go
+++ b/internal/runtime/pipeline/system_node_receipt_store.go
@@ -36,6 +36,7 @@ func (s *WorkflowInstanceStore) SystemNodeDeliveryAuthorized(ctx context.Context
 				WHERE event_id = ?
 				  AND subscriber_type = 'node'
 					  AND subscriber_id = ?
+					  AND COALESCE(delivery_target_route, '{}') = '{}'
 					  AND (
 						status IN ('pending', 'in_progress')
 						OR (status = 'failed' AND COALESCE(retry_count, 0) < ?)
@@ -52,6 +53,7 @@ func (s *WorkflowInstanceStore) SystemNodeDeliveryAuthorized(ctx context.Context
 			WHERE event_id = $1::uuid
 			  AND subscriber_type = 'node'
 				  AND subscriber_id = $2
+				  AND COALESCE(delivery_target_route, '{}'::jsonb) = '{}'::jsonb
 				  AND (
 					status IN ('pending', 'in_progress')
 					OR (status = 'failed' AND COALESCE(retry_count, 0) < $3)
@@ -381,12 +383,13 @@ func (s *WorkflowInstanceStore) markSQLiteSystemNodeProcessedAndSettleDelivery(c
 			    active_session_id = NULL,
 			    started_at = COALESCE(started_at, created_at),
 			    delivered_at = ?
-			WHERE event_id = ?
-			  AND subscriber_type = 'node'
-				  AND subscriber_id = ?
-				  AND (
-					status IN ('pending', 'in_progress')
-					OR (status = 'failed' AND COALESCE(retry_count, 0) < ?)
+				WHERE event_id = ?
+				  AND subscriber_type = 'node'
+					  AND subscriber_id = ?
+					  AND COALESCE(delivery_target_route, '{}') = '{}'
+					  AND (
+						status IN ('pending', 'in_progress')
+						OR (status = 'failed' AND COALESCE(retry_count, 0) < ?)
 				  )
 			`, now, eventID, nodeID, retryLimit)
 		if err != nil {
@@ -485,12 +488,13 @@ func (s *WorkflowInstanceStore) markSQLiteSystemNodeDeliveryInProgress(ctx conte
 			    active_session_id = NULL,
 			    started_at = COALESCE(started_at, ?),
 			    delivered_at = NULL
-			WHERE event_id = ?
-			  AND subscriber_type = 'node'
-			  AND subscriber_id = ?
-			  AND (
-				status IN ('pending', 'in_progress')
-				OR (status = 'failed' AND COALESCE(retry_count, 0) < ?)
+				WHERE event_id = ?
+				  AND subscriber_type = 'node'
+				  AND subscriber_id = ?
+				  AND COALESCE(delivery_target_route, '{}') = '{}'
+				  AND (
+					status IN ('pending', 'in_progress')
+					OR (status = 'failed' AND COALESCE(retry_count, 0) < ?)
 			  )
 		`, now, eventID, nodeID, retryLimit)
 		if err != nil {
@@ -563,11 +567,12 @@ func (s *WorkflowInstanceStore) markSQLiteSystemNodeDeliveryFailed(ctx context.C
 			    active_session_id = NULL,
 			    started_at = COALESCE(started_at, created_at),
 			    delivered_at = ?
-			WHERE event_id = ?
-			  AND subscriber_type = 'node'
-			  AND subscriber_id = ?
-			  AND status IN ('pending', 'in_progress', 'failed')
-			  AND COALESCE(retry_count, 0) < ?
+				WHERE event_id = ?
+				  AND subscriber_type = 'node'
+				  AND subscriber_id = ?
+				  AND COALESCE(delivery_target_route, '{}') = '{}'
+				  AND status IN ('pending', 'in_progress', 'failed')
+				  AND COALESCE(retry_count, 0) < ?
 		`, sanitizedSystemNodeRetryCount(retryCount), sanitizeSystemNodeReasonCode(reasonCode, "handler_error"), strings.TrimSpace(errText), now, eventID, nodeID, retryLimit)
 		if err != nil {
 			return fmt.Errorf("mark sqlite system node delivery failed: %w", err)
@@ -639,10 +644,11 @@ func (s *WorkflowInstanceStore) markSQLiteSystemNodeDeliveryDeadLetter(ctx conte
 			    active_session_id = NULL,
 			    started_at = COALESCE(started_at, created_at),
 			    delivered_at = ?
-			WHERE event_id = ?
-			  AND subscriber_type = 'node'
-			  AND subscriber_id = ?
-			  AND status IN ('pending', 'in_progress', 'failed')
+				WHERE event_id = ?
+				  AND subscriber_type = 'node'
+				  AND subscriber_id = ?
+				  AND COALESCE(delivery_target_route, '{}') = '{}'
+				  AND status IN ('pending', 'in_progress', 'failed')
 		`, sanitizedSystemNodeRetryCount(retryCount), reasonCode, errText, now, eventID, nodeID)
 		if err != nil {
 			return fmt.Errorf("dead-letter sqlite system node delivery: %w", err)
@@ -760,6 +766,7 @@ func sqliteSystemNodeDeliveryAuthorizedTx(ctx context.Context, tx *sql.Tx, nodeI
 			WHERE event_id = ?
 			  AND subscriber_type = 'node'
 			  AND subscriber_id = ?
+			  AND COALESCE(delivery_target_route, '{}') = '{}'
 			  AND (
 				status IN ('pending', 'in_progress')
 				OR (status = 'failed' AND COALESCE(retry_count, 0) < ?)
@@ -810,6 +817,7 @@ func sqliteSystemNodeDeliveryRowExistsTx(ctx context.Context, tx *sql.Tx, nodeID
 			WHERE event_id = ?
 			  AND subscriber_type = 'node'
 			  AND subscriber_id = ?
+			  AND COALESCE(delivery_target_route, '{}') = '{}'
 		)
 	`, strings.TrimSpace(eventID), strings.TrimSpace(nodeID)).Scan(&ok)
 	return ok, err

--- a/internal/runtime/pipeline/workflow_node_delivery_authority_test.go
+++ b/internal/runtime/pipeline/workflow_node_delivery_authority_test.go
@@ -3,6 +3,7 @@ package pipeline
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"testing"
 	"time"
 
@@ -39,6 +40,48 @@ func TestPipelineCoordinatorInterceptSkipsNodeWithoutPersistedDeliveryAuthority(
 	if len(logs) != 1 || logs[0].Action != "delivery_authority_missing" {
 		t.Fatalf("runtime logs = %#v, want one delivery_authority_missing entry", logs)
 	}
+}
+
+func TestPipelineCoordinatorInterceptSuppressesUntargetedAuthorityWhenTargetRouteOwnsExecution(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	ctx := context.Background()
+	pc, bus := newDeliveryAuthorityCoordinator(t, db)
+	runCtx := testPipelineCoordinatorRunContext(t, pc)
+	evt := seedDeliveryAuthorityEvent(t, db, runCtx)
+	seedDeliveryAuthorityWorkflowInstance(t, pc, runCtx, evt.EntityID())
+
+	genericPostCommit := make([]func(), 0, 1)
+	genericCtx := WithPipelinePostCommitActions(WithSuppressedUntargetedWorkflowNodeInterception(ctx), &genericPostCommit)
+	passthrough, _, err := pc.Intercept(genericCtx, evt)
+	if err != nil {
+		t.Fatalf("generic Intercept: %v", err)
+	}
+	if !passthrough {
+		t.Fatal("generic Intercept passthrough = false, want true when target route owns execution")
+	}
+	if deliveryAuthorityLogCount(bus.runtimeLogEntries()) != 0 {
+		t.Fatalf("generic runtime logs = %#v, want no delivery_authority_missing when untargeted authority is suppressed", bus.runtimeLogEntries())
+	}
+	assertDeliveryAuthorityReceiptCount(t, db, evt.ID(), "node-a", 0)
+
+	target := events.RouteIdentity{
+		EntityID: evt.EntityID(),
+	}
+	seedDeliveryAuthorityNodeDeliveryForTarget(t, db, evt.ID(), "node-a", target)
+	targetEvt := eventtest.TargetRouted(evt, target)
+	targetPostCommit := make([]func(), 0, 1)
+	targetCtx := WithPipelinePostCommitActions(WithSuppressedUntargetedWorkflowNodeInterception(ctx), &targetPostCommit)
+	passthrough, _, err = pc.Intercept(targetCtx, targetEvt)
+	if err != nil {
+		t.Fatalf("target Intercept: %v", err)
+	}
+	if passthrough {
+		t.Fatal("target Intercept passthrough = true, want false for consumed target-routed node event")
+	}
+	if deliveryAuthorityLogCount(bus.runtimeLogEntries()) != 0 {
+		t.Fatalf("target runtime logs = %#v, want no false delivery_authority_missing log", bus.runtimeLogEntries())
+	}
+	assertDeliveryAuthorityReceiptCount(t, db, evt.ID(), "node-a", 1)
 }
 
 func TestPipelineCoordinatorInterceptReplayScopeMarkerDoesNotAuthorizeConcreteNode(t *testing.T) {
@@ -263,6 +306,20 @@ func seedDeliveryAuthorityNodeDelivery(t *testing.T, db *sql.DB, eventID, nodeID
 	seedDeliveryAuthorityNodeDeliveryStatus(t, db, eventID, nodeID, "pending", 0)
 }
 
+func seedDeliveryAuthorityNodeDeliveryForTarget(t *testing.T, db *sql.DB, eventID, nodeID string, target events.RouteIdentity) {
+	t.Helper()
+	raw, err := json.Marshal(target.Normalized())
+	if err != nil {
+		t.Fatalf("marshal delivery authority target: %v", err)
+	}
+	if _, err := db.ExecContext(context.Background(), `
+		INSERT INTO event_deliveries (run_id, event_id, subscriber_type, subscriber_id, delivery_target_route, status, retry_count, created_at)
+		VALUES ($1::uuid, $2::uuid, 'node', $3, $4::jsonb, 'pending', 0, now())
+	`, testPipelineRunID, eventID, nodeID, string(raw)); err != nil {
+		t.Fatalf("seed target delivery authority node delivery: %v", err)
+	}
+}
+
 func seedDeliveryAuthorityNodeDeliveryStatus(t *testing.T, db *sql.DB, eventID, nodeID, status string, retryCount int) {
 	t.Helper()
 	if _, err := db.ExecContext(context.Background(), `
@@ -305,4 +362,14 @@ func assertDeliveryAuthorityDeliveryCount(t *testing.T, db *sql.DB, eventID, nod
 	if got != want {
 		t.Fatalf("delivery authority node deliveries = %d, want %d", got, want)
 	}
+}
+
+func deliveryAuthorityLogCount(logs []RuntimeLogEntry) int {
+	count := 0
+	for _, log := range logs {
+		if log.Action == "delivery_authority_missing" {
+			count++
+		}
+	}
+	return count
 }

--- a/internal/runtime/pipeline/workflow_node_delivery_authority_test.go
+++ b/internal/runtime/pipeline/workflow_node_delivery_authority_test.go
@@ -42,7 +42,7 @@ func TestPipelineCoordinatorInterceptSkipsNodeWithoutPersistedDeliveryAuthority(
 	}
 }
 
-func TestPipelineCoordinatorInterceptSuppressesUntargetedAuthorityWhenTargetRouteOwnsExecution(t *testing.T) {
+func TestPipelineCoordinatorInterceptDeliveryRouteConsumesTargetWithoutGenericAuthorityLog(t *testing.T) {
 	_, db, _ := testutil.StartPostgres(t)
 	ctx := context.Background()
 	pc, bus := newDeliveryAuthorityCoordinator(t, db)
@@ -50,38 +50,29 @@ func TestPipelineCoordinatorInterceptSuppressesUntargetedAuthorityWhenTargetRout
 	evt := seedDeliveryAuthorityEvent(t, db, runCtx)
 	seedDeliveryAuthorityWorkflowInstance(t, pc, runCtx, evt.EntityID())
 
-	genericPostCommit := make([]func(), 0, 1)
-	genericCtx := WithPipelinePostCommitActions(WithSuppressedUntargetedWorkflowNodeInterception(ctx), &genericPostCommit)
-	passthrough, _, err := pc.Intercept(genericCtx, evt)
-	if err != nil {
-		t.Fatalf("generic Intercept: %v", err)
-	}
-	if !passthrough {
-		t.Fatal("generic Intercept passthrough = false, want true when target route owns execution")
-	}
-	if deliveryAuthorityLogCount(bus.runtimeLogEntries()) != 0 {
-		t.Fatalf("generic runtime logs = %#v, want no delivery_authority_missing when untargeted authority is suppressed", bus.runtimeLogEntries())
-	}
-	assertDeliveryAuthorityReceiptCount(t, db, evt.ID(), "node-a", 0)
-
 	target := events.RouteIdentity{
 		EntityID: evt.EntityID(),
 	}
-	seedDeliveryAuthorityNodeDeliveryForTarget(t, db, evt.ID(), "node-a", target)
+	route := events.DeliveryRoute{
+		SubscriberType: "node",
+		SubscriberID:   "node-a",
+		Target:         target,
+	}
+	seedDeliveryAuthorityNodeDeliveryForTarget(t, db, evt.ID(), route.SubscriberID, target)
 	targetEvt := eventtest.TargetRouted(evt, target)
 	targetPostCommit := make([]func(), 0, 1)
-	targetCtx := WithPipelinePostCommitActions(WithSuppressedUntargetedWorkflowNodeInterception(ctx), &targetPostCommit)
-	passthrough, _, err = pc.Intercept(targetCtx, targetEvt)
+	targetCtx := WithPipelinePostCommitActions(ctx, &targetPostCommit)
+	passthrough, _, err := pc.InterceptDeliveryRoute(targetCtx, targetEvt, route)
 	if err != nil {
-		t.Fatalf("target Intercept: %v", err)
+		t.Fatalf("target InterceptDeliveryRoute: %v", err)
 	}
 	if passthrough {
-		t.Fatal("target Intercept passthrough = true, want false for consumed target-routed node event")
+		t.Fatal("target InterceptDeliveryRoute passthrough = true, want false for consumed target-routed node event")
 	}
 	if deliveryAuthorityLogCount(bus.runtimeLogEntries()) != 0 {
 		t.Fatalf("target runtime logs = %#v, want no false delivery_authority_missing log", bus.runtimeLogEntries())
 	}
-	assertDeliveryAuthorityReceiptCount(t, db, evt.ID(), "node-a", 1)
+	assertDeliveryAuthorityReceiptCount(t, db, evt.ID(), route.SubscriberID, 1)
 }
 
 func TestPipelineCoordinatorInterceptReplayScopeMarkerDoesNotAuthorizeConcreteNode(t *testing.T) {

--- a/internal/runtime/pipeline/workflow_nodes.go
+++ b/internal/runtime/pipeline/workflow_nodes.go
@@ -1168,7 +1168,7 @@ func (pc *PipelineCoordinator) workflowNodeMatchesDeliveryTarget(nodeID string, 
 	if workflowFlowMode(source, flowID) == runtimecontracts.FlowModeSingleton {
 		return targetPath == flowPath || targetPath == flowID
 	}
-	return targetPath == flowPath || strings.HasPrefix(targetPath, flowPath+"/")
+	return workflowNodeDeliveryTargetPathMatches(flowPath, targetPath)
 }
 
 func workflowNodeDeliveryTargetFlowInstanceMatches(source semanticview.Source, flowID, flowInstance string) bool {
@@ -1184,6 +1184,26 @@ func workflowNodeDeliveryTargetFlowInstanceMatches(source semanticview.Source, f
 		return flowInstance == flowPath || flowInstance == strings.Trim(strings.TrimSpace(flowID), "/")
 	}
 	return true
+}
+
+func workflowNodeDeliveryTargetPathMatches(flowPath, targetPath string) bool {
+	flowPath = strings.Trim(strings.TrimSpace(flowPath), "/")
+	targetPath = strings.Trim(strings.TrimSpace(targetPath), "/")
+	if flowPath == "" || targetPath == "" {
+		return false
+	}
+	if targetPath == flowPath || strings.HasPrefix(targetPath, flowPath+"/") {
+		return true
+	}
+	head, _, ok := strings.Cut(flowPath, "/")
+	if !ok || head == "" {
+		return false
+	}
+	collapsed, ok := strings.CutPrefix(targetPath, head+"/")
+	if !ok {
+		return false
+	}
+	return collapsed == flowPath || strings.HasPrefix(collapsed, flowPath+"/")
 }
 
 func workflowFlowMode(source semanticview.Source, flowID string) string {

--- a/internal/runtime/pipeline/workflow_nodes.go
+++ b/internal/runtime/pipeline/workflow_nodes.go
@@ -829,8 +829,11 @@ func (pc *PipelineCoordinator) workflowNodeExecutors() []workflowNodeExecutor {
 	return out
 }
 
-func (pc *PipelineCoordinator) workflowNodeInterceptPolicy(eventType string, evt events.Event) (bool, bool) {
+func (pc *PipelineCoordinator) workflowNodeInterceptPolicy(ctx context.Context, eventType string, evt events.Event) (bool, bool) {
 	eventType = strings.TrimSpace(eventType)
+	if suppressUntargetedWorkflowNodeInterception(ctx) && evt.TargetRoute().Empty() {
+		return false, false
+	}
 	source := pc.SemanticSource()
 	for _, node := range pc.WorkflowNodes() {
 		if !pc.workflowNodeMatchesDeliveryTarget(strings.TrimSpace(node.ID), evt.TargetRoute()) {

--- a/internal/runtime/pipeline/workflow_nodes.go
+++ b/internal/runtime/pipeline/workflow_nodes.go
@@ -831,12 +831,9 @@ func (pc *PipelineCoordinator) workflowNodeExecutors() []workflowNodeExecutor {
 
 func (pc *PipelineCoordinator) workflowNodeInterceptPolicy(ctx context.Context, eventType string, evt events.Event) (bool, bool) {
 	eventType = strings.TrimSpace(eventType)
-	if suppressUntargetedWorkflowNodeInterception(ctx) && evt.TargetRoute().Empty() {
-		return false, false
-	}
 	source := pc.SemanticSource()
 	for _, node := range pc.WorkflowNodes() {
-		if !pc.workflowNodeMatchesDeliveryTarget(strings.TrimSpace(node.ID), evt.TargetRoute()) {
+		if !pc.workflowNodeDeliveryRouteMatches(ctx, strings.TrimSpace(node.ID), evt.TargetRoute()) {
 			continue
 		}
 		var (
@@ -874,7 +871,7 @@ func (pc *PipelineCoordinator) dispatchWorkflowNodeEventResult(ctx context.Conte
 	handledAny := false
 	for _, node := range pc.WorkflowNodes() {
 		nodeID := strings.TrimSpace(node.ID)
-		if !pc.workflowNodeMatchesDeliveryTarget(nodeID, evt.TargetRoute()) {
+		if !pc.workflowNodeDeliveryRouteMatches(ctx, nodeID, evt.TargetRoute()) {
 			continue
 		}
 		handled, err := pc.executeNodeHandlerPlanResult(ctx, nodeID, evt)
@@ -887,6 +884,17 @@ func (pc *PipelineCoordinator) dispatchWorkflowNodeEventResult(ctx context.Conte
 		}
 	}
 	return handledAny, nil
+}
+
+func (pc *PipelineCoordinator) workflowNodeDeliveryRouteMatches(ctx context.Context, nodeID string, eventTarget events.RouteIdentity) bool {
+	nodeID = strings.TrimSpace(nodeID)
+	if route, ok := workflowNodeDeliveryRoute(ctx); ok {
+		if strings.TrimSpace(route.SubscriberID) != nodeID {
+			return false
+		}
+		return pc.workflowNodeMatchesDeliveryTarget(nodeID, route.Target)
+	}
+	return pc.workflowNodeMatchesDeliveryTarget(nodeID, eventTarget)
 }
 
 func (pc *PipelineCoordinator) markWorkflowNodeProcessed(ctx context.Context, nodeID string, evt events.Event) {

--- a/internal/runtime/pipeline/workflow_timer_lifecycle_test.go
+++ b/internal/runtime/pipeline/workflow_timer_lifecycle_test.go
@@ -302,7 +302,7 @@ func TestPipelineIntercept_EventTimerStartOnRegistersSchedule(t *testing.T) {
 
 	seedPipelineNodeDeliveryAuthority(t, db, evt, "test-node")
 
-	_, handled := pc.interceptPolicy("timer.scheduled", evt)
+	_, handled := pc.interceptPolicy(context.Background(), "timer.scheduled", evt)
 	if !handled {
 		t.Fatal("expected timer.scheduled to be interceptable")
 	}
@@ -1127,7 +1127,7 @@ func TestPipelineCoordinatorIntercept_NestedDescendantCompletionAlreadyTargetedT
 	}); err != nil {
 		t.Fatalf("seed child instance: %v", err)
 	}
-	if consume, handled := pc.workflowNodeInterceptPolicy("child/grandchild/micro.done", eventtest.RootIngress(
+	if consume, handled := pc.workflowNodeInterceptPolicy(context.Background(), "child/grandchild/micro.done", eventtest.RootIngress(
 		"",
 		events.EventType("child/grandchild/micro.done"),
 		"",

--- a/internal/runtime/testfixtures/finalflowinstanceauthoring/fixture.go
+++ b/internal/runtime/testfixtures/finalflowinstanceauthoring/fixture.go
@@ -1,0 +1,611 @@
+package finalflowinstanceauthoring
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
+	"github.com/division-sh/swarm/internal/runtime/semanticview"
+)
+
+const (
+	PackageName = "final-flow-instance-authoring"
+
+	ProducerFlowID    = "intake"
+	ProducerNodeID    = "intake-router"
+	ProducerInputPin  = "request_received"
+	ProducerOutputPin = "account_ready"
+	ProducerInput     = "request.received"
+	ProducerOutput    = "account.ready"
+
+	TemplateFlowID       = "account_case"
+	TemplateNodeID       = "account-case-worker"
+	TemplateEntityType   = "account_case_state"
+	TemplateInputPin     = "account_ready"
+	TemplateInstanceBy   = "account_id"
+	TemplatePayloadKey   = "source_account_id"
+	TemplateFlowInstance = TemplateFlowID
+
+	CoordinatorFlowID     = "coordinator"
+	CoordinatorNodeID     = "coordinator-indexer"
+	CoordinatorEntityType = "coordinator_state"
+	CoordinatorInput      = "lead.observed"
+	CoordinatorInstance   = CoordinatorFlowID
+
+	LegacyFlowID = "legacy_static"
+)
+
+// Options toggles final sealed authoring variants used by conformance,
+// EventBus, pipeline, and authoring-view tests. The positive fixture combines a
+// template flow-instance route and singleton/coordinator contained state in one
+// package; negative options only introduce declared fail-closed seams.
+type Options struct {
+	MissingOutputKey            bool
+	MissingOutputCarries        bool
+	BadConnectMapping           bool
+	DuplicateConnectMapping     bool
+	UnsupportedReceiverSelector bool
+	ProducerTarget              bool
+	ProducerBroadcast           bool
+
+	DynamicBracketTarget bool
+	MissingMapKey        bool
+	WrongMapValueShape   bool
+	UndeclaredMapTarget  bool
+	UnsupportedMapOp     bool
+	BadListIndex         bool
+
+	StaticCreateEntity        bool
+	StaticSelectEntity        bool
+	StaticSelectOrCreate      bool
+	StaticMissingAcquisition  bool
+	RootDefaultEntityIDSource bool
+}
+
+func LoadBundle(t testing.TB, opts Options) *runtimecontracts.WorkflowContractBundle {
+	t.Helper()
+	bundle, err := LoadBundleResult(t, opts)
+	if err != nil {
+		t.Fatalf("LoadWorkflowContractBundleWithOverrides: %v", err)
+	}
+	return bundle
+}
+
+func LoadBundleResult(t testing.TB, opts Options) (*runtimecontracts.WorkflowContractBundle, error) {
+	t.Helper()
+	root := Write(t, opts)
+	return runtimecontracts.LoadWorkflowContractBundleWithOverrides(repoRoot(t), root, runtimecontracts.DefaultPlatformSpecFile(repoRoot(t)))
+}
+
+func LoadSource(t testing.TB, opts Options) semanticview.Source {
+	t.Helper()
+	return semanticview.Wrap(LoadBundle(t, opts))
+}
+
+func Write(t testing.TB, opts Options) string {
+	t.Helper()
+	root := t.TempDir()
+	writeRoot(t, root, opts)
+	writeProducer(t, root, opts)
+	writeTemplate(t, root, opts)
+	writeCoordinator(t, root, opts)
+	if opts.StaticCreateEntity || opts.StaticSelectEntity || opts.StaticSelectOrCreate || opts.StaticMissingAcquisition {
+		writeLegacyStatic(t, root, opts)
+	}
+	return root
+}
+
+func writeRoot(t testing.TB, root string, opts Options) {
+	t.Helper()
+	legacyFlow := ""
+	if opts.StaticCreateEntity || opts.StaticSelectEntity || opts.StaticSelectOrCreate || opts.StaticMissingAcquisition {
+		legacyFlow = `  - id: legacy_static
+    flow: legacy_static
+    mode: static
+`
+	}
+	writeFile(t, filepath.Join(root, "package.yaml"), `
+name: final-flow-instance-authoring
+version: "1.0.0"
+platform_version: ">=1.6.0"
+flows:
+  - id: intake
+    flow: intake
+    mode: static
+  - id: account_case
+    flow: account_case
+    mode: template
+  - id: coordinator
+    flow: coordinator
+    mode: singleton
+`+legacyFlow+`connect:
+  - from: intake.account_ready
+    to: account_case.account_ready
+    delivery: one
+`+connectAdapterYAML(opts))
+	if opts.RootDefaultEntityIDSource {
+		writeRootDefaultStaticMaterializer(t, root)
+		return
+	}
+	writeFile(t, filepath.Join(root, "schema.yaml"), "name: final-flow-instance-authoring\n")
+	writeFile(t, filepath.Join(root, "policy.yaml"), "{}\n")
+	writeFile(t, filepath.Join(root, "tools.yaml"), "{}\n")
+	writeFile(t, filepath.Join(root, "agents.yaml"), "{}\n")
+	writeFile(t, filepath.Join(root, "events.yaml"), "{}\n")
+	writeFile(t, filepath.Join(root, "nodes.yaml"), "{}\n")
+}
+
+func connectAdapterYAML(opts Options) string {
+	switch {
+	case opts.BadConnectMapping:
+		return `    using:
+      instance:
+        source: missing_source_account_id
+        target: account_id
+`
+	case opts.DuplicateConnectMapping:
+		return `    using:
+      instance:
+        source: [source_account_id, source_account_id]
+        target: [account_id, account_id]
+`
+	default:
+		return `    using:
+      instance:
+        source: source_account_id
+        target: account_id
+`
+	}
+}
+
+func writeProducer(t testing.TB, root string, opts Options) {
+	t.Helper()
+	writeFile(t, filepath.Join(root, "flows", "intake", "schema.yaml"), `
+name: intake
+mode: static
+pins:
+  inputs:
+    events:
+      - name: request_received
+        event: request.received
+  outputs:
+    events:
+      - name: account_ready
+        event: account.ready
+`+producerOutputEvidenceYAML(opts))
+	writeFile(t, filepath.Join(root, "flows", "intake", "policy.yaml"), "{}\n")
+	writeFile(t, filepath.Join(root, "flows", "intake", "tools.yaml"), "{}\n")
+	writeFile(t, filepath.Join(root, "flows", "intake", "agents.yaml"), "{}\n")
+	writeFile(t, filepath.Join(root, "flows", "intake", "entities.yaml"), "{}\n")
+	writeFile(t, filepath.Join(root, "flows", "intake", "events.yaml"), `
+request.received:
+  account_id: string
+  score: string
+  decision: string
+account.ready:
+  source_account_id: string
+  score: string
+  decision: string
+`)
+	writeFile(t, filepath.Join(root, "flows", "intake", "nodes.yaml"), `
+intake-router:
+  id: intake-router
+  execution_type: system_node
+  subscribes_to: [request.received]
+  produces: [account.ready]
+  event_handlers:
+    request.received:
+      emit:
+        event: account.ready
+`+producerEmitRouteYAML(opts)+`        fields:
+          source_account_id: payload.account_id
+          score: payload.score
+          decision: payload.decision
+`)
+}
+
+func producerOutputEvidenceYAML(opts Options) string {
+	var b strings.Builder
+	if !opts.MissingOutputKey {
+		b.WriteString("        key: source_account_id\n")
+	}
+	if opts.MissingOutputCarries {
+		b.WriteString("        carries: [score, decision]\n")
+	} else {
+		b.WriteString("        carries: [source_account_id, score, decision]\n")
+	}
+	return b.String()
+}
+
+func producerEmitRouteYAML(opts Options) string {
+	if opts.ProducerTarget {
+		return `        target:
+          flow: account_case
+          match:
+            account_id: payload.account_id
+`
+	}
+	if opts.ProducerBroadcast {
+		return "        broadcast: true\n"
+	}
+	return ""
+}
+
+func writeTemplate(t testing.TB, root string, opts Options) {
+	t.Helper()
+	writeFile(t, filepath.Join(root, "flows", "account_case", "schema.yaml"), `
+name: account_case
+mode: template
+initial_state: pending
+states: [pending, reviewed]
+terminal_states: [reviewed]
+instance:
+  by: account_id
+  on_missing: create
+  on_conflict: reuse
+pins:
+  inputs:
+    events:
+      - name: account_ready
+        event: account.ready
+  outputs:
+    events: []
+`)
+	writeFile(t, filepath.Join(root, "flows", "account_case", "policy.yaml"), "{}\n")
+	writeFile(t, filepath.Join(root, "flows", "account_case", "tools.yaml"), "{}\n")
+	writeFile(t, filepath.Join(root, "flows", "account_case", "agents.yaml"), "{}\n")
+	writeFile(t, filepath.Join(root, "flows", "account_case", "events.yaml"), `
+account.ready:
+  source_account_id: string
+  score: string
+  decision: string
+`)
+	writeFile(t, filepath.Join(root, "flows", "account_case", "entities.yaml"), `
+account_case_state:
+  account_id:
+    type: string
+  score:
+    type: string
+  decision:
+    type: string
+`)
+	writeFile(t, filepath.Join(root, "flows", "account_case", "nodes.yaml"), `
+account-case-worker:
+  id: account-case-worker
+  execution_type: system_node
+  subscribes_to: [account.ready]
+  event_handlers:
+    account.ready:
+`+receiverSelectorYAML(opts)+`      data_accumulation:
+        writes:
+          - source_field: source_account_id
+            target_field: account_id
+          - source_field: score
+            target_field: score
+          - source_field: decision
+            target_field: decision
+      advances_to: reviewed
+`)
+}
+
+func receiverSelectorYAML(opts Options) string {
+	if !opts.UnsupportedReceiverSelector {
+		return ""
+	}
+	return `      select_entity:
+        by:
+          account_id: payload.source_account_id
+`
+}
+
+func writeCoordinator(t testing.TB, root string, opts Options) {
+	t.Helper()
+	writeFile(t, filepath.Join(root, "flows", "coordinator", "schema.yaml"), `
+name: coordinator
+mode: singleton
+initial_state: active
+states: [active]
+pins:
+  inputs:
+    events:
+      - name: lead_observed
+        event: lead.observed
+  outputs:
+    events: []
+`)
+	writeFile(t, filepath.Join(root, "flows", "coordinator", "policy.yaml"), "{}\n")
+	writeFile(t, filepath.Join(root, "flows", "coordinator", "tools.yaml"), "{}\n")
+	writeFile(t, filepath.Join(root, "flows", "coordinator", "agents.yaml"), "{}\n")
+	writeFile(t, filepath.Join(root, "flows", "coordinator", "types.yaml"), `
+types:
+  LeadScore:
+    status: text
+    score: integer
+    observations: "[Observation]"
+  Observation:
+    source: text
+    note: text
+  AuditEntry:
+    ref: text
+    action: text
+`)
+	writeFile(t, filepath.Join(root, "flows", "coordinator", "entities.yaml"), `
+coordinator_state:
+  coordinator_id: text
+  lead_index: map[text]LeadScore
+  audit_log: "[AuditEntry]"
+`)
+	writeFile(t, filepath.Join(root, "flows", "coordinator", "events.yaml"), `
+lead.observed:
+  coordinator_id: text
+  lead_id: text
+  observation: Observation
+  audit: AuditEntry
+  followup_audit: AuditEntry
+  corrected_audit: AuditEntry
+`)
+	writeFile(t, filepath.Join(root, "flows", "coordinator", "nodes.yaml"), `
+coordinator-indexer:
+  id: coordinator-indexer
+  execution_type: system_node
+  subscribes_to: [lead.observed]
+  event_handlers:
+    lead.observed:
+      select_entity:
+        by:
+          coordinator_id: payload.coordinator_id
+      data_accumulation:
+        writes:
+`+coordinatorWritesYAML(opts))
+}
+
+func coordinatorWritesYAML(opts Options) string {
+	if opts.DynamicBracketTarget {
+		return firstMapWriteYAML("set", "entity.lead_index[payload.lead_id]", "key:\n              ref: payload.lead_id", `
+            value:
+              status: active
+              score: 0
+              observations: []
+`)
+	}
+	if opts.MissingMapKey {
+		return firstMapWriteYAML("set", "entity.lead_index", "", `
+            value:
+              status: active
+              score: 0
+              observations: []
+`)
+	}
+	if opts.WrongMapValueShape {
+		return firstMapWriteYAML("set", "entity.lead_index", "key:\n              ref: payload.lead_id", `
+            value:
+              undeclared: true
+`)
+	}
+	if opts.UndeclaredMapTarget {
+		return firstMapWriteYAML("set", "entity.missing_index", "key:\n              ref: payload.lead_id", `
+            value:
+              status: active
+              score: 0
+              observations: []
+`)
+	}
+	if opts.UnsupportedMapOp {
+		return firstMapWriteYAML("replace", "entity.lead_index", "key:\n              ref: payload.lead_id", `
+            value:
+              status: active
+              score: 0
+              observations: []
+`)
+	}
+	if opts.BadListIndex {
+		return directCoordinatorWriteYAML() + validCoordinatorWritesPrefixYAML() + `          - op: update
+            target: entity.audit_log
+            index: -1
+            value:
+              ref: payload.corrected_audit
+`
+	}
+	return directCoordinatorWriteYAML() + validCoordinatorWritesPrefixYAML() + `          - op: update
+            target: entity.audit_log
+            index: 0
+            value:
+              ref: payload.corrected_audit
+`
+}
+
+func directCoordinatorWriteYAML() string {
+	return `          - source_field: coordinator_id
+            target_field: coordinator_id
+`
+}
+
+func validCoordinatorWritesPrefixYAML() string {
+	return `          - op: set
+            target: entity.lead_index
+            key:
+              ref: payload.lead_id
+            value:
+              status: active
+              score: 0
+              observations: []
+          - op: merge
+            target: entity.lead_index
+            key:
+              ref: payload.lead_id
+            value:
+              score: 1
+          - op: append
+            target: entity.lead_index.observations
+            key:
+              ref: payload.lead_id
+            value:
+              ref: payload.observation
+          - op: append
+            target: entity.audit_log
+            value:
+              ref: payload.audit
+          - op: append
+            target: entity.audit_log
+            value:
+              ref: payload.followup_audit
+`
+}
+
+func firstMapWriteYAML(op, target, keyBlock, valueBlock string) string {
+	out := directCoordinatorWriteYAML() + `          - op: ` + op + `
+            target: ` + target + `
+`
+	if strings.TrimSpace(keyBlock) != "" {
+		out += "            " + strings.ReplaceAll(strings.TrimRight(keyBlock, "\n"), "\n", "\n            ") + "\n"
+	}
+	out += strings.TrimLeft(valueBlock, "\n")
+	return out
+}
+
+func writeLegacyStatic(t testing.TB, root string, opts Options) {
+	t.Helper()
+	writeFile(t, filepath.Join(root, "flows", "legacy_static", "schema.yaml"), `
+name: legacy_static
+mode: static
+initial_state: active
+states: [active, archived]
+terminal_states: [archived]
+pins:
+  inputs:
+    events:
+      - name: legacy_seen
+        event: legacy.seen
+  outputs:
+    events: []
+`)
+	writeFile(t, filepath.Join(root, "flows", "legacy_static", "policy.yaml"), "{}\n")
+	writeFile(t, filepath.Join(root, "flows", "legacy_static", "tools.yaml"), "{}\n")
+	writeFile(t, filepath.Join(root, "flows", "legacy_static", "agents.yaml"), "{}\n")
+	writeFile(t, filepath.Join(root, "flows", "legacy_static", "events.yaml"), `
+legacy.seen:
+  legacy_id: string
+  amount: number
+`)
+	writeFile(t, filepath.Join(root, "flows", "legacy_static", "entities.yaml"), `
+legacy_record:
+  legacy_id:
+    type: string
+    indexed: true
+  amount:
+    type: number
+    initial: 0
+`)
+	writeFile(t, filepath.Join(root, "flows", "legacy_static", "nodes.yaml"), `
+legacy-writer:
+  id: legacy-writer
+  execution_type: system_node
+  subscribes_to: [legacy.seen]
+  event_handlers:
+    legacy.seen:
+`+legacyHandlerBody(opts))
+}
+
+func legacyHandlerBody(opts Options) string {
+	switch {
+	case opts.StaticCreateEntity:
+		return `      create_entity: true
+      data_accumulation:
+        writes:
+          - source_field: amount
+            target_field: amount
+`
+	case opts.StaticSelectEntity:
+		return `      select_entity:
+        by:
+          legacy_id: payload.legacy_id
+      data_accumulation:
+        writes:
+          - source_field: amount
+            target_field: amount
+`
+	case opts.StaticSelectOrCreate:
+		return `      select_or_create_entity:
+        by:
+          legacy_id: payload.legacy_id
+      data_accumulation:
+        writes:
+          - source_field: amount
+            target_field: amount
+`
+	case opts.StaticMissingAcquisition:
+		return `      data_accumulation:
+        writes:
+          - source_field: amount
+            target_field: amount
+`
+	default:
+		return `      emit:
+        event: legacy.seen
+        fields:
+          legacy_id: payload.legacy_id
+`
+	}
+}
+
+func writeRootDefaultStaticMaterializer(t testing.TB, root string) {
+	t.Helper()
+	writeFile(t, filepath.Join(root, "schema.yaml"), `
+name: final-flow-instance-authoring
+initial_state: active
+states: [active]
+pins:
+  inputs:
+    events:
+      - name: subject_created
+        event: subject.created
+  outputs:
+    events: []
+`)
+	writeFile(t, filepath.Join(root, "policy.yaml"), "{}\n")
+	writeFile(t, filepath.Join(root, "tools.yaml"), "{}\n")
+	writeFile(t, filepath.Join(root, "agents.yaml"), "{}\n")
+	writeFile(t, filepath.Join(root, "events.yaml"), `
+subject.created:
+  entity_id: string
+  display_name: string
+`)
+	writeFile(t, filepath.Join(root, "entities.yaml"), `
+subject:
+  display_name: text
+`)
+	writeFile(t, filepath.Join(root, "nodes.yaml"), `
+root-node:
+  id: root-node
+  execution_type: system_node
+  subscribes_to: [subject.created]
+  event_handlers:
+    subject.created:
+      data_accumulation:
+        writes:
+          - source_field: display_name
+            target_field: display_name
+`)
+}
+
+func repoRoot(t testing.TB) string {
+	t.Helper()
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("resolve repo root")
+	}
+	return filepath.Clean(filepath.Join(filepath.Dir(file), "..", "..", "..", ".."))
+}
+
+func writeFile(t testing.TB, path, contents string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, []byte(strings.TrimLeft(contents, "\n")), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}


### PR DESCRIPTION
## Summary

Closes #1555.

Adds the final sealed flow-instance authoring proof fixture for #1537 and closes the review-identified runtime proof gap. The fixture now proves the full template path: `account.ready` publishes through parent `connect`, creates the selected `account_case` template instance, dispatches `account-case-worker` through the persisted target route, and writes `account_id`, `score`, and `decision` onto that selected instance.

This update also fixes the runtime bug exposed by that proof: a generic untargeted node interpreter could consume a target-specific `event_deliveries.delivery_target_route` row. Target-routed node delivery now runs with a target-projected event, and generic node receipt/settlement paths only consume empty-target delivery rows.

## Governing Context

Exact governing spec refs:

- `platform-spec.yaml#flow_model.flow_instance_authoring`
- `platform-spec.yaml#flow_model.flow_instance_authoring.locked_principle`
- `platform-spec.yaml#flow_model.flow_instance_authoring.primary_entity_model`
- `platform-spec.yaml#flow_model.flow_instance_authoring.template_instance_model`
- `platform-spec.yaml#flow_model.flow_instance_authoring.composition_model`
- `platform-spec.yaml#flow_model.flow_instance_authoring.composition_model.connect_to_instance_route_planning`
- `platform-spec.yaml#flow_model.flow_instance_authoring.composition_model.connect_key_adapters`
- `platform-spec.yaml#flow_model.flow_instance_authoring.composition_model.output_pin_key_carries_contract`
- `platform-spec.yaml#flow_model.flow_instance_authoring.contained_state_model`
- `platform-spec.yaml#flow_model.flow_instance_authoring.singleton_coordinator_model`
- `platform-spec.yaml#flow_model.flow_instance_authoring.escape_hatches.static_multi_entity_flows`
- `platform-spec.yaml#flow_model.flow_instance_authoring.analyzer_obligations.expand_minimize_tooling`

No `platform-spec.yaml` update is included because the runtime changes implement the existing target-route authority model rather than adding a new platform contract.

## Semantic Migration Notes

- Canonical owners consumed: `event_deliveries.delivery_target_route`, EventBus `RoutePlan.DeliveryRoutes`, target-projected event envelopes, `WorkflowInstanceStore` node receipt/settlement APIs, and workflow-node target matching.
- Old producer/reader/writer path now invalid: generic untargeted node receipt authorization/settlement may no longer consume target-specific delivery rows.
- Production paths checked for surviving old behavior: async committed publish, transactional/acknowledged publish, deferred publish, workflow-runtime internal carrier delivery, Postgres and SQLite node receipt stores, and workflow-node target matching.
- Migration complete: yes for this chosen class. Target-routed node execution must now carry the persisted target identity; untargeted node execution remains valid only for empty-target delivery authority.

## Tests

- `go test ./internal/runtime -run TestFinalFlowInstanceAuthoringRuntime_PublishActivatesAndExecutesSelectedTemplateInstance -count=1 -v`
- `go test ./internal/runtime/conformance -run TestFinalFlowInstanceAuthoringFixture_FailClosedMatrix -count=1`
- `go test ./internal/runtime/bus ./internal/runtime/pipeline ./internal/runtime ./internal/runtime/conformance -count=1`
- `go test ./internal/events -count=1`
- `go test ./...`