### PR TITLE
[agent-f][issue #1529] Fail closed native tool admission

### DIFF
--- a/internal/runtime/agents/agent_llm.go
+++ b/internal/runtime/agents/agent_llm.go
@@ -137,7 +137,6 @@ func composeConversationTools(cfg models.AgentConfig, modelRuntime llm.Runtime, 
 		roleScopedToolSet = catalog.RoleScopedEntityToolNamesForActor(cfg)
 	}
 	tools = mergeTools(filterTools(tools, allowedToolSet, constrained, roleScopedToolSet), emitToolDefinitions(cfg, authority, emitRegistry))
-	tools = mergeTools(tools, nativeFallbackToolDefinitions(cfg, modelRuntime))
 	return tools
 }
 
@@ -618,74 +617,6 @@ func extractAllowedToolSet(cfg models.AgentConfig) (map[string]struct{}, bool) {
 		allowed[name] = struct{}{}
 	}
 	return allowed, found
-}
-
-func extractNativeToolConfig(cfg models.AgentConfig) map[string]bool {
-	if !cfg.NativeTools.Any() {
-		return nil
-	}
-	return map[string]bool{
-		"bash":       cfg.NativeTools.Bash,
-		"web_search": cfg.NativeTools.WebSearch,
-		"file_io":    cfg.NativeTools.FileIO,
-	}
-}
-
-func supportedNativeToolCapabilities(runtime llm.Runtime) llm.NativeToolCapabilities {
-	return llm.NativeToolCapabilitiesForRuntime(runtime)
-}
-
-func nativeFallbackToolDefinitions(cfg models.AgentConfig, modelRuntime llm.Runtime) []llm.ToolDefinition {
-	native := extractNativeToolConfig(cfg)
-	if len(native) == 0 {
-		return nil
-	}
-	supported := supportedNativeToolCapabilities(modelRuntime)
-	defs := make([]llm.ToolDefinition, 0, 4)
-	if native["bash"] && !supported.Bash {
-		defs = append(defs, llm.ToolDefinition{
-			Name:        "bash",
-			Description: "Execute a shell command locally in the agent workspace and return stdout, stderr, exit code, and duration.",
-			Usage:       runtimetools.NativeFallbackToolUsage("bash"),
-			Schema: runtimetools.ObjectSchema(map[string]any{
-				"command":         map[string]any{"type": "string"},
-				"timeout_seconds": map[string]any{"type": "integer", "minimum": 1, "maximum": 300},
-			}, "command"),
-		})
-	}
-	if native["web_search"] && !supported.WebSearch {
-		defs = append(defs, llm.ToolDefinition{
-			Name:        "web_search",
-			Description: "Search the web and return normalized results with title, url, and snippet.",
-			Usage:       runtimetools.NativeFallbackToolUsage("web_search"),
-			Schema: runtimetools.ObjectSchema(map[string]any{
-				"query":       map[string]any{"type": "string"},
-				"max_results": map[string]any{"type": "integer", "minimum": 1, "maximum": 20},
-			}, "query"),
-		})
-	}
-	if native["file_io"] && !supported.FileIO {
-		defs = append(defs,
-			llm.ToolDefinition{
-				Name:        "read_file",
-				Description: "Read a file from the agent workspace or mounted read-only data/contracts paths.",
-				Usage:       runtimetools.NativeFallbackToolUsage("read_file"),
-				Schema: runtimetools.ObjectSchema(map[string]any{
-					"path": map[string]any{"type": "string"},
-				}, "path"),
-			},
-			llm.ToolDefinition{
-				Name:        "write_file",
-				Description: "Write a file within the agent workspace.",
-				Usage:       runtimetools.NativeFallbackToolUsage("write_file"),
-				Schema: runtimetools.ObjectSchema(map[string]any{
-					"path":    map[string]any{"type": "string"},
-					"content": map[string]any{"type": "string"},
-				}, "path", "content"),
-			},
-		)
-	}
-	return defs
 }
 
 func extractEmitEvents(cfg models.AgentConfig) []string {

--- a/internal/runtime/agents/agent_llm_test.go
+++ b/internal/runtime/agents/agent_llm_test.go
@@ -1119,7 +1119,7 @@ func (s nativeCapabilityRuntimeStub) ProviderContract() llm.ProviderContract {
 	return contract
 }
 
-func TestNewLLMAgent_InjectsNativeFallbackToolsWhenProviderLacksSupport(t *testing.T) {
+func TestNewLLMAgent_DoesNotInjectNativeFallbackToolsWithoutExecutorAdmission(t *testing.T) {
 	agent := mustNewLLMAgent(t,
 		models.AgentConfig{
 			ID:   "researcher-1",
@@ -1138,24 +1138,11 @@ func TestNewLLMAgent_InjectsNativeFallbackToolsWhenProviderLacksSupport(t *testi
 	for _, tool := range agent.conversation.Tools {
 		names = append(names, tool.Name)
 	}
-	for _, want := range []string{"bash", "web_search", "read_file", "write_file"} {
-		if !containsString(names, want) {
-			t.Fatalf("expected native fallback tool %s in %v", want, names)
+	for _, forbidden := range []string{"bash", "web_search", "read_file", "write_file"} {
+		if containsString(names, forbidden) {
+			t.Fatalf("did not expect unproven native fallback tool %s in %v", forbidden, names)
 		}
 	}
-	for _, tool := range agent.conversation.Tools {
-		if tool.Name != "bash" {
-			continue
-		}
-		if !strings.Contains(tool.Usage, "trusted host bash is full host-user shell execution from the workspace backing directory") {
-			t.Fatalf("bash usage = %q, want trusted host path contract", tool.Usage)
-		}
-		if !strings.Contains(tool.Usage, "absolute paths follow the host deployment namespace and OS permissions") {
-			t.Fatalf("bash usage = %q, want host namespace caveat", tool.Usage)
-		}
-		return
-	}
-	t.Fatal("bash native fallback tool missing")
 }
 
 func TestNewLLMAgent_DoesNotInjectNativeFallbackToolsWhenProviderSupportsCapability(t *testing.T) {

--- a/internal/runtime/manager/agent_manager.go
+++ b/internal/runtime/manager/agent_manager.go
@@ -34,6 +34,7 @@ type AgentManager struct {
 	resetRuntimeOwnedState          func()
 	runtimeShutdownAdmissionClosed  func() bool
 	runtimeIngressSafetyPause       func(context.Context, string) error
+	nativeToolAdmissionValidator    func(context.Context, models.AgentConfig) error
 	runtimeMode                     string
 	llmBackend                      string
 	modelAliases                    llmselection.ModelAliases
@@ -123,6 +124,7 @@ func NewAgentManagerWithOptions(bus Bus, factory AgentFactory, opts AgentManager
 		resetRuntimeOwnedState:          opts.ResetRuntimeOwnedState,
 		runtimeShutdownAdmissionClosed:  opts.RuntimeShutdownAdmissionClosed,
 		runtimeIngressSafetyPause:       opts.RuntimeIngressSafetyPause,
+		nativeToolAdmissionValidator:    opts.NativeToolAdmissionValidator,
 		throttleSuppressPrefixes:        throttleSuppressPrefixes,
 		llmBackend:                      normalizeManagerLLMBackend(opts.LLMBackend),
 		modelAliases:                    llmselection.EffectiveModelAliases(opts.ModelAliases),
@@ -267,6 +269,9 @@ func (am *AgentManager) spawnAgentInternal(ctx context.Context, rec PersistedAge
 	if err := am.resolveAgentModel(&rec.Config); err != nil {
 		return err
 	}
+	if err := am.validateNativeToolAdmission(ctx, rec.Config); err != nil {
+		return err
+	}
 	if _, err := sessions.ValidateAgentSessionScopeConfig(rec.Config); err != nil {
 		return fmt.Errorf("invalid agent session scope: %w", err)
 	}
@@ -341,6 +346,19 @@ func (am *AgentManager) resolveAgentModel(cfg *models.AgentConfig) error {
 	return nil
 }
 
+func (am *AgentManager) validateNativeToolAdmission(ctx context.Context, cfg models.AgentConfig) error {
+	if am == nil || am.nativeToolAdmissionValidator == nil || !cfg.NativeTools.Any() {
+		return nil
+	}
+	if ctx == nil {
+		ctx = am.runtimeContext()
+	}
+	if err := am.nativeToolAdmissionValidator(ctx, cfg); err != nil {
+		return fmt.Errorf("native tool admission failed: %w", err)
+	}
+	return nil
+}
+
 func (am *AgentManager) buildAgent(cfg models.AgentConfig) (Agent, error) {
 	var err error
 	cfg, err = am.applyContractPrompt(cfg)
@@ -398,6 +416,12 @@ func (am *AgentManager) ReconfigureAgent(agentID string, cfg models.AgentConfig)
 	}
 	if updated.ID != agentID {
 		return fmt.Errorf("agent id mismatch: target=%s config.id=%s", agentID, updated.ID)
+	}
+	if err := am.resolveAgentModel(&updated); err != nil {
+		return err
+	}
+	if err := am.validateNativeToolAdmission(am.runtimeContext(), updated); err != nil {
+		return err
 	}
 	if _, err := sessions.ValidateAgentSessionScopeConfig(updated); err != nil {
 		return fmt.Errorf("invalid agent session scope: %w", err)

--- a/internal/runtime/manager/native_tool_admission_test.go
+++ b/internal/runtime/manager/native_tool_admission_test.go
@@ -1,0 +1,62 @@
+package manager
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	models "github.com/division-sh/swarm/internal/runtime/core/actors"
+)
+
+func TestAgentManagerSpawnAgentConsumesNativeToolAdmissionValidator(t *testing.T) {
+	t.Parallel()
+
+	am := NewAgentManagerWithOptions(nil, nil, AgentManagerOptions{
+		NativeToolAdmissionValidator: func(context.Context, models.AgentConfig) error {
+			return errors.New("native tool denied")
+		},
+	})
+
+	err := am.SpawnAgent(models.AgentConfig{
+		ID:          "worker-1",
+		Role:        "worker",
+		NativeTools: models.NativeToolConfig{FileIO: true},
+	})
+	if err == nil || !strings.Contains(err.Error(), "native tool admission failed: native tool denied") {
+		t.Fatalf("SpawnAgent error = %v, want native tool admission failure", err)
+	}
+	if _, ok := am.GetAgentConfig("worker-1"); ok {
+		t.Fatal("agent was registered despite native tool admission failure")
+	}
+}
+
+func TestAgentManagerReconfigureConsumesNativeToolAdmissionValidator(t *testing.T) {
+	t.Parallel()
+
+	am := NewAgentManagerWithOptions(nil, nil, AgentManagerOptions{
+		NativeToolAdmissionValidator: func(_ context.Context, cfg models.AgentConfig) error {
+			if cfg.NativeTools.Any() {
+				return errors.New("native tool denied")
+			}
+			return nil
+		},
+	})
+	if err := am.SpawnAgent(models.AgentConfig{ID: "worker-1", Role: "worker"}); err != nil {
+		t.Fatalf("SpawnAgent setup: %v", err)
+	}
+
+	err := am.ReconfigureAgent("worker-1", models.AgentConfig{
+		NativeTools: models.NativeToolConfig{FileIO: true},
+	})
+	if err == nil || !strings.Contains(err.Error(), "native tool admission failed: native tool denied") {
+		t.Fatalf("ReconfigureAgent error = %v, want native tool admission failure", err)
+	}
+	cfg, ok := am.GetAgentConfig("worker-1")
+	if !ok {
+		t.Fatal("setup agent missing after failed reconfigure")
+	}
+	if cfg.NativeTools.Any() {
+		t.Fatalf("agent native tools changed after denied reconfigure: %#v", cfg.NativeTools)
+	}
+}

--- a/internal/runtime/manager/types.go
+++ b/internal/runtime/manager/types.go
@@ -140,6 +140,7 @@ type AgentManagerOptions struct {
 	ResetRuntimeOwnedState         func()
 	RuntimeShutdownAdmissionClosed func() bool
 	RuntimeIngressSafetyPause      func(context.Context, string) error
+	NativeToolAdmissionValidator   func(context.Context, models.AgentConfig) error
 	ThrottleSuppressPrefixes       []string
 	DisableSpinupControl           bool
 	EnableLegacySpinupControl      bool

--- a/internal/runtime/runforkexecution/agent_runtime_materialization.go
+++ b/internal/runtime/runforkexecution/agent_runtime_materialization.go
@@ -249,6 +249,7 @@ func buildSelectedContractAgentRuntimeFactory(req publishSelectedContractForkEve
 	if credentials == nil {
 		credentials = runtimecredentials.NewEnvStore()
 	}
+	modelRuntime := options.LLMRuntime
 	var managerRef runtimetools.Manager
 	exec := runtimetools.NewExecutorWithOptions(bus, nil, runtimetools.ExecutorOptions{
 		Config:            options.Config,
@@ -259,6 +260,7 @@ func buildSelectedContractAgentRuntimeFactory(req publishSelectedContractForkEve
 		HumanTaskStore:    options.HumanTaskStore,
 		WorkflowSource:    source,
 		WorkspaceResolver: options.Workspace,
+		ModelRuntime:      modelRuntime,
 		AuthorityProvider: authority,
 		EmitRegistry:      emitRegistry,
 		ManagerProvider: func() runtimetools.Manager {
@@ -274,7 +276,6 @@ func buildSelectedContractAgentRuntimeFactory(req publishSelectedContractForkEve
 	if err != nil {
 		return selectedContractAgentRuntimeFactory{}, fmt.Errorf("start selected-fork tool gateway: %w", err)
 	}
-	modelRuntime := options.LLMRuntime
 	if modelRuntime == nil {
 		modelRuntime, err = runtimellm.RuntimeFactory{
 			Cfg:           options.Config,
@@ -293,6 +294,7 @@ func buildSelectedContractAgentRuntimeFactory(req publishSelectedContractForkEve
 			return selectedContractAgentRuntimeFactory{}, fmt.Errorf("build selected-fork agent runtime: %w", err)
 		}
 	}
+	exec.SetModelRuntime(modelRuntime)
 	factory := runtimeagents.NewLLMAgentFactory(modelRuntime, exec, exec.ToolDefinitions(), runtimeagents.LLMAgentOptions{
 		PromptResolver:    promptResolver,
 		AuthorityProvider: authority,

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -513,7 +513,7 @@ func NewRuntime(ctx context.Context, deps RuntimeDeps) (*Runtime, error) {
 		}
 	}
 	rt.LLM = modelRuntime
-	if warnings, err := runtimetools.ValidateNativeToolBootConfig(ctx, source, rt.Credentials, modelRuntime); err != nil {
+	if warnings, err := runtimetools.ValidateNativeToolBootConfig(ctx, source, rt.Credentials, modelRuntime, rt.Workspace); err != nil {
 		return nil, fmt.Errorf("native tool validation failed: %w", err)
 	} else {
 		if bootWarningsFatal() && len(warnings) > 0 {
@@ -538,6 +538,7 @@ func NewRuntime(ctx context.Context, deps RuntimeDeps) (*Runtime, error) {
 		WorkflowInstances: pipelineStore,
 		WorkflowSource:    source,
 		WorkspaceResolver: rt.Workspace,
+		ModelRuntime:      rt.LLM,
 		AuthorityProvider: rt.Authority,
 		EmitRegistry:      rt.EmitRegistry,
 		ManagerProvider: func() runtimetools.Manager {
@@ -599,6 +600,9 @@ func NewRuntime(ctx context.Context, deps RuntimeDeps) (*Runtime, error) {
 				ControlledBy: "runtime",
 			})
 			return err
+		},
+		NativeToolAdmissionValidator: func(ctx context.Context, cfg runtimeactors.AgentConfig) error {
+			return rt.ToolExecutor.ValidateNativeToolAdmission(ctx, cfg)
 		},
 		ThrottleSuppressPrefixes: runtimeThrottleSuppressPrefixes(source),
 		DisableSpinupControl:     true,

--- a/internal/runtime/tools/deps.go
+++ b/internal/runtime/tools/deps.go
@@ -8,6 +8,7 @@ import (
 	runtimeauthority "github.com/division-sh/swarm/internal/runtime/authority"
 	models "github.com/division-sh/swarm/internal/runtime/core/actors"
 	runtimecredentials "github.com/division-sh/swarm/internal/runtime/credentials"
+	llm "github.com/division-sh/swarm/internal/runtime/llm"
 	runtimemcp "github.com/division-sh/swarm/internal/runtime/mcp"
 	runtimepipeline "github.com/division-sh/swarm/internal/runtime/pipeline"
 	"github.com/division-sh/swarm/internal/runtime/semanticview"
@@ -54,6 +55,7 @@ type ExecutorOptions struct {
 	MCPClient         *runtimemcp.Client
 	WorkflowSource    semanticview.Source
 	WorkspaceResolver workspace.Resolver
+	ModelRuntime      llm.Runtime
 	AuthorityProvider runtimeauthority.Provider
 	EmitRegistry      *EmitRegistry
 	// Trusted runtime/test escape hatch for exercising retained legacy handlers.

--- a/internal/runtime/tools/executor.go
+++ b/internal/runtime/tools/executor.go
@@ -42,6 +42,7 @@ type Executor struct {
 	mcpClient                      *runtimemcp.Client
 	workflowSource                 semanticview.Source
 	workspaces                     workspace.Resolver
+	modelRuntime                   llm.Runtime
 	authority                      runtimeauthority.Provider
 	emitRegistry                   *EmitRegistry
 	authorizer                     *ToolAuthorizer
@@ -83,6 +84,7 @@ func NewExecutorWithOptions(bus EventPublisher, scheduler Scheduler, opts Execut
 		mcpClient:                      opts.MCPClient,
 		workflowSource:                 opts.WorkflowSource,
 		workspaces:                     opts.WorkspaceResolver,
+		modelRuntime:                   opts.ModelRuntime,
 		authority:                      runtimeauthority.ProviderOrNoop(opts.AuthorityProvider),
 		externalDispatchAdmission:      newExternalDispatchAdmissionController(),
 		allowInternalLegacyEntityTools: opts.AllowInternalLegacyEntityTools,
@@ -123,6 +125,16 @@ func NewExecutorWithOptions(bus EventPublisher, scheduler Scheduler, opts Execut
 		exec.buildToolHandlers(),
 	)
 	return exec
+}
+
+// SetModelRuntime updates the provider contract used by native-tool admission.
+func (e *Executor) SetModelRuntime(runtime llm.Runtime) {
+	if e == nil {
+		return
+	}
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.modelRuntime = runtime
 }
 
 func (e *Executor) contractDefinitions() ([]llm.ToolDefinition, error) {
@@ -171,7 +183,14 @@ func (e *Executor) resolveRegisteredTool(actor models.AgentConfig, name string) 
 		tool, ok := entries[name]
 		return tool, ok, nil
 	}
-	return resolveRegisteredToolForActor(source, actor, name, discovered)
+	tool, ok, err := resolveRegisteredToolForActor(source, actor, name, discovered)
+	if err != nil || !ok {
+		return tool, ok, err
+	}
+	if !e.nativeToolAdmittedForTool(context.Background(), actor, name) {
+		return RegisteredTool{}, false, nil
+	}
+	return tool, true, nil
 }
 
 func (e *Executor) ToolDefinitions() []llm.ToolDefinition {
@@ -206,6 +225,9 @@ func (e *Executor) ToolDefinitionsForActor(actor models.AgentConfig) []llm.ToolD
 	for _, name := range names {
 		entry := entries[name]
 		if !e.toolAuthorizationDecision(actor, name).allowed {
+			continue
+		}
+		if !e.nativeToolAdmittedForTool(context.Background(), actor, name) {
 			continue
 		}
 		filtered = append(filtered, llm.ToolDefinition{
@@ -271,6 +293,16 @@ func (e *Executor) ToolCapabilitiesForActor(actor models.AgentConfig, names []st
 		}
 		if !decision.allowed {
 			cap.DenialReason = "tool_not_allowed"
+		}
+		if decision.allowed && isNativeFallbackToolName(name) {
+			if admitted, reason := e.nativeToolAdmissionForTool(context.Background(), actor, name); !admitted {
+				cap.Visible = false
+				cap.Callable = false
+				if strings.TrimSpace(reason) == "" {
+					reason = "native_tool_admission_denied"
+				}
+				cap.DenialReason = reason
+			}
 		}
 		caps = append(caps, cap)
 	}
@@ -710,7 +742,7 @@ func (e *Executor) ExecConfigureRoutingDirect(actor models.AgentConfig, input an
 }
 
 func (e *Executor) ExecAgentHireDirect(actor models.AgentConfig, input any) (any, error) {
-	return e.execAgentHire(actor, input)
+	return e.execAgentHire(context.Background(), actor, input)
 }
 
 func (e *Executor) ExecAgentFireDirect(actor models.AgentConfig, input any) (any, error) {
@@ -718,7 +750,7 @@ func (e *Executor) ExecAgentFireDirect(actor models.AgentConfig, input any) (any
 }
 
 func (e *Executor) ExecAgentReconfigureDirect(actor models.AgentConfig, input any) (any, error) {
-	return e.execAgentReconfigure(actor, input)
+	return e.execAgentReconfigure(context.Background(), actor, input)
 }
 
 func (e *Executor) ExecMailboxSendDirect(actor models.AgentConfig, input any) (any, error) {

--- a/internal/runtime/tools/executor_agents.go
+++ b/internal/runtime/tools/executor_agents.go
@@ -229,7 +229,7 @@ func (e *Executor) execConfigureRouting(ctx context.Context, actor models.AgentC
 	return nil, errors.New("configure_routing is not yet implemented")
 }
 
-func (e *Executor) execAgentHire(actor models.AgentConfig, input any) (any, error) {
+func (e *Executor) execAgentHire(ctx context.Context, actor models.AgentConfig, input any) (any, error) {
 	manager := e.getManager()
 	if manager == nil {
 		return nil, errors.New("agent manager is not configured")
@@ -256,6 +256,9 @@ func (e *Executor) execAgentHire(actor models.AgentConfig, input any) (any, erro
 		return nil, err
 	}
 	if err := authorizeDelegableAgentConfig(actor, models.AgentConfig{}, in.Config, e.authority, e.emitRegistry); err != nil {
+		return nil, err
+	}
+	if err := e.ValidateNativeToolAdmission(ctx, in.Config); err != nil {
 		return nil, err
 	}
 	if err := manager.SpawnAgentForEntity(in.Config.EffectiveEntityID(), in.Config); err != nil {
@@ -297,7 +300,7 @@ func (e *Executor) execAgentFire(actor models.AgentConfig, input any) (any, erro
 	return map[string]any{"status": "fired", "agent_id": in.AgentID}, nil
 }
 
-func (e *Executor) execAgentReconfigure(actor models.AgentConfig, input any) (any, error) {
+func (e *Executor) execAgentReconfigure(ctx context.Context, actor models.AgentConfig, input any) (any, error) {
 	manager := e.getManager()
 	if manager == nil {
 		return nil, errors.New("agent manager is not configured")
@@ -322,6 +325,9 @@ func (e *Executor) execAgentReconfigure(actor models.AgentConfig, input any) (an
 	}
 	updatedCfg := mergeDelegablePrivilegeConfig(targetCfg, in.Config)
 	if err := authorizeDelegableAgentConfig(actor, targetCfg, updatedCfg, e.authority, e.emitRegistry); err != nil {
+		return nil, err
+	}
+	if err := e.ValidateNativeToolAdmission(ctx, updatedCfg); err != nil {
 		return nil, err
 	}
 	if err := manager.ReconfigureAgent(in.AgentID, in.Config); err != nil {

--- a/internal/runtime/tools/executor_agents_test.go
+++ b/internal/runtime/tools/executor_agents_test.go
@@ -11,6 +11,7 @@ import (
 	models "github.com/division-sh/swarm/internal/runtime/core/actors"
 	"github.com/division-sh/swarm/internal/runtime/semanticview"
 	runtimesessions "github.com/division-sh/swarm/internal/runtime/sessions"
+	workspace "github.com/division-sh/swarm/internal/runtime/workspace"
 )
 
 type managerStub struct {
@@ -324,6 +325,10 @@ func TestExecAgentHire_AllowsDelegablePrivileges(t *testing.T) {
 		Manager:           manager,
 		AuthorityProvider: runtimeauthority.NewSourceProvider(source),
 		WorkflowSource:    source,
+		ModelRuntime:      nativeCapabilityRuntimeStub{},
+		WorkspaceResolver: relayWorkspaceResolverStub{
+			target: &workspace.Target{Backend: workspace.BackendHost, Workdir: t.TempDir()},
+		},
 	})
 
 	_, err := exec.ExecAgentHireDirect(models.AgentConfig{
@@ -369,6 +374,48 @@ func TestExecAgentHire_AllowsDelegablePrivileges(t *testing.T) {
 	}
 	if len(manager.spawnedConfig.EmitEvents) != 1 || manager.spawnedConfig.EmitEvents[0] != "review.started" {
 		t.Fatalf("spawned emit events = %#v, want [review.started]", manager.spawnedConfig.EmitEvents)
+	}
+}
+
+func TestExecAgentHire_FailsClosedWhenNativeToolFallbackIsNotAdmitted(t *testing.T) {
+	t.Parallel()
+
+	source := semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
+		Agents: map[string]runtimecontracts.AgentRegistryEntry{
+			"manager": {ID: "manager", Role: "manager"},
+			"worker":  {ID: "worker", Role: "worker", ManagerFallback: "manager"},
+		},
+	})
+	manager := &captureManagerStub{}
+	exec := NewExecutorWithOptions(nil, nil, ExecutorOptions{
+		Manager:           manager,
+		AuthorityProvider: runtimeauthority.NewSourceProvider(source),
+		WorkflowSource:    source,
+	})
+
+	_, err := exec.ExecAgentHireDirect(models.AgentConfig{
+		ID:          "manager-1",
+		Role:        "manager",
+		Permissions: []string{"agent_hire"},
+		NativeTools: models.NativeToolConfig{FileIO: true},
+		FlowPath:    "review/inst-1",
+	}, map[string]any{
+		"config": map[string]any{
+			"id":               "worker-1",
+			"role":             "worker",
+			"mode":             "task",
+			"manager_fallback": "manager",
+			"flow_path":        "review/inst-1",
+			"native_tools": map[string]any{
+				"file_io": true,
+			},
+		},
+	})
+	if err == nil || !strings.Contains(err.Error(), "native_tools.file_io") {
+		t.Fatalf("ExecAgentHireDirect error = %v, want native_tools.file_io admission failure", err)
+	}
+	if manager.spawnCalled {
+		t.Fatal("expected native tool admission failure before spawning")
 	}
 }
 
@@ -558,6 +605,53 @@ func TestExecAgentReconfigure_DeniesNativeToolEscalation(t *testing.T) {
 	}
 	if manager.reconfigureCalled {
 		t.Fatal("expected denied reconfigure to fail closed before persistence")
+	}
+}
+
+func TestExecAgentReconfigure_FailsClosedWhenNativeToolFallbackIsNotAdmitted(t *testing.T) {
+	t.Parallel()
+
+	source := semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
+		Agents: map[string]runtimecontracts.AgentRegistryEntry{
+			"manager": {ID: "manager", Role: "manager"},
+			"worker":  {ID: "worker", Role: "worker", ManagerFallback: "manager"},
+		},
+	})
+	manager := &captureManagerStub{
+		agents: map[string]models.AgentConfig{
+			"worker-1": {
+				ID:              "worker-1",
+				Role:            "worker",
+				ManagerFallback: "manager",
+				FlowPath:        "review/inst-1",
+			},
+		},
+	}
+	exec := NewExecutorWithOptions(nil, nil, ExecutorOptions{
+		Manager:           manager,
+		AuthorityProvider: runtimeauthority.NewSourceProvider(source),
+		WorkflowSource:    source,
+	})
+
+	_, err := exec.ExecAgentReconfigureDirect(models.AgentConfig{
+		ID:          "manager-1",
+		Role:        "manager",
+		Permissions: []string{"agent_reconfigure"},
+		NativeTools: models.NativeToolConfig{FileIO: true},
+		FlowPath:    "review/inst-1",
+	}, map[string]any{
+		"agent_id": "worker-1",
+		"config": map[string]any{
+			"native_tools": map[string]any{
+				"file_io": true,
+			},
+		},
+	})
+	if err == nil || !strings.Contains(err.Error(), "native_tools.file_io") {
+		t.Fatalf("ExecAgentReconfigureDirect error = %v, want native_tools.file_io admission failure", err)
+	}
+	if manager.reconfigureCalled {
+		t.Fatal("expected native tool admission failure before reconfigure")
 	}
 }
 

--- a/internal/runtime/tools/executor_native_host_test.go
+++ b/internal/runtime/tools/executor_native_host_test.go
@@ -215,7 +215,10 @@ func TestExecutorHostFileToolsUseHostManagerSupportedSurfaceWithoutDocker(t *tes
 		t.Fatalf("write workspace input: %v", err)
 	}
 
-	exec := NewExecutorWithOptions(nil, nil, ExecutorOptions{WorkspaceResolver: manager})
+	exec := NewExecutorWithOptions(nil, nil, ExecutorOptions{
+		ModelRuntime:      nativeCapabilityRuntimeStub{},
+		WorkspaceResolver: manager,
+	})
 	exec.execWorkspaceFn = func(context.Context, workspace.ExecutionTarget, time.Duration, string, ...string) ([]byte, []byte, int, error) {
 		t.Fatalf("host file tools must use direct platform file operations, not workspace command execution")
 		return nil, nil, 0, nil
@@ -312,7 +315,10 @@ func TestExecutorHostNativeBashUsesExplicitHostManagerTarget(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ResolveWorkspace: %v", err)
 	}
-	exec := NewExecutorWithOptions(nil, nil, ExecutorOptions{WorkspaceResolver: manager})
+	exec := NewExecutorWithOptions(nil, nil, ExecutorOptions{
+		ModelRuntime:      nativeCapabilityRuntimeStub{},
+		WorkspaceResolver: manager,
+	})
 	actorCtx := models.WithActor(ctx, actor)
 
 	out, err := exec.Execute(actorCtx, "bash", map[string]any{
@@ -403,6 +409,7 @@ func TestNativeFileToolsKeepDockerWorkspaceCommandExecution(t *testing.T) {
 
 func TestNativeFallbackToolSurfaceConsumesWorkspaceExecutionTarget(t *testing.T) {
 	exec := &Executor{
+		modelRuntime: nativeCapabilityRuntimeStub{},
 		workspaces: relayWorkspaceResolverStub{
 			target: &workspace.Target{Backend: workspace.BackendHost, Workdir: t.TempDir()},
 		},
@@ -410,14 +417,13 @@ func TestNativeFallbackToolSurfaceConsumesWorkspaceExecutionTarget(t *testing.T)
 	actor := models.AgentConfig{
 		ID: "host-agent",
 		NativeTools: models.NativeToolConfig{
-			Bash:      true,
-			FileIO:    true,
-			WebSearch: true,
+			Bash:   true,
+			FileIO: true,
 		},
 	}
 
 	defs := exec.ToolDefinitionsForActorInContext(context.Background(), actor)
-	for _, allowed := range []string{"bash", "read_file", "write_file", "web_search"} {
+	for _, allowed := range []string{"bash", "read_file", "write_file"} {
 		if !containsToolDefinition(defs, allowed) {
 			t.Fatalf("context definitions missing %q: %#v", allowed, defs)
 		}
@@ -431,8 +437,63 @@ func TestNativeFallbackToolSurfaceConsumesWorkspaceExecutionTarget(t *testing.T)
 		}
 	}
 	web := caps.ByName["web_search"]
-	if !web.Visible || !web.Callable {
-		t.Fatalf("web_search capability = %#v, want visible/callable", web)
+	if web.Visible || web.Callable {
+		t.Fatalf("web_search capability = %#v, want hidden because native_tools.web_search is not enabled", web)
+	}
+}
+
+func TestNativeFallbackToolSurfaceRejectsStrictProviderNativeRuntime(t *testing.T) {
+	workspaceDir := t.TempDir()
+	exec := NewExecutorWithOptions(nil, nil, ExecutorOptions{
+		ModelRuntime: nativeCapabilityRuntimeStub{
+			caps: llm.NativeToolCapabilities{
+				Bash:      true,
+				FileIO:    true,
+				WebSearch: true,
+			},
+			strict: true,
+		},
+		WorkspaceResolver: relayWorkspaceResolverStub{
+			target: &workspace.Target{Backend: workspace.BackendHost, Workdir: workspaceDir},
+		},
+	})
+	actor := models.AgentConfig{
+		ID: "strict-provider-agent",
+		NativeTools: models.NativeToolConfig{
+			Bash:      true,
+			FileIO:    true,
+			WebSearch: true,
+		},
+	}
+
+	defs := exec.ToolDefinitionsForActorInContext(context.Background(), actor)
+	for _, denied := range []string{"bash", "read_file", "write_file", "web_search"} {
+		if containsToolDefinition(defs, denied) {
+			t.Fatalf("strict provider-native runtime exposed platform fallback definition %q: %#v", denied, defs)
+		}
+		if _, ok, err := exec.resolveRegisteredTool(actor, denied); err != nil || ok {
+			t.Fatalf("resolveRegisteredTool(%s) = ok:%v err:%v, want denied without error", denied, ok, err)
+		}
+	}
+
+	caps := exec.ToolCapabilitiesForActorInContext(context.Background(), actor, []string{"bash", "read_file", "write_file", "web_search"}, nil)
+	for _, denied := range []string{"bash", "read_file", "write_file", "web_search"} {
+		cap := caps.ByName[denied]
+		if cap.Visible || cap.Callable {
+			t.Fatalf("strict provider-native capability %s = %#v, want hidden/non-callable fallback surface", denied, cap)
+		}
+		if !strings.Contains(cap.DenialReason, nativeToolProviderOnlyFallbackDeny) {
+			t.Fatalf("strict provider-native capability %s denial = %q, want provider-native-only denial", denied, cap.DenialReason)
+		}
+	}
+
+	exec.execWorkspaceFn = func(context.Context, workspace.ExecutionTarget, time.Duration, string, ...string) ([]byte, []byte, int, error) {
+		t.Fatal("strict provider-native runtime must not execute platform fallback workspace tools")
+		return nil, nil, 0, nil
+	}
+	_, err := exec.Execute(models.WithActor(context.Background(), actor), "read_file", map[string]any{"path": "/workspace/missing.txt"})
+	if err == nil || !strings.Contains(err.Error(), "unsupported runtime tool") {
+		t.Fatalf("Execute(read_file) error = %v, want fallback execution denial", err)
 	}
 }
 

--- a/internal/runtime/tools/external_dispatch_admission_test.go
+++ b/internal/runtime/tools/external_dispatch_admission_test.go
@@ -417,6 +417,8 @@ func TestExecutor_NativeWebSearchHardcodedProviderUsesRateLimit(t *testing.T) {
 	var recorder dispatchTimeRecorder
 	exec := NewExecutorWithOptions(nil, nil, ExecutorOptions{
 		WorkflowSource: rateLimitedNativeWebSearchSource("brave", "1/40ms", "500ms", nil),
+		Credentials:    nativeWebSearchCredentialStore{"brave_search_api_key": "secret"},
+		ModelRuntime:   nativeCapabilityRuntimeStub{},
 	})
 	exec.httpClient.Transport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
 		recorder.record()
@@ -454,6 +456,7 @@ func TestExecutor_NativeWebSearchCustomProviderUsesRateLimit(t *testing.T) {
 	}
 	exec := NewExecutorWithOptions(nil, nil, ExecutorOptions{
 		WorkflowSource: rateLimitedNativeWebSearchSource("custom", "1/40ms", "500ms", customHTTP),
+		ModelRuntime:   nativeCapabilityRuntimeStub{},
 	})
 	ctx := models.WithActor(context.Background(), models.AgentConfig{
 		ID:          "agent-1",
@@ -480,6 +483,7 @@ func TestExecutor_NativeWebSearchInheritedProviderPolicySharesBucketAcrossFlows(
 
 	exec := NewExecutorWithOptions(nil, nil, ExecutorOptions{
 		WorkflowSource: rateLimitedNativeWebSearchSiblingFlowSource(server.URL),
+		ModelRuntime:   nativeCapabilityRuntimeStub{},
 	})
 	first := models.WithActor(context.Background(), models.AgentConfig{
 		ID:          "alpha-agent",
@@ -507,6 +511,31 @@ func TestExecutor_NativeWebSearchInheritedProviderPolicySharesBucketAcrossFlows(
 type dispatchTimeRecorder struct {
 	mu    sync.Mutex
 	times []time.Time
+}
+
+type nativeWebSearchCredentialStore map[string]string
+
+func (s nativeWebSearchCredentialStore) Get(_ context.Context, key string) (string, bool, error) {
+	value, ok := s[strings.TrimSpace(key)]
+	return value, ok, nil
+}
+
+func (s nativeWebSearchCredentialStore) Set(_ context.Context, key, value string) error {
+	s[strings.TrimSpace(key)] = value
+	return nil
+}
+
+func (s nativeWebSearchCredentialStore) List(context.Context) ([]string, error) {
+	out := make([]string, 0, len(s))
+	for key := range s {
+		out = append(out, key)
+	}
+	return out, nil
+}
+
+func (s nativeWebSearchCredentialStore) Delete(_ context.Context, key string) error {
+	delete(s, strings.TrimSpace(key))
+	return nil
 }
 
 func (r *dispatchTimeRecorder) record() {
@@ -579,6 +608,9 @@ func rateLimitedNativeWebSearchSource(provider, rateLimit, maxWait string, custo
 		"rate_limit_max_wait": maxWait,
 		"response_path":       "items",
 		"field_mapping":       map[string]any{"title": "title", "url": "link", "snippet": "summary"},
+	}
+	if provider != "custom" {
+		root["credentials_key"] = "brave_search_api_key"
 	}
 	if customHTTP != nil {
 		rawHTTP, _ := json.Marshal(customHTTP)

--- a/internal/runtime/tools/handler_registry.go
+++ b/internal/runtime/tools/handler_registry.go
@@ -21,13 +21,13 @@ func (e *Executor) registerAgentHandlers(handlers map[string]ToolHandler) {
 	handlers["agent_message"] = e.execAgentMessage
 	handlers["schedule"] = e.execSchedule
 	handlers["agent_hire"] = func(ctx context.Context, actor models.AgentConfig, input any) (any, error) {
-		return e.execAgentHire(actor, input)
+		return e.execAgentHire(ctx, actor, input)
 	}
 	handlers["agent_fire"] = func(ctx context.Context, actor models.AgentConfig, input any) (any, error) {
 		return e.execAgentFire(actor, input)
 	}
 	handlers["agent_reconfigure"] = func(ctx context.Context, actor models.AgentConfig, input any) (any, error) {
-		return e.execAgentReconfigure(actor, input)
+		return e.execAgentReconfigure(ctx, actor, input)
 	}
 }
 

--- a/internal/runtime/tools/native_tools_admission.go
+++ b/internal/runtime/tools/native_tools_admission.go
@@ -1,0 +1,263 @@
+package tools
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+
+	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
+	models "github.com/division-sh/swarm/internal/runtime/core/actors"
+	runtimecredentials "github.com/division-sh/swarm/internal/runtime/credentials"
+	llm "github.com/division-sh/swarm/internal/runtime/llm"
+	"github.com/division-sh/swarm/internal/runtime/semanticview"
+	workspace "github.com/division-sh/swarm/internal/runtime/workspace"
+)
+
+type NativeToolAdmissionOptions struct {
+	Runtime     llm.Runtime
+	Credentials runtimecredentials.Store
+	Source      semanticview.Source
+	Workspaces  workspace.Resolver
+}
+
+type NativeToolAdmissionDecision struct {
+	Capability             string
+	ToolNames              []string
+	Admitted               bool
+	ProviderNativeAdmitted bool
+	FallbackAdmitted       bool
+	Owner                  string
+	DenialReason           string
+}
+
+const (
+	nativeToolOwnerProviderNative      = "llm provider native capability"
+	nativeToolOwnerWorkspaceExecution  = "workspace execution target"
+	nativeToolOwnerWebSearchProvider   = "policy.web_search_provider"
+	nativeToolProviderOnlyFallbackDeny = "native tool is provider-native only for selected runtime; platform fallback is not admitted"
+)
+
+func ValidateNativeToolAgentAdmission(ctx context.Context, actor models.AgentConfig, opts NativeToolAdmissionOptions) error {
+	decisions := NativeToolAdmissionDecisions(ctx, actor, opts)
+	var denied []string
+	for _, decision := range decisions {
+		if decision.Admitted {
+			continue
+		}
+		reason := strings.TrimSpace(decision.DenialReason)
+		if reason == "" {
+			reason = "native tool admission was denied"
+		}
+		denied = append(denied, fmt.Sprintf("native_tools.%s for agent %s: %s", decision.Capability, actorLabel(actor), reason))
+	}
+	if len(denied) == 0 {
+		return nil
+	}
+	sort.Strings(denied)
+	return fmt.Errorf("%s", strings.Join(denied, "; "))
+}
+
+func NativeToolAdmissionDecisions(ctx context.Context, actor models.AgentConfig, opts NativeToolAdmissionOptions) []NativeToolAdmissionDecision {
+	if !actor.NativeTools.Any() {
+		return nil
+	}
+	capabilities := actor.NativeTools.Names()
+	sort.Strings(capabilities)
+	decisions := make([]NativeToolAdmissionDecision, 0, len(capabilities))
+	for _, capability := range capabilities {
+		decisions = append(decisions, nativeToolAdmissionDecision(ctx, actor, capability, opts))
+	}
+	return decisions
+}
+
+func nativeToolAdmissionDecision(ctx context.Context, actor models.AgentConfig, capability string, opts NativeToolAdmissionOptions) NativeToolAdmissionDecision {
+	capability = strings.TrimSpace(capability)
+	decision := NativeToolAdmissionDecision{
+		Capability: capability,
+		ToolNames:  nativeToolNameForCapability(capability),
+	}
+	if capability == "" {
+		decision.DenialReason = "native tool capability is empty"
+		return decision
+	}
+	providerCaps := llm.NativeToolCapabilitiesForRuntime(opts.Runtime)
+	if nativeToolCapabilitySupported(providerCaps, capability) {
+		decision.Admitted = true
+		decision.ProviderNativeAdmitted = true
+		decision.Owner = nativeToolOwnerProviderNative
+		return decision
+	}
+	contract, hasContract := llm.ProviderContractForRuntime(opts.Runtime)
+	if llm.RuntimeEnforcesProviderNativeTools(opts.Runtime) {
+		decision.DenialReason = "selected runtime is strict provider-native and does not support provider-native capability"
+		return decision
+	}
+	if !hasContract || !contract.NativeTools.FallbackToolsAllowed {
+		decision.DenialReason = "selected runtime does not allow native tool fallback"
+		return decision
+	}
+	switch capability {
+	case "bash":
+		return admitWorkspaceCapability(ctx, actor, decision, opts.Workspaces, workspace.ExecutionCapabilityNativeCommand)
+	case "file_io":
+		if first := workspaceCapabilityDenial(ctx, actor, opts.Workspaces, workspace.ExecutionCapabilityFileRead); first != "" {
+			decision.DenialReason = first
+			return decision
+		}
+		if second := workspaceCapabilityDenial(ctx, actor, opts.Workspaces, workspace.ExecutionCapabilityFileWrite); second != "" {
+			decision.DenialReason = second
+			return decision
+		}
+		decision.Admitted = true
+		decision.FallbackAdmitted = true
+		decision.Owner = nativeToolOwnerWorkspaceExecution
+		return decision
+	case "web_search":
+		return admitWebSearchFallback(ctx, actor, decision, opts)
+	default:
+		decision.DenialReason = "unsupported native tool capability"
+		return decision
+	}
+}
+
+func nativeToolCapabilitySupported(caps llm.NativeToolCapabilities, capability string) bool {
+	switch strings.TrimSpace(capability) {
+	case "bash":
+		return caps.Bash
+	case "web_search":
+		return caps.WebSearch
+	case "file_io":
+		return caps.FileIO
+	default:
+		return false
+	}
+}
+
+func admitWorkspaceCapability(ctx context.Context, actor models.AgentConfig, decision NativeToolAdmissionDecision, resolver workspace.Resolver, capability workspace.ExecutionCapability) NativeToolAdmissionDecision {
+	if reason := workspaceCapabilityDenial(ctx, actor, resolver, capability); reason != "" {
+		decision.DenialReason = reason
+		return decision
+	}
+	decision.Admitted = true
+	decision.FallbackAdmitted = true
+	decision.Owner = nativeToolOwnerWorkspaceExecution
+	return decision
+}
+
+func workspaceCapabilityDenial(ctx context.Context, actor models.AgentConfig, resolver workspace.Resolver, capability workspace.ExecutionCapability) string {
+	if resolver == nil {
+		return "workspace resolver is not configured"
+	}
+	target, err := resolver.ResolveWorkspace(ctx, actor)
+	if err != nil {
+		return err.Error()
+	}
+	execTarget := target.ExecutionTarget()
+	if !execTarget.Supports(capability) {
+		return execTarget.UnsupportedMessage(capability)
+	}
+	return ""
+}
+
+func admitWebSearchFallback(ctx context.Context, actor models.AgentConfig, decision NativeToolAdmissionDecision, opts NativeToolAdmissionOptions) NativeToolAdmissionDecision {
+	flowID := emitActorFlowID(opts.Source, actor, "")
+	cfg, err := resolveWebSearchProviderConfigFromSourceForFlow(opts.Source, flowID)
+	if err != nil {
+		decision.DenialReason = err.Error()
+		return decision
+	}
+	if requiresWebSearchCredential(cfg) {
+		if err := validateWebSearchCredential(ctx, opts.Source, actor, cfg, opts.Credentials); err != nil {
+			decision.DenialReason = err.Error()
+			return decision
+		}
+	}
+	decision.Admitted = true
+	decision.FallbackAdmitted = true
+	decision.Owner = nativeToolOwnerWebSearchProvider
+	return decision
+}
+
+func requiresWebSearchCredential(cfg webSearchProviderConfig) bool {
+	switch strings.ToLower(strings.TrimSpace(cfg.Provider)) {
+	case "brave", "serper", "tavily":
+		return true
+	default:
+		return strings.TrimSpace(cfg.CredentialsKey) != ""
+	}
+}
+
+func validateWebSearchCredential(ctx context.Context, source semanticview.Source, actor models.AgentConfig, cfg webSearchProviderConfig, store runtimecredentials.Store) error {
+	key := strings.TrimSpace(cfg.CredentialsKey)
+	if key == "" {
+		return fmt.Errorf("web_search provider %q requires credentials_key", strings.TrimSpace(cfg.Provider))
+	}
+	flowID := emitActorFlowID(source, actor, "")
+	storeKey, mapped := semanticview.CredentialStoreKeyForActorFlow(source, actor.ID, flowID, key)
+	if mapped && strings.TrimSpace(storeKey) == "" {
+		return fmt.Errorf("credential %q is not declared and bound for imported package actor %s", key, strings.TrimSpace(actor.ID))
+	}
+	storeKey = strings.TrimSpace(storeKey)
+	if storeKey == "" {
+		return fmt.Errorf("credential %q does not resolve to a deployment credential key", key)
+	}
+	if store == nil {
+		return fmt.Errorf("credential store is not configured")
+	}
+	value, ok, err := store.Get(ctx, storeKey)
+	if err != nil {
+		return err
+	}
+	if !ok || strings.TrimSpace(value) == "" {
+		return fmt.Errorf("missing credential %q", storeKey)
+	}
+	return nil
+}
+
+func nativeToolAgentConfig(agentID string, entry runtimecontracts.AgentRegistryEntry) models.AgentConfig {
+	cfg := models.AgentConfig{
+		ID:               coalesce(strings.TrimSpace(entry.ID), strings.TrimSpace(agentID)),
+		Type:             strings.TrimSpace(entry.Type),
+		Role:             strings.TrimSpace(entry.Role),
+		Mode:             strings.TrimSpace(entry.Mode),
+		Model:            strings.TrimSpace(entry.Model),
+		ConversationMode: strings.TrimSpace(entry.ConversationMode),
+		SessionScope:     strings.TrimSpace(entry.SessionScope),
+		MaxTurnsPerTask:  entry.MaxTurnsPerTask,
+		Subscriptions:    append([]string{}, entry.Subscriptions...),
+		EmitEvents:       append([]string{}, entry.EmitEvents...),
+		Tools:            entry.ConfiguredTools(),
+		Permissions:      append([]string{}, entry.Permissions...),
+		FlowDataAccess:   append([]string{}, entry.FlowDataAccess...),
+		WorkspaceClass:   strings.TrimSpace(entry.WorkspaceClass),
+		ManagerFallback:  strings.TrimSpace(entry.ManagerFallback),
+	}
+	cfg.NativeTools = nativeToolConfigFromContract(entry.NativeTools)
+	cfg.NormalizeRuntimeDescriptor()
+	return cfg
+}
+
+func nativeToolConfigFromContract(raw map[string]any) models.NativeToolConfig {
+	return models.NativeToolConfig{
+		Bash:      nativeToolContractFlag(raw, "bash"),
+		WebSearch: nativeToolContractFlag(raw, "web_search"),
+		FileIO:    nativeToolContractFlag(raw, "file_io"),
+	}
+}
+
+func nativeToolContractFlag(raw map[string]any, name string) bool {
+	value, ok := raw[strings.TrimSpace(name)]
+	flag, isBool := value.(bool)
+	return ok && isBool && flag
+}
+
+func actorLabel(actor models.AgentConfig) string {
+	if strings.TrimSpace(actor.ID) != "" {
+		return strings.TrimSpace(actor.ID)
+	}
+	if strings.TrimSpace(actor.Role) != "" {
+		return strings.TrimSpace(actor.Role)
+	}
+	return "<unknown>"
+}

--- a/internal/runtime/tools/native_tools_executor_admission.go
+++ b/internal/runtime/tools/native_tools_executor_admission.go
@@ -1,0 +1,65 @@
+package tools
+
+import (
+	"context"
+	"strings"
+
+	models "github.com/division-sh/swarm/internal/runtime/core/actors"
+)
+
+func (e *Executor) ValidateNativeToolAdmission(ctx context.Context, actor models.AgentConfig) error {
+	if e == nil || !actor.NativeTools.Any() {
+		return nil
+	}
+	return ValidateNativeToolAgentAdmission(ctx, actor, e.nativeToolAdmissionOptions())
+}
+
+func (e *Executor) nativeToolAdmissionOptions() NativeToolAdmissionOptions {
+	if e == nil {
+		return NativeToolAdmissionOptions{}
+	}
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+	return NativeToolAdmissionOptions{
+		Runtime:     e.modelRuntime,
+		Credentials: e.credentials,
+		Source:      e.workflowSource,
+		Workspaces:  e.workspaces,
+	}
+}
+
+func (e *Executor) nativeToolAdmittedForTool(ctx context.Context, actor models.AgentConfig, toolName string) bool {
+	admitted, _ := e.nativeToolAdmissionForTool(ctx, actor, toolName)
+	return admitted
+}
+
+func (e *Executor) nativeToolAdmissionForTool(ctx context.Context, actor models.AgentConfig, toolName string) (bool, string) {
+	toolName = normalizeNativeToolName(strings.TrimSpace(toolName))
+	if !isNativeFallbackToolName(toolName) {
+		return true, ""
+	}
+	for _, decision := range NativeToolAdmissionDecisions(ctx, actor, e.nativeToolAdmissionOptions()) {
+		for _, name := range decision.ToolNames {
+			if normalizeNativeToolName(name) != toolName {
+				continue
+			}
+			if decision.FallbackAdmitted {
+				return true, ""
+			}
+			if decision.ProviderNativeAdmitted {
+				return false, nativeToolProviderOnlyFallbackDeny
+			}
+			return false, decision.DenialReason
+		}
+	}
+	return false, "native tool capability is not enabled"
+}
+
+func isNativeFallbackToolName(name string) bool {
+	switch normalizeNativeToolName(name) {
+	case "bash", "web_search", "read_file", "write_file":
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/runtime/tools/native_tools_validation.go
+++ b/internal/runtime/tools/native_tools_validation.go
@@ -9,120 +9,32 @@ import (
 	runtimecredentials "github.com/division-sh/swarm/internal/runtime/credentials"
 	llm "github.com/division-sh/swarm/internal/runtime/llm"
 	"github.com/division-sh/swarm/internal/runtime/semanticview"
+	workspace "github.com/division-sh/swarm/internal/runtime/workspace"
 )
 
-func ValidateNativeToolBootConfig(ctx context.Context, source semanticview.Source, store runtimecredentials.Store, runtime llm.Runtime) ([]error, error) {
+func ValidateNativeToolBootConfig(ctx context.Context, source semanticview.Source, store runtimecredentials.Store, runtime llm.Runtime, workspaces workspace.Resolver) ([]error, error) {
 	if source == nil {
 		return nil, nil
 	}
-	enabled := enabledNativeCapabilities(source)
-	if len(enabled) == 0 {
-		return nil, nil
-	}
-	if !runtimeEnforcesProviderNativeTools(runtime) {
-		return validateFallbackNativeToolBootConfig(ctx, source, store, runtime)
-	}
-	caps := llm.NativeToolCapabilitiesForRuntime(runtime)
-	unsupported := make([]string, 0, len(enabled))
-	for _, capability := range enabled {
-		if nativeToolCapabilitySupported(caps, capability) {
+	var failures []string
+	for _, agentID := range sortedAgentIDs(source.AgentEntries()) {
+		entry := source.AgentEntries()[agentID]
+		actor := nativeToolAgentConfig(agentID, entry)
+		if !actor.NativeTools.Any() {
 			continue
 		}
-		unsupported = append(unsupported, capability)
-	}
-	if len(unsupported) == 0 {
-		return nil, nil
-	}
-	sort.Strings(unsupported)
-	parts := make([]string, 0, len(unsupported))
-	for _, capability := range unsupported {
-		parts = append(parts, "native_tools."+capability)
-	}
-	return nil, fmt.Errorf("%s enabled but runtime does not support provider-native capability", strings.Join(parts, ", "))
-}
-
-func runtimeEnforcesProviderNativeTools(runtime llm.Runtime) bool {
-	return llm.RuntimeEnforcesProviderNativeTools(runtime)
-}
-
-func validateFallbackNativeToolBootConfig(ctx context.Context, source semanticview.Source, store runtimecredentials.Store, runtime llm.Runtime) ([]error, error) {
-	if !nativeToolCapabilityEnabled(source, "web_search") {
-		return nil, nil
-	}
-	caps := llm.NativeToolCapabilitiesForRuntime(runtime)
-	if caps.WebSearch {
-		return nil, nil
-	}
-	if _, ok := semanticview.PolicyValueForFlow(source, "", "web_search_provider"); !ok {
-		return []error{fmt.Errorf("native_tools.web_search is enabled but policy.web_search_provider is not configured")}, nil
-	}
-	cfg, err := resolveWebSearchProviderConfigFromSource(source)
-	if err != nil {
-		return nil, err
-	}
-	if strings.TrimSpace(cfg.CredentialsKey) == "" || store == nil {
-		return nil, nil
-	}
-	_, ok, err := store.Get(ctx, cfg.CredentialsKey)
-	if err != nil {
-		return nil, err
-	}
-	if ok {
-		return nil, nil
-	}
-	return []error{fmt.Errorf("web_search provider credential %q is not present in the credential store", cfg.CredentialsKey)}, nil
-}
-
-func enabledNativeCapabilities(source semanticview.Source) []string {
-	if source == nil {
-		return nil
-	}
-	seen := map[string]struct{}{}
-	for _, agent := range source.AgentEntries() {
-		for capability, raw := range agent.NativeTools {
-			capability = strings.TrimSpace(capability)
-			flag, isBool := raw.(bool)
-			if capability == "" || !isBool || !flag {
-				continue
-			}
-			seen[capability] = struct{}{}
+		if err := ValidateNativeToolAgentAdmission(ctx, actor, NativeToolAdmissionOptions{
+			Runtime:     runtime,
+			Credentials: store,
+			Source:      source,
+			Workspaces:  workspaces,
+		}); err != nil {
+			failures = append(failures, err.Error())
 		}
 	}
-	out := make([]string, 0, len(seen))
-	for capability := range seen {
-		out = append(out, capability)
+	if len(failures) == 0 {
+		return nil, nil
 	}
-	sort.Strings(out)
-	return out
-}
-
-func nativeToolCapabilityEnabled(source semanticview.Source, capability string) bool {
-	if source == nil {
-		return false
-	}
-	capability = strings.TrimSpace(capability)
-	if capability == "" {
-		return false
-	}
-	for _, agent := range source.AgentEntries() {
-		raw, ok := agent.NativeTools[capability]
-		flag, isBool := raw.(bool)
-		if ok && isBool && flag {
-			return true
-		}
-	}
-	return false
-}
-
-func nativeToolCapabilitySupported(caps llm.NativeToolCapabilities, capability string) bool {
-	switch strings.TrimSpace(capability) {
-	case "bash":
-		return caps.Bash
-	case "web_search":
-		return caps.WebSearch
-	case "file_io":
-		return caps.FileIO
-	default:
-		return false
-	}
+	sort.Strings(failures)
+	return nil, fmt.Errorf("native tool admission failed: %s", strings.Join(failures, "; "))
 }

--- a/internal/runtime/tools/native_tools_validation_test.go
+++ b/internal/runtime/tools/native_tools_validation_test.go
@@ -2,12 +2,15 @@ package tools
 
 import (
 	"context"
+	"path/filepath"
 	"strings"
 	"testing"
 
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
+	runtimecredentials "github.com/division-sh/swarm/internal/runtime/credentials"
 	llm "github.com/division-sh/swarm/internal/runtime/llm"
 	"github.com/division-sh/swarm/internal/runtime/semanticview"
+	workspace "github.com/division-sh/swarm/internal/runtime/workspace"
 )
 
 type nativeCapabilityRuntimeStub struct {
@@ -38,8 +41,8 @@ func TestValidateNativeToolBootConfig_FailsClosedWhenRuntimeLacksNativeCapabilit
 		},
 	})
 
-	_, err := ValidateNativeToolBootConfig(context.Background(), source, nil, nativeCapabilityRuntimeStub{strict: true})
-	if err == nil || !strings.Contains(err.Error(), "native_tools.web_search enabled but runtime does not support provider-native capability") {
+	_, err := ValidateNativeToolBootConfig(context.Background(), source, nil, nativeCapabilityRuntimeStub{strict: true}, nil)
+	if err == nil || !strings.Contains(err.Error(), "selected runtime is strict provider-native and does not support provider-native capability") {
 		t.Fatalf("expected unsupported native capability error, got %v", err)
 	}
 }
@@ -59,7 +62,7 @@ func TestValidateNativeToolBootConfig_CLINativeWebSearchDoesNotRequireFallbackPr
 	warnings, err := ValidateNativeToolBootConfig(context.Background(), source, nil, nativeCapabilityRuntimeStub{
 		caps:   llm.NativeToolCapabilities{WebSearch: true},
 		strict: true,
-	})
+	}, nil)
 	if err != nil {
 		t.Fatalf("ValidateNativeToolBootConfig: %v", err)
 	}
@@ -68,7 +71,7 @@ func TestValidateNativeToolBootConfig_CLINativeWebSearchDoesNotRequireFallbackPr
 	}
 }
 
-func TestValidateNativeToolBootConfig_NonCLIRuntimePreservesWebSearchFallbackValidation(t *testing.T) {
+func TestValidateNativeToolBootConfig_NonCLIRuntimeRequiresWebSearchFallbackCredential(t *testing.T) {
 	source := semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
 		Agents: map[string]runtimecontracts.AgentRegistryEntry{
 			"agent-1": {
@@ -90,9 +93,53 @@ func TestValidateNativeToolBootConfig_NonCLIRuntimePreservesWebSearchFallbackVal
 		},
 	})
 
-	warnings, err := ValidateNativeToolBootConfig(context.Background(), source, nil, nativeCapabilityRuntimeStub{})
+	emptyStore, err := runtimecredentials.NewFileStore(filepath.Join(t.TempDir(), "empty-credentials.json"))
 	if err != nil {
-		t.Fatalf("ValidateNativeToolBootConfig: %v", err)
+		t.Fatalf("NewFileStore empty: %v", err)
+	}
+	_, err = ValidateNativeToolBootConfig(context.Background(), source, emptyStore, nativeCapabilityRuntimeStub{}, nil)
+	if err == nil || !strings.Contains(err.Error(), `missing credential "brave_search_api_key"`) {
+		t.Fatalf("ValidateNativeToolBootConfig error = %v, want missing web_search credential", err)
+	}
+
+	store, err := runtimecredentials.NewFileStore(filepath.Join(t.TempDir(), "credentials.json"))
+	if err != nil {
+		t.Fatalf("NewFileStore: %v", err)
+	}
+	if err := store.Set(context.Background(), "brave_search_api_key", "secret"); err != nil {
+		t.Fatalf("Set credential: %v", err)
+	}
+	warnings, err := ValidateNativeToolBootConfig(context.Background(), source, store, nativeCapabilityRuntimeStub{}, nil)
+	if err != nil {
+		t.Fatalf("ValidateNativeToolBootConfig with credential: %v", err)
+	}
+	if len(warnings) != 0 {
+		t.Fatalf("warnings = %#v, want none", warnings)
+	}
+}
+
+func TestValidateNativeToolBootConfig_FallbackFileIORequiresWorkspaceExecutionTarget(t *testing.T) {
+	source := semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
+		Agents: map[string]runtimecontracts.AgentRegistryEntry{
+			"agent-1": {
+				ID: "agent-1",
+				NativeTools: map[string]any{
+					"file_io": true,
+				},
+			},
+		},
+	})
+
+	_, err := ValidateNativeToolBootConfig(context.Background(), source, nil, nativeCapabilityRuntimeStub{}, nil)
+	if err == nil || !strings.Contains(err.Error(), "workspace resolver is not configured") {
+		t.Fatalf("ValidateNativeToolBootConfig error = %v, want missing workspace resolver", err)
+	}
+
+	warnings, err := ValidateNativeToolBootConfig(context.Background(), source, nil, nativeCapabilityRuntimeStub{}, relayWorkspaceResolverStub{
+		target: &workspace.Target{Backend: workspace.BackendHost, Workdir: t.TempDir()},
+	})
+	if err != nil {
+		t.Fatalf("ValidateNativeToolBootConfig with workspace: %v", err)
 	}
 	if len(warnings) != 0 {
 		t.Fatalf("warnings = %#v, want none", warnings)

--- a/internal/runtime/tools/tool_model_test.go
+++ b/internal/runtime/tools/tool_model_test.go
@@ -15,6 +15,7 @@ import (
 	models "github.com/division-sh/swarm/internal/runtime/core/actors"
 	runtimecredentials "github.com/division-sh/swarm/internal/runtime/credentials"
 	"github.com/division-sh/swarm/internal/runtime/semanticview"
+	workspace "github.com/division-sh/swarm/internal/runtime/workspace"
 )
 
 func TestExecutor_HTTPToolExecutesTemplateAndResponseMapping(t *testing.T) {
@@ -546,7 +547,13 @@ func TestExecutor_ToolDefinitionsForActor_UsesSharedActorRegistry(t *testing.T) 
 		},
 	})
 
-	exec := NewExecutorWithOptions(nil, nil, ExecutorOptions{WorkflowSource: source})
+	exec := NewExecutorWithOptions(nil, nil, ExecutorOptions{
+		WorkflowSource: source,
+		ModelRuntime:   nativeCapabilityRuntimeStub{},
+		WorkspaceResolver: relayWorkspaceResolverStub{
+			target: &workspace.Target{Backend: workspace.BackendHost, Workdir: t.TempDir()},
+		},
+	})
 	defs := exec.ToolDefinitionsForActor(models.AgentConfig{
 		ID:          "agent-1",
 		Tools:       []string{"check_domain"},

--- a/internal/runtime/tools/tool_result_relay_test.go
+++ b/internal/runtime/tools/tool_result_relay_test.go
@@ -226,6 +226,9 @@ func newHostRelayExecutor(t *testing.T) (*Executor, models.AgentConfig, *workspa
 	if err != nil {
 		t.Fatalf("ResolveWorkspace: %v", err)
 	}
-	exec := NewExecutorWithOptions(nil, nil, ExecutorOptions{WorkspaceResolver: manager})
+	exec := NewExecutorWithOptions(nil, nil, ExecutorOptions{
+		ModelRuntime:      nativeCapabilityRuntimeStub{},
+		WorkspaceResolver: manager,
+	})
 	return exec, actor, target
 }

--- a/internal/runtime/tools/tool_semantics_guardrails_test.go
+++ b/internal/runtime/tools/tool_semantics_guardrails_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	models "github.com/division-sh/swarm/internal/runtime/core/actors"
+	workspace "github.com/division-sh/swarm/internal/runtime/workspace"
 )
 
 func TestNormalizeNativeToolNameCanonicalAliases(t *testing.T) {
@@ -140,7 +141,12 @@ func TestRuntimeAndValidatorNormalizationStayAligned(t *testing.T) {
 func TestToolDefinitionsForActor_IncludesEnabledNativeTools(t *testing.T) {
 	t.Parallel()
 
-	exec := NewExecutorWithOptions(nil, nil, ExecutorOptions{})
+	exec := NewExecutorWithOptions(nil, nil, ExecutorOptions{
+		ModelRuntime: nativeCapabilityRuntimeStub{},
+		WorkspaceResolver: relayWorkspaceResolverStub{
+			target: &workspace.Target{Backend: workspace.BackendHost, Workdir: t.TempDir()},
+		},
+	})
 	defs := exec.ToolDefinitionsForActor(models.AgentConfig{
 		ID:          "analysis-agent",
 		NativeTools: models.NativeToolConfig{FileIO: true},

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -3483,6 +3483,14 @@ engine:
           rules:
           - The adapter must declare whether it is strict provider-native for native_tools and which native capabilities are callable.
           - Strict provider-native adapters must fail closed rather than satisfying native_tools through fallback paths.
+          - FallbackToolsAllowed only permits the runtime to consider platform fallback after a concrete fallback owner proves
+            callability; it is not itself admission.
+          - For non-strict fallback runtimes, bash and file_io native_tools are admitted only when the selected workspace
+            execution target supports the required native command and file capabilities.
+          - For non-strict fallback runtimes, web_search native_tools are admitted only when policy.web_search_provider resolves
+            to a supported provider and every provider-required credential resolves to a non-empty deployment credential.
+          - Static boot, dynamic agent_hire, and dynamic agent_reconfigure must fail closed before the affected agent's first
+            turn when provider-native support or the required fallback owner proof is missing.
           - Persisted turn visible-tool facts must reflect callable truth for the adapter's turn.
         persistence:
           rules:


### PR DESCRIPTION
Closes #1529

## Summary
- Add a single native-tool admission owner for provider-native support and fallback proof.
- Fail closed at static boot, executor tool catalogs/capabilities, registered fallback tool lookup, `agent_hire`, `agent_reconfigure`, and manager spawn/reconfigure.
- Remove the direct `NewLLMAgent` fallback native-tool injection path that had no workspace/policy proof.
- Update `platform-spec.yaml` to make fallback admission explicit.

## Governing refs/context
- `platform-spec.yaml` -> `engine.agent_runtime.llm_provider_adapter_contract.native_tools`.
- #1529 pre-audit and gate outcome approved the `runtime.native_tools.early_backend_and_fallback_admission` first slice.

## Semantic migration
- New canonical owner: `internal/runtime/tools/native_tools_admission.go` (`ValidateNativeToolAgentAdmission` / `NativeToolAdmissionDecisions`).
- Old non-authoritative paths now invalid: warning-only fallback boot validation, direct `NewLLMAgent` fallback injection, native fallback tool registration/definition/capability exposure without admission, and dynamic agent mutation before admission.
- Production paths checked: runtime boot validation, executor definitions/capabilities/registered-tool lookup, MCP and conversation visible surfaces through executor consumption, Claude startup visible-surface proof through executor consumption, `agent_hire`, `agent_reconfigure`, and manager spawn/reconfigure.
- Migration complete for the approved class. The broader provider/runtime transport parity parent remains outside this PR.

## Validation
- `go test ./...`