### PR TITLE
[agent-e][issue #1632] Retire event receiver projections

### DIFF
--- a/internal/apiv1/operator_mailbox_write_supported_surface_test.go
+++ b/internal/apiv1/operator_mailbox_write_supported_surface_test.go
@@ -820,7 +820,7 @@ func mailboxWriteSupportedSurfaceBundle(t *testing.T) *runtimecontracts.Workflow
 				ItemType: runtimecontracts.LiteralExpression("review_request"),
 				Severity: runtimecontracts.LiteralExpression("urgent"),
 				Summary:  runtimecontracts.LiteralExpression("Review validation package"),
-				EntityID: runtimecontracts.RefExpression("event.entity_id"),
+				EntityID: runtimecontracts.RefExpression("_entity.id"),
 				Payload: map[string]runtimecontracts.ExpressionValue{
 					"review_kind": runtimecontracts.LiteralExpression("validation"),
 					"who":         runtimecontracts.RefExpression("payload.who"),
@@ -900,7 +900,7 @@ func conditionalRuleMailboxWriteSupportedSurfaceBundle(t *testing.T) *runtimecon
 					Mailbox: &runtimecontracts.MailboxWriteSpec{
 						ItemType: runtimecontracts.LiteralExpression("approval"),
 						Summary:  runtimecontracts.LiteralExpression("Review refund"),
-						EntityID: runtimecontracts.RefExpression("event.entity_id"),
+						EntityID: runtimecontracts.RefExpression("_entity.id"),
 						Payload: map[string]runtimecontracts.ExpressionValue{
 							"review_kind": runtimecontracts.LiteralExpression("conditional"),
 							"who":         runtimecontracts.RefExpression("payload.who"),

--- a/internal/events/context_fields.go
+++ b/internal/events/context_fields.go
@@ -1,0 +1,86 @@
+package events
+
+import (
+	"fmt"
+	"strings"
+)
+
+const EventContextRoot = "event"
+
+func EventContextFieldSupported(field string) bool {
+	switch strings.TrimSpace(field) {
+	case "id",
+		"type",
+		"trigger_event_type",
+		"source_agent",
+		"task_id",
+		"source",
+		"target",
+		"target_set",
+		"source_event_id",
+		"emitted_at",
+		"current_state",
+		"run_id",
+		"scope":
+		return true
+	default:
+		return false
+	}
+}
+
+func EventContextFieldUnsupported(field string) bool {
+	switch strings.TrimSpace(field) {
+	case "entity_id", "flow_instance":
+		return true
+	default:
+		return false
+	}
+}
+
+func ValidateEventContextReference(ref string) error {
+	ref = strings.Trim(strings.TrimSpace(ref), ".")
+	if ref == "" {
+		return nil
+	}
+	field, tail, _ := strings.Cut(ref, ".")
+	field = strings.TrimSpace(field)
+	switch field {
+	case "entity_id":
+		return fmt.Errorf("event.entity_id is unsupported on handler expression surfaces; use _entity.id for current receiver context or event.source.entity_id/event.target.entity_id for route identity")
+	case "flow_instance":
+		return fmt.Errorf("event.flow_instance is unsupported on handler expression surfaces; use _entity.flow_instance for current receiver context or event.source.flow_instance/event.target.flow_instance for route identity")
+	case "source", "target":
+		return validateRouteIdentityReference(field, tail)
+	case "target_set":
+		if strings.TrimSpace(tail) != "" {
+			return fmt.Errorf("event.target_set is a list of route identities and does not support dotted field %q", tail)
+		}
+		return nil
+	default:
+		if EventContextFieldSupported(field) {
+			if strings.TrimSpace(tail) != "" {
+				return fmt.Errorf("event.%s is a platform scalar and does not support nested path %q", field, ref)
+			}
+			return nil
+		}
+		return fmt.Errorf("event.%s is not a supported handler event context field", field)
+	}
+}
+
+func validateRouteIdentityReference(root, tail string) error {
+	tail = strings.Trim(tail, ".")
+	if tail == "" {
+		return nil
+	}
+	field, rest, _ := strings.Cut(tail, ".")
+	field = strings.TrimSpace(field)
+	switch field {
+	case "entity_id", "flow_instance", "flow_id":
+		if strings.TrimSpace(rest) != "" {
+			return fmt.Errorf("event.%s.%s is a route identity scalar and does not support nested path %q", root, field, tail)
+		}
+		return nil
+	default:
+		return fmt.Errorf("event.%s.%s is not a supported route identity field", root, field)
+	}
+}

--- a/internal/events/types.go
+++ b/internal/events/types.go
@@ -344,12 +344,6 @@ func (e Event) ContextMap(currentState string) map[string]any {
 		out["task_id"] = taskID
 	}
 	envelope := e.NormalizedEnvelope()
-	if envelope.EntityID != "" {
-		out["entity_id"] = envelope.EntityID
-	}
-	if envelope.FlowInstance != "" {
-		out["flow_instance"] = envelope.FlowInstance
-	}
 	if envelope.Scope != "" {
 		out["scope"] = string(envelope.Scope)
 	}

--- a/internal/events/types_test.go
+++ b/internal/events/types_test.go
@@ -2,6 +2,7 @@ package events
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 	"time"
 )
@@ -84,6 +85,80 @@ func TestEventTargetSetDoesNotMaterializeFirstTargetProjection(t *testing.T) {
 	}
 	if got := delivered.TargetRoutes(); len(got) != 0 {
 		t.Fatalf("delivered TargetRoutes() count = %d, want 0 after singular delivery target", len(got))
+	}
+}
+
+func TestEventContextMapOmitsLegacyReceiverProjectionFields(t *testing.T) {
+	envelope := EnvelopeForSourceRoute(EventEnvelope{
+		EntityID:     "legacy-ent",
+		FlowInstance: "legacy-flow",
+		Scope:        EventScopeEntity,
+	}, RouteIdentity{EntityID: "source-ent", FlowInstance: "source-flow", FlowID: "source"})
+	envelope = EnvelopeForTargetRoute(envelope, RouteIdentity{EntityID: "target-ent", FlowInstance: "target-flow", FlowID: "target"})
+	evt := NewProjectionEvent(
+		"evt-1",
+		EventType("custom.triggered"),
+		"runtime",
+		"task-1",
+		nil,
+		0,
+		"run-1",
+		"parent-1",
+		envelope,
+		time.Date(2026, 7, 3, 1, 2, 3, 0, time.UTC),
+	)
+
+	got := evt.ContextMap("ready")
+	if _, ok := got["entity_id"]; ok {
+		t.Fatalf("ContextMap exposed legacy entity_id = %#v", got["entity_id"])
+	}
+	if _, ok := got["flow_instance"]; ok {
+		t.Fatalf("ContextMap exposed legacy flow_instance = %#v", got["flow_instance"])
+	}
+	for _, field := range []string{"id", "type", "trigger_event_type", "source_agent", "task_id", "source", "target", "source_event_id", "emitted_at", "current_state", "run_id", "scope"} {
+		if _, ok := got[field]; !ok {
+			t.Fatalf("ContextMap missing supported event field %q in %#v", field, got)
+		}
+	}
+}
+
+func TestValidateEventContextReferenceRejectsLegacyReceiverProjections(t *testing.T) {
+	for _, ref := range []string{"entity_id", "flow_instance"} {
+		t.Run(ref, func(t *testing.T) {
+			err := ValidateEventContextReference(ref)
+			if err == nil {
+				t.Fatalf("expected %s to be unsupported", ref)
+			}
+			if !strings.Contains(err.Error(), "_entity.") {
+				t.Fatalf("error = %q, want replacement guidance", err.Error())
+			}
+		})
+	}
+}
+
+func TestValidateEventContextReferenceAllowsRouteIdentity(t *testing.T) {
+	for _, ref := range []string{
+		"id",
+		"type",
+		"source.entity_id",
+		"source.flow_instance",
+		"source.flow_id",
+		"target.entity_id",
+		"target.flow_instance",
+		"target.flow_id",
+		"target_set",
+		"source_event_id",
+		"emitted_at",
+		"trigger_event_type",
+		"current_state",
+		"run_id",
+		"scope",
+	} {
+		t.Run(ref, func(t *testing.T) {
+			if err := ValidateEventContextReference(ref); err != nil {
+				t.Fatalf("ValidateEventContextReference(%q) error = %v", ref, err)
+			}
+		})
 	}
 }
 

--- a/internal/runtime/bootverify/report_test.go
+++ b/internal/runtime/bootverify/report_test.go
@@ -3819,7 +3819,7 @@ func TestRun_ErrorsWhenGuardEscalateObjectFieldsAuthorEnvelopeOwnedField(t *test
 	setGuardEscalationForBootverifyTest(bundle, runtimecontracts.EmitSpec{
 		Event: "check.escalated",
 		Fields: map[string]runtimecontracts.ExpressionValue{
-			"entity_id": runtimecontracts.RefExpression("event.entity_id"),
+			"entity_id": runtimecontracts.RefExpression("_entity.id"),
 		},
 	})
 
@@ -4451,7 +4451,7 @@ func TestRun_AllowsRuleConditionReferenceToDeclaredEntityAndEventContext(t *test
 	handler.CreateEntity = false
 	handler.Rules = []runtimecontracts.HandlerRuleEntry{{
 		ID:        "ready",
-		Condition: `entity.revision_count == 0 && payload.score >= 0 && event.entity_id != ""`,
+		Condition: `entity.revision_count == 0 && payload.score >= 0 && event.source.entity_id != ""`,
 	}}
 	writeFlowHandler(t, bundle, flowID, nodeID, eventType, handler)
 
@@ -4463,11 +4463,78 @@ func TestRun_AllowsRuleConditionReferenceToDeclaredEntityAndEventContext(t *test
 	if reportContains(report.Errors(), "expression_field_reference_validation", "entity.revision_count") {
 		t.Fatalf("unexpected rule-condition entity reference error, got %#v", report.Errors())
 	}
-	if reportContains(report.Errors(), "condition_expression_validation", "event.entity_id") {
+	if reportContains(report.Errors(), "condition_expression_validation", "event.source.entity_id") {
 		t.Fatalf("unexpected rule-condition event context validation error, got %#v", report.Errors())
 	}
 	if reportContains(report.Errors(), "condition_payload_alignment", "payload.score") {
 		t.Fatalf("unexpected rule-condition payload alignment error, got %#v", report.Errors())
+	}
+}
+
+func TestRun_RejectsLegacyEventReceiverProjectionReferences(t *testing.T) {
+	cases := []struct {
+		name       string
+		checkID    string
+		condition  string
+		emitFields map[string]runtimecontracts.ExpressionValue
+		want       string
+	}{
+		{
+			checkID:   "condition_expression_validation",
+			name:      "condition entity_id",
+			condition: `event.entity_id != ""`,
+			want:      "event.entity_id is unsupported",
+		},
+		{
+			checkID:   "condition_expression_validation",
+			name:      "condition flow_instance",
+			condition: `event.flow_instance != ""`,
+			want:      "event.flow_instance is unsupported",
+		},
+		{
+			name:    "emit field entity_id",
+			checkID: "emit_field_expression_validation",
+			emitFields: map[string]runtimecontracts.ExpressionValue{
+				"summary.entity": runtimecontracts.RefExpression("event.entity_id"),
+			},
+			want: "event.entity_id is unsupported",
+		},
+		{
+			name:    "emit field flow_instance",
+			checkID: "emit_field_expression_validation",
+			emitFields: map[string]runtimecontracts.ExpressionValue{
+				"summary.flow": runtimecontracts.CELExpression("event.flow_instance"),
+			},
+			want: "event.flow_instance is unsupported",
+		},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			bundle := loadWave1ExpressionFixtureBundle(t)
+			flowID, nodeID, eventType, handler := firstFlowHandlerInFlowView(t, bundle)
+			clearWave1ExpressionStaticCreateEntity(t, bundle, flowID, nodeID)
+			clearWave1ExpressionFeedbackEmit(t, bundle, flowID, nodeID)
+			handler.CreateEntity = false
+			if tt.condition != "" {
+				handler.Rules = []runtimecontracts.HandlerRuleEntry{{
+					ID:        "legacy",
+					Condition: tt.condition,
+				}}
+			}
+			if len(tt.emitFields) > 0 {
+				handler.Emit = runtimecontracts.EmitSpec{
+					Event:  "wave1.feedback",
+					Fields: tt.emitFields,
+				}
+			}
+			writeFlowHandler(t, bundle, flowID, nodeID, eventType, handler)
+
+			report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+
+			if !reportContains(report.Errors(), tt.checkID, tt.want) {
+				t.Fatalf("expected legacy event receiver projection error %q, got %#v", tt.want, report.Errors())
+			}
+		})
 	}
 }
 

--- a/internal/runtime/bootverify/report_test.go
+++ b/internal/runtime/bootverify/report_test.go
@@ -4451,7 +4451,7 @@ func TestRun_AllowsRuleConditionReferenceToDeclaredEntityAndEventContext(t *test
 	handler.CreateEntity = false
 	handler.Rules = []runtimecontracts.HandlerRuleEntry{{
 		ID:        "ready",
-		Condition: `entity.revision_count == 0 && payload.score >= 0 && event.source.entity_id != ""`,
+		Condition: `entity.revision_count == 0 && payload.score >= 0 && event["source"].entity_id != ""`,
 	}}
 	writeFlowHandler(t, bundle, flowID, nodeID, eventType, handler)
 
@@ -4463,7 +4463,7 @@ func TestRun_AllowsRuleConditionReferenceToDeclaredEntityAndEventContext(t *test
 	if reportContains(report.Errors(), "expression_field_reference_validation", "entity.revision_count") {
 		t.Fatalf("unexpected rule-condition entity reference error, got %#v", report.Errors())
 	}
-	if reportContains(report.Errors(), "condition_expression_validation", "event.source.entity_id") {
+	if reportContains(report.Errors(), "condition_expression_validation", `event["source"].entity_id`) {
 		t.Fatalf("unexpected rule-condition event context validation error, got %#v", report.Errors())
 	}
 	if reportContains(report.Errors(), "condition_payload_alignment", "payload.score") {

--- a/internal/runtime/bootverify/report_test.go
+++ b/internal/runtime/bootverify/report_test.go
@@ -4492,6 +4492,18 @@ func TestRun_RejectsLegacyEventReceiverProjectionReferences(t *testing.T) {
 			want:      "event.flow_instance is unsupported",
 		},
 		{
+			checkID:   "condition_expression_validation",
+			name:      "condition bracket entity_id",
+			condition: `event["entity_id"] != ""`,
+			want:      "event.entity_id is unsupported",
+		},
+		{
+			checkID:   "condition_expression_validation",
+			name:      "condition dynamic bracket",
+			condition: `event[payload.key] != ""`,
+			want:      "event[...] dynamic field access is unsupported",
+		},
+		{
 			name:    "emit field entity_id",
 			checkID: "emit_field_expression_validation",
 			emitFields: map[string]runtimecontracts.ExpressionValue{
@@ -4504,6 +4516,14 @@ func TestRun_RejectsLegacyEventReceiverProjectionReferences(t *testing.T) {
 			checkID: "emit_field_expression_validation",
 			emitFields: map[string]runtimecontracts.ExpressionValue{
 				"summary.flow": runtimecontracts.CELExpression("event.flow_instance"),
+			},
+			want: "event.flow_instance is unsupported",
+		},
+		{
+			name:    "emit field bracket flow_instance",
+			checkID: "emit_field_expression_validation",
+			emitFields: map[string]runtimecontracts.ExpressionValue{
+				"summary.flow": runtimecontracts.CELExpression(`event["flow_instance"]`),
 			},
 			want: "event.flow_instance is unsupported",
 		},

--- a/internal/runtime/contracts/workflow_contract_yaml_test.go
+++ b/internal/runtime/contracts/workflow_contract_yaml_test.go
@@ -2013,9 +2013,9 @@ action:
     summary:
       literal: Review validation package
     entity_id:
-      ref: event.entity_id
+      ref: _entity.id
     flow_instance:
-      ref: event.flow_instance
+      ref: _entity.flow_instance
     payload:
       review_kind:
         ref: payload.review_kind
@@ -2033,7 +2033,7 @@ action:
 	if got := handler.Action.Mailbox.ItemType.Literal; got != "review_request" {
 		t.Fatalf("Mailbox.ItemType.Literal = %#v", got)
 	}
-	if got := handler.Action.Mailbox.EntityID.Ref; got != "event.entity_id" {
+	if got := handler.Action.Mailbox.EntityID.Ref; got != "_entity.id" {
 		t.Fatalf("Mailbox.EntityID.Ref = %q", got)
 	}
 	if got := handler.Action.Mailbox.Payload["review_kind"].Ref; got != "payload.review_kind" {

--- a/internal/runtime/engine/executor_test.go
+++ b/internal/runtime/engine/executor_test.go
@@ -469,12 +469,19 @@ func TestCompiledExecutionCondition_AllowsSupportedEventRouteRoot(t *testing.T) 
 }
 
 func TestCompiledExecutionCondition_RejectsLegacyEventReceiverProjection(t *testing.T) {
-	_, err := compileExecutionCondition(`event.flow_instance == "legacy-flow"`)
-	if err == nil {
-		t.Fatal("expected event.flow_instance to fail closed")
-	}
-	if !strings.Contains(err.Error(), "event.flow_instance is unsupported") {
-		t.Fatalf("compileExecutionCondition error = %q, want event.flow_instance unsupported", err.Error())
+	for _, expression := range []string{
+		`event.flow_instance == "legacy-flow"`,
+		`event["flow_instance"] == "legacy-flow"`,
+	} {
+		t.Run(expression, func(t *testing.T) {
+			_, err := compileExecutionCondition(expression)
+			if err == nil {
+				t.Fatalf("expected %q to fail closed", expression)
+			}
+			if !strings.Contains(err.Error(), "event.flow_instance is unsupported") {
+				t.Fatalf("compileExecutionCondition error = %q, want event.flow_instance unsupported", err.Error())
+			}
+		})
 	}
 }
 

--- a/internal/runtime/engine/executor_test.go
+++ b/internal/runtime/engine/executor_test.go
@@ -406,27 +406,46 @@ func TestExecutor_ValidateRequestRejectsPlatformEntityWriteTargets(t *testing.T)
 	}
 }
 
-func TestExecutionScopeResolveOperand_AllowsEventRoot(t *testing.T) {
+func TestExecutionScopeResolveOperand_AllowsSupportedEventRouteRoot(t *testing.T) {
 	scope := newExecutionScope(
 		nil,
 		map[string]any{"entity_id": "payload-entity"},
-		map[string]any{"entity_id": "event-entity"},
+		map[string]any{"source": map[string]any{"entity_id": "source-entity"}},
 		nil,
 		nil,
 		nil,
 	)
 
-	got, err := scope.resolveOperand("event.entity_id", executionOperandDefaultNone)
+	got, err := scope.resolveOperand("event.source.entity_id", executionOperandDefaultNone)
 	if err != nil {
-		t.Fatalf("resolveOperand(event.entity_id) error: %v", err)
+		t.Fatalf("resolveOperand(event.source.entity_id) error: %v", err)
 	}
-	if got != "event-entity" {
-		t.Fatalf("resolveOperand(event.entity_id) = %#v, want event-entity", got)
+	if got != "source-entity" {
+		t.Fatalf("resolveOperand(event.source.entity_id) = %#v, want source-entity", got)
 	}
 }
 
-func TestCompiledExecutionCondition_AllowsEventRoot(t *testing.T) {
-	compiled, err := compileExecutionCondition(`event.entity_id == "event-entity"`)
+func TestExecutionScopeResolveOperand_RejectsLegacyEventReceiverProjection(t *testing.T) {
+	scope := newExecutionScope(
+		nil,
+		nil,
+		map[string]any{"entity_id": "legacy-entity"},
+		nil,
+		nil,
+		nil,
+	)
+
+	_, err := scope.resolveOperand("event.entity_id", executionOperandDefaultNone)
+	if err == nil {
+		t.Fatal("expected event.entity_id to fail closed")
+	}
+	if !strings.Contains(err.Error(), "event.entity_id is unsupported") {
+		t.Fatalf("resolveOperand error = %q, want event.entity_id unsupported", err.Error())
+	}
+}
+
+func TestCompiledExecutionCondition_AllowsSupportedEventRouteRoot(t *testing.T) {
+	compiled, err := compileExecutionCondition(`event.source.entity_id == "source-entity"`)
 	if err != nil {
 		t.Fatalf("compileExecutionCondition error: %v", err)
 	}
@@ -434,7 +453,7 @@ func TestCompiledExecutionCondition_AllowsEventRoot(t *testing.T) {
 	scope := newExecutionScope(
 		nil,
 		map[string]any{"entity_id": "payload-entity"},
-		map[string]any{"entity_id": "event-entity"},
+		map[string]any{"source": map[string]any{"entity_id": "source-entity"}},
 		nil,
 		nil,
 		nil,
@@ -446,6 +465,16 @@ func TestCompiledExecutionCondition_AllowsEventRoot(t *testing.T) {
 	}
 	if !ok {
 		t.Fatal("compiled condition evaluated false, want true")
+	}
+}
+
+func TestCompiledExecutionCondition_RejectsLegacyEventReceiverProjection(t *testing.T) {
+	_, err := compileExecutionCondition(`event.flow_instance == "legacy-flow"`)
+	if err == nil {
+		t.Fatal("expected event.flow_instance to fail closed")
+	}
+	if !strings.Contains(err.Error(), "event.flow_instance is unsupported") {
+		t.Fatalf("compileExecutionCondition error = %q, want event.flow_instance unsupported", err.Error())
 	}
 }
 
@@ -2805,7 +2834,11 @@ func TestExecutor_EmitIntentUsesTargetStateFlowIdentityBeforeInboundSource(t *te
 					0,
 					"",
 					"",
-					events.EnvelopeForFlowInstance(events.EnvelopeForEntityID(events.EventEnvelope{}, sourceEntityID), sourceFlowInstance),
+					events.EnvelopeForSourceRoute(events.EventEnvelope{}, events.RouteIdentity{
+						EntityID:     sourceEntityID,
+						FlowInstance: sourceFlowInstance,
+						FlowID:       "scoring",
+					}),
 					time.Time{},
 				),
 
@@ -2813,8 +2846,8 @@ func TestExecutor_EmitIntentUsesTargetStateFlowIdentityBeforeInboundSource(t *te
 					Emit: runtimecontracts.EmitSpec{
 						Event: eventType,
 						Fields: map[string]runtimecontracts.ExpressionValue{
-							"source_entity_id":     runtimecontracts.CELExpression("event.entity_id"),
-							"source_flow_instance": runtimecontracts.CELExpression("event.flow_instance"),
+							"source_entity_id":     runtimecontracts.CELExpression("event.source.entity_id"),
+							"source_flow_instance": runtimecontracts.CELExpression("event.source.flow_instance"),
 						},
 					},
 				},

--- a/internal/runtime/engine/helpers.go
+++ b/internal/runtime/engine/helpers.go
@@ -145,6 +145,11 @@ func evalExpressionValue(base BaseContext, state ExecutionState, expr runtimecon
 	case runtimecontracts.ExpressionKindLiteral:
 		return expr.Literal, true, nil
 	case runtimecontracts.ExpressionKindRef:
+		if expr.RefPath.Root == paths.RootEvent {
+			if err := events.ValidateEventContextReference(strings.Join(expr.RefPath.Segments, ".")); err != nil {
+				return nil, false, err
+			}
+		}
 		if value, ok := resolveParsedRef(base, state, expr.RefPath); ok {
 			return value, true, nil
 		}
@@ -567,6 +572,9 @@ func compileExecutionCondition(expr string) (*compiledExecutionCondition, error)
 	if expr == "" {
 		return nil, nil
 	}
+	if err := workflowexpr.ValidateEventReferences(expr); err != nil {
+		return nil, err
+	}
 	env, err := executionConditionEnv()
 	if err != nil {
 		return nil, err
@@ -644,6 +652,11 @@ func (s executionScope) resolveOperand(expr string, defaultScope executionOperan
 	}
 	parsed := paths.Parse(expr)
 	if parsed.HasExplicitRoot() {
+		if parsed.Root == paths.RootEvent {
+			if err := events.ValidateEventContextReference(strings.Join(parsed.Segments, ".")); err != nil {
+				return nil, err
+			}
+		}
 		value, ok := s.lookupExplicitRoot(parsed.Root, parsed.Segments)
 		if !ok {
 			return nil, fmt.Errorf("operand %q is unavailable in %s scope", expr, parsed.Root.String())

--- a/internal/runtime/pipeline/engine_adapter_test.go
+++ b/internal/runtime/pipeline/engine_adapter_test.go
@@ -1009,8 +1009,8 @@ func TestPipelineEngineActionRunner_MailboxWriteMaterializesIdempotentRow(t *tes
 			ItemType:     runtimecontracts.LiteralExpression("review_request"),
 			Severity:     runtimecontracts.LiteralExpression("urgent"),
 			Summary:      runtimecontracts.LiteralExpression("Review validation package"),
-			EntityID:     runtimecontracts.RefExpression("event.entity_id"),
-			FlowInstance: runtimecontracts.RefExpression("event.flow_instance"),
+			EntityID:     runtimecontracts.RefExpression("_entity.id"),
+			FlowInstance: runtimecontracts.RefExpression("_entity.flow_instance"),
 			Payload: map[string]runtimecontracts.ExpressionValue{
 				"review_kind":   runtimecontracts.RefExpression("payload.review_kind"),
 				"operator_hint": runtimecontracts.LiteralExpression("inspect_package"),
@@ -1037,6 +1037,10 @@ func TestPipelineEngineActionRunner_MailboxWriteMaterializesIdempotentRow(t *tes
 	base := values.NewContext()
 	base.Event = values.Wrap(evt.ContextMap(""))
 	base.Payload = values.Wrap(parsePayloadMap(evt.Payload()))
+	base.PlatformEntity = values.Wrap(map[string]any{
+		"id":            entityID,
+		"flow_instance": "validation/case-1",
+	})
 	execCtx := runtimeengine.ExecutionContext{
 		Base: base,
 		Request: runtimeengine.ExecutionRequest{

--- a/internal/runtime/pipeline/handler_engine_transaction_test.go
+++ b/internal/runtime/pipeline/handler_engine_transaction_test.go
@@ -2036,7 +2036,7 @@ func TestExecuteNodeContractHandlerAppliesEmitFieldsToEmittedEvent(t *testing.T)
 		Emit: runtimecontracts.EmitSpec{
 			Event: "custom.emitted",
 			Fields: map[string]runtimecontracts.ExpressionValue{
-				"summary.entity_id": runtimecontracts.CELExpression("event.entity_id"),
+				"summary.entity_id": runtimecontracts.CELExpression("_entity.id"),
 				"summary.stage":     runtimecontracts.CELExpression("_entity.current_state"),
 				"flags.ready":       runtimecontracts.CELExpression("true"),
 				"label":             runtimecontracts.CELExpression(`"done"`),

--- a/internal/runtime/pipeline/mailbox_materialization.go
+++ b/internal/runtime/pipeline/mailbox_materialization.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/division-sh/swarm/internal/events"
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
 	"github.com/division-sh/swarm/internal/runtime/core/paths"
 	"github.com/division-sh/swarm/internal/runtime/core/values"
@@ -162,15 +163,21 @@ func evalMailboxExpressionValue(base runtimeengine.BaseContext, expr runtimecont
 	case runtimecontracts.ExpressionKindLiteral:
 		return expr.Literal, true, nil
 	case runtimecontracts.ExpressionKindRef:
+		if expr.RefPath.Root == paths.RootEvent {
+			if err := events.ValidateEventContextReference(strings.Join(expr.RefPath.Segments, ".")); err != nil {
+				return nil, false, err
+			}
+		}
 		value, ok := base.Lookup(expr.RefPath)
 		return value, ok, nil
 	case runtimecontracts.ExpressionKindCEL:
 		value, err := workflowexpr.EvalValueExpressionWithOptions(expr.CEL, workflowexpr.ValueContext{
-			Entity:  base.Entity.Raw(),
-			Event:   base.Event.Raw(),
-			Payload: base.Payload.Raw(),
-			Policy:  base.Policy.Raw(),
-			FanOut:  base.FanOut.Raw(),
+			Entity:         base.Entity.Raw(),
+			PlatformEntity: base.PlatformEntity.Raw(),
+			Event:          base.Event.Raw(),
+			Payload:        base.Payload.Raw(),
+			Policy:         base.Policy.Raw(),
+			FanOut:         base.FanOut.Raw(),
 		}, workflowexpr.ValueExpressionOptions{})
 		if err != nil {
 			return nil, false, err

--- a/internal/runtime/pipeline/workflow_condition_validation.go
+++ b/internal/runtime/pipeline/workflow_condition_validation.go
@@ -77,28 +77,77 @@ func WorkflowConditionMissingRecognizedPrefix(expression string, context Workflo
 	case "true", "false", "null":
 		return false
 	}
-	for _, prefix := range workflowConditionRecognizedPrefixes(context) {
-		if strings.Contains(expression, prefix) {
+	for _, root := range workflowConditionRecognizedRoots(context) {
+		if workflowConditionContainsRecognizedRoot(expression, root) {
 			return false
 		}
 	}
 	return true
 }
 
-func workflowConditionRecognizedPrefixes(context WorkflowConditionContext) []string {
-	prefixes := []string{
-		"payload.",
-		"event.",
-		"entity.",
-		"_entity.",
-		"policy.",
-		"query_entities(",
+func workflowConditionContainsRecognizedRoot(expression, root string) bool {
+	root = strings.TrimSpace(root)
+	if root == "" {
+		return false
+	}
+	if root == "query_entities" {
+		return strings.Contains(expression, "query_entities(")
+	}
+	for pos := 0; pos < len(expression); {
+		idx := strings.Index(expression[pos:], root)
+		if idx < 0 {
+			return false
+		}
+		start := pos + idx
+		end := start + len(root)
+		pos = end
+		if start > 0 && isWorkflowConditionIdentifierPart(expression[start-1]) {
+			continue
+		}
+		if end < len(expression) && isWorkflowConditionIdentifierPart(expression[end]) {
+			continue
+		}
+		next := skipWorkflowConditionWhitespace(expression, end)
+		if next < len(expression) && (expression[next] == '.' || expression[next] == '[') {
+			return true
+		}
+	}
+	return false
+}
+
+func skipWorkflowConditionWhitespace(expression string, pos int) int {
+	for pos < len(expression) {
+		switch expression[pos] {
+		case ' ', '\t', '\n', '\r':
+			pos++
+		default:
+			return pos
+		}
+	}
+	return pos
+}
+
+func isWorkflowConditionIdentifierPart(ch byte) bool {
+	return (ch >= 'a' && ch <= 'z') ||
+		(ch >= 'A' && ch <= 'Z') ||
+		(ch >= '0' && ch <= '9') ||
+		ch == '_'
+}
+
+func workflowConditionRecognizedRoots(context WorkflowConditionContext) []string {
+	roots := []string{
+		"payload",
+		"event",
+		"entity",
+		"_entity",
+		"policy",
+		"query_entities",
 	}
 	switch context {
 	case WorkflowConditionContextOnComplete:
-		prefixes = append(prefixes, "accumulated.")
+		roots = append(roots, "accumulated")
 	case WorkflowConditionContextFilter, WorkflowConditionContextCount:
-		prefixes = append(prefixes, "accumulated.", "item.")
+		roots = append(roots, "accumulated", "item")
 	}
-	return prefixes
+	return roots
 }

--- a/internal/runtime/pipeline/workflow_expression_evaluator.go
+++ b/internal/runtime/pipeline/workflow_expression_evaluator.go
@@ -187,6 +187,9 @@ func normalizeWorkflowExpression(expression string, ctx workflowExpressionContex
 	})
 	normalized = normalizeWorkflowExpressionStringLiterals(normalized)
 	normalized = rewriteWorkflowExpressionEntityNullPresenceChecks(normalized)
+	if err := workflowexpr.ValidateEventReferences(normalized); err != nil {
+		return "", workflowExpressionContext{}, err
+	}
 	normalizedCtx := workflowExpressionContext{
 		Entity:                       cloneStringAnyMap(ctx.Entity),
 		PlatformEntity:               cloneStringAnyMap(ctx.PlatformEntity),

--- a/internal/runtime/pipeline/workflow_expression_evaluator_test.go
+++ b/internal/runtime/pipeline/workflow_expression_evaluator_test.go
@@ -54,7 +54,7 @@ func TestValidateConditionCEL_AllowsRuleConditionCanonicalRoots(t *testing.T) {
 	}{
 		{
 			name:       "payload entity policy event",
-			expression: `_entity.id != "" && payload.score >= policy.threshold && event.entity_id != ""`,
+			expression: `_entity.id != "" && payload.score >= policy.threshold && event.source.entity_id != ""`,
 		},
 		{
 			name:       "query entities",
@@ -88,6 +88,24 @@ func TestValidateConditionCEL_AllowsRuleConditionCanonicalRoots(t *testing.T) {
 			}
 			if err != nil {
 				t.Fatalf("expected rule condition %q to validate, got %v", tt.expression, err)
+			}
+		})
+	}
+}
+
+func TestValidateConditionCEL_RejectsLegacyEventReceiverProjections(t *testing.T) {
+	for _, expression := range []string{
+		`event.entity_id != ""`,
+		`event.flow_instance != ""`,
+		`query_entities(name == event.entity_id).count == 0`,
+	} {
+		t.Run(expression, func(t *testing.T) {
+			err := ValidateConditionCEL(expression, WorkflowConditionContextRule)
+			if err == nil {
+				t.Fatalf("expected %q to reject legacy event receiver projection", expression)
+			}
+			if !strings.Contains(err.Error(), "unsupported event context reference") {
+				t.Fatalf("error = %q, want unsupported event context reference", err.Error())
 			}
 		})
 	}

--- a/internal/runtime/pipeline/workflow_expression_evaluator_test.go
+++ b/internal/runtime/pipeline/workflow_expression_evaluator_test.go
@@ -98,6 +98,9 @@ func TestValidateConditionCEL_RejectsLegacyEventReceiverProjections(t *testing.T
 		`event.entity_id != ""`,
 		`event.flow_instance != ""`,
 		`query_entities(name == event.entity_id).count == 0`,
+		`event["entity_id"] != ""`,
+		`event["flow_instance"] != ""`,
+		`query_entities(name == event["entity_id"]).count == 0`,
 	} {
 		t.Run(expression, func(t *testing.T) {
 			err := ValidateConditionCEL(expression, WorkflowConditionContextRule)

--- a/internal/runtime/pipeline/workflow_expression_evaluator_test.go
+++ b/internal/runtime/pipeline/workflow_expression_evaluator_test.go
@@ -114,6 +114,56 @@ func TestValidateConditionCEL_RejectsLegacyEventReceiverProjections(t *testing.T
 	}
 }
 
+func TestWorkflowConditionMissingRecognizedPrefix_AllowsStaticBracketRoots(t *testing.T) {
+	tests := []struct {
+		name       string
+		expression string
+		context    WorkflowConditionContext
+	}{
+		{
+			name:       "event route bracket root",
+			expression: `event["source"].entity_id != ""`,
+			context:    WorkflowConditionContextRule,
+		},
+		{
+			name:       "payload bracket root",
+			expression: `payload["score"] >= 0`,
+			context:    WorkflowConditionContextRule,
+		},
+		{
+			name:       "entity bracket root",
+			expression: `entity["revision_count"] == 0`,
+			context:    WorkflowConditionContextRule,
+		},
+		{
+			name:       "filter item bracket root",
+			expression: `item["score"] >= 0`,
+			context:    WorkflowConditionContextFilter,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if WorkflowConditionMissingRecognizedPrefix(tt.expression, tt.context) {
+				t.Fatalf("WorkflowConditionMissingRecognizedPrefix(%q, %s) = true, want false", tt.expression, tt.context)
+			}
+		})
+	}
+}
+
+func TestWorkflowConditionMissingRecognizedPrefix_StillRejectsBareIdentifiers(t *testing.T) {
+	for _, expression := range []string{
+		`score >= 0`,
+		`some_event["source"].entity_id != ""`,
+		`eventual.source != ""`,
+	} {
+		t.Run(expression, func(t *testing.T) {
+			if !WorkflowConditionMissingRecognizedPrefix(expression, WorkflowConditionContextRule) {
+				t.Fatalf("WorkflowConditionMissingRecognizedPrefix(%q) = false, want true", expression)
+			}
+		})
+	}
+}
+
 func TestNormalizeWorkflowExpression_RewritesQueryEntitiesCount(t *testing.T) {
 	got, _, err := normalizeWorkflowExpression(
 		`query_entities(name == payload.name).count == 0`,

--- a/internal/runtime/pipeline/workflow_instance_activation.go
+++ b/internal/runtime/pipeline/workflow_instance_activation.go
@@ -143,6 +143,11 @@ func resolveFlowInstanceConfigValue(entry runtimecontracts.ConfigBinding, handle
 	if entry.RefPath.HasExplicitRoot() {
 		switch entry.RefPath.Root {
 		case paths.RootPayload, paths.RootEntity, paths.RootPlatformEntity, paths.RootEvent:
+			if entry.RefPath.Root == paths.RootEvent {
+				if err := events.ValidateEventContextReference(strings.Join(entry.RefPath.Segments, ".")); err != nil {
+					return nil, flowInstanceConfigRefError{Key: key, Ref: ref, Reason: err.Error()}
+				}
+			}
 			value, ok := lookupFlowInstanceConfigPath(handlerContext, entry.RefPath)
 			if !ok {
 				return nil, flowInstanceConfigRefError{Key: key, Ref: ref, Reason: "resolved empty"}

--- a/internal/runtime/pipeline/workflow_instance_activation_test.go
+++ b/internal/runtime/pipeline/workflow_instance_activation_test.go
@@ -260,7 +260,7 @@ func TestCreateFlowInstanceRejectsUnknownEventConfigRef(t *testing.T) {
 		InstanceIDPath: paths.Parse("payload.instance_id"),
 		ConfigFrom: &runtimecontracts.ConfigFromSpec{
 			Bindings: map[string]string{
-				"missing_event": "event.missing",
+				"missing_payload": "payload.missing",
 			},
 		},
 	}, testCreateFlowInstanceContext(triggerCtx))
@@ -268,7 +268,7 @@ func TestCreateFlowInstanceRejectsUnknownEventConfigRef(t *testing.T) {
 	if !errors.As(err, &refErr) {
 		t.Fatalf("createFlowInstance error = %T %v, want flowInstanceConfigRefError", err, err)
 	}
-	for _, want := range []string{`config_from "missing_event"`, `ref "event.missing"`, "resolved empty"} {
+	for _, want := range []string{`config_from "missing_payload"`, `ref "payload.missing"`, "resolved empty"} {
 		if !strings.Contains(err.Error(), want) {
 			t.Fatalf("createFlowInstance error = %v, want %q", err, want)
 		}

--- a/internal/runtime/workflowexpr/data_expression.go
+++ b/internal/runtime/workflowexpr/data_expression.go
@@ -23,7 +23,6 @@ var (
 
 	workflowExpressionEntityReferencePattern         = regexp.MustCompile(`(^|[^a-zA-Z0-9_])entity\.([a-zA-Z_][a-zA-Z0-9_.]*)`)
 	workflowExpressionPlatformEntityReferencePattern = regexp.MustCompile(`(^|[^a-zA-Z0-9_])_entity\.([a-zA-Z_][a-zA-Z0-9_.]*)`)
-	workflowExpressionEventReferencePattern          = regexp.MustCompile(`(^|[^a-zA-Z0-9_])event\.([a-zA-Z_][a-zA-Z0-9_.]*)`)
 	workflowExpressionEntityPresencePattern          = regexp.MustCompile(`["']([a-zA-Z_][a-zA-Z0-9_]*)["']\s+in\s+entity\b`)
 	workflowExpressionEntityHasPattern               = regexp.MustCompile(`\bhas\s*\(\s*entity\.([a-zA-Z_][a-zA-Z0-9_.]*)\s*\)`)
 	workflowExpressionEntityHasTernaryTruePattern    = regexp.MustCompile(`\bhas\s*\(\s*entity\.([a-zA-Z_][a-zA-Z0-9_.]*)\s*\)\s*\?\s*entity\.([a-zA-Z_][a-zA-Z0-9_.]*)`)
@@ -290,6 +289,27 @@ func isIdentifierPart(ch byte) bool {
 		ch == '_'
 }
 
+func isIdentifierStart(ch byte) bool {
+	return (ch >= 'a' && ch <= 'z') ||
+		(ch >= 'A' && ch <= 'Z') ||
+		ch == '_'
+}
+
+func isRootReferenceStart(expression string, start int) bool {
+	if start <= 0 {
+		return true
+	}
+	for pos := start - 1; pos >= 0; pos-- {
+		switch expression[pos] {
+		case ' ', '\t', '\n', '\r':
+			continue
+		default:
+			return !isIdentifierPart(expression[pos]) && expression[pos] != '.'
+		}
+	}
+	return true
+}
+
 func EntityReferences(expression string) []string {
 	expression = strings.TrimSpace(StripStringLiterals(expression))
 	if expression == "" {
@@ -345,14 +365,29 @@ func EventReferences(expression string) []string {
 	if expression == "" {
 		return nil
 	}
-	matches := workflowExpressionEventReferencePattern.FindAllStringSubmatch(expression, -1)
-	out := make([]string, 0, len(matches))
+	const eventPrefix = events.EventContextRoot + "."
+	out := []string{}
 	seen := map[string]struct{}{}
-	for _, match := range matches {
-		if len(match) < 3 {
+	for searchStart := 0; searchStart < len(expression); {
+		idx := strings.Index(expression[searchStart:], eventPrefix)
+		if idx < 0 {
+			break
+		}
+		start := searchStart + idx
+		refStart := start + len(eventPrefix)
+		searchStart = refStart
+		if !isRootReferenceStart(expression, start) {
 			continue
 		}
-		ref := strings.TrimSpace(match[2])
+		if refStart >= len(expression) || !isIdentifierStart(expression[refStart]) {
+			continue
+		}
+		refEnd := refStart + 1
+		for refEnd < len(expression) && (isIdentifierPart(expression[refEnd]) || expression[refEnd] == '.') {
+			refEnd++
+		}
+		searchStart = refEnd
+		ref := strings.Trim(strings.TrimSpace(expression[refStart:refEnd]), ".")
 		if ref == "" {
 			continue
 		}

--- a/internal/runtime/workflowexpr/data_expression.go
+++ b/internal/runtime/workflowexpr/data_expression.go
@@ -361,43 +361,166 @@ func PlatformEntityReferences(expression string) []string {
 }
 
 func EventReferences(expression string) []string {
-	expression = strings.TrimSpace(StripStringLiterals(expression))
+	refs, _ := scanEventReferences(expression)
+	return refs
+}
+
+func scanEventReferences(expression string) ([]string, []string) {
+	expression = strings.TrimSpace(expression)
 	if expression == "" {
-		return nil
+		return nil, nil
 	}
-	const eventPrefix = events.EventContextRoot + "."
 	out := []string{}
+	invalid := []string{}
 	seen := map[string]struct{}{}
-	for searchStart := 0; searchStart < len(expression); {
-		idx := strings.Index(expression[searchStart:], eventPrefix)
-		if idx < 0 {
-			break
-		}
-		start := searchStart + idx
-		refStart := start + len(eventPrefix)
-		searchStart = refStart
-		if !isRootReferenceStart(expression, start) {
-			continue
-		}
-		if refStart >= len(expression) || !isIdentifierStart(expression[refStart]) {
-			continue
-		}
-		refEnd := refStart + 1
-		for refEnd < len(expression) && (isIdentifierPart(expression[refEnd]) || expression[refEnd] == '.') {
-			refEnd++
-		}
-		searchStart = refEnd
-		ref := strings.Trim(strings.TrimSpace(expression[refStart:refEnd]), ".")
+	seenInvalid := map[string]struct{}{}
+	addRef := func(ref string) {
+		ref = strings.Trim(strings.TrimSpace(ref), ".")
 		if ref == "" {
-			continue
+			return
 		}
 		if _, ok := seen[ref]; ok {
-			continue
+			return
 		}
 		seen[ref] = struct{}{}
 		out = append(out, ref)
 	}
-	return out
+	addInvalid := func(message string) {
+		message = strings.TrimSpace(message)
+		if message == "" {
+			return
+		}
+		if _, ok := seenInvalid[message]; ok {
+			return
+		}
+		seenInvalid[message] = struct{}{}
+		invalid = append(invalid, message)
+	}
+	for pos := 0; pos < len(expression); {
+		switch expression[pos] {
+		case '\'', '"':
+			next, ok := skipQuotedString(expression, pos)
+			if ok {
+				pos = next
+				continue
+			}
+		}
+		if !strings.HasPrefix(expression[pos:], events.EventContextRoot) {
+			pos++
+			continue
+		}
+		rootStart := pos
+		rootEnd := pos + len(events.EventContextRoot)
+		pos = rootEnd
+		if !isRootReferenceStart(expression, rootStart) {
+			continue
+		}
+		if rootEnd < len(expression) && isIdentifierPart(expression[rootEnd]) {
+			continue
+		}
+		next := skipExpressionWhitespace(expression, rootEnd)
+		if next >= len(expression) || (expression[next] != '.' && expression[next] != '[') {
+			continue
+		}
+		ref, next, invalidMessage, ok := readEventReferenceAfterRoot(expression, next)
+		if invalidMessage != "" {
+			addInvalid(invalidMessage)
+		}
+		if ok {
+			addRef(ref)
+		}
+		if next > pos {
+			pos = next
+		}
+	}
+	return out, invalid
+}
+
+func readEventReferenceAfterRoot(expression string, pos int) (string, int, string, bool) {
+	segments := []string{}
+	for {
+		pos = skipExpressionWhitespace(expression, pos)
+		if pos >= len(expression) {
+			break
+		}
+		switch expression[pos] {
+		case '.':
+			pos = skipExpressionWhitespace(expression, pos+1)
+			if pos >= len(expression) || !isIdentifierStart(expression[pos]) {
+				return strings.Join(segments, "."), pos, "", len(segments) > 0
+			}
+			start := pos
+			pos++
+			for pos < len(expression) && isIdentifierPart(expression[pos]) {
+				pos++
+			}
+			segments = append(segments, expression[start:pos])
+		case '[':
+			segment, next, invalid, ok := readEventBracketSegment(expression, pos)
+			if invalid != "" {
+				return "", next, invalid, false
+			}
+			if !ok {
+				return strings.Join(segments, "."), next, "", len(segments) > 0
+			}
+			segments = append(segments, segment)
+			pos = next
+		default:
+			return strings.Join(segments, "."), pos, "", len(segments) > 0
+		}
+	}
+	return strings.Join(segments, "."), pos, "", len(segments) > 0
+}
+
+func readEventBracketSegment(expression string, pos int) (string, int, string, bool) {
+	start := pos
+	pos = skipExpressionWhitespace(expression, pos+1)
+	if pos >= len(expression) {
+		return "", len(expression), "event[...] field access is malformed", false
+	}
+	if expression[pos] != '\'' && expression[pos] != '"' {
+		return "", skipBracketExpression(expression, start), "event[...] dynamic field access is unsupported on handler expression surfaces; use literal event field names so unsupported fields fail closed", false
+	}
+	value, next, ok := readQuotedString(expression, pos)
+	if !ok {
+		return "", len(expression), "event[...] field access is malformed", false
+	}
+	next = skipExpressionWhitespace(expression, next)
+	if next >= len(expression) || expression[next] != ']' {
+		return "", next, "event[...] field access is malformed", false
+	}
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return "", next + 1, `event[""] is not a supported handler event context field`, false
+	}
+	if strings.Contains(value, ".") {
+		return "", next + 1, fmt.Sprintf("event[%q] is not a supported handler event context field; use dotted or nested bracket route fields instead", value), false
+	}
+	return value, next + 1, "", true
+}
+
+func skipBracketExpression(expression string, start int) int {
+	if start < 0 || start >= len(expression) || expression[start] != '[' {
+		return start
+	}
+	depth := 0
+	for pos := start; pos < len(expression); pos++ {
+		switch expression[pos] {
+		case '\'', '"':
+			next, ok := skipQuotedString(expression, pos)
+			if ok {
+				pos = next - 1
+			}
+		case '[':
+			depth++
+		case ']':
+			depth--
+			if depth <= 0 {
+				return pos + 1
+			}
+		}
+	}
+	return len(expression)
 }
 
 func ValidateEventReferences(expression string) error {
@@ -409,11 +532,9 @@ func ValidateEventReferences(expression string) error {
 }
 
 func InvalidEventReferences(expression string) []string {
-	refs := EventReferences(expression)
-	if len(refs) == 0 {
-		return nil
-	}
-	out := make([]string, 0, len(refs))
+	refs, invalid := scanEventReferences(expression)
+	out := make([]string, 0, len(refs)+len(invalid))
+	out = append(out, invalid...)
 	for _, ref := range refs {
 		if err := events.ValidateEventContextReference(ref); err != nil {
 			out = append(out, err.Error())

--- a/internal/runtime/workflowexpr/data_expression.go
+++ b/internal/runtime/workflowexpr/data_expression.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/division-sh/swarm/internal/events"
 	"github.com/google/cel-go/cel"
 	"github.com/google/cel-go/common/types/ref"
 )
@@ -22,6 +23,7 @@ var (
 
 	workflowExpressionEntityReferencePattern         = regexp.MustCompile(`(^|[^a-zA-Z0-9_])entity\.([a-zA-Z_][a-zA-Z0-9_.]*)`)
 	workflowExpressionPlatformEntityReferencePattern = regexp.MustCompile(`(^|[^a-zA-Z0-9_])_entity\.([a-zA-Z_][a-zA-Z0-9_.]*)`)
+	workflowExpressionEventReferencePattern          = regexp.MustCompile(`(^|[^a-zA-Z0-9_])event\.([a-zA-Z_][a-zA-Z0-9_.]*)`)
 	workflowExpressionEntityPresencePattern          = regexp.MustCompile(`["']([a-zA-Z_][a-zA-Z0-9_]*)["']\s+in\s+entity\b`)
 	workflowExpressionEntityHasPattern               = regexp.MustCompile(`\bhas\s*\(\s*entity\.([a-zA-Z_][a-zA-Z0-9_.]*)\s*\)`)
 	workflowExpressionEntityHasTernaryTruePattern    = regexp.MustCompile(`\bhas\s*\(\s*entity\.([a-zA-Z_][a-zA-Z0-9_.]*)\s*\)\s*\?\s*entity\.([a-zA-Z_][a-zA-Z0-9_.]*)`)
@@ -63,6 +65,9 @@ func ValidateValueExpressionWithOptions(expression string, opts ValueExpressionO
 	if expressionReferencesRetiredFanOutTarget(expression) {
 		return fmt.Errorf("fan_out.target is retired; use fan_out.item for per-item values or fan_out.count for fan-out count")
 	}
+	if err := ValidateEventReferences(expression); err != nil {
+		return err
+	}
 	_, issues := env.Compile(expression)
 	if issues != nil && issues.Err() != nil {
 		return issues.Err()
@@ -85,6 +90,9 @@ func EvalValueExpressionWithOptions(expression string, ctx ValueContext, opts Va
 	}
 	if expressionReferencesRetiredFanOutTarget(normalized) {
 		return nil, fmt.Errorf("fan_out.target is retired; use fan_out.item for per-item values or fan_out.count for fan-out count")
+	}
+	if err := ValidateEventReferences(normalized); err != nil {
+		return nil, err
 	}
 	if missing := MissingEntityReferences(normalized, ctx.Entity); len(missing) > 0 {
 		return nil, fmt.Errorf("entity field(s) unavailable in expression context: %s", strings.Join(missing, ", "))
@@ -329,6 +337,57 @@ func PlatformEntityReferences(expression string) []string {
 		seen[ref] = struct{}{}
 		out = append(out, ref)
 	}
+	return out
+}
+
+func EventReferences(expression string) []string {
+	expression = strings.TrimSpace(StripStringLiterals(expression))
+	if expression == "" {
+		return nil
+	}
+	matches := workflowExpressionEventReferencePattern.FindAllStringSubmatch(expression, -1)
+	out := make([]string, 0, len(matches))
+	seen := map[string]struct{}{}
+	for _, match := range matches {
+		if len(match) < 3 {
+			continue
+		}
+		ref := strings.TrimSpace(match[2])
+		if ref == "" {
+			continue
+		}
+		if _, ok := seen[ref]; ok {
+			continue
+		}
+		seen[ref] = struct{}{}
+		out = append(out, ref)
+	}
+	return out
+}
+
+func ValidateEventReferences(expression string) error {
+	invalid := InvalidEventReferences(expression)
+	if len(invalid) == 0 {
+		return nil
+	}
+	return fmt.Errorf("unsupported event context reference(s): %s", strings.Join(invalid, "; "))
+}
+
+func InvalidEventReferences(expression string) []string {
+	refs := EventReferences(expression)
+	if len(refs) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(refs))
+	for _, ref := range refs {
+		if err := events.ValidateEventContextReference(ref); err != nil {
+			out = append(out, err.Error())
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	sort.Strings(out)
 	return out
 }
 

--- a/internal/runtime/workflowexpr/data_expression_test.go
+++ b/internal/runtime/workflowexpr/data_expression_test.go
@@ -90,6 +90,10 @@ func TestValidateValueExpression_RejectsLegacyEventReceiverProjections(t *testin
 		`event.entity_id`,
 		`event.flow_instance`,
 		`event.entity_id == "ent-1"`,
+		`event["entity_id"]`,
+		`event['flow_instance']`,
+		`event["entity_id"] == "ent-1"`,
+		`event[payload.key]`,
 	} {
 		t.Run(expression, func(t *testing.T) {
 			err := ValidateValueExpression(expression)
@@ -120,6 +124,26 @@ func TestEventReferences_OnlyMatchesRootEventContext(t *testing.T) {
 			want:       []string{"flow_instance"},
 		},
 		{
+			name:       "bracket root",
+			expression: `event["entity_id"]`,
+			want:       []string{"entity_id"},
+		},
+		{
+			name:       "single-quote bracket root",
+			expression: `event['flow_instance']`,
+			want:       []string{"flow_instance"},
+		},
+		{
+			name:       "mixed route access",
+			expression: `event["source"].entity_id == event.target["flow_instance"]`,
+			want:       []string{"source.entity_id", "target.flow_instance"},
+		},
+		{
+			name:       "nested bracket route access",
+			expression: `event["source"]["flow_id"]`,
+			want:       []string{"source.flow_id"},
+		},
+		{
 			name:       "nested payload event object",
 			expression: `payload.event.entity_id`,
 			want:       nil,
@@ -132,6 +156,11 @@ func TestEventReferences_OnlyMatchesRootEventContext(t *testing.T) {
 		{
 			name:       "nested event object with spaced dot",
 			expression: `payload . event.entity_id`,
+			want:       nil,
+		},
+		{
+			name:       "nested event bracket object",
+			expression: `payload.event["entity_id"]`,
 			want:       nil,
 		},
 		{
@@ -155,12 +184,54 @@ func TestEventReferences_OnlyMatchesRootEventContext(t *testing.T) {
 	}
 }
 
+func TestValidateValueExpression_RejectsUnsupportedEventBracketRefs(t *testing.T) {
+	tests := []struct {
+		expression string
+		want       string
+	}{
+		{expression: `event["entity_id"]`, want: "event.entity_id is unsupported"},
+		{expression: `event['flow_instance']`, want: "event.flow_instance is unsupported"},
+		{expression: `event["source"]["entity_id"]["extra"]`, want: "event.source.entity_id is a route identity scalar"},
+		{expression: `event["source.entity_id"]`, want: `event["source.entity_id"] is not a supported handler event context field`},
+		{expression: `event[payload.key]`, want: "event[...] dynamic field access is unsupported"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.expression, func(t *testing.T) {
+			err := ValidateValueExpression(tt.expression)
+			if err == nil {
+				t.Fatalf("expected %q to reject unsupported event bracket ref", tt.expression)
+			}
+			if !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("error = %q, want %q", err.Error(), tt.want)
+			}
+		})
+	}
+}
+
+func TestValidateValueExpression_AllowsSupportedEventBracketRefs(t *testing.T) {
+	for _, expression := range []string{
+		`event["id"]`,
+		`event["source"]["entity_id"]`,
+		`event["source"].flow_instance`,
+		`event.target["flow_id"]`,
+		`event["target_set"]`,
+	} {
+		t.Run(expression, func(t *testing.T) {
+			if err := ValidateValueExpression(expression); err != nil {
+				t.Fatalf("ValidateValueExpression(%q) error = %v", expression, err)
+			}
+		})
+	}
+}
+
 func TestValidateValueExpression_AllowsNestedAuthorEventFields(t *testing.T) {
 	for _, expression := range []string{
 		`payload.event.entity_id`,
 		`payload.event.flow_instance == "flow-1"`,
 		`_entity.event.flow_instance`,
 		`payload.event.entity_id == event.source.entity_id`,
+		`payload.event["entity_id"]`,
+		`_entity.event["flow_instance"]`,
 	} {
 		t.Run(expression, func(t *testing.T) {
 			if err := ValidateValueExpression(expression); err != nil {

--- a/internal/runtime/workflowexpr/data_expression_test.go
+++ b/internal/runtime/workflowexpr/data_expression_test.go
@@ -103,6 +103,73 @@ func TestValidateValueExpression_RejectsLegacyEventReceiverProjections(t *testin
 	}
 }
 
+func TestEventReferences_OnlyMatchesRootEventContext(t *testing.T) {
+	tests := []struct {
+		name       string
+		expression string
+		want       []string
+	}{
+		{
+			name:       "root",
+			expression: `event.entity_id`,
+			want:       []string{"entity_id"},
+		},
+		{
+			name:       "root after delimiter",
+			expression: `(event.flow_instance == "flow-1") || payload.ok`,
+			want:       []string{"flow_instance"},
+		},
+		{
+			name:       "nested payload event object",
+			expression: `payload.event.entity_id`,
+			want:       nil,
+		},
+		{
+			name:       "nested platform entity event object",
+			expression: `_entity.event.flow_instance`,
+			want:       nil,
+		},
+		{
+			name:       "nested event object with spaced dot",
+			expression: `payload . event.entity_id`,
+			want:       nil,
+		},
+		{
+			name:       "identifier prefix",
+			expression: `some_event.entity_id`,
+			want:       nil,
+		},
+		{
+			name:       "string literal",
+			expression: `"event.entity_id"`,
+			want:       nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := EventReferences(tt.expression)
+			if strings.Join(got, ",") != strings.Join(tt.want, ",") {
+				t.Fatalf("EventReferences(%q) = %#v, want %#v", tt.expression, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestValidateValueExpression_AllowsNestedAuthorEventFields(t *testing.T) {
+	for _, expression := range []string{
+		`payload.event.entity_id`,
+		`payload.event.flow_instance == "flow-1"`,
+		`_entity.event.flow_instance`,
+		`payload.event.entity_id == event.source.entity_id`,
+	} {
+		t.Run(expression, func(t *testing.T) {
+			if err := ValidateValueExpression(expression); err != nil {
+				t.Fatalf("ValidateValueExpression(%q) error = %v", expression, err)
+			}
+		})
+	}
+}
+
 func TestEvalValueExpression_RejectsLegacyEventReceiverProjectionEvenWhenMapContainsValue(t *testing.T) {
 	_, err := EvalValueExpression(`event.entity_id`, ValueContext{
 		Event: map[string]any{"entity_id": "legacy-ent"},

--- a/internal/runtime/workflowexpr/data_expression_test.go
+++ b/internal/runtime/workflowexpr/data_expression_test.go
@@ -85,6 +85,62 @@ func TestValidateValueExpression_RejectsRetiredFanOutTarget(t *testing.T) {
 	}
 }
 
+func TestValidateValueExpression_RejectsLegacyEventReceiverProjections(t *testing.T) {
+	for _, expression := range []string{
+		`event.entity_id`,
+		`event.flow_instance`,
+		`event.entity_id == "ent-1"`,
+	} {
+		t.Run(expression, func(t *testing.T) {
+			err := ValidateValueExpression(expression)
+			if err == nil {
+				t.Fatalf("expected %q to reject legacy event receiver projection", expression)
+			}
+			if !strings.Contains(err.Error(), "unsupported event context reference") {
+				t.Fatalf("error = %q, want unsupported event context reference", err.Error())
+			}
+		})
+	}
+}
+
+func TestEvalValueExpression_RejectsLegacyEventReceiverProjectionEvenWhenMapContainsValue(t *testing.T) {
+	_, err := EvalValueExpression(`event.entity_id`, ValueContext{
+		Event: map[string]any{"entity_id": "legacy-ent"},
+	})
+	if err == nil {
+		t.Fatal("expected eval to reject legacy event receiver projection")
+	}
+	if !strings.Contains(err.Error(), "event.entity_id is unsupported") {
+		t.Fatalf("error = %q, want event.entity_id unsupported", err.Error())
+	}
+}
+
+func TestValidateValueExpression_AllowsSupportedEventContextRefs(t *testing.T) {
+	for _, expression := range []string{
+		`event.id`,
+		`event.type`,
+		`event.source.entity_id`,
+		`event.source.flow_instance`,
+		`event.source.flow_id`,
+		`event.target.entity_id`,
+		`event.target.flow_instance`,
+		`event.target.flow_id`,
+		`event.target_set`,
+		`event.source_event_id`,
+		`event.emitted_at`,
+		`event.trigger_event_type`,
+		`event.current_state`,
+		`event.run_id`,
+		`event.scope`,
+	} {
+		t.Run(expression, func(t *testing.T) {
+			if err := ValidateValueExpression(expression); err != nil {
+				t.Fatalf("ValidateValueExpression(%q) error = %v", expression, err)
+			}
+		})
+	}
+}
+
 func TestValidateValueExpression_AllowsFanOutItemAndStringLiteralTargetText(t *testing.T) {
 	tests := []string{
 		`fan_out.item.target`,

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -313,13 +313,18 @@ contract_formats:
           publish-time resolution. It is not a selector and it is not
           broadcast.
 
-        Legacy top-level event.entity_id and event.flow_instance references
-        are receiver-context projections only. They must resolve from
-        event.target when present, then from the current delivery target
-        materialized from event.target_set, then from
-        select_entity/select_or_create_entity late binding when present, then
-        from event.source. They are not a source-of-truth envelope model for
-        pin routing.
+        Top-level event.entity_id and event.flow_instance are retired
+        receiver-context projection shorthands and are unsupported on
+        handler authoring expression surfaces. Current receiver entity
+        context must be read through _entity.id and _entity.flow_instance.
+        Emitter route identity must be read through event.source.entity_id
+        and event.source.flow_instance. Singular receiver route identity
+        must be read through event.target.entity_id and
+        event.target.flow_instance. Fan-out receiver identity is represented
+        by event.target_set and by the per-recipient delivery target exposed
+        as event.target during dispatch. event.entity_id and
+        event.flow_instance are not a source-of-truth envelope model for pin
+        routing.
 
         Other envelope fields such as trigger_event_type, current_state,
         source_event_id, emitted_at, run_id, and scope remain
@@ -2126,11 +2131,15 @@ handler_specification:
         resolves_to: 'The inbound event payload. payload.X reads the X field from the triggering event''s
           JSONB payload.'
       event:
-        resolves_to: 'The runtime-owned triggering event envelope/context. event.X reads event context fields
-          such as event.id, event.type, event.entity_id, event.flow_instance, and platform-owned routing
-          envelope values supplied by the runtime.'
+        resolves_to: 'The runtime-owned triggering event envelope/context. event.X reads the supported
+          platform-populated event context fields supplied by the runtime.'
         available_in: 'rules.condition and other handler expression surfaces when the runtime supplies current
           event context. event.* is read-only handler context, not payload.'
+        read_model:
+          supported_top_level_fields: 'event.id, event.type, event.trigger_event_type, event.source_agent, event.task_id, event.source, event.target, event.target_set, event.source_event_id, event.emitted_at, event.current_state, event.run_id, and event.scope.'
+          route_identity_fields: 'event.source.entity_id, event.source.flow_instance, event.source.flow_id, event.target.entity_id, event.target.flow_instance, and event.target.flow_id are supported route identity reads. event.target_set is a list of route identities; it is not a selector and is not a top-level receiver projection.'
+          unsupported_fields: 'Top-level event.entity_id and event.flow_instance are unsupported legacy receiver-context projection shorthands. Use _entity.id / _entity.flow_instance for current receiver context, event.source.* for emitter route identity, event.target.* for singular receiver route identity, and event.target_set for fan-out recipient route identities.'
+          source_authority: 'select_entity and select_or_create_entity keys may not use event.*, _entity.*, or payload-owned envelope fields as a source-authority bypass.'
       policy:
         resolves_to: 'The merged policy context. policy.X reads the X key from the flow''s policy.yaml
           (or root policy.yaml if not overridden at flow level).'

--- a/tests/tier1-primitives/test-payload-transform-multi-source/nodes.yaml
+++ b/tests/tier1-primitives/test-payload-transform-multi-source/nodes.yaml
@@ -10,7 +10,7 @@ test-node:
         event: item.exported
         broadcast: true
         fields:
-          id: event.entity_id
+          id: _entity.id
           name: entity.name
           status: _entity.current_state
   state_schema:


### PR DESCRIPTION
## Summary

Closes #1632
Part of #1627

Retires the legacy top-level handler event receiver projections `event.entity_id` and `event.flow_instance` from supported authoring expression surfaces while keeping `event.*` as the platform-owned event context root.

## Governing refs / context

Exact spec refs updated in this PR:

- `platform-spec.yaml#contract_formats.event_schema.strict_payload_contract.envelope_split`
- `platform-spec.yaml#handler_specification.expression_context.namespaces.event`
- Adjacent preserved refs: `platform-spec.yaml#contract_formats.event_schema.strict_payload_contract.envelope_identity`, `platform-spec.yaml#handler_specification.expression_context.namespaces._entity`, and selector source-authority sections for `select_entity` / `select_or_create_entity`.

Binding issue/gate context:

- #1632 issue body.
- #1632 Pre-Implementation Coverage Audit.
- #1632 gate comment approved as first slice.
- #1627 remains the broader parent/watchlist for event envelope/root authority ambiguity.

## Semantic migration

New canonical owners:

- `internal/events/context_fields.go`: shared event authoring-field policy for supported and unsupported `event.*` authoring refs.
- `internal/events.Event.ContextMap`: runtime context-map producer, no longer emitting top-level `entity_id` / `flow_instance`.
- `platform-spec.yaml`: authoritative supported `event.*` authoring field surface and unsupported legacy projection guidance.

Old producer / reader / writer path now invalid:

- Top-level authoring refs `event.entity_id` and `event.flow_instance` are unsupported.
- Current receiver context moved to `_entity.id` / `_entity.flow_instance`.
- Route identity reads must use `event.source.*`, `event.target.*`, or `event.target_set` by meaning.

Production paths checked for surviving old behavior:

- Event context production: `Event.ContextMap`.
- Engine direct operand refs and CEL conditions.
- Pipeline workflow CEL/query normalization.
- Workflow value expressions.
- Mailbox/action expression refs and CEL.
- `create_flow_instance config_from` event refs.
- Bootverify condition and emit/action expression validation.
- Selector source-authority guards.

Migration complete for #1632: all in-repo supported authoring usages of `event.entity_id` / `event.flow_instance` are either migrated or retained only as intentional negative proof.

## Proof run

- `go test ./internal/events ./internal/runtime/workflowexpr ./internal/runtime/pipeline ./internal/runtime/engine ./internal/runtime/contracts ./internal/runtime/bootverify ./internal/apiv1 -count=1`
- `go test ./internal/runtime/cataloge2e -run 'TestTier1PrimitiveCatalogFixtures_RealRuntime/test-payload-transform-multi-source' -count=1`
- `go test ./internal/runtime/bootverify -run 'TestRun_RejectsSelectEntityByPlatformEntitySourceAuthority|TestRun_RejectsSelectEntityWithSourceEnvelopeAuthority|TestRun_RejectsSelectOrCreateEntityWithSourceEnvelopeAuthority' -count=1`
- `go test ./...`

## Scope notes

This PR does not introduce `_event.*`, does not change persisted event/readback/replay/dead-letter schema, does not alter payload/envelope admission, and does not rewrite route identity semantics. Those remain parent/watchlist territory under #1627 unless a future concrete child is opened.