### PR TITLE
[agent-b][issue #1635] Remove implicit repo dotenv authority

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,47 +1,13 @@
-# Copy to .env for local development. Plain local `swarm run --contracts ...`
-# uses SQLite at .swarm/dev.db by default and does not need this file. Do not
-# commit real secrets.
-
-# Plain loopback-only local serve uses the built-in dev token with bearer auth
-# still enabled. Set this before binding the API beyond loopback or sharing the
-# runtime with other users.
-SWARM_API_TOKEN=
-
-# Optional fallback for plain local `swarm serve` when --data and
-# workspace.data_source are not set. Do not combine this with
-# SWARM_WORKSPACE_VOLUMES_FROM.
-SWARM_WORKSPACE_DATA_SOURCE=
-
-# Workspace backend. Docker is the default isolation backend. Set host only for
-# explicit local-dev or trusted remote flows that use the supported host surface:
-# platform-managed read_file/write_file, tool-result relay, and trusted/unsafe
-# bash/native command execution when the agent contract also enables
-# native_tools.bash. Host bash is full host-user shell execution from the
-# workspace backing directory; use relative paths for workspace files, and
-# absolute paths follow the host deployment namespace and OS permissions. Host
-# mode runs commands as the host user, does not command-filter, and does not
-# provide Docker-equivalent isolation. Claude/provider host execution remains
-# unsupported/fail-closed.
-# Do not combine host mode with SWARM_WORKSPACE_VOLUMES_FROM.
-# SWARM_WORKSPACE_BACKEND=host
-# SWARM_WORKSPACE_HOST_ROOT=
-
-# Backend credentials. Set the one required by the backend you run.
-CLAUDE_CODE_OAUTH_TOKEN=
-ANTHROPIC_API_KEY=
-OPENAI_COMPATIBLE_API_KEY=
-OPENAI_API_KEY=
-
-# External Postgres opt-in. Leave unset for the local/dev SQLite default. To use
-# a user-managed Postgres service, pass `--store postgres` or set
-# `SWARM_STORE_BACKEND=postgres`, then fill in the connection details.
-# SWARM_STORE_BACKEND=postgres
-# SWARM_DB_HOST=127.0.0.1
-# SWARM_DB_PORT=5432
-# SWARM_DB_NAME=swarm
-# SWARM_DB_USER=postgres
-# SWARM_DB_PASSWORD=postgres
-# SWARM_DB_SSLMODE=disable
-
-# Optional MCP/tool-gateway token for deployments that expose that surface.
-SWARM_TOOL_GATEWAY_TOKEN=
+# non-authoritative repo dotenv example.
+#
+# Do not copy this file for normal Swarm setup. Production and user-facing
+# Swarm commands do not auto-load repo `.env` files.
+#
+# Use config.example.yaml for CLI-level non-secret settings, use
+# runtime-config.example.yaml for local runtime settings, and use
+# `swarm secrets set` / `swarm secrets check` for credentials required by
+# contracts.
+#
+# Direct shell environment variables are still supported only where an owning
+# command or subsystem explicitly documents them. Export those values in your
+# shell or process manager when needed; do not rely on repo `.env` loading.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,8 +12,10 @@ workflows.
   artifact.
 - Use [SECURITY.md](SECURITY.md) for suspected vulnerabilities. Do not report
   security issues in public GitHub issues.
-- Use [.env.example](.env.example) as the public environment template. Do not
-  commit real secrets.
+- Use [config.example.yaml](config.example.yaml) and
+  [runtime-config.example.yaml](runtime-config.example.yaml) for non-secret
+  local setup examples. Use `swarm secrets` for contract credentials. Repo
+  `.env` files are non-authoritative and are not loaded by Swarm commands.
 
 ## Local Checks
 

--- a/README.md
+++ b/README.md
@@ -103,7 +103,10 @@ Plain local runs need no database service (SQLite at `.swarm/dev.db` is the
 default) and no LLM credential (an agent-free flow boots without one). For
 Postgres, the agent workspace image, and LLM backend setup, see
 [Installation](https://docs.division.sh/installation) and
-[Configuration](https://docs.division.sh/reference/configuration).
+[Configuration](https://docs.division.sh/reference/configuration). For local
+non-secret defaults, use [`config.example.yaml`](config.example.yaml) or
+[`runtime-config.example.yaml`](runtime-config.example.yaml). For contract
+credentials, use `swarm secrets set` and validate with `swarm secrets check`.
 
 ---
 
@@ -208,7 +211,7 @@ Available in this repo too:
 
 Requirements: Go 1.23. Docker is the default workspace-isolation backend; an
 explicit host backend is available for local-dev or trusted remote work (see
-[`.env.example`](.env.example)). Host backend command execution is
+[`runtime-config.example.yaml`](runtime-config.example.yaml)). Host backend command execution is
 trusted/unsafe: native `bash` commands run as the host user when both host
 backend selection and `native_tools.bash` authorization are present. Host bash
 is full host-user shell execution from the workspace backing directory; use
@@ -217,10 +220,18 @@ deployment namespace and OS permissions. It is not command-limited or
 Docker-equivalent isolation, and Claude/provider host execution remains
 unsupported.
 Plain local `swarm run --contracts ...` uses SQLite at `.swarm/dev.db` unless
-you explicitly opt into Postgres with `SWARM_STORE_BACKEND=postgres` or
-`store.backend: postgres`. Build or pull the configured workspace image
-(`swarm-workspace:latest` by default), or set `SWARM_WORKSPACE_IMAGE` to a
-compatible image before commands that start the runtime.
+you explicitly opt into Postgres with `store.backend: postgres` in runtime
+config. Build or pull the configured workspace image (`swarm-workspace:latest`
+by default), or configure a compatible image before commands that start the
+runtime.
+
+Repo `.env` files are not loaded by Swarm commands. Keep durable settings in
+config files and put contract-required credentials in the local secrets store:
+
+```bash
+swarm secrets set sendgrid_api_key --stdin
+swarm secrets check --contracts ./contracts
+```
 
 Set `SWARM_ARTIFACT_ROOT` to a writable host path if your machine can't write
 the default `/var/lib/swarm/artifacts` (needed for `artifact_repo_commit`).

--- a/cmd/swarm/describe.go
+++ b/cmd/swarm/describe.go
@@ -67,12 +67,6 @@ func runDescribeCommandWithOutput(ctx context.Context, repo string, opts describ
 		}
 		return 2
 	}
-	if err := loadRepoDotEnv(repo); err != nil {
-		if errOut != nil {
-			fmt.Fprintf(errOut, "describe failed: load .env: %v\n", err)
-		}
-		return 1
-	}
 	resolvedPaths, err := resolveCLIContractPlatformSpecPaths(repo, cliContractPlatformSpecPathOptions{
 		ContractsPath:    opts.contractsPath,
 		PlatformSpecPath: opts.platformSpecPath,

--- a/cmd/swarm/doctor.go
+++ b/cmd/swarm/doctor.go
@@ -96,9 +96,6 @@ func runDoctorCommand(ctx context.Context, repo string, cmd *cobra.Command, opts
 	if opts.target {
 		return runDoctorTargetCommand(repo, cmd, opts)
 	}
-	if err := loadRepoDotEnv(repo); err != nil {
-		return returnCLIValidationError(cmd.ErrOrStderr(), fmt.Errorf("load .env: %w", err))
-	}
 	resolvedPaths, err := resolveCLIContractPlatformSpecPaths(repo, cliContractPlatformSpecPathOptions{
 		ContractsPath:    opts.contractsPath,
 		PlatformSpecPath: opts.platformSpecPath,

--- a/cmd/swarm/env_authority_test.go
+++ b/cmd/swarm/env_authority_test.go
@@ -133,6 +133,18 @@ func TestPublicEnvTemplateIsNonAuthoritative(t *testing.T) {
 			t.Fatalf("public docs missing replacement setup guidance %q", want)
 		}
 	}
+
+	runtimeConfig, err := os.ReadFile(filepath.Join(root, "runtime-config.example.yaml"))
+	if err != nil {
+		t.Fatalf("read runtime-config.example.yaml: %v", err)
+	}
+	runtimeConfigText := string(runtimeConfig)
+	if strings.Contains(runtimeConfigText, "\n  data_source:") {
+		t.Fatalf("runtime-config.example.yaml sets an explicit data_source that fresh repos may not have:\n%s", runtimeConfigText)
+	}
+	if !strings.Contains(runtimeConfigText, "default project data directory") {
+		t.Fatalf("runtime-config.example.yaml missing default data directory guidance:\n%s", runtimeConfigText)
+	}
 }
 
 func writeEnvAuthorityRepoWithMalformedDotEnv(t *testing.T) string {

--- a/cmd/swarm/env_authority_test.go
+++ b/cmd/swarm/env_authority_test.go
@@ -1,0 +1,178 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestServeCommandIgnoresMalformedRepoDotEnv(t *testing.T) {
+	isolateCLIAPIConfigEnv(t)
+	repo := writeEnvAuthorityRepoWithMalformedDotEnv(t)
+
+	var capturedRepo string
+	opts := defaultRootCommandOptions()
+	opts.runServe = func(_ context.Context, repo string, _ serveOptions) int {
+		capturedRepo = repo
+		return 0
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), repo, []string{"serve"}, &stdout, &stderr, opts)
+	if code != 0 {
+		t.Fatalf("serve code = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	if capturedRepo != repo {
+		t.Fatalf("serve repo = %q, want %q", capturedRepo, repo)
+	}
+	assertNoDotEnvLoadFailure(t, stdout.String()+stderr.String())
+}
+
+func TestDescribeCommandIgnoresMalformedRepoDotEnv(t *testing.T) {
+	isolateCLIAPIConfigEnv(t)
+	repo := writeEnvAuthorityRepoWithMalformedDotEnv(t)
+	contractsRoot := writeEnvAuthorityContractsFixture(t, "describe-dotenv-ignored")
+
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), repo, []string{
+		"describe",
+		"--contracts", contractsRoot,
+		"--json",
+	}, &stdout, &stderr, defaultRootCommandOptions())
+	if code != 0 {
+		t.Fatalf("describe code = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	assertNoDotEnvLoadFailure(t, stdout.String()+stderr.String())
+}
+
+func TestDoctorCommandIgnoresMalformedRepoDotEnv(t *testing.T) {
+	isolateCLIAPIConfigEnv(t)
+	configureDoctorDockerStub(t)
+	t.Setenv("CLAUDE_CODE_OAUTH_TOKEN", "")
+	t.Setenv("SWARM_TOOL_GATEWAY_URL", "")
+	t.Setenv("SWARM_TOOL_GATEWAY_CONTAINER_URL", "")
+	t.Setenv("SWARM_TOOL_GATEWAY_TOKEN", "")
+	repo := writeEnvAuthorityRepoWithMalformedDotEnv(t)
+	contractsRoot := writeEnvAuthorityContractsFixture(t, "doctor-dotenv-ignored")
+
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), repo, []string{
+		"doctor",
+		"--backend", "claude_cli",
+		"--config", writeDoctorClaudeConfig(t),
+		"--contracts", contractsRoot,
+		"--platform-spec", defaultPlatformSpecPath,
+		"--data", t.TempDir(),
+		"--api-listen-addr", "127.0.0.1:0",
+		"--mcp-listen-addr", "127.0.0.1:0",
+	}, &stdout, &stderr, defaultRootCommandOptions())
+	if code == 0 {
+		t.Fatalf("doctor unexpectedly succeeded; expected non-env preflight failure to keep proof meaningful")
+	}
+	assertNoDotEnvLoadFailure(t, stdout.String()+stderr.String())
+}
+
+func TestForkHarnessIgnoresMalformedRepoDotEnv(t *testing.T) {
+	isolateCLIAPIConfigEnv(t)
+	repo := writeEnvAuthorityRepoWithMalformedDotEnv(t)
+
+	var stdout bytes.Buffer
+	code := runForkRuntimeOwnerHarness(context.Background(), repo, []string{"--dry-run"}, &stdout)
+	if code == 0 {
+		t.Fatalf("fork unexpectedly succeeded; expected non-env runtime/store failure to keep proof meaningful")
+	}
+	assertNoDotEnvLoadFailure(t, stdout.String())
+}
+
+func TestPublicEnvTemplateIsNonAuthoritative(t *testing.T) {
+	root := repoRoot()
+	envExample, err := os.ReadFile(filepath.Join(root, ".env.example"))
+	if err != nil {
+		t.Fatalf("read .env.example: %v", err)
+	}
+	envText := string(envExample)
+	for _, forbidden := range []string{
+		"SWARM_API_TOKEN=",
+		"SWARM_TOOL_GATEWAY_TOKEN=",
+		"ANTHROPIC_API_KEY=",
+		"OPENAI_API_KEY=",
+		"POSTGRES_DSN=",
+		"SWARM_STORE_BACKEND=",
+		"SWARM_WORKSPACE_DATA_SOURCE=",
+		"SWARM_WORKSPACE_BACKEND=",
+	} {
+		if strings.Contains(envText, forbidden) {
+			t.Fatalf(".env.example still advertises authoritative assignment %q:\n%s", forbidden, envText)
+		}
+	}
+	for _, want := range []string{"non-authoritative", "config.example.yaml", "swarm secrets"} {
+		if !strings.Contains(envText, want) {
+			t.Fatalf(".env.example missing guidance %q:\n%s", want, envText)
+		}
+	}
+
+	readme, err := os.ReadFile(filepath.Join(root, "README.md"))
+	if err != nil {
+		t.Fatalf("read README.md: %v", err)
+	}
+	contributing, err := os.ReadFile(filepath.Join(root, "CONTRIBUTING.md"))
+	if err != nil {
+		t.Fatalf("read CONTRIBUTING.md: %v", err)
+	}
+	publicDocs := string(readme) + "\n" + string(contributing)
+	for _, forbidden := range []string{"Copy to .env", "public environment template"} {
+		if strings.Contains(publicDocs, forbidden) {
+			t.Fatalf("public docs still promote .env authority phrase %q", forbidden)
+		}
+	}
+	for _, want := range []string{"config.example.yaml", "swarm secrets"} {
+		if !strings.Contains(publicDocs, want) {
+			t.Fatalf("public docs missing replacement setup guidance %q", want)
+		}
+	}
+}
+
+func writeEnvAuthorityRepoWithMalformedDotEnv(t *testing.T) string {
+	t.Helper()
+	repo := t.TempDir()
+	writeWorkflowValidationFixtureFile(t, filepath.Join(repo, "go.mod"), "module dotenvignored\n")
+	writeWorkflowValidationFixtureFile(t, filepath.Join(repo, ".env"), "SWARM_API_TOKEN=repo-token\nBROKEN\n")
+	return repo
+}
+
+func writeEnvAuthorityContractsFixture(t *testing.T, name string) string {
+	t.Helper()
+	root := t.TempDir()
+	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "package.yaml"), `
+name: `+name+`
+version: "1.0.0"
+platform: ">=1.6.0"
+flows: []
+`)
+	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "schema.yaml"), `
+name: `+name+`
+initial_state: idle
+states:
+  - idle
+terminal_states:
+  - idle
+`)
+	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "policy.yaml"), "{}\n")
+	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "tools.yaml"), "{}\n")
+	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "agents.yaml"), "{}\n")
+	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "nodes.yaml"), "{}\n")
+	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "events.yaml"), "{}\n")
+	return root
+}
+
+func assertNoDotEnvLoadFailure(t testing.TB, output string) {
+	t.Helper()
+	for _, forbidden := range []string{"load .env", "expected KEY=VALUE"} {
+		if strings.Contains(output, forbidden) {
+			t.Fatalf("output still shows repo .env parsing failure %q:\n%s", forbidden, output)
+		}
+	}
+}

--- a/cmd/swarm/main.go
+++ b/cmd/swarm/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"bufio"
 	"context"
 	"database/sql"
 	"encoding/json"
@@ -744,11 +743,6 @@ func runServeRuntime(ctx context.Context, repo string, opts serveOptions) int {
 	runtimeInstanceID := uuid.NewString()
 	reporter := newServeBootReporter(opts.Verbose, opts.Output)
 	reporter.emit(1, "process_start", "ok", "")
-	if err := loadRepoDotEnv(repo); err != nil {
-		reporter.emit(2, "config_load", "FAILED", err.Error())
-		log.Printf("load .env: %v", err)
-		return 1
-	}
 	apiAuth := apiv1.ResolveAuthTokensFromEnvironment()
 	if err := validateServeAPIAuthBinding(opts.APIListenAddr, apiAuth); err != nil {
 		reporter.emit(2, "config_load", "FAILED", err.Error())
@@ -1264,12 +1258,6 @@ func runVerifyCommandWithOutput(ctx context.Context, repo string, opts verifyCom
 		}
 		return 2
 	}
-	if err := loadRepoDotEnv(repo); err != nil {
-		if errOut != nil {
-			fmt.Fprintf(errOut, "verify failed: load .env: %v\n", err)
-		}
-		return 1
-	}
 	resolvedPaths, err := resolveCLIContractPlatformSpecPaths(repo, cliContractPlatformSpecPathOptions{
 		ContractsPath:    opts.contractsPath,
 		PlatformSpecPath: opts.platformSpecPath,
@@ -1486,12 +1474,6 @@ func runForkRuntimeOwnerHarness(ctx context.Context, repo string, args []string,
 			fmt.Fprintln(out, "fork failed: --activate targets --run <fork_run_id> and does not accept --at")
 		}
 		return 2
-	}
-	if err := loadRepoDotEnv(repo); err != nil {
-		if out != nil {
-			fmt.Fprintf(out, "fork failed: load .env: %v\n", err)
-		}
-		return 1
 	}
 	cfgResult, err := loadRuntimeConfigWithOptions(runtimeConfigLoadOptions{
 		RepoRoot:        repo,
@@ -2414,67 +2396,6 @@ func envInt(key string, fallback int) int {
 		return fallback
 	}
 	return value
-}
-
-func loadRepoDotEnv(repo string) error {
-	repo = strings.TrimSpace(repo)
-	if repo == "" {
-		return nil
-	}
-	path := filepath.Join(repo, ".env")
-	return loadDotEnvFile(path)
-}
-
-func loadDotEnvFile(path string) error {
-	path = strings.TrimSpace(path)
-	if path == "" {
-		return nil
-	}
-	file, err := os.Open(path)
-	if err != nil {
-		if errors.Is(err, os.ErrNotExist) {
-			return nil
-		}
-		return err
-	}
-	defer file.Close()
-
-	scanner := bufio.NewScanner(file)
-	for lineNo := 1; scanner.Scan(); lineNo++ {
-		line := strings.TrimSpace(scanner.Text())
-		if line == "" || strings.HasPrefix(line, "#") {
-			continue
-		}
-		if strings.HasPrefix(line, "export ") {
-			line = strings.TrimSpace(strings.TrimPrefix(line, "export "))
-		}
-		key, value, ok := strings.Cut(line, "=")
-		if !ok {
-			return fmt.Errorf("%s:%d: expected KEY=VALUE", path, lineNo)
-		}
-		key = strings.TrimSpace(key)
-		if key == "" {
-			return fmt.Errorf("%s:%d: empty env key", path, lineNo)
-		}
-		if _, exists := os.LookupEnv(key); exists {
-			continue
-		}
-		value = strings.TrimSpace(value)
-		if unquoted, err := strconv.Unquote(value); err == nil {
-			value = unquoted
-		} else if len(value) >= 2 {
-			if (strings.HasPrefix(value, "'") && strings.HasSuffix(value, "'")) || (strings.HasPrefix(value, "\"") && strings.HasSuffix(value, "\"")) {
-				value = value[1 : len(value)-1]
-			}
-		}
-		if err := os.Setenv(key, value); err != nil {
-			return fmt.Errorf("%s:%d: set %s: %w", path, lineNo, key, err)
-		}
-	}
-	if err := scanner.Err(); err != nil {
-		return err
-	}
-	return nil
 }
 
 func envDuration(key string, fallback time.Duration) time.Duration {

--- a/cmd/swarm/main_test.go
+++ b/cmd/swarm/main_test.go
@@ -1378,42 +1378,41 @@ func TestAssetCommandsDiscoverRepoRootAtExecution(t *testing.T) {
 	}
 }
 
-func TestVerifyCommandLoadsRepoDotEnvAfterLazyRepoDiscovery(t *testing.T) {
+func TestVerifyCommandIgnoresRepoDotEnvAfterLazyRepoDiscovery(t *testing.T) {
 	isolateCLIAPIConfigEnv(t)
 	_ = os.Unsetenv("SWARM_CONTRACTS_PATH")
 	repo := t.TempDir()
 	writeWorkflowValidationFixtureFile(t, filepath.Join(repo, "go.mod"), "module testrepo\n")
-	contractsRoot := t.TempDir()
-	writeWorkflowValidationFixtureFile(t, filepath.Join(contractsRoot, "package.yaml"), `
-name: dot-env-contracts
-version: "1.0.0"
-platform: ">=1.6.0"
-`)
-	writeWorkflowValidationFixtureFile(t, filepath.Join(contractsRoot, "schema.yaml"), "name: dot-env-contracts\n")
-	writeWorkflowValidationFixtureFile(t, filepath.Join(contractsRoot, "policy.yaml"), "{}\n")
-	writeWorkflowValidationFixtureFile(t, filepath.Join(contractsRoot, "tools.yaml"), "{}\n")
-	writeWorkflowValidationFixtureFile(t, filepath.Join(contractsRoot, "agents.yaml"), "{}\n")
-	writeWorkflowValidationFixtureFile(t, filepath.Join(contractsRoot, "nodes.yaml"), "{}\n")
-	writeWorkflowValidationFixtureFile(t, filepath.Join(contractsRoot, "events.yaml"), "{}\n")
-	writeWorkflowValidationFixtureFile(t, filepath.Join(repo, ".env"), "SWARM_CONTRACTS_PATH="+contractsRoot+"\n")
+	contractsRoot := writeEnvAuthorityContractsFixture(t, "dot-env-contracts")
+	writeWorkflowValidationFixtureFile(t, filepath.Join(repo, ".env"), "SWARM_CONTRACTS_PATH="+contractsRoot+"\nBROKEN\n")
 	chdirForTest(t, repo)
 
 	var stdout, stderr bytes.Buffer
 	code := executeRootCommand(context.Background(), "", []string{"verify"}, &stdout, &stderr)
+	if code == 0 {
+		t.Fatalf("verify unexpectedly consumed contracts path from repo .env: stdout=%s stderr=%s", stdout.String(), stderr.String())
+	}
+	if strings.Contains(stdout.String()+stderr.String(), contractsRoot) {
+		t.Fatalf("verify output referenced repo .env contracts path stdout=%s stderr=%s", stdout.String(), stderr.String())
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	code = executeRootCommand(context.Background(), "", []string{"verify", "--contracts", contractsRoot}, &stdout, &stderr)
 	if code != 0 {
-		t.Fatalf("verify code = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+		t.Fatalf("verify with explicit contracts code = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
 	}
 	if !strings.Contains(stdout.String(), "verify ok: contracts="+contractsRoot) {
-		t.Fatalf("verify did not consume contracts path from repo .env:\n%s", stdout.String())
+		t.Fatalf("verify explicit contracts output missing success marker:\n%s", stdout.String())
 	}
 }
 
-func TestLocalRunDiscoversRepoRootBeforeDotEnvAndServe(t *testing.T) {
+func TestLocalRunDiscoversRepoRootWithoutLoadingDotEnv(t *testing.T) {
 	isolateCLIAPIConfigEnv(t)
 	_ = os.Unsetenv("SWARM_API_TOKEN")
 	repo := t.TempDir()
 	writeWorkflowValidationFixtureFile(t, filepath.Join(repo, "go.mod"), "module testrepo\n")
-	writeWorkflowValidationFixtureFile(t, filepath.Join(repo, ".env"), "SWARM_API_TOKEN=test-token\n")
+	writeWorkflowValidationFixtureFile(t, filepath.Join(repo, ".env"), "SWARM_API_TOKEN=test-token\nBROKEN\n")
 	payloadPath := filepath.Join(t.TempDir(), "payload.json")
 	writeWorkflowValidationFixtureFile(t, payloadPath, "{}\n")
 	chdirForTest(t, repo)
@@ -1437,6 +1436,9 @@ func TestLocalRunDiscoversRepoRootBeforeDotEnvAndServe(t *testing.T) {
 	_ = runRunCommand(context.Background(), "", &stdout, &stderr, opts)
 	if capturedRepo != repo {
 		t.Fatalf("local run serve repo = %q, want discovered repo %q; stderr=%s stdout=%s", capturedRepo, repo, stderr.String(), stdout.String())
+	}
+	if got := os.Getenv("SWARM_API_TOKEN"); got != "" {
+		t.Fatalf("local run loaded SWARM_API_TOKEN from repo .env: %q", got)
 	}
 }
 
@@ -9026,47 +9028,6 @@ func TestLoadRunStatusReport_ProjectsScoringOutcomeStall(t *testing.T) {
 		if strings.Contains(heuristic, "run appears settled after scoring started") {
 			t.Fatalf("unexpected scoring heuristic fallback: %#v", report.Heuristics)
 		}
-	}
-}
-
-func TestLoadDotEnvFileSetsMissingVarsOnly(t *testing.T) {
-	dir := t.TempDir()
-	path := filepath.Join(dir, ".env")
-	if err := os.WriteFile(path, []byte("ALPHA=one\nBETA=\"two words\"\nexport GAMMA='three'\n"), 0o644); err != nil {
-		t.Fatalf("WriteFile: %v", err)
-	}
-	t.Setenv("ALPHA", "shell")
-
-	if err := loadDotEnvFile(path); err != nil {
-		t.Fatalf("loadDotEnvFile: %v", err)
-	}
-
-	if got := os.Getenv("ALPHA"); got != "shell" {
-		t.Fatalf("ALPHA = %q, want shell override", got)
-	}
-	if got := os.Getenv("BETA"); got != "two words" {
-		t.Fatalf("BETA = %q", got)
-	}
-	if got := os.Getenv("GAMMA"); got != "three" {
-		t.Fatalf("GAMMA = %q", got)
-	}
-}
-
-func TestLoadDotEnvFileMissingIsNoop(t *testing.T) {
-	if err := loadDotEnvFile(filepath.Join(t.TempDir(), ".env")); err != nil {
-		t.Fatalf("loadDotEnvFile: %v", err)
-	}
-}
-
-func TestLoadDotEnvFileRejectsMalformedLine(t *testing.T) {
-	dir := t.TempDir()
-	path := filepath.Join(dir, ".env")
-	if err := os.WriteFile(path, []byte("BROKEN\n"), 0o644); err != nil {
-		t.Fatalf("WriteFile: %v", err)
-	}
-	err := loadDotEnvFile(path)
-	if err == nil || !strings.Contains(err.Error(), "expected KEY=VALUE") {
-		t.Fatalf("loadDotEnvFile error = %v", err)
 	}
 }
 

--- a/cmd/swarm/run_command.go
+++ b/cmd/swarm/run_command.go
@@ -147,10 +147,6 @@ func runRunCommand(ctx context.Context, repo string, out, errOut io.Writer, opts
 	var stopLocal func()
 	if strings.TrimSpace(opts.connectURL) == "" {
 		repo = assetCommandRepoRoot(repo)
-		if err := loadRepoDotEnv(repo); err != nil {
-			fmt.Fprintf(errOut, "load .env: %v\n", err)
-			return commandExitError{code: 3}
-		}
 		if _, err := newCLIAPIClient(opts.apiOptions); err != nil {
 			fmt.Fprintln(errOut, err)
 			return commandExitError{code: runCommandErrorExitCode(err)}

--- a/cmd/swarm/secrets.go
+++ b/cmd/swarm/secrets.go
@@ -89,9 +89,6 @@ func newSecretsSetCommand(ctx context.Context, repo string) *cobra.Command {
 			return fmt.Errorf("secret key is required")
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if err := loadRepoDotEnv(assetCommandRepoRoot(repo)); err != nil {
-				return returnSecretsRuntimeError(cmd.ErrOrStderr(), fmt.Errorf("load .env: %w", err))
-			}
 			value, err := readSecretValue(cmd.InOrStdin(), cmd.ErrOrStderr(), stdin)
 			if err != nil {
 				return returnCLIValidationError(cmd.ErrOrStderr(), err)
@@ -132,9 +129,6 @@ func newSecretsListCommand(ctx context.Context, repo string) *cobra.Command {
 			if opts.source != "" && opts.source != runtimecredentials.SourceEnv && opts.source != runtimecredentials.SourceFile {
 				return returnCLIValidationError(cmd.ErrOrStderr(), fmt.Errorf("--source must be env or file"))
 			}
-			if err := loadRepoDotEnv(assetCommandRepoRoot(repo)); err != nil {
-				return returnSecretsRuntimeError(cmd.ErrOrStderr(), fmt.Errorf("load .env: %w", err))
-			}
 			store, err := buildCredentialStore()
 			if err != nil {
 				return returnSecretsRuntimeError(cmd.ErrOrStderr(), fmt.Errorf("configure credential store: %w", err))
@@ -172,9 +166,6 @@ func newSecretsCheckCommand(ctx context.Context, repo string) *cobra.Command {
 		Short: "Validate required Swarm secrets are configured.",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if err := loadRepoDotEnv(assetCommandRepoRoot(repo)); err != nil {
-				return returnSecretsRuntimeError(cmd.ErrOrStderr(), fmt.Errorf("load .env: %w", err))
-			}
 			store, err := buildCredentialStore()
 			if err != nil {
 				return returnSecretsRuntimeError(cmd.ErrOrStderr(), fmt.Errorf("configure credential store: %w", err))
@@ -218,9 +209,6 @@ func newSecretsRemoveCommand(ctx context.Context, repo string) *cobra.Command {
 		Short:   "Remove a secret from the local file tier.",
 		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if err := loadRepoDotEnv(assetCommandRepoRoot(repo)); err != nil {
-				return returnSecretsRuntimeError(cmd.ErrOrStderr(), fmt.Errorf("load .env: %w", err))
-			}
 			store, err := buildCredentialStore()
 			if err != nil {
 				return returnSecretsRuntimeError(cmd.ErrOrStderr(), fmt.Errorf("configure credential store: %w", err))

--- a/cmd/swarm/secrets_test.go
+++ b/cmd/swarm/secrets_test.go
@@ -127,6 +127,71 @@ func TestSecretsListShowsEnvShadowingAndRemoveKeepsEnvEffective(t *testing.T) {
 	}
 }
 
+func TestSecretsCommandsIgnoreRepoDotEnv(t *testing.T) {
+	isolateCLIAPIConfigEnv(t)
+	unsetSecretEnvForTest(t, "SENDGRID_API_KEY")
+	repo := t.TempDir()
+	writeWorkflowValidationFixtureFile(t, filepath.Join(repo, "go.mod"), "module secrets-test\n")
+	writeWorkflowValidationFixtureFile(t, filepath.Join(repo, ".env"), "SENDGRID_API_KEY=repo-env-secret\nBROKEN\n")
+	contractsRoot := writeSecretsCommandContractsFixture(t)
+	credentialsPath := filepath.Join(t.TempDir(), "credentials.json")
+	t.Setenv("SWARM_CREDENTIALS_FILE", credentialsPath)
+
+	code, stdout, stderr := executeRootCommandWithInput(context.Background(), repo, []string{"secrets", "check", "--contracts", contractsRoot, "--json"}, "")
+	if code != cliExitRuntime {
+		t.Fatalf("initial check code = %d stdout=%s stderr=%s", code, stdout, stderr)
+	}
+	assertNoDotEnvLoadFailure(t, stdout+stderr)
+	var missing secretsCheckResult
+	if err := json.Unmarshal([]byte(stdout), &missing); err != nil {
+		t.Fatalf("decode check json: %v\n%s", err, stdout)
+	}
+	if missing.OK || len(missing.Missing) != 1 || missing.Missing[0].Key != "sendgrid_api_key" {
+		t.Fatalf("repo .env unexpectedly satisfied secret requirement: %+v", missing)
+	}
+
+	code, stdout, stderr = executeRootCommandWithInput(context.Background(), repo, []string{"secrets", "set", "sendgrid_api_key", "--stdin"}, "file-secret-token\n")
+	if code != 0 {
+		t.Fatalf("set code = %d stdout=%s stderr=%s", code, stdout, stderr)
+	}
+	assertNoDotEnvLoadFailure(t, stdout+stderr)
+
+	code, stdout, stderr = executeRootCommandWithInput(context.Background(), repo, []string{"secrets", "list", "--contracts", contractsRoot, "--json"}, "")
+	if code != 0 {
+		t.Fatalf("list code = %d stdout=%s stderr=%s", code, stdout, stderr)
+	}
+	assertNoDotEnvLoadFailure(t, stdout+stderr)
+	var listed secretsListResult
+	if err := json.Unmarshal([]byte(stdout), &listed); err != nil {
+		t.Fatalf("decode list json: %v\n%s", err, stdout)
+	}
+	if len(listed.Secrets) != 1 {
+		t.Fatalf("list result = %+v", listed)
+	}
+	record := listed.Secrets[0]
+	if record.Source != "file" || record.Shadowed || !record.Writable || !record.Present {
+		t.Fatalf("repo .env unexpectedly supplied or shadowed file-tier secret: %+v", record)
+	}
+	if strings.Contains(stdout+stderr, "repo-env-secret") || strings.Contains(stdout+stderr, "file-secret-token") {
+		t.Fatalf("secrets output leaked secret value stdout=%q stderr=%q", stdout, stderr)
+	}
+}
+
+func unsetSecretEnvForTest(t *testing.T, key string) {
+	t.Helper()
+	old, ok := os.LookupEnv(key)
+	if err := os.Unsetenv(key); err != nil {
+		t.Fatalf("unset %s: %v", key, err)
+	}
+	t.Cleanup(func() {
+		if ok {
+			_ = os.Setenv(key, old)
+			return
+		}
+		_ = os.Unsetenv(key)
+	})
+}
+
 func TestSecretsSetRejectsPlaintextArgvValues(t *testing.T) {
 	isolateCLIAPIConfigEnv(t)
 	repo := t.TempDir()

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -1,0 +1,13 @@
+# Example Swarm CLI config.
+#
+# Copy this shape to ${XDG_CONFIG_HOME:-$HOME/.config}/swarm/config.yaml, or
+# point SWARM_CONFIG at a file with this shape when bootstrap config discovery
+# is required. Keep secrets out of this file.
+
+# api_server: http://127.0.0.1:8081
+# api_token_file: /path/to/swarm-api-token
+# swarm_dir: ~/.swarm
+# contracts_path: ./contracts
+# platform_spec_path: ./platform-spec.yaml
+# serve_api_listen_addr: 127.0.0.1:8081
+# serve_mcp_listen_addr: 127.0.0.1:8082

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -12029,6 +12029,45 @@ cli_specification:
       - 'API-backed command target resolver consumes context descriptors through #1614 only.'
       - 'No runtime store/data path migration or `swarm run` behavior change in #1613; #1615 owns that behavior.'
       - 'No unix socket dialing policy in #1613; #1576 owns actual IPC transport behavior.'
+    repo_dotenv_source_authority:
+      promoted_by: '#1635'
+      implementation_status: implemented
+      canonical_owner: platform-spec.yaml#cli_specification.foundations.repo_dotenv_source_authority
+      scope: >
+        Merge-bearing authority for repository `.env` files as local CLI command input. Repo `.env` files are
+        non-authoritative for Swarm production and user-facing command startup. Commands MUST NOT implicitly read,
+        parse, or import repo `.env` values into the process environment. Public repository templates and docs MUST
+        present config files for durable non-secret settings and `swarm secrets`/token files for credentials rather
+        than teaching `.env` as normal Swarm setup.
+      applies_to:
+      - '`swarm serve` startup.'
+      - 'local foreground `swarm run` startup.'
+      - '`swarm verify` local contract validation.'
+      - '`swarm fork` runtime-owner harness.'
+      - 'default `swarm doctor` diagnostics.'
+      - '`swarm describe` local authoring view rendering.'
+      - '`swarm secrets set`, `swarm secrets list`, `swarm secrets check`, and `swarm secrets rm`.'
+      source_rule: >
+        A repo `.env` file MAY exist for external tools, but Swarm commands treat it as ordinary project data and
+        never as an implicit configuration, secret, target, path, or runtime-binding source. Malformed repo `.env`
+        contents MUST NOT fail Swarm commands unless a future explicitly gated env-file feature names the file as
+        command input.
+      explicit_process_env_boundary: >
+        This owner does not deauthorize process environment variables that are already present when Swarm starts.
+        Direct environment sources such as `SWARM_API_SERVER`, `SWARM_API_TOKEN`, `SWARM_CONTRACTS_PATH`, store and
+        database variables, provider credential variables, workspace/bootstrap variables, and final-boundary tooling
+        variables remain governed by their specific source-authority owners and #1600 sibling issues.
+      replacement_setup:
+        non_secret_settings: config.example.yaml and runtime-config.example.yaml guidance
+        credentials: '`swarm secrets set|check|list|rm` and token-file sources where explicitly owned'
+      rejected_sources:
+        repo_dotenv_autoload: >
+          Not promoted. Implicit repo dotenv loading is hidden mutable source authority and can shadow config,
+          secrets, contexts, token files, and runtime bindings.
+      implementation_boundaries:
+      - 'No direct process-env precedence migration is implied by #1635; #1636-#1640 own those sibling migrations.'
+      - 'No provider credential migration to the secrets store is implied by #1635; #1638 owns that migration.'
+      - 'No explicit `--env-file` or dotenv compatibility shim is promoted.'
     api_connection_auth_config_precedence:
       promoted_by: '#844'
       loopback_default_implemented_by: '#1124'

--- a/runtime-config.example.yaml
+++ b/runtime-config.example.yaml
@@ -15,7 +15,9 @@ store:
 
 workspace:
   backend: docker
-  data_source: .swarm/data
+  # Omit data_source for the default project data directory. Swarm can create
+  # that default path during local startup. Set data_source only when pointing
+  # at an existing, operator-managed directory.
 
 llm:
   backend: claude_cli

--- a/runtime-config.example.yaml
+++ b/runtime-config.example.yaml
@@ -1,0 +1,31 @@
+# Example Swarm runtime config for `swarm serve --config` or local
+# `swarm run --config` startup.
+#
+# This file uses the runtime-config shape, which is separate from the shared
+# CLI config shape in config.example.yaml. Keep credentials in `swarm secrets`
+# or explicit token files, not in this file.
+
+runtime:
+  recovery_on_startup: true
+
+store:
+  backend: sqlite
+  sqlite:
+    path: .swarm/stores/dev.db
+
+workspace:
+  backend: docker
+  data_source: .swarm/data
+
+llm:
+  backend: claude_cli
+  session:
+    lock_ttl: 10s
+    rotate_after_turns: 40
+    rotate_on_parse_failures: 3
+  claude_cli:
+    command: claude
+    timeout: 2m
+    output_format: stream-json
+    retries: 1
+    no_session_persistence: false


### PR DESCRIPTION
## Summary

Closes #1635.

This PR removes implicit repository `.env` loading from the approved #1635 command surfaces and replaces `.env.example` happy-path setup guidance with config examples plus `swarm secrets` guidance. Parent #1600 remains open for direct process-env source-authority migrations tracked by #1636-#1640.

## Governing refs / context

- Pre-audit: https://github.com/division-sh/swarm/issues/1635#issuecomment-4872167137
- Gate approval: https://github.com/division-sh/swarm/issues/1635#issuecomment-4872184402
- Exact spec update added in this PR: `platform-spec.yaml#cli_specification.foundations.repo_dotenv_source_authority`
- Adjacent spec refs retained as siblings: `api_connection_auth_config_precedence`, `contract_platform_spec_path_resolution`, `tool_model.credential_store`, and `cli_specification.command_catalog.secrets`

## Semantic migration

- New canonical owner: `platform-spec.yaml#cli_specification.foundations.repo_dotenv_source_authority`.
- Old producer/interpreter path now invalid: implicit `loadRepoDotEnv` / `loadDotEnvFile` ingestion of repo `.env` into process env.
- Old public guidance now invalid: `.env.example` as normal persistent setup or secret storage template.
- Production paths checked and migrated: `serve`, local foreground `run`, `verify`, `fork` runtime-owner harness, default `doctor`, `describe`, and `secrets set/list/check/rm`.
- Migration completeness: complete for implicit repo `.env` authority and public `.env` happy-path guidance. Direct process env precedence is intentionally unchanged and remains tracked by #1600 / #1636-#1640.

## Tests

- `go test ./cmd/swarm -run 'Test(VerifyCommandIgnoresRepoDotEnvAfterLazyRepoDiscovery|LocalRunDiscoversRepoRootWithoutLoadingDotEnv|ServeCommandIgnoresMalformedRepoDotEnv|DescribeCommandIgnoresMalformedRepoDotEnv|DoctorCommandIgnoresMalformedRepoDotEnv|ForkHarnessIgnoresMalformedRepoDotEnv|PublicEnvTemplateIsNonAuthoritative|SecretsCommandsIgnoreRepoDotEnv)'`
- `go test ./cmd/swarm`
- `go test ./...`
- `go run ./cmd/swarm-openrpc-gen --check`
- `rg -n "loadRepoDotEnv|loadDotEnvFile" . --glob '!**/*_test.go' --glob '!vendor/**' --glob '!node_modules/**'` returned no matches
- `rg -n "Copy to \.env|public environment template|SWARM_API_TOKEN=|ANTHROPIC_API_KEY=|OPENAI_API_KEY=|SWARM_TOOL_GATEWAY_TOKEN=|POSTGRES_DSN=|SWARM_STORE_BACKEND=|SWARM_WORKSPACE_DATA_SOURCE=" .env.example README.md CONTRIBUTING.md config.example.yaml runtime-config.example.yaml` returned no matches