### PR TITLE
[agent-f][issue #1457] Add LLM provider admission limits

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -88,20 +88,29 @@ func (w WorkspaceConfig) BackendConfigured() bool {
 }
 
 type LLMConfig struct {
-	Backend          string                    `yaml:"backend"`
-	RuntimeMode      string                    `yaml:"runtime_mode"`
-	Models           llmselection.ModelAliases `yaml:"models"`
-	Session          LLMSessionConfig          `yaml:"session"`
-	ClaudeAPI        ClaudeAPIConfig           `yaml:"claude_api"`
-	ClaudeCLI        ClaudeCLIConfig           `yaml:"claude_cli"`
-	OpenAICompatible OpenAICompatibleConfig    `yaml:"openai_compatible"`
-	OpenAIResponses  OpenAIResponsesConfig     `yaml:"openai_responses"`
+	Backend          string                            `yaml:"backend"`
+	RuntimeMode      string                            `yaml:"runtime_mode"`
+	Models           llmselection.ModelAliases         `yaml:"models"`
+	Session          LLMSessionConfig                  `yaml:"session"`
+	ProviderLimits   map[string]LLMProviderLimitPolicy `yaml:"provider_limits"`
+	ClaudeAPI        ClaudeAPIConfig                   `yaml:"claude_api"`
+	ClaudeCLI        ClaudeCLIConfig                   `yaml:"claude_cli"`
+	OpenAICompatible OpenAICompatibleConfig            `yaml:"openai_compatible"`
+	OpenAIResponses  OpenAIResponsesConfig             `yaml:"openai_responses"`
 }
 
 type LLMSessionConfig struct {
 	LockTTL               time.Duration `yaml:"lock_ttl"`
 	RotateAfterTurns      int           `yaml:"rotate_after_turns"`
 	RotateOnParseFailures int           `yaml:"rotate_on_parse_failures"`
+}
+
+type LLMProviderLimitPolicy struct {
+	RateLimit             string                            `yaml:"rate_limit"`
+	RateLimitMaxWait      string                            `yaml:"rate_limit_max_wait"`
+	MaxConcurrency        int                               `yaml:"max_concurrency"`
+	MaxConcurrencyMaxWait string                            `yaml:"max_concurrency_max_wait"`
+	Models                map[string]LLMProviderLimitPolicy `yaml:"models"`
 }
 
 type ClaudeAPIConfig struct {
@@ -179,6 +188,9 @@ func (c *Config) validate(backendOverride string) error {
 		return err
 	}
 	if err := llmselection.ValidateModelAliases(c.LLM.Models); err != nil {
+		return err
+	}
+	if err := c.validateLLMProviderLimits(); err != nil {
 		return err
 	}
 	profile, err := c.LLMBackendProfile()

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -286,6 +286,95 @@ func TestValidate_RejectsUnsupportedRuntimeControls(t *testing.T) {
 	}
 }
 
+func TestValidateLLMProviderLimits(t *testing.T) {
+	base := func() *Config {
+		return &Config{
+			LLM: LLMConfig{
+				Backend: "anthropic",
+				Session: LLMSessionConfig{
+					LockTTL:               time.Second,
+					RotateAfterTurns:      1,
+					RotateOnParseFailures: 1,
+				},
+			},
+		}
+	}
+	tests := []struct {
+		name    string
+		limits  map[string]LLMProviderLimitPolicy
+		wantErr string
+	}{
+		{
+			name: "valid profile and model limits",
+			limits: map[string]LLMProviderLimitPolicy{
+				"anthropic": {
+					RateLimit:             "10/s",
+					RateLimitMaxWait:      "1s",
+					MaxConcurrency:        2,
+					MaxConcurrencyMaxWait: "0s",
+					Models: map[string]LLMProviderLimitPolicy{
+						"regular": {
+							RateLimit:        "20/m",
+							RateLimitMaxWait: "5s",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "default no limit",
+		},
+		{
+			name: "missing rate wait",
+			limits: map[string]LLMProviderLimitPolicy{
+				"anthropic": {RateLimit: "1/s"},
+			},
+			wantErr: "rate_limit requires rate_limit_max_wait",
+		},
+		{
+			name: "missing concurrency wait",
+			limits: map[string]LLMProviderLimitPolicy{
+				"anthropic": {MaxConcurrency: 1},
+			},
+			wantErr: "max_concurrency requires max_concurrency_max_wait",
+		},
+		{
+			name: "reserved profile rejected",
+			limits: map[string]LLMProviderLimitPolicy{
+				"mock": {RateLimit: "1/s", RateLimitMaxWait: "1s"},
+			},
+			wantErr: "reserved",
+		},
+		{
+			name: "model nested models rejected",
+			limits: map[string]LLMProviderLimitPolicy{
+				"anthropic": {
+					Models: map[string]LLMProviderLimitPolicy{
+						"regular": {Models: map[string]LLMProviderLimitPolicy{"cheap": {}}},
+					},
+				},
+			},
+			wantErr: "nested model limits are not supported",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := base()
+			cfg.LLM.ProviderLimits = tc.limits
+			err := cfg.Validate()
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Fatalf("Validate: %v", err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("Validate error = %v, want %q", err, tc.wantErr)
+			}
+		})
+	}
+}
+
 func TestLoad_RejectsUnsupportedShardingExtension(t *testing.T) {
 	cfgText := strings.Join([]string{
 		"llm:",

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -346,6 +346,24 @@ func TestValidateLLMProviderLimits(t *testing.T) {
 			wantErr: "reserved",
 		},
 		{
+			name: "profile key whitespace rejected",
+			limits: map[string]LLMProviderLimitPolicy{
+				"anthropic ": {RateLimit: "1/s", RateLimitMaxWait: "1s"},
+			},
+			wantErr: "profile key must not contain leading or trailing whitespace",
+		},
+		{
+			name: "model key whitespace rejected",
+			limits: map[string]LLMProviderLimitPolicy{
+				"anthropic": {
+					Models: map[string]LLMProviderLimitPolicy{
+						"regular ": {RateLimit: "1/s", RateLimitMaxWait: "1s"},
+					},
+				},
+			},
+			wantErr: "model key must not contain leading or trailing whitespace",
+		},
+		{
 			name: "model nested models rejected",
 			limits: map[string]LLMProviderLimitPolicy{
 				"anthropic": {

--- a/internal/config/llm_provider_limits.go
+++ b/internal/config/llm_provider_limits.go
@@ -1,0 +1,224 @@
+package config
+
+import (
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+	"unicode"
+
+	llmselection "github.com/division-sh/swarm/internal/runtime/llm/selection"
+)
+
+type LLMProviderRateLimit struct {
+	Enabled bool
+	Limit   int
+	Period  time.Duration
+	MaxWait time.Duration
+}
+
+type LLMProviderConcurrencyLimit struct {
+	Enabled bool
+	Limit   int
+	MaxWait time.Duration
+}
+
+func (c *Config) validateLLMProviderLimits() error {
+	if c == nil || len(c.LLM.ProviderLimits) == 0 {
+		return nil
+	}
+	profiles := make([]string, 0, len(c.LLM.ProviderLimits))
+	for profile := range c.LLM.ProviderLimits {
+		profiles = append(profiles, profile)
+	}
+	sort.Strings(profiles)
+	for _, profile := range profiles {
+		trimmedProfile := strings.TrimSpace(profile)
+		if trimmedProfile == "" {
+			return fmt.Errorf("llm.provider_limits profile key is required")
+		}
+		if _, err := llmselection.ResolveActiveBackend(trimmedProfile); err != nil {
+			return fmt.Errorf("llm.provider_limits.%s: %w", trimmedProfile, err)
+		}
+		if err := validateLLMProviderLimitPolicy("llm.provider_limits."+trimmedProfile, c.LLM.ProviderLimits[profile], true); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateLLMProviderLimitPolicy(location string, policy LLMProviderLimitPolicy, allowModels bool) error {
+	if _, _, err := policy.ParseRateLimit(); err != nil {
+		return fmt.Errorf("%s: %w", location, err)
+	}
+	if _, _, err := policy.ParseConcurrencyLimit(); err != nil {
+		return fmt.Errorf("%s: %w", location, err)
+	}
+	if len(policy.Models) == 0 {
+		return nil
+	}
+	if !allowModels {
+		return fmt.Errorf("%s.models: nested model limits are not supported", location)
+	}
+	models := make([]string, 0, len(policy.Models))
+	for model := range policy.Models {
+		models = append(models, model)
+	}
+	sort.Strings(models)
+	for _, model := range models {
+		trimmedModel := strings.TrimSpace(model)
+		if trimmedModel == "" {
+			return fmt.Errorf("%s.models: model key is required", location)
+		}
+		if err := validateLLMProviderLimitPolicy(location+".models."+trimmedModel, policy.Models[model], false); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (p LLMProviderLimitPolicy) ParseRateLimit() (LLMProviderRateLimit, bool, error) {
+	rateLimitSet := strings.TrimSpace(p.RateLimit) != ""
+	maxWaitSet := strings.TrimSpace(p.RateLimitMaxWait) != ""
+	if !rateLimitSet && !maxWaitSet {
+		return LLMProviderRateLimit{}, false, nil
+	}
+	if !rateLimitSet {
+		return LLMProviderRateLimit{}, false, fmt.Errorf("rate_limit_max_wait requires rate_limit")
+	}
+	if !maxWaitSet {
+		return LLMProviderRateLimit{}, false, fmt.Errorf("rate_limit requires rate_limit_max_wait")
+	}
+	limit, period, err := parseLLMProviderRate(p.RateLimit)
+	if err != nil {
+		return LLMProviderRateLimit{}, false, fmt.Errorf("rate_limit: %w", err)
+	}
+	wait, err := parseLLMProviderDuration(p.RateLimitMaxWait, true)
+	if err != nil {
+		return LLMProviderRateLimit{}, false, fmt.Errorf("rate_limit_max_wait: %w", err)
+	}
+	return LLMProviderRateLimit{
+		Enabled: true,
+		Limit:   limit,
+		Period:  period,
+		MaxWait: wait,
+	}, true, nil
+}
+
+func (p LLMProviderLimitPolicy) ParseConcurrencyLimit() (LLMProviderConcurrencyLimit, bool, error) {
+	maxWaitSet := strings.TrimSpace(p.MaxConcurrencyMaxWait) != ""
+	if p.MaxConcurrency == 0 && !maxWaitSet {
+		return LLMProviderConcurrencyLimit{}, false, nil
+	}
+	if p.MaxConcurrency <= 0 {
+		return LLMProviderConcurrencyLimit{}, false, fmt.Errorf("max_concurrency must be a positive integer when max_concurrency_max_wait is present")
+	}
+	if !maxWaitSet {
+		return LLMProviderConcurrencyLimit{}, false, fmt.Errorf("max_concurrency requires max_concurrency_max_wait")
+	}
+	wait, err := parseLLMProviderDuration(p.MaxConcurrencyMaxWait, true)
+	if err != nil {
+		return LLMProviderConcurrencyLimit{}, false, fmt.Errorf("max_concurrency_max_wait: %w", err)
+	}
+	return LLMProviderConcurrencyLimit{
+		Enabled: true,
+		Limit:   p.MaxConcurrency,
+		MaxWait: wait,
+	}, true, nil
+}
+
+func (p LLMProviderLimitPolicy) ModelPolicy(keys ...string) (LLMProviderLimitPolicy, string, bool) {
+	if len(p.Models) == 0 {
+		return LLMProviderLimitPolicy{}, "", false
+	}
+	for _, key := range keys {
+		trimmed := strings.TrimSpace(key)
+		if trimmed == "" {
+			continue
+		}
+		if policy, ok := p.Models[trimmed]; ok {
+			return policy, trimmed, true
+		}
+	}
+	return LLMProviderLimitPolicy{}, "", false
+}
+
+func parseLLMProviderRate(raw string) (int, time.Duration, error) {
+	if err := rejectLLMProviderLimitWhitespace(raw); err != nil {
+		return 0, 0, err
+	}
+	countRaw, periodRaw, ok := strings.Cut(raw, "/")
+	if !ok || countRaw == "" || periodRaw == "" || strings.Contains(periodRaw, "/") {
+		return 0, 0, fmt.Errorf("must be <positive integer>/<period>")
+	}
+	count, err := strconv.Atoi(countRaw)
+	if err != nil || count <= 0 {
+		return 0, 0, fmt.Errorf("count must be a positive integer")
+	}
+	period, err := parseLLMProviderRatePeriod(periodRaw)
+	if err != nil {
+		return 0, 0, err
+	}
+	return count, period, nil
+}
+
+func parseLLMProviderRatePeriod(raw string) (time.Duration, error) {
+	switch raw {
+	case "ms", "s", "m", "h", "d":
+		raw = "1" + raw
+	}
+	return parseLLMProviderDuration(raw, false)
+}
+
+func parseLLMProviderDuration(raw string, allowZero bool) (time.Duration, error) {
+	if err := rejectLLMProviderLimitWhitespace(raw); err != nil {
+		return 0, err
+	}
+	if raw == "" {
+		return 0, fmt.Errorf("duration is required")
+	}
+	if len(raw) > 0 && raw[0] == '-' {
+		return 0, fmt.Errorf("duration must be positive")
+	}
+	i := 0
+	for i < len(raw) && raw[i] >= '0' && raw[i] <= '9' {
+		i++
+	}
+	if i == 0 || i == len(raw) {
+		return 0, fmt.Errorf("duration must be an integer with unit ms, s, m, h, or d")
+	}
+	value, err := strconv.Atoi(raw[:i])
+	if err != nil {
+		return 0, fmt.Errorf("duration value must be an integer")
+	}
+	if value == 0 && !allowZero {
+		return 0, fmt.Errorf("duration must be positive")
+	}
+	if value < 0 {
+		return 0, fmt.Errorf("duration must be positive")
+	}
+	switch raw[i:] {
+	case "ms":
+		return time.Duration(value) * time.Millisecond, nil
+	case "s":
+		return time.Duration(value) * time.Second, nil
+	case "m":
+		return time.Duration(value) * time.Minute, nil
+	case "h":
+		return time.Duration(value) * time.Hour, nil
+	case "d":
+		return time.Duration(value) * 24 * time.Hour, nil
+	default:
+		return 0, fmt.Errorf("duration unit must be ms, s, m, h, or d")
+	}
+}
+
+func rejectLLMProviderLimitWhitespace(raw string) error {
+	for _, r := range raw {
+		if unicode.IsSpace(r) {
+			return fmt.Errorf("must not contain whitespace")
+		}
+	}
+	return nil
+}

--- a/internal/config/llm_provider_limits.go
+++ b/internal/config/llm_provider_limits.go
@@ -38,6 +38,9 @@ func (c *Config) validateLLMProviderLimits() error {
 		if trimmedProfile == "" {
 			return fmt.Errorf("llm.provider_limits profile key is required")
 		}
+		if profile != trimmedProfile {
+			return fmt.Errorf("llm.provider_limits.%q: profile key must not contain leading or trailing whitespace", profile)
+		}
 		if _, err := llmselection.ResolveActiveBackend(trimmedProfile); err != nil {
 			return fmt.Errorf("llm.provider_limits.%s: %w", trimmedProfile, err)
 		}
@@ -70,6 +73,9 @@ func validateLLMProviderLimitPolicy(location string, policy LLMProviderLimitPoli
 		trimmedModel := strings.TrimSpace(model)
 		if trimmedModel == "" {
 			return fmt.Errorf("%s.models: model key is required", location)
+		}
+		if model != trimmedModel {
+			return fmt.Errorf("%s.models.%q: model key must not contain leading or trailing whitespace", location, model)
 		}
 		if err := validateLLMProviderLimitPolicy(location+".models."+trimmedModel, policy.Models[model], false); err != nil {
 			return err

--- a/internal/runtime/llm/api_runtime.go
+++ b/internal/runtime/llm/api_runtime.go
@@ -22,16 +22,17 @@ import (
 
 // AnthropicAPIRuntime provides production API-backed LLM execution.
 type AnthropicAPIRuntime struct {
-	cfg           *config.Config
-	sessions      sessions.Registry
-	turns         TurnPersistence
-	conversations ConversationPersistence
-	budget        BudgetGuard
-	lockOwner     string
-	httpClient    *http.Client
-	apiURL        string
-	apiKey        string
-	events        EventPublisher
+	cfg               *config.Config
+	sessions          sessions.Registry
+	turns             TurnPersistence
+	conversations     ConversationPersistence
+	budget            BudgetGuard
+	lockOwner         string
+	httpClient        *http.Client
+	apiURL            string
+	apiKey            string
+	events            EventPublisher
+	providerAdmission *ProviderAdmissionRegistry
 }
 
 func NewAnthropicAPIRuntime(cfg *config.Config, sessions sessions.Registry, lockOwner string, turns TurnPersistence, conversations ConversationPersistence, budget BudgetGuard, publisher EventPublisher) *AnthropicAPIRuntime {
@@ -46,9 +47,10 @@ func NewAnthropicAPIRuntime(cfg *config.Config, sessions sessions.Registry, lock
 		httpClient: &http.Client{
 			Timeout: 120 * time.Second,
 		},
-		apiURL: "https://api.anthropic.com/v1/messages",
-		apiKey: llmselection.CredentialValue(profile, os.LookupEnv),
-		events: publisher,
+		apiURL:            "https://api.anthropic.com/v1/messages",
+		apiKey:            llmselection.CredentialValue(profile, os.LookupEnv),
+		events:            publisher,
+		providerAdmission: NewProviderAdmissionRegistry(cfg),
 	}
 }
 
@@ -252,6 +254,10 @@ func (r *AnthropicAPIRuntime) ContinueSession(ctx context.Context, s *Session, m
 	if err != nil {
 		return nil, fmt.Errorf("marshal anthropic request: %w", err)
 	}
+	resolvedModel, err := resolveProviderAdmissionModel(ctx, r.cfg, r.providerAdmission, profile)
+	if err != nil {
+		return nil, err
+	}
 
 	maxRetries := r.cfg.LLM.ClaudeAPI.MaxRetries
 	if maxRetries <= 0 {
@@ -269,7 +275,7 @@ func (r *AnthropicAPIRuntime) ContinueSession(ctx context.Context, s *Session, m
 	var retryCount int
 	for attempt := 0; attempt < maxRetries; attempt++ {
 		retryCount = attempt
-		rawResp, parsed, lastErr = r.sendRequest(ctx, reqJSON)
+		rawResp, parsed, lastErr = r.sendAdmittedRequest(ctx, profile, resolvedModel, reqJSON)
 		if lastErr == nil {
 			break
 		}
@@ -361,6 +367,15 @@ func (r *AnthropicAPIRuntime) ContinueSession(ctx context.Context, s *Session, m
 	}
 
 	return &resp, nil
+}
+
+func (r *AnthropicAPIRuntime) sendAdmittedRequest(ctx context.Context, profile llmselection.Profile, model llmselection.ResolvedModel, payload []byte) ([]byte, anthropicResponse, error) {
+	release, err := admitProviderRequest(ctx, r.providerAdmission, profile, model)
+	if err != nil {
+		return nil, anthropicResponse{}, err
+	}
+	defer release()
+	return r.sendRequest(ctx, payload)
 }
 
 func (r *AnthropicAPIRuntime) persistConversation(ctx context.Context, s *Session) {

--- a/internal/runtime/llm/cli_runtime.go
+++ b/internal/runtime/llm/cli_runtime.go
@@ -373,7 +373,7 @@ func (r *ClaudeCLIRuntime) ContinueSession(ctx context.Context, s *Session, mess
 			return target.Container
 		}(),
 	}
-	resp, fallback, err := r.runAdmittedPromptTransportFallback(ctx, args, target, prompt, monitorMeta)
+	resp, fallback, err := r.runWithPromptTransportFallback(ctx, args, target, prompt, monitorMeta)
 	transportFallback.Attempted = transportFallback.Attempted || fallback.Attempted
 	transportFallback.Used = transportFallback.Used || fallback.Used
 	if err != nil && s.TurnCount == 0 && isUnsupportedCLIFlagError(err) {
@@ -393,7 +393,7 @@ func (r *ClaudeCLIRuntime) ContinueSession(ctx context.Context, s *Session, mess
 		if mcpEnabled {
 			args = append(args, "--mcp-config", mcpConfig, "--strict-mcp-config")
 		}
-		resp, fallback, err = r.runAdmittedPromptTransportFallback(ctx, args, target, buildInitialPrompt(s, prompt), monitorMeta)
+		resp, fallback, err = r.runWithPromptTransportFallback(ctx, args, target, buildInitialPrompt(s, prompt), monitorMeta)
 		transportFallback.Attempted = transportFallback.Attempted || fallback.Attempted
 		transportFallback.Used = transportFallback.Used || fallback.Used
 	}
@@ -444,7 +444,7 @@ func (r *ClaudeCLIRuntime) ContinueSession(ctx context.Context, s *Session, mess
 					args = append(args, "--mcp-config", mcpConfig, "--strict-mcp-config")
 				}
 				monitorMeta.SessionID = s.ID
-				resp, fallback, err = r.runAdmittedPromptTransportFallback(ctx, args, target, message.Content, monitorMeta)
+				resp, fallback, err = r.runWithPromptTransportFallback(ctx, args, target, message.Content, monitorMeta)
 				transportFallback.Attempted = transportFallback.Attempted || fallback.Attempted
 				transportFallback.Used = transportFallback.Used || fallback.Used
 				if err != nil && isUnsupportedCLIFlagError(err) {
@@ -464,7 +464,7 @@ func (r *ClaudeCLIRuntime) ContinueSession(ctx context.Context, s *Session, mess
 					if mcpEnabled {
 						args = append(args, "--mcp-config", mcpConfig, "--strict-mcp-config")
 					}
-					resp, fallback, err = r.runAdmittedPromptTransportFallback(ctx, args, target, buildInitialPrompt(s, message.Content), monitorMeta)
+					resp, fallback, err = r.runWithPromptTransportFallback(ctx, args, target, buildInitialPrompt(s, message.Content), monitorMeta)
 					transportFallback.Attempted = transportFallback.Attempted || fallback.Attempted
 					transportFallback.Used = transportFallback.Used || fallback.Used
 				}
@@ -578,18 +578,17 @@ func (r *ClaudeCLIRuntime) ContinueSession(ctx context.Context, s *Session, mess
 	return resp, nil
 }
 
-func (r *ClaudeCLIRuntime) runAdmittedPromptTransportFallback(ctx context.Context, args []string, target *workspace.Target, prompt string, meta MonitorTurnMeta) (*Response, promptTransportFallback, error) {
+func (r *ClaudeCLIRuntime) admitProviderDispatch(ctx context.Context) (func(), error) {
 	profile, _ := llmselection.ResolveActiveBackend(llmselection.BackendClaudeCLI)
 	resolvedModel, err := resolveProviderAdmissionModel(ctx, r.cfg, r.providerAdmission, profile)
 	if err != nil {
-		return nil, promptTransportFallback{}, err
+		return noopProviderAdmissionRelease, err
 	}
 	release, err := admitProviderRequest(ctx, r.providerAdmission, profile, resolvedModel)
 	if err != nil {
-		return nil, promptTransportFallback{}, err
+		return noopProviderAdmissionRelease, err
 	}
-	defer release()
-	return r.runWithPromptTransportFallback(ctx, args, target, prompt, meta)
+	return release, nil
 }
 
 func validateCLIResponseToolCallsForTurn(actor runtimeactors.AgentConfig, tools []ToolDefinition, resp *Response) error {

--- a/internal/runtime/llm/cli_runtime.go
+++ b/internal/runtime/llm/cli_runtime.go
@@ -18,18 +18,19 @@ import (
 )
 
 type ClaudeCLIRuntime struct {
-	cfg             *config.Config
-	sessions        sessions.Registry
-	turns           TurnPersistence
-	conversations   ConversationPersistence
-	budget          BudgetGuard
-	lockOwner       string
-	workspaces      workspace.Resolver
-	monitor         MonitorSink
-	events          EventPublisher
-	mcpTurns        MCPTurnContextStore
-	toolGateway     toolgateway.Binding
-	execWorkspaceFn func(ctx context.Context, target *workspace.Target, stdin string, args ...string) ([]byte, []byte, int, error)
+	cfg               *config.Config
+	sessions          sessions.Registry
+	turns             TurnPersistence
+	conversations     ConversationPersistence
+	budget            BudgetGuard
+	lockOwner         string
+	workspaces        workspace.Resolver
+	monitor           MonitorSink
+	events            EventPublisher
+	mcpTurns          MCPTurnContextStore
+	toolGateway       toolgateway.Binding
+	execWorkspaceFn   func(ctx context.Context, target *workspace.Target, stdin string, args ...string) ([]byte, []byte, int, error)
+	providerAdmission *ProviderAdmissionRegistry
 }
 
 var ErrClaudeAuthRequired = errors.New("claude auth required")
@@ -76,17 +77,18 @@ func NewClaudeCLIRuntimeWithOptions(
 		monitor = NewFileMonitorSink(DefaultMonitorDir())
 	}
 	return &ClaudeCLIRuntime{
-		cfg:           cfg,
-		sessions:      sessions,
-		turns:         turns,
-		conversations: conversations,
-		budget:        budget,
-		lockOwner:     lockOwner,
-		workspaces:    workspaces,
-		monitor:       monitor,
-		events:        publisher,
-		mcpTurns:      opts.MCPTurnContextStore,
-		toolGateway:   opts.ToolGateway,
+		cfg:               cfg,
+		sessions:          sessions,
+		turns:             turns,
+		conversations:     conversations,
+		budget:            budget,
+		lockOwner:         lockOwner,
+		workspaces:        workspaces,
+		monitor:           monitor,
+		events:            publisher,
+		mcpTurns:          opts.MCPTurnContextStore,
+		toolGateway:       opts.ToolGateway,
+		providerAdmission: NewProviderAdmissionRegistry(cfg),
 	}
 }
 
@@ -371,7 +373,7 @@ func (r *ClaudeCLIRuntime) ContinueSession(ctx context.Context, s *Session, mess
 			return target.Container
 		}(),
 	}
-	resp, fallback, err := r.runWithPromptTransportFallback(ctx, args, target, prompt, monitorMeta)
+	resp, fallback, err := r.runAdmittedPromptTransportFallback(ctx, args, target, prompt, monitorMeta)
 	transportFallback.Attempted = transportFallback.Attempted || fallback.Attempted
 	transportFallback.Used = transportFallback.Used || fallback.Used
 	if err != nil && s.TurnCount == 0 && isUnsupportedCLIFlagError(err) {
@@ -391,7 +393,7 @@ func (r *ClaudeCLIRuntime) ContinueSession(ctx context.Context, s *Session, mess
 		if mcpEnabled {
 			args = append(args, "--mcp-config", mcpConfig, "--strict-mcp-config")
 		}
-		resp, fallback, err = r.runWithPromptTransportFallback(ctx, args, target, buildInitialPrompt(s, prompt), monitorMeta)
+		resp, fallback, err = r.runAdmittedPromptTransportFallback(ctx, args, target, buildInitialPrompt(s, prompt), monitorMeta)
 		transportFallback.Attempted = transportFallback.Attempted || fallback.Attempted
 		transportFallback.Used = transportFallback.Used || fallback.Used
 	}
@@ -442,7 +444,7 @@ func (r *ClaudeCLIRuntime) ContinueSession(ctx context.Context, s *Session, mess
 					args = append(args, "--mcp-config", mcpConfig, "--strict-mcp-config")
 				}
 				monitorMeta.SessionID = s.ID
-				resp, fallback, err = r.runWithPromptTransportFallback(ctx, args, target, message.Content, monitorMeta)
+				resp, fallback, err = r.runAdmittedPromptTransportFallback(ctx, args, target, message.Content, monitorMeta)
 				transportFallback.Attempted = transportFallback.Attempted || fallback.Attempted
 				transportFallback.Used = transportFallback.Used || fallback.Used
 				if err != nil && isUnsupportedCLIFlagError(err) {
@@ -462,7 +464,7 @@ func (r *ClaudeCLIRuntime) ContinueSession(ctx context.Context, s *Session, mess
 					if mcpEnabled {
 						args = append(args, "--mcp-config", mcpConfig, "--strict-mcp-config")
 					}
-					resp, fallback, err = r.runWithPromptTransportFallback(ctx, args, target, buildInitialPrompt(s, message.Content), monitorMeta)
+					resp, fallback, err = r.runAdmittedPromptTransportFallback(ctx, args, target, buildInitialPrompt(s, message.Content), monitorMeta)
 					transportFallback.Attempted = transportFallback.Attempted || fallback.Attempted
 					transportFallback.Used = transportFallback.Used || fallback.Used
 				}
@@ -574,6 +576,20 @@ func (r *ClaudeCLIRuntime) ContinueSession(ctx context.Context, s *Session, mess
 		}
 	}
 	return resp, nil
+}
+
+func (r *ClaudeCLIRuntime) runAdmittedPromptTransportFallback(ctx context.Context, args []string, target *workspace.Target, prompt string, meta MonitorTurnMeta) (*Response, promptTransportFallback, error) {
+	profile, _ := llmselection.ResolveActiveBackend(llmselection.BackendClaudeCLI)
+	resolvedModel, err := resolveProviderAdmissionModel(ctx, r.cfg, r.providerAdmission, profile)
+	if err != nil {
+		return nil, promptTransportFallback{}, err
+	}
+	release, err := admitProviderRequest(ctx, r.providerAdmission, profile, resolvedModel)
+	if err != nil {
+		return nil, promptTransportFallback{}, err
+	}
+	defer release()
+	return r.runWithPromptTransportFallback(ctx, args, target, prompt, meta)
 }
 
 func validateCLIResponseToolCallsForTurn(actor runtimeactors.AgentConfig, tools []ToolDefinition, resp *Response) error {

--- a/internal/runtime/llm/cli_runtime_process.go
+++ b/internal/runtime/llm/cli_runtime_process.go
@@ -47,6 +47,11 @@ func (r *ClaudeCLIRuntime) runWithInput(ctx context.Context, args []string, targ
 	if err := llmselection.RequireCredential(profile, os.LookupEnv); err != nil {
 		return nil, fmt.Errorf("%w: %s is missing", ErrClaudeAuthRequired, profile.Credential.EnvVar)
 	}
+	release, err := r.admitProviderDispatch(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer release()
 
 	runCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()

--- a/internal/runtime/llm/factory.go
+++ b/internal/runtime/llm/factory.go
@@ -42,20 +42,25 @@ func (f RuntimeFactory) Build() (Runtime, error) {
 	if err != nil {
 		return nil, err
 	}
+	providerAdmission := NewProviderAdmissionRegistry(f.Cfg)
 
 	var runtime Runtime
 	switch profile.ID {
 	case llmselection.BackendAnthropic:
 		runtime = NewAnthropicAPIRuntime(f.Cfg, f.Sessions, f.LockOwner, f.Turns, f.Conversations, f.Budget, f.Events)
+		runtime.(*AnthropicAPIRuntime).providerAdmission = providerAdmission
 	case llmselection.BackendClaudeCLI:
 		runtime = NewClaudeCLIRuntimeWithOptions(f.Cfg, f.Sessions, f.LockOwner, f.Turns, f.Budget, f.Workspaces, f.Conversations, f.Events, ClaudeCLIRuntimeOptions{
 			MCPTurnContextStore: f.MCPTurns,
 			ToolGateway:         f.ToolGateway,
 		})
+		runtime.(*ClaudeCLIRuntime).providerAdmission = providerAdmission
 	case llmselection.BackendOpenAICompatible:
 		runtime = NewOpenAICompatibleRuntime(f.Cfg, f.Sessions, f.LockOwner, f.Turns, f.Conversations, f.Budget, f.Events)
+		runtime.(*OpenAICompatibleRuntime).providerAdmission = providerAdmission
 	case llmselection.BackendOpenAIResponses:
 		runtime = NewOpenAIResponsesRuntime(f.Cfg, f.Sessions, f.LockOwner, f.Turns, f.Conversations, f.Budget, f.Events)
+		runtime.(*OpenAIResponsesRuntime).providerAdmission = providerAdmission
 	default:
 		return nil, fmt.Errorf("unsupported llm backend profile: %s", profile.ID)
 	}

--- a/internal/runtime/llm/openai_compatible_runtime.go
+++ b/internal/runtime/llm/openai_compatible_runtime.go
@@ -21,16 +21,17 @@ import (
 )
 
 type OpenAICompatibleRuntime struct {
-	cfg           *config.Config
-	sessions      sessions.Registry
-	turns         TurnPersistence
-	conversations ConversationPersistence
-	budget        BudgetGuard
-	lockOwner     string
-	httpClient    *http.Client
-	baseURL       string
-	apiKey        string
-	events        EventPublisher
+	cfg               *config.Config
+	sessions          sessions.Registry
+	turns             TurnPersistence
+	conversations     ConversationPersistence
+	budget            BudgetGuard
+	lockOwner         string
+	httpClient        *http.Client
+	baseURL           string
+	apiKey            string
+	events            EventPublisher
+	providerAdmission *ProviderAdmissionRegistry
 }
 
 func NewOpenAICompatibleRuntime(cfg *config.Config, sessions sessions.Registry, lockOwner string, turns TurnPersistence, conversations ConversationPersistence, budget BudgetGuard, publisher EventPublisher) *OpenAICompatibleRuntime {
@@ -49,9 +50,10 @@ func NewOpenAICompatibleRuntime(cfg *config.Config, sessions sessions.Registry, 
 		httpClient: &http.Client{
 			Timeout: 120 * time.Second,
 		},
-		baseURL: baseURL,
-		apiKey:  llmselection.CredentialValue(profile, os.LookupEnv),
-		events:  publisher,
+		baseURL:           baseURL,
+		apiKey:            llmselection.CredentialValue(profile, os.LookupEnv),
+		events:            publisher,
+		providerAdmission: NewProviderAdmissionRegistry(cfg),
 	}
 }
 
@@ -258,9 +260,13 @@ func (r *OpenAICompatibleRuntime) ContinueSession(ctx context.Context, s *Sessio
 	if err != nil {
 		return nil, fmt.Errorf("marshal openai-compatible request: %w", err)
 	}
+	resolvedModel, err := resolveProviderAdmissionModel(ctx, r.cfg, r.providerAdmission, profile)
+	if err != nil {
+		return nil, err
+	}
 
 	start := time.Now()
-	rawResp, parsed, err := r.sendRequest(ctx, reqJSON)
+	rawResp, parsed, err := r.sendAdmittedRequest(ctx, profile, resolvedModel, reqJSON)
 	latency := time.Since(start)
 	if err != nil {
 		s.ParseFailures++
@@ -354,6 +360,15 @@ func (r *OpenAICompatibleRuntime) ContinueSession(ctx context.Context, s *Sessio
 	}
 
 	return &resp, nil
+}
+
+func (r *OpenAICompatibleRuntime) sendAdmittedRequest(ctx context.Context, profile llmselection.Profile, model llmselection.ResolvedModel, payload []byte) ([]byte, openAICompatibleResponse, error) {
+	release, err := admitProviderRequest(ctx, r.providerAdmission, profile, model)
+	if err != nil {
+		return nil, openAICompatibleResponse{}, err
+	}
+	defer release()
+	return r.sendRequest(ctx, payload)
 }
 
 func (r *OpenAICompatibleRuntime) persistConversation(ctx context.Context, s *Session) {

--- a/internal/runtime/llm/openai_responses_runtime.go
+++ b/internal/runtime/llm/openai_responses_runtime.go
@@ -22,16 +22,17 @@ import (
 )
 
 type OpenAIResponsesRuntime struct {
-	cfg           *config.Config
-	sessions      sessions.Registry
-	turns         TurnPersistence
-	conversations ConversationPersistence
-	budget        BudgetGuard
-	lockOwner     string
-	httpClient    *http.Client
-	baseURL       string
-	apiKey        string
-	events        EventPublisher
+	cfg               *config.Config
+	sessions          sessions.Registry
+	turns             TurnPersistence
+	conversations     ConversationPersistence
+	budget            BudgetGuard
+	lockOwner         string
+	httpClient        *http.Client
+	baseURL           string
+	apiKey            string
+	events            EventPublisher
+	providerAdmission *ProviderAdmissionRegistry
 }
 
 func NewOpenAIResponsesRuntime(cfg *config.Config, sessions sessions.Registry, lockOwner string, turns TurnPersistence, conversations ConversationPersistence, budget BudgetGuard, publisher EventPublisher) *OpenAIResponsesRuntime {
@@ -50,9 +51,10 @@ func NewOpenAIResponsesRuntime(cfg *config.Config, sessions sessions.Registry, l
 		httpClient: &http.Client{
 			Timeout: 120 * time.Second,
 		},
-		baseURL: baseURL,
-		apiKey:  llmselection.CredentialValue(profile, os.LookupEnv),
-		events:  publisher,
+		baseURL:           baseURL,
+		apiKey:            llmselection.CredentialValue(profile, os.LookupEnv),
+		events:            publisher,
+		providerAdmission: NewProviderAdmissionRegistry(cfg),
 	}
 }
 
@@ -259,9 +261,13 @@ func (r *OpenAIResponsesRuntime) ContinueSession(ctx context.Context, s *Session
 	if err != nil {
 		return nil, fmt.Errorf("marshal openai-responses request: %w", err)
 	}
+	resolvedModel, err := resolveProviderAdmissionModel(ctx, r.cfg, r.providerAdmission, profile)
+	if err != nil {
+		return nil, err
+	}
 
 	start := time.Now()
-	rawResp, parsed, err := r.sendRequest(ctx, reqJSON)
+	rawResp, parsed, err := r.sendAdmittedRequest(ctx, profile, resolvedModel, reqJSON)
 	latency := time.Since(start)
 	if err != nil {
 		s.ParseFailures++
@@ -354,6 +360,15 @@ func (r *OpenAIResponsesRuntime) ContinueSession(ctx context.Context, s *Session
 	}
 
 	return &resp, nil
+}
+
+func (r *OpenAIResponsesRuntime) sendAdmittedRequest(ctx context.Context, profile llmselection.Profile, model llmselection.ResolvedModel, payload []byte) ([]byte, openAIResponsesResponse, error) {
+	release, err := admitProviderRequest(ctx, r.providerAdmission, profile, model)
+	if err != nil {
+		return nil, openAIResponsesResponse{}, err
+	}
+	defer release()
+	return r.sendRequest(ctx, payload)
 }
 
 func (r *OpenAIResponsesRuntime) persistConversation(ctx context.Context, s *Session) {

--- a/internal/runtime/llm/provider_admission.go
+++ b/internal/runtime/llm/provider_admission.go
@@ -1,0 +1,368 @@
+package llm
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/division-sh/swarm/internal/config"
+	runtimeactors "github.com/division-sh/swarm/internal/runtime/core/actors"
+	llmselection "github.com/division-sh/swarm/internal/runtime/llm/selection"
+	runtimerterr "github.com/division-sh/swarm/internal/runtime/rterrors"
+)
+
+const (
+	llmProviderRateLimitedCode = "rate_limited"
+
+	llmProviderAdmissionComponent = "llm-provider"
+	llmProviderAdmissionOperation = "provider_admission"
+
+	llmProviderAdmissionModelAll = "*"
+)
+
+type ProviderAdmissionRegistry struct {
+	cfg        *config.Config
+	controller *llmProviderAdmissionController
+}
+
+type llmProviderAdmissionPolicy struct {
+	Profile        llmselection.Profile
+	ResolvedModel  llmselection.ResolvedModel
+	BucketName     string
+	RateBucketKey  string
+	Rate           config.LLMProviderRateLimit
+	ConcurrencyKey string
+	Concurrency    config.LLMProviderConcurrencyLimit
+}
+
+type llmProviderAdmissionController struct {
+	mu          sync.Mutex
+	rateBuckets map[string]*llmProviderRateBucket
+	concurrency map[string]*llmProviderConcurrencyBucket
+}
+
+type llmProviderRateBucket struct {
+	mu        sync.Mutex
+	scheduled []time.Time
+}
+
+type llmProviderConcurrencyBucket struct {
+	tokens chan struct{}
+}
+
+func NewProviderAdmissionRegistry(cfg *config.Config) *ProviderAdmissionRegistry {
+	return &ProviderAdmissionRegistry{
+		cfg:        cfg,
+		controller: newLLMProviderAdmissionController(),
+	}
+}
+
+func newLLMProviderAdmissionController() *llmProviderAdmissionController {
+	return &llmProviderAdmissionController{
+		rateBuckets: map[string]*llmProviderRateBucket{},
+		concurrency: map[string]*llmProviderConcurrencyBucket{},
+	}
+}
+
+func (r *ProviderAdmissionRegistry) Admit(ctx context.Context, profile llmselection.Profile, resolvedModel llmselection.ResolvedModel) (func(), error) {
+	if r == nil || r.controller == nil {
+		return noopProviderAdmissionRelease, nil
+	}
+	policy, ok, err := r.policy(profile, resolvedModel)
+	if err != nil {
+		return noopProviderAdmissionRelease, err
+	}
+	if !ok {
+		return noopProviderAdmissionRelease, nil
+	}
+	return r.controller.Admit(ctx, policy)
+}
+
+func admitProviderRequest(ctx context.Context, registry *ProviderAdmissionRegistry, profile llmselection.Profile, resolvedModel llmselection.ResolvedModel) (func(), error) {
+	if registry == nil {
+		return noopProviderAdmissionRelease, nil
+	}
+	return registry.Admit(ctx, profile, resolvedModel)
+}
+
+func resolveProviderAdmissionModel(ctx context.Context, cfg *config.Config, registry *ProviderAdmissionRegistry, profile llmselection.Profile) (llmselection.ResolvedModel, error) {
+	if registry == nil || !registry.configuredFor(profile) {
+		return llmselection.ResolvedModel{}, nil
+	}
+	return resolveAdmissionModel(ctx, cfg, profile)
+}
+
+func (r *ProviderAdmissionRegistry) configuredFor(profile llmselection.Profile) bool {
+	if r == nil || r.cfg == nil || len(r.cfg.LLM.ProviderLimits) == 0 {
+		return false
+	}
+	policy, ok := r.cfg.LLM.ProviderLimits[profile.ID]
+	return ok && providerAdmissionPolicyDeclared(policy)
+}
+
+func providerAdmissionPolicyDeclared(policy config.LLMProviderLimitPolicy) bool {
+	if strings.TrimSpace(policy.RateLimit) != "" || strings.TrimSpace(policy.RateLimitMaxWait) != "" ||
+		policy.MaxConcurrency != 0 || strings.TrimSpace(policy.MaxConcurrencyMaxWait) != "" {
+		return true
+	}
+	for _, modelPolicy := range policy.Models {
+		if providerAdmissionPolicyDeclared(modelPolicy) {
+			return true
+		}
+	}
+	return false
+}
+
+func (r *ProviderAdmissionRegistry) policy(profile llmselection.Profile, resolvedModel llmselection.ResolvedModel) (llmProviderAdmissionPolicy, bool, error) {
+	if r == nil || r.cfg == nil || len(r.cfg.LLM.ProviderLimits) == 0 {
+		return llmProviderAdmissionPolicy{}, false, nil
+	}
+	base, ok := r.cfg.LLM.ProviderLimits[profile.ID]
+	if !ok {
+		return llmProviderAdmissionPolicy{}, false, nil
+	}
+
+	rate, rateBucketModel, err := ratePolicyForModel(base, resolvedModel)
+	if err != nil {
+		return llmProviderAdmissionPolicy{}, false, err
+	}
+	concurrency, concurrencyBucketModel, err := concurrencyPolicyForModel(base, resolvedModel)
+	if err != nil {
+		return llmProviderAdmissionPolicy{}, false, err
+	}
+	if !rate.Enabled && !concurrency.Enabled {
+		return llmProviderAdmissionPolicy{}, false, nil
+	}
+
+	bucketName := strings.Join([]string{
+		strings.TrimSpace(profile.ID),
+		strings.TrimSpace(profile.Provider),
+		strings.TrimSpace(profile.Transport),
+		strings.TrimSpace(resolvedModel.ModelAlias),
+		strings.TrimSpace(resolvedModel.ConcreteModel),
+	}, "/")
+	return llmProviderAdmissionPolicy{
+		Profile:        profile,
+		ResolvedModel:  resolvedModel,
+		BucketName:     bucketName,
+		RateBucketKey:  llmProviderAdmissionBucketKey(profile, rateBucketModel),
+		Rate:           rate,
+		ConcurrencyKey: llmProviderAdmissionBucketKey(profile, concurrencyBucketModel),
+		Concurrency:    concurrency,
+	}, true, nil
+}
+
+func ratePolicyForModel(base config.LLMProviderLimitPolicy, resolvedModel llmselection.ResolvedModel) (config.LLMProviderRateLimit, string, error) {
+	rate, _, err := base.ParseRateLimit()
+	if err != nil {
+		return config.LLMProviderRateLimit{}, "", err
+	}
+	bucketModel := llmProviderAdmissionModelAll
+	if model, key, ok := base.ModelPolicy(resolvedModel.ModelAlias, resolvedModel.ConcreteModel); ok {
+		if modelRate, enabled, err := model.ParseRateLimit(); err != nil {
+			return config.LLMProviderRateLimit{}, "", err
+		} else if enabled {
+			rate = modelRate
+			bucketModel = key
+		}
+	}
+	return rate, bucketModel, nil
+}
+
+func concurrencyPolicyForModel(base config.LLMProviderLimitPolicy, resolvedModel llmselection.ResolvedModel) (config.LLMProviderConcurrencyLimit, string, error) {
+	limit, _, err := base.ParseConcurrencyLimit()
+	if err != nil {
+		return config.LLMProviderConcurrencyLimit{}, "", err
+	}
+	bucketModel := llmProviderAdmissionModelAll
+	if model, key, ok := base.ModelPolicy(resolvedModel.ModelAlias, resolvedModel.ConcreteModel); ok {
+		if modelLimit, enabled, err := model.ParseConcurrencyLimit(); err != nil {
+			return config.LLMProviderConcurrencyLimit{}, "", err
+		} else if enabled {
+			limit = modelLimit
+			bucketModel = key
+		}
+	}
+	return limit, bucketModel, nil
+}
+
+func (c *llmProviderAdmissionController) Admit(ctx context.Context, policy llmProviderAdmissionPolicy) (func(), error) {
+	release := noopProviderAdmissionRelease
+	if policy.Concurrency.Enabled {
+		concurrencyRelease, err := c.acquireConcurrency(ctx, policy)
+		if err != nil {
+			return noopProviderAdmissionRelease, err
+		}
+		release = concurrencyRelease
+	}
+	if policy.Rate.Enabled {
+		if err := c.admitRate(ctx, policy); err != nil {
+			release()
+			return noopProviderAdmissionRelease, err
+		}
+	}
+	return release, nil
+}
+
+func (c *llmProviderAdmissionController) admitRate(ctx context.Context, policy llmProviderAdmissionPolicy) error {
+	key := strings.TrimSpace(policy.RateBucketKey)
+	if key == "" {
+		return fmt.Errorf("llm provider rate admission bucket key is required")
+	}
+	bucket := c.rateBucket(key)
+	wait, scheduled, timedOut := bucket.reserve(policy.Rate.Limit, policy.Rate.Period, policy.Rate.MaxWait)
+	if timedOut {
+		return newLLMProviderAdmissionRateLimitedError(policy)
+	}
+	if wait <= 0 {
+		return nil
+	}
+	timer := time.NewTimer(wait)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		bucket.cancelReservation(scheduled)
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}
+
+func (c *llmProviderAdmissionController) acquireConcurrency(ctx context.Context, policy llmProviderAdmissionPolicy) (func(), error) {
+	key := strings.TrimSpace(policy.ConcurrencyKey)
+	if key == "" {
+		return noopProviderAdmissionRelease, fmt.Errorf("llm provider concurrency admission bucket key is required")
+	}
+	bucket := c.concurrencyBucket(key, policy.Concurrency.Limit)
+	select {
+	case <-bucket.tokens:
+		return func() {
+			bucket.tokens <- struct{}{}
+		}, nil
+	default:
+	}
+	if policy.Concurrency.MaxWait <= 0 {
+		return noopProviderAdmissionRelease, newLLMProviderAdmissionRateLimitedError(policy)
+	}
+	timer := time.NewTimer(policy.Concurrency.MaxWait)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return noopProviderAdmissionRelease, ctx.Err()
+	case <-timer.C:
+		return noopProviderAdmissionRelease, newLLMProviderAdmissionRateLimitedError(policy)
+	case <-bucket.tokens:
+		return func() {
+			bucket.tokens <- struct{}{}
+		}, nil
+	}
+}
+
+func (c *llmProviderAdmissionController) rateBucket(key string) *llmProviderRateBucket {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.rateBuckets == nil {
+		c.rateBuckets = map[string]*llmProviderRateBucket{}
+	}
+	bucket := c.rateBuckets[key]
+	if bucket == nil {
+		bucket = &llmProviderRateBucket{}
+		c.rateBuckets[key] = bucket
+	}
+	return bucket
+}
+
+func (c *llmProviderAdmissionController) concurrencyBucket(key string, limit int) *llmProviderConcurrencyBucket {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.concurrency == nil {
+		c.concurrency = map[string]*llmProviderConcurrencyBucket{}
+	}
+	bucket := c.concurrency[key]
+	if bucket == nil || cap(bucket.tokens) != limit {
+		tokens := make(chan struct{}, limit)
+		for i := 0; i < limit; i++ {
+			tokens <- struct{}{}
+		}
+		bucket = &llmProviderConcurrencyBucket{tokens: tokens}
+		c.concurrency[key] = bucket
+	}
+	return bucket
+}
+
+func (b *llmProviderRateBucket) reserve(limit int, period, maxWait time.Duration) (time.Duration, time.Time, bool) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	now := time.Now()
+	cutoff := now.Add(-period)
+	kept := b.scheduled[:0]
+	for _, scheduled := range b.scheduled {
+		if scheduled.After(cutoff) {
+			kept = append(kept, scheduled)
+		}
+	}
+	b.scheduled = kept
+	scheduled := now
+	if len(b.scheduled) >= limit {
+		next := b.scheduled[len(b.scheduled)-limit].Add(period)
+		if next.After(scheduled) {
+			scheduled = next
+		}
+	}
+	wait := scheduled.Sub(now)
+	if wait < 0 {
+		wait = 0
+	}
+	if wait > maxWait {
+		return wait, scheduled, true
+	}
+	b.scheduled = append(b.scheduled, scheduled)
+	return wait, scheduled, false
+}
+
+func (b *llmProviderRateBucket) cancelReservation(scheduled time.Time) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	for i, item := range b.scheduled {
+		if item.Equal(scheduled) {
+			b.scheduled = append(b.scheduled[:i], b.scheduled[i+1:]...)
+			return
+		}
+	}
+}
+
+func newLLMProviderAdmissionRateLimitedError(policy llmProviderAdmissionPolicy) error {
+	return runtimerterr.NewRuntimeError(
+		llmProviderRateLimitedCode,
+		llmProviderAdmissionComponent,
+		llmProviderAdmissionOperation,
+		true,
+		"llm provider admission limit exceeded for %s",
+		strings.TrimSpace(policy.BucketName),
+	)
+}
+
+func resolveAdmissionModel(ctx context.Context, cfg *config.Config, profile llmselection.Profile) (llmselection.ResolvedModel, error) {
+	if cfg == nil {
+		cfg = &config.Config{}
+	}
+	req := llmselection.ModelResolution{Models: cfg.LLM.Models}
+	if actor, ok := runtimeactors.ActorFromContext(ctx); ok {
+		req.Model = actor.Model
+	}
+	return llmselection.ResolveModel(profile, req)
+}
+
+func llmProviderAdmissionBucketKey(profile llmselection.Profile, modelKey string) string {
+	return strings.Join([]string{
+		"llm_provider",
+		strings.TrimSpace(profile.ID),
+		strings.TrimSpace(profile.Provider),
+		strings.TrimSpace(profile.Transport),
+		strings.TrimSpace(modelKey),
+	}, ":")
+}
+
+func noopProviderAdmissionRelease() {}

--- a/internal/runtime/llm/provider_admission.go
+++ b/internal/runtime/llm/provider_admission.go
@@ -189,14 +189,18 @@ func concurrencyPolicyForModel(base config.LLMProviderLimitPolicy, resolvedModel
 }
 
 func (c *llmProviderAdmissionController) Admit(ctx context.Context, policy llmProviderAdmissionPolicy) (func(), error) {
+	cancelRateReservation := noopProviderAdmissionRelease
 	if policy.Rate.Enabled {
-		if err := c.admitRate(ctx, policy); err != nil {
+		var err error
+		cancelRateReservation, err = c.admitRate(ctx, policy)
+		if err != nil {
 			return noopProviderAdmissionRelease, err
 		}
 	}
 	if policy.Concurrency.Enabled {
 		concurrencyRelease, err := c.acquireConcurrency(ctx, policy)
 		if err != nil {
+			cancelRateReservation()
 			return noopProviderAdmissionRelease, err
 		}
 		return concurrencyRelease, nil
@@ -204,27 +208,30 @@ func (c *llmProviderAdmissionController) Admit(ctx context.Context, policy llmPr
 	return noopProviderAdmissionRelease, nil
 }
 
-func (c *llmProviderAdmissionController) admitRate(ctx context.Context, policy llmProviderAdmissionPolicy) error {
+func (c *llmProviderAdmissionController) admitRate(ctx context.Context, policy llmProviderAdmissionPolicy) (func(), error) {
 	key := strings.TrimSpace(policy.RateBucketKey)
 	if key == "" {
-		return fmt.Errorf("llm provider rate admission bucket key is required")
+		return noopProviderAdmissionRelease, fmt.Errorf("llm provider rate admission bucket key is required")
 	}
 	bucket := c.rateBucket(key)
 	wait, scheduled, timedOut := bucket.reserve(policy.Rate.Limit, policy.Rate.Period, policy.Rate.MaxWait)
 	if timedOut {
-		return newLLMProviderAdmissionRateLimitedError(policy)
+		return noopProviderAdmissionRelease, newLLMProviderAdmissionRateLimitedError(policy)
+	}
+	cancelReservation := func() {
+		bucket.cancelReservation(scheduled)
 	}
 	if wait <= 0 {
-		return nil
+		return cancelReservation, nil
 	}
 	timer := time.NewTimer(wait)
 	defer timer.Stop()
 	select {
 	case <-ctx.Done():
 		bucket.cancelReservation(scheduled)
-		return ctx.Err()
+		return noopProviderAdmissionRelease, ctx.Err()
 	case <-timer.C:
-		return nil
+		return cancelReservation, nil
 	}
 }
 

--- a/internal/runtime/llm/provider_admission.go
+++ b/internal/runtime/llm/provider_admission.go
@@ -189,21 +189,19 @@ func concurrencyPolicyForModel(base config.LLMProviderLimitPolicy, resolvedModel
 }
 
 func (c *llmProviderAdmissionController) Admit(ctx context.Context, policy llmProviderAdmissionPolicy) (func(), error) {
-	release := noopProviderAdmissionRelease
+	if policy.Rate.Enabled {
+		if err := c.admitRate(ctx, policy); err != nil {
+			return noopProviderAdmissionRelease, err
+		}
+	}
 	if policy.Concurrency.Enabled {
 		concurrencyRelease, err := c.acquireConcurrency(ctx, policy)
 		if err != nil {
 			return noopProviderAdmissionRelease, err
 		}
-		release = concurrencyRelease
+		return concurrencyRelease, nil
 	}
-	if policy.Rate.Enabled {
-		if err := c.admitRate(ctx, policy); err != nil {
-			release()
-			return noopProviderAdmissionRelease, err
-		}
-	}
-	return release, nil
+	return noopProviderAdmissionRelease, nil
 }
 
 func (c *llmProviderAdmissionController) admitRate(ctx context.Context, policy llmProviderAdmissionPolicy) error {

--- a/internal/runtime/llm/provider_admission_test.go
+++ b/internal/runtime/llm/provider_admission_test.go
@@ -4,6 +4,10 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -13,6 +17,7 @@ import (
 	llmselection "github.com/division-sh/swarm/internal/runtime/llm/selection"
 	runtimerterr "github.com/division-sh/swarm/internal/runtime/rterrors"
 	"github.com/division-sh/swarm/internal/runtime/sessions"
+	workspace "github.com/division-sh/swarm/internal/runtime/workspace"
 )
 
 func TestProviderAdmissionDefaultsToNoLimitWhenUnconfigured(t *testing.T) {
@@ -102,6 +107,50 @@ func TestProviderAdmissionConcurrencyLimitFailsClosedAtMaxWait(t *testing.T) {
 		t.Fatalf("third Admit after release: %v", err)
 	}
 	release()
+}
+
+func TestProviderAdmissionDoesNotHoldConcurrencyWhileWaitingForRate(t *testing.T) {
+	controller := newLLMProviderAdmissionController()
+	policy := llmProviderAdmissionPolicy{
+		Profile:       mustAdmissionProfile(t, llmselection.BackendAnthropic),
+		BucketName:    "anthropic/api/regular",
+		RateBucketKey: "rate",
+		Rate: config.LLMProviderRateLimit{
+			Enabled: true,
+			Limit:   1,
+			Period:  time.Hour,
+			MaxWait: time.Hour,
+		},
+		ConcurrencyKey: "concurrency",
+		Concurrency: config.LLMProviderConcurrencyLimit{
+			Enabled: true,
+			Limit:   1,
+			MaxWait: 0,
+		},
+	}
+	controller.rateBucket(policy.RateBucketKey).scheduled = []time.Time{time.Now()}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() {
+		release, err := controller.Admit(ctx, policy)
+		if err == nil {
+			release()
+		}
+		done <- err
+	}()
+	time.Sleep(10 * time.Millisecond)
+
+	bucket := controller.concurrencyBucket(policy.ConcurrencyKey, policy.Concurrency.Limit)
+	if got := len(bucket.tokens); got != 1 {
+		t.Fatalf("available concurrency tokens = %d, want rate waiter not to hold token", got)
+	}
+
+	cancel()
+	if err := <-done; err == nil {
+		t.Fatal("Admit error = nil, want context cancellation after test cleanup")
+	}
 }
 
 func TestProviderAdmissionModelPolicyOverridesProfilePolicy(t *testing.T) {
@@ -307,8 +356,13 @@ func TestOpenAIResponsesProviderAdmissionRejectsBeforeHTTPDispatch(t *testing.T)
 }
 
 func TestClaudeCLIProviderAdmissionRejectsBeforeSubprocessDispatch(t *testing.T) {
+	t.Setenv("CLAUDE_CODE_OAUTH_TOKEN", "oauth-token")
 	cfg := &config.Config{
 		LLM: config.LLMConfig{
+			ClaudeCLI: config.ClaudeCLIConfig{
+				Command:      "claude",
+				OutputFormat: "json",
+			},
 			ProviderLimits: map[string]config.LLMProviderLimitPolicy{
 				llmselection.BackendClaudeCLI: {
 					MaxConcurrency:        1,
@@ -319,6 +373,11 @@ func TestClaudeCLIProviderAdmissionRejectsBeforeSubprocessDispatch(t *testing.T)
 	}
 	runtime := NewClaudeCLIRuntime(cfg, sessions.NewInMemoryRegistry(time.Second), "worker-1", nil, nil, nil, nil, nil)
 	ctx := runtimeactors.WithActor(context.Background(), runtimeactors.AgentConfig{ID: "agent-1", Model: llmselection.ModelAliasRegular})
+	scriptPath, countFile := writeProviderAdmissionFakeDocker(t, `cat >/dev/null
+printf '%s\n' '{"result":"done"}'
+`)
+	t.Setenv("SWARM_DOCKER_BIN", scriptPath)
+	target := &workspace.Target{Container: "swarm-agent", Workdir: "/workspace"}
 	profile := mustAdmissionProfile(t, llmselection.BackendClaudeCLI)
 	model := mustAdmissionModel(t, profile, llmselection.ModelAliasRegular)
 
@@ -328,8 +387,49 @@ func TestClaudeCLIProviderAdmissionRejectsBeforeSubprocessDispatch(t *testing.T)
 	}
 	defer release()
 
-	_, _, err = runtime.runAdmittedPromptTransportFallback(ctx, nil, nil, "hello", MonitorTurnMeta{})
+	_, err = runtime.runWithInput(ctx, nil, target, "hello", MonitorTurnMeta{})
 	requireProviderAdmissionRateLimited(t, err)
+	if got := readProviderAdmissionFakeDockerInvocations(t, countFile); got != 0 {
+		t.Fatalf("fake docker invocations = %d, want admission rejection before subprocess dispatch", got)
+	}
+}
+
+func TestClaudeCLIPromptFallbackConsumesAdmissionPerSubprocessAttempt(t *testing.T) {
+	t.Setenv("CLAUDE_CODE_OAUTH_TOKEN", "oauth-token")
+	cfg := &config.Config{
+		LLM: config.LLMConfig{
+			ClaudeCLI: config.ClaudeCLIConfig{
+				Command:      "claude",
+				OutputFormat: "json",
+			},
+			ProviderLimits: map[string]config.LLMProviderLimitPolicy{
+				llmselection.BackendClaudeCLI: {
+					RateLimit:        "1/h",
+					RateLimitMaxWait: "0s",
+				},
+			},
+		},
+	}
+	runtime := NewClaudeCLIRuntime(cfg, sessions.NewInMemoryRegistry(time.Second), "worker-1", nil, nil, nil, nil, nil)
+	ctx := runtimeactors.WithActor(context.Background(), runtimeactors.AgentConfig{ID: "agent-1", Model: llmselection.ModelAliasRegular})
+	scriptPath, countFile := writeProviderAdmissionFakeDocker(t, `cat >/dev/null
+if [ "$count" = "1" ]; then
+  printf '%s\n' 'input must be provided either through stdin or as a prompt argument when using --print' >&2
+  exit 1
+fi
+printf '%s\n' '{"result":"done"}'
+`)
+	t.Setenv("SWARM_DOCKER_BIN", scriptPath)
+	target := &workspace.Target{Container: "swarm-agent", Workdir: "/workspace"}
+
+	_, fallback, err := runtime.runWithPromptTransportFallback(ctx, []string{"--print"}, target, "hello", MonitorTurnMeta{})
+	requireProviderAdmissionRateLimited(t, err)
+	if !fallback.Attempted {
+		t.Fatalf("fallback = %#v, want prompt-argument fallback attempted", fallback)
+	}
+	if got := readProviderAdmissionFakeDockerInvocations(t, countFile); got != 1 {
+		t.Fatalf("fake docker invocations = %d, want second fallback subprocess rejected before dispatch", got)
+	}
 }
 
 func mustAdmissionProfile(t *testing.T, backend string) llmselection.Profile {
@@ -362,4 +462,41 @@ func requireProviderAdmissionRateLimited(t *testing.T, err error) {
 	if runtimeErr.Code != llmProviderRateLimitedCode || runtimeErr.Component != llmProviderAdmissionComponent || runtimeErr.Operation != llmProviderAdmissionOperation || !runtimeErr.Retryable {
 		t.Fatalf("runtime error = %#v, want provider admission rate_limited retryable error", runtimeErr)
 	}
+}
+
+func writeProviderAdmissionFakeDocker(t *testing.T, body string) (string, string) {
+	t.Helper()
+	dir := t.TempDir()
+	countFile := filepath.Join(dir, "invocations")
+	scriptPath := filepath.Join(dir, "fake-docker.sh")
+	script := strings.Join([]string{
+		"#!/bin/sh",
+		"set -eu",
+		"count_file=" + strconv.Quote(countFile),
+		"count=0",
+		"if [ -f \"$count_file\" ]; then count=$(cat \"$count_file\"); fi",
+		"count=$((count+1))",
+		"printf '%s' \"$count\" >\"$count_file\"",
+		body,
+	}, "\n") + "\n"
+	if err := os.WriteFile(scriptPath, []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake docker script: %v", err)
+	}
+	return scriptPath, countFile
+}
+
+func readProviderAdmissionFakeDockerInvocations(t *testing.T, countFile string) int {
+	t.Helper()
+	raw, err := os.ReadFile(countFile)
+	if os.IsNotExist(err) {
+		return 0
+	}
+	if err != nil {
+		t.Fatalf("read fake docker invocation count: %v", err)
+	}
+	count, err := strconv.Atoi(strings.TrimSpace(string(raw)))
+	if err != nil {
+		t.Fatalf("parse fake docker invocation count %q: %v", raw, err)
+	}
+	return count
 }

--- a/internal/runtime/llm/provider_admission_test.go
+++ b/internal/runtime/llm/provider_admission_test.go
@@ -153,6 +153,41 @@ func TestProviderAdmissionDoesNotHoldConcurrencyWhileWaitingForRate(t *testing.T
 	}
 }
 
+func TestProviderAdmissionRollsBackRateReservationWhenConcurrencyRejects(t *testing.T) {
+	controller := newLLMProviderAdmissionController()
+	policy := llmProviderAdmissionPolicy{
+		Profile:       mustAdmissionProfile(t, llmselection.BackendAnthropic),
+		BucketName:    "anthropic/api/regular",
+		RateBucketKey: "rate",
+		Rate: config.LLMProviderRateLimit{
+			Enabled: true,
+			Limit:   2,
+			Period:  time.Hour,
+			MaxWait: 0,
+		},
+		ConcurrencyKey: "concurrency",
+		Concurrency: config.LLMProviderConcurrencyLimit{
+			Enabled: true,
+			Limit:   1,
+			MaxWait: 0,
+		},
+	}
+
+	release, err := controller.Admit(context.Background(), policy)
+	if err != nil {
+		t.Fatalf("first Admit: %v", err)
+	}
+	_, err = controller.Admit(context.Background(), policy)
+	requireProviderAdmissionRateLimited(t, err)
+
+	release()
+	release, err = controller.Admit(context.Background(), policy)
+	if err != nil {
+		t.Fatalf("third Admit after concurrency rejection: %v", err)
+	}
+	release()
+}
+
 func TestProviderAdmissionModelPolicyOverridesProfilePolicy(t *testing.T) {
 	profile := mustAdmissionProfile(t, llmselection.BackendAnthropic)
 	regular := mustAdmissionModel(t, profile, llmselection.ModelAliasRegular)

--- a/internal/runtime/llm/provider_admission_test.go
+++ b/internal/runtime/llm/provider_admission_test.go
@@ -1,0 +1,365 @@
+package llm
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/division-sh/swarm/internal/config"
+	runtimeactors "github.com/division-sh/swarm/internal/runtime/core/actors"
+	llmselection "github.com/division-sh/swarm/internal/runtime/llm/selection"
+	runtimerterr "github.com/division-sh/swarm/internal/runtime/rterrors"
+	"github.com/division-sh/swarm/internal/runtime/sessions"
+)
+
+func TestProviderAdmissionDefaultsToNoLimitWhenUnconfigured(t *testing.T) {
+	profile := mustAdmissionProfile(t, llmselection.BackendAnthropic)
+	model := mustAdmissionModel(t, profile, llmselection.ModelAliasRegular)
+	registry := NewProviderAdmissionRegistry(&config.Config{})
+
+	for i := 0; i < 5; i++ {
+		release, err := registry.Admit(context.Background(), profile, model)
+		if err != nil {
+			t.Fatalf("Admit attempt %d: %v", i+1, err)
+		}
+		release()
+	}
+}
+
+func TestProviderAdmissionEmptyProfilePolicyDoesNotRequireModel(t *testing.T) {
+	profile := mustAdmissionProfile(t, llmselection.BackendAnthropic)
+	cfg := &config.Config{
+		LLM: config.LLMConfig{
+			ProviderLimits: map[string]config.LLMProviderLimitPolicy{
+				llmselection.BackendAnthropic: {},
+			},
+		},
+	}
+	registry := NewProviderAdmissionRegistry(cfg)
+
+	if _, err := resolveProviderAdmissionModel(context.Background(), cfg, registry, profile); err != nil {
+		t.Fatalf("resolveProviderAdmissionModel: %v", err)
+	}
+	release, err := registry.Admit(context.Background(), profile, llmselection.ResolvedModel{})
+	if err != nil {
+		t.Fatalf("Admit: %v", err)
+	}
+	release()
+}
+
+func TestProviderAdmissionRateLimitFailsClosedAtMaxWait(t *testing.T) {
+	profile := mustAdmissionProfile(t, llmselection.BackendAnthropic)
+	model := mustAdmissionModel(t, profile, llmselection.ModelAliasRegular)
+	registry := NewProviderAdmissionRegistry(&config.Config{
+		LLM: config.LLMConfig{
+			ProviderLimits: map[string]config.LLMProviderLimitPolicy{
+				llmselection.BackendAnthropic: {
+					RateLimit:        "1/s",
+					RateLimitMaxWait: "0s",
+				},
+			},
+		},
+	})
+
+	release, err := registry.Admit(context.Background(), profile, model)
+	if err != nil {
+		t.Fatalf("first Admit: %v", err)
+	}
+	release()
+
+	_, err = registry.Admit(context.Background(), profile, model)
+	requireProviderAdmissionRateLimited(t, err)
+}
+
+func TestProviderAdmissionConcurrencyLimitFailsClosedAtMaxWait(t *testing.T) {
+	profile := mustAdmissionProfile(t, llmselection.BackendAnthropic)
+	model := mustAdmissionModel(t, profile, llmselection.ModelAliasRegular)
+	registry := NewProviderAdmissionRegistry(&config.Config{
+		LLM: config.LLMConfig{
+			ProviderLimits: map[string]config.LLMProviderLimitPolicy{
+				llmselection.BackendAnthropic: {
+					MaxConcurrency:        1,
+					MaxConcurrencyMaxWait: "0s",
+				},
+			},
+		},
+	})
+
+	release, err := registry.Admit(context.Background(), profile, model)
+	if err != nil {
+		t.Fatalf("first Admit: %v", err)
+	}
+
+	_, err = registry.Admit(context.Background(), profile, model)
+	requireProviderAdmissionRateLimited(t, err)
+
+	release()
+	release, err = registry.Admit(context.Background(), profile, model)
+	if err != nil {
+		t.Fatalf("third Admit after release: %v", err)
+	}
+	release()
+}
+
+func TestProviderAdmissionModelPolicyOverridesProfilePolicy(t *testing.T) {
+	profile := mustAdmissionProfile(t, llmselection.BackendAnthropic)
+	regular := mustAdmissionModel(t, profile, llmselection.ModelAliasRegular)
+	cheap := mustAdmissionModel(t, profile, llmselection.ModelAliasCheap)
+	registry := NewProviderAdmissionRegistry(&config.Config{
+		LLM: config.LLMConfig{
+			ProviderLimits: map[string]config.LLMProviderLimitPolicy{
+				llmselection.BackendAnthropic: {
+					RateLimit:        "1/s",
+					RateLimitMaxWait: "0s",
+					Models: map[string]config.LLMProviderLimitPolicy{
+						llmselection.ModelAliasRegular: {
+							RateLimit:        "2/s",
+							RateLimitMaxWait: "0s",
+						},
+					},
+				},
+			},
+		},
+	})
+
+	for i := 0; i < 2; i++ {
+		release, err := registry.Admit(context.Background(), profile, regular)
+		if err != nil {
+			t.Fatalf("regular Admit %d: %v", i+1, err)
+		}
+		release()
+	}
+	_, err := registry.Admit(context.Background(), profile, regular)
+	requireProviderAdmissionRateLimited(t, err)
+
+	release, err := registry.Admit(context.Background(), profile, cheap)
+	if err != nil {
+		t.Fatalf("cheap first Admit: %v", err)
+	}
+	release()
+	_, err = registry.Admit(context.Background(), profile, cheap)
+	requireProviderAdmissionRateLimited(t, err)
+}
+
+func TestAnthropicProviderAdmissionAppliesToRetries(t *testing.T) {
+	t.Setenv("ANTHROPIC_API_KEY", "test-key")
+
+	var requests atomic.Int32
+	var firstRequest, secondRequest atomic.Int64
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		n := requests.Add(1)
+		now := time.Now().UnixNano()
+		w.Header().Set("content-type", "application/json")
+		switch n {
+		case 1:
+			firstRequest.Store(now)
+			w.WriteHeader(http.StatusTooManyRequests)
+			_, _ = w.Write([]byte(`{"error":{"message":"provider busy"}}`))
+		case 2:
+			secondRequest.Store(now)
+			_, _ = w.Write([]byte(`{"model":"claude-3-5-sonnet","usage":{"input_tokens":1,"output_tokens":1},"content":[{"type":"text","text":"done"}]}`))
+		default:
+			t.Fatalf("unexpected request %d", n)
+		}
+	}))
+	defer server.Close()
+
+	cfg := &config.Config{
+		LLM: config.LLMConfig{
+			Session: config.LLMSessionConfig{
+				LockTTL:               time.Second,
+				RotateAfterTurns:      40,
+				RotateOnParseFailures: 3,
+			},
+			ClaudeAPI: config.ClaudeAPIConfig{
+				MaxRetries:   2,
+				RetryBackoff: time.Millisecond,
+			},
+			ProviderLimits: map[string]config.LLMProviderLimitPolicy{
+				llmselection.BackendAnthropic: {
+					RateLimit:        "1/40ms",
+					RateLimitMaxWait: "500ms",
+				},
+			},
+		},
+	}
+	runtime := NewAnthropicAPIRuntime(cfg, sessions.NewInMemoryRegistry(time.Second), "worker-1", nil, nil, nil, nil)
+	runtime.apiURL = server.URL
+	runtime.apiKey = "test-key"
+
+	ctx := runtimeactors.WithActor(context.Background(), runtimeactors.AgentConfig{ID: "agent-1", Model: llmselection.ModelAliasRegular})
+	ctx = sessions.WithScope(ctx, sessions.RuntimeModeTask.String(), "", "task-1")
+	session, err := runtime.StartSession(ctx, "agent-1", "system", nil)
+	if err != nil {
+		t.Fatalf("StartSession: %v", err)
+	}
+	resp, err := runtime.ContinueSession(ctx, session, Message{Role: "user", Content: "hello"})
+	if err != nil {
+		t.Fatalf("ContinueSession: %v", err)
+	}
+	if resp.Message.Content != "done" {
+		t.Fatalf("response content = %q, want done", resp.Message.Content)
+	}
+	if got := requests.Load(); got != 2 {
+		t.Fatalf("requests = %d, want retry request", got)
+	}
+	elapsed := time.Duration(secondRequest.Load() - firstRequest.Load())
+	if elapsed < 25*time.Millisecond {
+		t.Fatalf("retry elapsed = %s, want provider admission to delay retry", elapsed)
+	}
+}
+
+func TestOpenAICompatibleProviderAdmissionRejectsBeforeHTTPDispatch(t *testing.T) {
+	t.Setenv("OPENAI_COMPATIBLE_API_KEY", "test-key")
+	cfg := openAICompatibleTestConfig("")
+	cfg.LLM.ProviderLimits = map[string]config.LLMProviderLimitPolicy{
+		llmselection.BackendOpenAICompatible: {
+			MaxConcurrency:        1,
+			MaxConcurrencyMaxWait: "0s",
+		},
+	}
+
+	entered := make(chan struct{})
+	releaseServer := make(chan struct{})
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if requests.Add(1) == 1 {
+			close(entered)
+			<-releaseServer
+		}
+		w.Header().Set("content-type", "application/json")
+		_, _ = w.Write([]byte(`{"model":"gpt-compatible","choices":[{"message":{"role":"assistant","content":"done"}}],"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}`))
+	}))
+	defer server.Close()
+	cfg.LLM.OpenAICompatible.BaseURL = server.URL
+
+	runtime := NewOpenAICompatibleRuntime(cfg, sessions.NewInMemoryRegistry(time.Second), "worker-1", nil, nil, nil, nil)
+	runtime.apiKey = "test-key"
+	profile := mustAdmissionProfile(t, llmselection.BackendOpenAICompatible)
+	model := mustAdmissionModel(t, profile, llmselection.ModelAliasRegular)
+	firstErr := make(chan error, 1)
+	go func() {
+		_, _, err := runtime.sendAdmittedRequest(context.Background(), profile, model, []byte(`{"model":"gpt-compatible","messages":[{"role":"user","content":"hello"}]}`))
+		firstErr <- err
+	}()
+	<-entered
+
+	_, _, err := runtime.sendAdmittedRequest(context.Background(), profile, model, []byte(`{"model":"gpt-compatible","messages":[{"role":"user","content":"second"}]}`))
+	requireProviderAdmissionRateLimited(t, err)
+	if got := requests.Load(); got != 1 {
+		t.Fatalf("requests = %d, want second request rejected before HTTP dispatch", got)
+	}
+
+	close(releaseServer)
+	if err := <-firstErr; err != nil {
+		t.Fatalf("first request: %v", err)
+	}
+}
+
+func TestOpenAIResponsesProviderAdmissionRejectsBeforeHTTPDispatch(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "test-key")
+	cfg := openAIResponsesTestConfig("")
+	cfg.LLM.ProviderLimits = map[string]config.LLMProviderLimitPolicy{
+		llmselection.BackendOpenAIResponses: {
+			MaxConcurrency:        1,
+			MaxConcurrencyMaxWait: "0s",
+		},
+	}
+
+	entered := make(chan struct{})
+	releaseServer := make(chan struct{})
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if requests.Add(1) == 1 {
+			close(entered)
+			<-releaseServer
+		}
+		w.Header().Set("content-type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"resp_1","model":"gpt-5.4","output":[{"type":"message","role":"assistant","content":[{"type":"output_text","text":"done"}]}],"usage":{"input_tokens":1,"output_tokens":1,"total_tokens":2}}`))
+	}))
+	defer server.Close()
+	cfg.LLM.OpenAIResponses.BaseURL = server.URL
+
+	runtime := NewOpenAIResponsesRuntime(cfg, sessions.NewInMemoryRegistry(time.Second), "worker-1", nil, nil, nil, nil)
+	runtime.apiKey = "test-key"
+	profile := mustAdmissionProfile(t, llmselection.BackendOpenAIResponses)
+	model := mustAdmissionModel(t, profile, llmselection.ModelAliasRegular)
+	firstErr := make(chan error, 1)
+	go func() {
+		_, _, err := runtime.sendAdmittedRequest(context.Background(), profile, model, []byte(`{"model":"gpt-5.4","input":[{"role":"user","content":"hello"}]}`))
+		firstErr <- err
+	}()
+	<-entered
+
+	_, _, err := runtime.sendAdmittedRequest(context.Background(), profile, model, []byte(`{"model":"gpt-5.4","input":[{"role":"user","content":"second"}]}`))
+	requireProviderAdmissionRateLimited(t, err)
+	if got := requests.Load(); got != 1 {
+		t.Fatalf("requests = %d, want second request rejected before HTTP dispatch", got)
+	}
+
+	close(releaseServer)
+	if err := <-firstErr; err != nil {
+		t.Fatalf("first request: %v", err)
+	}
+}
+
+func TestClaudeCLIProviderAdmissionRejectsBeforeSubprocessDispatch(t *testing.T) {
+	cfg := &config.Config{
+		LLM: config.LLMConfig{
+			ProviderLimits: map[string]config.LLMProviderLimitPolicy{
+				llmselection.BackendClaudeCLI: {
+					MaxConcurrency:        1,
+					MaxConcurrencyMaxWait: "0s",
+				},
+			},
+		},
+	}
+	runtime := NewClaudeCLIRuntime(cfg, sessions.NewInMemoryRegistry(time.Second), "worker-1", nil, nil, nil, nil, nil)
+	ctx := runtimeactors.WithActor(context.Background(), runtimeactors.AgentConfig{ID: "agent-1", Model: llmselection.ModelAliasRegular})
+	profile := mustAdmissionProfile(t, llmselection.BackendClaudeCLI)
+	model := mustAdmissionModel(t, profile, llmselection.ModelAliasRegular)
+
+	release, err := runtime.providerAdmission.Admit(ctx, profile, model)
+	if err != nil {
+		t.Fatalf("hold admission slot: %v", err)
+	}
+	defer release()
+
+	_, _, err = runtime.runAdmittedPromptTransportFallback(ctx, nil, nil, "hello", MonitorTurnMeta{})
+	requireProviderAdmissionRateLimited(t, err)
+}
+
+func mustAdmissionProfile(t *testing.T, backend string) llmselection.Profile {
+	t.Helper()
+	profile, err := llmselection.ResolveActiveBackend(backend)
+	if err != nil {
+		t.Fatalf("ResolveActiveBackend(%q): %v", backend, err)
+	}
+	return profile
+}
+
+func mustAdmissionModel(t *testing.T, profile llmselection.Profile, alias string) llmselection.ResolvedModel {
+	t.Helper()
+	model, err := llmselection.ResolveModel(profile, llmselection.ModelResolution{Model: alias})
+	if err != nil {
+		t.Fatalf("ResolveModel(%q, %q): %v", profile.ID, alias, err)
+	}
+	return model
+}
+
+func requireProviderAdmissionRateLimited(t *testing.T, err error) {
+	t.Helper()
+	if err == nil {
+		t.Fatal("error = nil, want provider admission rate_limited runtime error")
+	}
+	runtimeErr, ok := runtimerterr.AsRuntimeError(err)
+	if !ok {
+		t.Fatalf("error = %T %v, want runtime error", err, err)
+	}
+	if runtimeErr.Code != llmProviderRateLimitedCode || runtimeErr.Component != llmProviderAdmissionComponent || runtimeErr.Operation != llmProviderAdmissionOperation || !runtimeErr.Retryable {
+		t.Fatalf("runtime error = %#v, want provider admission rate_limited retryable error", runtimeErr)
+	}
+}

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -3815,6 +3815,53 @@ engine:
       - Implementing OpenAI Responses, OpenRouter, Ollama, Bedrock, Azure OpenAI, Vertex, vLLM, or any other additional
         provider remains a separate provider implementation/parity gate.
       - Native multi-backend-per-run remains deferred until a separate real user need is gated.
+    llm_provider_configured_outbound_admission:
+      promoted_by: '#1457'
+      implementation_status: configured_first_slice
+      description: >
+        Runtime LLM provider outbound admission is owned by runtime config plus
+        the shared internal/runtime/llm provider-admission registry. It applies
+        only when an operator declares limits for an active backend profile.
+        Absence of matching config means no provider admission limit. The
+        platform MUST NOT invent hardcoded numeric provider defaults.
+      owner: internal/runtime/llm provider admission registry consuming config llm.provider_limits
+      config_authority:
+        config_key: llm.provider_limits
+        profile_key_rule: Keys are active backend profile ids owned by llm_provider_selection_config_authority.
+        active_profile_keys:
+        - anthropic
+        - claude_cli
+        - openai_compatible
+        - openai_responses
+        supported_fields:
+          rate_limit: '<positive integer>/<period>, for example 60/m'
+          rate_limit_max_wait: 'Duration max wait before failing closed; 0s means reject immediately when queued.'
+          max_concurrency: Positive integer for simultaneous outbound requests/dispatches.
+          max_concurrency_max_wait: 'Duration max wait before failing closed; 0s means reject immediately when saturated.'
+          models: Optional map keyed by authored model alias or concrete provider model. Model entries override only the
+            limit dimensions they declare.
+        duration_units: ms, s, m, h, d
+        malformed_or_partial_policy: >
+          Unsupported profile keys, missing paired max-wait fields, invalid
+          duration syntax, non-positive limits, and nested model limit maps fail
+          closed during config validation.
+      runtime_rules:
+      - If llm.provider_limits is absent or has no entry for the active backend profile, provider admission is a no-op.
+      - Admission happens after backend/model resolution and before the outbound provider dispatch for API requests or CLI
+        subprocess dispatch.
+      - Anthropic API retry attempts, OpenAI-compatible requests, OpenAI Responses requests, and Claude CLI subprocess
+        dispatches all re-enter the same owner when configured.
+      - Bucket identity includes backend profile id, provider identity, transport, and either the profile-wide `*` model
+        bucket or the selected model-specific alias/concrete key.
+      - A wait timeout or immediate saturation returns a retryable runtime error with code rate_limited, component llm-provider,
+        and operation provider_admission before outbound dispatch.
+      split_boundaries:
+      - Exact TPM/default provider-limit semantics remain unimplemented until separately promoted; this slice only implements
+        explicit operator-configured admission.
+      - Agent scheduler/admission, tool/MCP rate limits, budget enforcement, session locking, and backend/provider selection
+        are separate owners and MUST NOT consume this section as their authority.
+      - OpenRouter, Ollama, Bedrock, Azure OpenAI, Vertex, vLLM, provider-specific quota discovery, and dynamic provider
+        adaptation remain separate provider-matrix gates.
     conversation_modes:
       description: How the platform manages agent session context across invocations. Public authored agent contracts
         use the field `mode`; the runtime persists the derived value in the internal `conversation_mode` column.


### PR DESCRIPTION
## Summary

Part of #1457.

This PR implements the approved first slice: configured LLM-provider outbound admission across active backend profiles, defaulting to no limit when no provider limit config is declared.

## Governing Refs / Context

- `platform-spec.yaml` `engine.agent_model.llm_provider_configured_outbound_admission` added in this PR.
- Existing governing sections: `engine.agent_model.llm_provider_adapter_contract` and `engine.agent_model.llm_provider_selection_config_authority`.
- Binding issue/gate context: #1457 Pre-Implementation Coverage Audit, approved as the first-slice `runtime.llm_provider_configured_outbound_admission` boundary.

## Semantic Migration

- New canonical owner: `internal/runtime/llm.ProviderAdmissionRegistry`, consuming `config.LLM.ProviderLimits` / `llm.provider_limits`.
- Old producer/reader/writer paths now invalid for configured provider admission: direct Anthropic/OpenAI HTTP dispatch without shared admission, Anthropic retry/backoff bypassing admission, and Claude CLI subprocess dispatch without the shared owner.
- Production paths checked/moved: Anthropic API initial dispatch and retry loop, OpenAI-compatible dispatch, OpenAI Responses dispatch, Claude CLI prompt dispatch wrapper, and `RuntimeFactory` construction.
- Migration completeness: complete for explicit configured request-rate/concurrency admission. Exact TPM/default provider-limit semantics remain residual on #1457 and are not claimed closed here.

## Proof

- `go test ./internal/runtime/llm ./internal/config -count=1`
- `go test ./...`

## Notes

- Missing provider limit config remains no-limit by default.
- Malformed or partial configured limits fail closed during config validation.
- The implementation does not change agent scheduling/admission, tool/MCP limits, budget semantics, session locking, or provider selection.