### PR TITLE
[agent-b][issue #1637] Demote store env precedence

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ relative paths for workspace files, and absolute paths follow the host
 deployment namespace and OS permissions. It is not command-limited or
 Docker-equivalent isolation, and Claude/provider host execution remains
 unsupported.
-Plain local `swarm run --contracts ...` uses SQLite at `.swarm/dev.db` unless
+Plain local `swarm run --contracts ...` uses SQLite at `.swarm/stores/dev.db` unless
 you explicitly opt into Postgres with `store.backend: postgres` in runtime
 config. Build or pull the configured workspace image (`swarm-workspace:latest`
 by default), or configure a compatible image before commands that start the

--- a/cmd/swarm/doctor_test.go
+++ b/cmd/swarm/doctor_test.go
@@ -348,9 +348,12 @@ func TestDoctorTargetJSONPreservesScriptableOutput(t *testing.T) {
 
 func TestDoctorTargetConsumesRuntimeConfigStoreAndData(t *testing.T) {
 	isolateCLIAPIConfigEnv(t)
+	unsetStoreSelectorEnv(t)
 	repo := writeDoctorTargetRepo(t)
 	sqlitePath := filepath.Join(t.TempDir(), "configured-dev.db")
 	dataDir := filepath.Join(t.TempDir(), "configured-data")
+	t.Setenv(storebackend.EnvStoreBackend, storebackend.BackendPostgres.String())
+	t.Setenv(storebackend.EnvSQLitePath, filepath.Join(t.TempDir(), "env-dev.db"))
 	configPath := writeDoctorTargetRuntimeConfig(t, `
 store:
   backend: sqlite

--- a/cmd/swarm/store_backend_selection_test.go
+++ b/cmd/swarm/store_backend_selection_test.go
@@ -38,7 +38,7 @@ func TestResolveRuntimeStoreSelectionConsumesCanonicalSources(t *testing.T) {
 		}
 	})
 
-	t.Run("env beats runtime config", func(t *testing.T) {
+	t.Run("runtime config beats env", func(t *testing.T) {
 		unsetStoreSelectorEnv(t)
 		t.Setenv(storebackend.EnvStoreBackend, storebackend.BackendPostgres.String())
 		got, err := resolveRuntimeStoreSelection(t.TempDir(), storebackend.ActiveDefaultBackend().String(), false, &config.Config{
@@ -47,8 +47,51 @@ func TestResolveRuntimeStoreSelectionConsumesCanonicalSources(t *testing.T) {
 		if err != nil {
 			t.Fatalf("resolveRuntimeStoreSelection: %v", err)
 		}
+		if got.Backend != storebackend.BackendSQLite || got.BackendSource != storebackend.SourceRuntimeConfig {
+			t.Fatalf("selection = %#v, want config-selected sqlite", got)
+		}
+	})
+
+	t.Run("env fallback remains visible", func(t *testing.T) {
+		unsetStoreSelectorEnv(t)
+		t.Setenv(storebackend.EnvStoreBackend, storebackend.BackendPostgres.String())
+		got, err := resolveRuntimeStoreSelection(t.TempDir(), storebackend.ActiveDefaultBackend().String(), false, &config.Config{})
+		if err != nil {
+			t.Fatalf("resolveRuntimeStoreSelection: %v", err)
+		}
 		if got.Backend != storebackend.BackendPostgres || got.BackendSource != storebackend.SourceEnvironment {
-			t.Fatalf("selection = %#v, want env-selected postgres", got)
+			t.Fatalf("selection = %#v, want env fallback postgres", got)
+		}
+	})
+
+	t.Run("runtime config sqlite path beats env", func(t *testing.T) {
+		unsetStoreSelectorEnv(t)
+		repo := t.TempDir()
+		t.Setenv(storebackend.EnvSQLitePath, "env/dev.db")
+		got, err := resolveRuntimeStoreSelection(repo, storebackend.ActiveDefaultBackend().String(), false, &config.Config{
+			Store: config.StoreConfig{
+				Backend: storebackend.BackendSQLite.String(),
+				SQLite:  config.StoreSQLiteConfig{Path: "config/dev.db"},
+			},
+		})
+		if err != nil {
+			t.Fatalf("resolveRuntimeStoreSelection: %v", err)
+		}
+		if want := filepath.Join(repo, "config", "dev.db"); got.SQLitePath != want || got.SQLitePathSource != storebackend.SourceRuntimeConfig {
+			t.Fatalf("sqlite path = %q source %q, want %q from runtime config", got.SQLitePath, got.SQLitePathSource, want)
+		}
+	})
+
+	t.Run("env sqlite path fallback remains visible", func(t *testing.T) {
+		unsetStoreSelectorEnv(t)
+		repo := t.TempDir()
+		t.Setenv(storebackend.EnvSQLitePath, "env/dev.db")
+		got, err := resolveRuntimeStoreSelection(repo, storebackend.ActiveDefaultBackend().String(), false, &config.Config{})
+		if err != nil {
+			t.Fatalf("resolveRuntimeStoreSelection: %v", err)
+		}
+		if want := filepath.Join(repo, "env", "dev.db"); got.SQLitePath != want || got.SQLitePathSource != storebackend.SourceEnvironment {
+			t.Fatalf("sqlite path = %q source %q, want %q from env fallback", got.SQLitePath, got.SQLitePathSource, want)
 		}
 	})
 
@@ -80,15 +123,19 @@ func TestRunServeRuntimeConsumesCanonicalStoreSelectionBeforeStoreConstruction(t
 		storeMode   string
 		storeFlag   bool
 		envBackend  string
+		envPath     string
 		configStore string
+		configPath  string
 		wantBackend storebackend.Backend
 		wantSource  storebackend.Source
+		wantPathSrc storebackend.Source
 	}{
 		{
 			name:        "rollout default sqlite reaches store construction",
 			storeMode:   storebackend.ActiveDefaultBackend().String(),
 			wantBackend: storebackend.BackendSQLite,
 			wantSource:  storebackend.SourceRolloutDefault,
+			wantPathSrc: storebackend.SourceSwarmDirDefault,
 		},
 		{
 			name:        "flag postgres reaches store construction",
@@ -96,16 +143,27 @@ func TestRunServeRuntimeConsumesCanonicalStoreSelectionBeforeStoreConstruction(t
 			storeFlag:   true,
 			envBackend:  storebackend.BackendSQLite.String(),
 			configStore: storebackend.BackendSQLite.String(),
+			configPath:  "config/dev.db",
 			wantBackend: storebackend.BackendPostgres,
 			wantSource:  storebackend.SourceFlag,
 		},
 		{
-			name:        "env postgres reaches store construction",
+			name:        "env postgres fallback reaches store construction",
 			storeMode:   storebackend.ActiveDefaultBackend().String(),
 			envBackend:  storebackend.BackendPostgres.String(),
-			configStore: storebackend.BackendSQLite.String(),
 			wantBackend: storebackend.BackendPostgres,
 			wantSource:  storebackend.SourceEnvironment,
+		},
+		{
+			name:        "config sqlite beats env selectors before store construction",
+			storeMode:   storebackend.ActiveDefaultBackend().String(),
+			envBackend:  storebackend.BackendPostgres.String(),
+			envPath:     "env/dev.db",
+			configStore: storebackend.BackendSQLite.String(),
+			configPath:  "config/dev.db",
+			wantBackend: storebackend.BackendSQLite,
+			wantSource:  storebackend.SourceRuntimeConfig,
+			wantPathSrc: storebackend.SourceRuntimeConfig,
 		},
 		{
 			name:        "config postgres reaches store construction",
@@ -121,6 +179,9 @@ func TestRunServeRuntimeConsumesCanonicalStoreSelectionBeforeStoreConstruction(t
 			if tt.envBackend != "" {
 				t.Setenv(storebackend.EnvStoreBackend, tt.envBackend)
 			}
+			if tt.envPath != "" {
+				t.Setenv(storebackend.EnvSQLitePath, tt.envPath)
+			}
 			oldBuildStores := buildStoresForServe
 			var captured storebackend.Selection
 			buildStoresForServe = func(_ context.Context, selection storebackend.Selection, _ *config.Config) (storeBundle, error) {
@@ -133,7 +194,7 @@ func TestRunServeRuntimeConsumesCanonicalStoreSelectionBeforeStoreConstruction(t
 
 			var out bytes.Buffer
 			code := runServeRuntime(context.Background(), t.TempDir(), serveOptions{
-				ConfigPath:         writeStoreBackendRuntimeConfig(t, tt.configStore, "config/dev.db"),
+				ConfigPath:         writeStoreBackendRuntimeConfig(t, tt.configStore, tt.configPath),
 				StoreMode:          tt.storeMode,
 				StoreModeSet:       tt.storeFlag,
 				APIListenAddr:      defaultAPIListenAddr,
@@ -150,7 +211,71 @@ func TestRunServeRuntimeConsumesCanonicalStoreSelectionBeforeStoreConstruction(t
 			if captured.Backend != tt.wantBackend || captured.BackendSource != tt.wantSource {
 				t.Fatalf("selection = %#v, want %s from %s", captured, tt.wantBackend, tt.wantSource)
 			}
+			if tt.wantPathSrc != "" && captured.SQLitePathSource != tt.wantPathSrc {
+				t.Fatalf("sqlite path source = %q, want %q in selection %#v", captured.SQLitePathSource, tt.wantPathSrc, captured)
+			}
 		})
+	}
+}
+
+func TestDatabaseEnvDetailsDoNotImplyPostgresSelection(t *testing.T) {
+	unsetStoreSelectorEnv(t)
+	t.Setenv("SWARM_DB_HOST", "db-env-host")
+	t.Setenv("SWARM_DB_PORT", "15432")
+	t.Setenv("SWARM_DB_NAME", "db_env_name")
+	t.Setenv("SWARM_DB_USER", "db_env_user")
+	t.Setenv("SWARM_DB_SSLMODE", "require")
+	t.Setenv("SWARM_DB_POOL_SIZE", "9")
+
+	cfg, err := defaultRuntimeConfig()
+	if err != nil {
+		t.Fatalf("defaultRuntimeConfig: %v", err)
+	}
+	if cfg.Database.Host != "db-env-host" || cfg.Database.Port != 15432 || cfg.Database.Name != "db_env_name" || cfg.Database.User != "db_env_user" || cfg.Database.SSLMode != "require" || cfg.Database.PoolSize != 9 {
+		t.Fatalf("database env fallback not reflected in built-in default config: %#v", cfg.Database)
+	}
+	got, err := resolveRuntimeStoreSelection(t.TempDir(), storebackend.ActiveDefaultBackend().String(), false, cfg)
+	if err != nil {
+		t.Fatalf("resolveRuntimeStoreSelection: %v", err)
+	}
+	if got.Backend != storebackend.BackendSQLite || got.BackendSource != storebackend.SourceRolloutDefault {
+		t.Fatalf("selection = %#v, want DB env details to leave backend at rollout default sqlite", got)
+	}
+}
+
+func TestExplicitRuntimeConfigDatabaseBeatsDatabaseEnv(t *testing.T) {
+	t.Setenv("SWARM_DB_HOST", "db-env-host")
+	t.Setenv("PGHOST", "pg-env-host")
+	t.Setenv("SWARM_DB_PASSWORD", "env-password")
+	t.Setenv("PGPASSWORD", "pg-env-password")
+
+	cfgResult, err := loadRuntimeConfigWithOptions(runtimeConfigLoadOptions{
+		RepoRoot:     t.TempDir(),
+		ExplicitPath: writeStoreDatabaseRuntimeConfig(t),
+	})
+	if err != nil {
+		t.Fatalf("loadRuntimeConfigWithOptions: %v", err)
+	}
+	got := cfgResult.Config.Database
+	if got.Host != "db-config-host" || got.Port != 15433 || got.Name != "db_config_name" || got.User != "db_config_user" || got.SSLMode != "verify-full" || got.PoolSize != 11 {
+		t.Fatalf("database config = %#v, want explicit runtime config values", got)
+	}
+	if got.Password != "" {
+		t.Fatalf("database password = %q, want absent password to remain unset rather than sourced from env", got.Password)
+	}
+}
+
+func TestRuntimeConfigExampleDoesNotPromoteDatabasePassword(t *testing.T) {
+	runtimeConfig, err := os.ReadFile(filepath.Join(repoRoot(), "runtime-config.example.yaml"))
+	if err != nil {
+		t.Fatalf("read runtime-config.example.yaml: %v", err)
+	}
+	text := string(runtimeConfig)
+	if strings.Contains(text, "password:") {
+		t.Fatalf("runtime-config.example.yaml must not promote plaintext DB password config:\n%s", text)
+	}
+	if !strings.Contains(text, "Keep credentials") || !strings.Contains(text, "swarm secrets") {
+		t.Fatalf("runtime-config.example.yaml must keep credential guidance out of plaintext config:\n%s", text)
 	}
 }
 
@@ -397,6 +522,32 @@ func writeStoreBackendRuntimeConfig(t *testing.T, backend string, sqlitePath str
 	)
 	path := filepath.Join(t.TempDir(), "swarm.yaml")
 	if err := os.WriteFile(path, []byte(strings.Join(lines, "\n")+"\n"), 0o644); err != nil {
+		t.Fatalf("write runtime config: %v", err)
+	}
+	return path
+}
+
+func writeStoreDatabaseRuntimeConfig(t *testing.T) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "swarm.yaml")
+	contents := strings.Join([]string{
+		"runtime:",
+		"  recovery_on_startup: false",
+		"database:",
+		"  host: db-config-host",
+		"  port: 15433",
+		"  name: db_config_name",
+		"  user: db_config_user",
+		"  sslmode: verify-full",
+		"  pool_size: 11",
+		"llm:",
+		"  backend: anthropic",
+		"  session:",
+		"    lock_ttl: 10s",
+		"    rotate_after_turns: 40",
+		"    rotate_on_parse_failures: 3",
+	}, "\n") + "\n"
+	if err := os.WriteFile(path, []byte(contents), 0o644); err != nil {
 		t.Fatalf("write runtime config: %v", err)
 	}
 	return path

--- a/internal/store/backendselection/selection.go
+++ b/internal/store/backendselection/selection.go
@@ -93,12 +93,12 @@ func resolveBackend(in Input) (Backend, Source, error) {
 	case in.FlagBackendSet:
 		backend, err := parseBackend(in.FlagBackend, SourceFlag)
 		return backend, SourceFlag, err
-	case in.EnvBackendSet:
-		backend, err := parseBackend(in.EnvBackend, SourceEnvironment)
-		return backend, SourceEnvironment, err
 	case strings.TrimSpace(in.ConfigBackend) != "":
 		backend, err := parseBackend(in.ConfigBackend, SourceRuntimeConfig)
 		return backend, SourceRuntimeConfig, err
+	case in.EnvBackendSet:
+		backend, err := parseBackend(in.EnvBackend, SourceEnvironment)
+		return backend, SourceEnvironment, err
 	default:
 		return ActiveDefaultBackend(), SourceRolloutDefault, nil
 	}
@@ -121,12 +121,12 @@ func parseBackend(raw string, source Source) (Backend, error) {
 
 func resolveSQLitePath(in Input) (string, Source, error) {
 	switch {
-	case in.EnvSQLitePathSet:
-		path, err := normalizeSQLitePath(in.RepoRoot, in.EnvSQLitePath, SourceEnvironment)
-		return path, SourceEnvironment, err
 	case strings.TrimSpace(in.ConfigSQLitePath) != "":
 		path, err := normalizeSQLitePath(in.RepoRoot, in.ConfigSQLitePath, SourceRuntimeConfig)
 		return path, SourceRuntimeConfig, err
+	case in.EnvSQLitePathSet:
+		path, err := normalizeSQLitePath(in.RepoRoot, in.EnvSQLitePath, SourceEnvironment)
+		return path, SourceEnvironment, err
 	default:
 		source := in.DefaultSQLitePathSource
 		if source == "" {

--- a/internal/store/backendselection/selection_test.go
+++ b/internal/store/backendselection/selection_test.go
@@ -30,12 +30,24 @@ func TestResolveBackendSourcePrecedence(t *testing.T) {
 			src:  SourceFlag,
 		},
 		{
-			name: "environment beats config",
+			name: "runtime config beats environment",
 			in: Input{
 				RepoRoot:                repo,
 				EnvBackend:              "sqlite",
 				EnvBackendSet:           true,
 				ConfigBackend:           "postgres",
+				DefaultSQLitePath:       filepath.Join(repo, "default.db"),
+				DefaultSQLitePathSource: SourceRolloutDefault,
+			},
+			want: BackendPostgres,
+			src:  SourceRuntimeConfig,
+		},
+		{
+			name: "environment fallback beats rollout default",
+			in: Input{
+				RepoRoot:                repo,
+				EnvBackend:              "sqlite",
+				EnvBackendSet:           true,
 				DefaultSQLitePath:       filepath.Join(repo, "default.db"),
 				DefaultSQLitePathSource: SourceRolloutDefault,
 			},
@@ -101,6 +113,20 @@ func TestResolveIgnoresInvalidLowerPriorityConfigBackend(t *testing.T) {
 	}
 }
 
+func TestResolveIgnoresInvalidLowerPriorityEnvironmentBackend(t *testing.T) {
+	got, err := Resolve(Input{
+		EnvBackend:    "mysql",
+		EnvBackendSet: true,
+		ConfigBackend: "postgres",
+	})
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if got.Backend != BackendPostgres || got.BackendSource != SourceRuntimeConfig {
+		t.Fatalf("selection = %#v, want config-selected postgres", got)
+	}
+}
+
 func TestResolveSQLitePathSources(t *testing.T) {
 	repo := t.TempDir()
 	tests := []struct {
@@ -110,7 +136,7 @@ func TestResolveSQLitePathSources(t *testing.T) {
 		src  Source
 	}{
 		{
-			name: "env path beats config",
+			name: "config path beats env path",
 			in: Input{
 				RepoRoot:                repo,
 				FlagBackend:             "sqlite",
@@ -118,6 +144,20 @@ func TestResolveSQLitePathSources(t *testing.T) {
 				EnvSQLitePath:           "env/dev.db",
 				EnvSQLitePathSet:        true,
 				ConfigSQLitePath:        "config/dev.db",
+				DefaultSQLitePath:       filepath.Join(repo, "default.db"),
+				DefaultSQLitePathSource: SourceRolloutDefault,
+			},
+			want: filepath.Join(repo, "config", "dev.db"),
+			src:  SourceRuntimeConfig,
+		},
+		{
+			name: "env path fallback beats default",
+			in: Input{
+				RepoRoot:                repo,
+				FlagBackend:             "sqlite",
+				FlagBackendSet:          true,
+				EnvSQLitePath:           "env/dev.db",
+				EnvSQLitePathSet:        true,
 				DefaultSQLitePath:       filepath.Join(repo, "default.db"),
 				DefaultSQLitePathSource: SourceRolloutDefault,
 			},

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -2913,12 +2913,12 @@ engine:
     canonical_owner: internal/store/backendselection runtime store backend resolver
     description: >
       Runtime store backend selection is owned by one typed resolver before runtime store construction. CLI flags,
-      environment variables, runtime config, harnesses, and local foreground startup may collect selector input, but they
-      must consume this owner rather than interpreting backend strings independently.
+      runtime config, deprecated environment fallback, harnesses, and local foreground startup may collect selector input,
+      but they must consume this owner rather than interpreting backend strings independently.
     backend_ids:
       postgres:
         status: active_supported_runtime_backend
-        meaning: External Postgres runtime store. Postgres remains explicitly selectable for production and existing operator deployments through flag, environment, or runtime config.
+        meaning: External Postgres runtime store. Postgres remains explicitly selectable for production and existing operator deployments through flag, runtime config, or deprecated environment fallback.
       sqlite:
         status: active_local_dev_default_runtime_backend
         meaning: >
@@ -2930,35 +2930,37 @@ engine:
     selector_precedence:
       source_order:
       - flag
-      - environment
       - runtime_config
+      - deprecated_environment
       - rollout_default
       flag:
         command: swarm serve
         name: --store <backend>
-      environment:
-        backend: SWARM_STORE_BACKEND
       runtime_config:
         backend_key: store.backend
+      deprecated_environment:
+        backend: SWARM_STORE_BACKEND
+        status: deprecated_transition_fallback
+        rule: Environment fallback remains visible for transition only and MUST NOT outrank typed runtime config.
       rollout_default:
         active_no_selection_default: sqlite
         postgres_opt_in_backend: postgres
         rule: >
           No-selection local/dev runtime startup resolves to SQLite. Postgres remains explicitly selectable through
-          --store postgres, SWARM_STORE_BACKEND=postgres, or store.backend=postgres and remains the production/external
-          backend.
+          --store postgres, store.backend=postgres, or deprecated SWARM_STORE_BACKEND=postgres fallback and remains the
+          production/external backend.
     sqlite_path:
       canonical_owner: internal/store/backendselection SQLite path resolver
-      environment: SWARM_SQLITE_PATH
       runtime_config_key: store.sqlite.path
+      deprecated_environment: SWARM_SQLITE_PATH
       default_authority: platform-spec.yaml#cli_specification.foundations.local_runtime_state_authority
       project_default_path: .swarm/stores/dev.db
       no_project_default_path: <swarm-dir>/stores/default/dev.db
       borrowed_project_default_path: <swarm-dir>/stores/projects/<project-key>/dev.db
       legacy_repo_relative_path: .swarm/dev.db
       source_order:
-      - environment
       - runtime_config
+      - deprecated_environment
       - local_runtime_state_default
       lifecycle:
       - Project-local startup whose canonical project root matches the active repo root uses `<project-root>/.swarm/stores/dev.db`.
@@ -2986,7 +2988,9 @@ engine:
       rule: >
         Existing SWARM_DB_* / PG* variables and database.* config keys are Postgres connection details after the canonical
         selector resolves to postgres. They are not generic backend selectors and must not imply backend selection by
-        presence alone.
+        presence alone. Non-secret connection details are owned by typed runtime config, with environment variables retained
+        only as deprecated transition fallback or deliberate external Postgres compatibility. SWARM_DB_PASSWORD and PGPASSWORD
+        are STORE-class secret material under #1600 and are not closed by the non-secret source-order child.
     runtime_backend_rule:
     - Unsupported backend ids fail closed with supported backend guidance.
     - >
@@ -2994,8 +2998,8 @@ engine:
       without passing a raw runtime SQL handle into Postgres-only runtime consumers. runtime.NewRuntime must consume
       backend-neutral owners for runtime construction, including #1186 mailbox_write materialization and #1157 agent.usage
       reads.
-    - Explicit postgres selection must remain available through flag, environment, and runtime config and must reach the
-      existing Postgres runtime store path.
+    - Explicit postgres selection must remain available through flag, runtime config, and deprecated environment fallback
+      and must reach the existing Postgres runtime store path.
     - >
       Local/dev SQLite `swarm run --contracts` may stamp an ephemeral bundle source fact when no Postgres bundle catalog
       is present. DB-loaded `--bundle-hash` boot remains Postgres-only until a separate bundle-catalog portability owner
@@ -11918,8 +11922,8 @@ cli_specification:
           root or a directory under it. Explicit `--contracts` paths outside the active repo root are borrowed-project inputs.
       store_resolution:
         sqlite_source_order:
-        - SWARM_SQLITE_PATH
         - store.sqlite.path
+        - SWARM_SQLITE_PATH
         - project_default_or_swarm_dir_default
         project_default: <project-root>/.swarm/stores/dev.db
         no_project_default: <swarm-dir>/stores/default/dev.db


### PR DESCRIPTION
Closes #1637

## Summary

- Demotes `SWARM_STORE_BACKEND` and `SWARM_SQLITE_PATH` below typed runtime config in the canonical store backend resolver.
- Keeps env-only fallback visible as `SourceEnvironment` for the approved deprecated-transition path.
- Adds supported CLI-path proof for serve/store construction, doctor target reporting, runtime config DB precedence, and DB-env-not-selector behavior.
- Updates `platform-spec.yaml` to make the changed source-authority order merge-bearing.

## Governing refs/context

Exact spec refs updated in this PR:

- `platform-spec.yaml#capabilities.runtime_store_backend_selection`
- `platform-spec.yaml#capabilities.runtime_store_backend_selection.selector_precedence`
- `platform-spec.yaml#capabilities.runtime_store_backend_selection.sqlite_path`
- `platform-spec.yaml#capabilities.runtime_store_backend_selection.postgres_connection_details`
- `platform-spec.yaml#cli_specification.foundations.local_runtime_state_authority.store_resolution`

Binding issue/gate context:

- #1637 issue body
- #1637 Pre-Implementation Coverage Audit comment
- #1637 Gate B review comment approving first-slice implementation
- #1600 REMOVE / STORE / KEEP-ENV parent model

## Semantic migration

New canonical owner:

- `internal/store/backendselection.Resolve` remains the canonical backend/SQLite selector.
- Typed runtime config now outranks deprecated env fallback for `store.backend` and `store.sqlite.path`.

Old producer/reader path now invalid:

- `SWARM_STORE_BACKEND` no longer overrides `store.backend`.
- `SWARM_SQLITE_PATH` no longer overrides `store.sqlite.path`.
- Spec source orders no longer present env as equal/normal store source authority.

Production paths checked for surviving old behavior:

- `swarm serve` via `runServeRuntime -> resolveLocalRuntimeState -> backendselection.Resolve`.
- Foreground `swarm run` via `startLocalRunServe -> runServeRuntime`.
- `swarm doctor --target` via `resolveDoctorTargetStore`.
- Internal fork harness via `resolveRuntimeStoreSelection` into the same canonical resolver.
- `buildStores` confirmed to consume typed `storebackend.Selection`, not env.

Migration complete for the chosen class: yes, for store backend and SQLite path precedence. DB password secure-source migration is explicitly not claimed; it remains #1600 STORE-class parent work per the approved gate.

## Proof

- `go test ./internal/store/backendselection`
- `go test ./cmd/swarm -run 'TestResolveRuntimeStoreSelectionConsumesCanonicalSources|TestRunServeRuntimeConsumesCanonicalStoreSelectionBeforeStoreConstruction|TestDatabaseEnvDetailsDoNotImplyPostgresSelection|TestExplicitRuntimeConfigDatabaseBeatsDatabaseEnv|TestRuntimeConfigExampleDoesNotPromoteDatabasePassword|TestDoctorTargetConsumesRuntimeConfigStoreAndData|TestDoctorTargetConsumesRuntimeConfigPostgresStore'`
- `go test ./cmd/swarm`
- `go test ./...`
- `go run ./cmd/swarm-openrpc-gen --check`