### PR TITLE
[agent-a][issue #1570] Reconcile save_entity_field dotted paths

### DIFF
--- a/internal/apispec/platform_spec_save_entity_field_test.go
+++ b/internal/apispec/platform_spec_save_entity_field_test.go
@@ -1,0 +1,32 @@
+package apispec
+
+import "testing"
+
+func TestPlatformSpecSaveEntityFieldDeclaredDottedReplacement(t *testing.T) {
+	root := loadPlatformSpecYAMLNode(t)
+
+	rule := mustYAMLPath(t, root, "runtime_enforcement", "save_entity_field", "rule")
+	assertScalarContains(t, rule, "declared dotted subpaths")
+	assertScalarContains(t, rule, "named types")
+	assertScalarContains(t, rule, "whole-value replacement")
+	assertScalarContains(t, rule, "Bracket")
+	assertScalarContains(t, rule, "index")
+	assertScalarContains(t, rule, "dynamic path writes are rejected")
+	assertScalarContains(t, rule, "Materialized/runtime-owned fields are rejected")
+
+	inputField := mustYAMLPath(t, root, "tool_model", "platform_builtin_tools", "entity_tool_schemas", "save_entity_field", "input", "field")
+	assertScalarContains(t, inputField, "declared top-level field name or declared dotted subpath")
+	assertScalarContains(t, inputField, "must not be an envelope field")
+
+	validation := mustYAMLPath(t, root, "tool_model", "platform_builtin_tools", "entity_tool_schemas", "save_entity_field", "validation")
+	assertScalarContains(t, validation, "bracket/index/dynamic paths")
+	assertScalarContains(t, validation, "Values must satisfy the resolved declared type")
+}
+
+func TestPlatformSpecGeneratedEntityUpdatesConsumeSaveEntityFieldPathOwner(t *testing.T) {
+	root := loadPlatformSpecYAMLNode(t)
+	updatePath := mustYAMLPath(t, root, "contract_formats", "persistence_model", "role_scoped_entity_tools", "generated_writes", "update_path")
+
+	assertScalarContains(t, updatePath, "exact declared subpath type")
+	assertScalarContains(t, updatePath, "same declared dotted replacement owner as save_entity_field")
+}

--- a/internal/runtime/bootverify/report_test.go
+++ b/internal/runtime/bootverify/report_test.go
@@ -4401,6 +4401,81 @@ types:
 	}
 }
 
+func TestRun_ReportsPromptSaveEntityFieldReadOnlyListSelectorWithAllAuthorization(t *testing.T) {
+	root := writePromptWriterCoverageFixture(t, `
+writer:
+  id: writer
+  role: writer
+  mode: task
+  prompt_ref: writer
+  workspace_class: factory
+  manager_fallback: ops
+  entity_writes:
+    case:
+      save: all
+`, `
+case:
+  validation_kit:
+    type: ValidationKit
+`, "Use `save_entity_field` for `validation_kit.checklist.size`.\n")
+	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "child", "types.yaml"), `
+types:
+  ValidationKit:
+    checklist: list<text>
+`)
+	bundle := loadFixtureBundleAt(t, repoRootForBootverifyTest(t), root, runtimecontracts.DefaultPlatformSpecFile(repoRootForBootverifyTest(t)))
+
+	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+
+	if !reportContains(report.Errors(), "entity_writer_coverage", "undeclared field path validation_kit.checklist.size") {
+		t.Fatalf("expected prompt save_entity_field list selector validation error, got %#v", report.Errors())
+	}
+}
+
+func TestRun_ReportsPromptSaveEntityFieldRootReadPinWithAllAuthorization(t *testing.T) {
+	root := writePromptWriterCoverageFixture(t, `
+writer:
+  id: writer
+  role: writer
+  mode: task
+  prompt_ref: writer
+  workspace_class: factory
+  manager_fallback: ops
+  entity_writes:
+    case:
+      save: all
+`, `
+case:
+  local_status:
+    type: text
+`, "Use `save_entity_field` for `priority`.\n")
+	writeBootverifyFixtureFile(t, filepath.Join(root, "entities.yaml"), `
+root_case:
+  priority:
+    type: integer
+    _unused_reason: child read-pin save-path validation proof
+`)
+	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "child", "schema.yaml"), `
+name: child
+initial_state: idle
+terminal_states: [done]
+states: [idle, done]
+pins:
+  inputs:
+    events: []
+    reads: [priority]
+  outputs:
+    events: []
+`)
+	bundle := loadFixtureBundleAt(t, repoRootForBootverifyTest(t), root, runtimecontracts.DefaultPlatformSpecFile(repoRootForBootverifyTest(t)))
+
+	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+
+	if !reportContains(report.Errors(), "entity_writer_coverage", "undeclared field path priority") {
+		t.Fatalf("expected prompt save_entity_field root read-pin validation error, got %#v", report.Errors())
+	}
+}
+
 func TestRun_PromptEntityWritesPrefersFlowScopedAuthorization(t *testing.T) {
 	root := writePromptWriterCoverageFixture(t, `
 writer:

--- a/internal/runtime/bootverify/report_test.go
+++ b/internal/runtime/bootverify/report_test.go
@@ -4338,6 +4338,42 @@ types:
 	}
 }
 
+func TestRun_ReportsPromptSaveEntityFieldMultilineDottedPathWithoutRootAuthorization(t *testing.T) {
+	root := writePromptWriterCoverageFixture(t, `
+writer:
+  id: writer
+  role: writer
+  mode: task
+  prompt_ref: writer
+  workspace_class: factory
+  manager_fallback: ops
+  entity_writes:
+    case:
+      save:
+      - research_context
+`, `
+case:
+  metadata:
+    type: Metadata
+    _unused_reason: prompt save auth proof
+  research_context:
+    type: text
+    _unused_reason: prompt save auth proof
+`, "Use save_entity_field.\n- `metadata.region`\n")
+	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "child", "types.yaml"), `
+types:
+  Metadata:
+    region: text
+`)
+	bundle := loadFixtureBundleAt(t, repoRootForBootverifyTest(t), root, runtimecontracts.DefaultPlatformSpecFile(repoRootForBootverifyTest(t)))
+
+	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+
+	if !reportContains(report.Errors(), "entity_writer_coverage", "metadata.region") {
+		t.Fatalf("expected multiline prompt save_entity_field dotted authorization error, got %#v", report.Errors())
+	}
+}
+
 func TestRun_ReportsPromptSaveEntityFieldUndeclaredDottedPath(t *testing.T) {
 	root := writePromptWriterCoverageFixture(t, `
 writer:

--- a/internal/runtime/bootverify/report_test.go
+++ b/internal/runtime/bootverify/report_test.go
@@ -4270,6 +4270,137 @@ case:
 	}
 }
 
+func TestRun_PromptSaveEntityFieldAllowsDeclaredDottedPathAuthorizedByRootField(t *testing.T) {
+	root := writePromptWriterCoverageFixture(t, `
+writer:
+  id: writer
+  role: writer
+  mode: task
+  prompt_ref: writer
+  workspace_class: factory
+  manager_fallback: ops
+  entity_writes:
+    case:
+      save:
+      - metadata
+`, `
+case:
+  metadata:
+    type: Metadata
+`, "Use `save_entity_field` for `metadata.region`.\n")
+	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "child", "types.yaml"), `
+types:
+  Metadata:
+    region: text
+`)
+	bundle := loadFixtureBundleAt(t, repoRootForBootverifyTest(t), root, runtimecontracts.DefaultPlatformSpecFile(repoRootForBootverifyTest(t)))
+
+	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+
+	if reportContains(report.Errors(), "entity_writer_coverage", "metadata.region") {
+		t.Fatalf("unexpected prompt save_entity_field dotted authorization error, got %#v", report.Errors())
+	}
+}
+
+func TestRun_ReportsPromptSaveEntityFieldDottedPathWithoutRootAuthorization(t *testing.T) {
+	root := writePromptWriterCoverageFixture(t, `
+writer:
+  id: writer
+  role: writer
+  mode: task
+  prompt_ref: writer
+  workspace_class: factory
+  manager_fallback: ops
+  entity_writes:
+    case:
+      save:
+      - research_context
+`, `
+case:
+  metadata:
+    type: Metadata
+    _unused_reason: prompt save auth proof
+  research_context:
+    type: text
+    _unused_reason: prompt save auth proof
+`, "Use `save_entity_field` for `metadata.region`.\n")
+	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "child", "types.yaml"), `
+types:
+  Metadata:
+    region: text
+`)
+	bundle := loadFixtureBundleAt(t, repoRootForBootverifyTest(t), root, runtimecontracts.DefaultPlatformSpecFile(repoRootForBootverifyTest(t)))
+
+	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+
+	if !reportContains(report.Errors(), "entity_writer_coverage", "metadata.region") {
+		t.Fatalf("expected prompt save_entity_field dotted authorization error, got %#v", report.Errors())
+	}
+}
+
+func TestRun_ReportsPromptSaveEntityFieldUndeclaredDottedPath(t *testing.T) {
+	root := writePromptWriterCoverageFixture(t, `
+writer:
+  id: writer
+  role: writer
+  mode: task
+  prompt_ref: writer
+  workspace_class: factory
+  manager_fallback: ops
+  entity_writes:
+    case:
+      save:
+      - metadata
+`, `
+case:
+  metadata:
+    type: Metadata
+`, "Use `save_entity_field` for `metadata.missing`.\n")
+	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "child", "types.yaml"), `
+types:
+  Metadata:
+    region: text
+`)
+	bundle := loadFixtureBundleAt(t, repoRootForBootverifyTest(t), root, runtimecontracts.DefaultPlatformSpecFile(repoRootForBootverifyTest(t)))
+
+	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+
+	if !reportContains(report.Errors(), "entity_writer_coverage", "undeclared field path metadata.missing") {
+		t.Fatalf("expected prompt save_entity_field dotted path validation error, got %#v", report.Errors())
+	}
+}
+
+func TestRun_ReportsPromptSaveEntityFieldUndeclaredDottedPathWithAllAuthorization(t *testing.T) {
+	root := writePromptWriterCoverageFixture(t, `
+writer:
+  id: writer
+  role: writer
+  mode: task
+  prompt_ref: writer
+  workspace_class: factory
+  manager_fallback: ops
+  entity_writes:
+    case:
+      save: all
+`, `
+case:
+  metadata:
+    type: Metadata
+`, "Use `save_entity_field` for `metadata.missing`.\n")
+	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "child", "types.yaml"), `
+types:
+  Metadata:
+    region: text
+`)
+	bundle := loadFixtureBundleAt(t, repoRootForBootverifyTest(t), root, runtimecontracts.DefaultPlatformSpecFile(repoRootForBootverifyTest(t)))
+
+	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+
+	if !reportContains(report.Errors(), "entity_writer_coverage", "undeclared field path metadata.missing") {
+		t.Fatalf("expected prompt save_entity_field all-authorization path validation error, got %#v", report.Errors())
+	}
+}
+
 func TestRun_PromptEntityWritesPrefersFlowScopedAuthorization(t *testing.T) {
 	root := writePromptWriterCoverageFixture(t, `
 writer:

--- a/internal/runtime/bootverify/workflow_entity_contract_coverage_checks.go
+++ b/internal/runtime/bootverify/workflow_entity_contract_coverage_checks.go
@@ -331,7 +331,7 @@ func wave1PromptEntityWriteAuthorizationFindings(source semanticview.Source) []F
 			continue
 		}
 		for _, field := range item.SaveFields {
-			if err := wave1PromptSaveEntityFieldPathValid(source, contract, field); err != nil {
+			if err := wave1PromptSaveEntityFieldPathValid(contract, field); err != nil {
 				findings = append(findings, Finding{
 					CheckID:  "entity_writer_coverage",
 					Severity: SeverityHardInvalidity,
@@ -356,13 +356,24 @@ func wave1PromptEntityWriteAuthorizationFindings(source semanticview.Source) []F
 	return findings
 }
 
-func wave1PromptSaveEntityFieldPathValid(source semanticview.Source, contract wave1EntityContractView, field string) error {
+func wave1PromptSaveEntityFieldPathValid(contract wave1EntityContractView, field string) error {
 	field = strings.TrimSpace(field)
 	if field == "" {
 		return fmt.Errorf("field is required")
 	}
-	_, err := wave1ResolveEntityPath(source, contract.FlowID, "entity."+field)
-	return err
+	resolved, err := entityruntime.ResolveFieldPath(entityruntime.Contract{
+		FlowID:     contract.FlowID,
+		EntityType: contract.EntityType,
+		Entity:     contract.Contract,
+		Types:      contract.Types,
+	}, field)
+	if err != nil {
+		return err
+	}
+	if strings.TrimSpace(resolved.FieldDecl.MaterializeFrom) != "" {
+		return fmt.Errorf("field %s is materialized by runtime accumulator projection and is not agent-writable", field)
+	}
+	return nil
 }
 
 func wave1PromptSaveEntityFieldAuthorized(rule runtimecontracts.AgentEntityWriteRule, field string) bool {

--- a/internal/runtime/bootverify/workflow_entity_contract_coverage_checks.go
+++ b/internal/runtime/bootverify/workflow_entity_contract_coverage_checks.go
@@ -327,22 +327,64 @@ func wave1PromptEntityWriteAuthorizationFindings(source semanticview.Source) []F
 			})
 			continue
 		}
-		if !item.SaveEntity || writeDecl.Save.All {
+		if !item.SaveEntity {
 			continue
 		}
 		for _, field := range item.SaveFields {
-			if writeDecl.Save.AllowsField(field) {
+			if err := wave1PromptSaveEntityFieldPathValid(source, contract, field); err != nil {
+				findings = append(findings, Finding{
+					CheckID:  "entity_writer_coverage",
+					Severity: SeverityHardInvalidity,
+					Message:  fmt.Sprintf("agent %s prompt declares save_entity_field for undeclared field path %s on flow %s entity_type %s: %v", item.AgentID, field, defaultFlowLabel(contract.FlowID), contract.EntityType, err),
+					Location: item.PromptFile,
+				})
 				continue
 			}
-			findings = append(findings, Finding{
-				CheckID:  "entity_writer_coverage",
-				Severity: SeverityHardInvalidity,
-				Message:  fmt.Sprintf("agent %s prompt declares save_entity_field for field %s on flow %s entity_type %s without matching agents.yaml entity_writes.%s.save authorization", item.AgentID, field, defaultFlowLabel(contract.FlowID), contract.EntityType, contract.EntityType),
-				Location: item.PromptFile,
-			})
+			if writeDecl.Save.All {
+				continue
+			}
+			if !wave1PromptSaveEntityFieldAuthorized(writeDecl.Save, field) {
+				findings = append(findings, Finding{
+					CheckID:  "entity_writer_coverage",
+					Severity: SeverityHardInvalidity,
+					Message:  fmt.Sprintf("agent %s prompt declares save_entity_field for field %s on flow %s entity_type %s without matching agents.yaml entity_writes.%s.save authorization", item.AgentID, field, defaultFlowLabel(contract.FlowID), contract.EntityType, contract.EntityType),
+					Location: item.PromptFile,
+				})
+			}
 		}
 	}
 	return findings
+}
+
+func wave1PromptSaveEntityFieldPathValid(source semanticview.Source, contract wave1EntityContractView, field string) error {
+	field = strings.TrimSpace(field)
+	if field == "" {
+		return fmt.Errorf("field is required")
+	}
+	_, err := wave1ResolveEntityPath(source, contract.FlowID, "entity."+field)
+	return err
+}
+
+func wave1PromptSaveEntityFieldAuthorized(rule runtimecontracts.AgentEntityWriteRule, field string) bool {
+	field = strings.TrimSpace(field)
+	if field == "" {
+		return false
+	}
+	if rule.All {
+		return true
+	}
+	root, _, _ := strings.Cut(field, ".")
+	root = strings.TrimSpace(root)
+	for _, candidate := range rule.Fields {
+		candidate = strings.TrimSpace(candidate)
+		if candidate == "" {
+			continue
+		}
+		if candidate == field || candidate == root {
+			return true
+		}
+	}
+	return false
 }
 
 func wave1PromptEntityWriteDecl(entry runtimecontracts.AgentRegistryEntry, contract wave1EntityContractView) (runtimecontracts.AgentEntityWriteDecl, bool) {

--- a/internal/runtime/contracts/prompt_entity_writes.go
+++ b/internal/runtime/contracts/prompt_entity_writes.go
@@ -86,22 +86,55 @@ func extractPromptEntityWriteEvidence(promptText string) (bool, bool, []string) 
 		return createEntity, false, nil
 	}
 	fields := make([]string, 0)
+	collectingSaveFields := false
+	sawSaveFieldInBlock := false
+	blankContinuationBudget := 0
 	for _, rawLine := range strings.Split(promptText, "\n") {
 		line := strings.TrimSpace(rawLine)
-		if line == "" || !promptContainsToken(line, "save_entity_field") {
+		lineHasSaveEntity := promptContainsToken(line, "save_entity_field")
+		switch {
+		case lineHasSaveEntity:
+			collectingSaveFields = true
+			sawSaveFieldInBlock = false
+			blankContinuationBudget = 1
+		case !collectingSaveFields:
+			continue
+		case line == "":
+			if sawSaveFieldInBlock || blankContinuationBudget == 0 {
+				collectingSaveFields = false
+				sawSaveFieldInBlock = false
+				blankContinuationBudget = 0
+			} else {
+				blankContinuationBudget--
+			}
 			continue
 		}
 		matches := promptSaveFieldPattern.FindAllStringSubmatch(line, -1)
+		collectedFromLine := false
 		for _, match := range matches {
 			if len(match) < 2 {
 				continue
 			}
 			field := strings.TrimSpace(match[1])
-			if field == "" || field == "save_entity_field" {
+			if promptEntityWriteToolToken(field) {
 				continue
 			}
 			fields = append(fields, field)
+			collectedFromLine = true
+		}
+		if collectedFromLine {
+			sawSaveFieldInBlock = true
+			blankContinuationBudget = 0
 		}
 	}
 	return createEntity, true, uniquePromptStrings(fields)
+}
+
+func promptEntityWriteToolToken(token string) bool {
+	switch strings.TrimSpace(token) {
+	case "", "create_entity", "get_entity", "query_entities", "query_metrics", "save_entity_field", "search_entities":
+		return true
+	default:
+		return false
+	}
 }

--- a/internal/runtime/contracts/prompt_entity_writes.go
+++ b/internal/runtime/contracts/prompt_entity_writes.go
@@ -18,7 +18,7 @@ type PromptEntityWriteEvidence struct {
 	SaveFields   []string
 }
 
-var promptSaveFieldPattern = regexp.MustCompile("`([a-zA-Z_][a-zA-Z0-9_]*)`")
+var promptSaveFieldPattern = regexp.MustCompile("`([a-zA-Z_][a-zA-Z0-9_]*(?:\\.[a-zA-Z_][a-zA-Z0-9_]*)*)`")
 
 func DerivePromptEntityWriteEvidence(bundle *WorkflowContractBundle) ([]PromptEntityWriteEvidence, error) {
 	if bundle == nil {

--- a/internal/runtime/contracts/prompt_entity_writes_test.go
+++ b/internal/runtime/contracts/prompt_entity_writes_test.go
@@ -104,6 +104,16 @@ func TestExtractPromptEntityWriteEvidence_IncludesDottedFields(t *testing.T) {
 	}
 }
 
+func TestExtractPromptEntityWriteEvidence_IncludesMultilineDottedFields(t *testing.T) {
+	_, saveEntity, saveFields := extractPromptEntityWriteEvidence("Use `save_entity_field`.\n- `metadata.region`\n- `business_brief`\n")
+	if !saveEntity {
+		t.Fatal("expected save_entity_field evidence")
+	}
+	if !reflect.DeepEqual(saveFields, []string{"metadata.region", "business_brief"}) {
+		t.Fatalf("SaveFields = %#v", saveFields)
+	}
+}
+
 func TestDerivePromptEntityWriteEvidence_IncludesScopedDuplicateAgentIDs(t *testing.T) {
 	repo := repoRoot(t)
 	root := t.TempDir()

--- a/internal/runtime/contracts/prompt_entity_writes_test.go
+++ b/internal/runtime/contracts/prompt_entity_writes_test.go
@@ -94,6 +94,16 @@ func TestExtractPromptEntityWriteEvidence_SkipsToolToken(t *testing.T) {
 	}
 }
 
+func TestExtractPromptEntityWriteEvidence_IncludesDottedFields(t *testing.T) {
+	_, saveEntity, saveFields := extractPromptEntityWriteEvidence("Use `save_entity_field` for `metadata.region` and `business_brief`.\n")
+	if !saveEntity {
+		t.Fatal("expected save_entity_field evidence")
+	}
+	if !reflect.DeepEqual(saveFields, []string{"metadata.region", "business_brief"}) {
+		t.Fatalf("SaveFields = %#v", saveFields)
+	}
+}
+
 func TestDerivePromptEntityWriteEvidence_IncludesScopedDuplicateAgentIDs(t *testing.T) {
 	repo := repoRoot(t)
 	root := t.TempDir()

--- a/internal/runtime/tools/executor_entity_test.go
+++ b/internal/runtime/tools/executor_entity_test.go
@@ -868,6 +868,7 @@ func TestEntityTools_SaveEntityFieldRejectsInvalidDottedPathsBeforePersistence(t
 		{name: "undeclared nested path", field: "metadata.regoin"},
 		{name: "envelope field", field: "entity_id"},
 		{name: "list index path", field: "validation_kit.checklist[0]"},
+		{name: "read-only list selector", field: "validation_kit.checklist.size"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			_, err := exec.Execute(ctx, "save_entity_field", map[string]any{

--- a/internal/runtime/tools/platform_builtin_catalog_test.go
+++ b/internal/runtime/tools/platform_builtin_catalog_test.go
@@ -1,6 +1,7 @@
 package tools
 
 import (
+	"reflect"
 	"testing"
 
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
@@ -62,5 +63,47 @@ func TestEntityToolWritablePathNames_ExcludesMaterializedFields(t *testing.T) {
 	got := entityToolWritablePathNames(contract)
 	if len(got) != 1 || got[0] != "status" {
 		t.Fatalf("entityToolWritablePathNames() = %#v, want [status]", got)
+	}
+}
+
+func TestEntityToolWritablePathNames_IncludesDeclaredDottedPaths(t *testing.T) {
+	contract := entityruntime.Contract{
+		Entity: runtimecontracts.EntityContract{
+			Fields: map[string]runtimecontracts.EntityFieldDecl{
+				"status":   {Type: "text"},
+				"metadata": {Type: "Metadata"},
+				"scores": {
+					Type:            "[DimensionScore]",
+					MaterializeFrom: "scoring-node.dimensions_received",
+				},
+			},
+		},
+		Types: runtimecontracts.TypeCatalogDocument{
+			Types: map[string]runtimecontracts.NamedTypeDecl{
+				"Address": {
+					Fields: map[string]runtimecontracts.TypeFieldSpec{
+						"city": {Type: "text"},
+					},
+				},
+				"DimensionScore": {
+					Fields: map[string]runtimecontracts.TypeFieldSpec{
+						"dimension": {Type: "text"},
+						"score":     {Type: "integer"},
+					},
+				},
+				"Metadata": {
+					Fields: map[string]runtimecontracts.TypeFieldSpec{
+						"address": {Type: "Address"},
+						"region":  {Type: "text"},
+					},
+				},
+			},
+		},
+	}
+
+	got := entityToolWritablePathNames(contract)
+	want := []string{"metadata", "metadata.address", "metadata.address.city", "metadata.region", "status"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("entityToolWritablePathNames() = %#v, want %#v", got, want)
 	}
 }

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -932,7 +932,8 @@ contract_formats:
         save_field: 'save_{entity_type}_{field}({value}) writes exactly one top-level declared field authorized by agents.yaml
           entity_writes.<entity_type>.save or entity_writes.<flow_id>.<entity_type>.save.'
         update_path: 'update_{entity_type}_{field}_{subpath}({value}) updates one generated top-level subpath for a writable
-          named-object field. The value schema is the exact declared subpath type.'
+          named-object field. The value schema is the exact declared subpath type. Runtime lowering consumes the same
+          declared dotted replacement owner as save_entity_field.'
         materialized_field_exclusion: 'Fields declaring materialize_from, and every nested subpath below them, MUST NOT
           appear in generated write tools or writable-path summaries. They are runtime-owned projection fields.'
         create_rule: 'create authorization in entity_writes is author evidence for prompt/boot coverage. Path alpha does not
@@ -1251,10 +1252,14 @@ runtime_enforcement:
       explicit `initial:` or the type default.
   save_entity_field:
     rule: |
-      save_entity_field targets only declared non-envelope fields on the
-      inferred entity contract. Wave 1 writes are top-level only;
-      dotted-path writes are rejected. Immutable fields reject
-      post-create writes. Values must satisfy the declared type.
+      save_entity_field targets only declared non-envelope top-level fields
+      or declared dotted subpaths on the inferred entity contract. Dotted
+      paths must resolve from a declared top-level field through declared
+      named types; the operation is whole-value replacement at the resolved
+      field path, not keyed or indexed contained-state mutation. Bracket,
+      index, and dynamic path writes are rejected. Immutable fields reject
+      post-create writes. Materialized/runtime-owned fields are rejected.
+      Values must satisfy the resolved declared type.
   get_entity:
     rule: |
       get_entity returns the full entity object with every declared
@@ -4962,14 +4967,16 @@ tool_model:
         input:
           flow_instance: string — required existing addressing surface for the owning flow instance
           entity_id: string — required
-          field: string — required top-level field name. Must exist on the inferred entity contract and must not be an envelope field.
+          field: string — required declared top-level field name or declared dotted subpath. Must resolve on the inferred
+            entity contract and must not be an envelope field.
           value: any — required, the value to write
         output:
           entity_id: string
           field: string
           revision: integer — new revision after write
-        validation: The field name must exist on the inferred entity contract. Undeclared fields, dotted-path writes, envelope
-          fields, and post-create writes to immutable fields are rejected.
+        validation: The field path must exist on the inferred entity contract. Undeclared fields, envelope fields,
+          bracket/index/dynamic paths, materialized/runtime-owned fields, and post-create writes to immutable fields are
+          rejected. Values must satisfy the resolved declared type.
       search_entities:
         description: Query entities by state, field values, or metadata. Returns matching entities from entity_state.
         input:


### PR DESCRIPTION
## Summary

- Update `platform-spec.yaml` so `save_entity_field` is declared as whole-value replacement for declared top-level fields or declared dotted subpaths.
- Keep bracket/index/dynamic contained-state mutation fail-closed and out of scope for this issue.
- Align prompt-derived `save_entity_field` coverage with dotted paths by extracting same-line and multi-line prompt field refs, then validating those refs against the same runtime save-path resolver used by `save_entity_field`.
- Add spec-lock, prompt evidence, bootverify integration, runtime tool integration, and writable-path catalog coverage.

Closes #1570

## Governing refs / context

- `platform-spec.yaml#runtime_enforcement.save_entity_field`
- `platform-spec.yaml#tool_model.platform_builtin_tools.entity_tool_schemas.save_entity_field`
- `platform-spec.yaml#contract_formats.persistence_model.role_scoped_entity_tools.generated_writes`
- Binding issue/gate context: #1570 and the approved gate comment on #1570.

## Semantic migration

- New canonical owner: `platform-spec.yaml#runtime_enforcement.save_entity_field` plus runtime code owner `execSaveEntityField` consuming `entityruntime.ResolveFieldPath`.
- Old invalid producer/reader path: spec/tool-schema wording that described `save_entity_field` as top-level-only and dotted-path rejected.
- Old prompt interpreter gap: prompt evidence extraction only captured simple same-line backtick field names, and bootverify prompt validation used the generic read/expression resolver instead of the runtime save-path resolver.
- Production paths checked for surviving old behavior: same-line and multi-line prompt evidence extraction, executor dotted write tests, runtime rejection of read-only list selector saves, writable-path summary generation, bootverify prompt authorization, bootverify rejection of multi-line unauthorized dotted save refs, bootverify rejection of read-pin-only save prompts, role-scoped generated update lowering spec text, and prompt-summary surface tests.
- Migration complete: yes for #1570. Typed keyed contained-state operations remain outside this issue and stay tracked separately by #1548/#1031 boundaries.

## Validation

- `go test ./internal/runtime/contracts -run 'TestExtractPromptEntityWriteEvidence_(SkipsToolToken|IncludesDottedFields|IncludesMultilineDottedFields)|TestDerivePromptEntityWriteEvidence' -count=1`
- `go test ./internal/runtime/bootverify -run 'TestRun_(PromptSaveEntityFieldAllowsDeclaredDottedPathAuthorizedByRootField|ReportsPromptSaveEntityFieldDottedPathWithoutRootAuthorization|ReportsPromptSaveEntityFieldMultilineDottedPathWithoutRootAuthorization|ReportsPromptSaveEntityFieldUndeclaredDottedPath|ReportsPromptSaveEntityFieldUndeclaredDottedPathWithAllAuthorization|ReportsPromptSaveEntityFieldReadOnlyListSelectorWithAllAuthorization|ReportsPromptSaveEntityFieldRootReadPinWithAllAuthorization|ReportsPromptSaveEntityFieldWithoutMatchingEntityWritesAuthorization|PromptEntityWritesPrefersFlowScopedAuthorization)' -count=1`
- `go test ./internal/runtime/tools -run 'Test(EntityToolWritablePathNames|EntityTools_SaveEntityFieldAllowsDeclaredNestedWritePath|EntityTools_SaveEntityFieldAllowsNestedListWritePath|EntityTools_SaveEntityFieldRejectsInvalidDottedPathsBeforePersistence|EntityTools_SaveEntityField_LogsNestedMutationRow|RoleScopedEntityTools_GeneratedSchemasAreClosedAndRuntimeRejectsExtras)' -count=1`
- `go test ./internal/apispec -run 'TestPlatformSpecSaveEntityFieldDeclaredDottedReplacement|TestPlatformSpecGeneratedEntityUpdatesConsumeSaveEntityFieldPathOwner' -count=1`
- `go test ./internal/runtime/agents ./internal/runtime/llm -run 'Test(FormatEventForAgent_IncludesToolSurfaceSummary|AnthropicAPIRuntime_StartSessionAugmentsSystemPromptWithDerivedToolSurface)' -count=1`
- `go test ./...` passed after the multi-line prompt fix.