### PR TITLE
[agent-b][issue #1636] Remove client API env authority

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,6 @@ jobs:
 
       - name: Prove no-selector SQLite local run
         env:
-          SWARM_API_TOKEN: ci-local-dev-token
           SWARM_WORKSPACE_DATA_SOURCE: ${{ github.workspace }}/data
         run: |
           payload=$(mktemp)

--- a/cmd/swarm/agent_deliveries_test.go
+++ b/cmd/swarm/agent_deliveries_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestAgentDeliveriesUsesAgentDeliveryLifecycleAndRendersRows(t *testing.T) {
-	t.Setenv("SWARM_API_TOKEN", "test-token")
+	setCLIAPITestToken(t, "test-token")
 	var captured jsonRPCRequest
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/v1/rpc" {
@@ -71,7 +71,7 @@ func TestAgentDeliveriesUsesAgentDeliveryLifecycleAndRendersRows(t *testing.T) {
 }
 
 func TestAgentDeliveriesEmptyResult(t *testing.T) {
-	t.Setenv("SWARM_API_TOKEN", "test-token")
+	setCLIAPITestToken(t, "test-token")
 	var captured jsonRPCRequest
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
@@ -102,7 +102,7 @@ func TestAgentDeliveriesEmptyResult(t *testing.T) {
 }
 
 func TestAgentDeliveriesJSONPreservesAPIResultShape(t *testing.T) {
-	t.Setenv("SWARM_API_TOKEN", "test-token")
+	setCLIAPITestToken(t, "test-token")
 	var captured jsonRPCRequest
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
@@ -150,7 +150,7 @@ func TestAgentDeliveriesJSONPreservesAPIResultShape(t *testing.T) {
 }
 
 func TestAgentDeliveriesRejectsInvalidInputBeforeRequest(t *testing.T) {
-	t.Setenv("SWARM_API_TOKEN", "test-token")
+	setCLIAPITestToken(t, "test-token")
 	var calls atomic.Int32
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		calls.Add(1)
@@ -207,7 +207,7 @@ func TestAgentDeliveriesFailClosedWithoutToken(t *testing.T) {
 	if code != cliExitAuth {
 		t.Fatalf("code = %d, want %d stdout=%s stderr=%s", code, cliExitAuth, stdout.String(), stderr.String())
 	}
-	if !strings.Contains(stderr.String(), "SWARM_API_TOKEN is required") {
+	if !strings.Contains(stderr.String(), "API token source is required") {
 		t.Fatalf("stderr = %q, want token failure", stderr.String())
 	}
 	if calls.Load() != 0 {
@@ -326,7 +326,7 @@ func TestAgentDeliveriesFailClosedOnRPCAndMalformedResponses(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			t.Setenv("SWARM_API_TOKEN", "test-token")
+			setCLIAPITestToken(t, "test-token")
 			server := httptest.NewServer(tc.handler)
 			defer server.Close()
 

--- a/cmd/swarm/agent_diagnose_test.go
+++ b/cmd/swarm/agent_diagnose_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestAgentDiagnoseUsesAgentDiagnoseAndRendersOwnedFields(t *testing.T) {
-	t.Setenv("SWARM_API_TOKEN", "test-token")
+	setCLIAPITestToken(t, "test-token")
 	var captured jsonRPCRequest
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/v1/rpc" {
@@ -68,7 +68,7 @@ func TestAgentDiagnoseUsesAgentDiagnoseAndRendersOwnedFields(t *testing.T) {
 }
 
 func TestAgentDiagnoseJSONPreservesAPIResultShape(t *testing.T) {
-	t.Setenv("SWARM_API_TOKEN", "test-token")
+	setCLIAPITestToken(t, "test-token")
 	var captured jsonRPCRequest
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
@@ -113,7 +113,7 @@ func TestAgentDiagnoseJSONPreservesAPIResultShape(t *testing.T) {
 }
 
 func TestAgentDiagnoseRejectsInvalidInputBeforeRequest(t *testing.T) {
-	t.Setenv("SWARM_API_TOKEN", "test-token")
+	setCLIAPITestToken(t, "test-token")
 	var calls atomic.Int32
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		calls.Add(1)
@@ -244,7 +244,7 @@ func TestAgentDiagnoseFailClosedOnRPCAndMalformedResponses(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			t.Setenv("SWARM_API_TOKEN", "test-token")
+			setCLIAPITestToken(t, "test-token")
 			server := httptest.NewServer(tc.handler)
 			defer server.Close()
 

--- a/cmd/swarm/agent_directive_test.go
+++ b/cmd/swarm/agent_directive_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestAgentDirectiveUsesV1RPCWithRunIDAndIdempotencyKey(t *testing.T) {
-	t.Setenv("SWARM_API_TOKEN", "test-token")
+	setCLIAPITestToken(t, "test-token")
 	var captured jsonRPCRequest
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/v1/rpc" {
@@ -69,7 +69,7 @@ func TestAgentDirectiveUsesV1RPCWithRunIDAndIdempotencyKey(t *testing.T) {
 }
 
 func TestAgentDirectiveOmitsOptionalParamsWhenNotProvided(t *testing.T) {
-	t.Setenv("SWARM_API_TOKEN", "test-token")
+	setCLIAPITestToken(t, "test-token")
 	var captured jsonRPCRequest
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
@@ -94,7 +94,7 @@ func TestAgentDirectiveOmitsOptionalParamsWhenNotProvided(t *testing.T) {
 }
 
 func TestAgentDirectivePreservesDirectiveWhitespace(t *testing.T) {
-	t.Setenv("SWARM_API_TOKEN", "test-token")
+	setCLIAPITestToken(t, "test-token")
 	var captured jsonRPCRequest
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
@@ -116,7 +116,7 @@ func TestAgentDirectivePreservesDirectiveWhitespace(t *testing.T) {
 }
 
 func TestAgentDirectiveRejectsInvalidInputBeforeRequest(t *testing.T) {
-	t.Setenv("SWARM_API_TOKEN", "test-token")
+	setCLIAPITestToken(t, "test-token")
 	var calls atomic.Int32
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		calls.Add(1)
@@ -166,7 +166,7 @@ func TestAgentDirectiveFailClosedWithoutToken(t *testing.T) {
 	if code != 4 {
 		t.Fatalf("code = %d, want 4 stdout=%s stderr=%s", code, stdout.String(), stderr.String())
 	}
-	if !strings.Contains(stderr.String(), "SWARM_API_TOKEN is required") {
+	if !strings.Contains(stderr.String(), "API token source is required") {
 		t.Fatalf("stderr = %q, want token failure", stderr.String())
 	}
 	if calls.Load() != 0 {
@@ -281,7 +281,7 @@ func TestAgentDirectiveMapsFailureExitCodes(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			t.Setenv("SWARM_API_TOKEN", "test-token")
+			setCLIAPITestToken(t, "test-token")
 			server := httptest.NewServer(tc.handler)
 			defer server.Close()
 

--- a/cmd/swarm/agent_replay_backlog_test.go
+++ b/cmd/swarm/agent_replay_backlog_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestAgentReplayBacklogUsesV1RPCWithIdempotencyKey(t *testing.T) {
-	t.Setenv("SWARM_API_TOKEN", "test-token")
+	setCLIAPITestToken(t, "test-token")
 	var captured jsonRPCRequest
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/v1/rpc" {
@@ -56,7 +56,7 @@ func TestAgentReplayBacklogUsesV1RPCWithIdempotencyKey(t *testing.T) {
 }
 
 func TestAgentReplayBacklogOmitsIdempotencyKeyWhenNotProvided(t *testing.T) {
-	t.Setenv("SWARM_API_TOKEN", "test-token")
+	setCLIAPITestToken(t, "test-token")
 	var captured jsonRPCRequest
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
@@ -78,7 +78,7 @@ func TestAgentReplayBacklogOmitsIdempotencyKeyWhenNotProvided(t *testing.T) {
 }
 
 func TestAgentReplayBacklogRejectsInvalidInputBeforeRequest(t *testing.T) {
-	t.Setenv("SWARM_API_TOKEN", "test-token")
+	setCLIAPITestToken(t, "test-token")
 	var calls atomic.Int32
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		calls.Add(1)
@@ -128,7 +128,7 @@ func TestAgentReplayBacklogFailClosedWithoutToken(t *testing.T) {
 	if code != 4 {
 		t.Fatalf("code = %d, want 4 stdout=%s stderr=%s", code, stdout.String(), stderr.String())
 	}
-	if !strings.Contains(stderr.String(), "SWARM_API_TOKEN is required") {
+	if !strings.Contains(stderr.String(), "API token source is required") {
 		t.Fatalf("stderr = %q, want token failure", stderr.String())
 	}
 	if calls.Load() != 0 {
@@ -231,7 +231,7 @@ func TestAgentReplayBacklogMapsFailureExitCodes(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			t.Setenv("SWARM_API_TOKEN", "test-token")
+			setCLIAPITestToken(t, "test-token")
 			server := httptest.NewServer(tc.handler)
 			defer server.Close()
 

--- a/cmd/swarm/agent_replay_test.go
+++ b/cmd/swarm/agent_replay_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestAgentReplayUsesV1RPCWithEventIDAndIdempotencyKey(t *testing.T) {
-	t.Setenv("SWARM_API_TOKEN", "test-token")
+	setCLIAPITestToken(t, "test-token")
 	var captured jsonRPCRequest
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/v1/rpc" {
@@ -68,7 +68,7 @@ func TestAgentReplayUsesV1RPCWithEventIDAndIdempotencyKey(t *testing.T) {
 }
 
 func TestAgentReplayOmitsIdempotencyKeyWhenNotProvided(t *testing.T) {
-	t.Setenv("SWARM_API_TOKEN", "test-token")
+	setCLIAPITestToken(t, "test-token")
 	var captured jsonRPCRequest
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
@@ -90,7 +90,7 @@ func TestAgentReplayOmitsIdempotencyKeyWhenNotProvided(t *testing.T) {
 }
 
 func TestAgentReplayRejectsInvalidInputBeforeRequest(t *testing.T) {
-	t.Setenv("SWARM_API_TOKEN", "test-token")
+	setCLIAPITestToken(t, "test-token")
 	var calls atomic.Int32
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		calls.Add(1)
@@ -141,7 +141,7 @@ func TestAgentReplayFailClosedWithoutToken(t *testing.T) {
 	if code != 4 {
 		t.Fatalf("code = %d, want 4 stdout=%s stderr=%s", code, stdout.String(), stderr.String())
 	}
-	if !strings.Contains(stderr.String(), "SWARM_API_TOKEN is required") {
+	if !strings.Contains(stderr.String(), "API token source is required") {
 		t.Fatalf("stderr = %q, want token failure", stderr.String())
 	}
 	if calls.Load() != 0 {
@@ -161,7 +161,7 @@ func TestAgentReplayMapsFailureExitCodes(t *testing.T) {
 	for _, code := range resourceErrors {
 		code := code
 		t.Run(code+" exits six", func(t *testing.T) {
-			t.Setenv("SWARM_API_TOKEN", "test-token")
+			setCLIAPITestToken(t, "test-token")
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				var req jsonRPCRequest
 				_ = json.NewDecoder(r.Body).Decode(&req)
@@ -272,7 +272,7 @@ func TestAgentReplayMapsFailureExitCodes(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			t.Setenv("SWARM_API_TOKEN", "test-token")
+			setCLIAPITestToken(t, "test-token")
 			server := httptest.NewServer(tc.handler)
 			defer server.Close()
 

--- a/cmd/swarm/agent_restart_test.go
+++ b/cmd/swarm/agent_restart_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestAgentRestartUsesV1RPCWithIdempotencyKey(t *testing.T) {
-	t.Setenv("SWARM_API_TOKEN", "test-token")
+	setCLIAPITestToken(t, "test-token")
 	var captured jsonRPCRequest
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/v1/rpc" {
@@ -53,7 +53,7 @@ func TestAgentRestartUsesV1RPCWithIdempotencyKey(t *testing.T) {
 }
 
 func TestAgentRestartOmitsIdempotencyKeyWhenNotProvided(t *testing.T) {
-	t.Setenv("SWARM_API_TOKEN", "test-token")
+	setCLIAPITestToken(t, "test-token")
 	var captured jsonRPCRequest
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
@@ -75,7 +75,7 @@ func TestAgentRestartOmitsIdempotencyKeyWhenNotProvided(t *testing.T) {
 }
 
 func TestAgentRestartRejectsInvalidInputBeforeRequest(t *testing.T) {
-	t.Setenv("SWARM_API_TOKEN", "test-token")
+	setCLIAPITestToken(t, "test-token")
 	var calls atomic.Int32
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		calls.Add(1)
@@ -124,7 +124,7 @@ func TestAgentRestartFailClosedWithoutToken(t *testing.T) {
 	if code != 4 {
 		t.Fatalf("code = %d, want 4 stdout=%s stderr=%s", code, stdout.String(), stderr.String())
 	}
-	if !strings.Contains(stderr.String(), "SWARM_API_TOKEN is required") {
+	if !strings.Contains(stderr.String(), "API token source is required") {
 		t.Fatalf("stderr = %q, want token failure", stderr.String())
 	}
 	if calls.Load() != 0 {
@@ -197,7 +197,7 @@ func TestAgentRestartMapsFailureExitCodes(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			t.Setenv("SWARM_API_TOKEN", "test-token")
+			setCLIAPITestToken(t, "test-token")
 			server := httptest.NewServer(tc.handler)
 			defer server.Close()
 

--- a/cmd/swarm/agents_test.go
+++ b/cmd/swarm/agents_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestAgentsListUsesV1RPCWithFilters(t *testing.T) {
-	t.Setenv("SWARM_API_TOKEN", "test-token")
+	setCLIAPITestToken(t, "test-token")
 	var captured jsonRPCRequest
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/v1/rpc" {
@@ -57,7 +57,7 @@ func TestAgentsListUsesV1RPCWithFilters(t *testing.T) {
 }
 
 func TestAgentsListEmptyResult(t *testing.T) {
-	t.Setenv("SWARM_API_TOKEN", "test-token")
+	setCLIAPITestToken(t, "test-token")
 	var captured jsonRPCRequest
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
@@ -87,7 +87,7 @@ func TestAgentsListEmptyResult(t *testing.T) {
 }
 
 func TestAgentViewUsesAgentGetAndRendersRefsOnly(t *testing.T) {
-	t.Setenv("SWARM_API_TOKEN", "test-token")
+	setCLIAPITestToken(t, "test-token")
 	var captured jsonRPCRequest
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if got := r.Header.Get("Authorization"); got != "Bearer test-token" {
@@ -137,7 +137,7 @@ func TestAgentViewUsesAgentGetAndRendersRefsOnly(t *testing.T) {
 }
 
 func TestAgentReadCommandsRejectInvalidInputBeforeRequest(t *testing.T) {
-	t.Setenv("SWARM_API_TOKEN", "test-token")
+	setCLIAPITestToken(t, "test-token")
 	var calls atomic.Int32
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		calls.Add(1)
@@ -188,7 +188,7 @@ func TestAgentReadCommandsFailClosedWithoutToken(t *testing.T) {
 	if code != 4 {
 		t.Fatalf("code = %d, want 4 stdout=%s stderr=%s", code, stdout.String(), stderr.String())
 	}
-	if !strings.Contains(stderr.String(), "SWARM_API_TOKEN is required") {
+	if !strings.Contains(stderr.String(), "API token source is required") {
 		t.Fatalf("stderr = %q, want token failure", stderr.String())
 	}
 	if calls.Load() != 0 {
@@ -275,7 +275,7 @@ func TestAgentReadCommandsFailClosedOnRPCAndMalformedResponses(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			t.Setenv("SWARM_API_TOKEN", "test-token")
+			setCLIAPITestToken(t, "test-token")
 			server := httptest.NewServer(tc.handler)
 			defer server.Close()
 

--- a/cmd/swarm/api_consumption_boundary_test.go
+++ b/cmd/swarm/api_consumption_boundary_test.go
@@ -225,7 +225,7 @@ func TestCLIRuntimeStateCommandsRequireSharedAPITokenBeforeRequest(t *testing.T)
 			if code != cliExitAuth {
 				t.Fatalf("code = %d, want %d stdout=%s stderr=%s", code, cliExitAuth, stdout.String(), stderr.String())
 			}
-			if !strings.Contains(stderr.String(), "SWARM_API_TOKEN is required") {
+			if !strings.Contains(stderr.String(), "API token source is required") {
 				t.Fatalf("stderr = %q, want shared missing-token error", stderr.String())
 			}
 			if calls.Load() != 0 {

--- a/cmd/swarm/bundle_test.go
+++ b/cmd/swarm/bundle_test.go
@@ -18,7 +18,7 @@ import (
 )
 
 func TestBundleCommandsUseCanonicalRPCAndRender(t *testing.T) {
-	t.Setenv("SWARM_API_TOKEN", "test-token")
+	setCLIAPITestToken(t, "test-token")
 	bundleHash := validBundleHash("a")
 	var requests []jsonRPCRequest
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -88,7 +88,7 @@ func TestBundleCommandsUseCanonicalRPCAndRender(t *testing.T) {
 }
 
 func TestBundleCommandsJSONPreserveAPIShape(t *testing.T) {
-	t.Setenv("SWARM_API_TOKEN", "test-token")
+	setCLIAPITestToken(t, "test-token")
 	bundleHash := validBundleHash("b")
 	var captured jsonRPCRequest
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -123,7 +123,7 @@ func TestBundleCommandsJSONPreserveAPIShape(t *testing.T) {
 }
 
 func TestBundleDeleteUsesCanonicalRPCAndRenders(t *testing.T) {
-	t.Setenv("SWARM_API_TOKEN", "test-token")
+	setCLIAPITestToken(t, "test-token")
 	bundleHash := validBundleHash("d")
 	var requests []jsonRPCRequest
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -207,7 +207,7 @@ func TestBundleDeleteUsesCanonicalRPCAndRenders(t *testing.T) {
 }
 
 func TestBundleDeleteJSONPreservesAPIShape(t *testing.T) {
-	t.Setenv("SWARM_API_TOKEN", "test-token")
+	setCLIAPITestToken(t, "test-token")
 	bundleHash := validBundleHash("e")
 	var captured jsonRPCRequest
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -249,7 +249,7 @@ func TestBundleDeleteJSONPreservesAPIShape(t *testing.T) {
 }
 
 func TestBundleDeletePartialFailureRendersAndExitsRuntime(t *testing.T) {
-	t.Setenv("SWARM_API_TOKEN", "test-token")
+	setCLIAPITestToken(t, "test-token")
 	bundleHash := validBundleHash("9")
 	for _, tc := range []struct {
 		name string
@@ -301,7 +301,7 @@ func TestBundleDeletePartialFailureRendersAndExitsRuntime(t *testing.T) {
 }
 
 func TestBundleAgentsJSONUsesCanonicalModelField(t *testing.T) {
-	t.Setenv("SWARM_API_TOKEN", "test-token")
+	setCLIAPITestToken(t, "test-token")
 	bundleHash := validBundleHash("f")
 	var captured jsonRPCRequest
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -397,7 +397,7 @@ func TestBundleRegisterHelpDocumentsPreparedEnvelopeAndContractsBoundary(t *test
 }
 
 func TestBundleRegisterContractsDirectoryUsesCanonicalRPCAndRenders(t *testing.T) {
-	t.Setenv("SWARM_API_TOKEN", "test-token")
+	setCLIAPITestToken(t, "test-token")
 	bundleHash := validBundleHash("9")
 	contractsDir := writeBundleRegisterContractsFixture(t)
 	var captured jsonRPCRequest
@@ -482,7 +482,7 @@ func TestBundleRegisterContractsDirectoryUsesCanonicalRPCAndRenders(t *testing.T
 }
 
 func TestBundleRegisterContractsPackageFileShorthandUsesCanonicalRPC(t *testing.T) {
-	t.Setenv("SWARM_API_TOKEN", "test-token")
+	setCLIAPITestToken(t, "test-token")
 	bundleHash := validBundleHash("8")
 	contractsDir := writeBundleRegisterContractsFixture(t)
 	var captured jsonRPCRequest
@@ -524,7 +524,7 @@ func TestBundleRegisterContractsPackageFileShorthandUsesCanonicalRPC(t *testing.
 }
 
 func TestBundleRegisterPreparedEnvelopeUsesCanonicalRPCAndRenders(t *testing.T) {
-	t.Setenv("SWARM_API_TOKEN", "test-token")
+	setCLIAPITestToken(t, "test-token")
 	bundleHash := validBundleHash("e")
 	envelopePath := writeBundleRegisterFixture(t, "bundle-register.yaml", "api_version: swarm.bundle.register.v1\nfiles:\n  - path: package.yaml\n    text: \"name: demo\\n\"\n")
 	dataBlobPath := writeBundleRegisterFixture(t, "bundle-data.json", `{"api_version":"swarm.bundle.data.v1","entries":[{"path":"flows/alpha/data/payload.bin","data_base64":"AQI="}]}`)
@@ -568,7 +568,7 @@ func TestBundleRegisterPreparedEnvelopeUsesCanonicalRPCAndRenders(t *testing.T) 
 }
 
 func TestBundleRegisterJSONPreservesAPIShape(t *testing.T) {
-	t.Setenv("SWARM_API_TOKEN", "test-token")
+	setCLIAPITestToken(t, "test-token")
 	bundleHash := validBundleHash("f")
 	envelopePath := writeBundleRegisterFixture(t, "bundle-register.yaml", "api_version: swarm.bundle.register.v1\nfiles:\n  - path: package.yaml\n    text: \"name: demo\\n\"\n")
 	var captured jsonRPCRequest
@@ -598,7 +598,7 @@ func TestBundleRegisterJSONPreservesAPIShape(t *testing.T) {
 }
 
 func TestBundleCommandsRejectInvalidInputBeforeRequest(t *testing.T) {
-	t.Setenv("SWARM_API_TOKEN", "test-token")
+	setCLIAPITestToken(t, "test-token")
 	var calls atomic.Int32
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		calls.Add(1)
@@ -666,7 +666,7 @@ func TestBundleCommandsRejectInvalidInputBeforeRequest(t *testing.T) {
 }
 
 func TestBundleRegisterContractsDirectoryRejectsSymlinkBeforeRequest(t *testing.T) {
-	t.Setenv("SWARM_API_TOKEN", "test-token")
+	setCLIAPITestToken(t, "test-token")
 	contractsDir := writeBundleRegisterContractsFixture(t)
 	if err := os.Symlink(filepath.Join(contractsDir, "prompts", "root.md"), filepath.Join(contractsDir, "prompts", "link.md")); err != nil {
 		t.Skipf("symlink unsupported: %v", err)
@@ -878,7 +878,7 @@ func TestBundleCommandsFailClosedOnRPCAndMalformedResponses(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			t.Setenv("SWARM_API_TOKEN", "test-token")
+			setCLIAPITestToken(t, "test-token")
 			server := httptest.NewServer(tc.handler)
 			defer server.Close()
 

--- a/cmd/swarm/cli_api.go
+++ b/cmd/swarm/cli_api.go
@@ -154,6 +154,9 @@ func resolveCLIAPISettings(opts rootCommandOptions) (cliAPISettings, error) {
 	if err != nil {
 		return cliAPISettings{}, err
 	}
+	if err := rejectRemovedClientAPIEnvSources(); err != nil {
+		return cliAPISettings{}, err
+	}
 	target, err := resolveCLIAPITarget(opts, cfg)
 	if err != nil {
 		return cliAPISettings{}, err
@@ -165,19 +168,6 @@ func resolveCLIAPISettings(opts rootCommandOptions) (cliAPISettings, error) {
 	return cliAPISettings{rpcEndpoint: target.rpcEndpoint, token: token.token, tokenSource: token.source, tokenExplicit: token.explicit, target: target}, nil
 }
 
-func resolveCLIAPIRPCEndpoint(opts rootCommandOptions, cfg cliAPIConfigFile) (string, error) {
-	if endpoint := strings.TrimSpace(opts.apiRPCEndpointOverride); endpoint != "" {
-		return normalizeCLIAPIRPCEndpoint(endpoint, "internal API endpoint")
-	}
-	server := firstNonEmpty(
-		opts.apiServer,
-		os.Getenv("SWARM_API_SERVER"),
-		cfg.APIServer,
-		defaultCLIAPIServer,
-	)
-	return cliAPIRPCEndpointFromServer(server, "API server")
-}
-
 type cliAPITokenResolution struct {
 	token    string
 	source   string
@@ -185,14 +175,11 @@ type cliAPITokenResolution struct {
 }
 
 func resolveCLIAPIToken(opts rootCommandOptions, cfg cliAPIConfigFile, rpcEndpoint string) (cliAPITokenResolution, error) {
+	if err := rejectRemovedClientAPIEnvSources(); err != nil {
+		return cliAPITokenResolution{}, err
+	}
 	if tokenFile := strings.TrimSpace(opts.apiTokenFile); tokenFile != "" {
 		return readCLIAPIExplicitTokenFile(tokenFile, "--api-token-file")
-	}
-	if token := strings.TrimSpace(os.Getenv("SWARM_API_TOKEN")); token != "" {
-		return cliAPITokenResolution{token: token, source: string(apiv1.AuthTokenSourceEnvironment), explicit: true}, nil
-	}
-	if tokenFile := strings.TrimSpace(os.Getenv("SWARM_API_TOKEN_FILE")); tokenFile != "" {
-		return readCLIAPIExplicitTokenFile(tokenFile, "SWARM_API_TOKEN_FILE")
 	}
 	if tokenFile := strings.TrimSpace(cfg.APITokenFile); tokenFile != "" {
 		return readCLIAPIExplicitTokenFile(tokenFile, "config api_token_file")
@@ -204,6 +191,24 @@ func resolveCLIAPIToken(opts rootCommandOptions, cfg cliAPIConfigFile, rpcEndpoi
 		}, nil
 	}
 	return cliAPITokenResolution{}, errCLIAPITokenRequired
+}
+
+func rejectRemovedClientAPIEnvSources() error {
+	replacements := map[string]string{
+		"SWARM_API_SERVER":     "use --api-server, --context, project/selected context, or config api_server",
+		"SWARM_API_TOKEN":      "use --api-token-file, context descriptor auth, or config api_token_file",
+		"SWARM_API_TOKEN_FILE": "use --api-token-file, context descriptor auth, or config api_token_file",
+	}
+	var found []string
+	for _, name := range []string{"SWARM_API_SERVER", "SWARM_API_TOKEN", "SWARM_API_TOKEN_FILE"} {
+		if strings.TrimSpace(os.Getenv(name)) != "" {
+			found = append(found, fmt.Sprintf("%s (%s)", name, replacements[name]))
+		}
+	}
+	if len(found) == 0 {
+		return nil
+	}
+	return &cliAPIValidationError{message: "client-side API environment sources are no longer accepted: " + strings.Join(found, "; ")}
 }
 
 type cliServeListenerAddressOptions struct {

--- a/cmd/swarm/cli_api_resolver_test.go
+++ b/cmd/swarm/cli_api_resolver_test.go
@@ -16,19 +16,15 @@ import (
 )
 
 func TestResolveCLIAPISettingsPrecedence(t *testing.T) {
-	t.Run("flag sources beat env config and defaults", func(t *testing.T) {
+	t.Run("flag sources beat config and defaults", func(t *testing.T) {
 		isolateCLIAPIConfigEnv(t)
 		configToken := writeCLIAPITokenFile(t, "config-token")
-		envToken := writeCLIAPITokenFile(t, "env-file-token")
 		flagToken := writeCLIAPITokenFile(t, "flag-token")
 		configPath := writeCLIAPIConfigFile(t, map[string]string{
 			"api_server":     "http://127.0.0.1:4444",
 			"api_token_file": configToken,
 		})
 		t.Setenv("SWARM_CONFIG", configPath)
-		t.Setenv("SWARM_API_SERVER", "http://127.0.0.1:5555")
-		t.Setenv("SWARM_API_TOKEN", "env-token")
-		t.Setenv("SWARM_API_TOKEN_FILE", envToken)
 
 		client, err := newCLIAPIClient(rootCommandOptions{
 			apiServer:    "http://127.0.0.1:6666",
@@ -45,7 +41,7 @@ func TestResolveCLIAPISettingsPrecedence(t *testing.T) {
 		}
 	})
 
-	t.Run("environment token beats token file and config", func(t *testing.T) {
+	t.Run("client environment sources fail closed instead of shadowing config", func(t *testing.T) {
 		isolateCLIAPIConfigEnv(t)
 		configToken := writeCLIAPITokenFile(t, "config-token")
 		envToken := writeCLIAPITokenFile(t, "env-file-token")
@@ -57,19 +53,18 @@ func TestResolveCLIAPISettingsPrecedence(t *testing.T) {
 		t.Setenv("SWARM_API_TOKEN", "env-token")
 		t.Setenv("SWARM_API_TOKEN_FILE", envToken)
 
-		client, err := newCLIAPIClient(rootCommandOptions{})
-		if err != nil {
-			t.Fatalf("newCLIAPIClient: %v", err)
+		_, err := newCLIAPIClient(rootCommandOptions{})
+		if err == nil {
+			t.Fatal("newCLIAPIClient returned nil error")
 		}
-		if client.endpoint != "http://127.0.0.1:5555/v1/rpc" {
-			t.Fatalf("endpoint = %q", client.endpoint)
-		}
-		if client.token != "env-token" {
-			t.Fatalf("token = %q", client.token)
+		for _, want := range []string{"client-side API environment sources are no longer accepted", "SWARM_API_SERVER", "SWARM_API_TOKEN", "SWARM_API_TOKEN_FILE", "--api-server", "--api-token-file"} {
+			if !strings.Contains(err.Error(), want) {
+				t.Fatalf("err = %q, want %q", err.Error(), want)
+			}
 		}
 	})
 
-	t.Run("environment token file beats config", func(t *testing.T) {
+	t.Run("client environment token file fails closed instead of shadowing config", func(t *testing.T) {
 		isolateCLIAPIConfigEnv(t)
 		configToken := writeCLIAPITokenFile(t, "config-token")
 		envToken := writeCLIAPITokenFile(t, "env-file-token")
@@ -79,15 +74,12 @@ func TestResolveCLIAPISettingsPrecedence(t *testing.T) {
 		}))
 		t.Setenv("SWARM_API_TOKEN_FILE", envToken)
 
-		client, err := newCLIAPIClient(rootCommandOptions{})
-		if err != nil {
-			t.Fatalf("newCLIAPIClient: %v", err)
+		_, err := newCLIAPIClient(rootCommandOptions{})
+		if err == nil {
+			t.Fatal("newCLIAPIClient returned nil error")
 		}
-		if client.endpoint != "http://127.0.0.1:4444/v1/rpc" {
-			t.Fatalf("endpoint = %q", client.endpoint)
-		}
-		if client.token != "env-file-token" {
-			t.Fatalf("token = %q", client.token)
+		if !strings.Contains(err.Error(), "SWARM_API_TOKEN_FILE") || !strings.Contains(err.Error(), "config api_token_file") {
+			t.Fatalf("err = %q, want SWARM_API_TOKEN_FILE replacement guidance", err.Error())
 		}
 	})
 
@@ -150,17 +142,17 @@ func TestCLIAPISettingsDefaultTokenLoopbackBoundary(t *testing.T) {
 		{
 			name:      "localhost needs explicit token",
 			apiServer: "http://localhost:8081",
-			wantErr:   "SWARM_API_TOKEN is required",
+			wantErr:   "API token source is required",
 		},
 		{
 			name:      "wildcard needs explicit token",
 			apiServer: "http://0.0.0.0:8081",
-			wantErr:   "SWARM_API_TOKEN is required",
+			wantErr:   "API token source is required",
 		},
 		{
 			name:      "routable address needs explicit token",
 			apiServer: "http://192.0.2.10:8081",
-			wantErr:   "SWARM_API_TOKEN is required",
+			wantErr:   "API token source is required",
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -361,7 +353,6 @@ func TestCLIAPISettingsFailClosed(t *testing.T) {
 		{
 			name: "invalid API server query",
 			setup: func(t *testing.T) rootCommandOptions {
-				t.Setenv("SWARM_API_TOKEN", "env-token")
 				return rootCommandOptions{apiServer: "http://127.0.0.1:8081?x=1"}
 			},
 			wantExit: cliExitValidation,
@@ -370,7 +361,6 @@ func TestCLIAPISettingsFailClosed(t *testing.T) {
 		{
 			name: "flag API server rejects direct RPC endpoint",
 			setup: func(t *testing.T) rootCommandOptions {
-				t.Setenv("SWARM_API_TOKEN", "env-token")
 				return rootCommandOptions{apiServer: "http://127.0.0.1:8081/v1/rpc"}
 			},
 			wantExit: cliExitValidation,
@@ -379,31 +369,30 @@ func TestCLIAPISettingsFailClosed(t *testing.T) {
 		{
 			name: "flag API server rejects prefixed RPC endpoint",
 			setup: func(t *testing.T) rootCommandOptions {
-				t.Setenv("SWARM_API_TOKEN", "env-token")
 				return rootCommandOptions{apiServer: "http://127.0.0.1:8081/proxy/v1/rpc"}
 			},
 			wantExit: cliExitValidation,
 			wantErr:  "not a direct /v1/rpc endpoint",
 		},
 		{
-			name: "environment API server rejects direct websocket endpoint",
+			name: "environment API server is removed before endpoint shape validation",
 			setup: func(t *testing.T) rootCommandOptions {
 				t.Setenv("SWARM_API_SERVER", "http://127.0.0.1:8081/v1/ws")
 				t.Setenv("SWARM_API_TOKEN", "env-token")
 				return rootCommandOptions{}
 			},
 			wantExit: cliExitValidation,
-			wantErr:  "not a direct /v1/ws endpoint",
+			wantErr:  "client-side API environment sources are no longer accepted",
 		},
 		{
-			name: "environment API server rejects prefixed websocket endpoint",
+			name: "environment API server with prefix is removed before endpoint shape validation",
 			setup: func(t *testing.T) rootCommandOptions {
 				t.Setenv("SWARM_API_SERVER", "http://127.0.0.1:8081/proxy/v1/ws")
 				t.Setenv("SWARM_API_TOKEN", "env-token")
 				return rootCommandOptions{}
 			},
 			wantExit: cliExitValidation,
-			wantErr:  "not a direct /v1/ws endpoint",
+			wantErr:  "client-side API environment sources are no longer accepted",
 		},
 		{
 			name: "config API server rejects direct RPC endpoint",
@@ -411,7 +400,6 @@ func TestCLIAPISettingsFailClosed(t *testing.T) {
 				t.Setenv("SWARM_CONFIG", writeCLIAPIConfigFile(t, map[string]string{
 					"api_server": "http://127.0.0.1:8081/v1/rpc",
 				}))
-				t.Setenv("SWARM_API_TOKEN", "env-token")
 				return rootCommandOptions{}
 			},
 			wantExit: cliExitValidation,
@@ -423,7 +411,6 @@ func TestCLIAPISettingsFailClosed(t *testing.T) {
 				t.Setenv("SWARM_CONFIG", writeCLIAPIConfigFile(t, map[string]string{
 					"api_server": "http://127.0.0.1:8081/proxy/v1/rpc",
 				}))
-				t.Setenv("SWARM_API_TOKEN", "env-token")
 				return rootCommandOptions{}
 			},
 			wantExit: cliExitValidation,
@@ -680,6 +667,56 @@ func TestCLIAPIProjectContextOutranksSelectedGlobal(t *testing.T) {
 	}
 }
 
+func TestCLIAPIContextDescriptorAuthOutranksConfigTokenFile(t *testing.T) {
+	isolateCLIAPIConfigEnv(t)
+	project := writeCLIAPIProjectFixture(t)
+	swarmDir := t.TempDir()
+	configToken := writeCLIAPITokenFile(t, "config-token")
+	t.Setenv("SWARM_CONFIG", writeCLIAPIConfigFile(t, map[string]string{
+		"api_server":     "http://127.0.0.1:4444",
+		"api_token_file": configToken,
+	}))
+	server := startCLIAPIRuntimeIdentityServer(t, "runtime-project")
+	registry := newLocalContextRegistry(swarmDir)
+	writeCLIAPITestContext(t, registry, localProjectContextName(project.canonicalRoot), "runtime-project", server.URL, project.canonicalRoot)
+
+	client, err := newCLIAPIClient(rootCommandOptions{
+		repoRoot: project.root,
+		rootFlags: &rootCommandFlagState{
+			swarmDir:    swarmDir,
+			swarmDirSet: true,
+		},
+	})
+	if err != nil {
+		t.Fatalf("newCLIAPIClient: %v", err)
+	}
+	if client.target.source != "project context" {
+		t.Fatalf("target source = %q, want project context", client.target.source)
+	}
+	if client.token != apiv1.DefaultLoopbackAPIToken {
+		t.Fatalf("token = %q, want descriptor built-in loopback token", client.token)
+	}
+
+	flagToken := writeCLIAPITokenFile(t, "flag-token")
+	settings, err := resolveCLIAPISettings(rootCommandOptions{
+		apiTokenFile: flagToken,
+		repoRoot:     project.root,
+		rootFlags: &rootCommandFlagState{
+			swarmDir:    swarmDir,
+			swarmDirSet: true,
+		},
+	})
+	if err != nil {
+		t.Fatalf("resolveCLIAPISettings with flag token: %v", err)
+	}
+	if settings.target.source != "project context" {
+		t.Fatalf("target source with flag token = %q, want project context", settings.target.source)
+	}
+	if settings.token != "flag-token" || settings.tokenSource != "--api-token-file" {
+		t.Fatalf("token/source = %q/%q, want flag-token/--api-token-file", settings.token, settings.tokenSource)
+	}
+}
+
 func TestCLIAPIExplicitAPIServerAndContextPrecedence(t *testing.T) {
 	isolateCLIAPIConfigEnv(t)
 	project := writeCLIAPIProjectFixture(t)
@@ -888,22 +925,22 @@ func TestEndpointShapedAPIServerRejectedBeforeRequest(t *testing.T) {
 			want: "not a direct /v1/ws endpoint",
 		},
 		{
-			name: "environment direct websocket endpoint",
+			name: "environment direct websocket endpoint is removed",
 			args: []string{"runs"},
 			setup: func(t *testing.T, serverURL string, _ string) {
 				t.Setenv("SWARM_API_SERVER", serverURL+"/v1/ws")
 				t.Setenv("SWARM_API_TOKEN", "env-token")
 			},
-			want: "not a direct /v1/ws endpoint",
+			want: "client-side API environment sources are no longer accepted",
 		},
 		{
-			name: "environment prefixed RPC endpoint",
+			name: "environment prefixed RPC endpoint is removed",
 			args: []string{"runs"},
 			setup: func(t *testing.T, serverURL string, _ string) {
 				t.Setenv("SWARM_API_SERVER", serverURL+"/proxy/v1/rpc")
 				t.Setenv("SWARM_API_TOKEN", "env-token")
 			},
-			want: "not a direct /v1/rpc endpoint",
+			want: "client-side API environment sources are no longer accepted",
 		},
 		{
 			name: "config direct RPC endpoint",
@@ -1076,6 +1113,17 @@ func isolateCLIAPIConfigEnv(t *testing.T) {
 	t.Setenv("SWARM_CONTRACTS_DIR", "")
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
 	t.Setenv("HOME", t.TempDir())
+}
+
+func setCLIAPITestToken(t *testing.T, token string) {
+	t.Helper()
+	if strings.TrimSpace(token) == "" {
+		t.Setenv("SWARM_CONFIG", "")
+		return
+	}
+	t.Setenv("SWARM_CONFIG", writeCLIAPIConfigFile(t, map[string]string{
+		"api_token_file": writeCLIAPITokenFile(t, token),
+	}))
 }
 
 func writeCLIAPITokenFile(t *testing.T, token string) string {

--- a/cmd/swarm/cli_errors.go
+++ b/cmd/swarm/cli_errors.go
@@ -18,7 +18,7 @@ const (
 	cliExitInterrupted = 130
 )
 
-var errCLIAPITokenRequired = errors.New("SWARM_API_TOKEN is required for non-loopback API targets")
+var errCLIAPITokenRequired = errors.New("API token source is required for non-loopback API targets; use --api-token-file, context descriptor auth, or config api_token_file")
 
 type cliAPIErrorClassifier struct {
 	runtimeExit   int

--- a/cmd/swarm/cli_logging_test.go
+++ b/cmd/swarm/cli_logging_test.go
@@ -107,7 +107,7 @@ func TestCLILoggingForSharedOutputConsumers(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			for _, mode := range []string{"", "--json", "--quiet"} {
 				t.Run("mode "+mode, func(t *testing.T) {
-					t.Setenv("SWARM_API_TOKEN", "test-token")
+					setCLIAPITestToken(t, "test-token")
 
 					args := append([]string{}, tc.args(t)...)
 					if mode != "" {
@@ -166,7 +166,7 @@ func TestCLILoggingAcceptedLevelsOnConsumer(t *testing.T) {
 }
 
 func TestCLILoggingInvalidLevelFailsBeforeSideEffects(t *testing.T) {
-	t.Setenv("SWARM_API_TOKEN", "test-token")
+	setCLIAPITestToken(t, "test-token")
 
 	var calls atomic.Int32
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -236,7 +236,7 @@ func TestCLILoggingInvalidLevelFailsBeforeSideEffects(t *testing.T) {
 }
 
 func TestCLILoggingUnsupportedSurfacesFailClosedBeforeSideEffects(t *testing.T) {
-	t.Setenv("SWARM_API_TOKEN", "test-token")
+	setCLIAPITestToken(t, "test-token")
 
 	var rpcCalls atomic.Int32
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/cmd/swarm/cli_output_test.go
+++ b/cmd/swarm/cli_output_test.go
@@ -43,7 +43,7 @@ func TestCLIOutputModesForLocalConsumers(t *testing.T) {
 		t.Fatalf("version --quiet stdout = %q, want binary version", got)
 	}
 
-	t.Setenv("SWARM_API_TOKEN", "test-token")
+	setCLIAPITestToken(t, "test-token")
 	for _, mode := range []string{"--json", "--quiet"} {
 		server, requests := newDiagnosticSuccessServer(t, func(req jsonRPCRequest, _ int) map[string]any {
 			if req.Method != "health.check" {
@@ -101,7 +101,7 @@ func TestCLIOutputModesForLocalConsumers(t *testing.T) {
 }
 
 func TestCLIOutputModesForDiagnosticConsumers(t *testing.T) {
-	t.Setenv("SWARM_API_TOKEN", "test-token")
+	setCLIAPITestToken(t, "test-token")
 
 	t.Run("runs", func(t *testing.T) {
 		for _, tc := range []struct {
@@ -243,7 +243,7 @@ func TestCLIOutputModesForDiagnosticConsumers(t *testing.T) {
 }
 
 func TestCLIOutputModesForConversationConsumers(t *testing.T) {
-	t.Setenv("SWARM_API_TOKEN", "test-token")
+	setCLIAPITestToken(t, "test-token")
 
 	for _, tc := range []struct {
 		name       string
@@ -443,7 +443,7 @@ func TestCLIOutputNoColorForSharedRendererConsumers(t *testing.T) {
 				{name: "quiet environment", outputMode: "--quiet", env: "1"},
 			} {
 				t.Run(mode.name, func(t *testing.T) {
-					t.Setenv("SWARM_API_TOKEN", "test-token")
+					setCLIAPITestToken(t, "test-token")
 					t.Setenv("NO_COLOR", mode.env)
 
 					args := append([]string{}, tc.args(t)...)
@@ -523,7 +523,7 @@ func TestCLIOutputNoColorDoesNotRewriteMachineModes(t *testing.T) {
 }
 
 func TestCLIOutputModeCollisionFailsBeforeSideEffects(t *testing.T) {
-	t.Setenv("SWARM_API_TOKEN", "test-token")
+	setCLIAPITestToken(t, "test-token")
 
 	for _, args := range [][]string{
 		{"version", "--json", "--quiet", "--no-color"},
@@ -574,7 +574,7 @@ func TestCLIOutputModeCollisionFailsBeforeSideEffects(t *testing.T) {
 }
 
 func TestCLIOutputModeExceptionRowsFailClosedBeforeSideEffects(t *testing.T) {
-	t.Setenv("SWARM_API_TOKEN", "test-token")
+	setCLIAPITestToken(t, "test-token")
 
 	var rpcCalls atomic.Int32
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/cmd/swarm/cli_target_resolution.go
+++ b/cmd/swarm/cli_target_resolution.go
@@ -10,8 +10,6 @@ import (
 	"regexp"
 	"strings"
 	"time"
-
-	"github.com/division-sh/swarm/internal/apiv1"
 )
 
 type cliAPICommandClass string
@@ -38,6 +36,9 @@ type cliProjectResolution struct {
 }
 
 func resolveCLIAPITarget(opts rootCommandOptions, cfg cliAPIConfigFile) (cliAPITargetResolution, error) {
+	if err := rejectRemovedClientAPIEnvSources(); err != nil {
+		return cliAPITargetResolution{}, err
+	}
 	if endpoint := strings.TrimSpace(opts.apiRPCEndpointOverride); endpoint != "" {
 		rpc, err := normalizeCLIAPIRPCEndpoint(endpoint, "internal API endpoint")
 		return cliAPITargetResolution{rpcEndpoint: rpc, source: "internal API endpoint"}, err
@@ -49,20 +50,12 @@ func resolveCLIAPITarget(opts rootCommandOptions, cfg cliAPIConfigFile) (cliAPIT
 	if contextName := strings.TrimSpace(opts.contextName); contextName != "" {
 		return resolveCLIAPIExplicitContextTarget(opts, cfg, contextName)
 	}
-	if server := strings.TrimSpace(os.Getenv("SWARM_API_SERVER")); server != "" {
-		rpc, err := cliAPIRPCEndpointFromServer(server, "SWARM_API_SERVER")
-		return cliAPITargetResolution{rpcEndpoint: rpc, source: "SWARM_API_SERVER"}, err
-	}
-	if server := strings.TrimSpace(cfg.APIServer); server != "" {
-		rpc, err := cliAPIRPCEndpointFromServer(server, "config api_server")
-		return cliAPITargetResolution{rpcEndpoint: rpc, source: "config api_server"}, err
-	}
 	if !opts.disableLocalTargeting {
 		if project, ok := resolveCLIAPIProject(opts, cfg); ok {
 			return resolveCLIAPIProjectTarget(opts, cfg, project)
 		}
 	}
-	return resolveCLIAPISelectedOrDefaultTarget(opts, cfg)
+	return resolveCLIAPISelectedConfigOrDefaultTarget(opts, cfg)
 }
 
 func resolveCLIAPIExplicitContextTarget(opts rootCommandOptions, cfg cliAPIConfigFile, contextName string) (cliAPITargetResolution, error) {
@@ -115,11 +108,11 @@ func resolveCLIAPIProjectTarget(opts rootCommandOptions, cfg cliAPIConfigFile, p
 		}
 		return cliAPITargetResolution{}, &cliAPIValidationError{message: fmt.Sprintf("no live project context for %s; refusing %s command without explicit --context or --api-server; start `swarm serve --dev` for this project or choose a target explicitly", project.canonicalProjectRoot, commandClass)}
 	default:
-		return resolveCLIAPISelectedOrDefaultTarget(opts, cfg)
+		return resolveCLIAPISelectedConfigOrDefaultTarget(opts, cfg)
 	}
 }
 
-func resolveCLIAPISelectedOrDefaultTarget(opts rootCommandOptions, cfg cliAPIConfigFile) (cliAPITargetResolution, error) {
+func resolveCLIAPISelectedConfigOrDefaultTarget(opts rootCommandOptions, cfg cliAPIConfigFile) (cliAPITargetResolution, error) {
 	registry, err := cliAPILocalContextRegistry(opts, cfg)
 	if err != nil {
 		return cliAPITargetResolution{}, err
@@ -136,6 +129,10 @@ func resolveCLIAPISelectedOrDefaultTarget(opts rootCommandOptions, cfg cliAPICon
 	}
 	if report.Status != "" && report.Status != "empty" && report.Status != "no_current" && report.Status != localContextStatusOK {
 		return cliAPITargetResolution{}, &cliAPIValidationError{message: fmt.Sprintf("local context registry is %s: %s", report.Status, report.Detail)}
+	}
+	if server := strings.TrimSpace(cfg.APIServer); server != "" {
+		rpc, err := cliAPIRPCEndpointFromServer(server, "config api_server")
+		return cliAPITargetResolution{rpcEndpoint: rpc, source: "config api_server"}, err
 	}
 	rpc, err := cliAPIRPCEndpointFromServer(defaultCLIAPIServer, "built-in loopback default")
 	return cliAPITargetResolution{rpcEndpoint: rpc, source: "built-in loopback default"}, err
@@ -187,20 +184,14 @@ func cliAPITargetFromDescriptor(entry localContextEntry, source string) (cliAPIT
 }
 
 func resolveCLIAPITokenForTarget(opts rootCommandOptions, cfg cliAPIConfigFile, target cliAPITargetResolution) (cliAPITokenResolution, error) {
-	if target.descriptor == nil {
-		return resolveCLIAPIToken(opts, cfg, target.rpcEndpoint)
+	if err := rejectRemovedClientAPIEnvSources(); err != nil {
+		return cliAPITokenResolution{}, err
 	}
 	if tokenFile := strings.TrimSpace(opts.apiTokenFile); tokenFile != "" {
 		return readCLIAPIExplicitTokenFile(tokenFile, "--api-token-file")
 	}
-	if token := strings.TrimSpace(os.Getenv("SWARM_API_TOKEN")); token != "" {
-		return cliAPITokenResolution{token: token, source: string(apiv1.AuthTokenSourceEnvironment), explicit: true}, nil
-	}
-	if tokenFile := strings.TrimSpace(os.Getenv("SWARM_API_TOKEN_FILE")); tokenFile != "" {
-		return readCLIAPIExplicitTokenFile(tokenFile, "SWARM_API_TOKEN_FILE")
-	}
-	if tokenFile := strings.TrimSpace(cfg.APITokenFile); tokenFile != "" {
-		return readCLIAPIExplicitTokenFile(tokenFile, "config api_token_file")
+	if target.descriptor == nil {
+		return resolveCLIAPIToken(opts, cfg, target.rpcEndpoint)
 	}
 	token, err := localContextDescriptorToken(*target.descriptor, target.rpcEndpoint)
 	if err != nil {

--- a/cmd/swarm/control_mailbox_test.go
+++ b/cmd/swarm/control_mailbox_test.go
@@ -57,7 +57,7 @@ func TestMailboxCommandsSendV1RPCRequests(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			t.Setenv("SWARM_API_TOKEN", "test-token")
+			setCLIAPITestToken(t, "test-token")
 			var captured jsonRPCRequest
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				if r.URL.Path != "/v1/rpc" {
@@ -117,7 +117,7 @@ func TestMailboxCommandsSendV1RPCRequests(t *testing.T) {
 }
 
 func TestMailboxApproveDecisionPayloadFileSendsV1RPCRequest(t *testing.T) {
-	t.Setenv("SWARM_API_TOKEN", "test-token")
+	setCLIAPITestToken(t, "test-token")
 	payloadPath := filepath.Join(t.TempDir(), "decision-payload.json")
 	if err := os.WriteFile(payloadPath, []byte(`{"approved":true,"source":"file"}`), 0o600); err != nil {
 		t.Fatalf("write payload file: %v", err)
@@ -175,7 +175,7 @@ func TestMailboxApproveDecisionPayloadFileSendsV1RPCRequest(t *testing.T) {
 }
 
 func TestMailboxListSendsV1RPCRequestAndRendersResult(t *testing.T) {
-	t.Setenv("SWARM_API_TOKEN", "test-token")
+	setCLIAPITestToken(t, "test-token")
 	var captured jsonRPCRequest
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/v1/rpc" {
@@ -243,7 +243,7 @@ func TestMailboxListSendsV1RPCRequestAndRendersResult(t *testing.T) {
 }
 
 func TestMailboxListDefaultsToPendingAndRendersEmptyResult(t *testing.T) {
-	t.Setenv("SWARM_API_TOKEN", "test-token")
+	setCLIAPITestToken(t, "test-token")
 	var captured jsonRPCRequest
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
@@ -270,7 +270,7 @@ func TestMailboxListDefaultsToPendingAndRendersEmptyResult(t *testing.T) {
 }
 
 func TestMailboxViewSendsV1RPCRequestAndRendersDetail(t *testing.T) {
-	t.Setenv("SWARM_API_TOKEN", "test-token")
+	setCLIAPITestToken(t, "test-token")
 	var captured jsonRPCRequest
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if got := r.Header.Get("Authorization"); got != "Bearer test-token" {
@@ -327,7 +327,7 @@ func TestMailboxViewSendsV1RPCRequestAndRendersDetail(t *testing.T) {
 }
 
 func TestMailboxRejectsInvalidInputBeforeRequest(t *testing.T) {
-	t.Setenv("SWARM_API_TOKEN", "test-token")
+	setCLIAPITestToken(t, "test-token")
 	var calls atomic.Int32
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		calls.Add(1)
@@ -473,7 +473,7 @@ func TestMailboxRequiresAPITokenBeforeRequest(t *testing.T) {
 			if code != 4 {
 				t.Fatalf("code = %d, want 4 stdout=%s stderr=%s", code, stdout.String(), stderr.String())
 			}
-			if !strings.Contains(stderr.String(), "SWARM_API_TOKEN is required") {
+			if !strings.Contains(stderr.String(), "API token source is required") {
 				t.Fatalf("stderr = %q, want missing-token message", stderr.String())
 			}
 			if calls.Load() != 0 {
@@ -484,7 +484,7 @@ func TestMailboxRequiresAPITokenBeforeRequest(t *testing.T) {
 }
 
 func TestControlMailboxRetiredAliasesFailClosedBeforeRequest(t *testing.T) {
-	t.Setenv("SWARM_API_TOKEN", "test-token")
+	setCLIAPITestToken(t, "test-token")
 	var calls atomic.Int32
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		calls.Add(1)
@@ -613,7 +613,7 @@ func TestMailboxSurfacesTransportAndRPCFailures(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			t.Setenv("SWARM_API_TOKEN", "test-token")
+			setCLIAPITestToken(t, "test-token")
 			server := httptest.NewServer(tc.handler)
 			defer server.Close()
 
@@ -781,7 +781,7 @@ func TestMailboxReadCommandsFailClosedOnRPCAndMalformedResponses(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			t.Setenv("SWARM_API_TOKEN", "test-token")
+			setCLIAPITestToken(t, "test-token")
 			server := httptest.NewServer(tc.handler)
 			defer server.Close()
 
@@ -827,7 +827,7 @@ func TestMailboxRejectsMalformedStatusByAction(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			t.Setenv("SWARM_API_TOKEN", "test-token")
+			setCLIAPITestToken(t, "test-token")
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				var req jsonRPCRequest
 				_ = json.NewDecoder(r.Body).Decode(&req)
@@ -900,7 +900,11 @@ func decisionForMailboxStatus(status string) string {
 
 func testRootCommandOptions(server *httptest.Server) rootCommandOptions {
 	opts := defaultRootCommandOptions()
-	if strings.TrimSpace(os.Getenv("SWARM_API_TOKEN")) == "" && strings.TrimSpace(os.Getenv("SWARM_API_TOKEN_FILE")) == "" {
+	hasTokenSource := strings.TrimSpace(opts.apiTokenFile) != ""
+	if cfg, err := loadCLIAPIConfigFile(); err == nil && strings.TrimSpace(cfg.APITokenFile) != "" {
+		hasTokenSource = true
+	}
+	if !hasTokenSource {
 		// Missing-token tests now prove fail-closed behavior on non-loopback targets.
 		opts.apiRPCEndpointOverride = "http://192.0.2.10:8081/v1/rpc"
 		return opts

--- a/cmd/swarm/control_nuke_test.go
+++ b/cmd/swarm/control_nuke_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestControlNukeDryRunSendsV1RPCRequest(t *testing.T) {
-	t.Setenv("SWARM_API_TOKEN", "test-token")
+	setCLIAPITestToken(t, "test-token")
 	var captured jsonRPCRequest
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/v1/rpc" {
@@ -52,7 +52,7 @@ func TestControlNukeDryRunSendsV1RPCRequest(t *testing.T) {
 }
 
 func TestControlNukeYesAppliesThroughV1RPC(t *testing.T) {
-	t.Setenv("SWARM_API_TOKEN", "test-token")
+	setCLIAPITestToken(t, "test-token")
 	var captured jsonRPCRequest
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
@@ -84,7 +84,7 @@ func TestControlNukeYesAppliesThroughV1RPC(t *testing.T) {
 }
 
 func TestControlNukeSendsIdempotencyKey(t *testing.T) {
-	t.Setenv("SWARM_API_TOKEN", "test-token")
+	setCLIAPITestToken(t, "test-token")
 	for _, tc := range []struct {
 		name          string
 		args          []string
@@ -153,7 +153,7 @@ func TestControlNukeSendsIdempotencyKey(t *testing.T) {
 }
 
 func TestControlNukeNoOpResultExitsZero(t *testing.T) {
-	t.Setenv("SWARM_API_TOKEN", "test-token")
+	setCLIAPITestToken(t, "test-token")
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var req jsonRPCRequest
 		_ = json.NewDecoder(r.Body).Decode(&req)
@@ -175,7 +175,7 @@ func TestControlNukeNoOpResultExitsZero(t *testing.T) {
 }
 
 func TestControlNukeConfirmationAndNoCallPaths(t *testing.T) {
-	t.Setenv("SWARM_API_TOKEN", "test-token")
+	setCLIAPITestToken(t, "test-token")
 	var calls atomic.Int32
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		calls.Add(1)
@@ -221,7 +221,7 @@ func TestControlNukeConfirmationAndNoCallPaths(t *testing.T) {
 }
 
 func TestControlNukeRejectsBlankIdempotencyKeyBeforePromptOrRequest(t *testing.T) {
-	t.Setenv("SWARM_API_TOKEN", "test-token")
+	setCLIAPITestToken(t, "test-token")
 	var calls atomic.Int32
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		calls.Add(1)
@@ -324,7 +324,7 @@ func TestControlNukeMapsFailureExitCodes(t *testing.T) {
 			handler: func(w http.ResponseWriter, r *http.Request) {
 				t.Fatal("unexpected request without SWARM_API_TOKEN")
 			},
-			wantStderr: "SWARM_API_TOKEN is required",
+			wantStderr: "API token source is required",
 		},
 		{
 			name:  "malformed response exits three",
@@ -350,7 +350,7 @@ func TestControlNukeMapsFailureExitCodes(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			t.Setenv("SWARM_API_TOKEN", tc.token)
+			setCLIAPITestToken(t, tc.token)
 			server := httptest.NewServer(tc.handler)
 			defer server.Close()
 
@@ -367,7 +367,7 @@ func TestControlNukeMapsFailureExitCodes(t *testing.T) {
 }
 
 func TestControlNukeTransportFailureExitsThree(t *testing.T) {
-	t.Setenv("SWARM_API_TOKEN", "test-token")
+	setCLIAPITestToken(t, "test-token")
 	var stdout, stderr bytes.Buffer
 	opts := defaultRootCommandOptions()
 	opts.apiRPCEndpointOverride = "http://127.0.0.1:1/v1/rpc"

--- a/cmd/swarm/control_run_test.go
+++ b/cmd/swarm/control_run_test.go
@@ -23,7 +23,7 @@ func TestControlRunSingleCommandsSendV1RPCRequests(t *testing.T) {
 		{action: "stop", wantMethod: controlCommandRunStopMethod, wantOutput: "control stop ok: scope=run run_id=run-1"},
 	} {
 		t.Run(tc.action, func(t *testing.T) {
-			t.Setenv("SWARM_API_TOKEN", "test-token")
+			setCLIAPITestToken(t, "test-token")
 			var captured jsonRPCRequest
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				if r.URL.Path != "/v1/rpc" {
@@ -70,7 +70,7 @@ func TestControlRunSingleCommandsSendIdempotencyKeys(t *testing.T) {
 		{action: "stop", wantMethod: controlCommandRunStopMethod},
 	} {
 		t.Run(tc.action, func(t *testing.T) {
-			t.Setenv("SWARM_API_TOKEN", "test-token")
+			setCLIAPITestToken(t, "test-token")
 			var captured jsonRPCRequest
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
@@ -103,7 +103,7 @@ func TestControlRunAllPauseContinueSendRuntimeRPCRequests(t *testing.T) {
 		{action: "continue", wantMethod: controlCommandRuntimeResumeMethod, wantOutput: "control continue ok: scope=runtime"},
 	} {
 		t.Run(tc.action, func(t *testing.T) {
-			t.Setenv("SWARM_API_TOKEN", "test-token")
+			setCLIAPITestToken(t, "test-token")
 			var captured jsonRPCRequest
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
@@ -143,7 +143,7 @@ func TestControlRunAllPauseContinueSendIdempotencyKeys(t *testing.T) {
 		{action: "continue", wantMethod: controlCommandRuntimeResumeMethod},
 	} {
 		t.Run(tc.action, func(t *testing.T) {
-			t.Setenv("SWARM_API_TOKEN", "test-token")
+			setCLIAPITestToken(t, "test-token")
 			var captured jsonRPCRequest
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
@@ -167,7 +167,7 @@ func TestControlRunAllPauseContinueSendIdempotencyKeys(t *testing.T) {
 }
 
 func TestControlStopAllListsActiveRunsAndStopsUniqueTargets(t *testing.T) {
-	t.Setenv("SWARM_API_TOKEN", "test-token")
+	setCLIAPITestToken(t, "test-token")
 	var captured []jsonRPCRequest
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var req jsonRPCRequest
@@ -227,7 +227,7 @@ func TestControlStopAllListsActiveRunsAndStopsUniqueTargets(t *testing.T) {
 }
 
 func TestControlRunRejectsInvalidTargetsBeforeRequest(t *testing.T) {
-	t.Setenv("SWARM_API_TOKEN", "test-token")
+	setCLIAPITestToken(t, "test-token")
 	var calls atomic.Int32
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		calls.Add(1)
@@ -297,7 +297,7 @@ func TestControlRunRequiresAPITokenBeforeRequest(t *testing.T) {
 			if strings.TrimSpace(stdout.String()) != "" {
 				t.Fatalf("stdout = %q, want empty", stdout.String())
 			}
-			if !strings.Contains(stderr.String(), "SWARM_API_TOKEN is required") {
+			if !strings.Contains(stderr.String(), "API token source is required") {
 				t.Fatalf("stderr = %q, want missing-token message", stderr.String())
 			}
 			if calls.Load() != 0 {
@@ -358,7 +358,7 @@ func TestControlRunFailsClosedOnTransportRPCAndMalformedResponses(t *testing.T) 
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			t.Setenv("SWARM_API_TOKEN", "test-token")
+			setCLIAPITestToken(t, "test-token")
 			server := httptest.NewServer(tc.handler)
 			defer server.Close()
 
@@ -378,7 +378,7 @@ func TestControlRunFailsClosedOnTransportRPCAndMalformedResponses(t *testing.T) 
 }
 
 func TestControlStopAllConfirmationAndNoCallPaths(t *testing.T) {
-	t.Setenv("SWARM_API_TOKEN", "test-token")
+	setCLIAPITestToken(t, "test-token")
 
 	for _, tc := range []struct {
 		name          string
@@ -500,7 +500,7 @@ func TestControlStopAllConfirmationPrecedesAPIClientConstruction(t *testing.T) {
 			input:         "y\n",
 			stdinTerminal: true,
 			wantCode:      4,
-			wantStderr:    "SWARM_API_TOKEN is required",
+			wantStderr:    "API token source is required",
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -531,7 +531,7 @@ func TestControlStopAllConfirmationPrecedesAPIClientConstruction(t *testing.T) {
 }
 
 func TestControlStopAllReportsPartialFailures(t *testing.T) {
-	t.Setenv("SWARM_API_TOKEN", "test-token")
+	setCLIAPITestToken(t, "test-token")
 	var captured []jsonRPCRequest
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var req jsonRPCRequest

--- a/cmd/swarm/conversations_test.go
+++ b/cmd/swarm/conversations_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestConversationsListUsesConversationListV1RPCWithFilters(t *testing.T) {
-	t.Setenv("SWARM_API_TOKEN", "test-token")
+	setCLIAPITestToken(t, "test-token")
 	var captured jsonRPCRequest
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/v1/rpc" {
@@ -66,7 +66,7 @@ func TestConversationsListUsesConversationListV1RPCWithFilters(t *testing.T) {
 }
 
 func TestConversationsListEmptyResultOmitsUnsetParams(t *testing.T) {
-	t.Setenv("SWARM_API_TOKEN", "test-token")
+	setCLIAPITestToken(t, "test-token")
 	var captured jsonRPCRequest
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
@@ -93,7 +93,7 @@ func TestConversationsListEmptyResultOmitsUnsetParams(t *testing.T) {
 }
 
 func TestConversationViewUsesConversationGetAndRendersTurns(t *testing.T) {
-	t.Setenv("SWARM_API_TOKEN", "test-token")
+	setCLIAPITestToken(t, "test-token")
 	var captured jsonRPCRequest
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
@@ -130,7 +130,7 @@ func TestConversationViewUsesConversationGetAndRendersTurns(t *testing.T) {
 }
 
 func TestConversationTurnUsesConversationGetTurnAndRendersDeepTurn(t *testing.T) {
-	t.Setenv("SWARM_API_TOKEN", "test-token")
+	setCLIAPITestToken(t, "test-token")
 	var captured jsonRPCRequest
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
@@ -170,7 +170,7 @@ func TestConversationTurnUsesConversationGetTurnAndRendersDeepTurn(t *testing.T)
 }
 
 func TestConversationCommandsRejectInvalidInputBeforeRequest(t *testing.T) {
-	t.Setenv("SWARM_API_TOKEN", "test-token")
+	setCLIAPITestToken(t, "test-token")
 	var calls atomic.Int32
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		calls.Add(1)
@@ -232,7 +232,7 @@ func TestConversationCommandsFailClosedWithoutTokenBeforeRequest(t *testing.T) {
 		if code != 4 {
 			t.Fatalf("%v code = %d, want 4 stdout=%s stderr=%s", args, code, stdout.String(), stderr.String())
 		}
-		if !strings.Contains(stderr.String(), "SWARM_API_TOKEN is required") {
+		if !strings.Contains(stderr.String(), "API token source is required") {
 			t.Fatalf("%v stderr = %q, want token failure", args, stderr.String())
 		}
 	}
@@ -358,7 +358,7 @@ func TestConversationCommandsMapRuntimeFailuresAndMalformedResults(t *testing.T)
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			t.Setenv("SWARM_API_TOKEN", "test-token")
+			setCLIAPITestToken(t, "test-token")
 			server := httptest.NewServer(tc.handler)
 			defer server.Close()
 

--- a/cmd/swarm/diagnostics_test.go
+++ b/cmd/swarm/diagnostics_test.go
@@ -18,7 +18,7 @@ import (
 )
 
 func TestRunsUseRunListV1RPC(t *testing.T) {
-	t.Setenv("SWARM_API_TOKEN", "test-token")
+	setCLIAPITestToken(t, "test-token")
 	server, requests := newDiagnosticSuccessServer(t, func(req jsonRPCRequest, _ int) map[string]any {
 		if req.Method != "run.list" {
 			t.Fatalf("method = %q, want run.list", req.Method)
@@ -143,7 +143,7 @@ func TestStatusUsesDiagnoseAndRunGet(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			t.Setenv("SWARM_API_TOKEN", "test-token")
+			setCLIAPITestToken(t, "test-token")
 			server, requests := newDiagnosticSuccessServer(t, func(req jsonRPCRequest, _ int) map[string]any {
 				if req.Method != tc.wantMethod {
 					t.Fatalf("method = %q, want %s", req.Method, tc.wantMethod)
@@ -222,7 +222,7 @@ func TestStatusAndTraceResolveOmittedRunThroughActivePreference(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			t.Setenv("SWARM_API_TOKEN", "test-token")
+			setCLIAPITestToken(t, "test-token")
 			server, requests := newDiagnosticSuccessServer(t, func(req jsonRPCRequest, callIndex int) map[string]any {
 				if callIndex < len(tc.lists) {
 					if req.Method != "run.list" {
@@ -352,7 +352,7 @@ func TestInvestigateTraceIsRetiredWithoutRequest(t *testing.T) {
 }
 
 func TestTraceUsesRunTraceSnapshot(t *testing.T) {
-	t.Setenv("SWARM_API_TOKEN", "test-token")
+	setCLIAPITestToken(t, "test-token")
 	server, requests := newDiagnosticSuccessServer(t, func(req jsonRPCRequest, _ int) map[string]any {
 		if req.Method != "run.trace" {
 			t.Fatalf("method = %q, want run.trace", req.Method)
@@ -425,7 +425,7 @@ func TestTraceUsesRunTraceSnapshot(t *testing.T) {
 }
 
 func TestTraceDeliveryDetailRendersRunTraceLifecycleFields(t *testing.T) {
-	t.Setenv("SWARM_API_TOKEN", "test-token")
+	setCLIAPITestToken(t, "test-token")
 	server, requests := newDiagnosticSuccessServer(t, func(req jsonRPCRequest, _ int) map[string]any {
 		if req.Method != "run.trace" {
 			t.Fatalf("method = %q, want run.trace", req.Method)
@@ -484,7 +484,7 @@ func TestTraceDeliveryDetailRendersRunTraceLifecycleFields(t *testing.T) {
 }
 
 func TestTraceDeliverySummaryExhaustsRunTracePages(t *testing.T) {
-	t.Setenv("SWARM_API_TOKEN", "test-token")
+	setCLIAPITestToken(t, "test-token")
 	server, requests := newDiagnosticSuccessServer(t, func(req jsonRPCRequest, callIndex int) map[string]any {
 		if req.Method != "run.trace" {
 			t.Fatalf("method[%d] = %q, want run.trace", callIndex, req.Method)
@@ -603,7 +603,7 @@ func TestTraceDeliverySummaryExhaustsRunTracePages(t *testing.T) {
 }
 
 func TestTraceDeliverySummaryUsesOmittedRunResolver(t *testing.T) {
-	t.Setenv("SWARM_API_TOKEN", "test-token")
+	setCLIAPITestToken(t, "test-token")
 	var capturedUntil string
 	server, requests := newDiagnosticSuccessServer(t, func(req jsonRPCRequest, callIndex int) map[string]any {
 		switch callIndex {
@@ -684,7 +684,7 @@ func wantFullTraceFilterParams() map[string]any {
 }
 
 func TestTraceSnapshotFiltersUseOmittedRunResolver(t *testing.T) {
-	t.Setenv("SWARM_API_TOKEN", "test-token")
+	setCLIAPITestToken(t, "test-token")
 	server, requests := newDiagnosticSuccessServer(t, func(req jsonRPCRequest, callIndex int) map[string]any {
 		switch callIndex {
 		case 0:
@@ -757,7 +757,7 @@ func TestTraceFollowUsesRunSubscribeTrace(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			t.Setenv("SWARM_API_TOKEN", "test-token")
+			setCLIAPITestToken(t, "test-token")
 			server, calls, wsRequests := newRunCommandServer(t, runCommandServerOptions{
 				wsRows:           []map[string]any{validRunCommandTraceRow("evt-follow")},
 				wsCloseAfterRows: true,
@@ -782,7 +782,7 @@ func TestTraceFollowUsesRunSubscribeTrace(t *testing.T) {
 }
 
 func TestTraceFollowOmittedRunReusesActivePreferenceResolver(t *testing.T) {
-	t.Setenv("SWARM_API_TOKEN", "test-token")
+	setCLIAPITestToken(t, "test-token")
 	server, calls, wsRequests := newRunCommandServer(t, runCommandServerOptions{
 		rpcResponder: func(req jsonRPCRequest, callIndex int) map[string]any {
 			if req.Method != "run.list" {
@@ -841,7 +841,7 @@ func TestTraceHelpPromotesNoRetryWithoutReplaySince(t *testing.T) {
 }
 
 func TestTraceFollowRecoversWithReplaySinceAfterClose(t *testing.T) {
-	t.Setenv("SWARM_API_TOKEN", "test-token")
+	setCLIAPITestToken(t, "test-token")
 	var mu sync.Mutex
 	rpcRequests := []jsonRPCRequest{}
 	wsRequests := []jsonRPCRequest{}
@@ -966,7 +966,7 @@ func TestTraceFollowRecoversWithReplaySinceAfterClose(t *testing.T) {
 }
 
 func TestTraceFollowRetriesRetryableReadFailure(t *testing.T) {
-	t.Setenv("SWARM_API_TOKEN", "test-token")
+	setCLIAPITestToken(t, "test-token")
 	var mu sync.Mutex
 	wsRequests := []jsonRPCRequest{}
 	recoveredRowSent := make(chan struct{})
@@ -1076,7 +1076,7 @@ func TestTraceFollowClassifiesPlainEOFAsRetryableTransportClose(t *testing.T) {
 }
 
 func TestTraceFollowCtrlCDetachesWithoutRunStop(t *testing.T) {
-	t.Setenv("SWARM_API_TOKEN", "test-token")
+	setCLIAPITestToken(t, "test-token")
 	wsSubscribed := make(chan struct{})
 	server, calls, wsRequests := newRunCommandServer(t, runCommandServerOptions{
 		rpcResponder: func(req jsonRPCRequest, _ int) map[string]any {
@@ -1108,7 +1108,7 @@ func TestTraceFollowCtrlCDetachesWithoutRunStop(t *testing.T) {
 }
 
 func TestTraceFollowMalformedWebSocketFailuresExitThree(t *testing.T) {
-	t.Setenv("SWARM_API_TOKEN", "test-token")
+	setCLIAPITestToken(t, "test-token")
 	for _, tc := range []struct {
 		name       string
 		serverOpts runCommandServerOptions
@@ -1149,7 +1149,7 @@ func TestTraceFollowMalformedWebSocketFailuresExitThree(t *testing.T) {
 }
 
 func TestHealthUsesHealthCheck(t *testing.T) {
-	t.Setenv("SWARM_API_TOKEN", "test-token")
+	setCLIAPITestToken(t, "test-token")
 	server, requests := newDiagnosticSuccessServer(t, func(req jsonRPCRequest, _ int) map[string]any {
 		if req.Method != "health.check" {
 			t.Fatalf("method = %q, want health.check", req.Method)
@@ -1211,7 +1211,7 @@ func TestInvestigateHealthIsRetiredWithoutRequest(t *testing.T) {
 }
 
 func TestDiagnosticsRejectInvalidInputBeforeRequest(t *testing.T) {
-	t.Setenv("SWARM_API_TOKEN", "test-token")
+	setCLIAPITestToken(t, "test-token")
 	var calls atomic.Int32
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		calls.Add(1)
@@ -1305,7 +1305,7 @@ func TestDiagnosticsRequireAPITokenBeforeRequest(t *testing.T) {
 			if code != 4 {
 				t.Fatalf("code = %d, want 4 stdout=%s stderr=%s", code, stdout.String(), stderr.String())
 			}
-			if !strings.Contains(stderr.String(), "SWARM_API_TOKEN is required") {
+			if !strings.Contains(stderr.String(), "API token source is required") {
 				t.Fatalf("stderr = %q, want missing-token message", stderr.String())
 			}
 			if calls.Load() != 0 {
@@ -1322,7 +1322,7 @@ func TestOmittedRunResolverFailsClosedWhenNoRunsExist(t *testing.T) {
 		{"trace"},
 	} {
 		t.Run(strings.Join(args, " "), func(t *testing.T) {
-			t.Setenv("SWARM_API_TOKEN", "test-token")
+			setCLIAPITestToken(t, "test-token")
 			server, requests := newDiagnosticSuccessServer(t, func(req jsonRPCRequest, _ int) map[string]any {
 				if req.Method != "run.list" {
 					t.Fatalf("method = %q, want run.list", req.Method)
@@ -1652,7 +1652,7 @@ func TestDiagnosticsFailClosedOnAPIAndMalformedResults(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			t.Setenv("SWARM_API_TOKEN", "test-token")
+			setCLIAPITestToken(t, "test-token")
 			server := httptest.NewServer(tc.handler)
 			defer server.Close()
 

--- a/cmd/swarm/doctor_test.go
+++ b/cmd/swarm/doctor_test.go
@@ -346,6 +346,31 @@ func TestDoctorTargetJSONPreservesScriptableOutput(t *testing.T) {
 	}
 }
 
+func TestDoctorTargetRejectsRemovedAPIClientEnv(t *testing.T) {
+	isolateCLIAPIConfigEnv(t)
+	repo := writeDoctorTargetRepo(t)
+	t.Setenv("SWARM_API_SERVER", "http://127.0.0.1:19002")
+	t.Setenv("SWARM_API_TOKEN", "env-token")
+	t.Setenv("SWARM_API_TOKEN_FILE", writeCLIAPITokenFile(t, "env-file-token"))
+
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), repo, []string{
+		"doctor", "--target",
+		"--contracts", filepath.Join(repo, "contracts"),
+	}, &stdout, &stderr, defaultRootCommandOptions())
+	if code != cliExitValidation {
+		t.Fatalf("code = %d, want %d stdout=%s stderr=%s", code, cliExitValidation, stdout.String(), stderr.String())
+	}
+	for _, want := range []string{"client-side API environment sources are no longer accepted", "SWARM_API_SERVER", "SWARM_API_TOKEN", "SWARM_API_TOKEN_FILE", "--api-server", "--api-token-file"} {
+		if !strings.Contains(stderr.String(), want) {
+			t.Fatalf("stderr missing %q:\n%s", want, stderr.String())
+		}
+	}
+	if stdout.String() != "" {
+		t.Fatalf("stdout = %q, want empty", stdout.String())
+	}
+}
+
 func TestDoctorTargetConsumesRuntimeConfigStoreAndData(t *testing.T) {
 	isolateCLIAPIConfigEnv(t)
 	unsetStoreSelectorEnv(t)
@@ -640,6 +665,9 @@ func TestPlatformSpecLocalTargetResolutionAuthorityPromoted(t *testing.T) {
 		if !stringSliceContains(target.TargetPrecedence.SourceOrder, want) {
 			t.Fatalf("target precedence missing %q: %#v", want, target.TargetPrecedence.SourceOrder)
 		}
+	}
+	if stringSliceContains(target.TargetPrecedence.SourceOrder, "existing_api_environment") {
+		t.Fatalf("target precedence still includes removed API environment source: %#v", target.TargetPrecedence.SourceOrder)
 	}
 	for _, class := range []string{"target_diagnostic", "read_only_inspection", "mutating_runtime_state", "control_destructive", "startup_and_run"} {
 		if _, ok := target.CommandClasses[class]; !ok {

--- a/cmd/swarm/doctor_test.go
+++ b/cmd/swarm/doctor_test.go
@@ -346,6 +346,35 @@ func TestDoctorTargetJSONPreservesScriptableOutput(t *testing.T) {
 	}
 }
 
+func TestDoctorTargetJSONReportsMissingAuthWithoutAborting(t *testing.T) {
+	isolateCLIAPIConfigEnv(t)
+	repo := writeDoctorTargetRepo(t)
+	apiServer := "http://192.0.2.10:8081"
+
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), repo, []string{
+		"doctor", "--target", "--json",
+		"--api-server", apiServer,
+		"--contracts", filepath.Join(repo, "contracts"),
+	}, &stdout, &stderr, defaultRootCommandOptions())
+	if code != cliExitOK {
+		t.Fatalf("code = %d, want %d stdout=%s stderr=%s", code, cliExitOK, stdout.String(), stderr.String())
+	}
+	if stderr.String() != "" {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+	var report doctorTargetReport
+	if err := json.Unmarshal(stdout.Bytes(), &report); err != nil {
+		t.Fatalf("parse target json: %v\n%s", err, stdout.String())
+	}
+	if report.API.Server != apiServer || report.API.Source != "--api-server" {
+		t.Fatalf("api target = %#v, want %q from --api-server", report.API, apiServer)
+	}
+	if report.API.Auth.Source != "none" || report.API.Auth.Status != "missing_explicit_token" {
+		t.Fatalf("api auth = %#v, want structured missing token diagnostic", report.API.Auth)
+	}
+}
+
 func TestDoctorTargetRejectsRemovedAPIClientEnv(t *testing.T) {
 	isolateCLIAPIConfigEnv(t)
 	repo := writeDoctorTargetRepo(t)
@@ -368,6 +397,42 @@ func TestDoctorTargetRejectsRemovedAPIClientEnv(t *testing.T) {
 	}
 	if stdout.String() != "" {
 		t.Fatalf("stdout = %q, want empty", stdout.String())
+	}
+}
+
+func TestDoctorTargetUsesResolvedSwarmDirForExplicitContext(t *testing.T) {
+	isolateCLIAPIConfigEnv(t)
+	repo := writeDoctorTargetRepo(t)
+	swarmDir := filepath.Join(t.TempDir(), "state")
+	server := startCLIAPIRuntimeIdentityServer(t, "runtime-target")
+	registry := newLocalContextRegistry(swarmDir)
+	writeCLIAPITestContext(t, registry, "target", "runtime-target", server.URL, "")
+
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), repo, []string{
+		"--swarm-dir", swarmDir,
+		"doctor", "--target", "--json",
+		"--context", "target",
+		"--contracts", filepath.Join(repo, "contracts"),
+	}, &stdout, &stderr, defaultRootCommandOptions())
+	if code != cliExitOK {
+		t.Fatalf("code = %d, want %d stdout=%s stderr=%s", code, cliExitOK, stdout.String(), stderr.String())
+	}
+	if stderr.String() != "" {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+	var report doctorTargetReport
+	if err := json.Unmarshal(stdout.Bytes(), &report); err != nil {
+		t.Fatalf("parse target json: %v\n%s", err, stdout.String())
+	}
+	if report.SwarmDir.Path != swarmDir || report.SwarmDir.Source != "--swarm-dir" {
+		t.Fatalf("swarm dir = %#v, want %q from --swarm-dir", report.SwarmDir, swarmDir)
+	}
+	if report.API.Server != server.URL || report.API.Source != "--context" {
+		t.Fatalf("api target = %#v, want explicit context from resolved swarm-dir", report.API)
+	}
+	if report.API.Auth.Source != "context descriptor "+localContextAuthBuiltinLoopback || report.API.Auth.Status != "configured" {
+		t.Fatalf("api auth = %#v, want context descriptor auth", report.API.Auth)
 	}
 }
 

--- a/cmd/swarm/entities_test.go
+++ b/cmd/swarm/entities_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 func TestEntitiesListUsesEntityListV1RPCWithFilters(t *testing.T) {
-	t.Setenv("SWARM_API_TOKEN", "test-token")
+	setCLIAPITestToken(t, "test-token")
 	var captured jsonRPCRequest
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/v1/rpc" {
@@ -74,7 +74,7 @@ func TestEntitiesListUsesEntityListV1RPCWithFilters(t *testing.T) {
 }
 
 func TestEntitiesListEmptyResultOmitsUnsetParams(t *testing.T) {
-	t.Setenv("SWARM_API_TOKEN", "test-token")
+	setCLIAPITestToken(t, "test-token")
 	var captured jsonRPCRequest
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
@@ -102,7 +102,7 @@ func TestEntitiesListEmptyResultOmitsUnsetParams(t *testing.T) {
 
 func TestEntityCommandsUseSQLiteEntityReadStoreThroughV1API(t *testing.T) {
 	ctx := context.Background()
-	t.Setenv("SWARM_API_TOKEN", "test-token")
+	setCLIAPITestToken(t, "test-token")
 	sqliteStore := storetest.StartSQLiteRuntimeStore(t)
 	runID := "11111111-1111-1111-1111-111111111111"
 	entityA := "22222222-2222-2222-2222-222222222222"
@@ -186,7 +186,7 @@ func TestEntityCommandsUseSQLiteEntityReadStoreThroughV1API(t *testing.T) {
 }
 
 func TestEntityViewUsesEntityGetAndRendersEntityNativeDetail(t *testing.T) {
-	t.Setenv("SWARM_API_TOKEN", "test-token")
+	setCLIAPITestToken(t, "test-token")
 	var captured jsonRPCRequest
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if got := r.Header.Get("Authorization"); got != "Bearer test-token" {
@@ -228,7 +228,7 @@ func TestEntityViewUsesEntityGetAndRendersEntityNativeDetail(t *testing.T) {
 }
 
 func TestEntityAggregateUsesEntityAggregateDefaultsAndFilters(t *testing.T) {
-	t.Setenv("SWARM_API_TOKEN", "test-token")
+	setCLIAPITestToken(t, "test-token")
 	var captured []jsonRPCRequest
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var req jsonRPCRequest
@@ -273,7 +273,7 @@ func TestEntityAggregateUsesEntityAggregateDefaultsAndFilters(t *testing.T) {
 }
 
 func TestEntityCommandsRejectInvalidInputBeforeRequest(t *testing.T) {
-	t.Setenv("SWARM_API_TOKEN", "test-token")
+	setCLIAPITestToken(t, "test-token")
 	var calls atomic.Int32
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		calls.Add(1)
@@ -333,7 +333,7 @@ func TestEntityCommandsFailClosedWithoutTokenBeforeRequest(t *testing.T) {
 		if code != 4 {
 			t.Fatalf("%v code = %d, want 4 stdout=%s stderr=%s", args, code, stdout.String(), stderr.String())
 		}
-		if !strings.Contains(stderr.String(), "SWARM_API_TOKEN is required") {
+		if !strings.Contains(stderr.String(), "API token source is required") {
 			t.Fatalf("%v stderr = %q, want token failure", args, stderr.String())
 		}
 	}
@@ -442,7 +442,7 @@ func TestEntityCommandsMapRuntimeFailuresAndMalformedResults(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			t.Setenv("SWARM_API_TOKEN", "test-token")
+			setCLIAPITestToken(t, "test-token")
 			server := httptest.NewServer(tc.handler)
 			defer server.Close()
 

--- a/cmd/swarm/event_publish_test.go
+++ b/cmd/swarm/event_publish_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestEventPublishUsesEventPublishV1RPCWithBoundParams(t *testing.T) {
-	t.Setenv("SWARM_API_TOKEN", "test-token")
+	setCLIAPITestToken(t, "test-token")
 	var captured jsonRPCRequest
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/v1/rpc" {
@@ -83,7 +83,7 @@ func TestEventPublishUsesEventPublishV1RPCWithBoundParams(t *testing.T) {
 }
 
 func TestEventPublishSerializesTargetRouteParam(t *testing.T) {
-	t.Setenv("SWARM_API_TOKEN", "test-token")
+	setCLIAPITestToken(t, "test-token")
 	var captured jsonRPCRequest
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
@@ -126,7 +126,7 @@ func TestEventPublishSerializesTargetRouteParam(t *testing.T) {
 }
 
 func TestEventPublishPassesFlowScopedEventNameToV1RPC(t *testing.T) {
-	t.Setenv("SWARM_API_TOKEN", "test-token")
+	setCLIAPITestToken(t, "test-token")
 	var captured jsonRPCRequest
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
@@ -161,7 +161,7 @@ func TestEventPublishPassesFlowScopedEventNameToV1RPC(t *testing.T) {
 }
 
 func TestEventPublishBundleHashSerializesCanonicalParamAndMapsUnsupported(t *testing.T) {
-	t.Setenv("SWARM_API_TOKEN", "test-token")
+	setCLIAPITestToken(t, "test-token")
 	var captured jsonRPCRequest
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
@@ -192,7 +192,7 @@ func TestEventPublishBundleHashSerializesCanonicalParamAndMapsUnsupported(t *tes
 }
 
 func TestEventPublishPayloadEntityIDServerRejectionMapsSupportedCLISurface(t *testing.T) {
-	t.Setenv("SWARM_API_TOKEN", "test-token")
+	setCLIAPITestToken(t, "test-token")
 	var captured jsonRPCRequest
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
@@ -242,7 +242,7 @@ func TestEventPublishPayloadEntityIDServerRejectionMapsSupportedCLISurface(t *te
 }
 
 func TestEventPublishLegacyBundleFingerprintSerializesBundleRef(t *testing.T) {
-	t.Setenv("SWARM_API_TOKEN", "test-token")
+	setCLIAPITestToken(t, "test-token")
 	var captured jsonRPCRequest
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
@@ -270,7 +270,7 @@ func TestEventPublishLegacyBundleFingerprintSerializesBundleRef(t *testing.T) {
 }
 
 func TestEventPublishOmitsOptionalParamsWhenNotProvided(t *testing.T) {
-	t.Setenv("SWARM_API_TOKEN", "test-token")
+	setCLIAPITestToken(t, "test-token")
 	var captured jsonRPCRequest
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
@@ -301,7 +301,7 @@ func TestEventPublishOmitsOptionalParamsWhenNotProvided(t *testing.T) {
 }
 
 func TestEventPublishRejectsInvalidInputBeforeRequest(t *testing.T) {
-	t.Setenv("SWARM_API_TOKEN", "test-token")
+	setCLIAPITestToken(t, "test-token")
 	var calls atomic.Int32
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		calls.Add(1)
@@ -372,7 +372,7 @@ func TestEventPublishFailClosedWithoutTokenBeforeRequest(t *testing.T) {
 	if code != 4 {
 		t.Fatalf("code = %d, want 4 stdout=%s stderr=%s", code, stdout.String(), stderr.String())
 	}
-	if !strings.Contains(stderr.String(), "SWARM_API_TOKEN is required") {
+	if !strings.Contains(stderr.String(), "API token source is required") {
 		t.Fatalf("stderr = %q, want token failure", stderr.String())
 	}
 	if calls.Load() != 0 {
@@ -572,7 +572,7 @@ func TestEventPublishMapsFailureExitCodes(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			t.Setenv("SWARM_API_TOKEN", "test-token")
+			setCLIAPITestToken(t, "test-token")
 			server := httptest.NewServer(tc.handler)
 			defer server.Close()
 
@@ -669,7 +669,7 @@ func TestEventPublishMalformedResultsFailClosed(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			t.Setenv("SWARM_API_TOKEN", "test-token")
+			setCLIAPITestToken(t, "test-token")
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				var req jsonRPCRequest
 				_ = json.NewDecoder(r.Body).Decode(&req)

--- a/cmd/swarm/events_test.go
+++ b/cmd/swarm/events_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func TestEventsListUsesEventListV1RPC(t *testing.T) {
-	t.Setenv("SWARM_API_TOKEN", "test-token")
+	setCLIAPITestToken(t, "test-token")
 	var captured jsonRPCRequest
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/v1/rpc" {
@@ -87,7 +87,7 @@ func TestEventsListUsesEventListV1RPC(t *testing.T) {
 }
 
 func TestEventViewUsesEventGetV1RPC(t *testing.T) {
-	t.Setenv("SWARM_API_TOKEN", "test-token")
+	setCLIAPITestToken(t, "test-token")
 	var captured jsonRPCRequest
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
@@ -138,7 +138,7 @@ func TestEventViewUsesEventGetV1RPC(t *testing.T) {
 }
 
 func TestEventReplayUsesEventReplayV1RPCWithSubscribersAndIdempotencyKey(t *testing.T) {
-	t.Setenv("SWARM_API_TOKEN", "test-token")
+	setCLIAPITestToken(t, "test-token")
 	var captured jsonRPCRequest
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/v1/rpc" {
@@ -195,7 +195,7 @@ func TestEventReplayUsesEventReplayV1RPCWithSubscribersAndIdempotencyKey(t *test
 }
 
 func TestEventReplayOmitsOptionalParamsWhenNotProvided(t *testing.T) {
-	t.Setenv("SWARM_API_TOKEN", "test-token")
+	setCLIAPITestToken(t, "test-token")
 	var captured jsonRPCRequest
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
@@ -238,7 +238,7 @@ func TestEventReplayOmitsOptionalParamsWhenNotProvided(t *testing.T) {
 }
 
 func TestEventsFollowUsesEventSubscribeV1WS(t *testing.T) {
-	t.Setenv("SWARM_API_TOKEN", "test-token")
+	setCLIAPITestToken(t, "test-token")
 	server, wsRequests := newEventObservationWSServer(t, eventObservationWSServerOptions{
 		events:         []map[string]any{validEventObservationEvent("event-live-1")},
 		closeAfterRows: true,
@@ -289,7 +289,7 @@ func TestEventsFollowUsesEventSubscribeV1WS(t *testing.T) {
 }
 
 func TestEventsRejectInvalidInputBeforeRequest(t *testing.T) {
-	t.Setenv("SWARM_API_TOKEN", "test-token")
+	setCLIAPITestToken(t, "test-token")
 	var calls atomic.Int32
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		calls.Add(1)
@@ -351,7 +351,7 @@ func TestEventsFailClosedWithoutTokenBeforeRequest(t *testing.T) {
 		if code != 4 {
 			t.Fatalf("args=%v code = %d, want 4 stdout=%s stderr=%s", args, code, stdout.String(), stderr.String())
 		}
-		if !strings.Contains(stderr.String(), "SWARM_API_TOKEN is required") {
+		if !strings.Contains(stderr.String(), "API token source is required") {
 			t.Fatalf("stderr = %q, want token failure", stderr.String())
 		}
 		if calls.Load() != 0 {
@@ -372,7 +372,7 @@ func TestEventsMapFailureExitCodes(t *testing.T) {
 	for _, code := range replayConflictErrors {
 		code := code
 		t.Run("event replay "+code+" exits six", func(t *testing.T) {
-			t.Setenv("SWARM_API_TOKEN", "test-token")
+			setCLIAPITestToken(t, "test-token")
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				var req jsonRPCRequest
 				_ = json.NewDecoder(r.Body).Decode(&req)
@@ -646,7 +646,7 @@ func TestEventsMapFailureExitCodes(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			t.Setenv("SWARM_API_TOKEN", "test-token")
+			setCLIAPITestToken(t, "test-token")
 			server := httptest.NewServer(tc.handler)
 			defer server.Close()
 
@@ -687,7 +687,7 @@ func TestEventsFollowMalformedWSFailsClosed(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			t.Setenv("SWARM_API_TOKEN", "test-token")
+			setCLIAPITestToken(t, "test-token")
 			server, _ := newEventObservationWSServer(t, eventObservationWSServerOptions{
 				subscriptionResult: tc.subscriptionResult,
 				events:             tc.events,
@@ -708,7 +708,7 @@ func TestEventsFollowMalformedWSFailsClosed(t *testing.T) {
 }
 
 func TestEventsFollowMapsHandshakeAuthToAuthExit(t *testing.T) {
-	t.Setenv("SWARM_API_TOKEN", "test-token")
+	setCLIAPITestToken(t, "test-token")
 	var rpcCalls atomic.Int32
 	var wsCalls atomic.Int32
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/cmd/swarm/fork_test.go
+++ b/cmd/swarm/fork_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestForkCommandUsesRunForkRPCAndRenders(t *testing.T) {
-	t.Setenv("SWARM_API_TOKEN", "test-token")
+	setCLIAPITestToken(t, "test-token")
 	sourceRunID := "11111111-1111-1111-1111-111111111111"
 	forkEventID := "22222222-2222-2222-2222-222222222222"
 	bundleHash := validBundleHash("d")
@@ -59,7 +59,7 @@ func TestForkCommandUsesRunForkRPCAndRenders(t *testing.T) {
 }
 
 func TestForkCommandJSONPreservesAPIShape(t *testing.T) {
-	t.Setenv("SWARM_API_TOKEN", "test-token")
+	setCLIAPITestToken(t, "test-token")
 	sourceRunID := "55555555-5555-5555-5555-555555555555"
 	bundleHash := validBundleHash("e")
 	var captured jsonRPCRequest
@@ -92,7 +92,7 @@ func TestForkCommandJSONPreservesAPIShape(t *testing.T) {
 }
 
 func TestForkCommandRejectsInvalidInputBeforeRequest(t *testing.T) {
-	t.Setenv("SWARM_API_TOKEN", "test-token")
+	setCLIAPITestToken(t, "test-token")
 	var calls atomic.Int32
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		calls.Add(1)
@@ -201,7 +201,7 @@ func TestForkCommandFailClosedOnRPCAndMalformedResponses(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			t.Setenv("SWARM_API_TOKEN", "test-token")
+			setCLIAPITestToken(t, "test-token")
 			server := httptest.NewServer(tc.handler)
 			defer server.Close()
 

--- a/cmd/swarm/forkchat_test.go
+++ b/cmd/swarm/forkchat_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestForkChatNewCreatesForkAndOptionalChatViaCanonicalRPC(t *testing.T) {
-	t.Setenv("SWARM_API_TOKEN", "test-token")
+	setCLIAPITestToken(t, "test-token")
 	var requests []jsonRPCRequest
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/v1/rpc" {
@@ -85,7 +85,7 @@ func TestForkChatNewCreatesForkAndOptionalChatViaCanonicalRPC(t *testing.T) {
 }
 
 func TestForkChatNewSelectorMappings(t *testing.T) {
-	t.Setenv("SWARM_API_TOKEN", "test-token")
+	setCLIAPITestToken(t, "test-token")
 	for _, tc := range []struct {
 		name          string
 		args          []string
@@ -129,7 +129,7 @@ func TestForkChatNewSelectorMappings(t *testing.T) {
 }
 
 func TestForkChatResumeJSONUsesConversationForkChat(t *testing.T) {
-	t.Setenv("SWARM_API_TOKEN", "test-token")
+	setCLIAPITestToken(t, "test-token")
 	var captured jsonRPCRequest
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
@@ -166,7 +166,7 @@ func TestForkChatResumeJSONUsesConversationForkChat(t *testing.T) {
 }
 
 func TestForkChatListViewDeleteUseCanonicalMethods(t *testing.T) {
-	t.Setenv("SWARM_API_TOKEN", "test-token")
+	setCLIAPITestToken(t, "test-token")
 	var requests []jsonRPCRequest
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var req jsonRPCRequest
@@ -222,7 +222,7 @@ func TestForkChatListViewDeleteUseCanonicalMethods(t *testing.T) {
 }
 
 func TestForkChatCommandsRejectInvalidInputBeforeRequest(t *testing.T) {
-	t.Setenv("SWARM_API_TOKEN", "test-token")
+	setCLIAPITestToken(t, "test-token")
 	var calls atomic.Int32
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		calls.Add(1)
@@ -266,7 +266,7 @@ func TestForkChatCommandsRejectInvalidInputBeforeRequest(t *testing.T) {
 }
 
 func TestForkChatAPIErrorAndMalformedResultHandling(t *testing.T) {
-	t.Setenv("SWARM_API_TOKEN", "test-token")
+	setCLIAPITestToken(t, "test-token")
 	for _, tc := range []struct {
 		name       string
 		args       []string
@@ -336,7 +336,7 @@ func TestForkChatAPIErrorAndMalformedResultHandling(t *testing.T) {
 }
 
 func TestForkChatRejectsMalformedSnapshotIdentityFields(t *testing.T) {
-	t.Setenv("SWARM_API_TOKEN", "test-token")
+	setCLIAPITestToken(t, "test-token")
 	for _, tc := range []struct {
 		name       string
 		mutate     func(map[string]any)

--- a/cmd/swarm/incidents_test.go
+++ b/cmd/swarm/incidents_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestIncidentsUsesRuntimeIncidentsV1RPCWithFilters(t *testing.T) {
-	t.Setenv("SWARM_API_TOKEN", "test-token")
+	setCLIAPITestToken(t, "test-token")
 	var captured jsonRPCRequest
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/v1/rpc" {
@@ -70,7 +70,7 @@ func TestIncidentsUsesRuntimeIncidentsV1RPCWithFilters(t *testing.T) {
 }
 
 func TestIncidentsOmitOptionalParamsWhenUnset(t *testing.T) {
-	t.Setenv("SWARM_API_TOKEN", "test-token")
+	setCLIAPITestToken(t, "test-token")
 	var captured jsonRPCRequest
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
@@ -97,7 +97,7 @@ func TestIncidentsOmitOptionalParamsWhenUnset(t *testing.T) {
 }
 
 func TestIncidentsRejectInvalidInputBeforeRequest(t *testing.T) {
-	t.Setenv("SWARM_API_TOKEN", "test-token")
+	setCLIAPITestToken(t, "test-token")
 	var calls atomic.Int32
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		calls.Add(1)
@@ -148,7 +148,7 @@ func TestIncidentsFailClosedWithoutTokenBeforeRequest(t *testing.T) {
 	if code != 4 {
 		t.Fatalf("code = %d, want 4 stdout=%s stderr=%s", code, stdout.String(), stderr.String())
 	}
-	if !strings.Contains(stderr.String(), "SWARM_API_TOKEN is required") {
+	if !strings.Contains(stderr.String(), "API token source is required") {
 		t.Fatalf("stderr = %q, want token failure", stderr.String())
 	}
 	if calls.Load() != 0 {
@@ -329,7 +329,7 @@ func TestIncidentsMapRuntimeFailuresAndMalformedResults(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			t.Setenv("SWARM_API_TOKEN", "test-token")
+			setCLIAPITestToken(t, "test-token")
 			server := httptest.NewServer(tc.handler)
 			defer server.Close()
 

--- a/cmd/swarm/logs_test.go
+++ b/cmd/swarm/logs_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func TestLogsUsesRuntimeLogsV1RPCWithSnapshotFilters(t *testing.T) {
-	t.Setenv("SWARM_API_TOKEN", "test-token")
+	setCLIAPITestToken(t, "test-token")
 	var captured jsonRPCRequest
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/v1/rpc" {
@@ -85,7 +85,7 @@ func TestLogsUsesRuntimeLogsV1RPCWithSnapshotFilters(t *testing.T) {
 }
 
 func TestLogsFollowUsesRuntimeSubscribeLogsV1WS(t *testing.T) {
-	t.Setenv("SWARM_API_TOKEN", "test-token")
+	setCLIAPITestToken(t, "test-token")
 	server, wsRequests := newRuntimeLogWSServer(t, runtimeLogWSServerOptions{
 		logs:           []map[string]any{validRuntimeLogEntry("log-live-1")},
 		closeAfterRows: true,
@@ -139,7 +139,7 @@ func TestLogsFollowUsesRuntimeSubscribeLogsV1WS(t *testing.T) {
 }
 
 func TestLogsRejectInvalidInputBeforeRequest(t *testing.T) {
-	t.Setenv("SWARM_API_TOKEN", "test-token")
+	setCLIAPITestToken(t, "test-token")
 	var calls atomic.Int32
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		calls.Add(1)
@@ -199,7 +199,7 @@ func TestLogsFailClosedWithoutTokenBeforeRequest(t *testing.T) {
 		if code != 4 {
 			t.Fatalf("args=%v code = %d, want 4 stdout=%s stderr=%s", args, code, stdout.String(), stderr.String())
 		}
-		if !strings.Contains(stderr.String(), "SWARM_API_TOKEN is required") {
+		if !strings.Contains(stderr.String(), "API token source is required") {
 			t.Fatalf("stderr = %q, want token failure", stderr.String())
 		}
 		if calls.Load() != 0 {
@@ -321,7 +321,7 @@ func TestLogsMapRuntimeFailuresAndMalformedResults(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			t.Setenv("SWARM_API_TOKEN", "test-token")
+			setCLIAPITestToken(t, "test-token")
 			server := httptest.NewServer(tc.handler)
 			defer server.Close()
 
@@ -384,7 +384,7 @@ func TestLogsFollowMalformedWSFailsClosed(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			t.Setenv("SWARM_API_TOKEN", "test-token")
+			setCLIAPITestToken(t, "test-token")
 			server, _ := newRuntimeLogWSServer(t, runtimeLogWSServerOptions{
 				subscriptionResult: tc.subscriptionResult,
 				logs:               tc.logs,
@@ -435,7 +435,7 @@ func TestLogsRenderMissingActionGracefully(t *testing.T) {
 }
 
 func TestLogsFollowMapsHandshakeAuthToAuthExit(t *testing.T) {
-	t.Setenv("SWARM_API_TOKEN", "test-token")
+	setCLIAPITestToken(t, "test-token")
 	var rpcCalls atomic.Int32
 	var wsCalls atomic.Int32
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -470,7 +470,7 @@ func TestLogsFollowMapsHandshakeAuthToAuthExit(t *testing.T) {
 }
 
 func TestLogsFollowCancellationReturnsInterrupted(t *testing.T) {
-	t.Setenv("SWARM_API_TOKEN", "test-token")
+	setCLIAPITestToken(t, "test-token")
 	ctx, cancel := context.WithCancel(context.Background())
 	server, _ := newRuntimeLogWSServer(t, runtimeLogWSServerOptions{
 		afterSubscription: cancel,

--- a/cmd/swarm/main_test.go
+++ b/cmd/swarm/main_test.go
@@ -1170,7 +1170,7 @@ func TestPlatformSpecCLIAPIConnectionAuthConfigPrecedencePromoted(t *testing.T) 
 	for _, stale := range []string{
 		"Runtime-state commands use v1 bearer auth through `SWARM_API_TOKEN`",
 		"SWARM_API_TOKEN is the only user-facing API bearer-token source",
-		"SWARM_API_TOKEN is required.",
+		"API token source is required.",
 	} {
 		if strings.Contains(platformSpecText, stale) {
 			t.Fatalf("platform spec still contains stale SWARM_API_TOKEN-only bearer-token authority %q", stale)
@@ -1188,8 +1188,11 @@ func TestPlatformSpecCLIAPIConnectionAuthConfigPrecedencePromoted(t *testing.T) 
 	if strings.TrimSpace(spec.PromotedBy) != "#844" {
 		t.Fatalf("api connection/auth/config promoted_by = %q, want #844", spec.PromotedBy)
 	}
-	if strings.TrimSpace(spec.ImplementationStatus) != "implemented_loopback_default" {
-		t.Fatalf("api connection/auth/config implementation_status = %q, want implemented_loopback_default", spec.ImplementationStatus)
+	if strings.TrimSpace(spec.ClientEnvRemovedBy) != "#1636" {
+		t.Fatalf("api connection/auth/config client_env_removed_by = %q, want #1636", spec.ClientEnvRemovedBy)
+	}
+	if strings.TrimSpace(spec.ImplementationStatus) != "implemented_loopback_default_no_client_env_sources" {
+		t.Fatalf("api connection/auth/config implementation_status = %q, want implemented_loopback_default_no_client_env_sources", spec.ImplementationStatus)
 	}
 	if !strings.Contains(spec.CanonicalOwner, "cli_specification.foundations.api_connection_auth_config_precedence") {
 		t.Fatalf("canonical owner does not point at promoted section: %s", spec.CanonicalOwner)
@@ -1199,7 +1202,7 @@ func TestPlatformSpecCLIAPIConnectionAuthConfigPrecedencePromoted(t *testing.T) 
 			t.Fatalf("scope missing boundary %q:\n%s", want, spec.Scope)
 		}
 	}
-	wantPrecedence := []string{"flag", "environment", "config_file", "built_in_default"}
+	wantPrecedence := []string{"flag", "context_descriptor", "config_file", "built_in_default"}
 	if len(spec.PrecedenceOrder) != len(wantPrecedence) {
 		t.Fatalf("precedence order = %#v, want %#v", spec.PrecedenceOrder, wantPrecedence)
 	}
@@ -1211,14 +1214,17 @@ func TestPlatformSpecCLIAPIConnectionAuthConfigPrecedencePromoted(t *testing.T) 
 	if spec.APIServer.AcceptedSources.Flag != "--api-server <url>" {
 		t.Fatalf("api_server flag = %q, want --api-server <url>", spec.APIServer.AcceptedSources.Flag)
 	}
-	if spec.APIServer.AcceptedSources.Environment != "SWARM_API_SERVER" {
-		t.Fatalf("api_server environment = %q, want SWARM_API_SERVER", spec.APIServer.AcceptedSources.Environment)
+	if !strings.Contains(spec.APIServer.AcceptedSources.ContextDescriptor, "context descriptor") {
+		t.Fatalf("api_server context_descriptor = %q, want context descriptor source", spec.APIServer.AcceptedSources.ContextDescriptor)
 	}
 	if spec.APIServer.AcceptedSources.ConfigKey != "api_server" {
 		t.Fatalf("api_server config key = %q, want api_server", spec.APIServer.AcceptedSources.ConfigKey)
 	}
 	if spec.APIServer.AcceptedSources.BuiltInDefault != "http://127.0.0.1:8081" {
 		t.Fatalf("api_server default = %q, want http://127.0.0.1:8081", spec.APIServer.AcceptedSources.BuiltInDefault)
+	}
+	if !strings.Contains(spec.APIServer.RejectedSources["SWARM_API_SERVER"], "#1636") {
+		t.Fatalf("api_server SWARM_API_SERVER rejection missing #1636:\n%s", spec.APIServer.RejectedSources["SWARM_API_SERVER"])
 	}
 	for _, want := range []string{"base URL", "`/v1/rpc`", "`/v1/ws`"} {
 		if !strings.Contains(spec.APIServer.ValueModel, want) {
@@ -1230,12 +1236,17 @@ func TestPlatformSpecCLIAPIConnectionAuthConfigPrecedencePromoted(t *testing.T) 
 			t.Fatalf("api_server rationale missing %q:\n%s", want, spec.APIServer.Rationale)
 		}
 	}
-	for _, want := range []string{"flag_file", "environment_token", "environment_file", "config_file_key"} {
+	for _, want := range []string{"flag_file", "context_descriptor", "config_file_key"} {
 		if strings.TrimSpace(spec.APIToken.AcceptedSources[want]) == "" {
 			t.Fatalf("api_token accepted sources missing %q: %#v", want, spec.APIToken.AcceptedSources)
 		}
 	}
-	wantTokenSourceOrder := []string{"--api-token-file", "SWARM_API_TOKEN", "SWARM_API_TOKEN_FILE", "config api_token_file", "built-in loopback default"}
+	for _, removed := range []string{"environment_token", "environment_file"} {
+		if strings.TrimSpace(spec.APIToken.AcceptedSources[removed]) != "" {
+			t.Fatalf("api_token accepted source %q should be removed: %#v", removed, spec.APIToken.AcceptedSources)
+		}
+	}
+	wantTokenSourceOrder := []string{"--api-token-file", "context descriptor auth", "config api_token_file", "built-in loopback default"}
 	if len(spec.APIToken.SourceOrder) != len(wantTokenSourceOrder) {
 		t.Fatalf("api_token source order = %#v, want %#v", spec.APIToken.SourceOrder, wantTokenSourceOrder)
 	}
@@ -1245,8 +1256,10 @@ func TestPlatformSpecCLIAPIConnectionAuthConfigPrecedencePromoted(t *testing.T) 
 		}
 	}
 	for key, want := range map[string]string{
-		"--api-token":      "shell history",
-		"config api_token": "inline",
+		"--api-token":          "shell history",
+		"config api_token":     "inline",
+		"SWARM_API_TOKEN":      "#1636",
+		"SWARM_API_TOKEN_FILE": "config `api_token_file`",
 	} {
 		if !strings.Contains(spec.APIToken.RejectedSources[key], want) {
 			t.Fatalf("api_token rejected source %q missing %q:\n%s", key, want, spec.APIToken.RejectedSources[key])
@@ -1264,6 +1277,14 @@ func TestPlatformSpecCLIAPIConnectionAuthConfigPrecedencePromoted(t *testing.T) 
 		if !stringSliceContains(spec.APIToken.BuiltInLoopbackDefault.RejectedWithoutExplicitToken, want) {
 			t.Fatalf("built-in default rejected hosts missing %q: %#v", want, spec.APIToken.BuiltInLoopbackDefault.RejectedWithoutExplicitToken)
 		}
+	}
+	for _, stale := range []string{"SWARM_API_TOKEN", "SWARM_API_TOKEN_FILE"} {
+		if strings.Contains(spec.APIToken.BuiltInLoopbackDefault.AppliesWhen, stale) {
+			t.Fatalf("built-in default applies_when still names removed client env %q:\n%s", stale, spec.APIToken.BuiltInLoopbackDefault.AppliesWhen)
+		}
+	}
+	if !strings.Contains(spec.APIToken.BuiltInLoopbackDefault.AppliesWhen, "numeric loopback") {
+		t.Fatalf("built-in default applies_when missing loopback boundary:\n%s", spec.APIToken.BuiltInLoopbackDefault.AppliesWhen)
 	}
 	for _, want := range []string{"no-auth", "Authorization: Bearer"} {
 		if !strings.Contains(spec.APIToken.BuiltInLoopbackDefault.NoAuthBypassRule, want) {
@@ -1311,13 +1332,13 @@ func TestPlatformSpecCLIAPIConnectionAuthConfigPrecedencePromoted(t *testing.T) 
 			t.Fatalf("serve listener accepted env %q missing listener owner:\n%s", key, spec.ServeListenerEnvConfigBoundary.AcceptedListenerEnvironment[key])
 		}
 	}
-	for _, want := range []string{"#848", "#884/#750", "#743", "`--no-retry`"} {
+	for _, want := range []string{"#848", "#884/#750", "#743", "#1636", "#1647", "`--no-retry`"} {
 		if !stringSliceContains(spec.SplitSiblings, want) {
 			t.Fatalf("split siblings missing %q: %#v", want, spec.SplitSiblings)
 		}
 	}
-	for _, want := range []string{"API-backed command leaves consume", "OpenRPC", "Future API-backed CLI commands MUST consume this owner"} {
-		if !stringSliceContains(spec.ImplementationBoundaries, want) {
+	for _, want := range []string{"API-backed command leaves consume", "SWARM_API_SERVER", "#1647", "OpenRPC"} {
+		if !strings.Contains(strings.Join(spec.ImplementationBoundaries, "\n"), want) {
 			t.Fatalf("implementation boundaries missing %q: %#v", want, spec.ImplementationBoundaries)
 		}
 	}
@@ -3493,7 +3514,6 @@ func TestRunServeRuntimeDBLoadedRunForkCrossBundleTargetExecutesAndStampsTargetI
 	_, db, pg := installServeRuntimePostgresTestStores(t, func() serveWorkspaceLifecycle {
 		return serveRuntimeWorkspaceStub{}
 	})
-	t.Setenv("SWARM_API_TOKEN", "test-token")
 	ctx := context.Background()
 	sourceBundle := loadWorkflowValidationFixtureBundle(t, filepath.Join("tests", "tier8-boot-verification", "test-boot-success"))
 	sourceProjection, err := runtimecontracts.BuildBundleCatalogProjection(sourceBundle)
@@ -4427,7 +4447,6 @@ func servedEventPublishProofOutboxSweeperConfig() runtimebus.OutboxSweeperConfig
 
 func startServedEventPublishFollowUpRuntime(t *testing.T, opts serveOptions) (string, *runtimepkg.Runtime) {
 	t.Helper()
-	t.Setenv("SWARM_API_TOKEN", "test-token")
 	serveCtx, cancelServe := context.WithCancel(context.Background())
 	var out lockedBuffer
 	done := make(chan int, 1)
@@ -5021,7 +5040,7 @@ func requestServedJSONRPC(t *testing.T, endpoint, method string, params map[stri
 		t.Fatalf("build %s request: %v", method, err)
 	}
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Authorization", "Bearer test-token")
+	req.Header.Set("Authorization", "Bearer "+apiv1.DefaultLoopbackAPIToken)
 	resp, err := (&http.Client{Timeout: 5 * time.Second}).Do(req)
 	if err != nil {
 		t.Fatalf("post %s request: %v", method, err)
@@ -11341,6 +11360,7 @@ type serveListenerTopologySpec struct {
 
 type cliAPIConnectionAuthConfigSpec struct {
 	PromotedBy           string   `yaml:"promoted_by"`
+	ClientEnvRemovedBy   string   `yaml:"client_env_removed_by"`
 	ImplementationStatus string   `yaml:"implementation_status"`
 	CanonicalOwner       string   `yaml:"canonical_owner"`
 	Scope                string   `yaml:"scope"`
@@ -11349,13 +11369,14 @@ type cliAPIConnectionAuthConfigSpec struct {
 	PrecedenceOrder      []string `yaml:"precedence_order"`
 	APIServer            struct {
 		AcceptedSources struct {
-			Flag           string `yaml:"flag"`
-			Environment    string `yaml:"environment"`
-			ConfigKey      string `yaml:"config_key"`
-			BuiltInDefault string `yaml:"built_in_default"`
+			Flag              string `yaml:"flag"`
+			ContextDescriptor string `yaml:"context_descriptor"`
+			ConfigKey         string `yaml:"config_key"`
+			BuiltInDefault    string `yaml:"built_in_default"`
 		} `yaml:"accepted_sources"`
-		ValueModel string `yaml:"value_model"`
-		Rationale  string `yaml:"rationale"`
+		RejectedSources map[string]string `yaml:"rejected_sources"`
+		ValueModel      string            `yaml:"value_model"`
+		Rationale       string            `yaml:"rationale"`
 	} `yaml:"api_server"`
 	APIToken struct {
 		AcceptedSources        map[string]string `yaml:"accepted_sources"`

--- a/cmd/swarm/run_command_test.go
+++ b/cmd/swarm/run_command_test.go
@@ -101,13 +101,13 @@ func TestRunCommandLocalForegroundConsumesServeOwnerAndV1API(t *testing.T) {
 
 func TestStartLocalRunServeConsumesContractPathConfigResolver(t *testing.T) {
 	isolateCLIAPIConfigEnv(t)
-	t.Setenv("SWARM_API_TOKEN", "test-token")
 	repo := t.TempDir()
 	configContracts := filepath.Join(t.TempDir(), "config-contracts")
 	configPlatform := filepath.Join(t.TempDir(), "config-platform.yaml")
 	t.Setenv("SWARM_CONFIG", writeCLIAPIConfigFile(t, map[string]string{
 		"contracts_path":     configContracts,
 		"platform_spec_path": configPlatform,
+		"api_token_file":     writeCLIAPITokenFile(t, "test-token"),
 	}))
 	server, _, _ := newRunCommandServer(t, runCommandServerOptions{
 		rpcResponder: func(req jsonRPCRequest, _ int) map[string]any {
@@ -170,7 +170,7 @@ func TestRunCommandHelpShowsDataFlag(t *testing.T) {
 }
 
 func TestRunCommandConnectedNoFollowUsesHealthAndRunStartOnly(t *testing.T) {
-	t.Setenv("SWARM_API_TOKEN", "test-token")
+	setCLIAPITestToken(t, "test-token")
 	payloadPath := writeRunCommandPayloadFile(t, map[string]any{"ok": true})
 	server, calls, wsRequests := newRunCommandServer(t, runCommandServerOptions{
 		rpcResponder: func(req jsonRPCRequest, _ int) map[string]any {
@@ -207,7 +207,7 @@ func TestRunCommandConnectedNoFollowUsesHealthAndRunStartOnly(t *testing.T) {
 }
 
 func TestRunCommandStartIncludesOptionalRunIDAndIdempotencyKey(t *testing.T) {
-	t.Setenv("SWARM_API_TOKEN", "test-token")
+	setCLIAPITestToken(t, "test-token")
 	payloadPath := writeRunCommandPayloadFile(t, map[string]any{"ok": true})
 	server, calls, _ := newRunCommandServer(t, runCommandServerOptions{
 		rpcResponder: func(req jsonRPCRequest, _ int) map[string]any {
@@ -239,7 +239,7 @@ func TestRunCommandStartIncludesOptionalRunIDAndIdempotencyKey(t *testing.T) {
 }
 
 func TestRunCommandBundleFingerprintMismatchFailsBeforeRunStart(t *testing.T) {
-	t.Setenv("SWARM_API_TOKEN", "test-token")
+	setCLIAPITestToken(t, "test-token")
 	payloadPath := writeRunCommandPayloadFile(t, map[string]any{"ok": true})
 	server, calls, _ := newRunCommandServer(t, runCommandServerOptions{
 		rpcResponder: func(req jsonRPCRequest, _ int) map[string]any {
@@ -263,7 +263,7 @@ func TestRunCommandBundleFingerprintMismatchFailsBeforeRunStart(t *testing.T) {
 }
 
 func TestRunCommandBundleHashSerializesCanonicalParamAndMapsUnsupported(t *testing.T) {
-	t.Setenv("SWARM_API_TOKEN", "test-token")
+	setCLIAPITestToken(t, "test-token")
 	payloadPath := writeRunCommandPayloadFile(t, map[string]any{"ok": true})
 	var calls []jsonRPCRequest
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -304,7 +304,7 @@ func TestRunCommandBundleHashSerializesCanonicalParamAndMapsUnsupported(t *testi
 }
 
 func TestRunCommandStartApplicationErrorsExitSixAndDoNotFollow(t *testing.T) {
-	t.Setenv("SWARM_API_TOKEN", "test-token")
+	setCLIAPITestToken(t, "test-token")
 	payloadPath := writeRunCommandPayloadFile(t, map[string]any{"ok": true})
 	for _, codeName := range []string{"BUNDLE_SCOPE_REQUIRED", "BUNDLE_UNAVAILABLE", "BUNDLE_DATA_INTEGRITY_ERROR", "BUNDLE_MISMATCH", "EVENT_NOT_DECLARED", "PAYLOAD_VALIDATION_FAILED", "EVENT_PUBLISH_FAILED"} {
 		t.Run(codeName, func(t *testing.T) {
@@ -350,7 +350,7 @@ func TestRunCommandStartApplicationErrorsExitSixAndDoNotFollow(t *testing.T) {
 }
 
 func TestRunCommandBundleFingerprintSerializesLegacyBundleRef(t *testing.T) {
-	t.Setenv("SWARM_API_TOKEN", "test-token")
+	setCLIAPITestToken(t, "test-token")
 	payloadPath := writeRunCommandPayloadFile(t, map[string]any{"ok": true})
 	server, calls, _ := newRunCommandServer(t, runCommandServerOptions{
 		rpcResponder: func(req jsonRPCRequest, _ int) map[string]any {
@@ -382,7 +382,7 @@ func TestRunCommandBundleFingerprintSerializesLegacyBundleRef(t *testing.T) {
 }
 
 func TestRunCommandConnectedForegroundFollowsTraceAndExitsOnTerminalRunGet(t *testing.T) {
-	t.Setenv("SWARM_API_TOKEN", "test-token")
+	setCLIAPITestToken(t, "test-token")
 	payloadPath := writeRunCommandPayloadFile(t, map[string]any{"ok": true})
 	server, calls, wsRequests := newRunCommandServer(t, runCommandServerOptions{
 		rpcResponder: func(req jsonRPCRequest, _ int) map[string]any {
@@ -420,7 +420,7 @@ func TestRunCommandConnectedForegroundFollowsTraceAndExitsOnTerminalRunGet(t *te
 }
 
 func TestRunCommandReattachTerminalUsesRunGetWithoutWebSocket(t *testing.T) {
-	t.Setenv("SWARM_API_TOKEN", "test-token")
+	setCLIAPITestToken(t, "test-token")
 	server, calls, wsRequests := newRunCommandServer(t, runCommandServerOptions{
 		rpcResponder: func(req jsonRPCRequest, _ int) map[string]any {
 			if req.Method != "run.get" {
@@ -450,7 +450,7 @@ func TestRunCommandReattachTerminalUsesRunGetWithoutWebSocket(t *testing.T) {
 }
 
 func TestRunCommandReattachActiveCtrlCDetachesWithoutRunStop(t *testing.T) {
-	t.Setenv("SWARM_API_TOKEN", "test-token")
+	setCLIAPITestToken(t, "test-token")
 	wsSubscribed := make(chan struct{})
 	server, calls, wsRequests := newRunCommandServer(t, runCommandServerOptions{
 		rpcResponder: func(req jsonRPCRequest, _ int) map[string]any {
@@ -486,7 +486,7 @@ func TestRunCommandReattachActiveCtrlCDetachesWithoutRunStop(t *testing.T) {
 }
 
 func TestRunCommandStartCtrlCCallsRunStopAfterRunID(t *testing.T) {
-	t.Setenv("SWARM_API_TOKEN", "test-token")
+	setCLIAPITestToken(t, "test-token")
 	payloadPath := writeRunCommandPayloadFile(t, map[string]any{"ok": true})
 	wsSubscribed := make(chan struct{})
 	server, calls, _ := newRunCommandServer(t, runCommandServerOptions{
@@ -529,7 +529,7 @@ func TestRunCommandStartCtrlCCallsRunStopAfterRunID(t *testing.T) {
 }
 
 func TestRunCommandLocalReadinessAuthFailureFailsFast(t *testing.T) {
-	t.Setenv("SWARM_API_TOKEN", "bad-token")
+	setCLIAPITestToken(t, "bad-token")
 	payloadPath := writeRunCommandPayloadFile(t, map[string]any{"ok": true})
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusUnauthorized)
@@ -561,7 +561,7 @@ func TestRunCommandLocalReadinessAuthFailureFailsFast(t *testing.T) {
 }
 
 func TestRunCommandClosedTraceChannelStillWaitsForRunGet(t *testing.T) {
-	t.Setenv("SWARM_API_TOKEN", "test-token")
+	setCLIAPITestToken(t, "test-token")
 	payloadPath := writeRunCommandPayloadFile(t, map[string]any{"ok": true})
 	var runGetCalls atomic.Int32
 	server, calls, _ := newRunCommandServer(t, runCommandServerOptions{
@@ -602,7 +602,7 @@ func TestRunCommandClosedTraceChannelStillWaitsForRunGet(t *testing.T) {
 }
 
 func TestRunCommandMalformedWebSocketFailuresExitThree(t *testing.T) {
-	t.Setenv("SWARM_API_TOKEN", "test-token")
+	setCLIAPITestToken(t, "test-token")
 	payloadPath := writeRunCommandPayloadFile(t, map[string]any{"ok": true})
 	for _, tc := range []struct {
 		name       string
@@ -692,13 +692,13 @@ func TestRunCommandValidationAndAuthNoCallPaths(t *testing.T) {
 		{name: "connect rejects api port local flag", token: "test-token", args: []string{"run", "--connect", "http://127.0.0.1:1", "--event", "scan.requested", "--payload", payloadPath, "--api-port", "8081"}, wantCode: 2, wantStderr: "--api-port requires local foreground mode"},
 		{name: "connect rejects legacy path", token: "test-token", args: []string{"run", "--connect", "http://127.0.0.1:1/api/rpc", "--event", "scan.requested", "--payload", payloadPath}, wantCode: 2, wantStderr: "--connect path must be empty or /v1/rpc"},
 		{name: "connect rejects unsupported scheme", token: "test-token", args: []string{"run", "--connect", "ftp://127.0.0.1:1", "--event", "scan.requested", "--payload", payloadPath}, wantCode: 2, wantStderr: "--connect must use http or https"},
-		{name: "missing explicit token for non-loopback exits four", args: []string{"run", "--connect", "http://192.0.2.10:1", "--event", "scan.requested", "--payload", payloadPath}, wantCode: 4, wantStderr: "SWARM_API_TOKEN is required"},
+		{name: "missing explicit token for non-loopback exits four", args: []string{"run", "--connect", "http://192.0.2.10:1", "--event", "scan.requested", "--payload", payloadPath}, wantCode: 4, wantStderr: "API token source is required"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			if tc.token == "" {
-				_ = os.Unsetenv("SWARM_API_TOKEN")
+				setCLIAPITestToken(t, "")
 			} else {
-				t.Setenv("SWARM_API_TOKEN", tc.token)
+				setCLIAPITestToken(t, tc.token)
 			}
 			var stdout, stderr bytes.Buffer
 			code := executeRootCommandWithOptions(context.Background(), t.TempDir(), tc.args, &stdout, &stderr, testRunCommandOptions(nil))
@@ -746,7 +746,7 @@ func TestRunCommandMapsRPCAndMalformedFailures(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			t.Setenv("SWARM_API_TOKEN", "test-token")
+			setCLIAPITestToken(t, "test-token")
 			server := httptest.NewServer(tc.handler)
 			defer server.Close()
 

--- a/cmd/swarm/target_resolution.go
+++ b/cmd/swarm/target_resolution.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/division-sh/swarm/internal/apiv1"
 	"github.com/division-sh/swarm/internal/config"
 	storebackend "github.com/division-sh/swarm/internal/store/backendselection"
 	"github.com/spf13/cobra"
@@ -167,7 +168,7 @@ func runDoctorTargetCommand(repo string, cmd *cobra.Command, opts doctorOptions)
 }
 
 func buildDoctorTargetReport(ctx context.Context, repo string, opts doctorOptions, cfg cliAPIConfigFile, swarmDir cliSwarmDirResolution, runtimeCfg *config.Config) (doctorTargetReport, error) {
-	api, err := resolveDoctorTargetAPI(opts, cfg)
+	api, err := resolveDoctorTargetAPI(repo, opts, cfg)
 	if err != nil {
 		return doctorTargetReport{}, err
 	}
@@ -272,65 +273,76 @@ func rootSwarmDirFlag(cmd *cobra.Command) (string, bool) {
 	return flag.Value.String(), flag.Changed
 }
 
-func resolveDoctorTargetAPI(opts doctorOptions, cfg cliAPIConfigFile) (doctorTargetAPI, error) {
-	server, source := firstDoctorTargetAPIServer(opts, cfg)
-	base, err := normalizeCLIAPIServerBase(server, source)
+func resolveDoctorTargetAPI(repo string, opts doctorOptions, cfg cliAPIConfigFile) (doctorTargetAPI, error) {
+	if err := rejectRemovedClientAPIEnvSources(); err != nil {
+		return doctorTargetAPI{}, err
+	}
+	target, err := resolveCLIAPITarget(rootCommandOptions{
+		apiServer:       opts.apiOptions.apiServer,
+		apiTokenFile:    opts.apiOptions.apiTokenFile,
+		contextName:     opts.apiOptions.contextName,
+		swarmDir:        opts.apiOptions.swarmDir,
+		rootFlags:       opts.apiOptions.rootFlags,
+		repoRoot:        repo,
+		apiCommandClass: cliAPICommandClassTargetDiagnostic,
+	}, cfg)
 	if err != nil {
 		return doctorTargetAPI{}, err
 	}
-	rpcEndpoint, err := cliAPIRPCEndpointFromServer(base.String(), source)
+	token, err := resolveCLIAPITokenForTarget(rootCommandOptions{
+		apiTokenFile: opts.apiOptions.apiTokenFile,
+	}, cfg, target)
+	if err != nil {
+		return doctorTargetAPI{}, err
+	}
+	server, err := cliAPIServerBaseFromRPCEndpoint(target.rpcEndpoint, target.source)
 	if err != nil {
 		return doctorTargetAPI{}, err
 	}
 	return doctorTargetAPI{
-		Server:      base.String(),
-		RPCEndpoint: rpcEndpoint,
-		Source:      source,
-		Auth:        resolveDoctorTargetAuth(opts, cfg, rpcEndpoint),
-		Reason:      doctorTargetAPIReason(source),
+		Server:      server,
+		RPCEndpoint: target.rpcEndpoint,
+		Source:      target.source,
+		Auth:        doctorTargetAuthFromTokenResolution(token),
+		Reason:      doctorTargetAPIReason(target.source),
 	}, nil
 }
 
-func firstDoctorTargetAPIServer(opts doctorOptions, cfg cliAPIConfigFile) (string, string) {
-	if server := strings.TrimSpace(opts.apiOptions.apiServer); server != "" {
-		return server, "--api-server"
+func cliAPIServerBaseFromRPCEndpoint(rpcEndpoint, source string) (string, error) {
+	parsed, err := normalizeCLIAPIRPCEndpoint(rpcEndpoint, source)
+	if err != nil {
+		return "", err
 	}
-	if server := strings.TrimSpace(os.Getenv("SWARM_API_SERVER")); server != "" {
-		return server, "SWARM_API_SERVER"
+	idx := strings.LastIndex(parsed, cliAPIRPCPath)
+	if idx < 0 {
+		return "", &cliAPIValidationError{message: fmt.Sprintf("%s must end with %s", source, cliAPIRPCPath)}
 	}
-	if server := strings.TrimSpace(cfg.APIServer); server != "" {
-		return server, "config api_server"
-	}
-	return defaultCLIAPIServer, "built-in loopback default"
+	return parsed[:idx], nil
 }
 
-func resolveDoctorTargetAuth(opts doctorOptions, cfg cliAPIConfigFile, rpcEndpoint string) doctorTargetAuth {
-	if tokenFile := strings.TrimSpace(opts.apiOptions.apiTokenFile); tokenFile != "" {
-		return doctorTargetAuth{Source: "--api-token-file", Status: "configured", Detail: tokenFile}
+func doctorTargetAuthFromTokenResolution(token cliAPITokenResolution) doctorTargetAuth {
+	switch token.source {
+	case "--api-token-file", "config api_token_file":
+		return doctorTargetAuth{Source: token.source, Status: "configured", Detail: "token file"}
+	case string(apiv1.AuthTokenSourceBuiltInLoopbackToken):
+		return doctorTargetAuth{Source: token.source, Status: "available", Detail: "numeric loopback target"}
+	default:
+		return doctorTargetAuth{Source: token.source, Status: "configured", Detail: "context/runtime auth"}
 	}
-	if strings.TrimSpace(os.Getenv("SWARM_API_TOKEN")) != "" {
-		return doctorTargetAuth{Source: "SWARM_API_TOKEN", Status: "configured", Detail: "value redacted"}
-	}
-	if tokenFile := strings.TrimSpace(os.Getenv("SWARM_API_TOKEN_FILE")); tokenFile != "" {
-		return doctorTargetAuth{Source: "SWARM_API_TOKEN_FILE", Status: "configured", Detail: tokenFile}
-	}
-	if tokenFile := strings.TrimSpace(cfg.APITokenFile); tokenFile != "" {
-		return doctorTargetAuth{Source: "config api_token_file", Status: "configured", Detail: tokenFile}
-	}
-	if cliAPIRPCEndpointAllowsDefaultToken(rpcEndpoint) {
-		return doctorTargetAuth{Source: "built-in loopback default", Status: "available", Detail: "numeric loopback target"}
-	}
-	return doctorTargetAuth{Source: "none", Status: "missing_explicit_token", Detail: "non-loopback targets require --api-token-file, SWARM_API_TOKEN, SWARM_API_TOKEN_FILE, or config api_token_file"}
 }
 
 func doctorTargetAPIReason(source string) string {
 	switch source {
 	case "--api-server":
 		return "explicit API server flag wins target precedence for this diagnostic"
-	case "SWARM_API_SERVER":
-		return "existing explicit API environment source wins after flags"
+	case "--context":
+		return "explicit context flag wins target precedence after explicit API server"
+	case "project context":
+		return "live project-scoped context wins before selected context and config"
+	case "selected context":
+		return "selected context wins before typed config when no live project context is selected"
 	case "config api_server":
-		return "existing bootstrap config API source wins after flags and environment"
+		return "typed config API source wins after explicit target and context resolution"
 	default:
 		return "when no explicit API source is configured, API-backed commands resolve project context, selected context, or built-in loopback according to command class"
 	}

--- a/cmd/swarm/target_resolution.go
+++ b/cmd/swarm/target_resolution.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -168,7 +169,7 @@ func runDoctorTargetCommand(repo string, cmd *cobra.Command, opts doctorOptions)
 }
 
 func buildDoctorTargetReport(ctx context.Context, repo string, opts doctorOptions, cfg cliAPIConfigFile, swarmDir cliSwarmDirResolution, runtimeCfg *config.Config) (doctorTargetReport, error) {
-	api, err := resolveDoctorTargetAPI(repo, opts, cfg)
+	api, err := resolveDoctorTargetAPI(repo, opts, cfg, swarmDir)
 	if err != nil {
 		return doctorTargetReport{}, err
 	}
@@ -273,25 +274,20 @@ func rootSwarmDirFlag(cmd *cobra.Command) (string, bool) {
 	return flag.Value.String(), flag.Changed
 }
 
-func resolveDoctorTargetAPI(repo string, opts doctorOptions, cfg cliAPIConfigFile) (doctorTargetAPI, error) {
+func resolveDoctorTargetAPI(repo string, opts doctorOptions, cfg cliAPIConfigFile, swarmDir cliSwarmDirResolution) (doctorTargetAPI, error) {
 	if err := rejectRemovedClientAPIEnvSources(); err != nil {
 		return doctorTargetAPI{}, err
 	}
-	target, err := resolveCLIAPITarget(rootCommandOptions{
+	targetOpts := rootCommandOptions{
 		apiServer:       opts.apiOptions.apiServer,
 		apiTokenFile:    opts.apiOptions.apiTokenFile,
 		contextName:     opts.apiOptions.contextName,
-		swarmDir:        opts.apiOptions.swarmDir,
-		rootFlags:       opts.apiOptions.rootFlags,
+		swarmDir:        swarmDir.Path,
+		rootFlags:       &rootCommandFlagState{swarmDir: swarmDir.Path, swarmDirSet: true},
 		repoRoot:        repo,
 		apiCommandClass: cliAPICommandClassTargetDiagnostic,
-	}, cfg)
-	if err != nil {
-		return doctorTargetAPI{}, err
 	}
-	token, err := resolveCLIAPITokenForTarget(rootCommandOptions{
-		apiTokenFile: opts.apiOptions.apiTokenFile,
-	}, cfg, target)
+	target, err := resolveCLIAPITarget(targetOpts, cfg)
 	if err != nil {
 		return doctorTargetAPI{}, err
 	}
@@ -299,11 +295,23 @@ func resolveDoctorTargetAPI(repo string, opts doctorOptions, cfg cliAPIConfigFil
 	if err != nil {
 		return doctorTargetAPI{}, err
 	}
+	token, err := resolveCLIAPITokenForTarget(rootCommandOptions{
+		apiTokenFile: opts.apiOptions.apiTokenFile,
+	}, cfg, target)
+	auth := doctorTargetAuth{}
+	if err != nil {
+		if !errors.Is(err, errCLIAPITokenRequired) {
+			return doctorTargetAPI{}, err
+		}
+		auth = doctorTargetMissingExplicitTokenAuth()
+	} else {
+		auth = doctorTargetAuthFromTokenResolution(token)
+	}
 	return doctorTargetAPI{
 		Server:      server,
 		RPCEndpoint: target.rpcEndpoint,
 		Source:      target.source,
-		Auth:        doctorTargetAuthFromTokenResolution(token),
+		Auth:        auth,
 		Reason:      doctorTargetAPIReason(target.source),
 	}, nil
 }
@@ -328,6 +336,14 @@ func doctorTargetAuthFromTokenResolution(token cliAPITokenResolution) doctorTarg
 		return doctorTargetAuth{Source: token.source, Status: "available", Detail: "numeric loopback target"}
 	default:
 		return doctorTargetAuth{Source: token.source, Status: "configured", Detail: "context/runtime auth"}
+	}
+}
+
+func doctorTargetMissingExplicitTokenAuth() doctorTargetAuth {
+	return doctorTargetAuth{
+		Source: "none",
+		Status: "missing_explicit_token",
+		Detail: "non-loopback target requires --api-token-file, context descriptor auth, or config api_token_file",
 	}
 }
 

--- a/cmd/swarm/version_command_test.go
+++ b/cmd/swarm/version_command_test.go
@@ -43,7 +43,7 @@ func TestVersionLocalDoesNotRequireTokenOrRequest(t *testing.T) {
 }
 
 func TestVersionServerUsesHealthCheck(t *testing.T) {
-	t.Setenv("SWARM_API_TOKEN", "test-token")
+	setCLIAPITestToken(t, "test-token")
 	var captured jsonRPCRequest
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {
@@ -94,7 +94,7 @@ func TestVersionServerUsesHealthCheck(t *testing.T) {
 }
 
 func TestVersionServerRejectsInvalidInputBeforeRequest(t *testing.T) {
-	t.Setenv("SWARM_API_TOKEN", "test-token")
+	setCLIAPITestToken(t, "test-token")
 	var calls atomic.Int32
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		calls.Add(1)
@@ -145,7 +145,7 @@ func TestVersionServerRequiresTokenBeforeRequest(t *testing.T) {
 	if code != 4 {
 		t.Fatalf("code = %d, want 4 stdout=%s stderr=%s", code, stdout.String(), stderr.String())
 	}
-	if !strings.Contains(stderr.String(), "SWARM_API_TOKEN is required") {
+	if !strings.Contains(stderr.String(), "API token source is required") {
 		t.Fatalf("stderr = %q, want missing-token message", stderr.String())
 	}
 	if strings.TrimSpace(stdout.String()) != "" {
@@ -220,7 +220,7 @@ func TestVersionServerFailsClosedOnAPIAndMalformedResults(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			t.Setenv("SWARM_API_TOKEN", "test-token")
+			setCLIAPITestToken(t, "test-token")
 			server := httptest.NewServer(tc.handler)
 			defer server.Close()
 
@@ -240,7 +240,7 @@ func TestVersionServerFailsClosedOnAPIAndMalformedResults(t *testing.T) {
 }
 
 func TestVersionServerFailsClosedOnTransportError(t *testing.T) {
-	t.Setenv("SWARM_API_TOKEN", "test-token")
+	setCLIAPITestToken(t, "test-token")
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		t.Errorf("unexpected request to closed server")
 	}))

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -11841,16 +11841,16 @@ cli_specification:
         source_order:
         - explicit_api_flags
         - explicit_context_flag
-        - existing_api_environment
-        - existing_api_config
         - live_project_scoped_context
         - known_dead_or_stale_project_context_fail_closed
         - selected_or_default_global_context
+        - existing_api_config
         - built_in_loopback_default
         current_behavior: >
-          `swarm doctor --target` explains explicit API flag, environment, config, project-root, Swarm-dir, current
+          `swarm doctor --target` explains explicit API flag, config, project-root, Swarm-dir, current
           rollout store/data, and local context registry/identity facts. API-backed commands consume the same target
-          order through the shared CLI API resolver after #1614. Unavailable facts MUST be reported as unavailable
+          order through the shared CLI API resolver after #1614 and #1636. Client-side `SWARM_API_SERVER`,
+          `SWARM_API_TOKEN`, and `SWARM_API_TOKEN_FILE` are not target/auth sources. Unavailable facts MUST be reported as unavailable
           rather than inferred from PID, port, URL, or health bundle fingerprint. A project context may be selected
           implicitly only when exactly one descriptor exists for the canonical project root and that descriptor validates
           `ok`; mixed live/stale or otherwise non-ok project descriptors fail closed.
@@ -12143,13 +12143,16 @@ cli_specification:
     api_connection_auth_config_precedence:
       promoted_by: '#844'
       loopback_default_implemented_by: '#1124'
-      implementation_status: implemented_loopback_default
+      client_env_removed_by: '#1636'
+      implementation_status: implemented_loopback_default_no_client_env_sources
       canonical_owner: platform-spec.yaml#cli_specification.foundations.api_connection_auth_config_precedence
       scope: >
         Merge-bearing authority for CLI API base URL selection, bearer-token selection, and CLI config-file
         discovery for API-backed commands. API-backed command leaves consume `--api-server`, `--api-token-file`,
-        `SWARM_API_SERVER`, `SWARM_API_TOKEN`, `SWARM_API_TOKEN_FILE`, `SWARM_CONFIG`, XDG config, and built-in
-        defaults through one shared resolver. When no explicit token source is configured, the shared resolver may
+        project/selected context descriptors, `SWARM_CONFIG`, XDG config, typed config, and built-in defaults
+        through one shared resolver. `SWARM_API_SERVER`, `SWARM_API_TOKEN`, and `SWARM_API_TOKEN_FILE` are removed as
+        client-side API target/auth sources and fail closed with replacement guidance when present. When no explicit
+        token source is configured, the shared resolver may
         use the fixed built-in dev API token only for numeric loopback API targets. This contract does not add OpenRPC behavior, retry behavior,
         output rendering, root/global `--config`, inline token flags, or serve listener binding.
       applies_to:
@@ -12163,15 +12166,19 @@ cli_specification:
       - Output mode, logging verbosity, retry, and color.
       precedence_order:
       - flag
-      - environment
+      - context_descriptor
       - config_file
       - built_in_default
       api_server:
         accepted_sources:
           flag: --api-server <url>
-          environment: SWARM_API_SERVER
+          context_descriptor: project/selected context descriptor api_server
           config_key: api_server
           built_in_default: http://127.0.0.1:8081
+        rejected_sources:
+          SWARM_API_SERVER: >
+            Removed by #1636. Client-side API target env is hidden mutable source authority; use `--api-server`,
+            `--context`, a project/selected context, or config `api_server`.
         value_model: >
           The configured value is an API server base URL, not a direct `/v1/rpc` endpoint. It MUST include an
           `http` or `https` scheme and host, MUST NOT include query or fragment components, and SHOULD use an
@@ -12184,20 +12191,24 @@ cli_specification:
       api_token:
         accepted_sources:
           flag_file: --api-token-file <path>
-          environment_token: SWARM_API_TOKEN
-          environment_file: SWARM_API_TOKEN_FILE
+          context_descriptor: project/selected context descriptor auth
           config_file_key: api_token_file
         source_order:
         - --api-token-file
-        - SWARM_API_TOKEN
-        - SWARM_API_TOKEN_FILE
+        - context descriptor auth
         - config api_token_file
         - built-in loopback default
         rejected_sources:
+          SWARM_API_TOKEN: >
+            Removed as a client-side API token source by #1636. Use `--api-token-file`, context descriptor auth, or
+            config `api_token_file`. Server-side `swarm serve` API auth source ownership is a separate seam tracked by
+            #1647.
+          SWARM_API_TOKEN_FILE: >
+            Removed as a client-side API token-file source by #1636. Use `--api-token-file`, context descriptor auth,
+            or config `api_token_file`.
           --api-token: >
             Not promoted. Inline token flags leak secrets into shell history and process listings; operators
-            must use `SWARM_API_TOKEN` for ephemeral credentials or token-file sources for file-backed
-            credentials.
+            must use token-file, context descriptor, or future secure-source owners for file-backed credentials.
           config api_token: >
             Not promoted. The config file may point at a token file but MUST NOT store the bearer token inline.
         token_file_rule: >
@@ -12208,8 +12219,8 @@ cli_specification:
           token_value: swarm-dev-loopback-api-token
           source: built-in-loopback-default
           applies_when: >
-            Applies only after `--api-token-file`, `SWARM_API_TOKEN`, `SWARM_API_TOKEN_FILE`, and config
-            `api_token_file` are all absent, and only when the API target host is numeric loopback.
+            Applies only after `--api-token-file`, context descriptor auth, and config `api_token_file` are all
+            absent, and only when the API target host is numeric loopback.
           allowed_target_hosts:
           - 127.0.0.0/8
           - ::1
@@ -12282,11 +12293,15 @@ cli_specification:
       - '#848 output modes/shared renderer; spec promoted, implementation pending'
       - '#846 error-channel and exit-code classification; closed first slice'
       - '#844 later behavior child for API config/auth resolver implementation'
+      - '#1636 client-side API target/auth env removal'
+      - '#1647 server-side swarm serve API token secure-source ownership'
       - '#884/#750 serve listener enable-disable controls and runtime topology siblings'
       - '#743 swarm run behavior and follow semantics'
       - '`--no-retry` retry policy'
       implementation_boundaries:
       - 'API-backed command leaves consume one cmd/swarm resolver for this owner.'
+      - 'Client-side `SWARM_API_SERVER`, `SWARM_API_TOKEN`, and `SWARM_API_TOKEN_FILE` are invalid sources after #1636.'
+      - 'Server-side `swarm serve` API auth token sourcing remains split to #1647.'
       - 'No root/global --config, inline --api-token, OpenRPC, output renderer, retry, or listener behavior changes are implied by this owner.'
       - 'Future API-backed CLI commands MUST consume this owner rather than the ignored review artifact.'
     contract_platform_spec_path_resolution:
@@ -12733,7 +12748,7 @@ cli_specification:
           - '`swarm serve` MCP listener bind address.'
           not_applies_to:
           - '`swarm run` local foreground listener startup.'
-          - API client connection/auth configuration such as `--api-server`, `SWARM_API_SERVER`, and `api_server`.
+          - API client connection/auth configuration such as `--api-server`, context descriptors, and `api_server`.
           - '`swarm serve --config`, which remains command-local runtime configuration.'
           source_order:
           - flag
@@ -14076,7 +14091,7 @@ cli_specification:
       - exact /v1/rpc bundle.register call with only content_yaml, optional data_blob, and optional idempotency_key
       - exact /v1/rpc bundle.delete call with only bundle_hash, optional force, optional dry_run, and optional idempotency_key
       - local directory packaging proves traversal/root escape, symlink fail-closed behavior, ignored file/dir policy, slash-relative NFC paths, duplicate and ASCII case-collision failure, text-vs-every-discovered-flow-data split including empty raw data, deterministic ordering, and no bundle_hash param
-      - invalid args, invalid local envelope/data blob files, invalid local contracts directories, and missing SWARM_API_TOKEN make zero API calls
+      - invalid args, invalid local envelope/data blob files, invalid local contracts directories, and missing API token source make zero API calls
       - human and --json output render only server-owned result fields
       - BUNDLE_NOT_FOUND, BUNDLE_REGISTER_CONFLICT, BUNDLE_HAS_ACTIVE_RUNS, BUNDLE_DELETE_IN_PROGRESS, IDEMPOTENCY_CONFLICT, invalid params, malformed responses, auth/HTTP/RPC failures, and transport failures fail closed with tested exit codes
       - no direct DB/store/runtime/hash-owner bundle reads or writes from CLI
@@ -14110,7 +14125,7 @@ cli_specification:
       - no direct DB/store/runtime/fork harness access from CLI
       - cross-bundle targets select already loaded/boot-pinned RuntimeContextManager BundleContexts; valid but unloaded/unavailable targets fail with BUNDLE_UNAVAILABLE and corrupt target catalog bytes fail with BUNDLE_DATA_INTEGRITY_ERROR
       - DB-loaded same-bundle source loading is exercised through /v1/rpc run.fork, not a direct CLI runtime/store helper
-      - missing SWARM_API_TOKEN, invalid args, and legacy harness flags make zero API calls
+      - missing API token source, invalid args, and legacy harness flags make zero API calls
       - RUN_NOT_FOUND, EVENT_NOT_FOUND, BUNDLE_UNAVAILABLE, BUNDLE_DATA_INTEGRITY_ERROR, IDEMPOTENCY_CONFLICT, malformed responses, auth/HTTP/RPC failures, and transport failures fail closed with tested exit codes
     forkchat:
       command: swarm forkchat new|resume|list|view|delete
@@ -20685,8 +20700,8 @@ api_specification:
     auth_token_disposition:
       v1_model: >
         User-facing API bearer-token sources are governed by
-        cli_specification.foundations.api_connection_auth_config_precedence. `SWARM_API_TOKEN` remains the
-        current direct environment-token implementation source until behavior consumes that owner.
+        cli_specification.foundations.api_connection_auth_config_precedence. Client-side `SWARM_API_TOKEN` is not
+        a valid API bearer-token source after #1636; server-side `swarm serve` API auth sourcing remains tracked by #1647.
         `SWARM_BUILDER_AUTH_TOKEN` and `SWARM_OPERATOR_AUTH_TOKEN` are retired and MUST NOT authorize /v1/rpc
         or /v1/ws.
       auth_boundary_bug_fix: "The current bug where /api/rpc and /api/ws bypass operator auth is moot under v1 \u2014 one\


### PR DESCRIPTION
Closes #1636

## Governing refs / context
- `platform-spec.yaml#cli_specification.foundations.api_connection_auth_config_precedence`
- `platform-spec.yaml#cli_specification.foundations.local_target_resolution_authority`
- Binding issue/gate context: #1600 env-source reduction map, #1636 locked no-fallback client-side API env removal, #1647 split for server-side `swarm serve` API token source ownership.

## Semantic migration
- New canonical owner: shared CLI API resolver backed by `api_connection_auth_config_precedence` and local context target resolution.
- Old producer/reader paths now invalid: client-side `SWARM_API_SERVER`, `SWARM_API_TOKEN`, and `SWARM_API_TOKEN_FILE`; the old direct `resolveCLIAPIRPCEndpoint` helper is removed.
- Production paths checked: `newCLIAPIClient`, `resolveCLIAPITarget`, `resolveCLIAPITokenForTarget`, `resolveCLIAPIToken`, `swarm doctor --target`, API-backed command tests, and authoritative `platform-spec.yaml`.
- Migration complete for the #1636 client-side class. Server-side `swarm serve` listener auth still uses `SWARM_API_TOKEN` and remains split to #1647.

## Proof
- `go test ./cmd/swarm -run 'TestPlatformSpecCLIAPIConnectionAuthConfigPrecedencePromoted|TestPlatformSpecLocalTargetResolutionAuthorityPromoted|TestRunServeListenerSourcePrecedencePromoted'`
- `go test ./cmd/swarm -run TestCLIAPIContextDescriptorAuthOutranksConfigTokenFile`
- `go test ./...`