### PR TITLE
[agent-e][issue #1652] Add deterministic scenario runner

### DIFF
--- a/cmd/swarm/api_consumption_boundary_test.go
+++ b/cmd/swarm/api_consumption_boundary_test.go
@@ -35,6 +35,7 @@ func TestCLIRuntimeStateAPIConsumersAreExplicitlyAccounted(t *testing.T) {
 		"incidents.go":            {},
 		"logs.go":                 {},
 		"run_command.go":          {},
+		"test_command.go":         {},
 	}
 
 	gotAPIConsumers := map[string]struct{}{}
@@ -74,6 +75,9 @@ func TestCLIRuntimeStateAPIConsumersAreExplicitlyAccounted(t *testing.T) {
 	for name := range wantAPIConsumers {
 		source := sources[name]
 		for _, needle := range localBypassNeedles {
+			if name == "test_command.go" && needle == "BundleHash(" {
+				continue
+			}
 			if strings.Contains(source, needle) {
 				t.Fatalf("%s contains local/runtime bypass %q; runtime-state CLI commands must consume newCLIAPIClient", name, needle)
 			}
@@ -151,6 +155,7 @@ func TestCLIRuntimeStateCommandsRequireSharedAPITokenBeforeRequest(t *testing.T)
 		t.Fatalf("write bundle register envelope: %v", err)
 	}
 	contractsDir := writeBundleRegisterContractsFixture(t)
+	scenarioContractsDir := writeScenarioRunnerFixture(t)
 
 	for _, tc := range []struct {
 		name string
@@ -206,6 +211,7 @@ func TestCLIRuntimeStateCommandsRequireSharedAPITokenBeforeRequest(t *testing.T)
 		{name: "forkchat list", args: []string{"forkchat", "list"}},
 		{name: "forkchat view", args: []string{"forkchat", "view", "fork-1"}},
 		{name: "forkchat delete", args: []string{"forkchat", "delete", "fork-1"}},
+		{name: "test", args: []string{"test", "--contracts", scenarioContractsDir, "--platform-spec", filepath.Join(repoRoot(), defaultPlatformSpecPath)}},
 		{name: "version server", args: []string{"version", "--server"}},
 	} {
 		t.Run(tc.name, func(t *testing.T) {

--- a/cmd/swarm/cli.go
+++ b/cmd/swarm/cli.go
@@ -109,6 +109,7 @@ start work with 'swarm run' or 'swarm event publish' and watch it with
 	)
 	addToGroup(commandGroupAuthor,
 		newVerifyCommand(ctx, repo),
+		newTestCommand(repo, opts),
 		newDescribeCommand(ctx, repo),
 		newBundleCommand(repo, opts),
 		newSecretsCommand(ctx, repo),

--- a/cmd/swarm/cli_api_flags.go
+++ b/cmd/swarm/cli_api_flags.go
@@ -54,6 +54,7 @@ func cliAPIConnectionFlagAfterLeafCommand(prefix []string) bool {
 	prefix = stripRootPersistentFlagsForCLIAPIPlacement(prefix)
 	leafCommands := [][]string{
 		{"runs"},
+		{"test"},
 		{"status"},
 		{"trace"},
 		{"health"},

--- a/cmd/swarm/cli_logging_test.go
+++ b/cmd/swarm/cli_logging_test.go
@@ -77,13 +77,7 @@ func TestCLILoggingForSharedOutputConsumers(t *testing.T) {
 			name:   "status",
 			args:   func(*testing.T) []string { return []string{"status", "run-1"} },
 			method: "run.diagnose",
-			result: map[string]any{
-				"run":               validDiagnosticRunHeader("run-1"),
-				"operational_state": "stalled",
-				"blocking_layer":    "delivery_lifecycle",
-				"blocking_reason":   "no_active_deliveries",
-				"heuristics":        []any{"dead letters exist for this run"},
-			},
+			result: validDiagnosticRunDiagnosis("run-1", "stalled", "delivery_lifecycle", "no_active_deliveries", []any{"dead letters exist for this run"}),
 		},
 		{
 			name:   "conversations list",

--- a/cmd/swarm/cli_output_test.go
+++ b/cmd/swarm/cli_output_test.go
@@ -214,13 +214,7 @@ func TestCLIOutputModesForDiagnosticConsumers(t *testing.T) {
 				if tc.method == "run.get" {
 					return map[string]any{"run": validDiagnosticRunHeader("run-1")}
 				}
-				return map[string]any{
-					"run":               validDiagnosticRunHeader("run-1"),
-					"operational_state": "stalled",
-					"blocking_layer":    "delivery_lifecycle",
-					"blocking_reason":   "no_active_deliveries",
-					"heuristics":        []any{"dead letters exist for this run"},
-				}
+				return validDiagnosticRunDiagnosis("run-1", "stalled", "delivery_lifecycle", "no_active_deliveries", []any{"dead letters exist for this run"})
 			})
 			defer server.Close()
 
@@ -400,13 +394,7 @@ func TestCLIOutputNoColorForSharedRendererConsumers(t *testing.T) {
 			name:   "status",
 			args:   func(*testing.T) []string { return []string{"status", "run-1"} },
 			method: "run.diagnose",
-			result: map[string]any{
-				"run":               validDiagnosticRunHeader("run-1"),
-				"operational_state": "stalled",
-				"blocking_layer":    "delivery_lifecycle",
-				"blocking_reason":   "no_active_deliveries",
-				"heuristics":        []any{"dead letters exist for this run"},
-			},
+			result: validDiagnosticRunDiagnosis("run-1", "stalled", "delivery_lifecycle", "no_active_deliveries", []any{"dead letters exist for this run"}),
 		},
 		{
 			name:   "conversations list",

--- a/cmd/swarm/diagnostics.go
+++ b/cmd/swarm/diagnostics.go
@@ -76,6 +76,15 @@ type diagnosticRunDiagnosisResult struct {
 	BlockingReason   *string                        `json:"blocking_reason"`
 	Heuristics       []string                       `json:"heuristics"`
 	FailedDeliveries []diagnosticRunFailureDelivery `json:"failed_deliveries"`
+	TestQuiescence   *diagnosticRunTestQuiescence   `json:"test_quiescence"`
+}
+
+type diagnosticRunTestQuiescence struct {
+	Ready                   *bool `json:"ready"`
+	ActiveDeliveries        *int  `json:"active_deliveries"`
+	UnsettledPipelineEvents *int  `json:"unsettled_pipeline_events"`
+	DueTimers               *int  `json:"due_timers"`
+	ActiveSessionLeases     *int  `json:"active_session_leases"`
 }
 
 type diagnosticRunTraceResult struct {
@@ -1186,9 +1195,39 @@ func validateDiagnosticRunDiagnosis(result diagnosticRunDiagnosisResult) error {
 	if result.Heuristics == nil {
 		return fmt.Errorf("malformed run.diagnose result: heuristics is required")
 	}
+	if result.TestQuiescence == nil {
+		return fmt.Errorf("malformed run.diagnose result: test_quiescence is required")
+	}
+	if err := validateDiagnosticRunTestQuiescence(*result.TestQuiescence); err != nil {
+		return err
+	}
 	for i, delivery := range result.FailedDeliveries {
 		if err := validateDiagnosticRunFailureDelivery(fmt.Sprintf("failed_deliveries[%d]", i), delivery); err != nil {
 			return err
+		}
+	}
+	return nil
+}
+
+func validateDiagnosticRunTestQuiescence(result diagnosticRunTestQuiescence) error {
+	fields := []struct {
+		name  string
+		value *int
+	}{
+		{name: "active_deliveries", value: result.ActiveDeliveries},
+		{name: "unsettled_pipeline_events", value: result.UnsettledPipelineEvents},
+		{name: "due_timers", value: result.DueTimers},
+		{name: "active_session_leases", value: result.ActiveSessionLeases},
+	}
+	if result.Ready == nil {
+		return fmt.Errorf("malformed run.diagnose result: test_quiescence.ready is required")
+	}
+	for _, field := range fields {
+		if field.value == nil {
+			return fmt.Errorf("malformed run.diagnose result: test_quiescence.%s is required", field.name)
+		}
+		if *field.value < 0 {
+			return fmt.Errorf("malformed run.diagnose result: test_quiescence.%s must be non-negative", field.name)
 		}
 	}
 	return nil
@@ -1405,6 +1444,15 @@ func writeDiagnosticRunDiagnosis(out io.Writer, result diagnosticRunDiagnosisRes
 		stringPointerValue(result.BlockingLayer),
 		stringPointerValue(result.BlockingReason),
 	)
+	if result.TestQuiescence != nil {
+		fmt.Fprintf(out, "test_quiescence_ready=%t active_deliveries=%d unsettled_pipeline_events=%d due_timers=%d active_session_leases=%d\n",
+			boolPointerValue(result.TestQuiescence.Ready),
+			intPointerValue(result.TestQuiescence.ActiveDeliveries),
+			intPointerValue(result.TestQuiescence.UnsettledPipelineEvents),
+			intPointerValue(result.TestQuiescence.DueTimers),
+			intPointerValue(result.TestQuiescence.ActiveSessionLeases),
+		)
+	}
 	if len(result.Heuristics) == 0 {
 		fmt.Fprintln(out, "heuristics=none")
 	} else {

--- a/cmd/swarm/diagnostics_test.go
+++ b/cmd/swarm/diagnostics_test.go
@@ -154,13 +154,7 @@ func TestStatusUsesDiagnoseAndRunGet(t *testing.T) {
 				if tc.wantMethod == "run.get" {
 					return map[string]any{"run": validDiagnosticRunHeader("run-1")}
 				}
-				return map[string]any{
-					"run":               validDiagnosticRunHeader("run-1"),
-					"operational_state": "stalled",
-					"blocking_layer":    "delivery_lifecycle",
-					"blocking_reason":   "no_active_deliveries",
-					"heuristics":        []any{"dead letters exist for this run"},
-				}
+				return validDiagnosticRunDiagnosis("run-1", "stalled", "delivery_lifecycle", "no_active_deliveries", []any{"dead letters exist for this run"})
 			})
 			defer server.Close()
 
@@ -258,13 +252,7 @@ func TestStatusAndTraceResolveOmittedRunThroughActivePreference(t *testing.T) {
 				case "run.get":
 					return map[string]any{"run": validDiagnosticRunHeaderWithStatus(tc.selected, "paused")}
 				default:
-					return map[string]any{
-						"run":               validDiagnosticRunHeader(tc.selected),
-						"operational_state": "running",
-						"blocking_layer":    "",
-						"blocking_reason":   "",
-						"heuristics":        []any{},
-					}
+					return validDiagnosticRunDiagnosis(tc.selected, "running", "", "", []any{})
 				}
 			})
 			defer server.Close()
@@ -1510,6 +1498,23 @@ func TestDiagnosticsFailClosedOnAPIAndMalformedResults(t *testing.T) {
 			wantStderr: "heuristics is required",
 		},
 		{
+			name: "run diagnose missing test quiescence",
+			args: []string{"status", "run-1"},
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				var req jsonRPCRequest
+				_ = json.NewDecoder(r.Body).Decode(&req)
+				writeJSONRPCResult(t, w, req.ID, map[string]any{
+					"run":               validDiagnosticRunHeader("run-1"),
+					"operational_state": "running",
+					"blocking_layer":    "",
+					"blocking_reason":   "",
+					"heuristics":        []any{},
+				})
+			},
+			wantCode:   3,
+			wantStderr: "test_quiescence is required",
+		},
+		{
 			name: "trace missing trace",
 			args: []string{"trace", "run-1"},
 			handler: func(w http.ResponseWriter, r *http.Request) {
@@ -1702,6 +1707,24 @@ func validDiagnosticRunHeader(runID string) map[string]any {
 		"entity_count":       2,
 		"event_count":        3,
 		"started_at":         "2026-05-13T10:00:00Z",
+	}
+}
+
+func validDiagnosticRunDiagnosis(runID, state, layer, reason string, heuristics []any) map[string]any {
+	return map[string]any{
+		"run":               validDiagnosticRunHeader(runID),
+		"operational_state": state,
+		"blocking_layer":    layer,
+		"blocking_reason":   reason,
+		"heuristics":        heuristics,
+		"failed_deliveries": []any{},
+		"test_quiescence": map[string]any{
+			"ready":                     true,
+			"active_deliveries":         0,
+			"unsettled_pipeline_events": 0,
+			"due_timers":                0,
+			"active_session_leases":     0,
+		},
 	}
 }
 

--- a/cmd/swarm/test_command.go
+++ b/cmd/swarm/test_command.go
@@ -1,0 +1,1515 @@
+package main
+
+import (
+	"context"
+	"crypto/sha1"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
+	runtimeeventschema "github.com/division-sh/swarm/internal/runtime/eventschema"
+	"github.com/google/cel-go/cel"
+	"github.com/google/cel-go/common/types"
+	"github.com/google/cel-go/common/types/ref"
+	"github.com/google/uuid"
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
+)
+
+const (
+	scenarioTestExitValidation = 2
+	scenarioTestExitRuntime    = 3
+	scenarioTestExitAuth       = 4
+	scenarioTestExitNotFound   = 5
+	scenarioTestExitRejected   = 6
+
+	defaultScenarioTestTimeout = 30 * time.Second
+	defaultScenarioTestPoll    = 250 * time.Millisecond
+)
+
+type scenarioTestCommandOptions struct {
+	apiOptions   rootCommandOptions
+	contracts    string
+	platformSpec string
+	timeout      time.Duration
+	pollInterval time.Duration
+}
+
+type scenarioTestFile struct {
+	Path   string
+	FlowID string
+}
+
+type scenarioDocument struct {
+	Name    string
+	Vars    map[string]any
+	Steps   []scenarioStep
+	Expect  scenarioExpect
+	Invalid *scenarioInvalid
+}
+
+type scenarioStep struct {
+	Action             string
+	PublishEvent       string
+	Payload            any
+	Match              map[string]any
+	Reason             any
+	Until              any
+	IdempotencyKey     any
+	Emitter            any
+	SourceEventID      any
+	TargetFlowInstance any
+	TargetEntityID     any
+}
+
+type scenarioExpect struct {
+	Events        scenarioEventExpect
+	NoDeadLetters *bool
+	Entities      []scenarioEntityExpect
+}
+
+type scenarioEventExpect struct {
+	Include []string
+	Exact   []string
+	Ordered []string
+}
+
+type scenarioEntityExpect struct {
+	EntityType string
+	Count      *int
+}
+
+type scenarioInvalid struct {
+	Base  map[string]any
+	Cases []scenarioInvalidCase
+}
+
+type scenarioInvalidCase struct {
+	Name   string
+	Set    map[string]any
+	Expect string
+}
+
+type scenarioRunState struct {
+	RunID       string
+	LastEventID string
+}
+
+type scenarioTestValidationError struct {
+	err error
+}
+
+func (e scenarioTestValidationError) Error() string {
+	if e.err == nil {
+		return ""
+	}
+	return e.err.Error()
+}
+
+func (e scenarioTestValidationError) Unwrap() error {
+	return e.err
+}
+
+type scenarioRunner struct {
+	client       *cliAPIClient
+	bundle       *runtimecontracts.WorkflowContractBundle
+	bundleHash   string
+	contractsDir string
+	timeout      time.Duration
+	pollInterval time.Duration
+	out          io.Writer
+}
+
+type scenarioExpressionEvaluator struct {
+	env  *cel.Env
+	seed string
+	vars map[string]any
+}
+
+func newTestCommand(repoRoot string, opts rootCommandOptions) *cobra.Command {
+	testOpts := scenarioTestCommandOptions{
+		apiOptions:   opts,
+		timeout:      defaultScenarioTestTimeout,
+		pollInterval: defaultScenarioTestPoll,
+	}
+	cmd := &cobra.Command{
+		Use:   "test [scenario-file ...]",
+		Short: "Run deterministic scenario tests through public v1 API owners.",
+		Args:  cobra.ArbitraryArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runScenarioTestCommand(cmd.Context(), repoRoot, cmd.OutOrStdout(), cmd.ErrOrStderr(), args, testOpts)
+		},
+	}
+	cmd.Flags().StringVar(&testOpts.contracts, "contracts", "", "Contract package root containing scenario tests")
+	cmd.Flags().StringVar(&testOpts.platformSpec, "platform-spec", "", "platform-spec.yaml path used to load the contract bundle")
+	cmd.Flags().DurationVar(&testOpts.timeout, "timeout", defaultScenarioTestTimeout, "Safety deadline for test quiescence")
+	cmd.Flags().DurationVar(&testOpts.pollInterval, "poll-interval", defaultScenarioTestPoll, "Canonical readback polling interval while waiting for quiescence")
+	bindCLIAPIConnectionFlagsWithClass(cmd, &testOpts.apiOptions, cliAPICommandClassMutating, "swarm test")
+	return cmd
+}
+
+func runScenarioTestCommand(ctx context.Context, repoRoot string, out, errOut io.Writer, args []string, opts scenarioTestCommandOptions) error {
+	if opts.timeout <= 0 {
+		return returnScenarioTestValidationError(errOut, fmt.Errorf("--timeout must be positive"))
+	}
+	if opts.pollInterval <= 0 {
+		return returnScenarioTestValidationError(errOut, fmt.Errorf("--poll-interval must be positive"))
+	}
+	contractsDir, platformSpec, err := resolveScenarioTestSources(repoRoot, opts.contracts, opts.platformSpec)
+	if err != nil {
+		return returnScenarioTestValidationError(errOut, err)
+	}
+	files, err := discoverScenarioTestFiles(contractsDir, args)
+	if err != nil {
+		return returnScenarioTestValidationError(errOut, err)
+	}
+	if len(files) == 0 {
+		return returnScenarioTestValidationError(errOut, fmt.Errorf("no scenario files found under contracts/tests or contracts/flows/<flow>/tests"))
+	}
+	bundle, err := runtimecontracts.LoadWorkflowContractBundleWithOverrides(repoRoot, contractsDir, platformSpec)
+	if err != nil {
+		return returnScenarioTestValidationError(errOut, fmt.Errorf("load contract bundle: %w", err))
+	}
+	bundleHash, err := runtimecontracts.BundleHash(bundle)
+	if err != nil {
+		return returnScenarioTestValidationError(errOut, fmt.Errorf("compute bundle_hash: %w", err))
+	}
+	client, err := newCLIAPIClient(opts.apiOptions)
+	if err != nil {
+		fmt.Fprintln(errOut, err)
+		return commandExitError{code: scenarioTestAPIErrorExitCode(err)}
+	}
+	runner := scenarioRunner{
+		client:       client,
+		bundle:       bundle,
+		bundleHash:   bundleHash,
+		contractsDir: contractsDir,
+		timeout:      opts.timeout,
+		pollInterval: opts.pollInterval,
+		out:          out,
+	}
+	for _, file := range files {
+		if err := runner.runScenarioFile(ctx, file); err != nil {
+			fmt.Fprintln(errOut, err)
+			return commandExitError{code: scenarioTestAPIErrorExitCode(err)}
+		}
+	}
+	fmt.Fprintf(out, "swarm test ok: scenarios=%d\n", len(files))
+	return nil
+}
+
+func resolveScenarioTestSources(repoRoot, contractsFlag, platformSpecFlag string) (string, string, error) {
+	repoRoot = strings.TrimSpace(repoRoot)
+	if repoRoot == "" {
+		repoRoot = "."
+	}
+	cfg, err := loadCLIAPIConfigFile()
+	if err != nil {
+		return "", "", err
+	}
+	contractsDir := strings.TrimSpace(contractsFlag)
+	if contractsDir == "" {
+		contractsDir = strings.TrimSpace(cfg.ContractsPath)
+	}
+	if contractsDir == "" {
+		contractsDir = filepath.Join(repoRoot, "contracts")
+		if _, err := os.Stat(filepath.Join(contractsDir, "package.yaml")); err != nil {
+			contractsDir = repoRoot
+		}
+	}
+	contractsDir, err = absFrom(repoRoot, contractsDir)
+	if err != nil {
+		return "", "", err
+	}
+	platformSpec := strings.TrimSpace(platformSpecFlag)
+	if platformSpec == "" {
+		platformSpec = strings.TrimSpace(cfg.PlatformSpecPath)
+	}
+	if platformSpec == "" {
+		platformSpec = runtimecontracts.DefaultPlatformSpecFile(repoRoot)
+	}
+	platformSpec, err = absFrom(repoRoot, platformSpec)
+	if err != nil {
+		return "", "", err
+	}
+	return contractsDir, platformSpec, nil
+}
+
+func absFrom(base, path string) (string, error) {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return "", fmt.Errorf("path is required")
+	}
+	if !filepath.IsAbs(path) {
+		path = filepath.Join(base, path)
+	}
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return "", err
+	}
+	return abs, nil
+}
+
+func discoverScenarioTestFiles(contractsDir string, args []string) ([]scenarioTestFile, error) {
+	contractsDir, err := filepath.Abs(contractsDir)
+	if err != nil {
+		return nil, err
+	}
+	if len(args) > 0 {
+		out := make([]scenarioTestFile, 0, len(args))
+		for _, arg := range args {
+			path, err := absFrom(contractsDir, arg)
+			if err != nil {
+				return nil, err
+			}
+			file, ok := classifyScenarioTestFile(contractsDir, path)
+			if !ok {
+				return nil, fmt.Errorf("scenario file %s is outside supported roots contracts/tests and contracts/flows/<flow>/tests", path)
+			}
+			out = append(out, file)
+		}
+		sort.Slice(out, func(i, j int) bool { return out[i].Path < out[j].Path })
+		return out, nil
+	}
+	var out []scenarioTestFile
+	for _, root := range []string{
+		filepath.Join(contractsDir, "tests"),
+		filepath.Join(contractsDir, "flows"),
+	} {
+		if _, err := os.Stat(root); err != nil {
+			continue
+		}
+		if err := filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+			if err != nil {
+				return err
+			}
+			if d.IsDir() {
+				return nil
+			}
+			if ext := strings.ToLower(filepath.Ext(path)); ext != ".yaml" && ext != ".yml" {
+				return nil
+			}
+			if file, ok := classifyScenarioTestFile(contractsDir, path); ok {
+				if autoDiscoveredScenarioCandidate(path) {
+					out = append(out, file)
+				}
+			}
+			return nil
+		}); err != nil {
+			return nil, err
+		}
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Path < out[j].Path })
+	return out, nil
+}
+
+func classifyScenarioTestFile(contractsDir, path string) (scenarioTestFile, bool) {
+	absContracts, err := filepath.Abs(contractsDir)
+	if err != nil {
+		return scenarioTestFile{}, false
+	}
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		return scenarioTestFile{}, false
+	}
+	rel, err := filepath.Rel(absContracts, absPath)
+	if err != nil || rel == "." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) || rel == ".." {
+		return scenarioTestFile{}, false
+	}
+	parts := splitPath(rel)
+	if len(parts) >= 2 && parts[0] == "tests" {
+		return scenarioTestFile{Path: absPath}, true
+	}
+	if len(parts) >= 4 && parts[0] == "flows" {
+		for i := 2; i < len(parts); i++ {
+			if parts[i] == "tests" {
+				return scenarioTestFile{Path: absPath, FlowID: strings.Join(parts[1:i], "/")}, true
+			}
+		}
+	}
+	return scenarioTestFile{}, false
+}
+
+func autoDiscoveredScenarioCandidate(path string) bool {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return true
+	}
+	var root yaml.Node
+	if err := yaml.Unmarshal(raw, &root); err != nil || len(root.Content) == 0 || root.Content[0].Kind != yaml.MappingNode {
+		return true
+	}
+	top := mappingNode(root.Content[0])
+	return top["version"] != nil || top["steps"] != nil || top["invalid"] != nil
+}
+
+func splitPath(path string) []string {
+	raw := strings.Split(filepath.ToSlash(path), "/")
+	out := raw[:0]
+	for _, part := range raw {
+		if part != "" && part != "." {
+			out = append(out, part)
+		}
+	}
+	return out
+}
+
+func (r scenarioRunner) runScenarioFile(ctx context.Context, file scenarioTestFile) error {
+	raw, err := os.ReadFile(file.Path)
+	if err != nil {
+		return scenarioTestValidationError{err: fmt.Errorf("%s: read scenario: %w", file.Path, err)}
+	}
+	doc, err := parseScenarioDocument(raw)
+	if err != nil {
+		return scenarioTestValidationError{err: fmt.Errorf("%s: %w", file.Path, err)}
+	}
+	evaluator, err := newScenarioExpressionEvaluator(file.Path, doc.Vars)
+	if err != nil {
+		return scenarioTestValidationError{err: fmt.Errorf("%s: %w", file.Path, err)}
+	}
+	if doc.Invalid != nil {
+		if err := r.runInvalidVariants(file, doc, evaluator); err != nil {
+			return scenarioTestValidationError{err: err}
+		}
+	}
+	state := &scenarioRunState{}
+	for i, step := range doc.Steps {
+		if err := r.runScenarioStep(ctx, file, evaluator, state, step); err != nil {
+			return fmt.Errorf("%s: step %d: %w", file.Path, i+1, err)
+		}
+		if state.RunID != "" {
+			if err := r.waitForQuiescence(ctx, state.RunID); err != nil {
+				return fmt.Errorf("%s: step %d: %w", file.Path, i+1, err)
+			}
+		}
+	}
+	if state.RunID != "" {
+		if err := r.waitForQuiescence(ctx, state.RunID); err != nil {
+			return fmt.Errorf("%s: %w", file.Path, err)
+		}
+		if !doc.Expect.empty() {
+			if err := r.evaluateExpectations(ctx, state.RunID, doc.Expect); err != nil {
+				return fmt.Errorf("%s: %w", file.Path, err)
+			}
+		}
+	}
+	fmt.Fprintf(r.out, "scenario ok: %s\n", file.Path)
+	return nil
+}
+
+func parseScenarioDocument(raw []byte) (scenarioDocument, error) {
+	var root yaml.Node
+	if err := yaml.Unmarshal(raw, &root); err != nil {
+		return scenarioDocument{}, fmt.Errorf("parse YAML: %w", err)
+	}
+	if len(root.Content) == 0 || root.Content[0].Kind != yaml.MappingNode {
+		return scenarioDocument{}, fmt.Errorf("scenario document must be a YAML mapping")
+	}
+	top := mappingNode(root.Content[0])
+	for key := range top {
+		switch key {
+		case "version", "name", "vars", "steps", "expect", "invalid":
+		default:
+			return scenarioDocument{}, fmt.Errorf("unsupported top-level field %q", key)
+		}
+	}
+	if node := top["version"]; node != nil {
+		version := strings.TrimSpace(fmt.Sprint(yamlNodeValue(node)))
+		if version != "" && version != "1" && version != "v1" {
+			return scenarioDocument{}, fmt.Errorf("unsupported scenario version %q", version)
+		}
+	}
+	doc := scenarioDocument{Vars: map[string]any{}}
+	if node := top["name"]; node != nil {
+		doc.Name = strings.TrimSpace(fmt.Sprint(yamlNodeValue(node)))
+	}
+	if node := top["vars"]; node != nil {
+		vars, ok := yamlNodeValue(node).(map[string]any)
+		if !ok {
+			return scenarioDocument{}, fmt.Errorf("vars must be a mapping")
+		}
+		doc.Vars = vars
+	}
+	stepsNode := top["steps"]
+	if stepsNode == nil {
+		return scenarioDocument{}, fmt.Errorf("steps is required")
+	}
+	if stepsNode.Kind != yaml.SequenceNode || len(stepsNode.Content) == 0 {
+		return scenarioDocument{}, fmt.Errorf("steps must be a non-empty list")
+	}
+	for _, node := range stepsNode.Content {
+		step, err := parseScenarioStep(node)
+		if err != nil {
+			return scenarioDocument{}, err
+		}
+		doc.Steps = append(doc.Steps, step)
+	}
+	if node := top["expect"]; node != nil {
+		expect, err := parseScenarioExpect(node)
+		if err != nil {
+			return scenarioDocument{}, err
+		}
+		doc.Expect = expect
+	}
+	if node := top["invalid"]; node != nil {
+		invalid, err := parseScenarioInvalid(node)
+		if err != nil {
+			return scenarioDocument{}, err
+		}
+		doc.Invalid = &invalid
+	}
+	return doc, nil
+}
+
+func parseScenarioStep(node *yaml.Node) (scenarioStep, error) {
+	if node.Kind != yaml.MappingNode {
+		return scenarioStep{}, fmt.Errorf("scenario step must be a mapping")
+	}
+	m := yamlNodeValue(node).(map[string]any)
+	if rawPublish, ok := m["publish"]; ok {
+		eventName := strings.TrimSpace(fmt.Sprint(rawPublish))
+		if eventName == "" {
+			return scenarioStep{}, fmt.Errorf("publish step requires non-empty event name")
+		}
+		for key := range m {
+			switch key {
+			case "publish", "payload", "idempotency_key", "emitter", "source_event_id", "target_flow_instance", "target_entity_id":
+			default:
+				return scenarioStep{}, fmt.Errorf("unsupported publish step field %q", key)
+			}
+		}
+		return scenarioStep{
+			Action:             "publish",
+			PublishEvent:       eventName,
+			Payload:            m["payload"],
+			IdempotencyKey:     m["idempotency_key"],
+			Emitter:            m["emitter"],
+			SourceEventID:      m["source_event_id"],
+			TargetFlowInstance: m["target_flow_instance"],
+			TargetEntityID:     m["target_entity_id"],
+		}, nil
+	}
+	if len(m) != 1 {
+		return scenarioStep{}, fmt.Errorf("scenario step must contain publish or one mailbox action")
+	}
+	for key, value := range m {
+		action := normalizeScenarioMailboxAction(key)
+		if action == "" {
+			return scenarioStep{}, fmt.Errorf("unsupported scenario action %q", key)
+		}
+		cfg, ok := value.(map[string]any)
+		if !ok {
+			return scenarioStep{}, fmt.Errorf("%s step must be a mapping", key)
+		}
+		for cfgKey := range cfg {
+			switch cfgKey {
+			case "match", "payload", "reason", "until", "idempotency_key":
+			default:
+				return scenarioStep{}, fmt.Errorf("unsupported %s step field %q", key, cfgKey)
+			}
+		}
+		match, ok := cfg["match"].(map[string]any)
+		if !ok {
+			match = map[string]any{}
+		}
+		return scenarioStep{
+			Action:         action,
+			Match:          match,
+			Payload:        cfg["payload"],
+			Reason:         cfg["reason"],
+			Until:          cfg["until"],
+			IdempotencyKey: cfg["idempotency_key"],
+		}, nil
+	}
+	return scenarioStep{}, fmt.Errorf("scenario step is empty")
+}
+
+func normalizeScenarioMailboxAction(value string) string {
+	switch strings.TrimSpace(value) {
+	case "mailbox.approve", "approve_mailbox":
+		return "mailbox.approve"
+	case "mailbox.reject", "reject_mailbox":
+		return "mailbox.reject"
+	case "mailbox.defer", "defer_mailbox":
+		return "mailbox.defer"
+	default:
+		return ""
+	}
+}
+
+func parseScenarioExpect(node *yaml.Node) (scenarioExpect, error) {
+	if node.Kind != yaml.MappingNode {
+		return scenarioExpect{}, fmt.Errorf("expect must be a mapping")
+	}
+	m := yamlNodeValue(node).(map[string]any)
+	var expect scenarioExpect
+	for key, value := range m {
+		switch key {
+		case "events":
+			events, err := parseScenarioEventExpect(value)
+			if err != nil {
+				return scenarioExpect{}, err
+			}
+			expect.Events = events
+		case "no_dead_letters":
+			b, ok := value.(bool)
+			if !ok {
+				return scenarioExpect{}, fmt.Errorf("expect.no_dead_letters must be boolean")
+			}
+			expect.NoDeadLetters = &b
+		case "entities":
+			entities, err := parseScenarioEntityExpect(value)
+			if err != nil {
+				return scenarioExpect{}, err
+			}
+			expect.Entities = entities
+		default:
+			return scenarioExpect{}, fmt.Errorf("unsupported expect field %q", key)
+		}
+	}
+	return expect, nil
+}
+
+func parseScenarioEventExpect(value any) (scenarioEventExpect, error) {
+	if list, ok := value.([]any); ok {
+		values, err := stringListFromAny("expect.events", list)
+		return scenarioEventExpect{Include: values}, err
+	}
+	m, ok := value.(map[string]any)
+	if !ok {
+		return scenarioEventExpect{}, fmt.Errorf("expect.events must be a list or mapping")
+	}
+	var out scenarioEventExpect
+	for key, raw := range m {
+		list, ok := raw.([]any)
+		if !ok {
+			return scenarioEventExpect{}, fmt.Errorf("expect.events.%s must be a list", key)
+		}
+		values, err := stringListFromAny("expect.events."+key, list)
+		if err != nil {
+			return scenarioEventExpect{}, err
+		}
+		switch key {
+		case "include":
+			out.Include = values
+		case "exact":
+			out.Exact = values
+		case "ordered":
+			out.Ordered = values
+		default:
+			return scenarioEventExpect{}, fmt.Errorf("unsupported expect.events field %q", key)
+		}
+	}
+	return out, nil
+}
+
+func parseScenarioEntityExpect(value any) ([]scenarioEntityExpect, error) {
+	list, ok := value.([]any)
+	if !ok {
+		return nil, fmt.Errorf("expect.entities must be a list")
+	}
+	out := make([]scenarioEntityExpect, 0, len(list))
+	for i, raw := range list {
+		m, ok := raw.(map[string]any)
+		if !ok {
+			return nil, fmt.Errorf("expect.entities[%d] must be a mapping", i)
+		}
+		var item scenarioEntityExpect
+		for key, value := range m {
+			switch key {
+			case "type":
+				item.EntityType = strings.TrimSpace(fmt.Sprint(value))
+			case "count":
+				count, ok := intFromAny(value)
+				if !ok || count < 0 {
+					return nil, fmt.Errorf("expect.entities[%d].count must be a non-negative integer", i)
+				}
+				item.Count = &count
+			default:
+				return nil, fmt.Errorf("unsupported expect.entities[%d] field %q", i, key)
+			}
+		}
+		if item.EntityType == "" {
+			return nil, fmt.Errorf("expect.entities[%d].type is required", i)
+		}
+		out = append(out, item)
+	}
+	return out, nil
+}
+
+func (e scenarioExpect) empty() bool {
+	return len(e.Events.Include) == 0 && len(e.Events.Exact) == 0 && len(e.Events.Ordered) == 0 && e.NoDeadLetters == nil && len(e.Entities) == 0
+}
+
+func parseScenarioInvalid(node *yaml.Node) (scenarioInvalid, error) {
+	if node.Kind != yaml.MappingNode {
+		return scenarioInvalid{}, fmt.Errorf("invalid must be a mapping")
+	}
+	m := yamlNodeValue(node).(map[string]any)
+	for key := range m {
+		switch key {
+		case "base", "cases":
+		default:
+			return scenarioInvalid{}, fmt.Errorf("unsupported invalid field %q", key)
+		}
+	}
+	base, ok := m["base"].(map[string]any)
+	if !ok || len(base) == 0 {
+		return scenarioInvalid{}, fmt.Errorf("invalid.base must be a mapping")
+	}
+	casesRaw, ok := m["cases"].([]any)
+	if !ok || len(casesRaw) == 0 {
+		return scenarioInvalid{}, fmt.Errorf("invalid.cases must be a non-empty list")
+	}
+	out := scenarioInvalid{Base: base}
+	for i, raw := range casesRaw {
+		m, ok := raw.(map[string]any)
+		if !ok {
+			return scenarioInvalid{}, fmt.Errorf("invalid.cases[%d] must be a mapping", i)
+		}
+		item := scenarioInvalidCase{Expect: "reject"}
+		for key, value := range m {
+			switch key {
+			case "name":
+				item.Name = strings.TrimSpace(fmt.Sprint(value))
+			case "set":
+				set, ok := value.(map[string]any)
+				if !ok {
+					return scenarioInvalid{}, fmt.Errorf("invalid.cases[%d].set must be a mapping", i)
+				}
+				item.Set = set
+			case "expect":
+				item.Expect = strings.TrimSpace(fmt.Sprint(value))
+			default:
+				return scenarioInvalid{}, fmt.Errorf("unsupported invalid.cases[%d] field %q", i, key)
+			}
+		}
+		if item.Name == "" {
+			item.Name = fmt.Sprintf("case-%d", i+1)
+		}
+		if item.Expect != "reject" && item.Expect != "fail_closed" {
+			return scenarioInvalid{}, fmt.Errorf("invalid.cases[%d].expect must be reject or fail_closed", i)
+		}
+		out.Cases = append(out.Cases, item)
+	}
+	return out, nil
+}
+
+func stringListFromAny(field string, list []any) ([]string, error) {
+	out := make([]string, 0, len(list))
+	for i, raw := range list {
+		value := strings.TrimSpace(fmt.Sprint(raw))
+		if value == "" {
+			return nil, fmt.Errorf("%s[%d] must be non-empty", field, i)
+		}
+		out = append(out, value)
+	}
+	return out, nil
+}
+
+func intFromAny(value any) (int, bool) {
+	switch typed := value.(type) {
+	case int:
+		return typed, true
+	case int64:
+		return int(typed), int64(int(typed)) == typed
+	case float64:
+		i := int(typed)
+		return i, typed == float64(i)
+	default:
+		return 0, false
+	}
+}
+
+func mappingNode(node *yaml.Node) map[string]*yaml.Node {
+	out := map[string]*yaml.Node{}
+	for i := 0; i+1 < len(node.Content); i += 2 {
+		out[strings.TrimSpace(node.Content[i].Value)] = node.Content[i+1]
+	}
+	return out
+}
+
+func yamlNodeValue(node *yaml.Node) any {
+	switch node.Kind {
+	case yaml.MappingNode:
+		out := map[string]any{}
+		for i := 0; i+1 < len(node.Content); i += 2 {
+			out[strings.TrimSpace(node.Content[i].Value)] = yamlNodeValue(node.Content[i+1])
+		}
+		return out
+	case yaml.SequenceNode:
+		out := make([]any, 0, len(node.Content))
+		for _, item := range node.Content {
+			out = append(out, yamlNodeValue(item))
+		}
+		return out
+	case yaml.ScalarNode:
+		var value any
+		if err := node.Decode(&value); err == nil {
+			return value
+		}
+		return node.Value
+	default:
+		return nil
+	}
+}
+
+func newScenarioExpressionEvaluator(seed string, rawVars map[string]any) (*scenarioExpressionEvaluator, error) {
+	e := &scenarioExpressionEvaluator{seed: seed, vars: map[string]any{}}
+	env, err := cel.NewEnv(
+		cel.Variable("vars", cel.DynType),
+		cel.Function("scenario.sha40",
+			cel.Overload("scenario_sha40_string", []*cel.Type{cel.StringType}, cel.StringType,
+				cel.UnaryBinding(func(value ref.Val) ref.Val {
+					return types.String(scenarioSHA40(fmt.Sprint(value.Value())))
+				}),
+			),
+		),
+		cel.Function("scenario.uuid",
+			cel.Overload("scenario_uuid_string", []*cel.Type{cel.StringType}, cel.StringType,
+				cel.UnaryBinding(func(value ref.Val) ref.Val {
+					return types.String(scenarioUUID(seed, fmt.Sprint(value.Value())))
+				}),
+			),
+		),
+	)
+	if err != nil {
+		return nil, err
+	}
+	e.env = env
+	keys := make([]string, 0, len(rawVars))
+	for key := range rawVars {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	for _, key := range keys {
+		value, err := e.evalValue(rawVars[key])
+		if err != nil {
+			return nil, fmt.Errorf("vars.%s: %w", key, err)
+		}
+		e.vars[key] = value
+	}
+	return e, nil
+}
+
+func (e *scenarioExpressionEvaluator) evalValue(value any) (any, error) {
+	switch typed := value.(type) {
+	case string:
+		if strings.HasPrefix(typed, "${") && strings.HasSuffix(typed, "}") && len(typed) >= 3 {
+			return e.evalExpression(strings.TrimSpace(typed[2 : len(typed)-1]))
+		}
+		return typed, nil
+	case []any:
+		out := make([]any, 0, len(typed))
+		for _, item := range typed {
+			value, err := e.evalValue(item)
+			if err != nil {
+				return nil, err
+			}
+			out = append(out, value)
+		}
+		return out, nil
+	case map[string]any:
+		out := map[string]any{}
+		keys := make([]string, 0, len(typed))
+		for key := range typed {
+			keys = append(keys, key)
+		}
+		sort.Strings(keys)
+		for _, key := range keys {
+			value, err := e.evalValue(typed[key])
+			if err != nil {
+				return nil, fmt.Errorf("%s: %w", key, err)
+			}
+			out[key] = value
+		}
+		return out, nil
+	default:
+		return typed, nil
+	}
+}
+
+func (e *scenarioExpressionEvaluator) evalExpression(expression string) (any, error) {
+	if expression == "" {
+		return nil, fmt.Errorf("CEL expression is empty")
+	}
+	ast, issues := e.env.Compile(expression)
+	if issues != nil && issues.Err() != nil {
+		return nil, issues.Err()
+	}
+	program, err := e.env.Program(ast)
+	if err != nil {
+		return nil, err
+	}
+	out, _, err := program.Eval(map[string]any{"vars": e.vars})
+	if err != nil {
+		return nil, err
+	}
+	return scenarioCELValue(out), nil
+}
+
+func scenarioCELValue(value ref.Val) any {
+	switch typed := value.(type) {
+	case types.String:
+		return string(typed)
+	case types.Bool:
+		return bool(typed)
+	case types.Int:
+		return int64(typed)
+	case types.Uint:
+		return uint64(typed)
+	case types.Double:
+		return float64(typed)
+	default:
+		return value.Value()
+	}
+}
+
+func optionalScenarioString(value any) string {
+	if value == nil {
+		return ""
+	}
+	return strings.TrimSpace(fmt.Sprint(value))
+}
+
+func scenarioSHA40(value string) string {
+	sum := sha1.Sum([]byte(value))
+	return hex.EncodeToString(sum[:])
+}
+
+func scenarioUUID(seed, label string) string {
+	return uuid.NewSHA1(uuid.NameSpaceURL, []byte(seed+"\x00"+label)).String()
+}
+
+func (r scenarioRunner) runInvalidVariants(file scenarioTestFile, doc scenarioDocument, evaluator *scenarioExpressionEvaluator) error {
+	baseStep, err := invalidBasePublishStep(doc.Invalid.Base)
+	if err != nil {
+		return fmt.Errorf("%s: invalid.base: %w", file.Path, err)
+	}
+	for _, item := range doc.Invalid.Cases {
+		step := baseStep
+		payloadSpec, _ := step.Payload.(map[string]any)
+		payloadSpec = cloneAnyMap(payloadSpec)
+		if payloadSpec == nil {
+			payloadSpec = map[string]any{}
+		}
+		if len(item.Set) > 0 {
+			payloadSet, _ := payloadSpec["set"].(map[string]any)
+			if payloadSet == nil {
+				payloadSet = map[string]any{}
+			}
+			for key, value := range item.Set {
+				payloadSet[key] = value
+			}
+			payloadSpec["set"] = payloadSet
+		}
+		step.Payload = payloadSpec
+		if _, err := r.buildPublishPayload(file, evaluator, step); err == nil {
+			return fmt.Errorf("%s: invalid case %s unexpectedly passed pre-mutation validation", file.Path, item.Name)
+		}
+	}
+	return nil
+}
+
+func invalidBasePublishStep(base map[string]any) (scenarioStep, error) {
+	raw, ok := base["publish"]
+	if !ok {
+		return scenarioStep{}, fmt.Errorf("publish is required")
+	}
+	eventName := strings.TrimSpace(fmt.Sprint(raw))
+	if eventName == "" {
+		return scenarioStep{}, fmt.Errorf("publish must be non-empty")
+	}
+	return scenarioStep{Action: "publish", PublishEvent: eventName, Payload: base["payload"]}, nil
+}
+
+func (r scenarioRunner) runScenarioStep(ctx context.Context, file scenarioTestFile, evaluator *scenarioExpressionEvaluator, state *scenarioRunState, step scenarioStep) error {
+	switch step.Action {
+	case "publish":
+		return r.runPublishStep(ctx, file, evaluator, state, step)
+	case "mailbox.approve", "mailbox.reject", "mailbox.defer":
+		return r.runMailboxStep(ctx, evaluator, state, step)
+	default:
+		return fmt.Errorf("unsupported action %q", step.Action)
+	}
+}
+
+func (r scenarioRunner) runPublishStep(ctx context.Context, file scenarioTestFile, evaluator *scenarioExpressionEvaluator, state *scenarioRunState, step scenarioStep) error {
+	payload, err := r.buildPublishPayload(file, evaluator, step)
+	if err != nil {
+		return scenarioTestValidationError{err: err}
+	}
+	eventName := r.scopedEventName(file.FlowID, step.PublishEvent)
+	params := map[string]any{
+		"event_name":  eventName,
+		"payload":     payload,
+		"bundle_hash": r.bundleHash,
+	}
+	if state.RunID != "" {
+		params["run_id"] = state.RunID
+	}
+	if state.RunID != "" && step.SourceEventID == nil && state.LastEventID != "" {
+		params["source_event_id"] = state.LastEventID
+	}
+	for _, field := range []struct {
+		name  string
+		value any
+	}{
+		{name: "idempotency_key", value: step.IdempotencyKey},
+		{name: "emitter", value: step.Emitter},
+		{name: "source_event_id", value: step.SourceEventID},
+	} {
+		value, err := evaluator.evalValue(field.value)
+		if err != nil {
+			return fmt.Errorf("%s: %w", field.name, err)
+		}
+		if text := optionalScenarioString(value); text != "" {
+			params[field.name] = text
+		}
+	}
+	targetFlow, err := evaluator.evalValue(step.TargetFlowInstance)
+	if err != nil {
+		return fmt.Errorf("target_flow_instance: %w", err)
+	}
+	targetEntity, err := evaluator.evalValue(step.TargetEntityID)
+	if err != nil {
+		return fmt.Errorf("target_entity_id: %w", err)
+	}
+	targetFlowText := optionalScenarioString(targetFlow)
+	targetEntityText := optionalScenarioString(targetEntity)
+	if targetFlowText != "" || targetEntityText != "" {
+		if state.RunID == "" {
+			return fmt.Errorf("target route requires an existing run context")
+		}
+		if targetFlowText == "" || targetEntityText == "" {
+			return fmt.Errorf("target route requires both target_flow_instance and target_entity_id")
+		}
+		params["target"] = map[string]any{
+			"flow_instance": strings.Trim(targetFlowText, "/"),
+			"entity_id":     targetEntityText,
+		}
+	}
+	var result eventPublishResult
+	if err := r.client.call(ctx, eventPublishMethod, params, &result); err != nil {
+		return err
+	}
+	if err := validateEventPublishResult(result); err != nil {
+		return err
+	}
+	state.RunID = result.RunID
+	state.LastEventID = result.EventID
+	return nil
+}
+
+func (r scenarioRunner) scopedEventName(flowID, eventName string) string {
+	eventName = strings.TrimSpace(eventName)
+	flowID = strings.Trim(strings.TrimSpace(flowID), "/")
+	if flowID == "" || eventName == "" || strings.Contains(eventName, "/") {
+		return eventName
+	}
+	return r.bundle.ResolveFlowEventReference(flowID, eventName)
+}
+
+func (r scenarioRunner) buildPublishPayload(file scenarioTestFile, evaluator *scenarioExpressionEvaluator, step scenarioStep) (map[string]any, error) {
+	payload, err := r.buildPayloadFromSpec(file, evaluator, step.Payload)
+	if err != nil {
+		return nil, err
+	}
+	schema, _, ok := runtimecontracts.EventSchemaForFlowEvent(r.bundle, file.FlowID, step.PublishEvent)
+	if !ok {
+		return nil, fmt.Errorf("event %s has no target schema in contract bundle", step.PublishEvent)
+	}
+	if err := runtimeeventschema.ValidatePayloadAgainstSchema(schema.Schema, payload); err != nil {
+		return nil, err
+	}
+	return payload, nil
+}
+
+func (r scenarioRunner) buildPayloadFromSpec(file scenarioTestFile, evaluator *scenarioExpressionEvaluator, spec any) (map[string]any, error) {
+	if spec == nil {
+		return nil, fmt.Errorf("payload is required")
+	}
+	spec, err := evaluator.evalValue(spec)
+	if err != nil {
+		return nil, err
+	}
+	m, ok := spec.(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("payload must be an object")
+	}
+	var payload map[string]any
+	if rawFrom, ok := m["from"]; ok {
+		fixturePath := strings.TrimSpace(fmt.Sprint(rawFrom))
+		if fixturePath == "" {
+			return nil, fmt.Errorf("payload.from must be non-empty")
+		}
+		payload, err = r.loadFixturePayload(file.Path, fixturePath)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		payload = cloneAnyMap(m)
+	}
+	if rawSet, ok := m["set"]; ok {
+		set, ok := rawSet.(map[string]any)
+		if !ok {
+			return nil, fmt.Errorf("payload.set must be a mapping")
+		}
+		for path, value := range set {
+			value, err := evaluator.evalValue(value)
+			if err != nil {
+				return nil, fmt.Errorf("payload.set.%s: %w", path, err)
+			}
+			if err := setPathValue(payload, strings.TrimPrefix(path, "payload."), value); err != nil {
+				return nil, err
+			}
+		}
+	}
+	delete(payload, "from")
+	delete(payload, "set")
+	return payload, nil
+}
+
+func (r scenarioRunner) loadFixturePayload(scenarioPath, rawPath string) (map[string]any, error) {
+	path := rawPath
+	if !filepath.IsAbs(path) {
+		path = filepath.Join(filepath.Dir(scenarioPath), path)
+	}
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return nil, err
+	}
+	if !pathWithin(r.contractsDir, abs) {
+		return nil, fmt.Errorf("payload.from %s escapes contract package root", rawPath)
+	}
+	raw, err := os.ReadFile(abs)
+	if err != nil {
+		return nil, fmt.Errorf("read payload.from %s: %w", rawPath, err)
+	}
+	var node yaml.Node
+	if err := yaml.Unmarshal(raw, &node); err != nil {
+		return nil, fmt.Errorf("parse payload.from %s: %w", rawPath, err)
+	}
+	if len(node.Content) == 0 {
+		return nil, fmt.Errorf("payload.from %s is empty", rawPath)
+	}
+	payload, ok := yamlNodeValue(node.Content[0]).(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("payload.from %s must contain an object", rawPath)
+	}
+	return payload, nil
+}
+
+func pathWithin(base, path string) bool {
+	base, err := filepath.Abs(base)
+	if err != nil {
+		return false
+	}
+	path, err = filepath.Abs(path)
+	if err != nil {
+		return false
+	}
+	rel, err := filepath.Rel(base, path)
+	return err == nil && rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator))
+}
+
+func setPathValue(root map[string]any, rawPath string, value any) error {
+	parts := strings.Split(strings.TrimSpace(rawPath), ".")
+	if len(parts) == 0 || strings.TrimSpace(parts[0]) == "" {
+		return fmt.Errorf("payload.set path is required")
+	}
+	cursor := root
+	for i, part := range parts {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			return fmt.Errorf("payload.set path %q contains an empty segment", rawPath)
+		}
+		if i == len(parts)-1 {
+			if value == nil {
+				delete(cursor, part)
+			} else {
+				cursor[part] = value
+			}
+			return nil
+		}
+		next, _ := cursor[part].(map[string]any)
+		if next == nil {
+			next = map[string]any{}
+			cursor[part] = next
+		}
+		cursor = next
+	}
+	return nil
+}
+
+func cloneAnyMap(in map[string]any) map[string]any {
+	if in == nil {
+		return nil
+	}
+	out := make(map[string]any, len(in))
+	for key, value := range in {
+		out[key] = cloneAny(value)
+	}
+	return out
+}
+
+func cloneAny(value any) any {
+	switch typed := value.(type) {
+	case map[string]any:
+		return cloneAnyMap(typed)
+	case []any:
+		out := make([]any, 0, len(typed))
+		for _, item := range typed {
+			out = append(out, cloneAny(item))
+		}
+		return out
+	default:
+		return typed
+	}
+}
+
+func (r scenarioRunner) runMailboxStep(ctx context.Context, evaluator *scenarioExpressionEvaluator, state *scenarioRunState, step scenarioStep) error {
+	if state.RunID == "" {
+		return fmt.Errorf("%s requires an existing run context", step.Action)
+	}
+	mailboxID, err := r.findMailboxID(ctx, evaluator, state.RunID, step.Match)
+	if err != nil {
+		return err
+	}
+	params := map[string]any{"mailbox_id": mailboxID}
+	if key, err := evaluator.evalValue(step.IdempotencyKey); err != nil {
+		return fmt.Errorf("idempotency_key: %w", err)
+	} else if text := optionalScenarioString(key); text != "" {
+		params["idempotency_key"] = text
+	}
+	switch step.Action {
+	case "mailbox.approve":
+		payload, err := evaluator.evalValue(step.Payload)
+		if err != nil {
+			return fmt.Errorf("payload: %w", err)
+		}
+		if payload != nil {
+			m, ok := payload.(map[string]any)
+			if !ok {
+				return fmt.Errorf("mailbox.approve payload must be an object")
+			}
+			params["decision_payload"] = m
+		}
+	case "mailbox.reject":
+		reason, err := evaluator.evalValue(step.Reason)
+		if err != nil {
+			return fmt.Errorf("reason: %w", err)
+		}
+		text := strings.TrimSpace(fmt.Sprint(reason))
+		if text == "" {
+			return fmt.Errorf("mailbox.reject reason is required")
+		}
+		params["reason"] = text
+	case "mailbox.defer":
+		until, err := evaluator.evalValue(step.Until)
+		if err != nil {
+			return fmt.Errorf("until: %w", err)
+		}
+		text := strings.TrimSpace(fmt.Sprint(until))
+		if text == "" {
+			return fmt.Errorf("mailbox.defer until is required")
+		}
+		if _, err := time.Parse(time.RFC3339, text); err != nil {
+			return fmt.Errorf("mailbox.defer until must be RFC3339: %w", err)
+		}
+		params["until"] = text
+	}
+	var result mailboxDecisionResult
+	if err := r.client.call(ctx, step.Action, params, &result); err != nil {
+		return err
+	}
+	if err := validateMailboxDecisionResult(strings.TrimPrefix(step.Action, "mailbox."), result); err != nil {
+		return err
+	}
+	if result.DownstreamEventID != "" {
+		state.LastEventID = result.DownstreamEventID
+	}
+	return nil
+}
+
+func (r scenarioRunner) findMailboxID(ctx context.Context, evaluator *scenarioExpressionEvaluator, runID string, match map[string]any) (string, error) {
+	params := map[string]any{
+		"status": "pending",
+		"run_id": runID,
+		"limit":  200,
+	}
+	for key, value := range match {
+		evaluated, err := evaluator.evalValue(value)
+		if err != nil {
+			return "", fmt.Errorf("match.%s: %w", key, err)
+		}
+		text := strings.TrimSpace(fmt.Sprint(evaluated))
+		if text == "" {
+			continue
+		}
+		switch key {
+		case "type":
+			params["type"] = text
+		case "priority":
+			params["priority"] = text
+		case "entity_id":
+			params["entity_id"] = text
+		default:
+			return "", fmt.Errorf("unsupported mailbox match field %q", key)
+		}
+	}
+	var result mailboxListResult
+	if err := r.client.call(ctx, "mailbox.list", params, &result); err != nil {
+		return "", err
+	}
+	if err := validateMailboxListResult(result); err != nil {
+		return "", err
+	}
+	if len(result.Items) != 1 {
+		return "", fmt.Errorf("mailbox match for run %s returned %d items, want exactly one", runID, len(result.Items))
+	}
+	return result.Items[0].MailboxID, nil
+}
+
+func (r scenarioRunner) waitForQuiescence(ctx context.Context, runID string) error {
+	deadline := time.Now().Add(r.timeout)
+	for {
+		active, err := r.activeDeliveryRows(ctx, runID)
+		if err != nil {
+			return err
+		}
+		if len(active) == 0 {
+			return nil
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("test quiescence deadline reached for run %s with %d active deliveries", runID, len(active))
+		}
+		timer := time.NewTimer(r.pollInterval)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return ctx.Err()
+		case <-timer.C:
+		}
+	}
+}
+
+func (r scenarioRunner) activeDeliveryRows(ctx context.Context, runID string) ([]diagnosticRunTraceRow, error) {
+	params := map[string]any{
+		"run_id": runID,
+		"limit":  200,
+		"filter": map[string]any{
+			"delivery_status": []string{"pending", "in_progress"},
+		},
+	}
+	var result diagnosticRunTraceResult
+	if err := r.client.call(ctx, "run.trace", params, &result); err != nil {
+		return nil, err
+	}
+	if err := validateDiagnosticRunTraceResult(result); err != nil {
+		return nil, err
+	}
+	if err := validateDiagnosticRunTraceSummaryRows(result.Trace); err != nil {
+		return nil, err
+	}
+	active := make([]diagnosticRunTraceRow, 0, len(result.Trace))
+	for _, row := range result.Trace {
+		switch strings.TrimSpace(row.DeliveryStatus) {
+		case "pending", "in_progress":
+			active = append(active, row)
+		}
+	}
+	return active, nil
+}
+
+func (r scenarioRunner) evaluateExpectations(ctx context.Context, runID string, expect scenarioExpect) error {
+	rows, err := r.fetchRunTraceRows(ctx, runID)
+	if err != nil {
+		return err
+	}
+	names := make([]string, 0, len(rows))
+	for _, row := range rows {
+		names = append(names, row.EventName)
+	}
+	if err := assertScenarioEventExpectations(names, expect.Events); err != nil {
+		return err
+	}
+	if expect.NoDeadLetters != nil && *expect.NoDeadLetters {
+		if err := r.assertNoDeadLetters(ctx, runID); err != nil {
+			return err
+		}
+	}
+	for _, entity := range expect.Entities {
+		if err := r.assertEntityExpectation(ctx, runID, entity); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (r scenarioRunner) fetchRunTraceRows(ctx context.Context, runID string) ([]diagnosticRunTraceRow, error) {
+	params := map[string]any{"run_id": runID, "limit": 500}
+	var out []diagnosticRunTraceRow
+	seen := map[string]struct{}{}
+	for {
+		var result diagnosticRunTraceResult
+		if err := r.client.call(ctx, "run.trace", params, &result); err != nil {
+			return nil, err
+		}
+		if err := validateDiagnosticRunTraceResult(result); err != nil {
+			return nil, err
+		}
+		out = append(out, result.Trace...)
+		cursor := strings.TrimSpace(result.NextCursor)
+		if cursor == "" {
+			return out, nil
+		}
+		if _, ok := seen[cursor]; ok {
+			return nil, fmt.Errorf("malformed run.trace result: repeated next_cursor %q", cursor)
+		}
+		seen[cursor] = struct{}{}
+		params["cursor"] = cursor
+	}
+}
+
+func assertScenarioEventExpectations(actual []string, expect scenarioEventExpect) error {
+	if len(expect.Include) > 0 {
+		for _, want := range expect.Include {
+			if !scenarioStringSliceContains(actual, want) {
+				return fmt.Errorf("expected event %s was not observed", want)
+			}
+		}
+	}
+	if len(expect.Exact) > 0 {
+		got := append([]string(nil), actual...)
+		want := append([]string(nil), expect.Exact...)
+		sort.Strings(got)
+		sort.Strings(want)
+		if strings.Join(got, "\x00") != strings.Join(want, "\x00") {
+			return fmt.Errorf("event exact expectation mismatch: got %v want %v", actual, expect.Exact)
+		}
+	}
+	if len(expect.Ordered) > 0 {
+		pos := 0
+		for _, eventName := range actual {
+			if eventName == expect.Ordered[pos] {
+				pos++
+				if pos == len(expect.Ordered) {
+					return nil
+				}
+			}
+		}
+		return fmt.Errorf("ordered event expectation %v was not observed in %v", expect.Ordered, actual)
+	}
+	return nil
+}
+
+func (r scenarioRunner) assertNoDeadLetters(ctx context.Context, runID string) error {
+	params := map[string]any{
+		"filter": map[string]any{
+			"run_id": runID,
+		},
+		"limit": 500,
+	}
+	seen := map[string]struct{}{}
+	for {
+		var result eventListResult
+		if err := r.client.call(ctx, eventObservationMethodList, params, &result); err != nil {
+			return err
+		}
+		if err := validateEventListResult(result); err != nil {
+			return err
+		}
+		for _, event := range result.Events {
+			if strings.TrimSpace(event.EventName) == "platform.dead_letter" || len(event.DeadLetters) > 0 {
+				return fmt.Errorf("expected no dead letters for run %s, found event %s", runID, event.EventID)
+			}
+			for _, delivery := range event.Deliveries {
+				if strings.TrimSpace(delivery.Status) == "dead_letter" || len(delivery.DeadLetters) > 0 {
+					return fmt.Errorf("expected no dead letters for run %s, found delivery %s on event %s", runID, delivery.DeliveryID, event.EventID)
+				}
+			}
+		}
+		cursor := strings.TrimSpace(result.NextCursor)
+		if cursor == "" {
+			return nil
+		}
+		if _, ok := seen[cursor]; ok {
+			return fmt.Errorf("malformed event.list result: repeated next_cursor %q", cursor)
+		}
+		seen[cursor] = struct{}{}
+		params["cursor"] = cursor
+	}
+}
+
+func (r scenarioRunner) assertEntityExpectation(ctx context.Context, runID string, expect scenarioEntityExpect) error {
+	params := map[string]any{
+		"run_id": runID,
+		"type":   expect.EntityType,
+		"limit":  500,
+	}
+	var result entityListResult
+	if err := r.client.call(ctx, entityListMethod, params, &result); err != nil {
+		return err
+	}
+	if err := validateEntityListResult(result); err != nil {
+		return err
+	}
+	if expect.Count != nil && len(result.Entities) != *expect.Count {
+		return fmt.Errorf("entity expectation for type %s got count %d, want %d", expect.EntityType, len(result.Entities), *expect.Count)
+	}
+	return nil
+}
+
+func scenarioStringSliceContains(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
+}
+
+func returnScenarioTestValidationError(errOut io.Writer, err error) error {
+	fmt.Fprintln(errOut, err)
+	return commandExitError{code: scenarioTestExitValidation}
+}
+
+func scenarioTestAPIErrorExitCode(err error) int {
+	var validation scenarioTestValidationError
+	if errors.As(err, &validation) {
+		return scenarioTestExitValidation
+	}
+	return cliAPIErrorExitCode(err, cliAPIErrorClassifier{
+		runtimeExit:  scenarioTestExitRuntime,
+		authExit:     scenarioTestExitAuth,
+		notFoundExit: scenarioTestExitNotFound,
+		conflictExit: scenarioTestExitRejected,
+		notFoundCodes: []string{
+			"RUN_NOT_FOUND",
+			"EVENT_NOT_FOUND",
+			"MAILBOX_NOT_FOUND",
+		},
+		conflictCodes: []string{
+			"BUNDLE_MISMATCH",
+			"BUNDLE_SCOPE_REQUIRED",
+			"BUNDLE_UNAVAILABLE",
+			"BUNDLE_DATA_INTEGRITY_ERROR",
+			"UNSUPPORTED_BUNDLE_HASH",
+			"EVENT_NOT_DECLARED",
+			"EVENT_PUBLISH_FAILED",
+			"PAYLOAD_VALIDATION_FAILED",
+			"RUN_ALREADY_TERMINAL",
+			"IDEMPOTENCY_CONFLICT",
+			"MAILBOX_ALREADY_DECIDED",
+			"MAILBOX_APPROVAL_EVENT_UNCONFIGURED",
+		},
+	})
+}

--- a/cmd/swarm/test_command.go
+++ b/cmd/swarm/test_command.go
@@ -49,6 +49,7 @@ type scenarioTestFile struct {
 
 type scenarioDocument struct {
 	Name    string
+	Seed    string
 	Vars    map[string]any
 	Steps   []scenarioStep
 	Expect  scenarioExpect
@@ -141,7 +142,7 @@ func newTestCommand(repoRoot string, opts rootCommandOptions) *cobra.Command {
 	}
 	cmd := &cobra.Command{
 		Use:   "test [scenario-file ...]",
-		Short: "Run deterministic scenario tests through public v1 API owners.",
+		Short: "Run deterministic scenario tests through public read owners.",
 		Args:  cobra.ArbitraryArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runScenarioTestCommand(cmd.Context(), repoRoot, cmd.OutOrStdout(), cmd.ErrOrStderr(), args, testOpts)
@@ -370,7 +371,11 @@ func (r scenarioRunner) runScenarioFile(ctx context.Context, file scenarioTestFi
 	if err != nil {
 		return scenarioTestValidationError{err: fmt.Errorf("%s: %w", file.Path, err)}
 	}
-	evaluator, err := newScenarioExpressionEvaluator(file.Path, doc.Vars)
+	seed, err := r.scenarioEvaluatorSeed(file, doc)
+	if err != nil {
+		return scenarioTestValidationError{err: fmt.Errorf("%s: %w", file.Path, err)}
+	}
+	evaluator, err := newScenarioExpressionEvaluator(seed, doc.Vars)
 	if err != nil {
 		return scenarioTestValidationError{err: fmt.Errorf("%s: %w", file.Path, err)}
 	}
@@ -415,7 +420,7 @@ func parseScenarioDocument(raw []byte) (scenarioDocument, error) {
 	top := mappingNode(root.Content[0])
 	for key := range top {
 		switch key {
-		case "version", "name", "vars", "steps", "expect", "invalid":
+		case "version", "name", "seed", "vars", "steps", "expect", "invalid":
 		default:
 			return scenarioDocument{}, fmt.Errorf("unsupported top-level field %q", key)
 		}
@@ -429,6 +434,9 @@ func parseScenarioDocument(raw []byte) (scenarioDocument, error) {
 	doc := scenarioDocument{Vars: map[string]any{}}
 	if node := top["name"]; node != nil {
 		doc.Name = strings.TrimSpace(fmt.Sprint(yamlNodeValue(node)))
+	}
+	if node := top["seed"]; node != nil {
+		doc.Seed = strings.TrimSpace(fmt.Sprint(yamlNodeValue(node)))
 	}
 	if node := top["vars"]; node != nil {
 		vars, ok := yamlNodeValue(node).(map[string]any)
@@ -466,6 +474,24 @@ func parseScenarioDocument(raw []byte) (scenarioDocument, error) {
 		doc.Invalid = &invalid
 	}
 	return doc, nil
+}
+
+func (r scenarioRunner) scenarioEvaluatorSeed(file scenarioTestFile, doc scenarioDocument) (string, error) {
+	rel, err := filepath.Rel(r.contractsDir, file.Path)
+	if err != nil {
+		return "", fmt.Errorf("derive scenario identity: %w", err)
+	}
+	rel = filepath.ToSlash(filepath.Clean(rel))
+	if rel == "." || strings.HasPrefix(rel, "../") || rel == ".." {
+		return "", fmt.Errorf("scenario file %s is outside contract package root", file.Path)
+	}
+	parts := []string{
+		"scenario-v1",
+		"path=" + rel,
+		"name=" + strings.TrimSpace(doc.Name),
+		"seed=" + strings.TrimSpace(doc.Seed),
+	}
+	return strings.Join(parts, "\x00"), nil
 }
 
 func parseScenarioStep(node *yaml.Node) (scenarioStep, error) {
@@ -1293,15 +1319,21 @@ func (r scenarioRunner) findMailboxID(ctx context.Context, evaluator *scenarioEx
 func (r scenarioRunner) waitForQuiescence(ctx context.Context, runID string) error {
 	deadline := time.Now().Add(r.timeout)
 	for {
-		active, err := r.activeDeliveryRows(ctx, runID)
+		quiescence, err := r.readTestQuiescence(ctx, runID)
 		if err != nil {
 			return err
 		}
-		if len(active) == 0 {
+		if boolPointerValue(quiescence.Ready) {
 			return nil
 		}
 		if time.Now().After(deadline) {
-			return fmt.Errorf("test quiescence deadline reached for run %s with %d active deliveries", runID, len(active))
+			return fmt.Errorf("test quiescence deadline reached for run %s with active_deliveries=%d unsettled_pipeline_events=%d due_timers=%d active_session_leases=%d",
+				runID,
+				intPointerValue(quiescence.ActiveDeliveries),
+				intPointerValue(quiescence.UnsettledPipelineEvents),
+				intPointerValue(quiescence.DueTimers),
+				intPointerValue(quiescence.ActiveSessionLeases),
+			)
 		}
 		timer := time.NewTimer(r.pollInterval)
 		select {
@@ -1313,32 +1345,16 @@ func (r scenarioRunner) waitForQuiescence(ctx context.Context, runID string) err
 	}
 }
 
-func (r scenarioRunner) activeDeliveryRows(ctx context.Context, runID string) ([]diagnosticRunTraceRow, error) {
-	params := map[string]any{
-		"run_id": runID,
-		"limit":  200,
-		"filter": map[string]any{
-			"delivery_status": []string{"pending", "in_progress"},
-		},
+func (r scenarioRunner) readTestQuiescence(ctx context.Context, runID string) (diagnosticRunTestQuiescence, error) {
+	params := map[string]any{"run_id": runID}
+	var result diagnosticRunDiagnosisResult
+	if err := r.client.call(ctx, "run.diagnose", params, &result); err != nil {
+		return diagnosticRunTestQuiescence{}, err
 	}
-	var result diagnosticRunTraceResult
-	if err := r.client.call(ctx, "run.trace", params, &result); err != nil {
-		return nil, err
+	if err := validateDiagnosticRunDiagnosis(result); err != nil {
+		return diagnosticRunTestQuiescence{}, err
 	}
-	if err := validateDiagnosticRunTraceResult(result); err != nil {
-		return nil, err
-	}
-	if err := validateDiagnosticRunTraceSummaryRows(result.Trace); err != nil {
-		return nil, err
-	}
-	active := make([]diagnosticRunTraceRow, 0, len(result.Trace))
-	for _, row := range result.Trace {
-		switch strings.TrimSpace(row.DeliveryStatus) {
-		case "pending", "in_progress":
-			active = append(active, row)
-		}
-	}
-	return active, nil
+	return *result.TestQuiescence, nil
 }
 
 func (r scenarioRunner) evaluateExpectations(ctx context.Context, runID string, expect scenarioExpect) error {
@@ -1481,15 +1497,29 @@ func (r scenarioRunner) assertEntityExpectation(ctx context.Context, runID strin
 		"type":   expect.EntityType,
 		"limit":  500,
 	}
-	var result entityListResult
-	if err := r.client.call(ctx, entityListMethod, params, &result); err != nil {
-		return err
+	count := 0
+	seen := map[string]struct{}{}
+	for {
+		var result entityListResult
+		if err := r.client.call(ctx, entityListMethod, params, &result); err != nil {
+			return err
+		}
+		if err := validateEntityListResult(result); err != nil {
+			return err
+		}
+		count += len(result.Entities)
+		cursor := strings.TrimSpace(result.NextCursor)
+		if cursor == "" {
+			break
+		}
+		if _, ok := seen[cursor]; ok {
+			return fmt.Errorf("malformed entity.list result: repeated next_cursor %q", cursor)
+		}
+		seen[cursor] = struct{}{}
+		params["cursor"] = cursor
 	}
-	if err := validateEntityListResult(result); err != nil {
-		return err
-	}
-	if expect.Count != nil && len(result.Entities) != *expect.Count {
-		return fmt.Errorf("entity expectation for type %s got count %d, want %d", expect.EntityType, len(result.Entities), *expect.Count)
+	if expect.Count != nil && count != *expect.Count {
+		return fmt.Errorf("entity expectation for type %s got count %d, want %d", expect.EntityType, count, *expect.Count)
 	}
 	return nil
 }

--- a/cmd/swarm/test_command.go
+++ b/cmd/swarm/test_command.go
@@ -1089,7 +1089,18 @@ func (r scenarioRunner) loadFixturePayload(scenarioPath, rawPath string) (map[st
 	if !pathWithin(r.contractsDir, abs) {
 		return nil, fmt.Errorf("payload.from %s escapes contract package root", rawPath)
 	}
-	raw, err := os.ReadFile(abs)
+	realContractsDir, err := filepath.EvalSymlinks(r.contractsDir)
+	if err != nil {
+		return nil, fmt.Errorf("resolve contract package root: %w", err)
+	}
+	realPath, err := filepath.EvalSymlinks(abs)
+	if err != nil {
+		return nil, fmt.Errorf("resolve payload.from %s: %w", rawPath, err)
+	}
+	if !pathWithin(realContractsDir, realPath) {
+		return nil, fmt.Errorf("payload.from %s escapes contract package root", rawPath)
+	}
+	raw, err := os.ReadFile(realPath)
 	if err != nil {
 		return nil, fmt.Errorf("read payload.from %s: %w", rawPath, err)
 	}
@@ -1179,11 +1190,7 @@ func (r scenarioRunner) runMailboxStep(ctx context.Context, evaluator *scenarioE
 	if state.RunID == "" {
 		return fmt.Errorf("%s requires an existing run context", step.Action)
 	}
-	mailboxID, err := r.findMailboxID(ctx, evaluator, state.RunID, step.Match)
-	if err != nil {
-		return err
-	}
-	params := map[string]any{"mailbox_id": mailboxID}
+	params := map[string]any{}
 	if key, err := evaluator.evalValue(step.IdempotencyKey); err != nil {
 		return fmt.Errorf("idempotency_key: %w", err)
 	} else if text := optionalScenarioString(key); text != "" {
@@ -1193,39 +1200,44 @@ func (r scenarioRunner) runMailboxStep(ctx context.Context, evaluator *scenarioE
 	case "mailbox.approve":
 		payload, err := evaluator.evalValue(step.Payload)
 		if err != nil {
-			return fmt.Errorf("payload: %w", err)
+			return scenarioTestValidationError{err: fmt.Errorf("payload: %w", err)}
 		}
 		if payload != nil {
 			m, ok := payload.(map[string]any)
 			if !ok {
-				return fmt.Errorf("mailbox.approve payload must be an object")
+				return scenarioTestValidationError{err: fmt.Errorf("mailbox.approve payload must be an object")}
 			}
 			params["decision_payload"] = m
 		}
 	case "mailbox.reject":
 		reason, err := evaluator.evalValue(step.Reason)
 		if err != nil {
-			return fmt.Errorf("reason: %w", err)
+			return scenarioTestValidationError{err: fmt.Errorf("reason: %w", err)}
 		}
-		text := strings.TrimSpace(fmt.Sprint(reason))
+		text := optionalScenarioString(reason)
 		if text == "" {
-			return fmt.Errorf("mailbox.reject reason is required")
+			return scenarioTestValidationError{err: fmt.Errorf("mailbox.reject reason is required")}
 		}
 		params["reason"] = text
 	case "mailbox.defer":
 		until, err := evaluator.evalValue(step.Until)
 		if err != nil {
-			return fmt.Errorf("until: %w", err)
+			return scenarioTestValidationError{err: fmt.Errorf("until: %w", err)}
 		}
-		text := strings.TrimSpace(fmt.Sprint(until))
+		text := optionalScenarioString(until)
 		if text == "" {
-			return fmt.Errorf("mailbox.defer until is required")
+			return scenarioTestValidationError{err: fmt.Errorf("mailbox.defer until is required")}
 		}
 		if _, err := time.Parse(time.RFC3339, text); err != nil {
-			return fmt.Errorf("mailbox.defer until must be RFC3339: %w", err)
+			return scenarioTestValidationError{err: fmt.Errorf("mailbox.defer until must be RFC3339: %w", err)}
 		}
 		params["until"] = text
 	}
+	mailboxID, err := r.findMailboxID(ctx, evaluator, state.RunID, step.Match)
+	if err != nil {
+		return err
+	}
+	params["mailbox_id"] = mailboxID
 	var result mailboxDecisionResult
 	if err := r.client.call(ctx, step.Action, params, &result); err != nil {
 		return err
@@ -1334,10 +1346,7 @@ func (r scenarioRunner) evaluateExpectations(ctx context.Context, runID string, 
 	if err != nil {
 		return err
 	}
-	names := make([]string, 0, len(rows))
-	for _, row := range rows {
-		names = append(names, row.EventName)
-	}
+	names := uniqueScenarioTraceEventNames(rows)
 	if err := assertScenarioEventExpectations(names, expect.Events); err != nil {
 		return err
 	}
@@ -1352,6 +1361,23 @@ func (r scenarioRunner) evaluateExpectations(ctx context.Context, runID string, 
 		}
 	}
 	return nil
+}
+
+func uniqueScenarioTraceEventNames(rows []diagnosticRunTraceRow) []string {
+	names := make([]string, 0, len(rows))
+	seen := map[string]struct{}{}
+	for _, row := range rows {
+		eventID := strings.TrimSpace(row.EventID)
+		if eventID == "" {
+			eventID = strings.TrimSpace(row.EventName)
+		}
+		if _, ok := seen[eventID]; ok {
+			continue
+		}
+		seen[eventID] = struct{}{}
+		names = append(names, row.EventName)
+	}
+	return names
 }
 
 func (r scenarioRunner) fetchRunTraceRows(ctx context.Context, runID string) ([]diagnosticRunTraceRow, error) {

--- a/cmd/swarm/test_command_test.go
+++ b/cmd/swarm/test_command_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"path/filepath"
 	"reflect"
 	"strings"
@@ -156,6 +157,54 @@ steps:
 	}
 }
 
+func TestSwarmTestRejectsSymlinkFixtureEscapeBeforePublish(t *testing.T) {
+	isolateCLIAPIConfigEnv(t)
+	setCLIAPITestToken(t, "test-token")
+	contractsPath := writeServedEventPublishFollowUpFixture(t)
+	outside := filepath.Join(t.TempDir(), "outside.yaml")
+	writeWorkflowValidationFixtureFile(t, outside, `
+amount: 7
+who: outside
+`)
+	fixtureDir := filepath.Join(contractsPath, "tests", "fixtures")
+	if err := os.MkdirAll(fixtureDir, 0o755); err != nil {
+		t.Fatalf("mkdir fixture dir: %v", err)
+	}
+	if err := os.Symlink(outside, filepath.Join(fixtureDir, "outside.yaml")); err != nil {
+		t.Skipf("symlink unsupported: %v", err)
+	}
+	writeWorkflowValidationFixtureFile(t, filepath.Join(contractsPath, "tests", "symlink-escape.yaml"), `
+name: symlink escape
+steps:
+  - publish: thing.created
+    payload:
+      from: fixtures/outside.yaml
+`)
+	var called bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		writeJSONRPCResult(t, w, "unexpected", map[string]any{})
+	}))
+	defer server.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), repoRoot(), []string{
+		"test",
+		filepath.Join(contractsPath, "tests", "symlink-escape.yaml"),
+		"--contracts", contractsPath,
+		"--platform-spec", defaultPlatformSpecPath,
+	}, &stdout, &stderr, testRootCommandOptions(server))
+	if code != scenarioTestExitValidation {
+		t.Fatalf("code = %d, want %d stdout=%s stderr=%s", code, scenarioTestExitValidation, stdout.String(), stderr.String())
+	}
+	if called {
+		t.Fatal("event.publish API was called for symlink-escaped fixture")
+	}
+	if !strings.Contains(stderr.String(), "escapes contract package root") {
+		t.Fatalf("stderr = %q, want contract-root escape failure", stderr.String())
+	}
+}
+
 func TestSwarmTestMailboxApproveFindsExactlyOneThenMutates(t *testing.T) {
 	isolateCLIAPIConfigEnv(t)
 	setCLIAPITestToken(t, "test-token")
@@ -231,6 +280,55 @@ steps:
 	})
 }
 
+func TestSwarmTestMailboxRejectMissingReasonFailsBeforeMailboxLookup(t *testing.T) {
+	isolateCLIAPIConfigEnv(t)
+	setCLIAPITestToken(t, "test-token")
+	contractsPath := writeServedEventPublishFollowUpFixture(t)
+	writeWorkflowValidationFixtureFile(t, filepath.Join(contractsPath, "tests", "mailbox-reject-missing-reason.yaml"), `
+name: mailbox reject missing reason
+steps:
+  - publish: thing.created
+    payload: {amount: 7, who: operator}
+  - mailbox.reject:
+      match:
+        type: review_request
+`)
+	var calls []jsonRPCRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req jsonRPCRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Errorf("decode request: %v", err)
+		}
+		calls = append(calls, req)
+		switch req.Method {
+		case eventPublishMethod:
+			writeJSONRPCResult(t, w, req.ID, eventPublishTestResult(true))
+		case "run.trace":
+			writeJSONRPCResult(t, w, req.ID, map[string]any{"trace": []any{}})
+		default:
+			t.Fatalf("unexpected method before reject validation = %s", req.Method)
+		}
+	}))
+	defer server.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), repoRoot(), []string{
+		"test",
+		filepath.Join(contractsPath, "tests", "mailbox-reject-missing-reason.yaml"),
+		"--contracts", contractsPath,
+		"--platform-spec", defaultPlatformSpecPath,
+		"--timeout", "2s",
+		"--poll-interval", "10ms",
+	}, &stdout, &stderr, testRootCommandOptions(server))
+	if code != scenarioTestExitValidation {
+		t.Fatalf("code = %d, want %d stdout=%s stderr=%s", code, scenarioTestExitValidation, stdout.String(), stderr.String())
+	}
+	assertScenarioTestMethods(t, calls, []string{eventPublishMethod, "run.trace"})
+	if !strings.Contains(stderr.String(), "mailbox.reject reason is required") {
+		t.Fatalf("stderr = %q, want reject reason validation failure", stderr.String())
+	}
+}
+
 func TestSwarmTestServedSQLiteNoLiveLLMProof(t *testing.T) {
 	unsetStoreSelectorEnv(t)
 	stubServeRuntimeWorkspaceLifecycle(t)
@@ -264,6 +362,24 @@ func TestSwarmTestServedSQLiteNoLiveLLMProof(t *testing.T) {
 	}
 	if !strings.Contains(stdout.String(), "swarm test ok: scenarios=1") {
 		t.Fatalf("stdout missing success:\n%s", stdout.String())
+	}
+}
+
+func TestScenarioEventExpectationsDeduplicateRunTraceDeliveryRows(t *testing.T) {
+	rows := []diagnosticRunTraceRow{
+		{EventID: "event-1", EventName: "thing.created", DeliveryID: "delivery-1"},
+		{EventID: "event-1", EventName: "thing.created", DeliveryID: "delivery-2"},
+		{EventID: "event-2", EventName: "thing.done", DeliveryID: "delivery-3"},
+	}
+	names := uniqueScenarioTraceEventNames(rows)
+	if got := strings.Join(names, ","); got != "thing.created,thing.done" {
+		t.Fatalf("unique names = %q", got)
+	}
+	if err := assertScenarioEventExpectations(names, scenarioEventExpect{
+		Exact:   []string{"thing.created", "thing.done"},
+		Ordered: []string{"thing.created", "thing.done"},
+	}); err != nil {
+		t.Fatalf("event expectations over deduplicated trace rows failed: %v", err)
 	}
 }
 

--- a/cmd/swarm/test_command_test.go
+++ b/cmd/swarm/test_command_test.go
@@ -1,0 +1,341 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	storebackend "github.com/division-sh/swarm/internal/store/backendselection"
+)
+
+func TestSwarmTestRunsScenarioThroughPublicRPC(t *testing.T) {
+	isolateCLIAPIConfigEnv(t)
+	setCLIAPITestToken(t, "test-token")
+	contractsPath := writeScenarioRunnerFixture(t)
+	bundleHash := servedEventPublishFixtureBundleHash(t, contractsPath)
+
+	var calls []jsonRPCRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/rpc" {
+			t.Errorf("path = %q, want /v1/rpc", r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer test-token" {
+			t.Errorf("Authorization = %q, want bearer token", got)
+		}
+		var req jsonRPCRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Errorf("decode request: %v", err)
+		}
+		calls = append(calls, req)
+		switch req.Method {
+		case eventPublishMethod:
+			if req.Params["event_name"] != "thing.created" || req.Params["bundle_hash"] != bundleHash || req.Params["idempotency_key"] != scenarioSHA40("empire-cost-router") {
+				t.Fatalf("event.publish params = %#v", req.Params)
+			}
+			payload, ok := req.Params["payload"].(map[string]any)
+			if !ok || payload["who"] != "operator" || !numberEquals(payload["amount"], 7) {
+				t.Fatalf("event.publish payload = %#v", req.Params["payload"])
+			}
+			writeJSONRPCResult(t, w, req.ID, eventPublishTestResult(true))
+		case "run.trace":
+			if _, ok := req.Params["filter"]; ok {
+				writeJSONRPCResult(t, w, req.ID, map[string]any{"trace": []any{}})
+				return
+			}
+			row := validRunCommandTraceRow("event-1")
+			row["event_name"] = "thing.created"
+			writeJSONRPCResult(t, w, req.ID, map[string]any{"trace": []map[string]any{row}})
+		case eventObservationMethodList:
+			writeJSONRPCResult(t, w, req.ID, map[string]any{"events": []any{}})
+		case entityListMethod:
+			entity := validEntitySummary("entity-1")
+			entity["entity_type"] = "widget"
+			writeJSONRPCResult(t, w, req.ID, map[string]any{"entities": []map[string]any{entity}})
+		default:
+			t.Fatalf("unexpected method = %s", req.Method)
+		}
+	}))
+	defer server.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), repoRoot(), []string{
+		"test",
+		"--contracts", contractsPath,
+		"--platform-spec", defaultPlatformSpecPath,
+		"--timeout", "2s",
+		"--poll-interval", "10ms",
+	}, &stdout, &stderr, testRootCommandOptions(server))
+	if code != 0 {
+		t.Fatalf("code = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	assertScenarioTestMethods(t, calls, []string{
+		eventPublishMethod,
+		"run.trace",
+		"run.trace",
+		"run.trace",
+		eventObservationMethodList,
+		entityListMethod,
+	})
+	for _, want := range []string{"scenario ok:", "swarm test ok: scenarios=1"} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("stdout missing %q:\n%s", want, stdout.String())
+		}
+	}
+	if strings.TrimSpace(stderr.String()) != "" {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+}
+
+func TestSwarmTestRejectsInvalidFixtureSchemaBeforePublish(t *testing.T) {
+	isolateCLIAPIConfigEnv(t)
+	setCLIAPITestToken(t, "test-token")
+	contractsPath := writeServedEventPublishFollowUpFixture(t)
+	writeWorkflowValidationFixtureFile(t, filepath.Join(contractsPath, "tests", "invalid-type.yaml"), `
+name: invalid type fixture
+steps:
+  - publish: thing.created
+    payload:
+      amount: not-an-integer
+      who: operator
+`)
+	var called bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		writeJSONRPCResult(t, w, "unexpected", map[string]any{})
+	}))
+	defer server.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), repoRoot(), []string{
+		"test",
+		filepath.Join(contractsPath, "tests", "invalid-type.yaml"),
+		"--contracts", contractsPath,
+		"--platform-spec", defaultPlatformSpecPath,
+	}, &stdout, &stderr, testRootCommandOptions(server))
+	if code != scenarioTestExitValidation {
+		t.Fatalf("code = %d, want %d stdout=%s stderr=%s", code, scenarioTestExitValidation, stdout.String(), stderr.String())
+	}
+	if called {
+		t.Fatal("event.publish API was called for schema-invalid fixture")
+	}
+	if !strings.Contains(stderr.String(), "amount must be integer") {
+		t.Fatalf("stderr = %q, want integer schema failure", stderr.String())
+	}
+}
+
+func TestSwarmTestRejectsScenariosOutsideSupportedRoots(t *testing.T) {
+	isolateCLIAPIConfigEnv(t)
+	setCLIAPITestToken(t, "test-token")
+	contractsPath := writeServedEventPublishFollowUpFixture(t)
+	outside := filepath.Join(contractsPath, "private.yaml")
+	writeWorkflowValidationFixtureFile(t, outside, `
+name: private scenario
+steps:
+  - publish: thing.created
+    payload: {amount: 7, who: operator}
+`)
+
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), repoRoot(), []string{
+		"test",
+		outside,
+		"--contracts", contractsPath,
+		"--platform-spec", defaultPlatformSpecPath,
+	}, &stdout, &stderr, defaultRootCommandOptions())
+	if code != scenarioTestExitValidation {
+		t.Fatalf("code = %d, want %d stdout=%s stderr=%s", code, scenarioTestExitValidation, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "outside supported roots") {
+		t.Fatalf("stderr = %q, want supported-root failure", stderr.String())
+	}
+}
+
+func TestSwarmTestMailboxApproveFindsExactlyOneThenMutates(t *testing.T) {
+	isolateCLIAPIConfigEnv(t)
+	setCLIAPITestToken(t, "test-token")
+	contractsPath := writeServedEventPublishFollowUpFixture(t)
+	writeWorkflowValidationFixtureFile(t, filepath.Join(contractsPath, "tests", "mailbox.yaml"), `
+name: mailbox scenario
+steps:
+  - publish: thing.created
+    payload: {amount: 7, who: operator}
+  - mailbox.approve:
+      match:
+        type: review_request
+      payload:
+        approved: true
+`)
+	var calls []jsonRPCRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req jsonRPCRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Errorf("decode request: %v", err)
+		}
+		calls = append(calls, req)
+		switch req.Method {
+		case eventPublishMethod:
+			writeJSONRPCResult(t, w, req.ID, eventPublishTestResult(true))
+		case "run.trace":
+			writeJSONRPCResult(t, w, req.ID, map[string]any{"trace": []any{}})
+		case "mailbox.list":
+			writeJSONRPCResult(t, w, req.ID, map[string]any{"items": []map[string]any{mailboxItemResult("mailbox-1", "pending", "normal")}})
+		case "mailbox.approve":
+			want := map[string]any{
+				"mailbox_id":       "mailbox-1",
+				"decision_payload": map[string]any{"approved": true},
+			}
+			if !reflect.DeepEqual(req.Params, want) {
+				t.Fatalf("mailbox.approve params = %#v, want %#v", req.Params, want)
+			}
+			writeJSONRPCResult(t, w, req.ID, map[string]any{
+				"ok":                           true,
+				"mailbox_decision_id":          "decision-1",
+				"status":                       "decided",
+				"idempotency_replayed":         false,
+				"downstream_event_id":          "event-2",
+				"downstream_event_name":        "thing.reviewed",
+				"downstream_subscribers":       []string{},
+				"downstream_subscriber_source": "none",
+			})
+		default:
+			t.Fatalf("unexpected method = %s", req.Method)
+		}
+	}))
+	defer server.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), repoRoot(), []string{
+		"test",
+		filepath.Join(contractsPath, "tests", "mailbox.yaml"),
+		"--contracts", contractsPath,
+		"--platform-spec", defaultPlatformSpecPath,
+		"--timeout", "2s",
+		"--poll-interval", "10ms",
+	}, &stdout, &stderr, testRootCommandOptions(server))
+	if code != 0 {
+		t.Fatalf("code = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	assertScenarioTestMethods(t, calls, []string{
+		eventPublishMethod,
+		"run.trace",
+		"mailbox.list",
+		"mailbox.approve",
+		"run.trace",
+		"run.trace",
+	})
+}
+
+func TestSwarmTestServedSQLiteNoLiveLLMProof(t *testing.T) {
+	unsetStoreSelectorEnv(t)
+	stubServeRuntimeWorkspaceLifecycle(t)
+	sqlitePath := filepath.Join(t.TempDir(), ".swarm", "dev.db")
+	t.Setenv(storebackend.EnvSQLitePath, sqlitePath)
+	contractsPath := writeScenarioRunnerFixture(t)
+	endpoint, _ := startServedEventPublishFollowUpRuntime(t, serveOptions{
+		ConfigPath:              writeServeRuntimeTestConfig(t),
+		ContractsPath:           contractsPath,
+		PlatformSpecPath:        defaultPlatformSpecPath,
+		APIListenAddr:           "127.0.0.1:0",
+		MCPListenAddr:           "127.0.0.1:0",
+		SelfCheck:               true,
+		RequireBundleMatch:      false,
+		NoRequireBundleMatch:    true,
+		Verbose:                 true,
+		TestOutboxSweeperConfig: servedEventPublishProofOutboxSweeperConfig(),
+	})
+
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), repoRoot(), []string{
+		"test",
+		"--contracts", contractsPath,
+		"--platform-spec", defaultPlatformSpecPath,
+		"--api-server", strings.TrimSuffix(endpoint, "/v1/rpc"),
+		"--timeout", "10s",
+		"--poll-interval", "25ms",
+	}, &stdout, &stderr, defaultRootCommandOptions())
+	if code != 0 {
+		t.Fatalf("code = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	if !strings.Contains(stdout.String(), "swarm test ok: scenarios=1") {
+		t.Fatalf("stdout missing success:\n%s", stdout.String())
+	}
+}
+
+func writeScenarioRunnerFixture(t *testing.T) string {
+	t.Helper()
+	contractsPath := writeServedEventPublishFollowUpFixture(t)
+	writeWorkflowValidationFixtureFile(t, filepath.Join(contractsPath, "tests", "fixtures", "thing-created.yaml"), `
+amount: 7
+who: fixture
+`)
+	writeWorkflowValidationFixtureFile(t, filepath.Join(contractsPath, "tests", "empire-routing.yaml"), `
+name: empire-style deterministic routing
+vars:
+  who: operator
+steps:
+  - publish: thing.created
+    idempotency_key: ${scenario.sha40("empire-cost-router")}
+    payload:
+      from: fixtures/thing-created.yaml
+      set:
+        who: ${vars.who}
+        amount: 7
+invalid:
+  base:
+    publish: thing.created
+    payload:
+      from: fixtures/thing-created.yaml
+  cases:
+    - name: invalid-amount
+      set:
+        payload.amount: not-an-integer
+      expect: reject
+expect:
+  events:
+    include: [thing.created]
+  no_dead_letters: true
+  entities:
+    - type: widget
+      count: 1
+`)
+	return contractsPath
+}
+
+func assertScenarioTestMethods(t *testing.T, calls []jsonRPCRequest, want []string) {
+	t.Helper()
+	if len(calls) != len(want) {
+		t.Fatalf("methods = %v, want %v", scenarioTestMethodNames(calls), want)
+	}
+	for i, req := range calls {
+		if req.Method != want[i] {
+			t.Fatalf("method[%d] = %q, want %q; all=%v", i, req.Method, want[i], scenarioTestMethodNames(calls))
+		}
+	}
+}
+
+func scenarioTestMethodNames(calls []jsonRPCRequest) []string {
+	out := make([]string, 0, len(calls))
+	for _, req := range calls {
+		out = append(out, req.Method)
+	}
+	return out
+}
+
+func numberEquals(value any, want int) bool {
+	switch typed := value.(type) {
+	case int:
+		return typed == want
+	case int64:
+		return typed == int64(want)
+	case float64:
+		return typed == float64(want)
+	default:
+		return false
+	}
+}

--- a/cmd/swarm/test_command_test.go
+++ b/cmd/swarm/test_command_test.go
@@ -44,11 +44,9 @@ func TestSwarmTestRunsScenarioThroughPublicRPC(t *testing.T) {
 				t.Fatalf("event.publish payload = %#v", req.Params["payload"])
 			}
 			writeJSONRPCResult(t, w, req.ID, eventPublishTestResult(true))
+		case "run.diagnose":
+			writeJSONRPCResult(t, w, req.ID, scenarioRunDiagnoseTestResult("run-1", true))
 		case "run.trace":
-			if _, ok := req.Params["filter"]; ok {
-				writeJSONRPCResult(t, w, req.ID, map[string]any{"trace": []any{}})
-				return
-			}
 			row := validRunCommandTraceRow("event-1")
 			row["event_name"] = "thing.created"
 			writeJSONRPCResult(t, w, req.ID, map[string]any{"trace": []map[string]any{row}})
@@ -77,8 +75,8 @@ func TestSwarmTestRunsScenarioThroughPublicRPC(t *testing.T) {
 	}
 	assertScenarioTestMethods(t, calls, []string{
 		eventPublishMethod,
-		"run.trace",
-		"run.trace",
+		"run.diagnose",
+		"run.diagnose",
 		"run.trace",
 		eventObservationMethodList,
 		entityListMethod,
@@ -230,8 +228,8 @@ steps:
 		switch req.Method {
 		case eventPublishMethod:
 			writeJSONRPCResult(t, w, req.ID, eventPublishTestResult(true))
-		case "run.trace":
-			writeJSONRPCResult(t, w, req.ID, map[string]any{"trace": []any{}})
+		case "run.diagnose":
+			writeJSONRPCResult(t, w, req.ID, scenarioRunDiagnoseTestResult("run-1", true))
 		case "mailbox.list":
 			writeJSONRPCResult(t, w, req.ID, map[string]any{"items": []map[string]any{mailboxItemResult("mailbox-1", "pending", "normal")}})
 		case "mailbox.approve":
@@ -272,11 +270,11 @@ steps:
 	}
 	assertScenarioTestMethods(t, calls, []string{
 		eventPublishMethod,
-		"run.trace",
+		"run.diagnose",
 		"mailbox.list",
 		"mailbox.approve",
-		"run.trace",
-		"run.trace",
+		"run.diagnose",
+		"run.diagnose",
 	})
 }
 
@@ -303,8 +301,8 @@ steps:
 		switch req.Method {
 		case eventPublishMethod:
 			writeJSONRPCResult(t, w, req.ID, eventPublishTestResult(true))
-		case "run.trace":
-			writeJSONRPCResult(t, w, req.ID, map[string]any{"trace": []any{}})
+		case "run.diagnose":
+			writeJSONRPCResult(t, w, req.ID, scenarioRunDiagnoseTestResult("run-1", true))
 		default:
 			t.Fatalf("unexpected method before reject validation = %s", req.Method)
 		}
@@ -323,7 +321,7 @@ steps:
 	if code != scenarioTestExitValidation {
 		t.Fatalf("code = %d, want %d stdout=%s stderr=%s", code, scenarioTestExitValidation, stdout.String(), stderr.String())
 	}
-	assertScenarioTestMethods(t, calls, []string{eventPublishMethod, "run.trace"})
+	assertScenarioTestMethods(t, calls, []string{eventPublishMethod, "run.diagnose"})
 	if !strings.Contains(stderr.String(), "mailbox.reject reason is required") {
 		t.Fatalf("stderr = %q, want reject reason validation failure", stderr.String())
 	}
@@ -383,6 +381,79 @@ func TestScenarioEventExpectationsDeduplicateRunTraceDeliveryRows(t *testing.T) 
 	}
 }
 
+func TestScenarioEvaluatorSeedIsContractRelativeAndRecorded(t *testing.T) {
+	rootA := t.TempDir()
+	rootB := t.TempDir()
+	fileA := scenarioTestFile{Path: filepath.Join(rootA, "tests", "same.yaml")}
+	fileB := scenarioTestFile{Path: filepath.Join(rootB, "tests", "same.yaml")}
+	doc := scenarioDocument{Name: "portable", Seed: "recorded-seed"}
+	seedA, err := (scenarioRunner{contractsDir: rootA}).scenarioEvaluatorSeed(fileA, doc)
+	if err != nil {
+		t.Fatalf("seed A: %v", err)
+	}
+	seedB, err := (scenarioRunner{contractsDir: rootB}).scenarioEvaluatorSeed(fileB, doc)
+	if err != nil {
+		t.Fatalf("seed B: %v", err)
+	}
+	if seedA != seedB {
+		t.Fatalf("seed differs across absolute roots:\nA=%q\nB=%q", seedA, seedB)
+	}
+	evalA, err := newScenarioExpressionEvaluator(seedA, nil)
+	if err != nil {
+		t.Fatalf("evaluator A: %v", err)
+	}
+	evalB, err := newScenarioExpressionEvaluator(seedB, nil)
+	if err != nil {
+		t.Fatalf("evaluator B: %v", err)
+	}
+	idA, err := evalA.evalExpression(`scenario.uuid("publish")`)
+	if err != nil {
+		t.Fatalf("uuid A: %v", err)
+	}
+	idB, err := evalB.evalExpression(`scenario.uuid("publish")`)
+	if err != nil {
+		t.Fatalf("uuid B: %v", err)
+	}
+	if idA != idB {
+		t.Fatalf("uuid differs across absolute roots: %v vs %v", idA, idB)
+	}
+}
+
+func TestScenarioEntityExpectationConsumesAllPages(t *testing.T) {
+	var calls []jsonRPCRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req jsonRPCRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Errorf("decode request: %v", err)
+		}
+		calls = append(calls, req)
+		entity := validEntitySummary("entity-1")
+		entity["entity_type"] = "widget"
+		switch len(calls) {
+		case 1:
+			writeJSONRPCResult(t, w, req.ID, map[string]any{"entities": []map[string]any{entity}, "next_cursor": "page-2"})
+		case 2:
+			entity["entity_id"] = "entity-2"
+			writeJSONRPCResult(t, w, req.ID, map[string]any{"entities": []map[string]any{entity}})
+		default:
+			t.Fatalf("unexpected extra request %#v", req)
+		}
+	}))
+	defer server.Close()
+	client, err := newCLIAPIClient(rootCommandOptions{apiServer: strings.TrimSuffix(server.URL, "/")})
+	if err != nil {
+		t.Fatalf("client: %v", err)
+	}
+	runner := scenarioRunner{client: client}
+	if err := runner.assertEntityExpectation(context.Background(), "run-1", scenarioEntityExpect{EntityType: "widget", Count: intPtr(2)}); err != nil {
+		t.Fatalf("entity expectation: %v", err)
+	}
+	assertScenarioTestMethods(t, calls, []string{entityListMethod, entityListMethod})
+	if calls[1].Params["cursor"] != "page-2" {
+		t.Fatalf("second entity.list cursor = %#v", calls[1].Params)
+	}
+}
+
 func writeScenarioRunnerFixture(t *testing.T) string {
 	t.Helper()
 	contractsPath := writeServedEventPublishFollowUpFixture(t)
@@ -421,6 +492,32 @@ expect:
       count: 1
 `)
 	return contractsPath
+}
+
+func scenarioRunDiagnoseTestResult(runID string, ready bool) map[string]any {
+	activeDeliveries := 0
+	if !ready {
+		activeDeliveries = 1
+	}
+	return map[string]any{
+		"run":               validDiagnosticRunHeader(runID),
+		"operational_state": "running",
+		"blocking_layer":    "",
+		"blocking_reason":   "",
+		"heuristics":        []string{},
+		"failed_deliveries": []any{},
+		"test_quiescence": map[string]any{
+			"ready":                     ready,
+			"active_deliveries":         activeDeliveries,
+			"unsettled_pipeline_events": 0,
+			"due_timers":                0,
+			"active_session_leases":     0,
+		},
+	}
+}
+
+func intPtr(value int) *int {
+	return &value
 }
 
 func assertScenarioTestMethods(t *testing.T, calls []jsonRPCRequest, want []string) {

--- a/internal/apispec/platform_spec_source_refs_test.go
+++ b/internal/apispec/platform_spec_source_refs_test.go
@@ -83,18 +83,37 @@ func TestPlatformSpecDeterministicScenarioRunnerSourceAuthority(t *testing.T) {
 	testSpec := mustMappingValue(t, root, "test_specification")
 	runner := mustMappingValue(t, testSpec, "deterministic_scenario_runner")
 
-	if got := scalarValue(mappingValue(runner, "implementation_status")); got != "source_authority_only" {
-		t.Fatalf("deterministic scenario runner implementation_status = %q, want source_authority_only", got)
+	if got := scalarValue(mappingValue(runner, "implementation_status")); got != "implemented_first_slice" {
+		t.Fatalf("deterministic scenario runner implementation_status = %q, want implemented_first_slice", got)
 	}
 
 	selectedSurface := mustMappingValue(t, runner, "selected_public_surface")
 	if got := scalarValue(mappingValue(selectedSurface, "command_family")); got != "swarm test" {
 		t.Fatalf("deterministic scenario runner command_family = %q, want swarm test", got)
 	}
+	commandStatus := scalarValue(mappingValue(selectedSurface, "command_catalog_status"))
+	for _, want := range []string{"implemented first-slice", "cli_specification.command_catalog"} {
+		if !strings.Contains(commandStatus, want) {
+			t.Fatalf("deterministic scenario runner command_catalog_status missing %q:\n%s", want, commandStatus)
+		}
+	}
 
 	sourceAuthority := mustMappingValue(t, runner, "source_authority")
 	if got := scalarValue(mappingValue(sourceAuthority, "merge_bearing_owner")); got != "platform-spec.yaml" {
 		t.Fatalf("deterministic scenario runner merge_bearing_owner = %q, want platform-spec.yaml", got)
+	}
+
+	cli := mustMappingValue(t, root, "cli_specification")
+	commandCatalog := mustMappingValue(t, cli, "command_catalog")
+	testCommand := mustMappingValue(t, commandCatalog, "test")
+	if got := scalarValue(mappingValue(testCommand, "command")); !strings.Contains(got, "swarm test") {
+		t.Fatalf("cli command_catalog.test.command = %q, want swarm test", got)
+	}
+	if got := scalarValue(mappingValue(testCommand, "implementation_status")); got != "implemented_first_slice" {
+		t.Fatalf("cli command_catalog.test.implementation_status = %q, want implemented_first_slice", got)
+	}
+	if got := scalarValue(mappingValue(testCommand, "owner")); got != "platform-spec.yaml#test_specification.deterministic_scenario_runner" {
+		t.Fatalf("cli command_catalog.test.owner = %q", got)
 	}
 	consumedOwners := mustMappingValue(t, sourceAuthority, "consumed_owners")
 	for _, key := range []string{

--- a/internal/apispec/spec_test.go
+++ b/internal/apispec/spec_test.go
@@ -20,8 +20,8 @@ func TestPlatformAPISpecValidationCoverage(t *testing.T) {
 	if report.MethodCount != 58 {
 		t.Fatalf("method count = %d, want 58", report.MethodCount)
 	}
-	if report.SchemaCount != 109 {
-		t.Fatalf("schema count = %d, want 109", report.SchemaCount)
+	if report.SchemaCount != 110 {
+		t.Fatalf("schema count = %d, want 110", report.SchemaCount)
 	}
 	if report.ErrorCodeCount != 39 {
 		t.Fatalf("error code count = %d, want 39", report.ErrorCodeCount)
@@ -83,8 +83,8 @@ func TestGeneratedOpenRPCArtifactMatchesPlatformSpec(t *testing.T) {
 	if len(doc.Methods) != 58 {
 		t.Fatalf("generated OpenRPC methods = %d, want 58", len(doc.Methods))
 	}
-	if len(doc.Components.Schemas) != 109 {
-		t.Fatalf("generated OpenRPC schemas = %d, want 109", len(doc.Components.Schemas))
+	if len(doc.Components.Schemas) != 110 {
+		t.Fatalf("generated OpenRPC schemas = %d, want 110", len(doc.Components.Schemas))
 	}
 	if len(doc.Components.Errors) != 39 {
 		t.Fatalf("generated OpenRPC errors = %d, want 39", len(doc.Components.Errors))

--- a/internal/apiv1/handler_test.go
+++ b/internal/apiv1/handler_test.go
@@ -449,6 +449,10 @@ func TestOperatorReadHandlersExposeHealthAndRunReadMethods(t *testing.T) {
 	if got := asMap(t, diagnose.Result)["operational_state"]; got != "running" {
 		t.Fatalf("run.diagnose operational_state = %v, want running", got)
 	}
+	quiescence := asMap(t, asMap(t, diagnose.Result)["test_quiescence"])
+	if quiescence["ready"] != true || quiescence["active_deliveries"] != float64(0) {
+		t.Fatalf("run.diagnose test_quiescence = %#v, want ready zero-count projection", quiescence)
+	}
 }
 
 func TestOperatorReadHandlersRunNotFoundAndRunStartStaysUnavailable(t *testing.T) {

--- a/internal/apiv1/openrpc_readonly_runtime_test.go
+++ b/internal/apiv1/openrpc_readonly_runtime_test.go
@@ -299,7 +299,7 @@ func readOnlyHTTPRuntimeFixtures() map[string]readOnlyHTTPRuntimeFixture {
 		"health.ping":                    {Params: map[string]any{}, ResultKeys: []string{"ok", "ts"}},
 		"mailbox.get":                    {Params: map[string]any{"mailbox_id": "mailbox-1"}, ResultKeys: []string{"item", "payload", "history", "decision_sheet"}},
 		"mailbox.list":                   {Params: map[string]any{}, ResultKeys: []string{"items"}},
-		"run.diagnose":                   {Params: map[string]any{"run_id": "run-1"}, ResultKeys: []string{"run", "operational_state", "blocking_layer", "blocking_reason", "heuristics"}},
+		"run.diagnose":                   {Params: map[string]any{"run_id": "run-1"}, ResultKeys: []string{"run", "operational_state", "blocking_layer", "blocking_reason", "heuristics", "test_quiescence"}},
 		"run.get":                        {Params: map[string]any{"run_id": "run-1"}, ResultKeys: []string{"run"}},
 		"run.list":                       {Params: map[string]any{}, ResultKeys: []string{"runs"}},
 		"run.trace":                      {Params: map[string]any{"run_id": "run-1"}, ResultKeys: []string{"trace"}},
@@ -1003,6 +1003,10 @@ func assertReadOnlyProbeSuccess(t *testing.T, methodName string, resp rpcRespons
 		}
 		if len(heuristics) != 0 {
 			t.Fatalf("run.diagnose heuristics = %#v, want empty array", heuristics)
+		}
+		quiescence := asMap(t, result["test_quiescence"])
+		if quiescence["ready"] != true {
+			t.Fatalf("run.diagnose test_quiescence = %#v, want ready", quiescence)
 		}
 	}
 	if methodName == "conversation.get" || methodName == "conversation.current_for_agent" {

--- a/internal/apiv1/operator_read.go
+++ b/internal/apiv1/operator_read.go
@@ -147,6 +147,7 @@ type runDiagnosis struct {
 	BlockingReason   string                          `json:"blocking_reason"`
 	Heuristics       []string                        `json:"heuristics"`
 	FailedDeliveries []store.RunDebugFailureDelivery `json:"failed_deliveries"`
+	TestQuiescence   store.RunTestQuiescence         `json:"test_quiescence"`
 }
 
 var runListStatuses = map[string]struct{}{
@@ -252,6 +253,7 @@ func OperatorReadHandlers(opts OperatorReadOptions) map[string]MethodHandler {
 				BlockingReason:   strings.TrimSpace(status.BlockingReason),
 				Heuristics:       status.Heuristics,
 				FailedDeliveries: failedDeliveries,
+				TestQuiescence:   normalizeRunTestQuiescence(report.TestQuiescence),
 			}, nil
 		},
 	}
@@ -304,6 +306,14 @@ func OperatorReadHandlers(opts OperatorReadOptions) map[string]MethodHandler {
 		handlers[name] = handler
 	}
 	return handlers
+}
+
+func normalizeRunTestQuiescence(value store.RunTestQuiescence) store.RunTestQuiescence {
+	value.Ready = value.ActiveDeliveries == 0 &&
+		value.UnsettledPipelineEvents == 0 &&
+		value.DueTimers == 0 &&
+		value.ActiveSessionLeases == 0
+	return value
 }
 
 func requireRunReadStore(runs RunReadStore) (RunReadStore, error) {

--- a/internal/store/run_debug_read_surface.go
+++ b/internal/store/run_debug_read_surface.go
@@ -125,6 +125,14 @@ type RunDebugRuntimeSummary struct {
 	Count     int    `json:"count"`
 }
 
+type RunTestQuiescence struct {
+	Ready                   bool `json:"ready"`
+	ActiveDeliveries        int  `json:"active_deliveries"`
+	UnsettledPipelineEvents int  `json:"unsettled_pipeline_events"`
+	DueTimers               int  `json:"due_timers"`
+	ActiveSessionLeases     int  `json:"active_session_leases"`
+}
+
 type RunDebugReport struct {
 	RunID             string                    `json:"run_id"`
 	RunTableStatus    string                    `json:"run_table_status,omitempty"`
@@ -146,6 +154,7 @@ type RunDebugReport struct {
 	Mutations         []RunDebugMutation        `json:"mutations,omitempty"`
 	RuntimeLogSummary []RunDebugRuntimeSummary  `json:"runtime_log_summary,omitempty"`
 	RuntimeLogs       []RunDebugRuntimeLog      `json:"runtime_logs,omitempty"`
+	TestQuiescence    RunTestQuiescence         `json:"test_quiescence"`
 }
 
 type RunDebugTraceQueryOptions struct {
@@ -533,6 +542,11 @@ func (s *PostgresStore) LoadRunDebugReport(ctx context.Context, runID string, op
 		return RunDebugReport{}, err
 	}
 	report.FailedDeliveries = failedDeliveries
+	testQuiescence, err := s.loadRunTestQuiescence(ctx, report.RunID)
+	if err != nil {
+		return RunDebugReport{}, err
+	}
+	report.TestQuiescence = testQuiescence
 
 	eventRows, err := s.DB.QueryContext(ctx, `
 		SELECT
@@ -670,6 +684,61 @@ func (s *PostgresStore) LoadRunDebugReport(ctx context.Context, runID string, op
 	}
 
 	return report, nil
+}
+
+func (s *PostgresStore) loadRunTestQuiescence(ctx context.Context, runID string) (RunTestQuiescence, error) {
+	var out RunTestQuiescence
+	if err := s.DB.QueryRowContext(ctx, `
+		SELECT COUNT(*)
+		FROM event_deliveries d
+		WHERE d.run_id = $1::uuid
+		  AND NOT (COALESCE(d.subscriber_type, '') = $2 AND COALESCE(d.subscriber_id, '') = $3)
+		  AND `+activeRunQuiescenceDeliveryPredicateSQL("d")+`
+	`, runID, replayScopeMarkerSubscriberType, replayScopeMarkerSubscriberID).Scan(&out.ActiveDeliveries); err != nil {
+		return RunTestQuiescence{}, fmt.Errorf("load run test quiescence active deliveries: %w", err)
+	}
+	if err := s.DB.QueryRowContext(ctx, `
+		SELECT COUNT(*)
+		FROM events e
+		LEFT JOIN event_receipts r
+			ON r.event_id = e.event_id
+			AND r.subscriber_type = 'platform'
+			AND r.subscriber_id = 'pipeline'
+		WHERE e.run_id = $1::uuid
+		  AND e.event_name <> '`+runtimeLogEventName+`'
+		  AND (r.event_id IS NULL OR COALESCE(r.outcome, '') <> 'success')
+	`, runID).Scan(&out.UnsettledPipelineEvents); err != nil {
+		return RunTestQuiescence{}, fmt.Errorf("load run test quiescence unsettled pipeline events: %w", err)
+	}
+	if err := s.DB.QueryRowContext(ctx, `
+		SELECT COUNT(*)
+		FROM timers
+		WHERE run_id = $1::uuid
+		  AND status = 'active'
+		  AND fire_at <= now()
+	`, runID).Scan(&out.DueTimers); err != nil {
+		return RunTestQuiescence{}, fmt.Errorf("load run test quiescence due timers: %w", err)
+	}
+	if err := s.DB.QueryRowContext(ctx, `
+		SELECT COUNT(*)
+		FROM agent_sessions
+		WHERE run_id = $1::uuid
+		  AND status = 'active'
+		  AND lease_holder IS NOT NULL
+		  AND lease_expires_at IS NOT NULL
+		  AND lease_expires_at > now()
+	`, runID).Scan(&out.ActiveSessionLeases); err != nil {
+		return RunTestQuiescence{}, fmt.Errorf("load run test quiescence active session leases: %w", err)
+	}
+	out.Ready = runTestQuiescenceReady(out)
+	return out, nil
+}
+
+func runTestQuiescenceReady(value RunTestQuiescence) bool {
+	return value.ActiveDeliveries == 0 &&
+		value.UnsettledPipelineEvents == 0 &&
+		value.DueTimers == 0 &&
+		value.ActiveSessionLeases == 0
 }
 
 func (s *PostgresStore) loadRunDebugFailureDeliveries(ctx context.Context, runID string, limit int) ([]RunDebugFailureDelivery, error) {

--- a/internal/store/run_debug_read_surface_test.go
+++ b/internal/store/run_debug_read_surface_test.go
@@ -33,6 +33,13 @@ func seedRunDebugAgent(t *testing.T, pg *PostgresStore, ctx context.Context, age
 	}
 }
 
+func assertRunTestQuiescence(t *testing.T, got RunTestQuiescence, want RunTestQuiescence) {
+	t.Helper()
+	if got != want {
+		t.Fatalf("TestQuiescence = %#v, want %#v", got, want)
+	}
+}
+
 func TestRunDebugReadSurface_ListRunDebugRuns_UsesCanonicalRunScope(t *testing.T) {
 	_, db, _ := testutil.StartPostgres(t)
 	pg := &PostgresStore{DB: db}
@@ -286,6 +293,107 @@ func TestRunDebugReadSurface_LoadRunDebugReport_UsesCanonicalRunIDForLogsAndMuta
 	if report.FailedDeliveries[0].DeliveryID == successDeliveryID {
 		t.Fatalf("successful delivered/node_processed delivery appeared in FailedDeliveries: %#v", report.FailedDeliveries)
 	}
+}
+
+func TestRunDebugReadSurface_LoadRunDebugReport_ProjectsTestQuiescenceCounts(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &PostgresStore{DB: db}
+	ctx := context.Background()
+
+	blockedRunID := uuid.NewString()
+	readyRunID := uuid.NewString()
+	activeEventID := uuid.NewString()
+	unsettledEventID := uuid.NewString()
+	runtimeLogEventID := uuid.NewString()
+	readyEventID := uuid.NewString()
+	now := time.Now().UTC()
+
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO runs (run_id, status, started_at)
+		VALUES
+			($1::uuid, 'running', $3),
+			($2::uuid, 'running', $3)
+	`, blockedRunID, readyRunID, now.Add(-time.Minute)); err != nil {
+		t.Fatalf("seed runs: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO events (
+			run_id, event_id, event_name, scope, payload, produced_by, produced_by_type, created_at
+		)
+		VALUES
+			($1::uuid, $2::uuid, 'quiescence.active_delivery', 'global', '{}'::jsonb, 'test', 'platform', $6),
+			($1::uuid, $3::uuid, 'quiescence.missing_pipeline_receipt', 'global', '{}'::jsonb, 'test', 'platform', $7),
+			($1::uuid, $4::uuid, '`+runtimeLogEventName+`', 'global', '{}'::jsonb, 'test', 'platform', $8),
+			($9::uuid, $5::uuid, 'quiescence.ready', 'global', '{}'::jsonb, 'test', 'platform', $10)
+	`, blockedRunID, activeEventID, unsettledEventID, runtimeLogEventID, readyEventID,
+		now.Add(-50*time.Second), now.Add(-40*time.Second), now.Add(-30*time.Second), readyRunID, now.Add(-20*time.Second)); err != nil {
+		t.Fatalf("seed events: %v", err)
+	}
+	if err := pg.UpsertPipelineReceipt(ctx, activeEventID, "processed", ""); err != nil {
+		t.Fatalf("UpsertPipelineReceipt active event: %v", err)
+	}
+	if err := pg.UpsertPipelineReceipt(ctx, readyEventID, "processed", ""); err != nil {
+		t.Fatalf("UpsertPipelineReceipt ready event: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO event_deliveries (
+			run_id, event_id, subscriber_type, subscriber_id, status, retry_count, reason_code, created_at
+		)
+		VALUES
+			($1::uuid, $2::uuid, 'agent', 'agent-active', 'pending', 0, 'matched_agent_subscription', now()),
+			($1::uuid, $2::uuid, $3, $4, 'pending', 0, 'replay_scope_marker', now()),
+			($5::uuid, $6::uuid, 'agent', 'agent-done', 'delivered', 0, 'handled', now())
+	`, blockedRunID, activeEventID, replayScopeMarkerSubscriberType, replayScopeMarkerSubscriberID, readyRunID, readyEventID); err != nil {
+		t.Fatalf("seed deliveries: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO timers (
+			timer_id, run_id, timer_name, fire_event, fire_payload,
+			fire_at, owner_agent, task_type, status, created_at
+		)
+		VALUES
+			(gen_random_uuid(), $1::uuid, 'due', 'quiescence.timeout', '{}'::jsonb, now() - interval '1 minute', 'timer-agent', 'timer', 'active', now()),
+			(gen_random_uuid(), $2::uuid, 'settled', 'quiescence.timeout', '{}'::jsonb, now() - interval '1 minute', 'timer-agent', 'timer', 'fired', now())
+	`, blockedRunID, readyRunID); err != nil {
+		t.Fatalf("seed timers: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO agents (agent_id, role, model, llm_backend, conversation_mode, created_at)
+		VALUES ('quiescence-agent', 'worker', 'standard', 'mock', 'session', now())
+	`); err != nil {
+		t.Fatalf("seed agent: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO agent_sessions (
+			session_id, run_id, agent_id, scope_key, scope, runtime_mode, runtime_state,
+			lease_holder, lease_expires_at, status, created_at, updated_at
+		)
+		VALUES
+			(gen_random_uuid(), $1::uuid, 'quiescence-agent', 'global', 'global', 'session', '{}'::jsonb,
+				'worker-1', now() + interval '1 minute', 'active', now(), now()),
+			(gen_random_uuid(), $2::uuid, 'quiescence-agent', 'global-ready', 'global', 'session', '{}'::jsonb,
+				'worker-1', now() - interval '1 minute', 'active', now(), now())
+	`, blockedRunID, readyRunID); err != nil {
+		t.Fatalf("seed sessions: %v", err)
+	}
+
+	blocked, err := pg.LoadRunDebugReport(ctx, blockedRunID, RunDebugQueryOptions{})
+	if err != nil {
+		t.Fatalf("LoadRunDebugReport blocked: %v", err)
+	}
+	assertRunTestQuiescence(t, blocked.TestQuiescence, RunTestQuiescence{
+		Ready:                   false,
+		ActiveDeliveries:        1,
+		UnsettledPipelineEvents: 1,
+		DueTimers:               1,
+		ActiveSessionLeases:     1,
+	})
+
+	ready, err := pg.LoadRunDebugReport(ctx, readyRunID, RunDebugQueryOptions{})
+	if err != nil {
+		t.Fatalf("LoadRunDebugReport ready: %v", err)
+	}
+	assertRunTestQuiescence(t, ready.TestQuiescence, RunTestQuiescence{Ready: true})
 }
 
 func TestRunDebugReadSurface_LoadRunDebugTrace_JoinsEventDeliverySessionAndTurn(t *testing.T) {

--- a/internal/store/sqlite_run_api_read_surface.go
+++ b/internal/store/sqlite_run_api_read_surface.go
@@ -162,6 +162,11 @@ func (s *SQLiteRuntimeStore) LoadRunDebugReport(ctx context.Context, runID strin
 		return RunDebugReport{}, err
 	}
 	report.FailedDeliveries = failedDeliveries
+	testQuiescence, err := s.sqliteRunTestQuiescence(ctx, header.RunID)
+	if err != nil {
+		return RunDebugReport{}, err
+	}
+	report.TestQuiescence = testQuiescence
 	events, err := s.sqliteRunDebugEvents(ctx, header.RunID, opts.EventLimit)
 	if err != nil {
 		return RunDebugReport{}, err
@@ -179,6 +184,85 @@ func (s *SQLiteRuntimeStore) LoadRunDebugReport(ctx context.Context, runID strin
 	report.RuntimeLogSummary = logSummary
 	report.WarnErrorLogCount = warnErrorCount
 	return report, nil
+}
+
+func (s *SQLiteRuntimeStore) sqliteRunTestQuiescence(ctx context.Context, runID string) (RunTestQuiescence, error) {
+	var out RunTestQuiescence
+	if err := s.DB.QueryRowContext(ctx, `
+		SELECT COUNT(*)
+		FROM event_deliveries
+		WHERE run_id = ?
+		  AND NOT (COALESCE(subscriber_type, '') = ? AND COALESCE(subscriber_id, '') = ?)
+		  AND (
+			status IN ('pending', 'in_progress')
+			OR (status = 'failed' AND COALESCE(retry_count, 0) < 2)
+		  )
+	`, runID, replayScopeMarkerSubscriberType, replayScopeMarkerSubscriberID).Scan(&out.ActiveDeliveries); err != nil {
+		return RunTestQuiescence{}, fmt.Errorf("load sqlite run test quiescence active deliveries: %w", err)
+	}
+	if err := s.DB.QueryRowContext(ctx, `
+		SELECT COUNT(*)
+		FROM events e
+		LEFT JOIN event_receipts r
+			ON r.event_id = e.event_id
+			AND r.subscriber_type = 'platform'
+			AND r.subscriber_id = 'pipeline'
+		WHERE e.run_id = ?
+		  AND e.event_name <> ?
+		  AND (r.event_id IS NULL OR COALESCE(r.outcome, '') <> 'success')
+	`, runID, runtimeLogEventName).Scan(&out.UnsettledPipelineEvents); err != nil {
+		return RunTestQuiescence{}, fmt.Errorf("load sqlite run test quiescence unsettled pipeline events: %w", err)
+	}
+	if err := s.DB.QueryRowContext(ctx, `
+		SELECT COUNT(*)
+		FROM timers
+		WHERE run_id = ?
+		  AND status = 'active'
+		  AND fire_at <= ?
+	`, runID, s.now()).Scan(&out.DueTimers); err != nil {
+		return RunTestQuiescence{}, fmt.Errorf("load sqlite run test quiescence due timers: %w", err)
+	}
+	activeSessionLeases, err := s.sqliteRunActiveSessionLeaseCount(ctx, runID)
+	if err != nil {
+		return RunTestQuiescence{}, err
+	}
+	out.ActiveSessionLeases = activeSessionLeases
+	out.Ready = runTestQuiescenceReady(out)
+	return out, nil
+}
+
+func (s *SQLiteRuntimeStore) sqliteRunActiveSessionLeaseCount(ctx context.Context, runID string) (int, error) {
+	rows, err := s.DB.QueryContext(ctx, `
+		SELECT lease_expires_at
+		FROM agent_sessions
+		WHERE run_id = ?
+		  AND status = 'active'
+		  AND lease_holder IS NOT NULL
+		  AND lease_expires_at IS NOT NULL
+	`, runID)
+	if err != nil {
+		return 0, fmt.Errorf("load sqlite run test quiescence active session leases: %w", err)
+	}
+	defer rows.Close()
+	count := 0
+	now := s.now()
+	for rows.Next() {
+		var raw any
+		if err := rows.Scan(&raw); err != nil {
+			return 0, fmt.Errorf("scan sqlite run test quiescence session lease expiry: %w", err)
+		}
+		expiresAt, ok, err := sqliteTimeValue(raw)
+		if err != nil {
+			return 0, err
+		}
+		if ok && expiresAt.After(now) {
+			count++
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return 0, fmt.Errorf("read sqlite run test quiescence session lease expiries: %w", err)
+	}
+	return count, nil
 }
 
 func sqliteRunHeaderSelectSQL() string {

--- a/internal/store/sqlite_run_api_read_surface_test.go
+++ b/internal/store/sqlite_run_api_read_surface_test.go
@@ -193,6 +193,119 @@ func TestSQLiteRunAPIReadSurface_LoadListAndDiagnoseEvidence(t *testing.T) {
 	}
 }
 
+func TestSQLiteRunAPIReadSurface_LoadRunDebugReportProjectsTestQuiescenceCounts(t *testing.T) {
+	ctx := context.Background()
+	sqliteStore := newBootstrappedSQLiteRuntimeStoreForTest(t)
+	now := time.Date(2026, 7, 4, 12, 0, 0, 0, time.UTC)
+	sqliteStore.nowFn = func() time.Time { return now }
+
+	blockedRunID := uuid.NewString()
+	readyRunID := uuid.NewString()
+	activeEventID := uuid.NewString()
+	unsettledEventID := uuid.NewString()
+	runtimeLogEventID := uuid.NewString()
+	readyEventID := uuid.NewString()
+
+	if _, err := sqliteStore.DB.ExecContext(ctx, `
+		INSERT INTO runs (run_id, status, started_at)
+		VALUES
+			(?, 'running', ?),
+			(?, 'running', ?)
+	`, blockedRunID, now.Add(-time.Minute), readyRunID, now.Add(-time.Minute)); err != nil {
+		t.Fatalf("seed sqlite runs: %v", err)
+	}
+	if _, err := sqliteStore.DB.ExecContext(ctx, `
+		INSERT INTO events (
+			run_id, event_id, event_name, scope, payload, produced_by, produced_by_type, created_at
+		)
+		VALUES
+			(?, ?, 'quiescence.active_delivery', 'global', '{}', 'test', 'platform', ?),
+			(?, ?, 'quiescence.missing_pipeline_receipt', 'global', '{}', 'test', 'platform', ?),
+			(?, ?, ?, 'global', '{}', 'test', 'platform', ?),
+			(?, ?, 'quiescence.ready', 'global', '{}', 'test', 'platform', ?)
+	`, blockedRunID, activeEventID, now.Add(-50*time.Second),
+		blockedRunID, unsettledEventID, now.Add(-40*time.Second),
+		blockedRunID, runtimeLogEventID, runtimeLogEventName, now.Add(-30*time.Second),
+		readyRunID, readyEventID, now.Add(-20*time.Second)); err != nil {
+		t.Fatalf("seed sqlite events: %v", err)
+	}
+	if err := sqliteStore.UpsertPipelineReceipt(ctx, activeEventID, "processed", ""); err != nil {
+		t.Fatalf("UpsertPipelineReceipt active event: %v", err)
+	}
+	if err := sqliteStore.UpsertPipelineReceipt(ctx, readyEventID, "processed", ""); err != nil {
+		t.Fatalf("UpsertPipelineReceipt ready event: %v", err)
+	}
+	if _, err := sqliteStore.DB.ExecContext(ctx, `
+		INSERT INTO event_deliveries (
+			delivery_id, run_id, event_id, subscriber_type, subscriber_id, status, retry_count, reason_code, created_at
+		)
+		VALUES
+			(?, ?, ?, 'agent', 'agent-active', 'pending', 0, 'matched_agent_subscription', ?),
+			(?, ?, ?, ?, ?, 'pending', 0, 'replay_scope_marker', ?),
+			(?, ?, ?, 'agent', 'agent-done', 'delivered', 0, 'handled', ?)
+	`, uuid.NewString(), blockedRunID, activeEventID, now,
+		uuid.NewString(), blockedRunID, activeEventID, replayScopeMarkerSubscriberType, replayScopeMarkerSubscriberID, now,
+		uuid.NewString(), readyRunID, readyEventID, now); err != nil {
+		t.Fatalf("seed sqlite deliveries: %v", err)
+	}
+	if _, err := sqliteStore.DB.ExecContext(ctx, `
+		INSERT INTO timers (
+			timer_id, run_id, timer_name, fire_event, fire_payload,
+			fire_at, owner_agent, task_type, status, created_at
+		)
+		VALUES
+			(?, ?, 'due', 'quiescence.timeout', '{}', ?, 'timer-agent', 'timer', 'active', ?),
+			(?, ?, 'settled', 'quiescence.timeout', '{}', ?, 'timer-agent', 'timer', 'fired', ?)
+	`, uuid.NewString(), blockedRunID, now.Add(-time.Minute), now,
+		uuid.NewString(), readyRunID, now.Add(-time.Minute), now); err != nil {
+		t.Fatalf("seed sqlite timers: %v", err)
+	}
+	if _, err := sqliteStore.DB.ExecContext(ctx, `
+		INSERT INTO agents (
+			agent_id, role, model, llm_backend, conversation_mode,
+			config, subscriptions, emit_events, tools, permissions, runtime_descriptor, status, created_at
+		)
+		VALUES (
+			'quiescence-agent', 'worker', 'regular', 'mock', 'session',
+			'{}', '[]', '[]', '[]', '{}', '{}', 'active', ?
+		)
+	`, now); err != nil {
+		t.Fatalf("seed sqlite agent: %v", err)
+	}
+	if _, err := sqliteStore.DB.ExecContext(ctx, `
+		INSERT INTO agent_sessions (
+			session_id, run_id, agent_id, scope_key, scope, runtime_mode, runtime_state,
+			lease_holder, lease_expires_at, status, created_at, updated_at
+		)
+		VALUES
+			(?, ?, 'quiescence-agent', 'global', 'global', 'session', '{}',
+				'worker-1', ?, 'active', ?, ?),
+			(?, ?, 'quiescence-agent', 'global-ready', 'global', 'session', '{}',
+				'worker-1', ?, 'active', ?, ?)
+	`, uuid.NewString(), blockedRunID, now.Add(time.Minute), now, now,
+		uuid.NewString(), readyRunID, now.Add(-time.Minute), now, now); err != nil {
+		t.Fatalf("seed sqlite sessions: %v", err)
+	}
+
+	blocked, err := sqliteStore.LoadRunDebugReport(ctx, blockedRunID, RunDebugQueryOptions{})
+	if err != nil {
+		t.Fatalf("LoadRunDebugReport blocked: %v", err)
+	}
+	assertRunTestQuiescence(t, blocked.TestQuiescence, RunTestQuiescence{
+		Ready:                   false,
+		ActiveDeliveries:        1,
+		UnsettledPipelineEvents: 1,
+		DueTimers:               1,
+		ActiveSessionLeases:     1,
+	})
+
+	ready, err := sqliteStore.LoadRunDebugReport(ctx, readyRunID, RunDebugQueryOptions{})
+	if err != nil {
+		t.Fatalf("LoadRunDebugReport ready: %v", err)
+	}
+	assertRunTestQuiescence(t, ready.TestQuiescence, RunTestQuiescence{Ready: true})
+}
+
 func TestSQLiteRunAPIReadSurface_LoadRunHeaderNotFound(t *testing.T) {
 	sqliteStore := newBootstrappedSQLiteRuntimeStoreForTest(t)
 	_, err := sqliteStore.LoadRunHeader(context.Background(), uuid.NewString())

--- a/openrpc.json
+++ b/openrpc.json
@@ -5362,7 +5362,7 @@
     },
     {
       "name": "run.diagnose",
-      "description": "Interpreted run diagnosis. Returns the run header plus the\noperator-state projection from\ninternal/store/run_operational_status_read_surface.go and concrete failed-delivery evidence from\nRunDebugReport.FailedDeliveries. The single canonical owner for\n\"why isn't this run progressing?\" routes persisted evidence through\nthe API instead of having every consumer recompute it.\n",
+      "description": "Interpreted run diagnosis. Returns the run header plus the\noperator-state projection from\ninternal/store/run_operational_status_read_surface.go and concrete failed-delivery evidence from\nRunDebugReport.FailedDeliveries, plus result.test_quiescence from\nRunDebugReport.TestQuiescence for deterministic test assertion barriers. The single canonical owner for\n\"why isn't this run progressing?\" routes persisted evidence through\nthe API instead of having every consumer recompute it.\n",
       "params": [
         {
           "name": "run_id",
@@ -10544,7 +10544,7 @@
       },
       "RunDiagnosis": {
         "additionalProperties": false,
-        "description": "Run header plus the canonical operator-state projection and concrete failed-delivery evidence. Source of truth: ProjectRunOperationalStatus for operational_state/blocking fields and RunDebugReport.FailedDeliveries for event_deliveries/dead_letters failure evidence.\n",
+        "description": "Run header plus the canonical operator-state projection and concrete failed-delivery evidence. Source of truth: ProjectRunOperationalStatus for operational_state/blocking fields, RunDebugReport.FailedDeliveries for event_deliveries/dead_letters failure evidence, and RunDebugReport.TestQuiescence for deterministic test assertion-barrier readiness.\n",
         "properties": {
           "blocking_layer": {
             "$ref": "#/components/schemas/BlockingLayer"
@@ -10572,6 +10572,9 @@
           },
           "run": {
             "$ref": "#/components/schemas/RunHeader"
+          },
+          "test_quiescence": {
+            "$ref": "#/components/schemas/RunTestQuiescence"
           }
         },
         "required": [
@@ -10580,7 +10583,8 @@
           "blocking_layer",
           "blocking_reason",
           "heuristics",
-          "failed_deliveries"
+          "failed_deliveries",
+          "test_quiescence"
         ],
         "type": "object"
       },
@@ -10682,6 +10686,44 @@
           "forked"
         ],
         "type": "string"
+      },
+      "RunTestQuiescence": {
+        "additionalProperties": false,
+        "description": "Canonical public test-quiescence projection for deterministic scenario assertions. Source of truth: persisted run completion inputs consumed by run_model.lifecycle.completion, exposed through run.diagnose so test runners do not infer readiness from partial trace rows or sleeps. `ready` is true exactly when all count fields are zero.\n",
+        "properties": {
+          "active_deliveries": {
+            "description": "Active delivery rows for the run, excluding committed replay-scope marker rows.",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "active_session_leases": {
+            "description": "Active agent/session leases for the run whose lease has not expired.",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "due_timers": {
+            "description": "Active timer rows for the run whose fire_at is currently due.",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "ready": {
+            "description": "True exactly when active_deliveries, unsettled_pipeline_events, due_timers, and active_session_leases are all zero.",
+            "type": "boolean"
+          },
+          "unsettled_pipeline_events": {
+            "description": "Same-run non-runtime-log events whose platform/pipeline receipt is absent or not successful.",
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "ready",
+          "active_deliveries",
+          "unsettled_pipeline_events",
+          "due_timers",
+          "active_session_leases"
+        ],
+        "type": "object"
       },
       "RunTraceFilter": {
         "additionalProperties": false,

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -10888,7 +10888,7 @@ test_specification:
         run_readback: platform-spec.yaml#api_specification.method_catalog.run.get/trace/diagnose
         entity_readback: platform-spec.yaml#api_specification.method_catalog.entity.*
         dead_letter_readback: event/delivery/dead-letter read owners consumed by run.trace and run.diagnose
-        test_quiescence_inputs: platform-spec.yaml#run_model.lifecycle.completion and ProjectRunOperationalStatus
+        test_quiescence_inputs: platform-spec.yaml#api_specification.method_catalog.run.diagnose result.test_quiescence backed by run_model.lifecycle.completion inputs and ProjectRunOperationalStatus
         contract_validation: engine.boot_verification.checks plus existing event payload/schema validation owners
     non_goals:
     - No runtime/backend/provider implementation is promoted by this section.
@@ -10910,6 +10910,8 @@ test_specification:
         format and omitted version continues to mean v1.
       top_level_fields:
         name: Optional human-readable scenario name.
+        seed: Optional recorded deterministic seed string for generated helper values. When omitted, the empty seed is
+          recorded by implication for v1.
         vars: Optional map of literal values or CEL expressions evaluated once before the first step.
         steps: Required non-empty list of scenario actions.
         expect: Optional final assertion block evaluated after the final step reaches test quiescence.
@@ -10930,7 +10932,8 @@ test_specification:
           are derived from scenario identity, case name, helper arguments, and
           the recorded scenario seed; they are not random wall-clock values.
         initial_helpers:
-          scenario.uuid: Deterministic UUID derived from the scenario seed and a caller-provided label.
+          scenario.uuid: Deterministic UUID derived from the contract-relative scenario identity, scenario name, recorded
+            scenario seed, and caller-provided label.
           scenario.sha40: Deterministic 40-character lowercase hex digest of its normalized string argument.
         forbidden_helpers:
         - wall-clock now
@@ -11017,9 +11020,10 @@ test_specification:
         not a replacement run status.
       rule: >
         After each mutating step and before final assertions, the runner waits
-        until the current run has no pending or in_progress deliveries, no
-        immediate queued/outbox work owned by committed post-commit callbacks,
-        no currently due timer work, and no active platform callback that can
+        by reading `/v1/rpc run.diagnose` result.test_quiescence until the
+        current run has no active deliveries, no unsettled same-run pipeline
+        receipt work owned by committed post-commit callbacks, no currently due
+        timer work, and no active session lease/callback evidence that can
         synchronously enqueue more work for the same run.
       timers: >
         Non-due active timers do not prevent test quiescence. Due timers do.
@@ -12790,11 +12794,12 @@ cli_specification:
         event schema owner before mutation, and executes scenario steps only through public v1 RPC owners. `publish` steps
         call /v1/rpc event.publish; mailbox approve/reject/defer steps locate exactly one pending mailbox item through
         mailbox.list and then call the matching mailbox decision RPC. The command waits for test quiescence by repeatedly
-        reading canonical run.trace delivery state until pending and in_progress deliveries are absent; --timeout is a safety
-        failure bound, not the semantic completion rule. Expectations consume run.trace, event.list dead-letter readback, and
-        entity.list. The command does not activate mock/local providers, implement ProviderContract, test live agent sessions/
-        tool calls/audit/spend semantics, execute inline code, copy cataloge2e private formats, or mutate EventBus/store/
-        mailbox tables directly.
+        reading canonical `run.diagnose` result.test_quiescence until active deliveries, unsettled same-run pipeline receipt
+        work, due timers, and active session leases are absent; --timeout is a safety failure bound, not the semantic
+        completion rule. Expectations consume run.trace, event.list dead-letter readback, and paginated entity.list. The
+        command does not activate mock/local providers, implement ProviderContract, test live agent sessions/tool calls/audit/
+        spend semantics, execute inline code, copy cataloge2e private formats, or mutate EventBus/store/mailbox tables
+        directly.
       flags:
       - name: --contracts <path>
         behavior: Contract package root used for bundle loading and scenario discovery. Omitted uses config contracts_path,
@@ -15952,10 +15957,44 @@ api_specification:
             description: Event-scoped terminal dead-letter records linked to this failed or dead-letter delivery when present.
             items:
               $ref: '#/components/schemas/DeadLetterRecord'
+      RunTestQuiescence:
+        description: "Canonical public test-quiescence projection for deterministic scenario assertions. Source of truth:\
+          \ persisted run completion inputs consumed by run_model.lifecycle.completion, exposed through run.diagnose so\
+          \ test runners do not infer readiness from partial trace rows or sleeps. `ready` is true exactly when all count\
+          \ fields are zero.\n"
+        type: object
+        additionalProperties: false
+        required:
+        - ready
+        - active_deliveries
+        - unsettled_pipeline_events
+        - due_timers
+        - active_session_leases
+        properties:
+          ready:
+            type: boolean
+            description: True exactly when active_deliveries, unsettled_pipeline_events, due_timers, and active_session_leases are all zero.
+          active_deliveries:
+            type: integer
+            minimum: 0
+            description: Active delivery rows for the run, excluding committed replay-scope marker rows.
+          unsettled_pipeline_events:
+            type: integer
+            minimum: 0
+            description: Same-run non-runtime-log events whose platform/pipeline receipt is absent or not successful.
+          due_timers:
+            type: integer
+            minimum: 0
+            description: Active timer rows for the run whose fire_at is currently due.
+          active_session_leases:
+            type: integer
+            minimum: 0
+            description: Active agent/session leases for the run whose lease has not expired.
       RunDiagnosis:
         description: "Run header plus the canonical operator-state projection and concrete failed-delivery evidence. Source\
-          \ of truth: ProjectRunOperationalStatus for operational_state/blocking fields and RunDebugReport.FailedDeliveries\
-          \ for event_deliveries/dead_letters failure evidence.\n"
+          \ of truth: ProjectRunOperationalStatus for operational_state/blocking fields, RunDebugReport.FailedDeliveries\
+          \ for event_deliveries/dead_letters failure evidence, and RunDebugReport.TestQuiescence for deterministic test\
+          \ assertion-barrier readiness.\n"
         type: object
         additionalProperties: false
         required:
@@ -15965,6 +16004,7 @@ api_specification:
         - blocking_reason
         - heuristics
         - failed_deliveries
+        - test_quiescence
         properties:
           run:
             $ref: '#/components/schemas/RunHeader'
@@ -15993,6 +16033,8 @@ api_specification:
             description: Failed or dead-letter delivery rows with persisted reason/error/retry/dead-letter evidence for this run.
             items:
               $ref: '#/components/schemas/RunDebugFailureDelivery'
+          test_quiescence:
+            $ref: '#/components/schemas/RunTestQuiescence'
       EntitySummary:
         type: object
         additionalProperties: false
@@ -19430,9 +19472,9 @@ api_specification:
     run.diagnose:
       tier: must_have
       description: "Interpreted run diagnosis. Returns the run header plus the\noperator-state projection from\ninternal/store/run_operational_status_read_surface.go\
-        \ and concrete failed-delivery evidence from\nRunDebugReport.FailedDeliveries. The single canonical owner for\n\"why\
-        \ isn't this run progressing?\" routes persisted evidence through\nthe API instead of having every consumer recompute\
-        \ it.\n"
+        \ and concrete failed-delivery evidence from\nRunDebugReport.FailedDeliveries, plus result.test_quiescence from\n\
+        RunDebugReport.TestQuiescence for deterministic test assertion barriers. The single canonical owner for\n\"why isn't\
+        \ this run progressing?\" routes persisted evidence through\nthe API instead of having every consumer recompute it.\n"
       scope:
         required:
         - read:runs

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -10845,7 +10845,7 @@ test_specification:
   deterministic_scenario_runner:
     id: testing.deterministic_scenario_runner_source_authority
     promoted_by: '#1646'
-    implementation_status: source_authority_only
+    implementation_status: implemented_first_slice
     owner: platform-spec.yaml#test_specification.deterministic_scenario_runner
     purpose: >
       Define the public deterministic scenario/injection runner semantics for
@@ -10857,11 +10857,11 @@ test_specification:
     selected_public_surface:
       command_family: swarm test
       command_catalog_status: >
-        `swarm test` is the selected user-facing runner family for later
-        implementation. The concrete cli_specification.command_catalog row,
-        flags, exit codes, and output rendering remain a separate
-        implementation child that consumes this owner. Until that child lands,
-        no `swarm test` behavior is implied by this source-authority slice.
+        `swarm test` is the selected and implemented first-slice user-facing
+        runner family. The concrete cli_specification.command_catalog row
+        defines the implemented flags, exit codes, output rendering, and
+        proof expectations while this source-authority section remains the
+        semantic owner for scenario format and runner behavior.
       scenario_roots:
       - contracts/tests
       - contracts/flows/<flow>/tests
@@ -12776,6 +12776,55 @@ cli_specification:
       - deployment-mode profile management
       - trusted runtime identity and context registry consumption
       - store/data migration and swarm run behavior
+    test:
+      command: swarm test [scenario-file ...] [--contracts <path>] [--platform-spec <path>] [--timeout <duration>] [--poll-interval <duration>]
+      tier: should_have
+      implementation_status: implemented_first_slice
+      owner: platform-spec.yaml#test_specification.deterministic_scenario_runner
+      behavior: >-
+        Public deterministic scenario-runner CLI consumer. The command discovers v1 YAML scenarios only under
+        contracts/tests/... and contracts/flows/<flow>/tests/...; automatic discovery treats YAML files with version, steps,
+        or invalid top-level scenario sentinels as scenario documents and leaves fixture YAML uninterpreted, while explicit
+        scenario-file arguments are always parsed fail-closed. The command loads the selected contract bundle, computes the
+        canonical bundle_hash through internal/runtime/contracts.BundleHash, validates fixture payloads through the existing
+        event schema owner before mutation, and executes scenario steps only through public v1 RPC owners. `publish` steps
+        call /v1/rpc event.publish; mailbox approve/reject/defer steps locate exactly one pending mailbox item through
+        mailbox.list and then call the matching mailbox decision RPC. The command waits for test quiescence by repeatedly
+        reading canonical run.trace delivery state until pending and in_progress deliveries are absent; --timeout is a safety
+        failure bound, not the semantic completion rule. Expectations consume run.trace, event.list dead-letter readback, and
+        entity.list. The command does not activate mock/local providers, implement ProviderContract, test live agent sessions/
+        tool calls/audit/spend semantics, execute inline code, copy cataloge2e private formats, or mutate EventBus/store/
+        mailbox tables directly.
+      flags:
+      - name: --contracts <path>
+        behavior: Contract package root used for bundle loading and scenario discovery. Omitted uses config contracts_path,
+          then repo-local contracts when present, then the repo root.
+      - name: --platform-spec <path>
+        behavior: platform-spec.yaml path used for bundle loading. Omitted uses config platform_spec_path, then the repo-local
+          default platform-spec.yaml.
+      - name: --timeout <duration>
+        behavior: Positive safety deadline for test quiescence waits. Reaching it fails the scenario with diagnostic context.
+      - name: --poll-interval <duration>
+        behavior: Positive interval between canonical readback probes while waiting for test quiescence.
+      output:
+        success_detail: >-
+          One scenario ok line per scenario file followed by
+          `swarm test ok: scenarios=<n>`.
+      exit_codes:
+        success: 0
+        cli_validation: 2
+        transport_or_malformed_response: 3
+        auth_or_missing_token: 4
+        not_found: 5
+        scenario_rejected: 6
+      proof_expectations:
+      - exact /v1/rpc event.publish calls with event_name, payload, canonical bundle_hash, optional run_id/source_event_id/
+        target/emitter/idempotency_key params only; no direct DB/store/runtime/EventBus publish path
+      - mailbox decisions are preceded by mailbox.list and fail closed unless exactly one pending mailbox item matches
+      - scenario discovery rejects files outside contracts/tests and contracts/flows/<flow>/tests
+      - fixture from paths cannot escape the contract root, set overrides are applied before schema validation, and invalid
+        fixture/schema variants fail before mutation
+      - no live LLM credentials, ProviderContract mock/local activation, or cataloge2e private scenario format is required
     workspace_build:
       command: swarm workspace build --backend claude_cli [--image <tag>]
       tier: should_have


### PR DESCRIPTION
Closes #1652
Part of #1252

## Summary
- Adds the first-slice public `swarm test` deterministic scenario runner.
- Supports v1 YAML scenarios under `contracts/tests/...` and `contracts/flows/<flow>/tests/...`, deterministic CEL interpolation helpers, fixture `from` + `set`, invalid variants, publish steps, mailbox decision steps, canonical quiescence waits, and public readback expectations.
- Promotes `run.diagnose.result.test_quiescence` as the public assertion-barrier readback consumed by `swarm test`.
- Registers `swarm test` in the CLI and command-class surfaces.
- Promotes the implemented command catalog/API result shape in `platform-spec.yaml`, regenerates `openrpc.json`, and updates source-authority sync tests.

## Governing Refs / Context
- `platform-spec.yaml#test_specification.deterministic_scenario_runner`
- `platform-spec.yaml#cli_specification.command_catalog.test`
- `platform-spec.yaml#api_specification.method_catalog.run.diagnose` / `RunDiagnosis.test_quiescence`
- Adjacent consumed owners: expression context/CEL helper rules, event payload schema validation, `/v1/rpc event.publish`, mailbox list/approve/reject/defer APIs, `run.trace`, `event.list`, and paginated `entity.list` readback.
- Binding issue/gate context: #1652 pre-audit and independent gate outcome.

## Semantic Migration Notes
- New canonical owners: `platform-spec.yaml#test_specification.deterministic_scenario_runner`, `cli_specification.command_catalog.test`, and `api_specification.method_catalog.run.diagnose.result.test_quiescence` for the public test assertion barrier.
- Old paths now non-authoritative for this slice: ad hoc manual event-publish proof scripts, private cataloge2e fixture formats, CLI-local `run.trace` active-delivery inference for quiescence, absolute-path-based scenario UUID seeds, and one-page entity-count assertions.
- Checked production paths: implementation uses `newCLIAPIClient` plus public v1 RPC calls only; no direct DB/store/EventBus/mailbox table mutation, no ProviderContract mock/local activation, and no live-agent/session/audit/spend claim.
- Migration completeness: complete for the approved first-slice deterministic runner boundary; faithful scripted backend, catalog convergence, static/docs/readme follow-ups remain parked/split under #1252.

## Validation
- `go test ./cmd/swarm -run 'TestSwarmTest|TestScenario|TestStatusUsesDiagnoseAndRunGet|TestMalformedAPIResponses' -count=1`
- `go test ./internal/apispec -count=1`
- `go test ./internal/apiv1 -run 'TestOperatorReadHandlersExposeHealthAndRunReadMethods|TestReadOnlyHTTPRuntime|TestGeneratedOpenRPC|TestOpenRPC' -count=1`
- `go test ./internal/store -run 'TestSQLiteRunAPIReadSurface|TestRunDebugReadSurface' -count=1`
- `go run ./cmd/swarm-openrpc-gen --check`
- `go test ./...`
