### PR TITLE
[agent-f][issue #1650] Add managed OAuth credential owner

### DIFF
--- a/cmd/swarm/cli.go
+++ b/cmd/swarm/cli.go
@@ -112,6 +112,7 @@ start work with 'swarm run' or 'swarm event publish' and watch it with
 		newDescribeCommand(ctx, repo),
 		newBundleCommand(repo, opts),
 		newSecretsCommand(ctx, repo),
+		newConnectionsCommand(ctx, repo),
 	)
 	addToGroup(commandGroupOperate,
 		newRunCommand(repo, opts),

--- a/cmd/swarm/connections.go
+++ b/cmd/swarm/connections.go
@@ -1,0 +1,379 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+	"text/tabwriter"
+	"time"
+
+	runtimemanagedcredentials "github.com/division-sh/swarm/internal/runtime/managedcredentials"
+	"github.com/division-sh/swarm/internal/runtime/semanticview"
+	"github.com/spf13/cobra"
+)
+
+type connectionsConnectOptions struct {
+	grant             string
+	provider          string
+	authURL           string
+	tokenURL          string
+	clientID          string
+	clientSecretStdin bool
+	redirectURL       string
+	account           string
+	scopes            []string
+	asJSON            bool
+}
+
+type connectionsStatusOptions struct {
+	contractsPath    string
+	platformSpecPath string
+	asJSON           bool
+}
+
+type connectionRecord struct {
+	Key        string                  `json:"key"`
+	Provider   string                  `json:"provider,omitempty"`
+	Account    string                  `json:"account,omitempty"`
+	GrantType  string                  `json:"grant_type,omitempty"`
+	Scopes     []string                `json:"scopes,omitempty"`
+	Status     string                  `json:"status"`
+	Failure    string                  `json:"failure,omitempty"`
+	ExpiresAt  string                  `json:"expires_at,omitempty"`
+	UpdatedAt  string                  `json:"updated_at,omitempty"`
+	Present    bool                    `json:"present"`
+	RequiredBy []connectionRequirement `json:"required_by,omitempty"`
+}
+
+type connectionRequirement struct {
+	Kind string `json:"kind"`
+	Name string `json:"name"`
+}
+
+type connectionsStatusResult struct {
+	Connections []connectionRecord `json:"connections"`
+}
+
+type connectionsConnectResult struct {
+	Connection   connectionRecord `json:"connection"`
+	AuthorizeURL string           `json:"authorize_url,omitempty"`
+	State        string           `json:"state,omitempty"`
+}
+
+func newConnectionsCommand(ctx context.Context, repo string) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "connections",
+		Short: "Manage local managed credential connections.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return cmd.Help()
+		},
+	}
+	cmd.AddCommand(
+		newConnectionsConnectCommand(ctx, repo),
+		newConnectionsCallbackCommand(ctx, repo),
+		newConnectionsStatusCommand(ctx, repo),
+		newConnectionsDisconnectCommand(ctx, repo),
+	)
+	return cmd
+}
+
+func newConnectionsConnectCommand(ctx context.Context, repo string) *cobra.Command {
+	opts := connectionsConnectOptions{grant: runtimemanagedcredentials.GrantAuthorizationCodePKCE}
+	cmd := &cobra.Command{
+		Use:   "connect <key>",
+		Short: "Start or complete a managed credential grant.",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			secret, err := readConnectionClientSecret(cmd.InOrStdin(), opts)
+			if err != nil {
+				return returnCLIValidationError(cmd.ErrOrStderr(), err)
+			}
+			store, err := buildManagedCredentialStore()
+			if err != nil {
+				return returnSecretsRuntimeError(cmd.ErrOrStderr(), fmt.Errorf("configure managed credential store: %w", err))
+			}
+			source := runtimemanagedcredentials.TokenSource{Store: store}
+			key := strings.TrimSpace(args[0])
+			switch strings.TrimSpace(opts.grant) {
+			case runtimemanagedcredentials.GrantAuthorizationCodePKCE:
+				result, err := source.BeginAuthCodePKCE(ctx, runtimemanagedcredentials.BeginAuthCodeRequest{
+					Key:          key,
+					Provider:     opts.provider,
+					AuthURL:      opts.authURL,
+					TokenURL:     opts.tokenURL,
+					ClientID:     opts.clientID,
+					ClientSecret: secret,
+					RedirectURL:  opts.redirectURL,
+					Scopes:       opts.scopes,
+					Account:      opts.account,
+				})
+				if err != nil {
+					return returnSecretsRuntimeError(cmd.ErrOrStderr(), err)
+				}
+				record, ok, err := store.Get(ctx, key)
+				if err != nil {
+					return returnSecretsRuntimeError(cmd.ErrOrStderr(), err)
+				}
+				output := connectionsConnectResult{
+					Connection:   connectionRecordFromDescriptor(record.Descriptor(), ok, nil),
+					AuthorizeURL: result.AuthorizeURL,
+					State:        result.State,
+				}
+				if opts.asJSON {
+					return encodeSecretsJSON(cmd.OutOrStdout(), output)
+				}
+				fmt.Fprintf(cmd.OutOrStdout(), "connection pending: key=%s status=%s\n", output.Connection.Key, output.Connection.Status)
+				fmt.Fprintf(cmd.OutOrStdout(), "authorize_url: %s\n", output.AuthorizeURL)
+				return nil
+			case runtimemanagedcredentials.GrantClientCredentials:
+				record, err := source.ConnectClientCredentials(ctx, runtimemanagedcredentials.ClientCredentialsRequest{
+					Key:          key,
+					Provider:     opts.provider,
+					TokenURL:     opts.tokenURL,
+					ClientID:     opts.clientID,
+					ClientSecret: secret,
+					Scopes:       opts.scopes,
+					Account:      opts.account,
+				})
+				if err != nil {
+					return returnSecretsRuntimeError(cmd.ErrOrStderr(), err)
+				}
+				output := connectionsConnectResult{Connection: connectionRecordFromDescriptor(record.Descriptor(), true, nil)}
+				if opts.asJSON {
+					return encodeSecretsJSON(cmd.OutOrStdout(), output)
+				}
+				fmt.Fprintf(cmd.OutOrStdout(), "connection connected: key=%s status=%s\n", output.Connection.Key, output.Connection.Status)
+				return nil
+			default:
+				return returnCLIValidationError(cmd.ErrOrStderr(), fmt.Errorf("--grant must be %s or %s", runtimemanagedcredentials.GrantAuthorizationCodePKCE, runtimemanagedcredentials.GrantClientCredentials))
+			}
+		},
+	}
+	cmd.Flags().StringVar(&opts.grant, "grant", opts.grant, "Grant type: authorization_code_pkce or client_credentials")
+	cmd.Flags().StringVar(&opts.provider, "provider", "", "Provider label for operator status")
+	cmd.Flags().StringVar(&opts.authURL, "auth-url", "", "OAuth authorization URL")
+	cmd.Flags().StringVar(&opts.tokenURL, "token-url", "", "OAuth token URL")
+	cmd.Flags().StringVar(&opts.clientID, "client-id", "", "OAuth client ID")
+	cmd.Flags().BoolVar(&opts.clientSecretStdin, "client-secret-stdin", false, "Read the OAuth client secret from stdin")
+	cmd.Flags().StringVar(&opts.redirectURL, "redirect-url", "", "OAuth redirect URL for authorization_code_pkce")
+	cmd.Flags().StringVar(&opts.account, "account", "", "Connected provider account label")
+	cmd.Flags().StringSliceVar(&opts.scopes, "scope", nil, "Required OAuth scope; repeat or comma-separate")
+	cmd.Flags().BoolVar(&opts.asJSON, "json", false, "Render successful output as one JSON document")
+	return cmd
+}
+
+func newConnectionsCallbackCommand(ctx context.Context, repo string) *cobra.Command {
+	var state string
+	var codeStdin bool
+	var asJSON bool
+	cmd := &cobra.Command{
+		Use:   "callback <key>",
+		Short: "Record an OAuth authorization-code callback.",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			code, err := readConnectionAuthCode(cmd.InOrStdin(), codeStdin)
+			if err != nil {
+				return returnCLIValidationError(cmd.ErrOrStderr(), err)
+			}
+			store, err := buildManagedCredentialStore()
+			if err != nil {
+				return returnSecretsRuntimeError(cmd.ErrOrStderr(), fmt.Errorf("configure managed credential store: %w", err))
+			}
+			source := runtimemanagedcredentials.TokenSource{Store: store}
+			record, err := source.CompleteAuthCode(ctx, runtimemanagedcredentials.CompleteAuthCodeRequest{
+				Key:   strings.TrimSpace(args[0]),
+				State: state,
+				Code:  code,
+			})
+			if err != nil {
+				return returnSecretsRuntimeError(cmd.ErrOrStderr(), err)
+			}
+			output := connectionsConnectResult{Connection: connectionRecordFromDescriptor(record.Descriptor(), true, nil)}
+			if asJSON {
+				return encodeSecretsJSON(cmd.OutOrStdout(), output)
+			}
+			fmt.Fprintf(cmd.OutOrStdout(), "connection connected: key=%s status=%s\n", output.Connection.Key, output.Connection.Status)
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&state, "state", "", "OAuth callback state")
+	cmd.Flags().BoolVar(&codeStdin, "code-stdin", false, "Read the OAuth authorization code from stdin")
+	cmd.Flags().BoolVar(&asJSON, "json", false, "Render successful output as one JSON document")
+	return cmd
+}
+
+func newConnectionsStatusCommand(ctx context.Context, repo string) *cobra.Command {
+	opts := connectionsStatusOptions{}
+	cmd := &cobra.Command{
+		Use:   "status [key]",
+		Short: "Show managed credential connection status.",
+		Args:  cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			store, err := buildManagedCredentialStore()
+			if err != nil {
+				return returnSecretsRuntimeError(cmd.ErrOrStderr(), fmt.Errorf("configure managed credential store: %w", err))
+			}
+			source, err := loadConnectionsSource(cmd, repo, opts.contractsPath, opts.platformSpecPath)
+			if err != nil {
+				return returnSecretsRuntimeError(cmd.ErrOrStderr(), err)
+			}
+			records, err := connectionRecords(ctx, store, source, args)
+			if err != nil {
+				return returnSecretsRuntimeError(cmd.ErrOrStderr(), err)
+			}
+			result := connectionsStatusResult{Connections: records}
+			if opts.asJSON {
+				return encodeSecretsJSON(cmd.OutOrStdout(), result)
+			}
+			writeConnectionsTable(cmd.OutOrStdout(), records)
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&opts.contractsPath, "contracts", opts.contractsPath, "Path to Swarm contract bundle root for required_by metadata")
+	cmd.Flags().StringVar(&opts.platformSpecPath, "platform-spec", opts.platformSpecPath, "Path to platform spec yaml")
+	cmd.Flags().BoolVar(&opts.asJSON, "json", false, "Render successful output as one JSON document")
+	return cmd
+}
+
+func newConnectionsDisconnectCommand(ctx context.Context, repo string) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "disconnect <key>",
+		Short: "Delete a managed credential token record.",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			store, err := buildManagedCredentialStore()
+			if err != nil {
+				return returnSecretsRuntimeError(cmd.ErrOrStderr(), fmt.Errorf("configure managed credential store: %w", err))
+			}
+			key := strings.TrimSpace(args[0])
+			if err := store.Delete(ctx, key); err != nil {
+				return returnSecretsRuntimeError(cmd.ErrOrStderr(), err)
+			}
+			fmt.Fprintf(cmd.OutOrStdout(), "connection disconnected: key=%s\n", key)
+			return nil
+		},
+	}
+	return cmd
+}
+
+func readConnectionClientSecret(in io.Reader, opts connectionsConnectOptions) (string, error) {
+	if !opts.clientSecretStdin {
+		return "", nil
+	}
+	raw, err := io.ReadAll(in)
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(raw)), nil
+}
+
+func readConnectionAuthCode(in io.Reader, codeStdin bool) (string, error) {
+	if !codeStdin {
+		return "", fmt.Errorf("--code-stdin is required")
+	}
+	raw, err := io.ReadAll(in)
+	if err != nil {
+		return "", err
+	}
+	code := strings.TrimSpace(string(raw))
+	if code == "" {
+		return "", fmt.Errorf("authorization code is required")
+	}
+	return code, nil
+}
+
+func loadConnectionsSource(cmd *cobra.Command, repo, contractsPath, platformSpecPath string) (semanticview.Source, error) {
+	if strings.TrimSpace(contractsPath) == "" {
+		return nil, nil
+	}
+	return loadSecretsSource(cmd, repo, contractsPath, platformSpecPath, true)
+}
+
+func connectionRecords(ctx context.Context, store runtimemanagedcredentials.Store, source semanticview.Source, args []string) ([]connectionRecord, error) {
+	if len(args) == 1 {
+		key := strings.TrimSpace(args[0])
+		record, ok, err := store.Get(ctx, key)
+		if err != nil {
+			return nil, err
+		}
+		desc := record.Descriptor()
+		if !ok {
+			desc = runtimemanagedcredentials.Descriptor{Key: key, Status: runtimemanagedcredentials.StatusUnconnected}
+		}
+		return []connectionRecord{connectionRecordFromDescriptor(desc, ok, nil)}, nil
+	}
+	descriptors, err := runtimemanagedcredentials.ListRequirementDescriptors(ctx, store, source)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]connectionRecord, 0, len(descriptors))
+	for _, desc := range descriptors {
+		out = append(out, connectionRecordFromDescriptor(desc.Descriptor, desc.Present, desc.RequiredBy))
+	}
+	return out, nil
+}
+
+func connectionRecordFromDescriptor(desc runtimemanagedcredentials.Descriptor, present bool, requiredBy []runtimemanagedcredentials.Requirement) connectionRecord {
+	record := connectionRecord{
+		Key:       strings.TrimSpace(desc.Key),
+		Provider:  strings.TrimSpace(desc.Provider),
+		Account:   strings.TrimSpace(desc.Account),
+		GrantType: strings.TrimSpace(desc.GrantType),
+		Scopes:    append([]string{}, desc.Scopes...),
+		Status:    strings.TrimSpace(desc.Status),
+		Failure:   strings.TrimSpace(desc.Failure),
+		Present:   present,
+	}
+	if !desc.ExpiresAt.IsZero() {
+		record.ExpiresAt = desc.ExpiresAt.Format(time.RFC3339)
+	}
+	if !desc.UpdatedAt.IsZero() {
+		record.UpdatedAt = desc.UpdatedAt.Format(time.RFC3339)
+	}
+	for _, item := range requiredBy {
+		record.RequiredBy = append(record.RequiredBy, connectionRequirement{
+			Kind: strings.TrimSpace(item.Kind),
+			Name: strings.TrimSpace(item.Name),
+		})
+	}
+	return record
+}
+
+func writeConnectionsTable(out io.Writer, records []connectionRecord) {
+	if out == nil {
+		return
+	}
+	writer := tabwriter.NewWriter(out, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(writer, "KEY\tPROVIDER\tACCOUNT\tGRANT\tSTATUS\tEXPIRES_AT\tREQUIRED_BY")
+	for _, record := range records {
+		fmt.Fprintf(writer, "%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+			record.Key,
+			dash(record.Provider),
+			dash(record.Account),
+			dash(record.GrantType),
+			dash(record.Status),
+			dash(record.ExpiresAt),
+			dash(formatConnectionRequirements(record.RequiredBy)),
+		)
+	}
+	_ = writer.Flush()
+}
+
+func formatConnectionRequirements(items []connectionRequirement) string {
+	if len(items) == 0 {
+		return ""
+	}
+	parts := make([]string, 0, len(items))
+	for _, item := range items {
+		item.Kind = strings.TrimSpace(item.Kind)
+		item.Name = strings.TrimSpace(item.Name)
+		if item.Kind == "" || item.Name == "" {
+			continue
+		}
+		parts = append(parts, item.Kind+":"+item.Name)
+	}
+	sort.Strings(parts)
+	return strings.Join(parts, ",")
+}

--- a/cmd/swarm/connections_test.go
+++ b/cmd/swarm/connections_test.go
@@ -1,0 +1,205 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestConnectionsClientCredentialsStatusDisconnectRedactsTokenMaterial(t *testing.T) {
+	repo := t.TempDir()
+	t.Setenv("SWARM_MANAGED_CREDENTIALS_FILE", filepath.Join(t.TempDir(), "managed.json"))
+	tokenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err != nil {
+			t.Fatalf("ParseForm: %v", err)
+		}
+		if got := r.Form.Get("grant_type"); got != "client_credentials" {
+			t.Fatalf("grant_type = %q, want client_credentials", got)
+		}
+		if got := r.Form.Get("client_secret"); got != "cli-secret" {
+			t.Fatalf("client_secret = %q, want cli-secret", got)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"access_token": "cli-access-token",
+			"expires_in":   3600,
+			"scope":        "repo.read",
+		})
+	}))
+	defer tokenServer.Close()
+
+	code, stdout, stderr := executeRootCommandWithInput(context.Background(), repo, []string{
+		"connections", "connect", "github",
+		"--grant", "client_credentials",
+		"--provider", "github",
+		"--token-url", tokenServer.URL,
+		"--client-id", "client-id",
+		"--client-secret-stdin",
+		"--scope", "repo.read",
+		"--json",
+	}, "cli-secret\n")
+	if code != 0 {
+		t.Fatalf("connections connect exit = %d err=%s", code, stderr)
+	}
+	if outputLeaksManagedSecret(stdout) {
+		t.Fatalf("connect output leaked secret material: %s", stdout)
+	}
+	if !strings.Contains(stdout, `"status": "connected"`) {
+		t.Fatalf("connect output = %s, want connected status", stdout)
+	}
+
+	var out bytes.Buffer
+	var errOut bytes.Buffer
+	out.Reset()
+	errOut.Reset()
+	code = executeRootCommand(context.Background(), repo, []string{"connections", "status", "github", "--json"}, &out, &errOut)
+	if code != 0 {
+		t.Fatalf("connections status exit = %d err=%s", code, errOut.String())
+	}
+	if outputLeaksManagedSecret(out.String()) {
+		t.Fatalf("status output leaked secret material: %s", out.String())
+	}
+	if !strings.Contains(out.String(), `"present": true`) {
+		t.Fatalf("status output = %s, want present true", out.String())
+	}
+
+	out.Reset()
+	errOut.Reset()
+	code = executeRootCommand(context.Background(), repo, []string{"connections", "disconnect", "github"}, &out, &errOut)
+	if code != 0 {
+		t.Fatalf("connections disconnect exit = %d err=%s", code, errOut.String())
+	}
+
+	out.Reset()
+	errOut.Reset()
+	code = executeRootCommand(context.Background(), repo, []string{"connections", "status", "github", "--json"}, &out, &errOut)
+	if code != 0 {
+		t.Fatalf("connections status after disconnect exit = %d err=%s", code, errOut.String())
+	}
+	if !strings.Contains(out.String(), `"present": false`) {
+		t.Fatalf("status after disconnect output = %s, want present false", out.String())
+	}
+}
+
+func TestConnectionsAuthCodeCallbackCompletesPKCERecord(t *testing.T) {
+	repo := t.TempDir()
+	t.Setenv("SWARM_MANAGED_CREDENTIALS_FILE", filepath.Join(t.TempDir(), "managed.json"))
+	tokenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err != nil {
+			t.Fatalf("ParseForm: %v", err)
+		}
+		if got := r.Form.Get("grant_type"); got != "authorization_code" {
+			t.Fatalf("grant_type = %q, want authorization_code", got)
+		}
+		if got := r.Form.Get("code"); got != "callback-code" {
+			t.Fatalf("code = %q, want callback-code", got)
+		}
+		if r.Form.Get("code_verifier") == "" {
+			t.Fatal("code_verifier is empty")
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"access_token":  "callback-access-token",
+			"refresh_token": "callback-refresh-token",
+			"expires_in":    3600,
+			"scope":         "drive.read",
+		})
+	}))
+	defer tokenServer.Close()
+
+	var out bytes.Buffer
+	var errOut bytes.Buffer
+	code := executeRootCommand(context.Background(), repo, []string{
+		"connections", "connect", "drive",
+		"--grant", "authorization_code_pkce",
+		"--provider", "google",
+		"--auth-url", tokenServer.URL + "/auth",
+		"--token-url", tokenServer.URL,
+		"--client-id", "client-id",
+		"--redirect-url", "http://127.0.0.1/callback",
+		"--scope", "drive.read",
+		"--json",
+	}, &out, &errOut)
+	if code != 0 {
+		t.Fatalf("connections connect exit = %d err=%s", code, errOut.String())
+	}
+	if outputLeaksManagedSecret(out.String()) {
+		t.Fatalf("auth connect output leaked secret material: %s", out.String())
+	}
+	var begin struct {
+		State string `json:"state"`
+	}
+	if err := json.Unmarshal(out.Bytes(), &begin); err != nil {
+		t.Fatalf("decode connect output: %v\n%s", err, out.String())
+	}
+	if begin.State == "" {
+		t.Fatalf("connect output missing state: %s", out.String())
+	}
+
+	out.Reset()
+	errOut.Reset()
+	code, stdout, stderr := executeRootCommandWithInput(context.Background(), repo, []string{
+		"connections", "callback", "drive",
+		"--state", begin.State,
+		"--code-stdin",
+		"--json",
+	}, "callback-code\n")
+	if code != 0 {
+		t.Fatalf("connections callback exit = %d err=%s", code, stderr)
+	}
+	if outputLeaksManagedSecret(stdout) {
+		t.Fatalf("callback output leaked secret material: %s", stdout)
+	}
+	if !strings.Contains(stdout, `"status": "connected"`) {
+		t.Fatalf("callback output = %s, want connected status", stdout)
+	}
+}
+
+func TestConnectionsRejectSecretBearingArgvFlags(t *testing.T) {
+	repo := t.TempDir()
+	t.Setenv("SWARM_MANAGED_CREDENTIALS_FILE", filepath.Join(t.TempDir(), "managed.json"))
+
+	code, stdout, stderr := executeRootCommandWithInput(context.Background(), repo, []string{
+		"connections", "connect", "github",
+		"--grant", "client_credentials",
+		"--token-url", "https://example.invalid/token",
+		"--client-id", "client-id",
+		"--client-secret", "argv-secret",
+	}, "")
+	if code == 0 {
+		t.Fatalf("connections connect with --client-secret exit = 0, want failure")
+	}
+	if strings.Contains(stdout+stderr, "argv-secret") {
+		t.Fatalf("--client-secret failure leaked secret stdout=%q stderr=%q", stdout, stderr)
+	}
+
+	code, stdout, stderr = executeRootCommandWithInput(context.Background(), repo, []string{
+		"connections", "callback", "github",
+		"--state", "state",
+		"--code", "argv-code",
+	}, "")
+	if code == 0 {
+		t.Fatalf("connections callback with --code exit = 0, want failure")
+	}
+	if strings.Contains(stdout+stderr, "argv-code") {
+		t.Fatalf("--code failure leaked code stdout=%q stderr=%q", stdout, stderr)
+	}
+}
+
+func outputLeaksManagedSecret(raw string) bool {
+	for _, secret := range []string{
+		"cli-access-token",
+		"cli-secret",
+		"callback-access-token",
+		"callback-refresh-token",
+		"callback-code",
+	} {
+		if strings.Contains(raw, secret) {
+			return true
+		}
+	}
+	return false
+}

--- a/cmd/swarm/main.go
+++ b/cmd/swarm/main.go
@@ -38,6 +38,7 @@ import (
 	runtimelifecycleprobe "github.com/division-sh/swarm/internal/runtime/lifecycleprobe"
 	runtimellm "github.com/division-sh/swarm/internal/runtime/llm"
 	llmselection "github.com/division-sh/swarm/internal/runtime/llm/selection"
+	runtimemanagedcredentials "github.com/division-sh/swarm/internal/runtime/managedcredentials"
 	runtimemanager "github.com/division-sh/swarm/internal/runtime/manager"
 	runtimemcp "github.com/division-sh/swarm/internal/runtime/mcp"
 	runtimepipeline "github.com/division-sh/swarm/internal/runtime/pipeline"
@@ -211,16 +212,17 @@ func selectedPostgresAPIOptionalCapabilityBuilder(pg *store.PostgresStore, store
 				SourceLoader:                   runForkSourceLoader,
 				ContractSelection:              runtimerunforkadmission.SelectedContractSelection(req.Source, req.ContractsRoot),
 				AgentRuntime: runtimerunforkexecution.SelectedContractAgentRuntimeOptions{
-					Config:            req.Config,
-					EntityStore:       stores.ToolEntityStore,
-					HumanTaskStore:    stores.HumanTaskStore,
-					SessionRegistry:   stores.SessionRegistry,
-					ConversationStore: stores.ConversationStore,
-					TurnStore:         stores.TurnStore,
-					ScheduleStore:     stores.ScheduleStore,
-					MailboxStore:      stores.MailboxStore,
-					Workspace:         req.Workspaces,
-					Credentials:       req.Credentials,
+					Config:             req.Config,
+					EntityStore:        stores.ToolEntityStore,
+					HumanTaskStore:     stores.HumanTaskStore,
+					SessionRegistry:    stores.SessionRegistry,
+					ConversationStore:  stores.ConversationStore,
+					TurnStore:          stores.TurnStore,
+					ScheduleStore:      stores.ScheduleStore,
+					MailboxStore:       stores.MailboxStore,
+					Workspace:          req.Workspaces,
+					Credentials:        req.Credentials,
+					ManagedCredentials: req.ManagedCredentials,
 				},
 			},
 			RuntimeContexts:  apiRuntimeContexts,
@@ -389,6 +391,7 @@ type serveRuntimeBundleContextRequest struct {
 	MountSources           workspaceMountSources
 	WorkspaceBackend       workspaceBackendSelection
 	Credentials            runtimecredentials.Store
+	ManagedCredentials     runtimemanagedcredentials.Store
 	BootStartedAt          time.Time
 	BootProgress           func(runtime.BootProgressEvent)
 	EnableToolGateway      bool
@@ -689,7 +692,9 @@ func buildServeRuntimeBundleContext(req serveRuntimeBundleContextRequest) (serve
 	if err := workspaces.EnsureSystemWorkspaces(req.Ctx); err != nil {
 		return serveRuntimeBundleContext{}, fmt.Errorf("ensure system workspaces: %w", err)
 	}
-	validation, err := runtime.ValidateWorkflowContractSurface(req.Ctx, loaded.source, runtime.DefaultWorkflowContractValidationOptions(req.Credentials))
+	validationOpts := runtime.DefaultWorkflowContractValidationOptions(req.Credentials)
+	validationOpts.ManagedCredentials = req.ManagedCredentials
+	validation, err := runtime.ValidateWorkflowContractSurface(req.Ctx, loaded.source, validationOpts)
 	if err != nil {
 		return serveRuntimeBundleContext{}, err
 	}
@@ -714,6 +719,7 @@ func buildServeRuntimeBundleContext(req serveRuntimeBundleContextRequest) (serve
 			BundleFingerprint:                bootIdentity.Fingerprint,
 			BundleSourceFact:                 bundleSourceFact,
 			Credentials:                      req.Credentials,
+			ManagedCredentials:               req.ManagedCredentials,
 			BootStartedAt:                    req.BootStartedAt,
 			BootProgress:                     req.BootProgress,
 			SystemContainers:                 systemWorkspaceContainers(workspaces),
@@ -964,6 +970,11 @@ func runServeRuntime(ctx context.Context, repo string, opts serveOptions) int {
 		slog.Error("configure credentials", "error", err)
 		return 1
 	}
+	managedCredentialStore, err := buildManagedCredentialStore()
+	if err != nil {
+		slog.Error("configure managed credentials", "error", err)
+		return 1
+	}
 
 	apiListener, err := listenServeHTTPListener("api", opts.APIListenAddr)
 	if err != nil {
@@ -1005,6 +1016,7 @@ func runServeRuntime(ctx context.Context, repo string, opts serveOptions) int {
 			MountSources:           mountSources,
 			WorkspaceBackend:       workspaceBackend,
 			Credentials:            credentialStore,
+			ManagedCredentials:     managedCredentialStore,
 			BootStartedAt:          bootStartedAt,
 			BootProgress:           reporter.runtimeSink(),
 			EnableToolGateway:      i == 0,
@@ -1065,6 +1077,7 @@ func runServeRuntime(ctx context.Context, repo string, opts serveOptions) int {
 		Config:                  cfg,
 		Workspaces:              workspaces,
 		Credentials:             credentialStore,
+		ManagedCredentials:      managedCredentialStore,
 	})
 	if err != nil {
 		reporter.emit(5, "runtime_context", "FAILED", err.Error())
@@ -1623,6 +1636,13 @@ func runForkRuntimeOwnerHarness(ctx context.Context, repo string, args []string,
 			}
 			return 1
 		}
+		managedCredentialStore, err := buildManagedCredentialStore()
+		if err != nil {
+			if out != nil {
+				fmt.Fprintf(out, "fork failed: configure managed credentials: %v\n", err)
+			}
+			return 1
+		}
 		selectedProject := resolveLocalRuntimeStateProject(repo, cliContractPlatformSpecPaths{ContractsPath: contractsRoot})
 		mountSources, err := resolveWorkspaceMountSourcesForLocalState(repo, "", cfg, selectedProject, true)
 		if err != nil {
@@ -1654,16 +1674,17 @@ func runForkRuntimeOwnerHarness(ctx context.Context, repo string, args []string,
 			},
 			ContractSelection: runtimerunforkadmission.SelectedContractSelection(source, contractsRoot),
 			AgentRuntime: runtimerunforkexecution.SelectedContractAgentRuntimeOptions{
-				Config:            cfg,
-				EntityStore:       stores.ToolEntityStore,
-				HumanTaskStore:    stores.HumanTaskStore,
-				SessionRegistry:   stores.SessionRegistry,
-				ConversationStore: stores.ConversationStore,
-				TurnStore:         stores.TurnStore,
-				ScheduleStore:     stores.ScheduleStore,
-				MailboxStore:      stores.MailboxStore,
-				Workspace:         workspaces,
-				Credentials:       credentialStore,
+				Config:             cfg,
+				EntityStore:        stores.ToolEntityStore,
+				HumanTaskStore:     stores.HumanTaskStore,
+				SessionRegistry:    stores.SessionRegistry,
+				ConversationStore:  stores.ConversationStore,
+				TurnStore:          stores.TurnStore,
+				ScheduleStore:      stores.ScheduleStore,
+				MailboxStore:       stores.MailboxStore,
+				Workspace:          workspaces,
+				Credentials:        credentialStore,
+				ManagedCredentials: managedCredentialStore,
 			},
 		})
 		if err != nil {
@@ -2175,7 +2196,13 @@ func verifyBundleResult(ctx context.Context, source semanticview.Source) (runtim
 	if err != nil {
 		return runtime.WorkflowContractValidationResult{}, fmt.Errorf("configure credentials: %w", err)
 	}
-	return verifyBundleResultWithOptions(ctx, source, runtime.DefaultWorkflowContractValidationOptions(credentialStore))
+	managedCredentialStore, err := buildManagedCredentialStore()
+	if err != nil {
+		return runtime.WorkflowContractValidationResult{}, fmt.Errorf("configure managed credentials: %w", err)
+	}
+	opts := runtime.DefaultWorkflowContractValidationOptions(credentialStore)
+	opts.ManagedCredentials = managedCredentialStore
+	return verifyBundleResultWithOptions(ctx, source, opts)
 }
 
 func verifyBundleResultWithOptions(ctx context.Context, source semanticview.Source, opts runtime.WorkflowContractValidationOptions) (runtime.WorkflowContractValidationResult, error) {
@@ -2191,6 +2218,11 @@ func verifyWorkflowContractValidationOptions(repo string) (runtime.WorkflowContr
 		return runtime.WorkflowContractValidationOptions{}, fmt.Errorf("configure credentials: %w", err)
 	}
 	opts := runtime.DefaultWorkflowContractValidationOptions(credentialStore)
+	managedCredentialStore, err := buildManagedCredentialStore()
+	if err != nil {
+		return runtime.WorkflowContractValidationOptions{}, fmt.Errorf("configure managed credentials: %w", err)
+	}
+	opts.ManagedCredentials = managedCredentialStore
 	configResult, err := loadRuntimeConfigWithOptions(runtimeConfigLoadOptions{RepoRoot: repo})
 	if err != nil {
 		return runtime.WorkflowContractValidationOptions{}, fmt.Errorf("load runtime config: %w", err)
@@ -3256,6 +3288,10 @@ func buildCredentialStore() (runtimecredentials.Store, error) {
 		return nil, err
 	}
 	return runtimecredentials.NewOverlayStore(runtimecredentials.NewEnvStore(), fileStore), nil
+}
+
+func buildManagedCredentialStore() (runtimemanagedcredentials.Store, error) {
+	return runtimemanagedcredentials.NewDefaultFileStore()
 }
 
 func configuredWorkspaceLifecycle(db *sql.DB, contractsRoot string, source semanticview.Source, mountSources workspaceMountSources) (*workspace.DockerManager, error) {

--- a/cmd/swarm/store_facade.go
+++ b/cmd/swarm/store_facade.go
@@ -9,6 +9,7 @@ import (
 	"github.com/division-sh/swarm/internal/config"
 	"github.com/division-sh/swarm/internal/runtime"
 	runtimecredentials "github.com/division-sh/swarm/internal/runtime/credentials"
+	runtimemanagedcredentials "github.com/division-sh/swarm/internal/runtime/managedcredentials"
 	runtimerunforkexecution "github.com/division-sh/swarm/internal/runtime/runforkexecution"
 	"github.com/division-sh/swarm/internal/runtime/semanticview"
 	runtimestartuprecovery "github.com/division-sh/swarm/internal/runtime/startuprecovery"
@@ -72,6 +73,7 @@ type selectedAPICapabilityRequest struct {
 	Config                  *config.Config
 	Workspaces              serveWorkspaceLifecycle
 	Credentials             runtimecredentials.Store
+	ManagedCredentials      runtimemanagedcredentials.Store
 }
 
 type selectedAPIOptionalCapabilityBuilder func(selectedAPICapabilityRequest) (selectedAPICapabilities, error)

--- a/internal/runtime/bootverify/managed_credentials_test.go
+++ b/internal/runtime/bootverify/managed_credentials_test.go
@@ -1,0 +1,98 @@
+package bootverify
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
+	runtimemanagedcredentials "github.com/division-sh/swarm/internal/runtime/managedcredentials"
+	"github.com/division-sh/swarm/internal/runtime/semanticview"
+)
+
+func TestBootVerifyReportsManagedCredentialState(t *testing.T) {
+	source := managedCredentialBootSource([]string{"repo.read", "repo.write"})
+
+	t.Run("missing store", func(t *testing.T) {
+		report := Run(context.Background(), source, Options{})
+		if !managedCredentialFindingContains(report.Findings, "managed credential github is missing") {
+			t.Fatalf("findings = %#v, want missing managed credential", report.Findings)
+		}
+	})
+
+	t.Run("unconnected", func(t *testing.T) {
+		store := runtimemanagedcredentials.NewMemoryStore(runtimemanagedcredentials.Record{
+			Key:    "github",
+			Status: runtimemanagedcredentials.StatusPendingConsent,
+		})
+		report := Run(context.Background(), source, Options{ManagedCredentials: store})
+		if !managedCredentialFindingContains(report.Findings, "managed credential github is pending_consent") {
+			t.Fatalf("findings = %#v, want pending_consent managed credential", report.Findings)
+		}
+	})
+
+	t.Run("refresh failed", func(t *testing.T) {
+		store := runtimemanagedcredentials.NewMemoryStore(runtimemanagedcredentials.Record{
+			Key:     "github",
+			Status:  runtimemanagedcredentials.StatusRefreshFailed,
+			Failure: "refresh failed",
+		})
+		report := Run(context.Background(), source, Options{ManagedCredentials: store})
+		if !managedCredentialFindingContains(report.Findings, "refresh_failed") || !managedCredentialFindingContains(report.Findings, "refresh failed") {
+			t.Fatalf("findings = %#v, want refresh failure managed credential", report.Findings)
+		}
+	})
+
+	t.Run("scope insufficient", func(t *testing.T) {
+		store := runtimemanagedcredentials.NewMemoryStore(runtimemanagedcredentials.Record{
+			Key:         "github",
+			Status:      runtimemanagedcredentials.StatusConnected,
+			Scopes:      []string{"repo.read"},
+			AccessToken: "access-token",
+		})
+		report := Run(context.Background(), source, Options{ManagedCredentials: store})
+		if !managedCredentialFindingContains(report.Findings, "scope_insufficient") || !managedCredentialFindingContains(report.Findings, "repo.write") {
+			t.Fatalf("findings = %#v, want scope-insufficient managed credential", report.Findings)
+		}
+	})
+
+	t.Run("connected", func(t *testing.T) {
+		store := runtimemanagedcredentials.NewMemoryStore(runtimemanagedcredentials.Record{
+			Key:         "github",
+			Status:      runtimemanagedcredentials.StatusConnected,
+			Scopes:      []string{"repo.read", "repo.write"},
+			AccessToken: "access-token",
+		})
+		report := Run(context.Background(), source, Options{ManagedCredentials: store})
+		if managedCredentialFindingContains(report.Findings, "managed credential github") {
+			t.Fatalf("findings = %#v, want no managed credential warning", report.Findings)
+		}
+	})
+}
+
+func managedCredentialBootSource(scopes []string) semanticview.Source {
+	return semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
+		Tools: map[string]runtimecontracts.ToolSchemaEntry{
+			"send_provider": {
+				HandlerType: "http",
+				HTTP: &runtimecontracts.HTTPToolSpec{
+					Method: "GET",
+					URL:    "https://provider.example.test",
+				},
+				ManagedCredential: &runtimecontracts.ManagedCredentialRef{
+					Key:    "github",
+					Scopes: scopes,
+				},
+			},
+		},
+	})
+}
+
+func managedCredentialFindingContains(findings []Finding, want string) bool {
+	for _, finding := range findings {
+		if finding.CheckID == "managed_credential_state" && strings.Contains(finding.Message, want) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/runtime/bootverify/report.go
+++ b/internal/runtime/bootverify/report.go
@@ -8,6 +8,7 @@ import (
 
 	runtimecredentials "github.com/division-sh/swarm/internal/runtime/credentials"
 	llmselection "github.com/division-sh/swarm/internal/runtime/llm/selection"
+	runtimemanagedcredentials "github.com/division-sh/swarm/internal/runtime/managedcredentials"
 	"github.com/division-sh/swarm/internal/runtime/semanticview"
 )
 
@@ -39,6 +40,7 @@ type Report struct {
 
 type Options struct {
 	Credentials             runtimecredentials.Store
+	ManagedCredentials      runtimemanagedcredentials.Store
 	CheckMCPReachable       bool
 	ValidateModelResolution bool
 	LLMProfile              llmselection.Profile

--- a/internal/runtime/bootverify/runtime_external_resource_checks.go
+++ b/internal/runtime/bootverify/runtime_external_resource_checks.go
@@ -1,9 +1,12 @@
 package bootverify
 
 import (
+	"fmt"
+	"sort"
 	"strings"
 
 	runtimecredentials "github.com/division-sh/swarm/internal/runtime/credentials"
+	runtimemanagedcredentials "github.com/division-sh/swarm/internal/runtime/managedcredentials"
 	runtimemcp "github.com/division-sh/swarm/internal/runtime/mcp"
 )
 
@@ -12,32 +15,73 @@ func (c *checkerContext) credentials() []Finding {
 		return c.credentialFindings
 	}
 	c.credentialLoaded = true
-	if c.opts.Credentials == nil {
-		return nil
+	if c.opts.Credentials != nil {
+		missing, err := runtimecredentials.MissingRequired(c.ctx, c.opts.Credentials, c.source)
+		if err != nil {
+			c.credentialFindings = append(c.credentialFindings, Finding{
+				CheckID:  "credential_key_exists",
+				Severity: "error",
+				Message:  strings.TrimSpace(err.Error()),
+				Location: "global",
+			})
+			return c.credentialFindings
+		}
+		for _, item := range missing {
+			requiredBy := make([]string, 0, len(item.RequiredBy))
+			for _, ref := range item.RequiredBy {
+				requiredBy = append(requiredBy, strings.TrimSpace(ref.Kind)+" "+strings.TrimSpace(ref.Name))
+			}
+			c.credentialFindings = append(c.credentialFindings, Finding{
+				CheckID:  "credential_key_exists",
+				Severity: "warning",
+				Message:  fmtCredentialWarning(item.Key, requiredBy),
+				Location: item.Key,
+			})
+		}
 	}
-	missing, err := runtimecredentials.MissingRequired(c.ctx, c.opts.Credentials, c.source)
+	managed, err := runtimemanagedcredentials.MissingOrUnusableRequired(c.ctx, c.opts.ManagedCredentials, c.source)
 	if err != nil {
 		c.credentialFindings = append(c.credentialFindings, Finding{
-			CheckID:  "credential_key_exists",
+			CheckID:  "managed_credential_state",
 			Severity: "error",
 			Message:  strings.TrimSpace(err.Error()),
 			Location: "global",
 		})
 		return c.credentialFindings
 	}
-	for _, item := range missing {
+	for _, item := range managed {
 		requiredBy := make([]string, 0, len(item.RequiredBy))
 		for _, ref := range item.RequiredBy {
 			requiredBy = append(requiredBy, strings.TrimSpace(ref.Kind)+" "+strings.TrimSpace(ref.Name))
 		}
 		c.credentialFindings = append(c.credentialFindings, Finding{
-			CheckID:  "credential_key_exists",
+			CheckID:  "managed_credential_state",
 			Severity: "warning",
-			Message:  fmtCredentialWarning(item.Key, requiredBy),
+			Message:  fmtManagedCredentialWarning(item, requiredBy),
 			Location: item.Key,
 		})
 	}
 	return c.credentialFindings
+}
+
+func fmtManagedCredentialWarning(item runtimemanagedcredentials.RequirementDescriptor, requiredBy []string) string {
+	key := strings.TrimSpace(item.Key)
+	status := strings.TrimSpace(item.Status)
+	if status == "" {
+		status = runtimemanagedcredentials.StatusUnconnected
+	}
+	message := fmt.Sprintf("managed credential %s is %s", key, status)
+	if !item.Present {
+		message = fmt.Sprintf("managed credential %s is missing", key)
+	}
+	if failure := strings.TrimSpace(item.Failure); failure != "" {
+		message += ": " + failure
+	}
+	if len(requiredBy) > 0 {
+		sort.Strings(requiredBy)
+		message += " (required by " + strings.Join(requiredBy, ", ") + ")"
+	}
+	return message
 }
 
 func (c *checkerContext) mcp() []Finding {

--- a/internal/runtime/bus/eventbus_publish_test.go
+++ b/internal/runtime/bus/eventbus_publish_test.go
@@ -1291,7 +1291,8 @@ func TestEventBusPublishAcknowledgedReturnsBeforePostCommitDispatchCompletes(t *
 			events.EventEnvelope{EntityID: "11111111-1111-1111-1111-111111111137"},
 			time.Now().UTC()))
 	}()
-	if err := requireErrorBefore(t, publishDone, 250*time.Millisecond, "acknowledged publish return before interceptor release"); err != nil {
+	requireSignalBefore(t, started, 5*time.Second, "async post-commit interceptor start")
+	if err := requireErrorBefore(t, publishDone, 5*time.Second, "acknowledged publish return before interceptor release"); err != nil {
 		t.Fatalf("PublishAcknowledged: %v", err)
 	}
 
@@ -1315,7 +1316,6 @@ func TestEventBusPublishAcknowledgedReturnsBeforePostCommitDispatchCompletes(t *
 		t.Fatalf("committed replay scope = %q, want %q", gotScope, runtimereplayclaim.CommittedReplayScopeSubscribed)
 	}
 
-	requireSignalBefore(t, started, time.Second, "async post-commit interceptor start")
 	waitCtx, cancel := context.WithTimeout(context.Background(), 25*time.Millisecond)
 	defer cancel()
 	if err := eb.WaitForQuiescence(waitCtx); !errors.Is(err, context.DeadlineExceeded) {

--- a/internal/runtime/contracts/workflow_contract_types.go
+++ b/internal/runtime/contracts/workflow_contract_types.go
@@ -618,6 +618,12 @@ type HTTPToolSpec struct {
 	TimeoutSeconds int               `yaml:"timeout_seconds"`
 	Retry          HTTPToolRetrySpec `yaml:"retry"`
 }
+type ManagedCredentialRef struct {
+	Key    string   `yaml:"key"`
+	Header string   `yaml:"header"`
+	Prefix string   `yaml:"prefix"`
+	Scopes []string `yaml:"scopes"`
+}
 type ToolInputSchema struct {
 	Type                 string                     `yaml:"type"`
 	Description          string                     `yaml:"description"`
@@ -1363,18 +1369,19 @@ func (e AgentRegistryEntry) ConfiguredTools() []string {
 }
 
 type ToolSchemaEntry struct {
-	Category           string          `yaml:"category"`
-	Description        string          `yaml:"description"`
-	HandlerType        string          `yaml:"handler_type"`
-	Permission         string          `yaml:"permission"`
-	RequiredPermission string          `yaml:"required_permission"`
-	RateLimit          string          `yaml:"rate_limit"`
-	RateLimitMaxWait   string          `yaml:"rate_limit_max_wait"`
-	InputSchema        ToolInputSchema `yaml:"input_schema"`
-	OutputSchema       ToolInputSchema `yaml:"output_schema"`
-	HTTP               *HTTPToolSpec   `yaml:"http"`
-	ResponseMapping    map[string]any  `yaml:"response_mapping"`
-	Credentials        []string        `yaml:"credentials"`
+	Category           string                `yaml:"category"`
+	Description        string                `yaml:"description"`
+	HandlerType        string                `yaml:"handler_type"`
+	Permission         string                `yaml:"permission"`
+	RequiredPermission string                `yaml:"required_permission"`
+	RateLimit          string                `yaml:"rate_limit"`
+	RateLimitMaxWait   string                `yaml:"rate_limit_max_wait"`
+	InputSchema        ToolInputSchema       `yaml:"input_schema"`
+	OutputSchema       ToolInputSchema       `yaml:"output_schema"`
+	HTTP               *HTTPToolSpec         `yaml:"http"`
+	ResponseMapping    map[string]any        `yaml:"response_mapping"`
+	Credentials        []string              `yaml:"credentials"`
+	ManagedCredential  *ManagedCredentialRef `yaml:"managed_credential"`
 }
 type PlatformSpecDocument struct {
 	Platform struct {

--- a/internal/runtime/contracts/workflow_contract_yaml_schema.go
+++ b/internal/runtime/contracts/workflow_contract_yaml_schema.go
@@ -267,6 +267,12 @@ func (t *ToolSchemaEntry) UnmarshalYAML(node *yaml.Node) error {
 	t.Permission = strings.TrimSpace(t.Permission)
 	t.RequiredPermission = strings.TrimSpace(t.RequiredPermission)
 	t.Credentials = normalizeStrings(t.Credentials)
+	if t.ManagedCredential != nil {
+		t.ManagedCredential.Key = strings.TrimSpace(t.ManagedCredential.Key)
+		t.ManagedCredential.Header = strings.TrimSpace(t.ManagedCredential.Header)
+		t.ManagedCredential.Prefix = strings.TrimSpace(t.ManagedCredential.Prefix)
+		t.ManagedCredential.Scopes = normalizeStrings(t.ManagedCredential.Scopes)
+	}
 	if t.HTTP != nil {
 		t.HTTP.Method = strings.TrimSpace(t.HTTP.Method)
 		t.HTTP.URL = strings.TrimSpace(t.HTTP.URL)

--- a/internal/runtime/managedcredentials/file_lock_other.go
+++ b/internal/runtime/managedcredentials/file_lock_other.go
@@ -1,0 +1,9 @@
+//go:build !aix && !darwin && !dragonfly && !freebsd && !hurd && !illumos && !linux && !netbsd && !openbsd && !solaris && !windows
+
+package managedcredentials
+
+import "fmt"
+
+func lockManagedCredentialFile(lockPath string) (func(), error) {
+	return nil, fmt.Errorf("%w: %s", ErrStoreLockUnsupported, lockPath)
+}

--- a/internal/runtime/managedcredentials/file_lock_unix.go
+++ b/internal/runtime/managedcredentials/file_lock_unix.go
@@ -1,0 +1,29 @@
+//go:build aix || darwin || dragonfly || freebsd || hurd || illumos || linux || netbsd || openbsd || solaris
+
+package managedcredentials
+
+import (
+	"errors"
+	"fmt"
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+func lockManagedCredentialFile(lockPath string) (func(), error) {
+	lock, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		return nil, fmt.Errorf("open managed credential lock %s: %w", lockPath, err)
+	}
+	if err := unix.Flock(int(lock.Fd()), unix.LOCK_EX|unix.LOCK_NB); err != nil {
+		_ = lock.Close()
+		if errors.Is(err, unix.EWOULDBLOCK) || errors.Is(err, unix.EAGAIN) {
+			return nil, fmt.Errorf("%w: %s", ErrStoreLocked, lockPath)
+		}
+		return nil, fmt.Errorf("lock managed credential file %s: %w", lockPath, err)
+	}
+	return func() {
+		_ = unix.Flock(int(lock.Fd()), unix.LOCK_UN)
+		_ = lock.Close()
+	}, nil
+}

--- a/internal/runtime/managedcredentials/file_lock_windows.go
+++ b/internal/runtime/managedcredentials/file_lock_windows.go
@@ -1,0 +1,32 @@
+//go:build windows
+
+package managedcredentials
+
+import (
+	"errors"
+	"fmt"
+	"os"
+
+	"golang.org/x/sys/windows"
+)
+
+func lockManagedCredentialFile(lockPath string) (func(), error) {
+	lock, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		return nil, fmt.Errorf("open managed credential lock %s: %w", lockPath, err)
+	}
+	handle := windows.Handle(lock.Fd())
+	overlapped := &windows.Overlapped{}
+	flags := uint32(windows.LOCKFILE_EXCLUSIVE_LOCK | windows.LOCKFILE_FAIL_IMMEDIATELY)
+	if err := windows.LockFileEx(handle, flags, 0, 1, 0, overlapped); err != nil {
+		_ = lock.Close()
+		if errors.Is(err, windows.ERROR_LOCK_VIOLATION) {
+			return nil, fmt.Errorf("%w: %s", ErrStoreLocked, lockPath)
+		}
+		return nil, fmt.Errorf("lock managed credential file %s: %w", lockPath, err)
+	}
+	return func() {
+		_ = windows.UnlockFileEx(handle, 0, 1, 0, overlapped)
+		_ = lock.Close()
+	}, nil
+}

--- a/internal/runtime/managedcredentials/requirements.go
+++ b/internal/runtime/managedcredentials/requirements.go
@@ -1,0 +1,177 @@
+package managedcredentials
+
+import (
+	"context"
+	"sort"
+	"strings"
+
+	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
+	"github.com/division-sh/swarm/internal/runtime/semanticview"
+)
+
+type Requirement struct {
+	Kind   string
+	Name   string
+	Scopes []string `json:"scopes,omitempty"`
+}
+
+type RequirementDescriptor struct {
+	Descriptor
+	Present    bool          `json:"present"`
+	RequiredBy []Requirement `json:"required_by,omitempty"`
+}
+
+func BuildRequirementIndex(source semanticview.Source) map[string][]Requirement {
+	index := map[string][]Requirement{}
+	if source == nil {
+		return index
+	}
+	appendToolRequirements(index, source, "", source.ToolEntries())
+	for _, scope := range source.ProjectScopes() {
+		appendToolRequirements(index, source, strings.TrimSpace(scope.OwningFlowID), scope.Tools)
+	}
+	for _, scope := range source.FlowScopes() {
+		appendToolRequirements(index, source, strings.TrimSpace(scope.ID), scope.Tools)
+	}
+	for key, refs := range index {
+		index[key] = normalizeRequirements(refs)
+	}
+	return index
+}
+
+func appendToolRequirements(index map[string][]Requirement, source semanticview.Source, flowID string, entries map[string]runtimecontracts.ToolSchemaEntry) {
+	for name, entry := range entries {
+		name = strings.TrimSpace(name)
+		if name == "" || entry.ManagedCredential == nil {
+			continue
+		}
+		key := strings.TrimSpace(entry.ManagedCredential.Key)
+		if key == "" {
+			continue
+		}
+		storeKey, mapped := semanticview.CredentialStoreKeyForFlow(source, flowID, key)
+		if mapped && strings.TrimSpace(storeKey) == "" {
+			continue
+		}
+		storeKey = strings.TrimSpace(storeKey)
+		if storeKey == "" {
+			continue
+		}
+		index[storeKey] = append(index[storeKey], Requirement{Kind: "tool", Name: name, Scopes: append([]string{}, entry.ManagedCredential.Scopes...)})
+	}
+}
+
+func ListRequirementDescriptors(ctx context.Context, store Store, source semanticview.Source) ([]RequirementDescriptor, error) {
+	index := BuildRequirementIndex(source)
+	keys := make([]string, 0)
+	seen := map[string]struct{}{}
+	for key := range index {
+		seen[key] = struct{}{}
+		keys = append(keys, key)
+	}
+	if store != nil {
+		descriptors, err := store.List(ctx)
+		if err != nil {
+			return nil, err
+		}
+		for _, desc := range descriptors {
+			key := strings.TrimSpace(desc.Key)
+			if key == "" {
+				continue
+			}
+			if _, ok := seen[key]; ok {
+				continue
+			}
+			seen[key] = struct{}{}
+			keys = append(keys, key)
+		}
+	}
+	sort.Strings(keys)
+	out := make([]RequirementDescriptor, 0, len(keys))
+	for _, key := range keys {
+		desc, present, err := describe(ctx, store, key)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, RequirementDescriptor{
+			Descriptor: desc,
+			Present:    present,
+			RequiredBy: append([]Requirement{}, index[key]...),
+		})
+	}
+	return out, nil
+}
+
+func MissingOrUnusableRequired(ctx context.Context, store Store, source semanticview.Source) ([]RequirementDescriptor, error) {
+	descriptors, err := ListRequirementDescriptors(ctx, store, source)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]RequirementDescriptor, 0)
+	for _, desc := range descriptors {
+		if len(desc.RequiredBy) == 0 {
+			continue
+		}
+		if !desc.Present || desc.Status != StatusConnected {
+			out = append(out, desc)
+			continue
+		}
+		for _, req := range desc.RequiredBy {
+			if err := ensureScopes(desc.Scopes, req.Scopes); err != nil {
+				scoped := desc
+				scoped.Status = StatusScopeInsufficient
+				scoped.Failure = "scope-insufficient: " + err.Error()
+				out = append(out, scoped)
+				break
+			}
+		}
+	}
+	return out, nil
+}
+
+func describe(ctx context.Context, store Store, key string) (Descriptor, bool, error) {
+	key = strings.TrimSpace(key)
+	if key == "" {
+		return Descriptor{}, false, nil
+	}
+	if store == nil {
+		return Descriptor{Key: key, Status: StatusUnconnected}, false, nil
+	}
+	record, ok, err := store.Get(ctx, key)
+	if err != nil {
+		return Descriptor{}, false, err
+	}
+	if !ok {
+		return Descriptor{Key: key, Status: StatusUnconnected}, false, nil
+	}
+	return record.Descriptor(), true, nil
+}
+
+func normalizeRequirements(items []Requirement) []Requirement {
+	if len(items) == 0 {
+		return nil
+	}
+	out := make([]Requirement, 0, len(items))
+	seen := map[string]struct{}{}
+	for _, item := range items {
+		item.Kind = strings.TrimSpace(item.Kind)
+		item.Name = strings.TrimSpace(item.Name)
+		item.Scopes = normalizeStrings(item.Scopes)
+		if item.Kind == "" || item.Name == "" {
+			continue
+		}
+		key := item.Kind + "\x00" + item.Name + "\x00" + strings.Join(item.Scopes, "\x00")
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		out = append(out, item)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Kind == out[j].Kind {
+			return out[i].Name < out[j].Name
+		}
+		return out[i].Kind < out[j].Kind
+	})
+	return out
+}

--- a/internal/runtime/managedcredentials/store.go
+++ b/internal/runtime/managedcredentials/store.go
@@ -1,0 +1,904 @@
+package managedcredentials
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+)
+
+const (
+	GrantAuthorizationCodePKCE = "authorization_code_pkce"
+	GrantClientCredentials     = "client_credentials"
+
+	StatusUnconnected       = "unconnected"
+	StatusPendingConsent    = "pending_consent"
+	StatusConnected         = "connected"
+	StatusRefreshFailed     = "refresh_failed"
+	StatusScopeInsufficient = "scope_insufficient"
+)
+
+const defaultRefreshWindow = 60 * time.Second
+
+var ErrStoreLocked = errors.New("managed credential store is locked")
+
+var ErrStoreLockUnsupported = errors.New("managed credential store locking is unsupported on this platform")
+
+type Store interface {
+	Get(ctx context.Context, key string) (Record, bool, error)
+	Put(ctx context.Context, record Record) error
+	Delete(ctx context.Context, key string) error
+	List(ctx context.Context) ([]Descriptor, error)
+}
+
+type Record struct {
+	Key             string    `json:"key"`
+	Provider        string    `json:"provider"`
+	Account         string    `json:"account,omitempty"`
+	GrantType       string    `json:"grant_type"`
+	AuthURL         string    `json:"auth_url,omitempty"`
+	TokenURL        string    `json:"token_url"`
+	ClientID        string    `json:"client_id"`
+	ClientSecret    string    `json:"client_secret,omitempty"`
+	RedirectURL     string    `json:"redirect_url,omitempty"`
+	Scopes          []string  `json:"scopes,omitempty"`
+	AccessToken     string    `json:"access_token,omitempty"`
+	RefreshToken    string    `json:"refresh_token,omitempty"`
+	TokenType       string    `json:"token_type,omitempty"`
+	ExpiresAt       time.Time `json:"expires_at,omitempty"`
+	Status          string    `json:"status"`
+	Failure         string    `json:"failure,omitempty"`
+	PKCEVerifier    string    `json:"pkce_verifier,omitempty"`
+	PKCEChallenge   string    `json:"pkce_challenge,omitempty"`
+	OAuthState      string    `json:"oauth_state,omitempty"`
+	RefreshWindowMS int64     `json:"refresh_window_ms,omitempty"`
+	UpdatedAt       time.Time `json:"updated_at"`
+}
+
+type Descriptor struct {
+	Key       string    `json:"key"`
+	Provider  string    `json:"provider,omitempty"`
+	Account   string    `json:"account,omitempty"`
+	GrantType string    `json:"grant_type,omitempty"`
+	Scopes    []string  `json:"scopes,omitempty"`
+	Status    string    `json:"status"`
+	Failure   string    `json:"failure,omitempty"`
+	ExpiresAt time.Time `json:"expires_at,omitempty"`
+	UpdatedAt time.Time `json:"updated_at,omitempty"`
+}
+
+type BeginAuthCodeRequest struct {
+	Key          string
+	Provider     string
+	AuthURL      string
+	TokenURL     string
+	ClientID     string
+	ClientSecret string
+	RedirectURL  string
+	Scopes       []string
+	Account      string
+}
+
+type BeginAuthCodeResult struct {
+	Key          string
+	State        string
+	CodeVerifier string
+	AuthorizeURL string
+}
+
+type CompleteAuthCodeRequest struct {
+	Key   string
+	State string
+	Code  string
+}
+
+type ClientCredentialsRequest struct {
+	Key          string
+	Provider     string
+	TokenURL     string
+	ClientID     string
+	ClientSecret string
+	Scopes       []string
+	Account      string
+}
+
+type AccessTokenRequest struct {
+	Key    string
+	Scopes []string
+}
+
+type TokenSource struct {
+	Store         Store
+	HTTPClient    *http.Client
+	Now           func() time.Time
+	RefreshWindow time.Duration
+}
+
+func DefaultFilePath() (string, error) {
+	if raw := strings.TrimSpace(os.Getenv("SWARM_MANAGED_CREDENTIALS_FILE")); raw != "" {
+		return raw, nil
+	}
+	cfg, err := os.UserConfigDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(cfg, "swarm", "managed_credentials.json"), nil
+}
+
+func NewDefaultFileStore() (*FileStore, error) {
+	path, err := DefaultFilePath()
+	if err != nil {
+		return nil, err
+	}
+	return NewFileStore(path)
+}
+
+func (s *TokenSource) BeginAuthCodePKCE(ctx context.Context, req BeginAuthCodeRequest) (BeginAuthCodeResult, error) {
+	if s == nil || s.Store == nil {
+		return BeginAuthCodeResult{}, fmt.Errorf("managed credential store is not configured")
+	}
+	key := strings.TrimSpace(req.Key)
+	if key == "" {
+		return BeginAuthCodeResult{}, fmt.Errorf("managed credential key is required")
+	}
+	authURL := strings.TrimSpace(req.AuthURL)
+	tokenURL := strings.TrimSpace(req.TokenURL)
+	clientID := strings.TrimSpace(req.ClientID)
+	redirectURL := strings.TrimSpace(req.RedirectURL)
+	if authURL == "" || tokenURL == "" || clientID == "" || redirectURL == "" {
+		return BeginAuthCodeResult{}, fmt.Errorf("auth_url, token_url, client_id, and redirect_url are required for authorization_code_pkce")
+	}
+	verifier, err := randomURLToken(48)
+	if err != nil {
+		return BeginAuthCodeResult{}, err
+	}
+	state, err := randomURLToken(32)
+	if err != nil {
+		return BeginAuthCodeResult{}, err
+	}
+	challenge := pkceChallenge(verifier)
+	values := url.Values{}
+	values.Set("response_type", "code")
+	values.Set("client_id", clientID)
+	values.Set("redirect_uri", redirectURL)
+	values.Set("code_challenge", challenge)
+	values.Set("code_challenge_method", "S256")
+	values.Set("state", state)
+	if scopes := normalizeStrings(req.Scopes); len(scopes) > 0 {
+		values.Set("scope", strings.Join(scopes, " "))
+	}
+	parsed, err := url.Parse(authURL)
+	if err != nil {
+		return BeginAuthCodeResult{}, fmt.Errorf("parse auth_url: %w", err)
+	}
+	query := parsed.Query()
+	for key, items := range values {
+		for _, item := range items {
+			query.Add(key, item)
+		}
+	}
+	parsed.RawQuery = query.Encode()
+	record := Record{
+		Key:           key,
+		Provider:      strings.TrimSpace(req.Provider),
+		Account:       strings.TrimSpace(req.Account),
+		GrantType:     GrantAuthorizationCodePKCE,
+		AuthURL:       authURL,
+		TokenURL:      tokenURL,
+		ClientID:      clientID,
+		ClientSecret:  strings.TrimSpace(req.ClientSecret),
+		RedirectURL:   redirectURL,
+		Scopes:        normalizeStrings(req.Scopes),
+		Status:        StatusPendingConsent,
+		PKCEVerifier:  verifier,
+		PKCEChallenge: challenge,
+		OAuthState:    state,
+		UpdatedAt:     s.now(),
+	}
+	if err := s.Store.Put(ctx, record); err != nil {
+		return BeginAuthCodeResult{}, err
+	}
+	return BeginAuthCodeResult{
+		Key:          key,
+		State:        state,
+		CodeVerifier: verifier,
+		AuthorizeURL: parsed.String(),
+	}, nil
+}
+
+func (s *TokenSource) CompleteAuthCode(ctx context.Context, req CompleteAuthCodeRequest) (Record, error) {
+	record, ok, err := s.record(ctx, req.Key)
+	if err != nil {
+		return Record{}, err
+	}
+	if !ok {
+		return Record{}, fmt.Errorf("missing managed credential %q", strings.TrimSpace(req.Key))
+	}
+	if record.GrantType != GrantAuthorizationCodePKCE {
+		return Record{}, fmt.Errorf("managed credential %q grant_type is %q, want %s", record.Key, record.GrantType, GrantAuthorizationCodePKCE)
+	}
+	if strings.TrimSpace(record.OAuthState) == "" || strings.TrimSpace(req.State) != record.OAuthState {
+		return Record{}, fmt.Errorf("managed credential %q callback state mismatch", record.Key)
+	}
+	if strings.TrimSpace(req.Code) == "" {
+		return Record{}, fmt.Errorf("authorization code is required")
+	}
+	values := url.Values{}
+	values.Set("grant_type", "authorization_code")
+	values.Set("code", strings.TrimSpace(req.Code))
+	values.Set("redirect_uri", strings.TrimSpace(record.RedirectURL))
+	values.Set("client_id", strings.TrimSpace(record.ClientID))
+	values.Set("code_verifier", strings.TrimSpace(record.PKCEVerifier))
+	if strings.TrimSpace(record.ClientSecret) != "" {
+		values.Set("client_secret", strings.TrimSpace(record.ClientSecret))
+	}
+	updated, err := s.exchange(ctx, record, values)
+	if err != nil {
+		return s.markFailure(ctx, record, err, req.Code)
+	}
+	updated.Status = StatusConnected
+	updated.Failure = ""
+	updated.OAuthState = ""
+	updated.PKCEVerifier = ""
+	updated.PKCEChallenge = ""
+	updated.UpdatedAt = s.now()
+	if err := s.Store.Put(ctx, updated); err != nil {
+		return Record{}, err
+	}
+	return updated, nil
+}
+
+func (s *TokenSource) ConnectClientCredentials(ctx context.Context, req ClientCredentialsRequest) (Record, error) {
+	if s == nil || s.Store == nil {
+		return Record{}, fmt.Errorf("managed credential store is not configured")
+	}
+	record := Record{
+		Key:          strings.TrimSpace(req.Key),
+		Provider:     strings.TrimSpace(req.Provider),
+		Account:      strings.TrimSpace(req.Account),
+		GrantType:    GrantClientCredentials,
+		TokenURL:     strings.TrimSpace(req.TokenURL),
+		ClientID:     strings.TrimSpace(req.ClientID),
+		ClientSecret: strings.TrimSpace(req.ClientSecret),
+		Scopes:       normalizeStrings(req.Scopes),
+		Status:       StatusUnconnected,
+		UpdatedAt:    s.now(),
+	}
+	if record.Key == "" || record.TokenURL == "" || record.ClientID == "" {
+		return Record{}, fmt.Errorf("key, token_url, and client_id are required for client_credentials")
+	}
+	values := url.Values{}
+	values.Set("grant_type", "client_credentials")
+	values.Set("client_id", record.ClientID)
+	if record.ClientSecret != "" {
+		values.Set("client_secret", record.ClientSecret)
+	}
+	if len(record.Scopes) > 0 {
+		values.Set("scope", strings.Join(record.Scopes, " "))
+	}
+	updated, err := s.exchange(ctx, record, values)
+	if err != nil {
+		return s.markFailure(ctx, record, err)
+	}
+	updated.Status = StatusConnected
+	updated.UpdatedAt = s.now()
+	if err := s.Store.Put(ctx, updated); err != nil {
+		return Record{}, err
+	}
+	return updated, nil
+}
+
+func (s *TokenSource) AccessToken(ctx context.Context, req AccessTokenRequest) (string, Record, error) {
+	record, ok, err := s.record(ctx, req.Key)
+	if err != nil {
+		return "", Record{}, err
+	}
+	if !ok {
+		return "", Record{}, fmt.Errorf("missing managed credential %q", strings.TrimSpace(req.Key))
+	}
+	if err := ensureScopes(record.Scopes, req.Scopes); err != nil {
+		return "", Record{}, fmt.Errorf("managed credential %q scope-insufficient: %w", record.Key, err)
+	}
+	if strings.TrimSpace(record.Status) != StatusConnected {
+		return "", Record{}, fmt.Errorf("managed credential %q is %s", record.Key, statusOrUnconnected(record.Status))
+	}
+	if strings.TrimSpace(record.AccessToken) == "" || s.shouldRefresh(record) {
+		record, err = s.refresh(ctx, record)
+		if err != nil {
+			return "", record, err
+		}
+		if err := ensureScopes(record.Scopes, req.Scopes); err != nil {
+			return "", record, fmt.Errorf("managed credential %q scope-insufficient: %w", record.Key, err)
+		}
+	}
+	return record.AccessToken, record, nil
+}
+
+func (s *TokenSource) Refresh(ctx context.Context, key string) (string, Record, error) {
+	record, ok, err := s.record(ctx, key)
+	if err != nil {
+		return "", Record{}, err
+	}
+	if !ok {
+		return "", Record{}, fmt.Errorf("missing managed credential %q", strings.TrimSpace(key))
+	}
+	record, err = s.refresh(ctx, record)
+	if err != nil {
+		return "", record, err
+	}
+	return record.AccessToken, record, nil
+}
+
+func (s *TokenSource) refresh(ctx context.Context, record Record) (Record, error) {
+	values := url.Values{}
+	switch record.GrantType {
+	case GrantAuthorizationCodePKCE:
+		if strings.TrimSpace(record.RefreshToken) == "" {
+			err := fmt.Errorf("managed credential %q has no refresh token", record.Key)
+			return s.markFailure(ctx, record, err)
+		}
+		values.Set("grant_type", "refresh_token")
+		values.Set("refresh_token", strings.TrimSpace(record.RefreshToken))
+		values.Set("client_id", strings.TrimSpace(record.ClientID))
+		if strings.TrimSpace(record.ClientSecret) != "" {
+			values.Set("client_secret", strings.TrimSpace(record.ClientSecret))
+		}
+	case GrantClientCredentials:
+		values.Set("grant_type", "client_credentials")
+		values.Set("client_id", strings.TrimSpace(record.ClientID))
+		if strings.TrimSpace(record.ClientSecret) != "" {
+			values.Set("client_secret", strings.TrimSpace(record.ClientSecret))
+		}
+		if len(record.Scopes) > 0 {
+			values.Set("scope", strings.Join(record.Scopes, " "))
+		}
+	default:
+		err := fmt.Errorf("managed credential %q has unsupported grant_type %q", record.Key, record.GrantType)
+		return s.markFailure(ctx, record, err)
+	}
+	updated, err := s.exchange(ctx, record, values)
+	if err != nil {
+		return s.markFailure(ctx, record, err)
+	}
+	updated.Status = StatusConnected
+	updated.Failure = ""
+	updated.UpdatedAt = s.now()
+	if err := s.Store.Put(ctx, updated); err != nil {
+		return Record{}, err
+	}
+	return updated, nil
+}
+
+func (s *TokenSource) exchange(ctx context.Context, record Record, values url.Values) (Record, error) {
+	tokenURL := strings.TrimSpace(record.TokenURL)
+	if tokenURL == "" {
+		return Record{}, fmt.Errorf("managed credential %q token_url is required", record.Key)
+	}
+	client := s.HTTPClient
+	if client == nil {
+		client = http.DefaultClient
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, tokenURL, strings.NewReader(values.Encode()))
+	if err != nil {
+		return Record{}, err
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	resp, err := client.Do(req)
+	if err != nil {
+		return Record{}, err
+	}
+	defer resp.Body.Close()
+	var body struct {
+		AccessToken  string `json:"access_token"`
+		RefreshToken string `json:"refresh_token"`
+		ExpiresIn    int64  `json:"expires_in"`
+		TokenType    string `json:"token_type"`
+		Scope        string `json:"scope"`
+		Error        string `json:"error"`
+		Description  string `json:"error_description"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		return Record{}, fmt.Errorf("decode token response: %w", err)
+	}
+	if resp.StatusCode >= 400 {
+		msg := strings.TrimSpace(body.Error)
+		if msg == "" {
+			msg = fmt.Sprintf("token endpoint returned status %d", resp.StatusCode)
+		}
+		if desc := strings.TrimSpace(body.Description); desc != "" {
+			msg += ": " + desc
+		}
+		return Record{}, fmt.Errorf("%s", msg)
+	}
+	access := strings.TrimSpace(body.AccessToken)
+	if access == "" {
+		return Record{}, fmt.Errorf("token endpoint did not return access_token")
+	}
+	updated := record
+	updated.AccessToken = access
+	if refresh := strings.TrimSpace(body.RefreshToken); refresh != "" {
+		updated.RefreshToken = refresh
+	}
+	if tokenType := strings.TrimSpace(body.TokenType); tokenType != "" {
+		updated.TokenType = tokenType
+	} else if updated.TokenType == "" {
+		updated.TokenType = "Bearer"
+	}
+	if scope := normalizeScopeString(body.Scope); len(scope) > 0 {
+		updated.Scopes = scope
+	}
+	if body.ExpiresIn > 0 {
+		updated.ExpiresAt = s.now().Add(time.Duration(body.ExpiresIn) * time.Second).UTC()
+	}
+	return updated, nil
+}
+
+func (s *TokenSource) markFailure(ctx context.Context, record Record, cause error, extraSecrets ...string) (Record, error) {
+	secrets := append(record.SecretValues(), normalizeStrings(extraSecrets)...)
+	record.Status = StatusRefreshFailed
+	if cause != nil {
+		record.Failure = RedactString(cause.Error(), secrets...)
+	}
+	record.UpdatedAt = s.now()
+	if s != nil && s.Store != nil {
+		if err := s.Store.Put(ctx, record); err != nil {
+			if cause == nil {
+				cause = fmt.Errorf("managed credential %q refresh failed", record.Key)
+			}
+			return record, fmt.Errorf(
+				"managed credential %q refresh failed: %s; persist refresh_failed state: %s",
+				record.Key,
+				RedactString(cause.Error(), secrets...),
+				RedactString(err.Error(), secrets...),
+			)
+		}
+	}
+	if cause == nil {
+		cause = fmt.Errorf("managed credential %q refresh failed", record.Key)
+	}
+	return record, fmt.Errorf("managed credential %q refresh failed: %s", record.Key, RedactString(cause.Error(), secrets...))
+}
+
+func (s *TokenSource) shouldRefresh(record Record) bool {
+	if strings.TrimSpace(record.AccessToken) == "" {
+		return true
+	}
+	if record.ExpiresAt.IsZero() {
+		return false
+	}
+	return !record.ExpiresAt.After(s.now().Add(s.refreshWindow()))
+}
+
+func (s *TokenSource) record(ctx context.Context, key string) (Record, bool, error) {
+	if s == nil || s.Store == nil {
+		return Record{}, false, fmt.Errorf("managed credential store is not configured")
+	}
+	key = strings.TrimSpace(key)
+	if key == "" {
+		return Record{}, false, fmt.Errorf("managed credential key is required")
+	}
+	return s.Store.Get(ctx, key)
+}
+
+func (s *TokenSource) now() time.Time {
+	if s != nil && s.Now != nil {
+		return s.Now().UTC()
+	}
+	return time.Now().UTC()
+}
+
+func (s *TokenSource) refreshWindow() time.Duration {
+	if s != nil && s.RefreshWindow > 0 {
+		return s.RefreshWindow
+	}
+	return defaultRefreshWindow
+}
+
+func (r Record) Descriptor() Descriptor {
+	status := statusOrUnconnected(r.Status)
+	return Descriptor{
+		Key:       strings.TrimSpace(r.Key),
+		Provider:  strings.TrimSpace(r.Provider),
+		Account:   strings.TrimSpace(r.Account),
+		GrantType: strings.TrimSpace(r.GrantType),
+		Scopes:    append([]string{}, r.Scopes...),
+		Status:    status,
+		Failure:   RedactString(strings.TrimSpace(r.Failure), r.SecretValues()...),
+		ExpiresAt: r.ExpiresAt,
+		UpdatedAt: r.UpdatedAt,
+	}
+}
+
+func (r Record) SecretValues() []string {
+	var out []string
+	for _, value := range []string{r.AccessToken, r.RefreshToken, r.ClientSecret, r.PKCEVerifier, r.OAuthState} {
+		value = strings.TrimSpace(value)
+		if value != "" {
+			out = append(out, value)
+		}
+	}
+	return out
+}
+
+type MemoryStore struct {
+	mu      sync.RWMutex
+	records map[string]Record
+}
+
+func NewMemoryStore(records ...Record) *MemoryStore {
+	store := &MemoryStore{records: map[string]Record{}}
+	for _, record := range records {
+		if key := strings.TrimSpace(record.Key); key != "" {
+			record.Key = key
+			store.records[key] = normalizeRecord(record)
+		}
+	}
+	return store
+}
+
+func (s *MemoryStore) Get(_ context.Context, key string) (Record, bool, error) {
+	if s == nil {
+		return Record{}, false, nil
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	record, ok := s.records[strings.TrimSpace(key)]
+	return normalizeRecord(record), ok, nil
+}
+
+func (s *MemoryStore) Put(_ context.Context, record Record) error {
+	if s == nil {
+		return fmt.Errorf("managed credential memory store is nil")
+	}
+	record = normalizeRecord(record)
+	if record.Key == "" {
+		return fmt.Errorf("managed credential key is required")
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.records[record.Key] = record
+	return nil
+}
+
+func (s *MemoryStore) Delete(_ context.Context, key string) error {
+	if s == nil {
+		return nil
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.records, strings.TrimSpace(key))
+	return nil
+}
+
+func (s *MemoryStore) List(_ context.Context) ([]Descriptor, error) {
+	if s == nil {
+		return nil, nil
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	out := make([]Descriptor, 0, len(s.records))
+	for _, record := range s.records {
+		out = append(out, normalizeRecord(record).Descriptor())
+	}
+	sortDescriptors(out)
+	return out, nil
+}
+
+type FileStore struct {
+	path string
+	mu   sync.Mutex
+}
+
+func NewFileStore(path string) (*FileStore, error) {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return nil, fmt.Errorf("managed credential file path is required")
+	}
+	return &FileStore{path: filepath.Clean(path)}, nil
+}
+
+func (s *FileStore) Get(ctx context.Context, key string) (Record, bool, error) {
+	records, err := s.read(ctx)
+	if err != nil {
+		return Record{}, false, err
+	}
+	record, ok := records[strings.TrimSpace(key)]
+	return normalizeRecord(record), ok, nil
+}
+
+func (s *FileStore) Put(ctx context.Context, record Record) error {
+	record = normalizeRecord(record)
+	if record.Key == "" {
+		return fmt.Errorf("managed credential key is required")
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.withWriteLockLocked(ctx, func() error {
+		records, err := s.readLocked(ctx)
+		if err != nil {
+			return err
+		}
+		records[record.Key] = record
+		return s.writeLocked(ctx, records)
+	})
+}
+
+func (s *FileStore) Delete(ctx context.Context, key string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.withWriteLockLocked(ctx, func() error {
+		records, err := s.readLocked(ctx)
+		if err != nil {
+			return err
+		}
+		delete(records, strings.TrimSpace(key))
+		return s.writeLocked(ctx, records)
+	})
+}
+
+func (s *FileStore) List(ctx context.Context) ([]Descriptor, error) {
+	records, err := s.read(ctx)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]Descriptor, 0, len(records))
+	for _, record := range records {
+		out = append(out, normalizeRecord(record).Descriptor())
+	}
+	sortDescriptors(out)
+	return out, nil
+}
+
+func (s *FileStore) read(ctx context.Context) (map[string]Record, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.readLocked(ctx)
+}
+
+func (s *FileStore) readLocked(ctx context.Context) (map[string]Record, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	raw, err := os.ReadFile(s.path)
+	if os.IsNotExist(err) {
+		return map[string]Record{}, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	if len(raw) == 0 {
+		return map[string]Record{}, nil
+	}
+	var wrapper struct {
+		Records map[string]Record `json:"records"`
+	}
+	if err := json.Unmarshal(raw, &wrapper); err != nil {
+		return nil, fmt.Errorf("decode managed credential file: %w", err)
+	}
+	if wrapper.Records == nil {
+		wrapper.Records = map[string]Record{}
+	}
+	for key, record := range wrapper.Records {
+		record.Key = strings.TrimSpace(record.Key)
+		if record.Key == "" {
+			record.Key = strings.TrimSpace(key)
+		}
+		wrapper.Records[key] = normalizeRecord(record)
+	}
+	return wrapper.Records, nil
+}
+
+func (s *FileStore) withWriteLockLocked(ctx context.Context, fn func() error) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(s.path), 0o700); err != nil {
+		return fmt.Errorf("create managed credential dir: %w", err)
+	}
+	unlock, err := lockManagedCredentialFile(s.path + ".lock")
+	if err != nil {
+		return err
+	}
+	defer unlock()
+	return fn()
+}
+
+func (s *FileStore) writeLocked(ctx context.Context, records map[string]Record) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(s.path), 0o700); err != nil {
+		return err
+	}
+	clean := map[string]Record{}
+	for key, record := range records {
+		record = normalizeRecord(record)
+		if record.Key == "" {
+			record.Key = strings.TrimSpace(key)
+		}
+		if record.Key == "" {
+			continue
+		}
+		clean[record.Key] = record
+	}
+	raw, err := json.MarshalIndent(struct {
+		Records map[string]Record `json:"records"`
+	}{Records: clean}, "", "  ")
+	if err != nil {
+		return err
+	}
+	tmp, err := os.CreateTemp(filepath.Dir(s.path), ".managed-credentials-*.json")
+	if err != nil {
+		return fmt.Errorf("create temp managed credential file: %w", err)
+	}
+	tmpPath := tmp.Name()
+	defer func() {
+		_ = os.Remove(tmpPath)
+	}()
+	if _, err := tmp.Write(append(raw, '\n')); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("write temp managed credential file: %w", err)
+	}
+	if err := tmp.Chmod(0o600); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("chmod temp managed credential file: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("close temp managed credential file: %w", err)
+	}
+	if err := os.Rename(tmpPath, s.path); err != nil {
+		return fmt.Errorf("replace managed credential file: %w", err)
+	}
+	return nil
+}
+
+func normalizeRecord(record Record) Record {
+	record.Key = strings.TrimSpace(record.Key)
+	record.Provider = strings.TrimSpace(record.Provider)
+	record.Account = strings.TrimSpace(record.Account)
+	record.GrantType = strings.TrimSpace(record.GrantType)
+	record.AuthURL = strings.TrimSpace(record.AuthURL)
+	record.TokenURL = strings.TrimSpace(record.TokenURL)
+	record.ClientID = strings.TrimSpace(record.ClientID)
+	record.ClientSecret = strings.TrimSpace(record.ClientSecret)
+	record.RedirectURL = strings.TrimSpace(record.RedirectURL)
+	record.Scopes = normalizeStrings(record.Scopes)
+	record.AccessToken = strings.TrimSpace(record.AccessToken)
+	record.RefreshToken = strings.TrimSpace(record.RefreshToken)
+	record.TokenType = strings.TrimSpace(record.TokenType)
+	record.Status = statusOrUnconnected(record.Status)
+	record.Failure = strings.TrimSpace(record.Failure)
+	record.PKCEVerifier = strings.TrimSpace(record.PKCEVerifier)
+	record.PKCEChallenge = strings.TrimSpace(record.PKCEChallenge)
+	record.OAuthState = strings.TrimSpace(record.OAuthState)
+	if !record.ExpiresAt.IsZero() {
+		record.ExpiresAt = record.ExpiresAt.UTC()
+	}
+	if !record.UpdatedAt.IsZero() {
+		record.UpdatedAt = record.UpdatedAt.UTC()
+	}
+	return record
+}
+
+func statusOrUnconnected(status string) string {
+	status = strings.TrimSpace(status)
+	if status == "" {
+		return StatusUnconnected
+	}
+	switch status {
+	case StatusUnconnected, StatusPendingConsent, StatusConnected, StatusRefreshFailed, StatusScopeInsufficient:
+		return status
+	}
+	return status
+}
+
+func normalizeStrings(values []string) []string {
+	if len(values) == 0 {
+		return nil
+	}
+	seen := map[string]struct{}{}
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		out = append(out, value)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func normalizeScopeString(raw string) []string {
+	return normalizeStrings(strings.Fields(strings.TrimSpace(raw)))
+}
+
+func ensureScopes(actual, required []string) error {
+	if len(required) == 0 {
+		return nil
+	}
+	have := map[string]struct{}{}
+	for _, scope := range normalizeStrings(actual) {
+		have[scope] = struct{}{}
+	}
+	var missing []string
+	for _, scope := range normalizeStrings(required) {
+		if _, ok := have[scope]; !ok {
+			missing = append(missing, scope)
+		}
+	}
+	if len(missing) > 0 {
+		return fmt.Errorf("missing scope(s): %s", strings.Join(missing, ", "))
+	}
+	return nil
+}
+
+func sortDescriptors(items []Descriptor) {
+	sort.Slice(items, func(i, j int) bool {
+		return items[i].Key < items[j].Key
+	})
+}
+
+func randomURLToken(bytesLen int) (string, error) {
+	if bytesLen <= 0 {
+		bytesLen = 32
+	}
+	buf := make([]byte, bytesLen)
+	if _, err := rand.Read(buf); err != nil {
+		return "", err
+	}
+	return base64.RawURLEncoding.EncodeToString(buf), nil
+}
+
+func pkceChallenge(verifier string) string {
+	sum := sha256.Sum256([]byte(verifier))
+	return base64.RawURLEncoding.EncodeToString(sum[:])
+}
+
+func RedactString(raw string, secrets ...string) string {
+	out := raw
+	for _, secret := range secrets {
+		secret = strings.TrimSpace(secret)
+		if secret == "" {
+			continue
+		}
+		out = strings.ReplaceAll(out, secret, "[REDACTED]")
+	}
+	return out
+}
+
+func RedactValue(value any, secrets ...string) any {
+	switch typed := value.(type) {
+	case string:
+		return RedactString(typed, secrets...)
+	case map[string]any:
+		out := make(map[string]any, len(typed))
+		for key, item := range typed {
+			out[key] = RedactValue(item, secrets...)
+		}
+		return out
+	case []any:
+		out := make([]any, 0, len(typed))
+		for _, item := range typed {
+			out = append(out, RedactValue(item, secrets...))
+		}
+		return out
+	default:
+		return value
+	}
+}

--- a/internal/runtime/managedcredentials/store_lock_unix_test.go
+++ b/internal/runtime/managedcredentials/store_lock_unix_test.go
@@ -1,0 +1,51 @@
+//go:build aix || darwin || dragonfly || freebsd || hurd || illumos || linux || netbsd || openbsd || solaris
+
+package managedcredentials
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"golang.org/x/sys/unix"
+)
+
+func TestFileStorePutDeleteFailClosedWhenManagedCredentialFileLocked(t *testing.T) {
+	ctx := context.Background()
+	path := filepath.Join(t.TempDir(), "managed_credentials.json")
+	store, err := NewFileStore(path)
+	if err != nil {
+		t.Fatalf("NewFileStore: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	lock, err := os.OpenFile(path+".lock", os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		t.Fatalf("open lock: %v", err)
+	}
+	defer lock.Close()
+	if err := unix.Flock(int(lock.Fd()), unix.LOCK_EX|unix.LOCK_NB); err != nil {
+		t.Fatalf("lock managed credential file: %v", err)
+	}
+	defer func() {
+		_ = unix.Flock(int(lock.Fd()), unix.LOCK_UN)
+	}()
+
+	record := Record{
+		Key:         "github",
+		GrantType:   GrantClientCredentials,
+		TokenURL:    "https://example.invalid/token",
+		ClientID:    "client-id",
+		AccessToken: "token",
+		Status:      StatusConnected,
+	}
+	if err := store.Put(ctx, record); !errors.Is(err, ErrStoreLocked) {
+		t.Fatalf("Put err = %v, want ErrStoreLocked", err)
+	}
+	if err := store.Delete(ctx, "github"); !errors.Is(err, ErrStoreLocked) {
+		t.Fatalf("Delete err = %v, want ErrStoreLocked", err)
+	}
+}

--- a/internal/runtime/managedcredentials/store_test.go
+++ b/internal/runtime/managedcredentials/store_test.go
@@ -1,0 +1,476 @@
+package managedcredentials
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestTokenSourceAuthCodePKCEPersistsStructuredTokenRecord(t *testing.T) {
+	ctx := context.Background()
+	var sawGrant string
+	var sawVerifier string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/token" {
+			http.NotFound(w, r)
+			return
+		}
+		if err := r.ParseForm(); err != nil {
+			t.Fatalf("ParseForm: %v", err)
+		}
+		sawGrant = r.Form.Get("grant_type")
+		sawVerifier = r.Form.Get("code_verifier")
+		if got := r.Form.Get("code"); got != "auth-code" {
+			t.Fatalf("code = %q, want auth-code", got)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"access_token":  "access-secret",
+			"refresh_token": "refresh-secret",
+			"expires_in":    3600,
+			"token_type":    "Bearer",
+			"scope":         "drive.read",
+		})
+	}))
+	defer server.Close()
+
+	path := filepath.Join(t.TempDir(), "managed.json")
+	store, err := NewFileStore(path)
+	if err != nil {
+		t.Fatalf("NewFileStore: %v", err)
+	}
+	source := TokenSource{Store: store}
+	begin, err := source.BeginAuthCodePKCE(ctx, BeginAuthCodeRequest{
+		Key:         "google_drive",
+		Provider:    "google",
+		AuthURL:     server.URL + "/auth",
+		TokenURL:    server.URL + "/token",
+		ClientID:    "client-id",
+		RedirectURL: "http://127.0.0.1/callback",
+		Scopes:      []string{"drive.read"},
+		Account:     "ops@example.test",
+	})
+	if err != nil {
+		t.Fatalf("BeginAuthCodePKCE: %v", err)
+	}
+	authorizeURL, err := url.Parse(begin.AuthorizeURL)
+	if err != nil {
+		t.Fatalf("Parse authorize URL: %v", err)
+	}
+	if got := authorizeURL.Query().Get("code_challenge_method"); got != "S256" {
+		t.Fatalf("code_challenge_method = %q, want S256", got)
+	}
+	if authorizeURL.Query().Get("code_challenge") == "" || authorizeURL.Query().Get("state") == "" {
+		t.Fatalf("authorize URL missing PKCE challenge/state: %s", begin.AuthorizeURL)
+	}
+	if begin.CodeVerifier == "" {
+		t.Fatal("CodeVerifier is empty")
+	}
+
+	record, err := source.CompleteAuthCode(ctx, CompleteAuthCodeRequest{
+		Key:   "google_drive",
+		State: begin.State,
+		Code:  "auth-code",
+	})
+	if err != nil {
+		t.Fatalf("CompleteAuthCode: %v", err)
+	}
+	if sawGrant != "authorization_code" || sawVerifier == "" {
+		t.Fatalf("token request grant/verifier = (%q, %q), want authorization_code and verifier", sawGrant, sawVerifier)
+	}
+	if record.Status != StatusConnected || record.AccessToken != "access-secret" || record.RefreshToken != "refresh-secret" {
+		t.Fatalf("record = %#v, want connected token record", record)
+	}
+	if record.PKCEVerifier != "" || record.OAuthState != "" {
+		t.Fatalf("record retained transient PKCE data: %#v", record)
+	}
+	reopened, err := NewFileStore(path)
+	if err != nil {
+		t.Fatalf("NewFileStore(reopen): %v", err)
+	}
+	persisted, ok, err := reopened.Get(ctx, "google_drive")
+	if err != nil || !ok {
+		t.Fatalf("reopened.Get = (%#v, %v, %v), want persisted record", persisted, ok, err)
+	}
+	if persisted.AccessToken != "access-secret" || persisted.RefreshToken != "refresh-secret" {
+		t.Fatalf("persisted tokens = (%q, %q), want stored tokens", persisted.AccessToken, persisted.RefreshToken)
+	}
+	desc := persisted.Descriptor()
+	raw, err := json.Marshal(desc)
+	if err != nil {
+		t.Fatalf("Marshal descriptor: %v", err)
+	}
+	if strings.Contains(string(raw), "access-secret") || strings.Contains(string(raw), "refresh-secret") {
+		t.Fatalf("descriptor leaked token material: %s", string(raw))
+	}
+}
+
+func TestTokenSourceAuthCodeFailureRedactsCallbackCode(t *testing.T) {
+	ctx := context.Background()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err != nil {
+			t.Fatalf("ParseForm: %v", err)
+		}
+		w.WriteHeader(http.StatusBadRequest)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"error":             "invalid_grant",
+			"error_description": "authorization code callback-code was rejected",
+		})
+	}))
+	defer server.Close()
+
+	store := NewMemoryStore()
+	source := TokenSource{Store: store}
+	begin, err := source.BeginAuthCodePKCE(ctx, BeginAuthCodeRequest{
+		Key:         "google_drive",
+		Provider:    "google",
+		AuthURL:     server.URL + "/auth",
+		TokenURL:    server.URL,
+		ClientID:    "client-id",
+		RedirectURL: "http://127.0.0.1/callback",
+		Scopes:      []string{"drive.read"},
+	})
+	if err != nil {
+		t.Fatalf("BeginAuthCodePKCE: %v", err)
+	}
+	_, err = source.CompleteAuthCode(ctx, CompleteAuthCodeRequest{
+		Key:   "google_drive",
+		State: begin.State,
+		Code:  "callback-code",
+	})
+	if err == nil {
+		t.Fatal("CompleteAuthCode error = nil, want redacted token endpoint failure")
+	}
+	if strings.Contains(err.Error(), "callback-code") {
+		t.Fatalf("CompleteAuthCode error leaked callback code: %v", err)
+	}
+	stored, ok, getErr := store.Get(ctx, "google_drive")
+	if getErr != nil || !ok {
+		t.Fatalf("store.Get = (%#v, %v, %v)", stored, ok, getErr)
+	}
+	if stored.Status != StatusRefreshFailed {
+		t.Fatalf("stored status = %q, want refresh_failed", stored.Status)
+	}
+	if strings.Contains(stored.Failure, "callback-code") {
+		t.Fatalf("stored failure leaked callback code: %q", stored.Failure)
+	}
+}
+
+func TestTokenSourceClientCredentialsRefreshBeforeUseAndFailureEvidence(t *testing.T) {
+	ctx := context.Background()
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		if err := r.ParseForm(); err != nil {
+			t.Fatalf("ParseForm: %v", err)
+		}
+		if got := r.Form.Get("grant_type"); got != "client_credentials" {
+			t.Fatalf("grant_type = %q, want client_credentials", got)
+		}
+		if requests == 1 {
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"access_token": "first-token",
+				"expires_in":   1,
+				"scope":        "repo.read",
+			})
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"access_token": "refreshed-token",
+			"expires_in":   3600,
+			"scope":        "repo.read",
+		})
+	}))
+	defer server.Close()
+
+	now := time.Date(2026, 7, 3, 12, 0, 0, 0, time.UTC)
+	store := NewMemoryStore()
+	source := TokenSource{
+		Store: store,
+		Now: func() time.Time {
+			return now
+		},
+	}
+	record, err := source.ConnectClientCredentials(ctx, ClientCredentialsRequest{
+		Key:      "github",
+		Provider: "github",
+		TokenURL: server.URL,
+		ClientID: "client-id",
+		Scopes:   []string{"repo.read"},
+	})
+	if err != nil {
+		t.Fatalf("ConnectClientCredentials: %v", err)
+	}
+	if record.Status != StatusConnected || record.AccessToken != "first-token" {
+		t.Fatalf("record = %#v, want connected first token", record)
+	}
+	now = now.Add(2 * time.Second)
+	token, record, err := source.AccessToken(ctx, AccessTokenRequest{Key: "github", Scopes: []string{"repo.read"}})
+	if err != nil {
+		t.Fatalf("AccessToken refresh-before-use: %v", err)
+	}
+	if token != "refreshed-token" || record.AccessToken != "refreshed-token" {
+		t.Fatalf("refreshed token = (%q, %q), want refreshed-token", token, record.AccessToken)
+	}
+	if requests != 2 {
+		t.Fatalf("token endpoint requests = %d, want 2", requests)
+	}
+}
+
+func TestTokenSourceClientCredentialsFailureRedactsProviderSecretEcho(t *testing.T) {
+	ctx := context.Background()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"error":             "invalid_client",
+			"error_description": "client secret cli-secret was rejected",
+		})
+	}))
+	defer server.Close()
+
+	store := NewMemoryStore()
+	source := TokenSource{Store: store}
+	_, err := source.ConnectClientCredentials(ctx, ClientCredentialsRequest{
+		Key:          "github",
+		Provider:     "github",
+		TokenURL:     server.URL,
+		ClientID:     "client-id",
+		ClientSecret: "cli-secret",
+		Scopes:       []string{"repo.read"},
+	})
+	if err == nil {
+		t.Fatal("ConnectClientCredentials error = nil, want redacted token endpoint failure")
+	}
+	if strings.Contains(err.Error(), "cli-secret") {
+		t.Fatalf("ConnectClientCredentials error leaked client secret: %v", err)
+	}
+	stored, ok, getErr := store.Get(ctx, "github")
+	if getErr != nil || !ok {
+		t.Fatalf("store.Get = (%#v, %v, %v)", stored, ok, getErr)
+	}
+	if stored.Status != StatusRefreshFailed {
+		t.Fatalf("stored status = %q, want refresh_failed", stored.Status)
+	}
+	if strings.Contains(stored.Failure, "cli-secret") {
+		t.Fatalf("stored failure leaked client secret: %q", stored.Failure)
+	}
+}
+
+func TestTokenSourceClientCredentialsFailurePropagatesFailureStatePersistenceError(t *testing.T) {
+	ctx := context.Background()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"error":             "invalid_client",
+			"error_description": "client secret cli-secret was rejected",
+		})
+	}))
+	defer server.Close()
+
+	store := failingPutStore{
+		Store: NewMemoryStore(),
+		err:   errors.New("permission denied while writing cli-secret"),
+	}
+	source := TokenSource{Store: store}
+	record, err := source.ConnectClientCredentials(ctx, ClientCredentialsRequest{
+		Key:          "github",
+		Provider:     "github",
+		TokenURL:     server.URL,
+		ClientID:     "client-id",
+		ClientSecret: "cli-secret",
+		Scopes:       []string{"repo.read"},
+	})
+	if err == nil {
+		t.Fatal("ConnectClientCredentials error = nil, want persistence failure surfaced")
+	}
+	if !strings.Contains(err.Error(), "persist refresh_failed state") {
+		t.Fatalf("ConnectClientCredentials error = %v, want persistence failure context", err)
+	}
+	if strings.Contains(err.Error(), "cli-secret") {
+		t.Fatalf("ConnectClientCredentials error leaked client secret: %v", err)
+	}
+	if record.Status != StatusRefreshFailed {
+		t.Fatalf("returned record status = %q, want refresh_failed", record.Status)
+	}
+	if strings.Contains(record.Failure, "cli-secret") {
+		t.Fatalf("returned record failure leaked client secret: %q", record.Failure)
+	}
+	if _, ok, getErr := store.Store.Get(ctx, "github"); getErr != nil || ok {
+		t.Fatalf("underlying store.Get = (_, %v, %v), want no silently persisted record", ok, getErr)
+	}
+}
+
+func TestTokenSourceAccessTokenFailsClosedWhenRefreshNarrowsScopes(t *testing.T) {
+	ctx := context.Background()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err != nil {
+			t.Fatalf("ParseForm: %v", err)
+		}
+		if got := r.Form.Get("grant_type"); got != "client_credentials" {
+			t.Fatalf("grant_type = %q, want client_credentials", got)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"access_token": "narrow-token",
+			"expires_in":   3600,
+			"scope":        "repo.read",
+		})
+	}))
+	defer server.Close()
+
+	now := time.Date(2026, 7, 3, 12, 0, 0, 0, time.UTC)
+	store := NewMemoryStore(Record{
+		Key:         "github",
+		GrantType:   GrantClientCredentials,
+		TokenURL:    server.URL,
+		ClientID:    "client-id",
+		AccessToken: "expired-token",
+		ExpiresAt:   now.Add(-time.Second),
+		Scopes:      []string{"repo.read", "repo.write"},
+		Status:      StatusConnected,
+	})
+	source := TokenSource{
+		Store: store,
+		Now: func() time.Time {
+			return now
+		},
+	}
+	token, record, err := source.AccessToken(ctx, AccessTokenRequest{Key: "github", Scopes: []string{"repo.write"}})
+	if err == nil {
+		t.Fatal("AccessToken error = nil, want scope-insufficient after narrowed refresh")
+	}
+	if token != "" {
+		t.Fatalf("token = %q, want empty token on narrowed scope", token)
+	}
+	if !strings.Contains(err.Error(), "scope-insufficient") || !strings.Contains(err.Error(), "repo.write") {
+		t.Fatalf("AccessToken error = %v, want scope-insufficient repo.write", err)
+	}
+	if record.AccessToken != "narrow-token" {
+		t.Fatalf("returned record token = %q, want refreshed narrow token retained only in record", record.AccessToken)
+	}
+	if record.Status != StatusConnected {
+		t.Fatalf("returned record status = %q, want connected for per-request scope failure", record.Status)
+	}
+	stored, ok, getErr := store.Get(ctx, "github")
+	if getErr != nil || !ok {
+		t.Fatalf("store.Get = (%#v, %v, %v)", stored, ok, getErr)
+	}
+	if got := strings.Join(stored.Scopes, " "); got != "repo.read" {
+		t.Fatalf("stored scopes = %q, want provider-narrowed repo.read", got)
+	}
+	if stored.Status != StatusConnected {
+		t.Fatalf("stored status = %q, want connected for per-request scope failure", stored.Status)
+	}
+}
+
+func TestTokenSourceRefreshFailureFailsClosedAndRedactsSecrets(t *testing.T) {
+	ctx := context.Background()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"error":             "invalid_client",
+			"error_description": "client-secret was rejected with refresh-secret",
+		})
+	}))
+	defer server.Close()
+
+	store := NewMemoryStore(Record{
+		Key:          "github",
+		GrantType:    GrantAuthorizationCodePKCE,
+		TokenURL:     server.URL,
+		ClientID:     "client-id",
+		ClientSecret: "client-secret",
+		AccessToken:  "access-secret",
+		RefreshToken: "refresh-secret",
+		Status:       StatusConnected,
+	})
+	source := TokenSource{Store: store}
+	_, record, err := source.Refresh(ctx, "github")
+	if err == nil {
+		t.Fatal("Refresh error = nil, want fail-closed error")
+	}
+	if strings.Contains(err.Error(), "client-secret") || strings.Contains(err.Error(), "refresh-secret") {
+		t.Fatalf("refresh error leaked secret material: %v", err)
+	}
+	stored, ok, getErr := store.Get(ctx, "github")
+	if getErr != nil || !ok {
+		t.Fatalf("store.Get = (%#v, %v, %v)", stored, ok, getErr)
+	}
+	if stored.Status != StatusRefreshFailed {
+		t.Fatalf("stored status = %q, want refresh_failed", stored.Status)
+	}
+	if strings.Contains(stored.Failure, "client-secret") || strings.Contains(stored.Failure, "refresh-secret") {
+		t.Fatalf("stored failure leaked secret material: %q", stored.Failure)
+	}
+	if record.Status != StatusRefreshFailed {
+		t.Fatalf("returned record status = %q, want refresh_failed", record.Status)
+	}
+}
+
+func TestTokenSourceRefreshFailurePropagatesFailureStatePersistenceError(t *testing.T) {
+	ctx := context.Background()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"error":             "invalid_client",
+			"error_description": "client-secret was rejected with refresh-secret",
+		})
+	}))
+	defer server.Close()
+
+	inner := NewMemoryStore(Record{
+		Key:          "github",
+		GrantType:    GrantAuthorizationCodePKCE,
+		TokenURL:     server.URL,
+		ClientID:     "client-id",
+		ClientSecret: "client-secret",
+		AccessToken:  "access-secret",
+		RefreshToken: "refresh-secret",
+		Status:       StatusConnected,
+	})
+	store := failingPutStore{
+		Store: inner,
+		err:   errors.New("database locked while writing client-secret and refresh-secret"),
+	}
+	source := TokenSource{Store: store}
+	_, record, err := source.Refresh(ctx, "github")
+	if err == nil {
+		t.Fatal("Refresh error = nil, want persistence failure surfaced")
+	}
+	if !strings.Contains(err.Error(), "persist refresh_failed state") {
+		t.Fatalf("Refresh error = %v, want persistence failure context", err)
+	}
+	if strings.Contains(err.Error(), "client-secret") || strings.Contains(err.Error(), "refresh-secret") {
+		t.Fatalf("Refresh error leaked secret material: %v", err)
+	}
+	if record.Status != StatusRefreshFailed {
+		t.Fatalf("returned record status = %q, want refresh_failed", record.Status)
+	}
+	if strings.Contains(record.Failure, "client-secret") || strings.Contains(record.Failure, "refresh-secret") {
+		t.Fatalf("returned record failure leaked secret material: %q", record.Failure)
+	}
+	stored, ok, getErr := inner.Get(ctx, "github")
+	if getErr != nil || !ok {
+		t.Fatalf("inner.Get = (%#v, %v, %v), want original stale record", stored, ok, getErr)
+	}
+	if stored.Status != StatusConnected {
+		t.Fatalf("stale stored status = %q, want connected to prove write failure was not hidden", stored.Status)
+	}
+}
+
+type failingPutStore struct {
+	Store
+	err error
+}
+
+func (s failingPutStore) Put(context.Context, Record) error {
+	if s.err != nil {
+		return s.err
+	}
+	return errors.New("put failed")
+}

--- a/internal/runtime/runforkexecution/agent_runtime_materialization.go
+++ b/internal/runtime/runforkexecution/agent_runtime_materialization.go
@@ -19,6 +19,7 @@ import (
 	runtimeactors "github.com/division-sh/swarm/internal/runtime/core/actors"
 	runtimecredentials "github.com/division-sh/swarm/internal/runtime/credentials"
 	runtimellm "github.com/division-sh/swarm/internal/runtime/llm"
+	runtimemanagedcredentials "github.com/division-sh/swarm/internal/runtime/managedcredentials"
 	runtimemanager "github.com/division-sh/swarm/internal/runtime/manager"
 	runtimemcp "github.com/division-sh/swarm/internal/runtime/mcp"
 	runtimepipeline "github.com/division-sh/swarm/internal/runtime/pipeline"
@@ -33,18 +34,19 @@ import (
 const selectedContractAgentRuntimeDefaultQuiescenceTimeout = 2 * time.Minute
 
 type SelectedContractAgentRuntimeOptions struct {
-	Config            *config.Config
-	EntityStore       runtimetools.EntityPersistence
-	HumanTaskStore    runtimetools.HumanTaskPersistence
-	SessionRegistry   runtimesessions.Registry
-	ConversationStore runtimellm.ConversationPersistence
-	TurnStore         runtimellm.TurnPersistence
-	ScheduleStore     runtimepipeline.SchedulePersistence
-	MailboxStore      runtimetools.MailboxPersistence
-	Workspace         workspace.Lifecycle
-	Credentials       runtimecredentials.Store
-	LLMRuntime        runtimellm.Runtime
-	MCPClient         *runtimemcp.Client
+	Config             *config.Config
+	EntityStore        runtimetools.EntityPersistence
+	HumanTaskStore     runtimetools.HumanTaskPersistence
+	SessionRegistry    runtimesessions.Registry
+	ConversationStore  runtimellm.ConversationPersistence
+	TurnStore          runtimellm.TurnPersistence
+	ScheduleStore      runtimepipeline.SchedulePersistence
+	MailboxStore       runtimetools.MailboxPersistence
+	Workspace          workspace.Lifecycle
+	Credentials        runtimecredentials.Store
+	ManagedCredentials runtimemanagedcredentials.Store
+	LLMRuntime         runtimellm.Runtime
+	MCPClient          *runtimemcp.Client
 
 	AgentFactory        runtimemanager.AgentFactory
 	AgentManagerOptions runtimemanager.AgentManagerOptions
@@ -252,17 +254,18 @@ func buildSelectedContractAgentRuntimeFactory(req publishSelectedContractForkEve
 	modelRuntime := options.LLMRuntime
 	var managerRef runtimetools.Manager
 	exec := runtimetools.NewExecutorWithOptions(bus, nil, runtimetools.ExecutorOptions{
-		Config:            options.Config,
-		Credentials:       credentials,
-		MailboxStore:      options.MailboxStore,
-		MCPClient:         options.MCPClient,
-		EntityStore:       options.EntityStore,
-		HumanTaskStore:    options.HumanTaskStore,
-		WorkflowSource:    source,
-		WorkspaceResolver: options.Workspace,
-		ModelRuntime:      modelRuntime,
-		AuthorityProvider: authority,
-		EmitRegistry:      emitRegistry,
+		Config:             options.Config,
+		Credentials:        credentials,
+		ManagedCredentials: options.ManagedCredentials,
+		MailboxStore:       options.MailboxStore,
+		MCPClient:          options.MCPClient,
+		EntityStore:        options.EntityStore,
+		HumanTaskStore:     options.HumanTaskStore,
+		WorkflowSource:     source,
+		WorkspaceResolver:  options.Workspace,
+		ModelRuntime:       modelRuntime,
+		AuthorityProvider:  authority,
+		EmitRegistry:       emitRegistry,
 		ManagerProvider: func() runtimetools.Manager {
 			return managerRef
 		},

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -28,6 +28,7 @@ import (
 	runtimeingress "github.com/division-sh/swarm/internal/runtime/ingress"
 	runtimelifecycleprobe "github.com/division-sh/swarm/internal/runtime/lifecycleprobe"
 	llm "github.com/division-sh/swarm/internal/runtime/llm"
+	runtimemanagedcredentials "github.com/division-sh/swarm/internal/runtime/managedcredentials"
 	runtimemanager "github.com/division-sh/swarm/internal/runtime/manager"
 	runtimemcp "github.com/division-sh/swarm/internal/runtime/mcp"
 	runtimepipeline "github.com/division-sh/swarm/internal/runtime/pipeline"
@@ -76,6 +77,7 @@ type RuntimeOptions struct {
 	WorkflowModule                   runtimepipeline.WorkflowModule
 	LLMRuntime                       llm.Runtime
 	Credentials                      runtimecredentials.Store
+	ManagedCredentials               runtimemanagedcredentials.Store
 	BootStartedAt                    time.Time
 	BootProgress                     func(BootProgressEvent)
 	SystemContainers                 []string
@@ -100,6 +102,7 @@ type validatedRuntimeDeps struct {
 	Source                   semanticview.Source
 	PromptResolver           runtimecontracts.PromptResolver
 	Credentials              runtimecredentials.Store
+	ManagedCredentials       runtimemanagedcredentials.Store
 	Authority                runtimeauthority.Provider
 	EmitRegistry             *runtimetools.EmitRegistry
 	EventReceiptCapability   func(context.Context) (bool, error)
@@ -135,28 +138,29 @@ type Runtime struct {
 	ownerID        string
 	shutdownGate   shutdownAdmission
 
-	Config         *config.Config
-	Stores         Stores
-	Options        RuntimeOptions
-	Bus            *runtimebus.EventBus
-	Logger         *RuntimeLogger
-	Pipeline       *runtimepipeline.PipelineCoordinator
-	SystemNodes    []runtimepipeline.BackgroundNode
-	Scheduler      *runtimepipeline.Scheduler
-	Workspace      workspace.Lifecycle
-	Budget         *BudgetTracker
-	Credentials    runtimecredentials.Store
-	LLM            llm.Runtime
-	ToolExecutor   *runtimetools.Executor
-	Manager        *runtimemanager.AgentManager
-	RuntimeIngress *runtimeingress.Controller
-	RunControl     *runtimeruncontrol.Controller
-	InboundGateway *InboundGateway
-	ToolGateway    *runtimemcp.Gateway
-	MCPTurns       *runtimemcp.TurnContextRegistry
-	Authority      runtimeauthority.Provider
-	EmitRegistry   *runtimetools.EmitRegistry
-	PromptResolver runtimecontracts.PromptResolver
+	Config             *config.Config
+	Stores             Stores
+	Options            RuntimeOptions
+	Bus                *runtimebus.EventBus
+	Logger             *RuntimeLogger
+	Pipeline           *runtimepipeline.PipelineCoordinator
+	SystemNodes        []runtimepipeline.BackgroundNode
+	Scheduler          *runtimepipeline.Scheduler
+	Workspace          workspace.Lifecycle
+	Budget             *BudgetTracker
+	Credentials        runtimecredentials.Store
+	ManagedCredentials runtimemanagedcredentials.Store
+	LLM                llm.Runtime
+	ToolExecutor       *runtimetools.Executor
+	Manager            *runtimemanager.AgentManager
+	RuntimeIngress     *runtimeingress.Controller
+	RunControl         *runtimeruncontrol.Controller
+	InboundGateway     *InboundGateway
+	ToolGateway        *runtimemcp.Gateway
+	MCPTurns           *runtimemcp.TurnContextRegistry
+	Authority          runtimeauthority.Provider
+	EmitRegistry       *runtimetools.EmitRegistry
+	PromptResolver     runtimecontracts.PromptResolver
 }
 
 func (rt *Runtime) emitBootProgress(step int, name, status, detail string) {
@@ -260,7 +264,9 @@ func ensureWorkflowBootWiring(opts RuntimeOptions) error {
 			return fmt.Errorf("workspace validation failed: %w", err)
 		}
 	}
-	result, err := ValidateWorkflowContractSurface(context.Background(), source, DefaultWorkflowContractValidationOptions(opts.Credentials))
+	validationOpts := DefaultWorkflowContractValidationOptions(opts.Credentials)
+	validationOpts.ManagedCredentials = opts.ManagedCredentials
+	result, err := ValidateWorkflowContractSurface(context.Background(), source, validationOpts)
 	if err != nil {
 		return err
 	}
@@ -349,6 +355,7 @@ func (deps RuntimeDeps) validated() (validatedRuntimeDeps, error) {
 		EventReceiptCapability:   canonicalEventReceiptCapabilities(stores),
 		TrimmedBundleFingerprint: strings.TrimSpace(opts.BundleFingerprint),
 		BundleSourceFact:         opts.BundleSourceFact.Normalized(),
+		ManagedCredentials:       opts.ManagedCredentials,
 	}, nil
 }
 
@@ -379,16 +386,17 @@ func NewRuntime(ctx context.Context, deps RuntimeDeps) (*Runtime, error) {
 	source := boot.Source
 	mcpTurns := runtimemcp.NewTurnContextRegistry(runtimeactors.ActorFromContext)
 	rt := &Runtime{
-		ownerID:        newRuntimeOwnerID(),
-		Config:         cfg,
-		Stores:         stores,
-		Options:        opts,
-		Workspace:      opts.WorkspaceLifecycle,
-		MCPTurns:       mcpTurns,
-		Authority:      boot.Authority,
-		EmitRegistry:   boot.EmitRegistry,
-		PromptResolver: boot.PromptResolver,
-		Credentials:    boot.Credentials,
+		ownerID:            newRuntimeOwnerID(),
+		Config:             cfg,
+		Stores:             stores,
+		Options:            opts,
+		Workspace:          opts.WorkspaceLifecycle,
+		MCPTurns:           mcpTurns,
+		Authority:          boot.Authority,
+		EmitRegistry:       boot.EmitRegistry,
+		PromptResolver:     boot.PromptResolver,
+		Credentials:        boot.Credentials,
+		ManagedCredentials: boot.ManagedCredentials,
 	}
 
 	if stores.RuntimeLogStore != nil {
@@ -529,17 +537,18 @@ func NewRuntime(ctx context.Context, deps RuntimeDeps) (*Runtime, error) {
 	}
 
 	rt.ToolExecutor = runtimetools.NewExecutorWithOptions(rt.Bus, rt.Scheduler, runtimetools.ExecutorOptions{
-		Config:            cfg,
-		Credentials:       rt.Credentials,
-		MailboxStore:      stores.MailboxStore,
-		EntityStore:       stores.ToolEntityStore,
-		HumanTaskStore:    stores.HumanTaskStore,
-		WorkflowInstances: pipelineStore,
-		WorkflowSource:    source,
-		WorkspaceResolver: rt.Workspace,
-		ModelRuntime:      rt.LLM,
-		AuthorityProvider: rt.Authority,
-		EmitRegistry:      rt.EmitRegistry,
+		Config:             cfg,
+		Credentials:        rt.Credentials,
+		ManagedCredentials: rt.ManagedCredentials,
+		MailboxStore:       stores.MailboxStore,
+		EntityStore:        stores.ToolEntityStore,
+		HumanTaskStore:     stores.HumanTaskStore,
+		WorkflowInstances:  pipelineStore,
+		WorkflowSource:     source,
+		WorkspaceResolver:  rt.Workspace,
+		ModelRuntime:       rt.LLM,
+		AuthorityProvider:  rt.Authority,
+		EmitRegistry:       rt.EmitRegistry,
 		ManagerProvider: func() runtimetools.Manager {
 			return managerRef
 		},
@@ -566,6 +575,34 @@ func NewRuntime(ctx context.Context, deps RuntimeDeps) (*Runtime, error) {
 				requiredBy = append(requiredBy, strings.TrimSpace(ref.Kind)+":"+strings.TrimSpace(ref.Name))
 			}
 			slog.Warn("credential requirement warning", "key", item.Key, "required_by", strings.Join(requiredBy, ", "))
+		}
+	}
+	if missing, err := runtimemanagedcredentials.MissingOrUnusableRequired(ctx, rt.ManagedCredentials, source); err != nil {
+		return nil, fmt.Errorf("managed credential validation failed: %w", err)
+	} else {
+		if bootWarningsFatal() && len(missing) > 0 {
+			parts := make([]string, 0, len(missing))
+			for _, item := range missing {
+				requiredBy := make([]string, 0, len(item.RequiredBy))
+				for _, ref := range item.RequiredBy {
+					requiredBy = append(requiredBy, strings.TrimSpace(ref.Kind)+":"+strings.TrimSpace(ref.Name))
+				}
+				sort.Strings(requiredBy)
+				status := strings.TrimSpace(item.Status)
+				if status == "" {
+					status = runtimemanagedcredentials.StatusUnconnected
+				}
+				parts = append(parts, fmt.Sprintf("%s status=%s required by %s", strings.TrimSpace(item.Key), status, strings.Join(requiredBy, ", ")))
+			}
+			sort.Strings(parts)
+			return nil, fmt.Errorf("unusable required managed credentials: %s", strings.Join(parts, "; "))
+		}
+		for _, item := range missing {
+			requiredBy := make([]string, 0, len(item.RequiredBy))
+			for _, ref := range item.RequiredBy {
+				requiredBy = append(requiredBy, strings.TrimSpace(ref.Kind)+":"+strings.TrimSpace(ref.Name))
+			}
+			slog.Warn("managed credential requirement warning", "key", item.Key, "status", item.Status, "required_by", strings.Join(requiredBy, ", "))
 		}
 	}
 	factory := runtimeagents.NewLLMAgentFactory(rt.LLM, rt.ToolExecutor, rt.ToolExecutor.ToolDefinitions(), runtimeagents.LLMAgentOptions{

--- a/internal/runtime/tools/deps.go
+++ b/internal/runtime/tools/deps.go
@@ -9,6 +9,7 @@ import (
 	models "github.com/division-sh/swarm/internal/runtime/core/actors"
 	runtimecredentials "github.com/division-sh/swarm/internal/runtime/credentials"
 	llm "github.com/division-sh/swarm/internal/runtime/llm"
+	runtimemanagedcredentials "github.com/division-sh/swarm/internal/runtime/managedcredentials"
 	runtimemcp "github.com/division-sh/swarm/internal/runtime/mcp"
 	runtimepipeline "github.com/division-sh/swarm/internal/runtime/pipeline"
 	"github.com/division-sh/swarm/internal/runtime/semanticview"
@@ -44,20 +45,21 @@ type Manager interface {
 type ManagerProvider func() Manager
 
 type ExecutorOptions struct {
-	Manager           Manager
-	ManagerProvider   ManagerProvider
-	Config            *config.Config
-	Credentials       runtimecredentials.Store
-	MailboxStore      MailboxPersistence
-	EntityStore       EntityPersistence
-	HumanTaskStore    HumanTaskPersistence
-	WorkflowInstances WorkflowInstanceLoader
-	MCPClient         *runtimemcp.Client
-	WorkflowSource    semanticview.Source
-	WorkspaceResolver workspace.Resolver
-	ModelRuntime      llm.Runtime
-	AuthorityProvider runtimeauthority.Provider
-	EmitRegistry      *EmitRegistry
+	Manager            Manager
+	ManagerProvider    ManagerProvider
+	Config             *config.Config
+	Credentials        runtimecredentials.Store
+	ManagedCredentials runtimemanagedcredentials.Store
+	MailboxStore       MailboxPersistence
+	EntityStore        EntityPersistence
+	HumanTaskStore     HumanTaskPersistence
+	WorkflowInstances  WorkflowInstanceLoader
+	MCPClient          *runtimemcp.Client
+	WorkflowSource     semanticview.Source
+	WorkspaceResolver  workspace.Resolver
+	ModelRuntime       llm.Runtime
+	AuthorityProvider  runtimeauthority.Provider
+	EmitRegistry       *EmitRegistry
 	// Trusted runtime/test escape hatch for exercising retained legacy handlers.
 	// Actor-authored config must never enable legacy entity tools for normal agents.
 	AllowInternalLegacyEntityTools bool

--- a/internal/runtime/tools/executor.go
+++ b/internal/runtime/tools/executor.go
@@ -19,6 +19,7 @@ import (
 	"github.com/division-sh/swarm/internal/runtime/diaglog"
 	"github.com/division-sh/swarm/internal/runtime/flowdata"
 	llm "github.com/division-sh/swarm/internal/runtime/llm"
+	runtimemanagedcredentials "github.com/division-sh/swarm/internal/runtime/managedcredentials"
 	runtimemcp "github.com/division-sh/swarm/internal/runtime/mcp"
 	runtimepipeline "github.com/division-sh/swarm/internal/runtime/pipeline"
 	"github.com/division-sh/swarm/internal/runtime/semanticview"
@@ -38,6 +39,7 @@ type Executor struct {
 	workflowInstances              WorkflowInstanceLoader
 	cfg                            *config.Config
 	credentials                    runtimecredentials.Store
+	managedCredentials             runtimemanagedcredentials.Store
 	httpClient                     *http.Client
 	mcpClient                      *runtimemcp.Client
 	workflowSource                 semanticview.Source
@@ -80,6 +82,7 @@ func NewExecutorWithOptions(bus EventPublisher, scheduler Scheduler, opts Execut
 		workflowInstances:              opts.WorkflowInstances,
 		cfg:                            opts.Config,
 		credentials:                    opts.Credentials,
+		managedCredentials:             opts.ManagedCredentials,
 		httpClient:                     &http.Client{Timeout: 30 * time.Second},
 		mcpClient:                      opts.MCPClient,
 		workflowSource:                 opts.WorkflowSource,

--- a/internal/runtime/tools/executor_http.go
+++ b/internal/runtime/tools/executor_http.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -14,10 +15,25 @@ import (
 	"time"
 
 	models "github.com/division-sh/swarm/internal/runtime/core/actors"
+	runtimemanagedcredentials "github.com/division-sh/swarm/internal/runtime/managedcredentials"
 	"github.com/division-sh/swarm/internal/runtime/semanticview"
 )
 
 var toolTemplatePattern = regexp.MustCompile(`\{\{\s*([^{}]+?)\s*\}\}`)
+
+type httpToolStatusError struct {
+	ToolName   string
+	StatusCode int
+	Body       any
+	Secrets    []string
+}
+
+func (e httpToolStatusError) Error() string {
+	return runtimemanagedcredentials.RedactString(
+		fmt.Sprintf("http tool %s returned status %d: %s", e.ToolName, e.StatusCode, strings.TrimSpace(asString(e.Body))),
+		e.Secrets...,
+	)
+}
 
 func (e *Executor) execHTTPTool(ctx context.Context, actor models.AgentConfig, tool RegisteredTool, input any) (any, error) {
 	if tool.HTTP == nil {
@@ -56,6 +72,17 @@ func (e *Executor) execHTTPTool(ctx context.Context, actor models.AgentConfig, t
 		}
 		headers.Set(strings.TrimSpace(key), strings.TrimSpace(asString(resolved)))
 	}
+	managedAuth, err := e.resolveManagedCredentialForActor(ctx, actor, tool)
+	if err != nil {
+		return nil, err
+	}
+	authSecrets := []string{}
+	if managedAuth != nil {
+		if err := applyManagedCredentialHeader(headers, managedAuth, false); err != nil {
+			return nil, err
+		}
+		authSecrets = append(authSecrets, managedAuth.SecretValues()...)
+	}
 
 	var bodyReader io.Reader
 	if tool.HTTP.Body != nil {
@@ -88,12 +115,30 @@ func (e *Executor) execHTTPTool(ctx context.Context, actor models.AgentConfig, t
 	}
 	backoff := strings.ToLower(strings.TrimSpace(tool.HTTP.Retry.Backoff))
 	var lastErr error
+	refreshedAfterUnauthorized := false
 	for attempt := 0; attempt <= maxRetries; attempt++ {
-		result, err := e.execHTTPRequestOnce(ctx, method, url, headers, bodyReader, timeout, tool)
+		result, err := e.execHTTPRequestOnce(ctx, method, url, headers, bodyReader, timeout, tool, authSecrets)
 		if err == nil {
 			return result, nil
 		}
 		lastErr = err
+		var statusErr httpToolStatusError
+		if managedAuth != nil && errors.As(err, &statusErr) && statusErr.StatusCode == http.StatusUnauthorized && !refreshedAfterUnauthorized {
+			refreshedAfterUnauthorized = true
+			token, record, refreshErr := e.managedTokenSource().Refresh(ctx, managedAuth.StoreKey)
+			if refreshErr != nil {
+				return nil, fmt.Errorf("%s", runtimemanagedcredentials.RedactString(refreshErr.Error(), append(authSecrets, record.SecretValues()...)...))
+			}
+			managedAuth.Token = token
+			managedAuth.Record = record
+			authSecrets = append(authSecrets, managedAuth.SecretValues()...)
+			if err := applyManagedCredentialHeader(headers, managedAuth, true); err != nil {
+				return nil, err
+			}
+			rewindBodyReader(bodyReader)
+			attempt--
+			continue
+		}
 		if isExternalDispatchRateLimited(err) {
 			break
 		}
@@ -105,14 +150,109 @@ func (e *Executor) execHTTPTool(ctx context.Context, actor models.AgentConfig, t
 			sleep = time.Duration(1<<attempt) * time.Second
 		}
 		time.Sleep(sleep)
-		if seeker, ok := bodyReader.(io.Seeker); ok {
-			_, _ = seeker.Seek(0, io.SeekStart)
-		}
+		rewindBodyReader(bodyReader)
 	}
 	return nil, lastErr
 }
 
-func (e *Executor) execHTTPRequestOnce(ctx context.Context, method, url string, headers http.Header, body io.Reader, timeout time.Duration, tool RegisteredTool) (any, error) {
+type managedHTTPAuth struct {
+	StoreKey string
+	Token    string
+	Record   runtimemanagedcredentials.Record
+	Header   string
+	Prefix   string
+}
+
+func (a managedHTTPAuth) SecretValues() []string {
+	secrets := a.Record.SecretValues()
+	token := strings.TrimSpace(a.Token)
+	if token != "" {
+		secrets = append(secrets, token)
+	}
+	return secrets
+}
+
+func (e *Executor) resolveManagedCredentialForActor(ctx context.Context, actor models.AgentConfig, tool RegisteredTool) (*managedHTTPAuth, error) {
+	if tool.ManagedCredential == nil {
+		return nil, nil
+	}
+	ref := *tool.ManagedCredential
+	key := strings.TrimSpace(ref.Key)
+	if key == "" {
+		return nil, fmt.Errorf("tool %s managed_credential.key is required", strings.TrimSpace(tool.Name))
+	}
+	e.mu.RLock()
+	source := e.workflowSource
+	e.mu.RUnlock()
+	flowID := emitActorFlowID(source, actor, "")
+	storeKey, mapped := semanticview.CredentialStoreKeyForActorFlow(source, actor.ID, flowID, key)
+	if mapped && strings.TrimSpace(storeKey) == "" {
+		return nil, fmt.Errorf("managed credential %q is not declared and bound for imported package actor %s", key, strings.TrimSpace(actor.ID))
+	}
+	storeKey = strings.TrimSpace(storeKey)
+	if storeKey == "" {
+		return nil, fmt.Errorf("managed credential %q does not resolve to a deployment credential key", key)
+	}
+	token, record, err := e.managedTokenSource().AccessToken(ctx, runtimemanagedcredentials.AccessTokenRequest{
+		Key:    storeKey,
+		Scopes: ref.Scopes,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("%s", runtimemanagedcredentials.RedactString(err.Error(), record.SecretValues()...))
+	}
+	header := strings.TrimSpace(ref.Header)
+	if header == "" {
+		header = "Authorization"
+	}
+	prefix := strings.TrimSpace(ref.Prefix)
+	if prefix == "" && strings.EqualFold(header, "Authorization") {
+		prefix = "Bearer"
+	}
+	return &managedHTTPAuth{
+		StoreKey: storeKey,
+		Token:    token,
+		Record:   record,
+		Header:   header,
+		Prefix:   prefix,
+	}, nil
+}
+
+func (e *Executor) managedTokenSource() *runtimemanagedcredentials.TokenSource {
+	return &runtimemanagedcredentials.TokenSource{
+		Store:      e.managedCredentials,
+		HTTPClient: e.httpClient,
+	}
+}
+
+func applyManagedCredentialHeader(headers http.Header, auth *managedHTTPAuth, replace bool) error {
+	if auth == nil {
+		return nil
+	}
+	header := strings.TrimSpace(auth.Header)
+	if header == "" {
+		header = "Authorization"
+	}
+	if existing := strings.TrimSpace(headers.Get(header)); existing != "" && !replace {
+		return fmt.Errorf("managed credential cannot set %s because the header is already configured", header)
+	}
+	value := strings.TrimSpace(auth.Token)
+	if value == "" {
+		return fmt.Errorf("managed credential %q did not provide an access token", auth.StoreKey)
+	}
+	if prefix := strings.TrimSpace(auth.Prefix); prefix != "" {
+		value = prefix + " " + value
+	}
+	headers.Set(header, value)
+	return nil
+}
+
+func rewindBodyReader(body io.Reader) {
+	if seeker, ok := body.(io.Seeker); ok {
+		_, _ = seeker.Seek(0, io.SeekStart)
+	}
+}
+
+func (e *Executor) execHTTPRequestOnce(ctx context.Context, method, url string, headers http.Header, body io.Reader, timeout time.Duration, tool RegisteredTool, secrets []string) (any, error) {
 	if err := e.admitExternalDispatch(ctx, e.httpToolExternalDispatchPolicy(tool)); err != nil {
 		return nil, err
 	}
@@ -137,8 +277,9 @@ func (e *Executor) execHTTPRequestOnce(ctx context.Context, method, url string, 
 		return nil, err
 	}
 	parsedBody := parseHTTPResponseBody(resp, rawBody)
+	parsedBody = runtimemanagedcredentials.RedactValue(parsedBody, secrets...)
 	if resp.StatusCode >= 400 {
-		return nil, fmt.Errorf("http tool %s returned status %d: %s", tool.Name, resp.StatusCode, strings.TrimSpace(asString(parsedBody)))
+		return nil, httpToolStatusError{ToolName: tool.Name, StatusCode: resp.StatusCode, Body: parsedBody, Secrets: secrets}
 	}
 	if len(tool.ResponseMapping) == 0 {
 		return parsedBody, nil

--- a/internal/runtime/tools/external_dispatch_admission_test.go
+++ b/internal/runtime/tools/external_dispatch_admission_test.go
@@ -179,10 +179,10 @@ func TestExecutor_HTTPTimeoutStartsAfterAdmissionWait(t *testing.T) {
 			MaxWait: 500 * time.Millisecond,
 		},
 	}
-	if _, err := exec.execHTTPRequestOnce(context.Background(), http.MethodGet, server.URL, http.Header{}, nil, 20*time.Millisecond, tool); err != nil {
+	if _, err := exec.execHTTPRequestOnce(context.Background(), http.MethodGet, server.URL, http.Header{}, nil, 20*time.Millisecond, tool, nil); err != nil {
 		t.Fatalf("initial execHTTPRequestOnce: %v", err)
 	}
-	if _, err := exec.execHTTPRequestOnce(context.Background(), http.MethodGet, server.URL, http.Header{}, nil, 20*time.Millisecond, tool); err != nil {
+	if _, err := exec.execHTTPRequestOnce(context.Background(), http.MethodGet, server.URL, http.Header{}, nil, 20*time.Millisecond, tool, nil); err != nil {
 		t.Fatalf("second execHTTPRequestOnce after admission wait: %v", err)
 	}
 	recorder.requireGapAtLeast(t, 45*time.Millisecond)

--- a/internal/runtime/tools/managed_credentials_test.go
+++ b/internal/runtime/tools/managed_credentials_test.go
@@ -1,0 +1,445 @@
+package tools
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
+	models "github.com/division-sh/swarm/internal/runtime/core/actors"
+	runtimemanagedcredentials "github.com/division-sh/swarm/internal/runtime/managedcredentials"
+	runtimemcp "github.com/division-sh/swarm/internal/runtime/mcp"
+	"github.com/division-sh/swarm/internal/runtime/semanticview"
+)
+
+func TestExecutorHTTPToolUsesManagedCredentialAndRefreshesOnUnauthorized(t *testing.T) {
+	ctx := context.Background()
+	var apiCalls atomic.Int32
+	var tokenCalls atomic.Int32
+	var sawAuth []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/token":
+			tokenCalls.Add(1)
+			if err := r.ParseForm(); err != nil {
+				t.Fatalf("ParseForm: %v", err)
+			}
+			if got := r.Form.Get("grant_type"); got != "refresh_token" {
+				t.Fatalf("refresh grant_type = %q, want refresh_token", got)
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"access_token":  "refreshed-token",
+				"refresh_token": "refresh-secret",
+				"expires_in":    3600,
+				"scope":         "repo.read",
+			})
+		case "/api":
+			sawAuth = append(sawAuth, r.Header.Get("Authorization"))
+			if apiCalls.Add(1) == 1 {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusUnauthorized)
+				_ = json.NewEncoder(w).Encode(map[string]any{"error": "expired old-token"})
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{"ok": true})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	store := runtimemanagedcredentials.NewMemoryStore(runtimemanagedcredentials.Record{
+		Key:          "github",
+		Provider:     "github",
+		GrantType:    runtimemanagedcredentials.GrantAuthorizationCodePKCE,
+		TokenURL:     server.URL + "/token",
+		ClientID:     "client-id",
+		AccessToken:  "old-token",
+		RefreshToken: "refresh-secret",
+		Scopes:       []string{"repo.read"},
+		Status:       runtimemanagedcredentials.StatusConnected,
+		ExpiresAt:    time.Now().Add(time.Hour),
+	})
+	exec := NewExecutorWithOptions(nil, nil, ExecutorOptions{
+		WorkflowSource:     managedCredentialSource(server.URL+"/api", "github", []string{"repo.read"}),
+		ManagedCredentials: store,
+	})
+	out, err := exec.Execute(models.WithActor(ctx, managedCredentialActor()), "send_provider", map[string]any{})
+	if err != nil {
+		t.Fatalf("Execute(send_provider): %v", err)
+	}
+	if got := out.(map[string]any)["ok"]; got != true {
+		t.Fatalf("result ok = %#v, want true", got)
+	}
+	if apiCalls.Load() != 2 || tokenCalls.Load() != 1 {
+		t.Fatalf("api/token calls = (%d, %d), want (2, 1)", apiCalls.Load(), tokenCalls.Load())
+	}
+	if strings.Join(sawAuth, ",") != "Bearer old-token,Bearer refreshed-token" {
+		t.Fatalf("Authorization sequence = %v, want old then refreshed", sawAuth)
+	}
+}
+
+func TestValidateToolImplementationsRejectsMalformedManagedCredentialReferences(t *testing.T) {
+	source := semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
+		Tools: map[string]runtimecontracts.ToolSchemaEntry{
+			"bad_http": {
+				HandlerType:       "http",
+				HTTP:              &runtimecontracts.HTTPToolSpec{Method: "GET", URL: "https://provider.example.test"},
+				ManagedCredential: &runtimecontracts.ManagedCredentialRef{},
+			},
+		},
+	})
+	if _, err := ValidateToolImplementations(source); err == nil || !strings.Contains(err.Error(), "managed_credential.key is required") {
+		t.Fatalf("ValidateToolImplementations err = %v, want managed_credential.key failure", err)
+	}
+
+	source = semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
+		Tools: map[string]runtimecontracts.ToolSchemaEntry{
+			"bad_mcp": {
+				HandlerType:       "mcp",
+				ManagedCredential: &runtimecontracts.ManagedCredentialRef{Key: "github"},
+			},
+		},
+	})
+	if _, err := ValidateToolImplementations(source); err == nil || !strings.Contains(err.Error(), "managed_credential is only supported") {
+		t.Fatalf("ValidateToolImplementations err = %v, want HTTP-only managed credential failure", err)
+	}
+}
+
+func TestExecutorHTTPToolRefreshesManagedCredentialBeforeUse(t *testing.T) {
+	ctx := context.Background()
+	var sawAuth string
+	var tokenCalls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/token":
+			tokenCalls.Add(1)
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"access_token": "preflight-refresh-token",
+				"expires_in":   3600,
+				"scope":        "repo.read",
+			})
+		case "/api":
+			sawAuth = r.Header.Get("Authorization")
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{"ok": true})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	store := runtimemanagedcredentials.NewMemoryStore(runtimemanagedcredentials.Record{
+		Key:          "github",
+		GrantType:    runtimemanagedcredentials.GrantAuthorizationCodePKCE,
+		TokenURL:     server.URL + "/token",
+		ClientID:     "client-id",
+		AccessToken:  "expired-token",
+		RefreshToken: "refresh-secret",
+		Scopes:       []string{"repo.read"},
+		Status:       runtimemanagedcredentials.StatusConnected,
+		ExpiresAt:    time.Now().Add(-time.Minute),
+	})
+	exec := NewExecutorWithOptions(nil, nil, ExecutorOptions{
+		WorkflowSource:     managedCredentialSource(server.URL+"/api", "github", []string{"repo.read"}),
+		ManagedCredentials: store,
+	})
+	if _, err := exec.Execute(models.WithActor(ctx, managedCredentialActor()), "send_provider", map[string]any{}); err != nil {
+		t.Fatalf("Execute(send_provider): %v", err)
+	}
+	if tokenCalls.Load() != 1 {
+		t.Fatalf("token calls = %d, want 1", tokenCalls.Load())
+	}
+	if sawAuth != "Bearer preflight-refresh-token" {
+		t.Fatalf("Authorization = %q, want refreshed token", sawAuth)
+	}
+}
+
+func TestExecutorHTTPToolManagedCredentialFailuresAreFailClosedAndRedacted(t *testing.T) {
+	ctx := context.Background()
+	serverCalled := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		serverCalled = true
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"error": "provider echoed access-secret refresh-secret client-secret",
+		})
+	}))
+	defer server.Close()
+
+	t.Run("missing", func(t *testing.T) {
+		serverCalled = false
+		exec := NewExecutorWithOptions(nil, nil, ExecutorOptions{
+			WorkflowSource:     managedCredentialSource(server.URL, "missing", nil),
+			ManagedCredentials: runtimemanagedcredentials.NewMemoryStore(),
+		})
+		_, err := exec.Execute(models.WithActor(ctx, managedCredentialActor()), "send_provider", map[string]any{})
+		if err == nil || !strings.Contains(err.Error(), `missing managed credential "missing"`) {
+			t.Fatalf("Execute err = %v, want missing managed credential", err)
+		}
+		if serverCalled {
+			t.Fatal("HTTP server should not be called for missing managed credential")
+		}
+	})
+
+	t.Run("scope insufficient", func(t *testing.T) {
+		serverCalled = false
+		store := runtimemanagedcredentials.NewMemoryStore(runtimemanagedcredentials.Record{
+			Key:         "github",
+			GrantType:   runtimemanagedcredentials.GrantClientCredentials,
+			AccessToken: "access-secret",
+			Scopes:      []string{"repo.read"},
+			Status:      runtimemanagedcredentials.StatusConnected,
+		})
+		exec := NewExecutorWithOptions(nil, nil, ExecutorOptions{
+			WorkflowSource:     managedCredentialSource(server.URL, "github", []string{"repo.write"}),
+			ManagedCredentials: store,
+		})
+		_, err := exec.Execute(models.WithActor(ctx, managedCredentialActor()), "send_provider", map[string]any{})
+		if err == nil || !strings.Contains(err.Error(), "scope-insufficient") {
+			t.Fatalf("Execute err = %v, want scope-insufficient", err)
+		}
+		if serverCalled {
+			t.Fatal("HTTP server should not be called for scope-insufficient managed credential")
+		}
+	})
+
+	t.Run("provider error redacted", func(t *testing.T) {
+		store := runtimemanagedcredentials.NewMemoryStore(runtimemanagedcredentials.Record{
+			Key:          "github",
+			GrantType:    runtimemanagedcredentials.GrantAuthorizationCodePKCE,
+			AccessToken:  "access-secret",
+			RefreshToken: "refresh-secret",
+			ClientSecret: "client-secret",
+			Status:       runtimemanagedcredentials.StatusConnected,
+		})
+		exec := NewExecutorWithOptions(nil, nil, ExecutorOptions{
+			WorkflowSource:     managedCredentialSource(server.URL, "github", nil),
+			ManagedCredentials: store,
+		})
+		_, err := exec.Execute(models.WithActor(ctx, managedCredentialActor()), "send_provider", map[string]any{})
+		if err == nil {
+			t.Fatal("Execute err = nil, want provider error")
+		}
+		for _, secret := range []string{"access-secret", "refresh-secret", "client-secret"} {
+			if strings.Contains(err.Error(), secret) {
+				t.Fatalf("error leaked %s: %v", secret, err)
+			}
+		}
+	})
+}
+
+func TestExecutorHTTPToolUsesImportedManagedCredentialBinding(t *testing.T) {
+	ctx := context.Background()
+	var sawAuth string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		sawAuth = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"ok": true})
+	}))
+	defer server.Close()
+
+	source := loadManagedCredentialImportSource(t, server.URL, "        provider_oauth: tenant_oauth\n", false)
+	store := runtimemanagedcredentials.NewMemoryStore(runtimemanagedcredentials.Record{
+		Key:         "tenant_oauth",
+		GrantType:   runtimemanagedcredentials.GrantClientCredentials,
+		AccessToken: "tenant-token",
+		Scopes:      []string{"repo.read"},
+		Status:      runtimemanagedcredentials.StatusConnected,
+	})
+	exec := NewExecutorWithOptions(nil, nil, ExecutorOptions{WorkflowSource: source, ManagedCredentials: store})
+	if _, err := exec.Execute(models.WithActor(ctx, managedCredentialActor()), "send_provider", map[string]any{}); err != nil {
+		t.Fatalf("Execute(send_provider): %v", err)
+	}
+	if sawAuth != "Bearer tenant-token" {
+		t.Fatalf("Authorization = %q, want bound tenant token", sawAuth)
+	}
+}
+
+func TestExecutorHTTPToolRejectsAmbientManagedCredentialFallback(t *testing.T) {
+	ctx := context.Background()
+	server := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		t.Fatal("HTTP server should not be called when managed credential binding is missing")
+	}))
+	defer server.Close()
+
+	source := loadManagedCredentialImportSource(t, server.URL, "", false)
+	store := runtimemanagedcredentials.NewMemoryStore(runtimemanagedcredentials.Record{
+		Key:         "provider_oauth",
+		GrantType:   runtimemanagedcredentials.GrantClientCredentials,
+		AccessToken: "ambient-token",
+		Status:      runtimemanagedcredentials.StatusConnected,
+	})
+	exec := NewExecutorWithOptions(nil, nil, ExecutorOptions{WorkflowSource: source, ManagedCredentials: store})
+	_, err := exec.Execute(models.WithActor(ctx, managedCredentialActor()), "send_provider", map[string]any{})
+	if err == nil || !strings.Contains(err.Error(), "not declared and bound") {
+		t.Fatalf("Execute err = %v, want imported managed credential binding failure", err)
+	}
+}
+
+func TestExecutorHTTPToolManagedCredentialServedAndMCPTransportsUseSameOwner(t *testing.T) {
+	var calls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		if got := r.Header.Get("Authorization"); got != "Bearer served-token" {
+			t.Fatalf("Authorization = %q, want served-token", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"ok": true})
+	}))
+	defer server.Close()
+
+	exec := NewExecutorWithOptions(nil, nil, ExecutorOptions{
+		WorkflowSource: managedCredentialSource(server.URL, "github", nil),
+		ManagedCredentials: runtimemanagedcredentials.NewMemoryStore(runtimemanagedcredentials.Record{
+			Key:         "github",
+			GrantType:   runtimemanagedcredentials.GrantClientCredentials,
+			AccessToken: "served-token",
+			Status:      runtimemanagedcredentials.StatusConnected,
+		}),
+	})
+	actor := managedCredentialActor()
+	gateway := runtimemcp.NewGateway(exec, "gateway-token", runtimemcp.GatewayHooks{
+		WithActor:        models.WithActor,
+		ActorFromContext: models.ActorFromContext,
+		ResolveTurnContext: func(token string) (runtimemcp.TurnContext, bool) {
+			if token != "ctx-managed" {
+				return runtimemcp.TurnContext{}, false
+			}
+			return runtimemcp.TurnContext{
+				Actor:   actor,
+				Allowed: map[string]struct{}{"send_provider": {}},
+			}, true
+		},
+	})
+
+	toolBody, _ := json.Marshal(map[string]any{"input": map[string]any{}})
+	toolReq := httptest.NewRequest(http.MethodPost, "/tools/send_provider", bytes.NewReader(toolBody))
+	toolReq.Header.Set("Authorization", "Bearer gateway-token")
+	toolReq.Header.Set("X-SWARM-Context-Token", "ctx-managed")
+	toolRec := httptest.NewRecorder()
+	gateway.Handler().ServeHTTP(toolRec, toolReq)
+	if toolRec.Code != http.StatusOK {
+		t.Fatalf("/tools status = %d body=%s", toolRec.Code, toolRec.Body.String())
+	}
+
+	mcpBody, _ := json.Marshal(map[string]any{
+		"jsonrpc": "2.0",
+		"id":      1,
+		"method":  "tools/call",
+		"params": map[string]any{
+			"name":      "send_provider",
+			"arguments": map[string]any{},
+		},
+	})
+	mcpReq := httptest.NewRequest(http.MethodPost, "/mcp", bytes.NewReader(mcpBody))
+	mcpReq.Header.Set("Authorization", "Bearer gateway-token")
+	mcpReq.Header.Set("X-SWARM-Context-Token", "ctx-managed")
+	mcpRec := httptest.NewRecorder()
+	gateway.Handler().ServeHTTP(mcpRec, mcpReq)
+	if mcpRec.Code != http.StatusOK {
+		t.Fatalf("/mcp status = %d body=%s", mcpRec.Code, mcpRec.Body.String())
+	}
+	if calls.Load() != 2 {
+		t.Fatalf("HTTP provider calls = %d, want 2", calls.Load())
+	}
+}
+
+func managedCredentialActor() models.AgentConfig {
+	return models.AgentConfig{
+		ID:       "worker-agent",
+		FlowPath: "worker/instance-1",
+		Tools:    []string{"send_provider"},
+	}
+}
+
+func managedCredentialSource(serverURL, key string, scopes []string) semanticview.Source {
+	return semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
+		Tools: map[string]runtimecontracts.ToolSchemaEntry{
+			"send_provider": {
+				HandlerType: "http",
+				InputSchema: runtimecontracts.ToolInputSchema{Type: "object"},
+				HTTP: &runtimecontracts.HTTPToolSpec{
+					Method: "GET",
+					URL:    serverURL,
+				},
+				ManagedCredential: &runtimecontracts.ManagedCredentialRef{
+					Key:    key,
+					Scopes: scopes,
+				},
+				ResponseMapping: map[string]any{"ok": "{{response.body.ok}}"},
+			},
+		},
+	})
+}
+
+func loadManagedCredentialImportSource(t *testing.T, serverURL, credentialBind string, omitRequires bool) semanticview.Source {
+	t.Helper()
+	repoRoot := toolsRepoRootForTest(t)
+	root := t.TempDir()
+	bindCredentials := ""
+	if strings.TrimSpace(credentialBind) != "" {
+		bindCredentials = "      credentials:\n" + credentialBind
+	}
+	writeToolFixtureFile(t, root+"/package.yaml", `
+name: managed-credential-import
+version: "1.0.0"
+flows:
+  - id: worker
+    flow: worker
+    mode: static
+    bind:
+`+bindCredentials)
+	writeToolFixtureFile(t, root+"/schema.yaml", "name: managed-credential-import\n")
+	writeToolFixtureFile(t, root+"/tools.yaml", "{}\n")
+	writeToolFixtureFile(t, root+"/agents.yaml", "{}\n")
+	writeToolFixtureFile(t, root+"/events.yaml", "{}\n")
+	writeToolFixtureFile(t, root+"/nodes.yaml", "{}\n")
+	requires := "  credentials: [provider_oauth]\n"
+	if omitRequires {
+		requires = ""
+	}
+	writeToolFixtureFile(t, root+"/flows/worker/package.yaml", `
+name: worker-package
+version: "1.0.0"
+requires:
+`+requires)
+	writeToolFixtureFile(t, root+"/flows/worker/schema.yaml", "name: worker\nmode: static\n")
+	writeToolFixtureFile(t, root+"/flows/worker/policy.yaml", "{}\n")
+	writeToolFixtureFile(t, root+"/flows/worker/agents.yaml", `
+worker-agent:
+  id: worker-agent
+  role: worker
+  mode: task
+  model: regular
+  tools: [send_provider]
+`)
+	writeToolFixtureFile(t, root+"/flows/worker/tools.yaml", `
+send_provider:
+  handler_type: http
+  managed_credential:
+    key: provider_oauth
+    scopes: [repo.read]
+  input_schema:
+    type: object
+  http:
+    method: GET
+    url: `+serverURL+`
+  response_mapping:
+    ok: '{{response.body.ok}}'
+`)
+	writeToolFixtureFile(t, root+"/flows/worker/events.yaml", "{}\n")
+	bundle, err := runtimecontracts.LoadWorkflowContractBundleWithOverrides(repoRoot, root, runtimecontracts.DefaultPlatformSpecFile(repoRoot))
+	if err != nil {
+		t.Fatalf("LoadWorkflowContractBundleWithOverrides: %v", err)
+	}
+	return semanticview.Wrap(bundle)
+}

--- a/internal/runtime/tools/registry.go
+++ b/internal/runtime/tools/registry.go
@@ -33,6 +33,7 @@ type RegisteredTool struct {
 	HTTP               *runtimecontracts.HTTPToolSpec
 	ResponseMapping    map[string]any
 	Credentials        []string
+	ManagedCredential  *runtimecontracts.ManagedCredentialRef
 	RateLimit          externalDispatchRateLimitConfig
 	MCPServerName      string
 	MCPRemoteName      string
@@ -239,8 +240,18 @@ func registeredToolFromContract(name string, entry runtimecontracts.ToolSchemaEn
 		HTTP:               entry.HTTP,
 		ResponseMapping:    deepCloneMap(entry.ResponseMapping),
 		Credentials:        append([]string{}, entry.Credentials...),
+		ManagedCredential:  cloneManagedCredentialRef(entry.ManagedCredential),
 		RateLimit:          rateLimit,
 	}, true, nil
+}
+
+func cloneManagedCredentialRef(ref *runtimecontracts.ManagedCredentialRef) *runtimecontracts.ManagedCredentialRef {
+	if ref == nil {
+		return nil
+	}
+	out := *ref
+	out.Scopes = append([]string{}, ref.Scopes...)
+	return &out
 }
 
 func normalizeImplementationClass(name string, entry runtimecontracts.ToolSchemaEntry) implementationClass {

--- a/internal/runtime/tools/validation.go
+++ b/internal/runtime/tools/validation.go
@@ -32,6 +32,9 @@ func ValidateToolImplementations(source semanticview.Source) ([]error, error) {
 		}
 		switch normalized {
 		case implementationPlatformBuiltin:
+			if entry.ManagedCredential != nil {
+				return warnings, fmt.Errorf("tool %s managed_credential is only supported for handler_type http", name)
+			}
 			if _, ok := supportedRuntimeToolNames[name]; !ok {
 				return warnings, fmt.Errorf("tool %s declares handler_type platform_builtin but is not shipped by the generic runtime", name)
 			}
@@ -45,7 +48,16 @@ func ValidateToolImplementations(source semanticview.Source) ([]error, error) {
 			if strings.TrimSpace(entry.HTTP.URL) == "" {
 				return warnings, fmt.Errorf("tool %s http.url is required", name)
 			}
+			if entry.ManagedCredential != nil && strings.TrimSpace(entry.ManagedCredential.Key) == "" {
+				return warnings, fmt.Errorf("tool %s managed_credential.key is required", name)
+			}
+			if entry.ManagedCredential != nil && strings.TrimSpace(entry.ManagedCredential.Header) == "" && strings.TrimSpace(entry.ManagedCredential.Prefix) != "" {
+				return warnings, fmt.Errorf("tool %s managed_credential.header is required when prefix is set", name)
+			}
 		case implementationMCP:
+			if entry.ManagedCredential != nil {
+				return warnings, fmt.Errorf("tool %s managed_credential is only supported for handler_type http", name)
+			}
 			if !strings.Contains(name, ".") {
 				warnings = append(warnings, fmt.Errorf("tool %s uses handler_type mcp but is not prefixed with a server namespace", name))
 			}

--- a/internal/runtime/workflow_validation.go
+++ b/internal/runtime/workflow_validation.go
@@ -9,12 +9,14 @@ import (
 	runtimebootverify "github.com/division-sh/swarm/internal/runtime/bootverify"
 	runtimecredentials "github.com/division-sh/swarm/internal/runtime/credentials"
 	llmselection "github.com/division-sh/swarm/internal/runtime/llm/selection"
+	runtimemanagedcredentials "github.com/division-sh/swarm/internal/runtime/managedcredentials"
 	"github.com/division-sh/swarm/internal/runtime/semanticview"
 	runtimetools "github.com/division-sh/swarm/internal/runtime/tools"
 )
 
 type WorkflowContractValidationOptions struct {
 	Credentials                    runtimecredentials.Store
+	ManagedCredentials             runtimemanagedcredentials.Store
 	CheckMCPReachable              bool
 	StrictEmitSchemas              bool
 	FatalToolImplementationWarning bool
@@ -54,6 +56,7 @@ func ValidateWorkflowContractSurface(ctx context.Context, source semanticview.So
 
 	result.BootReport = runtimebootverify.Run(ctx, source, runtimebootverify.Options{
 		Credentials:             opts.Credentials,
+		ManagedCredentials:      opts.ManagedCredentials,
 		CheckMCPReachable:       opts.CheckMCPReachable,
 		ValidateModelResolution: opts.ValidateLLMModelResolution,
 		LLMProfile:              opts.LLMProfile,

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -5181,6 +5181,16 @@ tool_model:
           returned as the tool result.
         credentials: list of strings — credential store key names this tool needs. The platform resolves them from the credential
           store at call time and makes them available as {{credentials.key}} in templates.
+        managed_credential: >
+          object — managed credential reference for deployment-level OAuth/token lifecycle. This is a sibling owner to
+          static `credentials`; it does not create {{credentials.*}} template variables and it is not stored in
+          `swarm secrets`. Fields: key is the required package-local credential handle; imported packages must declare the
+          handle under `requires.credentials` and the parent import site must bind it through `bind.credentials`; no ambient
+          same-name fallback is allowed. header optionally names the request header to receive the access token and defaults
+          to `Authorization`. prefix optionally names the value prefix and defaults to `Bearer` only when header is omitted
+          or `Authorization`; custom headers default to the raw access token. scopes optionally lists scopes required by this
+          tool call. Boot/verify and execution fail closed when the connected managed credential record does not cover every
+          required scope.
         rate_limit: string — optional external dispatch rate limit, format N/period.
         rate_limit_max_wait: string — required when rate_limit is present; maximum per-call admission wait before
           returning typed rate_limited.
@@ -5195,6 +5205,13 @@ tool_model:
           {{response.headers.header_name}}.
       missing_variable: If a required template variable cannot be resolved (missing input field, missing credential), the tool
         call fails with an error returned to the agent. The platform does not make the HTTP request.
+      managed_credentials: >
+        `managed_credential` is resolved after package/import credential binding and before request dispatch. The managed
+        credential owner provides only in-flight authorization material. The runtime refreshes before use when the record is
+        expired or near expiry, injects the token into the configured header, and on provider 401 refreshes once and retries
+        the request once. Missing, unconnected, refresh-failed, scope-insufficient, unsupported, or unbound managed
+        credentials fail closed before dispatch. A tool may not also configure the same header in `http.headers`; that would
+        create dual authorization ownership.
     external_provider_dispatch_rate_limit:
       description: >
         `rate_limit` on an HTTP tool declares process-local admission for outbound HTTP provider dispatch by that tool.
@@ -5301,6 +5318,80 @@ tool_model:
     platform_guarantee: The platform never logs, indexes, or persists credential values in the event store, dead letters, or
       any platform table. Credentials exist only in the credential store and in-flight tool requests. Supported operator
       surfaces never return credential values after write — only metadata.
+  managed_credential_store:
+    description: >
+      Sibling source authority for deployment-level managed OAuth/token credentials used by outbound HTTP tools. It owns
+      structured token records and lifecycle state. It is not the static credential store and MUST NOT be implemented as
+      hidden behavior inside `credentials.Store.Get(string) string`.
+    scope:
+    - single-tenant/self-hosted/operator-connected deployment token records
+    - authorization-code + PKCE consent and callback
+    - client_credentials as the first non-consent grant variant
+    - access token, refresh token when present, expiry, scopes, provider/account identity, grant type, status, refresh
+      policy, and failure evidence
+    - direct Executor.Execute, served /tools/{name}, and MCP tools/call HTTP-tool entry points
+    non_goals:
+    - multi-tenant per-user token vault or end-user account selection
+    - provider trigger/webhook adapters; those extend existing inbound.webhook in a separate owner
+    - DB connectors, AWS SigV4/AssumeRole, MCP/native connector authentication, and real-provider catalog conveniences
+    local_storage:
+      default: os.UserConfigDir()/swarm/managed_credentials.json
+      override: SWARM_MANAGED_CREDENTIALS_FILE
+      file_mode: "0600"
+      directory_mode: "0700"
+      format: JSON object containing structured managed credential records. Access tokens, refresh tokens, client secrets,
+        PKCE verifier/state, expiry, status, and failure evidence are record fields.
+      write_coordination: Cross-process advisory lock around file-tier connect/callback/disconnect writes, plus atomic
+        replace. Lock contention fails closed instead of risking lost updates or truncated token records.
+    production_storage: >
+      Production deployments may provide another implementation of the managed credential store interface. The semantic
+      record shape and resolver behavior remain the owner; production storage MUST preserve status/failure/scopes/expiry
+      semantics and redaction guarantees.
+    record_fields:
+      key: Deployment-level managed credential key after import-boundary binding.
+      provider: Provider label for operator status.
+      account: Optional connected account identity/label.
+      grant_type: authorization_code_pkce | client_credentials.
+      auth_url: Authorization endpoint for authorization_code_pkce records.
+      token_url: Token endpoint for grant and refresh requests.
+      client_id: OAuth client ID.
+      client_secret: Optional OAuth client secret.
+      redirect_url: Callback URL for authorization_code_pkce.
+      scopes: Granted/available scopes.
+      access_token: Secret access token, never returned by metadata/status surfaces.
+      refresh_token: Secret refresh token, never returned by metadata/status surfaces.
+      token_type: Token type, default Bearer.
+      expires_at: Access-token expiry timestamp when known.
+      status: unconnected | pending_consent | connected | refresh_failed | scope_insufficient.
+      failure: Redacted failure evidence for operator readback.
+    resolver_rule: >
+      HTTP tools name `managed_credential.key` as a package-local handle. Runtime consumers MUST map that handle through the
+      same import-boundary `requires.credentials` / `bind.credentials` resolver used by static credentials, then read the
+      managed credential record by the resulting deployment key. If the handle is undeclared, unbound, empty, or missing from
+      the managed store, execution fails before outbound dispatch. Same-name ambient fallback is forbidden for imported
+      packages.
+    refresh_rule: >
+      Before request dispatch, the resolver returns a valid access token or fails closed. It refreshes before use when the
+      access token is absent or expires within the configured refresh window. For provider 401 responses, the HTTP executor
+      refreshes once and retries the request once. Refresh failure sets refresh_failed state with redacted failure evidence
+      and returns a redacted runtime error.
+    operator_surface:
+      command: swarm connections connect|callback|status|disconnect
+      rule: >
+        `swarm connections` is the supported local operator CLI for managed credential lifecycle. `connect` starts
+        authorization_code_pkce consent or completes a client_credentials grant; `callback` records the authorization-code
+        callback; `status` returns metadata and required_by information only; `disconnect` deletes the token record. The
+        command is intentionally separate from `swarm secrets`, which remains static key/value secret storage. Secret
+        values accepted by the CLI, including OAuth client secrets and authorization callback codes, MUST NOT be accepted
+        as argv flag values; supported local secret input uses stdin or an equivalent non-argv source.
+    boot_validation: >
+      Boot/verify consumes managed_credential requirements and reports managed_credential_state for missing, pending,
+      refresh_failed, scope_insufficient, or otherwise unusable records. When boot warnings are fatal, these findings block
+      startup. Execution still fails closed even when boot warnings are non-fatal.
+    redaction_guarantee: >
+      Access tokens, refresh tokens, client secrets, authorization codes, PKCE verifier/state, and provider errors containing
+      those values MUST NOT be returned through logs, events, dead letters, tool results, metadata, or CLI/API/status
+      surfaces. Supported readback surfaces return only redacted metadata and failure evidence.
   custom_tool_schema:
     description: Accepted fields for tool definitions in tools.yaml. This is the union of fields across all implementation
       classes.
@@ -5317,6 +5408,7 @@ tool_model:
       http: object — HTTP request template (see http_tool_definition.schema.http_block)
       response_mapping: object — maps response fields to output fields
       credentials: list of strings — credential store keys
+      managed_credential: object — managed OAuth/token credential reference; supported only for handler_type http
       rate_limit: string — optional external dispatch admission rate, supported only when handler_type resolves to http.
       rate_limit_max_wait: string — required when rate_limit is present.
     not_accepted:
@@ -5986,11 +6078,12 @@ flow_model:
           different semantic concept and must not be used as an import compatibility shim.
         credentials: >
           Imported package credential dependencies resolve exactly in this order: package-local credential handle,
-          import-site `bind.credentials` value, deployment credential-store key, credential-store value at call time.
-          Credentials have no package defaults and no same-name raw-key fallback. Tool, MCP, native web-search, bootverify,
-          and credential metadata consumers must map package handles through this resolver before reading or indexing
-          deployment credential keys. The credential store remains the only owner of secret values; the import-boundary
-          resolver never exposes or persists credential values.
+          import-site `bind.credentials` value, deployment credential key, owner-specific value or managed record at call
+          time. Credentials have no package defaults and no same-name raw-key fallback. Static HTTP/MCP/native web-search,
+          managed HTTP credential, bootverify, and credential metadata/status consumers must map package handles through
+          this resolver before reading or indexing deployment credential keys. The static credential store remains the only
+          owner of static secret values; the managed credential store remains the only owner of managed token records; the
+          import-boundary resolver never exposes or persists secret values or token material.
         fail_closed: >
           Runtime and verify consumers must use the shared import-boundary dependency resolver. A remaining same-concept
           helper that independently interprets imported package policy or credential handles is non-authoritative. Imported
@@ -12841,6 +12934,49 @@ cli_specification:
       - external vault/team secret management
       - package credential binding semantics
       - boot-check severity policy
+    connections:
+      command: swarm connections connect|callback|status|disconnect
+      tier: must_have
+      implementation_status: implemented_first_slice
+      owner: tool_model.managed_credential_store
+      behavior: >
+        Local operator CLI for deployment-level managed OAuth/token credentials. This command owns managed credential
+        lifecycle metadata and token records; it MUST NOT store OAuth lifecycle state in `swarm secrets` and MUST NOT expose
+        access tokens, refresh tokens, authorization codes, PKCE verifiers/state, or client secrets in stdout/stderr/status
+        JSON.
+      subcommands:
+        connect:
+          command: swarm connections connect <key> --grant authorization_code_pkce|client_credentials [...]
+          behavior: >
+            For authorization_code_pkce, stores a pending consent record with provider config, PKCE challenge/state, and
+            metadata, then prints only the authorization URL/state and redacted connection metadata. For client_credentials,
+            exchanges with the token endpoint immediately and stores a connected token record. OAuth client secrets, when
+            required by the provider, are read through `--client-secret-stdin`; an argv `--client-secret <value>` source is
+            unsupported because it leaks through shell history and process listings.
+        callback:
+          command: swarm connections callback <key> --state <state> --code-stdin
+          behavior: >
+            Completes an authorization_code_pkce record by validating callback state, exchanging the code with the stored
+            verifier, clearing transient verifier/state fields, and persisting connected token metadata. The authorization
+            code is read from stdin and MUST NOT be accepted as an argv flag value. Output is metadata only.
+        status:
+          command: swarm connections status [<key>] [--json] [--contracts <path>]
+          behavior: >
+            Lists managed credential metadata only: key, provider, account, grant_type, scopes, status, redacted failure,
+            expires_at, updated_at, present, and required_by where contract source context is available. Values and token
+            material are never returned.
+        disconnect:
+          command: swarm connections disconnect <key>
+          behavior: Deletes the managed credential token record for the deployment key.
+      storage_path:
+        default: os.UserConfigDir()/swarm/managed_credentials.json
+        override: SWARM_MANAGED_CREDENTIALS_FILE
+      split_scope:
+        - static `swarm secrets` API-key/PAT/bearer-token values
+        - provider trigger/webhook adapters on inbound.webhook
+        - multi-tenant per-user token vaults
+        - DB/AWS SigV4/non-HTTP/native connector auth
+        - external vault/team managed credential UI/API
     serve:
       command: swarm serve [flags]
       tier: must_have


### PR DESCRIPTION
## Summary
- Adds a structured managed credential owner for single-tenant outbound HTTP OAuth/token credentials.
- Adds `managed_credential` tool syntax, runtime resolution through import-boundary credential binding, refresh-before-use, refresh-on-401 retry once, fail-closed states, and redacted errors/status.
- Adds `swarm connections connect|callback|status|disconnect` for local managed credential lifecycle.
- Wires managed credential checks through boot/verify, runtime startup, direct executor, served `/tools/{name}`, MCP `tools/call`, and selected fork runtime materialization.
- Hardens the existing event bus ACK timing test so the assertion is event-driven under full-suite load.

Closes #1650

## Governing Refs / Context
- `platform-spec.yaml`: `tool_model.http_tool_definition`
- `platform-spec.yaml`: `tool_model.credential_store`
- `platform-spec.yaml`: new `tool_model.managed_credential_store`
- `platform-spec.yaml`: `flow_model.flow_package.import_boundary.credentials`
- `platform-spec.yaml`: `cli_specification.connections`
- Binding issue/gate: #1650 pre-audit and independent gate approval.

## Semantic Migration
- New canonical owner: `tool_model.managed_credential_store` and `internal/runtime/managedcredentials` for managed OAuth/token records and lifecycle state.
- Old producer/reader/writer path now invalid for this concept: static `swarm secrets`, static `credentials: [...]`, and `{{credentials.key}}` remain valid only for static API-key/PAT/bearer-token values and do not own managed OAuth/token lifecycle.
- Production paths checked for surviving old behavior: direct `Executor.Execute`, served `/tools/{name}`, MCP `tools/call`, boot/verify/startup, import-boundary binding, selected fork runtime wiring, CLI status/readback.
- Migration completeness: complete for the approved #1650 first slice. Parent #1458 remains open for provider triggers on existing inbound webhook gateway, multi-tenant token vaults, non-HTTP/native/signed auth, and provider catalog conveniences.

## Validation
- `go test ./internal/runtime/managedcredentials ./internal/runtime/tools ./internal/runtime/bootverify ./cmd/swarm -count=1`
- `go test ./internal/runtime/bus -run TestEventBusPublishAcknowledgedReturnsBeforePostCommitDispatchCompletes -count=5 -v`
- `go test ./...`