### PR TITLE
[agent-z][issue #1649] CLI help intelligibility: journey groups, outcome descriptions, hidden advanced flags

### DIFF
--- a/cmd/swarm/agent_directive.go
+++ b/cmd/swarm/agent_directive.go
@@ -44,14 +44,15 @@ func newAgentDirectiveCommand(opts rootCommandOptions) *cobra.Command {
 	directiveOpts := agentDirectiveCommandOptions{apiOptions: opts}
 	cmd := &cobra.Command{
 		Use:   "directive <agent-id> <message>",
-		Short: "Send a directive to an agent through v1 RPC.",
+		Short: "Send a directive message to a running agent.",
 		Args:  cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runAgentDirectiveCommand(cmd.Context(), cmd.OutOrStdout(), cmd.ErrOrStderr(), args, directiveOpts)
 		},
 	}
 	cmd.Flags().StringVar(&directiveOpts.runID, "run-id", "", "Optional explicit nonterminal run target")
-	cmd.Flags().StringVar(&directiveOpts.idempotencyKey, "idempotency-key", "", "Optional v1 API idempotency key")
+	cmd.Flags().StringVar(&directiveOpts.idempotencyKey, "idempotency-key", "", "Optional idempotency key for safe retries (advanced)")
+	_ = cmd.Flags().MarkHidden("idempotency-key")
 	bindCLIAPIConnectionFlagsWithClass(cmd, &directiveOpts.apiOptions, cliAPICommandClassMutating, "swarm agent directive")
 	return cmd
 }

--- a/cmd/swarm/agent_replay.go
+++ b/cmd/swarm/agent_replay.go
@@ -54,14 +54,15 @@ func newAgentReplayCommand(opts rootCommandOptions) *cobra.Command {
 	replayOpts := agentReplayCommandOptions{apiOptions: opts}
 	cmd := &cobra.Command{
 		Use:   "replay <agent-id>",
-		Short: "Replay one event to an agent through v1 RPC.",
+		Short: "Replay a single event to an agent.",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runAgentReplayCommand(cmd.Context(), cmd.OutOrStdout(), cmd.ErrOrStderr(), args, replayOpts)
 		},
 	}
 	cmd.Flags().StringVar(&replayOpts.eventID, "event-id", "", "Required event ID to replay")
-	cmd.Flags().StringVar(&replayOpts.idempotencyKey, "idempotency-key", "", "Optional v1 API idempotency key")
+	cmd.Flags().StringVar(&replayOpts.idempotencyKey, "idempotency-key", "", "Optional idempotency key for safe retries (advanced)")
+	_ = cmd.Flags().MarkHidden("idempotency-key")
 	bindCLIAPIConnectionFlagsWithClass(cmd, &replayOpts.apiOptions, cliAPICommandClassMutating, "swarm agent replay")
 	return cmd
 }

--- a/cmd/swarm/agent_replay_backlog.go
+++ b/cmd/swarm/agent_replay_backlog.go
@@ -32,13 +32,14 @@ func newAgentReplayBacklogCommand(opts rootCommandOptions) *cobra.Command {
 	replayOpts := agentReplayBacklogCommandOptions{apiOptions: opts}
 	cmd := &cobra.Command{
 		Use:   "replay-backlog <agent-id>",
-		Short: "Replay an agent backlog through v1 RPC.",
+		Short: "Replay an agent's undelivered event backlog.",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runAgentReplayBacklogCommand(cmd.Context(), cmd.OutOrStdout(), cmd.ErrOrStderr(), args, replayOpts)
 		},
 	}
-	cmd.Flags().StringVar(&replayOpts.idempotencyKey, "idempotency-key", "", "Optional v1 API idempotency key")
+	cmd.Flags().StringVar(&replayOpts.idempotencyKey, "idempotency-key", "", "Optional idempotency key for safe retries (advanced)")
+	_ = cmd.Flags().MarkHidden("idempotency-key")
 	bindCLIAPIConnectionFlagsWithClass(cmd, &replayOpts.apiOptions, cliAPICommandClassMutating, "swarm agent replay-backlog")
 	return cmd
 }

--- a/cmd/swarm/agent_restart.go
+++ b/cmd/swarm/agent_restart.go
@@ -31,13 +31,14 @@ func newAgentRestartCommand(opts rootCommandOptions) *cobra.Command {
 	restartOpts := agentRestartCommandOptions{apiOptions: opts}
 	cmd := &cobra.Command{
 		Use:   "restart <agent-id>",
-		Short: "Restart an agent through v1 RPC.",
+		Short: "Restart a stuck or failed agent.",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runAgentRestartCommand(cmd.Context(), cmd.OutOrStdout(), cmd.ErrOrStderr(), args, restartOpts)
 		},
 	}
-	cmd.Flags().StringVar(&restartOpts.idempotencyKey, "idempotency-key", "", "Optional v1 API idempotency key")
+	cmd.Flags().StringVar(&restartOpts.idempotencyKey, "idempotency-key", "", "Optional idempotency key for safe retries (advanced)")
+	_ = cmd.Flags().MarkHidden("idempotency-key")
 	bindCLIAPIConnectionFlagsWithClass(cmd, &restartOpts.apiOptions, cliAPICommandClassMutating, "swarm agent restart")
 	return cmd
 }

--- a/cmd/swarm/agents.go
+++ b/cmd/swarm/agents.go
@@ -175,7 +175,7 @@ var agentValidSessionScopes = map[string]struct{}{
 func newAgentsCommand(opts rootCommandOptions) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "agents",
-		Short: "List agents through v1 RPC.",
+		Short: "List agents and their current state.",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return cmd.Help()
@@ -188,7 +188,7 @@ func newAgentsCommand(opts rootCommandOptions) *cobra.Command {
 func newAgentCommand(opts rootCommandOptions) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "agent",
-		Short: "View or direct one agent through v1 RPC.",
+		Short: "Inspect, direct, restart, or replay a single agent.",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return cmd.Help()
@@ -210,7 +210,7 @@ func newAgentDeliveriesCommand(opts rootCommandOptions) *cobra.Command {
 	deliveryOpts := agentDeliveriesCommandOptions{apiOptions: opts}
 	cmd := &cobra.Command{
 		Use:   "deliveries <agent-id>",
-		Short: "List one agent's delivery lifecycle rows through v1 RPC.",
+		Short: "List one agent's event delivery history.",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			deliveryOpts.runIDSet = cmd.Flags().Changed("run-id")
@@ -232,7 +232,7 @@ func newAgentDiagnoseCommand(opts rootCommandOptions) *cobra.Command {
 	diagnoseOpts := agentDiagnoseCommandOptions{apiOptions: opts}
 	cmd := &cobra.Command{
 		Use:   "diagnose <agent-id>",
-		Short: "Diagnose one agent through v1 RPC.",
+		Short: "Diagnose why an agent is stuck or failing.",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			diagnoseOpts.queueLimitSet = cmd.Flags().Changed("queue-limit")
@@ -251,7 +251,7 @@ func newAgentsListCommand(opts rootCommandOptions) *cobra.Command {
 	listOpts := agentListCommandOptions{apiOptions: opts}
 	cmd := &cobra.Command{
 		Use:   "list",
-		Short: "List declared agents through v1 RPC.",
+		Short: "List declared agents and their status.",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runAgentListCommand(cmd.Context(), cmd.OutOrStdout(), cmd.ErrOrStderr(), listOpts)
@@ -267,7 +267,7 @@ func newAgentViewCommand(opts rootCommandOptions) *cobra.Command {
 	apiOpts := opts
 	cmd := &cobra.Command{
 		Use:   "view <agent-id>",
-		Short: "View one agent through v1 RPC.",
+		Short: "View one agent's configuration and state.",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runAgentViewCommand(cmd.Context(), cmd.OutOrStdout(), cmd.ErrOrStderr(), apiOpts, args[0])

--- a/cmd/swarm/bundle.go
+++ b/cmd/swarm/bundle.go
@@ -141,7 +141,7 @@ type bundleAgentDefinition struct {
 func newBundleCommand(repoRoot string, opts rootCommandOptions) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "bundle",
-		Short: "Inspect persisted bundle catalog entries through v1 RPC.",
+		Short: "Inspect registered contract bundles.",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return cmd.Help()
@@ -161,7 +161,7 @@ func newBundleListCommand(opts rootCommandOptions) *cobra.Command {
 	listOpts := bundleListCommandOptions{apiOptions: opts}
 	cmd := &cobra.Command{
 		Use:   "list",
-		Short: "List persisted bundles through /v1/rpc bundle.list.",
+		Short: "List registered bundles.",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			listOpts.limitSet = cmd.Flags().Changed("limit")
@@ -183,7 +183,7 @@ func newBundleShowCommand(opts rootCommandOptions) *cobra.Command {
 	showOpts := bundleHashCommandOptions{apiOptions: opts}
 	cmd := &cobra.Command{
 		Use:   "show <bundle-hash>",
-		Short: "Show one persisted bundle through /v1/rpc bundle.get.",
+		Short: "Show one bundle's details.",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := showOpts.output.validate(); err != nil {
@@ -201,7 +201,7 @@ func newBundleAgentsCommand(opts rootCommandOptions) *cobra.Command {
 	agentsOpts := bundleHashCommandOptions{apiOptions: opts}
 	cmd := &cobra.Command{
 		Use:   "agents <bundle-hash>",
-		Short: "List bundle agent definitions through /v1/rpc bundle.agents.",
+		Short: "List the agents a bundle declares.",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := agentsOpts.output.validate(); err != nil {
@@ -219,7 +219,7 @@ func newBundleRegisterCommand(repoRoot string, opts rootCommandOptions) *cobra.C
 	registerOpts := bundleRegisterCommandOptions{apiOptions: opts, repoRoot: repoRoot}
 	cmd := &cobra.Command{
 		Use:   "register <registration-envelope-yaml> | register --contracts <contracts-directory>",
-		Short: "Register a bundle through /v1/rpc bundle.register.",
+		Short: "Register a contract bundle with the runtime.",
 		Args:  cobra.ArbitraryArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			registerOpts.dataBlobSet = cmd.Flags().Changed("data-blob")
@@ -234,6 +234,7 @@ func newBundleRegisterCommand(repoRoot string, opts rootCommandOptions) *cobra.C
 	cmd.Flags().StringVar(&registerOpts.dataBlobPath, "data-blob", "", "Path to a BundleRegisterDataBlobV1 JSON document")
 	cmd.Flags().StringVar(&registerOpts.contractsDir, "contracts", "", "Package a local contracts directory into BundleRegistrationEnvelopeV1 before calling bundle.register")
 	cmd.Flags().StringVar(&registerOpts.idempotencyKey, "idempotency-key", "", "Optional idempotency key for bundle.register")
+	_ = cmd.Flags().MarkHidden("idempotency-key")
 	bindCLIOutputFlags(cmd, &registerOpts.output)
 	bindCLIAPIConnectionFlagsWithClass(cmd, &registerOpts.apiOptions, cliAPICommandClassMutating, "swarm bundle register")
 	return cmd
@@ -243,7 +244,7 @@ func newBundleDeleteCommand(opts rootCommandOptions) *cobra.Command {
 	deleteOpts := bundleDeleteCommandOptions{apiOptions: opts}
 	cmd := &cobra.Command{
 		Use:   "delete <bundle-hash>",
-		Short: "Delete a persisted bundle through /v1/rpc bundle.delete.",
+		Short: "Delete a registered bundle.",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			deleteOpts.forceSet = cmd.Flags().Changed("force")
@@ -258,6 +259,7 @@ func newBundleDeleteCommand(opts rootCommandOptions) *cobra.Command {
 	cmd.Flags().BoolVar(&deleteOpts.force, "force", false, "Force bundle deletion by quiescing affected active work before deleting")
 	cmd.Flags().BoolVar(&deleteOpts.dryRun, "dry-run", false, "Plan bundle deletion without applying destructive changes")
 	cmd.Flags().StringVar(&deleteOpts.idempotencyKey, "idempotency-key", "", "Optional idempotency key for bundle.delete")
+	_ = cmd.Flags().MarkHidden("idempotency-key")
 	bindCLIOutputFlags(cmd, &deleteOpts.output)
 	bindCLIAPIConnectionFlagsWithClass(cmd, &deleteOpts.apiOptions, cliAPICommandClassMutating, "swarm bundle delete")
 	return cmd

--- a/cmd/swarm/bundle_test.go
+++ b/cmd/swarm/bundle_test.go
@@ -350,7 +350,6 @@ func TestBundleDeleteHelpDocumentsCanonicalFlags(t *testing.T) {
 		"delete <bundle-hash>",
 		"--force",
 		"--dry-run",
-		"--idempotency-key",
 		"--api-server",
 		"--json",
 	} {
@@ -358,7 +357,7 @@ func TestBundleDeleteHelpDocumentsCanonicalFlags(t *testing.T) {
 			t.Fatalf("help missing %q:\n%s", want, stdout.String())
 		}
 	}
-	for _, notWant := range []string{"archive", "contracts"} {
+	for _, notWant := range []string{"archive", "contracts", "--idempotency-key string"} {
 		if strings.Contains(stdout.String(), notWant) {
 			t.Fatalf("help contains out-of-scope term %q:\n%s", notWant, stdout.String())
 		}
@@ -378,7 +377,6 @@ func TestBundleRegisterHelpDocumentsPreparedEnvelopeAndContractsBoundary(t *test
 		"register <registration-envelope-yaml>",
 		"--contracts",
 		"--data-blob",
-		"--idempotency-key",
 		"--api-server",
 		"--json",
 	} {
@@ -386,7 +384,7 @@ func TestBundleRegisterHelpDocumentsPreparedEnvelopeAndContractsBoundary(t *test
 			t.Fatalf("help missing %q:\n%s", want, stdout.String())
 		}
 	}
-	for _, notWant := range []string{"archive"} {
+	for _, notWant := range []string{"archive", "--idempotency-key string"} {
 		if strings.Contains(stdout.String(), notWant) {
 			t.Fatalf("help contains unapproved packaging term %q:\n%s", notWant, stdout.String())
 		}

--- a/cmd/swarm/cli.go
+++ b/cmd/swarm/cli.go
@@ -62,8 +62,19 @@ func newRootCommandWithOptions(ctx context.Context, repo string, out, errOut io.
 	opts = opts.ensureRootFlagState()
 	opts.repoRoot = assetCommandRepoRoot(repo)
 	cmd := &cobra.Command{
-		Use:           "swarm",
-		Short:         "Run and inspect Swarm workflows.",
+		Use:   "swarm",
+		Short: "Run and inspect Swarm workflows.",
+		Long: `Swarm runs event-driven agent workflows defined by declarative contracts.
+
+The typical path: check your setup with 'swarm doctor', validate contracts
+with 'swarm verify', start the local runtime with 'swarm serve --dev', then
+start work with 'swarm run' or 'swarm event publish' and watch it with
+'swarm trace', 'swarm events', and 'swarm mailbox'.`,
+		Example: `  swarm doctor                                      # check local prerequisites
+  swarm verify --contracts ./contracts              # validate contracts before boot
+  swarm serve --dev                                 # start a local development runtime
+  swarm run --event <event-name> --payload payload.json
+  swarm trace <run-id>                              # see what a run did`,
 		SilenceUsage:  true,
 		SilenceErrors: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -76,40 +87,72 @@ func newRootCommandWithOptions(ctx context.Context, repo string, out, errOut io.
 	cmd.SetOut(out)
 	cmd.SetErr(errOut)
 	cmd.PersistentFlags().Var(&trackedRootStringFlag{value: &opts.rootFlags.swarmDir, changed: &opts.rootFlags.swarmDirSet}, "swarm-dir", "Path to the Swarm user/global state directory")
-	cmd.AddCommand(
-		newServeCommand(ctx, repo, opts.runServe),
-		newRunCommand(repo, opts),
+	cmd.AddGroup(
+		&cobra.Group{ID: commandGroupStart, Title: "Getting started:"},
+		&cobra.Group{ID: commandGroupAuthor, Title: "Author & validate:"},
+		&cobra.Group{ID: commandGroupOperate, Title: "Run & operate:"},
+		&cobra.Group{ID: commandGroupObserve, Title: "Observe & debug:"},
+		&cobra.Group{ID: commandGroupUtility, Title: "Utilities:"},
+	)
+	addToGroup := func(groupID string, subs ...*cobra.Command) {
+		for _, sub := range subs {
+			sub.GroupID = groupID
+			cmd.AddCommand(sub)
+		}
+	}
+	addToGroup(commandGroupStart,
 		newDoctorCommand(ctx, repo),
+		newWorkspaceCommand(ctx),
+		newContextCommand(ctx, opts),
+		newServeCommand(ctx, repo, opts.runServe),
+		newVersionCommand(opts),
+	)
+	addToGroup(commandGroupAuthor,
 		newVerifyCommand(ctx, repo),
 		newDescribeCommand(ctx, repo),
+		newBundleCommand(repo, opts),
 		newSecretsCommand(ctx, repo),
-		newContextCommand(ctx, opts),
-		newWorkspaceCommand(ctx),
-		newVersionCommand(opts),
-		newCompletionCommand(),
+	)
+	addToGroup(commandGroupOperate,
+		newRunCommand(repo, opts),
+		newControlCommand(opts),
+		newEventCommand(opts),
+		newMailboxCommand(opts),
+		newAgentCommand(opts),
+		newForkCommand(opts),
+		newForkChatCommand(opts),
+	)
+	addToGroup(commandGroupObserve,
 		newRunsCommand(opts),
 		newStatusCommand(opts),
 		newTraceCommand(opts),
-		newHealthCommand(opts),
-		newLogsCommand(opts),
-		newIncidentsCommand(opts),
-		newInvestigateCommand(opts),
 		newEventsCommand(opts),
-		newEventCommand(opts),
+		newEntitiesCommand(opts),
+		newEntityCommand(opts),
 		newConversationsCommand(opts),
 		newConversationCommand(opts),
 		newAgentsCommand(opts),
-		newAgentCommand(opts),
-		newForkChatCommand(opts),
-		newBundleCommand(repo, opts),
-		newEntitiesCommand(opts),
-		newEntityCommand(opts),
-		newMailboxCommand(opts),
-		newControlCommand(opts),
-		newForkCommand(opts),
+		newLogsCommand(opts),
+		newHealthCommand(opts),
+		newIncidentsCommand(opts),
 	)
+	addToGroup(commandGroupUtility,
+		newCompletionCommand(),
+	)
+	// Retired hidden stub; intentionally ungrouped so it never renders in help.
+	cmd.AddCommand(newInvestigateCommand(opts))
+	cmd.SetHelpCommandGroupID(commandGroupUtility)
 	return cmd
 }
+
+// Help groups, ordered as the newcomer journey: set up, author, run, observe.
+const (
+	commandGroupStart   = "getting-started"
+	commandGroupAuthor  = "author"
+	commandGroupOperate = "operate"
+	commandGroupObserve = "observe"
+	commandGroupUtility = "utilities"
+)
 
 type trackedRootStringFlag struct {
 	value   *string
@@ -144,8 +187,10 @@ func newServeCommand(ctx context.Context, repo string, runServe func(context.Con
 	}
 	cmd := &cobra.Command{
 		Use:   "serve",
-		Short: "Start the Swarm runtime, API, health, and MCP surfaces.",
-		Args:  cobra.NoArgs,
+		Short: "Start the Swarm runtime (server): engine, API, health, and MCP.",
+		Example: `  swarm serve --dev                      # local development runtime
+  swarm serve --contracts ./contracts    # serve a specific contract bundle`,
+		Args: cobra.NoArgs,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			if cmd.Flags().Changed("require-bundle-match") && cmd.Flags().Changed("no-require-bundle-match") && opts.RequireBundleMatch && opts.NoRequireBundleMatch {
 				return fmt.Errorf("--require-bundle-match and --no-require-bundle-match cannot both be set")
@@ -250,8 +295,9 @@ func newServeCommand(ctx context.Context, repo string, runServe func(context.Con
 func newVerifyCommand(ctx context.Context, repo string) *cobra.Command {
 	opts := defaultVerifyCommandOptions()
 	cmd := &cobra.Command{
-		Use:   "verify",
-		Short: "Validate local Swarm contract files.",
+		Use:     "verify",
+		Short:   "Validate contract files before boot.",
+		Example: `  swarm verify --contracts ./contracts`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := opts.logging.validate(); err != nil {
 				return returnCLIValidationError(cmd.ErrOrStderr(), err)
@@ -314,7 +360,7 @@ func newVersionCommand(opts rootCommandOptions) *cobra.Command {
 			return runVersionCommand(cmd.Context(), cmd.OutOrStdout(), cmd.ErrOrStderr(), versionOpts)
 		},
 	}
-	cmd.Flags().BoolVar(&versionOpts.server, "server", false, "Also query /v1/rpc health.check and print server bundle/runtime identity")
+	cmd.Flags().BoolVar(&versionOpts.server, "server", false, "Also query the connected server and print its bundle/runtime identity")
 	bindCLIOutputFlags(cmd, &versionOpts.output)
 	bindCLILoggingFlags(cmd, &versionOpts.logging)
 	bindCLIAPIConnectionFlags(cmd, &versionOpts.apiOptions)

--- a/cmd/swarm/context_command.go
+++ b/cmd/swarm/context_command.go
@@ -17,7 +17,7 @@ type contextCommandOptions struct {
 func newContextCommand(ctx context.Context, opts rootCommandOptions) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "context",
-		Short: "Inspect local Swarm runtime context descriptors.",
+		Short: "Show which runtime and directories this CLI targets.",
 	}
 	cmd.AddCommand(
 		newContextCurrentCommand(ctx, opts),

--- a/cmd/swarm/control_mailbox.go
+++ b/cmd/swarm/control_mailbox.go
@@ -105,7 +105,7 @@ type mailboxDecisionCommandOptions struct {
 func newControlCommand(opts rootCommandOptions) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "control",
-		Short: "Run supported v1 operator control actions.",
+		Short: "Pause, continue, stop, or reset runs (operator actions).",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return cmd.Help()
@@ -124,8 +124,10 @@ func newControlCommand(opts rootCommandOptions) *cobra.Command {
 func newMailboxCommand(opts rootCommandOptions) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "mailbox",
-		Short: "List, view, and decide mailbox items through v1 RPC.",
-		Args:  cobra.NoArgs,
+		Short: "List, view, and decide pending human decisions.",
+		Example: `  swarm mailbox list
+  swarm mailbox approve <mailbox-item-id>`,
+		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return cmd.Help()
 		},
@@ -171,7 +173,7 @@ func newMailboxListCommand(opts rootCommandOptions) *cobra.Command {
 	}
 	cmd := &cobra.Command{
 		Use:   "list",
-		Short: "List mailbox items through v1 RPC.",
+		Short: "List mailbox items.",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			listOpts.limitSet = cmd.Flags().Changed("limit")
@@ -194,7 +196,7 @@ func newMailboxViewCommand(opts rootCommandOptions) *cobra.Command {
 	apiOpts := opts
 	cmd := &cobra.Command{
 		Use:   "view <mailbox-item-id>",
-		Short: "View one mailbox item through v1 RPC.",
+		Short: "View one mailbox item.",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runMailboxViewCommand(cmd.Context(), cmd.OutOrStdout(), cmd.ErrOrStderr(), apiOpts, args[0])
@@ -212,7 +214,7 @@ func newMailboxApproveCommand(opts rootCommandOptions) *cobra.Command {
 	}
 	cmd := &cobra.Command{
 		Use:   "approve <mailbox-item-id>",
-		Short: "Approve a pending mailbox item through v1 RPC.",
+		Short: "Approve a pending mailbox item.",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			runOpts := actionOpts
@@ -221,7 +223,8 @@ func newMailboxApproveCommand(opts rootCommandOptions) *cobra.Command {
 			return runMailboxDecisionCommand(cmd.Context(), cmd.OutOrStdout(), cmd.ErrOrStderr(), runOpts, args[0])
 		},
 	}
-	cmd.Flags().StringVar(&actionOpts.idempotencyKey, "idempotency-key", "", "Optional v1 API idempotency key")
+	cmd.Flags().StringVar(&actionOpts.idempotencyKey, "idempotency-key", "", "Optional idempotency key for safe retries (advanced)")
+	_ = cmd.Flags().MarkHidden("idempotency-key")
 	cmd.Flags().StringVar(&actionOpts.decisionPayloadFile, "decision-payload", "", "Read optional approval event JSON object from file")
 	cmd.Flags().StringVar(&actionOpts.decisionPayloadJSON, "decision-payload-json", "", "Optional JSON object attached to the approval event")
 	bindCLIAPIConnectionFlagsWithClass(cmd, &actionOpts.apiOptions, cliAPICommandClassMutating, "swarm mailbox approve")
@@ -236,14 +239,15 @@ func newMailboxRejectCommand(opts rootCommandOptions) *cobra.Command {
 	}
 	cmd := &cobra.Command{
 		Use:   "reject <mailbox-item-id>",
-		Short: "Reject a pending mailbox item through v1 RPC.",
+		Short: "Reject a pending mailbox item.",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runMailboxDecisionCommand(cmd.Context(), cmd.OutOrStdout(), cmd.ErrOrStderr(), actionOpts, args[0])
 		},
 	}
 	cmd.Flags().StringVar(&actionOpts.reason, "reason", "", "Required rejection reason")
-	cmd.Flags().StringVar(&actionOpts.idempotencyKey, "idempotency-key", "", "Optional v1 API idempotency key")
+	cmd.Flags().StringVar(&actionOpts.idempotencyKey, "idempotency-key", "", "Optional idempotency key for safe retries (advanced)")
+	_ = cmd.Flags().MarkHidden("idempotency-key")
 	bindCLIAPIConnectionFlagsWithClass(cmd, &actionOpts.apiOptions, cliAPICommandClassMutating, "swarm mailbox reject")
 	return cmd
 }
@@ -256,14 +260,15 @@ func newMailboxDeferCommand(opts rootCommandOptions) *cobra.Command {
 	}
 	cmd := &cobra.Command{
 		Use:   "defer <mailbox-item-id>",
-		Short: "Defer a pending mailbox item through v1 RPC.",
+		Short: "Defer a pending mailbox item.",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runMailboxDecisionCommand(cmd.Context(), cmd.OutOrStdout(), cmd.ErrOrStderr(), actionOpts, args[0])
 		},
 	}
 	cmd.Flags().StringVar(&actionOpts.until, "until", "", "Required RFC3339 timestamp")
-	cmd.Flags().StringVar(&actionOpts.idempotencyKey, "idempotency-key", "", "Optional v1 API idempotency key")
+	cmd.Flags().StringVar(&actionOpts.idempotencyKey, "idempotency-key", "", "Optional idempotency key for safe retries (advanced)")
+	_ = cmd.Flags().MarkHidden("idempotency-key")
 	bindCLIAPIConnectionFlagsWithClass(cmd, &actionOpts.apiOptions, cliAPICommandClassMutating, "swarm mailbox defer")
 	return cmd
 }

--- a/cmd/swarm/control_nuke.go
+++ b/cmd/swarm/control_nuke.go
@@ -121,7 +121,7 @@ func newControlNukeCommand(opts rootCommandOptions) *cobra.Command {
 	nukeOpts := runtimeNukeCommandOptions{apiOptions: opts}
 	cmd := &cobra.Command{
 		Use:   "nuke",
-		Short: "Destructively reset Swarm runtime state through v1 RPC.",
+		Short: "Destructively reset all Swarm runtime state.",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts := nukeOpts
@@ -131,7 +131,8 @@ func newControlNukeCommand(opts rootCommandOptions) *cobra.Command {
 	}
 	cmd.Flags().BoolVarP(&nukeOpts.yes, "yes", "y", false, "Skip the destructive confirmation prompt")
 	cmd.Flags().BoolVar(&nukeOpts.dryRun, "dry-run", false, "Preview the destructive reset without applying it")
-	cmd.Flags().StringVar(&nukeOpts.idempotencyKey, "idempotency-key", "", "Optional v1 API idempotency key")
+	cmd.Flags().StringVar(&nukeOpts.idempotencyKey, "idempotency-key", "", "Optional idempotency key for safe retries (advanced)")
+	_ = cmd.Flags().MarkHidden("idempotency-key")
 	bindCLIAPIConnectionFlagsWithClass(cmd, &nukeOpts.apiOptions, cliAPICommandClassControl, "swarm control nuke")
 	return cmd
 }

--- a/cmd/swarm/control_run.go
+++ b/cmd/swarm/control_run.go
@@ -78,7 +78,7 @@ func newControlRunCommand(opts controlRunCommandOptions) *cobra.Command {
 	cmdOpts := opts
 	cmd := &cobra.Command{
 		Use:   opts.action + " [<run-id>] [--all]",
-		Short: fmt.Sprintf("%s a run or the supported all-runs scope through v1 RPC.", controlCommandTitle(opts.action)),
+		Short: fmt.Sprintf("%s a run, or all runs with --all.", controlCommandTitle(opts.action)),
 		Args:  cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			runOpts := cmdOpts
@@ -90,7 +90,8 @@ func newControlRunCommand(opts controlRunCommandOptions) *cobra.Command {
 	if opts.action == "stop" {
 		cmd.Flags().BoolVar(&cmdOpts.yes, "yes", false, "Skip the stop-all confirmation prompt")
 	}
-	cmd.Flags().StringVar(&cmdOpts.idempotencyKey, "idempotency-key", "", "Optional v1 API idempotency key")
+	cmd.Flags().StringVar(&cmdOpts.idempotencyKey, "idempotency-key", "", "Optional idempotency key for safe retries (advanced)")
+	_ = cmd.Flags().MarkHidden("idempotency-key")
 	bindCLIAPIConnectionFlagsWithClass(cmd, &cmdOpts.apiOptions, cliAPICommandClassControl, "swarm control "+opts.action)
 	return cmd
 }

--- a/cmd/swarm/conversations.go
+++ b/cmd/swarm/conversations.go
@@ -135,7 +135,7 @@ var conversationOpaqueIDPattern = regexp.MustCompile(`^[A-Za-z0-9_:.-]+$`)
 func newConversationsCommand(opts rootCommandOptions) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "conversations",
-		Short: "List conversations through v1 RPC.",
+		Short: "List agent conversations.",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return cmd.Help()
@@ -148,7 +148,7 @@ func newConversationsCommand(opts rootCommandOptions) *cobra.Command {
 func newConversationCommand(opts rootCommandOptions) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "conversation",
-		Short: "View conversation details and turns through v1 RPC.",
+		Short: "View one conversation and its turns.",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return cmd.Help()
@@ -165,7 +165,7 @@ func newConversationsListCommand(opts rootCommandOptions) *cobra.Command {
 	listOpts := conversationListCommandOptions{apiOptions: opts}
 	cmd := &cobra.Command{
 		Use:   "list",
-		Short: "List conversations through /v1/rpc conversation.list.",
+		Short: "List conversations.",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			listOpts.agentIDSet = cmd.Flags().Changed("agent-id")
@@ -195,7 +195,7 @@ func newConversationViewCommand(opts rootCommandOptions) *cobra.Command {
 	viewOpts := conversationViewCommandOptions{apiOptions: opts}
 	cmd := &cobra.Command{
 		Use:   "view <session-id>",
-		Short: "View one conversation through /v1/rpc conversation.get.",
+		Short: "View one conversation.",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := viewOpts.logging.validate(); err != nil {
@@ -217,7 +217,7 @@ func newConversationTurnCommand(opts rootCommandOptions) *cobra.Command {
 	turnOpts := conversationTurnCommandOptions{apiOptions: opts}
 	cmd := &cobra.Command{
 		Use:   "turn <session-id> <turn-index>",
-		Short: "View one conversation turn through /v1/rpc conversation.get_turn.",
+		Short: "View one conversation turn.",
 		Args:  cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := turnOpts.logging.validate(); err != nil {

--- a/cmd/swarm/diagnostics.go
+++ b/cmd/swarm/diagnostics.go
@@ -206,7 +206,7 @@ func newRunsCommand(opts rootCommandOptions) *cobra.Command {
 	runOpts := diagnosticRunListOptions{apiOptions: opts}
 	cmd := &cobra.Command{
 		Use:   "runs",
-		Short: "List runs through the v1 RPC read owner.",
+		Short: "List runs.",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if cmd.Flags().Changed("limit") && runOpts.limit == 0 {
@@ -234,7 +234,7 @@ func newHealthCommand(opts rootCommandOptions) *cobra.Command {
 	loggingOpts := cliLoggingOptions{}
 	cmd := &cobra.Command{
 		Use:   "health",
-		Short: "Print structured operator health through v1 RPC.",
+		Short: "Show runtime health.",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := loggingOpts.validate(); err != nil {
@@ -256,7 +256,7 @@ func newStatusCommand(opts rootCommandOptions) *cobra.Command {
 	runOpts := diagnosticRunOptions{apiOptions: opts}
 	cmd := &cobra.Command{
 		Use:   "status [run-id]",
-		Short: "Diagnose one run through the v1 RPC read owner.",
+		Short: "Diagnose one run (state, gates, stuck points).",
 		Args:  cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			runID := ""
@@ -283,8 +283,10 @@ func newTraceCommand(opts rootCommandOptions) *cobra.Command {
 	traceOpts := diagnosticTraceOptions{apiOptions: opts}
 	cmd := &cobra.Command{
 		Use:   "trace [run-id]",
-		Short: "Print or follow a run trace through v1 API owners.",
-		Args:  cobra.MaximumNArgs(1),
+		Short: "Print or follow a run's execution trace.",
+		Example: `  swarm trace <run-id>
+  swarm trace -f <run-id>    # follow live`,
+		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			traceOpts.sinceSet = cmd.Flags().Changed("since")
 			traceOpts.untilSet = cmd.Flags().Changed("until")
@@ -297,7 +299,7 @@ func newTraceCommand(opts rootCommandOptions) *cobra.Command {
 			return runDiagnosticTraceCommand(cmd.Context(), cmd.OutOrStdout(), cmd.ErrOrStderr(), traceOpts, runID)
 		},
 	}
-	cmd.Flags().BoolVarP(&traceOpts.follow, "follow", "f", false, "Follow live trace rows through /v1/ws run.subscribe_trace")
+	cmd.Flags().BoolVarP(&traceOpts.follow, "follow", "f", false, "Follow live trace rows as they stream")
 	cmd.Flags().BoolVar(&traceOpts.noRetry, "no-retry", false, "Disable trace follow reconnect/recovery retries")
 	cmd.Flags().BoolVar(&traceOpts.deliveryDetail, "delivery-detail", false, "Show snapshot delivery lifecycle fields from RunTraceRow")
 	cmd.Flags().BoolVar(&traceOpts.deliverySummary, "delivery-summary", false, "Summarize snapshot delivery lifecycle fields from all RunTraceRow pages")

--- a/cmd/swarm/doctor.go
+++ b/cmd/swarm/doctor.go
@@ -31,8 +31,10 @@ func newDoctorCommand(ctx context.Context, repo string) *cobra.Command {
 	}
 	cmd := &cobra.Command{
 		Use:   "doctor",
-		Short: "Diagnose local Swarm runtime prerequisites.",
-		Args:  cobra.NoArgs,
+		Short: "Check local prerequisites and diagnose setup problems.",
+		Example: `  swarm doctor
+  swarm doctor --target    # show which runtime this CLI targets`,
+		Args: cobra.NoArgs,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			if cliAPIConnectionFlagsChanged(cmd) && !opts.target {
 				return fmt.Errorf("--api-server and --api-token-file require --target")

--- a/cmd/swarm/entities.go
+++ b/cmd/swarm/entities.go
@@ -103,7 +103,7 @@ var (
 func newEntitiesCommand(opts rootCommandOptions) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "entities",
-		Short: "List entities through v1 RPC.",
+		Short: "List workflow entities.",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return cmd.Help()
@@ -116,7 +116,7 @@ func newEntitiesCommand(opts rootCommandOptions) *cobra.Command {
 func newEntityCommand(opts rootCommandOptions) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "entity",
-		Short: "View or aggregate entities through v1 RPC.",
+		Short: "View or aggregate one entity's state.",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return cmd.Help()
@@ -133,7 +133,7 @@ func newEntitiesListCommand(opts rootCommandOptions) *cobra.Command {
 	listOpts := entityListCommandOptions{apiOptions: opts}
 	cmd := &cobra.Command{
 		Use:   "list",
-		Short: "List entities through /v1/rpc entity.list.",
+		Short: "List entities with filters.",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			listOpts.runIDSet = cmd.Flags().Changed("run-id")
@@ -159,7 +159,7 @@ func newEntityViewCommand(opts rootCommandOptions) *cobra.Command {
 	viewOpts := entityViewCommandOptions{apiOptions: opts}
 	cmd := &cobra.Command{
 		Use:   "view <entity-id>",
-		Short: "View one entity through /v1/rpc entity.get.",
+		Short: "View one entity's state.",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			viewOpts.runIDSet = cmd.Flags().Changed("run-id")
@@ -175,7 +175,7 @@ func newEntityAggregateCommand(opts rootCommandOptions) *cobra.Command {
 	aggregateOpts := entityAggregateCommandOptions{apiOptions: opts}
 	cmd := &cobra.Command{
 		Use:   "aggregate",
-		Short: "Aggregate entity counts through /v1/rpc entity.aggregate.",
+		Short: "Aggregate entity counts by field.",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			aggregateOpts.runIDSet = cmd.Flags().Changed("run-id")

--- a/cmd/swarm/event_publish.go
+++ b/cmd/swarm/event_publish.go
@@ -70,9 +70,10 @@ type eventPublishDelivery struct {
 func newEventPublishCommand(opts rootCommandOptions) *cobra.Command {
 	publishOpts := eventPublishCommandOptions{apiOptions: opts}
 	cmd := &cobra.Command{
-		Use:   "publish <event-name>",
-		Short: "Publish one event through /v1/rpc event.publish.",
-		Args:  cobra.ExactArgs(1),
+		Use:     "publish <event-name>",
+		Short:   "Publish an event onto the bus.",
+		Example: `  swarm event publish account.scan_requested --payload payload.json`,
+		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			publishOpts.payloadJSONSet = cmd.Flags().Changed("payload-json")
 			publishOpts.runIDSet = cmd.Flags().Changed("run-id")
@@ -94,7 +95,8 @@ func newEventPublishCommand(opts rootCommandOptions) *cobra.Command {
 	cmd.Flags().StringVar(&publishOpts.bundleHash, "bundle-hash", "", "Optional expected server canonical bundle hash")
 	cmd.Flags().StringVar(&publishOpts.bundleFingerprint, "bundle-fingerprint", "", "Optional expected server bundle fingerprint")
 	cmd.Flags().StringVar(&publishOpts.emitter, "emitter", "", "Optional producer identifier")
-	cmd.Flags().StringVar(&publishOpts.idempotencyKey, "idempotency-key", "", "Optional v1 API idempotency key")
+	cmd.Flags().StringVar(&publishOpts.idempotencyKey, "idempotency-key", "", "Optional idempotency key for safe retries (advanced)")
+	_ = cmd.Flags().MarkHidden("idempotency-key")
 	bindCLIAPIConnectionFlagsWithClass(cmd, &publishOpts.apiOptions, cliAPICommandClassMutating, "swarm event publish")
 	return cmd
 }

--- a/cmd/swarm/event_publish.go
+++ b/cmd/swarm/event_publish.go
@@ -72,7 +72,7 @@ func newEventPublishCommand(opts rootCommandOptions) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "publish <event-name>",
 		Short:   "Publish an event onto the bus.",
-		Example: `  swarm event publish account.scan_requested --payload payload.json`,
+		Example: `  swarm event publish account.scan_requested --payload-json '{"handle": "@acme"}'`,
 		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			publishOpts.payloadJSONSet = cmd.Flags().Changed("payload-json")

--- a/cmd/swarm/events.go
+++ b/cmd/swarm/events.go
@@ -176,7 +176,7 @@ var eventObservationValidDeadLetterFailureTypes = map[string]struct{}{
 func newEventsCommand(opts rootCommandOptions) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "events",
-		Short: "List or follow events through v1 API owners.",
+		Short: "List or follow the event stream.",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return cmd.Help()
@@ -192,7 +192,7 @@ func newEventsCommand(opts rootCommandOptions) *cobra.Command {
 func newEventCommand(opts rootCommandOptions) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "event",
-		Short: "View or replay one event through v1 API owners.",
+		Short: "Publish, view, or replay a single event.",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return cmd.Help()
@@ -210,7 +210,7 @@ func newEventsListCommand(opts rootCommandOptions) *cobra.Command {
 	listOpts := eventListCommandOptions{apiOptions: opts}
 	cmd := &cobra.Command{
 		Use:   "list",
-		Short: "List events through /v1/rpc event.list.",
+		Short: "List events with filters.",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			listOpts.filter.hasDeadLetterSet = cmd.Flags().Changed("has-dead-letter")
@@ -231,7 +231,7 @@ func newEventsFollowCommand(opts rootCommandOptions) *cobra.Command {
 	followOpts := eventFollowCommandOptions{apiOptions: opts}
 	cmd := &cobra.Command{
 		Use:   "follow",
-		Short: "Follow events through /v1/ws event.subscribe.",
+		Short: "Follow the live event stream.",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			followOpts.filter.hasDeadLetterSet = cmd.Flags().Changed("has-dead-letter")
@@ -248,7 +248,7 @@ func newEventViewCommand(opts rootCommandOptions) *cobra.Command {
 	apiOpts := opts
 	cmd := &cobra.Command{
 		Use:   "view <event-id>",
-		Short: "View one event through /v1/rpc event.get.",
+		Short: "View one event.",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runEventViewCommand(cmd.Context(), cmd.OutOrStdout(), cmd.ErrOrStderr(), apiOpts, args[0])
@@ -262,14 +262,15 @@ func newEventReplayCommand(opts rootCommandOptions) *cobra.Command {
 	replayOpts := eventReplayCommandOptions{apiOptions: opts}
 	cmd := &cobra.Command{
 		Use:   "replay <event-id>",
-		Short: "Replay one event through /v1/rpc event.replay.",
+		Short: "Replay one event.",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runEventReplayCommand(cmd.Context(), cmd.OutOrStdout(), cmd.ErrOrStderr(), args, replayOpts)
 		},
 	}
 	cmd.Flags().StringArrayVar(&replayOpts.subscribers, "subscriber", nil, "Original agent subscriber to replay to; repeat to select a subset")
-	cmd.Flags().StringVar(&replayOpts.idempotencyKey, "idempotency-key", "", "Optional v1 API idempotency key")
+	cmd.Flags().StringVar(&replayOpts.idempotencyKey, "idempotency-key", "", "Optional idempotency key for safe retries (advanced)")
+	_ = cmd.Flags().MarkHidden("idempotency-key")
 	bindCLIAPIConnectionFlagsWithClass(cmd, &replayOpts.apiOptions, cliAPICommandClassMutating, "swarm event replay")
 	return cmd
 }

--- a/cmd/swarm/fork.go
+++ b/cmd/swarm/fork.go
@@ -41,10 +41,11 @@ type runForkResult struct {
 func newForkCommand(opts rootCommandOptions) *cobra.Command {
 	forkOpts := forkCommandOptions{apiOptions: opts}
 	cmd := &cobra.Command{
-		Use:   "fork <source-run-id>",
-		Short: "Fork one run through /v1/rpc run.fork.",
-		Long:  runForkCommandShape + "\n\nFork one run through /v1/rpc run.fork.",
-		Args:  cobra.ExactArgs(1),
+		Use:     "fork <source-run-id>",
+		Short:   "Branch a run to replay it with changed contracts or policy.",
+		Example: `  swarm fork <source-run-id> --at-event <event-id>`,
+		Long:    runForkCommandShape + "\n\nBranch a run to replay it with changed contracts or policy.",
+		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			forkOpts.bundleHashSet = cmd.Flags().Changed("bundle-hash")
 			forkOpts.atEventSet = cmd.Flags().Changed("at-event")
@@ -58,6 +59,7 @@ func newForkCommand(opts rootCommandOptions) *cobra.Command {
 	cmd.Flags().StringVar(&forkOpts.bundleHash, "bundle-hash", "", "Target bundle hash for run.fork selection")
 	cmd.Flags().StringVar(&forkOpts.atEvent, "at-event", "", "Fork at this source event id")
 	cmd.Flags().StringVar(&forkOpts.idempotencyKey, "idempotency-key", "", "Optional idempotency key for retry-safe fork creation")
+	_ = cmd.Flags().MarkHidden("idempotency-key")
 	bindCLIOutputFlags(cmd, &forkOpts.output)
 	bindCLIAPIConnectionFlagsWithClass(cmd, &forkOpts.apiOptions, cliAPICommandClassMutating, "swarm fork")
 	return cmd

--- a/cmd/swarm/forkchat.go
+++ b/cmd/swarm/forkchat.go
@@ -177,7 +177,7 @@ type forkChatSandboxPolicy struct {
 func newForkChatCommand(opts rootCommandOptions) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "forkchat",
-		Short: "Create and inspect sandboxed forkchat sessions through v1 RPC.",
+		Short: "Open sandboxed chat sessions against forked runs.",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return cmd.Help()
@@ -197,7 +197,7 @@ func newForkChatNewCommand(opts rootCommandOptions) *cobra.Command {
 	newOpts := forkChatNewCommandOptions{apiOptions: opts}
 	cmd := &cobra.Command{
 		Use:   "new <source-session-id>",
-		Short: "Create a forkchat session through /v1/rpc conversation.fork.",
+		Short: "Create a sandboxed forkchat session.",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			newOpts.turnIndexSet = cmd.Flags().Changed("turn-index")
@@ -218,7 +218,8 @@ func newForkChatNewCommand(opts rootCommandOptions) *cobra.Command {
 	cmd.Flags().StringVar(&newOpts.eventID, "event-id", "", "Fork at the source turn triggered by this event id")
 	cmd.Flags().StringVar(&newOpts.at, "at", "", "Fork at the latest source turn at or before this RFC3339 timestamp")
 	cmd.Flags().StringVarP(&newOpts.message, "message", "m", "", "Optional first sandboxed message after fork creation")
-	cmd.Flags().StringVar(&newOpts.idempotencyKey, "idempotency-key", "", "Optional v1 API idempotency key")
+	cmd.Flags().StringVar(&newOpts.idempotencyKey, "idempotency-key", "", "Optional idempotency key for safe retries (advanced)")
+	_ = cmd.Flags().MarkHidden("idempotency-key")
 	bindCLIOutputFlags(cmd, &newOpts.output)
 	bindCLILoggingFlags(cmd, &newOpts.logging)
 	bindCLIAPIConnectionFlagsWithClass(cmd, &newOpts.apiOptions, cliAPICommandClassMutating, "swarm forkchat new")
@@ -229,7 +230,7 @@ func newForkChatResumeCommand(opts rootCommandOptions) *cobra.Command {
 	resumeOpts := forkChatResumeCommandOptions{apiOptions: opts}
 	cmd := &cobra.Command{
 		Use:   "resume <fork-id>",
-		Short: "Send a sandboxed message through /v1/rpc conversation.fork_chat.",
+		Short: "Send a message in a forkchat session.",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			resumeOpts.messageSet = cmd.Flags().Changed("message")
@@ -244,7 +245,8 @@ func newForkChatResumeCommand(opts rootCommandOptions) *cobra.Command {
 		},
 	}
 	cmd.Flags().StringVarP(&resumeOpts.message, "message", "m", "", "Required sandboxed message to send")
-	cmd.Flags().StringVar(&resumeOpts.idempotencyKey, "idempotency-key", "", "Optional v1 API idempotency key")
+	cmd.Flags().StringVar(&resumeOpts.idempotencyKey, "idempotency-key", "", "Optional idempotency key for safe retries (advanced)")
+	_ = cmd.Flags().MarkHidden("idempotency-key")
 	bindCLIOutputFlags(cmd, &resumeOpts.output)
 	bindCLILoggingFlags(cmd, &resumeOpts.logging)
 	bindCLIAPIConnectionFlagsWithClass(cmd, &resumeOpts.apiOptions, cliAPICommandClassMutating, "swarm forkchat resume")
@@ -255,7 +257,7 @@ func newForkChatListCommand(opts rootCommandOptions) *cobra.Command {
 	listOpts := forkChatListCommandOptions{apiOptions: opts}
 	cmd := &cobra.Command{
 		Use:   "list",
-		Short: "List forkchat sessions through /v1/rpc conversation.fork_list.",
+		Short: "List forkchat sessions.",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			listOpts.sourceSessionIDSet = cmd.Flags().Changed("source-session-id")
@@ -283,7 +285,7 @@ func newForkChatViewCommand(opts rootCommandOptions) *cobra.Command {
 	viewOpts := forkChatViewCommandOptions{apiOptions: opts}
 	cmd := &cobra.Command{
 		Use:   "view <fork-id>",
-		Short: "View one forkchat session through /v1/rpc conversation.fork_view.",
+		Short: "View one forkchat session.",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := viewOpts.logging.validate(); err != nil {
@@ -305,7 +307,7 @@ func newForkChatDeleteCommand(opts rootCommandOptions) *cobra.Command {
 	deleteOpts := forkChatDeleteCommandOptions{apiOptions: opts}
 	cmd := &cobra.Command{
 		Use:   "delete <fork-id>",
-		Short: "Delete one forkchat session through /v1/rpc conversation.fork_delete.",
+		Short: "Delete one forkchat session.",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			deleteOpts.idempotencyKeySet = cmd.Flags().Changed("idempotency-key")
@@ -318,7 +320,8 @@ func newForkChatDeleteCommand(opts rootCommandOptions) *cobra.Command {
 			return runForkChatDeleteCommand(cmd.Context(), cmd.OutOrStdout(), cmd.ErrOrStderr(), deleteOpts, args[0])
 		},
 	}
-	cmd.Flags().StringVar(&deleteOpts.idempotencyKey, "idempotency-key", "", "Optional v1 API idempotency key")
+	cmd.Flags().StringVar(&deleteOpts.idempotencyKey, "idempotency-key", "", "Optional idempotency key for safe retries (advanced)")
+	_ = cmd.Flags().MarkHidden("idempotency-key")
 	bindCLIOutputFlags(cmd, &deleteOpts.output)
 	bindCLILoggingFlags(cmd, &deleteOpts.logging)
 	bindCLIAPIConnectionFlagsWithClass(cmd, &deleteOpts.apiOptions, cliAPICommandClassMutating, "swarm forkchat delete")

--- a/cmd/swarm/help_content_test.go
+++ b/cmd/swarm/help_content_test.go
@@ -146,3 +146,73 @@ func TestRootHelpHidesIdempotencyAndRetiredCommands(t *testing.T) {
 		}
 	}
 }
+
+// Example blocks are runnable invocations, not prose: every line must start
+// with "swarm", resolve to a real command path, and reference only flags that
+// command defines. Trailing "# comment" annotations are allowed.
+func TestExamplesReferenceRealCommandsAndFlags(t *testing.T) {
+	var out, errOut bytes.Buffer
+	root := newRootCommand(context.Background(), t.TempDir(), &out, &errOut)
+	walkCommands(root, func(cmd *cobra.Command) {
+		if strings.TrimSpace(cmd.Example) == "" {
+			return
+		}
+		for _, rawLine := range strings.Split(cmd.Example, "\n") {
+			line := rawLine
+			if idx := strings.Index(line, "  #"); idx >= 0 {
+				line = line[:idx]
+			}
+			fields := strings.Fields(line)
+			if len(fields) == 0 {
+				continue
+			}
+			if fields[0] != "swarm" {
+				t.Errorf("%s: example line does not start with \"swarm\": %q", cmd.CommandPath(), rawLine)
+				continue
+			}
+			target := root
+			args := fields[1:]
+			for len(args) > 0 && !strings.HasPrefix(args[0], "-") {
+				next := findSubcommand(target, args[0])
+				if next == nil {
+					break // positional argument, not a subcommand
+				}
+				target = next
+				args = args[1:]
+			}
+			if target == root && len(fields) > 1 {
+				t.Errorf("%s: example references unknown command %q: %q", cmd.CommandPath(), fields[1], rawLine)
+				continue
+			}
+			flags := target.LocalFlags()
+			inherited := target.InheritedFlags()
+			for _, tok := range args {
+				switch {
+				case strings.Contains(tok, "<"):
+					// placeholder value
+				case strings.HasPrefix(tok, "--"):
+					name := strings.TrimPrefix(tok, "--")
+					if idx := strings.Index(name, "="); idx >= 0 {
+						name = name[:idx]
+					}
+					if flags.Lookup(name) == nil && inherited.Lookup(name) == nil {
+						t.Errorf("%s: example references flag --%s that %s does not define: %q", cmd.CommandPath(), name, target.CommandPath(), rawLine)
+					}
+				case strings.HasPrefix(tok, "-") && len(tok) == 2:
+					if flags.ShorthandLookup(tok[1:]) == nil && inherited.ShorthandLookup(tok[1:]) == nil {
+						t.Errorf("%s: example references shorthand %s that %s does not define: %q", cmd.CommandPath(), tok, target.CommandPath(), rawLine)
+					}
+				}
+			}
+		}
+	})
+}
+
+func findSubcommand(cmd *cobra.Command, name string) *cobra.Command {
+	for _, sub := range cmd.Commands() {
+		if sub.Name() == name || sub.HasAlias(name) {
+			return sub
+		}
+	}
+	return nil
+}

--- a/cmd/swarm/help_content_test.go
+++ b/cmd/swarm/help_content_test.go
@@ -1,0 +1,148 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+// transportLeakPattern matches internal transport vocabulary that must never
+// appear in user-facing help content. Help describes operator outcomes; how a
+// command reaches the runtime is an implementation detail (#1649).
+var transportLeakPattern = regexp.MustCompile(`v1 RPC|/v1/|API owners|v1 API`)
+
+func walkCommands(cmd *cobra.Command, visit func(*cobra.Command)) {
+	visit(cmd)
+	for _, sub := range cmd.Commands() {
+		walkCommands(sub, visit)
+	}
+}
+
+func TestHelpContentHasNoTransportLeakage(t *testing.T) {
+	var out, errOut bytes.Buffer
+	root := newRootCommand(context.Background(), t.TempDir(), &out, &errOut)
+	walkCommands(root, func(cmd *cobra.Command) {
+		for field, value := range map[string]string{
+			"Short":   cmd.Short,
+			"Long":    cmd.Long,
+			"Example": cmd.Example,
+		} {
+			if match := transportLeakPattern.FindString(value); match != "" {
+				t.Errorf("%s: %s leaks transport vocabulary %q: %q", cmd.CommandPath(), field, match, value)
+			}
+		}
+		checkFlags := func(fs *pflag.FlagSet) {
+			fs.VisitAll(func(f *pflag.Flag) {
+				if match := transportLeakPattern.FindString(f.Usage); match != "" {
+					t.Errorf("%s: flag --%s usage leaks transport vocabulary %q: %q", cmd.CommandPath(), f.Name, match, f.Usage)
+				}
+			})
+		}
+		checkFlags(cmd.LocalFlags())
+		checkFlags(cmd.PersistentFlags())
+	})
+}
+
+func TestRootHelpGroupsRenderInJourneyOrder(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommand(context.Background(), t.TempDir(), []string{"--help"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("--help code = %d stderr=%s", code, stderr.String())
+	}
+	help := stdout.String()
+	groups := []string{
+		"Getting started:",
+		"Author & validate:",
+		"Run & operate:",
+		"Observe & debug:",
+		"Utilities:",
+	}
+	last := -1
+	for _, title := range groups {
+		idx := strings.Index(help, title)
+		if idx < 0 {
+			t.Fatalf("root help missing group %q:\n%s", title, help)
+		}
+		if idx < last {
+			t.Fatalf("group %q renders out of journey order:\n%s", title, help)
+		}
+		last = idx
+	}
+}
+
+func TestEveryVisibleCommandBelongsToAGroup(t *testing.T) {
+	var out, errOut bytes.Buffer
+	root := newRootCommand(context.Background(), t.TempDir(), &out, &errOut)
+	for _, sub := range root.Commands() {
+		if sub.Hidden {
+			continue
+		}
+		if sub.Name() == "help" {
+			continue // grouped via SetHelpCommandGroupID
+		}
+		if sub.GroupID == "" {
+			t.Errorf("visible command %q has no help group", sub.Name())
+		}
+	}
+}
+
+func TestIdempotencyKeyFlagIsHiddenEverywhere(t *testing.T) {
+	var out, errOut bytes.Buffer
+	root := newRootCommand(context.Background(), t.TempDir(), &out, &errOut)
+	found := 0
+	walkCommands(root, func(cmd *cobra.Command) {
+		flag := cmd.LocalFlags().Lookup("idempotency-key")
+		if flag == nil {
+			return
+		}
+		found++
+		if !flag.Hidden {
+			t.Errorf("%s: --idempotency-key must be hidden from default help", cmd.CommandPath())
+		}
+	})
+	if found == 0 {
+		t.Fatal("no --idempotency-key flags found; test wiring is broken")
+	}
+}
+
+func TestIdempotencyKeyFlagStillParses(t *testing.T) {
+	var out, errOut bytes.Buffer
+	root := newRootCommand(context.Background(), t.TempDir(), &out, &errOut)
+	var target *cobra.Command
+	walkCommands(root, func(cmd *cobra.Command) {
+		if target == nil && cmd.LocalFlags().Lookup("idempotency-key") != nil {
+			target = cmd
+		}
+	})
+	if target == nil {
+		t.Fatal("no command with --idempotency-key found")
+	}
+	if err := target.LocalFlags().Set("idempotency-key", "test-key"); err != nil {
+		t.Fatalf("hidden --idempotency-key no longer parses on %s: %v", target.CommandPath(), err)
+	}
+	value, err := target.LocalFlags().GetString("idempotency-key")
+	if err != nil || value != "test-key" {
+		t.Fatalf("hidden --idempotency-key round-trip failed on %s: value=%q err=%v", target.CommandPath(), value, err)
+	}
+}
+
+func TestRootHelpHidesIdempotencyAndRetiredCommands(t *testing.T) {
+	for _, cmdArgs := range [][]string{{"--help"}, {"fork", "--help"}} {
+		var stdout, stderr bytes.Buffer
+		code := executeRootCommand(context.Background(), t.TempDir(), cmdArgs, &stdout, &stderr)
+		if code != 0 {
+			t.Fatalf("%v code = %d stderr=%s", cmdArgs, code, stderr.String())
+		}
+		// The rendered flag list must not advertise the hidden flag. The Long
+		// command-shape line (e.g. "[--idempotency-key <key>]") mirrors the
+		// promoted command_catalog row and intentionally remains.
+		if strings.Contains(stdout.String(), "--idempotency-key string") {
+			t.Fatalf("%v flag list still advertises --idempotency-key:\n%s", cmdArgs, stdout.String())
+		}
+	}
+}

--- a/cmd/swarm/incidents.go
+++ b/cmd/swarm/incidents.go
@@ -57,7 +57,7 @@ func newIncidentsCommand(opts rootCommandOptions) *cobra.Command {
 	incidentOpts := runtimeIncidentCommandOptions{apiOptions: opts}
 	cmd := &cobra.Command{
 		Use:   "incidents [filters]",
-		Short: "List runtime incidents through /v1/rpc runtime.incidents.",
+		Short: "List runtime incidents.",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			incidentOpts.sinceHoursSet = cmd.Flags().Changed("since-hours")

--- a/cmd/swarm/logs.go
+++ b/cmd/swarm/logs.go
@@ -100,7 +100,7 @@ func newLogsCommand(opts rootCommandOptions) *cobra.Command {
 	logOpts := runtimeLogCommandOptions{apiOptions: opts}
 	cmd := &cobra.Command{
 		Use:   "logs [filters]",
-		Short: "List or follow runtime logs through v1 API owners.",
+		Short: "List or follow runtime logs.",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			logOpts.limitSet = cmd.Flags().Changed("limit")
@@ -118,7 +118,7 @@ func newLogsCommand(opts rootCommandOptions) *cobra.Command {
 	cmd.Flags().StringVar(&logOpts.level, "level", "", "Filter by log level: debug, info, warn, or error")
 	cmd.Flags().StringVar(&logOpts.errorCode, "error-code", "", "Filter by error code")
 	cmd.Flags().StringVar(&logOpts.source, "source", "", "Filter by log source")
-	cmd.Flags().BoolVar(&logOpts.follow, "follow", false, "Follow matching runtime logs through /v1/ws runtime.subscribe_logs")
+	cmd.Flags().BoolVar(&logOpts.follow, "follow", false, "Follow matching runtime logs as they stream")
 	cmd.Flags().StringVar(&logOpts.replaySince, "replay-since", "", "With --follow, optional RFC3339 catch-up window start")
 	cmd.Flags().StringVar(&logOpts.since, "since", "", "Snapshot-only RFC3339 lower timestamp bound")
 	cmd.Flags().StringVar(&logOpts.until, "until", "", "Snapshot-only RFC3339 upper timestamp bound")

--- a/cmd/swarm/main_test.go
+++ b/cmd/swarm/main_test.go
@@ -206,7 +206,7 @@ func TestCLI_RootNoArgsPrintsHelpAndDoesNotStartRuntime(t *testing.T) {
 	if code != 0 {
 		t.Fatalf("root code = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
 	}
-	for _, want := range []string{"Run and inspect Swarm workflows.", "serve", "verify", "completion", "version"} {
+	for _, want := range []string{"Swarm runs event-driven agent workflows", "Getting started:", "Observe & debug:", "serve", "verify", "completion", "version"} {
 		if !strings.Contains(stdout.String(), want) {
 			t.Fatalf("root help missing %q:\n%s", want, stdout.String())
 		}
@@ -227,7 +227,7 @@ func TestCLI_HelpCommandPrintsRootHelp(t *testing.T) {
 	if code != 0 {
 		t.Fatalf("help code = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
 	}
-	if !strings.Contains(stdout.String(), "Run and inspect Swarm workflows.") || !strings.Contains(stdout.String(), "serve") {
+	if !strings.Contains(stdout.String(), "Swarm runs event-driven agent workflows") || !strings.Contains(stdout.String(), "serve") {
 		t.Fatalf("help output missing root command help:\n%s", stdout.String())
 	}
 }
@@ -1334,8 +1334,8 @@ func TestRootNoAssetCommandsDoNotRequireRepoRoot(t *testing.T) {
 		{name: "version", args: []string{"version"}, want: "Swarm dev"},
 		{name: "completion", args: []string{"completion", "bash"}, want: "swarm"},
 		{name: "serve help", args: []string{"serve", "--help"}, want: "Start the Swarm runtime"},
-		{name: "verify help", args: []string{"verify", "--help"}, want: "Validate local Swarm contract files"},
-		{name: "run help", args: []string{"run", "--help"}, want: "Start or reattach to a Swarm run"},
+		{name: "verify help", args: []string{"verify", "--help"}, want: "Validate contract files before boot"},
+		{name: "run help", args: []string{"run", "--help"}, want: "Start a workflow run on a running runtime"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			isolateCLIAPIConfigEnv(t)

--- a/cmd/swarm/run_command.go
+++ b/cmd/swarm/run_command.go
@@ -85,8 +85,10 @@ func newRunCommand(repo string, rootOpts rootCommandOptions) *cobra.Command {
 	opts := runCommandOptions{apiOptions: rootOpts}
 	cmd := &cobra.Command{
 		Use:   "run",
-		Short: "Start or reattach to a Swarm run through v1 RPC and trace subscriptions.",
-		Args:  cobra.NoArgs,
+		Short: "Start a workflow run on a running runtime, or reattach to one.",
+		Example: `  swarm run --event <event-name> --payload payload.json
+  swarm run --reattach <run-id>`,
+		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			runOpts := opts
 			runOpts.changedFlags = runCommandChangedFlags(cmd)
@@ -106,6 +108,7 @@ func newRunCommand(repo string, rootOpts rootCommandOptions) *cobra.Command {
 	cmd.Flags().StringVar(&opts.dataSource, "data", "", "Path to agent-visible read-only /data reference directory")
 	cmd.Flags().StringVar(&opts.platformSpecPath, "platform-spec", "", "Path to platform spec yaml for local foreground startup")
 	cmd.Flags().StringVar(&opts.idempotencyKey, "idempotency-key", "", "Optional idempotency key for run.start")
+	_ = cmd.Flags().MarkHidden("idempotency-key")
 	cmd.Flags().StringVar(&opts.runID, "run-id", "", "Optional caller-provided run id for run.start")
 	cmd.Flags().IntVar(&opts.apiPort, "api-port", 0, "Local API listener port for local foreground startup")
 	cmd.Flags().IntVar(&opts.mcpPort, "mcp-port", 0, "Reserved local MCP port for local foreground startup")

--- a/cmd/swarm/secrets.go
+++ b/cmd/swarm/secrets.go
@@ -60,7 +60,9 @@ type secretsCheckResult struct {
 func newSecretsCommand(ctx context.Context, repo string) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "secrets",
-		Short: "Manage local Swarm secrets.",
+		Short: "Manage local secrets used by tools and providers.",
+		Example: `  swarm secrets set MY_API_KEY
+  swarm secrets check    # verify required secrets are present`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return cmd.Help()
 		},

--- a/cmd/swarm/workspace_build.go
+++ b/cmd/swarm/workspace_build.go
@@ -26,7 +26,7 @@ type workspaceBuildOptions struct {
 func newWorkspaceCommand(ctx context.Context) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "workspace",
-		Short: "Manage local workspace setup surfaces.",
+		Short: "Manage local workspace setup.",
 	}
 	cmd.AddCommand(newWorkspaceBuildCommand(ctx))
 	return cmd


### PR DESCRIPTION
Part of #1649 (Phase 1 only; Phase 2 topology work is gated on #1654).

## What this PR does

Eliminates the **CLI help-surface intelligibility drift** class (gate: `approved as first slice`, recorded on #1649):

- **Outcome-oriented descriptions** — all ~76 user-facing `Short:`/`Long:`/flag-usage strings rewritten to state what a command does for the operator; transport vocabulary ("through v1 RPC", "/v1/rpc …", "API owners") removed from help content everywhere.
- **Journey-ordered help groups** — root help now renders five cobra groups (Getting started / Author & validate / Run & operate / Observe & debug / Utilities) instead of a flat alphabetical list of 30 commands.
- **Root mental model** — root `Long:` describes the contract → verify → serve → run/publish → observe path, plus copy-pasteable `Example:` blocks on root and 9 key commands (serve, run, verify, doctor, trace, mailbox, event publish, secrets, fork).
- **`--idempotency-key` hidden from default help** at all 18 declaration sites — presentation only; the flag still parses, forwards, and keeps its spec-pinned semantics (proven by test). The `fork` Long's command-shape line keeps `[--idempotency-key <key>]` because it mirrors the promoted `command_catalog.run_fork` row.

**Zero behavior change**: no `Use:` string, flag semantics, RunE, exit code, or API call changed. Command topology is untouched (Phase 2, #1654).

## New invariant coverage (`cmd/swarm/help_content_test.go`)

- `TestHelpContentHasNoTransportLeakage` — walks the full command tree (including hidden commands) and fails if any `Short`/`Long`/`Example`/flag usage matches `v1 RPC|/v1/|API owners|v1 API`. This is the counterexample that fails if the class drifts back, including on future commands.
- `TestRootHelpGroupsRenderInJourneyOrder` — group titles present and in journey order.
- `TestEveryVisibleCommandBelongsToAGroup` — no visible command escapes grouping.
- `TestIdempotencyKeyFlagIsHiddenEverywhere` + `TestIdempotencyKeyFlagStillParses` — hidden-but-functional at every site.
- `TestRootHelpHidesIdempotencyAndRetiredCommands` — rendered flag lists clean; retired-command absence still enforced by existing tests.

Updated consumers of the old presentation: `main_test.go` root-help assertions (root now renders `Long`), `TestRootNoAssetCommandsDoNotRequireRepoRoot` (pinned old Shorts), `bundle_test.go` canonical-flag help tests (idempotency-key moved from expected-visible to expected-absent-from-flag-list).

## Spec references

- `platform-spec.yaml#cli_specification` — command topology authority: **not changed** by this PR; all `Use:` strings and catalog row shapes untouched (constraint honored, no promotion needed).
- `platform-spec.yaml#cli_specification.command_catalog.root` + `foundations.no_args_behavior` — bare `swarm` prints help, exits 0, never starts the runtime: preserved and still tested.
- v1 API idempotency contract — untouched; this PR changes flag *presentation* only.
- Otherwise: **non-semantic maintenance**. No exact spec section governs help prose/grouping; binding governing context is #1649 (body + Pre-Implementation Coverage Audit + recorded gate).

## Semantic migration statement

Not a semantic migration: no canonical owner moved, no producer/reader path invalidated. Help content's single owner (cobra definitions in `cmd/swarm`) is unchanged; its content is corrected and now guarded by an invariant test.

## Tests run

- `go test ./cmd/swarm -count=1` — pass (64s).
- `go test ./...` — result reported in the proof audit comment below.
- Supported-surface proof: rendered `swarm --help` (below), `swarm fork --help`, `swarm bundle delete/register --help` exercised via `executeRootCommand` in tests.

## Rendered root help after this PR

```
Swarm runs event-driven agent workflows defined by declarative contracts.

The typical path: check your setup with 'swarm doctor', validate contracts
with 'swarm verify', start the local runtime with 'swarm serve --dev', then
start work with 'swarm run' or 'swarm event publish' and watch it with
'swarm trace', 'swarm events', and 'swarm mailbox'.

Usage:
  swarm [flags]
  swarm [command]

Examples:
  swarm doctor                                      # check local prerequisites
  swarm verify --contracts ./contracts              # validate contracts before boot
  swarm serve --dev                                 # start a local development runtime
  swarm run --event <event-name> --payload payload.json
  swarm trace <run-id>                              # see what a run did

Getting started:
  context       Show which runtime and directories this CLI targets.
  doctor        Check local prerequisites and diagnose setup problems.
  serve         Start the Swarm runtime (server): engine, API, health, and MCP.
  version       Print local Swarm binary version information.
  workspace     Manage local workspace setup.

Author & validate:
  bundle        Inspect registered contract bundles.
  describe      Render the expanded authoring view for local Swarm contracts.
  secrets       Manage local secrets used by tools and providers.
  verify        Validate contract files before boot.

Run & operate:
  agent         Inspect, direct, restart, or replay a single agent.
  control       Pause, continue, stop, or reset runs (operator actions).
  event         Publish, view, or replay a single event.
  fork          Branch a run to replay it with changed contracts or policy.
  forkchat      Open sandboxed chat sessions against forked runs.
  mailbox       List, view, and decide pending human decisions.
  run           Start a workflow run on a running runtime, or reattach to one.

Observe & debug:
  agents        List agents and their current state.
  conversation  View one conversation and its turns.
  conversations List agent conversations.
  entities      List workflow entities.
  entity        View or aggregate one entity's state.
  events        List or follow the event stream.
  health        Show runtime health.
  incidents     List runtime incidents.
  logs          List or follow runtime logs.
  runs          List runs.
  status        Diagnose one run (state, gates, stuck points).
  trace         Print or follow a run's execution trace.

Utilities:
  completion    Generate shell completion scripts.
  help          Help about any command
```

## Residual risk

- Docs/README describe commands independently and are not updated here (tracked: #1578 walkthrough consumes the merged surface; watchlist node `cli_command_surface_ux_and_topology`).
- The cobra-`Use:`-to-`command_catalog`-row conformance binding does not exist yet (recorded on the watchlist; natural scope for #1654).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
