### PR TITLE
[agent-b][issue #1647] Move serve API auth to token files

### DIFF
--- a/cmd/swarm/cli.go
+++ b/cmd/swarm/cli.go
@@ -194,6 +194,13 @@ func newServeCommand(ctx context.Context, repo string, runServe func(context.Con
 			opts.StoreModeSet = cmd.Flags().Changed("store")
 			opts.WorkspaceBackendSet = cmd.Flags().Changed("workspace-backend")
 			opts.ContextNameSet = cmd.Flags().Changed("context")
+			opts.APITokenFileFlagSet = cmd.Flags().Changed("api-token-file")
+			if opts.APITokenFileFlagSet {
+				opts.APITokenFile = strings.TrimSpace(opts.APITokenFile)
+				if opts.APITokenFile == "" {
+					return fmt.Errorf("--api-token-file must be non-empty")
+				}
+			}
 			if opts.ShutdownGrace <= 0 {
 				return fmt.Errorf("--shutdown-grace must be a positive duration")
 			}
@@ -235,6 +242,7 @@ func newServeCommand(ctx context.Context, repo string, runServe func(context.Con
 	cmd.Flags().StringVar(&opts.PlatformSpecPath, "platform-spec", opts.PlatformSpecPath, "Path to platform spec yaml")
 	cmd.Flags().StringVar(&opts.StoreMode, "store", opts.StoreMode, runtimeStoreBackendHelp)
 	cmd.Flags().StringVar(&opts.ContextName, "context", opts.ContextName, "Local Swarm context name to register for --dev")
+	cmd.Flags().StringVar(&opts.APITokenFile, "api-token-file", opts.APITokenFile, "Path to file containing the serve API bearer token")
 	cmd.Flags().StringVar(&opts.APIListenAddr, "api-listen-addr", opts.APIListenAddr, "HTTP bind address for API, WebSocket, health, and readiness routes")
 	cmd.Flags().StringVar(&opts.MCPListenAddr, "mcp-listen-addr", opts.MCPListenAddr, "HTTP bind address for MCP and tools routes")
 	cmd.Flags().DurationVar(&opts.ShutdownGrace, "shutdown-grace", opts.ShutdownGrace, "Time to wait for in-flight work to drain after shutdown starts")

--- a/cmd/swarm/cli_api.go
+++ b/cmd/swarm/cli_api.go
@@ -28,6 +28,9 @@ const (
 
 	cliServeAPIListenAddrEnv = "SWARM_API_LISTEN_ADDR"
 	cliServeMCPListenAddrEnv = "SWARM_MCP_LISTEN_ADDR"
+
+	serveAPITokenFileFlagSource   = "--api-token-file"
+	serveAPITokenFileConfigSource = "config serve_api_token_file"
 )
 
 type rootCommandOptions struct {
@@ -124,6 +127,7 @@ type cliAPIConfigFile struct {
 	PlatformSpecPath   string `yaml:"platform_spec_path"`
 	ServeAPIListenAddr string `yaml:"serve_api_listen_addr"`
 	ServeMCPListenAddr string `yaml:"serve_mcp_listen_addr"`
+	ServeAPITokenFile  string `yaml:"serve_api_token_file"`
 }
 
 type cliAPIValidationError struct {
@@ -261,6 +265,58 @@ func resolveCLIServeListenerAddressHighPriority(flagValue string, flagSet bool, 
 	return "", false
 }
 
+func resolveServeAPIAuth(opts serveOptions) (apiv1.AuthTokenResolution, error) {
+	if err := rejectRemovedServeAPIEnvSource(); err != nil {
+		return apiv1.AuthTokenResolution{}, err
+	}
+	if opts.APITokenFileFlagSet || strings.TrimSpace(opts.APITokenFile) != "" {
+		tokenFile := strings.TrimSpace(opts.APITokenFile)
+		if tokenFile == "" {
+			return apiv1.AuthTokenResolution{}, &cliAPIAuthConfigError{message: serveAPITokenFileFlagSource + " is blank"}
+		}
+		return readServeAPITokenFile(tokenFile, serveAPITokenFileFlagSource)
+	}
+	cfg, err := loadCLIAPIConfigFile()
+	if err != nil {
+		return apiv1.AuthTokenResolution{}, err
+	}
+	if tokenFile := strings.TrimSpace(cfg.ServeAPITokenFile); tokenFile != "" {
+		return readServeAPITokenFile(tokenFile, serveAPITokenFileConfigSource)
+	}
+	return defaultServeAPIAuthResolution(), nil
+}
+
+func rejectRemovedServeAPIEnvSource() error {
+	if strings.TrimSpace(os.Getenv("SWARM_API_TOKEN")) == "" {
+		return nil
+	}
+	return &cliAPIValidationError{message: "server-side API environment source is no longer accepted: SWARM_API_TOKEN (use swarm serve --api-token-file or config serve_api_token_file)"}
+}
+
+func readServeAPITokenFile(tokenFile, source string) (apiv1.AuthTokenResolution, error) {
+	token, err := readCLIAPITokenFile(tokenFile, source)
+	if err != nil {
+		return apiv1.AuthTokenResolution{}, err
+	}
+	absoluteTokenFile, err := filepath.Abs(strings.TrimSpace(tokenFile))
+	if err != nil {
+		return apiv1.AuthTokenResolution{}, &cliAPIAuthConfigError{message: fmt.Sprintf("resolve %s path: %v", source, err)}
+	}
+	return apiv1.AuthTokenResolution{
+		Tokens:    []string{token},
+		Source:    apiv1.AuthTokenSource(source),
+		Explicit:  true,
+		TokenFile: absoluteTokenFile,
+	}, nil
+}
+
+func defaultServeAPIAuthResolution() apiv1.AuthTokenResolution {
+	return apiv1.AuthTokenResolution{
+		Tokens: []string{apiv1.DefaultLoopbackAPIToken},
+		Source: apiv1.AuthTokenSourceBuiltInLoopbackToken,
+	}
+}
+
 func readCLIAPIExplicitTokenFile(tokenFile, source string) (cliAPITokenResolution, error) {
 	token, err := readCLIAPITokenFile(tokenFile, source)
 	if err != nil {
@@ -329,7 +385,7 @@ func parseCLIAPIConfigFile(configPath string, raw []byte) (cliAPIConfigFile, err
 	}
 	for key, value := range decoded {
 		switch key {
-		case "api_server", "api_token_file", "swarm_dir", "contracts_path", "platform_spec_path", "serve_api_listen_addr", "serve_mcp_listen_addr":
+		case "api_server", "api_token_file", "swarm_dir", "contracts_path", "platform_spec_path", "serve_api_listen_addr", "serve_mcp_listen_addr", "serve_api_token_file":
 			if value == nil {
 				continue
 			}

--- a/cmd/swarm/cli_api_resolver_test.go
+++ b/cmd/swarm/cli_api_resolver_test.go
@@ -463,7 +463,7 @@ func TestCLIAPIConnectionFlagsSurfaceAndIsolation(t *testing.T) {
 	}
 
 	withoutFlags := []string{
-		"", "serve", "verify", "completion", "run",
+		"", "verify", "completion", "run",
 		"events", "event", "bundle", "agents", "agent", "conversations", "conversation", "entities", "entity", "mailbox", "control", "forkchat",
 		"investigate", "investigate health",
 	}
@@ -472,6 +472,14 @@ func TestCLIAPIConnectionFlagsSurfaceAndIsolation(t *testing.T) {
 		if cmd.Flags().Lookup("api-server") != nil || cmd.Flags().Lookup("api-token-file") != nil {
 			t.Fatalf("%s unexpectedly accepts API connection flags", path)
 		}
+	}
+
+	serve := mustFindCLICommand(t, root, "serve")
+	if serve.Flags().Lookup("api-token-file") == nil {
+		t.Fatal("serve missing server --api-token-file")
+	}
+	if serve.Flags().Lookup("api-server") != nil {
+		t.Fatal("serve unexpectedly accepts client --api-server")
 	}
 }
 
@@ -499,6 +507,34 @@ func TestServeContextFlagPassesRootPrevalidation(t *testing.T) {
 	}
 	if strings.Contains(stderr.String(), "unknown flag: --context") {
 		t.Fatalf("serve context flag was rejected by prevalidation: %s", stderr.String())
+	}
+}
+
+func TestServeAPITokenFileFlagPassesRootPrevalidation(t *testing.T) {
+	isolateCLIAPIConfigEnv(t)
+	tokenFile := writeCLIAPITokenFile(t, "serve-token")
+	var stdout, stderr bytes.Buffer
+	called := false
+	var got serveOptions
+	opts := defaultRootCommandOptions()
+	opts.runServe = func(_ context.Context, _ string, serveOpts serveOptions) int {
+		called = true
+		got = serveOpts
+		return 0
+	}
+
+	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"serve", "--api-token-file", tokenFile}, &stdout, &stderr, opts)
+	if code != 0 {
+		t.Fatalf("serve code = %d, want 0 stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if !called {
+		t.Fatal("serve runner was not called")
+	}
+	if got.APITokenFile != tokenFile || !got.APITokenFileFlagSet {
+		t.Fatalf("serve API token file = %q set=%v, want %q/set", got.APITokenFile, got.APITokenFileFlagSet, tokenFile)
+	}
+	if strings.Contains(stderr.String(), "unknown flag: --api-token-file") {
+		t.Fatalf("serve api-token-file flag was rejected by prevalidation: %s", stderr.String())
 	}
 }
 
@@ -1138,7 +1174,7 @@ func writeCLIAPITokenFile(t *testing.T, token string) string {
 func writeCLIAPIConfigFile(t *testing.T, values map[string]string) string {
 	t.Helper()
 	var body strings.Builder
-	for _, key := range []string{"api_server", "api_token_file", "swarm_dir", "contracts_path", "platform_spec_path", "serve_api_listen_addr", "serve_mcp_listen_addr"} {
+	for _, key := range []string{"api_server", "api_token_file", "swarm_dir", "contracts_path", "platform_spec_path", "serve_api_listen_addr", "serve_mcp_listen_addr", "serve_api_token_file"} {
 		if value, ok := values[key]; ok {
 			body.WriteString(key)
 			body.WriteString(": ")

--- a/cmd/swarm/main.go
+++ b/cmd/swarm/main.go
@@ -334,6 +334,8 @@ type serveOptions struct {
 	SwarmDirSet                      bool
 	ContextName                      string
 	ContextNameSet                   bool
+	APITokenFile                     string
+	APITokenFileFlagSet              bool
 	APIListenAddr                    string
 	MCPListenAddr                    string
 	ShutdownGrace                    time.Duration
@@ -743,14 +745,19 @@ func runServeRuntime(ctx context.Context, repo string, opts serveOptions) int {
 	runtimeInstanceID := uuid.NewString()
 	reporter := newServeBootReporter(opts.Verbose, opts.Output)
 	reporter.emit(1, "process_start", "ok", "")
-	apiAuth := apiv1.ResolveAuthTokensFromEnvironment()
+	apiAuth, err := resolveServeAPIAuth(opts)
+	if err != nil {
+		reporter.emit(2, "config_load", "FAILED", err.Error())
+		log.Printf("configure v1 api auth: %v", err)
+		return 1
+	}
 	if err := validateServeAPIAuthBinding(opts.APIListenAddr, apiAuth); err != nil {
 		reporter.emit(2, "config_load", "FAILED", err.Error())
 		log.Printf("configure v1 api auth: %v", err)
 		return 1
 	}
 	if apiAuth.UsesDefaultLoopbackToken() {
-		log.Print(apiv1.DefaultLoopbackAPITokenWarning)
+		log.Print("using built-in dev API token on numeric loopback; use swarm serve --api-token-file or config serve_api_token_file before exposing")
 	}
 	resolvedPaths, err := resolveCLIContractPlatformSpecPaths(repo, cliContractPlatformSpecPathOptions{
 		ContractsPath:    opts.ContractsPath,
@@ -2982,7 +2989,7 @@ func validateServeAPIAuthBinding(apiListenAddr string, auth apiv1.AuthTokenResol
 	if apiv1.DefaultLoopbackAPITokenAllowedHost(host) {
 		return nil
 	}
-	return fmt.Errorf("non-loopback API bind %s requires an explicit SWARM_API_TOKEN", strings.TrimSpace(apiListenAddr))
+	return fmt.Errorf("non-loopback API bind %s requires --api-token-file or config serve_api_token_file", strings.TrimSpace(apiListenAddr))
 }
 
 func listenServeHTTPListener(name, addr string) (net.Listener, error) {

--- a/cmd/swarm/main_test.go
+++ b/cmd/swarm/main_test.go
@@ -716,7 +716,7 @@ func TestCLI_ServeListenAddrEnvConfigValidation(t *testing.T) {
 
 func TestValidateServeAPIAuthBindingDefaultTokenLoopbackBoundary(t *testing.T) {
 	defaultAuth := apiv1.AuthTokenResolution{Tokens: []string{apiv1.DefaultLoopbackAPIToken}, Source: apiv1.AuthTokenSourceBuiltInLoopbackToken}
-	explicitAuth := apiv1.AuthTokenResolution{Tokens: []string{"operator-token"}, Source: apiv1.AuthTokenSourceEnvironment, Explicit: true}
+	explicitAuth := apiv1.AuthTokenResolution{Tokens: []string{"operator-token"}, Source: apiv1.AuthTokenSource(serveAPITokenFileFlagSource), Explicit: true, TokenFile: filepath.Join(t.TempDir(), "token")}
 	tests := []struct {
 		name    string
 		addr    string
@@ -725,9 +725,9 @@ func TestValidateServeAPIAuthBindingDefaultTokenLoopbackBoundary(t *testing.T) {
 	}{
 		{name: "default token allowed on ipv4 loopback", addr: "127.0.0.1:8081", auth: defaultAuth},
 		{name: "default token allowed on ipv6 loopback", addr: "[::1]:8081", auth: defaultAuth},
-		{name: "default token rejects localhost", addr: "localhost:8081", auth: defaultAuth, wantErr: "non-loopback API bind localhost:8081 requires an explicit SWARM_API_TOKEN"},
-		{name: "default token rejects wildcard", addr: "0.0.0.0:8081", auth: defaultAuth, wantErr: "non-loopback API bind 0.0.0.0:8081 requires an explicit SWARM_API_TOKEN"},
-		{name: "default token rejects routable", addr: "192.0.2.10:8081", auth: defaultAuth, wantErr: "non-loopback API bind 192.0.2.10:8081 requires an explicit SWARM_API_TOKEN"},
+		{name: "default token rejects localhost", addr: "localhost:8081", auth: defaultAuth, wantErr: "non-loopback API bind localhost:8081 requires --api-token-file or config serve_api_token_file"},
+		{name: "default token rejects wildcard", addr: "0.0.0.0:8081", auth: defaultAuth, wantErr: "non-loopback API bind 0.0.0.0:8081 requires --api-token-file or config serve_api_token_file"},
+		{name: "default token rejects routable", addr: "192.0.2.10:8081", auth: defaultAuth, wantErr: "non-loopback API bind 192.0.2.10:8081 requires --api-token-file or config serve_api_token_file"},
 		{name: "explicit token allows wildcard", addr: "0.0.0.0:8081", auth: explicitAuth},
 	}
 	for _, tc := range tests {
@@ -744,6 +744,78 @@ func TestValidateServeAPIAuthBindingDefaultTokenLoopbackBoundary(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestResolveServeAPIAuthSourceAuthority(t *testing.T) {
+	t.Run("default loopback when no explicit source", func(t *testing.T) {
+		isolateCLIAPIConfigEnv(t)
+		auth, err := resolveServeAPIAuth(defaultServeOptions())
+		if err != nil {
+			t.Fatalf("resolveServeAPIAuth: %v", err)
+		}
+		if !auth.UsesDefaultLoopbackToken() || !reflect.DeepEqual(auth.Tokens, []string{apiv1.DefaultLoopbackAPIToken}) {
+			t.Fatalf("auth = %#v, want built-in loopback default", auth)
+		}
+	})
+
+	t.Run("flag token file wins over config", func(t *testing.T) {
+		isolateCLIAPIConfigEnv(t)
+		configTokenFile := writeCLIAPITokenFile(t, "config-token")
+		flagTokenFile := writeCLIAPITokenFile(t, "flag-token")
+		t.Setenv("SWARM_CONFIG", writeCLIAPIConfigFile(t, map[string]string{
+			"serve_api_token_file": configTokenFile,
+		}))
+		auth, err := resolveServeAPIAuth(serveOptions{APITokenFile: flagTokenFile, APITokenFileFlagSet: true})
+		if err != nil {
+			t.Fatalf("resolveServeAPIAuth: %v", err)
+		}
+		if got := auth.Tokens; !reflect.DeepEqual(got, []string{"flag-token"}) {
+			t.Fatalf("tokens = %#v, want flag token", got)
+		}
+		if auth.Source != apiv1.AuthTokenSource(serveAPITokenFileFlagSource) || !auth.Explicit || auth.TokenFile != flagTokenFile {
+			t.Fatalf("auth = %#v, want flag token-file source", auth)
+		}
+	})
+
+	t.Run("config token file used when flag absent", func(t *testing.T) {
+		isolateCLIAPIConfigEnv(t)
+		configTokenFile := writeCLIAPITokenFile(t, "config-token")
+		t.Setenv("SWARM_CONFIG", writeCLIAPIConfigFile(t, map[string]string{
+			"serve_api_token_file": configTokenFile,
+		}))
+		auth, err := resolveServeAPIAuth(defaultServeOptions())
+		if err != nil {
+			t.Fatalf("resolveServeAPIAuth: %v", err)
+		}
+		if got := auth.Tokens; !reflect.DeepEqual(got, []string{"config-token"}) {
+			t.Fatalf("tokens = %#v, want config token", got)
+		}
+		if auth.Source != apiv1.AuthTokenSource(serveAPITokenFileConfigSource) || !auth.Explicit || auth.TokenFile != configTokenFile {
+			t.Fatalf("auth = %#v, want config token-file source", auth)
+		}
+	})
+
+	t.Run("raw env source rejected even with token file", func(t *testing.T) {
+		isolateCLIAPIConfigEnv(t)
+		tokenFile := writeCLIAPITokenFile(t, "flag-token")
+		t.Setenv("SWARM_API_TOKEN", "env-token")
+		_, err := resolveServeAPIAuth(serveOptions{APITokenFile: tokenFile, APITokenFileFlagSet: true})
+		if err == nil || !strings.Contains(err.Error(), "server-side API environment source is no longer accepted") || !strings.Contains(err.Error(), "serve_api_token_file") {
+			t.Fatalf("err = %v, want removed-env diagnostic", err)
+		}
+	})
+
+	t.Run("blank and missing token files fail closed", func(t *testing.T) {
+		isolateCLIAPIConfigEnv(t)
+		blank := writeCLIAPITokenFile(t, "  \n")
+		if _, err := resolveServeAPIAuth(serveOptions{APITokenFile: blank, APITokenFileFlagSet: true}); err == nil || !strings.Contains(err.Error(), "--api-token-file is blank") {
+			t.Fatalf("blank token err = %v, want blank token failure", err)
+		}
+		missing := filepath.Join(t.TempDir(), "missing-token")
+		if _, err := resolveServeAPIAuth(serveOptions{APITokenFile: missing, APITokenFileFlagSet: true}); err == nil || !strings.Contains(err.Error(), "read --api-token-file") {
+			t.Fatalf("missing token err = %v, want read failure", err)
+		}
+	})
 }
 
 func TestCLI_ServeRuntimeConfigDoesNotFeedListenerConfig(t *testing.T) {
@@ -1108,7 +1180,10 @@ func TestPlatformSpecServeListenerTopologyRuntimeBindingPromoted(t *testing.T) {
 	if strings.TrimSpace(spec.EnvConfigPrecedenceImplementedBy) != "#844" {
 		t.Fatalf("listener topology env_config_precedence_implemented_by = %q, want #844", spec.EnvConfigPrecedenceImplementedBy)
 	}
-	if strings.TrimSpace(spec.ImplementationStatus) != "runtime_bind_and_env_config_precedence_implemented_enable_disable_pending" {
+	if strings.TrimSpace(spec.ServerAPIAuthImplementedBy) != "#1647" {
+		t.Fatalf("listener topology server_api_auth_implemented_by = %q, want #1647", spec.ServerAPIAuthImplementedBy)
+	}
+	if strings.TrimSpace(spec.ImplementationStatus) != "runtime_bind_env_config_and_server_api_auth_implemented_enable_disable_pending" {
 		t.Fatalf("listener topology status = %q", spec.ImplementationStatus)
 	}
 	if spec.Listeners.API.BindFlag != "--api-listen-addr <host:port>" {
@@ -1137,6 +1212,42 @@ func TestPlatformSpecServeListenerTopologyRuntimeBindingPromoted(t *testing.T) {
 	}
 	if spec.SourcePrecedence.MCPListenAddr.Environment != "SWARM_MCP_LISTEN_ADDR" || spec.SourcePrecedence.MCPListenAddr.ConfigKey != "serve_mcp_listen_addr" {
 		t.Fatalf("mcp listener source precedence = %#v", spec.SourcePrecedence.MCPListenAddr)
+	}
+	if spec.SourcePrecedence.ServerAPIAuth.AcceptedSources["flag_file"] != "--api-token-file <path>" {
+		t.Fatalf("server api auth flag source = %#v", spec.SourcePrecedence.ServerAPIAuth.AcceptedSources)
+	}
+	if spec.SourcePrecedence.ServerAPIAuth.AcceptedSources["config_file_key"] != "serve_api_token_file" {
+		t.Fatalf("server api auth config source = %#v", spec.SourcePrecedence.ServerAPIAuth.AcceptedSources)
+	}
+	wantServeAuthOrder := []string{"--api-token-file", "config serve_api_token_file", "built-in loopback default"}
+	if !reflect.DeepEqual(spec.SourcePrecedence.ServerAPIAuth.SourceOrder, wantServeAuthOrder) {
+		t.Fatalf("server api auth source order = %#v, want %#v", spec.SourcePrecedence.ServerAPIAuth.SourceOrder, wantServeAuthOrder)
+	}
+	for key, want := range map[string]string{
+		"SWARM_API_TOKEN":       "#1647",
+		"SWARM_API_TOKEN_FILE":  "Not promoted",
+		"config api_token_file": "Client-side API auth only",
+		"config api_token":      "Inline bearer tokens",
+	} {
+		if !strings.Contains(spec.SourcePrecedence.ServerAPIAuth.RejectedSources[key], want) {
+			t.Fatalf("server api auth rejected source %q missing %q:\n%s", key, want, spec.SourcePrecedence.ServerAPIAuth.RejectedSources[key])
+		}
+	}
+	for _, want := range []string{"Missing", "blank", "MUST NOT fall back"} {
+		if !strings.Contains(spec.SourcePrecedence.ServerAPIAuth.TokenFileRule, want) {
+			t.Fatalf("server token_file_rule missing %q:\n%s", want, spec.SourcePrecedence.ServerAPIAuth.TokenFileRule)
+		}
+	}
+	for _, want := range []string{"--api-token-file", "serve_api_token_file"} {
+		if !strings.Contains(spec.SourcePrecedence.APIAuthCouplingRule, want) {
+			t.Fatalf("api auth coupling rule missing %q:\n%s", want, spec.SourcePrecedence.APIAuthCouplingRule)
+		}
+		if !strings.Contains(spec.InteractionRules.APIDefaultTokenExposure.Rule, want) {
+			t.Fatalf("api default token exposure rule missing %q:\n%s", want, spec.InteractionRules.APIDefaultTokenExposure.Rule)
+		}
+	}
+	if strings.Contains(spec.SourcePrecedence.APIAuthCouplingRule, "explicit `SWARM_API_TOKEN`") {
+		t.Fatalf("api auth coupling still names explicit SWARM_API_TOKEN:\n%s", spec.SourcePrecedence.APIAuthCouplingRule)
 	}
 	for _, key := range []string{"SWARM_API_PORT", "SWARM_MCP_PORT", "api_listen_addr", "mcp_listen_addr"} {
 		if strings.TrimSpace(spec.SourcePrecedence.RejectedSources[key]) == "" {
@@ -1321,6 +1432,11 @@ func TestPlatformSpecCLIAPIConnectionAuthConfigPrecedencePromoted(t *testing.T) 
 		if !strings.Contains(spec.CLIConfigFile.SharedNonAPIKeys[key], "listener_topology_v2_1.source_precedence") {
 			t.Fatalf("cli config shared non-API key %q missing listener source owner: %#v", key, spec.CLIConfigFile.SharedNonAPIKeys)
 		}
+	}
+	if !strings.Contains(spec.CLIConfigFile.SharedNonAPIKeys["serve_api_token_file"], "server_api_auth") ||
+		!strings.Contains(spec.CLIConfigFile.SharedNonAPIKeys["serve_api_token_file"], "server-side `swarm serve` auth only") ||
+		!strings.Contains(spec.CLIConfigFile.SharedNonAPIKeys["serve_api_token_file"], "MUST NOT") {
+		t.Fatalf("cli config serve_api_token_file missing server/client boundary: %#v", spec.CLIConfigFile.SharedNonAPIKeys["serve_api_token_file"])
 	}
 	for _, key := range []string{"SWARM_API_PORT", "SWARM_MCP_PORT"} {
 		if !strings.Contains(spec.ServeListenerEnvConfigBoundary.RejectedPorts[key], "Not promoted") {
@@ -3398,7 +3514,6 @@ func TestRunServeRuntimeDBLoadedRunForkSupportedSurfaceExecutesAndStampsPersiste
 	_, db, pg := installServeRuntimePostgresTestStores(t, func() serveWorkspaceLifecycle {
 		return serveRuntimeWorkspaceStub{}
 	})
-	t.Setenv("SWARM_API_TOKEN", "test-token")
 	ctx := context.Background()
 	bundle := loadWorkflowValidationFixtureBundle(t, filepath.Join("tests", "tier8-boot-verification", "test-boot-success"))
 	projection, err := runtimecontracts.BuildBundleCatalogProjection(bundle)
@@ -3452,7 +3567,7 @@ func TestRunServeRuntimeDBLoadedRunForkSupportedSurfaceExecutesAndStampsPersiste
 	if err != nil {
 		t.Fatalf("build run.fork request: %v", err)
 	}
-	req.Header.Set("Authorization", "Bearer test-token")
+	req.Header.Set("Authorization", "Bearer "+apiv1.DefaultLoopbackAPIToken)
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
@@ -5928,7 +6043,6 @@ func TestRunServeRuntimePassesDataFlagToWorkspaceLifecycle(t *testing.T) {
 }
 
 func TestRunServeRuntimeHostWorkspaceBackendBootsWithoutDockerForSystemOnlyFlow(t *testing.T) {
-	t.Setenv("SWARM_API_TOKEN", "test-token")
 	t.Setenv("SWARM_DOCKER_BIN", filepath.Join(t.TempDir(), "missing-docker"))
 	t.Setenv("SWARM_WORKSPACE_HOST_ROOT", filepath.Join(t.TempDir(), "host-workspaces"))
 	t.Setenv(storebackend.EnvSQLitePath, filepath.Join(t.TempDir(), "runtime.db"))
@@ -11320,6 +11434,7 @@ type serveListenerTopologySpec struct {
 	PromotedBy                       string `yaml:"promoted_by"`
 	RuntimeBindImplementedBy         string `yaml:"runtime_bind_implemented_by"`
 	EnvConfigPrecedenceImplementedBy string `yaml:"env_config_precedence_implemented_by"`
+	ServerAPIAuthImplementedBy       string `yaml:"server_api_auth_implemented_by"`
 	ImplementationStatus             string `yaml:"implementation_status"`
 	CanonicalOwner                   string `yaml:"canonical_owner"`
 	Summary                          string `yaml:"summary"`
@@ -11353,8 +11468,20 @@ type serveListenerTopologySpec struct {
 			ConfigKey      string `yaml:"config_key"`
 			BuiltInDefault string `yaml:"built_in_default"`
 		} `yaml:"mcp_listen_addr"`
-		RejectedSources map[string]string `yaml:"rejected_sources"`
+		ServerAPIAuth struct {
+			AcceptedSources map[string]string `yaml:"accepted_sources"`
+			SourceOrder     []string          `yaml:"source_order"`
+			RejectedSources map[string]string `yaml:"rejected_sources"`
+			TokenFileRule   string            `yaml:"token_file_rule"`
+		} `yaml:"server_api_auth"`
+		APIAuthCouplingRule string            `yaml:"api_auth_coupling_rule"`
+		RejectedSources     map[string]string `yaml:"rejected_sources"`
 	} `yaml:"source_precedence"`
+	InteractionRules struct {
+		APIDefaultTokenExposure struct {
+			Rule string `yaml:"rule"`
+		} `yaml:"api_default_token_exposure"`
+	} `yaml:"interaction_rules"`
 	ImplementationBoundaries []string `yaml:"implementation_boundaries"`
 }
 

--- a/cmd/swarm/run_command.go
+++ b/cmd/swarm/run_command.go
@@ -147,6 +147,12 @@ func runRunCommand(ctx context.Context, repo string, out, errOut io.Writer, opts
 	var stopLocal func()
 	if strings.TrimSpace(opts.connectURL) == "" {
 		repo = assetCommandRepoRoot(repo)
+		var err error
+		opts, err = opts.withLocalForegroundServeAuth()
+		if err != nil {
+			fmt.Fprintln(errOut, err)
+			return commandExitError{code: runCommandErrorExitCode(err)}
+		}
 		if _, err := newCLIAPIClient(opts.apiOptions); err != nil {
 			fmt.Fprintln(errOut, err)
 			return commandExitError{code: runCommandErrorExitCode(err)}
@@ -264,6 +270,17 @@ func (o runCommandOptions) validate() error {
 		return fmt.Errorf("--payload is required")
 	}
 	return nil
+}
+
+func (o runCommandOptions) withLocalForegroundServeAuth() (runCommandOptions, error) {
+	auth, err := resolveServeAPIAuth(defaultServeOptions())
+	if err != nil {
+		return o, err
+	}
+	if tokenFile := strings.TrimSpace(auth.TokenFile); tokenFile != "" {
+		o.apiOptions.apiTokenFile = tokenFile
+	}
+	return o, nil
 }
 
 func (o runCommandOptions) runtimeEndpoints() (rootCommandOptions, string, error) {

--- a/cmd/swarm/run_command_test.go
+++ b/cmd/swarm/run_command_test.go
@@ -99,6 +99,59 @@ func TestRunCommandLocalForegroundConsumesServeOwnerAndV1API(t *testing.T) {
 	}
 }
 
+func TestRunCommandLocalForegroundUsesServeAPITokenFileForEmbeddedClient(t *testing.T) {
+	isolateCLIAPIConfigEnv(t)
+	tokenFile := writeCLIAPITokenFile(t, "serve-token")
+	t.Setenv("SWARM_CONFIG", writeCLIAPIConfigFile(t, map[string]string{
+		"serve_api_token_file": tokenFile,
+	}))
+	payloadPath := writeRunCommandPayloadFile(t, map[string]any{"entity_id": "entity-1"})
+	server, calls, wsRequests := newRunCommandServer(t, runCommandServerOptions{
+		expectedToken: "serve-token",
+		strictAuth:    true,
+		rpcResponder: func(req jsonRPCRequest, _ int) map[string]any {
+			switch req.Method {
+			case "health.check":
+				return runCommandHealthResult()
+			case "run.start":
+				return map[string]any{"run_id": "run-token-file", "status": "running"}
+			case "run.get":
+				run := validDiagnosticRunHeader("run-token-file")
+				run["status"] = "completed"
+				run["ended_at"] = "2026-05-13T10:01:00Z"
+				return map[string]any{"run": run}
+			default:
+				t.Fatalf("unexpected method = %q", req.Method)
+			}
+			return nil
+		},
+		wsRows: []map[string]any{validRunCommandTraceRow("evt-token-file")},
+	})
+	defer server.Close()
+
+	opts := testRunCommandOptions(server)
+	var serveCalled atomic.Int32
+	opts.runServe = func(ctx context.Context, repo string, serveOpts serveOptions) int {
+		serveCalled.Add(1)
+		if !serveOpts.LocalRun {
+			t.Errorf("local run serve opts LocalRun = false, want true")
+		}
+		<-ctx.Done()
+		return 0
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"run", "--event", "scan.requested", "--payload", payloadPath}, &stdout, &stderr, opts)
+	if code != 0 {
+		t.Fatalf("code = %d stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if serveCalled.Load() != 1 {
+		t.Fatalf("serve called = %d, want 1", serveCalled.Load())
+	}
+	assertRunCommandMethods(t, calls, []string{"health.check", "health.check", "run.start", "run.get"})
+	assertRunCommandTraceSubscription(t, wsRequests, "run-token-file", true)
+}
+
 func TestStartLocalRunServeConsumesContractPathConfigResolver(t *testing.T) {
 	isolateCLIAPIConfigEnv(t)
 	repo := t.TempDir()
@@ -774,6 +827,7 @@ type runCommandServerOptions struct {
 	wsSubscriptionResult map[string]any
 	wsCloseAfterRows     bool
 	expectedToken        string
+	strictAuth           bool
 }
 
 func newRunCommandServer(t *testing.T, opts runCommandServerOptions) (*httptest.Server, *[]jsonRPCRequest, *[]jsonRPCRequest) {
@@ -790,6 +844,10 @@ func newRunCommandServer(t *testing.T, opts runCommandServerOptions) (*httptest.
 		switch r.URL.Path {
 		case "/v1/rpc":
 			if got := r.Header.Get("Authorization"); got != "Bearer "+expectedToken {
+				if opts.strictAuth {
+					http.Error(w, "invalid bearer token", http.StatusUnauthorized)
+					return
+				}
 				t.Errorf("Authorization = %q, want bearer token", got)
 			}
 			var req jsonRPCRequest
@@ -806,6 +864,10 @@ func newRunCommandServer(t *testing.T, opts runCommandServerOptions) (*httptest.
 			writeJSONRPCResult(t, w, req.ID, opts.rpcResponder(req, callIndex))
 		case "/v1/ws":
 			if got := r.Header.Get("Authorization"); got != "Bearer "+expectedToken {
+				if opts.strictAuth {
+					http.Error(w, "invalid bearer token", http.StatusUnauthorized)
+					return
+				}
 				t.Errorf("WS Authorization = %q, want bearer token", got)
 			}
 			conn, err := upgrader.Upgrade(w, r, nil)

--- a/cmd/swarm/serve_context_registration.go
+++ b/cmd/swarm/serve_context_registration.go
@@ -182,9 +182,6 @@ func (r *serveProjectContextRegistration) WriteFinal(runtimeInstanceID string, a
 	if r == nil {
 		return nil
 	}
-	if !apiAuth.UsesDefaultLoopbackToken() {
-		return fmt.Errorf("serve --dev project context registration currently supports only built-in loopback auth; explicit SWARM_API_TOKEN cannot be snapshotted into a safe context descriptor")
-	}
 	apiServer, err := serveProjectContextAPIServer(apiAddr)
 	if err != nil {
 		return err
@@ -193,7 +190,19 @@ func (r *serveProjectContextRegistration) WriteFinal(runtimeInstanceID string, a
 	if err != nil {
 		return err
 	}
-	if !cliAPIRPCEndpointAllowsDefaultToken(rpcEndpoint) {
+	auth := localContextDescriptorAuth{Mode: localContextAuthBuiltinLoopback}
+	if apiAuth.UsesDefaultLoopbackToken() {
+		if !cliAPIRPCEndpointAllowsDefaultToken(rpcEndpoint) {
+			return fmt.Errorf("serve --dev project context registration requires a numeric loopback API listener for built-in loopback auth, got %s", apiServer)
+		}
+	} else {
+		tokenFile := strings.TrimSpace(apiAuth.TokenFile)
+		if tokenFile == "" {
+			return fmt.Errorf("serve --dev project context registration requires token-file auth for explicit API auth source %s", apiAuth.Source)
+		}
+		auth = localContextDescriptorAuth{Mode: localContextAuthTokenFile, TokenFile: tokenFile}
+	}
+	if auth.Mode == localContextAuthBuiltinLoopback && !cliAPIRPCEndpointAllowsDefaultToken(rpcEndpoint) {
 		return fmt.Errorf("serve --dev project context registration requires a numeric loopback API listener, got %s", apiServer)
 	}
 	now := localContextTimestamp()
@@ -203,7 +212,7 @@ func (r *serveProjectContextRegistration) WriteFinal(runtimeInstanceID string, a
 		RuntimeInstanceID: runtimeInstanceID,
 		Transport:         localContextTransportTCP,
 		APIServer:         apiServer,
-		Auth:              localContextDescriptorAuth{Mode: localContextAuthBuiltinLoopback},
+		Auth:              auth,
 		ProjectRoot:       r.project.canonicalProjectRoot,
 		ContractsPath:     strings.TrimSpace(resolvedPaths.ContractsPath),
 		StorePath:         serveDescriptorStorePath(storeSelection),

--- a/cmd/swarm/serve_context_registration_test.go
+++ b/cmd/swarm/serve_context_registration_test.go
@@ -172,11 +172,59 @@ func TestServeProjectContextRegistrationRejectsUnsafeAuthDescriptor(t *testing.T
 	defer listener.Close()
 	err = reg.WriteFinal("runtime-1", listener.Addr(), apiv1.AuthTokenResolution{
 		Tokens:   []string{"secret"},
-		Source:   apiv1.AuthTokenSourceEnvironment,
+		Source:   apiv1.AuthTokenSource("explicit-without-token-file"),
 		Explicit: true,
 	}, cliContractPlatformSpecPaths{ContractsPath: project.contracts}, storebackend.Selection{Backend: storebackend.BackendSQLite}, workspaceMountSources{})
-	if err == nil || !strings.Contains(err.Error(), "cannot be snapshotted") {
+	if err == nil || !strings.Contains(err.Error(), "requires token-file auth") {
 		t.Fatalf("WriteFinal err = %v, want safe-auth rejection", err)
+	}
+}
+
+func TestServeProjectContextRegistrationWritesTokenFileAuthDescriptor(t *testing.T) {
+	isolateCLIAPIConfigEnv(t)
+	project := writeCLIAPIProjectFixture(t)
+	swarmDir := t.TempDir()
+	opts := defaultServeOptions()
+	opts.Dev = true
+	opts.SwarmDir = swarmDir
+	opts.SwarmDirSet = true
+	reg, err := prepareServeProjectContextRegistration(context.Background(), project.root, opts, cliContractPlatformSpecPaths{ContractsPath: project.contracts})
+	if err != nil {
+		t.Fatalf("prepare registration: %v", err)
+	}
+	defer reg.Release()
+	listener := listenLoopbackTestListener(t)
+	defer listener.Close()
+	tokenFile := writeCLIAPITokenFile(t, "serve-secret")
+	err = reg.WriteFinal("runtime-1", listener.Addr(), apiv1.AuthTokenResolution{
+		Tokens:    []string{"serve-secret"},
+		Source:    apiv1.AuthTokenSource(serveAPITokenFileFlagSource),
+		Explicit:  true,
+		TokenFile: tokenFile,
+	}, cliContractPlatformSpecPaths{ContractsPath: project.contracts}, storebackend.Selection{Backend: storebackend.BackendSQLite}, workspaceMountSources{})
+	if err != nil {
+		t.Fatalf("WriteFinal: %v", err)
+	}
+
+	registry := newLocalContextRegistry(swarmDir)
+	entry, err := registry.ReadDescriptor(localProjectContextName(project.canonicalRoot))
+	if err != nil {
+		t.Fatalf("read descriptor: %v", err)
+	}
+	desc := entry.Descriptor
+	if desc.Auth.Mode != localContextAuthTokenFile || desc.Auth.TokenFile != tokenFile {
+		t.Fatalf("descriptor auth = %#v, want token_file %q", desc.Auth, tokenFile)
+	}
+	rpcEndpoint, err := cliAPIRPCEndpointFromServer(desc.APIServer, "descriptor api_server")
+	if err != nil {
+		t.Fatalf("rpc endpoint: %v", err)
+	}
+	token, err := localContextDescriptorToken(desc, rpcEndpoint)
+	if err != nil {
+		t.Fatalf("descriptor token: %v", err)
+	}
+	if token != "serve-secret" {
+		t.Fatalf("descriptor token = %q, want serve-secret", token)
 	}
 }
 

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -11,3 +11,4 @@
 # platform_spec_path: ./platform-spec.yaml
 # serve_api_listen_addr: 127.0.0.1:8081
 # serve_mcp_listen_addr: 127.0.0.1:8082
+# serve_api_token_file: /path/to/serve-api-token

--- a/internal/apiv1/handler.go
+++ b/internal/apiv1/handler.go
@@ -11,7 +11,6 @@ import (
 	"io"
 	"net/http"
 	"net/netip"
-	"os"
 	"regexp"
 	"strconv"
 	"strings"
@@ -37,21 +36,20 @@ const (
 )
 
 const (
-	DefaultLoopbackAPIToken        = "swarm-dev-loopback-api-token"
-	DefaultLoopbackAPITokenWarning = "using built-in dev API token on loopback; set SWARM_API_TOKEN before exposing"
+	DefaultLoopbackAPIToken = "swarm-dev-loopback-api-token"
 )
 
 type AuthTokenSource string
 
 const (
-	AuthTokenSourceEnvironment          AuthTokenSource = "SWARM_API_TOKEN"
 	AuthTokenSourceBuiltInLoopbackToken AuthTokenSource = "built-in-loopback-default"
 )
 
 type AuthTokenResolution struct {
-	Tokens   []string
-	Source   AuthTokenSource
-	Explicit bool
+	Tokens    []string
+	Source    AuthTokenSource
+	Explicit  bool
+	TokenFile string
 }
 
 func (r AuthTokenResolution) UsesDefaultLoopbackToken() bool {
@@ -152,25 +150,6 @@ func NewHandler(opts Options) (*Handler, error) {
 		upgrader: websocket.Upgrader{CheckOrigin: func(*http.Request) bool { return true }},
 		subs:     opts.Subscriptions.withDefaults(),
 	}, nil
-}
-
-func AuthTokensFromEnvironment() []string {
-	return ResolveAuthTokensFromEnvironment().Tokens
-}
-
-func ResolveAuthTokensFromEnvironment() AuthTokenResolution {
-	value := strings.TrimSpace(os.Getenv("SWARM_API_TOKEN"))
-	if value != "" {
-		return AuthTokenResolution{
-			Tokens:   []string{value},
-			Source:   AuthTokenSourceEnvironment,
-			Explicit: true,
-		}
-	}
-	return AuthTokenResolution{
-		Tokens: []string{DefaultLoopbackAPIToken},
-		Source: AuthTokenSourceBuiltInLoopbackToken,
-	}
 }
 
 func DefaultLoopbackAPITokenAllowedHost(host string) bool {

--- a/internal/apiv1/handler_test.go
+++ b/internal/apiv1/handler_test.go
@@ -65,30 +65,6 @@ func TestNewHandlerRejectsHandlersOutsideCanonicalCatalog(t *testing.T) {
 	}
 }
 
-func TestAuthTokensFromEnvironmentUsesOnlyUnifiedToken(t *testing.T) {
-	t.Setenv("SWARM_API_TOKEN", "api")
-	t.Setenv("SWARM_BUILDER_AUTH_TOKEN", "legacy")
-	t.Setenv("SWARM_OPERATOR_AUTH_TOKEN", "operator")
-
-	got := AuthTokensFromEnvironment()
-	want := []string{"api"}
-	if !reflect.DeepEqual(got, want) {
-		t.Fatalf("AuthTokensFromEnvironment() = %v, want %v", got, want)
-	}
-}
-
-func TestResolveAuthTokensFromEnvironmentDefaultsToLoopbackToken(t *testing.T) {
-	t.Setenv("SWARM_API_TOKEN", "")
-	resolution := ResolveAuthTokensFromEnvironment()
-	if !resolution.UsesDefaultLoopbackToken() {
-		t.Fatalf("resolution = %#v, want default loopback token", resolution)
-	}
-	want := []string{DefaultLoopbackAPIToken}
-	if !reflect.DeepEqual(resolution.Tokens, want) {
-		t.Fatalf("tokens = %v, want %v", resolution.Tokens, want)
-	}
-}
-
 func TestDefaultLoopbackAPITokenAllowedHost(t *testing.T) {
 	for _, host := range []string{"127.0.0.1", "127.42.0.7", "::1", "[::1]"} {
 		if !DefaultLoopbackAPITokenAllowedHost(host) {
@@ -107,7 +83,7 @@ func TestLegacyEnvironmentTokensDoNotAuthorizeV1Transports(t *testing.T) {
 	t.Setenv("SWARM_BUILDER_AUTH_TOKEN", "legacy-builder")
 	t.Setenv("SWARM_OPERATOR_AUTH_TOKEN", "legacy-operator")
 
-	handler := testHandler(t, Options{AuthTokens: AuthTokensFromEnvironment()})
+	handler := testHandler(t, Options{AuthTokens: []string{DefaultLoopbackAPIToken}})
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodPost, "/v1/rpc", strings.NewReader(`{"jsonrpc":"2.0","id":"auth","method":"rpc.unsubscribe","params":{"subscription_id":"sub-1"}}`))
 	req.Header.Set("Authorization", "Bearer legacy-builder")

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -12527,6 +12527,11 @@ cli_specification:
             Accepted by the shared CLI config parser for
             cli_specification.command_catalog.serve.listener_topology_v2_1.source_precedence; ignored by the API
             connection and auth resolver.
+          serve_api_token_file: >
+            Accepted by the shared CLI config parser for
+            cli_specification.command_catalog.serve.listener_topology_v2_1.source_precedence.server_api_auth; ignored
+            by the API connection and auth resolver. This key is server-side `swarm serve` auth only and MUST NOT be
+            consumed as client API auth.
         rejected_keys:
           api_token: Inline bearer tokens in config files are not promoted.
           output_format: Split to #848 output renderer implementation.
@@ -12946,7 +12951,8 @@ cli_specification:
         promoted_by: '#884'
         runtime_bind_implemented_by: '#992'
         env_config_precedence_implemented_by: '#844'
-        implementation_status: runtime_bind_and_env_config_precedence_implemented_enable_disable_pending
+        server_api_auth_implemented_by: '#1647'
+        implementation_status: runtime_bind_env_config_and_server_api_auth_implemented_enable_disable_pending
         canonical_owner: platform-spec.yaml#cli_specification.command_catalog.serve.listener_topology_v2_1
         summary: >
           Final CLI v2.1 `swarm serve` topology uses two independently configurable HTTP listeners: one API
@@ -13025,6 +13031,31 @@ cli_specification:
             environment: SWARM_MCP_LISTEN_ADDR
             config_key: serve_mcp_listen_addr
             built_in_default: 127.0.0.1:8082
+          server_api_auth:
+            accepted_sources:
+              flag_file: --api-token-file <path>
+              config_file_key: serve_api_token_file
+              built_in_loopback_default: built-in-loopback-default
+            source_order:
+            - --api-token-file
+            - config serve_api_token_file
+            - built-in loopback default
+            rejected_sources:
+              SWARM_API_TOKEN: >
+                Removed as a server-side `swarm serve` API auth source by #1647. Raw env is hidden mutable token
+                authority; use `swarm serve --api-token-file` or config `serve_api_token_file`.
+              SWARM_API_TOKEN_FILE: >
+                Not promoted as a server-side `swarm serve` API auth source. Use `swarm serve --api-token-file` or
+                config `serve_api_token_file`.
+              config api_token_file: >
+                Client-side API auth only, governed by
+                cli_specification.foundations.api_connection_auth_config_precedence. Server-side `swarm serve` auth
+                uses config `serve_api_token_file` to avoid client/server source ownership ambiguity.
+              config api_token: >
+                Not promoted. Inline bearer tokens in config files leak secret material into durable plaintext config.
+            token_file_rule: >
+              Token-file sources are read once during `swarm serve` startup. Missing, unreadable, or blank token-file
+              contents fail closed and MUST NOT fall back to the built-in loopback default.
           cli_config_file:
             accepted_sources:
             - SWARM_CONFIG
@@ -13038,9 +13069,9 @@ cli_specification:
             Values from flags, environment, and CLI config MUST use the host:port address_format above and
             fail before runtime startup if invalid.
           api_auth_coupling_rule: >
-            If no explicit `SWARM_API_TOKEN` is configured for `swarm serve`, the API listener may start only when
+            If no explicit token-file source is configured for `swarm serve`, the API listener may start only when
             its host is numeric loopback (`127.0.0.0/8` or `::1`). `localhost`, wildcard, empty, routable IP, and
-            DNS hosts require an explicit `SWARM_API_TOKEN`. The built-in API token is never valid for a
+            DNS hosts require `swarm serve --api-token-file` or config `serve_api_token_file`. The built-in API token is never valid for a
             non-loopback API listener. This rule applies to the API listener only; MCP listener and tool-gateway
             tokens remain owned by local_cli_test_gateway_startup.
           rejected_sources:
@@ -13072,7 +13103,8 @@ cli_specification:
             rule: >
               If the API listener would use the built-in loopback default token on a non-loopback host,
               `swarm serve` MUST fail closed before readiness with a diagnostic naming that non-loopback API binds
-              require explicit `SWARM_API_TOKEN`.
+              require `--api-token-file` or config `serve_api_token_file`. Raw `SWARM_API_TOKEN` MUST NOT satisfy this
+              requirement.
         flag_disposition:
           --health-addr:
             disposition: retired_final_v2_1_name_current_migration_evidence


### PR DESCRIPTION
Closes #1647
Part of #1600

## Summary

- Moves server-side `swarm serve` API auth authority from raw `SWARM_API_TOKEN` env to explicit token-file sources.
- Adds `swarm serve --api-token-file` and config `serve_api_token_file` with source order `--api-token-file` > `serve_api_token_file` > built-in loopback default.
- Keeps client `api_token_file` distinct from server `serve_api_token_file`, and updates local context descriptor writes for `auth.mode=token_file`.
- Updates `platform-spec.yaml` to make the new server-auth source authority authoritative.

## Governing refs / context

Exact spec refs updated in this PR:

- `platform-spec.yaml#cli_specification.command_catalog.serve.listener_topology_v2_1.source_precedence.server_api_auth`
- `platform-spec.yaml#cli_specification.command_catalog.serve.listener_topology_v2_1.source_precedence.api_auth_coupling_rule`
- `platform-spec.yaml#cli_specification.command_catalog.serve.listener_topology_v2_1.interaction_rules.api_default_token_exposure`
- `platform-spec.yaml#cli_specification.foundations.local_context_registry_authority`
- `platform-spec.yaml#cli_specification.foundations.api_connection_auth_config_precedence`

Binding issue/gate context:

- #1647 pre-audit and gate approval: server-side `swarm serve` API bearer-token authority only.
- #1600 remains open for sibling env/source-authority families.

## Semantic migration

New canonical owner:

- Serve server-auth resolver in `cmd/swarm`, backed by the `platform-spec.yaml` server-auth contract.
- Local context descriptor auth remains the persisted binding owner for runtime/client consumption.

Old producer / reader / writer path now invalid:

- `SWARM_API_TOKEN` as production server-side `swarm serve` auth source.
- `internal/apiv1.ResolveAuthTokensFromEnvironment`, `AuthTokensFromEnvironment`, `AuthTokenSourceEnvironment`, and `DefaultLoopbackAPITokenWarning`.
- Serve diagnostics/spec text that told operators to expose APIs with `SWARM_API_TOKEN`.

Production paths checked for surviving old behavior:

- `runServeRuntime`, `validateServeAPIAuthBinding`, `apiv1.NewHandler`, `serve_context_registration.WriteFinal`, local context registry consumption, CLI config parsing, platform-spec source-authority tests.
- Production grep leaves no old env auth resolver symbols. The only remaining production `SWARM_API_TOKEN` read is the fail-closed rejection path.

Migration completeness:

- Complete for #1647 chosen class: raw env is no longer a supported server-side `swarm serve` API auth source.
- Parent #1600 remains open for provider credentials, tool-gateway token, workspace/bootstrap/debug envs, and DB password ownership.

## Proof

- `go test ./cmd/swarm ./internal/apiv1`
- `go test ./...`
- `git diff --check`
- `rg -n 'AuthTokenSourceEnvironment|ResolveAuthTokensFromEnvironment|AuthTokensFromEnvironment|DefaultLoopbackAPITokenWarning' cmd internal platform-spec.yaml` returned no matches.
- `rg -n 'os\.(Getenv|LookupEnv)\("SWARM_API_TOKEN"' cmd internal --glob '!**/*_test.go'` returns only the fail-closed removal diagnostic path.