### PR TITLE
[agent-c][issue #1664] Record deterministic work ladder Stage 0 gates

### DIFF
--- a/internal/runtime/conformance/deterministic_work_ladder_stage0_test.go
+++ b/internal/runtime/conformance/deterministic_work_ladder_stage0_test.go
@@ -1,0 +1,466 @@
+package conformance
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+const deterministicWorkLadderStage0Path = "internal/runtime/conformance/testdata/deterministic_work_ladder_stage0.yaml"
+
+type deterministicWorkLadderStage0 struct {
+	Version              int                                      `yaml:"version"`
+	Kind                 string                                   `yaml:"kind"`
+	Issue                int                                      `yaml:"issue"`
+	ParentIssue          int                                      `yaml:"parent_issue"`
+	Discussion           int                                      `yaml:"discussion"`
+	SourceBoundary       deterministicWorkLadderSourceBoundary    `yaml:"source_boundary"`
+	Policy               deterministicWorkLadderPolicy            `yaml:"policy"`
+	WatchlistNode        deterministicWorkLadderWatchlist         `yaml:"watchlist_node"`
+	ClassificationValues []string                                 `yaml:"classification_values"`
+	MeasurementPolicy    deterministicWorkLadderMeasurementPolicy `yaml:"measurement_policy"`
+	EvidenceMatrix       []deterministicWorkLadderEvidenceRow     `yaml:"evidence_matrix"`
+	GateCriteria         []deterministicWorkLadderGate            `yaml:"gate_criteria"`
+}
+
+type deterministicWorkLadderSourceBoundary struct {
+	PlatformSpec           string `yaml:"platform_spec"`
+	PreAuditComment        string `yaml:"pre_audit_comment"`
+	GateComment            string `yaml:"gate_comment"`
+	LockedDesignDiscussion string `yaml:"locked_design_discussion"`
+	EmpireEvidenceRoot     string `yaml:"empire_evidence_root"`
+}
+
+type deterministicWorkLadderPolicy struct {
+	ClosureLevel                  string `yaml:"closure_level"`
+	ClaimsParentClosure           bool   `yaml:"claims_parent_closure"`
+	ClaimsRuntimeBehaviorClosure  bool   `yaml:"claims_runtime_behavior_closure"`
+	RuntimeBehaviorChangesAllowed bool   `yaml:"runtime_behavior_changes_allowed"`
+	PlatformSpecChangesAllowed    bool   `yaml:"platform_spec_changes_allowed"`
+	RuntimeSemanticOwner          string `yaml:"runtime_semantic_owner"`
+	Stage0Owner                   string `yaml:"stage0_owner"`
+	NextAfterStage1               string `yaml:"next_after_stage1"`
+	OrderingBasis                 string `yaml:"ordering_basis"`
+	OrderingDecision              string `yaml:"ordering_decision"`
+}
+
+type deterministicWorkLadderWatchlist struct {
+	ID                   string                                 `yaml:"id"`
+	Status               string                                 `yaml:"status"`
+	PrivateWatchlistNote string                                 `yaml:"private_watchlist_note"`
+	BroaderClass         string                                 `yaml:"broader_class"`
+	NonClosureRule       string                                 `yaml:"non_closure_rule"`
+	ActiveTrackers       []deterministicWorkLadderActiveTracker `yaml:"active_trackers"`
+}
+
+type deterministicWorkLadderActiveTracker struct {
+	Issue     int    `yaml:"issue"`
+	Role      string `yaml:"role"`
+	Watchlist string `yaml:"watchlist"`
+}
+
+type deterministicWorkLadderMeasurementPolicy struct {
+	RoughEstimatesAllowed    bool     `yaml:"rough_estimates_allowed"`
+	AllowedStatuses          []string `yaml:"allowed_statuses"`
+	DefaultUnavailableReason string   `yaml:"default_unavailable_reason"`
+}
+
+type deterministicWorkLadderEvidenceRow struct {
+	InventoryID    int                                   `yaml:"inventory_id"`
+	DedupeGroup    string                                `yaml:"dedupe_group"`
+	Title          string                                `yaml:"title"`
+	Classification string                                `yaml:"classification"`
+	Disposition    string                                `yaml:"disposition"`
+	DuplicateOf    int                                   `yaml:"duplicate_of"`
+	ConsumerIssue  int                                   `yaml:"consumer_issue"`
+	ProofRefs      []string                              `yaml:"proof_refs"`
+	MetricEvidence deterministicWorkLadderMetricEvidence `yaml:"metric_evidence"`
+	Notes          string                                `yaml:"notes"`
+}
+
+type deterministicWorkLadderMetricEvidence struct {
+	Status string `yaml:"status"`
+	Reason string `yaml:"reason"`
+}
+
+type deterministicWorkLadderGate struct {
+	ID                  string   `yaml:"id"`
+	ConsumerIssue       int      `yaml:"consumer_issue"`
+	PromotionState      string   `yaml:"promotion_state"`
+	RequiredConditions  []string `yaml:"required_conditions"`
+	BlockingConditions  []string `yaml:"blocking_conditions"`
+	CurrentMatrixResult string   `yaml:"current_matrix_result"`
+}
+
+func TestDeterministicWorkLadderStage0CoversGateScope(t *testing.T) {
+	root := conformanceRepoRoot(t)
+	artifact := loadDeterministicWorkLadderStage0(t, root)
+	if problems := validateDeterministicWorkLadderStage0(artifact); len(problems) > 0 {
+		t.Fatalf("deterministic work ladder Stage 0 validation failed:\n- %s", strings.Join(problems, "\n- "))
+	}
+}
+
+func TestDeterministicWorkLadderStage0RejectsNarrowOrRuntimeClosure(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(*deterministicWorkLadderStage0)
+		want   string
+	}{
+		{
+			name: "parent closure claim",
+			mutate: func(artifact *deterministicWorkLadderStage0) {
+				artifact.Policy.ClaimsParentClosure = true
+			},
+			want: "policy claims_parent_closure = true, want false",
+		},
+		{
+			name: "runtime behavior claim",
+			mutate: func(artifact *deterministicWorkLadderStage0) {
+				artifact.Policy.ClaimsRuntimeBehaviorClosure = true
+			},
+			want: "policy claims_runtime_behavior_closure = true, want false",
+		},
+		{
+			name: "missing child tracker",
+			mutate: func(artifact *deterministicWorkLadderStage0) {
+				artifact.WatchlistNode.ActiveTrackers = deterministicWorkLadderTrackersExcept(artifact.WatchlistNode.ActiveTrackers, 1671)
+			},
+			want: "watchlist active_trackers missing #1671",
+		},
+		{
+			name: "missing inventory row",
+			mutate: func(artifact *deterministicWorkLadderStage0) {
+				artifact.EvidenceMatrix = deterministicWorkLadderRowsExcept(artifact.EvidenceMatrix, 13)
+			},
+			want: "evidence_matrix missing inventory_id 13",
+		},
+		{
+			name: "rough estimate metric",
+			mutate: func(artifact *deterministicWorkLadderStage0) {
+				row := deterministicWorkLadderRowByID(t, artifact, 1)
+				row.MetricEvidence.Status = "rough_estimate"
+			},
+			want: "inventory_id 1 metric_evidence.status = \"rough_estimate\" is not allowed",
+		},
+		{
+			name: "duplicate loses canonical row",
+			mutate: func(artifact *deterministicWorkLadderStage0) {
+				row := deterministicWorkLadderRowByID(t, artifact, 11)
+				row.DuplicateOf = 0
+			},
+			want: "inventory_id 11 duplicate_of = 0, want 1",
+		},
+		{
+			name: "ordering by intuition",
+			mutate: func(artifact *deterministicWorkLadderStage0) {
+				artifact.Policy.OrderingBasis = "intuition"
+			},
+			want: "policy ordering_basis = \"intuition\", want evidence_matrix",
+		},
+	}
+
+	root := conformanceRepoRoot(t)
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			artifact := loadDeterministicWorkLadderStage0(t, root)
+			tc.mutate(&artifact)
+			problems := validateDeterministicWorkLadderStage0(artifact)
+			if !routeAuthorityProblemsContain(problems, tc.want) {
+				t.Fatalf("validation problems missing %q:\n- %s", tc.want, strings.Join(problems, "\n- "))
+			}
+		})
+	}
+}
+
+func loadDeterministicWorkLadderStage0(t *testing.T, root string) deterministicWorkLadderStage0 {
+	t.Helper()
+	raw, err := os.ReadFile(filepath.Join(root, deterministicWorkLadderStage0Path))
+	if err != nil {
+		t.Fatalf("read deterministic work ladder Stage 0 artifact: %v", err)
+	}
+	var artifact deterministicWorkLadderStage0
+	if err := yaml.Unmarshal(raw, &artifact); err != nil {
+		t.Fatalf("parse deterministic work ladder Stage 0 artifact: %v", err)
+	}
+	return artifact
+}
+
+func validateDeterministicWorkLadderStage0(artifact deterministicWorkLadderStage0) []string {
+	var problems []string
+
+	if artifact.Version != 1 {
+		problems = append(problems, fmt.Sprintf("version = %d, want 1", artifact.Version))
+	}
+	if artifact.Kind != "deterministic_work_ladder_stage0" {
+		problems = append(problems, fmt.Sprintf("kind = %q, want deterministic_work_ladder_stage0", artifact.Kind))
+	}
+	if artifact.Issue != 1664 {
+		problems = append(problems, fmt.Sprintf("issue = %d, want 1664", artifact.Issue))
+	}
+	if artifact.ParentIssue != 1663 {
+		problems = append(problems, fmt.Sprintf("parent_issue = %d, want 1663", artifact.ParentIssue))
+	}
+	if artifact.Discussion != 1460 {
+		problems = append(problems, fmt.Sprintf("discussion = %d, want 1460", artifact.Discussion))
+	}
+
+	if artifact.SourceBoundary.PlatformSpec != "platform-spec.yaml" {
+		problems = append(problems, fmt.Sprintf("source_boundary platform_spec = %q, want platform-spec.yaml", artifact.SourceBoundary.PlatformSpec))
+	}
+	if artifact.SourceBoundary.PreAuditComment == "" {
+		problems = append(problems, "source_boundary pre_audit_comment missing")
+	}
+	if artifact.SourceBoundary.GateComment == "" {
+		problems = append(problems, "source_boundary gate_comment missing")
+	}
+	if strings.Contains(artifact.SourceBoundary.EmpireEvidenceRoot, "/Users/") {
+		problems = append(problems, "source_boundary empire_evidence_root must not use an absolute local path")
+	}
+
+	if artifact.Policy.ClaimsParentClosure {
+		problems = append(problems, "policy claims_parent_closure = true, want false")
+	}
+	if artifact.Policy.ClaimsRuntimeBehaviorClosure {
+		problems = append(problems, "policy claims_runtime_behavior_closure = true, want false")
+	}
+	if artifact.Policy.RuntimeBehaviorChangesAllowed {
+		problems = append(problems, "policy runtime_behavior_changes_allowed = true, want false")
+	}
+	if artifact.Policy.PlatformSpecChangesAllowed {
+		problems = append(problems, "policy platform_spec_changes_allowed = true, want false")
+	}
+	if artifact.Policy.RuntimeSemanticOwner != "platform-spec.yaml" {
+		problems = append(problems, fmt.Sprintf("policy runtime_semantic_owner = %q, want platform-spec.yaml", artifact.Policy.RuntimeSemanticOwner))
+	}
+	if artifact.Policy.Stage0Owner != deterministicWorkLadderStage0Path {
+		problems = append(problems, fmt.Sprintf("policy stage0_owner = %q, want %s", artifact.Policy.Stage0Owner, deterministicWorkLadderStage0Path))
+	}
+	if artifact.Policy.NextAfterStage1 != "declarative_readability_helpers_before_pure_function" {
+		problems = append(problems, fmt.Sprintf("policy next_after_stage1 = %q, want declarative_readability_helpers_before_pure_function", artifact.Policy.NextAfterStage1))
+	}
+	if artifact.Policy.OrderingBasis != "evidence_matrix" {
+		problems = append(problems, fmt.Sprintf("policy ordering_basis = %q, want evidence_matrix", artifact.Policy.OrderingBasis))
+	}
+
+	problems = append(problems, validateDeterministicWorkLadderWatchlist(artifact.WatchlistNode)...)
+	problems = append(problems, validateDeterministicWorkLadderEvidence(artifact)...)
+	problems = append(problems, validateDeterministicWorkLadderGates(artifact.GateCriteria)...)
+
+	return problems
+}
+
+func validateDeterministicWorkLadderWatchlist(watchlist deterministicWorkLadderWatchlist) []string {
+	var problems []string
+	const wantNode = "runtime_operations.deterministic_work_ladder"
+	if watchlist.ID != wantNode {
+		problems = append(problems, fmt.Sprintf("watchlist id = %q, want %s", watchlist.ID, wantNode))
+	}
+	if !strings.Contains(watchlist.NonClosureRule, "#1663") || !strings.Contains(watchlist.NonClosureRule, "must remain open") {
+		problems = append(problems, "watchlist non_closure_rule must keep #1663 open")
+	}
+
+	trackers := map[int]deterministicWorkLadderActiveTracker{}
+	for _, tracker := range watchlist.ActiveTrackers {
+		if tracker.Watchlist != wantNode {
+			problems = append(problems, fmt.Sprintf("watchlist active tracker #%d watchlist = %q, want %s", tracker.Issue, tracker.Watchlist, wantNode))
+		}
+		if tracker.Role == "" {
+			problems = append(problems, fmt.Sprintf("watchlist active tracker #%d missing role", tracker.Issue))
+		}
+		trackers[tracker.Issue] = tracker
+	}
+	for issue := 1663; issue <= 1672; issue++ {
+		if _, ok := trackers[issue]; !ok {
+			problems = append(problems, fmt.Sprintf("watchlist active_trackers missing #%d", issue))
+		}
+	}
+	return problems
+}
+
+func validateDeterministicWorkLadderEvidence(artifact deterministicWorkLadderStage0) []string {
+	var problems []string
+	allowedClassifications := stringSet(artifact.ClassificationValues)
+	allowedMetricStatuses := stringSet(artifact.MeasurementPolicy.AllowedStatuses)
+	if artifact.MeasurementPolicy.RoughEstimatesAllowed {
+		problems = append(problems, "measurement_policy rough_estimates_allowed = true, want false")
+	}
+
+	rows := map[int]deterministicWorkLadderEvidenceRow{}
+	for _, row := range artifact.EvidenceMatrix {
+		if _, ok := rows[row.InventoryID]; ok {
+			problems = append(problems, fmt.Sprintf("evidence_matrix inventory_id %d appears more than once", row.InventoryID))
+		}
+		rows[row.InventoryID] = row
+		if row.DedupeGroup == "" {
+			problems = append(problems, fmt.Sprintf("inventory_id %d missing dedupe_group", row.InventoryID))
+		}
+		if row.Title == "" {
+			problems = append(problems, fmt.Sprintf("inventory_id %d missing title", row.InventoryID))
+		}
+		if !allowedClassifications[row.Classification] {
+			problems = append(problems, fmt.Sprintf("inventory_id %d classification = %q is not allowed", row.InventoryID, row.Classification))
+		}
+		if row.ConsumerIssue == 0 {
+			problems = append(problems, fmt.Sprintf("inventory_id %d missing consumer_issue", row.InventoryID))
+		}
+		if len(row.ProofRefs) == 0 {
+			problems = append(problems, fmt.Sprintf("inventory_id %d missing proof_refs", row.InventoryID))
+		}
+		for _, ref := range row.ProofRefs {
+			if strings.Contains(ref, "/Users/") {
+				problems = append(problems, fmt.Sprintf("inventory_id %d proof_ref %q must not use an absolute local path", row.InventoryID, ref))
+			}
+		}
+		if !allowedMetricStatuses[row.MetricEvidence.Status] {
+			problems = append(problems, fmt.Sprintf("inventory_id %d metric_evidence.status = %q is not allowed", row.InventoryID, row.MetricEvidence.Status))
+		}
+		if row.MetricEvidence.Status == "unavailable" && row.MetricEvidence.Reason == "" {
+			problems = append(problems, fmt.Sprintf("inventory_id %d unavailable metric missing reason", row.InventoryID))
+		}
+		if strings.Contains(strings.ToLower(row.MetricEvidence.Status), "rough") {
+			problems = append(problems, fmt.Sprintf("inventory_id %d metric_evidence.status = %q is not allowed", row.InventoryID, row.MetricEvidence.Status))
+		}
+	}
+	for id := 1; id <= 16; id++ {
+		if _, ok := rows[id]; !ok {
+			problems = append(problems, fmt.Sprintf("evidence_matrix missing inventory_id %d", id))
+		}
+	}
+
+	problems = append(problems, requireDuplicateRow(rows, 11, 1)...)
+	problems = append(problems, requireDuplicateRow(rows, 12, 5)...)
+	problems = append(problems, requireDispositionContains(rows, 4, "planned_refactor")...)
+	problems = append(problems, requireDispositionContains(rows, 15, "draft_only")...)
+	problems = append(problems, requireDispositionContains(rows, 16, "architecture_not_node_shape")...)
+
+	helperRows := 0
+	durableRows := 0
+	pureFunctionRows := 0
+	for _, row := range rows {
+		switch row.Classification {
+		case "declarative_readability_helper":
+			helperRows++
+		case "durable_activity":
+			durableRows++
+		case "pure_function_compute_module":
+			pureFunctionRows++
+		}
+	}
+	if helperRows < 5 {
+		problems = append(problems, fmt.Sprintf("helper evidence rows = %d, want at least 5 for post-Stage-1 ordering", helperRows))
+	}
+	if durableRows < 2 {
+		problems = append(problems, fmt.Sprintf("durable activity evidence rows = %d, want at least 2", durableRows))
+	}
+	if pureFunctionRows != 0 && artifact.Policy.NextAfterStage1 == "declarative_readability_helpers_before_pure_function" && !strings.Contains(artifact.Policy.OrderingDecision, "contrary evidence") {
+		problems = append(problems, "pure function rows present but ordering decision does not explain why helpers still come first")
+	}
+
+	return problems
+}
+
+func validateDeterministicWorkLadderGates(gates []deterministicWorkLadderGate) []string {
+	var problems []string
+	byID := map[string]deterministicWorkLadderGate{}
+	for _, gate := range gates {
+		byID[gate.ID] = gate
+		if gate.ConsumerIssue == 0 {
+			problems = append(problems, fmt.Sprintf("gate %s missing consumer_issue", gate.ID))
+		}
+		if gate.PromotionState == "" {
+			problems = append(problems, fmt.Sprintf("gate %s missing promotion_state", gate.ID))
+		}
+		if len(gate.RequiredConditions) == 0 {
+			problems = append(problems, fmt.Sprintf("gate %s missing required_conditions", gate.ID))
+		}
+	}
+	required := map[string]int{
+		"stage1_durable_activity_proof":    1666,
+		"stage2_stage3_ordering":           1668,
+		"orchestration_function_promotion": 1671,
+	}
+	for id, issue := range required {
+		gate, ok := byID[id]
+		if !ok {
+			problems = append(problems, fmt.Sprintf("gate_criteria missing %s", id))
+			continue
+		}
+		if gate.ConsumerIssue != issue {
+			problems = append(problems, fmt.Sprintf("gate %s consumer_issue = %d, want %d", id, gate.ConsumerIssue, issue))
+		}
+	}
+	stage2 := byID["stage2_stage3_ordering"]
+	if stage2.PromotionState != "declarative_helpers_before_pure_function" {
+		problems = append(problems, fmt.Sprintf("gate stage2_stage3_ordering promotion_state = %q, want declarative_helpers_before_pure_function", stage2.PromotionState))
+	}
+	return problems
+}
+
+func requireDuplicateRow(rows map[int]deterministicWorkLadderEvidenceRow, id, duplicateOf int) []string {
+	row, ok := rows[id]
+	if !ok {
+		return nil
+	}
+	var problems []string
+	if row.DuplicateOf != duplicateOf {
+		problems = append(problems, fmt.Sprintf("inventory_id %d duplicate_of = %d, want %d", id, row.DuplicateOf, duplicateOf))
+	}
+	if !strings.Contains(row.Disposition, "duplicate") {
+		problems = append(problems, fmt.Sprintf("inventory_id %d disposition = %q, want duplicate disposition", id, row.Disposition))
+	}
+	return problems
+}
+
+func requireDispositionContains(rows map[int]deterministicWorkLadderEvidenceRow, id int, want string) []string {
+	row, ok := rows[id]
+	if !ok {
+		return nil
+	}
+	if !strings.Contains(row.Disposition, want) {
+		return []string{fmt.Sprintf("inventory_id %d disposition = %q, want to contain %q", id, row.Disposition, want)}
+	}
+	return nil
+}
+
+func deterministicWorkLadderRowByID(t *testing.T, artifact *deterministicWorkLadderStage0, id int) *deterministicWorkLadderEvidenceRow {
+	t.Helper()
+	for i := range artifact.EvidenceMatrix {
+		if artifact.EvidenceMatrix[i].InventoryID == id {
+			return &artifact.EvidenceMatrix[i]
+		}
+	}
+	t.Fatalf("inventory_id %d not found", id)
+	return nil
+}
+
+func deterministicWorkLadderRowsExcept(rows []deterministicWorkLadderEvidenceRow, id int) []deterministicWorkLadderEvidenceRow {
+	out := rows[:0]
+	for _, row := range rows {
+		if row.InventoryID != id {
+			out = append(out, row)
+		}
+	}
+	return out
+}
+
+func deterministicWorkLadderTrackersExcept(trackers []deterministicWorkLadderActiveTracker, issue int) []deterministicWorkLadderActiveTracker {
+	out := trackers[:0]
+	for _, tracker := range trackers {
+		if tracker.Issue != issue {
+			out = append(out, tracker)
+		}
+	}
+	return out
+}
+
+func stringSet(values []string) map[string]bool {
+	out := make(map[string]bool, len(values))
+	for _, value := range values {
+		out[value] = true
+	}
+	return out
+}

--- a/internal/runtime/conformance/deterministic_work_ladder_stage0_test.go
+++ b/internal/runtime/conformance/deterministic_work_ladder_stage0_test.go
@@ -147,6 +147,15 @@ func TestDeterministicWorkLadderStage0RejectsNarrowOrRuntimeClosure(t *testing.T
 			want: "inventory_id 1 metric_evidence.status = \"rough_estimate\" is not allowed",
 		},
 		{
+			name: "self-authorized metric status",
+			mutate: func(artifact *deterministicWorkLadderStage0) {
+				artifact.MeasurementPolicy.AllowedStatuses = append(artifact.MeasurementPolicy.AllowedStatuses, "estimated")
+				row := deterministicWorkLadderRowByID(t, artifact, 1)
+				row.MetricEvidence.Status = "estimated"
+			},
+			want: "measurement_policy allowed_statuses must exactly equal measured, unavailable, not_applicable",
+		},
+		{
 			name: "duplicate loses canonical row",
 			mutate: func(artifact *deterministicWorkLadderStage0) {
 				row := deterministicWorkLadderRowByID(t, artifact, 11)
@@ -160,6 +169,14 @@ func TestDeterministicWorkLadderStage0RejectsNarrowOrRuntimeClosure(t *testing.T
 				artifact.Policy.OrderingBasis = "intuition"
 			},
 			want: "policy ordering_basis = \"intuition\", want evidence_matrix",
+		},
+		{
+			name: "pure function row under helper-first decision",
+			mutate: func(artifact *deterministicWorkLadderStage0) {
+				row := deterministicWorkLadderRowByID(t, artifact, 13)
+				row.Classification = "pure_function_compute_module"
+			},
+			want: "pure function rows = 1, want 0 while next_after_stage1 is declarative_readability_helpers_before_pure_function",
 		},
 	}
 
@@ -284,7 +301,14 @@ func validateDeterministicWorkLadderWatchlist(watchlist deterministicWorkLadderW
 func validateDeterministicWorkLadderEvidence(artifact deterministicWorkLadderStage0) []string {
 	var problems []string
 	allowedClassifications := stringSet(artifact.ClassificationValues)
-	allowedMetricStatuses := stringSet(artifact.MeasurementPolicy.AllowedStatuses)
+	allowedMetricStatuses := map[string]bool{
+		"measured":       true,
+		"unavailable":    true,
+		"not_applicable": true,
+	}
+	if !sameStringSet(artifact.MeasurementPolicy.AllowedStatuses, allowedMetricStatuses) {
+		problems = append(problems, "measurement_policy allowed_statuses must exactly equal measured, unavailable, not_applicable")
+	}
 	if artifact.MeasurementPolicy.RoughEstimatesAllowed {
 		problems = append(problems, "measurement_policy rough_estimates_allowed = true, want false")
 	}
@@ -356,8 +380,8 @@ func validateDeterministicWorkLadderEvidence(artifact deterministicWorkLadderSta
 	if durableRows < 2 {
 		problems = append(problems, fmt.Sprintf("durable activity evidence rows = %d, want at least 2", durableRows))
 	}
-	if pureFunctionRows != 0 && artifact.Policy.NextAfterStage1 == "declarative_readability_helpers_before_pure_function" && !strings.Contains(artifact.Policy.OrderingDecision, "contrary evidence") {
-		problems = append(problems, "pure function rows present but ordering decision does not explain why helpers still come first")
+	if pureFunctionRows != 0 && artifact.Policy.NextAfterStage1 == "declarative_readability_helpers_before_pure_function" {
+		problems = append(problems, fmt.Sprintf("pure function rows = %d, want 0 while next_after_stage1 is declarative_readability_helpers_before_pure_function", pureFunctionRows))
 	}
 
 	return problems
@@ -463,4 +487,16 @@ func stringSet(values []string) map[string]bool {
 		out[value] = true
 	}
 	return out
+}
+
+func sameStringSet(values []string, want map[string]bool) bool {
+	if len(values) != len(want) {
+		return false
+	}
+	for _, value := range values {
+		if !want[value] {
+			return false
+		}
+	}
+	return true
 }

--- a/internal/runtime/conformance/testdata/deterministic_work_ladder_stage0.yaml
+++ b/internal/runtime/conformance/testdata/deterministic_work_ladder_stage0.yaml
@@ -1,0 +1,399 @@
+version: 1
+kind: deterministic_work_ladder_stage0
+issue: 1664
+parent_issue: 1663
+discussion: 1460
+source_boundary:
+  platform_spec: platform-spec.yaml
+  pre_audit_comment: https://github.com/division-sh/swarm/issues/1664#issuecomment-4880202522
+  gate_comment: https://github.com/division-sh/swarm/issues/1664#issuecomment-4880229413
+  locked_design_discussion: https://github.com/division-sh/swarm/discussions/1460
+  empire_evidence_root: external:empire
+policy:
+  closure_level: stage0_evidence_gate_watchlist_owner_complete
+  claims_parent_closure: false
+  claims_runtime_behavior_closure: false
+  runtime_behavior_changes_allowed: false
+  platform_spec_changes_allowed: false
+  runtime_semantic_owner: platform-spec.yaml
+  stage0_owner: internal/runtime/conformance/testdata/deterministic_work_ladder_stage0.yaml
+  next_after_stage1: declarative_readability_helpers_before_pure_function
+  ordering_basis: evidence_matrix
+  ordering_decision: >
+    Stage 1 durable activity remains first because #1663/#1666 already own the
+    approved first runtime slice. After Stage 1, the current Empire inventory
+    has multiple live no-I/O readability/helper candidates and no live pure-code
+    candidate that is not already covered by existing declarative compute or
+    better classified as helper work. Therefore #1668 should run before #1669
+    unless a later Stage 0 refresh produces measured contrary evidence.
+watchlist_node:
+  id: runtime_operations.deterministic_work_ladder
+  status: created_in_this_artifact
+  private_watchlist_note: private:swarm-docs/docs/watchlists/runtime-operations.yaml#deterministic_work_ladder
+  broader_class: deterministic work currently leaks into trivial agents, complex CEL, or implicit handler chains.
+  non_closure_rule: >
+    #1663 must remain open after #1664. The parent tracker cannot close until
+    Stage 0 evidence, ADR/design record, durable activities, artifact
+    disposition, declarative helpers or their explicit deferral, pure functions
+    or their explicit deferral, orchestration functions or their explicit
+    deferral, build/CLI, trace/test, and conformance obligations are all closed
+    or superseded with proof.
+  active_trackers:
+    - {issue: 1663, role: parent_tracker, watchlist: runtime_operations.deterministic_work_ladder}
+    - {issue: 1664, role: stage0_evidence_gates, watchlist: runtime_operations.deterministic_work_ladder}
+    - {issue: 1665, role: adr_design_record, watchlist: runtime_operations.deterministic_work_ladder}
+    - {issue: 1666, role: durable_activities, watchlist: runtime_operations.deterministic_work_ladder}
+    - {issue: 1667, role: artifact_repo_commit_disposition, watchlist: runtime_operations.deterministic_work_ladder}
+    - {issue: 1668, role: declarative_helpers, watchlist: runtime_operations.deterministic_work_ladder}
+    - {issue: 1669, role: pure_function_step, watchlist: runtime_operations.deterministic_work_ladder}
+    - {issue: 1670, role: function_build_cli_topology, watchlist: runtime_operations.deterministic_work_ladder}
+    - {issue: 1671, role: orchestration_functions, watchlist: runtime_operations.deterministic_work_ladder}
+    - {issue: 1672, role: trace_test_conformance, watchlist: runtime_operations.deterministic_work_ladder}
+classification_values:
+  - durable_activity
+  - declarative_readability_helper
+  - pure_function_compute_module
+  - orchestration_function
+  - already_covered_or_not_deterministic_work_ladder_issue
+measurement_policy:
+  rough_estimates_allowed: false
+  allowed_statuses: [measured, unavailable, not_applicable]
+  default_unavailable_reason: >
+    No committed Empire runtime trace, cost, token, or latency artifact was
+    found for the specific inventory row. Rough estimates from the design
+    discussion are not carried as evidence.
+evidence_matrix:
+  - inventory_id: 1
+    dedupe_group: repo_scaffold_template_preparation
+    title: repo-scaffold-agent template validator and flow-data reader
+    classification: durable_activity
+    disposition: surviving_stage1_activity_pilot_candidate
+    consumer_issue: 1666
+    proof_refs:
+      - external:empire/contracts/flows/repo-scaffold/prompts/repo-scaffold-agent.md:11
+      - external:empire/contracts/flows/repo-scaffold/prompts/repo-scaffold-agent.md:42
+      - external:empire/contracts/flows/repo-scaffold/agents.yaml:1
+      - external:empire/contracts/flows/repo-scaffold/nodes.yaml:98
+    metric_evidence:
+      status: unavailable
+      reason: no committed trace/cost/latency artifact for repo-scaffold-agent invocations
+    notes: >
+      The live prompt performs exact tuple validation, bounded flow-data reads,
+      and a typed commit-request emit. The tuple lookup remains useful helper
+      evidence, but the row's implementation consumer is Stage 1 durable
+      activity because the author-facing gap is deterministic bounded tool/data
+      access without an LLM turn.
+
+  - inventory_id: 2
+    dedupe_group: lifecycle_marginal_review
+    title: lifecycle-review-agent promote/park/reject classifier
+    classification: already_covered_or_not_deterministic_work_ladder_issue
+    disposition: insufficient_current_deterministic_proof
+    consumer_issue: 1663
+    proof_refs:
+      - external:empire/contracts/flows/lifecycle/prompts/lifecycle-review-agent.md:7
+      - external:empire/contracts/flows/lifecycle/prompts/lifecycle-review-agent.md:23
+      - external:empire/contracts/flows/lifecycle/agents.yaml:1
+    metric_evidence:
+      status: unavailable
+      reason: no committed trace/cost/latency artifact and no exact deterministic policy predicate for strong-enough marginal evidence
+    notes: >
+      The prompt names three fixed output events, but the current evidence still
+      depends on judgment such as whether evidence is strong enough. It should
+      not be counted as a helper/function/activity candidate until a contract
+      predicate or policy table owns that decision.
+
+  - inventory_id: 3
+    dedupe_group: scanner_source_scrape
+    title: scanner-agent source scrape coordinator
+    classification: durable_activity
+    disposition: surviving_stage1_activity_candidate_with_orchestration_watch
+    consumer_issue: 1666
+    proof_refs:
+      - external:empire/contracts/flows/discovery/prompts/scanner-agent.md:1
+      - external:empire/contracts/flows/discovery/prompts/scanner-agent.md:5
+      - external:empire/contracts/flows/discovery/agents.yaml:65
+      - external:empire/contracts/flows/discovery/nodes.yaml:281
+    metric_evidence:
+      status: unavailable
+      reason: no committed trace/cost/latency artifact for scanner-agent invocations
+    notes: >
+      Existing discovery nodes already fan out sources. The live gap is bounded
+      scrape/result work per source; orchestration-function promotion is not
+      justified by this row unless a later matrix proves fan_out plus activities
+      cannot express the flow.
+
+  - inventory_id: 4
+    dedupe_group: holding_devops_resource_router
+    title: holding-devops resource request router planned refactor
+    classification: already_covered_or_not_deterministic_work_ladder_issue
+    disposition: planned_refactor_not_live_stage0_evidence
+    consumer_issue: 1663
+    proof_refs:
+      - external:empire/contracts/flows/holding-devops/agents.yaml:1
+      - external:empire/contracts/flows/holding-devops/agents.yaml:25
+    metric_evidence:
+      status: not_applicable
+      reason: planned/refactor evidence is excluded from live ordering counts
+    notes: >
+      The current contract still names a bounded side-effect executor agent.
+      This row remains parent context, not a live ladder ordering proof.
+
+  - inventory_id: 5
+    dedupe_group: validation_revision_gating
+    title: validation CTO revision-gating rules
+    classification: declarative_readability_helper
+    disposition: surviving_helper_candidate
+    consumer_issue: 1668
+    proof_refs:
+      - external:empire/contracts/flows/validation/nodes.yaml:154
+      - external:empire/contracts/flows/validation/nodes.yaml:222
+      - external:empire/contracts/flows/validation/nodes.yaml:232
+    metric_evidence:
+      status: not_applicable
+      reason: readability/helper evidence uses contract complexity, not runtime cost
+    notes: >
+      This is a live multi-branch state/revision gate. It is helper evidence for
+      switch/FSM-like readability, not pure function evidence, because the
+      behavior is already contract-visible in ordered rules and data writes.
+
+  - inventory_id: 6
+    dedupe_group: holding_devops_manifest_validation
+    title: holding-devops deploy manifest provenance and seed-file validation
+    classification: declarative_readability_helper
+    disposition: surviving_helper_candidate
+    consumer_issue: 1668
+    proof_refs:
+      - external:empire/contracts/flows/holding-devops/nodes.yaml:231
+      - external:empire/contracts/flows/holding-devops/nodes.yaml:251
+      - external:empire/contracts/flows/holding-devops/nodes.yaml:267
+    metric_evidence:
+      status: not_applicable
+      reason: schema/lookup readability evidence uses contract complexity, not runtime cost
+    notes: >
+      The row is a schema/manifest validation candidate. It has no code or I/O
+      requirement and should feed #1668, not function or orchestration work.
+
+  - inventory_id: 7
+    dedupe_group: scoring_composite_branching
+    title: scoring composite branch classification with existing weighted_average compute
+    classification: declarative_readability_helper
+    disposition: surviving_helper_candidate_existing_compute_covers_numeric_part
+    consumer_issue: 1668
+    proof_refs:
+      - external:empire/contracts/flows/scoring/nodes.yaml:142
+      - external:empire/contracts/flows/scoring/nodes.yaml:145
+      - external:empire/contracts/flows/scoring/nodes.yaml:181
+    metric_evidence:
+      status: not_applicable
+      reason: existing compute already owns weighted average; remaining issue is branch readability
+    notes: >
+      The numeric aggregation is already handled by the current platform
+      compute step. The remaining awkward part is threshold/branch readability,
+      so this row supports helpers before pure code.
+
+  - inventory_id: 8
+    dedupe_group: repo_scaffold_tuple_lookup
+    title: repo-scaffold tuple to template/source path validation
+    classification: declarative_readability_helper
+    disposition: surviving_helper_candidate_deduped_with_activity_pilot
+    consumer_issue: 1668
+    proof_refs:
+      - external:empire/contracts/flows/repo-scaffold/nodes.yaml:98
+      - external:empire/contracts/flows/repo-scaffold/nodes.yaml:100
+      - external:empire/contracts/flows/repo-scaffold/prompts/repo-scaffold-agent.md:14
+    metric_evidence:
+      status: not_applicable
+      reason: lookup readability evidence uses contract/prompt duplication, not runtime cost
+    notes: >
+      Same domain as row 1, but a different sub-shape: an explicit lookup table
+      would remove copied tuple-to-path conditionals without adding runtime I/O
+      semantics.
+
+  - inventory_id: 9
+    dedupe_group: treasury_budget_thresholds
+    title: treasury budget threshold classification
+    classification: declarative_readability_helper
+    disposition: surviving_helper_candidate
+    consumer_issue: 1668
+    proof_refs:
+      - external:empire/contracts/flows/treasury/nodes.yaml:161
+      - external:empire/contracts/flows/treasury/nodes.yaml:162
+      - external:empire/contracts/flows/treasury/nodes.yaml:181
+      - external:empire/contracts/flows/treasury/nodes.yaml:197
+    metric_evidence:
+      status: not_applicable
+      reason: threshold/switch readability evidence uses contract complexity, not runtime cost
+    notes: >
+      Ordered emergency/throttle/warning/recorded branches are helper evidence
+      for switch or threshold-table grammar, not pure-code evidence.
+
+  - inventory_id: 10
+    dedupe_group: validation_packaging_agent
+    title: validation coordinator packaging and handoff-file writer
+    classification: already_covered_or_not_deterministic_work_ladder_issue
+    disposition: insufficient_current_deterministic_proof
+    consumer_issue: 1663
+    proof_refs:
+      - external:empire/contracts/flows/validation/agents.yaml:1
+      - external:empire/contracts/flows/validation/prompts/validation-coordinator.md:11
+      - external:empire/contracts/flows/validation/prompts/validation-coordinator.md:16
+      - external:empire/contracts/flows/validation/prompts/validation-coordinator.md:26
+    metric_evidence:
+      status: unavailable
+      reason: no committed trace/cost/latency artifact and prompt still asks for human-readable synthesis
+    notes: >
+      Some file copying is deterministic, but the current job includes summary
+      synthesis. Do not count it as pure deterministic ladder evidence until a
+      deterministic file-bundle owner is separated from the language work.
+
+  - inventory_id: 11
+    dedupe_group: repo_scaffold_template_preparation
+    title: repo-scaffold agents.yaml duplicate of row 1
+    classification: already_covered_or_not_deterministic_work_ladder_issue
+    disposition: duplicate_of_inventory_1
+    duplicate_of: 1
+    consumer_issue: 1666
+    proof_refs:
+      - external:empire/contracts/flows/repo-scaffold/agents.yaml:1
+      - external:empire/contracts/flows/repo-scaffold/agents.yaml:11
+    metric_evidence:
+      status: not_applicable
+      reason: duplicate row collapsed into row 1
+    notes: >
+      This is the agent declaration for the same repo-scaffold pattern covered
+      by row 1, not a separate manifestation.
+
+  - inventory_id: 12
+    dedupe_group: validation_revision_gating
+    title: validation revision-gating orchestration duplicate of row 5
+    classification: already_covered_or_not_deterministic_work_ladder_issue
+    disposition: duplicate_of_inventory_5
+    duplicate_of: 5
+    consumer_issue: 1668
+    proof_refs:
+      - external:empire/contracts/flows/validation/nodes.yaml:154
+      - external:empire/contracts/flows/validation/nodes.yaml:222
+    metric_evidence:
+      status: not_applicable
+      reason: duplicate domain collapsed into row 5
+    notes: >
+      The same validation revision-gating domain appeared once as complex CEL
+      and once as multi-step orchestration. Current evidence supports a helper
+      readability child first; orchestration remains unproven for this row.
+
+  - inventory_id: 13
+    dedupe_group: discovery_scan_mode_dispatch
+    title: discovery scan-mode dispatcher
+    classification: declarative_readability_helper
+    disposition: surviving_helper_candidate
+    consumer_issue: 1668
+    proof_refs:
+      - external:empire/contracts/flows/discovery/nodes.yaml:93
+      - external:empire/contracts/flows/discovery/nodes.yaml:127
+      - external:empire/contracts/flows/discovery/nodes.yaml:161
+    metric_evidence:
+      status: not_applicable
+      reason: dispatch readability evidence uses contract duplication, not runtime cost
+    notes: >
+      The evidence is repeated dispatch shape and target/event selection.
+      Current contract already has fan_out, so this row supports switch/lookup
+      helpers rather than orchestration functions.
+
+  - inventory_id: 14
+    dedupe_group: operating_state_machine
+    title: operating state machine handler chain
+    classification: already_covered_or_not_deterministic_work_ladder_issue
+    disposition: existing_primitives_adequate
+    consumer_issue: 1663
+    proof_refs:
+      - external:empire/contracts/flows/operating/nodes.yaml:1
+      - external:empire/contracts/flows/operating/nodes.yaml:38
+      - external:empire/contracts/flows/operating/nodes.yaml:105
+      - external:empire/contracts/flows/operating/nodes.yaml:130
+    metric_evidence:
+      status: not_applicable
+      reason: existing state-machine handlers are readable enough for this Stage 0 inventory
+    notes: >
+      The operating state machine is thick but already expressed as normal
+      handlers, guards, state advances, and emits. It is not a current ladder
+      implementation candidate.
+
+  - inventory_id: 15
+    dedupe_group: opco_draft_scaffolding_gate_accumulation
+    title: OPCO draft scaffolding gate accumulation
+    classification: already_covered_or_not_deterministic_work_ladder_issue
+    disposition: draft_only_not_live_contract_evidence
+    consumer_issue: 1663
+    proof_refs:
+      - external:empire/docs/OPCO-STATE-MACHINE-DRAFT.md:236
+      - external:empire/docs/OPCO-STATE-MACHINE-DRAFT.md:242
+    metric_evidence:
+      status: not_applicable
+      reason: draft-only row excluded from live ordering counts
+    notes: >
+      The draft describes possible coordinator-shape concerns. It is not a live
+      contract manifestation and must not drive primitive promotion by itself.
+
+  - inventory_id: 16
+    dedupe_group: opco_draft_data_access_patterns
+    title: OPCO draft mixed data-access patterns
+    classification: already_covered_or_not_deterministic_work_ladder_issue
+    disposition: architecture_not_node_shape
+    consumer_issue: 1663
+    proof_refs:
+      - external:empire/docs/OPCO-STATE-MACHINE-DRAFT.md:589
+      - external:empire/docs/OPCO-STATE-MACHINE-DRAFT.md:591
+      - external:empire/docs/OPCO-STATE-MACHINE-DRAFT.md:593
+      - external:empire/docs/OPCO-STATE-MACHINE-DRAFT.md:595
+    metric_evidence:
+      status: not_applicable
+      reason: architectural data-access pattern row is not node-shape evidence
+    notes: >
+      This row belongs to cross-flow data ownership/encapsulation thinking, not
+      deterministic-work-ladder primitive ordering.
+gate_criteria:
+  - id: stage1_durable_activity_proof
+    consumer_issue: 1666
+    promotion_state: next_runtime_child
+    required_conditions:
+      - pilot uses row 1 or another explicitly classified durable-activity row
+      - minimal activity form is specified and demonstrated
+      - generated result events are materialized in bundle/catalog/verify outputs
+      - tool effect classes are authoritative for supported activity tool sources
+      - unsupported callable tool sources fail closed and are tracked
+      - activity intent commits transactionally before tool execution
+      - retry, idempotency, and fork defaults are specified for supported effect classes
+      - artifact_repo_commit disposition is recorded by #1667 or explicitly split
+    blocking_conditions:
+      - hidden runtime-only result events
+      - synchronous tool execution while holding the entity transaction
+      - MCP-discovered self-classification treated as authoritative
+      - runtime behavior implemented without matching platform-spec promotion
+
+  - id: stage2_stage3_ordering
+    consumer_issue: 1668
+    promotion_state: declarative_helpers_before_pure_function
+    required_conditions:
+      - at least two live non-draft helper candidates remain after activity rows are removed
+      - candidate helpers preserve contract visibility and fail closed on ambiguity
+      - no accepted helper introduces arbitrary code, I/O, or richer CEL grammar
+      - pure-code work remains blocked on #1665 naming and a live pure-function evidence row not covered by existing compute
+    current_matrix_result: >
+      Rows 5, 6, 7, 8, 9, and 13 support declarative helpers. No surviving row
+      requires pure code ahead of helpers. Row 7's numeric work is already
+      covered by existing compute.
+
+  - id: orchestration_function_promotion
+    consumer_issue: 1671
+    promotion_state: blocked_until_later_evidence
+    required_conditions:
+      - durable activities have landed and provide journaled activity results
+      - at least two live same-class examples cannot be expressed by fan_out, accumulate, activities, or accepted helpers
+      - journal identity includes run/fork id, flow instance, entity, source event, node/handler, call ordinal, module version, and input hash
+      - fork/replay policies from activity effect classes are explicit and consumed
+      - buffered emit failure semantics are specified and tested
+    current_matrix_result: >
+      Current Stage 0 evidence does not justify promoting orchestration before
+      activities and helpers. Scanner and discovery dispatch decompose into
+      existing fan_out plus activities/helpers.


### PR DESCRIPTION
## Summary

Closes #1664.

This PR records the deterministic-work ladder Stage 0 evidence owner and gates without implementing any runtime semantics. It adds a committed evidence artifact plus conformance checks that enforce the approved gate boundary:

- all 16 #1460 inventory rows are covered and deduped;
- rough metric claims are replaced by measured / unavailable / not-applicable status;
- `runtime_operations.deterministic_work_ladder` maps #1663 and #1664-#1672 and encodes that #1663 remains open;
- the next post-Stage-1 ROI decision is evidence-based: declarative readability helpers before pure function work unless later evidence changes the gate;
- no activity, function, orchestration, CLI/build, runtime behavior, or `platform-spec.yaml` semantic change lands here.

## Governing Context

No exact governing `platform-spec.yaml` section exists for durable activities, pure functions, orchestration functions, or the deterministic-work ladder. That absence is binding for #1664: this PR must not promote runtime semantics.

Binding context used:

- #1664 issue body and pre-audit: Stage 0 evidence normalization, gates, and watchlist mapping.
- Lead gate comment on #1664: approved as first slice with Stage 0-only conditions.
- #1663 parent tracker: deterministic-work ladder remains open after #1664.
- #1460 locked design discussion: design evidence only, not merge-bearing runtime authority.
- Adjacent `platform-spec.yaml` sections: `spec_authority`, `vocabulary.agent_role.types.system_node`, `vocabulary.action`, `handler_specification.dependency_graph`, `handler_specification.handler_fields.compute`, `handler_specification.handler_fields.action`, and `design_principles`.

## Semantic Migration / Ownership

- New canonical owner for Stage 0 evidence/gate/watchlist state: `internal/runtime/conformance/testdata/deterministic_work_ladder_stage0.yaml`.
- Old non-authoritative producers/readers now invalid for closure by themselves: #1460 discussion prose, the old Empire logic-node design notes, rough cost/latency estimates, and #1663 prose-only non-closure memory.
- Production paths checked for surviving old behavior: current `origin/master` runtime/spec surfaces remain only existing `system_node`, bounded action ids, current `compute`, dependency graph ordering, and `artifact_repo_commit`; no deterministic-work runtime owner was implemented here.
- Migration completeness: complete for #1664 Stage 0 evidence/gate/watchlist ownership; incomplete for the parent ladder, which remains tracked by #1663 and children #1665-#1672.

## Validation

- `go test ./internal/runtime/conformance -run TestDeterministicWorkLadderStage0 -count=1 -timeout=60s`
- `go test ./...`
