### PR TITLE
[agent-b][issue #1639] Remove gateway token env authority

### DIFF
--- a/cmd/swarm/main.go
+++ b/cmd/swarm/main.go
@@ -697,7 +697,6 @@ func buildServeRuntimeBundleContext(req serveRuntimeBundleContextRequest) (serve
 			WorkflowModule:                   loaded.module,
 			WorkspaceLifecycle:               workspaces,
 			EnableToolGateway:                req.EnableToolGateway,
-			ToolGatewayToken:                 req.ToolGatewayBinding.AuthToken(),
 			ToolGatewayBinding:               req.ToolGatewayBinding,
 			BundleFingerprint:                bootIdentity.Fingerprint,
 			BundleSourceFact:                 bundleSourceFact,
@@ -3114,12 +3113,12 @@ func createServeToolGatewayBinding(mcpAddr net.Addr) (toolgateway.Binding, error
 	if err != nil {
 		return toolgateway.Binding{}, err
 	}
-	gatewayToken := strings.TrimSpace(os.Getenv("SWARM_TOOL_GATEWAY_TOKEN"))
-	if gatewayToken == "" {
-		gatewayToken, err = toolgateway.GenerateAuthToken()
-		if err != nil {
-			return toolgateway.Binding{}, fmt.Errorf("generate mcp gateway token: %w", err)
-		}
+	if strings.TrimSpace(os.Getenv(toolgateway.RetiredAuthTokenEnvName)) != "" {
+		return toolgateway.Binding{}, toolgateway.RetiredAuthTokenEnvError()
+	}
+	gatewayToken, err := toolgateway.GenerateAuthToken()
+	if err != nil {
+		return toolgateway.Binding{}, fmt.Errorf("generate mcp gateway token: %w", err)
 	}
 	binding := toolgateway.Binding{
 		Transport:         toolgateway.TransportHTTP,

--- a/cmd/swarm/main_test.go
+++ b/cmd/swarm/main_test.go
@@ -2596,12 +2596,12 @@ func TestPlatformSpecLocalCLITestGatewayStartupPromoted(t *testing.T) {
 			t.Fatalf("local cli_test gateway startup scope missing %q:\n%s", want, startup.Scope)
 		}
 	}
-	for _, want := range []string{"SWARM_TOOL_GATEWAY_TOKEN", "token-only source", "per-boot", "SWARM_TOOL_GATEWAY_URL", "not source authority", "Local foreground `swarm run`"} {
+	for _, want := range []string{"SWARM_TOOL_GATEWAY_TOKEN", "removed", "per-boot", "binding token", "SWARM_TOOL_GATEWAY_URL", "not source authority", "Local foreground `swarm run`"} {
 		if !strings.Contains(startup.GatewayTokenRule, want) {
 			t.Fatalf("gateway token rule missing %q:\n%s", want, startup.GatewayTokenRule)
 		}
 	}
-	for _, want := range []string{"RuntimeOptions.ToolGatewayBinding", "runtime MCP gateway auth", "ValidateClaudeCLIRuntimeConfig", "docker exec", "MCP HTTP binding"} {
+	for _, want := range []string{"RuntimeOptions.ToolGatewayBinding", "runtime MCP gateway auth", "ValidateClaudeCLIRuntimeConfig", "MCP HTTP binding"} {
 		if !stringSliceContains(startup.GatewayTokenConsumers, want) {
 			t.Fatalf("gateway token consumers missing %q: %#v", want, startup.GatewayTokenConsumers)
 		}
@@ -2675,7 +2675,7 @@ func TestPlatformSpecLocalToolGatewayBindingPromoted(t *testing.T) {
 			t.Fatalf("endpoint env rule missing %q:\n%s", want, binding.EndpointEnvRule)
 		}
 	}
-	for _, want := range []string{"SWARM_TOOL_GATEWAY_TOKEN", "token-only source authority", "per-boot token", "binding token", "Selected-fork ephemeral gateways follow the same token-only rule"} {
+	for _, want := range []string{"SWARM_TOOL_GATEWAY_TOKEN", "removed as public/operator token source", "per-boot token", "binding token", "selected-fork ephemeral gateways MUST generate their own binding token", "fail closed"} {
 		if !strings.Contains(binding.AuthRule, want) {
 			t.Fatalf("auth rule missing %q:\n%s", want, binding.AuthRule)
 		}
@@ -2690,7 +2690,7 @@ func TestPlatformSpecLocalToolGatewayBindingPromoted(t *testing.T) {
 			t.Fatalf("binding consumers missing %q: %#v", want, binding.Consumers)
 		}
 	}
-	for _, want := range []string{"#1568 token-source migration", "#1568 broader selected-contract", "no longer uses process-global URL env", "#979/#1012 are completed historical source-authority slices", "#1138/#1213", "#1567", "IPC/unix socket"} {
+	for _, want := range []string{"#1568 broader selected-contract", "no longer uses process-global URL env", "#979/#1012 are completed historical source-authority slices", "#1138/#1213", "#1567", "IPC/unix socket"} {
 		if !stringSliceContains(binding.SplitTail, want) {
 			t.Fatalf("binding split_tail missing %q: %#v", want, binding.SplitTail)
 		}
@@ -3038,6 +3038,9 @@ func TestPlatformSpecLLMProviderModelSelectionSourceAuthorityPromoted(t *testing
 		if !stringSliceContains(authority.CredentialAndConfigPolicy.SecretEnvSources, want) {
 			t.Fatalf("secret env sources missing %q: %#v", want, authority.CredentialAndConfigPolicy.SecretEnvSources)
 		}
+	}
+	if stringSliceContains(authority.CredentialAndConfigPolicy.SecretEnvSources, "SWARM_TOOL_GATEWAY_TOKEN") {
+		t.Fatalf("secret env sources still promote retired gateway token env: %#v", authority.CredentialAndConfigPolicy.SecretEnvSources)
 	}
 	for _, want := range []string{"backend selection", "provider model alias maps"} {
 		if !stringSliceContains(authority.CredentialAndConfigPolicy.RuntimeConfigCanonicalFor, want) {
@@ -10884,7 +10887,7 @@ func TestCreateServeToolGatewayBindingAlignsToMCPListenerWithoutMutatingURLEnv(t
 	}
 }
 
-func TestCreateServeToolGatewayBindingPreservesExplicitGatewayToken(t *testing.T) {
+func TestCreateServeToolGatewayBindingRejectsRetiredGatewayTokenEnv(t *testing.T) {
 	t.Setenv("SWARM_TOOL_GATEWAY_URL", "")
 	t.Setenv("SWARM_TOOL_GATEWAY_CONTAINER_URL", "")
 	t.Setenv("SWARM_TOOL_GATEWAY_TOKEN", "operator-token")
@@ -10894,12 +10897,9 @@ func TestCreateServeToolGatewayBindingPreservesExplicitGatewayToken(t *testing.T
 	}
 	defer listener.Close()
 
-	binding, err := createServeToolGatewayBinding(listener.Addr())
-	if err != nil {
-		t.Fatalf("create gateway binding: %v", err)
-	}
-	if got := binding.Token; got != "operator-token" {
-		t.Fatalf("binding token = %q, want explicit operator token", got)
+	_, err = createServeToolGatewayBinding(listener.Addr())
+	if err == nil || !strings.Contains(err.Error(), "SWARM_TOOL_GATEWAY_TOKEN is retired") || !strings.Contains(err.Error(), "ToolGatewayBinding") {
+		t.Fatalf("create gateway binding error = %v, want retired token env rejection", err)
 	}
 }
 

--- a/internal/runtime/llm/cli_runtime_process.go
+++ b/internal/runtime/llm/cli_runtime_process.go
@@ -305,9 +305,6 @@ func (r *ClaudeCLIRuntime) buildCommand(ctx context.Context, args []string, targ
 		if gatewayURL != "" {
 			dockerArgs = append(dockerArgs, "-e", "SWARM_TOOL_GATEWAY_URL="+gatewayURL)
 		}
-		if gatewayToken := r.toolGateway.AuthToken(); gatewayToken != "" {
-			dockerArgs = append(dockerArgs, "-e", "SWARM_TOOL_GATEWAY_TOKEN="+gatewayToken)
-		}
 		profile, _ := llmselection.ResolveActiveBackend(llmselection.BackendClaudeCLI)
 		if oauthToken := llmselection.CredentialValue(profile, os.LookupEnv); oauthToken != "" {
 			dockerArgs = append(dockerArgs, "-e", profile.Credential.EnvVar+"="+oauthToken)

--- a/internal/runtime/llm/cli_runtime_process_test.go
+++ b/internal/runtime/llm/cli_runtime_process_test.go
@@ -121,8 +121,8 @@ func TestClaudeCLIRuntimeBuildCommand_UsesContainerReachableMCPGatewayURL(t *tes
 	if !strings.Contains(got, "SWARM_TOOL_GATEWAY_URL=http://host.docker.internal:8082/mcp") {
 		t.Fatalf("docker args = %q, want explicit container MCP gateway URL", got)
 	}
-	if !strings.Contains(got, "SWARM_TOOL_GATEWAY_TOKEN=gateway-token") {
-		t.Fatalf("docker args = %q, want MCP gateway token propagated into cli_test container exec", got)
+	if strings.Contains(got, "SWARM_TOOL_GATEWAY_TOKEN=") {
+		t.Fatalf("docker args = %q, want no gateway token env propagated into cli_test container exec", got)
 	}
 	if strings.Contains(got, "stale.example.invalid") || strings.Contains(got, "stale-token") {
 		t.Fatalf("docker args = %q, stale operator gateway env leaked into launch", got)

--- a/internal/runtime/llm/cli_runtime_transport_test.go
+++ b/internal/runtime/llm/cli_runtime_transport_test.go
@@ -348,6 +348,9 @@ func TestBuildMCPConfigArg_UsesContextTokenWithoutLegacyCorrelationPropagation(t
 	if got := headers["X-SWARM-Trace-Id"]; got != nil {
 		t.Fatalf("unexpected trace header = %#v", got)
 	}
+	if got := headers["Authorization"]; got != "Bearer gateway-token" {
+		t.Fatalf("authorization header = %#v, want binding bearer token", got)
+	}
 	if got := headers[mcpContextTokenHeader]; got != contextToken {
 		t.Fatalf("context header = %#v, want %q", got, contextToken)
 	}

--- a/internal/runtime/runforkexecution/agent_runtime_materialization.go
+++ b/internal/runtime/runforkexecution/agent_runtime_materialization.go
@@ -322,13 +322,14 @@ func startSelectedContractAgentRuntimeGateway(exec *runtimetools.Executor, emitR
 	port := ln.Addr().(*net.TCPAddr).Port
 	hostURL := fmt.Sprintf("http://127.0.0.1:%d", port)
 	containerURL := fmt.Sprintf("http://host.docker.internal:%d", port)
-	gatewayToken := strings.TrimSpace(os.Getenv("SWARM_TOOL_GATEWAY_TOKEN"))
-	if gatewayToken == "" {
-		gatewayToken, err = toolgateway.GenerateAuthToken()
-		if err != nil {
-			_ = ln.Close()
-			return toolgateway.Binding{}, nil, fmt.Errorf("generate selected-fork tool gateway token: %w", err)
-		}
+	if strings.TrimSpace(os.Getenv(toolgateway.RetiredAuthTokenEnvName)) != "" {
+		_ = ln.Close()
+		return toolgateway.Binding{}, nil, toolgateway.RetiredAuthTokenEnvError()
+	}
+	gatewayToken, err := toolgateway.GenerateAuthToken()
+	if err != nil {
+		_ = ln.Close()
+		return toolgateway.Binding{}, nil, fmt.Errorf("generate selected-fork tool gateway token: %w", err)
 	}
 	binding := toolgateway.Binding{
 		Transport:         toolgateway.TransportHTTP,

--- a/internal/runtime/runforkexecution/execution_test.go
+++ b/internal/runtime/runforkexecution/execution_test.go
@@ -584,7 +584,7 @@ func TestStartSelectedContractAgentRuntimeGatewayReturnsGeneratedBinding(t *test
 	}
 }
 
-func TestStartSelectedContractAgentRuntimeGatewayUsesExplicitTokenWithoutURLMutation(t *testing.T) {
+func TestStartSelectedContractAgentRuntimeGatewayRejectsRetiredTokenEnv(t *testing.T) {
 	const staleHostURL = "http://127.0.0.1:9998"
 	const staleContainerURL = "http://host.docker.internal:9998"
 	t.Setenv("SWARM_TOOL_GATEWAY_URL", staleHostURL)
@@ -594,15 +594,15 @@ func TestStartSelectedContractAgentRuntimeGatewayUsesExplicitTokenWithoutURLMuta
 	exec := runtimetools.NewExecutorWithOptions(nil, nil, runtimetools.ExecutorOptions{})
 	turns := runtimemcp.NewTurnContextRegistry(runtimeactors.ActorFromContext)
 	binding, cleanup, err := startSelectedContractAgentRuntimeGateway(exec, nil, turns, nil)
-	if err != nil {
-		t.Fatalf("startSelectedContractAgentRuntimeGateway: %v", err)
+	if err == nil || !strings.Contains(err.Error(), "SWARM_TOOL_GATEWAY_TOKEN is retired") || !strings.Contains(err.Error(), "ToolGatewayBinding") {
+		t.Fatalf("startSelectedContractAgentRuntimeGateway error = %v, want retired token env rejection", err)
 	}
-	if cleanup == nil {
-		t.Fatal("cleanup is nil")
+	if cleanup != nil {
+		cleanup()
+		t.Fatal("cleanup was returned for rejected retired token env")
 	}
-	defer cleanup()
-	if got := binding.AuthToken(); got != "operator-token" {
-		t.Fatalf("binding token = %q, want explicit token", got)
+	if !binding.Empty() {
+		t.Fatalf("binding = %#v, want empty rejected binding", binding)
 	}
 	if got := strings.TrimSpace(os.Getenv("SWARM_TOOL_GATEWAY_URL")); got != staleHostURL {
 		t.Fatalf("SWARM_TOOL_GATEWAY_URL = %q, want unchanged %q", got, staleHostURL)

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -70,7 +70,6 @@ type RuntimeOptions struct {
 	SelfCheck                        bool
 	WorkspaceLifecycle               workspace.Lifecycle
 	EnableToolGateway                bool
-	ToolGatewayToken                 string
 	ToolGatewayBinding               toolgateway.Binding
 	BundleFingerprint                string
 	BundleSourceFact                 runtimecorrelation.BundleSourceFact
@@ -616,7 +615,7 @@ func NewRuntime(ctx context.Context, deps RuntimeDeps) (*Runtime, error) {
 	if opts.EnableToolGateway {
 		toolGatewayToken := opts.ToolGatewayBinding.AuthToken()
 		if toolGatewayToken == "" {
-			toolGatewayToken = strings.TrimSpace(opts.ToolGatewayToken)
+			return nil, fmt.Errorf("tool gateway binding token is required")
 		}
 		rt.ToolGateway = runtimemcp.NewGateway(rt.ToolExecutor, toolGatewayToken, RuntimeMCPGatewayHooks(rt.Logger, rt.RuntimeIngress, func(agentID string) (runtimeactors.AgentConfig, bool) {
 			if rt.Manager == nil {

--- a/internal/runtime/runtime_agent_free_claude_boot_test.go
+++ b/internal/runtime/runtime_agent_free_claude_boot_test.go
@@ -117,7 +117,6 @@ func TestRuntimeStart_ActiveManagerAgentRequiresFullClaudeStartupBinding(t *test
 			target: &workspace.Target{Container: "swarm-agent-recovered-agent", Workdir: "/workspace"},
 		},
 		EnableToolGateway:  true,
-		ToolGatewayToken:   "gateway-token",
 		ToolGatewayBinding: testToolGatewayBinding("http://127.0.0.1:8081", "", "gateway-token"),
 	}})
 
@@ -132,6 +131,22 @@ func TestRuntimeStart_ActiveManagerAgentRequiresFullClaudeStartupBinding(t *test
 	err = rt.Start(context.Background())
 	if err == nil || !strings.Contains(err.Error(), "claude runtime startup validation failed") || !strings.Contains(err.Error(), "tool gateway binding workspace endpoint") {
 		t.Fatalf("Start error = %v, want startup validation failure for missing workspace gateway binding", err)
+	}
+}
+
+func TestNewRuntimeToolGatewayRequiresBindingToken(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.LLM.Backend = "claude_cli"
+
+	_, err := NewRuntime(context.Background(), RuntimeDeps{Config: cfg, Stores: Stores{}, Options: RuntimeOptions{
+		SelfCheck:          false,
+		WorkflowModule:     loadAgentFreeRuntimeWorkflowModule(t),
+		LLMRuntime:         noopLLMRuntime{},
+		EnableToolGateway:  true,
+		ToolGatewayBinding: testToolGatewayBinding("http://127.0.0.1:8081", "http://host.docker.internal:8081", ""),
+	}})
+	if err == nil || !strings.Contains(err.Error(), "tool gateway binding token is required") {
+		t.Fatalf("NewRuntime error = %v, want missing binding token rejection", err)
 	}
 }
 

--- a/internal/runtime/runtime_claude_startup_test.go
+++ b/internal/runtime/runtime_claude_startup_test.go
@@ -111,7 +111,6 @@ func TestValidateClaudeStartupConfigForActiveAgents_RequiresFullCLIBindingForRec
 			target: &workspace.Target{Container: "swarm-agent-recovered-agent", Workdir: "/workspace"},
 		},
 		EnableToolGateway: true,
-		ToolGatewayToken:  "gateway-token",
 	}
 	t.Setenv("SWARM_CLAUDE_USE_MCP", "1")
 	t.Setenv("CLAUDE_CODE_OAUTH_TOKEN", "")

--- a/internal/runtime/toolgateway/binding.go
+++ b/internal/runtime/toolgateway/binding.go
@@ -13,7 +13,8 @@ type Transport string
 const (
 	TransportHTTP Transport = "http"
 
-	AuthTokenBytes = 32
+	AuthTokenBytes          = 32
+	RetiredAuthTokenEnvName = "SWARM_TOOL_GATEWAY_TOKEN"
 
 	LifecycleOwnerServeBoot            = "serve_boot"
 	LifecycleOwnerSelectedForkRuntime  = "selected_fork_agent_runtime"
@@ -66,6 +67,10 @@ func (b Binding) WorkspaceMCPURL() string {
 
 func (b Binding) AuthToken() string {
 	return strings.TrimSpace(b.Token)
+}
+
+func RetiredAuthTokenEnvError() error {
+	return fmt.Errorf("%s is retired and not accepted as gateway token configuration; unset %s because Swarm generates tool gateway auth tokens from ToolGatewayBinding", RetiredAuthTokenEnvName, RetiredAuthTokenEnvName)
 }
 
 func GenerateAuthToken() (string, error) {

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -3794,7 +3794,6 @@ engine:
         - CLAUDE_CODE_OAUTH_TOKEN
         - OPENAI_COMPATIBLE_API_KEY
         - OPENAI_API_KEY
-        - SWARM_TOOL_GATEWAY_TOKEN
         - SWARM_API_TOKEN
         - database password env/store sources
         runtime_config_canonical_for:
@@ -11462,10 +11461,10 @@ cli_specification:
         availability, Docker Compose setup, selected-contract/multi-bundle gateway materialization,
         or public one-secret quickstart polish.
       gateway_token_rule: >
-        `SWARM_TOOL_GATEWAY_TOKEN` remains a token-only source for the #1568 first slice:
-        when present and non-empty it supplies the local tool gateway binding auth token; when absent,
-        local serve/run MUST derive a per-boot token and store it on the typed binding. The token env var
-        MUST NOT own endpoint reachability. `SWARM_TOOL_GATEWAY_URL` and
+        `SWARM_TOOL_GATEWAY_TOKEN` is removed as a public/operator token source by #1639:
+        local serve/run MUST derive a per-boot token and store it on the typed binding. Runtime gateway auth,
+        startup probes, and MCP HTTP config generation MUST consume the binding token. The token env var
+        MUST NOT own endpoint reachability or token authority. `SWARM_TOOL_GATEWAY_URL` and
         `SWARM_TOOL_GATEWAY_CONTAINER_URL` are not source authority for local serve/run endpoint binding.
         Local foreground `swarm run` consumes the same serve startup owner and MUST NOT fork an independent
         gateway-token owner.
@@ -11473,7 +11472,6 @@ cli_specification:
       - 'runtime `RuntimeOptions.ToolGatewayBinding`'
       - runtime MCP gateway auth
       - '`llm.ValidateClaudeCLIRuntimeConfig`'
-      - Claude CLI docker exec environment
       - MCP HTTP binding for startup/runtime tool calls
       startup_probe_rule: >
         For agent-present `cli_test` managed agents, startup validation MUST execute the Claude
@@ -11533,11 +11531,13 @@ cli_specification:
         and local preflight may read these variables only to report retired/shadowed diagnostic evidence; matching
         non-empty URL env MUST NOT be rendered as accepted configuration.
       auth_rule: >
-        `SWARM_TOOL_GATEWAY_TOKEN` remains token-only source authority for this first slice. If it is empty,
-        serve boot MUST generate a per-boot token and place it on `ToolGatewayBinding`. Runtime gateway auth,
-        startup probes, MCP HTTP config generation, and Docker exec env injection MUST consume the binding token,
-        not a later ambient env read. Selected-fork ephemeral gateways follow the same token-only rule: explicit
-        `SWARM_TOOL_GATEWAY_TOKEN` may supply the binding token, and absent token generates a typed binding token.
+        `SWARM_TOOL_GATEWAY_TOKEN` is removed as public/operator token source authority by #1639. Serve boot
+        MUST generate a per-boot token and place it on `ToolGatewayBinding`; selected-fork ephemeral gateways
+        MUST generate their own binding token from the same typed binding owner. Runtime gateway auth, startup
+        probes, and MCP HTTP config generation MUST consume the binding token, not a later ambient env read.
+        Non-empty `SWARM_TOOL_GATEWAY_TOKEN` in production token-source paths MUST fail closed with replacement
+        guidance to unset it. The variable MUST NOT be used for Docker exec token propagation; supported Claude
+        CLI auth to the tool gateway is carried by MCP config headers derived from `ToolGatewayBinding`.
       multi_context_rule: >
         In DB-loaded multi-context serve, `claude_cli` tool-gateway and forkchat sandbox materialization are
         unsupported until a separately gated context-aware gateway router and forkchat runtime selector exist.
@@ -11562,7 +11562,7 @@ cli_specification:
       - local `claude_cli` preflight diagnostics as consumer-only stale-env reporter
       - non-dev serve retired URL-env admission
       split_tail:
-      - '#1568 token-source migration beyond token-only env remains split.'
+      - '#1639 closes raw `SWARM_TOOL_GATEWAY_TOKEN` source authority for local serve/run and selected-fork tool-gateway tokens.'
       - '#1568 broader selected-contract and multi-bundle gateway materialization remains split; selected-fork ephemeral gateway startup no longer uses process-global URL env as a propagation side channel, and DB-loaded multi-context claude_cli gateway/forkchat ambiguity now fails closed, but full context-aware MCP/forkchat routing remains open. #979/#1012 are completed historical source-authority slices and are not active trackers for this open gateway tail.'
       - '#1138/#1213 host workspace `claude_cli` execution remains split.'
       - '#1567 API connection discovery and connection-file authority remain split.'


### PR DESCRIPTION
## Summary

Closes #1639.

This removes `SWARM_TOOL_GATEWAY_TOKEN` as a public/operator source of tool-gateway auth authority. Serve and selected-fork gateway startup now generate the token through the typed `ToolGatewayBinding`, runtime gateway construction requires the binding token, and Docker Claude CLI launch no longer receives a gateway token through env. MCP auth continues through config headers derived from `ToolGatewayBinding`.

## Governing refs / context

- `platform-spec.yaml#cli_specification.foundations.local_tool_gateway_binding`
- `platform-spec.yaml#cli_specification.foundations.local_cli_test_gateway_startup`
- `platform-spec.yaml#cli_specification.foundations.repo_dotenv_non_authority`
- Parent env-source tracker: #1600
- Gateway endpoint authority context: #1568

## Semantic migration

- New canonical owner: `ToolGatewayBinding.Token`, generated by serve boot and selected-fork gateway startup under `platform-spec.yaml#cli_specification.foundations.local_tool_gateway_binding.auth_rule`.
- Old producer / reader / writer paths now invalid: raw `SWARM_TOOL_GATEWAY_TOKEN` reads in serve binding creation and selected-fork gateway startup, `RuntimeOptions.ToolGatewayToken` runtime fallback, and Docker token env propagation.
- Production paths checked for surviving old behavior: serve binding creation, foreground run via serve bundle construction, selected-fork gateway startup, `runtime.NewRuntime`, Claude CLI MCP config/header generation, Docker command construction, platform spec/tests, and public templates/docs grep.
- Migration complete for the chosen class: yes. `SWARM_TOOL_GATEWAY_TOKEN` remains only as a retired-env diagnostic constant/spec mention; non-empty raw env fails closed in token-source paths.

## Validation

- `go test ./cmd/swarm -run 'TestPlatformSpecLocalCLITestGatewayStartupPromoted|TestPlatformSpecLocalToolGatewayBindingPromoted|TestPlatformSpecLLMProviderSelectionConfigAuthorityPromoted|TestCreateServeToolGatewayBindingAlignsToMCPListenerWithoutMutatingURLEnv|TestCreateServeToolGatewayBindingRejectsRetiredGatewayTokenEnv|TestRunServeRuntimeDevClaudeCLIStaleGatewayEnvUsesTypedBinding|TestStartLocalRunServeClaudeCLIStaleGatewayEnvUsesTypedBinding' -count=1`
- `go test ./internal/runtime/runforkexecution -run 'TestStartSelectedContractAgentRuntimeGatewayReturnsGeneratedBinding|TestStartSelectedContractAgentRuntimeGatewayRejectsRetiredTokenEnv' -count=1`
- `go test ./internal/runtime -run 'TestNewRuntimeToolGatewayRequiresBindingToken|TestRuntimeStart_ActiveManagerAgentRequiresFullClaudeStartupBinding|TestValidateClaudeMCPToolsForManagedAgents_FailsClosedOnConfiguredGatewayTokenMismatch' -count=1`
- `go test ./internal/runtime/llm -run 'TestClaudeCLIRuntimeBuildCommand_UsesContainerReachableMCPGatewayURL|TestBuildMCPConfigArg_UsesContextTokenWithoutLegacyCorrelationPropagation|TestValidateClaudeCLIRuntimeConfig_RequiresToolGatewayBinding' -count=1`
- `go test ./internal/runtime/cataloge2e -count=1` after the first full-suite run hit catalog e2e timing timeouts
- `go test ./...` passed on rerun
- grep guard: no `ToolGatewayToken`; no production raw `SWARM_TOOL_GATEWAY_TOKEN` source reads; only retired-env constant/spec retirement text remains outside conformance env-clearing testdata