### PR TITLE
[agent-b][issue #1638] Resolve provider credentials from swarm secrets

### DIFF
--- a/cmd/swarm/builder_project_supervisor.go
+++ b/cmd/swarm/builder_project_supervisor.go
@@ -14,6 +14,7 @@ import (
 	"github.com/division-sh/swarm/internal/runtime"
 	runtimeagentcontrol "github.com/division-sh/swarm/internal/runtime/agentcontrol"
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
+	runtimecredentials "github.com/division-sh/swarm/internal/runtime/credentials"
 	runtimeingress "github.com/division-sh/swarm/internal/runtime/ingress"
 	runtimepipeline "github.com/division-sh/swarm/internal/runtime/pipeline"
 	"github.com/division-sh/swarm/internal/runtime/semanticview"
@@ -21,21 +22,23 @@ import (
 )
 
 type runtimeProjectSupervisor struct {
-	repoRoot         string
-	platformSpecPath string
-	cfg              *config.Config
-	stores           storeBundle
-	ready            *atomic.Bool
-	dev              bool
-	mountSources     workspaceMountSources
-	workspaceBackend workspaceBackendSelection
-	startRuntime     func(context.Context, *runtime.Runtime) error
-	shutdownRuntime  func(context.Context, *runtime.Runtime, runtime.ShutdownOptions) error
-	loadWorkflow     func(repoRoot, contractsRoot, platformSpecPath string) (runtimepipeline.WorkflowModule, *runtimecontracts.WorkflowContractBundle, error)
-	validateSource   func(context.Context, semanticview.Source) error
-	initStateStores  func(context.Context, storeBundle, *runtimecontracts.WorkflowContractBundle) (string, error)
-	newWorkspaces    func(storeBundle, string, semanticview.Source, workspaceMountSources) (workspace.Lifecycle, error)
-	createRuntime    func(context.Context, runtime.RuntimeDeps) (*runtime.Runtime, error)
+	repoRoot            string
+	platformSpecPath    string
+	cfg                 *config.Config
+	stores              storeBundle
+	ready               *atomic.Bool
+	dev                 bool
+	mountSources        workspaceMountSources
+	workspaceBackend    workspaceBackendSelection
+	credentials         runtimecredentials.Store
+	providerCredentials runtimecredentials.Store
+	startRuntime        func(context.Context, *runtime.Runtime) error
+	shutdownRuntime     func(context.Context, *runtime.Runtime, runtime.ShutdownOptions) error
+	loadWorkflow        func(repoRoot, contractsRoot, platformSpecPath string) (runtimepipeline.WorkflowModule, *runtimecontracts.WorkflowContractBundle, error)
+	validateSource      func(context.Context, semanticview.Source) error
+	initStateStores     func(context.Context, storeBundle, *runtimecontracts.WorkflowContractBundle) (string, error)
+	newWorkspaces       func(storeBundle, string, semanticview.Source, workspaceMountSources) (workspace.Lifecycle, error)
+	createRuntime       func(context.Context, runtime.RuntimeDeps) (*runtime.Runtime, error)
 
 	mu                              sync.RWMutex
 	currentRoot                     string
@@ -53,6 +56,8 @@ func newRuntimeProjectSupervisor(
 	ready *atomic.Bool,
 	mountSources workspaceMountSources,
 	workspaceBackend workspaceBackendSelection,
+	credentials runtimecredentials.Store,
+	providerCredentials runtimecredentials.Store,
 	initialRoot string,
 	initialBundle *runtimecontracts.WorkflowContractBundle,
 	initialSource semanticview.Source,
@@ -64,14 +69,16 @@ func newRuntimeProjectSupervisor(
 		dev = devMode[0]
 	}
 	return &runtimeProjectSupervisor{
-		repoRoot:         strings.TrimSpace(repoRoot),
-		platformSpecPath: strings.TrimSpace(platformSpecPath),
-		cfg:              cfg,
-		stores:           stores,
-		ready:            ready,
-		dev:              dev,
-		mountSources:     mountSources,
-		workspaceBackend: workspaceBackend,
+		repoRoot:            strings.TrimSpace(repoRoot),
+		platformSpecPath:    strings.TrimSpace(platformSpecPath),
+		cfg:                 cfg,
+		stores:              stores,
+		ready:               ready,
+		dev:                 dev,
+		mountSources:        mountSources,
+		workspaceBackend:    workspaceBackend,
+		credentials:         credentials,
+		providerCredentials: providerCredentials,
 		startRuntime: func(ctx context.Context, rt *runtime.Runtime) error {
 			return rt.Start(ctx)
 		},
@@ -202,11 +209,13 @@ func (s *runtimeProjectSupervisor) loadProject(ctx context.Context, projectDir s
 		Config: s.cfg,
 		Stores: s.stores.runtimeStores(),
 		Options: runtime.RuntimeOptions{
-			SelfCheck:          false,
-			WorkflowModule:     module,
-			WorkspaceLifecycle: workspaces,
-			BundleFingerprint:  bundleIdentity.Fingerprint,
-			BundleSourceFact:   bundleSourceFact,
+			SelfCheck:           false,
+			WorkflowModule:      module,
+			WorkspaceLifecycle:  workspaces,
+			BundleFingerprint:   bundleIdentity.Fingerprint,
+			BundleSourceFact:    bundleSourceFact,
+			Credentials:         s.credentials,
+			ProviderCredentials: s.providerCredentials,
 		},
 	})
 	if err != nil {

--- a/cmd/swarm/builder_project_supervisor_test.go
+++ b/cmd/swarm/builder_project_supervisor_test.go
@@ -275,7 +275,7 @@ func newSupervisorForLoadProjectFailureTest(
 	bundle := testBuilderSupervisorBundle(t)
 	source := semanticview.Wrap(bundle)
 	module := stubWorkflowModule{source: source}
-	supervisor := newRuntimeProjectSupervisor("", "", nil, storeBundle{}, new(atomic.Bool), workspaceMountSources{}, workspaceBackendSelection{Backend: defaultWorkspaceBackend, Source: "default"}, "", nil, nil, nil)
+	supervisor := newRuntimeProjectSupervisor("", "", nil, storeBundle{}, new(atomic.Bool), workspaceMountSources{}, workspaceBackendSelection{Backend: defaultWorkspaceBackend, Source: "default"}, nil, nil, "", nil, nil, nil)
 	supervisor.dev = true
 	supervisor.loadWorkflow = func(repoRoot, contractsRoot, platformSpecPath string) (runtimepipeline.WorkflowModule, *runtimecontracts.WorkflowContractBundle, error) {
 		if got := strings.TrimSpace(contractsRoot); got != strings.TrimSpace(projectRoot) {

--- a/cmd/swarm/doctor_test.go
+++ b/cmd/swarm/doctor_test.go
@@ -11,9 +11,23 @@ import (
 	"strings"
 	"testing"
 
+	runtimecredentials "github.com/division-sh/swarm/internal/runtime/credentials"
 	storebackend "github.com/division-sh/swarm/internal/store/backendselection"
 	"gopkg.in/yaml.v3"
 )
+
+func setDoctorProviderSecret(t *testing.T, key, value string) {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "provider-credentials.json")
+	t.Setenv("SWARM_CREDENTIALS_FILE", path)
+	store, err := runtimecredentials.NewFileStore(path)
+	if err != nil {
+		t.Fatalf("NewFileStore: %v", err)
+	}
+	if err := store.Set(context.Background(), key, value); err != nil {
+		t.Fatalf("Set provider credential: %v", err)
+	}
+}
 
 func TestDoctorClaudeCLIPreflightReportsMissingPrerequisites(t *testing.T) {
 	configureDoctorDockerStub(t)
@@ -32,7 +46,7 @@ func TestDoctorClaudeCLIPreflightReportsMissingPrerequisites(t *testing.T) {
 		"claude_cli preflight: failed",
 		"backend_prerequisite/missing_backend_credential",
 		"workspace_prerequisite/workspace_image_unavailable",
-		"set CLAUDE_CODE_OAUTH_TOKEN",
+		"swarm secrets set CLAUDE_CODE_OAUTH_TOKEN",
 		"set SWARM_WORKSPACE_IMAGE",
 	} {
 		if !strings.Contains(stdout.String(), want) {
@@ -46,7 +60,7 @@ func TestDoctorClaudeCLIPreflightReportsMissingPrerequisites(t *testing.T) {
 
 func TestDoctorClaudeCLIPreflightReportsMissingDocker(t *testing.T) {
 	configureDoctorDockerStub(t)
-	t.Setenv("CLAUDE_CODE_OAUTH_TOKEN", "oauth-token")
+	setDoctorProviderSecret(t, "CLAUDE_CODE_OAUTH_TOKEN", "oauth-token")
 	t.Setenv("SWARM_TEST_DOCKER_UNAVAILABLE", "1")
 	t.Setenv("SWARM_TOOL_GATEWAY_URL", "")
 	t.Setenv("SWARM_TOOL_GATEWAY_CONTAINER_URL", "")
@@ -70,7 +84,8 @@ func TestDoctorClaudeCLIPreflightReportsMissingDocker(t *testing.T) {
 
 func TestDoctorClaudeCLIPreflightJSONReportsOKWithoutDB(t *testing.T) {
 	configureDoctorDockerStub(t)
-	t.Setenv("CLAUDE_CODE_OAUTH_TOKEN", "oauth-token")
+	t.Setenv("CLAUDE_CODE_OAUTH_TOKEN", "stale-oauth-token")
+	setDoctorProviderSecret(t, "CLAUDE_CODE_OAUTH_TOKEN", "oauth-token")
 	t.Setenv("SWARM_TOOL_GATEWAY_URL", "")
 	t.Setenv("SWARM_TOOL_GATEWAY_CONTAINER_URL", "")
 	t.Setenv("SWARM_TOOL_GATEWAY_TOKEN", "")
@@ -134,7 +149,7 @@ func TestDoctorClaudeCLIPreflightSkipsCredentialForAgentFreeContracts(t *testing
 
 func TestDoctorClaudeCLIPreflightReportsMissingWorkspaceCLI(t *testing.T) {
 	configureDoctorDockerStub(t)
-	t.Setenv("CLAUDE_CODE_OAUTH_TOKEN", "oauth-token")
+	setDoctorProviderSecret(t, "CLAUDE_CODE_OAUTH_TOKEN", "oauth-token")
 	t.Setenv("SWARM_TEST_DOCKER_CLI_MISSING", "1")
 	t.Setenv("SWARM_TOOL_GATEWAY_URL", "")
 	t.Setenv("SWARM_TOOL_GATEWAY_CONTAINER_URL", "")
@@ -159,7 +174,7 @@ func TestDoctorClaudeCLIPreflightReportsMissingWorkspaceCLI(t *testing.T) {
 
 func TestDoctorClaudeCLIPreflightReportsBrokenWorkspaceCLI(t *testing.T) {
 	configureDoctorDockerStub(t)
-	t.Setenv("CLAUDE_CODE_OAUTH_TOKEN", "oauth-token")
+	setDoctorProviderSecret(t, "CLAUDE_CODE_OAUTH_TOKEN", "oauth-token")
 	t.Setenv("SWARM_TEST_DOCKER_CLI_BROKEN", "1")
 	t.Setenv("SWARM_TOOL_GATEWAY_URL", "")
 	t.Setenv("SWARM_TOOL_GATEWAY_CONTAINER_URL", "")
@@ -183,8 +198,7 @@ func TestDoctorClaudeCLIPreflightReportsBrokenWorkspaceCLI(t *testing.T) {
 }
 
 func TestDoctorClaudeCLIPreflightUsesCredentialStoreForContractSecrets(t *testing.T) {
-	t.Setenv("CLAUDE_CODE_OAUTH_TOKEN", "oauth-token")
-	t.Setenv("SWARM_CREDENTIALS_FILE", filepath.Join(t.TempDir(), "credentials.json"))
+	setDoctorProviderSecret(t, "CLAUDE_CODE_OAUTH_TOKEN", "oauth-token")
 	t.Setenv("SWARM_TOOL_GATEWAY_URL", "")
 	t.Setenv("SWARM_TOOL_GATEWAY_CONTAINER_URL", "")
 	t.Setenv("SWARM_TOOL_GATEWAY_TOKEN", "")
@@ -215,7 +229,7 @@ func TestDoctorClaudeCLIPreflightUsesCredentialStoreForContractSecrets(t *testin
 
 func TestDoctorClaudeCLIPreflightReportsRetiredBackendEnv(t *testing.T) {
 	t.Setenv("SWARM_LLM_BACKEND", "cli_test")
-	t.Setenv("CLAUDE_CODE_OAUTH_TOKEN", "oauth-token")
+	setDoctorProviderSecret(t, "CLAUDE_CODE_OAUTH_TOKEN", "oauth-token")
 
 	var stdout, stderr bytes.Buffer
 	code := executeRootCommandWithOptions(context.Background(), repoRoot(), doctorClaudeArgs(t, writeDoctorClaudeConfig(t), false), &stdout, &stderr, defaultRootCommandOptions())
@@ -235,7 +249,7 @@ func TestDoctorClaudeCLIPreflightReportsRetiredBackendEnv(t *testing.T) {
 
 func TestDoctorClaudeCLIPreflightWarnsOnRetiredGatewayEnv(t *testing.T) {
 	configureDoctorDockerStub(t)
-	t.Setenv("CLAUDE_CODE_OAUTH_TOKEN", "oauth-token")
+	setDoctorProviderSecret(t, "CLAUDE_CODE_OAUTH_TOKEN", "oauth-token")
 	t.Setenv("SWARM_TOOL_GATEWAY_TOKEN", "operator-token")
 
 	mcpPort := freeDoctorTCPPort(t)

--- a/cmd/swarm/local_preflight.go
+++ b/cmd/swarm/local_preflight.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/division-sh/swarm/internal/config"
 	runtimecredentials "github.com/division-sh/swarm/internal/runtime/credentials"
+	runtimellm "github.com/division-sh/swarm/internal/runtime/llm"
 	llmselection "github.com/division-sh/swarm/internal/runtime/llm/selection"
 	"github.com/division-sh/swarm/internal/runtime/semanticview"
 	workspace "github.com/division-sh/swarm/internal/runtime/workspace"
@@ -125,10 +126,27 @@ func runLocalClaudeCLIPreflight(ctx context.Context, req localPreflightRequest) 
 		report.add(localPreflightWorkspacePrerequisite, "agent_free_source", localPreflightSeverityInfo, localPreflightStatusSkipped, "selected contract source declares no agents; claude_cli workspace proof is not required", "")
 		return report.finalize()
 	}
-	if err := llmselection.RequireCredential(profile, os.LookupEnv); err != nil {
-		report.add(localPreflightBackendPrerequisite, "missing_backend_credential", localPreflightSeverityBlocker, localPreflightStatusFailed, err.Error(), fmt.Sprintf("set %s for claude_cli backend authentication", strings.TrimSpace(profile.Credential.EnvVar)))
+	providerCredentialStore, err := buildProviderCredentialStore()
+	if err != nil {
+		report.add(localPreflightBackendPrerequisite, "provider_credential_store_unavailable", localPreflightSeverityBlocker, localPreflightStatusFailed, err.Error(), "fix the local credential store used by swarm secrets")
+		return report.finalize()
+	}
+	resolver := runtimellm.NewProviderCredentialResolver(providerCredentialStore)
+	credential, err := resolver.Inspect(ctx, profile)
+	if err != nil {
+		report.add(localPreflightBackendPrerequisite, "backend_credential_check_failed", localPreflightSeverityBlocker, localPreflightStatusFailed, err.Error(), "fix the local credential store used by swarm secrets")
+	} else if strings.TrimSpace(credential.Value) == "" {
+		_, err := resolver.Resolve(ctx, profile)
+		if err == nil {
+			err = fmt.Errorf("%s is required for %s", runtimellm.ProviderCredentialKey(profile), profile.Credential.Purpose)
+		}
+		report.add(localPreflightBackendPrerequisite, "missing_backend_credential", localPreflightSeverityBlocker, localPreflightStatusFailed, err.Error(), fmt.Sprintf("store %s with `swarm secrets set %s`", runtimellm.ProviderCredentialKey(profile), runtimellm.ProviderCredentialKey(profile)))
 	} else {
-		report.add(localPreflightBackendPrerequisite, "backend_credential_present", localPreflightSeverityInfo, localPreflightStatusOK, fmt.Sprintf("%s is present", strings.TrimSpace(profile.Credential.EnvVar)), "")
+		message := fmt.Sprintf("%s is present in swarm secrets", runtimellm.ProviderCredentialKey(profile))
+		if credential.EnvShadowed {
+			message += "; process env value is ignored"
+		}
+		report.add(localPreflightBackendPrerequisite, "backend_credential_present", localPreflightSeverityInfo, localPreflightStatusOK, message, "")
 	}
 	report.checkWorkspace(ctx, source, contractsRoot, req.MountSources, req.WorkspaceBackend, req.Config.LLM.ClaudeCLI.Command)
 	return report.finalize()

--- a/cmd/swarm/main.go
+++ b/cmd/swarm/main.go
@@ -212,17 +212,18 @@ func selectedPostgresAPIOptionalCapabilityBuilder(pg *store.PostgresStore, store
 				SourceLoader:                   runForkSourceLoader,
 				ContractSelection:              runtimerunforkadmission.SelectedContractSelection(req.Source, req.ContractsRoot),
 				AgentRuntime: runtimerunforkexecution.SelectedContractAgentRuntimeOptions{
-					Config:             req.Config,
-					EntityStore:        stores.ToolEntityStore,
-					HumanTaskStore:     stores.HumanTaskStore,
-					SessionRegistry:    stores.SessionRegistry,
-					ConversationStore:  stores.ConversationStore,
-					TurnStore:          stores.TurnStore,
-					ScheduleStore:      stores.ScheduleStore,
-					MailboxStore:       stores.MailboxStore,
-					Workspace:          req.Workspaces,
-					Credentials:        req.Credentials,
-					ManagedCredentials: req.ManagedCredentials,
+					Config:              req.Config,
+					EntityStore:         stores.ToolEntityStore,
+					HumanTaskStore:      stores.HumanTaskStore,
+					SessionRegistry:     stores.SessionRegistry,
+					ConversationStore:   stores.ConversationStore,
+					TurnStore:           stores.TurnStore,
+					ScheduleStore:       stores.ScheduleStore,
+					MailboxStore:        stores.MailboxStore,
+					Workspace:           req.Workspaces,
+					Credentials:         req.Credentials,
+					ManagedCredentials:  req.ManagedCredentials,
+					ProviderCredentials: req.ProviderCredentials,
 				},
 			},
 			RuntimeContexts:  apiRuntimeContexts,
@@ -392,6 +393,7 @@ type serveRuntimeBundleContextRequest struct {
 	WorkspaceBackend       workspaceBackendSelection
 	Credentials            runtimecredentials.Store
 	ManagedCredentials     runtimemanagedcredentials.Store
+	ProviderCredentials    runtimecredentials.Store
 	BootStartedAt          time.Time
 	BootProgress           func(runtime.BootProgressEvent)
 	EnableToolGateway      bool
@@ -720,6 +722,7 @@ func buildServeRuntimeBundleContext(req serveRuntimeBundleContextRequest) (serve
 			BundleSourceFact:                 bundleSourceFact,
 			Credentials:                      req.Credentials,
 			ManagedCredentials:               req.ManagedCredentials,
+			ProviderCredentials:              req.ProviderCredentials,
 			BootStartedAt:                    req.BootStartedAt,
 			BootProgress:                     req.BootProgress,
 			SystemContainers:                 systemWorkspaceContainers(workspaces),
@@ -745,7 +748,7 @@ func buildServeRuntimeBundleContext(req serveRuntimeBundleContextRequest) (serve
 	}, nil
 }
 
-func buildForkChatSandboxLLMRuntime(cfg *config.Config, workspaces workspace.Resolver, binding toolgateway.Binding) (runtimellm.Runtime, error) {
+func buildForkChatSandboxLLMRuntime(cfg *config.Config, workspaces workspace.Resolver, binding toolgateway.Binding, providerCredentials runtimecredentials.Store) (runtimellm.Runtime, error) {
 	if cfg == nil {
 		return nil, fmt.Errorf("runtime config is required")
 	}
@@ -755,6 +758,7 @@ func buildForkChatSandboxLLMRuntime(cfg *config.Config, workspaces workspace.Res
 		LockOwner:   "forkchat-sandbox",
 		Workspaces:  workspaces,
 		ToolGateway: binding,
+		Credentials: providerCredentials,
 	}.Build()
 }
 
@@ -975,6 +979,11 @@ func runServeRuntime(ctx context.Context, repo string, opts serveOptions) int {
 		slog.Error("configure managed credentials", "error", err)
 		return 1
 	}
+	providerCredentialStore, err := buildProviderCredentialStore()
+	if err != nil {
+		slog.Error("configure provider credentials", "error", err)
+		return 1
+	}
 
 	apiListener, err := listenServeHTTPListener("api", opts.APIListenAddr)
 	if err != nil {
@@ -1017,6 +1026,7 @@ func runServeRuntime(ctx context.Context, repo string, opts serveOptions) int {
 			WorkspaceBackend:       workspaceBackend,
 			Credentials:            credentialStore,
 			ManagedCredentials:     managedCredentialStore,
+			ProviderCredentials:    providerCredentialStore,
 			BootStartedAt:          bootStartedAt,
 			BootProgress:           reporter.runtimeSink(),
 			EnableToolGateway:      i == 0,
@@ -1042,14 +1052,14 @@ func runServeRuntime(ctx context.Context, repo string, opts serveOptions) int {
 	bootReport := primaryContext.validation.BootReport
 	stateStoreSummary := serveRuntimeStateStoreSummary(runtimeContexts)
 
-	forkChatLLM, err := buildForkChatSandboxLLMRuntime(cfg, workspaces, toolGatewayBinding)
+	forkChatLLM, err := buildForkChatSandboxLLMRuntime(cfg, workspaces, toolGatewayBinding, providerCredentialStore)
 	if err != nil {
 		log.Printf("init forkchat sandbox runtime: %v", err)
 		return 1
 	}
 
 	var ready atomic.Bool
-	supervisor := newRuntimeProjectSupervisor(repo, resolvedPlatformSpecPath, cfg, stores, &ready, mountSources, workspaceBackend, contractsRoot, bundle, source, rt, opts.Dev)
+	supervisor := newRuntimeProjectSupervisor(repo, resolvedPlatformSpecPath, cfg, stores, &ready, mountSources, workspaceBackend, credentialStore, providerCredentialStore, contractsRoot, bundle, source, rt, opts.Dev)
 	if len(pinnedBundleHashes) > 0 {
 		supervisor.DisableSourceReplacement("swarm serve --bundle-hash pins persisted bundle contexts for the process; dynamic project reload is split to RuntimeContextManager Load/Unload work")
 	}
@@ -1078,6 +1088,7 @@ func runServeRuntime(ctx context.Context, repo string, opts serveOptions) int {
 		Workspaces:              workspaces,
 		Credentials:             credentialStore,
 		ManagedCredentials:      managedCredentialStore,
+		ProviderCredentials:     providerCredentialStore,
 	})
 	if err != nil {
 		reporter.emit(5, "runtime_context", "FAILED", err.Error())
@@ -1643,6 +1654,13 @@ func runForkRuntimeOwnerHarness(ctx context.Context, repo string, args []string,
 			}
 			return 1
 		}
+		providerCredentialStore, err := buildProviderCredentialStore()
+		if err != nil {
+			if out != nil {
+				fmt.Fprintf(out, "fork failed: configure provider credentials: %v\n", err)
+			}
+			return 1
+		}
 		selectedProject := resolveLocalRuntimeStateProject(repo, cliContractPlatformSpecPaths{ContractsPath: contractsRoot})
 		mountSources, err := resolveWorkspaceMountSourcesForLocalState(repo, "", cfg, selectedProject, true)
 		if err != nil {
@@ -1674,17 +1692,18 @@ func runForkRuntimeOwnerHarness(ctx context.Context, repo string, args []string,
 			},
 			ContractSelection: runtimerunforkadmission.SelectedContractSelection(source, contractsRoot),
 			AgentRuntime: runtimerunforkexecution.SelectedContractAgentRuntimeOptions{
-				Config:             cfg,
-				EntityStore:        stores.ToolEntityStore,
-				HumanTaskStore:     stores.HumanTaskStore,
-				SessionRegistry:    stores.SessionRegistry,
-				ConversationStore:  stores.ConversationStore,
-				TurnStore:          stores.TurnStore,
-				ScheduleStore:      stores.ScheduleStore,
-				MailboxStore:       stores.MailboxStore,
-				Workspace:          workspaces,
-				Credentials:        credentialStore,
-				ManagedCredentials: managedCredentialStore,
+				Config:              cfg,
+				EntityStore:         stores.ToolEntityStore,
+				HumanTaskStore:      stores.HumanTaskStore,
+				SessionRegistry:     stores.SessionRegistry,
+				ConversationStore:   stores.ConversationStore,
+				TurnStore:           stores.TurnStore,
+				ScheduleStore:       stores.ScheduleStore,
+				MailboxStore:        stores.MailboxStore,
+				Workspace:           workspaces,
+				Credentials:         credentialStore,
+				ManagedCredentials:  managedCredentialStore,
+				ProviderCredentials: providerCredentialStore,
 			},
 		})
 		if err != nil {
@@ -3274,7 +3293,7 @@ func isLocalListenerHost(host string) bool {
 	return host == "" || host == "::" || host == "0.0.0.0" || host == "127.0.0.1" || host == "::1" || strings.EqualFold(host, "localhost")
 }
 
-func buildCredentialStore() (runtimecredentials.Store, error) {
+func credentialFileStore() (*runtimecredentials.FileStore, error) {
 	path := strings.TrimSpace(os.Getenv("SWARM_CREDENTIALS_FILE"))
 	if path == "" {
 		var err error
@@ -3283,7 +3302,11 @@ func buildCredentialStore() (runtimecredentials.Store, error) {
 			return nil, err
 		}
 	}
-	fileStore, err := runtimecredentials.NewFileStore(path)
+	return runtimecredentials.NewFileStore(path)
+}
+
+func buildCredentialStore() (runtimecredentials.Store, error) {
+	fileStore, err := credentialFileStore()
 	if err != nil {
 		return nil, err
 	}
@@ -3292,6 +3315,10 @@ func buildCredentialStore() (runtimecredentials.Store, error) {
 
 func buildManagedCredentialStore() (runtimemanagedcredentials.Store, error) {
 	return runtimemanagedcredentials.NewDefaultFileStore()
+}
+
+func buildProviderCredentialStore() (runtimecredentials.Store, error) {
+	return credentialFileStore()
 }
 
 func configuredWorkspaceLifecycle(db *sql.DB, contractsRoot string, source semanticview.Source, mountSources workspaceMountSources) (*workspace.DockerManager, error) {

--- a/cmd/swarm/main_test.go
+++ b/cmd/swarm/main_test.go
@@ -2869,8 +2869,11 @@ func TestPlatformSpecLLMProviderModelSelectionSourceAuthorityPromoted(t *testing
 							ProviderContractRuntimeMode string   `yaml:"provider_contract_runtime_mode"`
 							LegacyBackendIDs            []string `yaml:"legacy_backend_ids"`
 							CredentialSource            struct {
-								EnvVar   string `yaml:"env_var"`
-								Required bool   `yaml:"required"`
+								SecretKey      string `yaml:"secret_key"`
+								Owner          string `yaml:"owner"`
+								LegacyEnvVar   string `yaml:"legacy_env_var"`
+								Required       bool   `yaml:"required"`
+								ResolutionRule string `yaml:"resolution_rule"`
 							} `yaml:"credential_source"`
 							EndpointSource struct {
 								ConfigKey      string `yaml:"config_key"`
@@ -2887,8 +2890,11 @@ func TestPlatformSpecLLMProviderModelSelectionSourceAuthorityPromoted(t *testing
 							ProviderContractRuntimeMode string `yaml:"provider_contract_runtime_mode"`
 							Protocol                    string `yaml:"protocol"`
 							CredentialSource            struct {
-								EnvVar   string `yaml:"env_var"`
-								Required bool   `yaml:"required"`
+								SecretKey      string `yaml:"secret_key"`
+								Owner          string `yaml:"owner"`
+								LegacyEnvVar   string `yaml:"legacy_env_var"`
+								Required       bool   `yaml:"required"`
+								ResolutionRule string `yaml:"resolution_rule"`
 							} `yaml:"credential_source"`
 							EndpointSource struct {
 								ConfigKey      string `yaml:"config_key"`
@@ -2922,8 +2928,11 @@ func TestPlatformSpecLLMProviderModelSelectionSourceAuthorityPromoted(t *testing
 						} `yaml:"protocol_family"`
 						CredentialAndEndpointPolicy struct {
 							CredentialSource struct {
-								EnvVar   string `yaml:"env_var"`
-								Required bool   `yaml:"required"`
+								SecretKey      string `yaml:"secret_key"`
+								Owner          string `yaml:"owner"`
+								LegacyEnvVar   string `yaml:"legacy_env_var"`
+								Required       bool   `yaml:"required"`
+								ResolutionRule string `yaml:"resolution_rule"`
 							} `yaml:"credential_source"`
 							EndpointSource struct {
 								ConfigKey      string `yaml:"config_key"`
@@ -2957,9 +2966,11 @@ func TestPlatformSpecLLMProviderModelSelectionSourceAuthorityPromoted(t *testing
 						AuditRule                  string                       `yaml:"audit_rule"`
 					} `yaml:"model_alias_authority"`
 					CredentialAndConfigPolicy struct {
-						SecretEnvSources              []string `yaml:"secret_env_sources"`
-						RuntimeConfigCanonicalFor     []string `yaml:"runtime_config_canonical_for"`
-						InfraConnectionOverridePolicy string   `yaml:"infra_connection_override_policy"`
+						ProviderSecretKeys                 []string `yaml:"provider_secret_keys"`
+						DeprecatedProviderEnvShadowSources []string `yaml:"deprecated_provider_env_shadow_sources"`
+						SecretEnvSources                   []string `yaml:"secret_env_sources"`
+						RuntimeConfigCanonicalFor          []string `yaml:"runtime_config_canonical_for"`
+						InfraConnectionOverridePolicy      string   `yaml:"infra_connection_override_policy"`
 					} `yaml:"credential_and_config_policy"`
 					PersistenceRules []string `yaml:"persistence_rules"`
 					SplitBoundaries  []string `yaml:"split_boundaries"`
@@ -3021,11 +3032,22 @@ func TestPlatformSpecLLMProviderModelSelectionSourceAuthorityPromoted(t *testing
 	if got := profiles["openai_compatible"]; got.Provider != "openai_compatible" || got.ProviderContractRuntimeMode != "openai_compatible" || got.EndpointSource.EnvVar != "" || !strings.Contains(got.EndpointSource.Rule, "SWARM_OPENAI_COMPATIBLE_BASE_URL is retired") {
 		t.Fatalf("openai_compatible profile = %#v", got)
 	}
+	for backend, wantKey := range map[string]string{
+		"anthropic":         "ANTHROPIC_API_KEY",
+		"claude_cli":        "CLAUDE_CODE_OAUTH_TOKEN",
+		"openai_compatible": "OPENAI_COMPATIBLE_API_KEY",
+		"openai_responses":  "OPENAI_API_KEY",
+	} {
+		source := profiles[backend].CredentialSource
+		if source.SecretKey != wantKey || source.Owner != "swarm secrets" || source.LegacyEnvVar != wantKey || !source.Required || !strings.Contains(source.ResolutionRule, "process env is deprecated diagnostic shadow") {
+			t.Fatalf("%s credential source = %#v, want swarm secrets source key %s with deprecated env shadow only", backend, source, wantKey)
+		}
+	}
 	openAIResponses := profiles["openai_responses"]
 	if openAIResponses.Provider != "openai" || openAIResponses.ProviderContractRuntimeMode != "openai_responses" || openAIResponses.Transport != "api" {
 		t.Fatalf("openai_responses profile = %#v", openAIResponses)
 	}
-	if openAIResponses.CredentialSource.EnvVar != "OPENAI_API_KEY" || !openAIResponses.CredentialSource.Required {
+	if openAIResponses.CredentialSource.SecretKey != "OPENAI_API_KEY" || openAIResponses.CredentialSource.Owner != "swarm secrets" || openAIResponses.CredentialSource.LegacyEnvVar != "OPENAI_API_KEY" || !openAIResponses.CredentialSource.Required || !strings.Contains(openAIResponses.CredentialSource.ResolutionRule, "must not beat a stored secret") {
 		t.Fatalf("openai_responses credential source = %#v", openAIResponses.CredentialSource)
 	}
 	if openAIResponses.EndpointSource.ConfigKey != "llm.openai_responses.base_url" || openAIResponses.EndpointSource.EnvVar != "" || openAIResponses.EndpointSource.Required || openAIResponses.EndpointSource.BuiltInDefault != "https://api.openai.com/v1" {
@@ -3069,7 +3091,7 @@ func TestPlatformSpecLLMProviderModelSelectionSourceAuthorityPromoted(t *testing
 			t.Fatalf("native responses protocol scope missing %q: %#v", want, protocol)
 		}
 	}
-	if responses.CredentialAndEndpointPolicy.CredentialSource.EnvVar != "OPENAI_API_KEY" || !responses.CredentialAndEndpointPolicy.CredentialSource.Required {
+	if responses.CredentialAndEndpointPolicy.CredentialSource.SecretKey != "OPENAI_API_KEY" || responses.CredentialAndEndpointPolicy.CredentialSource.Owner != "swarm secrets" || responses.CredentialAndEndpointPolicy.CredentialSource.LegacyEnvVar != "OPENAI_API_KEY" || !responses.CredentialAndEndpointPolicy.CredentialSource.Required {
 		t.Fatalf("native responses credential policy = %#v", responses.CredentialAndEndpointPolicy.CredentialSource)
 	}
 	if responses.CredentialAndEndpointPolicy.EndpointSource.ConfigKey != "llm.openai_responses.base_url" || responses.CredentialAndEndpointPolicy.EndpointSource.EnvVar != "" || responses.CredentialAndEndpointPolicy.EndpointSource.BuiltInDefault != "https://api.openai.com/v1" {
@@ -3127,8 +3149,14 @@ func TestPlatformSpecLLMProviderModelSelectionSourceAuthorityPromoted(t *testing
 		}
 	}
 	for _, want := range []string{"ANTHROPIC_API_KEY", "CLAUDE_CODE_OAUTH_TOKEN", "OPENAI_COMPATIBLE_API_KEY", "OPENAI_API_KEY"} {
-		if !stringSliceContains(authority.CredentialAndConfigPolicy.SecretEnvSources, want) {
-			t.Fatalf("secret env sources missing %q: %#v", want, authority.CredentialAndConfigPolicy.SecretEnvSources)
+		if !stringSliceContains(authority.CredentialAndConfigPolicy.ProviderSecretKeys, want) {
+			t.Fatalf("provider secret keys missing %q: %#v", want, authority.CredentialAndConfigPolicy.ProviderSecretKeys)
+		}
+		if !stringSliceContains(authority.CredentialAndConfigPolicy.DeprecatedProviderEnvShadowSources, want) {
+			t.Fatalf("deprecated provider env shadow sources missing %q: %#v", want, authority.CredentialAndConfigPolicy.DeprecatedProviderEnvShadowSources)
+		}
+		if stringSliceContains(authority.CredentialAndConfigPolicy.SecretEnvSources, want) {
+			t.Fatalf("provider key %q still promoted as secret env source: %#v", want, authority.CredentialAndConfigPolicy.SecretEnvSources)
 		}
 	}
 	if stringSliceContains(authority.CredentialAndConfigPolicy.SecretEnvSources, "SWARM_TOOL_GATEWAY_TOKEN") {

--- a/cmd/swarm/secrets.go
+++ b/cmd/swarm/secrets.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	runtimecredentials "github.com/division-sh/swarm/internal/runtime/credentials"
+	runtimellm "github.com/division-sh/swarm/internal/runtime/llm"
 	"github.com/division-sh/swarm/internal/runtime/semanticview"
 	"github.com/spf13/cobra"
 	"golang.org/x/term"
@@ -139,7 +140,15 @@ func newSecretsListCommand(ctx context.Context, repo string) *cobra.Command {
 			if err != nil {
 				return returnSecretsRuntimeError(cmd.ErrOrStderr(), err)
 			}
-			descriptors, err := runtimecredentials.ListDescriptors(ctx, store, source)
+			providerRequirements, err := loadSecretsProviderRequirements(repo, source)
+			if err != nil {
+				return returnSecretsRuntimeError(cmd.ErrOrStderr(), err)
+			}
+			providerStore, err := providerCredentialStoreForRequirements(providerRequirements)
+			if err != nil {
+				return returnSecretsRuntimeError(cmd.ErrOrStderr(), fmt.Errorf("configure provider credential store: %w", err))
+			}
+			descriptors, err := listSecretsDescriptors(ctx, store, providerStore, source, providerRequirements)
 			if err != nil {
 				return returnSecretsRuntimeError(cmd.ErrOrStderr(), err)
 			}
@@ -176,10 +185,19 @@ func newSecretsCheckCommand(ctx context.Context, repo string) *cobra.Command {
 			if err != nil {
 				return returnSecretsRuntimeError(cmd.ErrOrStderr(), err)
 			}
-			missing, err := runtimecredentials.MissingRequired(ctx, store, source)
+			providerRequirements, err := loadSecretsProviderRequirements(repo, source)
 			if err != nil {
 				return returnSecretsRuntimeError(cmd.ErrOrStderr(), err)
 			}
+			providerStore, err := providerCredentialStoreForRequirements(providerRequirements)
+			if err != nil {
+				return returnSecretsRuntimeError(cmd.ErrOrStderr(), fmt.Errorf("configure provider credential store: %w", err))
+			}
+			descriptors, err := listSecretsDescriptors(ctx, store, providerStore, source, providerRequirements)
+			if err != nil {
+				return returnSecretsRuntimeError(cmd.ErrOrStderr(), err)
+			}
+			missing := missingSecretDescriptors(descriptors)
 			records := secretRecordsFromDescriptors(missing)
 			result := secretsCheckResult{OK: len(records) == 0, Missing: records}
 			if opts.asJSON {
@@ -319,6 +337,116 @@ func loadSecretsSourceRequired(repo, contractsPath, platformSpecPath string) (se
 		return nil, fmt.Errorf("load Swarm contracts: %w", err)
 	}
 	return semanticview.Wrap(bundle), nil
+}
+
+func loadSecretsProviderRequirements(repo string, source semanticview.Source) (map[string][]runtimecredentials.Requirement, error) {
+	requirements := map[string][]runtimecredentials.Requirement{}
+	if !sourceDeclaresAgents(source) {
+		return requirements, nil
+	}
+	configResult, err := loadRuntimeConfigWithOptions(runtimeConfigLoadOptions{RepoRoot: repo})
+	if err != nil {
+		return nil, fmt.Errorf("load runtime config for provider secret requirements: %w", err)
+	}
+	profile, err := configResult.Config.LLMBackendProfile()
+	if err != nil {
+		return nil, fmt.Errorf("resolve provider secret requirement: %w", err)
+	}
+	key := runtimellm.ProviderCredentialKey(profile)
+	if !profile.Credential.Required || key == "" {
+		return requirements, nil
+	}
+	requirements[key] = []runtimecredentials.Requirement{{Kind: "provider", Name: strings.TrimSpace(profile.ID)}}
+	return requirements, nil
+}
+
+func providerCredentialStoreForRequirements(requirements map[string][]runtimecredentials.Requirement) (runtimecredentials.Store, error) {
+	if len(requirements) == 0 {
+		return nil, nil
+	}
+	return buildProviderCredentialStore()
+}
+
+func listSecretsDescriptors(ctx context.Context, store, providerStore runtimecredentials.Store, source semanticview.Source, providerRequirements map[string][]runtimecredentials.Requirement) ([]runtimecredentials.Descriptor, error) {
+	descriptors, err := runtimecredentials.ListDescriptors(ctx, store, source)
+	if err != nil {
+		return nil, err
+	}
+	return mergeProviderSecretDescriptors(ctx, descriptors, providerStore, providerRequirements)
+}
+
+func mergeProviderSecretDescriptors(ctx context.Context, descriptors []runtimecredentials.Descriptor, providerStore runtimecredentials.Store, providerRequirements map[string][]runtimecredentials.Requirement) ([]runtimecredentials.Descriptor, error) {
+	if len(providerRequirements) == 0 {
+		return descriptors, nil
+	}
+	byKey := make(map[string]runtimecredentials.Descriptor, len(descriptors)+len(providerRequirements))
+	for _, desc := range descriptors {
+		byKey[strings.TrimSpace(desc.Key)] = desc
+	}
+	for key, requiredBy := range providerRequirements {
+		key = strings.TrimSpace(key)
+		if key == "" {
+			continue
+		}
+		desc, err := runtimecredentials.Describe(ctx, providerStore, nil, key)
+		if err != nil {
+			return nil, err
+		}
+		if existing, ok := byKey[key]; ok {
+			desc.RequiredBy = mergeCredentialRequirements(existing.RequiredBy, requiredBy)
+		} else {
+			desc.RequiredBy = mergeCredentialRequirements(nil, requiredBy)
+		}
+		byKey[key] = desc
+	}
+	out := make([]runtimecredentials.Descriptor, 0, len(byKey))
+	for _, desc := range byKey {
+		if strings.TrimSpace(desc.Key) == "" {
+			continue
+		}
+		out = append(out, desc)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		return out[i].Key < out[j].Key
+	})
+	return out, nil
+}
+
+func mergeCredentialRequirements(left, right []runtimecredentials.Requirement) []runtimecredentials.Requirement {
+	items := append(append([]runtimecredentials.Requirement{}, left...), right...)
+	out := make([]runtimecredentials.Requirement, 0, len(items))
+	seen := map[string]struct{}{}
+	for _, item := range items {
+		item.Kind = strings.TrimSpace(item.Kind)
+		item.Name = strings.TrimSpace(item.Name)
+		if item.Kind == "" || item.Name == "" {
+			continue
+		}
+		key := item.Kind + "\x00" + item.Name
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		out = append(out, item)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Kind == out[j].Kind {
+			return out[i].Name < out[j].Name
+		}
+		return out[i].Kind < out[j].Kind
+	})
+	return out
+}
+
+func missingSecretDescriptors(descriptors []runtimecredentials.Descriptor) []runtimecredentials.Descriptor {
+	out := make([]runtimecredentials.Descriptor, 0)
+	for _, desc := range descriptors {
+		if desc.Present || len(desc.RequiredBy) == 0 {
+			continue
+		}
+		out = append(out, desc)
+	}
+	return out
 }
 
 func secretRecordsFromDescriptors(descriptors []runtimecredentials.Descriptor) []secretRecord {

--- a/cmd/swarm/secrets_test.go
+++ b/cmd/swarm/secrets_test.go
@@ -84,6 +84,74 @@ func TestSecretsSetListCheckAndRemoveUseFileTierWithoutLeakingValues(t *testing.
 	}
 }
 
+func TestSecretsCheckIncludesSelectedProviderCredential(t *testing.T) {
+	isolateCLIAPIConfigEnv(t)
+	repo := t.TempDir()
+	writeWorkflowValidationFixtureFile(t, filepath.Join(repo, "go.mod"), "module provider-secrets-test\n")
+	contractsRoot := writeProviderSecretsCommandContractsFixture(t)
+	t.Setenv("SWARM_CREDENTIALS_FILE", filepath.Join(t.TempDir(), "credentials.json"))
+	t.Setenv("OPENAI_API_KEY", "env-only-openai-key")
+	withExecutableRuntimeConfig(t, strings.Join([]string{
+		"llm:",
+		"  backend: openai_responses",
+		"  session:",
+		"    lock_ttl: 10s",
+		"    rotate_after_turns: 40",
+		"    rotate_on_parse_failures: 3",
+	}, "\n")+"\n")
+
+	code, stdout, stderr := executeRootCommandWithInput(context.Background(), repo, []string{"secrets", "check", "--contracts", contractsRoot, "--json"}, "")
+	if code != cliExitRuntime {
+		t.Fatalf("initial check code = %d stdout=%s stderr=%s", code, stdout, stderr)
+	}
+	var missing secretsCheckResult
+	if err := json.Unmarshal([]byte(stdout), &missing); err != nil {
+		t.Fatalf("decode check json: %v\n%s", err, stdout)
+	}
+	if missing.OK || len(missing.Missing) != 1 {
+		t.Fatalf("initial check result = %+v", missing)
+	}
+	provider := missing.Missing[0]
+	if provider.Key != "OPENAI_API_KEY" || provider.Present || provider.Source != "" {
+		t.Fatalf("provider missing record = %+v, want file-backed missing OPENAI_API_KEY", provider)
+	}
+	if len(provider.RequiredBy) != 1 || provider.RequiredBy[0].Kind != "provider" || provider.RequiredBy[0].Name != "openai_responses" {
+		t.Fatalf("provider required_by = %+v, want provider:openai_responses", provider.RequiredBy)
+	}
+
+	code, stdout, stderr = executeRootCommandWithInput(context.Background(), repo, []string{"secrets", "list", "--contracts", contractsRoot, "--missing", "--json"}, "")
+	if code != 0 {
+		t.Fatalf("list --missing code = %d stdout=%s stderr=%s", code, stdout, stderr)
+	}
+	var listed secretsListResult
+	if err := json.Unmarshal([]byte(stdout), &listed); err != nil {
+		t.Fatalf("decode list json: %v\n%s", err, stdout)
+	}
+	if len(listed.Secrets) != 1 || listed.Secrets[0].Key != "OPENAI_API_KEY" {
+		t.Fatalf("list --missing result = %+v, want missing OPENAI_API_KEY", listed)
+	}
+
+	code, stdout, stderr = executeRootCommandWithInput(context.Background(), repo, []string{"secrets", "set", "OPENAI_API_KEY", "--stdin"}, "stored-openai-key\n")
+	if code != 0 {
+		t.Fatalf("set provider code = %d stdout=%s stderr=%s", code, stdout, stderr)
+	}
+	if strings.Contains(stdout+stderr, "stored-openai-key") || strings.Contains(stdout+stderr, "env-only-openai-key") {
+		t.Fatalf("set provider output leaked secret stdout=%q stderr=%q", stdout, stderr)
+	}
+
+	code, stdout, stderr = executeRootCommandWithInput(context.Background(), repo, []string{"secrets", "check", "--contracts", contractsRoot, "--json"}, "")
+	if code != 0 {
+		t.Fatalf("check after set code = %d stdout=%s stderr=%s", code, stdout, stderr)
+	}
+	var ok secretsCheckResult
+	if err := json.Unmarshal([]byte(stdout), &ok); err != nil {
+		t.Fatalf("decode ok json: %v\n%s", err, stdout)
+	}
+	if !ok.OK || len(ok.Missing) != 0 {
+		t.Fatalf("check after set result = %+v, want ok", ok)
+	}
+}
+
 func TestSecretsListShowsEnvShadowingAndRemoveKeepsEnvEffective(t *testing.T) {
 	isolateCLIAPIConfigEnv(t)
 	repo := t.TempDir()
@@ -268,4 +336,44 @@ email_api:
 	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "nodes.yaml"), "{}\n")
 	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "events.yaml"), "{}\n")
 	return root
+}
+
+func writeProviderSecretsCommandContractsFixture(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "package.yaml"), `
+name: provider-secrets-command-fixture
+version: "1.0.0"
+platform_version: ">=0.7.0 <0.8.0"
+`)
+	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "schema.yaml"), "name: provider-secrets-command-fixture\n")
+	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "policy.yaml"), "{}\n")
+	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "tools.yaml"), "{}\n")
+	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "agents.yaml"), `
+provider-agent:
+  id: provider-agent
+  role: provider
+  prompt_ref: provider-agent
+  model: regular
+  mode: task
+`)
+	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "prompts", "provider-agent.md"), "Handle provider-backed work.\n")
+	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "nodes.yaml"), "{}\n")
+	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "events.yaml"), "{}\n")
+	return root
+}
+
+func withExecutableRuntimeConfig(t *testing.T, configText string) {
+	t.Helper()
+	original := runtimeConfigExecutablePath
+	exeDir := t.TempDir()
+	exePath := filepath.Join(exeDir, "swarm")
+	writeWorkflowValidationFixtureFile(t, exePath, "")
+	writeRuntimeConfigText(t, filepath.Join(exeDir, "config.yaml"), configText)
+	runtimeConfigExecutablePath = func() (string, error) {
+		return exePath, nil
+	}
+	t.Cleanup(func() {
+		runtimeConfigExecutablePath = original
+	})
 }

--- a/cmd/swarm/store_facade.go
+++ b/cmd/swarm/store_facade.go
@@ -74,6 +74,7 @@ type selectedAPICapabilityRequest struct {
 	Workspaces              serveWorkspaceLifecycle
 	Credentials             runtimecredentials.Store
 	ManagedCredentials      runtimemanagedcredentials.Store
+	ProviderCredentials     runtimecredentials.Store
 }
 
 type selectedAPIOptionalCapabilityBuilder func(selectedAPICapabilityRequest) (selectedAPICapabilities, error)

--- a/internal/runtime/cataloge2e/tier8_boot_e2e_test.go
+++ b/internal/runtime/cataloge2e/tier8_boot_e2e_test.go
@@ -14,6 +14,7 @@ import (
 	runtime "github.com/division-sh/swarm/internal/runtime"
 	runtimebootverify "github.com/division-sh/swarm/internal/runtime/bootverify"
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
+	runtimecredentials "github.com/division-sh/swarm/internal/runtime/credentials"
 	"github.com/division-sh/swarm/internal/runtime/semanticview"
 )
 
@@ -176,17 +177,29 @@ func TestTier8BootCatalogFixtures_AreExplicitlyClassified(t *testing.T) {
 
 func newTier8Runtime(t testing.TB, bundle *runtimecontracts.WorkflowContractBundle) (*runtime.Runtime, error) {
 	t.Helper()
-	t.Setenv("ANTHROPIC_API_KEY", "test-key")
 	strictCatalogFixtureStartupPolicy().apply(t)
 	module, err := newFixtureWorkflowModule(bundle)
 	if err != nil {
 		return nil, err
 	}
 	return runtime.NewRuntime(context.Background(), runtime.RuntimeDeps{Config: testRuntimeConfig(), Stores: runtime.Stores{}, Options: runtime.RuntimeOptions{
-		SelfCheck:      false,
-		WorkflowModule: module,
+		SelfCheck:           false,
+		WorkflowModule:      module,
+		ProviderCredentials: tier8ProviderCredentialStore(t, "ANTHROPIC_API_KEY", "test-key"),
 	}})
 
+}
+
+func tier8ProviderCredentialStore(t testing.TB, key, value string) runtimecredentials.Store {
+	t.Helper()
+	store, err := runtimecredentials.NewFileStore(filepath.Join(t.TempDir(), "provider-credentials.json"))
+	if err != nil {
+		t.Fatalf("NewFileStore: %v", err)
+	}
+	if err := store.Set(context.Background(), key, value); err != nil {
+		t.Fatalf("Set provider credential: %v", err)
+	}
+	return store
 }
 
 func assertTier8RuntimeBootMatchesAuthoritativeStartupTruth(t testing.TB, bundle *runtimecontracts.WorkflowContractBundle, expected tier8ExpectedDocument) {

--- a/internal/runtime/conformance/persisted_surfaces_test.go
+++ b/internal/runtime/conformance/persisted_surfaces_test.go
@@ -24,6 +24,7 @@ import (
 	runtimeactors "github.com/division-sh/swarm/internal/runtime/core/actors"
 	runtimeownership "github.com/division-sh/swarm/internal/runtime/core/ownership"
 	runtimecorrelation "github.com/division-sh/swarm/internal/runtime/correlation"
+	runtimecredentials "github.com/division-sh/swarm/internal/runtime/credentials"
 	runtimediaglog "github.com/division-sh/swarm/internal/runtime/diaglog"
 	runtimellm "github.com/division-sh/swarm/internal/runtime/llm"
 	runtimemanager "github.com/division-sh/swarm/internal/runtime/manager"
@@ -49,6 +50,18 @@ func (s staticWorkspaceResolver) ResolveWorkspace(context.Context, runtimeactors
 		return nil, s.err
 	}
 	return s.target, nil
+}
+
+func conformanceProviderCredentialResolver(t testing.TB, key, value string) runtimellm.ProviderCredentialResolver {
+	t.Helper()
+	store, err := runtimecredentials.NewFileStore(filepath.Join(t.TempDir(), "provider-credentials.json"))
+	if err != nil {
+		t.Fatalf("NewFileStore: %v", err)
+	}
+	if err := store.Set(context.Background(), key, value); err != nil {
+		t.Fatalf("Set provider credential: %v", err)
+	}
+	return runtimellm.NewProviderCredentialResolver(store)
 }
 
 func acquireLiveConversationSession(t *testing.T, ctx context.Context, db *sql.DB, agentID string, runtimeMode runtimesessions.RuntimeMode, sessionScope runtimesessions.SessionScope, scopeKey string) string {
@@ -262,14 +275,12 @@ func TestReusedLiveSessionKeepsDeliveryFrontierBoundToCanonicalSession(t *testin
 	defer func() {
 		http.DefaultTransport = previousTransport
 	}()
-	t.Setenv("ANTHROPIC_API_KEY", "test-key")
-
 	bus, err := runtimebus.NewEventBus(pg)
 	if err != nil {
 		t.Fatalf("NewEventBus: %v", err)
 	}
 	registry := runtimesessions.NewPostgresRegistry(db, 30*time.Second)
-	runtime := runtimellm.NewAnthropicAPIRuntime(&config.Config{}, registry, "worker-1", nil, pg, nil, bus)
+	runtime := runtimellm.NewAnthropicAPIRuntimeWithProviderCredentials(&config.Config{}, registry, "worker-1", nil, pg, nil, bus, conformanceProviderCredentialResolver(t, "ANTHROPIC_API_KEY", "test-key"))
 
 	newTurnContext := func(evt events.Event) context.Context {
 		base := runtimesessions.WithScope(context.Background(), runtimesessions.RuntimeModeSession.String(), runtimesessions.SessionScopeFlow.String(), "support/inst-1")
@@ -415,14 +426,14 @@ printf '{"result":"ok"}'
 	}
 	t.Setenv("SWARM_DOCKER_BIN", fakeDocker)
 	t.Setenv("SWARM_FAKE_DOCKER_STATE", dockerState)
-	t.Setenv("CLAUDE_CODE_OAUTH_TOKEN", "oauth-token")
+	t.Setenv("CLAUDE_CODE_OAUTH_TOKEN", "stale-oauth-token")
 
 	registry := runtimesessions.NewPostgresRegistry(db, 30*time.Second)
 	bus, err := runtimebus.NewEventBus(pg)
 	if err != nil {
 		t.Fatalf("NewEventBus: %v", err)
 	}
-	runtime := runtimellm.NewClaudeCLIRuntime(&config.Config{
+	runtime := runtimellm.NewClaudeCLIRuntimeWithOptions(&config.Config{
 		LLM: config.LLMConfig{
 			ClaudeCLI: config.ClaudeCLIConfig{
 				Command:      "claude",
@@ -434,7 +445,9 @@ printf '{"result":"ok"}'
 			Container: "swarm-agent-1",
 			Workdir:   "/workspace",
 		},
-	}, pg, bus)
+	}, pg, bus, runtimellm.ClaudeCLIRuntimeOptions{
+		ProviderCredentials: conformanceProviderCredentialResolver(t, "CLAUDE_CODE_OAUTH_TOKEN", "oauth-token"),
+	})
 
 	newTurnContext := func(evt events.Event) context.Context {
 		base := runtimesessions.WithScope(context.Background(), runtimesessions.RuntimeModeSession.String(), runtimesessions.SessionScopeFlow.String(), "support/inst-1")

--- a/internal/runtime/llm/api_runtime.go
+++ b/internal/runtime/llm/api_runtime.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"os"
 	"strings"
 	"time"
 
@@ -33,10 +32,16 @@ type AnthropicAPIRuntime struct {
 	apiKey            string
 	events            EventPublisher
 	providerAdmission *ProviderAdmissionRegistry
+	credentials       ProviderCredentialResolver
 }
 
 func NewAnthropicAPIRuntime(cfg *config.Config, sessions sessions.Registry, lockOwner string, turns TurnPersistence, conversations ConversationPersistence, budget BudgetGuard, publisher EventPublisher) *AnthropicAPIRuntime {
+	return NewAnthropicAPIRuntimeWithProviderCredentials(cfg, sessions, lockOwner, turns, conversations, budget, publisher, NewProviderCredentialResolver(nil))
+}
+
+func NewAnthropicAPIRuntimeWithProviderCredentials(cfg *config.Config, sessions sessions.Registry, lockOwner string, turns TurnPersistence, conversations ConversationPersistence, budget BudgetGuard, publisher EventPublisher, credentials ProviderCredentialResolver) *AnthropicAPIRuntime {
 	profile, _ := llmselection.ResolveActiveBackend(llmselection.BackendAnthropic)
+	_ = profile
 	return &AnthropicAPIRuntime{
 		cfg:           cfg,
 		sessions:      sessions,
@@ -48,9 +53,9 @@ func NewAnthropicAPIRuntime(cfg *config.Config, sessions sessions.Registry, lock
 			Timeout: 120 * time.Second,
 		},
 		apiURL:            "https://api.anthropic.com/v1/messages",
-		apiKey:            llmselection.CredentialValue(profile, os.LookupEnv),
 		events:            publisher,
 		providerAdmission: NewProviderAdmissionRegistry(cfg),
+		credentials:       credentials,
 	}
 }
 
@@ -240,10 +245,11 @@ func (r *AnthropicAPIRuntime) ContinueSession(ctx context.Context, s *Session, m
 
 	profile, _ := llmselection.ResolveActiveBackend(llmselection.BackendAnthropic)
 	if strings.TrimSpace(r.apiKey) == "" {
-		r.apiKey = llmselection.CredentialValue(profile, os.LookupEnv)
-		if strings.TrimSpace(r.apiKey) == "" {
-			return nil, llmselection.RequireCredential(profile, os.LookupEnv)
+		credential, err := r.credentials.Resolve(ctx, profile)
+		if err != nil {
+			return nil, err
 		}
+		r.apiKey = credential.Value
 	}
 
 	reqBody, err := r.buildRequest(ctx, s, message)

--- a/internal/runtime/llm/cli_runtime.go
+++ b/internal/runtime/llm/cli_runtime.go
@@ -18,19 +18,20 @@ import (
 )
 
 type ClaudeCLIRuntime struct {
-	cfg               *config.Config
-	sessions          sessions.Registry
-	turns             TurnPersistence
-	conversations     ConversationPersistence
-	budget            BudgetGuard
-	lockOwner         string
-	workspaces        workspace.Resolver
-	monitor           MonitorSink
-	events            EventPublisher
-	mcpTurns          MCPTurnContextStore
-	toolGateway       toolgateway.Binding
-	execWorkspaceFn   func(ctx context.Context, target *workspace.Target, stdin string, args ...string) ([]byte, []byte, int, error)
-	providerAdmission *ProviderAdmissionRegistry
+	cfg                 *config.Config
+	sessions            sessions.Registry
+	turns               TurnPersistence
+	conversations       ConversationPersistence
+	budget              BudgetGuard
+	lockOwner           string
+	workspaces          workspace.Resolver
+	monitor             MonitorSink
+	events              EventPublisher
+	mcpTurns            MCPTurnContextStore
+	toolGateway         toolgateway.Binding
+	providerCredentials ProviderCredentialResolver
+	execWorkspaceFn     func(ctx context.Context, target *workspace.Target, stdin string, args ...string) ([]byte, []byte, int, error)
+	providerAdmission   *ProviderAdmissionRegistry
 }
 
 var ErrClaudeAuthRequired = errors.New("claude auth required")
@@ -46,6 +47,7 @@ type ClaudeCLIRuntimeOptions struct {
 	MonitorSink         MonitorSink
 	MCPTurnContextStore MCPTurnContextStore
 	ToolGateway         toolgateway.Binding
+	ProviderCredentials ProviderCredentialResolver
 }
 
 func NewClaudeCLIRuntime(
@@ -76,19 +78,24 @@ func NewClaudeCLIRuntimeWithOptions(
 	if monitor == nil {
 		monitor = NewFileMonitorSink(DefaultMonitorDir())
 	}
+	providerCredentials := opts.ProviderCredentials
+	if providerCredentials.EnvLookup == nil {
+		providerCredentials = NewProviderCredentialResolver(providerCredentials.Store)
+	}
 	return &ClaudeCLIRuntime{
-		cfg:               cfg,
-		sessions:          sessions,
-		turns:             turns,
-		conversations:     conversations,
-		budget:            budget,
-		lockOwner:         lockOwner,
-		workspaces:        workspaces,
-		monitor:           monitor,
-		events:            publisher,
-		mcpTurns:          opts.MCPTurnContextStore,
-		toolGateway:       opts.ToolGateway,
-		providerAdmission: NewProviderAdmissionRegistry(cfg),
+		cfg:                 cfg,
+		sessions:            sessions,
+		turns:               turns,
+		conversations:       conversations,
+		budget:              budget,
+		lockOwner:           lockOwner,
+		workspaces:          workspaces,
+		monitor:             monitor,
+		events:              publisher,
+		mcpTurns:            opts.MCPTurnContextStore,
+		toolGateway:         opts.ToolGateway,
+		providerCredentials: providerCredentials,
+		providerAdmission:   NewProviderAdmissionRegistry(cfg),
 	}
 }
 

--- a/internal/runtime/llm/cli_runtime_boot.go
+++ b/internal/runtime/llm/cli_runtime_boot.go
@@ -1,15 +1,15 @@
 package llm
 
 import (
+	"context"
 	"fmt"
-	"os"
 
 	"github.com/division-sh/swarm/internal/config"
 	llmselection "github.com/division-sh/swarm/internal/runtime/llm/selection"
 	"github.com/division-sh/swarm/internal/runtime/toolgateway"
 )
 
-func ValidateClaudeCLIRuntimeConfig(cfg *config.Config, binding toolgateway.Binding) error {
+func ValidateClaudeCLIRuntimeConfig(ctx context.Context, cfg *config.Config, binding toolgateway.Binding, credentials ProviderCredentialResolver) error {
 	if cfg == nil {
 		return nil
 	}
@@ -26,7 +26,7 @@ func ValidateClaudeCLIRuntimeConfig(cfg *config.Config, binding toolgateway.Bind
 	if err := binding.Validate(); err != nil {
 		return fmt.Errorf("claude cli tool gateway binding invalid: %w", err)
 	}
-	if err := llmselection.RequireCredential(profile, os.LookupEnv); err != nil {
+	if _, err := credentials.Resolve(ctx, profile); err != nil {
 		return err
 	}
 	return nil

--- a/internal/runtime/llm/cli_runtime_boot_test.go
+++ b/internal/runtime/llm/cli_runtime_boot_test.go
@@ -1,12 +1,29 @@
 package llm
 
 import (
+	"context"
+	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/division-sh/swarm/internal/config"
+	runtimecredentials "github.com/division-sh/swarm/internal/runtime/credentials"
 	"github.com/division-sh/swarm/internal/runtime/toolgateway"
 )
+
+func testProviderCredentialResolver(t *testing.T, key, value string) ProviderCredentialResolver {
+	t.Helper()
+	store, err := runtimecredentials.NewFileStore(filepath.Join(t.TempDir(), "credentials.json"))
+	if err != nil {
+		t.Fatalf("NewFileStore: %v", err)
+	}
+	if strings.TrimSpace(value) != "" {
+		if err := store.Set(context.Background(), key, value); err != nil {
+			t.Fatalf("Set provider credential: %v", err)
+		}
+	}
+	return NewProviderCredentialResolver(store)
+}
 
 func TestValidateClaudeCLIRuntimeConfig_RequiresToolGatewayBinding(t *testing.T) {
 	cfg := &config.Config{}
@@ -18,7 +35,7 @@ func TestValidateClaudeCLIRuntimeConfig_RequiresToolGatewayBinding(t *testing.T)
 	t.Setenv("SWARM_TOOL_GATEWAY_TOKEN", "")
 	t.Setenv("CLAUDE_CODE_OAUTH_TOKEN", "")
 
-	err := ValidateClaudeCLIRuntimeConfig(cfg, testToolGatewayBinding("", "", ""))
+	err := ValidateClaudeCLIRuntimeConfig(context.Background(), cfg, testToolGatewayBinding("", "", ""), ProviderCredentialResolver{})
 	if err == nil || !strings.Contains(err.Error(), "tool gateway binding") {
 		t.Fatalf("expected missing gateway binding error, got %v", err)
 	}
@@ -28,7 +45,7 @@ func TestValidateClaudeCLIRuntimeConfig_RejectsRetiredRuntimeMode(t *testing.T) 
 	cfg := &config.Config{}
 	cfg.LLM.RuntimeMode = "cli_test"
 
-	if err := ValidateClaudeCLIRuntimeConfig(cfg, toolgateway.Binding{}); err == nil || !strings.Contains(err.Error(), "llm.runtime_mode is retired") {
+	if err := ValidateClaudeCLIRuntimeConfig(context.Background(), cfg, toolgateway.Binding{}, ProviderCredentialResolver{}); err == nil || !strings.Contains(err.Error(), "llm.runtime_mode is retired") {
 		t.Fatalf("ValidateClaudeCLIRuntimeConfig error = %v, want retired runtime mode rejection", err)
 	}
 }
@@ -43,7 +60,7 @@ func TestValidateClaudeCLIRuntimeConfig_RequiresMCPBridgeEnabled(t *testing.T) {
 	t.Setenv("SWARM_TOOL_GATEWAY_TOKEN", "gateway-token")
 	t.Setenv("CLAUDE_CODE_OAUTH_TOKEN", "oauth-token")
 
-	err := ValidateClaudeCLIRuntimeConfig(cfg, testToolGatewayBinding("http://127.0.0.1:8081", "http://host.docker.internal:8081", "gateway-token"))
+	err := ValidateClaudeCLIRuntimeConfig(context.Background(), cfg, testToolGatewayBinding("http://127.0.0.1:8081", "http://host.docker.internal:8081", "gateway-token"), testProviderCredentialResolver(t, "CLAUDE_CODE_OAUTH_TOKEN", "oauth-token"))
 	if err == nil || !strings.Contains(err.Error(), "SWARM_CLAUDE_USE_MCP") {
 		t.Fatalf("expected MCP enabled error, got %v", err)
 	}
@@ -59,7 +76,7 @@ func TestValidateClaudeCLIRuntimeConfig_AcceptsExplicitConfig(t *testing.T) {
 	t.Setenv("SWARM_TOOL_GATEWAY_TOKEN", "gateway-token")
 	t.Setenv("CLAUDE_CODE_OAUTH_TOKEN", "oauth-token")
 
-	if err := ValidateClaudeCLIRuntimeConfig(cfg, testToolGatewayBinding("http://127.0.0.1:8081", "http://host.docker.internal:8081", "gateway-token")); err != nil {
+	if err := ValidateClaudeCLIRuntimeConfig(context.Background(), cfg, testToolGatewayBinding("http://127.0.0.1:8081", "http://host.docker.internal:8081", "gateway-token"), testProviderCredentialResolver(t, "CLAUDE_CODE_OAUTH_TOKEN", "oauth-token")); err != nil {
 		t.Fatalf("ValidateClaudeCLIRuntimeConfig: %v", err)
 	}
 }
@@ -74,7 +91,7 @@ func TestValidateClaudeCLIRuntimeConfig_RequiresWorkspaceGatewayEndpoint(t *test
 	t.Setenv("SWARM_TOOL_GATEWAY_TOKEN", "gateway-token")
 	t.Setenv("CLAUDE_CODE_OAUTH_TOKEN", "oauth-token")
 
-	err := ValidateClaudeCLIRuntimeConfig(cfg, testToolGatewayBinding("http://127.0.0.1:8081", "", "gateway-token"))
+	err := ValidateClaudeCLIRuntimeConfig(context.Background(), cfg, testToolGatewayBinding("http://127.0.0.1:8081", "", "gateway-token"), testProviderCredentialResolver(t, "CLAUDE_CODE_OAUTH_TOKEN", "oauth-token"))
 	if err == nil || !strings.Contains(err.Error(), "workspace endpoint") {
 		t.Fatalf("expected missing workspace endpoint error, got %v", err)
 	}

--- a/internal/runtime/llm/cli_runtime_process.go
+++ b/internal/runtime/llm/cli_runtime_process.go
@@ -43,10 +43,6 @@ func (r *ClaudeCLIRuntime) runWithInput(ctx context.Context, args []string, targ
 	if _, err := requireClaudeExecutionTarget(target); err != nil {
 		return nil, err
 	}
-	profile, _ := llmselection.ResolveActiveBackend(llmselection.BackendClaudeCLI)
-	if err := llmselection.RequireCredential(profile, os.LookupEnv); err != nil {
-		return nil, fmt.Errorf("%w: %s is missing", ErrClaudeAuthRequired, profile.Credential.EnvVar)
-	}
 	release, err := r.admitProviderDispatch(ctx)
 	if err != nil {
 		return nil, err
@@ -58,6 +54,9 @@ func (r *ClaudeCLIRuntime) runWithInput(ctx context.Context, args []string, targ
 
 	cmd, err := r.buildCommand(runCtx, args, target)
 	if err != nil {
+		if IsMissingProviderCredential(err) {
+			return nil, fmt.Errorf("%w: %w", ErrClaudeAuthRequired, err)
+		}
 		return nil, err
 	}
 	if configuredCLIOutputFormat(r.cfg) == "stream-json" {
@@ -306,8 +305,12 @@ func (r *ClaudeCLIRuntime) buildCommand(ctx context.Context, args []string, targ
 			dockerArgs = append(dockerArgs, "-e", "SWARM_TOOL_GATEWAY_URL="+gatewayURL)
 		}
 		profile, _ := llmselection.ResolveActiveBackend(llmselection.BackendClaudeCLI)
-		if oauthToken := llmselection.CredentialValue(profile, os.LookupEnv); oauthToken != "" {
-			dockerArgs = append(dockerArgs, "-e", profile.Credential.EnvVar+"="+oauthToken)
+		credential, err := r.providerCredentials.Resolve(ctx, profile)
+		if err != nil {
+			return nil, err
+		}
+		if oauthToken := strings.TrimSpace(credential.Value); oauthToken != "" {
+			dockerArgs = append(dockerArgs, "-e", ProviderCredentialKey(profile)+"="+oauthToken)
 		}
 		if strings.TrimSpace(execTarget.Workdir) != "" {
 			dockerArgs = append(dockerArgs, "-w", execTarget.Workdir)

--- a/internal/runtime/llm/cli_runtime_process_test.go
+++ b/internal/runtime/llm/cli_runtime_process_test.go
@@ -103,11 +103,12 @@ func TestClaudeCLIRuntimeWorkspaceCommandRejectsHostWorkspaceBackend(t *testing.
 func TestClaudeCLIRuntimeBuildCommand_UsesContainerReachableMCPGatewayURL(t *testing.T) {
 	t.Setenv("SWARM_TOOL_GATEWAY_CONTAINER_URL", "http://stale.example.invalid:8081")
 	t.Setenv("SWARM_TOOL_GATEWAY_TOKEN", "stale-token")
-	t.Setenv("CLAUDE_CODE_OAUTH_TOKEN", "oauth-token")
+	t.Setenv("CLAUDE_CODE_OAUTH_TOKEN", "stale-oauth-token")
 
 	runtime := NewClaudeCLIRuntime(&config.Config{}, sessions.NewInMemoryRegistry(0), "worker-1", nil, nil, nil, nil, nil)
 	runtime.cfg.LLM.ClaudeCLI.Command = "claude"
 	runtime.toolGateway = testToolGatewayBinding("http://127.0.0.1:8082", "http://host.docker.internal:8082", "gateway-token")
+	runtime.providerCredentials = testProviderCredentialResolver(t, "CLAUDE_CODE_OAUTH_TOKEN", "stored-oauth-token")
 
 	cmd, err := runtime.buildCommand(context.Background(), []string{"--print", "hello"}, &workspace.Target{
 		Backend:   workspace.BackendDocker,
@@ -124,13 +125,19 @@ func TestClaudeCLIRuntimeBuildCommand_UsesContainerReachableMCPGatewayURL(t *tes
 	if strings.Contains(got, "SWARM_TOOL_GATEWAY_TOKEN=") {
 		t.Fatalf("docker args = %q, want no gateway token env propagated into cli_test container exec", got)
 	}
+	if !strings.Contains(got, "CLAUDE_CODE_OAUTH_TOKEN=stored-oauth-token") {
+		t.Fatalf("docker args = %q, want provider credential from swarm secrets", got)
+	}
 	if strings.Contains(got, "stale.example.invalid") || strings.Contains(got, "stale-token") {
 		t.Fatalf("docker args = %q, stale operator gateway env leaked into launch", got)
+	}
+	if strings.Contains(got, "stale-oauth-token") {
+		t.Fatalf("docker args = %q, stale provider env leaked into launch", got)
 	}
 }
 
 func TestClaudeCLIRuntimeRunWithInput_MissingWorkspaceCLIUsesActionableDiagnostic(t *testing.T) {
-	t.Setenv("CLAUDE_CODE_OAUTH_TOKEN", "oauth-token")
+	t.Setenv("CLAUDE_CODE_OAUTH_TOKEN", "stale-oauth-token")
 	t.Setenv("SWARM_WORKSPACE_IMAGE", "swarm-workspace:test")
 
 	tempDir := t.TempDir()
@@ -150,6 +157,7 @@ exit 127
 	cfg.LLM.ClaudeCLI.Command = "claude"
 	cfg.LLM.ClaudeCLI.OutputFormat = "json"
 	runtime := NewClaudeCLIRuntime(cfg, sessions.NewInMemoryRegistry(0), "worker-1", nil, nil, nil, nil, nil)
+	runtime.providerCredentials = testProviderCredentialResolver(t, "CLAUDE_CODE_OAUTH_TOKEN", "oauth-token")
 
 	_, err := runtime.runWithInput(context.Background(), nil, &workspace.Target{Container: "swarm-agent-market-research", Workdir: "/workspace"}, "hello", MonitorTurnMeta{})
 	if !errors.Is(err, ErrClaudeWorkspaceCLIUnavailable) {

--- a/internal/runtime/llm/cli_runtime_startup_probe_test.go
+++ b/internal/runtime/llm/cli_runtime_startup_probe_test.go
@@ -21,7 +21,7 @@ func TestClaudeCLIRuntimeProbeStartupVisibleToolSurface_CapturesProviderInitVisi
 	t.Setenv("SWARM_CLAUDE_USE_MCP", "1")
 	t.Setenv("SWARM_TOOL_GATEWAY_CONTAINER_URL", "http://host.docker.internal:8081")
 	t.Setenv("SWARM_TOOL_GATEWAY_TOKEN", "gateway-token")
-	t.Setenv("CLAUDE_CODE_OAUTH_TOKEN", "oauth-token")
+	t.Setenv("CLAUDE_CODE_OAUTH_TOKEN", "stale-oauth-token")
 
 	tempDir := t.TempDir()
 	scriptPath := filepath.Join(tempDir, "fake-docker.sh")
@@ -62,6 +62,7 @@ printf '%s\n' '{"type":"system","subtype":"init","session_id":"provider-startup-
 		nil,
 		nil,
 		ClaudeCLIRuntimeOptions{
+			ProviderCredentials: testProviderCredentialResolver(t, "CLAUDE_CODE_OAUTH_TOKEN", "oauth-token"),
 			MCPTurnContextStore: mcpTurnContextStoreStub{
 				register:   func(context.Context, time.Duration, []string) string { return "ctx-token-startup" },
 				unregister: func(string) {},
@@ -98,7 +99,7 @@ func TestClaudeCLIRuntimeProbeStartupVisibleToolSurface_UsesUUIDSessionID(t *tes
 	t.Setenv("SWARM_CLAUDE_USE_MCP", "1")
 	t.Setenv("SWARM_TOOL_GATEWAY_CONTAINER_URL", "http://host.docker.internal:8081")
 	t.Setenv("SWARM_TOOL_GATEWAY_TOKEN", "gateway-token")
-	t.Setenv("CLAUDE_CODE_OAUTH_TOKEN", "oauth-token")
+	t.Setenv("CLAUDE_CODE_OAUTH_TOKEN", "stale-oauth-token")
 
 	tempDir := t.TempDir()
 	scriptPath := filepath.Join(tempDir, "fake-docker.sh")
@@ -143,6 +144,7 @@ printf '%s\n' '{"type":"system","subtype":"init","session_id":"provider-startup-
 		nil,
 		nil,
 		ClaudeCLIRuntimeOptions{
+			ProviderCredentials: testProviderCredentialResolver(t, "CLAUDE_CODE_OAUTH_TOKEN", "oauth-token"),
 			MCPTurnContextStore: mcpTurnContextStoreStub{
 				register:   func(context.Context, time.Duration, []string) string { return "ctx-token-startup" },
 				unregister: func(string) {},
@@ -180,7 +182,7 @@ func TestClaudeCLIRuntimeProbeStartupVisibleToolSurface_MissingWorkspaceCLIIsAct
 	t.Setenv("SWARM_TOOL_GATEWAY_CONTAINER_URL", "http://host.docker.internal:8081")
 	t.Setenv("SWARM_TOOL_GATEWAY_TOKEN", "gateway-token")
 	t.Setenv("SWARM_WORKSPACE_IMAGE", "swarm-workspace:test")
-	t.Setenv("CLAUDE_CODE_OAUTH_TOKEN", "oauth-token")
+	t.Setenv("CLAUDE_CODE_OAUTH_TOKEN", "stale-oauth-token")
 
 	tempDir := t.TempDir()
 	scriptPath := filepath.Join(tempDir, "fake-docker.sh")
@@ -209,6 +211,7 @@ exit 127
 		nil,
 		nil,
 		ClaudeCLIRuntimeOptions{
+			ProviderCredentials: testProviderCredentialResolver(t, "CLAUDE_CODE_OAUTH_TOKEN", "oauth-token"),
 			MCPTurnContextStore: mcpTurnContextStoreStub{
 				register:   func(context.Context, time.Duration, []string) string { return "ctx-token-missing-cli" },
 				unregister: func(string) {},

--- a/internal/runtime/llm/cli_runtime_supported_path_test.go
+++ b/internal/runtime/llm/cli_runtime_supported_path_test.go
@@ -65,7 +65,7 @@ func TestConversationStep_ClaudeCLIFirstTurnPreservesSupportedReadFileSurface(t 
 	t.Setenv("SWARM_CLAUDE_USE_MCP", "1")
 	t.Setenv("SWARM_TOOL_GATEWAY_CONTAINER_URL", "http://host.docker.internal:8081")
 	t.Setenv("SWARM_TOOL_GATEWAY_TOKEN", "gateway-token")
-	t.Setenv("CLAUDE_CODE_OAUTH_TOKEN", "oauth-token")
+	t.Setenv("CLAUDE_CODE_OAUTH_TOKEN", "stale-oauth-token")
 
 	tempDir := t.TempDir()
 	captureDir := filepath.Join(tempDir, "captures")
@@ -97,7 +97,8 @@ func TestConversationStep_ClaudeCLIFirstTurnPreservesSupportedReadFileSurface(t 
 		nil,
 		nil,
 		ClaudeCLIRuntimeOptions{
-			ToolGateway: testToolGatewayBinding("http://127.0.0.1:8081", "http://host.docker.internal:8081", "gateway-token"),
+			ToolGateway:         testToolGatewayBinding("http://127.0.0.1:8081", "http://host.docker.internal:8081", "gateway-token"),
+			ProviderCredentials: testProviderCredentialResolver(t, "CLAUDE_CODE_OAUTH_TOKEN", "oauth-token"),
 			MCPTurnContextStore: mcpTurnContextStoreStub{
 				register: func(_ context.Context, _ time.Duration, got []string) string {
 					allowedTools = append([]string(nil), got...)

--- a/internal/runtime/llm/factory.go
+++ b/internal/runtime/llm/factory.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/division-sh/swarm/internal/config"
 	"github.com/division-sh/swarm/internal/events"
+	runtimecredentials "github.com/division-sh/swarm/internal/runtime/credentials"
 	llmselection "github.com/division-sh/swarm/internal/runtime/llm/selection"
 	"github.com/division-sh/swarm/internal/runtime/sessions"
 	"github.com/division-sh/swarm/internal/runtime/toolgateway"
@@ -25,6 +26,7 @@ type RuntimeFactory struct {
 	Events        EventPublisher
 	MCPTurns      MCPTurnContextStore
 	ToolGateway   toolgateway.Binding
+	Credentials   runtimecredentials.Store
 }
 
 func (f RuntimeFactory) Build() (Runtime, error) {
@@ -43,23 +45,25 @@ func (f RuntimeFactory) Build() (Runtime, error) {
 		return nil, err
 	}
 	providerAdmission := NewProviderAdmissionRegistry(f.Cfg)
+	providerCredentials := NewProviderCredentialResolver(f.Credentials)
 
 	var runtime Runtime
 	switch profile.ID {
 	case llmselection.BackendAnthropic:
-		runtime = NewAnthropicAPIRuntime(f.Cfg, f.Sessions, f.LockOwner, f.Turns, f.Conversations, f.Budget, f.Events)
+		runtime = NewAnthropicAPIRuntimeWithProviderCredentials(f.Cfg, f.Sessions, f.LockOwner, f.Turns, f.Conversations, f.Budget, f.Events, providerCredentials)
 		runtime.(*AnthropicAPIRuntime).providerAdmission = providerAdmission
 	case llmselection.BackendClaudeCLI:
 		runtime = NewClaudeCLIRuntimeWithOptions(f.Cfg, f.Sessions, f.LockOwner, f.Turns, f.Budget, f.Workspaces, f.Conversations, f.Events, ClaudeCLIRuntimeOptions{
 			MCPTurnContextStore: f.MCPTurns,
 			ToolGateway:         f.ToolGateway,
+			ProviderCredentials: providerCredentials,
 		})
 		runtime.(*ClaudeCLIRuntime).providerAdmission = providerAdmission
 	case llmselection.BackendOpenAICompatible:
-		runtime = NewOpenAICompatibleRuntime(f.Cfg, f.Sessions, f.LockOwner, f.Turns, f.Conversations, f.Budget, f.Events)
+		runtime = NewOpenAICompatibleRuntimeWithProviderCredentials(f.Cfg, f.Sessions, f.LockOwner, f.Turns, f.Conversations, f.Budget, f.Events, providerCredentials)
 		runtime.(*OpenAICompatibleRuntime).providerAdmission = providerAdmission
 	case llmselection.BackendOpenAIResponses:
-		runtime = NewOpenAIResponsesRuntime(f.Cfg, f.Sessions, f.LockOwner, f.Turns, f.Conversations, f.Budget, f.Events)
+		runtime = NewOpenAIResponsesRuntimeWithProviderCredentials(f.Cfg, f.Sessions, f.LockOwner, f.Turns, f.Conversations, f.Budget, f.Events, providerCredentials)
 		runtime.(*OpenAIResponsesRuntime).providerAdmission = providerAdmission
 	default:
 		return nil, fmt.Errorf("unsupported llm backend profile: %s", profile.ID)

--- a/internal/runtime/llm/openai_compatible_runtime.go
+++ b/internal/runtime/llm/openai_compatible_runtime.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"os"
 	"strings"
 	"time"
 
@@ -32,9 +31,14 @@ type OpenAICompatibleRuntime struct {
 	apiKey            string
 	events            EventPublisher
 	providerAdmission *ProviderAdmissionRegistry
+	credentials       ProviderCredentialResolver
 }
 
 func NewOpenAICompatibleRuntime(cfg *config.Config, sessions sessions.Registry, lockOwner string, turns TurnPersistence, conversations ConversationPersistence, budget BudgetGuard, publisher EventPublisher) *OpenAICompatibleRuntime {
+	return NewOpenAICompatibleRuntimeWithProviderCredentials(cfg, sessions, lockOwner, turns, conversations, budget, publisher, NewProviderCredentialResolver(nil))
+}
+
+func NewOpenAICompatibleRuntimeWithProviderCredentials(cfg *config.Config, sessions sessions.Registry, lockOwner string, turns TurnPersistence, conversations ConversationPersistence, budget BudgetGuard, publisher EventPublisher, credentials ProviderCredentialResolver) *OpenAICompatibleRuntime {
 	if cfg == nil {
 		cfg = &config.Config{}
 	}
@@ -51,9 +55,9 @@ func NewOpenAICompatibleRuntime(cfg *config.Config, sessions sessions.Registry, 
 			Timeout: 120 * time.Second,
 		},
 		baseURL:           baseURL,
-		apiKey:            llmselection.CredentialValue(profile, os.LookupEnv),
 		events:            publisher,
 		providerAdmission: NewProviderAdmissionRegistry(cfg),
+		credentials:       credentials,
 	}
 }
 
@@ -239,10 +243,11 @@ func (r *OpenAICompatibleRuntime) ContinueSession(ctx context.Context, s *Sessio
 
 	profile, _ := llmselection.ResolveActiveBackend(llmselection.BackendOpenAICompatible)
 	if strings.TrimSpace(r.apiKey) == "" {
-		r.apiKey = llmselection.CredentialValue(profile, os.LookupEnv)
-		if strings.TrimSpace(r.apiKey) == "" {
-			return nil, llmselection.RequireCredential(profile, os.LookupEnv)
+		credential, err := r.credentials.Resolve(ctx, profile)
+		if err != nil {
+			return nil, err
 		}
+		r.apiKey = credential.Value
 	}
 	if strings.TrimSpace(r.baseURL) == "" {
 		baseURL, err := llmselection.ResolveBaseURL(profile, r.cfg.LLM.OpenAICompatible.BaseURL)

--- a/internal/runtime/llm/openai_compatible_runtime_test.go
+++ b/internal/runtime/llm/openai_compatible_runtime_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func TestOpenAICompatibleRuntimeConversationToolBudgetAndPersistence(t *testing.T) {
-	t.Setenv("OPENAI_COMPATIBLE_API_KEY", "test-key")
+	t.Setenv("OPENAI_COMPATIBLE_API_KEY", "stale-test-key")
 
 	var requests []openAICompatibleRequest
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -74,6 +74,7 @@ func TestOpenAICompatibleRuntimeConversationToolBudgetAndPersistence(t *testing.
 		Conversations: conversations,
 		Budget:        budget,
 		LockOwner:     "worker-1",
+		Credentials:   testProviderCredentialResolver(t, "OPENAI_COMPATIBLE_API_KEY", "test-key").Store,
 	}.Build()
 	if err != nil {
 		t.Fatalf("Build: %v", err)
@@ -133,7 +134,7 @@ func TestOpenAICompatibleRuntimeConversationToolBudgetAndPersistence(t *testing.
 }
 
 func TestOpenAICompatibleRuntimeFailsClosedWhenUsageMissing(t *testing.T) {
-	t.Setenv("OPENAI_COMPATIBLE_API_KEY", "test-key")
+	t.Setenv("OPENAI_COMPATIBLE_API_KEY", "stale-test-key")
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("content-type", "application/json")
 		_, _ = w.Write([]byte(`{"model":"gpt-compatible","choices":[{"message":{"role":"assistant","content":"done"}}]}`))
@@ -142,6 +143,7 @@ func TestOpenAICompatibleRuntimeFailsClosedWhenUsageMissing(t *testing.T) {
 
 	turns := &turnCapture{}
 	runtime := NewOpenAICompatibleRuntime(openAICompatibleTestConfig(server.URL), sessions.NewInMemoryRegistry(time.Second), "worker-1", turns, nil, nil, nil)
+	runtime.credentials = testProviderCredentialResolver(t, "OPENAI_COMPATIBLE_API_KEY", "test-key")
 	ctx := runtimeactors.WithActor(context.Background(), runtimeactors.AgentConfig{ID: "agent-1", Model: "regular"})
 	ctx = sessions.WithScope(ctx, sessions.RuntimeModeTask.String(), "", "task-1")
 	session, err := runtime.StartSession(ctx, "agent-1", "system", nil)

--- a/internal/runtime/llm/openai_responses_runtime.go
+++ b/internal/runtime/llm/openai_responses_runtime.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"os"
 	"strings"
 	"time"
 
@@ -33,9 +32,14 @@ type OpenAIResponsesRuntime struct {
 	apiKey            string
 	events            EventPublisher
 	providerAdmission *ProviderAdmissionRegistry
+	credentials       ProviderCredentialResolver
 }
 
 func NewOpenAIResponsesRuntime(cfg *config.Config, sessions sessions.Registry, lockOwner string, turns TurnPersistence, conversations ConversationPersistence, budget BudgetGuard, publisher EventPublisher) *OpenAIResponsesRuntime {
+	return NewOpenAIResponsesRuntimeWithProviderCredentials(cfg, sessions, lockOwner, turns, conversations, budget, publisher, NewProviderCredentialResolver(nil))
+}
+
+func NewOpenAIResponsesRuntimeWithProviderCredentials(cfg *config.Config, sessions sessions.Registry, lockOwner string, turns TurnPersistence, conversations ConversationPersistence, budget BudgetGuard, publisher EventPublisher, credentials ProviderCredentialResolver) *OpenAIResponsesRuntime {
 	if cfg == nil {
 		cfg = &config.Config{}
 	}
@@ -52,9 +56,9 @@ func NewOpenAIResponsesRuntime(cfg *config.Config, sessions sessions.Registry, l
 			Timeout: 120 * time.Second,
 		},
 		baseURL:           baseURL,
-		apiKey:            llmselection.CredentialValue(profile, os.LookupEnv),
 		events:            publisher,
 		providerAdmission: NewProviderAdmissionRegistry(cfg),
+		credentials:       credentials,
 	}
 }
 
@@ -240,10 +244,11 @@ func (r *OpenAIResponsesRuntime) ContinueSession(ctx context.Context, s *Session
 
 	profile, _ := llmselection.ResolveActiveBackend(llmselection.BackendOpenAIResponses)
 	if strings.TrimSpace(r.apiKey) == "" {
-		r.apiKey = llmselection.CredentialValue(profile, os.LookupEnv)
-		if strings.TrimSpace(r.apiKey) == "" {
-			return nil, llmselection.RequireCredential(profile, os.LookupEnv)
+		credential, err := r.credentials.Resolve(ctx, profile)
+		if err != nil {
+			return nil, err
 		}
+		r.apiKey = credential.Value
 	}
 	if strings.TrimSpace(r.baseURL) == "" {
 		baseURL, err := llmselection.ResolveBaseURL(profile, r.cfg.LLM.OpenAIResponses.BaseURL)

--- a/internal/runtime/llm/openai_responses_runtime_test.go
+++ b/internal/runtime/llm/openai_responses_runtime_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func TestOpenAIResponsesRuntimeConversationToolBudgetAndPersistence(t *testing.T) {
-	t.Setenv("OPENAI_API_KEY", "test-key")
+	t.Setenv("OPENAI_API_KEY", "stale-test-key")
 
 	var requests []openAIResponsesRequest
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -82,6 +82,7 @@ func TestOpenAIResponsesRuntimeConversationToolBudgetAndPersistence(t *testing.T
 		Conversations: conversations,
 		Budget:        budget,
 		LockOwner:     "worker-1",
+		Credentials:   testProviderCredentialResolver(t, "OPENAI_API_KEY", "test-key").Store,
 	}.Build()
 	if err != nil {
 		t.Fatalf("Build: %v", err)
@@ -147,7 +148,7 @@ func TestOpenAIResponsesRuntimeConversationToolBudgetAndPersistence(t *testing.T
 }
 
 func TestOpenAIResponsesRuntimeFailsClosedWhenUsageMissing(t *testing.T) {
-	t.Setenv("OPENAI_API_KEY", "test-key")
+	t.Setenv("OPENAI_API_KEY", "stale-test-key")
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("content-type", "application/json")
 		_, _ = w.Write([]byte(`{"id":"resp_1","model":"gpt-5.4","output":[{"type":"message","role":"assistant","content":[{"type":"output_text","text":"done"}]}]}`))
@@ -156,6 +157,7 @@ func TestOpenAIResponsesRuntimeFailsClosedWhenUsageMissing(t *testing.T) {
 
 	turns := &turnCapture{}
 	runtime := NewOpenAIResponsesRuntime(openAIResponsesTestConfig(server.URL), sessions.NewInMemoryRegistry(time.Second), "worker-1", turns, nil, nil, nil)
+	runtime.credentials = testProviderCredentialResolver(t, "OPENAI_API_KEY", "test-key")
 	ctx := runtimeactors.WithActor(context.Background(), runtimeactors.AgentConfig{ID: "agent-1", Model: "regular"})
 	ctx = sessions.WithScope(ctx, sessions.RuntimeModeTask.String(), "", "task-1")
 	session, err := runtime.StartSession(ctx, "agent-1", "system", nil)

--- a/internal/runtime/llm/provider_admission_test.go
+++ b/internal/runtime/llm/provider_admission_test.go
@@ -229,8 +229,6 @@ func TestProviderAdmissionModelPolicyOverridesProfilePolicy(t *testing.T) {
 }
 
 func TestAnthropicProviderAdmissionAppliesToRetries(t *testing.T) {
-	t.Setenv("ANTHROPIC_API_KEY", "test-key")
-
 	var requests atomic.Int32
 	var firstRequest, secondRequest atomic.Int64
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
@@ -297,7 +295,6 @@ func TestAnthropicProviderAdmissionAppliesToRetries(t *testing.T) {
 }
 
 func TestOpenAICompatibleProviderAdmissionRejectsBeforeHTTPDispatch(t *testing.T) {
-	t.Setenv("OPENAI_COMPATIBLE_API_KEY", "test-key")
 	cfg := openAICompatibleTestConfig("")
 	cfg.LLM.ProviderLimits = map[string]config.LLMProviderLimitPolicy{
 		llmselection.BackendOpenAICompatible: {
@@ -344,7 +341,6 @@ func TestOpenAICompatibleProviderAdmissionRejectsBeforeHTTPDispatch(t *testing.T
 }
 
 func TestOpenAIResponsesProviderAdmissionRejectsBeforeHTTPDispatch(t *testing.T) {
-	t.Setenv("OPENAI_API_KEY", "test-key")
 	cfg := openAIResponsesTestConfig("")
 	cfg.LLM.ProviderLimits = map[string]config.LLMProviderLimitPolicy{
 		llmselection.BackendOpenAIResponses: {
@@ -391,7 +387,7 @@ func TestOpenAIResponsesProviderAdmissionRejectsBeforeHTTPDispatch(t *testing.T)
 }
 
 func TestClaudeCLIProviderAdmissionRejectsBeforeSubprocessDispatch(t *testing.T) {
-	t.Setenv("CLAUDE_CODE_OAUTH_TOKEN", "oauth-token")
+	t.Setenv("CLAUDE_CODE_OAUTH_TOKEN", "stale-oauth-token")
 	cfg := &config.Config{
 		LLM: config.LLMConfig{
 			ClaudeCLI: config.ClaudeCLIConfig{
@@ -407,6 +403,7 @@ func TestClaudeCLIProviderAdmissionRejectsBeforeSubprocessDispatch(t *testing.T)
 		},
 	}
 	runtime := NewClaudeCLIRuntime(cfg, sessions.NewInMemoryRegistry(time.Second), "worker-1", nil, nil, nil, nil, nil)
+	runtime.providerCredentials = testProviderCredentialResolver(t, "CLAUDE_CODE_OAUTH_TOKEN", "oauth-token")
 	ctx := runtimeactors.WithActor(context.Background(), runtimeactors.AgentConfig{ID: "agent-1", Model: llmselection.ModelAliasRegular})
 	scriptPath, countFile := writeProviderAdmissionFakeDocker(t, `cat >/dev/null
 printf '%s\n' '{"result":"done"}'
@@ -430,7 +427,7 @@ printf '%s\n' '{"result":"done"}'
 }
 
 func TestClaudeCLIPromptFallbackConsumesAdmissionPerSubprocessAttempt(t *testing.T) {
-	t.Setenv("CLAUDE_CODE_OAUTH_TOKEN", "oauth-token")
+	t.Setenv("CLAUDE_CODE_OAUTH_TOKEN", "stale-oauth-token")
 	cfg := &config.Config{
 		LLM: config.LLMConfig{
 			ClaudeCLI: config.ClaudeCLIConfig{
@@ -446,6 +443,7 @@ func TestClaudeCLIPromptFallbackConsumesAdmissionPerSubprocessAttempt(t *testing
 		},
 	}
 	runtime := NewClaudeCLIRuntime(cfg, sessions.NewInMemoryRegistry(time.Second), "worker-1", nil, nil, nil, nil, nil)
+	runtime.providerCredentials = testProviderCredentialResolver(t, "CLAUDE_CODE_OAUTH_TOKEN", "oauth-token")
 	ctx := runtimeactors.WithActor(context.Background(), runtimeactors.AgentConfig{ID: "agent-1", Model: llmselection.ModelAliasRegular})
 	scriptPath, countFile := writeProviderAdmissionFakeDocker(t, `cat >/dev/null
 if [ "$count" = "1" ]; then

--- a/internal/runtime/llm/provider_credentials.go
+++ b/internal/runtime/llm/provider_credentials.go
@@ -1,0 +1,176 @@
+package llm
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+
+	runtimecredentials "github.com/division-sh/swarm/internal/runtime/credentials"
+	llmselection "github.com/division-sh/swarm/internal/runtime/llm/selection"
+)
+
+type ProviderCredentialResolver struct {
+	Store     runtimecredentials.Store
+	EnvLookup llmselection.EnvLookup
+}
+
+type ProviderCredential struct {
+	Key         string
+	Value       string
+	Source      string
+	EnvPresent  bool
+	EnvShadowed bool
+}
+
+type MissingProviderCredentialError struct {
+	Key        string
+	Purpose    string
+	EnvPresent bool
+}
+
+func NewProviderCredentialResolver(store runtimecredentials.Store) ProviderCredentialResolver {
+	return ProviderCredentialResolver{
+		Store:     store,
+		EnvLookup: os.LookupEnv,
+	}
+}
+
+func NewProviderCredentialResolverWithEnvLookup(store runtimecredentials.Store, lookup llmselection.EnvLookup) ProviderCredentialResolver {
+	if lookup == nil {
+		lookup = os.LookupEnv
+	}
+	return ProviderCredentialResolver{
+		Store:     store,
+		EnvLookup: lookup,
+	}
+}
+
+func ProviderCredentialKey(profile llmselection.Profile) string {
+	return strings.TrimSpace(profile.Credential.EnvVar)
+}
+
+func (e MissingProviderCredentialError) Error() string {
+	key := strings.TrimSpace(e.Key)
+	if key == "" {
+		key = "provider credential"
+	}
+	purpose := strings.TrimSpace(e.Purpose)
+	if purpose == "" {
+		purpose = "selected llm provider"
+	}
+	msg := fmt.Sprintf("%s is required for %s; store it with `swarm secrets set %s`", key, purpose, key)
+	if e.EnvPresent {
+		msg += fmt.Sprintf("; process env %s is deprecated for Swarm provider credentials and is ignored", key)
+	}
+	return msg
+}
+
+func IsMissingProviderCredential(err error) bool {
+	var missing MissingProviderCredentialError
+	return errors.As(err, &missing)
+}
+
+func (r ProviderCredentialResolver) Resolve(ctx context.Context, profile llmselection.Profile) (ProviderCredential, error) {
+	key := ProviderCredentialKey(profile)
+	if key == "" {
+		return ProviderCredential{}, fmt.Errorf("provider credential key is required for backend %q", strings.TrimSpace(profile.ID))
+	}
+	if !profile.Credential.Required {
+		return ProviderCredential{Key: key}, nil
+	}
+	envPresent := r.envPresent(key)
+	value, ok, err := r.storeValue(ctx, key)
+	if err != nil {
+		return ProviderCredential{}, err
+	}
+	if ok {
+		source := runtimecredentials.SourceFile
+		if meta, metaErr := inspectProviderCredentialStore(ctx, r.Store, key); metaErr != nil {
+			return ProviderCredential{}, metaErr
+		} else if strings.TrimSpace(meta.Source) != "" {
+			source = strings.TrimSpace(meta.Source)
+		}
+		return ProviderCredential{
+			Key:         key,
+			Value:       value,
+			Source:      source,
+			EnvPresent:  envPresent,
+			EnvShadowed: envPresent,
+		}, nil
+	}
+	return ProviderCredential{}, MissingProviderCredentialError{
+		Key:        key,
+		Purpose:    profile.Credential.Purpose,
+		EnvPresent: envPresent,
+	}
+}
+
+func (r ProviderCredentialResolver) Inspect(ctx context.Context, profile llmselection.Profile) (ProviderCredential, error) {
+	key := ProviderCredentialKey(profile)
+	if key == "" {
+		return ProviderCredential{}, fmt.Errorf("provider credential key is required for backend %q", strings.TrimSpace(profile.ID))
+	}
+	envPresent := r.envPresent(key)
+	value, ok, err := r.storeValue(ctx, key)
+	if err != nil {
+		return ProviderCredential{}, err
+	}
+	credential := ProviderCredential{
+		Key:         key,
+		Value:       value,
+		EnvPresent:  envPresent,
+		EnvShadowed: envPresent && ok,
+	}
+	if ok {
+		credential.Source = runtimecredentials.SourceFile
+		if meta, metaErr := inspectProviderCredentialStore(ctx, r.Store, key); metaErr != nil {
+			return ProviderCredential{}, metaErr
+		} else if strings.TrimSpace(meta.Source) != "" {
+			credential.Source = strings.TrimSpace(meta.Source)
+		}
+	}
+	return credential, nil
+}
+
+func (r ProviderCredentialResolver) envPresent(key string) bool {
+	if r.EnvLookup == nil {
+		return false
+	}
+	value, ok := r.EnvLookup(key)
+	return ok && strings.TrimSpace(value) != ""
+}
+
+func (r ProviderCredentialResolver) storeValue(ctx context.Context, key string) (string, bool, error) {
+	if r.Store == nil {
+		return "", false, nil
+	}
+	value, ok, err := r.Store.Get(ctx, key)
+	if err != nil {
+		return "", false, err
+	}
+	value = strings.TrimSpace(value)
+	if !ok || value == "" {
+		return "", false, nil
+	}
+	return value, true, nil
+}
+
+func inspectProviderCredentialStore(ctx context.Context, store runtimecredentials.Store, key string) (runtimecredentials.Metadata, error) {
+	if inspector, ok := store.(runtimecredentials.Inspector); ok && inspector != nil {
+		meta, err := inspector.Inspect(ctx, key)
+		if err != nil {
+			return runtimecredentials.Metadata{}, err
+		}
+		return meta, nil
+	}
+	if store == nil {
+		return runtimecredentials.Metadata{Key: key}, nil
+	}
+	_, ok, err := store.Get(ctx, key)
+	if err != nil {
+		return runtimecredentials.Metadata{}, err
+	}
+	return runtimecredentials.Metadata{Key: key, Present: ok}, nil
+}

--- a/internal/runtime/llm/provider_credentials_test.go
+++ b/internal/runtime/llm/provider_credentials_test.go
@@ -1,0 +1,59 @@
+package llm
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	runtimecredentials "github.com/division-sh/swarm/internal/runtime/credentials"
+	llmselection "github.com/division-sh/swarm/internal/runtime/llm/selection"
+)
+
+func TestProviderCredentialResolver_StoreWinsOverEnvForActiveProfiles(t *testing.T) {
+	for backend, key := range map[string]string{
+		llmselection.BackendAnthropic:        "ANTHROPIC_API_KEY",
+		llmselection.BackendClaudeCLI:        "CLAUDE_CODE_OAUTH_TOKEN",
+		llmselection.BackendOpenAICompatible: "OPENAI_COMPATIBLE_API_KEY",
+		llmselection.BackendOpenAIResponses:  "OPENAI_API_KEY",
+	} {
+		t.Run(backend, func(t *testing.T) {
+			t.Setenv(key, "env-"+key)
+			profile, err := llmselection.ResolveActiveBackend(backend)
+			if err != nil {
+				t.Fatalf("ResolveActiveBackend: %v", err)
+			}
+			resolver := testProviderCredentialResolver(t, key, "stored-"+key)
+			credential, err := resolver.Resolve(context.Background(), profile)
+			if err != nil {
+				t.Fatalf("Resolve: %v", err)
+			}
+			if credential.Value != "stored-"+key {
+				t.Fatalf("credential value = %q, want stored secret", credential.Value)
+			}
+			if credential.Source != runtimecredentials.SourceFile {
+				t.Fatalf("credential source = %q, want file", credential.Source)
+			}
+			if !credential.EnvPresent || !credential.EnvShadowed {
+				t.Fatalf("credential env diagnostics = present:%v shadowed:%v, want true/true", credential.EnvPresent, credential.EnvShadowed)
+			}
+		})
+	}
+}
+
+func TestProviderCredentialResolver_EnvOnlyFailsClosed(t *testing.T) {
+	t.Setenv("ANTHROPIC_API_KEY", "env-only")
+	profile, err := llmselection.ResolveActiveBackend(llmselection.BackendAnthropic)
+	if err != nil {
+		t.Fatalf("ResolveActiveBackend: %v", err)
+	}
+	resolver := testProviderCredentialResolver(t, "ANTHROPIC_API_KEY", "")
+	_, err = resolver.Resolve(context.Background(), profile)
+	if err == nil {
+		t.Fatal("Resolve error = nil, want missing provider credential")
+	}
+	for _, want := range []string{"swarm secrets set ANTHROPIC_API_KEY", "deprecated", "ignored"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("Resolve error = %q, want %q", err.Error(), want)
+		}
+	}
+}

--- a/internal/runtime/llm/selection/profile.go
+++ b/internal/runtime/llm/selection/profile.go
@@ -308,14 +308,6 @@ func RejectRetiredModelEnv(lookup EnvLookup) error {
 	return nil
 }
 
-func CredentialValue(profile Profile, lookup EnvLookup) string {
-	if lookup == nil || strings.TrimSpace(profile.Credential.EnvVar) == "" {
-		return ""
-	}
-	value, _ := lookup(profile.Credential.EnvVar)
-	return strings.TrimSpace(value)
-}
-
 func ResolveBaseURL(profile Profile, raw string) (string, error) {
 	baseURL := strings.TrimSpace(raw)
 	if baseURL == "" {
@@ -339,16 +331,6 @@ func ResolveBaseURL(profile Profile, raw string) (string, error) {
 		return "", fmt.Errorf("%s must be an http(s) URL for backend %q", profile.BaseURL.ConfigKey, profile.ID)
 	}
 	return strings.TrimRight(baseURL, "/"), nil
-}
-
-func RequireCredential(profile Profile, lookup EnvLookup) error {
-	if !profile.Credential.Required {
-		return nil
-	}
-	if CredentialValue(profile, lookup) == "" {
-		return fmt.Errorf("%s is required for %s", profile.Credential.EnvVar, profile.Credential.Purpose)
-	}
-	return nil
 }
 
 func BuiltInModelAliases() ModelAliases {

--- a/internal/runtime/llm/selection/profile_test.go
+++ b/internal/runtime/llm/selection/profile_test.go
@@ -114,28 +114,6 @@ func TestRejectRetiredSelectors(t *testing.T) {
 	}
 }
 
-func TestCredentialAuthority(t *testing.T) {
-	profile, err := ResolveActiveBackend(BackendAnthropic)
-	if err != nil {
-		t.Fatalf("ResolveActiveBackend: %v", err)
-	}
-	lookup := func(key string) (string, bool) {
-		if key == profile.Credential.EnvVar {
-			return " token ", true
-		}
-		return "", false
-	}
-	if got := CredentialValue(profile, lookup); got != "token" {
-		t.Fatalf("CredentialValue = %q, want token", got)
-	}
-	if err := RequireCredential(profile, lookup); err != nil {
-		t.Fatalf("RequireCredential: %v", err)
-	}
-	if err := RequireCredential(profile, func(string) (string, bool) { return "", false }); err == nil {
-		t.Fatal("expected missing credential error")
-	}
-}
-
 func TestResolveModelNameUsesModel(t *testing.T) {
 	profile, err := ResolveActiveBackend(BackendAnthropic)
 	if err != nil {

--- a/internal/runtime/runforkexecution/agent_runtime_materialization.go
+++ b/internal/runtime/runforkexecution/agent_runtime_materialization.go
@@ -34,19 +34,20 @@ import (
 const selectedContractAgentRuntimeDefaultQuiescenceTimeout = 2 * time.Minute
 
 type SelectedContractAgentRuntimeOptions struct {
-	Config             *config.Config
-	EntityStore        runtimetools.EntityPersistence
-	HumanTaskStore     runtimetools.HumanTaskPersistence
-	SessionRegistry    runtimesessions.Registry
-	ConversationStore  runtimellm.ConversationPersistence
-	TurnStore          runtimellm.TurnPersistence
-	ScheduleStore      runtimepipeline.SchedulePersistence
-	MailboxStore       runtimetools.MailboxPersistence
-	Workspace          workspace.Lifecycle
-	Credentials        runtimecredentials.Store
-	ManagedCredentials runtimemanagedcredentials.Store
-	LLMRuntime         runtimellm.Runtime
-	MCPClient          *runtimemcp.Client
+	Config              *config.Config
+	EntityStore         runtimetools.EntityPersistence
+	HumanTaskStore      runtimetools.HumanTaskPersistence
+	SessionRegistry     runtimesessions.Registry
+	ConversationStore   runtimellm.ConversationPersistence
+	TurnStore           runtimellm.TurnPersistence
+	ScheduleStore       runtimepipeline.SchedulePersistence
+	MailboxStore        runtimetools.MailboxPersistence
+	Workspace           workspace.Lifecycle
+	Credentials         runtimecredentials.Store
+	ManagedCredentials  runtimemanagedcredentials.Store
+	ProviderCredentials runtimecredentials.Store
+	LLMRuntime          runtimellm.Runtime
+	MCPClient           *runtimemcp.Client
 
 	AgentFactory        runtimemanager.AgentFactory
 	AgentManagerOptions runtimemanager.AgentManagerOptions
@@ -289,6 +290,7 @@ func buildSelectedContractAgentRuntimeFactory(req publishSelectedContractForkEve
 			Events:        bus,
 			MCPTurns:      mcpTurns,
 			ToolGateway:   binding,
+			Credentials:   options.ProviderCredentials,
 		}.Build()
 		if err != nil {
 			if cleanup != nil {

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -78,6 +78,7 @@ type RuntimeOptions struct {
 	LLMRuntime                       llm.Runtime
 	Credentials                      runtimecredentials.Store
 	ManagedCredentials               runtimemanagedcredentials.Store
+	ProviderCredentials              runtimecredentials.Store
 	BootStartedAt                    time.Time
 	BootProgress                     func(BootProgressEvent)
 	SystemContainers                 []string
@@ -96,18 +97,19 @@ type RuntimeDeps struct {
 }
 
 type validatedRuntimeDeps struct {
-	Config                   *config.Config
-	Stores                   Stores
-	Options                  RuntimeOptions
-	Source                   semanticview.Source
-	PromptResolver           runtimecontracts.PromptResolver
-	Credentials              runtimecredentials.Store
-	ManagedCredentials       runtimemanagedcredentials.Store
-	Authority                runtimeauthority.Provider
-	EmitRegistry             *runtimetools.EmitRegistry
-	EventReceiptCapability   func(context.Context) (bool, error)
-	TrimmedBundleFingerprint string
-	BundleSourceFact         runtimecorrelation.BundleSourceFact
+	Config                     *config.Config
+	Stores                     Stores
+	Options                    RuntimeOptions
+	Source                     semanticview.Source
+	PromptResolver             runtimecontracts.PromptResolver
+	Credentials                runtimecredentials.Store
+	ManagedCredentials         runtimemanagedcredentials.Store
+	ProviderCredentialResolver llm.ProviderCredentialResolver
+	Authority                  runtimeauthority.Provider
+	EmitRegistry               *runtimetools.EmitRegistry
+	EventReceiptCapability     func(context.Context) (bool, error)
+	TrimmedBundleFingerprint   string
+	BundleSourceFact           runtimecorrelation.BundleSourceFact
 }
 
 const BootProgressTotalSteps = 22
@@ -278,6 +280,10 @@ func bootWarningsFatal() bool {
 	return runtimeEnvBool("SWARM_BOOT_WARNINGS_FATAL", true)
 }
 
+func providerCredentialResolverForRuntimeOptions(opts RuntimeOptions) llm.ProviderCredentialResolver {
+	return llm.NewProviderCredentialResolver(opts.ProviderCredentials)
+}
+
 func newRuntimePromptResolver(source semanticview.Source) (runtimecontracts.PromptResolver, error) {
 	if source == nil {
 		return nil, fmt.Errorf("semantic source is required")
@@ -325,12 +331,13 @@ func (deps RuntimeDeps) validated() (validatedRuntimeDeps, error) {
 	if err := validateSelectedBackendModelAliasesForDeclaredAgents(cfg, source); err != nil {
 		return validatedRuntimeDeps{}, fmt.Errorf("llm model alias validation failed: %w", err)
 	}
+	providerCredentialResolver := providerCredentialResolverForRuntimeOptions(opts)
 	if opts.LLMRuntime == nil {
-		if err := validateSelectedBackendCredentialForDeclaredAgents(cfg, source); err != nil {
+		if err := validateSelectedBackendCredentialForDeclaredAgents(context.Background(), cfg, opts, source); err != nil {
 			return validatedRuntimeDeps{}, fmt.Errorf("llm backend credential validation failed: %w", err)
 		}
 	}
-	if err := validateClaudeStartupConfig(cfg, opts, source); err != nil {
+	if err := validateClaudeStartupConfig(context.Background(), cfg, opts, source); err != nil {
 		return validatedRuntimeDeps{}, fmt.Errorf("claude runtime startup validation failed: %w", err)
 	}
 	promptResolver, err := newRuntimePromptResolver(source)
@@ -344,18 +351,19 @@ func (deps RuntimeDeps) validated() (validatedRuntimeDeps, error) {
 		credentials = runtimecredentials.NewEnvStore()
 	}
 	return validatedRuntimeDeps{
-		Config:                   cfg,
-		Stores:                   stores,
-		Options:                  opts,
-		Source:                   source,
-		PromptResolver:           promptResolver,
-		Credentials:              credentials,
-		Authority:                authorityProvider,
-		EmitRegistry:             emitRegistry,
-		EventReceiptCapability:   canonicalEventReceiptCapabilities(stores),
-		TrimmedBundleFingerprint: strings.TrimSpace(opts.BundleFingerprint),
-		BundleSourceFact:         opts.BundleSourceFact.Normalized(),
-		ManagedCredentials:       opts.ManagedCredentials,
+		Config:                     cfg,
+		Stores:                     stores,
+		Options:                    opts,
+		Source:                     source,
+		PromptResolver:             promptResolver,
+		Credentials:                credentials,
+		ManagedCredentials:         opts.ManagedCredentials,
+		ProviderCredentialResolver: providerCredentialResolver,
+		Authority:                  authorityProvider,
+		EmitRegistry:               emitRegistry,
+		EventReceiptCapability:     canonicalEventReceiptCapabilities(stores),
+		TrimmedBundleFingerprint:   strings.TrimSpace(opts.BundleFingerprint),
+		BundleSourceFact:           opts.BundleSourceFact.Normalized(),
 	}, nil
 }
 
@@ -514,6 +522,7 @@ func NewRuntime(ctx context.Context, deps RuntimeDeps) (*Runtime, error) {
 			Events:        rt.Bus,
 			MCPTurns:      rt.MCPTurns,
 			ToolGateway:   opts.ToolGatewayBinding,
+			Credentials:   boot.ProviderCredentialResolver.Store,
 		}.Build()
 		if err != nil {
 			return nil, fmt.Errorf("build runtime: %w", err)
@@ -987,12 +996,12 @@ func (rt *Runtime) Start(ctx context.Context) error {
 	}
 	source := rt.Options.WorkflowModule.SemanticSource()
 	if rt.Options.LLMRuntime == nil {
-		if err := validateSelectedBackendCredentialForActiveAgents(rt.Config, source, rt.Manager); err != nil {
+		if err := validateSelectedBackendCredentialForActiveAgents(ctx, rt.Config, rt.Options, source, rt.Manager); err != nil {
 			rt.emitBootProgress(15, "workspace_validation_and_system_containers", "FAILED", err.Error())
 			return fmt.Errorf("llm backend credential validation failed: %w", err)
 		}
 	}
-	if err := validateClaudeStartupConfigForActiveAgents(rt.Config, rt.Options, source, rt.Manager); err != nil {
+	if err := validateClaudeStartupConfigForActiveAgents(ctx, rt.Config, rt.Options, source, rt.Manager); err != nil {
 		rt.emitBootProgress(15, "workspace_validation_and_system_containers", "FAILED", err.Error())
 		return fmt.Errorf("claude runtime startup validation failed: %w", err)
 	}

--- a/internal/runtime/runtime_claude_startup.go
+++ b/internal/runtime/runtime_claude_startup.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"os"
 	"sort"
 	"strings"
 	"time"
@@ -23,7 +22,7 @@ import (
 	workspace "github.com/division-sh/swarm/internal/runtime/workspace"
 )
 
-func validateClaudeStartupConfig(cfg *config.Config, opts RuntimeOptions, source semanticview.Source) error {
+func validateClaudeStartupConfig(ctx context.Context, cfg *config.Config, opts RuntimeOptions, source semanticview.Source) error {
 	enabled, err := isClaudeCLIBackend(cfg)
 	if err != nil {
 		return err
@@ -38,10 +37,10 @@ func validateClaudeStartupConfig(cfg *config.Config, opts RuntimeOptions, source
 	if !hasAgents {
 		return nil
 	}
-	return validateClaudeStartupRequirements(cfg, opts)
+	return validateClaudeStartupRequirements(ctx, cfg, opts)
 }
 
-func validateClaudeStartupConfigForActiveAgents(cfg *config.Config, opts RuntimeOptions, source semanticview.Source, manager *runtimemanager.AgentManager) error {
+func validateClaudeStartupConfigForActiveAgents(ctx context.Context, cfg *config.Config, opts RuntimeOptions, source semanticview.Source, manager *runtimemanager.AgentManager) error {
 	enabled, err := isClaudeCLIBackend(cfg)
 	if err != nil {
 		return err
@@ -56,10 +55,10 @@ func validateClaudeStartupConfigForActiveAgents(cfg *config.Config, opts Runtime
 	if !hasAgents {
 		return nil
 	}
-	return validateClaudeStartupRequirements(cfg, opts)
+	return validateClaudeStartupRequirements(ctx, cfg, opts)
 }
 
-func validateSelectedBackendCredentialForDeclaredAgents(cfg *config.Config, source semanticview.Source) error {
+func validateSelectedBackendCredentialForDeclaredAgents(ctx context.Context, cfg *config.Config, opts RuntimeOptions, source semanticview.Source) error {
 	hasAgents, err := workflowSourceDeclaresAgents(source)
 	if err != nil {
 		return err
@@ -67,7 +66,7 @@ func validateSelectedBackendCredentialForDeclaredAgents(cfg *config.Config, sour
 	if !hasAgents {
 		return nil
 	}
-	return validateSelectedBackendCredential(cfg)
+	return validateSelectedBackendCredential(ctx, cfg, providerCredentialResolverForRuntimeOptions(opts))
 }
 
 func validateSelectedBackendModelAliasesForDeclaredAgents(cfg *config.Config, source semanticview.Source) error {
@@ -92,7 +91,7 @@ func validateSelectedBackendModelAliasesForDeclaredAgents(cfg *config.Config, so
 	return nil
 }
 
-func validateSelectedBackendCredentialForActiveAgents(cfg *config.Config, source semanticview.Source, manager *runtimemanager.AgentManager) error {
+func validateSelectedBackendCredentialForActiveAgents(ctx context.Context, cfg *config.Config, opts RuntimeOptions, source semanticview.Source, manager *runtimemanager.AgentManager) error {
 	hasAgents, err := workflowSourceOrManagerDeclaresAgents(source, manager)
 	if err != nil {
 		return err
@@ -100,10 +99,10 @@ func validateSelectedBackendCredentialForActiveAgents(cfg *config.Config, source
 	if !hasAgents {
 		return nil
 	}
-	return validateSelectedBackendCredential(cfg)
+	return validateSelectedBackendCredential(ctx, cfg, providerCredentialResolverForRuntimeOptions(opts))
 }
 
-func validateSelectedBackendCredential(cfg *config.Config) error {
+func validateSelectedBackendCredential(ctx context.Context, cfg *config.Config, credentials llm.ProviderCredentialResolver) error {
 	if cfg == nil {
 		return nil
 	}
@@ -111,11 +110,12 @@ func validateSelectedBackendCredential(cfg *config.Config) error {
 	if err != nil {
 		return err
 	}
-	return llmselection.RequireCredential(profile, os.LookupEnv)
+	_, err = credentials.Resolve(ctx, profile)
+	return err
 }
 
-func validateClaudeStartupRequirements(cfg *config.Config, opts RuntimeOptions) error {
-	if err := llm.ValidateClaudeCLIRuntimeConfig(cfg, opts.ToolGatewayBinding); err != nil {
+func validateClaudeStartupRequirements(ctx context.Context, cfg *config.Config, opts RuntimeOptions) error {
+	if err := llm.ValidateClaudeCLIRuntimeConfig(ctx, cfg, opts.ToolGatewayBinding, providerCredentialResolverForRuntimeOptions(opts)); err != nil {
 		return err
 	}
 	if opts.WorkspaceLifecycle == nil {

--- a/internal/runtime/runtime_claude_startup_test.go
+++ b/internal/runtime/runtime_claude_startup_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"net/http/httptest"
+	"path/filepath"
 	"slices"
 	"strings"
 	"testing"
@@ -13,6 +14,7 @@ import (
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
 	runtimeactors "github.com/division-sh/swarm/internal/runtime/core/actors"
 	"github.com/division-sh/swarm/internal/runtime/core/toolcapabilities"
+	runtimecredentials "github.com/division-sh/swarm/internal/runtime/credentials"
 	llm "github.com/division-sh/swarm/internal/runtime/llm"
 	runtimemanager "github.com/division-sh/swarm/internal/runtime/manager"
 	runtimemcp "github.com/division-sh/swarm/internal/runtime/mcp"
@@ -30,6 +32,20 @@ func testToolGatewayBinding(hostURL, workspaceURL, token string) toolgateway.Bin
 		LifecycleOwner:    toolgateway.LifecycleOwnerServeBoot,
 		Source:            toolgateway.SourceBoundMCPListener,
 	}
+}
+
+func testProviderCredentialStore(t *testing.T, key, value string) runtimecredentials.Store {
+	t.Helper()
+	store, err := runtimecredentials.NewFileStore(filepath.Join(t.TempDir(), "credentials.json"))
+	if err != nil {
+		t.Fatalf("NewFileStore: %v", err)
+	}
+	if strings.TrimSpace(value) != "" {
+		if err := store.Set(context.Background(), key, value); err != nil {
+			t.Fatalf("Set provider credential: %v", err)
+		}
+	}
+	return store
 }
 
 type claudeStartupWorkspaceStub struct {
@@ -77,8 +93,9 @@ func TestValidateClaudeStartupConfig_RequiresWorkspaceAndGateway(t *testing.T) {
 	t.Setenv("SWARM_CLAUDE_USE_MCP", "1")
 	t.Setenv("CLAUDE_CODE_OAUTH_TOKEN", "oauth-token")
 
-	err := validateClaudeStartupConfig(cfg, RuntimeOptions{
-		ToolGatewayBinding: testToolGatewayBinding("http://127.0.0.1:8081", "http://host.docker.internal:8081", "gateway-token"),
+	err := validateClaudeStartupConfig(context.Background(), cfg, RuntimeOptions{
+		ToolGatewayBinding:  testToolGatewayBinding("http://127.0.0.1:8081", "http://host.docker.internal:8081", "gateway-token"),
+		ProviderCredentials: testProviderCredentialStore(t, "CLAUDE_CODE_OAUTH_TOKEN", "oauth-token"),
 	}, claudeStartupAgentSource())
 	if err == nil || !strings.Contains(err.Error(), "workspace lifecycle") {
 		t.Fatalf("expected workspace lifecycle error, got %v", err)
@@ -94,7 +111,7 @@ func TestValidateClaudeStartupConfig_SkipsClaudeEnvForAgentFreeSource(t *testing
 	t.Setenv("SWARM_TOOL_GATEWAY_TOKEN", "")
 	t.Setenv("CLAUDE_CODE_OAUTH_TOKEN", "")
 
-	if err := validateClaudeStartupConfig(cfg, RuntimeOptions{}, claudeStartupAgentFreeSource()); err != nil {
+	if err := validateClaudeStartupConfig(context.Background(), cfg, RuntimeOptions{}, claudeStartupAgentFreeSource()); err != nil {
 		t.Fatalf("validateClaudeStartupConfig: %v", err)
 	}
 }
@@ -116,13 +133,13 @@ func TestValidateClaudeStartupConfigForActiveAgents_RequiresFullCLIBindingForRec
 	t.Setenv("CLAUDE_CODE_OAUTH_TOKEN", "")
 
 	opts.ToolGatewayBinding = testToolGatewayBinding("http://127.0.0.1:8081", "", "gateway-token")
-	err := validateClaudeStartupConfigForActiveAgents(cfg, opts, claudeStartupAgentFreeSource(), manager)
+	err := validateClaudeStartupConfigForActiveAgents(context.Background(), cfg, opts, claudeStartupAgentFreeSource(), manager)
 	if err == nil || !strings.Contains(err.Error(), "tool gateway binding workspace endpoint") {
 		t.Fatalf("expected workspace gateway binding error, got %v", err)
 	}
 
 	opts.ToolGatewayBinding = testToolGatewayBinding("http://127.0.0.1:8081", "http://host.docker.internal:8081", "gateway-token")
-	err = validateClaudeStartupConfigForActiveAgents(cfg, opts, claudeStartupAgentFreeSource(), manager)
+	err = validateClaudeStartupConfigForActiveAgents(context.Background(), cfg, opts, claudeStartupAgentFreeSource(), manager)
 	if err == nil || !strings.Contains(err.Error(), "CLAUDE_CODE_OAUTH_TOKEN") {
 		t.Fatalf("expected oauth token error, got %v", err)
 	}

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -3598,8 +3598,9 @@ engine:
         - SWARM_LLM_RUNTIME_MODE
         rules:
         - Runtime config is canonical for non-secret LLM behavior.
-        - Environment variables never select the backend profile. Environment variables remain valid only for provider
-          secrets and pragmatic infra/connection overrides explicitly owned by their configuration sections.
+        - Environment variables never select the backend profile. Provider secrets resolve from swarm secrets; provider env
+          names remain only deprecated shadow diagnostics. Pragmatic infra/connection env overrides are allowed only when
+          explicitly owned by their configuration sections.
         - Commands that need runtime/operator config discover explicit --config first, config.yaml beside the running binary
           when present second, and built-in/default config last.
         - The platform must not infer backend profile from credential, endpoint, model, or tool-gateway env presence.
@@ -3613,8 +3614,11 @@ engine:
             legacy_backend_ids:
             - api
             credential_source:
-              env_var: ANTHROPIC_API_KEY
+              secret_key: ANTHROPIC_API_KEY
+              owner: swarm secrets
+              legacy_env_var: ANTHROPIC_API_KEY
               required: true
+              resolution_rule: "Resolve from the provider credential store backed by swarm secrets; process env is deprecated diagnostic shadow input only and must not beat a stored secret."
           claude_cli:
             provider: claude
             transport: cli
@@ -3622,8 +3626,11 @@ engine:
             legacy_backend_ids:
             - cli_test
             credential_source:
-              env_var: CLAUDE_CODE_OAUTH_TOKEN
+              secret_key: CLAUDE_CODE_OAUTH_TOKEN
+              owner: swarm secrets
+              legacy_env_var: CLAUDE_CODE_OAUTH_TOKEN
               required: true
+              resolution_rule: "Resolve from the provider credential store backed by swarm secrets; process env is deprecated diagnostic shadow input only and must not beat a stored secret. Subprocess/container env injection is allowed only as final-boundary Claude CLI plumbing using the resolved secret value."
           openai_compatible:
             provider: openai_compatible
             transport: api
@@ -3631,8 +3638,11 @@ engine:
             protocol: Chat Completions-compatible HTTP JSON at /v1/chat/completions relative to the configured base URL.
             legacy_backend_ids: []
             credential_source:
-              env_var: OPENAI_COMPATIBLE_API_KEY
+              secret_key: OPENAI_COMPATIBLE_API_KEY
+              owner: swarm secrets
+              legacy_env_var: OPENAI_COMPATIBLE_API_KEY
               required: true
+              resolution_rule: "Resolve from the provider credential store backed by swarm secrets; process env is deprecated diagnostic shadow input only and must not beat a stored secret."
             endpoint_source:
               config_key: llm.openai_compatible.base_url
               env_var: null
@@ -3648,8 +3658,11 @@ engine:
             protocol: Native OpenAI Responses API resource path /responses relative to the configured base URL.
             legacy_backend_ids: []
             credential_source:
-              env_var: OPENAI_API_KEY
+              secret_key: OPENAI_API_KEY
+              owner: swarm secrets
+              legacy_env_var: OPENAI_API_KEY
               required: true
+              resolution_rule: "Resolve from the provider credential store backed by swarm secrets; process env is deprecated diagnostic shadow input only and must not beat a stored secret."
             endpoint_source:
               config_key: llm.openai_responses.base_url
               env_var: null
@@ -3709,17 +3722,20 @@ engine:
             unless a later gate promotes it explicitly.
         credential_and_endpoint_policy:
           credential_source:
-            env_var: OPENAI_API_KEY
+            secret_key: OPENAI_API_KEY
+            owner: swarm secrets
+            legacy_env_var: OPENAI_API_KEY
             required: true
+            resolution_rule: "Resolve from the provider credential store backed by swarm secrets; process env is deprecated diagnostic shadow input only and must not beat a stored secret."
           endpoint_source:
             config_key: llm.openai_responses.base_url
             env_var: null
             required: false
             built_in_default: https://api.openai.com/v1
           rules:
-            - Environment variables provide the OpenAI API secret only; they do not select the backend or endpoint.
+            - Swarm secrets provide the OpenAI API secret; environment variables do not select the backend or endpoint and are not the provider credential owner.
             - Runtime config is canonical for endpoint/base URL overrides used by deterministic tests or deployments.
-            - "Credential validation happens after openai_responses is selected and must fail closed before HTTP if OPENAI_API_KEY is missing."
+            - "Credential validation happens after openai_responses is selected and must fail closed before HTTP if OPENAI_API_KEY is missing from swarm secrets."
         model_alias_defaults:
           cheap: gpt-5.4-nano
           regular: gpt-5.4
@@ -3789,11 +3805,17 @@ engine:
         audit_rule: Runtime audit writes authored model alias plus resolved backend profile, provider identity, and concrete
           model at write time. Readers consume recorded values and MUST NOT reconstruct from current config.
       credential_and_config_policy:
-        secret_env_sources:
+        provider_secret_keys:
         - ANTHROPIC_API_KEY
         - CLAUDE_CODE_OAUTH_TOKEN
         - OPENAI_COMPATIBLE_API_KEY
         - OPENAI_API_KEY
+        deprecated_provider_env_shadow_sources:
+        - ANTHROPIC_API_KEY
+        - CLAUDE_CODE_OAUTH_TOKEN
+        - OPENAI_COMPATIBLE_API_KEY
+        - OPENAI_API_KEY
+        secret_env_sources:
         - SWARM_API_TOKEN
         - database password env/store sources
         runtime_config_canonical_for:


### PR DESCRIPTION
## Summary

- Adds a provider credential resolver backed by the existing `swarm secrets` file store for `ANTHROPIC_API_KEY`, `CLAUDE_CODE_OAUTH_TOKEN`, `OPENAI_COMPATIBLE_API_KEY`, and `OPENAI_API_KEY`.
- Wires runtime startup, `RuntimeFactory`, API providers, Claude CLI validation/final-boundary launch, serve, forkchat sandbox, selected-contract fork materialization, and doctor/preflight through that resolver.
- Removes active provider env authority: process env values are deprecated shadow diagnostics only and stored secrets win; env-only provider credentials fail closed with `swarm secrets set <KEY>` guidance.
- Updates `platform-spec.yaml` for provider credential source authority. Also adds missing CLI command-catalog group fields for `test` and `connections` to satisfy current source-authority conformance after rebasing; that part is non-runtime and non-closure-bearing for #1638.

Closes #1638
Part of #1600

## Governing refs / context

- `platform-spec.yaml#engine.llm_provider_selection_config_authority`
- `platform-spec.yaml#engine.backend_profile_identity`
- `platform-spec.yaml#engine.native_openai_responses_source_authority`
- `platform-spec.yaml#engine.credential_and_config_policy`
- Binding issue/gate context: #1638 approved first slice for provider credentials only; generic contract/tool credential store precedence and managed OAuth credentials remain split.

## Semantic migration

- New canonical owner: `internal/runtime/llm.ProviderCredentialResolver`, backed by `internal/runtime/credentials.FileStore` via `swarm secrets`.
- Old non-authoritative paths invalidated: direct provider env reads in LLM profile helpers, API runtime constructors/continuations, Claude CLI startup validation, local doctor/preflight, and parent-env propagation into Claude CLI subprocess/container launch.
- Production paths checked: serve runtime bundle construction, runtime project supervisor, `runtime.NewRuntime`, `llm.RuntimeFactory`, API runtimes, Claude CLI validation/build command, forkchat sandbox runtime creation, selected-contract fork runtime materialization, and doctor/preflight.
- Migration status: complete for the provider-credential class named by #1638. Generic contract/tool secrets and managed OAuth credentials are intentionally not migrated by this PR.

## Validation

- `go test ./...`
- Focused supported-surface proof while iterating: `go test ./internal/runtime/llm ./internal/runtime ./internal/runtime/runforkexecution ./cmd/swarm -count=1`
- Provider env-read audit: no active production `CredentialValue`, `RequireCredential`, or direct provider-key env reads remain outside profile key metadata and deprecated-shadow diagnostics.
