### PR TITLE
[agent-c][issue #1665] Lock deterministic ladder design record

### DIFF
--- a/internal/runtime/conformance/deterministic_work_ladder_design_record_test.go
+++ b/internal/runtime/conformance/deterministic_work_ladder_design_record_test.go
@@ -1,0 +1,622 @@
+package conformance
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+const deterministicWorkLadderDesignRecordPath = "internal/runtime/conformance/testdata/deterministic_work_ladder_design_record.yaml"
+
+type deterministicWorkLadderDesignRecord struct {
+	Version               int                                          `yaml:"version"`
+	Kind                  string                                       `yaml:"kind"`
+	Issue                 int                                          `yaml:"issue"`
+	ParentIssue           int                                          `yaml:"parent_issue"`
+	Stage0Issue           int                                          `yaml:"stage0_issue"`
+	Discussion            int                                          `yaml:"discussion"`
+	Authority             deterministicWorkLadderDesignAuthority       `yaml:"authority"`
+	SourceRefs            deterministicWorkLadderDesignSourceRefs      `yaml:"source_refs"`
+	Watchlist             deterministicWorkLadderDesignWatchlist       `yaml:"watchlist"`
+	LockedBoundary        deterministicWorkLadderLockedBoundary        `yaml:"locked_boundary"`
+	Repairs               []deterministicWorkLadderDesignRepair        `yaml:"repairs"`
+	LaunchLanguage        deterministicWorkLadderLaunchLanguage        `yaml:"launch_language"`
+	ChildConsumers        []deterministicWorkLadderDesignChildConsumer `yaml:"child_consumers"`
+	InvalidatedClaims     []string                                     `yaml:"invalidated_claims"`
+	ManifestationCoverage []deterministicWorkLadderDesignManifestation `yaml:"manifestation_coverage"`
+}
+
+type deterministicWorkLadderDesignAuthority struct {
+	Status                        string   `yaml:"status"`
+	RuntimeSemanticOwner          string   `yaml:"runtime_semantic_owner"`
+	PlatformSpecChangesAllowed    bool     `yaml:"platform_spec_changes_allowed"`
+	RuntimeBehaviorChangesAllowed bool     `yaml:"runtime_behavior_changes_allowed"`
+	ClaimsImplementedSemantics    bool     `yaml:"claims_implemented_semantics"`
+	PromotionRule                 string   `yaml:"promotion_rule"`
+	ProhibitedUses                []string `yaml:"prohibited_uses"`
+}
+
+type deterministicWorkLadderDesignSourceRefs struct {
+	Issue                  string   `yaml:"issue"`
+	PreAuditComment        string   `yaml:"pre_audit_comment"`
+	GateComment            string   `yaml:"gate_comment"`
+	ParentTracker          string   `yaml:"parent_tracker"`
+	Stage0Artifact         string   `yaml:"stage0_artifact"`
+	LockedDesignDiscussion string   `yaml:"locked_design_discussion"`
+	DiscussionAmendment    string   `yaml:"discussion_amendment"`
+	AdjacentContext        []string `yaml:"adjacent_context"`
+}
+
+type deterministicWorkLadderDesignWatchlist struct {
+	ID               string `yaml:"id"`
+	Owner            string `yaml:"owner"`
+	Role             string `yaml:"role"`
+	ParentNonClosure bool   `yaml:"parent_non_closure"`
+	ParentIssue      int    `yaml:"parent_issue"`
+}
+
+type deterministicWorkLadderLockedBoundary struct {
+	GenericLogicNode          string `yaml:"generic_logic_node"`
+	SystemNodeRename          string `yaml:"system_node_rename"`
+	SystemNodeVocabularyOwner string `yaml:"system_node_vocabulary_owner"`
+	ExternalIOPolicy          string `yaml:"external_io_policy"`
+	CodeContractRelation      string `yaml:"code_contract_relation"`
+	PlatformSpecPolicy        string `yaml:"platform_spec_policy"`
+	ExpressionLanguagePolicy  string `yaml:"expression_language_policy"`
+	ContractVisibilityRule    string `yaml:"contract_visibility_rule"`
+}
+
+type deterministicWorkLadderDesignRepair struct {
+	ID                                    string   `yaml:"id"`
+	OwnerIssue                            int      `yaml:"owner_issue"`
+	Decision                              string   `yaml:"decision"`
+	HiddenRuntimeSurfaceAllowed           bool     `yaml:"hidden_runtime_surface_allowed"`
+	RequiredSurfaces                      []string `yaml:"required_surfaces"`
+	SelectedName                          string   `yaml:"selected_name"`
+	ExistingComputeOwner                  string   `yaml:"existing_compute_owner"`
+	ExistingComputePreserved              bool     `yaml:"existing_compute_preserved"`
+	ForbiddenOverloads                    []string `yaml:"forbidden_overloads"`
+	ProseOnlyPlacementAllowed             bool     `yaml:"prose_only_placement_allowed"`
+	MCPSelfClassificationAuthoritative    bool     `yaml:"mcp_self_classification_authoritative"`
+	DefaultWithoutAuthoredClassification  string   `yaml:"default_without_authored_classification"`
+	CurrentActionSurvivesUntilDisposition bool     `yaml:"current_action_survives_until_disposition"`
+	EvidenceOwner                         string   `yaml:"evidence_owner"`
+	Note                                  string   `yaml:"note"`
+}
+
+type deterministicWorkLadderLaunchLanguage struct {
+	OwnerIssue                  int    `yaml:"owner_issue"`
+	Selected                    string `yaml:"selected"`
+	Status                      string `yaml:"status"`
+	OpenEndedMultiLanguageScope bool   `yaml:"open_ended_multi_language_scope"`
+	ImplementationNote          string `yaml:"implementation_note"`
+}
+
+type deterministicWorkLadderDesignChildConsumer struct {
+	Issue    int      `yaml:"issue"`
+	Role     string   `yaml:"role"`
+	Consumes []string `yaml:"consumes"`
+}
+
+type deterministicWorkLadderDesignManifestation struct {
+	ID     string `yaml:"id"`
+	Status string `yaml:"status"`
+	Proof  string `yaml:"proof"`
+}
+
+func TestDeterministicWorkLadderDesignRecordLocksGateBoundary(t *testing.T) {
+	root := conformanceRepoRoot(t)
+	record := loadDeterministicWorkLadderDesignRecord(t, root)
+	if problems := validateDeterministicWorkLadderDesignRecord(record); len(problems) > 0 {
+		t.Fatalf("deterministic work ladder design record validation failed:\n- %s", strings.Join(problems, "\n- "))
+	}
+}
+
+func TestDeterministicWorkLadderDesignRecordRejectsStaleOrRuntimeClaims(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(*deterministicWorkLadderDesignRecord)
+		want   string
+	}{
+		{
+			name: "runtime authority claim",
+			mutate: func(record *deterministicWorkLadderDesignRecord) {
+				record.Authority.ClaimsImplementedSemantics = true
+			},
+			want: "authority claims_implemented_semantics = true, want false",
+		},
+		{
+			name: "platform spec promotion claim",
+			mutate: func(record *deterministicWorkLadderDesignRecord) {
+				record.Authority.PlatformSpecChangesAllowed = true
+			},
+			want: "authority platform_spec_changes_allowed = true, want false",
+		},
+		{
+			name: "generic logic node accepted",
+			mutate: func(record *deterministicWorkLadderDesignRecord) {
+				record.LockedBoundary.GenericLogicNode = "accepted"
+			},
+			want: "locked_boundary generic_logic_node = \"accepted\", want rejected",
+		},
+		{
+			name: "system node rename accepted",
+			mutate: func(record *deterministicWorkLadderDesignRecord) {
+				record.LockedBoundary.SystemNodeRename = "accepted"
+			},
+			want: "locked_boundary system_node_rename = \"accepted\", want rejected",
+		},
+		{
+			name: "hidden activity result events",
+			mutate: func(record *deterministicWorkLadderDesignRecord) {
+				repair := deterministicWorkLadderDesignRepairByID(t, record, "activity_result_event_materialization")
+				repair.HiddenRuntimeSurfaceAllowed = true
+			},
+			want: "repair activity_result_event_materialization hidden_runtime_surface_allowed = true, want false",
+		},
+		{
+			name: "compute overload selected",
+			mutate: func(record *deterministicWorkLadderDesignRecord) {
+				repair := deterministicWorkLadderDesignRepairByID(t, record, "compute_name_collision")
+				repair.SelectedName = "compute"
+			},
+			want: "repair compute_name_collision selected_name = \"compute\", want compute_module",
+		},
+		{
+			name: "missing minimal activity form",
+			mutate: func(record *deterministicWorkLadderDesignRecord) {
+				repair := deterministicWorkLadderDesignRepairByID(t, record, "activity_minimal_authoring_form")
+				repair.Decision = "defer_minimal_form"
+			},
+			want: "repair activity_minimal_authoring_form decision = \"defer_minimal_form\", want tool_input_minimal_form_with_platform_defaults",
+		},
+		{
+			name: "fork policy invented downstream",
+			mutate: func(record *deterministicWorkLadderDesignRecord) {
+				repair := deterministicWorkLadderDesignRepairByID(t, record, "effect_class_fork_policy_defaults")
+				repair.Decision = "orchestration_decides_later"
+			},
+			want: "repair effect_class_fork_policy_defaults decision = \"orchestration_decides_later\", want default_fork_policy_must_be_specified_with_effect_classes",
+		},
+		{
+			name: "open ended languages",
+			mutate: func(record *deterministicWorkLadderDesignRecord) {
+				record.LaunchLanguage.OpenEndedMultiLanguageScope = true
+			},
+			want: "launch_language open_ended_multi_language_scope = true, want false",
+		},
+		{
+			name: "missing discussion amendment",
+			mutate: func(record *deterministicWorkLadderDesignRecord) {
+				record.SourceRefs.DiscussionAmendment = ""
+			},
+			want: "source_refs discussion_amendment missing #1460 discussion comment URL",
+		},
+		{
+			name: "missing child consumer",
+			mutate: func(record *deterministicWorkLadderDesignRecord) {
+				record.ChildConsumers = deterministicWorkLadderDesignConsumersExcept(record.ChildConsumers, 1671)
+			},
+			want: "child_consumers missing #1671",
+		},
+	}
+
+	root := conformanceRepoRoot(t)
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			record := loadDeterministicWorkLadderDesignRecord(t, root)
+			tc.mutate(&record)
+			problems := validateDeterministicWorkLadderDesignRecord(record)
+			if !routeAuthorityProblemsContain(problems, tc.want) {
+				t.Fatalf("validation problems missing %q:\n- %s", tc.want, strings.Join(problems, "\n- "))
+			}
+		})
+	}
+}
+
+func loadDeterministicWorkLadderDesignRecord(t *testing.T, root string) deterministicWorkLadderDesignRecord {
+	t.Helper()
+	raw, err := os.ReadFile(filepath.Join(root, deterministicWorkLadderDesignRecordPath))
+	if err != nil {
+		t.Fatalf("read deterministic work ladder design record: %v", err)
+	}
+	var record deterministicWorkLadderDesignRecord
+	if err := yaml.Unmarshal(raw, &record); err != nil {
+		t.Fatalf("parse deterministic work ladder design record: %v", err)
+	}
+	return record
+}
+
+func validateDeterministicWorkLadderDesignRecord(record deterministicWorkLadderDesignRecord) []string {
+	var problems []string
+	if record.Version != 1 {
+		problems = append(problems, fmt.Sprintf("version = %d, want 1", record.Version))
+	}
+	if record.Kind != "deterministic_work_ladder_design_record" {
+		problems = append(problems, fmt.Sprintf("kind = %q, want deterministic_work_ladder_design_record", record.Kind))
+	}
+	if record.Issue != 1665 {
+		problems = append(problems, fmt.Sprintf("issue = %d, want 1665", record.Issue))
+	}
+	if record.ParentIssue != 1663 {
+		problems = append(problems, fmt.Sprintf("parent_issue = %d, want 1663", record.ParentIssue))
+	}
+	if record.Stage0Issue != 1664 {
+		problems = append(problems, fmt.Sprintf("stage0_issue = %d, want 1664", record.Stage0Issue))
+	}
+	if record.Discussion != 1460 {
+		problems = append(problems, fmt.Sprintf("discussion = %d, want 1460", record.Discussion))
+	}
+
+	problems = append(problems, validateDeterministicWorkLadderDesignAuthority(record.Authority)...)
+	problems = append(problems, validateDeterministicWorkLadderDesignRefs(record.SourceRefs)...)
+	problems = append(problems, validateDeterministicWorkLadderDesignWatchlist(record.Watchlist)...)
+	problems = append(problems, validateDeterministicWorkLadderLockedBoundary(record.LockedBoundary)...)
+	problems = append(problems, validateDeterministicWorkLadderDesignRepairs(record.Repairs)...)
+	problems = append(problems, validateDeterministicWorkLadderLaunchLanguage(record.LaunchLanguage)...)
+	problems = append(problems, validateDeterministicWorkLadderDesignConsumers(record.ChildConsumers)...)
+	problems = append(problems, validateDeterministicWorkLadderInvalidatedClaims(record.InvalidatedClaims)...)
+	problems = append(problems, validateDeterministicWorkLadderManifestationCoverage(record.ManifestationCoverage)...)
+	return problems
+}
+
+func validateDeterministicWorkLadderDesignAuthority(authority deterministicWorkLadderDesignAuthority) []string {
+	var problems []string
+	if authority.Status != "non_authoritative_design_record" {
+		problems = append(problems, fmt.Sprintf("authority status = %q, want non_authoritative_design_record", authority.Status))
+	}
+	if authority.RuntimeSemanticOwner != "platform-spec.yaml" {
+		problems = append(problems, fmt.Sprintf("authority runtime_semantic_owner = %q, want platform-spec.yaml", authority.RuntimeSemanticOwner))
+	}
+	if authority.PlatformSpecChangesAllowed {
+		problems = append(problems, "authority platform_spec_changes_allowed = true, want false")
+	}
+	if authority.RuntimeBehaviorChangesAllowed {
+		problems = append(problems, "authority runtime_behavior_changes_allowed = true, want false")
+	}
+	if authority.ClaimsImplementedSemantics {
+		problems = append(problems, "authority claims_implemented_semantics = true, want false")
+	}
+	for _, want := range []string{"platform-spec.yaml", "same PR", "true on master"} {
+		if !strings.Contains(authority.PromotionRule, want) {
+			problems = append(problems, fmt.Sprintf("authority promotion_rule missing %q", want))
+		}
+	}
+	for _, want := range []string{"runtime_source_authority", "platform_spec_authority", "compatibility_seam_or_legacy_behavior_approval"} {
+		if !stringSet(recordStringSlice(authority.ProhibitedUses))[want] {
+			problems = append(problems, fmt.Sprintf("authority prohibited_uses missing %s", want))
+		}
+	}
+	return problems
+}
+
+func validateDeterministicWorkLadderDesignRefs(refs deterministicWorkLadderDesignSourceRefs) []string {
+	var problems []string
+	if refs.Stage0Artifact != deterministicWorkLadderStage0Path {
+		problems = append(problems, fmt.Sprintf("source_refs stage0_artifact = %q, want %s", refs.Stage0Artifact, deterministicWorkLadderStage0Path))
+	}
+	if !strings.Contains(refs.DiscussionAmendment, "github.com/division-sh/swarm/discussions/1460#discussioncomment-") {
+		problems = append(problems, "source_refs discussion_amendment missing #1460 discussion comment URL")
+	}
+	for _, ref := range []string{refs.Issue, refs.PreAuditComment, refs.GateComment, refs.ParentTracker, refs.LockedDesignDiscussion} {
+		if strings.TrimSpace(ref) == "" {
+			problems = append(problems, "source_refs contains empty required URL")
+		}
+	}
+	for _, want := range []string{"1652", "1654", "platform-spec.yaml#spec_authority.review_artifact_boundary", "platform-spec.yaml#handler_specification.handler_fields.compute"} {
+		if !containsSubstring(refs.AdjacentContext, want) {
+			problems = append(problems, fmt.Sprintf("source_refs adjacent_context missing %s", want))
+		}
+	}
+	return problems
+}
+
+func validateDeterministicWorkLadderDesignWatchlist(watchlist deterministicWorkLadderDesignWatchlist) []string {
+	var problems []string
+	if watchlist.ID != "runtime_operations.deterministic_work_ladder" {
+		problems = append(problems, fmt.Sprintf("watchlist id = %q, want runtime_operations.deterministic_work_ladder", watchlist.ID))
+	}
+	if watchlist.Owner != deterministicWorkLadderStage0Path {
+		problems = append(problems, fmt.Sprintf("watchlist owner = %q, want %s", watchlist.Owner, deterministicWorkLadderStage0Path))
+	}
+	if watchlist.Role != "adr_design_record" {
+		problems = append(problems, fmt.Sprintf("watchlist role = %q, want adr_design_record", watchlist.Role))
+	}
+	if !watchlist.ParentNonClosure {
+		problems = append(problems, "watchlist parent_non_closure = false, want true")
+	}
+	if watchlist.ParentIssue != 1663 {
+		problems = append(problems, fmt.Sprintf("watchlist parent_issue = %d, want 1663", watchlist.ParentIssue))
+	}
+	return problems
+}
+
+func validateDeterministicWorkLadderLockedBoundary(boundary deterministicWorkLadderLockedBoundary) []string {
+	var problems []string
+	if boundary.GenericLogicNode != "rejected" {
+		problems = append(problems, fmt.Sprintf("locked_boundary generic_logic_node = %q, want rejected", boundary.GenericLogicNode))
+	}
+	if boundary.SystemNodeRename != "rejected" {
+		problems = append(problems, fmt.Sprintf("locked_boundary system_node_rename = %q, want rejected", boundary.SystemNodeRename))
+	}
+	if boundary.SystemNodeVocabularyOwner != "platform-spec.yaml#vocabulary.agent_role.types.system_node" {
+		problems = append(problems, fmt.Sprintf("locked_boundary system_node_vocabulary_owner = %q, want platform-spec.yaml#vocabulary.agent_role.types.system_node", boundary.SystemNodeVocabularyOwner))
+	}
+	if boundary.ExternalIOPolicy != "durable_activities_only" {
+		problems = append(problems, fmt.Sprintf("locked_boundary external_io_policy = %q, want durable_activities_only", boundary.ExternalIOPolicy))
+	}
+	if boundary.CodeContractRelation != "code_subordinate_to_contract" {
+		problems = append(problems, fmt.Sprintf("locked_boundary code_contract_relation = %q, want code_subordinate_to_contract", boundary.CodeContractRelation))
+	}
+	if boundary.PlatformSpecPolicy != "no_speculative_v2_semantics" {
+		problems = append(problems, fmt.Sprintf("locked_boundary platform_spec_policy = %q, want no_speculative_v2_semantics", boundary.PlatformSpecPolicy))
+	}
+	if boundary.ExpressionLanguagePolicy != "no_middle_language_no_richer_cel" {
+		problems = append(problems, fmt.Sprintf("locked_boundary expression_language_policy = %q, want no_middle_language_no_richer_cel", boundary.ExpressionLanguagePolicy))
+	}
+	for _, want := range []string{"states", "emitted events", "entity writes", "external effects"} {
+		if !strings.Contains(boundary.ContractVisibilityRule, want) {
+			problems = append(problems, fmt.Sprintf("locked_boundary contract_visibility_rule missing %q", want))
+		}
+	}
+	return problems
+}
+
+func validateDeterministicWorkLadderDesignRepairs(repairs []deterministicWorkLadderDesignRepair) []string {
+	var problems []string
+	byID := map[string]deterministicWorkLadderDesignRepair{}
+	for _, repair := range repairs {
+		byID[repair.ID] = repair
+	}
+
+	resultEvents := byID["activity_result_event_materialization"]
+	if resultEvents.Decision != "generated_materialized_contract_outputs" {
+		problems = append(problems, fmt.Sprintf("repair activity_result_event_materialization decision = %q, want generated_materialized_contract_outputs", resultEvents.Decision))
+	}
+	if resultEvents.HiddenRuntimeSurfaceAllowed {
+		problems = append(problems, "repair activity_result_event_materialization hidden_runtime_surface_allowed = true, want false")
+	}
+	for _, want := range []string{"bundle", "catalog", "verify"} {
+		if !stringSet(resultEvents.RequiredSurfaces)[want] {
+			problems = append(problems, fmt.Sprintf("repair activity_result_event_materialization required_surfaces missing %s", want))
+		}
+	}
+
+	computeName := byID["compute_name_collision"]
+	if computeName.SelectedName != "compute_module" {
+		problems = append(problems, fmt.Sprintf("repair compute_name_collision selected_name = %q, want compute_module", computeName.SelectedName))
+	}
+	if computeName.ExistingComputeOwner != "platform-spec.yaml#handler_specification.handler_fields.compute" {
+		problems = append(problems, fmt.Sprintf("repair compute_name_collision existing_compute_owner = %q, want platform-spec.yaml#handler_specification.handler_fields.compute", computeName.ExistingComputeOwner))
+	}
+	if !computeName.ExistingComputePreserved {
+		problems = append(problems, "repair compute_name_collision existing_compute_preserved = false, want true")
+	}
+	for _, forbidden := range []string{"compute", "handler_fields.compute"} {
+		if !stringSet(computeName.ForbiddenOverloads)[forbidden] {
+			problems = append(problems, fmt.Sprintf("repair compute_name_collision forbidden_overloads missing %s", forbidden))
+		}
+	}
+
+	graphPlacement := byID["activity_graph_placement"]
+	if graphPlacement.Decision != "dependency_graph_delta_required" {
+		problems = append(problems, fmt.Sprintf("repair activity_graph_placement decision = %q, want dependency_graph_delta_required", graphPlacement.Decision))
+	}
+	if graphPlacement.ProseOnlyPlacementAllowed {
+		problems = append(problems, "repair activity_graph_placement prose_only_placement_allowed = true, want false")
+	}
+
+	effectClass := byID["tool_effect_class_authority"]
+	if effectClass.Decision != "ship_with_first_consumer" {
+		problems = append(problems, fmt.Sprintf("repair tool_effect_class_authority decision = %q, want ship_with_first_consumer", effectClass.Decision))
+	}
+	if effectClass.MCPSelfClassificationAuthoritative {
+		problems = append(problems, "repair tool_effect_class_authority mcp_self_classification_authoritative = true, want false")
+	}
+	if effectClass.DefaultWithoutAuthoredClassification != "deny" {
+		problems = append(problems, fmt.Sprintf("repair tool_effect_class_authority default_without_authored_classification = %q, want deny", effectClass.DefaultWithoutAuthoredClassification))
+	}
+
+	minimalForm := byID["activity_minimal_authoring_form"]
+	if minimalForm.OwnerIssue != 1666 {
+		problems = append(problems, fmt.Sprintf("repair activity_minimal_authoring_form owner_issue = %d, want 1666", minimalForm.OwnerIssue))
+	}
+	if minimalForm.Decision != "tool_input_minimal_form_with_platform_defaults" {
+		problems = append(problems, fmt.Sprintf("repair activity_minimal_authoring_form decision = %q, want tool_input_minimal_form_with_platform_defaults", minimalForm.Decision))
+	}
+	for _, want := range []string{"spec", "pilot"} {
+		if !stringSet(minimalForm.RequiredSurfaces)[want] {
+			problems = append(problems, fmt.Sprintf("repair activity_minimal_authoring_form required_surfaces missing %s", want))
+		}
+	}
+	for _, want := range []string{"tool plus input", "effect class", "not an implementation claim"} {
+		if !strings.Contains(minimalForm.Note, want) {
+			problems = append(problems, fmt.Sprintf("repair activity_minimal_authoring_form note missing %q", want))
+		}
+	}
+
+	forkPolicy := byID["effect_class_fork_policy_defaults"]
+	if forkPolicy.OwnerIssue != 1666 {
+		problems = append(problems, fmt.Sprintf("repair effect_class_fork_policy_defaults owner_issue = %d, want 1666", forkPolicy.OwnerIssue))
+	}
+	if forkPolicy.Decision != "default_fork_policy_must_be_specified_with_effect_classes" {
+		problems = append(problems, fmt.Sprintf("repair effect_class_fork_policy_defaults decision = %q, want default_fork_policy_must_be_specified_with_effect_classes", forkPolicy.Decision))
+	}
+	for _, want := range []string{"spec", "verify", "trace"} {
+		if !stringSet(forkPolicy.RequiredSurfaces)[want] {
+			problems = append(problems, fmt.Sprintf("repair effect_class_fork_policy_defaults required_surfaces missing %s", want))
+		}
+	}
+	for _, want := range []string{"#1671", "#1672", "must not invent"} {
+		if !strings.Contains(forkPolicy.Note, want) {
+			problems = append(problems, fmt.Sprintf("repair effect_class_fork_policy_defaults note missing %q", want))
+		}
+	}
+
+	artifactDisposition := byID["artifact_repo_commit_disposition"]
+	if artifactDisposition.OwnerIssue != 1667 {
+		problems = append(problems, fmt.Sprintf("repair artifact_repo_commit_disposition owner_issue = %d, want 1667", artifactDisposition.OwnerIssue))
+	}
+	if !artifactDisposition.CurrentActionSurvivesUntilDisposition {
+		problems = append(problems, "repair artifact_repo_commit_disposition current_action_survives_until_disposition = false, want true")
+	}
+
+	stageOrder := byID["stage_order_after_activity"]
+	if stageOrder.Decision != "declarative_helpers_before_compute_module" {
+		problems = append(problems, fmt.Sprintf("repair stage_order_after_activity decision = %q, want declarative_helpers_before_compute_module", stageOrder.Decision))
+	}
+	if stageOrder.EvidenceOwner != deterministicWorkLadderStage0Path {
+		problems = append(problems, fmt.Sprintf("repair stage_order_after_activity evidence_owner = %q, want %s", stageOrder.EvidenceOwner, deterministicWorkLadderStage0Path))
+	}
+
+	for _, id := range []string{"activity_result_event_materialization", "compute_name_collision", "activity_graph_placement", "tool_effect_class_authority", "activity_minimal_authoring_form", "effect_class_fork_policy_defaults", "artifact_repo_commit_disposition", "stage_order_after_activity"} {
+		if _, ok := byID[id]; !ok {
+			problems = append(problems, fmt.Sprintf("repairs missing %s", id))
+		}
+	}
+	return problems
+}
+
+func validateDeterministicWorkLadderLaunchLanguage(language deterministicWorkLadderLaunchLanguage) []string {
+	var problems []string
+	if language.OwnerIssue != 1670 {
+		problems = append(problems, fmt.Sprintf("launch_language owner_issue = %d, want 1670", language.OwnerIssue))
+	}
+	if language.Selected != "python" {
+		problems = append(problems, fmt.Sprintf("launch_language selected = %q, want python", language.Selected))
+	}
+	if language.Status != "decided_and_revisable" {
+		problems = append(problems, fmt.Sprintf("launch_language status = %q, want decided_and_revisable", language.Status))
+	}
+	if language.OpenEndedMultiLanguageScope {
+		problems = append(problems, "launch_language open_ended_multi_language_scope = true, want false")
+	}
+	return problems
+}
+
+func validateDeterministicWorkLadderDesignConsumers(consumers []deterministicWorkLadderDesignChildConsumer) []string {
+	var problems []string
+	byIssue := map[int]deterministicWorkLadderDesignChildConsumer{}
+	for _, consumer := range consumers {
+		byIssue[consumer.Issue] = consumer
+		if consumer.Role == "" {
+			problems = append(problems, fmt.Sprintf("child_consumers #%d missing role", consumer.Issue))
+		}
+		if len(consumer.Consumes) == 0 {
+			problems = append(problems, fmt.Sprintf("child_consumers #%d missing consumes", consumer.Issue))
+		}
+	}
+	for issue := 1666; issue <= 1672; issue++ {
+		if _, ok := byIssue[issue]; !ok {
+			problems = append(problems, fmt.Sprintf("child_consumers missing #%d", issue))
+		}
+	}
+	if !containsSubstring(byIssue[1669].Consumes, "compute_name_collision") {
+		problems = append(problems, "child_consumers #1669 does not consume compute_name_collision")
+	}
+	if !containsSubstring(byIssue[1666].Consumes, "activity_result_event_materialization") {
+		problems = append(problems, "child_consumers #1666 does not consume activity_result_event_materialization")
+	}
+	if !containsSubstring(byIssue[1666].Consumes, "activity_minimal_authoring_form") {
+		problems = append(problems, "child_consumers #1666 does not consume activity_minimal_authoring_form")
+	}
+	if !containsSubstring(byIssue[1671].Consumes, "effect_class_fork_policy_defaults") {
+		problems = append(problems, "child_consumers #1671 does not consume effect_class_fork_policy_defaults")
+	}
+	if !containsSubstring(byIssue[1672].Consumes, "effect_class_fork_policy_defaults") {
+		problems = append(problems, "child_consumers #1672 does not consume effect_class_fork_policy_defaults")
+	}
+	return problems
+}
+
+func validateDeterministicWorkLadderInvalidatedClaims(claims []string) []string {
+	var problems []string
+	set := stringSet(claims)
+	for _, claim := range []string{
+		"generic_logic_node_is_accepted_direction",
+		"system_node_should_be_renamed_to_routing_node",
+		"activity_result_events_can_be_hidden_runtime_only_surface",
+		"handler_fields_compute_can_be_overloaded_for_modules",
+		"minimal_activity_form_can_be_deferred_from_stage1",
+		"fork_policy_defaults_can_be_invented_by_later_consumers",
+		"launch_language_scope_is_open_ended_multi_language",
+		"design_discussion_or_private_docs_are_runtime_authority",
+		"speculative_platform_spec_notes_are_allowed_without_implementation",
+	} {
+		if !set[claim] {
+			problems = append(problems, fmt.Sprintf("invalidated_claims missing %s", claim))
+		}
+	}
+	return problems
+}
+
+func validateDeterministicWorkLadderManifestationCoverage(coverage []deterministicWorkLadderDesignManifestation) []string {
+	var problems []string
+	byID := map[string]deterministicWorkLadderDesignManifestation{}
+	for _, manifestation := range coverage {
+		byID[manifestation.ID] = manifestation
+		if manifestation.Status == "" {
+			problems = append(problems, fmt.Sprintf("manifestation %s missing status", manifestation.ID))
+		}
+		if manifestation.Proof == "" {
+			problems = append(problems, fmt.Sprintf("manifestation %s missing proof", manifestation.ID))
+		}
+	}
+	for _, id := range []string{
+		"stale_logic_node_language",
+		"system_node_rename_language",
+		"hidden_result_event_risk",
+		"compute_name_collision",
+		"prose_only_activity_placement",
+		"mcp_effect_class_self_classification",
+		"minimal_activity_form_ergonomics_gap",
+		"fork_policy_definition_gap",
+		"artifact_repo_commit_silence",
+		"python_launch_language_decision",
+		"stale_discussion_authority",
+		"speculative_platform_spec_authority",
+	} {
+		if _, ok := byID[id]; !ok {
+			problems = append(problems, fmt.Sprintf("manifestation_coverage missing %s", id))
+		}
+	}
+	return problems
+}
+
+func deterministicWorkLadderDesignRepairByID(t *testing.T, record *deterministicWorkLadderDesignRecord, id string) *deterministicWorkLadderDesignRepair {
+	t.Helper()
+	for i := range record.Repairs {
+		if record.Repairs[i].ID == id {
+			return &record.Repairs[i]
+		}
+	}
+	t.Fatalf("repair %s not found", id)
+	return nil
+}
+
+func deterministicWorkLadderDesignConsumersExcept(consumers []deterministicWorkLadderDesignChildConsumer, issue int) []deterministicWorkLadderDesignChildConsumer {
+	out := consumers[:0]
+	for _, consumer := range consumers {
+		if consumer.Issue != issue {
+			out = append(out, consumer)
+		}
+	}
+	return out
+}
+
+func containsSubstring(values []string, want string) bool {
+	for _, value := range values {
+		if strings.Contains(value, want) {
+			return true
+		}
+	}
+	return false
+}
+
+func recordStringSlice(values []string) []string {
+	return values
+}

--- a/internal/runtime/conformance/deterministic_work_ladder_design_record_test.go
+++ b/internal/runtime/conformance/deterministic_work_ladder_design_record_test.go
@@ -210,6 +210,47 @@ func TestDeterministicWorkLadderDesignRecordRejectsStaleOrRuntimeClaims(t *testi
 			},
 			want: "child_consumers missing #1671",
 		},
+		{
+			name: "duplicate child consumer issue",
+			mutate: func(record *deterministicWorkLadderDesignRecord) {
+				record.ChildConsumers = append(record.ChildConsumers, deterministicWorkLadderDesignConsumerByIssue(t, record, 1666))
+			},
+			want: "child_consumers duplicate issue #1666",
+		},
+		{
+			name: "zero child consumer issue",
+			mutate: func(record *deterministicWorkLadderDesignRecord) {
+				record.ChildConsumers = append(record.ChildConsumers, deterministicWorkLadderDesignChildConsumer{
+					Role:     "invalid_zero_issue",
+					Consumes: []string{"authority.promotion_rule"},
+				})
+			},
+			want: "child_consumers contains entry with zero issue",
+		},
+		{
+			name: "missing tool call invalidated claim",
+			mutate: func(record *deterministicWorkLadderDesignRecord) {
+				record.InvalidatedClaims = deterministicWorkLadderStringsExcept(record.InvalidatedClaims, "tool_call_action_is_the_whole_deterministic_io_solution")
+			},
+			want: "invalidated_claims missing tool_call_action_is_the_whole_deterministic_io_solution",
+		},
+		{
+			name: "duplicate manifestation id",
+			mutate: func(record *deterministicWorkLadderDesignRecord) {
+				record.ManifestationCoverage = append(record.ManifestationCoverage, deterministicWorkLadderManifestationByID(t, record, "compute_name_collision"))
+			},
+			want: "manifestation_coverage duplicate id compute_name_collision",
+		},
+		{
+			name: "empty manifestation id",
+			mutate: func(record *deterministicWorkLadderDesignRecord) {
+				record.ManifestationCoverage = append(record.ManifestationCoverage, deterministicWorkLadderDesignManifestation{
+					Status: "closed_by_design_record",
+					Proof:  "authority",
+				})
+			},
+			want: "manifestation_coverage contains entry with empty id",
+		},
 	}
 
 	root := conformanceRepoRoot(t)
@@ -517,6 +558,14 @@ func validateDeterministicWorkLadderDesignConsumers(consumers []deterministicWor
 	var problems []string
 	byIssue := map[int]deterministicWorkLadderDesignChildConsumer{}
 	for _, consumer := range consumers {
+		if consumer.Issue == 0 {
+			problems = append(problems, "child_consumers contains entry with zero issue")
+			continue
+		}
+		if _, exists := byIssue[consumer.Issue]; exists {
+			problems = append(problems, fmt.Sprintf("child_consumers duplicate issue #%d", consumer.Issue))
+			continue
+		}
 		byIssue[consumer.Issue] = consumer
 		if consumer.Role == "" {
 			problems = append(problems, fmt.Sprintf("child_consumers #%d missing role", consumer.Issue))
@@ -554,6 +603,7 @@ func validateDeterministicWorkLadderInvalidatedClaims(claims []string) []string 
 	for _, claim := range []string{
 		"generic_logic_node_is_accepted_direction",
 		"system_node_should_be_renamed_to_routing_node",
+		"tool_call_action_is_the_whole_deterministic_io_solution",
 		"activity_result_events_can_be_hidden_runtime_only_surface",
 		"handler_fields_compute_can_be_overloaded_for_modules",
 		"minimal_activity_form_can_be_deferred_from_stage1",
@@ -573,6 +623,14 @@ func validateDeterministicWorkLadderManifestationCoverage(coverage []determinist
 	var problems []string
 	byID := map[string]deterministicWorkLadderDesignManifestation{}
 	for _, manifestation := range coverage {
+		if strings.TrimSpace(manifestation.ID) == "" {
+			problems = append(problems, "manifestation_coverage contains entry with empty id")
+			continue
+		}
+		if _, exists := byID[manifestation.ID]; exists {
+			problems = append(problems, fmt.Sprintf("manifestation_coverage duplicate id %s", manifestation.ID))
+			continue
+		}
 		byID[manifestation.ID] = manifestation
 		if manifestation.Status == "" {
 			problems = append(problems, fmt.Sprintf("manifestation %s missing status", manifestation.ID))
@@ -618,6 +676,38 @@ func deterministicWorkLadderDesignConsumersExcept(consumers []deterministicWorkL
 	for _, consumer := range consumers {
 		if consumer.Issue != issue {
 			out = append(out, consumer)
+		}
+	}
+	return out
+}
+
+func deterministicWorkLadderDesignConsumerByIssue(t *testing.T, record *deterministicWorkLadderDesignRecord, issue int) deterministicWorkLadderDesignChildConsumer {
+	t.Helper()
+	for _, consumer := range record.ChildConsumers {
+		if consumer.Issue == issue {
+			return consumer
+		}
+	}
+	t.Fatalf("child consumer #%d not found", issue)
+	return deterministicWorkLadderDesignChildConsumer{}
+}
+
+func deterministicWorkLadderManifestationByID(t *testing.T, record *deterministicWorkLadderDesignRecord, id string) deterministicWorkLadderDesignManifestation {
+	t.Helper()
+	for _, manifestation := range record.ManifestationCoverage {
+		if manifestation.ID == id {
+			return manifestation
+		}
+	}
+	t.Fatalf("manifestation %s not found", id)
+	return deterministicWorkLadderDesignManifestation{}
+}
+
+func deterministicWorkLadderStringsExcept(values []string, remove string) []string {
+	out := values[:0]
+	for _, value := range values {
+		if value != remove {
+			out = append(out, value)
 		}
 	}
 	return out

--- a/internal/runtime/conformance/deterministic_work_ladder_design_record_test.go
+++ b/internal/runtime/conformance/deterministic_work_ladder_design_record_test.go
@@ -183,6 +183,13 @@ func TestDeterministicWorkLadderDesignRecordRejectsStaleOrRuntimeClaims(t *testi
 			want: "repair effect_class_fork_policy_defaults decision = \"orchestration_decides_later\", want default_fork_policy_must_be_specified_with_effect_classes",
 		},
 		{
+			name: "duplicate repair id",
+			mutate: func(record *deterministicWorkLadderDesignRecord) {
+				record.Repairs = append(record.Repairs, *deterministicWorkLadderDesignRepairByID(t, record, "compute_name_collision"))
+			},
+			want: "repairs duplicate id compute_name_collision",
+		},
+		{
 			name: "open ended languages",
 			mutate: func(record *deterministicWorkLadderDesignRecord) {
 				record.LaunchLanguage.OpenEndedMultiLanguageScope = true
@@ -370,6 +377,14 @@ func validateDeterministicWorkLadderDesignRepairs(repairs []deterministicWorkLad
 	var problems []string
 	byID := map[string]deterministicWorkLadderDesignRepair{}
 	for _, repair := range repairs {
+		if strings.TrimSpace(repair.ID) == "" {
+			problems = append(problems, "repairs contains entry with empty id")
+			continue
+		}
+		if _, exists := byID[repair.ID]; exists {
+			problems = append(problems, fmt.Sprintf("repairs duplicate id %s", repair.ID))
+			continue
+		}
 		byID[repair.ID] = repair
 	}
 

--- a/internal/runtime/conformance/testdata/deterministic_work_ladder_design_record.yaml
+++ b/internal/runtime/conformance/testdata/deterministic_work_ladder_design_record.yaml
@@ -1,0 +1,220 @@
+version: 1
+kind: deterministic_work_ladder_design_record
+issue: 1665
+parent_issue: 1663
+stage0_issue: 1664
+discussion: 1460
+authority:
+  status: non_authoritative_design_record
+  runtime_semantic_owner: platform-spec.yaml
+  platform_spec_changes_allowed: false
+  runtime_behavior_changes_allowed: false
+  claims_implemented_semantics: false
+  promotion_rule: >
+    This artifact is design evidence and watchpoint state only. New runtime,
+    verifier, CLI, test, or platform semantics become merge-bearing only when
+    promoted into platform-spec.yaml in the same PR that makes those semantics
+    true on master.
+  prohibited_uses:
+    - runtime_source_authority
+    - platform_spec_authority
+    - implementation_permission_without_child_gate
+    - compatibility_seam_or_legacy_behavior_approval
+source_refs:
+  issue: https://github.com/division-sh/swarm/issues/1665
+  pre_audit_comment: https://github.com/division-sh/swarm/issues/1665#issuecomment-4882658819
+  gate_comment: https://github.com/division-sh/swarm/issues/1665#issuecomment-4882704109
+  parent_tracker: https://github.com/division-sh/swarm/issues/1663
+  stage0_artifact: internal/runtime/conformance/testdata/deterministic_work_ladder_stage0.yaml
+  locked_design_discussion: https://github.com/division-sh/swarm/discussions/1460
+  discussion_amendment: https://github.com/division-sh/swarm/discussions/1460#discussioncomment-17533294
+  adjacent_context:
+    - https://github.com/division-sh/swarm/issues/1652
+    - https://github.com/division-sh/swarm/issues/1654
+    - platform-spec.yaml#spec_authority.review_artifact_boundary
+    - platform-spec.yaml#vocabulary.agent_role.types.system_node
+    - platform-spec.yaml#handler_specification.dependency_graph
+    - platform-spec.yaml#handler_specification.handler_fields.compute
+    - platform-spec.yaml#handler_specification.handler_fields.action
+watchlist:
+  id: runtime_operations.deterministic_work_ladder
+  owner: internal/runtime/conformance/testdata/deterministic_work_ladder_stage0.yaml
+  role: adr_design_record
+  parent_non_closure: true
+  parent_issue: 1663
+locked_boundary:
+  generic_logic_node: rejected
+  system_node_rename: rejected
+  system_node_vocabulary_owner: platform-spec.yaml#vocabulary.agent_role.types.system_node
+  external_io_policy: durable_activities_only
+  code_contract_relation: code_subordinate_to_contract
+  platform_spec_policy: no_speculative_v2_semantics
+  expression_language_policy: no_middle_language_no_richer_cel
+  contract_visibility_rule: >
+    Removing authored code must still leave the contract/build outputs able to
+    enumerate possible states, emitted events, entity writes, and external
+    effects.
+repairs:
+  - id: activity_result_event_materialization
+    owner_issue: 1666
+    decision: generated_materialized_contract_outputs
+    hidden_runtime_surface_allowed: false
+    required_surfaces:
+      - bundle
+      - catalog
+      - verify
+    note: >
+      Activity result events are generated from activity declarations and tool
+      output schema. They are visible contract-derived outputs, not hidden
+      runtime-only events.
+  - id: compute_name_collision
+    owner_issue: 1669
+    selected_name: compute_module
+    existing_compute_owner: platform-spec.yaml#handler_specification.handler_fields.compute
+    existing_compute_preserved: true
+    forbidden_overloads:
+      - compute
+      - handler_fields.compute
+    note: >
+      Existing compute remains the declarative operation grammar for weighted
+      average, pick_or_average, sum, min, max, and count. Future pure-code work
+      must not reuse that field as a module/executable-code carrier.
+  - id: activity_graph_placement
+    owner_issue: 1666
+    decision: dependency_graph_delta_required
+    prose_only_placement_allowed: false
+  - id: tool_effect_class_authority
+    owner_issue: 1666
+    decision: ship_with_first_consumer
+    mcp_self_classification_authoritative: false
+    default_without_authored_classification: deny
+  - id: activity_minimal_authoring_form
+    owner_issue: 1666
+    decision: tool_input_minimal_form_with_platform_defaults
+    required_surfaces:
+      - spec
+      - pilot
+    note: >
+      Stage 1 must preserve the locked-design friction budget: the minimal
+      activity form remains authored as tool plus input, with generated
+      result-event naming and retry, timeout, and idempotency defaults derived
+      from the tool output schema plus the authored effect class. This record
+      is not an implementation claim.
+  - id: effect_class_fork_policy_defaults
+    owner_issue: 1666
+    decision: default_fork_policy_must_be_specified_with_effect_classes
+    required_surfaces:
+      - spec
+      - verify
+      - trace
+    note: >
+      Effect-class fork/replay defaults are part of the effect-class authority
+      slice. #1671 and #1672 consume those defaults later; they must not invent
+      fork policy ad hoc from orchestration or trace code.
+  - id: artifact_repo_commit_disposition
+    owner_issue: 1667
+    decision: split_explicit_disposition
+    current_action_survives_until_disposition: true
+  - id: stage_order_after_activity
+    owner_issue: 1668
+    decision: declarative_helpers_before_compute_module
+    evidence_owner: internal/runtime/conformance/testdata/deterministic_work_ladder_stage0.yaml
+launch_language:
+  owner_issue: 1670
+  selected: python
+  status: decided_and_revisable
+  open_ended_multi_language_scope: false
+  implementation_note: >
+    Additional languages may be added later behind the same generated-bindings
+    interface, but launch scope is Python so build/tooling work does not expand
+    into a multi-language platform before the first supported surface exists.
+child_consumers:
+  - issue: 1666
+    role: durable_activities
+    consumes:
+      - activity_result_event_materialization
+      - activity_graph_placement
+      - tool_effect_class_authority
+      - activity_minimal_authoring_form
+      - effect_class_fork_policy_defaults
+      - locked_boundary.external_io_policy
+  - issue: 1667
+    role: artifact_repo_commit_disposition
+    consumes:
+      - artifact_repo_commit_disposition
+  - issue: 1668
+    role: declarative_helpers
+    consumes:
+      - stage_order_after_activity
+      - locked_boundary.expression_language_policy
+  - issue: 1669
+    role: compute_module_runtime
+    consumes:
+      - compute_name_collision
+      - locked_boundary.code_contract_relation
+  - issue: 1670
+    role: build_cli_topology
+    consumes:
+      - launch_language
+      - source_refs.adjacent_context.1654
+  - issue: 1671
+    role: orchestration_functions
+    consumes:
+      - locked_boundary.external_io_policy
+      - repairs.tool_effect_class_authority
+      - repairs.effect_class_fork_policy_defaults
+      - stage0_orchestration_gate
+  - issue: 1672
+    role: trace_test_conformance
+    consumes:
+      - source_refs.adjacent_context.1652
+      - repairs.effect_class_fork_policy_defaults
+      - authority.promotion_rule
+invalidated_claims:
+  - generic_logic_node_is_accepted_direction
+  - system_node_should_be_renamed_to_routing_node
+  - tool_call_action_is_the_whole_deterministic_io_solution
+  - activity_result_events_can_be_hidden_runtime_only_surface
+  - handler_fields_compute_can_be_overloaded_for_modules
+  - minimal_activity_form_can_be_deferred_from_stage1
+  - fork_policy_defaults_can_be_invented_by_later_consumers
+  - launch_language_scope_is_open_ended_multi_language
+  - design_discussion_or_private_docs_are_runtime_authority
+  - speculative_platform_spec_notes_are_allowed_without_implementation
+manifestation_coverage:
+  - id: stale_logic_node_language
+    status: closed_by_design_record
+    proof: locked_boundary.generic_logic_node
+  - id: system_node_rename_language
+    status: closed_by_design_record
+    proof: locked_boundary.system_node_rename
+  - id: hidden_result_event_risk
+    status: closed_by_design_record
+    proof: repairs.activity_result_event_materialization
+  - id: compute_name_collision
+    status: closed_by_design_record
+    proof: repairs.compute_name_collision
+  - id: prose_only_activity_placement
+    status: closed_by_design_record
+    proof: repairs.activity_graph_placement
+  - id: mcp_effect_class_self_classification
+    status: closed_by_design_record
+    proof: repairs.tool_effect_class_authority
+  - id: minimal_activity_form_ergonomics_gap
+    status: closed_by_design_record
+    proof: repairs.activity_minimal_authoring_form
+  - id: fork_policy_definition_gap
+    status: closed_by_design_record
+    proof: repairs.effect_class_fork_policy_defaults
+  - id: artifact_repo_commit_silence
+    status: split_to_child_issue
+    proof: repairs.artifact_repo_commit_disposition
+  - id: python_launch_language_decision
+    status: closed_by_design_record
+    proof: launch_language
+  - id: stale_discussion_authority
+    status: closed_by_design_record
+    proof: source_refs.discussion_amendment
+  - id: speculative_platform_spec_authority
+    status: closed_by_design_record
+    proof: authority


### PR DESCRIPTION
Closes #1665

## Summary

Adds the committed non-authoritative design-record/watchpoint artifact for the deterministic-work ladder and validates it with conformance coverage. The record locks the #1460 amendments for later children without promoting runtime behavior:

- rejects generic `logic_node` and `system_node` rename paths;
- records activity result events as generated/materialized contract outputs, not hidden runtime-only events;
- resolves the current `compute` name collision by locking the later pure-code naming family to `compute_module`;
- records Python as the decided-and-revisable launch language;
- records minimal activity authoring form and effect-class fork-policy defaults as #1666 design obligations;
- preserves #1663 as the open parent and #1666-#1672 as split implementation/conformance tails.

## Governing Refs / Context

No exact governing `platform-spec.yaml` section exists for durable activities, compute modules, orchestration functions, or the deterministic-work ladder. Binding context is #1665, #1663, the #1664 Stage 0 artifact, the #1460 locked design discussion plus amendment, and adjacent contract sections used only to constrain the boundary:

- `platform-spec.yaml#spec_authority.review_artifact_boundary`
- `platform-spec.yaml#vocabulary.agent_role.types.system_node`
- `platform-spec.yaml#handler_specification.dependency_graph`
- `platform-spec.yaml#handler_specification.handler_fields.compute`
- `platform-spec.yaml#handler_specification.handler_fields.action`
- #1652 and #1654 as later test/CLI adjacent surfaces

This PR does not edit `platform-spec.yaml` and does not claim new runtime semantics.

## Semantic Migration

New canonical owner for the #1665 design-record/watchpoint class:

- `internal/runtime/conformance/testdata/deterministic_work_ladder_design_record.yaml`

Old non-authoritative producer/reader/writer paths now invalid for this class:

- stale #1460 prose for generic `logic_node` / `system_node` rename;
- hidden runtime-only activity result-event interpretation;
- overloading current `handler_fields.compute` for pure-code modules;
- open-ended multi-language launch scope;
- treating discussion/private docs/design artifacts as runtime authority;
- speculative platform-spec notes without same-PR implementation.

Production paths checked for surviving old behavior:

- no `platform-spec.yaml` edit in this PR;
- existing `system_node` vocabulary survives as current platform vocabulary;
- existing `handler_fields.compute` declarative operation grammar survives;
- existing `artifact_repo_commit` action survives pending #1667 disposition;
- #1663 remains open and #1666-#1672 remain split children.

Migration completeness: complete for #1665's design-record/watchpoint owner only. Parent #1663 remains open.

## Validation

Passed:

- `go test ./internal/runtime/conformance -run TestDeterministicWorkLadderDesignRecord -count=1 -timeout=60s`

Full suite was run but is currently blocked by an unrelated `internal/apispec` failure on current master:

- `go test ./...`
- failing package: `github.com/division-sh/swarm/internal/apispec`
- failing test: `TestCLICommandCatalogRowsDeclareContractBearingGroups`
- failure: `command_catalog.test` and `command_catalog.connections` are missing required contract-bearing group fields
- reproduced with: `go test ./internal/apispec -run TestCLICommandCatalogRowsDeclareContractBearingGroups -count=1`
