### PR TITLE
[agent-f][issue #1651] Add provider trigger adapter owner

### DIFF
--- a/cmd/swarm/builder_project_supervisor.go
+++ b/cmd/swarm/builder_project_supervisor.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"net/http"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -326,6 +327,23 @@ func (s *runtimeProjectSupervisor) projectStatusLocked() builderpkg.ProjectStatu
 
 type dashboardDynamicRuntimeControl struct {
 	supervisor *runtimeProjectSupervisor
+}
+
+type runtimeProjectInboundHandler struct {
+	supervisor *runtimeProjectSupervisor
+}
+
+func (h runtimeProjectInboundHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if h.supervisor == nil {
+		http.Error(w, "runtime unavailable", http.StatusServiceUnavailable)
+		return
+	}
+	rt := h.supervisor.CurrentRuntime()
+	if rt == nil || rt.InboundGateway == nil {
+		http.Error(w, "runtime ingress unavailable", http.StatusServiceUnavailable)
+		return
+	}
+	rt.InboundGateway.Handler().ServeHTTP(w, r)
 }
 
 func (c dashboardDynamicRuntimeControl) PauseIngress() error {

--- a/cmd/swarm/builder_project_supervisor_test.go
+++ b/cmd/swarm/builder_project_supervisor_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
@@ -168,6 +170,53 @@ func TestRuntimeProjectSupervisorReplaceCurrentRuntime_WaitsForRuntimeStartBefor
 	}
 	if !ready.Load() {
 		t.Fatal("ready flag = false after runtime start completed")
+	}
+}
+
+func TestRuntimeProjectInboundHandlerRoutesThroughCurrentRuntimeAfterReplacement(t *testing.T) {
+	oldRT := &runtimepkg.Runtime{
+		InboundGateway: runtimepkg.NewInboundGateway(nil, nil, func() bool { return true }),
+	}
+	newRT := &runtimepkg.Runtime{
+		InboundGateway: runtimepkg.NewInboundGateway(nil, nil, nil),
+	}
+	var ready atomic.Bool
+	ready.Store(true)
+
+	supervisor := &runtimeProjectSupervisor{
+		ready:         &ready,
+		currentRoot:   "/tmp/old-project",
+		currentBundle: &runtimecontracts.WorkflowContractBundle{},
+		currentSource: semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{}),
+		currentRT:     oldRT,
+	}
+	supervisor.shutdownRuntime = func(context.Context, *runtimepkg.Runtime, runtimepkg.ShutdownOptions) error {
+		return nil
+	}
+	supervisor.startRuntime = func(context.Context, *runtimepkg.Runtime) error {
+		return nil
+	}
+
+	staticOld := httptest.NewRecorder()
+	oldRT.InboundGateway.Handler().ServeHTTP(staticOld, httptest.NewRequest(http.MethodPost, "/webhooks/customer-a/custom", strings.NewReader(`{"ok":true}`)))
+	if staticOld.Code != http.StatusServiceUnavailable {
+		t.Fatalf("old captured gateway status = %d, want 503", staticOld.Code)
+	}
+
+	if _, err := supervisor.replaceCurrentRuntime(
+		context.Background(),
+		"/tmp/new-project",
+		semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{}),
+		&runtimecontracts.WorkflowContractBundle{},
+		newRT,
+	); err != nil {
+		t.Fatalf("replaceCurrentRuntime: %v", err)
+	}
+
+	rec := httptest.NewRecorder()
+	runtimeProjectInboundHandler{supervisor: supervisor}.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/webhooks/customer-a/custom", strings.NewReader(`{"ok":true}`)))
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("dynamic inbound handler status = %d, want 202 body=%s", rec.Code, rec.Body.String())
 	}
 }
 

--- a/cmd/swarm/main.go
+++ b/cmd/swarm/main.go
@@ -65,7 +65,7 @@ const (
 	defaultPlatformSpecPath = platform.DefaultPlatformSpecPath
 	defaultAPIListenAddr    = "127.0.0.1:8081"
 	defaultMCPListenAddr    = "127.0.0.1:8082"
-	serveAPIRoutes          = "/healthz /readyz /v1/rpc /v1/ws"
+	serveAPIRoutes          = "/healthz /readyz /v1/rpc /v1/ws /webhooks/"
 	serveMCPRoutes          = "/mcp /tools/"
 	serveReadinessRoutes    = "/healthz /readyz"
 	serveExitDataIntegrity  = 78
@@ -136,6 +136,7 @@ type storeBundle struct {
 	ToolEntityStore              runtimetools.EntityPersistence
 	HumanTaskStore               runtimetools.HumanTaskPersistence
 	BudgetSpendStore             budgetspend.Store
+	InboundStore                 runtime.InboundPersistence
 	MailboxAPIStore              apiv1.MailboxAPIStore
 	ObservabilityStore           apiv1.ObservabilityReadStore
 	AgentUsageStore              apiv1.AgentUsageReadStore
@@ -287,6 +288,7 @@ func selectedPostgresStoreBundle(pg *store.PostgresStore, cfg *config.Config) st
 		ToolEntityStore:             pg,
 		HumanTaskStore:              pg,
 		BudgetSpendStore:            pg,
+		InboundStore:                pg,
 		MailboxAPIStore:             pg,
 		ObservabilityStore:          pg,
 		AgentUsageStore:             pg,
@@ -1146,7 +1148,11 @@ func runServeRuntime(ctx context.Context, repo string, opts serveOptions) int {
 		log.Printf("init v1 api: %v", err)
 		return 1
 	}
-	apiServer := newAPIServer(&ready, apiV1Handler)
+	var inboundHandler http.Handler
+	if rt.InboundGateway != nil {
+		inboundHandler = runtimeProjectInboundHandler{supervisor: supervisor}
+	}
+	apiServer := newAPIServer(&ready, apiV1Handler, inboundHandler)
 	mcpServer := newMCPServer(rt.ToolGateway)
 	if err := projectContextRegistration.WriteFinal(runtimeInstanceID, apiListener.Addr(), apiAuth, resolvedPaths, storeSelection, mountSources); err != nil {
 		reporter.emit(20, "context_registry", "FAILED", err.Error())
@@ -2577,6 +2583,7 @@ func buildStores(ctx context.Context, selection storebackend.Selection, cfg *con
 			ToolEntityStore:             sqliteStore,
 			HumanTaskStore:              sqliteStore,
 			BudgetSpendStore:            sqliteStore,
+			InboundStore:                sqliteStore,
 			MailboxAPIStore:             sqliteStore,
 			ObservabilityStore:          sqliteStore,
 			AgentUsageStore:             sqliteStore,
@@ -2975,7 +2982,7 @@ func systemWorkspaceContainers(lifecycle workspace.Lifecycle) []string {
 	return lister.SystemWorkspaceContainers()
 }
 
-func newAPIServer(ready *atomic.Bool, apiV1Handler http.Handler) *http.Server {
+func newAPIServer(ready *atomic.Bool, apiV1Handler http.Handler, inboundHandler http.Handler) *http.Server {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/healthz", func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
@@ -2992,6 +2999,15 @@ func newAPIServer(ready *atomic.Bool, apiV1Handler http.Handler) *http.Server {
 	if apiV1Handler != nil {
 		mux.Handle("/v1/rpc", apiV1Handler)
 		mux.Handle("/v1/ws", apiV1Handler)
+	}
+	if inboundHandler != nil {
+		mux.Handle("/webhooks/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if ready != nil && !ready.Load() {
+				http.Error(w, "booting", http.StatusServiceUnavailable)
+				return
+			}
+			inboundHandler.ServeHTTP(w, r)
+		}))
 	}
 	return &http.Server{
 		Handler:           mux,

--- a/cmd/swarm/main_test.go
+++ b/cmd/swarm/main_test.go
@@ -3554,6 +3554,9 @@ func TestLoadServeRuntimeBundleFromCatalogLoadsPersistedRuntimeSource(t *testing
 	}
 
 	stores := selectedPostgresStoreBundle(pg, &config.Config{})
+	if stores.InboundStore == nil || stores.runtimeStores().InboundStore == nil {
+		t.Fatal("selected Postgres store bundle missing InboundStore for served webhook ingress")
+	}
 	loaded, err := loadServeRuntimeBundleFromCatalog(ctx, repoRoot(), stores, projection.BundleHash, runningPlatformSpecPath)
 	if err != nil {
 		t.Fatalf("loadServeRuntimeBundleFromCatalog: %v", err)
@@ -7277,8 +7280,17 @@ func TestServeListenerServersPartitionAPIAndMCPRoutes(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":"test","result":{"ok":true}}`))
 	})
+	var inboundHit atomic.Bool
+	inboundHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		inboundHit.Store(true)
+		if r.URL.Path != "/webhooks/customer-a/github" {
+			t.Errorf("inbound path = %q, want /webhooks/customer-a/github", r.URL.Path)
+		}
+		w.WriteHeader(http.StatusAccepted)
+		_, _ = w.Write([]byte(`{"status":"accepted"}`))
+	})
 	toolGateway := runtimemcp.NewGateway(nil, "", runtimemcp.GatewayHooks{})
-	apiHandlerMux := newAPIServer(&ready, apiHandler).Handler
+	apiHandlerMux := newAPIServer(&ready, apiHandler, inboundHandler).Handler
 	mcpHandlerMux := newMCPServer(toolGateway).Handler
 
 	rec := httptest.NewRecorder()
@@ -7315,6 +7327,15 @@ func TestServeListenerServersPartitionAPIAndMCPRoutes(t *testing.T) {
 	}
 
 	rec = httptest.NewRecorder()
+	apiHandlerMux.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/webhooks/customer-a/github", strings.NewReader(`{"zen":"ok"}`)))
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("/webhooks/ status = %d, want 202 body=%s", rec.Code, rec.Body.String())
+	}
+	if !inboundHit.Load() {
+		t.Fatal("/webhooks/ did not route to inbound handler")
+	}
+
+	rec = httptest.NewRecorder()
 	apiHandlerMux.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/mcp", nil))
 	if rec.Code != http.StatusNotFound {
 		t.Fatalf("api listener /mcp status = %d, want 404", rec.Code)
@@ -7337,7 +7358,7 @@ func TestServeListenerServersPartitionAPIAndMCPRoutes(t *testing.T) {
 		t.Fatalf("/tools/ route status = %d, want mounted gateway 405", rec.Code)
 	}
 
-	for _, path := range []string{"/healthz", "/readyz", "/v1/rpc", "/v1/ws"} {
+	for _, path := range []string{"/healthz", "/readyz", "/v1/rpc", "/v1/ws", "/webhooks/customer-a/github"} {
 		rec = httptest.NewRecorder()
 		mcpHandlerMux.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, path, nil))
 		if rec.Code != http.StatusNotFound {

--- a/cmd/swarm/store_backend_selection_test.go
+++ b/cmd/swarm/store_backend_selection_test.go
@@ -324,7 +324,7 @@ func TestBuildStoresAcceptsSQLiteSelectedCoreRuntimeStore(t *testing.T) {
 		t.Fatalf("buildStores(sqlite): %v", err)
 	}
 	t.Cleanup(func() { closeDB(stores.SQLDB) })
-	if stores.SQLDB == nil || stores.RuntimeLogStore == nil || stores.SchemaBootstrapper == nil || stores.EventStore == nil || stores.PipelineStore == nil || stores.SessionRegistry == nil || stores.ConversationStore == nil || stores.ManagerStore == nil || stores.ScheduleStore == nil || stores.MailboxMaterializer == nil || stores.MailboxStore == nil || stores.BudgetSpendStore == nil || stores.MailboxAPIStore == nil || stores.ObservabilityStore == nil || stores.AgentUsageStore == nil || stores.AgentDeliveryLifecycleStore == nil || stores.RuntimeIngressStore == nil || stores.IdempotencyStore == nil || stores.TurnStore == nil || stores.StartupOwnership == nil {
+	if stores.SQLDB == nil || stores.RuntimeLogStore == nil || stores.SchemaBootstrapper == nil || stores.EventStore == nil || stores.PipelineStore == nil || stores.SessionRegistry == nil || stores.ConversationStore == nil || stores.ManagerStore == nil || stores.ScheduleStore == nil || stores.MailboxMaterializer == nil || stores.MailboxStore == nil || stores.BudgetSpendStore == nil || stores.InboundStore == nil || stores.MailboxAPIStore == nil || stores.ObservabilityStore == nil || stores.AgentUsageStore == nil || stores.AgentDeliveryLifecycleStore == nil || stores.RuntimeIngressStore == nil || stores.IdempotencyStore == nil || stores.TurnStore == nil || stores.StartupOwnership == nil {
 		t.Fatalf("sqlite store bundle missing selected core owners: %#v", stores)
 	}
 	if stores.Postgres != nil {
@@ -357,6 +357,9 @@ func TestBuildStoresAcceptsSQLiteSelectedCoreRuntimeStore(t *testing.T) {
 	}
 	if runtimeStores.BudgetSpendStore == nil {
 		t.Fatal("sqlite runtimeStores BudgetSpendStore missing backend-neutral budget/spend owner")
+	}
+	if runtimeStores.InboundStore == nil {
+		t.Fatal("sqlite runtimeStores InboundStore missing backend-neutral inbound webhook owner")
 	}
 	if runtimeStores.ToolEntityStore == nil {
 		t.Fatal("sqlite runtimeStores ToolEntityStore missing backend-neutral entity tool owner")

--- a/cmd/swarm/store_facade.go
+++ b/cmd/swarm/store_facade.go
@@ -112,6 +112,7 @@ func (f selectedRuntimeStoreFacade) runtimeStores() runtime.Stores {
 		ToolEntityStore:     s.ToolEntityStore,
 		HumanTaskStore:      s.HumanTaskStore,
 		BudgetSpendStore:    s.BudgetSpendStore,
+		InboundStore:        s.InboundStore,
 		RuntimeIngressStore: s.RuntimeIngressStore,
 		TurnStore:           s.TurnStore,
 	}

--- a/internal/runtime/inbound.go
+++ b/internal/runtime/inbound.go
@@ -60,6 +60,7 @@ type InboundGateway struct {
 	logger                  *RuntimeLogger
 	shutdownAdmissionClosed func() bool
 	runtimeIngress          *runtimeingress.Controller
+	providers               map[string]inboundProviderAdapter
 }
 
 func NewInboundGateway(bus *runtimebus.EventBus, logger *RuntimeLogger, shutdownAdmissionClosed func() bool, stores ...InboundPersistence) *InboundGateway {
@@ -73,6 +74,7 @@ func NewInboundGateway(bus *runtimebus.EventBus, logger *RuntimeLogger, shutdown
 		store:                   store,
 		logger:                  logger,
 		shutdownAdmissionClosed: shutdownAdmissionClosed,
+		providers:               defaultInboundProviderAdapters(),
 	}
 	g.mux.HandleFunc("/webhooks/", g.handleWebhook)
 	return g
@@ -132,23 +134,31 @@ func (g *InboundGateway) handleWebhook(w http.ResponseWriter, r *http.Request) {
 		target = resolved
 	}
 	target.NormalizeEntity()
-	if !verifyProviderSignature(provider, target.WebhookSecret, body, r.Header) {
-		http.Error(w, "invalid signature", http.StatusUnauthorized)
-		return
-	}
-
 	var payload any
 	if err := json.Unmarshal(body, &payload); err != nil {
 		payload = map[string]any{"raw": string(body)}
 	}
 	entityID := target.EffectiveEntityID()
 	entitySlug := target.EffectiveEntitySlug()
-	providerEventID := firstNonEmpty(
-		r.Header.Get("X-Provider-Event-ID"),
-		r.Header.Get("X-Request-ID"),
-		extractProviderEventID(payload),
-		fingerprintInbound(entityID, provider, body),
-	)
+	now := time.Now().UTC()
+	delivery, err := g.providerAdapter(provider).AcceptInbound(inboundProviderRequest{
+		Provider:  provider,
+		Target:    target,
+		Body:      body,
+		Headers:   r.Header,
+		Payload:   payload,
+		Received:  now,
+		UserAgent: r.UserAgent(),
+	})
+	if err != nil {
+		status := http.StatusBadRequest
+		if providerErr, ok := err.(inboundProviderError); ok {
+			status = providerErr.Status
+		}
+		http.Error(w, err.Error(), status)
+		return
+	}
+	providerEventID := delivery.ProviderEventID
 
 	if g.store != nil {
 		inserted, err := g.store.RecordInboundEvent(r.Context(), providerEventID, entityID, provider)
@@ -157,16 +167,18 @@ func (g *InboundGateway) handleWebhook(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		if !inserted {
-			writeJSON(w, http.StatusOK, map[string]any{"status": "duplicate", "provider_event_id": providerEventID})
+			writeJSON(w, http.StatusOK, map[string]any{
+				"status":              "duplicate",
+				"provider":            provider,
+				"provider_event_id":   providerEventID,
+				"provider_event_type": delivery.ProviderEventType,
+				"event_name":          string(delivery.EventName),
+			})
 			return
 		}
 	}
 
-	now := time.Now().UTC()
-	pubType, pubPayload := buildInboundPublishPayload(provider, entityID, providerEventID, payload, now)
-	pubPayload["headers"] = map[string]any{
-		"user_agent": r.UserAgent(),
-	}
+	pubType, pubPayload := delivery.EventName, delivery.Payload
 	envelopeBytes := mustJSON(pubPayload)
 	if g.bus != nil {
 		pubCtx := runtimebus.WithCurrentRuntimeEpoch(r.Context())
@@ -195,12 +207,23 @@ func (g *InboundGateway) handleWebhook(w http.ResponseWriter, r *http.Request) {
 	}
 
 	writeJSON(w, http.StatusAccepted, map[string]any{
-		"status":            "accepted",
-		"entity_id":         entityID,
-		"entity_slug":       entitySlug,
-		"provider":          provider,
-		"provider_event_id": providerEventID,
+		"status":              "accepted",
+		"entity_id":           entityID,
+		"entity_slug":         entitySlug,
+		"provider":            provider,
+		"provider_event_id":   providerEventID,
+		"provider_event_type": delivery.ProviderEventType,
+		"event_name":          string(delivery.EventName),
 	})
+}
+
+func (g *InboundGateway) providerAdapter(provider string) inboundProviderAdapter {
+	if g != nil {
+		if adapter, ok := g.providers[normalizeProviderName(provider)]; ok && adapter != nil {
+			return adapter
+		}
+	}
+	return rawInboundProviderAdapter{}
 }
 
 func parseWebhookPath(path string) (entityID, provider string, ok bool) {
@@ -215,6 +238,127 @@ func parseWebhookPath(path string) (entityID, provider string, ok bool) {
 		return "", "", false
 	}
 	return entityID, provider, true
+}
+
+func normalizeProviderName(raw string) string {
+	return normalizeEventToken(raw)
+}
+
+type inboundProviderAdapter interface {
+	AcceptInbound(inboundProviderRequest) (inboundProviderDelivery, error)
+}
+
+type inboundProviderRequest struct {
+	Provider  string
+	Target    InboundTarget
+	Body      []byte
+	Headers   http.Header
+	Payload   any
+	Received  time.Time
+	UserAgent string
+}
+
+type inboundProviderDelivery struct {
+	ProviderEventID   string
+	ProviderEventType string
+	EventName         events.EventType
+	Payload           map[string]any
+}
+
+type inboundProviderError struct {
+	Status  int
+	Message string
+}
+
+func (e inboundProviderError) Error() string {
+	return e.Message
+}
+
+func inboundBadRequest(message string) inboundProviderError {
+	return inboundProviderError{Status: http.StatusBadRequest, Message: message}
+}
+
+func inboundUnauthorized(message string) inboundProviderError {
+	return inboundProviderError{Status: http.StatusUnauthorized, Message: message}
+}
+
+func defaultInboundProviderAdapters() map[string]inboundProviderAdapter {
+	return map[string]inboundProviderAdapter{
+		"github": githubInboundProviderAdapter{},
+	}
+}
+
+type githubInboundProviderAdapter struct{}
+
+func (githubInboundProviderAdapter) AcceptInbound(req inboundProviderRequest) (inboundProviderDelivery, error) {
+	secret := strings.TrimSpace(req.Target.WebhookSecret)
+	if secret == "" {
+		return inboundProviderDelivery{}, inboundUnauthorized("github webhook signing secret is required")
+	}
+	if !verifyGitHubSignature(secret, req.Body, req.Headers) {
+		return inboundProviderDelivery{}, inboundUnauthorized("invalid github signature")
+	}
+	deliveryID := strings.TrimSpace(req.Headers.Get("X-GitHub-Delivery"))
+	if deliveryID == "" {
+		return inboundProviderDelivery{}, inboundBadRequest("github delivery id is required")
+	}
+	eventType := normalizeEventToken(req.Headers.Get("X-GitHub-Event"))
+	if eventType == "event" {
+		return inboundProviderDelivery{}, inboundBadRequest("github event type is required")
+	}
+	entityID := req.Target.EffectiveEntityID()
+	payload := buildProviderPublishPayload("github", entityID, deliveryID, eventType, req.Payload, req.Received, map[string]any{
+		"user_agent":      req.UserAgent,
+		"github_delivery": deliveryID,
+		"github_event":    eventType,
+	})
+	return inboundProviderDelivery{
+		ProviderEventID:   deliveryID,
+		ProviderEventType: eventType,
+		EventName:         events.EventType("inbound.github." + eventType),
+		Payload:           payload,
+	}, nil
+}
+
+type rawInboundProviderAdapter struct{}
+
+func (rawInboundProviderAdapter) AcceptInbound(req inboundProviderRequest) (inboundProviderDelivery, error) {
+	provider := normalizeProviderName(req.Provider)
+	if provider == "" {
+		return inboundProviderDelivery{}, inboundBadRequest("provider is required")
+	}
+	if !verifyRawWebhookSignature(req.Target.WebhookSecret, req.Body, req.Headers) {
+		return inboundProviderDelivery{}, inboundUnauthorized("invalid signature")
+	}
+	entityID := req.Target.EffectiveEntityID()
+	providerEventID := firstNonEmpty(
+		req.Headers.Get("X-Provider-Event-ID"),
+		req.Headers.Get("X-Request-ID"),
+		extractProviderEventID(req.Payload),
+		fingerprintInbound(entityID, provider, req.Body),
+	)
+	providerEventType := resolveProviderEventType(provider, req.Payload)
+	payload := buildProviderPublishPayload(provider, entityID, providerEventID, providerEventType, req.Payload, req.Received, map[string]any{
+		"user_agent": req.UserAgent,
+	})
+	return inboundProviderDelivery{
+		ProviderEventID:   providerEventID,
+		ProviderEventType: providerEventType,
+		EventName:         events.EventType("inbound." + provider),
+		Payload:           payload,
+	}, nil
+}
+
+func buildProviderPublishPayload(provider, entityID, providerEventID, providerEventType string, rawPayload any, now time.Time, headers map[string]any) map[string]any {
+	return map[string]any{
+		"entity_id":         strings.TrimSpace(entityID),
+		"provider":          strings.TrimSpace(provider),
+		"event_type":        strings.TrimSpace(providerEventType),
+		"provider_event_id": strings.TrimSpace(providerEventID),
+		"payload":           rawPayload,
+		"headers":           headers,
+		"received_at":       now.Format(time.RFC3339),
+	}
 }
 
 func extractProviderEventID(payload any) string {
@@ -247,17 +391,6 @@ func firstNonEmpty(values ...string) string {
 		}
 	}
 	return ""
-}
-
-func buildInboundPublishPayload(provider, entityID, providerEventID string, rawPayload any, now time.Time) (events.EventType, map[string]any) {
-	return events.EventType("inbound." + normalizeEventToken(provider)), map[string]any{
-		"entity_id":         strings.TrimSpace(entityID),
-		"provider":          strings.TrimSpace(provider),
-		"event_type":        resolveProviderEventType(provider, rawPayload),
-		"provider_event_id": strings.TrimSpace(providerEventID),
-		"payload":           rawPayload,
-		"received_at":       now.Format(time.RFC3339),
-	}
 }
 
 func firstStringByKeys(obj map[string]any, keys ...string) string {
@@ -345,7 +478,19 @@ func normalizeEventToken(raw string) string {
 	return token
 }
 
-func verifyProviderSignature(provider, secret string, body []byte, headers http.Header) bool {
+func verifyGitHubSignature(secret string, body []byte, headers http.Header) bool {
+	sig := strings.TrimSpace(headers.Get("X-Hub-Signature-256"))
+	if !strings.HasPrefix(strings.ToLower(sig), "sha256=") {
+		return false
+	}
+	given := strings.TrimSpace(sig[len("sha256="):])
+	mac := hmac.New(sha256.New, []byte(strings.TrimSpace(secret)))
+	_, _ = mac.Write(body)
+	expected := hex.EncodeToString(mac.Sum(nil))
+	return hmac.Equal([]byte(strings.ToLower(given)), []byte(strings.ToLower(expected)))
+}
+
+func verifyRawWebhookSignature(secret string, body []byte, headers http.Header) bool {
 	secret = strings.TrimSpace(secret)
 	// If no secret is configured, accept unsigned ingress.
 	if secret == "" {

--- a/internal/runtime/inbound_postgres_test.go
+++ b/internal/runtime/inbound_postgres_test.go
@@ -1,0 +1,331 @@
+package runtime_test
+
+import (
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"database/sql"
+	"encoding/hex"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/division-sh/swarm/internal/events"
+	runtimepkg "github.com/division-sh/swarm/internal/runtime"
+	runtimebus "github.com/division-sh/swarm/internal/runtime/bus"
+	runtimeactors "github.com/division-sh/swarm/internal/runtime/core/actors"
+	runtimecorrelation "github.com/division-sh/swarm/internal/runtime/correlation"
+	runtimeingress "github.com/division-sh/swarm/internal/runtime/ingress"
+	runtimemanager "github.com/division-sh/swarm/internal/runtime/manager"
+	"github.com/division-sh/swarm/internal/store"
+	"github.com/division-sh/swarm/internal/testutil"
+)
+
+func TestInboundGateway_GitHubPausedRuntimePersistsAndReleasesSubscribedDispatch(t *testing.T) {
+	_, db, cleanup := testutil.StartPostgres(t)
+	t.Cleanup(cleanup)
+
+	const (
+		runID             = "41000000-0000-0000-0000-000000000001"
+		entityID          = "41000000-0000-0000-0000-000000000002"
+		flowInstance      = "github-provider-trigger-instance"
+		entitySlug        = "customer-a"
+		provider          = "github"
+		webhookSecret     = "github-secret"
+		providerEventID   = "delivery-123"
+		agentID           = "github-webhook-subscriber"
+		providerEventName = "inbound.github.push"
+	)
+	ctx := runtimecorrelation.WithRunID(context.Background(), runID)
+	pg := &store.PostgresStore{DB: db}
+	seedPostgresInboundGatewayRuntime(t, ctx, db, pg, runID, entityID, flowInstance, entitySlug, provider, webhookSecret, agentID)
+
+	bus, err := runtimebus.NewEventBus(pg)
+	if err != nil {
+		t.Fatalf("NewEventBus: %v", err)
+	}
+	controller := runtimeingress.NewController(pg, bus, runtimeingress.Options{})
+	t.Cleanup(runtimebus.ResumeRuntimeIngress)
+	bus.SetRuntimeIngressDispatchGate(controller)
+
+	eventType := events.EventType(providerEventName)
+	ch := bus.Subscribe(agentID, eventType)
+	defer bus.Unsubscribe(agentID)
+
+	if _, err := controller.Pause(ctx, runtimeingress.TransitionRequest{
+		Reason:       "test_pause",
+		ControlledBy: "test",
+	}); err != nil {
+		t.Fatalf("Pause: %v", err)
+	}
+
+	g := runtimepkg.NewInboundGateway(bus, nil, nil, pg)
+	g.SetRuntimeIngress(controller)
+
+	body := []byte(`{"zen":"Keep it logically awesome."}`)
+	req := httptest.NewRequest(http.MethodPost, "/webhooks/customer-a/github", strings.NewReader(string(body)))
+	req = req.WithContext(ctx)
+	req.Header.Set("X-Hub-Signature-256", githubWebhookSignature(webhookSecret, body))
+	req.Header.Set("X-GitHub-Delivery", providerEventID)
+	req.Header.Set("X-GitHub-Event", "push")
+	rec := httptest.NewRecorder()
+	g.Handler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("status = %d, want 202 body=%s", rec.Code, rec.Body.String())
+	}
+	if got := countPostgresInboundMarkers(t, ctx, db, providerEventID, entityID, provider); got != 1 {
+		t.Fatalf("inbound marker rows = %d, want 1", got)
+	}
+	eventID := loadPostgresInboundProviderEventID(t, ctx, db, runID, entityID, providerEventName, providerEventID)
+	if got := countPostgresInboundProviderEvents(t, ctx, db, runID, entityID, providerEventName, providerEventID); got != 1 {
+		t.Fatalf("provider event rows = %d, want 1", got)
+	}
+	requireNoInboundBusEvent(t, ch, "paused GitHub webhook before resume")
+	if got := countPostgresAgentDeliveriesForEvent(t, ctx, db, eventID, agentID); got != 1 {
+		t.Fatalf("agent delivery rows while paused = %d, want 1", got)
+	}
+	if got := loadPostgresAgentDeliveryStatus(t, ctx, db, eventID, agentID); got != "pending" {
+		t.Fatalf("agent delivery status while paused = %q, want pending", got)
+	}
+	if got := countPostgresPipelineReceiptsForEvent(t, ctx, db, eventID); got != 0 {
+		t.Fatalf("pipeline receipts while paused = %d, want 0", got)
+	}
+	if got := countPostgresAgentReceiptsForEvent(t, ctx, db, eventID, agentID); got != 0 {
+		t.Fatalf("agent receipts while paused = %d, want 0", got)
+	}
+
+	resumed, err := controller.Resume(ctx, runtimeingress.TransitionRequest{
+		Reason:       "test_resume",
+		ControlledBy: "test",
+	})
+	if err != nil {
+		t.Fatalf("Resume: %v", err)
+	}
+	if resumed.ReleasedCount != 1 {
+		t.Fatalf("released count = %d, want 1", resumed.ReleasedCount)
+	}
+	got := requireInboundBusEvent(t, ch, "paused GitHub webhook release after resume")
+	if got.ID() != eventID {
+		t.Fatalf("delivered event = %s, want %s", got.ID(), eventID)
+	}
+	if got.Type() != eventType {
+		t.Fatalf("delivered event type = %s, want %s", got.Type(), eventType)
+	}
+	requireNoInboundBusEvent(t, ch, "paused GitHub webhook releases exactly once")
+	if got := countPostgresPipelineReceiptsForEvent(t, ctx, db, eventID); got != 1 {
+		t.Fatalf("pipeline receipts after resume = %d, want 1", got)
+	}
+	if got := countPostgresInboundMarkers(t, ctx, db, providerEventID, entityID, provider); got != 1 {
+		t.Fatalf("inbound marker rows after resume = %d, want 1", got)
+	}
+	if got := countPostgresInboundProviderEvents(t, ctx, db, runID, entityID, providerEventName, providerEventID); got != 1 {
+		t.Fatalf("provider event rows after resume = %d, want 1", got)
+	}
+}
+
+func seedPostgresInboundGatewayRuntime(
+	t *testing.T,
+	ctx context.Context,
+	db *sql.DB,
+	pg *store.PostgresStore,
+	runID string,
+	entityID string,
+	flowInstance string,
+	entitySlug string,
+	provider string,
+	webhookSecret string,
+	agentID string,
+) {
+	t.Helper()
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO runs (run_id, status)
+		VALUES ($1::uuid, 'running')
+		ON CONFLICT (run_id) DO NOTHING
+	`, runID); err != nil {
+		t.Fatalf("seed run: %v", err)
+	}
+	configBytes, err := json.Marshal(map[string]any{
+		"secrets": map[string]any{
+			"webhook_signing": map[string]string{
+				provider: webhookSecret,
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("marshal flow config: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO flow_instances (instance_id, flow_template, mode, config, status, created_at)
+		VALUES ($1, 'test', 'static', $2::jsonb, 'active', now())
+		ON CONFLICT (instance_id) DO UPDATE SET config = EXCLUDED.config, status = EXCLUDED.status
+	`, flowInstance, string(configBytes)); err != nil {
+		t.Fatalf("seed flow instance: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO entity_state (
+			run_id, entity_id, flow_instance, entity_type, slug, name, current_state,
+			gates, fields, accumulator, revision, entered_state_at, created_at, updated_at
+		) VALUES (
+			$1::uuid, $2::uuid, $3, 'default', $4, 'Customer A', 'active',
+			'{}'::jsonb, '{}'::jsonb, '{}'::jsonb, 1, now(), now(), now()
+		)
+		ON CONFLICT (run_id, entity_id) DO NOTHING
+	`, runID, entityID, flowInstance, entitySlug); err != nil {
+		t.Fatalf("seed entity state: %v", err)
+	}
+	if err := pg.UpsertAgent(ctx, runtimemanager.PersistedAgent{
+		Config: runtimeactors.AgentConfig{
+			ID:     agentID,
+			Role:   "observer",
+			Mode:   "global",
+			Type:   "stub",
+			Model:  "regular",
+			Config: []byte(`{}`),
+		},
+		Status:    "active",
+		HiredBy:   "test",
+		StartedAt: time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("UpsertAgent(%s): %v", agentID, err)
+	}
+}
+
+func loadPostgresInboundProviderEventID(t *testing.T, ctx context.Context, db *sql.DB, runID string, entityID string, eventName string, providerEventID string) string {
+	t.Helper()
+	var eventID string
+	if err := db.QueryRowContext(ctx, `
+		SELECT event_id::text
+		FROM events
+		WHERE run_id = $1::uuid
+		  AND entity_id = $2::uuid
+		  AND event_name = $3
+		  AND payload->>'provider_event_id' = $4
+		ORDER BY created_at DESC
+		LIMIT 1
+	`, runID, entityID, eventName, providerEventID).Scan(&eventID); err != nil {
+		t.Fatalf("load inbound provider event id: %v", err)
+	}
+	return eventID
+}
+
+func countPostgresInboundProviderEvents(t *testing.T, ctx context.Context, db *sql.DB, runID string, entityID string, eventName string, providerEventID string) int {
+	t.Helper()
+	var count int
+	if err := db.QueryRowContext(ctx, `
+		SELECT COUNT(*)
+		FROM events
+		WHERE run_id = $1::uuid
+		  AND entity_id = $2::uuid
+		  AND event_name = $3
+		  AND payload->>'provider_event_id' = $4
+	`, runID, entityID, eventName, providerEventID).Scan(&count); err != nil {
+		t.Fatalf("count inbound provider events: %v", err)
+	}
+	return count
+}
+
+func countPostgresInboundMarkers(t *testing.T, ctx context.Context, db *sql.DB, providerEventID string, entityID string, provider string) int {
+	t.Helper()
+	var count int
+	if err := db.QueryRowContext(ctx, `
+		SELECT COUNT(*)
+		FROM events
+		WHERE event_name = 'platform.inbound_recorded'
+		  AND entity_id = $1::uuid
+		  AND payload->>'provider_event_id' = $2
+		  AND payload->>'provider' = $3
+	`, entityID, providerEventID, provider).Scan(&count); err != nil {
+		t.Fatalf("count inbound marker events: %v", err)
+	}
+	return count
+}
+
+func countPostgresAgentDeliveriesForEvent(t *testing.T, ctx context.Context, db *sql.DB, eventID string, agentID string) int {
+	t.Helper()
+	var count int
+	if err := db.QueryRowContext(ctx, `
+		SELECT COUNT(*)
+		FROM event_deliveries
+		WHERE event_id = $1::uuid
+		  AND subscriber_type = 'agent'
+		  AND subscriber_id = $2
+	`, eventID, agentID).Scan(&count); err != nil {
+		t.Fatalf("count agent deliveries for %s: %v", eventID, err)
+	}
+	return count
+}
+
+func loadPostgresAgentDeliveryStatus(t *testing.T, ctx context.Context, db *sql.DB, eventID string, agentID string) string {
+	t.Helper()
+	var status string
+	if err := db.QueryRowContext(ctx, `
+		SELECT status
+		FROM event_deliveries
+		WHERE event_id = $1::uuid
+		  AND subscriber_type = 'agent'
+		  AND subscriber_id = $2
+	`, eventID, agentID).Scan(&status); err != nil {
+		t.Fatalf("load agent delivery status for %s: %v", eventID, err)
+	}
+	return status
+}
+
+func countPostgresPipelineReceiptsForEvent(t *testing.T, ctx context.Context, db *sql.DB, eventID string) int {
+	t.Helper()
+	var count int
+	if err := db.QueryRowContext(ctx, `
+		SELECT COUNT(*)
+		FROM event_receipts
+		WHERE event_id = $1::uuid
+		  AND subscriber_type = 'platform'
+		  AND subscriber_id = 'pipeline'
+	`, eventID).Scan(&count); err != nil {
+		t.Fatalf("count pipeline receipts for %s: %v", eventID, err)
+	}
+	return count
+}
+
+func countPostgresAgentReceiptsForEvent(t *testing.T, ctx context.Context, db *sql.DB, eventID string, agentID string) int {
+	t.Helper()
+	var count int
+	if err := db.QueryRowContext(ctx, `
+		SELECT COUNT(*)
+		FROM event_receipts
+		WHERE event_id = $1::uuid
+		  AND subscriber_type = 'agent'
+		  AND subscriber_id = $2
+	`, eventID, agentID).Scan(&count); err != nil {
+		t.Fatalf("count agent receipts for %s: %v", eventID, err)
+	}
+	return count
+}
+
+func requireInboundBusEvent(t testing.TB, ch <-chan events.Event, context string) events.Event {
+	t.Helper()
+	select {
+	case evt := <-ch:
+		return evt
+	default:
+		t.Fatalf("%s: expected queued bus event", context)
+		return events.EmptyEvent()
+	}
+}
+
+func requireNoInboundBusEvent(t testing.TB, ch <-chan events.Event, context string) {
+	t.Helper()
+	select {
+	case evt := <-ch:
+		t.Fatalf("%s: unexpected bus event: %#v", context, evt)
+	default:
+	}
+}
+
+func githubWebhookSignature(secret string, body []byte) string {
+	mac := hmac.New(sha256.New, []byte(secret))
+	_, _ = mac.Write(body)
+	return "sha256=" + hex.EncodeToString(mac.Sum(nil))
+}

--- a/internal/runtime/inbound_test.go
+++ b/internal/runtime/inbound_test.go
@@ -2,6 +2,10 @@ package runtime
 
 import (
 	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"net/http"
 	"net/http/httptest"
@@ -28,6 +32,23 @@ func (failingInboundEventStore) ListEventDeliveryRecipients(context.Context, str
 	return []string{}, nil
 }
 
+type capturingInboundEventStore struct {
+	events []events.Event
+}
+
+func (s *capturingInboundEventStore) AppendEvent(_ context.Context, evt events.Event) error {
+	s.events = append(s.events, evt)
+	return nil
+}
+
+func (*capturingInboundEventStore) InsertEventDeliveries(context.Context, string, []string) error {
+	return nil
+}
+
+func (*capturingInboundEventStore) ListEventDeliveryRecipients(context.Context, string) ([]string, error) {
+	return []string{}, nil
+}
+
 type rollbackTrackingInboundStore struct {
 	recorded bool
 	rolled   bool
@@ -51,6 +72,31 @@ func (s *rollbackTrackingInboundStore) DeleteInboundEvent(context.Context, strin
 	return nil
 }
 
+type recordingInboundStore struct {
+	target          InboundTarget
+	inserted        bool
+	recorded        bool
+	providerEventID string
+	entityID        string
+	provider        string
+}
+
+func (s *recordingInboundStore) RecordInboundEvent(_ context.Context, providerEventID, entityID, provider string) (bool, error) {
+	s.recorded = true
+	s.providerEventID = providerEventID
+	s.entityID = entityID
+	s.provider = provider
+	return s.inserted, nil
+}
+
+func (s *recordingInboundStore) ResolveInboundTarget(context.Context, string, string) (InboundTarget, error) {
+	return s.target, nil
+}
+
+func (*recordingInboundStore) PurgeInboundEventsBefore(context.Context, time.Time, int) (int, error) {
+	return 0, nil
+}
+
 func TestInboundGateway_Returns503AndRollsBackMarkerWhenPublishFails(t *testing.T) {
 	bus, err := runtimebus.NewEventBus(failingInboundEventStore{})
 	if err != nil {
@@ -59,7 +105,7 @@ func TestInboundGateway_Returns503AndRollsBackMarkerWhenPublishFails(t *testing.
 	store := &rollbackTrackingInboundStore{}
 	g := NewInboundGateway(bus, nil, nil, store)
 
-	req := httptest.NewRequest(http.MethodPost, "/webhooks/entity-1/github", strings.NewReader(`{"id":"evt-1","type":"push"}`))
+	req := httptest.NewRequest(http.MethodPost, "/webhooks/entity-1/custom", strings.NewReader(`{"id":"evt-1","type":"push"}`))
 	rec := httptest.NewRecorder()
 	g.Handler().ServeHTTP(rec, req)
 
@@ -82,7 +128,7 @@ func TestInboundGateway_Returns503WhenRuntimeShutdownAdmissionClosed(t *testing.
 	store := &rollbackTrackingInboundStore{}
 	g := NewInboundGateway(bus, nil, func() bool { return true }, store)
 
-	req := httptest.NewRequest(http.MethodPost, "/webhooks/entity-1/github", strings.NewReader(`{"id":"evt-1","type":"push"}`))
+	req := httptest.NewRequest(http.MethodPost, "/webhooks/entity-1/custom", strings.NewReader(`{"id":"evt-1","type":"push"}`))
 	rec := httptest.NewRecorder()
 	g.Handler().ServeHTTP(rec, req)
 
@@ -115,7 +161,7 @@ func TestInboundGateway_PausedRuntimeUsesIngressOwnerAndAcceptsQueueableWebhook(
 	g := NewInboundGateway(bus, nil, nil, store)
 	g.SetRuntimeIngress(controller)
 
-	req := httptest.NewRequest(http.MethodPost, "/webhooks/entity-1/github", strings.NewReader(`{"id":"evt-1","type":"push"}`))
+	req := httptest.NewRequest(http.MethodPost, "/webhooks/entity-1/custom", strings.NewReader(`{"id":"evt-1","type":"push"}`))
 	rec := httptest.NewRecorder()
 	g.Handler().ServeHTTP(rec, req)
 
@@ -128,4 +174,176 @@ func TestInboundGateway_PausedRuntimeUsesIngressOwnerAndAcceptsQueueableWebhook(
 	if store.rolled {
 		t.Fatal("did not expect inbound marker rollback for queued paused ingress")
 	}
+}
+
+func TestInboundGateway_GitHubPausedRuntimeUsesIngressOwnerAndAcceptsQueueableWebhook(t *testing.T) {
+	bus, err := runtimebus.NewEventBus(nil)
+	if err != nil {
+		t.Fatalf("NewEventBus: %v", err)
+	}
+	controller := runtimeingress.NewController(nil, bus, runtimeingress.Options{})
+	bus.SetRuntimeIngressDispatchGate(controller)
+	if _, err := controller.Pause(context.Background(), runtimeingress.TransitionRequest{
+		Reason:       "test_pause",
+		ControlledBy: "test",
+	}); err != nil {
+		t.Fatalf("Pause: %v", err)
+	}
+	t.Cleanup(runtimebus.ResumeRuntimeIngress)
+	store := &recordingInboundStore{
+		target: InboundTarget{
+			EntityID:      "3fd8fc37-6d02-4d50-8bb7-14c6cb0fed0a",
+			EntitySlug:    "customer-a",
+			WebhookSecret: "github-secret",
+		},
+		inserted: true,
+	}
+	g := NewInboundGateway(bus, nil, nil, store)
+	g.SetRuntimeIngress(controller)
+
+	body := []byte(`{"zen":"Keep it logically awesome."}`)
+	req := httptest.NewRequest(http.MethodPost, "/webhooks/customer-a/github", strings.NewReader(string(body)))
+	req.Header.Set("X-Hub-Signature-256", githubWebhookSignature("github-secret", body))
+	req.Header.Set("X-GitHub-Delivery", "delivery-123")
+	req.Header.Set("X-GitHub-Event", "push")
+	rec := httptest.NewRecorder()
+	g.Handler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("status = %d, want 202 body=%s", rec.Code, rec.Body.String())
+	}
+	if !store.recorded {
+		t.Fatal("expected GitHub delivery to record inbound marker while paused")
+	}
+	if store.providerEventID != "delivery-123" {
+		t.Fatalf("providerEventID = %q, want delivery-123", store.providerEventID)
+	}
+}
+
+func TestInboundGateway_GitHubAdapterOwnsSignatureDeliveryIDAndEventMapping(t *testing.T) {
+	eventStore := &capturingInboundEventStore{}
+	bus, err := runtimebus.NewEventBus(eventStore)
+	if err != nil {
+		t.Fatalf("NewEventBus: %v", err)
+	}
+	store := &recordingInboundStore{
+		target: InboundTarget{
+			EntityID:      "3fd8fc37-6d02-4d50-8bb7-14c6cb0fed0a",
+			EntitySlug:    "customer-a",
+			WebhookSecret: "github-secret",
+		},
+		inserted: true,
+	}
+	g := NewInboundGateway(bus, nil, nil, store)
+
+	body := []byte(`{"zen":"Keep it logically awesome."}`)
+	req := httptest.NewRequest(http.MethodPost, "/webhooks/customer-a/github", strings.NewReader(string(body)))
+	req.Header.Set("X-Hub-Signature-256", githubWebhookSignature("github-secret", body))
+	req.Header.Set("X-GitHub-Delivery", "delivery-123")
+	req.Header.Set("X-GitHub-Event", "push")
+	rec := httptest.NewRecorder()
+	g.Handler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("status = %d, want 202 body=%s", rec.Code, rec.Body.String())
+	}
+	if !store.recorded {
+		t.Fatal("expected GitHub delivery to record inbound marker")
+	}
+	if store.providerEventID != "delivery-123" {
+		t.Fatalf("providerEventID = %q, want delivery-123", store.providerEventID)
+	}
+	if len(eventStore.events) != 1 {
+		t.Fatalf("published events = %d, want 1", len(eventStore.events))
+	}
+	evt := eventStore.events[0]
+	if evt.Type() != events.EventType("inbound.github.push") {
+		t.Fatalf("event type = %q, want inbound.github.push", evt.Type())
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(evt.Payload(), &payload); err != nil {
+		t.Fatalf("unmarshal payload: %v", err)
+	}
+	if payload["provider_event_id"] != "delivery-123" || payload["event_type"] != "push" || payload["provider"] != "github" {
+		t.Fatalf("payload = %+v, want GitHub delivery identity", payload)
+	}
+	if strings.Contains(rec.Body.String(), "github-secret") || strings.Contains(string(evt.Payload()), "github-secret") {
+		t.Fatal("GitHub signing secret leaked into readback or event payload")
+	}
+}
+
+func TestInboundGateway_GitHubAdapterRejectsInvalidSignatureBeforeMarkerAndPublish(t *testing.T) {
+	eventStore := &capturingInboundEventStore{}
+	bus, err := runtimebus.NewEventBus(eventStore)
+	if err != nil {
+		t.Fatalf("NewEventBus: %v", err)
+	}
+	store := &recordingInboundStore{
+		target: InboundTarget{
+			EntityID:      "3fd8fc37-6d02-4d50-8bb7-14c6cb0fed0a",
+			EntitySlug:    "customer-a",
+			WebhookSecret: "github-secret",
+		},
+		inserted: true,
+	}
+	g := NewInboundGateway(bus, nil, nil, store)
+
+	body := []byte(`{"zen":"Keep it logically awesome."}`)
+	req := httptest.NewRequest(http.MethodPost, "/webhooks/customer-a/github", strings.NewReader(string(body)))
+	req.Header.Set("X-Hub-Signature-256", githubWebhookSignature("wrong-secret", body))
+	req.Header.Set("X-GitHub-Delivery", "delivery-123")
+	req.Header.Set("X-GitHub-Event", "push")
+	rec := httptest.NewRecorder()
+	g.Handler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401 body=%s", rec.Code, rec.Body.String())
+	}
+	if store.recorded {
+		t.Fatal("invalid GitHub signature recorded inbound marker")
+	}
+	if len(eventStore.events) != 0 {
+		t.Fatalf("published events = %d, want 0", len(eventStore.events))
+	}
+}
+
+func TestInboundGateway_GitHubAdapterDuplicateDeliveryDoesNotPublishAgain(t *testing.T) {
+	eventStore := &capturingInboundEventStore{}
+	bus, err := runtimebus.NewEventBus(eventStore)
+	if err != nil {
+		t.Fatalf("NewEventBus: %v", err)
+	}
+	store := &recordingInboundStore{
+		target: InboundTarget{
+			EntityID:      "3fd8fc37-6d02-4d50-8bb7-14c6cb0fed0a",
+			EntitySlug:    "customer-a",
+			WebhookSecret: "github-secret",
+		},
+		inserted: false,
+	}
+	g := NewInboundGateway(bus, nil, nil, store)
+
+	body := []byte(`{"zen":"Keep it logically awesome."}`)
+	req := httptest.NewRequest(http.MethodPost, "/webhooks/customer-a/github", strings.NewReader(string(body)))
+	req.Header.Set("X-Hub-Signature-256", githubWebhookSignature("github-secret", body))
+	req.Header.Set("X-GitHub-Delivery", "delivery-123")
+	req.Header.Set("X-GitHub-Event", "push")
+	rec := httptest.NewRecorder()
+	g.Handler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 body=%s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), `"status":"duplicate"`) {
+		t.Fatalf("duplicate response = %s", rec.Body.String())
+	}
+	if len(eventStore.events) != 0 {
+		t.Fatalf("published events = %d, want 0", len(eventStore.events))
+	}
+}
+
+func githubWebhookSignature(secret string, body []byte) string {
+	mac := hmac.New(sha256.New, []byte(secret))
+	_, _ = mac.Write(body)
+	return "sha256=" + hex.EncodeToString(mac.Sum(nil))
 }

--- a/internal/runtime/runtime_shutdown_admission_test.go
+++ b/internal/runtime/runtime_shutdown_admission_test.go
@@ -158,7 +158,7 @@ func TestRuntimeShutdown_ClosesAdmissionBeforeManagerDrainAndInboundIngress(t *t
 		t.Fatal("ReplayAgentBacklog touched manager persistence even though runtime shutdown admission was closed")
 	}
 
-	req := httptest.NewRequest(http.MethodPost, "/webhooks/entity-1/github", strings.NewReader(`{"id":"evt-1","type":"push"}`))
+	req := httptest.NewRequest(http.MethodPost, "/webhooks/entity-1/custom", strings.NewReader(`{"id":"evt-1","type":"push"}`))
 	rec := httptest.NewRecorder()
 	rt.InboundGateway.Handler().ServeHTTP(rec, req)
 	if rec.Code != http.StatusServiceUnavailable {

--- a/internal/store/inbound.go
+++ b/internal/store/inbound.go
@@ -43,7 +43,7 @@ func (s *PostgresStore) ResolveInboundTarget(ctx context.Context, entityKey, pro
 		return runtime.InboundTarget{}, err
 	}
 	entityKey = strings.TrimSpace(entityKey)
-	provider = strings.TrimSpace(strings.ToLower(provider))
+	provider = normalizeInboundProviderKey(provider)
 	if entityKey == "" {
 		return runtime.InboundTarget{}, fmt.Errorf("entity key is required")
 	}
@@ -68,20 +68,20 @@ func (s *PostgresStore) ResolveInboundTarget(ctx context.Context, entityKey, pro
 }
 
 func (s *PostgresStore) resolveInboundTargetForRun(ctx context.Context, entityKey, provider, runID string) (runtime.InboundTarget, error) {
-	_ = provider
-
 	var target runtime.InboundTarget
 	const q = `
 		SELECT
-			entity_id::text,
-			COALESCE(NULLIF(slug, ''), '')
-		FROM entity_state
-		WHERE run_id = $2::uuid
-		  AND (slug = $1 OR entity_id::text = $1)
-		ORDER BY CASE WHEN slug = $1 THEN 0 ELSE 1 END, created_at DESC, updated_at DESC
+			es.entity_id::text,
+			COALESCE(NULLIF(es.slug, ''), ''),
+			COALESCE((fi.config->'secrets'->'webhook_signing')->>$3, '')
+		FROM entity_state es
+		LEFT JOIN flow_instances fi ON fi.instance_id = es.flow_instance
+		WHERE es.run_id = $2::uuid
+		  AND (es.slug = $1 OR es.entity_id::text = $1)
+		ORDER BY CASE WHEN es.slug = $1 THEN 0 ELSE 1 END, es.created_at DESC, es.updated_at DESC
 		LIMIT 1
 	`
-	if err := s.DB.QueryRowContext(ctx, q, entityKey, runID).Scan(&target.EntityID, &target.EntitySlug); err != nil {
+	if err := s.DB.QueryRowContext(ctx, q, entityKey, runID, provider).Scan(&target.EntityID, &target.EntitySlug, &target.WebhookSecret); err != nil {
 		if err == sql.ErrNoRows {
 			return runtime.InboundTarget{}, fmt.Errorf("entity not found for key: %s", entityKey)
 		}
@@ -94,18 +94,18 @@ func (s *PostgresStore) resolveInboundTargetForRun(ctx context.Context, entityKe
 }
 
 func (s *PostgresStore) resolveInboundTargetUnambiguous(ctx context.Context, entityKey, provider string) (runtime.InboundTarget, error) {
-	_ = provider
-
 	rows, err := s.DB.QueryContext(ctx, `
 		SELECT
-			entity_id::text,
-			COALESCE(NULLIF(slug, ''), ''),
-			run_id::text
-		FROM entity_state
-		WHERE slug = $1 OR entity_id::text = $1
-		ORDER BY CASE WHEN slug = $1 THEN 0 ELSE 1 END, created_at DESC, updated_at DESC
+			es.entity_id::text,
+			COALESCE(NULLIF(es.slug, ''), ''),
+			COALESCE((fi.config->'secrets'->'webhook_signing')->>$2, ''),
+			es.run_id::text
+		FROM entity_state es
+		LEFT JOIN flow_instances fi ON fi.instance_id = es.flow_instance
+		WHERE es.slug = $1 OR es.entity_id::text = $1
+		ORDER BY CASE WHEN es.slug = $1 THEN 0 ELSE 1 END, es.created_at DESC, es.updated_at DESC
 		LIMIT 2
-	`, entityKey)
+	`, entityKey, provider)
 	if err != nil {
 		return runtime.InboundTarget{}, fmt.Errorf("resolve inbound target: %w", err)
 	}
@@ -115,7 +115,7 @@ func (s *PostgresStore) resolveInboundTargetUnambiguous(ctx context.Context, ent
 	for rows.Next() {
 		var target runtime.InboundTarget
 		var runID string
-		if err := rows.Scan(&target.EntityID, &target.EntitySlug, &runID); err != nil {
+		if err := rows.Scan(&target.EntityID, &target.EntitySlug, &target.WebhookSecret, &runID); err != nil {
 			return runtime.InboundTarget{}, fmt.Errorf("scan inbound target: %w", err)
 		}
 		if target.EntitySlug == "" {
@@ -181,6 +181,14 @@ func (s *PostgresStore) DeleteInboundEvent(ctx context.Context, providerEventID,
 		return fmt.Errorf("delete inbound event marker: %w", err)
 	}
 	return nil
+}
+
+func normalizeInboundProviderKey(raw string) string {
+	key := strings.TrimSpace(strings.ToLower(raw))
+	key = strings.ReplaceAll(key, ".", "_")
+	key = strings.ReplaceAll(key, "-", "_")
+	key = strings.ReplaceAll(key, " ", "_")
+	return key
 }
 
 func (s *PostgresStore) recordInboundEventSpec(ctx context.Context, providerEventID, entityID, provider string) (bool, error) {

--- a/internal/store/inbound_sqlite_test.go
+++ b/internal/store/inbound_sqlite_test.go
@@ -1,0 +1,119 @@
+package store
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	runtimecorrelation "github.com/division-sh/swarm/internal/runtime/correlation"
+	"github.com/google/uuid"
+)
+
+func TestSQLiteRuntimeStore_RecordInboundEvent_DedupesWithCanonicalMarker(t *testing.T) {
+	sqliteStore := newBootstrappedSQLiteRuntimeStoreForTest(t)
+	ctx := context.Background()
+	runID := uuid.NewString()
+	entityID := uuid.NewString()
+	seedSQLiteInboundRunAndEntity(t, ctx, sqliteStore, runID, entityID, "customer-a", "github", "github-secret")
+
+	inserted, err := sqliteStore.RecordInboundEvent(ctx, "delivery-123", entityID, "github")
+	if err != nil {
+		t.Fatalf("RecordInboundEvent: %v", err)
+	}
+	if !inserted {
+		t.Fatal("RecordInboundEvent inserted=false, want first insert")
+	}
+	duplicate, err := sqliteStore.RecordInboundEvent(ctx, "delivery-123", entityID, "github")
+	if err != nil {
+		t.Fatalf("RecordInboundEvent duplicate: %v", err)
+	}
+	if duplicate {
+		t.Fatal("RecordInboundEvent duplicate inserted=true, want false")
+	}
+
+	var count int
+	if err := sqliteStore.DB.QueryRowContext(ctx, `
+		SELECT COUNT(*)
+		FROM events
+		WHERE event_name = 'platform.inbound_recorded'
+		  AND idempotency_key = ?
+	`, inboundEventIdempotencyKey("delivery-123", entityID, "github")).Scan(&count); err != nil {
+		t.Fatalf("count inbound marker: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("inbound marker count = %d, want 1", count)
+	}
+}
+
+func TestSQLiteRuntimeStore_ResolveInboundTargetNormalizesWebhookSigningProviderKey(t *testing.T) {
+	sqliteStore := newBootstrappedSQLiteRuntimeStoreForTest(t)
+	ctx := context.Background()
+	runID := uuid.NewString()
+	entityID := uuid.NewString()
+	seedSQLiteInboundRunAndEntity(t, ctx, sqliteStore, runID, entityID, "customer-a", "my-provider", "provider-secret")
+
+	target, err := sqliteStore.ResolveInboundTarget(runtimecorrelation.WithRunID(ctx, runID), "customer-a", "my-provider")
+	if err != nil {
+		t.Fatalf("ResolveInboundTarget: %v", err)
+	}
+	if target.EntityID != entityID || target.EntitySlug != "customer-a" {
+		t.Fatalf("target = %+v, want entity=%s slug=customer-a", target, entityID)
+	}
+	if target.WebhookSecret != "provider-secret" {
+		t.Fatalf("WebhookSecret = %q, want provider-secret", target.WebhookSecret)
+	}
+}
+
+func TestSQLiteRuntimeStore_DeleteInboundEventRemovesRollbackMarker(t *testing.T) {
+	sqliteStore := newBootstrappedSQLiteRuntimeStoreForTest(t)
+	ctx := context.Background()
+	runID := uuid.NewString()
+	entityID := uuid.NewString()
+	seedSQLiteInboundRunAndEntity(t, ctx, sqliteStore, runID, entityID, "customer-a", "github", "github-secret")
+
+	if inserted, err := sqliteStore.RecordInboundEvent(ctx, "delivery-123", entityID, "github"); err != nil || !inserted {
+		t.Fatalf("RecordInboundEvent inserted=%v err=%v, want first insert", inserted, err)
+	}
+	if err := sqliteStore.DeleteInboundEvent(ctx, "delivery-123", entityID, "github"); err != nil {
+		t.Fatalf("DeleteInboundEvent: %v", err)
+	}
+	if inserted, err := sqliteStore.RecordInboundEvent(ctx, "delivery-123", entityID, "github"); err != nil || !inserted {
+		t.Fatalf("RecordInboundEvent after delete inserted=%v err=%v, want fresh insert", inserted, err)
+	}
+}
+
+func seedSQLiteInboundRunAndEntity(t *testing.T, ctx context.Context, sqliteStore *SQLiteRuntimeStore, runID, entityID, slug, provider, secret string) {
+	t.Helper()
+	now := time.Now().UTC()
+	if _, err := sqliteStore.DB.ExecContext(ctx, `
+		INSERT INTO runs (run_id, status, started_at)
+		VALUES (?, 'running', ?)
+	`, runID, now); err != nil {
+		t.Fatalf("insert run: %v", err)
+	}
+	configBytes, err := json.Marshal(map[string]any{
+		"secrets": map[string]any{
+			"webhook_signing": map[string]string{
+				normalizeInboundProviderKey(provider): secret,
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("marshal flow config: %v", err)
+	}
+	if _, err := sqliteStore.DB.ExecContext(ctx, `
+		INSERT INTO flow_instances (instance_id, flow_template, mode, config, status, created_at)
+		VALUES ('root', 'root', 'static', ?, 'active', ?)
+	`, string(configBytes), now); err != nil {
+		t.Fatalf("insert flow instance: %v", err)
+	}
+	if _, err := sqliteStore.DB.ExecContext(ctx, `
+		INSERT INTO entity_state (
+			run_id, entity_id, flow_instance, entity_type, slug, name, current_state, created_at, updated_at
+		)
+		VALUES (?, ?, 'root', 'default', ?, 'Customer A', 'active', ?, ?)
+	`, runID, entityID, slug, now, now); err != nil {
+		t.Fatalf("insert entity state: %v", err)
+	}
+}

--- a/internal/store/postgres_store_additional_test.go
+++ b/internal/store/postgres_store_additional_test.go
@@ -2666,6 +2666,42 @@ func TestPostgresStore_Inbound_ResolveWithoutRunContextAllowsUnambiguousTarget(t
 	}
 }
 
+func TestPostgresStore_Inbound_ResolveNormalizesWebhookSigningProviderKey(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	s := &PostgresStore{DB: db}
+	ctx := context.Background()
+	runID := uuid.NewString()
+	entityID := uuid.NewString()
+	if _, err := db.ExecContext(ctx, `INSERT INTO runs (run_id, status) VALUES ($1::uuid, 'running')`, runID); err != nil {
+		t.Fatalf("insert run: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO flow_instances (instance_id, flow_template, mode, config, status, created_at)
+		VALUES ('root', 'root', 'static', '{"secrets":{"webhook_signing":{"my_provider":"provider-secret"}}}'::jsonb, 'active', NOW())
+	`); err != nil {
+		t.Fatalf("insert flow instance: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO entity_state (
+			run_id, entity_id, flow_instance, entity_type, slug, name, current_state
+		)
+		VALUES ($1::uuid, $2::uuid, 'root', 'default', 'customer-a', 'Customer A', 'active')
+	`, runID, entityID); err != nil {
+		t.Fatalf("insert entity state: %v", err)
+	}
+
+	target, err := s.ResolveInboundTarget(runtimecorrelation.WithRunID(ctx, runID), "customer-a", "my-provider")
+	if err != nil {
+		t.Fatalf("ResolveInboundTarget: %v", err)
+	}
+	if target.EntityID != entityID || target.EntitySlug != "customer-a" {
+		t.Fatalf("target = %+v, want entity=%s slug=customer-a", target, entityID)
+	}
+	if target.WebhookSecret != "provider-secret" {
+		t.Fatalf("WebhookSecret = %q, want provider-secret", target.WebhookSecret)
+	}
+}
+
 func TestPostgresStore_Inbound_ResolveWithoutRunContextRejectsAmbiguousTarget(t *testing.T) {
 	_, db, _ := testutil.StartPostgres(t)
 	s := &PostgresStore{DB: db}

--- a/internal/store/sqlite_inbound.go
+++ b/internal/store/sqlite_inbound.go
@@ -1,0 +1,280 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/division-sh/swarm/internal/events"
+	"github.com/division-sh/swarm/internal/runtime"
+	runtimecorrelation "github.com/division-sh/swarm/internal/runtime/correlation"
+	runtimecurrentstate "github.com/division-sh/swarm/internal/runtime/currentstate"
+	"github.com/google/uuid"
+)
+
+var _ runtime.InboundPersistence = (*SQLiteRuntimeStore)(nil)
+
+func (s *SQLiteRuntimeStore) RecordInboundEvent(ctx context.Context, providerEventID, entityID, provider string) (bool, error) {
+	if strings.TrimSpace(providerEventID) == "" {
+		return false, fmt.Errorf("provider_event_id is required")
+	}
+	if strings.TrimSpace(entityID) == "" {
+		return false, fmt.Errorf("entity_id is required")
+	}
+	if strings.TrimSpace(provider) == "" {
+		return false, fmt.Errorf("provider is required")
+	}
+	caps, err := s.schemaCapabilities(ctx)
+	if err != nil {
+		return false, err
+	}
+	if caps.Events.Log != SchemaFlavorCanonical || !caps.Events.LogIdempotencyKey {
+		if caps.Events.Log != SchemaFlavorCanonical {
+			return false, unsupportedSchemaCapability("events", caps.Events.Log)
+		}
+		return false, fmt.Errorf("store: inbound event recording requires canonical events.idempotency_key support")
+	}
+	inserted := false
+	err = s.runRuntimeMutation(ctx, "sqlite record inbound event", func(txctx context.Context, tx *sql.Tx) error {
+		idempotencyKey := inboundEventIdempotencyKey(providerEventID, entityID, provider)
+		var exists bool
+		if err := tx.QueryRowContext(txctx, `
+			SELECT EXISTS(
+				SELECT 1
+				FROM events
+				WHERE idempotency_key = ?
+				  AND event_name = 'platform.inbound_recorded'
+				  AND entity_id IS ?
+			)
+		`, idempotencyKey, sqliteNullUUID(entityID)).Scan(&exists); err != nil {
+			return fmt.Errorf("check sqlite inbound event dedupe: %w", err)
+		}
+		if exists {
+			inserted = false
+			return nil
+		}
+
+		payload, err := json.Marshal(map[string]any{
+			"provider":          provider,
+			"provider_event_id": providerEventID,
+			"entity_id":         entityID,
+		})
+		if err != nil {
+			return fmt.Errorf("marshal inbound event payload: %w", err)
+		}
+		if err := s.validateEventPayload("platform.inbound_recorded", payload); err != nil {
+			return err
+		}
+		runID := strings.TrimSpace(runtimecorrelation.RunIDFromContext(txctx))
+		evt, err := events.AdmitForPersistence(
+			events.NewDiagnosticDirectEvent(
+				uuid.NewString(),
+				events.EventType("platform.inbound_recorded"),
+				provider,
+				"",
+				payload,
+				0,
+				runID,
+				"",
+				events.EventEnvelope{EntityID: entityID},
+				time.Time{},
+			),
+			events.AdmissionOptions{},
+		)
+		if err != nil {
+			return err
+		}
+		if caps.Events.LogRunID {
+			if err := sqliteEnsureRunRow(txctx, tx, evt.RunID(), "", "", evt.CreatedAt()); err != nil {
+				return err
+			}
+		}
+		_, err = tx.ExecContext(txctx, `
+			INSERT INTO events (
+				event_id, run_id, event_name, entity_id, flow_instance, source_route, target_route, target_set,
+				scope, payload, chain_depth, produced_by, produced_by_type, idempotency_key, created_at
+			)
+			VALUES (?, ?, 'platform.inbound_recorded', ?, NULL, '{}', '{}', '[]', 'entity', ?, 0, ?, 'external', ?, ?)
+		`, evt.ID(), sqliteNullUUID(evt.RunID()), sqliteNullUUID(entityID), string(evt.Payload()), provider, idempotencyKey, evt.CreatedAt().UTC())
+		if err != nil {
+			return fmt.Errorf("record sqlite inbound event in events: %w", err)
+		}
+		inserted = true
+		return nil
+	})
+	return inserted, err
+}
+
+func (s *SQLiteRuntimeStore) ResolveInboundTarget(ctx context.Context, entityKey, provider string) (runtime.InboundTarget, error) {
+	caps, err := s.schemaCapabilities(ctx)
+	if err != nil {
+		return runtime.InboundTarget{}, err
+	}
+	entityKey = strings.TrimSpace(entityKey)
+	provider = normalizeInboundProviderKey(provider)
+	if entityKey == "" {
+		return runtime.InboundTarget{}, fmt.Errorf("entity key is required")
+	}
+	if provider == "" {
+		return runtime.InboundTarget{}, fmt.Errorf("provider is required")
+	}
+	runID, ok, err := runtimecurrentstate.RunIDFromContext(ctx)
+	if err != nil {
+		return runtime.InboundTarget{}, fmt.Errorf("resolve inbound target: %w", err)
+	}
+	if ok {
+		return s.resolveSQLiteInboundTargetForRun(ctx, entityKey, provider, runID)
+	}
+	if caps.EntityState != SchemaFlavorCanonical || !caps.EntityRunID {
+		if caps.EntityState != SchemaFlavorCanonical {
+			return runtime.InboundTarget{}, unsupportedSchemaCapability("entity_state", caps.EntityState)
+		}
+		return runtime.InboundTarget{}, fmt.Errorf("resolve inbound target: entity_state.run_id schema capability is required")
+	}
+	return s.resolveSQLiteInboundTargetUnambiguous(ctx, entityKey, provider)
+}
+
+func (s *SQLiteRuntimeStore) resolveSQLiteInboundTargetForRun(ctx context.Context, entityKey, provider, runID string) (runtime.InboundTarget, error) {
+	var target runtime.InboundTarget
+	err := s.DB.QueryRowContext(ctx, `
+		SELECT
+			es.entity_id,
+			COALESCE(NULLIF(es.slug, ''), ''),
+			COALESCE(json_extract(fi.config, ?), '')
+		FROM entity_state es
+		LEFT JOIN flow_instances fi ON fi.instance_id = es.flow_instance
+		WHERE es.run_id = ?
+		  AND (es.slug = ? OR es.entity_id = ?)
+		ORDER BY CASE WHEN es.slug = ? THEN 0 ELSE 1 END, es.created_at DESC, es.updated_at DESC
+		LIMIT 1
+	`, inboundWebhookSecretPath(provider), runID, entityKey, entityKey, entityKey).Scan(&target.EntityID, &target.EntitySlug, &target.WebhookSecret)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return runtime.InboundTarget{}, fmt.Errorf("entity not found for key: %s", entityKey)
+		}
+		return runtime.InboundTarget{}, fmt.Errorf("resolve inbound target: %w", err)
+	}
+	if target.EntitySlug == "" {
+		target.EntitySlug = entityKey
+	}
+	return target, nil
+}
+
+func (s *SQLiteRuntimeStore) resolveSQLiteInboundTargetUnambiguous(ctx context.Context, entityKey, provider string) (runtime.InboundTarget, error) {
+	rows, err := s.DB.QueryContext(ctx, `
+		SELECT
+			es.entity_id,
+			COALESCE(NULLIF(es.slug, ''), ''),
+			COALESCE(json_extract(fi.config, ?), ''),
+			COALESCE(es.run_id, '')
+		FROM entity_state es
+		LEFT JOIN flow_instances fi ON fi.instance_id = es.flow_instance
+		WHERE es.slug = ? OR es.entity_id = ?
+		ORDER BY CASE WHEN es.slug = ? THEN 0 ELSE 1 END, es.created_at DESC, es.updated_at DESC
+		LIMIT 2
+	`, inboundWebhookSecretPath(provider), entityKey, entityKey, entityKey)
+	if err != nil {
+		return runtime.InboundTarget{}, fmt.Errorf("resolve inbound target: %w", err)
+	}
+	defer rows.Close()
+
+	var matches []runtime.InboundTarget
+	for rows.Next() {
+		var target runtime.InboundTarget
+		var runID string
+		if err := rows.Scan(&target.EntityID, &target.EntitySlug, &target.WebhookSecret, &runID); err != nil {
+			return runtime.InboundTarget{}, fmt.Errorf("scan inbound target: %w", err)
+		}
+		if target.EntitySlug == "" {
+			target.EntitySlug = entityKey
+		}
+		matches = append(matches, target)
+	}
+	if err := rows.Err(); err != nil {
+		return runtime.InboundTarget{}, fmt.Errorf("iterate inbound targets: %w", err)
+	}
+	switch len(matches) {
+	case 0:
+		return runtime.InboundTarget{}, fmt.Errorf("entity not found for key: %s", entityKey)
+	case 1:
+		return matches[0], nil
+	default:
+		return runtime.InboundTarget{}, fmt.Errorf("entity key %s is ambiguous across runs; run_id is required", entityKey)
+	}
+}
+
+func (s *SQLiteRuntimeStore) PurgeInboundEventsBefore(ctx context.Context, before time.Time, limit int) (int, error) {
+	caps, err := s.schemaCapabilities(ctx)
+	if err != nil {
+		return 0, err
+	}
+	if limit <= 0 {
+		limit = 1000
+	}
+	if caps.Events.Log != SchemaFlavorCanonical {
+		return 0, unsupportedSchemaCapability("events", caps.Events.Log)
+	}
+	deleted := 0
+	err = s.runRuntimeMutation(ctx, "sqlite purge inbound events", func(txctx context.Context, tx *sql.Tx) error {
+		res, err := tx.ExecContext(txctx, `
+			DELETE FROM events
+			WHERE event_id IN (
+				SELECT event_id
+				FROM events
+				WHERE event_name = 'platform.inbound_recorded'
+				  AND produced_by_type = 'external'
+				  AND created_at < ?
+				ORDER BY created_at ASC
+				LIMIT ?
+			)
+		`, before.UTC(), limit)
+		if err != nil {
+			return fmt.Errorf("purge sqlite inbound events from events: %w", err)
+		}
+		n, _ := res.RowsAffected()
+		deleted = int(n)
+		return nil
+	})
+	return deleted, err
+}
+
+func (s *SQLiteRuntimeStore) DeleteInboundEvent(ctx context.Context, providerEventID, entityID, provider string) error {
+	if strings.TrimSpace(providerEventID) == "" {
+		return fmt.Errorf("provider_event_id is required")
+	}
+	if strings.TrimSpace(entityID) == "" {
+		return fmt.Errorf("entity_id is required")
+	}
+	if strings.TrimSpace(provider) == "" {
+		return fmt.Errorf("provider is required")
+	}
+	caps, err := s.schemaCapabilities(ctx)
+	if err != nil {
+		return err
+	}
+	if caps.Events.Log != SchemaFlavorCanonical || !caps.Events.LogIdempotencyKey {
+		if caps.Events.Log != SchemaFlavorCanonical {
+			return unsupportedSchemaCapability("events", caps.Events.Log)
+		}
+		return fmt.Errorf("store: inbound event deletion requires canonical events.idempotency_key support")
+	}
+	return s.runRuntimeMutation(ctx, "sqlite delete inbound event", func(txctx context.Context, tx *sql.Tx) error {
+		idempotencyKey := inboundEventIdempotencyKey(providerEventID, entityID, provider)
+		if _, err := tx.ExecContext(txctx, `
+			DELETE FROM events
+			WHERE idempotency_key = ?
+			  AND event_name = 'platform.inbound_recorded'
+			  AND entity_id IS ?
+		`, idempotencyKey, sqliteNullUUID(entityID)); err != nil {
+			return fmt.Errorf("delete sqlite inbound event marker: %w", err)
+		}
+		return nil
+	})
+}
+
+func inboundWebhookSecretPath(provider string) string {
+	return "$.secrets.webhook_signing." + normalizeInboundProviderKey(provider)
+}

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -5414,6 +5414,51 @@ tool_model:
       Access tokens, refresh tokens, client secrets, authorization codes, PKCE verifier/state, and provider errors containing
       those values MUST NOT be returned through logs, events, dead letters, tool results, metadata, or CLI/API/status
       surfaces. Supported readback surfaces return only redacted metadata and failure evidence.
+  provider_trigger_adapters:
+    description: >
+      Source authority for first-class provider webhook triggers on top of the existing `inbound.webhook` gateway. It does
+      not replace the generic gateway; it makes provider-specific callback binding, signing, delivery identity, event
+      mapping, dedupe, and redacted readback semantics explicit for configured providers.
+    scope:
+    - manual/declarative webhook registration for configured provider triggers
+    - served `/webhooks/{entity}/{provider}` route mounted on the supported API listener
+    - selected runtime store wiring through `runtime.Stores.InboundStore`
+    - provider-specific signature policy and signing-secret lookup
+    - provider delivery-id extraction and dedupe-key authority
+    - provider event-type extraction and canonical Swarm event mapping
+    - redacted per-request delivery readback in webhook responses and persisted `platform.inbound_recorded` markers
+    non_goals:
+    - creating a second generic webhook gateway
+    - managed OAuth/token lifecycle, which belongs to `managed_credential_store`
+    - provider API subscription setup/teardown unless a later child explicitly selects it
+    - Slack URL-verification challenge handling or broad provider-catalog expansion in the first slice
+    - DB connectors, AWS SigV4/AssumeRole, non-HTTP, or native connector auth
+    existing_gateway_owner: >
+      `internal/runtime/inbound.go` remains the generic HTTP ingress executor for `/webhooks/{entity}/{provider}`. It
+      consumes `runtime_ingress.queueable_ingress.inbound.webhook`, persists the inbound dedupe marker before publish, and
+      publishes the normalized root ingress event returned by the provider adapter.
+    secret_binding: >
+      The first-slice signing-secret binding is `flow_instances.config.secrets.webhook_signing.<provider>`, where
+      `<provider>` is the normalized provider token. Secret values are never returned by webhook responses or readback
+      surfaces. Production deployments may replace the backing config storage with an external vault reference while
+      preserving the same semantic binding.
+    first_provider:
+      provider: github
+      signature: >
+        GitHub webhook deliveries require a configured signing secret and a valid `X-Hub-Signature-256` HMAC-SHA256
+        signature over the raw request body. Missing signing secret, missing signature, or invalid signature fails before
+        dedupe marker persistence and before event publish.
+      delivery_id: >
+        `X-GitHub-Delivery` is the authoritative provider delivery id and the dedupe key input for configured GitHub
+        triggers. Missing delivery id fails before dedupe marker persistence.
+      event_type: >
+        `X-GitHub-Event` is the authoritative provider event type. The canonical emitted event name is
+        `inbound.github.<normalized_event_type>` and the payload includes provider, provider_event_id, event_type,
+        original payload, redacted headers, and received_at.
+    raw_webhook_mode: >
+      Unknown providers may continue through the raw generic webhook mode, but that path is a different semantic concept and
+      does not prove provider-trigger adapter closure. Configured providers MUST consume their adapter owner rather than
+      generic signature, delivery-id, event-type, or `inbound.{provider}` mapping fallbacks.
   custom_tool_schema:
     description: Accepted fields for tool definitions in tools.yaml. This is the union of fields across all implementation
       classes.


### PR DESCRIPTION
## Summary

Part of #1651.

Adds the approved first-slice provider-trigger adapter authority on top of the existing `inbound.webhook` gateway:

- introduces provider adapter ownership in `internal/runtime/inbound.go` without creating a second generic gateway
- makes GitHub strict for `X-Hub-Signature-256`, `X-GitHub-Delivery`, and `X-GitHub-Event`
- keeps raw unknown-provider webhooks as a separate generic fallback concept
- wires served `/webhooks/` through the API listener and selected runtime `InboundStore`
- adds SQLite inbound persistence/readback parity instead of failing closed unsupported
- reads webhook signing secrets from `flow_instances.config.secrets.webhook_signing.<provider>` for Postgres and SQLite
- updates `platform-spec.yaml` with `tool_model.provider_trigger_adapters`

## Governing refs / context

- #1651 Pre-Implementation Coverage Audit: https://github.com/division-sh/swarm/issues/1651#issuecomment-4882679422
- #1651 independent gate approval: https://github.com/division-sh/swarm/issues/1651#issuecomment-4882703244
- `platform-spec.yaml#tool_model.provider_trigger_adapters`
- `platform-spec.yaml#runtime_ingress.queueable_ingress.inbound.webhook`
- Existing inbound gateway owner: `internal/runtime/inbound.go`

`docs/IMPLEMENTER_GUIDELINES.md` and `docs/SEMANTIC_DRIFT.md` are still absent in this checkout, matching the pre-audit record.

## Semantic migration

- New canonical owner: provider trigger adapters under `tool_model.provider_trigger_adapters`, implemented by the runtime inbound provider adapter registry and consumed by the existing `InboundGateway`.
- Old invalid path for configured GitHub providers: generic signature fallback, generic event-id extraction, payload-probed event-type inference, and `inbound.{provider}` event naming.
- Production paths checked for surviving old behavior: served `/webhooks/` routing, runtime `InboundGateway`, EventBus publish/dedupe path, selected store facade, Postgres `InboundStore`, SQLite `InboundStore`, paused-runtime ingress gating.
- Migration completeness: complete for the approved first slice and first provider proof; parent #1651 remains open for automatic provider API subscription setup/teardown, Slack challenge handling, and wider provider catalog tails.

## Validation

- `go test ./internal/runtime ./internal/store ./cmd/swarm -count=1 -v`
- `go test ./internal/apispec -run TestCLICommandCatalogRowsDeclareContractBearingGroups -count=1 -v`
- `go test ./internal/runtime ./internal/store ./cmd/swarm ./internal/apispec -count=1`
- `go test ./...` passed on the rebased patch before the final master refresh.
- After the final master refresh, `go test ./...` was rerun; it exposed timing-sensitive aggregate failures outside this PR's ingress surface, and the exact failed tests passed in isolation:
  - `go test ./internal/apiv1 -run TestOperatorEventPublishReturnsDurableAckBeforePostCommitDispatchCompletes -count=1 -v`
  - `go test ./internal/runtime/cataloge2e -run 'TestTier10PolicyPatternCatalogFixtures_RealRuntime/test-policy-capacity-query' -count=1 -v`
