### PR TITLE
[agent-e][issue #1681] Public scenario entity detail assertions

### DIFF
--- a/cmd/swarm/test_command.go
+++ b/cmd/swarm/test_command.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/sha1"
 	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -83,8 +84,14 @@ type scenarioEventExpect struct {
 }
 
 type scenarioEntityExpect struct {
-	EntityType string
-	Count      *int
+	EntityType   string
+	Count        *int
+	CurrentState any
+	StateSet     bool
+	Fields       map[string]any
+	FieldsSet    bool
+	Gates        map[string]any
+	GatesSet     bool
 }
 
 type scenarioInvalid struct {
@@ -400,7 +407,7 @@ func (r scenarioRunner) runScenarioFile(ctx context.Context, file scenarioTestFi
 			return fmt.Errorf("%s: %w", file.Path, err)
 		}
 		if !doc.Expect.empty() {
-			if err := r.evaluateExpectations(ctx, state.RunID, doc.Expect); err != nil {
+			if err := r.evaluateExpectations(ctx, state.RunID, evaluator, doc.Expect); err != nil {
 				return fmt.Errorf("%s: %w", file.Path, err)
 			}
 		}
@@ -658,12 +665,39 @@ func parseScenarioEntityExpect(value any) ([]scenarioEntityExpect, error) {
 					return nil, fmt.Errorf("expect.entities[%d].count must be a non-negative integer", i)
 				}
 				item.Count = &count
+			case "current_state":
+				if text, ok := value.(string); ok && strings.TrimSpace(text) == "" {
+					return nil, fmt.Errorf("expect.entities[%d].current_state must be non-empty", i)
+				}
+				item.CurrentState = cloneAny(value)
+				item.StateSet = true
+			case "fields":
+				fields, ok := value.(map[string]any)
+				if !ok {
+					return nil, fmt.Errorf("expect.entities[%d].fields must be a mapping", i)
+				}
+				item.Fields = cloneAnyMap(fields)
+				item.FieldsSet = true
+			case "gates":
+				gates, ok := value.(map[string]any)
+				if !ok {
+					return nil, fmt.Errorf("expect.entities[%d].gates must be a mapping", i)
+				}
+				item.Gates = cloneAnyMap(gates)
+				item.GatesSet = true
 			default:
 				return nil, fmt.Errorf("unsupported expect.entities[%d] field %q", i, key)
 			}
 		}
 		if item.EntityType == "" {
 			return nil, fmt.Errorf("expect.entities[%d].type is required", i)
+		}
+		detail := item.hasDetailAssertion()
+		if item.Count != nil && detail {
+			return nil, fmt.Errorf("expect.entities[%d].count cannot be combined with current_state, fields, or gates", i)
+		}
+		if item.Count == nil && !detail {
+			return nil, fmt.Errorf("expect.entities[%d] requires count, current_state, fields, or gates", i)
 		}
 		out = append(out, item)
 	}
@@ -672,6 +706,10 @@ func parseScenarioEntityExpect(value any) ([]scenarioEntityExpect, error) {
 
 func (e scenarioExpect) empty() bool {
 	return len(e.Events.Include) == 0 && len(e.Events.Exact) == 0 && len(e.Events.Ordered) == 0 && e.NoDeadLetters == nil && len(e.Entities) == 0
+}
+
+func (e scenarioEntityExpect) hasDetailAssertion() bool {
+	return e.StateSet || e.FieldsSet || e.GatesSet
 }
 
 func parseScenarioInvalid(node *yaml.Node) (scenarioInvalid, error) {
@@ -1357,7 +1395,7 @@ func (r scenarioRunner) readTestQuiescence(ctx context.Context, runID string) (d
 	return *result.TestQuiescence, nil
 }
 
-func (r scenarioRunner) evaluateExpectations(ctx context.Context, runID string, expect scenarioExpect) error {
+func (r scenarioRunner) evaluateExpectations(ctx context.Context, runID string, evaluator *scenarioExpressionEvaluator, expect scenarioExpect) error {
 	rows, err := r.fetchRunTraceRows(ctx, runID)
 	if err != nil {
 		return err
@@ -1372,7 +1410,7 @@ func (r scenarioRunner) evaluateExpectations(ctx context.Context, runID string, 
 		}
 	}
 	for _, entity := range expect.Entities {
-		if err := r.assertEntityExpectation(ctx, runID, entity); err != nil {
+		if err := r.assertEntityExpectation(ctx, runID, evaluator, entity); err != nil {
 			return err
 		}
 	}
@@ -1491,13 +1529,13 @@ func (r scenarioRunner) assertNoDeadLetters(ctx context.Context, runID string) e
 	}
 }
 
-func (r scenarioRunner) assertEntityExpectation(ctx context.Context, runID string, expect scenarioEntityExpect) error {
+func (r scenarioRunner) assertEntityExpectation(ctx context.Context, runID string, evaluator *scenarioExpressionEvaluator, expect scenarioEntityExpect) error {
 	params := map[string]any{
 		"run_id": runID,
 		"type":   expect.EntityType,
 		"limit":  500,
 	}
-	count := 0
+	entities := []entitySummary{}
 	seen := map[string]struct{}{}
 	for {
 		var result entityListResult
@@ -1507,7 +1545,7 @@ func (r scenarioRunner) assertEntityExpectation(ctx context.Context, runID strin
 		if err := validateEntityListResult(result); err != nil {
 			return err
 		}
-		count += len(result.Entities)
+		entities = append(entities, result.Entities...)
 		cursor := strings.TrimSpace(result.NextCursor)
 		if cursor == "" {
 			break
@@ -1518,10 +1556,141 @@ func (r scenarioRunner) assertEntityExpectation(ctx context.Context, runID strin
 		seen[cursor] = struct{}{}
 		params["cursor"] = cursor
 	}
+	count := len(entities)
 	if expect.Count != nil && count != *expect.Count {
 		return fmt.Errorf("entity expectation for type %s got count %d, want %d", expect.EntityType, count, *expect.Count)
 	}
+	if !expect.hasDetailAssertion() {
+		return nil
+	}
+	if count != 1 {
+		return fmt.Errorf("entity detail expectation for type %s returned %d entities, want exactly one", expect.EntityType, count)
+	}
+	detail, err := expect.evaluatedDetail(evaluator)
+	if err != nil {
+		return err
+	}
+	entityID := entities[0].EntityID
+	var full entityFull
+	if err := r.client.call(ctx, entityGetMethod, map[string]any{"entity_id": entityID, "run_id": runID}, &full); err != nil {
+		return err
+	}
+	if err := validateEntityFullResult("entity.get result", full); err != nil {
+		return err
+	}
+	if full.Entity.EntityID != entityID {
+		return fmt.Errorf("malformed entity.get result: entity.entity_id = %q, want %q", full.Entity.EntityID, entityID)
+	}
+	if full.Entity.RunID != runID {
+		return fmt.Errorf("malformed entity.get result: entity.run_id = %q, want %q", full.Entity.RunID, runID)
+	}
+	if full.Entity.EntityType != expect.EntityType {
+		return fmt.Errorf("malformed entity.get result: entity.entity_type = %q, want %q", full.Entity.EntityType, expect.EntityType)
+	}
+	if detail.State != nil && full.Entity.CurrentState != *detail.State {
+		return fmt.Errorf("entity %s current_state = %q, want %q", entityID, full.Entity.CurrentState, *detail.State)
+	}
+	if detail.FieldsSet {
+		if err := assertScenarioJSONEqual(fmt.Sprintf("entity %s fields", entityID), full.Fields, detail.Fields); err != nil {
+			return err
+		}
+	}
+	if detail.GatesSet {
+		if err := assertScenarioJSONEqual(fmt.Sprintf("entity %s gates", entityID), full.Gates, detail.Gates); err != nil {
+			return err
+		}
+	}
 	return nil
+}
+
+type evaluatedScenarioEntityDetail struct {
+	State     *string
+	Fields    map[string]any
+	FieldsSet bool
+	Gates     map[string]bool
+	GatesSet  bool
+}
+
+func (e scenarioEntityExpect) evaluatedDetail(evaluator *scenarioExpressionEvaluator) (evaluatedScenarioEntityDetail, error) {
+	var out evaluatedScenarioEntityDetail
+	if evaluator == nil {
+		return out, fmt.Errorf("scenario expression evaluator is required for entity detail assertions")
+	}
+	if e.StateSet {
+		value, err := evaluator.evalValue(e.CurrentState)
+		if err != nil {
+			return out, fmt.Errorf("expect.entities.current_state: %w", err)
+		}
+		state, ok := value.(string)
+		if !ok || strings.TrimSpace(state) == "" {
+			return out, fmt.Errorf("expect.entities.current_state must evaluate to a non-empty string")
+		}
+		state = strings.TrimSpace(state)
+		out.State = &state
+	}
+	if e.FieldsSet {
+		value, err := evaluator.evalValue(e.Fields)
+		if err != nil {
+			return out, fmt.Errorf("expect.entities.fields: %w", err)
+		}
+		fields, ok := value.(map[string]any)
+		if !ok {
+			return out, fmt.Errorf("expect.entities.fields must evaluate to a mapping")
+		}
+		out.Fields = fields
+		out.FieldsSet = true
+	}
+	if e.GatesSet {
+		value, err := evaluator.evalValue(e.Gates)
+		if err != nil {
+			return out, fmt.Errorf("expect.entities.gates: %w", err)
+		}
+		gates, ok := value.(map[string]any)
+		if !ok {
+			return out, fmt.Errorf("expect.entities.gates must evaluate to a mapping")
+		}
+		out.Gates = map[string]bool{}
+		for gate, raw := range gates {
+			value, ok := raw.(bool)
+			if !ok {
+				return out, fmt.Errorf("expect.entities.gates.%s must evaluate to boolean", gate)
+			}
+			out.Gates[gate] = value
+		}
+		out.GatesSet = true
+	}
+	return out, nil
+}
+
+func assertScenarioJSONEqual(label string, got, want any) error {
+	gotJSON, err := scenarioCanonicalJSON(got)
+	if err != nil {
+		return fmt.Errorf("%s actual value is not JSON encodable: %w", label, err)
+	}
+	wantJSON, err := scenarioCanonicalJSON(want)
+	if err != nil {
+		return fmt.Errorf("%s expected value is not JSON encodable: %w", label, err)
+	}
+	if gotJSON != wantJSON {
+		return fmt.Errorf("%s mismatch: got %s want %s", label, gotJSON, wantJSON)
+	}
+	return nil
+}
+
+func scenarioCanonicalJSON(value any) (string, error) {
+	raw, err := json.Marshal(value)
+	if err != nil {
+		return "", err
+	}
+	var normalized any
+	if err := json.Unmarshal(raw, &normalized); err != nil {
+		return "", err
+	}
+	out, err := json.Marshal(normalized)
+	if err != nil {
+		return "", err
+	}
+	return string(out), nil
 }
 
 func scenarioStringSliceContains(values []string, want string) bool {

--- a/cmd/swarm/test_command_test.go
+++ b/cmd/swarm/test_command_test.go
@@ -22,6 +22,7 @@ func TestSwarmTestRunsScenarioThroughPublicRPC(t *testing.T) {
 	bundleHash := servedEventPublishFixtureBundleHash(t, contractsPath)
 
 	var calls []jsonRPCRequest
+	var publishCalls int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/v1/rpc" {
 			t.Errorf("path = %q, want /v1/rpc", r.URL.Path)
@@ -36,26 +37,56 @@ func TestSwarmTestRunsScenarioThroughPublicRPC(t *testing.T) {
 		calls = append(calls, req)
 		switch req.Method {
 		case eventPublishMethod:
-			if req.Params["event_name"] != "thing.created" || req.Params["bundle_hash"] != bundleHash || req.Params["idempotency_key"] != scenarioSHA40("empire-cost-router") {
-				t.Fatalf("event.publish params = %#v", req.Params)
+			publishCalls++
+			switch publishCalls {
+			case 1:
+				if req.Params["event_name"] != "thing.created" || req.Params["bundle_hash"] != bundleHash || req.Params["idempotency_key"] != scenarioSHA40("empire-cost-router") {
+					t.Fatalf("event.publish initial params = %#v", req.Params)
+				}
+				payload, ok := req.Params["payload"].(map[string]any)
+				if !ok || payload["who"] != "operator" || !numberEquals(payload["amount"], 7) {
+					t.Fatalf("event.publish initial payload = %#v", req.Params["payload"])
+				}
+				writeJSONRPCResult(t, w, req.ID, eventPublishTestResult(true))
+			case 2:
+				if req.Params["event_name"] != "thing.reviewed" || req.Params["bundle_hash"] != bundleHash || req.Params["run_id"] != "run-1" || req.Params["source_event_id"] != "event-1" {
+					t.Fatalf("event.publish follow-up params = %#v", req.Params)
+				}
+				payload, ok := req.Params["payload"].(map[string]any)
+				if !ok || payload["note"] != "approved" {
+					t.Fatalf("event.publish follow-up payload = %#v", req.Params["payload"])
+				}
+				result := eventPublishTestResult(false)
+				result["event_id"] = "event-2"
+				result["source_event_id"] = "event-1"
+				writeJSONRPCResult(t, w, req.ID, result)
+			default:
+				t.Fatalf("unexpected extra event.publish params = %#v", req.Params)
 			}
-			payload, ok := req.Params["payload"].(map[string]any)
-			if !ok || payload["who"] != "operator" || !numberEquals(payload["amount"], 7) {
-				t.Fatalf("event.publish payload = %#v", req.Params["payload"])
-			}
-			writeJSONRPCResult(t, w, req.ID, eventPublishTestResult(true))
 		case "run.diagnose":
 			writeJSONRPCResult(t, w, req.ID, scenarioRunDiagnoseTestResult("run-1", true))
 		case "run.trace":
 			row := validRunCommandTraceRow("event-1")
 			row["event_name"] = "thing.created"
-			writeJSONRPCResult(t, w, req.ID, map[string]any{"trace": []map[string]any{row}})
+			followUp := validRunCommandTraceRow("event-2")
+			followUp["event_name"] = "thing.reviewed"
+			writeJSONRPCResult(t, w, req.ID, map[string]any{"trace": []map[string]any{row, followUp}})
 		case eventObservationMethodList:
 			writeJSONRPCResult(t, w, req.ID, map[string]any{"events": []any{}})
 		case entityListMethod:
 			entity := validEntitySummary("entity-1")
 			entity["entity_type"] = "widget"
+			entity["current_state"] = "done"
 			writeJSONRPCResult(t, w, req.ID, map[string]any{"entities": []map[string]any{entity}})
+		case entityGetMethod:
+			if req.Params["entity_id"] != "entity-1" || req.Params["run_id"] != "run-1" {
+				t.Fatalf("entity.get params = %#v", req.Params)
+			}
+			result := validEntityFullResult("entity-1")
+			entity := result["entity"].(map[string]any)
+			entity["entity_type"] = "widget"
+			entity["current_state"] = "done"
+			writeJSONRPCResult(t, w, req.ID, result)
 		default:
 			t.Fatalf("unexpected method = %s", req.Method)
 		}
@@ -76,10 +107,13 @@ func TestSwarmTestRunsScenarioThroughPublicRPC(t *testing.T) {
 	assertScenarioTestMethods(t, calls, []string{
 		eventPublishMethod,
 		"run.diagnose",
+		eventPublishMethod,
+		"run.diagnose",
 		"run.diagnose",
 		"run.trace",
 		eventObservationMethodList,
 		entityListMethod,
+		entityGetMethod,
 	})
 	for _, want := range []string{"scenario ok:", "swarm test ok: scenarios=1"} {
 		if !strings.Contains(stdout.String(), want) {
@@ -445,12 +479,128 @@ func TestScenarioEntityExpectationConsumesAllPages(t *testing.T) {
 		t.Fatalf("client: %v", err)
 	}
 	runner := scenarioRunner{client: client}
-	if err := runner.assertEntityExpectation(context.Background(), "run-1", scenarioEntityExpect{EntityType: "widget", Count: intPtr(2)}); err != nil {
+	if err := runner.assertEntityExpectation(context.Background(), "run-1", mustScenarioExpressionEvaluator(t, nil), scenarioEntityExpect{EntityType: "widget", Count: intPtr(2)}); err != nil {
 		t.Fatalf("entity expectation: %v", err)
 	}
 	assertScenarioTestMethods(t, calls, []string{entityListMethod, entityListMethod})
 	if calls[1].Params["cursor"] != "page-2" {
 		t.Fatalf("second entity.list cursor = %#v", calls[1].Params)
+	}
+}
+
+func TestScenarioEntityExpectationConsumesCanonicalDetail(t *testing.T) {
+	var calls []jsonRPCRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req jsonRPCRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Errorf("decode request: %v", err)
+		}
+		calls = append(calls, req)
+		switch req.Method {
+		case entityListMethod:
+			if req.Params["run_id"] != "run-1" || req.Params["type"] != "widget" {
+				t.Fatalf("entity.list params = %#v", req.Params)
+			}
+			entity := validEntitySummary("entity-1")
+			entity["entity_type"] = "widget"
+			entity["current_state"] = "done"
+			writeJSONRPCResult(t, w, req.ID, map[string]any{"entities": []map[string]any{entity}})
+		case entityGetMethod:
+			if req.Params["entity_id"] != "entity-1" || req.Params["run_id"] != "run-1" {
+				t.Fatalf("entity.get params = %#v", req.Params)
+			}
+			result := validEntityFullResult("entity-1")
+			entity := result["entity"].(map[string]any)
+			entity["entity_type"] = "widget"
+			entity["current_state"] = "done"
+			writeJSONRPCResult(t, w, req.ID, result)
+		default:
+			t.Fatalf("unexpected request %#v", req)
+		}
+	}))
+	defer server.Close()
+	client, err := newCLIAPIClient(rootCommandOptions{apiServer: strings.TrimSuffix(server.URL, "/")})
+	if err != nil {
+		t.Fatalf("client: %v", err)
+	}
+	runner := scenarioRunner{client: client}
+	evaluator := mustScenarioExpressionEvaluator(t, map[string]any{
+		"done_state": "done",
+		"score":      7,
+		"ready":      true,
+	})
+	if err := runner.assertEntityExpectation(context.Background(), "run-1", evaluator, scenarioEntityExpect{
+		EntityType:   "widget",
+		CurrentState: "${vars.done_state}",
+		StateSet:     true,
+		Fields:       map[string]any{"score": "${vars.score}"},
+		FieldsSet:    true,
+		Gates:        map[string]any{"ready": "${vars.ready}"},
+		GatesSet:     true,
+	}); err != nil {
+		t.Fatalf("entity detail expectation: %v", err)
+	}
+	assertScenarioTestMethods(t, calls, []string{entityListMethod, entityGetMethod})
+}
+
+func TestScenarioEntityDetailExpectationFailsClosedOnMultipleMatches(t *testing.T) {
+	var calls []jsonRPCRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req jsonRPCRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Errorf("decode request: %v", err)
+		}
+		calls = append(calls, req)
+		if req.Method != entityListMethod {
+			t.Fatalf("unexpected request %#v", req)
+		}
+		entity1 := validEntitySummary("entity-1")
+		entity1["entity_type"] = "widget"
+		entity2 := validEntitySummary("entity-2")
+		entity2["entity_type"] = "widget"
+		writeJSONRPCResult(t, w, req.ID, map[string]any{"entities": []map[string]any{entity1, entity2}})
+	}))
+	defer server.Close()
+	client, err := newCLIAPIClient(rootCommandOptions{apiServer: strings.TrimSuffix(server.URL, "/")})
+	if err != nil {
+		t.Fatalf("client: %v", err)
+	}
+	runner := scenarioRunner{client: client}
+	err = runner.assertEntityExpectation(context.Background(), "run-1", mustScenarioExpressionEvaluator(t, nil), scenarioEntityExpect{
+		EntityType:   "widget",
+		CurrentState: "done",
+		StateSet:     true,
+	})
+	if err == nil || !strings.Contains(err.Error(), "returned 2 entities, want exactly one") {
+		t.Fatalf("entity detail expectation error = %v, want multiple-match failure", err)
+	}
+	assertScenarioTestMethods(t, calls, []string{entityListMethod})
+}
+
+func TestScenarioEntityExpectationRejectsAmbiguousRows(t *testing.T) {
+	for _, raw := range []string{
+		`
+steps:
+  - publish: thing.created
+    payload: {amount: 7, who: operator}
+expect:
+  entities:
+    - type: widget
+`,
+		`
+steps:
+  - publish: thing.created
+    payload: {amount: 7, who: operator}
+expect:
+  entities:
+    - type: widget
+      count: 1
+      current_state: done
+`,
+	} {
+		if _, err := parseScenarioDocument([]byte(raw)); err == nil {
+			t.Fatalf("parseScenarioDocument(%s) unexpectedly succeeded", raw)
+		}
 	}
 }
 
@@ -473,6 +623,9 @@ steps:
       set:
         who: ${vars.who}
         amount: 7
+  - publish: thing.reviewed
+    payload:
+      note: approved
 invalid:
   base:
     publish: thing.created
@@ -485,11 +638,11 @@ invalid:
       expect: reject
 expect:
   events:
-    include: [thing.created]
+    include: [thing.created, thing.reviewed]
   no_dead_letters: true
   entities:
     - type: widget
-      count: 1
+      current_state: done
 `)
 	return contractsPath
 }
@@ -518,6 +671,15 @@ func scenarioRunDiagnoseTestResult(runID string, ready bool) map[string]any {
 
 func intPtr(value int) *int {
 	return &value
+}
+
+func mustScenarioExpressionEvaluator(t *testing.T, vars map[string]any) *scenarioExpressionEvaluator {
+	t.Helper()
+	evaluator, err := newScenarioExpressionEvaluator("test-seed", vars)
+	if err != nil {
+		t.Fatalf("newScenarioExpressionEvaluator: %v", err)
+	}
+	return evaluator
 }
 
 func assertScenarioTestMethods(t *testing.T, calls []jsonRPCRequest, want []string) {

--- a/internal/apispec/platform_spec_source_refs_test.go
+++ b/internal/apispec/platform_spec_source_refs_test.go
@@ -153,6 +153,28 @@ func TestPlatformSpecDeterministicScenarioRunnerSourceAuthority(t *testing.T) {
 			t.Fatalf("deterministic scenario runner expectations.%s missing", key)
 		}
 	}
+	entities := mustMappingValue(t, expectations, "entities")
+	for _, key := range []string{"current_state", "fields", "gates", "count_interaction"} {
+		if !hasMappingKey(entities, key) {
+			t.Fatalf("deterministic scenario runner expectations.entities.%s missing", key)
+		}
+	}
+	for _, item := range []struct {
+		key  string
+		want []string
+	}{
+		{key: "current_state", want: []string{"scenario literal model", "CEL", "entity.list", "entity.get", "current_state"}},
+		{key: "fields", want: []string{"EntityFull.fields", "scenario literal model", "CEL", "exactly"}},
+		{key: "gates", want: []string{"EntityFull.gates", "scenario literal model", "CEL", "booleans"}},
+		{key: "count_interaction", want: []string{"count-only", "MUST NOT be combined"}},
+	} {
+		text := scalarValue(mappingValue(entities, item.key))
+		for _, want := range item.want {
+			if !strings.Contains(text, want) {
+				t.Fatalf("deterministic scenario runner expectations.entities.%s missing %q:\n%s", item.key, want, text)
+			}
+		}
+	}
 
 	catalogConvergence := mustMappingValue(t, runner, "catalog_convergence")
 	if got := scalarValue(mappingValue(catalogConvergence, "decision")); got != "split_follow_up" {

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -11209,6 +11209,34 @@ test_specification:
           plus field predicates, or by a mailbox/event-derived id. Zero or
           multiple matches fail closed unless the assertion explicitly expects a
           count.
+        current_state: >
+          A row with `current_state` is a detail assertion, not a count
+          assertion. Expected values consume the scenario literal model, so
+          `${...}` values are evaluated as CEL before comparison. The runner
+          first resolves matching entity summaries through the canonical
+          `entity.list` owner in the current run. The match must resolve to
+          exactly one entity, then the runner reads that entity through
+          `entity.get` and compares `EntityFull.entity.current_state` exactly.
+        fields: >
+          A row with `fields` is a detail assertion over
+          `EntityFull.fields`. Expected field values consume the scenario
+          literal model, so nested `${...}` values are evaluated as CEL before
+          comparison. The expected YAML object is compared exactly to the
+          canonical `entity.get` field map after JSON-compatible scalar
+          normalization; missing, extra, or differently-valued fields fail the
+          scenario.
+        gates: >
+          A row with `gates` is a detail assertion over `EntityFull.gates`.
+          Gate expectations consume the scenario literal model, so nested
+          `${...}` values are evaluated as CEL and must resolve to booleans.
+          The resulting boolean map compares exactly to the canonical
+          `entity.get` gate map. Missing, extra, non-boolean, or
+          differently-valued gates fail the scenario.
+        count_interaction: >
+          `count` is a count-only assertion and MUST NOT be combined with
+          `current_state`, `fields`, or `gates`. A type-only entity row is not a
+          valid assertion. This prevents the runner from preserving two
+          different interpretations of the same `expect.entities` row.
       mailbox:
         rule: >
           Mailbox assertions consume mailbox read owners and are scoped to the
@@ -12955,7 +12983,8 @@ cli_specification:
         mailbox.list and then call the matching mailbox decision RPC. The command waits for test quiescence by repeatedly
         reading canonical `run.diagnose` result.test_quiescence until active deliveries, unsettled same-run pipeline receipt
         work, due timers, and active session leases are absent; --timeout is a safety failure bound, not the semantic
-        completion rule. Expectations consume run.trace, event.list dead-letter readback, and paginated entity.list. The
+        completion rule. Expectations consume run.trace, event.list dead-letter readback, paginated entity.list, and
+        entity.get for detail assertions. The
         command does not activate mock/local providers, implement ProviderContract, test live agent sessions/tool calls/audit/
         spend semantics, execute inline code, copy cataloge2e private formats, or mutate EventBus/store/mailbox tables
         directly.
@@ -12988,6 +13017,8 @@ cli_specification:
       - scenario discovery rejects files outside contracts/tests and contracts/flows/<flow>/tests
       - fixture from paths cannot escape the contract root, set overrides are applied before schema validation, and invalid
         fixture/schema variants fail before mutation
+      - entity current_state, fields, and gates expectations resolve entities through paginated entity.list, fail closed on
+        zero/multiple detail matches, and read canonical detail through entity.get
       - no live LLM credentials, ProviderContract mock/local activation, or cataloge2e private scenario format is required
     workspace_build:
       command: swarm workspace build --backend claude_cli [--image <tag>]


### PR DESCRIPTION
## Summary

Adds public `swarm test` entity-detail assertions for the approved #1681 first slice:

- `expect.entities[].current_state`
- `expect.entities[].fields`
- `expect.entities[].gates`

Detail assertions resolve entities through paginated `entity.list`, fail closed unless exactly one entity matches, and then read canonical detail through `entity.get`. `count` remains count-only and cannot be combined with detail assertions.

Part of #1681.

## Governing Refs / Context

Exact governing spec refs updated in this PR:

- `platform-spec.yaml#test_specification.deterministic_scenario_runner.expectations.entities`
- `platform-spec.yaml#cli_specification.command_catalog.test`
- `platform-spec.yaml#api_specification.method_catalog.entity.list`
- `platform-spec.yaml#api_specification.method_catalog.entity.get`

Binding gate context:

- #1681 `Pre-Implementation Coverage Audit`
- #1681 `Independent Gate Review`, approved as first slice for `testing.public_scenario_entity_detail_assertion_source_authority`

## Semantic Boundary

New/confirmed canonical owner for public scenario entity-detail assertions:

- Scenario semantics: `platform-spec.yaml#test_specification.deterministic_scenario_runner.expectations.entities`
- Public read owners consumed by implementation: `entity.list` for exact selection and `entity.get` for `EntityFull` detail

Old/non-authoritative paths preserved only as private evidence, not public runner authority:

- `tests/**/expected.yaml` private catalog assertion format
- `internal/runtime/cataloge2e` direct DB/runtime assertion readers
- `event_receipts.outcome` handler outcome proof

Production paths checked for surviving old behavior:

- `swarm test` continues to consume only public RPC owners; no direct DB/store/EventBus/catalog harness reads were added.
- Existing event expectations and `no_dead_letters` behavior are preserved.
- Handler outcome, causal event chains, positive dead-letter details, and flow/template instance assertions remain split/out of scope.

Migration completeness:

- Complete for the approved public scenario entity-detail assertion class.
- Not a catalog smoke replacement migration; `test-emits-single` still has private `handler_outcome: success` proof outside this PR.

## Validation

- `go test ./cmd/swarm -run 'TestSwarmTest|TestScenario|TestEntities' -count=1`
- `go test ./internal/apispec -run 'TestPlatformSpecDeterministicScenarioRunnerSourceAuthority|TestEntityFullAccumulatedSchemaPublishesRuntimeAccumulatorState' -count=1`
- `go test ./internal/apiv1 -run 'TestOpenRPCReadonlyRuntimeMethods|TestOperatorEntity|TestOperatorObservability' -count=1`
- `go test ./...`
