### PR TITLE
[agent-a][issue #1683] Add emit field lowering sugar

### DIFF
--- a/internal/runtime/bootverify/report_test.go
+++ b/internal/runtime/bootverify/report_test.go
@@ -3372,6 +3372,32 @@ func TestRun_DoesNotWarnWhenEmitFieldsCoverRequiredPayload(t *testing.T) {
 	}
 }
 
+func TestRun_RejectsEmitFieldsForEmptyPayloadSchema(t *testing.T) {
+	bundle := bootverifyPayloadCompletenessBundle()
+	entry := bundle.Events["market_research.scan_assigned"]
+	entry.Payload = runtimecontracts.EventPayloadSpec{}
+	entry.Required = nil
+	bundle.Events["market_research.scan_assigned"] = entry
+
+	node := bundle.Nodes["dispatcher"]
+	handler := node.EventHandlers["scan.corpus_dispatch"]
+	handler.Emit = runtimecontracts.EmitSpec{
+		Event: "market_research.scan_assigned",
+		Fields: map[string]runtimecontracts.ExpressionValue{
+			"scan_id": runtimecontracts.RefExpression("payload.scan_id"),
+		},
+	}
+	node.EventHandlers["scan.corpus_dispatch"] = handler
+	bundle.Nodes["dispatcher"] = node
+	bundle.Semantics.NodeHandlers["dispatcher"]["scan.corpus_dispatch"] = handler
+
+	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+
+	if !reportContains(report.Errors(), "semantic_drift_payload_completeness", "authors undeclared payload field scan_id in emit.fields") {
+		t.Fatalf("expected undeclared emit field error for empty payload schema, got %#v", report.Errors())
+	}
+}
+
 func TestRun_LowersEmitFromBeforePayloadCompletenessAndExpressionValidation(t *testing.T) {
 	bundle := bootverifyPayloadCompletenessBundle()
 	entry := bundle.Events["market_research.scan_assigned"]

--- a/internal/runtime/bootverify/report_test.go
+++ b/internal/runtime/bootverify/report_test.go
@@ -3372,6 +3372,91 @@ func TestRun_DoesNotWarnWhenEmitFieldsCoverRequiredPayload(t *testing.T) {
 	}
 }
 
+func TestRun_LowersEmitFromBeforePayloadCompletenessAndExpressionValidation(t *testing.T) {
+	bundle := bootverifyPayloadCompletenessBundle()
+	entry := bundle.Events["market_research.scan_assigned"]
+	entry.Required = []string{"scan_id", "geography"}
+	bundle.Events["market_research.scan_assigned"] = entry
+	node := bundle.Nodes["dispatcher"]
+	handler := node.EventHandlers["scan.corpus_dispatch"]
+	handler.Emit = runtimecontracts.EmitSpec{
+		Event: "market_research.scan_assigned",
+		From:  "entity",
+		Fields: map[string]runtimecontracts.ExpressionValue{
+			"geography": runtimecontracts.CELExpression("payload"),
+		},
+	}
+	node.EventHandlers["scan.corpus_dispatch"] = handler
+	bundle.Nodes["dispatcher"] = node
+	bundle.Semantics.NodeHandlers["dispatcher"]["scan.corpus_dispatch"] = handler
+
+	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+
+	if reportContains(report.Errors(), "semantic_drift_payload_completeness", "handler.emit") {
+		t.Fatalf("unexpected payload completeness error after emit.from lowering, got %#v", report.Errors())
+	}
+	if reportContains(report.Errors(), "emit_field_expression_validation", "payload") {
+		t.Fatalf("bare namespace micro-sugar was validated before lowering, got %#v", report.Errors())
+	}
+}
+
+func TestRun_LowersEmitFromThroughRulesEmitTemplateSpecialization(t *testing.T) {
+	bundle := bootverifyPayloadCompletenessBundle()
+	entry := bundle.Events["market_research.scan_assigned"]
+	entry.Required = []string{"scan_id", "geography"}
+	bundle.Events["market_research.scan_assigned"] = entry
+	node := bundle.Nodes["dispatcher"]
+	handler := node.EventHandlers["scan.corpus_dispatch"]
+	handler.Emit = runtimecontracts.EmitSpec{
+		Event: "market_research.scan_assigned",
+		From:  "entity",
+	}
+	handler.Rules = []runtimecontracts.HandlerRuleEntry{{
+		ID:        "full",
+		Condition: "else",
+		Emit: runtimecontracts.EmitSpec{
+			Fields: map[string]runtimecontracts.ExpressionValue{
+				"geography": runtimecontracts.CELExpression("payload"),
+			},
+		},
+	}}
+	node.EventHandlers["scan.corpus_dispatch"] = handler
+	bundle.Nodes["dispatcher"] = node
+	bundle.Semantics.NodeHandlers["dispatcher"]["scan.corpus_dispatch"] = handler
+
+	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+
+	if reportContains(report.Errors(), "semantic_drift_payload_completeness", "rules[full].emit_template") {
+		t.Fatalf("unexpected template payload completeness error after emit.from lowering, got %#v", report.Errors())
+	}
+	if reportContains(report.Errors(), "emit_field_expression_validation", "payload") {
+		t.Fatalf("template bare namespace micro-sugar was validated before lowering, got %#v", report.Errors())
+	}
+}
+
+func TestRun_ReportsEmitFromLoweringErrorsAsPayloadCompletenessFailures(t *testing.T) {
+	bundle := bootverifyPayloadCompletenessBundle()
+	entry := bundle.Events["market_research.scan_assigned"]
+	entry.Required = []string{"scan_id", "missing_required"}
+	entry.Payload.Properties["missing_required"] = runtimecontracts.EventFieldSpec{Type: "string"}
+	bundle.Events["market_research.scan_assigned"] = entry
+	node := bundle.Nodes["dispatcher"]
+	handler := node.EventHandlers["scan.corpus_dispatch"]
+	handler.Emit = runtimecontracts.EmitSpec{
+		Event: "market_research.scan_assigned",
+		From:  "entity",
+	}
+	node.EventHandlers["scan.corpus_dispatch"] = handler
+	bundle.Nodes["dispatcher"] = node
+	bundle.Semantics.NodeHandlers["dispatcher"]["scan.corpus_dispatch"] = handler
+
+	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+
+	if !reportContains(report.Errors(), "semantic_drift_payload_completeness", "emit.from entity cannot fill required emitted payload field missing_required") {
+		t.Fatalf("expected emit.from missing source field error, got %#v", report.Errors())
+	}
+}
+
 func TestRun_DoesNotWarnWhenEmitFieldsCoverRequiredPayloadAcrossExpressionKinds(t *testing.T) {
 	t.Parallel()
 

--- a/internal/runtime/bootverify/workflow_entity_contract_coverage_checks.go
+++ b/internal/runtime/bootverify/workflow_entity_contract_coverage_checks.go
@@ -509,7 +509,7 @@ func wave1EntityReaderCoverageByFlow(source semanticview.Source) map[string]map[
 		}
 		for eventType, handler := range source.NodeEventHandlers(nodeID) {
 			eventType = strings.TrimSpace(eventType)
-			for _, expr := range handlerEntityExpressions(handler) {
+			for _, expr := range handlerEntityExpressionsForSource(source, flowID, nodeID, eventType, handler) {
 				for _, ref := range wave1ResolvedExpressionRefs(source, flowID, nodeID, eventType, expr) {
 					ownerFlowID := strings.TrimSpace(ref.OwnerFlowID)
 					if out[ownerFlowID] == nil {

--- a/internal/runtime/bootverify/workflow_expression_checks.go
+++ b/internal/runtime/bootverify/workflow_expression_checks.go
@@ -8,6 +8,7 @@ import (
 	runtimepaths "github.com/division-sh/swarm/internal/runtime/core/paths"
 	runtimeengine "github.com/division-sh/swarm/internal/runtime/engine"
 	runtimepipeline "github.com/division-sh/swarm/internal/runtime/pipeline"
+	"github.com/division-sh/swarm/internal/runtime/semanticview"
 	"github.com/division-sh/swarm/internal/runtime/workflowexpr"
 )
 
@@ -74,7 +75,8 @@ func (c *checkerContext) dataAccumulationExpressions() []Finding {
 		nodeID = strings.TrimSpace(nodeID)
 		for eventType, handler := range node.EventHandlers {
 			eventType = strings.TrimSpace(eventType)
-			for _, expr := range handlerEntityExpressions(handler) {
+			flowID := nodeFlowID(c.source, nodeID)
+			for _, expr := range handlerEntityExpressionsForSource(c.source, flowID, nodeID, eventType, handler) {
 				if expr.Phase != runtimepipeline.WorkflowEntityFieldLifecycleDataAccumulation {
 					continue
 				}
@@ -101,7 +103,8 @@ func (c *checkerContext) emitFieldExpressions() []Finding {
 		nodeID = strings.TrimSpace(nodeID)
 		for eventType, handler := range node.EventHandlers {
 			eventType = strings.TrimSpace(eventType)
-			for _, expr := range handlerEntityExpressions(handler) {
+			flowID := nodeFlowID(c.source, nodeID)
+			for _, expr := range handlerEntityExpressionsForSource(c.source, flowID, nodeID, eventType, handler) {
 				if expr.Phase != runtimepipeline.WorkflowEntityFieldLifecycleEmitFields &&
 					expr.Phase != runtimepipeline.WorkflowEntityFieldLifecycleGuardEscalation {
 					continue
@@ -135,7 +138,7 @@ func (c *checkerContext) expressionFieldReferences() []Finding {
 		}
 		for eventType, handler := range node.EventHandlers {
 			eventType = strings.TrimSpace(eventType)
-			for _, expr := range handlerEntityExpressions(handler) {
+			for _, expr := range handlerEntityExpressionsForSource(c.source, flowID, nodeID, eventType, handler) {
 				for _, ref := range runtimepipeline.WorkflowEntityReferences(expr.Expression) {
 					ref = strings.TrimSpace(ref)
 					if ref == "" {
@@ -441,64 +444,6 @@ func handlerEntityExpressions(handler runtimecontracts.SystemNodeEventHandler) [
 			out = append(out, expressionReference{Kind: "count condition", Expression: condition, Phase: runtimepipeline.WorkflowEntityFieldLifecycleCount})
 		}
 	}
-	appendEmitExpressions := func(kindPrefix string, spec runtimecontracts.EmitSpec, allowBareItem bool) {
-		for key, value := range spec.Fields {
-			expr := strings.TrimSpace(value.CEL)
-			if expr == "" && value.Kind == runtimecontracts.ExpressionKindRef {
-				expr = strings.TrimSpace(value.Ref)
-			}
-			if expr != "" {
-				out = append(out, expressionReference{
-					Kind:          kindPrefix + " emit field " + strings.TrimSpace(key),
-					Expression:    expr,
-					Phase:         runtimepipeline.WorkflowEntityFieldLifecycleEmitFields,
-					AllowBareItem: allowBareItem,
-				})
-			}
-		}
-	}
-	appendEmitExpressions("handler", handler.Emit, false)
-	if handler.Guard != nil {
-		if failureSpec, err := handler.Guard.FailureSpec(); err == nil {
-			appendEmitExpressions("guard escalation", failureSpec.EscalationEmitSpec(), false)
-			if len(out) > 0 {
-				for i := range out {
-					if strings.HasPrefix(out[i].Kind, "guard escalation emit field ") {
-						out[i].Phase = runtimepipeline.WorkflowEntityFieldLifecycleGuardEscalation
-					}
-				}
-			}
-		}
-	}
-	if handler.FanOut != nil {
-		appendEmitExpressions("fan_out", handler.FanOut.Emit, true)
-	}
-	for _, rule := range handler.Rules {
-		appendEmitExpressions("rule", rule.Emit, false)
-		if rule.FanOut != nil {
-			appendEmitExpressions("rule fan_out", rule.FanOut.Emit, true)
-		}
-	}
-	for _, rule := range handler.OnComplete {
-		appendEmitExpressions("on_complete", rule.Emit, false)
-		if rule.FanOut != nil {
-			appendEmitExpressions("on_complete fan_out", rule.FanOut.Emit, true)
-		}
-	}
-	if handler.Accumulate != nil {
-		for _, rule := range handler.Accumulate.OnComplete {
-			appendEmitExpressions("accumulate.on_complete", rule.Emit, false)
-			if rule.FanOut != nil {
-				appendEmitExpressions("accumulate.on_complete fan_out", rule.FanOut.Emit, true)
-			}
-		}
-		if handler.Accumulate.OnTimeout != nil {
-			appendEmitExpressions("accumulate.on_timeout", handler.Accumulate.OnTimeout.Emit, false)
-			if handler.Accumulate.OnTimeout.FanOut != nil {
-				appendEmitExpressions("accumulate.on_timeout fan_out", handler.Accumulate.OnTimeout.FanOut.Emit, true)
-			}
-		}
-	}
 	if handler.Query != nil {
 		appendQueryExpressions(&out, *handler.Query)
 	}
@@ -518,6 +463,60 @@ func handlerEntityExpressions(handler runtimecontracts.SystemNodeEventHandler) [
 		}
 		if branch.Else != nil {
 			appendRuleExpressions("branch.else", *branch.Else)
+		}
+	}
+	return out
+}
+
+func handlerEntityExpressionsForSource(source semanticview.Source, flowID, nodeID, eventType string, handler runtimecontracts.SystemNodeEventHandler) []expressionReference {
+	out := handlerEntityExpressions(handler)
+	out = append(out, handlerEmitExpressionsForSource(source, flowID, nodeID, eventType, handler)...)
+	return out
+}
+
+func handlerEmitExpressionsForSource(source semanticview.Source, flowID, nodeID, eventType string, handler runtimecontracts.SystemNodeEventHandler) []expressionReference {
+	out := make([]expressionReference, 0, 8)
+	appendSpec := func(kindPrefix, siteKey string, spec runtimecontracts.EmitSpec, phase runtimepipeline.WorkflowEntityFieldLifecyclePhase, allowBareItem bool) {
+		if spec.Empty() {
+			return
+		}
+		if bundle, ok := semanticview.Bundle(source); ok && bundle != nil {
+			lowered, err := bundle.LowerEmitSpecFields(runtimecontracts.EmitFieldLoweringContext{
+				NodeID:           nodeID,
+				FlowID:           flowID,
+				TriggerEventType: eventType,
+				Site:             siteKey,
+			}, spec)
+			if err != nil {
+				return
+			}
+			spec = lowered
+		}
+		for key, value := range spec.Fields {
+			expr := strings.TrimSpace(value.CEL)
+			if expr == "" && value.Kind == runtimecontracts.ExpressionKindRef {
+				expr = strings.TrimSpace(value.Ref)
+			}
+			if expr == "" {
+				continue
+			}
+			out = append(out, expressionReference{
+				Kind:          kindPrefix + " emit field " + strings.TrimSpace(key),
+				Expression:    expr,
+				Phase:         phase,
+				AllowBareItem: allowBareItem,
+			})
+		}
+	}
+	for _, site := range runtimecontracts.HandlerDeclarativeEmitSites(handler) {
+		allowBareItem := strings.Contains(site.Source, "fan_out.emit")
+		appendSpec(site.Source, site.SiteKey, site.Spec, runtimepipeline.WorkflowEntityFieldLifecycleEmitFields, allowBareItem)
+	}
+	if handler.Guard != nil {
+		if failureSpec, err := handler.Guard.FailureSpec(); err == nil {
+			if parsed, err := runtimeengine.GuardFailureFromSpec(failureSpec); err == nil && parsed.Action == runtimeengine.GuardFailureEscalate {
+				appendSpec("guard escalation", "guard.on_fail.escalate", failureSpec.EscalationEmitSpec(), runtimepipeline.WorkflowEntityFieldLifecycleGuardEscalation, false)
+			}
 		}
 	}
 	return out

--- a/internal/runtime/bootverify/workflow_flow_boundary_checks.go
+++ b/internal/runtime/bootverify/workflow_flow_boundary_checks.go
@@ -1059,8 +1059,14 @@ func bootverifyEmitSitesReferenceEntity(handler runtimecontracts.SystemNodeEvent
 }
 
 func bootverifyEmitReferencesEntity(spec runtimecontracts.EmitSpec) bool {
+	if strings.TrimSpace(spec.From) == runtimecontracts.EmitFromEntity {
+		return true
+	}
 	for _, value := range spec.Fields {
 		if value.Kind == runtimecontracts.ExpressionKindCEL && workflowexpr.ExpressionReferencesEntity(value.CEL) {
+			return true
+		}
+		if value.Kind == runtimecontracts.ExpressionKindCEL && strings.TrimSpace(value.CEL) == runtimecontracts.EmitFromEntity {
 			return true
 		}
 	}

--- a/internal/runtime/bootverify/workflow_payload_completeness_checks.go
+++ b/internal/runtime/bootverify/workflow_payload_completeness_checks.go
@@ -37,7 +37,16 @@ func (c *checkerContext) payloadCompleteness() []Finding {
 		for triggerEventType, handler := range c.source.NodeEventHandlers(nodeID) {
 			triggerEventType = strings.TrimSpace(triggerEventType)
 			triggerProof := semanticview.ResolveFlowEventProof(c.source, flowID, triggerEventType)
-			for _, emitSite := range payloadCompletenessEmitSites(handler) {
+			for _, emitSite := range payloadCompletenessEmitSites(c.source, nodeID, flowID, triggerEventType, handler) {
+				if emitSite.Err != nil {
+					c.payloadCompletenessFindings = append(c.payloadCompletenessFindings, Finding{
+						CheckID:  "semantic_drift_payload_completeness",
+						Severity: "error",
+						Message:  fmt.Sprintf("node %s handler %s at %s %v", nodeID, triggerEventType, emitSite.Label, emitSite.Err),
+						Location: nodeID,
+					})
+					continue
+				}
 				emitted := strings.TrimSpace(emitSite.EventType)
 				if emitted == "" {
 					continue
@@ -58,6 +67,15 @@ func (c *checkerContext) payloadCompleteness() []Finding {
 				}
 				if !emittedProof.HasSchema {
 					continue
+				}
+				declared := payloadCompletenessDeclaredFields(emittedProof.Entry)
+				for _, field := range payloadCompletenessUndeclaredFields(emitSite.Fields, declared) {
+					c.payloadCompletenessFindings = append(c.payloadCompletenessFindings, Finding{
+						CheckID:  "semantic_drift_payload_completeness",
+						Severity: "error",
+						Message:  fmt.Sprintf("event %s emitted by node %s handler %s at %s authors undeclared payload field %s in emit.fields", emittedDisplayName, nodeID, triggerEventType, emitSite.Label, field),
+						Location: nodeID,
+					})
 				}
 				required := payloadCompletenessRequiredFields(emittedProof.Entry)
 				if len(required) == 0 {
@@ -103,15 +121,34 @@ type payloadCompletenessEmitSite struct {
 	EventType string
 	Label     string
 	Fields    map[string]struct{}
+	Err       error
 }
 
 func payloadCompletenessRequiredFields(entry runtimecontracts.EventCatalogEntry) []string {
-	return uniquePayloadCompletenessStrings(entry.Required...)
+	required := append([]string{}, entry.Required...)
+	required = append(required, entry.Payload.Required...)
+	return uniquePayloadCompletenessStrings(required...)
 }
 
-func payloadCompletenessEmitSites(handler runtimecontracts.SystemNodeEventHandler) []payloadCompletenessEmitSite {
+func payloadCompletenessEmitSites(source semanticview.Source, nodeID, flowID, triggerEventType string, handler runtimecontracts.SystemNodeEventHandler) []payloadCompletenessEmitSite {
 	var out []payloadCompletenessEmitSite
 	add := func(label string, spec runtimecontracts.EmitSpec) {
+		if bundle, ok := semanticview.Bundle(source); ok && bundle != nil {
+			lowered, err := bundle.LowerEmitSpecFields(runtimecontracts.EmitFieldLoweringContext{
+				NodeID:           nodeID,
+				FlowID:           flowID,
+				TriggerEventType: triggerEventType,
+				Site:             label,
+			}, spec)
+			if err != nil {
+				out = append(out, payloadCompletenessEmitSite{
+					Label: strings.TrimSpace(label),
+					Err:   err,
+				})
+				return
+			}
+			spec = lowered
+		}
 		eventType := spec.EventType()
 		if eventType == "" {
 			return
@@ -130,49 +167,8 @@ func payloadCompletenessEmitSites(handler runtimecontracts.SystemNodeEventHandle
 			Fields:    targets,
 		})
 	}
-	templateSites := runtimecontracts.HandlerRuleEmitTemplateSites(handler)
-	if len(templateSites) == 0 {
-		add("handler.emit", handler.Emit)
-	} else {
-		for _, site := range templateSites {
-			label := site.SiteKey
-			if strings.TrimSpace(site.RuleID) != "" {
-				label = "rules[" + strings.TrimSpace(site.RuleID) + "].emit_template"
-			}
-			add(label, site.Spec)
-		}
-	}
-	add("handler.on_success.emit", handler.OnSuccess.Emit)
-	if handler.FanOut != nil {
-		add("handler.fan_out.emit", handler.FanOut.Emit)
-	}
-	if len(templateSites) == 0 {
-		for i, rule := range handler.Rules {
-			add(payloadCompletenessRuleLabel("rules", i, rule.ID, "emit"), rule.Emit)
-			if rule.FanOut != nil {
-				add(payloadCompletenessRuleLabel("rules", i, rule.ID, "fan_out.emit"), rule.FanOut.Emit)
-			}
-		}
-	}
-	for i, rule := range handler.OnComplete {
-		add(payloadCompletenessRuleLabel("on_complete", i, rule.ID, "emit"), rule.Emit)
-		if rule.FanOut != nil {
-			add(payloadCompletenessRuleLabel("on_complete", i, rule.ID, "fan_out.emit"), rule.FanOut.Emit)
-		}
-	}
-	if handler.Accumulate != nil {
-		for i, rule := range handler.Accumulate.OnComplete {
-			add(payloadCompletenessRuleLabel("accumulate.on_complete", i, rule.ID, "emit"), rule.Emit)
-			if rule.FanOut != nil {
-				add(payloadCompletenessRuleLabel("accumulate.on_complete", i, rule.ID, "fan_out.emit"), rule.FanOut.Emit)
-			}
-		}
-		if handler.Accumulate.OnTimeout != nil {
-			add(payloadCompletenessRuleLabel("accumulate.on_timeout", 0, handler.Accumulate.OnTimeout.ID, "emit"), handler.Accumulate.OnTimeout.Emit)
-			if handler.Accumulate.OnTimeout.FanOut != nil {
-				add(payloadCompletenessRuleLabel("accumulate.on_timeout", 0, handler.Accumulate.OnTimeout.ID, "fan_out.emit"), handler.Accumulate.OnTimeout.FanOut.Emit)
-			}
-		}
+	for _, site := range runtimecontracts.HandlerDeclarativeEmitSites(handler) {
+		add(payloadCompletenessDeclarativeSiteLabel(site), site.Spec)
 	}
 	if handler.Guard != nil {
 		if failureSpec, err := handler.Guard.FailureSpec(); err == nil {
@@ -181,6 +177,41 @@ func payloadCompletenessEmitSites(handler runtimecontracts.SystemNodeEventHandle
 			}
 		}
 	}
+	return out
+}
+
+func payloadCompletenessDeclaredFields(entry runtimecontracts.EventCatalogEntry) map[string]struct{} {
+	out := map[string]struct{}{}
+	for field := range entry.Payload.Properties {
+		field = strings.TrimSpace(field)
+		if field != "" {
+			out[field] = struct{}{}
+		}
+	}
+	for _, field := range append(entry.Required, entry.Payload.Required...) {
+		field = strings.TrimSpace(field)
+		if field != "" {
+			out[field] = struct{}{}
+		}
+	}
+	return out
+}
+
+func payloadCompletenessUndeclaredFields(fields, declared map[string]struct{}) []string {
+	if len(fields) == 0 || len(declared) == 0 {
+		return nil
+	}
+	out := make([]string, 0)
+	for field := range fields {
+		field = strings.TrimSpace(field)
+		if field == "" {
+			continue
+		}
+		if _, ok := declared[field]; !ok {
+			out = append(out, field)
+		}
+	}
+	sort.Strings(out)
 	return out
 }
 
@@ -209,16 +240,6 @@ func isRuntimeOwnedCanonicalContextField(field string) bool {
 	}
 }
 
-func payloadCompletenessRuleLabel(scope string, index int, id, suffix string) string {
-	scope = strings.TrimSpace(scope)
-	id = strings.TrimSpace(id)
-	suffix = strings.TrimSpace(suffix)
-	if id != "" {
-		return fmt.Sprintf("%s[%s].%s", scope, id, suffix)
-	}
-	return fmt.Sprintf("%s[%d].%s", scope, index, suffix)
-}
-
 func payloadCompletenessTriggerSchemaState(entry runtimecontracts.EventCatalogEntry, hasSchema bool, field string) string {
 	if !hasSchema {
 		return "no schema"
@@ -228,7 +249,7 @@ func payloadCompletenessTriggerSchemaState(entry runtimecontracts.EventCatalogEn
 		return "no"
 	}
 	required := map[string]struct{}{}
-	for _, item := range entry.Required {
+	for _, item := range append(entry.Required, entry.Payload.Required...) {
 		item = strings.TrimSpace(item)
 		if item != "" {
 			required[item] = struct{}{}
@@ -252,6 +273,48 @@ func payloadCompletenessEntitySchemaState(entityFields map[string]struct{}, fiel
 		return "yes"
 	}
 	return "no"
+}
+
+func payloadCompletenessDeclarativeSiteLabel(site runtimecontracts.HandlerDeclarativeEmitSite) string {
+	switch strings.TrimSpace(site.Source) {
+	case "handler.rules.emit":
+		return payloadCompletenessRuleLabel("rules", site.RuleIndex, site.RuleID, "emit")
+	case "handler.rules.fan_out.emit":
+		return payloadCompletenessRuleLabel("rules", site.RuleIndex, site.RuleID, "fan_out.emit")
+	case "handler.rules.emit_template":
+		return payloadCompletenessRuleLabel("rules", site.RuleIndex, site.RuleID, "emit_template")
+	case "handler.on_complete.emit":
+		return payloadCompletenessRuleLabel("on_complete", site.RuleIndex, site.RuleID, "emit")
+	case "handler.on_complete.fan_out.emit":
+		return payloadCompletenessRuleLabel("on_complete", site.RuleIndex, site.RuleID, "fan_out.emit")
+	case "handler.accumulate.on_complete.emit":
+		return payloadCompletenessRuleLabel("accumulate.on_complete", site.RuleIndex, site.RuleID, "emit")
+	case "handler.accumulate.on_complete.fan_out.emit":
+		return payloadCompletenessRuleLabel("accumulate.on_complete", site.RuleIndex, site.RuleID, "fan_out.emit")
+	case "handler.accumulate.on_timeout.emit":
+		return payloadCompletenessRuleLabel("accumulate.on_timeout", site.RuleIndex, site.RuleID, "emit")
+	case "handler.accumulate.on_timeout.fan_out.emit":
+		return payloadCompletenessRuleLabel("accumulate.on_timeout", site.RuleIndex, site.RuleID, "fan_out.emit")
+	case "handler.branch.then.emit":
+		return payloadCompletenessRuleLabel("branch", site.RuleIndex, site.RuleID, "then.emit")
+	case "handler.branch.else.emit":
+		return payloadCompletenessRuleLabel("branch", site.RuleIndex, site.RuleID, "else.emit")
+	default:
+		if label := strings.TrimSpace(site.SiteKey); label != "" {
+			return label
+		}
+		return strings.TrimSpace(site.Source)
+	}
+}
+
+func payloadCompletenessRuleLabel(scope string, index int, id, suffix string) string {
+	scope = strings.TrimSpace(scope)
+	id = strings.TrimSpace(id)
+	suffix = strings.TrimSpace(suffix)
+	if id != "" {
+		return fmt.Sprintf("%s[%s].%s", scope, id, suffix)
+	}
+	return fmt.Sprintf("%s[%d].%s", scope, index, suffix)
 }
 
 func payloadCompletenessMessage(nodeID, triggerEventType, emittedEventType, field, emitSiteLabel string, emitFieldTargets map[string]struct{}, triggerEntry runtimecontracts.EventCatalogEntry, hasTriggerSchema bool, entityFields map[string]struct{}) string {

--- a/internal/runtime/bootverify/workflow_payload_completeness_checks.go
+++ b/internal/runtime/bootverify/workflow_payload_completeness_checks.go
@@ -198,7 +198,7 @@ func payloadCompletenessDeclaredFields(entry runtimecontracts.EventCatalogEntry)
 }
 
 func payloadCompletenessUndeclaredFields(fields, declared map[string]struct{}) []string {
-	if len(fields) == 0 || len(declared) == 0 {
+	if len(fields) == 0 {
 		return nil
 	}
 	out := make([]string, 0)

--- a/internal/runtime/contracts/workflow_contract_emit.go
+++ b/internal/runtime/contracts/workflow_contract_emit.go
@@ -162,6 +162,12 @@ func EffectiveRuleEmitTemplateSpec(handler SystemNodeEventHandler, rule HandlerR
 		return EmitSpec{}, false
 	}
 	spec := cloneEmitSpec(handler.Emit)
+	if strings.TrimSpace(rule.Emit.From) != "" {
+		if strings.TrimSpace(spec.From) != "" && strings.TrimSpace(spec.From) != strings.TrimSpace(rule.Emit.From) {
+			return EmitSpec{}, false
+		}
+		spec.From = strings.TrimSpace(rule.Emit.From)
+	}
 	if spec.Fields == nil {
 		spec.Fields = map[string]ExpressionValue{}
 	}
@@ -345,6 +351,9 @@ func validateHandlerRuleEmitTemplateSpecialization(handler SystemNodeEventHandle
 		}
 		if !rule.Emit.Target.Empty() || rule.Emit.Broadcast {
 			return fmt.Errorf("UNSUPPORTED-EMIT: rules[%d].emit may only contribute fields in handler emit template specialization", idx)
+		}
+		if strings.TrimSpace(rule.Emit.From) != "" && strings.TrimSpace(handler.Emit.From) != "" && strings.TrimSpace(rule.Emit.From) != strings.TrimSpace(handler.Emit.From) {
+			return fmt.Errorf("INVALID-EMIT: rules[%d].emit.from conflicts with handler emit template from", idx)
 		}
 		if !rule.Emit.HasFields() {
 			return fmt.Errorf("INVALID-EMIT: handler emit template specialization requires rules[%d].emit.fields", idx)

--- a/internal/runtime/contracts/workflow_contract_emit_lowering.go
+++ b/internal/runtime/contracts/workflow_contract_emit_lowering.go
@@ -1,0 +1,271 @@
+package contracts
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+const (
+	EmitFromEntity  = "entity"
+	EmitFromPayload = "payload"
+)
+
+type EmitFieldLoweringContext struct {
+	NodeID           string
+	FlowID           string
+	TriggerEventType string
+	Site             string
+}
+
+func (b *WorkflowContractBundle) LowerEmitSpecFields(ctx EmitFieldLoweringContext, spec EmitSpec) (EmitSpec, error) {
+	spec = cloneEmitSpec(spec)
+	ctx = b.normalizeEmitFieldLoweringContext(ctx)
+	if spec.Empty() {
+		return spec, nil
+	}
+	if err := validateEmitFromSource(spec.From); err != nil {
+		return EmitSpec{}, emitLoweringError(ctx, err.Error())
+	}
+	if !emitSpecNeedsFieldLowering(spec) {
+		return spec, nil
+	}
+	eventType := spec.EventType()
+	if eventType == "" {
+		return EmitSpec{}, emitLoweringError(ctx, "emit.from and bare namespace emit.fields values require emit.event")
+	}
+	targetFields, required, err := b.emitPayloadTargetFields(ctx, eventType)
+	if err != nil {
+		return EmitSpec{}, emitLoweringError(ctx, err.Error())
+	}
+	fields := cloneExpressionValueMap(spec.Fields)
+	if len(fields) == 0 {
+		fields = map[string]ExpressionValue{}
+	}
+	for target, value := range fields {
+		target = strings.TrimSpace(target)
+		if target == "" {
+			continue
+		}
+		if !emitPayloadTargetDeclared(targetFields, target) {
+			return EmitSpec{}, emitLoweringError(ctx, fmt.Sprintf("emit.fields.%s is not declared by emitted event %s payload schema", target, eventType))
+		}
+		source := bareEmitNamespaceValue(value)
+		if source == "" {
+			continue
+		}
+		if err := validateEmitFromSource(source); err != nil {
+			return EmitSpec{}, emitLoweringError(ctx, err.Error())
+		}
+		if !emitSimplePayloadField(target) {
+			return EmitSpec{}, emitLoweringError(ctx, fmt.Sprintf("emit.fields.%s bare namespace value %q requires a top-level payload field target", target, source))
+		}
+		sourceFields, err := b.emitFieldSourceFields(ctx, source)
+		if err != nil {
+			return EmitSpec{}, emitLoweringError(ctx, err.Error())
+		}
+		if !emitPayloadTargetDeclared(sourceFields, target) {
+			return EmitSpec{}, emitLoweringError(ctx, fmt.Sprintf("emit.fields.%s source %s does not declare same-named field %s", target, source, target))
+		}
+		fields[target] = CELExpression(source + "." + target)
+	}
+	if source := strings.TrimSpace(spec.From); source != "" {
+		sourceFields, err := b.emitFieldSourceFields(ctx, source)
+		if err != nil {
+			return EmitSpec{}, emitLoweringError(ctx, err.Error())
+		}
+		for _, field := range required {
+			if field == "" {
+				continue
+			}
+			if _, explicit := fields[field]; explicit {
+				continue
+			}
+			if !emitPayloadTargetDeclared(sourceFields, field) {
+				return EmitSpec{}, emitLoweringError(ctx, fmt.Sprintf("emit.from %s cannot fill required emitted payload field %s because source %s does not declare it", source, field, source))
+			}
+			fields[field] = CELExpression(source + "." + field)
+		}
+	}
+	spec.From = ""
+	spec.Fields = fields
+	return spec, nil
+}
+
+func validateEmitFromSource(source string) error {
+	source = strings.TrimSpace(source)
+	switch source {
+	case "", EmitFromEntity, EmitFromPayload:
+		return nil
+	default:
+		return fmt.Errorf("emit.from source %q is unsupported; use entity or payload", source)
+	}
+}
+
+func emitSpecNeedsFieldLowering(spec EmitSpec) bool {
+	return EmitSpecNeedsFieldLowering(spec)
+}
+
+func EmitSpecNeedsFieldLowering(spec EmitSpec) bool {
+	if strings.TrimSpace(spec.From) != "" {
+		return true
+	}
+	for _, value := range spec.Fields {
+		if bareEmitNamespaceValue(value) != "" {
+			return true
+		}
+	}
+	return false
+}
+
+func bareEmitNamespaceValue(value ExpressionValue) string {
+	value.hydrate()
+	if value.Kind != ExpressionKindCEL {
+		return ""
+	}
+	switch strings.TrimSpace(value.CEL) {
+	case EmitFromEntity:
+		return EmitFromEntity
+	case EmitFromPayload:
+		return EmitFromPayload
+	default:
+		return ""
+	}
+}
+
+func (b *WorkflowContractBundle) normalizeEmitFieldLoweringContext(ctx EmitFieldLoweringContext) EmitFieldLoweringContext {
+	ctx.NodeID = strings.TrimSpace(ctx.NodeID)
+	ctx.FlowID = strings.TrimSpace(ctx.FlowID)
+	ctx.TriggerEventType = strings.TrimSpace(ctx.TriggerEventType)
+	ctx.Site = strings.TrimSpace(ctx.Site)
+	if ctx.Site == "" {
+		ctx.Site = "emit"
+	}
+	if b != nil && ctx.FlowID == "" && ctx.NodeID != "" {
+		if source, ok := b.NodeContractSource(ctx.NodeID); ok {
+			ctx.FlowID = strings.TrimSpace(source.FlowID)
+		}
+	}
+	return ctx
+}
+
+func (b *WorkflowContractBundle) emitPayloadTargetFields(ctx EmitFieldLoweringContext, eventType string) (map[string]struct{}, []string, error) {
+	if b == nil {
+		return nil, nil, fmt.Errorf("emit field lowering requires a workflow contract bundle")
+	}
+	entry, resolved, ok := b.ResolveFlowEventCatalogEntry(ctx.FlowID, eventType)
+	if !ok {
+		if platformEntry, platformKey, platformOK := PlatformEventCatalogEntry(b.Platform, eventType); platformOK {
+			entry = platformEntry
+			resolved = platformKey
+			ok = true
+		}
+	}
+	if !ok {
+		return nil, nil, fmt.Errorf("emit field lowering requires emitted event %s payload schema", strings.TrimSpace(eventType))
+	}
+	fields := eventPayloadDeclaredFields(entry)
+	required := eventPayloadRequiredFields(entry)
+	if len(fields) == 0 && len(required) == 0 {
+		return nil, nil, fmt.Errorf("emit field lowering requires emitted event %s payload schema", strings.TrimSpace(resolved))
+	}
+	for _, field := range required {
+		fields[field] = struct{}{}
+	}
+	return fields, required, nil
+}
+
+func (b *WorkflowContractBundle) emitFieldSourceFields(ctx EmitFieldLoweringContext, source string) (map[string]struct{}, error) {
+	switch strings.TrimSpace(source) {
+	case EmitFromEntity:
+		primary, err := b.ResolveFlowPrimaryEntity(ctx.FlowID)
+		if err != nil {
+			return nil, fmt.Errorf("emit.from entity requires a primary entity contract: %w", err)
+		}
+		fields := make(map[string]struct{}, len(primary.Contract.Fields))
+		for field := range primary.Contract.Fields {
+			field = strings.TrimSpace(field)
+			if field != "" {
+				fields[field] = struct{}{}
+			}
+		}
+		return fields, nil
+	case EmitFromPayload:
+		entry, resolved, ok := b.ResolveFlowEventCatalogEntry(ctx.FlowID, ctx.TriggerEventType)
+		if !ok {
+			if platformEntry, platformKey, platformOK := PlatformEventCatalogEntry(b.Platform, ctx.TriggerEventType); platformOK {
+				entry = platformEntry
+				resolved = platformKey
+				ok = true
+			}
+		}
+		if !ok {
+			return nil, fmt.Errorf("emit.from payload requires trigger event %s payload schema", strings.TrimSpace(ctx.TriggerEventType))
+		}
+		fields := eventPayloadDeclaredFields(entry)
+		for _, field := range eventPayloadRequiredFields(entry) {
+			fields[field] = struct{}{}
+		}
+		if len(fields) == 0 {
+			return nil, fmt.Errorf("emit.from payload requires trigger event %s payload schema", strings.TrimSpace(resolved))
+		}
+		return fields, nil
+	default:
+		return nil, fmt.Errorf("emit.from source %q is unsupported; use entity or payload", source)
+	}
+}
+
+func eventPayloadDeclaredFields(entry EventCatalogEntry) map[string]struct{} {
+	fields := map[string]struct{}{}
+	for field := range entry.Payload.Properties {
+		field = strings.TrimSpace(field)
+		if field != "" {
+			fields[field] = struct{}{}
+		}
+	}
+	return fields
+}
+
+func eventPayloadRequiredFields(entry EventCatalogEntry) []string {
+	return uniqueEmitFieldNames(entry.Required, entry.Payload.Required)
+}
+
+func uniqueEmitFieldNames(groups ...[]string) []string {
+	seen := map[string]struct{}{}
+	for _, group := range groups {
+		for _, field := range group {
+			field = strings.TrimSpace(field)
+			if field != "" {
+				seen[field] = struct{}{}
+			}
+		}
+	}
+	out := make([]string, 0, len(seen))
+	for field := range seen {
+		out = append(out, field)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func emitPayloadTargetDeclared(fields map[string]struct{}, target string) bool {
+	target = strings.TrimSpace(target)
+	if target == "" {
+		return false
+	}
+	_, ok := fields[target]
+	return ok
+}
+
+func emitSimplePayloadField(target string) bool {
+	target = strings.TrimSpace(target)
+	return target != "" && !strings.Contains(target, ".")
+}
+
+func emitLoweringError(ctx EmitFieldLoweringContext, message string) error {
+	prefix := strings.TrimSpace(ctx.Site)
+	if prefix == "" {
+		prefix = "emit"
+	}
+	return fmt.Errorf("INVALID-EMIT: %s: %s", prefix, strings.TrimSpace(message))
+}

--- a/internal/runtime/contracts/workflow_contract_emit_lowering_test.go
+++ b/internal/runtime/contracts/workflow_contract_emit_lowering_test.go
@@ -1,0 +1,208 @@
+package contracts
+
+import (
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestLowerEmitSpecFieldsLowersFromAndBareNamespaceValues(t *testing.T) {
+	bundle := emitFieldLoweringTestBundle()
+	spec := EmitSpec{
+		Event: "account.bucketed",
+		From:  "entity",
+		Fields: map[string]ExpressionValue{
+			"interest_score": CELExpression("payload"),
+			"tier":           CELExpression("payload.computed_tier"),
+		},
+	}
+
+	lowered, err := bundle.LowerEmitSpecFields(EmitFieldLoweringContext{
+		NodeID:           "bucket-node",
+		TriggerEventType: "account.scored",
+		Site:             "handler.emit",
+	}, spec)
+	if err != nil {
+		t.Fatalf("LowerEmitSpecFields error: %v", err)
+	}
+
+	if lowered.From != "" {
+		t.Fatalf("lowered From = %q, want empty canonical spec", lowered.From)
+	}
+	assertEmitCEL(t, lowered.Fields, "account_id", "entity.account_id")
+	assertEmitCEL(t, lowered.Fields, "bucket", "entity.bucket")
+	assertEmitCEL(t, lowered.Fields, "interest_score", "payload.interest_score")
+	assertEmitCEL(t, lowered.Fields, "tier", "payload.computed_tier")
+}
+
+func TestLowerEmitSpecFieldsExplicitFieldsWinAndOptionalsRemainExplicit(t *testing.T) {
+	bundle := emitFieldLoweringTestBundle()
+	spec := EmitSpec{
+		Event: "account.bucketed",
+		From:  "entity",
+		Fields: map[string]ExpressionValue{
+			"bucket":         CELExpression(`"manual"`),
+			"interest_score": CELExpression("payload"),
+		},
+	}
+
+	lowered, err := bundle.LowerEmitSpecFields(EmitFieldLoweringContext{
+		NodeID:           "bucket-node",
+		TriggerEventType: "account.scored",
+		Site:             "handler.emit",
+	}, spec)
+	if err != nil {
+		t.Fatalf("LowerEmitSpecFields error: %v", err)
+	}
+
+	assertEmitCEL(t, lowered.Fields, "account_id", "entity.account_id")
+	assertEmitCEL(t, lowered.Fields, "bucket", `"manual"`)
+	if _, ok := lowered.Fields["tier"]; ok {
+		t.Fatalf("optional tier was auto-filled by emit.from: %#v", lowered.Fields)
+	}
+}
+
+func TestLowerEmitSpecFieldsFailsClosed(t *testing.T) {
+	tests := []struct {
+		name string
+		spec EmitSpec
+		want string
+	}{
+		{
+			name: "missing source field",
+			spec: EmitSpec{Event: "account.bucketed", From: "payload"},
+			want: "source payload does not declare it",
+		},
+		{
+			name: "undeclared output field",
+			spec: EmitSpec{
+				Event: "account.bucketed",
+				From:  "entity",
+				Fields: map[string]ExpressionValue{
+					"extra": CELExpression("payload.interest_score"),
+				},
+			},
+			want: "emit.fields.extra is not declared",
+		},
+		{
+			name: "bare namespace missing same named field",
+			spec: EmitSpec{
+				Event: "account.bucketed",
+				Fields: map[string]ExpressionValue{
+					"tier": CELExpression("payload"),
+				},
+			},
+			want: "source payload does not declare same-named field tier",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := emitFieldLoweringTestBundle().LowerEmitSpecFields(EmitFieldLoweringContext{
+				NodeID:           "bucket-node",
+				TriggerEventType: "account.scored",
+				Site:             "handler.emit",
+			}, tc.spec)
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("LowerEmitSpecFields error = %v, want substring %q", err, tc.want)
+			}
+		})
+	}
+}
+
+func TestEmitFromSugarDoesNotBleedIntoTargetMatch(t *testing.T) {
+	var spec EmitSpec
+	err := yaml.Unmarshal([]byte(`
+event: account.bucketed
+from: entity
+target:
+  flow: account
+  match:
+    account_id: payload
+fields:
+  interest_score: payload
+`), &spec)
+	if err != nil {
+		t.Fatalf("yaml.Unmarshal: %v", err)
+	}
+
+	lowered, err := emitFieldLoweringTestBundle().LowerEmitSpecFields(EmitFieldLoweringContext{
+		NodeID:           "bucket-node",
+		TriggerEventType: "account.scored",
+		Site:             "handler.emit",
+	}, spec)
+	if err != nil {
+		t.Fatalf("LowerEmitSpecFields error: %v", err)
+	}
+
+	assertEmitCEL(t, lowered.Fields, "interest_score", "payload.interest_score")
+	assertEmitCEL(t, lowered.Target.Match, "account_id", "payload")
+}
+
+func TestMailboxPayloadDoesNotAcceptEmitFromSugar(t *testing.T) {
+	var spec MailboxWriteSpec
+	err := yaml.Unmarshal([]byte(`
+from: entity
+item_type:
+  literal: review
+severity:
+  literal: info
+summary:
+  literal: ready
+payload:
+  interest_score: payload
+`), &spec)
+	if err == nil || !strings.Contains(err.Error(), `UNDEFINED-FIELD: mailbox field "from"`) {
+		t.Fatalf("yaml.Unmarshal error = %v, want mailbox from-field rejection", err)
+	}
+}
+
+func emitFieldLoweringTestBundle() *WorkflowContractBundle {
+	return &WorkflowContractBundle{
+		RootEntities: EntityContractsDocument{
+			"account": {
+				Fields: map[string]EntityFieldDecl{
+					"account_id": {Type: "string"},
+					"bucket":     {Type: "string"},
+				},
+			},
+		},
+		Events: map[string]EventCatalogEntry{
+			"account.scored": {
+				Payload: EventPayloadSpec{
+					Properties: map[string]EventFieldSpec{
+						"account_id":      {Type: "string"},
+						"interest_score":  {Type: "number"},
+						"computed_tier":   {Type: "string"},
+						"unrelated_input": {Type: "string"},
+					},
+					Required: []string{"account_id", "interest_score"},
+				},
+			},
+			"account.bucketed": {
+				Payload: EventPayloadSpec{
+					Properties: map[string]EventFieldSpec{
+						"account_id":     {Type: "string"},
+						"bucket":         {Type: "string"},
+						"interest_score": {Type: "number"},
+						"tier":           {Type: "string"},
+					},
+				},
+				Required: []string{"account_id", "bucket", "interest_score"},
+			},
+		},
+	}
+}
+
+func assertEmitCEL(t *testing.T, fields map[string]ExpressionValue, field, want string) {
+	t.Helper()
+	got, ok := fields[field]
+	if !ok {
+		t.Fatalf("field %s missing from %#v", field, fields)
+	}
+	got.hydrate()
+	if got.Kind != ExpressionKindCEL || got.CEL != want {
+		t.Fatalf("field %s = %#v, want CEL %q", field, got, want)
+	}
+}

--- a/internal/runtime/contracts/workflow_contract_types.go
+++ b/internal/runtime/contracts/workflow_contract_types.go
@@ -1096,6 +1096,7 @@ func (e EventEmission) Empty() bool {
 
 type EmitSpec struct {
 	Event     string                     `yaml:"event"`
+	From      string                     `yaml:"from,omitempty"`
 	Fields    map[string]ExpressionValue `yaml:"fields"`
 	Target    EmitTargetSpec             `yaml:"target"`
 	Broadcast bool                       `yaml:"broadcast"`
@@ -1106,7 +1107,7 @@ func (e EmitSpec) EventType() string {
 }
 
 func (e EmitSpec) Empty() bool {
-	return strings.TrimSpace(e.Event) == "" && len(e.Fields) == 0 && e.Target.Empty() && !e.Broadcast
+	return strings.TrimSpace(e.Event) == "" && strings.TrimSpace(e.From) == "" && len(e.Fields) == 0 && e.Target.Empty() && !e.Broadcast
 }
 
 func (e EmitSpec) HasFields() bool {
@@ -1179,6 +1180,7 @@ func cloneEmitSpec(spec EmitSpec) EmitSpec {
 	target := spec.Target.Normalized()
 	return EmitSpec{
 		Event:     strings.TrimSpace(spec.Event),
+		From:      strings.TrimSpace(spec.From),
 		Fields:    cloneExpressionValueMap(spec.Fields),
 		Target:    cloneEmitTargetSpec(target),
 		Broadcast: spec.Broadcast,

--- a/internal/runtime/contracts/workflow_contract_yaml_handlers.go
+++ b/internal/runtime/contracts/workflow_contract_yaml_handlers.go
@@ -156,12 +156,13 @@ func (e *EmitSpec) UnmarshalYAML(node *yaml.Node) error {
 		for i := 0; i+1 < len(node.Content); i += 2 {
 			key := strings.TrimSpace(node.Content[i].Value)
 			switch key {
-			case "", "event", "fields", "target", "broadcast":
+			case "", "event", "from", "fields", "target", "broadcast":
 			default:
 				return fmt.Errorf("UNDEFINED-FIELD: emit field %q not in platform spec", key)
 			}
 		}
 		var event string
+		var from string
 		fields := map[string]ExpressionValue{}
 		var target EmitTargetSpec
 		var broadcast bool
@@ -171,6 +172,13 @@ func (e *EmitSpec) UnmarshalYAML(node *yaml.Node) error {
 			switch key {
 			case "event":
 				if err := value.Decode(&event); err != nil {
+					return err
+				}
+			case "from":
+				if err := value.Decode(&from); err != nil {
+					return err
+				}
+				if err := validateEmitFromSource(from); err != nil {
 					return err
 				}
 			case "fields":
@@ -193,6 +201,7 @@ func (e *EmitSpec) UnmarshalYAML(node *yaml.Node) error {
 		}
 		*e = EmitSpec{
 			Event:     strings.TrimSpace(event),
+			From:      strings.TrimSpace(from),
 			Fields:    fields,
 			Target:    target.Normalized(),
 			Broadcast: broadcast,
@@ -275,7 +284,7 @@ func decodeEmitTargetNode(node *yaml.Node) (EmitTargetSpec, error) {
 					return EmitTargetSpec{}, err
 				}
 			case "match":
-				match, err := decodeEmitFieldsNode(value)
+				match, err := decodeExpressionValueMapNode(value, "emit.target.match")
 				if err != nil {
 					return EmitTargetSpec{}, fmt.Errorf("INVALID-EMIT: emit.target.match must be a mapping: %w", err)
 				}
@@ -306,6 +315,10 @@ func decodeEmitTargetNode(node *yaml.Node) (EmitTargetSpec, error) {
 }
 
 func decodeEmitFieldsNode(node *yaml.Node) (map[string]ExpressionValue, error) {
+	return decodeExpressionValueMapNode(node, "emit.fields")
+}
+
+func decodeExpressionValueMapNode(node *yaml.Node, label string) (map[string]ExpressionValue, error) {
 	if node == nil {
 		return nil, nil
 	}
@@ -313,7 +326,7 @@ func decodeEmitFieldsNode(node *yaml.Node) (map[string]ExpressionValue, error) {
 		return nil, nil
 	}
 	if node.Kind != yaml.MappingNode {
-		return nil, fmt.Errorf("INVALID-EMIT: emit.fields must be a mapping")
+		return nil, fmt.Errorf("INVALID-EMIT: %s must be a mapping", label)
 	}
 	fields := make(map[string]ExpressionValue, len(node.Content)/2)
 	for i := 0; i+1 < len(node.Content); i += 2 {
@@ -323,7 +336,7 @@ func decodeEmitFieldsNode(node *yaml.Node) (map[string]ExpressionValue, error) {
 		}
 		value, err := decodeEmitFieldValueNode(node.Content[i+1])
 		if err != nil {
-			return nil, fmt.Errorf("INVALID-EMIT: emit.fields.%s: %w", target, err)
+			return nil, fmt.Errorf("INVALID-EMIT: %s.%s: %w", label, target, err)
 		}
 		fields[target] = value
 	}

--- a/internal/runtime/contracts/workflow_contract_yaml_rules.go
+++ b/internal/runtime/contracts/workflow_contract_yaml_rules.go
@@ -100,6 +100,7 @@ func decodeGuardEscalationNode(node *yaml.Node) (EmitSpec, error) {
 	switch node.Kind {
 	case yaml.MappingNode:
 		var event string
+		var from string
 		var fields map[string]ExpressionValue
 		for i := 0; i+1 < len(node.Content); i += 2 {
 			key := strings.TrimSpace(node.Content[i].Value)
@@ -107,6 +108,13 @@ func decodeGuardEscalationNode(node *yaml.Node) (EmitSpec, error) {
 			switch key {
 			case "event":
 				if err := value.Decode(&event); err != nil {
+					return EmitSpec{}, err
+				}
+			case "from":
+				if err := value.Decode(&from); err != nil {
+					return EmitSpec{}, err
+				}
+				if err := validateEmitFromSource(from); err != nil {
 					return EmitSpec{}, err
 				}
 			case "fields":
@@ -119,7 +127,7 @@ func decodeGuardEscalationNode(node *yaml.Node) (EmitSpec, error) {
 				return EmitSpec{}, fmt.Errorf("UNDEFINED-FIELD: guard.on_fail.escalate field %q not in platform spec", key)
 			}
 		}
-		return EmitSpec{Event: strings.TrimSpace(event), Fields: fields}, nil
+		return EmitSpec{Event: strings.TrimSpace(event), From: strings.TrimSpace(from), Fields: fields}, nil
 	default:
 		return EmitSpec{}, fmt.Errorf("guard.on_fail.escalate must be a mapping with event and optional fields")
 	}

--- a/internal/runtime/engine/executor.go
+++ b/internal/runtime/engine/executor.go
@@ -1012,7 +1012,10 @@ func (e *Executor) stepFanOut(frame *executionFrame) (bool, error) {
 			continue
 		}
 		eventType = e.resolveDeclarativeEmitEventType(frame, eventType)
-		emitSpec := spec.Emit
+		emitSpec, err := e.lowerEmitSpecForFrame(frame, "handler.fan_out.emit", spec.Emit)
+		if err != nil {
+			return false, err
+		}
 		emitSpec.Event = eventType
 		frame.state.SetFanOut("item", item)
 		payload := map[string]any{}
@@ -1385,7 +1388,10 @@ func lookupProjectionPath(raw map[string]any, path string) (any, bool) {
 }
 
 func (e *Executor) stepTransform(frame *executionFrame) error {
-	activeEmits := selectedDeclarativeEmitSpecs(frame.req.Handler, frame.rule)
+	activeEmits, err := e.selectedDeclarativeEmitSpecs(frame)
+	if err != nil {
+		return err
+	}
 	if len(activeEmits) != 1 {
 		return nil
 	}
@@ -1407,7 +1413,10 @@ func (e *Executor) stepTransform(frame *executionFrame) error {
 }
 
 func (e *Executor) stepEmits(frame *executionFrame) error {
-	activeEmits := selectedDeclarativeEmitSpecs(frame.req.Handler, frame.rule)
+	activeEmits, err := e.selectedDeclarativeEmitSpecs(frame)
+	if err != nil {
+		return err
+	}
 	if len(activeEmits) == 0 {
 		return nil
 	}
@@ -2058,6 +2067,41 @@ type activeDeclarativeEmitSpec struct {
 	Spec   runtimecontracts.EmitSpec
 }
 
+func (e *Executor) selectedDeclarativeEmitSpecs(frame *executionFrame) ([]activeDeclarativeEmitSpec, error) {
+	active := selectedDeclarativeEmitSpecs(frame.req.Handler, frame.rule)
+	for i := range active {
+		lowered, err := e.lowerEmitSpecForFrame(frame, active[i].Source, active[i].Spec)
+		if err != nil {
+			return nil, err
+		}
+		active[i].Spec = lowered
+	}
+	return active, nil
+}
+
+func (e *Executor) lowerEmitSpecForFrame(frame *executionFrame, site string, spec runtimecontracts.EmitSpec) (runtimecontracts.EmitSpec, error) {
+	if !runtimecontracts.EmitSpecNeedsFieldLowering(spec) {
+		return spec, nil
+	}
+	if e == nil || e.deps.Source == nil || frame == nil {
+		return runtimecontracts.EmitSpec{}, fmt.Errorf("%s uses emit field lowering sugar but runtime has no contract source for canonical lowering", strings.TrimSpace(site))
+	}
+	bundle, ok := semanticview.Bundle(e.deps.Source)
+	if !ok || bundle == nil {
+		return runtimecontracts.EmitSpec{}, fmt.Errorf("%s uses emit field lowering sugar but runtime source is not a workflow contract bundle", strings.TrimSpace(site))
+	}
+	triggerEvent := strings.TrimSpace(frame.req.HandlerEventKey)
+	if triggerEvent == "" {
+		triggerEvent = strings.TrimSpace(string(frame.req.Event.Type()))
+	}
+	return bundle.LowerEmitSpecFields(runtimecontracts.EmitFieldLoweringContext{
+		NodeID:           frame.req.NodeID.String(),
+		FlowID:           frame.req.FlowID.String(),
+		TriggerEventType: triggerEvent,
+		Site:             site,
+	}, spec)
+}
+
 func selectedDeclarativeEmitSpecs(handler runtimecontracts.SystemNodeEventHandler, rule *runtimecontracts.HandlerRuleEntry) []activeDeclarativeEmitSpec {
 	out := make([]activeDeclarativeEmitSpec, 0, 2)
 	if rule != nil {
@@ -2398,7 +2442,10 @@ func (e *Executor) applyGuardFailure(frame *executionFrame, spec *runtimecontrac
 		eventType := parsed.EventType
 		frame.result.Status = OutcomeEscalated
 		frame.result.ActionsExecuted = append(frame.result.ActionsExecuted, "escalate:"+eventType)
-		emitSpec := failureSpec.EscalationEmitSpec()
+		emitSpec, err := e.lowerEmitSpecForFrame(frame, "guard.on_fail.escalate", failureSpec.EscalationEmitSpec())
+		if err != nil {
+			return err
+		}
 		emitSpec.Event = eventType
 		payload := map[string]any{}
 		transformed, err := emitFieldsPayload(e.currentContext(frame), frame.state, emitSpec, workflowexpr.ValueExpressionOptions{})

--- a/internal/runtime/engine/executor_test.go
+++ b/internal/runtime/engine/executor_test.go
@@ -2224,6 +2224,94 @@ func TestExecutor_RulesEmitTemplateSpecializationQueuesOneMergedEvent(t *testing
 	}
 }
 
+func TestExecutor_EmitFromLoweringQueuesCanonicalPayload(t *testing.T) {
+	outbox := &recordingEmitOutbox{}
+	exec, err := NewExecutor(RuntimeDependencies{
+		Source:        emitFromExecutorSource(),
+		StateRepo:     stubStateRepo{},
+		TxRunner:      stubRunner{},
+		Locker:        stubLocker{},
+		Outbox:        outbox,
+		Dispatcher:    stubDispatcher{},
+		PayloadShaper: stubPayloadShaper{},
+		MaxChainDepth: 5,
+	}, stubEvaluator{})
+	if err != nil {
+		t.Fatalf("NewExecutor error: %v", err)
+	}
+
+	result, err := exec.Execute(context.Background(), ExecutionRequest{
+		EntityID:   "entity-1",
+		NodeID:     "bucket-node",
+		ChainDepth: 1,
+		Event: eventtest.RootIngress(
+			"evt-1",
+			"account.scored",
+			"",
+			"",
+			mustEncodeJSON(t, map[string]any{"interest_score": 0.91, "computed_tier": "gold"}),
+			0,
+			"",
+			"",
+			events.EventEnvelope{},
+			time.Time{},
+		),
+		Handler: runtimecontracts.SystemNodeEventHandler{
+			Emit: runtimecontracts.EmitSpec{
+				Event: "account.bucketed",
+				From:  "entity",
+				Fields: map[string]runtimecontracts.ExpressionValue{
+					"interest_score": runtimecontracts.CELExpression("payload"),
+					"tier":           runtimecontracts.CELExpression("payload.computed_tier"),
+				},
+			},
+		},
+		State: testStateSnapshot("pending", map[string]any{
+			"account_id": "acct-1",
+			"bucket":     "vip",
+		}, nil, map[string]map[string]any{}),
+	})
+	if err != nil {
+		t.Fatalf("Execute error: %v", err)
+	}
+	if got := len(result.EmitIntents); got != 1 {
+		t.Fatalf("EmitIntents len = %d, want 1", got)
+	}
+	if got := string(result.EmitIntents[0].Event.Type()); got != "account.bucketed" {
+		t.Fatalf("emit event = %q, want account.bucketed", got)
+	}
+	payload := eventPayloadMap(t, result.EmitIntents[0].Event)
+	if got := payload["account_id"]; got != "acct-1" {
+		t.Fatalf("account_id = %#v, want acct-1", got)
+	}
+	if got := payload["bucket"]; got != "vip" {
+		t.Fatalf("bucket = %#v, want vip", got)
+	}
+	if got := payload["interest_score"]; got != 0.91 {
+		t.Fatalf("interest_score = %#v, want 0.91", got)
+	}
+	if got := payload["tier"]; got != "gold" {
+		t.Fatalf("tier = %#v, want gold", got)
+	}
+	if got := payload["shaped_for"]; got != "account.bucketed" {
+		t.Fatalf("shaped_for = %#v, want account.bucketed", got)
+	}
+	if got := len(outbox.intents); got != 1 {
+		t.Fatalf("outbox intents len = %d, want 1", got)
+	}
+}
+
+func TestExecutor_EmitFromLoweringRequiresCanonicalBundleAtRuntime(t *testing.T) {
+	exec := &Executor{}
+	_, err := exec.lowerEmitSpecForFrame(&executionFrame{}, "handler.emit", runtimecontracts.EmitSpec{
+		Event: "account.bucketed",
+		From:  "entity",
+	})
+	if err == nil || !strings.Contains(err.Error(), "runtime has no contract source for canonical lowering") {
+		t.Fatalf("lowerEmitSpecForFrame error = %v, want missing contract source failure", err)
+	}
+}
+
 func TestExecutor_OnSuccessEmitWithMatchedRuleQueuesRuleThenSuccess(t *testing.T) {
 	outbox := &recordingEmitOutbox{}
 	exec, err := NewExecutor(RuntimeDependencies{
@@ -2289,6 +2377,41 @@ func TestExecutor_OnSuccessEmitWithMatchedRuleQueuesRuleThenSuccess(t *testing.T
 	if got := successPayload["audit"]; got != "ok" {
 		t.Fatalf("success payload audit = %#v, want ok", got)
 	}
+}
+
+func emitFromExecutorSource() semanticview.Source {
+	return semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
+		RootEntities: runtimecontracts.EntityContractsDocument{
+			"account": {
+				Fields: map[string]runtimecontracts.EntityFieldDecl{
+					"account_id": {Type: "string"},
+					"bucket":     {Type: "string"},
+				},
+			},
+		},
+		Events: map[string]runtimecontracts.EventCatalogEntry{
+			"account.scored": {
+				Payload: runtimecontracts.EventPayloadSpec{
+					Properties: map[string]runtimecontracts.EventFieldSpec{
+						"interest_score": {Type: "number"},
+						"computed_tier":  {Type: "string"},
+					},
+					Required: []string{"interest_score"},
+				},
+			},
+			"account.bucketed": {
+				Payload: runtimecontracts.EventPayloadSpec{
+					Properties: map[string]runtimecontracts.EventFieldSpec{
+						"account_id":     {Type: "string"},
+						"bucket":         {Type: "string"},
+						"interest_score": {Type: "number"},
+						"tier":           {Type: "string"},
+					},
+				},
+				Required: []string{"account_id", "bucket", "interest_score"},
+			},
+		},
+	})
 }
 
 func TestExecutor_OnSuccessEmitFiresWhenRulesDoNotMatch(t *testing.T) {

--- a/internal/runtime/pipeline/node_declarative.go
+++ b/internal/runtime/pipeline/node_declarative.go
@@ -697,8 +697,14 @@ func emitSitesReferenceEntity(handler SystemNodeEventHandler) bool {
 }
 
 func emitReferencesEntity(spec runtimecontracts.EmitSpec) bool {
+	if strings.TrimSpace(spec.From) == runtimecontracts.EmitFromEntity {
+		return true
+	}
 	for _, value := range spec.Fields {
 		if value.Kind == runtimecontracts.ExpressionKindCEL && workflowexpr.ExpressionReferencesEntity(value.CEL) {
+			return true
+		}
+		if value.Kind == runtimecontracts.ExpressionKindCEL && strings.TrimSpace(value.CEL) == runtimecontracts.EmitFromEntity {
 			return true
 		}
 	}

--- a/internal/runtime/semanticview/authored_emit_sites.go
+++ b/internal/runtime/semanticview/authored_emit_sites.go
@@ -2,7 +2,6 @@ package semanticview
 
 import (
 	"sort"
-	"strconv"
 	"strings"
 
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
@@ -39,6 +38,9 @@ func AuthoredEmitSites(source Source) []AuthoredEmitSite {
 	builder := authoredEmitSiteBuilder{
 		seen: map[string]struct{}{},
 	}
+	if bundle, ok := Bundle(source); ok {
+		builder.bundle = bundle
+	}
 	projectScopes := sortedAuthoredProjectScopes(source.ProjectScopes())
 	for _, scope := range projectScopes {
 		if authoredEmitSiteSkipsProjectScope(scope) {
@@ -71,8 +73,9 @@ func authoredEmitSiteSkipsProjectScope(scope ProjectScope) bool {
 }
 
 type authoredEmitSiteBuilder struct {
-	seen  map[string]struct{}
-	sites []AuthoredEmitSite
+	bundle *runtimecontracts.WorkflowContractBundle
+	seen   map[string]struct{}
+	sites  []AuthoredEmitSite
 }
 
 func (b *authoredEmitSiteBuilder) appendScope(kind AuthoredEmitSiteSourceKind, scopeKey, flowID, flowPath, flowPackageKey string, nodes map[string]runtimecontracts.SystemNodeContract) {
@@ -98,6 +101,16 @@ func (b *authoredEmitSiteBuilder) appendHandlerSites(kind AuthoredEmitSiteSource
 		if spec.Empty() {
 			return
 		}
+		if b.bundle != nil {
+			if lowered, err := b.bundle.LowerEmitSpecFields(runtimecontracts.EmitFieldLoweringContext{
+				NodeID:           nodeID,
+				FlowID:           flowID,
+				TriggerEventType: handlerEvent,
+				Site:             siteKey,
+			}, spec); err == nil {
+				spec = lowered
+			}
+		}
 		id := authoredEmitSiteIdentity(flowID, scopeKey, nodeKey, handlerEvent, siteKey)
 		if _, ok := b.seen[id]; ok {
 			return
@@ -120,50 +133,13 @@ func (b *authoredEmitSiteBuilder) appendHandlerSites(kind AuthoredEmitSiteSource
 			Handler:        handler,
 		})
 	}
-	templateSites := runtimecontracts.HandlerRuleEmitTemplateSites(handler)
-	if len(templateSites) == 0 {
-		add("handler.emit", "handler.emit", "", handler.Emit)
-	} else {
-		for _, site := range templateSites {
-			add(site.Source, site.SiteKey, site.RuleID, site.Spec)
-		}
+	for _, site := range runtimecontracts.HandlerDeclarativeEmitSites(handler) {
+		add(site.Source, site.SiteKey, site.RuleID, site.Spec)
 	}
-	add("handler.on_success.emit", "handler.on_success.emit", "", handler.OnSuccess.Emit)
 	if handler.Guard != nil {
 		if emitSpec := authoredGuardEscalationEmitSpec(handler.Guard); !emitSpec.Empty() {
 			add("handler.guard.on_fail.escalate", "handler.guard.on_fail.escalate", handler.Guard.ID, emitSpec)
 		}
-	}
-	if len(templateSites) == 0 {
-		for idx, rule := range handler.Rules {
-			add("handler.rules.emit", indexedAuthoredEmitSiteKey("handler.rules", idx, "emit"), rule.ID, rule.Emit)
-			if rule.FanOut != nil {
-				add("handler.rules.fan_out.emit", indexedAuthoredEmitSiteKey("handler.rules", idx, "fan_out.emit"), rule.ID, rule.FanOut.Emit)
-			}
-		}
-	}
-	for idx, rule := range handler.OnComplete {
-		add("handler.on_complete.emit", indexedAuthoredEmitSiteKey("handler.on_complete", idx, "emit"), rule.ID, rule.Emit)
-		if rule.FanOut != nil {
-			add("handler.on_complete.fan_out.emit", indexedAuthoredEmitSiteKey("handler.on_complete", idx, "fan_out.emit"), rule.ID, rule.FanOut.Emit)
-		}
-	}
-	if handler.Accumulate != nil {
-		for idx, rule := range handler.Accumulate.OnComplete {
-			add("handler.accumulate.on_complete.emit", indexedAuthoredEmitSiteKey("handler.accumulate.on_complete", idx, "emit"), rule.ID, rule.Emit)
-			if rule.FanOut != nil {
-				add("handler.accumulate.on_complete.fan_out.emit", indexedAuthoredEmitSiteKey("handler.accumulate.on_complete", idx, "fan_out.emit"), rule.ID, rule.FanOut.Emit)
-			}
-		}
-		if handler.Accumulate.OnTimeout != nil {
-			add("handler.accumulate.on_timeout.emit", "handler.accumulate.on_timeout.emit", handler.Accumulate.OnTimeout.ID, handler.Accumulate.OnTimeout.Emit)
-			if handler.Accumulate.OnTimeout.FanOut != nil {
-				add("handler.accumulate.on_timeout.fan_out.emit", "handler.accumulate.on_timeout.fan_out.emit", handler.Accumulate.OnTimeout.ID, handler.Accumulate.OnTimeout.FanOut.Emit)
-			}
-		}
-	}
-	if handler.FanOut != nil {
-		add("handler.fan_out.emit", "handler.fan_out.emit", "", handler.FanOut.Emit)
 	}
 }
 
@@ -317,10 +293,6 @@ func authoredEmitSiteIdentity(flowID, scopeKey, nodeKey, handlerEvent, siteKey s
 		strings.TrimSpace(handlerEvent),
 		strings.TrimSpace(siteKey),
 	}, "\x1f")
-}
-
-func indexedAuthoredEmitSiteKey(prefix string, index int, suffix string) string {
-	return prefix + "[" + strconv.Itoa(index) + "]." + suffix
 }
 
 func authoredGuardEscalationEmitSpec(guard *runtimecontracts.GuardSpec) runtimecontracts.EmitSpec {

--- a/internal/runtime/semanticview/authored_emit_sites_test.go
+++ b/internal/runtime/semanticview/authored_emit_sites_test.go
@@ -113,6 +113,25 @@ func TestAuthoredEmitSites_UsesRulesEmitTemplateEffectiveSite(t *testing.T) {
 	}
 }
 
+func TestAuthoredEmitSites_LowersEmitFromToCanonicalFields(t *testing.T) {
+	source := loadAuthoredEmitSiteLoweringFixture(t)
+
+	sites := AuthoredEmitSites(source)
+	matches := authoredEmitSitesByFlowNodeEvent(sites, "", "dispatcher", "market_research.scan_assigned")
+	if len(matches) != 1 {
+		t.Fatalf("expected one lowered authored emit site, got %d: %#v", len(matches), authoredEmitSiteSummaries(sites))
+	}
+	if matches[0].Spec.From != "" {
+		t.Fatalf("semantic view retained authored emit.from = %q", matches[0].Spec.From)
+	}
+	if expr := matches[0].Spec.Fields["scan_id"]; expr.Kind != runtimecontracts.ExpressionKindCEL || expr.CEL != "entity.scan_id" {
+		t.Fatalf("scan_id field = %#v, want CEL entity.scan_id", expr)
+	}
+	if expr := matches[0].Spec.Fields["geography"]; expr.Kind != runtimecontracts.ExpressionKindCEL || expr.CEL != "payload.geography" {
+		t.Fatalf("geography field = %#v, want CEL payload.geography", expr)
+	}
+}
+
 func TestAuthoredEmitSites_DeduplicatesPackageProjectionWithoutCollapsingDistinctSources(t *testing.T) {
 	source := loadAuthoredEmitSiteFixture(t, authoredEmitSiteFixture{
 		rootNodeID:      "root-node",
@@ -284,6 +303,69 @@ flows: []
 		writeSemanticviewFixtureFile(t, filepath.Join(root, "flows", "support", "addon", "nodes.yaml"), authoredEmitSiteNodeYAML(opts.nestedPackageNodeID, "support.start", opts.nestedPackageEmit, "", false))
 	}
 
+	bundle, err := runtimecontracts.LoadWorkflowContractBundleWithOverrides(repoRoot, root, runtimecontracts.DefaultPlatformSpecFile(repoRoot))
+	if err != nil {
+		t.Fatalf("LoadWorkflowContractBundleWithOverrides: %v", err)
+	}
+	return Wrap(bundle)
+}
+
+func loadAuthoredEmitSiteLoweringFixture(t *testing.T) Source {
+	t.Helper()
+	repoRoot, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd: %v", err)
+	}
+	repoRoot = filepath.Clean(filepath.Join(repoRoot, "..", "..", ".."))
+	root := t.TempDir()
+	writeSemanticviewFixtureFile(t, filepath.Join(root, "package.yaml"), `
+name: authored-emit-site-lowering
+version: "1.0.0"
+platform_version: ">=0.7.0 <0.8.0"
+flows: []
+`)
+	writeSemanticviewFixtureFile(t, filepath.Join(root, "schema.yaml"), `
+initial_state: pending
+states: [pending, done]
+terminal_states: [done]
+pins:
+  inputs:
+    events: [scan.corpus_dispatch]
+  outputs:
+    events: [market_research.scan_assigned]
+`)
+	writeSemanticviewFixtureFile(t, filepath.Join(root, "events.yaml"), `
+scan.corpus_dispatch:
+  geography:
+    type: string
+  required: [geography]
+market_research.scan_assigned:
+  scan_id:
+    type: string
+  geography:
+    type: string
+  required: [scan_id, geography]
+`)
+	writeSemanticviewFixtureFile(t, filepath.Join(root, "entities.yaml"), `
+scan:
+  scan_id:
+    type: text
+`)
+	writeSemanticviewFixtureFile(t, filepath.Join(root, "policy.yaml"), "{}\n")
+	writeSemanticviewFixtureFile(t, filepath.Join(root, "tools.yaml"), "{}\n")
+	writeSemanticviewFixtureFile(t, filepath.Join(root, "agents.yaml"), "{}\n")
+	writeSemanticviewFixtureFile(t, filepath.Join(root, "nodes.yaml"), `
+dispatcher:
+  id: dispatcher
+  execution_type: system_node
+  event_handlers:
+    scan.corpus_dispatch:
+      emit:
+        event: market_research.scan_assigned
+        from: entity
+        fields:
+          geography: payload
+`)
 	bundle, err := runtimecontracts.LoadWorkflowContractBundleWithOverrides(repoRoot, root, runtimecontracts.DefaultPlatformSpecFile(repoRoot))
 	if err != nil {
 		t.Fatalf("LoadWorkflowContractBundleWithOverrides: %v", err)

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -288,9 +288,13 @@ contract_formats:
       rule: |
         Event payloads are producer-complete only. Every declared
         payload field must be populated by the active emit site's
-        `emit.fields`. No payload defaults. No implicit passthrough.
-        No nested `payload:` block. Missing declared fields and
-        undeclared emitted fields are contract violations.
+        canonical explicit `emit.fields` map. `emit.from` and same-named
+        bare namespace `emit.fields` values are only authoring sugar for
+        system-node emitted payload maps; they lower to the same explicit map
+        before validation, generated/semantic views, and runtime execution. No
+        payload defaults. No implicit passthrough. No nested `payload:` block.
+        Missing declared fields and undeclared emitted fields are contract
+        violations.
       envelope_split: |
         Envelope fields are runtime-owned and are not author-declared
         in event schemas. Consumers access them through event.*,
@@ -1229,8 +1233,10 @@ event_payload_migration:
       Author-declared payload fields are accessed through payload.*.
     strict_payload_completeness: |
       Event payloads are producer-complete only. Every declared payload
-      field must be populated by the emitting surface's emit.fields. No
-      payload defaults, no implicit passthrough, no undeclared extras.
+      field must be populated by the emitting surface's canonical explicit
+      emit.fields. `emit.from` lowering may fill required declared fields before
+      completeness checks, but it is not runtime passthrough. No payload
+      defaults, no implicit passthrough, no undeclared extras.
     retired:
     - nested payload wrappers
     - jsonb payload fields
@@ -1796,6 +1802,27 @@ handler_specification:
         ordinary rules emit sites, on_complete, accumulate.on_timeout, or fan_out emit, boot fails with ambiguity. Payload
         ownership must move to the active emit site. The only approved additive rules success surface is explicit
         on_success.emit, which is not a handler-level emit overload.
+      emit_field_lowering:
+        syntax: "`emit.from` is an optional sibling of `emit.event`, `emit.fields`, `emit.target`, and `emit.broadcast`.
+          It is valid only on emitted-event payload `EmitSpec` surfaces."
+        allowed_sources: "`entity` and `payload` only. The value names exactly one source namespace; lists, fallbacks,
+          wildcards, multi-source selection, and heuristic matching are invalid."
+        lowering: "`emit.from: <source>` fills required declared payload fields for the emitted event when the same-named
+          field exists in the source and the target field is not explicitly present in `emit.fields`. Optional payload fields
+          are never auto-filled; authors opt into optionals through explicit `emit.fields` entries."
+        field_value_micro_sugar: "Inside emitted payload `emit.fields` only, a bare namespace value means same-named source
+          field: `interest_score: payload` lowers to `interest_score: payload.interest_score`; `bucket: entity` lowers to
+          `bucket: entity.bucket`. Explicit dotted CEL values remain the canonical authoring form for renames and computed
+          selections."
+        canonical_output: The generated/semantic view and every validator/runtime consumer see the lowered canonical explicit
+          `emit.fields` map with `emit.from` removed. Runtime evaluates only that explicit map; it never performs implicit
+          entity or trigger-payload passthrough.
+        fail_closed: Missing source namespace, invalid source namespace, missing source field, missing emitted event payload
+          schema, missing required emitted payload field after lowering, undeclared target payload field, and envelope-owned
+          payload keys are hard invalidity.
+        excluded_surfaces: This sugar is not valid for `config_from`, `emit.target.match`, action mailbox payloads,
+          artifact-repo payload/provenance maps, connect maps, or data-handoff maps. Those remain separate mapping surfaces
+          and must not inherit `emit.from` or bare namespace field-value lowering.
       on_success:
         field: on_success
         type: object
@@ -1830,11 +1857,14 @@ handler_specification:
         description: string — human-readable note
       emit_template_specialization:
         syntax: A rules handler may declare handler-level emit as the template, with `emit.event` and optional shared
-          `emit.fields`. Each rule then declares `emit.fields` without `emit.event` to add branch-specific fields. `emit`
-          remains one object shape everywhere, `{event?, fields?, target?, broadcast?}`.
-        field_values: All `emit.fields` values use the normal CEL expression string grammar. String constants are CEL string
-          literals, for example YAML value `'"high"'`. The platform does not support `emit_fields`, flattened rule emit
-          payload maps, `literal`, `value`, or any second field-value dialect for this specialization.
+          `emit.from` / `emit.fields`. Each rule then declares `emit.fields` and may declare the same `emit.from` without
+          `emit.event` to add branch-specific fields. `emit` remains one object shape everywhere, `{event?, from?, fields?,
+          target?, broadcast?}`.
+        field_values: All `emit.fields` values use the normal CEL expression string grammar after emitted-payload lowering.
+          String constants are CEL string literals, for example YAML value `'"high"'`. The same-named bare namespace
+          micro-sugar described in `emit_field_lowering` is the only additional emitted-payload field-value shorthand.
+          The platform does not support `emit_fields`, flattened rule emit payload maps, `literal`, `value`, or any second
+          field-value dialect for this specialization.
         matching: Rules keep ordered first-match semantics. Threshold-style overlapping rules are valid when ordered from
           most specific to least specific; the platform does not fail closed merely because multiple conditions could be true.
         required_else: Every rules emit template specialization must include an `else` rule so every successful rules-handler
@@ -1843,10 +1873,10 @@ handler_specification:
           one effective emit. Runtime evaluates that merged effective emit's fields, then emits its inherited `emit.event`.
         fill_only: Rule specialization fields are fill-only. A rule field that redefines a handler template field is invalid
           and boot fails closed.
-        unsupported_combinations: Rule-level specialization may not set `emit.event`, `emit.target`, or `emit.broadcast`;
-          those are not template refinements in this slice. Handler-level `on_success.emit` remains the separate additive
-          two-event surface and is not part of template specialization. on_complete, accumulate.on_timeout, fan_out, and
-          action-originated emits are out of this specialization slice.
+        unsupported_combinations: Rule-level specialization may not set `emit.event`, `emit.target`, or `emit.broadcast`.
+          If both handler template and rule specialization declare `emit.from`, the values must match. Handler-level
+          `on_success.emit` remains the separate additive two-event surface and is not part of template specialization.
+          on_complete, accumulate.on_timeout, fan_out, and action-originated emits are out of this specialization slice.
         proof_consumers: Bootverify, semantic view, produces derivation, route authority, runtime execution, and pipeline/outbox
           proof consume the same merged effective emit, not the raw handler template and raw rule specialization as separate
           events.
@@ -2816,10 +2846,12 @@ engine:
       agents: Not constrained. Multiple agents may subscribe to the same event freely.
       enforcement: Boot validation rejects duplicate node handlers for the same event.
     emit_payload_default: 'For supported declarative system-node emit sites, the platform constructs the business payload by:
-      1. Start from an empty payload. 2. Evaluate emit.fields, if present, into the payload. 3. Attach runtime-owned envelope
-      context on the emitted event carrier rather than copying it into payload. There is no implicit entity or trigger-payload
-      passthrough on this surface. Runtime rejects authored envelope-owned keys in emit.fields fail-closed. Runtime also validates
-      the resulting payload fail-closed: undeclared producer-authored payload fields are rejected, not silently trimmed.'
+      1. Lower emitted-payload authoring sugar (`emit.from` and bare namespace same-named `emit.fields` values) to a canonical
+      explicit emit.fields map. 2. Start from an empty payload. 3. Evaluate the canonical emit.fields, if present, into the
+      payload. 4. Attach runtime-owned envelope context on the emitted event carrier rather than copying it into payload.
+      There is no implicit entity or trigger-payload passthrough on this surface. Runtime rejects authored envelope-owned keys
+      in emit.fields fail-closed. Runtime also validates the resulting payload fail-closed: undeclared producer-authored payload
+      fields are rejected, not silently trimmed.'
     dual_path_events: An event can be both an input pin (arriving from outside the flow) and internally generated (emitted
       by a handler within the flow). The system node handler processes it identically regardless of source. No priority or
       deduplication between paths — if the same event fires from both, it runs twice (idempotency_key in the events table
@@ -9795,13 +9827,15 @@ observation_model:
       description: Rules for constructing emitted event payloads on supported system-node runtime emit surfaces.
       declarative_system_node_emit_surface:
         construction_order:
-        - 1. Start from an empty business payload
-        - 2. Evaluate emit.fields for the active emit site, if present
-        - 3. Attach runtime-owned envelope context to the emitted event carrier; envelope fields are not copied into payload
+        - 1. Lower emitted-payload `emit.from` and bare namespace field-value sugar to the canonical explicit emit.fields map
+        - 2. Start from an empty business payload
+        - 3. Evaluate canonical emit.fields for the active emit site, if present
+        - 4. Attach runtime-owned envelope context to the emitted event carrier; envelope fields are not copied into payload
         ownership_rule: Runtime-owned envelope fields belong to the event carrier, not to emit.fields or payload.*
-        note: This surface has no implicit entity passthrough or trigger-payload passthrough. If an emitted event needs a field
-          beyond the runtime-owned envelope context, the producer must declare it explicitly in emit.fields at the active emit
-          site. Consumers read envelope fields through event.*.
+        note: This surface has no implicit entity passthrough or trigger-payload passthrough. `emit.from` is compile-time
+          lowering to explicit fields, not a runtime copy source. If an emitted event needs a field beyond the runtime-owned
+          envelope context, the producer must declare it explicitly in canonical emit.fields at the active emit site. Consumers
+          read envelope fields through event.*.
         runtime_validation:
           description: Runtime validates the emitted payload fail-closed on this surface.
           validation_view: Validate the producer-authored payload carrier against the target event schema after canonical
@@ -10369,14 +10403,22 @@ static_analyzer:
       - agent write proof via save_entity_field
     proof_carriers:
       explicit_emit_fields:
-        valid_for: producer-authored payload keys explicitly declared in emit.fields at the active emit site
+        valid_for: producer-authored payload keys in the canonical explicit emit.fields map at the active emit site
+      lowered_emit_from:
+        valid_for: required declared emitted payload fields filled by `emit.from` before validation when the same-named source
+          field exists in exactly one allowed source namespace (`entity` or `payload`)
+      lowered_bare_namespace_field_values:
+        valid_for: explicit emitted payload field entries whose value is the bare allowed namespace (`entity` or `payload`),
+          lowered to the same-named dotted source reference before expression validation
       non_payload_envelope_context:
         valid_for: runtime-owned envelope fields accessed through event.* rather than payload completeness proof
     no_emit_fields_rule:
-      description: When emit.fields is absent, no producer-authored payload fields are statically provable in this slice.
-    rule: For each required emitted-event payload field, emit hard-invalidity unless the field is explicitly covered by emit.fields
-      at the active emit site. Envelope-owned fields do not clear this proof because they are not payload carriers. The finding
-      message must say the field is not statically provable in the emitted payload.
+      description: When both canonical emit.fields and valid lowered emit.from coverage are absent, no producer-authored payload
+        fields are statically provable in this slice.
+    rule: For each required emitted-event payload field, emit hard-invalidity unless the field is covered by the canonical
+      explicit emit.fields map after emitted-payload lowering at the active emit site. Envelope-owned fields do not clear this
+      proof because they are not payload carriers. The finding message must say the field is not statically provable in the
+      emitted payload.
   slice_3_input_pin_producer_path_satisfaction:
     id: input_pin_wiring
     domain: semantic_drift
@@ -10902,7 +10944,7 @@ static_analyzer:
       - handler guards
       - handler conditions
       - on_complete and rules conditions
-      - emit.fields expressions
+      - canonical emit.fields expressions after emitted-payload lowering
       - data_accumulation expressions
       - query/filter expressions on entity paths
       excludes:


### PR DESCRIPTION
Closes #1683

## Summary

Adds the approved emitted-payload `EmitSpec` lowering sugar:

- `emit.from: entity|payload` fills missing required declared emitted-event payload fields from same-named source fields.
- Bare namespace field values such as `interest_score: payload` lower to `payload.interest_score` inside emitted payload `fields` only.
- Lowering produces canonical explicit `EmitSpec.Fields` before payload completeness, expression validation, semantic/generated views, and runtime emission.
- Runtime evaluates only the canonical explicit map and fails closed if unlowered emit sugar reaches execution without bundle context.

## Governing Refs / Context

- Binding issue/gate: #1683 lead direction and approved `Pre-Implementation Coverage Audit` / independent gate outcome.
- Parent tracker: #1464 remains open for non-emit mapping sugar surfaces.
- Authoritative spec updated in `platform-spec.yaml` for `emit.from`, same-named bare namespace lowering, canonical generated view requirements, fail-closed validation, and explicit non-goals.

## Semantic Migration

- New canonical owner: `WorkflowContractBundle.LowerEmitSpecFields`.
- Old non-authoritative paths now invalid: parser-local sugar interpretation, runtime implicit passthrough, per-consumer raw `EmitSpec.Fields` interpretation, and accidental `emit.target.match` inheritance from emit-field parsing.
- Production paths checked/migrated: YAML admission, `EmitSpec`, rule emit-template effective emit, `HandlerDeclarativeEmitSites`, semantic view, bootverify payload completeness/expression/entity coverage, runtime executor emit/fanout/guard paths, and pipeline entity-reference detection.
- Non-emit sibling maps checked and left split under #1464: `config_from`, `emit.target.match`, mailbox payload, artifact repo payload/provenance, connect/data-handoff maps.
- Migration complete for the approved emitted-payload `EmitSpec` child slice. Parent #1464 remains open.

## Validation

- `go test ./internal/runtime/contracts ./internal/runtime/bootverify ./internal/runtime/semanticview ./internal/runtime/authoringview ./internal/runtime/engine ./internal/runtime/pipeline -run 'EmitFrom|Emit|PayloadCompleteness|AuthoredEmitSites|Expression|ConfigFrom|Mailbox|ArtifactRepo|FanOut|Guard|Template|Platform' -count=1`
- `go test ./...`
