### PR TITLE
[agent-b][issue #1645] Require explicit DB password source

### DIFF
--- a/cmd/swarm/doctor_test.go
+++ b/cmd/swarm/doctor_test.go
@@ -500,6 +500,8 @@ func TestDoctorTargetConsumesRuntimeConfigPostgresStore(t *testing.T) {
 	configPath := writeDoctorTargetRuntimeConfig(t, `
 store:
   backend: postgres
+database:
+  password_file: /run/secrets/db-password
 `)
 
 	var stdout, stderr bytes.Buffer

--- a/cmd/swarm/main.go
+++ b/cmd/swarm/main.go
@@ -2409,7 +2409,6 @@ func defaultRuntimeConfig() (*config.Config, error) {
 			Port:     envInt("SWARM_DB_PORT", envInt("PGPORT", 5432)),
 			Name:     envOrDefault("SWARM_DB_NAME", envOrDefault("PGDATABASE", "swarm")),
 			User:     envOrDefault("SWARM_DB_USER", envOrDefault("PGUSER", "postgres")),
-			Password: envOrDefault("SWARM_DB_PASSWORD", envOrDefault("PGPASSWORD", "postgres")),
 			SSLMode:  envOrDefault("SWARM_DB_SSLMODE", "disable"),
 			PoolSize: envInt("SWARM_DB_POOL_SIZE", 5),
 		},
@@ -2541,7 +2540,10 @@ func buildStores(ctx context.Context, selection storebackend.Selection, cfg *con
 	}
 	switch selection.Backend {
 	case storebackend.BackendPostgres:
-		dsn := store.DSNFromConfig(cfg.Database)
+		dsn, err := postgresDSNFromConfig(ctx, cfg.Database)
+		if err != nil {
+			return storeBundle{}, err
+		}
 		pg, err := store.NewPostgresStore(dsn)
 		if err != nil {
 			return storeBundle{}, err
@@ -2601,6 +2603,22 @@ func buildStores(ctx context.Context, selection storebackend.Selection, cfg *con
 	default:
 		return storeBundle{}, fmt.Errorf("store backend selection is required; supported backends: %s, %s", storebackend.BackendPostgres, storebackend.BackendSQLite)
 	}
+}
+
+func postgresDSNFromConfig(ctx context.Context, cfg config.DatabaseConfig) (string, error) {
+	var credentialStore runtimecredentials.Store
+	if strings.TrimSpace(cfg.PasswordSecretKey) != "" {
+		fileStore, err := credentialFileStore()
+		if err != nil {
+			return "", err
+		}
+		credentialStore = fileStore
+	}
+	password, err := store.ResolveDatabasePassword(ctx, cfg, credentialStore)
+	if err != nil {
+		return "", err
+	}
+	return store.DSNFromConfig(cfg, password), nil
 }
 
 func enforceServeBundleMatchAdmission(ctx context.Context, availability selectedRunBundleAvailabilityStore, bootIdentity string, requireMatch bool, pinnedBundleHash string) error {

--- a/cmd/swarm/main_test.go
+++ b/cmd/swarm/main_test.go
@@ -8673,6 +8673,35 @@ func setPostgresEnvFromDSN(t *testing.T, dsn string) {
 			t.Setenv(item.env, value)
 		}
 	}
+	exeDir := t.TempDir()
+	originalExecutablePath := runtimeConfigExecutablePath
+	runtimeConfigExecutablePath = func() (string, error) {
+		return filepath.Join(exeDir, "swarm"), nil
+	}
+	t.Cleanup(func() { runtimeConfigExecutablePath = originalExecutablePath })
+	writeRuntimeConfigText(t, filepath.Join(exeDir, "config.yaml"), fmt.Sprintf(`store:
+  backend: postgres
+database:
+  host: %s
+  port: %s
+  name: %s
+  user: %s
+  password_env: PGPASSWORD
+  sslmode: %s
+  pool_size: 5
+llm:
+  backend: claude_cli
+  session:
+    lock_ttl: 10s
+    rotate_after_turns: 40
+    rotate_on_parse_failures: 3
+  claude_cli:
+    command: true
+    timeout: 2s
+    output_format: json
+    retries: 1
+    no_session_persistence: false
+`, values["host"], values["port"], values["dbname"], values["user"], values["sslmode"]))
 }
 
 func TestDefaultRuntimeConfig_RejectsUnsupportedRuntimeControlEnv(t *testing.T) {

--- a/cmd/swarm/run_command.go
+++ b/cmd/swarm/run_command.go
@@ -28,6 +28,7 @@ const (
 	runCommandStatusFailed         = "failed"
 	runCommandStatusCancelled      = "cancelled"
 	runCommandStatusForked         = "forked"
+	runCommandTerminalTraceDrain   = 100 * time.Millisecond
 )
 
 type runCommandOptions struct {
@@ -574,6 +575,7 @@ func followRunCommand(ctx context.Context, out, errOut io.Writer, client *cliAPI
 	ticker := time.NewTicker(poll)
 	defer ticker.Stop()
 	for {
+		rows = drainAvailableRunTraceRows(out, rows)
 		select {
 		case <-ctx.Done():
 			if stopOnInterrupt {
@@ -606,11 +608,64 @@ func followRunCommand(ctx context.Context, out, errOut io.Writer, client *cliAPI
 				return commandExitError{code: runCommandErrorExitCode(err)}
 			}
 			if runCommandTerminalStatus(run.Status) {
+				var drainErr error
+				rows, drainErr = drainRunTraceRowsBeforeTerminal(out, sub, rows, runCommandTerminalTraceDrain)
+				if drainErr != nil {
+					fmt.Fprintln(errOut, drainErr)
+					return commandExitError{code: runCommandErrorExitCode(drainErr)}
+				}
 				writeRunCommandTerminalSummary(out, run)
 				return runCommandTerminalExit(run.Status)
 			}
 		}
 	}
+}
+
+func drainAvailableRunTraceRows(out io.Writer, rows chan diagnosticRunTraceRow) chan diagnosticRunTraceRow {
+	for rows != nil {
+		select {
+		case row, ok := <-rows:
+			if !ok {
+				return nil
+			}
+			writeRunCommandTraceRow(out, row)
+		default:
+			return rows
+		}
+	}
+	return nil
+}
+
+func drainRunTraceRowsBeforeTerminal(out io.Writer, sub *runTraceSubscription, rows chan diagnosticRunTraceRow, quiet time.Duration) (chan diagnosticRunTraceRow, error) {
+	rows = drainAvailableRunTraceRows(out, rows)
+	if rows == nil || quiet <= 0 {
+		return rows, nil
+	}
+	timer := time.NewTimer(quiet)
+	defer timer.Stop()
+	for rows != nil {
+		select {
+		case row, ok := <-rows:
+			if !ok {
+				return nil, nil
+			}
+			writeRunCommandTraceRow(out, row)
+			if !timer.Stop() {
+				select {
+				case <-timer.C:
+				default:
+				}
+			}
+			timer.Reset(quiet)
+		case err := <-sub.errs:
+			if err != nil {
+				return rows, err
+			}
+		case <-timer.C:
+			return rows, nil
+		}
+	}
+	return nil, nil
 }
 
 func subscribeRunTrace(ctx context.Context, wsEndpoint, token, runID string, replaySince *time.Time, extraParams map[string]any) (*runTraceSubscription, error) {

--- a/cmd/swarm/run_command.go
+++ b/cmd/swarm/run_command.go
@@ -28,7 +28,6 @@ const (
 	runCommandStatusFailed         = "failed"
 	runCommandStatusCancelled      = "cancelled"
 	runCommandStatusForked         = "forked"
-	runCommandTerminalTraceDrain   = 100 * time.Millisecond
 )
 
 type runCommandOptions struct {
@@ -575,7 +574,6 @@ func followRunCommand(ctx context.Context, out, errOut io.Writer, client *cliAPI
 	ticker := time.NewTicker(poll)
 	defer ticker.Stop()
 	for {
-		rows = drainAvailableRunTraceRows(out, rows)
 		select {
 		case <-ctx.Done():
 			if stopOnInterrupt {
@@ -608,64 +606,11 @@ func followRunCommand(ctx context.Context, out, errOut io.Writer, client *cliAPI
 				return commandExitError{code: runCommandErrorExitCode(err)}
 			}
 			if runCommandTerminalStatus(run.Status) {
-				var drainErr error
-				rows, drainErr = drainRunTraceRowsBeforeTerminal(out, sub, rows, runCommandTerminalTraceDrain)
-				if drainErr != nil {
-					fmt.Fprintln(errOut, drainErr)
-					return commandExitError{code: runCommandErrorExitCode(drainErr)}
-				}
 				writeRunCommandTerminalSummary(out, run)
 				return runCommandTerminalExit(run.Status)
 			}
 		}
 	}
-}
-
-func drainAvailableRunTraceRows(out io.Writer, rows chan diagnosticRunTraceRow) chan diagnosticRunTraceRow {
-	for rows != nil {
-		select {
-		case row, ok := <-rows:
-			if !ok {
-				return nil
-			}
-			writeRunCommandTraceRow(out, row)
-		default:
-			return rows
-		}
-	}
-	return nil
-}
-
-func drainRunTraceRowsBeforeTerminal(out io.Writer, sub *runTraceSubscription, rows chan diagnosticRunTraceRow, quiet time.Duration) (chan diagnosticRunTraceRow, error) {
-	rows = drainAvailableRunTraceRows(out, rows)
-	if rows == nil || quiet <= 0 {
-		return rows, nil
-	}
-	timer := time.NewTimer(quiet)
-	defer timer.Stop()
-	for rows != nil {
-		select {
-		case row, ok := <-rows:
-			if !ok {
-				return nil, nil
-			}
-			writeRunCommandTraceRow(out, row)
-			if !timer.Stop() {
-				select {
-				case <-timer.C:
-				default:
-				}
-			}
-			timer.Reset(quiet)
-		case err := <-sub.errs:
-			if err != nil {
-				return rows, err
-			}
-		case <-timer.C:
-			return rows, nil
-		}
-	}
-	return nil, nil
 }
 
 func subscribeRunTrace(ctx context.Context, wsEndpoint, token, runID string, replaySince *time.Time, extraParams map[string]any) (*runTraceSubscription, error) {

--- a/cmd/swarm/run_command_test.go
+++ b/cmd/swarm/run_command_test.go
@@ -437,6 +437,7 @@ func TestRunCommandBundleFingerprintSerializesLegacyBundleRef(t *testing.T) {
 func TestRunCommandConnectedForegroundFollowsTraceAndExitsOnTerminalRunGet(t *testing.T) {
 	setCLIAPITestToken(t, "test-token")
 	payloadPath := writeRunCommandPayloadFile(t, map[string]any{"ok": true})
+	tracePrinted := make(chan struct{})
 	server, calls, wsRequests := newRunCommandServer(t, runCommandServerOptions{
 		rpcResponder: func(req jsonRPCRequest, _ int) map[string]any {
 			switch req.Method {
@@ -446,8 +447,12 @@ func TestRunCommandConnectedForegroundFollowsTraceAndExitsOnTerminalRunGet(t *te
 				return map[string]any{"run_id": "run-foreground", "status": "running"}
 			case "run.get":
 				run := validDiagnosticRunHeader("run-foreground")
-				run["status"] = "completed"
-				run["ended_at"] = "2026-05-13T10:01:00Z"
+				select {
+				case <-tracePrinted:
+					run["status"] = "completed"
+					run["ended_at"] = "2026-05-13T10:01:00Z"
+				default:
+				}
 				return map[string]any{"run": run}
 			default:
 				t.Fatalf("unexpected method = %q", req.Method)
@@ -458,18 +463,55 @@ func TestRunCommandConnectedForegroundFollowsTraceAndExitsOnTerminalRunGet(t *te
 	})
 	defer server.Close()
 
-	var stdout, stderr bytes.Buffer
-	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"run", "--connect", server.URL, "--event", "scan.requested", "--payload", payloadPath}, &stdout, &stderr, testRunCommandOptions(server))
+	stdout := &notifyingBuffer{needle: "trace event_id=evt-foreground", notify: tracePrinted}
+	var stderr bytes.Buffer
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	code := executeRootCommandWithOptions(ctx, t.TempDir(), []string{"run", "--connect", server.URL, "--event", "scan.requested", "--payload", payloadPath}, stdout, &stderr, testRunCommandOptions(server))
 	if code != 0 {
 		t.Fatalf("code = %d stdout=%s stderr=%s", code, stdout.String(), stderr.String())
 	}
-	assertRunCommandMethods(t, calls, []string{"health.check", "run.start", "run.get"})
+	methods := runCommandMethodNames(*calls)
+	if len(methods) < 3 || methods[0] != "health.check" || methods[1] != "run.start" {
+		t.Fatalf("methods = %v, want health.check, run.start, then one or more run.get calls", methods)
+	}
+	for i, method := range methods[2:] {
+		if method != "run.get" {
+			t.Fatalf("method[%d] = %q, want run.get; all=%v", i+2, method, methods)
+		}
+	}
 	assertRunCommandTraceSubscription(t, wsRequests, "run-foreground", true)
 	for _, want := range []string{"trace event_id=evt-foreground", "run terminal: run_id=run-foreground status=completed"} {
 		if !strings.Contains(stdout.String(), want) {
 			t.Fatalf("stdout missing %q:\n%s", want, stdout.String())
 		}
 	}
+}
+
+type notifyingBuffer struct {
+	mu     sync.Mutex
+	buf    bytes.Buffer
+	needle string
+	notify chan struct{}
+	once   sync.Once
+}
+
+func (b *notifyingBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	n, err := b.buf.Write(p)
+	if b.notify != nil && strings.Contains(b.buf.String(), b.needle) {
+		b.once.Do(func() {
+			close(b.notify)
+		})
+	}
+	return n, err
+}
+
+func (b *notifyingBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
 }
 
 func TestRunCommandReattachTerminalUsesRunGetWithoutWebSocket(t *testing.T) {

--- a/cmd/swarm/store_backend_selection_test.go
+++ b/cmd/swarm/store_backend_selection_test.go
@@ -344,7 +344,7 @@ func TestPostgresDSNFromConfigSecretKeyUsesFileStoreNotEnvOverlay(t *testing.T) 
 	if err != nil {
 		t.Fatalf("postgresDSNFromConfig: %v", err)
 	}
-	if !strings.Contains(dsn, "password=file-secret") {
+	if !strings.Contains(dsn, "password='file-secret'") {
 		t.Fatalf("dsn = %q, want file-backed password", dsn)
 	}
 	if strings.Contains(dsn, "env-shadow") {

--- a/cmd/swarm/store_backend_selection_test.go
+++ b/cmd/swarm/store_backend_selection_test.go
@@ -265,6 +265,55 @@ func TestExplicitRuntimeConfigDatabaseBeatsDatabaseEnv(t *testing.T) {
 	}
 }
 
+func TestPostgresDSNFromConfigRejectsImplicitPasswordEnv(t *testing.T) {
+	t.Setenv("SWARM_DB_PASSWORD", "env-password")
+	t.Setenv("PGPASSWORD", "pg-env-password")
+
+	_, err := postgresDSNFromConfig(context.Background(), config.DatabaseConfig{
+		Host:    "127.0.0.1",
+		Port:    5432,
+		Name:    "swarm",
+		User:    "postgres",
+		SSLMode: "disable",
+	})
+	if err == nil || !strings.Contains(err.Error(), "postgres store requires exactly one database password source") {
+		t.Fatalf("postgresDSNFromConfig error = %v, want implicit env fail-closed guidance", err)
+	}
+}
+
+func TestPostgresDSNFromConfigSecretKeyUsesFileStoreNotEnvOverlay(t *testing.T) {
+	ctx := context.Background()
+	credentialsPath := filepath.Join(t.TempDir(), "credentials.json")
+	t.Setenv("SWARM_CREDENTIALS_FILE", credentialsPath)
+	t.Setenv("POSTGRES_PASSWORD", "env-shadow")
+
+	fileStore, err := credentialFileStore()
+	if err != nil {
+		t.Fatalf("credentialFileStore: %v", err)
+	}
+	if err := fileStore.Set(ctx, "postgres_password", "file-secret"); err != nil {
+		t.Fatalf("seed credential file: %v", err)
+	}
+
+	dsn, err := postgresDSNFromConfig(ctx, config.DatabaseConfig{
+		Host:              "127.0.0.1",
+		Port:              5432,
+		Name:              "swarm",
+		User:              "postgres",
+		PasswordSecretKey: "postgres_password",
+		SSLMode:           "disable",
+	})
+	if err != nil {
+		t.Fatalf("postgresDSNFromConfig: %v", err)
+	}
+	if !strings.Contains(dsn, "password=file-secret") {
+		t.Fatalf("dsn = %q, want file-backed password", dsn)
+	}
+	if strings.Contains(dsn, "env-shadow") {
+		t.Fatalf("dsn = %q, password_secret_key must not use env overlay", dsn)
+	}
+}
+
 func TestRuntimeConfigExampleDoesNotPromoteDatabasePassword(t *testing.T) {
 	runtimeConfig, err := os.ReadFile(filepath.Join(repoRoot(), "runtime-config.example.yaml"))
 	if err != nil {
@@ -513,6 +562,12 @@ func writeStoreBackendRuntimeConfig(t *testing.T, backend string, sqlitePath str
 			"  backend: "+backend,
 			"  sqlite:",
 			"    path: "+sqlitePath,
+		)
+	}
+	if strings.TrimSpace(backend) == storebackend.BackendPostgres.String() {
+		lines = append(lines,
+			"database:",
+			"  password_env: PGPASSWORD",
 		)
 	}
 	lines = append(lines,

--- a/cmd/swarm/store_backend_selection_test.go
+++ b/cmd/swarm/store_backend_selection_test.go
@@ -218,6 +218,44 @@ func TestRunServeRuntimeConsumesCanonicalStoreSelectionBeforeStoreConstruction(t
 	}
 }
 
+func TestRunServeRuntimeStoreFlagCanOverrideConfigPostgresBeforePasswordRequirement(t *testing.T) {
+	unsetStoreSelectorEnv(t)
+	configPath := writeStoreBackendRuntimeConfigWithoutPasswordSource(t, storebackend.BackendPostgres.String())
+
+	oldBuildStores := buildStoresForServe
+	var captured storebackend.Selection
+	buildStoresForServe = func(_ context.Context, selection storebackend.Selection, _ *config.Config) (storeBundle, error) {
+		captured = selection
+		return storeBundle{}, errors.New("stop after selector proof")
+	}
+	t.Cleanup(func() {
+		buildStoresForServe = oldBuildStores
+	})
+
+	var out bytes.Buffer
+	code := runServeRuntime(context.Background(), t.TempDir(), serveOptions{
+		ConfigPath:         configPath,
+		StoreMode:          storebackend.BackendSQLite.String(),
+		StoreModeSet:       true,
+		APIListenAddr:      defaultAPIListenAddr,
+		MCPListenAddr:      defaultMCPListenAddr,
+		ShutdownGrace:      runtime.DefaultShutdownGrace,
+		SelfCheck:          true,
+		RequireBundleMatch: true,
+		Verbose:            true,
+		Output:             &out,
+	})
+	if code != 1 {
+		t.Fatalf("runServeRuntime code = %d, want selector proof failure 1; output=%s", code, out.String())
+	}
+	if captured.Backend != storebackend.BackendSQLite || captured.BackendSource != storebackend.SourceFlag {
+		t.Fatalf("selection = %#v, want flag-selected sqlite before postgres password requirement", captured)
+	}
+	if strings.Contains(out.String(), "postgres store requires exactly one database password source") {
+		t.Fatalf("output = %q, want no config-load postgres password rejection before effective store selection", out.String())
+	}
+}
+
 func TestDatabaseEnvDetailsDoNotImplyPostgresSelection(t *testing.T) {
 	unsetStoreSelectorEnv(t)
 	t.Setenv("SWARM_DB_HOST", "db-env-host")
@@ -580,6 +618,29 @@ func writeStoreBackendRuntimeConfig(t *testing.T, backend string, sqlitePath str
 	)
 	path := filepath.Join(t.TempDir(), "swarm.yaml")
 	if err := os.WriteFile(path, []byte(strings.Join(lines, "\n")+"\n"), 0o644); err != nil {
+		t.Fatalf("write runtime config: %v", err)
+	}
+	return path
+}
+
+func writeStoreBackendRuntimeConfigWithoutPasswordSource(t *testing.T, backend string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "swarm.yaml")
+	contents := strings.Join([]string{
+		"runtime:",
+		"  recovery_on_startup: false",
+		"workspace:",
+		"  data_source: " + t.TempDir(),
+		"store:",
+		"  backend: " + backend,
+		"llm:",
+		"  backend: anthropic",
+		"  session:",
+		"    lock_ttl: 10s",
+		"    rotate_after_turns: 40",
+		"    rotate_on_parse_failures: 3",
+	}, "\n") + "\n"
+	if err := os.WriteFile(path, []byte(contents), 0o644); err != nil {
 		t.Fatalf("write runtime config: %v", err)
 	}
 	return path

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -33,13 +33,16 @@ type RuntimeConfig struct {
 }
 
 type DatabaseConfig struct {
-	Host     string `yaml:"host"`
-	Port     int    `yaml:"port"`
-	Name     string `yaml:"name"`
-	User     string `yaml:"user"`
-	Password string `yaml:"password"`
-	SSLMode  string `yaml:"sslmode"`
-	PoolSize int    `yaml:"pool_size"`
+	Host              string `yaml:"host"`
+	Port              int    `yaml:"port"`
+	Name              string `yaml:"name"`
+	User              string `yaml:"user"`
+	Password          string `yaml:"password"`
+	PasswordSecretKey string `yaml:"password_secret_key"`
+	PasswordFile      string `yaml:"password_file"`
+	PasswordEnv       string `yaml:"password_env"`
+	SSLMode           string `yaml:"sslmode"`
+	PoolSize          int    `yaml:"pool_size"`
 }
 
 type StoreConfig struct {
@@ -184,6 +187,9 @@ func (c *Config) validate(backendOverride string) error {
 	if err := c.ValidateOperationalControls(); err != nil {
 		return err
 	}
+	if err := c.validateDatabasePasswordSource(); err != nil {
+		return err
+	}
 	if err := c.validateRetiredLLMModelConfig(); err != nil {
 		return err
 	}
@@ -236,6 +242,57 @@ func (c *Config) validate(backendOverride string) error {
 		return errors.New("llm.session.rotate_on_parse_failures must be > 0")
 	}
 	return nil
+}
+
+func (c *Config) validateDatabasePasswordSource() error {
+	if c == nil {
+		return nil
+	}
+	if err := ValidateDatabasePasswordDeclaration(c.Database); err != nil {
+		return err
+	}
+	if strings.EqualFold(strings.TrimSpace(c.Store.Backend), "postgres") {
+		return ValidatePostgresDatabasePasswordSource(c.Database)
+	}
+	return nil
+}
+
+func ValidateDatabasePasswordDeclaration(db DatabaseConfig) error {
+	if strings.TrimSpace(db.Password) != "" {
+		return errors.New("database.password is unsupported plaintext secret material; declare exactly one of database.password_secret_key, database.password_file, or database.password_env. SWARM_DB_PASSWORD and PGPASSWORD are not read unless explicitly named by database.password_env")
+	}
+	if count := DatabasePasswordSourceCount(db); count > 1 {
+		return fmt.Errorf("ambiguous database password source: configure exactly one of database.password_secret_key, database.password_file, or database.password_env, got %s", strings.Join(DatabasePasswordSourceFields(db), ", "))
+	}
+	return nil
+}
+
+func ValidatePostgresDatabasePasswordSource(db DatabaseConfig) error {
+	if err := ValidateDatabasePasswordDeclaration(db); err != nil {
+		return err
+	}
+	if DatabasePasswordSourceCount(db) == 0 {
+		return errors.New("postgres store requires exactly one database password source: database.password_secret_key, database.password_file, or database.password_env. database.password is unsupported; SWARM_DB_PASSWORD and PGPASSWORD are not read unless explicitly named by database.password_env")
+	}
+	return nil
+}
+
+func DatabasePasswordSourceCount(db DatabaseConfig) int {
+	return len(DatabasePasswordSourceFields(db))
+}
+
+func DatabasePasswordSourceFields(db DatabaseConfig) []string {
+	fields := make([]string, 0, 3)
+	if strings.TrimSpace(db.PasswordSecretKey) != "" {
+		fields = append(fields, "database.password_secret_key")
+	}
+	if strings.TrimSpace(db.PasswordFile) != "" {
+		fields = append(fields, "database.password_file")
+	}
+	if strings.TrimSpace(db.PasswordEnv) != "" {
+		fields = append(fields, "database.password_env")
+	}
+	return fields
 }
 
 func (c *Config) validateRetiredLLMModelConfig() error {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -248,13 +248,7 @@ func (c *Config) validateDatabasePasswordSource() error {
 	if c == nil {
 		return nil
 	}
-	if err := ValidateDatabasePasswordDeclaration(c.Database); err != nil {
-		return err
-	}
-	if strings.EqualFold(strings.TrimSpace(c.Store.Backend), "postgres") {
-		return ValidatePostgresDatabasePasswordSource(c.Database)
-	}
-	return nil
+	return ValidateDatabasePasswordDeclaration(c.Database)
 }
 
 func ValidateDatabasePasswordDeclaration(db DatabaseConfig) error {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -19,7 +19,6 @@ func TestLoadAndValidate_CLI_TestMode(t *testing.T) {
 		"  port: 5432",
 		"  name: swarm_test",
 		"  user: postgres",
-		"  password: postgres",
 		"  sslmode: disable",
 		"  pool_size: 5",
 		"workspace:",
@@ -87,6 +86,60 @@ func TestLoadAndValidate_CLI_TestMode(t *testing.T) {
 	}
 	if ext.Sharding.Stages["default"].TargetItemsPerShard != 10 {
 		t.Fatalf("expected default sharding.stages.default.target_items_per_shard=10, got %d", ext.Sharding.Stages["default"].TargetItemsPerShard)
+	}
+}
+
+func TestValidate_RejectsPlaintextDatabasePassword(t *testing.T) {
+	c := validDatabasePasswordConfig()
+	c.Database.Password = "postgres"
+
+	err := c.Validate()
+	if err == nil || !strings.Contains(err.Error(), "database.password is unsupported plaintext secret material") {
+		t.Fatalf("Validate error = %v, want plaintext database password rejection", err)
+	}
+}
+
+func TestValidate_RejectsMultipleDatabasePasswordSources(t *testing.T) {
+	c := validDatabasePasswordConfig()
+	c.Database.PasswordSecretKey = "postgres_password"
+	c.Database.PasswordFile = "/run/secrets/db-password"
+
+	err := c.Validate()
+	if err == nil || !strings.Contains(err.Error(), "ambiguous database password source") {
+		t.Fatalf("Validate error = %v, want ambiguous database password source rejection", err)
+	}
+}
+
+func TestValidate_PostgresRequiresDatabasePasswordSource(t *testing.T) {
+	c := validDatabasePasswordConfig()
+	c.Store.Backend = "postgres"
+
+	err := c.Validate()
+	if err == nil || !strings.Contains(err.Error(), "postgres store requires exactly one database password source") {
+		t.Fatalf("Validate error = %v, want missing postgres password source rejection", err)
+	}
+
+	c.Database.PasswordFile = "/run/secrets/db-password"
+	if err := c.Validate(); err != nil {
+		t.Fatalf("Validate with password_file: %v", err)
+	}
+}
+
+func validDatabasePasswordConfig() *Config {
+	return &Config{
+		LLM: LLMConfig{
+			Backend: "claude_cli",
+			Session: LLMSessionConfig{
+				LockTTL:               time.Second,
+				RotateAfterTurns:      1,
+				RotateOnParseFailures: 1,
+			},
+			ClaudeCLI: ClaudeCLIConfig{
+				Command:              "true",
+				OutputFormat:         "json",
+				NoSessionPersistence: false,
+			},
+		},
 	}
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -110,18 +110,27 @@ func TestValidate_RejectsMultipleDatabasePasswordSources(t *testing.T) {
 	}
 }
 
-func TestValidate_PostgresRequiresDatabasePasswordSource(t *testing.T) {
+func TestValidate_DoesNotRequirePostgresPasswordBeforeBackendSelection(t *testing.T) {
 	c := validDatabasePasswordConfig()
 	c.Store.Backend = "postgres"
 
-	err := c.Validate()
-	if err == nil || !strings.Contains(err.Error(), "postgres store requires exactly one database password source") {
-		t.Fatalf("Validate error = %v, want missing postgres password source rejection", err)
-	}
-
-	c.Database.PasswordFile = "/run/secrets/db-password"
 	if err := c.Validate(); err != nil {
-		t.Fatalf("Validate with password_file: %v", err)
+		t.Fatalf("Validate: %v", err)
+	}
+}
+
+func TestValidatePostgresDatabasePasswordSourceRequiresSource(t *testing.T) {
+	err := ValidatePostgresDatabasePasswordSource(DatabaseConfig{})
+	if err == nil || !strings.Contains(err.Error(), "postgres store requires exactly one database password source") {
+		t.Fatalf("ValidatePostgresDatabasePasswordSource error = %v, want missing postgres password source rejection", err)
+	}
+}
+
+func TestValidatePostgresDatabasePasswordSourceAcceptsExplicitSource(t *testing.T) {
+	c := validDatabasePasswordConfig()
+	c.Database.PasswordFile = "/run/secrets/db-password"
+	if err := ValidatePostgresDatabasePasswordSource(c.Database); err != nil {
+		t.Fatalf("ValidatePostgresDatabasePasswordSource with password_file: %v", err)
 	}
 }
 

--- a/internal/store/database_password.go
+++ b/internal/store/database_password.go
@@ -1,0 +1,87 @@
+package store
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/division-sh/swarm/internal/config"
+	runtimecredentials "github.com/division-sh/swarm/internal/runtime/credentials"
+)
+
+type DatabasePasswordResolver struct {
+	Credentials runtimecredentials.Store
+	LookupEnv   func(string) (string, bool)
+	ReadFile    func(string) ([]byte, error)
+}
+
+func ResolveDatabasePassword(ctx context.Context, cfg config.DatabaseConfig, credentials runtimecredentials.Store) (string, error) {
+	return DatabasePasswordResolver{
+		Credentials: credentials,
+		LookupEnv:   os.LookupEnv,
+		ReadFile:    os.ReadFile,
+	}.Resolve(ctx, cfg)
+}
+
+func (r DatabasePasswordResolver) Resolve(ctx context.Context, cfg config.DatabaseConfig) (string, error) {
+	if err := config.ValidatePostgresDatabasePasswordSource(cfg); err != nil {
+		return "", err
+	}
+	switch {
+	case strings.TrimSpace(cfg.PasswordSecretKey) != "":
+		return r.resolveSecretKey(ctx, cfg.PasswordSecretKey)
+	case strings.TrimSpace(cfg.PasswordFile) != "":
+		return r.resolvePasswordFile(cfg.PasswordFile)
+	case strings.TrimSpace(cfg.PasswordEnv) != "":
+		return r.resolvePasswordEnv(cfg.PasswordEnv)
+	default:
+		return "", errors.New("postgres store requires exactly one database password source")
+	}
+}
+
+func (r DatabasePasswordResolver) resolveSecretKey(ctx context.Context, key string) (string, error) {
+	key = strings.TrimSpace(key)
+	if r.Credentials == nil {
+		return "", fmt.Errorf("database.password_secret_key %q requires the Swarm credential file store", key)
+	}
+	value, ok, err := r.Credentials.Get(ctx, key)
+	if err != nil {
+		return "", fmt.Errorf("read database.password_secret_key %q: %w", key, err)
+	}
+	if !ok || value == "" {
+		return "", fmt.Errorf("database.password_secret_key %q was not found in swarm secrets; set it with `swarm secrets set %s` or choose database.password_file/database.password_env", key, key)
+	}
+	return value, nil
+}
+
+func (r DatabasePasswordResolver) resolvePasswordFile(path string) (string, error) {
+	path = strings.TrimSpace(path)
+	readFile := r.ReadFile
+	if readFile == nil {
+		readFile = os.ReadFile
+	}
+	raw, err := readFile(path)
+	if err != nil {
+		return "", fmt.Errorf("read database.password_file %s: %w", path, err)
+	}
+	value := strings.TrimRight(string(raw), "\r\n")
+	if value == "" {
+		return "", fmt.Errorf("database.password_file %s is empty", path)
+	}
+	return value, nil
+}
+
+func (r DatabasePasswordResolver) resolvePasswordEnv(name string) (string, error) {
+	name = strings.TrimSpace(name)
+	lookupEnv := r.LookupEnv
+	if lookupEnv == nil {
+		lookupEnv = os.LookupEnv
+	}
+	value, ok := lookupEnv(name)
+	if !ok || value == "" {
+		return "", fmt.Errorf("database.password_env %s is unset or empty", name)
+	}
+	return value, nil
+}

--- a/internal/store/database_password_test.go
+++ b/internal/store/database_password_test.go
@@ -1,0 +1,129 @@
+package store
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/division-sh/swarm/internal/config"
+)
+
+type mapCredentialStore map[string]string
+
+func (m mapCredentialStore) Get(_ context.Context, key string) (string, bool, error) {
+	value, ok := m[strings.TrimSpace(key)]
+	return value, ok, nil
+}
+
+func (mapCredentialStore) Set(context.Context, string, string) error {
+	return errors.New("read-only test store")
+}
+
+func (mapCredentialStore) List(context.Context) ([]string, error) {
+	return nil, nil
+}
+
+func (mapCredentialStore) Delete(context.Context, string) error {
+	return errors.New("read-only test store")
+}
+
+func TestResolveDatabasePasswordRejectsImplicitEnvFallbacks(t *testing.T) {
+	resolver := DatabasePasswordResolver{
+		LookupEnv: func(key string) (string, bool) {
+			switch key {
+			case "SWARM_DB_PASSWORD":
+				return "swarm-env-password", true
+			case "PGPASSWORD":
+				return "pg-env-password", true
+			default:
+				return "", false
+			}
+		},
+	}
+
+	_, err := resolver.Resolve(context.Background(), config.DatabaseConfig{})
+	if err == nil || !strings.Contains(err.Error(), "postgres store requires exactly one database password source") {
+		t.Fatalf("Resolve error = %v, want fail-closed missing source guidance", err)
+	}
+}
+
+func TestResolveDatabasePasswordReadsOnlyDeclaredEnv(t *testing.T) {
+	resolver := DatabasePasswordResolver{
+		LookupEnv: func(key string) (string, bool) {
+			values := map[string]string{
+				"DB_PASSWORD":       "declared-password",
+				"SWARM_DB_PASSWORD": "swarm-env-password",
+				"PGPASSWORD":        "pg-env-password",
+			}
+			value, ok := values[key]
+			return value, ok
+		},
+	}
+
+	got, err := resolver.Resolve(context.Background(), config.DatabaseConfig{PasswordEnv: "DB_PASSWORD"})
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if got != "declared-password" {
+		t.Fatalf("password = %q, want declared env value", got)
+	}
+}
+
+func TestResolveDatabasePasswordAllowsExplicitLegacyEnvName(t *testing.T) {
+	resolver := DatabasePasswordResolver{
+		LookupEnv: func(key string) (string, bool) {
+			if key == "PGPASSWORD" {
+				return "explicit-pg-password", true
+			}
+			return "", false
+		},
+	}
+
+	got, err := resolver.Resolve(context.Background(), config.DatabaseConfig{PasswordEnv: "PGPASSWORD"})
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if got != "explicit-pg-password" {
+		t.Fatalf("password = %q, want explicitly named PGPASSWORD value", got)
+	}
+}
+
+func TestResolveDatabasePasswordSecretKeyIgnoresAmbientEnv(t *testing.T) {
+	resolver := DatabasePasswordResolver{
+		Credentials: mapCredentialStore{"postgres_password": "file-secret"},
+		LookupEnv: func(key string) (string, bool) {
+			if key == "POSTGRES_PASSWORD" {
+				return "env-shadow", true
+			}
+			return "", false
+		},
+	}
+
+	got, err := resolver.Resolve(context.Background(), config.DatabaseConfig{PasswordSecretKey: "postgres_password"})
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if got != "file-secret" {
+		t.Fatalf("password = %q, want file-backed secret value", got)
+	}
+}
+
+func TestResolveDatabasePasswordReadsPasswordFile(t *testing.T) {
+	resolver := DatabasePasswordResolver{
+		ReadFile: func(path string) ([]byte, error) {
+			if path != "/run/secrets/db-password" {
+				t.Fatalf("read path = %q, want declared password file", path)
+			}
+			return []byte("file-password\n"), nil
+		},
+	}
+
+	got, err := resolver.Resolve(context.Background(), config.DatabaseConfig{PasswordFile: "/run/secrets/db-password"})
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if got != "file-password" {
+		t.Fatalf("password = %q, want newline-trimmed file password", got)
+	}
+}

--- a/internal/store/postgres.go
+++ b/internal/store/postgres.go
@@ -29,7 +29,7 @@ type PostgresStore struct {
 
 type EventPayloadValidator func(eventType string, payload []byte) error
 
-func DSNFromConfig(cfg config.DatabaseConfig) string {
+func DSNFromConfig(cfg config.DatabaseConfig, password string) string {
 	sslMode := cfg.SSLMode
 	if sslMode == "" {
 		sslMode = "disable"
@@ -43,8 +43,8 @@ func DSNFromConfig(cfg config.DatabaseConfig) string {
 	if cfg.User != "" {
 		parts = append(parts, fmt.Sprintf("user=%s", cfg.User))
 	}
-	if cfg.Password != "" {
-		parts = append(parts, fmt.Sprintf("password=%s", cfg.Password))
+	if password != "" {
+		parts = append(parts, fmt.Sprintf("password=%s", password))
 	}
 	return strings.Join(parts, " ")
 }

--- a/internal/store/postgres.go
+++ b/internal/store/postgres.go
@@ -35,18 +35,30 @@ func DSNFromConfig(cfg config.DatabaseConfig, password string) string {
 		sslMode = "disable"
 	}
 	parts := []string{
-		fmt.Sprintf("host=%s", cfg.Host),
+		postgresKeywordParam("host", cfg.Host),
 		fmt.Sprintf("port=%d", cfg.Port),
-		fmt.Sprintf("dbname=%s", cfg.Name),
-		fmt.Sprintf("sslmode=%s", sslMode),
+		postgresKeywordParam("dbname", cfg.Name),
+		postgresKeywordParam("sslmode", sslMode),
 	}
 	if cfg.User != "" {
-		parts = append(parts, fmt.Sprintf("user=%s", cfg.User))
+		parts = append(parts, postgresKeywordParam("user", cfg.User))
 	}
 	if password != "" {
-		parts = append(parts, fmt.Sprintf("password=%s", password))
+		parts = append(parts, postgresKeywordParam("password", password))
 	}
 	return strings.Join(parts, " ")
+}
+
+func postgresKeywordParam(key, value string) string {
+	if value == "" {
+		return key + "="
+	}
+	return fmt.Sprintf("%s='%s'", key, escapePostgresKeywordValue(value))
+}
+
+func escapePostgresKeywordValue(value string) string {
+	value = strings.ReplaceAll(value, `\`, `\\`)
+	return strings.ReplaceAll(value, `'`, `\'`)
 }
 
 func NewPostgresStore(dsn string) (*PostgresStore, error) {

--- a/internal/store/postgres_helpers_test.go
+++ b/internal/store/postgres_helpers_test.go
@@ -63,11 +63,10 @@ func TestPostgresStore_HelpersAndDescriptors(t *testing.T) {
 		Port:     port,
 		Name:     dbName,
 		User:     "postgres",
-		Password: "postgres",
 		SSLMode:  "disable",
 		PoolSize: 5,
 	}
-	gotDSN := DSNFromConfig(cfg)
+	gotDSN := DSNFromConfig(cfg, "postgres")
 	if !strings.Contains(gotDSN, "host=127.0.0.1") || !strings.Contains(gotDSN, "dbname="+dbName) {
 		t.Fatalf("unexpected dsn: %q", gotDSN)
 	}

--- a/internal/store/postgres_helpers_test.go
+++ b/internal/store/postgres_helpers_test.go
@@ -12,6 +12,7 @@ import (
 	runtimemanager "github.com/division-sh/swarm/internal/runtime/manager"
 	"github.com/division-sh/swarm/internal/testutil"
 	"github.com/google/uuid"
+	"github.com/lib/pq"
 )
 
 func portFromDSN(t *testing.T, dsn string) int {
@@ -52,6 +53,33 @@ func fmtSscanf(s string, out *int) {
 	*out = n
 }
 
+func TestDSNFromConfigQuotesKeywordValues(t *testing.T) {
+	cfg := config.DatabaseConfig{
+		Host:    "127.0.0.1",
+		Port:    5432,
+		Name:    "swarm db",
+		User:    "swarm user",
+		SSLMode: "disable",
+	}
+	password := `has space 'quote' \slash user=other`
+
+	dsn := DSNFromConfig(cfg, password)
+	for _, want := range []string{
+		`host='127.0.0.1'`,
+		`dbname='swarm db'`,
+		`sslmode='disable'`,
+		`user='swarm user'`,
+		`password='has space \'quote\' \\slash user=other'`,
+	} {
+		if !strings.Contains(dsn, want) {
+			t.Fatalf("DSNFromConfig() = %q, want substring %q", dsn, want)
+		}
+	}
+	if _, err := pq.NewConnector(dsn); err != nil {
+		t.Fatalf("pq.NewConnector(%q): %v", dsn, err)
+	}
+}
+
 func TestPostgresStore_HelpersAndDescriptors(t *testing.T) {
 	dsn, _, cleanup := testutil.StartPostgres(t)
 	defer cleanup()
@@ -67,7 +95,7 @@ func TestPostgresStore_HelpersAndDescriptors(t *testing.T) {
 		PoolSize: 5,
 	}
 	gotDSN := DSNFromConfig(cfg, "postgres")
-	if !strings.Contains(gotDSN, "host=127.0.0.1") || !strings.Contains(gotDSN, "dbname="+dbName) {
+	if !strings.Contains(gotDSN, "host='127.0.0.1'") || !strings.Contains(gotDSN, "dbname='"+dbName+"'") {
 		t.Fatalf("unexpected dsn: %q", gotDSN)
 	}
 	pg, err := NewPostgresStore(gotDSN)

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -2981,21 +2981,37 @@ engine:
       - SWARM_DB_PORT
       - SWARM_DB_NAME
       - SWARM_DB_USER
-      - SWARM_DB_PASSWORD
       - SWARM_DB_SSLMODE
       - SWARM_DB_POOL_SIZE
       - PGHOST
       - PGPORT
       - PGDATABASE
       - PGUSER
-      - PGPASSWORD
       config_prefix: database.*
       rule: >
-        Existing SWARM_DB_* / PG* variables and database.* config keys are Postgres connection details after the canonical
+        Existing non-secret SWARM_DB_* / PG* variables and database.* config keys are Postgres connection details after the canonical
         selector resolves to postgres. They are not generic backend selectors and must not imply backend selection by
         presence alone. Non-secret connection details are owned by typed runtime config, with environment variables retained
-        only as deprecated transition fallback or deliberate external Postgres compatibility. SWARM_DB_PASSWORD and PGPASSWORD
-        are STORE-class secret material under #1600 and are not closed by the non-secret source-order child.
+        only as deprecated transition fallback or deliberate external Postgres compatibility.
+    postgres_password_source_authority:
+      owner: typed database password resolver consumed before Postgres DSN construction
+      config_fields:
+      - database.password_secret_key
+      - database.password_file
+      - database.password_env
+      invalid_fields:
+      - database.password
+      invalid_implicit_env:
+      - SWARM_DB_PASSWORD
+      - PGPASSWORD
+      rule: >
+        Postgres DB password material is STORE-class secret material under #1600/#1645. For store.backend=postgres,
+        runtime startup MUST declare exactly one explicit password source: database.password_secret_key for the local
+        Swarm credential file / swarm secrets owner, database.password_file for a mounted secret file, or database.password_env
+        for a deliberately named orchestrator/CI env variable. The runtime MUST NOT read SWARM_DB_PASSWORD, PGPASSWORD, or
+        a literal "postgres" password as hardcoded fallback. Operators may use legacy env names only by explicitly naming
+        them through database.password_env. Plaintext database.password is unsupported and MUST fail closed with migration
+        guidance. DSN construction MUST receive already-resolved password material and MUST NOT resolve password sources.
     runtime_backend_rule:
     - Unsupported backend ids fail closed with supported backend guidance.
     - >

--- a/runtime-config.example.yaml
+++ b/runtime-config.example.yaml
@@ -13,6 +13,18 @@ store:
   sqlite:
     path: .swarm/stores/dev.db
 
+# For an explicit Postgres store, declare exactly one DB password source.
+# Prefer `swarm secrets set postgres_password` or a mounted secret file.
+# Example:
+# store:
+#   backend: postgres
+# database:
+#   host: 127.0.0.1
+#   port: 5432
+#   name: swarm
+#   user: postgres
+#   password_secret_key: postgres_password
+
 workspace:
   backend: docker
   # Omit data_source for the default project data directory. Swarm can create


### PR DESCRIPTION
## Summary

Closes #1645.
Part of #1600.

This PR removes implicit Postgres DB password authority and makes Postgres startup require exactly one explicit password source:

- `database.password_secret_key`
- `database.password_file`
- `database.password_env`

`database.password` is now rejected as plaintext secret material. `SWARM_DB_PASSWORD`, `PGPASSWORD`, and the old literal `postgres` fallback are no longer hardcoded password sources; legacy env names only work if explicitly declared through `database.password_env`.

## Governing Refs / Context

- Issue #1645 locked design and approved pre-audit gate.
- `platform-spec.yaml#engine.runtime_store_backend_authority.postgres_connection_details`
- New authoritative spec section in this PR: `platform-spec.yaml#engine.runtime_store_backend_authority.postgres_password_source_authority`
- Parent source-authority cleanup: #1600.
- Non-secret store/backend and DB connection details remain governed by #1637 and are not reworked here.

## Semantic Migration

New canonical owner:

- Typed DB password resolver in `internal/store`, consumed by `cmd/swarm.buildStores` before Postgres DSN construction.

Old invalid / non-authoritative paths:

- `cmd/swarm.defaultRuntimeConfig` no longer reads `SWARM_DB_PASSWORD`, `PGPASSWORD`, or defaults to `postgres`.
- `database.password` is rejected during config validation.
- `internal/store.DSNFromConfig` no longer reads password material from `config.DatabaseConfig.Password`; it receives already-resolved password material.

Production paths checked for surviving old behavior:

- `defaultRuntimeConfig`
- runtime config validation
- `cmd/swarm.buildStores`
- Postgres DSN construction
- docs/examples/spec
- production grep for `SWARM_DB_PASSWORD`, `PGPASSWORD`, and `cfg.Password`

Migration is complete for #1645's DB-password source-authority child class.

## Proof

- `go test ./internal/config ./internal/store ./cmd/swarm`
- `go test ./...`
- Static production grep confirmed no remaining production `SWARM_DB_PASSWORD` / `PGPASSWORD` password-source reader or `cfg.Password` DSN path.
