### PR TITLE
[agent-f][issue #1691] Add Slack provider trigger adapter

### DIFF
--- a/internal/runtime/inbound.go
+++ b/internal/runtime/inbound.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strconv"
 	"strings"
 	"time"
 
@@ -158,6 +159,20 @@ func (g *InboundGateway) handleWebhook(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), status)
 		return
 	}
+	if delivery.Response != nil {
+		status := delivery.Response.Status
+		if status == 0 {
+			status = http.StatusOK
+		}
+		contentType := strings.TrimSpace(delivery.Response.ContentType)
+		if contentType == "" {
+			contentType = "text/plain; charset=utf-8"
+		}
+		w.Header().Set("content-type", contentType)
+		w.WriteHeader(status)
+		_, _ = w.Write(delivery.Response.Body)
+		return
+	}
 	providerEventID := delivery.ProviderEventID
 
 	if g.store != nil {
@@ -182,7 +197,14 @@ func (g *InboundGateway) handleWebhook(w http.ResponseWriter, r *http.Request) {
 	envelopeBytes := mustJSON(pubPayload)
 	if g.bus != nil {
 		pubCtx := runtimebus.WithCurrentRuntimeEpoch(r.Context())
-		if err := g.bus.Publish(pubCtx, events.NewRootIngressEvent(uuid.NewString(), pubType, "inbound-gateway", "", envelopeBytes, 0, "", "", events.EventEnvelope{EntityID: entityID}, now)); err != nil {
+		published := events.NewRootIngressEvent(uuid.NewString(), pubType, "inbound-gateway", "", envelopeBytes, 0, "", "", events.EventEnvelope{EntityID: entityID}, now)
+		var err error
+		if delivery.AcknowledgeBeforeDispatch {
+			err = g.bus.PublishAcknowledged(pubCtx, published)
+		} else {
+			err = g.bus.Publish(pubCtx, published)
+		}
+		if err != nil {
 			if g.logger != nil {
 				handleRuntimeLogPersistenceError("inbound-gateway", "publish_failed", g.logger.Error(r.Context(), "inbound-gateway", "publish_failed", map[string]any{
 					"provider":          provider,
@@ -259,10 +281,18 @@ type inboundProviderRequest struct {
 }
 
 type inboundProviderDelivery struct {
-	ProviderEventID   string
-	ProviderEventType string
-	EventName         events.EventType
-	Payload           map[string]any
+	ProviderEventID           string
+	ProviderEventType         string
+	EventName                 events.EventType
+	Payload                   map[string]any
+	Response                  *inboundProviderResponse
+	AcknowledgeBeforeDispatch bool
+}
+
+type inboundProviderResponse struct {
+	Status      int
+	ContentType string
+	Body        []byte
 }
 
 type inboundProviderError struct {
@@ -285,6 +315,7 @@ func inboundUnauthorized(message string) inboundProviderError {
 func defaultInboundProviderAdapters() map[string]inboundProviderAdapter {
 	return map[string]inboundProviderAdapter{
 		"github": githubInboundProviderAdapter{},
+		"slack":  slackInboundProviderAdapter{},
 	}
 }
 
@@ -321,6 +352,69 @@ func (githubInboundProviderAdapter) AcceptInbound(req inboundProviderRequest) (i
 }
 
 type rawInboundProviderAdapter struct{}
+
+type slackInboundProviderAdapter struct{}
+
+func (slackInboundProviderAdapter) AcceptInbound(req inboundProviderRequest) (inboundProviderDelivery, error) {
+	secret := strings.TrimSpace(req.Target.WebhookSecret)
+	if secret == "" {
+		return inboundProviderDelivery{}, inboundUnauthorized("slack webhook signing secret is required")
+	}
+	if err := verifySlackSignature(secret, req.Body, req.Headers, req.Received); err != nil {
+		return inboundProviderDelivery{}, err
+	}
+
+	payload, ok := req.Payload.(map[string]any)
+	if !ok {
+		return inboundProviderDelivery{}, inboundBadRequest("slack payload object is required")
+	}
+	payloadType := normalizeEventToken(firstStringByKeys(payload, "type"))
+	switch payloadType {
+	case "url_verification":
+		challenge := firstStringByKeys(payload, "challenge")
+		if challenge == "" {
+			return inboundProviderDelivery{}, inboundBadRequest("slack challenge is required")
+		}
+		return inboundProviderDelivery{
+			Response: &inboundProviderResponse{
+				Status:      http.StatusOK,
+				ContentType: "text/plain; charset=utf-8",
+				Body:        []byte(challenge),
+			},
+		}, nil
+	case "event_callback":
+		eventID := firstStringByKeys(payload, "event_id")
+		if eventID == "" {
+			return inboundProviderDelivery{}, inboundBadRequest("slack event_id is required")
+		}
+		innerEvent, ok := payload["event"].(map[string]any)
+		if !ok {
+			return inboundProviderDelivery{}, inboundBadRequest("slack inner event is required")
+		}
+		eventType := normalizeEventToken(firstStringByKeys(innerEvent, "type"))
+		if eventType == "event" {
+			return inboundProviderDelivery{}, inboundBadRequest("slack inner event type is required")
+		}
+		entityID := req.Target.EffectiveEntityID()
+		publishPayload := buildProviderPublishPayload("slack", entityID, eventID, eventType, redactSlackPayload(req.Payload), req.Received, map[string]any{
+			"user_agent":       req.UserAgent,
+			"slack_event_id":   eventID,
+			"slack_event_type": eventType,
+		})
+		return inboundProviderDelivery{
+			ProviderEventID:           eventID,
+			ProviderEventType:         eventType,
+			EventName:                 events.EventType("inbound.slack." + eventType),
+			Payload:                   publishPayload,
+			AcknowledgeBeforeDispatch: true,
+		}, nil
+	default:
+		if payloadType == "event" {
+			return inboundProviderDelivery{}, inboundBadRequest("slack payload type is required")
+		}
+		return inboundProviderDelivery{}, inboundBadRequest("unsupported slack payload type")
+	}
+}
 
 func (rawInboundProviderAdapter) AcceptInbound(req inboundProviderRequest) (inboundProviderDelivery, error) {
 	provider := normalizeProviderName(req.Provider)
@@ -488,6 +582,57 @@ func verifyGitHubSignature(secret string, body []byte, headers http.Header) bool
 	_, _ = mac.Write(body)
 	expected := hex.EncodeToString(mac.Sum(nil))
 	return hmac.Equal([]byte(strings.ToLower(given)), []byte(strings.ToLower(expected)))
+}
+
+func verifySlackSignature(secret string, body []byte, headers http.Header, now time.Time) error {
+	timestampHeader := strings.TrimSpace(headers.Get("X-Slack-Request-Timestamp"))
+	if timestampHeader == "" {
+		return inboundUnauthorized("slack request timestamp is required")
+	}
+	timestamp, err := strconv.ParseInt(timestampHeader, 10, 64)
+	if err != nil {
+		return inboundUnauthorized("invalid slack request timestamp")
+	}
+	requestTime := time.Unix(timestamp, 0).UTC()
+	if requestTime.After(now.Add(5*time.Minute)) || requestTime.Before(now.Add(-5*time.Minute)) {
+		return inboundUnauthorized("stale slack request timestamp")
+	}
+
+	signature := strings.TrimSpace(headers.Get("X-Slack-Signature"))
+	if !strings.HasPrefix(strings.ToLower(signature), "v0=") {
+		return inboundUnauthorized("slack signature is required")
+	}
+	base := "v0:" + timestampHeader + ":" + string(body)
+	mac := hmac.New(sha256.New, []byte(strings.TrimSpace(secret)))
+	_, _ = mac.Write([]byte(base))
+	expected := "v0=" + hex.EncodeToString(mac.Sum(nil))
+	if !hmac.Equal([]byte(strings.ToLower(signature)), []byte(strings.ToLower(expected))) {
+		return inboundUnauthorized("invalid slack signature")
+	}
+	return nil
+}
+
+func redactSlackPayload(payload any) any {
+	switch v := payload.(type) {
+	case map[string]any:
+		redacted := make(map[string]any, len(v))
+		for key, value := range v {
+			if strings.EqualFold(key, "token") {
+				redacted[key] = "[redacted]"
+				continue
+			}
+			redacted[key] = redactSlackPayload(value)
+		}
+		return redacted
+	case []any:
+		redacted := make([]any, len(v))
+		for i, value := range v {
+			redacted[i] = redactSlackPayload(value)
+		}
+		return redacted
+	default:
+		return v
+	}
 }
 
 func verifyRawWebhookSignature(secret string, body []byte, headers http.Header) bool {

--- a/internal/runtime/inbound_postgres_test.go
+++ b/internal/runtime/inbound_postgres_test.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -116,6 +117,109 @@ func TestInboundGateway_GitHubPausedRuntimePersistsAndReleasesSubscribedDispatch
 		t.Fatalf("delivered event type = %s, want %s", got.Type(), eventType)
 	}
 	requireNoInboundBusEvent(t, ch, "paused GitHub webhook releases exactly once")
+	if got := countPostgresPipelineReceiptsForEvent(t, ctx, db, eventID); got != 1 {
+		t.Fatalf("pipeline receipts after resume = %d, want 1", got)
+	}
+	if got := countPostgresInboundMarkers(t, ctx, db, providerEventID, entityID, provider); got != 1 {
+		t.Fatalf("inbound marker rows after resume = %d, want 1", got)
+	}
+	if got := countPostgresInboundProviderEvents(t, ctx, db, runID, entityID, providerEventName, providerEventID); got != 1 {
+		t.Fatalf("provider event rows after resume = %d, want 1", got)
+	}
+}
+
+func TestInboundGateway_SlackPausedRuntimePersistsAndReleasesSubscribedDispatch(t *testing.T) {
+	_, db, cleanup := testutil.StartPostgres(t)
+	t.Cleanup(cleanup)
+
+	const (
+		runID             = "42000000-0000-0000-0000-000000000001"
+		entityID          = "42000000-0000-0000-0000-000000000002"
+		flowInstance      = "slack-provider-trigger-instance"
+		entitySlug        = "customer-a"
+		provider          = "slack"
+		webhookSecret     = "slack-secret"
+		providerEventID   = "Ev123ABC456"
+		agentID           = "slack-webhook-subscriber"
+		providerEventName = "inbound.slack.message"
+	)
+	ctx := runtimecorrelation.WithRunID(context.Background(), runID)
+	pg := &store.PostgresStore{DB: db}
+	seedPostgresInboundGatewayRuntime(t, ctx, db, pg, runID, entityID, flowInstance, entitySlug, provider, webhookSecret, agentID)
+
+	bus, err := runtimebus.NewEventBus(pg)
+	if err != nil {
+		t.Fatalf("NewEventBus: %v", err)
+	}
+	controller := runtimeingress.NewController(pg, bus, runtimeingress.Options{})
+	t.Cleanup(runtimebus.ResumeRuntimeIngress)
+	bus.SetRuntimeIngressDispatchGate(controller)
+
+	eventType := events.EventType(providerEventName)
+	ch := bus.Subscribe(agentID, eventType)
+	defer bus.Unsubscribe(agentID)
+
+	if _, err := controller.Pause(ctx, runtimeingress.TransitionRequest{
+		Reason:       "test_pause",
+		ControlledBy: "test",
+	}); err != nil {
+		t.Fatalf("Pause: %v", err)
+	}
+
+	g := runtimepkg.NewInboundGateway(bus, nil, nil, pg)
+	g.SetRuntimeIngress(controller)
+
+	body := []byte(`{"type":"event_callback","event_id":"Ev123ABC456","event":{"type":"message","text":"hello"}}`)
+	timestamp := strconv.FormatInt(time.Now().UTC().Unix(), 10)
+	req := httptest.NewRequest(http.MethodPost, "/webhooks/customer-a/slack", strings.NewReader(string(body)))
+	req = req.WithContext(ctx)
+	req.Header.Set("X-Slack-Request-Timestamp", timestamp)
+	req.Header.Set("X-Slack-Signature", slackWebhookSignature(webhookSecret, timestamp, body))
+	rec := httptest.NewRecorder()
+	g.Handler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("status = %d, want 202 body=%s", rec.Code, rec.Body.String())
+	}
+	if got := countPostgresInboundMarkers(t, ctx, db, providerEventID, entityID, provider); got != 1 {
+		t.Fatalf("inbound marker rows = %d, want 1", got)
+	}
+	eventID := loadPostgresInboundProviderEventID(t, ctx, db, runID, entityID, providerEventName, providerEventID)
+	if got := countPostgresInboundProviderEvents(t, ctx, db, runID, entityID, providerEventName, providerEventID); got != 1 {
+		t.Fatalf("provider event rows = %d, want 1", got)
+	}
+	requireNoInboundBusEvent(t, ch, "paused Slack webhook before resume")
+	if got := countPostgresAgentDeliveriesForEvent(t, ctx, db, eventID, agentID); got != 1 {
+		t.Fatalf("agent delivery rows while paused = %d, want 1", got)
+	}
+	if got := loadPostgresAgentDeliveryStatus(t, ctx, db, eventID, agentID); got != "pending" {
+		t.Fatalf("agent delivery status while paused = %q, want pending", got)
+	}
+	if got := countPostgresPipelineReceiptsForEvent(t, ctx, db, eventID); got != 0 {
+		t.Fatalf("pipeline receipts while paused = %d, want 0", got)
+	}
+	if got := countPostgresAgentReceiptsForEvent(t, ctx, db, eventID, agentID); got != 0 {
+		t.Fatalf("agent receipts while paused = %d, want 0", got)
+	}
+
+	resumed, err := controller.Resume(ctx, runtimeingress.TransitionRequest{
+		Reason:       "test_resume",
+		ControlledBy: "test",
+	})
+	if err != nil {
+		t.Fatalf("Resume: %v", err)
+	}
+	if resumed.ReleasedCount != 1 {
+		t.Fatalf("released count = %d, want 1", resumed.ReleasedCount)
+	}
+	got := requireInboundBusEvent(t, ch, "paused Slack webhook release after resume")
+	if got.ID() != eventID {
+		t.Fatalf("delivered event = %s, want %s", got.ID(), eventID)
+	}
+	if got.Type() != eventType {
+		t.Fatalf("delivered event type = %s, want %s", got.Type(), eventType)
+	}
+	requireNoInboundBusEvent(t, ch, "paused Slack webhook releases exactly once")
 	if got := countPostgresPipelineReceiptsForEvent(t, ctx, db, eventID); got != 1 {
 		t.Fatalf("pipeline receipts after resume = %d, want 1", got)
 	}
@@ -328,4 +432,10 @@ func githubWebhookSignature(secret string, body []byte) string {
 	mac := hmac.New(sha256.New, []byte(secret))
 	_, _ = mac.Write(body)
 	return "sha256=" + hex.EncodeToString(mac.Sum(nil))
+}
+
+func slackWebhookSignature(secret string, timestamp string, body []byte) string {
+	mac := hmac.New(sha256.New, []byte(secret))
+	_, _ = mac.Write([]byte("v0:" + timestamp + ":" + string(body)))
+	return "v0=" + hex.EncodeToString(mac.Sum(nil))
 }

--- a/internal/runtime/inbound_test.go
+++ b/internal/runtime/inbound_test.go
@@ -9,7 +9,9 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -342,8 +344,413 @@ func TestInboundGateway_GitHubAdapterDuplicateDeliveryDoesNotPublishAgain(t *tes
 	}
 }
 
+func TestInboundGateway_SlackURLVerificationReturnsChallengeWithoutMarkerOrPublish(t *testing.T) {
+	eventStore := &capturingInboundEventStore{}
+	bus, err := runtimebus.NewEventBus(eventStore)
+	if err != nil {
+		t.Fatalf("NewEventBus: %v", err)
+	}
+	store := &recordingInboundStore{
+		target: InboundTarget{
+			EntityID:      "3fd8fc37-6d02-4d50-8bb7-14c6cb0fed0a",
+			EntitySlug:    "customer-a",
+			WebhookSecret: "slack-secret",
+		},
+		inserted: true,
+	}
+	g := NewInboundGateway(bus, nil, nil, store)
+
+	body := []byte(`{"type":"url_verification","challenge":"challenge-value","token":"deprecated-token"}`)
+	req := newSignedSlackRequest("/webhooks/customer-a/slack", "slack-secret", body, strconv.FormatInt(time.Now().UTC().Unix(), 10))
+	rec := httptest.NewRecorder()
+	g.Handler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 body=%s", rec.Code, rec.Body.String())
+	}
+	if rec.Body.String() != "challenge-value" {
+		t.Fatalf("body = %q, want challenge-value", rec.Body.String())
+	}
+	if store.recorded {
+		t.Fatal("Slack url_verification recorded inbound marker")
+	}
+	if len(eventStore.events) != 0 {
+		t.Fatalf("published events = %d, want 0", len(eventStore.events))
+	}
+	if strings.Contains(rec.Body.String(), "slack-secret") || strings.Contains(rec.Body.String(), "deprecated-token") {
+		t.Fatal("Slack secret material leaked into challenge response")
+	}
+}
+
+func TestInboundGateway_SlackURLVerificationRequiresChallengeBeforeMarkerAndPublish(t *testing.T) {
+	eventStore := &capturingInboundEventStore{}
+	bus, err := runtimebus.NewEventBus(eventStore)
+	if err != nil {
+		t.Fatalf("NewEventBus: %v", err)
+	}
+	store := &recordingInboundStore{
+		target: InboundTarget{
+			EntityID:      "3fd8fc37-6d02-4d50-8bb7-14c6cb0fed0a",
+			EntitySlug:    "customer-a",
+			WebhookSecret: "slack-secret",
+		},
+		inserted: true,
+	}
+	g := NewInboundGateway(bus, nil, nil, store)
+
+	body := []byte(`{"type":"url_verification","token":"deprecated-token"}`)
+	req := newSignedSlackRequest("/webhooks/customer-a/slack", "slack-secret", body, strconv.FormatInt(time.Now().UTC().Unix(), 10))
+	rec := httptest.NewRecorder()
+	g.Handler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400 body=%s", rec.Code, rec.Body.String())
+	}
+	if store.recorded {
+		t.Fatal("Slack url_verification without challenge recorded inbound marker")
+	}
+	if len(eventStore.events) != 0 {
+		t.Fatalf("published events = %d, want 0", len(eventStore.events))
+	}
+}
+
+func TestInboundGateway_SlackRejectsMissingSecretBeforeMarkerAndPublish(t *testing.T) {
+	eventStore := &capturingInboundEventStore{}
+	bus, err := runtimebus.NewEventBus(eventStore)
+	if err != nil {
+		t.Fatalf("NewEventBus: %v", err)
+	}
+	store := &recordingInboundStore{
+		target: InboundTarget{
+			EntityID:   "3fd8fc37-6d02-4d50-8bb7-14c6cb0fed0a",
+			EntitySlug: "customer-a",
+		},
+		inserted: true,
+	}
+	g := NewInboundGateway(bus, nil, nil, store)
+
+	body := []byte(`{"type":"event_callback","event_id":"Ev123","event":{"type":"message"}}`)
+	req := newSignedSlackRequest("/webhooks/customer-a/slack", "slack-secret", body, strconv.FormatInt(time.Now().UTC().Unix(), 10))
+	rec := httptest.NewRecorder()
+	g.Handler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401 body=%s", rec.Code, rec.Body.String())
+	}
+	if store.recorded {
+		t.Fatal("Slack request without configured signing secret recorded inbound marker")
+	}
+	if len(eventStore.events) != 0 {
+		t.Fatalf("published events = %d, want 0", len(eventStore.events))
+	}
+}
+
+func TestInboundGateway_SlackRejectsMissingOrInvalidSignatureBeforeMarkerAndPublish(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		configure func(*http.Request, []byte)
+	}{
+		{
+			name: "missing signature",
+			configure: func(req *http.Request, body []byte) {
+				req.Header.Set("X-Slack-Request-Timestamp", strconv.FormatInt(time.Now().UTC().Unix(), 10))
+			},
+		},
+		{
+			name: "invalid signature",
+			configure: func(req *http.Request, body []byte) {
+				timestamp := strconv.FormatInt(time.Now().UTC().Unix(), 10)
+				req.Header.Set("X-Slack-Request-Timestamp", timestamp)
+				req.Header.Set("X-Slack-Signature", slackWebhookSignature("wrong-secret", timestamp, body))
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			eventStore := &capturingInboundEventStore{}
+			bus, err := runtimebus.NewEventBus(eventStore)
+			if err != nil {
+				t.Fatalf("NewEventBus: %v", err)
+			}
+			store := &recordingInboundStore{
+				target: InboundTarget{
+					EntityID:      "3fd8fc37-6d02-4d50-8bb7-14c6cb0fed0a",
+					EntitySlug:    "customer-a",
+					WebhookSecret: "slack-secret",
+				},
+				inserted: true,
+			}
+			g := NewInboundGateway(bus, nil, nil, store)
+
+			body := []byte(`{"type":"event_callback","event_id":"Ev123","event":{"type":"message"}}`)
+			req := httptest.NewRequest(http.MethodPost, "/webhooks/customer-a/slack", strings.NewReader(string(body)))
+			tc.configure(req, body)
+			rec := httptest.NewRecorder()
+			g.Handler().ServeHTTP(rec, req)
+
+			if rec.Code != http.StatusUnauthorized {
+				t.Fatalf("status = %d, want 401 body=%s", rec.Code, rec.Body.String())
+			}
+			if store.recorded {
+				t.Fatal("Slack request with invalid signature recorded inbound marker")
+			}
+			if len(eventStore.events) != 0 {
+				t.Fatalf("published events = %d, want 0", len(eventStore.events))
+			}
+		})
+	}
+}
+
+func TestInboundGateway_SlackRejectsStaleTimestampBeforeMarkerAndPublish(t *testing.T) {
+	eventStore := &capturingInboundEventStore{}
+	bus, err := runtimebus.NewEventBus(eventStore)
+	if err != nil {
+		t.Fatalf("NewEventBus: %v", err)
+	}
+	store := &recordingInboundStore{
+		target: InboundTarget{
+			EntityID:      "3fd8fc37-6d02-4d50-8bb7-14c6cb0fed0a",
+			EntitySlug:    "customer-a",
+			WebhookSecret: "slack-secret",
+		},
+		inserted: true,
+	}
+	g := NewInboundGateway(bus, nil, nil, store)
+
+	body := []byte(`{"type":"event_callback","event_id":"Ev123","event":{"type":"message"}}`)
+	req := newSignedSlackRequest("/webhooks/customer-a/slack", "slack-secret", body, "1")
+	rec := httptest.NewRecorder()
+	g.Handler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401 body=%s", rec.Code, rec.Body.String())
+	}
+	if store.recorded {
+		t.Fatal("Slack request with stale timestamp recorded inbound marker")
+	}
+	if len(eventStore.events) != 0 {
+		t.Fatalf("published events = %d, want 0", len(eventStore.events))
+	}
+}
+
+func TestInboundGateway_SlackEventCallbackOwnsEventIDAndInnerEventMapping(t *testing.T) {
+	eventStore := &capturingInboundEventStore{}
+	bus, err := runtimebus.NewEventBus(eventStore)
+	if err != nil {
+		t.Fatalf("NewEventBus: %v", err)
+	}
+	store := &recordingInboundStore{
+		target: InboundTarget{
+			EntityID:      "3fd8fc37-6d02-4d50-8bb7-14c6cb0fed0a",
+			EntitySlug:    "customer-a",
+			WebhookSecret: "slack-secret",
+		},
+		inserted: true,
+	}
+	g := NewInboundGateway(bus, nil, nil, store)
+
+	body := []byte(`{"type":"event_callback","token":"deprecated-token","event_id":"Ev123ABC456","event":{"type":"message.channels","text":"hello"}}`)
+	req := newSignedSlackRequest("/webhooks/customer-a/slack", "slack-secret", body, strconv.FormatInt(time.Now().UTC().Unix(), 10))
+	rec := httptest.NewRecorder()
+	g.Handler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("status = %d, want 202 body=%s", rec.Code, rec.Body.String())
+	}
+	if !store.recorded {
+		t.Fatal("expected Slack callback to record inbound marker")
+	}
+	if store.providerEventID != "Ev123ABC456" {
+		t.Fatalf("providerEventID = %q, want Ev123ABC456", store.providerEventID)
+	}
+	if store.provider != "slack" {
+		t.Fatalf("provider = %q, want slack", store.provider)
+	}
+	if len(eventStore.events) != 1 {
+		t.Fatalf("published events = %d, want 1", len(eventStore.events))
+	}
+	evt := eventStore.events[0]
+	if evt.Type() != events.EventType("inbound.slack.message_channels") {
+		t.Fatalf("event type = %q, want inbound.slack.message_channels", evt.Type())
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(evt.Payload(), &payload); err != nil {
+		t.Fatalf("unmarshal payload: %v", err)
+	}
+	if payload["provider_event_id"] != "Ev123ABC456" || payload["event_type"] != "message_channels" || payload["provider"] != "slack" {
+		t.Fatalf("payload = %+v, want Slack delivery identity", payload)
+	}
+	payloadJSON := string(evt.Payload())
+	if strings.Contains(rec.Body.String(), "slack-secret") || strings.Contains(payloadJSON, "slack-secret") {
+		t.Fatal("Slack signing secret leaked into readback or event payload")
+	}
+	if strings.Contains(payloadJSON, "deprecated-token") {
+		t.Fatal("Slack deprecated verification token leaked into event payload")
+	}
+}
+
+func TestInboundGateway_SlackEventCallbackAcknowledgesBeforePostCommitDispatchCompletes(t *testing.T) {
+	eventStore := &capturingInboundEventStore{}
+	started := make(chan struct{}, 1)
+	release := make(chan struct{})
+	var releaseOnce sync.Once
+	releaseDispatch := func() {
+		releaseOnce.Do(func() {
+			close(release)
+		})
+	}
+	t.Cleanup(releaseDispatch)
+	bus, err := runtimebus.NewEventBusWithOptions(eventStore, runtimebus.EventBusOptions{
+		Interceptors: []runtimebus.EventInterceptor{
+			blockingInboundInterceptor{started: started, release: release},
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewEventBusWithOptions: %v", err)
+	}
+	store := &recordingInboundStore{
+		target: InboundTarget{
+			EntityID:      "3fd8fc37-6d02-4d50-8bb7-14c6cb0fed0a",
+			EntitySlug:    "customer-a",
+			WebhookSecret: "slack-secret",
+		},
+		inserted: true,
+	}
+	g := NewInboundGateway(bus, nil, nil, store)
+
+	body := []byte(`{"type":"event_callback","event_id":"Ev123ABC456","event":{"type":"message","text":"hello"}}`)
+	req := newSignedSlackRequest("/webhooks/customer-a/slack", "slack-secret", body, strconv.FormatInt(time.Now().UTC().Unix(), 10))
+	responseDone := make(chan *httptest.ResponseRecorder, 1)
+	go func() {
+		rec := httptest.NewRecorder()
+		g.Handler().ServeHTTP(rec, req)
+		responseDone <- rec
+	}()
+
+	select {
+	case <-started:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Slack callback post-commit dispatch did not start")
+	}
+	select {
+	case rec := <-responseDone:
+		if rec.Code != http.StatusAccepted {
+			t.Fatalf("status = %d, want 202 body=%s", rec.Code, rec.Body.String())
+		}
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("Slack callback response waited for post-commit dispatch completion")
+	}
+	if !store.recorded {
+		t.Fatal("expected Slack callback to record inbound marker before acknowledgement")
+	}
+	if len(eventStore.events) != 1 {
+		t.Fatalf("published events = %d, want 1 before dispatch release", len(eventStore.events))
+	}
+
+	releaseDispatch()
+	waitCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := bus.WaitForQuiescence(waitCtx); err != nil {
+		t.Fatalf("WaitForQuiescence after dispatch release: %v", err)
+	}
+}
+
+func TestInboundGateway_SlackEventCallbackRequiresEventIDBeforeMarkerAndPublish(t *testing.T) {
+	eventStore := &capturingInboundEventStore{}
+	bus, err := runtimebus.NewEventBus(eventStore)
+	if err != nil {
+		t.Fatalf("NewEventBus: %v", err)
+	}
+	store := &recordingInboundStore{
+		target: InboundTarget{
+			EntityID:      "3fd8fc37-6d02-4d50-8bb7-14c6cb0fed0a",
+			EntitySlug:    "customer-a",
+			WebhookSecret: "slack-secret",
+		},
+		inserted: true,
+	}
+	g := NewInboundGateway(bus, nil, nil, store)
+
+	body := []byte(`{"type":"event_callback","event":{"type":"message"}}`)
+	req := newSignedSlackRequest("/webhooks/customer-a/slack", "slack-secret", body, strconv.FormatInt(time.Now().UTC().Unix(), 10))
+	rec := httptest.NewRecorder()
+	g.Handler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400 body=%s", rec.Code, rec.Body.String())
+	}
+	if store.recorded {
+		t.Fatal("Slack callback without event_id recorded inbound marker")
+	}
+	if len(eventStore.events) != 0 {
+		t.Fatalf("published events = %d, want 0", len(eventStore.events))
+	}
+}
+
+func TestInboundGateway_SlackDuplicateEventDoesNotPublishAgain(t *testing.T) {
+	eventStore := &capturingInboundEventStore{}
+	bus, err := runtimebus.NewEventBus(eventStore)
+	if err != nil {
+		t.Fatalf("NewEventBus: %v", err)
+	}
+	store := &recordingInboundStore{
+		target: InboundTarget{
+			EntityID:      "3fd8fc37-6d02-4d50-8bb7-14c6cb0fed0a",
+			EntitySlug:    "customer-a",
+			WebhookSecret: "slack-secret",
+		},
+		inserted: false,
+	}
+	g := NewInboundGateway(bus, nil, nil, store)
+
+	body := []byte(`{"type":"event_callback","event_id":"Ev123ABC456","event":{"type":"message"}}`)
+	req := newSignedSlackRequest("/webhooks/customer-a/slack", "slack-secret", body, strconv.FormatInt(time.Now().UTC().Unix(), 10))
+	rec := httptest.NewRecorder()
+	g.Handler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 body=%s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), `"status":"duplicate"`) {
+		t.Fatalf("duplicate response = %s", rec.Body.String())
+	}
+	if len(eventStore.events) != 0 {
+		t.Fatalf("published events = %d, want 0", len(eventStore.events))
+	}
+}
+
 func githubWebhookSignature(secret string, body []byte) string {
 	mac := hmac.New(sha256.New, []byte(secret))
 	_, _ = mac.Write(body)
 	return "sha256=" + hex.EncodeToString(mac.Sum(nil))
+}
+
+func newSignedSlackRequest(path string, secret string, body []byte, timestamp string) *http.Request {
+	req := httptest.NewRequest(http.MethodPost, path, strings.NewReader(string(body)))
+	req.Header.Set("X-Slack-Request-Timestamp", timestamp)
+	req.Header.Set("X-Slack-Signature", slackWebhookSignature(secret, timestamp, body))
+	return req
+}
+
+func slackWebhookSignature(secret string, timestamp string, body []byte) string {
+	mac := hmac.New(sha256.New, []byte(secret))
+	_, _ = mac.Write([]byte("v0:" + timestamp + ":" + string(body)))
+	return "v0=" + hex.EncodeToString(mac.Sum(nil))
+}
+
+type blockingInboundInterceptor struct {
+	started chan<- struct{}
+	release <-chan struct{}
+}
+
+func (i blockingInboundInterceptor) Intercept(ctx context.Context, evt events.Event) (bool, []events.Event, error) {
+	select {
+	case i.started <- struct{}{}:
+	default:
+	}
+	select {
+	case <-i.release:
+		return true, nil, nil
+	case <-ctx.Done():
+		return false, nil, ctx.Err()
+	}
 }

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -5528,12 +5528,14 @@ tool_model:
     - creating a second generic webhook gateway
     - managed OAuth/token lifecycle, which belongs to `managed_credential_store`
     - provider API subscription setup/teardown unless a later child explicitly selects it
-    - Slack URL-verification challenge handling or broad provider-catalog expansion in the first slice
+    - broad provider-catalog expansion outside explicitly selected provider children
     - DB connectors, AWS SigV4/AssumeRole, non-HTTP, or native connector auth
     existing_gateway_owner: >
       `internal/runtime/inbound.go` remains the generic HTTP ingress executor for `/webhooks/{entity}/{provider}`. It
-      consumes `runtime_ingress.queueable_ingress.inbound.webhook`, persists the inbound dedupe marker before publish, and
-      publishes the normalized root ingress event returned by the provider adapter.
+      consumes `runtime_ingress.queueable_ingress.inbound.webhook`, delegates configured-provider interpretation to the
+      provider adapter, persists the inbound dedupe marker before publish for delivery callbacks, and publishes the
+      normalized root ingress event returned by the provider adapter. Provider adapters may also return an authenticated
+      response-only result when the provider protocol requires a challenge response that is not a delivery.
     secret_binding: >
       The first-slice signing-secret binding is `flow_instances.config.secrets.webhook_signing.<provider>`, where
       `<provider>` is the normalized provider token. Secret values are never returned by webhook responses or readback
@@ -5552,6 +5554,38 @@ tool_model:
         `X-GitHub-Event` is the authoritative provider event type. The canonical emitted event name is
         `inbound.github.<normalized_event_type>` and the payload includes provider, provider_event_id, event_type,
         original payload, redacted headers, and received_at.
+    configured_provider_children:
+    - provider: slack
+      issue: "#1691"
+      signature: >
+        Slack webhook deliveries and URL-verification requests require a configured signing secret and valid
+        `X-Slack-Signature` over the raw body. The verifier MUST compute HMAC-SHA256 using the base string
+        `v0:{X-Slack-Request-Timestamp}:{raw_body}` and compare the full `v0=` signature in constant time. Missing signing
+        secret, missing or malformed signature headers, invalid signatures, and stale timestamps fail before dedupe marker
+        persistence and before event publish.
+      replay_window: >
+        `X-Slack-Request-Timestamp` MUST parse as Unix seconds and be within five minutes of runtime receipt time. Requests
+        outside that window are rejected as replay-risk traffic before any marker or event side effect.
+      url_verification: >
+        Slack `type: url_verification` requests are authenticated provider ingress but not provider deliveries. After
+        successful signature and replay validation, the adapter returns HTTP 200 with the `challenge` value as a
+        response-only result. Missing `challenge` fails closed. URL verification MUST NOT call `RecordInboundEvent` and MUST
+        NOT publish an EventBus event.
+      delivery_id: >
+        Slack `type: event_callback` requests require the outer `event_id`; that value is the authoritative provider
+        delivery id and dedupe-key input. Missing `event_id` fails before dedupe marker persistence.
+      acknowledgement: >
+        Accepted Slack `event_callback` requests return success after the inbound dedupe marker, canonical event record,
+        recipient manifest, and subscribed replay scope are durably persisted or dispatch-queued. The HTTP acknowledgement
+        MUST NOT wait for post-commit pipeline dispatch, system-node handler execution, or agent delivery completion.
+      event_type: >
+        Slack event callbacks use the inner `event.type` as the authoritative provider event type. The canonical emitted
+        event name is `inbound.slack.<normalized_inner_event_type>`. Missing inner event or missing inner event type fails
+        before dedupe marker persistence.
+      redaction: >
+        Slack signing secrets and deprecated verification tokens are not returned by webhook responses, logs, persisted
+        marker readback, or published provider payloads. Deprecated Slack `token` fields are not accepted as primary proof
+        of request authenticity.
     raw_webhook_mode: >
       Unknown providers may continue through the raw generic webhook mode, but that path is a different semantic concept and
       does not prove provider-trigger adapter closure. Configured providers MUST consume their adapter owner rather than


### PR DESCRIPTION
## Summary
- Adds Slack as a configured provider adapter on the existing `InboundGateway` / `/webhooks/{entity}/{provider}` path.
- Verifies Slack signatures with `X-Slack-Request-Timestamp`, `X-Slack-Signature`, raw-body HMAC-SHA256, constant-time compare, and a five-minute replay window.
- Handles Slack `url_verification` as an authenticated response-only result with no inbound marker and no EventBus publish.
- Publishes Slack `event_callback` deliveries as `inbound.slack.<normalized_inner_event_type>` using outer `event_id` as the dedupe identity.
- Updates `platform-spec.yaml` with the selected Slack provider child semantics.

Closes #1691
Part of #1651
Related to #1458

## Governing Refs
- `platform-spec.yaml` `tool_model.provider_trigger_adapters`
- `platform-spec.yaml` `runtime_ingress.queueable_ingress.inbound.webhook`
- #1691 Pre-Implementation Coverage Audit and independent gate outcome
- Official Slack docs checked: https://docs.slack.dev/authentication/verifying-requests-from-slack/ and https://docs.slack.dev/apis/events-api/using-http-request-urls/
- `docs/IMPLEMENTER_GUIDELINES.md` and `docs/SEMANTIC_DRIFT.md` were requested but are absent in this worktree.

## Semantic Migration
- New canonical owner: configured Slack provider adapter registered under `defaultInboundProviderAdapters` and documented in `platform-spec.yaml`.
- Old non-authoritative path now invalid for configured Slack: raw webhook fallback event-id probing, generic signature/token handling, generic event-type probing, and `inbound.slack` generic mapping.
- Production paths checked for surviving old behavior: `InboundGateway.handleWebhook`, configured adapter registry, raw fallback, GitHub adapter regression, Postgres/SQLite target secret lookup through `webhook_signing.<provider>`, inbound marker persistence, EventBus publish, and paused runtime release.
- Migration completeness: complete for manual/declarative Slack `url_verification` and `event_callback` ingress. Provider API subscription setup and broader provider catalog tails remain under #1651.

## Validation
- `go test ./internal/runtime -run 'TestInboundGateway_(Slack|GitHub)' -count=1`
- `go test ./internal/runtime -run 'TestInboundGateway_(SlackPausedRuntimePersistsAndReleasesSubscribedDispatch|GitHubPausedRuntimePersistsAndReleasesSubscribedDispatch)' -count=1 -v`
- `go test ./internal/apiv1 -run TestOperatorEventPublishReturnsDurableAckBeforePostCommitDispatchCompletes -count=1 -v`
- `go test ./internal/runtime -run 'TestArtifactRepoCommitResultEventsFlowThrough(Durable|StaticService)CallbackDelivery/(success|failure)' -count=1 -v`
- `go test ./internal/runtime/cataloge2e -run 'TestCatalogRequiredSmoke/tier1_emits_single_runtime|TestTier10PolicyPatternCatalogFixtures_RealRuntime/test-policy-hard-gate-override|TestTier11FlowCompositionCatalogFixtures_RealRuntime/test-dynamic-flow-instance|TestTier3ListProcessingCatalogFixtures_RealRuntime/test-(fan-out-emit-mapping|fan-out-empty|filter-empty)' -count=1 -v`
- `go test ./...` passed on rebased branch.