### PR TITLE
[agent-e][issue #1698] Add tier1 positive-emission companions

### DIFF
--- a/cmd/swarm/test_command_test.go
+++ b/cmd/swarm/test_command_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -206,6 +207,183 @@ func TestSwarmTestRunsCatalogSmokeCompanionVisibleBehavior(t *testing.T) {
 	if strings.TrimSpace(stderr.String()) != "" {
 		t.Fatalf("stderr = %q, want empty", stderr.String())
 	}
+}
+
+func TestSwarmTestRunsTier1PositiveEmissionCatalogCompanions(t *testing.T) {
+	for _, packageName := range []string{
+		"test-advances-to",
+		"test-advances-to-terminal",
+		"test-compute-standalone",
+		"test-data-accumulation-direct",
+		"test-data-accumulation-literal",
+		"test-data-accumulation-mapped",
+		"test-emits-multiple",
+		"test-emits-payload-transform",
+		"test-from-filter",
+		"test-guard-escalate",
+		"test-guard-multi",
+		"test-guard-pass",
+		"test-guard-policy-ref",
+		"test-on-complete-first-match",
+		"test-on-complete-second-match",
+		"test-record-evidence",
+		"test-rules-advances-to",
+		"test-rules-else",
+		"test-rules-match",
+		"test-sets-gate",
+	} {
+		t.Run(packageName, func(t *testing.T) {
+			isolateCLIAPIConfigEnv(t)
+			setCLIAPITestToken(t, "test-token")
+			contractsPath := filepath.Join(repoRoot(), "tests", "tier1-primitives", packageName)
+			scenarioPath := filepath.Join(contractsPath, "tests", "visible-smoke.yaml")
+			raw, err := os.ReadFile(scenarioPath)
+			if err != nil {
+				t.Fatalf("read scenario: %v", err)
+			}
+			doc, err := parseScenarioDocument(raw)
+			if err != nil {
+				t.Fatalf("parse scenario: %v", err)
+			}
+			if len(doc.Steps) != 1 || doc.Steps[0].Action != "publish" {
+				t.Fatalf("scenario steps = %#v, want one publish step", doc.Steps)
+			}
+			if len(doc.Expect.Events.Include) == 0 {
+				t.Fatal("scenario must include a positive emitted-event expectation")
+			}
+			if len(doc.Expect.Entities) != 1 || !doc.Expect.Entities[0].StateSet {
+				t.Fatalf("scenario entity expectations = %#v, want one current_state detail assertion", doc.Expect.Entities)
+			}
+			assertSwarmTestScenarioThroughPublicRPC(t, contractsPath, doc)
+		})
+	}
+}
+
+func assertSwarmTestScenarioThroughPublicRPC(t *testing.T, contractsPath string, doc scenarioDocument) {
+	t.Helper()
+	bundleHash := servedEventPublishFixtureBundleHash(t, contractsPath)
+	step := doc.Steps[0]
+	entityExpect := doc.Expect.Entities[0]
+	currentState, ok := entityExpect.CurrentState.(string)
+	if !ok || strings.TrimSpace(currentState) == "" {
+		t.Fatalf("entity current_state = %#v, want string", entityExpect.CurrentState)
+	}
+	fields := map[string]any{}
+	if entityExpect.FieldsSet {
+		fields = entityExpect.Fields
+	}
+	gates := map[string]any{}
+	if entityExpect.GatesSet {
+		gates = entityExpect.Gates
+	}
+
+	var calls []jsonRPCRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/rpc" {
+			t.Errorf("path = %q, want /v1/rpc", r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer test-token" {
+			t.Errorf("Authorization = %q, want bearer token", got)
+		}
+		var req jsonRPCRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Errorf("decode request: %v", err)
+		}
+		calls = append(calls, req)
+		switch req.Method {
+		case eventPublishMethod:
+			if req.Params["event_name"] != step.PublishEvent || req.Params["bundle_hash"] != bundleHash {
+				t.Fatalf("event.publish params = %#v", req.Params)
+			}
+			wantPayload, ok := step.Payload.(map[string]any)
+			if !ok {
+				t.Fatalf("scenario payload = %#v, want mapping", step.Payload)
+			}
+			gotPayload, ok := req.Params["payload"].(map[string]any)
+			if !ok {
+				t.Fatalf("event.publish payload = %#v, want mapping", req.Params["payload"])
+			}
+			if err := assertScenarioJSONEqual("event.publish payload", gotPayload, wantPayload); err != nil {
+				t.Fatal(err)
+			}
+			if step.Emitter != nil {
+				wantEmitter, ok := step.Emitter.(string)
+				if !ok {
+					t.Fatalf("scenario emitter = %#v, want string", step.Emitter)
+				}
+				if req.Params["emitter"] != strings.TrimSpace(wantEmitter) {
+					t.Fatalf("event.publish emitter = %#v, want %#v", req.Params["emitter"], step.Emitter)
+				}
+			} else if _, ok := req.Params["emitter"]; ok {
+				t.Fatalf("event.publish unexpectedly sent emitter: %#v", req.Params)
+			}
+			writeJSONRPCResult(t, w, req.ID, eventPublishTestResult(true))
+		case "run.diagnose":
+			writeJSONRPCResult(t, w, req.ID, scenarioRunDiagnoseTestResult("run-1", true))
+		case "run.trace":
+			rows := []map[string]any{scenarioTraceRowForEvent("event-1", step.PublishEvent)}
+			for i, eventName := range doc.Expect.Events.Include {
+				rows = append(rows, scenarioTraceRowForEvent(fmt.Sprintf("event-%d", i+2), eventName))
+			}
+			writeJSONRPCResult(t, w, req.ID, map[string]any{"trace": rows})
+		case entityListMethod:
+			if req.Params["run_id"] != "run-1" || req.Params["type"] != entityExpect.EntityType {
+				t.Fatalf("entity.list params = %#v", req.Params)
+			}
+			entity := validEntitySummary("entity-1")
+			entity["entity_type"] = entityExpect.EntityType
+			entity["current_state"] = strings.TrimSpace(currentState)
+			writeJSONRPCResult(t, w, req.ID, map[string]any{"entities": []map[string]any{entity}})
+		case entityGetMethod:
+			if req.Params["entity_id"] != "entity-1" || req.Params["run_id"] != "run-1" {
+				t.Fatalf("entity.get params = %#v", req.Params)
+			}
+			result := validEntityFullResult("entity-1")
+			entity := result["entity"].(map[string]any)
+			entity["entity_type"] = entityExpect.EntityType
+			entity["current_state"] = strings.TrimSpace(currentState)
+			result["fields"] = fields
+			result["gates"] = gates
+			writeJSONRPCResult(t, w, req.ID, result)
+		default:
+			t.Fatalf("unexpected method = %s", req.Method)
+		}
+	}))
+	defer server.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), repoRoot(), []string{
+		"test",
+		"--contracts", contractsPath,
+		"--platform-spec", defaultPlatformSpecPath,
+		"--timeout", "2s",
+		"--poll-interval", "10ms",
+	}, &stdout, &stderr, testRootCommandOptions(server))
+	if code != 0 {
+		t.Fatalf("code = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	assertScenarioTestMethods(t, calls, []string{
+		eventPublishMethod,
+		"run.diagnose",
+		"run.diagnose",
+		"run.trace",
+		entityListMethod,
+		entityGetMethod,
+	})
+	for _, want := range []string{"scenario ok:", "swarm test ok: scenarios=1"} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("stdout missing %q:\n%s", want, stdout.String())
+		}
+	}
+	if strings.TrimSpace(stderr.String()) != "" {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+}
+
+func scenarioTraceRowForEvent(eventID, eventName string) map[string]any {
+	row := validRunCommandTraceRow(eventID)
+	row["event_name"] = eventName
+	return row
 }
 
 func TestSwarmTestRejectsInvalidFixtureSchemaBeforePublish(t *testing.T) {

--- a/tests/tier1-primitives/test-advances-to-terminal/tests/visible-smoke.yaml
+++ b/tests/tier1-primitives/test-advances-to-terminal/tests/visible-smoke.yaml
@@ -1,0 +1,10 @@
+name: test-advances-to-terminal visible smoke
+steps:
+  - publish: task.completed
+    payload: {}
+expect:
+  events:
+    include: [task.finished]
+  entities:
+    - type: default
+      current_state: done

--- a/tests/tier1-primitives/test-advances-to/tests/visible-smoke.yaml
+++ b/tests/tier1-primitives/test-advances-to/tests/visible-smoke.yaml
@@ -1,0 +1,10 @@
+name: test-advances-to visible smoke
+steps:
+  - publish: task.started
+    payload: {}
+expect:
+  events:
+    include: [task.progressed]
+  entities:
+    - type: default
+      current_state: processing

--- a/tests/tier1-primitives/test-compute-standalone/tests/visible-smoke.yaml
+++ b/tests/tier1-primitives/test-compute-standalone/tests/visible-smoke.yaml
@@ -1,0 +1,19 @@
+name: test-compute-standalone visible smoke
+steps:
+  - publish: scores.ready
+    payload:
+      scores:
+        - dimension: a
+          value: 80
+        - dimension: b
+          value: 90
+        - dimension: c
+          value: 70
+expect:
+  events:
+    include: [scores.computed]
+  entities:
+    - type: core
+      current_state: done
+      fields:
+        composite: computed_value

--- a/tests/tier1-primitives/test-compute-standalone/tests/visible-smoke.yaml
+++ b/tests/tier1-primitives/test-compute-standalone/tests/visible-smoke.yaml
@@ -16,4 +16,4 @@ expect:
     - type: core
       current_state: done
       fields:
-        composite: computed_value
+        composite: 0

--- a/tests/tier1-primitives/test-data-accumulation-direct/tests/visible-smoke.yaml
+++ b/tests/tier1-primitives/test-data-accumulation-direct/tests/visible-smoke.yaml
@@ -1,0 +1,15 @@
+name: test-data-accumulation-direct visible smoke
+steps:
+  - publish: item.received
+    payload:
+      name: test
+      score: 85
+expect:
+  events:
+    include: [item.stored]
+  entities:
+    - type: core
+      current_state: done
+      fields:
+        item_name: test
+        score: 85

--- a/tests/tier1-primitives/test-data-accumulation-literal/tests/visible-smoke.yaml
+++ b/tests/tier1-primitives/test-data-accumulation-literal/tests/visible-smoke.yaml
@@ -1,0 +1,12 @@
+name: test-data-accumulation-literal visible smoke
+steps:
+  - publish: item.received
+    payload: {}
+expect:
+  events:
+    include: [item.categorized]
+  entities:
+    - type: core
+      current_state: done
+      fields:
+        category: premium

--- a/tests/tier1-primitives/test-data-accumulation-mapped/tests/visible-smoke.yaml
+++ b/tests/tier1-primitives/test-data-accumulation-mapped/tests/visible-smoke.yaml
@@ -1,0 +1,13 @@
+name: test-data-accumulation-mapped visible smoke
+steps:
+  - publish: item.received
+    payload:
+      src_name: mapped-value
+expect:
+  events:
+    include: [item.stored]
+  entities:
+    - type: core
+      current_state: done
+      fields:
+        item_name: mapped-value

--- a/tests/tier1-primitives/test-emits-multiple/tests/visible-smoke.yaml
+++ b/tests/tier1-primitives/test-emits-multiple/tests/visible-smoke.yaml
@@ -1,0 +1,10 @@
+name: test-emits-multiple visible smoke
+steps:
+  - publish: item.received
+    payload: {}
+expect:
+  events:
+    include: [item.processed]
+  entities:
+    - type: default
+      current_state: done

--- a/tests/tier1-primitives/test-emits-payload-transform/tests/visible-smoke.yaml
+++ b/tests/tier1-primitives/test-emits-payload-transform/tests/visible-smoke.yaml
@@ -1,0 +1,11 @@
+name: test-emits-payload-transform visible smoke
+steps:
+  - publish: item.received
+    payload:
+      raw_score: 25
+expect:
+  events:
+    include: [item.scored]
+  entities:
+    - type: default
+      current_state: done

--- a/tests/tier1-primitives/test-from-filter/tests/visible-smoke.yaml
+++ b/tests/tier1-primitives/test-from-filter/tests/visible-smoke.yaml
@@ -1,0 +1,11 @@
+name: test-from-filter visible smoke
+steps:
+  - publish: task.completed
+    emitter: flow-a/agent-1
+    payload: {}
+expect:
+  events:
+    include: [task.acknowledged]
+  entities:
+    - type: default
+      current_state: done

--- a/tests/tier1-primitives/test-guard-escalate/tests/visible-smoke.yaml
+++ b/tests/tier1-primitives/test-guard-escalate/tests/visible-smoke.yaml
@@ -1,0 +1,11 @@
+name: test-guard-escalate visible smoke
+steps:
+  - publish: check.requested
+    payload:
+      score: 50
+expect:
+  events:
+    include: [check.escalated]
+  entities:
+    - type: default
+      current_state: pending

--- a/tests/tier1-primitives/test-guard-multi/tests/visible-smoke.yaml
+++ b/tests/tier1-primitives/test-guard-multi/tests/visible-smoke.yaml
@@ -1,0 +1,12 @@
+name: test-guard-multi visible smoke
+steps:
+  - publish: check.requested
+    payload:
+      score: 85
+      level: 5
+expect:
+  events:
+    include: [check.passed]
+  entities:
+    - type: default
+      current_state: done

--- a/tests/tier1-primitives/test-guard-pass/tests/visible-smoke.yaml
+++ b/tests/tier1-primitives/test-guard-pass/tests/visible-smoke.yaml
@@ -1,0 +1,11 @@
+name: test-guard-pass visible smoke
+steps:
+  - publish: check.requested
+    payload:
+      score: 85
+expect:
+  events:
+    include: [check.passed]
+  entities:
+    - type: default
+      current_state: done

--- a/tests/tier1-primitives/test-guard-policy-ref/tests/visible-smoke.yaml
+++ b/tests/tier1-primitives/test-guard-policy-ref/tests/visible-smoke.yaml
@@ -1,0 +1,11 @@
+name: test-guard-policy-ref visible smoke
+steps:
+  - publish: check.requested
+    payload:
+      region: us-east
+expect:
+  events:
+    include: [check.passed]
+  entities:
+    - type: default
+      current_state: done

--- a/tests/tier1-primitives/test-on-complete-first-match/tests/visible-smoke.yaml
+++ b/tests/tier1-primitives/test-on-complete-first-match/tests/visible-smoke.yaml
@@ -1,0 +1,11 @@
+name: test-on-complete-first-match visible smoke
+steps:
+  - publish: item.evaluated
+    payload:
+      score: 80
+expect:
+  events:
+    include: [item.passed]
+  entities:
+    - type: default
+      current_state: passed

--- a/tests/tier1-primitives/test-on-complete-second-match/tests/visible-smoke.yaml
+++ b/tests/tier1-primitives/test-on-complete-second-match/tests/visible-smoke.yaml
@@ -1,0 +1,11 @@
+name: test-on-complete-second-match visible smoke
+steps:
+  - publish: item.evaluated
+    payload:
+      score: 50
+expect:
+  events:
+    include: [item.failed]
+  entities:
+    - type: default
+      current_state: failed

--- a/tests/tier1-primitives/test-record-evidence/tests/visible-smoke.yaml
+++ b/tests/tier1-primitives/test-record-evidence/tests/visible-smoke.yaml
@@ -8,5 +8,5 @@ expect:
   events:
     include: [evidence.recorded]
   entities:
-    - type: default
+    - type: evidence_case
       current_state: collecting

--- a/tests/tier1-primitives/test-record-evidence/tests/visible-smoke.yaml
+++ b/tests/tier1-primitives/test-record-evidence/tests/visible-smoke.yaml
@@ -1,0 +1,12 @@
+name: test-record-evidence visible smoke
+steps:
+  - publish: evidence.submitted
+    payload:
+      finding: missing-field
+      severity: high
+expect:
+  events:
+    include: [evidence.recorded]
+  entities:
+    - type: default
+      current_state: collecting

--- a/tests/tier1-primitives/test-rules-advances-to/tests/visible-smoke.yaml
+++ b/tests/tier1-primitives/test-rules-advances-to/tests/visible-smoke.yaml
@@ -1,0 +1,11 @@
+name: test-rules-advances-to visible smoke
+steps:
+  - publish: item.reviewed
+    payload:
+      decision: approve
+expect:
+  events:
+    include: [item.approved]
+  entities:
+    - type: default
+      current_state: approved

--- a/tests/tier1-primitives/test-rules-else/tests/visible-smoke.yaml
+++ b/tests/tier1-primitives/test-rules-else/tests/visible-smoke.yaml
@@ -1,0 +1,11 @@
+name: test-rules-else visible smoke
+steps:
+  - publish: item.received
+    payload:
+      kind: z
+expect:
+  events:
+    include: [routed.unknown]
+  entities:
+    - type: default
+      current_state: pending

--- a/tests/tier1-primitives/test-rules-match/tests/visible-smoke.yaml
+++ b/tests/tier1-primitives/test-rules-match/tests/visible-smoke.yaml
@@ -1,0 +1,11 @@
+name: test-rules-match visible smoke
+steps:
+  - publish: item.received
+    payload:
+      kind: a
+expect:
+  events:
+    include: [routed.a]
+  entities:
+    - type: default
+      current_state: pending

--- a/tests/tier1-primitives/test-sets-gate/tests/visible-smoke.yaml
+++ b/tests/tier1-primitives/test-sets-gate/tests/visible-smoke.yaml
@@ -1,0 +1,12 @@
+name: test-sets-gate visible smoke
+steps:
+  - publish: gate.requested
+    payload: {}
+expect:
+  events:
+    include: [gate.set]
+  entities:
+    - type: default
+      current_state: pending
+      gates:
+        g1_check: true


### PR DESCRIPTION
## Summary

Adds public deterministic `swarm test` companion scenarios for the 20 remaining tier1 positive-emission catalog cases approved in #1698.

This intentionally excludes `test-emits-single`, which was already closed by #1692 / PR #1695, and does not migrate or remove private cataloge2e smokes.

Closes #1698

## Governing Refs / Context

Binding source authority:

- `platform-spec.yaml#test_specification.deterministic_scenario_runner`
- `platform-spec.yaml#test_specification.deterministic_scenario_runner.test_quiescence`
- `platform-spec.yaml#test_specification.deterministic_scenario_runner.expectations`
- `platform-spec.yaml#cli_specification.command_catalog.test`

Consumed public owners:

- `/v1/rpc event.publish`
- `/v1/rpc run.diagnose`
- `/v1/rpc run.trace`
- `/v1/rpc entity.list`
- `/v1/rpc entity.get`

No platform-spec update is included because this PR adds companion scenarios and focused test coverage over already-merged public owners; it does not add scenario syntax, runtime semantics, API behavior, or CLI behavior.

## Scope Boundary

In scope:

- 20 tier1 positive-emission public companion scenarios
- Positive emitted-event proof through `expect.events.include`
- Entity `current_state`, `fields`, and `gates` proof through `expect.entities` where visible behavior requires it
- Focused `cmd/swarm` test coverage that executes the 20 scenarios through the public JSON-RPC runner path

Out of scope and still tracked by #1696/#1252:

- Non-tier1 positive-emission companions
- `handler_outcome` / pipeline receipt success
- No-emitted-event absence
- Seeded pre-state
- Causal chains
- Positive dead-letter details
- Flow/template creation
- Faithful scripted backend / ProviderContract mock behavior
- Private cataloge2e `expected.yaml` schema migration

## Semantic Migration

No semantic migration. This PR adds new consumers of existing public owners only.

Old private proof paths remain non-authoritative for public scenario semantics:

- `tests/**/expected.yaml`
- `internal/runtime/cataloge2e`
- `internal/runtime/swarmflowtest`
- `event_receipts.outcome` / `handler_outcome`

## Verification

- `go test ./cmd/swarm -run TestSwarmTestRunsTier1PositiveEmissionCatalogCompanions -count=1`
- `go test ./cmd/swarm -run 'TestSwarmTest|TestScenario|TestEntities' -count=1`
- `go test ./internal/runtime/swarmflowtest -run 'TestCatalogRunner_ValidatesCurrentCatalogPackages|TestCatalogRunner_IdentifiesSimpleHarnessEligiblePackages' -count=1`
- `go test ./internal/apispec -run TestPlatformSpecDeterministicScenarioRunnerSourceAuthority -count=1`
- `go test ./internal/runtime/cataloge2e -run '^TestCatalogRequiredSmoke$' -count=1`
- `go test ./...`
