### PR TITLE
[agent-c][issue #1667] Resolve artifact repo activity disposition

### DIFF
--- a/internal/runtime/conformance/deterministic_work_ladder_design_record_test.go
+++ b/internal/runtime/conformance/deterministic_work_ladder_design_record_test.go
@@ -594,8 +594,8 @@ func validateDeterministicWorkLadderDesignRepairs(repairs []deterministicWorkLad
 	if artifactDisposition.Decision != "canonical_action_owner_until_write_activity_journal" {
 		problems = append(problems, fmt.Sprintf("repair artifact_repo_commit_disposition decision = %q, want canonical_action_owner_until_write_activity_journal", artifactDisposition.Decision))
 	}
-	if artifactDisposition.CanonicalOwner != "platform-spec.yaml#handler_specification.handler_fields.action.artifact_repo_commit" {
-		problems = append(problems, fmt.Sprintf("repair artifact_repo_commit_disposition canonical_owner = %q, want platform-spec.yaml#handler_specification.handler_fields.action.artifact_repo_commit", artifactDisposition.CanonicalOwner))
+	if artifactDisposition.CanonicalOwner != "platform-spec.yaml#handler_specification.handler_fields.action.valid_values.artifact_repo_commit" {
+		problems = append(problems, fmt.Sprintf("repair artifact_repo_commit_disposition canonical_owner = %q, want platform-spec.yaml#handler_specification.handler_fields.action.valid_values.artifact_repo_commit", artifactDisposition.CanonicalOwner))
 	}
 	if artifactDisposition.CurrentDisposition != "canonical_platform_action_owner" {
 		problems = append(problems, fmt.Sprintf("repair artifact_repo_commit_disposition current_disposition = %q, want canonical_platform_action_owner", artifactDisposition.CurrentDisposition))

--- a/internal/runtime/conformance/deterministic_work_ladder_design_record_test.go
+++ b/internal/runtime/conformance/deterministic_work_ladder_design_record_test.go
@@ -71,21 +71,26 @@ type deterministicWorkLadderLockedBoundary struct {
 }
 
 type deterministicWorkLadderDesignRepair struct {
-	ID                                    string   `yaml:"id"`
-	OwnerIssue                            int      `yaml:"owner_issue"`
-	Decision                              string   `yaml:"decision"`
-	HiddenRuntimeSurfaceAllowed           bool     `yaml:"hidden_runtime_surface_allowed"`
-	RequiredSurfaces                      []string `yaml:"required_surfaces"`
-	SelectedName                          string   `yaml:"selected_name"`
-	ExistingComputeOwner                  string   `yaml:"existing_compute_owner"`
-	ExistingComputePreserved              bool     `yaml:"existing_compute_preserved"`
-	ForbiddenOverloads                    []string `yaml:"forbidden_overloads"`
-	ProseOnlyPlacementAllowed             bool     `yaml:"prose_only_placement_allowed"`
-	MCPSelfClassificationAuthoritative    bool     `yaml:"mcp_self_classification_authoritative"`
-	DefaultWithoutAuthoredClassification  string   `yaml:"default_without_authored_classification"`
-	CurrentActionSurvivesUntilDisposition bool     `yaml:"current_action_survives_until_disposition"`
-	EvidenceOwner                         string   `yaml:"evidence_owner"`
-	Note                                  string   `yaml:"note"`
+	ID                                   string   `yaml:"id"`
+	OwnerIssue                           int      `yaml:"owner_issue"`
+	Decision                             string   `yaml:"decision"`
+	HiddenRuntimeSurfaceAllowed          bool     `yaml:"hidden_runtime_surface_allowed"`
+	RequiredSurfaces                     []string `yaml:"required_surfaces"`
+	SelectedName                         string   `yaml:"selected_name"`
+	ExistingComputeOwner                 string   `yaml:"existing_compute_owner"`
+	ExistingComputePreserved             bool     `yaml:"existing_compute_preserved"`
+	ForbiddenOverloads                   []string `yaml:"forbidden_overloads"`
+	ProseOnlyPlacementAllowed            bool     `yaml:"prose_only_placement_allowed"`
+	MCPSelfClassificationAuthoritative   bool     `yaml:"mcp_self_classification_authoritative"`
+	DefaultWithoutAuthoredClassification string   `yaml:"default_without_authored_classification"`
+	CanonicalOwner                       string   `yaml:"canonical_owner"`
+	CurrentDisposition                   string   `yaml:"current_disposition"`
+	ActivityOwnerStatus                  string   `yaml:"activity_owner_status"`
+	MigrationBlocker                     string   `yaml:"migration_blocker"`
+	FutureMigrationCondition             string   `yaml:"future_migration_condition"`
+	CurrentActionSurvivesUntilMigration  bool     `yaml:"current_action_survives_until_migration"`
+	EvidenceOwner                        string   `yaml:"evidence_owner"`
+	Note                                 string   `yaml:"note"`
 }
 
 type deterministicWorkLadderLaunchLanguage struct {
@@ -263,6 +268,75 @@ func TestDeterministicWorkLadderDesignRecordRejectsStaleOrRuntimeClaims(t *testi
 				t.Fatalf("validation problems missing %q:\n- %s", tc.want, strings.Join(problems, "\n- "))
 			}
 		})
+	}
+}
+
+func TestDeterministicWorkLadderArtifactRepoDispositionPromotedToPlatformSpec(t *testing.T) {
+	root := conformanceRepoRoot(t)
+	raw, err := os.ReadFile(filepath.Join(root, "platform-spec.yaml"))
+	if err != nil {
+		t.Fatalf("read platform spec: %v", err)
+	}
+	var spec map[string]any
+	if err := yaml.Unmarshal(raw, &spec); err != nil {
+		t.Fatalf("parse platform spec: %v", err)
+	}
+	artifact := yamlMapAt(t, spec,
+		"handler_specification",
+		"handler_fields",
+		"action",
+		"valid_values",
+		"artifact_repo_commit",
+	)
+	disposition := yamlMapValue(t, artifact, "durable_activity_disposition")
+	for field, wants := range map[string][]string{
+		"current_owner": {
+			"canonical platform owner",
+			"action.id: artifact_repo_commit",
+			"not an alternate",
+		},
+		"activity_non_owner_paths": {
+			"platform_builtin",
+			"MCP",
+			"native/generated",
+			"shell",
+			"HTTP-tool activity",
+			"fail closed",
+		},
+		"migration_blocker": {
+			"read_only authored HTTP",
+			"idempotent_write",
+			"non_idempotent_write",
+			"stable activity attempt/result journal",
+			"idempotency execution owner",
+		},
+		"future_migration_condition": {
+			"separately gated migration",
+			"provider/root/path allowlist",
+			"provider request history",
+			"output-state repair",
+			"success/failure result-event guarantees",
+		},
+	} {
+		got := yamlStringValue(t, disposition, field)
+		for _, want := range wants {
+			if !strings.Contains(got, want) {
+				t.Fatalf("platform spec artifact_repo_commit durable_activity_disposition.%s missing %q in:\n%s", field, want, got)
+			}
+		}
+	}
+
+	platformBuiltin := yamlStringAt(t, spec,
+		"handler_specification",
+		"handler_fields",
+		"activity",
+		"supported_tool_sources",
+		"platform_builtin",
+	)
+	for _, want := range []string{"Not callable from activity", "artifact_repo_commit", "action-owned", "write-effect activity migration"} {
+		if !strings.Contains(platformBuiltin, want) {
+			t.Fatalf("platform spec activity.supported_tool_sources.platform_builtin missing %q in:\n%s", want, platformBuiltin)
+		}
 	}
 }
 
@@ -517,8 +591,28 @@ func validateDeterministicWorkLadderDesignRepairs(repairs []deterministicWorkLad
 	if artifactDisposition.OwnerIssue != 1667 {
 		problems = append(problems, fmt.Sprintf("repair artifact_repo_commit_disposition owner_issue = %d, want 1667", artifactDisposition.OwnerIssue))
 	}
-	if !artifactDisposition.CurrentActionSurvivesUntilDisposition {
-		problems = append(problems, "repair artifact_repo_commit_disposition current_action_survives_until_disposition = false, want true")
+	if artifactDisposition.Decision != "canonical_action_owner_until_write_activity_journal" {
+		problems = append(problems, fmt.Sprintf("repair artifact_repo_commit_disposition decision = %q, want canonical_action_owner_until_write_activity_journal", artifactDisposition.Decision))
+	}
+	if artifactDisposition.CanonicalOwner != "platform-spec.yaml#handler_specification.handler_fields.action.artifact_repo_commit" {
+		problems = append(problems, fmt.Sprintf("repair artifact_repo_commit_disposition canonical_owner = %q, want platform-spec.yaml#handler_specification.handler_fields.action.artifact_repo_commit", artifactDisposition.CanonicalOwner))
+	}
+	if artifactDisposition.CurrentDisposition != "canonical_platform_action_owner" {
+		problems = append(problems, fmt.Sprintf("repair artifact_repo_commit_disposition current_disposition = %q, want canonical_platform_action_owner", artifactDisposition.CurrentDisposition))
+	}
+	if artifactDisposition.ActivityOwnerStatus != "non_owner_for_artifact_commits" {
+		problems = append(problems, fmt.Sprintf("repair artifact_repo_commit_disposition activity_owner_status = %q, want non_owner_for_artifact_commits", artifactDisposition.ActivityOwnerStatus))
+	}
+	if artifactDisposition.MigrationBlocker != "stable_activity_attempt_result_journal_and_idempotency_execution_owner" {
+		problems = append(problems, fmt.Sprintf("repair artifact_repo_commit_disposition migration_blocker = %q, want stable_activity_attempt_result_journal_and_idempotency_execution_owner", artifactDisposition.MigrationBlocker))
+	}
+	for _, want := range []string{"separately gated", "artifact root/path safety", "provider request history", "output-state repair", "result-event guarantees"} {
+		if !strings.Contains(artifactDisposition.FutureMigrationCondition, want) {
+			problems = append(problems, fmt.Sprintf("repair artifact_repo_commit_disposition future_migration_condition missing %q", want))
+		}
+	}
+	if !artifactDisposition.CurrentActionSurvivesUntilMigration {
+		problems = append(problems, "repair artifact_repo_commit_disposition current_action_survives_until_migration = false, want true")
 	}
 
 	stageOrder := byID["stage_order_after_activity"]
@@ -657,6 +751,9 @@ func validateDeterministicWorkLadderManifestationCoverage(coverage []determinist
 			problems = append(problems, fmt.Sprintf("manifestation_coverage missing %s", id))
 		}
 	}
+	if artifactSilence, ok := byID["artifact_repo_commit_silence"]; ok && artifactSilence.Status != "closed_by_child_issue" {
+		problems = append(problems, fmt.Sprintf("manifestation artifact_repo_commit_silence status = %q, want closed_by_child_issue", artifactSilence.Status))
+	}
 	return problems
 }
 
@@ -701,6 +798,50 @@ func deterministicWorkLadderManifestationByID(t *testing.T, record *deterministi
 	}
 	t.Fatalf("manifestation %s not found", id)
 	return deterministicWorkLadderDesignManifestation{}
+}
+
+func yamlMapAt(t *testing.T, root map[string]any, path ...string) map[string]any {
+	t.Helper()
+	current := root
+	for _, key := range path {
+		current = yamlMapValue(t, current, key)
+	}
+	return current
+}
+
+func yamlStringAt(t *testing.T, root map[string]any, path ...string) string {
+	t.Helper()
+	if len(path) == 0 {
+		t.Fatal("empty yaml string path")
+	}
+	parent := yamlMapAt(t, root, path[:len(path)-1]...)
+	return yamlStringValue(t, parent, path[len(path)-1])
+}
+
+func yamlMapValue(t *testing.T, parent map[string]any, key string) map[string]any {
+	t.Helper()
+	raw, ok := parent[key]
+	if !ok {
+		t.Fatalf("yaml map missing key %s", key)
+	}
+	value, ok := raw.(map[string]any)
+	if !ok {
+		t.Fatalf("yaml key %s type = %T, want map[string]any", key, raw)
+	}
+	return value
+}
+
+func yamlStringValue(t *testing.T, parent map[string]any, key string) string {
+	t.Helper()
+	raw, ok := parent[key]
+	if !ok {
+		t.Fatalf("yaml map missing key %s", key)
+	}
+	value, ok := raw.(string)
+	if !ok {
+		t.Fatalf("yaml key %s type = %T, want string", key, raw)
+	}
+	return value
 }
 
 func deterministicWorkLadderStringsExcept(values []string, remove string) []string {

--- a/internal/runtime/conformance/testdata/deterministic_work_ladder_design_record.yaml
+++ b/internal/runtime/conformance/testdata/deterministic_work_ladder_design_record.yaml
@@ -113,8 +113,18 @@ repairs:
       fork policy ad hoc from orchestration or trace code.
   - id: artifact_repo_commit_disposition
     owner_issue: 1667
-    decision: split_explicit_disposition
-    current_action_survives_until_disposition: true
+    decision: canonical_action_owner_until_write_activity_journal
+    canonical_owner: platform-spec.yaml#handler_specification.handler_fields.action.artifact_repo_commit
+    current_disposition: canonical_platform_action_owner
+    activity_owner_status: non_owner_for_artifact_commits
+    migration_blocker: stable_activity_attempt_result_journal_and_idempotency_execution_owner
+    future_migration_condition: >
+      Only a separately gated write-effect activity migration may rebind
+      artifact repository commits, and only if it preserves artifact root/path
+      safety, provider request history, output-state repair, and declared
+      success/failure result-event guarantees in the same merge-bearing
+      spec/runtime/verifier PR.
+    current_action_survives_until_migration: true
   - id: stage_order_after_activity
     owner_issue: 1668
     decision: declarative_helpers_before_compute_module
@@ -207,7 +217,7 @@ manifestation_coverage:
     status: closed_by_design_record
     proof: repairs.effect_class_fork_policy_defaults
   - id: artifact_repo_commit_silence
-    status: split_to_child_issue
+    status: closed_by_child_issue
     proof: repairs.artifact_repo_commit_disposition
   - id: python_launch_language_decision
     status: closed_by_design_record

--- a/internal/runtime/conformance/testdata/deterministic_work_ladder_design_record.yaml
+++ b/internal/runtime/conformance/testdata/deterministic_work_ladder_design_record.yaml
@@ -114,7 +114,7 @@ repairs:
   - id: artifact_repo_commit_disposition
     owner_issue: 1667
     decision: canonical_action_owner_until_write_activity_journal
-    canonical_owner: platform-spec.yaml#handler_specification.handler_fields.action.artifact_repo_commit
+    canonical_owner: platform-spec.yaml#handler_specification.handler_fields.action.valid_values.artifact_repo_commit
     current_disposition: canonical_platform_action_owner
     activity_owner_status: non_owner_for_artifact_commits
     migration_blocker: stable_activity_attempt_result_journal_and_idempotency_execution_owner

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -2142,8 +2142,8 @@ handler_specification:
           using credentials, managed_credential, response_mapping, rate_limit, or rate_limit_max_wait are not admitted to
           activities in Stage 1; those subfeatures require later owner consumption before activity execution may claim them.
         platform_builtin: Not callable from activity in Stage 1; fail closed. This includes `artifact_repo_commit`, which
-          remains action-owned under `handler_fields.action.artifact_repo_commit` until a separately gated write-effect
-          activity migration preserves that action's artifact safety and idempotency guarantees.
+          remains action-owned under `handler_fields.action.valid_values.artifact_repo_commit` until a separately gated
+          write-effect activity migration preserves that action's artifact safety and idempotency guarantees.
         mcp: Not callable from activity in Stage 1. MCP-discovered/self-described effect classes are not authoritative; an
           authored registration-site override is required in a future slice before MCP tools can be activity-callable.
         native_or_generated_tools: Not callable from activity in Stage 1; fail closed.

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -2087,6 +2087,24 @@ handler_specification:
             the accepted request but entity output persistence is missing or stale, retry reconstructs and persists the
             contract-visible repo_url, current_ref, file_manifest, status, and last_source_event_id from durable provider history.
             If failure_event is declared, the runtime also enqueues that typed event in the same transaction as failed status.
+          durable_activity_disposition:
+            current_owner: >
+              This action remains the canonical platform owner for artifact repository commits. Authors request
+              artifact repository writes through `action.id: artifact_repo_commit`; durable `activity` is not an alternate
+              authoring, verification, dispatch, replay, or result-event path for artifact commits in the current platform.
+            activity_non_owner_paths: >
+              `artifact_repo_commit` is not callable as a platform_builtin, MCP, native/generated,
+              shell, product-local git, or HTTP-tool activity. Those paths must fail closed or remain different semantic
+              concepts; they do not prove artifact commit support.
+            migration_blocker: >
+              Generic durable activities currently execute only read_only authored HTTP tools. idempotent_write
+              and non_idempotent_write activities remain non-executable until a stable activity attempt/result journal and
+              idempotency execution owner are specified and implemented.
+            future_migration_condition: >
+              A separately gated migration may rebind artifact repository commits to a built-in
+              activity only if it preserves the current provider/root/path allowlist, schema/size/ref validation, provider
+              request history, output-state repair, and success/failure result-event guarantees in the same merge-bearing
+              spec/runtime/verifier PR.
           fail_closed: Invalid provider, missing or non-UUID identities, invalid root, traversal, symlink/root escape, allowlist
             miss, unsupported content type, missing/failed yaml schema validation, size-limit violation, git write/commit failure,
             invalid ref, and idempotency conflict all fail closed. No agent prompt, native_tools, shell command, or product-local
@@ -2123,7 +2141,9 @@ handler_specification:
           in tools.yaml, resolve to handler_type http, include an http block, and declare effect_class read_only. HTTP tools
           using credentials, managed_credential, response_mapping, rate_limit, or rate_limit_max_wait are not admitted to
           activities in Stage 1; those subfeatures require later owner consumption before activity execution may claim them.
-        platform_builtin: Not callable from activity in Stage 1; fail closed.
+        platform_builtin: Not callable from activity in Stage 1; fail closed. This includes `artifact_repo_commit`, which
+          remains action-owned under `handler_fields.action.artifact_repo_commit` until a separately gated write-effect
+          activity migration preserves that action's artifact safety and idempotency guarantees.
         mcp: Not callable from activity in Stage 1. MCP-discovered/self-described effect classes are not authoritative; an
           authored registration-site override is required in a future slice before MCP tools can be activity-callable.
         native_or_generated_tools: Not callable from activity in Stage 1; fail closed.


### PR DESCRIPTION
## Summary

Closes #1667
Part of #1663

Records the durable-activity disposition for `artifact_repo_commit` in the authoritative spec and deterministic-work conformance record:

- `artifact_repo_commit` remains the canonical platform action owner for artifact repository commits.
- Generic durable `activity` is explicitly non-authoritative for artifact commits in the current platform.
- `platform_builtin`, MCP, native/generated, shell, product-local git, and HTTP-tool activity paths are not artifact commit owners and must fail closed or remain different concepts.
- Future migration is blocked until write-effect activities have a stable attempt/result journal and idempotency execution owner that can preserve artifact safety, output-state repair, provider history, and result-event guarantees.

## Governing Refs / Context

Exact spec refs:

- `platform-spec.yaml#handler_specification.handler_fields.action.valid_values.artifact_repo_commit`
- `platform-spec.yaml#handler_specification.handler_fields.activity`
- `platform-spec.yaml#handler_specification.handler_fields.activity.supported_tool_sources`
- `platform-spec.yaml#handler_specification.handler_fields.activity.effect_classes`
- `platform-spec.yaml#runtime_storage.artifact_root`

Binding issue/gate context:

- #1667 Pre-Implementation Coverage Audit
- #1667 Gate C outcome: approved as first-slice disposition work
- #1663 deterministic-work ladder parent tracker
- #1666 / PR #1689 read-only authored HTTP activity boundary; write-effect activity execution remains fail-closed

## Semantic Migration / Disposition

No runtime migration is performed in this PR.

- New canonical owner after this PR: the existing `action.valid_values.artifact_repo_commit` platform-spec/runtime action owner.
- Old invalid paths now explicit: generic durable activity, `platform_builtin`, MCP, native/generated, shell, product-local git, and HTTP-tool activity paths are not artifact commit owners.
- Production paths checked for surviving old behavior: platform spec action/activity surfaces, artifact action runner, engine action dispatch, artifact boot/verify checks, artifact root readiness, action result-event delivery, and activity admission boundaries.
- Migration complete? Disposition is complete for #1667. Actual migration of artifact commits into a built-in durable activity is deferred until separately gated write-effect journal/idempotency work exists.

## Validation

Using host Postgres as requested:

- `SWARM_TEST_POSTGRES_DSN='host=127.0.0.1 port=5432 user=youmew dbname=postgres sslmode=disable' PGPASSWORD=postgres go test ./internal/runtime/conformance -run 'TestDeterministicWorkLadder(ArtifactRepoDispositionPromotedToPlatformSpec|DesignRecord|Stage0)' -count=1 -timeout=60s`
- `SWARM_TEST_POSTGRES_DSN='host=127.0.0.1 port=5432 user=youmew dbname=postgres sslmode=disable' PGPASSWORD=postgres go test ./internal/runtime/pipeline -run 'ArtifactRepo|ArtifactRepoCommit|SourceUsesArtifactRepoCommit' -count=1 -timeout=120s`
- `SWARM_TEST_POSTGRES_DSN='host=127.0.0.1 port=5432 user=youmew dbname=postgres sslmode=disable' PGPASSWORD=postgres go test ./internal/runtime/bootverify -run 'ArtifactRepoCommit|ArtifactRepo' -count=1 -timeout=120s`
- `SWARM_TEST_POSTGRES_DSN='host=127.0.0.1 port=5432 user=youmew dbname=postgres sslmode=disable' PGPASSWORD=postgres go test ./internal/runtime -run 'ArtifactRepoCommitResultEvents|ArtifactRepo' -count=1 -timeout=120s`
- `SWARM_TEST_POSTGRES_DSN='host=127.0.0.1 port=5432 user=youmew dbname=postgres sslmode=disable' PGPASSWORD=postgres go test ./...`

Review follow-up:

- `SWARM_TEST_POSTGRES_DSN='host=127.0.0.1 port=5432 user=youmew dbname=postgres sslmode=disable' PGPASSWORD=postgres go test ./internal/runtime/conformance -run 'TestDeterministicWorkLadder(ArtifactRepoDispositionPromotedToPlatformSpec|DesignRecord|Stage0)' -count=1 -timeout=60s`
- `SWARM_TEST_POSTGRES_DSN='host=127.0.0.1 port=5432 user=youmew dbname=postgres sslmode=disable' PGPASSWORD=postgres go test ./internal/runtime/conformance -count=1 -timeout=180s`
