### PR TITLE
[agent-e][issue #1705] Add tier3 list processing companions

### DIFF
--- a/cmd/swarm/test_command_test.go
+++ b/cmd/swarm/test_command_test.go
@@ -259,6 +259,53 @@ func TestSwarmTestRunsTier1PositiveEmissionCatalogCompanions(t *testing.T) {
 	}
 }
 
+func TestSwarmTestRunsTier3ListProcessingCatalogCompanions(t *testing.T) {
+	for _, tc := range []struct {
+		packageName       string
+		wantPositiveEvent bool
+	}{
+		{packageName: "test-fan-out-basic", wantPositiveEvent: true},
+		{packageName: "test-fan-out-count", wantPositiveEvent: true},
+		{packageName: "test-fan-out-emit-mapping", wantPositiveEvent: true},
+		{packageName: "test-fan-out-empty"},
+		{packageName: "test-filter-basic", wantPositiveEvent: true},
+		{packageName: "test-filter-empty", wantPositiveEvent: true},
+		{packageName: "test-group-by-standalone", wantPositiveEvent: true},
+		{packageName: "test-reduce-count", wantPositiveEvent: true},
+		{packageName: "test-reduce-max", wantPositiveEvent: true},
+		{packageName: "test-reduce-min", wantPositiveEvent: true},
+		{packageName: "test-reduce-operation-count", wantPositiveEvent: true},
+	} {
+		t.Run(tc.packageName, func(t *testing.T) {
+			isolateCLIAPIConfigEnv(t)
+			setCLIAPITestToken(t, "test-token")
+			contractsPath := filepath.Join(repoRoot(), "tests", "tier3-list-processing", tc.packageName)
+			scenarioPath := filepath.Join(contractsPath, "tests", "visible-smoke.yaml")
+			raw, err := os.ReadFile(scenarioPath)
+			if err != nil {
+				t.Fatalf("read scenario: %v", err)
+			}
+			doc, err := parseScenarioDocument(raw)
+			if err != nil {
+				t.Fatalf("parse scenario: %v", err)
+			}
+			if len(doc.Steps) != 1 || doc.Steps[0].Action != "publish" {
+				t.Fatalf("scenario steps = %#v, want one publish step", doc.Steps)
+			}
+			if tc.wantPositiveEvent && len(doc.Expect.Events.Include) == 0 {
+				t.Fatal("scenario must include a positive emitted-event expectation")
+			}
+			if !tc.wantPositiveEvent && len(doc.Expect.Events.Include) != 0 {
+				t.Fatalf("scenario includes events %#v, want no event-output assertion", doc.Expect.Events.Include)
+			}
+			if len(doc.Expect.Entities) != 1 || !doc.Expect.Entities[0].StateSet {
+				t.Fatalf("scenario entity expectations = %#v, want one current_state detail assertion", doc.Expect.Entities)
+			}
+			assertSwarmTestScenarioThroughPublicRPC(t, contractsPath, doc)
+		})
+	}
+}
+
 func assertSwarmTestScenarioThroughPublicRPC(t *testing.T, contractsPath string, doc scenarioDocument) {
 	t.Helper()
 	bundleHash := servedEventPublishFixtureBundleHash(t, contractsPath)

--- a/tests/tier3-list-processing/test-fan-out-basic/tests/visible-smoke.yaml
+++ b/tests/tier3-list-processing/test-fan-out-basic/tests/visible-smoke.yaml
@@ -1,0 +1,16 @@
+name: test-fan-out-basic visible smoke
+steps:
+  - publish: batch.submitted
+    payload:
+      items:
+        - id: item-1
+        - id: item-2
+        - id: item-3
+expect:
+  events:
+    include: [item.assigned]
+  entities:
+    - type: default
+      current_state: scanning
+      fields:
+        fan_out_count: 3

--- a/tests/tier3-list-processing/test-fan-out-count/tests/visible-smoke.yaml
+++ b/tests/tier3-list-processing/test-fan-out-count/tests/visible-smoke.yaml
@@ -1,0 +1,16 @@
+name: test-fan-out-count visible smoke
+steps:
+  - publish: batch.received
+    payload:
+      items:
+        - id: task-a
+        - id: task-b
+        - id: task-c
+expect:
+  events:
+    include: [task.dispatched]
+  entities:
+    - type: default
+      current_state: processing
+      fields:
+        fan_out_count: 3

--- a/tests/tier3-list-processing/test-fan-out-emit-mapping/tests/visible-smoke.yaml
+++ b/tests/tier3-list-processing/test-fan-out-emit-mapping/tests/visible-smoke.yaml
@@ -1,0 +1,15 @@
+name: test-fan-out-emit-mapping visible smoke
+steps:
+  - publish: batch.submitted
+    payload:
+      items:
+        - kind: a
+          id: item-1
+        - kind: b
+          id: item-2
+expect:
+  events:
+    include: [routed.a]
+  entities:
+    - type: default
+      current_state: routing

--- a/tests/tier3-list-processing/test-fan-out-empty/tests/visible-smoke.yaml
+++ b/tests/tier3-list-processing/test-fan-out-empty/tests/visible-smoke.yaml
@@ -1,0 +1,11 @@
+name: test-fan-out-empty visible smoke
+steps:
+  - publish: batch.submitted
+    payload:
+      items: []
+expect:
+  entities:
+    - type: default
+      current_state: scanning
+      fields:
+        fan_out_count: 0

--- a/tests/tier3-list-processing/test-filter-basic/tests/visible-smoke.yaml
+++ b/tests/tier3-list-processing/test-filter-basic/tests/visible-smoke.yaml
@@ -1,0 +1,18 @@
+name: test-filter-basic visible smoke
+steps:
+  - publish: items.submitted
+    payload:
+      items:
+        - score: 80
+        - score: 30
+        - score: 70
+expect:
+  events:
+    include: [items.filtered]
+  entities:
+    - type: core
+      current_state: done
+      fields:
+        filtered:
+          - score: 80
+          - score: 70

--- a/tests/tier3-list-processing/test-filter-empty/tests/visible-smoke.yaml
+++ b/tests/tier3-list-processing/test-filter-empty/tests/visible-smoke.yaml
@@ -1,0 +1,16 @@
+name: test-filter-empty visible smoke
+steps:
+  - publish: items.submitted
+    payload:
+      items:
+        - score: 10
+        - score: 20
+        - score: 40
+expect:
+  events:
+    include: [items.filtered]
+  entities:
+    - type: core
+      current_state: done
+      fields:
+        filtered: []

--- a/tests/tier3-list-processing/test-group-by-standalone/tests/visible-smoke.yaml
+++ b/tests/tier3-list-processing/test-group-by-standalone/tests/visible-smoke.yaml
@@ -1,0 +1,27 @@
+name: test-group-by-standalone visible smoke
+steps:
+  - publish: items.submitted
+    payload:
+      items:
+        - name: a
+          category: x
+        - name: b
+          category: y
+        - name: c
+          category: x
+expect:
+  events:
+    include: [items.grouped]
+  entities:
+    - type: core
+      current_state: done
+      fields:
+        grouped:
+          x:
+            - name: a
+              category: x
+            - name: c
+              category: x
+          y:
+            - name: b
+              category: y

--- a/tests/tier3-list-processing/test-reduce-count/tests/visible-smoke.yaml
+++ b/tests/tier3-list-processing/test-reduce-count/tests/visible-smoke.yaml
@@ -1,0 +1,19 @@
+name: test-reduce-count visible smoke
+steps:
+  - publish: items.submitted
+    payload:
+      items:
+        - id: item-1
+          active: true
+        - id: item-2
+          active: false
+        - id: item-3
+          active: true
+expect:
+  events:
+    include: [items.counted]
+  entities:
+    - type: core
+      current_state: done
+      fields:
+        active_count: 2

--- a/tests/tier3-list-processing/test-reduce-max/tests/visible-smoke.yaml
+++ b/tests/tier3-list-processing/test-reduce-max/tests/visible-smoke.yaml
@@ -1,0 +1,18 @@
+name: test-reduce-max visible smoke
+steps:
+  - publish: values.submitted
+    payload:
+      values:
+        - 10
+        - 5
+        - 20
+        - 3
+        - 15
+expect:
+  events:
+    include: [values.reduced]
+  entities:
+    - type: core
+      current_state: done
+      fields:
+        maximum: 20

--- a/tests/tier3-list-processing/test-reduce-min/tests/visible-smoke.yaml
+++ b/tests/tier3-list-processing/test-reduce-min/tests/visible-smoke.yaml
@@ -1,0 +1,18 @@
+name: test-reduce-min visible smoke
+steps:
+  - publish: values.submitted
+    payload:
+      values:
+        - 10
+        - 5
+        - 20
+        - 3
+        - 15
+expect:
+  events:
+    include: [values.reduced]
+  entities:
+    - type: core
+      current_state: done
+      fields:
+        minimum: 3

--- a/tests/tier3-list-processing/test-reduce-operation-count/tests/visible-smoke.yaml
+++ b/tests/tier3-list-processing/test-reduce-operation-count/tests/visible-smoke.yaml
@@ -1,0 +1,17 @@
+name: test-reduce-operation-count visible smoke
+steps:
+  - publish: batch.submitted
+    payload:
+      items:
+        - id: a
+        - id: b
+        - id: c
+        - id: d
+expect:
+  events:
+    include: [batch.counted]
+  entities:
+    - type: core
+      current_state: done
+      fields:
+        item_count: 4


### PR DESCRIPTION
## Summary

Adds public deterministic `swarm test` visible-smoke companions for the repaired #1705 tier3 list-processing slice.

In scope:

- 11 tier3 current-public-owner visible companions.
- `test-fan-out-empty` asserts only public entity state/field behavior; no-output absence remains split.
- Fan-out duplicate-event rows assert positive event-name presence plus `fan_out_count`; exact emitted-event multiplicity remains split.
- Focused `cmd/swarm` proof that the new companions execute through public scenario owners.

Out of scope:

- Public `handler_outcome`.
- No-output absence proof.
- Exact emitted-event multiplicity/count authority.
- Seeded entity/setup behavior for the three seeded reduce rows.
- Runtime atomicity/serialization proof, causal chains, positive dead-letter details, flow/template creation, and faithful scripted backend behavior.

Closes #1705

## Governing Context

Exact source authority exists:

- `platform-spec.yaml#test_specification.deterministic_scenario_runner`
- `platform-spec.yaml#test_specification.deterministic_scenario_runner.test_quiescence`
- `platform-spec.yaml#test_specification.deterministic_scenario_runner.expectations`
- `platform-spec.yaml#test_specification.deterministic_scenario_runner.catalog_convergence`
- `platform-spec.yaml#cli_specification.command_catalog.test`

Binding issue/gate context:

- #1705 Pre-Implementation Coverage Audit and Independent Gate Re-Review.
- Parent trackers #1696 and #1252 remain open for broader catalog-convergence tail.

## Semantic Migration

No platform runtime semantics or platform architecture changed.

- New canonical owner consumed: existing public deterministic scenario runner owners listed above.
- Old producer/reader/writer path now invalid for this public proof: private `tests/**/expected.yaml` / cataloge2e proof files are not public scenario schema.
- Production paths checked for surviving old behavior: private cataloge2e and swarmflowtest smoke proofs remain unchanged and were run.
- Migration complete: complete only for the #1705 tier3 current-public-owner visible companion class. Broader catalog migration remains open under #1696/#1252.

## Tests

All with host Postgres env:

- `go test ./cmd/swarm -run TestSwarmTestRunsTier3ListProcessingCatalogCompanions -count=1`
- `go test ./cmd/swarm -run 'TestSwarmTest|TestScenario|TestEntities' -count=1`
- `go test ./internal/apispec -run TestPlatformSpecDeterministicScenarioRunnerSourceAuthority -count=1`
- `go test ./internal/runtime/swarmflowtest -run 'TestCatalogRunner_ValidatesCurrentCatalogPackages|TestCatalogRunner_IdentifiesSimpleHarnessEligiblePackages' -count=1`
- `go test ./internal/runtime/cataloge2e -run '^TestCatalogRequiredSmoke$' -count=1`
- `go test ./...`
