### PR TITLE
[agent-a][issue #1685] Add effective agent platform defaults

### DIFF
--- a/internal/runtime/authoringview/view.go
+++ b/internal/runtime/authoringview/view.go
@@ -33,6 +33,7 @@ type EquivalenceView struct {
 
 type RootView struct {
 	SourceFiles        RootSourceFiles    `json:"source_files"`
+	Agents             []AgentView        `json:"agents,omitempty"`
 	RequiredAgents     RequiredAgentsView `json:"required_agents"`
 	PrimaryEntity      *PrimaryEntityView `json:"primary_entity,omitempty"`
 	PrimaryEntityError string             `json:"primary_entity_error,omitempty"`
@@ -50,6 +51,7 @@ type FlowView struct {
 	Path                 string                    `json:"path,omitempty"`
 	Mode                 string                    `json:"mode,omitempty"`
 	SourceFiles          FlowSourceFiles           `json:"source_files"`
+	Agents               []AgentView               `json:"agents,omitempty"`
 	RequiredAgents       RequiredAgentsView        `json:"required_agents"`
 	PrimaryEntity        *PrimaryEntityView        `json:"primary_entity,omitempty"`
 	PrimaryEntityError   string                    `json:"primary_entity_error,omitempty"`
@@ -84,6 +86,17 @@ type RequiredAgentView struct {
 	Description  string   `json:"description,omitempty"`
 	Source       string   `json:"source"`
 	SourceFile   string   `json:"source_file,omitempty"`
+}
+
+type AgentView struct {
+	ID         string                    `json:"id"`
+	SourceFile string                    `json:"source_file,omitempty"`
+	Fields     map[string]AgentFieldView `json:"fields,omitempty"`
+}
+
+type AgentFieldView struct {
+	Value  any    `json:"value"`
+	Source string `json:"source"`
 }
 
 type PrimaryEntityView struct {
@@ -261,6 +274,7 @@ func Build(_ context.Context, source semanticview.Source, opts BuildOptions) (Vi
 }
 
 func buildRoot(bundle *runtimecontracts.WorkflowContractBundle) RootView {
+	rootAgents, rootAgentsFile := rootAgentViewEntries(bundle)
 	out := RootView{
 		SourceFiles: RootSourceFiles{
 			Schema:   strings.TrimSpace(bundle.Paths.RootSchemaFile),
@@ -268,6 +282,7 @@ func buildRoot(bundle *runtimecontracts.WorkflowContractBundle) RootView {
 			Package:  strings.TrimSpace(bundle.Paths.ProjectPackageFile),
 			Agents:   strings.TrimSpace(bundle.Paths.ProjectAgentsFile),
 		},
+		Agents: agentViews(rootAgents, rootAgentsFile),
 	}
 	if bundle.RootSchema != nil {
 		out.RequiredAgents = requiredAgentsView(*bundle.RootSchema, bundle.RootRequiredAgentFacts(), bundle.Paths.RootSchemaFile, bundle.Paths.ProjectAgentsFile)
@@ -300,6 +315,7 @@ func buildFlows(source semanticview.Source, bundle *runtimecontracts.WorkflowCon
 			Path:        strings.Trim(strings.TrimSpace(flow.Path), "/"),
 			Mode:        strings.TrimSpace(schema.Mode),
 			SourceFiles: flowSourceFiles(bundle, flow),
+			Agents:      agentViews(flow.Agents, flow.Paths.AgentsFile),
 			RequiredAgents: requiredAgentsView(
 				schema,
 				bundle.FlowRequiredAgentFacts(flowID),
@@ -338,6 +354,81 @@ func buildFlows(source semanticview.Source, bundle *runtimecontracts.WorkflowCon
 		out = append(out, item)
 	}
 	return out
+}
+
+func rootAgentViewEntries(bundle *runtimecontracts.WorkflowContractBundle) (map[string]runtimecontracts.AgentRegistryEntry, string) {
+	if bundle == nil {
+		return nil, ""
+	}
+	for _, view := range bundle.ProjectViews() {
+		if strings.TrimSpace(view.Paths.ParentKey) == "" && view.Paths.Depth == 0 {
+			return view.Agents, strings.TrimSpace(view.Paths.ProjectAgentsFile)
+		}
+	}
+	for _, view := range bundle.ProjectViews() {
+		if strings.TrimSpace(view.Paths.ParentKey) == "" {
+			return view.Agents, strings.TrimSpace(view.Paths.ProjectAgentsFile)
+		}
+	}
+	return bundle.AgentEntries(), strings.TrimSpace(bundle.Paths.ProjectAgentsFile)
+}
+
+func agentViews(entries map[string]runtimecontracts.AgentRegistryEntry, sourceFile string) []AgentView {
+	if len(entries) == 0 {
+		return nil
+	}
+	ids := make([]string, 0, len(entries))
+	for id := range entries {
+		if id = strings.TrimSpace(id); id != "" {
+			ids = append(ids, id)
+		}
+	}
+	sort.Strings(ids)
+	out := make([]AgentView, 0, len(ids))
+	for _, id := range ids {
+		entry := runtimecontracts.EffectiveAgentRegistryEntry(id, entries[id])
+		fields := map[string]AgentFieldView{}
+		addAgentField(fields, entry, "type", entry.Type)
+		addAgentField(fields, entry, "model", entry.Model)
+		addAgentField(fields, entry, "mode", entry.Mode)
+		addAgentField(fields, entry, "session_scope", entry.SessionScope)
+		addAgentField(fields, entry, "max_turns_per_task", entry.MaxTurnsPerTask)
+		addAgentField(fields, entry, "workspace_class", entry.WorkspaceClass)
+		addAgentField(fields, entry, "manager_fallback", entry.ManagerFallback)
+		out = append(out, AgentView{
+			ID:         id,
+			SourceFile: strings.TrimSpace(sourceFile),
+			Fields:     fields,
+		})
+	}
+	return out
+}
+
+func addAgentField(fields map[string]AgentFieldView, entry runtimecontracts.AgentRegistryEntry, name string, value any) {
+	source := entry.EffectiveSourceForField(name)
+	if strings.TrimSpace(source) == "" {
+		switch typed := value.(type) {
+		case string:
+			if strings.TrimSpace(typed) == "" {
+				return
+			}
+			source = runtimecontracts.AgentFieldSourceAuthored
+		case int:
+			if typed == 0 {
+				return
+			}
+			source = runtimecontracts.AgentFieldSourceAuthored
+		default:
+			if value == nil {
+				return
+			}
+			source = runtimecontracts.AgentFieldSourceAuthored
+		}
+	}
+	fields[name] = AgentFieldView{
+		Value:  value,
+		Source: source,
+	}
 }
 
 func flowSourceFiles(bundle *runtimecontracts.WorkflowContractBundle, flow runtimecontracts.FlowContractView) FlowSourceFiles {

--- a/internal/runtime/authoringview/view_test.go
+++ b/internal/runtime/authoringview/view_test.go
@@ -162,6 +162,80 @@ func TestBuildShowsRequiredAgentProvenance(t *testing.T) {
 	}
 }
 
+func TestBuildShowsEffectiveAgentPlatformDefaultProvenance(t *testing.T) {
+	flow := runtimecontracts.FlowContractView{
+		Path: "analysis",
+		Paths: runtimecontracts.FlowContractPaths{
+			ID:         "analysis",
+			SchemaFile: "flows/analysis/schema.yaml",
+			AgentsFile: "flows/analysis/agents.yaml",
+		},
+		Schema: runtimecontracts.FlowSchemaDocument{Name: "analysis"},
+		Agents: map[string]runtimecontracts.AgentRegistryEntry{
+			"analyzer": {
+				Model:         "regular",
+				Subscriptions: []string{"analysis.requested"},
+			},
+		},
+	}
+	bundle := &runtimecontracts.WorkflowContractBundle{
+		Paths: runtimecontracts.ContractPaths{
+			RootSchemaFile:    "schema.yaml",
+			ProjectAgentsFile: "agents.yaml",
+		},
+		RootSchema: &runtimecontracts.FlowSchemaDocument{},
+		Agents: map[string]runtimecontracts.AgentRegistryEntry{
+			"root-agent": {
+				Model:         "regular",
+				Subscriptions: []string{"root.requested"},
+			},
+		},
+		FlowSchemas: map[string]runtimecontracts.FlowSchemaDocument{
+			"analysis": flow.Schema,
+		},
+		FlowTree: runtimecontracts.FlowTree{
+			Root: &runtimecontracts.FlowContractView{
+				Children: []runtimecontracts.FlowContractView{flow},
+			},
+			ByID: map[string]*runtimecontracts.FlowContractView{
+				"analysis": &flow,
+			},
+		},
+	}
+
+	view := mustBuild(t, semanticview.Wrap(bundle), nil)
+
+	rootAgent := agentByID(t, view.Root.Agents, "root-agent")
+	assertDefaultedAgentField(t, rootAgent, "type", runtimecontracts.DefaultAgentType)
+	assertDefaultedAgentField(t, rootAgent, "mode", runtimecontracts.DefaultAgentMode)
+	assertDefaultedAgentField(t, rootAgent, "max_turns_per_task", runtimecontracts.DefaultAgentMaxTurnsPerTask)
+	assertDefaultedAgentField(t, rootAgent, "workspace_class", "")
+	if got := rootAgent.Fields["model"].Source; got != runtimecontracts.AgentFieldSourceAuthored {
+		t.Fatalf("root-agent model source = %q, want authored", got)
+	}
+
+	analysis := flowByID(t, view, "analysis")
+	flowAgent := agentByID(t, analysis.Agents, "analyzer")
+	assertDefaultedAgentField(t, flowAgent, "type", runtimecontracts.DefaultAgentType)
+	assertDefaultedAgentField(t, flowAgent, "mode", runtimecontracts.DefaultAgentMode)
+	assertDefaultedAgentField(t, flowAgent, "max_turns_per_task", runtimecontracts.DefaultAgentMaxTurnsPerTask)
+	assertDefaultedAgentField(t, flowAgent, "workspace_class", "")
+}
+
+func assertDefaultedAgentField(t testing.TB, agent AgentView, field string, want any) {
+	t.Helper()
+	got, ok := agent.Fields[field]
+	if !ok {
+		t.Fatalf("agent %s field %s missing in %#v", agent.ID, field, agent.Fields)
+	}
+	if got.Value != want {
+		t.Fatalf("agent %s field %s value = %#v, want %#v", agent.ID, field, got.Value, want)
+	}
+	if got.Source != runtimecontracts.AgentFieldSourcePlatformDefault {
+		t.Fatalf("agent %s field %s source = %q, want %q", agent.ID, field, got.Source, runtimecontracts.AgentFieldSourcePlatformDefault)
+	}
+}
+
 func TestBuildShowsRouteIssueAndAuthoredDiagnosticLocation(t *testing.T) {
 	source := templateflowpilot.LoadSource(t, templateflowpilot.Options{BadConnectMapping: true})
 	report := runtimebootverify.Run(context.Background(), source, runtimebootverify.Options{})
@@ -323,6 +397,17 @@ func outputPinByName(t testing.TB, flow FlowView, name string) OutputPinView {
 	}
 	t.Fatalf("output pin %q not found in %#v", name, flow.OutputPins)
 	return OutputPinView{}
+}
+
+func agentByID(t testing.TB, agents []AgentView, id string) AgentView {
+	t.Helper()
+	for _, agent := range agents {
+		if agent.ID == id {
+			return agent
+		}
+	}
+	t.Fatalf("agent %q not found in %#v", id, agents)
+	return AgentView{}
 }
 
 func diagnosticByCheckID(t testing.TB, view View, checkID string) DiagnosticView {

--- a/internal/runtime/bootverify/report_test.go
+++ b/internal/runtime/bootverify/report_test.go
@@ -2640,6 +2640,35 @@ root-flow:
 	}
 }
 
+func TestRun_DefaultsOmittedAgentModeButKeepsModelExplicit(t *testing.T) {
+	root := writeSessionScopeValidationFixture(t, `
+root-defaulted:
+  id: root-defaulted
+  model: regular
+  subscriptions:
+    - item.created
+`, "", "")
+
+	report := Run(context.Background(), loadSessionScopeValidationFixture(t, root), Options{})
+
+	if reportContains(report.Errors(), "invalid_field_detection", "missing required field mode") {
+		t.Fatalf("unexpected missing mode error with platform default: %#v", report.Errors())
+	}
+
+	root = writeSessionScopeValidationFixture(t, `
+root-missing-model:
+  id: root-missing-model
+  subscriptions:
+    - item.created
+`, "", "")
+
+	report = Run(context.Background(), loadSessionScopeValidationFixture(t, root), Options{})
+
+	if !reportContains(report.Errors(), "invalid_field_detection", "model is required") {
+		t.Fatalf("expected missing model error to remain explicit, got %#v", report.Errors())
+	}
+}
+
 func TestRun_RejectsEntitySessionScopeInStatelessFlow(t *testing.T) {
 	root := writeSessionScopeValidationFixture(t, "{}\n", `
 name: support

--- a/internal/runtime/contracts/load_validation_test.go
+++ b/internal/runtime/contracts/load_validation_test.go
@@ -413,6 +413,33 @@ subscriptions: [scan.requested]
 	}
 }
 
+func TestLoadWorkflowContractBundleAllowsAgentPromptInputs(t *testing.T) {
+	repoRoot := contractRepoRoot(t)
+	root := t.TempDir()
+	writeFieldReconciliationBundle(t, root, "", "{}\n")
+	writeFixtureFile(t, filepath.Join(root, "agents.yaml"), `
+worker:
+  model: regular
+  prompt_inputs: [customer_name, order_type]
+  subscriptions: [work.requested]
+`)
+
+	bundle, err := LoadWorkflowContractBundleWithOverrides(repoRoot, root, DefaultPlatformSpecFile(repoRoot))
+	if err != nil {
+		t.Fatalf("LoadWorkflowContractBundleWithOverrides: %v", err)
+	}
+	entry, ok := bundle.AgentEntry("worker")
+	if !ok {
+		t.Fatalf("worker agent missing: %#v", bundle.Agents)
+	}
+	if got, want := strings.Join(entry.PromptInputs, ","), "customer_name,order_type"; got != want {
+		t.Fatalf("PromptInputs = %q, want %q", got, want)
+	}
+	if !entry.AuthoredFields["prompt_inputs"] {
+		t.Fatalf("prompt_inputs authored field not recorded: %#v", entry.AuthoredFields)
+	}
+}
+
 func TestLoadWorkflowContractBundleRejectsLayer2AgentDefaultsBlock(t *testing.T) {
 	repoRoot := contractRepoRoot(t)
 	root := t.TempDir()

--- a/internal/runtime/contracts/load_validation_test.go
+++ b/internal/runtime/contracts/load_validation_test.go
@@ -300,6 +300,64 @@ subscriptions: [scan.requested]
 	}
 }
 
+func TestEffectiveAgentRegistryEntryAppliesLayer1PlatformDefaults(t *testing.T) {
+	var entry AgentRegistryEntry
+	err := yaml.Unmarshal([]byte(`
+role: researcher
+model: regular
+subscriptions: [scan.requested]
+`), &entry)
+	if err != nil {
+		t.Fatalf("yaml.Unmarshal: %v", err)
+	}
+	effective := EffectiveAgentRegistryEntry("researcher", entry)
+	if effective.Type != DefaultAgentType {
+		t.Fatalf("type = %q, want %q", effective.Type, DefaultAgentType)
+	}
+	if effective.Mode != DefaultAgentMode || effective.ConversationMode != DefaultAgentMode || effective.SessionScope != "" {
+		t.Fatalf("mode/conversation/session = (%q, %q, %q), want task/task/empty", effective.Mode, effective.ConversationMode, effective.SessionScope)
+	}
+	if effective.MaxTurnsPerTask != DefaultAgentMaxTurnsPerTask {
+		t.Fatalf("max_turns_per_task = %d, want %d", effective.MaxTurnsPerTask, DefaultAgentMaxTurnsPerTask)
+	}
+	if effective.WorkspaceClass != "" {
+		t.Fatalf("workspace_class = %q, want empty", effective.WorkspaceClass)
+	}
+	for _, field := range []string{"type", "mode", "max_turns_per_task", "workspace_class"} {
+		if got := effective.EffectiveSourceForField(field); got != AgentFieldSourcePlatformDefault {
+			t.Fatalf("%s source = %q, want %q", field, got, AgentFieldSourcePlatformDefault)
+		}
+	}
+	if got := effective.EffectiveSourceForField("model"); got != AgentFieldSourceAuthored {
+		t.Fatalf("model source = %q, want %q", got, AgentFieldSourceAuthored)
+	}
+}
+
+func TestAgentRegistryEntryRejectsExplicitInvalidLayer1Values(t *testing.T) {
+	tests := []struct {
+		name     string
+		body     string
+		contains string
+	}{
+		{name: "empty_mode", body: "mode:\n", contains: "mode is required"},
+		{name: "zero_max_turns", body: "max_turns_per_task: 0\n", contains: "max_turns_per_task must be positive"},
+		{name: "negative_max_turns", body: "max_turns_per_task: -1\n", contains: "max_turns_per_task must be positive"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var entry AgentRegistryEntry
+			err := yaml.Unmarshal([]byte(`
+role: researcher
+model: regular
+subscriptions: [scan.requested]
+`+tt.body), &entry)
+			if err == nil || !strings.Contains(err.Error(), tt.contains) {
+				t.Fatalf("yaml.Unmarshal error = %v, want %q", err, tt.contains)
+			}
+		})
+	}
+}
+
 func TestAgentRegistryEntryRejectsRetiredMemoryModeFieldsAndAliases(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -327,6 +385,48 @@ subscriptions: [scan.requested]
 				t.Fatalf("yaml.Unmarshal error = %v, want %q", err, tt.contains)
 			}
 		})
+	}
+}
+
+func TestAgentRegistryEntryRejectsUnsupportedLayerSyntaxAndUnknownFields(t *testing.T) {
+	tests := []struct {
+		name     string
+		body     string
+		contains string
+	}{
+		{name: "profile", body: "profile: cheap\n", contains: "reserved for a later #1685/#1703 gate"},
+		{name: "runtime_id_template", body: "runtime_id_template: worker-{entity_id}\n", contains: "reserved for a later #1685/#1703 gate"},
+		{name: "unknown", body: "surprise_field: true\n", contains: "UNDEFINED-FIELD"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var entry AgentRegistryEntry
+			err := yaml.Unmarshal([]byte(`
+role: researcher
+model: regular
+subscriptions: [scan.requested]
+`+tt.body), &entry)
+			if err == nil || !strings.Contains(err.Error(), tt.contains) {
+				t.Fatalf("yaml.Unmarshal error = %v, want %q", err, tt.contains)
+			}
+		})
+	}
+}
+
+func TestLoadWorkflowContractBundleRejectsLayer2AgentDefaultsBlock(t *testing.T) {
+	repoRoot := contractRepoRoot(t)
+	root := t.TempDir()
+	writeFieldReconciliationBundle(t, root, "", "{}\n")
+	writeFixtureFile(t, filepath.Join(root, "agents.yaml"), `
+agent_defaults:
+  model: regular
+worker:
+  model: regular
+  subscriptions: [work.requested]
+`)
+	_, err := LoadWorkflowContractBundleWithOverrides(repoRoot, root, DefaultPlatformSpecFile(repoRoot))
+	if err == nil || !strings.Contains(err.Error(), "agent_defaults") || !strings.Contains(err.Error(), "Layer 1 platform defaults") {
+		t.Fatalf("LoadWorkflowContractBundleWithOverrides error = %v, want agent_defaults Layer 1 rejection", err)
 	}
 }
 

--- a/internal/runtime/contracts/workflow_contract_accessors.go
+++ b/internal/runtime/contracts/workflow_contract_accessors.go
@@ -174,7 +174,7 @@ func (b *WorkflowContractBundle) AgentEntries() map[string]AgentRegistryEntry {
 	if b == nil {
 		return nil
 	}
-	return cloneAgentRegistryEntryMap(b.Agents)
+	return EffectiveAgentRegistryEntries(b.Agents)
 }
 func (b *WorkflowContractBundle) AgentEntry(id string) (AgentRegistryEntry, bool) {
 	id = strings.TrimSpace(id)
@@ -182,7 +182,10 @@ func (b *WorkflowContractBundle) AgentEntry(id string) (AgentRegistryEntry, bool
 		return AgentRegistryEntry{}, false
 	}
 	entry, ok := b.Agents[id]
-	return entry, ok
+	if !ok {
+		return AgentRegistryEntry{}, false
+	}
+	return EffectiveAgentRegistryEntry(id, entry), true
 }
 func (b *WorkflowContractBundle) HasAgent(id string) bool {
 	_, ok := b.AgentEntry(id)
@@ -661,15 +664,15 @@ func (b *WorkflowContractBundle) rootRequiredAgentScope() (map[string]AgentRegis
 	}
 	for _, view := range b.ProjectViews() {
 		if strings.TrimSpace(view.Paths.ParentKey) == "" && view.Paths.Depth == 0 {
-			return cloneAgentRegistryEntryMap(view.Agents), strings.TrimSpace(view.Paths.ProjectAgentsFile)
+			return EffectiveAgentRegistryEntries(view.Agents), strings.TrimSpace(view.Paths.ProjectAgentsFile)
 		}
 	}
 	for _, view := range b.ProjectViews() {
 		if strings.TrimSpace(view.Paths.ParentKey) == "" {
-			return cloneAgentRegistryEntryMap(view.Agents), strings.TrimSpace(view.Paths.ProjectAgentsFile)
+			return EffectiveAgentRegistryEntries(view.Agents), strings.TrimSpace(view.Paths.ProjectAgentsFile)
 		}
 	}
-	return cloneAgentRegistryEntryMap(b.Agents), strings.TrimSpace(b.Paths.ProjectAgentsFile)
+	return EffectiveAgentRegistryEntries(b.Agents), strings.TrimSpace(b.Paths.ProjectAgentsFile)
 }
 func (b *WorkflowContractBundle) flowRequiredAgentScope(flowID string) (map[string]AgentRegistryEntry, string) {
 	flowID = strings.TrimSpace(flowID)
@@ -677,7 +680,7 @@ func (b *WorkflowContractBundle) flowRequiredAgentScope(flowID string) (map[stri
 		return nil, ""
 	}
 	if view, ok := b.FlowViewByID(flowID); ok && view != nil {
-		return cloneAgentRegistryEntryMap(view.Agents), strings.TrimSpace(view.Paths.AgentsFile)
+		return EffectiveAgentRegistryEntries(view.Agents), strings.TrimSpace(view.Paths.AgentsFile)
 	}
 	return nil, ""
 }
@@ -821,7 +824,7 @@ func (b *WorkflowContractBundle) ScopedAgentEntries() map[string]AgentRegistryEn
 	if b == nil {
 		return nil
 	}
-	return cloneAgentRegistryEntryMap(b.scopedAgents)
+	return EffectiveAgentRegistryEntries(b.scopedAgents)
 }
 func (b *WorkflowContractBundle) ScopedEventEntries() map[string]EventCatalogEntry {
 	if b == nil {

--- a/internal/runtime/contracts/workflow_contract_effective.go
+++ b/internal/runtime/contracts/workflow_contract_effective.go
@@ -5,12 +5,117 @@ import (
 	"strings"
 
 	"github.com/division-sh/swarm/internal/runtime/core/eventidentity"
+	runtimesessions "github.com/division-sh/swarm/internal/runtime/sessions"
 )
 
 const (
 	RequiredAgentSourceExplicit = "explicit"
 	RequiredAgentSourceInferred = "inferred"
 )
+
+const (
+	AgentFieldSourceAuthored        = "authored"
+	AgentFieldSourcePlatformDefault = "platform_default"
+	AgentFieldSourceDerived         = "derived"
+
+	DefaultAgentType            = "generic"
+	DefaultAgentMode            = "task"
+	DefaultAgentMaxTurnsPerTask = 100
+)
+
+func EffectiveAgentRegistryEntries(entries map[string]AgentRegistryEntry) map[string]AgentRegistryEntry {
+	if len(entries) == 0 {
+		return map[string]AgentRegistryEntry{}
+	}
+	out := make(map[string]AgentRegistryEntry, len(entries))
+	for key, entry := range entries {
+		out[key] = EffectiveAgentRegistryEntry(key, entry)
+	}
+	return out
+}
+
+func EffectiveAgentRegistryEntry(logicalID string, entry AgentRegistryEntry) AgentRegistryEntry {
+	_ = strings.TrimSpace(logicalID)
+	effective := cloneAgentRegistryEntry(entry)
+	effective.AuthoredFields = cloneBoolMap(entry.AuthoredFields)
+	effective.EffectiveFieldSources = cloneStringMap(entry.EffectiveFieldSources)
+	if effective.EffectiveFieldSources == nil {
+		effective.EffectiveFieldSources = map[string]string{}
+	}
+
+	if strings.TrimSpace(effective.Type) == "" {
+		effective.Type = DefaultAgentType
+		effective.EffectiveFieldSources["type"] = AgentFieldSourcePlatformDefault
+	} else {
+		setAgentFieldSourceIfEmpty(effective.EffectiveFieldSources, "type", AgentFieldSourceAuthored)
+	}
+
+	modeValue := firstNonEmpty(effective.Mode, effective.ConversationMode)
+	if modeValue == "" {
+		modeValue = DefaultAgentMode
+		effective.EffectiveFieldSources["mode"] = AgentFieldSourcePlatformDefault
+	} else {
+		setAgentFieldSourceIfEmpty(effective.EffectiveFieldSources, "mode", AgentFieldSourceAuthored)
+	}
+	mode, scope, err := runtimesessions.ResolveAuthoredAgentMemoryMode(modeValue)
+	if err == nil {
+		effective.Mode = mode.String()
+		effective.ConversationMode = mode.String()
+		effective.SessionScope = scope.String()
+	}
+	if strings.TrimSpace(effective.SessionScope) != "" {
+		setAgentFieldSourceIfEmpty(effective.EffectiveFieldSources, "session_scope", AgentFieldSourceDerived)
+	}
+
+	if effective.MaxTurnsPerTask <= 0 {
+		effective.MaxTurnsPerTask = DefaultAgentMaxTurnsPerTask
+		effective.EffectiveFieldSources["max_turns_per_task"] = AgentFieldSourcePlatformDefault
+	} else {
+		setAgentFieldSourceIfEmpty(effective.EffectiveFieldSources, "max_turns_per_task", AgentFieldSourceAuthored)
+	}
+
+	if _, ok := effective.EffectiveFieldSources["workspace_class"]; !ok {
+		if effective.AuthoredFields["workspace_class"] {
+			effective.EffectiveFieldSources["workspace_class"] = AgentFieldSourceAuthored
+		} else {
+			effective.EffectiveFieldSources["workspace_class"] = AgentFieldSourcePlatformDefault
+		}
+	}
+	if strings.TrimSpace(effective.Model) != "" || effective.AuthoredFields["model"] {
+		setAgentFieldSourceIfEmpty(effective.EffectiveFieldSources, "model", AgentFieldSourceAuthored)
+	}
+	if strings.TrimSpace(effective.ManagerFallback) != "" || effective.AuthoredFields["manager_fallback"] {
+		setAgentFieldSourceIfEmpty(effective.EffectiveFieldSources, "manager_fallback", AgentFieldSourceAuthored)
+	}
+
+	return effective
+}
+
+func (e AgentRegistryEntry) EffectiveSourceForField(field string) string {
+	if len(e.EffectiveFieldSources) == 0 {
+		return ""
+	}
+	return strings.TrimSpace(e.EffectiveFieldSources[strings.TrimSpace(field)])
+}
+
+func setAgentFieldSourceIfEmpty(sources map[string]string, field, source string) {
+	field = strings.TrimSpace(field)
+	if field == "" || strings.TrimSpace(sources[field]) != "" {
+		return
+	}
+	sources[field] = strings.TrimSpace(source)
+}
+
+func cloneBoolMap(in map[string]bool) map[string]bool {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make(map[string]bool, len(in))
+	for key, value := range in {
+		out[key] = value
+	}
+	return out
+}
 
 func EffectiveSystemNodeID(nodeKey string, node SystemNodeContract) string {
 	if nodeKey := strings.TrimSpace(nodeKey); nodeKey != "" {

--- a/internal/runtime/contracts/workflow_contract_merging.go
+++ b/internal/runtime/contracts/workflow_contract_merging.go
@@ -217,6 +217,10 @@ func mergeAgentContracts(bundle *WorkflowContractBundle, entries map[string]Agen
 		if key == "" {
 			continue
 		}
+		if err := validateAgentRegistryMapKey(key, source.File); err != nil {
+			return err
+		}
+		entry = EffectiveAgentRegistryEntry(key, entry)
 		scopedKey := contractScopeKey(source, key)
 		if existing, ok := bundle.scopedAgentSources[scopedKey]; ok {
 			if reflect.DeepEqual(bundle.scopedAgents[scopedKey], entry) {

--- a/internal/runtime/contracts/workflow_contract_paths.go
+++ b/internal/runtime/contracts/workflow_contract_paths.go
@@ -362,6 +362,9 @@ func cloneAgentRegistryEntry(in AgentRegistryEntry) AgentRegistryEntry {
 	if len(in.Subscriptions) > 0 {
 		out.Subscriptions = append([]string{}, in.Subscriptions...)
 	}
+	if len(in.PromptInputs) > 0 {
+		out.PromptInputs = append([]string{}, in.PromptInputs...)
+	}
 	if len(in.Tools) > 0 {
 		out.Tools = append([]string{}, in.Tools...)
 	}

--- a/internal/runtime/contracts/workflow_contract_paths.go
+++ b/internal/runtime/contracts/workflow_contract_paths.go
@@ -336,7 +336,40 @@ func cloneAgentRegistryEntryMap(in map[string]AgentRegistryEntry) map[string]Age
 	}
 	out := make(map[string]AgentRegistryEntry, len(in))
 	for key, value := range in {
-		out[key] = value
+		out[key] = cloneAgentRegistryEntry(value)
+	}
+	return out
+}
+func cloneAgentRegistryEntry(in AgentRegistryEntry) AgentRegistryEntry {
+	out := in
+	out.AuthoredFields = cloneBoolMap(in.AuthoredFields)
+	out.EffectiveFieldSources = cloneStringMap(in.EffectiveFieldSources)
+	if len(in.EntityWrites) > 0 {
+		out.EntityWrites = make(map[string]AgentEntityWriteDecl, len(in.EntityWrites))
+		for key, value := range in.EntityWrites {
+			out.EntityWrites[key] = value
+		}
+	}
+	if len(in.NativeTools) > 0 {
+		out.NativeTools = make(map[string]any, len(in.NativeTools))
+		for key, value := range in.NativeTools {
+			out.NativeTools[key] = value
+		}
+	}
+	if len(in.Permissions) > 0 {
+		out.Permissions = append([]string{}, in.Permissions...)
+	}
+	if len(in.Subscriptions) > 0 {
+		out.Subscriptions = append([]string{}, in.Subscriptions...)
+	}
+	if len(in.Tools) > 0 {
+		out.Tools = append([]string{}, in.Tools...)
+	}
+	if len(in.FlowDataAccess) > 0 {
+		out.FlowDataAccess = append([]string{}, in.FlowDataAccess...)
+	}
+	if len(in.EmitEvents) > 0 {
+		out.EmitEvents = append([]string{}, in.EmitEvents...)
 	}
 	return out
 }

--- a/internal/runtime/contracts/workflow_contract_tree.go
+++ b/internal/runtime/contracts/workflow_contract_tree.go
@@ -35,6 +35,11 @@ func loadProjectContractView(paths ProjectPackagePaths, manifest ProjectPackageD
 	if err := loadOptionalYAMLMap(paths.ProjectAgentsFile, &view.Agents); err != nil {
 		return view, err
 	}
+	agents, err := normalizeAgentRegistryEntries(view.Agents, paths.ProjectAgentsFile)
+	if err != nil {
+		return view, err
+	}
+	view.Agents = agents
 	if err := loadOptionalYAMLMap(paths.ProjectToolsFile, &view.Tools); err != nil {
 		return view, err
 	}
@@ -67,6 +72,11 @@ func loadFlowContractView(paths FlowContractPaths, schema FlowSchemaDocument) (F
 	if err := loadOptionalYAMLMap(paths.AgentsFile, &view.Agents); err != nil {
 		return view, err
 	}
+	agents, err := normalizeAgentRegistryEntries(view.Agents, paths.AgentsFile)
+	if err != nil {
+		return view, err
+	}
+	view.Agents = agents
 	if err := loadOptionalYAMLMap(paths.ToolsFile, &view.Tools); err != nil {
 		return view, err
 	}
@@ -74,6 +84,33 @@ func loadFlowContractView(paths FlowContractPaths, schema FlowSchemaDocument) (F
 		return view, err
 	}
 	return view, nil
+}
+
+func normalizeAgentRegistryEntries(entries map[string]AgentRegistryEntry, sourceFile string) (map[string]AgentRegistryEntry, error) {
+	if len(entries) == 0 {
+		return map[string]AgentRegistryEntry{}, nil
+	}
+	out := make(map[string]AgentRegistryEntry, len(entries))
+	for key, entry := range entries {
+		trimmedKey := strings.TrimSpace(key)
+		if trimmedKey == "" {
+			continue
+		}
+		if err := validateAgentRegistryMapKey(trimmedKey, sourceFile); err != nil {
+			return nil, err
+		}
+		out[trimmedKey] = EffectiveAgentRegistryEntry(trimmedKey, entry)
+	}
+	return out, nil
+}
+
+func validateAgentRegistryMapKey(key, sourceFile string) error {
+	switch strings.TrimSpace(key) {
+	case "agent_defaults", "agent_profiles", "profiles":
+		return fmt.Errorf("UNSUPPORTED: %s key %q is reserved for a later #1685 gate and is not accepted by Layer 1 platform defaults", strings.TrimSpace(sourceFile), key)
+	default:
+		return nil
+	}
 }
 func buildFlowTree(bundle *WorkflowContractBundle, flowViewsByID map[string]FlowContractView) error {
 	if bundle == nil {

--- a/internal/runtime/contracts/workflow_contract_types.go
+++ b/internal/runtime/contracts/workflow_contract_types.go
@@ -1376,28 +1376,24 @@ type AgentRegistryEntry struct {
 	FlowDataAccess         []string                        `yaml:"flow_data_access" json:"flow_data_access,omitempty"`
 	EmitEvents             []string                        `yaml:"emit_events"`
 	Implementation         string                          `yaml:"implementation"`
+	AuthoredFields         map[string]bool                 `yaml:"-" json:"-"`
+	EffectiveFieldSources  map[string]string               `yaml:"-" json:"-"`
 }
 
 type agentRegistryEntryYAML AgentRegistryEntry
 
 func (e *AgentRegistryEntry) UnmarshalYAML(value *yaml.Node) error {
-	if value != nil && value.Kind == yaml.MappingNode {
-		for i := 0; i+1 < len(value.Content); i += 2 {
-			switch strings.TrimSpace(value.Content[i].Value) {
-			case "model_tier":
-				return fmt.Errorf("RETIRED: agent field model_tier is retired; use model")
-			case "conversation_mode":
-				return fmt.Errorf("RETIRED: agent field conversation_mode is retired; use mode")
-			case "session_scope":
-				return fmt.Errorf("RETIRED: agent field session_scope is runtime-derived from mode")
-			case "session_scope_authority":
-				return fmt.Errorf("RETIRED: agent field session_scope_authority is platform-internal runtime state")
-			case "tools_tier2":
-				return fmt.Errorf("RETIRED: agent field tools_tier2 is retired; use tools")
-			case "subscriptions_bootstrap":
-				return fmt.Errorf("RETIRED: agent field subscriptions_bootstrap is retired; use subscriptions")
-			case "subscribes_to":
-				return fmt.Errorf("RETIRED: agent field subscribes_to is retired for agents.yaml; use subscriptions")
+	authoredFields, err := validateAgentRegistryEntryYAMLFields(value)
+	if err != nil {
+		return err
+	}
+	if authoredFields["max_turns_per_task"] {
+		for i := 0; value != nil && value.Kind == yaml.MappingNode && i+1 < len(value.Content); i += 2 {
+			if strings.TrimSpace(value.Content[i].Value) != "max_turns_per_task" {
+				continue
+			}
+			if strings.TrimSpace(value.Content[i+1].Value) == "" {
+				return fmt.Errorf("agent field max_turns_per_task must be positive when authored")
 			}
 		}
 	}
@@ -1405,15 +1401,66 @@ func (e *AgentRegistryEntry) UnmarshalYAML(value *yaml.Node) error {
 	if err := value.Decode(&decoded); err != nil {
 		return err
 	}
-	mode, scope, err := runtimesessions.ResolveAuthoredAgentMemoryMode(decoded.Mode)
-	if err != nil {
-		return fmt.Errorf("agent field mode: %w", err)
+	if authoredFields["max_turns_per_task"] && decoded.MaxTurnsPerTask <= 0 {
+		return fmt.Errorf("agent field max_turns_per_task must be positive when authored")
 	}
-	decoded.Mode = mode.String()
-	decoded.ConversationMode = mode.String()
-	decoded.SessionScope = scope.String()
+	if authoredFields["mode"] {
+		mode, scope, err := runtimesessions.ResolveAuthoredAgentMemoryMode(decoded.Mode)
+		if err != nil {
+			return fmt.Errorf("agent field mode: %w", err)
+		}
+		decoded.Mode = mode.String()
+		decoded.ConversationMode = mode.String()
+		decoded.SessionScope = scope.String()
+	}
 	*e = AgentRegistryEntry(decoded)
+	e.AuthoredFields = authoredFields
 	return nil
+}
+
+func validateAgentRegistryEntryYAMLFields(value *yaml.Node) (map[string]bool, error) {
+	authoredFields := map[string]bool{}
+	if value != nil && value.Kind == yaml.MappingNode {
+		for i := 0; i+1 < len(value.Content); i += 2 {
+			field := strings.TrimSpace(value.Content[i].Value)
+			authoredFields[field] = true
+			switch field {
+			case "model_tier":
+				return nil, fmt.Errorf("RETIRED: agent field model_tier is retired; use model")
+			case "conversation_mode":
+				return nil, fmt.Errorf("RETIRED: agent field conversation_mode is retired; use mode")
+			case "session_scope":
+				return nil, fmt.Errorf("RETIRED: agent field session_scope is runtime-derived from mode")
+			case "session_scope_authority":
+				return nil, fmt.Errorf("RETIRED: agent field session_scope_authority is platform-internal runtime state")
+			case "tools_tier2":
+				return nil, fmt.Errorf("RETIRED: agent field tools_tier2 is retired; use tools")
+			case "subscriptions_bootstrap":
+				return nil, fmt.Errorf("RETIRED: agent field subscriptions_bootstrap is retired; use subscriptions")
+			case "subscribes_to":
+				return nil, fmt.Errorf("RETIRED: agent field subscribes_to is retired for agents.yaml; use subscriptions")
+			case "profile", "agent_defaults", "agent_profiles", "runtime_id_template":
+				return nil, fmt.Errorf("UNSUPPORTED: agent field %s is reserved for a later #1685/#1703 gate and is not accepted by Layer 1 platform defaults", field)
+			default:
+				if !supportedAgentRegistryEntryField(field) {
+					return nil, fmt.Errorf("UNDEFINED-FIELD: agent field %s is not supported", field)
+				}
+			}
+		}
+	}
+	return authoredFields, nil
+}
+
+func supportedAgentRegistryEntryField(field string) bool {
+	switch strings.TrimSpace(field) {
+	case "id", "type", "role", "prompt_ref", "entity_writes",
+		"permissions", "permissions_bundle", "workspace_class", "manager_fallback",
+		"node_type", "model", "mode", "max_turns_per_task", "subscriptions",
+		"tools", "native_tools", "flow_data_access", "emit_events", "implementation":
+		return true
+	default:
+		return false
+	}
 }
 
 func (e AgentRegistryEntry) ConfiguredTools() []string {

--- a/internal/runtime/contracts/workflow_contract_types.go
+++ b/internal/runtime/contracts/workflow_contract_types.go
@@ -1367,6 +1367,7 @@ type AgentRegistryEntry struct {
 	ConversationMode       string                          `yaml:"conversation_mode"`
 	SessionScope           string                          `yaml:"session_scope"`
 	MaxTurnsPerTask        int                             `yaml:"max_turns_per_task"`
+	PromptInputs           []string                        `yaml:"prompt_inputs" json:"prompt_inputs,omitempty"`
 	Subscriptions          []string                        `yaml:"subscriptions"`
 	SubscriptionsBootstrap []string                        `yaml:"subscriptions_bootstrap"`
 	SubscribesTo           []string                        `yaml:"subscribes_to"`
@@ -1456,7 +1457,7 @@ func supportedAgentRegistryEntryField(field string) bool {
 	case "id", "type", "role", "prompt_ref", "entity_writes",
 		"permissions", "permissions_bundle", "workspace_class", "manager_fallback",
 		"node_type", "model", "mode", "max_turns_per_task", "subscriptions",
-		"tools", "native_tools", "flow_data_access", "emit_events", "implementation":
+		"prompt_inputs", "tools", "native_tools", "flow_data_access", "emit_events", "implementation":
 		return true
 	default:
 		return false

--- a/internal/runtime/manager/flow_activation_test.go
+++ b/internal/runtime/manager/flow_activation_test.go
@@ -1829,3 +1829,111 @@ func TestBuildFlowAgentConfig_PassesContractToolsAndEmitEvents(t *testing.T) {
 		t.Fatalf("native_tools = %#v, want bash/file_io true", cfg.NativeTools)
 	}
 }
+
+func TestStaticAndTemplateAgentMaterializationConsumeEffectivePlatformDefaults(t *testing.T) {
+	source := loadAgentPlatformDefaultsMaterializationSource(t)
+
+	staticScope, ok := source.FlowScopeByID("static_support")
+	if !ok {
+		t.Fatal("static_support flow scope missing")
+	}
+	staticEntry := staticScope.Agents["worker"]
+	staticCfg, err := buildStaticFlowAgentConfig(source, "static_support", "static_support", "worker", staticEntry, staticFlowLocalEventSet(staticScope.Agents))
+	if err != nil {
+		t.Fatalf("buildStaticFlowAgentConfig: %v", err)
+	}
+	assertMaterializedAgentPlatformDefaults(t, staticCfg)
+
+	templateScope, ok := source.FlowScopeByID("template_support")
+	if !ok {
+		t.Fatal("template_support flow scope missing")
+	}
+	templateEntry := templateScope.Agents["worker"]
+	templateCfg, err := buildFlowAgentConfig(
+		source,
+		"template_support",
+		"inst-1",
+		"entity-1",
+		"template_support/inst-1",
+		"worker",
+		templateEntry,
+		map[string]string{"instance_id": "inst-1"},
+		staticFlowLocalEventSet(templateScope.Agents),
+		map[string]any{},
+	)
+	if err != nil {
+		t.Fatalf("buildFlowAgentConfig: %v", err)
+	}
+	assertMaterializedAgentPlatformDefaults(t, templateCfg)
+}
+
+func assertMaterializedAgentPlatformDefaults(t *testing.T, cfg models.AgentConfig) {
+	t.Helper()
+	if cfg.Type != runtimecontracts.DefaultAgentType {
+		t.Fatalf("Type = %q, want %q", cfg.Type, runtimecontracts.DefaultAgentType)
+	}
+	if cfg.ConversationMode != runtimecontracts.DefaultAgentMode {
+		t.Fatalf("ConversationMode = %q, want %q", cfg.ConversationMode, runtimecontracts.DefaultAgentMode)
+	}
+	if cfg.SessionScope != "" {
+		t.Fatalf("SessionScope = %q, want empty for task default", cfg.SessionScope)
+	}
+	if cfg.MaxTurnsPerTask != runtimecontracts.DefaultAgentMaxTurnsPerTask {
+		t.Fatalf("MaxTurnsPerTask = %d, want %d", cfg.MaxTurnsPerTask, runtimecontracts.DefaultAgentMaxTurnsPerTask)
+	}
+	if cfg.WorkspaceClass != "" {
+		t.Fatalf("WorkspaceClass = %q, want empty default", cfg.WorkspaceClass)
+	}
+}
+
+func loadAgentPlatformDefaultsMaterializationSource(t *testing.T) semanticview.Source {
+	t.Helper()
+	repoRoot := runtimepipeline.WorkflowRepoRoot()
+	root := t.TempDir()
+
+	writeFlowActivationFixtureFile(t, filepath.Join(root, "package.yaml"), `
+name: agent-defaults-materialization
+version: "1.0.0"
+platform_version: ">=0.7.0 <0.8.0"
+flows:
+  - id: static_support
+    flow: static_support
+    mode: static
+  - id: template_support
+    flow: template_support
+    mode: template
+`)
+	writeFlowActivationFixtureFile(t, filepath.Join(root, "schema.yaml"), "name: agent-defaults-materialization\n")
+	writeFlowActivationFixtureFile(t, filepath.Join(root, "policy.yaml"), "{}\n")
+	writeFlowActivationFixtureFile(t, filepath.Join(root, "tools.yaml"), "{}\n")
+	writeFlowActivationFixtureFile(t, filepath.Join(root, "agents.yaml"), "{}\n")
+	writeFlowActivationFixtureFile(t, filepath.Join(root, "events.yaml"), "{}\n")
+
+	for _, flowID := range []string{"static_support", "template_support"} {
+		writeFlowActivationFixtureFile(t, filepath.Join(root, "flows", flowID, "schema.yaml"), "name: "+flowID+"\n")
+		writeFlowActivationFixtureFile(t, filepath.Join(root, "flows", flowID, "policy.yaml"), "{}\n")
+		writeFlowActivationFixtureFile(t, filepath.Join(root, "flows", flowID, "tools.yaml"), "{}\n")
+		writeFlowActivationFixtureFile(t, filepath.Join(root, "flows", flowID, "events.yaml"), flowID+".requested:\n  entity_id: string\n")
+	}
+	writeFlowActivationFixtureFile(t, filepath.Join(root, "flows", "static_support", "agents.yaml"), `
+worker:
+  model: regular
+  subscriptions:
+    - static_support.requested
+  emit_events: []
+`)
+	writeFlowActivationFixtureFile(t, filepath.Join(root, "flows", "template_support", "agents.yaml"), `
+worker:
+  id: worker-{instance_id}
+  model: regular
+  subscriptions:
+    - template_support.requested
+  emit_events: []
+`)
+
+	bundle, err := runtimecontracts.LoadWorkflowContractBundleWithOverrides(repoRoot, root, runtimecontracts.DefaultPlatformSpecFile(repoRoot))
+	if err != nil {
+		t.Fatalf("LoadWorkflowContractBundleWithOverrides: %v", err)
+	}
+	return semanticview.Wrap(bundle)
+}

--- a/internal/runtime/semanticview/bundle_source.go
+++ b/internal/runtime/semanticview/bundle_source.go
@@ -120,7 +120,7 @@ func (s bundleSource) ProjectScopes() []ProjectScope {
 			PromptsDir:   strings.TrimSpace(view.Paths.ProjectPromptsDir),
 			Nodes:        view.Nodes,
 			Events:       view.Events,
-			Agents:       view.Agents,
+			Agents:       runtimecontracts.EffectiveAgentRegistryEntries(view.Agents),
 			Tools:        view.Tools,
 			Policy:       view.Policy,
 		})
@@ -349,7 +349,7 @@ func (s bundleSource) NodeEntries() map[string]runtimecontracts.SystemNodeContra
 	return s.bundle.NodeEntries()
 }
 func (s bundleSource) AgentEntries() map[string]runtimecontracts.AgentRegistryEntry {
-	return s.bundle.AgentEntries()
+	return runtimecontracts.EffectiveAgentRegistryEntries(s.bundle.AgentEntries())
 }
 func (s bundleSource) AuthoredEventEntries() map[string]runtimecontracts.EventCatalogEntry {
 	return s.bundle.AuthoredEventEntries()

--- a/internal/runtime/semanticview/scopes.go
+++ b/internal/runtime/semanticview/scopes.go
@@ -95,7 +95,7 @@ func flowScopeFromView(view runtimecontracts.FlowContractView) FlowScope {
 		AutoEmitEvent: strings.TrimSpace(view.Schema.AutoEmitOnCreate.Event),
 		Nodes:         view.Nodes,
 		Events:        view.Events,
-		Agents:        view.Agents,
+		Agents:        runtimecontracts.EffectiveAgentRegistryEntries(view.Agents),
 		Tools:         view.Tools,
 		Policy:        view.Policy,
 	}

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -4048,6 +4048,46 @@ engine:
           context across multiple events for the same entity but has separate sessions for different entities. Useful for
           agents that need continuity (e.g., research agent building a brief over multiple turns).'
       default: task
+    platform_defaults:
+      description: Agent contracts have a contracts-owned effective view before boot verification, generated/expanded
+        views, catalog/read surfaces, and runtime materialization consume them. Layer 1 defaults add no authored
+        syntax; they derive only safe platform-owned fields when omitted from an agent declaration.
+      canonical_owner: internal/runtime/contracts effective AgentRegistryEntry normalization
+      precedence:
+      - Explicit authored agent field wins.
+      - If the field is omitted and listed in this section, the platform default is materialized into the effective
+        agent entry with provenance `platform_default`.
+      - If the field is omitted and not listed in this section, no platform default exists.
+      fields:
+        type:
+          default: generic
+          rationale: Promotes the historical runtime fallback in generic agent construction into contracts-owned
+            effective semantics.
+        mode:
+          default: task
+          rationale: Consumes the public `mode` owner and derives runtime `conversation_mode` / `session_scope`
+            from the effective value.
+        max_turns_per_task:
+          default: 100
+          authored_constraint: When explicitly authored, the value MUST be positive.
+          rationale: Promotes the historical LLM-agent runtime fallback into contracts-owned effective semantics.
+        workspace_class:
+          default: absent/empty
+          rationale: No workspace class is invented by the platform. Named classes remain explicit product policy.
+      no_default_fields:
+        model: Cost/provider-bearing. It remains explicit in Layer 1 and missing model aliases fail validation.
+        manager_fallback: No platform default in Layer 1; explicit value only.
+      generated_view:
+        rule: Generated/expanded views MUST show each effective Layer 1 field value and whether it was authored
+          directly or platform-defaulted. Derived runtime session fields may be shown as derived from the effective
+          `mode`.
+      unsupported_layer_syntax:
+        rule: Authored `agent_defaults`, named `profile`, `agent_profiles`, and `runtime_id_template` syntax is not
+          accepted by Layer 1. These fields/blocks MUST fail closed or be separately gated before implementation.
+      exclusions:
+      - No defaults for logical identity, runtime/display id templates, subscriptions, emit_events, required_agents,
+        pins, events, entities, public interfaces, policy, credentials, permissions, permissions_bundle, tools,
+        native_tools, or flow_data_access.
     subscription_types:
       subscriptions: Static subscription list. Always active from boot (or from instance creation for dynamic flows). Cannot
         be modified at runtime. This is the agent's declared event contract.


### PR DESCRIPTION
## Summary

Part of #1685.

This PR implements the approved Layer 1 slice only: spec-owned effective platform defaults for safe agent fields, with no new authoring syntax.

- Adds a contracts-owned effective `AgentRegistryEntry` normalization owner for `type: generic`, `mode: task`, `max_turns_per_task: 100`, and absent/empty `workspace_class`.
- Makes bundle accessors and semantic scopes expose effective agent entries before bootverify/runtime materialization.
- Adds generated authoring-view agent fields with direct vs `platform_default` provenance.
- Fails closed on unsupported later-slice syntax (`agent_defaults`, `profile`, `agent_profiles`, `runtime_id_template`) and unknown agent fields.

## Governing Refs / Context

- `platform-spec.yaml` `engine.agent_model.platform_defaults`
- `platform-spec.yaml` `engine.agent_model.conversation_modes`
- #1685 Gate A approved boundary: Layer 1 platform defaults, zero new authoring syntax, effective contract/default view only.
- #1527 remains the memory-mode owner consumed through effective `mode`.
- #1684 required-agent inference remains separate.
- #1703 remains the split runtime/display id template issue.

## Semantic Migration

- New canonical owner: `internal/runtime/contracts.EffectiveAgentRegistryEntry` / `EffectiveAgentRegistryEntries`.
- Old local producer/reader paths now non-authoritative: manager/static-template materialization, bootverify, semanticview, generated authoring view, and catalog/read surfaces must consume effective entries instead of interpreting defaults locally.
- Production paths checked for surviving old behavior: loader project/flow agent maps, merge path, `WorkflowContractBundle.AgentEntries()`, `ScopedAgentEntries()`, `ProjectScopes()`, `FlowScopes()`, bootverify invalid-field checks, static/template agent materialization, authoring view, and bundle catalog via `AgentEntries()`.
- Migration complete for the approved Layer 1 defaults. #1685 remains open for later same-scope defaults/profiles unless the issue is narrowed.

## Validation

- `SWARM_TEST_POSTGRES_DSN='host=127.0.0.1 port=5432 user=youmew dbname=postgres sslmode=disable' PGPASSWORD=postgres go test ./...`
- Reran `go test ./internal/runtime -run TestTemplateInstanceAcknowledgedPublishDispatchesRoutedSystemNodeWithoutInternalCarrierAndEmpireStyleSideEffect -count=1 -v` and `go test ./internal/runtime -count=1` after one transient post-rebase suite-order failure; both passed, then the final `go test ./...` passed.
