### PR TITLE
[agent-c][issue #1713] Add policy sheet selection rows

### DIFF
--- a/internal/runtime/conformance/deterministic_work_ladder_design_record_test.go
+++ b/internal/runtime/conformance/deterministic_work_ladder_design_record_test.go
@@ -645,7 +645,7 @@ func validateDeterministicWorkLadderDesignRepairs(repairs []deterministicWorkLad
 	if policySheet.EvidenceOwner != deterministicWorkLadderStage0Path {
 		problems = append(problems, fmt.Sprintf("repair policy_sheet_row_model evidence_owner = %q, want %s", policySheet.EvidenceOwner, deterministicWorkLadderStage0Path))
 	}
-	for _, forbidden := range []string{"handler_fields.switch", "handler_fields.lookup", "handler_fields.threshold"} {
+	for _, forbidden := range []string{"handler_fields.switch", "handler_fields.lookup", "handler_fields.threshold", "handler_fields.policy"} {
 		if !stringSet(policySheet.ForbiddenOverloads)[forbidden] {
 			problems = append(problems, fmt.Sprintf("repair policy_sheet_row_model forbidden_overloads missing %s", forbidden))
 		}
@@ -655,7 +655,7 @@ func validateDeterministicWorkLadderDesignRepairs(repairs []deterministicWorkLad
 			problems = append(problems, fmt.Sprintf("repair policy_sheet_row_model required_surfaces missing %s", surface))
 		}
 	}
-	for _, want := range []string{"ordered policy-sheet authoring construct", "not standalone handler", "closed and statically verifiable", "rules selected-branch model", "value-derivation rows lower to compute", "not an implementation claim"} {
+	for _, want := range []string{"ordered policy-sheet authoring construct", "not standalone handler", "current spelling", "enhance rules in place", "closed and statically verifiable", "rules selected-branch model", "value-derivation rows lower to compute", "Stable row IDs", "Discovery row 13", "Treasury row 9", "not an implementation claim"} {
 		if !strings.Contains(policySheet.Note, want) {
 			problems = append(problems, fmt.Sprintf("repair policy_sheet_row_model note missing %q", want))
 		}

--- a/internal/runtime/conformance/testdata/deterministic_work_ladder_design_record.yaml
+++ b/internal/runtime/conformance/testdata/deterministic_work_ladder_design_record.yaml
@@ -134,11 +134,12 @@ repairs:
     owner_issue: 1668
     decision: first_selection_helpers_are_policy_sheet_row_types
     evidence_owner: internal/runtime/conformance/testdata/deterministic_work_ladder_stage0.yaml
-    canonical_owner: future policy-sheet authoring construct; selection rows lower to platform-spec.yaml#handler_specification.handler_fields.rules and value rows lower to platform-spec.yaml#handler_specification.handler_fields.compute
+    canonical_owner: current rules policy-sheet authoring construct; selection rows lower to platform-spec.yaml#handler_specification.handler_fields.rules and value rows lower to platform-spec.yaml#handler_specification.handler_fields.compute
     forbidden_overloads:
       - handler_fields.switch
       - handler_fields.lookup
       - handler_fields.threshold
+      - handler_fields.policy
     required_surfaces:
       - design_record
       - future_platform_spec
@@ -146,12 +147,23 @@ repairs:
     note: >
       #1668 switch, lookup, and threshold candidates are the first row types of
       one ordered policy-sheet authoring construct, not standalone handler
-      fields. The row-type vocabulary is closed and statically verifiable:
-      branch-selection rows lower to the existing rules selected-branch model,
-      value-derivation rows lower to compute, and future temporal, join, loop,
-      collection, or schedule rows may be added only as separately gated closed
-      row types with their own verifier checks. This record is not an
-      implementation claim and does not promote policy-sheet runtime semantics.
+      fields. The current spelling of that policy sheet is rules: enhance rules
+      in place instead of adding a co-authorable policy field. The row-type
+      vocabulary is closed and statically verifiable: branch-selection rows
+      lower to the existing rules selected-branch model, value-derivation rows
+      lower to compute, and future temporal, join, loop, collection, or schedule
+      rows may be added only as separately gated closed row types with their own
+      verifier checks. Stable row IDs are trace-addressable contract identity.
+      The evidence pitch is dedup/readability first, then stable IDs plus
+      ordered-explicit rows, then keeping dispatch out of code/agents, with
+      exhaustiveness proof as the safety layer. Discovery row 13 is the
+      strongest selector proof because the legacy mode dispatcher showed
+      switch-as-event-proliferation plus escape to Go; it pre-registers future
+      temporal and collection rows without implementing them here. Treasury row
+      9 is the composition proof: a value row can normalize spend_ratio through
+      compute, then an adjacent selection row dispatches on policy-constant
+      threshold bounds. This record was originally not an implementation claim;
+      #1713 promotes the selection-row subset in platform-spec.yaml.
 launch_language:
   owner_issue: 1670
   selected: python

--- a/internal/runtime/contracts/workflow_contract_policy_sheet.go
+++ b/internal/runtime/contracts/workflow_contract_policy_sheet.go
@@ -1,0 +1,664 @@
+package contracts
+
+import (
+	"fmt"
+	"math"
+	"strconv"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+func lowerPolicySheetRuleNode(node *yaml.Node, rule *HandlerRuleEntry) error {
+	if node == nil || node.Kind != yaml.MappingNode || rule == nil {
+		return nil
+	}
+	rowNodes := map[string]*yaml.Node{}
+	for _, key := range []string{"when", "case", "range", "else", "default"} {
+		if value := yamlMappingValueNode(node, key); value != nil {
+			rowNodes[key] = value
+		}
+	}
+	if len(rowNodes) == 0 {
+		rule.Condition = strings.TrimSpace(rule.Condition)
+		return nil
+	}
+	if len(rowNodes) > 1 {
+		return fmt.Errorf("POLICY-SHEET-ROW: rule %q declares multiple row types", strings.TrimSpace(rule.ID))
+	}
+	if strings.TrimSpace(rule.Condition) != "" {
+		return fmt.Errorf("POLICY-SHEET-ROW: rule %q declares both condition and typed policy-sheet row syntax", strings.TrimSpace(rule.ID))
+	}
+	switch {
+	case rowNodes["when"] != nil:
+		condition, err := decodePolicySheetScalarString(rowNodes["when"], "when")
+		if err != nil {
+			return err
+		}
+		if condition == "" {
+			return fmt.Errorf("POLICY-SHEET-ROW: when row %q requires a non-empty condition", strings.TrimSpace(rule.ID))
+		}
+		rule.Condition = condition
+		rule.PolicyRow = PolicySheetRowMetadata{Kind: PolicySheetRowKindWhen}
+	case rowNodes["case"] != nil:
+		condition, metadata, err := decodePolicySheetCaseRow(rowNodes["case"])
+		if err != nil {
+			return err
+		}
+		rule.Condition = condition
+		rule.PolicyRow = metadata
+	case rowNodes["range"] != nil:
+		condition, metadata, err := decodePolicySheetRangeRow(rowNodes["range"])
+		if err != nil {
+			return err
+		}
+		rule.Condition = condition
+		rule.PolicyRow = metadata
+	case rowNodes["else"] != nil:
+		if err := requirePolicySheetBoolTrue(rowNodes["else"], "else"); err != nil {
+			return err
+		}
+		rule.Condition = "else"
+		rule.PolicyRow = PolicySheetRowMetadata{Kind: PolicySheetRowKindDefault}
+	case rowNodes["default"] != nil:
+		if err := requirePolicySheetBoolTrue(rowNodes["default"], "default"); err != nil {
+			return err
+		}
+		rule.Condition = "else"
+		rule.PolicyRow = PolicySheetRowMetadata{Kind: PolicySheetRowKindDefault}
+	}
+	return nil
+}
+
+func validatePolicySheetRows(rules []HandlerRuleEntry, context handlerRuleDecodeContext) error {
+	hasPolicyRows := false
+	for _, rule := range rules {
+		if rule.PolicyRow.Kind != "" {
+			hasPolicyRows = true
+			break
+		}
+	}
+	if !hasPolicyRows {
+		return nil
+	}
+	if context != handlerRuleDecodeContextRules {
+		return fmt.Errorf("POLICY-SHEET-ROW: typed policy-sheet rows are only supported under handler.rules")
+	}
+	seenIDs := map[string]int{}
+	hasDefault := false
+	caseKeys := map[string]int{}
+	rangesByValue := map[string][]policySheetRangeForValidation{}
+	for idx, rule := range rules {
+		id := strings.TrimSpace(rule.ID)
+		if id == "" {
+			return fmt.Errorf("POLICY-SHEET-ROW: rules[%d] requires stable id when policy-sheet rows are present", idx)
+		}
+		if prev, ok := seenIDs[id]; ok {
+			return fmt.Errorf("POLICY-SHEET-ROW: duplicate stable row id %q at rules[%d] and rules[%d]", id, prev, idx)
+		}
+		seenIDs[id] = idx
+		if strings.EqualFold(strings.TrimSpace(rule.Condition), "else") {
+			hasDefault = true
+		}
+		switch rule.PolicyRow.Kind {
+		case PolicySheetRowKindCase:
+			key := strings.Join(rule.PolicyRow.Selectors, "\x00") + "\x01" + strings.Join(rule.PolicyRow.CaseValues, "\x00")
+			if prev, ok := caseKeys[key]; ok {
+				return fmt.Errorf("POLICY-SHEET-ROW: duplicate case key at rules[%d] and rules[%d]", prev, idx)
+			}
+			caseKeys[key] = idx
+		case PolicySheetRowKindRange:
+			metadata := rule.PolicyRow
+			rangesByValue[metadata.RangeValue] = append(rangesByValue[metadata.RangeValue], policySheetRangeForValidation{
+				Index:        idx,
+				Lower:        metadata.RangeLower,
+				Upper:        metadata.RangeUpper,
+				Monotonicity: metadata.Monotonicity,
+			})
+		}
+	}
+	if !hasDefault {
+		return fmt.Errorf("POLICY-SHEET-ROW: rules with typed policy-sheet rows require an else/default row")
+	}
+	for value, ranges := range rangesByValue {
+		if err := validatePolicySheetRanges(value, ranges); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+type policySheetRangeForValidation struct {
+	Index        int
+	Lower        PolicySheetRangeBound
+	Upper        PolicySheetRangeBound
+	Monotonicity []string
+}
+
+func decodePolicySheetCaseRow(node *yaml.Node) (string, PolicySheetRowMetadata, error) {
+	if node == nil || node.Kind != yaml.MappingNode {
+		return "", PolicySheetRowMetadata{}, fmt.Errorf("POLICY-SHEET-ROW: case row must be a mapping")
+	}
+	if err := validatePolicySheetMappingKeys(node, "case", map[string]struct{}{"selector": {}, "selectors": {}, "equals": {}}); err != nil {
+		return "", PolicySheetRowMetadata{}, err
+	}
+	selectors, err := decodePolicySheetSelectors(node)
+	if err != nil {
+		return "", PolicySheetRowMetadata{}, err
+	}
+	equalsNode := yamlMappingValueNode(node, "equals")
+	if equalsNode == nil {
+		return "", PolicySheetRowMetadata{}, fmt.Errorf("POLICY-SHEET-ROW: case row requires equals")
+	}
+	values, literals, err := decodePolicySheetEquals(equalsNode)
+	if err != nil {
+		return "", PolicySheetRowMetadata{}, err
+	}
+	if len(values) != len(selectors) {
+		return "", PolicySheetRowMetadata{}, fmt.Errorf("POLICY-SHEET-ROW: case row selector count %d does not match equals count %d", len(selectors), len(values))
+	}
+	parts := make([]string, 0, len(selectors))
+	for i := range selectors {
+		parts = append(parts, selectors[i]+" == "+literals[i])
+	}
+	return strings.Join(parts, " && "), PolicySheetRowMetadata{
+		Kind:       PolicySheetRowKindCase,
+		Selectors:  selectors,
+		CaseValues: values,
+	}, nil
+}
+
+func decodePolicySheetRangeRow(node *yaml.Node) (string, PolicySheetRowMetadata, error) {
+	if node == nil || node.Kind != yaml.MappingNode {
+		return "", PolicySheetRowMetadata{}, fmt.Errorf("POLICY-SHEET-ROW: range row must be a mapping")
+	}
+	if err := validatePolicySheetMappingKeys(node, "range", map[string]struct{}{"value": {}, "gt": {}, "gte": {}, "lt": {}, "lte": {}, "monotonicity": {}}); err != nil {
+		return "", PolicySheetRowMetadata{}, err
+	}
+	value, err := decodePolicySheetScalarString(yamlMappingValueNode(node, "value"), "range.value")
+	if err != nil {
+		return "", PolicySheetRowMetadata{}, err
+	}
+	if err := validatePolicySheetSelector(value, "range.value"); err != nil {
+		return "", PolicySheetRowMetadata{}, err
+	}
+	lower, err := decodePolicySheetRangeBound(node, "gt", ">")
+	if err != nil {
+		return "", PolicySheetRowMetadata{}, err
+	}
+	lowerEq, err := decodePolicySheetRangeBound(node, "gte", ">=")
+	if err != nil {
+		return "", PolicySheetRowMetadata{}, err
+	}
+	upper, err := decodePolicySheetRangeBound(node, "lt", "<")
+	if err != nil {
+		return "", PolicySheetRowMetadata{}, err
+	}
+	upperEq, err := decodePolicySheetRangeBound(node, "lte", "<=")
+	if err != nil {
+		return "", PolicySheetRowMetadata{}, err
+	}
+	if lower.Value != "" && lowerEq.Value != "" {
+		return "", PolicySheetRowMetadata{}, fmt.Errorf("POLICY-SHEET-ROW: range row declares both gt and gte")
+	}
+	if upper.Value != "" && upperEq.Value != "" {
+		return "", PolicySheetRowMetadata{}, fmt.Errorf("POLICY-SHEET-ROW: range row declares both lt and lte")
+	}
+	if lower.Value == "" {
+		lower = lowerEq
+	}
+	if upper.Value == "" {
+		upper = upperEq
+	}
+	if lower.Value == "" && upper.Value == "" {
+		return "", PolicySheetRowMetadata{}, fmt.Errorf("POLICY-SHEET-ROW: range row requires at least one bound")
+	}
+	monotonicity, err := decodePolicySheetStringList(yamlMappingValueNode(node, "monotonicity"), "range.monotonicity")
+	if err != nil {
+		return "", PolicySheetRowMetadata{}, err
+	}
+	parts := make([]string, 0, 2)
+	if lower.Value != "" {
+		parts = append(parts, value+" "+lower.Operator+" "+lower.Value)
+	}
+	if upper.Value != "" {
+		parts = append(parts, value+" "+upper.Operator+" "+upper.Value)
+	}
+	return strings.Join(parts, " && "), PolicySheetRowMetadata{
+		Kind:         PolicySheetRowKindRange,
+		RangeValue:   value,
+		RangeLower:   lower,
+		RangeUpper:   upper,
+		Monotonicity: monotonicity,
+	}, nil
+}
+
+func decodePolicySheetSelectors(node *yaml.Node) ([]string, error) {
+	selectorNode := yamlMappingValueNode(node, "selector")
+	selectorsNode := yamlMappingValueNode(node, "selectors")
+	if selectorNode != nil && selectorsNode != nil {
+		return nil, fmt.Errorf("POLICY-SHEET-ROW: case row declares both selector and selectors")
+	}
+	var selectors []string
+	var err error
+	switch {
+	case selectorNode != nil:
+		var selector string
+		selector, err = decodePolicySheetScalarString(selectorNode, "case.selector")
+		selectors = []string{selector}
+	case selectorsNode != nil:
+		selectors, err = decodePolicySheetStringList(selectorsNode, "case.selectors")
+	default:
+		err = fmt.Errorf("POLICY-SHEET-ROW: case row requires selector or selectors")
+	}
+	if err != nil {
+		return nil, err
+	}
+	if len(selectors) == 0 {
+		return nil, fmt.Errorf("POLICY-SHEET-ROW: case row requires at least one selector")
+	}
+	for _, selector := range selectors {
+		if err := validatePolicySheetSelector(selector, "case.selector"); err != nil {
+			return nil, err
+		}
+	}
+	return selectors, nil
+}
+
+func decodePolicySheetEquals(node *yaml.Node) ([]string, []string, error) {
+	if node == nil || node.Kind == 0 {
+		return nil, nil, fmt.Errorf("POLICY-SHEET-ROW: case.equals is required")
+	}
+	if node.Kind == yaml.SequenceNode {
+		values := make([]string, 0, len(node.Content))
+		literals := make([]string, 0, len(node.Content))
+		for _, item := range node.Content {
+			value, literal, err := decodePolicySheetLiteral(item, "case.equals")
+			if err != nil {
+				return nil, nil, err
+			}
+			values = append(values, value)
+			literals = append(literals, literal)
+		}
+		return values, literals, nil
+	}
+	value, literal, err := decodePolicySheetLiteral(node, "case.equals")
+	if err != nil {
+		return nil, nil, err
+	}
+	return []string{value}, []string{literal}, nil
+}
+
+func decodePolicySheetLiteral(node *yaml.Node, label string) (string, string, error) {
+	if node == nil || node.Kind != yaml.ScalarNode {
+		return "", "", fmt.Errorf("POLICY-SHEET-ROW: %s must be a scalar or scalar list", label)
+	}
+	raw := strings.TrimSpace(node.Value)
+	switch strings.TrimSpace(node.Tag) {
+	case "!!int", "!!float":
+		if _, err := strconv.ParseFloat(raw, 64); err != nil {
+			return "", "", fmt.Errorf("POLICY-SHEET-ROW: %s numeric literal %q is invalid", label, raw)
+		}
+		return raw, raw, nil
+	case "!!bool":
+		if raw != "true" && raw != "false" {
+			return "", "", fmt.Errorf("POLICY-SHEET-ROW: %s bool literal %q is invalid", label, raw)
+		}
+		return raw, raw, nil
+	case "!!str", "":
+		return raw, strconv.Quote(raw), nil
+	default:
+		return "", "", fmt.Errorf("POLICY-SHEET-ROW: %s uses unsupported literal tag %s", label, node.Tag)
+	}
+}
+
+func decodePolicySheetRangeBound(node *yaml.Node, key, operator string) (PolicySheetRangeBound, error) {
+	valueNode := yamlMappingValueNode(node, key)
+	if valueNode == nil {
+		return PolicySheetRangeBound{}, nil
+	}
+	if valueNode.Kind != yaml.ScalarNode {
+		return PolicySheetRangeBound{}, fmt.Errorf("POLICY-SHEET-ROW: range.%s must be a scalar bound", key)
+	}
+	raw := strings.TrimSpace(valueNode.Value)
+	if raw == "" {
+		return PolicySheetRangeBound{}, fmt.Errorf("POLICY-SHEET-ROW: range.%s must be non-empty", key)
+	}
+	if _, err := strconv.ParseFloat(raw, 64); err == nil {
+		return PolicySheetRangeBound{Operator: operator, Value: raw, Kind: "literal"}, nil
+	}
+	if isPolicySheetPolicyConstantExpression(raw) {
+		return PolicySheetRangeBound{Operator: operator, Value: raw, Kind: "policy"}, nil
+	}
+	if policySheetRoot(raw) != "" {
+		return PolicySheetRangeBound{}, fmt.Errorf("POLICY-SHEET-ROW: range.%s dynamic bound %q is forbidden; normalize with compute/value rows first", key, raw)
+	}
+	return PolicySheetRangeBound{}, fmt.Errorf("POLICY-SHEET-ROW: range.%s bound %q must be a numeric literal or policy constant", key, raw)
+}
+
+func validatePolicySheetRanges(value string, ranges []policySheetRangeForValidation) error {
+	graph := newPolicySheetMonotonicityGraph()
+	for _, row := range ranges {
+		for _, constraint := range row.Monotonicity {
+			if err := graph.addConstraint(constraint); err != nil {
+				return fmt.Errorf("POLICY-SHEET-ROW: rules[%d] range.monotonicity: %w", row.Index, err)
+			}
+		}
+	}
+	for _, row := range ranges {
+		if row.Lower.Kind == "policy" || row.Upper.Kind == "policy" {
+			if len(row.Monotonicity) == 0 {
+				return fmt.Errorf("POLICY-SHEET-ROW: rules[%d] range with policy-constant bounds requires monotonicity", row.Index)
+			}
+		}
+		if row.Lower.Value != "" && row.Upper.Value != "" {
+			if err := graph.proveOrdered(row.Lower.Value, row.Upper.Value); err != nil {
+				return fmt.Errorf("POLICY-SHEET-ROW: rules[%d] range lower/upper bounds for %s: %w", row.Index, value, err)
+			}
+		}
+	}
+	for i := 0; i < len(ranges); i++ {
+		for j := i + 1; j < len(ranges); j++ {
+			if policySheetNumericRangesOverlap(ranges[i], ranges[j]) {
+				return fmt.Errorf("POLICY-SHEET-ROW: overlapping literal ranges for %s at rules[%d] and rules[%d]", value, ranges[i].Index, ranges[j].Index)
+			}
+		}
+	}
+	for i := 1; i < len(ranges); i++ {
+		prev := ranges[i-1]
+		curr := ranges[i]
+		if prev.Upper.Value == "" || curr.Lower.Value == "" {
+			continue
+		}
+		if prev.Upper.Kind == "policy" || curr.Lower.Kind == "policy" {
+			if err := graph.proveOrdered(prev.Upper.Value, curr.Lower.Value); err != nil {
+				return fmt.Errorf("POLICY-SHEET-ROW: adjacent ranges for %s at rules[%d]/rules[%d]: %w", value, prev.Index, curr.Index, err)
+			}
+		}
+	}
+	return nil
+}
+
+func policySheetNumericRangesOverlap(a, b policySheetRangeForValidation) bool {
+	aMin, aMax, aMinClosed, aMaxClosed, okA := policySheetNumericInterval(a)
+	bMin, bMax, bMinClosed, bMaxClosed, okB := policySheetNumericInterval(b)
+	if !okA || !okB {
+		return false
+	}
+	if aMax < bMin || bMax < aMin {
+		return false
+	}
+	if aMax == bMin {
+		return aMaxClosed && bMinClosed
+	}
+	if bMax == aMin {
+		return bMaxClosed && aMinClosed
+	}
+	return true
+}
+
+func policySheetNumericInterval(row policySheetRangeForValidation) (float64, float64, bool, bool, bool) {
+	min := math.Inf(-1)
+	max := math.Inf(1)
+	minClosed := false
+	maxClosed := false
+	if row.Lower.Value != "" {
+		if row.Lower.Kind != "literal" {
+			return 0, 0, false, false, false
+		}
+		parsed, err := strconv.ParseFloat(row.Lower.Value, 64)
+		if err != nil {
+			return 0, 0, false, false, false
+		}
+		min = parsed
+		minClosed = row.Lower.Operator == ">="
+	}
+	if row.Upper.Value != "" {
+		if row.Upper.Kind != "literal" {
+			return 0, 0, false, false, false
+		}
+		parsed, err := strconv.ParseFloat(row.Upper.Value, 64)
+		if err != nil {
+			return 0, 0, false, false, false
+		}
+		max = parsed
+		maxClosed = row.Upper.Operator == "<="
+	}
+	return min, max, minClosed, maxClosed, true
+}
+
+type policySheetMonotonicityGraph struct {
+	edges map[string]map[string]struct{}
+}
+
+func newPolicySheetMonotonicityGraph() *policySheetMonotonicityGraph {
+	return &policySheetMonotonicityGraph{edges: map[string]map[string]struct{}{}}
+}
+
+func (g *policySheetMonotonicityGraph) addConstraint(raw string) error {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return fmt.Errorf("constraint must be non-empty")
+	}
+	parts := strings.Split(raw, "<=")
+	if len(parts) < 2 {
+		return fmt.Errorf("constraint %q must use <= monotonicity", raw)
+	}
+	for i := range parts {
+		parts[i] = canonicalPolicySheetTerm(parts[i])
+		if err := validatePolicySheetMonotonicityTerm(parts[i]); err != nil {
+			return err
+		}
+	}
+	for i := 0; i+1 < len(parts); i++ {
+		from, to := parts[i], parts[i+1]
+		if g.edges[from] == nil {
+			g.edges[from] = map[string]struct{}{}
+		}
+		g.edges[from][to] = struct{}{}
+	}
+	return nil
+}
+
+func (g *policySheetMonotonicityGraph) proveOrdered(lower, upper string) error {
+	lower = canonicalPolicySheetTerm(lower)
+	upper = canonicalPolicySheetTerm(upper)
+	if lower == "" || upper == "" || lower == upper {
+		return nil
+	}
+	if l, errL := strconv.ParseFloat(lower, 64); errL == nil {
+		if u, errU := strconv.ParseFloat(upper, 64); errU == nil {
+			if l <= u {
+				return nil
+			}
+			return fmt.Errorf("%s is greater than %s", lower, upper)
+		}
+	}
+	seen := map[string]struct{}{lower: {}}
+	queue := []string{lower}
+	for len(queue) > 0 {
+		current := queue[0]
+		queue = queue[1:]
+		for next := range g.edges[current] {
+			if next == upper {
+				return nil
+			}
+			if _, ok := seen[next]; ok {
+				continue
+			}
+			seen[next] = struct{}{}
+			queue = append(queue, next)
+		}
+	}
+	return fmt.Errorf("monotonicity does not prove %s <= %s", lower, upper)
+}
+
+func validatePolicySheetMonotonicityTerm(term string) error {
+	term = canonicalPolicySheetTerm(term)
+	if term == "" {
+		return fmt.Errorf("monotonicity term must be non-empty")
+	}
+	if _, err := strconv.ParseFloat(term, 64); err == nil {
+		return nil
+	}
+	if isPolicySheetPolicyConstantExpression(term) {
+		return nil
+	}
+	return fmt.Errorf("POLICY-SHEET-ROW: range.monotonicity term %q must be a numeric literal or policy-constant expression", term)
+}
+
+func validatePolicySheetSelector(selector, label string) error {
+	return validatePolicySheetPath(selector, label, []string{"payload", "entity", "policy", "event"})
+}
+
+func validatePolicySheetPath(expr, label string, allowedRoots []string) error {
+	expr = strings.TrimSpace(expr)
+	if expr == "" {
+		return fmt.Errorf("POLICY-SHEET-ROW: %s must be non-empty", label)
+	}
+	root := policySheetRoot(expr)
+	if root == "" {
+		return fmt.Errorf("POLICY-SHEET-ROW: %s %q must be a dotted path rooted in %s", label, expr, strings.Join(allowedRoots, ", "))
+	}
+	for _, allowed := range allowedRoots {
+		if root == allowed {
+			if strings.ContainsAny(expr, " \t+-*/()[]") {
+				return fmt.Errorf("POLICY-SHEET-ROW: %s %q must be a simple dotted path", label, expr)
+			}
+			return nil
+		}
+	}
+	return fmt.Errorf("POLICY-SHEET-ROW: %s %q uses unsupported root %q", label, expr, root)
+}
+
+func policySheetRoot(expr string) string {
+	expr = strings.TrimSpace(expr)
+	if idx := strings.Index(expr, "."); idx > 0 {
+		return expr[:idx]
+	}
+	return ""
+}
+
+func canonicalPolicySheetTerm(term string) string {
+	return strings.Join(strings.Fields(strings.TrimSpace(term)), "")
+}
+
+func isPolicySheetPolicyConstantExpression(expr string) bool {
+	expr = canonicalPolicySheetTerm(expr)
+	if expr == "" {
+		return false
+	}
+	hasPolicy := false
+	tokens := strings.FieldsFunc(expr, func(r rune) bool {
+		switch r {
+		case '+', '-', '*', '/', '(', ')':
+			return true
+		default:
+			return false
+		}
+	})
+	for _, token := range tokens {
+		token = strings.TrimSpace(token)
+		if token == "" {
+			continue
+		}
+		if _, err := strconv.ParseFloat(token, 64); err == nil {
+			continue
+		}
+		if strings.HasPrefix(token, "policy.") {
+			if err := validatePolicySheetPath(token, "policy-constant bound", []string{"policy"}); err != nil {
+				return false
+			}
+			hasPolicy = true
+			continue
+		}
+		return false
+	}
+	for _, r := range expr {
+		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == '_' || r == '.' || r == '+' || r == '-' || r == '*' || r == '/' || r == '(' || r == ')' {
+			continue
+		}
+		return false
+	}
+	return hasPolicy
+}
+
+func requirePolicySheetBoolTrue(node *yaml.Node, label string) error {
+	if node == nil || node.Kind == 0 {
+		return fmt.Errorf("POLICY-SHEET-ROW: %s is required", label)
+	}
+	if node.Kind != yaml.ScalarNode {
+		return fmt.Errorf("POLICY-SHEET-ROW: %s must be true", label)
+	}
+	value := strings.TrimSpace(node.Value)
+	if value != "true" {
+		return fmt.Errorf("POLICY-SHEET-ROW: %s must be true", label)
+	}
+	return nil
+}
+
+func decodePolicySheetScalarString(node *yaml.Node, label string) (string, error) {
+	if node == nil || node.Kind == 0 {
+		return "", fmt.Errorf("POLICY-SHEET-ROW: %s is required", label)
+	}
+	if node.Kind != yaml.ScalarNode {
+		return "", fmt.Errorf("POLICY-SHEET-ROW: %s must be a scalar string", label)
+	}
+	return strings.TrimSpace(node.Value), nil
+}
+
+func decodePolicySheetStringList(node *yaml.Node, label string) ([]string, error) {
+	if node == nil || node.Kind == 0 {
+		return nil, nil
+	}
+	switch node.Kind {
+	case yaml.ScalarNode:
+		value := strings.TrimSpace(node.Value)
+		if value == "" {
+			return nil, nil
+		}
+		return []string{value}, nil
+	case yaml.SequenceNode:
+		out := make([]string, 0, len(node.Content))
+		for _, item := range node.Content {
+			value, err := decodePolicySheetScalarString(item, label)
+			if err != nil {
+				return nil, err
+			}
+			if value != "" {
+				out = append(out, value)
+			}
+		}
+		return out, nil
+	default:
+		return nil, fmt.Errorf("POLICY-SHEET-ROW: %s must be a scalar string or string list", label)
+	}
+}
+
+func validatePolicySheetMappingKeys(node *yaml.Node, label string, allowed map[string]struct{}) error {
+	if node == nil || node.Kind != yaml.MappingNode {
+		return nil
+	}
+	for i := 0; i+1 < len(node.Content); i += 2 {
+		key := strings.TrimSpace(node.Content[i].Value)
+		if key == "" {
+			continue
+		}
+		if _, ok := allowed[key]; !ok {
+			return fmt.Errorf("UNDEFINED-FIELD: %s field %q not in platform spec", label, key)
+		}
+	}
+	return nil
+}
+
+func yamlMappingValueNode(node *yaml.Node, key string) *yaml.Node {
+	if node == nil || node.Kind != yaml.MappingNode {
+		return nil
+	}
+	for i := 0; i+1 < len(node.Content); i += 2 {
+		if strings.TrimSpace(node.Content[i].Value) == key {
+			return node.Content[i+1]
+		}
+	}
+	return nil
+}

--- a/internal/runtime/contracts/workflow_contract_policy_sheet.go
+++ b/internal/runtime/contracts/workflow_contract_policy_sheet.go
@@ -359,24 +359,49 @@ func validatePolicySheetRanges(value string, ranges []policySheetRangeForValidat
 	}
 	for i := 0; i < len(ranges); i++ {
 		for j := i + 1; j < len(ranges); j++ {
-			if policySheetNumericRangesOverlap(ranges[i], ranges[j]) {
-				return fmt.Errorf("POLICY-SHEET-ROW: overlapping literal ranges for %s at rules[%d] and rules[%d]", value, ranges[i].Index, ranges[j].Index)
-			}
-		}
-	}
-	for i := 1; i < len(ranges); i++ {
-		prev := ranges[i-1]
-		curr := ranges[i]
-		if prev.Upper.Value == "" || curr.Lower.Value == "" {
-			continue
-		}
-		if prev.Upper.Kind == "policy" || curr.Lower.Kind == "policy" {
-			if err := graph.proveOrdered(prev.Upper.Value, curr.Lower.Value); err != nil {
-				return fmt.Errorf("POLICY-SHEET-ROW: adjacent ranges for %s at rules[%d]/rules[%d]: %w", value, prev.Index, curr.Index, err)
+			if err := validatePolicySheetRangePairDoesNotOverlap(value, graph, ranges[i], ranges[j]); err != nil {
+				return err
 			}
 		}
 	}
 	return nil
+}
+
+func validatePolicySheetRangePairDoesNotOverlap(value string, graph *policySheetMonotonicityGraph, a, b policySheetRangeForValidation) error {
+	if aNumeric := policySheetRangeUsesOnlyLiteralBounds(a); aNumeric && policySheetRangeUsesOnlyLiteralBounds(b) {
+		if policySheetNumericRangesOverlap(a, b) {
+			return fmt.Errorf("POLICY-SHEET-ROW: overlapping literal ranges for %s at rules[%d] and rules[%d]", value, a.Index, b.Index)
+		}
+		return nil
+	}
+	if policySheetRangesAreStructurallyDisjoint(graph, a, b) {
+		return nil
+	}
+	return fmt.Errorf("POLICY-SHEET-ROW: overlapping ranges for %s at rules[%d] and rules[%d]", value, a.Index, b.Index)
+}
+
+func policySheetRangeUsesOnlyLiteralBounds(row policySheetRangeForValidation) bool {
+	if row.Lower.Value != "" && row.Lower.Kind != "literal" {
+		return false
+	}
+	if row.Upper.Value != "" && row.Upper.Kind != "literal" {
+		return false
+	}
+	return true
+}
+
+func policySheetRangesAreStructurallyDisjoint(graph *policySheetMonotonicityGraph, a, b policySheetRangeForValidation) bool {
+	return policySheetUpperBeforeLower(graph, a.Upper, b.Lower) || policySheetUpperBeforeLower(graph, b.Upper, a.Lower)
+}
+
+func policySheetUpperBeforeLower(graph *policySheetMonotonicityGraph, upper, lower PolicySheetRangeBound) bool {
+	if upper.Value == "" || lower.Value == "" {
+		return false
+	}
+	if err := graph.proveOrdered(upper.Value, lower.Value); err != nil {
+		return false
+	}
+	return upper.Operator == "<" || lower.Operator == ">"
 }
 
 func policySheetNumericRangesOverlap(a, b policySheetRangeForValidation) bool {

--- a/internal/runtime/contracts/workflow_contract_policy_sheet.go
+++ b/internal/runtime/contracts/workflow_contract_policy_sheet.go
@@ -522,13 +522,40 @@ func validatePolicySheetPath(expr, label string, allowedRoots []string) error {
 	}
 	for _, allowed := range allowedRoots {
 		if root == allowed {
-			if strings.ContainsAny(expr, " \t+-*/()[]") {
-				return fmt.Errorf("POLICY-SHEET-ROW: %s %q must be a simple dotted path", label, expr)
+			parts := strings.Split(expr, ".")
+			for idx, part := range parts {
+				if !isPolicySheetPathSegment(part) {
+					return fmt.Errorf("POLICY-SHEET-ROW: %s %q must be a simple dotted path", label, expr)
+				}
+				if idx == 0 && part != allowed {
+					return fmt.Errorf("POLICY-SHEET-ROW: %s %q uses unsupported root %q", label, expr, root)
+				}
 			}
 			return nil
 		}
 	}
 	return fmt.Errorf("POLICY-SHEET-ROW: %s %q uses unsupported root %q", label, expr, root)
+}
+
+func isPolicySheetPathSegment(segment string) bool {
+	if segment == "" {
+		return false
+	}
+	for idx, r := range segment {
+		switch {
+		case r == '_':
+			continue
+		case r >= 'a' && r <= 'z':
+			continue
+		case r >= 'A' && r <= 'Z':
+			continue
+		case idx > 0 && r >= '0' && r <= '9':
+			continue
+		default:
+			return false
+		}
+	}
+	return true
 }
 
 func policySheetRoot(expr string) string {

--- a/internal/runtime/contracts/workflow_contract_types.go
+++ b/internal/runtime/contracts/workflow_contract_types.go
@@ -151,6 +151,7 @@ type HandlerRuleEntry struct {
 	ID               string                   `yaml:"id"`
 	Description      string                   `yaml:"description"`
 	Condition        string                   `yaml:"condition"`
+	PolicyRow        PolicySheetRowMetadata   `yaml:"-"`
 	AdvancesTo       string                   `yaml:"advances_to"`
 	Emit             EmitSpec                 `yaml:"emit"`
 	Action           ActionSpec               `yaml:"action"`
@@ -158,6 +159,31 @@ type HandlerRuleEntry struct {
 	DataAccumulation WorkflowDataAccumulation `yaml:"data_accumulation"`
 	Compute          *ComputeSpec             `yaml:"compute"`
 	FanOut           *FanOutSpec              `yaml:"fan_out"`
+}
+
+type PolicySheetRowKind string
+
+const (
+	PolicySheetRowKindWhen    PolicySheetRowKind = "when"
+	PolicySheetRowKindCase    PolicySheetRowKind = "case"
+	PolicySheetRowKindRange   PolicySheetRowKind = "range"
+	PolicySheetRowKindDefault PolicySheetRowKind = "default"
+)
+
+type PolicySheetRowMetadata struct {
+	Kind         PolicySheetRowKind
+	Selectors    []string
+	CaseValues   []string
+	RangeValue   string
+	RangeLower   PolicySheetRangeBound
+	RangeUpper   PolicySheetRangeBound
+	Monotonicity []string
+}
+
+type PolicySheetRangeBound struct {
+	Operator string
+	Value    string
+	Kind     string
 }
 
 type ActivityEffectClass string

--- a/internal/runtime/contracts/workflow_contract_yaml_flow.go
+++ b/internal/runtime/contracts/workflow_contract_yaml_flow.go
@@ -21,6 +21,9 @@ func (r *HandlerRuleEntry) UnmarshalYAML(node *yaml.Node) error {
 		return err
 	}
 	*r = HandlerRuleEntry(aux)
+	if err := lowerPolicySheetRuleNode(node, r); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -32,6 +35,11 @@ func validateRuleFieldNodes(node *yaml.Node) error {
 		"id":                {},
 		"description":       {},
 		"condition":         {},
+		"when":              {},
+		"case":              {},
+		"range":             {},
+		"else":              {},
+		"default":           {},
 		"advances_to":       {},
 		"emit":              {},
 		"action":            {},
@@ -50,6 +58,12 @@ func validateRuleFieldNodes(node *yaml.Node) error {
 			return fmt.Errorf("RETIRED: rule field %q is retired; use emit: <event> or emit: {event, fields}", key)
 		case "payload_transform":
 			return fmt.Errorf("RETIRED: rule field %q is retired; move payload ownership into rule-local emit.fields", key)
+		case "switch", "lookup", "threshold":
+			return fmt.Errorf("UNSUPPORTED-POLICY-SHEET-ROW: rule field %q is not a standalone row type; use rules when/case/range selection rows or split value lookup to compute", key)
+		case "policy":
+			return fmt.Errorf("UNSUPPORTED-POLICY-SHEET-ROW: rule field %q would create a second policy-sheet authoring owner; enhance rules in place", key)
+		case "temporal", "join", "loop", "collection", "schedule", "validate":
+			return fmt.Errorf("UNSUPPORTED-POLICY-SHEET-ROW: rule field %q is outside the #1713 selection-row scope", key)
 		}
 		if _, ok := allowed[key]; !ok {
 			return fmt.Errorf("UNDEFINED-FIELD: rule field %q not in platform spec", key)

--- a/internal/runtime/contracts/workflow_contract_yaml_handlers.go
+++ b/internal/runtime/contracts/workflow_contract_yaml_handlers.go
@@ -1254,14 +1254,21 @@ func decodeHandlerRuleEntriesNode(node *yaml.Node, context handlerRuleDecodeCont
 				return nil, err
 			}
 		}
+		if err := validatePolicySheetRows(rules, context); err != nil {
+			return nil, err
+		}
 		return rules, nil
 	case yaml.MappingNode:
-		if hasAnyYAMLMappingKey(node, "condition", "advances_to", "emit", "emits", "action", "data_accumulation", "compute", "fan_out") {
+		if hasAnyYAMLMappingKey(node, "condition", "when", "case", "range", "else", "default", "advances_to", "emit", "emits", "action", "data_accumulation", "compute", "fan_out") {
 			rule, err := decodeHandlerRuleEntryNode(node, context)
 			if err != nil || rule == nil {
 				return nil, err
 			}
-			return []HandlerRuleEntry{*rule}, nil
+			rules := []HandlerRuleEntry{*rule}
+			if err := validatePolicySheetRows(rules, context); err != nil {
+				return nil, err
+			}
+			return rules, nil
 		}
 		rules := make([]HandlerRuleEntry, 0, len(node.Content)/2)
 		for i := 0; i+1 < len(node.Content); i += 2 {
@@ -1280,6 +1287,9 @@ func decodeHandlerRuleEntriesNode(node *yaml.Node, context handlerRuleDecodeCont
 				rule.ID = id
 			}
 			rules = append(rules, rule)
+		}
+		if err := validatePolicySheetRows(rules, context); err != nil {
+			return nil, err
 		}
 		return rules, nil
 	default:

--- a/internal/runtime/contracts/workflow_contract_yaml_handlers.go
+++ b/internal/runtime/contracts/workflow_contract_yaml_handlers.go
@@ -1259,7 +1259,7 @@ func decodeHandlerRuleEntriesNode(node *yaml.Node, context handlerRuleDecodeCont
 		}
 		return rules, nil
 	case yaml.MappingNode:
-		if hasAnyYAMLMappingKey(node, "condition", "when", "case", "range", "else", "default", "advances_to", "emit", "emits", "action", "data_accumulation", "compute", "fan_out") {
+		if mappingIsSingleHandlerRuleEntry(node) {
 			rule, err := decodeHandlerRuleEntryNode(node, context)
 			if err != nil || rule == nil {
 				return nil, err
@@ -1295,6 +1295,31 @@ func decodeHandlerRuleEntriesNode(node *yaml.Node, context handlerRuleDecodeCont
 	default:
 		return nil, fmt.Errorf("unsupported rules yaml node kind %d", node.Kind)
 	}
+}
+
+func mappingIsSingleHandlerRuleEntry(node *yaml.Node) bool {
+	if hasAnyYAMLMappingKey(node, "condition", "advances_to", "emit", "emits", "action", "data_accumulation", "compute", "fan_out") {
+		return true
+	}
+	if !hasAnyYAMLMappingKey(node, "when", "case", "range", "else", "default") {
+		return false
+	}
+	return !mappingCanBeKeyedHandlerRules(node)
+}
+
+func mappingCanBeKeyedHandlerRules(node *yaml.Node) bool {
+	if node == nil || node.Kind != yaml.MappingNode {
+		return false
+	}
+	for i := 0; i+1 < len(node.Content); i += 2 {
+		if strings.TrimSpace(node.Content[i].Value) == "" {
+			continue
+		}
+		if node.Content[i+1].Kind != yaml.MappingNode {
+			return false
+		}
+	}
+	return true
 }
 
 func rejectRuleActionOutsideRules(rule HandlerRuleEntry, context handlerRuleDecodeContext) error {

--- a/internal/runtime/contracts/workflow_contract_yaml_test.go
+++ b/internal/runtime/contracts/workflow_contract_yaml_test.go
@@ -753,13 +753,21 @@ rules:
       monotonicity:
         - policy.warning_pct / 100 <= policy.throttle_pct / 100 <= 1.0
     emit: treasury.warning_recorded
+  - id: treasury_throttle
+    range:
+      value: entity.spend_ratio
+      gte: policy.throttle_pct / 100
+      lt: 1.0
+      monotonicity:
+        - policy.warning_pct / 100 <= policy.throttle_pct / 100 <= 1.0
+    emit: treasury.throttle_recorded
   - id: default_route
     default: true
     emit: scan.default_requested
 `), &handler); err != nil {
 		t.Fatalf("yaml.Unmarshal: %v", err)
 	}
-	if got, want := len(handler.Rules), 5; got != want {
+	if got, want := len(handler.Rules), 6; got != want {
 		t.Fatalf("rules len = %d, want %d", got, want)
 	}
 	wantConditions := []string{
@@ -767,12 +775,14 @@ rules:
 		`payload.mode == "deep"`,
 		`payload.mode == "quick" && payload.target == "repository"`,
 		`entity.spend_ratio >= policy.warning_pct / 100 && entity.spend_ratio < policy.throttle_pct / 100`,
+		`entity.spend_ratio >= policy.throttle_pct / 100 && entity.spend_ratio < 1.0`,
 		"else",
 	}
 	wantKinds := []PolicySheetRowKind{
 		PolicySheetRowKindWhen,
 		PolicySheetRowKindCase,
 		PolicySheetRowKindCase,
+		PolicySheetRowKindRange,
 		PolicySheetRowKindRange,
 		PolicySheetRowKindDefault,
 	}
@@ -925,6 +935,30 @@ rules:
     advances_to: fallback
 `,
 			contains: "requires monotonicity",
+		},
+		{
+			name: "overlapping open ended policy ranges",
+			body: `
+rules:
+  - id: warning
+    range:
+      value: entity.spend_ratio
+      gte: policy.warning_ratio
+      monotonicity:
+        - policy.warning_ratio <= policy.throttle_ratio <= 1.0
+    advances_to: warning
+  - id: throttle
+    range:
+      value: entity.spend_ratio
+      gte: policy.throttle_ratio
+      monotonicity:
+        - policy.warning_ratio <= policy.throttle_ratio <= 1.0
+    advances_to: throttle
+  - id: fallback
+    default: true
+    advances_to: fallback
+`,
+			contains: "overlapping ranges",
 		},
 		{
 			name: "unsupported selector root",

--- a/internal/runtime/contracts/workflow_contract_yaml_test.go
+++ b/internal/runtime/contracts/workflow_contract_yaml_test.go
@@ -792,6 +792,36 @@ rules:
 	}
 }
 
+func TestSystemNodeEventHandlerDecode_PreservesPolicyRowWordsAsRuleIDsInKeyedMap(t *testing.T) {
+	var handler SystemNodeEventHandler
+	if err := yaml.Unmarshal([]byte(`
+rules:
+  case:
+    condition: payload.mode == "case"
+    emit: scan.case_requested
+  default:
+    condition: else
+    emit: scan.default_requested
+`), &handler); err != nil {
+		t.Fatalf("yaml.Unmarshal: %v", err)
+	}
+	if got, want := len(handler.Rules), 2; got != want {
+		t.Fatalf("rules len = %d, want %d", got, want)
+	}
+	if got := handler.Rules[0].ID; got != "case" {
+		t.Fatalf("rules[0].ID = %q, want case", got)
+	}
+	if got := handler.Rules[0].PolicyRow.Kind; got != "" {
+		t.Fatalf("rules[0].PolicyRow.Kind = %q, want empty", got)
+	}
+	if got := handler.Rules[1].ID; got != "default" {
+		t.Fatalf("rules[1].ID = %q, want default", got)
+	}
+	if got := handler.Rules[1].Condition; got != "else" {
+		t.Fatalf("rules[1].Condition = %q, want else", got)
+	}
+}
+
 func TestSystemNodeEventHandlerDecode_RejectsInvalidPolicySheetRows(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -910,6 +940,21 @@ rules:
     advances_to: fallback
 `,
 			contains: "unsupported root",
+		},
+		{
+			name: "selector operator injection",
+			body: `
+rules:
+  - id: injected
+    case:
+      selector: 'payload.mode=="admin"||payload.mode'
+      equals: deep
+    advances_to: injected
+  - id: fallback
+    default: true
+    advances_to: fallback
+`,
+			contains: "simple dotted path",
 		},
 		{
 			name: "policy field dual owner",

--- a/internal/runtime/contracts/workflow_contract_yaml_test.go
+++ b/internal/runtime/contracts/workflow_contract_yaml_test.go
@@ -728,6 +728,230 @@ branch:
 	}
 }
 
+func TestSystemNodeEventHandlerDecode_LowersPolicySheetSelectionRows(t *testing.T) {
+	var handler SystemNodeEventHandler
+	if err := yaml.Unmarshal([]byte(`
+rules:
+  - id: cto_revision_gate
+    when: "payload.spec_revision > entity.last_cto_reviewed_revision && entity.revision_count >= policy.inner_revision_max"
+    advances_to: cto_review
+  - id: deep_scan
+    case:
+      selector: payload.mode
+      equals: deep
+    emit: scan.deep_requested
+  - id: repository_quick_scan
+    case:
+      selectors: [payload.mode, payload.target]
+      equals: [quick, repository]
+    emit: scan.quick_repo_requested
+  - id: treasury_warning
+    range:
+      value: entity.spend_ratio
+      gte: policy.warning_pct / 100
+      lt: policy.throttle_pct / 100
+      monotonicity:
+        - policy.warning_pct / 100 <= policy.throttle_pct / 100 <= 1.0
+    emit: treasury.warning_recorded
+  - id: default_route
+    default: true
+    emit: scan.default_requested
+`), &handler); err != nil {
+		t.Fatalf("yaml.Unmarshal: %v", err)
+	}
+	if got, want := len(handler.Rules), 5; got != want {
+		t.Fatalf("rules len = %d, want %d", got, want)
+	}
+	wantConditions := []string{
+		"payload.spec_revision > entity.last_cto_reviewed_revision && entity.revision_count >= policy.inner_revision_max",
+		`payload.mode == "deep"`,
+		`payload.mode == "quick" && payload.target == "repository"`,
+		`entity.spend_ratio >= policy.warning_pct / 100 && entity.spend_ratio < policy.throttle_pct / 100`,
+		"else",
+	}
+	wantKinds := []PolicySheetRowKind{
+		PolicySheetRowKindWhen,
+		PolicySheetRowKindCase,
+		PolicySheetRowKindCase,
+		PolicySheetRowKindRange,
+		PolicySheetRowKindDefault,
+	}
+	for idx := range handler.Rules {
+		if got := handler.Rules[idx].Condition; got != wantConditions[idx] {
+			t.Fatalf("rules[%d].Condition = %q, want %q", idx, got, wantConditions[idx])
+		}
+		if got := handler.Rules[idx].PolicyRow.Kind; got != wantKinds[idx] {
+			t.Fatalf("rules[%d].PolicyRow.Kind = %q, want %q", idx, got, wantKinds[idx])
+		}
+	}
+	if got := handler.Rules[2].PolicyRow.Selectors; !reflect.DeepEqual(got, []string{"payload.mode", "payload.target"}) {
+		t.Fatalf("tuple selectors = %#v", got)
+	}
+	if got := handler.Rules[3].PolicyRow.RangeLower.Value; got != "policy.warning_pct / 100" {
+		t.Fatalf("range lower = %q", got)
+	}
+}
+
+func TestSystemNodeEventHandlerDecode_RejectsInvalidPolicySheetRows(t *testing.T) {
+	tests := []struct {
+		name     string
+		body     string
+		contains string
+	}{
+		{
+			name: "missing default",
+			body: `
+rules:
+  - id: deep_scan
+    case:
+      selector: payload.mode
+      equals: deep
+    emit: scan.deep_requested
+`,
+			contains: "require an else/default row",
+		},
+		{
+			name: "duplicate row ids",
+			body: `
+rules:
+  - id: duplicate
+    when: "payload.ok"
+    advances_to: ok
+  - id: duplicate
+    default: true
+    advances_to: fallback
+`,
+			contains: "duplicate stable row id",
+		},
+		{
+			name: "duplicate case key",
+			body: `
+rules:
+  - id: deep_a
+    case:
+      selector: payload.mode
+      equals: deep
+    emit: scan.deep_a
+  - id: deep_b
+    case:
+      selector: payload.mode
+      equals: deep
+    emit: scan.deep_b
+  - id: fallback
+    default: true
+    emit: scan.default
+`,
+			contains: "duplicate case key",
+		},
+		{
+			name: "overlapping literal ranges",
+			body: `
+rules:
+  - id: low
+    range:
+      value: payload.score
+      gte: 0
+      lt: 10
+    advances_to: low
+  - id: overlap
+    range:
+      value: payload.score
+      gte: 5
+      lt: 15
+    advances_to: overlap
+  - id: fallback
+    default: true
+    advances_to: fallback
+`,
+			contains: "overlapping literal ranges",
+		},
+		{
+			name: "dynamic bound",
+			body: `
+rules:
+  - id: dynamic_bound
+    range:
+      value: entity.spend_ratio
+      gte: payload.warning_ratio
+    advances_to: warning
+  - id: fallback
+    default: true
+    advances_to: fallback
+`,
+			contains: "dynamic bound",
+		},
+		{
+			name: "policy bound missing monotonicity",
+			body: `
+rules:
+  - id: warning
+    range:
+      value: entity.spend_ratio
+      gte: policy.warning_ratio
+      lt: policy.throttle_ratio
+    advances_to: warning
+  - id: fallback
+    default: true
+    advances_to: fallback
+`,
+			contains: "requires monotonicity",
+		},
+		{
+			name: "unsupported selector root",
+			body: `
+rules:
+  - id: fanout_selector
+    case:
+      selector: fan_out.count
+      equals: 3
+    advances_to: fanout
+  - id: fallback
+    default: true
+    advances_to: fallback
+`,
+			contains: "unsupported root",
+		},
+		{
+			name: "policy field dual owner",
+			body: `
+rules:
+  - id: bad_policy
+    policy:
+      row: true
+    advances_to: bad
+`,
+			contains: "second policy-sheet authoring owner",
+		},
+		{
+			name: "typed row outside rules",
+			body: `
+on_complete:
+  - id: done
+    when: "payload.ok"
+    advances_to: done
+`,
+			contains: "only supported under handler.rules",
+		},
+		{
+			name: "standalone handler switch",
+			body: `
+switch:
+  selector: payload.mode
+`,
+			contains: `handler field "switch"`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var handler SystemNodeEventHandler
+			err := yaml.Unmarshal([]byte(tt.body), &handler)
+			if err == nil || !strings.Contains(err.Error(), tt.contains) {
+				t.Fatalf("yaml.Unmarshal error = %v, want %q", err, tt.contains)
+			}
+		})
+	}
+}
+
 func TestSystemNodeEventHandlerDecode_RejectsRetiredClearTarget(t *testing.T) {
 	var handler SystemNodeEventHandler
 	err := yaml.Unmarshal([]byte(`

--- a/internal/runtime/engine/executor_test.go
+++ b/internal/runtime/engine/executor_test.go
@@ -18,6 +18,7 @@ import (
 	runtimeregistry "github.com/division-sh/swarm/internal/runtime/core/registry"
 	"github.com/division-sh/swarm/internal/runtime/flowmodel"
 	"github.com/division-sh/swarm/internal/runtime/semanticview"
+	"gopkg.in/yaml.v3"
 )
 
 func stubSource() semanticview.Source {
@@ -2086,6 +2087,53 @@ func TestExecutor_RulesUseFirstMatchAndSkipLaterEntries(t *testing.T) {
 	}
 	if result.NextState != "approved" {
 		t.Fatalf("NextState = %q", result.NextState)
+	}
+}
+
+func TestExecutor_PolicySheetRowsExecuteThroughRules(t *testing.T) {
+	var handler runtimecontracts.SystemNodeEventHandler
+	if err := yaml.Unmarshal([]byte(`
+rules:
+  - id: deep_scan
+    case:
+      selector: payload.mode
+      equals: deep
+    advances_to: deep_scan
+  - id: fallback
+    default: true
+    advances_to: fallback
+`), &handler); err != nil {
+		t.Fatalf("yaml.Unmarshal: %v", err)
+	}
+	exec, err := NewExecutor(RuntimeDependencies{
+		Source:     stubSource(),
+		StateRepo:  stubStateRepo{},
+		TxRunner:   stubRunner{},
+		Locker:     stubLocker{},
+		Outbox:     stubOutbox{},
+		Dispatcher: stubDispatcher{},
+	}, stubEvaluator{bools: map[string]bool{
+		`payload.mode == "deep"`: true,
+	}})
+	if err != nil {
+		t.Fatalf("NewExecutor error: %v", err)
+	}
+	result, err := exec.Execute(context.Background(), ExecutionRequest{
+		EntityID: "entity-1",
+		NodeID:   "node-1",
+		FlowID:   "flow-1",
+		Event:    eventtest.RootIngress("evt-1", "scan.requested", "", "", json.RawMessage(`{"mode":"deep"}`), 0, "", "", events.EventEnvelope{}, time.Time{}),
+		Handler:  handler,
+		State:    testStateSnapshot("pending", map[string]any{}, nil, map[string]map[string]any{}),
+	})
+	if err != nil {
+		t.Fatalf("Execute error: %v", err)
+	}
+	if got := result.RuleID; got != "deep_scan" {
+		t.Fatalf("RuleID = %q, want deep_scan", got)
+	}
+	if got := result.NextState; got != "deep_scan" {
+		t.Fatalf("NextState = %q, want deep_scan", got)
 	}
 }
 

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -1389,8 +1389,8 @@ handler_specification:
   on_complete_vs_rules:
     description: Mutually exclusive. A handler uses on_complete OR rules, never both.
     on_complete: Ordered list of {condition, advances_to, emit} — first match wins. Used after accumulation/computation.
-    rules: Map of {condition, emit/advances_to/data_accumulation} — condition-based routing over the rule
-      condition context. `rules` is the canonical handler-phase branch-selection owner. Retired `handler.branch`
+    rules: Current concrete spelling of the ordered policy-sheet authoring construct for handler-phase selection. Existing
+      condition rules and typed selection rows lower to the canonical selected-branch owner. Retired `handler.branch`
       syntax is unsupported and must fail closed instead of being interpreted, lowered, or preserved as compatibility syntax.
   short_circuits:
     guard_fail: If guard fails, handler stops. on_fail action executes (reject/kill/discard/escalate). No further steps.
@@ -1850,19 +1850,53 @@ handler_specification:
           event rolls back both emitted events and all same-handler state changes.
     rules:
       field: rules
-      type: map of rule_name → rule
-      purpose: Type-based routing. Match rule conditions over the rule-condition handler context; common dispatch
-        reads payload fields, but rule conditions are not payload-only.
+      type: ordered list of rules, or a keyed map that is decoded into ordered rules. `rules` is the current policy-sheet
+        spelling; it is enhanced in place rather than adding a co-authorable `policy` field. Every typed policy-sheet
+        selection row must have a stable `id` that acts as trace-addressable contract identity.
+      purpose: Type-based routing and policy-sheet selection. Match rule conditions or typed selection rows over the
+        rule-condition handler context; common dispatch reads payload fields, but selection is not payload-only.
       rule_fields:
         condition: string — CEL expression evaluated against the rule-condition handler context. Allowed roots
           are payload.*, entity.*, policy.*, event.*, and query_entities(...). accumulated.*, fan_out.*, and
           item.* are unavailable in rules.condition. entity.* reads use the pre-rule entity state and the same
           declared-field validation as other rule-phase handler conditions.
+        when: >-
+          string — first-class policy-sheet selection row for compound relational conditions. Lowers to condition
+          and otherwise uses the ordinary selected-branch rule fields. Must not be combined with condition, case, range,
+          else, or default.
+        case: >-
+          object — first-class policy-sheet selection row for scalar or tuple dispatch. Shape is
+          `{selector: <path>, equals: <scalar>}` or `{selectors: [<path>, ...], equals: [<scalar>, ...]}`. Selectors
+          must be simple dotted paths rooted in payload, entity, policy, or event. The row lowers to equality conditions
+          joined by AND. Duplicate selector/value keys fail closed.
+        range: >-
+          object — first-class policy-sheet selection row for numeric threshold/range dispatch. Shape includes
+          `value` and one or more of `gt`, `gte`, `lt`, `lte`; bounds may be numeric literals or policy-constant
+          expressions. Entity/payload/event dynamic bounds are forbidden and fail closed; normalize those values through
+          compute/value rows first. Policy-constant bounds require `monotonicity` declarations using `<=` so verify can
+          prove structural ordering and non-overlap. Literal ranges are checked for absolute overlap.
+        else: boolean true — explicit default row. Lowers to the ordinary else selected branch.
+        default: boolean true — alias for else, used when the authoring intent is an explicit policy-sheet default row.
         emit: string or object — rule-local event to emit, or an eventless object with fields only when participating in
           rules emit template specialization.
         advances_to: string — optional state change
         data_accumulation: object — optional data write (same format as handler-level)
         description: string — human-readable note
+      policy_sheet_selection_rows:
+        scope: Selection-only rows in this slice are `when`, `case`, `range`, and explicit else/default rows. Value
+          derivation rows lower to compute in a separate child; schema validation and temporal/join/loop/collection/schedule
+          rows are separate future gates.
+        stable_identity: Typed policy-sheet rows require stable IDs. The selected row ID is trace-addressable contract
+          identity and must survive authoring edits.
+        lowering: Accepted selection rows lower before runtime execution into ordinary selected `HandlerRuleEntry` branches.
+          Runtime must not contain a second switch/table/range interpreter.
+        default_requirement: A rules block containing typed policy-sheet rows must include an else/default selected branch
+          unless a later spec-promoted row type supplies a stronger exhaustiveness proof.
+        forbidden_authoring_surfaces:
+          - "`handler.branch` — retired; fail closed"
+          - "`handler.switch`, `handler.lookup`, `handler.threshold` — not standalone handler fields"
+          - "`policy` as a co-authorable handler field while `rules` remains authorable"
+          - runtime-only table, switch, lookup, threshold, or range interpreters
       emit_template_specialization:
         syntax: A rules handler may declare handler-level emit as the template, with `emit.event` and optional shared
           `emit.from` / `emit.fields`. Each rule then declares `emit.fields` and may declare the same `emit.from` without


### PR DESCRIPTION
## Summary

Closes #1713
Part of #1668
Part of #1663

Promotes the first policy-sheet selection rows on the current `rules:` surface: `when`, `case`, `range`, and explicit `else`/`default`. The rows lower during contract decode into existing `HandlerRuleEntry` selected branches, so runtime still executes through the canonical rules path rather than a second switch/table/range interpreter.

This also updates `platform-spec.yaml` and the deterministic-work-ladder design record to reflect the lead-approved framing: the policy sheet is one ordered authoring construct, `rules` is its current concrete spelling, and selection rows lower to rules while value rows stay for compute.

## Governing Refs

- `platform-spec.yaml#handler_specification.on_complete_vs_rules`
- `platform-spec.yaml#handler_specification.handler_fields.rules`
- Adjacent contract sections used for boundaries: `handler_specification.expression_context`, `handler_specification.dependency_graph`, `handler_specification.dependency_rules`, `contract_formats.produces_derivation`, `node_specification.effective_semantics`
- #1713 rewritten `Pre-Implementation Coverage Audit`
- #1713 Gate C approval: `approved as first slice`
- Deterministic work ladder design record and Stage 0 evidence context from #1668/#1663

## Semantic Migration

- New canonical owner: the current `rules:` policy-sheet authoring construct for ordered selection rows, lowered into `HandlerRuleEntry` and the existing selected-branch runtime owner.
- Old producer / reader / writer paths now invalid: retired `handler.branch`; standalone `handler.switch`, `handler.lookup`, and `handler.threshold`; co-authorable `handler.policy`; runtime-only table/switch/range interpreters.
- Production paths checked for surviving old behavior: contract YAML decode, handler rule field validation, selected-branch runtime execution, design-record conformance, and authoritative platform spec rows.
- Migration completeness: complete for #1713 selection rows. Value lookup rows remain split to #1715, validation rows to #1714, and temporal/join/loop/collection/schedule rows remain future gated work.

## Validation

- `SWARM_TEST_POSTGRES_DSN='host=127.0.0.1 port=5432 user=youmew dbname=postgres sslmode=disable' PGPASSWORD=postgres go test ./...`
- `git diff --check`
