### PR TITLE
[agent-f][issue #1704] Provider trigger manifests

### DIFF
--- a/internal/providertriggers/manifests/github.yaml
+++ b/internal/providertriggers/manifests/github.yaml
@@ -1,0 +1,27 @@
+provider: github
+payload_object_required: false
+secret:
+  required: true
+signature:
+  type: hmac_sha256
+  header: X-Hub-Signature-256
+  prefix: sha256=
+  signed_payload: raw_body
+  missing_error: invalid github signature
+  invalid_error: invalid github signature
+delivery_id:
+  header: X-GitHub-Delivery
+  required: true
+  missing_error: github delivery id is required
+event_type:
+  header: X-GitHub-Event
+  required: true
+  missing_error: github event type is required
+event_name:
+  template: inbound.github.{event_type}
+ack:
+  mode: after_publish
+metadata:
+  user_agent: user_agent
+  github_delivery: delivery_id
+  github_event: event_type

--- a/internal/providertriggers/manifests/slack.yaml
+++ b/internal/providertriggers/manifests/slack.yaml
@@ -1,0 +1,52 @@
+provider: slack
+payload_object_required: true
+payload_object_error: slack payload object is required
+secret:
+  required: true
+signature:
+  type: hmac_sha256
+  header: X-Slack-Signature
+  prefix: v0=
+  signed_payload: slack_v0
+  missing_error: slack signature is required
+  invalid_error: invalid slack signature
+  timestamp:
+    header: X-Slack-Request-Timestamp
+    tolerance: 5m
+    missing_error: slack request timestamp is required
+    invalid_error: invalid slack request timestamp
+    stale_error: stale slack request timestamp
+challenge:
+  when:
+    json_path: $.type
+    equals: url_verification
+    normalize: true
+  response:
+    json_path: $.challenge
+    missing_error: slack challenge is required
+    content_type: text/plain; charset=utf-8
+    status: 200
+delivery_condition:
+  json_path: $.type
+  equals: event_callback
+  normalize: true
+  missing_error: slack payload type is required
+  mismatch_error: unsupported slack payload type
+delivery_id:
+  json_path: $.event_id
+  required: true
+  missing_error: slack event_id is required
+event_type:
+  json_path: $.event.type
+  required: true
+  missing_error: slack inner event type is required
+event_name:
+  template: inbound.slack.{event_type}
+ack:
+  mode: durable_before_dispatch
+redact_keys:
+  - token
+metadata:
+  user_agent: user_agent
+  slack_event_id: delivery_id
+  slack_event_type: event_type

--- a/internal/providertriggers/manifests/stripe.yaml
+++ b/internal/providertriggers/manifests/stripe.yaml
@@ -1,0 +1,34 @@
+provider: stripe
+payload_object_required: true
+payload_object_error: stripe payload object is required
+secret:
+  required: true
+signature:
+  type: hmac_sha256
+  header: Stripe-Signature
+  signed_payload: timestamp_dot_raw_body
+  signature_param: v1
+  missing_error: stripe signature is required
+  invalid_error: invalid stripe signature
+  timestamp:
+    param: t
+    tolerance: 5m
+    missing_error: stripe signature timestamp is required
+    invalid_error: invalid stripe signature timestamp
+    stale_error: stale stripe signature timestamp
+delivery_id:
+  json_path: $.id
+  required: true
+  missing_error: stripe event id is required
+event_type:
+  json_path: $.type
+  required: true
+  missing_error: stripe event type is required
+event_name:
+  literal: inbound.stripe
+ack:
+  mode: durable_before_dispatch
+metadata:
+  user_agent: user_agent
+  stripe_event_id: delivery_id
+  stripe_event_type: event_type

--- a/internal/providertriggers/providertriggers.go
+++ b/internal/providertriggers/providertriggers.go
@@ -246,16 +246,53 @@ func (m Manifest) Validate() error {
 	if m.DeliveryID.Required && m.DeliveryID.Header == "" && m.DeliveryID.JSONPath == "" {
 		return fmt.Errorf("%s manifest delivery_id source is required", provider)
 	}
+	if err := validateJSONPath(provider, "delivery_id.json_path", m.DeliveryID.JSONPath); err != nil {
+		return err
+	}
 	if m.EventType.Required && m.EventType.Header == "" && m.EventType.JSONPath == "" {
 		return fmt.Errorf("%s manifest event_type source is required", provider)
 	}
-	if strings.TrimSpace(m.EventName.Literal) == "" && strings.TrimSpace(m.EventName.Template) == "" {
+	if err := validateJSONPath(provider, "event_type.json_path", m.EventType.JSONPath); err != nil {
+		return err
+	}
+	if m.Challenge != nil {
+		if err := validateJSONPath(provider, "challenge.when.json_path", m.Challenge.When.JSONPath); err != nil {
+			return err
+		}
+		if err := validateJSONPath(provider, "challenge.response.json_path", m.Challenge.Response.JSONPath); err != nil {
+			return err
+		}
+	}
+	if m.DeliveryCondition != nil {
+		if err := validateJSONPath(provider, "delivery_condition.json_path", m.DeliveryCondition.JSONPath); err != nil {
+			return err
+		}
+	}
+	eventNameLiteral := strings.TrimSpace(m.EventName.Literal)
+	eventNameTemplate := strings.TrimSpace(m.EventName.Template)
+	if eventNameLiteral == "" && eventNameTemplate == "" {
 		return fmt.Errorf("%s manifest event_name is required", provider)
+	}
+	if eventNameLiteral != "" && eventNameTemplate != "" {
+		return fmt.Errorf("%s manifest event_name must use literal or template, not both", provider)
+	}
+	if eventNameTemplate != "" && provider != "github" && provider != "slack" {
+		return fmt.Errorf("%s manifest event_name template is reserved for grandfathered GitHub/Slack compatibility", provider)
 	}
 	switch strings.TrimSpace(m.Ack.Mode) {
 	case "", "after_publish", "durable_before_dispatch":
 	default:
 		return fmt.Errorf("%s manifest has unsupported ack mode %q", provider, m.Ack.Mode)
+	}
+	for key, source := range m.Metadata {
+		if strings.TrimSpace(key) == "" {
+			return fmt.Errorf("%s manifest metadata key is required", provider)
+		}
+		switch strings.TrimSpace(source) {
+		case "user_agent", "delivery_id", "event_type":
+		default:
+			return fmt.Errorf("%s manifest metadata %q has unsupported source %q", provider, key, source)
+		}
 	}
 	return nil
 }
@@ -307,11 +344,11 @@ func (m Manifest) Accept(req Request) (Delivery, error) {
 	if !ok || strings.TrimSpace(deliveryID) == "" {
 		return Delivery{}, badRequest(firstNonEmpty(m.DeliveryID.MissingError, provider+" delivery id is required"))
 	}
-	eventType, ok := m.EventType.Resolve(req)
-	eventType = NormalizeEventToken(eventType)
-	if !ok || eventType == "event" {
+	rawEventType, ok := m.EventType.Resolve(req)
+	if !ok || strings.TrimSpace(rawEventType) == "" {
 		return Delivery{}, badRequest(firstNonEmpty(m.EventType.MissingError, provider+" event type is required"))
 	}
+	eventType := NormalizeEventToken(rawEventType)
 	entityID := req.Target.EffectiveEntityID()
 	payload := m.buildPublishPayload(provider, entityID, deliveryID, eventType, req)
 	return Delivery{
@@ -338,6 +375,9 @@ func (m Manifest) verifySignature(secret string, req Request) error {
 			return unauthorized(firstNonEmpty(m.Signature.InvalidError, "invalid signature"))
 		}
 		timestampValues := params.Values(firstNonEmpty(m.Signature.TimestampParam(), "t"))
+		if len(timestampValues) > 1 {
+			return unauthorized(firstNonEmpty(m.Signature.InvalidError, "invalid signature"))
+		}
 		if len(timestampValues) > 0 {
 			timestamp = timestampValues[0]
 		}
@@ -616,6 +656,42 @@ func valueFromJSONPath(payload any, path string) (any, bool) {
 		}
 	}
 	return current, true
+}
+
+func validateJSONPath(provider, field, path string) error {
+	path = strings.TrimSpace(path)
+	if path == "" || path == "$" {
+		return nil
+	}
+	if !strings.HasPrefix(path, "$.") {
+		return fmt.Errorf("%s manifest %s has unsupported json_path %q", provider, field, path)
+	}
+	parts := strings.Split(strings.TrimPrefix(path, "$."), ".")
+	for _, part := range parts {
+		if strings.TrimSpace(part) == "" || !validJSONPathSegment(part) {
+			return fmt.Errorf("%s manifest %s has unsupported json_path %q", provider, field, path)
+		}
+	}
+	return nil
+}
+
+func validJSONPathSegment(part string) bool {
+	for _, r := range part {
+		if r >= 'a' && r <= 'z' {
+			continue
+		}
+		if r >= 'A' && r <= 'Z' {
+			continue
+		}
+		if r >= '0' && r <= '9' {
+			continue
+		}
+		if r == '_' || r == '-' {
+			continue
+		}
+		return false
+	}
+	return true
 }
 
 func redactPayload(payload any, keys []string) any {

--- a/internal/providertriggers/providertriggers.go
+++ b/internal/providertriggers/providertriggers.go
@@ -1,0 +1,718 @@
+package providertriggers
+
+import (
+	"crypto/hmac"
+	"crypto/sha1"
+	"crypto/sha256"
+	"embed"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/division-sh/swarm/internal/events"
+	"gopkg.in/yaml.v3"
+)
+
+//go:embed manifests/*.yaml
+var builtinManifestFS embed.FS
+
+type Target struct {
+	EntityID      string
+	EntitySlug    string
+	WebhookSecret string
+}
+
+func (t Target) EffectiveEntityID() string {
+	return firstNonEmpty(t.EntityID, t.EntitySlug)
+}
+
+type Request struct {
+	Provider  string
+	Target    Target
+	Body      []byte
+	Headers   http.Header
+	Payload   any
+	Received  time.Time
+	UserAgent string
+}
+
+type Delivery struct {
+	ProviderEventID           string
+	ProviderEventType         string
+	EventName                 events.EventType
+	Payload                   map[string]any
+	Response                  *Response
+	AcknowledgeBeforeDispatch bool
+}
+
+type Response struct {
+	Status      int
+	ContentType string
+	Body        []byte
+}
+
+type Error struct {
+	Status  int
+	Message string
+}
+
+func (e Error) Error() string {
+	return e.Message
+}
+
+type Registry struct {
+	manifests map[string]Manifest
+}
+
+func DefaultRegistry() *Registry {
+	return defaultRegistry
+}
+
+var defaultRegistry = mustDefaultRegistry()
+
+func mustDefaultRegistry() *Registry {
+	entries, err := builtinManifestFS.ReadDir("manifests")
+	if err != nil {
+		panic(err)
+	}
+	manifests := make([]Manifest, 0, len(entries))
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".yaml") {
+			continue
+		}
+		body, err := builtinManifestFS.ReadFile("manifests/" + entry.Name())
+		if err != nil {
+			panic(err)
+		}
+		manifest, err := ParseManifest(body)
+		if err != nil {
+			panic(fmt.Sprintf("%s: %v", entry.Name(), err))
+		}
+		manifests = append(manifests, manifest)
+	}
+	registry, err := NewRegistry(manifests...)
+	if err != nil {
+		panic(err)
+	}
+	return registry
+}
+
+func NewRegistry(manifests ...Manifest) (*Registry, error) {
+	r := &Registry{manifests: make(map[string]Manifest, len(manifests))}
+	for _, manifest := range manifests {
+		if err := manifest.Validate(); err != nil {
+			return nil, err
+		}
+		provider := NormalizeProviderName(manifest.Provider)
+		if _, exists := r.manifests[provider]; exists {
+			return nil, fmt.Errorf("duplicate provider trigger manifest for %q", provider)
+		}
+		manifest.Provider = provider
+		r.manifests[provider] = manifest
+	}
+	return r, nil
+}
+
+func (r *Registry) Accept(req Request) (Delivery, error) {
+	provider := NormalizeProviderName(req.Provider)
+	if provider == "" {
+		return Delivery{}, badRequest("provider is required")
+	}
+	if r != nil {
+		if manifest, ok := r.manifests[provider]; ok {
+			return manifest.Accept(req.withProvider(provider))
+		}
+	}
+	return acceptRaw(req.withProvider(provider))
+}
+
+func (req Request) withProvider(provider string) Request {
+	req.Provider = provider
+	return req
+}
+
+type Manifest struct {
+	Provider              string             `yaml:"provider"`
+	PayloadObjectRequired bool               `yaml:"payload_object_required"`
+	PayloadObjectError    string             `yaml:"payload_object_error"`
+	Secret                SecretManifest     `yaml:"secret"`
+	Signature             SignatureManifest  `yaml:"signature"`
+	Challenge             *ChallengeManifest `yaml:"challenge"`
+	DeliveryCondition     *ConditionManifest `yaml:"delivery_condition"`
+	DeliveryID            ValueSource        `yaml:"delivery_id"`
+	EventType             ValueSource        `yaml:"event_type"`
+	EventName             EventNameManifest  `yaml:"event_name"`
+	Ack                   AckManifest        `yaml:"ack"`
+	RedactKeys            []string           `yaml:"redact_keys"`
+	Metadata              map[string]string  `yaml:"metadata"`
+}
+
+type SecretManifest struct {
+	Required bool `yaml:"required"`
+}
+
+type SignatureManifest struct {
+	Type           string             `yaml:"type"`
+	Header         string             `yaml:"header"`
+	Prefix         string             `yaml:"prefix"`
+	SignedPayload  string             `yaml:"signed_payload"`
+	SignatureParam string             `yaml:"signature_param"`
+	MissingError   string             `yaml:"missing_error"`
+	InvalidError   string             `yaml:"invalid_error"`
+	Timestamp      *TimestampManifest `yaml:"timestamp"`
+}
+
+type TimestampManifest struct {
+	Header       string `yaml:"header"`
+	Param        string `yaml:"param"`
+	Tolerance    string `yaml:"tolerance"`
+	MissingError string `yaml:"missing_error"`
+	InvalidError string `yaml:"invalid_error"`
+	StaleError   string `yaml:"stale_error"`
+}
+
+type ChallengeManifest struct {
+	When     ConditionManifest `yaml:"when"`
+	Response ResponseManifest  `yaml:"response"`
+}
+
+type ResponseManifest struct {
+	JSONPath    string `yaml:"json_path"`
+	MissingErr  string `yaml:"missing_error"`
+	ContentType string `yaml:"content_type"`
+	Status      int    `yaml:"status"`
+}
+
+type ConditionManifest struct {
+	JSONPath     string `yaml:"json_path"`
+	Equals       string `yaml:"equals"`
+	Normalize    bool   `yaml:"normalize"`
+	MissingError string `yaml:"missing_error"`
+	MismatchErr  string `yaml:"mismatch_error"`
+}
+
+type ValueSource struct {
+	Header       string `yaml:"header"`
+	JSONPath     string `yaml:"json_path"`
+	Required     bool   `yaml:"required"`
+	MissingError string `yaml:"missing_error"`
+}
+
+type EventNameManifest struct {
+	Literal  string `yaml:"literal"`
+	Template string `yaml:"template"`
+}
+
+type AckManifest struct {
+	Mode string `yaml:"mode"`
+}
+
+func ParseManifest(body []byte) (Manifest, error) {
+	var manifest Manifest
+	if err := yaml.Unmarshal(body, &manifest); err != nil {
+		return Manifest{}, err
+	}
+	return manifest, nil
+}
+
+func (m Manifest) Validate() error {
+	provider := NormalizeProviderName(m.Provider)
+	if provider == "" {
+		return fmt.Errorf("provider is required")
+	}
+	if m.Secret.Required && m.Signature.Type == "" {
+		return fmt.Errorf("%s manifest requires signature when secret is required", provider)
+	}
+	if m.Signature.Type != "" && strings.TrimSpace(m.Signature.Type) != "hmac_sha256" {
+		return fmt.Errorf("%s manifest has unsupported signature type %q", provider, m.Signature.Type)
+	}
+	if m.Signature.Type != "" {
+		if strings.TrimSpace(m.Signature.Header) == "" {
+			return fmt.Errorf("%s manifest signature header is required", provider)
+		}
+		switch strings.TrimSpace(m.Signature.SignedPayload) {
+		case "raw_body", "slack_v0", "timestamp_dot_raw_body":
+		default:
+			return fmt.Errorf("%s manifest has unsupported signed_payload %q", provider, m.Signature.SignedPayload)
+		}
+		if m.Signature.SignedPayload != "raw_body" && m.Signature.Timestamp == nil {
+			return fmt.Errorf("%s manifest timestamp is required for %s", provider, m.Signature.SignedPayload)
+		}
+	}
+	if m.DeliveryID.Required && m.DeliveryID.Header == "" && m.DeliveryID.JSONPath == "" {
+		return fmt.Errorf("%s manifest delivery_id source is required", provider)
+	}
+	if m.EventType.Required && m.EventType.Header == "" && m.EventType.JSONPath == "" {
+		return fmt.Errorf("%s manifest event_type source is required", provider)
+	}
+	if strings.TrimSpace(m.EventName.Literal) == "" && strings.TrimSpace(m.EventName.Template) == "" {
+		return fmt.Errorf("%s manifest event_name is required", provider)
+	}
+	switch strings.TrimSpace(m.Ack.Mode) {
+	case "", "after_publish", "durable_before_dispatch":
+	default:
+		return fmt.Errorf("%s manifest has unsupported ack mode %q", provider, m.Ack.Mode)
+	}
+	return nil
+}
+
+func (m Manifest) Accept(req Request) (Delivery, error) {
+	provider := NormalizeProviderName(m.Provider)
+	secret := strings.TrimSpace(req.Target.WebhookSecret)
+	if m.Secret.Required && secret == "" {
+		return Delivery{}, unauthorized(provider + " webhook signing secret is required")
+	}
+	if m.Signature.Type != "" {
+		if err := m.verifySignature(secret, req); err != nil {
+			return Delivery{}, err
+		}
+	}
+	if m.PayloadObjectRequired {
+		if _, ok := req.Payload.(map[string]any); !ok {
+			return Delivery{}, badRequest(firstNonEmpty(m.PayloadObjectError, provider+" payload object is required"))
+		}
+	}
+	if m.Challenge != nil {
+		matched, err := m.Challenge.When.Evaluate(req.Payload)
+		if err != nil {
+			return Delivery{}, err
+		}
+		if matched {
+			value, ok := stringFromJSONPath(req.Payload, m.Challenge.Response.JSONPath)
+			if !ok || strings.TrimSpace(value) == "" {
+				return Delivery{}, badRequest(firstNonEmpty(m.Challenge.Response.MissingErr, provider+" challenge is required"))
+			}
+			status := m.Challenge.Response.Status
+			if status == 0 {
+				status = http.StatusOK
+			}
+			contentType := firstNonEmpty(m.Challenge.Response.ContentType, "text/plain; charset=utf-8")
+			return Delivery{Response: &Response{Status: status, ContentType: contentType, Body: []byte(value)}}, nil
+		}
+	}
+	if m.DeliveryCondition != nil {
+		matched, err := m.DeliveryCondition.Evaluate(req.Payload)
+		if err != nil {
+			return Delivery{}, err
+		}
+		if !matched {
+			return Delivery{}, badRequest(firstNonEmpty(m.DeliveryCondition.MismatchErr, "unsupported "+provider+" payload type"))
+		}
+	}
+	deliveryID, ok := m.DeliveryID.Resolve(req)
+	if !ok || strings.TrimSpace(deliveryID) == "" {
+		return Delivery{}, badRequest(firstNonEmpty(m.DeliveryID.MissingError, provider+" delivery id is required"))
+	}
+	eventType, ok := m.EventType.Resolve(req)
+	eventType = NormalizeEventToken(eventType)
+	if !ok || eventType == "event" {
+		return Delivery{}, badRequest(firstNonEmpty(m.EventType.MissingError, provider+" event type is required"))
+	}
+	entityID := req.Target.EffectiveEntityID()
+	payload := m.buildPublishPayload(provider, entityID, deliveryID, eventType, req)
+	return Delivery{
+		ProviderEventID:           deliveryID,
+		ProviderEventType:         eventType,
+		EventName:                 events.EventType(m.resolveEventName(eventType)),
+		Payload:                   payload,
+		AcknowledgeBeforeDispatch: strings.TrimSpace(m.Ack.Mode) == "durable_before_dispatch",
+	}, nil
+}
+
+func (m Manifest) verifySignature(secret string, req Request) error {
+	sigHeader := strings.TrimSpace(req.Headers.Get(m.Signature.Header))
+	if sigHeader == "" {
+		return unauthorized(firstNonEmpty(m.Signature.MissingError, "signature is required"))
+	}
+	var (
+		timestamp  string
+		candidates []string
+	)
+	if strings.TrimSpace(m.Signature.SignatureParam) != "" {
+		params := parseHeaderParams(sigHeader)
+		timestampValues := params.Values(firstNonEmpty(m.Signature.TimestampParam(), "t"))
+		if len(timestampValues) > 0 {
+			timestamp = timestampValues[0]
+		}
+		candidates = params.Values(strings.TrimSpace(m.Signature.SignatureParam))
+	} else {
+		if m.Signature.Prefix != "" {
+			lower := strings.ToLower(sigHeader)
+			prefix := strings.ToLower(m.Signature.Prefix)
+			if !strings.HasPrefix(lower, prefix) {
+				return unauthorized(firstNonEmpty(m.Signature.MissingError, "signature is required"))
+			}
+			candidates = []string{strings.TrimSpace(sigHeader[len(m.Signature.Prefix):])}
+		} else {
+			candidates = []string{sigHeader}
+		}
+	}
+	if m.Signature.Timestamp != nil {
+		var err error
+		timestamp, err = m.Signature.Timestamp.Resolve(timestamp, req)
+		if err != nil {
+			return err
+		}
+	}
+	if len(candidates) == 0 {
+		return unauthorized(firstNonEmpty(m.Signature.MissingError, "signature is required"))
+	}
+	signedPayload, err := m.Signature.signedPayload(timestamp, req.Body)
+	if err != nil {
+		return err
+	}
+	mac := hmac.New(sha256.New, []byte(strings.TrimSpace(secret)))
+	_, _ = mac.Write(signedPayload)
+	expected := hex.EncodeToString(mac.Sum(nil))
+	for _, candidate := range candidates {
+		if hmac.Equal([]byte(strings.ToLower(strings.TrimSpace(candidate))), []byte(strings.ToLower(expected))) {
+			return nil
+		}
+	}
+	return unauthorized(firstNonEmpty(m.Signature.InvalidError, "invalid signature"))
+}
+
+func (s SignatureManifest) TimestampParam() string {
+	if s.Timestamp == nil {
+		return ""
+	}
+	return strings.TrimSpace(s.Timestamp.Param)
+}
+
+func (s SignatureManifest) signedPayload(timestamp string, body []byte) ([]byte, error) {
+	switch strings.TrimSpace(s.SignedPayload) {
+	case "raw_body":
+		return body, nil
+	case "slack_v0":
+		return []byte("v0:" + timestamp + ":" + string(body)), nil
+	case "timestamp_dot_raw_body":
+		return []byte(timestamp + "." + string(body)), nil
+	default:
+		return nil, unauthorized(firstNonEmpty(s.InvalidError, "invalid signature"))
+	}
+}
+
+func (t TimestampManifest) Resolve(paramTimestamp string, req Request) (string, error) {
+	raw := strings.TrimSpace(paramTimestamp)
+	if strings.TrimSpace(t.Header) != "" {
+		raw = strings.TrimSpace(req.Headers.Get(t.Header))
+	}
+	if raw == "" {
+		return "", unauthorized(firstNonEmpty(t.MissingError, "signature timestamp is required"))
+	}
+	secs, err := strconv.ParseInt(raw, 10, 64)
+	if err != nil {
+		return "", unauthorized(firstNonEmpty(t.InvalidError, "invalid signature timestamp"))
+	}
+	if strings.TrimSpace(t.Tolerance) != "" {
+		tolerance, err := time.ParseDuration(strings.TrimSpace(t.Tolerance))
+		if err != nil {
+			return "", unauthorized(firstNonEmpty(t.InvalidError, "invalid signature timestamp"))
+		}
+		requestTime := time.Unix(secs, 0).UTC()
+		now := req.Received.UTC()
+		if requestTime.After(now.Add(tolerance)) || requestTime.Before(now.Add(-tolerance)) {
+			return "", unauthorized(firstNonEmpty(t.StaleError, "stale signature timestamp"))
+		}
+	}
+	return raw, nil
+}
+
+func (c ConditionManifest) Evaluate(payload any) (bool, error) {
+	value, ok := stringFromJSONPath(payload, c.JSONPath)
+	if !ok || strings.TrimSpace(value) == "" {
+		if c.MissingError != "" {
+			return false, badRequest(c.MissingError)
+		}
+		return false, nil
+	}
+	if c.Normalize {
+		value = NormalizeEventToken(value)
+	}
+	expected := c.Equals
+	if c.Normalize {
+		expected = NormalizeEventToken(expected)
+	}
+	return value == expected, nil
+}
+
+func (s ValueSource) Resolve(req Request) (string, bool) {
+	if strings.TrimSpace(s.Header) != "" {
+		value := strings.TrimSpace(req.Headers.Get(s.Header))
+		return value, value != ""
+	}
+	if strings.TrimSpace(s.JSONPath) != "" {
+		return stringFromJSONPath(req.Payload, s.JSONPath)
+	}
+	return "", false
+}
+
+func (m Manifest) resolveEventName(eventType string) string {
+	if name := strings.TrimSpace(m.EventName.Literal); name != "" {
+		return name
+	}
+	name := strings.TrimSpace(m.EventName.Template)
+	name = strings.ReplaceAll(name, "{event_type}", eventType)
+	return name
+}
+
+func (m Manifest) buildPublishPayload(provider, entityID, deliveryID, eventType string, req Request) map[string]any {
+	rawPayload := redactPayload(req.Payload, m.RedactKeys)
+	headers := make(map[string]any, len(m.Metadata))
+	for key, source := range m.Metadata {
+		switch source {
+		case "user_agent":
+			headers[key] = req.UserAgent
+		case "delivery_id":
+			headers[key] = deliveryID
+		case "event_type":
+			headers[key] = eventType
+		}
+	}
+	return map[string]any{
+		"entity_id":            strings.TrimSpace(entityID),
+		"provider":             strings.TrimSpace(provider),
+		"event_type":           strings.TrimSpace(eventType),
+		"provider_event_type":  strings.TrimSpace(eventType),
+		"provider_event_id":    strings.TrimSpace(deliveryID),
+		"provider_delivery_id": strings.TrimSpace(deliveryID),
+		"payload":              rawPayload,
+		"headers":              headers,
+		"received_at":          req.Received.UTC().Format(time.RFC3339),
+	}
+}
+
+func acceptRaw(req Request) (Delivery, error) {
+	provider := NormalizeProviderName(req.Provider)
+	if provider == "" {
+		return Delivery{}, badRequest("provider is required")
+	}
+	if !verifyRawWebhookSignature(req.Target.WebhookSecret, req.Body, req.Headers) {
+		return Delivery{}, unauthorized("invalid signature")
+	}
+	entityID := req.Target.EffectiveEntityID()
+	deliveryID := firstNonEmpty(
+		req.Headers.Get("X-Provider-Event-ID"),
+		req.Headers.Get("X-Request-ID"),
+		extractProviderEventID(req.Payload),
+		fingerprintInbound(entityID, provider, req.Body),
+	)
+	eventType := resolveProviderEventType(req.Payload)
+	payload := map[string]any{
+		"entity_id":            strings.TrimSpace(entityID),
+		"provider":             provider,
+		"event_type":           eventType,
+		"provider_event_type":  eventType,
+		"provider_event_id":    deliveryID,
+		"provider_delivery_id": deliveryID,
+		"payload":              req.Payload,
+		"headers":              map[string]any{"user_agent": req.UserAgent},
+		"received_at":          req.Received.UTC().Format(time.RFC3339),
+	}
+	return Delivery{
+		ProviderEventID:   deliveryID,
+		ProviderEventType: eventType,
+		EventName:         events.EventType("inbound." + provider),
+		Payload:           payload,
+	}, nil
+}
+
+func verifyRawWebhookSignature(secret string, body []byte, headers http.Header) bool {
+	secret = strings.TrimSpace(secret)
+	if secret == "" {
+		return true
+	}
+	if sig := strings.TrimSpace(headers.Get("X-Hub-Signature-256")); strings.HasPrefix(strings.ToLower(sig), "sha256=") {
+		given := strings.TrimSpace(sig[len("sha256="):])
+		mac := hmac.New(sha256.New, []byte(secret))
+		_, _ = mac.Write(body)
+		expected := hex.EncodeToString(mac.Sum(nil))
+		return hmac.Equal([]byte(strings.ToLower(given)), []byte(strings.ToLower(expected)))
+	}
+	token := strings.TrimSpace(headers.Get("X-Webhook-Token"))
+	if token == "" {
+		auth := strings.TrimSpace(headers.Get("Authorization"))
+		if strings.HasPrefix(strings.ToLower(auth), "bearer ") {
+			token = strings.TrimSpace(auth[7:])
+		}
+	}
+	return hmac.Equal([]byte(token), []byte(secret))
+}
+
+func extractProviderEventID(payload any) string {
+	m, ok := payload.(map[string]any)
+	if !ok {
+		return ""
+	}
+	for _, key := range []string{"id", "event_id", "message_id"} {
+		if v, ok := m[key].(string); ok && strings.TrimSpace(v) != "" {
+			return strings.TrimSpace(v)
+		}
+	}
+	return ""
+}
+
+func fingerprintInbound(entityID, provider string, body []byte) string {
+	h := sha1.New()
+	_, _ = h.Write([]byte(entityID))
+	_, _ = h.Write([]byte("|"))
+	_, _ = h.Write([]byte(provider))
+	_, _ = h.Write([]byte("|"))
+	_, _ = h.Write(body)
+	return "fp:" + hex.EncodeToString(h.Sum(nil))
+}
+
+func resolveProviderEventType(payload any) string {
+	m, _ := payload.(map[string]any)
+	for _, key := range []string{"event_type", "type", "status", "kind", "action"} {
+		if v, ok := m[key].(string); ok && strings.TrimSpace(v) != "" {
+			return NormalizeEventToken(v)
+		}
+	}
+	return "event"
+}
+
+func stringFromJSONPath(payload any, path string) (string, bool) {
+	value, ok := valueFromJSONPath(payload, path)
+	if !ok {
+		return "", false
+	}
+	switch t := value.(type) {
+	case string:
+		return strings.TrimSpace(t), strings.TrimSpace(t) != ""
+	case json.Number:
+		return strings.TrimSpace(t.String()), strings.TrimSpace(t.String()) != ""
+	default:
+		s := strings.TrimSpace(fmt.Sprint(t))
+		if s == "" || s == "<nil>" || s == "map[]" || s == "[]" {
+			return "", false
+		}
+		return s, true
+	}
+}
+
+func valueFromJSONPath(payload any, path string) (any, bool) {
+	path = strings.TrimSpace(path)
+	if path == "$" {
+		return payload, true
+	}
+	if !strings.HasPrefix(path, "$.") {
+		return nil, false
+	}
+	current := payload
+	for _, part := range strings.Split(strings.TrimPrefix(path, "$."), ".") {
+		obj, ok := current.(map[string]any)
+		if !ok {
+			return nil, false
+		}
+		current, ok = obj[part]
+		if !ok {
+			return nil, false
+		}
+	}
+	return current, true
+}
+
+func redactPayload(payload any, keys []string) any {
+	if len(keys) == 0 {
+		return payload
+	}
+	keySet := make(map[string]struct{}, len(keys))
+	for _, key := range keys {
+		keySet[strings.ToLower(strings.TrimSpace(key))] = struct{}{}
+	}
+	return redactValue(payload, keySet)
+}
+
+func redactValue(payload any, keys map[string]struct{}) any {
+	switch v := payload.(type) {
+	case map[string]any:
+		redacted := make(map[string]any, len(v))
+		for key, value := range v {
+			if _, ok := keys[strings.ToLower(key)]; ok {
+				redacted[key] = "[redacted]"
+				continue
+			}
+			redacted[key] = redactValue(value, keys)
+		}
+		return redacted
+	case []any:
+		redacted := make([]any, len(v))
+		for i, value := range v {
+			redacted[i] = redactValue(value, keys)
+		}
+		return redacted
+	default:
+		return v
+	}
+}
+
+type headerParams map[string][]string
+
+func parseHeaderParams(header string) headerParams {
+	out := make(headerParams)
+	for _, part := range strings.Split(header, ",") {
+		kv := strings.SplitN(strings.TrimSpace(part), "=", 2)
+		if len(kv) != 2 {
+			continue
+		}
+		key := strings.TrimSpace(kv[0])
+		value := strings.TrimSpace(kv[1])
+		if key == "" || value == "" {
+			continue
+		}
+		out[key] = append(out[key], value)
+	}
+	return out
+}
+
+func (p headerParams) Values(key string) []string {
+	values := p[strings.TrimSpace(key)]
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			out = append(out, strings.TrimSpace(value))
+		}
+	}
+	return out
+}
+
+func NormalizeProviderName(raw string) string {
+	token := strings.TrimSpace(strings.ToLower(raw))
+	token = strings.ReplaceAll(token, ".", "_")
+	token = strings.ReplaceAll(token, "-", "_")
+	token = strings.ReplaceAll(token, " ", "_")
+	return token
+}
+
+func NormalizeEventToken(raw string) string {
+	token := strings.TrimSpace(strings.ToLower(raw))
+	token = strings.ReplaceAll(token, ".", "_")
+	token = strings.ReplaceAll(token, "-", "_")
+	token = strings.ReplaceAll(token, " ", "_")
+	if token == "" {
+		return "event"
+	}
+	return token
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, v := range values {
+		if strings.TrimSpace(v) != "" {
+			return strings.TrimSpace(v)
+		}
+	}
+	return ""
+}
+
+func badRequest(message string) Error {
+	return Error{Status: http.StatusBadRequest, Message: message}
+}
+
+func unauthorized(message string) Error {
+	return Error{Status: http.StatusUnauthorized, Message: message}
+}

--- a/internal/providertriggers/providertriggers.go
+++ b/internal/providertriggers/providertriggers.go
@@ -333,7 +333,10 @@ func (m Manifest) verifySignature(secret string, req Request) error {
 		candidates []string
 	)
 	if strings.TrimSpace(m.Signature.SignatureParam) != "" {
-		params := parseHeaderParams(sigHeader)
+		params, err := parseHeaderParams(sigHeader)
+		if err != nil {
+			return unauthorized(firstNonEmpty(m.Signature.InvalidError, "invalid signature"))
+		}
 		timestampValues := params.Values(firstNonEmpty(m.Signature.TimestampParam(), "t"))
 		if len(timestampValues) > 0 {
 			timestamp = timestampValues[0]
@@ -586,12 +589,10 @@ func stringFromJSONPath(payload any, path string) (string, bool) {
 		return strings.TrimSpace(t), strings.TrimSpace(t) != ""
 	case json.Number:
 		return strings.TrimSpace(t.String()), strings.TrimSpace(t.String()) != ""
+	case float64:
+		return strings.TrimSpace(strconv.FormatFloat(t, 'f', -1, 64)), true
 	default:
-		s := strings.TrimSpace(fmt.Sprint(t))
-		if s == "" || s == "<nil>" || s == "map[]" || s == "[]" {
-			return "", false
-		}
-		return s, true
+		return "", false
 	}
 }
 
@@ -653,21 +654,25 @@ func redactValue(payload any, keys map[string]struct{}) any {
 
 type headerParams map[string][]string
 
-func parseHeaderParams(header string) headerParams {
+func parseHeaderParams(header string) (headerParams, error) {
 	out := make(headerParams)
 	for _, part := range strings.Split(header, ",") {
-		kv := strings.SplitN(strings.TrimSpace(part), "=", 2)
+		part = strings.TrimSpace(part)
+		if part == "" {
+			return nil, fmt.Errorf("empty signature parameter")
+		}
+		kv := strings.SplitN(part, "=", 2)
 		if len(kv) != 2 {
-			continue
+			return nil, fmt.Errorf("malformed signature parameter")
 		}
 		key := strings.TrimSpace(kv[0])
 		value := strings.TrimSpace(kv[1])
 		if key == "" || value == "" {
-			continue
+			return nil, fmt.Errorf("empty signature parameter")
 		}
 		out[key] = append(out[key], value)
 	}
-	return out
+	return out, nil
 }
 
 func (p headerParams) Values(key string) []string {

--- a/internal/providertriggers/providertriggers_test.go
+++ b/internal/providertriggers/providertriggers_test.go
@@ -68,6 +68,92 @@ func TestManifestInterpreterHostileProviderRejectsBoundaryAttacks(t *testing.T) 
 		_, err := registry.Accept(req)
 		requireProviderTriggerError(t, err, http.StatusUnauthorized)
 	})
+
+	t.Run("object event type fails closed", func(t *testing.T) {
+		body := []byte(`{"event_type":"safe.event"}`)
+		req := hostileRequest(now, body)
+		req.Headers.Set("X-Hostile-Delivery", "delivery-header")
+		req.Headers.Set("X-Hostile-Timestamp", strconvFormatUnix(now))
+		req.Headers.Set("X-Hostile-Signature", hostileSignature("hostile-secret", strconvFormatUnix(now), body))
+		req.Payload = map[string]any{
+			"event_type": map[string]any{"nested": "safe.event"},
+		}
+		_, err := registry.Accept(req)
+		requireProviderTriggerError(t, err, http.StatusBadRequest)
+	})
+
+	t.Run("list event type fails closed", func(t *testing.T) {
+		body := []byte(`{"event_type":"safe.event"}`)
+		req := hostileRequest(now, body)
+		req.Headers.Set("X-Hostile-Delivery", "delivery-header")
+		req.Headers.Set("X-Hostile-Timestamp", strconvFormatUnix(now))
+		req.Headers.Set("X-Hostile-Signature", hostileSignature("hostile-secret", strconvFormatUnix(now), body))
+		req.Payload = map[string]any{
+			"event_type": []any{"safe.event"},
+		}
+		_, err := registry.Accept(req)
+		requireProviderTriggerError(t, err, http.StatusBadRequest)
+	})
+
+	t.Run("bool event type fails closed", func(t *testing.T) {
+		body := []byte(`{"event_type":"safe.event"}`)
+		req := hostileRequest(now, body)
+		req.Headers.Set("X-Hostile-Delivery", "delivery-header")
+		req.Headers.Set("X-Hostile-Timestamp", strconvFormatUnix(now))
+		req.Headers.Set("X-Hostile-Signature", hostileSignature("hostile-secret", strconvFormatUnix(now), body))
+		req.Payload = map[string]any{
+			"event_type": true,
+		}
+		_, err := registry.Accept(req)
+		requireProviderTriggerError(t, err, http.StatusBadRequest)
+	})
+}
+
+func TestManifestInterpreterRejectsMalformedJSONPathIdentityPayloads(t *testing.T) {
+	registry := newHostilePayloadIdentityRegistry(t)
+	now := time.Unix(1710000000, 0).UTC()
+
+	t.Run("object delivery id fails closed", func(t *testing.T) {
+		body := []byte(`{"event_id":{"nested":"delivery"},"event_type":"safe.event"}`)
+		req := hostileRequest(now, body)
+		req.Headers.Set("X-Hostile-Timestamp", strconvFormatUnix(now))
+		req.Headers.Set("X-Hostile-Signature", hostileSignature("hostile-secret", strconvFormatUnix(now), body))
+		req.Payload = map[string]any{
+			"event_id":   map[string]any{"nested": "delivery"},
+			"event_type": "safe.event",
+		}
+
+		_, err := registry.Accept(req)
+		requireProviderTriggerError(t, err, http.StatusBadRequest)
+	})
+
+	t.Run("list delivery id fails closed", func(t *testing.T) {
+		body := []byte(`{"event_id":["delivery"],"event_type":"safe.event"}`)
+		req := hostileRequest(now, body)
+		req.Headers.Set("X-Hostile-Timestamp", strconvFormatUnix(now))
+		req.Headers.Set("X-Hostile-Signature", hostileSignature("hostile-secret", strconvFormatUnix(now), body))
+		req.Payload = map[string]any{
+			"event_id":   []any{"delivery"},
+			"event_type": "safe.event",
+		}
+
+		_, err := registry.Accept(req)
+		requireProviderTriggerError(t, err, http.StatusBadRequest)
+	})
+
+	t.Run("bool event type fails closed", func(t *testing.T) {
+		body := []byte(`{"event_id":"delivery","event_type":true}`)
+		req := hostileRequest(now, body)
+		req.Headers.Set("X-Hostile-Timestamp", strconvFormatUnix(now))
+		req.Headers.Set("X-Hostile-Signature", hostileSignature("hostile-secret", strconvFormatUnix(now), body))
+		req.Payload = map[string]any{
+			"event_id":   "delivery",
+			"event_type": true,
+		}
+
+		_, err := registry.Accept(req)
+		requireProviderTriggerError(t, err, http.StatusBadRequest)
+	})
 }
 
 func TestStripeManifestRejectsMalformedSignatureParams(t *testing.T) {
@@ -87,6 +173,10 @@ func TestStripeManifestRejectsMalformedSignatureParams(t *testing.T) {
 	req.Headers.Set("Stripe-Signature", "t="+strconvFormatUnix(now)+",v0="+stripeSignatureHex("stripe-secret", strconvFormatUnix(now), body))
 
 	_, err := DefaultRegistry().Accept(req)
+	requireProviderTriggerError(t, err, http.StatusUnauthorized)
+
+	req.Headers.Set("Stripe-Signature", "t="+strconvFormatUnix(now)+",broken,v1="+stripeSignatureHex("stripe-secret", strconvFormatUnix(now), body))
+	_, err = DefaultRegistry().Accept(req)
 	requireProviderTriggerError(t, err, http.StatusUnauthorized)
 }
 
@@ -142,6 +232,48 @@ func newHostileRegistry(t *testing.T) *Registry {
 	registry, err := NewRegistry(manifest)
 	if err != nil {
 		t.Fatalf("NewRegistry hostile: %v", err)
+	}
+	return registry
+}
+
+func newHostilePayloadIdentityRegistry(t *testing.T) *Registry {
+	t.Helper()
+	manifest := Manifest{
+		Provider:              "hostile",
+		PayloadObjectRequired: true,
+		PayloadObjectError:    "hostile payload object is required",
+		Secret:                SecretManifest{Required: true},
+		Signature: SignatureManifest{
+			Type:          "hmac_sha256",
+			Header:        "X-Hostile-Signature",
+			Prefix:        "v1=",
+			SignedPayload: "timestamp_dot_raw_body",
+			MissingError:  "hostile signature is required",
+			InvalidError:  "invalid hostile signature",
+			Timestamp: &TimestampManifest{
+				Header:       "X-Hostile-Timestamp",
+				Tolerance:    "5m",
+				MissingError: "hostile timestamp is required",
+				InvalidError: "invalid hostile timestamp",
+				StaleError:   "stale hostile timestamp",
+			},
+		},
+		DeliveryID: ValueSource{
+			JSONPath:     "$.event_id",
+			Required:     true,
+			MissingError: "hostile delivery id is required",
+		},
+		EventType: ValueSource{
+			JSONPath:     "$.event_type",
+			Required:     true,
+			MissingError: "hostile event type is required",
+		},
+		EventName: EventNameManifest{Literal: "inbound.hostile"},
+		Ack:       AckManifest{Mode: "durable_before_dispatch"},
+	}
+	registry, err := NewRegistry(manifest)
+	if err != nil {
+		t.Fatalf("NewRegistry hostile payload identity: %v", err)
 	}
 	return registry
 }

--- a/internal/providertriggers/providertriggers_test.go
+++ b/internal/providertriggers/providertriggers_test.go
@@ -178,6 +178,92 @@ func TestStripeManifestRejectsMalformedSignatureParams(t *testing.T) {
 	req.Headers.Set("Stripe-Signature", "t="+strconvFormatUnix(now)+",broken,v1="+stripeSignatureHex("stripe-secret", strconvFormatUnix(now), body))
 	_, err = DefaultRegistry().Accept(req)
 	requireProviderTriggerError(t, err, http.StatusUnauthorized)
+
+	req.Headers.Set("Stripe-Signature", "t="+strconvFormatUnix(now)+",t="+strconvFormatUnix(now)+",v1="+stripeSignatureHex("stripe-secret", strconvFormatUnix(now), body))
+	_, err = DefaultRegistry().Accept(req)
+	requireProviderTriggerError(t, err, http.StatusUnauthorized)
+}
+
+func TestStripeManifestAcceptsLiteralEventType(t *testing.T) {
+	now := time.Unix(1710000000, 0).UTC()
+	body := []byte(`{"id":"evt_123","type":"event"}`)
+	req := Request{
+		Provider: "stripe",
+		Target: Target{
+			EntityID:      "entity-1",
+			WebhookSecret: "stripe-secret",
+		},
+		Body:     body,
+		Headers:  make(http.Header),
+		Payload:  map[string]any{"id": "evt_123", "type": "event"},
+		Received: now,
+	}
+	req.Headers.Set("Stripe-Signature", "t="+strconvFormatUnix(now)+",v1="+stripeSignatureHex("stripe-secret", strconvFormatUnix(now), body))
+
+	delivery, err := DefaultRegistry().Accept(req)
+	if err != nil {
+		t.Fatalf("Accept Stripe literal event type: %v", err)
+	}
+	if delivery.ProviderEventType != "event" {
+		t.Fatalf("ProviderEventType = %q, want event", delivery.ProviderEventType)
+	}
+	if delivery.EventName != "inbound.stripe" {
+		t.Fatalf("EventName = %q, want inbound.stripe", delivery.EventName)
+	}
+}
+
+func TestManifestValidationRejectsAuthoringErrors(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		manifest Manifest
+	}{
+		{
+			name: "invalid json path syntax",
+			manifest: Manifest{
+				Provider:   "badpath",
+				DeliveryID: ValueSource{JSONPath: "$..id", Required: true},
+				EventType:  ValueSource{JSONPath: "$.type", Required: true},
+				EventName:  EventNameManifest{Literal: "inbound.badpath"},
+			},
+		},
+		{
+			name: "unknown metadata source",
+			manifest: Manifest{
+				Provider:   "badmetadata",
+				DeliveryID: ValueSource{JSONPath: "$.id", Required: true},
+				EventType:  ValueSource{JSONPath: "$.type", Required: true},
+				EventName:  EventNameManifest{Literal: "inbound.badmetadata"},
+				Metadata:   map[string]string{"bad": "unknown_source"},
+			},
+		},
+		{
+			name: "new provider event name template",
+			manifest: Manifest{
+				Provider:   "badtemplate",
+				DeliveryID: ValueSource{JSONPath: "$.id", Required: true},
+				EventType:  ValueSource{JSONPath: "$.type", Required: true},
+				EventName:  EventNameManifest{Template: "inbound.badtemplate.{event_type}"},
+			},
+		},
+		{
+			name: "literal and template both set",
+			manifest: Manifest{
+				Provider:   "ambiguousname",
+				DeliveryID: ValueSource{JSONPath: "$.id", Required: true},
+				EventType:  ValueSource{JSONPath: "$.type", Required: true},
+				EventName: EventNameManifest{
+					Literal:  "inbound.ambiguousname",
+					Template: "inbound.ambiguousname.{event_type}",
+				},
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := NewRegistry(tc.manifest); err == nil {
+				t.Fatal("NewRegistry succeeded, want validation error")
+			}
+		})
+	}
 }
 
 func TestRegistryRejectsEmptyProvider(t *testing.T) {

--- a/internal/providertriggers/providertriggers_test.go
+++ b/internal/providertriggers/providertriggers_test.go
@@ -1,0 +1,203 @@
+package providertriggers
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"net/http"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestManifestInterpreterHostileProviderRejectsBoundaryAttacks(t *testing.T) {
+	registry := newHostileRegistry(t)
+	now := time.Unix(1710000000, 0).UTC()
+
+	t.Run("smuggled fields do not override manifest sources", func(t *testing.T) {
+		body := []byte(`{"event_type":"safe.event","event_id":"payload-evil","provider_event_type":"payload-evil"}`)
+		req := hostileRequest(now, body)
+		req.Headers.Set("X-Hostile-Delivery", "delivery-header")
+		req.Headers.Set("X-Hostile-Timestamp", strconvFormatUnix(now))
+		req.Headers.Set("X-Hostile-Signature", hostileSignature("hostile-secret", strconvFormatUnix(now), body))
+
+		delivery, err := registry.Accept(req)
+		if err != nil {
+			t.Fatalf("Accept hostile valid request: %v", err)
+		}
+		if delivery.ProviderEventID != "delivery-header" {
+			t.Fatalf("provider event id = %q, want manifest header source", delivery.ProviderEventID)
+		}
+		if delivery.ProviderEventType != "safe_event" {
+			t.Fatalf("provider event type = %q, want manifest json path source", delivery.ProviderEventType)
+		}
+		if delivery.Payload["provider_event_id"] != "delivery-header" || delivery.Payload["provider_event_type"] != "safe_event" {
+			t.Fatalf("payload identity = %+v, want manifest-derived fields", delivery.Payload)
+		}
+	})
+
+	t.Run("signature confusion fails closed", func(t *testing.T) {
+		body := []byte(`{"event_type":"safe.event"}`)
+		req := hostileRequest(now, body)
+		req.Headers.Set("X-Hostile-Delivery", "delivery-header")
+		req.Headers.Set("X-Hostile-Timestamp", strconvFormatUnix(now))
+		req.Headers.Set("X-Other-Signature", hostileSignature("hostile-secret", strconvFormatUnix(now), body))
+		_, err := registry.Accept(req)
+		requireProviderTriggerError(t, err, http.StatusUnauthorized)
+	})
+
+	t.Run("replayed timestamp fails closed", func(t *testing.T) {
+		old := now.Add(-10 * time.Minute)
+		body := []byte(`{"event_type":"safe.event"}`)
+		req := hostileRequest(now, body)
+		req.Headers.Set("X-Hostile-Delivery", "delivery-header")
+		req.Headers.Set("X-Hostile-Timestamp", strconvFormatUnix(old))
+		req.Headers.Set("X-Hostile-Signature", hostileSignature("hostile-secret", strconvFormatUnix(old), body))
+		_, err := registry.Accept(req)
+		requireProviderTriggerError(t, err, http.StatusUnauthorized)
+	})
+
+	t.Run("raw-byte unicode canonicalization mismatch fails closed", func(t *testing.T) {
+		signedBody := []byte(`{"event_type":"café","amount":1}`)
+		deliveredBody := []byte(`{"amount":1,"event_type":"café"}`)
+		req := hostileRequest(now, deliveredBody)
+		req.Headers.Set("X-Hostile-Delivery", "delivery-header")
+		req.Headers.Set("X-Hostile-Timestamp", strconvFormatUnix(now))
+		req.Headers.Set("X-Hostile-Signature", hostileSignature("hostile-secret", strconvFormatUnix(now), signedBody))
+		_, err := registry.Accept(req)
+		requireProviderTriggerError(t, err, http.StatusUnauthorized)
+	})
+}
+
+func TestStripeManifestRejectsMalformedSignatureParams(t *testing.T) {
+	now := time.Unix(1710000000, 0).UTC()
+	body := []byte(`{"id":"evt_123","type":"invoice.paid"}`)
+	req := Request{
+		Provider: "stripe",
+		Target: Target{
+			EntityID:      "entity-1",
+			WebhookSecret: "stripe-secret",
+		},
+		Body:     body,
+		Headers:  make(http.Header),
+		Payload:  map[string]any{"id": "evt_123", "type": "invoice.paid"},
+		Received: now,
+	}
+	req.Headers.Set("Stripe-Signature", "t="+strconvFormatUnix(now)+",v0="+stripeSignatureHex("stripe-secret", strconvFormatUnix(now), body))
+
+	_, err := DefaultRegistry().Accept(req)
+	requireProviderTriggerError(t, err, http.StatusUnauthorized)
+}
+
+func TestRegistryRejectsEmptyProvider(t *testing.T) {
+	_, err := DefaultRegistry().Accept(Request{
+		Target:  Target{EntityID: "entity-1"},
+		Body:    []byte(`{}`),
+		Headers: make(http.Header),
+		Payload: map[string]any{},
+	})
+	requireProviderTriggerError(t, err, http.StatusBadRequest)
+}
+
+func newHostileRegistry(t *testing.T) *Registry {
+	t.Helper()
+	manifest := Manifest{
+		Provider:              "hostile",
+		PayloadObjectRequired: true,
+		PayloadObjectError:    "hostile payload object is required",
+		Secret:                SecretManifest{Required: true},
+		Signature: SignatureManifest{
+			Type:          "hmac_sha256",
+			Header:        "X-Hostile-Signature",
+			Prefix:        "v1=",
+			SignedPayload: "timestamp_dot_raw_body",
+			MissingError:  "hostile signature is required",
+			InvalidError:  "invalid hostile signature",
+			Timestamp: &TimestampManifest{
+				Header:       "X-Hostile-Timestamp",
+				Tolerance:    "5m",
+				MissingError: "hostile timestamp is required",
+				InvalidError: "invalid hostile timestamp",
+				StaleError:   "stale hostile timestamp",
+			},
+		},
+		DeliveryID: ValueSource{
+			Header:       "X-Hostile-Delivery",
+			Required:     true,
+			MissingError: "hostile delivery id is required",
+		},
+		EventType: ValueSource{
+			JSONPath:     "$.event_type",
+			Required:     true,
+			MissingError: "hostile event type is required",
+		},
+		EventName: EventNameManifest{Literal: "inbound.hostile"},
+		Ack:       AckManifest{Mode: "durable_before_dispatch"},
+		Metadata: map[string]string{
+			"hostile_delivery": "delivery_id",
+			"hostile_event":    "event_type",
+		},
+	}
+	registry, err := NewRegistry(manifest)
+	if err != nil {
+		t.Fatalf("NewRegistry hostile: %v", err)
+	}
+	return registry
+}
+
+func hostileRequest(now time.Time, body []byte) Request {
+	return Request{
+		Provider: "hostile",
+		Target: Target{
+			EntityID:      "entity-1",
+			WebhookSecret: "hostile-secret",
+		},
+		Body:     body,
+		Headers:  make(http.Header),
+		Payload:  mustPayload(body),
+		Received: now,
+	}
+}
+
+func mustPayload(body []byte) map[string]any {
+	out := make(map[string]any)
+	for _, pair := range strings.Split(strings.Trim(strings.TrimSpace(string(body)), "{}"), ",") {
+		kv := strings.SplitN(pair, ":", 2)
+		if len(kv) != 2 {
+			continue
+		}
+		key := strings.Trim(strings.TrimSpace(kv[0]), `"`)
+		value := strings.Trim(strings.TrimSpace(kv[1]), `"`)
+		out[key] = value
+	}
+	return out
+}
+
+func requireProviderTriggerError(t *testing.T, err error, status int) {
+	t.Helper()
+	if err == nil {
+		t.Fatal("err = nil, want provider trigger error")
+	}
+	providerErr, ok := err.(Error)
+	if !ok {
+		t.Fatalf("err type = %T, want providertriggers.Error", err)
+	}
+	if providerErr.Status != status {
+		t.Fatalf("status = %d, want %d (%v)", providerErr.Status, status, err)
+	}
+}
+
+func hostileSignature(secret, timestamp string, body []byte) string {
+	return "v1=" + stripeSignatureHex(secret, timestamp, body)
+}
+
+func stripeSignatureHex(secret, timestamp string, body []byte) string {
+	mac := hmac.New(sha256.New, []byte(secret))
+	_, _ = mac.Write([]byte(timestamp + "." + string(body)))
+	return hex.EncodeToString(mac.Sum(nil))
+}
+
+func strconvFormatUnix(t time.Time) string {
+	return strconv.FormatInt(t.Unix(), 10)
+}

--- a/internal/runtime/inbound.go
+++ b/internal/runtime/inbound.go
@@ -2,23 +2,20 @@ package runtime
 
 import (
 	"context"
-	"crypto/hmac"
-	"crypto/sha1"
-	"crypto/sha256"
-	"encoding/hex"
 	"encoding/json"
-	"fmt"
 	"io"
 	"net/http"
-	"strconv"
 	"strings"
 	"time"
 
 	"github.com/division-sh/swarm/internal/events"
+	"github.com/division-sh/swarm/internal/providertriggers"
 	runtimebus "github.com/division-sh/swarm/internal/runtime/bus"
 	runtimeingress "github.com/division-sh/swarm/internal/runtime/ingress"
 	"github.com/google/uuid"
 )
+
+const inboundWebhookMaxBodyBytes = 1 << 20
 
 type InboundPersistence interface {
 	RecordInboundEvent(ctx context.Context, providerEventID, entityID, provider string) (bool, error)
@@ -61,7 +58,7 @@ type InboundGateway struct {
 	logger                  *RuntimeLogger
 	shutdownAdmissionClosed func() bool
 	runtimeIngress          *runtimeingress.Controller
-	providers               map[string]inboundProviderAdapter
+	providers               *providertriggers.Registry
 }
 
 func NewInboundGateway(bus *runtimebus.EventBus, logger *RuntimeLogger, shutdownAdmissionClosed func() bool, stores ...InboundPersistence) *InboundGateway {
@@ -75,7 +72,7 @@ func NewInboundGateway(bus *runtimebus.EventBus, logger *RuntimeLogger, shutdown
 		store:                   store,
 		logger:                  logger,
 		shutdownAdmissionClosed: shutdownAdmissionClosed,
-		providers:               defaultInboundProviderAdapters(),
+		providers:               providertriggers.DefaultRegistry(),
 	}
 	g.mux.HandleFunc("/webhooks/", g.handleWebhook)
 	return g
@@ -113,9 +110,13 @@ func (g *InboundGateway) handleWebhook(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	body, err := io.ReadAll(io.LimitReader(r.Body, 1<<20))
+	body, err := io.ReadAll(io.LimitReader(r.Body, inboundWebhookMaxBodyBytes+1))
 	if err != nil {
 		http.Error(w, "read body failed", http.StatusBadRequest)
+		return
+	}
+	if len(body) > inboundWebhookMaxBodyBytes {
+		http.Error(w, "webhook body too large", http.StatusRequestEntityTooLarge)
 		return
 	}
 	if len(body) == 0 {
@@ -142,9 +143,13 @@ func (g *InboundGateway) handleWebhook(w http.ResponseWriter, r *http.Request) {
 	entityID := target.EffectiveEntityID()
 	entitySlug := target.EffectiveEntitySlug()
 	now := time.Now().UTC()
-	delivery, err := g.providerAdapter(provider).AcceptInbound(inboundProviderRequest{
-		Provider:  provider,
-		Target:    target,
+	delivery, err := g.providers.Accept(providertriggers.Request{
+		Provider: provider,
+		Target: providertriggers.Target{
+			EntityID:      target.EntityID,
+			EntitySlug:    target.EntitySlug,
+			WebhookSecret: target.WebhookSecret,
+		},
 		Body:      body,
 		Headers:   r.Header,
 		Payload:   payload,
@@ -153,7 +158,7 @@ func (g *InboundGateway) handleWebhook(w http.ResponseWriter, r *http.Request) {
 	})
 	if err != nil {
 		status := http.StatusBadRequest
-		if providerErr, ok := err.(inboundProviderError); ok {
+		if providerErr, ok := err.(providertriggers.Error); ok {
 			status = providerErr.Status
 		}
 		http.Error(w, err.Error(), status)
@@ -239,15 +244,6 @@ func (g *InboundGateway) handleWebhook(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
-func (g *InboundGateway) providerAdapter(provider string) inboundProviderAdapter {
-	if g != nil {
-		if adapter, ok := g.providers[normalizeProviderName(provider)]; ok && adapter != nil {
-			return adapter
-		}
-	}
-	return rawInboundProviderAdapter{}
-}
-
 func parseWebhookPath(path string) (entityID, provider string, ok bool) {
 	p := strings.Trim(path, "/")
 	parts := strings.Split(p, "/")
@@ -262,222 +258,6 @@ func parseWebhookPath(path string) (entityID, provider string, ok bool) {
 	return entityID, provider, true
 }
 
-func normalizeProviderName(raw string) string {
-	return normalizeEventToken(raw)
-}
-
-type inboundProviderAdapter interface {
-	AcceptInbound(inboundProviderRequest) (inboundProviderDelivery, error)
-}
-
-type inboundProviderRequest struct {
-	Provider  string
-	Target    InboundTarget
-	Body      []byte
-	Headers   http.Header
-	Payload   any
-	Received  time.Time
-	UserAgent string
-}
-
-type inboundProviderDelivery struct {
-	ProviderEventID           string
-	ProviderEventType         string
-	EventName                 events.EventType
-	Payload                   map[string]any
-	Response                  *inboundProviderResponse
-	AcknowledgeBeforeDispatch bool
-}
-
-type inboundProviderResponse struct {
-	Status      int
-	ContentType string
-	Body        []byte
-}
-
-type inboundProviderError struct {
-	Status  int
-	Message string
-}
-
-func (e inboundProviderError) Error() string {
-	return e.Message
-}
-
-func inboundBadRequest(message string) inboundProviderError {
-	return inboundProviderError{Status: http.StatusBadRequest, Message: message}
-}
-
-func inboundUnauthorized(message string) inboundProviderError {
-	return inboundProviderError{Status: http.StatusUnauthorized, Message: message}
-}
-
-func defaultInboundProviderAdapters() map[string]inboundProviderAdapter {
-	return map[string]inboundProviderAdapter{
-		"github": githubInboundProviderAdapter{},
-		"slack":  slackInboundProviderAdapter{},
-	}
-}
-
-type githubInboundProviderAdapter struct{}
-
-func (githubInboundProviderAdapter) AcceptInbound(req inboundProviderRequest) (inboundProviderDelivery, error) {
-	secret := strings.TrimSpace(req.Target.WebhookSecret)
-	if secret == "" {
-		return inboundProviderDelivery{}, inboundUnauthorized("github webhook signing secret is required")
-	}
-	if !verifyGitHubSignature(secret, req.Body, req.Headers) {
-		return inboundProviderDelivery{}, inboundUnauthorized("invalid github signature")
-	}
-	deliveryID := strings.TrimSpace(req.Headers.Get("X-GitHub-Delivery"))
-	if deliveryID == "" {
-		return inboundProviderDelivery{}, inboundBadRequest("github delivery id is required")
-	}
-	eventType := normalizeEventToken(req.Headers.Get("X-GitHub-Event"))
-	if eventType == "event" {
-		return inboundProviderDelivery{}, inboundBadRequest("github event type is required")
-	}
-	entityID := req.Target.EffectiveEntityID()
-	payload := buildProviderPublishPayload("github", entityID, deliveryID, eventType, req.Payload, req.Received, map[string]any{
-		"user_agent":      req.UserAgent,
-		"github_delivery": deliveryID,
-		"github_event":    eventType,
-	})
-	return inboundProviderDelivery{
-		ProviderEventID:   deliveryID,
-		ProviderEventType: eventType,
-		EventName:         events.EventType("inbound.github." + eventType),
-		Payload:           payload,
-	}, nil
-}
-
-type rawInboundProviderAdapter struct{}
-
-type slackInboundProviderAdapter struct{}
-
-func (slackInboundProviderAdapter) AcceptInbound(req inboundProviderRequest) (inboundProviderDelivery, error) {
-	secret := strings.TrimSpace(req.Target.WebhookSecret)
-	if secret == "" {
-		return inboundProviderDelivery{}, inboundUnauthorized("slack webhook signing secret is required")
-	}
-	if err := verifySlackSignature(secret, req.Body, req.Headers, req.Received); err != nil {
-		return inboundProviderDelivery{}, err
-	}
-
-	payload, ok := req.Payload.(map[string]any)
-	if !ok {
-		return inboundProviderDelivery{}, inboundBadRequest("slack payload object is required")
-	}
-	payloadType := normalizeEventToken(firstStringByKeys(payload, "type"))
-	switch payloadType {
-	case "url_verification":
-		challenge := firstStringByKeys(payload, "challenge")
-		if challenge == "" {
-			return inboundProviderDelivery{}, inboundBadRequest("slack challenge is required")
-		}
-		return inboundProviderDelivery{
-			Response: &inboundProviderResponse{
-				Status:      http.StatusOK,
-				ContentType: "text/plain; charset=utf-8",
-				Body:        []byte(challenge),
-			},
-		}, nil
-	case "event_callback":
-		eventID := firstStringByKeys(payload, "event_id")
-		if eventID == "" {
-			return inboundProviderDelivery{}, inboundBadRequest("slack event_id is required")
-		}
-		innerEvent, ok := payload["event"].(map[string]any)
-		if !ok {
-			return inboundProviderDelivery{}, inboundBadRequest("slack inner event is required")
-		}
-		eventType := normalizeEventToken(firstStringByKeys(innerEvent, "type"))
-		if eventType == "event" {
-			return inboundProviderDelivery{}, inboundBadRequest("slack inner event type is required")
-		}
-		entityID := req.Target.EffectiveEntityID()
-		publishPayload := buildProviderPublishPayload("slack", entityID, eventID, eventType, redactSlackPayload(req.Payload), req.Received, map[string]any{
-			"user_agent":       req.UserAgent,
-			"slack_event_id":   eventID,
-			"slack_event_type": eventType,
-		})
-		return inboundProviderDelivery{
-			ProviderEventID:           eventID,
-			ProviderEventType:         eventType,
-			EventName:                 events.EventType("inbound.slack." + eventType),
-			Payload:                   publishPayload,
-			AcknowledgeBeforeDispatch: true,
-		}, nil
-	default:
-		if payloadType == "event" {
-			return inboundProviderDelivery{}, inboundBadRequest("slack payload type is required")
-		}
-		return inboundProviderDelivery{}, inboundBadRequest("unsupported slack payload type")
-	}
-}
-
-func (rawInboundProviderAdapter) AcceptInbound(req inboundProviderRequest) (inboundProviderDelivery, error) {
-	provider := normalizeProviderName(req.Provider)
-	if provider == "" {
-		return inboundProviderDelivery{}, inboundBadRequest("provider is required")
-	}
-	if !verifyRawWebhookSignature(req.Target.WebhookSecret, req.Body, req.Headers) {
-		return inboundProviderDelivery{}, inboundUnauthorized("invalid signature")
-	}
-	entityID := req.Target.EffectiveEntityID()
-	providerEventID := firstNonEmpty(
-		req.Headers.Get("X-Provider-Event-ID"),
-		req.Headers.Get("X-Request-ID"),
-		extractProviderEventID(req.Payload),
-		fingerprintInbound(entityID, provider, req.Body),
-	)
-	providerEventType := resolveProviderEventType(provider, req.Payload)
-	payload := buildProviderPublishPayload(provider, entityID, providerEventID, providerEventType, req.Payload, req.Received, map[string]any{
-		"user_agent": req.UserAgent,
-	})
-	return inboundProviderDelivery{
-		ProviderEventID:   providerEventID,
-		ProviderEventType: providerEventType,
-		EventName:         events.EventType("inbound." + provider),
-		Payload:           payload,
-	}, nil
-}
-
-func buildProviderPublishPayload(provider, entityID, providerEventID, providerEventType string, rawPayload any, now time.Time, headers map[string]any) map[string]any {
-	return map[string]any{
-		"entity_id":         strings.TrimSpace(entityID),
-		"provider":          strings.TrimSpace(provider),
-		"event_type":        strings.TrimSpace(providerEventType),
-		"provider_event_id": strings.TrimSpace(providerEventID),
-		"payload":           rawPayload,
-		"headers":           headers,
-		"received_at":       now.Format(time.RFC3339),
-	}
-}
-
-func extractProviderEventID(payload any) string {
-	m, ok := payload.(map[string]any)
-	if !ok {
-		return ""
-	}
-	for _, key := range []string{"id", "event_id", "message_id"} {
-		if v, ok := m[key].(string); ok && strings.TrimSpace(v) != "" {
-			return strings.TrimSpace(v)
-		}
-	}
-	return ""
-}
-
-func fingerprintInbound(entityID, provider string, body []byte) string {
-	h := sha1.New()
-	_, _ = h.Write([]byte(entityID))
-	_, _ = h.Write([]byte("|"))
-	_, _ = h.Write([]byte(provider))
-	_, _ = h.Write([]byte("|"))
-	_, _ = h.Write(body)
-	return "fp:" + hex.EncodeToString(h.Sum(nil))
-}
-
 func firstNonEmpty(values ...string) string {
 	for _, v := range values {
 		if strings.TrimSpace(v) != "" {
@@ -485,207 +265,6 @@ func firstNonEmpty(values ...string) string {
 		}
 	}
 	return ""
-}
-
-func firstStringByKeys(obj map[string]any, keys ...string) string {
-	for _, key := range keys {
-		if obj == nil {
-			break
-		}
-		if v, ok := obj[key]; ok {
-			switch t := v.(type) {
-			case string:
-				if s := strings.TrimSpace(t); s != "" {
-					return s
-				}
-			case json.Number:
-				if s := strings.TrimSpace(t.String()); s != "" {
-					return s
-				}
-			default:
-				if s := strings.TrimSpace(fmt.Sprint(t)); s != "" && s != "<nil>" && s != "map[]" && s != "[]" {
-					return s
-				}
-			}
-		}
-	}
-	return ""
-}
-
-func firstStringSliceByKeys(obj map[string]any, keys ...string) []string {
-	for _, key := range keys {
-		if obj == nil {
-			break
-		}
-		v, ok := obj[key]
-		if !ok {
-			continue
-		}
-		switch t := v.(type) {
-		case []string:
-			out := make([]string, 0, len(t))
-			for _, s := range t {
-				if trimmed := strings.TrimSpace(s); trimmed != "" {
-					out = append(out, trimmed)
-				}
-			}
-			if len(out) > 0 {
-				return out
-			}
-		case []any:
-			out := make([]string, 0, len(t))
-			for _, item := range t {
-				if trimmed := strings.TrimSpace(fmt.Sprint(item)); trimmed != "" && trimmed != "<nil>" {
-					out = append(out, trimmed)
-				}
-			}
-			if len(out) > 0 {
-				return out
-			}
-		case string:
-			if trimmed := strings.TrimSpace(t); trimmed != "" {
-				return []string{trimmed}
-			}
-		}
-	}
-	return []string{}
-}
-
-func resolveProviderEventType(provider string, payload any) string {
-	m, _ := payload.(map[string]any)
-	for _, key := range []string{"event_type", "type", "status", "kind", "action"} {
-		if v, ok := m[key].(string); ok && strings.TrimSpace(v) != "" {
-			return normalizeEventToken(v)
-		}
-	}
-	return "event"
-}
-
-func normalizeEventToken(raw string) string {
-	token := strings.TrimSpace(strings.ToLower(raw))
-	token = strings.ReplaceAll(token, ".", "_")
-	token = strings.ReplaceAll(token, "-", "_")
-	token = strings.ReplaceAll(token, " ", "_")
-	if token == "" {
-		return "event"
-	}
-	return token
-}
-
-func verifyGitHubSignature(secret string, body []byte, headers http.Header) bool {
-	sig := strings.TrimSpace(headers.Get("X-Hub-Signature-256"))
-	if !strings.HasPrefix(strings.ToLower(sig), "sha256=") {
-		return false
-	}
-	given := strings.TrimSpace(sig[len("sha256="):])
-	mac := hmac.New(sha256.New, []byte(strings.TrimSpace(secret)))
-	_, _ = mac.Write(body)
-	expected := hex.EncodeToString(mac.Sum(nil))
-	return hmac.Equal([]byte(strings.ToLower(given)), []byte(strings.ToLower(expected)))
-}
-
-func verifySlackSignature(secret string, body []byte, headers http.Header, now time.Time) error {
-	timestampHeader := strings.TrimSpace(headers.Get("X-Slack-Request-Timestamp"))
-	if timestampHeader == "" {
-		return inboundUnauthorized("slack request timestamp is required")
-	}
-	timestamp, err := strconv.ParseInt(timestampHeader, 10, 64)
-	if err != nil {
-		return inboundUnauthorized("invalid slack request timestamp")
-	}
-	requestTime := time.Unix(timestamp, 0).UTC()
-	if requestTime.After(now.Add(5*time.Minute)) || requestTime.Before(now.Add(-5*time.Minute)) {
-		return inboundUnauthorized("stale slack request timestamp")
-	}
-
-	signature := strings.TrimSpace(headers.Get("X-Slack-Signature"))
-	if !strings.HasPrefix(strings.ToLower(signature), "v0=") {
-		return inboundUnauthorized("slack signature is required")
-	}
-	base := "v0:" + timestampHeader + ":" + string(body)
-	mac := hmac.New(sha256.New, []byte(strings.TrimSpace(secret)))
-	_, _ = mac.Write([]byte(base))
-	expected := "v0=" + hex.EncodeToString(mac.Sum(nil))
-	if !hmac.Equal([]byte(strings.ToLower(signature)), []byte(strings.ToLower(expected))) {
-		return inboundUnauthorized("invalid slack signature")
-	}
-	return nil
-}
-
-func redactSlackPayload(payload any) any {
-	switch v := payload.(type) {
-	case map[string]any:
-		redacted := make(map[string]any, len(v))
-		for key, value := range v {
-			if strings.EqualFold(key, "token") {
-				redacted[key] = "[redacted]"
-				continue
-			}
-			redacted[key] = redactSlackPayload(value)
-		}
-		return redacted
-	case []any:
-		redacted := make([]any, len(v))
-		for i, value := range v {
-			redacted[i] = redactSlackPayload(value)
-		}
-		return redacted
-	default:
-		return v
-	}
-}
-
-func verifyRawWebhookSignature(secret string, body []byte, headers http.Header) bool {
-	secret = strings.TrimSpace(secret)
-	// If no secret is configured, accept unsigned ingress.
-	if secret == "" {
-		return true
-	}
-	if sig := strings.TrimSpace(headers.Get("X-Hub-Signature-256")); strings.HasPrefix(strings.ToLower(sig), "sha256=") {
-		given := strings.TrimPrefix(sig, "sha256=")
-		mac := hmac.New(sha256.New, []byte(secret))
-		_, _ = mac.Write(body)
-		expected := hex.EncodeToString(mac.Sum(nil))
-		return hmac.Equal([]byte(strings.ToLower(given)), []byte(strings.ToLower(expected)))
-	}
-	if sig := strings.TrimSpace(headers.Get("Stripe-Signature")); sig != "" {
-		timestamp := ""
-		v1Sigs := make([]string, 0, 2)
-		for _, part := range strings.Split(sig, ",") {
-			kv := strings.SplitN(strings.TrimSpace(part), "=", 2)
-			if len(kv) != 2 {
-				continue
-			}
-			switch strings.TrimSpace(kv[0]) {
-			case "t":
-				timestamp = strings.TrimSpace(kv[1])
-			case "v1":
-				v1Sigs = append(v1Sigs, strings.TrimSpace(kv[1]))
-			}
-		}
-		if timestamp == "" || len(v1Sigs) == 0 {
-			return false
-		}
-		mac := hmac.New(sha256.New, []byte(secret))
-		_, _ = mac.Write([]byte(timestamp))
-		_, _ = mac.Write([]byte("."))
-		_, _ = mac.Write(body)
-		expected := hex.EncodeToString(mac.Sum(nil))
-		for _, candidate := range v1Sigs {
-			if hmac.Equal([]byte(strings.ToLower(candidate)), []byte(strings.ToLower(expected))) {
-				return true
-			}
-		}
-		return false
-	}
-	token := strings.TrimSpace(headers.Get("X-Webhook-Token"))
-	if token == "" {
-		auth := strings.TrimSpace(headers.Get("Authorization"))
-		if strings.HasPrefix(strings.ToLower(auth), "bearer ") {
-			token = strings.TrimSpace(auth[7:])
-		}
-	}
-	return hmac.Equal([]byte(token), []byte(secret))
 }
 
 func writeJSON(w http.ResponseWriter, status int, v any) {

--- a/internal/runtime/inbound_postgres_test.go
+++ b/internal/runtime/inbound_postgres_test.go
@@ -22,6 +22,7 @@ import (
 	runtimeingress "github.com/division-sh/swarm/internal/runtime/ingress"
 	runtimemanager "github.com/division-sh/swarm/internal/runtime/manager"
 	"github.com/division-sh/swarm/internal/store"
+	"github.com/division-sh/swarm/internal/store/storetest"
 	"github.com/division-sh/swarm/internal/testutil"
 )
 
@@ -231,6 +232,171 @@ func TestInboundGateway_SlackPausedRuntimePersistsAndReleasesSubscribedDispatch(
 	}
 }
 
+func TestInboundGateway_StripePausedRuntimePersistsAndReleasesSubscribedDispatch(t *testing.T) {
+	_, db, cleanup := testutil.StartPostgres(t)
+	t.Cleanup(cleanup)
+
+	const (
+		runID             = "43000000-0000-0000-0000-000000000001"
+		entityID          = "43000000-0000-0000-0000-000000000002"
+		flowInstance      = "stripe-provider-trigger-instance"
+		entitySlug        = "customer-a"
+		provider          = "stripe"
+		webhookSecret     = "stripe-secret"
+		providerEventID   = "evt_123"
+		agentID           = "stripe-webhook-subscriber"
+		providerEventName = "inbound.stripe"
+	)
+	ctx := runtimecorrelation.WithRunID(context.Background(), runID)
+	pg := &store.PostgresStore{DB: db}
+	seedPostgresInboundGatewayRuntime(t, ctx, db, pg, runID, entityID, flowInstance, entitySlug, provider, webhookSecret, agentID)
+
+	bus, err := runtimebus.NewEventBus(pg)
+	if err != nil {
+		t.Fatalf("NewEventBus: %v", err)
+	}
+	controller := runtimeingress.NewController(pg, bus, runtimeingress.Options{})
+	t.Cleanup(runtimebus.ResumeRuntimeIngress)
+	bus.SetRuntimeIngressDispatchGate(controller)
+
+	eventType := events.EventType(providerEventName)
+	ch := bus.Subscribe(agentID, eventType)
+	defer bus.Unsubscribe(agentID)
+
+	if _, err := controller.Pause(ctx, runtimeingress.TransitionRequest{
+		Reason:       "test_pause",
+		ControlledBy: "test",
+	}); err != nil {
+		t.Fatalf("Pause: %v", err)
+	}
+
+	g := runtimepkg.NewInboundGateway(bus, nil, nil, pg)
+	g.SetRuntimeIngress(controller)
+
+	body := []byte(`{"id":"evt_123","type":"invoice.paid","data":{"object":{"id":"in_123"}}}`)
+	timestamp := strconv.FormatInt(time.Now().UTC().Unix(), 10)
+	req := httptest.NewRequest(http.MethodPost, "/webhooks/customer-a/stripe", strings.NewReader(string(body)))
+	req = req.WithContext(ctx)
+	req.Header.Set("Stripe-Signature", stripeWebhookSignature(webhookSecret, timestamp, body))
+	rec := httptest.NewRecorder()
+	g.Handler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("status = %d, want 202 body=%s", rec.Code, rec.Body.String())
+	}
+	if got := countPostgresInboundMarkers(t, ctx, db, providerEventID, entityID, provider); got != 1 {
+		t.Fatalf("inbound marker rows = %d, want 1", got)
+	}
+	eventID := loadPostgresInboundProviderEventID(t, ctx, db, runID, entityID, providerEventName, providerEventID)
+	if got := countPostgresInboundProviderEvents(t, ctx, db, runID, entityID, providerEventName, providerEventID); got != 1 {
+		t.Fatalf("provider event rows = %d, want 1", got)
+	}
+	if got := loadPostgresInboundProviderEventPayloadField(t, ctx, db, eventID, "provider_event_type"); got != "invoice_paid" {
+		t.Fatalf("provider_event_type = %q, want invoice_paid", got)
+	}
+	requireNoInboundBusEvent(t, ch, "paused Stripe webhook before resume")
+	if got := countPostgresAgentDeliveriesForEvent(t, ctx, db, eventID, agentID); got != 1 {
+		t.Fatalf("agent delivery rows while paused = %d, want 1", got)
+	}
+	if got := loadPostgresAgentDeliveryStatus(t, ctx, db, eventID, agentID); got != "pending" {
+		t.Fatalf("agent delivery status while paused = %q, want pending", got)
+	}
+	if got := countPostgresPipelineReceiptsForEvent(t, ctx, db, eventID); got != 0 {
+		t.Fatalf("pipeline receipts while paused = %d, want 0", got)
+	}
+	if got := countPostgresAgentReceiptsForEvent(t, ctx, db, eventID, agentID); got != 0 {
+		t.Fatalf("agent receipts while paused = %d, want 0", got)
+	}
+
+	resumed, err := controller.Resume(ctx, runtimeingress.TransitionRequest{
+		Reason:       "test_resume",
+		ControlledBy: "test",
+	})
+	if err != nil {
+		t.Fatalf("Resume: %v", err)
+	}
+	if resumed.ReleasedCount != 1 {
+		t.Fatalf("released count = %d, want 1", resumed.ReleasedCount)
+	}
+	got := requireInboundBusEvent(t, ch, "paused Stripe webhook release after resume")
+	if got.ID() != eventID {
+		t.Fatalf("delivered event = %s, want %s", got.ID(), eventID)
+	}
+	if got.Type() != eventType {
+		t.Fatalf("delivered event type = %s, want %s", got.Type(), eventType)
+	}
+	requireNoInboundBusEvent(t, ch, "paused Stripe webhook releases exactly once")
+	if got := countPostgresPipelineReceiptsForEvent(t, ctx, db, eventID); got != 1 {
+		t.Fatalf("pipeline receipts after resume = %d, want 1", got)
+	}
+	if got := countPostgresInboundMarkers(t, ctx, db, providerEventID, entityID, provider); got != 1 {
+		t.Fatalf("inbound marker rows after resume = %d, want 1", got)
+	}
+	if got := countPostgresInboundProviderEvents(t, ctx, db, runID, entityID, providerEventName, providerEventID); got != 1 {
+		t.Fatalf("provider event rows after resume = %d, want 1", got)
+	}
+}
+
+func TestInboundGateway_StripeSQLitePersistsConfiguredManifestDelivery(t *testing.T) {
+	const (
+		runID             = "44000000-0000-0000-0000-000000000001"
+		entityID          = "44000000-0000-0000-0000-000000000002"
+		flowInstance      = "stripe-sqlite-provider-trigger-instance"
+		entitySlug        = "customer-a"
+		provider          = "stripe"
+		webhookSecret     = "stripe-secret"
+		providerEventID   = "evt_456"
+		agentID           = "stripe-sqlite-webhook-subscriber"
+		providerEventName = "inbound.stripe"
+	)
+	ctx := runtimecorrelation.WithRunID(context.Background(), runID)
+	sqliteStore := storetest.StartSQLiteRuntimeStoreWithContext(t, ctx)
+	seedSQLiteInboundGatewayRuntime(t, ctx, sqliteStore, runID, entityID, flowInstance, entitySlug, provider, webhookSecret, agentID)
+
+	bus, err := runtimebus.NewEventBus(sqliteStore)
+	if err != nil {
+		t.Fatalf("NewEventBus: %v", err)
+	}
+	ch := bus.Subscribe(agentID, events.EventType(providerEventName))
+	defer bus.Unsubscribe(agentID)
+
+	g := runtimepkg.NewInboundGateway(bus, nil, nil, sqliteStore)
+
+	body := []byte(`{"id":"evt_456","type":"customer.created","data":{"object":{"id":"cus_123"}}}`)
+	timestamp := strconv.FormatInt(time.Now().UTC().Unix(), 10)
+	req := httptest.NewRequest(http.MethodPost, "/webhooks/customer-a/stripe", strings.NewReader(string(body)))
+	req = req.WithContext(ctx)
+	req.Header.Set("Stripe-Signature", stripeWebhookSignature(webhookSecret, timestamp, body))
+	rec := httptest.NewRecorder()
+	g.Handler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("status = %d, want 202 body=%s", rec.Code, rec.Body.String())
+	}
+	if got := countSQLiteInboundMarkers(t, ctx, sqliteStore, providerEventID, entityID, provider); got != 1 {
+		t.Fatalf("inbound marker rows = %d, want 1", got)
+	}
+	eventID := loadSQLiteInboundProviderEventID(t, ctx, sqliteStore, runID, entityID, providerEventName, providerEventID)
+	if got := countSQLiteInboundProviderEvents(t, ctx, sqliteStore, runID, entityID, providerEventName, providerEventID); got != 1 {
+		t.Fatalf("provider event rows = %d, want 1", got)
+	}
+	if got := loadSQLiteInboundProviderEventPayloadField(t, ctx, sqliteStore, eventID, "provider_event_type"); got != "customer_created" {
+		t.Fatalf("provider_event_type = %q, want customer_created", got)
+	}
+	if got := countSQLiteAgentDeliveriesForEvent(t, ctx, sqliteStore, eventID, agentID); got != 1 {
+		t.Fatalf("agent delivery rows = %d, want 1", got)
+	}
+	select {
+	case got := <-ch:
+		if got.ID() != eventID || got.Type() != events.EventType(providerEventName) {
+			t.Fatalf("delivered event = %s/%s, want %s/%s", got.ID(), got.Type(), eventID, providerEventName)
+		}
+	default:
+		// The Stripe manifest uses durable_before_dispatch; this proof is about
+		// durable persisted evidence, not immediate post-ack handler scheduling.
+	}
+}
+
 func seedPostgresInboundGatewayRuntime(
 	t *testing.T,
 	ctx context.Context,
@@ -298,6 +464,69 @@ func seedPostgresInboundGatewayRuntime(
 	}
 }
 
+func seedSQLiteInboundGatewayRuntime(
+	t *testing.T,
+	ctx context.Context,
+	sqliteStore *store.SQLiteRuntimeStore,
+	runID string,
+	entityID string,
+	flowInstance string,
+	entitySlug string,
+	provider string,
+	webhookSecret string,
+	agentID string,
+) {
+	t.Helper()
+	now := time.Now().UTC()
+	if _, err := sqliteStore.DB.ExecContext(ctx, `
+		INSERT INTO runs (run_id, status, started_at)
+		VALUES (?, 'running', ?)
+	`, runID, now); err != nil {
+		t.Fatalf("seed sqlite run: %v", err)
+	}
+	configBytes, err := json.Marshal(map[string]any{
+		"secrets": map[string]any{
+			"webhook_signing": map[string]string{
+				provider: webhookSecret,
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("marshal sqlite flow config: %v", err)
+	}
+	if _, err := sqliteStore.DB.ExecContext(ctx, `
+		INSERT INTO flow_instances (instance_id, flow_template, mode, config, status, created_at)
+		VALUES (?, 'test', 'static', ?, 'active', ?)
+	`, flowInstance, string(configBytes), now); err != nil {
+		t.Fatalf("seed sqlite flow instance: %v", err)
+	}
+	if _, err := sqliteStore.DB.ExecContext(ctx, `
+		INSERT INTO entity_state (
+			run_id, entity_id, flow_instance, entity_type, slug, name, current_state,
+			gates, fields, accumulator, revision, entered_state_at, created_at, updated_at
+		) VALUES (?, ?, ?, 'default', ?, 'Customer A', 'active',
+			'{}', '{}', '{}', 1, ?, ?, ?)
+	`, runID, entityID, flowInstance, entitySlug, now, now, now); err != nil {
+		t.Fatalf("seed sqlite entity state: %v", err)
+	}
+	if err := sqliteStore.UpsertAgent(ctx, runtimemanager.PersistedAgent{
+		Config: runtimeactors.AgentConfig{
+			ID:            agentID,
+			Role:          "observer",
+			Mode:          "global",
+			Type:          "stub",
+			Model:         "regular",
+			Config:        []byte(`{}`),
+			Subscriptions: []string{"inbound.stripe"},
+		},
+		Status:    "active",
+		HiredBy:   "test",
+		StartedAt: now,
+	}); err != nil {
+		t.Fatalf("UpsertAgent(%s): %v", agentID, err)
+	}
+}
+
 func loadPostgresInboundProviderEventID(t *testing.T, ctx context.Context, db *sql.DB, runID string, entityID string, eventName string, providerEventID string) string {
 	t.Helper()
 	var eventID string
@@ -316,6 +545,19 @@ func loadPostgresInboundProviderEventID(t *testing.T, ctx context.Context, db *s
 	return eventID
 }
 
+func loadPostgresInboundProviderEventPayloadField(t *testing.T, ctx context.Context, db *sql.DB, eventID string, field string) string {
+	t.Helper()
+	var value string
+	if err := db.QueryRowContext(ctx, `
+		SELECT payload->>$2
+		FROM events
+		WHERE event_id = $1::uuid
+	`, eventID, field).Scan(&value); err != nil {
+		t.Fatalf("load postgres inbound provider payload field %s: %v", field, err)
+	}
+	return value
+}
+
 func countPostgresInboundProviderEvents(t *testing.T, ctx context.Context, db *sql.DB, runID string, entityID string, eventName string, providerEventID string) int {
 	t.Helper()
 	var count int
@@ -328,6 +570,84 @@ func countPostgresInboundProviderEvents(t *testing.T, ctx context.Context, db *s
 		  AND payload->>'provider_event_id' = $4
 	`, runID, entityID, eventName, providerEventID).Scan(&count); err != nil {
 		t.Fatalf("count inbound provider events: %v", err)
+	}
+	return count
+}
+
+func loadSQLiteInboundProviderEventID(t *testing.T, ctx context.Context, sqliteStore *store.SQLiteRuntimeStore, runID string, entityID string, eventName string, providerEventID string) string {
+	t.Helper()
+	var eventID string
+	if err := sqliteStore.DB.QueryRowContext(ctx, `
+		SELECT event_id
+		FROM events
+		WHERE run_id = ?
+		  AND entity_id = ?
+		  AND event_name = ?
+		  AND json_extract(payload, '$.provider_event_id') = ?
+		ORDER BY created_at DESC
+		LIMIT 1
+	`, runID, entityID, eventName, providerEventID).Scan(&eventID); err != nil {
+		t.Fatalf("load sqlite inbound provider event id: %v", err)
+	}
+	return eventID
+}
+
+func countSQLiteInboundProviderEvents(t *testing.T, ctx context.Context, sqliteStore *store.SQLiteRuntimeStore, runID string, entityID string, eventName string, providerEventID string) int {
+	t.Helper()
+	var count int
+	if err := sqliteStore.DB.QueryRowContext(ctx, `
+		SELECT COUNT(*)
+		FROM events
+		WHERE run_id = ?
+		  AND entity_id = ?
+		  AND event_name = ?
+		  AND json_extract(payload, '$.provider_event_id') = ?
+	`, runID, entityID, eventName, providerEventID).Scan(&count); err != nil {
+		t.Fatalf("count sqlite inbound provider events: %v", err)
+	}
+	return count
+}
+
+func loadSQLiteInboundProviderEventPayloadField(t *testing.T, ctx context.Context, sqliteStore *store.SQLiteRuntimeStore, eventID string, field string) string {
+	t.Helper()
+	var value string
+	if err := sqliteStore.DB.QueryRowContext(ctx, `
+		SELECT json_extract(payload, ?)
+		FROM events
+		WHERE event_id = ?
+	`, "$."+field, eventID).Scan(&value); err != nil {
+		t.Fatalf("load sqlite inbound provider payload field %s: %v", field, err)
+	}
+	return value
+}
+
+func countSQLiteInboundMarkers(t *testing.T, ctx context.Context, sqliteStore *store.SQLiteRuntimeStore, providerEventID string, entityID string, provider string) int {
+	t.Helper()
+	var count int
+	if err := sqliteStore.DB.QueryRowContext(ctx, `
+		SELECT COUNT(*)
+		FROM events
+		WHERE event_name = 'platform.inbound_recorded'
+		  AND entity_id = ?
+		  AND json_extract(payload, '$.provider_event_id') = ?
+		  AND json_extract(payload, '$.provider') = ?
+	`, entityID, providerEventID, provider).Scan(&count); err != nil {
+		t.Fatalf("count sqlite inbound marker events: %v", err)
+	}
+	return count
+}
+
+func countSQLiteAgentDeliveriesForEvent(t *testing.T, ctx context.Context, sqliteStore *store.SQLiteRuntimeStore, eventID string, agentID string) int {
+	t.Helper()
+	var count int
+	if err := sqliteStore.DB.QueryRowContext(ctx, `
+		SELECT COUNT(*)
+		FROM event_deliveries
+		WHERE event_id = ?
+		  AND subscriber_type = 'agent'
+		  AND subscriber_id = ?
+	`, eventID, agentID).Scan(&count); err != nil {
+		t.Fatalf("count sqlite agent deliveries for %s: %v", eventID, err)
 	}
 	return count
 }
@@ -438,4 +758,10 @@ func slackWebhookSignature(secret string, timestamp string, body []byte) string 
 	mac := hmac.New(sha256.New, []byte(secret))
 	_, _ = mac.Write([]byte("v0:" + timestamp + ":" + string(body)))
 	return "v0=" + hex.EncodeToString(mac.Sum(nil))
+}
+
+func stripeWebhookSignature(secret string, timestamp string, body []byte) string {
+	mac := hmac.New(sha256.New, []byte(secret))
+	_, _ = mac.Write([]byte(timestamp + "." + string(body)))
+	return "t=" + timestamp + ",v1=" + hex.EncodeToString(mac.Sum(nil))
 }

--- a/internal/runtime/inbound_test.go
+++ b/internal/runtime/inbound_test.go
@@ -718,6 +718,274 @@ func TestInboundGateway_SlackDuplicateEventDoesNotPublishAgain(t *testing.T) {
 	}
 }
 
+func TestInboundGateway_StripeManifestOwnsSignatureReplayIDTypeAndAck(t *testing.T) {
+	eventStore := &capturingInboundEventStore{}
+	started := make(chan struct{}, 1)
+	release := make(chan struct{})
+	var releaseOnce sync.Once
+	releaseDispatch := func() {
+		releaseOnce.Do(func() {
+			close(release)
+		})
+	}
+	t.Cleanup(releaseDispatch)
+	bus, err := runtimebus.NewEventBusWithOptions(eventStore, runtimebus.EventBusOptions{
+		Interceptors: []runtimebus.EventInterceptor{
+			blockingInboundInterceptor{started: started, release: release},
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewEventBusWithOptions: %v", err)
+	}
+	store := &recordingInboundStore{
+		target: InboundTarget{
+			EntityID:      "3fd8fc37-6d02-4d50-8bb7-14c6cb0fed0a",
+			EntitySlug:    "customer-a",
+			WebhookSecret: "stripe-secret",
+		},
+		inserted: true,
+	}
+	g := NewInboundGateway(bus, nil, nil, store)
+
+	body := []byte(`{"id":"evt_123","type":"invoice.paid","data":{"object":{"id":"in_123"}}}`)
+	timestamp := strconv.FormatInt(time.Now().UTC().Unix(), 10)
+	req := httptest.NewRequest(http.MethodPost, "/webhooks/customer-a/stripe", strings.NewReader(string(body)))
+	req.Header.Set("Stripe-Signature", stripeWebhookSignature("stripe-secret", timestamp, body))
+	responseDone := make(chan *httptest.ResponseRecorder, 1)
+	go func() {
+		rec := httptest.NewRecorder()
+		g.Handler().ServeHTTP(rec, req)
+		responseDone <- rec
+	}()
+
+	select {
+	case <-started:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Stripe callback post-commit dispatch did not start")
+	}
+	select {
+	case rec := <-responseDone:
+		if rec.Code != http.StatusAccepted {
+			t.Fatalf("status = %d, want 202 body=%s", rec.Code, rec.Body.String())
+		}
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("Stripe callback response waited for post-commit dispatch completion")
+	}
+	if !store.recorded {
+		t.Fatal("expected Stripe callback to record inbound marker")
+	}
+	if store.providerEventID != "evt_123" {
+		t.Fatalf("providerEventID = %q, want evt_123", store.providerEventID)
+	}
+	if len(eventStore.events) != 1 {
+		t.Fatalf("published events = %d, want 1 before dispatch release", len(eventStore.events))
+	}
+	evt := eventStore.events[0]
+	if evt.Type() != events.EventType("inbound.stripe") {
+		t.Fatalf("event type = %q, want inbound.stripe", evt.Type())
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(evt.Payload(), &payload); err != nil {
+		t.Fatalf("unmarshal payload: %v", err)
+	}
+	if payload["provider_event_id"] != "evt_123" || payload["provider_event_type"] != "invoice_paid" || payload["provider"] != "stripe" {
+		t.Fatalf("payload = %+v, want Stripe delivery identity", payload)
+	}
+	if strings.Contains(string(evt.Payload()), "stripe-secret") {
+		t.Fatal("Stripe signing secret leaked into event payload")
+	}
+
+	releaseDispatch()
+	waitCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := bus.WaitForQuiescence(waitCtx); err != nil {
+		t.Fatalf("WaitForQuiescence after dispatch release: %v", err)
+	}
+}
+
+func TestInboundGateway_StripeRejectsInvalidInputsBeforeMarkerAndPublish(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		body       []byte
+		configure  func(*http.Request, []byte)
+		wantStatus int
+	}{
+		{
+			name:       "missing signature",
+			body:       []byte(`{"id":"evt_123","type":"invoice.paid"}`),
+			configure:  func(*http.Request, []byte) {},
+			wantStatus: http.StatusUnauthorized,
+		},
+		{
+			name: "malformed signature params",
+			body: []byte(`{"id":"evt_123","type":"invoice.paid"}`),
+			configure: func(req *http.Request, body []byte) {
+				timestamp := strconv.FormatInt(time.Now().UTC().Unix(), 10)
+				req.Header.Set("Stripe-Signature", "t="+timestamp+",v0="+stripeSignatureHex("stripe-secret", timestamp, body))
+			},
+			wantStatus: http.StatusUnauthorized,
+		},
+		{
+			name: "stale timestamp",
+			body: []byte(`{"id":"evt_123","type":"invoice.paid"}`),
+			configure: func(req *http.Request, body []byte) {
+				timestamp := strconv.FormatInt(time.Now().UTC().Add(-10*time.Minute).Unix(), 10)
+				req.Header.Set("Stripe-Signature", stripeWebhookSignature("stripe-secret", timestamp, body))
+			},
+			wantStatus: http.StatusUnauthorized,
+		},
+		{
+			name: "missing event id",
+			body: []byte(`{"type":"invoice.paid"}`),
+			configure: func(req *http.Request, body []byte) {
+				timestamp := strconv.FormatInt(time.Now().UTC().Unix(), 10)
+				req.Header.Set("Stripe-Signature", stripeWebhookSignature("stripe-secret", timestamp, body))
+			},
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name: "missing event type",
+			body: []byte(`{"id":"evt_123"}`),
+			configure: func(req *http.Request, body []byte) {
+				timestamp := strconv.FormatInt(time.Now().UTC().Unix(), 10)
+				req.Header.Set("Stripe-Signature", stripeWebhookSignature("stripe-secret", timestamp, body))
+			},
+			wantStatus: http.StatusBadRequest,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			eventStore := &capturingInboundEventStore{}
+			bus, err := runtimebus.NewEventBus(eventStore)
+			if err != nil {
+				t.Fatalf("NewEventBus: %v", err)
+			}
+			store := &recordingInboundStore{
+				target: InboundTarget{
+					EntityID:      "3fd8fc37-6d02-4d50-8bb7-14c6cb0fed0a",
+					EntitySlug:    "customer-a",
+					WebhookSecret: "stripe-secret",
+				},
+				inserted: true,
+			}
+			g := NewInboundGateway(bus, nil, nil, store)
+
+			req := httptest.NewRequest(http.MethodPost, "/webhooks/customer-a/stripe", strings.NewReader(string(tc.body)))
+			tc.configure(req, tc.body)
+			rec := httptest.NewRecorder()
+			g.Handler().ServeHTTP(rec, req)
+
+			if rec.Code != tc.wantStatus {
+				t.Fatalf("status = %d, want %d body=%s", rec.Code, tc.wantStatus, rec.Body.String())
+			}
+			if store.recorded {
+				t.Fatal("invalid Stripe request recorded inbound marker")
+			}
+			if len(eventStore.events) != 0 {
+				t.Fatalf("published events = %d, want 0", len(eventStore.events))
+			}
+		})
+	}
+}
+
+func TestInboundGateway_StripeDuplicateEventDoesNotPublishAgain(t *testing.T) {
+	eventStore := &capturingInboundEventStore{}
+	bus, err := runtimebus.NewEventBus(eventStore)
+	if err != nil {
+		t.Fatalf("NewEventBus: %v", err)
+	}
+	store := &recordingInboundStore{
+		target: InboundTarget{
+			EntityID:      "3fd8fc37-6d02-4d50-8bb7-14c6cb0fed0a",
+			EntitySlug:    "customer-a",
+			WebhookSecret: "stripe-secret",
+		},
+		inserted: false,
+	}
+	g := NewInboundGateway(bus, nil, nil, store)
+
+	body := []byte(`{"id":"evt_123","type":"invoice.paid"}`)
+	timestamp := strconv.FormatInt(time.Now().UTC().Unix(), 10)
+	req := httptest.NewRequest(http.MethodPost, "/webhooks/customer-a/stripe", strings.NewReader(string(body)))
+	req.Header.Set("Stripe-Signature", stripeWebhookSignature("stripe-secret", timestamp, body))
+	rec := httptest.NewRecorder()
+	g.Handler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 body=%s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), `"status":"duplicate"`) {
+		t.Fatalf("duplicate response = %s", rec.Body.String())
+	}
+	if len(eventStore.events) != 0 {
+		t.Fatalf("published events = %d, want 0", len(eventStore.events))
+	}
+}
+
+func TestInboundGateway_RawFallbackDoesNotInterpretStripeSignature(t *testing.T) {
+	eventStore := &capturingInboundEventStore{}
+	bus, err := runtimebus.NewEventBus(eventStore)
+	if err != nil {
+		t.Fatalf("NewEventBus: %v", err)
+	}
+	store := &recordingInboundStore{
+		target: InboundTarget{
+			EntityID:      "3fd8fc37-6d02-4d50-8bb7-14c6cb0fed0a",
+			EntitySlug:    "customer-a",
+			WebhookSecret: "raw-secret",
+		},
+		inserted: true,
+	}
+	g := NewInboundGateway(bus, nil, nil, store)
+
+	body := []byte(`{"id":"evt_123","type":"invoice.paid"}`)
+	timestamp := strconv.FormatInt(time.Now().UTC().Unix(), 10)
+	req := httptest.NewRequest(http.MethodPost, "/webhooks/customer-a/custom", strings.NewReader(string(body)))
+	req.Header.Set("Stripe-Signature", stripeWebhookSignature("raw-secret", timestamp, body))
+	rec := httptest.NewRecorder()
+	g.Handler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401 body=%s", rec.Code, rec.Body.String())
+	}
+	if store.recorded {
+		t.Fatal("raw fallback accepted Stripe-Signature and recorded inbound marker")
+	}
+	if len(eventStore.events) != 0 {
+		t.Fatalf("published events = %d, want 0", len(eventStore.events))
+	}
+}
+
+func TestInboundGateway_RejectsOversizedBodyBeforeMarkerAndPublish(t *testing.T) {
+	eventStore := &capturingInboundEventStore{}
+	bus, err := runtimebus.NewEventBus(eventStore)
+	if err != nil {
+		t.Fatalf("NewEventBus: %v", err)
+	}
+	store := &recordingInboundStore{
+		target: InboundTarget{
+			EntityID:      "3fd8fc37-6d02-4d50-8bb7-14c6cb0fed0a",
+			EntitySlug:    "customer-a",
+			WebhookSecret: "github-secret",
+		},
+		inserted: true,
+	}
+	g := NewInboundGateway(bus, nil, nil, store)
+
+	req := httptest.NewRequest(http.MethodPost, "/webhooks/customer-a/github", strings.NewReader(strings.Repeat("a", inboundWebhookMaxBodyBytes+1)))
+	rec := httptest.NewRecorder()
+	g.Handler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("status = %d, want 413 body=%s", rec.Code, rec.Body.String())
+	}
+	if store.recorded {
+		t.Fatal("oversized webhook body recorded inbound marker")
+	}
+	if len(eventStore.events) != 0 {
+		t.Fatalf("published events = %d, want 0", len(eventStore.events))
+	}
+}
+
 func githubWebhookSignature(secret string, body []byte) string {
 	mac := hmac.New(sha256.New, []byte(secret))
 	_, _ = mac.Write(body)
@@ -735,6 +1003,16 @@ func slackWebhookSignature(secret string, timestamp string, body []byte) string 
 	mac := hmac.New(sha256.New, []byte(secret))
 	_, _ = mac.Write([]byte("v0:" + timestamp + ":" + string(body)))
 	return "v0=" + hex.EncodeToString(mac.Sum(nil))
+}
+
+func stripeWebhookSignature(secret string, timestamp string, body []byte) string {
+	return "t=" + timestamp + ",v1=" + stripeSignatureHex(secret, timestamp, body)
+}
+
+func stripeSignatureHex(secret string, timestamp string, body []byte) string {
+	mac := hmac.New(sha256.New, []byte(secret))
+	_, _ = mac.Write([]byte(timestamp + "." + string(body)))
+	return hex.EncodeToString(mac.Sum(nil))
 }
 
 type blockingInboundInterceptor struct {

--- a/internal/runtime/inbound_test.go
+++ b/internal/runtime/inbound_test.go
@@ -835,6 +835,15 @@ func TestInboundGateway_StripeRejectsInvalidInputsBeforeMarkerAndPublish(t *test
 			wantStatus: http.StatusUnauthorized,
 		},
 		{
+			name: "duplicate timestamp params with otherwise valid signature",
+			body: []byte(`{"id":"evt_123","type":"invoice.paid"}`),
+			configure: func(req *http.Request, body []byte) {
+				timestamp := strconv.FormatInt(time.Now().UTC().Unix(), 10)
+				req.Header.Set("Stripe-Signature", "t="+timestamp+",t="+timestamp+",v1="+stripeSignatureHex("stripe-secret", timestamp, body))
+			},
+			wantStatus: http.StatusUnauthorized,
+		},
+		{
 			name: "stale timestamp",
 			body: []byte(`{"id":"evt_123","type":"invoice.paid"}`),
 			configure: func(req *http.Request, body []byte) {

--- a/internal/runtime/inbound_test.go
+++ b/internal/runtime/inbound_test.go
@@ -817,11 +817,20 @@ func TestInboundGateway_StripeRejectsInvalidInputsBeforeMarkerAndPublish(t *test
 			wantStatus: http.StatusUnauthorized,
 		},
 		{
-			name: "malformed signature params",
+			name: "wrong signature version param",
 			body: []byte(`{"id":"evt_123","type":"invoice.paid"}`),
 			configure: func(req *http.Request, body []byte) {
 				timestamp := strconv.FormatInt(time.Now().UTC().Unix(), 10)
 				req.Header.Set("Stripe-Signature", "t="+timestamp+",v0="+stripeSignatureHex("stripe-secret", timestamp, body))
+			},
+			wantStatus: http.StatusUnauthorized,
+		},
+		{
+			name: "malformed signature component with otherwise valid signature",
+			body: []byte(`{"id":"evt_123","type":"invoice.paid"}`),
+			configure: func(req *http.Request, body []byte) {
+				timestamp := strconv.FormatInt(time.Now().UTC().Unix(), 10)
+				req.Header.Set("Stripe-Signature", "t="+timestamp+",broken,v1="+stripeSignatureHex("stripe-secret", timestamp, body))
 			},
 			wantStatus: http.StatusUnauthorized,
 		},
@@ -844,8 +853,35 @@ func TestInboundGateway_StripeRejectsInvalidInputsBeforeMarkerAndPublish(t *test
 			wantStatus: http.StatusBadRequest,
 		},
 		{
+			name: "object event id",
+			body: []byte(`{"id":{"nested":"evt_123"},"type":"invoice.paid"}`),
+			configure: func(req *http.Request, body []byte) {
+				timestamp := strconv.FormatInt(time.Now().UTC().Unix(), 10)
+				req.Header.Set("Stripe-Signature", stripeWebhookSignature("stripe-secret", timestamp, body))
+			},
+			wantStatus: http.StatusBadRequest,
+		},
+		{
 			name: "missing event type",
 			body: []byte(`{"id":"evt_123"}`),
+			configure: func(req *http.Request, body []byte) {
+				timestamp := strconv.FormatInt(time.Now().UTC().Unix(), 10)
+				req.Header.Set("Stripe-Signature", stripeWebhookSignature("stripe-secret", timestamp, body))
+			},
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name: "bool event type",
+			body: []byte(`{"id":"evt_123","type":true}`),
+			configure: func(req *http.Request, body []byte) {
+				timestamp := strconv.FormatInt(time.Now().UTC().Unix(), 10)
+				req.Header.Set("Stripe-Signature", stripeWebhookSignature("stripe-secret", timestamp, body))
+			},
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name: "list event type",
+			body: []byte(`{"id":"evt_123","type":["invoice.paid"]}`),
 			configure: func(req *http.Request, body []byte) {
 				timestamp := strconv.FormatInt(time.Now().UTC().Unix(), 10)
 				req.Header.Set("Stripe-Signature", stripeWebhookSignature("stripe-secret", timestamp, body))

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -5637,13 +5637,15 @@ tool_model:
       surfaces. Supported readback surfaces return only redacted metadata and failure evidence.
   provider_trigger_adapters:
     description: >
-      Source authority for first-class provider webhook triggers on top of the existing `inbound.webhook` gateway. It does
-      not replace the generic gateway; it makes provider-specific callback binding, signing, delivery identity, event
-      mapping, dedupe, and redacted readback semantics explicit for configured providers.
+      Source authority for first-class provider webhook triggers on top of the existing `inbound.webhook` gateway. The
+      provider-trigger manifest interpreter is the configured-provider semantic owner. It does not replace the generic
+      gateway; it makes provider-specific callback binding, signing, delivery identity, event mapping, dedupe,
+      acknowledgement timing, and redacted readback semantics explicit for configured providers.
     scope:
     - manual/declarative webhook registration for configured provider triggers
     - served `/webhooks/{entity}/{provider}` route mounted on the supported API listener
     - selected runtime store wiring through `runtime.Stores.InboundStore`
+    - static built-in provider-trigger manifest loading for selected first-class providers
     - provider-specific signature policy and signing-secret lookup
     - provider delivery-id extraction and dedupe-key authority
     - provider event-type extraction and canonical Swarm event mapping
@@ -5657,16 +5659,43 @@ tool_model:
     existing_gateway_owner: >
       `internal/runtime/inbound.go` remains the generic HTTP ingress executor for `/webhooks/{entity}/{provider}`. It
       consumes `runtime_ingress.queueable_ingress.inbound.webhook`, delegates configured-provider interpretation to the
-      provider adapter, persists the inbound dedupe marker before publish for delivery callbacks, and publishes the
-      normalized root ingress event returned by the provider adapter. Provider adapters may also return an authenticated
-      response-only result when the provider protocol requires a challenge response that is not a delivery.
+      provider-trigger manifest interpreter, persists the inbound dedupe marker before publish for delivery callbacks, and
+      publishes the normalized root ingress event returned by the manifest interpreter. Provider manifests may also return
+      an authenticated response-only result when the provider protocol requires a challenge response that is not a
+      delivery.
+    manifest_interpreter_owner: >
+      `internal/providertriggers` is the configured-provider manifest interpreter and canonical owner for first-class
+      provider trigger admission. Runtime-local Go implementations for selected configured providers are non-authoritative.
+      A selected configured provider must consume a provider-trigger manifest for signing, replay checks, delivery-id
+      extraction, event-type extraction, event naming, acknowledgement timing, and redaction.
+    manifest_vocabulary:
+      provider: normalized provider token matched from `/webhooks/{entity}/{provider}`
+      payload_object_required: fail closed when the decoded request payload is not a JSON object
+      secret.required: require a configured signing secret before accepting the provider callback
+      signature: >
+        HMAC-SHA256 signature verification over a manifest-selected signed payload. Supported signed payloads are
+        `raw_body`, `slack_v0`, and `timestamp_dot_raw_body`. The interpreter supports fixed signature prefixes, structured
+        comma-separated signature parameters, timestamp extraction from headers or parameters, replay tolerance windows, and
+        constant-time comparison against every configured signature candidate.
+      challenge: >
+        Authenticated response-only callback handling. A matched challenge branch must not persist an inbound dedupe marker
+        and must not publish a Swarm event.
+      delivery_condition: JSON object condition that must match before a provider delivery is accepted.
+      delivery_id: authoritative provider delivery id source for dedupe marker input.
+      event_type: authoritative provider event type source for normalized provider_event_type payload metadata.
+      event_name: literal or `{event_type}` template for the emitted Swarm event name.
+      ack.mode: >
+        `after_publish` returns after normal publish completion. `durable_before_dispatch` returns after the inbound marker,
+        event row, recipient manifest, and subscribed replay scope are durably persisted or queued, without waiting for
+        post-commit pipeline dispatch, system-node execution, or agent handling.
+      redact_keys: payload keys that must be replaced before publication or readback.
     secret_binding: >
       The first-slice signing-secret binding is `flow_instances.config.secrets.webhook_signing.<provider>`, where
       `<provider>` is the normalized provider token. Secret values are never returned by webhook responses or readback
       surfaces. Production deployments may replace the backing config storage with an external vault reference while
       preserving the same semantic binding.
-    first_provider:
-      provider: github
+    configured_provider_manifests:
+    - provider: github
       signature: >
         GitHub webhook deliveries require a configured signing secret and a valid `X-Hub-Signature-256` HMAC-SHA256
         signature over the raw request body. Missing signing secret, missing signature, or invalid signature fails before
@@ -5677,8 +5706,7 @@ tool_model:
       event_type: >
         `X-GitHub-Event` is the authoritative provider event type. The canonical emitted event name is
         `inbound.github.<normalized_event_type>` and the payload includes provider, provider_event_id, event_type,
-        original payload, redacted headers, and received_at.
-    configured_provider_children:
+        provider_event_type, provider_delivery_id, original payload, redacted headers, and received_at.
     - provider: slack
       issue: "#1691"
       signature: >
@@ -5710,10 +5738,34 @@ tool_model:
         Slack signing secrets and deprecated verification tokens are not returned by webhook responses, logs, persisted
         marker readback, or published provider payloads. Deprecated Slack `token` fields are not accepted as primary proof
         of request authenticity.
+    - provider: stripe
+      issue: "#1704"
+      signature: >
+        Stripe webhook deliveries require a configured signing secret and valid `Stripe-Signature` HMAC-SHA256 signature.
+        The manifest interpreter MUST parse comma-separated signature parameters, require `t` and at least one `v1`
+        candidate, compute the signed payload as `{t}.{raw_body}`, and compare each `v1` candidate in constant time.
+        Missing signing secret, missing signature, missing `t`, missing `v1`, malformed timestamp, invalid signature, and
+        stale timestamp fail before dedupe marker persistence and before event publish.
+      replay_window: >
+        The `t` signature parameter MUST parse as Unix seconds and be within five minutes of runtime receipt time. Requests
+        outside that window are rejected as replay-risk traffic before any marker or event side effect.
+      delivery_id: >
+        Stripe payload `id` is the authoritative provider delivery id and dedupe-key input. Missing `id` fails before
+        dedupe marker persistence.
+      acknowledgement: >
+        Accepted Stripe deliveries return success after the inbound dedupe marker, canonical event record, recipient
+        manifest, and subscribed replay scope are durably persisted or dispatch-queued. The HTTP acknowledgement MUST NOT
+        wait for post-commit pipeline dispatch, system-node handler execution, or agent delivery completion.
+      event_type: >
+        Stripe payload `type` is the authoritative provider event type and is emitted in payload metadata as normalized
+        `provider_event_type`. The canonical emitted event name is `inbound.stripe`, not `inbound.stripe.<event_type>`.
+        Missing `type` fails before dedupe marker persistence.
     raw_webhook_mode: >
       Unknown providers may continue through the raw generic webhook mode, but that path is a different semantic concept and
-      does not prove provider-trigger adapter closure. Configured providers MUST consume their adapter owner rather than
-      generic signature, delivery-id, event-type, or `inbound.{provider}` mapping fallbacks.
+      does not prove provider-trigger adapter closure. Configured providers MUST consume their manifest interpreter owner
+      rather than generic signature, delivery-id, event-type, acknowledgement, or `inbound.{provider}` mapping fallbacks.
+      Raw webhook mode MUST NOT interpret `Stripe-Signature`; Stripe-signature semantics belong only to the configured
+      Stripe provider manifest.
   custom_tool_schema:
     description: Accepted fields for tool definitions in tools.yaml. This is the union of fields across all implementation
       classes.

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -5684,11 +5684,20 @@ tool_model:
       delivery_id: authoritative provider delivery id source for dedupe marker input.
       event_type: authoritative provider event type source for normalized provider_event_type payload metadata.
       event_name: literal or `{event_type}` template for the emitted Swarm event name.
+      event_name_policy: >
+        New provider-trigger manifests MUST use a literal Swarm event name and carry the provider-specific event kind in
+        `provider_event_type`. The `{event_type}` template form is grandfathered only for the existing GitHub and Slack
+        manifests because live subscriptions already consume `inbound.github.<event_type>` and
+        `inbound.slack.<event_type>`. Any additional dynamic event-name template requires an explicit spec/gate migration
+        decision.
       ack.mode: >
         `after_publish` returns after normal publish completion. `durable_before_dispatch` returns after the inbound marker,
         event row, recipient manifest, and subscribed replay scope are durably persisted or queued, without waiting for
         post-commit pipeline dispatch, system-node execution, or agent handling.
       redact_keys: payload keys that must be replaced before publication or readback.
+      signed_payload_recipe_discipline: >
+        Signed-payload recipes are shared scheme families, not provider-specific escape hatches. New recipes should be added
+        only when they generalize a provider family; recipe count should grow sublinearly as provider coverage expands.
     secret_binding: >
       The first-slice signing-secret binding is `flow_instances.config.secrets.webhook_signing.<provider>`, where
       `<provider>` is the normalized provider token. Secret values are never returned by webhook responses or readback


### PR DESCRIPTION
## Summary

- Adds `internal/providertriggers` as the configured-provider manifest interpreter for first-class inbound provider triggers.
- Re-expresses GitHub and Slack as built-in manifests, adds Stripe as a built-in manifest, and routes `InboundGateway` configured-provider admission through that owner.
- Removes runtime-local GitHub/Slack adapter ownership and removes raw `Stripe-Signature` interpretation from generic raw webhook fallback.
- Updates `platform-spec.yaml` provider-trigger authority to define manifest vocabulary, GitHub/Slack/Stripe semantics, Stripe `inbound.stripe` event naming, ack timing, and raw fallback boundaries.

Closes #1704
Part of #1651

## Governing Refs / Context

- `platform-spec.yaml` `runtime_capabilities.provider_trigger_adapters`
- `platform-spec.yaml` `runtime_ingress.queueable_ingress.inbound.webhook`
- #1704 Pre-Implementation Coverage Audit and approved gate comment
- #1651 parent external integration source authority context

## Semantic Migration

- New canonical owner: `internal/providertriggers` manifest interpreter plus built-in provider manifests under `internal/providertriggers/manifests/`.
- Old producer/reader/writer path now invalid: runtime-local GitHub/Slack provider adapter structs/functions in `internal/runtime/inbound.go`.
- Raw Stripe fallback now invalid: generic raw webhook signature verification no longer interprets `Stripe-Signature`.
- Production paths checked: served `/webhooks/{entity}/{provider}` for GitHub, Slack URL verification, Slack event callback, Stripe valid/invalid/stale/malformed/missing-id/missing-type/duplicate, raw custom provider with Stripe signature, SQLite store path, Postgres paused-runtime path, and `durable_before_dispatch` ack behavior.
- Migration status: complete for the approved GitHub/Slack/Stripe configured-provider manifest class; unknown-provider raw webhook mode remains a separate non-authoritative concept.

## Proof

- `go test ./internal/providertriggers -count=1`
- `go test ./internal/runtime -run 'TestInboundGateway_(GitHubAdapterOwnsSignatureDeliveryIDAndEventMapping|SlackURLVerificationReturnsChallengeWithoutMarkerOrPublish|SlackEventCallbackOwnsEventIDAndInnerEventMapping|StripeManifestOwnsSignatureReplayIDTypeAndAck|StripeRejectsInvalidInputsBeforeMarkerAndPublish|StripeDuplicateEventDoesNotPublishAgain|RawFallbackDoesNotInterpretStripeSignature|RejectsOversizedBodyBeforeMarkerAndPublish|StripeSQLitePersistsConfiguredManifestDelivery)$' -count=1 -v`
- `SWARM_TEST_POSTGRES_DSN='host=127.0.0.1 port=5432 user=youmew dbname=postgres sslmode=disable' PGPASSWORD=postgres go test ./internal/runtime -run 'TestInboundGateway_(GitHubPausedRuntimePersistsAndReleasesSubscribedDispatch|SlackPausedRuntimePersistsAndReleasesSubscribedDispatch|StripePausedRuntimePersistsAndReleasesSubscribedDispatch)$' -count=1 -v`
- `SWARM_TEST_POSTGRES_DSN='host=127.0.0.1 port=5432 user=youmew dbname=postgres sslmode=disable' PGPASSWORD=postgres go test ./internal/providertriggers ./internal/runtime -count=1`
- `SWARM_TEST_POSTGRES_DSN='host=127.0.0.1 port=5432 user=youmew dbname=postgres sslmode=disable' PGPASSWORD=postgres go test ./...`
