### PR TITLE
[agent-f][issue #1725] Add Twilio provider trigger manifest

### DIFF
--- a/internal/providertriggers/manifests/twilio.yaml
+++ b/internal/providertriggers/manifests/twilio.yaml
@@ -1,0 +1,26 @@
+provider: twilio
+payload_source: form
+secret:
+  required: true
+signature:
+  type: hmac_sha1
+  encoding: base64
+  header: X-Twilio-Signature
+  signed_payload: url_plus_sorted_form
+  missing_error: twilio signature is required
+  invalid_error: invalid twilio signature
+delivery_id:
+  form_param: MessageSid
+  required: true
+  missing_error: twilio MessageSid is required
+event_type:
+  literal: message_received
+  required: true
+event_name:
+  literal: inbound.twilio
+ack:
+  mode: durable_before_dispatch
+metadata:
+  user_agent: user_agent
+  twilio_message_sid: delivery_id
+  twilio_event_type: event_type

--- a/internal/providertriggers/providertriggers.go
+++ b/internal/providertriggers/providertriggers.go
@@ -5,10 +5,14 @@ import (
 	"crypto/sha1"
 	"crypto/sha256"
 	"embed"
+	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"hash"
 	"net/http"
+	"net/url"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -31,13 +35,21 @@ func (t Target) EffectiveEntityID() string {
 }
 
 type Request struct {
-	Provider  string
-	Target    Target
-	Body      []byte
-	Headers   http.Header
-	Payload   any
-	Received  time.Time
-	UserAgent string
+	Provider        string
+	Target          Target
+	Method          string
+	URL             string
+	Body            []byte
+	Headers         http.Header
+	Payload         any
+	ContentType     string
+	Query           url.Values
+	QueryParseError string
+	Form            url.Values
+	FormParsed      bool
+	FormParseError  string
+	Received        time.Time
+	UserAgent       string
 }
 
 type Delivery struct {
@@ -139,6 +151,7 @@ type Manifest struct {
 	Provider              string             `yaml:"provider"`
 	PayloadObjectRequired bool               `yaml:"payload_object_required"`
 	PayloadObjectError    string             `yaml:"payload_object_error"`
+	PayloadSource         string             `yaml:"payload_source"`
 	Secret                SecretManifest     `yaml:"secret"`
 	Signature             SignatureManifest  `yaml:"signature"`
 	Challenge             *ChallengeManifest `yaml:"challenge"`
@@ -157,6 +170,7 @@ type SecretManifest struct {
 
 type SignatureManifest struct {
 	Type           string             `yaml:"type"`
+	Encoding       string             `yaml:"encoding"`
 	Header         string             `yaml:"header"`
 	Prefix         string             `yaml:"prefix"`
 	SignedPayload  string             `yaml:"signed_payload"`
@@ -198,6 +212,9 @@ type ConditionManifest struct {
 type ValueSource struct {
 	Header       string `yaml:"header"`
 	JSONPath     string `yaml:"json_path"`
+	FormParam    string `yaml:"form_param"`
+	QueryParam   string `yaml:"query_param"`
+	Literal      string `yaml:"literal"`
 	Required     bool   `yaml:"required"`
 	MissingError string `yaml:"missing_error"`
 }
@@ -227,33 +244,56 @@ func (m Manifest) Validate() error {
 	if m.Secret.Required && m.Signature.Type == "" {
 		return fmt.Errorf("%s manifest requires signature when secret is required", provider)
 	}
-	if m.Signature.Type != "" && strings.TrimSpace(m.Signature.Type) != "hmac_sha256" {
-		return fmt.Errorf("%s manifest has unsupported signature type %q", provider, m.Signature.Type)
+	switch strings.TrimSpace(m.PayloadSource) {
+	case "", "payload", "form":
+	default:
+		return fmt.Errorf("%s manifest has unsupported payload_source %q", provider, m.PayloadSource)
+	}
+	if m.Signature.Type != "" {
+		switch strings.TrimSpace(m.Signature.Type) {
+		case "hmac_sha256", "hmac_sha1":
+		default:
+			return fmt.Errorf("%s manifest has unsupported signature type %q", provider, m.Signature.Type)
+		}
+		switch m.Signature.digestEncoding() {
+		case "hex", "base64":
+		default:
+			return fmt.Errorf("%s manifest has unsupported signature encoding %q", provider, m.Signature.Encoding)
+		}
 	}
 	if m.Signature.Type != "" {
 		if strings.TrimSpace(m.Signature.Header) == "" {
 			return fmt.Errorf("%s manifest signature header is required", provider)
 		}
 		switch strings.TrimSpace(m.Signature.SignedPayload) {
-		case "raw_body", "slack_v0", "timestamp_dot_raw_body":
+		case "raw_body", "slack_v0", "timestamp_dot_raw_body", "url_plus_sorted_form":
 		default:
 			return fmt.Errorf("%s manifest has unsupported signed_payload %q", provider, m.Signature.SignedPayload)
 		}
-		if m.Signature.SignedPayload != "raw_body" && m.Signature.Timestamp == nil {
-			return fmt.Errorf("%s manifest timestamp is required for %s", provider, m.Signature.SignedPayload)
+		switch strings.TrimSpace(m.Signature.SignedPayload) {
+		case "slack_v0", "timestamp_dot_raw_body":
+			if m.Signature.Timestamp == nil {
+				return fmt.Errorf("%s manifest timestamp is required for %s", provider, m.Signature.SignedPayload)
+			}
+		}
+		if strings.TrimSpace(m.Signature.SignedPayload) == "url_plus_sorted_form" && m.Signature.digestEncoding() != "base64" {
+			return fmt.Errorf("%s manifest url_plus_sorted_form signatures require base64 encoding", provider)
+		}
+		if strings.TrimSpace(m.Signature.SignedPayload) == "url_plus_sorted_form" && strings.TrimSpace(m.Signature.Type) != "hmac_sha1" {
+			return fmt.Errorf("%s manifest url_plus_sorted_form signatures require hmac_sha1", provider)
 		}
 	}
-	if m.DeliveryID.Required && m.DeliveryID.Header == "" && m.DeliveryID.JSONPath == "" {
+	if err := validateValueSource(provider, "delivery_id", m.DeliveryID); err != nil {
+		return err
+	}
+	if m.DeliveryID.Required && m.DeliveryID.sourceCount() == 0 {
 		return fmt.Errorf("%s manifest delivery_id source is required", provider)
 	}
-	if err := validateJSONPath(provider, "delivery_id.json_path", m.DeliveryID.JSONPath); err != nil {
+	if err := validateValueSource(provider, "event_type", m.EventType); err != nil {
 		return err
 	}
-	if m.EventType.Required && m.EventType.Header == "" && m.EventType.JSONPath == "" {
+	if m.EventType.Required && m.EventType.sourceCount() == 0 {
 		return fmt.Errorf("%s manifest event_type source is required", provider)
-	}
-	if err := validateJSONPath(provider, "event_type.json_path", m.EventType.JSONPath); err != nil {
-		return err
 	}
 	if m.Challenge != nil {
 		if err := validateJSONPath(provider, "challenge.when.json_path", m.Challenge.When.JSONPath); err != nil {
@@ -404,15 +444,19 @@ func (m Manifest) verifySignature(secret string, req Request) error {
 	if len(candidates) == 0 {
 		return unauthorized(firstNonEmpty(m.Signature.MissingError, "signature is required"))
 	}
-	signedPayload, err := m.Signature.signedPayload(timestamp, req.Body)
+	signedPayload, err := m.Signature.signedPayload(timestamp, req)
 	if err != nil {
 		return err
 	}
-	mac := hmac.New(sha256.New, []byte(strings.TrimSpace(secret)))
+	hashFunc, err := m.Signature.hashFunc()
+	if err != nil {
+		return err
+	}
+	mac := hmac.New(hashFunc, []byte(strings.TrimSpace(secret)))
 	_, _ = mac.Write(signedPayload)
-	expected := hex.EncodeToString(mac.Sum(nil))
+	expected := m.Signature.encodeDigest(mac.Sum(nil))
 	for _, candidate := range candidates {
-		if hmac.Equal([]byte(strings.ToLower(strings.TrimSpace(candidate))), []byte(strings.ToLower(expected))) {
+		if m.Signature.signatureEqual(candidate, expected) {
 			return nil
 		}
 	}
@@ -426,14 +470,53 @@ func (s SignatureManifest) TimestampParam() string {
 	return strings.TrimSpace(s.Timestamp.Param)
 }
 
-func (s SignatureManifest) signedPayload(timestamp string, body []byte) ([]byte, error) {
+func (s SignatureManifest) hashFunc() (func() hash.Hash, error) {
+	switch strings.TrimSpace(s.Type) {
+	case "hmac_sha256":
+		return sha256.New, nil
+	case "hmac_sha1":
+		return sha1.New, nil
+	default:
+		return nil, unauthorized(firstNonEmpty(s.InvalidError, "invalid signature"))
+	}
+}
+
+func (s SignatureManifest) digestEncoding() string {
+	encoding := strings.TrimSpace(s.Encoding)
+	if encoding == "" {
+		return "hex"
+	}
+	return encoding
+}
+
+func (s SignatureManifest) encodeDigest(sum []byte) string {
+	switch s.digestEncoding() {
+	case "base64":
+		return base64.StdEncoding.EncodeToString(sum)
+	default:
+		return hex.EncodeToString(sum)
+	}
+}
+
+func (s SignatureManifest) signatureEqual(candidate, expected string) bool {
+	candidate = strings.TrimSpace(candidate)
+	if s.digestEncoding() == "hex" {
+		candidate = strings.ToLower(candidate)
+		expected = strings.ToLower(expected)
+	}
+	return hmac.Equal([]byte(candidate), []byte(expected))
+}
+
+func (s SignatureManifest) signedPayload(timestamp string, req Request) ([]byte, error) {
 	switch strings.TrimSpace(s.SignedPayload) {
 	case "raw_body":
-		return body, nil
+		return req.Body, nil
 	case "slack_v0":
-		return []byte("v0:" + timestamp + ":" + string(body)), nil
+		return []byte("v0:" + timestamp + ":" + string(req.Body)), nil
 	case "timestamp_dot_raw_body":
-		return []byte(timestamp + "." + string(body)), nil
+		return []byte(timestamp + "." + string(req.Body)), nil
+	case "url_plus_sorted_form":
+		return signedPayloadURLPlusSortedForm(s, req)
 	default:
 		return nil, unauthorized(firstNonEmpty(s.InvalidError, "invalid signature"))
 	}
@@ -484,12 +567,21 @@ func (c ConditionManifest) Evaluate(payload any) (bool, error) {
 }
 
 func (s ValueSource) Resolve(req Request) (string, bool) {
+	if strings.TrimSpace(s.Literal) != "" {
+		return strings.TrimSpace(s.Literal), true
+	}
 	if strings.TrimSpace(s.Header) != "" {
 		value := strings.TrimSpace(req.Headers.Get(s.Header))
 		return value, value != ""
 	}
 	if strings.TrimSpace(s.JSONPath) != "" {
 		return stringFromJSONPath(req.Payload, s.JSONPath)
+	}
+	if strings.TrimSpace(s.FormParam) != "" {
+		return singleParamValue(req.Form, s.FormParam)
+	}
+	if strings.TrimSpace(s.QueryParam) != "" {
+		return singleParamValue(req.Query, s.QueryParam)
 	}
 	return "", false
 }
@@ -505,6 +597,9 @@ func (m Manifest) resolveEventName(eventType string) string {
 
 func (m Manifest) buildPublishPayload(provider, entityID, deliveryID, eventType string, req Request) map[string]any {
 	rawPayload := redactPayload(req.Payload, m.RedactKeys)
+	if strings.TrimSpace(m.PayloadSource) == "form" {
+		rawPayload = redactPayload(formValuesPayload(req.Form), m.RedactKeys)
+	}
 	headers := make(map[string]any, len(m.Metadata))
 	for key, source := range m.Metadata {
 		switch source {
@@ -527,6 +622,67 @@ func (m Manifest) buildPublishPayload(provider, entityID, deliveryID, eventType 
 		"headers":              headers,
 		"received_at":          req.Received.UTC().Format(time.RFC3339),
 	}
+}
+
+func signedPayloadURLPlusSortedForm(s SignatureManifest, req Request) ([]byte, error) {
+	if strings.TrimSpace(req.URL) == "" {
+		return nil, unauthorized(firstNonEmpty(s.InvalidError, "invalid signature"))
+	}
+	if strings.TrimSpace(req.QueryParseError) != "" || strings.TrimSpace(req.FormParseError) != "" {
+		return nil, unauthorized(firstNonEmpty(s.InvalidError, "invalid signature"))
+	}
+	if !req.FormParsed {
+		return nil, unauthorized(firstNonEmpty(s.InvalidError, "invalid signature"))
+	}
+	if hasDuplicateValues(req.Query) || hasDuplicateValues(req.Form) {
+		return nil, unauthorized(firstNonEmpty(s.InvalidError, "invalid signature"))
+	}
+	keys := make([]string, 0, len(req.Form))
+	for key := range req.Form {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	var b strings.Builder
+	b.WriteString(req.URL)
+	for _, key := range keys {
+		b.WriteString(key)
+		b.WriteString(req.Form.Get(key))
+	}
+	return []byte(b.String()), nil
+}
+
+func hasDuplicateValues(values url.Values) bool {
+	for _, items := range values {
+		if len(items) > 1 {
+			return true
+		}
+	}
+	return false
+}
+
+func singleParamValue(values url.Values, key string) (string, bool) {
+	items := values[strings.TrimSpace(key)]
+	if len(items) != 1 {
+		return "", false
+	}
+	value := strings.TrimSpace(items[0])
+	return value, value != ""
+}
+
+func formValuesPayload(values url.Values) map[string]any {
+	payload := make(map[string]any, len(values))
+	for key, items := range values {
+		if len(items) == 1 {
+			payload[key] = items[0]
+			continue
+		}
+		copied := make([]any, 0, len(items))
+		for _, item := range items {
+			copied = append(copied, item)
+		}
+		payload[key] = copied
+	}
+	return payload
 }
 
 func acceptRaw(req Request) (Delivery, error) {
@@ -673,6 +829,23 @@ func validateJSONPath(provider, field, path string) error {
 		}
 	}
 	return nil
+}
+
+func validateValueSource(provider, field string, source ValueSource) error {
+	if source.sourceCount() > 1 {
+		return fmt.Errorf("%s manifest %s must use exactly one source", provider, field)
+	}
+	return validateJSONPath(provider, field+".json_path", source.JSONPath)
+}
+
+func (s ValueSource) sourceCount() int {
+	count := 0
+	for _, value := range []string{s.Header, s.JSONPath, s.FormParam, s.QueryParam, s.Literal} {
+		if strings.TrimSpace(value) != "" {
+			count++
+		}
+	}
+	return count
 }
 
 func validJSONPathSegment(part string) bool {

--- a/internal/providertriggers/providertriggers_test.go
+++ b/internal/providertriggers/providertriggers_test.go
@@ -2,9 +2,15 @@ package providertriggers
 
 import (
 	"crypto/hmac"
+	"crypto/sha1"
 	"crypto/sha256"
+	"encoding/base64"
 	"encoding/hex"
+	"encoding/json"
+	"fmt"
 	"net/http"
+	"net/url"
+	"sort"
 	"strconv"
 	"strings"
 	"testing"
@@ -212,6 +218,175 @@ func TestStripeManifestAcceptsLiteralEventType(t *testing.T) {
 	}
 }
 
+func TestTwilioManifestAcceptsSignedFormWebhook(t *testing.T) {
+	now := time.Unix(1710000000, 0).UTC()
+	requestURL := "https://example.com/webhooks/customer-a/twilio?tenant=alpha"
+	form := url.Values{
+		"Body":          {"hello from twilio"},
+		"From":          {"+15551234567"},
+		"MessageSid":    {"SM1234567890abcdef"},
+		"To":            {"+15557654321"},
+		"UnexpectedNew": {"still signed"},
+	}
+	req := Request{
+		Provider: "twilio",
+		Target: Target{
+			EntityID:      "entity-1",
+			WebhookSecret: "twilio-secret",
+		},
+		Method:      http.MethodPost,
+		URL:         requestURL,
+		Body:        []byte(form.Encode()),
+		Headers:     make(http.Header),
+		Payload:     map[string]any{"raw": form.Encode()},
+		ContentType: "application/x-www-form-urlencoded",
+		Query:       url.Values{"tenant": {"alpha"}},
+		Form:        form,
+		FormParsed:  true,
+		Received:    now,
+		UserAgent:   "twilio-test",
+	}
+	req.Headers.Set("X-Twilio-Signature", twilioSignatureBase64("twilio-secret", requestURL, form))
+
+	delivery, err := DefaultRegistry().Accept(req)
+	if err != nil {
+		t.Fatalf("Accept Twilio form webhook: %v", err)
+	}
+	if delivery.ProviderEventID != "SM1234567890abcdef" {
+		t.Fatalf("ProviderEventID = %q, want MessageSid", delivery.ProviderEventID)
+	}
+	if delivery.ProviderEventType != "message_received" {
+		t.Fatalf("ProviderEventType = %q, want message_received", delivery.ProviderEventType)
+	}
+	if delivery.EventName != "inbound.twilio" {
+		t.Fatalf("EventName = %q, want inbound.twilio", delivery.EventName)
+	}
+	if !delivery.AcknowledgeBeforeDispatch {
+		t.Fatal("Twilio delivery did not request durable_before_dispatch acknowledgement")
+	}
+	payload, ok := delivery.Payload["payload"].(map[string]any)
+	if !ok {
+		t.Fatalf("payload = %T, want form payload map", delivery.Payload["payload"])
+	}
+	if payload["Body"] != "hello from twilio" || payload["UnexpectedNew"] != "still signed" {
+		t.Fatalf("form payload = %+v, want Twilio form parameters without allowlist loss", payload)
+	}
+	headers, ok := delivery.Payload["headers"].(map[string]any)
+	if !ok {
+		t.Fatalf("headers = %T, want metadata map", delivery.Payload["headers"])
+	}
+	if headers["twilio_message_sid"] != "SM1234567890abcdef" || headers["twilio_event_type"] != "message_received" {
+		t.Fatalf("headers = %+v, want Twilio manifest metadata", headers)
+	}
+	encoded := fmtPayload(delivery.Payload)
+	if strings.Contains(encoded, "twilio-secret") {
+		t.Fatal("Twilio signing secret leaked into delivery payload")
+	}
+}
+
+func TestTwilioManifestRejectsAmbiguousOrUnsupportedCallbacks(t *testing.T) {
+	now := time.Unix(1710000000, 0).UTC()
+	requestURL := "https://example.com/webhooks/customer-a/twilio?tenant=alpha"
+	validForm := url.Values{
+		"Body":       {"hello"},
+		"MessageSid": {"SM1234567890abcdef"},
+	}
+	validRequest := func() Request {
+		req := Request{
+			Provider: "twilio",
+			Target: Target{
+				EntityID:      "entity-1",
+				WebhookSecret: "twilio-secret",
+			},
+			Method:      http.MethodPost,
+			URL:         requestURL,
+			Body:        []byte(validForm.Encode()),
+			Headers:     make(http.Header),
+			Payload:     map[string]any{"raw": validForm.Encode()},
+			ContentType: "application/x-www-form-urlencoded",
+			Query:       url.Values{"tenant": {"alpha"}},
+			Form:        cloneValues(validForm),
+			FormParsed:  true,
+			Received:    now,
+		}
+		req.Headers.Set("X-Twilio-Signature", twilioSignatureBase64("twilio-secret", requestURL, validForm))
+		return req
+	}
+	for _, tc := range []struct {
+		name       string
+		configure  func(Request) Request
+		wantStatus int
+	}{
+		{
+			name: "missing signature",
+			configure: func(req Request) Request {
+				req.Headers.Del("X-Twilio-Signature")
+				return req
+			},
+			wantStatus: http.StatusUnauthorized,
+		},
+		{
+			name: "url mismatch",
+			configure: func(req Request) Request {
+				req.URL = "https://example.com/webhooks/customer-a/twilio?tenant=beta"
+				req.Query = url.Values{"tenant": {"beta"}}
+				return req
+			},
+			wantStatus: http.StatusUnauthorized,
+		},
+		{
+			name: "duplicate query params",
+			configure: func(req Request) Request {
+				req.URL = "https://example.com/webhooks/customer-a/twilio?tenant=alpha&tenant=beta"
+				req.Query = url.Values{"tenant": {"alpha", "beta"}}
+				req.Headers.Set("X-Twilio-Signature", twilioSignatureBase64("twilio-secret", req.URL, validForm))
+				return req
+			},
+			wantStatus: http.StatusUnauthorized,
+		},
+		{
+			name: "duplicate form params",
+			configure: func(req Request) Request {
+				req.Form = cloneValues(validForm)
+				req.Form["Body"] = []string{"hello", "tampered"}
+				req.Body = []byte(req.Form.Encode())
+				req.Headers.Set("X-Twilio-Signature", twilioSignatureBase64("twilio-secret", req.URL, req.Form))
+				return req
+			},
+			wantStatus: http.StatusUnauthorized,
+		},
+		{
+			name: "missing message sid",
+			configure: func(req Request) Request {
+				req.Form = url.Values{"Body": {"hello"}}
+				req.Body = []byte(req.Form.Encode())
+				req.Headers.Set("X-Twilio-Signature", twilioSignatureBase64("twilio-secret", req.URL, req.Form))
+				return req
+			},
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name: "json body sha256 mode unsupported in this slice",
+			configure: func(req Request) Request {
+				req.URL = "https://example.com/webhooks/customer-a/twilio?bodySHA256=abc123"
+				req.Query = url.Values{"bodySHA256": {"abc123"}}
+				req.Body = []byte(`{"MessageSid":"SM1234567890abcdef"}`)
+				req.Payload = map[string]any{"MessageSid": "SM1234567890abcdef"}
+				req.ContentType = "application/json"
+				req.Form = nil
+				req.FormParsed = false
+				return req
+			},
+			wantStatus: http.StatusUnauthorized,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := DefaultRegistry().Accept(tc.configure(validRequest()))
+			requireProviderTriggerError(t, err, tc.wantStatus)
+		})
+	}
+}
+
 func TestManifestValidationRejectsAuthoringErrors(t *testing.T) {
 	for _, tc := range []struct {
 		name     string
@@ -255,6 +430,47 @@ func TestManifestValidationRejectsAuthoringErrors(t *testing.T) {
 					Literal:  "inbound.ambiguousname",
 					Template: "inbound.ambiguousname.{event_type}",
 				},
+			},
+		},
+		{
+			name: "url sorted form requires hmac sha1",
+			manifest: Manifest{
+				Provider: "badformsignature",
+				Secret:   SecretManifest{Required: true},
+				Signature: SignatureManifest{
+					Type:          "hmac_sha256",
+					Encoding:      "base64",
+					Header:        "X-Signature",
+					SignedPayload: "url_plus_sorted_form",
+				},
+				DeliveryID: ValueSource{FormParam: "MessageSid", Required: true},
+				EventType:  ValueSource{Literal: "message_received", Required: true},
+				EventName:  EventNameManifest{Literal: "inbound.badformsignature"},
+			},
+		},
+		{
+			name: "url sorted form requires base64",
+			manifest: Manifest{
+				Provider: "badformencoding",
+				Secret:   SecretManifest{Required: true},
+				Signature: SignatureManifest{
+					Type:          "hmac_sha1",
+					Encoding:      "hex",
+					Header:        "X-Signature",
+					SignedPayload: "url_plus_sorted_form",
+				},
+				DeliveryID: ValueSource{FormParam: "MessageSid", Required: true},
+				EventType:  ValueSource{Literal: "message_received", Required: true},
+				EventName:  EventNameManifest{Literal: "inbound.badformencoding"},
+			},
+		},
+		{
+			name: "ambiguous value source",
+			manifest: Manifest{
+				Provider:   "badsource",
+				DeliveryID: ValueSource{Header: "X-Delivery", FormParam: "MessageSid", Required: true},
+				EventType:  ValueSource{Literal: "message_received", Required: true},
+				EventName:  EventNameManifest{Literal: "inbound.badsource"},
 			},
 		},
 	} {
@@ -414,6 +630,43 @@ func stripeSignatureHex(secret, timestamp string, body []byte) string {
 	mac := hmac.New(sha256.New, []byte(secret))
 	_, _ = mac.Write([]byte(timestamp + "." + string(body)))
 	return hex.EncodeToString(mac.Sum(nil))
+}
+
+func twilioSignatureBase64(secret, requestURL string, form url.Values) string {
+	mac := hmac.New(sha1.New, []byte(secret))
+	_, _ = mac.Write([]byte(twilioSignedPayload(requestURL, form)))
+	return base64.StdEncoding.EncodeToString(mac.Sum(nil))
+}
+
+func twilioSignedPayload(requestURL string, form url.Values) string {
+	keys := make([]string, 0, len(form))
+	for key := range form {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	var b strings.Builder
+	b.WriteString(requestURL)
+	for _, key := range keys {
+		b.WriteString(key)
+		b.WriteString(form.Get(key))
+	}
+	return b.String()
+}
+
+func cloneValues(values url.Values) url.Values {
+	cloned := make(url.Values, len(values))
+	for key, items := range values {
+		cloned[key] = append([]string(nil), items...)
+	}
+	return cloned
+}
+
+func fmtPayload(payload map[string]any) string {
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Sprintf("%+v", payload)
+	}
+	return string(body)
 }
 
 func strconvFormatUnix(t time.Time) string {

--- a/internal/runtime/inbound.go
+++ b/internal/runtime/inbound.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"encoding/json"
 	"io"
+	"mime"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 
@@ -122,6 +124,9 @@ func (g *InboundGateway) handleWebhook(w http.ResponseWriter, r *http.Request) {
 	if len(body) == 0 {
 		body = []byte("{}")
 	}
+	requestURL := inboundRequestURL(r)
+	queryValues, queryParseError := inboundQueryValues(r)
+	formValues, formParsed, formParseError := inboundFormValues(r.Header.Get("Content-Type"), body)
 
 	target := InboundTarget{
 		EntityID:   entityKey,
@@ -150,11 +155,19 @@ func (g *InboundGateway) handleWebhook(w http.ResponseWriter, r *http.Request) {
 			EntitySlug:    target.EntitySlug,
 			WebhookSecret: target.WebhookSecret,
 		},
-		Body:      body,
-		Headers:   r.Header,
-		Payload:   payload,
-		Received:  now,
-		UserAgent: r.UserAgent(),
+		Method:          r.Method,
+		URL:             requestURL,
+		Body:            body,
+		Headers:         r.Header,
+		Payload:         payload,
+		ContentType:     r.Header.Get("Content-Type"),
+		Query:           queryValues,
+		QueryParseError: queryParseError,
+		Form:            formValues,
+		FormParsed:      formParsed,
+		FormParseError:  formParseError,
+		Received:        now,
+		UserAgent:       r.UserAgent(),
 	})
 	if err != nil {
 		status := http.StatusBadRequest
@@ -256,6 +269,63 @@ func parseWebhookPath(path string) (entityID, provider string, ok bool) {
 		return "", "", false
 	}
 	return entityID, provider, true
+}
+
+func inboundRequestURL(r *http.Request) string {
+	if r == nil || r.URL == nil || strings.TrimSpace(r.URL.Fragment) != "" {
+		return ""
+	}
+	scheme := "http"
+	host := strings.TrimSpace(r.Host)
+	if r.URL.IsAbs() {
+		if strings.TrimSpace(r.URL.Scheme) == "" {
+			return ""
+		}
+		scheme = strings.TrimSpace(r.URL.Scheme)
+		if host == "" {
+			host = strings.TrimSpace(r.URL.Host)
+		}
+	} else if r.TLS != nil {
+		scheme = "https"
+	}
+	if host == "" {
+		return ""
+	}
+	uri := r.URL.RequestURI()
+	if strings.TrimSpace(uri) == "" {
+		uri = "/"
+	}
+	return scheme + "://" + host + uri
+}
+
+func inboundQueryValues(r *http.Request) (url.Values, string) {
+	if r == nil || r.URL == nil || strings.TrimSpace(r.URL.RawQuery) == "" {
+		return nil, ""
+	}
+	values, err := url.ParseQuery(r.URL.RawQuery)
+	if err != nil {
+		return nil, err.Error()
+	}
+	return values, ""
+}
+
+func inboundFormValues(contentType string, body []byte) (url.Values, bool, string) {
+	contentType = strings.TrimSpace(contentType)
+	if contentType == "" {
+		return nil, false, ""
+	}
+	mediaType, _, err := mime.ParseMediaType(contentType)
+	if err != nil {
+		return nil, false, err.Error()
+	}
+	if !strings.EqualFold(mediaType, "application/x-www-form-urlencoded") {
+		return nil, false, ""
+	}
+	values, err := url.ParseQuery(string(body))
+	if err != nil {
+		return nil, true, err.Error()
+	}
+	return values, true, ""
 }
 
 func firstNonEmpty(values ...string) string {

--- a/internal/runtime/inbound_postgres_test.go
+++ b/internal/runtime/inbound_postgres_test.go
@@ -3,12 +3,16 @@ package runtime_test
 import (
 	"context"
 	"crypto/hmac"
+	"crypto/sha1"
 	"crypto/sha256"
 	"database/sql"
+	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
+	"sort"
 	"strconv"
 	"strings"
 	"testing"
@@ -397,6 +401,137 @@ func TestInboundGateway_StripeSQLitePersistsConfiguredManifestDelivery(t *testin
 	}
 }
 
+func TestInboundGateway_TwilioPostgresPersistsConfiguredManifestDelivery(t *testing.T) {
+	_, db, cleanup := testutil.StartPostgres(t)
+	t.Cleanup(cleanup)
+
+	const (
+		runID             = "45000000-0000-0000-0000-000000000001"
+		entityID          = "45000000-0000-0000-0000-000000000002"
+		flowInstance      = "twilio-provider-trigger-instance"
+		entitySlug        = "customer-a"
+		provider          = "twilio"
+		webhookSecret     = "twilio-secret"
+		providerEventID   = "SM1234567890abcdef"
+		agentID           = "twilio-webhook-subscriber"
+		providerEventName = "inbound.twilio"
+	)
+	ctx := runtimecorrelation.WithRunID(context.Background(), runID)
+	pg := &store.PostgresStore{DB: db}
+	seedPostgresInboundGatewayRuntime(t, ctx, db, pg, runID, entityID, flowInstance, entitySlug, provider, webhookSecret, agentID)
+
+	bus, err := runtimebus.NewEventBus(pg)
+	if err != nil {
+		t.Fatalf("NewEventBus: %v", err)
+	}
+	ch := bus.Subscribe(agentID, events.EventType(providerEventName))
+	defer bus.Unsubscribe(agentID)
+
+	g := runtimepkg.NewInboundGateway(bus, nil, nil, pg)
+
+	requestURL := "https://example.com/webhooks/customer-a/twilio?tenant=alpha"
+	form := url.Values{
+		"Body":       {"hello from twilio"},
+		"From":       {"+15551234567"},
+		"MessageSid": {providerEventID},
+		"To":         {"+15557654321"},
+	}
+	req := newSignedTwilioRequest(requestURL, webhookSecret, form)
+	req = req.WithContext(ctx)
+	rec := httptest.NewRecorder()
+	g.Handler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("status = %d, want 202 body=%s", rec.Code, rec.Body.String())
+	}
+	if got := countPostgresInboundMarkers(t, ctx, db, providerEventID, entityID, provider); got != 1 {
+		t.Fatalf("inbound marker rows = %d, want 1", got)
+	}
+	eventID := loadPostgresInboundProviderEventID(t, ctx, db, runID, entityID, providerEventName, providerEventID)
+	if got := countPostgresInboundProviderEvents(t, ctx, db, runID, entityID, providerEventName, providerEventID); got != 1 {
+		t.Fatalf("provider event rows = %d, want 1", got)
+	}
+	if got := loadPostgresInboundProviderEventPayloadField(t, ctx, db, eventID, "provider_event_type"); got != "message_received" {
+		t.Fatalf("provider_event_type = %q, want message_received", got)
+	}
+	if got := countPostgresAgentDeliveriesForEvent(t, ctx, db, eventID, agentID); got != 1 {
+		t.Fatalf("agent delivery rows = %d, want 1", got)
+	}
+	select {
+	case got := <-ch:
+		if got.ID() != eventID || got.Type() != events.EventType(providerEventName) {
+			t.Fatalf("delivered event = %s/%s, want %s/%s", got.ID(), got.Type(), eventID, providerEventName)
+		}
+	default:
+		// Twilio uses durable_before_dispatch; this proof is about persisted
+		// evidence and supported store admission, not handler completion.
+	}
+}
+
+func TestInboundGateway_TwilioSQLitePersistsConfiguredManifestDelivery(t *testing.T) {
+	const (
+		runID             = "46000000-0000-0000-0000-000000000001"
+		entityID          = "46000000-0000-0000-0000-000000000002"
+		flowInstance      = "twilio-sqlite-provider-trigger-instance"
+		entitySlug        = "customer-a"
+		provider          = "twilio"
+		webhookSecret     = "twilio-secret"
+		providerEventID   = "SMabcdef1234567890"
+		agentID           = "twilio-sqlite-webhook-subscriber"
+		providerEventName = "inbound.twilio"
+	)
+	ctx := runtimecorrelation.WithRunID(context.Background(), runID)
+	sqliteStore := storetest.StartSQLiteRuntimeStoreWithContext(t, ctx)
+	seedSQLiteInboundGatewayRuntime(t, ctx, sqliteStore, runID, entityID, flowInstance, entitySlug, provider, webhookSecret, agentID)
+
+	bus, err := runtimebus.NewEventBus(sqliteStore)
+	if err != nil {
+		t.Fatalf("NewEventBus: %v", err)
+	}
+	ch := bus.Subscribe(agentID, events.EventType(providerEventName))
+	defer bus.Unsubscribe(agentID)
+
+	g := runtimepkg.NewInboundGateway(bus, nil, nil, sqliteStore)
+
+	requestURL := "https://example.com/webhooks/customer-a/twilio?tenant=alpha"
+	form := url.Values{
+		"Body":       {"hello from sqlite"},
+		"From":       {"+15551234567"},
+		"MessageSid": {providerEventID},
+		"To":         {"+15557654321"},
+	}
+	req := newSignedTwilioRequest(requestURL, webhookSecret, form)
+	req = req.WithContext(ctx)
+	rec := httptest.NewRecorder()
+	g.Handler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("status = %d, want 202 body=%s", rec.Code, rec.Body.String())
+	}
+	if got := countSQLiteInboundMarkers(t, ctx, sqliteStore, providerEventID, entityID, provider); got != 1 {
+		t.Fatalf("inbound marker rows = %d, want 1", got)
+	}
+	eventID := loadSQLiteInboundProviderEventID(t, ctx, sqliteStore, runID, entityID, providerEventName, providerEventID)
+	if got := countSQLiteInboundProviderEvents(t, ctx, sqliteStore, runID, entityID, providerEventName, providerEventID); got != 1 {
+		t.Fatalf("provider event rows = %d, want 1", got)
+	}
+	if got := loadSQLiteInboundProviderEventPayloadField(t, ctx, sqliteStore, eventID, "provider_event_type"); got != "message_received" {
+		t.Fatalf("provider_event_type = %q, want message_received", got)
+	}
+	if got := countSQLiteAgentDeliveriesForEvent(t, ctx, sqliteStore, eventID, agentID); got != 1 {
+		t.Fatalf("agent delivery rows = %d, want 1", got)
+	}
+	select {
+	case got := <-ch:
+		if got.ID() != eventID || got.Type() != events.EventType(providerEventName) {
+			t.Fatalf("delivered event = %s/%s, want %s/%s", got.ID(), got.Type(), eventID, providerEventName)
+		}
+	default:
+		// Twilio uses durable_before_dispatch; this proof is about persisted
+		// evidence and supported store admission, not handler completion.
+	}
+}
+
 func seedPostgresInboundGatewayRuntime(
 	t *testing.T,
 	ctx context.Context,
@@ -764,4 +899,32 @@ func stripeWebhookSignature(secret string, timestamp string, body []byte) string
 	mac := hmac.New(sha256.New, []byte(secret))
 	_, _ = mac.Write([]byte(timestamp + "." + string(body)))
 	return "t=" + timestamp + ",v1=" + hex.EncodeToString(mac.Sum(nil))
+}
+
+func newSignedTwilioRequest(requestURL string, secret string, form url.Values) *http.Request {
+	req := httptest.NewRequest(http.MethodPost, requestURL, strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("X-Twilio-Signature", twilioWebhookSignature(secret, requestURL, form))
+	return req
+}
+
+func twilioWebhookSignature(secret, requestURL string, form url.Values) string {
+	mac := hmac.New(sha1.New, []byte(secret))
+	_, _ = mac.Write([]byte(twilioSignedPayload(requestURL, form)))
+	return base64.StdEncoding.EncodeToString(mac.Sum(nil))
+}
+
+func twilioSignedPayload(requestURL string, form url.Values) string {
+	keys := make([]string, 0, len(form))
+	for key := range form {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	var b strings.Builder
+	b.WriteString(requestURL)
+	for _, key := range keys {
+		b.WriteString(key)
+		b.WriteString(form.Get(key))
+	}
+	return b.String()
 }

--- a/internal/runtime/inbound_test.go
+++ b/internal/runtime/inbound_test.go
@@ -3,12 +3,17 @@ package runtime
 import (
 	"context"
 	"crypto/hmac"
+	"crypto/sha1"
 	"crypto/sha256"
+	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -966,6 +971,199 @@ func TestInboundGateway_StripeDuplicateEventDoesNotPublishAgain(t *testing.T) {
 	}
 }
 
+func TestInboundGateway_TwilioManifestOwnsURLFormSignatureAndLiteralEvent(t *testing.T) {
+	eventStore := &capturingInboundEventStore{}
+	bus, err := runtimebus.NewEventBus(eventStore)
+	if err != nil {
+		t.Fatalf("NewEventBus: %v", err)
+	}
+	store := &recordingInboundStore{
+		target: InboundTarget{
+			EntityID:      "3fd8fc37-6d02-4d50-8bb7-14c6cb0fed0a",
+			EntitySlug:    "customer-a",
+			WebhookSecret: "twilio-secret",
+		},
+		inserted: true,
+	}
+	g := NewInboundGateway(bus, nil, nil, store)
+
+	requestURL := "https://example.com/webhooks/customer-a/twilio?tenant=alpha"
+	form := url.Values{
+		"Body":          {"hello from twilio"},
+		"From":          {"+15551234567"},
+		"MessageSid":    {"SM1234567890abcdef"},
+		"To":            {"+15557654321"},
+		"UnexpectedNew": {"still signed"},
+	}
+	req := newSignedTwilioRequest(requestURL, "twilio-secret", form)
+	rec := httptest.NewRecorder()
+	g.Handler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("status = %d, want 202 body=%s", rec.Code, rec.Body.String())
+	}
+	if !store.recorded {
+		t.Fatal("expected Twilio delivery to record inbound marker")
+	}
+	if store.providerEventID != "SM1234567890abcdef" {
+		t.Fatalf("providerEventID = %q, want MessageSid", store.providerEventID)
+	}
+	if store.provider != "twilio" {
+		t.Fatalf("provider = %q, want twilio", store.provider)
+	}
+	if len(eventStore.events) != 1 {
+		t.Fatalf("published events = %d, want 1", len(eventStore.events))
+	}
+	evt := eventStore.events[0]
+	if evt.Type() != events.EventType("inbound.twilio") {
+		t.Fatalf("event type = %q, want inbound.twilio", evt.Type())
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(evt.Payload(), &payload); err != nil {
+		t.Fatalf("unmarshal payload: %v", err)
+	}
+	if payload["provider_event_id"] != "SM1234567890abcdef" ||
+		payload["provider_event_type"] != "message_received" ||
+		payload["provider"] != "twilio" {
+		t.Fatalf("payload = %+v, want Twilio manifest delivery identity", payload)
+	}
+	formPayload, ok := payload["payload"].(map[string]any)
+	if !ok {
+		t.Fatalf("payload.payload = %T, want form payload map", payload["payload"])
+	}
+	if formPayload["Body"] != "hello from twilio" || formPayload["UnexpectedNew"] != "still signed" {
+		t.Fatalf("form payload = %+v, want evolving Twilio form parameters preserved", formPayload)
+	}
+	if strings.Contains(rec.Body.String(), "twilio-secret") || strings.Contains(string(evt.Payload()), "twilio-secret") {
+		t.Fatal("Twilio signing secret leaked into readback or event payload")
+	}
+}
+
+func TestInboundGateway_TwilioRejectsInvalidInputsBeforeMarkerAndPublish(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		requestURL string
+		form       url.Values
+		configure  func(*http.Request, url.Values, string)
+		wantStatus int
+	}{
+		{
+			name:       "missing signature",
+			requestURL: "https://example.com/webhooks/customer-a/twilio?tenant=alpha",
+			form:       url.Values{"MessageSid": {"SM1234567890abcdef"}, "Body": {"hello"}},
+			configure: func(req *http.Request, form url.Values, requestURL string) {
+				req.Header.Del("X-Twilio-Signature")
+			},
+			wantStatus: http.StatusUnauthorized,
+		},
+		{
+			name:       "url mismatch",
+			requestURL: "https://example.com/webhooks/customer-a/twilio?tenant=beta",
+			form:       url.Values{"MessageSid": {"SM1234567890abcdef"}, "Body": {"hello"}},
+			configure: func(req *http.Request, form url.Values, requestURL string) {
+				req.Header.Set("X-Twilio-Signature", twilioWebhookSignature("twilio-secret", "https://example.com/webhooks/customer-a/twilio?tenant=alpha", form))
+			},
+			wantStatus: http.StatusUnauthorized,
+		},
+		{
+			name:       "duplicate query params",
+			requestURL: "https://example.com/webhooks/customer-a/twilio?tenant=alpha&tenant=beta",
+			form:       url.Values{"MessageSid": {"SM1234567890abcdef"}, "Body": {"hello"}},
+			configure:  func(*http.Request, url.Values, string) {},
+			wantStatus: http.StatusUnauthorized,
+		},
+		{
+			name:       "duplicate form params",
+			requestURL: "https://example.com/webhooks/customer-a/twilio?tenant=alpha",
+			form:       url.Values{"MessageSid": {"SM1234567890abcdef"}, "Body": {"hello", "tampered"}},
+			configure:  func(*http.Request, url.Values, string) {},
+			wantStatus: http.StatusUnauthorized,
+		},
+		{
+			name:       "missing message sid",
+			requestURL: "https://example.com/webhooks/customer-a/twilio?tenant=alpha",
+			form:       url.Values{"Body": {"hello"}},
+			configure:  func(*http.Request, url.Values, string) {},
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:       "json body sha256 mode unsupported in this slice",
+			requestURL: "https://example.com/webhooks/customer-a/twilio?bodySHA256=abc123",
+			form:       url.Values{"MessageSid": {"SM1234567890abcdef"}, "Body": {"hello"}},
+			configure: func(req *http.Request, form url.Values, requestURL string) {
+				req.Header.Set("Content-Type", "application/json")
+				req.Body = io.NopCloser(strings.NewReader(`{"MessageSid":"SM1234567890abcdef"}`))
+				req.ContentLength = int64(len(`{"MessageSid":"SM1234567890abcdef"}`))
+			},
+			wantStatus: http.StatusUnauthorized,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			eventStore := &capturingInboundEventStore{}
+			bus, err := runtimebus.NewEventBus(eventStore)
+			if err != nil {
+				t.Fatalf("NewEventBus: %v", err)
+			}
+			store := &recordingInboundStore{
+				target: InboundTarget{
+					EntityID:      "3fd8fc37-6d02-4d50-8bb7-14c6cb0fed0a",
+					EntitySlug:    "customer-a",
+					WebhookSecret: "twilio-secret",
+				},
+				inserted: true,
+			}
+			g := NewInboundGateway(bus, nil, nil, store)
+			req := newSignedTwilioRequest(tc.requestURL, "twilio-secret", tc.form)
+			tc.configure(req, tc.form, tc.requestURL)
+			rec := httptest.NewRecorder()
+			g.Handler().ServeHTTP(rec, req)
+
+			if rec.Code != tc.wantStatus {
+				t.Fatalf("status = %d, want %d body=%s", rec.Code, tc.wantStatus, rec.Body.String())
+			}
+			if store.recorded {
+				t.Fatal("invalid Twilio request recorded inbound marker")
+			}
+			if len(eventStore.events) != 0 {
+				t.Fatalf("published events = %d, want 0", len(eventStore.events))
+			}
+		})
+	}
+}
+
+func TestInboundGateway_TwilioDuplicateDeliveryDoesNotPublishAgain(t *testing.T) {
+	eventStore := &capturingInboundEventStore{}
+	bus, err := runtimebus.NewEventBus(eventStore)
+	if err != nil {
+		t.Fatalf("NewEventBus: %v", err)
+	}
+	store := &recordingInboundStore{
+		target: InboundTarget{
+			EntityID:      "3fd8fc37-6d02-4d50-8bb7-14c6cb0fed0a",
+			EntitySlug:    "customer-a",
+			WebhookSecret: "twilio-secret",
+		},
+		inserted: false,
+	}
+	g := NewInboundGateway(bus, nil, nil, store)
+
+	requestURL := "https://example.com/webhooks/customer-a/twilio?tenant=alpha"
+	form := url.Values{"MessageSid": {"SM1234567890abcdef"}, "Body": {"hello"}}
+	req := newSignedTwilioRequest(requestURL, "twilio-secret", form)
+	rec := httptest.NewRecorder()
+	g.Handler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 body=%s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), `"status":"duplicate"`) {
+		t.Fatalf("duplicate response = %s", rec.Body.String())
+	}
+	if len(eventStore.events) != 0 {
+		t.Fatalf("published events = %d, want 0", len(eventStore.events))
+	}
+}
+
 func TestInboundGateway_RawFallbackDoesNotInterpretStripeSignature(t *testing.T) {
 	eventStore := &capturingInboundEventStore{}
 	bus, err := runtimebus.NewEventBus(eventStore)
@@ -1058,6 +1256,34 @@ func stripeSignatureHex(secret string, timestamp string, body []byte) string {
 	mac := hmac.New(sha256.New, []byte(secret))
 	_, _ = mac.Write([]byte(timestamp + "." + string(body)))
 	return hex.EncodeToString(mac.Sum(nil))
+}
+
+func newSignedTwilioRequest(requestURL string, secret string, form url.Values) *http.Request {
+	req := httptest.NewRequest(http.MethodPost, requestURL, strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("X-Twilio-Signature", twilioWebhookSignature(secret, requestURL, form))
+	return req
+}
+
+func twilioWebhookSignature(secret, requestURL string, form url.Values) string {
+	mac := hmac.New(sha1.New, []byte(secret))
+	_, _ = mac.Write([]byte(twilioSignedPayload(requestURL, form)))
+	return base64.StdEncoding.EncodeToString(mac.Sum(nil))
+}
+
+func twilioSignedPayload(requestURL string, form url.Values) string {
+	keys := make([]string, 0, len(form))
+	for key := range form {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	var b strings.Builder
+	b.WriteString(requestURL)
+	for _, key := range keys {
+		b.WriteString(key)
+		b.WriteString(form.Get(key))
+	}
+	return b.String()
 }
 
 type blockingInboundInterceptor struct {

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -5671,18 +5671,30 @@ tool_model:
     manifest_vocabulary:
       provider: normalized provider token matched from `/webhooks/{entity}/{provider}`
       payload_object_required: fail closed when the decoded request payload is not a JSON object
+      payload_source: >
+        Source for the provider payload embedded in the published normalized event. The default `payload` uses the decoded
+        JSON object or raw-body wrapper. `form` uses the gateway-parsed `application/x-www-form-urlencoded` parameter set
+        and requires the relevant signed-payload recipe to fail closed on malformed form input.
       secret.required: require a configured signing secret before accepting the provider callback
       signature: >
-        HMAC-SHA256 signature verification over a manifest-selected signed payload. Supported signed payloads are
-        `raw_body`, `slack_v0`, and `timestamp_dot_raw_body`. The interpreter supports fixed signature prefixes, structured
-        comma-separated signature parameters, timestamp extraction from headers or parameters, replay tolerance windows, and
-        constant-time comparison against every configured signature candidate.
+        HMAC-SHA256 or HMAC-SHA1 signature verification over a manifest-selected signed payload, encoded as lowercase hex
+        by default or Base64 when the manifest selects `encoding: base64`. Supported signed payloads are `raw_body`,
+        `slack_v0`, `timestamp_dot_raw_body`, and `url_plus_sorted_form`. The interpreter supports fixed signature
+        prefixes, structured comma-separated signature parameters, timestamp extraction from headers or parameters, replay
+        tolerance windows, exact request URL plus sorted form-parameter canonicalization, and constant-time comparison
+        against every configured signature candidate.
       challenge: >
         Authenticated response-only callback handling. A matched challenge branch must not persist an inbound dedupe marker
         and must not publish a Swarm event.
       delivery_condition: JSON object condition that must match before a provider delivery is accepted.
-      delivery_id: authoritative provider delivery id source for dedupe marker input.
-      event_type: authoritative provider event type source for normalized provider_event_type payload metadata.
+      request_facts: >
+        The gateway passes provider-neutral request facts to the manifest interpreter: method, direct scheme/host/request
+        URI URL, content type, parsed query values, parsed form values, parse-error state, raw body, headers, decoded payload,
+        receipt time, and user agent. The first-slice exact URL source is the request received by the API listener; forwarded
+        proxy/header trust and callback URL lifecycle remain parent-tail work. Recipes that require URL/form facts MUST fail
+        closed when those facts are missing, malformed, or ambiguous.
+      delivery_id: authoritative provider delivery id source for dedupe marker input. Sources may be header, JSONPath, form parameter, query parameter, or manifest literal.
+      event_type: authoritative provider event type source for normalized provider_event_type payload metadata. Sources may be header, JSONPath, form parameter, query parameter, or manifest literal.
       event_name: literal or `{event_type}` template for the emitted Swarm event name.
       event_name_policy: >
         New provider-trigger manifests MUST use a literal Swarm event name and carry the provider-specific event kind in
@@ -5769,12 +5781,36 @@ tool_model:
         Stripe payload `type` is the authoritative provider event type and is emitted in payload metadata as normalized
         `provider_event_type`. The canonical emitted event name is `inbound.stripe`, not `inbound.stripe.<event_type>`.
         Missing `type` fails before dedupe marker persistence.
+    - provider: twilio
+      issue: "#1725"
+      signature: >
+        Twilio form/query webhook deliveries in this slice require a configured signing secret and a valid
+        `X-Twilio-Signature` HMAC-SHA1 Base64 signature. The manifest interpreter MUST compute the signed payload as the
+        exact request URL received by the API listener, including any query string, followed by every parsed form parameter
+        name and value concatenated in lexicographic parameter-name order with no delimiters. Missing signing secret,
+        missing signature, invalid signature, URL mismatch, malformed query/form parsing, and duplicate query or form
+        parameter names fail before dedupe marker persistence and before event publish.
+      callback_shape: >
+        The approved #1725 slice supports `application/x-www-form-urlencoded` Twilio callbacks only. Twilio JSON callbacks
+        using `bodySHA256` are not supported by this slice and MUST fail closed rather than falling through to raw webhook
+        mode or partial Twilio acceptance.
+      delivery_id: >
+        `MessageSid` form parameter is the authoritative provider delivery id and dedupe-key input for the selected Twilio
+        messaging callback slice. Missing `MessageSid` fails before dedupe marker persistence.
+      acknowledgement: >
+        Accepted Twilio deliveries return success after the inbound dedupe marker, canonical event record, recipient
+        manifest, and subscribed replay scope are durably persisted or dispatch-queued. The HTTP acknowledgement MUST NOT
+        wait for post-commit pipeline dispatch, system-node handler execution, or agent delivery completion.
+      event_type: >
+        The selected Twilio messaging callback slice emits literal provider_event_type `message_received` in payload
+        metadata. The canonical emitted Swarm event name is literal `inbound.twilio`, not a dynamic template.
     raw_webhook_mode: >
       Unknown providers may continue through the raw generic webhook mode, but that path is a different semantic concept and
       does not prove provider-trigger adapter closure. Configured providers MUST consume their manifest interpreter owner
       rather than generic signature, delivery-id, event-type, acknowledgement, or `inbound.{provider}` mapping fallbacks.
-      Raw webhook mode MUST NOT interpret `Stripe-Signature`; Stripe-signature semantics belong only to the configured
-      Stripe provider manifest.
+      Raw webhook mode MUST NOT interpret configured-provider signatures such as `Stripe-Signature` or
+      `X-Twilio-Signature`; configured-provider signature semantics belong only to the corresponding configured-provider
+      manifest.
   custom_tool_schema:
     description: Accepted fields for tool definitions in tools.yaml. This is the union of fields across all implementation
       classes.


### PR DESCRIPTION
## Summary

Closes #1725
Part of #1651

Adds Twilio form/query configured-provider trigger support as manifest data interpreted by `internal/providertriggers`.

## Governing Context

- `platform-spec.yaml` `provider_trigger_adapters`
- #1725 Pre-Implementation Coverage Audit and independent gate
- #1651 provider-diversity ladder / freeze-rule parent
- #1709 §7 provider-pack design context
- Twilio official docs for request validation and webhook parameters:
  - https://www.twilio.com/docs/usage/webhooks/webhooks-security
  - https://www.twilio.com/docs/usage/security#validating-requests
  - https://www.twilio.com/docs/messaging/guides/webhook-request

Requested process docs note: `docs/IMPLEMENTER_GUIDELINES.md` and `docs/SEMANTIC_DRIFT.md` are not present in this worktree; this PR follows the issue/gate plus `platform-spec.yaml` as binding context.

## Semantic Migration

- New canonical owner remains `internal/providertriggers`; Twilio is a built-in manifest, not a Go provider adapter.
- Runtime gateway only adds provider-neutral request facts: direct request URL, content type, query/form values, and parse-error state.
- Old invalid path: no Twilio branch in `internal/runtime/inbound.go`, no raw fallback interpretation of `X-Twilio-Signature`.
- Checked production paths: manifest registry load, served `/webhooks/{entity}/twilio`, target/secret resolution, marker persistence, EventBus publish, SQLite and Postgres stores.
- Migration complete for the approved #1725 Twilio form/query slice. Twilio JSON/bodySHA256 remains unsupported in this slice and fails closed.

## Proof

- `go test ./internal/providertriggers -count=1`
- `SWARM_TEST_POSTGRES_DSN='host=127.0.0.1 port=5432 user=youmew dbname=postgres sslmode=disable' PGPASSWORD=postgres go test ./internal/runtime -run 'Twilio|Provider|Webhook|Inbound' -count=1`
- `SWARM_TEST_POSTGRES_DSN='host=127.0.0.1 port=5432 user=youmew dbname=postgres sslmode=disable' PGPASSWORD=postgres go test ./internal/providertriggers ./internal/runtime -count=1`
- `SWARM_TEST_POSTGRES_DSN='host=127.0.0.1 port=5432 user=youmew dbname=postgres sslmode=disable' PGPASSWORD=postgres go test ./...`
