### PR TITLE
[agent-c][issue #1715] Add lookup value rows

### DIFF
--- a/internal/runtime/bootverify/checks.go
+++ b/internal/runtime/bootverify/checks.go
@@ -226,6 +226,7 @@ var bootCheckRegistry = []Check{
 	{ID: "accumulator_input_producer_path", Severity: SeverityHardInvalidity, Run: checkAccumulatorInputProducerPath},
 	{ID: "required_agents_match", Severity: "error", Run: checkRequiredAgentsMatch},
 	{ID: "handler_field_compliance", Severity: "error", Run: checkHandlerFieldCompliance},
+	{ID: policySheetLookupCheckID, Severity: SeverityHardInvalidity, Run: checkPolicySheetLookupValueRows},
 	{ID: "tool_resolution", Severity: "warning", Run: checkToolResolution},
 	{ID: "required_mcp_tool_availability", Severity: SeverityHardInvalidity, Run: checkRequiredMCPToolAvailability},
 	{ID: "platform_tool_usage_hints", Severity: SeverityHardInvalidity, Run: checkPlatformToolUsageHints},

--- a/internal/runtime/bootverify/flow_data_access_test.go
+++ b/internal/runtime/bootverify/flow_data_access_test.go
@@ -66,8 +66,8 @@ func TestRun_ValidatesFlowDataAccessDeclarations(t *testing.T) {
 }
 
 func TestBootCheckRegistry_HasFlowDataAccessCheckCount(t *testing.T) {
-	if got := len(bootCheckRegistry); got != 70 {
-		t.Fatalf("bootCheckRegistry count = %d, want 70", got)
+	if got := len(bootCheckRegistry); got != 71 {
+		t.Fatalf("bootCheckRegistry count = %d, want 71", got)
 	}
 }
 

--- a/internal/runtime/bootverify/report_test.go
+++ b/internal/runtime/bootverify/report_test.go
@@ -6070,8 +6070,8 @@ func TestRun_ReportsMissingRuntimeExecutorForOwnedRuntimeEvent(t *testing.T) {
 }
 
 func TestBootCheckRegistry_HasSpecCheckCount(t *testing.T) {
-	if got := len(bootCheckRegistry); got != 70 {
-		t.Fatalf("bootCheckRegistry count = %d, want 70", got)
+	if got := len(bootCheckRegistry); got != 71 {
+		t.Fatalf("bootCheckRegistry count = %d, want 71", got)
 	}
 	if got := len(supplementalChecks); got != 3 {
 		t.Fatalf("supplementalChecks count = %d, want 3", got)

--- a/internal/runtime/bootverify/workflow_policy_sheet_lookup_checks.go
+++ b/internal/runtime/bootverify/workflow_policy_sheet_lookup_checks.go
@@ -1,0 +1,369 @@
+package bootverify
+
+import (
+	"fmt"
+	"strings"
+
+	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
+	runtimepaths "github.com/division-sh/swarm/internal/runtime/core/paths"
+	"github.com/division-sh/swarm/internal/runtime/semanticview"
+)
+
+const policySheetLookupCheckID = "policy_sheet_lookup_value_rows"
+
+func checkPolicySheetLookupValueRows(c *checkerContext) []Finding {
+	findings := make([]Finding, 0)
+	nodes := c.source.NodeEntries()
+	for _, nodeID := range sortedNodeIDs(c.source) {
+		node, ok := nodes[nodeID]
+		if !ok {
+			continue
+		}
+		flowID := nodeFlowID(c.source, nodeID)
+		for eventType, handler := range node.EventHandlers {
+			eventType = strings.TrimSpace(eventType)
+			findings = append(findings, policySheetLookupDuplicateComputedBindings(nodeID, eventType, handler)...)
+			for idx, rule := range handler.Rules {
+				if !policySheetRuleIsLookupValueRow(rule) {
+					continue
+				}
+				ref := policySheetLookupRef{
+					FlowID:    flowID,
+					NodeID:    nodeID,
+					EventType: eventType,
+					RuleIndex: idx,
+					RuleID:    strings.TrimSpace(rule.ID),
+				}
+				findings = append(findings, validatePolicySheetLookupValueRow(c.source, ref, handler, rule)...)
+			}
+		}
+	}
+	return findings
+}
+
+type policySheetLookupRef struct {
+	FlowID    string
+	NodeID    string
+	EventType string
+	RuleIndex int
+	RuleID    string
+}
+
+func policySheetLookupFinding(ref policySheetLookupRef, detail string) Finding {
+	return Finding{
+		CheckID:  policySheetLookupCheckID,
+		Severity: SeverityHardInvalidity,
+		Message:  fmt.Sprintf("flow %s node %s handler %s lookup row %s: %s", defaultFlowLabel(ref.FlowID), ref.NodeID, ref.EventType, ref.RowLabel(), detail),
+		Location: ref.NodeID,
+	}
+}
+
+func (r policySheetLookupRef) RowLabel() string {
+	if id := strings.TrimSpace(r.RuleID); id != "" {
+		return id
+	}
+	return fmt.Sprintf("#%d", r.RuleIndex)
+}
+
+func policySheetRuleIsLookupValueRow(rule runtimecontracts.HandlerRuleEntry) bool {
+	if rule.PolicyRow.Kind == runtimecontracts.PolicySheetRowKindLookup {
+		return true
+	}
+	return rule.Compute != nil && rule.Compute.Operation == runtimecontracts.ComputeOpLookup
+}
+
+func validatePolicySheetLookupValueRow(source semanticview.Source, ref policySheetLookupRef, handler runtimecontracts.SystemNodeEventHandler, rule runtimecontracts.HandlerRuleEntry) []Finding {
+	findings := make([]Finding, 0)
+	if rule.PolicyRow.Kind != runtimecontracts.PolicySheetRowKindLookup {
+		findings = append(findings, policySheetLookupFinding(ref, "lookup compute must originate from a policy-sheet lookup row"))
+	}
+	if rule.Compute == nil || rule.Compute.Operation != runtimecontracts.ComputeOpLookup {
+		findings = append(findings, policySheetLookupFinding(ref, "lookup row must lower to compute-owned lookup operation"))
+		return findings
+	}
+	spec := rule.Compute.Lookup
+	if spec == nil {
+		findings = append(findings, policySheetLookupFinding(ref, "lookup row has no canonical lookup plan"))
+		return findings
+	}
+	storePath := runtimepaths.Parse(rule.Compute.StoreAs)
+	if storePath.Root != runtimepaths.RootComputed || len(storePath.Segments) == 0 {
+		findings = append(findings, policySheetLookupFinding(ref, fmt.Sprintf("lookup.into must target computed.*, got %q", strings.TrimSpace(rule.Compute.StoreAs))))
+	} else if !policySheetLookupPathIsSimple(storePath) {
+		findings = append(findings, policySheetLookupFinding(ref, fmt.Sprintf("lookup.into %q must be a simple computed.* path", strings.TrimSpace(rule.Compute.StoreAs))))
+	}
+	if !spec.DefaultDeclared {
+		if !policySheetLookupDomainsClosedAndExhaustive(source, ref, spec, &findings) {
+			findings = append(findings, policySheetLookupFinding(ref, "lookup.default: fail is required because at least one lookup.on root has an open or unknown domain or the closed-domain table is not exhaustive"))
+		}
+	} else if !spec.DefaultFail {
+		findings = append(findings, policySheetLookupFinding(ref, "lookup.default currently supports only fail"))
+	}
+	findings = append(findings, validatePolicySheetLookupKeyTypes(source, ref, spec)...)
+	if !policySheetLookupBindingConsumed(handler, rule, strings.TrimSpace(rule.Compute.StoreAs)) {
+		findings = append(findings, policySheetLookupFinding(ref, fmt.Sprintf("lookup.into %q is not consumed by a supported downstream condition, emit field, activity input, fan_out, or expression", strings.TrimSpace(rule.Compute.StoreAs))))
+	}
+	return findings
+}
+
+func policySheetLookupPathIsSimple(path runtimepaths.Path) bool {
+	if path.Root == runtimepaths.RootUnknown || len(path.Segments) == 0 {
+		return false
+	}
+	for _, segment := range path.Segments {
+		if strings.TrimSpace(segment) == "" {
+			return false
+		}
+	}
+	return true
+}
+
+func policySheetLookupDomainsClosedAndExhaustive(source semanticview.Source, ref policySheetLookupRef, spec *runtimecontracts.ComputeLookupSpec, findings *[]Finding) bool {
+	domains := make([][]string, 0, len(spec.OnPaths))
+	for _, path := range spec.OnPaths {
+		kind, closed := policySheetLookupPathDomain(source, ref.FlowID, ref.EventType, path)
+		if kind == "" {
+			kind = "unknown"
+		}
+		if !closed {
+			return false
+		}
+		switch kind {
+		case "bool":
+			domains = append(domains, []string{"bool:false", "bool:true"})
+		default:
+			if findings != nil {
+				*findings = append(*findings, policySheetLookupFinding(ref, fmt.Sprintf("lookup.on %q resolves to unsupported closed domain kind %s", path.String(), kind)))
+			}
+			return false
+		}
+	}
+	required := policySheetLookupCartesianKeys(domains)
+	seen := map[string]struct{}{}
+	for _, entry := range spec.Entries {
+		seen[policySheetLookupEntryKey(entry.Key)] = struct{}{}
+	}
+	for _, key := range required {
+		if _, ok := seen[key]; !ok {
+			return false
+		}
+	}
+	return true
+}
+
+func policySheetLookupCartesianKeys(domains [][]string) []string {
+	if len(domains) == 0 {
+		return nil
+	}
+	out := []string{""}
+	for _, domain := range domains {
+		next := make([]string, 0, len(out)*len(domain))
+		for _, prefix := range out {
+			for _, value := range domain {
+				if prefix == "" {
+					next = append(next, value)
+					continue
+				}
+				next = append(next, prefix+"\x00"+value)
+			}
+		}
+		out = next
+	}
+	return out
+}
+
+func policySheetLookupEntryKey(key []runtimecontracts.ComputeLookupLiteral) string {
+	parts := make([]string, 0, len(key))
+	for _, literal := range key {
+		parts = append(parts, strings.TrimSpace(literal.Canonical))
+	}
+	return strings.Join(parts, "\x00")
+}
+
+func validatePolicySheetLookupKeyTypes(source semanticview.Source, ref policySheetLookupRef, spec *runtimecontracts.ComputeLookupSpec) []Finding {
+	findings := make([]Finding, 0)
+	kinds := make([]string, 0, len(spec.OnPaths))
+	for _, path := range spec.OnPaths {
+		kind, _ := policySheetLookupPathDomain(source, ref.FlowID, ref.EventType, path)
+		kinds = append(kinds, kind)
+	}
+	for entryIdx, entry := range spec.Entries {
+		if len(entry.Key) != len(kinds) {
+			findings = append(findings, policySheetLookupFinding(ref, fmt.Sprintf("lookup.entries[%d] key width %d does not match lookup.on width %d", entryIdx, len(entry.Key), len(kinds))))
+			continue
+		}
+		for keyIdx, literal := range entry.Key {
+			want := kinds[keyIdx]
+			if want == "" {
+				continue
+			}
+			if !policySheetLookupLiteralMatchesKind(literal.Kind, want) {
+				findings = append(findings, policySheetLookupFinding(ref, fmt.Sprintf("lookup.entries[%d].key[%d] literal %s has type %s but lookup.on %q is %s", entryIdx, keyIdx, literal.Summary, literal.Kind, spec.On[keyIdx], want)))
+			}
+		}
+	}
+	return findings
+}
+
+func policySheetLookupLiteralMatchesKind(got, want string) bool {
+	got = strings.TrimSpace(got)
+	want = strings.TrimSpace(want)
+	switch want {
+	case "":
+		return true
+	case "number":
+		return got == "number"
+	default:
+		return got == want
+	}
+}
+
+func policySheetLookupPathDomain(source semanticview.Source, flowID, eventType string, path runtimepaths.Path) (kind string, closed bool) {
+	if path.Root != runtimepaths.RootPayload || len(path.Segments) != 1 {
+		return "", false
+	}
+	proof := semanticview.ResolveFlowEventProof(source, flowID, eventType)
+	if !proof.HasSchema {
+		return "", false
+	}
+	field, ok := proof.Entry.Payload.Properties[strings.TrimSpace(path.Segments[0])]
+	if !ok {
+		return "", false
+	}
+	switch strings.TrimSpace(strings.ToLower(field.Type)) {
+	case "bool", "boolean":
+		return "bool", true
+	case "int", "integer":
+		return "int", false
+	case "number", "numeric", "float", "double":
+		return "number", false
+	case "string", "text", "uuid", "timestamp", "datetime", "date":
+		return "string", false
+	default:
+		return "", false
+	}
+}
+
+func policySheetLookupBindingConsumed(handler runtimecontracts.SystemNodeEventHandler, lookupRule runtimecontracts.HandlerRuleEntry, target string) bool {
+	target = strings.TrimSpace(target)
+	if target == "" {
+		return false
+	}
+	for _, expr := range handlerEntityExpressions(handler) {
+		if policySheetLookupExpressionConsumes(expr.Expression, target) {
+			return true
+		}
+	}
+	if policySheetLookupActivityConsumes(handler.Activity, target) {
+		return true
+	}
+	if handler.FanOut != nil && policySheetLookupFanOutConsumes(*handler.FanOut, target) {
+		return true
+	}
+	for _, rule := range handler.Rules {
+		if strings.TrimSpace(rule.ID) == strings.TrimSpace(lookupRule.ID) && rule.Compute == lookupRule.Compute {
+			continue
+		}
+		if policySheetLookupActivityConsumes(rule.Activity, target) {
+			return true
+		}
+		if rule.FanOut != nil && policySheetLookupFanOutConsumes(*rule.FanOut, target) {
+			return true
+		}
+	}
+	return false
+}
+
+func policySheetLookupActivityConsumes(activity runtimecontracts.ActivitySpec, target string) bool {
+	for _, expr := range activity.Input {
+		if policySheetLookupExpressionValueConsumes(expr, target) {
+			return true
+		}
+	}
+	return false
+}
+
+func policySheetLookupFanOutConsumes(spec runtimecontracts.FanOutSpec, target string) bool {
+	if policySheetLookupExpressionConsumes(spec.ItemsFrom, target) {
+		return true
+	}
+	for _, expr := range spec.Emit.Fields {
+		if policySheetLookupExpressionValueConsumes(expr, target) {
+			return true
+		}
+	}
+	return false
+}
+
+func policySheetLookupExpressionValueConsumes(expr runtimecontracts.ExpressionValue, target string) bool {
+	switch expr.Kind {
+	case runtimecontracts.ExpressionKindRef:
+		return strings.TrimSpace(expr.Ref) == target
+	case runtimecontracts.ExpressionKindCEL:
+		return policySheetLookupExpressionConsumes(expr.CEL, target)
+	default:
+		return false
+	}
+}
+
+func policySheetLookupExpressionConsumes(expression, target string) bool {
+	expression = strings.TrimSpace(expression)
+	target = strings.TrimSpace(target)
+	if expression == "" || target == "" {
+		return false
+	}
+	if expression == target {
+		return true
+	}
+	return strings.Contains(expression, target+".") ||
+		strings.Contains(expression, target+" ") ||
+		strings.Contains(expression, target+"=") ||
+		strings.Contains(expression, target+")") ||
+		strings.Contains(expression, target+"]") ||
+		strings.Contains(expression, target+",") ||
+		strings.Contains(expression, target+"!") ||
+		strings.HasSuffix(expression, target)
+}
+
+func policySheetLookupDuplicateComputedBindings(nodeID, eventType string, handler runtimecontracts.SystemNodeEventHandler) []Finding {
+	type binding struct {
+		Target string
+		Scope  string
+	}
+	bindings := make([]binding, 0)
+	appendCompute := func(scope string, spec *runtimecontracts.ComputeSpec) {
+		if spec == nil {
+			return
+		}
+		target := strings.TrimSpace(spec.StoreAs)
+		if target == "" {
+			return
+		}
+		if runtimepaths.Parse(target).Root == runtimepaths.RootComputed {
+			bindings = append(bindings, binding{Target: target, Scope: scope})
+		}
+	}
+	appendCompute("handler.compute", handler.Compute)
+	for idx, rule := range handler.Rules {
+		scope := fmt.Sprintf("handler.rules[%d].compute", idx)
+		if id := strings.TrimSpace(rule.ID); id != "" {
+			scope = "handler.rules[" + id + "].compute"
+		}
+		appendCompute(scope, rule.Compute)
+	}
+	seen := map[string]binding{}
+	findings := make([]Finding, 0)
+	for _, item := range bindings {
+		if prev, ok := seen[item.Target]; ok {
+			findings = append(findings, Finding{
+				CheckID:  policySheetLookupCheckID,
+				Severity: SeverityHardInvalidity,
+				Message:  fmt.Sprintf("node %s handler %s computed binding %q is written by both %s and %s", nodeID, eventType, item.Target, prev.Scope, item.Scope),
+				Location: nodeID,
+			})
+			continue
+		}
+		seen[item.Target] = item
+	}
+	return findings
+}

--- a/internal/runtime/bootverify/workflow_policy_sheet_lookup_checks.go
+++ b/internal/runtime/bootverify/workflow_policy_sheet_lookup_checks.go
@@ -254,6 +254,9 @@ func policySheetLookupBindingConsumed(handler runtimecontracts.SystemNodeEventHa
 			return true
 		}
 	}
+	if policySheetLookupEmitFieldsConsume(handler, target) {
+		return true
+	}
 	if policySheetLookupActivityConsumes(handler.Activity, target) {
 		return true
 	}
@@ -269,6 +272,17 @@ func policySheetLookupBindingConsumed(handler runtimecontracts.SystemNodeEventHa
 		}
 		if rule.FanOut != nil && policySheetLookupFanOutConsumes(*rule.FanOut, target) {
 			return true
+		}
+	}
+	return false
+}
+
+func policySheetLookupEmitFieldsConsume(handler runtimecontracts.SystemNodeEventHandler, target string) bool {
+	for _, site := range runtimecontracts.HandlerDeclarativeEmitSites(handler) {
+		for _, expr := range site.Spec.Fields {
+			if policySheetLookupExpressionValueConsumes(expr, target) {
+				return true
+			}
 		}
 	}
 	return false

--- a/internal/runtime/bootverify/workflow_policy_sheet_lookup_checks_test.go
+++ b/internal/runtime/bootverify/workflow_policy_sheet_lookup_checks_test.go
@@ -18,6 +18,24 @@ func TestPolicySheetLookupValueRowsAcceptsConsumedDefaultedInlineLookup(t *testi
 	}
 }
 
+func TestPolicySheetLookupValueRowsAcceptsEmitFieldConsumer(t *testing.T) {
+	handler := bootverifyLookupHandler(true, false)
+	handler.Rules = append(handler.Rules, runtimecontracts.HandlerRuleEntry{
+		ID:        "emit_template",
+		Condition: "true",
+		Emit: runtimecontracts.EmitSpec{
+			Event: "repo.service_template_selected",
+			Fields: map[string]runtimecontracts.ExpressionValue{
+				"template_path": runtimecontracts.CELExpression("computed.template_path"),
+			},
+		},
+	})
+	findings := bootverifyLookupFindings(handler)
+	if len(findings) != 0 {
+		t.Fatalf("lookup findings = %#v, want none", findings)
+	}
+}
+
 func TestPolicySheetLookupValueRowsRequiresDefaultForOpenDomains(t *testing.T) {
 	handler := bootverifyLookupHandler(false, true)
 	findings := bootverifyLookupFindings(handler)

--- a/internal/runtime/bootverify/workflow_policy_sheet_lookup_checks_test.go
+++ b/internal/runtime/bootverify/workflow_policy_sheet_lookup_checks_test.go
@@ -1,0 +1,123 @@
+package bootverify
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
+	"github.com/division-sh/swarm/internal/runtime/core/paths"
+	"github.com/division-sh/swarm/internal/runtime/semanticview"
+)
+
+func TestPolicySheetLookupValueRowsAcceptsConsumedDefaultedInlineLookup(t *testing.T) {
+	handler := bootverifyLookupHandler(true, true)
+	findings := bootverifyLookupFindings(handler)
+	if len(findings) != 0 {
+		t.Fatalf("lookup findings = %#v, want none", findings)
+	}
+}
+
+func TestPolicySheetLookupValueRowsRequiresDefaultForOpenDomains(t *testing.T) {
+	handler := bootverifyLookupHandler(false, true)
+	findings := bootverifyLookupFindings(handler)
+	if !bootverifyLookupFindingContains(findings, "lookup.default: fail is required") {
+		t.Fatalf("lookup findings = %#v, want missing default failure", findings)
+	}
+}
+
+func TestPolicySheetLookupValueRowsRejectsDeadBinding(t *testing.T) {
+	handler := bootverifyLookupHandler(true, false)
+	findings := bootverifyLookupFindings(handler)
+	if !bootverifyLookupFindingContains(findings, "is not consumed") {
+		t.Fatalf("lookup findings = %#v, want dead binding failure", findings)
+	}
+}
+
+func TestPolicySheetLookupValueRowsTypeChecksPayloadKeys(t *testing.T) {
+	handler := bootverifyLookupHandler(true, true)
+	handler.Rules[0].Compute.Lookup.Entries[0].Key[1] = runtimecontracts.ComputeLookupLiteral{
+		Value:     int64(1),
+		Kind:      "int",
+		Canonical: "int:1",
+		Summary:   "1",
+	}
+	findings := bootverifyLookupFindings(handler)
+	if !bootverifyLookupFindingContains(findings, "payload.language") || !bootverifyLookupFindingContains(findings, "has type int") {
+		t.Fatalf("lookup findings = %#v, want key type mismatch", findings)
+	}
+}
+
+func bootverifyLookupFindings(handler runtimecontracts.SystemNodeEventHandler) []Finding {
+	bundle := &runtimecontracts.WorkflowContractBundle{
+		Nodes: map[string]runtimecontracts.SystemNodeContract{
+			"repo_scaffold": {
+				ID: "repo_scaffold",
+				EventHandlers: map[string]runtimecontracts.SystemNodeEventHandler{
+					"repo.scaffold_requested": handler,
+				},
+			},
+		},
+		Events: map[string]runtimecontracts.EventCatalogEntry{
+			"repo.scaffold_requested": {
+				Payload: runtimecontracts.EventPayloadSpec{
+					Properties: map[string]runtimecontracts.EventFieldSpec{
+						"scaffold_type": {Type: "string"},
+						"language":      {Type: "string"},
+					},
+				},
+			},
+		},
+	}
+	source := semanticview.Wrap(bundle)
+	return checkPolicySheetLookupValueRows(newCheckerContext(context.Background(), source, Options{}))
+}
+
+func bootverifyLookupHandler(defaultDeclared, includeConsumer bool) runtimecontracts.SystemNodeEventHandler {
+	lookup := &runtimecontracts.ComputeLookupSpec{
+		RowID: "scaffold_paths",
+		On:    []string{"payload.scaffold_type", "payload.language"},
+		OnPaths: []paths.Path{
+			paths.Parse("payload.scaffold_type"),
+			paths.Parse("payload.language"),
+		},
+		DefaultDeclared: defaultDeclared,
+		DefaultFail:     defaultDeclared,
+		Entries: []runtimecontracts.ComputeLookupEntry{{
+			Key: []runtimecontracts.ComputeLookupLiteral{
+				{Value: "service", Kind: "string", Canonical: "string:\"service\"", Summary: `"service"`},
+				{Value: "go", Kind: "string", Canonical: "string:\"go\"", Summary: `"go"`},
+			},
+			Value:        "templates/service/go",
+			ValueKind:    "string",
+			ValueSummary: `"templates/service/go"`,
+		}},
+	}
+	handler := runtimecontracts.SystemNodeEventHandler{
+		Rules: []runtimecontracts.HandlerRuleEntry{{
+			ID:        "scaffold_paths",
+			PolicyRow: runtimecontracts.PolicySheetRowMetadata{Kind: runtimecontracts.PolicySheetRowKindLookup, Lookup: lookup},
+			Compute: &runtimecontracts.ComputeSpec{
+				Operation: runtimecontracts.ComputeOpLookup,
+				StoreAs:   "computed.template_path",
+				Lookup:    lookup,
+			},
+		}},
+	}
+	if includeConsumer {
+		handler.Rules = append(handler.Rules, runtimecontracts.HandlerRuleEntry{
+			ID:        "service_route",
+			Condition: `computed.template_path == "templates/service/go"`,
+		})
+	}
+	return handler
+}
+
+func bootverifyLookupFindingContains(findings []Finding, contains string) bool {
+	for _, finding := range findings {
+		if finding.CheckID == policySheetLookupCheckID && strings.Contains(finding.Message, contains) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/runtime/contracts/enums.go
+++ b/internal/runtime/contracts/enums.go
@@ -68,6 +68,7 @@ const (
 	ComputeOpMin
 	ComputeOpMax
 	ComputeOpCount
+	ComputeOpLookup
 )
 
 func ParseComputeOperation(text string) (ComputeOperation, error) {
@@ -84,6 +85,8 @@ func ParseComputeOperation(text string) (ComputeOperation, error) {
 		return ComputeOpMax, nil
 	case "count":
 		return ComputeOpCount, nil
+	case "lookup":
+		return ComputeOpUnknown, fmt.Errorf("compute operation %q is internal to policy-sheet value rows; author lookup rows under rules", text)
 	case "":
 		return ComputeOpUnknown, nil
 	default:
@@ -105,6 +108,8 @@ func (o ComputeOperation) String() string {
 		return "max"
 	case ComputeOpCount:
 		return "count"
+	case ComputeOpLookup:
+		return "lookup"
 	default:
 		return ""
 	}

--- a/internal/runtime/contracts/workflow_contract_policy_sheet.go
+++ b/internal/runtime/contracts/workflow_contract_policy_sheet.go
@@ -308,7 +308,7 @@ func decodePolicySheetLookupOn(node *yaml.Node) ([]string, error) {
 		return nil, fmt.Errorf("POLICY-SHEET-ROW: lookup.on requires at least one explicit root path")
 	}
 	for _, selector := range on {
-		if err := validatePolicySheetPath(selector, "lookup.on", []string{"payload", "entity", "policy", "event"}); err != nil {
+		if err := validatePolicySheetPath(selector, "lookup.on", []string{"payload"}); err != nil {
 			return nil, err
 		}
 	}

--- a/internal/runtime/contracts/workflow_contract_policy_sheet.go
+++ b/internal/runtime/contracts/workflow_contract_policy_sheet.go
@@ -1,11 +1,13 @@
 package contracts
 
 import (
+	"encoding/json"
 	"fmt"
 	"math"
 	"strconv"
 	"strings"
 
+	"github.com/division-sh/swarm/internal/runtime/core/paths"
 	"gopkg.in/yaml.v3"
 )
 
@@ -14,7 +16,7 @@ func lowerPolicySheetRuleNode(node *yaml.Node, rule *HandlerRuleEntry) error {
 		return nil
 	}
 	rowNodes := map[string]*yaml.Node{}
-	for _, key := range []string{"when", "case", "range", "else", "default"} {
+	for _, key := range []string{"when", "case", "range", "lookup", "else", "default"} {
 		if value := yamlMappingValueNode(node, key); value != nil {
 			rowNodes[key] = value
 		}
@@ -54,6 +56,17 @@ func lowerPolicySheetRuleNode(node *yaml.Node, rule *HandlerRuleEntry) error {
 		}
 		rule.Condition = condition
 		rule.PolicyRow = metadata
+	case rowNodes["lookup"] != nil:
+		metadata, compute, err := decodePolicySheetLookupRow(rowNodes["lookup"], strings.TrimSpace(rule.ID))
+		if err != nil {
+			return err
+		}
+		if !rule.Emit.Empty() || strings.TrimSpace(rule.AdvancesTo) != "" || strings.TrimSpace(rule.Action.ID) != "" ||
+			!rule.Activity.Empty() || rule.DataAccumulation.HasWrites() || rule.FanOut != nil || rule.Compute != nil {
+			return fmt.Errorf("POLICY-SHEET-ROW: lookup row %q derives a value only and cannot declare branch outputs", strings.TrimSpace(rule.ID))
+		}
+		rule.Compute = compute
+		rule.PolicyRow = metadata
 	case rowNodes["else"] != nil:
 		if err := requirePolicySheetBoolTrue(rowNodes["else"], "else"); err != nil {
 			return err
@@ -85,6 +98,7 @@ func validatePolicySheetRows(rules []HandlerRuleEntry, context handlerRuleDecode
 		return fmt.Errorf("POLICY-SHEET-ROW: typed policy-sheet rows are only supported under handler.rules")
 	}
 	seenIDs := map[string]int{}
+	hasSelectionRow := false
 	hasDefault := false
 	caseKeys := map[string]int{}
 	rangesByValue := map[string][]policySheetRangeForValidation{}
@@ -99,6 +113,9 @@ func validatePolicySheetRows(rules []HandlerRuleEntry, context handlerRuleDecode
 		seenIDs[id] = idx
 		if strings.EqualFold(strings.TrimSpace(rule.Condition), "else") {
 			hasDefault = true
+		}
+		if rule.PolicyRow.Kind == PolicySheetRowKindWhen || rule.PolicyRow.Kind == PolicySheetRowKindCase || rule.PolicyRow.Kind == PolicySheetRowKindRange {
+			hasSelectionRow = true
 		}
 		switch rule.PolicyRow.Kind {
 		case PolicySheetRowKindCase:
@@ -117,7 +134,7 @@ func validatePolicySheetRows(rules []HandlerRuleEntry, context handlerRuleDecode
 			})
 		}
 	}
-	if !hasDefault {
+	if hasSelectionRow && !hasDefault {
 		return fmt.Errorf("POLICY-SHEET-ROW: rules with typed policy-sheet rows require an else/default row")
 	}
 	for value, ranges := range rangesByValue {
@@ -231,6 +248,287 @@ func decodePolicySheetRangeRow(node *yaml.Node) (string, PolicySheetRowMetadata,
 		RangeUpper:   upper,
 		Monotonicity: monotonicity,
 	}, nil
+}
+
+func decodePolicySheetLookupRow(node *yaml.Node, rowID string) (PolicySheetRowMetadata, *ComputeSpec, error) {
+	if node == nil || node.Kind != yaml.MappingNode {
+		return PolicySheetRowMetadata{}, nil, fmt.Errorf("POLICY-SHEET-ROW: lookup row must be a mapping")
+	}
+	if err := validatePolicySheetMappingKeys(node, "lookup", map[string]struct{}{"on": {}, "entries": {}, "into": {}, "default": {}}); err != nil {
+		return PolicySheetRowMetadata{}, nil, err
+	}
+	on, err := decodePolicySheetLookupOn(yamlMappingValueNode(node, "on"))
+	if err != nil {
+		return PolicySheetRowMetadata{}, nil, err
+	}
+	into, err := decodePolicySheetScalarString(yamlMappingValueNode(node, "into"), "lookup.into")
+	if err != nil {
+		return PolicySheetRowMetadata{}, nil, err
+	}
+	if err := validatePolicySheetLookupInto(into); err != nil {
+		return PolicySheetRowMetadata{}, nil, err
+	}
+	entries, err := decodePolicySheetLookupEntries(yamlMappingValueNode(node, "entries"), len(on))
+	if err != nil {
+		return PolicySheetRowMetadata{}, nil, err
+	}
+	defaultFail, defaultDeclared, err := decodePolicySheetLookupDefault(yamlMappingValueNode(node, "default"))
+	if err != nil {
+		return PolicySheetRowMetadata{}, nil, err
+	}
+	spec := ComputeLookupSpec{
+		RowID:           strings.TrimSpace(rowID),
+		On:              on,
+		OnPaths:         make([]paths.Path, 0, len(on)),
+		Entries:         entries,
+		DefaultFail:     defaultFail,
+		DefaultDeclared: defaultDeclared,
+	}
+	for _, selector := range on {
+		spec.OnPaths = append(spec.OnPaths, paths.Parse(selector))
+	}
+	compute := &ComputeSpec{
+		Operation: ComputeOpLookup,
+		StoreAs:   strings.TrimSpace(into),
+		Lookup:    &spec,
+	}
+	metadata := PolicySheetRowMetadata{
+		Kind:   PolicySheetRowKindLookup,
+		Lookup: &spec,
+	}
+	return metadata, compute, nil
+}
+
+func decodePolicySheetLookupOn(node *yaml.Node) ([]string, error) {
+	on, err := decodePolicySheetStringList(node, "lookup.on")
+	if err != nil {
+		return nil, err
+	}
+	if len(on) == 0 {
+		return nil, fmt.Errorf("POLICY-SHEET-ROW: lookup.on requires at least one explicit root path")
+	}
+	for _, selector := range on {
+		if err := validatePolicySheetPath(selector, "lookup.on", []string{"payload", "entity", "policy", "event"}); err != nil {
+			return nil, err
+		}
+	}
+	return on, nil
+}
+
+func validatePolicySheetLookupInto(into string) error {
+	parsed := paths.Parse(into)
+	if parsed.Root != paths.RootComputed || len(parsed.Segments) == 0 {
+		return fmt.Errorf("POLICY-SHEET-ROW: lookup.into %q must target computed.*", strings.TrimSpace(into))
+	}
+	for _, segment := range parsed.Segments {
+		if !isPolicySheetPathSegment(segment) {
+			return fmt.Errorf("POLICY-SHEET-ROW: lookup.into %q must be a simple computed.* path", strings.TrimSpace(into))
+		}
+	}
+	return nil
+}
+
+func decodePolicySheetLookupEntries(node *yaml.Node, keyWidth int) ([]ComputeLookupEntry, error) {
+	if node == nil || node.Kind == 0 {
+		return nil, fmt.Errorf("POLICY-SHEET-ROW: lookup.entries is required")
+	}
+	if node.Kind != yaml.SequenceNode {
+		return nil, fmt.Errorf("POLICY-SHEET-ROW: lookup.entries must be a list of {key, value} entries")
+	}
+	if len(node.Content) == 0 {
+		return nil, fmt.Errorf("POLICY-SHEET-ROW: lookup.entries requires at least one entry")
+	}
+	out := make([]ComputeLookupEntry, 0, len(node.Content))
+	seen := map[string]int{}
+	valueKind := ""
+	for idx, item := range node.Content {
+		entry, err := decodePolicySheetLookupEntry(item, keyWidth)
+		if err != nil {
+			return nil, fmt.Errorf("POLICY-SHEET-ROW: lookup.entries[%d]: %w", idx, err)
+		}
+		key := canonicalPolicySheetLookupKey(entry.Key)
+		if prev, ok := seen[key]; ok {
+			return nil, fmt.Errorf("POLICY-SHEET-ROW: duplicate lookup key at entries[%d] and entries[%d]", prev, idx)
+		}
+		seen[key] = idx
+		if valueKind == "" {
+			valueKind = entry.ValueKind
+		} else if entry.ValueKind != valueKind {
+			return nil, fmt.Errorf("POLICY-SHEET-ROW: lookup.entries[%d] value type %s does not match earlier value type %s", idx, entry.ValueKind, valueKind)
+		}
+		out = append(out, entry)
+	}
+	return out, nil
+}
+
+func decodePolicySheetLookupEntry(node *yaml.Node, keyWidth int) (ComputeLookupEntry, error) {
+	if node == nil || node.Kind != yaml.MappingNode {
+		return ComputeLookupEntry{}, fmt.Errorf("entry must be a mapping")
+	}
+	if err := validatePolicySheetMappingKeys(node, "lookup.entry", map[string]struct{}{"key": {}, "value": {}}); err != nil {
+		return ComputeLookupEntry{}, err
+	}
+	keyNode := yamlMappingValueNode(node, "key")
+	if keyNode == nil {
+		return ComputeLookupEntry{}, fmt.Errorf("key is required")
+	}
+	valueNode := yamlMappingValueNode(node, "value")
+	if valueNode == nil {
+		return ComputeLookupEntry{}, fmt.Errorf("value is required")
+	}
+	key, err := decodePolicySheetLookupKey(keyNode, keyWidth)
+	if err != nil {
+		return ComputeLookupEntry{}, err
+	}
+	value, valueKind, valueSummary, err := decodePolicySheetLookupScalar(valueNode, "value")
+	if err != nil {
+		return ComputeLookupEntry{}, err
+	}
+	return ComputeLookupEntry{
+		Key:          key,
+		Value:        value,
+		ValueKind:    valueKind,
+		ValueSummary: valueSummary,
+	}, nil
+}
+
+func decodePolicySheetLookupKey(node *yaml.Node, keyWidth int) ([]ComputeLookupLiteral, error) {
+	if keyWidth == 1 && node.Kind != yaml.SequenceNode {
+		literal, err := decodePolicySheetLookupLiteral(node, "key")
+		if err != nil {
+			return nil, err
+		}
+		return []ComputeLookupLiteral{literal}, nil
+	}
+	if node.Kind != yaml.SequenceNode {
+		return nil, fmt.Errorf("key must be a scalar list matching lookup.on")
+	}
+	if len(node.Content) != keyWidth {
+		return nil, fmt.Errorf("key width %d does not match lookup.on width %d", len(node.Content), keyWidth)
+	}
+	out := make([]ComputeLookupLiteral, 0, len(node.Content))
+	for idx, item := range node.Content {
+		literal, err := decodePolicySheetLookupLiteral(item, fmt.Sprintf("key[%d]", idx))
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, literal)
+	}
+	return out, nil
+}
+
+func decodePolicySheetLookupLiteral(node *yaml.Node, label string) (ComputeLookupLiteral, error) {
+	value, _, _, err := decodePolicySheetLookupScalar(node, label)
+	if err != nil {
+		return ComputeLookupLiteral{}, err
+	}
+	kind, summary, canonical, ok := CanonicalizeComputeLookupValue(value)
+	if !ok {
+		return ComputeLookupLiteral{}, fmt.Errorf("%s uses unsupported lookup key type %T", label, value)
+	}
+	return ComputeLookupLiteral{
+		Value:     value,
+		Kind:      kind,
+		Canonical: canonical,
+		Summary:   summary,
+	}, nil
+}
+
+func decodePolicySheetLookupScalar(node *yaml.Node, label string) (any, string, string, error) {
+	if node == nil || node.Kind != yaml.ScalarNode {
+		return nil, "", "", fmt.Errorf("%s must be a scalar", label)
+	}
+	raw := strings.TrimSpace(node.Value)
+	switch strings.TrimSpace(node.Tag) {
+	case "!!str", "":
+		return raw, "string", strconv.Quote(raw), nil
+	case "!!bool":
+		if raw != "true" && raw != "false" {
+			return nil, "", "", fmt.Errorf("%s bool literal %q is invalid", label, raw)
+		}
+		return raw == "true", "bool", raw, nil
+	case "!!int":
+		parsed, err := strconv.ParseInt(raw, 10, 64)
+		if err != nil {
+			return nil, "", "", fmt.Errorf("%s integer literal %q is invalid", label, raw)
+		}
+		return parsed, "int", strconv.FormatInt(parsed, 10), nil
+	case "!!float":
+		parsed, err := strconv.ParseFloat(raw, 64)
+		if err != nil {
+			return nil, "", "", fmt.Errorf("%s numeric literal %q is invalid", label, raw)
+		}
+		return parsed, "number", strconv.FormatFloat(parsed, 'g', -1, 64), nil
+	case "!!null":
+		return nil, "", "", fmt.Errorf("%s null literal is not supported in lookup tables", label)
+	default:
+		return nil, "", "", fmt.Errorf("%s uses unsupported literal tag %s", label, node.Tag)
+	}
+}
+
+func decodePolicySheetLookupDefault(node *yaml.Node) (bool, bool, error) {
+	if node == nil || node.Kind == 0 {
+		return false, false, nil
+	}
+	if node.Kind != yaml.ScalarNode {
+		return false, false, fmt.Errorf("POLICY-SHEET-ROW: lookup.default must be scalar fail")
+	}
+	if strings.TrimSpace(node.Value) != "fail" {
+		return false, false, fmt.Errorf("POLICY-SHEET-ROW: lookup.default currently supports only fail")
+	}
+	return true, true, nil
+}
+
+func canonicalPolicySheetLookupKey(key []ComputeLookupLiteral) string {
+	parts := make([]string, 0, len(key))
+	for _, literal := range key {
+		parts = append(parts, literal.Canonical)
+	}
+	return strings.Join(parts, "\x00")
+}
+
+func CanonicalizeComputeLookupValue(value any) (kind, summary, canonical string, ok bool) {
+	switch typed := value.(type) {
+	case string:
+		kind, summary = "string", strconv.Quote(typed)
+	case bool:
+		kind, summary = "bool", strconv.FormatBool(typed)
+	case int:
+		kind, summary = "int", strconv.FormatInt(int64(typed), 10)
+	case int8:
+		kind, summary = "int", strconv.FormatInt(int64(typed), 10)
+	case int16:
+		kind, summary = "int", strconv.FormatInt(int64(typed), 10)
+	case int32:
+		kind, summary = "int", strconv.FormatInt(int64(typed), 10)
+	case int64:
+		kind, summary = "int", strconv.FormatInt(typed, 10)
+	case uint:
+		kind, summary = "int", strconv.FormatUint(uint64(typed), 10)
+	case uint8:
+		kind, summary = "int", strconv.FormatUint(uint64(typed), 10)
+	case uint16:
+		kind, summary = "int", strconv.FormatUint(uint64(typed), 10)
+	case uint32:
+		kind, summary = "int", strconv.FormatUint(uint64(typed), 10)
+	case uint64:
+		kind, summary = "int", strconv.FormatUint(typed, 10)
+	case float32:
+		kind, summary = "number", strconv.FormatFloat(float64(typed), 'g', -1, 64)
+	case float64:
+		kind, summary = "number", strconv.FormatFloat(typed, 'g', -1, 64)
+	case json.Number:
+		if i, err := typed.Int64(); err == nil {
+			kind, summary = "int", strconv.FormatInt(i, 10)
+		} else if f, err := typed.Float64(); err == nil {
+			kind, summary = "number", strconv.FormatFloat(f, 'g', -1, 64)
+		} else {
+			return "", "", "", false
+		}
+	default:
+		return "", "", "", false
+	}
+	return kind, summary, kind + ":" + summary, true
 }
 
 func decodePolicySheetSelectors(node *yaml.Node) ([]string, error) {

--- a/internal/runtime/contracts/workflow_contract_types.go
+++ b/internal/runtime/contracts/workflow_contract_types.go
@@ -167,6 +167,7 @@ const (
 	PolicySheetRowKindWhen    PolicySheetRowKind = "when"
 	PolicySheetRowKindCase    PolicySheetRowKind = "case"
 	PolicySheetRowKindRange   PolicySheetRowKind = "range"
+	PolicySheetRowKindLookup  PolicySheetRowKind = "lookup"
 	PolicySheetRowKindDefault PolicySheetRowKind = "default"
 )
 
@@ -178,6 +179,7 @@ type PolicySheetRowMetadata struct {
 	RangeLower   PolicySheetRangeBound
 	RangeUpper   PolicySheetRangeBound
 	Monotonicity []string
+	Lookup       *ComputeLookupSpec
 }
 
 type PolicySheetRangeBound struct {
@@ -307,14 +309,38 @@ type AccumulateSpec struct {
 	OnTimeout    *HandlerRuleEntry    `yaml:"on_timeout"`
 }
 type ComputeSpec struct {
-	Operation   ComputeOperation `yaml:"operation"`
-	Tiers       []ComputeTier    `yaml:"tiers"`
-	Keys        ComputeKeyConfig `yaml:"keys"`
-	Params      map[string]any   `yaml:"params"`
-	StoreAs     string           `yaml:"store_as"`
-	Description string           `yaml:"description"`
-	ValueField  string           `yaml:"value_field"`
-	WeightField string           `yaml:"weight_field"`
+	Operation   ComputeOperation   `yaml:"operation"`
+	Tiers       []ComputeTier      `yaml:"tiers"`
+	Keys        ComputeKeyConfig   `yaml:"keys"`
+	Params      map[string]any     `yaml:"params"`
+	StoreAs     string             `yaml:"store_as"`
+	Description string             `yaml:"description"`
+	ValueField  string             `yaml:"value_field"`
+	WeightField string             `yaml:"weight_field"`
+	Lookup      *ComputeLookupSpec `yaml:"-"`
+}
+
+type ComputeLookupSpec struct {
+	RowID           string               `yaml:"-"`
+	On              []string             `yaml:"-"`
+	OnPaths         []paths.Path         `yaml:"-"`
+	Entries         []ComputeLookupEntry `yaml:"-"`
+	DefaultFail     bool                 `yaml:"-"`
+	DefaultDeclared bool                 `yaml:"-"`
+}
+
+type ComputeLookupEntry struct {
+	Key          []ComputeLookupLiteral `yaml:"-"`
+	Value        any                    `yaml:"-"`
+	ValueKind    string                 `yaml:"-"`
+	ValueSummary string                 `yaml:"-"`
+}
+
+type ComputeLookupLiteral struct {
+	Value     any    `yaml:"-"`
+	Kind      string `yaml:"-"`
+	Canonical string `yaml:"-"`
+	Summary   string `yaml:"-"`
 }
 type ComputeTier struct {
 	Dimensions []string `yaml:"dimensions"`

--- a/internal/runtime/contracts/workflow_contract_yaml_flow.go
+++ b/internal/runtime/contracts/workflow_contract_yaml_flow.go
@@ -38,6 +38,7 @@ func validateRuleFieldNodes(node *yaml.Node) error {
 		"when":              {},
 		"case":              {},
 		"range":             {},
+		"lookup":            {},
 		"else":              {},
 		"default":           {},
 		"advances_to":       {},
@@ -58,7 +59,7 @@ func validateRuleFieldNodes(node *yaml.Node) error {
 			return fmt.Errorf("RETIRED: rule field %q is retired; use emit: <event> or emit: {event, fields}", key)
 		case "payload_transform":
 			return fmt.Errorf("RETIRED: rule field %q is retired; move payload ownership into rule-local emit.fields", key)
-		case "switch", "lookup", "threshold":
+		case "switch", "threshold":
 			return fmt.Errorf("UNSUPPORTED-POLICY-SHEET-ROW: rule field %q is not a standalone row type; use rules when/case/range selection rows or split value lookup to compute", key)
 		case "policy":
 			return fmt.Errorf("UNSUPPORTED-POLICY-SHEET-ROW: rule field %q would create a second policy-sheet authoring owner; enhance rules in place", key)

--- a/internal/runtime/contracts/workflow_contract_yaml_handlers.go
+++ b/internal/runtime/contracts/workflow_contract_yaml_handlers.go
@@ -1301,7 +1301,7 @@ func mappingIsSingleHandlerRuleEntry(node *yaml.Node) bool {
 	if hasAnyYAMLMappingKey(node, "condition", "advances_to", "emit", "emits", "action", "data_accumulation", "compute", "fan_out") {
 		return true
 	}
-	if !hasAnyYAMLMappingKey(node, "when", "case", "range", "else", "default") {
+	if !hasAnyYAMLMappingKey(node, "when", "case", "range", "lookup", "else", "default") {
 		return false
 	}
 	return !mappingCanBeKeyedHandlerRules(node)

--- a/internal/runtime/contracts/workflow_contract_yaml_test.go
+++ b/internal/runtime/contracts/workflow_contract_yaml_test.go
@@ -802,6 +802,65 @@ rules:
 	}
 }
 
+func TestSystemNodeEventHandlerDecode_LowersPolicySheetLookupValueRows(t *testing.T) {
+	var handler SystemNodeEventHandler
+	if err := yaml.Unmarshal([]byte(`
+rules:
+  - id: scaffold_paths
+    lookup:
+      on: [payload.scaffold_type, payload.language]
+      entries:
+        - key: [service, go]
+          value: templates/service/go
+        - key: [library, go]
+          value: templates/library/go
+      into: computed.template_path
+      default: fail
+  - id: use_service_template
+    when: computed.template_path == "templates/service/go"
+    emit: repo.service_template_selected
+  - id: fallback
+    default: true
+    emit: repo.other_template_selected
+`), &handler); err != nil {
+		t.Fatalf("yaml.Unmarshal: %v", err)
+	}
+	if got, want := len(handler.Rules), 3; got != want {
+		t.Fatalf("rules len = %d, want %d", got, want)
+	}
+	lookupRule := handler.Rules[0]
+	if got := lookupRule.PolicyRow.Kind; got != PolicySheetRowKindLookup {
+		t.Fatalf("lookup PolicyRow.Kind = %q, want lookup", got)
+	}
+	if lookupRule.Compute == nil {
+		t.Fatal("lookup row Compute = nil")
+	}
+	if got := lookupRule.Compute.Operation; got != ComputeOpLookup {
+		t.Fatalf("lookup Compute.Operation = %q, want lookup", got)
+	}
+	if got := lookupRule.Compute.StoreAs; got != "computed.template_path" {
+		t.Fatalf("lookup StoreAs = %q, want computed.template_path", got)
+	}
+	if lookupRule.Compute.Lookup == nil {
+		t.Fatal("lookup Compute.Lookup = nil")
+	}
+	if got := lookupRule.Compute.Lookup.On; !reflect.DeepEqual(got, []string{"payload.scaffold_type", "payload.language"}) {
+		t.Fatalf("lookup on = %#v", got)
+	}
+	if got := len(lookupRule.Compute.Lookup.Entries); got != 2 {
+		t.Fatalf("lookup entries len = %d, want 2", got)
+	}
+	if got := lookupRule.Compute.Lookup.Entries[0].Value; got != "templates/service/go" {
+		t.Fatalf("lookup first value = %#v", got)
+	}
+	if !lookupRule.Compute.Lookup.DefaultDeclared || !lookupRule.Compute.Lookup.DefaultFail {
+		t.Fatalf("lookup default flags = declared:%v fail:%v, want declared fail", lookupRule.Compute.Lookup.DefaultDeclared, lookupRule.Compute.Lookup.DefaultFail)
+	}
+	if got := handler.Rules[1].Condition; got != `computed.template_path == "templates/service/go"` {
+		t.Fatalf("consumer condition = %q", got)
+	}
+}
+
 func TestSystemNodeEventHandlerDecode_PreservesPolicyRowWordsAsRuleIDsInKeyedMap(t *testing.T) {
 	var handler SystemNodeEventHandler
 	if err := yaml.Unmarshal([]byte(`
@@ -1000,6 +1059,63 @@ rules:
     advances_to: bad
 `,
 			contains: "second policy-sheet authoring owner",
+		},
+		{
+			name: "lookup into entity",
+			body: `
+rules:
+  - id: bad_lookup
+    lookup:
+      on: payload.kind
+      entries:
+        - key: service
+          value: templates/service/go
+      into: entity.template_path
+      default: fail
+`,
+			contains: "computed.*",
+		},
+		{
+			name: "lookup duplicate key",
+			body: `
+rules:
+  - id: duplicate_lookup
+    lookup:
+      on: [payload.kind, payload.language]
+      entries:
+        - key: [service, go]
+          value: templates/service/go
+        - key: [service, go]
+          value: templates/service/go-v2
+      into: computed.template_path
+      default: fail
+`,
+			contains: "duplicate lookup key",
+		},
+		{
+			name: "lookup branch output",
+			body: `
+rules:
+  - id: bad_lookup_branch
+    lookup:
+      on: payload.kind
+      entries:
+        - key: service
+          value: templates/service/go
+      into: computed.template_path
+      default: fail
+    emit: repo.service_template_selected
+`,
+			contains: "cannot declare branch outputs",
+		},
+		{
+			name: "public compute lookup",
+			body: `
+compute:
+  operation: lookup
+  store_as: computed.template_path
+`,
+			contains: "internal to policy-sheet value rows",
 		},
 		{
 			name: "typed row outside rules",

--- a/internal/runtime/contracts/workflow_contract_yaml_test.go
+++ b/internal/runtime/contracts/workflow_contract_yaml_test.go
@@ -1093,6 +1093,51 @@ rules:
 			contains: "duplicate lookup key",
 		},
 		{
+			name: "lookup entity root unsupported",
+			body: `
+rules:
+  - id: entity_lookup
+    lookup:
+      on: entity.kind
+      entries:
+        - key: service
+          value: templates/service/go
+      into: computed.template_path
+      default: fail
+`,
+			contains: `unsupported root "entity"`,
+		},
+		{
+			name: "lookup policy root unsupported",
+			body: `
+rules:
+  - id: policy_lookup
+    lookup:
+      on: policy.kind
+      entries:
+        - key: service
+          value: templates/service/go
+      into: computed.template_path
+      default: fail
+`,
+			contains: `unsupported root "policy"`,
+		},
+		{
+			name: "lookup event root unsupported",
+			body: `
+rules:
+  - id: event_lookup
+    lookup:
+      on: event.kind
+      entries:
+        - key: service
+          value: templates/service/go
+      into: computed.template_path
+      default: fail
+`,
+			contains: `unsupported root "event"`,
+		},
+		{
 			name: "lookup branch output",
 			body: `
 rules:

--- a/internal/runtime/engine/executor.go
+++ b/internal/runtime/engine/executor.go
@@ -988,12 +988,44 @@ func (e *Executor) stepCount(frame *executionFrame) error {
 }
 
 func (e *Executor) stepCompute(frame *executionFrame) error {
-	spec := e.selectedCompute(frame)
+	if frame.rule != nil {
+		spec := frame.rule.Compute
+		if spec == nil || spec.Operation == runtimecontracts.ComputeOpLookup {
+			return nil
+		}
+		return e.executeComputeSpec(frame, spec)
+	}
+	if frame.req.Handler.Compute != nil {
+		if err := e.executeComputeSpec(frame, frame.req.Handler.Compute); err != nil {
+			return err
+		}
+	}
+	for idx := range frame.req.Handler.Rules {
+		rule := &frame.req.Handler.Rules[idx]
+		if rule.PolicyRow.Kind != runtimecontracts.PolicySheetRowKindLookup || rule.Compute == nil {
+			continue
+		}
+		if err := e.executeComputeSpec(frame, rule.Compute); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (e *Executor) executeComputeSpec(frame *executionFrame, spec *runtimecontracts.ComputeSpec) error {
 	if spec == nil {
 		return nil
 	}
 	acc, _ := loadAccumulatorForBucket(frame.state.State, handlerAccumulatorBucketRef(frame.req))
-	value, err := computeValue(acc, frame.payload, spec)
+	var (
+		value any
+		err   error
+	)
+	if spec.Operation == runtimecontracts.ComputeOpLookup {
+		value, err = computeLookupValue(e.currentContext(frame), spec)
+	} else {
+		value, err = computeValue(acc, frame.payload, spec)
+	}
 	if err != nil {
 		return err
 	}
@@ -2116,6 +2148,9 @@ func (e *Executor) evaluateGuardCheck(frame *executionFrame, id, check, policyRe
 func (e *Executor) selectRule(frame *executionFrame, rules []runtimecontracts.HandlerRuleEntry) (*runtimecontracts.HandlerRuleEntry, error) {
 	for idx := range rules {
 		rule := &rules[idx]
+		if rule.PolicyRow.Kind == runtimecontracts.PolicySheetRowKindLookup {
+			continue
+		}
 		condition := strings.TrimSpace(rule.Condition)
 		if condition == "" || strings.EqualFold(condition, "else") {
 			return rule, nil

--- a/internal/runtime/engine/executor_test.go
+++ b/internal/runtime/engine/executor_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/division-sh/swarm/internal/events/eventtest"
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
 	"github.com/division-sh/swarm/internal/runtime/core/identity"
+	runtimepaths "github.com/division-sh/swarm/internal/runtime/core/paths"
 	runtimeregistry "github.com/division-sh/swarm/internal/runtime/core/registry"
 	"github.com/division-sh/swarm/internal/runtime/flowmodel"
 	"github.com/division-sh/swarm/internal/runtime/semanticview"
@@ -1519,6 +1520,91 @@ func TestExecutor_ComputeReadsAccumulatorByMatchedHandlerEventKey(t *testing.T) 
 	}
 	if got := result.StateMutation.Metadata["component_count"]; got != 2 {
 		t.Fatalf("component_count = %#v, want 2", got)
+	}
+}
+
+func TestExecutor_PolicySheetLookupRowFeedsSelectionRow(t *testing.T) {
+	exec, err := NewExecutor(RuntimeDependencies{
+		Source:       stubSource(),
+		StateRepo:    stubStateRepo{},
+		TxRunner:     stubRunner{},
+		Locker:       stubLocker{},
+		Outbox:       stubOutbox{},
+		TimerApplier: stubTimerApplier{},
+		Dispatcher:   stubDispatcher{},
+	}, contextualBoolEvaluator{bools: map[string]func(BaseContext) (bool, error){
+		`computed.template_path == "templates/service/go"`: func(base BaseContext) (bool, error) {
+			return base.Computed.Raw()["template_path"] == "templates/service/go", nil
+		},
+	}})
+	if err != nil {
+		t.Fatalf("NewExecutor error: %v", err)
+	}
+	lookup := &runtimecontracts.ComputeLookupSpec{
+		RowID: "scaffold_paths",
+		On:    []string{"payload.scaffold_type", "payload.language"},
+		OnPaths: []runtimepaths.Path{
+			runtimepaths.Parse("payload.scaffold_type"),
+			runtimepaths.Parse("payload.language"),
+		},
+		DefaultDeclared: true,
+		DefaultFail:     true,
+		Entries: []runtimecontracts.ComputeLookupEntry{{
+			Key: []runtimecontracts.ComputeLookupLiteral{
+				{Value: "service", Kind: "string", Canonical: "string:\"service\"", Summary: `"service"`},
+				{Value: "go", Kind: "string", Canonical: "string:\"go\"", Summary: `"go"`},
+			},
+			Value:        "templates/service/go",
+			ValueKind:    "string",
+			ValueSummary: `"templates/service/go"`,
+		}},
+	}
+	result, err := exec.Execute(context.Background(), ExecutionRequest{
+		EntityID: identity.NormalizeEntityID("11111111-1111-1111-1111-111111111111"),
+		NodeID:   identity.NodeID("repo-scaffold"),
+		Event: eventtest.RootIngress(
+			"evt-1",
+			events.EventType("repo.scaffold_requested"),
+			"",
+			"",
+			mustEncodeJSON(t, map[string]any{"scaffold_type": "service", "language": "go"}),
+			0,
+			"",
+			"",
+			events.EventEnvelope{},
+			time.Date(2026, time.January, 1, 0, 0, 0, 0, time.UTC),
+		),
+		State: testStateSnapshot("pending", map[string]any{}, nil, map[string]map[string]any{}),
+		Handler: runtimecontracts.SystemNodeEventHandler{
+			Rules: []runtimecontracts.HandlerRuleEntry{
+				{
+					ID:        "scaffold_paths",
+					PolicyRow: runtimecontracts.PolicySheetRowMetadata{Kind: runtimecontracts.PolicySheetRowKindLookup, Lookup: lookup},
+					Compute: &runtimecontracts.ComputeSpec{
+						Operation: runtimecontracts.ComputeOpLookup,
+						StoreAs:   "computed.template_path",
+						Lookup:    lookup,
+					},
+				},
+				{
+					ID:        "service_route",
+					Condition: `computed.template_path == "templates/service/go"`,
+					Emit:      runtimecontracts.EmitSpec{Event: "repo.service_template_selected"},
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Execute error: %v", err)
+	}
+	if got := result.Computed["template_path"]; got != "templates/service/go" {
+		t.Fatalf("result computed template_path = %#v, want templates/service/go", got)
+	}
+	if got := len(result.EmitIntents); got != 1 {
+		t.Fatalf("emit intents = %d, want 1", got)
+	}
+	if got := string(result.EmitIntents[0].Event.Type()); got != "repo.service_template_selected" {
+		t.Fatalf("emit event = %q, want repo.service_template_selected", got)
 	}
 }
 

--- a/internal/runtime/engine/helpers.go
+++ b/internal/runtime/engine/helpers.go
@@ -240,6 +240,7 @@ func evalWorkflowValueExpression(base BaseContext, state ExecutionState, express
 		Event:          base.Event.Raw(),
 		Payload:        base.Payload.Raw(),
 		Policy:         base.Policy.Raw(),
+		Computed:       base.Computed.Raw(),
 		FanOut:         state.FanOut,
 	}, opts)
 }
@@ -868,9 +869,60 @@ func computeValue(acc *Accumulator, payload map[string]any, spec *runtimecontrac
 		}), nil
 	case runtimecontracts.ComputeOpCount:
 		return len(acc.Items), nil
+	case runtimecontracts.ComputeOpLookup:
+		return nil, fmt.Errorf("lookup compute requires handler context")
 	default:
 		return nil, ErrNotImplemented
 	}
+}
+
+func computeLookupValue(ctx BaseContext, spec *runtimecontracts.ComputeSpec) (any, error) {
+	if spec == nil || spec.Lookup == nil {
+		return nil, ErrNotImplemented
+	}
+	lookup := spec.Lookup
+	key := make([]runtimecontracts.ComputeLookupLiteral, 0, len(lookup.OnPaths))
+	unmatched := make([]string, 0, len(lookup.OnPaths))
+	for idx, path := range lookup.OnPaths {
+		value, ok := ctx.Lookup(path)
+		if !ok {
+			unmatched = append(unmatched, strings.TrimSpace(lookup.On[idx])+"=<missing>")
+			key = append(key, runtimecontracts.ComputeLookupLiteral{Canonical: "<missing>"})
+			continue
+		}
+		kind, summary, canonical, ok := runtimecontracts.CanonicalizeComputeLookupValue(value)
+		if !ok {
+			unmatched = append(unmatched, strings.TrimSpace(lookup.On[idx])+"=<unsupported>")
+			key = append(key, runtimecontracts.ComputeLookupLiteral{Canonical: "<unsupported>"})
+			continue
+		}
+		unmatched = append(unmatched, strings.TrimSpace(lookup.On[idx])+"="+summary)
+		key = append(key, runtimecontracts.ComputeLookupLiteral{
+			Value:     value,
+			Kind:      kind,
+			Canonical: canonical,
+			Summary:   summary,
+		})
+	}
+	canonical := computeLookupCanonicalKey(key)
+	for _, entry := range lookup.Entries {
+		if computeLookupCanonicalKey(entry.Key) == canonical {
+			return entry.Value, nil
+		}
+	}
+	rowID := strings.TrimSpace(lookup.RowID)
+	if rowID == "" {
+		rowID = strings.TrimSpace(spec.StoreAs)
+	}
+	return nil, fmt.Errorf("lookup_miss_no_retry: row %s unmatched tuple [%s]", rowID, strings.Join(unmatched, ", "))
+}
+
+func computeLookupCanonicalKey(key []runtimecontracts.ComputeLookupLiteral) string {
+	parts := make([]string, 0, len(key))
+	for _, literal := range key {
+		parts = append(parts, literal.Canonical)
+	}
+	return strings.Join(parts, "\x00")
 }
 
 func computeWeightedAverage(acc *Accumulator, spec *runtimecontracts.ComputeSpec) float64 {

--- a/internal/runtime/engine/helpers.go
+++ b/internal/runtime/engine/helpers.go
@@ -890,7 +890,7 @@ func computeLookupValue(ctx BaseContext, spec *runtimecontracts.ComputeSpec) (an
 			key = append(key, runtimecontracts.ComputeLookupLiteral{Canonical: "<missing>"})
 			continue
 		}
-		kind, summary, canonical, ok := runtimecontracts.CanonicalizeComputeLookupValue(value)
+		kind, summary, canonical, ok := canonicalizeComputeLookupRuntimeValue(value, lookup, idx)
 		if !ok {
 			unmatched = append(unmatched, strings.TrimSpace(lookup.On[idx])+"=<unsupported>")
 			key = append(key, runtimecontracts.ComputeLookupLiteral{Canonical: "<unsupported>"})
@@ -915,6 +915,62 @@ func computeLookupValue(ctx BaseContext, spec *runtimecontracts.ComputeSpec) (an
 		rowID = strings.TrimSpace(spec.StoreAs)
 	}
 	return nil, fmt.Errorf("lookup_miss_no_retry: row %s unmatched tuple [%s]", rowID, strings.Join(unmatched, ", "))
+}
+
+func canonicalizeComputeLookupRuntimeValue(value any, lookup *runtimecontracts.ComputeLookupSpec, column int) (kind, summary, canonical string, ok bool) {
+	kind, summary, canonical, ok = runtimecontracts.CanonicalizeComputeLookupValue(value)
+	if !ok || kind != "number" || computeLookupColumnKind(lookup, column) != "int" {
+		return kind, summary, canonical, ok
+	}
+	integer, ok := integralLookupFloatSummary(value)
+	if !ok {
+		return kind, summary, canonical, true
+	}
+	return "int", integer, "int:" + integer, true
+}
+
+func computeLookupColumnKind(lookup *runtimecontracts.ComputeLookupSpec, column int) string {
+	if lookup == nil || column < 0 {
+		return ""
+	}
+	kind := ""
+	for _, entry := range lookup.Entries {
+		if column >= len(entry.Key) {
+			return ""
+		}
+		entryKind := strings.TrimSpace(entry.Key[column].Kind)
+		if entryKind == "" {
+			return ""
+		}
+		if kind == "" {
+			kind = entryKind
+			continue
+		}
+		if kind != entryKind {
+			return ""
+		}
+	}
+	return kind
+}
+
+func integralLookupFloatSummary(value any) (string, bool) {
+	var f float64
+	switch typed := value.(type) {
+	case float32:
+		f = float64(typed)
+	case float64:
+		f = typed
+	default:
+		return "", false
+	}
+	if math.IsNaN(f) || math.IsInf(f, 0) || math.Trunc(f) != f {
+		return "", false
+	}
+	summary := strconv.FormatFloat(f, 'f', 0, 64)
+	if _, err := strconv.ParseInt(summary, 10, 64); err != nil {
+		return "", false
+	}
+	return summary, true
 }
 
 func computeLookupCanonicalKey(key []runtimecontracts.ComputeLookupLiteral) string {

--- a/internal/runtime/engine/helpers_test.go
+++ b/internal/runtime/engine/helpers_test.go
@@ -628,6 +628,41 @@ func TestComputeLookupValueMatchesExactTuple(t *testing.T) {
 	}
 }
 
+func TestComputeLookupValueMatchesJSONIntegerPayloadToIntKey(t *testing.T) {
+	value, err := computeLookupValue(BaseContext{
+		Payload: values.Wrap(map[string]any{
+			"tier": float64(1),
+		}),
+	}, &runtimecontracts.ComputeSpec{
+		Operation: runtimecontracts.ComputeOpLookup,
+		StoreAs:   "computed.tier_label",
+		Lookup: &runtimecontracts.ComputeLookupSpec{
+			RowID:           "tier_labels",
+			On:              []string{"payload.tier"},
+			OnPaths:         []paths.Path{paths.Parse("payload.tier")},
+			DefaultDeclared: true,
+			DefaultFail:     true,
+			Entries: []runtimecontracts.ComputeLookupEntry{{
+				Key: []runtimecontracts.ComputeLookupLiteral{{
+					Value:     int64(1),
+					Kind:      "int",
+					Canonical: "int:1",
+					Summary:   "1",
+				}},
+				Value:        "gold",
+				ValueKind:    "string",
+				ValueSummary: `"gold"`,
+			}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("computeLookupValue JSON integer payload error = %v", err)
+	}
+	if got := value; got != "gold" {
+		t.Fatalf("computeLookupValue = %#v, want gold", got)
+	}
+}
+
 func TestComputeLookupValueMissFailsClosedNoRetry(t *testing.T) {
 	base := BaseContext{
 		Payload: values.Wrap(map[string]any{

--- a/internal/runtime/engine/helpers_test.go
+++ b/internal/runtime/engine/helpers_test.go
@@ -111,12 +111,14 @@ func TestSetValuePathAndEmitFieldsPayload(t *testing.T) {
 	base := BaseContext{
 		PlatformEntity: values.Wrap(map[string]any{"current_state": "researching"}),
 		Payload:        values.Wrap(map[string]any{"score": 9}),
+		Computed:       values.Wrap(map[string]any{"template_path": "templates/service/go"}),
 	}
 	state := ExecutionState{}
 	transformed, err := emitFieldsPayload(base, state, runtimecontracts.EmitSpec{
 		Fields: map[string]runtimecontracts.ExpressionValue{
 			"nested.score":   runtimecontracts.CELExpression("payload.score"),
 			"nested.state":   runtimecontracts.CELExpression("_entity.current_state"),
+			"nested.path":    runtimecontracts.CELExpression("computed.template_path"),
 			"literal.string": runtimecontracts.CELExpression(`"hello"`),
 			"explicit.ref":   runtimecontracts.RefExpression("payload.score"),
 			"explicit.value": runtimecontracts.LiteralExpression("ready"),
@@ -134,6 +136,9 @@ func TestSetValuePathAndEmitFieldsPayload(t *testing.T) {
 	}
 	if got := nested["state"]; got != "researching" {
 		t.Fatalf("nested.state = %#v", got)
+	}
+	if got := nested["path"]; got != "templates/service/go" {
+		t.Fatalf("nested.path = %#v", got)
 	}
 	literal, ok := transformed["literal"].(map[string]any)
 	if !ok || literal["string"] != "hello" {
@@ -582,5 +587,83 @@ func TestComputeValue(t *testing.T) {
 	}
 	if got := value.(float64); got != 81 {
 		t.Fatalf("computeValue legacy weighted_average = %v, want 81", got)
+	}
+}
+
+func TestComputeLookupValueMatchesExactTuple(t *testing.T) {
+	base := BaseContext{
+		Payload: values.Wrap(map[string]any{
+			"scaffold_type": "service",
+			"language":      "go",
+		}),
+	}
+	value, err := computeLookupValue(base, &runtimecontracts.ComputeSpec{
+		Operation: runtimecontracts.ComputeOpLookup,
+		StoreAs:   "computed.template_path",
+		Lookup: &runtimecontracts.ComputeLookupSpec{
+			RowID: "scaffold_paths",
+			On:    []string{"payload.scaffold_type", "payload.language"},
+			OnPaths: []paths.Path{
+				paths.Parse("payload.scaffold_type"),
+				paths.Parse("payload.language"),
+			},
+			DefaultDeclared: true,
+			DefaultFail:     true,
+			Entries: []runtimecontracts.ComputeLookupEntry{{
+				Key: []runtimecontracts.ComputeLookupLiteral{
+					{Value: "service", Kind: "string", Canonical: "string:\"service\"", Summary: `"service"`},
+					{Value: "go", Kind: "string", Canonical: "string:\"go\"", Summary: `"go"`},
+				},
+				Value:        "templates/service/go",
+				ValueKind:    "string",
+				ValueSummary: `"templates/service/go"`,
+			}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("computeLookupValue error = %v", err)
+	}
+	if got := value; got != "templates/service/go" {
+		t.Fatalf("computeLookupValue = %#v, want templates/service/go", got)
+	}
+}
+
+func TestComputeLookupValueMissFailsClosedNoRetry(t *testing.T) {
+	base := BaseContext{
+		Payload: values.Wrap(map[string]any{
+			"scaffold_type": "service",
+			"language":      "rust",
+		}),
+	}
+	_, err := computeLookupValue(base, &runtimecontracts.ComputeSpec{
+		Operation: runtimecontracts.ComputeOpLookup,
+		StoreAs:   "computed.template_path",
+		Lookup: &runtimecontracts.ComputeLookupSpec{
+			RowID: "scaffold_paths",
+			On:    []string{"payload.scaffold_type", "payload.language"},
+			OnPaths: []paths.Path{
+				paths.Parse("payload.scaffold_type"),
+				paths.Parse("payload.language"),
+			},
+			DefaultDeclared: true,
+			DefaultFail:     true,
+			Entries: []runtimecontracts.ComputeLookupEntry{{
+				Key: []runtimecontracts.ComputeLookupLiteral{
+					{Value: "service", Kind: "string", Canonical: "string:\"service\"", Summary: `"service"`},
+					{Value: "go", Kind: "string", Canonical: "string:\"go\"", Summary: `"go"`},
+				},
+				Value:        "templates/service/go",
+				ValueKind:    "string",
+				ValueSummary: `"templates/service/go"`,
+			}},
+		},
+	})
+	if err == nil {
+		t.Fatal("expected lookup miss error")
+	}
+	for _, want := range []string{"lookup_miss_no_retry", "scaffold_paths", `"rust"`} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("lookup miss error = %q, want containing %q", err.Error(), want)
+		}
 	}
 }

--- a/internal/runtime/pipeline/engine_adapter.go
+++ b/internal/runtime/pipeline/engine_adapter.go
@@ -39,6 +39,7 @@ func (e pipelineEngineEvaluator) EvalBool(expression string, ctx runtimeengine.B
 		Event:          cloneStringAnyMap(ctx.Event.Raw()),
 		Payload:        cloneStringAnyMap(ctx.Payload.Raw()),
 		Policy:         cloneStringAnyMap(ctx.Policy.Raw()),
+		Computed:       cloneStringAnyMap(ctx.Computed.Raw()),
 		Accumulated:    accumulatedItemsForCEL(ctx.Accumulated.Raw()),
 		FanOut:         cloneStringAnyMap(ctx.FanOut.Raw()),
 		WorkflowName:   firstNonEmptyString(strings.TrimSpace(ctx.FlowID), e.workflowName()),

--- a/internal/runtime/pipeline/mailbox_materialization.go
+++ b/internal/runtime/pipeline/mailbox_materialization.go
@@ -177,6 +177,7 @@ func evalMailboxExpressionValue(base runtimeengine.BaseContext, expr runtimecont
 			Event:          base.Event.Raw(),
 			Payload:        base.Payload.Raw(),
 			Policy:         base.Policy.Raw(),
+			Computed:       base.Computed.Raw(),
 			FanOut:         base.FanOut.Raw(),
 		}, workflowexpr.ValueExpressionOptions{})
 		if err != nil {

--- a/internal/runtime/pipeline/workflow_condition_validation.go
+++ b/internal/runtime/pipeline/workflow_condition_validation.go
@@ -47,6 +47,7 @@ func celValidationEnv(context WorkflowConditionContext) (*cel.Env, error) {
 		cel.Variable("event", cel.DynType),
 		cel.Variable("payload", cel.DynType),
 		cel.Variable("policy", cel.DynType),
+		cel.Variable("computed", cel.DynType),
 		cel.Function("count_ge",
 			cel.Overload(
 				"count_ge_dyn_dyn",
@@ -141,6 +142,7 @@ func workflowConditionRecognizedRoots(context WorkflowConditionContext) []string
 		"entity",
 		"_entity",
 		"policy",
+		"computed",
 		"query_entities",
 	}
 	switch context {

--- a/internal/runtime/pipeline/workflow_condition_validation.go
+++ b/internal/runtime/pipeline/workflow_condition_validation.go
@@ -47,7 +47,6 @@ func celValidationEnv(context WorkflowConditionContext) (*cel.Env, error) {
 		cel.Variable("event", cel.DynType),
 		cel.Variable("payload", cel.DynType),
 		cel.Variable("policy", cel.DynType),
-		cel.Variable("computed", cel.DynType),
 		cel.Function("count_ge",
 			cel.Overload(
 				"count_ge_dyn_dyn",
@@ -56,6 +55,10 @@ func celValidationEnv(context WorkflowConditionContext) (*cel.Env, error) {
 				cel.FunctionBinding(workflowExpressionCountGE),
 			),
 		),
+	}
+	switch context {
+	case WorkflowConditionContextRule, WorkflowConditionContextOnComplete:
+		options = append(options, cel.Variable("computed", cel.DynType))
 	}
 	switch context {
 	case WorkflowConditionContextOnComplete:
@@ -142,8 +145,11 @@ func workflowConditionRecognizedRoots(context WorkflowConditionContext) []string
 		"entity",
 		"_entity",
 		"policy",
-		"computed",
 		"query_entities",
+	}
+	switch context {
+	case WorkflowConditionContextRule, WorkflowConditionContextOnComplete:
+		roots = append(roots, "computed")
 	}
 	switch context {
 	case WorkflowConditionContextOnComplete:

--- a/internal/runtime/pipeline/workflow_expression_evaluator.go
+++ b/internal/runtime/pipeline/workflow_expression_evaluator.go
@@ -27,6 +27,7 @@ type workflowExpressionContext struct {
 	Event                        map[string]any
 	Payload                      map[string]any
 	Policy                       map[string]any
+	Computed                     map[string]any
 	Accumulated                  any
 	FanOut                       map[string]any
 	WorkflowName                 string
@@ -47,6 +48,7 @@ func newWorkflowExpressionEvaluator() *workflowExpressionEvaluator {
 		cel.Variable("event", cel.DynType),
 		cel.Variable("payload", cel.DynType),
 		cel.Variable("policy", cel.DynType),
+		cel.Variable("computed", cel.DynType),
 		cel.Variable("accumulated", cel.DynType),
 		cel.Variable("fan_out", cel.DynType),
 		cel.Function("count_ge",
@@ -91,6 +93,7 @@ func (e *workflowExpressionEvaluator) EvalBool(expression string, ctx workflowEx
 		"event":       workflowNormalizeCELInput(cloneStringAnyMap(normalizedCtx.Event)),
 		"payload":     workflowNormalizeCELInput(cloneStringAnyMap(normalizedCtx.Payload)),
 		"policy":      workflowNormalizeCELInput(cloneStringAnyMap(normalizedCtx.Policy)),
+		"computed":    workflowNormalizeCELInput(cloneStringAnyMap(normalizedCtx.Computed)),
 		"accumulated": normalizedCtx.Accumulated,
 		"fan_out":     workflowNormalizeCELInput(cloneStringAnyMap(normalizedCtx.FanOut)),
 	})
@@ -159,6 +162,7 @@ func normalizeWorkflowExpression(expression string, ctx workflowExpressionContex
 			Event:                        cloneStringAnyMap(ctx.Event),
 			Payload:                      cloneStringAnyMap(ctx.Payload),
 			Policy:                       cloneStringAnyMap(ctx.Policy),
+			Computed:                     cloneStringAnyMap(ctx.Computed),
 			Accumulated:                  cloneAccumulatedItems(ctx.Accumulated),
 			FanOut:                       cloneStringAnyMap(ctx.FanOut),
 			WorkflowName:                 strings.TrimSpace(ctx.WorkflowName),
@@ -196,6 +200,7 @@ func normalizeWorkflowExpression(expression string, ctx workflowExpressionContex
 		Event:                        cloneStringAnyMap(ctx.Event),
 		Payload:                      cloneStringAnyMap(ctx.Payload),
 		Policy:                       cloneStringAnyMap(ctx.Policy),
+		Computed:                     cloneStringAnyMap(ctx.Computed),
 		Accumulated:                  cloneAccumulatedItems(ctx.Accumulated),
 		FanOut:                       cloneStringAnyMap(ctx.FanOut),
 		WorkflowName:                 strings.TrimSpace(ctx.WorkflowName),
@@ -307,7 +312,7 @@ func workflowExpressionResolveQueryOperand(raw string, ctx workflowExpressionCon
 	}
 	if root, scoped := workflowExpressionQueryOperandScope(raw); scoped {
 		switch root {
-		case "entity", "_entity", "event", "payload", "policy", "fan_out":
+		case "entity", "_entity", "event", "payload", "policy", "computed", "fan_out":
 			if ctx.AllowUnresolvedQueryOperands {
 				return raw, nil
 			}
@@ -350,6 +355,8 @@ func workflowExpressionLookupContextValue(ref string, ctx workflowExpressionCont
 		return workflowExpressionLookupPath(ctx.Payload, strings.TrimPrefix(ref, "payload."))
 	case strings.HasPrefix(ref, "policy."):
 		return workflowExpressionLookupPath(ctx.Policy, strings.TrimPrefix(ref, "policy."))
+	case strings.HasPrefix(ref, "computed."):
+		return workflowExpressionLookupPath(ctx.Computed, strings.TrimPrefix(ref, "computed."))
 	case strings.HasPrefix(ref, "fan_out."):
 		return workflowExpressionLookupPath(ctx.FanOut, strings.TrimPrefix(ref, "fan_out."))
 	default:

--- a/internal/runtime/pipeline/workflow_expression_evaluator_test.go
+++ b/internal/runtime/pipeline/workflow_expression_evaluator_test.go
@@ -97,6 +97,37 @@ func TestValidateConditionCEL_AllowsRuleConditionCanonicalRoots(t *testing.T) {
 	}
 }
 
+func TestValidateConditionCEL_RestrictsComputedToPostComputeContexts(t *testing.T) {
+	expression := `computed.template_path == "templates/service/go"`
+	for _, context := range []WorkflowConditionContext{
+		WorkflowConditionContextRule,
+		WorkflowConditionContextOnComplete,
+	} {
+		t.Run(string(context)+" allowed", func(t *testing.T) {
+			if err := ValidateConditionCEL(expression, context); err != nil {
+				t.Fatalf("expected computed namespace to validate in %s, got %v", context, err)
+			}
+			if WorkflowConditionMissingRecognizedPrefix(expression, context) {
+				t.Fatalf("expected computed namespace to be a recognized root in %s", context)
+			}
+		})
+	}
+	for _, context := range []WorkflowConditionContext{
+		WorkflowConditionContextGuard,
+		WorkflowConditionContextFilter,
+		WorkflowConditionContextCount,
+	} {
+		t.Run(string(context)+" rejected", func(t *testing.T) {
+			if err := ValidateConditionCEL(expression, context); err == nil {
+				t.Fatalf("expected computed namespace to fail validation in %s", context)
+			}
+			if !WorkflowConditionMissingRecognizedPrefix(expression, context) {
+				t.Fatalf("expected computed namespace to be unrecognized in %s", context)
+			}
+		})
+	}
+}
+
 func TestWorkflowExpressionEvaluator_AllowsComputedNamespace(t *testing.T) {
 	eval := newWorkflowExpressionEvaluator()
 	ok, err := eval.EvalBool(`computed.template_path == "templates/service/go"`, workflowExpressionContext{

--- a/internal/runtime/pipeline/workflow_expression_evaluator_test.go
+++ b/internal/runtime/pipeline/workflow_expression_evaluator_test.go
@@ -57,6 +57,10 @@ func TestValidateConditionCEL_AllowsRuleConditionCanonicalRoots(t *testing.T) {
 			expression: `_entity.id != "" && payload.score >= policy.threshold && event.source.entity_id != ""`,
 		},
 		{
+			name:       "computed",
+			expression: `computed.template_path == "templates/service/go"`,
+		},
+		{
 			name:       "query entities",
 			expression: `query_entities(name == payload.name).count == 0`,
 		},
@@ -90,6 +94,19 @@ func TestValidateConditionCEL_AllowsRuleConditionCanonicalRoots(t *testing.T) {
 				t.Fatalf("expected rule condition %q to validate, got %v", tt.expression, err)
 			}
 		})
+	}
+}
+
+func TestWorkflowExpressionEvaluator_AllowsComputedNamespace(t *testing.T) {
+	eval := newWorkflowExpressionEvaluator()
+	ok, err := eval.EvalBool(`computed.template_path == "templates/service/go"`, workflowExpressionContext{
+		Computed: map[string]any{"template_path": "templates/service/go"},
+	})
+	if err != nil {
+		t.Fatalf("EvalBool computed namespace error = %v", err)
+	}
+	if !ok {
+		t.Fatal("expected computed namespace condition to evaluate true")
 	}
 }
 

--- a/internal/runtime/workflowexpr/data_expression.go
+++ b/internal/runtime/workflowexpr/data_expression.go
@@ -41,6 +41,7 @@ type ValueContext struct {
 	Event          map[string]any
 	Payload        map[string]any
 	Policy         map[string]any
+	Computed       map[string]any
 	FanOut         map[string]any
 }
 
@@ -105,12 +106,13 @@ func EvalValueExpressionWithOptions(expression string, ctx ValueContext, opts Va
 		return nil, err
 	}
 	activation := map[string]any{
-		"entity":  NormalizeCELInputMap(ctx.Entity),
-		"_entity": NormalizeCELInputMap(ctx.PlatformEntity),
-		"event":   NormalizeCELInputMap(ctx.Event),
-		"payload": NormalizeCELInputMap(ctx.Payload),
-		"policy":  NormalizeCELInputMap(ctx.Policy),
-		"fan_out": NormalizeCELInputMap(ctx.FanOut),
+		"entity":   NormalizeCELInputMap(ctx.Entity),
+		"_entity":  NormalizeCELInputMap(ctx.PlatformEntity),
+		"event":    NormalizeCELInputMap(ctx.Event),
+		"payload":  NormalizeCELInputMap(ctx.Payload),
+		"policy":   NormalizeCELInputMap(ctx.Policy),
+		"computed": NormalizeCELInputMap(ctx.Computed),
+		"fan_out":  NormalizeCELInputMap(ctx.FanOut),
 	}
 	if opts.AllowBareItem {
 		activation["item"] = NormalizeCELValue(ctx.FanOut["item"])
@@ -706,6 +708,7 @@ func newDataExpressionEnv(allowBareItem bool) (*cel.Env, error) {
 		cel.Variable("event", cel.DynType),
 		cel.Variable("payload", cel.DynType),
 		cel.Variable("policy", cel.DynType),
+		cel.Variable("computed", cel.DynType),
 		cel.Variable("fan_out", cel.DynType),
 	}
 	if allowBareItem {

--- a/internal/runtime/workflowexpr/data_expression_test.go
+++ b/internal/runtime/workflowexpr/data_expression_test.go
@@ -21,6 +21,18 @@ func TestEvalValueExpression_AllowsNullPresenceCheckOnMissingField(t *testing.T)
 	}
 }
 
+func TestEvalValueExpression_AllowsComputedNamespace(t *testing.T) {
+	value, err := EvalValueExpression(`computed.template_path`, ValueContext{
+		Computed: map[string]any{"template_path": "templates/service/go"},
+	})
+	if err != nil {
+		t.Fatalf("EvalValueExpression computed namespace error = %v", err)
+	}
+	if got := value; got != "templates/service/go" {
+		t.Fatalf("EvalValueExpression computed namespace = %#v, want templates/service/go", got)
+	}
+}
+
 func TestEvalValueExpression_FailsClosedOnMissingEntityValueRead(t *testing.T) {
 	_, err := EvalValueExpression(`entity.revision_count + 1`, ValueContext{
 		Entity: map[string]any{},

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -1610,6 +1610,21 @@ handler_specification:
         store_as: string — entity field to store result
         description: string — human-readable note
       operation_requirements:
+        lookup:
+          status: internal_lowering_only
+          description: |
+            `lookup` is the compute-owned internal operation produced by
+            policy-sheet lookup value rows. It is not a public
+            `compute.operation` authoring value. Public YAML must author lookup
+            value derivation as a `rules[*].lookup` policy-sheet row. The
+            lowered compute plan reads explicit context roots, performs exact
+            typed tuple matching against an inline finite table, and writes the
+            result to a turn-scoped `computed.*` binding.
+          public_authoring: 'forbidden; `compute.operation: lookup` fails closed.'
+          miss_disposition: |
+            A table miss with `default: fail` is deterministic, no-retry, emits
+            a typed diagnostic naming the row ID and unmatched tuple, and
+            performs no side effects.
         weighted_average:
           description: Compute a weighted average across tiers of accumulated items.
           required:
@@ -1857,9 +1872,10 @@ handler_specification:
         rule-condition handler context; common dispatch reads payload fields, but selection is not payload-only.
       rule_fields:
         condition: string — CEL expression evaluated against the rule-condition handler context. Allowed roots
-          are payload.*, entity.*, policy.*, event.*, and query_entities(...). accumulated.*, fan_out.*, and
-          item.* are unavailable in rules.condition. entity.* reads use the pre-rule entity state and the same
-          declared-field validation as other rule-phase handler conditions.
+          are payload.*, entity.*, policy.*, event.*, computed.*, and query_entities(...). accumulated.*, fan_out.*,
+          and item.* are unavailable in rules.condition. entity.* reads use the pre-rule entity state and the same
+          declared-field validation as other rule-phase handler conditions. computed.* reads are turn-scoped
+          values written earlier in the handler compute phase, including lookup value rows.
         when: >-
           string — first-class policy-sheet selection row for compound relational conditions. Lowers to condition
           and otherwise uses the ordinary selected-branch rule fields. Must not be combined with condition, case, range,
@@ -1875,6 +1891,13 @@ handler_specification:
           expressions. Entity/payload/event dynamic bounds are forbidden and fail closed; normalize those values through
           compute/value rows first. Policy-constant bounds require `monotonicity` declarations using `<=` so verify can
           prove structural ordering and non-overlap. Literal ranges are checked for absolute overlap.
+        lookup: >-
+          object — first-class policy-sheet value row for finite tuple/key-to-value mapping. Public shape is
+          `{on: [<explicit root path>, ...], entries: [{key: [<scalar>, ...], value: <scalar>}], into: computed.<name>,
+          default: fail}`. Single-key rows may author a scalar `key`; tuple rows use list keys. Entries are inline only
+          in this slice. Lookup rows bind a value and do not select a branch, emit, advance state, execute action/activity,
+          fan_out, data_accumulation, or public compute. The row lowers to the compute-owned internal lookup operation
+          and runs before selection rows consume computed.*.
         else: boolean true — explicit default row. Lowers to the ordinary else selected branch.
         default: boolean true — alias for else, used when the authoring intent is an explicit policy-sheet default row.
         emit: string or object — rule-local event to emit, or an eventless object with fields only when participating in
@@ -1883,9 +1906,9 @@ handler_specification:
         data_accumulation: object — optional data write (same format as handler-level)
         description: string — human-readable note
       policy_sheet_selection_rows:
-        scope: Selection-only rows in this slice are `when`, `case`, `range`, and explicit else/default rows. Value
-          derivation rows lower to compute in a separate child; schema validation and temporal/join/loop/collection/schedule
-          rows are separate future gates.
+        scope: Selection rows are `when`, `case`, `range`, and explicit else/default rows. Lookup value rows are specified
+          under `policy_sheet_value_rows`; schema validation, arithmetic/expression derivation, and
+          temporal/join/loop/collection/schedule rows are separate future gates.
         stable_identity: Typed policy-sheet rows require stable IDs. The selected row ID is trace-addressable contract
           identity and must survive authoring edits.
         lowering: Accepted selection rows lower before runtime execution into ordinary selected `HandlerRuleEntry` branches.
@@ -1897,6 +1920,29 @@ handler_specification:
           - "`handler.switch`, `handler.lookup`, `handler.threshold` — not standalone handler fields"
           - "`policy` as a co-authorable handler field while `rules` remains authorable"
           - runtime-only table, switch, lookup, threshold, or range interpreters
+      policy_sheet_value_rows:
+        scope: Value rows in this slice support only `lookup`, a finite inline exact-match table whose right-hand side is
+          a scalar value. Arithmetic/expression derivation, schema validation, file-backed tables, temporal rows, join rows,
+          loop rows, collection rows, and schedule rows are separate gates.
+        ownership: The policy sheet is the authoring construct. Lookup rows lower to the compute owner; they do not create
+          a second runtime table interpreter and do not make public `compute.lookup` authorable.
+        ordering: The sheet is not a sequential program. Row types lower into their declared runtime phases. Lookup value
+          rows run in compute phase before branch selection; selection rows then read computed.*. Selection outcomes are
+          not values and may not be consumed by lookup rows.
+        target_namespace: lookup.into MUST be an explicit simple computed.* path. Entity persistence is forbidden for
+          derived lookup values; computed.* is turn-scoped and is not written to entity_state unless a separate declared
+          data write explicitly persists a value under its own owner.
+        matching: lookup.on entries MUST use explicit roots. Matching is exact typed equality through one canonicalization
+          path shared by duplicate-key detection and runtime matching. Key literals are type-checked against known root
+          schemas; the string "1" and the number 1 are different keys.
+        default_and_exhaustiveness: >-
+          Closed domains may omit `default: fail` only when boot verification proves exhaustive table coverage. Any open or
+          unknown domain component requires `default: fail`.
+        diagnostics: >-
+          A `default: fail` miss is deterministic no-retry failure with row ID and unmatched tuple in diagnostics, distinct from
+          validation failures.
+        dead_binding: lookup.into bindings must be consumed by a supported downstream condition, emit field, activity input,
+          fan_out, or expression in the same handler; unconsumed bindings fail boot verification.
       emit_template_specialization:
         syntax: A rules handler may declare handler-level emit as the template, with `emit.event` and optional shared
           `emit.from` / `emit.fields`. Each rule then declares `emit.fields` and may declare the same `emit.from` without
@@ -2287,6 +2333,17 @@ handler_specification:
           fields written by data_accumulation instead.'
         usage_example: "data_accumulation:\n  writes:\n  - target_field: expected_count\n    expression:\
           \ fan_out.count"
+      computed:
+        resolves_to: 'Turn-scoped derived handler values written by compute-owned operations. Public authors may read
+          computed.* in rule conditions and expression-value surfaces after the value has been produced by the handler
+          dependency graph.'
+        populated_by: 'compute.store_as targets under computed.* and policy-sheet lookup value rows lowering to internal
+          compute lookup plans.'
+        persistence_model: 'Read/write handler context only. computed.* is not persisted entity state, not event payload,
+          and not replay authority unless a separate declared owner explicitly writes a computed value to a durable surface.'
+        available_in: 'rules.condition, emit.fields CEL expressions, mailbox/action expression values, activity inputs,
+          fan_out inputs, and query_entities scoped operands when the runtime context contains the value.'
+        not_available_as: 'lookup.into may write computed.*; entity.* durable cache fallback for lookup values is forbidden.'
       payload:
         resolves_to: 'The inbound event payload. payload.X reads the X field from the triggering event''s
           JSONB payload.'
@@ -2311,7 +2368,7 @@ handler_specification:
         declared_field_resolution: Every entity.X reference must resolve against the inferred entity contract.
         nested_type_resolution: Nested paths must resolve through named types to a declared field.
         filter_leaf_rule: query_entities filter paths must resolve to scalar or enum leaves.
-        query_operand_rule: query_entities operands with supported scopes (entity, event, payload, policy, fan_out)
+        query_operand_rule: query_entities operands with supported scopes (entity, event, payload, policy, computed, fan_out)
           are validated as scoped operands; unsupported scoped roots are invalid. Runtime evaluation fails closed
           when a supported scoped operand is unavailable in the handler context.
       rule: 'For every entity.X used as a value, X must be declared on the inferred entity contract. Universal

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -1893,8 +1893,10 @@ handler_specification:
           prove structural ordering and non-overlap. Literal ranges are checked for absolute overlap.
         lookup: >-
           object — first-class policy-sheet value row for finite tuple/key-to-value mapping. Public shape is
-          `{on: [<explicit root path>, ...], entries: [{key: [<scalar>, ...], value: <scalar>}], into: computed.<name>,
-          default: fail}`. Single-key rows may author a scalar `key`; tuple rows use list keys. Entries are inline only
+          `{on: [payload.<field>, ...], entries: [{key: [<scalar>, ...], value: <scalar>}], into: computed.<name>,
+          default: fail}`. `lookup.on` supports explicit `payload.*` roots only in this slice; entity, policy, event, and
+          computed lookup keys require a later schema/domain verifier before they can be promoted. Single-key rows may author
+          a scalar `key`; tuple rows use list keys. Entries are inline only
           in this slice. Lookup rows bind a value and do not select a branch, emit, advance state, execute action/activity,
           fan_out, data_accumulation, or public compute. The row lowers to the compute-owned internal lookup operation
           and runs before selection rows consume computed.*.
@@ -1932,9 +1934,9 @@ handler_specification:
         target_namespace: lookup.into MUST be an explicit simple computed.* path. Entity persistence is forbidden for
           derived lookup values; computed.* is turn-scoped and is not written to entity_state unless a separate declared
           data write explicitly persists a value under its own owner.
-        matching: lookup.on entries MUST use explicit roots. Matching is exact typed equality through one canonicalization
-          path shared by duplicate-key detection and runtime matching. Key literals are type-checked against known root
-          schemas; the string "1" and the number 1 are different keys.
+        matching: lookup.on entries MUST use explicit payload.* roots in this slice. Matching is exact typed equality through
+          one canonicalization path shared by duplicate-key detection and runtime matching. Key literals are type-checked
+          against declared payload field schemas; the string "1" and the number 1 are different keys.
         default_and_exhaustiveness: >-
           Closed domains may omit `default: fail` only when boot verification proves exhaustive table coverage. Any open or
           unknown domain component requires `default: fail`.


### PR DESCRIPTION
## Summary
- Add finite inline policy-sheet lookup value rows under `rules[*].lookup`.
- Lower lookup rows to a compute-owned internal `lookup` plan while rejecting public `compute.lookup` authoring.
- Promote turn-scoped `computed.*` reads through supported expression/value consumers and add fail-closed boot verification for lookup rows.

Closes #1715
Part of #1668
Part of #1663

## Governing Refs / Context
Exact spec sections promoted in this PR:
- `contract_formats.system_node.rules.rule_fields.lookup`
- `contract_formats.system_node.rules.policy_sheet_value_rows`
- `contract_formats.system_node.compute.operation_requirements.lookup`
- `contract_formats.system_node.expression_context.namespaces.computed`
- `contract_formats.system_node.dependency_rules`
- `contract_formats.system_node.query_operand_rule`

Binding gate context:
- #1715 Pre-Implementation Coverage Audit: https://github.com/division-sh/swarm/issues/1715#issuecomment-4887981877
- #1715 Gate C outcome: https://github.com/division-sh/swarm/issues/1715#issuecomment-4887996526
- #1713 selection-row work is the sibling/consumer context.
- #1714 validation, #1669 compute modules, and #1717 file-backed criteria/artifact work remain split.

`docs/IMPLEMENTER_GUIDELINES.md` and `docs/SEMANTIC_DRIFT.md` are not present in this checkout or `origin/master`; I followed the issue-stated gate/process constraints directly.

## Semantic Migration
- New canonical owner: policy-sheet value rows authored as `rules[*].lookup`, with compute-owned internal lookup lowering and turn-scoped `computed.*` result binding.
- Old invalid paths: standalone `handler.lookup`, public authorable `compute.operation: lookup`, hidden runtime-only lookup tables, and `entity.*` durable caches for pure lookup results.
- Production paths checked for surviving old behavior: typed YAML decode/lowering, compute operation parsing, executor compute/rules order, CEL/value evaluators, emit/materialization paths, bootverify registry, and platform spec.
- Migration completion: complete for the chosen child class of finite inline exact tuple/key-to-value lookup rows. Parent classes (#1668/#1663) remain open.

## Validation
- `SWARM_TEST_POSTGRES_DSN='host=127.0.0.1 port=5432 user=youmew dbname=postgres sslmode=disable' PGPASSWORD=postgres go test ./...`
