### PR TITLE
[agent-f][issue #1728] Add Shopify provider trigger manifest

### DIFF
--- a/internal/providertriggers/manifests/shopify.yaml
+++ b/internal/providertriggers/manifests/shopify.yaml
@@ -1,0 +1,28 @@
+provider: shopify
+payload_object_required: true
+payload_object_error: shopify payload object is required
+secret:
+  required: true
+signature:
+  type: hmac_sha256
+  encoding: base64
+  header: X-Shopify-Hmac-Sha256
+  signed_payload: raw_body
+  missing_error: shopify signature is required
+  invalid_error: invalid shopify signature
+delivery_id:
+  header: X-Shopify-Webhook-Id
+  required: true
+  missing_error: shopify webhook id is required
+event_type:
+  header: X-Shopify-Topic
+  required: true
+  missing_error: shopify topic is required
+event_name:
+  literal: inbound.shopify
+ack:
+  mode: durable_before_dispatch
+metadata:
+  user_agent: user_agent
+  shopify_webhook_id: delivery_id
+  shopify_topic: event_type

--- a/internal/providertriggers/providertriggers.go
+++ b/internal/providertriggers/providertriggers.go
@@ -947,6 +947,7 @@ func NormalizeEventToken(raw string) string {
 	token := strings.TrimSpace(strings.ToLower(raw))
 	token = strings.ReplaceAll(token, ".", "_")
 	token = strings.ReplaceAll(token, "-", "_")
+	token = strings.ReplaceAll(token, "/", "_")
 	token = strings.ReplaceAll(token, " ", "_")
 	if token == "" {
 		return "event"

--- a/internal/providertriggers/providertriggers_test.go
+++ b/internal/providertriggers/providertriggers_test.go
@@ -387,6 +387,138 @@ func TestTwilioManifestRejectsAmbiguousOrUnsupportedCallbacks(t *testing.T) {
 	}
 }
 
+func TestShopifyManifestAcceptsRawBodyBase64Signature(t *testing.T) {
+	now := time.Unix(1710000000, 0).UTC()
+	body := []byte(`{"id":123,"line_items":[{"sku":"abc"}]}`)
+	req := Request{
+		Provider: "shopify",
+		Target: Target{
+			EntityID:      "entity-1",
+			WebhookSecret: "shopify-secret",
+		},
+		Body:      body,
+		Headers:   make(http.Header),
+		Payload:   map[string]any{"id": float64(123), "line_items": []any{map[string]any{"sku": "abc"}}},
+		Received:  now,
+		UserAgent: "shopify-test",
+	}
+	req.Headers.Set("X-Shopify-Hmac-Sha256", shopifySignatureBase64("shopify-secret", body))
+	req.Headers.Set("X-Shopify-Webhook-Id", "webhook-123")
+	req.Headers.Set("X-Shopify-Topic", "orders/create")
+
+	delivery, err := DefaultRegistry().Accept(req)
+	if err != nil {
+		t.Fatalf("Accept Shopify webhook: %v", err)
+	}
+	if delivery.ProviderEventID != "webhook-123" {
+		t.Fatalf("ProviderEventID = %q, want webhook-123", delivery.ProviderEventID)
+	}
+	if delivery.ProviderEventType != "orders_create" {
+		t.Fatalf("ProviderEventType = %q, want orders_create", delivery.ProviderEventType)
+	}
+	if delivery.EventName != "inbound.shopify" {
+		t.Fatalf("EventName = %q, want inbound.shopify", delivery.EventName)
+	}
+	if !delivery.AcknowledgeBeforeDispatch {
+		t.Fatal("Shopify delivery did not request durable_before_dispatch acknowledgement")
+	}
+	headers, ok := delivery.Payload["headers"].(map[string]any)
+	if !ok {
+		t.Fatalf("headers = %T, want metadata map", delivery.Payload["headers"])
+	}
+	if headers["shopify_webhook_id"] != "webhook-123" || headers["shopify_topic"] != "orders_create" {
+		t.Fatalf("headers = %+v, want Shopify manifest metadata", headers)
+	}
+	encoded := fmtPayload(delivery.Payload)
+	if strings.Contains(encoded, "shopify-secret") {
+		t.Fatal("Shopify signing secret leaked into delivery payload")
+	}
+}
+
+func TestShopifyManifestRejectsInvalidInputsBeforeDelivery(t *testing.T) {
+	now := time.Unix(1710000000, 0).UTC()
+	validBody := []byte(`{"id":123,"line_items":[{"sku":"abc"}]}`)
+	validRequest := func() Request {
+		req := Request{
+			Provider: "shopify",
+			Target: Target{
+				EntityID:      "entity-1",
+				WebhookSecret: "shopify-secret",
+			},
+			Body:     validBody,
+			Headers:  make(http.Header),
+			Payload:  map[string]any{"id": float64(123), "line_items": []any{map[string]any{"sku": "abc"}}},
+			Received: now,
+		}
+		req.Headers.Set("X-Shopify-Hmac-Sha256", shopifySignatureBase64("shopify-secret", validBody))
+		req.Headers.Set("X-Shopify-Webhook-Id", "webhook-123")
+		req.Headers.Set("X-Shopify-Topic", "orders/create")
+		return req
+	}
+	for _, tc := range []struct {
+		name       string
+		configure  func(Request) Request
+		wantStatus int
+	}{
+		{
+			name: "missing signature",
+			configure: func(req Request) Request {
+				req.Headers.Del("X-Shopify-Hmac-Sha256")
+				return req
+			},
+			wantStatus: http.StatusUnauthorized,
+		},
+		{
+			name: "invalid signature",
+			configure: func(req Request) Request {
+				req.Headers.Set("X-Shopify-Hmac-Sha256", shopifySignatureBase64("wrong-secret", req.Body))
+				return req
+			},
+			wantStatus: http.StatusUnauthorized,
+		},
+		{
+			name: "raw body mutation",
+			configure: func(req Request) Request {
+				signedBody := []byte(`{"line_items":[{"sku":"abc"}],"id":123}`)
+				req.Headers.Set("X-Shopify-Hmac-Sha256", shopifySignatureBase64("shopify-secret", signedBody))
+				return req
+			},
+			wantStatus: http.StatusUnauthorized,
+		},
+		{
+			name: "missing webhook id",
+			configure: func(req Request) Request {
+				req.Headers.Del("X-Shopify-Webhook-Id")
+				return req
+			},
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name: "missing topic",
+			configure: func(req Request) Request {
+				req.Headers.Del("X-Shopify-Topic")
+				return req
+			},
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name: "non object payload",
+			configure: func(req Request) Request {
+				req.Body = []byte(`[{"id":123}]`)
+				req.Payload = []any{map[string]any{"id": float64(123)}}
+				req.Headers.Set("X-Shopify-Hmac-Sha256", shopifySignatureBase64("shopify-secret", req.Body))
+				return req
+			},
+			wantStatus: http.StatusBadRequest,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := DefaultRegistry().Accept(tc.configure(validRequest()))
+			requireProviderTriggerError(t, err, tc.wantStatus)
+		})
+	}
+}
+
 func TestManifestValidationRejectsAuthoringErrors(t *testing.T) {
 	for _, tc := range []struct {
 		name     string
@@ -490,6 +622,12 @@ func TestRegistryRejectsEmptyProvider(t *testing.T) {
 		Payload: map[string]any{},
 	})
 	requireProviderTriggerError(t, err, http.StatusBadRequest)
+}
+
+func TestNormalizeEventTokenNormalizesProviderTopicSeparators(t *testing.T) {
+	if got := NormalizeEventToken("orders/create"); got != "orders_create" {
+		t.Fatalf("NormalizeEventToken = %q, want orders_create", got)
+	}
 }
 
 func newHostileRegistry(t *testing.T) *Registry {
@@ -651,6 +789,12 @@ func twilioSignedPayload(requestURL string, form url.Values) string {
 		b.WriteString(form.Get(key))
 	}
 	return b.String()
+}
+
+func shopifySignatureBase64(secret string, body []byte) string {
+	mac := hmac.New(sha256.New, []byte(secret))
+	_, _ = mac.Write(body)
+	return base64.StdEncoding.EncodeToString(mac.Sum(nil))
 }
 
 func cloneValues(values url.Values) url.Values {

--- a/internal/runtime/inbound_postgres_test.go
+++ b/internal/runtime/inbound_postgres_test.go
@@ -131,6 +131,7 @@ func TestInboundGateway_GitHubPausedRuntimePersistsAndReleasesSubscribedDispatch
 	if got := countPostgresInboundProviderEvents(t, ctx, db, runID, entityID, providerEventName, providerEventID); got != 1 {
 		t.Fatalf("provider event rows after resume = %d, want 1", got)
 	}
+	waitForInboundBusQuiescence(t, bus)
 }
 
 func TestInboundGateway_SlackPausedRuntimePersistsAndReleasesSubscribedDispatch(t *testing.T) {
@@ -234,6 +235,7 @@ func TestInboundGateway_SlackPausedRuntimePersistsAndReleasesSubscribedDispatch(
 	if got := countPostgresInboundProviderEvents(t, ctx, db, runID, entityID, providerEventName, providerEventID); got != 1 {
 		t.Fatalf("provider event rows after resume = %d, want 1", got)
 	}
+	waitForInboundBusQuiescence(t, bus)
 }
 
 func TestInboundGateway_StripePausedRuntimePersistsAndReleasesSubscribedDispatch(t *testing.T) {
@@ -339,6 +341,7 @@ func TestInboundGateway_StripePausedRuntimePersistsAndReleasesSubscribedDispatch
 	if got := countPostgresInboundProviderEvents(t, ctx, db, runID, entityID, providerEventName, providerEventID); got != 1 {
 		t.Fatalf("provider event rows after resume = %d, want 1", got)
 	}
+	waitForInboundBusQuiescence(t, bus)
 }
 
 func TestInboundGateway_StripeSQLitePersistsConfiguredManifestDelivery(t *testing.T) {
@@ -399,6 +402,7 @@ func TestInboundGateway_StripeSQLitePersistsConfiguredManifestDelivery(t *testin
 		// The Stripe manifest uses durable_before_dispatch; this proof is about
 		// durable persisted evidence, not immediate post-ack handler scheduling.
 	}
+	waitForInboundBusQuiescence(t, bus)
 }
 
 func TestInboundGateway_TwilioPostgresPersistsConfiguredManifestDelivery(t *testing.T) {
@@ -466,6 +470,7 @@ func TestInboundGateway_TwilioPostgresPersistsConfiguredManifestDelivery(t *test
 		// Twilio uses durable_before_dispatch; this proof is about persisted
 		// evidence and supported store admission, not handler completion.
 	}
+	waitForInboundBusQuiescence(t, bus)
 }
 
 func TestInboundGateway_TwilioSQLitePersistsConfiguredManifestDelivery(t *testing.T) {
@@ -530,6 +535,132 @@ func TestInboundGateway_TwilioSQLitePersistsConfiguredManifestDelivery(t *testin
 		// Twilio uses durable_before_dispatch; this proof is about persisted
 		// evidence and supported store admission, not handler completion.
 	}
+	waitForInboundBusQuiescence(t, bus)
+}
+
+func TestInboundGateway_ShopifyPostgresPersistsConfiguredManifestDelivery(t *testing.T) {
+	_, db, cleanup := testutil.StartPostgres(t)
+	t.Cleanup(cleanup)
+
+	const (
+		runID             = "47000000-0000-0000-0000-000000000001"
+		entityID          = "47000000-0000-0000-0000-000000000002"
+		flowInstance      = "shopify-provider-trigger-instance"
+		entitySlug        = "customer-a"
+		provider          = "shopify"
+		webhookSecret     = "shopify-secret"
+		providerEventID   = "webhook-123"
+		agentID           = "shopify-webhook-subscriber"
+		providerEventName = "inbound.shopify"
+	)
+	ctx := runtimecorrelation.WithRunID(context.Background(), runID)
+	pg := &store.PostgresStore{DB: db}
+	seedPostgresInboundGatewayRuntime(t, ctx, db, pg, runID, entityID, flowInstance, entitySlug, provider, webhookSecret, agentID)
+
+	bus, err := runtimebus.NewEventBus(pg)
+	if err != nil {
+		t.Fatalf("NewEventBus: %v", err)
+	}
+	ch := bus.Subscribe(agentID, events.EventType(providerEventName))
+	defer bus.Unsubscribe(agentID)
+
+	g := runtimepkg.NewInboundGateway(bus, nil, nil, pg)
+
+	body := []byte(`{"id":123,"line_items":[{"sku":"abc"}]}`)
+	req := newSignedShopifyRequest("/webhooks/customer-a/shopify", webhookSecret, body)
+	req = req.WithContext(ctx)
+	req.Header.Set("X-Shopify-Webhook-Id", providerEventID)
+	req.Header.Set("X-Shopify-Topic", "orders/create")
+	rec := httptest.NewRecorder()
+	g.Handler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("status = %d, want 202 body=%s", rec.Code, rec.Body.String())
+	}
+	if got := countPostgresInboundMarkers(t, ctx, db, providerEventID, entityID, provider); got != 1 {
+		t.Fatalf("inbound marker rows = %d, want 1", got)
+	}
+	eventID := loadPostgresInboundProviderEventID(t, ctx, db, runID, entityID, providerEventName, providerEventID)
+	if got := countPostgresInboundProviderEvents(t, ctx, db, runID, entityID, providerEventName, providerEventID); got != 1 {
+		t.Fatalf("provider event rows = %d, want 1", got)
+	}
+	if got := loadPostgresInboundProviderEventPayloadField(t, ctx, db, eventID, "provider_event_type"); got != "orders_create" {
+		t.Fatalf("provider_event_type = %q, want orders_create", got)
+	}
+	if got := countPostgresAgentDeliveriesForEvent(t, ctx, db, eventID, agentID); got != 1 {
+		t.Fatalf("agent delivery rows = %d, want 1", got)
+	}
+	select {
+	case got := <-ch:
+		if got.ID() != eventID || got.Type() != events.EventType(providerEventName) {
+			t.Fatalf("delivered event = %s/%s, want %s/%s", got.ID(), got.Type(), eventID, providerEventName)
+		}
+	default:
+		// Shopify uses durable_before_dispatch; this proof is about persisted
+		// evidence and supported store admission, not handler completion.
+	}
+	waitForInboundBusQuiescence(t, bus)
+}
+
+func TestInboundGateway_ShopifySQLitePersistsConfiguredManifestDelivery(t *testing.T) {
+	const (
+		runID             = "48000000-0000-0000-0000-000000000001"
+		entityID          = "48000000-0000-0000-0000-000000000002"
+		flowInstance      = "shopify-sqlite-provider-trigger-instance"
+		entitySlug        = "customer-a"
+		provider          = "shopify"
+		webhookSecret     = "shopify-secret"
+		providerEventID   = "webhook-456"
+		agentID           = "shopify-sqlite-webhook-subscriber"
+		providerEventName = "inbound.shopify"
+	)
+	ctx := runtimecorrelation.WithRunID(context.Background(), runID)
+	sqliteStore := storetest.StartSQLiteRuntimeStoreWithContext(t, ctx)
+	seedSQLiteInboundGatewayRuntime(t, ctx, sqliteStore, runID, entityID, flowInstance, entitySlug, provider, webhookSecret, agentID)
+
+	bus, err := runtimebus.NewEventBus(sqliteStore)
+	if err != nil {
+		t.Fatalf("NewEventBus: %v", err)
+	}
+	ch := bus.Subscribe(agentID, events.EventType(providerEventName))
+	defer bus.Unsubscribe(agentID)
+
+	g := runtimepkg.NewInboundGateway(bus, nil, nil, sqliteStore)
+
+	body := []byte(`{"id":456,"line_items":[{"sku":"xyz"}]}`)
+	req := newSignedShopifyRequest("/webhooks/customer-a/shopify", webhookSecret, body)
+	req = req.WithContext(ctx)
+	req.Header.Set("X-Shopify-Webhook-Id", providerEventID)
+	req.Header.Set("X-Shopify-Topic", "orders/updated")
+	rec := httptest.NewRecorder()
+	g.Handler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("status = %d, want 202 body=%s", rec.Code, rec.Body.String())
+	}
+	if got := countSQLiteInboundMarkers(t, ctx, sqliteStore, providerEventID, entityID, provider); got != 1 {
+		t.Fatalf("inbound marker rows = %d, want 1", got)
+	}
+	eventID := loadSQLiteInboundProviderEventID(t, ctx, sqliteStore, runID, entityID, providerEventName, providerEventID)
+	if got := countSQLiteInboundProviderEvents(t, ctx, sqliteStore, runID, entityID, providerEventName, providerEventID); got != 1 {
+		t.Fatalf("provider event rows = %d, want 1", got)
+	}
+	if got := loadSQLiteInboundProviderEventPayloadField(t, ctx, sqliteStore, eventID, "provider_event_type"); got != "orders_updated" {
+		t.Fatalf("provider_event_type = %q, want orders_updated", got)
+	}
+	if got := countSQLiteAgentDeliveriesForEvent(t, ctx, sqliteStore, eventID, agentID); got != 1 {
+		t.Fatalf("agent delivery rows = %d, want 1", got)
+	}
+	select {
+	case got := <-ch:
+		if got.ID() != eventID || got.Type() != events.EventType(providerEventName) {
+			t.Fatalf("delivered event = %s/%s, want %s/%s", got.ID(), got.Type(), eventID, providerEventName)
+		}
+	default:
+		// Shopify uses durable_before_dispatch; this proof is about persisted
+		// evidence and supported store admission, not handler completion.
+	}
+	waitForInboundBusQuiescence(t, bus)
 }
 
 func seedPostgresInboundGatewayRuntime(
@@ -652,7 +783,7 @@ func seedSQLiteInboundGatewayRuntime(
 			Type:          "stub",
 			Model:         "regular",
 			Config:        []byte(`{}`),
-			Subscriptions: []string{"inbound.stripe"},
+			Subscriptions: []string{"inbound." + provider},
 		},
 		Status:    "active",
 		HiredBy:   "test",
@@ -883,6 +1014,15 @@ func requireNoInboundBusEvent(t testing.TB, ch <-chan events.Event, context stri
 	}
 }
 
+func waitForInboundBusQuiescence(t testing.TB, bus *runtimebus.EventBus) {
+	t.Helper()
+	waitCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := bus.WaitForQuiescence(waitCtx); err != nil {
+		t.Fatalf("WaitForQuiescence: %v", err)
+	}
+}
+
 func githubWebhookSignature(secret string, body []byte) string {
 	mac := hmac.New(sha256.New, []byte(secret))
 	_, _ = mac.Write(body)
@@ -927,4 +1067,16 @@ func twilioSignedPayload(requestURL string, form url.Values) string {
 		b.WriteString(form.Get(key))
 	}
 	return b.String()
+}
+
+func newSignedShopifyRequest(path string, secret string, body []byte) *http.Request {
+	req := httptest.NewRequest(http.MethodPost, path, strings.NewReader(string(body)))
+	req.Header.Set("X-Shopify-Hmac-Sha256", shopifyWebhookSignature(secret, body))
+	return req
+}
+
+func shopifyWebhookSignature(secret string, body []byte) string {
+	mac := hmac.New(sha256.New, []byte(secret))
+	_, _ = mac.Write(body)
+	return base64.StdEncoding.EncodeToString(mac.Sum(nil))
 }

--- a/internal/runtime/inbound_test.go
+++ b/internal/runtime/inbound_test.go
@@ -1164,6 +1164,221 @@ func TestInboundGateway_TwilioDuplicateDeliveryDoesNotPublishAgain(t *testing.T)
 	}
 }
 
+func TestInboundGateway_ShopifyManifestOwnsRawBodySignatureDeliveryIDAndTopic(t *testing.T) {
+	eventStore := &capturingInboundEventStore{}
+	bus, err := runtimebus.NewEventBus(eventStore)
+	if err != nil {
+		t.Fatalf("NewEventBus: %v", err)
+	}
+	store := &recordingInboundStore{
+		target: InboundTarget{
+			EntityID:      "3fd8fc37-6d02-4d50-8bb7-14c6cb0fed0a",
+			EntitySlug:    "customer-a",
+			WebhookSecret: "shopify-secret",
+		},
+		inserted: true,
+	}
+	g := NewInboundGateway(bus, nil, nil, store)
+
+	body := []byte(`{"id":123,"line_items":[{"sku":"abc"}]}`)
+	req := newSignedShopifyRequest("/webhooks/customer-a/shopify", "shopify-secret", body)
+	req.Header.Set("X-Shopify-Webhook-Id", "webhook-123")
+	req.Header.Set("X-Shopify-Topic", "orders/create")
+	rec := httptest.NewRecorder()
+	g.Handler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("status = %d, want 202 body=%s", rec.Code, rec.Body.String())
+	}
+	if !store.recorded {
+		t.Fatal("expected Shopify delivery to record inbound marker")
+	}
+	if store.providerEventID != "webhook-123" {
+		t.Fatalf("providerEventID = %q, want webhook-123", store.providerEventID)
+	}
+	if store.provider != "shopify" {
+		t.Fatalf("provider = %q, want shopify", store.provider)
+	}
+	if len(eventStore.events) != 1 {
+		t.Fatalf("published events = %d, want 1", len(eventStore.events))
+	}
+	evt := eventStore.events[0]
+	if evt.Type() != events.EventType("inbound.shopify") {
+		t.Fatalf("event type = %q, want inbound.shopify", evt.Type())
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(evt.Payload(), &payload); err != nil {
+		t.Fatalf("unmarshal payload: %v", err)
+	}
+	if payload["provider_event_id"] != "webhook-123" ||
+		payload["provider_event_type"] != "orders_create" ||
+		payload["provider"] != "shopify" {
+		t.Fatalf("payload = %+v, want Shopify manifest delivery identity", payload)
+	}
+	if strings.Contains(rec.Body.String(), "shopify-secret") || strings.Contains(string(evt.Payload()), "shopify-secret") {
+		t.Fatal("Shopify signing secret leaked into readback or event payload")
+	}
+}
+
+func TestInboundGateway_ShopifyRejectsInvalidInputsBeforeMarkerAndPublish(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		body       []byte
+		configure  func(*http.Request, []byte)
+		wantStatus int
+	}{
+		{
+			name:       "missing signature",
+			body:       []byte(`{"id":123,"line_items":[{"sku":"abc"}]}`),
+			configure:  func(*http.Request, []byte) {},
+			wantStatus: http.StatusUnauthorized,
+		},
+		{
+			name: "invalid signature",
+			body: []byte(`{"id":123,"line_items":[{"sku":"abc"}]}`),
+			configure: func(req *http.Request, body []byte) {
+				req.Header.Set("X-Shopify-Hmac-Sha256", shopifyWebhookSignature("wrong-secret", body))
+			},
+			wantStatus: http.StatusUnauthorized,
+		},
+		{
+			name: "raw body mutation",
+			body: []byte(`{"id":123,"line_items":[{"sku":"abc"}]}`),
+			configure: func(req *http.Request, body []byte) {
+				signedBody := []byte(`{"line_items":[{"sku":"abc"}],"id":123}`)
+				req.Header.Set("X-Shopify-Hmac-Sha256", shopifyWebhookSignature("shopify-secret", signedBody))
+			},
+			wantStatus: http.StatusUnauthorized,
+		},
+		{
+			name: "missing webhook id",
+			body: []byte(`{"id":123,"line_items":[{"sku":"abc"}]}`),
+			configure: func(req *http.Request, body []byte) {
+				req.Header.Set("X-Shopify-Hmac-Sha256", shopifyWebhookSignature("shopify-secret", body))
+				req.Header.Del("X-Shopify-Webhook-Id")
+			},
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name: "missing topic",
+			body: []byte(`{"id":123,"line_items":[{"sku":"abc"}]}`),
+			configure: func(req *http.Request, body []byte) {
+				req.Header.Set("X-Shopify-Hmac-Sha256", shopifyWebhookSignature("shopify-secret", body))
+				req.Header.Del("X-Shopify-Topic")
+			},
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name: "non object payload",
+			body: []byte(`[{"id":123}]`),
+			configure: func(req *http.Request, body []byte) {
+				req.Header.Set("X-Shopify-Hmac-Sha256", shopifyWebhookSignature("shopify-secret", body))
+			},
+			wantStatus: http.StatusBadRequest,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			eventStore := &capturingInboundEventStore{}
+			bus, err := runtimebus.NewEventBus(eventStore)
+			if err != nil {
+				t.Fatalf("NewEventBus: %v", err)
+			}
+			store := &recordingInboundStore{
+				target: InboundTarget{
+					EntityID:      "3fd8fc37-6d02-4d50-8bb7-14c6cb0fed0a",
+					EntitySlug:    "customer-a",
+					WebhookSecret: "shopify-secret",
+				},
+				inserted: true,
+			}
+			g := NewInboundGateway(bus, nil, nil, store)
+			req := httptest.NewRequest(http.MethodPost, "/webhooks/customer-a/shopify", strings.NewReader(string(tc.body)))
+			req.Header.Set("X-Shopify-Webhook-Id", "webhook-123")
+			req.Header.Set("X-Shopify-Topic", "orders/create")
+			tc.configure(req, tc.body)
+			rec := httptest.NewRecorder()
+			g.Handler().ServeHTTP(rec, req)
+
+			if rec.Code != tc.wantStatus {
+				t.Fatalf("status = %d, want %d body=%s", rec.Code, tc.wantStatus, rec.Body.String())
+			}
+			if store.recorded {
+				t.Fatal("invalid Shopify request recorded inbound marker")
+			}
+			if len(eventStore.events) != 0 {
+				t.Fatalf("published events = %d, want 0", len(eventStore.events))
+			}
+		})
+	}
+}
+
+func TestInboundGateway_ShopifyDuplicateDeliveryDoesNotPublishAgain(t *testing.T) {
+	eventStore := &capturingInboundEventStore{}
+	bus, err := runtimebus.NewEventBus(eventStore)
+	if err != nil {
+		t.Fatalf("NewEventBus: %v", err)
+	}
+	store := &recordingInboundStore{
+		target: InboundTarget{
+			EntityID:      "3fd8fc37-6d02-4d50-8bb7-14c6cb0fed0a",
+			EntitySlug:    "customer-a",
+			WebhookSecret: "shopify-secret",
+		},
+		inserted: false,
+	}
+	g := NewInboundGateway(bus, nil, nil, store)
+
+	body := []byte(`{"id":123,"line_items":[{"sku":"abc"}]}`)
+	req := newSignedShopifyRequest("/webhooks/customer-a/shopify", "shopify-secret", body)
+	req.Header.Set("X-Shopify-Webhook-Id", "webhook-123")
+	req.Header.Set("X-Shopify-Topic", "orders/create")
+	rec := httptest.NewRecorder()
+	g.Handler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 body=%s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), `"status":"duplicate"`) {
+		t.Fatalf("duplicate response = %s", rec.Body.String())
+	}
+	if len(eventStore.events) != 0 {
+		t.Fatalf("published events = %d, want 0", len(eventStore.events))
+	}
+}
+
+func TestInboundGateway_RawFallbackDoesNotInterpretShopifySignature(t *testing.T) {
+	eventStore := &capturingInboundEventStore{}
+	bus, err := runtimebus.NewEventBus(eventStore)
+	if err != nil {
+		t.Fatalf("NewEventBus: %v", err)
+	}
+	store := &recordingInboundStore{
+		target: InboundTarget{
+			EntityID:      "3fd8fc37-6d02-4d50-8bb7-14c6cb0fed0a",
+			EntitySlug:    "customer-a",
+			WebhookSecret: "raw-secret",
+		},
+		inserted: true,
+	}
+	g := NewInboundGateway(bus, nil, nil, store)
+
+	body := []byte(`{"id":123,"line_items":[{"sku":"abc"}]}`)
+	req := httptest.NewRequest(http.MethodPost, "/webhooks/customer-a/custom", strings.NewReader(string(body)))
+	req.Header.Set("X-Shopify-Hmac-Sha256", shopifyWebhookSignature("raw-secret", body))
+	rec := httptest.NewRecorder()
+	g.Handler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401 body=%s", rec.Code, rec.Body.String())
+	}
+	if store.recorded {
+		t.Fatal("raw fallback accepted Shopify signature and recorded inbound marker")
+	}
+	if len(eventStore.events) != 0 {
+		t.Fatalf("published events = %d, want 0", len(eventStore.events))
+	}
+}
+
 func TestInboundGateway_RawFallbackDoesNotInterpretStripeSignature(t *testing.T) {
 	eventStore := &capturingInboundEventStore{}
 	bus, err := runtimebus.NewEventBus(eventStore)
@@ -1284,6 +1499,18 @@ func twilioSignedPayload(requestURL string, form url.Values) string {
 		b.WriteString(form.Get(key))
 	}
 	return b.String()
+}
+
+func newSignedShopifyRequest(path string, secret string, body []byte) *http.Request {
+	req := httptest.NewRequest(http.MethodPost, path, strings.NewReader(string(body)))
+	req.Header.Set("X-Shopify-Hmac-Sha256", shopifyWebhookSignature(secret, body))
+	return req
+}
+
+func shopifyWebhookSignature(secret string, body []byte) string {
+	mac := hmac.New(sha256.New, []byte(secret))
+	_, _ = mac.Write(body)
+	return base64.StdEncoding.EncodeToString(mac.Sum(nil))
 }
 
 type blockingInboundInterceptor struct {

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -5804,6 +5804,25 @@ tool_model:
       event_type: >
         The selected Twilio messaging callback slice emits literal provider_event_type `message_received` in payload
         metadata. The canonical emitted Swarm event name is literal `inbound.twilio`, not a dynamic template.
+    - provider: shopify
+      issue: "#1728"
+      signature: >
+        Shopify webhook deliveries require a configured signing secret and a valid `X-Shopify-Hmac-Sha256`
+        HMAC-SHA256 Base64 signature over the exact raw request body received by the API listener. The manifest
+        interpreter MUST verify the raw bytes before decoded JSON payload interpretation can influence delivery
+        admission. Missing signing secret, missing signature, invalid signature, or any parsed/re-encoded JSON
+        canonicalization mismatch fails before dedupe marker persistence and before event publish.
+      delivery_id: >
+        `X-Shopify-Webhook-Id` is the authoritative provider delivery id and dedupe-key input for configured Shopify
+        triggers. Missing webhook id fails before dedupe marker persistence.
+      acknowledgement: >
+        Accepted Shopify deliveries return success after the inbound dedupe marker, canonical event record, recipient
+        manifest, and subscribed replay scope are durably persisted or dispatch-queued. The HTTP acknowledgement MUST NOT
+        wait for post-commit pipeline dispatch, system-node handler execution, or agent delivery completion.
+      event_type: >
+        `X-Shopify-Topic` is the authoritative provider event type and is emitted in payload metadata as normalized
+        `provider_event_type`. The canonical emitted Swarm event name is literal `inbound.shopify`, not a dynamic
+        template. Missing topic fails before dedupe marker persistence.
     raw_webhook_mode: >
       Unknown providers may continue through the raw generic webhook mode, but that path is a different semantic concept and
       does not prove provider-trigger adapter closure. Configured providers MUST consume their manifest interpreter owner


### PR DESCRIPTION
## Summary

Closes #1728
Part of #1651
Related to #1458

Adds Shopify as a configured-provider trigger manifest interpreted by `internal/providertriggers`, with no Shopify-specific Go adapter or runtime gateway branch.

## Governing Refs / Context

- `platform-spec.yaml` `provider_trigger_adapters`:
  - `internal/runtime/inbound.go` remains the generic `/webhooks/{entity}/{provider}` gateway owner.
  - `internal/providertriggers` is the configured-provider manifest interpreter and canonical owner for provider-specific admission.
  - New provider manifests use literal Swarm event names and carry provider topic/type in `provider_event_type`.
- #1728 Pre-Implementation Coverage Audit and independent gate.
- #1651 provider-diversity ladder / freeze rule.
- Shopify docs used by the gate/audit:
  - https://shopify.dev/docs/apps/build/webhooks/verify-deliveries
  - https://shopify.dev/docs/apps/build/webhooks/delivery-structure

Requested process docs note: `docs/IMPLEMENTER_GUIDELINES.md` and `docs/SEMANTIC_DRIFT.md` are not present in this worktree.

## Semantic Migration / Authority

- New canonical owner: `internal/providertriggers` built-in Shopify manifest plus the existing manifest interpreter.
- Old producer/reader/writer path now invalid: raw generic webhook fallback and any future Shopify branch in `internal/runtime/inbound.go` are non-authoritative for configured Shopify trigger semantics.
- Production paths checked for surviving old behavior: configured-provider registry loading, gateway raw-body request materialization, marker/publish flow, SQLite/Postgres inbound store proofs, and raw fallback separation.
- Migration complete for #1728: Shopify configured-provider trigger admission is manifest data only. #1651 remains open for the provider-diversity freeze rule.
- Vocabulary delta: zero new manifest vocabulary additions. Shopify consumes existing `hmac_sha256`, `encoding: base64`, `signed_payload: raw_body`, header value sources, literal event name, and `durable_before_dispatch` ack mode.

## Tests

- `go test ./internal/providertriggers -count=1`
- `SWARM_TEST_POSTGRES_DSN='host=127.0.0.1 port=5432 user=youmew dbname=postgres sslmode=disable' PGPASSWORD=postgres go test ./internal/runtime -run 'Shopify|Provider|Webhook|Inbound' -count=1`
- `SWARM_TEST_POSTGRES_DSN='host=127.0.0.1 port=5432 user=youmew dbname=postgres sslmode=disable' PGPASSWORD=postgres go test ./internal/providertriggers ./internal/runtime -count=1`
- `SWARM_TEST_POSTGRES_DSN='host=127.0.0.1 port=5432 user=youmew dbname=postgres sslmode=disable' PGPASSWORD=postgres go test ./internal/runtime -count=1`
- `SWARM_TEST_POSTGRES_DSN='host=127.0.0.1 port=5432 user=youmew dbname=postgres sslmode=disable' PGPASSWORD=postgres go test ./...`
