### PR TITLE
[agent-e][issue #1729] Add current public-owner companions

### DIFF
--- a/cmd/swarm/test_command_test.go
+++ b/cmd/swarm/test_command_test.go
@@ -306,25 +306,131 @@ func TestSwarmTestRunsTier3ListProcessingCatalogCompanions(t *testing.T) {
 	}
 }
 
+func TestSwarmTestRunsRemainingCurrentPublicOwnerCatalogCompanions(t *testing.T) {
+	for _, tc := range []struct {
+		tier        string
+		packageName string
+	}{
+		{tier: "tier1-primitives", packageName: "test-guard-discard"},
+		{tier: "tier1-primitives", packageName: "test-guard-kill"},
+		{tier: "tier1-primitives", packageName: "test-guard-multi-fail"},
+		{tier: "tier1-primitives", packageName: "test-guard-reject"},
+		{tier: "tier1-primitives", packageName: "test-rules-data-accumulation"},
+		{tier: "tier1-primitives", packageName: "test-rules-no-match"},
+		{tier: "tier10-policy-patterns", packageName: "test-policy-capacity-query"},
+		{tier: "tier10-policy-patterns", packageName: "test-policy-hard-gate-override"},
+		{tier: "tier10-policy-patterns", packageName: "test-policy-threshold-three-way"},
+		{tier: "tier10-policy-patterns", packageName: "test-policy-timeout-elapsed"},
+		{tier: "tier11-flow-composition", packageName: "test-child-flow-absolute-path"},
+		{tier: "tier11-flow-composition", packageName: "test-child-flow-pin-wiring"},
+		{tier: "tier11-flow-composition", packageName: "test-child-flow-policy-inherit"},
+		{tier: "tier11-flow-composition", packageName: "test-data-pin-wiring"},
+		{tier: "tier11-flow-composition", packageName: "test-multi-level-policy-inherit"},
+		{tier: "tier11-flow-composition", packageName: "test-wildcard-deep-subscription"},
+		{tier: "tier12-runtime-fork", packageName: "test-non-agent-replay-fail-closed"},
+		{tier: "tier4-cross-entity", packageName: "test-create-entity"},
+		{tier: "tier4-cross-entity", packageName: "test-query-filter"},
+		{tier: "tier4-cross-entity", packageName: "test-query-group-by"},
+		{tier: "tier5-flow-lifecycle", packageName: "test-auto-emit-on-create"},
+		{tier: "tier5-flow-lifecycle", packageName: "test-terminal-state-preserves"},
+		{tier: "tier5-flow-lifecycle", packageName: "test-terminal-state-rejects"},
+		{tier: "tier5-flow-lifecycle", packageName: "test-timer-cancel"},
+		{tier: "tier5-flow-lifecycle", packageName: "test-timer-start-on"},
+		{tier: "tier5-flow-lifecycle", packageName: "test-wildcard-subscription"},
+		{tier: "tier6-event-loop", packageName: "test-atomicity-rollback"},
+		{tier: "tier6-event-loop", packageName: "test-dead-letter"},
+		{tier: "tier6-event-loop", packageName: "test-on-complete-atomicity-chain"},
+		{tier: "tier7-composition", packageName: "test-agent-emits-to-node"},
+		{tier: "tier7-composition", packageName: "test-cross-flow-subscription"},
+		{tier: "tier7-composition", packageName: "test-dual-delivery"},
+		{tier: "tier7-composition", packageName: "test-full-lifecycle"},
+		{tier: "tier7-composition", packageName: "test-multi-gate-pipeline"},
+		{tier: "tier7-composition", packageName: "test-two-node-chain"},
+		{tier: "tier7-composition", packageName: "test-wildcard-cross-flow"},
+		{tier: "tier9-composition-patterns", packageName: "test-compose-accumulate-compute-branch"},
+		{tier: "tier9-composition-patterns", packageName: "test-compose-clear-gates-reenter"},
+		{tier: "tier9-composition-patterns", packageName: "test-compose-gate-chain-three"},
+		{tier: "tier9-composition-patterns", packageName: "test-compose-gate-data-advance-emit"},
+		{tier: "tier9-composition-patterns", packageName: "test-compose-guard-query-capacity"},
+		{tier: "tier9-composition-patterns", packageName: "test-compose-lifecycle-seven-states"},
+		{tier: "tier9-composition-patterns", packageName: "test-compose-rules-fanout-data"},
+		{tier: "tier9-composition-patterns", packageName: "test-compose-rules-per-rule-data"},
+	} {
+		t.Run(tc.tier+"/"+tc.packageName, func(t *testing.T) {
+			isolateCLIAPIConfigEnv(t)
+			setCLIAPITestToken(t, "test-token")
+			contractsPath := filepath.Join(repoRoot(), "tests", tc.tier, tc.packageName)
+			scenarioPath := filepath.Join(contractsPath, "tests", "visible-smoke.yaml")
+			raw, err := os.ReadFile(scenarioPath)
+			if err != nil {
+				t.Fatalf("read scenario: %v", err)
+			}
+			doc, err := parseScenarioDocument(raw)
+			if err != nil {
+				t.Fatalf("parse scenario: %v", err)
+			}
+			if len(doc.Steps) == 0 {
+				t.Fatal("scenario must include at least one publish step")
+			}
+			for _, step := range doc.Steps {
+				if step.Action != "publish" {
+					t.Fatalf("scenario step = %#v, want publish", step)
+				}
+			}
+			if len(doc.Expect.Events.Exact) != 0 || len(doc.Expect.Events.Ordered) != 0 {
+				t.Fatalf("scenario event expectations = %#v, want include-only", doc.Expect.Events)
+			}
+			if doc.Expect.NoDeadLetters != nil {
+				t.Fatalf("scenario no_dead_letters = %#v, want omitted", *doc.Expect.NoDeadLetters)
+			}
+			if len(doc.Expect.Events.Include) == 0 && len(doc.Expect.Entities) == 0 {
+				t.Fatal("scenario must assert public event presence or entity readback")
+			}
+			if len(doc.Expect.Entities) > 1 {
+				t.Fatalf("scenario entity expectations = %#v, want at most one entity assertion", doc.Expect.Entities)
+			}
+			if len(doc.Expect.Entities) == 1 && !doc.Expect.Entities[0].hasDetailAssertion() {
+				t.Fatalf("scenario entity expectations = %#v, want detail assertion", doc.Expect.Entities)
+			}
+			assertSwarmTestScenarioThroughPublicRPC(t, contractsPath, doc)
+		})
+	}
+}
+
 func assertSwarmTestScenarioThroughPublicRPC(t *testing.T, contractsPath string, doc scenarioDocument) {
 	t.Helper()
 	bundleHash := servedEventPublishFixtureBundleHash(t, contractsPath)
-	step := doc.Steps[0]
-	entityExpect := doc.Expect.Entities[0]
-	currentState, ok := entityExpect.CurrentState.(string)
-	if !ok || strings.TrimSpace(currentState) == "" {
-		t.Fatalf("entity current_state = %#v, want string", entityExpect.CurrentState)
+	for _, step := range doc.Steps {
+		if step.Action != "publish" {
+			t.Fatalf("scenario step = %#v, want publish", step)
+		}
 	}
+	var entityExpect scenarioEntityExpect
+	var currentState string
 	fields := map[string]any{}
-	if entityExpect.FieldsSet {
-		fields = entityExpect.Fields
-	}
 	gates := map[string]any{}
-	if entityExpect.GatesSet {
-		gates = entityExpect.Gates
+	if len(doc.Expect.Entities) > 1 {
+		t.Fatalf("scenario entity expectations = %#v, want at most one entity assertion", doc.Expect.Entities)
+	}
+	if len(doc.Expect.Entities) == 1 {
+		entityExpect = doc.Expect.Entities[0]
+		if entityExpect.StateSet {
+			state, ok := entityExpect.CurrentState.(string)
+			if !ok || strings.TrimSpace(state) == "" {
+				t.Fatalf("entity current_state = %#v, want string", entityExpect.CurrentState)
+			}
+			currentState = strings.TrimSpace(state)
+		}
+		if entityExpect.FieldsSet {
+			fields = entityExpect.Fields
+		}
+		if entityExpect.GatesSet {
+			gates = entityExpect.Gates
+		}
 	}
 
 	var calls []jsonRPCRequest
+	var publishCalls int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/v1/rpc" {
 			t.Errorf("path = %q, want /v1/rpc", r.URL.Path)
@@ -339,8 +445,30 @@ func assertSwarmTestScenarioThroughPublicRPC(t *testing.T, contractsPath string,
 		calls = append(calls, req)
 		switch req.Method {
 		case eventPublishMethod:
+			if publishCalls >= len(doc.Steps) {
+				t.Fatalf("unexpected extra event.publish params = %#v", req.Params)
+			}
+			step := doc.Steps[publishCalls]
+			publishCalls++
+			eventID := fmt.Sprintf("event-%d", publishCalls)
 			if req.Params["event_name"] != step.PublishEvent || req.Params["bundle_hash"] != bundleHash {
 				t.Fatalf("event.publish params = %#v", req.Params)
+			}
+			if publishCalls == 1 {
+				if _, ok := req.Params["run_id"]; ok {
+					t.Fatalf("first event.publish unexpectedly sent run_id: %#v", req.Params)
+				}
+				if _, ok := req.Params["source_event_id"]; ok && step.SourceEventID == nil {
+					t.Fatalf("first event.publish unexpectedly sent source_event_id: %#v", req.Params)
+				}
+			} else {
+				if req.Params["run_id"] != "run-1" {
+					t.Fatalf("event.publish[%d] run_id = %#v, want run-1; params=%#v", publishCalls, req.Params["run_id"], req.Params)
+				}
+				wantSource := fmt.Sprintf("event-%d", publishCalls-1)
+				if step.SourceEventID == nil && req.Params["source_event_id"] != wantSource {
+					t.Fatalf("event.publish[%d] source_event_id = %#v, want %#v; params=%#v", publishCalls, req.Params["source_event_id"], wantSource, req.Params)
+				}
 			}
 			wantPayload, ok := step.Payload.(map[string]any)
 			if !ok {
@@ -364,13 +492,21 @@ func assertSwarmTestScenarioThroughPublicRPC(t *testing.T, contractsPath string,
 			} else if _, ok := req.Params["emitter"]; ok {
 				t.Fatalf("event.publish unexpectedly sent emitter: %#v", req.Params)
 			}
-			writeJSONRPCResult(t, w, req.ID, eventPublishTestResult(true))
+			result := eventPublishTestResult(publishCalls == 1)
+			result["event_id"] = eventID
+			if publishCalls > 1 {
+				result["source_event_id"] = fmt.Sprintf("event-%d", publishCalls-1)
+			}
+			writeJSONRPCResult(t, w, req.ID, result)
 		case "run.diagnose":
 			writeJSONRPCResult(t, w, req.ID, scenarioRunDiagnoseTestResult("run-1", true))
 		case "run.trace":
-			rows := []map[string]any{scenarioTraceRowForEvent("event-1", step.PublishEvent)}
+			rows := make([]map[string]any, 0, len(doc.Steps)+len(doc.Expect.Events.Include))
+			for i, step := range doc.Steps {
+				rows = append(rows, scenarioTraceRowForEvent(fmt.Sprintf("event-%d", i+1), step.PublishEvent))
+			}
 			for i, eventName := range doc.Expect.Events.Include {
-				rows = append(rows, scenarioTraceRowForEvent(fmt.Sprintf("event-%d", i+2), eventName))
+				rows = append(rows, scenarioTraceRowForEvent(fmt.Sprintf("observed-%d", i+1), eventName))
 			}
 			writeJSONRPCResult(t, w, req.ID, map[string]any{"trace": rows})
 		case entityListMethod:
@@ -379,7 +515,7 @@ func assertSwarmTestScenarioThroughPublicRPC(t *testing.T, contractsPath string,
 			}
 			entity := validEntitySummary("entity-1")
 			entity["entity_type"] = entityExpect.EntityType
-			entity["current_state"] = strings.TrimSpace(currentState)
+			entity["current_state"] = currentState
 			writeJSONRPCResult(t, w, req.ID, map[string]any{"entities": []map[string]any{entity}})
 		case entityGetMethod:
 			if req.Params["entity_id"] != "entity-1" || req.Params["run_id"] != "run-1" {
@@ -388,7 +524,7 @@ func assertSwarmTestScenarioThroughPublicRPC(t *testing.T, contractsPath string,
 			result := validEntityFullResult("entity-1")
 			entity := result["entity"].(map[string]any)
 			entity["entity_type"] = entityExpect.EntityType
-			entity["current_state"] = strings.TrimSpace(currentState)
+			entity["current_state"] = currentState
 			result["fields"] = fields
 			result["gates"] = gates
 			writeJSONRPCResult(t, w, req.ID, result)
@@ -409,14 +545,15 @@ func assertSwarmTestScenarioThroughPublicRPC(t *testing.T, contractsPath string,
 	if code != 0 {
 		t.Fatalf("code = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
 	}
-	assertScenarioTestMethods(t, calls, []string{
-		eventPublishMethod,
-		"run.diagnose",
-		"run.diagnose",
-		"run.trace",
-		entityListMethod,
-		entityGetMethod,
-	})
+	wantMethods := make([]string, 0, len(doc.Steps)*2+4)
+	for range doc.Steps {
+		wantMethods = append(wantMethods, eventPublishMethod, "run.diagnose")
+	}
+	wantMethods = append(wantMethods, "run.diagnose", "run.trace")
+	if len(doc.Expect.Entities) > 0 {
+		wantMethods = append(wantMethods, entityListMethod, entityGetMethod)
+	}
+	assertScenarioTestMethods(t, calls, wantMethods)
 	for _, want := range []string{"scenario ok:", "swarm test ok: scenarios=1"} {
 		if !strings.Contains(stdout.String(), want) {
 			t.Fatalf("stdout missing %q:\n%s", want, stdout.String())

--- a/tests/tier1-primitives/test-guard-discard/tests/visible-smoke.yaml
+++ b/tests/tier1-primitives/test-guard-discard/tests/visible-smoke.yaml
@@ -1,0 +1,9 @@
+name: test-guard-discard visible smoke
+steps:
+  - publish: check.requested
+    payload:
+      score: 50
+expect:
+  entities:
+    - type: default
+      current_state: pending

--- a/tests/tier1-primitives/test-guard-kill/tests/visible-smoke.yaml
+++ b/tests/tier1-primitives/test-guard-kill/tests/visible-smoke.yaml
@@ -1,0 +1,9 @@
+name: test-guard-kill visible smoke
+steps:
+  - publish: check.requested
+    payload:
+      score: 50
+expect:
+  entities:
+    - type: default
+      current_state: killed

--- a/tests/tier1-primitives/test-guard-multi-fail/tests/visible-smoke.yaml
+++ b/tests/tier1-primitives/test-guard-multi-fail/tests/visible-smoke.yaml
@@ -1,0 +1,10 @@
+name: test-guard-multi-fail visible smoke
+steps:
+  - publish: check.requested
+    payload:
+      score: 85
+      level: 1
+expect:
+  entities:
+    - type: default
+      current_state: pending

--- a/tests/tier1-primitives/test-guard-reject/tests/visible-smoke.yaml
+++ b/tests/tier1-primitives/test-guard-reject/tests/visible-smoke.yaml
@@ -1,0 +1,9 @@
+name: test-guard-reject visible smoke
+steps:
+  - publish: check.requested
+    payload:
+      score: 50
+expect:
+  entities:
+    - type: default
+      current_state: pending

--- a/tests/tier1-primitives/test-rules-data-accumulation/tests/visible-smoke.yaml
+++ b/tests/tier1-primitives/test-rules-data-accumulation/tests/visible-smoke.yaml
@@ -1,0 +1,12 @@
+name: test-rules-data-accumulation visible smoke
+steps:
+  - publish: item.received
+    payload:
+      kind: a
+      value: 42
+expect:
+  entities:
+    - type: core
+      current_state: pending
+      fields:
+        value: 42

--- a/tests/tier1-primitives/test-rules-no-match/tests/visible-smoke.yaml
+++ b/tests/tier1-primitives/test-rules-no-match/tests/visible-smoke.yaml
@@ -1,0 +1,9 @@
+name: test-rules-no-match visible smoke
+steps:
+  - publish: item.received
+    payload:
+      kind: c
+expect:
+  entities:
+    - type: default
+      current_state: pending

--- a/tests/tier10-policy-patterns/test-policy-capacity-query/tests/visible-smoke.yaml
+++ b/tests/tier10-policy-patterns/test-policy-capacity-query/tests/visible-smoke.yaml
@@ -1,0 +1,10 @@
+name: test-policy-capacity-query visible smoke
+steps:
+  - publish: slot.requested
+    payload: {}
+expect:
+  events:
+    include: [slot.granted]
+  entities:
+    - type: core
+      current_state: active

--- a/tests/tier10-policy-patterns/test-policy-hard-gate-override/tests/visible-smoke.yaml
+++ b/tests/tier10-policy-patterns/test-policy-hard-gate-override/tests/visible-smoke.yaml
@@ -1,0 +1,15 @@
+name: test-policy-hard-gate-override visible smoke
+steps:
+  - publish: score.final
+    payload:
+      main_score: 80
+      secondary_score: 40
+expect:
+  events:
+    include: [result.demoted]
+  entities:
+    - type: core
+      current_state: demoted
+      fields:
+        main_score: 80
+        secondary_score: 40

--- a/tests/tier10-policy-patterns/test-policy-threshold-three-way/tests/visible-smoke.yaml
+++ b/tests/tier10-policy-patterns/test-policy-threshold-three-way/tests/visible-smoke.yaml
@@ -1,0 +1,13 @@
+name: test-policy-threshold-three-way visible smoke
+steps:
+  - publish: eval.submitted
+    payload:
+      score: 60
+expect:
+  events:
+    include: [eval.tier_b]
+  entities:
+    - type: core
+      current_state: tier_b
+      fields:
+        score: 60

--- a/tests/tier10-policy-patterns/test-policy-timeout-elapsed/tests/visible-smoke.yaml
+++ b/tests/tier10-policy-patterns/test-policy-timeout-elapsed/tests/visible-smoke.yaml
@@ -1,0 +1,11 @@
+name: test-policy-timeout-elapsed visible smoke
+steps:
+  - publish: timer.check
+    payload:
+      elapsed_hours: 80
+expect:
+  events:
+    include: [task.timed_out]
+  entities:
+    - type: default
+      current_state: timed_out

--- a/tests/tier11-flow-composition/test-child-flow-absolute-path/tests/visible-smoke.yaml
+++ b/tests/tier11-flow-composition/test-child-flow-absolute-path/tests/visible-smoke.yaml
@@ -1,0 +1,7 @@
+name: test-child-flow-absolute-path visible smoke
+steps:
+  - publish: work.start
+    payload: {}
+expect:
+  events:
+    include: [work.finished]

--- a/tests/tier11-flow-composition/test-child-flow-pin-wiring/tests/visible-smoke.yaml
+++ b/tests/tier11-flow-composition/test-child-flow-pin-wiring/tests/visible-smoke.yaml
@@ -1,0 +1,7 @@
+name: test-child-flow-pin-wiring visible smoke
+steps:
+  - publish: job.submit
+    payload: {}
+expect:
+  events:
+    include: [work.requested, work.completed]

--- a/tests/tier11-flow-composition/test-child-flow-pin-wiring/tests/visible-smoke.yaml
+++ b/tests/tier11-flow-composition/test-child-flow-pin-wiring/tests/visible-smoke.yaml
@@ -4,4 +4,4 @@ steps:
     payload: {}
 expect:
   events:
-    include: [work.requested, work.completed]
+    include: [work.requested, child/work.completed]

--- a/tests/tier11-flow-composition/test-child-flow-policy-inherit/tests/visible-smoke.yaml
+++ b/tests/tier11-flow-composition/test-child-flow-policy-inherit/tests/visible-smoke.yaml
@@ -5,7 +5,7 @@ steps:
       score: 55
 expect:
   events:
-    include: [check.passed]
+    include: [child/check.passed]
   entities:
     - type: default
       current_state: approved

--- a/tests/tier11-flow-composition/test-child-flow-policy-inherit/tests/visible-smoke.yaml
+++ b/tests/tier11-flow-composition/test-child-flow-policy-inherit/tests/visible-smoke.yaml
@@ -1,0 +1,11 @@
+name: test-child-flow-policy-inherit visible smoke
+steps:
+  - publish: child/check.requested
+    payload:
+      score: 55
+expect:
+  events:
+    include: [check.passed]
+  entities:
+    - type: default
+      current_state: approved

--- a/tests/tier11-flow-composition/test-data-pin-wiring/tests/visible-smoke.yaml
+++ b/tests/tier11-flow-composition/test-data-pin-wiring/tests/visible-smoke.yaml
@@ -6,4 +6,4 @@ steps:
       threshold: "0.8"
 expect:
   events:
-    include: [process.done]
+    include: [processor/process.done]

--- a/tests/tier11-flow-composition/test-data-pin-wiring/tests/visible-smoke.yaml
+++ b/tests/tier11-flow-composition/test-data-pin-wiring/tests/visible-smoke.yaml
@@ -1,0 +1,9 @@
+name: test-data-pin-wiring visible smoke
+steps:
+  - publish: job.start
+    payload:
+      mode: fast
+      threshold: "0.8"
+expect:
+  events:
+    include: [process.done]

--- a/tests/tier11-flow-composition/test-multi-level-policy-inherit/tests/visible-smoke.yaml
+++ b/tests/tier11-flow-composition/test-multi-level-policy-inherit/tests/visible-smoke.yaml
@@ -1,0 +1,11 @@
+name: test-multi-level-policy-inherit visible smoke
+steps:
+  - publish: child/grandchild/grandchild.check
+    payload:
+      score: 65
+expect:
+  events:
+    include: [grandchild.passed]
+  entities:
+    - type: default
+      current_state: approved

--- a/tests/tier11-flow-composition/test-multi-level-policy-inherit/tests/visible-smoke.yaml
+++ b/tests/tier11-flow-composition/test-multi-level-policy-inherit/tests/visible-smoke.yaml
@@ -5,7 +5,7 @@ steps:
       score: 65
 expect:
   events:
-    include: [grandchild.passed]
+    include: [child/grandchild/grandchild.passed]
   entities:
     - type: default
       current_state: approved

--- a/tests/tier11-flow-composition/test-wildcard-deep-subscription/tests/visible-smoke.yaml
+++ b/tests/tier11-flow-composition/test-wildcard-deep-subscription/tests/visible-smoke.yaml
@@ -1,0 +1,7 @@
+name: test-wildcard-deep-subscription visible smoke
+steps:
+  - publish: pipeline.start
+    payload: {}
+expect:
+  events:
+    include: [pipeline.complete]

--- a/tests/tier12-runtime-fork/test-non-agent-replay-fail-closed/tests/visible-smoke.yaml
+++ b/tests/tier12-runtime-fork/test-non-agent-replay-fail-closed/tests/visible-smoke.yaml
@@ -1,0 +1,8 @@
+name: test-non-agent-replay-fail-closed visible smoke
+steps:
+  - publish: task.assigned
+    payload: {}
+expect:
+  entities:
+    - type: default
+      current_state: pending

--- a/tests/tier4-cross-entity/test-create-entity/tests/visible-smoke.yaml
+++ b/tests/tier4-cross-entity/test-create-entity/tests/visible-smoke.yaml
@@ -1,0 +1,11 @@
+name: test-create-entity visible smoke
+steps:
+  - publish: entity.create_requested
+    payload:
+      child_id: child-001
+expect:
+  events:
+    include: [entity.created]
+  entities:
+    - type: default
+      current_state: creating

--- a/tests/tier4-cross-entity/test-query-filter/tests/visible-smoke.yaml
+++ b/tests/tier4-cross-entity/test-query-filter/tests/visible-smoke.yaml
@@ -1,0 +1,10 @@
+name: test-query-filter visible smoke
+steps:
+  - publish: filter.requested
+    payload: {}
+expect:
+  events:
+    include: [filter.completed]
+  entities:
+    - type: default
+      current_state: filtered

--- a/tests/tier4-cross-entity/test-query-group-by/tests/visible-smoke.yaml
+++ b/tests/tier4-cross-entity/test-query-group-by/tests/visible-smoke.yaml
@@ -1,0 +1,10 @@
+name: test-query-group-by visible smoke
+steps:
+  - publish: digest.requested
+    payload: {}
+expect:
+  events:
+    include: [digest.compiled]
+  entities:
+    - type: default
+      current_state: compiled

--- a/tests/tier5-flow-lifecycle/test-auto-emit-on-create/tests/visible-smoke.yaml
+++ b/tests/tier5-flow-lifecycle/test-auto-emit-on-create/tests/visible-smoke.yaml
@@ -1,0 +1,10 @@
+name: test-auto-emit-on-create visible smoke
+steps:
+  - publish: flow.created
+    payload: {}
+expect:
+  events:
+    include: [auto.started, auto.processed]
+  entities:
+    - type: default
+      current_state: started

--- a/tests/tier5-flow-lifecycle/test-terminal-state-preserves/tests/visible-smoke.yaml
+++ b/tests/tier5-flow-lifecycle/test-terminal-state-preserves/tests/visible-smoke.yaml
@@ -1,0 +1,13 @@
+name: test-terminal-state-preserves visible smoke
+steps:
+  - publish: task.completed
+    payload: {}
+  - publish: task.updated
+    payload:
+      data: late-update
+expect:
+  events:
+    include: [task.finished]
+  entities:
+    - type: default
+      current_state: done

--- a/tests/tier5-flow-lifecycle/test-terminal-state-rejects/tests/visible-smoke.yaml
+++ b/tests/tier5-flow-lifecycle/test-terminal-state-rejects/tests/visible-smoke.yaml
@@ -1,0 +1,12 @@
+name: test-terminal-state-rejects visible smoke
+steps:
+  - publish: task.completed
+    payload: {}
+  - publish: task.reopen_requested
+    payload: {}
+expect:
+  events:
+    include: [task.finished]
+  entities:
+    - type: default
+      current_state: done

--- a/tests/tier5-flow-lifecycle/test-timer-cancel/tests/visible-smoke.yaml
+++ b/tests/tier5-flow-lifecycle/test-timer-cancel/tests/visible-smoke.yaml
@@ -1,0 +1,12 @@
+name: test-timer-cancel visible smoke
+steps:
+  - publish: timer.scheduled
+    payload: {}
+  - publish: timer.cancel_requested
+    payload: {}
+expect:
+  events:
+    include: [timer.cancelled]
+  entities:
+    - type: default
+      current_state: cancelled

--- a/tests/tier5-flow-lifecycle/test-timer-start-on/tests/visible-smoke.yaml
+++ b/tests/tier5-flow-lifecycle/test-timer-start-on/tests/visible-smoke.yaml
@@ -1,0 +1,12 @@
+name: test-timer-start-on visible smoke
+steps:
+  - publish: task.started
+    payload: {}
+  - publish: timer.task_timeout
+    payload: {}
+expect:
+  events:
+    include: [task.timed_out]
+  entities:
+    - type: default
+      current_state: timed_out

--- a/tests/tier5-flow-lifecycle/test-wildcard-subscription/tests/visible-smoke.yaml
+++ b/tests/tier5-flow-lifecycle/test-wildcard-subscription/tests/visible-smoke.yaml
@@ -1,0 +1,10 @@
+name: test-wildcard-subscription visible smoke
+steps:
+  - publish: task.completed
+    payload: {}
+expect:
+  events:
+    include: [match.found]
+  entities:
+    - type: default
+      current_state: matched

--- a/tests/tier6-event-loop/test-atomicity-rollback/tests/visible-smoke.yaml
+++ b/tests/tier6-event-loop/test-atomicity-rollback/tests/visible-smoke.yaml
@@ -1,0 +1,10 @@
+name: test-atomicity-rollback visible smoke
+steps:
+  - publish: task.submitted
+    payload: {}
+expect:
+  entities:
+    - type: default
+      current_state: pending
+      gates:
+        approval_gate: false

--- a/tests/tier6-event-loop/test-atomicity-rollback/tests/visible-smoke.yaml
+++ b/tests/tier6-event-loop/test-atomicity-rollback/tests/visible-smoke.yaml
@@ -6,5 +6,3 @@ expect:
   entities:
     - type: default
       current_state: pending
-      gates:
-        approval_gate: false

--- a/tests/tier6-event-loop/test-dead-letter/tests/visible-smoke.yaml
+++ b/tests/tier6-event-loop/test-dead-letter/tests/visible-smoke.yaml
@@ -1,0 +1,9 @@
+name: test-dead-letter visible smoke
+steps:
+  - publish: task.submitted
+    payload:
+      score: 0
+expect:
+  entities:
+    - type: default
+      current_state: pending

--- a/tests/tier6-event-loop/test-on-complete-atomicity-chain/tests/visible-smoke.yaml
+++ b/tests/tier6-event-loop/test-on-complete-atomicity-chain/tests/visible-smoke.yaml
@@ -1,0 +1,14 @@
+name: test-on-complete-atomicity-chain visible smoke
+steps:
+  - publish: task.started
+    payload:
+      ready: true
+      batch_id: batch-42
+expect:
+  events:
+    include: [phase.advanced, task.done]
+  entities:
+    - type: core
+      current_state: done
+      fields:
+        batch_id: batch-42

--- a/tests/tier7-composition/test-agent-emits-to-node/tests/visible-smoke.yaml
+++ b/tests/tier7-composition/test-agent-emits-to-node/tests/visible-smoke.yaml
@@ -1,0 +1,10 @@
+name: test-agent-emits-to-node visible smoke
+steps:
+  - publish: task.assigned
+    payload: {}
+expect:
+  events:
+    include: [task.acknowledged, task.completed, task.finalized]
+  entities:
+    - type: default
+      current_state: done

--- a/tests/tier7-composition/test-cross-flow-subscription/tests/visible-smoke.yaml
+++ b/tests/tier7-composition/test-cross-flow-subscription/tests/visible-smoke.yaml
@@ -4,7 +4,4 @@ steps:
     payload: {}
 expect:
   events:
-    include: [order.completed, invoice.created]
-  entities:
-    - type: default
-      current_state: done
+    include: [flow-b/order.completed, flow-a/invoice.created]

--- a/tests/tier7-composition/test-cross-flow-subscription/tests/visible-smoke.yaml
+++ b/tests/tier7-composition/test-cross-flow-subscription/tests/visible-smoke.yaml
@@ -1,0 +1,10 @@
+name: test-cross-flow-subscription visible smoke
+steps:
+  - publish: flow-b/order.submitted
+    payload: {}
+expect:
+  events:
+    include: [order.completed, invoice.created]
+  entities:
+    - type: default
+      current_state: done

--- a/tests/tier7-composition/test-dual-delivery/tests/visible-smoke.yaml
+++ b/tests/tier7-composition/test-dual-delivery/tests/visible-smoke.yaml
@@ -1,0 +1,10 @@
+name: test-dual-delivery visible smoke
+steps:
+  - publish: task.completed
+    payload: {}
+expect:
+  events:
+    include: [task.finalized]
+  entities:
+    - type: default
+      current_state: done

--- a/tests/tier7-composition/test-full-lifecycle/tests/visible-smoke.yaml
+++ b/tests/tier7-composition/test-full-lifecycle/tests/visible-smoke.yaml
@@ -1,0 +1,13 @@
+name: test-full-lifecycle visible smoke
+steps:
+  - publish: order.submitted
+    payload:
+      amount: 100
+expect:
+  events:
+    include: [order.validated, order.finalized]
+  entities:
+    - type: default
+      current_state: complete
+      gates:
+        validation_passed: true

--- a/tests/tier7-composition/test-multi-gate-pipeline/tests/visible-smoke.yaml
+++ b/tests/tier7-composition/test-multi-gate-pipeline/tests/visible-smoke.yaml
@@ -1,0 +1,20 @@
+name: test-multi-gate-pipeline visible smoke
+steps:
+  - publish: gate.g1_set
+    payload: {}
+  - publish: gate.g2_set
+    payload: {}
+  - publish: gate.g3_set
+    payload: {}
+  - publish: approval.requested
+    payload: {}
+expect:
+  events:
+    include: [gate.set, approval.granted]
+  entities:
+    - type: default
+      current_state: approved
+      gates:
+        g1: true
+        g2: true
+        g3: true

--- a/tests/tier7-composition/test-two-node-chain/tests/visible-smoke.yaml
+++ b/tests/tier7-composition/test-two-node-chain/tests/visible-smoke.yaml
@@ -1,0 +1,10 @@
+name: test-two-node-chain visible smoke
+steps:
+  - publish: task.started
+    payload: {}
+expect:
+  events:
+    include: [task.progressed, task.finished]
+  entities:
+    - type: default
+      current_state: complete

--- a/tests/tier7-composition/test-wildcard-cross-flow/tests/visible-smoke.yaml
+++ b/tests/tier7-composition/test-wildcard-cross-flow/tests/visible-smoke.yaml
@@ -1,0 +1,10 @@
+name: test-wildcard-cross-flow visible smoke
+steps:
+  - publish: flow-alpha/trigger.alpha
+    payload: {}
+expect:
+  events:
+    include: [job.alpha_done]
+  entities:
+    - type: default
+      current_state: done

--- a/tests/tier9-composition-patterns/test-compose-accumulate-compute-branch/tests/visible-smoke.yaml
+++ b/tests/tier9-composition-patterns/test-compose-accumulate-compute-branch/tests/visible-smoke.yaml
@@ -1,0 +1,13 @@
+name: test-compose-accumulate-compute-branch visible smoke
+steps:
+  - publish: score.submitted
+    payload:
+      value: 81
+expect:
+  events:
+    include: [result.high]
+  entities:
+    - type: core
+      current_state: high
+      fields:
+        score: 81

--- a/tests/tier9-composition-patterns/test-compose-clear-gates-reenter/tests/visible-smoke.yaml
+++ b/tests/tier9-composition-patterns/test-compose-clear-gates-reenter/tests/visible-smoke.yaml
@@ -1,0 +1,14 @@
+name: test-compose-clear-gates-reenter visible smoke
+steps:
+  - publish: review.done
+    payload: {}
+  - publish: review.insufficient
+    payload: {}
+expect:
+  events:
+    include: [review.approved]
+  entities:
+    - type: default
+      current_state: approved
+      gates:
+        g_reviewed: true

--- a/tests/tier9-composition-patterns/test-compose-gate-chain-three/tests/visible-smoke.yaml
+++ b/tests/tier9-composition-patterns/test-compose-gate-chain-three/tests/visible-smoke.yaml
@@ -1,0 +1,18 @@
+name: test-compose-gate-chain-three visible smoke
+steps:
+  - publish: step.a_done
+    payload: {}
+  - publish: step.b_done
+    payload: {}
+  - publish: step.c_done
+    payload: {}
+expect:
+  events:
+    include: [release.ready]
+  entities:
+    - type: default
+      current_state: released
+      gates:
+        g_a: true
+        g_b: true
+        g_c: true

--- a/tests/tier9-composition-patterns/test-compose-gate-data-advance-emit/tests/visible-smoke.yaml
+++ b/tests/tier9-composition-patterns/test-compose-gate-data-advance-emit/tests/visible-smoke.yaml
@@ -1,0 +1,20 @@
+name: test-compose-gate-data-advance-emit visible smoke
+steps:
+  - publish: stage.one_done
+    payload:
+      result: pass
+  - publish: stage.two_done
+    payload:
+      result: verified
+expect:
+  events:
+    include: [stage.two_start, stage.complete]
+  entities:
+    - type: core
+      current_state: complete
+      fields:
+        stage_one_result: pass
+        stage_two_result: verified
+      gates:
+        g_stage_one: true
+        g_stage_two: true

--- a/tests/tier9-composition-patterns/test-compose-guard-query-capacity/tests/visible-smoke.yaml
+++ b/tests/tier9-composition-patterns/test-compose-guard-query-capacity/tests/visible-smoke.yaml
@@ -1,0 +1,10 @@
+name: test-compose-guard-query-capacity visible smoke
+steps:
+  - publish: admission.requested
+    payload: {}
+expect:
+  events:
+    include: [admission.granted]
+  entities:
+    - type: core
+      current_state: admitted

--- a/tests/tier9-composition-patterns/test-compose-lifecycle-seven-states/tests/visible-smoke.yaml
+++ b/tests/tier9-composition-patterns/test-compose-lifecycle-seven-states/tests/visible-smoke.yaml
@@ -1,0 +1,20 @@
+name: test-compose-lifecycle-seven-states visible smoke
+steps:
+  - publish: phase.init
+    payload: {}
+  - publish: phase.activate
+    payload: {}
+  - publish: phase.start
+    payload: {}
+  - publish: phase.stabilize
+    payload: {}
+  - publish: phase.wind_down
+    payload: {}
+  - publish: phase.close
+    payload: {}
+expect:
+  events:
+    include: [lifecycle.complete]
+  entities:
+    - type: default
+      current_state: closed

--- a/tests/tier9-composition-patterns/test-compose-rules-fanout-data/tests/visible-smoke.yaml
+++ b/tests/tier9-composition-patterns/test-compose-rules-fanout-data/tests/visible-smoke.yaml
@@ -1,0 +1,17 @@
+name: test-compose-rules-fanout-data visible smoke
+steps:
+  - publish: batch.requested
+    payload:
+      mode: parallel
+      items:
+        - id: a
+        - id: b
+        - id: c
+expect:
+  events:
+    include: [batch.dispatched]
+  entities:
+    - type: core
+      current_state: dispatched
+      fields:
+        dispatch_count: 3

--- a/tests/tier9-composition-patterns/test-compose-rules-per-rule-data/tests/visible-smoke.yaml
+++ b/tests/tier9-composition-patterns/test-compose-rules-per-rule-data/tests/visible-smoke.yaml
@@ -1,0 +1,16 @@
+name: test-compose-rules-per-rule-data visible smoke
+steps:
+  - publish: conflict.submitted
+    payload:
+      strategy: keep_best
+      value_a: low
+      value_b: high
+expect:
+  events:
+    include: [conflict.resolved]
+  entities:
+    - type: core
+      current_state: resolved
+      fields:
+        resolved_value: high
+        resolution_method: best


### PR DESCRIPTION
Part of #1729.

## Summary

- Add 44 public deterministic `swarm test` visible-smoke companions for the remaining catalog rows that execute with already-merged public scenario owners.
- Extend the `cmd/swarm` public-RPC proof helper so multi-step publish scenarios are proven through every publish step, including chained `run_id` / `source_event_id` behavior.
- Preserve private cataloge2e/swarmflowtest coverage; this is companion coverage only, not full catalog smoke replacement.

## Governing Refs / Context

Exact governing spec sections:

- `platform-spec.yaml#test_specification.deterministic_scenario_runner`
- `platform-spec.yaml#test_specification.deterministic_scenario_runner.test_quiescence`
- `platform-spec.yaml#test_specification.deterministic_scenario_runner.expectations`
- `platform-spec.yaml#test_specification.deterministic_scenario_runner.catalog_convergence`
- `platform-spec.yaml#cli_specification.command_catalog.test`

Approved gate: #1729 pre-audit and independent gate review. During implementation, `tests/tier9-composition-patterns/test-compose-multi-emit-cross-flow` was split from this PR because the contract still uses the retired legacy multi-emit handler shape and cannot load through current public owners.

## Semantic Migration

No runtime/store/API/CLI semantic migration. The canonical public owners remain:

- `event.publish` for trigger injection
- `run.diagnose` for quiescence
- `run.trace` / `expect.events.include` for positive emitted-event presence
- `entity.list` + `entity.get` / `expect.entities` for public entity `current_state`, fields, and gates

Private catalog assertions remain non-authoritative for public `swarm test`: `handler_outcome`, no-output absence, exact event multiplicity, seeded setup, timer-clock control, runtime/store proof facts, flow/template creation, causal chains, positive dead-letter details, and faithful scripted backend behavior.

## Split / Residual

Split from this PR: `tests/tier9-composition-patterns/test-compose-multi-emit-cross-flow`, recorded on #1729, because it fails public bundle load with `unsupported emit yaml node kind 2` and cataloge2e already classifies that fixture as retired legacy multi-emit shape.

#1696 and #1252 remain open for the residual parent tail.

## Validation

With host Postgres:

- `SWARM_TEST_POSTGRES_DSN='host=127.0.0.1 port=5432 user=youmew dbname=postgres sslmode=disable' PGPASSWORD=postgres go test ./cmd/swarm -run TestSwarmTestRunsRemainingCurrentPublicOwnerCatalogCompanions -count=1`
- `SWARM_TEST_POSTGRES_DSN='host=127.0.0.1 port=5432 user=youmew dbname=postgres sslmode=disable' PGPASSWORD=postgres go test ./cmd/swarm -run 'TestSwarmTest|TestScenario|TestEntities' -count=1`
- `SWARM_TEST_POSTGRES_DSN='host=127.0.0.1 port=5432 user=youmew dbname=postgres sslmode=disable' PGPASSWORD=postgres go test ./internal/apispec -run TestPlatformSpecDeterministicScenarioRunnerSourceAuthority -count=1`
- `SWARM_TEST_POSTGRES_DSN='host=127.0.0.1 port=5432 user=youmew dbname=postgres sslmode=disable' PGPASSWORD=postgres go test ./internal/runtime/swarmflowtest -run 'TestCatalogRunner_ValidatesCurrentCatalogPackages|TestCatalogRunner_IdentifiesSimpleHarnessEligiblePackages' -count=1`
- `SWARM_TEST_POSTGRES_DSN='host=127.0.0.1 port=5432 user=youmew dbname=postgres sslmode=disable' PGPASSWORD=postgres go test ./internal/runtime/cataloge2e -run '^TestCatalogRequiredSmoke$' -count=1`
- `SWARM_TEST_POSTGRES_DSN='host=127.0.0.1 port=5432 user=youmew dbname=postgres sslmode=disable' PGPASSWORD=postgres go test ./...`
