### PR TITLE
[agent-b][issue #1640] Classify workspace env authority

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,6 +8,6 @@
 # `swarm secrets set` / `swarm secrets check` for credentials required by
 # contracts.
 #
-# Direct shell environment variables are still supported only where an owning
-# command or subsystem explicitly documents them. Export those values in your
-# shell or process manager when needed; do not rely on repo `.env` loading.
+# Direct shell environment variables are a narrow bootstrap/compatibility
+# surface. Use them only where an owning spec section explicitly names them,
+# and keep assignments out of repo `.env` files.

--- a/README.md
+++ b/README.md
@@ -233,8 +233,10 @@ swarm secrets set sendgrid_api_key --stdin
 swarm secrets check --contracts ./contracts
 ```
 
-Set `SWARM_ARTIFACT_ROOT` to a writable host path if your machine can't write
-the default `/var/lib/swarm/artifacts` (needed for `artifact_repo_commit`).
+If a flow uses `artifact_repo_commit`, the runtime artifact root must resolve to
+a writable runtime-private host path. The authoritative storage rules are in
+`platform-spec.yaml#runtime_storage.artifact_root`; do not put runtime storage
+settings in repo `.env` files.
 
 ```bash
 go build ./cmd/swarm

--- a/cmd/swarm/env_authority_test.go
+++ b/cmd/swarm/env_authority_test.go
@@ -7,6 +7,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"gopkg.in/yaml.v3"
 )
 
 func TestServeCommandIgnoresMalformedRepoDotEnv(t *testing.T) {
@@ -103,6 +105,9 @@ func TestPublicEnvTemplateIsNonAuthoritative(t *testing.T) {
 		"SWARM_STORE_BACKEND=",
 		"SWARM_WORKSPACE_DATA_SOURCE=",
 		"SWARM_WORKSPACE_BACKEND=",
+		"SWARM_ARTIFACT_ROOT=",
+		"SWARM_MONITOR_DIR=",
+		"SWARM_SQL_DEBUG=",
 	} {
 		if strings.Contains(envText, forbidden) {
 			t.Fatalf(".env.example still advertises authoritative assignment %q:\n%s", forbidden, envText)
@@ -128,6 +133,19 @@ func TestPublicEnvTemplateIsNonAuthoritative(t *testing.T) {
 			t.Fatalf("public docs still promote .env authority phrase %q", forbidden)
 		}
 	}
+	for _, forbidden := range []string{
+		"SWARM_ARTIFACT_ROOT",
+		"SWARM_MONITOR_DIR",
+		"SWARM_PROMPTS_DIR",
+		"SWARM_SQL_DEBUG",
+		"SWARM_BOOT_WARNINGS_FATAL",
+		"SWARM_EMIT_SCHEMA_STRICT",
+		"SWARM_CATALOG_E2E_DEBUG",
+	} {
+		if strings.Contains(publicDocs, forbidden) {
+			t.Fatalf("public docs still advertise #1640 env %q as normal setup", forbidden)
+		}
+	}
 	for _, want := range []string{"config.example.yaml", "swarm secrets"} {
 		if !strings.Contains(publicDocs, want) {
 			t.Fatalf("public docs missing replacement setup guidance %q", want)
@@ -144,6 +162,128 @@ func TestPublicEnvTemplateIsNonAuthoritative(t *testing.T) {
 	}
 	if !strings.Contains(runtimeConfigText, "default project data directory") {
 		t.Fatalf("runtime-config.example.yaml missing default data directory guidance:\n%s", runtimeConfigText)
+	}
+}
+
+func TestPlatformSpecIssue1640EnvClassificationCoversRetainedSlice(t *testing.T) {
+	var spec struct {
+		EnvironmentSourceAuthority struct {
+			WorkspaceMonitorArtifactDebugSlice struct {
+				PromotedBy           string `yaml:"promoted_by"`
+				ParentTracker        string `yaml:"parent_tracker"`
+				ImplementationStatus string `yaml:"implementation_status"`
+				CanonicalOwner       string `yaml:"canonical_owner"`
+				Scope                string `yaml:"scope"`
+				ClassificationRule   string `yaml:"classification_rule"`
+				Classifications      map[string]struct {
+					Disposition string   `yaml:"disposition"`
+					Owner       string   `yaml:"owner"`
+					EnvVars     []string `yaml:"env_vars"`
+					EnvPrefixes []string `yaml:"env_prefixes"`
+					Rule        string   `yaml:"rule"`
+				} `yaml:"classifications"`
+				PublicDocQuarantine struct {
+					Rule string `yaml:"rule"`
+				} `yaml:"public_doc_quarantine"`
+				SplitSiblings []string `yaml:"split_siblings"`
+			} `yaml:"workspace_monitor_artifact_debug_slice"`
+		} `yaml:"environment_source_authority"`
+	}
+	data, err := os.ReadFile(filepath.Join(repoRoot(), defaultPlatformSpecPath))
+	if err != nil {
+		t.Fatalf("read platform spec: %v", err)
+	}
+	if err := yaml.Unmarshal(data, &spec); err != nil {
+		t.Fatalf("parse platform spec: %v", err)
+	}
+
+	authority := spec.EnvironmentSourceAuthority.WorkspaceMonitorArtifactDebugSlice
+	if authority.PromotedBy != "#1640" || authority.ParentTracker != "#1600" || authority.ImplementationStatus != "classification_spec_lock_only" {
+		t.Fatalf("#1640 env authority status = promoted_by:%q parent:%q status:%q", authority.PromotedBy, authority.ParentTracker, authority.ImplementationStatus)
+	}
+	if !strings.Contains(authority.CanonicalOwner, "environment_source_authority.workspace_monitor_artifact_debug_slice") {
+		t.Fatalf("#1640 canonical owner = %q", authority.CanonicalOwner)
+	}
+	for _, want := range []string{"classification authority", "#1731", "does not implement unknown-env", "Public docs"} {
+		if !strings.Contains(authority.Scope+authority.ClassificationRule+authority.PublicDocQuarantine.Rule, want) {
+			t.Fatalf("#1640 env authority missing %q:\n%#v", want, authority)
+		}
+	}
+	if !joinedContains(authority.SplitSiblings, "#1731") || !joinedContains(authority.SplitSiblings, "unknown-env guard") {
+		t.Fatalf("#1640 split siblings do not preserve #1731 guard split: %#v", authority.SplitSiblings)
+	}
+
+	for name, wantDisposition := range map[string]string{
+		"existing_config_owned_workspace_sources":     "existing_config_owned_env_source",
+		"production_bootstrap_or_deployment_plumbing": "keep_env_first_slice_bootstrap_or_deployment_plumbing",
+		"internal_workspace_lifecycle_names":          "keep_env_first_slice_internal_runtime_plumbing",
+		"runtime_private_storage_and_observability":   "keep_env_first_slice_runtime_private_storage_or_observability",
+		"internal_prompt_and_spec_helpers":            "keep_env_first_slice_internal_developer_helper",
+		"debug_and_test_quarantine":                   "keep_env_first_slice_debug_or_test_quarantine",
+		"governed_outside_1640":                       "governed_by_existing_owner_or_split",
+	} {
+		got, ok := authority.Classifications[name]
+		if !ok {
+			t.Fatalf("#1640 env classification missing category %q: %#v", name, authority.Classifications)
+		}
+		if got.Disposition != wantDisposition {
+			t.Fatalf("#1640 classification %q disposition = %q, want %q", name, got.Disposition, wantDisposition)
+		}
+		if strings.TrimSpace(got.Owner) == "" || strings.TrimSpace(got.Rule) == "" {
+			t.Fatalf("#1640 classification %q missing owner/rule: %#v", name, got)
+		}
+	}
+
+	classified := make(map[string]string)
+	for category, entry := range authority.Classifications {
+		for _, envName := range entry.EnvVars {
+			classified[envName] = category
+		}
+	}
+	for _, want := range []string{
+		"SWARM_WORKSPACE_DATA_SOURCE",
+		"SWARM_WORKSPACE_BACKEND",
+		"SWARM_DOCKER_BIN",
+		"SWARM_WORKSPACE_IMAGE",
+		"SWARM_WORKSPACE_HOST_ROOT",
+		"SWARM_WORKSPACE_VOLUMES_FROM",
+		"SWARM_WORKSPACE_NETWORK",
+		"SWARM_WORKSPACE_DATA_MOUNT",
+		"SWARM_WORKSPACE_CONTRACTS_SOURCE",
+		"SWARM_WORKSPACE_CONTRACTS_MOUNT",
+		"SWARM_SCAFFOLD_CONTAINER",
+		"SWARM_SCAFFOLD_WORKDIR",
+		"SWARM_SCAFFOLD_VOLUME",
+		"SWARM_SYSTEM_CONTAINER",
+		"SWARM_SYSTEM_WORKDIR",
+		"SWARM_SYSTEM_ENTITIES_VOLUME",
+		"SWARM_SYSTEM_NGINX_VOLUME",
+		"SWARM_SYSTEM_SYSTEMD_VOLUME",
+		"SWARM_ENTITY_CONTAINER_PREFIX",
+		"SWARM_ENTITY_WORKDIR",
+		"SWARM_ARTIFACT_ROOT",
+		"SWARM_MONITOR_DIR",
+		"SWARM_PROMPTS_DIR",
+		"SWARM_AGENT_CONFIG_MAP_FILE",
+		"SWARM_VERIFICATION_GATES_FILE",
+		"SWARM_TOOLING_LOCK_FILE",
+		"SWARM_SQL_DEBUG",
+		"SWARM_BOOT_WARNINGS_FATAL",
+		"SWARM_EMIT_SCHEMA_STRICT",
+		"SWARM_CATALOG_E2E_DEBUG",
+		"SWARM_TEST_POSTGRES_DSN",
+		"SWARM_TEST_POSTGRES_TEMPLATE_CLEANUP",
+		"SWARM_TEST_POSTGRES_TEMPLATE_PARENT_PID",
+		"SWARM_TEST_POSTGRES_TEMPLATE_ADMIN_DSN",
+		"SWARM_TEST_POSTGRES_TEMPLATE_NAME",
+		"SWARM_LOG_LEVEL",
+	} {
+		if classified[want] == "" {
+			t.Fatalf("#1640 env %q missing classification; classified=%#v", want, classified)
+		}
+	}
+	if !stringSliceContains(authority.Classifications["debug_and_test_quarantine"].EnvPrefixes, "SWARM_TEST_") {
+		t.Fatalf("#1640 debug/test quarantine missing SWARM_TEST_ prefix: %#v", authority.Classifications["debug_and_test_quarantine"].EnvPrefixes)
 	}
 }
 

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -10402,6 +10402,130 @@ runtime_storage:
       validation MUST fail closed before git writes.
     - Product contracts and agents MUST NOT rely on the raw host path. The stable product surface remains the opaque
       `swarm-artifact://repos/<repo_id>` URL plus immutable commit ref.
+environment_source_authority:
+  workspace_monitor_artifact_debug_slice:
+    promoted_by: '#1640'
+    parent_tracker: '#1600'
+    implementation_status: classification_spec_lock_only
+    canonical_owner: platform-spec.yaml#environment_source_authority.workspace_monitor_artifact_debug_slice
+    scope: >
+      Merge-bearing classification authority for the retained #1640 first slice: workspace Docker/host environment sources,
+      local workspace image/bootstrap knobs, runtime-private artifact and monitor roots, prompt/spec helper path overrides,
+      and debug/test environment toggles. This owner records the current source-authority disposition and public-doc quarantine
+      for those envs. It does not implement unknown-env guarding, typed env delegation, doctor env reporting, generated-boundary
+      enforcement, or parent-wide accepted-set ownership; those are split to #1731.
+    classification_rule: >
+      Every env listed here is either governed by an existing typed owner, retained as first-slice production bootstrap /
+      deployment plumbing, retained as internal developer helper source, quarantined as debug/test-only, or explicitly governed
+      by another owner. Public docs and templates MUST NOT present these envs as normal setup. A future migration may move any
+      retained env into typed config or typed delegation only through a later gate; #1640 does not create env-over-config
+      precedence or dual semantic ownership.
+    classifications:
+      existing_config_owned_workspace_sources:
+        disposition: existing_config_owned_env_source
+        owner: workspace_model.data_source_authority and workspace_model.workspace_backend_selection
+        env_vars:
+        - SWARM_WORKSPACE_DATA_SOURCE
+        - SWARM_WORKSPACE_BACKEND
+        rule: >
+          These envs already have canonical owners and source order. #1640 classifies them for the retained workspace env
+          inventory only; any removal, typed delegation, or accepted-set guard behavior belongs to #1731 or a later child.
+      production_bootstrap_or_deployment_plumbing:
+        disposition: keep_env_first_slice_bootstrap_or_deployment_plumbing
+        owner: workspace_model.runtime_image_packaging, workspace_model.local_workspace_image_build_authority, workspace_model.data_source_authority, workspace_model.workspace_backend_selection, and workspace lifecycle config construction
+        env_vars:
+        - SWARM_DOCKER_BIN
+        - SWARM_WORKSPACE_IMAGE
+        - SWARM_WORKSPACE_HOST_ROOT
+        - SWARM_WORKSPACE_VOLUMES_FROM
+        - SWARM_WORKSPACE_NETWORK
+        - SWARM_WORKSPACE_DATA_MOUNT
+        - SWARM_WORKSPACE_CONTRACTS_SOURCE
+        - SWARM_WORKSPACE_CONTRACTS_MOUNT
+        rule: >
+          These envs remain live first-slice workspace/bootstrap inputs because current local Docker/host workspace lifecycle
+          consumers read them before a single typed workspace runtime config owner exists. `SWARM_DOCKER_BIN` is production
+          host-tool bootstrap/plumbing, not debug/test. `SWARM_WORKSPACE_IMAGE` is the current local workspace image selector
+          consumed by startup and `swarm workspace build`. Mount/network/volumes envs are deployment plumbing and MUST NOT be
+          advertised as ordinary project setup. Promotion to typed config or typed env delegation is split to #1731 or later
+          accepted migration children.
+      internal_workspace_lifecycle_names:
+        disposition: keep_env_first_slice_internal_runtime_plumbing
+        owner: internal/runtime/workspace Docker lifecycle configuration
+        env_vars:
+        - SWARM_SCAFFOLD_CONTAINER
+        - SWARM_SCAFFOLD_WORKDIR
+        - SWARM_SCAFFOLD_VOLUME
+        - SWARM_SYSTEM_CONTAINER
+        - SWARM_SYSTEM_WORKDIR
+        - SWARM_SYSTEM_ENTITIES_VOLUME
+        - SWARM_SYSTEM_NGINX_VOLUME
+        - SWARM_SYSTEM_SYSTEMD_VOLUME
+        - SWARM_ENTITY_CONTAINER_PREFIX
+        - SWARM_ENTITY_WORKDIR
+        rule: >
+          These are internal local Docker lifecycle naming/workdir knobs. They are not product contract fields, public setup
+          guidance, or proof that container identity is semantically configurable by agents. They remain implementation
+          plumbing until a later typed deployment-config owner promotes or removes them.
+      runtime_private_storage_and_observability:
+        disposition: keep_env_first_slice_runtime_private_storage_or_observability
+        owner: runtime_storage.artifact_root and runtime monitor sink
+        env_vars:
+        - SWARM_ARTIFACT_ROOT
+        - SWARM_MONITOR_DIR
+        rule: >
+          `SWARM_ARTIFACT_ROOT` remains the current spec-listed runtime-private artifact root override for local-git artifact
+          storage, but public docs MUST NOT teach repo `.env` or ambient shell exports as normal setup. `SWARM_MONITOR_DIR`
+          remains an observability/debug monitor log root until a later config/state-dir owner is promoted. Neither path may be
+          agent-visible workspace data.
+      internal_prompt_and_spec_helpers:
+        disposition: keep_env_first_slice_internal_developer_helper
+        owner: prompt/spec helper path resolvers
+        env_vars:
+        - SWARM_PROMPTS_DIR
+        - SWARM_AGENT_CONFIG_MAP_FILE
+        - SWARM_VERIFICATION_GATES_FILE
+        - SWARM_TOOLING_LOCK_FILE
+        rule: >
+          These envs are internal developer/helper path overrides for prompt and auxiliary spec files. Installed-binary runtime
+          behavior MUST NOT depend on old source-checkout helper paths becoming public configuration. Public docs/templates
+          MUST NOT advertise them as normal setup.
+      debug_and_test_quarantine:
+        disposition: keep_env_first_slice_debug_or_test_quarantine
+        owner: runtime debug/test harnesses
+        env_vars:
+        - SWARM_SQL_DEBUG
+        - SWARM_BOOT_WARNINGS_FATAL
+        - SWARM_EMIT_SCHEMA_STRICT
+        - SWARM_CATALOG_E2E_DEBUG
+        - SWARM_TEST_POSTGRES_DSN
+        - SWARM_TEST_POSTGRES_TEMPLATE_CLEANUP
+        - SWARM_TEST_POSTGRES_TEMPLATE_PARENT_PID
+        - SWARM_TEST_POSTGRES_TEMPLATE_ADMIN_DSN
+        - SWARM_TEST_POSTGRES_TEMPLATE_NAME
+        env_prefixes:
+        - SWARM_TEST_
+        rule: >
+          Debug and test envs are not production/user setup. They may remain for tests, CI, and narrow developer diagnostics in
+          this first slice, but public docs/templates MUST NOT advertise them. If any becomes production behavior, a later gate
+          must promote a typed flag/config owner instead of relying on ambient env.
+      governed_outside_1640:
+        disposition: governed_by_existing_owner_or_split
+        owner: cli_specification.foundations.cli_logging_policy and #1731
+        env_vars:
+        - SWARM_LOG_LEVEL
+        rule: >
+          `SWARM_LOG_LEVEL` is not a universal CLI env source and remains governed by
+          cli_specification.foundations.cli_logging_policy. Parent-wide accepted-set, typed env delegation, doctor env reporting,
+          generated-boundary env closure, and unknown-env guard behavior are split to #1731.
+    public_doc_quarantine:
+      rule: >
+        Public repository setup docs and `.env.example` MUST NOT include assignment examples or normal-setup instructions for
+        the envs classified by this owner. Internal test/debug documentation may mention a quarantined env only when the
+        surrounding text clearly scopes it to tests, CI, or developer diagnostics.
+    split_siblings:
+    - '#1731 repo-wide SWARM env accepted-set guard, typed delegation schema, doctor env reporting, generated-boundary env closure, and unknown-env guard'
+    - '#1600 parent residual env-source-authority closeout'
 workspace_model:
   description: Defines the filesystem contract for agent sessions. The platform provides three standard mount points and a
     scoping model. Products define workspace classes that map agent roles to specific scope configurations. If a product declares


### PR DESCRIPTION
## Summary

- Adds `platform-spec.yaml#environment_source_authority.workspace_monitor_artifact_debug_slice` as the merge-bearing #1640 classification owner.
- Classifies the retained workspace/monitor/artifact/prompt/debug env families as existing-owner, first-slice KEEP-ENV, internal helper, debug/test quarantine, or outside-owner/split.
- Records #1731 as the split owner for repo-wide accepted-set, typed delegation, doctor env reporting, generated-boundary closure, and unknown-env guard work.
- Removes public README guidance that advertised `SWARM_ARTIFACT_ROOT` as normal setup and tightens `.env.example` wording.
- Adds executable spec/docs proof for the retained #1640 env inventory and public-doc quarantine.

Closes #1640
Part of #1600
Related to #1731

## Governing Refs / Context

- #1640 pre-audit: https://github.com/division-sh/swarm/issues/1640#issuecomment-4884729199
- #1640 design refinement: https://github.com/division-sh/swarm/issues/1640#issuecomment-4888365816
- #1640 Gate B approval after split repair: https://github.com/division-sh/swarm/issues/1640#issuecomment-4888424882
- #1600 parent tracker update: https://github.com/division-sh/swarm/issues/1600#issuecomment-4888397798
- `platform-spec.yaml`: `spec_authority`, `runtime_storage.artifact_root`, `workspace_model.runtime_image_packaging`, `workspace_model.local_workspace_image_build_authority`, `workspace_model.data_source_authority`, `workspace_model.workspace_backend_selection`, `cli_specification.foundations.repo_dotenv_source_authority`, `cli_specification.foundations.cli_logging_policy`, `cli_specification.command_catalog.doctor`.

`docs/IMPLEMENTER_GUIDELINES.md` and `docs/SEMANTIC_DRIFT.md` are not present on current `origin/master`; this PR follows the recorded issue gate and authoritative `platform-spec.yaml` context.

## Semantic Migration

This PR is classification/spec/docs/test closure only under the approved first-slice boundary.

- New canonical owner: `platform-spec.yaml#environment_source_authority.workspace_monitor_artifact_debug_slice`.
- Old producer/reader/writer paths invalidated: none in this PR.
- Surviving old behavior: direct env readers for retained #1640 families still survive and are explicitly classified as first-slice existing-owner, bootstrap/deployment plumbing, internal helper, debug/test quarantine, or outside-owner/split.
- Migration complete: complete for #1640 classification/spec-lock; not complete for #1600 parent-wide ambient env removal. #1731 owns guard/delegation/accepted-set migration.

## Validation

- `go test ./cmd/swarm -run 'TestPublicEnvTemplateIsNonAuthoritative|TestPlatformSpecIssue1640EnvClassificationCoversRetainedSlice'`
- `go test ./cmd/swarm` with inline `SWARM_TEST_POSTGRES_DSN='host=127.0.0.1 port=5432 user=postgres password=postgres dbname=postgres sslmode=disable'`
- `go test ./...` with the same inline host Postgres DSN
- `rg -n "SWARM_(ARTIFACT_ROOT|MONITOR_DIR|PROMPTS_DIR|SQL_DEBUG|BOOT_WARNINGS_FATAL|EMIT_SCHEMA_STRICT|CATALOG_E2E_DEBUG)" README.md CONTRIBUTING.md .env.example config.example.yaml runtime-config.example.yaml` produced no matches.
