### PR TITLE
[agent-c][issue #1714] Promote schema refinements

### DIFF
--- a/internal/runtime/contracts/load_validation_test.go
+++ b/internal/runtime/contracts/load_validation_test.go
@@ -140,6 +140,66 @@ func TestValidateWorkflowContractBundleLoadConstraintsRejectsUnsupportedHandlerA
 	}
 }
 
+func TestValidateWorkflowContractBundleLoadConstraintsRejectsInvalidSchemaRefinements(t *testing.T) {
+	minLength := 1
+	bundle := &WorkflowContractBundle{
+		Events: map[string]EventCatalogEntry{
+			"deploy.requested": {
+				Payload: EventPayloadSpec{
+					Properties: map[string]EventFieldSpec{
+						"score": {
+							Type:        "integer",
+							Refinements: SchemaRefinements{Pattern: "^[0-9]+$"},
+						},
+						"component": {Type: "text"},
+						"owner": {
+							Type:        "text",
+							Refinements: SchemaRefinements{EqualTo: "missing"},
+						},
+					},
+				},
+			},
+		},
+		RootTypes: TypeCatalogDocument{
+			Types: map[string]NamedTypeDecl{
+				"Manifest": {
+					Fields: map[string]TypeFieldSpec{
+						"files": {
+							Type:        "integer",
+							Refinements: SchemaRefinements{Length: SchemaLengthRefinement{Min: &minLength}},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	err := validateWorkflowContractBundleLoadConstraints(bundle)
+	if err == nil {
+		t.Fatal("expected invalid schema refinements to fail")
+	}
+	for _, want := range []string{
+		"pattern refinement requires string/text type",
+		"equal_to references undeclared sibling field",
+		"length refinement requires string/text or list type",
+	} {
+		if !contractErrorContains(err, want) {
+			t.Fatalf("load validation error = %v, want %q", err, want)
+		}
+	}
+}
+
+func TestEventFieldSpecDecodeRejectsMalformedSchemaRefinement(t *testing.T) {
+	var field EventFieldSpec
+	err := yaml.Unmarshal([]byte(`
+type: text
+pattern: "["
+`), &field)
+	if err == nil || !strings.Contains(err.Error(), "pattern") {
+		t.Fatalf("EventFieldSpec decode error = %v, want pattern failure", err)
+	}
+}
+
 func TestLoadWorkflowContractBundle_PreservesEvidenceTarget(t *testing.T) {
 	bundle := loadCurrentWorkflowBundleForTest(t)
 	for _, node := range bundle.Nodes {

--- a/internal/runtime/contracts/load_validation_test.go
+++ b/internal/runtime/contracts/load_validation_test.go
@@ -172,6 +172,16 @@ func TestValidateWorkflowContractBundleLoadConstraintsRejectsInvalidSchemaRefine
 				},
 			},
 		},
+		RootEntities: EntityContractsDocument{
+			"deploy": {
+				Fields: map[string]EntityFieldDecl{
+					"created_at": {
+						Type:        "timestamp",
+						Refinements: SchemaRefinements{Pattern: "^2026-"},
+					},
+				},
+			},
+		},
 	}
 
 	err := validateWorkflowContractBundleLoadConstraints(bundle)
@@ -182,6 +192,7 @@ func TestValidateWorkflowContractBundleLoadConstraintsRejectsInvalidSchemaRefine
 		"pattern refinement requires string/text type",
 		"equal_to references undeclared sibling field",
 		"length refinement requires string/text or list type",
+		"root entities.deploy.created_at pattern refinement requires string/text type",
 	} {
 		if !contractErrorContains(err, want) {
 			t.Fatalf("load validation error = %v, want %q", err, want)

--- a/internal/runtime/contracts/schema_refinement_validation.go
+++ b/internal/runtime/contracts/schema_refinement_validation.go
@@ -207,8 +207,10 @@ func schemaRefinementKind(types TypeCatalogDocument, typeRef string) string {
 		normalized = typeName
 	}
 	switch strings.ToLower(strings.TrimSpace(normalized)) {
-	case "text", "string", "timestamp", "uuid":
+	case "text", "string", "uuid":
 		return "string"
+	case "timestamp":
+		return "timestamp"
 	case "integer":
 		return "integer"
 	case "numeric", "number", "float", "double", "real":

--- a/internal/runtime/contracts/schema_refinement_validation.go
+++ b/internal/runtime/contracts/schema_refinement_validation.go
@@ -1,0 +1,269 @@
+package contracts
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+func validateWorkflowSchemaRefinements(bundle *WorkflowContractBundle) []error {
+	if bundle == nil {
+		return nil
+	}
+	errs := []error{}
+	errs = append(errs, validateSchemaRefinementsInTypeCatalog("root types", bundle.RootTypeCatalog())...)
+	errs = append(errs, validateSchemaRefinementsInEntities("root entities", bundle.RootTypeCatalog(), bundle.RootEntities)...)
+	for _, flowID := range sortedFlowSchemaIDs(bundle.FlowSchemas) {
+		types := bundle.ResolvedTypeCatalogForFlow(flowID)
+		errs = append(errs, validateSchemaRefinementsInTypeCatalog("flow "+flowID+" types", types)...)
+		errs = append(errs, validateSchemaRefinementsInEntities("flow "+flowID+" entities", types, bundle.flowEntities[flowID])...)
+	}
+	scopedKeys := make([]string, 0, len(bundle.scopedEvents))
+	for scopedKey := range bundle.scopedEvents {
+		scopedKey = strings.TrimSpace(scopedKey)
+		if scopedKey != "" {
+			scopedKeys = append(scopedKeys, scopedKey)
+		}
+	}
+	sort.Strings(scopedKeys)
+	for _, scopedKey := range scopedKeys {
+		source := bundle.scopedEventSources[scopedKey]
+		types := bundle.RootTypeCatalog()
+		if strings.TrimSpace(source.FlowID) != "" {
+			types = bundle.ResolvedTypeCatalogForFlow(source.FlowID)
+		}
+		entry := bundle.scopedEvents[scopedKey]
+		fields := make(map[string]schemaRefinementField, len(entry.Payload.Properties))
+		for name, spec := range entry.Payload.Properties {
+			name = strings.TrimSpace(name)
+			if name == "" {
+				continue
+			}
+			fields[name] = schemaRefinementField{
+				Name:        name,
+				TypeRef:     spec.Type,
+				Refinements: spec.Refinements,
+			}
+		}
+		errs = append(errs, validateSchemaRefinementFields("event "+scopedKey+" payload", types, fields)...)
+	}
+	if len(bundle.scopedEvents) == 0 {
+		eventNames := make([]string, 0, len(bundle.Events))
+		for name := range bundle.Events {
+			name = strings.TrimSpace(name)
+			if name != "" {
+				eventNames = append(eventNames, name)
+			}
+		}
+		sort.Strings(eventNames)
+		for _, name := range eventNames {
+			entry := bundle.Events[name]
+			fields := make(map[string]schemaRefinementField, len(entry.Payload.Properties))
+			for fieldName, spec := range entry.Payload.Properties {
+				fieldName = strings.TrimSpace(fieldName)
+				if fieldName == "" {
+					continue
+				}
+				fields[fieldName] = schemaRefinementField{
+					Name:        fieldName,
+					TypeRef:     spec.Type,
+					Refinements: spec.Refinements,
+				}
+			}
+			errs = append(errs, validateSchemaRefinementFields("event "+name+" payload", bundle.RootTypeCatalog(), fields)...)
+		}
+	}
+	return errs
+}
+
+func validateSchemaRefinementsInTypeCatalog(context string, types TypeCatalogDocument) []error {
+	errs := []error{}
+	typeNames := make([]string, 0, len(types.Types))
+	for name := range types.Types {
+		name = strings.TrimSpace(name)
+		if name != "" {
+			typeNames = append(typeNames, name)
+		}
+	}
+	sort.Strings(typeNames)
+	for _, typeName := range typeNames {
+		named := types.Types[typeName]
+		fields := make(map[string]schemaRefinementField, len(named.Fields))
+		for fieldName, spec := range named.Fields {
+			fieldName = strings.TrimSpace(fieldName)
+			if fieldName == "" {
+				continue
+			}
+			fields[fieldName] = schemaRefinementField{
+				Name:        fieldName,
+				TypeRef:     spec.Type,
+				Refinements: spec.Refinements,
+			}
+		}
+		errs = append(errs, validateSchemaRefinementFields(context+"."+typeName, types, fields)...)
+	}
+	return errs
+}
+
+func validateSchemaRefinementsInEntities(context string, types TypeCatalogDocument, entities EntityContractsDocument) []error {
+	errs := []error{}
+	entityNames := sortedEntityContractKeys(entities)
+	for _, entityName := range entityNames {
+		entity := entities[entityName]
+		fields := make(map[string]schemaRefinementField, len(entity.Fields))
+		for fieldName, spec := range entity.Fields {
+			fieldName = strings.TrimSpace(fieldName)
+			if fieldName == "" {
+				continue
+			}
+			fields[fieldName] = schemaRefinementField{
+				Name:        fieldName,
+				TypeRef:     spec.Type,
+				Refinements: spec.Refinements,
+			}
+		}
+		errs = append(errs, validateSchemaRefinementFields(context+"."+entityName, types, fields)...)
+	}
+	return errs
+}
+
+type schemaRefinementField struct {
+	Name        string
+	TypeRef     string
+	Refinements SchemaRefinements
+}
+
+func validateSchemaRefinementFields(context string, types TypeCatalogDocument, fields map[string]schemaRefinementField) []error {
+	errs := []error{}
+	names := make([]string, 0, len(fields))
+	for name := range fields {
+		name = strings.TrimSpace(name)
+		if name != "" {
+			names = append(names, name)
+		}
+	}
+	sort.Strings(names)
+	for _, name := range names {
+		field := fields[name]
+		refs := field.Refinements
+		if refs.Empty() {
+			continue
+		}
+		fieldContext := context + "." + name
+		kind := schemaRefinementKind(types, field.TypeRef)
+		if kind == "unknown" {
+			errs = append(errs, fmt.Errorf("%s refinements require a supported schema type, got %q", fieldContext, strings.TrimSpace(field.TypeRef)))
+			continue
+		}
+		if strings.TrimSpace(refs.Pattern) != "" && kind != "string" {
+			errs = append(errs, fmt.Errorf("%s pattern refinement requires string/text type, got %q", fieldContext, strings.TrimSpace(field.TypeRef)))
+		}
+		if !refs.Length.Empty() && kind != "string" && kind != "array" {
+			errs = append(errs, fmt.Errorf("%s length refinement requires string/text or list type, got %q", fieldContext, strings.TrimSpace(field.TypeRef)))
+		}
+		if !refs.Range.Empty() && kind != "integer" && kind != "number" {
+			errs = append(errs, fmt.Errorf("%s range refinement requires integer/numeric type, got %q", fieldContext, strings.TrimSpace(field.TypeRef)))
+		}
+		if target := strings.TrimSpace(refs.EqualTo); target != "" {
+			if target == name {
+				errs = append(errs, fmt.Errorf("%s equal_to must reference a different sibling field", fieldContext))
+				continue
+			}
+			targetField, ok := fields[target]
+			if !ok {
+				errs = append(errs, fmt.Errorf("%s equal_to references undeclared sibling field %q", fieldContext, target))
+				continue
+			}
+			left := schemaRefinementComparableType(types, field.TypeRef)
+			right := schemaRefinementComparableType(types, targetField.TypeRef)
+			if left == "" || right == "" || left != right {
+				errs = append(errs, fmt.Errorf("%s equal_to target %q must have the same declared type", fieldContext, target))
+			}
+		}
+	}
+	return errs
+}
+
+func schemaRefinementKind(types TypeCatalogDocument, typeRef string) string {
+	typeRef = strings.TrimSpace(typeRef)
+	if typeRef == "" {
+		return "unknown"
+	}
+	if isEventListType(typeRef) {
+		return "array"
+	}
+	if _, _, ok := parseWave1MapTypeRef(typeRef); ok {
+		return "object"
+	}
+	typeName := eventTypeName(types, typeRef)
+	if _, ok := types.Enums[typeName]; ok {
+		return "string"
+	}
+	if _, ok := types.Types[typeName]; ok {
+		return "object"
+	}
+	normalized, _ := normalizeEventFieldType(typeName)
+	if normalized == "" {
+		normalized = typeName
+	}
+	switch strings.ToLower(strings.TrimSpace(normalized)) {
+	case "text", "string", "timestamp", "uuid":
+		return "string"
+	case "integer":
+		return "integer"
+	case "numeric", "number", "float", "double", "real":
+		return "number"
+	case "array":
+		return "array"
+	case "object", "json", "jsonb":
+		return "object"
+	case "boolean":
+		return "boolean"
+	default:
+		return "unknown"
+	}
+}
+
+func schemaRefinementComparableType(types TypeCatalogDocument, typeRef string) string {
+	typeRef = strings.TrimSpace(typeRef)
+	if typeRef == "" {
+		return ""
+	}
+	if isEventListType(typeRef) {
+		return "list:" + schemaRefinementComparableType(types, eventListItemType(typeRef))
+	}
+	if keyType, valueType, ok := parseWave1MapTypeRef(typeRef); ok {
+		return "map:" + schemaRefinementComparableType(types, keyType) + ":" + schemaRefinementComparableType(types, valueType)
+	}
+	typeName := eventTypeName(types, typeRef)
+	if _, ok := types.Enums[typeName]; ok {
+		return "enum:" + typeName
+	}
+	if _, ok := types.Types[typeName]; ok {
+		return "type:" + typeName
+	}
+	normalized, _ := normalizeEventFieldType(typeName)
+	if normalized == "" {
+		normalized = typeName
+	}
+	switch strings.ToLower(strings.TrimSpace(normalized)) {
+	case "text", "string":
+		return "string"
+	case "integer":
+		return "integer"
+	case "numeric", "number", "float", "double", "real":
+		return "number"
+	case "boolean":
+		return "boolean"
+	case "timestamp":
+		return "timestamp"
+	case "uuid":
+		return "uuid"
+	case "array":
+		return "array"
+	case "object", "json", "jsonb":
+		return "object"
+	default:
+		return ""
+	}
+}

--- a/internal/runtime/contracts/schema_refinements.go
+++ b/internal/runtime/contracts/schema_refinements.go
@@ -1,0 +1,37 @@
+package contracts
+
+func (r SchemaRefinements) Empty() bool {
+	return r.Pattern == "" && r.EqualTo == "" && r.Length.Empty() && r.Range.Empty()
+}
+
+func (r SchemaRefinements) Clone() SchemaRefinements {
+	out := SchemaRefinements{
+		Pattern: r.Pattern,
+		EqualTo: r.EqualTo,
+	}
+	if r.Length.Min != nil {
+		value := *r.Length.Min
+		out.Length.Min = &value
+	}
+	if r.Length.Max != nil {
+		value := *r.Length.Max
+		out.Length.Max = &value
+	}
+	if r.Range.Min != nil {
+		value := *r.Range.Min
+		out.Range.Min = &value
+	}
+	if r.Range.Max != nil {
+		value := *r.Range.Max
+		out.Range.Max = &value
+	}
+	return out
+}
+
+func (r SchemaLengthRefinement) Empty() bool {
+	return r.Min == nil && r.Max == nil
+}
+
+func (r SchemaRangeRefinement) Empty() bool {
+	return r.Min == nil && r.Max == nil
+}

--- a/internal/runtime/contracts/schema_registry.go
+++ b/internal/runtime/contracts/schema_registry.go
@@ -49,6 +49,7 @@ func eventSchemaFromCatalogEntry(eventType string, entry EventCatalogEntry, type
 		if description != "" {
 			prop["description"] = description
 		}
+		applySchemaRefinements(prop, field.Refinements)
 		properties[fieldName] = prop
 	}
 	schema := map[string]any{
@@ -527,7 +528,9 @@ func eventSchemaForResolvedType(typeRef string, types TypeCatalogDocument, seen 
 				continue
 			}
 			spec := named.Fields[fieldName]
-			props[fieldName] = eventSchemaForTypeRefSchema(spec.Type, types, seen)
+			prop := eventSchemaForTypeRefSchema(spec.Type, types, seen)
+			applySchemaRefinements(prop, spec.Refinements)
+			props[fieldName] = prop
 			required = append(required, fieldName)
 		}
 		return map[string]any{
@@ -570,6 +573,49 @@ func eventTypeName(types TypeCatalogDocument, typeRef string) string {
 func eventSchemaForTypeRefSchema(raw string, types TypeCatalogDocument, seen map[string]struct{}) map[string]any {
 	schema, _ := eventSchemaForTypeRef(raw, types, seen)
 	return schema
+}
+
+func applySchemaRefinements(schema map[string]any, refinements SchemaRefinements) {
+	if schema == nil || refinements.Empty() {
+		return
+	}
+	if value := strings.TrimSpace(refinements.Pattern); value != "" {
+		schema["pattern"] = value
+	}
+	if min := refinements.Length.Min; min != nil {
+		switch strings.TrimSpace(asSchemaString(schema["type"])) {
+		case "array":
+			schema["minItems"] = *min
+		default:
+			schema["minLength"] = *min
+		}
+	}
+	if max := refinements.Length.Max; max != nil {
+		switch strings.TrimSpace(asSchemaString(schema["type"])) {
+		case "array":
+			schema["maxItems"] = *max
+		default:
+			schema["maxLength"] = *max
+		}
+	}
+	if min := refinements.Range.Min; min != nil {
+		schema["minimum"] = *min
+	}
+	if max := refinements.Range.Max; max != nil {
+		schema["maximum"] = *max
+	}
+	if value := strings.TrimSpace(refinements.EqualTo); value != "" {
+		schema["x-swarm-equalTo"] = value
+	}
+}
+
+func asSchemaString(value any) string {
+	switch typed := value.(type) {
+	case string:
+		return typed
+	default:
+		return strings.TrimSpace(fmt.Sprint(value))
+	}
 }
 
 func eventNamedTypeName(types TypeCatalogDocument, typeRef string) (string, bool) {

--- a/internal/runtime/contracts/schema_registry_test.go
+++ b/internal/runtime/contracts/schema_registry_test.go
@@ -49,6 +49,60 @@ func TestEventSchemaRegistryFromCatalog_NormalizesAnnotatedFieldTypes(t *testing
 	}
 }
 
+func TestEventSchemaRegistryFromCatalog_ProjectsSchemaRefinements(t *testing.T) {
+	minLength := 40
+	maxLength := 40
+	minScore := 0.0
+	maxScore := 1.0
+	minFiles := 1
+	schema := eventSchemaFromCatalogEntry("deploy.requested", EventCatalogEntry{
+		Payload: EventPayloadSpec{
+			Properties: map[string]EventFieldSpec{
+				"source_ref": {
+					Type: "text",
+					Refinements: SchemaRefinements{
+						Pattern: "^[0-9a-f]{40}$",
+						Length:  SchemaLengthRefinement{Min: &minLength, Max: &maxLength},
+					},
+				},
+				"source_repo_url": {Type: "text"},
+				"score": {
+					Type:        "numeric",
+					Refinements: SchemaRefinements{Range: SchemaRangeRefinement{Min: &minScore, Max: &maxScore}},
+				},
+				"file_manifest": {
+					Type:        "[text]",
+					Refinements: SchemaRefinements{Length: SchemaLengthRefinement{Min: &minFiles}},
+				},
+				"component": {Type: "text"},
+				"owner": {
+					Type:        "text",
+					Refinements: SchemaRefinements{EqualTo: "component"},
+				},
+			},
+			Required: []string{"source_ref", "source_repo_url", "file_manifest", "score", "component", "owner"},
+		},
+	}, TypeCatalogDocument{})
+
+	props, _ := schema.Schema["properties"].(map[string]any)
+	sourceRef, _ := props["source_ref"].(map[string]any)
+	if sourceRef["pattern"] != "^[0-9a-f]{40}$" || sourceRef["minLength"] != 40 || sourceRef["maxLength"] != 40 {
+		t.Fatalf("source_ref refinements = %#v", sourceRef)
+	}
+	score, _ := props["score"].(map[string]any)
+	if score["minimum"] != 0.0 || score["maximum"] != 1.0 {
+		t.Fatalf("score refinements = %#v", score)
+	}
+	fileManifest, _ := props["file_manifest"].(map[string]any)
+	if fileManifest["minItems"] != 1 {
+		t.Fatalf("file_manifest refinements = %#v", fileManifest)
+	}
+	owner, _ := props["owner"].(map[string]any)
+	if owner["x-swarm-equalTo"] != "component" {
+		t.Fatalf("owner refinements = %#v", owner)
+	}
+}
+
 func TestPlatformEventCatalogImplicitRequiredSkipsNullableFields(t *testing.T) {
 	var node yaml.Node
 	if err := yaml.Unmarshal([]byte(`

--- a/internal/runtime/contracts/workflow_contract_loading.go
+++ b/internal/runtime/contracts/workflow_contract_loading.go
@@ -179,6 +179,7 @@ func validateWorkflowContractBundleLoadConstraints(bundle *WorkflowContractBundl
 			errs = append(errs, fmt.Errorf("%w: event %s has multiple authoritative system node owners: %s", ErrMultipleAuthoritativeOwners, strings.TrimSpace(eventType), strings.Join(normalizeStrings(owners), ", ")))
 		}
 	}
+	errs = append(errs, validateWorkflowSchemaRefinements(bundle)...)
 	if len(errs) > 0 {
 		sort.Slice(errs, func(i, j int) bool {
 			return strings.TrimSpace(errs[i].Error()) < strings.TrimSpace(errs[j].Error())

--- a/internal/runtime/contracts/workflow_contract_types.go
+++ b/internal/runtime/contracts/workflow_contract_types.go
@@ -681,8 +681,23 @@ type EventPayloadSpec struct {
 	Required   []string                  `yaml:"required"`
 }
 type EventFieldSpec struct {
-	Type        string `yaml:"type"`
-	Description string `yaml:"description"`
+	Type        string            `yaml:"type"`
+	Description string            `yaml:"description"`
+	Refinements SchemaRefinements `yaml:"-"`
+}
+type SchemaLengthRefinement struct {
+	Min *int `yaml:"min"`
+	Max *int `yaml:"max"`
+}
+type SchemaRangeRefinement struct {
+	Min *float64 `yaml:"min"`
+	Max *float64 `yaml:"max"`
+}
+type SchemaRefinements struct {
+	Pattern string                 `yaml:"pattern"`
+	Length  SchemaLengthRefinement `yaml:"length"`
+	Range   SchemaRangeRefinement  `yaml:"range"`
+	EqualTo string                 `yaml:"equal_to"`
 }
 type SchemaLiteral struct {
 	Node yaml.Node
@@ -793,8 +808,9 @@ type NamedTypeDecl struct {
 }
 
 type TypeFieldSpec struct {
-	Type        string `yaml:"type"`
-	Description string `yaml:"description"`
+	Type        string            `yaml:"type"`
+	Description string            `yaml:"description"`
+	Refinements SchemaRefinements `yaml:"-"`
 }
 
 type EntityContractsDocument map[string]EntityContract
@@ -806,15 +822,16 @@ type EntityContract struct {
 }
 
 type EntityFieldDecl struct {
-	Type               string         `yaml:"type"`
-	Initial            any            `yaml:"initial"`
-	Indexed            bool           `yaml:"indexed"`
-	Immutable          bool           `yaml:"immutable"`
-	Description        string         `yaml:"description"`
-	MaterializeFrom    string         `yaml:"materialize_from"`
-	Project            map[string]any `yaml:"project"`
-	UnusedReason       string         `yaml:"_unused_reason"`
-	UnusedReaderReason string         `yaml:"_unused_reader_reason"`
+	Type               string            `yaml:"type"`
+	Initial            any               `yaml:"initial"`
+	Indexed            bool              `yaml:"indexed"`
+	Immutable          bool              `yaml:"immutable"`
+	Description        string            `yaml:"description"`
+	Refinements        SchemaRefinements `yaml:"-"`
+	MaterializeFrom    string            `yaml:"materialize_from"`
+	Project            map[string]any    `yaml:"project"`
+	UnusedReason       string            `yaml:"_unused_reason"`
+	UnusedReaderReason string            `yaml:"_unused_reader_reason"`
 }
 type ProjectPackageRef struct {
 	ID      string          `yaml:"id"`

--- a/internal/runtime/contracts/workflow_contract_yaml_schema.go
+++ b/internal/runtime/contracts/workflow_contract_yaml_schema.go
@@ -138,6 +138,7 @@ func (s *EventFieldSpec) UnmarshalYAML(node *yaml.Node) error {
 	*s = EventFieldSpec{
 		Type:        parsed.Type,
 		Description: parsed.Description,
+		Refinements: parsed.Refinements,
 	}
 	return nil
 }

--- a/internal/runtime/contracts/workflow_contract_yaml_wave1.go
+++ b/internal/runtime/contracts/workflow_contract_yaml_wave1.go
@@ -2,6 +2,7 @@ package contracts
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 
 	"gopkg.in/yaml.v3"
@@ -692,6 +693,7 @@ func (f *TypeFieldSpec) UnmarshalYAML(node *yaml.Node) error {
 	}
 	f.Type = parsed.Type
 	f.Description = parsed.Description
+	f.Refinements = parsed.Refinements
 	return nil
 }
 
@@ -796,6 +798,7 @@ func (f *EntityFieldDecl) UnmarshalYAML(node *yaml.Node) error {
 	f.Indexed = parsed.Indexed
 	f.Immutable = parsed.Immutable
 	f.Description = parsed.Description
+	f.Refinements = parsed.Refinements
 	f.MaterializeFrom = parsed.MaterializeFrom
 	f.Project = parsed.Project
 	f.UnusedReason = parsed.UnusedReason
@@ -838,6 +841,10 @@ func decodeWave1FieldNode(node *yaml.Node, opts wave1FieldNodeOptions) (wave1Par
 	allowed := map[string]struct{}{
 		"type":        {},
 		"description": {},
+		"pattern":     {},
+		"length":      {},
+		"range":       {},
+		"equal_to":    {},
 	}
 	if opts.AllowInitial {
 		allowed["initial"] = struct{}{}
@@ -899,6 +906,34 @@ func decodeWave1FieldNode(node *yaml.Node, opts wave1FieldNodeOptions) (wave1Par
 				return wave1ParsedFieldNode{}, err
 			}
 			field.Description = text
+		case "pattern":
+			pattern, err := decodeSchemaRefinementPattern(value)
+			if err != nil {
+				return wave1ParsedFieldNode{}, fmt.Errorf("%s pattern: %w", opts.Context, err)
+			}
+			field.Refinements.Pattern = pattern
+		case "length":
+			length, err := decodeSchemaLengthRefinement(value)
+			if err != nil {
+				return wave1ParsedFieldNode{}, fmt.Errorf("%s length: %w", opts.Context, err)
+			}
+			field.Refinements.Length = length
+		case "range":
+			bounds, err := decodeSchemaRangeRefinement(value)
+			if err != nil {
+				return wave1ParsedFieldNode{}, fmt.Errorf("%s range: %w", opts.Context, err)
+			}
+			field.Refinements.Range = bounds
+		case "equal_to":
+			target, err := decodeScalarStringNode(value)
+			if err != nil {
+				return wave1ParsedFieldNode{}, err
+			}
+			target = strings.TrimSpace(target)
+			if target == "" {
+				return wave1ParsedFieldNode{}, fmt.Errorf("%s equal_to field is required", opts.Context)
+			}
+			field.Refinements.EqualTo = target
 		case "initial":
 			var initial any
 			if err := value.Decode(&initial); err != nil {
@@ -962,6 +997,115 @@ func decodeWave1FieldNode(node *yaml.Node, opts wave1FieldNodeOptions) (wave1Par
 		return wave1ParsedFieldNode{}, fmt.Errorf("%s _unused_reader_reason must be at least 10 characters", opts.Context)
 	}
 	return field, nil
+}
+
+func decodeSchemaRefinementPattern(node *yaml.Node) (string, error) {
+	pattern, err := decodeScalarStringNode(node)
+	if err != nil {
+		return "", err
+	}
+	pattern = strings.TrimSpace(pattern)
+	if pattern == "" {
+		return "", fmt.Errorf("must not be empty")
+	}
+	if _, err := regexp.Compile(pattern); err != nil {
+		return "", fmt.Errorf("must compile as a regular expression: %w", err)
+	}
+	return pattern, nil
+}
+
+func decodeSchemaLengthRefinement(node *yaml.Node) (SchemaLengthRefinement, error) {
+	if node == nil || node.Kind != yaml.MappingNode {
+		return SchemaLengthRefinement{}, fmt.Errorf("must be a mapping with min and/or max")
+	}
+	var out SchemaLengthRefinement
+	for i := 0; i+1 < len(node.Content); i += 2 {
+		key := strings.TrimSpace(node.Content[i].Value)
+		value := node.Content[i+1]
+		switch key {
+		case "":
+			continue
+		case "min":
+			min, err := decodeIntNode(value)
+			if err != nil {
+				return SchemaLengthRefinement{}, fmt.Errorf("min: %w", err)
+			}
+			out.Min = &min
+		case "max":
+			max, err := decodeIntNode(value)
+			if err != nil {
+				return SchemaLengthRefinement{}, fmt.Errorf("max: %w", err)
+			}
+			out.Max = &max
+		default:
+			return SchemaLengthRefinement{}, fmt.Errorf("UNDEFINED-FIELD: length field %q not in platform spec", key)
+		}
+	}
+	if out.Min == nil && out.Max == nil {
+		return SchemaLengthRefinement{}, fmt.Errorf("must declare min and/or max")
+	}
+	if out.Min != nil && *out.Min < 0 {
+		return SchemaLengthRefinement{}, fmt.Errorf("min must be >= 0")
+	}
+	if out.Max != nil && *out.Max < 0 {
+		return SchemaLengthRefinement{}, fmt.Errorf("max must be >= 0")
+	}
+	if out.Min != nil && out.Max != nil && *out.Min > *out.Max {
+		return SchemaLengthRefinement{}, fmt.Errorf("min must be <= max")
+	}
+	return out, nil
+}
+
+func decodeSchemaRangeRefinement(node *yaml.Node) (SchemaRangeRefinement, error) {
+	if node == nil || node.Kind != yaml.MappingNode {
+		return SchemaRangeRefinement{}, fmt.Errorf("must be a mapping with min and/or max")
+	}
+	var out SchemaRangeRefinement
+	for i := 0; i+1 < len(node.Content); i += 2 {
+		key := strings.TrimSpace(node.Content[i].Value)
+		value := node.Content[i+1]
+		switch key {
+		case "":
+			continue
+		case "min":
+			min, err := decodeFloatNode(value)
+			if err != nil {
+				return SchemaRangeRefinement{}, fmt.Errorf("min: %w", err)
+			}
+			out.Min = &min
+		case "max":
+			max, err := decodeFloatNode(value)
+			if err != nil {
+				return SchemaRangeRefinement{}, fmt.Errorf("max: %w", err)
+			}
+			out.Max = &max
+		default:
+			return SchemaRangeRefinement{}, fmt.Errorf("UNDEFINED-FIELD: range field %q not in platform spec", key)
+		}
+	}
+	if out.Min == nil && out.Max == nil {
+		return SchemaRangeRefinement{}, fmt.Errorf("must declare min and/or max")
+	}
+	if out.Min != nil && out.Max != nil && *out.Min > *out.Max {
+		return SchemaRangeRefinement{}, fmt.Errorf("min must be <= max")
+	}
+	return out, nil
+}
+
+func decodeIntNode(node *yaml.Node) (int, error) {
+	var value int
+	if err := node.Decode(&value); err != nil {
+		return 0, err
+	}
+	return value, nil
+}
+
+func decodeFloatNode(node *yaml.Node) (float64, error) {
+	var value float64
+	if err := node.Decode(&value); err != nil {
+		return 0, err
+	}
+	return value, nil
 }
 
 func decodeProjectionMapNode(node *yaml.Node) (map[string]any, error) {
@@ -1101,6 +1245,7 @@ type wave1ParsedFieldNode struct {
 	Indexed            bool
 	Immutable          bool
 	Description        string
+	Refinements        SchemaRefinements
 	MaterializeFrom    string
 	Project            map[string]any
 	UnusedReason       string

--- a/internal/runtime/entityruntime/contracts.go
+++ b/internal/runtime/entityruntime/contracts.go
@@ -331,7 +331,7 @@ func Materialize(contract Contract, provided map[string]any) (map[string]any, er
 			}
 		} else {
 			var err error
-			value, err = NormalizeFieldValue(contract, name, value)
+			value, err = normalizeFieldValue(contract, name, value, true)
 			if err != nil {
 				return nil, err
 			}
@@ -379,9 +379,18 @@ func MaterializeMetadataForFlow(source semanticview.Source, flowID string, metad
 }
 
 func NormalizeFieldValue(contract Contract, fieldName string, value any) (any, error) {
+	return normalizeFieldValue(contract, fieldName, value, false)
+}
+
+func normalizeFieldValue(contract Contract, fieldName string, value any, allowEqualityParticipant bool) (any, error) {
 	field, err := ResolveFieldPath(contract, fieldName)
 	if err != nil {
 		return nil, err
+	}
+	if !allowEqualityParticipant {
+		if fieldPathParticipatesInEquality(contract, strings.TrimSpace(field.Path)) {
+			return nil, fieldTypeError(strings.TrimSpace(field.Path), "cannot be written in isolation because it participates in equal_to")
+		}
 	}
 	normalized, err := normalizeValueForType(contract, strings.TrimSpace(field.Path), strings.TrimSpace(field.Type), value)
 	if err != nil {
@@ -542,11 +551,19 @@ func defaultValue(contract Contract, typeRef string, explicit any) (any, error) 
 		named := contract.Types.Types[typeName(contract, typeRef)]
 		out := make(map[string]any, len(named.Fields))
 		for name, spec := range named.Fields {
+			name = strings.TrimSpace(name)
 			value, err := defaultValue(contract, spec.Type, nil)
 			if err != nil {
 				return nil, err
 			}
-			out[strings.TrimSpace(name)] = value
+			value, err = validateValueRefinements(contract, name, spec.Type, spec.Refinements, value)
+			if err != nil {
+				return nil, err
+			}
+			out[name] = value
+		}
+		if err := validateTypeFieldEqualities(typeName(contract, typeRef), named.Fields, out); err != nil {
+			return nil, err
 		}
 		return out, nil
 	default:
@@ -830,6 +847,79 @@ func validateEqualityValue(context, name, target string, values map[string]any) 
 		return fieldTypeError(joinFieldName(context, name), "must equal "+joinFieldName(context, target))
 	}
 	return nil
+}
+
+func fieldPathParticipatesInEquality(contract Contract, path string) bool {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return false
+	}
+	segments := strings.Split(path, ".")
+	if len(segments) == 0 {
+		return false
+	}
+	if len(segments) == 1 {
+		return entityFieldParticipatesInEquality(contract.Entity.Fields, strings.TrimSpace(segments[0]))
+	}
+	currentType := ""
+	root := strings.TrimSpace(segments[0])
+	if decl, ok := contract.Entity.Fields[root]; ok {
+		currentType = strings.TrimSpace(decl.Type)
+	} else {
+		return false
+	}
+	for _, segment := range segments[1 : len(segments)-1] {
+		named, ok := contract.Types.Types[typeName(contract, currentType)]
+		if !ok {
+			return false
+		}
+		spec, ok := named.Fields[strings.TrimSpace(segment)]
+		if !ok {
+			return false
+		}
+		currentType = strings.TrimSpace(spec.Type)
+	}
+	named, ok := contract.Types.Types[typeName(contract, currentType)]
+	if !ok {
+		return false
+	}
+	return typeFieldParticipatesInEquality(named.Fields, strings.TrimSpace(segments[len(segments)-1]))
+}
+
+func entityFieldParticipatesInEquality(fields map[string]runtimecontracts.EntityFieldDecl, name string) bool {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return false
+	}
+	for fieldName, field := range fields {
+		fieldName = strings.TrimSpace(fieldName)
+		target := strings.TrimSpace(field.Refinements.EqualTo)
+		if fieldName == name && target != "" {
+			return true
+		}
+		if target == name {
+			return true
+		}
+	}
+	return false
+}
+
+func typeFieldParticipatesInEquality(fields map[string]runtimecontracts.TypeFieldSpec, name string) bool {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return false
+	}
+	for fieldName, field := range fields {
+		fieldName = strings.TrimSpace(fieldName)
+		target := strings.TrimSpace(field.Refinements.EqualTo)
+		if fieldName == name && target != "" {
+			return true
+		}
+		if target == name {
+			return true
+		}
+	}
+	return false
 }
 
 func leafKind(contract Contract, typeRef string) (string, error) {

--- a/internal/runtime/entityruntime/contracts.go
+++ b/internal/runtime/entityruntime/contracts.go
@@ -3,9 +3,11 @@ package entityruntime
 import (
 	"fmt"
 	"reflect"
+	"regexp"
 	"sort"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
 	"github.com/division-sh/swarm/internal/runtime/core/paths"
@@ -22,10 +24,11 @@ type Contract struct {
 }
 
 type Field struct {
-	Path      string
-	Type      string
-	LeafKind  string
-	FieldDecl runtimecontracts.EntityFieldDecl
+	Path        string
+	Type        string
+	LeafKind    string
+	FieldDecl   runtimecontracts.EntityFieldDecl
+	Refinements runtimecontracts.SchemaRefinements
 }
 
 type WriteTarget struct {
@@ -322,6 +325,10 @@ func Materialize(contract Contract, provided map[string]any) (map[string]any, er
 			if err != nil {
 				return nil, fmt.Errorf("materialize %s: %w", name, err)
 			}
+			value, err = validateValueRefinements(contract, name, decl.Type, decl.Refinements, value)
+			if err != nil {
+				return nil, err
+			}
 		} else {
 			var err error
 			value, err = NormalizeFieldValue(contract, name, value)
@@ -339,6 +346,9 @@ func Materialize(contract Contract, provided map[string]any) (map[string]any, er
 		if _, ok := contract.Entity.Fields[name]; !ok {
 			return nil, fmt.Errorf("undeclared field %s", name)
 		}
+	}
+	if err := validateEntityFieldEqualities("entity", contract.Entity.Fields, out); err != nil {
+		return nil, err
 	}
 	return out, nil
 }
@@ -373,7 +383,11 @@ func NormalizeFieldValue(contract Contract, fieldName string, value any) (any, e
 	if err != nil {
 		return nil, err
 	}
-	return normalizeValueForType(contract, strings.TrimSpace(field.Path), strings.TrimSpace(field.Type), value)
+	normalized, err := normalizeValueForType(contract, strings.TrimSpace(field.Path), strings.TrimSpace(field.Type), value)
+	if err != nil {
+		return nil, err
+	}
+	return validateValueRefinements(contract, strings.TrimSpace(field.Path), strings.TrimSpace(field.Type), field.Refinements, normalized)
 }
 
 func EntityWritePath(target string) (string, bool, error) {
@@ -443,6 +457,7 @@ func ResolveFieldPath(contract Contract, path string) (Field, error) {
 		return Field{}, err
 	}
 	currentType := strings.TrimSpace(decl.Type)
+	currentRefinements := decl.Refinements
 	for _, segment := range segments[1:] {
 		segment = strings.TrimSpace(segment)
 		if segment == "" {
@@ -457,9 +472,10 @@ func ResolveFieldPath(contract Contract, path string) (Field, error) {
 			return Field{}, fmt.Errorf("undeclared path %s", path)
 		}
 		currentType = strings.TrimSpace(spec.Type)
+		currentRefinements = spec.Refinements
 	}
 	kind := pathKind(contract, currentType)
-	return Field{Path: path, Type: currentType, LeafKind: kind, FieldDecl: decl}, nil
+	return Field{Path: path, Type: currentType, LeafKind: kind, FieldDecl: decl, Refinements: currentRefinements}, nil
 }
 
 func ResolveLeafField(contract Contract, path string) (Field, error) {
@@ -672,10 +688,18 @@ func normalizeValueForType(contract Contract, fieldName, typeRef string, value a
 				if err != nil {
 					return nil, err
 				}
+				normalized, err = validateValueRefinements(contract, joinFieldName(fieldName, key), spec.Type, spec.Refinements, normalized)
+				if err != nil {
+					return nil, err
+				}
 				out[key] = normalized
 				continue
 			}
 			defaulted, err := defaultValue(contract, spec.Type, nil)
+			if err != nil {
+				return nil, err
+			}
+			defaulted, err = validateValueRefinements(contract, joinFieldName(fieldName, key), spec.Type, spec.Refinements, defaulted)
 			if err != nil {
 				return nil, err
 			}
@@ -690,10 +714,122 @@ func normalizeValueForType(contract Contract, fieldName, typeRef string, value a
 				return nil, fieldTypeError(joinFieldName(fieldName, key), "is undeclared")
 			}
 		}
+		if err := validateTypeFieldEqualities(fieldName, named.Fields, out); err != nil {
+			return nil, err
+		}
 		return out, nil
 	default:
 		return nil, fieldTypeError(fieldName, "has unsupported type "+typeRef)
 	}
+}
+
+func validateValueRefinements(contract Contract, fieldName, typeRef string, refinements runtimecontracts.SchemaRefinements, value any) (any, error) {
+	if refinements.Empty() {
+		return value, nil
+	}
+	if pattern := strings.TrimSpace(refinements.Pattern); pattern != "" {
+		text, ok := value.(string)
+		if !ok {
+			return nil, fieldTypeError(fieldName, "must be string for pattern refinement")
+		}
+		compiled, err := regexp.Compile(pattern)
+		if err != nil {
+			return nil, fieldTypeError(fieldName, "has invalid pattern refinement")
+		}
+		if !compiled.MatchString(text) {
+			return nil, fieldTypeError(fieldName, "must match pattern")
+		}
+	}
+	if !refinements.Length.Empty() {
+		length, ok := refinementLength(value)
+		if !ok {
+			return nil, fieldTypeError(fieldName, "must be string or list for length refinement")
+		}
+		if min := refinements.Length.Min; min != nil && length < *min {
+			return nil, fieldTypeError(fieldName, fmt.Sprintf("length must be >= %d", *min))
+		}
+		if max := refinements.Length.Max; max != nil && length > *max {
+			return nil, fieldTypeError(fieldName, fmt.Sprintf("length must be <= %d", *max))
+		}
+	}
+	if !refinements.Range.Empty() {
+		if !isIntegerType(contract, typeRef) && !isNumericType(contract, typeRef) {
+			return nil, fieldTypeError(fieldName, "must be numeric for range refinement")
+		}
+		number, ok := runtimesharedjson.AsFloat64(value)
+		if !ok {
+			return nil, fieldTypeError(fieldName, "must be numeric for range refinement")
+		}
+		if min := refinements.Range.Min; min != nil && number < *min {
+			return nil, fieldTypeError(fieldName, fmt.Sprintf("must be >= %v", *min))
+		}
+		if max := refinements.Range.Max; max != nil && number > *max {
+			return nil, fieldTypeError(fieldName, fmt.Sprintf("must be <= %v", *max))
+		}
+	}
+	return value, nil
+}
+
+func refinementLength(value any) (int, bool) {
+	switch typed := value.(type) {
+	case string:
+		return utf8.RuneCountInString(typed), true
+	default:
+		items, ok := listValues(value)
+		if !ok {
+			return 0, false
+		}
+		return len(items), true
+	}
+}
+
+func validateEntityFieldEqualities(context string, fields map[string]runtimecontracts.EntityFieldDecl, values map[string]any) error {
+	if len(fields) == 0 {
+		return nil
+	}
+	for name, field := range fields {
+		name = strings.TrimSpace(name)
+		target := strings.TrimSpace(field.Refinements.EqualTo)
+		if name == "" || target == "" {
+			continue
+		}
+		if err := validateEqualityValue(context, name, target, values); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateTypeFieldEqualities(context string, fields map[string]runtimecontracts.TypeFieldSpec, values map[string]any) error {
+	if len(fields) == 0 {
+		return nil
+	}
+	for name, field := range fields {
+		name = strings.TrimSpace(name)
+		target := strings.TrimSpace(field.Refinements.EqualTo)
+		if name == "" || target == "" {
+			continue
+		}
+		if err := validateEqualityValue(context, name, target, values); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateEqualityValue(context, name, target string, values map[string]any) error {
+	left, ok := values[name]
+	if !ok {
+		return fieldTypeError(joinFieldName(context, name), "must equal "+joinFieldName(context, target)+" but source is missing")
+	}
+	right, ok := values[target]
+	if !ok {
+		return fieldTypeError(joinFieldName(context, name), "must equal "+joinFieldName(context, target)+" but target is missing")
+	}
+	if !reflect.DeepEqual(left, right) {
+		return fieldTypeError(joinFieldName(context, name), "must equal "+joinFieldName(context, target))
+	}
+	return nil
 }
 
 func leafKind(contract Contract, typeRef string) (string, error) {

--- a/internal/runtime/entityruntime/contracts.go
+++ b/internal/runtime/entityruntime/contracts.go
@@ -382,6 +382,12 @@ func NormalizeFieldValue(contract Contract, fieldName string, value any) (any, e
 	return normalizeFieldValue(contract, fieldName, value, false)
 }
 
+// FieldPathParticipatesInEquality reports whether an isolated write to path
+// would bypass an equal_to proof owned by the surrounding entity/object.
+func FieldPathParticipatesInEquality(contract Contract, path string) bool {
+	return fieldPathParticipatesInEquality(contract, path)
+}
+
 func normalizeFieldValue(contract Contract, fieldName string, value any, allowEqualityParticipant bool) (any, error) {
 	field, err := ResolveFieldPath(contract, fieldName)
 	if err != nil {
@@ -858,32 +864,34 @@ func fieldPathParticipatesInEquality(contract Contract, path string) bool {
 	if len(segments) == 0 {
 		return false
 	}
-	if len(segments) == 1 {
-		return entityFieldParticipatesInEquality(contract.Entity.Fields, strings.TrimSpace(segments[0]))
-	}
-	currentType := ""
 	root := strings.TrimSpace(segments[0])
-	if decl, ok := contract.Entity.Fields[root]; ok {
-		currentType = strings.TrimSpace(decl.Type)
-	} else {
+	decl, ok := contract.Entity.Fields[root]
+	if !ok {
 		return false
 	}
-	for _, segment := range segments[1 : len(segments)-1] {
+	if entityFieldParticipatesInEquality(contract.Entity.Fields, root) {
+		return true
+	}
+	if len(segments) == 1 {
+		return false
+	}
+	currentType := strings.TrimSpace(decl.Type)
+	for _, segment := range segments[1:] {
 		named, ok := contract.Types.Types[typeName(contract, currentType)]
 		if !ok {
 			return false
 		}
-		spec, ok := named.Fields[strings.TrimSpace(segment)]
+		segment = strings.TrimSpace(segment)
+		if typeFieldParticipatesInEquality(named.Fields, segment) {
+			return true
+		}
+		spec, ok := named.Fields[segment]
 		if !ok {
 			return false
 		}
 		currentType = strings.TrimSpace(spec.Type)
 	}
-	named, ok := contract.Types.Types[typeName(contract, currentType)]
-	if !ok {
-		return false
-	}
-	return typeFieldParticipatesInEquality(named.Fields, strings.TrimSpace(segments[len(segments)-1]))
+	return false
 }
 
 func entityFieldParticipatesInEquality(fields map[string]runtimecontracts.EntityFieldDecl, name string) bool {

--- a/internal/runtime/entityruntime/contracts_test.go
+++ b/internal/runtime/entityruntime/contracts_test.go
@@ -90,6 +90,59 @@ func TestMaterialize_EnforcesSchemaRefinementEquality(t *testing.T) {
 	}
 }
 
+func TestNormalizeFieldValue_RejectsIsolatedEqualityParticipants(t *testing.T) {
+	contract := Contract{
+		Entity: runtimecontracts.EntityContract{
+			Fields: map[string]runtimecontracts.EntityFieldDecl{
+				"component": {Type: "text"},
+				"owner": {
+					Type:        "text",
+					Refinements: runtimecontracts.SchemaRefinements{EqualTo: "component"},
+				},
+			},
+		},
+	}
+
+	for _, field := range []string{"owner", "component"} {
+		if _, err := NormalizeFieldValue(contract, field, "deploy"); err == nil || !strings.Contains(err.Error(), "participates in equal_to") {
+			t.Fatalf("NormalizeFieldValue(%s) = %v, want isolated equality rejection", field, err)
+		}
+	}
+	if _, err := Materialize(contract, map[string]any{"component": "deploy", "owner": "deploy"}); err != nil {
+		t.Fatalf("Materialize should still allow full-object equality proof: %v", err)
+	}
+}
+
+func TestMaterialize_EnforcesNestedDefaultRefinements(t *testing.T) {
+	minLength := 1
+	contract := Contract{
+		Entity: runtimecontracts.EntityContract{
+			Fields: map[string]runtimecontracts.EntityFieldDecl{
+				"spec": {Type: "Spec"},
+			},
+		},
+		Types: runtimecontracts.TypeCatalogDocument{
+			Types: map[string]runtimecontracts.NamedTypeDecl{
+				"Spec": {
+					Fields: map[string]runtimecontracts.TypeFieldSpec{
+						"name": {
+							Type:        "text",
+							Refinements: runtimecontracts.SchemaRefinements{Length: runtimecontracts.SchemaLengthRefinement{Min: &minLength}},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	if _, err := Materialize(contract, nil); err == nil || !strings.Contains(err.Error(), "length must be >=") {
+		t.Fatalf("Materialize defaulted nested object = %v, want nested refinement failure", err)
+	}
+	if _, err := Materialize(contract, map[string]any{"spec": map[string]any{"name": "deploy"}}); err != nil {
+		t.Fatalf("Materialize explicit nested object: %v", err)
+	}
+}
+
 func TestMaterialize_AcceptsBracketFormListRefs(t *testing.T) {
 	contract := Contract{
 		Entity: runtimecontracts.EntityContract{

--- a/internal/runtime/entityruntime/contracts_test.go
+++ b/internal/runtime/entityruntime/contracts_test.go
@@ -35,6 +35,61 @@ func TestNormalizeFieldValue_AcceptsBuiltInNumberAndJSONTypes(t *testing.T) {
 	}
 }
 
+func TestNormalizeFieldValue_EnforcesSchemaRefinements(t *testing.T) {
+	minLength := 40
+	maxLength := 40
+	minScore := 0.0
+	maxScore := 1.0
+	contract := Contract{
+		Entity: runtimecontracts.EntityContract{
+			Fields: map[string]runtimecontracts.EntityFieldDecl{
+				"source_ref": {
+					Type: "text",
+					Refinements: runtimecontracts.SchemaRefinements{
+						Pattern: "^[0-9a-f]{40}$",
+						Length:  runtimecontracts.SchemaLengthRefinement{Min: &minLength, Max: &maxLength},
+					},
+				},
+				"score": {
+					Type:        "number",
+					Refinements: runtimecontracts.SchemaRefinements{Range: runtimecontracts.SchemaRangeRefinement{Min: &minScore, Max: &maxScore}},
+				},
+			},
+		},
+	}
+
+	if _, err := NormalizeFieldValue(contract, "source_ref", "0123456789abcdef0123456789abcdef01234567"); err != nil {
+		t.Fatalf("NormalizeFieldValue(source_ref): %v", err)
+	}
+	if _, err := NormalizeFieldValue(contract, "source_ref", "not-a-sha"); err == nil || !strings.Contains(err.Error(), "pattern") {
+		t.Fatalf("NormalizeFieldValue(source_ref bad) = %v, want pattern failure", err)
+	}
+	if _, err := NormalizeFieldValue(contract, "score", 1.5); err == nil || !strings.Contains(err.Error(), "<=") {
+		t.Fatalf("NormalizeFieldValue(score bad) = %v, want range failure", err)
+	}
+}
+
+func TestMaterialize_EnforcesSchemaRefinementEquality(t *testing.T) {
+	contract := Contract{
+		Entity: runtimecontracts.EntityContract{
+			Fields: map[string]runtimecontracts.EntityFieldDecl{
+				"component": {Type: "text"},
+				"owner": {
+					Type:        "text",
+					Refinements: runtimecontracts.SchemaRefinements{EqualTo: "component"},
+				},
+			},
+		},
+	}
+
+	if _, err := Materialize(contract, map[string]any{"component": "deploy", "owner": "deploy"}); err != nil {
+		t.Fatalf("Materialize matching equality: %v", err)
+	}
+	if _, err := Materialize(contract, map[string]any{"component": "deploy", "owner": "other"}); err == nil || !strings.Contains(err.Error(), "must equal") {
+		t.Fatalf("Materialize mismatched equality = %v, want equality failure", err)
+	}
+}
+
 func TestMaterialize_AcceptsBracketFormListRefs(t *testing.T) {
 	contract := Contract{
 		Entity: runtimecontracts.EntityContract{

--- a/internal/runtime/eventschema/validate.go
+++ b/internal/runtime/eventschema/validate.go
@@ -2,8 +2,11 @@ package eventschema
 
 import (
 	"fmt"
+	"reflect"
+	"regexp"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	runtimesharedjson "github.com/division-sh/swarm/internal/runtime/sharedjson"
 	"github.com/google/uuid"
@@ -40,6 +43,23 @@ func validateSchemaObject(path string, schema map[string]any, payload map[string
 			return err
 		}
 	}
+	for key, propSchema := range props {
+		target := strings.TrimSpace(asString(propSchema["x-swarm-equalTo"]))
+		if target == "" {
+			continue
+		}
+		value, ok := payload[key]
+		if !ok {
+			continue
+		}
+		other, ok := payload[target]
+		if !ok {
+			return fmt.Errorf("schema validation failed: %s.%s must equal %s.%s, but target is missing", path, key, path, target)
+		}
+		if !reflect.DeepEqual(value, other) {
+			return fmt.Errorf("schema validation failed: %s.%s must equal %s.%s", path, key, path, target)
+		}
+	}
 	return nil
 }
 
@@ -71,6 +91,9 @@ func validateValue(path string, schema map[string]any, value any) error {
 			return fmt.Errorf("schema validation failed: %s must be string", path)
 		}
 		if err := validateStringFormat(path, schema, text); err != nil {
+			return err
+		}
+		if err := validateStringRefinements(path, schema, text); err != nil {
 			return err
 		}
 	case "boolean":
@@ -105,6 +128,9 @@ func validateValue(path string, schema map[string]any, value any) error {
 				}
 			}
 		}
+		if err := validateArrayLength(path, schema, len(arr)); err != nil {
+			return err
+		}
 	case "object":
 		obj, ok := value.(map[string]any)
 		if !ok {
@@ -119,6 +145,44 @@ func validateValue(path string, schema map[string]any, value any) error {
 		}
 	default:
 		return fmt.Errorf("schema validation failed: %s has unsupported schema type %q", path, st)
+	}
+	return nil
+}
+
+func validateStringRefinements(path string, schema map[string]any, value string) error {
+	if pattern := strings.TrimSpace(asString(schema["pattern"])); pattern != "" {
+		compiled, err := regexp.Compile(pattern)
+		if err != nil {
+			return fmt.Errorf("schema validation failed: %s has invalid pattern refinement", path)
+		}
+		if !compiled.MatchString(value) {
+			return fmt.Errorf("schema validation failed: %s must match pattern %q", path, pattern)
+		}
+	}
+	length := utf8.RuneCountInString(value)
+	if minRaw, ok := schema["minLength"]; ok {
+		if min, ok := runtimesharedjson.AsFloat64(minRaw); ok && length < int(min) {
+			return fmt.Errorf("schema validation failed: %s length must be >= %d", path, int(min))
+		}
+	}
+	if maxRaw, ok := schema["maxLength"]; ok {
+		if max, ok := runtimesharedjson.AsFloat64(maxRaw); ok && length > int(max) {
+			return fmt.Errorf("schema validation failed: %s length must be <= %d", path, int(max))
+		}
+	}
+	return nil
+}
+
+func validateArrayLength(path string, schema map[string]any, length int) error {
+	if minRaw, ok := schema["minItems"]; ok {
+		if min, ok := runtimesharedjson.AsFloat64(minRaw); ok && length < int(min) {
+			return fmt.Errorf("schema validation failed: %s length must be >= %d", path, int(min))
+		}
+	}
+	if maxRaw, ok := schema["maxItems"]; ok {
+		if max, ok := runtimesharedjson.AsFloat64(maxRaw); ok && length > int(max) {
+			return fmt.Errorf("schema validation failed: %s length must be <= %d", path, int(max))
+		}
 	}
 	return nil
 }

--- a/internal/runtime/eventschema/validate_test.go
+++ b/internal/runtime/eventschema/validate_test.go
@@ -1,6 +1,9 @@
 package eventschema
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func TestValidatePayloadAgainstSchema_RejectsUnsupportedSchemaType(t *testing.T) {
 	t.Parallel()
@@ -91,4 +94,82 @@ func TestValidatePayloadAgainstSchema_RejectsCaseVariantEnumValue(t *testing.T) 
 	if err == nil {
 		t.Fatal("expected case-variant enum value to fail")
 	}
+}
+
+func TestValidatePayloadAgainstSchema_EnforcesSchemaRefinements(t *testing.T) {
+	t.Parallel()
+
+	schema := map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"source_ref": map[string]any{
+				"type":      "string",
+				"pattern":   "^[0-9a-f]{40}$",
+				"minLength": 40,
+				"maxLength": 40,
+			},
+			"label": map[string]any{
+				"type":      "string",
+				"minLength": 3,
+			},
+			"files": map[string]any{
+				"type":     "array",
+				"minItems": 1,
+				"items":    map[string]any{"type": "string"},
+			},
+			"score": map[string]any{
+				"type":    "number",
+				"minimum": 0.5,
+				"maximum": 1.0,
+			},
+			"component": map[string]any{"type": "string"},
+			"owner": map[string]any{
+				"type":            "string",
+				"x-swarm-equalTo": "component",
+			},
+		},
+		"required":             []any{"source_ref", "label", "files", "score", "component", "owner"},
+		"additionalProperties": false,
+	}
+
+	valid := map[string]any{
+		"source_ref": "0123456789abcdef0123456789abcdef01234567",
+		"label":      "deploy",
+		"files":      []any{"manifest.yaml"},
+		"score":      0.9,
+		"component":  "deploy",
+		"owner":      "deploy",
+	}
+	if err := ValidatePayloadAgainstSchema(schema, valid); err != nil {
+		t.Fatalf("valid payload rejected: %v", err)
+	}
+
+	for _, tc := range []struct {
+		name    string
+		mutate  func(map[string]any)
+		wantErr string
+	}{
+		{name: "pattern", mutate: func(p map[string]any) { p["source_ref"] = "not-a-sha" }, wantErr: "pattern"},
+		{name: "length", mutate: func(p map[string]any) { p["label"] = "x" }, wantErr: "length"},
+		{name: "min items", mutate: func(p map[string]any) { p["files"] = []any{} }, wantErr: "length"},
+		{name: "range", mutate: func(p map[string]any) { p["score"] = 1.5 }, wantErr: "<="},
+		{name: "equality", mutate: func(p map[string]any) { p["owner"] = "other" }, wantErr: "must equal"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			payload := cloneTestPayload(valid)
+			tc.mutate(payload)
+			err := ValidatePayloadAgainstSchema(schema, payload)
+			if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("ValidatePayloadAgainstSchema error = %v, want %q", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+func cloneTestPayload(in map[string]any) map[string]any {
+	out := make(map[string]any, len(in))
+	for key, value := range in {
+		out[key] = value
+	}
+	return out
 }

--- a/internal/runtime/tools/executor_entity_test.go
+++ b/internal/runtime/tools/executor_entity_test.go
@@ -409,6 +409,80 @@ func TestRoleScopedEntityTools_OptedInActorReceivesGeneratedSurfaceOnly(t *testi
 	}
 }
 
+func TestRoleScopedEntityTools_ExcludeEqualityParticipantWriteAffordances(t *testing.T) {
+	actor := models.AgentConfig{ID: "validation-orchestrator", Role: "validation_orchestrator", Tools: []string{"save_entity_field"}}
+	bundle := loadWave1EntityToolMultiFlowBundle(t, map[string]entityToolFlowFixture{
+		"validation": {
+			SchemaYAML: `
+name: validation
+mode: static
+initial_state: queued
+states: [queued, closed]
+terminal_states: [closed]
+tool_surface:
+  role_scoped_entity_tools: true
+`,
+			TypesYAML: `
+types:
+  manifest:
+    component: text
+    owner:
+      type: text
+      equal_to: component
+    description: text
+`,
+			EntitiesYAML: `
+validation_case:
+  component: text
+  owner:
+    type: text
+    equal_to: component
+  manifest: manifest
+  notes: text
+`,
+			AgentsYAML: `
+validation-orchestrator:
+  id: validation-orchestrator
+  role: validation_orchestrator
+  mode: task
+  tools:
+    - save_entity_field
+  entity_writes:
+    validation_case:
+      save:
+        - component
+        - owner
+        - manifest
+        - notes
+`,
+		},
+	})
+	exec := runtimetools.NewExecutorWithOptions(nil, nil, runtimetools.ExecutorOptions{
+		WorkflowSource: semanticview.Wrap(bundle),
+	})
+
+	names := roleScopedToolDefinitionMap(exec.ToolDefinitionsForActor(actor))
+	for _, name := range []string{
+		"save_validation_case_manifest",
+		"update_validation_case_manifest_description",
+		"save_validation_case_notes",
+	} {
+		if _, ok := names[name]; !ok {
+			t.Fatalf("expected generated role-scoped tool %q in %#v", name, sortedRoleScopedToolNames(names))
+		}
+	}
+	for _, name := range []string{
+		"save_validation_case_component",
+		"save_validation_case_owner",
+		"update_validation_case_manifest_component",
+		"update_validation_case_manifest_owner",
+	} {
+		if _, ok := names[name]; ok {
+			t.Fatalf("equality participant produced mutation tool %q in %#v", name, sortedRoleScopedToolNames(names))
+		}
+	}
+}
+
 func TestRoleScopedEntityTools_CurrentEntityEligibilityFiltersTurnSurface(t *testing.T) {
 	actor := models.AgentConfig{ID: "validation-orchestrator", Role: "validation_orchestrator", Tools: []string{
 		"get_entity",

--- a/internal/runtime/tools/platform_builtin_catalog.go
+++ b/internal/runtime/tools/platform_builtin_catalog.go
@@ -4,6 +4,7 @@ import (
 	"sort"
 	"strings"
 
+	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
 	models "github.com/division-sh/swarm/internal/runtime/core/actors"
 	"github.com/division-sh/swarm/internal/runtime/entityruntime"
 	"github.com/division-sh/swarm/internal/runtime/flowdata"
@@ -199,7 +200,7 @@ func entityToolSchemaEntriesForContract(contract entityruntime.Contract, readCon
 		if err != nil {
 			continue
 		}
-		fieldProperties[name] = entityContractJSONSchema(contract, decl.Type, map[string]struct{}{})
+		fieldProperties[name] = entityContractJSONSchemaWithRefinements(contract, decl.Type, decl.Refinements, true, map[string]struct{}{})
 	}
 	selectorEnum := make([]any, 0, len(selectableSelectors))
 	for _, name := range selectableSelectors {
@@ -371,7 +372,7 @@ func entityToolReadFilterPropertySchema(contracts []entityruntime.Contract, name
 		if err != nil {
 			continue
 		}
-		return entityContractJSONSchema(contract, field.Type, map[string]struct{}{})
+		return entityContractJSONSchemaWithRefinements(contract, field.Type, field.Refinements, false, map[string]struct{}{})
 	}
 	return map[string]any{}
 }
@@ -532,7 +533,7 @@ func entityContractJSONSchema(contract entityruntime.Contract, typeRef string, s
 		sort.Strings(names)
 		for _, name := range names {
 			spec := named.Fields[name]
-			props[name] = entityContractJSONSchema(contract, spec.Type, seen)
+			props[name] = entityContractJSONSchemaWithRefinements(contract, spec.Type, spec.Refinements, true, seen)
 			required = append(required, name)
 		}
 		delete(seen, typeName)
@@ -541,6 +542,46 @@ func entityContractJSONSchema(contract entityruntime.Contract, typeRef string, s
 		return schema
 	default:
 		return map[string]any{}
+	}
+}
+
+func entityContractJSONSchemaWithRefinements(contract entityruntime.Contract, typeRef string, refinements runtimecontracts.SchemaRefinements, includeEquality bool, seen map[string]struct{}) map[string]any {
+	schema := entityContractJSONSchema(contract, typeRef, seen)
+	applyEntitySchemaRefinements(schema, refinements, includeEquality)
+	return schema
+}
+
+func applyEntitySchemaRefinements(schema map[string]any, refinements runtimecontracts.SchemaRefinements, includeEquality bool) {
+	if len(schema) == 0 || refinements.Empty() {
+		return
+	}
+	if value := strings.TrimSpace(refinements.Pattern); value != "" {
+		schema["pattern"] = value
+	}
+	if min := refinements.Length.Min; min != nil {
+		if strings.TrimSpace(asString(schema["type"])) == "array" {
+			schema["minItems"] = *min
+		} else {
+			schema["minLength"] = *min
+		}
+	}
+	if max := refinements.Length.Max; max != nil {
+		if strings.TrimSpace(asString(schema["type"])) == "array" {
+			schema["maxItems"] = *max
+		} else {
+			schema["maxLength"] = *max
+		}
+	}
+	if min := refinements.Range.Min; min != nil {
+		schema["minimum"] = *min
+	}
+	if max := refinements.Range.Max; max != nil {
+		schema["maximum"] = *max
+	}
+	if includeEquality {
+		if value := strings.TrimSpace(refinements.EqualTo); value != "" {
+			schema["x-swarm-equalTo"] = value
+		}
 	}
 }
 

--- a/internal/runtime/tools/platform_builtin_catalog.go
+++ b/internal/runtime/tools/platform_builtin_catalog.go
@@ -438,7 +438,9 @@ func collectEntityToolWritablePaths(contract entityruntime.Contract, path, typeR
 	}
 	if _, ok := seen[path]; !ok {
 		seen[path] = struct{}{}
-		*out = append(*out, path)
+		if !entityruntime.FieldPathParticipatesInEquality(contract, path) {
+			*out = append(*out, path)
+		}
 	}
 	if !deliveryNamedType(contract, typeRef) {
 		return

--- a/internal/runtime/tools/platform_builtin_catalog_test.go
+++ b/internal/runtime/tools/platform_builtin_catalog_test.go
@@ -107,3 +107,39 @@ func TestEntityToolWritablePathNames_IncludesDeclaredDottedPaths(t *testing.T) {
 		t.Fatalf("entityToolWritablePathNames() = %#v, want %#v", got, want)
 	}
 }
+
+func TestEntityToolWritablePathNames_ExcludesEqualityParticipants(t *testing.T) {
+	contract := entityruntime.Contract{
+		Entity: runtimecontracts.EntityContract{
+			Fields: map[string]runtimecontracts.EntityFieldDecl{
+				"component": {Type: "text"},
+				"owner": {
+					Type:        "text",
+					Refinements: runtimecontracts.SchemaRefinements{EqualTo: "component"},
+				},
+				"manifest": {Type: "Manifest"},
+				"notes":    {Type: "text"},
+			},
+		},
+		Types: runtimecontracts.TypeCatalogDocument{
+			Types: map[string]runtimecontracts.NamedTypeDecl{
+				"Manifest": {
+					Fields: map[string]runtimecontracts.TypeFieldSpec{
+						"component": {Type: "text"},
+						"owner": {
+							Type:        "text",
+							Refinements: runtimecontracts.SchemaRefinements{EqualTo: "component"},
+						},
+						"description": {Type: "text"},
+					},
+				},
+			},
+		},
+	}
+
+	got := entityToolWritablePathNames(contract)
+	want := []string{"manifest", "manifest.description", "notes"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("entityToolWritablePathNames() = %#v, want %#v", got, want)
+	}
+}

--- a/internal/runtime/tools/role_scoped_entity_tools.go
+++ b/internal/runtime/tools/role_scoped_entity_tools.go
@@ -90,19 +90,24 @@ func roleScopedEntityToolSchemaEntry(contract entityruntime.Contract, spec roleS
 		entry.OutputSchema = roleScopedEntityWholeReadOutputSchema(contract)
 	case roleScopedEntityToolReadField:
 		if decl, err := entityruntime.FieldDecl(contract, spec.Field); err == nil {
-			entry.OutputSchema = entityContractJSONSchema(contract, decl.Type, map[string]struct{}{})
+			entry.OutputSchema = entityContractJSONSchemaWithRefinements(contract, decl.Type, decl.Refinements, false, map[string]struct{}{})
 		}
 	case roleScopedEntityToolSaveField, roleScopedEntityToolUpdatePath:
 		typeRef := ""
+		refinements := runtimecontracts.SchemaRefinements{}
 		if spec.Subpath == "" {
 			if decl, err := entityruntime.FieldDecl(contract, spec.Field); err == nil {
 				typeRef = decl.Type
+				refinements = decl.Refinements
 			}
 		} else if typeRefForSubpath, ok := roleScopedEntitySubpathTypeRef(contract, spec.Field, spec.Subpath); ok {
 			typeRef = typeRefForSubpath
+			if field, err := entityruntime.ResolveFieldPath(contract, spec.Field+"."+spec.Subpath); err == nil {
+				refinements = field.Refinements
+			}
 		}
 		entry.InputSchema = ObjectSchema(map[string]any{
-			"value": entityContractJSONSchema(contract, typeRef, map[string]struct{}{}),
+			"value": entityContractJSONSchemaWithRefinements(contract, typeRef, refinements, false, map[string]struct{}{}),
 		}, "value")
 		entry.OutputSchema = ObjectSchema(map[string]any{
 			"entity_id": map[string]any{"type": "string"},
@@ -121,7 +126,7 @@ func roleScopedEntityWholeReadOutputSchema(contract entityruntime.Contract) map[
 		if err != nil {
 			continue
 		}
-		fieldProps[field] = entityContractJSONSchema(contract, decl.Type, map[string]struct{}{})
+		fieldProps[field] = entityContractJSONSchemaWithRefinements(contract, decl.Type, decl.Refinements, true, map[string]struct{}{})
 		requiredFields = append(requiredFields, field)
 	}
 	return ObjectSchema(map[string]any{

--- a/internal/runtime/tools/role_scoped_entity_tools.go
+++ b/internal/runtime/tools/role_scoped_entity_tools.go
@@ -180,6 +180,9 @@ func roleScopedEntityToolSpecsForActor(source semanticview.Source, actor models.
 		if fieldName == "" {
 			continue
 		}
+		if entityruntime.FieldPathParticipatesInEquality(contract, field) {
+			continue
+		}
 		out["save_"+entityName+"_"+fieldName] = roleScopedEntityToolSpec{
 			Kind:       roleScopedEntityToolSaveField,
 			EntityType: contract.EntityType,
@@ -188,6 +191,9 @@ func roleScopedEntityToolSpecsForActor(source semanticview.Source, actor models.
 		for _, subpath := range roleScopedTopLevelSubpaths(contract, field) {
 			subpathName := roleScopedToolNamePart(subpath)
 			if subpathName == "" {
+				continue
+			}
+			if entityruntime.FieldPathParticipatesInEquality(contract, field+"."+subpath) {
 				continue
 			}
 			out["update_"+entityName+"_"+fieldName+"_"+subpathName] = roleScopedEntityToolSpec{

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -284,6 +284,14 @@ contract_formats:
         nested_field:
           type: NamedType
           description: Human-readable annotation
+          pattern: ^[0-9a-f]{40}$
+          length:
+            min: 40
+            max: 40
+          range:
+            min: 0
+            max: 100
+          equal_to: sibling_field
     strict_payload_contract:
       rule: |
         Event payloads are producer-complete only. Every declared
@@ -1059,6 +1067,50 @@ type_system:
     named_types: Composite types with declared inner fields.
     enums: Closed named sets of values.
     lists: Ordered collections of a declared element type.
+  schema_refinements:
+    description: |
+      Declared event payload fields, named-type fields, and entity fields
+      may carry only the closed schema-refinement vocabulary listed here.
+      These refinements extend the shared type/schema owner; they are not a
+      handler-level validation row, not a rule artifact grammar, not CEL, and
+      not a generic JSON Schema drawer. Unsupported refinement keys and
+      malformed refinement declarations are contract-load failures.
+    vocabulary:
+      required_presence: |
+        Declared event payload fields and entity fields remain required by
+        default unless another explicit supported contract form states
+        otherwise. Presence is enforced by the existing event/entity schema
+        owners.
+      pattern: |
+        `pattern: <regular expression>` is allowed only on text/string-like
+        fields. The pattern must compile during contract loading.
+      length: |
+        `length: {min, max}` is allowed only on text/string-like fields and
+        list fields. Text length is character length; list length is item
+        count. At least one bound is required; bounds must be non-negative and
+        `min <= max` when both are present.
+      enum: |
+        Enums remain closed named sets in the shared type system. Field-local
+        enum dialects are not introduced by this slice.
+      range: |
+        `range: {min, max}` is allowed only on integer/numeric fields. At
+        least one bound is required and `min <= max` when both are present.
+      equal_to: |
+        `equal_to: <sibling_field>` declares pure same-object field equality.
+        The target must be a declared sibling field with the same resolved
+        type. Non-equality predicates, provenance checks, external file
+        checks, rule IDs, and failure routing are not schema refinements.
+    runtime_consumption: |
+      Event payload validators, entity materialization/write normalization,
+      and generated entity/tool schemas that derive from the shared
+      type/schema owner MUST consume the same refinement model. A consumer may
+      omit a refinement only when it is a different semantic concept or an
+      explicitly tracked surviving follow-up.
+    validation_row_boundary: |
+      Machine-evaluated validation criteria rows are a later #1714 slice and
+      depend on the #1717 stable-ID criteria artifact grammar. They bind
+      computed validation results only; branch routing remains owned by
+      policy-sheet selection rows.
   field_forms:
     terse: 'field_name: TypeName'
     verbose: |
@@ -1067,6 +1119,14 @@ type_system:
         initial: <value>          # entities only
         immutable: true           # entities only
         description: Human-readable annotation
+        pattern: ^[0-9a-f]{40}$
+        length:
+          min: 40
+          max: 40
+        range:
+          min: 0
+          max: 100
+        equal_to: sibling_field
         _unused_reason: Reason    # entities only; verify suppression for E1
         _unused_reader_reason: Reason # entities only; reader lint suppression for external/operator readout
   restrictions:
@@ -1124,6 +1184,14 @@ entity_contracts:
           immutable: <bool>
           indexed: <bool>
           description: <text>
+          pattern: <regular expression>
+          length:
+            min: <non-negative integer>
+            max: <non-negative integer>
+          range:
+            min: <number>
+            max: <number>
+          equal_to: <sibling_field>
           materialize_from: <node_id>.<accumulator_name>
           project:
             <target_item_field>: source.<source_item_field>


### PR DESCRIPTION
## Summary

Promotes the approved #1714 Slice A schema-refinement vocabulary on the shared type/schema owners:

- adds `pattern`, `length`, `range`, and `equal_to` field refinements, with required/presence and enum continuing through the existing owners;
- validates refinement syntax and type compatibility during contract loading;
- lowers refinements into generated event/entity/tool JSON schema surfaces where those surfaces derive from the shared type/schema owner;
- enforces refinements in event payload validation and entity materialization/write normalization.

Part of #1714.
Part of #1668.
Part of #1663.

## Governing Refs / Context

No prior exact authoritative `platform-spec.yaml` section defined the #1714 schema-refinement vocabulary. This PR promotes the new authoritative section in `platform-spec.yaml` under `type_system.schema_refinements`, with adjacent governing context from:

- `contract_formats.event_schema`
- `contract_formats.entity_schema`
- `type_system`
- `entity_contracts`
- `runtime_enforcement`
- #1714 design lock and Pre-Implementation Coverage Audit
- #1714 Gate C outcome: approved as first slice

The PR intentionally does not add handler-level `validate:`, `ValidationRow`, `computed.validation.*`, stable-ID criteria grammar, validation-result routing, or failure-decision logic. Those remain split/blocked behind #1717 and later #1714 work.

## Semantic Migration

- New canonical owner: `platform-spec.yaml#type_system.schema_refinements`, consumed through the shared type/schema field model.
- Old producer / reader / writer paths now invalid: ad hoc same-concept pattern/length/range/equality checks must not be introduced as handler-local validation helpers, runtime-only callbacks, CEL shims, prompt prose, or action/provider-local schema dialects when they are expressible by the closed refinement vocabulary.
- Production paths checked for surviving old behavior: event payload schema lowering/admission, entity materialization/write normalization, generated entity/tool schemas, boot/static contract validation, provider-trigger manifests, and `artifact_repo_commit` YAML schemas.
- Migration completeness: complete for the approved Slice A vocabulary on the claimed shared event/entity/generated-schema consumers; not complete for full #1714 validation criteria rows or local provider/action schemas that remain different semantic owners or explicit future follow-up.

## Tests

- `go test ./internal/runtime/contracts ./internal/runtime/eventschema ./internal/runtime/entityruntime ./internal/runtime/tools -run 'Test(EventSchemaRegistryFromCatalog_ProjectsSchemaRefinements|ValidatePayloadAgainstSchema_EnforcesSchemaRefinements|ValidateWorkflowContractBundleLoadConstraintsRejectsInvalidSchemaRefinements|EventFieldSpecDecodeRejectsMalformedSchemaRefinement|NormalizeFieldValue_EnforcesSchemaRefinements|Materialize_EnforcesSchemaRefinementEquality|ValidatePayloadAgainstSchema|EventSchemaRegistryFromCatalog)' -count=1`
- `SWARM_TEST_POSTGRES_DSN='host=127.0.0.1 port=5432 user=youmew dbname=postgres sslmode=disable' PGPASSWORD=postgres go test ./...`
