### PR TITLE
[agent-f][issue #1733] Add zero-vocabulary provider manifests

### DIFF
--- a/internal/providertriggers/manifests/intercom.yaml
+++ b/internal/providertriggers/manifests/intercom.yaml
@@ -1,0 +1,28 @@
+provider: intercom
+payload_object_required: true
+payload_object_error: intercom payload object is required
+secret:
+  required: true
+signature:
+  type: hmac_sha1
+  header: X-Hub-Signature
+  prefix: sha1=
+  signed_payload: raw_body
+  missing_error: intercom signature is required
+  invalid_error: invalid intercom signature
+delivery_id:
+  json_path: $.id
+  required: true
+  missing_error: intercom notification id is required
+event_type:
+  json_path: $.topic
+  required: true
+  missing_error: intercom topic is required
+event_name:
+  literal: inbound.intercom
+ack:
+  mode: durable_before_dispatch
+metadata:
+  user_agent: user_agent
+  intercom_notification_id: delivery_id
+  intercom_topic: event_type

--- a/internal/providertriggers/manifests/typeform.yaml
+++ b/internal/providertriggers/manifests/typeform.yaml
@@ -1,0 +1,29 @@
+provider: typeform
+payload_object_required: true
+payload_object_error: typeform payload object is required
+secret:
+  required: true
+signature:
+  type: hmac_sha256
+  encoding: base64
+  header: Typeform-Signature
+  prefix: sha256=
+  signed_payload: raw_body
+  missing_error: typeform signature is required
+  invalid_error: invalid typeform signature
+delivery_id:
+  json_path: $.event_id
+  required: true
+  missing_error: typeform event_id is required
+event_type:
+  json_path: $.event_type
+  required: true
+  missing_error: typeform event_type is required
+event_name:
+  literal: inbound.typeform
+ack:
+  mode: durable_before_dispatch
+metadata:
+  user_agent: user_agent
+  typeform_event_id: delivery_id
+  typeform_event_type: event_type

--- a/internal/providertriggers/providertriggers_test.go
+++ b/internal/providertriggers/providertriggers_test.go
@@ -519,6 +519,272 @@ func TestShopifyManifestRejectsInvalidInputsBeforeDelivery(t *testing.T) {
 	}
 }
 
+func TestTypeformManifestAcceptsRawBodyBase64Signature(t *testing.T) {
+	now := time.Unix(1710000000, 0).UTC()
+	body := []byte(`{"event_id":"tf-evt-123","event_type":"form_response","form_response":{"token":"abc"}}`)
+	req := Request{
+		Provider: "typeform",
+		Target: Target{
+			EntityID:      "entity-1",
+			WebhookSecret: "typeform-secret",
+		},
+		Body:      body,
+		Headers:   make(http.Header),
+		Payload:   map[string]any{"event_id": "tf-evt-123", "event_type": "form_response", "form_response": map[string]any{"token": "abc"}},
+		Received:  now,
+		UserAgent: "typeform-test",
+	}
+	req.Headers.Set("Typeform-Signature", typeformSignatureBase64("typeform-secret", body))
+
+	delivery, err := DefaultRegistry().Accept(req)
+	if err != nil {
+		t.Fatalf("Accept Typeform webhook: %v", err)
+	}
+	if delivery.ProviderEventID != "tf-evt-123" {
+		t.Fatalf("ProviderEventID = %q, want tf-evt-123", delivery.ProviderEventID)
+	}
+	if delivery.ProviderEventType != "form_response" {
+		t.Fatalf("ProviderEventType = %q, want form_response", delivery.ProviderEventType)
+	}
+	if delivery.EventName != "inbound.typeform" {
+		t.Fatalf("EventName = %q, want inbound.typeform", delivery.EventName)
+	}
+	if !delivery.AcknowledgeBeforeDispatch {
+		t.Fatal("Typeform delivery did not request durable_before_dispatch acknowledgement")
+	}
+	headers, ok := delivery.Payload["headers"].(map[string]any)
+	if !ok {
+		t.Fatalf("headers = %T, want metadata map", delivery.Payload["headers"])
+	}
+	if headers["typeform_event_id"] != "tf-evt-123" || headers["typeform_event_type"] != "form_response" {
+		t.Fatalf("headers = %+v, want Typeform manifest metadata", headers)
+	}
+	encoded := fmtPayload(delivery.Payload)
+	if strings.Contains(encoded, "typeform-secret") {
+		t.Fatal("Typeform signing secret leaked into delivery payload")
+	}
+}
+
+func TestTypeformManifestRejectsInvalidInputsBeforeDelivery(t *testing.T) {
+	now := time.Unix(1710000000, 0).UTC()
+	validBody := []byte(`{"event_id":"tf-evt-123","event_type":"form_response","form_response":{"token":"abc"}}`)
+	validPayload := map[string]any{"event_id": "tf-evt-123", "event_type": "form_response", "form_response": map[string]any{"token": "abc"}}
+	validRequest := func() Request {
+		req := Request{
+			Provider: "typeform",
+			Target: Target{
+				EntityID:      "entity-1",
+				WebhookSecret: "typeform-secret",
+			},
+			Body:     validBody,
+			Headers:  make(http.Header),
+			Payload:  validPayload,
+			Received: now,
+		}
+		req.Headers.Set("Typeform-Signature", typeformSignatureBase64("typeform-secret", validBody))
+		return req
+	}
+	for _, tc := range []struct {
+		name       string
+		configure  func(Request) Request
+		wantStatus int
+	}{
+		{
+			name: "missing signature",
+			configure: func(req Request) Request {
+				req.Headers.Del("Typeform-Signature")
+				return req
+			},
+			wantStatus: http.StatusUnauthorized,
+		},
+		{
+			name: "invalid signature",
+			configure: func(req Request) Request {
+				req.Headers.Set("Typeform-Signature", typeformSignatureBase64("wrong-secret", req.Body))
+				return req
+			},
+			wantStatus: http.StatusUnauthorized,
+		},
+		{
+			name: "raw body mutation",
+			configure: func(req Request) Request {
+				signedBody := []byte(`{"event_type":"form_response","event_id":"tf-evt-123","form_response":{"token":"abc"}}`)
+				req.Headers.Set("Typeform-Signature", typeformSignatureBase64("typeform-secret", signedBody))
+				return req
+			},
+			wantStatus: http.StatusUnauthorized,
+		},
+		{
+			name: "missing event id",
+			configure: func(req Request) Request {
+				req.Body = []byte(`{"event_type":"form_response","form_response":{"token":"abc"}}`)
+				req.Payload = map[string]any{"event_type": "form_response", "form_response": map[string]any{"token": "abc"}}
+				req.Headers.Set("Typeform-Signature", typeformSignatureBase64("typeform-secret", req.Body))
+				return req
+			},
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name: "missing event type",
+			configure: func(req Request) Request {
+				req.Body = []byte(`{"event_id":"tf-evt-123","form_response":{"token":"abc"}}`)
+				req.Payload = map[string]any{"event_id": "tf-evt-123", "form_response": map[string]any{"token": "abc"}}
+				req.Headers.Set("Typeform-Signature", typeformSignatureBase64("typeform-secret", req.Body))
+				return req
+			},
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name: "non object payload",
+			configure: func(req Request) Request {
+				req.Body = []byte(`[{"event_id":"tf-evt-123","event_type":"form_response"}]`)
+				req.Payload = []any{map[string]any{"event_id": "tf-evt-123", "event_type": "form_response"}}
+				req.Headers.Set("Typeform-Signature", typeformSignatureBase64("typeform-secret", req.Body))
+				return req
+			},
+			wantStatus: http.StatusBadRequest,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := DefaultRegistry().Accept(tc.configure(validRequest()))
+			requireProviderTriggerError(t, err, tc.wantStatus)
+		})
+	}
+}
+
+func TestIntercomManifestAcceptsRawBodySHA1Signature(t *testing.T) {
+	now := time.Unix(1710000000, 0).UTC()
+	body := []byte(`{"id":"notif_123","topic":"conversation.user.created","data":{"item":{"id":"conv_1"}}}`)
+	req := Request{
+		Provider: "intercom",
+		Target: Target{
+			EntityID:      "entity-1",
+			WebhookSecret: "intercom-secret",
+		},
+		Body:      body,
+		Headers:   make(http.Header),
+		Payload:   map[string]any{"id": "notif_123", "topic": "conversation.user.created", "data": map[string]any{"item": map[string]any{"id": "conv_1"}}},
+		Received:  now,
+		UserAgent: "intercom-test",
+	}
+	req.Headers.Set("X-Hub-Signature", intercomSignatureHex("intercom-secret", body))
+
+	delivery, err := DefaultRegistry().Accept(req)
+	if err != nil {
+		t.Fatalf("Accept Intercom webhook: %v", err)
+	}
+	if delivery.ProviderEventID != "notif_123" {
+		t.Fatalf("ProviderEventID = %q, want notif_123", delivery.ProviderEventID)
+	}
+	if delivery.ProviderEventType != "conversation_user_created" {
+		t.Fatalf("ProviderEventType = %q, want conversation_user_created", delivery.ProviderEventType)
+	}
+	if delivery.EventName != "inbound.intercom" {
+		t.Fatalf("EventName = %q, want inbound.intercom", delivery.EventName)
+	}
+	if !delivery.AcknowledgeBeforeDispatch {
+		t.Fatal("Intercom delivery did not request durable_before_dispatch acknowledgement")
+	}
+	headers, ok := delivery.Payload["headers"].(map[string]any)
+	if !ok {
+		t.Fatalf("headers = %T, want metadata map", delivery.Payload["headers"])
+	}
+	if headers["intercom_notification_id"] != "notif_123" || headers["intercom_topic"] != "conversation_user_created" {
+		t.Fatalf("headers = %+v, want Intercom manifest metadata", headers)
+	}
+	encoded := fmtPayload(delivery.Payload)
+	if strings.Contains(encoded, "intercom-secret") {
+		t.Fatal("Intercom signing secret leaked into delivery payload")
+	}
+}
+
+func TestIntercomManifestRejectsInvalidInputsBeforeDelivery(t *testing.T) {
+	now := time.Unix(1710000000, 0).UTC()
+	validBody := []byte(`{"id":"notif_123","topic":"conversation.user.created","data":{"item":{"id":"conv_1"}}}`)
+	validPayload := map[string]any{"id": "notif_123", "topic": "conversation.user.created", "data": map[string]any{"item": map[string]any{"id": "conv_1"}}}
+	validRequest := func() Request {
+		req := Request{
+			Provider: "intercom",
+			Target: Target{
+				EntityID:      "entity-1",
+				WebhookSecret: "intercom-secret",
+			},
+			Body:     validBody,
+			Headers:  make(http.Header),
+			Payload:  validPayload,
+			Received: now,
+		}
+		req.Headers.Set("X-Hub-Signature", intercomSignatureHex("intercom-secret", validBody))
+		return req
+	}
+	for _, tc := range []struct {
+		name       string
+		configure  func(Request) Request
+		wantStatus int
+	}{
+		{
+			name: "missing signature",
+			configure: func(req Request) Request {
+				req.Headers.Del("X-Hub-Signature")
+				return req
+			},
+			wantStatus: http.StatusUnauthorized,
+		},
+		{
+			name: "invalid signature",
+			configure: func(req Request) Request {
+				req.Headers.Set("X-Hub-Signature", intercomSignatureHex("wrong-secret", req.Body))
+				return req
+			},
+			wantStatus: http.StatusUnauthorized,
+		},
+		{
+			name: "raw body mutation",
+			configure: func(req Request) Request {
+				signedBody := []byte(`{"topic":"conversation.user.created","id":"notif_123","data":{"item":{"id":"conv_1"}}}`)
+				req.Headers.Set("X-Hub-Signature", intercomSignatureHex("intercom-secret", signedBody))
+				return req
+			},
+			wantStatus: http.StatusUnauthorized,
+		},
+		{
+			name: "missing notification id",
+			configure: func(req Request) Request {
+				req.Body = []byte(`{"topic":"conversation.user.created","data":{"item":{"id":"conv_1"}}}`)
+				req.Payload = map[string]any{"topic": "conversation.user.created", "data": map[string]any{"item": map[string]any{"id": "conv_1"}}}
+				req.Headers.Set("X-Hub-Signature", intercomSignatureHex("intercom-secret", req.Body))
+				return req
+			},
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name: "missing topic",
+			configure: func(req Request) Request {
+				req.Body = []byte(`{"id":"notif_123","data":{"item":{"id":"conv_1"}}}`)
+				req.Payload = map[string]any{"id": "notif_123", "data": map[string]any{"item": map[string]any{"id": "conv_1"}}}
+				req.Headers.Set("X-Hub-Signature", intercomSignatureHex("intercom-secret", req.Body))
+				return req
+			},
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name: "non object payload",
+			configure: func(req Request) Request {
+				req.Body = []byte(`[{"id":"notif_123","topic":"conversation.user.created"}]`)
+				req.Payload = []any{map[string]any{"id": "notif_123", "topic": "conversation.user.created"}}
+				req.Headers.Set("X-Hub-Signature", intercomSignatureHex("intercom-secret", req.Body))
+				return req
+			},
+			wantStatus: http.StatusBadRequest,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := DefaultRegistry().Accept(tc.configure(validRequest()))
+			requireProviderTriggerError(t, err, tc.wantStatus)
+		})
+	}
+}
+
 func TestManifestValidationRejectsAuthoringErrors(t *testing.T) {
 	for _, tc := range []struct {
 		name     string
@@ -795,6 +1061,18 @@ func shopifySignatureBase64(secret string, body []byte) string {
 	mac := hmac.New(sha256.New, []byte(secret))
 	_, _ = mac.Write(body)
 	return base64.StdEncoding.EncodeToString(mac.Sum(nil))
+}
+
+func typeformSignatureBase64(secret string, body []byte) string {
+	mac := hmac.New(sha256.New, []byte(secret))
+	_, _ = mac.Write(body)
+	return "sha256=" + base64.StdEncoding.EncodeToString(mac.Sum(nil))
+}
+
+func intercomSignatureHex(secret string, body []byte) string {
+	mac := hmac.New(sha1.New, []byte(secret))
+	_, _ = mac.Write(body)
+	return "sha1=" + hex.EncodeToString(mac.Sum(nil))
 }
 
 func cloneValues(values url.Values) url.Values {

--- a/internal/runtime/inbound_postgres_test.go
+++ b/internal/runtime/inbound_postgres_test.go
@@ -663,6 +663,195 @@ func TestInboundGateway_ShopifySQLitePersistsConfiguredManifestDelivery(t *testi
 	waitForInboundBusQuiescence(t, bus)
 }
 
+func TestInboundGateway_TypeformAndIntercomPostgresPersistsConfiguredManifestDelivery(t *testing.T) {
+	for _, tc := range []struct {
+		name              string
+		runID             string
+		entityID          string
+		flowInstance      string
+		provider          string
+		webhookSecret     string
+		providerEventID   string
+		providerEventType string
+		agentID           string
+		providerEventName string
+		body              []byte
+		newRequest        func(path string, secret string, body []byte) *http.Request
+	}{
+		{
+			name:              "typeform",
+			runID:             "49000000-0000-0000-0000-000000000001",
+			entityID:          "49000000-0000-0000-0000-000000000002",
+			flowInstance:      "typeform-provider-trigger-instance",
+			provider:          "typeform",
+			webhookSecret:     "typeform-secret",
+			providerEventID:   "tf-evt-pg-123",
+			providerEventType: "form_response",
+			agentID:           "typeform-webhook-subscriber",
+			providerEventName: "inbound.typeform",
+			body:              []byte(`{"event_id":"tf-evt-pg-123","event_type":"form_response","form_response":{"token":"abc"}}`),
+			newRequest:        newSignedTypeformRequest,
+		},
+		{
+			name:              "intercom",
+			runID:             "4a000000-0000-0000-0000-000000000001",
+			entityID:          "4a000000-0000-0000-0000-000000000002",
+			flowInstance:      "intercom-provider-trigger-instance",
+			provider:          "intercom",
+			webhookSecret:     "intercom-secret",
+			providerEventID:   "notif_pg_123",
+			providerEventType: "conversation_user_created",
+			agentID:           "intercom-webhook-subscriber",
+			providerEventName: "inbound.intercom",
+			body:              []byte(`{"id":"notif_pg_123","topic":"conversation.user.created","data":{"item":{"id":"conv_1"}}}`),
+			newRequest:        newSignedIntercomRequest,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, db, cleanup := testutil.StartPostgres(t)
+			t.Cleanup(cleanup)
+
+			ctx := runtimecorrelation.WithRunID(context.Background(), tc.runID)
+			pg := &store.PostgresStore{DB: db}
+			seedPostgresInboundGatewayRuntime(t, ctx, db, pg, tc.runID, tc.entityID, tc.flowInstance, "customer-a", tc.provider, tc.webhookSecret, tc.agentID)
+
+			bus, err := runtimebus.NewEventBus(pg)
+			if err != nil {
+				t.Fatalf("NewEventBus: %v", err)
+			}
+			ch := bus.Subscribe(tc.agentID, events.EventType(tc.providerEventName))
+			defer bus.Unsubscribe(tc.agentID)
+
+			g := runtimepkg.NewInboundGateway(bus, nil, nil, pg)
+
+			req := tc.newRequest("/webhooks/customer-a/"+tc.provider, tc.webhookSecret, tc.body)
+			req = req.WithContext(ctx)
+			rec := httptest.NewRecorder()
+			g.Handler().ServeHTTP(rec, req)
+
+			if rec.Code != http.StatusAccepted {
+				t.Fatalf("status = %d, want 202 body=%s", rec.Code, rec.Body.String())
+			}
+			if got := countPostgresInboundMarkers(t, ctx, db, tc.providerEventID, tc.entityID, tc.provider); got != 1 {
+				t.Fatalf("inbound marker rows = %d, want 1", got)
+			}
+			eventID := loadPostgresInboundProviderEventID(t, ctx, db, tc.runID, tc.entityID, tc.providerEventName, tc.providerEventID)
+			if got := countPostgresInboundProviderEvents(t, ctx, db, tc.runID, tc.entityID, tc.providerEventName, tc.providerEventID); got != 1 {
+				t.Fatalf("provider event rows = %d, want 1", got)
+			}
+			if got := loadPostgresInboundProviderEventPayloadField(t, ctx, db, eventID, "provider_event_type"); got != tc.providerEventType {
+				t.Fatalf("provider_event_type = %q, want %s", got, tc.providerEventType)
+			}
+			if got := countPostgresAgentDeliveriesForEvent(t, ctx, db, eventID, tc.agentID); got != 1 {
+				t.Fatalf("agent delivery rows = %d, want 1", got)
+			}
+			select {
+			case got := <-ch:
+				if got.ID() != eventID || got.Type() != events.EventType(tc.providerEventName) {
+					t.Fatalf("delivered event = %s/%s, want %s/%s", got.ID(), got.Type(), eventID, tc.providerEventName)
+				}
+			default:
+				// Typeform and Intercom use durable_before_dispatch; this proof is
+				// about persisted evidence and supported store admission.
+			}
+			waitForInboundBusQuiescence(t, bus)
+		})
+	}
+}
+
+func TestInboundGateway_TypeformAndIntercomSQLitePersistsConfiguredManifestDelivery(t *testing.T) {
+	for _, tc := range []struct {
+		name              string
+		runID             string
+		entityID          string
+		flowInstance      string
+		provider          string
+		webhookSecret     string
+		providerEventID   string
+		providerEventType string
+		agentID           string
+		providerEventName string
+		body              []byte
+		newRequest        func(path string, secret string, body []byte) *http.Request
+	}{
+		{
+			name:              "typeform",
+			runID:             "4b000000-0000-0000-0000-000000000001",
+			entityID:          "4b000000-0000-0000-0000-000000000002",
+			flowInstance:      "typeform-sqlite-provider-trigger-instance",
+			provider:          "typeform",
+			webhookSecret:     "typeform-secret",
+			providerEventID:   "tf-evt-sqlite-123",
+			providerEventType: "form_response",
+			agentID:           "typeform-sqlite-webhook-subscriber",
+			providerEventName: "inbound.typeform",
+			body:              []byte(`{"event_id":"tf-evt-sqlite-123","event_type":"form_response","form_response":{"token":"abc"}}`),
+			newRequest:        newSignedTypeformRequest,
+		},
+		{
+			name:              "intercom",
+			runID:             "4c000000-0000-0000-0000-000000000001",
+			entityID:          "4c000000-0000-0000-0000-000000000002",
+			flowInstance:      "intercom-sqlite-provider-trigger-instance",
+			provider:          "intercom",
+			webhookSecret:     "intercom-secret",
+			providerEventID:   "notif_sqlite_123",
+			providerEventType: "conversation_user_created",
+			agentID:           "intercom-sqlite-webhook-subscriber",
+			providerEventName: "inbound.intercom",
+			body:              []byte(`{"id":"notif_sqlite_123","topic":"conversation.user.created","data":{"item":{"id":"conv_1"}}}`),
+			newRequest:        newSignedIntercomRequest,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := runtimecorrelation.WithRunID(context.Background(), tc.runID)
+			sqliteStore := storetest.StartSQLiteRuntimeStoreWithContext(t, ctx)
+			seedSQLiteInboundGatewayRuntime(t, ctx, sqliteStore, tc.runID, tc.entityID, tc.flowInstance, "customer-a", tc.provider, tc.webhookSecret, tc.agentID)
+
+			bus, err := runtimebus.NewEventBus(sqliteStore)
+			if err != nil {
+				t.Fatalf("NewEventBus: %v", err)
+			}
+			ch := bus.Subscribe(tc.agentID, events.EventType(tc.providerEventName))
+			defer bus.Unsubscribe(tc.agentID)
+
+			g := runtimepkg.NewInboundGateway(bus, nil, nil, sqliteStore)
+
+			req := tc.newRequest("/webhooks/customer-a/"+tc.provider, tc.webhookSecret, tc.body)
+			req = req.WithContext(ctx)
+			rec := httptest.NewRecorder()
+			g.Handler().ServeHTTP(rec, req)
+
+			if rec.Code != http.StatusAccepted {
+				t.Fatalf("status = %d, want 202 body=%s", rec.Code, rec.Body.String())
+			}
+			if got := countSQLiteInboundMarkers(t, ctx, sqliteStore, tc.providerEventID, tc.entityID, tc.provider); got != 1 {
+				t.Fatalf("inbound marker rows = %d, want 1", got)
+			}
+			eventID := loadSQLiteInboundProviderEventID(t, ctx, sqliteStore, tc.runID, tc.entityID, tc.providerEventName, tc.providerEventID)
+			if got := countSQLiteInboundProviderEvents(t, ctx, sqliteStore, tc.runID, tc.entityID, tc.providerEventName, tc.providerEventID); got != 1 {
+				t.Fatalf("provider event rows = %d, want 1", got)
+			}
+			if got := loadSQLiteInboundProviderEventPayloadField(t, ctx, sqliteStore, eventID, "provider_event_type"); got != tc.providerEventType {
+				t.Fatalf("provider_event_type = %q, want %s", got, tc.providerEventType)
+			}
+			if got := countSQLiteAgentDeliveriesForEvent(t, ctx, sqliteStore, eventID, tc.agentID); got != 1 {
+				t.Fatalf("agent delivery rows = %d, want 1", got)
+			}
+			select {
+			case got := <-ch:
+				if got.ID() != eventID || got.Type() != events.EventType(tc.providerEventName) {
+					t.Fatalf("delivered event = %s/%s, want %s/%s", got.ID(), got.Type(), eventID, tc.providerEventName)
+				}
+			default:
+				// Typeform and Intercom use durable_before_dispatch; this proof is
+				// about persisted evidence and supported store admission.
+			}
+			waitForInboundBusQuiescence(t, bus)
+		})
+	}
+}
+
 func seedPostgresInboundGatewayRuntime(
 	t *testing.T,
 	ctx context.Context,
@@ -1079,4 +1268,28 @@ func shopifyWebhookSignature(secret string, body []byte) string {
 	mac := hmac.New(sha256.New, []byte(secret))
 	_, _ = mac.Write(body)
 	return base64.StdEncoding.EncodeToString(mac.Sum(nil))
+}
+
+func newSignedTypeformRequest(path string, secret string, body []byte) *http.Request {
+	req := httptest.NewRequest(http.MethodPost, path, strings.NewReader(string(body)))
+	req.Header.Set("Typeform-Signature", typeformWebhookSignature(secret, body))
+	return req
+}
+
+func typeformWebhookSignature(secret string, body []byte) string {
+	mac := hmac.New(sha256.New, []byte(secret))
+	_, _ = mac.Write(body)
+	return "sha256=" + base64.StdEncoding.EncodeToString(mac.Sum(nil))
+}
+
+func newSignedIntercomRequest(path string, secret string, body []byte) *http.Request {
+	req := httptest.NewRequest(http.MethodPost, path, strings.NewReader(string(body)))
+	req.Header.Set("X-Hub-Signature", intercomWebhookSignature(secret, body))
+	return req
+}
+
+func intercomWebhookSignature(secret string, body []byte) string {
+	mac := hmac.New(sha1.New, []byte(secret))
+	_, _ = mac.Write(body)
+	return "sha1=" + hex.EncodeToString(mac.Sum(nil))
 }

--- a/internal/runtime/inbound_test.go
+++ b/internal/runtime/inbound_test.go
@@ -1346,6 +1346,374 @@ func TestInboundGateway_ShopifyDuplicateDeliveryDoesNotPublishAgain(t *testing.T
 	}
 }
 
+func TestInboundGateway_TypeformAndIntercomManifestsOwnRawBodySignatureDeliveryIDAndEventType(t *testing.T) {
+	for _, tc := range []struct {
+		name              string
+		provider          string
+		secret            string
+		body              []byte
+		newRequest        func(path string, secret string, body []byte) *http.Request
+		wantProviderID    string
+		wantProviderType  string
+		wantEventName     events.EventType
+		wantMetadataKeyID string
+		wantMetadataKeyTy string
+	}{
+		{
+			name:              "typeform",
+			provider:          "typeform",
+			secret:            "typeform-secret",
+			body:              []byte(`{"event_id":"tf-evt-123","event_type":"form_response","form_response":{"token":"abc"}}`),
+			newRequest:        newSignedTypeformRequest,
+			wantProviderID:    "tf-evt-123",
+			wantProviderType:  "form_response",
+			wantEventName:     events.EventType("inbound.typeform"),
+			wantMetadataKeyID: "typeform_event_id",
+			wantMetadataKeyTy: "typeform_event_type",
+		},
+		{
+			name:              "intercom",
+			provider:          "intercom",
+			secret:            "intercom-secret",
+			body:              []byte(`{"id":"notif_123","topic":"conversation.user.created","data":{"item":{"id":"conv_1"}}}`),
+			newRequest:        newSignedIntercomRequest,
+			wantProviderID:    "notif_123",
+			wantProviderType:  "conversation_user_created",
+			wantEventName:     events.EventType("inbound.intercom"),
+			wantMetadataKeyID: "intercom_notification_id",
+			wantMetadataKeyTy: "intercom_topic",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			eventStore := &capturingInboundEventStore{}
+			bus, err := runtimebus.NewEventBus(eventStore)
+			if err != nil {
+				t.Fatalf("NewEventBus: %v", err)
+			}
+			store := &recordingInboundStore{
+				target: InboundTarget{
+					EntityID:      "3fd8fc37-6d02-4d50-8bb7-14c6cb0fed0a",
+					EntitySlug:    "customer-a",
+					WebhookSecret: tc.secret,
+				},
+				inserted: true,
+			}
+			g := NewInboundGateway(bus, nil, nil, store)
+
+			req := tc.newRequest("/webhooks/customer-a/"+tc.provider, tc.secret, tc.body)
+			rec := httptest.NewRecorder()
+			g.Handler().ServeHTTP(rec, req)
+
+			if rec.Code != http.StatusAccepted {
+				t.Fatalf("status = %d, want 202 body=%s", rec.Code, rec.Body.String())
+			}
+			if !store.recorded {
+				t.Fatalf("expected %s delivery to record inbound marker", tc.provider)
+			}
+			if store.providerEventID != tc.wantProviderID {
+				t.Fatalf("providerEventID = %q, want %s", store.providerEventID, tc.wantProviderID)
+			}
+			if store.provider != tc.provider {
+				t.Fatalf("provider = %q, want %s", store.provider, tc.provider)
+			}
+			if len(eventStore.events) != 1 {
+				t.Fatalf("published events = %d, want 1", len(eventStore.events))
+			}
+			evt := eventStore.events[0]
+			if evt.Type() != tc.wantEventName {
+				t.Fatalf("event type = %q, want %s", evt.Type(), tc.wantEventName)
+			}
+			var payload map[string]any
+			if err := json.Unmarshal(evt.Payload(), &payload); err != nil {
+				t.Fatalf("unmarshal payload: %v", err)
+			}
+			headers, ok := payload["headers"].(map[string]any)
+			if !ok {
+				t.Fatalf("headers = %T, want metadata map", payload["headers"])
+			}
+			if payload["provider_event_id"] != tc.wantProviderID ||
+				payload["provider_event_type"] != tc.wantProviderType ||
+				payload["provider"] != tc.provider ||
+				headers[tc.wantMetadataKeyID] != tc.wantProviderID ||
+				headers[tc.wantMetadataKeyTy] != tc.wantProviderType {
+				t.Fatalf("payload = %+v, want %s manifest delivery identity", payload, tc.provider)
+			}
+			if strings.Contains(rec.Body.String(), tc.secret) || strings.Contains(string(evt.Payload()), tc.secret) {
+				t.Fatalf("%s signing secret leaked into readback or event payload", tc.provider)
+			}
+		})
+	}
+}
+
+func TestInboundGateway_TypeformAndIntercomRejectInvalidInputsBeforeMarkerAndPublish(t *testing.T) {
+	for _, providerCase := range []struct {
+		provider   string
+		secret     string
+		validBody  []byte
+		newRequest func(path string, secret string, body []byte) *http.Request
+		cases      []struct {
+			name       string
+			body       []byte
+			configure  func(*http.Request, []byte)
+			wantStatus int
+		}
+	}{
+		{
+			provider:   "typeform",
+			secret:     "typeform-secret",
+			validBody:  []byte(`{"event_id":"tf-evt-123","event_type":"form_response","form_response":{"token":"abc"}}`),
+			newRequest: newSignedTypeformRequest,
+			cases: []struct {
+				name       string
+				body       []byte
+				configure  func(*http.Request, []byte)
+				wantStatus int
+			}{
+				{
+					name:       "missing signature",
+					body:       []byte(`{"event_id":"tf-evt-123","event_type":"form_response","form_response":{"token":"abc"}}`),
+					configure:  func(req *http.Request, _ []byte) { req.Header.Del("Typeform-Signature") },
+					wantStatus: http.StatusUnauthorized,
+				},
+				{
+					name: "invalid signature",
+					body: []byte(`{"event_id":"tf-evt-123","event_type":"form_response","form_response":{"token":"abc"}}`),
+					configure: func(req *http.Request, body []byte) {
+						req.Header.Set("Typeform-Signature", typeformWebhookSignature("wrong-secret", body))
+					},
+					wantStatus: http.StatusUnauthorized,
+				},
+				{
+					name: "raw body mutation",
+					body: []byte(`{"event_id":"tf-evt-123","event_type":"form_response","form_response":{"token":"abc"}}`),
+					configure: func(req *http.Request, _ []byte) {
+						signedBody := []byte(`{"event_type":"form_response","event_id":"tf-evt-123","form_response":{"token":"abc"}}`)
+						req.Header.Set("Typeform-Signature", typeformWebhookSignature("typeform-secret", signedBody))
+					},
+					wantStatus: http.StatusUnauthorized,
+				},
+				{
+					name:       "missing delivery id",
+					body:       []byte(`{"event_type":"form_response","form_response":{"token":"abc"}}`),
+					configure:  func(*http.Request, []byte) {},
+					wantStatus: http.StatusBadRequest,
+				},
+				{
+					name:       "missing event type",
+					body:       []byte(`{"event_id":"tf-evt-123","form_response":{"token":"abc"}}`),
+					configure:  func(*http.Request, []byte) {},
+					wantStatus: http.StatusBadRequest,
+				},
+				{
+					name:       "non object payload",
+					body:       []byte(`[{"event_id":"tf-evt-123","event_type":"form_response"}]`),
+					configure:  func(*http.Request, []byte) {},
+					wantStatus: http.StatusBadRequest,
+				},
+			},
+		},
+		{
+			provider:   "intercom",
+			secret:     "intercom-secret",
+			validBody:  []byte(`{"id":"notif_123","topic":"conversation.user.created","data":{"item":{"id":"conv_1"}}}`),
+			newRequest: newSignedIntercomRequest,
+			cases: []struct {
+				name       string
+				body       []byte
+				configure  func(*http.Request, []byte)
+				wantStatus int
+			}{
+				{
+					name:       "missing signature",
+					body:       []byte(`{"id":"notif_123","topic":"conversation.user.created","data":{"item":{"id":"conv_1"}}}`),
+					configure:  func(req *http.Request, _ []byte) { req.Header.Del("X-Hub-Signature") },
+					wantStatus: http.StatusUnauthorized,
+				},
+				{
+					name: "invalid signature",
+					body: []byte(`{"id":"notif_123","topic":"conversation.user.created","data":{"item":{"id":"conv_1"}}}`),
+					configure: func(req *http.Request, body []byte) {
+						req.Header.Set("X-Hub-Signature", intercomWebhookSignature("wrong-secret", body))
+					},
+					wantStatus: http.StatusUnauthorized,
+				},
+				{
+					name: "raw body mutation",
+					body: []byte(`{"id":"notif_123","topic":"conversation.user.created","data":{"item":{"id":"conv_1"}}}`),
+					configure: func(req *http.Request, _ []byte) {
+						signedBody := []byte(`{"topic":"conversation.user.created","id":"notif_123","data":{"item":{"id":"conv_1"}}}`)
+						req.Header.Set("X-Hub-Signature", intercomWebhookSignature("intercom-secret", signedBody))
+					},
+					wantStatus: http.StatusUnauthorized,
+				},
+				{
+					name:       "missing delivery id",
+					body:       []byte(`{"topic":"conversation.user.created","data":{"item":{"id":"conv_1"}}}`),
+					configure:  func(*http.Request, []byte) {},
+					wantStatus: http.StatusBadRequest,
+				},
+				{
+					name:       "missing event type",
+					body:       []byte(`{"id":"notif_123","data":{"item":{"id":"conv_1"}}}`),
+					configure:  func(*http.Request, []byte) {},
+					wantStatus: http.StatusBadRequest,
+				},
+				{
+					name:       "non object payload",
+					body:       []byte(`[{"id":"notif_123","topic":"conversation.user.created"}]`),
+					configure:  func(*http.Request, []byte) {},
+					wantStatus: http.StatusBadRequest,
+				},
+			},
+		},
+	} {
+		for _, tc := range providerCase.cases {
+			t.Run(providerCase.provider+"/"+tc.name, func(t *testing.T) {
+				eventStore := &capturingInboundEventStore{}
+				bus, err := runtimebus.NewEventBus(eventStore)
+				if err != nil {
+					t.Fatalf("NewEventBus: %v", err)
+				}
+				store := &recordingInboundStore{
+					target: InboundTarget{
+						EntityID:      "3fd8fc37-6d02-4d50-8bb7-14c6cb0fed0a",
+						EntitySlug:    "customer-a",
+						WebhookSecret: providerCase.secret,
+					},
+					inserted: true,
+				}
+				g := NewInboundGateway(bus, nil, nil, store)
+				body := tc.body
+				if len(body) == 0 {
+					body = providerCase.validBody
+				}
+				req := providerCase.newRequest("/webhooks/customer-a/"+providerCase.provider, providerCase.secret, body)
+				tc.configure(req, body)
+				rec := httptest.NewRecorder()
+				g.Handler().ServeHTTP(rec, req)
+
+				if rec.Code != tc.wantStatus {
+					t.Fatalf("status = %d, want %d body=%s", rec.Code, tc.wantStatus, rec.Body.String())
+				}
+				if store.recorded {
+					t.Fatalf("invalid %s request recorded inbound marker", providerCase.provider)
+				}
+				if len(eventStore.events) != 0 {
+					t.Fatalf("published events = %d, want 0", len(eventStore.events))
+				}
+			})
+		}
+	}
+}
+
+func TestInboundGateway_TypeformAndIntercomDuplicateDeliveryDoesNotPublishAgain(t *testing.T) {
+	for _, tc := range []struct {
+		provider   string
+		secret     string
+		body       []byte
+		newRequest func(path string, secret string, body []byte) *http.Request
+	}{
+		{
+			provider:   "typeform",
+			secret:     "typeform-secret",
+			body:       []byte(`{"event_id":"tf-evt-123","event_type":"form_response","form_response":{"token":"abc"}}`),
+			newRequest: newSignedTypeformRequest,
+		},
+		{
+			provider:   "intercom",
+			secret:     "intercom-secret",
+			body:       []byte(`{"id":"notif_123","topic":"conversation.user.created","data":{"item":{"id":"conv_1"}}}`),
+			newRequest: newSignedIntercomRequest,
+		},
+	} {
+		t.Run(tc.provider, func(t *testing.T) {
+			eventStore := &capturingInboundEventStore{}
+			bus, err := runtimebus.NewEventBus(eventStore)
+			if err != nil {
+				t.Fatalf("NewEventBus: %v", err)
+			}
+			store := &recordingInboundStore{
+				target: InboundTarget{
+					EntityID:      "3fd8fc37-6d02-4d50-8bb7-14c6cb0fed0a",
+					EntitySlug:    "customer-a",
+					WebhookSecret: tc.secret,
+				},
+				inserted: false,
+			}
+			g := NewInboundGateway(bus, nil, nil, store)
+
+			req := tc.newRequest("/webhooks/customer-a/"+tc.provider, tc.secret, tc.body)
+			rec := httptest.NewRecorder()
+			g.Handler().ServeHTTP(rec, req)
+
+			if rec.Code != http.StatusOK {
+				t.Fatalf("status = %d, want 200 body=%s", rec.Code, rec.Body.String())
+			}
+			if !strings.Contains(rec.Body.String(), `"status":"duplicate"`) {
+				t.Fatalf("duplicate response = %s", rec.Body.String())
+			}
+			if len(eventStore.events) != 0 {
+				t.Fatalf("published events = %d, want 0", len(eventStore.events))
+			}
+		})
+	}
+}
+
+func TestInboundGateway_RawFallbackDoesNotInterpretTypeformOrIntercomSignatures(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		body      []byte
+		configure func(*http.Request, []byte)
+	}{
+		{
+			name: "typeform",
+			body: []byte(`{"event_id":"tf-evt-123","event_type":"form_response"}`),
+			configure: func(req *http.Request, body []byte) {
+				req.Header.Set("Typeform-Signature", typeformWebhookSignature("raw-secret", body))
+			},
+		},
+		{
+			name: "intercom",
+			body: []byte(`{"id":"notif_123","topic":"conversation.user.created"}`),
+			configure: func(req *http.Request, body []byte) {
+				req.Header.Set("X-Hub-Signature", intercomWebhookSignature("raw-secret", body))
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			eventStore := &capturingInboundEventStore{}
+			bus, err := runtimebus.NewEventBus(eventStore)
+			if err != nil {
+				t.Fatalf("NewEventBus: %v", err)
+			}
+			store := &recordingInboundStore{
+				target: InboundTarget{
+					EntityID:      "3fd8fc37-6d02-4d50-8bb7-14c6cb0fed0a",
+					EntitySlug:    "customer-a",
+					WebhookSecret: "raw-secret",
+				},
+				inserted: true,
+			}
+			g := NewInboundGateway(bus, nil, nil, store)
+
+			req := httptest.NewRequest(http.MethodPost, "/webhooks/customer-a/custom", strings.NewReader(string(tc.body)))
+			tc.configure(req, tc.body)
+			rec := httptest.NewRecorder()
+			g.Handler().ServeHTTP(rec, req)
+
+			if rec.Code != http.StatusUnauthorized {
+				t.Fatalf("status = %d, want 401 body=%s", rec.Code, rec.Body.String())
+			}
+			if store.recorded {
+				t.Fatalf("raw fallback accepted %s signature and recorded inbound marker", tc.name)
+			}
+			if len(eventStore.events) != 0 {
+				t.Fatalf("published events = %d, want 0", len(eventStore.events))
+			}
+		})
+	}
+}
+
 func TestInboundGateway_RawFallbackDoesNotInterpretShopifySignature(t *testing.T) {
 	eventStore := &capturingInboundEventStore{}
 	bus, err := runtimebus.NewEventBus(eventStore)
@@ -1511,6 +1879,30 @@ func shopifyWebhookSignature(secret string, body []byte) string {
 	mac := hmac.New(sha256.New, []byte(secret))
 	_, _ = mac.Write(body)
 	return base64.StdEncoding.EncodeToString(mac.Sum(nil))
+}
+
+func newSignedTypeformRequest(path string, secret string, body []byte) *http.Request {
+	req := httptest.NewRequest(http.MethodPost, path, strings.NewReader(string(body)))
+	req.Header.Set("Typeform-Signature", typeformWebhookSignature(secret, body))
+	return req
+}
+
+func typeformWebhookSignature(secret string, body []byte) string {
+	mac := hmac.New(sha256.New, []byte(secret))
+	_, _ = mac.Write(body)
+	return "sha256=" + base64.StdEncoding.EncodeToString(mac.Sum(nil))
+}
+
+func newSignedIntercomRequest(path string, secret string, body []byte) *http.Request {
+	req := httptest.NewRequest(http.MethodPost, path, strings.NewReader(string(body)))
+	req.Header.Set("X-Hub-Signature", intercomWebhookSignature(secret, body))
+	return req
+}
+
+func intercomWebhookSignature(secret string, body []byte) string {
+	mac := hmac.New(sha1.New, []byte(secret))
+	_, _ = mac.Write(body)
+	return "sha1=" + hex.EncodeToString(mac.Sum(nil))
 }
 
 type blockingInboundInterceptor struct {

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -5882,6 +5882,42 @@ tool_model:
         `X-Shopify-Topic` is the authoritative provider event type and is emitted in payload metadata as normalized
         `provider_event_type`. The canonical emitted Swarm event name is literal `inbound.shopify`, not a dynamic
         template. Missing topic fails before dedupe marker persistence.
+    - provider: typeform
+      issue: "#1733"
+      signature: >
+        Typeform webhook deliveries require a configured signing secret and a valid `Typeform-Signature` HMAC-SHA256
+        Base64 signature over the exact raw request body received by the API listener. The header value MUST use the
+        `sha256=` prefix. Missing signing secret, missing signature, invalid signature, or any parsed/re-encoded JSON
+        canonicalization mismatch fails before dedupe marker persistence and before event publish.
+      delivery_id: >
+        Payload `event_id` is the authoritative provider delivery id and dedupe-key input for configured Typeform
+        triggers. Missing `event_id` fails before dedupe marker persistence.
+      acknowledgement: >
+        Accepted Typeform deliveries return success after the inbound dedupe marker, canonical event record, recipient
+        manifest, and subscribed replay scope are durably persisted or dispatch-queued. The HTTP acknowledgement MUST NOT
+        wait for post-commit pipeline dispatch, system-node handler execution, or agent delivery completion.
+      event_type: >
+        Payload `event_type` is the authoritative provider event type and is emitted in payload metadata as normalized
+        `provider_event_type`. The canonical emitted Swarm event name is literal `inbound.typeform`, not a dynamic
+        template. Missing `event_type` fails before dedupe marker persistence.
+    - provider: intercom
+      issue: "#1733"
+      signature: >
+        Intercom webhook deliveries require a configured signing secret and a valid `X-Hub-Signature` HMAC-SHA1 hex
+        signature over the exact raw request body received by the API listener. The header value MUST use the `sha1=`
+        prefix. Missing signing secret, missing signature, invalid signature, or any parsed/re-encoded JSON
+        canonicalization mismatch fails before dedupe marker persistence and before event publish.
+      delivery_id: >
+        Payload `id` is the authoritative provider delivery id and dedupe-key input for configured Intercom triggers.
+        Missing `id` fails before dedupe marker persistence.
+      acknowledgement: >
+        Accepted Intercom deliveries return success after the inbound dedupe marker, canonical event record, recipient
+        manifest, and subscribed replay scope are durably persisted or dispatch-queued. The HTTP acknowledgement MUST NOT
+        wait for post-commit pipeline dispatch, system-node handler execution, or agent delivery completion.
+      event_type: >
+        Payload `topic` is the authoritative provider event type and is emitted in payload metadata as normalized
+        `provider_event_type`. The canonical emitted Swarm event name is literal `inbound.intercom`, not a dynamic
+        template. Missing `topic` fails before dedupe marker persistence.
     raw_webhook_mode: >
       Unknown providers may continue through the raw generic webhook mode, but that path is a different semantic concept and
       does not prove provider-trigger adapter closure. Configured providers MUST consume their manifest interpreter owner


### PR DESCRIPTION
## Summary

Closes #1733.
Part of #1651.
Related to #1736 and #1737.

Adds the approved zero-vocabulary configured-provider batch after Shopify:

- Typeform built-in trigger manifest.
- Intercom built-in trigger manifest.
- `platform-spec.yaml` configured-provider entries for both providers.
- Manifest-interpreter, gateway, duplicate, raw-fallback separation, SQLite, and Postgres proofs.

## Governing Context

Exact governing spec: `platform-spec.yaml` `provider_trigger_adapters`.

Binding issue context:

- #1733 Pre-Implementation Coverage Audit: https://github.com/division-sh/swarm/issues/1733#issuecomment-4888597497
- #1733 independent re-gate approval: https://github.com/division-sh/swarm/issues/1733#issuecomment-4888754188
- Parent #1651 freeze rule and provider-diversity ladder.

## Semantic Boundary

Canonical owner after this PR: `internal/providertriggers` built-in manifest interpreter.

This PR does not add manifest vocabulary, signed-payload recipes, timestamp semantics, runtime provider branches, Go provider adapters, OAuth, subscription setup, or #1724 pack-envelope work.

Old/non-authoritative paths remain invalid for configured Typeform/Intercom closure:

- raw generic webhook fallback;
- body-fingerprint dedupe fallback;
- runtime-local provider branches;
- dynamic event-name templates for new providers;
- parsed/re-encoded JSON signature verification.

Production paths checked for surviving old behavior:

- default manifest registry loading;
- `internal/runtime/inbound.go` gateway delegation to `internal/providertriggers`;
- raw fallback separation for Typeform and Intercom signatures;
- SQLite and Postgres inbound marker/event/delivery persistence.

Migration status: no semantic migration is introduced; this is additive configured-provider support inside the existing manifest owner.

## Validation

Using host Postgres:

```sh
export SWARM_TEST_POSTGRES_DSN='host=127.0.0.1 port=5432 user=youmew dbname=postgres sslmode=disable'
export PGPASSWORD=postgres
```

Proof run:

```sh
go test ./internal/providertriggers -run 'Typeform|Intercom|GitHub|Slack|Stripe|Twilio|Shopify|DefaultRegistry' -count=1 -v
go test ./internal/runtime -run 'Typeform|Intercom|GitHub|Slack|Stripe|Twilio|Shopify|Inbound' -count=1 -v
go test ./internal/providertriggers ./internal/runtime ./internal/apispec -count=1
go test ./...
```
