### PR TITLE
[agent-b][issue #1731] Add SWARM env accepted-set guard

### DIFF
--- a/cmd/swarm/api_consumption_boundary_test.go
+++ b/cmd/swarm/api_consumption_boundary_test.go
@@ -228,11 +228,17 @@ func TestCLIRuntimeStateCommandsRequireSharedAPITokenBeforeRequest(t *testing.T)
 
 			var stdout, stderr bytes.Buffer
 			code := executeRootCommandWithOptions(context.Background(), t.TempDir(), tc.args, &stdout, &stderr, testRootCommandOptions(server))
-			if code != cliExitAuth {
-				t.Fatalf("code = %d, want %d stdout=%s stderr=%s", code, cliExitAuth, stdout.String(), stderr.String())
+			if code != cliExitValidation {
+				t.Fatalf("code = %d, want %d stdout=%s stderr=%s", code, cliExitValidation, stdout.String(), stderr.String())
 			}
-			if !strings.Contains(stderr.String(), "API token source is required") {
-				t.Fatalf("stderr = %q, want shared missing-token error", stderr.String())
+			for _, want := range []string{
+				"env/known_retired: SWARM_BUILDER_AUTH_TOKEN",
+				"env/known_retired: SWARM_OPERATOR_AUTH_TOKEN",
+				"not accepted as API auth fallback",
+			} {
+				if !strings.Contains(stderr.String(), want) {
+					t.Fatalf("stderr missing %q:\n%s", want, stderr.String())
+				}
 			}
 			if calls.Load() != 0 {
 				t.Fatalf("server calls = %d, want 0 before auth", calls.Load())

--- a/cmd/swarm/cli.go
+++ b/cmd/swarm/cli.go
@@ -40,6 +40,12 @@ func executeRootCommandWithOptions(ctx context.Context, repo string, args []stri
 		}
 		return cliExitValidation
 	}
+	if err := validateSwarmEnvForCommand(args, repo); err != nil {
+		if errOut != nil {
+			fmt.Fprintln(errOut, err)
+		}
+		return cliExitValidation
+	}
 	cmd := newRootCommandWithOptions(ctx, repo, out, errOut, opts)
 	cmd.SetArgs(args)
 	if err := cmd.ExecuteContext(ctx); err != nil {

--- a/cmd/swarm/cli_target_resolution.go
+++ b/cmd/swarm/cli_target_resolution.go
@@ -36,8 +36,10 @@ type cliProjectResolution struct {
 }
 
 func resolveCLIAPITarget(opts rootCommandOptions, cfg cliAPIConfigFile) (cliAPITargetResolution, error) {
-	if err := rejectRemovedClientAPIEnvSources(); err != nil {
-		return cliAPITargetResolution{}, err
+	if opts.apiCommandClass != cliAPICommandClassTargetDiagnostic {
+		if err := rejectRemovedClientAPIEnvSources(); err != nil {
+			return cliAPITargetResolution{}, err
+		}
 	}
 	if endpoint := strings.TrimSpace(opts.apiRPCEndpointOverride); endpoint != "" {
 		rpc, err := normalizeCLIAPIRPCEndpoint(endpoint, "internal API endpoint")

--- a/cmd/swarm/doctor.go
+++ b/cmd/swarm/doctor.go
@@ -57,23 +57,6 @@ func newDoctorCommand(ctx context.Context, repo string) *cobra.Command {
 				opts.workspaceBackend = backend
 			}
 			opts.workspaceBackendSet = cmd.Flags().Changed("workspace-backend")
-			apiListenAddr, mcpListenAddr, err := resolveCLIServeListenerAddresses(cliServeListenerAddressOptions{
-				APIListenAddr:        opts.apiListenAddr,
-				MCPListenAddr:        opts.mcpListenAddr,
-				APIListenAddrFlagSet: cmd.Flags().Changed("api-listen-addr"),
-				MCPListenAddrFlagSet: cmd.Flags().Changed("mcp-listen-addr"),
-			})
-			if err != nil {
-				return err
-			}
-			opts.apiListenAddr = apiListenAddr
-			opts.mcpListenAddr = mcpListenAddr
-			if err := validateServeListenAddr("--api-listen-addr", opts.apiListenAddr); err != nil {
-				return err
-			}
-			if err := validateServeListenAddr("--mcp-listen-addr", opts.mcpListenAddr); err != nil {
-				return err
-			}
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -98,12 +81,18 @@ func runDoctorCommand(ctx context.Context, repo string, cmd *cobra.Command, opts
 	if opts.target {
 		return runDoctorTargetCommand(repo, cmd, opts)
 	}
+	envFindings := doctorSwarmEnvFindings(repo, opts.configPath)
+	newReport := func() localPreflightReport {
+		report := localPreflightReport{Owner: localPreflightOwner, Mode: "doctor"}
+		addSwarmEnvFindingsToLocalPreflightReport(&report, envFindings)
+		return report
+	}
 	resolvedPaths, err := resolveCLIContractPlatformSpecPaths(repo, cliContractPlatformSpecPathOptions{
 		ContractsPath:    opts.contractsPath,
 		PlatformSpecPath: opts.platformSpecPath,
 	})
 	if err != nil {
-		report := localPreflightReport{Owner: localPreflightOwner, Mode: "doctor"}
+		report := newReport()
 		report.add(localPreflightBackendPrerequisite, "path_resolution_failed", localPreflightSeverityBlocker, localPreflightStatusFailed, err.Error(), "fix --contracts or --platform-spec")
 		return returnLocalPreflightResult(cmd, report.finalize(), opts.asJSON)
 	}
@@ -113,30 +102,57 @@ func runDoctorCommand(ctx context.Context, repo string, cmd *cobra.Command, opts
 		BackendOverride: opts.backend,
 	})
 	if err != nil {
-		report := localPreflightReport{Owner: localPreflightOwner, Mode: "doctor"}
+		report := newReport()
 		report.add(localPreflightBackendPrerequisite, "config_load_failed", localPreflightSeverityBlocker, localPreflightStatusFailed, err.Error(), "fix --config, --backend, retired env vars, or llm.backend")
 		return returnLocalPreflightResult(cmd, report.finalize(), opts.asJSON)
 	}
 	providerPackLoad, err := loadConfiguredProviderTriggerPacks(repo, cfgResult)
 	if err != nil {
-		report := localPreflightReport{OK: true, Owner: localPreflightOwner, Mode: "doctor"}
+		report := newReport()
 		report.add(localPreflightProviderPackPrerequisite, "provider_trigger_pack_load_failed", localPreflightSeverityBlocker, localPreflightStatusFailed, err.Error(), "fix provider_triggers.packs.external_dirs or the referenced provider pack envelope")
+		return returnLocalPreflightResult(cmd, report.finalize(), opts.asJSON)
+	}
+	apiListenAddr, mcpListenAddr, err := resolveCLIServeListenerAddresses(cliServeListenerAddressOptions{
+		APIListenAddr:        opts.apiListenAddr,
+		MCPListenAddr:        opts.mcpListenAddr,
+		APIListenAddrFlagSet: cmd.Flags().Changed("api-listen-addr"),
+		MCPListenAddrFlagSet: cmd.Flags().Changed("mcp-listen-addr"),
+	})
+	if err != nil {
+		report := newReport()
+		report.add(localPreflightServeListenerPrerequisite, "listener_resolution_failed", localPreflightSeverityBlocker, localPreflightStatusFailed, err.Error(), "fix --api-listen-addr, --mcp-listen-addr, config listener addresses, or SWARM_CONFIG")
+		return returnLocalPreflightResult(cmd, report.finalize(), opts.asJSON)
+	}
+	opts.apiListenAddr = apiListenAddr
+	opts.mcpListenAddr = mcpListenAddr
+	if err := validateServeListenAddr("--api-listen-addr", opts.apiListenAddr); err != nil {
+		report := newReport()
+		report.add(localPreflightServeListenerPrerequisite, "api_listener_invalid", localPreflightSeverityBlocker, localPreflightStatusFailed, err.Error(), "fix --api-listen-addr or config serve_api_listen_addr")
+		return returnLocalPreflightResult(cmd, report.finalize(), opts.asJSON)
+	}
+	if err := validateServeListenAddr("--mcp-listen-addr", opts.mcpListenAddr); err != nil {
+		report := newReport()
+		report.add(localPreflightServeListenerPrerequisite, "mcp_listener_invalid", localPreflightSeverityBlocker, localPreflightStatusFailed, err.Error(), "fix --mcp-listen-addr or config serve_mcp_listen_addr")
 		return returnLocalPreflightResult(cmd, report.finalize(), opts.asJSON)
 	}
 	workspaceBackend, err := resolveWorkspaceBackend(opts.workspaceBackend, opts.workspaceBackendSet, cfgResult.Config)
 	if err != nil {
-		report := localPreflightReport{Owner: localPreflightOwner, Mode: "doctor"}
+		report := newReport()
 		report.add(localPreflightWorkspacePrerequisite, "workspace_backend_invalid", localPreflightSeverityBlocker, localPreflightStatusFailed, err.Error(), "fix --workspace-backend, workspace.backend, or SWARM_WORKSPACE_BACKEND")
 		return returnLocalPreflightResult(cmd, report.finalize(), opts.asJSON)
 	}
 	cliCfg, err := loadCLIAPIConfigFile()
 	if err != nil {
-		return returnCLIValidationError(cmd.ErrOrStderr(), err)
+		report := newReport()
+		report.add(localPreflightBackendPrerequisite, "cli_config_load_failed", localPreflightSeverityBlocker, localPreflightStatusFailed, err.Error(), "fix SWARM_CONFIG or the CLI config file")
+		return returnLocalPreflightResult(cmd, report.finalize(), opts.asJSON)
 	}
 	swarmDirFlag, swarmDirFlagSet := rootSwarmDirFlag(cmd)
 	swarmDir, err := resolveCLISwarmDirFromConfig(cliSwarmDirOptions{SwarmDir: swarmDirFlag, SwarmDirFlagSet: swarmDirFlagSet}, cliCfg)
 	if err != nil {
-		return returnCLIValidationError(cmd.ErrOrStderr(), err)
+		report := newReport()
+		report.add(localPreflightBackendPrerequisite, "swarm_dir_resolution_failed", localPreflightSeverityBlocker, localPreflightStatusFailed, err.Error(), "fix --swarm-dir or CLI config swarm_dir")
+		return returnLocalPreflightResult(cmd, report.finalize(), opts.asJSON)
 	}
 	localState, err := resolveLocalRuntimeState(localRuntimeStateOptions{
 		RepoRoot:                repo,
@@ -147,7 +163,7 @@ func runDoctorCommand(ctx context.Context, repo string, cmd *cobra.Command, opts
 		CreateDefaultDataSource: true,
 	})
 	if err != nil {
-		report := localPreflightReport{Owner: localPreflightOwner, Mode: "doctor"}
+		report := newReport()
 		report.add(localPreflightWorkspacePrerequisite, "workspace_data_source_invalid", localPreflightSeverityBlocker, localPreflightStatusFailed, err.Error(), "fix --data, workspace.data_source, or SWARM_WORKSPACE_DATA_SOURCE")
 		return returnLocalPreflightResult(cmd, report.finalize(), opts.asJSON)
 	}
@@ -167,5 +183,6 @@ func runDoctorCommand(ctx context.Context, repo string, cmd *cobra.Command, opts
 		ContractSecretSeverity: localPreflightCommandSeverityForContractSecrets("doctor"),
 	})
 	appendProviderTriggerPackSurfaceFindings(&report, providerPackLoad.Loaded)
+	addSwarmEnvFindingsToLocalPreflightReport(&report, envFindings)
 	return returnLocalPreflightResult(cmd, report.finalize(), opts.asJSON)
 }

--- a/cmd/swarm/doctor_test.go
+++ b/cmd/swarm/doctor_test.go
@@ -257,7 +257,7 @@ func TestDoctorClaudeCLIPreflightReportsRetiredBackendEnv(t *testing.T) {
 	}
 }
 
-func TestDoctorClaudeCLIPreflightWarnsOnRetiredGatewayEnv(t *testing.T) {
+func TestDoctorClaudeCLIPreflightBlocksGeneratedGatewayParentEnv(t *testing.T) {
 	configureDoctorDockerStub(t)
 	setDoctorProviderSecret(t, "CLAUDE_CODE_OAUTH_TOKEN", "oauth-token")
 	t.Setenv("SWARM_TOOL_GATEWAY_TOKEN", "operator-token")
@@ -270,10 +270,13 @@ func TestDoctorClaudeCLIPreflightWarnsOnRetiredGatewayEnv(t *testing.T) {
 	args = append(args[:len(args)-4], "--api-listen-addr", "127.0.0.1:0", "--mcp-listen-addr", "127.0.0.1:"+mcpPort)
 	var stdout, stderr bytes.Buffer
 	code := executeRootCommandWithOptions(context.Background(), repoRoot(), args, &stdout, &stderr, defaultRootCommandOptions())
-	if code != cliExitOK {
-		t.Fatalf("code = %d, want %d stdout=%s stderr=%s", code, cliExitOK, stdout.String(), stderr.String())
+	if code != cliExitRuntime {
+		t.Fatalf("code = %d, want %d stdout=%s stderr=%s", code, cliExitRuntime, stdout.String(), stderr.String())
 	}
 	for _, want := range []string{
+		"[BLOCKER] env/generated_boundary: SWARM_TOOL_GATEWAY_URL",
+		"[BLOCKER] env/generated_boundary: SWARM_TOOL_GATEWAY_CONTAINER_URL",
+		"[BLOCKER] env/known_retired: SWARM_TOOL_GATEWAY_TOKEN",
 		"[WARNING] gateway_prerequisite/swarm_tool_gateway_url_retired",
 		"[WARNING] gateway_prerequisite/swarm_tool_gateway_container_url_retired",
 		"SWARM_TOOL_GATEWAY_URL is retired and not accepted as gateway endpoint configuration",
@@ -399,7 +402,7 @@ func TestDoctorTargetJSONReportsMissingAuthWithoutAborting(t *testing.T) {
 	}
 }
 
-func TestDoctorTargetRejectsRemovedAPIClientEnv(t *testing.T) {
+func TestDoctorTargetReportsRemovedAPIClientEnv(t *testing.T) {
 	isolateCLIAPIConfigEnv(t)
 	repo := writeDoctorTargetRepo(t)
 	t.Setenv("SWARM_API_SERVER", "http://127.0.0.1:19002")
@@ -408,20 +411,25 @@ func TestDoctorTargetRejectsRemovedAPIClientEnv(t *testing.T) {
 
 	var stdout, stderr bytes.Buffer
 	code := executeRootCommandWithOptions(context.Background(), repo, []string{
-		"doctor", "--target",
+		"doctor", "--target", "--json",
 		"--contracts", filepath.Join(repo, "contracts"),
 	}, &stdout, &stderr, defaultRootCommandOptions())
-	if code != cliExitValidation {
-		t.Fatalf("code = %d, want %d stdout=%s stderr=%s", code, cliExitValidation, stdout.String(), stderr.String())
+	if code != cliExitRuntime {
+		t.Fatalf("code = %d, want %d stdout=%s stderr=%s", code, cliExitRuntime, stdout.String(), stderr.String())
 	}
-	for _, want := range []string{"client-side API environment sources are no longer accepted", "SWARM_API_SERVER", "SWARM_API_TOKEN", "SWARM_API_TOKEN_FILE", "--api-server", "--api-token-file"} {
-		if !strings.Contains(stderr.String(), want) {
-			t.Fatalf("stderr missing %q:\n%s", want, stderr.String())
-		}
+	if stderr.String() != "" {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
 	}
-	if stdout.String() != "" {
-		t.Fatalf("stdout = %q, want empty", stdout.String())
+	var report doctorTargetReport
+	if err := json.Unmarshal(stdout.Bytes(), &report); err != nil {
+		t.Fatalf("parse target json: %v\n%s", err, stdout.String())
 	}
+	if report.OK {
+		t.Fatalf("report OK=true, want env blockers: %#v", report)
+	}
+	assertDoctorTargetEnvFinding(t, report, string(swarmEnvCategoryKnownRetired), "SWARM_API_SERVER")
+	assertDoctorTargetEnvFinding(t, report, string(swarmEnvCategoryKnownRetired), "SWARM_API_TOKEN")
+	assertDoctorTargetEnvFinding(t, report, string(swarmEnvCategoryKnownRetired), "SWARM_API_TOKEN_FILE")
 }
 
 func TestDoctorTargetUsesResolvedSwarmDirForExplicitContext(t *testing.T) {

--- a/cmd/swarm/env_authority_test.go
+++ b/cmd/swarm/env_authority_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
@@ -287,6 +288,459 @@ func TestPlatformSpecIssue1640EnvClassificationCoversRetainedSlice(t *testing.T)
 	}
 }
 
+func TestRepoWideSwarmEnvAcceptedSetMatchesSpec(t *testing.T) {
+	var spec struct {
+		EnvironmentSourceAuthority struct {
+			RepoWideSwarmEnvAcceptedSet struct {
+				PromotedBy           string   `yaml:"promoted_by"`
+				ParentTracker        string   `yaml:"parent_tracker"`
+				ImplementationStatus string   `yaml:"implementation_status"`
+				CanonicalOwner       string   `yaml:"canonical_owner"`
+				SourceAuthorityRule  string   `yaml:"source_authority_rule"`
+				Categories           []string `yaml:"categories"`
+				AcceptedEnv          []struct {
+					Name      string `yaml:"name"`
+					Prefix    string `yaml:"prefix"`
+					Category  string `yaml:"category"`
+					Owner     string `yaml:"owner"`
+					Migration string `yaml:"migration"`
+				} `yaml:"accepted_env"`
+			} `yaml:"repo_wide_swarm_env_accepted_set"`
+		} `yaml:"environment_source_authority"`
+	}
+	data, err := os.ReadFile(filepath.Join(repoRoot(), defaultPlatformSpecPath))
+	if err != nil {
+		t.Fatalf("read platform spec: %v", err)
+	}
+	if err := yaml.Unmarshal(data, &spec); err != nil {
+		t.Fatalf("parse platform spec: %v", err)
+	}
+
+	authority := spec.EnvironmentSourceAuthority.RepoWideSwarmEnvAcceptedSet
+	if authority.PromotedBy != "#1731" || authority.ParentTracker != "#1600" || authority.ImplementationStatus != "implemented_first_slice" {
+		t.Fatalf("#1731 env authority status = promoted_by:%q parent:%q status:%q", authority.PromotedBy, authority.ParentTracker, authority.ImplementationStatus)
+	}
+	if authority.CanonicalOwner != swarmEnvAuthorityOwner {
+		t.Fatalf("#1731 canonical owner = %q, want %q", authority.CanonicalOwner, swarmEnvAuthorityOwner)
+	}
+	for _, want := range []string{"no ambient source authority", "typed delegation", "doctor", "generated-boundary", "fail closed"} {
+		if !strings.Contains(authority.SourceAuthorityRule, want) {
+			t.Fatalf("#1731 source authority rule missing %q:\n%s", want, authority.SourceAuthorityRule)
+		}
+	}
+
+	specCategories := map[string]bool{}
+	for _, category := range authority.Categories {
+		if specCategories[category] {
+			t.Fatalf("#1731 duplicate category %q", category)
+		}
+		specCategories[category] = true
+	}
+	for _, category := range []swarmEnvCategory{
+		swarmEnvCategoryBootstrap,
+		swarmEnvCategoryTypedDelegation,
+		swarmEnvCategoryGeneratedBoundary,
+		swarmEnvCategoryTestQuarantine,
+		swarmEnvCategorySeededLegacy,
+		swarmEnvCategoryKnownRetired,
+		swarmEnvCategoryUnknownStale,
+	} {
+		if !specCategories[string(category)] {
+			t.Fatalf("#1731 spec missing category %q: %#v", category, authority.Categories)
+		}
+	}
+
+	specRows := map[string]struct {
+		Category  string
+		Owner     string
+		Migration string
+	}{}
+	for _, row := range authority.AcceptedEnv {
+		key := specSwarmEnvRowKey(row.Name, row.Prefix)
+		if key == "" {
+			t.Fatalf("#1731 accepted env row has neither name nor prefix: %#v", row)
+		}
+		if specRows[key].Category != "" {
+			t.Fatalf("#1731 duplicate accepted env row %q", key)
+		}
+		if !specCategories[row.Category] {
+			t.Fatalf("#1731 row %q uses unknown category %q", key, row.Category)
+		}
+		if strings.TrimSpace(row.Owner) == "" || strings.TrimSpace(row.Migration) == "" {
+			t.Fatalf("#1731 row %q missing owner/migration: %#v", key, row)
+		}
+		if row.Category == string(swarmEnvCategorySeededLegacy) && !strings.Contains(row.Migration, "#") && !strings.Contains(row.Migration, "config") && !strings.Contains(row.Migration, "--") {
+			t.Fatalf("#1731 seeded legacy row %q missing migration pointer: %#v", key, row)
+		}
+		specRows[key] = struct {
+			Category  string
+			Owner     string
+			Migration string
+		}{Category: row.Category, Owner: row.Owner, Migration: row.Migration}
+	}
+
+	codeRows := map[string]swarmEnvCatalogEntry{}
+	for _, entry := range swarmEnvCatalogEntries() {
+		key := catalogSwarmEnvRowKey(entry)
+		if key == "" {
+			t.Fatalf("code catalog entry has neither name nor prefix: %#v", entry)
+		}
+		if _, ok := codeRows[key]; ok {
+			t.Fatalf("code catalog duplicate row %q", key)
+		}
+		codeRows[key] = entry
+	}
+	for key, entry := range codeRows {
+		row, ok := specRows[key]
+		if !ok {
+			t.Fatalf("code catalog row %q missing from #1731 spec", key)
+		}
+		if row.Category != string(entry.Category) || row.Owner != entry.Owner || row.Migration != entry.Migration {
+			t.Fatalf("#1731 spec row %q mismatch\nspec: %#v\ncode: %#v", key, row, entry)
+		}
+	}
+	for key := range specRows {
+		if _, ok := codeRows[key]; !ok {
+			t.Fatalf("#1731 spec row %q missing from code catalog", key)
+		}
+	}
+}
+
+func TestSwarmEnvGuardBlocksUnknownWithSuggestion(t *testing.T) {
+	isolateCLIAPIConfigEnv(t)
+	t.Setenv("SWARM_WORSKPACE_IMAGE", "stale")
+
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), repoRoot(), []string{
+		"serve",
+		"--api-listen-addr", "127.0.0.1:0",
+		"--mcp-listen-addr", "127.0.0.1:0",
+	}, &stdout, &stderr, defaultRootCommandOptions())
+	if code != cliExitValidation {
+		t.Fatalf("code = %d, want %d stdout=%s stderr=%s", code, cliExitValidation, stdout.String(), stderr.String())
+	}
+	for _, want := range []string{
+		"[BLOCKER] env/unknown_stale: SWARM_WORSKPACE_IMAGE",
+		"did you mean SWARM_WORKSPACE_IMAGE",
+		"unset SWARM_WORSKPACE_IMAGE",
+	} {
+		if !strings.Contains(stderr.String(), want) {
+			t.Fatalf("stderr missing %q:\n%s", want, stderr.String())
+		}
+	}
+}
+
+func TestSwarmEnvGuardSkipsPureVersionAndCompletion(t *testing.T) {
+	isolateCLIAPIConfigEnv(t)
+	t.Setenv("SWARM_WORSKPACE_IMAGE", "stale")
+
+	for _, args := range [][]string{
+		{"version"},
+		{"completion", "bash"},
+	} {
+		var stdout, stderr bytes.Buffer
+		code := executeRootCommandWithOptions(context.Background(), repoRoot(), args, &stdout, &stderr, defaultRootCommandOptions())
+		if code != cliExitOK {
+			t.Fatalf("%v code = %d, want %d stdout=%s stderr=%s", args, code, cliExitOK, stdout.String(), stderr.String())
+		}
+		if strings.Contains(stdout.String()+stderr.String(), "SWARM_WORSKPACE_IMAGE") {
+			t.Fatalf("%v should skip env guard, got stdout=%s stderr=%s", args, stdout.String(), stderr.String())
+		}
+	}
+}
+
+func TestSwarmEnvGuardSkipsPureSubcommandHelpFlags(t *testing.T) {
+	isolateCLIAPIConfigEnv(t)
+	t.Setenv("SWARM_WORSKPACE_IMAGE", "stale")
+
+	for _, args := range [][]string{
+		{"event", "publish", "--help"},
+		{"run", "start", "--help"},
+		{"run", "start", "-h"},
+	} {
+		t.Run(strings.Join(args, " "), func(t *testing.T) {
+			var stdout, stderr bytes.Buffer
+			code := executeRootCommandWithOptions(context.Background(), repoRoot(), args, &stdout, &stderr, defaultRootCommandOptions())
+			if code != cliExitOK {
+				t.Fatalf("%v code = %d, want %d stdout=%s stderr=%s", args, code, cliExitOK, stdout.String(), stderr.String())
+			}
+			output := stdout.String() + stderr.String()
+			if strings.Contains(output, "SWARM_WORSKPACE_IMAGE") {
+				t.Fatalf("%v should skip env guard, got stdout=%s stderr=%s", args, stdout.String(), stderr.String())
+			}
+			if !strings.Contains(output, "Usage:") {
+				t.Fatalf("%v help output missing Usage: stdout=%s stderr=%s", args, stdout.String(), stderr.String())
+			}
+		})
+	}
+}
+
+func TestSwarmEnvGuardDoesNotSkipWhenHelpIsCommandData(t *testing.T) {
+	isolateCLIAPIConfigEnv(t)
+	t.Setenv("SWARM_WORSKPACE_IMAGE", "stale")
+
+	cases := []struct {
+		name string
+		args []string
+	}{
+		{
+			name: "positional help",
+			args: []string{"event", "publish", "help", "--payload-json", "{}"},
+		},
+		{
+			name: "double dash help data",
+			args: []string{"event", "publish", "--payload-json", "{}", "--", "--help"},
+		},
+		{
+			name: "flag value help data",
+			args: []string{"event", "publish", "--payload-json", "--help"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var stdout, stderr bytes.Buffer
+			code := executeRootCommandWithOptions(context.Background(), repoRoot(), tc.args, &stdout, &stderr, defaultRootCommandOptions())
+			if code != cliExitValidation {
+				t.Fatalf("code = %d, want %d stdout=%s stderr=%s", code, cliExitValidation, stdout.String(), stderr.String())
+			}
+			for _, want := range []string{
+				"[BLOCKER] env/unknown_stale: SWARM_WORSKPACE_IMAGE",
+				"did you mean SWARM_WORKSPACE_IMAGE",
+			} {
+				if !strings.Contains(stderr.String(), want) {
+					t.Fatalf("stderr missing %q:\n%s", want, stderr.String())
+				}
+			}
+		})
+	}
+}
+
+func TestSwarmEnvGuardDoesNotSkipVersionServerEqualsTrue(t *testing.T) {
+	isolateCLIAPIConfigEnv(t)
+	t.Setenv("SWARM_WORSKPACE_IMAGE", "stale")
+
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), repoRoot(), []string{
+		"version",
+		"--server=true",
+		"--api-server", "http://127.0.0.1:9",
+	}, &stdout, &stderr, defaultRootCommandOptions())
+	if code != cliExitValidation {
+		t.Fatalf("code = %d, want %d stdout=%s stderr=%s", code, cliExitValidation, stdout.String(), stderr.String())
+	}
+	for _, want := range []string{
+		"[BLOCKER] env/unknown_stale: SWARM_WORSKPACE_IMAGE",
+		"did you mean SWARM_WORKSPACE_IMAGE",
+	} {
+		if !strings.Contains(stderr.String(), want) {
+			t.Fatalf("stderr missing %q:\n%s", want, stderr.String())
+		}
+	}
+}
+
+func TestSwarmEnvGuardBlocksGeneratedBoundaryParentEnv(t *testing.T) {
+	isolateCLIAPIConfigEnv(t)
+	t.Setenv("SWARM_TOOL_GATEWAY_URL", "http://127.0.0.1:19002")
+
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), repoRoot(), []string{
+		"serve",
+		"--api-listen-addr", "127.0.0.1:0",
+		"--mcp-listen-addr", "127.0.0.1:0",
+	}, &stdout, &stderr, defaultRootCommandOptions())
+	if code != cliExitValidation {
+		t.Fatalf("code = %d, want %d stdout=%s stderr=%s", code, cliExitValidation, stdout.String(), stderr.String())
+	}
+	for _, want := range []string{
+		"[BLOCKER] env/generated_boundary: SWARM_TOOL_GATEWAY_URL",
+		"generated final-boundary env must be injected by Swarm",
+		"unset SWARM_TOOL_GATEWAY_URL",
+	} {
+		if !strings.Contains(stderr.String(), want) {
+			t.Fatalf("stderr missing %q:\n%s", want, stderr.String())
+		}
+	}
+}
+
+func TestSwarmEnvGuardAllowsTypedDatabasePasswordEnvDelegation(t *testing.T) {
+	isolateCLIAPIConfigEnv(t)
+	t.Setenv("SWARM_DB_PASSWORD", "secret")
+	configPath := filepath.Join(t.TempDir(), "runtime.yaml")
+	writeWorkflowValidationFixtureFile(t, configPath, "database:\n  password_env: SWARM_DB_PASSWORD\n")
+
+	called := false
+	opts := defaultRootCommandOptions()
+	opts.runServe = func(_ context.Context, _ string, _ serveOptions) int {
+		called = true
+		return 0
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), repoRoot(), []string{
+		"serve",
+		"--config", configPath,
+		"--api-listen-addr", "127.0.0.1:0",
+		"--mcp-listen-addr", "127.0.0.1:0",
+	}, &stdout, &stderr, opts)
+	if code != cliExitOK {
+		t.Fatalf("code = %d, want %d stdout=%s stderr=%s", code, cliExitOK, stdout.String(), stderr.String())
+	}
+	if !called {
+		t.Fatalf("serve callback was not called; stdout=%s stderr=%s", stdout.String(), stderr.String())
+	}
+}
+
+func TestSwarmEnvGuardAllowsExecutableAdjacentTypedDatabasePasswordEnvDelegation(t *testing.T) {
+	isolateCLIAPIConfigEnv(t)
+	t.Setenv("SWARM_DB_PASSWORD", "secret")
+	binDir := t.TempDir()
+	writeWorkflowValidationFixtureFile(t, filepath.Join(binDir, "config.yaml"), "database:\n  password_env: SWARM_DB_PASSWORD\n")
+	originalExecutablePath := runtimeConfigExecutablePath
+	runtimeConfigExecutablePath = func() (string, error) {
+		return filepath.Join(binDir, "swarm"), nil
+	}
+	t.Cleanup(func() { runtimeConfigExecutablePath = originalExecutablePath })
+
+	called := false
+	opts := defaultRootCommandOptions()
+	opts.runServe = func(_ context.Context, _ string, _ serveOptions) int {
+		called = true
+		return 0
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), repoRoot(), []string{
+		"serve",
+		"--api-listen-addr", "127.0.0.1:0",
+		"--mcp-listen-addr", "127.0.0.1:0",
+	}, &stdout, &stderr, opts)
+	if code != cliExitOK {
+		t.Fatalf("code = %d, want %d stdout=%s stderr=%s", code, cliExitOK, stdout.String(), stderr.String())
+	}
+	if !called {
+		t.Fatalf("serve callback was not called; stdout=%s stderr=%s", stdout.String(), stderr.String())
+	}
+}
+
+func TestSwarmEnvGuardEmptyRetiredEnvUsesNonEmptyBoundary(t *testing.T) {
+	isolateCLIAPIConfigEnv(t)
+	t.Setenv("SWARM_RUNTIME_MAX_CONCURRENT_AGENTS", "")
+	t.Setenv("SWARM_LLM_BACKEND", "")
+
+	called := false
+	opts := defaultRootCommandOptions()
+	opts.runServe = func(_ context.Context, _ string, _ serveOptions) int {
+		called = true
+		return 0
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), repoRoot(), []string{
+		"serve",
+		"--api-listen-addr", "127.0.0.1:0",
+		"--mcp-listen-addr", "127.0.0.1:0",
+	}, &stdout, &stderr, opts)
+	if code != cliExitOK {
+		t.Fatalf("code = %d, want %d stdout=%s stderr=%s", code, cliExitOK, stdout.String(), stderr.String())
+	}
+	if !called {
+		t.Fatalf("serve callback was not called; stdout=%s stderr=%s", stdout.String(), stderr.String())
+	}
+}
+
+func TestDoctorReportsSwarmEnvFindingsWithConfigFailure(t *testing.T) {
+	isolateCLIAPIConfigEnv(t)
+	t.Setenv("SWARM_WORSKPACE_IMAGE", "stale")
+	contractsRoot := writeEnvAuthorityContractsFixture(t, "doctor-env-report")
+
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), repoRoot(), []string{
+		"doctor",
+		"--json",
+		"--config", filepath.Join(t.TempDir(), "missing-runtime.yaml"),
+		"--contracts", contractsRoot,
+		"--platform-spec", defaultPlatformSpecPath,
+	}, &stdout, &stderr, defaultRootCommandOptions())
+	if code != cliExitRuntime {
+		t.Fatalf("code = %d, want %d stdout=%s stderr=%s", code, cliExitRuntime, stdout.String(), stderr.String())
+	}
+	var report localPreflightReport
+	if err := json.Unmarshal(stdout.Bytes(), &report); err != nil {
+		t.Fatalf("parse doctor JSON: %v\nstdout=%s\nstderr=%s", err, stdout.String(), stderr.String())
+	}
+	if report.OK {
+		t.Fatalf("doctor report OK=true, want blockers: %#v", report)
+	}
+	assertLocalPreflightFinding(t, report, localPreflightEnvPrerequisite, string(swarmEnvCategoryUnknownStale), "SWARM_WORSKPACE_IMAGE")
+	assertLocalPreflightFinding(t, report, localPreflightBackendPrerequisite, "config_load_failed", "missing-runtime.yaml")
+}
+
+func TestDoctorTargetReportsSwarmEnvFindings(t *testing.T) {
+	isolateCLIAPIConfigEnv(t)
+	t.Setenv("SWARM_WORSKPACE_IMAGE", "stale")
+	repo := writeDoctorTargetRepo(t)
+
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), repo, []string{
+		"doctor",
+		"--target",
+		"--json",
+		"--contracts", filepath.Join(repo, "contracts"),
+	}, &stdout, &stderr, defaultRootCommandOptions())
+	if code != cliExitRuntime {
+		t.Fatalf("code = %d, want %d stdout=%s stderr=%s", code, cliExitRuntime, stdout.String(), stderr.String())
+	}
+	if stderr.String() != "" {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+	var report doctorTargetReport
+	if err := json.Unmarshal(stdout.Bytes(), &report); err != nil {
+		t.Fatalf("parse doctor target JSON: %v\nstdout=%s\nstderr=%s", err, stdout.String(), stderr.String())
+	}
+	if report.OK {
+		t.Fatalf("doctor target report OK=true, want env blocker: %#v", report)
+	}
+	assertDoctorTargetEnvFinding(t, report, string(swarmEnvCategoryUnknownStale), "SWARM_WORSKPACE_IMAGE")
+}
+
+func TestDoctorTargetReportsRuntimeConfigEnvRejectors(t *testing.T) {
+	cases := []string{
+		"SWARM_LLM_BACKEND",
+		"SWARM_RUNTIME_MAX_CONCURRENT_AGENTS",
+		"SWARM_OPENAI_COMPATIBLE_BASE_URL",
+		"SWARM_OPENAI_COMPATIBLE_DEFAULT_MODEL",
+	}
+	for _, envName := range cases {
+		t.Run(envName, func(t *testing.T) {
+			isolateCLIAPIConfigEnv(t)
+			t.Setenv(envName, "stale")
+			repo := writeDoctorTargetRepo(t)
+
+			var stdout, stderr bytes.Buffer
+			code := executeRootCommandWithOptions(context.Background(), repo, []string{
+				"doctor",
+				"--target",
+				"--json",
+				"--contracts", filepath.Join(repo, "contracts"),
+			}, &stdout, &stderr, defaultRootCommandOptions())
+			if code != cliExitRuntime {
+				t.Fatalf("code = %d, want %d stdout=%s stderr=%s", code, cliExitRuntime, stdout.String(), stderr.String())
+			}
+			if stderr.String() != "" {
+				t.Fatalf("stderr = %q, want empty", stderr.String())
+			}
+			var report doctorTargetReport
+			if err := json.Unmarshal(stdout.Bytes(), &report); err != nil {
+				t.Fatalf("parse doctor target JSON: %v\nstdout=%s\nstderr=%s", err, stdout.String(), stderr.String())
+			}
+			if report.OK {
+				t.Fatalf("doctor target report OK=true, want env blocker: %#v", report)
+			}
+			assertDoctorTargetEnvFinding(t, report, string(swarmEnvCategoryKnownRetired), envName)
+		})
+	}
+}
+
 func writeEnvAuthorityRepoWithMalformedDotEnv(t *testing.T) string {
 	t.Helper()
 	repo := t.TempDir()
@@ -318,6 +772,43 @@ terminal_states:
 	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "nodes.yaml"), "{}\n")
 	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "events.yaml"), "{}\n")
 	return root
+}
+
+func specSwarmEnvRowKey(name, prefix string) string {
+	name = strings.TrimSpace(name)
+	prefix = strings.TrimSpace(prefix)
+	switch {
+	case name != "" && prefix == "":
+		return "name:" + name
+	case prefix != "" && name == "":
+		return "prefix:" + prefix
+	default:
+		return ""
+	}
+}
+
+func catalogSwarmEnvRowKey(entry swarmEnvCatalogEntry) string {
+	return specSwarmEnvRowKey(entry.Name, entry.Prefix)
+}
+
+func assertLocalPreflightFinding(t *testing.T, report localPreflightReport, category localPreflightCategory, code, messagePart string) {
+	t.Helper()
+	for _, finding := range report.Findings {
+		if finding.Category == category && finding.Code == code && strings.Contains(finding.Message, messagePart) {
+			return
+		}
+	}
+	t.Fatalf("missing finding category=%s code=%s message containing %q: %#v", category, code, messagePart, report.Findings)
+}
+
+func assertDoctorTargetEnvFinding(t *testing.T, report doctorTargetReport, code, messagePart string) {
+	t.Helper()
+	for _, finding := range report.Env {
+		if finding.Category == localPreflightEnvPrerequisite && finding.Code == code && strings.Contains(finding.Message, messagePart) {
+			return
+		}
+	}
+	t.Fatalf("missing target env finding code=%s message containing %q: %#v", code, messagePart, report.Env)
 }
 
 func assertNoDotEnvLoadFailure(t testing.TB, output string) {

--- a/cmd/swarm/env_guard.go
+++ b/cmd/swarm/env_guard.go
@@ -1,0 +1,651 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+const (
+	swarmEnvAuthorityOwner = "platform-spec.yaml#environment_source_authority.repo_wide_swarm_env_accepted_set"
+	swarmTestHarnessEnv    = "SWARM_TEST_HARNESS"
+)
+
+type swarmEnvCategory string
+
+const (
+	swarmEnvCategoryBootstrap         swarmEnvCategory = "bootstrap"
+	swarmEnvCategoryTypedDelegation   swarmEnvCategory = "typed_delegation"
+	swarmEnvCategoryGeneratedBoundary swarmEnvCategory = "generated_boundary"
+	swarmEnvCategoryTestQuarantine    swarmEnvCategory = "test_quarantine"
+	swarmEnvCategorySeededLegacy      swarmEnvCategory = "seeded_legacy"
+	swarmEnvCategoryKnownRetired      swarmEnvCategory = "known_retired"
+	swarmEnvCategoryUnknownStale      swarmEnvCategory = "unknown_stale"
+)
+
+type swarmEnvCatalogEntry struct {
+	Name        string
+	Prefix      string
+	Category    swarmEnvCategory
+	Owner       string
+	Migration   string
+	Message     string
+	Remediation string
+}
+
+type swarmEnvFinding struct {
+	Name        string           `json:"name"`
+	Category    swarmEnvCategory `json:"category"`
+	Severity    string           `json:"severity"`
+	AcceptedBy  string           `json:"accepted_by,omitempty"`
+	Message     string           `json:"message"`
+	Remediation string           `json:"remediation,omitempty"`
+	Owner       string           `json:"owner"`
+}
+
+type swarmEnvGuardError struct {
+	findings []swarmEnvFinding
+}
+
+func (e swarmEnvGuardError) Error() string {
+	if len(e.findings) == 0 {
+		return ""
+	}
+	lines := []string{"environment source authority blockers:"}
+	for _, finding := range e.findings {
+		lines = append(lines, formatSwarmEnvFinding(finding))
+	}
+	return strings.Join(lines, "\n")
+}
+
+func formatSwarmEnvFinding(finding swarmEnvFinding) string {
+	severity := strings.ToUpper(strings.TrimSpace(finding.Severity))
+	if severity == "" {
+		severity = "INFO"
+	}
+	line := fmt.Sprintf("[%s] env/%s: %s - %s", severity, finding.Category, finding.Name, finding.Message)
+	if remediation := strings.TrimSpace(finding.Remediation); remediation != "" {
+		line += "\n  remediation: " + remediation
+	}
+	return line
+}
+
+func validateSwarmEnvForCommand(args []string, repoRoot string) error {
+	if shouldSkipSwarmEnvGuard(args) {
+		return nil
+	}
+	findings := collectSwarmEnvFindings(swarmEnvGuardContext{
+		RepoRoot:          repoRoot,
+		Args:              args,
+		RuntimeConfigPath: runtimeConfigPathFromArgs(args),
+	})
+	blockers := swarmEnvBlockers(findings)
+	if len(blockers) == 0 {
+		return nil
+	}
+	return swarmEnvGuardError{findings: blockers}
+}
+
+func shouldSkipSwarmEnvGuard(args []string) bool {
+	if len(args) == 0 {
+		return true
+	}
+	if isPureHelpFlagRequest(args) {
+		return true
+	}
+	command := firstSwarmCommandArg(args)
+	switch command {
+	case "", "help", "completion", "doctor":
+		return true
+	case "version":
+		return !versionServerRequested(args)
+	default:
+		return false
+	}
+}
+
+func isPureHelpFlagRequest(args []string) bool {
+	consumeNext := false
+	for _, raw := range args {
+		arg := strings.TrimSpace(raw)
+		if arg == "" {
+			continue
+		}
+		if arg == "--" {
+			return false
+		}
+		if consumeNext {
+			consumeNext = false
+			continue
+		}
+		switch arg {
+		case "-h", "--help":
+			return true
+		}
+		if swarmEnvGuardFlagConsumesNext(arg) {
+			consumeNext = true
+		}
+	}
+	return false
+}
+
+func swarmEnvGuardFlagConsumesNext(arg string) bool {
+	arg = strings.TrimSpace(arg)
+	if arg == "" || arg == "-" || arg == "--" || !strings.HasPrefix(arg, "-") || strings.Contains(arg, "=") {
+		return false
+	}
+	if strings.HasPrefix(arg, "--") {
+		name := strings.TrimPrefix(arg, "--")
+		return !swarmEnvGuardKnownBoolLongFlags()[name]
+	}
+	if strings.HasPrefix(arg, "-") {
+		return strings.TrimPrefix(arg, "-") == "m"
+	}
+	return false
+}
+
+func swarmEnvGuardKnownBoolLongFlags() map[string]bool {
+	return map[string]bool{
+		"abandon-active-runs":     true,
+		"all":                     true,
+		"client-secret-stdin":     true,
+		"code-stdin":              true,
+		"delivery-detail":         true,
+		"delivery-summary":        true,
+		"detach":                  true,
+		"dev":                     true,
+		"dry-run":                 true,
+		"follow":                  true,
+		"force":                   true,
+		"has-dead-letter":         true,
+		"help":                    true,
+		"json":                    true,
+		"mcp-only":                true,
+		"missing":                 true,
+		"no-color":                true,
+		"no-diagnose":             true,
+		"no-follow":               true,
+		"no-require-bundle-match": true,
+		"no-retry":                true,
+		"present":                 true,
+		"quiet":                   true,
+		"require-bundle-match":    true,
+		"self-check":              true,
+		"server":                  true,
+		"stdin":                   true,
+		"target":                  true,
+		"verbose":                 true,
+		"yes":                     true,
+	}
+}
+
+func firstSwarmCommandArg(args []string) string {
+	for i := 0; i < len(args); i++ {
+		arg := strings.TrimSpace(args[i])
+		if arg == "" {
+			continue
+		}
+		if arg == "--" {
+			return ""
+		}
+		if arg == "--swarm-dir" {
+			i++
+			continue
+		}
+		if strings.HasPrefix(arg, "--swarm-dir=") {
+			continue
+		}
+		if strings.HasPrefix(arg, "-") {
+			continue
+		}
+		return arg
+	}
+	return ""
+}
+
+func versionServerRequested(args []string) bool {
+	afterVersion := false
+	for _, arg := range args {
+		arg = strings.TrimSpace(arg)
+		if arg == "" {
+			continue
+		}
+		if arg == "--" {
+			return false
+		}
+		if !afterVersion {
+			if arg == "version" {
+				afterVersion = true
+			}
+			continue
+		}
+		if arg == "--server" {
+			return true
+		}
+		if value, ok := strings.CutPrefix(arg, "--server="); ok {
+			value = strings.TrimSpace(strings.ToLower(value))
+			return value == "" || value == "1" || value == "t" || value == "true" || value == "yes" || value == "y"
+		}
+	}
+	return false
+}
+
+func runtimeConfigPathFromArgs(args []string) string {
+	for i := 0; i < len(args); i++ {
+		arg := strings.TrimSpace(args[i])
+		if arg == "--" {
+			return ""
+		}
+		if arg == "--config" && i+1 < len(args) {
+			return strings.TrimSpace(args[i+1])
+		}
+		if strings.HasPrefix(arg, "--config=") {
+			return strings.TrimSpace(strings.TrimPrefix(arg, "--config="))
+		}
+	}
+	return ""
+}
+
+type swarmEnvGuardContext struct {
+	RepoRoot          string
+	Args              []string
+	RuntimeConfigPath string
+}
+
+func doctorSwarmEnvFindings(repoRoot, runtimeConfigPath string) []swarmEnvFinding {
+	return collectSwarmEnvFindings(swarmEnvGuardContext{
+		RepoRoot:          repoRoot,
+		RuntimeConfigPath: runtimeConfigPath,
+	})
+}
+
+func collectSwarmEnvFindings(ctx swarmEnvGuardContext) []swarmEnvFinding {
+	delegated := delegatedSwarmEnvSources(ctx.RepoRoot, ctx.RuntimeConfigPath)
+	entries := swarmEnvCatalogByName()
+	prefixes := swarmEnvCatalogPrefixes()
+	names := visibleSwarmEnvNames()
+	findings := make([]swarmEnvFinding, 0, len(names))
+	for _, name := range names {
+		if source := delegated[name]; source != "" {
+			findings = append(findings, swarmEnvFinding{
+				Name:       name,
+				Category:   swarmEnvCategoryTypedDelegation,
+				Severity:   "info",
+				AcceptedBy: source,
+				Message:    "accepted by explicit typed config delegation " + source,
+				Owner:      swarmEnvAuthorityOwner,
+			})
+			continue
+		}
+		entry, ok := entries[name]
+		if !ok {
+			for _, prefixEntry := range prefixes {
+				if strings.HasPrefix(name, prefixEntry.Prefix) {
+					entry, ok = prefixEntry, true
+					break
+				}
+			}
+		}
+		if !ok {
+			findings = append(findings, unknownSwarmEnvFinding(name, entries))
+			continue
+		}
+		findings = append(findings, findingForSwarmEnvEntry(name, entry))
+	}
+	return findings
+}
+
+func delegatedSwarmEnvSources(repoRoot, runtimeConfigPath string) map[string]string {
+	out := map[string]string{}
+	path := runtimeConfigPathForEnvDelegation(repoRoot, runtimeConfigPath)
+	if path == "" {
+		return out
+	}
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return out
+	}
+	var cfg struct {
+		Database struct {
+			PasswordEnv string `yaml:"password_env"`
+		} `yaml:"database"`
+	}
+	if err := yaml.Unmarshal(raw, &cfg); err != nil {
+		return out
+	}
+	if name := strings.TrimSpace(cfg.Database.PasswordEnv); strings.HasPrefix(name, "SWARM_") {
+		out[name] = "database.password_env"
+	}
+	return out
+}
+
+func runtimeConfigPathForEnvDelegation(repoRoot, explicitPath string) string {
+	if path := strings.TrimSpace(explicitPath); path != "" {
+		return resolvePath(repoRoot, path)
+	}
+	path, ok, err := executableAdjacentRuntimeConfigPath()
+	if err != nil || !ok {
+		return ""
+	}
+	return path
+}
+
+func visibleSwarmEnvNames() []string {
+	seen := map[string]struct{}{}
+	for _, item := range os.Environ() {
+		name, value, ok := strings.Cut(item, "=")
+		name = strings.TrimSpace(name)
+		if !ok || !strings.HasPrefix(name, "SWARM_") || strings.TrimSpace(value) == "" {
+			continue
+		}
+		seen[name] = struct{}{}
+	}
+	names := make([]string, 0, len(seen))
+	for name := range seen {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+func findingForSwarmEnvEntry(name string, entry swarmEnvCatalogEntry) swarmEnvFinding {
+	finding := swarmEnvFinding{
+		Name:        name,
+		Category:    entry.Category,
+		Owner:       nonEmpty(entry.Owner, swarmEnvAuthorityOwner),
+		Message:     nonEmpty(entry.Message, defaultSwarmEnvMessage(entry)),
+		Remediation: entry.Remediation,
+	}
+	switch entry.Category {
+	case swarmEnvCategoryBootstrap, swarmEnvCategorySeededLegacy, swarmEnvCategoryTypedDelegation:
+		finding.Severity = "info"
+		finding.AcceptedBy = entry.Owner
+	case swarmEnvCategoryTestQuarantine:
+		if isSwarmEnvTestContext() {
+			finding.Severity = "info"
+			finding.AcceptedBy = entry.Owner
+		} else {
+			finding.Severity = "blocker"
+			if finding.Remediation == "" {
+				finding.Remediation = "unset " + name + "; test-quarantined SWARM_* env is accepted only under the Swarm test harness"
+			}
+		}
+	case swarmEnvCategoryGeneratedBoundary, swarmEnvCategoryKnownRetired:
+		finding.Severity = "blocker"
+	default:
+		finding.Severity = "blocker"
+	}
+	if finding.Remediation == "" && finding.Severity == "blocker" {
+		finding.Remediation = "unset " + name
+	}
+	return finding
+}
+
+func defaultSwarmEnvMessage(entry swarmEnvCatalogEntry) string {
+	switch entry.Category {
+	case swarmEnvCategorySeededLegacy:
+		return "accepted temporarily as seeded legacy env pending migration"
+	case swarmEnvCategoryBootstrap:
+		return "accepted as bootstrap config locator"
+	case swarmEnvCategoryTestQuarantine:
+		return "test-quarantined env is not production configuration"
+	case swarmEnvCategoryGeneratedBoundary:
+		return "generated final-boundary env must be injected by Swarm, not set in the parent process"
+	case swarmEnvCategoryKnownRetired:
+		return "known retired env source is no longer accepted"
+	default:
+		return "classified by the repo-wide SWARM env accepted-set"
+	}
+}
+
+func unknownSwarmEnvFinding(name string, entries map[string]swarmEnvCatalogEntry) swarmEnvFinding {
+	message := "unknown SWARM_* env is not accepted; this is usually a stale export or typo"
+	if suggestion := nearestSwarmEnvName(name, entries); suggestion != "" {
+		message += "; did you mean " + suggestion + "?"
+	}
+	return swarmEnvFinding{
+		Name:        name,
+		Category:    swarmEnvCategoryUnknownStale,
+		Severity:    "blocker",
+		Message:     message,
+		Remediation: "unset " + name + " or declare an explicit typed config delegation if this env is intentional",
+		Owner:       swarmEnvAuthorityOwner,
+	}
+}
+
+func swarmEnvBlockers(findings []swarmEnvFinding) []swarmEnvFinding {
+	out := []swarmEnvFinding{}
+	for _, finding := range findings {
+		if strings.EqualFold(finding.Severity, "blocker") {
+			out = append(out, finding)
+		}
+	}
+	return out
+}
+
+func addSwarmEnvFindingsToLocalPreflightReport(report *localPreflightReport, findings []swarmEnvFinding) {
+	if report == nil {
+		return
+	}
+	for _, finding := range findings {
+		severity := localPreflightSeverityInfo
+		status := localPreflightStatusOK
+		if strings.EqualFold(finding.Severity, "blocker") {
+			severity = localPreflightSeverityBlocker
+			status = localPreflightStatusFailed
+		}
+		message := strings.TrimSpace(finding.Name)
+		if msg := strings.TrimSpace(finding.Message); msg != "" {
+			message += " - " + msg
+		}
+		if acceptedBy := strings.TrimSpace(finding.AcceptedBy); acceptedBy != "" {
+			message += " (accepted by " + acceptedBy + ")"
+		}
+		report.addWithOwner(
+			localPreflightEnvPrerequisite,
+			string(finding.Category),
+			severity,
+			status,
+			message,
+			finding.Remediation,
+			finding.Owner,
+		)
+	}
+}
+
+func isSwarmEnvTestContext() bool {
+	base := filepath.Base(os.Args[0])
+	return strings.HasSuffix(base, ".test")
+}
+
+func nearestSwarmEnvName(name string, entries map[string]swarmEnvCatalogEntry) string {
+	best := ""
+	bestDistance := 4
+	for candidate := range entries {
+		distance := editDistance(name, candidate)
+		if distance < bestDistance {
+			bestDistance = distance
+			best = candidate
+		}
+	}
+	return best
+}
+
+func editDistance(a, b string) int {
+	ar := []rune(a)
+	br := []rune(b)
+	prev := make([]int, len(br)+1)
+	for j := range prev {
+		prev[j] = j
+	}
+	for i := 1; i <= len(ar); i++ {
+		curr := make([]int, len(br)+1)
+		curr[0] = i
+		for j := 1; j <= len(br); j++ {
+			cost := 0
+			if ar[i-1] != br[j-1] {
+				cost = 1
+			}
+			curr[j] = minInt(curr[j-1]+1, prev[j]+1, prev[j-1]+cost)
+		}
+		prev = curr
+	}
+	return prev[len(br)]
+}
+
+func minInt(values ...int) int {
+	if len(values) == 0 {
+		return 0
+	}
+	min := values[0]
+	for _, value := range values[1:] {
+		if value < min {
+			min = value
+		}
+	}
+	return min
+}
+
+func nonEmpty(value, fallback string) string {
+	if strings.TrimSpace(value) != "" {
+		return value
+	}
+	return fallback
+}
+
+func swarmEnvCatalogByName() map[string]swarmEnvCatalogEntry {
+	entries := map[string]swarmEnvCatalogEntry{}
+	for _, entry := range swarmEnvCatalogEntries() {
+		if entry.Name == "" {
+			continue
+		}
+		entries[entry.Name] = entry
+	}
+	return entries
+}
+
+func swarmEnvCatalogPrefixes() []swarmEnvCatalogEntry {
+	prefixes := []swarmEnvCatalogEntry{}
+	for _, entry := range swarmEnvCatalogEntries() {
+		if entry.Prefix != "" {
+			prefixes = append(prefixes, entry)
+		}
+	}
+	sort.Slice(prefixes, func(i, j int) bool {
+		return len(prefixes[i].Prefix) > len(prefixes[j].Prefix)
+	})
+	return prefixes
+}
+
+func swarmEnvCatalogEntries() []swarmEnvCatalogEntry {
+	e := func(name string, category swarmEnvCategory, owner, migration, message, remediation string) swarmEnvCatalogEntry {
+		return swarmEnvCatalogEntry{Name: name, Category: category, Owner: owner, Migration: migration, Message: message, Remediation: remediation}
+	}
+	p := func(prefix string, category swarmEnvCategory, owner, migration, message, remediation string) swarmEnvCatalogEntry {
+		return swarmEnvCatalogEntry{Prefix: prefix, Category: category, Owner: owner, Migration: migration, Message: message, Remediation: remediation}
+	}
+	seeded := func(name, owner, migration string) swarmEnvCatalogEntry {
+		return e(name, swarmEnvCategorySeededLegacy, owner, migration, "", "migrate "+name+" through "+migration+" and then remove it from the seeded accepted set")
+	}
+	retired := func(name, message, remediation string) swarmEnvCatalogEntry {
+		return e(name, swarmEnvCategoryKnownRetired, swarmEnvAuthorityOwner, "retired", message, remediation)
+	}
+	testOnly := func(name string) swarmEnvCatalogEntry {
+		return e(name, swarmEnvCategoryTestQuarantine, swarmEnvAuthorityOwner, "test/debug quarantine", "", "")
+	}
+	return []swarmEnvCatalogEntry{
+		e("SWARM_CONFIG", swarmEnvCategoryBootstrap, "platform-spec.yaml#cli_specification.foundations.api_connection_auth_config_precedence.cli_config_file", "keep bootstrap locator", "", ""),
+		retired("SWARM_API_SERVER", "client-side API environment sources are no longer accepted: SWARM_API_SERVER", "use --api-server, --context, project/selected context, or config api_server"),
+		retired("SWARM_API_TOKEN", "client-side API environment sources are no longer accepted: SWARM_API_TOKEN", "use --api-token-file, context descriptor auth, config api_token_file, or serve_api_token_file for server auth"),
+		retired("SWARM_API_TOKEN_FILE", "client-side API environment sources are no longer accepted: SWARM_API_TOKEN_FILE", "use --api-token-file, context descriptor auth, or config api_token_file"),
+		seeded("SWARM_API_LISTEN_ADDR", "platform-spec.yaml#cli_specification.command_catalog.serve.listener_topology_v2_1", "#1600 listener config migration"),
+		seeded("SWARM_MCP_LISTEN_ADDR", "platform-spec.yaml#cli_specification.command_catalog.serve.listener_topology_v2_1", "#1600 listener config migration"),
+		retired("SWARM_API_PORT", "SWARM_API_PORT is retired; final listener topology uses full listen addresses", "use --api-listen-addr or config serve_api_listen_addr"),
+		retired("SWARM_MCP_PORT", "SWARM_MCP_PORT is retired; final listener topology uses full listen addresses", "use --mcp-listen-addr or config serve_mcp_listen_addr"),
+		seeded("SWARM_CONTRACTS_PATH", "platform-spec.yaml#cli_specification.foundations.contract_platform_spec_path_resolution", "config contracts_path or --contracts"),
+		retired("SWARM_CONTRACTS_DIR", "SWARM_CONTRACTS_DIR is not a promoted CLI source", "use --contracts or config contracts_path"),
+		retired("SWARM_PLATFORM_SPEC_PATH", "SWARM_PLATFORM_SPEC_PATH is not promoted", "use --platform-spec or config platform_spec_path where supported"),
+		retired("SWARM_DIR", "SWARM_DIR is not promoted as state directory authority", "use --swarm-dir or config swarm_dir"),
+		retired("SWARM_HOME", "SWARM_HOME is not promoted as state directory authority", "use --swarm-dir or config swarm_dir"),
+		seeded("SWARM_STORE_BACKEND", "platform-spec.yaml#runtime_storage.runtime_store_backend_selection", "#1637 store.backend"),
+		seeded("SWARM_SQLITE_PATH", "platform-spec.yaml#runtime_storage.runtime_store_backend_selection.sqlite_path", "#1637 store.sqlite.path"),
+		seeded("SWARM_DB_HOST", "platform-spec.yaml#runtime_storage.runtime_store_backend_selection.postgres_connection_details", "#1637 database.host"),
+		seeded("SWARM_DB_PORT", "platform-spec.yaml#runtime_storage.runtime_store_backend_selection.postgres_connection_details", "#1637 database.port"),
+		seeded("SWARM_DB_NAME", "platform-spec.yaml#runtime_storage.runtime_store_backend_selection.postgres_connection_details", "#1637 database.name"),
+		seeded("SWARM_DB_USER", "platform-spec.yaml#runtime_storage.runtime_store_backend_selection.postgres_connection_details", "#1637 database.user"),
+		seeded("SWARM_DB_SSLMODE", "platform-spec.yaml#runtime_storage.runtime_store_backend_selection.postgres_connection_details", "#1637 database.sslmode"),
+		seeded("SWARM_DB_POOL_SIZE", "platform-spec.yaml#runtime_storage.runtime_store_backend_selection.postgres_connection_details", "#1637 database.pool_size"),
+		retired("SWARM_DB_PASSWORD", "SWARM_DB_PASSWORD is not read implicitly; it is accepted only when explicitly named by database.password_env", "unset SWARM_DB_PASSWORD or declare database.password_env: SWARM_DB_PASSWORD in the runtime config"),
+		seeded("SWARM_WORKSPACE_DATA_SOURCE", "platform-spec.yaml#workspace_model.data_source_authority", "#1600 workspace.data_source"),
+		seeded("SWARM_WORKSPACE_BACKEND", "platform-spec.yaml#workspace_model.workspace_backend_selection", "#1600 workspace.backend"),
+		seeded("SWARM_DOCKER_BIN", "platform-spec.yaml#environment_source_authority.workspace_monitor_artifact_debug_slice", "#1600 workspace/tooling config"),
+		seeded("SWARM_WORKSPACE_IMAGE", "platform-spec.yaml#workspace_model.runtime_image_packaging", "#1600 workspace.image"),
+		seeded("SWARM_WORKSPACE_HOST_ROOT", "platform-spec.yaml#workspace_model.workspace_backend_selection", "#1600 workspace.host_root"),
+		seeded("SWARM_WORKSPACE_VOLUMES_FROM", "platform-spec.yaml#workspace_model.data_source_authority", "#1600 workspace volumes config"),
+		seeded("SWARM_WORKSPACE_NETWORK", "platform-spec.yaml#environment_source_authority.workspace_monitor_artifact_debug_slice", "#1600 workspace network config"),
+		seeded("SWARM_WORKSPACE_DATA_MOUNT", "platform-spec.yaml#environment_source_authority.workspace_monitor_artifact_debug_slice", "#1600 workspace mount config"),
+		seeded("SWARM_WORKSPACE_CONTRACTS_SOURCE", "platform-spec.yaml#environment_source_authority.workspace_monitor_artifact_debug_slice", "#1600 workspace contracts source config"),
+		seeded("SWARM_WORKSPACE_CONTRACTS_MOUNT", "platform-spec.yaml#environment_source_authority.workspace_monitor_artifact_debug_slice", "#1600 workspace contracts mount config"),
+		seeded("SWARM_SCAFFOLD_CONTAINER", "platform-spec.yaml#environment_source_authority.workspace_monitor_artifact_debug_slice", "#1600 workspace lifecycle config"),
+		seeded("SWARM_SCAFFOLD_WORKDIR", "platform-spec.yaml#environment_source_authority.workspace_monitor_artifact_debug_slice", "#1600 workspace lifecycle config"),
+		seeded("SWARM_SCAFFOLD_VOLUME", "platform-spec.yaml#environment_source_authority.workspace_monitor_artifact_debug_slice", "#1600 workspace lifecycle config"),
+		seeded("SWARM_SYSTEM_CONTAINER", "platform-spec.yaml#environment_source_authority.workspace_monitor_artifact_debug_slice", "#1600 workspace lifecycle config"),
+		seeded("SWARM_SYSTEM_WORKDIR", "platform-spec.yaml#environment_source_authority.workspace_monitor_artifact_debug_slice", "#1600 workspace lifecycle config"),
+		seeded("SWARM_SYSTEM_ENTITIES_VOLUME", "platform-spec.yaml#environment_source_authority.workspace_monitor_artifact_debug_slice", "#1600 workspace lifecycle config"),
+		seeded("SWARM_SYSTEM_NGINX_VOLUME", "platform-spec.yaml#environment_source_authority.workspace_monitor_artifact_debug_slice", "#1600 workspace lifecycle config"),
+		seeded("SWARM_SYSTEM_SYSTEMD_VOLUME", "platform-spec.yaml#environment_source_authority.workspace_monitor_artifact_debug_slice", "#1600 workspace lifecycle config"),
+		seeded("SWARM_ENTITY_CONTAINER_PREFIX", "platform-spec.yaml#environment_source_authority.workspace_monitor_artifact_debug_slice", "#1600 workspace lifecycle config"),
+		seeded("SWARM_ENTITY_WORKDIR", "platform-spec.yaml#environment_source_authority.workspace_monitor_artifact_debug_slice", "#1600 workspace lifecycle config"),
+		seeded("SWARM_RUNTIME_RECOVERY_ON_STARTUP", "platform-spec.yaml#runtime_storage.runtime_store_backend_selection", "#1600 runtime.recovery_on_startup"),
+		retired("SWARM_RUNTIME_MAX_CONCURRENT_AGENTS", "SWARM_RUNTIME_MAX_CONCURRENT_AGENTS is unsupported inert runtime control", "remove it; no runtime path enforces this control"),
+		retired("SWARM_RUNTIME_EVENT_POLL_INTERVAL", "SWARM_RUNTIME_EVENT_POLL_INTERVAL is unsupported inert runtime control", "remove it; no runtime path enforces this control"),
+		seeded("SWARM_LLM_SESSION_LOCK_TTL", "platform-spec.yaml#engine.agent_session_management.llm_provider_selection_config_authority", "#1600 llm.session.lock_ttl"),
+		seeded("SWARM_LLM_SESSION_ROTATE_AFTER_TURNS", "platform-spec.yaml#engine.agent_session_management.llm_provider_selection_config_authority", "#1600 llm.session.rotate_after_turns"),
+		seeded("SWARM_LLM_SESSION_ROTATE_ON_PARSE_FAILURES", "platform-spec.yaml#engine.agent_session_management.llm_provider_selection_config_authority", "#1600 llm.session.rotate_on_parse_failures"),
+		seeded("SWARM_CLAUDE_API_MAX_RETRIES", "platform-spec.yaml#engine.agent_session_management.llm_provider_selection_config_authority", "#1600 llm.claude_api.max_retries"),
+		seeded("SWARM_CLAUDE_API_RETRY_BACKOFF", "platform-spec.yaml#engine.agent_session_management.llm_provider_selection_config_authority", "#1600 llm.claude_api.retry_backoff"),
+		seeded("SWARM_CLAUDE_CLI_COMMAND", "platform-spec.yaml#engine.agent_session_management.llm_provider_selection_config_authority", "#1600 llm.claude_cli.command"),
+		seeded("SWARM_CLAUDE_CLI_TIMEOUT", "platform-spec.yaml#engine.agent_session_management.llm_provider_selection_config_authority", "#1600 llm.claude_cli.timeout"),
+		seeded("SWARM_CLAUDE_CLI_OUTPUT_FORMAT", "platform-spec.yaml#engine.agent_session_management.llm_provider_selection_config_authority", "#1600 llm.claude_cli.output_format"),
+		seeded("SWARM_CLAUDE_CLI_RETRIES", "platform-spec.yaml#engine.agent_session_management.llm_provider_selection_config_authority", "#1600 llm.claude_cli.retries"),
+		seeded("SWARM_CLAUDE_CLI_NO_SESSION_PERSISTENCE", "platform-spec.yaml#engine.agent_session_management.llm_provider_selection_config_authority", "#1600 llm.claude_cli.no_session_persistence"),
+		seeded("SWARM_CLAUDE_CLI_USE_TMUX", "platform-spec.yaml#engine.agent_session_management.llm_provider_selection_config_authority", "#1600 llm.claude_cli.use_tmux"),
+		seeded("SWARM_CLAUDE_TIMEOUT_SECONDS", "platform-spec.yaml#engine.agent_session_management.llm_provider_selection_config_authority", "#1600 llm.claude_cli.timeout"),
+		seeded("SWARM_CLAUDE_PERMISSION_MODE", "platform-spec.yaml#engine.agent_session_management.llm_provider_selection_config_authority", "#1600 llm.claude_cli.permission_mode"),
+		seeded("SWARM_CLAUDE_BYPASS_PERMISSIONS", "platform-spec.yaml#engine.agent_session_management.llm_provider_selection_config_authority", "#1600 llm.claude_cli.permission_mode"),
+		seeded("SWARM_CLAUDE_USE_MCP", "platform-spec.yaml#cli_specification.foundations.local_tool_gateway_binding", "#1600 typed Claude CLI transport config"),
+		retired("SWARM_LLM_BACKEND", "SWARM_LLM_BACKEND is retired; use --backend or llm.backend", "use --backend or llm.backend"),
+		retired("SWARM_LLM_RUNTIME_MODE", "SWARM_LLM_RUNTIME_MODE is retired; use llm.backend", "use llm.backend"),
+		retired("SWARM_CLAUDE_DEFAULT_MODEL", "SWARM_CLAUDE_DEFAULT_MODEL is retired for model selection; use llm.models", "use llm.models"),
+		retired("SWARM_CLAUDE_HAIKU_MODEL", "SWARM_CLAUDE_HAIKU_MODEL is retired for model selection; use llm.models", "use llm.models"),
+		retired("SWARM_OPENAI_COMPATIBLE_BASE_URL", "SWARM_OPENAI_COMPATIBLE_BASE_URL is retired; use llm.openai_compatible.base_url", "use llm.openai_compatible.base_url"),
+		retired("SWARM_OPENAI_COMPATIBLE_DEFAULT_MODEL", "SWARM_OPENAI_COMPATIBLE_DEFAULT_MODEL is retired for model selection; use llm.models", "use llm.models"),
+		retired("SWARM_OPENAI_COMPATIBLE_LOW_COST_MODEL", "SWARM_OPENAI_COMPATIBLE_LOW_COST_MODEL is retired for model selection; use llm.models", "use llm.models"),
+		seeded("SWARM_CREDENTIALS_FILE", "platform-spec.yaml#environment_source_authority.repo_wide_swarm_env_accepted_set", "#1600 secrets file config"),
+		seeded("SWARM_MANAGED_CREDENTIALS_FILE", "platform-spec.yaml#environment_source_authority.repo_wide_swarm_env_accepted_set", "#1600 managed credentials file config"),
+		seeded("SWARM_ARTIFACT_ROOT", "platform-spec.yaml#runtime_storage.artifact_root", "#1600 runtime.artifact_root"),
+		seeded("SWARM_MONITOR_DIR", "platform-spec.yaml#environment_source_authority.workspace_monitor_artifact_debug_slice", "#1600 monitor config"),
+		seeded("SWARM_PROMPTS_DIR", "platform-spec.yaml#environment_source_authority.workspace_monitor_artifact_debug_slice", "#1600 prompt helper config"),
+		seeded("SWARM_AGENT_CONFIG_MAP_FILE", "platform-spec.yaml#environment_source_authority.workspace_monitor_artifact_debug_slice", "#1600 spec helper config"),
+		seeded("SWARM_VERIFICATION_GATES_FILE", "platform-spec.yaml#environment_source_authority.workspace_monitor_artifact_debug_slice", "#1600 spec helper config"),
+		seeded("SWARM_TOOLING_LOCK_FILE", "platform-spec.yaml#environment_source_authority.workspace_monitor_artifact_debug_slice", "#1600 spec helper config"),
+		retired("SWARM_LOG_LEVEL", "SWARM_LOG_LEVEL is not promoted as CLI logging source", "use --log-level on supported commands"),
+		testOnly("SWARM_SQL_DEBUG"),
+		testOnly("SWARM_BOOT_WARNINGS_FATAL"),
+		testOnly("SWARM_EMIT_SCHEMA_STRICT"),
+		testOnly("SWARM_CATALOG_E2E_DEBUG"),
+		testOnly("SWARM_FAKE_DOCKER_STATE"),
+		testOnly("SWARM_LLM_FIRST_TURN_FAKE_DOCKER"),
+		testOnly(swarmTestHarnessEnv),
+		p("SWARM_TEST_", swarmEnvCategoryTestQuarantine, swarmEnvAuthorityOwner, "test/debug quarantine", "", ""),
+		e("SWARM_TOOL_GATEWAY_URL", swarmEnvCategoryGeneratedBoundary, "platform-spec.yaml#cli_specification.foundations.local_tool_gateway_binding", "generated final-boundary only", "SWARM_TOOL_GATEWAY_URL is retired and not accepted as gateway endpoint configuration; generated final-boundary env must be injected by Swarm", "unset SWARM_TOOL_GATEWAY_URL; local serve/run derives the gateway binding from the bound MCP listener and ignores this retired URL"),
+		e("SWARM_TOOL_GATEWAY_CONTAINER_URL", swarmEnvCategoryGeneratedBoundary, "platform-spec.yaml#cli_specification.foundations.local_tool_gateway_binding", "generated final-boundary only", "SWARM_TOOL_GATEWAY_CONTAINER_URL is retired and not accepted as gateway endpoint configuration; generated final-boundary env must be injected by Swarm", "unset SWARM_TOOL_GATEWAY_CONTAINER_URL; local serve/run derives the gateway binding from the bound MCP listener and ignores this retired URL"),
+		retired("SWARM_TOOL_GATEWAY_TOKEN", "SWARM_TOOL_GATEWAY_TOKEN is retired; ToolGatewayBinding owns per-boot gateway auth", "unset SWARM_TOOL_GATEWAY_TOKEN; use the generated ToolGatewayBinding token path"),
+		retired("SWARM_BUILDER_AUTH_TOKEN", "SWARM_BUILDER_AUTH_TOKEN is not accepted as API auth fallback", "use token files, context descriptor auth, or configured auth sources"),
+		retired("SWARM_OPERATOR_AUTH_TOKEN", "SWARM_OPERATOR_AUTH_TOKEN is not accepted as API auth fallback", "use token files, context descriptor auth, or configured auth sources"),
+	}
+}

--- a/cmd/swarm/local_preflight.go
+++ b/cmd/swarm/local_preflight.go
@@ -30,6 +30,7 @@ const (
 	localPreflightContractSecretPrerequisite localPreflightCategory = "contract_secret_prerequisite"
 	localPreflightProviderPackPrerequisite   localPreflightCategory = "provider_pack_prerequisite"
 	localPreflightDevConveniencePrerequisite localPreflightCategory = "dev_convenience_prerequisite"
+	localPreflightEnvPrerequisite            localPreflightCategory = "env"
 )
 
 type localPreflightSeverity string
@@ -154,6 +155,10 @@ func runLocalClaudeCLIPreflight(ctx context.Context, req localPreflightRequest) 
 }
 
 func (r *localPreflightReport) add(category localPreflightCategory, code string, severity localPreflightSeverity, status localPreflightFindingStatus, message, remediation string) {
+	r.addWithOwner(category, code, severity, status, message, remediation, localPreflightOwner)
+}
+
+func (r *localPreflightReport) addWithOwner(category localPreflightCategory, code string, severity localPreflightSeverity, status localPreflightFindingStatus, message, remediation, owner string) {
 	if r == nil {
 		return
 	}
@@ -165,6 +170,10 @@ func (r *localPreflightReport) add(category localPreflightCategory, code string,
 	if status == "" {
 		status = localPreflightStatusOK
 	}
+	owner = strings.TrimSpace(owner)
+	if owner == "" {
+		owner = localPreflightOwner
+	}
 	r.Findings = append(r.Findings, localPreflightFinding{
 		Category:    category,
 		Code:        code,
@@ -172,7 +181,7 @@ func (r *localPreflightReport) add(category localPreflightCategory, code string,
 		Severity:    severity,
 		Message:     message,
 		Remediation: strings.TrimSpace(remediation),
-		Owner:       localPreflightOwner,
+		Owner:       owner,
 	})
 }
 

--- a/cmd/swarm/main.go
+++ b/cmd/swarm/main.go
@@ -2452,10 +2452,10 @@ func defaultRuntimeConfig() (*config.Config, error) {
 
 func rejectUnsupportedRuntimeControlEnv() error {
 	unsupported := make([]string, 0, 2)
-	if _, ok := os.LookupEnv("SWARM_RUNTIME_MAX_CONCURRENT_AGENTS"); ok {
+	if strings.TrimSpace(os.Getenv("SWARM_RUNTIME_MAX_CONCURRENT_AGENTS")) != "" {
 		unsupported = append(unsupported, "SWARM_RUNTIME_MAX_CONCURRENT_AGENTS")
 	}
-	if _, ok := os.LookupEnv("SWARM_RUNTIME_EVENT_POLL_INTERVAL"); ok {
+	if strings.TrimSpace(os.Getenv("SWARM_RUNTIME_EVENT_POLL_INTERVAL")) != "" {
 		unsupported = append(unsupported, "SWARM_RUNTIME_EVENT_POLL_INTERVAL")
 	}
 	if len(unsupported) == 0 {

--- a/cmd/swarm/target_resolution.go
+++ b/cmd/swarm/target_resolution.go
@@ -85,6 +85,7 @@ type doctorTargetReport struct {
 	RuntimeIdentity doctorTargetPendingFact    `json:"runtime_identity"`
 	Store           doctorTargetPath           `json:"store"`
 	Data            doctorTargetPath           `json:"data"`
+	Env             []localPreflightFinding    `json:"env,omitempty"`
 	CommandClasses  []doctorTargetCommandClass `json:"command_classes"`
 	SplitSiblings   []string                   `json:"split_siblings"`
 }
@@ -140,6 +141,8 @@ type doctorTargetCommandClass struct {
 }
 
 func runDoctorTargetCommand(repo string, cmd *cobra.Command, opts doctorOptions) error {
+	envFindings := doctorSwarmEnvFindings(repo, opts.configPath)
+	envReport := doctorTargetEnvReport(envFindings)
 	cfg, err := loadCLIAPIConfigFile()
 	if err != nil {
 		return returnCLIValidationError(cmd.ErrOrStderr(), err)
@@ -155,17 +158,34 @@ func runDoctorTargetCommand(repo string, cmd *cobra.Command, opts doctorOptions)
 		BackendOverride: opts.backend,
 	})
 	if err != nil {
-		return returnCLIValidationError(cmd.ErrOrStderr(), err)
+		if !envReport.HasBlockers() {
+			return returnCLIValidationError(cmd.ErrOrStderr(), err)
+		}
+		runtimeCfgResult.Config = &config.Config{}
 	}
 	report, err := buildDoctorTargetReport(cmd.Context(), repo, opts, cfg, swarmDir, runtimeCfgResult.Config)
 	if err != nil {
 		return returnCLIValidationError(cmd.ErrOrStderr(), err)
 	}
+	report.Env = envReport.Findings
+	report.OK = report.OK && !envReport.HasBlockers()
 	if opts.asJSON {
-		return writeDoctorTargetJSON(cmd.OutOrStdout(), report)
+		if err := writeDoctorTargetJSON(cmd.OutOrStdout(), report); err != nil {
+			return err
+		}
+	} else {
+		writeDoctorTargetText(cmd.OutOrStdout(), report)
 	}
-	writeDoctorTargetText(cmd.OutOrStdout(), report)
+	if !report.OK {
+		return commandExitError{code: cliExitRuntime}
+	}
 	return nil
+}
+
+func doctorTargetEnvReport(findings []swarmEnvFinding) localPreflightReport {
+	report := localPreflightReport{Owner: localPreflightOwner, Mode: "doctor_target"}
+	addSwarmEnvFindingsToLocalPreflightReport(&report, findings)
+	return report.finalize()
 }
 
 func buildDoctorTargetReport(ctx context.Context, repo string, opts doctorOptions, cfg cliAPIConfigFile, swarmDir cliSwarmDirResolution, runtimeCfg *config.Config) (doctorTargetReport, error) {
@@ -275,9 +295,6 @@ func rootSwarmDirFlag(cmd *cobra.Command) (string, bool) {
 }
 
 func resolveDoctorTargetAPI(repo string, opts doctorOptions, cfg cliAPIConfigFile, swarmDir cliSwarmDirResolution) (doctorTargetAPI, error) {
-	if err := rejectRemovedClientAPIEnvSources(); err != nil {
-		return doctorTargetAPI{}, err
-	}
 	targetOpts := rootCommandOptions{
 		apiServer:       opts.apiOptions.apiServer,
 		apiTokenFile:    opts.apiOptions.apiTokenFile,
@@ -295,7 +312,7 @@ func resolveDoctorTargetAPI(repo string, opts doctorOptions, cfg cliAPIConfigFil
 	if err != nil {
 		return doctorTargetAPI{}, err
 	}
-	token, err := resolveCLIAPITokenForTarget(rootCommandOptions{
+	token, err := resolveDoctorTargetAPITokenForTarget(rootCommandOptions{
 		apiTokenFile: opts.apiOptions.apiTokenFile,
 	}, cfg, target)
 	auth := doctorTargetAuth{}
@@ -314,6 +331,33 @@ func resolveDoctorTargetAPI(repo string, opts doctorOptions, cfg cliAPIConfigFil
 		Auth:        auth,
 		Reason:      doctorTargetAPIReason(target.source),
 	}, nil
+}
+
+func resolveDoctorTargetAPITokenForTarget(opts rootCommandOptions, cfg cliAPIConfigFile, target cliAPITargetResolution) (cliAPITokenResolution, error) {
+	if tokenFile := strings.TrimSpace(opts.apiTokenFile); tokenFile != "" {
+		return readCLIAPIExplicitTokenFile(tokenFile, "--api-token-file")
+	}
+	if target.descriptor == nil {
+		return resolveDoctorTargetCLIToken(cfg, target.rpcEndpoint)
+	}
+	token, err := localContextDescriptorToken(*target.descriptor, target.rpcEndpoint)
+	if err != nil {
+		return cliAPITokenResolution{}, err
+	}
+	return cliAPITokenResolution{token: token, source: "context descriptor " + target.descriptor.Auth.Mode}, nil
+}
+
+func resolveDoctorTargetCLIToken(cfg cliAPIConfigFile, rpcEndpoint string) (cliAPITokenResolution, error) {
+	if tokenFile := strings.TrimSpace(cfg.APITokenFile); tokenFile != "" {
+		return readCLIAPIExplicitTokenFile(tokenFile, "config api_token_file")
+	}
+	if cliAPIRPCEndpointAllowsDefaultToken(rpcEndpoint) {
+		return cliAPITokenResolution{
+			token:  apiv1.DefaultLoopbackAPIToken,
+			source: string(apiv1.AuthTokenSourceBuiltInLoopbackToken),
+		}, nil
+	}
+	return cliAPITokenResolution{}, errCLIAPITokenRequired
 }
 
 func cliAPIServerBaseFromRPCEndpoint(rpcEndpoint, source string) (string, error) {
@@ -609,8 +653,21 @@ func writeDoctorTargetText(out io.Writer, report doctorTargetReport) {
 	if out == nil {
 		return
 	}
-	fmt.Fprintf(out, "swarm target diagnostics: ok\n")
+	status := "ok"
+	if !report.OK {
+		status = "failed"
+	}
+	fmt.Fprintf(out, "swarm target diagnostics: %s\n", status)
 	fmt.Fprintf(out, "owner: %s\n", report.Owner)
+	if len(report.Env) > 0 {
+		fmt.Fprintln(out, "env:")
+		for _, finding := range report.Env {
+			fmt.Fprintf(out, "[%s] %s/%s: %s\n", strings.ToUpper(string(finding.Severity)), finding.Category, finding.Code, finding.Message)
+			if finding.Remediation != "" {
+				fmt.Fprintf(out, "  remediation: %s\n", finding.Remediation)
+			}
+		}
+	}
 	fmt.Fprintf(out, "swarm_dir: %s (source: %s)\n", report.SwarmDir.Path, report.SwarmDir.Source)
 	if report.Project.Status == "resolved" {
 		fmt.Fprintf(out, "project_root: %s (source: %s; canonical: %s; canonicalization: %s)\n", report.Project.ProjectRoot, report.Project.ContractsSource, report.Project.CanonicalProjectRoot, report.Project.CanonicalizationStatus)

--- a/internal/runtime/credentials/store.go
+++ b/internal/runtime/credentials/store.go
@@ -46,6 +46,9 @@ func (EnvStore) Get(_ context.Context, key string) (string, bool, error) {
 		if !ok {
 			continue
 		}
+		if strings.HasPrefix(candidate, "SWARM_") {
+			return "", false, fmt.Errorf("credential env %s is not accepted through dynamic credential lookup; declare a typed source or store the secret with swarm secrets", candidate)
+		}
 		return value, true, nil
 	}
 	return "", false, nil

--- a/internal/runtime/credentials/store_test.go
+++ b/internal/runtime/credentials/store_test.go
@@ -67,6 +67,24 @@ func TestOverlayStore_EnvOverridesFile(t *testing.T) {
 	}
 }
 
+func TestEnvStoreRejectsSwarmCredentialBackdoor(t *testing.T) {
+	ctx := context.Background()
+	t.Setenv("SWARM_SECRET_TOKEN", "secret")
+
+	value, ok, err := EnvStore{}.Get(ctx, "SWARM_SECRET_TOKEN")
+	if err == nil {
+		t.Fatalf("Get returned value=%q ok=%v err=nil, want SWARM_* rejection", value, ok)
+	}
+	for _, want := range []string{"SWARM_SECRET_TOKEN", "not accepted through dynamic credential lookup", "swarm secrets"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("error missing %q: %v", want, err)
+		}
+	}
+	if ok || value != "" {
+		t.Fatalf("Get returned value=%q ok=%v, want no dynamic SWARM_* credential", value, ok)
+	}
+}
+
 func TestListDescriptors_IndexesToolsMCPServersAndWebSearchProvider(t *testing.T) {
 	ctx := context.Background()
 	fileStore, err := NewFileStore(filepath.Join(t.TempDir(), "credentials.json"))

--- a/internal/runtime/llm/selection/profile.go
+++ b/internal/runtime/llm/selection/profile.go
@@ -265,7 +265,7 @@ func RejectRetiredEnvBackend(lookup EnvLookup) error {
 	if lookup == nil {
 		return nil
 	}
-	if _, ok := lookup(EnvBackend); ok {
+	if value, ok := lookup(EnvBackend); ok && strings.TrimSpace(value) != "" {
 		return fmt.Errorf("%s is retired and must not select the LLM backend; use --backend or %s", EnvBackend, ConfigBackendField)
 	}
 	return nil
@@ -275,7 +275,7 @@ func RejectRetiredEnvRuntimeMode(lookup EnvLookup) error {
 	if lookup == nil {
 		return nil
 	}
-	if _, ok := lookup(RetiredEnvRuntimeMode); ok {
+	if value, ok := lookup(RetiredEnvRuntimeMode); ok && strings.TrimSpace(value) != "" {
 		return fmt.Errorf("%s is retired; use --backend or %s", RetiredEnvRuntimeMode, ConfigBackendField)
 	}
 	return nil
@@ -285,7 +285,7 @@ func RejectRetiredOpenAICompatibleBaseURLEnv(lookup EnvLookup) error {
 	if lookup == nil {
 		return nil
 	}
-	if _, ok := lookup(OpenAICompatibleBaseURLEnv); ok {
+	if value, ok := lookup(OpenAICompatibleBaseURLEnv); ok && strings.TrimSpace(value) != "" {
 		return fmt.Errorf("%s is retired; use %s", OpenAICompatibleBaseURLEnv, OpenAICompatibleBaseURLConfigField)
 	}
 	return nil
@@ -301,7 +301,7 @@ func RejectRetiredModelEnv(lookup EnvLookup) error {
 		OpenAICompatibleDefaultModelEnv,
 		OpenAICompatibleLowCostModelEnv,
 	} {
-		if _, ok := lookup(env); ok {
+		if value, ok := lookup(env); ok && strings.TrimSpace(value) != "" {
 			return fmt.Errorf("%s is retired for model selection; use %s", env, "llm.models")
 		}
 	}

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -10603,6 +10603,416 @@ runtime_storage:
     - Product contracts and agents MUST NOT rely on the raw host path. The stable product surface remains the opaque
       `swarm-artifact://repos/<repo_id>` URL plus immutable commit ref.
 environment_source_authority:
+  repo_wide_swarm_env_accepted_set:
+    promoted_by: '#1731'
+    parent_tracker: '#1600'
+    implementation_status: implemented_first_slice
+    canonical_owner: platform-spec.yaml#environment_source_authority.repo_wide_swarm_env_accepted_set
+    scope: >
+      Repo-wide acceptance authority for process-visible `SWARM_*` environment variables. This owner defines the closed
+      category enum, the static accepted-set catalog, typed delegation admission, doctor reporting, generated-boundary
+      closure, and unknown/stale env fail-closed behavior for covered CLI commands. It does not complete the #1600 parent
+      migration: seeded legacy rows remain live only as migration-bearing TODO entries and MUST shrink in later children.
+    source_authority_rule: >
+      Environment variables have no ambient source authority. A `SWARM_*` variable is accepted only when it is `SWARM_CONFIG`,
+      an exact typed delegation declared by schema-visible config, a currently seeded legacy row with a migration pointer, a
+      test-quarantined row under a test harness, or a generated-boundary row injected by Swarm into a child process. Unknown,
+      known-retired, generated-boundary-in-parent, and production test-quarantine usages MUST fail closed before side effects
+      on covered commands. The guard's source-authority boundary is non-empty after trimming; empty `SWARM_*=` values have
+      no source authority, and any remaining direct legacy readers MUST use the same non-empty boundary until their seeded
+      row is migrated. `swarm doctor` MUST render the same findings instead of being blocked by them.
+    command_guard_scope:
+      guarded: >
+        All side-effect-capable and runtime/target-consuming CLI commands after root flag placement validation and before
+        command side effects.
+      skipped: >
+        Pure help/completion surfaces, including subcommand `-h`/`--help` forms that are not consumed as flag values or
+        written after `--`, and `swarm version` without `--server` do not consume runtime env semantics and skip the guard.
+        Server-targeting version forms, including `--server=true`, are target-consuming and MUST be guarded. `swarm doctor`
+        skips the blocking guard but MUST include an env finding section and exit nonzero when blockers exist, including when
+        legacy runtime-config env rejectors would otherwise fail before the diagnostic report renders.
+    typed_delegation:
+      rule: >
+        Typed delegation is schema-visible and exact. A config field may name one concrete env variable only when that field's
+        schema explicitly supports env delegation. Guard admission MUST use the same supported runtime config source classes
+        as runtime loading, including explicit `--config` and executable-adjacent `config.yaml`. Arbitrary string
+        interpolation such as `${VAR}` is not accepted.
+      first_slice_fields:
+      - database.password_env
+    generated_boundary:
+      rule: >
+        Generated-boundary envs are child-process injection names, not user/operator source authority. Seeing one of these
+        names in Swarm's parent process env is a blocker. The child-process injection set is closed and must be drift-tested
+        against the implementation.
+    test_quarantine:
+      rule: >
+        Test/debug envs are accepted only under the Swarm test harness or Go test binary context. They are banned from public
+        setup docs and must not become production behavior without a new typed flag/config owner.
+    categories:
+    - bootstrap
+    - typed_delegation
+    - generated_boundary
+    - test_quarantine
+    - seeded_legacy
+    - known_retired
+    - unknown_stale
+    accepted_env:
+    - name: SWARM_CONFIG
+      category: bootstrap
+      owner: platform-spec.yaml#cli_specification.foundations.api_connection_auth_config_precedence.cli_config_file
+      migration: keep bootstrap locator
+    - name: SWARM_API_SERVER
+      category: known_retired
+      owner: platform-spec.yaml#environment_source_authority.repo_wide_swarm_env_accepted_set
+      migration: retired
+    - name: SWARM_API_TOKEN
+      category: known_retired
+      owner: platform-spec.yaml#environment_source_authority.repo_wide_swarm_env_accepted_set
+      migration: retired
+    - name: SWARM_API_TOKEN_FILE
+      category: known_retired
+      owner: platform-spec.yaml#environment_source_authority.repo_wide_swarm_env_accepted_set
+      migration: retired
+    - name: SWARM_API_LISTEN_ADDR
+      category: seeded_legacy
+      owner: platform-spec.yaml#cli_specification.command_catalog.serve.listener_topology_v2_1
+      migration: '#1600 listener config migration'
+    - name: SWARM_MCP_LISTEN_ADDR
+      category: seeded_legacy
+      owner: platform-spec.yaml#cli_specification.command_catalog.serve.listener_topology_v2_1
+      migration: '#1600 listener config migration'
+    - name: SWARM_API_PORT
+      category: known_retired
+      owner: platform-spec.yaml#environment_source_authority.repo_wide_swarm_env_accepted_set
+      migration: retired
+    - name: SWARM_MCP_PORT
+      category: known_retired
+      owner: platform-spec.yaml#environment_source_authority.repo_wide_swarm_env_accepted_set
+      migration: retired
+    - name: SWARM_CONTRACTS_PATH
+      category: seeded_legacy
+      owner: platform-spec.yaml#cli_specification.foundations.contract_platform_spec_path_resolution
+      migration: config contracts_path or --contracts
+    - name: SWARM_CONTRACTS_DIR
+      category: known_retired
+      owner: platform-spec.yaml#environment_source_authority.repo_wide_swarm_env_accepted_set
+      migration: retired
+    - name: SWARM_PLATFORM_SPEC_PATH
+      category: known_retired
+      owner: platform-spec.yaml#environment_source_authority.repo_wide_swarm_env_accepted_set
+      migration: retired
+    - name: SWARM_DIR
+      category: known_retired
+      owner: platform-spec.yaml#environment_source_authority.repo_wide_swarm_env_accepted_set
+      migration: retired
+    - name: SWARM_HOME
+      category: known_retired
+      owner: platform-spec.yaml#environment_source_authority.repo_wide_swarm_env_accepted_set
+      migration: retired
+    - name: SWARM_STORE_BACKEND
+      category: seeded_legacy
+      owner: platform-spec.yaml#runtime_storage.runtime_store_backend_selection
+      migration: '#1637 store.backend'
+    - name: SWARM_SQLITE_PATH
+      category: seeded_legacy
+      owner: platform-spec.yaml#runtime_storage.runtime_store_backend_selection.sqlite_path
+      migration: '#1637 store.sqlite.path'
+    - name: SWARM_DB_HOST
+      category: seeded_legacy
+      owner: platform-spec.yaml#runtime_storage.runtime_store_backend_selection.postgres_connection_details
+      migration: '#1637 database.host'
+    - name: SWARM_DB_PORT
+      category: seeded_legacy
+      owner: platform-spec.yaml#runtime_storage.runtime_store_backend_selection.postgres_connection_details
+      migration: '#1637 database.port'
+    - name: SWARM_DB_NAME
+      category: seeded_legacy
+      owner: platform-spec.yaml#runtime_storage.runtime_store_backend_selection.postgres_connection_details
+      migration: '#1637 database.name'
+    - name: SWARM_DB_USER
+      category: seeded_legacy
+      owner: platform-spec.yaml#runtime_storage.runtime_store_backend_selection.postgres_connection_details
+      migration: '#1637 database.user'
+    - name: SWARM_DB_SSLMODE
+      category: seeded_legacy
+      owner: platform-spec.yaml#runtime_storage.runtime_store_backend_selection.postgres_connection_details
+      migration: '#1637 database.sslmode'
+    - name: SWARM_DB_POOL_SIZE
+      category: seeded_legacy
+      owner: platform-spec.yaml#runtime_storage.runtime_store_backend_selection.postgres_connection_details
+      migration: '#1637 database.pool_size'
+    - name: SWARM_DB_PASSWORD
+      category: known_retired
+      owner: platform-spec.yaml#environment_source_authority.repo_wide_swarm_env_accepted_set
+      migration: retired
+    - name: SWARM_WORKSPACE_DATA_SOURCE
+      category: seeded_legacy
+      owner: platform-spec.yaml#workspace_model.data_source_authority
+      migration: '#1600 workspace.data_source'
+    - name: SWARM_WORKSPACE_BACKEND
+      category: seeded_legacy
+      owner: platform-spec.yaml#workspace_model.workspace_backend_selection
+      migration: '#1600 workspace.backend'
+    - name: SWARM_DOCKER_BIN
+      category: seeded_legacy
+      owner: platform-spec.yaml#environment_source_authority.workspace_monitor_artifact_debug_slice
+      migration: '#1600 workspace/tooling config'
+    - name: SWARM_WORKSPACE_IMAGE
+      category: seeded_legacy
+      owner: platform-spec.yaml#workspace_model.runtime_image_packaging
+      migration: '#1600 workspace.image'
+    - name: SWARM_WORKSPACE_HOST_ROOT
+      category: seeded_legacy
+      owner: platform-spec.yaml#workspace_model.workspace_backend_selection
+      migration: '#1600 workspace.host_root'
+    - name: SWARM_WORKSPACE_VOLUMES_FROM
+      category: seeded_legacy
+      owner: platform-spec.yaml#workspace_model.data_source_authority
+      migration: '#1600 workspace volumes config'
+    - name: SWARM_WORKSPACE_NETWORK
+      category: seeded_legacy
+      owner: platform-spec.yaml#environment_source_authority.workspace_monitor_artifact_debug_slice
+      migration: '#1600 workspace network config'
+    - name: SWARM_WORKSPACE_DATA_MOUNT
+      category: seeded_legacy
+      owner: platform-spec.yaml#environment_source_authority.workspace_monitor_artifact_debug_slice
+      migration: '#1600 workspace mount config'
+    - name: SWARM_WORKSPACE_CONTRACTS_SOURCE
+      category: seeded_legacy
+      owner: platform-spec.yaml#environment_source_authority.workspace_monitor_artifact_debug_slice
+      migration: '#1600 workspace contracts source config'
+    - name: SWARM_WORKSPACE_CONTRACTS_MOUNT
+      category: seeded_legacy
+      owner: platform-spec.yaml#environment_source_authority.workspace_monitor_artifact_debug_slice
+      migration: '#1600 workspace contracts mount config'
+    - name: SWARM_SCAFFOLD_CONTAINER
+      category: seeded_legacy
+      owner: platform-spec.yaml#environment_source_authority.workspace_monitor_artifact_debug_slice
+      migration: '#1600 workspace lifecycle config'
+    - name: SWARM_SCAFFOLD_WORKDIR
+      category: seeded_legacy
+      owner: platform-spec.yaml#environment_source_authority.workspace_monitor_artifact_debug_slice
+      migration: '#1600 workspace lifecycle config'
+    - name: SWARM_SCAFFOLD_VOLUME
+      category: seeded_legacy
+      owner: platform-spec.yaml#environment_source_authority.workspace_monitor_artifact_debug_slice
+      migration: '#1600 workspace lifecycle config'
+    - name: SWARM_SYSTEM_CONTAINER
+      category: seeded_legacy
+      owner: platform-spec.yaml#environment_source_authority.workspace_monitor_artifact_debug_slice
+      migration: '#1600 workspace lifecycle config'
+    - name: SWARM_SYSTEM_WORKDIR
+      category: seeded_legacy
+      owner: platform-spec.yaml#environment_source_authority.workspace_monitor_artifact_debug_slice
+      migration: '#1600 workspace lifecycle config'
+    - name: SWARM_SYSTEM_ENTITIES_VOLUME
+      category: seeded_legacy
+      owner: platform-spec.yaml#environment_source_authority.workspace_monitor_artifact_debug_slice
+      migration: '#1600 workspace lifecycle config'
+    - name: SWARM_SYSTEM_NGINX_VOLUME
+      category: seeded_legacy
+      owner: platform-spec.yaml#environment_source_authority.workspace_monitor_artifact_debug_slice
+      migration: '#1600 workspace lifecycle config'
+    - name: SWARM_SYSTEM_SYSTEMD_VOLUME
+      category: seeded_legacy
+      owner: platform-spec.yaml#environment_source_authority.workspace_monitor_artifact_debug_slice
+      migration: '#1600 workspace lifecycle config'
+    - name: SWARM_ENTITY_CONTAINER_PREFIX
+      category: seeded_legacy
+      owner: platform-spec.yaml#environment_source_authority.workspace_monitor_artifact_debug_slice
+      migration: '#1600 workspace lifecycle config'
+    - name: SWARM_ENTITY_WORKDIR
+      category: seeded_legacy
+      owner: platform-spec.yaml#environment_source_authority.workspace_monitor_artifact_debug_slice
+      migration: '#1600 workspace lifecycle config'
+    - name: SWARM_RUNTIME_RECOVERY_ON_STARTUP
+      category: seeded_legacy
+      owner: platform-spec.yaml#runtime_storage.runtime_store_backend_selection
+      migration: '#1600 runtime.recovery_on_startup'
+    - name: SWARM_RUNTIME_MAX_CONCURRENT_AGENTS
+      category: known_retired
+      owner: platform-spec.yaml#environment_source_authority.repo_wide_swarm_env_accepted_set
+      migration: retired
+    - name: SWARM_RUNTIME_EVENT_POLL_INTERVAL
+      category: known_retired
+      owner: platform-spec.yaml#environment_source_authority.repo_wide_swarm_env_accepted_set
+      migration: retired
+    - name: SWARM_LLM_SESSION_LOCK_TTL
+      category: seeded_legacy
+      owner: platform-spec.yaml#engine.agent_session_management.llm_provider_selection_config_authority
+      migration: '#1600 llm.session.lock_ttl'
+    - name: SWARM_LLM_SESSION_ROTATE_AFTER_TURNS
+      category: seeded_legacy
+      owner: platform-spec.yaml#engine.agent_session_management.llm_provider_selection_config_authority
+      migration: '#1600 llm.session.rotate_after_turns'
+    - name: SWARM_LLM_SESSION_ROTATE_ON_PARSE_FAILURES
+      category: seeded_legacy
+      owner: platform-spec.yaml#engine.agent_session_management.llm_provider_selection_config_authority
+      migration: '#1600 llm.session.rotate_on_parse_failures'
+    - name: SWARM_CLAUDE_API_MAX_RETRIES
+      category: seeded_legacy
+      owner: platform-spec.yaml#engine.agent_session_management.llm_provider_selection_config_authority
+      migration: '#1600 llm.claude_api.max_retries'
+    - name: SWARM_CLAUDE_API_RETRY_BACKOFF
+      category: seeded_legacy
+      owner: platform-spec.yaml#engine.agent_session_management.llm_provider_selection_config_authority
+      migration: '#1600 llm.claude_api.retry_backoff'
+    - name: SWARM_CLAUDE_CLI_COMMAND
+      category: seeded_legacy
+      owner: platform-spec.yaml#engine.agent_session_management.llm_provider_selection_config_authority
+      migration: '#1600 llm.claude_cli.command'
+    - name: SWARM_CLAUDE_CLI_TIMEOUT
+      category: seeded_legacy
+      owner: platform-spec.yaml#engine.agent_session_management.llm_provider_selection_config_authority
+      migration: '#1600 llm.claude_cli.timeout'
+    - name: SWARM_CLAUDE_CLI_OUTPUT_FORMAT
+      category: seeded_legacy
+      owner: platform-spec.yaml#engine.agent_session_management.llm_provider_selection_config_authority
+      migration: '#1600 llm.claude_cli.output_format'
+    - name: SWARM_CLAUDE_CLI_RETRIES
+      category: seeded_legacy
+      owner: platform-spec.yaml#engine.agent_session_management.llm_provider_selection_config_authority
+      migration: '#1600 llm.claude_cli.retries'
+    - name: SWARM_CLAUDE_CLI_NO_SESSION_PERSISTENCE
+      category: seeded_legacy
+      owner: platform-spec.yaml#engine.agent_session_management.llm_provider_selection_config_authority
+      migration: '#1600 llm.claude_cli.no_session_persistence'
+    - name: SWARM_CLAUDE_CLI_USE_TMUX
+      category: seeded_legacy
+      owner: platform-spec.yaml#engine.agent_session_management.llm_provider_selection_config_authority
+      migration: '#1600 llm.claude_cli.use_tmux'
+    - name: SWARM_CLAUDE_TIMEOUT_SECONDS
+      category: seeded_legacy
+      owner: platform-spec.yaml#engine.agent_session_management.llm_provider_selection_config_authority
+      migration: '#1600 llm.claude_cli.timeout'
+    - name: SWARM_CLAUDE_PERMISSION_MODE
+      category: seeded_legacy
+      owner: platform-spec.yaml#engine.agent_session_management.llm_provider_selection_config_authority
+      migration: '#1600 llm.claude_cli.permission_mode'
+    - name: SWARM_CLAUDE_BYPASS_PERMISSIONS
+      category: seeded_legacy
+      owner: platform-spec.yaml#engine.agent_session_management.llm_provider_selection_config_authority
+      migration: '#1600 llm.claude_cli.permission_mode'
+    - name: SWARM_CLAUDE_USE_MCP
+      category: seeded_legacy
+      owner: platform-spec.yaml#cli_specification.foundations.local_tool_gateway_binding
+      migration: '#1600 typed Claude CLI transport config'
+    - name: SWARM_LLM_BACKEND
+      category: known_retired
+      owner: platform-spec.yaml#environment_source_authority.repo_wide_swarm_env_accepted_set
+      migration: retired
+    - name: SWARM_LLM_RUNTIME_MODE
+      category: known_retired
+      owner: platform-spec.yaml#environment_source_authority.repo_wide_swarm_env_accepted_set
+      migration: retired
+    - name: SWARM_CLAUDE_DEFAULT_MODEL
+      category: known_retired
+      owner: platform-spec.yaml#environment_source_authority.repo_wide_swarm_env_accepted_set
+      migration: retired
+    - name: SWARM_CLAUDE_HAIKU_MODEL
+      category: known_retired
+      owner: platform-spec.yaml#environment_source_authority.repo_wide_swarm_env_accepted_set
+      migration: retired
+    - name: SWARM_OPENAI_COMPATIBLE_BASE_URL
+      category: known_retired
+      owner: platform-spec.yaml#environment_source_authority.repo_wide_swarm_env_accepted_set
+      migration: retired
+    - name: SWARM_OPENAI_COMPATIBLE_DEFAULT_MODEL
+      category: known_retired
+      owner: platform-spec.yaml#environment_source_authority.repo_wide_swarm_env_accepted_set
+      migration: retired
+    - name: SWARM_OPENAI_COMPATIBLE_LOW_COST_MODEL
+      category: known_retired
+      owner: platform-spec.yaml#environment_source_authority.repo_wide_swarm_env_accepted_set
+      migration: retired
+    - name: SWARM_CREDENTIALS_FILE
+      category: seeded_legacy
+      owner: platform-spec.yaml#environment_source_authority.repo_wide_swarm_env_accepted_set
+      migration: '#1600 secrets file config'
+    - name: SWARM_MANAGED_CREDENTIALS_FILE
+      category: seeded_legacy
+      owner: platform-spec.yaml#environment_source_authority.repo_wide_swarm_env_accepted_set
+      migration: '#1600 managed credentials file config'
+    - name: SWARM_ARTIFACT_ROOT
+      category: seeded_legacy
+      owner: platform-spec.yaml#runtime_storage.artifact_root
+      migration: '#1600 runtime.artifact_root'
+    - name: SWARM_MONITOR_DIR
+      category: seeded_legacy
+      owner: platform-spec.yaml#environment_source_authority.workspace_monitor_artifact_debug_slice
+      migration: '#1600 monitor config'
+    - name: SWARM_PROMPTS_DIR
+      category: seeded_legacy
+      owner: platform-spec.yaml#environment_source_authority.workspace_monitor_artifact_debug_slice
+      migration: '#1600 prompt helper config'
+    - name: SWARM_AGENT_CONFIG_MAP_FILE
+      category: seeded_legacy
+      owner: platform-spec.yaml#environment_source_authority.workspace_monitor_artifact_debug_slice
+      migration: '#1600 spec helper config'
+    - name: SWARM_VERIFICATION_GATES_FILE
+      category: seeded_legacy
+      owner: platform-spec.yaml#environment_source_authority.workspace_monitor_artifact_debug_slice
+      migration: '#1600 spec helper config'
+    - name: SWARM_TOOLING_LOCK_FILE
+      category: seeded_legacy
+      owner: platform-spec.yaml#environment_source_authority.workspace_monitor_artifact_debug_slice
+      migration: '#1600 spec helper config'
+    - name: SWARM_LOG_LEVEL
+      category: known_retired
+      owner: platform-spec.yaml#environment_source_authority.repo_wide_swarm_env_accepted_set
+      migration: retired
+    - name: SWARM_SQL_DEBUG
+      category: test_quarantine
+      owner: platform-spec.yaml#environment_source_authority.repo_wide_swarm_env_accepted_set
+      migration: test/debug quarantine
+    - name: SWARM_BOOT_WARNINGS_FATAL
+      category: test_quarantine
+      owner: platform-spec.yaml#environment_source_authority.repo_wide_swarm_env_accepted_set
+      migration: test/debug quarantine
+    - name: SWARM_EMIT_SCHEMA_STRICT
+      category: test_quarantine
+      owner: platform-spec.yaml#environment_source_authority.repo_wide_swarm_env_accepted_set
+      migration: test/debug quarantine
+    - name: SWARM_CATALOG_E2E_DEBUG
+      category: test_quarantine
+      owner: platform-spec.yaml#environment_source_authority.repo_wide_swarm_env_accepted_set
+      migration: test/debug quarantine
+    - name: SWARM_FAKE_DOCKER_STATE
+      category: test_quarantine
+      owner: platform-spec.yaml#environment_source_authority.repo_wide_swarm_env_accepted_set
+      migration: test/debug quarantine
+    - name: SWARM_LLM_FIRST_TURN_FAKE_DOCKER
+      category: test_quarantine
+      owner: platform-spec.yaml#environment_source_authority.repo_wide_swarm_env_accepted_set
+      migration: test/debug quarantine
+    - name: SWARM_TEST_HARNESS
+      category: test_quarantine
+      owner: platform-spec.yaml#environment_source_authority.repo_wide_swarm_env_accepted_set
+      migration: test/debug quarantine
+    - prefix: SWARM_TEST_
+      category: test_quarantine
+      owner: platform-spec.yaml#environment_source_authority.repo_wide_swarm_env_accepted_set
+      migration: test/debug quarantine
+    - name: SWARM_TOOL_GATEWAY_URL
+      category: generated_boundary
+      owner: platform-spec.yaml#cli_specification.foundations.local_tool_gateway_binding
+      migration: generated final-boundary only
+    - name: SWARM_TOOL_GATEWAY_CONTAINER_URL
+      category: generated_boundary
+      owner: platform-spec.yaml#cli_specification.foundations.local_tool_gateway_binding
+      migration: generated final-boundary only
+    - name: SWARM_TOOL_GATEWAY_TOKEN
+      category: known_retired
+      owner: platform-spec.yaml#environment_source_authority.repo_wide_swarm_env_accepted_set
+      migration: retired
+    - name: SWARM_BUILDER_AUTH_TOKEN
+      category: known_retired
+      owner: platform-spec.yaml#environment_source_authority.repo_wide_swarm_env_accepted_set
+      migration: retired
+    - name: SWARM_OPERATOR_AUTH_TOKEN
+      category: known_retired
+      owner: platform-spec.yaml#environment_source_authority.repo_wide_swarm_env_accepted_set
+      migration: retired
   workspace_monitor_artifact_debug_slice:
     promoted_by: '#1640'
     parent_tracker: '#1600'


### PR DESCRIPTION
## Summary

Closes #1731.
Part of #1600.

Adds the first implementation slice for repo-wide `SWARM_*` environment source authority:

- adds `platform-spec.yaml#environment_source_authority.repo_wide_swarm_env_accepted_set` as the authoritative accepted-set owner
- wires a pre-side-effect CLI guard for covered commands, with fail-closed blockers for unknown/stale, known-retired, generated-boundary-in-parent, and non-test test-quarantine env
- adds typed delegation admission for `database.password_env` so explicit env delegation is schema-visible rather than ambient
- adds non-blocking `swarm doctor` env reporting with JSON/text findings and combined config/env failures
- closes the dynamic credential lookup backdoor for present `SWARM_*` credential names
- adds code/spec drift tests for the accepted-set catalog

## Governing Refs / Context

Exact binding spec refs:

- `platform-spec.yaml#environment_source_authority.repo_wide_swarm_env_accepted_set`
- `platform-spec.yaml#environment_source_authority.workspace_monitor_artifact_debug_slice`
- `platform-spec.yaml#runtime_storage.runtime_store_backend_selection.postgres_password_source_authority`
- `platform-spec.yaml#cli_specification.foundations.api_connection_auth_config_precedence`
- `platform-spec.yaml#cli_specification.foundations.local_tool_gateway_binding`
- `platform-spec.yaml#cli_specification.command_catalog.doctor`

Binding issue context:

- #1731 approved as first slice after the pre-implementation gate
- #1600 remains the broader parent for completing env-source-authority removal/migration

## Semantic Migration

New canonical owner:

- `platform-spec.yaml#environment_source_authority.repo_wide_swarm_env_accepted_set`

Old paths now invalid/non-authoritative:

- unknown or typoed `SWARM_*` parent-process env for covered CLI commands
- known-retired API/auth/gateway/model/runtime env as ambient authority
- parent-process generated-boundary env such as `SWARM_TOOL_GATEWAY_URL` and `SWARM_TOOL_GATEWAY_CONTAINER_URL`
- dynamic credential lookup of present `SWARM_*` names

Surviving old behavior checked:

- seeded legacy rows remain accepted only as spec/catalog TODO entries with migration pointers
- test-quarantined env remains accepted under Go test context
- `SWARM_CONFIG` remains the bootstrap config locator
- `database.password_env` can explicitly delegate to a named env variable

Migration completeness:

- complete for #1731 chosen class
- not complete for #1600 parent; later child PRs should shrink seeded legacy rows toward `{SWARM_CONFIG} + test quarantine + generated boundary`

## Proof

- `go test ./cmd/swarm -run 'TestRepoWideSwarmEnvAcceptedSetMatchesSpec|TestSwarmEnvGuard|TestDoctorReportsSwarmEnvFindingsWithConfigFailure|TestDoctorClaudeCLIPreflightReportsRetiredBackendEnv|TestDoctorClaudeCLIPreflightBlocksGeneratedGatewayParentEnv' -count=1`
- `go test ./internal/runtime/credentials -run 'TestEnvStoreRejectsSwarmCredentialBackdoor|TestOverlayStore_EnvOverridesFile' -count=1`
- `SWARM_TEST_POSTGRES_DSN='host=127.0.0.1 port=5432 user=postgres password=postgres dbname=postgres sslmode=disable' go test ./...`

Note: an initial unqualified `go test ./...` attempted Docker-backed Postgres and failed because Docker/Colima was unavailable at `/var/run/docker.sock`. The required whole-suite proof passed against the configured host Postgres DSN.
