### PR TITLE
[agent-g][issue #1445] Preserve task audit scope identity

### DIFF
--- a/internal/runtime/llm/persistence.go
+++ b/internal/runtime/llm/persistence.go
@@ -17,6 +17,7 @@ type AgentTurnRecord struct {
 	ScopeKey         string
 	RunID            string
 	EntityID         string
+	FlowInstance     string
 	TriggerEventID   string
 	TriggerEventType string
 	AvailableTools   []string
@@ -65,6 +66,9 @@ func enrichTurnRecord(ctx context.Context, s *Session, rec AgentTurnRecord, resp
 		}
 		if strings.TrimSpace(rec.EntityID) == "" {
 			rec.EntityID = strings.TrimSpace(inbound.EntityID())
+		}
+		if strings.TrimSpace(rec.FlowInstance) == "" {
+			rec.FlowInstance = strings.TrimSpace(inbound.FlowInstance())
 		}
 	}
 	if resp != nil && len(rec.ToolCalls) == 0 {

--- a/internal/runtime/llm/session_events_test.go
+++ b/internal/runtime/llm/session_events_test.go
@@ -323,6 +323,35 @@ func TestEnrichTurnRecord_UsesCanonicalVisibleToolsForNativeCapabilities(t *test
 	}
 }
 
+func TestEnrichTurnRecord_CarriesInboundFlowInstance(t *testing.T) {
+	ctx := runtimebus.WithInboundEvent(context.Background(), eventtest.RootIngress(
+		"11111111-1111-1111-1111-111111111111",
+		events.EventType("analysis.requested"),
+		"tester",
+		"",
+		nil,
+		0,
+		"run-123",
+		"",
+		events.EventEnvelope{FlowInstance: "review/inst-1"},
+		time.Now(),
+	))
+	rec := enrichTurnRecord(ctx, &Session{
+		ID: "session-1",
+	}, AgentTurnRecord{
+		AgentID:     "analysis-agent",
+		RuntimeMode: sessions.RuntimeModeTask.String(),
+		SessionID:   "session-1",
+	}, nil)
+
+	if rec.FlowInstance != "review/inst-1" {
+		t.Fatalf("flow_instance = %q, want review/inst-1", rec.FlowInstance)
+	}
+	if rec.EntityID != "" {
+		t.Fatalf("entity_id = %q, want empty for flow-only inbound event", rec.EntityID)
+	}
+}
+
 func TestEnrichTurnRecord_FiltersCLIControlToolsFromObservedVisibleTools(t *testing.T) {
 	ctx := runtimeactors.WithActor(context.Background(), runtimeactors.AgentConfig{
 		ID: "analysis-agent",

--- a/internal/runtime/llm/session_events_test.go
+++ b/internal/runtime/llm/session_events_test.go
@@ -714,6 +714,28 @@ func TestClaudeCLIRuntime_PersistConversationIncludesSessionScope(t *testing.T) 
 	}
 }
 
+func TestClaudeCLIRuntime_PersistConversationSuccessDoesNotLogFailure(t *testing.T) {
+	store := &captureConversationStore{}
+	publisher := &eventPublisherStub{}
+	runtime := NewClaudeCLIRuntime(&config.Config{}, sessions.NewInMemoryRegistry(0), "worker-1", nil, nil, nil, store, publisher)
+
+	runtime.persistConversation(context.Background(), &Session{
+		ID:               "session-task",
+		AgentID:          "agent-task",
+		ConversationMode: sessions.RuntimeModeTask.String(),
+		ScopeKey:         "task-scope",
+		Messages:         []Message{{Role: "assistant", Content: "done"}},
+		TurnCount:        1,
+	})
+
+	if store.record.Mode != sessions.RuntimeModeTask.String() || store.record.SessionID != "session-task" {
+		t.Fatalf("stored conversation = %+v, want task session snapshot", store.record)
+	}
+	if len(publisher.runtimeLogs) != 0 {
+		t.Fatalf("runtime log count = %d, want 0 after successful task conversation persistence", len(publisher.runtimeLogs))
+	}
+}
+
 func TestClaudeCLIRuntime_StartSessionLoadsRetryLineage(t *testing.T) {
 	store := &captureConversationStore{
 		load: ConversationRecord{

--- a/internal/store/llm_store.go
+++ b/internal/store/llm_store.go
@@ -452,7 +452,7 @@ func (s *PostgresStore) ensureTaskConversationAuditRowTx(ctx context.Context, tx
 	if caps.Conversations.Audits != SchemaFlavorCanonical {
 		return unsupportedSchemaCapability("agent_conversation_audits", caps.Conversations.Audits)
 	}
-	scopeKey := strings.TrimSpace(rec.ScopeKey)
+	identity := taskAuditIdentityFromTurn(rec)
 	if caps.Conversations.AuditRunID {
 		if err := s.ensureRunRow(ctx, caps, tx, rec.RunID, "", "", true); err != nil {
 			return err
@@ -471,27 +471,40 @@ func (s *PostgresStore) ensureTaskConversationAuditRowTx(ctx context.Context, tx
 			$1::uuid,
 			$2,
 			NULLIF($3,'')::uuid,
-			NULL,
-			NULLIF($4, ''),
-			$5,
+			NULLIF($4,''),
+			NULLIF($5, ''),
+			$6,
 			'[]'::jsonb,
 			0,
-			$6,
+			$7,
 			'{}'::jsonb,
 			'active',
 			now(),
 			now()
 		)
 		ON CONFLICT (session_id) DO UPDATE SET
+			entity_id = COALESCE(EXCLUDED.entity_id, agent_conversation_audits.entity_id),
+			flow_instance = COALESCE(EXCLUDED.flow_instance, agent_conversation_audits.flow_instance),
+			scope_key = CASE
+				WHEN EXCLUDED.entity_id IS NOT NULL OR EXCLUDED.flow_instance IS NOT NULL THEN EXCLUDED.scope_key
+				WHEN agent_conversation_audits.entity_id IS NOT NULL OR agent_conversation_audits.flow_instance IS NOT NULL THEN agent_conversation_audits.scope_key
+				ELSE COALESCE(EXCLUDED.scope_key, agent_conversation_audits.scope_key)
+			END,
+			scope = CASE
+				WHEN EXCLUDED.entity_id IS NOT NULL OR EXCLUDED.flow_instance IS NOT NULL THEN EXCLUDED.scope
+				WHEN agent_conversation_audits.entity_id IS NOT NULL OR agent_conversation_audits.flow_instance IS NOT NULL THEN agent_conversation_audits.scope
+				ELSE EXCLUDED.scope
+			END,
 			status = 'active',
 			updated_at = now()
 	`
 	args := []any{
 		rec.SessionID,
 		rec.AgentID,
-		rec.EntityID,
-		scopeKey,
-		"global",
+		identity.EntityID,
+		identity.FlowInstance,
+		identity.ScopeKey,
+		identity.Scope,
 		runtimesessions.RuntimeModeTask.String(),
 	}
 	if caps.Conversations.AuditRunID {
@@ -505,12 +518,12 @@ func (s *PostgresStore) ensureTaskConversationAuditRowTx(ctx context.Context, tx
 				NULLIF($2,'')::uuid,
 				$3,
 				NULLIF($4,'')::uuid,
-				NULL,
-				NULLIF($5, ''),
-				$6,
+				NULLIF($5,''),
+				NULLIF($6, ''),
+				$7,
 				'[]'::jsonb,
 				0,
-				$7,
+				$8,
 				'{}'::jsonb,
 				'active',
 				now(),
@@ -518,6 +531,18 @@ func (s *PostgresStore) ensureTaskConversationAuditRowTx(ctx context.Context, tx
 			)
 			ON CONFLICT (session_id) DO UPDATE SET
 				run_id = COALESCE(agent_conversation_audits.run_id, EXCLUDED.run_id),
+				entity_id = COALESCE(EXCLUDED.entity_id, agent_conversation_audits.entity_id),
+				flow_instance = COALESCE(EXCLUDED.flow_instance, agent_conversation_audits.flow_instance),
+				scope_key = CASE
+					WHEN EXCLUDED.entity_id IS NOT NULL OR EXCLUDED.flow_instance IS NOT NULL THEN EXCLUDED.scope_key
+					WHEN agent_conversation_audits.entity_id IS NOT NULL OR agent_conversation_audits.flow_instance IS NOT NULL THEN agent_conversation_audits.scope_key
+					ELSE COALESCE(EXCLUDED.scope_key, agent_conversation_audits.scope_key)
+				END,
+				scope = CASE
+					WHEN EXCLUDED.entity_id IS NOT NULL OR EXCLUDED.flow_instance IS NOT NULL THEN EXCLUDED.scope
+					WHEN agent_conversation_audits.entity_id IS NOT NULL OR agent_conversation_audits.flow_instance IS NOT NULL THEN agent_conversation_audits.scope
+					ELSE EXCLUDED.scope
+				END,
 				status = 'active',
 				updated_at = now()
 		`
@@ -525,9 +550,10 @@ func (s *PostgresStore) ensureTaskConversationAuditRowTx(ctx context.Context, tx
 			rec.SessionID,
 			nullUUIDString(rec.RunID),
 			rec.AgentID,
-			rec.EntityID,
-			scopeKey,
-			"global",
+			identity.EntityID,
+			identity.FlowInstance,
+			identity.ScopeKey,
+			identity.Scope,
 			runtimesessions.RuntimeModeTask.String(),
 		}
 	}
@@ -612,11 +638,7 @@ func (s *PostgresStore) UpsertConversation(ctx context.Context, rec runtimellm.C
 		if caps.Conversations.Audits != SchemaFlavorCanonical {
 			return unsupportedSchemaCapability("agent_conversation_audits", caps.Conversations.Audits)
 		}
-		scopeKey := strings.TrimSpace(rec.ScopeKey)
-		scope := resolved.Scope.String()
-		if scope == "" {
-			scope = runtimesessions.SessionScopeGlobal.String()
-		}
+		identity := taskAuditIdentityFromConversation(rec)
 		q := `
 			INSERT INTO agent_conversation_audits (
 				session_id, agent_id, entity_id, flow_instance, scope_key, scope,
@@ -624,13 +646,13 @@ func (s *PostgresStore) UpsertConversation(ctx context.Context, rec runtimellm.C
 			)
 			VALUES (
 				$1::uuid,
-				$2,
-				NULLIF($3,'')::uuid,
-				NULLIF($4,''),
-				$5,
-				$6,
-				$7::jsonb,
-				$8,
+			$2,
+			NULLIF($3,'')::uuid,
+			NULLIF($4,''),
+			NULLIF($5, ''),
+			$6,
+			$7::jsonb,
+			$8,
 				$9,
 				$10::jsonb,
 				$11,
@@ -639,10 +661,18 @@ func (s *PostgresStore) UpsertConversation(ctx context.Context, rec runtimellm.C
 			)
 			ON CONFLICT (session_id) DO UPDATE SET
 				agent_id = EXCLUDED.agent_id,
-				entity_id = EXCLUDED.entity_id,
-				flow_instance = EXCLUDED.flow_instance,
-				scope_key = EXCLUDED.scope_key,
-				scope = EXCLUDED.scope,
+				entity_id = COALESCE(EXCLUDED.entity_id, agent_conversation_audits.entity_id),
+				flow_instance = COALESCE(EXCLUDED.flow_instance, agent_conversation_audits.flow_instance),
+				scope_key = CASE
+					WHEN EXCLUDED.entity_id IS NOT NULL OR EXCLUDED.flow_instance IS NOT NULL THEN EXCLUDED.scope_key
+					WHEN agent_conversation_audits.entity_id IS NOT NULL OR agent_conversation_audits.flow_instance IS NOT NULL THEN agent_conversation_audits.scope_key
+					ELSE COALESCE(EXCLUDED.scope_key, agent_conversation_audits.scope_key)
+				END,
+				scope = CASE
+					WHEN EXCLUDED.entity_id IS NOT NULL OR EXCLUDED.flow_instance IS NOT NULL THEN EXCLUDED.scope
+					WHEN agent_conversation_audits.entity_id IS NOT NULL OR agent_conversation_audits.flow_instance IS NOT NULL THEN agent_conversation_audits.scope
+					ELSE EXCLUDED.scope
+				END,
 				conversation = EXCLUDED.conversation,
 				turn_count = EXCLUDED.turn_count,
 				runtime_mode = EXCLUDED.runtime_mode,
@@ -653,10 +683,10 @@ func (s *PostgresStore) UpsertConversation(ctx context.Context, rec runtimellm.C
 		args := []any{
 			sessionID,
 			rec.AgentID,
-			resolved.EntityID,
-			resolved.FlowInstance,
-			scopeKey,
-			scope,
+			identity.EntityID,
+			identity.FlowInstance,
+			identity.ScopeKey,
+			identity.Scope,
 			string(msgJSON),
 			rec.TurnCount,
 			mode.String(),
@@ -678,7 +708,7 @@ func (s *PostgresStore) UpsertConversation(ctx context.Context, rec runtimellm.C
 					$3,
 					NULLIF($4,'')::uuid,
 					NULLIF($5,''),
-					$6,
+					NULLIF($6, ''),
 					$7,
 					$8::jsonb,
 					$9,
@@ -691,10 +721,18 @@ func (s *PostgresStore) UpsertConversation(ctx context.Context, rec runtimellm.C
 				ON CONFLICT (session_id) DO UPDATE SET
 					run_id = COALESCE(EXCLUDED.run_id, agent_conversation_audits.run_id),
 					agent_id = EXCLUDED.agent_id,
-					entity_id = EXCLUDED.entity_id,
-					flow_instance = EXCLUDED.flow_instance,
-					scope_key = EXCLUDED.scope_key,
-					scope = EXCLUDED.scope,
+					entity_id = COALESCE(EXCLUDED.entity_id, agent_conversation_audits.entity_id),
+					flow_instance = COALESCE(EXCLUDED.flow_instance, agent_conversation_audits.flow_instance),
+					scope_key = CASE
+						WHEN EXCLUDED.entity_id IS NOT NULL OR EXCLUDED.flow_instance IS NOT NULL THEN EXCLUDED.scope_key
+						WHEN agent_conversation_audits.entity_id IS NOT NULL OR agent_conversation_audits.flow_instance IS NOT NULL THEN agent_conversation_audits.scope_key
+						ELSE COALESCE(EXCLUDED.scope_key, agent_conversation_audits.scope_key)
+					END,
+					scope = CASE
+						WHEN EXCLUDED.entity_id IS NOT NULL OR EXCLUDED.flow_instance IS NOT NULL THEN EXCLUDED.scope
+						WHEN agent_conversation_audits.entity_id IS NOT NULL OR agent_conversation_audits.flow_instance IS NOT NULL THEN agent_conversation_audits.scope
+						ELSE EXCLUDED.scope
+					END,
 					conversation = EXCLUDED.conversation,
 					turn_count = EXCLUDED.turn_count,
 					runtime_mode = EXCLUDED.runtime_mode,
@@ -706,10 +744,10 @@ func (s *PostgresStore) UpsertConversation(ctx context.Context, rec runtimellm.C
 				sessionID,
 				runID,
 				rec.AgentID,
-				resolved.EntityID,
-				resolved.FlowInstance,
-				scopeKey,
-				scope,
+				identity.EntityID,
+				identity.FlowInstance,
+				identity.ScopeKey,
+				identity.Scope,
 				string(msgJSON),
 				rec.TurnCount,
 				mode.String(),

--- a/internal/store/postgres_store_additional_test.go
+++ b/internal/store/postgres_store_additional_test.go
@@ -5169,20 +5169,111 @@ func TestManagerStore_AppendAgentTurn_TaskCreatesAuditRowIfMissing(t *testing.T)
 	}
 
 	var count, turns int
+	var persistedScope, persistedScopeKey string
 	if err := db.QueryRowContext(ctx, `
 		SELECT
 			COUNT(*),
+			COALESCE(MAX(scope), ''),
+			COALESCE(MAX(scope_key), ''),
 			(SELECT COUNT(*) FROM agent_turns WHERE session_id = $1::uuid AND runtime_mode = 'task')
 		FROM agent_conversation_audits
 		WHERE session_id = $1::uuid
-	`, sessionID).Scan(&count, &turns); err != nil {
+	`, sessionID).Scan(&count, &persistedScope, &persistedScopeKey, &turns); err != nil {
 		t.Fatalf("count synthesized task persistence: %v", err)
 	}
 	if count != 1 {
 		t.Fatalf("expected one synthesized task audit row, got %d", count)
 	}
+	if persistedScope != "global" || persistedScopeKey != "" {
+		t.Fatalf("synthesized task audit identity scope=%q scope_key=%q, want global/no scope_key", persistedScope, persistedScopeKey)
+	}
 	if turns != 1 {
 		t.Fatalf("expected one task agent_turn row after synthesized append, got %d", turns)
+	}
+}
+
+func TestManagerStore_AppendAgentTurn_TaskEntityScopeSurvivesConversationUpsert(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &PostgresStore{DB: db}
+	ctx := context.Background()
+	resetAgentSessionsSpecTable(t, ctx, pg)
+	seedSpecAgent(t, ctx, pg, "a1", "", "")
+
+	sessionID := uuid.NewString()
+	entityID := uuid.NewString()
+	runID := uuid.NewString()
+	if err := pg.AppendAgentTurn(ctx, runtimellm.AgentTurnRecord{
+		AgentID:        "a1",
+		RuntimeMode:    "task",
+		SessionID:      sessionID,
+		ScopeKey:       "noncanonical-task-key",
+		RunID:          runID,
+		EntityID:       entityID,
+		RequestPayload: []byte(`{"kind":"task"}`),
+		ResponseRaw:    []byte(`{"ok":true}`),
+		ParseOK:        true,
+		Latency:        5 * time.Millisecond,
+	}); err != nil {
+		t.Fatalf("AppendAgentTurn(task entity): %v", err)
+	}
+	if err := pg.UpsertConversation(ctx, runtimellm.ConversationRecord{
+		SessionID: sessionID,
+		AgentID:   "a1",
+		ScopeKey:  "snapshot-task-key",
+		RunID:     runID,
+		Mode:      "task",
+		Messages: []llm.Message{
+			{Role: "user", Content: "entity task"},
+			{Role: "assistant", Content: "entity done"},
+		},
+		TurnCount: 1,
+		Status:    "active",
+	}); err != nil {
+		t.Fatalf("UpsertConversation(task entity): %v", err)
+	}
+
+	var count, turns int
+	var scope, scopeKey, gotEntityID, flowInstance, conversation, persistedRunID string
+	if err := db.QueryRowContext(ctx, `
+		SELECT
+			COUNT(*),
+			COALESCE(MAX(scope), ''),
+			COALESCE(MAX(scope_key), ''),
+			COALESCE(MAX(entity_id::text), ''),
+			COALESCE(MAX(flow_instance), ''),
+			COALESCE(MAX(conversation::text), ''),
+			COALESCE(MAX(run_id::text), ''),
+			(SELECT COUNT(*) FROM agent_turns WHERE session_id = $1::uuid AND runtime_mode = 'task' AND entity_id = $2::uuid)
+		FROM agent_conversation_audits
+		WHERE session_id = $1::uuid
+	`, sessionID, entityID).Scan(&count, &scope, &scopeKey, &gotEntityID, &flowInstance, &conversation, &persistedRunID, &turns); err != nil {
+		t.Fatalf("read entity task audit row: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("audit row count = %d, want 1", count)
+	}
+	if scope != "entity" || scopeKey != entityID || gotEntityID != entityID || flowInstance != "" {
+		t.Fatalf("audit identity scope=%q scope_key=%q entity_id=%q flow_instance=%q, want entity %s", scope, scopeKey, gotEntityID, flowInstance, entityID)
+	}
+	if persistedRunID != "" && persistedRunID != runID {
+		t.Fatalf("audit run_id = %q, want %q or absent when audit run_id capability is unavailable", persistedRunID, runID)
+	}
+	if !strings.Contains(conversation, "entity done") {
+		t.Fatalf("conversation = %s, want persisted assistant message", conversation)
+	}
+	if turns != 1 {
+		t.Fatalf("linked task turn count = %d, want 1", turns)
+	}
+
+	detail, err := pg.LoadOperatorConversation(ctx, sessionID)
+	if err != nil {
+		t.Fatalf("LoadOperatorConversation: %v", err)
+	}
+	if detail.Conversation.Scope != "entity" || detail.Conversation.ScopeKey != entityID || detail.Conversation.RuntimeMode != "task" || detail.Conversation.TurnCount != 1 {
+		t.Fatalf("operator conversation summary = %+v, want entity-scoped task audit with one turn", detail.Conversation)
+	}
+	if len(detail.Turns) != 1 {
+		t.Fatalf("operator conversation turns = %d, want 1", len(detail.Turns))
 	}
 }
 

--- a/internal/store/postgres_store_additional_test.go
+++ b/internal/store/postgres_store_additional_test.go
@@ -5277,6 +5277,91 @@ func TestManagerStore_AppendAgentTurn_TaskEntityScopeSurvivesConversationUpsert(
 	}
 }
 
+func TestManagerStore_AppendAgentTurn_TaskFlowScopeSurvivesConversationUpsert(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &PostgresStore{DB: db}
+	ctx := context.Background()
+	resetAgentSessionsSpecTable(t, ctx, pg)
+	seedSpecAgent(t, ctx, pg, "a1", "", "")
+
+	sessionID := uuid.NewString()
+	flowInstance := "review/inst-1"
+	runID := uuid.NewString()
+	if err := pg.AppendAgentTurn(ctx, runtimellm.AgentTurnRecord{
+		AgentID:        "a1",
+		RuntimeMode:    "task",
+		SessionID:      sessionID,
+		ScopeKey:       "noncanonical-task-key",
+		RunID:          runID,
+		FlowInstance:   flowInstance,
+		RequestPayload: []byte(`{"kind":"task"}`),
+		ResponseRaw:    []byte(`{"ok":true}`),
+		ParseOK:        true,
+		Latency:        5 * time.Millisecond,
+	}); err != nil {
+		t.Fatalf("AppendAgentTurn(task flow): %v", err)
+	}
+	if err := pg.UpsertConversation(ctx, runtimellm.ConversationRecord{
+		SessionID: sessionID,
+		AgentID:   "a1",
+		ScopeKey:  "snapshot-task-key",
+		RunID:     runID,
+		Mode:      "task",
+		Messages: []llm.Message{
+			{Role: "user", Content: "flow task"},
+			{Role: "assistant", Content: "flow done"},
+		},
+		TurnCount: 1,
+		Status:    "active",
+	}); err != nil {
+		t.Fatalf("UpsertConversation(task flow): %v", err)
+	}
+
+	var count, turns int
+	var scope, scopeKey, entityID, gotFlowInstance, conversation, persistedRunID string
+	if err := db.QueryRowContext(ctx, `
+		SELECT
+			COUNT(*),
+			COALESCE(MAX(scope), ''),
+			COALESCE(MAX(scope_key), ''),
+			COALESCE(MAX(entity_id::text), ''),
+			COALESCE(MAX(flow_instance), ''),
+			COALESCE(MAX(conversation::text), ''),
+			COALESCE(MAX(run_id::text), ''),
+			(SELECT COUNT(*) FROM agent_turns WHERE session_id = $1::uuid AND runtime_mode = 'task')
+		FROM agent_conversation_audits
+		WHERE session_id = $1::uuid
+	`, sessionID).Scan(&count, &scope, &scopeKey, &entityID, &gotFlowInstance, &conversation, &persistedRunID, &turns); err != nil {
+		t.Fatalf("read flow task audit row: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("audit row count = %d, want 1", count)
+	}
+	if scope != "flow" || scopeKey != flowInstance || gotFlowInstance != flowInstance || entityID != "" {
+		t.Fatalf("audit identity scope=%q scope_key=%q entity_id=%q flow_instance=%q, want flow %s", scope, scopeKey, entityID, gotFlowInstance, flowInstance)
+	}
+	if persistedRunID != "" && persistedRunID != runID {
+		t.Fatalf("audit run_id = %q, want %q or absent when audit run_id capability is unavailable", persistedRunID, runID)
+	}
+	if !strings.Contains(conversation, "flow done") {
+		t.Fatalf("conversation = %s, want persisted assistant message", conversation)
+	}
+	if turns != 1 {
+		t.Fatalf("linked task turn count = %d, want 1", turns)
+	}
+
+	detail, err := pg.LoadOperatorConversation(ctx, sessionID)
+	if err != nil {
+		t.Fatalf("LoadOperatorConversation: %v", err)
+	}
+	if detail.Conversation.Scope != "flow" || detail.Conversation.ScopeKey != flowInstance || detail.Conversation.RuntimeMode != "task" || detail.Conversation.TurnCount != 1 {
+		t.Fatalf("operator conversation summary = %+v, want flow-scoped task audit with one turn", detail.Conversation)
+	}
+	if len(detail.Turns) != 1 {
+		t.Fatalf("operator conversation turns = %d, want 1", len(detail.Turns))
+	}
+}
+
 func TestManagerStore_AppendAgentTurn_TaskDoesNotAdoptLegacySessionRow(t *testing.T) {
 	_, db, _ := testutil.StartPostgres(t)
 	pg := &PostgresStore{DB: db}

--- a/internal/store/sqlite_runtime_llm.go
+++ b/internal/store/sqlite_runtime_llm.go
@@ -128,6 +128,7 @@ func (s *SQLiteRuntimeStore) UpsertConversation(ctx context.Context, rec runtime
 			return err
 		}
 		if resolved.Stateless {
+			identity := taskAuditIdentityFromConversation(rec)
 			if _, err := tx.ExecContext(txctx, `
 				INSERT INTO agent_conversation_audits (
 					session_id, run_id, agent_id, entity_id, flow_instance, scope_key, scope,
@@ -139,18 +140,26 @@ func (s *SQLiteRuntimeStore) UpsertConversation(ctx context.Context, rec runtime
 				ON CONFLICT(session_id) DO UPDATE SET
 					run_id = COALESCE(excluded.run_id, agent_conversation_audits.run_id),
 					agent_id = excluded.agent_id,
-					entity_id = excluded.entity_id,
-					flow_instance = excluded.flow_instance,
-					scope_key = excluded.scope_key,
-					scope = excluded.scope,
+					entity_id = COALESCE(excluded.entity_id, agent_conversation_audits.entity_id),
+					flow_instance = COALESCE(excluded.flow_instance, agent_conversation_audits.flow_instance),
+					scope_key = CASE
+						WHEN excluded.entity_id IS NOT NULL OR excluded.flow_instance IS NOT NULL THEN excluded.scope_key
+						WHEN agent_conversation_audits.entity_id IS NOT NULL OR agent_conversation_audits.flow_instance IS NOT NULL THEN agent_conversation_audits.scope_key
+						ELSE COALESCE(excluded.scope_key, agent_conversation_audits.scope_key)
+					END,
+					scope = CASE
+						WHEN excluded.entity_id IS NOT NULL OR excluded.flow_instance IS NOT NULL THEN excluded.scope
+						WHEN agent_conversation_audits.entity_id IS NOT NULL OR agent_conversation_audits.flow_instance IS NOT NULL THEN agent_conversation_audits.scope
+						ELSE excluded.scope
+					END,
 					conversation = excluded.conversation,
 					turn_count = excluded.turn_count,
 					runtime_mode = excluded.runtime_mode,
 					runtime_state = json_patch(COALESCE(agent_conversation_audits.runtime_state, '{}'), excluded.runtime_state),
 					status = excluded.status,
 					updated_at = excluded.updated_at
-			`, sessionID, sqliteNullUUID(runID), agentID, sqliteNullUUID(resolved.EntityID), sqliteNullString(resolved.FlowInstance),
-				sqliteNullString(resolved.ScopeKey), resolved.Scope.String(), string(msgJSON), rec.TurnCount, mode.String(),
+			`, sessionID, sqliteNullUUID(runID), agentID, sqliteNullUUID(identity.EntityID), sqliteNullString(identity.FlowInstance),
+				sqliteNullString(identity.ScopeKey), identity.Scope, string(msgJSON), rec.TurnCount, mode.String(),
 				runtimeStatePatch, status, now, now); err != nil {
 				return fmt.Errorf("upsert sqlite task conversation audit: %w", err)
 			}
@@ -302,14 +311,7 @@ func (s *SQLiteRuntimeStore) ensureSQLiteTaskConversationAuditRowTx(ctx context.
 		return fmt.Errorf("task conversation audit session_id is required")
 	}
 	runID := nullUUIDString(rec.RunID)
-	scopeKey := strings.TrimSpace(rec.ScopeKey)
-	scope := "global"
-	if strings.TrimSpace(rec.EntityID) != "" {
-		scope = "entity"
-		if scopeKey == "" {
-			scopeKey = strings.TrimSpace(rec.EntityID)
-		}
-	}
+	identity := taskAuditIdentityFromTurn(rec)
 	_, err := tx.ExecContext(ctx, `
 		INSERT INTO agent_conversation_audits (
 			session_id, run_id, agent_id, entity_id, flow_instance, scope_key, scope,
@@ -320,9 +322,22 @@ func (s *SQLiteRuntimeStore) ensureSQLiteTaskConversationAuditRowTx(ctx context.
 		)
 		ON CONFLICT(session_id) DO UPDATE SET
 			run_id = COALESCE(agent_conversation_audits.run_id, excluded.run_id),
+			entity_id = COALESCE(excluded.entity_id, agent_conversation_audits.entity_id),
+			flow_instance = COALESCE(excluded.flow_instance, agent_conversation_audits.flow_instance),
+			scope_key = CASE
+				WHEN excluded.entity_id IS NOT NULL OR excluded.flow_instance IS NOT NULL THEN excluded.scope_key
+				WHEN agent_conversation_audits.entity_id IS NOT NULL OR agent_conversation_audits.flow_instance IS NOT NULL THEN agent_conversation_audits.scope_key
+				ELSE COALESCE(excluded.scope_key, agent_conversation_audits.scope_key)
+			END,
+			scope = CASE
+				WHEN excluded.entity_id IS NOT NULL OR excluded.flow_instance IS NOT NULL THEN excluded.scope
+				WHEN agent_conversation_audits.entity_id IS NOT NULL OR agent_conversation_audits.flow_instance IS NOT NULL THEN agent_conversation_audits.scope
+				ELSE excluded.scope
+			END,
+			status = excluded.status,
 			updated_at = excluded.updated_at
-	`, sessionID, sqliteNullUUID(runID), strings.TrimSpace(rec.AgentID), sqliteNullUUID(rec.EntityID), nil,
-		sqliteNullString(scopeKey), scope, now, now)
+	`, sessionID, sqliteNullUUID(runID), strings.TrimSpace(rec.AgentID), sqliteNullUUID(identity.EntityID), sqliteNullString(identity.FlowInstance),
+		sqliteNullString(identity.ScopeKey), identity.Scope, now, now)
 	if err != nil {
 		return fmt.Errorf("ensure sqlite task conversation audit row: %w", err)
 	}

--- a/internal/store/sqlite_runtime_test.go
+++ b/internal/store/sqlite_runtime_test.go
@@ -1413,6 +1413,150 @@ func TestSQLiteRuntimeStoreSessionStartupConversationAndTraceVisibility(t *testi
 	}
 }
 
+func TestSQLiteRuntimeStore_TaskAuditAppendThenUpsertUsesGlobalScope(t *testing.T) {
+	ctx := context.Background()
+	store := newBootstrappedSQLiteRuntimeStoreForTest(t)
+	runID := uuid.NewString()
+	sessionID := uuid.NewString()
+
+	if err := store.AppendAgentTurn(ctx, runtimellm.AgentTurnRecord{
+		AgentID:        "task-agent",
+		RuntimeMode:    "task",
+		SessionID:      sessionID,
+		RunID:          runID,
+		RequestPayload: []byte(`{"kind":"task"}`),
+		ResponseRaw:    []byte(`{"ok":true}`),
+		ParseOK:        true,
+		Latency:        5 * time.Millisecond,
+	}); err != nil {
+		t.Fatalf("AppendAgentTurn(task): %v", err)
+	}
+	if err := store.UpsertConversation(ctx, runtimellm.ConversationRecord{
+		SessionID: sessionID,
+		AgentID:   "task-agent",
+		RunID:     runID,
+		Mode:      "task",
+		Messages: []runtimellm.Message{
+			{Role: "user", Content: "one-shot"},
+			{Role: "assistant", Content: "done"},
+		},
+		TurnCount: 1,
+		Status:    "active",
+	}); err != nil {
+		t.Fatalf("UpsertConversation(task): %v", err)
+	}
+	if rec, ok, err := store.LoadActiveConversation(ctx, "task-agent", "task", "", ""); err != nil || ok || rec.AgentID != "" {
+		t.Fatalf("LoadActiveConversation(task) ok=%v err=%v rec=%+v", ok, err, rec)
+	}
+
+	var count int
+	var scope, scopeKey, entityID, flowInstance, conversation, persistedRunID, status string
+	if err := store.DB.QueryRowContext(ctx, `
+		SELECT COUNT(*), COALESCE(MAX(scope), ''), COALESCE(MAX(scope_key), ''),
+		       COALESCE(MAX(entity_id), ''), COALESCE(MAX(flow_instance), ''),
+		       COALESCE(MAX(conversation), ''), COALESCE(MAX(run_id), ''), COALESCE(MAX(status), '')
+		FROM agent_conversation_audits
+		WHERE session_id = ?
+	`, sessionID).Scan(&count, &scope, &scopeKey, &entityID, &flowInstance, &conversation, &persistedRunID, &status); err != nil {
+		t.Fatalf("read task audit row: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("audit row count = %d, want 1", count)
+	}
+	if scope != "global" || scopeKey != "" || entityID != "" || flowInstance != "" {
+		t.Fatalf("audit identity scope=%q scope_key=%q entity_id=%q flow_instance=%q, want global/no identity", scope, scopeKey, entityID, flowInstance)
+	}
+	if persistedRunID != runID || status != "active" {
+		t.Fatalf("audit run/status = %q/%q, want %q/active", persistedRunID, status, runID)
+	}
+	if !strings.Contains(conversation, "done") {
+		t.Fatalf("conversation = %s, want persisted assistant message", conversation)
+	}
+
+	var turns int
+	if err := store.DB.QueryRowContext(ctx, `
+		SELECT COUNT(*)
+		FROM agent_turns
+		WHERE session_id = ? AND runtime_mode = 'task'
+	`, sessionID).Scan(&turns); err != nil {
+		t.Fatalf("count task turns: %v", err)
+	}
+	if turns != 1 {
+		t.Fatalf("task turn count = %d, want 1", turns)
+	}
+}
+
+func TestSQLiteRuntimeStore_TaskAuditEntityScopeSurvivesConversationUpsert(t *testing.T) {
+	ctx := context.Background()
+	store := newBootstrappedSQLiteRuntimeStoreForTest(t)
+	runID := uuid.NewString()
+	sessionID := uuid.NewString()
+	entityID := uuid.NewString()
+
+	if err := store.AppendAgentTurn(ctx, runtimellm.AgentTurnRecord{
+		AgentID:        "task-agent",
+		RuntimeMode:    "task",
+		SessionID:      sessionID,
+		ScopeKey:       "noncanonical-task-key",
+		RunID:          runID,
+		EntityID:       entityID,
+		RequestPayload: []byte(`{"kind":"task"}`),
+		ResponseRaw:    []byte(`{"ok":true}`),
+		ParseOK:        true,
+		Latency:        5 * time.Millisecond,
+	}); err != nil {
+		t.Fatalf("AppendAgentTurn(task entity): %v", err)
+	}
+	if err := store.UpsertConversation(ctx, runtimellm.ConversationRecord{
+		SessionID: sessionID,
+		AgentID:   "task-agent",
+		ScopeKey:  "snapshot-task-key",
+		RunID:     runID,
+		Mode:      "task",
+		Messages: []runtimellm.Message{
+			{Role: "user", Content: "entity task"},
+			{Role: "assistant", Content: "entity done"},
+		},
+		TurnCount: 1,
+		Status:    "active",
+	}); err != nil {
+		t.Fatalf("UpsertConversation(task entity): %v", err)
+	}
+
+	var count int
+	var scope, scopeKey, gotEntityID, flowInstance, conversation string
+	if err := store.DB.QueryRowContext(ctx, `
+		SELECT COUNT(*), COALESCE(MAX(scope), ''), COALESCE(MAX(scope_key), ''),
+		       COALESCE(MAX(entity_id), ''), COALESCE(MAX(flow_instance), ''),
+		       COALESCE(MAX(conversation), '')
+		FROM agent_conversation_audits
+		WHERE session_id = ?
+	`, sessionID).Scan(&count, &scope, &scopeKey, &gotEntityID, &flowInstance, &conversation); err != nil {
+		t.Fatalf("read entity task audit row: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("audit row count = %d, want 1", count)
+	}
+	if scope != "entity" || scopeKey != entityID || gotEntityID != entityID || flowInstance != "" {
+		t.Fatalf("audit identity scope=%q scope_key=%q entity_id=%q flow_instance=%q, want entity %s", scope, scopeKey, gotEntityID, flowInstance, entityID)
+	}
+	if !strings.Contains(conversation, "entity done") {
+		t.Fatalf("conversation = %s, want persisted assistant message", conversation)
+	}
+
+	var linkedTurns int
+	if err := store.DB.QueryRowContext(ctx, `
+		SELECT COUNT(*)
+		FROM agent_turns
+		WHERE session_id = ? AND runtime_mode = 'task' AND entity_id = ?
+	`, sessionID, entityID).Scan(&linkedTurns); err != nil {
+		t.Fatalf("count linked task turns: %v", err)
+	}
+	if linkedTurns != 1 {
+		t.Fatalf("linked task turn count = %d, want 1", linkedTurns)
+	}
+}
+
 func TestSQLiteRuntimeStoreMarkAgentTerminatedCleansRuntimeState(t *testing.T) {
 	ctx := context.Background()
 	store := newBootstrappedSQLiteRuntimeStoreForTest(t)

--- a/internal/store/sqlite_runtime_test.go
+++ b/internal/store/sqlite_runtime_test.go
@@ -1557,6 +1557,77 @@ func TestSQLiteRuntimeStore_TaskAuditEntityScopeSurvivesConversationUpsert(t *te
 	}
 }
 
+func TestSQLiteRuntimeStore_TaskAuditFlowScopeSurvivesConversationUpsert(t *testing.T) {
+	ctx := context.Background()
+	store := newBootstrappedSQLiteRuntimeStoreForTest(t)
+	runID := uuid.NewString()
+	sessionID := uuid.NewString()
+	flowInstance := "review/inst-1"
+
+	if err := store.AppendAgentTurn(ctx, runtimellm.AgentTurnRecord{
+		AgentID:        "task-agent",
+		RuntimeMode:    "task",
+		SessionID:      sessionID,
+		ScopeKey:       "noncanonical-task-key",
+		RunID:          runID,
+		FlowInstance:   flowInstance,
+		RequestPayload: []byte(`{"kind":"task"}`),
+		ResponseRaw:    []byte(`{"ok":true}`),
+		ParseOK:        true,
+		Latency:        5 * time.Millisecond,
+	}); err != nil {
+		t.Fatalf("AppendAgentTurn(task flow): %v", err)
+	}
+	if err := store.UpsertConversation(ctx, runtimellm.ConversationRecord{
+		SessionID: sessionID,
+		AgentID:   "task-agent",
+		ScopeKey:  "snapshot-task-key",
+		RunID:     runID,
+		Mode:      "task",
+		Messages: []runtimellm.Message{
+			{Role: "user", Content: "flow task"},
+			{Role: "assistant", Content: "flow done"},
+		},
+		TurnCount: 1,
+		Status:    "active",
+	}); err != nil {
+		t.Fatalf("UpsertConversation(task flow): %v", err)
+	}
+
+	var count int
+	var scope, scopeKey, entityID, gotFlowInstance, conversation string
+	if err := store.DB.QueryRowContext(ctx, `
+		SELECT COUNT(*), COALESCE(MAX(scope), ''), COALESCE(MAX(scope_key), ''),
+		       COALESCE(MAX(entity_id), ''), COALESCE(MAX(flow_instance), ''),
+		       COALESCE(MAX(conversation), '')
+		FROM agent_conversation_audits
+		WHERE session_id = ?
+	`, sessionID).Scan(&count, &scope, &scopeKey, &entityID, &gotFlowInstance, &conversation); err != nil {
+		t.Fatalf("read flow task audit row: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("audit row count = %d, want 1", count)
+	}
+	if scope != "flow" || scopeKey != flowInstance || gotFlowInstance != flowInstance || entityID != "" {
+		t.Fatalf("audit identity scope=%q scope_key=%q entity_id=%q flow_instance=%q, want flow %s", scope, scopeKey, entityID, gotFlowInstance, flowInstance)
+	}
+	if !strings.Contains(conversation, "flow done") {
+		t.Fatalf("conversation = %s, want persisted assistant message", conversation)
+	}
+
+	var linkedTurns int
+	if err := store.DB.QueryRowContext(ctx, `
+		SELECT COUNT(*)
+		FROM agent_turns
+		WHERE session_id = ? AND runtime_mode = 'task'
+	`, sessionID).Scan(&linkedTurns); err != nil {
+		t.Fatalf("count linked task turns: %v", err)
+	}
+	if linkedTurns != 1 {
+		t.Fatalf("linked task turn count = %d, want 1", linkedTurns)
+	}
+}
+
 func TestSQLiteRuntimeStoreMarkAgentTerminatedCleansRuntimeState(t *testing.T) {
 	ctx := context.Background()
 	store := newBootstrappedSQLiteRuntimeStoreForTest(t)

--- a/internal/store/task_audit_scope.go
+++ b/internal/store/task_audit_scope.go
@@ -15,7 +15,7 @@ type taskAuditIdentity struct {
 }
 
 func taskAuditIdentityFromTurn(rec runtimellm.AgentTurnRecord) taskAuditIdentity {
-	return newTaskAuditIdentity(rec.EntityID, "", rec.ScopeKey)
+	return newTaskAuditIdentity(rec.EntityID, rec.FlowInstance, rec.ScopeKey)
 }
 
 func taskAuditIdentityFromConversation(rec runtimellm.ConversationRecord) taskAuditIdentity {

--- a/internal/store/task_audit_scope.go
+++ b/internal/store/task_audit_scope.go
@@ -1,0 +1,48 @@
+package store
+
+import (
+	"strings"
+
+	runtimellm "github.com/division-sh/swarm/internal/runtime/llm"
+	runtimesessions "github.com/division-sh/swarm/internal/runtime/sessions"
+)
+
+type taskAuditIdentity struct {
+	EntityID     string
+	FlowInstance string
+	ScopeKey     string
+	Scope        string
+}
+
+func taskAuditIdentityFromTurn(rec runtimellm.AgentTurnRecord) taskAuditIdentity {
+	return newTaskAuditIdentity(rec.EntityID, "", rec.ScopeKey)
+}
+
+func taskAuditIdentityFromConversation(rec runtimellm.ConversationRecord) taskAuditIdentity {
+	return newTaskAuditIdentity("", "", rec.ScopeKey)
+}
+
+func newTaskAuditIdentity(entityID, flowInstance, scopeKey string) taskAuditIdentity {
+	entityID = strings.TrimSpace(entityID)
+	flowInstance = strings.TrimSpace(flowInstance)
+	scopeKey = strings.TrimSpace(scopeKey)
+
+	if entityID != "" {
+		return taskAuditIdentity{
+			EntityID: entityID,
+			ScopeKey: entityID,
+			Scope:    runtimesessions.SessionScopeEntity.String(),
+		}
+	}
+	if flowInstance != "" {
+		return taskAuditIdentity{
+			FlowInstance: flowInstance,
+			ScopeKey:     flowInstance,
+			Scope:        runtimesessions.SessionScopeFlow.String(),
+		}
+	}
+	return taskAuditIdentity{
+		ScopeKey: scopeKey,
+		Scope:    runtimesessions.SessionScopeGlobal.String(),
+	}
+}


### PR DESCRIPTION
## Summary
- Adds a backend-neutral task audit identity compiler for task audit scope, scope_key, entity_id, and flow_instance.
- Routes SQLite and Postgres task audit ensure-row/upsert writers through that owner.
- Preserves stronger same-session audit identity on conflict while allowing explicit entity/flow identity promotion.
- Adds SQLite no-scope/entity append-then-upsert proof, Postgres parity proof, and runtime success logging proof.

Closes #1445

## Governing refs/context
- `platform-spec.yaml` `task_mode_audit`: task mode must not create `agent_sessions`; task transcripts persist to `agent_conversation_audits` and `agent_turns`.
- `platform-spec.yaml` `agent_conversation_audits.scope_model`: task audits use `scope IN (entity, flow, global)`, nullable `scope_key`, and entity/flow scope when runtime context is available.
- Approved gate: https://github.com/division-sh/swarm/issues/1445#issuecomment-4893774178

## Semantic Migration
- New canonical owner: `internal/store/task_audit_scope.go` compiles task audit identity for task audit writers.
- Old non-authoritative paths now invalid: SQLite `UpsertConversation(task)` no longer derives an empty scope from stateless `ResolveScope`; Postgres task audit append no longer hard-codes global while carrying entity_id; conflict handlers no longer erase existing scope/scope_key/entity_id/flow_instance with empty snapshot values.
- Production paths checked in code/tests: Postgres `AppendAgentTurn(task)`, Postgres `UpsertConversation(task)`, operator conversation read surface, and matching SQLite local-runtime task audit writers.
- Migration is complete for the approved child class. No schema change, no `task` scope enum extension, and no `agent_sessions` bridge.

## Validation
- `go test ./internal/runtime/llm -run 'TestClaudeCLIRuntime_PersistConversationSuccessDoesNotLogFailure|TestAnthropicAPIRuntime_PersistConversationFailureLogsRuntime|TestClaudeCLIRuntime_PersistConversationIncludesSessionScope' -count=1` passed.\n- `go test ./internal/store -run 'TestSQLiteRuntimeStore_TaskAudit' -count=1` passed.\n- `go test ./internal/store -run 'TestManagerStore_AppendAgentTurn_TaskCreatesAuditRowIfMissing|TestManagerStore_AppendAgentTurn_TaskEntityScopeSurvivesConversationUpsert|TestManagerStore_StatelessConversationPersistsAuditRowWithoutReload' -count=1` blocked locally by missing Docker socket for Postgres test helper: `dial unix /var/run/docker.sock: connect: no such file or directory`.\n- `go test ./...` run; failed locally for the same Docker/Postgres infrastructure reason across Postgres-dependent packages.\n- `docker ps` confirms local Docker socket is unavailable with the same error.\n