### PR TITLE
[agent-c][issue #1714] Add policy validation rows

### DIFF
--- a/internal/runtime/bootverify/checks.go
+++ b/internal/runtime/bootverify/checks.go
@@ -227,6 +227,7 @@ var bootCheckRegistry = []Check{
 	{ID: "required_agents_match", Severity: "error", Run: checkRequiredAgentsMatch},
 	{ID: "handler_field_compliance", Severity: "error", Run: checkHandlerFieldCompliance},
 	{ID: policySheetLookupCheckID, Severity: SeverityHardInvalidity, Run: checkPolicySheetLookupValueRows},
+	{ID: policySheetValidationCheckID, Severity: SeverityHardInvalidity, Run: checkPolicySheetValidationValueRows},
 	{ID: "tool_resolution", Severity: "warning", Run: checkToolResolution},
 	{ID: "required_mcp_tool_availability", Severity: SeverityHardInvalidity, Run: checkRequiredMCPToolAvailability},
 	{ID: "platform_tool_usage_hints", Severity: SeverityHardInvalidity, Run: checkPlatformToolUsageHints},

--- a/internal/runtime/bootverify/flow_data_access_test.go
+++ b/internal/runtime/bootverify/flow_data_access_test.go
@@ -66,8 +66,8 @@ func TestRun_ValidatesFlowDataAccessDeclarations(t *testing.T) {
 }
 
 func TestBootCheckRegistry_HasFlowDataAccessCheckCount(t *testing.T) {
-	if got := len(bootCheckRegistry); got != 71 {
-		t.Fatalf("bootCheckRegistry count = %d, want 71", got)
+	if got := len(bootCheckRegistry); got != 72 {
+		t.Fatalf("bootCheckRegistry count = %d, want 72", got)
 	}
 }
 

--- a/internal/runtime/bootverify/report_test.go
+++ b/internal/runtime/bootverify/report_test.go
@@ -6070,8 +6070,8 @@ func TestRun_ReportsMissingRuntimeExecutorForOwnedRuntimeEvent(t *testing.T) {
 }
 
 func TestBootCheckRegistry_HasSpecCheckCount(t *testing.T) {
-	if got := len(bootCheckRegistry); got != 71 {
-		t.Fatalf("bootCheckRegistry count = %d, want 71", got)
+	if got := len(bootCheckRegistry); got != 72 {
+		t.Fatalf("bootCheckRegistry count = %d, want 72", got)
 	}
 	if got := len(supplementalChecks); got != 3 {
 		t.Fatalf("supplementalChecks count = %d, want 3", got)

--- a/internal/runtime/bootverify/workflow_policy_sheet_validation_checks.go
+++ b/internal/runtime/bootverify/workflow_policy_sheet_validation_checks.go
@@ -1,0 +1,152 @@
+package bootverify
+
+import (
+	"fmt"
+	"strings"
+
+	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
+	runtimepaths "github.com/division-sh/swarm/internal/runtime/core/paths"
+	"github.com/division-sh/swarm/internal/runtime/semanticview"
+)
+
+const policySheetValidationCheckID = "policy_sheet_validation_value_rows"
+
+func checkPolicySheetValidationValueRows(c *checkerContext) []Finding {
+	findings := make([]Finding, 0)
+	nodes := c.source.NodeEntries()
+	for _, nodeID := range sortedNodeIDs(c.source) {
+		node, ok := nodes[nodeID]
+		if !ok {
+			continue
+		}
+		flowID := nodeFlowID(c.source, nodeID)
+		for eventType, handler := range node.EventHandlers {
+			eventType = strings.TrimSpace(eventType)
+			for idx, rule := range handler.Rules {
+				if !policySheetRuleIsValidationValueRow(rule) {
+					continue
+				}
+				ref := policySheetValidationRef{
+					FlowID:    flowID,
+					NodeID:    nodeID,
+					EventType: eventType,
+					RuleIndex: idx,
+					RuleID:    strings.TrimSpace(rule.ID),
+				}
+				findings = append(findings, validatePolicySheetValidationValueRow(c.source, ref, handler, rule)...)
+			}
+		}
+	}
+	return findings
+}
+
+type policySheetValidationRef struct {
+	FlowID    string
+	NodeID    string
+	EventType string
+	RuleIndex int
+	RuleID    string
+}
+
+func policySheetValidationFinding(ref policySheetValidationRef, detail string) Finding {
+	return Finding{
+		CheckID:  policySheetValidationCheckID,
+		Severity: SeverityHardInvalidity,
+		Message:  fmt.Sprintf("flow %s node %s handler %s validate row %s: %s", defaultFlowLabel(ref.FlowID), ref.NodeID, ref.EventType, ref.RowLabel(), detail),
+		Location: ref.NodeID,
+	}
+}
+
+func (r policySheetValidationRef) RowLabel() string {
+	if id := strings.TrimSpace(r.RuleID); id != "" {
+		return id
+	}
+	return fmt.Sprintf("#%d", r.RuleIndex)
+}
+
+func policySheetRuleIsValidationValueRow(rule runtimecontracts.HandlerRuleEntry) bool {
+	if rule.PolicyRow.Kind == runtimecontracts.PolicySheetRowKindValidate {
+		return true
+	}
+	return rule.Compute != nil && rule.Compute.Operation == runtimecontracts.ComputeOpValidate
+}
+
+func validatePolicySheetValidationValueRow(source semanticview.Source, ref policySheetValidationRef, handler runtimecontracts.SystemNodeEventHandler, rule runtimecontracts.HandlerRuleEntry) []Finding {
+	findings := make([]Finding, 0)
+	if rule.PolicyRow.Kind != runtimecontracts.PolicySheetRowKindValidate {
+		findings = append(findings, policySheetValidationFinding(ref, "validate compute must originate from a policy-sheet validate row"))
+	}
+	if rule.Compute == nil || rule.Compute.Operation != runtimecontracts.ComputeOpValidate {
+		findings = append(findings, policySheetValidationFinding(ref, "validate row must lower to compute-owned validate operation"))
+		return findings
+	}
+	spec := rule.Compute.Validation
+	if spec == nil {
+		findings = append(findings, policySheetValidationFinding(ref, "validate row has no canonical validation plan"))
+		return findings
+	}
+	storeAs := strings.TrimSpace(rule.Compute.StoreAs)
+	storePath := runtimepaths.Parse(storeAs)
+	if storePath.Root != runtimepaths.RootComputed || len(storePath.Segments) < 2 || storePath.Segments[0] != "validation" {
+		findings = append(findings, policySheetValidationFinding(ref, fmt.Sprintf("validate.into must target computed.validation.*, got %q", storeAs)))
+	} else if !policySheetLookupPathIsSimple(storePath) {
+		findings = append(findings, policySheetValidationFinding(ref, fmt.Sprintf("validate.into %q must be a simple computed.validation.* path", storeAs)))
+	}
+	policy := source.ResolvedPolicyForFlow(ref.FlowID)
+	set, ok := policy.Validation[strings.TrimSpace(spec.Set)]
+	if !ok {
+		findings = append(findings, policySheetValidationFinding(ref, fmt.Sprintf("validate.set %q does not resolve in policy.validation", strings.TrimSpace(spec.Set))))
+	} else {
+		findings = append(findings, validatePolicySheetValidationDispositionConsumer(ref, handler, rule, storeAs, set)...)
+	}
+	if !policySheetLookupBindingConsumed(handler, rule, storeAs) {
+		findings = append(findings, policySheetValidationFinding(ref, fmt.Sprintf("validate.into %q is not consumed by a supported downstream condition, emit field, activity input, fan_out, or expression", storeAs)))
+	}
+	return findings
+}
+
+func validatePolicySheetValidationDispositionConsumer(ref policySheetValidationRef, handler runtimecontracts.SystemNodeEventHandler, validateRule runtimecontracts.HandlerRuleEntry, target string, set runtimecontracts.PolicyValidationSet) []Finding {
+	dispositions := map[string]struct{}{}
+	for _, class := range set.Classes {
+		disposition := strings.TrimSpace(class.Disposition)
+		if disposition == "" || disposition == "none" {
+			continue
+		}
+		dispositions[disposition] = struct{}{}
+	}
+	if len(dispositions) == 0 {
+		return nil
+	}
+	matched := false
+	findings := make([]Finding, 0)
+	for _, rule := range handler.Rules {
+		if strings.TrimSpace(rule.ID) == strings.TrimSpace(validateRule.ID) && rule.Compute == validateRule.Compute {
+			continue
+		}
+		if !policySheetValidationConditionConsumesInvalidResult(rule.Condition, target) {
+			continue
+		}
+		eventType := strings.TrimSpace(rule.Emit.EventType())
+		if _, ok := dispositions[eventType]; !ok {
+			findings = append(findings, policySheetValidationFinding(ref, fmt.Sprintf("invalid-result consumer row %q emits %q, which is not declared as a policy.validation class disposition", strings.TrimSpace(rule.ID), eventType)))
+			continue
+		}
+		matched = true
+	}
+	if !matched {
+		findings = append(findings, policySheetValidationFinding(ref, fmt.Sprintf("validate result %q has no invalid-result selection row emitting a declared policy.validation disposition", target)))
+	}
+	return findings
+}
+
+func policySheetValidationConditionConsumesInvalidResult(condition, target string) bool {
+	condition = strings.Join(strings.Fields(strings.TrimSpace(condition)), " ")
+	target = strings.TrimSpace(target)
+	if condition == "" || target == "" {
+		return false
+	}
+	validRef := target + ".valid"
+	return strings.Contains(condition, validRef+" == false") ||
+		strings.Contains(condition, "false == "+validRef) ||
+		strings.Contains(condition, "!"+validRef)
+}

--- a/internal/runtime/bootverify/workflow_policy_sheet_validation_checks_test.go
+++ b/internal/runtime/bootverify/workflow_policy_sheet_validation_checks_test.go
@@ -1,0 +1,120 @@
+package bootverify
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
+	"github.com/division-sh/swarm/internal/runtime/core/paths"
+	"github.com/division-sh/swarm/internal/runtime/semanticview"
+)
+
+func TestPolicySheetValidationValueRowsAcceptsConsumedDispositionRoute(t *testing.T) {
+	handler := bootverifyValidationHandler(true, "deploy.manifest_invalid")
+	findings := bootverifyValidationFindings(handler)
+	if len(findings) != 0 {
+		t.Fatalf("validation findings = %#v, want none", findings)
+	}
+}
+
+func TestPolicySheetValidationValueRowsRejectsDeadResult(t *testing.T) {
+	handler := bootverifyValidationHandler(false, "")
+	findings := bootverifyValidationFindings(handler)
+	if !bootverifyValidationFindingContains(findings, "is not consumed") {
+		t.Fatalf("validation findings = %#v, want dead result failure", findings)
+	}
+}
+
+func TestPolicySheetValidationValueRowsRejectsUndeclaredInvalidDisposition(t *testing.T) {
+	handler := bootverifyValidationHandler(true, "deploy.other_invalid")
+	findings := bootverifyValidationFindings(handler)
+	if !bootverifyValidationFindingContains(findings, "is not declared as a policy.validation class disposition") {
+		t.Fatalf("validation findings = %#v, want disposition mismatch failure", findings)
+	}
+}
+
+func bootverifyValidationFindings(handler runtimecontracts.SystemNodeEventHandler) []Finding {
+	pinCandidate := true
+	bundle := &runtimecontracts.WorkflowContractBundle{
+		Policy: runtimecontracts.PolicyDocument{
+			Validation: map[string]runtimecontracts.PolicyValidationSet{
+				"deploy_manifest": {
+					Classes: map[string]runtimecontracts.PolicyValidationClass{
+						"invalid": {Disposition: "deploy.manifest_invalid"},
+					},
+					Inputs: map[string]string{
+						"source_ref":          "string",
+						"manifest_source_ref": "string",
+					},
+					Rules: []runtimecontracts.PolicyValidationRule{{
+						ID:           "VR-001",
+						Class:        "invalid",
+						Text:         "Manifest source ref must match request source ref.",
+						PinCandidate: &pinCandidate,
+						Check: runtimecontracts.PolicyValidationCheck{
+							Equal: &runtimecontracts.PolicyValidationEqualCheck{
+								Left:  "input.source_ref",
+								Right: "input.manifest_source_ref",
+							},
+						},
+					}},
+				},
+			},
+		},
+		Nodes: map[string]runtimecontracts.SystemNodeContract{
+			"deploy_node": {
+				ID: "deploy_node",
+				EventHandlers: map[string]runtimecontracts.SystemNodeEventHandler{
+					"deploy.requested": handler,
+				},
+			},
+		},
+	}
+	source := semanticview.Wrap(bundle)
+	return checkPolicySheetValidationValueRows(newCheckerContext(context.Background(), source, Options{}))
+}
+
+func bootverifyValidationHandler(includeConsumer bool, emitEvent string) runtimecontracts.SystemNodeEventHandler {
+	validation := &runtimecontracts.ComputeValidationSpec{
+		RowID: "validate_manifest",
+		Set:   "deploy_manifest",
+		Into:  "computed.validation.deploy_manifest",
+		Input: map[string]string{
+			"source_ref":          "payload.source_ref",
+			"manifest_source_ref": "payload.file_manifest.source_ref",
+		},
+		InputPaths: map[string]paths.Path{
+			"source_ref":          paths.Parse("payload.source_ref"),
+			"manifest_source_ref": paths.Parse("payload.file_manifest.source_ref"),
+		},
+	}
+	handler := runtimecontracts.SystemNodeEventHandler{
+		Rules: []runtimecontracts.HandlerRuleEntry{{
+			ID:        "validate_manifest",
+			PolicyRow: runtimecontracts.PolicySheetRowMetadata{Kind: runtimecontracts.PolicySheetRowKindValidate, Validation: validation},
+			Compute: &runtimecontracts.ComputeSpec{
+				Operation:  runtimecontracts.ComputeOpValidate,
+				StoreAs:    "computed.validation.deploy_manifest",
+				Validation: validation,
+			},
+		}},
+	}
+	if includeConsumer {
+		handler.Rules = append(handler.Rules, runtimecontracts.HandlerRuleEntry{
+			ID:        "invalid_manifest",
+			Condition: "computed.validation.deploy_manifest.valid == false",
+			Emit:      runtimecontracts.EmitSpec{Event: emitEvent},
+		})
+	}
+	return handler
+}
+
+func bootverifyValidationFindingContains(findings []Finding, contains string) bool {
+	for _, finding := range findings {
+		if finding.CheckID == policySheetValidationCheckID && strings.Contains(finding.Message, contains) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/runtime/contracts/enums.go
+++ b/internal/runtime/contracts/enums.go
@@ -69,6 +69,7 @@ const (
 	ComputeOpMax
 	ComputeOpCount
 	ComputeOpLookup
+	ComputeOpValidate
 )
 
 func ParseComputeOperation(text string) (ComputeOperation, error) {
@@ -87,6 +88,8 @@ func ParseComputeOperation(text string) (ComputeOperation, error) {
 		return ComputeOpCount, nil
 	case "lookup":
 		return ComputeOpUnknown, fmt.Errorf("compute operation %q is internal to policy-sheet value rows; author lookup rows under rules", text)
+	case "validate":
+		return ComputeOpUnknown, fmt.Errorf("compute operation %q is internal to policy-sheet value rows; author validate rows under rules", text)
 	case "":
 		return ComputeOpUnknown, nil
 	default:
@@ -110,6 +113,8 @@ func (o ComputeOperation) String() string {
 		return "count"
 	case ComputeOpLookup:
 		return "lookup"
+	case ComputeOpValidate:
+		return "validate"
 	default:
 		return ""
 	}

--- a/internal/runtime/contracts/load_validation_test.go
+++ b/internal/runtime/contracts/load_validation_test.go
@@ -200,6 +200,133 @@ func TestValidateWorkflowContractBundleLoadConstraintsRejectsInvalidSchemaRefine
 	}
 }
 
+func TestValidateWorkflowContractBundleLoadConstraintsRejectsMalformedPolicyValidationSet(t *testing.T) {
+	pinCandidate := true
+	flow := &FlowContractView{
+		Paths: FlowContractPaths{ID: "deploy", Flow: "deploy"},
+		Policy: PolicyDocument{Validation: map[string]PolicyValidationSet{
+			"deploy_manifest": {
+				Classes: map[string]PolicyValidationClass{"invalid": {Disposition: "deploy.manifest_invalid"}},
+				Inputs:  map[string]string{"source_ref": "string", "manifest_source_ref": "number"},
+				Rules: []PolicyValidationRule{{
+					ID:           "VR-001",
+					Class:        "invalid",
+					Text:         "Manifest source ref must match request source ref.",
+					PinCandidate: &pinCandidate,
+					Check:        PolicyValidationCheck{Equal: &PolicyValidationEqualCheck{Left: "input.source_ref", Right: "input.manifest_source_ref"}},
+				}},
+			},
+		}},
+	}
+	bundle := &WorkflowContractBundle{
+		FlowSchemas: map[string]FlowSchemaDocument{"deploy": {}},
+		FlowTree: FlowTree{
+			Root: flow,
+			ByID: map[string]*FlowContractView{
+				"deploy": flow,
+			},
+		},
+	}
+
+	err := validateWorkflowContractBundleLoadConstraints(bundle)
+	if err == nil || !contractErrorContains(err, "compares input.source_ref type string with input.manifest_source_ref type number") {
+		t.Fatalf("load validation error = %v, want validation input type mismatch", err)
+	}
+}
+
+func TestValidateWorkflowContractBundleLoadConstraintsRequiresPolicyValidationPinCandidate(t *testing.T) {
+	flow := &FlowContractView{
+		Paths: FlowContractPaths{ID: "deploy", Flow: "deploy"},
+		Policy: PolicyDocument{Validation: map[string]PolicyValidationSet{
+			"deploy_manifest": {
+				Classes: map[string]PolicyValidationClass{"invalid": {Disposition: "deploy.manifest_invalid"}},
+				Inputs:  map[string]string{"source_ref": "string", "manifest_source_ref": "string"},
+				Rules: []PolicyValidationRule{{
+					ID:    "VR-001",
+					Class: "invalid",
+					Text:  "Manifest source ref must match request source ref.",
+					Check: PolicyValidationCheck{Equal: &PolicyValidationEqualCheck{Left: "input.source_ref", Right: "input.manifest_source_ref"}},
+				}},
+			},
+		}},
+	}
+	bundle := &WorkflowContractBundle{
+		FlowSchemas: map[string]FlowSchemaDocument{"deploy": {}},
+		FlowTree: FlowTree{
+			Root: flow,
+			ByID: map[string]*FlowContractView{
+				"deploy": flow,
+			},
+		},
+	}
+
+	err := validateWorkflowContractBundleLoadConstraints(bundle)
+	if err == nil || !contractErrorContains(err, "pin_candidate must be explicitly true or false") {
+		t.Fatalf("load validation error = %v, want missing pin_candidate", err)
+	}
+}
+
+func TestValidateWorkflowContractBundleLoadConstraintsRequiresValidateRowsToMapDeclaredInputs(t *testing.T) {
+	pinCandidate := true
+	validation := &ComputeValidationSpec{
+		RowID: "validate_manifest",
+		Set:   "deploy_manifest",
+		Into:  "computed.validation.deploy_manifest",
+		Input: map[string]string{
+			"source_ref": "payload.source_ref",
+		},
+	}
+	flow := &FlowContractView{
+		Paths: FlowContractPaths{ID: "deploy", Flow: "deploy"},
+		Policy: PolicyDocument{Validation: map[string]PolicyValidationSet{
+			"deploy_manifest": {
+				Classes: map[string]PolicyValidationClass{"invalid": {Disposition: "deploy.manifest_invalid"}},
+				Inputs:  map[string]string{"source_ref": "string", "manifest_source_ref": "string"},
+				Rules: []PolicyValidationRule{{
+					ID:           "VR-001",
+					Class:        "invalid",
+					Text:         "Manifest source ref must match request source ref.",
+					PinCandidate: &pinCandidate,
+					Check:        PolicyValidationCheck{Equal: &PolicyValidationEqualCheck{Left: "input.source_ref", Right: "input.manifest_source_ref"}},
+				}},
+			},
+		}},
+	}
+	bundle := &WorkflowContractBundle{
+		FlowSchemas: map[string]FlowSchemaDocument{"deploy": {}},
+		FlowTree: FlowTree{
+			Root: flow,
+			ByID: map[string]*FlowContractView{
+				"deploy": flow,
+			},
+		},
+		nodeSources: map[string]ContractItemSource{"deploy_node": {FlowID: "deploy"}},
+		Nodes: map[string]SystemNodeContract{
+			"deploy_node": {
+				ID: "deploy_node",
+				EventHandlers: map[string]SystemNodeEventHandler{
+					"deploy.requested": {
+						Rules: []HandlerRuleEntry{{
+							ID:        "validate_manifest",
+							PolicyRow: PolicySheetRowMetadata{Kind: PolicySheetRowKindValidate, Validation: validation},
+							Compute: &ComputeSpec{
+								Operation:  ComputeOpValidate,
+								StoreAs:    "computed.validation.deploy_manifest",
+								Validation: validation,
+							},
+						}},
+					},
+				},
+			},
+		},
+	}
+
+	err := validateWorkflowContractBundleLoadConstraints(bundle)
+	if err == nil || !contractErrorContains(err, `validate.input missing required set input "manifest_source_ref"`) {
+		t.Fatalf("load validation error = %v, want missing validate input", err)
+	}
+}
+
 func TestEventFieldSpecDecodeRejectsMalformedSchemaRefinement(t *testing.T) {
 	var field EventFieldSpec
 	err := yaml.Unmarshal([]byte(`

--- a/internal/runtime/contracts/validation_policy_validation.go
+++ b/internal/runtime/contracts/validation_policy_validation.go
@@ -1,0 +1,303 @@
+package contracts
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/division-sh/swarm/internal/runtime/core/paths"
+)
+
+func validateWorkflowPolicyValidationContracts(bundle *WorkflowContractBundle) []error {
+	if bundle == nil {
+		return nil
+	}
+	errs := []error{}
+	errs = append(errs, validateProjectPolicyValidationUnsupported(bundle)...)
+	errs = append(errs, validateFlowPolicyValidationSets(bundle)...)
+	errs = append(errs, validatePolicySheetValidationRows(bundle)...)
+	return errs
+}
+
+func validateProjectPolicyValidationUnsupported(bundle *WorkflowContractBundle) []error {
+	errs := []error{}
+	for _, view := range bundle.ProjectViews() {
+		if len(view.Policy.Validation) == 0 {
+			continue
+		}
+		errs = append(errs, fmt.Errorf("%w: project policy %s declares validation; validation must be declared in flow policy.yaml", ErrInvalidField, strings.TrimSpace(view.Paths.Key)))
+	}
+	return errs
+}
+
+func validateFlowPolicyValidationSets(bundle *WorkflowContractBundle) []error {
+	errs := []error{}
+	for _, flowID := range sortedFlowSchemaIDs(bundle.FlowSchemas) {
+		view, ok := bundle.FlowViewByID(flowID)
+		if !ok || view == nil {
+			continue
+		}
+		policy := bundle.ResolvedPolicyForFlow(flowID)
+		setNames := sortedValidationSetNames(view.Policy.Validation)
+		for _, setName := range setNames {
+			set := view.Policy.Validation[setName]
+			errs = append(errs, validatePolicyValidationSet("flow "+flowID+" policy.validation."+setName, set, policy)...)
+		}
+	}
+	return errs
+}
+
+func validatePolicyValidationSet(context string, set PolicyValidationSet, policy PolicyDocument) []error {
+	errs := []error{}
+	if len(set.Classes) == 0 {
+		errs = append(errs, fmt.Errorf("%w: %s classes must declare at least one class", ErrInvalidField, context))
+	}
+	classNames := sortedValidationClassNames(set.Classes)
+	for _, className := range classNames {
+		if strings.TrimSpace(set.Classes[className].Disposition) == "" {
+			errs = append(errs, fmt.Errorf("%w: %s classes.%s disposition is required", ErrInvalidField, context, className))
+		}
+	}
+	if len(set.Inputs) == 0 {
+		errs = append(errs, fmt.Errorf("%w: %s inputs must declare at least one typed input", ErrInvalidField, context))
+	}
+	for _, name := range sortedValidationInputNames(set.Inputs) {
+		if !isValidationInputTypeSupported(set.Inputs[name]) {
+			errs = append(errs, fmt.Errorf("%w: %s inputs.%s type %q is not supported by Slice B validation rows", ErrInvalidField, context, name, strings.TrimSpace(set.Inputs[name])))
+		}
+	}
+	if len(set.Rules) == 0 {
+		errs = append(errs, fmt.Errorf("%w: %s rules must declare at least one rule", ErrInvalidField, context))
+	}
+	seenIDs := map[string]struct{}{}
+	for idx, rule := range set.Rules {
+		ruleContext := fmt.Sprintf("%s.rules[%d]", context, idx)
+		id := strings.TrimSpace(rule.ID)
+		if id == "" {
+			errs = append(errs, fmt.Errorf("%w: %s id is required", ErrInvalidField, ruleContext))
+		} else if _, exists := seenIDs[id]; exists {
+			errs = append(errs, fmt.Errorf("%w: %s duplicate stable validation id %q", ErrInvalidField, context, id))
+		} else {
+			seenIDs[id] = struct{}{}
+		}
+		className := strings.TrimSpace(rule.Class)
+		if className == "" {
+			errs = append(errs, fmt.Errorf("%w: %s class is required", ErrInvalidField, ruleContext))
+		} else if _, ok := set.Classes[className]; !ok {
+			errs = append(errs, fmt.Errorf("%w: %s class %q is not declared in classes", ErrInvalidField, ruleContext, className))
+		}
+		if strings.TrimSpace(rule.Text) == "" {
+			errs = append(errs, fmt.Errorf("%w: %s text is required", ErrInvalidField, ruleContext))
+		}
+		if rule.PinCandidate == nil {
+			errs = append(errs, fmt.Errorf("%w: %s pin_candidate must be explicitly true or false", ErrInvalidField, ruleContext))
+		}
+		errs = append(errs, validatePolicyValidationRuleCheck(ruleContext, rule.Check, set.Inputs)...)
+		paramNames := make([]string, 0, len(rule.Params))
+		for name := range rule.Params {
+			name = strings.TrimSpace(name)
+			if name != "" {
+				paramNames = append(paramNames, name)
+			}
+		}
+		sort.Strings(paramNames)
+		for _, name := range paramNames {
+			if err := validateCriteriaParam(ruleContext+".params."+name, rule.Params[name].Value, policy); err != nil {
+				errs = append(errs, err)
+			}
+		}
+	}
+	return errs
+}
+
+func validatePolicyValidationRuleCheck(context string, check PolicyValidationCheck, inputs map[string]string) []error {
+	errs := []error{}
+	if check.Equal == nil {
+		return append(errs, fmt.Errorf("%w: %s check.equal is required; Slice B supports only equal checks", ErrInvalidField, context))
+	}
+	left, leftType, leftErr := validationInputRefType(check.Equal.Left, inputs)
+	right, rightType, rightErr := validationInputRefType(check.Equal.Right, inputs)
+	if leftErr != nil {
+		errs = append(errs, fmt.Errorf("%w: %s check.equal.left %v", ErrInvalidField, context, leftErr))
+	}
+	if rightErr != nil {
+		errs = append(errs, fmt.Errorf("%w: %s check.equal.right %v", ErrInvalidField, context, rightErr))
+	}
+	if leftErr == nil && rightErr == nil && leftType != rightType {
+		errs = append(errs, fmt.Errorf("%w: %s check.equal compares input.%s type %s with input.%s type %s", ErrInvalidField, context, left, leftType, right, rightType))
+	}
+	return errs
+}
+
+func validationInputRefType(ref string, inputs map[string]string) (string, string, error) {
+	ref = strings.TrimSpace(ref)
+	name, ok := strings.CutPrefix(ref, "input.")
+	if !ok || strings.TrimSpace(name) == "" || strings.Contains(strings.TrimSpace(name), ".") {
+		return "", "", fmt.Errorf("%q must be an input.* reference", ref)
+	}
+	name = strings.TrimSpace(name)
+	rawType, ok := inputs[name]
+	if !ok {
+		return name, "", fmt.Errorf("%q references undeclared input %q", ref, name)
+	}
+	kind := normalizeValidationInputType(rawType)
+	if kind == "" {
+		return name, "", fmt.Errorf("%q has unsupported declared type %q", ref, strings.TrimSpace(rawType))
+	}
+	return name, kind, nil
+}
+
+func validatePolicySheetValidationRows(bundle *WorkflowContractBundle) []error {
+	errs := []error{}
+	for nodeID, node := range bundle.Nodes {
+		source, _ := bundle.NodeContractSource(nodeID)
+		flowID := strings.TrimSpace(source.FlowID)
+		policy := bundle.ResolvedPolicyForFlow(flowID)
+		for eventType, handler := range node.EventHandlers {
+			for idx, rule := range handler.Rules {
+				if !policySheetRuleIsValidationValueRow(rule) {
+					continue
+				}
+				context := fmt.Sprintf("node %s handler %s rules[%d] validate row %s", strings.TrimSpace(nodeID), strings.TrimSpace(eventType), idx, strings.TrimSpace(rule.ID))
+				errs = append(errs, validatePolicySheetValidationRow(context, rule, policy)...)
+			}
+		}
+	}
+	return errs
+}
+
+func policySheetRuleIsValidationValueRow(rule HandlerRuleEntry) bool {
+	if rule.PolicyRow.Kind == PolicySheetRowKindValidate {
+		return true
+	}
+	return rule.Compute != nil && rule.Compute.Operation == ComputeOpValidate
+}
+
+func validatePolicySheetValidationRow(context string, rule HandlerRuleEntry, policy PolicyDocument) []error {
+	errs := []error{}
+	if rule.PolicyRow.Kind != PolicySheetRowKindValidate {
+		errs = append(errs, fmt.Errorf("%w: %s validate compute must originate from a policy-sheet validate row", ErrInvalidField, context))
+	}
+	if rule.Compute == nil || rule.Compute.Operation != ComputeOpValidate || rule.Compute.Validation == nil {
+		return append(errs, fmt.Errorf("%w: %s validate row must lower to compute-owned validate operation", ErrInvalidField, context))
+	}
+	spec := rule.Compute.Validation
+	target := strings.TrimSpace(spec.StoreTarget())
+	if target == "" {
+		errs = append(errs, fmt.Errorf("%w: %s validate.into is required", ErrInvalidField, context))
+	} else if err := validatePolicyValidationStoreTarget(target); err != nil {
+		errs = append(errs, fmt.Errorf("%w: %s %v", ErrInvalidField, context, err))
+	}
+	if computeTarget := strings.TrimSpace(rule.Compute.StoreAs); computeTarget != "" && target != "" && computeTarget != target {
+		errs = append(errs, fmt.Errorf("%w: %s validate.into %q must match compute.store_as %q", ErrInvalidField, context, target, computeTarget))
+	}
+	setName := strings.TrimSpace(spec.Set)
+	set, ok := policy.Validation[setName]
+	if setName == "" {
+		errs = append(errs, fmt.Errorf("%w: %s validate.set is required", ErrInvalidField, context))
+	} else if !ok {
+		errs = append(errs, fmt.Errorf("%w: %s validate.set %q does not resolve in flow policy.validation", ErrInvalidField, context, setName))
+	}
+	if !ok {
+		return errs
+	}
+	declared := stringSetFromMap(set.Inputs)
+	mapped := stringSetFromMap(spec.Input)
+	for name := range declared {
+		if _, ok := mapped[name]; !ok {
+			errs = append(errs, fmt.Errorf("%w: %s validate.input missing required set input %q", ErrInvalidField, context, name))
+		}
+	}
+	for name := range mapped {
+		if _, ok := declared[name]; !ok {
+			errs = append(errs, fmt.Errorf("%w: %s validate.input maps undeclared set input %q", ErrInvalidField, context, name))
+		}
+	}
+	return errs
+}
+
+func validatePolicyValidationStoreTarget(target string) error {
+	parsed := paths.Parse(target)
+	if parsed.Root != paths.RootComputed || len(parsed.Segments) < 2 || parsed.Segments[0] != "validation" {
+		return fmt.Errorf("validate.into %q must target computed.validation.*", strings.TrimSpace(target))
+	}
+	for _, segment := range parsed.Segments {
+		if !isPolicySheetPathSegment(segment) {
+			return fmt.Errorf("validate.into %q must be a simple computed.validation.* path", strings.TrimSpace(target))
+		}
+	}
+	return nil
+}
+
+func (s ComputeValidationSpec) StoreTarget() string {
+	if strings.TrimSpace(s.Into) != "" {
+		return strings.TrimSpace(s.Into)
+	}
+	return ""
+}
+
+func normalizeValidationInputType(raw string) string {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "string", "text", "uuid", "timestamp", "datetime", "date":
+		return "string"
+	case "bool", "boolean":
+		return "bool"
+	case "int", "integer":
+		return "int"
+	case "number", "numeric", "float", "double":
+		return "number"
+	default:
+		return ""
+	}
+}
+
+func isValidationInputTypeSupported(raw string) bool {
+	return normalizeValidationInputType(raw) != ""
+}
+
+func sortedValidationSetNames(in map[string]PolicyValidationSet) []string {
+	names := make([]string, 0, len(in))
+	for name := range in {
+		name = strings.TrimSpace(name)
+		if name != "" {
+			names = append(names, name)
+		}
+	}
+	sort.Strings(names)
+	return names
+}
+
+func sortedValidationClassNames(in map[string]PolicyValidationClass) []string {
+	names := make([]string, 0, len(in))
+	for name := range in {
+		name = strings.TrimSpace(name)
+		if name != "" {
+			names = append(names, name)
+		}
+	}
+	sort.Strings(names)
+	return names
+}
+
+func sortedValidationInputNames(in map[string]string) []string {
+	names := make([]string, 0, len(in))
+	for name := range in {
+		name = strings.TrimSpace(name)
+		if name != "" {
+			names = append(names, name)
+		}
+	}
+	sort.Strings(names)
+	return names
+}
+
+func stringSetFromMap[V any](in map[string]V) map[string]struct{} {
+	out := map[string]struct{}{}
+	for key := range in {
+		key = strings.TrimSpace(key)
+		if key != "" {
+			out[key] = struct{}{}
+		}
+	}
+	return out
+}

--- a/internal/runtime/contracts/workflow_contract_loading.go
+++ b/internal/runtime/contracts/workflow_contract_loading.go
@@ -181,6 +181,7 @@ func validateWorkflowContractBundleLoadConstraints(bundle *WorkflowContractBundl
 	}
 	errs = append(errs, validateWorkflowSchemaRefinements(bundle)...)
 	errs = append(errs, validateWorkflowCriteriaContracts(bundle)...)
+	errs = append(errs, validateWorkflowPolicyValidationContracts(bundle)...)
 	if len(errs) > 0 {
 		sort.Slice(errs, func(i, j int) bool {
 			return strings.TrimSpace(errs[i].Error()) < strings.TrimSpace(errs[j].Error())

--- a/internal/runtime/contracts/workflow_contract_policy_sheet.go
+++ b/internal/runtime/contracts/workflow_contract_policy_sheet.go
@@ -16,7 +16,7 @@ func lowerPolicySheetRuleNode(node *yaml.Node, rule *HandlerRuleEntry) error {
 		return nil
 	}
 	rowNodes := map[string]*yaml.Node{}
-	for _, key := range []string{"when", "case", "range", "lookup", "else", "default"} {
+	for _, key := range []string{"when", "case", "range", "lookup", "validate", "else", "default"} {
 		if value := yamlMappingValueNode(node, key); value != nil {
 			rowNodes[key] = value
 		}
@@ -64,6 +64,17 @@ func lowerPolicySheetRuleNode(node *yaml.Node, rule *HandlerRuleEntry) error {
 		if !rule.Emit.Empty() || strings.TrimSpace(rule.AdvancesTo) != "" || strings.TrimSpace(rule.Action.ID) != "" ||
 			!rule.Activity.Empty() || rule.DataAccumulation.HasWrites() || rule.FanOut != nil || rule.Compute != nil {
 			return fmt.Errorf("POLICY-SHEET-ROW: lookup row %q derives a value only and cannot declare branch outputs", strings.TrimSpace(rule.ID))
+		}
+		rule.Compute = compute
+		rule.PolicyRow = metadata
+	case rowNodes["validate"] != nil:
+		metadata, compute, err := decodePolicySheetValidateRow(rowNodes["validate"], strings.TrimSpace(rule.ID))
+		if err != nil {
+			return err
+		}
+		if !rule.Emit.Empty() || strings.TrimSpace(rule.AdvancesTo) != "" || strings.TrimSpace(rule.Action.ID) != "" ||
+			!rule.Activity.Empty() || rule.DataAccumulation.HasWrites() || rule.FanOut != nil || rule.Compute != nil {
+			return fmt.Errorf("POLICY-SHEET-ROW: validate row %q derives a value only and cannot declare branch outputs", strings.TrimSpace(rule.ID))
 		}
 		rule.Compute = compute
 		rule.PolicyRow = metadata
@@ -150,6 +161,96 @@ type policySheetRangeForValidation struct {
 	Lower        PolicySheetRangeBound
 	Upper        PolicySheetRangeBound
 	Monotonicity []string
+}
+
+func decodePolicySheetValidateRow(node *yaml.Node, rowID string) (PolicySheetRowMetadata, *ComputeSpec, error) {
+	if node == nil || node.Kind != yaml.MappingNode {
+		return PolicySheetRowMetadata{}, nil, fmt.Errorf("POLICY-SHEET-ROW: validate row must be a mapping")
+	}
+	if err := validatePolicySheetMappingKeys(node, "validate", map[string]struct{}{"set": {}, "input": {}, "into": {}}); err != nil {
+		return PolicySheetRowMetadata{}, nil, err
+	}
+	set, err := decodePolicySheetScalarString(yamlMappingValueNode(node, "set"), "validate.set")
+	if err != nil {
+		return PolicySheetRowMetadata{}, nil, err
+	}
+	if !isPolicySheetPathSegment(set) {
+		return PolicySheetRowMetadata{}, nil, fmt.Errorf("POLICY-SHEET-ROW: validate.set %q must be a short validation set name", strings.TrimSpace(set))
+	}
+	into, err := decodePolicySheetScalarString(yamlMappingValueNode(node, "into"), "validate.into")
+	if err != nil {
+		return PolicySheetRowMetadata{}, nil, err
+	}
+	if err := validatePolicySheetValidateInto(into); err != nil {
+		return PolicySheetRowMetadata{}, nil, err
+	}
+	input, inputPaths, err := decodePolicySheetValidateInput(yamlMappingValueNode(node, "input"))
+	if err != nil {
+		return PolicySheetRowMetadata{}, nil, err
+	}
+	spec := ComputeValidationSpec{
+		RowID:      strings.TrimSpace(rowID),
+		Set:        strings.TrimSpace(set),
+		Into:       strings.TrimSpace(into),
+		Input:      input,
+		InputPaths: inputPaths,
+	}
+	compute := &ComputeSpec{
+		Operation:  ComputeOpValidate,
+		StoreAs:    strings.TrimSpace(into),
+		Validation: &spec,
+	}
+	metadata := PolicySheetRowMetadata{
+		Kind:       PolicySheetRowKindValidate,
+		Validation: &spec,
+	}
+	return metadata, compute, nil
+}
+
+func validatePolicySheetValidateInto(into string) error {
+	parsed := paths.Parse(into)
+	if parsed.Root != paths.RootComputed || len(parsed.Segments) < 2 || parsed.Segments[0] != "validation" {
+		return fmt.Errorf("POLICY-SHEET-ROW: validate.into %q must target computed.validation.*", strings.TrimSpace(into))
+	}
+	for _, segment := range parsed.Segments {
+		if !isPolicySheetPathSegment(segment) {
+			return fmt.Errorf("POLICY-SHEET-ROW: validate.into %q must be a simple computed.validation.* path", strings.TrimSpace(into))
+		}
+	}
+	return nil
+}
+
+func decodePolicySheetValidateInput(node *yaml.Node) (map[string]string, map[string]paths.Path, error) {
+	if node == nil || node.Kind == 0 {
+		return nil, nil, fmt.Errorf("POLICY-SHEET-ROW: validate.input is required")
+	}
+	if node.Kind != yaml.MappingNode {
+		return nil, nil, fmt.Errorf("POLICY-SHEET-ROW: validate.input must be a mapping from validation input name to explicit root path")
+	}
+	out := map[string]string{}
+	parsed := map[string]paths.Path{}
+	for i := 0; i+1 < len(node.Content); i += 2 {
+		name := strings.TrimSpace(node.Content[i].Value)
+		if !isPolicySheetPathSegment(name) {
+			return nil, nil, fmt.Errorf("POLICY-SHEET-ROW: validate.input key %q must be a simple input name", name)
+		}
+		value, err := decodePolicySheetScalarString(node.Content[i+1], "validate.input."+name)
+		if err != nil {
+			return nil, nil, err
+		}
+		if err := validatePolicySheetPath(value, "validate.input."+name, []string{"payload", "entity", "event", "computed"}); err != nil {
+			return nil, nil, err
+		}
+		if _, exists := out[name]; exists {
+			return nil, nil, fmt.Errorf("POLICY-SHEET-ROW: validate.input declares duplicate key %q", name)
+		}
+		out[name] = strings.TrimSpace(value)
+		parsed[name] = paths.Parse(value)
+	}
+	if len(out) == 0 {
+		return nil, nil, fmt.Errorf("POLICY-SHEET-ROW: validate.input requires at least one input mapping")
+	}
+	return out, parsed, nil
 }
 
 func decodePolicySheetCaseRow(node *yaml.Node) (string, PolicySheetRowMetadata, error) {

--- a/internal/runtime/contracts/workflow_contract_types.go
+++ b/internal/runtime/contracts/workflow_contract_types.go
@@ -164,11 +164,12 @@ type HandlerRuleEntry struct {
 type PolicySheetRowKind string
 
 const (
-	PolicySheetRowKindWhen    PolicySheetRowKind = "when"
-	PolicySheetRowKindCase    PolicySheetRowKind = "case"
-	PolicySheetRowKindRange   PolicySheetRowKind = "range"
-	PolicySheetRowKindLookup  PolicySheetRowKind = "lookup"
-	PolicySheetRowKindDefault PolicySheetRowKind = "default"
+	PolicySheetRowKindWhen     PolicySheetRowKind = "when"
+	PolicySheetRowKindCase     PolicySheetRowKind = "case"
+	PolicySheetRowKindRange    PolicySheetRowKind = "range"
+	PolicySheetRowKindLookup   PolicySheetRowKind = "lookup"
+	PolicySheetRowKindValidate PolicySheetRowKind = "validate"
+	PolicySheetRowKindDefault  PolicySheetRowKind = "default"
 )
 
 type PolicySheetRowMetadata struct {
@@ -180,6 +181,7 @@ type PolicySheetRowMetadata struct {
 	RangeUpper   PolicySheetRangeBound
 	Monotonicity []string
 	Lookup       *ComputeLookupSpec
+	Validation   *ComputeValidationSpec
 }
 
 type PolicySheetRangeBound struct {
@@ -309,15 +311,16 @@ type AccumulateSpec struct {
 	OnTimeout    *HandlerRuleEntry    `yaml:"on_timeout"`
 }
 type ComputeSpec struct {
-	Operation   ComputeOperation   `yaml:"operation"`
-	Tiers       []ComputeTier      `yaml:"tiers"`
-	Keys        ComputeKeyConfig   `yaml:"keys"`
-	Params      map[string]any     `yaml:"params"`
-	StoreAs     string             `yaml:"store_as"`
-	Description string             `yaml:"description"`
-	ValueField  string             `yaml:"value_field"`
-	WeightField string             `yaml:"weight_field"`
-	Lookup      *ComputeLookupSpec `yaml:"-"`
+	Operation   ComputeOperation       `yaml:"operation"`
+	Tiers       []ComputeTier          `yaml:"tiers"`
+	Keys        ComputeKeyConfig       `yaml:"keys"`
+	Params      map[string]any         `yaml:"params"`
+	StoreAs     string                 `yaml:"store_as"`
+	Description string                 `yaml:"description"`
+	ValueField  string                 `yaml:"value_field"`
+	WeightField string                 `yaml:"weight_field"`
+	Lookup      *ComputeLookupSpec     `yaml:"-"`
+	Validation  *ComputeValidationSpec `yaml:"-"`
 }
 
 type ComputeLookupSpec struct {
@@ -342,6 +345,15 @@ type ComputeLookupLiteral struct {
 	Canonical string `yaml:"-"`
 	Summary   string `yaml:"-"`
 }
+
+type ComputeValidationSpec struct {
+	RowID      string                `yaml:"-"`
+	Set        string                `yaml:"-"`
+	Into       string                `yaml:"-"`
+	Input      map[string]string     `yaml:"-"`
+	InputPaths map[string]paths.Path `yaml:"-"`
+}
+
 type ComputeTier struct {
 	Dimensions []string `yaml:"dimensions"`
 	Weight     float64  `yaml:"weight"`
@@ -603,6 +615,11 @@ type PolicyCriteriaSet = flowmodel.PolicyCriteriaSet
 type PolicyCriteriaClass = flowmodel.PolicyCriteriaClass
 type PolicyCriteriaRule = flowmodel.PolicyCriteriaRule
 type PolicyCriteriaParam = flowmodel.PolicyCriteriaParam
+type PolicyValidationSet = flowmodel.PolicyValidationSet
+type PolicyValidationClass = flowmodel.PolicyValidationClass
+type PolicyValidationRule = flowmodel.PolicyValidationRule
+type PolicyValidationCheck = flowmodel.PolicyValidationCheck
+type PolicyValidationEqualCheck = flowmodel.PolicyValidationEqualCheck
 type ContractURIRegistry = flowmodel.URIRegistry
 type ContractURIRef = flowmodel.URIRef
 type ExpressionKind string

--- a/internal/runtime/contracts/workflow_contract_yaml_flow.go
+++ b/internal/runtime/contracts/workflow_contract_yaml_flow.go
@@ -39,6 +39,7 @@ func validateRuleFieldNodes(node *yaml.Node) error {
 		"case":              {},
 		"range":             {},
 		"lookup":            {},
+		"validate":          {},
 		"else":              {},
 		"default":           {},
 		"advances_to":       {},
@@ -63,7 +64,7 @@ func validateRuleFieldNodes(node *yaml.Node) error {
 			return fmt.Errorf("UNSUPPORTED-POLICY-SHEET-ROW: rule field %q is not a standalone row type; use rules when/case/range selection rows or split value lookup to compute", key)
 		case "policy":
 			return fmt.Errorf("UNSUPPORTED-POLICY-SHEET-ROW: rule field %q would create a second policy-sheet authoring owner; enhance rules in place", key)
-		case "temporal", "join", "loop", "collection", "schedule", "validate":
+		case "temporal", "join", "loop", "collection", "schedule":
 			return fmt.Errorf("UNSUPPORTED-POLICY-SHEET-ROW: rule field %q is outside the #1713 selection-row scope", key)
 		}
 		if _, ok := allowed[key]; !ok {

--- a/internal/runtime/contracts/workflow_contract_yaml_test.go
+++ b/internal/runtime/contracts/workflow_contract_yaml_test.go
@@ -861,6 +861,56 @@ rules:
 	}
 }
 
+func TestSystemNodeEventHandlerDecode_LowersPolicySheetValidateValueRows(t *testing.T) {
+	var handler SystemNodeEventHandler
+	if err := yaml.Unmarshal([]byte(`
+rules:
+  - id: validate_manifest
+    validate:
+      set: deploy_manifest
+      input:
+        source_ref: payload.source_ref
+        manifest_source_ref: payload.file_manifest.source_ref
+      into: computed.validation.deploy_manifest
+  - id: invalid_manifest
+    when: computed.validation.deploy_manifest.valid == false
+    emit: deploy.manifest_invalid
+  - id: fallback
+    default: true
+    emit: deploy.manifest_accepted
+`), &handler); err != nil {
+		t.Fatalf("yaml.Unmarshal: %v", err)
+	}
+	if got, want := len(handler.Rules), 3; got != want {
+		t.Fatalf("rules len = %d, want %d", got, want)
+	}
+	validateRule := handler.Rules[0]
+	if got := validateRule.PolicyRow.Kind; got != PolicySheetRowKindValidate {
+		t.Fatalf("validate PolicyRow.Kind = %q, want validate", got)
+	}
+	if validateRule.Compute == nil {
+		t.Fatal("validate row Compute = nil")
+	}
+	if got := validateRule.Compute.Operation; got != ComputeOpValidate {
+		t.Fatalf("validate Compute.Operation = %q, want validate", got)
+	}
+	if got := validateRule.Compute.StoreAs; got != "computed.validation.deploy_manifest" {
+		t.Fatalf("validate StoreAs = %q, want computed.validation.deploy_manifest", got)
+	}
+	if validateRule.Compute.Validation == nil {
+		t.Fatal("validate Compute.Validation = nil")
+	}
+	if got := validateRule.Compute.Validation.Set; got != "deploy_manifest" {
+		t.Fatalf("validate set = %q, want deploy_manifest", got)
+	}
+	if got := validateRule.Compute.Validation.Input["source_ref"]; got != "payload.source_ref" {
+		t.Fatalf("validate input source_ref = %q, want payload.source_ref", got)
+	}
+	if got := handler.Rules[1].Condition; got != `computed.validation.deploy_manifest.valid == false` {
+		t.Fatalf("consumer condition = %q", got)
+	}
+}
+
 func TestSystemNodeEventHandlerDecode_PreservesPolicyRowWordsAsRuleIDsInKeyedMap(t *testing.T) {
 	var handler SystemNodeEventHandler
 	if err := yaml.Unmarshal([]byte(`
@@ -1159,6 +1209,15 @@ rules:
 compute:
   operation: lookup
   store_as: computed.template_path
+`,
+			contains: "internal to policy-sheet value rows",
+		},
+		{
+			name: "public compute validate",
+			body: `
+compute:
+  operation: validate
+  store_as: computed.validation.deploy_manifest
 `,
 			contains: "internal to policy-sheet value rows",
 		},

--- a/internal/runtime/engine/executor.go
+++ b/internal/runtime/engine/executor.go
@@ -1112,7 +1112,7 @@ func (e *Executor) computeValidationValue(frame *executionFrame, spec *runtimeco
 		if !leftOK || !rightOK {
 			return nil, fmt.Errorf("validation_input_no_retry: row %s rule %s references unmapped validation input", rowID, strings.TrimSpace(rule.ID))
 		}
-		if reflect.DeepEqual(left, right) {
+		if validationRuntimeValuesEqual(left, right, set.Inputs[leftName]) {
 			continue
 		}
 		violations = append(violations, map[string]any{
@@ -1157,6 +1157,48 @@ func validationRuntimeValueMatchesType(value any, declared string) bool {
 		return kind == "number" || kind == "int"
 	default:
 		return false
+	}
+}
+
+func validationRuntimeValuesEqual(left, right any, declared string) bool {
+	switch strings.ToLower(strings.TrimSpace(declared)) {
+	case "int", "integer":
+		leftCanonical, leftOK := validationRuntimeIntegralCanonical(left)
+		rightCanonical, rightOK := validationRuntimeIntegralCanonical(right)
+		return leftOK && rightOK && leftCanonical == rightCanonical
+	case "number", "numeric", "float", "double":
+		leftCanonical, leftOK := validationRuntimeNumericCanonical(left)
+		rightCanonical, rightOK := validationRuntimeNumericCanonical(right)
+		return leftOK && rightOK && leftCanonical == rightCanonical
+	default:
+		return reflect.DeepEqual(left, right)
+	}
+}
+
+func validationRuntimeIntegralCanonical(value any) (string, bool) {
+	kind, summary, _, ok := runtimecontracts.CanonicalizeComputeLookupValue(value)
+	if !ok {
+		return "", false
+	}
+	if kind == "int" {
+		return summary, true
+	}
+	if integral, ok := integralLookupFloatSummary(value); ok {
+		return integral, true
+	}
+	return "", false
+}
+
+func validationRuntimeNumericCanonical(value any) (string, bool) {
+	kind, summary, _, ok := runtimecontracts.CanonicalizeComputeLookupValue(value)
+	if !ok {
+		return "", false
+	}
+	switch kind {
+	case "int", "number":
+		return summary, true
+	default:
+		return "", false
 	}
 }
 

--- a/internal/runtime/engine/executor.go
+++ b/internal/runtime/engine/executor.go
@@ -990,7 +990,7 @@ func (e *Executor) stepCount(frame *executionFrame) error {
 func (e *Executor) stepCompute(frame *executionFrame) error {
 	if frame.rule != nil {
 		spec := frame.rule.Compute
-		if spec == nil || spec.Operation == runtimecontracts.ComputeOpLookup {
+		if spec == nil || spec.Operation == runtimecontracts.ComputeOpLookup || spec.Operation == runtimecontracts.ComputeOpValidate {
 			return nil
 		}
 		return e.executeComputeSpec(frame, spec)
@@ -1002,7 +1002,7 @@ func (e *Executor) stepCompute(frame *executionFrame) error {
 	}
 	for idx := range frame.req.Handler.Rules {
 		rule := &frame.req.Handler.Rules[idx]
-		if rule.PolicyRow.Kind != runtimecontracts.PolicySheetRowKindLookup || rule.Compute == nil {
+		if (rule.PolicyRow.Kind != runtimecontracts.PolicySheetRowKindLookup && rule.PolicyRow.Kind != runtimecontracts.PolicySheetRowKindValidate) || rule.Compute == nil {
 			continue
 		}
 		if err := e.executeComputeSpec(frame, rule.Compute); err != nil {
@@ -1021,13 +1021,19 @@ func (e *Executor) executeComputeSpec(frame *executionFrame, spec *runtimecontra
 		value any
 		err   error
 	)
-	if spec.Operation == runtimecontracts.ComputeOpLookup {
+	switch spec.Operation {
+	case runtimecontracts.ComputeOpLookup:
 		value, err = computeLookupValue(e.currentContext(frame), spec)
-	} else {
+	case runtimecontracts.ComputeOpValidate:
+		value, err = e.computeValidationValue(frame, spec)
+	default:
 		value, err = computeValue(acc, frame.payload, spec)
 	}
 	if err != nil {
 		return err
+	}
+	if spec.Operation == runtimecontracts.ComputeOpValidate {
+		return e.storeComputedPathOnly(frame, spec.StoreAs, value)
 	}
 	if storeAs := strings.TrimSpace(spec.StoreAs); storeAs != "" {
 		if handlerTargetRequiresCanonicalWrite(storeAs) {
@@ -1052,6 +1058,121 @@ func (e *Executor) executeComputeSpec(frame *executionFrame, spec *runtimecontra
 	frame.state.State.SetMetadata("computed", value)
 	frame.result.StateMutation.StateCarrier.Metadata = cloneStringAnyMap(frame.state.State.StateCarrier.Metadata)
 	frame.result.StateMutation.SetMetadata("computed", value)
+	return nil
+}
+
+func (e *Executor) computeValidationValue(frame *executionFrame, spec *runtimecontracts.ComputeSpec) (any, error) {
+	if spec == nil || spec.Validation == nil {
+		return nil, ErrNotImplemented
+	}
+	plan := spec.Validation
+	rowID := strings.TrimSpace(plan.RowID)
+	if rowID == "" {
+		rowID = strings.TrimSpace(spec.StoreAs)
+	}
+	policy := e.deps.Source.ResolvedPolicyForFlow(frame.req.FlowID.String())
+	setName := strings.TrimSpace(plan.Set)
+	set, ok := policy.Validation[setName]
+	if !ok {
+		return nil, fmt.Errorf("validation_config_no_retry: row %s references unknown validation set %q", rowID, setName)
+	}
+	current := e.currentContext(frame)
+	inputs := map[string]any{}
+	for name, declaredType := range set.Inputs {
+		name = strings.TrimSpace(name)
+		if name == "" {
+			continue
+		}
+		path, ok := plan.InputPaths[name]
+		if !ok {
+			path = paths.Parse(plan.Input[name])
+		}
+		if path.IsZero() {
+			return nil, fmt.Errorf("validation_input_no_retry: row %s input.%s has no mapped source path", rowID, name)
+		}
+		value, exists := current.Lookup(path)
+		if !exists {
+			return nil, fmt.Errorf("validation_input_no_retry: row %s input.%s source %s is missing", rowID, name, path.String())
+		}
+		if !validationRuntimeValueMatchesType(value, declaredType) {
+			return nil, fmt.Errorf("validation_input_no_retry: row %s input.%s source %s does not match declared type %s", rowID, name, path.String(), strings.TrimSpace(declaredType))
+		}
+		inputs[name] = value
+	}
+	violations := make([]any, 0)
+	for _, rule := range set.Rules {
+		equal := rule.Check.Equal
+		if equal == nil {
+			return nil, fmt.Errorf("validation_config_no_retry: row %s rule %s has no equal check", rowID, strings.TrimSpace(rule.ID))
+		}
+		leftName := validationInputName(equal.Left)
+		rightName := validationInputName(equal.Right)
+		left, leftOK := inputs[leftName]
+		right, rightOK := inputs[rightName]
+		if !leftOK || !rightOK {
+			return nil, fmt.Errorf("validation_input_no_retry: row %s rule %s references unmapped validation input", rowID, strings.TrimSpace(rule.ID))
+		}
+		if reflect.DeepEqual(left, right) {
+			continue
+		}
+		violations = append(violations, map[string]any{
+			"id":          strings.TrimSpace(rule.ID),
+			"class":       strings.TrimSpace(rule.Class),
+			"content_ref": strings.Join([]string{strings.TrimSpace(equal.Left), strings.TrimSpace(equal.Right)}, ","),
+		})
+	}
+	return map[string]any{
+		"valid":      len(violations) == 0,
+		"violations": violations,
+	}, nil
+}
+
+func validationInputName(ref string) string {
+	name, ok := strings.CutPrefix(strings.TrimSpace(ref), "input.")
+	if !ok {
+		return ""
+	}
+	return strings.TrimSpace(name)
+}
+
+func validationRuntimeValueMatchesType(value any, declared string) bool {
+	kind, _, _, ok := runtimecontracts.CanonicalizeComputeLookupValue(value)
+	if !ok {
+		return false
+	}
+	switch strings.ToLower(strings.TrimSpace(declared)) {
+	case "string", "text", "uuid", "timestamp", "datetime", "date":
+		return kind == "string"
+	case "bool", "boolean":
+		return kind == "bool"
+	case "int", "integer":
+		if kind == "int" {
+			return true
+		}
+		if _, ok := integralLookupFloatSummary(value); ok {
+			return true
+		}
+		return false
+	case "number", "numeric", "float", "double":
+		return kind == "number" || kind == "int"
+	default:
+		return false
+	}
+}
+
+func (e *Executor) storeComputedPathOnly(frame *executionFrame, storeAs string, value any) error {
+	parsed := paths.Parse(storeAs)
+	if parsed.Root != paths.RootComputed || len(parsed.Segments) < 2 || parsed.Segments[0] != "validation" {
+		return fmt.Errorf("validation_config_no_retry: validate.into %q must target computed.validation.*", strings.TrimSpace(storeAs))
+	}
+	if frame.state.Computed == nil {
+		frame.state.Computed = map[string]any{}
+	}
+	if frame.result.Computed == nil {
+		frame.result.Computed = map[string]any{}
+	}
+	values.Wrap(frame.state.Computed).SetPath(parsed, value)
+	values.Wrap(frame.result.Computed).SetPath(parsed, value)
 	return nil
 }
 
@@ -2148,7 +2269,7 @@ func (e *Executor) evaluateGuardCheck(frame *executionFrame, id, check, policyRe
 func (e *Executor) selectRule(frame *executionFrame, rules []runtimecontracts.HandlerRuleEntry) (*runtimecontracts.HandlerRuleEntry, error) {
 	for idx := range rules {
 		rule := &rules[idx]
-		if rule.PolicyRow.Kind == runtimecontracts.PolicySheetRowKindLookup {
+		if rule.PolicyRow.Kind == runtimecontracts.PolicySheetRowKindLookup || rule.PolicyRow.Kind == runtimecontracts.PolicySheetRowKindValidate {
 			continue
 		}
 		condition := strings.TrimSpace(rule.Condition)

--- a/internal/runtime/engine/executor_test.go
+++ b/internal/runtime/engine/executor_test.go
@@ -1732,6 +1732,116 @@ func TestExecutor_PolicySheetValidateRowFeedsSelectionRow(t *testing.T) {
 	}
 }
 
+func TestExecutor_PolicySheetValidateNumericEqualityCanonicalizesRuntimeValues(t *testing.T) {
+	pinCandidate := true
+	source := semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
+		Policy: runtimecontracts.PolicyDocument{Validation: map[string]runtimecontracts.PolicyValidationSet{
+			"count_match": {
+				Classes: map[string]runtimecontracts.PolicyValidationClass{
+					"invalid": {Disposition: "deploy.count_mismatch"},
+				},
+				Inputs: map[string]string{
+					"payload_count": "number",
+					"entity_count":  "number",
+				},
+				Rules: []runtimecontracts.PolicyValidationRule{{
+					ID:           "VR-COUNT-001",
+					Class:        "invalid",
+					Text:         "Payload count must match entity count.",
+					PinCandidate: &pinCandidate,
+					Check: runtimecontracts.PolicyValidationCheck{
+						Equal: &runtimecontracts.PolicyValidationEqualCheck{
+							Left:  "input.payload_count",
+							Right: "input.entity_count",
+						},
+					},
+				}},
+			},
+		}},
+	})
+	exec, err := NewExecutor(RuntimeDependencies{
+		Source:       source,
+		StateRepo:    stubStateRepo{},
+		TxRunner:     stubRunner{},
+		Locker:       stubLocker{},
+		Outbox:       stubOutbox{},
+		TimerApplier: stubTimerApplier{},
+		Dispatcher:   stubDispatcher{},
+	}, contextualBoolEvaluator{bools: map[string]func(BaseContext) (bool, error){
+		`computed.validation.count_match.valid == true`: func(base BaseContext) (bool, error) {
+			validation, _ := base.Computed.Raw()["validation"].(map[string]any)
+			count, _ := validation["count_match"].(map[string]any)
+			return count["valid"] == true, nil
+		},
+	}})
+	if err != nil {
+		t.Fatalf("NewExecutor error: %v", err)
+	}
+	validation := &runtimecontracts.ComputeValidationSpec{
+		RowID: "validate_count",
+		Set:   "count_match",
+		Into:  "computed.validation.count_match",
+		Input: map[string]string{
+			"payload_count": "payload.count",
+			"entity_count":  "entity.expected_count",
+		},
+		InputPaths: map[string]runtimepaths.Path{
+			"payload_count": runtimepaths.Parse("payload.count"),
+			"entity_count":  runtimepaths.Parse("entity.expected_count"),
+		},
+	}
+	result, err := exec.Execute(context.Background(), ExecutionRequest{
+		EntityID: identity.NormalizeEntityID("11111111-1111-1111-1111-111111111111"),
+		NodeID:   identity.NodeID("deploy-node"),
+		Event: eventtest.RootIngress(
+			"evt-1",
+			events.EventType("deploy.requested"),
+			"",
+			"",
+			mustEncodeJSON(t, map[string]any{"count": 1}),
+			0,
+			"",
+			"",
+			events.EventEnvelope{},
+			time.Date(2026, time.January, 1, 0, 0, 0, 0, time.UTC),
+		),
+		State: testStateSnapshot("pending", map[string]any{"expected_count": int(1)}, nil, map[string]map[string]any{}),
+		Handler: runtimecontracts.SystemNodeEventHandler{
+			Rules: []runtimecontracts.HandlerRuleEntry{
+				{
+					ID:        "validate_count",
+					PolicyRow: runtimecontracts.PolicySheetRowMetadata{Kind: runtimecontracts.PolicySheetRowKindValidate, Validation: validation},
+					Compute: &runtimecontracts.ComputeSpec{
+						Operation:  runtimecontracts.ComputeOpValidate,
+						StoreAs:    "computed.validation.count_match",
+						Validation: validation,
+					},
+				},
+				{
+					ID:        "valid_count",
+					Condition: `computed.validation.count_match.valid == true`,
+					Emit:      runtimecontracts.EmitSpec{Event: "deploy.count_matched"},
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Execute error: %v", err)
+	}
+	validationResult, _ := result.Computed["validation"].(map[string]any)
+	countResult, _ := validationResult["count_match"].(map[string]any)
+	if got := countResult["valid"]; got != true {
+		t.Fatalf("validation valid = %#v, want true; result %#v", got, countResult)
+	}
+	violations, _ := countResult["violations"].([]any)
+	if len(violations) != 0 {
+		t.Fatalf("violations len = %d, want 0: %#v", len(violations), countResult["violations"])
+	}
+	if got := result.RuleID; got != "valid_count" {
+		t.Fatalf("selected rule = %q, want valid_count", got)
+	}
+}
+
 func TestExecutor_AccumulatorProjectionFailsClosedWhenDeclaredBindingDoesNotResolveAtRuntime(t *testing.T) {
 	source := semanticview.Wrap(loadEngineProjectionFlowBundle(t))
 	exec, err := NewExecutor(RuntimeDependencies{

--- a/internal/runtime/engine/executor_test.go
+++ b/internal/runtime/engine/executor_test.go
@@ -1608,6 +1608,130 @@ func TestExecutor_PolicySheetLookupRowFeedsSelectionRow(t *testing.T) {
 	}
 }
 
+func TestExecutor_PolicySheetValidateRowFeedsSelectionRow(t *testing.T) {
+	pinCandidate := true
+	source := semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
+		Policy: runtimecontracts.PolicyDocument{Validation: map[string]runtimecontracts.PolicyValidationSet{
+			"deploy_manifest": {
+				Classes: map[string]runtimecontracts.PolicyValidationClass{
+					"invalid": {Disposition: "deploy.manifest_invalid"},
+				},
+				Inputs: map[string]string{
+					"source_ref":          "string",
+					"manifest_source_ref": "string",
+				},
+				Rules: []runtimecontracts.PolicyValidationRule{{
+					ID:           "VR-001",
+					Class:        "invalid",
+					Text:         "Manifest source ref must match request source ref.",
+					PinCandidate: &pinCandidate,
+					Check: runtimecontracts.PolicyValidationCheck{
+						Equal: &runtimecontracts.PolicyValidationEqualCheck{
+							Left:  "input.source_ref",
+							Right: "input.manifest_source_ref",
+						},
+					},
+				}},
+			},
+		}},
+	})
+	exec, err := NewExecutor(RuntimeDependencies{
+		Source:       source,
+		StateRepo:    stubStateRepo{},
+		TxRunner:     stubRunner{},
+		Locker:       stubLocker{},
+		Outbox:       stubOutbox{},
+		TimerApplier: stubTimerApplier{},
+		Dispatcher:   stubDispatcher{},
+	}, contextualBoolEvaluator{bools: map[string]func(BaseContext) (bool, error){
+		`computed.validation.deploy_manifest.valid == false`: func(base BaseContext) (bool, error) {
+			validation, _ := base.Computed.Raw()["validation"].(map[string]any)
+			deploy, _ := validation["deploy_manifest"].(map[string]any)
+			return deploy["valid"] == false, nil
+		},
+	}})
+	if err != nil {
+		t.Fatalf("NewExecutor error: %v", err)
+	}
+	validation := &runtimecontracts.ComputeValidationSpec{
+		RowID: "validate_manifest",
+		Set:   "deploy_manifest",
+		Into:  "computed.validation.deploy_manifest",
+		Input: map[string]string{
+			"source_ref":          "payload.source_ref",
+			"manifest_source_ref": "payload.file_manifest.source_ref",
+		},
+		InputPaths: map[string]runtimepaths.Path{
+			"source_ref":          runtimepaths.Parse("payload.source_ref"),
+			"manifest_source_ref": runtimepaths.Parse("payload.file_manifest.source_ref"),
+		},
+	}
+	result, err := exec.Execute(context.Background(), ExecutionRequest{
+		EntityID: identity.NormalizeEntityID("11111111-1111-1111-1111-111111111111"),
+		NodeID:   identity.NodeID("deploy-node"),
+		Event: eventtest.RootIngress(
+			"evt-1",
+			events.EventType("deploy.requested"),
+			"",
+			"",
+			mustEncodeJSON(t, map[string]any{
+				"source_ref": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+				"file_manifest": map[string]any{
+					"source_ref": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+				},
+			}),
+			0,
+			"",
+			"",
+			events.EventEnvelope{},
+			time.Date(2026, time.January, 1, 0, 0, 0, 0, time.UTC),
+		),
+		State: testStateSnapshot("pending", map[string]any{}, nil, map[string]map[string]any{}),
+		Handler: runtimecontracts.SystemNodeEventHandler{
+			Rules: []runtimecontracts.HandlerRuleEntry{
+				{
+					ID:        "validate_manifest",
+					PolicyRow: runtimecontracts.PolicySheetRowMetadata{Kind: runtimecontracts.PolicySheetRowKindValidate, Validation: validation},
+					Compute: &runtimecontracts.ComputeSpec{
+						Operation:  runtimecontracts.ComputeOpValidate,
+						StoreAs:    "computed.validation.deploy_manifest",
+						Validation: validation,
+					},
+				},
+				{
+					ID:        "invalid_manifest",
+					Condition: `computed.validation.deploy_manifest.valid == false`,
+					Emit:      runtimecontracts.EmitSpec{Event: "deploy.manifest_invalid"},
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Execute error: %v", err)
+	}
+	validationResult, _ := result.Computed["validation"].(map[string]any)
+	deployResult, _ := validationResult["deploy_manifest"].(map[string]any)
+	if got := deployResult["valid"]; got != false {
+		t.Fatalf("validation valid = %#v, want false", got)
+	}
+	violations, _ := deployResult["violations"].([]any)
+	if len(violations) != 1 {
+		t.Fatalf("violations len = %d, want 1: %#v", len(violations), deployResult["violations"])
+	}
+	if got := result.RuleID; got != "invalid_manifest" {
+		t.Fatalf("selected rule = %q, want invalid_manifest", got)
+	}
+	if got := len(result.EmitIntents); got != 1 {
+		t.Fatalf("emit intents = %d, want 1", got)
+	}
+	if got := string(result.EmitIntents[0].Event.Type()); got != "deploy.manifest_invalid" {
+		t.Fatalf("emit event = %q, want deploy.manifest_invalid", got)
+	}
+	if _, ok := result.StateMutation.Metadata["validation"]; ok {
+		t.Fatalf("validation result leaked into state mutation metadata: %#v", result.StateMutation.Metadata)
+	}
+}
+
 func TestExecutor_AccumulatorProjectionFailsClosedWhenDeclaredBindingDoesNotResolveAtRuntime(t *testing.T) {
 	source := semanticview.Wrap(loadEngineProjectionFlowBundle(t))
 	exec, err := NewExecutor(RuntimeDependencies{

--- a/internal/runtime/flowmodel/model.go
+++ b/internal/runtime/flowmodel/model.go
@@ -8,8 +8,9 @@ import (
 )
 
 type PolicyDocument struct {
-	Values   map[string]PolicyValue       `yaml:",inline"`
-	Criteria map[string]PolicyCriteriaSet `yaml:"criteria,omitempty"`
+	Values     map[string]PolicyValue         `yaml:",inline"`
+	Criteria   map[string]PolicyCriteriaSet   `yaml:"criteria,omitempty"`
+	Validation map[string]PolicyValidationSet `yaml:"validation,omitempty"`
 }
 
 type PolicyValue struct {
@@ -36,6 +37,34 @@ type PolicyCriteriaRule struct {
 
 type PolicyCriteriaParam struct {
 	Value any
+}
+
+type PolicyValidationSet struct {
+	Classes map[string]PolicyValidationClass `yaml:"classes"`
+	Inputs  map[string]string                `yaml:"inputs"`
+	Rules   []PolicyValidationRule           `yaml:"rules"`
+}
+
+type PolicyValidationClass struct {
+	Disposition string `yaml:"disposition"`
+}
+
+type PolicyValidationRule struct {
+	ID           string                         `yaml:"id"`
+	Class        string                         `yaml:"class"`
+	Text         string                         `yaml:"text"`
+	Params       map[string]PolicyCriteriaParam `yaml:"params"`
+	PinCandidate *bool                          `yaml:"pin_candidate"`
+	Check        PolicyValidationCheck          `yaml:"check"`
+}
+
+type PolicyValidationCheck struct {
+	Equal *PolicyValidationEqualCheck `yaml:"equal"`
+}
+
+type PolicyValidationEqualCheck struct {
+	Left  string `yaml:"left"`
+	Right string `yaml:"right"`
 }
 
 type Tree[T any] struct {
@@ -74,6 +103,7 @@ func (d *PolicyDocument) UnmarshalYAML(node *yaml.Node) error {
 		return fmt.Errorf("policy document must be a mapping")
 	}
 	criteria := map[string]PolicyCriteriaSet{}
+	validation := map[string]PolicyValidationSet{}
 	for i := 0; i+1 < len(node.Content); i += 2 {
 		key := strings.TrimSpace(node.Content[i].Value)
 		if key == "" {
@@ -85,6 +115,12 @@ func (d *PolicyDocument) UnmarshalYAML(node *yaml.Node) error {
 			}
 			continue
 		}
+		if key == "validation" {
+			if err := node.Content[i+1].Decode(&validation); err != nil {
+				return fmt.Errorf("policy validation: %w", err)
+			}
+			continue
+		}
 		var value PolicyValue
 		if err := node.Content[i+1].Decode(&value); err != nil {
 			return err
@@ -93,6 +129,7 @@ func (d *PolicyDocument) UnmarshalYAML(node *yaml.Node) error {
 	}
 	d.Values = values
 	d.Criteria = criteria
+	d.Validation = validation
 	return nil
 }
 

--- a/internal/runtime/flowmodel/model.go
+++ b/internal/runtime/flowmodel/model.go
@@ -170,6 +170,120 @@ func (p *PolicyCriteriaParam) UnmarshalYAML(node *yaml.Node) error {
 	return nil
 }
 
+func (s *PolicyValidationSet) UnmarshalYAML(node *yaml.Node) error {
+	if s == nil {
+		return nil
+	}
+	if err := validateYAMLMappingKeys(node, "policy validation set", map[string]struct{}{
+		"classes": {},
+		"inputs":  {},
+		"rules":   {},
+	}); err != nil {
+		return err
+	}
+	type alias PolicyValidationSet
+	var aux alias
+	if err := node.Decode(&aux); err != nil {
+		return err
+	}
+	*s = PolicyValidationSet(aux)
+	return nil
+}
+
+func (c *PolicyValidationClass) UnmarshalYAML(node *yaml.Node) error {
+	if c == nil {
+		return nil
+	}
+	if err := validateYAMLMappingKeys(node, "policy validation class", map[string]struct{}{
+		"disposition": {},
+	}); err != nil {
+		return err
+	}
+	type alias PolicyValidationClass
+	var aux alias
+	if err := node.Decode(&aux); err != nil {
+		return err
+	}
+	*c = PolicyValidationClass(aux)
+	return nil
+}
+
+func (r *PolicyValidationRule) UnmarshalYAML(node *yaml.Node) error {
+	if r == nil {
+		return nil
+	}
+	if err := validateYAMLMappingKeys(node, "policy validation rule", map[string]struct{}{
+		"id":            {},
+		"class":         {},
+		"text":          {},
+		"params":        {},
+		"pin_candidate": {},
+		"check":         {},
+	}); err != nil {
+		return err
+	}
+	type alias PolicyValidationRule
+	var aux alias
+	if err := node.Decode(&aux); err != nil {
+		return err
+	}
+	*r = PolicyValidationRule(aux)
+	return nil
+}
+
+func (c *PolicyValidationCheck) UnmarshalYAML(node *yaml.Node) error {
+	if c == nil {
+		return nil
+	}
+	if err := validateYAMLMappingKeys(node, "policy validation check", map[string]struct{}{
+		"equal": {},
+	}); err != nil {
+		return err
+	}
+	type alias PolicyValidationCheck
+	var aux alias
+	if err := node.Decode(&aux); err != nil {
+		return err
+	}
+	*c = PolicyValidationCheck(aux)
+	return nil
+}
+
+func (c *PolicyValidationEqualCheck) UnmarshalYAML(node *yaml.Node) error {
+	if c == nil {
+		return nil
+	}
+	if err := validateYAMLMappingKeys(node, "policy validation equal check", map[string]struct{}{
+		"left":  {},
+		"right": {},
+	}); err != nil {
+		return err
+	}
+	type alias PolicyValidationEqualCheck
+	var aux alias
+	if err := node.Decode(&aux); err != nil {
+		return err
+	}
+	*c = PolicyValidationEqualCheck(aux)
+	return nil
+}
+
+func validateYAMLMappingKeys(node *yaml.Node, context string, allowed map[string]struct{}) error {
+	if node == nil || node.Kind == 0 {
+		return fmt.Errorf("%s must be a mapping", context)
+	}
+	if node.Kind != yaml.MappingNode {
+		return fmt.Errorf("%s must be a mapping", context)
+	}
+	for i := 0; i+1 < len(node.Content); i += 2 {
+		key := strings.TrimSpace(node.Content[i].Value)
+		if _, ok := allowed[key]; !ok {
+			return fmt.Errorf("%s unsupported field %q", context, key)
+		}
+	}
+	return nil
+}
+
 func hasYAMLMappingKey(node *yaml.Node, key string) bool {
 	if node == nil || node.Kind != yaml.MappingNode {
 		return false

--- a/internal/runtime/flowmodel/model_test.go
+++ b/internal/runtime/flowmodel/model_test.go
@@ -114,6 +114,49 @@ criteria:
 	}
 }
 
+func TestPolicyDocumentValidationIsTypedSectionNotGenericValue(t *testing.T) {
+	var doc PolicyDocument
+	if err := yaml.Unmarshal([]byte(`
+threshold: 12
+validation:
+  deploy_manifest:
+    classes:
+      invalid: {disposition: deploy.manifest_invalid}
+    inputs:
+      source_ref: string
+      manifest_source_ref: string
+    rules:
+      - id: VR-001
+        class: invalid
+        text: Manifest source ref must match request source ref.
+        pin_candidate: true
+        check:
+          equal: {left: input.source_ref, right: input.manifest_source_ref}
+`), &doc); err != nil {
+		t.Fatalf("yaml.Unmarshal PolicyDocument: %v", err)
+	}
+
+	if _, ok := doc.Values["validation"]; ok {
+		t.Fatalf("validation leaked into generic policy values: %#v", doc.Values["validation"])
+	}
+	set, ok := doc.Validation["deploy_manifest"]
+	if !ok {
+		t.Fatalf("validation set missing: %#v", doc.Validation)
+	}
+	if got := set.Classes["invalid"].Disposition; got != "deploy.manifest_invalid" {
+		t.Fatalf("invalid disposition = %q, want deploy.manifest_invalid", got)
+	}
+	if got := set.Inputs["source_ref"]; got != "string" {
+		t.Fatalf("input source_ref type = %q, want string", got)
+	}
+	if len(set.Rules) != 1 || set.Rules[0].ID != "VR-001" {
+		t.Fatalf("rules = %#v, want VR-001", set.Rules)
+	}
+	if set.Rules[0].PinCandidate == nil || !*set.Rules[0].PinCandidate {
+		t.Fatalf("pin_candidate = %#v, want true", set.Rules[0].PinCandidate)
+	}
+}
+
 func TestResolvePolicyByID_MergesCriteriaAlongAncestorChain(t *testing.T) {
 	root := &testNode{
 		ID: "root",
@@ -175,6 +218,107 @@ func TestResolvePolicyByID_MergesCriteriaAlongAncestorChain(t *testing.T) {
 	}
 	if gotID := got.Criteria["shared"].Rules[0].ID; gotID != "CHILD-SHARED" {
 		t.Fatalf("shared criteria rule = %q, want child override", gotID)
+	}
+}
+
+func TestResolvePolicyByID_MergesValidationAlongAncestorChain(t *testing.T) {
+	falseValue := false
+	trueValue := true
+	root := &testNode{
+		ID: "root",
+		Policy: PolicyDocument{
+			Validation: map[string]PolicyValidationSet{
+				"root_set": {
+					Classes: map[string]PolicyValidationClass{"invalid": {Disposition: "root.invalid"}},
+					Inputs:  map[string]string{"left": "string", "right": "string"},
+					Rules: []PolicyValidationRule{{
+						ID:           "ROOT-1",
+						Class:        "invalid",
+						Text:         "Root validation.",
+						PinCandidate: &falseValue,
+						Check:        PolicyValidationCheck{Equal: &PolicyValidationEqualCheck{Left: "input.left", Right: "input.right"}},
+					}},
+				},
+				"shared": {
+					Classes: map[string]PolicyValidationClass{"invalid": {Disposition: "root.shared_invalid"}},
+					Inputs:  map[string]string{"left": "string", "right": "string"},
+					Rules: []PolicyValidationRule{{
+						ID:           "ROOT-SHARED",
+						Class:        "invalid",
+						Text:         "Root shared.",
+						PinCandidate: &falseValue,
+						Check:        PolicyValidationCheck{Equal: &PolicyValidationEqualCheck{Left: "input.left", Right: "input.right"}},
+					}},
+				},
+			},
+		},
+		Children: []testNode{{
+			ID: "child",
+			Policy: PolicyDocument{
+				Validation: map[string]PolicyValidationSet{
+					"child_set": {
+						Classes: map[string]PolicyValidationClass{"invalid": {Disposition: "child.invalid"}},
+						Inputs:  map[string]string{"left": "string", "right": "string"},
+						Rules: []PolicyValidationRule{{
+							ID:           "CHILD-1",
+							Class:        "invalid",
+							Text:         "Child validation.",
+							PinCandidate: &trueValue,
+							Check:        PolicyValidationCheck{Equal: &PolicyValidationEqualCheck{Left: "input.left", Right: "input.right"}},
+						}},
+					},
+					"shared": {
+						Classes: map[string]PolicyValidationClass{"invalid": {Disposition: "child.shared_invalid"}},
+						Inputs:  map[string]string{"left": "string", "right": "string"},
+						Rules: []PolicyValidationRule{{
+							ID:           "CHILD-SHARED",
+							Class:        "invalid",
+							Text:         "Child shared.",
+							PinCandidate: &trueValue,
+							Check:        PolicyValidationCheck{Equal: &PolicyValidationEqualCheck{Left: "input.left", Right: "input.right"}},
+						}},
+					},
+				},
+			},
+		}},
+	}
+	tree := Tree[testNode]{
+		Root: root,
+		ByID: map[string]*testNode{
+			"root":  root,
+			"child": &root.Children[0],
+		},
+	}
+	base := PolicyDocument{Validation: map[string]PolicyValidationSet{
+		"base_set": {
+			Classes: map[string]PolicyValidationClass{"invalid": {Disposition: "base.invalid"}},
+			Inputs:  map[string]string{"left": "string", "right": "string"},
+			Rules: []PolicyValidationRule{{
+				ID:           "BASE-1",
+				Class:        "invalid",
+				Text:         "Base validation.",
+				PinCandidate: &falseValue,
+				Check:        PolicyValidationCheck{Equal: &PolicyValidationEqualCheck{Left: "input.left", Right: "input.right"}},
+			}},
+		},
+	}}
+
+	got := ResolvePolicyByID(
+		base,
+		tree,
+		"child",
+		func(node *testNode) string { return node.ID },
+		func(node *testNode) PolicyDocument { return node.Policy },
+		testChildren,
+	)
+
+	for _, name := range []string{"base_set", "root_set", "child_set", "shared"} {
+		if _, ok := got.Validation[name]; !ok {
+			t.Fatalf("merged validation missing %q: %#v", name, got.Validation)
+		}
+	}
+	if gotID := got.Validation["shared"].Rules[0].ID; gotID != "CHILD-SHARED" {
+		t.Fatalf("shared validation rule = %q, want child override", gotID)
 	}
 }
 

--- a/internal/runtime/flowmodel/model_test.go
+++ b/internal/runtime/flowmodel/model_test.go
@@ -1,6 +1,7 @@
 package flowmodel
 
 import (
+	"strings"
 	"testing"
 
 	"gopkg.in/yaml.v3"
@@ -154,6 +155,132 @@ validation:
 	}
 	if set.Rules[0].PinCandidate == nil || !*set.Rules[0].PinCandidate {
 		t.Fatalf("pin_candidate = %#v, want true", set.Rules[0].PinCandidate)
+	}
+}
+
+func TestPolicyDocumentValidationRejectsUnknownFields(t *testing.T) {
+	tests := []struct {
+		name     string
+		body     string
+		contains string
+	}{
+		{
+			name: "set unknown field",
+			body: `
+validation:
+  deploy_manifest:
+    schema: {}
+    classes:
+      invalid: {disposition: deploy.manifest_invalid}
+    inputs:
+      source_ref: string
+      manifest_source_ref: string
+    rules:
+      - id: VR-001
+        class: invalid
+        text: Manifest source ref must match request source ref.
+        pin_candidate: true
+        check:
+          equal: {left: input.source_ref, right: input.manifest_source_ref}
+`,
+			contains: `unsupported field "schema"`,
+		},
+		{
+			name: "class unknown field",
+			body: `
+validation:
+  deploy_manifest:
+    classes:
+      invalid:
+        disposition: deploy.manifest_invalid
+        retry: never
+    inputs:
+      source_ref: string
+      manifest_source_ref: string
+    rules:
+      - id: VR-001
+        class: invalid
+        text: Manifest source ref must match request source ref.
+        pin_candidate: true
+        check:
+          equal: {left: input.source_ref, right: input.manifest_source_ref}
+`,
+			contains: `unsupported field "retry"`,
+		},
+		{
+			name: "rule unknown field",
+			body: `
+validation:
+  deploy_manifest:
+    classes:
+      invalid: {disposition: deploy.manifest_invalid}
+    inputs:
+      source_ref: string
+      manifest_source_ref: string
+    rules:
+      - id: VR-001
+        class: invalid
+        text: Manifest source ref must match request source ref.
+        pin_candidate: true
+        emit: deploy.manifest_invalid
+        check:
+          equal: {left: input.source_ref, right: input.manifest_source_ref}
+`,
+			contains: `unsupported field "emit"`,
+		},
+		{
+			name: "check extra predicate",
+			body: `
+validation:
+  deploy_manifest:
+    classes:
+      invalid: {disposition: deploy.manifest_invalid}
+    inputs:
+      source_ref: string
+      manifest_source_ref: string
+    rules:
+      - id: VR-001
+        class: invalid
+        text: Manifest source ref must match request source ref.
+        pin_candidate: true
+        check:
+          equal: {left: input.source_ref, right: input.manifest_source_ref}
+          regex: {input: input.source_ref, pattern: "^[a-f0-9]+$"}
+`,
+			contains: `unsupported field "regex"`,
+		},
+		{
+			name: "equal unknown field",
+			body: `
+validation:
+  deploy_manifest:
+    classes:
+      invalid: {disposition: deploy.manifest_invalid}
+    inputs:
+      source_ref: string
+      manifest_source_ref: string
+    rules:
+      - id: VR-001
+        class: invalid
+        text: Manifest source ref must match request source ref.
+        pin_candidate: true
+        check:
+          equal:
+            left: input.source_ref
+            right: input.manifest_source_ref
+            normalize: true
+`,
+			contains: `unsupported field "normalize"`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var doc PolicyDocument
+			err := yaml.Unmarshal([]byte(tt.body), &doc)
+			if err == nil || !strings.Contains(err.Error(), tt.contains) {
+				t.Fatalf("yaml.Unmarshal error = %v, want %q", err, tt.contains)
+			}
+		})
 	}
 }
 

--- a/internal/runtime/flowmodel/query.go
+++ b/internal/runtime/flowmodel/query.go
@@ -4,8 +4,9 @@ import "strings"
 
 func ClonePolicyDocument(in PolicyDocument) PolicyDocument {
 	out := PolicyDocument{
-		Values:   map[string]PolicyValue{},
-		Criteria: map[string]PolicyCriteriaSet{},
+		Values:     map[string]PolicyValue{},
+		Criteria:   map[string]PolicyCriteriaSet{},
+		Validation: map[string]PolicyValidationSet{},
 	}
 	for key, value := range in.Values {
 		key = strings.TrimSpace(key)
@@ -20,6 +21,13 @@ func ClonePolicyDocument(in PolicyDocument) PolicyDocument {
 			continue
 		}
 		out.Criteria[key] = clonePolicyCriteriaSet(value)
+	}
+	for key, value := range in.Validation {
+		key = strings.TrimSpace(key)
+		if key == "" {
+			continue
+		}
+		out.Validation[key] = clonePolicyValidationSet(value)
 	}
 	return out
 }
@@ -76,6 +84,67 @@ func cloneCriteriaParamValue(value any) any {
 		return out
 	default:
 		return value
+	}
+}
+
+func clonePolicyValidationSet(in PolicyValidationSet) PolicyValidationSet {
+	out := PolicyValidationSet{
+		Classes: map[string]PolicyValidationClass{},
+		Inputs:  map[string]string{},
+	}
+	for key, value := range in.Classes {
+		key = strings.TrimSpace(key)
+		if key == "" {
+			continue
+		}
+		out.Classes[key] = PolicyValidationClass{Disposition: strings.TrimSpace(value.Disposition)}
+	}
+	for key, value := range in.Inputs {
+		key = strings.TrimSpace(key)
+		if key == "" {
+			continue
+		}
+		out.Inputs[key] = strings.TrimSpace(value)
+	}
+	if len(in.Rules) > 0 {
+		out.Rules = make([]PolicyValidationRule, 0, len(in.Rules))
+		for _, rule := range in.Rules {
+			cloned := PolicyValidationRule{
+				ID:     strings.TrimSpace(rule.ID),
+				Class:  strings.TrimSpace(rule.Class),
+				Text:   strings.TrimSpace(rule.Text),
+				Params: map[string]PolicyCriteriaParam{},
+				Check: PolicyValidationCheck{
+					Equal: clonePolicyValidationEqualCheck(rule.Check.Equal),
+				},
+			}
+			if rule.PinCandidate != nil {
+				value := *rule.PinCandidate
+				cloned.PinCandidate = &value
+			}
+			for key, value := range rule.Params {
+				key = strings.TrimSpace(key)
+				if key == "" {
+					continue
+				}
+				cloned.Params[key] = PolicyCriteriaParam{Value: cloneCriteriaParamValue(value.Value)}
+			}
+			if len(cloned.Params) == 0 {
+				cloned.Params = nil
+			}
+			out.Rules = append(out.Rules, cloned)
+		}
+	}
+	return out
+}
+
+func clonePolicyValidationEqualCheck(in *PolicyValidationEqualCheck) *PolicyValidationEqualCheck {
+	if in == nil {
+		return nil
+	}
+	return &PolicyValidationEqualCheck{
+		Left:  strings.TrimSpace(in.Left),
+		Right: strings.TrimSpace(in.Right),
 	}
 }
 

--- a/internal/runtime/flowmodel/resolve.go
+++ b/internal/runtime/flowmodel/resolve.go
@@ -37,6 +37,9 @@ func ResolvePolicyByID[T any](
 	if out.Criteria == nil {
 		out.Criteria = map[string]PolicyCriteriaSet{}
 	}
+	if out.Validation == nil {
+		out.Validation = map[string]PolicyValidationSet{}
+	}
 	if tree.Root == nil {
 		return out
 	}
@@ -62,6 +65,13 @@ func ResolvePolicyByID[T any](
 				continue
 			}
 			out.Criteria[key] = clonePolicyCriteriaSet(value)
+		}
+		for key, value := range policy(view).Validation {
+			key = strings.TrimSpace(key)
+			if key == "" {
+				continue
+			}
+			out.Validation[key] = clonePolicyValidationSet(value)
 		}
 	}
 	return out

--- a/internal/runtime/semanticview/import_boundary_dependencies.go
+++ b/internal/runtime/semanticview/import_boundary_dependencies.go
@@ -432,8 +432,9 @@ func deleteNestedValue(root map[string]any, path string) {
 
 func clonePolicyDocument(in runtimecontracts.PolicyDocument) runtimecontracts.PolicyDocument {
 	out := runtimecontracts.PolicyDocument{
-		Values:   map[string]runtimecontracts.PolicyValue{},
-		Criteria: map[string]runtimecontracts.PolicyCriteriaSet{},
+		Values:     map[string]runtimecontracts.PolicyValue{},
+		Criteria:   map[string]runtimecontracts.PolicyCriteriaSet{},
+		Validation: map[string]runtimecontracts.PolicyValidationSet{},
 	}
 	for key, value := range in.Values {
 		key = strings.TrimSpace(key)
@@ -448,6 +449,13 @@ func clonePolicyDocument(in runtimecontracts.PolicyDocument) runtimecontracts.Po
 			continue
 		}
 		out.Criteria[key] = clonePolicyCriteriaSet(value)
+	}
+	for key, value := range in.Validation {
+		key = strings.TrimSpace(key)
+		if key == "" {
+			continue
+		}
+		out.Validation[key] = clonePolicyValidationSet(value)
 	}
 	return out
 }
@@ -493,6 +501,67 @@ func clonePolicyValue(in runtimecontracts.PolicyValue) runtimecontracts.PolicyVa
 	}
 }
 
+func clonePolicyValidationSet(in runtimecontracts.PolicyValidationSet) runtimecontracts.PolicyValidationSet {
+	out := runtimecontracts.PolicyValidationSet{
+		Classes: map[string]runtimecontracts.PolicyValidationClass{},
+		Inputs:  map[string]string{},
+		Rules:   make([]runtimecontracts.PolicyValidationRule, 0, len(in.Rules)),
+	}
+	for key, value := range in.Classes {
+		key = strings.TrimSpace(key)
+		if key == "" {
+			continue
+		}
+		out.Classes[key] = runtimecontracts.PolicyValidationClass{
+			Disposition: strings.TrimSpace(value.Disposition),
+		}
+	}
+	for key, value := range in.Inputs {
+		key = strings.TrimSpace(key)
+		if key == "" {
+			continue
+		}
+		out.Inputs[key] = strings.TrimSpace(value)
+	}
+	for _, rule := range in.Rules {
+		cloned := runtimecontracts.PolicyValidationRule{
+			ID:     strings.TrimSpace(rule.ID),
+			Class:  strings.TrimSpace(rule.Class),
+			Text:   strings.TrimSpace(rule.Text),
+			Params: map[string]runtimecontracts.PolicyCriteriaParam{},
+			Check: runtimecontracts.PolicyValidationCheck{
+				Equal: clonePolicyValidationEqualCheck(rule.Check.Equal),
+			},
+		}
+		if rule.PinCandidate != nil {
+			value := *rule.PinCandidate
+			cloned.PinCandidate = &value
+		}
+		for key, value := range rule.Params {
+			key = strings.TrimSpace(key)
+			if key == "" {
+				continue
+			}
+			cloned.Params[key] = runtimecontracts.PolicyCriteriaParam{Value: cloneAny(value.Value)}
+		}
+		if len(cloned.Params) == 0 {
+			cloned.Params = nil
+		}
+		out.Rules = append(out.Rules, cloned)
+	}
+	return out
+}
+
+func clonePolicyValidationEqualCheck(in *runtimecontracts.PolicyValidationEqualCheck) *runtimecontracts.PolicyValidationEqualCheck {
+	if in == nil {
+		return nil
+	}
+	return &runtimecontracts.PolicyValidationEqualCheck{
+		Left:  strings.TrimSpace(in.Left),
+		Right: strings.TrimSpace(in.Right),
+	}
+}
+
 func cloneAny(value any) any {
 	switch typed := value.(type) {
 	case map[string]any:
@@ -520,8 +589,9 @@ func cloneAny(value any) any {
 
 func emptyPolicyDocument() runtimecontracts.PolicyDocument {
 	return runtimecontracts.PolicyDocument{
-		Values:   map[string]runtimecontracts.PolicyValue{},
-		Criteria: map[string]runtimecontracts.PolicyCriteriaSet{},
+		Values:     map[string]runtimecontracts.PolicyValue{},
+		Criteria:   map[string]runtimecontracts.PolicyCriteriaSet{},
+		Validation: map[string]runtimecontracts.PolicyValidationSet{},
 	}
 }
 

--- a/internal/runtime/semanticview/import_boundary_dependencies.go
+++ b/internal/runtime/semanticview/import_boundary_dependencies.go
@@ -383,6 +383,16 @@ func mergePolicyValues(dst *runtimecontracts.PolicyDocument, src runtimecontract
 		}
 		dst.Criteria[key] = clonePolicyCriteriaSet(value)
 	}
+	if dst.Validation == nil {
+		dst.Validation = map[string]runtimecontracts.PolicyValidationSet{}
+	}
+	for key, value := range src.Validation {
+		key = strings.TrimSpace(key)
+		if key == "" {
+			continue
+		}
+		dst.Validation[key] = clonePolicyValidationSet(value)
+	}
 }
 
 func deletePolicyValueAtPath(doc *runtimecontracts.PolicyDocument, path string) {

--- a/internal/runtime/semanticview/import_boundary_dependencies_test.go
+++ b/internal/runtime/semanticview/import_boundary_dependencies_test.go
@@ -34,6 +34,45 @@ func TestImportBoundaryPolicyResolutionUsesBindingThenPackageDefault(t *testing.
 	}
 }
 
+func TestImportBoundaryPolicyMergePreservesFlowValidationSets(t *testing.T) {
+	pinCandidate := false
+	dst := runtimecontracts.PolicyDocument{}
+	mergePolicyValues(&dst, runtimecontracts.PolicyDocument{Validation: map[string]runtimecontracts.PolicyValidationSet{
+		"deploy_manifest": {
+			Classes: map[string]runtimecontracts.PolicyValidationClass{
+				"invalid": {Disposition: "deploy.manifest_invalid"},
+			},
+			Inputs: map[string]string{
+				"source_ref":          "string",
+				"manifest_source_ref": "string",
+			},
+			Rules: []runtimecontracts.PolicyValidationRule{{
+				ID:           "VR-001",
+				Class:        "invalid",
+				Text:         "Manifest source ref must match request source ref.",
+				PinCandidate: &pinCandidate,
+				Check: runtimecontracts.PolicyValidationCheck{
+					Equal: &runtimecontracts.PolicyValidationEqualCheck{
+						Left:  "input.source_ref",
+						Right: "input.manifest_source_ref",
+					},
+				},
+			}},
+		},
+	}})
+
+	set, ok := dst.Validation["deploy_manifest"]
+	if !ok {
+		t.Fatalf("merged policy missing validation set: %#v", dst.Validation)
+	}
+	if got := set.Classes["invalid"].Disposition; got != "deploy.manifest_invalid" {
+		t.Fatalf("validation invalid disposition = %q, want deploy.manifest_invalid", got)
+	}
+	if got := len(set.Rules); got != 1 {
+		t.Fatalf("validation rules len = %d, want 1", got)
+	}
+}
+
 func TestImportBoundaryPolicyResolutionReportsOwnerForBindingAndPackageDefault(t *testing.T) {
 	source := loadImportBoundaryDependencyFixture(t, importBoundaryDependencyFixtureOptions{
 		policyBind: "        provider.threshold: parent.policy.provider.threshold\n",

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -1107,10 +1107,10 @@ type_system:
       omit a refinement only when it is a different semantic concept or an
       explicitly tracked surviving follow-up.
     validation_row_boundary: |
-      Machine-evaluated validation criteria rows are a later #1714 slice and
-      depend on the #1717 stable-ID criteria artifact grammar. They bind
-      computed validation results only; branch routing remains owned by
-      policy-sheet selection rows.
+      Machine-evaluated validation rows are governed by
+      policy_validation_contracts. They consume the stable-ID criteria artifact
+      family with a machine evaluator, bind computed.validation.* results only,
+      and leave branch routing to policy-sheet selection rows.
   field_forms:
     terse: 'field_name: TypeName'
     verbose: |
@@ -1404,10 +1404,113 @@ criteria_contracts:
     - event citation field type and allowed class metadata
     - emitted-event citation fields consumed only by agents that declare the referenced criteria set
   split_boundaries:
-  - '#1714 machine-evaluated validation rows consume this stable-ID rule grammar later; they do not ship in #1717.'
+  - '#1714 machine-evaluated validation rows consume this stable-ID rule grammar as a sibling policy section with a different
+    evaluator.'
   - '#1718 prompt-frame generation may absorb the deterministic criteria section later; #1717 does not ship the full frame
     generator.'
   - Structured predicates, criteria packs, team packs, CLI/editor UX, and criteria evaluation harnesses are separate gates.
+policy_validation_contracts:
+  status: merge_bearing_runtime_behavior
+  implementation_slice: '#1714'
+  description: |
+    Flow-local machine-evaluated validation sets are stable-ID rule sets
+    declared as a typed `validation:` section inside the owning flow's
+    `policy.yaml`. They share the criteria artifact family but use the
+    platform machine evaluator, not agent judgment. Validation rows bind
+    turn-scoped computed facts only; they do not route, emit, advance state,
+    persist data, call tools, read files, run CEL, or execute code.
+  policy_section:
+    location: flow policy.yaml only
+    field: validation
+    owner: flow-owned PolicyDocument.Validation
+    shape: |
+      validation:
+        <set_name>:
+          classes:
+            <class_name>:
+              disposition: <event_name-or-none>
+          inputs:
+            <input_name>: <scalar_type>
+          rules:
+            - id: <stable-never-reused-id>
+              class: <declared-class>
+              text: <human-readable rule>
+              pin_candidate: true|false
+              check:
+                equal:
+                  left: input.<input_name>
+                  right: input.<input_name>
+    rules:
+    - '`validation:` is a closed typed policy section. It is decoded separately from generic `PolicyDocument.Values` and
+      MUST NOT appear as `policy.validation`, a prompt variable, or arbitrary policy object data.'
+    - Validation sets are flow-local in this slice. Root/project policy validation, shared validation packs, team packs,
+      marketplace distribution, file-backed rule sets, and external data reads are not implemented.
+    - Rule IDs are stable and never reused within a set. Every set MUST declare at least one class, at least one typed input,
+      and at least one rule.
+    - Every class MUST declare a disposition. Dispositions are consistency metadata for downstream selection-row routing;
+      validation rows themselves do not emit or route.
+    - 'Every rule MUST declare id/class/text, every rule class MUST be declared, every rule MUST explicitly declare
+      `pin_candidate: true|false`, and duplicate rule IDs fail static validation.'
+    - Rule parameters, when present, follow `criteria_contracts` inert scalar/ref rules. They are not expressions and are
+      not consumed by the Slice B equal-only evaluator.
+  evaluator:
+    supported_checks:
+    - equal
+    equal_semantics: |
+      Slice B supports only exact typed equality between declared `input.*` names. Both sides must reference declared inputs
+      with compatible scalar types. Regex, length/range, non_empty, CEL, arithmetic, schema-shape validation, code, tools,
+      I/O, and WASM are outside this slice.
+    inputs: |
+      Validation rule sets are root-agnostic. Handler rows map execution context roots into the declared input signature.
+      Runtime missing inputs, unmapped inputs, unknown sets, or ill-typed inputs are deterministic no-retry failures.
+    result_shape: |
+      Runtime evaluation produces `{valid: bool, violations: [{id, class, content_ref}]}`. A failed equality check appends
+      one violation citing the stable rule ID, class, and violating input references.
+  policy_sheet_validate_rows:
+    field: validate
+    location: handler.rules value row
+    shape: |
+      rules:
+        - id: validate_manifest
+          validate:
+            set: deploy_manifest
+            input:
+              source_ref: payload.source_ref
+              manifest_source_ref: payload.file_manifest.source_ref
+            into: computed.validation.deploy_manifest
+        - id: invalid_manifest
+          when: computed.validation.deploy_manifest.valid == false
+          emit: deploy.manifest_invalid
+    lowering: |
+      `validate:` rows lower to the compute-owned internal validate operation. They run in the value/compute phase before
+      selection rows and bind only `computed.validation.*`. Public `compute.operation: validate` is forbidden.
+    input_roots: '`validate.input` values must be simple explicit paths rooted in payload, entity, event, or computed.'
+    target_namespace: '`validate.into` MUST be a simple explicit `computed.validation.*` path. Entity persistence and generic
+      computed target names are forbidden for validation results.'
+    routing: |
+      Branch routing remains owned by #1713 selection rows. A selection row that consumes an invalid validation result must
+      emit an event declared by the validation set's class dispositions. The validation row never emits, advances state,
+      executes action/activity, fans out, writes data_accumulation, or persists entity state.
+    dead_binding: '`validate.into` bindings must be consumed by a supported downstream condition, emit field, activity input,
+      fan_out, or expression in the same handler; unconsumed bindings fail boot verification.'
+  static_verification:
+    checks:
+    - typed policy.validation shape and flow-local placement
+    - class declaration and disposition completeness
+    - typed input declaration and rule input compatibility
+    - explicit pin_candidate on every rule
+    - equal-only check shape over declared input.* references
+    - validate row set resolution and exact input mapping coverage
+    - validate row lowering to compute-owned internal operation
+    - computed.validation.* target namespace
+    - dead validation-result binding detection
+    - invalid-result routing consistency with declared dispositions
+  split_boundaries:
+  - Schema refinements own pattern, length, range, presence, enum, and same-object equal_to checks.
+  - 'Receiver input pins and static interface negotiation may later absorb `pin_candidate: true` rules; this slice records the
+    marker but does not promote pin declarations.'
+  - Non-equality predicates, richer expression/derive rows, criteria packs, prompt-frame validation, compute/WASM validation,
+    and file-backed validation sets are separate gates.
 runtime_enforcement:
   description: |
     Wave 1 adds authoritative behavioral rules on top of the existing
@@ -1784,6 +1887,23 @@ handler_specification:
             A table miss with `default: fail` is deterministic, no-retry, emits
             a typed diagnostic naming the row ID and unmatched tuple, and
             performs no side effects.
+        validate:
+          status: internal_lowering_only
+          description: |
+            `validate` is the compute-owned internal operation produced by
+            policy-sheet validate value rows. It is not a public
+            `compute.operation` authoring value. Public YAML must author
+            machine validation as a `rules[*].validate` policy-sheet row. The
+            lowered compute plan reads explicit context roots, evaluates the
+            referenced policy.validation set with the Slice B equal-only
+            machine evaluator, and writes the result to a turn-scoped
+            computed.validation.* binding.
+          public_authoring: 'forbidden; `compute.operation: validate` fails closed.'
+          failure_disposition: |
+            Unknown sets, unmapped inputs, missing source paths, ill-typed
+            source values, and malformed rules are deterministic no-retry
+            failures. Equality mismatches produce a computed validation result
+            with stable rule-ID violations and do not retry.
         weighted_average:
           description: Compute a weighted average across tiers of accumulated items.
           required:
@@ -2034,7 +2154,7 @@ handler_specification:
           are payload.*, entity.*, policy.*, event.*, computed.*, and query_entities(...). accumulated.*, fan_out.*,
           and item.* are unavailable in rules.condition. entity.* reads use the pre-rule entity state and the same
           declared-field validation as other rule-phase handler conditions. computed.* reads are turn-scoped
-          values written earlier in the handler compute phase, including lookup value rows.
+          values written earlier in the handler compute phase, including lookup and validate value rows.
         when: >-
           string — first-class policy-sheet selection row for compound relational conditions. Lowers to condition
           and otherwise uses the ordinary selected-branch rule fields. Must not be combined with condition, case, range,
@@ -2059,6 +2179,13 @@ handler_specification:
           in this slice. Lookup rows bind a value and do not select a branch, emit, advance state, execute action/activity,
           fan_out, data_accumulation, or public compute. The row lowers to the compute-owned internal lookup operation
           and runs before selection rows consume computed.*.
+        validate: >-
+          object — first-class policy-sheet value row for machine-evaluated validation against a flow policy.validation
+          set. Public shape is `{set: <validation_set>, input: {<input_name>: <payload|entity|event|computed path>},
+          into: computed.validation.<name>}`. The row maps execution context roots into the validation set's typed input
+          signature, lowers to the compute-owned internal validate operation, binds `{valid, violations}` under
+          computed.validation.*, and runs before selection rows consume the result. It cannot emit, advance state,
+          execute action/activity, fan_out, data_accumulation, or public compute.
         else: boolean true — explicit default row. Lowers to the ordinary else selected branch.
         default: boolean true — alias for else, used when the authoring intent is an explicit policy-sheet default row.
         emit: string or object — rule-local event to emit, or an eventless object with fields only when participating in
@@ -2068,8 +2195,8 @@ handler_specification:
         description: string — human-readable note
       policy_sheet_selection_rows:
         scope: Selection rows are `when`, `case`, `range`, and explicit else/default rows. Lookup value rows are specified
-          under `policy_sheet_value_rows`; schema validation, arithmetic/expression derivation, and
-          temporal/join/loop/collection/schedule rows are separate future gates.
+          under `policy_sheet_value_rows`; validate value rows are governed by policy_validation_contracts. Arithmetic/expression
+          derivation and temporal/join/loop/collection/schedule rows are separate future gates.
         stable_identity: Typed policy-sheet rows require stable IDs. The selected row ID is trace-addressable contract
           identity and must survive authoring edits.
         lowering: Accepted selection rows lower before runtime execution into ordinary selected `HandlerRuleEntry` branches.
@@ -2082,17 +2209,20 @@ handler_specification:
           - "`policy` as a co-authorable handler field while `rules` remains authorable"
           - runtime-only table, switch, lookup, threshold, or range interpreters
       policy_sheet_value_rows:
-        scope: Value rows in this slice support only `lookup`, a finite inline exact-match table whose right-hand side is
-          a scalar value. Arithmetic/expression derivation, schema validation, file-backed tables, temporal rows, join rows,
-          loop rows, collection rows, and schedule rows are separate gates.
-        ownership: The policy sheet is the authoring construct. Lookup rows lower to the compute owner; they do not create
-          a second runtime table interpreter and do not make public `compute.lookup` authorable.
+        scope: Value rows in this slice support `lookup`, a finite inline exact-match table whose right-hand side is
+          a scalar value, and `validate`, a machine-evaluated policy.validation row that binds a typed validation result.
+          Arithmetic/expression derivation, file-backed tables, temporal rows, join rows, loop rows, collection rows, and
+          schedule rows are separate gates.
+        ownership: The policy sheet is the authoring construct. Lookup and validate rows lower to the compute owner; they
+          do not create a second runtime table/validation interpreter and do not make public `compute.lookup` or
+          `compute.validate` authorable.
         ordering: The sheet is not a sequential program. Row types lower into their declared runtime phases. Lookup value
-          rows run in compute phase before branch selection; selection rows then read computed.*. Selection outcomes are
-          not values and may not be consumed by lookup rows.
-        target_namespace: lookup.into MUST be an explicit simple computed.* path. Entity persistence is forbidden for
-          derived lookup values; computed.* is turn-scoped and is not written to entity_state unless a separate declared
-          data write explicitly persists a value under its own owner.
+          rows and validate value rows run in compute phase before branch selection; selection rows then read computed.*.
+          Selection outcomes are not values and may not be consumed by value rows.
+        target_namespace: lookup.into MUST be an explicit simple computed.* path. validate.into MUST be an explicit simple
+          computed.validation.* path. Entity persistence is forbidden for derived lookup values and validation results;
+          computed.* is turn-scoped and is not written to entity_state unless a separate declared data write explicitly
+          persists a value under its own owner.
         matching: lookup.on entries MUST use explicit payload.* roots in this slice. Matching is exact typed equality through
           one canonicalization path shared by duplicate-key detection and runtime matching. Key literals are type-checked
           against declared payload field schemas; the string "1" and the number 1 are different keys.
@@ -2102,8 +2232,12 @@ handler_specification:
         diagnostics: >-
           A `default: fail` miss is deterministic no-retry failure with row ID and unmatched tuple in diagnostics, distinct from
           validation failures.
-        dead_binding: lookup.into bindings must be consumed by a supported downstream condition, emit field, activity input,
-          fan_out, or expression in the same handler; unconsumed bindings fail boot verification.
+        validation_rows: >-
+          validate rows reference flow policy.validation sets, map exactly the declared typed inputs, evaluate only Slice B
+          equal checks, and bind `{valid, violations}`. Invalid-result routing is expressed by ordinary selection rows that
+          consume computed.validation.* and emit events declared by the validation set class dispositions.
+        dead_binding: lookup.into and validate.into bindings must be consumed by a supported downstream condition, emit field,
+          activity input, fan_out, or expression in the same handler; unconsumed bindings fail boot verification.
       emit_template_specialization:
         syntax: A rules handler may declare handler-level emit as the template, with `emit.event` and optional shared
           `emit.from` / `emit.fields`. Each rule then declares `emit.fields` and may declare the same `emit.from` without
@@ -2498,13 +2632,14 @@ handler_specification:
         resolves_to: 'Turn-scoped derived handler values written by compute-owned operations. Public authors may read
           computed.* in rule conditions and expression-value surfaces after the value has been produced by the handler
           dependency graph.'
-        populated_by: 'compute.store_as targets under computed.* and policy-sheet lookup value rows lowering to internal
-          compute lookup plans.'
+        populated_by: 'compute.store_as targets under computed.*, policy-sheet lookup value rows lowering to internal
+          compute lookup plans, and policy-sheet validate value rows lowering to internal compute validation plans.'
         persistence_model: 'Read/write handler context only. computed.* is not persisted entity state, not event payload,
           and not replay authority unless a separate declared owner explicitly writes a computed value to a durable surface.'
         available_in: 'rules.condition, emit.fields CEL expressions, mailbox/action expression values, activity inputs,
           fan_out inputs, and query_entities scoped operands when the runtime context contains the value.'
-        not_available_as: 'lookup.into may write computed.*; entity.* durable cache fallback for lookup values is forbidden.'
+        not_available_as: 'lookup.into may write computed.*; validate.into may write computed.validation.*; entity.* durable
+          cache fallback for lookup or validation values is forbidden.'
       payload:
         resolves_to: 'The inbound event payload. payload.X reads the X field from the triggering event''s
           JSONB payload.'
@@ -5058,6 +5193,13 @@ engine:
         inert params, or non-flow-local placement; an agent criteria ref is malformed or unresolved; an event citation field
         has an unsupported type or missing/invalid allowed_classes; or an agent emits a citation-bearing event without
         declaring the referenced criteria set.
+      when: boot-only
+    - id: policy_sheet_validation_value_rows
+      severity: hard_invalidity
+      scope: per-handler
+      trigger: A policy-sheet validate value row fails to lower through the compute-owned validate operation, writes outside
+        computed.validation.*, references an unresolved policy.validation set, leaves its result unconsumed, or routes an
+        invalid-result branch to an event not declared by the validation set dispositions.
       when: boot-only
     - id: mcp_server_reachable
       severity: warning


### PR DESCRIPTION
## Summary

Adds the approved #1714 Slice B policy validation row surface:

- promotes flow-local `policy.validation` as a typed `PolicyDocument.Validation` section
- adds `validate:` policy-sheet value rows under `handler.rules`, lowering to an internal compute-owned validate operation
- binds turn-scoped `{valid, violations}` results under `computed.validation.*` for #1713 selection-row consumption
- adds load validation, bootverify checks, runtime execution, semantic import cloning, and spec coverage

Closes #1714.
Part of #1668.
Part of #1663.

## Governing Refs / Context

- Issue #1714 body and thread
- Pre-Implementation Coverage Audit: https://github.com/division-sh/swarm/issues/1714#issuecomment-4893788288
- Gate C outcome: https://github.com/division-sh/swarm/issues/1714#issuecomment-4893858413
- Authoritative spec updates in `platform-spec.yaml`:
  - `policy_validation_contracts`
  - `handler_specification.compute.operation_requirements.validate`
  - `handler_specification.rules.rule_fields.validate`
  - `handler_specification.expression_context.computed`
  - `type_system.schema_refinements.validation_row_boundary`
  - `engine.boot_verification.policy_sheet_validation_value_rows`

## Semantic Migration

New canonical owner:

- Flow-owned `PolicyDocument.Validation` for typed `policy.validation` sets
- policy-sheet `validate:` value rows as the only public authoring surface
- internal compute-owned validate lowering for execution
- `computed.validation.*` for turn-scoped validation results

Old producer / reader / writer paths now invalid or non-authoritative:

- prompt-only validation prose as the enforcement owner
- generic `PolicyDocument.Values["validation"]` / `policy.validation` object data
- public `compute.operation: validate`
- entity persistence or metadata writes for validation facts
- validation-owned branch routing, emit, advance, action, activity, fan-out, data accumulation, or I/O/code execution

Production paths checked for surviving old behavior:

- policy decode / resolve / clone / import boundary
- policy-sheet YAML lowering and public compute operation parsing
- contract load validation
- bootverify validation-row checks
- engine compute phase and selection-row consumption
- platform spec loaders via full test suite

Migration completeness:

- Complete for #1714 Slice B equal-only policy validation rows.
- Broader non-equality validation, prompt-frame migration, pins/interfaces, compute/WASM validation, and file-backed rule sets remain split to their existing trackers.

## Validation

- `go test ./internal/runtime/flowmodel ./internal/runtime/contracts ./internal/runtime/bootverify ./internal/runtime/engine`
- `SWARM_TEST_POSTGRES_DSN='host=127.0.0.1 port=5432 user=youmew dbname=postgres sslmode=disable' PGPASSWORD=postgres go test ./...`
