### PR TITLE
[agent-e][issue #1754] Add setup prestate smoke companions

### DIFF
--- a/cmd/swarm/test_command.go
+++ b/cmd/swarm/test_command.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
+	runtimeflowidentity "github.com/division-sh/swarm/internal/runtime/core/flowidentity"
 	"github.com/division-sh/swarm/internal/runtime/entityruntime"
 	runtimeeventschema "github.com/division-sh/swarm/internal/runtime/eventschema"
 	"github.com/google/cel-go/cel"
@@ -1103,6 +1104,13 @@ func scenarioUUID(seed, label string) string {
 	return uuid.NewSHA1(uuid.NameSpaceURL, []byte(seed+"\x00"+label)).String()
 }
 
+func scenarioSetupEntityID(seed, runID string, entity evaluatedScenarioSetupEntity) string {
+	if strings.TrimSpace(entity.FlowID) == "" {
+		return runtimeflowidentity.EntityID(runID)
+	}
+	return scenarioUUID(seed, "setup.entity."+entity.Alias)
+}
+
 func (r scenarioRunner) runInvalidVariants(file scenarioTestFile, doc scenarioDocument, evaluator *scenarioExpressionEvaluator) error {
 	baseStep, err := invalidBasePublishStep(doc.Invalid.Base)
 	if err != nil {
@@ -1161,7 +1169,7 @@ func (r scenarioRunner) runScenarioSetup(ctx context.Context, file scenarioTestF
 		if err != nil {
 			return scenarioTestValidationError{err: err}
 		}
-		entityID := scenarioUUID(evaluator.seed, "setup.entity."+evaluated.Alias)
+		entityID := scenarioSetupEntityID(evaluator.seed, runID, evaluated)
 		entities = append(entities, map[string]any{
 			"alias":         evaluated.Alias,
 			"entity_id":     entityID,
@@ -1213,7 +1221,7 @@ func (r scenarioRunner) evaluateScenarioSetupEntity(file scenarioTestFile, evalu
 		}
 		flowID = strings.Trim(optionalScenarioString(value), "/")
 	}
-	primary, err := r.bundle.ResolveFlowPrimaryEntity(flowID)
+	primary, err := r.bundle.ResolveTestSetupPrimaryEntity(flowID, entity.EntityType)
 	if err != nil {
 		return evaluatedScenarioSetupEntity{}, fmt.Errorf("setup.entities[%s].flow: %w", entity.Alias, err)
 	}

--- a/cmd/swarm/test_command_test.go
+++ b/cmd/swarm/test_command_test.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"testing"
 
+	runtimeflowidentity "github.com/division-sh/swarm/internal/runtime/core/flowidentity"
 	"github.com/google/uuid"
 
 	storebackend "github.com/division-sh/swarm/internal/store/backendselection"
@@ -215,6 +216,119 @@ func TestSwarmTestSetupEntitiesSeedsAliasTargetAndExpectationThroughPublicRPC(t 
 			entity["current_state"] = "ready"
 			result["fields"] = map[string]any{"product_id": "p-1", "note": "approved"}
 			result["gates"] = map[string]any{"review_ready": false}
+			writeJSONRPCResult(t, w, req.ID, result)
+		default:
+			t.Fatalf("unexpected method = %s", req.Method)
+		}
+	}))
+	defer server.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), repoRoot(), []string{
+		"test",
+		"--contracts", contractsPath,
+		"--platform-spec", defaultPlatformSpecPath,
+		"--timeout", "2s",
+		"--poll-interval", "10ms",
+	}, &stdout, &stderr, testRootCommandOptions(server))
+	if code != 0 {
+		t.Fatalf("code = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	assertScenarioTestMethods(t, calls, []string{
+		scenarioTestSetupEntitiesMethod,
+		eventPublishMethod,
+		"run.diagnose",
+		"run.diagnose",
+		"run.trace",
+		entityGetMethod,
+	})
+	if strings.TrimSpace(stderr.String()) != "" {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+}
+
+func TestSwarmTestSetupEntitiesSeedsRootRunEntityThroughPublicRPC(t *testing.T) {
+	isolateCLIAPIConfigEnv(t)
+	setCLIAPITestToken(t, "test-token")
+	contractsPath := writeScenarioRootSetupFixture(t)
+	bundleHash := servedEventPublishFixtureBundleHash(t, contractsPath)
+
+	var calls []jsonRPCRequest
+	var setupRunID string
+	var setupEntityID string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req jsonRPCRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Errorf("decode request: %v", err)
+		}
+		calls = append(calls, req)
+		switch req.Method {
+		case scenarioTestSetupEntitiesMethod:
+			if req.Params["bundle_hash"] != bundleHash {
+				t.Fatalf("test.setup_entities bundle_hash = %#v, want %s", req.Params["bundle_hash"], bundleHash)
+			}
+			setupRunID, _ = req.Params["run_id"].(string)
+			if _, err := uuid.Parse(setupRunID); err != nil {
+				t.Fatalf("test.setup_entities run_id = %#v, want UUID", req.Params["run_id"])
+			}
+			entities, ok := req.Params["entities"].([]any)
+			if !ok || len(entities) != 1 {
+				t.Fatalf("test.setup_entities entities = %#v, want one", req.Params["entities"])
+			}
+			entity, ok := entities[0].(map[string]any)
+			if !ok {
+				t.Fatalf("test.setup_entities entity = %#v, want mapping", entities[0])
+			}
+			setupEntityID, _ = entity["entity_id"].(string)
+			if want := runtimeflowidentity.EntityID(setupRunID); setupEntityID != want {
+				t.Fatalf("test.setup_entities root entity_id = %q, want canonical run root %q", setupEntityID, want)
+			}
+			if entity["alias"] != "widget" || entity["flow_instance"] != "" || entity["entity_type"] != "widget" || entity["current_state"] != "waiting" {
+				t.Fatalf("test.setup_entities root entity = %#v", entity)
+			}
+			if err := assertScenarioJSONEqual("test.setup_entities root fields", entity["fields"], map[string]any{"score": float64(5)}); err != nil {
+				t.Fatal(err)
+			}
+			writeJSONRPCResult(t, w, req.ID, map[string]any{
+				"run_id": setupRunID,
+				"entities": []map[string]any{{
+					"alias":         "widget",
+					"entity_id":     setupEntityID,
+					"flow_instance": "",
+					"entity_type":   "widget",
+					"current_state": "waiting",
+				}},
+			})
+		case eventPublishMethod:
+			if req.Params["event_name"] != "widget.scored" || req.Params["bundle_hash"] != bundleHash || req.Params["run_id"] != setupRunID {
+				t.Fatalf("event.publish root setup params = %#v", req.Params)
+			}
+			if _, ok := req.Params["target"]; ok {
+				t.Fatalf("event.publish root setup target = %#v, want omitted", req.Params["target"])
+			}
+			payload, ok := req.Params["payload"].(map[string]any)
+			if !ok || !numberEquals(payload["delta"], 7) {
+				t.Fatalf("event.publish root setup payload = %#v", req.Params["payload"])
+			}
+			result := eventPublishTestResult(false)
+			result["run_id"] = setupRunID
+			result["event_id"] = "event-root-setup"
+			result["source_event_id"] = ""
+			writeJSONRPCResult(t, w, req.ID, result)
+		case "run.diagnose":
+			writeJSONRPCResult(t, w, req.ID, scenarioRunDiagnoseTestResult(setupRunID, true))
+		case "run.trace":
+			writeJSONRPCResult(t, w, req.ID, map[string]any{"trace": []map[string]any{scenarioTraceRowForEvent("event-root-setup", "widget.scored")}})
+		case entityGetMethod:
+			if req.Params["entity_id"] != setupEntityID || req.Params["run_id"] != setupRunID {
+				t.Fatalf("entity.get root setup params = %#v", req.Params)
+			}
+			result := validEntityFullResult(setupEntityID)
+			entity := result["entity"].(map[string]any)
+			entity["run_id"] = setupRunID
+			entity["entity_type"] = "widget"
+			entity["current_state"] = "done"
+			result["fields"] = map[string]any{"score": float64(12)}
 			writeJSONRPCResult(t, w, req.ID, result)
 		default:
 			t.Fatalf("unexpected method = %s", req.Method)
@@ -517,6 +631,82 @@ func TestSwarmTestRunsRemainingCurrentPublicOwnerCatalogCompanions(t *testing.T)
 	}
 }
 
+func TestSwarmTestRunsSetupPrestateCatalogCompanions(t *testing.T) {
+	for _, tc := range []struct {
+		tier              string
+		packageName       string
+		wantPositiveEvent bool
+	}{
+		{tier: "tier1-primitives", packageName: "test-clear-gates", wantPositiveEvent: true},
+		{tier: "tier1-primitives", packageName: "test-guard-compound-condition", wantPositiveEvent: true},
+		{tier: "tier1-primitives", packageName: "test-guard-entity-ref", wantPositiveEvent: true},
+		{tier: "tier1-primitives", packageName: "test-on-complete-with-state", wantPositiveEvent: true},
+		{tier: "tier1-primitives", packageName: "test-payload-transform-multi-source", wantPositiveEvent: true},
+		{tier: "tier10-policy-patterns", packageName: "test-policy-counter-escalate", wantPositiveEvent: true},
+		{tier: "tier10-policy-patterns", packageName: "test-policy-multi-guard-partial"},
+		{tier: "tier2-accumulation", packageName: "test-accumulate-all", wantPositiveEvent: true},
+		{tier: "tier2-accumulation", packageName: "test-accumulate-crash-recovery", wantPositiveEvent: true},
+		{tier: "tier2-accumulation", packageName: "test-accumulate-expected-from-entity", wantPositiveEvent: true},
+		{tier: "tier2-accumulation", packageName: "test-accumulate-from-filter", wantPositiveEvent: true},
+		{tier: "tier2-accumulation", packageName: "test-accumulate-idempotent"},
+		{tier: "tier2-accumulation", packageName: "test-accumulate-on-complete-rollback", wantPositiveEvent: true},
+		{tier: "tier2-accumulation", packageName: "test-accumulate-partial"},
+		{tier: "tier2-accumulation", packageName: "test-accumulate-threshold", wantPositiveEvent: true},
+		{tier: "tier2-accumulation", packageName: "test-accumulate-with-compute", wantPositiveEvent: true},
+		{tier: "tier4-cross-entity", packageName: "test-clear-multiple-targets", wantPositiveEvent: true},
+		{tier: "tier4-cross-entity", packageName: "test-clear-state", wantPositiveEvent: true},
+		{tier: "tier6-event-loop", packageName: "test-atomicity-guard-rollback"},
+		{tier: "tier6-event-loop", packageName: "test-guards-pre-handler-state"},
+		{tier: "tier9-composition-patterns", packageName: "test-compose-guard-counter-escalate", wantPositiveEvent: true},
+		{tier: "tier9-composition-patterns", packageName: "test-compose-guard-multi-source", wantPositiveEvent: true},
+	} {
+		t.Run(tc.tier+"/"+tc.packageName, func(t *testing.T) {
+			isolateCLIAPIConfigEnv(t)
+			setCLIAPITestToken(t, "test-token")
+			contractsPath := filepath.Join(repoRoot(), "tests", tc.tier, tc.packageName)
+			scenarioPath := filepath.Join(contractsPath, "tests", "visible-smoke.yaml")
+			raw, err := os.ReadFile(scenarioPath)
+			if err != nil {
+				t.Fatalf("read scenario: %v", err)
+			}
+			doc, err := parseScenarioDocument(raw)
+			if err != nil {
+				t.Fatalf("parse scenario: %v", err)
+			}
+			if len(doc.Setup.Entities) != 1 {
+				t.Fatalf("scenario setup = %#v, want one public setup entity", doc.Setup.Entities)
+			}
+			if len(doc.Steps) == 0 {
+				t.Fatal("scenario must include at least one publish step")
+			}
+			for _, step := range doc.Steps {
+				if step.Action != "publish" {
+					t.Fatalf("scenario step = %#v, want publish", step)
+				}
+				if step.Target != nil || step.TargetEntityID != nil || step.TargetFlowInstance != nil {
+					t.Fatalf("root setup companion must not use publish target fields: %#v", step)
+				}
+			}
+			if tc.wantPositiveEvent && len(doc.Expect.Events.Include) == 0 {
+				t.Fatal("scenario must include positive emitted-event proof")
+			}
+			if !tc.wantPositiveEvent && len(doc.Expect.Events.Include) != 0 {
+				t.Fatalf("scenario includes events %#v, want no event-output assertion", doc.Expect.Events.Include)
+			}
+			if len(doc.Expect.Events.Exact) != 0 || len(doc.Expect.Events.Ordered) != 0 {
+				t.Fatalf("scenario event expectations = %#v, want include-only", doc.Expect.Events)
+			}
+			if doc.Expect.NoDeadLetters != nil {
+				t.Fatalf("scenario no_dead_letters = %#v, want omitted", *doc.Expect.NoDeadLetters)
+			}
+			if len(doc.Expect.Entities) != 1 || doc.Expect.Entities[0].Ref != "entity" || !doc.Expect.Entities[0].StateSet {
+				t.Fatalf("scenario entity expectations = %#v, want setup ref current_state assertion", doc.Expect.Entities)
+			}
+			assertSwarmTestScenarioThroughPublicRPC(t, contractsPath, doc)
+		})
+	}
+}
+
 func assertSwarmTestScenarioThroughPublicRPC(t *testing.T, contractsPath string, doc scenarioDocument) {
 	t.Helper()
 	bundleHash := servedEventPublishFixtureBundleHash(t, contractsPath)
@@ -551,6 +741,9 @@ func assertSwarmTestScenarioThroughPublicRPC(t *testing.T, contractsPath string,
 
 	var calls []jsonRPCRequest
 	var publishCalls int
+	activeRunID := "run-1"
+	setupEntityIDs := map[string]string{}
+	setupEntityTypes := map[string]string{}
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/v1/rpc" {
 			t.Errorf("path = %q, want /v1/rpc", r.URL.Path)
@@ -564,6 +757,59 @@ func assertSwarmTestScenarioThroughPublicRPC(t *testing.T, contractsPath string,
 		}
 		calls = append(calls, req)
 		switch req.Method {
+		case scenarioTestSetupEntitiesMethod:
+			if req.Params["bundle_hash"] != bundleHash {
+				t.Fatalf("test.setup_entities bundle_hash = %#v, want %s", req.Params["bundle_hash"], bundleHash)
+			}
+			runID, _ := req.Params["run_id"].(string)
+			if _, err := uuid.Parse(runID); err != nil {
+				t.Fatalf("test.setup_entities run_id = %#v, want UUID", req.Params["run_id"])
+			}
+			activeRunID = runID
+			entities, ok := req.Params["entities"].([]any)
+			if !ok || len(entities) != len(doc.Setup.Entities) {
+				t.Fatalf("test.setup_entities entities = %#v, want %d rows", req.Params["entities"], len(doc.Setup.Entities))
+			}
+			resultRows := make([]map[string]any, 0, len(entities))
+			for i, raw := range entities {
+				entity, ok := raw.(map[string]any)
+				if !ok {
+					t.Fatalf("test.setup_entities entities[%d] = %#v, want mapping", i, raw)
+				}
+				want := doc.Setup.Entities[i]
+				if entity["alias"] != want.Alias || entity["entity_type"] != want.EntityType {
+					t.Fatalf("test.setup_entities entities[%d] = %#v, want alias %q type %q", i, entity, want.Alias, want.EntityType)
+				}
+				entityID, _ := entity["entity_id"].(string)
+				if _, err := uuid.Parse(entityID); err != nil {
+					t.Fatalf("test.setup_entities entities[%d].entity_id = %#v, want UUID", i, entity["entity_id"])
+				}
+				if strings.TrimSpace(fmt.Sprint(entity["flow_instance"])) == "" {
+					if wantID := runtimeflowidentity.EntityID(runID); entityID != wantID {
+						t.Fatalf("test.setup_entities root entity_id = %q, want %q", entityID, wantID)
+					}
+				}
+				if want.FieldsSet {
+					if err := assertScenarioJSONEqual("test.setup_entities fields", entity["fields"], want.Fields); err != nil {
+						t.Fatal(err)
+					}
+				}
+				if want.GatesSet {
+					if err := assertScenarioJSONEqual("test.setup_entities gates", entity["gates"], want.Gates); err != nil {
+						t.Fatal(err)
+					}
+				}
+				setupEntityIDs[want.Alias] = entityID
+				setupEntityTypes[want.Alias] = want.EntityType
+				resultRows = append(resultRows, map[string]any{
+					"alias":         want.Alias,
+					"entity_id":     entityID,
+					"flow_instance": strings.TrimSpace(fmt.Sprint(entity["flow_instance"])),
+					"entity_type":   want.EntityType,
+					"current_state": strings.TrimSpace(fmt.Sprint(entity["current_state"])),
+				})
+			}
+			writeJSONRPCResult(t, w, req.ID, map[string]any{"run_id": runID, "entities": resultRows})
 		case eventPublishMethod:
 			if publishCalls >= len(doc.Steps) {
 				t.Fatalf("unexpected extra event.publish params = %#v", req.Params)
@@ -574,7 +820,11 @@ func assertSwarmTestScenarioThroughPublicRPC(t *testing.T, contractsPath string,
 			if req.Params["event_name"] != step.PublishEvent || req.Params["bundle_hash"] != bundleHash {
 				t.Fatalf("event.publish params = %#v", req.Params)
 			}
-			if publishCalls == 1 {
+			if len(doc.Setup.Entities) > 0 {
+				if req.Params["run_id"] != activeRunID {
+					t.Fatalf("event.publish[%d] run_id = %#v, want setup run %s; params=%#v", publishCalls, req.Params["run_id"], activeRunID, req.Params)
+				}
+			} else if publishCalls == 1 {
 				if _, ok := req.Params["run_id"]; ok {
 					t.Fatalf("first event.publish unexpectedly sent run_id: %#v", req.Params)
 				}
@@ -582,11 +832,23 @@ func assertSwarmTestScenarioThroughPublicRPC(t *testing.T, contractsPath string,
 					t.Fatalf("first event.publish unexpectedly sent source_event_id: %#v", req.Params)
 				}
 			} else {
-				if req.Params["run_id"] != "run-1" {
+				if req.Params["run_id"] != activeRunID {
 					t.Fatalf("event.publish[%d] run_id = %#v, want run-1; params=%#v", publishCalls, req.Params["run_id"], req.Params)
 				}
+			}
+			if publishCalls > 1 {
 				wantSource := fmt.Sprintf("event-%d", publishCalls-1)
 				if step.SourceEventID == nil && req.Params["source_event_id"] != wantSource {
+					t.Fatalf("event.publish[%d] source_event_id = %#v, want %#v; params=%#v", publishCalls, req.Params["source_event_id"], wantSource, req.Params)
+				}
+			}
+			if step.SourceEventID != nil {
+				wantSource := strings.TrimSpace(fmt.Sprint(step.SourceEventID))
+				if wantSource == "" {
+					if _, ok := req.Params["source_event_id"]; ok {
+						t.Fatalf("event.publish[%d] source_event_id = %#v, want omitted", publishCalls, req.Params["source_event_id"])
+					}
+				} else if req.Params["source_event_id"] != wantSource {
 					t.Fatalf("event.publish[%d] source_event_id = %#v, want %#v; params=%#v", publishCalls, req.Params["source_event_id"], wantSource, req.Params)
 				}
 			}
@@ -612,14 +874,17 @@ func assertSwarmTestScenarioThroughPublicRPC(t *testing.T, contractsPath string,
 			} else if _, ok := req.Params["emitter"]; ok {
 				t.Fatalf("event.publish unexpectedly sent emitter: %#v", req.Params)
 			}
-			result := eventPublishTestResult(publishCalls == 1)
+			result := eventPublishTestResult(len(doc.Setup.Entities) == 0 && publishCalls == 1)
 			result["event_id"] = eventID
-			if publishCalls > 1 {
-				result["source_event_id"] = fmt.Sprintf("event-%d", publishCalls-1)
+			result["run_id"] = activeRunID
+			if source, ok := req.Params["source_event_id"].(string); ok {
+				result["source_event_id"] = source
+			} else {
+				result["source_event_id"] = ""
 			}
 			writeJSONRPCResult(t, w, req.ID, result)
 		case "run.diagnose":
-			writeJSONRPCResult(t, w, req.ID, scenarioRunDiagnoseTestResult("run-1", true))
+			writeJSONRPCResult(t, w, req.ID, scenarioRunDiagnoseTestResult(activeRunID, true))
 		case "run.trace":
 			rows := make([]map[string]any, 0, len(doc.Steps)+len(doc.Expect.Events.Include))
 			for i, step := range doc.Steps {
@@ -630,20 +895,32 @@ func assertSwarmTestScenarioThroughPublicRPC(t *testing.T, contractsPath string,
 			}
 			writeJSONRPCResult(t, w, req.ID, map[string]any{"trace": rows})
 		case entityListMethod:
-			if req.Params["run_id"] != "run-1" || req.Params["type"] != entityExpect.EntityType {
+			if req.Params["run_id"] != activeRunID || req.Params["type"] != entityExpect.EntityType {
 				t.Fatalf("entity.list params = %#v", req.Params)
 			}
 			entity := validEntitySummary("entity-1")
+			entity["run_id"] = activeRunID
 			entity["entity_type"] = entityExpect.EntityType
 			entity["current_state"] = currentState
 			writeJSONRPCResult(t, w, req.ID, map[string]any{"entities": []map[string]any{entity}})
 		case entityGetMethod:
-			if req.Params["entity_id"] != "entity-1" || req.Params["run_id"] != "run-1" {
-				t.Fatalf("entity.get params = %#v", req.Params)
+			entityID := "entity-1"
+			entityType := entityExpect.EntityType
+			if entityExpect.Ref != "" {
+				var ok bool
+				entityID, ok = setupEntityIDs[entityExpect.Ref]
+				if !ok {
+					t.Fatalf("entity expectation ref %q missing setup binding", entityExpect.Ref)
+				}
+				entityType = setupEntityTypes[entityExpect.Ref]
 			}
-			result := validEntityFullResult("entity-1")
+			if req.Params["entity_id"] != entityID || req.Params["run_id"] != activeRunID {
+				t.Fatalf("entity.get params = %#v, want run %s entity %s", req.Params, activeRunID, entityID)
+			}
+			result := validEntityFullResult(entityID)
 			entity := result["entity"].(map[string]any)
-			entity["entity_type"] = entityExpect.EntityType
+			entity["run_id"] = activeRunID
+			entity["entity_type"] = entityType
 			entity["current_state"] = currentState
 			result["fields"] = fields
 			result["gates"] = gates
@@ -666,12 +943,18 @@ func assertSwarmTestScenarioThroughPublicRPC(t *testing.T, contractsPath string,
 		t.Fatalf("code = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
 	}
 	wantMethods := make([]string, 0, len(doc.Steps)*2+4)
+	if len(doc.Setup.Entities) > 0 {
+		wantMethods = append(wantMethods, scenarioTestSetupEntitiesMethod)
+	}
 	for range doc.Steps {
 		wantMethods = append(wantMethods, eventPublishMethod, "run.diagnose")
 	}
 	wantMethods = append(wantMethods, "run.diagnose", "run.trace")
 	if len(doc.Expect.Entities) > 0 {
-		wantMethods = append(wantMethods, entityListMethod, entityGetMethod)
+		if doc.Expect.Entities[0].Ref == "" {
+			wantMethods = append(wantMethods, entityListMethod)
+		}
+		wantMethods = append(wantMethods, entityGetMethod)
 	}
 	assertScenarioTestMethods(t, calls, wantMethods)
 	for _, want := range []string{"scenario ok:", "swarm test ok: scenarios=1"} {
@@ -1383,6 +1666,70 @@ expect:
       current_state: ready
       fields: {product_id: p-1, note: approved}
       gates: {review_ready: false}
+`)
+	return root
+}
+
+func writeScenarioRootSetupFixture(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "package.yaml"), `
+name: scenario-root-setup-fixture
+version: "1.0.0"
+platform_version: ">=0.7.0 <0.8.0"
+`)
+	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "schema.yaml"), `
+name: scenario-root-setup-fixture
+initial_state: waiting
+terminal_states: [done]
+states: [waiting, done]
+pins:
+  inputs:
+    events: [widget.scored]
+`)
+	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "entities.yaml"), `
+widget:
+  score: integer
+`)
+	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "events.yaml"), `
+widget.scored:
+  swarm:
+    source: external
+  delta: integer
+`)
+	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "nodes.yaml"), `
+scorer:
+  id: scorer
+  execution_type: system_node
+  subscribes_to: [widget.scored]
+  event_handlers:
+    widget.scored:
+      data_accumulation:
+        source_event: widget.scored
+        writes:
+          - target_field: score
+            expression: entity.score + payload.delta
+      advances_to: done
+`)
+	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "policy.yaml"), `{}`)
+	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "tools.yaml"), `{}`)
+	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "agents.yaml"), `{}`)
+	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "tests", "root-setup.yaml"), `
+name: root setup and expectation
+setup:
+  entities:
+    - as: widget
+      type: widget
+      current_state: waiting
+      fields: {score: 5}
+steps:
+  - publish: widget.scored
+    payload: {delta: 7}
+expect:
+  entities:
+    - ref: widget
+      current_state: done
+      fields: {score: 12}
 `)
 	return root
 }

--- a/cmd/swarm/test_command_test.go
+++ b/cmd/swarm/test_command_test.go
@@ -15,6 +15,7 @@ import (
 
 	runtimeflowidentity "github.com/division-sh/swarm/internal/runtime/core/flowidentity"
 	"github.com/google/uuid"
+	"gopkg.in/yaml.v3"
 
 	storebackend "github.com/division-sh/swarm/internal/store/backendselection"
 )
@@ -702,8 +703,73 @@ func TestSwarmTestRunsSetupPrestateCatalogCompanions(t *testing.T) {
 			if len(doc.Expect.Entities) != 1 || doc.Expect.Entities[0].Ref != "entity" || !doc.Expect.Entities[0].StateSet {
 				t.Fatalf("scenario entity expectations = %#v, want setup ref current_state assertion", doc.Expect.Entities)
 			}
+			assertSetupPrestateVisibleManifestations(t, tc.tier, tc.packageName, contractsPath, doc.Expect.Entities[0])
 			assertSwarmTestScenarioThroughPublicRPC(t, contractsPath, doc)
 		})
+	}
+}
+
+func assertSetupPrestateVisibleManifestations(t *testing.T, tier, packageName, contractsPath string, entityExpect scenarioEntityExpect) {
+	t.Helper()
+	fields, gates := loadCatalogExpectedFieldGateManifestations(t, contractsPath)
+	key := tier + "/" + packageName
+	if override, ok := publicScenarioFieldManifestationOverrides()[key]; ok {
+		fields = override
+	}
+	if split, ok := splitCatalogExpectedGateManifestations()[key]; ok {
+		for gate := range split {
+			delete(gates, gate)
+		}
+	}
+	if len(fields) > 0 {
+		if !entityExpect.FieldsSet {
+			t.Fatalf("%s expected public field manifestations %#v, but companion has no expect.entities.fields", key, fields)
+		}
+		if err := assertScenarioJSONEqual(key+" expect.entities.fields", entityExpect.Fields, fields); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if len(gates) > 0 {
+		if !entityExpect.GatesSet {
+			t.Fatalf("%s expected public gate manifestations %#v, but companion has no expect.entities.gates", key, gates)
+		}
+		if err := assertScenarioJSONEqual(key+" expect.entities.gates", entityExpect.Gates, gates); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+func loadCatalogExpectedFieldGateManifestations(t *testing.T, contractsPath string) (map[string]any, map[string]any) {
+	t.Helper()
+	raw, err := os.ReadFile(filepath.Join(contractsPath, "expected.yaml"))
+	if err != nil {
+		t.Fatalf("read expected.yaml: %v", err)
+	}
+	var doc struct {
+		Expected struct {
+			EntityFields map[string]any `yaml:"entity_fields"`
+			Gates        map[string]any `yaml:"gates"`
+		} `yaml:"expected"`
+	}
+	if err := yaml.Unmarshal(raw, &doc); err != nil {
+		t.Fatalf("parse expected.yaml: %v", err)
+	}
+	fields := cloneAnyMap(doc.Expected.EntityFields)
+	gates := cloneAnyMap(doc.Expected.Gates)
+	return fields, gates
+}
+
+func publicScenarioFieldManifestationOverrides() map[string]map[string]any {
+	return map[string]map[string]any{
+		"tier2-accumulation/test-accumulate-with-compute": {"composite": 81},
+	}
+}
+
+func splitCatalogExpectedGateManifestations() map[string]map[string]string {
+	return map[string]map[string]string{
+		"tier1-primitives/test-clear-gates": {
+			"g1_check": "private catalog gate without a declared public gate owner",
+		},
 	}
 }
 

--- a/internal/apiv1/operator_test_setup.go
+++ b/internal/apiv1/operator_test_setup.go
@@ -259,7 +259,7 @@ func validateTestSetupEntitiesAgainstBundle(source semanticview.Source, request 
 func validateTestSetupEntityAgainstBundle(bundle *runtimecontracts.WorkflowContractBundle, entity store.ScenarioSetupEntityRequest, i int) error {
 	flowID := strings.Trim(strings.TrimSpace(entity.FlowInstance), "/")
 	fieldPrefix := fmt.Sprintf("entities[%d]", i)
-	primary, err := bundle.ResolveFlowPrimaryEntity(flowID)
+	primary, err := bundle.ResolveTestSetupPrimaryEntity(flowID, entity.EntityType)
 	if err != nil {
 		return NewInvalidParamsError(map[string]any{
 			"field":  fieldPrefix + ".flow_instance",

--- a/internal/runtime/contracts/workflow_contract_accessors.go
+++ b/internal/runtime/contracts/workflow_contract_accessors.go
@@ -375,32 +375,32 @@ func (b *WorkflowContractBundle) FlowStates(flowID string) []string {
 	}
 	flowID = strings.TrimSpace(flowID)
 	if flowID == "" {
-		out := make([]string, 0, len(b.Semantics.Stages))
-		for _, stage := range b.Semantics.Stages {
-			stageID := strings.TrimSpace(stage.ID)
-			if stageID == "" {
-				continue
-			}
-			out = append(out, stageID)
-		}
-		return out
+		return rootSchemaStates(b.RootSchema)
 	}
 	if states := b.Semantics.FlowStates[flowID]; len(states) > 0 {
 		return append([]string{}, states...)
 	}
 	if flowID != "" && flowID == b.WorkflowName() {
-		out := make([]string, 0, len(b.Semantics.Stages))
-		for _, stage := range b.Semantics.Stages {
-			stageID := strings.TrimSpace(stage.ID)
-			if stageID == "" {
-				continue
-			}
-			out = append(out, stageID)
-		}
-		return out
+		return rootSchemaStates(b.RootSchema)
 	}
 	return nil
 }
+
+func rootSchemaStates(root *FlowSchemaDocument) []string {
+	if root == nil {
+		return nil
+	}
+	out := make([]string, 0, len(root.States))
+	for _, state := range root.States {
+		state = strings.TrimSpace(state)
+		if state == "" {
+			continue
+		}
+		out = append(out, state)
+	}
+	return out
+}
+
 func (b *WorkflowContractBundle) FlowTerminalStages(flowID string) []string {
 	if b == nil {
 		return nil

--- a/internal/runtime/contracts/workflow_contract_accessors.go
+++ b/internal/runtime/contracts/workflow_contract_accessors.go
@@ -358,6 +358,9 @@ func (b *WorkflowContractBundle) FlowInitialStage(flowID string) string {
 		return ""
 	}
 	flowID = strings.TrimSpace(flowID)
+	if flowID == "" {
+		return b.WorkflowInitialStage()
+	}
 	if initial := strings.TrimSpace(b.Semantics.FlowInitial[flowID]); initial != "" {
 		return initial
 	}
@@ -371,6 +374,17 @@ func (b *WorkflowContractBundle) FlowStates(flowID string) []string {
 		return nil
 	}
 	flowID = strings.TrimSpace(flowID)
+	if flowID == "" {
+		out := make([]string, 0, len(b.Semantics.Stages))
+		for _, stage := range b.Semantics.Stages {
+			stageID := strings.TrimSpace(stage.ID)
+			if stageID == "" {
+				continue
+			}
+			out = append(out, stageID)
+		}
+		return out
+	}
 	if states := b.Semantics.FlowStates[flowID]; len(states) > 0 {
 		return append([]string{}, states...)
 	}

--- a/internal/runtime/contracts/workflow_contract_accessors_test.go
+++ b/internal/runtime/contracts/workflow_contract_accessors_test.go
@@ -1,10 +1,44 @@
 package contracts
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/division-sh/swarm/internal/runtime/flowmodel"
 )
+
+func TestFlowStatesRootScopeExcludesChildFlowStates(t *testing.T) {
+	bundle := &WorkflowContractBundle{
+		Package: ProjectPackageDocument{Name: "root-workflow", Version: "1.0.0"},
+		RootSchema: &FlowSchemaDocument{
+			InitialState: "root-new",
+			States:       []string{"root-new", "root-done"},
+		},
+		Paths: ContractPaths{Flows: []FlowContractPaths{
+			{ID: "child", Flow: "child"},
+		}},
+		FlowSchemas: map[string]FlowSchemaDocument{
+			"child": {
+				InitialState: "child-new",
+				States:       []string{"child-new", "child-done"},
+			},
+		},
+	}
+	populateWorkflowSemantics(bundle)
+
+	if got, want := bundle.FlowStates(""), []string{"root-new", "root-done"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("FlowStates(\"\") = %#v, want %#v", got, want)
+	}
+	if got, want := bundle.FlowStates(bundle.WorkflowName()), []string{"root-new", "root-done"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("FlowStates(workflow name) = %#v, want %#v", got, want)
+	}
+	if got, want := bundle.FlowStates("child"), []string{"child-new", "child-done"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("FlowStates(child) = %#v, want %#v", got, want)
+	}
+	if got := bundle.WorkflowStages(); len(got) != 4 {
+		t.Fatalf("WorkflowStages length = %d, want aggregate root+child states", len(got))
+	}
+}
 
 func TestResolveFlowInputAutoWire_ReturnsScopedProducerForUniquePinMatch(t *testing.T) {
 	producer := FlowContractView{

--- a/internal/runtime/contracts/workflow_contract_wave1_accessors.go
+++ b/internal/runtime/contracts/workflow_contract_wave1_accessors.go
@@ -600,6 +600,22 @@ func (b *WorkflowContractBundle) ResolveRootPrimaryEntity() (PrimaryEntityContra
 	return resolvePrimaryEntityContract("", entity, b.RootEntities, b.RootTypeCatalog())
 }
 
+func (b *WorkflowContractBundle) ResolveTestSetupPrimaryEntity(flowID, entityType string) (PrimaryEntityContract, error) {
+	primary, err := b.ResolveFlowPrimaryEntity(flowID)
+	if err == nil {
+		return primary, nil
+	}
+	if strings.TrimSpace(flowID) == "" && strings.TrimSpace(entityType) == "default" && len(b.RootEntities) == 0 {
+		return PrimaryEntityContract{
+			FlowID:     "",
+			EntityType: "default",
+			Contract:   EntityContract{Fields: map[string]EntityFieldDecl{}},
+			Types:      b.RootTypeCatalog(),
+		}, nil
+	}
+	return PrimaryEntityContract{}, err
+}
+
 func resolvePrimaryEntityContract(flowID, declared string, entities EntityContractsDocument, types TypeCatalogDocument) (PrimaryEntityContract, error) {
 	flowID = strings.TrimSpace(flowID)
 	declared = strings.TrimSpace(declared)

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -12511,7 +12511,11 @@ test_specification:
           identity and recorded seed, validates the authored setup against the
           loaded contract bundle, then submits exactly one idempotent
           `test.setup_entities` request carrying canonical bundle_hash,
-          run_id, and the validated entity rows. The runner MUST NOT write the
+          run_id, and the validated entity rows. Root-flow setup rows use the
+          same canonical root entity identity as same-run root event handling:
+          the root setup entity_id is derived from the scenario run_id. Flow-scoped
+          setup rows use deterministic alias-specific entity_id values and may
+          be consumed by `target` aliases. The runner MUST NOT write the
           database/store directly, call EventBus, create deliveries, infer
           handler outcomes, or expose a generic entity.create/entity.update
           public mutation surface.
@@ -12520,6 +12524,9 @@ test_specification:
             `as` aliases are non-empty and unique within the scenario.
           - >
             `type` must match the primary entity type for the selected flow scope.
+            For legacy root packages with no entities.yaml, root setup may use
+            `type: default` only for state/gate setup; public setup fields still
+            require a declared entity contract field.
           - >
             `current_state`, when supplied, must be a declared state for the selected flow; otherwise the selected flow's
             initial state is used.

--- a/tests/tier1-primitives/test-clear-gates/tests/visible-smoke.yaml
+++ b/tests/tier1-primitives/test-clear-gates/tests/visible-smoke.yaml
@@ -1,0 +1,15 @@
+name: test-clear-gates setup visible smoke
+setup:
+  entities:
+  - as: entity
+    type: default
+steps:
+- publish: gates.clear_requested
+  payload: {}
+expect:
+  events:
+    include:
+    - gates.cleared
+  entities:
+  - ref: entity
+    current_state: pending

--- a/tests/tier1-primitives/test-guard-compound-condition/tests/visible-smoke.yaml
+++ b/tests/tier1-primitives/test-guard-compound-condition/tests/visible-smoke.yaml
@@ -1,0 +1,19 @@
+name: test-guard-compound-condition setup visible smoke
+setup:
+  entities:
+  - as: entity
+    type: core
+    fields:
+      priority: high
+steps:
+- publish: check.requested
+  payload:
+    score: 60
+    override: false
+expect:
+  events:
+    include:
+    - check.passed
+  entities:
+  - ref: entity
+    current_state: done

--- a/tests/tier1-primitives/test-guard-entity-ref/tests/visible-smoke.yaml
+++ b/tests/tier1-primitives/test-guard-entity-ref/tests/visible-smoke.yaml
@@ -1,0 +1,17 @@
+name: test-guard-entity-ref setup visible smoke
+setup:
+  entities:
+  - as: entity
+    type: core
+    fields:
+      level: 5
+steps:
+- publish: check.requested
+  payload: {}
+expect:
+  events:
+    include:
+    - check.passed
+  entities:
+  - ref: entity
+    current_state: done

--- a/tests/tier1-primitives/test-on-complete-with-state/tests/visible-smoke.yaml
+++ b/tests/tier1-primitives/test-on-complete-with-state/tests/visible-smoke.yaml
@@ -1,0 +1,17 @@
+name: test-on-complete-with-state setup visible smoke
+setup:
+  entities:
+  - as: entity
+    type: core
+    fields:
+      priority: high
+steps:
+- publish: item.evaluated
+  payload: {}
+expect:
+  events:
+    include:
+    - item.expedited
+  entities:
+  - ref: entity
+    current_state: done

--- a/tests/tier1-primitives/test-payload-transform-multi-source/tests/visible-smoke.yaml
+++ b/tests/tier1-primitives/test-payload-transform-multi-source/tests/visible-smoke.yaml
@@ -1,0 +1,17 @@
+name: test-payload-transform-multi-source setup visible smoke
+setup:
+  entities:
+  - as: entity
+    type: core
+    fields:
+      name: test-entity
+steps:
+- publish: export.requested
+  payload: {}
+expect:
+  events:
+    include:
+    - item.exported
+  entities:
+  - ref: entity
+    current_state: done

--- a/tests/tier10-policy-patterns/test-policy-counter-escalate/tests/visible-smoke.yaml
+++ b/tests/tier10-policy-patterns/test-policy-counter-escalate/tests/visible-smoke.yaml
@@ -1,0 +1,18 @@
+name: test-policy-counter-escalate setup visible smoke
+setup:
+  entities:
+  - as: entity
+    type: core
+    current_state: retrying
+    fields:
+      attempt_count: 3
+steps:
+- publish: attempt.requested
+  payload: {}
+expect:
+  events:
+    include:
+    - attempt.limit_hit
+  entities:
+  - ref: entity
+    current_state: retrying

--- a/tests/tier10-policy-patterns/test-policy-multi-guard-partial/tests/visible-smoke.yaml
+++ b/tests/tier10-policy-patterns/test-policy-multi-guard-partial/tests/visible-smoke.yaml
@@ -1,0 +1,18 @@
+name: test-policy-multi-guard-partial setup visible smoke
+setup:
+  entities:
+  - as: entity
+    type: core
+    fields:
+      depth: 3
+      flag_count: 0
+      item_count: 10
+steps:
+- publish: check.requested
+  payload:
+    score: 55
+    confidence: 50
+expect:
+  entities:
+  - ref: entity
+    current_state: pending

--- a/tests/tier2-accumulation/test-accumulate-all/tests/visible-smoke.yaml
+++ b/tests/tier2-accumulation/test-accumulate-all/tests/visible-smoke.yaml
@@ -1,0 +1,26 @@
+name: test-accumulate-all setup visible smoke
+setup:
+  entities:
+  - as: entity
+    type: core
+    fields:
+      expected_count: 3
+steps:
+- publish: item.arrived
+  payload:
+    item_id: a
+- publish: item.arrived
+  payload:
+    item_id: b
+  source_event_id: ''
+- publish: item.arrived
+  payload:
+    item_id: c
+  source_event_id: ''
+expect:
+  events:
+    include:
+    - collection.done
+  entities:
+  - ref: entity
+    current_state: complete

--- a/tests/tier2-accumulation/test-accumulate-crash-recovery/tests/visible-smoke.yaml
+++ b/tests/tier2-accumulation/test-accumulate-crash-recovery/tests/visible-smoke.yaml
@@ -1,0 +1,26 @@
+name: test-accumulate-crash-recovery setup visible smoke
+setup:
+  entities:
+  - as: entity
+    type: core
+    fields:
+      expected_count: 3
+steps:
+- publish: item.arrived
+  payload:
+    item_id: a
+- publish: item.arrived
+  payload:
+    item_id: b
+  source_event_id: ''
+- publish: item.arrived
+  payload:
+    item_id: c
+  source_event_id: ''
+expect:
+  events:
+    include:
+    - collection.done
+  entities:
+  - ref: entity
+    current_state: complete

--- a/tests/tier2-accumulation/test-accumulate-expected-from-entity/tests/visible-smoke.yaml
+++ b/tests/tier2-accumulation/test-accumulate-expected-from-entity/tests/visible-smoke.yaml
@@ -1,0 +1,22 @@
+name: test-accumulate-expected-from-entity setup visible smoke
+setup:
+  entities:
+  - as: entity
+    type: core
+    fields:
+      item_count: 2
+steps:
+- publish: item.arrived
+  payload:
+    item_id: a
+- publish: item.arrived
+  payload:
+    item_id: b
+  source_event_id: ''
+expect:
+  events:
+    include:
+    - collection.done
+  entities:
+  - ref: entity
+    current_state: complete

--- a/tests/tier2-accumulation/test-accumulate-from-filter/tests/visible-smoke.yaml
+++ b/tests/tier2-accumulation/test-accumulate-from-filter/tests/visible-smoke.yaml
@@ -1,0 +1,29 @@
+name: test-accumulate-from-filter setup visible smoke
+setup:
+  entities:
+  - as: entity
+    type: core
+    fields:
+      expected_count: 3
+steps:
+- publish: score.received
+  payload:
+    score: 85.0
+  emitter: scoring/analysis-agent
+- publish: score.received
+  payload:
+    score: 90.0
+  source_event_id: ''
+  emitter: scoring/analysis-agent
+- publish: score.received
+  payload:
+    score: 78.0
+  source_event_id: ''
+  emitter: scoring/analysis-agent
+expect:
+  events:
+    include:
+    - scores.collected
+  entities:
+  - ref: entity
+    current_state: complete

--- a/tests/tier2-accumulation/test-accumulate-idempotent/tests/visible-smoke.yaml
+++ b/tests/tier2-accumulation/test-accumulate-idempotent/tests/visible-smoke.yaml
@@ -1,0 +1,23 @@
+name: test-accumulate-idempotent setup visible smoke
+setup:
+  entities:
+  - as: entity
+    type: core
+    fields:
+      expected_count: 3
+steps:
+- publish: item.arrived
+  payload:
+    item_id: a
+- publish: item.arrived
+  payload:
+    item_id: a
+  source_event_id: ''
+- publish: item.arrived
+  payload:
+    item_id: b
+  source_event_id: ''
+expect:
+  entities:
+  - ref: entity
+    current_state: collecting

--- a/tests/tier2-accumulation/test-accumulate-on-complete-rollback/tests/visible-smoke.yaml
+++ b/tests/tier2-accumulation/test-accumulate-on-complete-rollback/tests/visible-smoke.yaml
@@ -1,0 +1,27 @@
+name: test-accumulate-on-complete-rollback setup visible smoke
+setup:
+  entities:
+  - as: entity
+    type: core
+    fields:
+      expected_count: 3
+steps:
+- publish: score.received
+  payload:
+    score: 80
+- publish: score.received
+  payload:
+    score: 90
+  source_event_id: ''
+- publish: score.received
+  payload:
+    score: 70
+  source_event_id: ''
+expect:
+  events:
+    include:
+    - batch.scored
+    - scores.verified
+  entities:
+  - ref: entity
+    current_state: verified

--- a/tests/tier2-accumulation/test-accumulate-partial/tests/visible-smoke.yaml
+++ b/tests/tier2-accumulation/test-accumulate-partial/tests/visible-smoke.yaml
@@ -1,0 +1,19 @@
+name: test-accumulate-partial setup visible smoke
+setup:
+  entities:
+  - as: entity
+    type: core
+    fields:
+      expected_count: 3
+steps:
+- publish: item.arrived
+  payload:
+    item_id: a
+- publish: item.arrived
+  payload:
+    item_id: b
+  source_event_id: ''
+expect:
+  entities:
+  - ref: entity
+    current_state: collecting

--- a/tests/tier2-accumulation/test-accumulate-threshold/tests/visible-smoke.yaml
+++ b/tests/tier2-accumulation/test-accumulate-threshold/tests/visible-smoke.yaml
@@ -1,0 +1,22 @@
+name: test-accumulate-threshold setup visible smoke
+setup:
+  entities:
+  - as: entity
+    type: core
+    fields:
+      expected_count: 3
+steps:
+- publish: item.arrived
+  payload:
+    item_id: a
+- publish: item.arrived
+  payload:
+    item_id: b
+  source_event_id: ''
+expect:
+  events:
+    include:
+    - collection.done
+  entities:
+  - ref: entity
+    current_state: complete

--- a/tests/tier2-accumulation/test-accumulate-with-compute/tests/visible-smoke.yaml
+++ b/tests/tier2-accumulation/test-accumulate-with-compute/tests/visible-smoke.yaml
@@ -27,3 +27,5 @@ expect:
   entities:
   - ref: entity
     current_state: complete
+    fields:
+      composite: 81

--- a/tests/tier2-accumulation/test-accumulate-with-compute/tests/visible-smoke.yaml
+++ b/tests/tier2-accumulation/test-accumulate-with-compute/tests/visible-smoke.yaml
@@ -1,0 +1,29 @@
+name: test-accumulate-with-compute setup visible smoke
+setup:
+  entities:
+  - as: entity
+    type: core
+    fields:
+      expected_count: 3
+steps:
+- publish: score.received
+  payload:
+    dimension: a
+    score: 80
+- publish: score.received
+  payload:
+    dimension: b
+    score: 90
+  source_event_id: ''
+- publish: score.received
+  payload:
+    dimension: c
+    score: 70
+  source_event_id: ''
+expect:
+  events:
+    include:
+    - scores.aggregated
+  entities:
+  - ref: entity
+    current_state: complete

--- a/tests/tier4-cross-entity/test-clear-multiple-targets/tests/visible-smoke.yaml
+++ b/tests/tier4-cross-entity/test-clear-multiple-targets/tests/visible-smoke.yaml
@@ -1,0 +1,15 @@
+name: test-clear-multiple-targets setup visible smoke
+setup:
+  entities:
+  - as: entity
+    type: default
+steps:
+- publish: state.reset_requested
+  payload: {}
+expect:
+  events:
+    include:
+    - state.reset_completed
+  entities:
+  - ref: entity
+    current_state: cleared

--- a/tests/tier4-cross-entity/test-clear-state/tests/visible-smoke.yaml
+++ b/tests/tier4-cross-entity/test-clear-state/tests/visible-smoke.yaml
@@ -1,0 +1,15 @@
+name: test-clear-state setup visible smoke
+setup:
+  entities:
+  - as: entity
+    type: default
+steps:
+- publish: state.clear_requested
+  payload: {}
+expect:
+  events:
+    include:
+    - state.cleared
+  entities:
+  - ref: entity
+    current_state: cleared

--- a/tests/tier6-event-loop/test-atomicity-guard-rollback/tests/visible-smoke.yaml
+++ b/tests/tier6-event-loop/test-atomicity-guard-rollback/tests/visible-smoke.yaml
@@ -1,0 +1,23 @@
+name: test-atomicity-guard-rollback setup visible smoke
+setup:
+  entities:
+  - as: entity
+    type: core
+    current_state: pending
+    fields:
+      status: not_ready
+      counter: 0
+    gates:
+      g_processed: false
+steps:
+- publish: process.requested
+  payload: {}
+expect:
+  entities:
+  - ref: entity
+    current_state: pending
+    fields:
+      status: not_ready
+      counter: 0
+    gates:
+      g_processed: false

--- a/tests/tier6-event-loop/test-guards-pre-handler-state/tests/visible-smoke.yaml
+++ b/tests/tier6-event-loop/test-guards-pre-handler-state/tests/visible-smoke.yaml
@@ -1,0 +1,17 @@
+name: test-guards-pre-handler-state setup visible smoke
+setup:
+  entities:
+  - as: entity
+    type: core
+    current_state: active
+    fields:
+      counter: 5
+steps:
+- publish: process.requested
+  payload: {}
+expect:
+  entities:
+  - ref: entity
+    current_state: active
+    fields:
+      counter: 5

--- a/tests/tier9-composition-patterns/test-compose-guard-counter-escalate/tests/visible-smoke.yaml
+++ b/tests/tier9-composition-patterns/test-compose-guard-counter-escalate/tests/visible-smoke.yaml
@@ -1,0 +1,18 @@
+name: test-compose-guard-counter-escalate setup visible smoke
+setup:
+  entities:
+  - as: entity
+    type: core
+    current_state: active
+    fields:
+      retry_count: 3
+steps:
+- publish: retry.requested
+  payload: {}
+expect:
+  events:
+    include:
+    - limit.reached
+  entities:
+  - ref: entity
+    current_state: active

--- a/tests/tier9-composition-patterns/test-compose-guard-multi-source/tests/visible-smoke.yaml
+++ b/tests/tier9-composition-patterns/test-compose-guard-multi-source/tests/visible-smoke.yaml
@@ -1,0 +1,21 @@
+name: test-compose-guard-multi-source setup visible smoke
+setup:
+  entities:
+  - as: entity
+    type: core
+    fields:
+      depth: 2
+      child_count: 1
+      flag_count: 0
+steps:
+- publish: candidate.submitted
+  payload:
+    name: unique-item
+    score: 55
+expect:
+  events:
+    include:
+    - candidate.accepted
+  entities:
+  - ref: entity
+    current_state: accepted


### PR DESCRIPTION
## Summary

Closes #1754.

Adds public deterministic `swarm test` visible-smoke companions for setup/pre-state catalog rows that are expressible with the already-merged public owners from #1741 / PR #1750. This PR accounts for all 27 gate candidate rows: 22 receive public companions, 5 full rows are explicitly split because they require timer/timeout or private state-schema setup authority, and one companion row (`test-clear-gates`) explicitly splits its private undeclared gate manifestation while still proving its public event/state behavior.

## Governing Context

- Approved pre-audit: https://github.com/division-sh/swarm/issues/1754#issuecomment-4893872308
- Independent gate: https://github.com/division-sh/swarm/issues/1754#issuecomment-4894067738
- `platform-spec.yaml#test_specification.deterministic_scenario_runner.setup_pre_state`
- `platform-spec.yaml#api_specification.method_catalog.test.setup_entities`
- `platform-spec.yaml#cli_specification.command_catalog.test`

## What Changed

- Adds 22 `tests/**/tests/visible-smoke.yaml` setup/pre-state companions using only public scenario owners.
- Adds exact public field proof for `test-accumulate-with-compute` via `expect.entities.fields.composite: 81`.
- Tightens `cmd/swarm` companion proof so supported `expected.yaml` field/gate manifestations cannot be silently omitted from public companions.
- Keeps the private catalog smoke harness intact; this does not migrate or remove private `expected.yaml` proof.
- Teaches public scenario setup to seed root-scope setup rows into the canonical scenario run root entity.
- Shares setup primary entity resolution between CLI and `/v1/rpc test.setup_entities` validation.
- Allows legacy root packages without `entities.yaml` to use setup-only `type: default` for state/gate setup while still failing closed for undeclared field setup.
- Updates `platform-spec.yaml` for the root setup identity and legacy default setup-only boundary.

## Explicit Splits

The following full candidate rows are not implemented as public companions in this PR because they need unsupported public authority:

- `tests/tier2-accumulation/test-accumulate-on-timeout`: timer/timeout control and `timer_handle` payload authority.
- `tests/tier2-accumulation/test-accumulate-timeout`: timer/timeout control and `timer_handle` payload authority.
- `tests/tier3-list-processing/test-reduce-pick-or-average`: private state-schema setup field `scores`.
- `tests/tier3-list-processing/test-reduce-sum`: private state-schema setup field `values`.
- `tests/tier3-list-processing/test-reduce-weighted-average`: private state-schema setup field `scores`.

Partial manifestation split inside an implemented companion:

- `tests/tier1-primitives/test-clear-gates`: public companion proves `gates.cleared` and final `current_state: pending`; private `g1_check` gate setup/final proof is split because no public declared gate owner exists for `g1_check` in that package.

This PR does not promote `handler_outcome`, no-output absence, exact emitted-event counts/multiplicity, timer-clock advancement, runtime/store atomicity proof, flow/template creation, causal chains, positive dead-letter details, agent/tool behavior, faithful scripted backend behavior, retired multi-emit syntax, undeclared private gates, or private state-schema setup.

## Semantic Migration Notes

New canonical owners consumed:

- Public setup/pre-state: `platform-spec.yaml#test_specification.deterministic_scenario_runner.setup_pre_state` and `/v1/rpc test.setup_entities`.
- Scenario execution/readback: `event.publish`, `run.diagnose`, `run.trace`, `entity.list`, and `entity.get`.
- Setup primary entity resolution: `WorkflowContractBundle.ResolveTestSetupPrimaryEntity`.

Old private paths remain internal and non-authoritative for public scenarios:

- `trigger.entity`, `entity_state_before`, `entity_fields_before`, `gates_before`, `handler_outcome`, and `emitted_events` in private catalog `expected.yaml`.

Production paths checked for surviving old behavior:

- CLI scenario setup path.
- API `/v1/rpc test.setup_entities` validation path.
- Public companion scenario execution under `cmd/swarm` tests.
- Private catalog harness survival via the full Go suite.

Migration status: complete for expressible public setup/pre-state visible companion manifestations approved by the gate; unsupported private gate/timer/state-schema manifestations are explicitly split and the broader catalog migration parent remains open.

## Validation

- `go test ./internal/runtime/contracts -run TestFlowStatesRootScopeExcludesChildFlowStates -count=1`
- `SWARM_TEST_POSTGRES_DSN='host=127.0.0.1 port=5432 user=youmew dbname=postgres sslmode=disable' PGPASSWORD=postgres go test ./cmd/swarm -run 'TestSwarmTestRunsSetupPrestateCatalogCompanions' -count=1`
- `SWARM_TEST_POSTGRES_DSN='host=127.0.0.1 port=5432 user=youmew dbname=postgres sslmode=disable' PGPASSWORD=postgres go test ./cmd/swarm -count=1`
- `SWARM_TEST_POSTGRES_DSN='host=127.0.0.1 port=5432 user=youmew dbname=postgres sslmode=disable' PGPASSWORD=postgres go test ./internal/apiv1 -run 'TestOperatorTestSetup|TestOpenRPCMutatingRuntime' -count=1`
- `go test ./internal/runtime/contracts ./internal/apispec -count=1`
- `SWARM_TEST_POSTGRES_DSN='host=127.0.0.1 port=5432 user=youmew dbname=postgres sslmode=disable' PGPASSWORD=postgres go test ./...`
