### PR TITLE
[agent-b][issue #1138] Derive workspace backend from capabilities

### DIFF
--- a/cmd/swarm/builder_project_supervisor.go
+++ b/cmd/swarm/builder_project_supervisor.go
@@ -38,7 +38,7 @@ type runtimeProjectSupervisor struct {
 	loadWorkflow        func(repoRoot, contractsRoot, platformSpecPath string) (runtimepipeline.WorkflowModule, *runtimecontracts.WorkflowContractBundle, error)
 	validateSource      func(context.Context, semanticview.Source) error
 	initStateStores     func(context.Context, storeBundle, *runtimecontracts.WorkflowContractBundle) (string, error)
-	newWorkspaces       func(storeBundle, string, semanticview.Source, workspaceMountSources) (workspace.Lifecycle, error)
+	newWorkspaces       func(storeBundle, string, semanticview.Source, workspaceMountSources) (workspace.Lifecycle, workspaceBackendSelection, error)
 	createRuntime       func(context.Context, runtime.RuntimeDeps) (*runtime.Runtime, error)
 
 	mu                              sync.RWMutex
@@ -95,12 +95,16 @@ func newRuntimeProjectSupervisor(
 		initStateStores: func(ctx context.Context, stores storeBundle, bundle *runtimecontracts.WorkflowContractBundle) (string, error) {
 			return initializeStateStores(ctx, stores, bundle, false)
 		},
-		newWorkspaces: func(stores storeBundle, contractsRoot string, source semanticview.Source, mountSources workspaceMountSources) (workspace.Lifecycle, error) {
+		newWorkspaces: func(stores storeBundle, contractsRoot string, source semanticview.Source, mountSources workspaceMountSources) (workspace.Lifecycle, workspaceBackendSelection, error) {
 			decision, err := decideWorkspaceBackend(workspaceBackend, cfg, source)
 			if err != nil {
-				return nil, err
+				return nil, workspaceBackendSelection{}, err
 			}
-			return configuredWorkspaceLifecycleForBackend(stores.facade().workspaceDB(), contractsRoot, source, mountSources, decision)
+			lifecycle, err := configuredWorkspaceLifecycleForBackend(stores.facade().workspaceDB(), contractsRoot, source, mountSources, decision)
+			if err != nil {
+				return nil, decision, err
+			}
+			return lifecycle, decision, nil
 		},
 		createRuntime: func(ctx context.Context, deps runtime.RuntimeDeps) (*runtime.Runtime, error) {
 			return runtime.NewRuntime(ctx, deps)
@@ -196,18 +200,24 @@ func (s *runtimeProjectSupervisor) loadProject(ctx context.Context, projectDir s
 	if err != nil {
 		return builderpkg.ProjectStatus{}, fmt.Errorf("prepare project bundle source: %w", err)
 	}
-	workspaces, err := s.newWorkspaces(s.stores, resolvedRoot, source, s.mountSources)
+	workspaces, workspaceBackend, err := s.newWorkspaces(s.stores, resolvedRoot, source, s.mountSources)
 	if err != nil {
 		return builderpkg.ProjectStatus{}, err
 	}
-	if err := workspaces.ValidateSource(ctx, source); err != nil {
-		return builderpkg.ProjectStatus{}, err
-	}
-	if err := workspaces.EnsurePrereqs(ctx); err != nil {
-		return builderpkg.ProjectStatus{}, err
-	}
-	if err := workspaces.EnsureSystemWorkspaces(ctx); err != nil {
-		return builderpkg.ProjectStatus{}, err
+	if workspaces == nil {
+		if !workspaceBackend.NoWorkspace {
+			return builderpkg.ProjectStatus{}, fmt.Errorf("workspace lifecycle is not configured for backend %q; no lifecycle is only valid for canonical no-workspace decision", strings.TrimSpace(workspaceBackend.Backend))
+		}
+	} else {
+		if err := workspaces.ValidateSource(ctx, source); err != nil {
+			return builderpkg.ProjectStatus{}, err
+		}
+		if err := workspaces.EnsurePrereqs(ctx); err != nil {
+			return builderpkg.ProjectStatus{}, err
+		}
+		if err := workspaces.EnsureSystemWorkspaces(ctx); err != nil {
+			return builderpkg.ProjectStatus{}, err
+		}
 	}
 
 	newRT, err := s.createRuntime(ctx, runtime.RuntimeDeps{

--- a/cmd/swarm/builder_project_supervisor.go
+++ b/cmd/swarm/builder_project_supervisor.go
@@ -96,7 +96,11 @@ func newRuntimeProjectSupervisor(
 			return initializeStateStores(ctx, stores, bundle, false)
 		},
 		newWorkspaces: func(stores storeBundle, contractsRoot string, source semanticview.Source, mountSources workspaceMountSources) (workspace.Lifecycle, error) {
-			return configuredWorkspaceLifecycleForBackend(stores.facade().workspaceDB(), contractsRoot, source, mountSources, workspaceBackend)
+			decision, err := decideWorkspaceBackend(workspaceBackend, cfg, source)
+			if err != nil {
+				return nil, err
+			}
+			return configuredWorkspaceLifecycleForBackend(stores.facade().workspaceDB(), contractsRoot, source, mountSources, decision)
 		},
 		createRuntime: func(ctx context.Context, deps runtime.RuntimeDeps) (*runtime.Runtime, error) {
 			return runtime.NewRuntime(ctx, deps)

--- a/cmd/swarm/builder_project_supervisor_test.go
+++ b/cmd/swarm/builder_project_supervisor_test.go
@@ -324,7 +324,7 @@ func newSupervisorForLoadProjectFailureTest(
 	bundle := testBuilderSupervisorBundle(t)
 	source := semanticview.Wrap(bundle)
 	module := stubWorkflowModule{source: source}
-	supervisor := newRuntimeProjectSupervisor("", "", nil, storeBundle{}, new(atomic.Bool), workspaceMountSources{}, workspaceBackendSelection{Backend: defaultWorkspaceBackend, Source: "default"}, nil, nil, "", nil, nil, nil)
+	supervisor := newRuntimeProjectSupervisor("", "", nil, storeBundle{}, new(atomic.Bool), workspaceMountSources{}, workspaceBackendSelection{Backend: workspace.BackendDocker, Source: "test"}, nil, nil, "", nil, nil, nil)
 	supervisor.dev = true
 	supervisor.loadWorkflow = func(repoRoot, contractsRoot, platformSpecPath string) (runtimepipeline.WorkflowModule, *runtimecontracts.WorkflowContractBundle, error) {
 		if got := strings.TrimSpace(contractsRoot); got != strings.TrimSpace(projectRoot) {

--- a/cmd/swarm/builder_project_supervisor_test.go
+++ b/cmd/swarm/builder_project_supervisor_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/division-sh/swarm/internal/config"
 	"github.com/division-sh/swarm/internal/events"
 	runtimepkg "github.com/division-sh/swarm/internal/runtime"
 	runtimeagentcontrol "github.com/division-sh/swarm/internal/runtime/agentcontrol"
@@ -336,8 +337,8 @@ func newSupervisorForLoadProjectFailureTest(
 	supervisor.initStateStores = func(context.Context, storeBundle, *runtimecontracts.WorkflowContractBundle) (string, error) {
 		return "store wiring ready", nil
 	}
-	supervisor.newWorkspaces = func(storeBundle, string, semanticview.Source, workspaceMountSources) (workspace.Lifecycle, error) {
-		return lifecycle, nil
+	supervisor.newWorkspaces = func(storeBundle, string, semanticview.Source, workspaceMountSources) (workspace.Lifecycle, workspaceBackendSelection, error) {
+		return lifecycle, workspaceBackendSelection{Backend: workspace.BackendDocker, Source: "test"}, nil
 	}
 	if createRuntime != nil {
 		supervisor.createRuntime = createRuntime
@@ -358,9 +359,9 @@ func TestRuntimeProjectSupervisorLoadProjectUsesResolvedWorkspaceMountSources(t 
 		return &runtimepkg.Runtime{}, nil
 	})
 	supervisor.mountSources = wantMountSources
-	supervisor.newWorkspaces = func(_ storeBundle, _ string, _ semanticview.Source, mountSources workspaceMountSources) (workspace.Lifecycle, error) {
+	supervisor.newWorkspaces = func(_ storeBundle, _ string, _ semanticview.Source, mountSources workspaceMountSources) (workspace.Lifecycle, workspaceBackendSelection, error) {
 		gotMountSources = mountSources
-		return stubWorkspaceLifecycle{}, nil
+		return stubWorkspaceLifecycle{}, workspaceBackendSelection{Backend: workspace.BackendDocker, Source: "test"}, nil
 	}
 	supervisor.startRuntime = func(context.Context, *runtimepkg.Runtime) error { return nil }
 	supervisor.shutdownRuntime = func(context.Context, *runtimepkg.Runtime, runtimepkg.ShutdownOptions) error { return nil }
@@ -415,6 +416,68 @@ func TestRuntimeProjectSupervisorLoadProject_PropagatesWorkspaceAdmissionFailure
 				t.Fatalf("CurrentRuntime = %p after %s failure, want nil", supervisor.CurrentRuntime(), tc.name)
 			}
 		})
+	}
+}
+
+func TestRuntimeProjectSupervisorOpenProjectNoAgentSkipsWorkspaceLifecycle(t *testing.T) {
+	projectRoot := writeProjectRoot(t)
+	var ready atomic.Bool
+	var createdWorkspace bool
+	var gotWorkspace workspace.Lifecycle
+
+	supervisor := newSupervisorForLoadProjectFailureTest(t, projectRoot, nil, func(_ context.Context, deps runtimepkg.RuntimeDeps) (*runtimepkg.Runtime, error) {
+		gotWorkspace = deps.Options.WorkspaceLifecycle
+		return &runtimepkg.Runtime{}, nil
+	})
+	supervisor.ready = &ready
+	supervisor.cfg = &config.Config{LLM: config.LLMConfig{Backend: "anthropic"}}
+	supervisor.workspaceBackend = workspaceBackendSelection{Source: "capability-derived"}
+	supervisor.newWorkspaces = func(stores storeBundle, contractsRoot string, source semanticview.Source, mountSources workspaceMountSources) (workspace.Lifecycle, workspaceBackendSelection, error) {
+		createdWorkspace = true
+		decision, err := decideWorkspaceBackend(supervisor.workspaceBackend, supervisor.cfg, source)
+		if err != nil {
+			return nil, workspaceBackendSelection{}, err
+		}
+		lifecycle, err := configuredWorkspaceLifecycleForBackend(stores.facade().workspaceDB(), contractsRoot, source, mountSources, decision)
+		if err != nil {
+			return nil, decision, err
+		}
+		return lifecycle, decision, nil
+	}
+	supervisor.startRuntime = func(context.Context, *runtimepkg.Runtime) error { return nil }
+	supervisor.shutdownRuntime = func(context.Context, *runtimepkg.Runtime, runtimepkg.ShutdownOptions) error { return nil }
+
+	status, err := supervisor.OpenProject(context.Background(), projectRoot)
+	if err != nil {
+		t.Fatalf("OpenProject: %v", err)
+	}
+	if !status.Loaded {
+		t.Fatal("status.Loaded = false, want true")
+	}
+	if !ready.Load() {
+		t.Fatal("ready flag = false, want true")
+	}
+	if !createdWorkspace {
+		t.Fatal("shared backend workspace factory was not called")
+	}
+	if gotWorkspace != nil {
+		t.Fatalf("runtime workspace lifecycle = %T, want nil for no-agent no-workspace decision", gotWorkspace)
+	}
+}
+
+func TestRuntimeProjectSupervisorOpenProjectRejectsNilLifecycleWithoutNoWorkspaceDecision(t *testing.T) {
+	projectRoot := writeProjectRoot(t)
+	supervisor := newSupervisorForLoadProjectFailureTest(t, projectRoot, nil, func(context.Context, runtimepkg.RuntimeDeps) (*runtimepkg.Runtime, error) {
+		t.Fatal("createRuntime should not be called when lifecycle is nil without no-workspace decision")
+		return nil, nil
+	})
+	supervisor.newWorkspaces = func(storeBundle, string, semanticview.Source, workspaceMountSources) (workspace.Lifecycle, workspaceBackendSelection, error) {
+		return nil, workspaceBackendSelection{Backend: workspace.BackendHost, Source: "test"}, nil
+	}
+
+	_, err := supervisor.OpenProject(context.Background(), projectRoot)
+	if err == nil || !strings.Contains(err.Error(), "no lifecycle is only valid for canonical no-workspace decision") {
+		t.Fatalf("OpenProject err = %v, want nil lifecycle guard", err)
 	}
 }
 

--- a/cmd/swarm/cli.go
+++ b/cmd/swarm/cli.go
@@ -316,7 +316,7 @@ func newServeCommand(ctx context.Context, repo string, runServe func(context.Con
 	cmd.Flags().StringVar(&opts.Backend, "backend", opts.Backend, "LLM backend profile for local runtime startup: anthropic, claude_cli, openai_compatible, or openai_responses")
 	cmd.Flags().StringVar(&opts.ContractsPath, "contracts", opts.ContractsPath, "Path to Swarm contract bundle root")
 	cmd.Flags().StringVar(&opts.DataSource, "data", opts.DataSource, "Path to agent-visible read-only /data reference directory")
-	cmd.Flags().StringVar(&opts.WorkspaceBackend, "workspace-backend", opts.WorkspaceBackend, "Workspace backend for local serve: docker (default isolation backend) or host (explicit trusted/unsafe local-dev opt-in)")
+	cmd.Flags().StringVar(&opts.WorkspaceBackend, "workspace-backend", opts.WorkspaceBackend, "Workspace backend preference for local serve: docker, or host for explicit trusted/unsafe local-dev opt-in")
 	cmd.Flags().StringArrayVar(&opts.BundleHashes, "bundle-hash", opts.BundleHashes, "Load a persisted bundle catalog row by canonical bundle_hash; repeat to boot multiple pinned contexts")
 	cmd.Flags().StringVar(&opts.PlatformSpecPath, "platform-spec", opts.PlatformSpecPath, "Path to platform spec yaml")
 	cmd.Flags().StringVar(&opts.StoreMode, "store", opts.StoreMode, runtimeStoreBackendHelp)

--- a/cmd/swarm/describe.go
+++ b/cmd/swarm/describe.go
@@ -19,6 +19,11 @@ type describeCommandOptions struct {
 	logging          cliLoggingOptions
 }
 
+type describeCommandOutput struct {
+	authoringview.View
+	WorkspaceBackend string `json:"workspace_backend"`
+}
+
 func defaultDescribeCommandOptions() describeCommandOptions {
 	return describeCommandOptions{
 		logging: defaultCLILoggingOptions(),
@@ -92,6 +97,14 @@ func runDescribeCommandWithOutput(ctx context.Context, repo string, opts describ
 		return 1
 	}
 	source := semanticview.Wrap(bundle)
+	workspaceBackend, err := resolveWorkspaceBackendDiagnostic(repo, source)
+	if err != nil {
+		if errOut != nil {
+			fmt.Fprintf(errOut, "describe failed: resolve workspace backend: %v\n", err)
+		}
+		return 1
+	}
+	workspaceBackendDetail := workspaceBackendDecisionDetail(workspaceBackend)
 	report := runtimebootverify.Run(ctx, source, runtimebootverify.Options{})
 	view, err := authoringview.Build(ctx, source, authoringview.BuildOptions{BootReport: &report})
 	if err != nil {
@@ -101,8 +114,12 @@ func runDescribeCommandWithOutput(ctx context.Context, repo string, opts describ
 		return 1
 	}
 	view.ContractsRoot = contractsRoot
-	if err := renderCLIOutput(out, errOut, opts.output, view, func(w io.Writer) {
-		writeDescribeText(w, view)
+	output := describeCommandOutput{
+		View:             view,
+		WorkspaceBackend: workspaceBackendDetail,
+	}
+	if err := renderCLIOutput(out, errOut, opts.output, output, func(w io.Writer) {
+		writeDescribeText(w, view, workspaceBackendDetail)
 	}, func() ([]string, error) {
 		return describeQuietValues(view), nil
 	}); err != nil {
@@ -111,12 +128,15 @@ func runDescribeCommandWithOutput(ctx context.Context, repo string, opts describ
 	return 0
 }
 
-func writeDescribeText(out io.Writer, view authoringview.View) {
+func writeDescribeText(out io.Writer, view authoringview.View, workspaceBackendDetail string) {
 	if out == nil {
 		return
 	}
 	fmt.Fprintf(out, "describe: contracts=%s\n", view.ContractsRoot)
 	fmt.Fprintf(out, "source authority: %s\n", view.SourceAuthority)
+	if strings.TrimSpace(workspaceBackendDetail) != "" {
+		fmt.Fprintf(out, "%s\n", workspaceBackendDetail)
+	}
 	if view.Root.PrimaryEntity != nil {
 		fmt.Fprintf(out, "root primary entity: %s\n", view.Root.PrimaryEntity.Type)
 	}

--- a/cmd/swarm/doctor_test.go
+++ b/cmd/swarm/doctor_test.go
@@ -617,7 +617,7 @@ func TestDoctorAPIFlagsRequireTargetMode(t *testing.T) {
 	}
 }
 
-func TestRunServeRuntimeConsumesLocalClaudePreflightBeforeStoreSelection(t *testing.T) {
+func TestRunServeRuntimeConsumesLocalClaudePreflightAfterBundleDecision(t *testing.T) {
 	configureDoctorDockerStub(t)
 	t.Setenv("CLAUDE_CODE_OAUTH_TOKEN", "")
 	t.Setenv("SWARM_TOOL_GATEWAY_URL", "")
@@ -645,8 +645,10 @@ func TestRunServeRuntimeConsumesLocalClaudePreflightBeforeStoreSelection(t *test
 	if !strings.Contains(out.String(), "local_preflight") || !strings.Contains(out.String(), "missing_backend_credential") {
 		t.Fatalf("serve output missing shared local preflight failure:\n%s", out.String())
 	}
-	if strings.Contains(out.String(), "not-a-store") || strings.Contains(out.String(), "db_connection") {
-		t.Fatalf("serve reached store selection instead of failing preflight first:\n%s", out.String())
+	for _, want := range []string{"db_connection", "bundle_load", "workspace backend: docker"} {
+		if !strings.Contains(out.String(), want) {
+			t.Fatalf("serve output missing preflight ordering proof %q:\n%s", want, out.String())
+		}
 	}
 }
 

--- a/cmd/swarm/forkchat_workspace_admission.go
+++ b/cmd/swarm/forkchat_workspace_admission.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	apiv1 "github.com/division-sh/swarm/internal/apiv1"
+	"github.com/division-sh/swarm/internal/config"
+	llmselection "github.com/division-sh/swarm/internal/runtime/llm/selection"
+	workspace "github.com/division-sh/swarm/internal/runtime/workspace"
+	"github.com/division-sh/swarm/internal/store"
+)
+
+type workspaceAdmittedForkChatExecutor struct {
+	inner     apiv1.ForkChatExecutor
+	decision  workspaceBackendSelection
+	profileID string
+}
+
+func newWorkspaceAdmittedForkChatExecutor(inner apiv1.ForkChatExecutor, cfg *config.Config, decision workspaceBackendSelection) apiv1.ForkChatExecutor {
+	profileID := ""
+	if cfg != nil {
+		if profile, err := cfg.LLMBackendProfile(); err == nil {
+			profileID = strings.TrimSpace(profile.ID)
+		}
+	}
+	return workspaceAdmittedForkChatExecutor{
+		inner:     inner,
+		decision:  decision,
+		profileID: profileID,
+	}
+}
+
+func (e workspaceAdmittedForkChatExecutor) ExecuteForkChat(ctx context.Context, prepared store.ConversationForkChatPrepared, message string) (store.ConversationForkChatExecution, error) {
+	if e.profileID == llmselection.BackendClaudeCLI {
+		switch {
+		case e.decision.Backend == workspace.BackendDocker:
+			return e.inner.ExecuteForkChat(ctx, prepared, message)
+		case e.decision.Backend == workspace.BackendHost || e.decision.UnsafeHost:
+			return store.ConversationForkChatExecution{}, fmt.Errorf("conversation.fork_chat cannot use host workspace backend with claude_cli; use docker because claude_cli process execution on host remains split")
+		case e.decision.NoWorkspace || e.decision.Backend == workspaceBackendNone:
+			return store.ConversationForkChatExecution{}, fmt.Errorf("conversation.fork_chat requires container isolation because forkchat uses claude_cli; start Docker or configure an API-backed LLM backend")
+		default:
+			return store.ConversationForkChatExecution{}, fmt.Errorf("conversation.fork_chat workspace backend decision %q cannot run claude_cli; use docker", strings.TrimSpace(e.decision.Backend))
+		}
+	}
+	return e.inner.ExecuteForkChat(ctx, prepared, message)
+}

--- a/cmd/swarm/local_preflight.go
+++ b/cmd/swarm/local_preflight.go
@@ -102,7 +102,7 @@ func runLocalClaudeCLIPreflight(ctx context.Context, req localPreflightRequest) 
 		return report.finalize()
 	}
 	report.Backend = strings.TrimSpace(profile.ID)
-	if profile.ID != llmselection.BackendClaudeCLI {
+	if profile.ID != llmselection.BackendClaudeCLI && report.Mode != "doctor" {
 		report.add(localPreflightBackendPrerequisite, "backend_not_claude_cli", localPreflightSeverityInfo, localPreflightStatusSkipped, fmt.Sprintf("backend %q does not require claude_cli local proof prerequisites", profile.ID), "")
 		return report.finalize()
 	}
@@ -120,8 +120,27 @@ func runLocalClaudeCLIPreflight(ctx context.Context, req localPreflightRequest) 
 		report.add(localPreflightWorkspacePrerequisite, "contract_source_load_failed", localPreflightSeverityBlocker, localPreflightStatusFailed, err.Error(), "fix the selected --contracts and --platform-spec paths")
 		return report.finalize()
 	}
+	workspaceBackend, err := decideWorkspaceBackend(req.WorkspaceBackend, req.Config, source)
+	if err != nil {
+		report.add(localPreflightWorkspacePrerequisite, "workspace_backend_decision_failed", localPreflightSeverityBlocker, localPreflightStatusFailed, err.Error(), "fix workspace.backend, workspace.allow_exec_on_host, or the selected contract capabilities")
+		return report.finalize()
+	}
+	status := localPreflightStatusOK
+	severity := localPreflightSeverityInfo
+	code := "workspace_backend_decision"
+	remediation := ""
+	if workspaceBackend.UnsafeHost {
+		severity = localPreflightSeverityWarning
+		code = "workspace_backend_unsafe_host"
+		remediation = "use Docker for container isolation unless this is a trusted local-only run"
+	}
+	report.add(localPreflightWorkspacePrerequisite, code, severity, status, workspaceBackendDecisionDetail(workspaceBackend), remediation)
 	if req.CheckContractSecrets {
 		report.checkContractSecrets(ctx, source, req.ContractSecretSeverity)
+	}
+	if profile.ID != llmselection.BackendClaudeCLI {
+		report.add(localPreflightBackendPrerequisite, "backend_not_claude_cli", localPreflightSeverityInfo, localPreflightStatusSkipped, fmt.Sprintf("backend %q does not require claude_cli local proof prerequisites", profile.ID), "")
+		return report.finalize()
 	}
 	if !sourceDeclaresAgents(source) {
 		report.add(localPreflightBackendPrerequisite, "backend_credential_skipped_agent_free", localPreflightSeverityInfo, localPreflightStatusSkipped, "selected contract source declares no agents; claude_cli backend credential is not required", "")
@@ -150,7 +169,7 @@ func runLocalClaudeCLIPreflight(ctx context.Context, req localPreflightRequest) 
 		}
 		report.add(localPreflightBackendPrerequisite, "backend_credential_present", localPreflightSeverityInfo, localPreflightStatusOK, message, "")
 	}
-	report.checkWorkspace(ctx, source, contractsRoot, req.MountSources, req.WorkspaceBackend, req.Config.LLM.ClaudeCLI.Command)
+	report.checkWorkspace(ctx, source, contractsRoot, req.MountSources, workspaceBackend, req.Config.LLM.ClaudeCLI.Command)
 	return report.finalize()
 }
 

--- a/cmd/swarm/main.go
+++ b/cmd/swarm/main.go
@@ -92,6 +92,8 @@ type serveStartupRecoveryContainers struct {
 	lifecycle serveWorkspaceLifecycle
 }
 
+type noWorkspaceStartupRecoveryContainers struct{}
+
 func (s serveStartupRecoveryContainers) ManagedContainers(ctx context.Context) ([]runtimestartuprecovery.ManagedContainer, error) {
 	if s.lifecycle == nil {
 		return nil, fmt.Errorf("workspace lifecycle is not configured")
@@ -116,6 +118,14 @@ func (s serveStartupRecoveryContainers) StopManagedContainer(ctx context.Context
 		return fmt.Errorf("workspace lifecycle is not configured")
 	}
 	return s.lifecycle.StopManagedContainer(ctx, name)
+}
+
+func (noWorkspaceStartupRecoveryContainers) ManagedContainers(context.Context) ([]runtimestartuprecovery.ManagedContainer, error) {
+	return nil, nil
+}
+
+func (noWorkspaceStartupRecoveryContainers) StopManagedContainer(context.Context, string) error {
+	return fmt.Errorf("workspace lifecycle is not configured")
 }
 
 type storeBundle struct {
@@ -380,6 +390,7 @@ type serveRuntimeBundleContext struct {
 	stateStoreSummary string
 	bundleSourceFact  runtimecorrelation.BundleSourceFact
 	bootIdentity      runtimecontracts.BundleIdentity
+	workspaceBackend  workspaceBackendSelection
 	workspaces        serveWorkspaceLifecycle
 	validation        runtime.WorkflowContractValidationResult
 	runtime           *runtime.Runtime
@@ -410,7 +421,6 @@ type serveRuntimeBundleContextRequest struct {
 func defaultServeOptions() serveOptions {
 	return serveOptions{
 		StoreMode:          storebackend.ActiveDefaultBackend().String(),
-		WorkspaceBackend:   defaultWorkspaceBackend,
 		APIListenAddr:      defaultAPIListenAddr,
 		MCPListenAddr:      defaultMCPListenAddr,
 		ShutdownGrace:      runtime.DefaultShutdownGrace,
@@ -681,7 +691,7 @@ func buildServeRuntimeBundleContext(req serveRuntimeBundleContextRequest) (serve
 	if err != nil {
 		return serveRuntimeBundleContext{}, fmt.Errorf("configure workspaces: %w", err)
 	}
-	if workspaces == nil {
+	if workspaces == nil && !req.WorkspaceBackend.NoWorkspace {
 		return serveRuntimeBundleContext{}, fmt.Errorf("workspace lifecycle is not configured")
 	}
 	if req.RequireBundleScopeName {
@@ -689,14 +699,16 @@ func buildServeRuntimeBundleContext(req serveRuntimeBundleContextRequest) (serve
 			scoper.SetBundleScope(bundleSourceFact.BundleHash)
 		}
 	}
-	if err := workspaces.ValidateSource(req.Ctx, loaded.source); err != nil {
-		return serveRuntimeBundleContext{}, fmt.Errorf("validate workspaces: %w", err)
-	}
-	if err := workspaces.EnsurePrereqs(req.Ctx); err != nil {
-		return serveRuntimeBundleContext{}, fmt.Errorf("prepare workspaces: %w", err)
-	}
-	if err := workspaces.EnsureSystemWorkspaces(req.Ctx); err != nil {
-		return serveRuntimeBundleContext{}, fmt.Errorf("ensure system workspaces: %w", err)
+	if workspaces != nil {
+		if err := workspaces.ValidateSource(req.Ctx, loaded.source); err != nil {
+			return serveRuntimeBundleContext{}, fmt.Errorf("validate workspaces: %w", err)
+		}
+		if err := workspaces.EnsurePrereqs(req.Ctx); err != nil {
+			return serveRuntimeBundleContext{}, fmt.Errorf("prepare workspaces: %w", err)
+		}
+		if err := workspaces.EnsureSystemWorkspaces(req.Ctx); err != nil {
+			return serveRuntimeBundleContext{}, fmt.Errorf("ensure system workspaces: %w", err)
+		}
 	}
 	validationOpts := runtime.DefaultWorkflowContractValidationOptions(req.Credentials)
 	validationOpts.ManagedCredentials = req.ManagedCredentials
@@ -747,6 +759,7 @@ func buildServeRuntimeBundleContext(req serveRuntimeBundleContextRequest) (serve
 		stateStoreSummary: stateStoreSummary,
 		bundleSourceFact:  bundleSourceFact,
 		bootIdentity:      bootIdentity,
+		workspaceBackend:  req.WorkspaceBackend,
 		workspaces:        workspaces,
 		validation:        validation,
 		runtime:           rt,
@@ -851,23 +864,11 @@ func runServeRuntime(ctx context.Context, repo string, opts serveOptions) int {
 		return 1
 	}
 	mountSources := localState.MountSources
-	workspaceBackend, err := resolveWorkspaceBackend(opts.WorkspaceBackend, opts.WorkspaceBackendSet, cfg)
+	workspaceBackendPreference, err := resolveWorkspaceBackend(opts.WorkspaceBackend, opts.WorkspaceBackendSet, cfg)
 	if err != nil {
 		reporter.emit(2, "config_load", "FAILED", err.Error())
 		log.Printf("resolve workspace backend: %v", err)
 		return 1
-	}
-	if shouldRunServeLocalClaudeCLIPreflight(opts) {
-		preflight := runServeLocalClaudeCLIPreflight(ctx, repo, opts, cfg, resolvedPaths, workspaceBackend, mountSources)
-		if preflight.HasBlockers() {
-			detail := preflight.BlockerSummary()
-			reporter.emit(2, "local_preflight", "FAILED", detail)
-			if opts.Output != nil {
-				writeLocalPreflightText(opts.Output, preflight)
-			}
-			log.Printf("local claude_cli preflight failed: %s", detail)
-			return 3
-		}
 	}
 	storeSelection := localState.StoreSelection
 	stores, err := buildStoresForServe(ctx, storeSelection, cfg)
@@ -915,6 +916,25 @@ func runServeRuntime(ctx context.Context, repo string, opts serveOptions) int {
 	source := loadedBundle.source
 	resolvedPlatformSpecPath := loadedBundle.platformSpecPath
 	reporter.emit(4, "bundle_load", "ok", serveBootBundleLoadDetail(serveRuntimeBundleIdentitiesDetail(loadedBundles), source))
+	primaryWorkspaceBackend, err := decideWorkspaceBackend(workspaceBackendPreference, cfg, source)
+	if err != nil {
+		reporter.emit(5, "runtime_context", "FAILED", err.Error())
+		log.Printf("resolve workspace backend decision: %v", err)
+		return 3
+	}
+	logWorkspaceBackendDecision(opts.Output, primaryWorkspaceBackend)
+	if shouldRunServeLocalClaudeCLIPreflight(opts) {
+		preflight := runServeLocalClaudeCLIPreflight(ctx, repo, opts, cfg, resolvedPaths, workspaceBackendPreference, mountSources)
+		if preflight.HasBlockers() {
+			detail := preflight.BlockerSummary()
+			reporter.emit(5, "local_preflight", "FAILED", detail)
+			if opts.Output != nil {
+				writeLocalPreflightText(opts.Output, preflight)
+			}
+			log.Printf("local claude_cli preflight failed: %s", detail)
+			return 3
+		}
+	}
 	if err := validateServeMultiContextToolGatewayAdmission(cfg, loadedBundles); err != nil {
 		reporter.emit(5, "runtime_context", "FAILED", err.Error())
 		log.Printf("validate multi-context tool gateway admission: %v", err)
@@ -942,19 +962,19 @@ func runServeRuntime(ctx context.Context, repo string, opts serveOptions) int {
 		log.Printf("serve abandon active runs complete: runs=%d deliveries=%d pipeline_receipts=%d", len(result.Runs), len(result.Deliveries), result.PipelineReceiptCount)
 	}
 	if recoveryStore := storeFacade.startupRecoveryStore(); recoveryStore != nil {
-		recoveryWorkspaces, err := configuredWorkspaceLifecycleForServe(storeFacade.workspaceDB(), loadedBundle.contractsRoot, source, mountSources, workspaceBackend)
+		recoveryWorkspaces, err := configuredWorkspaceLifecycleForServe(storeFacade.workspaceDB(), loadedBundle.contractsRoot, source, mountSources, primaryWorkspaceBackend)
 		if err != nil {
 			slog.Error("configure recovery workspaces", "error", err)
 			return 1
 		}
+		recoveryContainers := runtimestartuprecovery.ManagedContainerOwner(serveStartupRecoveryContainers{lifecycle: recoveryWorkspaces})
 		if recoveryWorkspaces == nil {
-			slog.Error("workspace lifecycle is not configured")
-			return 1
+			recoveryContainers = noWorkspaceStartupRecoveryContainers{}
 		}
 		recovery, err := runtimestartuprecovery.Recover(ctx, runtimestartuprecovery.Request{
 			AvailabilityReader: recoveryStore,
 			CleanupStore:       recoveryStore,
-			Containers:         serveStartupRecoveryContainers{lifecycle: recoveryWorkspaces},
+			Containers:         recoveryContainers,
 			RequestedAt:        time.Now().UTC(),
 		})
 		if err != nil {
@@ -1026,6 +1046,15 @@ func runServeRuntime(ctx context.Context, repo string, opts serveOptions) int {
 		if i == 0 {
 			contextToolGatewayBinding = toolGatewayBinding
 		}
+		workspaceBackend, err := decideWorkspaceBackend(workspaceBackendPreference, cfg, loaded.source)
+		if err != nil {
+			reporter.emit(5, "runtime_context", "FAILED", err.Error())
+			slog.Error("resolve workspace backend decision", "bundle_hash", strings.TrimSpace(loaded.bundleSourceFact.BundleHash), "error", err)
+			return 3
+		}
+		if i > 0 {
+			logWorkspaceBackendDecision(opts.Output, workspaceBackend)
+		}
 		contextDef, err := buildServeRuntimeBundleContext(serveRuntimeBundleContextRequest{
 			Ctx:                     ctx,
 			Stores:                  stores,
@@ -1060,6 +1089,7 @@ func runServeRuntime(ctx context.Context, repo string, opts serveOptions) int {
 	contractsRoot := primaryContext.loaded.contractsRoot
 	bootBundleIdentity := primaryContext.bootIdentity
 	workspaces := primaryContext.workspaces
+	primaryWorkspaceBackend = primaryContext.workspaceBackend
 	rt := primaryContext.runtime
 	bootReport := primaryContext.validation.BootReport
 	stateStoreSummary := serveRuntimeStateStoreSummary(runtimeContexts)
@@ -1071,7 +1101,7 @@ func runServeRuntime(ctx context.Context, repo string, opts serveOptions) int {
 	}
 
 	var ready atomic.Bool
-	supervisor := newRuntimeProjectSupervisor(repo, resolvedPlatformSpecPath, cfg, stores, &ready, mountSources, workspaceBackend, credentialStore, providerCredentialStore, contractsRoot, bundle, source, rt, opts.Dev)
+	supervisor := newRuntimeProjectSupervisor(repo, resolvedPlatformSpecPath, cfg, stores, &ready, mountSources, workspaceBackendPreference, credentialStore, providerCredentialStore, contractsRoot, bundle, source, rt, opts.Dev)
 	if len(pinnedBundleHashes) > 0 {
 		supervisor.DisableSourceReplacement("swarm serve --bundle-hash pins persisted bundle contexts for the process; dynamic project reload is split to RuntimeContextManager Load/Unload work")
 	}
@@ -1123,7 +1153,7 @@ func runServeRuntime(ctx context.Context, repo string, opts serveOptions) int {
 		BundleCatalog:          apiStoreCaps.BundleCatalog,
 		BundleDelete:           apiStoreCaps.BundleDelete,
 		ConversationForks:      apiStoreCaps.ConversationForks,
-		ForkChatExecutor:       apiv1.NewLLMForkChatExecutor(forkChatLLM),
+		ForkChatExecutor:       newWorkspaceAdmittedForkChatExecutor(apiv1.NewLLMForkChatExecutor(forkChatLLM), cfg, primaryWorkspaceBackend),
 		RunBundleContext:       apiStoreCaps.RunBundleContext,
 		TestSetup:              apiStoreCaps.TestSetup,
 		RunForkAvailability:    apiStoreCaps.RunForkAvailability,
@@ -1211,14 +1241,24 @@ func closeServeRuntime(ctx context.Context, supervisor *runtimeProjectSupervisor
 		_, shutdownErr = supervisor.CloseProjectWithShutdownOptions(ctx, shutdownOpts)
 	}
 	var cleanupErr error
-	if opts.Dev {
-		if workspaces == nil {
-			cleanupErr = fmt.Errorf("dev entity cleanup owner unavailable")
-		} else {
-			_, cleanupErr = workspaces.CleanupDevEntityContainers(ctx)
-		}
+	if opts.Dev && workspaces != nil {
+		_, cleanupErr = workspaces.CleanupDevEntityContainers(ctx)
 	}
 	return errors.Join(shutdownErr, cleanupErr)
+}
+
+func logWorkspaceBackendDecision(out io.Writer, decision workspaceBackendSelection) {
+	detail := workspaceBackendDecisionDetail(decision)
+	log.Print(detail)
+	if out != nil {
+		fmt.Fprintln(out, detail)
+	}
+	if warning := workspaceBackendUnsafeWarning(decision); warning != "" {
+		log.Print(warning)
+		if out != nil {
+			fmt.Fprintln(out, warning)
+		}
+	}
 }
 
 func serveRuntimeContextManager(reader runtime.RunBundleAvailabilityReader, contexts []serveRuntimeBundleContext) (*runtime.RuntimeContextManager, error) {
@@ -1276,10 +1316,11 @@ func closeAdditionalServeRuntimeContexts(ctx context.Context, contexts []serveRu
 }
 
 type verifyCommandResult struct {
-	OK           bool                  `json:"ok"`
-	Contracts    string                `json:"contracts"`
-	Warnings     []verifyFindingOutput `json:"warnings"`
-	LintEvidence []verifyFindingOutput `json:"lint_evidence"`
+	OK               bool                  `json:"ok"`
+	Contracts        string                `json:"contracts"`
+	WorkspaceBackend string                `json:"workspace_backend"`
+	Warnings         []verifyFindingOutput `json:"warnings"`
+	LintEvidence     []verifyFindingOutput `json:"lint_evidence"`
 }
 
 type verifyFindingOutput struct {
@@ -1351,7 +1392,16 @@ func runVerifyCommandWithOutput(ctx context.Context, repo string, opts verifyCom
 		}
 		return 1
 	} else {
-		result, err := verifyBundleResultWithOptions(ctx, semanticview.Wrap(bundle), validationOpts)
+		source := semanticview.Wrap(bundle)
+		workspaceBackend, err := resolveWorkspaceBackendDiagnostic(repo, source)
+		if err != nil {
+			if errOut != nil {
+				fmt.Fprintf(errOut, "verify failed: resolve workspace backend: %v\n", err)
+			}
+			return 1
+		}
+		workspaceBackendDetail := workspaceBackendDecisionDetail(workspaceBackend)
+		result, err := verifyBundleResultWithOptions(ctx, source, validationOpts)
 		if err != nil {
 			if errOut != nil {
 				fmt.Fprintf(errOut, "verify failed: %v\n", err)
@@ -1359,16 +1409,18 @@ func runVerifyCommandWithOutput(ctx context.Context, repo string, opts verifyCom
 			return 1
 		}
 		output := verifyCommandResult{
-			OK:           true,
-			Contracts:    contractsRoot,
-			Warnings:     verifyFindingOutputs(result.BootReport.Warnings()),
-			LintEvidence: verifyFindingOutputs(result.BootReport.LintEvidence()),
+			OK:               true,
+			Contracts:        contractsRoot,
+			WorkspaceBackend: workspaceBackendDetail,
+			Warnings:         verifyFindingOutputs(result.BootReport.Warnings()),
+			LintEvidence:     verifyFindingOutputs(result.BootReport.LintEvidence()),
 		}
 		if err := renderCLIOutput(out, errOut, opts.output, output, func(_ io.Writer) {
 			writeVerifyFindings(errOut, result.BootReport.Warnings(), false)
 			writeVerifyFindings(errOut, result.BootReport.LintEvidence(), false)
 			if out != nil {
 				fmt.Fprintf(out, "verify ok: contracts=%s\n", contractsRoot)
+				fmt.Fprintf(out, "%s\n", workspaceBackendDetail)
 			}
 		}, func() ([]string, error) {
 			return []string{"ok"}, nil
@@ -1686,7 +1738,14 @@ func runForkRuntimeOwnerHarness(ctx context.Context, repo string, args []string,
 			}
 			return 1
 		}
-		workspaceBackend, err := resolveWorkspaceBackend("", false, cfg)
+		workspaceBackendPreference, err := resolveWorkspaceBackend("", false, cfg)
+		if err != nil {
+			if out != nil {
+				fmt.Fprintf(out, "fork failed: resolve workspace backend: %v\n", err)
+			}
+			return 1
+		}
+		workspaceBackend, err := decideWorkspaceBackend(workspaceBackendPreference, cfg, source)
 		if err != nil {
 			if out != nil {
 				fmt.Fprintf(out, "fork failed: resolve workspace backend: %v\n", err)
@@ -3390,9 +3449,11 @@ func configuredWorkspaceLifecycle(db *sql.DB, contractsRoot string, source seman
 func configuredWorkspaceLifecycleForBackend(db *sql.DB, contractsRoot string, source semanticview.Source, mountSources workspaceMountSources, backend workspaceBackendSelection) (serveWorkspaceLifecycle, error) {
 	selected := strings.TrimSpace(backend.Backend)
 	if selected == "" {
-		selected = defaultWorkspaceBackend
+		return nil, fmt.Errorf("workspace backend decision is required")
 	}
 	switch selected {
+	case workspaceBackendNone:
+		return nil, nil
 	case workspace.BackendDocker:
 		return configuredWorkspaceLifecycle(db, contractsRoot, source, mountSources)
 	case workspace.BackendHost:

--- a/cmd/swarm/main_test.go
+++ b/cmd/swarm/main_test.go
@@ -2083,8 +2083,8 @@ func TestResolveWorkspaceBackendPrecedence(t *testing.T) {
 	if err != nil {
 		t.Fatalf("resolve workspace backend default: %v", err)
 	}
-	if result.Backend != workspace.BackendDocker || result.Source != "default" {
-		t.Fatalf("default result = %#v, want docker default", result)
+	if result.Backend != "" || result.Source != "capability-derived" || result.PreferenceExplicit {
+		t.Fatalf("default preference result = %#v, want capability-derived no explicit backend", result)
 	}
 }
 
@@ -2319,10 +2319,14 @@ func TestPlatformSpecWorkspaceBackendSelectionPromoted(t *testing.T) {
 				Scope                string   `yaml:"scope"`
 				CLIFlag              string   `yaml:"cli_flag"`
 				ConfigKey            string   `yaml:"config_key"`
-				EnvVar               string   `yaml:"env_var"`
+				UnsafeConfigKey      string   `yaml:"unsafe_config_key"`
+				LegacyEnvVar         string   `yaml:"legacy_env_var"`
 				SourceOrder          []string `yaml:"source_order"`
 				DefaultBackend       string   `yaml:"default_backend"`
-				Backends             map[string]struct {
+				CapabilityClasses    map[string]struct {
+					Rule string `yaml:"rule"`
+				} `yaml:"capability_classes"`
+				Backends map[string]struct {
 					Behavior      string `yaml:"behavior"`
 					WorkspaceRoot struct {
 						EnvVar  string `yaml:"env_var"`
@@ -2339,13 +2343,14 @@ func TestPlatformSpecWorkspaceBackendSelectionPromoted(t *testing.T) {
 			CommandCatalog struct {
 				Serve struct {
 					WorkspaceBackendSelection struct {
-						PromotedBy     string   `yaml:"promoted_by"`
-						Owner          string   `yaml:"owner"`
-						Flag           string   `yaml:"flag"`
-						ConfigKey      string   `yaml:"config_key"`
-						EnvVar         string   `yaml:"env_var"`
-						DefaultBackend string   `yaml:"default_backend"`
-						Consumers      []string `yaml:"consumers"`
+						PromotedBy      string   `yaml:"promoted_by"`
+						Owner           string   `yaml:"owner"`
+						Flag            string   `yaml:"flag"`
+						ConfigKey       string   `yaml:"config_key"`
+						UnsafeConfigKey string   `yaml:"unsafe_config_key"`
+						LegacyEnvVar    string   `yaml:"legacy_env_var"`
+						DefaultBackend  string   `yaml:"default_backend"`
+						Consumers       []string `yaml:"consumers"`
 					} `yaml:"workspace_backend_selection"`
 				} `yaml:"serve"`
 			} `yaml:"command_catalog"`
@@ -2359,29 +2364,38 @@ func TestPlatformSpecWorkspaceBackendSelectionPromoted(t *testing.T) {
 		t.Fatalf("parse platform spec: %v", err)
 	}
 	authority := spec.WorkspaceModel.WorkspaceBackendSelection
-	if strings.TrimSpace(authority.PromotedBy) != "#1138" || strings.TrimSpace(authority.ImplementationStatus) != "implemented_first_slice" {
+	if strings.TrimSpace(authority.PromotedBy) != "#1138" || strings.TrimSpace(authority.ImplementationStatus) != "implemented_capability_driven_first_slice" {
 		t.Fatalf("workspace backend authority status = promoted_by:%q implementation_status:%q", authority.PromotedBy, authority.ImplementationStatus)
 	}
 	if !strings.Contains(authority.CanonicalOwner, "workspace_model.workspace_backend_selection") {
 		t.Fatalf("workspace backend canonical owner = %q", authority.CanonicalOwner)
 	}
-	if authority.CLIFlag != "--workspace-backend <docker|host>" || authority.ConfigKey != "workspace.backend" || authority.EnvVar != envWorkspaceBackend {
+	if authority.CLIFlag != "--workspace-backend <docker|host>" || authority.ConfigKey != "workspace.backend" || authority.UnsafeConfigKey != "workspace.allow_exec_on_host" || authority.LegacyEnvVar != envWorkspaceBackend {
 		t.Fatalf("workspace backend selectors = %#v", authority)
 	}
-	for _, want := range []string{"--workspace-backend", "workspace.backend", envWorkspaceBackend, "docker default"} {
+	for _, want := range []string{"loaded contract execution capability", "--workspace-backend", "workspace.backend", envWorkspaceBackend} {
 		if !stringSliceContains(authority.SourceOrder, want) {
 			t.Fatalf("workspace backend order missing %q: %#v", want, authority.SourceOrder)
 		}
 	}
-	if authority.DefaultBackend != workspace.BackendDocker {
-		t.Fatalf("workspace backend default = %q, want docker", authority.DefaultBackend)
+	if authority.DefaultBackend != "capability-derived" {
+		t.Fatalf("workspace backend default = %q, want capability-derived", authority.DefaultBackend)
+	}
+	for _, want := range []string{"none", "workspace_write", "exec"} {
+		if _, ok := authority.CapabilityClasses[want]; !ok {
+			t.Fatalf("workspace backend capability class %q missing: %#v", want, authority.CapabilityClasses)
+		}
+	}
+	noneBackend, ok := authority.Backends[workspaceBackendNone]
+	if !ok || !strings.Contains(noneBackend.Behavior, "No workspace lifecycle") || !strings.Contains(noneBackend.Behavior, "forkchat") {
+		t.Fatalf("none backend spec missing no-workspace forkchat behavior: %#v", authority.Backends)
 	}
 	dockerBackend, ok := authority.Backends[workspace.BackendDocker]
-	if !ok || !strings.Contains(dockerBackend.Behavior, "Docker fail-closed") || !strings.Contains(dockerBackend.Behavior, "configured workspace image") {
+	if !ok || !strings.Contains(dockerBackend.Behavior, "exec-capable") || !strings.Contains(dockerBackend.Behavior, "configured workspace image") {
 		t.Fatalf("docker backend spec missing default fail-closed behavior: %#v", authority.Backends)
 	}
 	hostBackend, ok := authority.Backends[workspace.BackendHost]
-	if !ok || !strings.Contains(hostBackend.Behavior, "Explicit local-dev opt-in") || !strings.Contains(hostBackend.Behavior, "MUST NOT require Docker") {
+	if !ok || !strings.Contains(hostBackend.Behavior, "workspace.allow_exec_on_host") || !strings.Contains(hostBackend.Behavior, "MUST NOT require Docker") {
 		t.Fatalf("host backend spec missing local-dev no-Docker behavior: %#v", authority.Backends)
 	}
 	if hostBackend.WorkspaceRoot.EnvVar != workspace.EnvHostWorkspaceRoot || hostBackend.WorkspaceRoot.Default != "~/.swarm/workspaces" {
@@ -2392,12 +2406,12 @@ func TestPlatformSpecWorkspaceBackendSelectionPromoted(t *testing.T) {
 			t.Fatalf("host workspace root rule missing %q:\n%s", want, hostBackend.WorkspaceRoot.Rule)
 		}
 	}
-	for _, want := range []string{"Unsupported backend", "Empty explicit backend", "SWARM_WORKSPACE_VOLUMES_FROM", "Claude CLI", "native tool execution"} {
+	for _, want := range []string{"Unsupported backend", "Empty explicit backend", "SWARM_WORKSPACE_VOLUMES_FROM", "Claude CLI", "SWARM_WORKSPACE_BACKEND=host", "conversation.fork_chat", "native command execution"} {
 		if !joinedContains(authority.FailureBehavior, want) {
 			t.Fatalf("workspace backend failure behavior missing %q: %#v", want, authority.FailureBehavior)
 		}
 	}
-	for _, want := range []string{"serve boot", "Builder project reload", "selected-contract run-fork"} {
+	for _, want := range []string{"serve boot", "run start", "Builder project reload", "selected-contract run-fork", "swarm verify", "swarm describe", "swarm doctor", "conversation.fork_chat"} {
 		if !joinedContains(authority.Consumers, want) {
 			t.Fatalf("workspace backend consumers missing %q: %#v", want, authority.Consumers)
 		}
@@ -2411,10 +2425,10 @@ func TestPlatformSpecWorkspaceBackendSelectionPromoted(t *testing.T) {
 	if command.PromotedBy != "#1138" || command.Owner != "workspace_model.workspace_backend_selection" || command.Flag != "--workspace-backend <docker|host>" {
 		t.Fatalf("serve command workspace backend authority = %#v", command)
 	}
-	if command.ConfigKey != "workspace.backend" || command.EnvVar != envWorkspaceBackend || command.DefaultBackend != workspace.BackendDocker {
+	if command.ConfigKey != "workspace.backend" || command.UnsafeConfigKey != "workspace.allow_exec_on_host" || command.LegacyEnvVar != envWorkspaceBackend || command.DefaultBackend != "capability-derived" {
 		t.Fatalf("serve command workspace backend selectors = %#v", command)
 	}
-	for _, want := range []string{"serve boot", "Builder project reload", "selected-contract run-fork"} {
+	for _, want := range []string{"serve boot", "run start", "Builder project reload", "selected-contract run-fork", "verify/describe/doctor", "conversation.fork_chat"} {
 		if !joinedContains(command.Consumers, want) {
 			t.Fatalf("serve command workspace backend consumers missing %q: %#v", want, command.Consumers)
 		}
@@ -6202,6 +6216,36 @@ func TestRunServeRuntimeHostWorkspaceBackendBootsWithoutDockerForSystemOnlyFlow(
 	}
 	if strings.Contains(serve.outputString(), "workspace image") || strings.Contains(serve.outputString(), "docker is not available") {
 		t.Fatalf("host workspace serve output shows Docker dependency despite host backend:\n%s", serve.outputString())
+	}
+}
+
+func TestRunServeRuntimeNoAgentDefaultBootsWithoutDocker(t *testing.T) {
+	t.Setenv("SWARM_DOCKER_BIN", filepath.Join(t.TempDir(), "missing-docker"))
+	t.Setenv(storebackend.EnvSQLitePath, filepath.Join(t.TempDir(), "runtime.db"))
+
+	serve := startServeRuntimeTestProcess(t, serveOptions{
+		ConfigPath:           writeServeRuntimeTestConfig(t),
+		ContractsPath:        filepath.Join("tests", "tier1-primitives", "test-emits-single"),
+		DataSource:           t.TempDir(),
+		PlatformSpecPath:     defaultPlatformSpecPath,
+		StoreMode:            storebackend.ActiveDefaultBackend().String(),
+		APIListenAddr:        "127.0.0.1:0",
+		MCPListenAddr:        "127.0.0.1:0",
+		SelfCheck:            true,
+		RequireBundleMatch:   false,
+		ShutdownGrace:        runtimepkg.DefaultShutdownGrace,
+		Verbose:              true,
+		NoRequireBundleMatch: true,
+	})
+	serve.waitForReadyLine()
+	if code := serve.stop(); code != 0 {
+		t.Fatalf("runServeRuntime code = %d\noutput:\n%s", code, serve.outputString())
+	}
+	if !strings.Contains(serve.outputString(), "workspace backend: none") {
+		t.Fatalf("serve output missing no-workspace decision:\n%s", serve.outputString())
+	}
+	if strings.Contains(serve.outputString(), "workspace image") || strings.Contains(serve.outputString(), "docker is not available") {
+		t.Fatalf("no-agent serve output shows Docker dependency despite no-workspace decision:\n%s", serve.outputString())
 	}
 }
 

--- a/cmd/swarm/main_test.go
+++ b/cmd/swarm/main_test.go
@@ -6249,6 +6249,74 @@ func TestRunServeRuntimeNoAgentDefaultBootsWithoutDocker(t *testing.T) {
 	}
 }
 
+func TestRunServeRuntimeAPIAgentDefaultHostBootsWithoutDocker(t *testing.T) {
+	t.Setenv("SWARM_DOCKER_BIN", filepath.Join(t.TempDir(), "missing-docker"))
+	t.Setenv("SWARM_WORKSPACE_HOST_ROOT", filepath.Join(t.TempDir(), "host-workspaces"))
+	t.Setenv(storebackend.EnvSQLitePath, filepath.Join(t.TempDir(), "runtime.db"))
+
+	serve := startServeRuntimeTestProcess(t, serveOptions{
+		ConfigPath:           writeServeRuntimeTestConfig(t),
+		ContractsPath:        writeServeRuntimeAgentSlugFixture(t, "api-agent-host-default", "api-worker"),
+		DataSource:           t.TempDir(),
+		PlatformSpecPath:     defaultPlatformSpecPath,
+		StoreMode:            storebackend.ActiveDefaultBackend().String(),
+		APIListenAddr:        "127.0.0.1:0",
+		MCPListenAddr:        "127.0.0.1:0",
+		SelfCheck:            true,
+		RequireBundleMatch:   false,
+		ShutdownGrace:        runtimepkg.DefaultShutdownGrace,
+		Verbose:              true,
+		NoRequireBundleMatch: true,
+		TestLLMRuntime:       runtimellm.NoopRuntime{},
+	})
+	serve.waitForReadyLine()
+	if code := serve.stop(); code != 0 {
+		t.Fatalf("runServeRuntime code = %d\noutput:\n%s", code, serve.outputString())
+	}
+	output := serve.outputString()
+	if !strings.Contains(output, "workspace backend: host") {
+		t.Fatalf("serve output missing host workspace decision for API-backed agent:\n%s", output)
+	}
+	if strings.Contains(strings.ToLower(output), "docker is not available") {
+		t.Fatalf("API-backed agent serve output shows Docker dependency despite host decision:\n%s", output)
+	}
+}
+
+func TestRunServeRuntimeNativeBashDefaultDockerFailsWithoutDocker(t *testing.T) {
+	t.Setenv("SWARM_DOCKER_BIN", filepath.Join(t.TempDir(), "missing-docker"))
+	t.Setenv(storebackend.EnvSQLitePath, filepath.Join(t.TempDir(), "runtime.db"))
+
+	var out lockedBuffer
+	code := runServeRuntime(context.Background(), repoRoot(), serveOptions{
+		ConfigPath:           writeServeRuntimeTestConfig(t),
+		ContractsPath:        writeServeRuntimeNativeBashFixture(t),
+		DataSource:           t.TempDir(),
+		PlatformSpecPath:     defaultPlatformSpecPath,
+		StoreMode:            storebackend.ActiveDefaultBackend().String(),
+		APIListenAddr:        "127.0.0.1:0",
+		MCPListenAddr:        "127.0.0.1:0",
+		SelfCheck:            true,
+		RequireBundleMatch:   false,
+		ShutdownGrace:        runtimepkg.DefaultShutdownGrace,
+		Verbose:              true,
+		NoRequireBundleMatch: true,
+		TestLLMRuntime:       runtimellm.NoopRuntime{},
+		Output:               &out,
+	})
+	if code == 0 {
+		t.Fatalf("runServeRuntime code = 0, want Docker prerequisite failure\noutput:\n%s", out.String())
+	}
+	output := out.String()
+	for _, want := range []string{"[5/22] runtime_context", "workspace backend: docker", "native_tools.bash", "docker is not available"} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("serve output missing %q:\n%s", want, output)
+		}
+	}
+	if strings.Contains(output, "[22/22] ready") {
+		t.Fatalf("native bash serve reached readiness despite missing Docker:\n%s", output)
+	}
+}
+
 func TestRunServeRuntimeFreshEmptyPostgresBootstrapsSchemaBeforeDiskContractsServe(t *testing.T) {
 	_, db, _ := installServeRuntimeEmptyPostgresTestStores(t, func() serveWorkspaceLifecycle {
 		return serveRuntimeWorkspaceStub{}
@@ -10308,6 +10376,24 @@ agent.requested:
   subscriptions: [agent.requested]
 `, agentKey, agentID, agentID, agentID))
 	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "prompts", agentID+".md"), "Handle assigned work.\n")
+	return root
+}
+
+func writeServeRuntimeNativeBashFixture(t *testing.T) string {
+	t.Helper()
+	const agentID = "native-bash-worker"
+	root := writeServeRuntimeAgentSlugFixture(t, "native-bash-docker-required", agentID)
+	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "agents.yaml"), fmt.Sprintf(`
+%s:
+  id: %s
+  role: %s
+  prompt_ref: %s
+  model: regular
+  mode: task
+  native_tools:
+    bash: true
+  subscriptions: [agent.requested]
+`, agentID, agentID, agentID, agentID))
 	return root
 }
 

--- a/cmd/swarm/workspace_backend.go
+++ b/cmd/swarm/workspace_backend.go
@@ -3,20 +3,41 @@ package main
 import (
 	"fmt"
 	"os"
+	"sort"
 	"strings"
 
 	"github.com/division-sh/swarm/internal/config"
+	llmselection "github.com/division-sh/swarm/internal/runtime/llm/selection"
+	"github.com/division-sh/swarm/internal/runtime/semanticview"
 	workspace "github.com/division-sh/swarm/internal/runtime/workspace"
 )
 
 const (
-	envWorkspaceBackend     = "SWARM_WORKSPACE_BACKEND"
-	defaultWorkspaceBackend = workspace.BackendDocker
+	envWorkspaceBackend = "SWARM_WORKSPACE_BACKEND"
+
+	workspaceBackendNone = "none"
+)
+
+type workspaceCapabilityClass string
+
+const (
+	workspaceCapabilityNone           workspaceCapabilityClass = "none"
+	workspaceCapabilityWorkspaceWrite workspaceCapabilityClass = "workspace_write"
+	workspaceCapabilityExec           workspaceCapabilityClass = "exec"
 )
 
 type workspaceBackendSelection struct {
 	Backend string
 	Source  string
+
+	PreferenceExplicit bool
+	AllowExecOnHost    bool
+	NoWorkspace        bool
+	UnsafeHost         bool
+
+	CapabilityClass workspaceCapabilityClass
+	Reasons         []string
+	HostUnsupported []string
 }
 
 type workspaceBackendInput struct {
@@ -28,34 +49,67 @@ type workspaceBackendInput struct {
 
 	EnvBackend string
 	EnvSet     bool
+
+	AllowExecOnHost bool
 }
 
 func resolveWorkspaceBackend(flagBackend string, flagSet bool, cfg *config.Config) (workspaceBackendSelection, error) {
 	envBackend, envSet := os.LookupEnv(envWorkspaceBackend)
 	configBackend, configSet := runtimeConfigWorkspaceBackend(cfg)
 	return resolveWorkspaceBackendFromInput(workspaceBackendInput{
-		FlagBackend:   flagBackend,
-		FlagSet:       flagSet,
-		ConfigBackend: configBackend,
-		ConfigSet:     configSet,
-		EnvBackend:    envBackend,
-		EnvSet:        envSet,
+		FlagBackend:     flagBackend,
+		FlagSet:         flagSet,
+		ConfigBackend:   configBackend,
+		ConfigSet:       configSet,
+		EnvBackend:      envBackend,
+		EnvSet:          envSet,
+		AllowExecOnHost: runtimeConfigAllowExecOnHost(cfg),
 	})
+}
+
+func resolveWorkspaceBackendDecision(flagBackend string, flagSet bool, cfg *config.Config, source semanticview.Source) (workspaceBackendSelection, error) {
+	preference, err := resolveWorkspaceBackend(flagBackend, flagSet, cfg)
+	if err != nil {
+		return preference, err
+	}
+	return decideWorkspaceBackend(preference, cfg, source)
+}
+
+func resolveWorkspaceBackendDiagnostic(repo string, source semanticview.Source) (workspaceBackendSelection, error) {
+	cfgResult, err := loadRuntimeConfigWithOptions(runtimeConfigLoadOptions{RepoRoot: repo})
+	if err != nil {
+		return workspaceBackendSelection{}, err
+	}
+	return resolveWorkspaceBackendDecision("", false, cfgResult.Config, source)
 }
 
 func resolveWorkspaceBackendFromInput(in workspaceBackendInput) (workspaceBackendSelection, error) {
 	switch {
 	case in.FlagSet:
 		backend, err := normalizeWorkspaceBackend(in.FlagBackend, "--workspace-backend")
-		return workspaceBackendSelection{Backend: backend, Source: "--workspace-backend"}, err
+		return workspaceBackendSelection{
+			Backend:            backend,
+			Source:             "--workspace-backend",
+			PreferenceExplicit: true,
+			AllowExecOnHost:    strings.EqualFold(backend, workspace.BackendHost),
+		}, err
 	case in.ConfigSet:
 		backend, err := normalizeWorkspaceBackend(in.ConfigBackend, "workspace.backend")
-		return workspaceBackendSelection{Backend: backend, Source: "workspace.backend"}, err
+		return workspaceBackendSelection{
+			Backend:            backend,
+			Source:             "workspace.backend",
+			PreferenceExplicit: true,
+			AllowExecOnHost:    in.AllowExecOnHost,
+		}, err
 	case in.EnvSet:
 		backend, err := normalizeWorkspaceBackend(in.EnvBackend, envWorkspaceBackend)
-		return workspaceBackendSelection{Backend: backend, Source: envWorkspaceBackend}, err
+		return workspaceBackendSelection{
+			Backend:            backend,
+			Source:             envWorkspaceBackend,
+			PreferenceExplicit: true,
+		}, err
 	default:
-		return workspaceBackendSelection{Backend: defaultWorkspaceBackend, Source: "default"}, nil
+		return workspaceBackendSelection{Source: "capability-derived"}, nil
 	}
 }
 
@@ -64,6 +118,10 @@ func runtimeConfigWorkspaceBackend(cfg *config.Config) (string, bool) {
 		return "", false
 	}
 	return cfg.Workspace.Backend, cfg.Workspace.BackendConfigured()
+}
+
+func runtimeConfigAllowExecOnHost(cfg *config.Config) bool {
+	return cfg != nil && cfg.Workspace.AllowExecOnHost
 }
 
 func normalizeWorkspaceBackend(raw string, source string) (string, error) {
@@ -77,4 +135,175 @@ func normalizeWorkspaceBackend(raw string, source string) (string, error) {
 	default:
 		return "", fmt.Errorf("workspace backend from %s must be docker or host, got %q", source, strings.TrimSpace(raw))
 	}
+}
+
+func decideWorkspaceBackend(preference workspaceBackendSelection, cfg *config.Config, source semanticview.Source) (workspaceBackendSelection, error) {
+	class, reasons, hostUnsupported, err := classifyWorkspaceBackendRequirement(cfg, source)
+	if err != nil {
+		return preference, err
+	}
+	decision := preference
+	decision.CapabilityClass = class
+	decision.Reasons = reasons
+	decision.HostUnsupported = hostUnsupported
+
+	switch class {
+	case workspaceCapabilityNone:
+		if decision.Backend == "" {
+			decision.Backend = workspaceBackendNone
+			decision.NoWorkspace = true
+			decision.Source = "capability-derived"
+		}
+	case workspaceCapabilityWorkspaceWrite:
+		if decision.Backend == "" {
+			decision.Backend = workspace.BackendHost
+			decision.Source = "capability-derived"
+		}
+	case workspaceCapabilityExec:
+		if decision.Backend == "" {
+			decision.Backend = workspace.BackendDocker
+			decision.Source = "capability-derived"
+			break
+		}
+		if decision.Backend == workspace.BackendHost {
+			if len(hostUnsupported) > 0 {
+				return decision, fmt.Errorf("workspace backend host is unsupported for this exec-capable contract: %s; use Docker", strings.Join(hostUnsupported, "; "))
+			}
+			if !decision.AllowExecOnHost {
+				switch decision.Source {
+				case "--workspace-backend":
+					decision.AllowExecOnHost = true
+				case "workspace.backend":
+					return decision, fmt.Errorf("workspace.backend: host grants agent execution on this machine for %s; set workspace.allow_exec_on_host: true or use Docker", workspaceBackendReasonSummary(reasons))
+				default:
+					return decision, fmt.Errorf("%s=host cannot authorize unsafe host execution for %s; use --workspace-backend host for one command or workspace.backend: host with workspace.allow_exec_on_host: true", envWorkspaceBackend, workspaceBackendReasonSummary(reasons))
+				}
+			}
+			decision.UnsafeHost = true
+		}
+	}
+	return decision, nil
+}
+
+func classifyWorkspaceBackendRequirement(cfg *config.Config, source semanticview.Source) (workspaceCapabilityClass, []string, []string, error) {
+	if cfg == nil {
+		return "", nil, nil, fmt.Errorf("runtime config is required")
+	}
+	if source == nil {
+		return "", nil, nil, fmt.Errorf("semantic source is required")
+	}
+	profile, err := cfg.LLMBackendProfile()
+	if err != nil {
+		return "", nil, nil, err
+	}
+	entries := source.AgentEntries()
+	if len(entries) == 0 {
+		return workspaceCapabilityNone, []string{"selected contract source declares no agents"}, nil, nil
+	}
+
+	agentIDs := make([]string, 0, len(entries))
+	for id := range entries {
+		agentIDs = append(agentIDs, strings.TrimSpace(id))
+	}
+	sort.Strings(agentIDs)
+
+	class := workspaceCapabilityWorkspaceWrite
+	reasons := []string{"declared agents use runtime-mediated workspace lifecycle"}
+	hostUnsupported := []string{}
+	for _, agentID := range agentIDs {
+		entry := entries[agentID]
+		label := workspaceBackendAgentLabel(agentID, entry.ID, entry.Role)
+		if profile.ID == llmselection.BackendClaudeCLI {
+			class = workspaceCapabilityExec
+			reasons = append(reasons, fmt.Sprintf("agent %s uses claude_cli backend", label))
+			hostUnsupported = append(hostUnsupported, fmt.Sprintf("agent %s uses claude_cli backend", label))
+		}
+		if nativeToolEnabled(entry.NativeTools, "bash") {
+			class = workspaceCapabilityExec
+			reasons = append(reasons, fmt.Sprintf("agent %s has native_tools.bash", label))
+		}
+		for _, tool := range entry.ConfiguredTools() {
+			if workspaceExecClassTool(tool) {
+				class = workspaceCapabilityExec
+				reasons = append(reasons, fmt.Sprintf("agent %s has exec-class tool %s", label, strings.TrimSpace(tool)))
+			}
+		}
+		if class != workspaceCapabilityExec && nativeToolEnabled(entry.NativeTools, "file_io") {
+			reasons = append(reasons, fmt.Sprintf("agent %s has native_tools.file_io", label))
+		}
+	}
+	return class, uniqueNonEmptyStrings(reasons), uniqueNonEmptyStrings(hostUnsupported), nil
+}
+
+func nativeToolEnabled(raw map[string]any, name string) bool {
+	value, ok := raw[strings.TrimSpace(name)]
+	if !ok {
+		return false
+	}
+	enabled, ok := value.(bool)
+	return ok && enabled
+}
+
+func workspaceExecClassTool(raw string) bool {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "bash", "shell", "code_execution", "code-execution", "native_command":
+		return true
+	default:
+		return false
+	}
+}
+
+func workspaceBackendAgentLabel(parts ...string) string {
+	for _, part := range parts {
+		if part = strings.TrimSpace(part); part != "" {
+			return part
+		}
+	}
+	return "<unknown>"
+}
+
+func workspaceBackendReasonSummary(reasons []string) string {
+	if len(reasons) == 0 {
+		return "the selected contract"
+	}
+	return strings.Join(reasons, "; ")
+}
+
+func workspaceBackendDecisionDetail(decision workspaceBackendSelection) string {
+	backend := strings.TrimSpace(decision.Backend)
+	if backend == workspaceBackendNone || decision.NoWorkspace {
+		backend = "none"
+	}
+	if backend == "" {
+		backend = "unknown"
+	}
+	reason := workspaceBackendReasonSummary(decision.Reasons)
+	if decision.UnsafeHost {
+		return fmt.Sprintf("workspace backend: %s (%s); UNSAFE: grants the agent execution on this machine", backend, reason)
+	}
+	return fmt.Sprintf("workspace backend: %s (%s)", backend, reason)
+}
+
+func workspaceBackendUnsafeWarning(decision workspaceBackendSelection) string {
+	if !decision.UnsafeHost {
+		return ""
+	}
+	return fmt.Sprintf("UNSAFE: grants the agent execution on this machine via workspace backend host (%s)", workspaceBackendReasonSummary(decision.Reasons))
+}
+
+func uniqueNonEmptyStrings(values []string) []string {
+	seen := map[string]struct{}{}
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		out = append(out, value)
+	}
+	return out
 }

--- a/cmd/swarm/workspace_backend_decision_test.go
+++ b/cmd/swarm/workspace_backend_decision_test.go
@@ -1,0 +1,186 @@
+package main
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/division-sh/swarm/internal/config"
+	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
+	llmselection "github.com/division-sh/swarm/internal/runtime/llm/selection"
+	"github.com/division-sh/swarm/internal/runtime/semanticview"
+	workspace "github.com/division-sh/swarm/internal/runtime/workspace"
+	"github.com/division-sh/swarm/internal/store"
+)
+
+func TestWorkspaceBackendDecisionCapabilityMatrix(t *testing.T) {
+	tests := []struct {
+		name          string
+		cfg           *config.Config
+		agents        map[string]runtimecontracts.AgentRegistryEntry
+		preference    workspaceBackendSelection
+		wantBackend   string
+		wantClass     workspaceCapabilityClass
+		wantNo        bool
+		wantUnsafe    bool
+		wantErr       string
+		wantHostBlock string
+	}{
+		{
+			name:        "no agents defaults to no workspace lifecycle",
+			cfg:         testWorkspaceBackendConfig(llmselection.BackendOpenAIResponses),
+			wantBackend: workspaceBackendNone,
+			wantClass:   workspaceCapabilityNone,
+			wantNo:      true,
+		},
+		{
+			name: "api backed agents default to host workspace",
+			cfg:  testWorkspaceBackendConfig(llmselection.BackendOpenAIResponses),
+			agents: map[string]runtimecontracts.AgentRegistryEntry{
+				"worker": {ID: "worker"},
+			},
+			wantBackend: workspace.BackendHost,
+			wantClass:   workspaceCapabilityWorkspaceWrite,
+		},
+		{
+			name: "file io stays host workspace write",
+			cfg:  testWorkspaceBackendConfig(llmselection.BackendOpenAIResponses),
+			agents: map[string]runtimecontracts.AgentRegistryEntry{
+				"worker": {ID: "worker", NativeTools: map[string]any{"file_io": true}},
+			},
+			wantBackend: workspace.BackendHost,
+			wantClass:   workspaceCapabilityWorkspaceWrite,
+		},
+		{
+			name: "native bash defaults to docker",
+			cfg:  testWorkspaceBackendConfig(llmselection.BackendOpenAIResponses),
+			agents: map[string]runtimecontracts.AgentRegistryEntry{
+				"worker": {ID: "worker", NativeTools: map[string]any{"bash": true}},
+			},
+			wantBackend: workspace.BackendDocker,
+			wantClass:   workspaceCapabilityExec,
+		},
+		{
+			name: "claude cli defaults to docker and marks host unsupported",
+			cfg:  testWorkspaceBackendConfig(llmselection.BackendClaudeCLI),
+			agents: map[string]runtimecontracts.AgentRegistryEntry{
+				"worker": {ID: "worker"},
+			},
+			wantBackend:   workspace.BackendDocker,
+			wantClass:     workspaceCapabilityExec,
+			wantHostBlock: "claude_cli",
+		},
+		{
+			name: "flag host is loud unsafe opt out for host supported exec",
+			cfg:  testWorkspaceBackendConfig(llmselection.BackendOpenAIResponses),
+			agents: map[string]runtimecontracts.AgentRegistryEntry{
+				"worker": {ID: "worker", NativeTools: map[string]any{"bash": true}},
+			},
+			preference:  workspaceBackendSelection{Backend: workspace.BackendHost, Source: "--workspace-backend", PreferenceExplicit: true, AllowExecOnHost: true},
+			wantBackend: workspace.BackendHost,
+			wantClass:   workspaceCapabilityExec,
+			wantUnsafe:  true,
+		},
+		{
+			name: "config host needs explicit unsafe allow for exec",
+			cfg:  testWorkspaceBackendConfig(llmselection.BackendOpenAIResponses),
+			agents: map[string]runtimecontracts.AgentRegistryEntry{
+				"worker": {ID: "worker", NativeTools: map[string]any{"bash": true}},
+			},
+			preference: workspaceBackendSelection{Backend: workspace.BackendHost, Source: "workspace.backend", PreferenceExplicit: true},
+			wantErr:    "workspace.allow_exec_on_host",
+		},
+		{
+			name: "config host with unsafe allow is accepted for host supported exec",
+			cfg:  testWorkspaceBackendConfig(llmselection.BackendOpenAIResponses),
+			agents: map[string]runtimecontracts.AgentRegistryEntry{
+				"worker": {ID: "worker", NativeTools: map[string]any{"bash": true}},
+			},
+			preference:  workspaceBackendSelection{Backend: workspace.BackendHost, Source: "workspace.backend", PreferenceExplicit: true, AllowExecOnHost: true},
+			wantBackend: workspace.BackendHost,
+			wantClass:   workspaceCapabilityExec,
+			wantUnsafe:  true,
+		},
+		{
+			name: "legacy env host cannot authorize unsafe exec",
+			cfg:  testWorkspaceBackendConfig(llmselection.BackendOpenAIResponses),
+			agents: map[string]runtimecontracts.AgentRegistryEntry{
+				"worker": {ID: "worker", NativeTools: map[string]any{"bash": true}},
+			},
+			preference: workspaceBackendSelection{Backend: workspace.BackendHost, Source: envWorkspaceBackend, PreferenceExplicit: true},
+			wantErr:    "cannot authorize unsafe host execution",
+		},
+		{
+			name: "claude cli host remains split even with unsafe allow",
+			cfg:  testWorkspaceBackendConfig(llmselection.BackendClaudeCLI),
+			agents: map[string]runtimecontracts.AgentRegistryEntry{
+				"worker": {ID: "worker"},
+			},
+			preference: workspaceBackendSelection{Backend: workspace.BackendHost, Source: "--workspace-backend", PreferenceExplicit: true, AllowExecOnHost: true},
+			wantErr:    "claude_cli",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			decision, err := decideWorkspaceBackend(tt.preference, tt.cfg, semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{Agents: tt.agents}))
+			if tt.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("decideWorkspaceBackend error = %v, want containing %q", err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("decideWorkspaceBackend: %v", err)
+			}
+			if decision.Backend != tt.wantBackend || decision.CapabilityClass != tt.wantClass || decision.NoWorkspace != tt.wantNo || decision.UnsafeHost != tt.wantUnsafe {
+				t.Fatalf("decision = %#v, want backend=%s class=%s no=%v unsafe=%v", decision, tt.wantBackend, tt.wantClass, tt.wantNo, tt.wantUnsafe)
+			}
+			if tt.wantHostBlock != "" && !joinedContains(decision.HostUnsupported, tt.wantHostBlock) {
+				t.Fatalf("host unsupported = %#v, want %q", decision.HostUnsupported, tt.wantHostBlock)
+			}
+		})
+	}
+}
+
+func TestConfiguredWorkspaceLifecycleForBackendNoWorkspace(t *testing.T) {
+	lifecycle, err := configuredWorkspaceLifecycleForBackend(nil, "", semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{}), workspaceMountSources{}, workspaceBackendSelection{Backend: workspaceBackendNone, Source: "capability-derived", NoWorkspace: true})
+	if err != nil {
+		t.Fatalf("configuredWorkspaceLifecycleForBackend: %v", err)
+	}
+	if lifecycle != nil {
+		t.Fatalf("lifecycle = %#v, want nil for no-workspace decision", lifecycle)
+	}
+}
+
+func TestWorkspaceAdmittedForkChatExecutorRejectsClaudeCLIWithoutDocker(t *testing.T) {
+	executor := newWorkspaceAdmittedForkChatExecutor(recordingForkChatExecutor{}, testWorkspaceBackendConfig(llmselection.BackendClaudeCLI), workspaceBackendSelection{Backend: workspaceBackendNone, NoWorkspace: true})
+	_, err := executor.ExecuteForkChat(context.Background(), store.ConversationForkChatPrepared{}, "inspect")
+	if err == nil || !strings.Contains(err.Error(), "conversation.fork_chat") || !strings.Contains(err.Error(), "claude_cli") {
+		t.Fatalf("ExecuteForkChat error = %v, want forkchat claude_cli admission failure", err)
+	}
+}
+
+func TestWorkspaceAdmittedForkChatExecutorAllowsAPIBackend(t *testing.T) {
+	inner := recordingForkChatExecutor{result: store.ConversationForkChatExecution{AssistantMessage: "ok"}}
+	executor := newWorkspaceAdmittedForkChatExecutor(inner, testWorkspaceBackendConfig(llmselection.BackendOpenAIResponses), workspaceBackendSelection{Backend: workspaceBackendNone, NoWorkspace: true})
+	got, err := executor.ExecuteForkChat(context.Background(), store.ConversationForkChatPrepared{}, "inspect")
+	if err != nil {
+		t.Fatalf("ExecuteForkChat: %v", err)
+	}
+	if got.AssistantMessage != "ok" {
+		t.Fatalf("ExecuteForkChat result = %#v, want inner executor result", got)
+	}
+}
+
+type recordingForkChatExecutor struct {
+	result store.ConversationForkChatExecution
+}
+
+func (r recordingForkChatExecutor) ExecuteForkChat(context.Context, store.ConversationForkChatPrepared, string) (store.ConversationForkChatExecution, error) {
+	return r.result, nil
+}
+
+func testWorkspaceBackendConfig(backend string) *config.Config {
+	return &config.Config{LLM: config.LLMConfig{Backend: backend}}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -64,11 +64,13 @@ type StoreSQLiteConfig struct {
 }
 
 type WorkspaceConfig struct {
-	DataSource string `yaml:"data_source"`
-	Backend    string `yaml:"backend"`
+	DataSource      string `yaml:"data_source"`
+	Backend         string `yaml:"backend"`
+	AllowExecOnHost bool   `yaml:"allow_exec_on_host"`
 
-	dataSourceSet bool
-	backendSet    bool
+	dataSourceSet      bool
+	backendSet         bool
+	allowExecOnHostSet bool
 }
 
 func (w *WorkspaceConfig) UnmarshalYAML(value *yaml.Node) error {
@@ -85,6 +87,8 @@ func (w *WorkspaceConfig) UnmarshalYAML(value *yaml.Node) error {
 				w.dataSourceSet = true
 			case "backend":
 				w.backendSet = true
+			case "allow_exec_on_host":
+				w.allowExecOnHostSet = true
 			}
 		}
 	}
@@ -97,6 +101,10 @@ func (w WorkspaceConfig) DataSourceConfigured() bool {
 
 func (w WorkspaceConfig) BackendConfigured() bool {
 	return w.backendSet || strings.TrimSpace(w.Backend) != ""
+}
+
+func (w WorkspaceConfig) AllowExecOnHostConfigured() bool {
+	return w.allowExecOnHostSet || w.AllowExecOnHost
 }
 
 type LLMConfig struct {

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -11518,36 +11518,70 @@ workspace_model:
     - mount destination override semantics such as SWARM_WORKSPACE_DATA_MOUNT
   workspace_backend_selection:
     promoted_by: '#1138'
-    implementation_status: implemented_first_slice
+    implementation_status: implemented_capability_driven_first_slice
     canonical_owner: platform-spec.yaml#workspace_model.workspace_backend_selection
     scope: >
-      Defines the workspace backend selector for `swarm serve` boot, dynamic Builder project reload, and selected-contract
-      run-fork lifecycle consumers. The selector chooses either the existing Docker workspace lifecycle or the explicit
-      host local-dev lifecycle; it does not make host execution behavior equivalent to Docker isolation.
+      Defines the capability-derived effective workspace backend requirement for `swarm serve` boot, dynamic Builder project
+      reload, selected-contract run-fork lifecycle consumers, local foreground `swarm run start`, `swarm doctor`, `swarm
+      verify`, `swarm describe`, and the `conversation.fork_chat` sandbox runtime. The loaded contract and effective runtime
+      backend decide whether a workspace is needed, whether host is sufficient, or whether container isolation is required.
+      Operator backend input is a preference or explicit unsafe opt-out; it is not the semantic source of the requirement.
     cli_flag: --workspace-backend <docker|host>
     config_key: workspace.backend
-    env_var: SWARM_WORKSPACE_BACKEND
+    unsafe_config_key: workspace.allow_exec_on_host
+    legacy_env_var: SWARM_WORKSPACE_BACKEND
     source_order:
-    - --workspace-backend
-    - workspace.backend
-    - SWARM_WORKSPACE_BACKEND
-    - docker default
-    default_backend: docker
+    - loaded contract execution capability
+    - --workspace-backend preference / unsafe host opt-out
+    - workspace.backend preference plus workspace.allow_exec_on_host for persistent unsafe host opt-out
+    - SWARM_WORKSPACE_BACKEND legacy preference, not unsafe opt-out authority
+    default_backend: capability-derived
+    capability_classes:
+      none:
+        rule: No declared agents require no workspace lifecycle by default and MUST boot with zero Docker/workspace external dependencies.
+      workspace_write:
+        rule: >
+          Runtime-mediated agents or agents with `native_tools.file_io` but no process-spawning capability use the host
+          lifecycle by default. Host file operations remain scoped by `workspace_execution_target_capability`.
+      exec:
+        rule: >
+          Any agent whose effective backend spawns a local process (`claude_cli`) or that is granted an exec-class capability
+          such as `native_tools.bash` requires Docker by default. The first slice is coarse any-exec => Docker; per-agent
+          backend selection remains split.
+    decision_table:
+      - contents: no declared agents
+        backend: none
+        posture: zero external dependencies unless the operator explicitly requests docker or host for diagnostics/setup
+      - contents: API/runtime-mediated agents with no exec-class tools
+        backend: host
+        posture: default and silent
+      - contents: anything exec-capable
+        backend: docker_required
+        posture: >
+          Docker missing fails closed at the `runtime_context` boot step with doctor-format remediation naming the
+          exec-capable agent/capability. Host is allowed only through explicit loud unsafe opt-out.
     backends:
+      none:
+        behavior: >
+          No workspace lifecycle is constructed. Runtime boot and forkchat wiring MUST NOT require Docker only because the
+          API exposes a potential forkchat executor. If a later API operation reaches a workspace-required path, it fails
+          closed through this owner instead of falling back to Docker, host cwd, or nil workspace behavior.
       docker:
         behavior: >
-          Default workspace backend. Startup preserves the existing Docker fail-closed checks for the configured workspace
+          Required backend for exec-capable bundles unless unsafe host opt-out is accepted, and allowed as an explicit
+          operator preference for non-exec diagnostics/setup. Startup preserves the existing Docker fail-closed checks for the configured workspace
           image, Docker binary availability, Docker network, container creation, mounted `/data`, mounted contracts, and
           managed container lifecycle.
       host:
         behavior: >
-          Explicit local-dev opt-in. Startup consumes the selected `/data` source from
+          Default backend for non-exec agent bundles and explicit local-dev/trusted opt-in where accepted. Startup consumes the selected `/data` source from
           `workspace_model.data_source_authority`, the loaded contracts source, and a platform-managed host workspace root.
           It MUST NOT require Docker, build Docker images, or create containers. It supports trusted/unsafe native command
-          execution only through `workspace_execution_target_capability` after explicit host backend selection and actor
+          execution only through `workspace_execution_target_capability` after explicit unsafe host opt-out and actor
           `native_tools.bash` authorization. Host native command execution is full host-user shell execution and must not be
           command-filtered by the runtime. It MUST fail closed for unsupported execution surfaces until those host execution
-          semantics are explicitly promoted.
+          semantics are explicitly promoted. `workspace.backend: host` alone is insufficient for exec-capable bundles; it
+          must be paired with `workspace.allow_exec_on_host: true` and the runtime must print a loud warning every boot.
         workspace_root:
           env_var: SWARM_WORKSPACE_HOST_ROOT
           default: ~/.swarm/workspaces
@@ -11559,18 +11593,27 @@ workspace_model:
             host workspace root.
     failure_behavior:
     - Unsupported backend names fail closed before runtime construction.
-    - Empty explicit backend sources from the flag, config, or environment fail closed instead of falling through.
+    - Empty explicit backend sources from the flag, config, or legacy environment fail closed instead of falling through.
     - Host backend MUST reject `SWARM_WORKSPACE_VOLUMES_FROM`; the host backend consumes explicit path authorities, not Docker
       volume inheritance.
-    - Host backend MUST fail closed for Claude CLI/provider execution. Host native command execution is supported only as
-      trusted/unsafe explicit host-mode execution through `workspace_execution_target_capability`; unsupported native tool
-      execution MUST still fail closed.
+    - Host backend MUST fail closed for Claude CLI/provider execution unless a future gate promotes that support. Host native
+      command execution is supported only as trusted/unsafe explicit host-mode execution through
+      `workspace_execution_target_capability`; unsupported native tool execution MUST still fail closed.
+    - A legacy environment value such as `SWARM_WORKSPACE_BACKEND=host` MUST NOT act as the unsafe host opt-out for
+      exec-capable bundles.
+    - conversation.fork_chat MUST consume the same decision owner. It MUST NOT preserve implicit primary-workspace
+      inheritance or discover required isolation only by failing inside the LLM process startup path.
     - Docker target failures, missing containers, nil targets, empty targets, unknown backends, and non-host-authorized
       contexts MUST NOT silently fall back to host native command execution.
     consumers:
     - swarm serve boot workspace lifecycle
+    - local foreground `swarm run start` startup through the serve startup owner
     - dynamic Builder project reload workspace lifecycle
     - selected-contract run-fork workspace lifecycle
+    - swarm verify isolation diagnostics
+    - swarm describe isolation diagnostics
+    - swarm doctor local diagnostics
+    - conversation.fork_chat sandbox LLM runtime admission
     split_scope:
     - '#1137 Compose/Postgres onboarding and Compose cleanup'
     - '#1136 broader local onboarding/docs'
@@ -14782,16 +14825,22 @@ cli_specification:
         owner: workspace_model.workspace_backend_selection
         flag: --workspace-backend <docker|host>
         config_key: workspace.backend
-        env_var: SWARM_WORKSPACE_BACKEND
-        default_backend: docker
+        unsafe_config_key: workspace.allow_exec_on_host
+        legacy_env_var: SWARM_WORKSPACE_BACKEND
+        default_backend: capability-derived
         rule: >
-          `swarm serve` MUST resolve workspace backend selection through
-          `workspace_model.workspace_backend_selection` before constructing any workspace lifecycle. The command MUST keep
-          Docker as the default isolation backend and MUST require an explicit selector for the host local-dev backend.
+          `swarm serve` MUST resolve the effective workspace backend requirement through
+          `workspace_model.workspace_backend_selection` after loading the selected contract source and before constructing
+          any workspace lifecycle. No-agent bundles default to no workspace lifecycle, non-exec API/runtime-mediated bundles
+          default to host, and exec-capable bundles require Docker unless the operator takes the explicit loud unsafe host
+          opt-out. `SWARM_WORKSPACE_BACKEND` is a legacy preference input and MUST NOT be the unsafe host opt-out authority.
         consumers:
         - serve boot workspace lifecycle
+        - local foreground run start
         - dynamic Builder project reload workspace lifecycle
         - selected-contract run-fork workspace lifecycle
+        - verify/describe/doctor diagnostics
+        - conversation.fork_chat sandbox LLM runtime admission
       workspace_execution_target_capability:
         promoted_by: '#1213/#1235/#1286/#1356'
         owner: workspace_model.workspace_execution_target_capability


### PR DESCRIPTION
## Summary

Closes #1138.

Implements the approved first-slice gate for capability-driven workspace backend selection:

- Adds `platform-spec.yaml#workspace_model.workspace_backend_selection` as the authoritative capability-derived decision table, including `conversation.fork_chat` obligations.
- Introduces one shared backend decision owner that derives `none`, `workspace_write`, or `exec` from the loaded contract source and effective LLM backend.
- Moves serve boot, startup recovery, Builder reload, selected-contract run-fork, local foreground serve path, doctor/local preflight, verify, describe, runtime construction, and forkchat admission onto that owner.
- Adds `workspace.allow_exec_on_host` for persistent loud unsafe host opt-out and rejects legacy `SWARM_WORKSPACE_BACKEND=host` as unsafe opt-out authority.
- Preserves `claude_cli` as Docker-required by default; host Claude/provider execution remains split.

## Governing refs / context

Exact governing spec section updated in this PR:

- `platform-spec.yaml#workspace_model.workspace_backend_selection`
- `platform-spec.yaml#cli_specification.command_catalog.serve.workspace_backend_selection`

Binding issue/gate context:

- #1138 Pre-Implementation Coverage Audit plus forkchat amendment.
- Gate B re-review outcome: `approved as first slice`.
- Parent isolation/source-authority context remains #746.

## Semantic migration

- New canonical owner: `platform-spec.yaml#workspace_model.workspace_backend_selection` plus `cmd/swarm/workspace_backend.go` shared decision owner.
- Old producer/reader path now invalid: raw `--workspace-backend` / `workspace.backend` / `SWARM_WORKSPACE_BACKEND` selection before contract load deciding lifecycle directly.
- Checked production paths for surviving old behavior: serve boot, startup recovery, Builder reload, selected-contract run-fork, local foreground run start through serve, doctor/local preflight, verify, describe, runtime construction, and forkchat API admission.
- Migration completeness: complete for the approved #1138 first-slice boundary; per-agent backend selection, full host Claude/provider execution, Docker-equivalent host isolation, Compose retirement, and broader #746 isolation work remain split.

## Verification

- `SWARM_TEST_POSTGRES_DSN='host=127.0.0.1 port=5432 user=postgres dbname=postgres sslmode=disable' PGPASSWORD=postgres go test ./...`
- Supported-surface proofs include no-agent no-workspace boot without Docker, API/file_io host decisions, `claude_cli` and native bash Docker-required decisions, unsafe host opt-out gating/warning, config host-without-allow fail-closed, verify/describe/doctor diagnostics, and forkchat admission.
