### PR TITLE
[agent-e][issue #1759] Expose structured verify errors

### DIFF
--- a/cmd/swarm/main.go
+++ b/cmd/swarm/main.go
@@ -1319,6 +1319,7 @@ type verifyCommandResult struct {
 	OK               bool                  `json:"ok"`
 	Contracts        string                `json:"contracts"`
 	WorkspaceBackend string                `json:"workspace_backend"`
+	Errors           []verifyFindingOutput `json:"errors"`
 	Warnings         []verifyFindingOutput `json:"warnings"`
 	LintEvidence     []verifyFindingOutput `json:"lint_evidence"`
 }
@@ -1403,18 +1404,19 @@ func runVerifyCommandWithOutput(ctx context.Context, repo string, opts verifyCom
 		workspaceBackendDetail := workspaceBackendDecisionDetail(workspaceBackend)
 		result, err := verifyBundleResultWithOptions(ctx, source, validationOpts)
 		if err != nil {
+			if opts.output.asJSON && verifyValidationResultHasBlockingBootFindings(result, validationOpts) {
+				output := verifyCommandOutput(false, contractsRoot, workspaceBackendDetail, result)
+				if renderErr := renderCLIOutput(out, errOut, opts.output, output, nil, nil); renderErr != nil {
+					return 2
+				}
+				return 1
+			}
 			if errOut != nil {
 				fmt.Fprintf(errOut, "verify failed: %v\n", err)
 			}
 			return 1
 		}
-		output := verifyCommandResult{
-			OK:               true,
-			Contracts:        contractsRoot,
-			WorkspaceBackend: workspaceBackendDetail,
-			Warnings:         verifyFindingOutputs(result.BootReport.Warnings()),
-			LintEvidence:     verifyFindingOutputs(result.BootReport.LintEvidence()),
-		}
+		output := verifyCommandOutput(true, contractsRoot, workspaceBackendDetail, result)
 		if err := renderCLIOutput(out, errOut, opts.output, output, func(_ io.Writer) {
 			writeVerifyFindings(errOut, result.BootReport.Warnings(), false)
 			writeVerifyFindings(errOut, result.BootReport.LintEvidence(), false)
@@ -1429,6 +1431,39 @@ func runVerifyCommandWithOutput(ctx context.Context, repo string, opts verifyCom
 		}
 	}
 	return 0
+}
+
+func verifyCommandOutput(ok bool, contractsRoot string, workspaceBackend string, result runtime.WorkflowContractValidationResult) verifyCommandResult {
+	return verifyCommandResult{
+		OK:               ok,
+		Contracts:        contractsRoot,
+		WorkspaceBackend: workspaceBackend,
+		Errors:           verifyFindingOutputs(result.BootReport.Errors()),
+		Warnings:         verifyFindingOutputs(result.BootReport.Warnings()),
+		LintEvidence:     verifyFindingOutputs(result.BootReport.LintEvidence()),
+	}
+}
+
+func verifyValidationResultHasBlockingBootFindings(result runtime.WorkflowContractValidationResult, opts runtime.WorkflowContractValidationOptions) bool {
+	if len(result.BootReport.Errors()) > 0 {
+		return true
+	}
+	if !opts.FatalBootWarnings {
+		return false
+	}
+	excluded := make(map[string]struct{}, len(opts.ExcludedFatalBootWarningChecks))
+	for _, checkID := range opts.ExcludedFatalBootWarningChecks {
+		if checkID = strings.TrimSpace(checkID); checkID != "" {
+			excluded[checkID] = struct{}{}
+		}
+	}
+	for _, finding := range result.BootReport.Warnings() {
+		if _, skip := excluded[strings.TrimSpace(finding.CheckID)]; skip {
+			continue
+		}
+		return true
+	}
+	return false
 }
 
 func verifyFindingOutputs(findings []runtimebootverify.Finding) []verifyFindingOutput {

--- a/cmd/swarm/main_test.go
+++ b/cmd/swarm/main_test.go
@@ -9519,6 +9519,68 @@ func TestNormalizeContractsRootExplicitPathValidation(t *testing.T) {
 }
 
 func TestRunVerifyCommand_SurfacesLintEvidence(t *testing.T) {
+	root := writeVerifyLintEvidenceFixture(t)
+
+	var stdout, stderr bytes.Buffer
+	code := runVerifyCommandWithContractsOutputForTest(context.Background(), repoRoot(), root, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("runVerifyCommand exit code = %d, stdout = %q stderr = %q", code, stdout.String(), stderr.String())
+	}
+	if out := stdout.String(); !strings.Contains(out, "verify ok: contracts=") {
+		t.Fatalf("verify stdout missing success marker:\n%s", out)
+	} else if strings.Contains(out, "entity_reader_coverage") || strings.Contains(out, "lint_evidence") {
+		t.Fatalf("verify stdout contains advisory diagnostics:\n%s", out)
+	}
+	errText := stderr.String()
+	if !strings.Contains(errText, "INFO: entity_reader_coverage [root] flow root entity_type case declares field untouched with no detected internal reader coverage") {
+		t.Fatalf("verify stderr missing lint evidence:\n%s", errText)
+	}
+	if strings.Contains(errText, "lint_evidence:") {
+		t.Fatalf("verify stderr used legacy lint_evidence prefix:\n%s", errText)
+	}
+
+	opts := defaultVerifyCommandOptions()
+	opts.contractsPath = root
+	opts.output.asJSON = true
+	stdout.Reset()
+	stderr.Reset()
+	code = runVerifyCommandWithOutput(context.Background(), repoRoot(), opts, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("runVerifyCommand --json exit code = %d, stdout = %q stderr = %q", code, stdout.String(), stderr.String())
+	}
+	if strings.TrimSpace(stderr.String()) != "" {
+		t.Fatalf("verify --json stderr = %q, want empty", stderr.String())
+	}
+	verifyJSON := decodeOutputJSON[verifyCommandResult](t, stdout.String())
+	if len(verifyJSON.LintEvidence) == 0 || verifyJSON.LintEvidence[0].Severity != "lint_evidence" {
+		t.Fatalf("verify --json lint evidence = %#v, want canonical severity", verifyJSON.LintEvidence)
+	}
+}
+
+func TestRunVerifyCommand_JSONDoesNotHideLaterValidationErrorBehindAdvisoryBootFindings(t *testing.T) {
+	t.Setenv("SWARM_BOOT_WARNINGS_FATAL", "false")
+	t.Setenv("SWARM_EMIT_SCHEMA_STRICT", "true")
+
+	root := writeVerifyLintEvidenceWithMissingEmitSchemaFixture(t)
+	opts := defaultVerifyCommandOptions()
+	opts.contractsPath = root
+	opts.output.asJSON = true
+
+	var stdout, stderr bytes.Buffer
+	code := runVerifyCommandWithOutput(context.Background(), repoRoot(), opts, &stdout, &stderr)
+	if code == 0 {
+		t.Fatalf("runVerifyCommand --json exit code = 0, stdout = %q stderr = %q", stdout.String(), stderr.String())
+	}
+	if strings.TrimSpace(stdout.String()) != "" {
+		t.Fatalf("verify --json stdout = %q, want empty for non-boot validation failure", stdout.String())
+	}
+	if errText := stderr.String(); !strings.Contains(errText, "verify failed: emit schema strict mode enabled") {
+		t.Fatalf("verify --json stderr = %q, want strict emit schema validation failure", errText)
+	}
+}
+
+func writeVerifyLintEvidenceFixture(t *testing.T) string {
+	t.Helper()
 	root := t.TempDir()
 	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "package.yaml"), `
 name: verify-lint-evidence
@@ -9579,41 +9641,26 @@ reader:
         check: "entity.priority >= 0"
       advances_to: done
 `)
+	return root
+}
 
-	var stdout, stderr bytes.Buffer
-	code := runVerifyCommandWithContractsOutputForTest(context.Background(), repoRoot(), root, &stdout, &stderr)
-	if code != 0 {
-		t.Fatalf("runVerifyCommand exit code = %d, stdout = %q stderr = %q", code, stdout.String(), stderr.String())
-	}
-	if out := stdout.String(); !strings.Contains(out, "verify ok: contracts=") {
-		t.Fatalf("verify stdout missing success marker:\n%s", out)
-	} else if strings.Contains(out, "entity_reader_coverage") || strings.Contains(out, "lint_evidence") {
-		t.Fatalf("verify stdout contains advisory diagnostics:\n%s", out)
-	}
-	errText := stderr.String()
-	if !strings.Contains(errText, "INFO: entity_reader_coverage [root] flow root entity_type case declares field untouched with no detected internal reader coverage") {
-		t.Fatalf("verify stderr missing lint evidence:\n%s", errText)
-	}
-	if strings.Contains(errText, "lint_evidence:") {
-		t.Fatalf("verify stderr used legacy lint_evidence prefix:\n%s", errText)
-	}
-
-	opts := defaultVerifyCommandOptions()
-	opts.contractsPath = root
-	opts.output.asJSON = true
-	stdout.Reset()
-	stderr.Reset()
-	code = runVerifyCommandWithOutput(context.Background(), repoRoot(), opts, &stdout, &stderr)
-	if code != 0 {
-		t.Fatalf("runVerifyCommand --json exit code = %d, stdout = %q stderr = %q", code, stdout.String(), stderr.String())
-	}
-	if strings.TrimSpace(stderr.String()) != "" {
-		t.Fatalf("verify --json stderr = %q, want empty", stderr.String())
-	}
-	verifyJSON := decodeOutputJSON[verifyCommandResult](t, stdout.String())
-	if len(verifyJSON.LintEvidence) == 0 || verifyJSON.LintEvidence[0].Severity != "lint_evidence" {
-		t.Fatalf("verify --json lint evidence = %#v, want canonical severity", verifyJSON.LintEvidence)
-	}
+func writeVerifyLintEvidenceWithMissingEmitSchemaFixture(t *testing.T) string {
+	t.Helper()
+	root := writeVerifyLintEvidenceFixture(t)
+	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "agents.yaml"), `
+strict-schema-agent:
+  id: strict-schema-agent
+  role: strict_schema_agent
+  prompt_ref: strict-schema-agent
+  model: regular
+  mode: task
+  subscriptions: [task.assigned]
+  emit_events: [missing.event]
+`)
+	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "prompts", "strict-schema-agent.md"), `
+Emit the missing event when requested.
+`)
+	return root
 }
 
 func TestRunVerifyCommand_AllowsBootTimerWithoutCancelOn(t *testing.T) {
@@ -9650,16 +9697,43 @@ func TestRunVerifyCommand_RejectsBootTimerWithCancelOn(t *testing.T) {
 			t.Fatalf("verify stderr missing %q:\n%s", want, errText)
 		}
 	}
+
+	opts := defaultVerifyCommandOptions()
+	opts.contractsPath = root
+	opts.output.asJSON = true
+	stdout.Reset()
+	stderr.Reset()
+	code = runVerifyCommandWithOutput(context.Background(), repoRoot(), opts, &stdout, &stderr)
+	if code == 0 {
+		t.Fatalf("runVerifyCommand --json exit code = 0, stdout = %q stderr = %q", stdout.String(), stderr.String())
+	}
+	if strings.TrimSpace(stderr.String()) != "" {
+		t.Fatalf("verify --json stderr = %q, want empty structured failure", stderr.String())
+	}
+	verifyJSON := decodeOutputJSON[verifyCommandResult](t, stdout.String())
+	if verifyJSON.OK {
+		t.Fatalf("verify --json ok = true, want false: %#v", verifyJSON)
+	}
+	if strings.TrimSpace(verifyJSON.Contracts) != root {
+		t.Fatalf("verify --json contracts = %q, want %q", verifyJSON.Contracts, root)
+	}
+	if len(verifyJSON.Errors) == 0 {
+		t.Fatalf("verify --json errors = %#v, want timer_validation", verifyJSON.Errors)
+	}
+	if got := verifyJSON.Errors[0]; got.CheckID != "timer_validation" || got.Severity != "hard_invalidity" || !strings.Contains(got.Message, "start_on boot does not support cancel_on state:done") {
+		t.Fatalf("verify --json first error = %#v, want structured timer_validation hard invalidity", got)
+	}
 }
 
 func TestRunVerifyCommand_EscalatedWarningUsesBlockingAnalyzerOutput(t *testing.T) {
 	t.Setenv("SWARM_BOOT_WARNINGS_FATAL", "true")
 
+	root := writeVerifyMissingPinWarningFixture(t)
 	var stdout, stderr bytes.Buffer
 	code := runVerifyCommandWithContractsOutputForTest(
 		context.Background(),
 		repoRoot(),
-		writeVerifyMissingPinWarningFixture(t),
+		root,
 		&stdout,
 		&stderr,
 	)
@@ -9682,6 +9756,48 @@ func TestRunVerifyCommand_EscalatedWarningUsesBlockingAnalyzerOutput(t *testing.
 	if strings.Contains(errText, "boot verification warnings:") {
 		t.Fatalf("verify stderr used legacy fatal warning banner:\n%s", errText)
 	}
+
+	opts := defaultVerifyCommandOptions()
+	opts.contractsPath = root
+	opts.output.asJSON = true
+	stdout.Reset()
+	stderr.Reset()
+	code = runVerifyCommandWithOutput(context.Background(), repoRoot(), opts, &stdout, &stderr)
+	if code == 0 {
+		t.Fatalf("runVerifyCommand --json exit code = 0, stdout = %q stderr = %q", stdout.String(), stderr.String())
+	}
+	if strings.TrimSpace(stderr.String()) != "" {
+		t.Fatalf("verify --json stderr = %q, want empty structured warning failure", stderr.String())
+	}
+	verifyJSON := decodeOutputJSON[verifyCommandResult](t, stdout.String())
+	if verifyJSON.OK {
+		t.Fatalf("verify --json ok = true, want false: %#v", verifyJSON)
+	}
+	if len(verifyJSON.Errors) != 0 {
+		t.Fatalf("verify --json errors = %#v, want warning-only structured failure", verifyJSON.Errors)
+	}
+	if len(verifyJSON.Warnings) == 0 {
+		t.Fatalf("verify --json warnings = %#v, want input_pin_wiring", verifyJSON.Warnings)
+	}
+	if !verifyFindingOutputsContain(verifyJSON.Warnings, "input_pin_wiring", "semantic_drift_warning", "no producer path was found in the authored bundle") {
+		t.Fatalf("verify --json warnings = %#v, want structured input_pin_wiring warning", verifyJSON.Warnings)
+	}
+}
+
+func verifyFindingOutputsContain(findings []verifyFindingOutput, checkID, severity, messageContains string) bool {
+	for _, finding := range findings {
+		if strings.TrimSpace(finding.CheckID) != checkID {
+			continue
+		}
+		if strings.TrimSpace(finding.Severity) != severity {
+			continue
+		}
+		if !strings.Contains(finding.Message, messageContains) {
+			continue
+		}
+		return true
+	}
+	return false
 }
 
 func writeVerifyBootTimerCommandFixture(t *testing.T, cancelOn string) string {

--- a/internal/apispec/cli_topology_spec_test.go
+++ b/internal/apispec/cli_topology_spec_test.go
@@ -72,6 +72,30 @@ func TestCLICommandCatalogRowsDeclareContractBearingGroups(t *testing.T) {
 	}
 }
 
+func TestCLIVerifyJSONShapeIncludesStructuredFailureFindings(t *testing.T) {
+	outputContract := mustMappingValue(t, mustMappingValue(t, cliSpecification(t), "foundations"), "output_contract")
+	commandSupport := mustMappingValue(t, outputContract, "command_support")
+	implemented := mustMappingValue(t, commandSupport, "implemented_output_mode_first_slice")
+	consumers := mustMappingValue(t, implemented, "consumers")
+	verify := mustMappingValue(t, consumers, "verify")
+	jsonShape := mustMappingValue(t, verify, "json_shape")
+
+	for _, want := range []string{
+		"errors",
+		"workspace_backend",
+		"warnings",
+		"lint_evidence",
+		"check_id",
+		"severity",
+		"location",
+		"message",
+		"ok: false",
+		"human stderr",
+	} {
+		assertScalarContains(t, jsonShape, want)
+	}
+}
+
 func TestCLITopologyRevisionV22IsImplementedHistoricalRecord(t *testing.T) {
 	revision := mustMappingValue(t, cliSpecification(t), "topology_revision_v2_2")
 	assertScalarValue(t, mustMappingValue(t, revision, "status"), "implemented_historical_record")

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -13663,7 +13663,11 @@ cli_specification:
               - server_bundle_fingerprint when --server is supplied
             verify:
               fact_owner: local contract verification
-              json_shape: object with ok, contracts, warnings, and lint_evidence
+              json_shape: >
+                object with ok, contracts, workspace_backend, errors, warnings, and lint_evidence. `errors`, `warnings`,
+                and `lint_evidence` are arrays of structured boot verification findings with canonical `check_id`,
+                `severity`, `location`, and `message` fields. `--json` renders this same object for structured boot
+                verification failures with `ok: false` instead of requiring consumers to parse human stderr.
               human_text_streams:
                 stdout: "successful load-bearing `verify ok: contracts=...` result only"
                 stderr: "analyzer diagnostics and advisory findings, rendered with the boot verification surface severity prefixes `ERROR:`, `WARN:`, or `INFO:`"


### PR DESCRIPTION
## Summary

- Adds structured `errors` to `swarm verify --json` output for boot verification hard-invalidity failures.
- Preserves human stderr behavior for non-JSON verify failures.
- Updates `platform-spec.yaml` and apispec coverage for the public verify JSON shape.

Closes #1759
Part of #1696
Part of #1252

## Governing Refs / Context

- `platform-spec.yaml#engine.boot_verification`
- `platform-spec.yaml#cli_specification.command_catalog.verify`
- `platform-spec.yaml#cli_specification.foundations.output_contract.command_support.implemented_output_mode_first_slice.consumers.verify`
- `platform-spec.yaml#test_specification.deterministic_scenario_runner.catalog_convergence`
- `platform-spec.yaml#api_specification.deferred_namespaces.verify`
- Binding issue/gate context: #1759 approved as a first slice for structured public `swarm verify` finding source authority only. Direct tier8 public companion migration remains split.

## Semantic Migration

- New canonical owner: public `swarm verify --json` structured finding output, backed by `runtimebootverify.Finding` and `runtime.ValidateWorkflowContractSurface`, with spec authority in `platform-spec.yaml`.
- Old producer/reader/writer path now invalid: public hard-invalidity proof by human stderr substring and private `expected.yaml` fields such as `error_category` / `error_contains` as public scenario syntax.
- Production paths checked for surviving old behavior: `cmd/swarm runVerifyCommandWithOutput`, `renderCLIOutput`, `ValidateWorkflowContractSurface`, bootverify, cataloge2e tier8 survival.
- Migration completeness: complete for the approved structured local `swarm verify --json` finding source-authority class; tier8 public companion migration remains intentionally split.

## Tests

- `SWARM_TEST_POSTGRES_DSN='host=127.0.0.1 port=5432 user=youmew dbname=postgres sslmode=disable' PGPASSWORD=postgres go test ./cmd/swarm -run 'TestRunVerifyCommand|TestVerifyBundle|TestCLI_Verify' -count=1`
- `go test ./internal/runtime/bootverify -count=1`
- `SWARM_TEST_POSTGRES_DSN='host=127.0.0.1 port=5432 user=youmew dbname=postgres sslmode=disable' PGPASSWORD=postgres go test ./internal/runtime/cataloge2e -run '^TestTier8BootCatalogFixtures_RealRuntimeBoot$|^TestTier8BootCatalogFixtures_AreExplicitlyClassified$' -count=1`
- `go test ./internal/apispec -run 'TestCLIVerifyJSONShapeIncludesStructuredFailureFindings|Test.*Boot|Test.*CLI|TestPlatformSpecDeterministicScenarioRunnerSourceAuthority|TestCLITopology' -count=1`
- `SWARM_TEST_POSTGRES_DSN='host=127.0.0.1 port=5432 user=youmew dbname=postgres sslmode=disable' PGPASSWORD=postgres go test ./...`
