### PR TITLE
[agent-f][issue #1764] Add Telegram provider trigger manifest

### DIFF
--- a/cmd/swarm/doctor_test.go
+++ b/cmd/swarm/doctor_test.go
@@ -115,6 +115,7 @@ func TestDoctorClaudeCLIPreflightJSONReportsOKWithoutDB(t *testing.T) {
 		"provider_trigger_pack_shopify",
 		"provider_trigger_pack_slack",
 		"provider_trigger_pack_stripe",
+		"provider_trigger_pack_telegram",
 		"provider_trigger_pack_twilio",
 		"provider_trigger_pack_typeform",
 	} {
@@ -131,6 +132,11 @@ func TestDoctorClaudeCLIPreflightJSONReportsOKWithoutDB(t *testing.T) {
 		!localPreflightReportFindingContains(report, "provider_trigger_pack_stripe", "CANNOT emit_undeclared_events") ||
 		!localPreflightReportFindingContains(report, "provider_trigger_pack_stripe", "requires webhook_signing.stripe=UNBOUND") {
 		t.Fatalf("stripe provider pack surface missing CAN/CANNOT/requires readback: %#v", report.Findings)
+	}
+	if !localPreflightReportFindingContains(report, "provider_trigger_pack_telegram", "CAN receive HTTPS route /webhooks/{entity}/telegram") ||
+		!localPreflightReportFindingContains(report, "provider_trigger_pack_telegram", "CANNOT emit_undeclared_events") ||
+		!localPreflightReportFindingContains(report, "provider_trigger_pack_telegram", "requires webhook_signing.telegram=UNBOUND") {
+		t.Fatalf("telegram provider pack surface missing CAN/CANNOT/requires readback: %#v", report.Findings)
 	}
 }
 

--- a/internal/providertriggers/packs/telegram/pack.yaml
+++ b/internal/providertriggers/packs/telegram/pack.yaml
@@ -1,0 +1,23 @@
+id: provider.telegram
+version: 0.1.0
+platform_version: ">=0.7.0 <0.8.0"
+type: trigger
+manifest_hash: sha256:5e3c264b31da7a2d2cba83ab97d9f9af6005c8f35f1fcc25e538e1c9bd5fb638
+provenance:
+  source: platform
+capabilities:
+  can:
+    receive_https_route: /webhooks/{entity}/telegram
+    verify_secret: webhook_signing.telegram
+    emit_events:
+      - inbound.telegram
+    persist_dedupe_markers: true
+  cannot:
+    - emit_undeclared_events
+    - run_code_before_admission
+    - touch_unbound_resources
+requires:
+  secrets:
+    - webhook_signing.telegram
+tests:
+  - providertriggers/telegram

--- a/internal/providertriggers/packs/telegram/trigger.yaml
+++ b/internal/providertriggers/packs/telegram/trigger.yaml
@@ -1,0 +1,25 @@
+provider: telegram
+payload_object_required: true
+payload_object_error: telegram update object is required
+secret:
+  required: true
+signature:
+  type: token_equality
+  header: X-Telegram-Bot-Api-Secret-Token
+  missing_error: telegram secret token is required
+  invalid_error: invalid telegram secret token
+delivery_id:
+  json_path: $.update_id
+  required: true
+  missing_error: telegram update_id is required
+event_type:
+  literal: update
+  required: true
+event_name:
+  literal: inbound.telegram
+ack:
+  mode: durable_before_dispatch
+metadata:
+  user_agent: user_agent
+  telegram_update_id: delivery_id
+  telegram_update_type: event_type

--- a/internal/providertriggers/providertriggers.go
+++ b/internal/providertriggers/providertriggers.go
@@ -37,6 +37,10 @@ const (
 	cannotRunCodeBeforeAdmission = "run_code_before_admission"
 	cannotEmitUndeclaredEvents   = "emit_undeclared_events"
 	cannotTouchUnboundResources  = "touch_unbound_resources"
+
+	signatureTypeHMACSHA256    = "hmac_sha256"
+	signatureTypeHMACSHA1      = "hmac_sha1"
+	signatureTypeTokenEquality = "token_equality"
 )
 
 type Target struct {
@@ -440,7 +444,8 @@ func (m Manifest) Validate() error {
 	if provider == "" {
 		return fmt.Errorf("provider is required")
 	}
-	if m.Secret.Required && m.Signature.Type == "" {
+	signatureType := strings.TrimSpace(m.Signature.Type)
+	if m.Secret.Required && signatureType == "" {
 		return fmt.Errorf("%s manifest requires signature when secret is required", provider)
 	}
 	switch strings.TrimSpace(m.PayloadSource) {
@@ -448,38 +453,58 @@ func (m Manifest) Validate() error {
 	default:
 		return fmt.Errorf("%s manifest has unsupported payload_source %q", provider, m.PayloadSource)
 	}
-	if m.Signature.Type != "" {
-		switch strings.TrimSpace(m.Signature.Type) {
-		case "hmac_sha256", "hmac_sha1":
+	if signatureType != "" {
+		switch signatureType {
+		case signatureTypeHMACSHA256, signatureTypeHMACSHA1, signatureTypeTokenEquality:
 		default:
 			return fmt.Errorf("%s manifest has unsupported signature type %q", provider, m.Signature.Type)
 		}
-		switch m.Signature.digestEncoding() {
-		case "hex", "base64":
-		default:
-			return fmt.Errorf("%s manifest has unsupported signature encoding %q", provider, m.Signature.Encoding)
-		}
-	}
-	if m.Signature.Type != "" {
 		if strings.TrimSpace(m.Signature.Header) == "" {
 			return fmt.Errorf("%s manifest signature header is required", provider)
 		}
-		switch strings.TrimSpace(m.Signature.SignedPayload) {
-		case "raw_body", "slack_v0", "timestamp_dot_raw_body", "url_plus_sorted_form":
-		default:
-			return fmt.Errorf("%s manifest has unsupported signed_payload %q", provider, m.Signature.SignedPayload)
-		}
-		switch strings.TrimSpace(m.Signature.SignedPayload) {
-		case "slack_v0", "timestamp_dot_raw_body":
-			if m.Signature.Timestamp == nil {
-				return fmt.Errorf("%s manifest timestamp is required for %s", provider, m.Signature.SignedPayload)
+		switch signatureType {
+		case signatureTypeHMACSHA256, signatureTypeHMACSHA1:
+			switch m.Signature.digestEncoding() {
+			case "hex", "base64":
+			default:
+				return fmt.Errorf("%s manifest has unsupported signature encoding %q", provider, m.Signature.Encoding)
 			}
-		}
-		if strings.TrimSpace(m.Signature.SignedPayload) == "url_plus_sorted_form" && m.Signature.digestEncoding() != "base64" {
-			return fmt.Errorf("%s manifest url_plus_sorted_form signatures require base64 encoding", provider)
-		}
-		if strings.TrimSpace(m.Signature.SignedPayload) == "url_plus_sorted_form" && strings.TrimSpace(m.Signature.Type) != "hmac_sha1" {
-			return fmt.Errorf("%s manifest url_plus_sorted_form signatures require hmac_sha1", provider)
+			switch strings.TrimSpace(m.Signature.SignedPayload) {
+			case "raw_body", "slack_v0", "timestamp_dot_raw_body", "url_plus_sorted_form":
+			default:
+				return fmt.Errorf("%s manifest has unsupported signed_payload %q", provider, m.Signature.SignedPayload)
+			}
+			switch strings.TrimSpace(m.Signature.SignedPayload) {
+			case "slack_v0", "timestamp_dot_raw_body":
+				if m.Signature.Timestamp == nil {
+					return fmt.Errorf("%s manifest timestamp is required for %s", provider, m.Signature.SignedPayload)
+				}
+			}
+			if strings.TrimSpace(m.Signature.SignedPayload) == "url_plus_sorted_form" && m.Signature.digestEncoding() != "base64" {
+				return fmt.Errorf("%s manifest url_plus_sorted_form signatures require base64 encoding", provider)
+			}
+			if strings.TrimSpace(m.Signature.SignedPayload) == "url_plus_sorted_form" && signatureType != signatureTypeHMACSHA1 {
+				return fmt.Errorf("%s manifest url_plus_sorted_form signatures require hmac_sha1", provider)
+			}
+		case signatureTypeTokenEquality:
+			if !m.Secret.Required {
+				return fmt.Errorf("%s manifest token_equality requires secret.required", provider)
+			}
+			if strings.TrimSpace(m.Signature.Encoding) != "" {
+				return fmt.Errorf("%s manifest token_equality must not set encoding", provider)
+			}
+			if strings.TrimSpace(m.Signature.Prefix) != "" {
+				return fmt.Errorf("%s manifest token_equality must not set prefix", provider)
+			}
+			if strings.TrimSpace(m.Signature.SignedPayload) != "" {
+				return fmt.Errorf("%s manifest token_equality must not set signed_payload", provider)
+			}
+			if strings.TrimSpace(m.Signature.SignatureParam) != "" {
+				return fmt.Errorf("%s manifest token_equality must not set signature_param", provider)
+			}
+			if m.Signature.Timestamp != nil {
+				return fmt.Errorf("%s manifest token_equality must not set timestamp", provider)
+			}
 		}
 	}
 	if err := validateValueSource(provider, "delivery_id", m.DeliveryID); err != nil {
@@ -600,6 +625,9 @@ func (m Manifest) Accept(req Request) (Delivery, error) {
 }
 
 func (m Manifest) verifySignature(secret string, req Request) error {
+	if strings.TrimSpace(m.Signature.Type) == signatureTypeTokenEquality {
+		return m.verifyTokenEquality(secret, req)
+	}
 	sigHeader := strings.TrimSpace(req.Headers.Get(m.Signature.Header))
 	if sigHeader == "" {
 		return unauthorized(firstNonEmpty(m.Signature.MissingError, "signature is required"))
@@ -662,6 +690,21 @@ func (m Manifest) verifySignature(secret string, req Request) error {
 	return unauthorized(firstNonEmpty(m.Signature.InvalidError, "invalid signature"))
 }
 
+func (m Manifest) verifyTokenEquality(secret string, req Request) error {
+	values := req.Headers.Values(m.Signature.Header)
+	if len(values) == 0 || strings.TrimSpace(values[0]) == "" {
+		return unauthorized(firstNonEmpty(m.Signature.MissingError, "signature is required"))
+	}
+	if len(values) != 1 {
+		return unauthorized(firstNonEmpty(m.Signature.InvalidError, "invalid signature"))
+	}
+	token := strings.TrimSpace(values[0])
+	if hmac.Equal([]byte(token), []byte(strings.TrimSpace(secret))) {
+		return nil
+	}
+	return unauthorized(firstNonEmpty(m.Signature.InvalidError, "invalid signature"))
+}
+
 func (s SignatureManifest) TimestampParam() string {
 	if s.Timestamp == nil {
 		return ""
@@ -671,9 +714,9 @@ func (s SignatureManifest) TimestampParam() string {
 
 func (s SignatureManifest) hashFunc() (func() hash.Hash, error) {
 	switch strings.TrimSpace(s.Type) {
-	case "hmac_sha256":
+	case signatureTypeHMACSHA256:
 		return sha256.New, nil
-	case "hmac_sha1":
+	case signatureTypeHMACSHA1:
 		return sha1.New, nil
 	default:
 		return nil, unauthorized(firstNonEmpty(s.InvalidError, "invalid signature"))

--- a/internal/providertriggers/providertriggers_test.go
+++ b/internal/providertriggers/providertriggers_test.go
@@ -22,7 +22,7 @@ import (
 
 func TestDefaultRegistryLoadsFirstPartyProvidersFromVerifiedPlatformPacks(t *testing.T) {
 	registry := DefaultRegistry()
-	for _, provider := range []string{"github", "intercom", "shopify", "slack", "stripe", "twilio", "typeform"} {
+	for _, provider := range []string{"github", "intercom", "shopify", "slack", "stripe", "telegram", "twilio", "typeform"} {
 		want := "platform:provider." + provider
 		if got := registry.sources[provider]; got != want {
 			t.Fatalf("%s source = %q, want verified platform pack %q", provider, got, want)
@@ -215,6 +215,32 @@ func TestExternalProviderTriggerPackUsesSameVerifier(t *testing.T) {
 	}
 	if len(loaded) != 1 || loaded[0].Manifest.Provider != "stripe" {
 		t.Fatalf("loaded external packs = %+v, want stripe", loaded)
+	}
+}
+
+func TestExternalTelegramProviderTriggerPackUsesSameTokenEqualityVerifier(t *testing.T) {
+	dir := copyBuiltinPackToTemp(t, "telegram")
+	replaceInFile(t, filepath.Join(dir, "pack.yaml"), "source: platform", "source: external")
+
+	loaded, err := LoadExternalPackDirs("0.7.0", dir)
+	if err != nil {
+		t.Fatalf("LoadExternalPackDirs: %v", err)
+	}
+	registry, err := NewRegistryFromSources(SourcesFromLoadedPacks(loaded...)...)
+	if err != nil {
+		t.Fatalf("NewRegistryFromSources: %v", err)
+	}
+
+	body := []byte(`{"update_id":123456789,"message":{"message_id":7,"chat":{"id":42},"text":"hello"}}`)
+	delivery, err := registry.Accept(telegramRequest("telegram-secret", body, map[string]any{
+		"update_id": float64(123456789),
+		"message":   map[string]any{"message_id": float64(7), "chat": map[string]any{"id": float64(42)}, "text": "hello"},
+	}))
+	if err != nil {
+		t.Fatalf("Accept external Telegram webhook: %v", err)
+	}
+	if delivery.ProviderEventID != "123456789" || delivery.ProviderEventType != "update" || delivery.EventName != "inbound.telegram" {
+		t.Fatalf("delivery = %+v, want Telegram manifest identity", delivery)
 	}
 }
 
@@ -986,6 +1012,114 @@ func TestIntercomManifestRejectsInvalidInputsBeforeDelivery(t *testing.T) {
 	}
 }
 
+func TestTelegramManifestAcceptsHeaderTokenUpdate(t *testing.T) {
+	body := []byte(`{"update_id":123456789,"message":{"message_id":7,"chat":{"id":42},"text":"hello"}}`)
+	req := telegramRequest("telegram-secret", body, map[string]any{
+		"update_id": float64(123456789),
+		"message":   map[string]any{"message_id": float64(7), "chat": map[string]any{"id": float64(42)}, "text": "hello"},
+	})
+
+	delivery, err := DefaultRegistry().Accept(req)
+	if err != nil {
+		t.Fatalf("Accept Telegram webhook: %v", err)
+	}
+	if delivery.ProviderEventID != "123456789" {
+		t.Fatalf("ProviderEventID = %q, want 123456789", delivery.ProviderEventID)
+	}
+	if delivery.ProviderEventType != "update" {
+		t.Fatalf("ProviderEventType = %q, want update", delivery.ProviderEventType)
+	}
+	if delivery.EventName != "inbound.telegram" {
+		t.Fatalf("EventName = %q, want inbound.telegram", delivery.EventName)
+	}
+	if !delivery.AcknowledgeBeforeDispatch {
+		t.Fatal("Telegram delivery did not request durable_before_dispatch acknowledgement")
+	}
+	headers, ok := delivery.Payload["headers"].(map[string]any)
+	if !ok {
+		t.Fatalf("headers = %T, want metadata map", delivery.Payload["headers"])
+	}
+	if headers["telegram_update_id"] != "123456789" || headers["telegram_update_type"] != "update" {
+		t.Fatalf("headers = %+v, want Telegram manifest metadata", headers)
+	}
+	encoded := fmtPayload(delivery.Payload)
+	if strings.Contains(encoded, "telegram-secret") {
+		t.Fatal("Telegram secret token leaked into delivery payload")
+	}
+}
+
+func TestTelegramManifestRejectsInvalidInputsBeforeDelivery(t *testing.T) {
+	validBody := []byte(`{"update_id":123456789,"message":{"message_id":7,"chat":{"id":42},"text":"hello"}}`)
+	validPayload := map[string]any{
+		"update_id": float64(123456789),
+		"message":   map[string]any{"message_id": float64(7), "chat": map[string]any{"id": float64(42)}, "text": "hello"},
+	}
+	validRequest := func() Request {
+		return telegramRequest("telegram-secret", validBody, validPayload)
+	}
+	for _, tc := range []struct {
+		name       string
+		configure  func(Request) Request
+		wantStatus int
+	}{
+		{
+			name: "missing configured secret",
+			configure: func(req Request) Request {
+				req.Target.WebhookSecret = ""
+				return req
+			},
+			wantStatus: http.StatusUnauthorized,
+		},
+		{
+			name: "missing token header",
+			configure: func(req Request) Request {
+				req.Headers.Del("X-Telegram-Bot-Api-Secret-Token")
+				return req
+			},
+			wantStatus: http.StatusUnauthorized,
+		},
+		{
+			name: "duplicate token header",
+			configure: func(req Request) Request {
+				req.Headers.Add("X-Telegram-Bot-Api-Secret-Token", "telegram-secret")
+				return req
+			},
+			wantStatus: http.StatusUnauthorized,
+		},
+		{
+			name: "invalid token header",
+			configure: func(req Request) Request {
+				req.Headers.Set("X-Telegram-Bot-Api-Secret-Token", "wrong-secret")
+				return req
+			},
+			wantStatus: http.StatusUnauthorized,
+		},
+		{
+			name: "missing update id",
+			configure: func(req Request) Request {
+				req.Body = []byte(`{"message":{"message_id":7,"text":"hello"}}`)
+				req.Payload = map[string]any{"message": map[string]any{"message_id": float64(7), "text": "hello"}}
+				return req
+			},
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name: "non object payload",
+			configure: func(req Request) Request {
+				req.Body = []byte(`[{"update_id":123456789}]`)
+				req.Payload = []any{map[string]any{"update_id": float64(123456789)}}
+				return req
+			},
+			wantStatus: http.StatusBadRequest,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := DefaultRegistry().Accept(tc.configure(validRequest()))
+			requireProviderTriggerError(t, err, tc.wantStatus)
+		})
+	}
+}
+
 func TestManifestValidationRejectsAuthoringErrors(t *testing.T) {
 	for _, tc := range []struct {
 		name     string
@@ -1072,6 +1206,46 @@ func TestManifestValidationRejectsAuthoringErrors(t *testing.T) {
 				EventName:  EventNameManifest{Literal: "inbound.badsource"},
 			},
 		},
+		{
+			name: "token equality requires secret",
+			manifest: Manifest{
+				Provider:   "badtokenwithoutsecret",
+				Signature:  SignatureManifest{Type: "token_equality", Header: "X-Token"},
+				DeliveryID: ValueSource{JSONPath: "$.update_id", Required: true},
+				EventType:  ValueSource{Literal: "update", Required: true},
+				EventName:  EventNameManifest{Literal: "inbound.badtokenwithoutsecret"},
+			},
+		},
+		{
+			name: "token equality rejects encoding",
+			manifest: tokenEqualityValidationManifest("badtokenencoding", func(sig *SignatureManifest) {
+				sig.Encoding = "hex"
+			}),
+		},
+		{
+			name: "token equality rejects prefix",
+			manifest: tokenEqualityValidationManifest("badtokenprefix", func(sig *SignatureManifest) {
+				sig.Prefix = "v1="
+			}),
+		},
+		{
+			name: "token equality rejects signed payload",
+			manifest: tokenEqualityValidationManifest("badtokensignedpayload", func(sig *SignatureManifest) {
+				sig.SignedPayload = "raw_body"
+			}),
+		},
+		{
+			name: "token equality rejects signature param",
+			manifest: tokenEqualityValidationManifest("badtokensignatureparam", func(sig *SignatureManifest) {
+				sig.SignatureParam = "v1"
+			}),
+		},
+		{
+			name: "token equality rejects timestamp",
+			manifest: tokenEqualityValidationManifest("badtokentimestamp", func(sig *SignatureManifest) {
+				sig.Timestamp = &TimestampManifest{Header: "X-Timestamp", Tolerance: "5m"}
+			}),
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			if _, err := NewRegistry(tc.manifest); err == nil {
@@ -1094,6 +1268,36 @@ func TestRegistryRejectsEmptyProvider(t *testing.T) {
 func TestNormalizeEventTokenNormalizesProviderTopicSeparators(t *testing.T) {
 	if got := NormalizeEventToken("orders/create"); got != "orders_create" {
 		t.Fatalf("NormalizeEventToken = %q, want orders_create", got)
+	}
+}
+
+func telegramRequest(secret string, body []byte, payload any) Request {
+	req := Request{
+		Provider: "telegram",
+		Target: Target{
+			EntityID:      "entity-1",
+			WebhookSecret: secret,
+		},
+		Body:      body,
+		Headers:   make(http.Header),
+		Payload:   payload,
+		Received:  time.Unix(1710000000, 0).UTC(),
+		UserAgent: "telegram-test",
+	}
+	req.Headers.Set("X-Telegram-Bot-Api-Secret-Token", secret)
+	return req
+}
+
+func tokenEqualityValidationManifest(provider string, mutate func(*SignatureManifest)) Manifest {
+	sig := SignatureManifest{Type: "token_equality", Header: "X-Token"}
+	mutate(&sig)
+	return Manifest{
+		Provider:   provider,
+		Secret:     SecretManifest{Required: true},
+		Signature:  sig,
+		DeliveryID: ValueSource{JSONPath: "$.update_id", Required: true},
+		EventType:  ValueSource{Literal: "update", Required: true},
+		EventName:  EventNameManifest{Literal: "inbound." + provider},
 	}
 }
 

--- a/internal/runtime/inbound_postgres_test.go
+++ b/internal/runtime/inbound_postgres_test.go
@@ -663,6 +663,133 @@ func TestInboundGateway_ShopifySQLitePersistsConfiguredManifestDelivery(t *testi
 	waitForInboundBusQuiescence(t, bus)
 }
 
+func TestInboundGateway_TelegramPostgresPersistsConfiguredManifestDelivery(t *testing.T) {
+	_, db, cleanup := testutil.StartPostgres(t)
+	t.Cleanup(cleanup)
+
+	const (
+		runID             = "4d000000-0000-0000-0000-000000000001"
+		entityID          = "4d000000-0000-0000-0000-000000000002"
+		flowInstance      = "telegram-provider-trigger-instance"
+		entitySlug        = "customer-a"
+		provider          = "telegram"
+		webhookSecret     = "telegram-secret"
+		providerEventID   = "123456789"
+		agentID           = "telegram-webhook-subscriber"
+		providerEventName = "inbound.telegram"
+	)
+	ctx := runtimecorrelation.WithRunID(context.Background(), runID)
+	pg := &store.PostgresStore{DB: db}
+	seedPostgresInboundGatewayRuntime(t, ctx, db, pg, runID, entityID, flowInstance, entitySlug, provider, webhookSecret, agentID)
+
+	bus, err := runtimebus.NewEventBus(pg)
+	if err != nil {
+		t.Fatalf("NewEventBus: %v", err)
+	}
+	ch := bus.Subscribe(agentID, events.EventType(providerEventName))
+	defer bus.Unsubscribe(agentID)
+
+	g := runtimepkg.NewInboundGateway(bus, nil, nil, pg)
+
+	body := []byte(`{"update_id":123456789,"message":{"message_id":7,"chat":{"id":42},"text":"hello"}}`)
+	req := newSignedTelegramRequest("/webhooks/customer-a/telegram", webhookSecret, body)
+	req = req.WithContext(ctx)
+	rec := httptest.NewRecorder()
+	g.Handler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("status = %d, want 202 body=%s", rec.Code, rec.Body.String())
+	}
+	if strings.Contains(rec.Body.String(), webhookSecret) {
+		t.Fatal("Telegram secret token leaked into response")
+	}
+	if got := countPostgresInboundMarkers(t, ctx, db, providerEventID, entityID, provider); got != 1 {
+		t.Fatalf("inbound marker rows = %d, want 1", got)
+	}
+	eventID := loadPostgresInboundProviderEventID(t, ctx, db, runID, entityID, providerEventName, providerEventID)
+	if got := countPostgresInboundProviderEvents(t, ctx, db, runID, entityID, providerEventName, providerEventID); got != 1 {
+		t.Fatalf("provider event rows = %d, want 1", got)
+	}
+	if got := loadPostgresInboundProviderEventPayloadField(t, ctx, db, eventID, "provider_event_type"); got != "update" {
+		t.Fatalf("provider_event_type = %q, want update", got)
+	}
+	if got := countPostgresAgentDeliveriesForEvent(t, ctx, db, eventID, agentID); got != 1 {
+		t.Fatalf("agent delivery rows = %d, want 1", got)
+	}
+	select {
+	case got := <-ch:
+		if got.ID() != eventID || got.Type() != events.EventType(providerEventName) {
+			t.Fatalf("delivered event = %s/%s, want %s/%s", got.ID(), got.Type(), eventID, providerEventName)
+		}
+	default:
+		// Telegram uses durable_before_dispatch; this proof is about persisted
+		// evidence and supported store admission.
+	}
+	waitForInboundBusQuiescence(t, bus)
+}
+
+func TestInboundGateway_TelegramSQLitePersistsConfiguredManifestDelivery(t *testing.T) {
+	const (
+		runID             = "4e000000-0000-0000-0000-000000000001"
+		entityID          = "4e000000-0000-0000-0000-000000000002"
+		flowInstance      = "telegram-sqlite-provider-trigger-instance"
+		entitySlug        = "customer-a"
+		provider          = "telegram"
+		webhookSecret     = "telegram-secret"
+		providerEventID   = "987654321"
+		agentID           = "telegram-sqlite-webhook-subscriber"
+		providerEventName = "inbound.telegram"
+	)
+	ctx := runtimecorrelation.WithRunID(context.Background(), runID)
+	sqliteStore := storetest.StartSQLiteRuntimeStoreWithContext(t, ctx)
+	seedSQLiteInboundGatewayRuntime(t, ctx, sqliteStore, runID, entityID, flowInstance, entitySlug, provider, webhookSecret, agentID)
+
+	bus, err := runtimebus.NewEventBus(sqliteStore)
+	if err != nil {
+		t.Fatalf("NewEventBus: %v", err)
+	}
+	ch := bus.Subscribe(agentID, events.EventType(providerEventName))
+	defer bus.Unsubscribe(agentID)
+
+	g := runtimepkg.NewInboundGateway(bus, nil, nil, sqliteStore)
+
+	body := []byte(`{"update_id":987654321,"message":{"message_id":8,"chat":{"id":42},"text":"hello sqlite"}}`)
+	req := newSignedTelegramRequest("/webhooks/customer-a/telegram", webhookSecret, body)
+	req = req.WithContext(ctx)
+	rec := httptest.NewRecorder()
+	g.Handler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("status = %d, want 202 body=%s", rec.Code, rec.Body.String())
+	}
+	if strings.Contains(rec.Body.String(), webhookSecret) {
+		t.Fatal("Telegram secret token leaked into response")
+	}
+	if got := countSQLiteInboundMarkers(t, ctx, sqliteStore, providerEventID, entityID, provider); got != 1 {
+		t.Fatalf("inbound marker rows = %d, want 1", got)
+	}
+	eventID := loadSQLiteInboundProviderEventID(t, ctx, sqliteStore, runID, entityID, providerEventName, providerEventID)
+	if got := countSQLiteInboundProviderEvents(t, ctx, sqliteStore, runID, entityID, providerEventName, providerEventID); got != 1 {
+		t.Fatalf("provider event rows = %d, want 1", got)
+	}
+	if got := loadSQLiteInboundProviderEventPayloadField(t, ctx, sqliteStore, eventID, "provider_event_type"); got != "update" {
+		t.Fatalf("provider_event_type = %q, want update", got)
+	}
+	if got := countSQLiteAgentDeliveriesForEvent(t, ctx, sqliteStore, eventID, agentID); got != 1 {
+		t.Fatalf("agent delivery rows = %d, want 1", got)
+	}
+	select {
+	case got := <-ch:
+		if got.ID() != eventID || got.Type() != events.EventType(providerEventName) {
+			t.Fatalf("delivered event = %s/%s, want %s/%s", got.ID(), got.Type(), eventID, providerEventName)
+		}
+	default:
+		// Telegram uses durable_before_dispatch; this proof is about persisted
+		// evidence and supported store admission.
+	}
+	waitForInboundBusQuiescence(t, bus)
+}
+
 func TestInboundGateway_TypeformAndIntercomPostgresPersistsConfiguredManifestDelivery(t *testing.T) {
 	for _, tc := range []struct {
 		name              string
@@ -1268,6 +1395,12 @@ func shopifyWebhookSignature(secret string, body []byte) string {
 	mac := hmac.New(sha256.New, []byte(secret))
 	_, _ = mac.Write(body)
 	return base64.StdEncoding.EncodeToString(mac.Sum(nil))
+}
+
+func newSignedTelegramRequest(path string, secret string, body []byte) *http.Request {
+	req := httptest.NewRequest(http.MethodPost, path, strings.NewReader(string(body)))
+	req.Header.Set("X-Telegram-Bot-Api-Secret-Token", secret)
+	return req
 }
 
 func newSignedTypeformRequest(path string, secret string, body []byte) *http.Request {

--- a/internal/runtime/inbound_test.go
+++ b/internal/runtime/inbound_test.go
@@ -1659,6 +1659,223 @@ func TestInboundGateway_TypeformAndIntercomDuplicateDeliveryDoesNotPublishAgain(
 	}
 }
 
+func TestInboundGateway_TelegramManifestOwnsTokenDeliveryIDLiteralEventAndAck(t *testing.T) {
+	eventStore := &capturingInboundEventStore{}
+	started := make(chan struct{}, 1)
+	release := make(chan struct{})
+	var releaseOnce sync.Once
+	releaseDispatch := func() {
+		releaseOnce.Do(func() {
+			close(release)
+		})
+	}
+	t.Cleanup(releaseDispatch)
+	bus, err := runtimebus.NewEventBusWithOptions(eventStore, runtimebus.EventBusOptions{
+		Interceptors: []runtimebus.EventInterceptor{
+			blockingInboundInterceptor{started: started, release: release},
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewEventBusWithOptions: %v", err)
+	}
+	store := &recordingInboundStore{
+		target: InboundTarget{
+			EntityID:      "3fd8fc37-6d02-4d50-8bb7-14c6cb0fed0a",
+			EntitySlug:    "customer-a",
+			WebhookSecret: "telegram-secret",
+		},
+		inserted: true,
+	}
+	g := NewInboundGateway(bus, nil, nil, store)
+
+	body := []byte(`{"update_id":123456789,"message":{"message_id":7,"chat":{"id":42},"text":"hello"}}`)
+	req := newSignedTelegramRequest("/webhooks/customer-a/telegram", "telegram-secret", body)
+	responseDone := make(chan *httptest.ResponseRecorder, 1)
+	go func() {
+		rec := httptest.NewRecorder()
+		g.Handler().ServeHTTP(rec, req)
+		responseDone <- rec
+	}()
+
+	select {
+	case <-started:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Telegram callback post-commit dispatch did not start")
+	}
+	select {
+	case rec := <-responseDone:
+		if rec.Code != http.StatusAccepted {
+			t.Fatalf("status = %d, want 202 body=%s", rec.Code, rec.Body.String())
+		}
+		if strings.Contains(rec.Body.String(), "telegram-secret") {
+			t.Fatal("Telegram secret token leaked into readback")
+		}
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("Telegram callback response waited for post-commit dispatch completion")
+	}
+	if !store.recorded {
+		t.Fatal("expected Telegram delivery to record inbound marker")
+	}
+	if store.providerEventID != "123456789" {
+		t.Fatalf("providerEventID = %q, want 123456789", store.providerEventID)
+	}
+	if store.provider != "telegram" {
+		t.Fatalf("provider = %q, want telegram", store.provider)
+	}
+	if len(eventStore.events) != 1 {
+		t.Fatalf("published events = %d, want 1 before dispatch release", len(eventStore.events))
+	}
+	evt := eventStore.events[0]
+	if evt.Type() != events.EventType("inbound.telegram") {
+		t.Fatalf("event type = %q, want inbound.telegram", evt.Type())
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(evt.Payload(), &payload); err != nil {
+		t.Fatalf("unmarshal payload: %v", err)
+	}
+	headers, ok := payload["headers"].(map[string]any)
+	if !ok {
+		t.Fatalf("headers = %T, want metadata map", payload["headers"])
+	}
+	if payload["provider_event_id"] != "123456789" ||
+		payload["provider_event_type"] != "update" ||
+		payload["provider"] != "telegram" ||
+		headers["telegram_update_id"] != "123456789" ||
+		headers["telegram_update_type"] != "update" {
+		t.Fatalf("payload = %+v, want Telegram manifest delivery identity", payload)
+	}
+	if strings.Contains(string(evt.Payload()), "telegram-secret") {
+		t.Fatal("Telegram secret token leaked into event payload")
+	}
+
+	releaseDispatch()
+	waitCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := bus.WaitForQuiescence(waitCtx); err != nil {
+		t.Fatalf("WaitForQuiescence after dispatch release: %v", err)
+	}
+}
+
+func TestInboundGateway_TelegramRejectsInvalidInputsBeforeMarkerAndPublish(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		body       []byte
+		target     InboundTarget
+		configure  func(*http.Request, []byte)
+		wantStatus int
+	}{
+		{
+			name:       "missing configured secret",
+			body:       []byte(`{"update_id":123456789,"message":{"message_id":7,"text":"hello"}}`),
+			target:     InboundTarget{EntityID: "3fd8fc37-6d02-4d50-8bb7-14c6cb0fed0a", EntitySlug: "customer-a"},
+			configure:  func(*http.Request, []byte) {},
+			wantStatus: http.StatusUnauthorized,
+		},
+		{
+			name:       "missing token header",
+			body:       []byte(`{"update_id":123456789,"message":{"message_id":7,"text":"hello"}}`),
+			configure:  func(req *http.Request, _ []byte) { req.Header.Del("X-Telegram-Bot-Api-Secret-Token") },
+			wantStatus: http.StatusUnauthorized,
+		},
+		{
+			name: "duplicate token header",
+			body: []byte(`{"update_id":123456789,"message":{"message_id":7,"text":"hello"}}`),
+			configure: func(req *http.Request, _ []byte) {
+				req.Header.Add("X-Telegram-Bot-Api-Secret-Token", "telegram-secret")
+			},
+			wantStatus: http.StatusUnauthorized,
+		},
+		{
+			name: "invalid token header",
+			body: []byte(`{"update_id":123456789,"message":{"message_id":7,"text":"hello"}}`),
+			configure: func(req *http.Request, _ []byte) {
+				req.Header.Set("X-Telegram-Bot-Api-Secret-Token", "wrong-secret")
+			},
+			wantStatus: http.StatusUnauthorized,
+		},
+		{
+			name:       "missing update id",
+			body:       []byte(`{"message":{"message_id":7,"text":"hello"}}`),
+			configure:  func(*http.Request, []byte) {},
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:       "non object payload",
+			body:       []byte(`[{"update_id":123456789}]`),
+			configure:  func(*http.Request, []byte) {},
+			wantStatus: http.StatusBadRequest,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			eventStore := &capturingInboundEventStore{}
+			bus, err := runtimebus.NewEventBus(eventStore)
+			if err != nil {
+				t.Fatalf("NewEventBus: %v", err)
+			}
+			target := tc.target
+			if target.EntityID == "" {
+				target = InboundTarget{
+					EntityID:      "3fd8fc37-6d02-4d50-8bb7-14c6cb0fed0a",
+					EntitySlug:    "customer-a",
+					WebhookSecret: "telegram-secret",
+				}
+			}
+			store := &recordingInboundStore{
+				target:   target,
+				inserted: true,
+			}
+			g := NewInboundGateway(bus, nil, nil, store)
+
+			req := newSignedTelegramRequest("/webhooks/customer-a/telegram", "telegram-secret", tc.body)
+			tc.configure(req, tc.body)
+			rec := httptest.NewRecorder()
+			g.Handler().ServeHTTP(rec, req)
+
+			if rec.Code != tc.wantStatus {
+				t.Fatalf("status = %d, want %d body=%s", rec.Code, tc.wantStatus, rec.Body.String())
+			}
+			if store.recorded {
+				t.Fatal("invalid Telegram request recorded inbound marker")
+			}
+			if len(eventStore.events) != 0 {
+				t.Fatalf("published events = %d, want 0", len(eventStore.events))
+			}
+		})
+	}
+}
+
+func TestInboundGateway_TelegramDuplicateDeliveryDoesNotPublishAgain(t *testing.T) {
+	eventStore := &capturingInboundEventStore{}
+	bus, err := runtimebus.NewEventBus(eventStore)
+	if err != nil {
+		t.Fatalf("NewEventBus: %v", err)
+	}
+	store := &recordingInboundStore{
+		target: InboundTarget{
+			EntityID:      "3fd8fc37-6d02-4d50-8bb7-14c6cb0fed0a",
+			EntitySlug:    "customer-a",
+			WebhookSecret: "telegram-secret",
+		},
+		inserted: false,
+	}
+	g := NewInboundGateway(bus, nil, nil, store)
+
+	body := []byte(`{"update_id":123456789,"message":{"message_id":7,"text":"hello"}}`)
+	req := newSignedTelegramRequest("/webhooks/customer-a/telegram", "telegram-secret", body)
+	rec := httptest.NewRecorder()
+	g.Handler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 body=%s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), `"status":"duplicate"`) {
+		t.Fatalf("duplicate response = %s", rec.Body.String())
+	}
+	if len(eventStore.events) != 0 {
+		t.Fatalf("published events = %d, want 0", len(eventStore.events))
+	}
+}
+
 func TestInboundGateway_RawFallbackDoesNotInterpretTypeformOrIntercomSignatures(t *testing.T) {
 	for _, tc := range []struct {
 		name      string
@@ -1711,6 +1928,39 @@ func TestInboundGateway_RawFallbackDoesNotInterpretTypeformOrIntercomSignatures(
 				t.Fatalf("published events = %d, want 0", len(eventStore.events))
 			}
 		})
+	}
+}
+
+func TestInboundGateway_RawFallbackDoesNotInterpretTelegramSecretToken(t *testing.T) {
+	eventStore := &capturingInboundEventStore{}
+	bus, err := runtimebus.NewEventBus(eventStore)
+	if err != nil {
+		t.Fatalf("NewEventBus: %v", err)
+	}
+	store := &recordingInboundStore{
+		target: InboundTarget{
+			EntityID:      "3fd8fc37-6d02-4d50-8bb7-14c6cb0fed0a",
+			EntitySlug:    "customer-a",
+			WebhookSecret: "raw-secret",
+		},
+		inserted: true,
+	}
+	g := NewInboundGateway(bus, nil, nil, store)
+
+	body := []byte(`{"update_id":123456789}`)
+	req := httptest.NewRequest(http.MethodPost, "/webhooks/customer-a/custom", strings.NewReader(string(body)))
+	req.Header.Set("X-Telegram-Bot-Api-Secret-Token", "raw-secret")
+	rec := httptest.NewRecorder()
+	g.Handler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401 body=%s", rec.Code, rec.Body.String())
+	}
+	if store.recorded {
+		t.Fatal("raw fallback accepted Telegram secret token and recorded inbound marker")
+	}
+	if len(eventStore.events) != 0 {
+		t.Fatalf("published events = %d, want 0", len(eventStore.events))
 	}
 }
 
@@ -1879,6 +2129,12 @@ func shopifyWebhookSignature(secret string, body []byte) string {
 	mac := hmac.New(sha256.New, []byte(secret))
 	_, _ = mac.Write(body)
 	return base64.StdEncoding.EncodeToString(mac.Sum(nil))
+}
+
+func newSignedTelegramRequest(path string, secret string, body []byte) *http.Request {
+	req := httptest.NewRequest(http.MethodPost, path, strings.NewReader(string(body)))
+	req.Header.Set("X-Telegram-Bot-Api-Secret-Token", secret)
+	return req
 }
 
 func newSignedTypeformRequest(path string, secret string, body []byte) *http.Request {

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -6122,9 +6122,9 @@ tool_model:
         still fails closed before signature verification, dedupe marker persistence, or event publish when a required
         signing secret is unavailable.
       first_party_pack_migration: >
-        GitHub, Slack, Stripe, Twilio, Shopify, Typeform, and Intercom provider-trigger manifests are first-party bundled
-        packs loaded through this envelope path. There is no permanent built-in-control exemption for configured-provider
-        manifests.
+        GitHub, Slack, Stripe, Twilio, Shopify, Typeform, Intercom, and Telegram provider-trigger manifests are first-party
+        bundled packs loaded through this envelope path. There is no permanent built-in-control exemption for
+        configured-provider manifests.
       non_goals:
       - provider-trigger manifest vocabulary changes
       - pack signing, remote distribution, ownership transfer, or marketplace trust economics
@@ -6140,12 +6140,15 @@ tool_model:
         and requires the relevant signed-payload recipe to fail closed on malformed form input.
       secret.required: require a configured signing secret before accepting the provider callback
       signature: >
-        HMAC-SHA256 or HMAC-SHA1 signature verification over a manifest-selected signed payload, encoded as lowercase hex
-        by default or Base64 when the manifest selects `encoding: base64`. Supported signed payloads are `raw_body`,
-        `slack_v0`, `timestamp_dot_raw_body`, and `url_plus_sorted_form`. The interpreter supports fixed signature
-        prefixes, structured comma-separated signature parameters, timestamp extraction from headers or parameters, replay
-        tolerance windows, exact request URL plus sorted form-parameter canonicalization, and constant-time comparison
-        against every configured signature candidate.
+        Configured-provider authenticity verification. HMAC-SHA256 and HMAC-SHA1 verify a manifest-selected signed payload,
+        encoded as lowercase hex by default or Base64 when the manifest selects `encoding: base64`. Supported signed
+        payloads are `raw_body`, `slack_v0`, `timestamp_dot_raw_body`, and `url_plus_sorted_form`. The interpreter supports
+        fixed signature prefixes, structured comma-separated signature parameters, timestamp extraction from headers or
+        parameters, replay tolerance windows, exact request URL plus sorted form-parameter canonicalization, and
+        constant-time comparison against every configured signature candidate. `token_equality` verifies providers that send
+        the configured signing secret directly in a manifest-selected header; it MUST require `secret.required`, MUST compare
+        the header value to the configured `webhook_signing.<provider>` secret in constant time, and MUST reject HMAC-only
+        fields such as `encoding`, `prefix`, `signed_payload`, `signature_param`, and timestamp settings.
       challenge: >
         Authenticated response-only callback handling. A matched challenge branch must not persist an inbound dedupe marker
         and must not publish a Swarm event.
@@ -6322,6 +6325,25 @@ tool_model:
         Payload `topic` is the authoritative provider event type and is emitted in payload metadata as normalized
         `provider_event_type`. The canonical emitted Swarm event name is literal `inbound.intercom`, not a dynamic
         template. Missing `topic` fails before dedupe marker persistence.
+    - provider: telegram
+      issue: "#1764"
+      signature: >
+        Telegram webhook deliveries require a configured `secret_token` binding and a matching
+        `X-Telegram-Bot-Api-Secret-Token` header. The manifest interpreter MUST compare the header token to
+        `webhook_signing.telegram` in constant time. Missing signing secret, missing token header, duplicate token headers,
+        wrong token header, or any HMAC-style payload/signature interpretation fails before dedupe marker persistence and
+        before event publish.
+      delivery_id: >
+        Payload `update_id` is the authoritative provider delivery id and dedupe-key input for configured Telegram triggers.
+        Missing `update_id` fails before dedupe marker persistence.
+      acknowledgement: >
+        Accepted Telegram deliveries return success after the inbound dedupe marker, canonical event record, recipient
+        manifest, and subscribed replay scope are durably persisted or dispatch-queued. The HTTP acknowledgement MUST NOT
+        wait for post-commit pipeline dispatch, system-node handler execution, or agent delivery completion.
+      event_type: >
+        The approved #1764 slice emits literal provider_event_type `update` in payload metadata. The canonical emitted Swarm
+        event name is literal `inbound.telegram`, not a dynamic template. Granular Telegram update classification from fields
+        such as `message`, `edited_message`, or `callback_query` is a later gated semantic concept.
     raw_webhook_mode: >
       Unknown providers may continue through the raw generic webhook mode, but that path is a different semantic concept and
       does not prove provider-trigger adapter closure. Configured providers MUST consume their manifest interpreter owner


### PR DESCRIPTION
## Summary
- Adds provider-neutral `signature.type: token_equality` validation and verification in `internal/providertriggers`, with constant-time comparison against the configured signing secret and fail-closed rejection of HMAC-only fields.
- Adds the first-party Telegram provider-trigger pack as manifest data, emitting literal `inbound.telegram` with `update_id` as the delivery/dedupe id.
- Extends runtime, pack/readback, SQLite, and Postgres tests for Telegram acceptance, invalid-token failures, missing `update_id`, non-object payload, duplicate dedupe, and raw-fallback non-authority.

Closes #1764
Related to #1651
Related to #1458

## Governing refs / context
- `platform-spec.yaml` `provider_trigger_adapters`: existing gateway owner, `internal/providertriggers` manifest interpreter owner, pack envelope source authority, manifest vocabulary `signature`, event-name policy, `ack.mode`, configured provider manifests, and raw webhook split.
- `platform-spec.yaml` `runtime_ingress.queueable_ingress.inbound.webhook`: served inbound webhooks are queueable ingress and persist/dedupe before dispatch release.
- #1764 Pre-Implementation Coverage Audit and independent gate: approved focused Telegram token-equality provider-trigger slice.

## Semantic migration
- New canonical owner: `platform-spec.yaml` plus `internal/providertriggers` for configured-provider token equality; `internal/providertriggers/packs/telegram` for Telegram manifest data.
- Old/non-authoritative paths now invalid for Telegram closure: raw webhook fallback token equality, URL secrecy, fake HMAC interpretation, runtime Go provider branches, and outbound Telegram mailbox code.
- Production paths checked for surviving old behavior: `internal/runtime/inbound.go` remains generic and delegates to `DefaultRegistry`; raw fallback still rejects `X-Telegram-Bot-Api-Secret-Token`; doctor/provider-pack readback uses verified pack surfaces.
- Migration complete for the chosen class: Telegram configured-provider webhook admission. Live Telegram setup, local Bot API smoke, granular update classification, and outbound Telegram actions remain split.

## Validation
- `go test ./internal/providertriggers -run 'Test.*Telegram|TestDefaultRegistryLoadsFirstPartyProvidersFromVerifiedPlatformPacks|TestManifestValidationRejectsAuthoringErrors|TestProviderTriggerPackVerificationFailsClosed' -count=1`
- `SWARM_TEST_POSTGRES_DSN='host=127.0.0.1 port=5432 user=youmew dbname=postgres sslmode=disable' PGPASSWORD=postgres go test ./internal/runtime -run 'TestInboundGateway_Telegram|TestInboundGateway_RawFallbackDoesNotInterpretTelegramSecretToken' -count=1`
- `go test ./cmd/swarm -run 'TestDoctorClaudeCLIPreflightJSONReportsOKWithoutDB' -count=1`
- `SWARM_TEST_POSTGRES_DSN='host=127.0.0.1 port=5432 user=youmew dbname=postgres sslmode=disable' PGPASSWORD=postgres go test ./internal/runtime -count=1`
- `SWARM_TEST_POSTGRES_DSN='host=127.0.0.1 port=5432 user=youmew dbname=postgres sslmode=disable' PGPASSWORD=postgres go test ./cmd/swarm -count=1`
- `SWARM_TEST_POSTGRES_DSN='host=127.0.0.1 port=5432 user=youmew dbname=postgres sslmode=disable' PGPASSWORD=postgres go test ./...`
