### PR TITLE
[agent-g][issue #1778] Classify run.start parity transitively

### DIFF
--- a/internal/apiv1/public_surface_backend_matrix_test.go
+++ b/internal/apiv1/public_surface_backend_matrix_test.go
@@ -36,10 +36,11 @@ type publicSurfaceMatrixSource struct {
 }
 
 type publicSurfaceMatrixPolicy struct {
-	ClosureLevel                string `yaml:"closure_level"`
-	ClaimsParentClosure         bool   `yaml:"claims_parent_closure"`
-	NamedFullConformanceCommand string `yaml:"named_full_conformance_command"`
-	RequiredSmokePolicy         string `yaml:"required_smoke_policy"`
+	ClosureLevel                          string `yaml:"closure_level"`
+	ClaimsParentClosure                   bool   `yaml:"claims_parent_closure"`
+	NamedFullConformanceCommand           string `yaml:"named_full_conformance_command"`
+	RequiredSmokePolicy                   string `yaml:"required_smoke_policy"`
+	MutatingAPIParityClassificationPolicy string `yaml:"mutating_api_parity_classification_policy"`
 }
 
 type publicSurfaceMatrixRow struct {
@@ -68,15 +69,17 @@ type publicSurfaceProofRef struct {
 }
 
 type publicSurfaceMutatingAPIParityEntry struct {
-	Method           string                  `yaml:"method"`
-	Classification   string                  `yaml:"classification"`
-	Backends         []string                `yaml:"backends,omitempty"`
-	Scenario         string                  `yaml:"scenario,omitempty"`
-	SpecRef          string                  `yaml:"spec_ref,omitempty"`
-	SplitIssue       int                     `yaml:"split_issue,omitempty"`
-	UnsupportedIssue int                     `yaml:"unsupported_issue,omitempty"`
-	ProofRefs        []publicSurfaceProofRef `yaml:"proof_refs"`
-	Notes            string                  `yaml:"notes,omitempty"`
+	Method            string                  `yaml:"method"`
+	Classification    string                  `yaml:"classification"`
+	Backends          []string                `yaml:"backends,omitempty"`
+	Scenario          string                  `yaml:"scenario,omitempty"`
+	CoveredByMethod   string                  `yaml:"covered_by_method,omitempty"`
+	CoveredByScenario string                  `yaml:"covered_by_scenario,omitempty"`
+	SpecRef           string                  `yaml:"spec_ref,omitempty"`
+	SplitIssue        int                     `yaml:"split_issue,omitempty"`
+	UnsupportedIssue  int                     `yaml:"unsupported_issue,omitempty"`
+	ProofRefs         []publicSurfaceProofRef `yaml:"proof_refs"`
+	Notes             string                  `yaml:"notes,omitempty"`
 }
 
 type publicSurfaceValidationContext struct {
@@ -435,6 +438,62 @@ func TestPublicSurfaceBackendMatrixRejectsStaleReferences(t *testing.T) {
 			},
 			want: "ledger method event.publish dual_backend_served_proof backends = [default_sqlite], want [default_sqlite explicit_postgres]",
 		},
+		{
+			name: "mutating api ledger rejects transitive coverage without covered method",
+			mutate: func(matrix *publicSurfaceBackendMatrix) {
+				entry := publicSurfaceMutatingLedgerEntryByMethod(t, matrix, "run.start")
+				entry.Classification = "covered_transitively"
+				entry.Backends = []string{"default_sqlite", "explicit_postgres"}
+				entry.CoveredByMethod = ""
+				entry.CoveredByScenario = "event_publish_dynamic_auto_emit_lifecycle"
+				entry.ProofRefs = []publicSurfaceProofRef{
+					{Kind: "go_test", Name: "TestServedParityHarnessEventPublishDynamicAutoEmitLifecycle"},
+				}
+			},
+			want: "ledger method run.start covered_transitively missing covered_by_method",
+		},
+		{
+			name: "mutating api ledger rejects transitive coverage without scenario",
+			mutate: func(matrix *publicSurfaceBackendMatrix) {
+				entry := publicSurfaceMutatingLedgerEntryByMethod(t, matrix, "run.start")
+				entry.Classification = "covered_transitively"
+				entry.Backends = []string{"default_sqlite", "explicit_postgres"}
+				entry.CoveredByMethod = "event.publish"
+				entry.CoveredByScenario = ""
+				entry.ProofRefs = []publicSurfaceProofRef{
+					{Kind: "go_test", Name: "TestServedParityHarnessEventPublishDynamicAutoEmitLifecycle"},
+				}
+			},
+			want: "ledger method run.start covered_transitively missing covered_by_scenario",
+		},
+		{
+			name: "mutating api ledger rejects transitive coverage over split method",
+			mutate: func(matrix *publicSurfaceBackendMatrix) {
+				entry := publicSurfaceMutatingLedgerEntryByMethod(t, matrix, "run.start")
+				entry.Classification = "covered_transitively"
+				entry.Backends = []string{"default_sqlite", "explicit_postgres"}
+				entry.CoveredByMethod = "event.replay"
+				entry.CoveredByScenario = "event_publish_dynamic_auto_emit_lifecycle"
+				entry.ProofRefs = []publicSurfaceProofRef{
+					{Kind: "go_test", Name: "TestServedParityHarnessEventPublishDynamicAutoEmitLifecycle"},
+				}
+			},
+			want: "ledger method run.start covered_by_method event.replay classification = \"split_with_issue_ref\", want dual_backend_served_proof",
+		},
+		{
+			name: "mutating api ledger rejects transitive coverage with wrong scenario method",
+			mutate: func(matrix *publicSurfaceBackendMatrix) {
+				entry := publicSurfaceMutatingLedgerEntryByMethod(t, matrix, "run.start")
+				entry.Classification = "covered_transitively"
+				entry.Backends = []string{"default_sqlite", "explicit_postgres"}
+				entry.CoveredByMethod = "run.start"
+				entry.CoveredByScenario = "event_publish_dynamic_auto_emit_lifecycle"
+				entry.ProofRefs = []publicSurfaceProofRef{
+					{Kind: "go_test", Name: "TestServedParityHarnessEventPublishDynamicAutoEmitLifecycle"},
+				}
+			},
+			want: "ledger method run.start covered_by_method must differ from method",
+		},
 	}
 
 	for _, tc := range tests {
@@ -721,6 +780,8 @@ func validatePublicSurfaceMutatingAPIParityLedger(root string, entries []publicS
 		switch entry.Classification {
 		case "dual_backend_served_proof":
 			problems = append(problems, validatePublicSurfaceMutatingLedgerDualProof(label, entry, ctx)...)
+		case "covered_transitively":
+			problems = append(problems, validatePublicSurfaceMutatingLedgerTransitiveCoverage(label, entry, entries, ctx)...)
 		case "postgres_only_with_spec_ref":
 			if !publicSurfaceSameStringSet(entry.Backends, []string{"postgres_only"}) {
 				problems = append(problems, fmt.Sprintf("%s postgres_only_with_spec_ref backends = %v, want [postgres_only]", label, publicSurfaceSortedStrings(entry.Backends)))
@@ -837,6 +898,82 @@ func validatePublicSurfaceMutatingLedgerDualProof(label string, entry publicSurf
 		if ref.Kind == "go_test" && ref.Name != scenario.TestName {
 			problems = append(problems, fmt.Sprintf("%s dual_backend_served_proof go_test proof_ref %s is not the served parity harness test %s", label, ref.Name, scenario.TestName))
 		}
+	}
+	return problems
+}
+
+func validatePublicSurfaceMutatingLedgerTransitiveCoverage(label string, entry publicSurfaceMutatingAPIParityEntry, entries []publicSurfaceMutatingAPIParityEntry, ctx publicSurfaceValidationContext) []string {
+	var problems []string
+	if !publicSurfaceSameStringSet(entry.Backends, []string{"default_sqlite", "explicit_postgres"}) {
+		problems = append(problems, fmt.Sprintf("%s covered_transitively backends = %v, want [default_sqlite explicit_postgres]", label, publicSurfaceSortedStrings(entry.Backends)))
+	}
+	coveredByMethod := strings.TrimSpace(entry.CoveredByMethod)
+	if coveredByMethod == "" {
+		problems = append(problems, fmt.Sprintf("%s covered_transitively missing covered_by_method", label))
+	}
+	if coveredByMethod == strings.TrimSpace(entry.Method) {
+		problems = append(problems, fmt.Sprintf("%s covered_by_method must differ from method", label))
+	}
+	if coveredByMethod != "" {
+		if _, ok := ctx.mutatingAPIMethods[coveredByMethod]; !ok {
+			problems = append(problems, fmt.Sprintf("%s covered_by_method %s is not declared in platform idempotency mutating_methods", label, coveredByMethod))
+		}
+		if _, ok := ctx.apiMethods[coveredByMethod]; !ok {
+			problems = append(problems, fmt.Sprintf("%s covered_by_method %s missing from platform method_catalog", label, coveredByMethod))
+		}
+		if _, ok := ctx.openRPCMethods[coveredByMethod]; !ok {
+			problems = append(problems, fmt.Sprintf("%s covered_by_method %s missing from generated openrpc.json", label, coveredByMethod))
+		}
+		coveredEntry, ok := publicSurfaceMutatingLedgerEntry(entries, coveredByMethod)
+		if !ok {
+			problems = append(problems, fmt.Sprintf("%s covered_by_method %s missing from mutating api parity ledger", label, coveredByMethod))
+		} else if coveredEntry.Classification != "dual_backend_served_proof" {
+			problems = append(problems, fmt.Sprintf("%s covered_by_method %s classification = %q, want dual_backend_served_proof", label, coveredByMethod, coveredEntry.Classification))
+		}
+	}
+	coveredByScenario := strings.TrimSpace(entry.CoveredByScenario)
+	if coveredByScenario == "" {
+		problems = append(problems, fmt.Sprintf("%s covered_transitively missing covered_by_scenario", label))
+		return problems
+	}
+	if coveredEntry, ok := publicSurfaceMutatingLedgerEntry(entries, coveredByMethod); ok &&
+		coveredEntry.Classification == "dual_backend_served_proof" &&
+		strings.TrimSpace(coveredEntry.Scenario) != coveredByScenario {
+		problems = append(problems, fmt.Sprintf("%s covered_by_scenario %s does not match covered_by_method %s scenario %s", label, coveredByScenario, coveredByMethod, coveredEntry.Scenario))
+	}
+	scenario, ok := ctx.servedScenarios[coveredByScenario]
+	if !ok {
+		problems = append(problems, fmt.Sprintf("%s covered_transitively covered_by_scenario %s is not registered in served parity harness", label, coveredByScenario))
+		return problems
+	}
+	if scenario.APIMethod != coveredByMethod {
+		problems = append(problems, fmt.Sprintf("%s covered_by_scenario %s api_method = %s, want covered_by_method %s", label, scenario.ID, scenario.APIMethod, coveredByMethod))
+	}
+	for _, backend := range servedparity.RequiredBackends {
+		if !publicSurfaceScenarioHasBackend(scenario, backend) {
+			problems = append(problems, fmt.Sprintf("%s covered_by_scenario %s missing backend %s", label, scenario.ID, backend))
+		}
+	}
+	for _, postcondition := range []servedparity.Postcondition{
+		servedparity.PostconditionNoNonTerminalDeliveries,
+		servedparity.PostconditionNoPendingPipelineEvents,
+		servedparity.PostconditionNoUnfiredDueTimers,
+	} {
+		if !publicSurfaceScenarioHasPostcondition(scenario, postcondition) {
+			problems = append(problems, fmt.Sprintf("%s covered_by_scenario %s missing postcondition %s", label, scenario.ID, postcondition))
+		}
+	}
+	if !publicSurfaceHasGoTestProof(entry.ProofRefs, scenario.TestName) {
+		problems = append(problems, fmt.Sprintf("%s covered_transitively missing served parity harness go_test proof_ref %s", label, scenario.TestName))
+	}
+	for _, ref := range entry.ProofRefs {
+		if ref.Kind == "go_test" && ref.Name != scenario.TestName {
+			problems = append(problems, fmt.Sprintf("%s covered_transitively go_test proof_ref %s is not the covered served parity harness test %s", label, ref.Name, scenario.TestName))
+		}
+	}
+	notes := strings.TrimSpace(entry.Notes)
+	if !strings.Contains(notes, "Deprecated wrapper") || (coveredByMethod != "" && !strings.Contains(notes, coveredByMethod)) {
+		problems = append(problems, fmt.Sprintf("%s covered_transitively notes must justify deprecated wrapper coverage through %s", label, coveredByMethod))
 	}
 	return problems
 }
@@ -1077,6 +1214,12 @@ func validatePublicSurfacePolicy(policy publicSurfaceMatrixPolicy) []string {
 	}
 	if strings.TrimSpace(policy.RequiredSmokePolicy) == "" {
 		problems = append(problems, "policy required_smoke_policy missing")
+	}
+	classificationPolicy := strings.TrimSpace(policy.MutatingAPIParityClassificationPolicy)
+	if classificationPolicy == "" {
+		problems = append(problems, "policy mutating_api_parity_classification_policy missing")
+	} else if !strings.Contains(classificationPolicy, "covered_transitively") || !strings.Contains(strings.ToLower(classificationPolicy), "deprecated wrapper") {
+		problems = append(problems, "policy mutating_api_parity_classification_policy must document covered_transitively deprecated wrapper handling")
 	}
 	return problems
 }
@@ -1328,6 +1471,15 @@ func publicSurfaceMutatingLedgerEntryByMethod(t *testing.T, matrix *publicSurfac
 	return nil
 }
 
+func publicSurfaceMutatingLedgerEntry(entries []publicSurfaceMutatingAPIParityEntry, method string) (publicSurfaceMutatingAPIParityEntry, bool) {
+	for _, entry := range entries {
+		if entry.Method == method {
+			return entry, true
+		}
+	}
+	return publicSurfaceMutatingAPIParityEntry{}, false
+}
+
 func publicSurfaceProblemsContain(problems []string, want string) bool {
 	for _, problem := range problems {
 		if strings.Contains(problem, want) {
@@ -1550,6 +1702,7 @@ func allowedPublicSurfaceClassifications() map[string]struct{} {
 func allowedPublicSurfaceMutatingLedgerClassifications() map[string]struct{} {
 	return complianceStringSet([]string{
 		"dual_backend_served_proof",
+		"covered_transitively",
 		"postgres_only_with_spec_ref",
 		"unsupported_with_issue_ref",
 		"split_with_issue_ref",

--- a/internal/apiv1/public_surface_backend_matrix_test.go
+++ b/internal/apiv1/public_surface_backend_matrix_test.go
@@ -84,12 +84,18 @@ type publicSurfaceMutatingAPIParityEntry struct {
 
 type publicSurfaceValidationContext struct {
 	apiMethods           map[string]struct{}
+	apiMethodInfo        map[string]publicSurfaceAPIMethodInfo
 	mutatingAPIMethods   map[string]struct{}
 	openRPCMethods       map[string]struct{}
 	openRPCMatrixMethods map[string]struct{}
 	cliCommands          map[string]struct{}
 	goTests              map[string]string
 	servedScenarios      map[string]servedparity.Scenario
+}
+
+type publicSurfaceAPIMethodInfo struct {
+	Deprecated  bool
+	Description string
 }
 
 func TestPublicSurfaceBackendMatrixCoversSelectedBackendRows(t *testing.T) {
@@ -494,6 +500,22 @@ func TestPublicSurfaceBackendMatrixRejectsStaleReferences(t *testing.T) {
 			},
 			want: "ledger method run.start covered_by_method must differ from method",
 		},
+		{
+			name: "mutating api ledger rejects transitive coverage for non-deprecated mutator",
+			mutate: func(matrix *publicSurfaceBackendMatrix) {
+				entry := publicSurfaceMutatingLedgerEntryByMethod(t, matrix, "run.stop")
+				entry.Classification = "covered_transitively"
+				entry.Backends = []string{"default_sqlite", "explicit_postgres"}
+				entry.CoveredByMethod = "event.publish"
+				entry.CoveredByScenario = "event_publish_dynamic_auto_emit_lifecycle"
+				entry.SplitIssue = 0
+				entry.ProofRefs = []publicSurfaceProofRef{
+					{Kind: "go_test", Name: "TestServedParityHarnessEventPublishDynamicAutoEmitLifecycle"},
+				}
+				entry.Notes = "Deprecated wrapper over event.publish."
+			},
+			want: "ledger method run.stop covered_transitively requires deprecated method_catalog entry",
+		},
 	}
 
 	for _, tc := range tests {
@@ -532,8 +554,13 @@ func newPublicSurfaceValidationContext(t *testing.T, root string) publicSurfaceV
 	}
 
 	apiMethods := map[string]struct{}{}
-	for name := range api.MethodCatalog {
+	apiMethodInfo := map[string]publicSurfaceAPIMethodInfo{}
+	for name, method := range api.MethodCatalog {
 		apiMethods[name] = struct{}{}
+		apiMethodInfo[name] = publicSurfaceAPIMethodInfo{
+			Deprecated:  method.Deprecated,
+			Description: method.Description,
+		}
 	}
 	mutatingAPIMethods := map[string]struct{}{}
 	for _, method := range api.Conventions.Idempotency.MutatingMethods {
@@ -550,6 +577,7 @@ func newPublicSurfaceValidationContext(t *testing.T, root string) publicSurfaceV
 
 	return publicSurfaceValidationContext{
 		apiMethods:           apiMethods,
+		apiMethodInfo:        apiMethodInfo,
 		mutatingAPIMethods:   mutatingAPIMethods,
 		openRPCMethods:       openRPCMethods,
 		openRPCMatrixMethods: openRPCMatrixMethods,
@@ -914,6 +942,14 @@ func validatePublicSurfaceMutatingLedgerTransitiveCoverage(label string, entry p
 	if coveredByMethod == strings.TrimSpace(entry.Method) {
 		problems = append(problems, fmt.Sprintf("%s covered_by_method must differ from method", label))
 	}
+	if methodInfo, ok := ctx.apiMethodInfo[strings.TrimSpace(entry.Method)]; ok {
+		if !methodInfo.Deprecated {
+			problems = append(problems, fmt.Sprintf("%s covered_transitively requires deprecated method_catalog entry", label))
+		}
+		if coveredByMethod != "" && !publicSurfaceMethodCatalogDeclaresDeprecatedWrapper(methodInfo, coveredByMethod) {
+			problems = append(problems, fmt.Sprintf("%s method_catalog description must declare deprecated wrapper coverage through %s", label, coveredByMethod))
+		}
+	}
 	if coveredByMethod != "" {
 		if _, ok := ctx.mutatingAPIMethods[coveredByMethod]; !ok {
 			problems = append(problems, fmt.Sprintf("%s covered_by_method %s is not declared in platform idempotency mutating_methods", label, coveredByMethod))
@@ -971,11 +1007,13 @@ func validatePublicSurfaceMutatingLedgerTransitiveCoverage(label string, entry p
 			problems = append(problems, fmt.Sprintf("%s covered_transitively go_test proof_ref %s is not the covered served parity harness test %s", label, ref.Name, scenario.TestName))
 		}
 	}
-	notes := strings.TrimSpace(entry.Notes)
-	if !strings.Contains(notes, "Deprecated wrapper") || (coveredByMethod != "" && !strings.Contains(notes, coveredByMethod)) {
-		problems = append(problems, fmt.Sprintf("%s covered_transitively notes must justify deprecated wrapper coverage through %s", label, coveredByMethod))
-	}
 	return problems
+}
+
+func publicSurfaceMethodCatalogDeclaresDeprecatedWrapper(method publicSurfaceAPIMethodInfo, coveredByMethod string) bool {
+	description := strings.ToLower(method.Description)
+	return strings.Contains(description, "deprecated wrapper") &&
+		strings.Contains(method.Description, coveredByMethod)
 }
 
 func publicSurfaceSpecRefExists(root, specRef string) error {

--- a/internal/apiv1/testdata/public_surface_backend_matrix.yaml
+++ b/internal/apiv1/testdata/public_surface_backend_matrix.yaml
@@ -16,6 +16,14 @@ policy:
     public surfaces. The matrix composes existing selected-store, real v1 handler,
     and CLI exact-method proofs instead of expanding every surface into a backend
     Cartesian product.
+  mutating_api_parity_classification_policy: >
+    Every mutating public method must be classified as direct
+    dual_backend_served_proof, covered_transitively, postgres_only_with_spec_ref,
+    unsupported_with_issue_ref, or split_with_issue_ref. Deprecated wrapper
+    methods whose behavior is inherited from a directly proven mutating method
+    use covered_transitively and must name the covered method, covered harness
+    scenario, and live proof refs; this classification must not be used as a
+    generic bypass for methods with independent backend-sensitive behavior.
 active_trackers:
   - kind: github_issue
     issue: 1239
@@ -66,9 +74,18 @@ mutating_api_parity_ledger:
     split_issue: 1386
     proof_refs: [{kind: tracker, issue: 1386, watchlist: runtime_operations.runtime_store_backend_default_and_sqlite_portability}]
   - method: run.start
-    classification: split_with_issue_ref
-    split_issue: 1386
-    proof_refs: [{kind: tracker, issue: 1386, watchlist: runtime_operations.runtime_store_backend_default_and_sqlite_portability}]
+    classification: covered_transitively
+    backends: [default_sqlite, explicit_postgres]
+    covered_by_method: event.publish
+    covered_by_scenario: event_publish_dynamic_auto_emit_lifecycle
+    proof_refs:
+      - kind: go_test
+        name: TestServedParityHarnessEventPublishDynamicAutoEmitLifecycle
+    notes: >
+      Deprecated wrapper over event.publish. The wrapper delegates to the
+      canonical event-publication owner, and served dual-backend parity is
+      covered transitively by the event.publish servedparity scenario rather
+      than by a dedicated wrapper scenario.
   - method: run.stop
     classification: split_with_issue_ref
     split_issue: 1386


### PR DESCRIPTION
## Summary

Closes #1778.

Adds `covered_transitively` as a first-class mutating API parity ledger classification and reclassifies only `run.start` through the existing `event.publish` servedparity proof. This follows the lead gate outcome on #1778: `run.start` is a deprecated wrapper over `event.publish`, so it should not get a dedicated servedparity scenario.

## Governing Refs

- `platform-spec.yaml#api_specification.conventions.idempotency.mutating_methods`
- `platform-spec.yaml#api_specification.method_catalog.run.start`
- `platform-spec.yaml#api_specification.method_catalog.event.publish`
- `platform-spec.yaml#engine.runtime_store_backend_selection`
- `platform-spec.yaml#engine.runtime_core_persistence_store_contracts`
- #1778 gate outcome: resolved by classification, do not build the harness scenario

## Semantic Migration

- New canonical classification: `covered_transitively` in `internal/apiv1/testdata/public_surface_backend_matrix.yaml#mutating_api_parity_ledger`.
- Old non-authoritative path now invalid: leaving deprecated wrappers as `split_with_issue_ref` when they are already behaviorally covered by a direct dual-backend served proof.
- Production paths checked for old behavior: no runtime paths changed; this is ledger/validator-only.
- Migration completeness: complete for `run.start` only. Other mutating methods remain #1386 split tails.

## Validation

- `go test ./internal/apiv1 -run TestPublicSurfaceBackendMatrix -count=1`
- `go test ./internal/servedparity -count=1`
- `SWARM_TEST_POSTGRES_DSN='host=localhost port=5432 user=postgres password=postgres dbname=postgres sslmode=disable' go test ./internal/apiv1 -count=1`
- `HOME=$(mktemp -d) SWARM_TEST_POSTGRES_DSN='host=localhost port=5432 user=postgres password=postgres dbname=postgres sslmode=disable' go test ./cmd/swarm -count=1`
- `HOME=$(mktemp -d) SWARM_TEST_POSTGRES_DSN='host=localhost port=5432 user=postgres password=postgres dbname=postgres sslmode=disable' go test ./...`

The isolated `HOME` avoids local `~/.swarm` credentials affecting credential-store-sensitive doctor tests.
