### PR TITLE
[agent-c][issue #1670] Add embedded Python compute modules

### DIFF
--- a/cmd/swarm/bundle_test.go
+++ b/cmd/swarm/bundle_test.go
@@ -424,7 +424,11 @@ func TestBundleBuildMaterializesContractsAndJSONReport(t *testing.T) {
 	if module := report.Modules[0]; module.ID != "structured_renderer" || module.Kind != "wasm" || module.Path != "modules/structured_renderer.wasm" || module.SourcePath != "src/structured_renderer.rs" || module.SourceHash == "" {
 		t.Fatalf("report module = %#v", module)
 	}
-	if len(report.Steps) != 1 || report.Steps[0].Name != "wasm_policy_modules" || report.Steps[0].Status != "passed" {
+	if len(report.Steps) != 2 ||
+		report.Steps[0].Name != "wasm_policy_modules" ||
+		report.Steps[0].Status != "passed" ||
+		report.Steps[1].Name != "python_policy_modules" ||
+		report.Steps[1].Status != "passed" {
 		t.Fatalf("report steps = %#v", report.Steps)
 	}
 }

--- a/internal/runtime/bootverify/workflow_compute_module_checks.go
+++ b/internal/runtime/bootverify/workflow_compute_module_checks.go
@@ -7,6 +7,7 @@ import (
 	"github.com/division-sh/swarm/internal/runtime/computemodule"
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
 	runtimepaths "github.com/division-sh/swarm/internal/runtime/core/paths"
+	"github.com/division-sh/swarm/internal/runtime/pythonmodule"
 	"github.com/division-sh/swarm/internal/runtime/semanticview"
 )
 
@@ -103,11 +104,11 @@ func validateComputeModuleValueRow(source semanticview.Source, ref computeModule
 		if !hasBundle || bundle == nil {
 			findings = append(findings, computeModuleFinding(ref, "compute_module boot verification requires a workflow contract bundle source"))
 		} else {
-			bytes, _, err := runtimecontracts.PolicyModuleBytes(bundle, module)
+			moduleBytes, _, err := runtimecontracts.PolicyModuleBytes(bundle, module)
 			if err != nil {
 				findings = append(findings, computeModuleFinding(ref, fmt.Sprintf("module bytes unavailable: %v", err)))
-			} else if err := computemodule.ValidateCoreJSONModule(bytes, module.Entry, module.Limits.MemoryPages); err != nil {
-				findings = append(findings, computeModuleFinding(ref, fmt.Sprintf("module ABI/import validation failed: %v", err)))
+			} else if err := validateComputeModuleArtifact(ref, moduleID, module, moduleBytes); err != nil {
+				findings = append(findings, computeModuleFinding(ref, fmt.Sprintf("module validation failed: %v", err)))
 			}
 		}
 	}
@@ -115,4 +116,32 @@ func validateComputeModuleValueRow(source semanticview.Source, ref computeModule
 		findings = append(findings, computeModuleFinding(ref, fmt.Sprintf("compute_module.into %q is not consumed by a supported downstream condition, emit field, activity input, fan_out, or expression", storeAs)))
 	}
 	return findings
+}
+
+func validateComputeModuleArtifact(ref computeModuleRef, moduleID string, module runtimecontracts.PolicyModule, moduleBytes []byte) error {
+	switch computeModuleKind(module) {
+	case "wasm":
+		return computemodule.ValidateCoreJSONModule(moduleBytes, module.Entry, module.Limits.MemoryPages)
+	case pythonmodule.Kind:
+		return pythonmodule.ValidateSource(pythonmodule.Request{
+			ModuleID:    moduleID,
+			RowID:       ref.RowLabel(),
+			Digest:      strings.TrimSpace(module.Digest),
+			Entry:       strings.TrimSpace(module.Entry),
+			Source:      moduleBytes,
+			Fuel:        module.Limits.Gas,
+			MemoryPages: module.Limits.MemoryPages,
+			OutputBytes: module.Limits.OutputBytes,
+		})
+	default:
+		return fmt.Errorf("unsupported module kind %q", strings.TrimSpace(module.Kind))
+	}
+}
+
+func computeModuleKind(module runtimecontracts.PolicyModule) string {
+	kind := strings.TrimSpace(module.Kind)
+	if kind == "" {
+		return "wasm"
+	}
+	return kind
 }

--- a/internal/runtime/bootverify/workflow_compute_module_checks_test.go
+++ b/internal/runtime/bootverify/workflow_compute_module_checks_test.go
@@ -10,6 +10,7 @@ import (
 
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
 	runtimepaths "github.com/division-sh/swarm/internal/runtime/core/paths"
+	"github.com/division-sh/swarm/internal/runtime/pythonmodule"
 	"github.com/division-sh/swarm/internal/runtime/semanticview"
 )
 
@@ -26,6 +27,14 @@ func TestCheckComputeModuleValueRowsRejectsDeadBinding(t *testing.T) {
 	findings := checkComputeModuleValueRows(&checkerContext{source: source})
 	if !computeModuleFindingContains(findings, "is not consumed") {
 		t.Fatalf("findings = %#v, want dead binding", findings)
+	}
+}
+
+func TestCheckComputeModuleValueRowsDispatchesPythonValidation(t *testing.T) {
+	source := pythonComputeModuleCheckSource(t)
+	findings := checkComputeModuleValueRows(&checkerContext{source: source})
+	if len(findings) > 0 {
+		t.Fatalf("findings = %#v, want none", findings)
 	}
 }
 
@@ -81,6 +90,73 @@ func computeModuleCheckSource(t *testing.T, consumed bool) semanticview.Source {
 			Condition: `computed.rendered_bundle.format == "yaml"`,
 			Emit:      runtimecontracts.EmitSpec{Event: "bundle.rendered"},
 		})
+	}
+	return semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
+		Paths: runtimecontracts.ContractPaths{ContractsRoot: root},
+		Policy: runtimecontracts.PolicyDocument{Modules: map[string]runtimecontracts.PolicyModule{
+			"structured_renderer": module,
+		}},
+		Nodes: map[string]runtimecontracts.SystemNodeContract{
+			"render-node": {
+				ID: "render-node",
+				EventHandlers: map[string]runtimecontracts.SystemNodeEventHandler{
+					"render.requested": {Rules: rules},
+				},
+			},
+		},
+	})
+}
+
+func pythonComputeModuleCheckSource(t *testing.T) semanticview.Source {
+	t.Helper()
+	root := t.TempDir()
+	raw := []byte("def handle(input):\n    return {\"content\": input[\"component\"], \"format\": \"yaml\"}\n")
+	modulePath := filepath.Join(root, "modules", "structured_renderer.py")
+	if err := os.MkdirAll(filepath.Dir(modulePath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(modulePath, raw, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	sum := sha256.Sum256(raw)
+	module := runtimecontracts.PolicyModule{
+		Path:   "modules/structured_renderer.py",
+		Kind:   pythonmodule.Kind,
+		ABI:    pythonmodule.ABI,
+		Entry:  pythonmodule.DefaultEntry,
+		Digest: "sha256:" + hex.EncodeToString(sum[:]),
+		Limits: runtimecontracts.PolicyModuleLimits{
+			Gas:         2_000_000_000,
+			MemoryPages: 8192,
+			OutputBytes: 1024,
+		},
+	}
+	spec := &runtimecontracts.ComputeModuleSpec{
+		RowID:  "render_bundle",
+		Module: "structured_renderer",
+		Into:   "computed.rendered_bundle",
+		Input: map[string]string{
+			"component": "payload.component",
+		},
+		InputPaths: map[string]runtimepaths.Path{
+			"component": runtimepaths.Parse("payload.component"),
+		},
+	}
+	rules := []runtimecontracts.HandlerRuleEntry{
+		{
+			ID:        "render_bundle",
+			PolicyRow: runtimecontracts.PolicySheetRowMetadata{Kind: runtimecontracts.PolicySheetRowKindModule, Module: spec},
+			Compute: &runtimecontracts.ComputeSpec{
+				Operation: runtimecontracts.ComputeOpModule,
+				StoreAs:   "computed.rendered_bundle",
+				Module:    spec,
+			},
+		},
+		{
+			ID:        "rendered_yaml",
+			Condition: `computed.rendered_bundle.format == "yaml"`,
+			Emit:      runtimecontracts.EmitSpec{Event: "bundle.rendered"},
+		},
 	}
 	return semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
 		Paths: runtimecontracts.ContractPaths{ContractsRoot: root},

--- a/internal/runtime/computemodule/engine.go
+++ b/internal/runtime/computemodule/engine.go
@@ -24,16 +24,18 @@ const (
 type Code string
 
 const (
-	CodeCompile      Code = "compute_module_compile"
-	CodeDigest       Code = "compute_module_digest"
-	CodeImport       Code = "compute_module_import"
-	CodeABI          Code = "compute_module_abi"
-	CodeMemory       Code = "compute_module_memory_limit"
-	CodeFuel         Code = "compute_module_fuel_exhausted"
-	CodeTrap         Code = "compute_module_trap"
-	CodeOutputSize   Code = "compute_module_output_size"
-	CodeOutputBounds Code = "compute_module_output_bounds"
-	CodeReplay       Code = "compute_module_replay_divergence"
+	CodeCompile          Code = "compute_module_compile"
+	CodeDigest           Code = "compute_module_digest"
+	CodeImport           Code = "compute_module_import"
+	CodeABI              Code = "compute_module_abi"
+	CodeMemory           Code = "compute_module_memory_limit"
+	CodeFuel             Code = "compute_module_fuel_exhausted"
+	CodeTrap             Code = "compute_module_trap"
+	CodeOutputSize       Code = "compute_module_output_size"
+	CodeOutputBounds     Code = "compute_module_output_bounds"
+	CodeDeniedCapability Code = "compute_module_denied_capability"
+	CodePythonException  Code = "compute_module_python_exception"
+	CodeReplay           Code = "compute_module_replay_divergence"
 )
 
 type ModuleImport struct {

--- a/internal/runtime/contracts/bundle_build.go
+++ b/internal/runtime/contracts/bundle_build.go
@@ -10,13 +10,17 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+
+	"github.com/division-sh/swarm/internal/runtime/pythonmodule"
 )
 
 const (
 	bundleBuildManifestAPIVersion = "swarm.bundle.build.v1"
 	bundleBuildManifestPath       = "build-manifest.json"
 	bundleBuildStepWasmModules    = "wasm_policy_modules"
+	bundleBuildStepPythonModules  = "python_policy_modules"
 	bundleBuildKindWasm           = "wasm"
+	bundleBuildKindPython         = pythonmodule.Kind
 )
 
 var bundleBuildReservedArtifactPaths = map[string]string{
@@ -71,13 +75,17 @@ type BundleBuildManifest struct {
 }
 
 type BundleBuildModule struct {
-	ID         string `json:"id"`
-	FlowID     string `json:"flow_id,omitempty"`
-	Kind       string `json:"kind"`
-	Path       string `json:"path"`
-	Digest     string `json:"digest"`
-	SourcePath string `json:"source_path,omitempty"`
-	SourceHash string `json:"source_hash"`
+	ID                string `json:"id"`
+	FlowID            string `json:"flow_id,omitempty"`
+	Kind              string `json:"kind"`
+	Path              string `json:"path"`
+	Digest            string `json:"digest"`
+	SourcePath        string `json:"source_path,omitempty"`
+	SourceHash        string `json:"source_hash"`
+	Interpreter       string `json:"interpreter,omitempty"`
+	InterpreterDigest string `json:"interpreter_digest,omitempty"`
+	SnapshotDigest    string `json:"snapshot_digest,omitempty"`
+	HarnessABI        string `json:"harness_abi,omitempty"`
 }
 
 type BundleBuildInput struct {
@@ -98,7 +106,7 @@ type BundleBuildDiagnostic struct {
 }
 
 func DefaultBundleBuildSteps() []BundleBuildStep {
-	return []BundleBuildStep{wasmPolicyModulesBuildStep{}}
+	return []BundleBuildStep{wasmPolicyModulesBuildStep{}, pythonPolicyModulesBuildStep{}}
 }
 
 func BundleBuildStepNames(steps []BundleBuildStep) []string {
@@ -264,8 +272,39 @@ func (wasmPolicyModulesBuildStep) Run(_ context.Context, ctx *BundleBuildContext
 		return fmt.Errorf("bundle build context is required")
 	}
 	for _, module := range ctx.Modules {
-		if module.Kind != bundleBuildKindWasm {
+		if module.Kind == bundleBuildKindWasm {
+			continue
+		}
+		if module.Kind != bundleBuildKindPython {
 			return fmt.Errorf("unsupported module kind %q for policy module %s", module.Kind, module.ID)
+		}
+	}
+	return nil
+}
+
+type pythonPolicyModulesBuildStep struct{}
+
+func (pythonPolicyModulesBuildStep) Name() string {
+	return bundleBuildStepPythonModules
+}
+
+func (pythonPolicyModulesBuildStep) Run(_ context.Context, ctx *BundleBuildContext) error {
+	if ctx == nil {
+		return fmt.Errorf("bundle build context is required")
+	}
+	identity := pythonmodule.RuntimeIdentity()
+	for _, module := range ctx.Modules {
+		if module.Kind != bundleBuildKindPython {
+			continue
+		}
+		if module.SourcePath == "" || module.SourceHash == "" {
+			return fmt.Errorf("python policy module %s missing source identity", module.ID)
+		}
+		if module.Interpreter != identity.Interpreter ||
+			module.InterpreterDigest != identity.InterpreterDigest ||
+			module.SnapshotDigest != identity.SnapshotDigest ||
+			module.HarnessABI != identity.HarnessABI {
+			return fmt.Errorf("python policy module %s runtime identity drift", module.ID)
 		}
 	}
 	return nil
@@ -384,7 +423,11 @@ func collectBundleBuildModules(bundle *WorkflowContractBundle) ([]BundleBuildMod
 			}
 			sourcePath := strings.TrimSpace(module.SourcePath)
 			sourceHash := strings.TrimSpace(module.SourceHash)
-			if sourcePath != "" || sourceHash != "" {
+			kind := policyModuleKind(module)
+			if kind == bundleBuildKindPython {
+				sourcePath = relPath
+				sourceHash = strings.TrimSpace(module.Digest)
+			} else if sourcePath != "" || sourceHash != "" {
 				sourceRel, verifiedHash, err := verifyPolicyModuleSourceHash(bundle, moduleID, module)
 				if err != nil {
 					return nil, err
@@ -392,15 +435,23 @@ func collectBundleBuildModules(bundle *WorkflowContractBundle) ([]BundleBuildMod
 				sourcePath = sourceRel
 				sourceHash = verifiedHash
 			}
-			modules = append(modules, BundleBuildModule{
+			buildModule := BundleBuildModule{
 				ID:         moduleID,
 				FlowID:     flowID,
-				Kind:       bundleBuildKindWasm,
+				Kind:       kind,
 				Path:       relPath,
 				Digest:     strings.TrimSpace(module.Digest),
 				SourcePath: sourcePath,
 				SourceHash: sourceHash,
-			})
+			}
+			if kind == bundleBuildKindPython {
+				identity := pythonmodule.RuntimeIdentity()
+				buildModule.Interpreter = identity.Interpreter
+				buildModule.InterpreterDigest = identity.InterpreterDigest
+				buildModule.SnapshotDigest = identity.SnapshotDigest
+				buildModule.HarnessABI = identity.HarnessABI
+			}
+			modules = append(modules, buildModule)
 		}
 	}
 	sort.Slice(modules, func(i, j int) bool {

--- a/internal/runtime/contracts/bundle_build_test.go
+++ b/internal/runtime/contracts/bundle_build_test.go
@@ -10,6 +10,8 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+
+	"github.com/division-sh/swarm/internal/runtime/pythonmodule"
 )
 
 func TestBuildBundleMaterializationWritesReproducibleContractsRoot(t *testing.T) {
@@ -63,7 +65,11 @@ func TestBuildBundleMaterializationWritesReproducibleContractsRoot(t *testing.T)
 	if module.ID != "structured_renderer" || module.Kind != "wasm" || module.Path != "modules/structured_renderer.wasm" || module.SourcePath != "src/structured_renderer.rs" || module.SourceHash == "" {
 		t.Fatalf("manifest module = %#v", module)
 	}
-	if len(reportA.Steps) != 1 || reportA.Steps[0].Name != bundleBuildStepWasmModules || reportA.Steps[0].Status != "passed" {
+	if len(reportA.Steps) != 2 ||
+		reportA.Steps[0].Name != bundleBuildStepWasmModules ||
+		reportA.Steps[0].Status != "passed" ||
+		reportA.Steps[1].Name != bundleBuildStepPythonModules ||
+		reportA.Steps[1].Status != "passed" {
 		t.Fatalf("steps = %#v", reportA.Steps)
 	}
 
@@ -242,15 +248,77 @@ func TestBuildBundleMaterializationRejectsOutputInsideHashedRecursiveInput(t *te
 	}
 }
 
-func TestBundleBuildStepRegistryHasOnlyWasmSliceA(t *testing.T) {
+func TestBundleBuildStepRegistryHasWasmAndPythonSliceB(t *testing.T) {
 	names := BundleBuildStepNames(nil)
-	if !reflect.DeepEqual(names, []string{bundleBuildStepWasmModules}) {
-		t.Fatalf("BundleBuildStepNames(nil) = %#v, want wasm-only slice", names)
+	want := []string{bundleBuildStepWasmModules, bundleBuildStepPythonModules}
+	if !reflect.DeepEqual(names, want) {
+		t.Fatalf("BundleBuildStepNames(nil) = %#v, want %#v", names, want)
 	}
-	for _, name := range names {
-		if strings.Contains(strings.ToLower(name), "python") || strings.Contains(strings.ToLower(name), "snapshot") {
-			t.Fatalf("slice A build step %q must not register python/snapshot support", name)
-		}
+}
+
+func TestBuildBundleMaterializationMaterializesPythonModuleIdentity(t *testing.T) {
+	repo := repoRootForContractsTest(t)
+	root := writePythonBundleBuildContractsDir(t, pythonRendererSource())
+	platform := DefaultPlatformSpecFile(repo)
+
+	report, err := BuildBundleMaterialization(context.Background(), BundleBuildRequest{
+		RepoRoot:         repo,
+		ContractsRoot:    root,
+		PlatformSpecPath: platform,
+		OutputRoot:       filepath.Join(t.TempDir(), "build"),
+	})
+	if err != nil {
+		t.Fatalf("BuildBundleMaterialization: %v", err)
+	}
+	if len(report.Steps) != 2 || report.Steps[0].Name != bundleBuildStepWasmModules || report.Steps[1].Name != bundleBuildStepPythonModules {
+		t.Fatalf("steps = %#v", report.Steps)
+	}
+	var manifest BundleBuildManifest
+	if err := json.Unmarshal([]byte(readBundleBuildFile(t, report.OutputPath, "build-manifest.json")), &manifest); err != nil {
+		t.Fatalf("decode build manifest: %v", err)
+	}
+	if got, want := len(manifest.Modules), 1; got != want {
+		t.Fatalf("manifest modules = %d, want %d", got, want)
+	}
+	module := manifest.Modules[0]
+	if module.ID != "python_renderer" ||
+		module.Kind != pythonmodule.Kind ||
+		module.Path != "modules/python_renderer.py" ||
+		module.SourcePath != "modules/python_renderer.py" ||
+		module.SourceHash != module.Digest ||
+		module.Interpreter != pythonmodule.Interpreter ||
+		module.InterpreterDigest != pythonmodule.InterpreterDigest ||
+		module.SnapshotDigest == "" ||
+		module.HarnessABI != pythonmodule.HarnessABI {
+		t.Fatalf("manifest module = %#v", module)
+	}
+	if _, err := os.Stat(filepath.Join(report.OutputPath, "modules", "python_renderer.py")); err != nil {
+		t.Fatalf("materialized python source missing: %v", err)
+	}
+}
+
+func TestBuildBundleMaterializationFailsClosedForPythonSyntax(t *testing.T) {
+	repo := repoRootForContractsTest(t)
+	for _, tc := range []struct {
+		name   string
+		source []byte
+		want   string
+	}{
+		{name: "syntax", source: []byte("def handle(input):\n    return {\n"), want: "compute_module_compile"},
+		{name: "missing_handle", source: []byte("def other(input):\n    return {}\n"), want: "must define callable handle(input)"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			root := writePythonBundleBuildContractsDir(t, tc.source)
+			_, err := BuildBundleMaterialization(context.Background(), BundleBuildRequest{
+				RepoRoot:         repo,
+				ContractsRoot:    root,
+				PlatformSpecPath: DefaultPlatformSpecFile(repo),
+				OutputRoot:       filepath.Join(t.TempDir(), "build"),
+			})
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("BuildBundleMaterialization error = %v, want %q", err, tc.want)
+			}
+		})
 	}
 }
 
@@ -278,6 +346,87 @@ terminal_states: [ready]
 	writeBundleHashText(t, filepath.Join(root, "src", "structured_renderer.rs"), "fn compute() {}\n")
 	writeBundleHashText(t, filepath.Join(root, "flows", "render", "policy.yaml"), bundleBuildPolicyYAML(t, root, bundleBuildSourceHash(t, root)))
 	return root
+}
+
+func writePythonBundleBuildContractsDir(t *testing.T, source []byte) string {
+	t.Helper()
+	root := t.TempDir()
+	writeBundleHashText(t, filepath.Join(root, "package.yaml"), `name: python-bundle-build-module
+version: "1.0.0"
+platform_version: ">=0.7.0 <0.8.0"
+flows:
+  - id: render
+    flow: render
+`)
+	writeBundleHashText(t, filepath.Join(root, "flows", "render", "schema.yaml"), `name: render
+mode: static
+states: [ready]
+initial_state: ready
+terminal_states: [ready]
+`)
+	writeBundleHashBytes(t, filepath.Join(root, "modules", "python_renderer.py"), source)
+	writeBundleHashText(t, filepath.Join(root, "flows", "render", "policy.yaml"), pythonBundleBuildPolicyYAML(source))
+	return root
+}
+
+func pythonBundleBuildPolicyYAML(source []byte) string {
+	sum := sha256.Sum256(source)
+	return `modules:
+  python_renderer:
+    path: modules/python_renderer.py
+    kind: python
+    abi: python-json-v1
+    entry: handle
+    digest: sha256:` + hex.EncodeToString(sum[:]) + `
+    limits:
+      gas: 2500000000
+      memory_pages: 8192
+      output_bytes: 4096
+    input_schema:
+      type: object
+      additionalProperties: false
+      required: [component, owner, language, files]
+      properties:
+        component:
+          type: string
+        owner:
+          type: string
+        language:
+          type: string
+        files:
+          type: array
+          items:
+            type: string
+    output_schema:
+      type: object
+      additionalProperties: false
+      required: [content, format, line_count]
+      properties:
+        content:
+          type: string
+        format:
+          type: string
+        line_count:
+          type: integer
+`
+}
+
+func pythonRendererSource() []byte {
+	return []byte(`def handle(input):
+    lines = [
+        "component: " + input["component"],
+        "owner: " + input["owner"],
+        "language: " + input["language"],
+    ]
+    for name in input["files"]:
+        if name.endswith(".yaml"):
+            lines.append("- deploy/" + name)
+        elif name.endswith(".go"):
+            lines.append("- src/" + name)
+        else:
+            lines.append("- " + name)
+    return {"content": "\n".join(lines), "format": "yaml", "line_count": len(lines)}
+`)
 }
 
 func bundleBuildPolicyYAML(t *testing.T, root, sourceHash string) string {

--- a/internal/runtime/contracts/compute_module_validation.go
+++ b/internal/runtime/contracts/compute_module_validation.go
@@ -9,9 +9,16 @@ import (
 	"strings"
 
 	"github.com/division-sh/swarm/internal/runtime/core/paths"
+	"github.com/division-sh/swarm/internal/runtime/pythonmodule"
 )
 
 var computeModuleDigestPattern = regexp.MustCompile(`^sha256:[0-9a-f]{64}$`)
+
+const (
+	policyModuleKindWasm   = "wasm"
+	policyModuleKindPython = pythonmodule.Kind
+	policyModuleWasmABI    = "core-json-v1"
+)
 
 func validateWorkflowComputeModuleContracts(bundle *WorkflowContractBundle) []error {
 	if bundle == nil {
@@ -58,12 +65,7 @@ func validatePolicyModuleDeclaration(bundle *WorkflowContractBundle, context, mo
 	if strings.TrimSpace(module.Path) == "" {
 		errs = append(errs, fmt.Errorf("%w: %s path is required", ErrInvalidField, context))
 	}
-	if abi := strings.TrimSpace(module.ABI); abi != "core-json-v1" {
-		errs = append(errs, fmt.Errorf("%w: %s abi must be core-json-v1, got %q", ErrInvalidField, context, abi))
-	}
-	if entry := strings.TrimSpace(module.Entry); entry != "compute" {
-		errs = append(errs, fmt.Errorf("%w: %s entry must be compute, got %q", ErrInvalidField, context, entry))
-	}
+	kind := policyModuleKind(module)
 	if digest := strings.TrimSpace(module.Digest); !computeModuleDigestPattern.MatchString(digest) {
 		errs = append(errs, fmt.Errorf("%w: %s digest must be sha256:<64 lowercase hex>", ErrInvalidField, context))
 	}
@@ -91,6 +93,25 @@ func validatePolicyModuleDeclaration(bundle *WorkflowContractBundle, context, mo
 		errs = append(errs, fmt.Errorf("%w: %s %v", ErrInvalidField, context, readErr))
 		return errs
 	}
+	switch kind {
+	case policyModuleKindWasm:
+		errs = append(errs, validateWasmPolicyModuleDeclaration(context, module, raw)...)
+	case policyModuleKindPython:
+		errs = append(errs, validatePythonPolicyModuleDeclaration(context, moduleID, module, raw)...)
+	default:
+		errs = append(errs, fmt.Errorf("%w: %s kind must be wasm or python, got %q", ErrInvalidField, context, strings.TrimSpace(module.Kind)))
+	}
+	return errs
+}
+
+func validateWasmPolicyModuleDeclaration(context string, module PolicyModule, raw []byte) []error {
+	errs := []error{}
+	if abi := strings.TrimSpace(module.ABI); abi != policyModuleWasmABI {
+		errs = append(errs, fmt.Errorf("%w: %s abi must be %s for wasm modules, got %q", ErrInvalidField, context, policyModuleWasmABI, abi))
+	}
+	if entry := strings.TrimSpace(module.Entry); entry != "compute" {
+		errs = append(errs, fmt.Errorf("%w: %s entry must be compute for wasm modules, got %q", ErrInvalidField, context, entry))
+	}
 	if len(raw) < 4 || string(raw[:4]) != "\x00asm" {
 		errs = append(errs, fmt.Errorf("%w: %s path must point to a WebAssembly module", ErrInvalidField, context))
 	}
@@ -100,6 +121,66 @@ func validatePolicyModuleDeclaration(bundle *WorkflowContractBundle, context, mo
 		errs = append(errs, fmt.Errorf("%w: %s digest %s does not match module bytes %s", ErrInvalidField, context, strings.TrimSpace(module.Digest), actual))
 	}
 	return errs
+}
+
+func validatePythonPolicyModuleDeclaration(context, moduleID string, module PolicyModule, raw []byte) []error {
+	errs := []error{}
+	if abi := strings.TrimSpace(module.ABI); abi != pythonmodule.ABI {
+		errs = append(errs, fmt.Errorf("%w: %s abi must be %s for python modules, got %q", ErrInvalidField, context, pythonmodule.ABI, abi))
+	}
+	if entry := strings.TrimSpace(module.Entry); entry != pythonmodule.DefaultEntry {
+		errs = append(errs, fmt.Errorf("%w: %s entry must be %s for python modules, got %q", ErrInvalidField, context, pythonmodule.DefaultEntry, entry))
+	}
+	if strings.TrimSpace(module.SourcePath) != "" || strings.TrimSpace(module.SourceHash) != "" {
+		errs = append(errs, fmt.Errorf("%w: %s python modules use path/digest as source authority; source_path/source_hash are invalid", ErrInvalidField, context))
+	}
+	identity := pythonmodule.RuntimeIdentity()
+	if runtime := module.Runtime; strings.TrimSpace(runtime.Interpreter) != "" ||
+		strings.TrimSpace(runtime.InterpreterDigest) != "" ||
+		strings.TrimSpace(runtime.SnapshotDigest) != "" ||
+		strings.TrimSpace(runtime.HarnessABI) != "" {
+		if strings.TrimSpace(runtime.Interpreter) != identity.Interpreter {
+			errs = append(errs, fmt.Errorf("%w: %s runtime.interpreter must be %s", ErrInvalidField, context, identity.Interpreter))
+		}
+		if strings.TrimSpace(runtime.InterpreterDigest) != identity.InterpreterDigest {
+			errs = append(errs, fmt.Errorf("%w: %s runtime.interpreter_digest must be %s", ErrInvalidField, context, identity.InterpreterDigest))
+		}
+		if strings.TrimSpace(runtime.SnapshotDigest) != identity.SnapshotDigest {
+			errs = append(errs, fmt.Errorf("%w: %s runtime.snapshot_digest must be %s", ErrInvalidField, context, identity.SnapshotDigest))
+		}
+		if strings.TrimSpace(runtime.HarnessABI) != identity.HarnessABI {
+			errs = append(errs, fmt.Errorf("%w: %s runtime.harness_abi must be %s", ErrInvalidField, context, identity.HarnessABI))
+		}
+	}
+	sum := sha256.Sum256(raw)
+	actual := "sha256:" + hex.EncodeToString(sum[:])
+	if strings.TrimSpace(module.Digest) != "" && strings.TrimSpace(module.Digest) != actual {
+		errs = append(errs, fmt.Errorf("%w: %s digest %s does not match python source bytes %s", ErrInvalidField, context, strings.TrimSpace(module.Digest), actual))
+	}
+	if len(errs) > 0 {
+		return errs
+	}
+	if err := pythonmodule.ValidateSource(pythonmodule.Request{
+		ModuleID:    moduleID,
+		RowID:       "policy.modules." + moduleID,
+		Digest:      strings.TrimSpace(module.Digest),
+		Entry:       strings.TrimSpace(module.Entry),
+		Source:      raw,
+		Fuel:        module.Limits.Gas,
+		MemoryPages: module.Limits.MemoryPages,
+		OutputBytes: module.Limits.OutputBytes,
+	}); err != nil {
+		errs = append(errs, fmt.Errorf("%w: %s %v", ErrInvalidField, context, err))
+	}
+	return errs
+}
+
+func policyModuleKind(module PolicyModule) string {
+	kind := strings.TrimSpace(module.Kind)
+	if kind == "" {
+		return policyModuleKindWasm
+	}
+	return kind
 }
 
 func validateComputeModuleSchema(context string, schema map[string]any) []error {

--- a/internal/runtime/contracts/workflow_contract_types.go
+++ b/internal/runtime/contracts/workflow_contract_types.go
@@ -632,6 +632,7 @@ type PolicyValidationRule = flowmodel.PolicyValidationRule
 type PolicyValidationCheck = flowmodel.PolicyValidationCheck
 type PolicyValidationEqualCheck = flowmodel.PolicyValidationEqualCheck
 type PolicyModule = flowmodel.PolicyModule
+type PolicyModuleRuntime = flowmodel.PolicyModuleRuntime
 type PolicyModuleLimits = flowmodel.PolicyModuleLimits
 type ContractURIRegistry = flowmodel.URIRegistry
 type ContractURIRef = flowmodel.URIRef

--- a/internal/runtime/engine/executor.go
+++ b/internal/runtime/engine/executor.go
@@ -22,6 +22,7 @@ import (
 	"github.com/division-sh/swarm/internal/runtime/core/values"
 	"github.com/division-sh/swarm/internal/runtime/entityruntime"
 	"github.com/division-sh/swarm/internal/runtime/eventschema"
+	"github.com/division-sh/swarm/internal/runtime/pythonmodule"
 	"github.com/division-sh/swarm/internal/runtime/semanticview"
 	"github.com/division-sh/swarm/internal/runtime/workflowexpr"
 )
@@ -1118,35 +1119,71 @@ func (e *Executor) computeModuleValue(frame *executionFrame, spec *runtimecontra
 	if err != nil {
 		return nil, &computemodule.Error{Code: computemodule.CodeABI, ModuleID: moduleID, RowID: rowID, Err: err}
 	}
-	wasmBytes, _, err := runtimecontracts.PolicyModuleBytes(bundle, module)
+	moduleBytes, _, err := runtimecontracts.PolicyModuleBytes(bundle, module)
 	if err != nil {
 		return nil, &computemodule.Error{Code: computemodule.CodeCompile, ModuleID: moduleID, RowID: rowID, Err: err}
 	}
-	result, err := computemodule.Execute(computemodule.Request{
-		ModuleID:    moduleID,
-		RowID:       rowID,
-		Digest:      strings.TrimSpace(module.Digest),
-		Entry:       strings.TrimSpace(module.Entry),
-		Wasm:        wasmBytes,
-		Input:       inputBytes,
-		Fuel:        module.Limits.Gas,
-		MemoryPages: module.Limits.MemoryPages,
-		OutputBytes: module.Limits.OutputBytes,
-	})
-	if err != nil {
-		return nil, err
-	}
-	output, err := decodeComputeModuleOutput(moduleID, rowID, result.Output, module.OutputSchema)
-	if err != nil {
-		return nil, err
+	kind := strings.TrimSpace(module.Kind)
+	if kind == "" {
+		kind = "wasm"
 	}
 	trace := ComputeModuleTrace{
-		ModuleID:     moduleID,
-		RowID:        rowID,
-		Digest:       strings.TrimSpace(module.Digest),
-		Engine:       result.Engine,
-		OutputHash:   result.OutputHash,
-		FuelConsumed: result.FuelConsumed,
+		ModuleID: moduleID,
+		RowID:    rowID,
+		Kind:     kind,
+		Digest:   strings.TrimSpace(module.Digest),
+	}
+	var rawOutput []byte
+	switch kind {
+	case "wasm":
+		result, err := computemodule.Execute(computemodule.Request{
+			ModuleID:    moduleID,
+			RowID:       rowID,
+			Digest:      strings.TrimSpace(module.Digest),
+			Entry:       strings.TrimSpace(module.Entry),
+			Wasm:        moduleBytes,
+			Input:       inputBytes,
+			Fuel:        module.Limits.Gas,
+			MemoryPages: module.Limits.MemoryPages,
+			OutputBytes: module.Limits.OutputBytes,
+		})
+		if err != nil {
+			return nil, err
+		}
+		rawOutput = result.Output
+		trace.Engine = result.Engine
+		trace.OutputHash = result.OutputHash
+		trace.FuelConsumed = result.FuelConsumed
+	case pythonmodule.Kind:
+		result, err := pythonmodule.Execute(pythonmodule.Request{
+			ModuleID:    moduleID,
+			RowID:       rowID,
+			Digest:      strings.TrimSpace(module.Digest),
+			Entry:       strings.TrimSpace(module.Entry),
+			Source:      moduleBytes,
+			Input:       inputBytes,
+			Fuel:        module.Limits.Gas,
+			MemoryPages: module.Limits.MemoryPages,
+			OutputBytes: module.Limits.OutputBytes,
+		})
+		if err != nil {
+			return nil, err
+		}
+		rawOutput = result.Output
+		trace.Engine = result.Engine
+		trace.OutputHash = result.OutputHash
+		trace.FuelConsumed = result.FuelConsumed
+		trace.Interpreter = result.Interpreter
+		trace.InterpreterDigest = result.InterpreterSHA
+		trace.SnapshotDigest = result.SnapshotHash
+		trace.HarnessABI = result.HarnessABI
+		trace.SourceHash = result.SourceHash
+	default:
+		return nil, &computemodule.Error{Code: computemodule.CodeCompile, ModuleID: moduleID, RowID: rowID, Err: fmt.Errorf("unsupported module kind %q", kind)}
+	}
+	output, err := decodeComputeModuleOutput(moduleID, rowID, rawOutput, module.OutputSchema)
+	if err != nil {
+		return nil, err
 	}
 	if err := verifyComputeModuleReplayTrace(frame, trace); err != nil {
 		return nil, err
@@ -1184,19 +1221,26 @@ func verifyComputeModuleReplayTrace(frame *executionFrame, actual ComputeModuleT
 		}
 	}
 	want := expected[idx]
+	compareFuel := strings.TrimSpace(actual.Kind) != pythonmodule.Kind
 	if strings.TrimSpace(want.ModuleID) != strings.TrimSpace(actual.ModuleID) ||
 		strings.TrimSpace(want.RowID) != strings.TrimSpace(actual.RowID) ||
+		strings.TrimSpace(want.Kind) != strings.TrimSpace(actual.Kind) ||
 		strings.TrimSpace(want.Digest) != strings.TrimSpace(actual.Digest) ||
+		strings.TrimSpace(want.Interpreter) != strings.TrimSpace(actual.Interpreter) ||
+		strings.TrimSpace(want.InterpreterDigest) != strings.TrimSpace(actual.InterpreterDigest) ||
+		strings.TrimSpace(want.SnapshotDigest) != strings.TrimSpace(actual.SnapshotDigest) ||
+		strings.TrimSpace(want.HarnessABI) != strings.TrimSpace(actual.HarnessABI) ||
+		strings.TrimSpace(want.SourceHash) != strings.TrimSpace(actual.SourceHash) ||
 		strings.TrimSpace(want.OutputHash) != strings.TrimSpace(actual.OutputHash) ||
-		want.FuelConsumed != actual.FuelConsumed {
+		(compareFuel && want.FuelConsumed != actual.FuelConsumed) {
 		return &computemodule.Error{
 			Code:     computemodule.CodeReplay,
 			ModuleID: actual.ModuleID,
 			RowID:    actual.RowID,
-			Err: fmt.Errorf("compute_module replay divergence at index %d: expected module=%s row=%s digest=%s output_hash=%s fuel=%d engine=%s; got module=%s row=%s digest=%s output_hash=%s fuel=%d engine=%s",
+			Err: fmt.Errorf("compute_module replay divergence at index %d: expected module=%s row=%s kind=%s digest=%s interpreter=%s interpreter_digest=%s snapshot_digest=%s harness_abi=%s source_hash=%s output_hash=%s fuel=%d engine=%s; got module=%s row=%s kind=%s digest=%s interpreter=%s interpreter_digest=%s snapshot_digest=%s harness_abi=%s source_hash=%s output_hash=%s fuel=%d engine=%s",
 				idx,
-				want.ModuleID, want.RowID, want.Digest, want.OutputHash, want.FuelConsumed, want.Engine,
-				actual.ModuleID, actual.RowID, actual.Digest, actual.OutputHash, actual.FuelConsumed, actual.Engine,
+				want.ModuleID, want.RowID, want.Kind, want.Digest, want.Interpreter, want.InterpreterDigest, want.SnapshotDigest, want.HarnessABI, want.SourceHash, want.OutputHash, want.FuelConsumed, want.Engine,
+				actual.ModuleID, actual.RowID, actual.Kind, actual.Digest, actual.Interpreter, actual.InterpreterDigest, actual.SnapshotDigest, actual.HarnessABI, actual.SourceHash, actual.OutputHash, actual.FuelConsumed, actual.Engine,
 			),
 		}
 	}

--- a/internal/runtime/engine/executor_test.go
+++ b/internal/runtime/engine/executor_test.go
@@ -21,6 +21,7 @@ import (
 	runtimepaths "github.com/division-sh/swarm/internal/runtime/core/paths"
 	runtimeregistry "github.com/division-sh/swarm/internal/runtime/core/registry"
 	"github.com/division-sh/swarm/internal/runtime/flowmodel"
+	"github.com/division-sh/swarm/internal/runtime/pythonmodule"
 	"github.com/division-sh/swarm/internal/runtime/semanticview"
 	"gopkg.in/yaml.v3"
 )
@@ -97,6 +98,91 @@ func sourceWithStructuredRendererModule(t *testing.T) (semanticview.Source, runt
 	return semanticview.Wrap(bundle), module
 }
 
+func sourceWithPythonRendererModule(t *testing.T) (semanticview.Source, runtimecontracts.PolicyModule) {
+	t.Helper()
+	source := []byte(`def handle(input):
+    lines = [
+        "component: " + input["component"],
+        "owner: " + input["owner"],
+        "language: " + input["language"],
+    ]
+    for name in input["files"]:
+        if name.endswith(".yaml"):
+            lines.append("- deploy/" + name)
+        elif name.endswith(".go"):
+            lines.append("- src/" + name)
+        else:
+            lines.append("- " + name)
+    return {"content": "\n".join(lines), "format": "yaml", "line_count": len(lines)}
+`)
+	return sourceWithPythonRendererSource(t, source)
+}
+
+func sourceWithPythonRendererSource(t *testing.T, source []byte) (semanticview.Source, runtimecontracts.PolicyModule) {
+	t.Helper()
+	root := t.TempDir()
+	modulePath := filepath.Join(root, "modules", "python_renderer.py")
+	if err := os.MkdirAll(filepath.Dir(modulePath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(modulePath, source, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	sum := sha256.Sum256(source)
+	module := runtimecontracts.PolicyModule{
+		Path:   "modules/python_renderer.py",
+		Kind:   pythonmodule.Kind,
+		ABI:    pythonmodule.ABI,
+		Entry:  pythonmodule.DefaultEntry,
+		Digest: "sha256:" + hex.EncodeToString(sum[:]),
+		InputSchema: map[string]any{
+			"type":                 "object",
+			"additionalProperties": false,
+			"required":             []any{"component", "owner", "language", "files"},
+			"properties": map[string]any{
+				"component": map[string]any{"type": "string"},
+				"owner":     map[string]any{"type": "string"},
+				"language":  map[string]any{"type": "string"},
+				"files": map[string]any{
+					"type":  "array",
+					"items": map[string]any{"type": "string"},
+				},
+			},
+		},
+		OutputSchema: map[string]any{
+			"type":                 "object",
+			"additionalProperties": false,
+			"required":             []any{"content", "format", "line_count"},
+			"properties": map[string]any{
+				"content":    map[string]any{"type": "string"},
+				"format":     map[string]any{"type": "string"},
+				"line_count": map[string]any{"type": "integer"},
+			},
+		},
+		Limits: runtimecontracts.PolicyModuleLimits{
+			Gas:         2_500_000_000,
+			MemoryPages: 8192,
+			OutputBytes: 4096,
+		},
+	}
+	flow := runtimecontracts.FlowContractView{
+		Paths: runtimecontracts.FlowContractPaths{ID: "render", Flow: "render"},
+		Policy: runtimecontracts.PolicyDocument{Modules: map[string]runtimecontracts.PolicyModule{
+			"python_renderer": module,
+		}},
+	}
+	bundle := &runtimecontracts.WorkflowContractBundle{
+		Paths: runtimecontracts.ContractPaths{ContractsRoot: root},
+		FlowTree: flowmodel.Tree[runtimecontracts.FlowContractView]{
+			Root: &flow,
+			ByID: map[string]*runtimecontracts.FlowContractView{
+				"render": &flow,
+			},
+		},
+	}
+	return semanticview.Wrap(bundle), module
+}
+
 func newStructuredRendererExecutor(t *testing.T, source semanticview.Source) *Executor {
 	t.Helper()
 	exec, err := NewExecutor(RuntimeDependencies{
@@ -137,6 +223,12 @@ func structuredRendererModuleSpec() *runtimecontracts.ComputeModuleSpec {
 			"files":     runtimepaths.Parse("payload.files"),
 		},
 	}
+}
+
+func pythonRendererModuleSpec() *runtimecontracts.ComputeModuleSpec {
+	spec := structuredRendererModuleSpec()
+	spec.Module = "python_renderer"
+	return spec
 }
 
 func structuredRendererExecutionRequest(t *testing.T, moduleSpec *runtimecontracts.ComputeModuleSpec) ExecutionRequest {
@@ -1875,6 +1967,83 @@ func TestExecutor_PolicySheetComputeModuleRowFeedsSelectionRow(t *testing.T) {
 	trace := result.ComputeModuleTraces[0]
 	if trace.ModuleID != "structured_renderer" || trace.RowID != "render_bundle" || trace.Digest != module.Digest || trace.FuelConsumed == 0 || trace.OutputHash == "" || trace.Engine == "" {
 		t.Fatalf("trace = %#v", trace)
+	}
+}
+
+func TestExecutor_PolicySheetPythonModuleRowFeedsSelectionRow(t *testing.T) {
+	source, module := sourceWithPythonRendererModule(t)
+	exec := newStructuredRendererExecutor(t, source)
+	req := structuredRendererExecutionRequest(t, pythonRendererModuleSpec())
+	result, err := exec.Execute(context.Background(), req)
+	if err != nil {
+		t.Fatalf("Execute error: %v", err)
+	}
+	rendered, _ := result.Computed["rendered_bundle"].(map[string]any)
+	content, _ := rendered["content"].(string)
+	for _, want := range []string{"component: api", "owner: platform", "- src/main.go", "- deploy/service.yaml"} {
+		if !strings.Contains(content, want) {
+			t.Fatalf("rendered content missing %q: %s", want, content)
+		}
+	}
+	if got := result.RuleID; got != "rendered_yaml" {
+		t.Fatalf("selected rule = %q, want rendered_yaml", got)
+	}
+	if got := len(result.ComputeModuleTraces); got != 1 {
+		t.Fatalf("module traces = %d, want 1", got)
+	}
+	trace := result.ComputeModuleTraces[0]
+	if trace.ModuleID != "python_renderer" ||
+		trace.RowID != "render_bundle" ||
+		trace.Kind != pythonmodule.Kind ||
+		trace.Digest != module.Digest ||
+		trace.Interpreter != pythonmodule.Interpreter ||
+		trace.InterpreterDigest != pythonmodule.InterpreterDigest ||
+		trace.SnapshotDigest == "" ||
+		trace.HarnessABI != pythonmodule.HarnessABI ||
+		trace.SourceHash != module.Digest ||
+		trace.FuelConsumed == 0 ||
+		trace.OutputHash == "" ||
+		trace.Engine == "" {
+		t.Fatalf("trace = %#v", trace)
+	}
+
+	req.ExpectedComputeModuleTraces = append([]ComputeModuleTrace(nil), result.ComputeModuleTraces...)
+	replayed, err := exec.Execute(context.Background(), req)
+	if err != nil {
+		t.Fatalf("replay Execute with matching trace error: %v", err)
+	}
+	if got := len(replayed.ComputeModuleTraces); got != 1 {
+		t.Fatalf("replay traces = %d, want 1", got)
+	}
+	req.ExpectedComputeModuleTraces[0].SourceHash = "sha256:0000000000000000000000000000000000000000000000000000000000000000"
+	_, err = exec.Execute(context.Background(), req)
+	if err == nil {
+		t.Fatal("replay Execute error = nil, want source hash divergence")
+	}
+	var typed *computemodule.Error
+	if !errors.As(err, &typed) || typed.Code != computemodule.CodeReplay {
+		t.Fatalf("error = %#v, want code %s", err, computemodule.CodeReplay)
+	}
+	if !strings.Contains(err.Error(), "source_hash") {
+		t.Fatalf("error = %v, want source hash diagnostic", err)
+	}
+}
+
+func TestExecutor_PythonModuleOutputSchemaFailureStopsBeforeEmit(t *testing.T) {
+	source, _ := sourceWithPythonRendererSource(t, []byte(`def handle(input):
+    return {"content": "ok", "format": "yaml", "line_count": "three"}
+`))
+	exec := newStructuredRendererExecutor(t, source)
+	_, err := exec.Execute(context.Background(), structuredRendererExecutionRequest(t, pythonRendererModuleSpec()))
+	if err == nil {
+		t.Fatal("Execute error = nil, want output schema violation")
+	}
+	var typed *computemodule.Error
+	if !errors.As(err, &typed) || typed.Code != computemodule.CodeABI {
+		t.Fatalf("error = %#v, want code %s", err, computemodule.CodeABI)
+	}
+	if !strings.Contains(err.Error(), "output schema violation") {
+		t.Fatalf("error = %v, want output schema diagnostic", err)
 	}
 }
 

--- a/internal/runtime/engine/types.go
+++ b/internal/runtime/engine/types.go
@@ -435,12 +435,18 @@ type ExecutionResult struct {
 }
 
 type ComputeModuleTrace struct {
-	ModuleID     string
-	RowID        string
-	Digest       string
-	Engine       string
-	OutputHash   string
-	FuelConsumed uint64
+	ModuleID          string
+	RowID             string
+	Kind              string
+	Digest            string
+	Engine            string
+	OutputHash        string
+	FuelConsumed      uint64
+	Interpreter       string
+	InterpreterDigest string
+	SnapshotDigest    string
+	HarnessABI        string
+	SourceHash        string
 }
 
 func (r ExecutionResult) ComputedBucket() values.Bucket {

--- a/internal/runtime/flowmodel/model.go
+++ b/internal/runtime/flowmodel/model.go
@@ -69,15 +69,24 @@ type PolicyValidationEqualCheck struct {
 }
 
 type PolicyModule struct {
-	Path         string             `yaml:"path"`
-	ABI          string             `yaml:"abi"`
-	Entry        string             `yaml:"entry"`
-	Digest       string             `yaml:"digest"`
-	SourcePath   string             `yaml:"source_path"`
-	SourceHash   string             `yaml:"source_hash"`
-	InputSchema  map[string]any     `yaml:"input_schema"`
-	OutputSchema map[string]any     `yaml:"output_schema"`
-	Limits       PolicyModuleLimits `yaml:"limits"`
+	Path         string              `yaml:"path"`
+	Kind         string              `yaml:"kind"`
+	ABI          string              `yaml:"abi"`
+	Entry        string              `yaml:"entry"`
+	Digest       string              `yaml:"digest"`
+	SourcePath   string              `yaml:"source_path"`
+	SourceHash   string              `yaml:"source_hash"`
+	Runtime      PolicyModuleRuntime `yaml:"runtime"`
+	InputSchema  map[string]any      `yaml:"input_schema"`
+	OutputSchema map[string]any      `yaml:"output_schema"`
+	Limits       PolicyModuleLimits  `yaml:"limits"`
+}
+
+type PolicyModuleRuntime struct {
+	Interpreter       string `yaml:"interpreter"`
+	InterpreterDigest string `yaml:"interpreter_digest"`
+	SnapshotDigest    string `yaml:"snapshot_digest"`
+	HarnessABI        string `yaml:"harness_abi"`
 }
 
 type PolicyModuleLimits struct {
@@ -166,11 +175,13 @@ func (m *PolicyModule) UnmarshalYAML(node *yaml.Node) error {
 	}
 	if err := validateYAMLMappingKeys(node, "policy module", map[string]struct{}{
 		"path":          {},
+		"kind":          {},
 		"abi":           {},
 		"entry":         {},
 		"digest":        {},
 		"source_path":   {},
 		"source_hash":   {},
+		"runtime":       {},
 		"input_schema":  {},
 		"output_schema": {},
 		"limits":        {},
@@ -183,6 +194,27 @@ func (m *PolicyModule) UnmarshalYAML(node *yaml.Node) error {
 		return err
 	}
 	*m = PolicyModule(aux)
+	return nil
+}
+
+func (r *PolicyModuleRuntime) UnmarshalYAML(node *yaml.Node) error {
+	if r == nil {
+		return nil
+	}
+	if err := validateYAMLMappingKeys(node, "policy module runtime", map[string]struct{}{
+		"interpreter":        {},
+		"interpreter_digest": {},
+		"snapshot_digest":    {},
+		"harness_abi":        {},
+	}); err != nil {
+		return err
+	}
+	type alias PolicyModuleRuntime
+	var aux alias
+	if err := node.Decode(&aux); err != nil {
+		return err
+	}
+	*r = PolicyModuleRuntime(aux)
 	return nil
 }
 

--- a/internal/runtime/flowmodel/query.go
+++ b/internal/runtime/flowmodel/query.go
@@ -42,12 +42,19 @@ func ClonePolicyDocument(in PolicyDocument) PolicyDocument {
 
 func clonePolicyModule(in PolicyModule) PolicyModule {
 	return PolicyModule{
-		Path:         strings.TrimSpace(in.Path),
-		ABI:          strings.TrimSpace(in.ABI),
-		Entry:        strings.TrimSpace(in.Entry),
-		Digest:       strings.TrimSpace(in.Digest),
-		SourcePath:   strings.TrimSpace(in.SourcePath),
-		SourceHash:   strings.TrimSpace(in.SourceHash),
+		Path:       strings.TrimSpace(in.Path),
+		Kind:       strings.TrimSpace(in.Kind),
+		ABI:        strings.TrimSpace(in.ABI),
+		Entry:      strings.TrimSpace(in.Entry),
+		Digest:     strings.TrimSpace(in.Digest),
+		SourcePath: strings.TrimSpace(in.SourcePath),
+		SourceHash: strings.TrimSpace(in.SourceHash),
+		Runtime: PolicyModuleRuntime{
+			Interpreter:       strings.TrimSpace(in.Runtime.Interpreter),
+			InterpreterDigest: strings.TrimSpace(in.Runtime.InterpreterDigest),
+			SnapshotDigest:    strings.TrimSpace(in.Runtime.SnapshotDigest),
+			HarnessABI:        strings.TrimSpace(in.Runtime.HarnessABI),
+		},
 		InputSchema:  clonePolicyModuleSchema(in.InputSchema),
 		OutputSchema: clonePolicyModuleSchema(in.OutputSchema),
 		Limits: PolicyModuleLimits{

--- a/internal/runtime/pythonmodule/runtime.go
+++ b/internal/runtime/pythonmodule/runtime.go
@@ -334,15 +334,16 @@ func extractArtifact() (string, error) {
 	if actual != InterpreterDigest {
 		return "", fmt.Errorf("embedded CPython-WASI artifact digest %s does not match declared %s", actual, InterpreterDigest)
 	}
-	dir := filepath.Join(os.TempDir(), "swarm-"+Interpreter+"-"+hex.EncodeToString(sum[:8]))
-	if _, err := os.Stat(filepath.Join(dir, pythonWasmPath)); err == nil {
-		return dir, nil
-	}
-	tmp := dir + ".tmp"
-	_ = os.RemoveAll(tmp)
-	if err := os.MkdirAll(tmp, artifactCachePerm); err != nil {
+	dir, err := os.MkdirTemp("", "swarm-"+Interpreter+"-")
+	if err != nil {
 		return "", err
 	}
+	success := false
+	defer func() {
+		if !success {
+			_ = os.RemoveAll(dir)
+		}
+	}()
 	reader, err := zip.NewReader(bytes.NewReader(raw), int64(len(raw)))
 	if err != nil {
 		return "", err
@@ -350,49 +351,38 @@ func extractArtifact() (string, error) {
 	for _, file := range reader.File {
 		name := filepath.Clean(filepath.FromSlash(file.Name))
 		if name == "." || name == "" || strings.HasPrefix(name, ".."+string(filepath.Separator)) || filepath.IsAbs(name) {
-			_ = os.RemoveAll(tmp)
 			return "", fmt.Errorf("embedded CPython-WASI artifact contains unsafe path %q", file.Name)
 		}
-		target := filepath.Join(tmp, name)
+		target := filepath.Join(dir, name)
 		if file.FileInfo().IsDir() {
 			if err := os.MkdirAll(target, artifactCachePerm); err != nil {
-				_ = os.RemoveAll(tmp)
 				return "", err
 			}
 			continue
 		}
 		if err := os.MkdirAll(filepath.Dir(target), artifactCachePerm); err != nil {
-			_ = os.RemoveAll(tmp)
 			return "", err
 		}
 		src, err := file.Open()
 		if err != nil {
-			_ = os.RemoveAll(tmp)
 			return "", err
 		}
 		dst, err := os.OpenFile(target, os.O_CREATE|os.O_EXCL|os.O_WRONLY, artifactFilePerm)
 		if err != nil {
 			src.Close()
-			_ = os.RemoveAll(tmp)
 			return "", err
 		}
 		_, copyErr := io.Copy(dst, src)
 		closeErr := dst.Close()
 		src.Close()
 		if copyErr != nil {
-			_ = os.RemoveAll(tmp)
 			return "", copyErr
 		}
 		if closeErr != nil {
-			_ = os.RemoveAll(tmp)
 			return "", closeErr
 		}
 	}
-	_ = os.RemoveAll(dir)
-	if err := os.Rename(tmp, dir); err != nil {
-		_ = os.RemoveAll(tmp)
-		return "", err
-	}
+	success = true
 	return dir, nil
 }
 
@@ -435,7 +425,7 @@ COMPILE_CODE = "compute_module_compile"
 ABI_CODE = "compute_module_abi"
 EXCEPTION_CODE = "compute_module_python_exception"
 ALLOWED_IMPORTS = {"json", "re", "collections", "itertools", "functools", "operator", "string", "textwrap", "decimal"}
-DENIED_NAMES = {"open", "eval", "exec", "compile", "__import__", "globals", "locals", "vars", "dir", "getattr", "setattr", "delattr", "help", "breakpoint"}
+DENIED_NAMES = {"open", "eval", "exec", "compile", "__import__", "__builtins__", "globals", "locals", "vars", "dir", "getattr", "setattr", "delattr", "help", "breakpoint"}
 SAFE_BUILTIN_NAMES = {
     "abs", "all", "any", "bool", "dict", "enumerate", "filter", "float", "int", "isinstance",
     "len", "list", "map", "max", "min", "pow", "range", "reversed", "round", "set", "slice",
@@ -464,6 +454,10 @@ def check_tree(tree):
                     return DENIED_CODE, "import %s is not available to python compute modules" % name, getattr(node, "lineno", 0)
         if isinstance(node, ast.Name) and node.id in DENIED_NAMES:
             return DENIED_CODE, "%s is not available to python compute modules" % node.id, getattr(node, "lineno", 0)
+        if isinstance(node, ast.Name) and node.id.startswith("__"):
+            return DENIED_CODE, "%s is not available to python compute modules" % node.id, getattr(node, "lineno", 0)
+        if isinstance(node, ast.Attribute) and node.attr.startswith("__"):
+            return DENIED_CODE, "%s is not available to python compute modules" % node.attr, getattr(node, "lineno", 0)
     return "", "", 0
 
 def limited_import(name, globals=None, locals=None, fromlist=(), level=0):

--- a/internal/runtime/pythonmodule/runtime.go
+++ b/internal/runtime/pythonmodule/runtime.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"crypto/sha256"
 	"embed"
+	"encoding/binary"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
@@ -32,6 +33,8 @@ const (
 	artifactFilePerm    = 0o644
 	wasmPageSize        = 64 * 1024
 	defaultValidateFuel = 2_000_000_000
+	wasiErrnoSuccess    = int32(0)
+	wasiErrnoFault      = int32(21)
 )
 
 //go:embed testdata/python-3.13.14-wasi_sdk-24.zip
@@ -233,7 +236,11 @@ func runHarness(req Request, envelope harnessEnvelope, fuel uint64) (harnessWire
 	}
 	store.SetWasi(wasi)
 	linker := wasmtime.NewLinker(engine)
+	linker.AllowShadowing(true)
 	if err := linker.DefineWasi(); err != nil {
+		return harnessWireResult{}, &computemodule.Error{Code: computemodule.CodeCompile, ModuleID: req.ModuleID, RowID: req.RowID, Err: err}
+	}
+	if err := defineDeterministicWASI(linker); err != nil {
 		return harnessWireResult{}, &computemodule.Error{Code: computemodule.CodeCompile, ModuleID: req.ModuleID, RowID: req.RowID, Err: err}
 	}
 	instance, err := linker.Instantiate(store, module)
@@ -268,6 +275,44 @@ func runHarness(req Request, envelope harnessEnvelope, fuel uint64) (harnessWire
 		return harnessWireResult{}, classifyPythonCallError(req, computemodule.CodeTrap, fmt.Errorf("%w; stderr=%s", callErr, strings.TrimSpace(string(stderr))))
 	}
 	return harnessWireResult{}, &computemodule.Error{Code: computemodule.CodeABI, ModuleID: req.ModuleID, RowID: req.RowID, Err: fmt.Errorf("python harness emitted invalid response stdout=%q stderr=%q", strings.TrimSpace(string(stdout)), strings.TrimSpace(string(stderr)))}
+}
+
+func defineDeterministicWASI(linker *wasmtime.Linker) error {
+	if err := linker.FuncWrap("wasi_snapshot_preview1", "random_get", deterministicRandomGet); err != nil {
+		return err
+	}
+	return linker.FuncWrap("wasi_snapshot_preview1", "clock_time_get", deterministicClockTimeGet)
+}
+
+func deterministicRandomGet(caller *wasmtime.Caller, ptr int32, length int32) int32 {
+	data, ok := callerMemoryData(caller)
+	if !ok || ptr < 0 || length < 0 || int64(ptr)+int64(length) > int64(len(data)) {
+		return wasiErrnoFault
+	}
+	for idx := int32(0); idx < length; idx++ {
+		data[int(ptr+idx)] = 0
+	}
+	return wasiErrnoSuccess
+}
+
+func deterministicClockTimeGet(caller *wasmtime.Caller, _ int32, _ int64, resultPtr int32) int32 {
+	data, ok := callerMemoryData(caller)
+	if !ok || resultPtr < 0 || int64(resultPtr)+8 > int64(len(data)) {
+		return wasiErrnoFault
+	}
+	binary.LittleEndian.PutUint64(data[int(resultPtr):int(resultPtr)+8], 0)
+	return wasiErrnoSuccess
+}
+
+func callerMemoryData(caller *wasmtime.Caller) ([]byte, bool) {
+	if caller == nil {
+		return nil, false
+	}
+	ext := caller.GetExport("memory")
+	if ext == nil || ext.Memory() == nil {
+		return nil, false
+	}
+	return ext.Memory().UnsafeData(caller), true
 }
 
 func harnessError(req Request, wire harnessWireResult) error {

--- a/internal/runtime/pythonmodule/runtime.go
+++ b/internal/runtime/pythonmodule/runtime.go
@@ -35,6 +35,7 @@ const (
 	defaultValidateFuel = 2_000_000_000
 	wasiErrnoSuccess    = int32(0)
 	wasiErrnoFault      = int32(21)
+	wasiErrnoNotSup     = int32(58)
 )
 
 //go:embed testdata/python-3.13.14-wasi_sdk-24.zip
@@ -281,7 +282,10 @@ func defineDeterministicWASI(linker *wasmtime.Linker) error {
 	if err := linker.FuncWrap("wasi_snapshot_preview1", "random_get", deterministicRandomGet); err != nil {
 		return err
 	}
-	return linker.FuncWrap("wasi_snapshot_preview1", "clock_time_get", deterministicClockTimeGet)
+	if err := linker.FuncWrap("wasi_snapshot_preview1", "clock_time_get", deterministicClockTimeGet); err != nil {
+		return err
+	}
+	return linker.FuncWrap("wasi_snapshot_preview1", "poll_oneoff", deterministicPollOneoff)
 }
 
 func deterministicRandomGet(caller *wasmtime.Caller, ptr int32, length int32) int32 {
@@ -302,6 +306,10 @@ func deterministicClockTimeGet(caller *wasmtime.Caller, _ int32, _ int64, result
 	}
 	binary.LittleEndian.PutUint64(data[int(resultPtr):int(resultPtr)+8], 0)
 	return wasiErrnoSuccess
+}
+
+func deterministicPollOneoff(_ *wasmtime.Caller, _ int32, _ int32, _ int32, _ int32) int32 {
+	return wasiErrnoNotSup
 }
 
 func callerMemoryData(caller *wasmtime.Caller) ([]byte, bool) {

--- a/internal/runtime/pythonmodule/runtime.go
+++ b/internal/runtime/pythonmodule/runtime.go
@@ -1,0 +1,514 @@
+package pythonmodule
+
+import (
+	"archive/zip"
+	"bytes"
+	"crypto/sha256"
+	"embed"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+
+	"github.com/bytecodealliance/wasmtime-go/v46"
+	"github.com/division-sh/swarm/internal/runtime/computemodule"
+)
+
+const (
+	Kind         = "python"
+	ABI          = "python-json-v1"
+	DefaultEntry = "handle"
+
+	Interpreter         = "cpython-wasi-3.13.14-wasi_sdk-24"
+	InterpreterDigest   = "sha256:a70a750951302744d84746340b4932b80dabad5b153cc3392bcae114b293c060"
+	HarnessABI          = "swarm-python-json-v1"
+	artifactZipPath     = "testdata/python-3.13.14-wasi_sdk-24.zip"
+	pythonWasmPath      = "python.wasm"
+	artifactCachePerm   = 0o755
+	artifactFilePerm    = 0o644
+	wasmPageSize        = 64 * 1024
+	defaultValidateFuel = 2_000_000_000
+)
+
+//go:embed testdata/python-3.13.14-wasi_sdk-24.zip
+var artifactFS embed.FS
+
+var (
+	artifactOnce sync.Once
+	artifactDir  string
+	artifactErr  error
+)
+
+type Identity struct {
+	Interpreter       string
+	InterpreterDigest string
+	SnapshotDigest    string
+	HarnessABI        string
+	Engine            string
+}
+
+type Request struct {
+	ModuleID    string
+	RowID       string
+	Digest      string
+	Entry       string
+	Source      []byte
+	Input       []byte
+	Fuel        uint64
+	MemoryPages uint32
+	OutputBytes int
+}
+
+type Result struct {
+	Output         []byte
+	FuelConsumed   uint64
+	Engine         string
+	OutputHash     string
+	Interpreter    string
+	InterpreterSHA string
+	SnapshotHash   string
+	HarnessABI     string
+	SourceHash     string
+}
+
+func RuntimeIdentity() Identity {
+	return Identity{
+		Interpreter:       Interpreter,
+		InterpreterDigest: InterpreterDigest,
+		SnapshotDigest:    embeddedSnapshotDigest(),
+		HarnessABI:        HarnessABI,
+		Engine:            computemodule.EngineVersion(),
+	}
+}
+
+func ValidateSource(req Request) error {
+	req.Entry = normalizeEntry(req.Entry)
+	if err := validateRequestShape(req); err != nil {
+		return err
+	}
+	if err := computemodule.ValidateDigest(req.Source, req.Digest); err != nil {
+		return &computemodule.Error{Code: computemodule.CodeDigest, ModuleID: req.ModuleID, RowID: req.RowID, Err: err}
+	}
+	fuel := req.Fuel
+	if fuel == 0 {
+		fuel = defaultValidateFuel
+	}
+	_, err := runHarness(req, harnessEnvelope{
+		Mode:   "validate",
+		Source: string(req.Source),
+		Entry:  req.Entry,
+	}, fuel)
+	return err
+}
+
+func Execute(req Request) (Result, error) {
+	req.Entry = normalizeEntry(req.Entry)
+	if err := validateRequestShape(req); err != nil {
+		return Result{}, err
+	}
+	if err := computemodule.ValidateDigest(req.Source, req.Digest); err != nil {
+		return Result{}, &computemodule.Error{Code: computemodule.CodeDigest, ModuleID: req.ModuleID, RowID: req.RowID, Err: err}
+	}
+	if req.Fuel == 0 {
+		return Result{}, &computemodule.Error{Code: computemodule.CodeFuel, ModuleID: req.ModuleID, RowID: req.RowID, Err: fmt.Errorf("fuel limit is required")}
+	}
+	var input map[string]any
+	if err := json.Unmarshal(req.Input, &input); err != nil {
+		return Result{}, &computemodule.Error{Code: computemodule.CodeABI, ModuleID: req.ModuleID, RowID: req.RowID, Err: fmt.Errorf("input is not JSON object: %w", err)}
+	}
+	if input == nil {
+		return Result{}, &computemodule.Error{Code: computemodule.CodeABI, ModuleID: req.ModuleID, RowID: req.RowID, Err: fmt.Errorf("input is not JSON object")}
+	}
+	wire, err := runHarness(req, harnessEnvelope{
+		Mode:   "execute",
+		Source: string(req.Source),
+		Entry:  req.Entry,
+		Input:  input,
+	}, req.Fuel)
+	if err != nil {
+		return Result{}, err
+	}
+	output, err := json.Marshal(wire.Output)
+	if err != nil {
+		return Result{}, &computemodule.Error{Code: computemodule.CodeABI, ModuleID: req.ModuleID, RowID: req.RowID, Err: fmt.Errorf("output cannot be encoded as JSON object: %w", err)}
+	}
+	if req.OutputBytes > 0 && len(output) > req.OutputBytes {
+		return Result{}, &computemodule.Error{Code: computemodule.CodeOutputSize, ModuleID: req.ModuleID, RowID: req.RowID, Err: fmt.Errorf("output %d bytes exceeds cap %d", len(output), req.OutputBytes)}
+	}
+	sum := sha256.Sum256(output)
+	identity := RuntimeIdentity()
+	return Result{
+		Output:         output,
+		FuelConsumed:   wire.FuelConsumed,
+		Engine:         identity.Engine,
+		OutputHash:     "sha256:" + hex.EncodeToString(sum[:]),
+		Interpreter:    identity.Interpreter,
+		InterpreterSHA: identity.InterpreterDigest,
+		SnapshotHash:   identity.SnapshotDigest,
+		HarnessABI:     identity.HarnessABI,
+		SourceHash:     sourceHash(req.Source),
+	}, nil
+}
+
+type harnessEnvelope struct {
+	Mode   string         `json:"mode"`
+	Source string         `json:"source"`
+	Entry  string         `json:"entry"`
+	Input  map[string]any `json:"input,omitempty"`
+}
+
+type harnessWireResult struct {
+	OK           bool           `json:"ok"`
+	Code         string         `json:"code,omitempty"`
+	Message      string         `json:"message,omitempty"`
+	Line         int            `json:"line,omitempty"`
+	Output       map[string]any `json:"output,omitempty"`
+	FuelConsumed uint64         `json:"-"`
+}
+
+func runHarness(req Request, envelope harnessEnvelope, fuel uint64) (harnessWireResult, error) {
+	root, err := materializedArtifactDir()
+	if err != nil {
+		return harnessWireResult{}, &computemodule.Error{Code: computemodule.CodeCompile, ModuleID: req.ModuleID, RowID: req.RowID, Err: err}
+	}
+	wasm, err := os.ReadFile(filepath.Join(root, pythonWasmPath))
+	if err != nil {
+		return harnessWireResult{}, &computemodule.Error{Code: computemodule.CodeCompile, ModuleID: req.ModuleID, RowID: req.RowID, Err: fmt.Errorf("read embedded %s: %w", pythonWasmPath, err)}
+	}
+	input, err := json.Marshal(envelope)
+	if err != nil {
+		return harnessWireResult{}, &computemodule.Error{Code: computemodule.CodeABI, ModuleID: req.ModuleID, RowID: req.RowID, Err: err}
+	}
+	runDir, err := os.MkdirTemp("", "swarm-python-module-")
+	if err != nil {
+		return harnessWireResult{}, &computemodule.Error{Code: computemodule.CodeCompile, ModuleID: req.ModuleID, RowID: req.RowID, Err: err}
+	}
+	defer os.RemoveAll(runDir)
+	stdinPath := filepath.Join(runDir, "stdin.json")
+	stdoutPath := filepath.Join(runDir, "stdout.json")
+	stderrPath := filepath.Join(runDir, "stderr.txt")
+	if err := os.WriteFile(stdinPath, input, 0o600); err != nil {
+		return harnessWireResult{}, &computemodule.Error{Code: computemodule.CodeCompile, ModuleID: req.ModuleID, RowID: req.RowID, Err: err}
+	}
+
+	cfg := wasmtime.NewConfig()
+	cfg.SetConsumeFuel(true)
+	cfg.SetWasmBulkMemory(true)
+	cfg.SetWasmMemory64(false)
+	cfg.SetWasmMultiMemory(false)
+	cfg.SetWasmSIMD(false)
+	cfg.SetWasmRelaxedSIMD(false)
+	cfg.SetWasmThreads(false)
+	engine := wasmtime.NewEngineWithConfig(cfg)
+	module, err := wasmtime.NewModule(engine, wasm)
+	if err != nil {
+		return harnessWireResult{}, &computemodule.Error{Code: computemodule.CodeCompile, ModuleID: req.ModuleID, RowID: req.RowID, Err: err}
+	}
+	store := wasmtime.NewStore(engine)
+	store.Limiter(memoryLimitBytes(req.MemoryPages), -1, -1, -1, -1)
+	if err := store.SetFuel(fuel); err != nil {
+		return harnessWireResult{}, &computemodule.Error{Code: computemodule.CodeFuel, ModuleID: req.ModuleID, RowID: req.RowID, Err: err}
+	}
+	wasi := wasmtime.NewWasiConfig()
+	wasi.SetArgv([]string{"python", "-c", harnessSource})
+	wasi.SetEnv(
+		[]string{"PYTHONHOME", "PYTHONPATH", "PYTHONHASHSEED", "PYTHONNOUSERSITE"},
+		[]string{"/", "/lib/python3.13", "0", "1"},
+	)
+	if err := wasi.SetStdinFile(stdinPath); err != nil {
+		return harnessWireResult{}, &computemodule.Error{Code: computemodule.CodeCompile, ModuleID: req.ModuleID, RowID: req.RowID, Err: err}
+	}
+	if err := wasi.SetStdoutFile(stdoutPath); err != nil {
+		return harnessWireResult{}, &computemodule.Error{Code: computemodule.CodeCompile, ModuleID: req.ModuleID, RowID: req.RowID, Err: err}
+	}
+	if err := wasi.SetStderrFile(stderrPath); err != nil {
+		return harnessWireResult{}, &computemodule.Error{Code: computemodule.CodeCompile, ModuleID: req.ModuleID, RowID: req.RowID, Err: err}
+	}
+	if err := wasi.PreopenDir(root, "/", wasmtime.DIR_READ, wasmtime.FILE_READ); err != nil {
+		return harnessWireResult{}, &computemodule.Error{Code: computemodule.CodeCompile, ModuleID: req.ModuleID, RowID: req.RowID, Err: err}
+	}
+	store.SetWasi(wasi)
+	linker := wasmtime.NewLinker(engine)
+	if err := linker.DefineWasi(); err != nil {
+		return harnessWireResult{}, &computemodule.Error{Code: computemodule.CodeCompile, ModuleID: req.ModuleID, RowID: req.RowID, Err: err}
+	}
+	instance, err := linker.Instantiate(store, module)
+	if err != nil {
+		return harnessWireResult{}, classifyPythonCallError(req, computemodule.CodeTrap, err)
+	}
+	start := instance.GetFunc(store, "_start")
+	if start == nil {
+		return harnessWireResult{}, &computemodule.Error{Code: computemodule.CodeABI, ModuleID: req.ModuleID, RowID: req.RowID, Err: fmt.Errorf("embedded interpreter missing _start")}
+	}
+	_, callErr := start.Call(store)
+	fuelConsumed := fuel
+	if remaining, err := store.GetFuel(); err == nil && remaining <= fuel {
+		fuelConsumed = fuel - remaining
+	}
+	stdout, _ := os.ReadFile(stdoutPath)
+	stderr, _ := os.ReadFile(stderrPath)
+	var wire harnessWireResult
+	if len(bytes.TrimSpace(stdout)) > 0 {
+		if err := json.Unmarshal(bytes.TrimSpace(stdout), &wire); err == nil {
+			wire.FuelConsumed = fuelConsumed
+			if wire.OK {
+				if wire.Output == nil {
+					return harnessWireResult{}, &computemodule.Error{Code: computemodule.CodeABI, ModuleID: req.ModuleID, RowID: req.RowID, Err: fmt.Errorf("python harness returned ok without output")}
+				}
+				return wire, nil
+			}
+			return harnessWireResult{}, harnessError(req, wire)
+		}
+	}
+	if callErr != nil {
+		return harnessWireResult{}, classifyPythonCallError(req, computemodule.CodeTrap, fmt.Errorf("%w; stderr=%s", callErr, strings.TrimSpace(string(stderr))))
+	}
+	return harnessWireResult{}, &computemodule.Error{Code: computemodule.CodeABI, ModuleID: req.ModuleID, RowID: req.RowID, Err: fmt.Errorf("python harness emitted invalid response stdout=%q stderr=%q", strings.TrimSpace(string(stdout)), strings.TrimSpace(string(stderr)))}
+}
+
+func harnessError(req Request, wire harnessWireResult) error {
+	code := computemodule.CodeABI
+	switch wire.Code {
+	case string(computemodule.CodeDeniedCapability):
+		code = computemodule.CodeDeniedCapability
+	case string(computemodule.CodeCompile):
+		code = computemodule.CodeCompile
+	case string(computemodule.CodePythonException):
+		code = computemodule.CodePythonException
+	case string(computemodule.CodeABI):
+		code = computemodule.CodeABI
+	}
+	msg := strings.TrimSpace(wire.Message)
+	if wire.Line > 0 {
+		msg = fmt.Sprintf("%s at line %d", msg, wire.Line)
+	}
+	return &computemodule.Error{Code: code, ModuleID: req.ModuleID, RowID: req.RowID, Err: fmt.Errorf("%s", msg)}
+}
+
+func classifyPythonCallError(req Request, fallback computemodule.Code, err error) error {
+	code := fallback
+	message := strings.ToLower(err.Error())
+	switch {
+	case strings.Contains(message, "fuel"):
+		code = computemodule.CodeFuel
+	case strings.Contains(message, "memory") || strings.Contains(message, "resource limiter"):
+		code = computemodule.CodeMemory
+	}
+	return &computemodule.Error{Code: code, ModuleID: req.ModuleID, RowID: req.RowID, Err: err}
+}
+
+func validateRequestShape(req Request) error {
+	if strings.TrimSpace(req.ModuleID) == "" {
+		return &computemodule.Error{Code: computemodule.CodeABI, RowID: req.RowID, Err: fmt.Errorf("module id is required")}
+	}
+	if len(req.Source) == 0 {
+		return &computemodule.Error{Code: computemodule.CodeCompile, ModuleID: req.ModuleID, RowID: req.RowID, Err: fmt.Errorf("python source is required")}
+	}
+	if req.MemoryPages == 0 {
+		return &computemodule.Error{Code: computemodule.CodeMemory, ModuleID: req.ModuleID, RowID: req.RowID, Err: fmt.Errorf("memory page limit is required")}
+	}
+	if req.OutputBytes <= 0 {
+		return &computemodule.Error{Code: computemodule.CodeOutputSize, ModuleID: req.ModuleID, RowID: req.RowID, Err: fmt.Errorf("output byte limit is required")}
+	}
+	return nil
+}
+
+func materializedArtifactDir() (string, error) {
+	artifactOnce.Do(func() {
+		artifactDir, artifactErr = extractArtifact()
+	})
+	return artifactDir, artifactErr
+}
+
+func extractArtifact() (string, error) {
+	raw, err := artifactFS.ReadFile(artifactZipPath)
+	if err != nil {
+		return "", err
+	}
+	sum := sha256.Sum256(raw)
+	actual := "sha256:" + hex.EncodeToString(sum[:])
+	if actual != InterpreterDigest {
+		return "", fmt.Errorf("embedded CPython-WASI artifact digest %s does not match declared %s", actual, InterpreterDigest)
+	}
+	dir := filepath.Join(os.TempDir(), "swarm-"+Interpreter+"-"+hex.EncodeToString(sum[:8]))
+	if _, err := os.Stat(filepath.Join(dir, pythonWasmPath)); err == nil {
+		return dir, nil
+	}
+	tmp := dir + ".tmp"
+	_ = os.RemoveAll(tmp)
+	if err := os.MkdirAll(tmp, artifactCachePerm); err != nil {
+		return "", err
+	}
+	reader, err := zip.NewReader(bytes.NewReader(raw), int64(len(raw)))
+	if err != nil {
+		return "", err
+	}
+	for _, file := range reader.File {
+		name := filepath.Clean(filepath.FromSlash(file.Name))
+		if name == "." || name == "" || strings.HasPrefix(name, ".."+string(filepath.Separator)) || filepath.IsAbs(name) {
+			_ = os.RemoveAll(tmp)
+			return "", fmt.Errorf("embedded CPython-WASI artifact contains unsafe path %q", file.Name)
+		}
+		target := filepath.Join(tmp, name)
+		if file.FileInfo().IsDir() {
+			if err := os.MkdirAll(target, artifactCachePerm); err != nil {
+				_ = os.RemoveAll(tmp)
+				return "", err
+			}
+			continue
+		}
+		if err := os.MkdirAll(filepath.Dir(target), artifactCachePerm); err != nil {
+			_ = os.RemoveAll(tmp)
+			return "", err
+		}
+		src, err := file.Open()
+		if err != nil {
+			_ = os.RemoveAll(tmp)
+			return "", err
+		}
+		dst, err := os.OpenFile(target, os.O_CREATE|os.O_EXCL|os.O_WRONLY, artifactFilePerm)
+		if err != nil {
+			src.Close()
+			_ = os.RemoveAll(tmp)
+			return "", err
+		}
+		_, copyErr := io.Copy(dst, src)
+		closeErr := dst.Close()
+		src.Close()
+		if copyErr != nil {
+			_ = os.RemoveAll(tmp)
+			return "", copyErr
+		}
+		if closeErr != nil {
+			_ = os.RemoveAll(tmp)
+			return "", closeErr
+		}
+	}
+	_ = os.RemoveAll(dir)
+	if err := os.Rename(tmp, dir); err != nil {
+		_ = os.RemoveAll(tmp)
+		return "", err
+	}
+	return dir, nil
+}
+
+func embeddedSnapshotDigest() string {
+	sum := sha256.Sum256([]byte(strings.Join([]string{
+		Interpreter,
+		InterpreterDigest,
+		HarnessABI,
+		harnessSource,
+		"preimports=json,ast,builtins",
+	}, "\n")))
+	return "sha256:" + hex.EncodeToString(sum[:])
+}
+
+func sourceHash(source []byte) string {
+	sum := sha256.Sum256(source)
+	return "sha256:" + hex.EncodeToString(sum[:])
+}
+
+func normalizeEntry(entry string) string {
+	entry = strings.TrimSpace(entry)
+	if entry == "" {
+		return DefaultEntry
+	}
+	return entry
+}
+
+func memoryLimitBytes(memoryPages uint32) int64 {
+	return int64(memoryPages) * wasmPageSize
+}
+
+const harnessSource = `
+import ast
+import builtins
+import json
+import sys
+
+DENIED_CODE = "compute_module_denied_capability"
+COMPILE_CODE = "compute_module_compile"
+ABI_CODE = "compute_module_abi"
+EXCEPTION_CODE = "compute_module_python_exception"
+ALLOWED_IMPORTS = {"json", "re", "collections", "itertools", "functools", "operator", "string", "textwrap", "decimal"}
+DENIED_NAMES = {"open", "eval", "exec", "compile", "__import__", "globals", "locals", "vars", "dir", "getattr", "setattr", "delattr", "help", "breakpoint"}
+SAFE_BUILTIN_NAMES = {
+    "abs", "all", "any", "bool", "dict", "enumerate", "filter", "float", "int", "isinstance",
+    "len", "list", "map", "max", "min", "pow", "range", "reversed", "round", "set", "slice",
+    "sorted", "str", "sum", "tuple", "zip", "Exception", "ValueError", "TypeError", "KeyError",
+}
+
+def emit_error(code, message, line=0):
+    sys.stdout.write(json.dumps({"ok": False, "code": code, "message": str(message), "line": int(line or 0)}, sort_keys=True))
+
+def emit_ok(output=None):
+    payload = {"ok": True}
+    if output is not None:
+        payload["output"] = output
+    sys.stdout.write(json.dumps(payload, sort_keys=True))
+
+def check_tree(tree):
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.Import, ast.ImportFrom)):
+            names = []
+            if isinstance(node, ast.Import):
+                names = [alias.name.split(".")[0] for alias in node.names]
+            elif node.module:
+                names = [node.module.split(".")[0]]
+            for name in names:
+                if name not in ALLOWED_IMPORTS:
+                    return DENIED_CODE, "import %s is not available to python compute modules" % name, getattr(node, "lineno", 0)
+        if isinstance(node, ast.Name) and node.id in DENIED_NAMES:
+            return DENIED_CODE, "%s is not available to python compute modules" % node.id, getattr(node, "lineno", 0)
+    return "", "", 0
+
+def limited_import(name, globals=None, locals=None, fromlist=(), level=0):
+    root = name.split(".")[0]
+    if root not in ALLOWED_IMPORTS:
+        raise PermissionError("import %s is not available to python compute modules" % root)
+    return builtins.__import__(name, globals, locals, fromlist, level)
+
+def safe_globals():
+    safe = {name: getattr(builtins, name) for name in SAFE_BUILTIN_NAMES if hasattr(builtins, name)}
+    safe["__import__"] = limited_import
+    return {"__builtins__": safe}
+
+try:
+    envelope = json.load(sys.stdin)
+    source = envelope.get("source") or ""
+    entry = envelope.get("entry") or "handle"
+    filename = "<swarm-python-module>"
+    tree = ast.parse(source, filename=filename, mode="exec")
+    code, message, line = check_tree(tree)
+    if code:
+        emit_error(code, message, line)
+        sys.exit(1)
+    compiled = compile(tree, filename, "exec")
+    namespace = safe_globals()
+    exec(compiled, namespace, namespace)
+    handle = namespace.get(entry)
+    if not callable(handle):
+        emit_error(ABI_CODE, "python module must define callable %s(input)" % entry)
+        sys.exit(1)
+    if envelope.get("mode") == "validate":
+        emit_ok({})
+        sys.exit(0)
+    result = handle(envelope.get("input") or {})
+    if not isinstance(result, dict):
+        emit_error(ABI_CODE, "python module %s(input) must return a JSON object/dict" % entry)
+        sys.exit(1)
+    emit_ok(result)
+except SyntaxError as exc:
+    emit_error(COMPILE_CODE, exc.msg, exc.lineno or 0)
+    sys.exit(1)
+except PermissionError as exc:
+    emit_error(DENIED_CODE, str(exc))
+    sys.exit(1)
+except Exception as exc:
+    emit_error(EXCEPTION_CODE, "%s: %s" % (exc.__class__.__name__, exc), getattr(exc, "__traceback__", None).tb_lineno if getattr(exc, "__traceback__", None) else 0)
+    sys.exit(1)
+`

--- a/internal/runtime/pythonmodule/runtime_test.go
+++ b/internal/runtime/pythonmodule/runtime_test.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/division-sh/swarm/internal/runtime/computemodule"
 )
@@ -139,6 +140,35 @@ def handle(input):
 	}
 	if output["random"] == nil {
 		t.Fatalf("random missing from boundary output: %#v", output)
+	}
+}
+
+func TestExecuteWASIBoundaryDeniesRecoveredSleepTimer(t *testing.T) {
+	source := []byte(`import json
+import operator
+
+def handle(input):
+    full_builtins = operator.attrgetter("__globals__")(json.loads)["__builtins__"]
+    time = full_builtins["__import__"]("time")
+    time.sleep(5)
+    return {"slept": True}
+`)
+	start := time.Now()
+	_, err := Execute(Request{
+		ModuleID:    "sleep_probe",
+		RowID:       "sleep_probe",
+		Digest:      digestSource(source),
+		Entry:       DefaultEntry,
+		Source:      source,
+		Input:       []byte(`{}`),
+		Fuel:        3_000_000_000,
+		MemoryPages: 8192,
+		OutputBytes: 4096,
+	})
+	elapsed := time.Since(start)
+	assertComputeModuleCode(t, err, computemodule.CodePythonException)
+	if elapsed >= 4*time.Second {
+		t.Fatalf("time.sleep consumed host wall time: elapsed=%s", elapsed)
 	}
 }
 

--- a/internal/runtime/pythonmodule/runtime_test.go
+++ b/internal/runtime/pythonmodule/runtime_test.go
@@ -5,6 +5,8 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"errors"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -80,6 +82,51 @@ func TestValidateSourceRejectsDeniedCapability(t *testing.T) {
 		OutputBytes: 1024,
 	})
 	assertComputeModuleCode(t, err, computemodule.CodeDeniedCapability)
+}
+
+func TestValidateSourceRejectsBuiltinEscape(t *testing.T) {
+	source := []byte(`def handle(input):
+    os = __builtins__["__import__"].__globals__["builtins"].__import__("os")
+    return {"cwd": os.getcwd()}
+`)
+	err := ValidateSource(Request{
+		ModuleID:    "bad",
+		RowID:       "policy.modules.bad",
+		Digest:      digestSource(source),
+		Entry:       DefaultEntry,
+		Source:      source,
+		Fuel:        2_000_000_000,
+		MemoryPages: 8192,
+		OutputBytes: 1024,
+	})
+	assertComputeModuleCode(t, err, computemodule.CodeDeniedCapability)
+}
+
+func TestExtractArtifactIgnoresPredictableStaleCache(t *testing.T) {
+	digestHex := strings.TrimPrefix(InterpreterDigest, "sha256:")
+	predictable := filepath.Join(os.TempDir(), "swarm-"+Interpreter+"-"+digestHex[:16])
+	if err := os.MkdirAll(predictable, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(predictable) })
+	if err := os.WriteFile(filepath.Join(predictable, pythonWasmPath), []byte("poisoned"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dir, err := extractArtifact()
+	if err != nil {
+		t.Fatalf("extractArtifact: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	if dir == predictable {
+		t.Fatalf("extractArtifact reused predictable stale cache %s", dir)
+	}
+	raw, err := os.ReadFile(filepath.Join(dir, pythonWasmPath))
+	if err != nil {
+		t.Fatalf("read extracted python.wasm: %v", err)
+	}
+	if string(raw) == "poisoned" {
+		t.Fatalf("extractArtifact returned stale poisoned python.wasm")
+	}
 }
 
 func TestExecuteClassifiesExceptionOutputCapAndFuel(t *testing.T) {

--- a/internal/runtime/pythonmodule/runtime_test.go
+++ b/internal/runtime/pythonmodule/runtime_test.go
@@ -1,0 +1,150 @@
+package pythonmodule
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/division-sh/swarm/internal/runtime/computemodule"
+)
+
+func TestExecuteStructuredTransform(t *testing.T) {
+	source := []byte(`def handle(input):
+    lines = [
+        "component: " + input["component"],
+        "owner: " + input["owner"],
+    ]
+    for name in input["files"]:
+        if name.endswith(".yaml"):
+            lines.append("- deploy/" + name)
+        elif name.endswith(".go"):
+            lines.append("- src/" + name)
+        else:
+            lines.append("- " + name)
+    return {"content": "\n".join(lines), "format": "yaml", "line_count": len(lines)}
+`)
+	input := map[string]any{
+		"component": "api",
+		"owner":     "platform",
+		"files":     []any{"main.go", "README.md", "service.yaml"},
+	}
+	raw, err := json.Marshal(input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, err := Execute(Request{
+		ModuleID:    "python_renderer",
+		RowID:       "render_bundle",
+		Digest:      digestSource(source),
+		Entry:       DefaultEntry,
+		Source:      source,
+		Input:       raw,
+		Fuel:        2_500_000_000,
+		MemoryPages: 8192,
+		OutputBytes: 4096,
+	})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if result.Interpreter != Interpreter || result.InterpreterSHA != InterpreterDigest || result.SnapshotHash == "" || result.HarnessABI != HarnessABI || result.SourceHash != digestSource(source) {
+		t.Fatalf("runtime identity = %#v", result)
+	}
+	if result.FuelConsumed == 0 || result.OutputHash == "" || !strings.Contains(result.Engine, "wasmtime-go") {
+		t.Fatalf("trace evidence missing: %#v", result)
+	}
+	var output map[string]any
+	if err := json.Unmarshal(result.Output, &output); err != nil {
+		t.Fatalf("output JSON: %v", err)
+	}
+	content, _ := output["content"].(string)
+	for _, want := range []string{"component: api", "owner: platform", "- src/main.go", "- deploy/service.yaml"} {
+		if !strings.Contains(content, want) {
+			t.Fatalf("content missing %q: %s", want, content)
+		}
+	}
+}
+
+func TestValidateSourceRejectsDeniedCapability(t *testing.T) {
+	source := []byte("import os\n\ndef handle(input):\n    return {\"cwd\": os.getcwd()}\n")
+	err := ValidateSource(Request{
+		ModuleID:    "bad",
+		RowID:       "policy.modules.bad",
+		Digest:      digestSource(source),
+		Entry:       DefaultEntry,
+		Source:      source,
+		Fuel:        2_000_000_000,
+		MemoryPages: 8192,
+		OutputBytes: 1024,
+	})
+	assertComputeModuleCode(t, err, computemodule.CodeDeniedCapability)
+}
+
+func TestExecuteClassifiesExceptionOutputCapAndFuel(t *testing.T) {
+	tests := []struct {
+		name   string
+		source []byte
+		fuel   uint64
+		output int
+		code   computemodule.Code
+	}{
+		{
+			name:   "exception",
+			source: []byte("def handle(input):\n    raise ValueError(\"bad payload\")\n"),
+			fuel:   2_000_000_000,
+			output: 1024,
+			code:   computemodule.CodePythonException,
+		},
+		{
+			name:   "output_cap",
+			source: []byte("def handle(input):\n    return {\"content\": \"x\" * 200}\n"),
+			fuel:   2_000_000_000,
+			output: 16,
+			code:   computemodule.CodeOutputSize,
+		},
+		{
+			name:   "fuel",
+			source: []byte("def handle(input):\n    while True:\n        pass\n"),
+			fuel:   10,
+			output: 1024,
+			code:   computemodule.CodeFuel,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := Execute(Request{
+				ModuleID:    "bad",
+				RowID:       tc.name,
+				Digest:      digestSource(tc.source),
+				Entry:       DefaultEntry,
+				Source:      tc.source,
+				Input:       []byte(`{}`),
+				Fuel:        tc.fuel,
+				MemoryPages: 8192,
+				OutputBytes: tc.output,
+			})
+			assertComputeModuleCode(t, err, tc.code)
+		})
+	}
+}
+
+func assertComputeModuleCode(t *testing.T, err error, code computemodule.Code) {
+	t.Helper()
+	if err == nil {
+		t.Fatalf("error = nil, want %s", code)
+	}
+	if !computemodule.IsDeterministicFailure(err) {
+		t.Fatalf("IsDeterministicFailure(%v) = false", err)
+	}
+	var typed *computemodule.Error
+	if !errors.As(err, &typed) || typed.Code != code {
+		t.Fatalf("error = %#v, want code %s", err, code)
+	}
+}
+
+func digestSource(source []byte) string {
+	sum := sha256.Sum256(source)
+	return "sha256:" + hex.EncodeToString(sum[:])
+}

--- a/internal/runtime/pythonmodule/runtime_test.go
+++ b/internal/runtime/pythonmodule/runtime_test.go
@@ -150,25 +150,29 @@ import operator
 def handle(input):
     full_builtins = operator.attrgetter("__globals__")(json.loads)["__builtins__"]
     time = full_builtins["__import__"]("time")
-    time.sleep(5)
+    time.sleep(60)
     return {"slept": True}
 `)
-	start := time.Now()
-	_, err := Execute(Request{
-		ModuleID:    "sleep_probe",
-		RowID:       "sleep_probe",
-		Digest:      digestSource(source),
-		Entry:       DefaultEntry,
-		Source:      source,
-		Input:       []byte(`{}`),
-		Fuel:        3_000_000_000,
-		MemoryPages: 8192,
-		OutputBytes: 4096,
-	})
-	elapsed := time.Since(start)
-	assertComputeModuleCode(t, err, computemodule.CodePythonException)
-	if elapsed >= 4*time.Second {
-		t.Fatalf("time.sleep consumed host wall time: elapsed=%s", elapsed)
+	done := make(chan error, 1)
+	go func() {
+		_, err := Execute(Request{
+			ModuleID:    "sleep_probe",
+			RowID:       "sleep_probe",
+			Digest:      digestSource(source),
+			Entry:       DefaultEntry,
+			Source:      source,
+			Input:       []byte(`{}`),
+			Fuel:        3_000_000_000,
+			MemoryPages: 8192,
+			OutputBytes: 4096,
+		})
+		done <- err
+	}()
+	select {
+	case err := <-done:
+		assertComputeModuleCode(t, err, computemodule.CodePythonException)
+	case <-time.After(20 * time.Second):
+		t.Fatalf("time.sleep used host timer instead of deterministic denial")
 	}
 }
 

--- a/internal/runtime/pythonmodule/runtime_test.go
+++ b/internal/runtime/pythonmodule/runtime_test.go
@@ -102,6 +102,46 @@ func TestValidateSourceRejectsBuiltinEscape(t *testing.T) {
 	assertComputeModuleCode(t, err, computemodule.CodeDeniedCapability)
 }
 
+func TestExecuteWASIBoundaryWithRecoveredImports(t *testing.T) {
+	t.Setenv("SWARM_PYTHON_BOUNDARY_HOST_ENV", "must-not-leak")
+	source := []byte(`import json
+import operator
+
+def handle(input):
+    full_builtins = operator.attrgetter("__globals__")(json.loads)["__builtins__"]
+    os = full_builtins["__import__"]("os")
+    time = full_builtins["__import__"]("time")
+    random = full_builtins["__import__"]("random")
+    return {
+        "env": sorted(os.environ.keys()),
+        "random": random.random(),
+        "root": sorted(os.listdir("/")),
+        "time": time.time(),
+    }
+`)
+	first := executeBoundaryProbe(t, source)
+	second := executeBoundaryProbe(t, source)
+	if string(first.Output) != string(second.Output) {
+		t.Fatalf("boundary probe output drifted:\nfirst=%s\nsecond=%s", first.Output, second.Output)
+	}
+	var output map[string]any
+	if err := json.Unmarshal(first.Output, &output); err != nil {
+		t.Fatalf("decode boundary output: %v", err)
+	}
+	if got, want := strings.Join(jsonStringSlice(t, output["root"]), ","), "LICENSE,lib,python.wasm"; got != want {
+		t.Fatalf("root = %s, want embedded interpreter root only", got)
+	}
+	if got, want := strings.Join(jsonStringSlice(t, output["env"]), ","), "PYTHONHASHSEED,PYTHONHOME,PYTHONNOUSERSITE,PYTHONPATH"; got != want {
+		t.Fatalf("env = %s, want fixed runtime env only", got)
+	}
+	if got, _ := output["time"].(float64); got != 0 {
+		t.Fatalf("time = %v, want deterministic zero clock", output["time"])
+	}
+	if output["random"] == nil {
+		t.Fatalf("random missing from boundary output: %#v", output)
+	}
+}
+
 func TestExtractArtifactIgnoresPredictableStaleCache(t *testing.T) {
 	digestHex := strings.TrimPrefix(InterpreterDigest, "sha256:")
 	predictable := filepath.Join(os.TempDir(), "swarm-"+Interpreter+"-"+digestHex[:16])
@@ -127,6 +167,42 @@ func TestExtractArtifactIgnoresPredictableStaleCache(t *testing.T) {
 	if string(raw) == "poisoned" {
 		t.Fatalf("extractArtifact returned stale poisoned python.wasm")
 	}
+}
+
+func executeBoundaryProbe(t *testing.T, source []byte) Result {
+	t.Helper()
+	result, err := Execute(Request{
+		ModuleID:    "boundary_probe",
+		RowID:       "boundary_probe",
+		Digest:      digestSource(source),
+		Entry:       DefaultEntry,
+		Source:      source,
+		Input:       []byte(`{}`),
+		Fuel:        3_000_000_000,
+		MemoryPages: 8192,
+		OutputBytes: 4096,
+	})
+	if err != nil {
+		t.Fatalf("Execute boundary probe: %v", err)
+	}
+	return result
+}
+
+func jsonStringSlice(t *testing.T, value any) []string {
+	t.Helper()
+	list, ok := value.([]any)
+	if !ok {
+		t.Fatalf("value = %#v, want JSON array", value)
+	}
+	out := make([]string, 0, len(list))
+	for _, item := range list {
+		text, ok := item.(string)
+		if !ok {
+			t.Fatalf("array item = %#v, want string", item)
+		}
+		out = append(out, text)
+	}
+	return out
 }
 
 func TestExecuteClassifiesExceptionOutputCapAndFuel(t *testing.T) {

--- a/internal/runtime/semanticview/import_boundary_dependencies.go
+++ b/internal/runtime/semanticview/import_boundary_dependencies.go
@@ -490,12 +490,19 @@ func clonePolicyDocument(in runtimecontracts.PolicyDocument) runtimecontracts.Po
 
 func clonePolicyModule(in runtimecontracts.PolicyModule) runtimecontracts.PolicyModule {
 	return runtimecontracts.PolicyModule{
-		Path:         strings.TrimSpace(in.Path),
-		ABI:          strings.TrimSpace(in.ABI),
-		Entry:        strings.TrimSpace(in.Entry),
-		Digest:       strings.TrimSpace(in.Digest),
-		SourcePath:   strings.TrimSpace(in.SourcePath),
-		SourceHash:   strings.TrimSpace(in.SourceHash),
+		Path:       strings.TrimSpace(in.Path),
+		Kind:       strings.TrimSpace(in.Kind),
+		ABI:        strings.TrimSpace(in.ABI),
+		Entry:      strings.TrimSpace(in.Entry),
+		Digest:     strings.TrimSpace(in.Digest),
+		SourcePath: strings.TrimSpace(in.SourcePath),
+		SourceHash: strings.TrimSpace(in.SourceHash),
+		Runtime: runtimecontracts.PolicyModuleRuntime{
+			Interpreter:       strings.TrimSpace(in.Runtime.Interpreter),
+			InterpreterDigest: strings.TrimSpace(in.Runtime.InterpreterDigest),
+			SnapshotDigest:    strings.TrimSpace(in.Runtime.SnapshotDigest),
+			HarnessABI:        strings.TrimSpace(in.Runtime.HarnessABI),
+		},
 		InputSchema:  cloneAnyMap(in.InputSchema),
 		OutputSchema: cloneAnyMap(in.OutputSchema),
 		Limits: runtimecontracts.PolicyModuleLimits{

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -1637,11 +1637,12 @@ compute_module_contracts:
         mounted. Network, subprocess, threads, third-party packages, generated
         bindings, and ambient host capabilities are not supported.
 
-        Author-reachable WASI clock and random imports MUST be deterministic in
-        this slice. The host shadows `clock_time_get` with a zero clock and
-        `random_get` with deterministic bytes; real wall-clock and host entropy
-        are not exposed even if author code recovers unrestricted CPython
-        imports through reflection.
+        Author-reachable WASI clock, random, and timer/sleep imports MUST be
+        deterministic in this slice. The host shadows `clock_time_get` with a
+        zero clock, `random_get` with deterministic bytes, and `poll_oneoff`
+        with a deterministic unsupported-capability result; real wall-clock
+        values, host entropy, and host timer waits are not exposed even if
+        author code recovers unrestricted CPython imports through reflection.
     deterministic_features: |
       Runtime configuration MUST disable nondeterministic or unapproved features
       including threads, SIMD, memory64, and multi-memory. Deterministic core
@@ -1750,8 +1751,8 @@ compute_module_contracts:
   - '#1670 owns public build/source tooling and any instrumentation pipeline.'
   - Declarative lookup, validation, selection, and future derive rows remain preferred when they can express the work.
   - Durable activities, orchestration, timers, joins, loops, schedules, host imports, WASI capabilities beyond the fixed
-    Python interpreter mount and deterministic clock/random stubs, filesystem/network access beyond that read-only mount,
-    shared module packs, source compilation, and file-backed module inputs are separate gates.
+    Python interpreter mount and deterministic clock/random/timer stubs, filesystem/network access beyond that read-only
+    mount, shared module packs, source compilation, and file-backed module inputs are separate gates.
 bundle_build_materialization:
   status: merge_bearing_build_surface
   implementation_slice: '#1670 Slice A + Slice B'

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -1513,14 +1513,15 @@ policy_validation_contracts:
     and file-backed validation sets are separate gates.
 compute_module_contracts:
   status: merge_bearing_runtime_behavior
-  implementation_slice: '#1669'
+  implementation_slice: '#1669 + #1670 Slice B'
   description: |
-    Flow-local `modules:` declarations inside policy.yaml define precompiled
-    deterministic Wasm compute modules. Policy-sheet `compute_module` value rows
-    instantiate those declarations, map explicit handler context inputs into the
-    module, and bind the validated JSON object result under computed.*. This is
-    the supported PR1 surface for pure algorithmic deterministic work that
-    cannot be represented by lookup, validation, selection, or simple
+    Flow-local `modules:` declarations inside policy.yaml define deterministic
+    compute modules. Policy-sheet `compute_module` value rows instantiate those
+    declarations, map explicit handler context inputs into the module, and bind
+    the validated JSON object result under computed.*. Supported kinds are
+    precompiled zero-import Wasm modules and embedded CPython-WASI Python source
+    modules. This is the supported surface for pure algorithmic deterministic
+    work that cannot be represented by lookup, validation, selection, or simple
     arithmetic/derive rows.
   policy_section:
     location: flow policy.yaml only
@@ -1529,6 +1530,7 @@ compute_module_contracts:
     shape: |
       modules:
         <module_id>:
+          kind: wasm              # optional default for existing declarations
           path: modules/<name>.wasm
           abi: core-json-v1
           entry: compute
@@ -1545,6 +1547,23 @@ compute_module_contracts:
             gas: <positive integer>
             memory_pages: <positive integer>
             output_bytes: <positive integer>
+      modules:
+        <module_id>:
+          kind: python
+          path: modules/<name>.py
+          abi: python-json-v1
+          entry: handle
+          digest: sha256:<64 lowercase hex> # source bytes
+          input_schema:
+            type: object
+            properties: {...}
+          output_schema:
+            type: object
+            properties: {...}
+          limits:
+            gas: <positive integer>         # Python-specific fuel profile
+            memory_pages: <positive integer>
+            output_bytes: <positive integer>
     rules:
     - '`modules:` is a closed typed policy section. It is decoded separately from generic PolicyDocument.Values and MUST NOT
       appear as a generic policy expression object or prompt variable.'
@@ -1553,21 +1572,61 @@ compute_module_contracts:
     - Module IDs are short stable identifiers. A row references a module by short ID, not by filesystem path.
     - Module bytes MUST live inside the owning contracts root and MUST be regular files. Ambient filesystem lookup,
       symlinks, out-of-tree paths, network fetches, and runtime-generated module bytes fail closed.
-    - The declared digest MUST be `sha256:<64 lowercase hex>` and MUST match the bundle-pinned module bytes before
-      execution. Optional source provenance is metadata only in this slice.
+    - >
+      The declared digest MUST be `sha256:<64 lowercase hex>` and MUST match the bundle-pinned module bytes before
+      execution. For `kind: wasm`, the bytes are the `.wasm` module. For `kind: python`, the bytes are the Python source.
+    - >
+      `kind` defaults to `wasm` only for existing declarations that omit it. Unknown kinds fail closed. Compatibility
+      fallback beyond that default is forbidden.
+    - >
+      Optional `source_path`/`source_hash` provenance is valid for Wasm only in this slice. Python source authority is
+      `path` plus `digest`; separate source_path/source_hash would create a second source owner and fails closed.
   abi:
-    name: core-json-v1
-    entrypoint: '`entry` MUST be `compute`.'
-    exports:
-    - '`memory` linear memory export'
-    - '`alloc(i32) -> i32` allocator used by the host to copy canonical JSON input bytes into guest memory'
-    - '`compute(i32, i32) -> i64` entrypoint receiving input pointer/length and returning output pointer/length packed in
-      the high/low 32-bit halves'
-    imports: |
-      Author modules MUST declare zero imports. WASI, filesystem, network, clock,
-      random, process, and other host capabilities are not available. Platform
-      instrumentation used by a future build pipeline is not an author-declared
-      host capability and is outside this slice.
+    wasm:
+      name: core-json-v1
+      entrypoint: '`entry` MUST be `compute`.'
+      exports:
+      - '`memory` linear memory export'
+      - '`alloc(i32) -> i32` allocator used by the host to copy canonical JSON input bytes into guest memory'
+      - '`compute(i32, i32) -> i64` entrypoint receiving input pointer/length and returning output pointer/length packed in
+        the high/low 32-bit halves'
+      imports: |
+        Author Wasm modules MUST declare zero imports. WASI, filesystem,
+        network, clock, random, process, and other host capabilities are not
+        available. Platform instrumentation used by a future build pipeline is
+        not an author-declared host capability and is outside this slice.
+    python:
+      name: python-json-v1
+      entrypoint: '`entry` MUST be `handle`.'
+      callable: 'Author source MUST define `def handle(input): return {...}`.'
+      transport: |
+        The platform harness owns JSON input/output transport. Author code
+        receives a Python dict and must return a JSON-object-compatible dict.
+        Authors do not read stdin, write stdout, or manage generated bindings.
+      embedded_artifact: |
+        The interpreter artifact is CPython-WASI 3.13.14 built with WASI SDK 24,
+        pinned as `brettcannon/cpython-wasi-build` v3.13.14
+        `python-3.13.14-wasi_sdk-24.zip`, digest
+        `sha256:a70a750951302744d84746340b4932b80dabad5b153cc3392bcae114b293c060`.
+        No official python.org prebuilt WASI binary exists; this first slice
+        records the artifact as an unofficial-but-canonical community/core-dev
+        build. Self-building CPython-WASI from source in swarm release CI is a
+        hardening follow-up, not a first-slice prerequisite.
+      snapshot_boundary: |
+        The shared bare-interpreter snapshot is a swarm release artifact, not a
+        `swarm bundle build` output. Release CI may use Wizer/WASI SDK offline
+        to produce an embedded initialized interpreter+harness Wasm artifact.
+        User machines, `swarm bundle build`, `swarm test`, runtime execution,
+        and `bundle register` MUST NOT require external Python, Wizer, WASI SDK,
+        shell tools, package managers, or a local toolchain. Per-module snapshots
+        remain blocked until a promoted in-process snapshot API or embedded
+        Wizer path exists.
+      sandbox: |
+        v1 is stdlib pure-compute only. Host filesystem, network, clock/random,
+        subprocess, threads, third-party packages, generated bindings, and
+        ambient environment access are not supported. The platform sets
+        `PYTHONHASHSEED=0`, does not inherit host env, and frames denied
+        capability and user exceptions as typed deterministic diagnostics.
     deterministic_features: |
       Runtime configuration MUST disable nondeterministic or unapproved features
       including threads, SIMD, memory64, and multi-memory. Deterministic core
@@ -1624,7 +1683,7 @@ compute_module_contracts:
     dead_binding: '`compute_module.into` bindings must be consumed by a supported downstream condition, emit field, activity
       input, fan_out, or expression in the same handler; unconsumed bindings fail boot verification.'
   runtime_execution:
-    owner: internal/runtime/computemodule adapter behind the compute runtime owner
+    owner: internal/runtime/computemodule and internal/runtime/pythonmodule adapters behind the compute runtime owner
     engine_boundary: |
       The Wasm engine is an implementation detail behind an internal adapter.
       The semantic owners are policy.modules, compute_module rows, the ABI
@@ -1637,15 +1696,22 @@ compute_module_contracts:
       Compile/ABI/import rejection, digest mismatch, trap/unreachable, gas/fuel
       exhaustion, memory limit, output-size limit, output bounds, and output
       schema violation are deterministic no-retry failures with typed
-      diagnostics carrying module ID and row ID.
+      diagnostics carrying module ID and row ID. Python denied-capability and
+      framed user-exception failures are the same deterministic no-retry class.
     trace_and_replay: |
       Runtime traces record module ID, row ID, declared digest, engine version,
-      output hash, and fuel/gas consumed. Supported replay re-executes module
-      rows and compares the recorded output hash and fuel/gas consumed against
-      the replay execution. Replay mode is explicit: an empty expected trace set
-      means zero module executions are expected, not normal non-replay execution.
-      Divergence is a typed deterministic replay failure, never silent
-      acceptance.
+      output hash, and fuel/gas consumed. Python traces additionally record
+      interpreter version, interpreter digest, harness ABI, snapshot identity,
+      and source hash. Supported replay re-executes module rows and compares the
+      recorded output hash plus identity fields against replay execution. Wasm
+      replay also compares fuel exactly. Python fuel is retained as evidence but
+      not exact divergence-bearing in this slice because CPython-WASI startup
+      under wasmtime fuel can vary across identical invocations by small
+      implementation-accounting deltas; exact Python fuel divergence detection
+      remains split until the release-time snapshot/gas envelope is stabilized.
+      Replay mode is explicit: an empty expected trace set means zero module
+      executions are expected, not normal non-replay execution. Divergence is a
+      typed deterministic replay failure, never silent acceptance.
   bundle_identity:
     rule: |
       Module bytes referenced by policy.modules are part of the bundle contract
@@ -1654,8 +1720,9 @@ compute_module_contracts:
   static_verification:
     checks:
     - typed policy.modules shape and flow-local placement
-    - module path containment, regular-file loading, Wasm magic, and digest match
-    - supported ABI exports and zero author imports
+    - module path containment, regular-file loading, kind-specific byte/source digest match
+    - supported Wasm ABI exports and zero author imports
+    - supported Python ABI, source syntax/callable validation, embedded runtime identity, and denied capability checks
     - deterministic capability/resource limits
     - object input/output schemas and PR1 float/numeric schema rejection
     - compute_module row module resolution and exact input mapping coverage
@@ -1669,17 +1736,17 @@ compute_module_contracts:
     shared module packs, source compilation, and file-backed module inputs are separate gates.
 bundle_build_materialization:
   status: merge_bearing_build_surface
-  implementation_slice: '#1670 Slice A'
+  implementation_slice: '#1670 Slice A + Slice B'
   command: swarm bundle build [--contracts <path>] [--output <path>] [--report json]
   description: |
     `swarm bundle build` is the public materialization owner for local
-    contract bundles before explicit test/register/runtime consumption. Slice A
-    supports the existing precompiled Wasm `policy.modules` lane only. The
-    command loads and validates the selected contracts root, consumes canonical
-    BundleHash identity, writes a materialized contracts directory, and emits a
-    deterministic build report. It does not compile source, rewrite policy
-    digests, register bundles, execute tests, or introduce Python runtime
-    semantics.
+    contract bundles before explicit test/register/runtime consumption. It
+    supports precompiled Wasm policy modules and embedded CPython-WASI Python
+    source modules. The command loads and validates the selected contracts root,
+    consumes canonical BundleHash identity, writes a materialized contracts
+    directory, and emits a deterministic build report. It does not rewrite
+    policy digests, register bundles, execute tests, or create interpreter
+    snapshots.
   artifact_contract:
     directory: .swarm/build/<bundle-hash> by default, or <output>/<bundle-hash> when --output is provided
     contents:
@@ -1693,7 +1760,7 @@ bundle_build_materialization:
       - bundle_hash
       - platform_version
       - spec_version
-      - modules[] with id, flow_id, kind, path, digest, source_path, and source_hash
+      - modules[] with id, flow_id, kind, path, digest, source_path, source_hash, and Python runtime identity fields when applicable
       - inputs[] with canonical bundle labels, slash-relative paths, content policy, and size
       authority: |
         build-manifest.json is not a semantic owner, source of identity, or
@@ -1719,11 +1786,12 @@ bundle_build_materialization:
       hashed contract content.
   build_steps:
     rule: |
-      The implementation exposes an ordered build-step seam. Slice A registers
-      only the existing Wasm policy.modules validation/materialization lane.
-      Python snapshot, archive packaging, watch mode, scaffolding, and source
-      compilation steps are unregistered and unsupported until separately
-      promoted.
+      The implementation exposes an ordered build-step seam. The supported steps
+      are Wasm policy.modules validation/materialization and Python policy
+      module source/ABI/runtime-identity validation. Python interpreter snapshot
+      production is not a bundle-build step; it is a release artifact. Archive
+      packaging, watch mode, scaffolding, source compilation, and per-module
+      snapshots are unregistered and unsupported until separately promoted.
   drift_validation:
     fail_closed_before_runtime:
     - missing contract inputs or module bytes
@@ -1731,6 +1799,7 @@ bundle_build_materialization:
     - module digest mismatch
     - stale source_hash when source_path/source_hash provenance is declared
     - invalid module ABI, schema, resource limits, or unsupported module shape
+    - invalid Python source syntax, missing callable handle, unsupported Python capability, or embedded runtime identity drift
     - unsupported build-step requirements
     - bundle input, module byte, or source_path proof collisions with reserved generated artifact paths such as build-manifest.json, including ASCII case variants
     - output roots or target directories inside hashed recursive inputs such as prompts/ or flow data/
@@ -1743,8 +1812,8 @@ bundle_build_materialization:
   consumer_boundaries:
   - swarm test --contracts remains an explicit contracts-root consumer and MUST NOT auto-build.
   - swarm bundle register --contracts remains a non-hashing upload packager and MUST NOT auto-build or silently become bundle build.
-  - Archive/register transport, `--watch`, `bundle new`, Python `kind`, CPython-WASI snapshots, generated Python bindings,
-    and source instrumentation are separate gates.
+  - Archive/register transport, `--watch`, `bundle new`, CPython-WASI release-pipeline snapshot production, per-module
+    snapshots, generated Python bindings, and source instrumentation are separate gates.
 runtime_enforcement:
   description: |
     Wave 1 adds authoritative behavioral rules on top of the existing
@@ -10438,18 +10507,20 @@ multi_bundle_persistence:
         split until archive format and extraction safety rules are promoted.
     bundle_build_materialization:
       owner: internal/runtime/contracts.BuildBundleMaterialization
-      status: implemented_wasm_slice_a
+      status: implemented_wasm_and_python_slice_b
       cli_consumer: swarm bundle build [--contracts <contracts-directory>] [--output <output-root>] [--report json]
       rule: >
         The bundle build command materializes a local contracts root under <output>/<bundle-hash> (default
         .swarm/build/<bundle-hash>) for explicit consumption. It consumes BundleHash as the canonical identity owner,
-        copies only bundle contract inputs and referenced module bytes needed to reconstruct that identity, writes
+        copies only bundle contract inputs and referenced module bytes/source needed to reconstruct that identity, writes
         build-manifest.json as a proof artifact, and emits a build report. It fails closed before runtime for invalid
-        contract/module shape, missing module bytes, digest mismatch, stale declared source_hash, unsupported build-step
-        requirements, reserved generated-artifact path collisions including case variants, output roots inside hashed recursive inputs, and materialized hash mismatch. Declared source_path files may be copied for source_hash freshness
-        proof but are not BundleHash identity owners. It MUST NOT call bundle.register, run test scenarios, touch
-        store/runtime writers, archive bundles, produce Python snapshots, run Python build steps, or write generated
-        bindings.
+        contract/module shape, missing module bytes/source, digest mismatch, stale declared source_hash, unsupported
+        build-step requirements, invalid Python source/ABI/capability/runtime identity, reserved generated-artifact path
+        collisions including case variants, output roots inside hashed recursive inputs, and materialized hash mismatch.
+        Declared source_path files may be copied for Wasm source_hash freshness proof but are not BundleHash identity
+        owners. Python source uses module path/digest as source authority. It MUST NOT call bundle.register, run test
+        scenarios, touch store/runtime writers, archive bundles, produce Python snapshots, invoke external Python/Wizer/WASI
+        SDK tooling, auto-build for test/register, or write generated bindings.
     modified_commands_planned:
       - swarm serve --bundle-hash <bundle_hash> [--bundle-hash <bundle_hash> ...] (implemented boot-pinned Postgres DB-loaded process mode)
       - swarm serve --dev
@@ -16673,7 +16744,7 @@ cli_specification:
       group: author_validate
       tier: should_have
       implementation_status: implemented_inventory_build_prepared_envelope_directory_register_and_delete
-      blocker_state: 'Read-only bundle list/show/agents are implemented by #1023 over /v1/rpc bundle.list/get/agents. Local swarm bundle build materialization is implemented by #1670 Slice A and remains distinct from register/test. Prepared-envelope swarm bundle register and local directory swarm bundle register --contracts are implemented over /v1/rpc bundle.register. Destructive swarm bundle delete is implemented over /v1/rpc bundle.delete. Archive packaging remains split; bundle new, watch mode, and Python snapshot/build support remain split until their authorities are promoted.'
+      blocker_state: 'Read-only bundle list/show/agents are implemented by #1023 over /v1/rpc bundle.list/get/agents. Local swarm bundle build materialization is implemented by #1670 Slice A/B for Wasm and embedded Python module validation/materialization and remains distinct from register/test. Prepared-envelope swarm bundle register and local directory swarm bundle register --contracts are implemented over /v1/rpc bundle.register. Destructive swarm bundle delete is implemented over /v1/rpc bundle.delete. Archive packaging remains split; bundle new, watch mode, release-pipeline/per-module Python snapshot production, and generated bindings remain split until their authorities are promoted.'
       owners:
       - multi_bundle_persistence.cli_surface.bundle_commands_supported
       - multi_bundle_persistence.cli_surface.bundle_build_materialization
@@ -16698,8 +16769,9 @@ cli_specification:
       proof_expectations:
       - exact /v1/rpc bundle.list/get/agents calls with only promoted params
       - local swarm bundle build proves command shape `--contracts`, `--output`, and `--report json`; materialized output
-        under <output>/<bundle-hash>; build-manifest/report fields; wasm-only Slice A build-step registry; source_hash
-        freshness drift; case-folded reserved generated-artifact path collisions; missing module bytes; schema drift; rejection of outputs under hashed recursive inputs;
+        under <output>/<bundle-hash>; build-manifest/report fields; Wasm and Python build-step registry; source_hash
+        freshness drift; Python source/ABI/runtime identity validation; case-folded reserved generated-artifact path
+        collisions; missing module bytes/source; schema drift; rejection of outputs under hashed recursive inputs;
         reproducible identical bundle_hash and hashed materialized content; and no API/store/runtime/register/test calls
       - exact /v1/rpc bundle.register call with only content_yaml, optional data_blob, and optional idempotency_key
       - exact /v1/rpc bundle.delete call with only bundle_hash, optional force, optional dry_run, and optional idempotency_key
@@ -16709,7 +16781,7 @@ cli_specification:
       - BUNDLE_NOT_FOUND, BUNDLE_REGISTER_CONFLICT, BUNDLE_HAS_ACTIVE_RUNS, BUNDLE_DELETE_IN_PROGRESS, IDEMPOTENCY_CONFLICT, invalid params, malformed responses, auth/HTTP/RPC failures, and transport failures fail closed with tested exit codes
       - no direct DB/store/runtime/hash-owner bundle reads or writes from CLI
       - unpromoted bundle.get alias, bundle new, bundle build --watch, archive register packaging, auto-build in test/register,
-        Python kind/snapshot support, and generated bindings remain absent/unknown until later CLI gates
+        release-pipeline/per-module Python snapshot production, and generated bindings remain absent/unknown until later CLI gates
     run_fork:
       command: swarm run fork <source-run-id> [--bundle-hash <bundle_hash>] [--at-event <event-id>] [--idempotency-key <key>]
       group: run_operate

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -1622,11 +1622,26 @@ compute_module_contracts:
         remain blocked until a promoted in-process snapshot API or embedded
         Wizer path exists.
       sandbox: |
-        v1 is stdlib pure-compute only. Host filesystem, network, clock/random,
-        subprocess, threads, third-party packages, generated bindings, and
-        ambient environment access are not supported. The platform sets
-        `PYTHONHASHSEED=0`, does not inherit host env, and frames denied
-        capability and user exceptions as typed deterministic diagnostics.
+        v1 is stdlib pure-compute only. The load-bearing capability boundary is
+        the platform-owned WASI/process configuration, not CPython source
+        rewriting, AST lint, or builtins filtering. Source lint may reject direct
+        unsupported imports and obvious denied names early for author feedback,
+        but it is non-authoritative and non-security-bearing.
+
+        Python modules run with a fixed runtime environment containing only
+        `PYTHONHOME`, `PYTHONPATH`, `PYTHONHASHSEED`, and `PYTHONNOUSERSITE`;
+        host/user environment variables MUST NOT be inherited. The only
+        filesystem mount is the embedded CPython-WASI interpreter artifact,
+        mounted read-only at `/` so the interpreter can import its standard
+        library. Host, project, user, and working-directory filesystems are not
+        mounted. Network, subprocess, threads, third-party packages, generated
+        bindings, and ambient host capabilities are not supported.
+
+        Author-reachable WASI clock and random imports MUST be deterministic in
+        this slice. The host shadows `clock_time_get` with a zero clock and
+        `random_get` with deterministic bytes; real wall-clock and host entropy
+        are not exposed even if author code recovers unrestricted CPython
+        imports through reflection.
     deterministic_features: |
       Runtime configuration MUST disable nondeterministic or unapproved features
       including threads, SIMD, memory64, and multi-memory. Deterministic core
@@ -1696,8 +1711,10 @@ compute_module_contracts:
       Compile/ABI/import rejection, digest mismatch, trap/unreachable, gas/fuel
       exhaustion, memory limit, output-size limit, output bounds, and output
       schema violation are deterministic no-retry failures with typed
-      diagnostics carrying module ID and row ID. Python denied-capability and
-      framed user-exception failures are the same deterministic no-retry class.
+      diagnostics carrying module ID and row ID. Python direct-lint
+      denied-capability failures and framed user-exception failures are the same
+      deterministic no-retry class; the runtime boundary does not rely on that
+      lint to deny host filesystem, inherited environment, clock, or entropy.
     trace_and_replay: |
       Runtime traces record module ID, row ID, declared digest, engine version,
       output hash, and fuel/gas consumed. Python traces additionally record
@@ -1722,7 +1739,7 @@ compute_module_contracts:
     - typed policy.modules shape and flow-local placement
     - module path containment, regular-file loading, kind-specific byte/source digest match
     - supported Wasm ABI exports and zero author imports
-    - supported Python ABI, source syntax/callable validation, embedded runtime identity, and denied capability checks
+    - supported Python ABI, source syntax/callable validation, embedded runtime identity, direct denied-capability lint, and deterministic WASI boundary checks
     - deterministic capability/resource limits
     - object input/output schemas and PR1 float/numeric schema rejection
     - compute_module row module resolution and exact input mapping coverage
@@ -1732,7 +1749,8 @@ compute_module_contracts:
   split_boundaries:
   - '#1670 owns public build/source tooling and any instrumentation pipeline.'
   - Declarative lookup, validation, selection, and future derive rows remain preferred when they can express the work.
-  - Durable activities, orchestration, timers, joins, loops, schedules, host imports, WASI, filesystem/network access,
+  - Durable activities, orchestration, timers, joins, loops, schedules, host imports, WASI capabilities beyond the fixed
+    Python interpreter mount and deterministic clock/random stubs, filesystem/network access beyond that read-only mount,
     shared module packs, source compilation, and file-backed module inputs are separate gates.
 bundle_build_materialization:
   status: merge_bearing_build_surface


### PR DESCRIPTION
## Summary

- Adds `kind: python` policy modules backed by an embedded pinned CPython-WASI artifact and a platform-owned JSON harness.
- Routes Python `compute_module` rows through the existing compute owner, binding results under `computed.*` with shared schema validation and deterministic failure taxonomy.
- Extends `swarm bundle build` materialization to validate Python source modules, record embedded runtime identity, and keep snapshot creation out of bundle build.
- Updates `platform-spec.yaml` for the Slice B Python runtime/materialization contract.

Part of #1670

## Governing Refs / Context

- `platform-spec.yaml#compute_module_contracts`
- `platform-spec.yaml#bundle_build_materialization`
- #1670 `Pre-Implementation Coverage Audit` and approved gate comments
- Gate repair recorded on #1670: https://github.com/division-sh/swarm/issues/1670#issuecomment-4900247173

## Semantic Migration

New canonical owner:
- `policy.modules` kind-specific declarations plus `compute_module` rows under `compute_module_contracts`.
- `internal/runtime/pythonmodule` owns embedded CPython-WASI execution/harness identity behind the compute runtime owner.
- `swarm bundle build` owns Python module source/runtime identity materialization for supported contract bundles.

Old/non-authoritative paths now invalid:
- User-side Wizer/WASI/Python/toolchain requirements for `swarm bundle build`.
- In-process wasmtime-go snapshot production during bundle build.
- Per-module snapshots.
- Python `source_path`/`source_hash` as a second source authority.
- Generated Python bindings or direct stdin/stdout author ABI.

Production paths checked:
- Contract loading/flowmodel clone and strict YAML keys.
- Boot/contract validation for kind, ABI, digest, source syntax, callable entrypoint, denied capabilities, runtime identity.
- Bundle materialization/report/manifest build-step surface.
- Runtime executor dispatch, output schema validation, deterministic diagnostics, and replay trace identity comparison.
- Existing Wasm compute-module path remains covered.

Migration status:
- Complete for #1670 Slice B embedded Python source modules.
- Release-pipeline Wizer snapshot production, self-built CPython-WASI provenance hardening, exact Python fuel divergence checks, generated bindings, and per-module snapshots remain split/follow-up work.

## Tests

- `go test ./internal/runtime/contracts ./cmd/swarm -run 'TestBuildBundleMaterializationWritesReproducibleContractsRoot|TestValidateWorkflowComputeModuleContractsRejectsDigestMismatchAndFloats|TestBundleBuildMaterializesContractsAndJSONReport' -count=1`
- `go test ./internal/runtime/pythonmodule ./internal/runtime/contracts ./internal/runtime/engine -run 'TestExecuteStructuredTransform|TestValidateSourceRejectsDeniedCapability|TestExecuteClassifiesExceptionOutputCapAndFuel|TestBuildBundleMaterializationMaterializesPythonModuleIdentity|TestBuildBundleMaterializationFailsClosedForPythonSyntax|TestBundleBuildStepRegistryHasWasmAndPythonSliceB|TestExecutor_PolicySheetPythonModuleRowFeedsSelectionRow|TestExecutor_PythonModuleOutputSchemaFailureStopsBeforeEmit|TestExecutor_PolicySheetComputeModuleRowFeedsSelectionRow|TestExecutor_ComputeModuleReplayTraceComparison' -count=1`
- `SWARM_CREDENTIALS_FILE=$(mktemp) SWARM_TEST_POSTGRES_DSN='host=127.0.0.1 port=5432 user=youmew dbname=postgres sslmode=disable' PGPASSWORD=postgres go test ./...`
