### PR TITLE
[agent-f][issue #1747] Typeform live webhook smoke

### DIFF
--- a/cmd/swarm/provider_trigger_shopify_smoke_test.go
+++ b/cmd/swarm/provider_trigger_shopify_smoke_test.go
@@ -3,27 +3,19 @@ package main
 import (
 	"bytes"
 	"context"
-	"encoding/json"
 	"fmt"
 	"io"
-	"net"
 	"net/http"
-	"net/http/httptest"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
-	"sync"
-	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/division-sh/swarm/internal/events"
-	runtimepkg "github.com/division-sh/swarm/internal/runtime"
 	runtimebus "github.com/division-sh/swarm/internal/runtime/bus"
-	runtimeactors "github.com/division-sh/swarm/internal/runtime/core/actors"
 	runtimecorrelation "github.com/division-sh/swarm/internal/runtime/correlation"
-	runtimemanager "github.com/division-sh/swarm/internal/runtime/manager"
 	"github.com/division-sh/swarm/internal/store"
 	"github.com/division-sh/swarm/internal/store/storetest"
 )
@@ -65,7 +57,7 @@ func TestShopifyLocalProviderToolSmoke(t *testing.T) {
 	)
 	ctx := runtimecorrelation.WithRunID(context.Background(), runID)
 	sqliteStore := storetest.StartSQLiteRuntimeStoreWithContext(t, ctx)
-	seedShopifyLocalSmokeRuntime(t, ctx, sqliteStore, runID, entityID, flowInstance, entitySlug, provider, clientSecret, agentID)
+	seedProviderTriggerSmokeRuntime(t, ctx, sqliteStore, runID, entityID, flowInstance, entitySlug, provider, clientSecret, agentID)
 
 	bus, err := runtimebus.NewEventBus(sqliteStore)
 	if err != nil {
@@ -74,39 +66,15 @@ func TestShopifyLocalProviderToolSmoke(t *testing.T) {
 	ch := bus.Subscribe(agentID, events.EventType(providerEventName))
 	defer bus.Unsubscribe(agentID)
 
-	gateway := runtimepkg.NewInboundGateway(bus, nil, nil, sqliteStore)
-	responseCapture := &shopifyLocalSmokeResponseCapture{}
-	inboundHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		rec := &shopifyLocalSmokeCaptureWriter{ResponseWriter: w, status: http.StatusOK}
-		gateway.Handler().ServeHTTP(rec, r.WithContext(ctx))
-		responseCapture.record(rec.status, rec.body.String())
-	})
-	apiHandler := http.NotFoundHandler()
-	var ready atomic.Bool
-	ready.Store(true)
-	listener, err := net.Listen("tcp", "localhost:0")
-	if err != nil {
-		t.Fatalf("listen on localhost for Shopify smoke: %v", err)
-	}
-	_, port, err := net.SplitHostPort(listener.Addr().String())
-	if err != nil {
-		t.Fatalf("parse Shopify smoke listener address %q: %v", listener.Addr().String(), err)
-	}
-	server := &httptest.Server{
-		Listener: listener,
-		Config: &http.Server{
-			Handler: newAPIServer(&ready, apiHandler, inboundHandler).Handler,
-		},
-	}
-	server.Start()
-	defer server.Close()
+	responseCapture := newProviderTriggerSmokeResponseCapture()
+	baseURL := startProviderTriggerSmokeServer(t, ctx, "localhost:0", bus, sqliteStore, responseCapture)
 
-	address := "http://localhost:" + port + "/webhooks/" + entitySlug + "/" + provider
+	address := baseURL + "/webhooks/" + entitySlug + "/" + provider
 	output := runShopifyWebhookTrigger(t, shopifyPath, address, topic, apiVersion, clientID, clientSecret, appPath)
 	if strings.Contains(output, clientSecret) {
 		t.Fatal("Shopify CLI output contained the client secret")
 	}
-	responseStatus, responseBody := responseCapture.last()
+	responseStatus, responseBody := responseCapture.lastResponse()
 	if responseStatus != http.StatusAccepted {
 		t.Fatalf("Shopify local smoke response status = %d, want 202 body=%s", responseStatus, responseBody)
 	}
@@ -114,7 +82,7 @@ func TestShopifyLocalProviderToolSmoke(t *testing.T) {
 		t.Fatal("Shopify signing secret leaked into accepted webhook response")
 	}
 
-	event := loadShopifyLocalSmokeEvent(t, ctx, sqliteStore, runID, entityID, providerEventName)
+	event := loadProviderTriggerSmokeEvent(t, ctx, sqliteStore, runID, entityID, providerEventName)
 	if event.ProviderEventID == "" {
 		t.Fatal("Shopify provider event id is empty")
 	}
@@ -124,17 +92,17 @@ func TestShopifyLocalProviderToolSmoke(t *testing.T) {
 	if event.Provider != provider {
 		t.Fatalf("provider = %q, want %q", event.Provider, provider)
 	}
-	assertShopifyLocalSmokeAcceptedResponse(t, responseBody, provider, providerEventName, event.ProviderEventID, event.ProviderEventType)
-	if got := countShopifyLocalSmokeInboundMarkers(t, ctx, sqliteStore, event.ProviderEventID, entityID, provider); got != 1 {
+	assertProviderTriggerSmokeAcceptedResponse(t, responseBody, provider, providerEventName, event.ProviderEventID, event.ProviderEventType)
+	if got := countProviderTriggerSmokeInboundMarkers(t, ctx, sqliteStore, event.ProviderEventID, entityID, provider); got != 1 {
 		t.Fatalf("inbound marker rows = %d, want 1", got)
 	}
 	if strings.Contains(event.Payload, clientSecret) {
 		t.Fatal("Shopify signing secret leaked into persisted event payload")
 	}
-	if got := countShopifyLocalSmokeProviderEvents(t, ctx, sqliteStore, runID, entityID, providerEventName); got != 1 {
+	if got := countProviderTriggerSmokeProviderEvents(t, ctx, sqliteStore, runID, entityID, providerEventName); got != 1 {
 		t.Fatalf("provider event rows = %d, want 1", got)
 	}
-	if got := countShopifyLocalSmokeAgentDeliveriesForEvent(t, ctx, sqliteStore, event.EventID, agentID); got != 1 {
+	if got := countProviderTriggerSmokeAgentDeliveriesForEvent(t, ctx, sqliteStore, event.EventID, agentID); got != 1 {
 		t.Fatalf("agent delivery rows = %d, want 1", got)
 	}
 	select {
@@ -171,44 +139,6 @@ api_version = %q
 		t.Fatalf("write throwaway Shopify app config: %v", err)
 	}
 	return dir
-}
-
-type shopifyLocalSmokeResponseCapture struct {
-	mu     sync.Mutex
-	status int
-	body   string
-}
-
-func (c *shopifyLocalSmokeResponseCapture) record(status int, body string) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	c.status = status
-	c.body = body
-}
-
-func (c *shopifyLocalSmokeResponseCapture) last() (int, string) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	return c.status, c.body
-}
-
-type shopifyLocalSmokeCaptureWriter struct {
-	http.ResponseWriter
-	status int
-	body   bytes.Buffer
-}
-
-func (w *shopifyLocalSmokeCaptureWriter) WriteHeader(statusCode int) {
-	w.status = statusCode
-	w.ResponseWriter.WriteHeader(statusCode)
-}
-
-func (w *shopifyLocalSmokeCaptureWriter) Write(data []byte) (int, error) {
-	if w.status == 0 {
-		w.status = http.StatusOK
-	}
-	w.body.Write(data)
-	return w.ResponseWriter.Write(data)
 }
 
 func runShopifyWebhookTrigger(t *testing.T, shopifyPath string, address string, topic string, apiVersion string, clientID string, clientSecret string, appPath string) string {
@@ -249,28 +179,9 @@ func runShopifyWebhookTrigger(t *testing.T, shopifyPath string, address string, 
 		t.Fatal("Shopify CLI output contained the client secret")
 	}
 	if err != nil {
-		t.Fatalf("shopify app webhook trigger failed: %v\n%s", err, sanitizeShopifyLocalSmokeOutput(rawOutput, clientSecret))
+		t.Fatalf("shopify app webhook trigger failed: %v\n%s", err, sanitizeProviderTriggerSmokeOutput(rawOutput, clientSecret))
 	}
 	return rawOutput
-}
-
-func assertShopifyLocalSmokeAcceptedResponse(t *testing.T, body string, provider string, eventName string, providerEventID string, providerEventType string) {
-	t.Helper()
-	var response map[string]any
-	if err := json.Unmarshal([]byte(body), &response); err != nil {
-		t.Fatalf("unmarshal accepted webhook response: %v body=%s", err, body)
-	}
-	for field, want := range map[string]string{
-		"status":              "accepted",
-		"provider":            provider,
-		"provider_event_id":   providerEventID,
-		"provider_event_type": providerEventType,
-		"event_name":          eventName,
-	} {
-		if got, _ := response[field].(string); got != want {
-			t.Fatalf("accepted response %s = %q, want %q body=%s", field, got, want, body)
-		}
-	}
 }
 
 func assertShopifyLocalSmokeBadSignatureFailsClosed(t *testing.T, ctx context.Context, address string, sqliteStore *store.SQLiteRuntimeStore, runID string, entityID string, eventName string, provider string) {
@@ -293,172 +204,10 @@ func assertShopifyLocalSmokeBadSignatureFailsClosed(t *testing.T, ctx context.Co
 	if resp.StatusCode != http.StatusUnauthorized {
 		t.Fatalf("bad-signature status = %d, want 401 body=%s", resp.StatusCode, string(respBody))
 	}
-	if got := countShopifyLocalSmokeInboundMarkers(t, ctx, sqliteStore, "shopify-local-smoke-invalid", entityID, provider); got != 0 {
+	if got := countProviderTriggerSmokeInboundMarkers(t, ctx, sqliteStore, "shopify-local-smoke-invalid", entityID, provider); got != 0 {
 		t.Fatalf("bad-signature inbound marker rows = %d, want 0", got)
 	}
-	if got := countShopifyLocalSmokeProviderEventsByProviderEventID(t, ctx, sqliteStore, runID, entityID, eventName, "shopify-local-smoke-invalid"); got != 0 {
+	if got := countProviderTriggerSmokeProviderEventsByProviderEventID(t, ctx, sqliteStore, runID, entityID, eventName, "shopify-local-smoke-invalid"); got != 0 {
 		t.Fatalf("bad-signature provider event rows = %d, want 0", got)
 	}
-}
-
-func seedShopifyLocalSmokeRuntime(
-	t *testing.T,
-	ctx context.Context,
-	sqliteStore *store.SQLiteRuntimeStore,
-	runID string,
-	entityID string,
-	flowInstance string,
-	entitySlug string,
-	provider string,
-	webhookSecret string,
-	agentID string,
-) {
-	t.Helper()
-	now := time.Now().UTC()
-	if _, err := sqliteStore.DB.ExecContext(ctx, `
-		INSERT INTO runs (run_id, status, started_at)
-		VALUES (?, 'running', ?)
-	`, runID, now); err != nil {
-		t.Fatalf("seed sqlite run: %v", err)
-	}
-	configBytes, err := json.Marshal(map[string]any{
-		"secrets": map[string]any{
-			"webhook_signing": map[string]string{
-				provider: webhookSecret,
-			},
-		},
-	})
-	if err != nil {
-		t.Fatalf("marshal sqlite flow config: %v", err)
-	}
-	if _, err := sqliteStore.DB.ExecContext(ctx, `
-		INSERT INTO flow_instances (instance_id, flow_template, mode, config, status, created_at)
-		VALUES (?, 'test', 'static', ?, 'active', ?)
-	`, flowInstance, string(configBytes), now); err != nil {
-		t.Fatalf("seed sqlite flow instance: %v", err)
-	}
-	if _, err := sqliteStore.DB.ExecContext(ctx, `
-		INSERT INTO entity_state (
-			run_id, entity_id, flow_instance, entity_type, slug, name, current_state,
-			gates, fields, accumulator, revision, entered_state_at, created_at, updated_at
-		) VALUES (?, ?, ?, 'default', ?, 'Customer A', 'active',
-			'{}', '{}', '{}', 1, ?, ?, ?)
-	`, runID, entityID, flowInstance, entitySlug, now, now, now); err != nil {
-		t.Fatalf("seed sqlite entity state: %v", err)
-	}
-	if err := sqliteStore.UpsertAgent(ctx, runtimemanager.PersistedAgent{
-		Config: runtimeactors.AgentConfig{
-			ID:            agentID,
-			Role:          "observer",
-			Mode:          "global",
-			Type:          "stub",
-			Model:         "regular",
-			Config:        []byte(`{}`),
-			Subscriptions: []string{"inbound." + provider},
-		},
-		Status:    "active",
-		HiredBy:   "test",
-		StartedAt: now,
-	}); err != nil {
-		t.Fatalf("UpsertAgent(%s): %v", agentID, err)
-	}
-}
-
-type shopifyLocalSmokeEvent struct {
-	EventID           string
-	Provider          string
-	ProviderEventID   string
-	ProviderEventType string
-	Payload           string
-}
-
-func loadShopifyLocalSmokeEvent(t *testing.T, ctx context.Context, sqliteStore *store.SQLiteRuntimeStore, runID string, entityID string, eventName string) shopifyLocalSmokeEvent {
-	t.Helper()
-	var event shopifyLocalSmokeEvent
-	if err := sqliteStore.DB.QueryRowContext(ctx, `
-		SELECT
-			event_id,
-			json_extract(payload, '$.provider'),
-			json_extract(payload, '$.provider_event_id'),
-			json_extract(payload, '$.provider_event_type'),
-			payload
-		FROM events
-		WHERE run_id = ?
-		  AND entity_id = ?
-		  AND event_name = ?
-		ORDER BY created_at DESC
-		LIMIT 1
-	`, runID, entityID, eventName).Scan(&event.EventID, &event.Provider, &event.ProviderEventID, &event.ProviderEventType, &event.Payload); err != nil {
-		t.Fatalf("load Shopify local smoke event: %v", err)
-	}
-	return event
-}
-
-func countShopifyLocalSmokeProviderEvents(t *testing.T, ctx context.Context, sqliteStore *store.SQLiteRuntimeStore, runID string, entityID string, eventName string) int {
-	t.Helper()
-	var count int
-	if err := sqliteStore.DB.QueryRowContext(ctx, `
-		SELECT COUNT(*)
-		FROM events
-		WHERE run_id = ?
-		  AND entity_id = ?
-		  AND event_name = ?
-	`, runID, entityID, eventName).Scan(&count); err != nil {
-		t.Fatalf("count Shopify local smoke provider events: %v", err)
-	}
-	return count
-}
-
-func countShopifyLocalSmokeProviderEventsByProviderEventID(t *testing.T, ctx context.Context, sqliteStore *store.SQLiteRuntimeStore, runID string, entityID string, eventName string, providerEventID string) int {
-	t.Helper()
-	var count int
-	if err := sqliteStore.DB.QueryRowContext(ctx, `
-		SELECT COUNT(*)
-		FROM events
-		WHERE run_id = ?
-		  AND entity_id = ?
-		  AND event_name = ?
-		  AND json_extract(payload, '$.provider_event_id') = ?
-	`, runID, entityID, eventName, providerEventID).Scan(&count); err != nil {
-		t.Fatalf("count Shopify local smoke provider events for %q: %v", providerEventID, err)
-	}
-	return count
-}
-
-func countShopifyLocalSmokeInboundMarkers(t *testing.T, ctx context.Context, sqliteStore *store.SQLiteRuntimeStore, providerEventID string, entityID string, provider string) int {
-	t.Helper()
-	var count int
-	if err := sqliteStore.DB.QueryRowContext(ctx, `
-		SELECT COUNT(*)
-		FROM events
-		WHERE event_name = 'platform.inbound_recorded'
-		  AND entity_id = ?
-		  AND json_extract(payload, '$.provider_event_id') = ?
-		  AND json_extract(payload, '$.provider') = ?
-	`, entityID, providerEventID, provider).Scan(&count); err != nil {
-		t.Fatalf("count Shopify local smoke inbound marker events: %v", err)
-	}
-	return count
-}
-
-func countShopifyLocalSmokeAgentDeliveriesForEvent(t *testing.T, ctx context.Context, sqliteStore *store.SQLiteRuntimeStore, eventID string, agentID string) int {
-	t.Helper()
-	var count int
-	if err := sqliteStore.DB.QueryRowContext(ctx, `
-		SELECT COUNT(*)
-		FROM event_deliveries
-		WHERE event_id = ?
-		  AND subscriber_type = 'agent'
-		  AND subscriber_id = ?
-	`, eventID, agentID).Scan(&count); err != nil {
-		t.Fatalf("count Shopify local smoke agent deliveries for %s: %v", eventID, err)
-	}
-	return count
-}
-
-func sanitizeShopifyLocalSmokeOutput(output string, secret string) string {
-	if secret == "" {
-		return output
-	}
-	return strings.ReplaceAll(output, secret, fmt.Sprintf("<redacted:%d>", len(secret)))
 }

--- a/cmd/swarm/provider_trigger_smoke_helpers_test.go
+++ b/cmd/swarm/provider_trigger_smoke_helpers_test.go
@@ -1,0 +1,317 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	runtimepkg "github.com/division-sh/swarm/internal/runtime"
+	runtimebus "github.com/division-sh/swarm/internal/runtime/bus"
+	runtimeactors "github.com/division-sh/swarm/internal/runtime/core/actors"
+	runtimemanager "github.com/division-sh/swarm/internal/runtime/manager"
+	"github.com/division-sh/swarm/internal/store"
+)
+
+type providerTriggerSmokeResponse struct {
+	status int
+	body   string
+}
+
+type providerTriggerSmokeResponseCapture struct {
+	mu   sync.Mutex
+	last providerTriggerSmokeResponse
+	ch   chan providerTriggerSmokeResponse
+}
+
+func newProviderTriggerSmokeResponseCapture() *providerTriggerSmokeResponseCapture {
+	return &providerTriggerSmokeResponseCapture{ch: make(chan providerTriggerSmokeResponse, 16)}
+}
+
+func (c *providerTriggerSmokeResponseCapture) record(status int, body string) {
+	response := providerTriggerSmokeResponse{status: status, body: body}
+	c.mu.Lock()
+	c.last = response
+	c.mu.Unlock()
+	select {
+	case c.ch <- response:
+	default:
+	}
+}
+
+func (c *providerTriggerSmokeResponseCapture) lastResponse() (int, string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.last.status, c.last.body
+}
+
+func (c *providerTriggerSmokeResponseCapture) wait(ctx context.Context) (providerTriggerSmokeResponse, error) {
+	select {
+	case response := <-c.ch:
+		return response, nil
+	case <-ctx.Done():
+		return providerTriggerSmokeResponse{}, ctx.Err()
+	}
+}
+
+type providerTriggerSmokeCaptureWriter struct {
+	http.ResponseWriter
+	status int
+	body   bytes.Buffer
+}
+
+func (w *providerTriggerSmokeCaptureWriter) WriteHeader(statusCode int) {
+	w.status = statusCode
+	w.ResponseWriter.WriteHeader(statusCode)
+}
+
+func (w *providerTriggerSmokeCaptureWriter) Write(data []byte) (int, error) {
+	if w.status == 0 {
+		w.status = http.StatusOK
+	}
+	w.body.Write(data)
+	return w.ResponseWriter.Write(data)
+}
+
+func startProviderTriggerSmokeServer(
+	t *testing.T,
+	ctx context.Context,
+	listenAddr string,
+	bus *runtimebus.EventBus,
+	sqliteStore *store.SQLiteRuntimeStore,
+	responseCapture *providerTriggerSmokeResponseCapture,
+) string {
+	t.Helper()
+	if strings.TrimSpace(listenAddr) == "" {
+		listenAddr = "localhost:0"
+	}
+	gateway := runtimepkg.NewInboundGateway(bus, nil, nil, sqliteStore)
+	inboundHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		rec := &providerTriggerSmokeCaptureWriter{ResponseWriter: w, status: http.StatusOK}
+		gateway.Handler().ServeHTTP(rec, r.WithContext(ctx))
+		if responseCapture != nil && r.Method == http.MethodPost {
+			responseCapture.record(rec.status, rec.body.String())
+		}
+	})
+	apiHandler := http.NotFoundHandler()
+	var ready atomic.Bool
+	ready.Store(true)
+	listener, err := net.Listen("tcp", listenAddr)
+	if err != nil {
+		t.Fatalf("listen on %s for provider trigger smoke: %v", listenAddr, err)
+	}
+	server := &httptest.Server{
+		Listener: listener,
+		Config: &http.Server{
+			Handler: newAPIServer(&ready, apiHandler, inboundHandler).Handler,
+		},
+	}
+	server.Start()
+	t.Cleanup(server.Close)
+	return "http://" + providerTriggerSmokeHTTPHostPort(t, listener.Addr(), listenAddr)
+}
+
+func providerTriggerSmokeHTTPHostPort(t *testing.T, addr net.Addr, requestedListenAddr string) string {
+	t.Helper()
+	host, port, err := net.SplitHostPort(addr.String())
+	if err != nil {
+		t.Fatalf("parse provider trigger smoke listener address %q: %v", addr.String(), err)
+	}
+	requestedHost, _, requestedErr := net.SplitHostPort(requestedListenAddr)
+	if requestedErr == nil && requestedHost == "localhost" {
+		host = "localhost"
+	}
+	if host == "" || host == "::" || host == "0.0.0.0" || host == "[::]" {
+		host = "127.0.0.1"
+	}
+	return net.JoinHostPort(host, port)
+}
+
+func assertProviderTriggerSmokeAcceptedResponse(t *testing.T, body string, provider string, eventName string, providerEventID string, providerEventType string) {
+	t.Helper()
+	var response map[string]any
+	if err := json.Unmarshal([]byte(body), &response); err != nil {
+		t.Fatalf("unmarshal accepted webhook response: %v body=%s", err, body)
+	}
+	for field, want := range map[string]string{
+		"status":              "accepted",
+		"provider":            provider,
+		"provider_event_id":   providerEventID,
+		"provider_event_type": providerEventType,
+		"event_name":          eventName,
+	} {
+		if got, _ := response[field].(string); got != want {
+			t.Fatalf("accepted response %s = %q, want %q body=%s", field, got, want, body)
+		}
+	}
+}
+
+func seedProviderTriggerSmokeRuntime(
+	t *testing.T,
+	ctx context.Context,
+	sqliteStore *store.SQLiteRuntimeStore,
+	runID string,
+	entityID string,
+	flowInstance string,
+	entitySlug string,
+	provider string,
+	webhookSecret string,
+	agentID string,
+) {
+	t.Helper()
+	now := time.Now().UTC()
+	if _, err := sqliteStore.DB.ExecContext(ctx, `
+		INSERT INTO runs (run_id, status, started_at)
+		VALUES (?, 'running', ?)
+	`, runID, now); err != nil {
+		t.Fatalf("seed sqlite run: %v", err)
+	}
+	configBytes, err := json.Marshal(map[string]any{
+		"secrets": map[string]any{
+			"webhook_signing": map[string]string{
+				provider: webhookSecret,
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("marshal sqlite flow config: %v", err)
+	}
+	if _, err := sqliteStore.DB.ExecContext(ctx, `
+		INSERT INTO flow_instances (instance_id, flow_template, mode, config, status, created_at)
+		VALUES (?, 'test', 'static', ?, 'active', ?)
+	`, flowInstance, string(configBytes), now); err != nil {
+		t.Fatalf("seed sqlite flow instance: %v", err)
+	}
+	if _, err := sqliteStore.DB.ExecContext(ctx, `
+		INSERT INTO entity_state (
+			run_id, entity_id, flow_instance, entity_type, slug, name, current_state,
+			gates, fields, accumulator, revision, entered_state_at, created_at, updated_at
+		) VALUES (?, ?, ?, 'default', ?, 'Customer A', 'active',
+			'{}', '{}', '{}', 1, ?, ?, ?)
+	`, runID, entityID, flowInstance, entitySlug, now, now, now); err != nil {
+		t.Fatalf("seed sqlite entity state: %v", err)
+	}
+	if err := sqliteStore.UpsertAgent(ctx, runtimemanager.PersistedAgent{
+		Config: runtimeactors.AgentConfig{
+			ID:            agentID,
+			Role:          "observer",
+			Mode:          "global",
+			Type:          "stub",
+			Model:         "regular",
+			Config:        []byte(`{}`),
+			Subscriptions: []string{"inbound." + provider},
+		},
+		Status:    "active",
+		HiredBy:   "test",
+		StartedAt: now,
+	}); err != nil {
+		t.Fatalf("UpsertAgent(%s): %v", agentID, err)
+	}
+}
+
+type providerTriggerSmokeEvent struct {
+	EventID           string
+	Provider          string
+	ProviderEventID   string
+	ProviderEventType string
+	Payload           string
+}
+
+func loadProviderTriggerSmokeEvent(t *testing.T, ctx context.Context, sqliteStore *store.SQLiteRuntimeStore, runID string, entityID string, eventName string) providerTriggerSmokeEvent {
+	t.Helper()
+	var event providerTriggerSmokeEvent
+	if err := sqliteStore.DB.QueryRowContext(ctx, `
+		SELECT
+			event_id,
+			json_extract(payload, '$.provider'),
+			json_extract(payload, '$.provider_event_id'),
+			json_extract(payload, '$.provider_event_type'),
+			payload
+		FROM events
+		WHERE run_id = ?
+		  AND entity_id = ?
+		  AND event_name = ?
+		ORDER BY created_at DESC
+		LIMIT 1
+	`, runID, entityID, eventName).Scan(&event.EventID, &event.Provider, &event.ProviderEventID, &event.ProviderEventType, &event.Payload); err != nil {
+		t.Fatalf("load provider trigger smoke event: %v", err)
+	}
+	return event
+}
+
+func countProviderTriggerSmokeProviderEvents(t *testing.T, ctx context.Context, sqliteStore *store.SQLiteRuntimeStore, runID string, entityID string, eventName string) int {
+	t.Helper()
+	var count int
+	if err := sqliteStore.DB.QueryRowContext(ctx, `
+		SELECT COUNT(*)
+		FROM events
+		WHERE run_id = ?
+		  AND entity_id = ?
+		  AND event_name = ?
+	`, runID, entityID, eventName).Scan(&count); err != nil {
+		t.Fatalf("count provider trigger smoke events: %v", err)
+	}
+	return count
+}
+
+func countProviderTriggerSmokeProviderEventsByProviderEventID(t *testing.T, ctx context.Context, sqliteStore *store.SQLiteRuntimeStore, runID string, entityID string, eventName string, providerEventID string) int {
+	t.Helper()
+	var count int
+	if err := sqliteStore.DB.QueryRowContext(ctx, `
+		SELECT COUNT(*)
+		FROM events
+		WHERE run_id = ?
+		  AND entity_id = ?
+		  AND event_name = ?
+		  AND json_extract(payload, '$.provider_event_id') = ?
+	`, runID, entityID, eventName, providerEventID).Scan(&count); err != nil {
+		t.Fatalf("count provider trigger smoke events for %q: %v", providerEventID, err)
+	}
+	return count
+}
+
+func countProviderTriggerSmokeInboundMarkers(t *testing.T, ctx context.Context, sqliteStore *store.SQLiteRuntimeStore, providerEventID string, entityID string, provider string) int {
+	t.Helper()
+	var count int
+	if err := sqliteStore.DB.QueryRowContext(ctx, `
+		SELECT COUNT(*)
+		FROM events
+		WHERE event_name = 'platform.inbound_recorded'
+		  AND entity_id = ?
+		  AND json_extract(payload, '$.provider_event_id') = ?
+		  AND json_extract(payload, '$.provider') = ?
+	`, entityID, providerEventID, provider).Scan(&count); err != nil {
+		t.Fatalf("count provider trigger smoke inbound marker events: %v", err)
+	}
+	return count
+}
+
+func countProviderTriggerSmokeAgentDeliveriesForEvent(t *testing.T, ctx context.Context, sqliteStore *store.SQLiteRuntimeStore, eventID string, agentID string) int {
+	t.Helper()
+	var count int
+	if err := sqliteStore.DB.QueryRowContext(ctx, `
+		SELECT COUNT(*)
+		FROM event_deliveries
+		WHERE event_id = ?
+		  AND subscriber_type = 'agent'
+		  AND subscriber_id = ?
+	`, eventID, agentID).Scan(&count); err != nil {
+		t.Fatalf("count provider trigger smoke agent deliveries for %s: %v", eventID, err)
+	}
+	return count
+}
+
+func sanitizeProviderTriggerSmokeOutput(output string, secret string) string {
+	if secret == "" {
+		return output
+	}
+	return strings.ReplaceAll(output, secret, fmt.Sprintf("<redacted:%d>", len(secret)))
+}

--- a/cmd/swarm/provider_trigger_typeform_smoke_test.go
+++ b/cmd/swarm/provider_trigger_typeform_smoke_test.go
@@ -1,0 +1,188 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/division-sh/swarm/internal/events"
+	runtimebus "github.com/division-sh/swarm/internal/runtime/bus"
+	runtimecorrelation "github.com/division-sh/swarm/internal/runtime/correlation"
+	"github.com/division-sh/swarm/internal/store"
+	"github.com/division-sh/swarm/internal/store/storetest"
+)
+
+func TestTypeformManualLiveHTTPSWebhookSmoke(t *testing.T) {
+	if os.Getenv("SWARM_TYPEFORM_LIVE_SMOKE") != "1" {
+		t.Skip("set SWARM_TYPEFORM_LIVE_SMOKE=1 to run the optional Typeform manual-live HTTPS smoke")
+	}
+	const (
+		runID             = "74700000-0000-0000-0000-000000000001"
+		entityID          = "74700000-0000-0000-0000-000000000002"
+		flowInstance      = "typeform-live-smoke-instance"
+		entitySlug        = "customer-a"
+		provider          = "typeform"
+		agentID           = "typeform-live-smoke-subscriber"
+		providerEventName = "inbound.typeform"
+		webhookPath       = "/webhooks/customer-a/typeform"
+	)
+	publicWebhookURL := typeformLiveSmokePublicURL(t, webhookPath)
+	webhookSecret := os.Getenv("TYPEFORM_WEBHOOK_SECRET")
+	if strings.TrimSpace(webhookSecret) == "" {
+		t.Skip("TYPEFORM_WEBHOOK_SECRET is required for the optional Typeform manual-live HTTPS smoke")
+	}
+	listenAddr := typeformLiveSmokeListenAddr(t)
+	timeout := typeformLiveSmokeTimeout(t)
+
+	ctx := runtimecorrelation.WithRunID(context.Background(), runID)
+	sqliteStore := storetest.StartSQLiteRuntimeStoreWithContext(t, ctx)
+	seedProviderTriggerSmokeRuntime(t, ctx, sqliteStore, runID, entityID, flowInstance, entitySlug, provider, webhookSecret, agentID)
+
+	bus, err := runtimebus.NewEventBus(sqliteStore)
+	if err != nil {
+		t.Fatalf("NewEventBus: %v", err)
+	}
+	ch := bus.Subscribe(agentID, events.EventType(providerEventName))
+	defer bus.Unsubscribe(agentID)
+
+	responseCapture := newProviderTriggerSmokeResponseCapture()
+	baseURL := startProviderTriggerSmokeServer(t, ctx, listenAddr, bus, sqliteStore, responseCapture)
+	localAddress := baseURL + webhookPath
+	t.Logf("waiting up to %s for Typeform to POST to %s through a tunnel that forwards to %s", timeout, publicWebhookURL, localAddress)
+	t.Log("trigger a Typeform UI Send test request or submit the configured form; this smoke does not call the Typeform API")
+
+	waitCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	response, err := responseCapture.wait(waitCtx)
+	if err != nil {
+		t.Fatalf("timed out waiting for Typeform live webhook delivery at %s: %v", publicWebhookURL, err)
+	}
+	if response.status != http.StatusAccepted {
+		t.Fatalf("Typeform live smoke response status = %d, want 202 body=%s", response.status, response.body)
+	}
+	if strings.Contains(response.body, webhookSecret) {
+		t.Fatal("Typeform signing secret leaked into accepted webhook response")
+	}
+
+	event := loadProviderTriggerSmokeEvent(t, ctx, sqliteStore, runID, entityID, providerEventName)
+	if event.ProviderEventID == "" {
+		t.Fatal("Typeform provider event id is empty")
+	}
+	if event.ProviderEventType == "" {
+		t.Fatal("Typeform provider event type is empty")
+	}
+	if event.Provider != provider {
+		t.Fatalf("provider = %q, want %q", event.Provider, provider)
+	}
+	assertProviderTriggerSmokeAcceptedResponse(t, response.body, provider, providerEventName, event.ProviderEventID, event.ProviderEventType)
+	if got := countProviderTriggerSmokeInboundMarkers(t, ctx, sqliteStore, event.ProviderEventID, entityID, provider); got != 1 {
+		t.Fatalf("inbound marker rows = %d, want 1", got)
+	}
+	if strings.Contains(event.Payload, webhookSecret) {
+		t.Fatal("Typeform signing secret leaked into persisted event payload")
+	}
+	if got := countProviderTriggerSmokeProviderEvents(t, ctx, sqliteStore, runID, entityID, providerEventName); got != 1 {
+		t.Fatalf("provider event rows = %d, want 1", got)
+	}
+	if got := countProviderTriggerSmokeAgentDeliveriesForEvent(t, ctx, sqliteStore, event.EventID, agentID); got != 1 {
+		t.Fatalf("agent delivery rows = %d, want 1", got)
+	}
+	select {
+	case got := <-ch:
+		if got.ID() != event.EventID || got.Type() != events.EventType(providerEventName) {
+			t.Fatalf("delivered event = %s/%s, want %s/%s", got.ID(), got.Type(), event.EventID, providerEventName)
+		}
+	default:
+		// The smoke asserts durable_before_dispatch evidence. Handler execution
+		// is intentionally not a prerequisite for the HTTP acknowledgement.
+	}
+
+	assertTypeformLiveSmokeBadSignatureFailsClosed(t, ctx, localAddress, sqliteStore, runID, entityID, providerEventName, provider)
+}
+
+func typeformLiveSmokePublicURL(t *testing.T, webhookPath string) string {
+	t.Helper()
+	rawURL := strings.TrimSpace(os.Getenv("SWARM_TYPEFORM_LIVE_SMOKE_WEBHOOK_URL"))
+	if rawURL == "" {
+		t.Skip("SWARM_TYPEFORM_LIVE_SMOKE_WEBHOOK_URL is required for the optional Typeform manual-live HTTPS smoke")
+	}
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		t.Fatalf("parse SWARM_TYPEFORM_LIVE_SMOKE_WEBHOOK_URL: %v", err)
+	}
+	if parsed.Scheme != "https" {
+		t.Fatalf("SWARM_TYPEFORM_LIVE_SMOKE_WEBHOOK_URL must use https, got %q", parsed.Scheme)
+	}
+	if parsed.Host == "" {
+		t.Fatal("SWARM_TYPEFORM_LIVE_SMOKE_WEBHOOK_URL must include a host")
+	}
+	if parsed.Path != webhookPath {
+		t.Fatalf("SWARM_TYPEFORM_LIVE_SMOKE_WEBHOOK_URL path = %q, want %q", parsed.Path, webhookPath)
+	}
+	return rawURL
+}
+
+func typeformLiveSmokeListenAddr(t *testing.T) string {
+	t.Helper()
+	listenAddr := strings.TrimSpace(os.Getenv("SWARM_TYPEFORM_LIVE_SMOKE_LISTEN_ADDR"))
+	if listenAddr == "" {
+		listenAddr = "127.0.0.1:17470"
+	}
+	_, port, err := net.SplitHostPort(listenAddr)
+	if err != nil {
+		t.Fatalf("parse SWARM_TYPEFORM_LIVE_SMOKE_LISTEN_ADDR: %v", err)
+	}
+	if port == "0" {
+		t.Fatal("SWARM_TYPEFORM_LIVE_SMOKE_LISTEN_ADDR must use a stable port so the HTTPS tunnel can forward to it")
+	}
+	return listenAddr
+}
+
+func typeformLiveSmokeTimeout(t *testing.T) time.Duration {
+	t.Helper()
+	raw := strings.TrimSpace(os.Getenv("SWARM_TYPEFORM_LIVE_SMOKE_TIMEOUT"))
+	if raw == "" {
+		return 5 * time.Minute
+	}
+	timeout, err := time.ParseDuration(raw)
+	if err != nil {
+		t.Fatalf("parse SWARM_TYPEFORM_LIVE_SMOKE_TIMEOUT: %v", err)
+	}
+	if timeout <= 0 {
+		t.Fatalf("SWARM_TYPEFORM_LIVE_SMOKE_TIMEOUT must be positive, got %s", timeout)
+	}
+	return timeout
+}
+
+func assertTypeformLiveSmokeBadSignatureFailsClosed(t *testing.T, ctx context.Context, address string, sqliteStore *store.SQLiteRuntimeStore, runID string, entityID string, eventName string, provider string) {
+	t.Helper()
+	body := []byte(`{"event_id":"typeform-live-smoke-invalid","event_type":"form_response","form_response":{"token":"invalid"}}`)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, address, bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("new Typeform bad-signature request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Typeform-Signature", "sha256=invalid")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("send Typeform bad-signature request: %v", err)
+	}
+	defer resp.Body.Close()
+	respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("Typeform bad-signature status = %d, want 401 body=%s", resp.StatusCode, string(respBody))
+	}
+	if got := countProviderTriggerSmokeInboundMarkers(t, ctx, sqliteStore, "typeform-live-smoke-invalid", entityID, provider); got != 0 {
+		t.Fatalf("Typeform bad-signature inbound marker rows = %d, want 0", got)
+	}
+	if got := countProviderTriggerSmokeProviderEventsByProviderEventID(t, ctx, sqliteStore, runID, entityID, eventName, "typeform-live-smoke-invalid"); got != 0 {
+		t.Fatalf("Typeform bad-signature provider event rows = %d, want 0", got)
+	}
+}

--- a/internal/providertriggers/SMOKE.md
+++ b/internal/providertriggers/SMOKE.md
@@ -31,3 +31,33 @@ SHOPIFY_FLAG_PATH='/path/to/shopify/app'
 ```
 
 The smoke intentionally uses `SHOPIFY_FLAG_CLIENT_SECRET` as an environment variable instead of a CLI argument so the signing secret is not placed in the process argv. Missing prerequisites skip the test. Present prerequisites plus mismatched provider delivery fail the test.
+
+## Typeform Manual-Live HTTPS Smoke
+
+This profile starts a local Swarm API listener with a SQLite runtime store in the test process, waits for a real Typeform webhook delivery at `/webhooks/customer-a/typeform`, and verifies the existing runtime gateway, Typeform provider-trigger pack, inbound marker, event-store, and delivery outcomes. It does not call the Typeform API, create or update webhooks, or claim Postgres live-smoke coverage; deterministic Typeform gateway coverage still proves both SQLite and Postgres stores.
+
+Prerequisites:
+
+- A Typeform form with a webhook configured manually in the Typeform UI.
+- A public HTTPS tunnel that forwards to the local listener address.
+- The Typeform webhook destination URL must be `https://<public-host>/webhooks/customer-a/typeform`.
+- The Typeform webhook secret must match `TYPEFORM_WEBHOOK_SECRET`.
+- Run with `go test -v` so the waiting instructions are visible while the smoke is running.
+
+Run:
+
+```sh
+SWARM_TYPEFORM_LIVE_SMOKE=1 \
+SWARM_TYPEFORM_LIVE_SMOKE_WEBHOOK_URL='https://<public-host>/webhooks/customer-a/typeform' \
+TYPEFORM_WEBHOOK_SECRET='<typeform-webhook-secret>' \
+go test ./cmd/swarm -run TestTypeformManualLiveHTTPSWebhookSmoke -count=1 -v
+```
+
+By default the smoke listens on `127.0.0.1:17470`, so configure the HTTPS tunnel to forward to `http://127.0.0.1:17470`. Override the listener only when your tunnel uses a different local address:
+
+```sh
+SWARM_TYPEFORM_LIVE_SMOKE_LISTEN_ADDR='127.0.0.1:18470'
+SWARM_TYPEFORM_LIVE_SMOKE_TIMEOUT='5m'
+```
+
+After the test logs that it is waiting, trigger Typeform delivery with either the Webhooks UI `Send test request` button or a real form submission. Missing prerequisites skip the test. Present prerequisites plus a Typeform delivery that no longer matches the Typeform pack contract fail the test. The smoke also sends a controlled bad-signature request through the same served route and verifies that it fails before marker/event persistence.


### PR DESCRIPTION
## Summary

Adds an opt-in Typeform manual-live HTTPS smoke harness for #1747.

The new smoke starts the same cmd-level served webhook path used by the Shopify smoke, waits for a Typeform-originated POST through an operator-provided HTTPS tunnel, and verifies the existing Typeform provider-trigger pack path by checking the accepted response, inbound marker, persisted `inbound.typeform` event, agent delivery row, and secret redaction. It also sends a controlled bad-signature request through the same served route and verifies that it fails before marker/event persistence.

This PR also extracts neutral provider-trigger smoke test helpers from the Shopify smoke so Shopify and Typeform consume the same served listener/readback plumbing without adding a provider-specific interpreter or a broader smoke-profile framework.

Part of #1747.

## Governing Refs

- #1747 Typeform-specific pre-audit and independent gate outcome.
- `platform-spec.yaml` `provider_trigger_adapters`: `internal/runtime/inbound.go` owns `/webhooks/{entity}/{provider}` and delegates configured providers to `internal/providertriggers`.
- `platform-spec.yaml` `manifest_vocabulary`: signature, raw-body request facts, delivery id, event type, event name, and `durable_before_dispatch` semantics.
- `platform-spec.yaml` `configured_provider_manifests.typeform`: Typeform uses `Typeform-Signature`, HMAC-SHA256 Base64 over exact raw body, `sha256=` prefix, payload `event_id`, payload `event_type`, and literal `inbound.typeform`.
- `platform-spec.yaml` `runtime_ingress.queueable_ingress.inbound.webhook`.
- Typeform docs checked during audit: https://www.typeform.com/developers/webhooks/, https://www.typeform.com/developers/webhooks/secure-your-webhooks/, https://www.typeform.com/developers/webhooks/reference/create-or-update-webhook/, https://help.typeform.com/hc/en-us/articles/360029573471-Webhooks.

## Scope Boundaries

- No Typeform API-managed webhook setup/teardown.
- No runtime gateway semantic change.
- No provider-trigger vocabulary or Typeform pack semantic change.
- No standard CI network or credential requirement.
- No generic smoke-profile abstraction beyond local test helper reuse.
- This does not close #1747; Intercom and optional Stripe tails remain unless separately retired or split.

## Validation

- `go test ./cmd/swarm -run 'Test(TypeformManualLiveHTTPSWebhookSmoke|ShopifyLocalProviderToolSmoke)$' -count=1 -v`
- `SWARM_TYPEFORM_LIVE_SMOKE=1 go test ./cmd/swarm -run TestTypeformManualLiveHTTPSWebhookSmoke -count=1 -v`
- `SWARM_TYPEFORM_LIVE_SMOKE=1 SWARM_TYPEFORM_LIVE_SMOKE_WEBHOOK_URL='https://example.com/webhooks/customer-a/typeform' go test ./cmd/swarm -run TestTypeformManualLiveHTTPSWebhookSmoke -count=1 -v`
- `SWARM_TEST_POSTGRES_DSN='host=127.0.0.1 port=5432 user=youmew dbname=postgres sslmode=disable' PGPASSWORD=postgres go test ./internal/runtime -run 'TestInboundGateway_Typeform|TestInboundGateway_RawFallbackDoesNotInterpretTypeformOrIntercomSignatures' -count=1 -v`
- `SWARM_CREDENTIALS_FILE=$(mktemp -t swarm-empty-credentials) SWARM_TEST_POSTGRES_DSN='host=127.0.0.1 port=5432 user=youmew dbname=postgres sslmode=disable' PGPASSWORD=postgres go test ./...`

The Typeform live positive smoke requires an actual Typeform form, configured webhook secret, and public HTTPS tunnel. Those external prerequisites were not available in this local environment, so the live Typeform-originated delivery was not run here; the PR adds the opt-in harness and documents the required invocation.

## Semantic Migration

No semantic migration. The canonical owners remain `internal/runtime/inbound.go`, `internal/providertriggers`, `provider.typeform`, `runtime.Stores.InboundStore`, and EventBus/EventStore. This PR only adds optional smoke proof plumbing and docs.
