### PR TITLE
[agent-c][issue #1791] Nail compute-module replay envelope

### DIFF
--- a/internal/runtime/computemodule/engine.go
+++ b/internal/runtime/computemodule/engine.go
@@ -72,6 +72,7 @@ type Error struct {
 	Code     Code
 	ModuleID string
 	RowID    string
+	Finding  *ReplayFinding
 	Err      error
 }
 
@@ -82,6 +83,18 @@ func (e *Error) Error() string {
 	}
 	if strings.TrimSpace(e.RowID) != "" {
 		parts = append(parts, "row="+strings.TrimSpace(e.RowID))
+	}
+	if e.Finding != nil {
+		finding := e.Finding.Normalized()
+		if finding.Kind != "" {
+			parts = append(parts, "finding="+string(finding.Kind))
+		}
+		if finding.Field != "" {
+			parts = append(parts, "field="+finding.Field)
+		}
+		if finding.Remediation != "" {
+			parts = append(parts, "remediation="+finding.Remediation)
+		}
 	}
 	if e.Err != nil {
 		parts = append(parts, e.Err.Error())
@@ -229,12 +242,15 @@ func Execute(req Request) (Result, error) {
 	if remaining, err := store.GetFuel(); err == nil && remaining <= req.Fuel {
 		fuelConsumed = req.Fuel - remaining
 	}
-	sum := sha256.Sum256(output)
+	outputHash, err := CanonicalJSONHashRaw(output)
+	if err != nil {
+		return Result{}, &Error{Code: CodeABI, ModuleID: req.ModuleID, RowID: req.RowID, Err: fmt.Errorf("output is not canonical JSON: %w", err)}
+	}
 	return Result{
 		Output:       output,
 		FuelConsumed: fuelConsumed,
 		Engine:       EngineVersion(),
-		OutputHash:   "sha256:" + hex.EncodeToString(sum[:]),
+		OutputHash:   outputHash,
 	}, nil
 }
 

--- a/internal/runtime/computemodule/replay.go
+++ b/internal/runtime/computemodule/replay.go
@@ -1,0 +1,306 @@
+package computemodule
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"runtime"
+	"strings"
+)
+
+const (
+	ReplayEvidenceSchema = "swarm.compute_module.replay.v1"
+	ReplayEvidenceAction = "compute_module_replay_evidence"
+)
+
+type ReplayOutcome string
+
+const (
+	ReplayOutcomeSuccess ReplayOutcome = "success"
+	ReplayOutcomeFailure ReplayOutcome = "failure"
+)
+
+type ReplayFindingKind string
+
+const (
+	ReplayFindingIdentityDivergence ReplayFindingKind = "identity_divergence"
+	ReplayFindingUnsupportedProfile ReplayFindingKind = "unsupported_profile"
+	ReplayFindingResultDivergence   ReplayFindingKind = "result_divergence"
+	ReplayFindingResourceDivergence ReplayFindingKind = "resource_envelope_divergence"
+)
+
+type ReplayLimits struct {
+	Fuel        uint64 `json:"fuel"`
+	MemoryPages uint32 `json:"memory_pages"`
+	OutputBytes int    `json:"output_bytes"`
+}
+
+type ReplayEnvelope struct {
+	ModuleID          string        `json:"module_id"`
+	RowID             string        `json:"row_id"`
+	Kind              string        `json:"kind"`
+	ABI               string        `json:"abi"`
+	Entry             string        `json:"entry"`
+	Digest            string        `json:"digest"`
+	SourceHash        string        `json:"source_hash,omitempty"`
+	InputHash         string        `json:"input_hash"`
+	Outcome           ReplayOutcome `json:"outcome"`
+	OutputHash        string        `json:"output_hash,omitempty"`
+	ErrorCode         string        `json:"error_code,omitempty"`
+	FuelConsumed      uint64        `json:"fuel_consumed"`
+	Limits            ReplayLimits  `json:"limits"`
+	Engine            string        `json:"engine"`
+	Arch              string        `json:"arch"`
+	Interpreter       string        `json:"interpreter,omitempty"`
+	InterpreterDigest string        `json:"interpreter_digest,omitempty"`
+	SnapshotDigest    string        `json:"snapshot_digest,omitempty"`
+	HarnessABI        string        `json:"harness_abi,omitempty"`
+}
+
+func (e ReplayEnvelope) Normalized() ReplayEnvelope {
+	e.ModuleID = strings.TrimSpace(e.ModuleID)
+	e.RowID = strings.TrimSpace(e.RowID)
+	e.Kind = strings.TrimSpace(e.Kind)
+	if e.Kind == "" {
+		e.Kind = "wasm"
+	}
+	e.ABI = strings.TrimSpace(e.ABI)
+	e.Entry = strings.TrimSpace(e.Entry)
+	e.Digest = strings.TrimSpace(e.Digest)
+	e.SourceHash = strings.TrimSpace(e.SourceHash)
+	e.InputHash = strings.TrimSpace(e.InputHash)
+	e.Outcome = ReplayOutcome(strings.TrimSpace(string(e.Outcome)))
+	e.OutputHash = strings.TrimSpace(e.OutputHash)
+	e.ErrorCode = strings.TrimSpace(e.ErrorCode)
+	e.Engine = strings.TrimSpace(e.Engine)
+	e.Arch = strings.TrimSpace(e.Arch)
+	e.Interpreter = strings.TrimSpace(e.Interpreter)
+	e.InterpreterDigest = strings.TrimSpace(e.InterpreterDigest)
+	e.SnapshotDigest = strings.TrimSpace(e.SnapshotDigest)
+	e.HarnessABI = strings.TrimSpace(e.HarnessABI)
+	return e
+}
+
+func CurrentArch() string {
+	return runtime.GOARCH
+}
+
+type ReplayFinding struct {
+	Schema      string            `json:"schema"`
+	Kind        ReplayFindingKind `json:"kind"`
+	Field       string            `json:"field"`
+	ModuleID    string            `json:"module_id,omitempty"`
+	RowID       string            `json:"row_id,omitempty"`
+	Expected    string            `json:"expected,omitempty"`
+	Actual      string            `json:"actual,omitempty"`
+	Message     string            `json:"message"`
+	Remediation string            `json:"remediation"`
+}
+
+func (f ReplayFinding) Normalized() ReplayFinding {
+	f.Schema = strings.TrimSpace(f.Schema)
+	if f.Schema == "" {
+		f.Schema = ReplayEvidenceSchema
+	}
+	f.Kind = ReplayFindingKind(strings.TrimSpace(string(f.Kind)))
+	f.Field = strings.TrimSpace(f.Field)
+	f.ModuleID = strings.TrimSpace(f.ModuleID)
+	f.RowID = strings.TrimSpace(f.RowID)
+	f.Expected = strings.TrimSpace(f.Expected)
+	f.Actual = strings.TrimSpace(f.Actual)
+	f.Message = strings.TrimSpace(f.Message)
+	f.Remediation = strings.TrimSpace(f.Remediation)
+	return f
+}
+
+type ReplayEvidenceDetail struct {
+	Schema    string           `json:"schema"`
+	Envelopes []ReplayEnvelope `json:"envelopes"`
+}
+
+func NewReplayEvidenceDetail(envelopes []ReplayEnvelope) map[string]any {
+	out := make([]ReplayEnvelope, 0, len(envelopes))
+	for _, envelope := range envelopes {
+		out = append(out, envelope.Normalized())
+	}
+	return map[string]any{
+		"compute_module_replay": ReplayEvidenceDetail{
+			Schema:    ReplayEvidenceSchema,
+			Envelopes: out,
+		},
+	}
+}
+
+func DecodeReplayEvidenceDetail(detail map[string]any) ([]ReplayEnvelope, error) {
+	if len(detail) == 0 {
+		return nil, nil
+	}
+	raw, ok := detail["compute_module_replay"]
+	if !ok || raw == nil {
+		return nil, nil
+	}
+	encoded, err := json.Marshal(raw)
+	if err != nil {
+		return nil, fmt.Errorf("encode compute_module replay detail: %w", err)
+	}
+	var payload ReplayEvidenceDetail
+	if err := json.Unmarshal(encoded, &payload); err != nil {
+		return nil, fmt.Errorf("decode compute_module replay detail: %w", err)
+	}
+	if strings.TrimSpace(payload.Schema) != ReplayEvidenceSchema {
+		return nil, fmt.Errorf("unsupported compute_module replay detail schema %q", payload.Schema)
+	}
+	out := make([]ReplayEnvelope, 0, len(payload.Envelopes))
+	for _, envelope := range payload.Envelopes {
+		out = append(out, envelope.Normalized())
+	}
+	return out, nil
+}
+
+func CompareReplayEnvelopes(expected, actual ReplayEnvelope) *ReplayFinding {
+	expected = expected.Normalized()
+	actual = actual.Normalized()
+	identityFields := []struct {
+		name string
+		want string
+		got  string
+	}{
+		{"module_id", expected.ModuleID, actual.ModuleID},
+		{"row_id", expected.RowID, actual.RowID},
+		{"kind", expected.Kind, actual.Kind},
+		{"abi", expected.ABI, actual.ABI},
+		{"entry", expected.Entry, actual.Entry},
+		{"digest", expected.Digest, actual.Digest},
+		{"source_hash", expected.SourceHash, actual.SourceHash},
+		{"input_hash", expected.InputHash, actual.InputHash},
+		{"limits.fuel", fmt.Sprint(expected.Limits.Fuel), fmt.Sprint(actual.Limits.Fuel)},
+		{"limits.memory_pages", fmt.Sprint(expected.Limits.MemoryPages), fmt.Sprint(actual.Limits.MemoryPages)},
+		{"limits.output_bytes", fmt.Sprint(expected.Limits.OutputBytes), fmt.Sprint(actual.Limits.OutputBytes)},
+		{"interpreter", expected.Interpreter, actual.Interpreter},
+		{"interpreter_digest", expected.InterpreterDigest, actual.InterpreterDigest},
+		{"snapshot_digest", expected.SnapshotDigest, actual.SnapshotDigest},
+		{"harness_abi", expected.HarnessABI, actual.HarnessABI},
+	}
+	for _, field := range identityFields {
+		if field.want != field.got {
+			return replayFinding(ReplayFindingIdentityDivergence, field.name, expected, actual, field.want, field.got)
+		}
+	}
+	profileFields := []struct {
+		name string
+		want string
+		got  string
+	}{
+		{"engine", expected.Engine, actual.Engine},
+		{"arch", expected.Arch, actual.Arch},
+	}
+	for _, field := range profileFields {
+		if field.want != field.got {
+			return replayFinding(ReplayFindingUnsupportedProfile, field.name, expected, actual, field.want, field.got)
+		}
+	}
+	if expected.Outcome != actual.Outcome {
+		return replayFinding(ReplayFindingResultDivergence, "outcome", expected, actual, string(expected.Outcome), string(actual.Outcome))
+	}
+	switch actual.Outcome {
+	case ReplayOutcomeFailure:
+		if expected.ErrorCode != actual.ErrorCode {
+			return replayFinding(ReplayFindingResultDivergence, "error_code", expected, actual, expected.ErrorCode, actual.ErrorCode)
+		}
+	default:
+		if expected.OutputHash != actual.OutputHash {
+			return replayFinding(ReplayFindingResultDivergence, "output_hash", expected, actual, expected.OutputHash, actual.OutputHash)
+		}
+	}
+	if actual.Kind != "python" && expected.FuelConsumed != actual.FuelConsumed {
+		return replayFinding(ReplayFindingResourceDivergence, "fuel_consumed", expected, actual, fmt.Sprint(expected.FuelConsumed), fmt.Sprint(actual.FuelConsumed))
+	}
+	return nil
+}
+
+func replayFinding(kind ReplayFindingKind, field string, expected, actual ReplayEnvelope, want, got string) *ReplayFinding {
+	remediation := "re-run with the original compute_module bundle, module bytes, runtime profile, and input evidence"
+	if kind == ReplayFindingResultDivergence {
+		remediation = "treat this as a deterministic replay correctness failure and inspect the module/runtime determinism boundary"
+	}
+	if kind == ReplayFindingUnsupportedProfile {
+		remediation = "replay this trace with the recorded engine and architecture profile, or regenerate replay evidence under the current profile"
+	}
+	if kind == ReplayFindingResourceDivergence {
+		remediation = "inspect fuel/resource accounting under the recorded engine profile before accepting replay"
+	}
+	finding := ReplayFinding{
+		Schema:      ReplayEvidenceSchema,
+		Kind:        kind,
+		Field:       field,
+		ModuleID:    firstNonEmpty(actual.ModuleID, expected.ModuleID),
+		RowID:       firstNonEmpty(actual.RowID, expected.RowID),
+		Expected:    want,
+		Actual:      got,
+		Message:     fmt.Sprintf("compute_module replay %s on %s", kind, field),
+		Remediation: remediation,
+	}.Normalized()
+	return &finding
+}
+
+func CanonicalJSONBytes(v any) ([]byte, error) {
+	raw, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return CanonicalizeJSON(raw)
+}
+
+func CanonicalizeJSON(raw []byte) ([]byte, error) {
+	dec := json.NewDecoder(bytes.NewReader(raw))
+	dec.UseNumber()
+	var value any
+	if err := dec.Decode(&value); err != nil {
+		return nil, err
+	}
+	var extra any
+	if err := dec.Decode(&extra); err != io.EOF {
+		if err == nil {
+			err = fmt.Errorf("trailing JSON content")
+		}
+		return nil, fmt.Errorf("trailing JSON content")
+	}
+	out, err := json.Marshal(value)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func CanonicalJSONHash(v any) (string, error) {
+	raw, err := CanonicalJSONBytes(v)
+	if err != nil {
+		return "", err
+	}
+	return HashBytes(raw), nil
+}
+
+func CanonicalJSONHashRaw(raw []byte) (string, error) {
+	canonical, err := CanonicalizeJSON(raw)
+	if err != nil {
+		return "", err
+	}
+	return HashBytes(canonical), nil
+}
+
+func HashBytes(raw []byte) string {
+	sum := sha256.Sum256(raw)
+	return "sha256:" + hex.EncodeToString(sum[:])
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if trimmed := strings.TrimSpace(value); trimmed != "" {
+			return trimmed
+		}
+	}
+	return ""
+}

--- a/internal/runtime/computemodule/replay_test.go
+++ b/internal/runtime/computemodule/replay_test.go
@@ -1,0 +1,123 @@
+package computemodule
+
+import "testing"
+
+func TestCanonicalJSONHashIgnoresObjectKeyOrder(t *testing.T) {
+	first, err := CanonicalJSONHashRaw([]byte(`{"b":2,"a":{"z":true,"m":["x","y"]}}`))
+	if err != nil {
+		t.Fatalf("CanonicalJSONHashRaw first: %v", err)
+	}
+	second, err := CanonicalJSONHashRaw([]byte(`{"a":{"m":["x","y"],"z":true},"b":2}`))
+	if err != nil {
+		t.Fatalf("CanonicalJSONHashRaw second: %v", err)
+	}
+	if first != second {
+		t.Fatalf("canonical hashes differ: %s != %s", first, second)
+	}
+	if _, err := CanonicalJSONHashRaw([]byte(`{"a":1}{"b":2}`)); err == nil {
+		t.Fatal("CanonicalJSONHashRaw accepted trailing JSON")
+	}
+}
+
+func TestCompareReplayEnvelopesSeparatesDivergenceClasses(t *testing.T) {
+	base := ReplayEnvelope{
+		ModuleID:     "renderer",
+		RowID:        "render",
+		Kind:         "wasm",
+		ABI:          ABI,
+		Entry:        DefaultEntry,
+		Digest:       "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		InputHash:    "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+		Outcome:      ReplayOutcomeSuccess,
+		OutputHash:   "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+		FuelConsumed: 10,
+		Limits: ReplayLimits{
+			Fuel:        100,
+			MemoryPages: 1,
+			OutputBytes: 64,
+		},
+		Engine: "wasmtime-go:v46.0.0",
+		Arch:   "arm64",
+	}
+	tests := []struct {
+		name      string
+		mutate    func(*ReplayEnvelope)
+		wantKind  ReplayFindingKind
+		wantField string
+	}{
+		{
+			name: "identity",
+			mutate: func(env *ReplayEnvelope) {
+				env.InputHash = "sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+			},
+			wantKind:  ReplayFindingIdentityDivergence,
+			wantField: "input_hash",
+		},
+		{
+			name: "profile",
+			mutate: func(env *ReplayEnvelope) {
+				env.Engine = "wasmtime-go:v47.0.0"
+			},
+			wantKind:  ReplayFindingUnsupportedProfile,
+			wantField: "engine",
+		},
+		{
+			name: "result",
+			mutate: func(env *ReplayEnvelope) {
+				env.OutputHash = "sha256:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
+			},
+			wantKind:  ReplayFindingResultDivergence,
+			wantField: "output_hash",
+		},
+		{
+			name: "resource",
+			mutate: func(env *ReplayEnvelope) {
+				env.FuelConsumed++
+			},
+			wantKind:  ReplayFindingResourceDivergence,
+			wantField: "fuel_consumed",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			actual := base
+			tc.mutate(&actual)
+			finding := CompareReplayEnvelopes(base, actual)
+			if finding == nil || finding.Kind != tc.wantKind || finding.Field != tc.wantField {
+				t.Fatalf("finding = %#v, want %s on %s", finding, tc.wantKind, tc.wantField)
+			}
+		})
+	}
+}
+
+func TestCompareReplayEnvelopesTreatsPythonFuelAsEvidenceOnly(t *testing.T) {
+	expected := ReplayEnvelope{
+		ModuleID:     "python_renderer",
+		RowID:        "render",
+		Kind:         "python",
+		ABI:          "python-json-v1",
+		Entry:        "handle",
+		Digest:       "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		InputHash:    "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+		Outcome:      ReplayOutcomeSuccess,
+		OutputHash:   "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+		FuelConsumed: 10,
+		Limits: ReplayLimits{
+			Fuel:        100,
+			MemoryPages: 8192,
+			OutputBytes: 4096,
+		},
+		Engine:            "wasmtime-go:v46.0.0",
+		Arch:              "arm64",
+		Interpreter:       "cpython-wasi",
+		InterpreterDigest: "sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+		SnapshotDigest:    "sha256:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+		HarnessABI:        "swarm-python-json-v1",
+		SourceHash:        "sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+	}
+	actual := expected
+	actual.FuelConsumed++
+	if finding := CompareReplayEnvelopes(expected, actual); finding != nil {
+		t.Fatalf("CompareReplayEnvelopes finding = %#v, want nil for python fuel drift", finding)
+	}
+}

--- a/internal/runtime/engine/compute_module_replay.go
+++ b/internal/runtime/engine/compute_module_replay.go
@@ -9,7 +9,7 @@ import (
 )
 
 type ComputeModuleReplayEvidenceLoader interface {
-	LoadComputeModuleReplayEvidence(ctx context.Context, runID string) ([]computemodule.ReplayEnvelope, error)
+	LoadComputeModuleReplayEvidenceForExecution(ctx context.Context, runID, eventID, nodeID string) ([]computemodule.ReplayEnvelope, error)
 }
 
 func (e *Executor) ExecuteWithPersistedComputeModuleReplayEvidence(ctx context.Context, loader ComputeModuleReplayEvidenceLoader, runID string, req ExecutionRequest) (ExecutionResult, error) {
@@ -23,15 +23,23 @@ func (e *Executor) ExecuteWithPersistedComputeModuleReplayEvidence(ctx context.C
 	if runID == "" {
 		return ExecutionResult{}, fmt.Errorf("compute_module persisted replay requires run id")
 	}
+	eventID := strings.TrimSpace(req.Event.ID())
+	if eventID == "" {
+		return ExecutionResult{}, fmt.Errorf("compute_module persisted replay requires request event id")
+	}
+	nodeID := strings.TrimSpace(string(req.NodeID))
+	if nodeID == "" {
+		return ExecutionResult{}, fmt.Errorf("compute_module persisted replay requires request node id")
+	}
 	if req.ExpectedComputeModuleTraces != nil {
 		return ExecutionResult{}, &computemodule.Error{
 			Code: computemodule.CodeReplay,
 			Err:  fmt.Errorf("compute_module persisted replay cannot combine loaded evidence with explicit expected traces"),
 		}
 	}
-	evidence, err := loader.LoadComputeModuleReplayEvidence(ctx, runID)
+	evidence, err := loader.LoadComputeModuleReplayEvidenceForExecution(ctx, runID, eventID, nodeID)
 	if err != nil {
-		return ExecutionResult{}, fmt.Errorf("load compute_module replay evidence for run %s: %w", runID, err)
+		return ExecutionResult{}, fmt.Errorf("load compute_module replay evidence for run %s event %s node %s: %w", runID, eventID, nodeID, err)
 	}
 	req.ExpectedComputeModuleTraces = make([]ComputeModuleTrace, 0, len(evidence))
 	for _, trace := range evidence {

--- a/internal/runtime/engine/compute_module_replay.go
+++ b/internal/runtime/engine/compute_module_replay.go
@@ -1,0 +1,41 @@
+package engine
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/division-sh/swarm/internal/runtime/computemodule"
+)
+
+type ComputeModuleReplayEvidenceLoader interface {
+	LoadComputeModuleReplayEvidence(ctx context.Context, runID string) ([]computemodule.ReplayEnvelope, error)
+}
+
+func (e *Executor) ExecuteWithPersistedComputeModuleReplayEvidence(ctx context.Context, loader ComputeModuleReplayEvidenceLoader, runID string, req ExecutionRequest) (ExecutionResult, error) {
+	if e == nil {
+		return ExecutionResult{}, fmt.Errorf("compute_module persisted replay requires executor")
+	}
+	if loader == nil {
+		return ExecutionResult{}, fmt.Errorf("compute_module persisted replay requires evidence loader")
+	}
+	runID = strings.TrimSpace(runID)
+	if runID == "" {
+		return ExecutionResult{}, fmt.Errorf("compute_module persisted replay requires run id")
+	}
+	if req.ExpectedComputeModuleTraces != nil {
+		return ExecutionResult{}, &computemodule.Error{
+			Code: computemodule.CodeReplay,
+			Err:  fmt.Errorf("compute_module persisted replay cannot combine loaded evidence with explicit expected traces"),
+		}
+	}
+	evidence, err := loader.LoadComputeModuleReplayEvidence(ctx, runID)
+	if err != nil {
+		return ExecutionResult{}, fmt.Errorf("load compute_module replay evidence for run %s: %w", runID, err)
+	}
+	req.ExpectedComputeModuleTraces = make([]ComputeModuleTrace, 0, len(evidence))
+	for _, trace := range evidence {
+		req.ExpectedComputeModuleTraces = append(req.ExpectedComputeModuleTraces, trace.Normalized())
+	}
+	return e.Execute(ctx, req)
+}

--- a/internal/runtime/engine/compute_module_replay_test.go
+++ b/internal/runtime/engine/compute_module_replay_test.go
@@ -1,0 +1,287 @@
+package engine_test
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/division-sh/swarm/internal/events"
+	"github.com/division-sh/swarm/internal/events/eventtest"
+	"github.com/division-sh/swarm/internal/platform"
+	runtimepkg "github.com/division-sh/swarm/internal/runtime"
+	"github.com/division-sh/swarm/internal/runtime/computemodule"
+	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
+	"github.com/division-sh/swarm/internal/runtime/core/identity"
+	runtimecorrelation "github.com/division-sh/swarm/internal/runtime/correlation"
+	runtimeengine "github.com/division-sh/swarm/internal/runtime/engine"
+	"github.com/division-sh/swarm/internal/runtime/flowmodel"
+	"github.com/division-sh/swarm/internal/runtime/semanticview"
+	"github.com/division-sh/swarm/internal/store"
+	"github.com/google/uuid"
+	"gopkg.in/yaml.v3"
+)
+
+func TestExecuteWithPersistedComputeModuleReplayEvidenceLoadsAndFailsClosedOnStoredDivergence(t *testing.T) {
+	ctx := context.Background()
+	sqliteStore := newComputeModuleReplaySQLiteStore(t)
+	runID := uuid.NewString()
+	ctx = runtimecorrelation.WithRunID(ctx, runID)
+	if _, err := sqliteStore.DB.ExecContext(ctx, `
+		INSERT INTO runs (run_id, status, started_at)
+		VALUES (?, 'running', ?)
+	`, runID, time.Now().UTC()); err != nil {
+		t.Fatalf("seed sqlite run: %v", err)
+	}
+
+	source := computeModuleReplaySource(t)
+	exec := newComputeModuleReplayExecutor(t, source)
+	req := computeModuleReplayExecutionRequest(t)
+	first, err := exec.Execute(ctx, req)
+	if err != nil {
+		t.Fatalf("initial Execute: %v", err)
+	}
+	if len(first.ComputeModuleTraces) != 1 {
+		t.Fatalf("initial traces = %#v, want one", first.ComputeModuleTraces)
+	}
+
+	persisted := first.ComputeModuleTraces[0]
+	persisted.OutputHash = "sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+	logger := runtimepkg.NewRuntimeLogger(sqliteStore)
+	if err := logger.Log(ctx, runtimepkg.RuntimeLogEntry{
+		Level:     "info",
+		Message:   "Compute module replay evidence recorded",
+		Component: "compute_module",
+		Action:    computemodule.ReplayEvidenceAction,
+		Detail:    computemodule.NewReplayEvidenceDetail([]computemodule.ReplayEnvelope{persisted}),
+	}); err != nil {
+		t.Fatalf("RuntimeLogger.Log persisted replay evidence: %v", err)
+	}
+
+	_, err = exec.ExecuteWithPersistedComputeModuleReplayEvidence(ctx, sqliteStore, runID, req)
+	if err == nil {
+		t.Fatal("persisted replay Execute error = nil, want result divergence")
+	}
+	var moduleErr *computemodule.Error
+	if !errors.As(err, &moduleErr) || moduleErr.Code != computemodule.CodeReplay {
+		t.Fatalf("persisted replay error = %#v, want compute_module replay error", err)
+	}
+	if moduleErr.Finding == nil ||
+		moduleErr.Finding.Kind != computemodule.ReplayFindingResultDivergence ||
+		moduleErr.Finding.Field != "output_hash" {
+		t.Fatalf("persisted replay finding = %#v, want result divergence on output_hash", moduleErr.Finding)
+	}
+}
+
+func newComputeModuleReplaySQLiteStore(t *testing.T) *store.SQLiteRuntimeStore {
+	t.Helper()
+	var spec runtimecontracts.PlatformSpecDocument
+	if err := yaml.Unmarshal(platform.PlatformSpecYAML(), &spec); err != nil {
+		t.Fatalf("decode platform spec: %v", err)
+	}
+	plans, err := store.GeneratePlatformTableDDLs(spec)
+	if err != nil {
+		t.Fatalf("GeneratePlatformTableDDLs: %v", err)
+	}
+	dbPath := filepath.Join(t.TempDir(), ".swarm", "dev.db")
+	sqliteStore, err := store.NewSQLiteRuntimeStore(dbPath)
+	if err != nil {
+		t.Fatalf("NewSQLiteRuntimeStore: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := sqliteStore.Close(); err != nil {
+			t.Fatalf("close sqlite runtime store: %v", err)
+		}
+	})
+	if err := sqliteStore.EnsureSchemaTables(context.Background(), plans); err != nil {
+		t.Fatalf("EnsureSchemaTables: %v", err)
+	}
+	return sqliteStore
+}
+
+func computeModuleReplaySource(t *testing.T) semanticview.Source {
+	t.Helper()
+	root := t.TempDir()
+	raw, err := os.ReadFile(filepath.Join("..", "computemodule", "testdata", "structured_renderer.wasm"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	modulePath := filepath.Join(root, "modules", "structured_renderer.wasm")
+	if err := os.MkdirAll(filepath.Dir(modulePath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(modulePath, raw, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	sum := sha256.Sum256(raw)
+	module := runtimecontracts.PolicyModule{
+		Path:   "modules/structured_renderer.wasm",
+		ABI:    computemodule.ABI,
+		Entry:  computemodule.DefaultEntry,
+		Digest: "sha256:" + hex.EncodeToString(sum[:]),
+		InputSchema: map[string]any{
+			"type":                 "object",
+			"additionalProperties": false,
+			"required":             []any{"component", "owner", "language", "files"},
+			"properties": map[string]any{
+				"component": map[string]any{"type": "string"},
+				"owner":     map[string]any{"type": "string"},
+				"language":  map[string]any{"type": "string"},
+				"files": map[string]any{
+					"type":  "array",
+					"items": map[string]any{"type": "string"},
+				},
+			},
+		},
+		OutputSchema: map[string]any{
+			"type":                 "object",
+			"additionalProperties": false,
+			"required":             []any{"content", "format", "line_count"},
+			"properties": map[string]any{
+				"content":    map[string]any{"type": "string"},
+				"format":     map[string]any{"type": "string"},
+				"line_count": map[string]any{"type": "integer"},
+			},
+		},
+		Limits: runtimecontracts.PolicyModuleLimits{
+			Gas:         5_000_000,
+			MemoryPages: 17,
+			OutputBytes: 1024,
+		},
+	}
+	flow := runtimecontracts.FlowContractView{
+		Paths: runtimecontracts.FlowContractPaths{ID: "render", Flow: "render"},
+		Policy: runtimecontracts.PolicyDocument{Modules: map[string]runtimecontracts.PolicyModule{
+			"structured_renderer": module,
+		}},
+	}
+	bundle := &runtimecontracts.WorkflowContractBundle{
+		Paths: runtimecontracts.ContractPaths{ContractsRoot: root},
+		FlowTree: flowmodel.Tree[runtimecontracts.FlowContractView]{
+			Root: &flow,
+			ByID: map[string]*runtimecontracts.FlowContractView{
+				"render": &flow,
+			},
+		},
+	}
+	return semanticview.Wrap(bundle)
+}
+
+func newComputeModuleReplayExecutor(t *testing.T, source semanticview.Source) *runtimeengine.Executor {
+	t.Helper()
+	exec, err := runtimeengine.NewExecutor(runtimeengine.RuntimeDependencies{
+		Source:     source,
+		StateRepo:  replayStateRepo{},
+		TxRunner:   replayTxRunner{},
+		Locker:     replayLocker{},
+		Outbox:     replayOutbox{},
+		Dispatcher: replayDispatcher{},
+	}, nil)
+	if err != nil {
+		t.Fatalf("NewExecutor: %v", err)
+	}
+	return exec
+}
+
+func computeModuleReplayExecutionRequest(t *testing.T) runtimeengine.ExecutionRequest {
+	t.Helper()
+	return runtimeengine.ExecutionRequest{
+		EntityID: identity.NormalizeEntityID("11111111-1111-1111-1111-111111111111"),
+		NodeID:   identity.NormalizeNodeID("render-node"),
+		FlowID:   identity.NormalizeFlowID("render"),
+		Event: eventtest.RootIngress(
+			"evt-1",
+			events.EventType("render.requested"),
+			"",
+			"",
+			mustComputeModuleReplayJSON(t, map[string]any{
+				"component": "api",
+				"owner":     "platform",
+				"language":  "go",
+				"files":     []any{"main.go", "README.md", "service.yaml"},
+			}),
+			0,
+			"",
+			"",
+			events.EventEnvelope{},
+			time.Date(2026, time.January, 1, 0, 0, 0, 0, time.UTC),
+		),
+		Handler: runtimecontracts.SystemNodeEventHandler{
+			Compute: &runtimecontracts.ComputeSpec{
+				Operation: runtimecontracts.ComputeOpModule,
+				StoreAs:   "computed.rendered_bundle",
+				Module: &runtimecontracts.ComputeModuleSpec{
+					RowID:  "render_bundle",
+					Module: "structured_renderer",
+					Into:   "computed.rendered_bundle",
+					Input: map[string]string{
+						"component": "payload.component",
+						"owner":     "payload.owner",
+						"language":  "payload.language",
+						"files":     "payload.files",
+					},
+				},
+			},
+		},
+		State: runtimeengine.StateSnapshot{
+			EntityID:     identity.NormalizeEntityID("11111111-1111-1111-1111-111111111111"),
+			CurrentState: "pending",
+		},
+	}
+}
+
+func mustComputeModuleReplayJSON(t *testing.T, value any) []byte {
+	t.Helper()
+	raw, err := json.Marshal(value)
+	if err != nil {
+		t.Fatalf("marshal JSON: %v", err)
+	}
+	return raw
+}
+
+type replayStateRepo struct{}
+
+func (replayStateRepo) LoadState(context.Context, identity.EntityID) (runtimeengine.StateSnapshot, bool, error) {
+	return runtimeengine.StateSnapshot{}, false, nil
+}
+
+func (replayStateRepo) SaveState(context.Context, identity.EntityID, runtimeengine.StateMutation) error {
+	return nil
+}
+
+type replayTxRunner struct{}
+
+func (replayTxRunner) Run(ctx context.Context, fn func(runtimeengine.Tx) error) error {
+	return fn(replayTx{ctx: ctx})
+}
+
+type replayTx struct {
+	ctx context.Context
+}
+
+func (tx replayTx) Context() context.Context {
+	return tx.ctx
+}
+
+type replayLocker struct{}
+
+func (replayLocker) WithEntityLock(ctx context.Context, _ identity.EntityID, fn func(context.Context) error) error {
+	return fn(ctx)
+}
+
+type replayOutbox struct{}
+
+func (replayOutbox) WriteOutbox(context.Context, []runtimeengine.EmitIntent) error {
+	return nil
+}
+
+type replayDispatcher struct{}
+
+func (replayDispatcher) DispatchPostCommit(context.Context, []runtimeengine.EmitIntent) error {
+	return nil
+}

--- a/internal/runtime/engine/compute_module_replay_test.go
+++ b/internal/runtime/engine/compute_module_replay_test.go
@@ -50,17 +50,20 @@ func TestExecuteWithPersistedComputeModuleReplayEvidenceLoadsAndFailsClosedOnSto
 		t.Fatalf("initial traces = %#v, want one", first.ComputeModuleTraces)
 	}
 
+	unrelated := first.ComputeModuleTraces[0]
+	unrelated.ModuleID = "unrelated_renderer"
+	persistComputeModuleReplayEvidenceForExecution(t, ctx, sqliteStore, "evt-unrelated", "other-node", unrelated)
+
 	persisted := first.ComputeModuleTraces[0]
 	persisted.OutputHash = "sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
-	logger := runtimepkg.NewRuntimeLogger(sqliteStore)
-	if err := logger.Log(ctx, runtimepkg.RuntimeLogEntry{
-		Level:     "info",
-		Message:   "Compute module replay evidence recorded",
-		Component: "compute_module",
-		Action:    computemodule.ReplayEvidenceAction,
-		Detail:    computemodule.NewReplayEvidenceDetail([]computemodule.ReplayEnvelope{persisted}),
-	}); err != nil {
-		t.Fatalf("RuntimeLogger.Log persisted replay evidence: %v", err)
+	persistComputeModuleReplayEvidenceForExecution(t, ctx, sqliteStore, req.Event.ID(), string(req.NodeID), persisted)
+
+	loaded, err := sqliteStore.LoadComputeModuleReplayEvidenceForExecution(ctx, runID, req.Event.ID(), string(req.NodeID))
+	if err != nil {
+		t.Fatalf("LoadComputeModuleReplayEvidenceForExecution: %v", err)
+	}
+	if len(loaded) != 1 || loaded[0].Normalized() != persisted.Normalized() {
+		t.Fatalf("scoped replay evidence = %#v, want only matching envelope %#v", loaded, persisted.Normalized())
 	}
 
 	_, err = exec.ExecuteWithPersistedComputeModuleReplayEvidence(ctx, sqliteStore, runID, req)
@@ -75,6 +78,23 @@ func TestExecuteWithPersistedComputeModuleReplayEvidenceLoadsAndFailsClosedOnSto
 		moduleErr.Finding.Kind != computemodule.ReplayFindingResultDivergence ||
 		moduleErr.Finding.Field != "output_hash" {
 		t.Fatalf("persisted replay finding = %#v, want result divergence on output_hash", moduleErr.Finding)
+	}
+}
+
+func persistComputeModuleReplayEvidenceForExecution(t *testing.T, ctx context.Context, sqliteStore *store.SQLiteRuntimeStore, eventID, nodeID string, envelope computemodule.ReplayEnvelope) {
+	t.Helper()
+	detail := computemodule.NewReplayEvidenceDetail([]computemodule.ReplayEnvelope{envelope})
+	detail["node_id"] = nodeID
+	logger := runtimepkg.NewRuntimeLogger(sqliteStore)
+	if err := logger.Log(ctx, runtimepkg.RuntimeLogEntry{
+		Level:     "info",
+		Message:   "Compute module replay evidence recorded",
+		Component: "compute_module",
+		Action:    computemodule.ReplayEvidenceAction,
+		EventID:   eventID,
+		Detail:    detail,
+	}); err != nil {
+		t.Fatalf("RuntimeLogger.Log persisted replay evidence: %v", err)
 	}
 }
 

--- a/internal/runtime/engine/executor.go
+++ b/internal/runtime/engine/executor.go
@@ -538,6 +538,15 @@ func (e *Executor) Execute(ctx context.Context, req ExecutionRequest) (Execution
 			frame := e.newExecutionFrame(contextTx{Tx: tx, ctx: txCtx}, req)
 			if err := e.runSteps(&frame); err != nil {
 				result = frame.result
+				var moduleErr *computemodule.Error
+				if errors.As(err, &moduleErr) && moduleErr.Code == computemodule.CodeReplay {
+					result.FailureClass = ClassifyFailure(err)
+					return err
+				}
+				if replayErr := verifyComputeModuleReplayTraceCount(frame); replayErr != nil {
+					result.FailureClass = ClassifyFailure(replayErr)
+					return replayErr
+				}
 				result.FailureClass = ClassifyFailure(err)
 				return err
 			}
@@ -1115,7 +1124,7 @@ func (e *Executor) computeModuleValue(frame *executionFrame, spec *runtimecontra
 	if err := eventschema.ValidatePayloadAgainstSchema(module.InputSchema, inputs); err != nil {
 		return nil, &computemodule.Error{Code: computemodule.CodeABI, ModuleID: moduleID, RowID: rowID, Err: fmt.Errorf("input schema violation: %w", err)}
 	}
-	inputBytes, err := json.Marshal(inputs)
+	inputBytes, err := computemodule.CanonicalJSONBytes(inputs)
 	if err != nil {
 		return nil, &computemodule.Error{Code: computemodule.CodeABI, ModuleID: moduleID, RowID: rowID, Err: err}
 	}
@@ -1127,20 +1136,50 @@ func (e *Executor) computeModuleValue(frame *executionFrame, spec *runtimecontra
 	if kind == "" {
 		kind = "wasm"
 	}
+	abi := strings.TrimSpace(module.ABI)
+	entry := strings.TrimSpace(module.Entry)
+	switch kind {
+	case pythonmodule.Kind:
+		if abi == "" {
+			abi = pythonmodule.ABI
+		}
+		if entry == "" {
+			entry = pythonmodule.DefaultEntry
+		}
+	default:
+		if abi == "" {
+			abi = computemodule.ABI
+		}
+		if entry == "" {
+			entry = computemodule.DefaultEntry
+		}
+	}
 	trace := ComputeModuleTrace{
-		ModuleID: moduleID,
-		RowID:    rowID,
-		Kind:     kind,
-		Digest:   strings.TrimSpace(module.Digest),
+		ModuleID:   moduleID,
+		RowID:      rowID,
+		Kind:       kind,
+		ABI:        abi,
+		Entry:      entry,
+		Digest:     strings.TrimSpace(module.Digest),
+		SourceHash: strings.TrimSpace(module.SourceHash),
+		InputHash:  computemodule.HashBytes(inputBytes),
+		Outcome:    computemodule.ReplayOutcomeSuccess,
+		Arch:       computemodule.CurrentArch(),
+		Limits: computemodule.ReplayLimits{
+			Fuel:        module.Limits.Gas,
+			MemoryPages: module.Limits.MemoryPages,
+			OutputBytes: module.Limits.OutputBytes,
+		},
 	}
 	var rawOutput []byte
 	switch kind {
 	case "wasm":
+		trace.Engine = computemodule.EngineVersion()
 		result, err := computemodule.Execute(computemodule.Request{
 			ModuleID:    moduleID,
 			RowID:       rowID,
 			Digest:      strings.TrimSpace(module.Digest),
-			Entry:       strings.TrimSpace(module.Entry),
+			Entry:       entry,
 			Wasm:        moduleBytes,
 			Input:       inputBytes,
 			Fuel:        module.Limits.Gas,
@@ -1148,18 +1187,24 @@ func (e *Executor) computeModuleValue(frame *executionFrame, spec *runtimecontra
 			OutputBytes: module.Limits.OutputBytes,
 		})
 		if err != nil {
-			return nil, err
+			return nil, e.recordComputeModuleFailure(frame, trace, err)
 		}
 		rawOutput = result.Output
 		trace.Engine = result.Engine
-		trace.OutputHash = result.OutputHash
 		trace.FuelConsumed = result.FuelConsumed
 	case pythonmodule.Kind:
+		identity := pythonmodule.RuntimeIdentity()
+		trace.Engine = identity.Engine
+		trace.Interpreter = identity.Interpreter
+		trace.InterpreterDigest = identity.InterpreterDigest
+		trace.SnapshotDigest = identity.SnapshotDigest
+		trace.HarnessABI = identity.HarnessABI
+		trace.SourceHash = computemodule.HashBytes(moduleBytes)
 		result, err := pythonmodule.Execute(pythonmodule.Request{
 			ModuleID:    moduleID,
 			RowID:       rowID,
 			Digest:      strings.TrimSpace(module.Digest),
-			Entry:       strings.TrimSpace(module.Entry),
+			Entry:       entry,
 			Source:      moduleBytes,
 			Input:       inputBytes,
 			Fuel:        module.Limits.Gas,
@@ -1167,11 +1212,10 @@ func (e *Executor) computeModuleValue(frame *executionFrame, spec *runtimecontra
 			OutputBytes: module.Limits.OutputBytes,
 		})
 		if err != nil {
-			return nil, err
+			return nil, e.recordComputeModuleFailure(frame, trace, err)
 		}
 		rawOutput = result.Output
 		trace.Engine = result.Engine
-		trace.OutputHash = result.OutputHash
 		trace.FuelConsumed = result.FuelConsumed
 		trace.Interpreter = result.Interpreter
 		trace.InterpreterDigest = result.InterpreterSHA
@@ -1183,13 +1227,43 @@ func (e *Executor) computeModuleValue(frame *executionFrame, spec *runtimecontra
 	}
 	output, err := decodeComputeModuleOutput(moduleID, rowID, rawOutput, module.OutputSchema)
 	if err != nil {
-		return nil, err
+		return nil, e.recordComputeModuleFailure(frame, trace, err)
 	}
+	outputHash, err := computemodule.CanonicalJSONHash(output)
+	if err != nil {
+		return nil, e.recordComputeModuleFailure(frame, trace, &computemodule.Error{Code: computemodule.CodeABI, ModuleID: moduleID, RowID: rowID, Err: err})
+	}
+	trace.OutputHash = outputHash
 	if err := verifyComputeModuleReplayTrace(frame, trace); err != nil {
 		return nil, err
 	}
-	frame.result.ComputeModuleTraces = append(frame.result.ComputeModuleTraces, trace)
+	frame.result.ComputeModuleTraces = append(frame.result.ComputeModuleTraces, trace.Normalized())
 	return output, nil
+}
+
+func (e *Executor) recordComputeModuleFailure(frame *executionFrame, trace ComputeModuleTrace, cause error) error {
+	if frame == nil {
+		return cause
+	}
+	trace = trace.Normalized()
+	trace.Outcome = computemodule.ReplayOutcomeFailure
+	trace.OutputHash = ""
+	trace.ErrorCode = string(computemodule.CodeABI)
+	var typed *computemodule.Error
+	if errors.As(cause, &typed) {
+		trace.ErrorCode = string(typed.Code)
+		if strings.TrimSpace(trace.ModuleID) == "" {
+			trace.ModuleID = strings.TrimSpace(typed.ModuleID)
+		}
+		if strings.TrimSpace(trace.RowID) == "" {
+			trace.RowID = strings.TrimSpace(typed.RowID)
+		}
+	}
+	if err := verifyComputeModuleReplayTrace(frame, trace); err != nil {
+		return err
+	}
+	frame.result.ComputeModuleTraces = append(frame.result.ComputeModuleTraces, trace.Normalized())
+	return cause
 }
 
 func decodeComputeModuleOutput(moduleID, rowID string, raw []byte, schema map[string]any) (map[string]any, error) {
@@ -1213,34 +1287,38 @@ func verifyComputeModuleReplayTrace(frame *executionFrame, actual ComputeModuleT
 	}
 	idx := len(frame.result.ComputeModuleTraces)
 	if idx >= len(expected) {
+		finding := computemodule.ReplayFinding{
+			Schema:      computemodule.ReplayEvidenceSchema,
+			Kind:        computemodule.ReplayFindingIdentityDivergence,
+			Field:       "trace_count",
+			ModuleID:    actual.ModuleID,
+			RowID:       actual.RowID,
+			Actual:      fmt.Sprint(idx + 1),
+			Expected:    fmt.Sprint(len(expected)),
+			Message:     "compute_module replay unexpected trace",
+			Remediation: "replay with matching persisted compute_module trace count and order",
+		}.Normalized()
 		return &computemodule.Error{
 			Code:     computemodule.CodeReplay,
 			ModuleID: actual.ModuleID,
 			RowID:    actual.RowID,
-			Err:      fmt.Errorf("unexpected compute_module trace at replay index %d: module=%s row=%s output_hash=%s fuel=%d", idx, actual.ModuleID, actual.RowID, actual.OutputHash, actual.FuelConsumed),
+			Finding:  &finding,
+			Err:      fmt.Errorf("unexpected compute_module trace at replay index %d: module=%s row=%s outcome=%s output_hash=%s error_code=%s fuel=%d", idx, actual.ModuleID, actual.RowID, actual.Outcome, actual.OutputHash, actual.ErrorCode, actual.FuelConsumed),
 		}
 	}
 	want := expected[idx]
-	compareFuel := strings.TrimSpace(actual.Kind) != pythonmodule.Kind
-	if strings.TrimSpace(want.ModuleID) != strings.TrimSpace(actual.ModuleID) ||
-		strings.TrimSpace(want.RowID) != strings.TrimSpace(actual.RowID) ||
-		strings.TrimSpace(want.Kind) != strings.TrimSpace(actual.Kind) ||
-		strings.TrimSpace(want.Digest) != strings.TrimSpace(actual.Digest) ||
-		strings.TrimSpace(want.Interpreter) != strings.TrimSpace(actual.Interpreter) ||
-		strings.TrimSpace(want.InterpreterDigest) != strings.TrimSpace(actual.InterpreterDigest) ||
-		strings.TrimSpace(want.SnapshotDigest) != strings.TrimSpace(actual.SnapshotDigest) ||
-		strings.TrimSpace(want.HarnessABI) != strings.TrimSpace(actual.HarnessABI) ||
-		strings.TrimSpace(want.SourceHash) != strings.TrimSpace(actual.SourceHash) ||
-		strings.TrimSpace(want.OutputHash) != strings.TrimSpace(actual.OutputHash) ||
-		(compareFuel && want.FuelConsumed != actual.FuelConsumed) {
+	if finding := computemodule.CompareReplayEnvelopes(want, actual); finding != nil {
 		return &computemodule.Error{
 			Code:     computemodule.CodeReplay,
 			ModuleID: actual.ModuleID,
 			RowID:    actual.RowID,
-			Err: fmt.Errorf("compute_module replay divergence at index %d: expected module=%s row=%s kind=%s digest=%s interpreter=%s interpreter_digest=%s snapshot_digest=%s harness_abi=%s source_hash=%s output_hash=%s fuel=%d engine=%s; got module=%s row=%s kind=%s digest=%s interpreter=%s interpreter_digest=%s snapshot_digest=%s harness_abi=%s source_hash=%s output_hash=%s fuel=%d engine=%s",
+			Finding:  finding,
+			Err: fmt.Errorf("compute_module replay %s at index %d field=%s: expected module=%s row=%s kind=%s abi=%s entry=%s digest=%s input_hash=%s interpreter=%s interpreter_digest=%s snapshot_digest=%s harness_abi=%s source_hash=%s outcome=%s output_hash=%s error_code=%s fuel=%d fuel_limit=%d memory_pages=%d output_bytes=%d engine=%s arch=%s; got module=%s row=%s kind=%s abi=%s entry=%s digest=%s input_hash=%s interpreter=%s interpreter_digest=%s snapshot_digest=%s harness_abi=%s source_hash=%s outcome=%s output_hash=%s error_code=%s fuel=%d fuel_limit=%d memory_pages=%d output_bytes=%d engine=%s arch=%s",
+				finding.Kind,
 				idx,
-				want.ModuleID, want.RowID, want.Kind, want.Digest, want.Interpreter, want.InterpreterDigest, want.SnapshotDigest, want.HarnessABI, want.SourceHash, want.OutputHash, want.FuelConsumed, want.Engine,
-				actual.ModuleID, actual.RowID, actual.Kind, actual.Digest, actual.Interpreter, actual.InterpreterDigest, actual.SnapshotDigest, actual.HarnessABI, actual.SourceHash, actual.OutputHash, actual.FuelConsumed, actual.Engine,
+				finding.Field,
+				want.ModuleID, want.RowID, want.Kind, want.ABI, want.Entry, want.Digest, want.InputHash, want.Interpreter, want.InterpreterDigest, want.SnapshotDigest, want.HarnessABI, want.SourceHash, want.Outcome, want.OutputHash, want.ErrorCode, want.FuelConsumed, want.Limits.Fuel, want.Limits.MemoryPages, want.Limits.OutputBytes, want.Engine, want.Arch,
+				actual.ModuleID, actual.RowID, actual.Kind, actual.ABI, actual.Entry, actual.Digest, actual.InputHash, actual.Interpreter, actual.InterpreterDigest, actual.SnapshotDigest, actual.HarnessABI, actual.SourceHash, actual.Outcome, actual.OutputHash, actual.ErrorCode, actual.FuelConsumed, actual.Limits.Fuel, actual.Limits.MemoryPages, actual.Limits.OutputBytes, actual.Engine, actual.Arch,
 			),
 		}
 	}
@@ -1252,9 +1330,19 @@ func verifyComputeModuleReplayTraceCount(frame executionFrame) error {
 	if expected == nil || len(frame.result.ComputeModuleTraces) == len(expected) {
 		return nil
 	}
+	finding := computemodule.ReplayFinding{
+		Schema:      computemodule.ReplayEvidenceSchema,
+		Kind:        computemodule.ReplayFindingIdentityDivergence,
+		Field:       "trace_count",
+		Expected:    fmt.Sprint(len(expected)),
+		Actual:      fmt.Sprint(len(frame.result.ComputeModuleTraces)),
+		Message:     "compute_module replay trace count mismatch",
+		Remediation: "replay with matching persisted compute_module trace count and order",
+	}.Normalized()
 	return &computemodule.Error{
-		Code: computemodule.CodeReplay,
-		Err:  fmt.Errorf("compute_module replay trace count mismatch: expected %d trace(s), got %d", len(expected), len(frame.result.ComputeModuleTraces)),
+		Code:    computemodule.CodeReplay,
+		Finding: &finding,
+		Err:     fmt.Errorf("compute_module replay trace count mismatch: expected %d trace(s), got %d", len(expected), len(frame.result.ComputeModuleTraces)),
 	}
 }
 

--- a/internal/runtime/engine/executor_test.go
+++ b/internal/runtime/engine/executor_test.go
@@ -2015,6 +2015,10 @@ func TestExecutor_PolicySheetPythonModuleRowFeedsSelectionRow(t *testing.T) {
 	if got := len(replayed.ComputeModuleTraces); got != 1 {
 		t.Fatalf("replay traces = %d, want 1", got)
 	}
+	req.ExpectedComputeModuleTraces[0].FuelConsumed++
+	if _, err := exec.Execute(context.Background(), req); err != nil {
+		t.Fatalf("python replay with fuel evidence drift error = %v, want fuel evidence-only acceptance", err)
+	}
 	req.ExpectedComputeModuleTraces[0].SourceHash = "sha256:0000000000000000000000000000000000000000000000000000000000000000"
 	_, err = exec.Execute(context.Background(), req)
 	if err == nil {
@@ -2034,7 +2038,8 @@ func TestExecutor_PythonModuleOutputSchemaFailureStopsBeforeEmit(t *testing.T) {
     return {"content": "ok", "format": "yaml", "line_count": "three"}
 `))
 	exec := newStructuredRendererExecutor(t, source)
-	_, err := exec.Execute(context.Background(), structuredRendererExecutionRequest(t, pythonRendererModuleSpec()))
+	req := structuredRendererExecutionRequest(t, pythonRendererModuleSpec())
+	result, err := exec.Execute(context.Background(), req)
 	if err == nil {
 		t.Fatal("Execute error = nil, want output schema violation")
 	}
@@ -2044,6 +2049,32 @@ func TestExecutor_PythonModuleOutputSchemaFailureStopsBeforeEmit(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "output schema violation") {
 		t.Fatalf("error = %v, want output schema diagnostic", err)
+	}
+	if got := len(result.ComputeModuleTraces); got != 1 {
+		t.Fatalf("failure traces = %d, want 1", got)
+	}
+	trace := result.ComputeModuleTraces[0]
+	if trace.Outcome != computemodule.ReplayOutcomeFailure || trace.ErrorCode != string(computemodule.CodeABI) || trace.OutputHash != "" {
+		t.Fatalf("failure trace = %#v, want ABI failure outcome without output hash", trace)
+	}
+	req.ExpectedComputeModuleTraces = append([]ComputeModuleTrace(nil), result.ComputeModuleTraces...)
+	_, err = exec.Execute(context.Background(), req)
+	if err == nil {
+		t.Fatal("replay Execute error = nil, want reproduced deterministic failure")
+	}
+	if !errors.As(err, &typed) || typed.Code != computemodule.CodeABI {
+		t.Fatalf("replay error = %#v, want original deterministic code %s", err, computemodule.CodeABI)
+	}
+	req.ExpectedComputeModuleTraces[0].ErrorCode = string(computemodule.CodeTrap)
+	_, err = exec.Execute(context.Background(), req)
+	if err == nil {
+		t.Fatal("replay Execute error = nil, want error-code divergence")
+	}
+	if !errors.As(err, &typed) || typed.Code != computemodule.CodeReplay {
+		t.Fatalf("error-code divergence = %#v, want replay code", err)
+	}
+	if typed.Finding == nil || typed.Finding.Kind != computemodule.ReplayFindingResultDivergence || typed.Finding.Field != "error_code" {
+		t.Fatalf("finding = %#v, want result divergence on error_code", typed.Finding)
 	}
 }
 
@@ -2091,8 +2122,94 @@ func TestExecutor_ComputeModuleReplayTraceComparison(t *testing.T) {
 	if !errors.As(err, &typed) || typed.Code != computemodule.CodeReplay {
 		t.Fatalf("error = %#v, want code %s", err, computemodule.CodeReplay)
 	}
+	if typed.Finding == nil || typed.Finding.Kind != computemodule.ReplayFindingResultDivergence || typed.Finding.Field != "output_hash" {
+		t.Fatalf("finding = %#v, want result divergence on output_hash", typed.Finding)
+	}
 	if !strings.Contains(err.Error(), "output_hash") {
 		t.Fatalf("error = %v, want output hash diagnostic", err)
+	}
+}
+
+func TestExecutor_ComputeModuleReplayEnvelopeClassifiesDivergenceKinds(t *testing.T) {
+	source, _ := sourceWithStructuredRendererModule(t)
+	exec := newStructuredRendererExecutor(t, source)
+	req := structuredRendererExecutionRequest(t, structuredRendererModuleSpec())
+	first, err := exec.Execute(context.Background(), req)
+	if err != nil {
+		t.Fatalf("initial Execute error: %v", err)
+	}
+	if got := len(first.ComputeModuleTraces); got != 1 {
+		t.Fatalf("initial traces = %d, want 1", got)
+	}
+	base := first.ComputeModuleTraces[0]
+	if base.InputHash == "" || base.ABI != computemodule.ABI || base.Entry != computemodule.DefaultEntry || base.Limits.Fuel == 0 || base.Arch == "" || base.Outcome != computemodule.ReplayOutcomeSuccess {
+		t.Fatalf("base envelope missing replay identity: %#v", base)
+	}
+	tests := []struct {
+		name      string
+		mutate    func(*ComputeModuleTrace)
+		wantKind  computemodule.ReplayFindingKind
+		wantField string
+	}{
+		{
+			name: "identity_input_hash",
+			mutate: func(trace *ComputeModuleTrace) {
+				trace.InputHash = "sha256:0000000000000000000000000000000000000000000000000000000000000000"
+			},
+			wantKind:  computemodule.ReplayFindingIdentityDivergence,
+			wantField: "input_hash",
+		},
+		{
+			name: "unsupported_engine_profile",
+			mutate: func(trace *ComputeModuleTrace) {
+				trace.Engine = "wasmtime-go:v0.unsupported"
+			},
+			wantKind:  computemodule.ReplayFindingUnsupportedProfile,
+			wantField: "engine",
+		},
+		{
+			name: "unsupported_arch_profile",
+			mutate: func(trace *ComputeModuleTrace) {
+				trace.Arch = "unsupported-arch"
+			},
+			wantKind:  computemodule.ReplayFindingUnsupportedProfile,
+			wantField: "arch",
+		},
+		{
+			name: "result_output_hash",
+			mutate: func(trace *ComputeModuleTrace) {
+				trace.OutputHash = "sha256:1111111111111111111111111111111111111111111111111111111111111111"
+			},
+			wantKind:  computemodule.ReplayFindingResultDivergence,
+			wantField: "output_hash",
+		},
+		{
+			name: "resource_fuel",
+			mutate: func(trace *ComputeModuleTrace) {
+				trace.FuelConsumed++
+			},
+			wantKind:  computemodule.ReplayFindingResourceDivergence,
+			wantField: "fuel_consumed",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			replayReq := structuredRendererExecutionRequest(t, structuredRendererModuleSpec())
+			trace := base
+			tc.mutate(&trace)
+			replayReq.ExpectedComputeModuleTraces = []ComputeModuleTrace{trace}
+			_, err := exec.Execute(context.Background(), replayReq)
+			if err == nil {
+				t.Fatal("replay Execute error = nil, want replay finding")
+			}
+			var typed *computemodule.Error
+			if !errors.As(err, &typed) || typed.Code != computemodule.CodeReplay {
+				t.Fatalf("error = %#v, want code %s", err, computemodule.CodeReplay)
+			}
+			if typed.Finding == nil || typed.Finding.Kind != tc.wantKind || typed.Finding.Field != tc.wantField {
+				t.Fatalf("finding = %#v, want %s on %s", typed.Finding, tc.wantKind, tc.wantField)
+			}
+		})
 	}
 }
 

--- a/internal/runtime/engine/types.go
+++ b/internal/runtime/engine/types.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/division-sh/swarm/internal/events"
+	"github.com/division-sh/swarm/internal/runtime/computemodule"
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
 	"github.com/division-sh/swarm/internal/runtime/core/identity"
 	"github.com/division-sh/swarm/internal/runtime/core/values"
@@ -224,8 +225,8 @@ type ExecutionRequest struct {
 	// ExpectedComputeModuleTraces carries prior deterministic module evidence
 	// for supported replay. Nil means normal execution; a non-nil empty slice
 	// means replay mode with zero expected module executions. When present,
-	// module execution re-runs and compares output hash plus fuel consumption
-	// against this ordered evidence.
+	// module execution re-runs and compares identity/profile, semantic
+	// outcome, and resource evidence against this ordered evidence.
 	ExpectedComputeModuleTraces []ComputeModuleTrace
 	ChainDepth                  int
 	MaxDepth                    int
@@ -434,20 +435,7 @@ type ExecutionResult struct {
 	AccumulatorCompletionDiagnostics AccumulatorCompletionDiagnostics
 }
 
-type ComputeModuleTrace struct {
-	ModuleID          string
-	RowID             string
-	Kind              string
-	Digest            string
-	Engine            string
-	OutputHash        string
-	FuelConsumed      uint64
-	Interpreter       string
-	InterpreterDigest string
-	SnapshotDigest    string
-	HarnessABI        string
-	SourceHash        string
-}
+type ComputeModuleTrace = computemodule.ReplayEnvelope
 
 func (r ExecutionResult) ComputedBucket() values.Bucket {
 	return values.Wrap(r.Computed)

--- a/internal/runtime/pipeline/compute_module_replay_log.go
+++ b/internal/runtime/pipeline/compute_module_replay_log.go
@@ -1,0 +1,29 @@
+package pipeline
+
+import (
+	"context"
+	"strings"
+
+	"github.com/division-sh/swarm/internal/events"
+	"github.com/division-sh/swarm/internal/runtime/computemodule"
+	"github.com/division-sh/swarm/internal/runtime/diaglog"
+	runtimeengine "github.com/division-sh/swarm/internal/runtime/engine"
+)
+
+func logComputeModuleReplayEvidence(ctx context.Context, bus Bus, nodeID string, evt events.Event, traces []runtimeengine.ComputeModuleTrace) {
+	if bus == nil || len(traces) == 0 {
+		return
+	}
+	detail := computemodule.NewReplayEvidenceDetail(traces)
+	detail["node_id"] = strings.TrimSpace(nodeID)
+	_ = bus.LogRuntime(ctx, RuntimeLogEntry{
+		Level:     diaglog.LevelInfo,
+		Message:   "Compute module replay evidence recorded",
+		Component: "compute_module",
+		Action:    computemodule.ReplayEvidenceAction,
+		EventID:   strings.TrimSpace(evt.ID()),
+		EventType: strings.TrimSpace(string(evt.Type())),
+		EntityID:  workflowEventEntityID(evt),
+		Detail:    detail,
+	})
+}

--- a/internal/runtime/pipeline/engine_bridge.go
+++ b/internal/runtime/pipeline/engine_bridge.go
@@ -249,12 +249,10 @@ func (pc *PipelineCoordinator) executeNodeContractHandler(
 	})
 	if !preview {
 		logAccumulatorCompletionOutcome(ctx, pc.bus, nodeID, triggerCtx.Event, result.AccumulatorCompletionDiagnostics, err)
+		logComputeModuleReplayEvidence(ctx, pc.bus, nodeID, triggerCtx.Event, result.ComputeModuleTraces)
 	}
 	if err != nil {
 		return contractHandlerExecutionResult{}, err
-	}
-	if !preview {
-		logComputeModuleReplayEvidence(ctx, pc.bus, nodeID, triggerCtx.Event, result.ComputeModuleTraces)
 	}
 	if handler.CreateEntity && result.StateMutation.StateCarrier.Metadata == nil {
 		result.StateMutation.StateCarrier.Metadata = cloneStringAnyMap(stateSnapshot.StateCarrier.Metadata)

--- a/internal/runtime/pipeline/engine_bridge.go
+++ b/internal/runtime/pipeline/engine_bridge.go
@@ -253,6 +253,9 @@ func (pc *PipelineCoordinator) executeNodeContractHandler(
 	if err != nil {
 		return contractHandlerExecutionResult{}, err
 	}
+	if !preview {
+		logComputeModuleReplayEvidence(ctx, pc.bus, nodeID, triggerCtx.Event, result.ComputeModuleTraces)
+	}
 	if handler.CreateEntity && result.StateMutation.StateCarrier.Metadata == nil {
 		result.StateMutation.StateCarrier.Metadata = cloneStringAnyMap(stateSnapshot.StateCarrier.Metadata)
 	}

--- a/internal/runtime/pipeline/handler_engine_transaction_test.go
+++ b/internal/runtime/pipeline/handler_engine_transaction_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/division-sh/swarm/internal/events"
 	"github.com/division-sh/swarm/internal/events/eventtest"
+	"github.com/division-sh/swarm/internal/runtime/computemodule"
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
 	runtimecorrelation "github.com/division-sh/swarm/internal/runtime/correlation"
 	runtimeengine "github.com/division-sh/swarm/internal/runtime/engine"
@@ -128,6 +129,61 @@ func (b *recordingPipelineBus) runtimeLogEntries() []RuntimeLogEntry {
 	out := make([]RuntimeLogEntry, len(b.runtimeLogs))
 	copy(out, b.runtimeLogs)
 	return out
+}
+
+func TestLogComputeModuleReplayEvidenceEmitsRuntimeLogCarrier(t *testing.T) {
+	bus := &recordingPipelineBus{}
+	evt := eventtest.PersistedProjection(
+		"evt-1",
+		events.EventType("render.requested"),
+		"tester",
+		"",
+		json.RawMessage(`{"component":"api"}`),
+		0,
+		"",
+		"",
+		events.EventEnvelope{EntityID: "ent-1"},
+		time.Now().UTC(),
+	)
+	trace := runtimeengine.ComputeModuleTrace{
+		ModuleID:     "structured_renderer",
+		RowID:        "render_bundle",
+		Kind:         "wasm",
+		ABI:          computemodule.ABI,
+		Entry:        computemodule.DefaultEntry,
+		Digest:       "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		InputHash:    "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+		Outcome:      computemodule.ReplayOutcomeSuccess,
+		OutputHash:   "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+		FuelConsumed: 7,
+		Limits: computemodule.ReplayLimits{
+			Fuel:        100,
+			MemoryPages: 17,
+			OutputBytes: 1024,
+		},
+		Engine: "wasmtime-go:v46.0.0",
+		Arch:   "arm64",
+	}
+	logComputeModuleReplayEvidence(context.Background(), bus, "renderer", evt, []runtimeengine.ComputeModuleTrace{trace})
+	logs := bus.runtimeLogEntries()
+	if len(logs) != 1 {
+		t.Fatalf("runtime logs = %#v, want one replay evidence carrier", logs)
+	}
+	entry := logs[0]
+	if entry.Component != "compute_module" || entry.Action != computemodule.ReplayEvidenceAction || entry.EventID != "evt-1" || entry.EntityID != "ent-1" {
+		t.Fatalf("runtime log entry = %#v, want compute_module replay action/event/entity", entry)
+	}
+	detail, ok := entry.Detail.(map[string]any)
+	if !ok {
+		t.Fatalf("detail = %#v, want map", entry.Detail)
+	}
+	envelopes, err := computemodule.DecodeReplayEvidenceDetail(detail)
+	if err != nil {
+		t.Fatalf("DecodeReplayEvidenceDetail: %v", err)
+	}
+	if len(envelopes) != 1 || envelopes[0].Normalized() != trace.Normalized() {
+		t.Fatalf("decoded envelopes = %#v, want %#v", envelopes, trace.Normalized())
+	}
 }
 
 func TestPipelineCoordinatorPublish_ReturnsBusPublishError(t *testing.T) {

--- a/internal/runtime/pipeline/handler_engine_transaction_test.go
+++ b/internal/runtime/pipeline/handler_engine_transaction_test.go
@@ -2,9 +2,13 @@ package pipeline
 
 import (
 	"context"
+	"crypto/sha256"
 	"database/sql"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
+	"os"
+	"path/filepath"
 	"reflect"
 	"strings"
 	"sync"
@@ -17,6 +21,7 @@ import (
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
 	runtimecorrelation "github.com/division-sh/swarm/internal/runtime/correlation"
 	runtimeengine "github.com/division-sh/swarm/internal/runtime/engine"
+	"github.com/division-sh/swarm/internal/runtime/flowmodel"
 	"github.com/division-sh/swarm/internal/runtime/semanticview"
 	"github.com/division-sh/swarm/internal/testutil"
 	"github.com/google/uuid"
@@ -184,6 +189,152 @@ func TestLogComputeModuleReplayEvidenceEmitsRuntimeLogCarrier(t *testing.T) {
 	if len(envelopes) != 1 || envelopes[0].Normalized() != trace.Normalized() {
 		t.Fatalf("decoded envelopes = %#v, want %#v", envelopes, trace.Normalized())
 	}
+}
+
+func TestExecuteNodeContractHandlerLogsComputeModuleReplayEvidenceBeforeFailureReturn(t *testing.T) {
+	source := pipelineSourceWithStructuredRendererModule(t, map[string]any{
+		"type":                 "object",
+		"additionalProperties": false,
+		"required":             []any{"missing"},
+		"properties": map[string]any{
+			"missing": map[string]any{"type": "string"},
+		},
+	})
+	bus := &recordingPipelineBus{}
+	pc := &PipelineCoordinator{
+		bus:            bus,
+		module:         staticSemanticWorkflowModule{source: source},
+		expressionEval: newWorkflowExpressionEvaluator(),
+		entityLocks:    map[string]*sync.Mutex{},
+	}
+	_, err := pc.executeNodeContractHandler(testPipelineCoordinatorRunContext(t, pc), "node-a", runtimecontracts.SystemNodeEventHandler{
+		Compute: &runtimecontracts.ComputeSpec{
+			Operation: runtimecontracts.ComputeOpModule,
+			StoreAs:   "computed.rendered_bundle",
+			Module: &runtimecontracts.ComputeModuleSpec{
+				RowID:  "render_bundle",
+				Module: "structured_renderer",
+				Into:   "computed.rendered_bundle",
+				Input: map[string]string{
+					"component": "payload.component",
+					"owner":     "payload.owner",
+					"language":  "payload.language",
+					"files":     "payload.files",
+				},
+			},
+		},
+	}, workflowTriggerContext{
+		Event: eventtest.RootIngress(
+			"evt-failure",
+			events.EventType("render.requested"),
+			"",
+			"",
+			mustJSON(map[string]any{
+				"component": "api",
+				"owner":     "platform",
+				"language":  "go",
+				"files":     []any{"main.go", "README.md", "service.yaml"},
+			}),
+			0,
+			"",
+			"",
+			events.EnvelopeForEntityID(events.EventEnvelope{}, "ent-1"),
+			time.Time{},
+		),
+		State: WorkflowState{
+			EntityID: "ent-1",
+			Stage:    WorkflowStateID("pending"),
+			Metadata: map[string]any{},
+		},
+	}, false)
+	if err == nil {
+		t.Fatal("executeNodeContractHandler error = nil, want output-schema failure")
+	}
+	var moduleErr *computemodule.Error
+	if !errors.As(err, &moduleErr) || moduleErr.Code != computemodule.CodeABI {
+		t.Fatalf("executeNodeContractHandler error = %#v, want compute module ABI failure", err)
+	}
+	logs := bus.runtimeLogEntries()
+	if len(logs) != 1 {
+		t.Fatalf("runtime logs = %#v, want failure replay evidence before error return", logs)
+	}
+	detail, ok := logs[0].Detail.(map[string]any)
+	if !ok {
+		t.Fatalf("detail = %#v, want map", logs[0].Detail)
+	}
+	envelopes, err := computemodule.DecodeReplayEvidenceDetail(detail)
+	if err != nil {
+		t.Fatalf("DecodeReplayEvidenceDetail: %v", err)
+	}
+	if len(envelopes) != 1 {
+		t.Fatalf("decoded envelopes = %#v, want one failure envelope", envelopes)
+	}
+	trace := envelopes[0].Normalized()
+	if trace.Outcome != computemodule.ReplayOutcomeFailure || trace.ErrorCode != string(computemodule.CodeABI) || trace.OutputHash != "" {
+		t.Fatalf("failure trace = %#v, want ABI failure outcome without output hash", trace)
+	}
+}
+
+func pipelineSourceWithStructuredRendererModule(t *testing.T, outputSchema map[string]any) semanticview.Source {
+	t.Helper()
+	root := t.TempDir()
+	raw, err := os.ReadFile(filepath.Join("..", "computemodule", "testdata", "structured_renderer.wasm"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	modulePath := filepath.Join(root, "modules", "structured_renderer.wasm")
+	if err := os.MkdirAll(filepath.Dir(modulePath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(modulePath, raw, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	sum := sha256.Sum256(raw)
+	module := runtimecontracts.PolicyModule{
+		Path:   "modules/structured_renderer.wasm",
+		ABI:    computemodule.ABI,
+		Entry:  computemodule.DefaultEntry,
+		Digest: "sha256:" + hex.EncodeToString(sum[:]),
+		InputSchema: map[string]any{
+			"type":                 "object",
+			"additionalProperties": false,
+			"required":             []any{"component", "owner", "language", "files"},
+			"properties": map[string]any{
+				"component": map[string]any{"type": "string"},
+				"owner":     map[string]any{"type": "string"},
+				"language":  map[string]any{"type": "string"},
+				"files": map[string]any{
+					"type":  "array",
+					"items": map[string]any{"type": "string"},
+				},
+			},
+		},
+		OutputSchema: outputSchema,
+		Limits: runtimecontracts.PolicyModuleLimits{
+			Gas:         5_000_000,
+			MemoryPages: 17,
+			OutputBytes: 1024,
+		},
+	}
+	flow := runtimecontracts.FlowContractView{
+		Paths: runtimecontracts.FlowContractPaths{ID: "render", Flow: "render"},
+		Nodes: map[string]runtimecontracts.SystemNodeContract{
+			"node-a": {ID: "node-a"},
+		},
+		Policy: runtimecontracts.PolicyDocument{Modules: map[string]runtimecontracts.PolicyModule{
+			"structured_renderer": module,
+		}},
+	}
+	bundle := &runtimecontracts.WorkflowContractBundle{
+		Paths: runtimecontracts.ContractPaths{ContractsRoot: root},
+		FlowTree: flowmodel.Tree[runtimecontracts.FlowContractView]{
+			Root: &flow,
+			ByID: map[string]*runtimecontracts.FlowContractView{
+				"render": &flow,
+			},
+		},
+	}
+	return semanticview.Wrap(bundle)
 }
 
 func TestPipelineCoordinatorPublish_ReturnsBusPublishError(t *testing.T) {

--- a/internal/runtime/pipeline/node_declarative.go
+++ b/internal/runtime/pipeline/node_declarative.go
@@ -394,6 +394,7 @@ func (e *coordinatorHandlerExecutionEngine) ExecuteHandlerSteps(ctx context.Cont
 	if err != nil {
 		return nil, err
 	}
+	logComputeModuleReplayEvidence(ctx, e.coordinator.bus, e.nodeID, evt, result.ComputeModuleTraces)
 	e.coordinator.recordInterceptedEmitDeadLetters(ctx, evt, e.nodeID, &handlerExecutionOutcome{
 		InterceptedEmits: append([]runtimeengine.EmitIntent(nil), result.DeadLetterIntents...),
 	})

--- a/internal/runtime/pipeline/node_declarative.go
+++ b/internal/runtime/pipeline/node_declarative.go
@@ -391,10 +391,10 @@ func (e *coordinatorHandlerExecutionEngine) ExecuteHandlerSteps(ctx context.Cont
 		Handler:         handler,
 		State:           stateSnapshot,
 	})
+	logComputeModuleReplayEvidence(ctx, e.coordinator.bus, e.nodeID, evt, result.ComputeModuleTraces)
 	if err != nil {
 		return nil, err
 	}
-	logComputeModuleReplayEvidence(ctx, e.coordinator.bus, e.nodeID, evt, result.ComputeModuleTraces)
 	e.coordinator.recordInterceptedEmitDeadLetters(ctx, evt, e.nodeID, &handlerExecutionOutcome{
 		InterceptedEmits: append([]runtimeengine.EmitIntent(nil), result.DeadLetterIntents...),
 	})

--- a/internal/runtime/pythonmodule/runtime.go
+++ b/internal/runtime/pythonmodule/runtime.go
@@ -136,20 +136,19 @@ func Execute(req Request) (Result, error) {
 	if err != nil {
 		return Result{}, err
 	}
-	output, err := json.Marshal(wire.Output)
+	output, err := computemodule.CanonicalJSONBytes(wire.Output)
 	if err != nil {
 		return Result{}, &computemodule.Error{Code: computemodule.CodeABI, ModuleID: req.ModuleID, RowID: req.RowID, Err: fmt.Errorf("output cannot be encoded as JSON object: %w", err)}
 	}
 	if req.OutputBytes > 0 && len(output) > req.OutputBytes {
 		return Result{}, &computemodule.Error{Code: computemodule.CodeOutputSize, ModuleID: req.ModuleID, RowID: req.RowID, Err: fmt.Errorf("output %d bytes exceeds cap %d", len(output), req.OutputBytes)}
 	}
-	sum := sha256.Sum256(output)
 	identity := RuntimeIdentity()
 	return Result{
 		Output:         output,
 		FuelConsumed:   wire.FuelConsumed,
 		Engine:         identity.Engine,
-		OutputHash:     "sha256:" + hex.EncodeToString(sum[:]),
+		OutputHash:     computemodule.HashBytes(output),
 		Interpreter:    identity.Interpreter,
 		InterpreterSHA: identity.InterpreterDigest,
 		SnapshotHash:   identity.SnapshotDigest,

--- a/internal/runtime/template_instance_delivery_test.go
+++ b/internal/runtime/template_instance_delivery_test.go
@@ -1075,7 +1075,7 @@ func seedRuntimeTestRun(t *testing.T, db *sql.DB) context.Context {
 
 func waitRuntimeDBCount(t *testing.T, ctx context.Context, db *sql.DB, query string, want int, args ...any) {
 	t.Helper()
-	deadline := time.Now().Add(2 * time.Second)
+	deadline := time.Now().Add(10 * time.Second)
 	for {
 		var got int
 		if err := db.QueryRowContext(ctx, query, args...).Scan(&got); err != nil {
@@ -1093,7 +1093,7 @@ func waitRuntimeDBCount(t *testing.T, ctx context.Context, db *sql.DB, query str
 
 func waitRuntimeEventID(t *testing.T, ctx context.Context, db *sql.DB, query string, args []any) string {
 	t.Helper()
-	deadline := time.Now().Add(2 * time.Second)
+	deadline := time.Now().Add(10 * time.Second)
 	for {
 		var got string
 		err := db.QueryRowContext(ctx, query, args...).Scan(&got)

--- a/internal/store/compute_module_replay_evidence.go
+++ b/internal/store/compute_module_replay_evidence.go
@@ -9,13 +9,13 @@ import (
 	"github.com/division-sh/swarm/internal/runtime/computemodule"
 )
 
-func (s *PostgresStore) LoadComputeModuleReplayEvidence(ctx context.Context, runID string) ([]computemodule.ReplayEnvelope, error) {
+func (s *PostgresStore) LoadComputeModuleReplayEvidenceForExecution(ctx context.Context, runID, eventID, nodeID string) ([]computemodule.ReplayEnvelope, error) {
 	if s == nil || s.DB == nil {
 		return nil, fmt.Errorf("postgres store is required")
 	}
-	runID = strings.TrimSpace(runID)
-	if runID == "" {
-		return nil, fmt.Errorf("run id is required")
+	runID, eventID, nodeID, err := normalizeComputeModuleReplayEvidenceScope(runID, eventID, nodeID)
+	if err != nil {
+		return nil, err
 	}
 	rows, err := s.DB.QueryContext(ctx, `
 		SELECT payload
@@ -23,8 +23,10 @@ func (s *PostgresStore) LoadComputeModuleReplayEvidence(ctx context.Context, run
 		WHERE event_name = 'platform.runtime_log'
 		  AND run_id = $1::uuid
 		  AND payload->'details'->>'action' = $2
+		  AND payload->'details'->>'event_id' = $3
+		  AND payload->'details'->>'node_id' = $4
 		ORDER BY created_at, event_id
-	`, runID, computemodule.ReplayEvidenceAction)
+	`, runID, computemodule.ReplayEvidenceAction, eventID, nodeID)
 	if err != nil {
 		return nil, fmt.Errorf("load postgres compute_module replay evidence: %w", err)
 	}
@@ -32,13 +34,13 @@ func (s *PostgresStore) LoadComputeModuleReplayEvidence(ctx context.Context, run
 	return scanComputeModuleReplayEvidenceRows(rows)
 }
 
-func (s *SQLiteRuntimeStore) LoadComputeModuleReplayEvidence(ctx context.Context, runID string) ([]computemodule.ReplayEnvelope, error) {
+func (s *SQLiteRuntimeStore) LoadComputeModuleReplayEvidenceForExecution(ctx context.Context, runID, eventID, nodeID string) ([]computemodule.ReplayEnvelope, error) {
 	if s == nil || s.DB == nil {
 		return nil, fmt.Errorf("sqlite runtime store is required")
 	}
-	runID = strings.TrimSpace(runID)
-	if runID == "" {
-		return nil, fmt.Errorf("run id is required")
+	runID, eventID, nodeID, err := normalizeComputeModuleReplayEvidenceScope(runID, eventID, nodeID)
+	if err != nil {
+		return nil, err
 	}
 	rows, err := s.DB.QueryContext(ctx, `
 		SELECT payload
@@ -46,13 +48,31 @@ func (s *SQLiteRuntimeStore) LoadComputeModuleReplayEvidence(ctx context.Context
 		WHERE event_name = 'platform.runtime_log'
 		  AND run_id = ?
 		  AND json_extract(payload, '$.details.action') = ?
+		  AND json_extract(payload, '$.details.event_id') = ?
+		  AND json_extract(payload, '$.details.node_id') = ?
 		ORDER BY created_at, event_id
-	`, runID, computemodule.ReplayEvidenceAction)
+	`, runID, computemodule.ReplayEvidenceAction, eventID, nodeID)
 	if err != nil {
 		return nil, fmt.Errorf("load sqlite compute_module replay evidence: %w", err)
 	}
 	defer rows.Close()
 	return scanComputeModuleReplayEvidenceRows(rows)
+}
+
+func normalizeComputeModuleReplayEvidenceScope(runID, eventID, nodeID string) (string, string, string, error) {
+	runID = strings.TrimSpace(runID)
+	eventID = strings.TrimSpace(eventID)
+	nodeID = strings.TrimSpace(nodeID)
+	if runID == "" {
+		return "", "", "", fmt.Errorf("run id is required")
+	}
+	if eventID == "" {
+		return "", "", "", fmt.Errorf("event id is required")
+	}
+	if nodeID == "" {
+		return "", "", "", fmt.Errorf("node id is required")
+	}
+	return runID, eventID, nodeID, nil
 }
 
 type replayEvidenceRows interface {

--- a/internal/store/compute_module_replay_evidence.go
+++ b/internal/store/compute_module_replay_evidence.go
@@ -1,0 +1,97 @@
+package store
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/division-sh/swarm/internal/runtime/computemodule"
+)
+
+func (s *PostgresStore) LoadComputeModuleReplayEvidence(ctx context.Context, runID string) ([]computemodule.ReplayEnvelope, error) {
+	if s == nil || s.DB == nil {
+		return nil, fmt.Errorf("postgres store is required")
+	}
+	runID = strings.TrimSpace(runID)
+	if runID == "" {
+		return nil, fmt.Errorf("run id is required")
+	}
+	rows, err := s.DB.QueryContext(ctx, `
+		SELECT payload
+		FROM events
+		WHERE event_name = 'platform.runtime_log'
+		  AND run_id = $1::uuid
+		  AND payload->'details'->>'action' = $2
+		ORDER BY created_at, event_id
+	`, runID, computemodule.ReplayEvidenceAction)
+	if err != nil {
+		return nil, fmt.Errorf("load postgres compute_module replay evidence: %w", err)
+	}
+	defer rows.Close()
+	return scanComputeModuleReplayEvidenceRows(rows)
+}
+
+func (s *SQLiteRuntimeStore) LoadComputeModuleReplayEvidence(ctx context.Context, runID string) ([]computemodule.ReplayEnvelope, error) {
+	if s == nil || s.DB == nil {
+		return nil, fmt.Errorf("sqlite runtime store is required")
+	}
+	runID = strings.TrimSpace(runID)
+	if runID == "" {
+		return nil, fmt.Errorf("run id is required")
+	}
+	rows, err := s.DB.QueryContext(ctx, `
+		SELECT payload
+		FROM events
+		WHERE event_name = 'platform.runtime_log'
+		  AND run_id = ?
+		  AND json_extract(payload, '$.details.action') = ?
+		ORDER BY created_at, event_id
+	`, runID, computemodule.ReplayEvidenceAction)
+	if err != nil {
+		return nil, fmt.Errorf("load sqlite compute_module replay evidence: %w", err)
+	}
+	defer rows.Close()
+	return scanComputeModuleReplayEvidenceRows(rows)
+}
+
+type replayEvidenceRows interface {
+	Next() bool
+	Scan(dest ...any) error
+	Err() error
+}
+
+func scanComputeModuleReplayEvidenceRows(rows replayEvidenceRows) ([]computemodule.ReplayEnvelope, error) {
+	var out []computemodule.ReplayEnvelope
+	for rows.Next() {
+		var raw []byte
+		if err := rows.Scan(&raw); err != nil {
+			return nil, fmt.Errorf("scan compute_module replay evidence: %w", err)
+		}
+		envelopes, err := decodeRuntimeLogReplayEvidencePayload(raw)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, envelopes...)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("read compute_module replay evidence: %w", err)
+	}
+	return out, nil
+}
+
+func decodeRuntimeLogReplayEvidencePayload(raw []byte) ([]computemodule.ReplayEnvelope, error) {
+	payload := map[string]any{}
+	if err := json.Unmarshal(raw, &payload); err != nil {
+		return nil, fmt.Errorf("decode runtime log payload: %w", err)
+	}
+	detail, _ := payload["details"].(map[string]any)
+	if len(detail) == 0 {
+		return nil, nil
+	}
+	envelopes, err := computemodule.DecodeReplayEvidenceDetail(detail)
+	if err != nil {
+		return nil, err
+	}
+	return envelopes, nil
+}

--- a/internal/store/runtime_log_persistence_test.go
+++ b/internal/store/runtime_log_persistence_test.go
@@ -92,19 +92,22 @@ func TestSQLiteRuntimeLogCarriesComputeModuleReplayEvidenceForReplayConsumer(t *
 	}
 
 	envelope := computeModuleReplayEvidenceTestEnvelope()
+	detail := computemodule.NewReplayEvidenceDetail([]computemodule.ReplayEnvelope{envelope})
+	detail["node_id"] = "node-a"
 	logger := runtimepkg.NewRuntimeLogger(store)
 	if err := logger.Log(ctx, runtimepkg.RuntimeLogEntry{
 		Level:     "info",
 		Message:   "Compute module replay evidence recorded",
 		Component: "compute_module",
 		Action:    computemodule.ReplayEvidenceAction,
-		Detail:    computemodule.NewReplayEvidenceDetail([]computemodule.ReplayEnvelope{envelope}),
+		EventID:   "evt-a",
+		Detail:    detail,
 	}); err != nil {
 		t.Fatalf("RuntimeLogger.Log: %v", err)
 	}
-	loaded, err := store.LoadComputeModuleReplayEvidence(ctx, runID)
+	loaded, err := store.LoadComputeModuleReplayEvidenceForExecution(ctx, runID, "evt-a", "node-a")
 	if err != nil {
-		t.Fatalf("LoadComputeModuleReplayEvidence: %v", err)
+		t.Fatalf("LoadComputeModuleReplayEvidenceForExecution: %v", err)
 	}
 	if len(loaded) != 1 {
 		t.Fatalf("loaded replay evidence = %#v, want one envelope", loaded)
@@ -140,6 +143,8 @@ func TestPostgresRuntimeLogCarriesComputeModuleReplayEvidenceForReplayConsumer(t
 	detail := computemodule.NewReplayEvidenceDetail([]computemodule.ReplayEnvelope{envelope})
 	detail["component"] = "compute_module"
 	detail["action"] = computemodule.ReplayEvidenceAction
+	detail["event_id"] = "evt-a"
+	detail["node_id"] = "node-a"
 	payload, err := json.Marshal(map[string]any{
 		"log_level": "info",
 		"message":   "Compute module replay evidence recorded",
@@ -156,9 +161,9 @@ func TestPostgresRuntimeLogCarriesComputeModuleReplayEvidenceForReplayConsumer(t
 	`, runID, string(payload)); err != nil {
 		t.Fatalf("seed postgres runtime log: %v", err)
 	}
-	loaded, err := pg.LoadComputeModuleReplayEvidence(ctx, runID)
+	loaded, err := pg.LoadComputeModuleReplayEvidenceForExecution(ctx, runID, "evt-a", "node-a")
 	if err != nil {
-		t.Fatalf("LoadComputeModuleReplayEvidence postgres: %v", err)
+		t.Fatalf("LoadComputeModuleReplayEvidenceForExecution postgres: %v", err)
 	}
 	if len(loaded) != 1 {
 		t.Fatalf("loaded postgres replay evidence = %#v, want one envelope", loaded)

--- a/internal/store/runtime_log_persistence_test.go
+++ b/internal/store/runtime_log_persistence_test.go
@@ -91,25 +91,7 @@ func TestSQLiteRuntimeLogCarriesComputeModuleReplayEvidenceForReplayConsumer(t *
 		t.Fatalf("seed sqlite run: %v", err)
 	}
 
-	envelope := computemodule.ReplayEnvelope{
-		ModuleID:     "structured_renderer",
-		RowID:        "render_bundle",
-		Kind:         "wasm",
-		ABI:          computemodule.ABI,
-		Entry:        computemodule.DefaultEntry,
-		Digest:       "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-		InputHash:    "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
-		Outcome:      computemodule.ReplayOutcomeSuccess,
-		OutputHash:   "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
-		FuelConsumed: 42,
-		Limits: computemodule.ReplayLimits{
-			Fuel:        1_000,
-			MemoryPages: 17,
-			OutputBytes: 1024,
-		},
-		Engine: "wasmtime-go:v46.0.0",
-		Arch:   "arm64",
-	}
+	envelope := computeModuleReplayEvidenceTestEnvelope()
 	logger := runtimepkg.NewRuntimeLogger(store)
 	if err := logger.Log(ctx, runtimepkg.RuntimeLogEntry{
 		Level:     "info",
@@ -136,6 +118,75 @@ func TestSQLiteRuntimeLogCarriesComputeModuleReplayEvidenceForReplayConsumer(t *
 	finding := computemodule.CompareReplayEnvelopes(loaded[0], actual)
 	if finding == nil || finding.Kind != computemodule.ReplayFindingResultDivergence || finding.Field != "output_hash" {
 		t.Fatalf("planted divergence finding = %#v, want result divergence on output_hash", finding)
+	}
+}
+
+func TestPostgresRuntimeLogCarriesComputeModuleReplayEvidenceForReplayConsumer(t *testing.T) {
+	ctx := context.Background()
+	_, db, cleanup := testutil.StartPostgres(t)
+	defer cleanup()
+	pg := &PostgresStore{DB: db}
+	if _, err := pg.BindSchemaCapabilities(ctx); err != nil {
+		t.Fatalf("BindSchemaCapabilities: %v", err)
+	}
+	runID := uuid.NewString()
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO runs (run_id, status, started_at)
+		VALUES ($1::uuid, 'running', NOW())
+	`, runID); err != nil {
+		t.Fatalf("seed postgres run: %v", err)
+	}
+	envelope := computeModuleReplayEvidenceTestEnvelope()
+	detail := computemodule.NewReplayEvidenceDetail([]computemodule.ReplayEnvelope{envelope})
+	detail["component"] = "compute_module"
+	detail["action"] = computemodule.ReplayEvidenceAction
+	payload, err := json.Marshal(map[string]any{
+		"log_level": "info",
+		"message":   "Compute module replay evidence recorded",
+		"details":   detail,
+	})
+	if err != nil {
+		t.Fatalf("marshal runtime log payload: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO events (
+			event_id, run_id, event_name, scope, payload, produced_by, produced_by_type, created_at
+		)
+		VALUES (gen_random_uuid(), $1::uuid, 'platform.runtime_log', 'global', $2::jsonb, 'runtime', 'platform', NOW())
+	`, runID, string(payload)); err != nil {
+		t.Fatalf("seed postgres runtime log: %v", err)
+	}
+	loaded, err := pg.LoadComputeModuleReplayEvidence(ctx, runID)
+	if err != nil {
+		t.Fatalf("LoadComputeModuleReplayEvidence postgres: %v", err)
+	}
+	if len(loaded) != 1 {
+		t.Fatalf("loaded postgres replay evidence = %#v, want one envelope", loaded)
+	}
+	if loaded[0].Normalized() != envelope.Normalized() {
+		t.Fatalf("loaded postgres envelope = %#v, want %#v", loaded[0].Normalized(), envelope.Normalized())
+	}
+}
+
+func computeModuleReplayEvidenceTestEnvelope() computemodule.ReplayEnvelope {
+	return computemodule.ReplayEnvelope{
+		ModuleID:     "structured_renderer",
+		RowID:        "render_bundle",
+		Kind:         "wasm",
+		ABI:          computemodule.ABI,
+		Entry:        computemodule.DefaultEntry,
+		Digest:       "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		InputHash:    "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+		Outcome:      computemodule.ReplayOutcomeSuccess,
+		OutputHash:   "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+		FuelConsumed: 42,
+		Limits: computemodule.ReplayLimits{
+			Fuel:        1_000,
+			MemoryPages: 17,
+			OutputBytes: 1024,
+		},
+		Engine: "wasmtime-go:v46.0.0",
+		Arch:   "arm64",
 	}
 }
 

--- a/internal/store/runtime_log_persistence_test.go
+++ b/internal/store/runtime_log_persistence_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/division-sh/swarm/internal/events"
 	"github.com/division-sh/swarm/internal/events/eventtest"
 	runtimepkg "github.com/division-sh/swarm/internal/runtime"
+	"github.com/division-sh/swarm/internal/runtime/computemodule"
 	runtimecorrelation "github.com/division-sh/swarm/internal/runtime/correlation"
 	storerunlifecycle "github.com/division-sh/swarm/internal/store/runlifecycle"
 	"github.com/division-sh/swarm/internal/testutil"
@@ -75,6 +76,66 @@ func TestSQLiteRuntimeLogPersistenceWritesLoggerRowsForObservability(t *testing.
 	}
 	if sourceEventID != subjectEventID {
 		t.Fatalf("sqlite source_event_id = %q, want %q", sourceEventID, subjectEventID)
+	}
+}
+
+func TestSQLiteRuntimeLogCarriesComputeModuleReplayEvidenceForReplayConsumer(t *testing.T) {
+	ctx := context.Background()
+	store := newBootstrappedSQLiteRuntimeStoreForTest(t)
+	runID := uuid.NewString()
+	ctx = runtimecorrelation.WithRunID(ctx, runID)
+	if _, err := store.DB.ExecContext(ctx, `
+		INSERT INTO runs (run_id, status, started_at)
+		VALUES (?, 'running', ?)
+	`, runID, time.Now().UTC()); err != nil {
+		t.Fatalf("seed sqlite run: %v", err)
+	}
+
+	envelope := computemodule.ReplayEnvelope{
+		ModuleID:     "structured_renderer",
+		RowID:        "render_bundle",
+		Kind:         "wasm",
+		ABI:          computemodule.ABI,
+		Entry:        computemodule.DefaultEntry,
+		Digest:       "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		InputHash:    "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+		Outcome:      computemodule.ReplayOutcomeSuccess,
+		OutputHash:   "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+		FuelConsumed: 42,
+		Limits: computemodule.ReplayLimits{
+			Fuel:        1_000,
+			MemoryPages: 17,
+			OutputBytes: 1024,
+		},
+		Engine: "wasmtime-go:v46.0.0",
+		Arch:   "arm64",
+	}
+	logger := runtimepkg.NewRuntimeLogger(store)
+	if err := logger.Log(ctx, runtimepkg.RuntimeLogEntry{
+		Level:     "info",
+		Message:   "Compute module replay evidence recorded",
+		Component: "compute_module",
+		Action:    computemodule.ReplayEvidenceAction,
+		Detail:    computemodule.NewReplayEvidenceDetail([]computemodule.ReplayEnvelope{envelope}),
+	}); err != nil {
+		t.Fatalf("RuntimeLogger.Log: %v", err)
+	}
+	loaded, err := store.LoadComputeModuleReplayEvidence(ctx, runID)
+	if err != nil {
+		t.Fatalf("LoadComputeModuleReplayEvidence: %v", err)
+	}
+	if len(loaded) != 1 {
+		t.Fatalf("loaded replay evidence = %#v, want one envelope", loaded)
+	}
+	if loaded[0].Normalized() != envelope.Normalized() {
+		t.Fatalf("loaded envelope = %#v, want %#v", loaded[0].Normalized(), envelope.Normalized())
+	}
+
+	actual := loaded[0]
+	actual.OutputHash = "sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+	finding := computemodule.CompareReplayEnvelopes(loaded[0], actual)
+	if finding == nil || finding.Kind != computemodule.ReplayFindingResultDivergence || finding.Field != "output_hash" {
+		t.Fatalf("planted divergence finding = %#v, want result divergence on output_hash", finding)
 	}
 }
 

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -1717,19 +1717,48 @@ compute_module_contracts:
       deterministic no-retry class; the runtime boundary does not rely on that
       lint to deny host filesystem, inherited environment, clock, or entropy.
     trace_and_replay: |
-      Runtime traces record module ID, row ID, declared digest, engine version,
-      output hash, and fuel/gas consumed. Python traces additionally record
-      interpreter version, interpreter digest, harness ABI, snapshot identity,
-      and source hash. Supported replay re-executes module rows and compares the
-      recorded output hash plus identity fields against replay execution. Wasm
-      replay also compares fuel exactly. Python fuel is retained as evidence but
-      not exact divergence-bearing in this slice because CPython-WASI startup
-      under wasmtime fuel can vary across identical invocations by small
-      implementation-accounting deltas; exact Python fuel divergence detection
-      remains split until the release-time snapshot/gas envelope is stabilized.
+      Runtime compute-module replay evidence is a typed
+      `swarm.compute_module.replay.v1` envelope, not an engine-local helper.
+      Each envelope records module ID, row ID, kind, ABI, entrypoint, declared
+      digest, source hash when applicable, canonical input hash, outcome
+      (`success` or `failure`), output hash for success, deterministic error
+      code for failure, fuel/gas consumed, declared limits, engine version,
+      architecture, and Python interpreter/interpreter-digest/harness/snapshot
+      identity when kind is `python`.
+
+      Input and output hashes MUST be computed over canonical JSON so map order
+      or incidental serialization does not create false replay divergence.
+      Diagnostic text is not semantic replay identity. For failed executions,
+      the deterministic error code is the replay outcome.
+
+      Supported replay re-executes module rows and compares envelopes in this
+      order:
+      1. Identity fields (module, row, kind, ABI, entry, digest, source hash,
+         input hash, declared limits, and Python interpreter/harness/snapshot
+         identity) must match. Mismatch is `identity_divergence`.
+      2. Engine/architecture profile must match. Mismatch is
+         `unsupported_profile`, not nondeterminism, because the replay ruler
+         changed.
+      3. Semantic outcome must match. Success compares output hash; failure
+         compares deterministic error code. Mismatch is fatal
+         `result_divergence`.
+      4. Wasm replay compares fuel exactly under a matching profile. Mismatch
+         is `resource_envelope_divergence`. Python fuel is retained as evidence
+         but is not divergence-bearing in this slice because CPython-WASI
+         startup under wasmtime fuel can vary across identical invocations by
+         small implementation-accounting deltas; exact Python fuel divergence
+         detection remains split until the release-time snapshot/gas envelope
+         is stabilized.
+
       Replay mode is explicit: an empty expected trace set means zero module
-      executions are expected, not normal non-replay execution. Divergence is a
-      typed deterministic replay failure, never silent acceptance.
+      executions are expected, not normal non-replay execution. Runtime logs may
+      carry persisted replay envelopes under action
+      `compute_module_replay_evidence`; those logs are carriers/readback
+      consumers only and do not become the semantic owner. Divergence diagnostics
+      MUST be typed, include the finding kind and field, include module/row IDs
+      and hashes only, and avoid raw input/output dumps. True result divergence
+      is a fatal deterministic replay failure; identity/profile mismatch is
+      fail-closed unsupported/incompatible replay.
   bundle_identity:
     rule: |
       Module bytes referenced by policy.modules are part of the bundle contract

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -1753,11 +1753,13 @@ compute_module_contracts:
       Replay mode is explicit: an empty expected trace set means zero module
       executions are expected, not normal non-replay execution. Runtime logs may
       carry persisted replay envelopes under action
-      `compute_module_replay_evidence`; those logs are carriers/readback
-      consumers only and do not become the semantic owner. Divergence diagnostics
-      MUST be typed, include the finding kind and field, include module/row IDs
-      and hashes only, and avoid raw input/output dumps. True result divergence
-      is a fatal deterministic replay failure; identity/profile mismatch is
+      `compute_module_replay_evidence`; supported persisted replay loaders read
+      those envelopes and feed them into the same expected-trace execution path
+      used by in-memory replay. Runtime logs and store rows are carriers only
+      and do not become the semantic owner. Divergence diagnostics MUST be
+      typed, include the finding kind and field, include module/row IDs and
+      hashes only, and avoid raw input/output dumps. True result divergence is a
+      fatal deterministic replay failure; identity/profile mismatch is
       fail-closed unsupported/incompatible replay.
   bundle_identity:
     rule: |

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -1754,13 +1754,14 @@ compute_module_contracts:
       executions are expected, not normal non-replay execution. Runtime logs may
       carry persisted replay envelopes under action
       `compute_module_replay_evidence`; supported persisted replay loaders read
-      those envelopes and feed them into the same expected-trace execution path
-      used by in-memory replay. Runtime logs and store rows are carriers only
-      and do not become the semantic owner. Divergence diagnostics MUST be
-      typed, include the finding kind and field, include module/row IDs and
-      hashes only, and avoid raw input/output dumps. True result divergence is a
-      fatal deterministic replay failure; identity/profile mismatch is
-      fail-closed unsupported/incompatible replay.
+      those envelopes for the replayed execution identity, scoped at minimum by
+      run id, source event id, and node id, and feed them into the same
+      expected-trace execution path used by in-memory replay. Runtime logs and
+      store rows are carriers only and do not become the semantic owner.
+      Divergence diagnostics MUST be typed, include the finding kind and field,
+      include module/row IDs and hashes only, and avoid raw input/output dumps.
+      True result divergence is a fatal deterministic replay failure;
+      identity/profile mismatch is fail-closed unsupported/incompatible replay.
   bundle_identity:
     rule: |
       Module bytes referenced by policy.modules are part of the bundle contract


### PR DESCRIPTION
Closes #1791

## Summary
- Adds the canonical `swarm.compute_module.replay.v1` evidence envelope for Wasm and Python `compute_module` executions.
- Compares replay traces in the required order: identity divergence, unsupported engine/arch profile, semantic result divergence, then Wasm-only fuel/resource divergence.
- Records deterministic failures as replay outcomes by error code, uses canonical JSON input/output hashes, and treats Python fuel as evidence-only.
- Persists replay evidence through the runtime-log carrier and adds SQLite/Postgres readback consumers for a planted-divergence replay path.

## Governing refs / context
- `platform-spec.yaml`: `compute_module_contracts.runtime_execution.trace_and_replay` is updated as the authoritative merge artifact.
- Issue #1791 pre-audit and gate comments define the approved child boundary: unified Wasm+Python compute-module replay-divergence + fuel envelope, absorbing the #1761 divergence tail.
- Adjacent governing context: #1669 compute-module execution semantics, #1670 bundle materialization, #1672 broader conformance/replay parent, and #1790 typed verifier diagnostic shape.

## Semantic migration
- New canonical owner: `internal/runtime/computemodule.ReplayEnvelope`, `CompareReplayEnvelopes`, and canonical JSON hashing helpers, backed by the spec section above.
- Old producer/reader path now invalid: engine-local compute-module trace comparison without a typed schema or persisted replay consumer is no longer authoritative.
- Production paths checked: Wasm adapter execution, Python adapter execution, engine compute-module invocation, runtime pipeline logging carriers, and SQLite/Postgres replay-evidence readback.
- Migration completeness: complete for supported Wasm+Python `compute_module` replay evidence in this PR. Broader historical replay/orchestration remains tracked by the parent #1672 lane.

## Validation
- `SWARM_TEST_POSTGRES_DSN='host=127.0.0.1 port=5432 user=youmew dbname=postgres sslmode=disable' PGPASSWORD=postgres go test ./internal/runtime/computemodule ./internal/runtime/pythonmodule ./internal/runtime/engine ./internal/runtime/pipeline ./internal/store -run 'Test(CanonicalJSONHashIgnoresObjectKeyOrder|CompareReplayEnvelopes|ExecuteStructuredRenderer|ExecuteStructuredTransform|Executor_.*ComputeModule|Executor_PythonModuleOutputSchema|LogComputeModuleReplayEvidence|SQLiteRuntimeLogCarriesComputeModuleReplayEvidence)' -count=1`
- `SWARM_TEST_POSTGRES_DSN='host=127.0.0.1 port=5432 user=youmew dbname=postgres sslmode=disable' PGPASSWORD=postgres go test ./internal/runtime/conformance -run 'Test.*(ComputeModule|Deterministic|PlatformSpec|Replay)' -count=1`
- `SWARM_TEST_POSTGRES_DSN='host=127.0.0.1 port=5432 user=youmew dbname=postgres sslmode=disable' PGPASSWORD=postgres go test ./internal/runtime/... ./internal/store/... -count=1`
- `SWARM_CREDENTIALS_FILE=$(mktemp -d)/provider-credentials.json SWARM_TEST_POSTGRES_DSN='host=127.0.0.1 port=5432 user=youmew dbname=postgres sslmode=disable' PGPASSWORD=postgres go test ./...`

Note: the final full-suite command uses an isolated credentials file because local user Claude credentials otherwise make unrelated `cmd/swarm` doctor tests observe a credential-present state.
