### PR TITLE
[agent-e][issue #1797] Add verifier remediation evidence

### DIFF
--- a/cmd/swarm/describe.go
+++ b/cmd/swarm/describe.go
@@ -171,7 +171,19 @@ func writeDescribeText(out io.Writer, view authoringview.View, workspaceBackendD
 	if len(view.Diagnostics) > 0 {
 		fmt.Fprintln(out, "diagnostics:")
 		for _, diagnostic := range view.Diagnostics {
-			fmt.Fprintf(out, "  - [%s] %s %s: %s\n", diagnostic.Severity, diagnostic.CheckID, diagnostic.AuthoredLocation, diagnostic.Message)
+			location := strings.TrimSpace(diagnostic.AuthoredLocation)
+			if location == "" {
+				location = strings.TrimSpace(diagnostic.Location)
+			}
+			rendered := runtimebootverify.FormatTypedDiagnosticFinding(runtimebootverify.TypedDiagnosticFinding{
+				CheckID:     diagnostic.CheckID,
+				Severity:    diagnostic.Severity,
+				Location:    location,
+				Message:     diagnostic.Message,
+				Remediation: diagnostic.Remediation,
+				Evidence:    diagnostic.Evidence,
+			}, false)
+			fmt.Fprintf(out, "  - %s\n", strings.ReplaceAll(rendered, "\n", "\n    "))
 		}
 	}
 }

--- a/cmd/swarm/describe_test.go
+++ b/cmd/swarm/describe_test.go
@@ -52,6 +52,64 @@ func TestDescribeCommandJSONRendersExpandedAuthoringView(t *testing.T) {
 	}
 }
 
+func TestDescribeCommandDiagnosticsCarryRemediationAndEvidence(t *testing.T) {
+	contractsRoot := writeVerifyBootTimerCommandFixture(t, "state:done")
+
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), repoRoot(), []string{
+		"describe",
+		"--contracts", contractsRoot,
+		"--json",
+	}, &stdout, &stderr, defaultRootCommandOptions())
+	if code != 0 {
+		t.Fatalf("describe --json code = %d stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	var output describeCommandOutput
+	if err := json.Unmarshal(stdout.Bytes(), &output); err != nil {
+		t.Fatalf("decode describe json: %v\n%s", err, stdout.String())
+	}
+	if len(output.Diagnostics) == 0 {
+		t.Fatalf("describe diagnostics = %#v, want timer_validation", output.Diagnostics)
+	}
+	var timerDiagnostic *authoringview.DiagnosticView
+	for i := range output.Diagnostics {
+		if output.Diagnostics[i].CheckID == "timer_validation" {
+			timerDiagnostic = &output.Diagnostics[i]
+			break
+		}
+	}
+	if timerDiagnostic == nil {
+		t.Fatalf("describe diagnostics = %#v, want timer_validation", output.Diagnostics)
+	}
+	if strings.TrimSpace(timerDiagnostic.Remediation) == "" {
+		t.Fatalf("timer diagnostic missing remediation: %#v", *timerDiagnostic)
+	}
+	if len(timerDiagnostic.Evidence) == 0 || !strings.Contains(strings.Join(timerDiagnostic.Evidence, "\n"), "cancel_on: state:done") {
+		t.Fatalf("timer diagnostic evidence = %#v, want cancel_on evidence", timerDiagnostic.Evidence)
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	code = executeRootCommandWithOptions(context.Background(), repoRoot(), []string{
+		"describe",
+		"--contracts", contractsRoot,
+	}, &stdout, &stderr, defaultRootCommandOptions())
+	if code != 0 {
+		t.Fatalf("describe code = %d stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	text := stdout.String()
+	for _, want := range []string{
+		"[BLOCKER] timer_validation @",
+		"remediation:",
+		"evidence:",
+		"cancel_on: state:done",
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("describe text missing %q:\n%s", want, text)
+		}
+	}
+}
+
 func TestDescribeCommandRendersDefaultedTemplateInstancePolicies(t *testing.T) {
 	contractsRoot := writeDescribeDefaultedTemplatePolicyContracts(t)
 	var stdout, stderr bytes.Buffer

--- a/cmd/swarm/main.go
+++ b/cmd/swarm/main.go
@@ -1325,10 +1325,12 @@ type verifyCommandResult struct {
 }
 
 type verifyFindingOutput struct {
-	CheckID  string `json:"check_id"`
-	Severity string `json:"severity"`
-	Location string `json:"location"`
-	Message  string `json:"message"`
+	CheckID     string   `json:"check_id"`
+	Severity    string   `json:"severity"`
+	Location    string   `json:"location"`
+	Message     string   `json:"message"`
+	Remediation string   `json:"remediation,omitempty"`
+	Evidence    []string `json:"evidence,omitempty"`
 }
 
 type verifyCommandOptions struct {
@@ -1470,11 +1472,26 @@ func verifyFindingOutputs(findings []runtimebootverify.Finding) []verifyFindingO
 	out := make([]verifyFindingOutput, 0, len(findings))
 	for _, finding := range findings {
 		out = append(out, verifyFindingOutput{
-			CheckID:  strings.TrimSpace(finding.CheckID),
-			Severity: strings.TrimSpace(finding.Severity),
-			Location: strings.TrimSpace(finding.Location),
-			Message:  strings.TrimSpace(finding.Message),
+			CheckID:     strings.TrimSpace(finding.CheckID),
+			Severity:    strings.TrimSpace(finding.Severity),
+			Location:    strings.TrimSpace(finding.Location),
+			Message:     strings.TrimSpace(finding.Message),
+			Remediation: strings.TrimSpace(finding.Remediation),
+			Evidence:    trimmedStringSlice(finding.Evidence),
 		})
+	}
+	return out
+}
+
+func trimmedStringSlice(items []string) []string {
+	if len(items) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(items))
+	for _, item := range items {
+		if item = strings.TrimSpace(item); item != "" {
+			out = append(out, item)
+		}
 	}
 	return out
 }

--- a/cmd/swarm/main_test.go
+++ b/cmd/swarm/main_test.go
@@ -9586,7 +9586,7 @@ func TestRunVerifyCommand_SurfacesLintEvidence(t *testing.T) {
 		t.Fatalf("verify stdout contains advisory diagnostics:\n%s", out)
 	}
 	errText := stderr.String()
-	if !strings.Contains(errText, "INFO: entity_reader_coverage [root] flow root entity_type case declares field untouched with no detected internal reader coverage") {
+	if !strings.Contains(errText, "[INFO] entity_reader_coverage @ root: flow root entity_type case declares field untouched with no detected internal reader coverage") {
 		t.Fatalf("verify stderr missing lint evidence:\n%s", errText)
 	}
 	if strings.Contains(errText, "lint_evidence:") {
@@ -9744,8 +9744,9 @@ func TestRunVerifyCommand_RejectsBootTimerWithCancelOn(t *testing.T) {
 	errText := stderr.String()
 	for _, want := range []string{
 		"verify failed: boot verification failed:",
-		"ERROR: timer_validation",
+		"[BLOCKER] timer_validation @",
 		"start_on boot does not support cancel_on state:done",
+		"remediation:",
 	} {
 		if !strings.Contains(errText, want) {
 			t.Fatalf("verify stderr missing %q:\n%s", want, errText)
@@ -9777,6 +9778,12 @@ func TestRunVerifyCommand_RejectsBootTimerWithCancelOn(t *testing.T) {
 	if got := verifyJSON.Errors[0]; got.CheckID != "timer_validation" || got.Severity != "hard_invalidity" || !strings.Contains(got.Message, "start_on boot does not support cancel_on state:done") {
 		t.Fatalf("verify --json first error = %#v, want structured timer_validation hard invalidity", got)
 	}
+	if strings.TrimSpace(verifyJSON.Errors[0].Remediation) == "" {
+		t.Fatalf("verify --json first error missing remediation: %#v", verifyJSON.Errors[0])
+	}
+	if len(verifyJSON.Errors[0].Evidence) == 0 || !strings.Contains(strings.Join(verifyJSON.Errors[0].Evidence, "\n"), "cancel_on: state:done") {
+		t.Fatalf("verify --json first error evidence = %#v, want timer cancel_on evidence", verifyJSON.Errors[0].Evidence)
+	}
 }
 
 func TestRunVerifyCommand_EscalatedWarningUsesBlockingAnalyzerOutput(t *testing.T) {
@@ -9800,7 +9807,7 @@ func TestRunVerifyCommand_EscalatedWarningUsesBlockingAnalyzerOutput(t *testing.
 	errText := stderr.String()
 	for _, want := range []string{
 		"verify failed: boot verification blocked by policy-escalated findings:",
-		"ERROR: input_pin_wiring",
+		"[BLOCKER] input_pin_wiring @",
 		"no producer path was found in the authored bundle",
 	} {
 		if !strings.Contains(errText, want) {
@@ -10110,7 +10117,7 @@ Use save_entity_field for `+"`business_brief`"+`.
 	errText := stderr.String()
 	for _, want := range []string{
 		"verify failed: boot verification failed:",
-		"ERROR: entity_writer_coverage",
+		"[BLOCKER] entity_writer_coverage @",
 		"business_brief",
 	} {
 		if !strings.Contains(errText, want) {
@@ -10307,7 +10314,7 @@ func TestRunVerifyCommand_WarnsForAccumulateAllWithoutBoundedEscape(t *testing.T
 		t.Fatalf("verify stdout missing success marker:\n%s", out)
 	}
 	errText := stderr.String()
-	if !strings.Contains(errText, "WARN: accumulate_all_bounded_escape") ||
+	if !strings.Contains(errText, "[WARN] accumulate_all_bounded_escape @") ||
 		!strings.Contains(errText, "without a bounded timeout escape") {
 		t.Fatalf("verify stderr missing accumulator bounded-escape warning:\n%s", errText)
 	}
@@ -10333,8 +10340,9 @@ func TestRunVerifyCommand_FailsForAccumulateTimeoutWithoutTimeoutMS(t *testing.T
 	errText := stderr.String()
 	for _, want := range []string{
 		"verify failed: boot verification failed:",
-		"ERROR: accumulator_timeout_requires_timeout_ms",
+		"[BLOCKER] accumulator_timeout_requires_timeout_ms @",
 		"without positive timeout_ms",
+		"remediation:",
 	} {
 		if !strings.Contains(errText, want) {
 			t.Fatalf("verify stderr missing %q:\n%s", want, errText)
@@ -10362,8 +10370,9 @@ func TestRunVerifyCommand_FailsForAccumulatorInputWithoutProducerPath(t *testing
 	errText := stderr.String()
 	for _, want := range []string{
 		"verify failed: boot verification failed:",
-		"ERROR: accumulator_input_producer_path",
+		"[BLOCKER] accumulator_input_producer_path @",
 		"no accepted producer/source path",
+		"remediation:",
 	} {
 		if !strings.Contains(errText, want) {
 			t.Fatalf("verify stderr missing %q:\n%s", want, errText)

--- a/internal/apispec/cli_topology_spec_test.go
+++ b/internal/apispec/cli_topology_spec_test.go
@@ -89,10 +89,23 @@ func TestCLIVerifyJSONShapeIncludesStructuredFailureFindings(t *testing.T) {
 		"severity",
 		"location",
 		"message",
+		"remediation",
+		"evidence",
 		"ok: false",
 		"human stderr",
 	} {
 		assertScalarContains(t, jsonShape, want)
+	}
+
+	humanStreams := mustMappingValue(t, verify, "human_text_streams")
+	for _, want := range []string{
+		"[BLOCKER]",
+		"[WARN]",
+		"[INFO]",
+		"ERROR:",
+		"WARNING:",
+	} {
+		assertScalarContains(t, mustMappingValue(t, humanStreams, "stderr"), want)
 	}
 }
 

--- a/internal/apispec/platform_spec_flow_instance_authoring_test.go
+++ b/internal/apispec/platform_spec_flow_instance_authoring_test.go
@@ -255,7 +255,9 @@ func TestPlatformSpecFlowInstanceAuthoringSourceAuthority(t *testing.T) {
 	assertScalarContains(t, mustMappingValue(t, expandMinimize, "canonical_code_owner"), "internal/runtime/authoringview.Build")
 	assertScalarContains(t, mustMappingValue(t, expandMinimize, "rule"), "projection over existing semantic owners")
 	assertScalarContains(t, mustMappingValue(t, expandMinimize, "rule"), "without becoming a new semantic owner")
-	assertScalarContains(t, mustMappingValue(t, expandMinimize, "source_location_rule"), "check_id plus authored YAML file")
+	assertScalarContains(t, mustMappingValue(t, expandMinimize, "source_location_rule"), "check_id")
+	assertScalarContains(t, mustMappingValue(t, expandMinimize, "source_location_rule"), "authored YAML file")
+	assertScalarContains(t, mustMappingValue(t, expandMinimize, "source_location_rule"), "remediation/evidence")
 	if !sequenceContainsScalar(mustMappingValue(t, expandMinimize, "non_authoritative_paths"), "generated expanded YAML as merge authority") {
 		t.Fatal("expand_minimize_tooling must keep generated expanded YAML non-authoritative")
 	}

--- a/internal/builder/api.go
+++ b/internal/builder/api.go
@@ -101,13 +101,15 @@ type WSEventFrame struct {
 }
 
 type ValidationIssue struct {
-	CheckID    string `json:"check_id"`
-	Severity   string `json:"severity"`
-	Message    string `json:"message"`
-	FlowPath   string `json:"flow_path,omitempty"`
-	NodeID     string `json:"node_id,omitempty"`
-	AgentID    string `json:"agent_id,omitempty"`
-	Suggestion string `json:"suggestion,omitempty"`
+	CheckID     string   `json:"check_id"`
+	Severity    string   `json:"severity"`
+	Message     string   `json:"message"`
+	Remediation string   `json:"remediation,omitempty"`
+	Evidence    []string `json:"evidence,omitempty"`
+	FlowPath    string   `json:"flow_path,omitempty"`
+	NodeID      string   `json:"node_id,omitempty"`
+	AgentID     string   `json:"agent_id,omitempty"`
+	Suggestion  string   `json:"suggestion,omitempty"`
 }
 
 type ValidationSummary struct {

--- a/internal/builder/handler_state.go
+++ b/internal/builder/handler_state.go
@@ -66,7 +66,7 @@ func (h *handler) runFullValidation(_ context.Context) ValidationResult {
 	})
 	for _, finding := range report.Findings {
 		issue := validationIssueFromFinding(finding)
-		if finding.Severity == "warning" {
+		if validationFindingIsWarning(finding) {
 			result.Warnings = append(result.Warnings, issue)
 			continue
 		}
@@ -89,10 +89,14 @@ func validationIssueFromFinding(finding runtimebootverify.Finding) ValidationIss
 		Remediation: finding.Remediation,
 		Evidence:    append([]string(nil), finding.Evidence...),
 	}
-	if finding.CheckID == "credential_key_exists" && finding.Severity == "warning" {
+	if finding.CheckID == "credential_key_exists" && validationFindingIsWarning(finding) {
 		issue.Suggestion = "set the secret with swarm secrets set before executing dependent tools"
 	}
 	return issue
+}
+
+func validationFindingIsWarning(finding runtimebootverify.Finding) bool {
+	return finding.Severity == runtimebootverify.SeveritySemanticDriftWarn
 }
 
 func (h *handler) legacyBuilderListEntities(ctx context.Context) ([]store.OperatorEntitySummary, error) {

--- a/internal/builder/handler_state.go
+++ b/internal/builder/handler_state.go
@@ -65,14 +65,7 @@ func (h *handler) runFullValidation(_ context.Context) ValidationResult {
 		CheckMCPReachable: true,
 	})
 	for _, finding := range report.Findings {
-		issue := ValidationIssue{
-			CheckID:  finding.CheckID,
-			Severity: finding.Severity,
-			Message:  finding.Message,
-		}
-		if finding.CheckID == "credential_key_exists" && finding.Severity == "warning" {
-			issue.Suggestion = "set the secret with swarm secrets set before executing dependent tools"
-		}
+		issue := validationIssueFromFinding(finding)
 		if finding.Severity == "warning" {
 			result.Warnings = append(result.Warnings, issue)
 			continue
@@ -86,6 +79,20 @@ func (h *handler) runFullValidation(_ context.Context) ValidationResult {
 	result.Summary.Warnings = len(result.Warnings)
 	result.Summary.DurationMS = time.Since(startedAt).Milliseconds()
 	return result
+}
+
+func validationIssueFromFinding(finding runtimebootverify.Finding) ValidationIssue {
+	issue := ValidationIssue{
+		CheckID:     finding.CheckID,
+		Severity:    finding.Severity,
+		Message:     finding.Message,
+		Remediation: finding.Remediation,
+		Evidence:    append([]string(nil), finding.Evidence...),
+	}
+	if finding.CheckID == "credential_key_exists" && finding.Severity == "warning" {
+		issue.Suggestion = "set the secret with swarm secrets set before executing dependent tools"
+	}
+	return issue
 }
 
 func (h *handler) legacyBuilderListEntities(ctx context.Context) ([]store.OperatorEntitySummary, error) {

--- a/internal/builder/handler_state_test.go
+++ b/internal/builder/handler_state_test.go
@@ -75,14 +75,26 @@ func TestValidationIssueFromFindingCopiesRemediationAndEvidence(t *testing.T) {
 	}
 }
 
-func TestValidationIssueFromFindingPreservesCredentialSuggestion(t *testing.T) {
-	issue := validationIssueFromFinding(runtimebootverify.Finding{
+func TestValidationIssueFromFindingPreservesCredentialSuggestionForNormalizedWarning(t *testing.T) {
+	report := runtimebootverify.Report{}
+	report.Add(runtimebootverify.Finding{
 		CheckID:     "credential_key_exists",
 		Severity:    "warning",
 		Message:     "credential missing",
 		Remediation: "store the credential",
 	})
+	if len(report.Findings) != 1 {
+		t.Fatalf("findings = %#v, want one normalized finding", report.Findings)
+	}
+	finding := report.Findings[0]
+	if finding.Severity != runtimebootverify.SeveritySemanticDriftWarn {
+		t.Fatalf("severity = %q, want normalized warning severity", finding.Severity)
+	}
+	if !validationFindingIsWarning(finding) {
+		t.Fatalf("normalized warning was not classified as Builder warning: %#v", finding)
+	}
 
+	issue := validationIssueFromFinding(finding)
 	if issue.Remediation != "store the credential" {
 		t.Fatalf("remediation = %q", issue.Remediation)
 	}

--- a/internal/builder/handler_state_test.go
+++ b/internal/builder/handler_state_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"testing"
+
+	runtimebootverify "github.com/division-sh/swarm/internal/runtime/bootverify"
 )
 
 type projectControlStub struct {
@@ -44,5 +46,47 @@ func TestHandlerHealthSnapshot_ProjectsAndErrors(t *testing.T) {
 	}
 	if snapshot.Version != "builder-test" {
 		t.Fatalf("version = %q", snapshot.Version)
+	}
+}
+
+func TestValidationIssueFromFindingCopiesRemediationAndEvidence(t *testing.T) {
+	finding := runtimebootverify.Finding{
+		CheckID:     "timer_validation",
+		Severity:    runtimebootverify.SeverityHardInvalidity,
+		Message:     "timer reminder start_on boot does not support cancel_on state:done",
+		Remediation: "remove cancel_on from boot timer",
+		Evidence:    []string{"timer: reminder", "cancel_on: state:done"},
+	}
+
+	issue := validationIssueFromFinding(finding)
+	if issue.CheckID != finding.CheckID || issue.Severity != finding.Severity || issue.Message != finding.Message {
+		t.Fatalf("issue = %#v, want core fields copied from %#v", issue, finding)
+	}
+	if issue.Remediation != finding.Remediation {
+		t.Fatalf("remediation = %q, want %q", issue.Remediation, finding.Remediation)
+	}
+	if len(issue.Evidence) != 2 || issue.Evidence[0] != "timer: reminder" || issue.Evidence[1] != "cancel_on: state:done" {
+		t.Fatalf("evidence = %#v", issue.Evidence)
+	}
+
+	finding.Evidence[0] = "mutated"
+	if issue.Evidence[0] != "timer: reminder" {
+		t.Fatalf("issue evidence aliases finding evidence: %#v", issue.Evidence)
+	}
+}
+
+func TestValidationIssueFromFindingPreservesCredentialSuggestion(t *testing.T) {
+	issue := validationIssueFromFinding(runtimebootverify.Finding{
+		CheckID:     "credential_key_exists",
+		Severity:    "warning",
+		Message:     "credential missing",
+		Remediation: "store the credential",
+	})
+
+	if issue.Remediation != "store the credential" {
+		t.Fatalf("remediation = %q", issue.Remediation)
+	}
+	if issue.Suggestion == "" {
+		t.Fatalf("suggestion missing for credential compatibility: %#v", issue)
 	}
 }

--- a/internal/runtime/authoringview/view.go
+++ b/internal/runtime/authoringview/view.go
@@ -231,11 +231,13 @@ type ContainedOperationView struct {
 }
 
 type DiagnosticView struct {
-	CheckID          string `json:"check_id"`
-	Severity         string `json:"severity"`
-	Location         string `json:"location,omitempty"`
-	AuthoredLocation string `json:"authored_location,omitempty"`
-	Message          string `json:"message"`
+	CheckID          string   `json:"check_id"`
+	Severity         string   `json:"severity"`
+	Location         string   `json:"location,omitempty"`
+	AuthoredLocation string   `json:"authored_location,omitempty"`
+	Message          string   `json:"message"`
+	Remediation      string   `json:"remediation,omitempty"`
+	Evidence         []string `json:"evidence,omitempty"`
 }
 
 type BuildOptions struct {
@@ -758,7 +760,22 @@ func buildDiagnostics(bundle *runtimecontracts.WorkflowContractBundle, report *r
 			Location:         strings.TrimSpace(finding.Location),
 			AuthoredLocation: authoredLocationForFinding(bundle, finding),
 			Message:          strings.TrimSpace(finding.Message),
+			Remediation:      strings.TrimSpace(finding.Remediation),
+			Evidence:         trimDiagnosticEvidence(finding.Evidence),
 		})
+	}
+	return out
+}
+
+func trimDiagnosticEvidence(items []string) []string {
+	if len(items) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(items))
+	for _, item := range items {
+		if item = strings.TrimSpace(item); item != "" {
+			out = append(out, item)
+		}
 	}
 	return out
 }

--- a/internal/runtime/authoringview/view_test.go
+++ b/internal/runtime/authoringview/view_test.go
@@ -69,6 +69,30 @@ func TestBuildShowsTemplateInstanceRouteKeysAndCarries(t *testing.T) {
 	}
 }
 
+func TestBuildDiagnosticsPreservesRemediationAndEvidence(t *testing.T) {
+	report := runtimebootverify.Report{}
+	report.Add(runtimebootverify.Finding{
+		CheckID:     "timer_validation",
+		Severity:    runtimebootverify.SeverityHardInvalidity,
+		Location:    "reminder",
+		Message:     "timer reminder start_on boot does not support cancel_on state:done",
+		Remediation: "remove cancel_on from boot timer",
+		Evidence:    []string{" timer: reminder ", "", "cancel_on: state:done"},
+	})
+
+	diagnostics := buildDiagnostics(nil, &report)
+	if len(diagnostics) != 1 {
+		t.Fatalf("diagnostics = %#v, want one", diagnostics)
+	}
+	got := diagnostics[0]
+	if got.Remediation != "remove cancel_on from boot timer" {
+		t.Fatalf("remediation = %q", got.Remediation)
+	}
+	if len(got.Evidence) != 2 || got.Evidence[0] != "timer: reminder" || got.Evidence[1] != "cancel_on: state:done" {
+		t.Fatalf("evidence = %#v", got.Evidence)
+	}
+}
+
 func TestBuildShowsDefaultedTemplateInstancePolicies(t *testing.T) {
 	source := loadDefaultedTemplatePolicySource(t)
 	report := runtimebootverify.Run(context.Background(), source, runtimebootverify.Options{})

--- a/internal/runtime/bootverify/report.go
+++ b/internal/runtime/bootverify/report.go
@@ -13,10 +13,12 @@ import (
 )
 
 type Finding struct {
-	CheckID  string
-	Severity string
-	Message  string
-	Location string
+	CheckID     string
+	Severity    string
+	Message     string
+	Location    string
+	Remediation string
+	Evidence    []string
 }
 
 const (
@@ -29,10 +31,121 @@ const (
 )
 
 const (
-	FindingSurfaceLevelError = "ERROR"
-	FindingSurfaceLevelWarn  = "WARN"
-	FindingSurfaceLevelInfo  = "INFO"
+	FindingSurfaceLevelBlocker = "BLOCKER"
+	FindingSurfaceLevelWarn    = "WARN"
+	FindingSurfaceLevelInfo    = "INFO"
 )
+
+var stableHardInvalidityRemediation = map[string]string{
+	"agent_permission_validation":             "Grant the required agent permission or remove the unauthorized tool/action from the contract.",
+	"condition_expression_validation":         "Fix the condition expression so it references declared fields and uses supported CEL syntax.",
+	"data_accumulation_expression_validation": "Fix the data_accumulation expression so it references declared fields and uses supported CEL syntax.",
+	"emit_field_expression_validation":        "Fix the emit field expression so it references declared fields and uses supported CEL syntax.",
+	"entity_write_target_compliance":          "Update the entity write target to a declared writable entity field or remove the invalid write.",
+	"event_metadata_authority":                "Move platform-owned event metadata out of authored business payload declarations.",
+	"flow_boundary_create_entity_validation":  "Fix the cross-flow create_entity declaration so it preserves the receiving flow boundary.",
+	"flow_data_access_validation":             "Use the supported flow data access form for the referenced field or remove the unsupported access.",
+	"flow_package_dependency_binding":         "Declare the required imported package binding or remove the unresolved dependency reference.",
+	"flow_package_import_completeness":        "Complete the imported package dependency binding or remove the incomplete import.",
+	"gate_schema_validation":                  "Fix the gate declaration so it uses supported gate fields and value types.",
+	"generated_tool_schema_closure":           "Fix the generated tool schema inputs/outputs so they close over declared contract types.",
+	"handler_field_compliance":                "Move the unsupported handler field to its promoted location or remove it.",
+	"impl.platform_metadata_validation":       "Remove authored declarations that conflict with platform-owned metadata.",
+	"invalid_field_detection":                 "Remove unsupported fields or replace them with the promoted contract field supported by the spec.",
+	"managed_credential_state":                "Configure the required managed credential or remove the dependency that requires it.",
+	"missing_external_select_entity":          "Add an explicit select_entity/select_or_create_entity for the external input or make the event topology in-flow.",
+	"native_tools_valid":                      "Fix the native tool declaration so it references a supported runtime tool surface.",
+	"payload_field_coverage":                  "Populate every required emitted payload field or make the target event schema optional where appropriate.",
+	"platform_namespace_violation":            "Rename authored business fields away from platform-reserved namespace roots.",
+	"platform_version_compatibility":          "Update the contract platform_version range or run with a compatible Swarm platform version.",
+	"policy_conflict_detection":               "Resolve the conflicting policy declarations so only one authoritative value remains.",
+	"primary_entity_validation":               "Declare a valid primary entity or remove the stateful surface that requires one.",
+	"prompt_exists":                           "Add the referenced prompt file or update the agent prompt_ref.",
+	"redundant_in_topology_select_entity":     "Remove redundant select_entity/select_or_create_entity from an in-topology handler.",
+	"reply_lineage_missing":                   "Add the required reply lineage metadata or remove the reply-mode handler contract.",
+	"required_agents_match":                   "Update required agent declarations so subscriptions and emitted events match the contract topology.",
+	"required_mcp_tool_availability":          "Expose the required MCP tool from the configured server or update the agent tool requirement.",
+	"select_entity_validation":                "Fix the select_entity/select_or_create_entity declaration so it uses supported source and target fields.",
+	"single_node_per_event":                   "Ensure only one system node owns the exact event handler or split the event ownership.",
+	"singleton_coordinator_validation":        "Fix the singleton coordinator declaration so it names supported contained state fields.",
+	"state_machine_coherence":                 "Fix the state machine declarations so initial, terminal, and transition states are declared consistently.",
+	"template_instance_validation":            "Fix the template instance declaration so instance keys and policies are valid.",
+	"timer_validation":                        "Use only supported timer start_on/cancel_on forms and ensure referenced states/events are declared and reachable.",
+	"transition_ownership_validation":         "Move the transition owner to the handler that owns the triggering event or change the transition.",
+	"transition_reference_validation":         "Fix transition references so all events and states are declared and reachable.",
+	"workflow_contract_validation":            "Fix the contract source/load error named by the message, then rerun `swarm verify`.",
+	"workspace_class_exists":                  "Declare the referenced workspace class or update the agent workspace_class.",
+	"write_pin_ownership_validation":          "Fix write pin ownership so the writer and target field share the supported owner boundary.",
+}
+
+var routingRemediationSplitCheckIDs = map[string]struct{}{
+	"composition_connect_validation":         {},
+	"connect_key_adapter_cardinality":        {},
+	"connect_key_adapter_duplicate_source":   {},
+	"connect_key_adapter_duplicate_target":   {},
+	"connect_key_adapter_invalid":            {},
+	"connect_key_adapter_missing_source":     {},
+	"connect_key_adapter_missing_target":     {},
+	"connect_key_adapter_partial":            {},
+	"connect_key_adapter_source_missing":     {},
+	"connect_key_adapter_target_missing":     {},
+	"connect_key_adapter_unsupported":        {},
+	"connect_map_unknown_address_key":        {},
+	"cross_flow_pin_ambiguity_validation":    {},
+	"flow_package_pin_bind_alias_validation": {},
+	"input_pin_wiring":                       {},
+	"instance_key_mismatch":                  {},
+	"key_types_incompatible":                 {},
+	"output_carries_address_key":             {},
+	"output_carries_instance_key":            {},
+	"output_key_missing":                     {},
+	"pin_target_resolution":                  {},
+	"producer_flow_missing":                  {},
+	"producer_output_pin_missing":            {},
+	"producer_reference_invalid":             {},
+	"receiver_address_rule_invalid":          {},
+	"receiver_address_rule_missing":          {},
+	"receiver_flow_missing":                  {},
+	"receiver_input_pin_missing":             {},
+	"receiver_instance_key_invalid":          {},
+	"receiver_instance_key_unavailable":      {},
+	"receiver_reference_invalid":             {},
+	"receiver_root_unsupported":              {},
+	"receiver_route_key_missing":             {},
+}
+
+type FindingOption func(*Finding)
+
+func WithRemediation(remediation string) FindingOption {
+	return func(f *Finding) {
+		f.Remediation = remediation
+	}
+}
+
+func WithEvidence(evidence ...string) FindingOption {
+	return func(f *Finding) {
+		f.Evidence = append(f.Evidence, evidence...)
+	}
+}
+
+func NewFinding(checkID, severity, location, message string, opts ...FindingOption) Finding {
+	f := Finding{
+		CheckID:  checkID,
+		Severity: severity,
+		Location: location,
+		Message:  message,
+	}
+	for _, opt := range opts {
+		if opt != nil {
+			opt(&f)
+		}
+	}
+	return f
+}
+
+func NewHardInvalidityFinding(checkID, location, message, remediation string, evidence ...string) Finding {
+	return NewFinding(checkID, SeverityHardInvalidity, location, message, WithRemediation(remediation), WithEvidence(evidence...))
+}
 
 type Report struct {
 	Findings []Finding
@@ -82,6 +195,11 @@ func (r *Report) Add(f Finding) {
 	f.Severity = normalizeFindingSeverity(f.Severity)
 	f.Message = strings.TrimSpace(f.Message)
 	f.Location = strings.TrimSpace(f.Location)
+	f.Remediation = strings.TrimSpace(f.Remediation)
+	f.Evidence = normalizeFindingEvidence(f.Evidence)
+	if findingRequiresRemediation(f) && f.Remediation == "" {
+		f.Remediation = defaultRemediationForFinding(f)
+	}
 	r.Findings = append(r.Findings, f)
 }
 
@@ -199,27 +317,95 @@ func FindingSurfaceLevel(f Finding, blocking bool) string {
 
 func SurfaceLevelForSeverity(severity string, blocking bool) string {
 	if blocking {
-		return FindingSurfaceLevelError
+		return FindingSurfaceLevelBlocker
 	}
 	switch normalizeFindingSeverity(severity) {
 	case SeverityHardInvalidity:
-		return FindingSurfaceLevelError
+		return FindingSurfaceLevelBlocker
 	case SeveritySemanticDriftWarn:
 		return FindingSurfaceLevelWarn
 	case SeverityAuditAnalysis, SeverityLintEvidence:
 		return FindingSurfaceLevelInfo
 	default:
-		return FindingSurfaceLevelError
+		return FindingSurfaceLevelBlocker
 	}
 }
 
 func FormatSurfaceFinding(f Finding, blocking bool) string {
-	return fmt.Sprintf("%s: %s [%s] %s",
-		FindingSurfaceLevel(f, blocking),
-		strings.TrimSpace(f.CheckID),
-		strings.TrimSpace(f.Location),
+	return FormatTypedDiagnosticFinding(TypedDiagnosticFinding{
+		CheckID:     f.CheckID,
+		Severity:    f.Severity,
+		Location:    f.Location,
+		Message:     f.Message,
+		Remediation: f.Remediation,
+		Evidence:    f.Evidence,
+	}, blocking)
+}
+
+type TypedDiagnosticFinding struct {
+	CheckID     string
+	Severity    string
+	Location    string
+	Message     string
+	Remediation string
+	Evidence    []string
+}
+
+func FormatTypedDiagnosticFinding(f TypedDiagnosticFinding, blocking bool) string {
+	checkID := strings.TrimSpace(f.CheckID)
+	if checkID == "" {
+		checkID = "workflow_contract_validation"
+	}
+	location := strings.TrimSpace(f.Location)
+	if location == "" {
+		location = "global"
+	}
+	var b strings.Builder
+	fmt.Fprintf(&b, "[%s] %s @ %s: %s",
+		SurfaceLevelForSeverity(f.Severity, blocking),
+		checkID,
+		location,
 		strings.TrimSpace(f.Message),
 	)
+	if remediation := strings.TrimSpace(f.Remediation); remediation != "" {
+		fmt.Fprintf(&b, "\n  remediation: %s", remediation)
+	}
+	evidence := normalizeFindingEvidence(f.Evidence)
+	if len(evidence) > 0 {
+		b.WriteString("\n  evidence:")
+		for _, item := range evidence {
+			fmt.Fprintf(&b, "\n    - %s", item)
+		}
+	}
+	return b.String()
+}
+
+func normalizeFindingEvidence(items []string) []string {
+	if len(items) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(items))
+	for _, item := range items {
+		if item = strings.TrimSpace(item); item != "" {
+			out = append(out, item)
+		}
+	}
+	return out
+}
+
+func findingRequiresRemediation(f Finding) bool {
+	return normalizeFindingSeverity(f.Severity) == SeverityHardInvalidity
+}
+
+func defaultRemediationForFinding(f Finding) string {
+	checkID := strings.TrimSpace(f.CheckID)
+	if _, split := routingRemediationSplitCheckIDs[checkID]; split {
+		return "Fix or remove the invalid routing declaration identified by this finding, then rerun `swarm verify`."
+	}
+	if remediation := stableHardInvalidityRemediation[checkID]; remediation != "" {
+		return remediation
+	}
+	return "Fix or remove the invalid contract declaration identified by this finding, then rerun `swarm verify`."
 }
 
 func locationFromMessage(message string) string {

--- a/internal/runtime/bootverify/report_test.go
+++ b/internal/runtime/bootverify/report_test.go
@@ -32,6 +32,108 @@ func TestRun_MapsMissingToolToToolResolutionWarning(t *testing.T) {
 	}
 }
 
+func TestReportAddBackfillsHardInvalidityRemediationAndEvidence(t *testing.T) {
+	var report Report
+	report.Add(Finding{
+		CheckID:  "timer_validation",
+		Severity: SeverityHardInvalidity,
+		Location: "node.reminder",
+		Message:  "start_on boot does not support cancel_on state:done",
+		Evidence: []string{"  timer id: reminder  ", "", "cancel_on: state:done"},
+	})
+
+	errors := report.Errors()
+	if len(errors) != 1 {
+		t.Fatalf("errors = %#v, want one hard invalidity", errors)
+	}
+	got := errors[0]
+	if got.Remediation == "" {
+		t.Fatalf("remediation was not backfilled: %#v", got)
+	}
+	if !strings.Contains(got.Remediation, "timer") {
+		t.Fatalf("remediation = %q, want timer-specific stable remediation", got.Remediation)
+	}
+	if len(got.Evidence) != 2 || got.Evidence[0] != "timer id: reminder" || got.Evidence[1] != "cancel_on: state:done" {
+		t.Fatalf("evidence = %#v, want trimmed non-empty evidence", got.Evidence)
+	}
+}
+
+func TestReportAddUsesGenericRemediationForRoutingSplitChecks(t *testing.T) {
+	var report Report
+	report.Add(Finding{
+		CheckID:  "pin_target_resolution",
+		Severity: SeverityHardInvalidity,
+		Location: "producer",
+		Message:  "pin target is unresolved",
+	})
+
+	errors := report.Errors()
+	if len(errors) != 1 {
+		t.Fatalf("errors = %#v, want one hard invalidity", errors)
+	}
+	got := errors[0].Remediation
+	if got != "Fix or remove the invalid routing declaration identified by this finding, then rerun `swarm verify`." {
+		t.Fatalf("remediation = %q, want generic routing split remediation", got)
+	}
+}
+
+func TestNewHardInvalidityFindingCarriesRequiredActionFields(t *testing.T) {
+	finding := NewHardInvalidityFinding(
+		"workflow_contract_validation",
+		"global",
+		"semantic source is not configured",
+		"fix the selected contract source",
+		"contracts path: /tmp/missing",
+	)
+
+	if finding.Severity != SeverityHardInvalidity {
+		t.Fatalf("severity = %q, want %q", finding.Severity, SeverityHardInvalidity)
+	}
+	if finding.Remediation != "fix the selected contract source" {
+		t.Fatalf("remediation = %q", finding.Remediation)
+	}
+	if len(finding.Evidence) != 1 || finding.Evidence[0] != "contracts path: /tmp/missing" {
+		t.Fatalf("evidence = %#v", finding.Evidence)
+	}
+}
+
+func TestFormatSurfaceFindingUsesTypedDiagnosticRendering(t *testing.T) {
+	warning := Finding{
+		CheckID:     "input_pin_wiring",
+		Severity:    SeveritySemanticDriftWarn,
+		Location:    "flow.items",
+		Message:     "no producer path was found in the authored bundle",
+		Remediation: "connect a producer or mark the event external",
+		Evidence:    []string{"pin: receive"},
+	}
+
+	rendered := FormatSurfaceFinding(warning, false)
+	for _, want := range []string{
+		"[WARN] input_pin_wiring @ flow.items: no producer path was found in the authored bundle",
+		"  remediation: connect a producer or mark the event external",
+		"  evidence:\n    - pin: receive",
+	} {
+		if !strings.Contains(rendered, want) {
+			t.Fatalf("rendered warning missing %q:\n%s", want, rendered)
+		}
+	}
+
+	blocking := FormatSurfaceFinding(warning, true)
+	if !strings.HasPrefix(blocking, "[BLOCKER] input_pin_wiring @ flow.items:") {
+		t.Fatalf("blocking warning rendered as %q, want BLOCKER tag", blocking)
+	}
+
+	info := FormatSurfaceFinding(Finding{
+		CheckID:  "entity_reader_coverage",
+		Severity: SeverityLintEvidence,
+		Location: "root",
+		Message:  "field has no internal reader coverage",
+	}, false)
+	if !strings.HasPrefix(info, "[INFO] entity_reader_coverage @ root:") {
+		t.Fatalf("info rendered as %q, want INFO tag", info)
+	}
+}
+
 func TestRun_DoesNotWarnForBuiltinRuntimeToolReference(t *testing.T) {
 	bundle := &runtimecontracts.WorkflowContractBundle{}
 	bundle.Platform.Platform.Name = "swarm"

--- a/internal/runtime/bootverify/workflow_timer_checks.go
+++ b/internal/runtime/bootverify/workflow_timer_checks.go
@@ -75,6 +75,11 @@ func (c *checkerContext) timerValidation() []Finding {
 				Severity: "error",
 				Message:  fmt.Sprintf("timer %s start_on boot does not support cancel_on %s", timer.ID, cancelTrigger.String()),
 				Location: strings.TrimSpace(timer.ID),
+				Evidence: []string{
+					fmt.Sprintf("timer: %s", strings.TrimSpace(timer.ID)),
+					fmt.Sprintf("start_on: %s", strings.TrimSpace(timer.StartOn)),
+					fmt.Sprintf("cancel_on: %s", strings.TrimSpace(timer.CancelOn)),
+				},
 			})
 		} else {
 			c.validateTimerTrigger(timer, "cancel_on", cancelTrigger)

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -5716,13 +5716,20 @@ engine:
       description: Analyzer finding severity and supported-surface fatality are separate concepts. A finding keeps its
         canonical severity for JSON/scriptable consumers even when a strict policy makes the current surface block.
       strict_warning_escalation: When strict startup or verify warning escalation is enabled, warning-level analyzer findings
-        may block startup or `swarm verify`. Human-readable output must render those findings as blocking/error-level surface
+        may block startup or `swarm verify`. Human-readable typed diagnostic lists must render those findings as blocking surface
         failures, not as non-fatal warnings.
       text_rendering:
-        error_or_blocking: Human text lines for hard invalidities, errors, and policy-escalated warning findings use an
-          `ERROR:` prefix.
-        non_blocking_warning: Human text lines for non-blocking warning-level findings use a `WARN:` prefix.
-        informational: Human text lines for audit/informational lint evidence use an `INFO:` prefix.
+        typed_finding_list: >-
+          Human text lines for typed analyzer finding lists render `[BLOCKER] check_id @ location: message`,
+          `[WARN] check_id @ location: message`, or `[INFO] check_id @ location: message`. `remediation:` renders on an
+          indented continuation line when present. `evidence:` renders only when present and useful.
+        command_outcome_failures: >-
+          Single command-outcome failures that are not typed analyzer finding lists continue to use
+          the CLI command-outcome prefixes such as `ERROR:` or `WARNING:`.
+        error_or_blocking: Hard invalidities, errors, and policy-escalated warning findings in typed diagnostic lists use
+          `[BLOCKER]`.
+        non_blocking_warning: Non-blocking warning-level findings in typed diagnostic lists use `[WARN]`.
+        informational: Audit/informational lint evidence in typed diagnostic lists uses `[INFO]`.
       stream_contract:
         stdout: Successful load-bearing command result only, such as `verify ok` for human output, the single JSON document
           for `--json`, or `ok` for `--quiet`.
@@ -5730,7 +5737,9 @@ engine:
     check_count: 43 primary checks plus 3 supplemental checks
     implementation_notes:
       framework: Each check is a named function that receives the loaded contract bundle and returns a list of findings. Each
-        finding has the check ID, severity, message, and location (flow, node, agent, or event name). The boot sequence runs
+        finding has the check ID, severity, message, location (flow, node, agent, or event name), optional evidence, and
+        optional remediation. Hard-invalidity/error findings must carry remediation by construction or through the canonical
+        report normalization path, except for explicitly split/gate-recorded unsettled remediation language. The boot sequence runs
         all checks after contract loading and before starting nodes/agents.
       always_on: All checks run on every boot. There is no mechanism to disable individual checks. Acknowledged warnings
         (builder feature) are a UI concern, not a runtime concern.
@@ -7307,9 +7316,10 @@ flow_model:
           and retired static multi-entity diagnostics without becoming a new
           semantic owner or reimplementing verifier/runtime decisions.
         source_location_rule: >
-          Diagnostics in the expanded view must carry check_id plus authored
-          YAML file or other stable authored location derived from contract
-          bundle source metadata.
+          Diagnostics in the expanded view must carry check_id, message,
+          remediation/evidence when available from the verifier finding owner,
+          plus authored YAML file or other stable authored location derived from
+          contract bundle source metadata.
         non_authoritative_paths:
         - CLI-local verifier decisions
         - API-local verifier decisions
@@ -14064,11 +14074,12 @@ cli_specification:
               json_shape: >
                 object with ok, contracts, workspace_backend, errors, warnings, and lint_evidence. `errors`, `warnings`,
                 and `lint_evidence` are arrays of structured boot verification findings with canonical `check_id`,
-                `severity`, `location`, and `message` fields. `--json` renders this same object for structured boot
+                `severity`, `location`, and `message` fields plus optional additive `remediation` and `evidence` fields.
+                Existing fields are stable and MUST NOT be renamed; `message` remains the problem text. `--json` renders this same object for structured boot
                 verification failures with `ok: false` instead of requiring consumers to parse human stderr.
               human_text_streams:
                 stdout: "successful load-bearing `verify ok: contracts=...` result only"
-                stderr: "analyzer diagnostics and advisory findings, rendered with the boot verification surface severity prefixes `ERROR:`, `WARN:`, or `INFO:`"
+                stderr: "analyzer diagnostics and advisory findings rendered as typed diagnostic lists with `[BLOCKER]`, `[WARN]`, or `[INFO]`; single command-outcome failures still use `ERROR:`/`WARNING:`"
               quiet_values:
               - ok
             health:


### PR DESCRIPTION
## Summary

- Add `remediation` and optional `evidence` to the canonical `runtimebootverify.Finding` model and preserve them through `Report.Add`.
- Render typed verifier/boot diagnostics as `[BLOCKER]`, `[WARN]`, and `[INFO]`, with indented remediation/evidence details.
- Project the new canonical fields through `swarm verify --json`, workflow validation formatting, `swarm describe` / `authoringview.DiagnosticView`, and Builder `ValidationIssue` while preserving existing public fields and Builder `suggestion` compatibility.
- Update `platform-spec.yaml` and apispec tests for the additive verifier JSON contract and typed diagnostic rendering.

Closes #1797
Part of #1790
Related to #1712, #1746, #1786

## Governing Context

- Approved #1797 gate: `verifier.typed_finding_actionability_contract_public_projection_slice`.
- `platform-spec.yaml#engine.boot_verification.severity_behavior` and `surface_fatality`.
- `platform-spec.yaml#cli_specification.foundations.output_contract.command_support.implemented_output_mode_first_slice.consumers.verify`.
- `platform-spec.yaml#flow_model.flow_instance_authoring.analyzer.expand_minimize_tooling`.

## Semantic Migration

- New canonical owner: `internal/runtime/bootverify.Finding`, `Report.Add`, and typed diagnostic rendering helpers in `internal/runtime/bootverify/report.go`.
- Old non-authoritative paths now invalid/stale: verifier-originated remediation only embedded in `message`, typed verifier lists rendered with `ERROR:` / `WARN:` / `INFO:`, and direct `runtimebootverify.Finding` projections that omitted remediation/evidence.
- Production/direct projection paths checked and moved: `cmd/swarm verify`, `internal/runtime/workflow_validation.go`, `cmd/swarm describe` / `internal/runtime/authoringview`, and `internal/builder.ValidationIssue`.
- Migration completeness: complete for the approved direct-projection slice. True source maps remain split to #1746; routing-specific final remediation prose remains split to #1786 and uses only generic routing remediation here.

## Tests

Focused:

- `SWARM_TEST_POSTGRES_DSN='host=127.0.0.1 port=5432 user=youmew dbname=postgres sslmode=disable' PGPASSWORD=postgres go test ./internal/runtime/bootverify -run 'TestReportAddBackfillsHardInvalidityRemediationAndEvidence|TestReportAddUsesGenericRemediationForRoutingSplitChecks|TestNewHardInvalidityFindingCarriesRequiredActionFields|TestFormatSurfaceFindingUsesTypedDiagnosticRendering|TestRun_ReportsErrorForBootTimerCancelOnState' -count=1`
- `SWARM_TEST_POSTGRES_DSN='host=127.0.0.1 port=5432 user=youmew dbname=postgres sslmode=disable' PGPASSWORD=postgres go test ./cmd/swarm -run 'TestRunVerifyCommand_SurfacesLintEvidence|TestRunVerifyCommand_RejectsBootTimerWithCancelOn|TestRunVerifyCommand_EscalatedWarningUsesBlockingAnalyzerOutput|TestRunVerifyCommand_FailsWhenRequiredEntityWriterMissing|TestRunVerifyCommand_WarnsForAccumulateAllWithoutBoundedEscape|TestRunVerifyCommand_FailsForAccumulateTimeoutWithoutTimeoutMS|TestRunVerifyCommand_FailsForAccumulatorInputWithoutProducerPath|TestDescribeCommandDiagnosticsCarryRemediationAndEvidence|TestDescribeCommandJSONRendersExpandedAuthoringView' -count=1`
- `SWARM_TEST_POSTGRES_DSN='host=127.0.0.1 port=5432 user=youmew dbname=postgres sslmode=disable' PGPASSWORD=postgres go test ./internal/runtime/authoringview ./internal/builder ./internal/apispec -run 'TestBuildDiagnosticsPreservesRemediationAndEvidence|TestBuildShowsRouteIssueAndAuthoredDiagnosticLocation|TestValidationIssueFromFinding|TestHandlerHealthSnapshot_ProjectsAndErrors|TestCLIVerifyJSONShapeIncludesStructuredFailureFindings|TestPlatformSpecFlowInstanceAuthoringSourceAuthority' -count=1`

Full suite:

- `tmp=$(mktemp); SWARM_CREDENTIALS_FILE="$tmp" SWARM_TEST_POSTGRES_DSN='host=127.0.0.1 port=5432 user=youmew dbname=postgres sslmode=disable' PGPASSWORD=postgres go test ./...`

Note: local full-suite run without `SWARM_CREDENTIALS_FILE` isolation was contaminated by an existing local Claude credential store; the isolated run matches CI-style clean credentials while keeping the requested host Postgres setup.
