### PR TITLE
[agent-b][issue #1804] Spec-lock unified swarm config model

### DIFF
--- a/internal/apispec/platform_spec_unified_config_test.go
+++ b/internal/apispec/platform_spec_unified_config_test.go
@@ -72,6 +72,9 @@ func TestPlatformSpecUnifiedSwarmConfigSourceAuthority(t *testing.T) {
 	for _, key := range []string{
 		"claude_api.default_model",
 		"claude_api.haiku_model",
+		"claude_cli.retries",
+		"claude_cli.no_session_persistence",
+		"claude_cli.use_tmux",
 		"openai_compatible.default_model",
 		"openai_compatible.low_cost_model",
 	} {
@@ -82,6 +85,11 @@ func TestPlatformSpecUnifiedSwarmConfigSourceAuthority(t *testing.T) {
 	for _, want := range []string{"retired model-selection inputs", "keep rejecting", "llm.models"} {
 		if !strings.Contains(scalarValue(mustMappingValue(t, llm, "retired_model_selection_keys")), want) {
 			t.Fatalf("retired model-selection rule missing %q:\n%s", want, scalarValue(mustMappingValue(t, llm, "retired_model_selection_keys")))
+		}
+	}
+	for _, want := range []string{"#1803", "inert or unsupported Claude CLI config", "MUST NOT accept"} {
+		if !strings.Contains(scalarValue(mustMappingValue(t, llm, "inert_claude_cli_controls")), want) {
+			t.Fatalf("inert Claude CLI controls rule missing %q:\n%s", want, scalarValue(mustMappingValue(t, llm, "inert_claude_cli_controls")))
 		}
 	}
 
@@ -131,6 +139,7 @@ func TestPlatformSpecUnifiedSwarmConfigSourceAuthority(t *testing.T) {
 		"provider_triggers_packs_external_dirs": "consumed_by_unified_owner",
 		"sharding_inline_extension":             "split_unsupported_retired",
 		"llm_retired_model_selection_keys":      "split_unsupported_retired_use_llm.models",
+		"llm_claude_cli_inert_controls":         "split_unsupported_tracked_by_1803",
 		"context_descriptors":                   "different_semantic_owner_local_target_context_registry",
 		"token_and_secret_material":             "different_semantic_owner_secret_or_token_file_reference_only",
 	}

--- a/internal/apispec/platform_spec_unified_config_test.go
+++ b/internal/apispec/platform_spec_unified_config_test.go
@@ -56,12 +56,50 @@ func TestPlatformSpecUnifiedSwarmConfigSourceAuthority(t *testing.T) {
 		"llm",
 		"provider_triggers",
 		"budget",
-		"human_tasks",
 		"sharding",
 		"paths",
 	} {
 		if !hasMappingKey(sections, section) {
 			t.Fatalf("unified config section %s missing", section)
+		}
+	}
+	if hasMappingKey(sections, "human_tasks") {
+		t.Fatal("human_tasks must remain nested under budget, not top-level")
+	}
+
+	llm := mustMappingValue(t, sections, "llm")
+	llmKeys := mustMappingValue(t, llm, "keys")
+	for _, key := range []string{
+		"claude_api.default_model",
+		"claude_api.haiku_model",
+		"openai_compatible.default_model",
+		"openai_compatible.low_cost_model",
+	} {
+		if got := scalarValue(mustMappingValue(t, llmKeys, key)); got != "split_unsupported" {
+			t.Fatalf("llm.%s = %q, want split_unsupported", key, got)
+		}
+	}
+	for _, want := range []string{"retired model-selection inputs", "keep rejecting", "llm.models"} {
+		if !strings.Contains(scalarValue(mustMappingValue(t, llm, "retired_model_selection_keys")), want) {
+			t.Fatalf("retired model-selection rule missing %q:\n%s", want, scalarValue(mustMappingValue(t, llm, "retired_model_selection_keys")))
+		}
+	}
+
+	budget := mustMappingValue(t, sections, "budget")
+	budgetKeys := mustMappingValue(t, budget, "keys")
+	for _, key := range []string{
+		"human_tasks.max_tasks_per_week",
+		"human_tasks.budget_reset",
+		"human_tasks.auto_expire_hours",
+		"human_tasks.categories_enabled",
+	} {
+		if got := scalarValue(mustMappingValue(t, budgetKeys, key)); got != "project_safe" {
+			t.Fatalf("budget.%s = %q, want project_safe", key, got)
+		}
+	}
+	for _, want := range []string{"budget.human_tasks", "top-level `human_tasks` section is not part"} {
+		if !strings.Contains(scalarValue(mustMappingValue(t, budget, "nested_shape")), want) {
+			t.Fatalf("budget nested shape rule missing %q:\n%s", want, scalarValue(mustMappingValue(t, budget, "nested_shape")))
 		}
 	}
 
@@ -92,6 +130,7 @@ func TestPlatformSpecUnifiedSwarmConfigSourceAuthority(t *testing.T) {
 		"runtime_config_loader":                 "consumed_by_unified_owner_implementation_split",
 		"provider_triggers_packs_external_dirs": "consumed_by_unified_owner",
 		"sharding_inline_extension":             "split_unsupported_retired",
+		"llm_retired_model_selection_keys":      "split_unsupported_retired_use_llm.models",
 		"context_descriptors":                   "different_semantic_owner_local_target_context_registry",
 		"token_and_secret_material":             "different_semantic_owner_secret_or_token_file_reference_only",
 	}

--- a/internal/apispec/platform_spec_unified_config_test.go
+++ b/internal/apispec/platform_spec_unified_config_test.go
@@ -144,6 +144,17 @@ func TestPlatformSpecUnifiedSwarmConfigSourceAuthority(t *testing.T) {
 	if got := scalarValue(mustMappingValue(t, oldShapePolicy, "unknown_keys")); got != "fail_closed_with_key_path_and_source" {
 		t.Fatalf("unknown key policy = %q", got)
 	}
+	rejectionDiagnostics := mustMappingValue(t, oldShapePolicy, "rejection_diagnostics")
+	for _, key := range []string{"unknown_key", "trust_tier_rejection", "split_unsupported_key"} {
+		if !hasMappingKey(rejectionDiagnostics, key) {
+			t.Fatalf("rejection diagnostic %s missing", key)
+		}
+	}
+	assertContainsScalar(t, mustMappingValue(t, rejectionDiagnostics, "unknown_key"), "unknown config key")
+	assertContainsScalar(t, mustMappingValue(t, rejectionDiagnostics, "trust_tier_rejection"), "not-allowed-here")
+	for _, want := range []string{"recognized but not wired", "not-yet-wired", "MUST NOT be reported as typos or", "trust-tier violations"} {
+		assertContainsScalar(t, mustMappingValue(t, rejectionDiagnostics, "split_unsupported_key"), want)
+	}
 	for _, key := range []string{"flat_cli_shape", "runtime_config_shape", "executable_adjacent_config_yaml"} {
 		if !hasMappingKey(oldShapePolicy, key) {
 			t.Fatalf("old-shape policy %s missing", key)

--- a/internal/apispec/platform_spec_unified_config_test.go
+++ b/internal/apispec/platform_spec_unified_config_test.go
@@ -1,0 +1,198 @@
+package apispec
+
+import (
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestPlatformSpecUnifiedSwarmConfigSourceAuthority(t *testing.T) {
+	root := loadPlatformSpecYAMLNode(t)
+	authority := mustMappingValue(t, mustMappingValue(t, root, "configuration_source_authority"), "unified_swarm_config")
+
+	if got := scalarValue(mustMappingValue(t, authority, "promoted_by")); got != "#1804" {
+		t.Fatalf("unified config promoted_by = %q, want #1804", got)
+	}
+	if got := scalarValue(mustMappingValue(t, authority, "implementation_status")); got != "spec_lock_only" {
+		t.Fatalf("unified config implementation_status = %q, want spec_lock_only", got)
+	}
+	if got := scalarValue(mustMappingValue(t, authority, "canonical_owner")); got != "platform-spec.yaml#configuration_source_authority.unified_swarm_config" {
+		t.Fatalf("unified config canonical owner = %q", got)
+	}
+	for _, want := range []string{"Env", "never a normal precedence layer", "schema-declared exact env delegation"} {
+		if !strings.Contains(scalarValue(mustMappingValue(t, authority, "invariant")), want) {
+			t.Fatalf("unified config invariant missing %q:\n%s", want, scalarValue(mustMappingValue(t, authority, "invariant")))
+		}
+	}
+
+	sourcePrecedence := mustMappingValue(t, authority, "source_precedence")
+	wantOrder := []string{"flags", "explicit_config", "local_operator_config", "project_config", "user_global_config", "built_in_defaults"}
+	if got := scalarSequenceValues(mustMappingValue(t, sourcePrecedence, "order")); !sameStrings(got, wantOrder) {
+		t.Fatalf("source precedence = %#v, want %#v", got, wantOrder)
+	}
+
+	trustTiers := mustMappingValue(t, authority, "trust_tiers")
+	for _, tier := range []string{"full", "medium", "low"} {
+		if !hasMappingKey(trustTiers, tier) {
+			t.Fatalf("trust tier %s missing", tier)
+		}
+	}
+	keyTrustClasses := mustMappingValue(t, authority, "key_trust_classes")
+	for _, class := range []string{"project_safe", "elevated", "secret_reference", "project_contained_path", "split_unsupported"} {
+		if !hasMappingKey(keyTrustClasses, class) {
+			t.Fatalf("key trust class %s missing", class)
+		}
+	}
+
+	sections := mustMappingValue(t, mustMappingValue(t, authority, "schema"), "sections")
+	for _, section := range []string{
+		"connection",
+		"serve",
+		"runtime",
+		"store",
+		"database",
+		"workspace",
+		"llm",
+		"provider_triggers",
+		"budget",
+		"human_tasks",
+		"sharding",
+		"paths",
+	} {
+		if !hasMappingKey(sections, section) {
+			t.Fatalf("unified config section %s missing", section)
+		}
+	}
+
+	providerTriggers := mustMappingValue(t, sections, "provider_triggers")
+	providerTriggerKeys := mustMappingValue(t, providerTriggers, "keys")
+	if got := scalarValue(mustMappingValue(t, providerTriggerKeys, "packs.external_dirs")); got != "project_contained_path_or_elevated" {
+		t.Fatalf("provider_triggers.packs.external_dirs classification = %q", got)
+	}
+	for _, want := range []string{"Project config", "project-contained relative directories", "Absolute paths"} {
+		if !strings.Contains(scalarValue(mustMappingValue(t, providerTriggers, "path_rule")), want) {
+			t.Fatalf("provider trigger path rule missing %q:\n%s", want, scalarValue(mustMappingValue(t, providerTriggers, "path_rule")))
+		}
+	}
+
+	sharding := mustMappingValue(t, sections, "sharding")
+	if got := scalarValue(mustMappingValue(t, sharding, "trust")); got != "split_unsupported" {
+		t.Fatalf("sharding trust = %q, want split_unsupported", got)
+	}
+	for _, want := range []string{"Current code rejects", "does not promote sharding runtime behavior"} {
+		if !strings.Contains(scalarValue(mustMappingValue(t, sharding, "rule")), want) {
+			t.Fatalf("sharding rule missing %q:\n%s", want, scalarValue(mustMappingValue(t, sharding, "rule")))
+		}
+	}
+
+	consumerMatrix := mustMappingValue(t, authority, "consumer_matrix")
+	wantConsumers := map[string]string{
+		"flat_cli_config":                       "superseded_by_unified_owner_implementation_split",
+		"runtime_config_loader":                 "consumed_by_unified_owner_implementation_split",
+		"provider_triggers_packs_external_dirs": "consumed_by_unified_owner",
+		"sharding_inline_extension":             "split_unsupported_retired",
+		"context_descriptors":                   "different_semantic_owner_local_target_context_registry",
+		"token_and_secret_material":             "different_semantic_owner_secret_or_token_file_reference_only",
+	}
+	for key, want := range wantConsumers {
+		if got := scalarValue(mustMappingValue(t, consumerMatrix, key)); got != want {
+			t.Fatalf("consumer_matrix.%s = %q, want %q", key, got, want)
+		}
+	}
+
+	oldShapePolicy := mustMappingValue(t, authority, "old_shape_and_unknown_key_policy")
+	if got := scalarValue(mustMappingValue(t, oldShapePolicy, "unknown_keys")); got != "fail_closed_with_key_path_and_source" {
+		t.Fatalf("unknown key policy = %q", got)
+	}
+	for _, key := range []string{"flat_cli_shape", "runtime_config_shape", "executable_adjacent_config_yaml"} {
+		if !hasMappingKey(oldShapePolicy, key) {
+			t.Fatalf("old-shape policy %s missing", key)
+		}
+	}
+
+	envDrain := mustMappingValue(t, authority, "env_drain")
+	for _, want := range []string{"seeded #1600 env row", "unified typed key", "terminal secret/token-file owner"} {
+		if !strings.Contains(scalarValue(mustMappingValue(t, envDrain, "rule")), want) {
+			t.Fatalf("env_drain rule missing %q:\n%s", want, scalarValue(mustMappingValue(t, envDrain, "rule")))
+		}
+	}
+}
+
+func TestPlatformSpecUnifiedConfigSupersedesOldConfigCommitments(t *testing.T) {
+	root := loadPlatformSpecYAMLNode(t)
+
+	cliSpec := mustMappingValue(t, root, "cli_specification")
+	foundations := mustMappingValue(t, cliSpec, "foundations")
+	apiConfig := mustMappingValue(t, foundations, "api_connection_auth_config_precedence")
+	cliConfig := mustMappingValue(t, apiConfig, "cli_config_file")
+	assertContainsScalar(t, mustMappingValue(t, cliConfig, "unified_config_supersession"), "configuration_source_authority.unified_swarm_config")
+	assertContainsScalar(t, mustMappingValue(t, cliConfig, "unified_config_supersession"), "global `--config`")
+
+	pathConfig := mustMappingValue(t, mustMappingValue(t, foundations, "contract_platform_spec_path_resolution"), "cli_config_file")
+	assertContainsScalar(t, mustMappingValue(t, pathConfig, "unified_config_supersession"), "`paths` section")
+
+	envAuthority := mustMappingValue(t, mustMappingValue(t, root, "environment_source_authority"), "repo_wide_swarm_env_accepted_set")
+	typedDelegation := mustMappingValue(t, envAuthority, "typed_delegation")
+	assertContainsScalar(t, mustMappingValue(t, typedDelegation, "rule"), "configuration_source_authority.unified_swarm_config")
+	assertContainsScalar(t, mustMappingValue(t, typedDelegation, "rule"), "executable-adjacent `config.yaml` is superseded")
+
+	serve := mustMappingValue(t, mustMappingValue(t, cliSpec, "command_catalog"), "serve")
+	runtimeConfig := mustMappingValue(t, serve, "runtime_config_backend_selection")
+	assertContainsScalar(t, mustMappingValue(t, runtimeConfig, "unified_config_supersession"), "executable-adjacent")
+
+	listenerTopology := mustMappingValue(t, serve, "listener_topology_v2_1")
+	sourcePrecedence := mustMappingValue(t, listenerTopology, "source_precedence")
+	assertContainsScalar(t, mustMappingValue(t, sourcePrecedence, "unified_config_supersession"), "`serve`")
+
+	legacyCommitments := mustMappingValue(t, mustMappingValue(t, root, "configuration_source_authority"), "unified_swarm_config")
+	legacyCommitments = mustMappingValue(t, legacyCommitments, "legacy_spec_commitments_superseded")
+	if !sequenceContainsMappingValue(legacyCommitments, "owner", "cli_specification.foundations.api_connection_auth_config_precedence.cli_config_file") {
+		t.Fatal("legacy supersession missing API CLI config owner")
+	}
+	if !sequenceContainsMappingValue(legacyCommitments, "owner", "cli_specification.command_catalog.serve.runtime_config_backend_selection") {
+		t.Fatal("legacy supersession missing serve runtime config owner")
+	}
+}
+
+func assertContainsScalar(t *testing.T, node *yaml.Node, want string) {
+	t.Helper()
+	if !strings.Contains(scalarValue(node), want) {
+		t.Fatalf("scalar missing %q:\n%s", want, scalarValue(node))
+	}
+}
+
+func scalarSequenceValues(node *yaml.Node) []string {
+	if node == nil || node.Kind != yaml.SequenceNode {
+		return nil
+	}
+	out := make([]string, 0, len(node.Content))
+	for _, child := range node.Content {
+		out = append(out, scalarValue(child))
+	}
+	return out
+}
+
+func sameStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func sequenceContainsMappingValue(node *yaml.Node, key, want string) bool {
+	if node == nil || node.Kind != yaml.SequenceNode {
+		return false
+	}
+	for _, child := range node.Content {
+		if scalarValue(mappingValue(child, key)) == want {
+			return true
+		}
+	}
+	return false
+}

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -11292,9 +11292,10 @@ environment_source_authority:
     typed_delegation:
       rule: >
         Typed delegation is schema-visible and exact. A config field may name one concrete env variable only when that field's
-        schema explicitly supports env delegation. Guard admission MUST use the same supported runtime config source classes
-        as runtime loading, including explicit `--config` and executable-adjacent `config.yaml`. Arbitrary string
-        interpolation such as `${VAR}` is not accepted.
+        schema explicitly supports env delegation. The final config source classes are owned by
+        configuration_source_authority.unified_swarm_config; executable-adjacent `config.yaml` is superseded ambient
+        file authority and MUST NOT be treated as a final typed-delegation source. Arbitrary string interpolation such
+        as `${VAR}` is not accepted.
       first_slice_fields:
       - database.password_env
     generated_boundary:
@@ -11794,6 +11795,287 @@ environment_source_authority:
     split_siblings:
     - '#1731 repo-wide SWARM env accepted-set guard, typed delegation schema, doctor env reporting, generated-boundary env closure, and unknown-env guard'
     - '#1600 parent residual env-source-authority closeout'
+configuration_source_authority:
+  unified_swarm_config:
+    promoted_by: '#1804'
+    parent_trackers:
+    - '#1801'
+    - '#1600'
+    related_trackers:
+    - '#1731'
+    - '#1748'
+    implementation_status: spec_lock_only
+    canonical_owner: platform-spec.yaml#configuration_source_authority.unified_swarm_config
+    scope: >
+      Merge-bearing authority for the unified `swarm.yaml` configuration model. This owner defines the final
+      schema sections, source layers, trust tiers, source precedence, strict/old-shape handling, deep-merge and
+      provenance semantics, and #1600 env-drain destinations. It is a spec lock only: parser/discovery implementation,
+      old reader deletion, examples migration, provider-trigger runtime behavior changes, sharding runtime promotion,
+      and seeded env-row shrinkage remain split to later children.
+    invariant: >
+      Swarm configuration is explicit, typed, and provenance-bearing. Environment variables are never a normal
+      precedence layer; they are accepted only as the `SWARM_CONFIG` config-file locator/replacement, as a
+      schema-declared exact env delegation field, as a seeded #1600 migration row, as a test quarantine row, or as a
+      generated child-process boundary row. File config may name secret/token sources, but MUST NOT store inline
+      secret values.
+    source_precedence:
+      order:
+      - flags
+      - explicit_config
+      - local_operator_config
+      - project_config
+      - user_global_config
+      - built_in_defaults
+      rules:
+        flags: >
+          Invocation-scoped flags win for the semantic owner they target. Inline secret values remain forbidden; flags
+          may name files or other non-argv secret sources only where the owning section allows it.
+        explicit_config: >
+          A global `--config <path>` selects a full-trust unified `swarm.yaml` file. `SWARM_CONFIG`, when non-empty and
+          no `--config` flag is supplied, is only a bootstrap locator/replacement for a config file; it never injects
+          individual values or creates env-over-config precedence.
+        local_operator_config: >
+          A gitignored `.swarm/swarm.yaml` under the current project root is the local operator layer. It may set
+          runtime behavior and local overrides but not connection/auth values or other explicitly elevated keys.
+        project_config: >
+          A checked-in `./swarm.yaml` is the low-trust project layer. It may set only project-safe runtime behavior.
+          It cannot set connection/auth keys, non-loopback or wildcard listener binds, serve token files,
+          `workspace.allow_exec_on_host`, or absolute/outside-project path references.
+        user_global_config: >
+          `${XDG_CONFIG_HOME:-$HOME/.config}/swarm/swarm.yaml` is full-trust user-global config. It replaces the
+          current flat `config.yaml` target after the parser/discovery migration child.
+        built_in_defaults: >
+          Built-in defaults are lowest precedence and must remain explicit in the consuming owner. Defaults do not
+          authorize ambient repo, executable-adjacent, env, or source-checkout discovery.
+    trust_tiers:
+      full:
+        sources:
+        - flags
+        - explicit_config
+        - user_global_config
+        may_set: any non-secret config key accepted by that key's semantic owner
+      medium:
+        sources:
+        - local_operator_config
+        may_set: runtime behavior, local paths, and local overrides except connection/auth and explicitly elevated keys
+      low:
+        sources:
+        - project_config
+        may_set: project-safe runtime behavior only
+    key_trust_classes:
+      project_safe: May be set by project config.
+      elevated: Requires flags, explicit config, user-global config, or an allowed local-operator key.
+      secret_reference: May reference a token file, secret key, secret file, or explicit env delegation; inline secret values are rejected.
+      project_contained_path: Project config may set only relative paths that remain under the canonical project root after clean/eval checks.
+      split_unsupported: Known config-looking seam that remains invalid or split until a later gate promotes it.
+    schema:
+      strict_unknown_keys: fail_closed
+      env_interpolation: rejected
+      sections:
+        connection:
+          trust: elevated
+          keys:
+            api_server: elevated
+            api_token_file: secret_reference
+          owner: cli_specification.foundations.api_connection_auth_config_precedence
+          notes: >
+            Connection config is an elevated file-config input. Live project/selected context descriptors remain a
+            separate target authority and are not demoted into ordinary file-layer precedence.
+        serve:
+          trust: elevated_for_public_listener_or_auth
+          keys:
+            api_listen_addr: elevated_when_non_loopback_or_wildcard
+            mcp_listen_addr: elevated_when_non_loopback_or_wildcard
+            api_token_file: secret_reference
+          owner: cli_specification.command_catalog.serve.listener_topology_v2_1
+        runtime:
+          trust: project_safe_unless_key_is_marked_elevated
+          keys:
+            max_concurrent_agents: split_unsupported
+            event_poll_interval: split_unsupported
+            recovery_on_startup: project_safe
+          owner: runtime_storage.runtime_store_backend_selection
+        store:
+          trust: elevated
+          keys:
+            backend: elevated
+            sqlite.path: project_contained_path_or_elevated
+          owner: runtime_storage.runtime_store_backend_selection
+        database:
+          trust: elevated
+          keys:
+            host: elevated
+            port: elevated
+            name: elevated
+            user: elevated
+            sslmode: elevated
+            pool_size: elevated
+            password: rejected_inline_secret
+            password_secret_key: secret_reference
+            password_file: secret_reference
+            password_env: schema_declared_env_delegation
+          owner: runtime_storage.runtime_store_backend_selection.postgres_connection_details
+        workspace:
+          trust: project_safe_unless_key_is_marked_elevated
+          keys:
+            data_source: project_contained_path_or_elevated
+            backend: project_safe
+            allow_exec_on_host: elevated
+          owner: workspace_model.workspace_backend_selection
+        llm:
+          trust: project_safe_unless_key_is_marked_elevated
+          keys:
+            backend: project_safe
+            runtime_mode: split_unsupported
+            models: project_safe
+            session.lock_ttl: project_safe
+            session.rotate_after_turns: project_safe
+            session.rotate_on_parse_failures: project_safe
+            provider_limits: project_safe
+            claude_api.default_model: project_safe
+            claude_api.haiku_model: project_safe
+            claude_api.max_retries: project_safe
+            claude_api.retry_backoff: project_safe
+            claude_cli.command: elevated
+            claude_cli.timeout: project_safe
+            claude_cli.output_format: project_safe
+            claude_cli.retries: project_safe
+            claude_cli.no_session_persistence: split_unsupported
+            claude_cli.use_tmux: project_safe
+            openai_compatible.base_url: elevated
+            openai_compatible.default_model: project_safe
+            openai_compatible.low_cost_model: project_safe
+            openai_responses.base_url: elevated
+          owner: engine.agent_session_management.llm_provider_selection_config_authority
+        provider_triggers:
+          trust: project_contained_path_or_elevated
+          keys:
+            packs.external_dirs: project_contained_path_or_elevated
+          owner: contract_formats.configured_provider_triggers
+          path_rule: >
+            Project config may name only project-contained relative directories. Absolute paths, parent escapes,
+            symlink escapes, or paths outside the canonical project root are elevated and require local-operator,
+            user-global, explicit config, or a future promoted flag.
+        budget:
+          trust: project_safe
+          keys:
+            global_monthly_cap: project_safe
+            per_entity_monthly_cap: project_safe
+            system_monthly_cap: project_safe
+          owner: config extensions budget owner, to be promoted by parser migration child
+        human_tasks:
+          trust: project_safe
+          keys:
+            max_tasks_per_week: project_safe
+            budget_reset: project_safe
+            auto_expire_hours: project_safe
+            categories_enabled: project_safe
+          owner: config extensions human-tasks owner, to be promoted by parser migration child
+        sharding:
+          trust: split_unsupported
+          keys:
+            '*': split_unsupported
+          owner: split_runtime_sharding_owner_required
+          rule: >
+            Current code rejects `sharding` with `sharding extension is unsupported: no runtime path consumes it`.
+            #1804 does not promote sharding runtime behavior.
+        paths:
+          trust: project_contained_path_or_elevated
+          keys:
+            swarm_dir: elevated
+            contracts_path: project_contained_path_or_elevated
+            platform_spec_path: elevated
+            prompts_dir: project_contained_path_or_elevated
+            artifact_root: elevated
+            monitor_dir: elevated
+            agent_config_map_file: project_contained_path_or_elevated
+            verification_gates_file: project_contained_path_or_elevated
+            tooling_lock_file: project_contained_path_or_elevated
+          owner: contract/platform path owners, runtime_storage.artifact_root, and #1600 helper-path drains
+    merge_semantics:
+      rule: >
+        Layers deep-merge key-by-key by section. Implementations MUST track presence separately from zero values so
+        omitted means inherit lower-precedence value while explicit false, zero, empty list, or empty string are
+        validated as deliberate values by the owning key.
+      provenance: >
+        The unified parser must retain source layer, source path, line/column when available, and trust-class result for
+        every accepted or blocked key so `swarm doctor` can explain the effective config.
+    old_shape_and_unknown_key_policy:
+      unknown_keys: fail_closed_with_key_path_and_source
+      flat_cli_shape: >
+        Top-level flat CLI keys such as `api_server`, `api_token_file`, `serve_api_listen_addr`, and
+        `serve_api_token_file` are old-shape evidence outside their unified sections and must fail closed with
+        migration guidance.
+      runtime_config_shape: >
+        Runtime section keys that remain canonical may be valid as a subset of unified `swarm.yaml`; old command-local
+        runtime config discovery and executable-adjacent `config.yaml` remain superseded sources and must fail closed
+        or route through migration guidance when the parser/discovery child lands.
+      executable_adjacent_config_yaml: >
+        Executable-adjacent `config.yaml` is ambient file authority and is not part of the unified discovery model.
+        Removal is split but must be atomic with the parser/discovery implementation.
+    doctor_provenance:
+      command: swarm doctor
+      requirements:
+      - list loaded config files and layers in precedence order
+      - show per-key provenance for effective values
+      - show blocked keys with source path, trust-tier reason, and remediation
+      - show old-shape diagnostics with migration guidance
+      - render despite config/env blockers where possible and exit nonzero when blockers exist
+    env_drain:
+      rule: >
+        Every seeded #1600 env row must drain to either a unified typed key in this owner or a terminal secret/token-file
+        owner. Direct env readers are not proof of configuration ownership; each migration child must shrink the seeded
+        accepted set or explicitly leave a tracked residual row.
+      examples:
+        SWARM_API_LISTEN_ADDR: serve.api_listen_addr
+        SWARM_MCP_LISTEN_ADDR: serve.mcp_listen_addr
+        SWARM_CONTRACTS_PATH: paths.contracts_path or --contracts
+        SWARM_STORE_BACKEND: store.backend
+        SWARM_SQLITE_PATH: store.sqlite.path
+        SWARM_DB_HOST: database.host
+        SWARM_DB_PORT: database.port
+        SWARM_DB_NAME: database.name
+        SWARM_DB_USER: database.user
+        SWARM_DB_SSLMODE: database.sslmode
+        SWARM_DB_POOL_SIZE: database.pool_size
+        SWARM_WORKSPACE_DATA_SOURCE: workspace.data_source
+        SWARM_WORKSPACE_BACKEND: workspace.backend
+        SWARM_WORKSPACE_IMAGE: workspace.image, pending workspace schema child
+        SWARM_ARTIFACT_ROOT: paths.artifact_root
+        SWARM_MONITOR_DIR: paths.monitor_dir
+        SWARM_PROMPTS_DIR: paths.prompts_dir
+        SWARM_AGENT_CONFIG_MAP_FILE: paths.agent_config_map_file
+        SWARM_VERIFICATION_GATES_FILE: paths.verification_gates_file
+        SWARM_CREDENTIALS_FILE: secrets file owner, not inline config secret
+        SWARM_MANAGED_CREDENTIALS_FILE: managed credential store owner, not inline config secret
+    consumer_matrix:
+      flat_cli_config: superseded_by_unified_owner_implementation_split
+      xdg_config_yaml: superseded_by_user_global_swarm_yaml_implementation_split
+      runtime_config_loader: consumed_by_unified_owner_implementation_split
+      executable_adjacent_config_yaml: invalid_ambient_reader_removal_split
+      provider_triggers_packs_external_dirs: consumed_by_unified_owner
+      budget_and_human_tasks_inline_extensions: consumed_by_unified_owner_code_migration_split
+      sharding_inline_extension: split_unsupported_retired
+      context_descriptors: different_semantic_owner_local_target_context_registry
+      token_and_secret_material: different_semantic_owner_secret_or_token_file_reference_only
+      env_accepted_set_seeded_rows: migration_backlog_to_unified_keys_or_secret_owners
+    legacy_spec_commitments_superseded:
+    - owner: cli_specification.foundations.api_connection_auth_config_precedence.cli_config_file
+      commitment: root/global --config rejected and XDG flat config.yaml accepted
+      superseded_by: configuration_source_authority.unified_swarm_config
+    - owner: cli_specification.command_catalog.serve.runtime_config_backend_selection
+      commitment: command-local --config plus executable-adjacent config.yaml runtime config discovery
+      superseded_by: configuration_source_authority.unified_swarm_config
+    - owner: cli_specification.command_catalog.serve.listener_topology_v2_1
+      commitment: listener env/config keys as flat CLI config keys
+      superseded_by: configuration_source_authority.unified_swarm_config serve section
+    split_siblings:
+    - '#1801 unified parser and layered discovery implementation'
+    - '#1600 seeded env-row family migrations'
+    - '#1799 paused config-var migration pending this spec lock'
+    - examples/docs cleanup for one `swarm.example.yaml`
+    - runtime sharding behavior promotion, if ever desired
+    - provider-trigger runtime behavior changes, explicitly not part of #1804
 workspace_model:
   description: Defines the filesystem contract for agent sessions. The platform provides three standard mount points and a
     scoping model. Products define workspace classes that map agent roles to specific scope configurations. If a product declares
@@ -14735,6 +15017,11 @@ cli_specification:
             `Authorization: Bearer <token>` and the v1 API handler still validates the bearer value.
       cli_config_file:
         owner: platform-spec.yaml#cli_specification.foundations.api_connection_auth_config_precedence.cli_config_file
+        unified_config_supersession: >
+          #1804 supersedes this flat CLI config-file model with
+          configuration_source_authority.unified_swarm_config. The current implementation remains until the parser/CLI
+          migration child replaces XDG `config.yaml`, promotes global `--config`, and moves flat keys under
+          `connection`, `serve`, and `paths`.
         accepted_sources:
           environment: SWARM_CONFIG
           xdg_default: '${XDG_CONFIG_HOME:-$HOME/.config}/swarm/config.yaml'
@@ -14882,6 +15169,9 @@ cli_specification:
           `SWARM_CONFIG` and the XDG default config path are shared with
           cli_specification.foundations.api_connection_auth_config_precedence. The parser accepts this owner's
           path keys plus API connection/auth keys, while each semantic resolver consumes only its own keys.
+        unified_config_supersession: >
+          #1804 moves `contracts_path` and `platform_spec_path` under the unified config model's `paths` section.
+          This current shared flat parser remains implementation state until the parser/discovery child lands.
         accepted_keys:
           contracts_path: Consumed only by this contract path resolver.
           platform_spec_path: Consumed only by this platform spec path resolver.
@@ -15198,6 +15488,11 @@ cli_specification:
         config_flag: --config <path>
         backend_flag: --backend <anthropic|claude_cli|openai_compatible|openai_responses>
         owner: engine.agent_session_management.llm_provider_selection_config_authority
+        unified_config_supersession: >
+          #1804 supersedes command-local runtime config discovery with
+          configuration_source_authority.unified_swarm_config. Current `--config` and executable-adjacent
+          `config.yaml` loading are implementation state only until the parser/discovery child promotes global
+          `--config`, layered `swarm.yaml`, and executable-adjacent removal atomically.
         rule: >
           `swarm serve` consumes the shared runtime config resolver: explicit --config first, config.yaml beside the
           running binary second when present, built-in/default config last, then --backend overrides config llm.backend.
@@ -15375,6 +15670,10 @@ cli_specification:
           - '`swarm run start` local foreground listener startup.'
           - API client connection/auth configuration such as `--api-server`, context descriptors, and `api_server`.
           - '`swarm serve --config`, which remains command-local runtime configuration.'
+          unified_config_supersession: >
+            #1804 moves serve listener and server API token-file config under
+            configuration_source_authority.unified_swarm_config `serve`. Flat CLI config listener keys and listener
+            env rows remain current implementation/migration state until their #1600 family migration lands.
           source_order:
           - flag
           - environment

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -12007,6 +12007,20 @@ configuration_source_authority:
         every accepted or blocked key so `swarm doctor` can explain the effective config.
     old_shape_and_unknown_key_policy:
       unknown_keys: fail_closed_with_key_path_and_source
+      rejection_diagnostics:
+        unknown_key: >
+          Typos or truly unknown keys MUST fail closed with the key path, source path/layer, and nearest-known-key
+          suggestion when available. Message shape: "unknown config key `<path>` in `<source>`; did you mean `<known>`?"
+        trust_tier_rejection: >
+          Keys recognized by the unified schema but forbidden from the source's trust tier MUST fail closed as
+          not-allowed-here, not as unknown. The diagnostic MUST include the key path, source layer, required trust
+          class, and exact remediation such as "move this to .swarm/swarm.yaml, user-global config, explicit --config,
+          or a flag".
+        split_unsupported_key: >
+          Keys classified as `split_unsupported` are recognized but not wired. They MUST fail closed with a distinct
+          not-yet-wired diagnostic that names the key path, owning/split tracker when known, and a current replacement
+          or "no supported replacement" guidance. They MUST NOT be silently ignored and MUST NOT be reported as typos or
+          trust-tier violations.
       flat_cli_shape: >
         Top-level flat CLI keys such as `api_server`, `api_token_file`, `serve_api_listen_addr`, and
         `serve_api_token_file` are old-shape evidence outside their unified sections and must fail closed with

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -11932,8 +11932,8 @@ configuration_source_authority:
             session.rotate_after_turns: project_safe
             session.rotate_on_parse_failures: project_safe
             provider_limits: project_safe
-            claude_api.default_model: project_safe
-            claude_api.haiku_model: project_safe
+            claude_api.default_model: split_unsupported
+            claude_api.haiku_model: split_unsupported
             claude_api.max_retries: project_safe
             claude_api.retry_backoff: project_safe
             claude_cli.command: elevated
@@ -11943,10 +11943,15 @@ configuration_source_authority:
             claude_cli.no_session_persistence: split_unsupported
             claude_cli.use_tmux: project_safe
             openai_compatible.base_url: elevated
-            openai_compatible.default_model: project_safe
-            openai_compatible.low_cost_model: project_safe
+            openai_compatible.default_model: split_unsupported
+            openai_compatible.low_cost_model: split_unsupported
             openai_responses.base_url: elevated
           owner: engine.agent_session_management.llm_provider_selection_config_authority
+          retired_model_selection_keys: >
+            `llm.claude_api.default_model`, `llm.claude_api.haiku_model`,
+            `llm.openai_compatible.default_model`, and `llm.openai_compatible.low_cost_model`
+            are retired model-selection inputs. Unified config migration MUST keep rejecting them with guidance to use
+            `llm.models`; this spec does not re-admit them as accepted project-safe keys.
         provider_triggers:
           trust: project_contained_path_or_elevated
           keys:
@@ -11962,15 +11967,15 @@ configuration_source_authority:
             global_monthly_cap: project_safe
             per_entity_monthly_cap: project_safe
             system_monthly_cap: project_safe
+            human_tasks.max_tasks_per_week: project_safe
+            human_tasks.budget_reset: project_safe
+            human_tasks.auto_expire_hours: project_safe
+            human_tasks.categories_enabled: project_safe
           owner: config extensions budget owner, to be promoted by parser migration child
-        human_tasks:
-          trust: project_safe
-          keys:
-            max_tasks_per_week: project_safe
-            budget_reset: project_safe
-            auto_expire_hours: project_safe
-            categories_enabled: project_safe
-          owner: config extensions human-tasks owner, to be promoted by parser migration child
+          nested_shape: >
+            Human task budget controls remain under `budget.human_tasks`, matching the implemented
+            `BudgetConfig.HumanTasks` shape. A separate top-level `human_tasks` section is not part of the unified
+            schema unless a future migration explicitly promotes and gates that shape.
         sharding:
           trust: split_unsupported
           keys:
@@ -12054,7 +12059,8 @@ configuration_source_authority:
       runtime_config_loader: consumed_by_unified_owner_implementation_split
       executable_adjacent_config_yaml: invalid_ambient_reader_removal_split
       provider_triggers_packs_external_dirs: consumed_by_unified_owner
-      budget_and_human_tasks_inline_extensions: consumed_by_unified_owner_code_migration_split
+      budget_human_tasks_inline_extension: consumed_by_unified_owner_code_migration_split
+      llm_retired_model_selection_keys: split_unsupported_retired_use_llm.models
       sharding_inline_extension: split_unsupported_retired
       context_descriptors: different_semantic_owner_local_target_context_registry
       token_and_secret_material: different_semantic_owner_secret_or_token_file_reference_only

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -11939,9 +11939,9 @@ configuration_source_authority:
             claude_cli.command: elevated
             claude_cli.timeout: project_safe
             claude_cli.output_format: project_safe
-            claude_cli.retries: project_safe
+            claude_cli.retries: split_unsupported
             claude_cli.no_session_persistence: split_unsupported
-            claude_cli.use_tmux: project_safe
+            claude_cli.use_tmux: split_unsupported
             openai_compatible.base_url: elevated
             openai_compatible.default_model: split_unsupported
             openai_compatible.low_cost_model: split_unsupported
@@ -11952,6 +11952,11 @@ configuration_source_authority:
             `llm.openai_compatible.default_model`, and `llm.openai_compatible.low_cost_model`
             are retired model-selection inputs. Unified config migration MUST keep rejecting them with guidance to use
             `llm.models`; this spec does not re-admit them as accepted project-safe keys.
+          inert_claude_cli_controls: >
+            `llm.claude_cli.retries`, `llm.claude_cli.use_tmux`, and
+            `llm.claude_cli.no_session_persistence` are tracked by #1803 as inert or unsupported Claude CLI config
+            surfaces. Unified config migration MUST NOT accept them as ordinary supported config keys unless a later
+            gate deliberately promotes a real production runtime owner.
         provider_triggers:
           trust: project_contained_path_or_elevated
           keys:
@@ -12075,6 +12080,7 @@ configuration_source_authority:
       provider_triggers_packs_external_dirs: consumed_by_unified_owner
       budget_human_tasks_inline_extension: consumed_by_unified_owner_code_migration_split
       llm_retired_model_selection_keys: split_unsupported_retired_use_llm.models
+      llm_claude_cli_inert_controls: split_unsupported_tracked_by_1803
       sharding_inline_extension: split_unsupported_retired
       context_descriptors: different_semantic_owner_local_target_context_registry
       token_and_secret_material: different_semantic_owner_secret_or_token_file_reference_only
@@ -12091,6 +12097,7 @@ configuration_source_authority:
       superseded_by: configuration_source_authority.unified_swarm_config serve section
     split_siblings:
     - '#1801 unified parser and layered discovery implementation'
+    - '#1803 inert/unsupported Claude CLI config-surface cleanup'
     - '#1600 seeded env-row family migrations'
     - '#1799 paused config-var migration pending this spec lock'
     - examples/docs cleanup for one `swarm.example.yaml`


### PR DESCRIPTION
## Summary

Closes #1804.

Part of #1801 and #1600.

This PR is intentionally spec-lock only. It adds `platform-spec.yaml#configuration_source_authority.unified_swarm_config` as the canonical owner for the unified `swarm.yaml` model and adds apispec proof for the approved #1804 gate boundary.

## Governing Refs / Context

Exact spec refs treated as binding:

- `platform-spec.yaml#environment_source_authority.repo_wide_swarm_env_accepted_set`
- `platform-spec.yaml#cli_specification.foundations.local_target_resolution_authority`
- `platform-spec.yaml#cli_specification.foundations.api_connection_auth_config_precedence`
- `platform-spec.yaml#cli_specification.foundations.contract_platform_spec_path_resolution`
- `platform-spec.yaml#cli_specification.command_catalog.serve.runtime_config_backend_selection`
- `platform-spec.yaml#cli_specification.command_catalog.serve.listener_topology_v2_1`
- `platform-spec.yaml#tool_model.credential_store`

Binding issue/thread context:

- #1801 settled unified config design and trust-tier model.
- #1804 Gate B approval comment: approved as first slice, spec-lock only.
- #1600 / #1731 env-source-authority direction: env is not normal precedence; config may only use typed, schema-declared delegation.

`docs/IMPLEMENTER_GUIDELINES.md`, `docs/SEMANTIC_DRIFT.md`, and `docs/watchlists` are not present on this ref; the issue thread and adjacent spec sections were used as the binding governing context where those docs/watchlists were unavailable.

## Semantic Migration Statement

New canonical owner:

- `platform-spec.yaml#configuration_source_authority.unified_swarm_config`

Old producer / reader / writer paths now marked non-authoritative or superseded by spec:

- flat CLI config shape (`api_server`, `api_token_file`, flat listener keys)
- XDG flat `config.yaml` target
- command-local serve runtime config discovery as standalone source authority
- executable-adjacent `config.yaml`
- hidden inline extension maps / unknown-key acceptance
- env as normal config precedence

Production paths checked for surviving old behavior:

- CLI API config precedence owner
- contract/platform path config owner
- serve runtime config owner
- serve listener topology owner
- env typed-delegation owner
- context descriptor and secret/token sibling owners
- provider trigger external-dir config seam
- sharding inline-extension seam

Migration completeness:

- Complete for #1804 spec-lock only.
- Parser/discovery implementation, old-reader deletion, examples/docs migration, seeded env-row shrinkage, provider-trigger runtime changes, and sharding runtime promotion remain explicitly split outside this PR.

## Proof

Targeted:

```sh
go test ./internal/apispec -run 'TestPlatformSpecUnifiedSwarmConfigSourceAuthority|TestPlatformSpecUnifiedConfigSupersedesOldConfigCommitments' -count=1
```

Full suite:

```sh
SWARM_CREDENTIALS_FILE=$(mktemp -t swarm-empty-credentials.XXXXXX.json) \
SWARM_TEST_POSTGRES_DSN='host=127.0.0.1 port=5432 user=postgres password=postgres dbname=postgres sslmode=disable' \
go test ./...
```

Notes:

- Initial `go test ./...` without Docker failed because Docker-backed Postgres tests could not connect to `/var/run/docker.sock`.
- Rerunning with host Postgres matched the CI-supported `SWARM_TEST_POSTGRES_DSN` path.
- `cmd/swarm` also required isolated `SWARM_CREDENTIALS_FILE` because this machine's default local Swarm credential store contains a Claude credential, which contaminates doctor tests that intentionally assert missing credentials.
