### PR TITLE
[agent-g][issue #1810] Add operator read parity guard

### DIFF
--- a/cmd/swarm/store_backend_selection_test.go
+++ b/cmd/swarm/store_backend_selection_test.go
@@ -6,6 +6,8 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"reflect"
+	"sort"
 	"strings"
 	"testing"
 
@@ -448,6 +450,9 @@ func TestBuildStoresAcceptsSQLiteSelectedCoreRuntimeStore(t *testing.T) {
 			t.Fatalf("sqlite optional capability %s = %T, want nil classified split/postgres-only capability", name, capability)
 		}
 	}
+	if apiCaps.RuntimeContexts != nil {
+		t.Fatalf("sqlite optional capability RuntimeContexts = %T, want nil classified split/postgres-only capability", apiCaps.RuntimeContexts)
+	}
 	runtimeStores := stores.runtimeStores()
 	if runtimeStores.SQLDB != nil {
 		t.Fatalf("sqlite runtimeStores SQLDB = %#v, want nil raw runtime SQL handle", runtimeStores.SQLDB)
@@ -531,70 +536,108 @@ func TestSelectedOperatorReadConstructionParityClassifiesSQLitePostgresDelta(t *
 		t.Fatalf("sqlite apiCapabilities: %v", err)
 	}
 
-	pureOperatorReads := map[string]struct {
-		postgres any
-		sqlite   any
-	}{
-		"AgentConversations": {postgres: postgresCaps.AgentConversations, sqlite: sqliteCaps.AgentConversations},
-		"BundleCatalog":      {postgres: postgresCaps.BundleCatalog, sqlite: sqliteCaps.BundleCatalog},
-	}
-	for name, caps := range pureOperatorReads {
-		if caps.postgres == nil {
-			t.Fatalf("postgres pure operator-read capability %s unexpectedly nil; parity guard lost its baseline", name)
+	ledger := selectedOperatorReadConstructionCapabilityLedger()
+	seen := map[string]struct{}{}
+	for _, entry := range ledger {
+		if entry.Reason == "" {
+			t.Fatalf("selected operator-read construction capability %s missing classification reason", entry.Name)
 		}
-		if caps.sqlite == nil {
-			t.Fatalf("sqlite pure operator-read capability %s nil while postgres wires it; wire SQLite or classify explicitly", name)
+		if _, exists := seen[entry.Name]; exists {
+			t.Fatalf("selected operator-read construction capability %s appears more than once in classification ledger", entry.Name)
+		}
+		seen[entry.Name] = struct{}{}
+		postgresValue, ok := selectedAPICapabilityField(postgresCaps, entry.Name)
+		if !ok {
+			t.Fatalf("selected operator-read construction capability ledger names unknown field %s", entry.Name)
+		}
+		sqliteValue, _ := selectedAPICapabilityField(sqliteCaps, entry.Name)
+		postgresConfigured := selectedAPICapabilityConfigured(postgresValue)
+		sqliteConfigured := selectedAPICapabilityConfigured(sqliteValue)
+		switch entry.Classification {
+		case "wired_both":
+			if !postgresConfigured {
+				t.Fatalf("postgres selected operator-read capability %s unexpectedly nil; parity guard lost its baseline", entry.Name)
+			}
+			if !sqliteConfigured {
+				t.Fatalf("sqlite selected operator-read capability %s nil while postgres wires it; wire SQLite or classify explicitly: %s", entry.Name, entry.Reason)
+			}
+		case "split_with_issue_ref", "different_semantic_concept_with_proof":
+			if entry.Issue == 0 {
+				t.Fatalf("selected operator-read construction capability %s classification %s missing issue", entry.Name, entry.Classification)
+			}
+			if entry.RequiresPostgresBaseline && !postgresConfigured {
+				t.Fatalf("classified optional capability %s no longer has a postgres baseline; update construction-parity classification: %s", entry.Name, entry.Reason)
+			}
+			if sqliteConfigured {
+				t.Fatalf("sqlite optional capability %s is configured; keep it classified until separately gated: %s", entry.Name, entry.Reason)
+			}
+		default:
+			t.Fatalf("selected operator-read construction capability %s has unsupported classification %q", entry.Name, entry.Classification)
 		}
 	}
+	for _, field := range selectedAPICapabilityFieldNames() {
+		if _, ok := seen[field]; !ok {
+			t.Fatalf("selected operator-read construction capability ledger missing field %s", field)
+		}
+	}
+}
 
-	classifiedSQLiteOmissions := map[string]struct {
-		postgres any
-		sqlite   any
-		reason   string
-	}{
-		"ConversationForks": {
-			postgres: postgresCaps.ConversationForks,
-			sqlite:   sqliteCaps.ConversationForks,
-			reason:   "mixed read/write lifecycle capability; split to #1783 before SQLite promotion",
-		},
-		"BundleDelete": {
-			postgres: postgresCaps.BundleDelete,
-			sqlite:   sqliteCaps.BundleDelete,
-			reason:   "mutating/destructive bundle capability, not pure operator read",
-		},
-		"RunForkAvailability": {
-			postgres: postgresCaps.RunForkAvailability,
-			sqlite:   sqliteCaps.RunForkAvailability,
-			reason:   "run.fork availability/execution product seam split from operator reads",
-		},
-		"RunFork": {
-			postgres: postgresCaps.RunFork,
-			sqlite:   sqliteCaps.RunFork,
-			reason:   "run.fork execution product seam split from operator reads",
-		},
-		"ResetCoordinator": {
-			postgres: postgresCaps.ResetCoordinator,
-			sqlite:   sqliteCaps.ResetCoordinator,
-			reason:   "destructive reset capability split from operator reads",
-		},
-		"ResetQuiescer": {
-			postgres: postgresCaps.ResetQuiescer,
-			sqlite:   sqliteCaps.ResetQuiescer,
-			reason:   "destructive reset capability split from operator reads",
-		},
-		"ResetCleaner": {
-			postgres: postgresCaps.ResetCleaner,
-			sqlite:   sqliteCaps.ResetCleaner,
-			reason:   "destructive reset capability split from operator reads",
-		},
+type selectedOperatorReadConstructionCapabilityEntry struct {
+	Name                     string
+	Classification           string
+	Issue                    int
+	RequiresPostgresBaseline bool
+	Reason                   string
+}
+
+func selectedOperatorReadConstructionCapabilityLedger() []selectedOperatorReadConstructionCapabilityEntry {
+	return []selectedOperatorReadConstructionCapabilityEntry{
+		{Name: "Database", Classification: "wired_both", Reason: "health.check/readiness pinger is selected on SQLite and Postgres"},
+		{Name: "Runs", Classification: "wired_both", Reason: "run.get/list/diagnose read owner is backend-neutral selected-store surface"},
+		{Name: "Entities", Classification: "wired_both", Reason: "entity.get/list/aggregate read owner is backend-neutral selected-store surface"},
+		{Name: "AgentConversations", Classification: "wired_both", Reason: "agent and conversation read owner was promoted by #1782/#1805"},
+		{Name: "Observability", Classification: "wired_both", Reason: "event/runtime log/run trace read owner is backend-neutral selected-store surface"},
+		{Name: "RunBundleContext", Classification: "wired_both", Reason: "served event.publish follow-up read context is required on both selected stores"},
+		{Name: "TestSetup", Classification: "wired_both", Reason: "test.setup_entities capability is selected through entity owner and remains mutating-ledger classified separately"},
+		{Name: "BundleCatalog", Classification: "wired_both", Reason: "bundle.list/get/agents read owner was promoted by #1782/#1805"},
+		{Name: "BundleDelete", Classification: "split_with_issue_ref", Issue: 1386, RequiresPostgresBaseline: true, Reason: "bundle.delete is a mutating/destructive bundle lifecycle capability, not operator-read parity"},
+		{Name: "ConversationForks", Classification: "split_with_issue_ref", Issue: 1783, RequiresPostgresBaseline: true, Reason: "ConversationForkLifecycleStore mixes fork_list/view reads with fork/fork_chat/fork_delete mutations and needs interface segregation"},
+		{Name: "RunForkAvailability", Classification: "split_with_issue_ref", Issue: 1386, RequiresPostgresBaseline: true, Reason: "run.fork availability is a product/mutating lifecycle seam split from operator reads"},
+		{Name: "RunFork", Classification: "split_with_issue_ref", Issue: 1386, RequiresPostgresBaseline: true, Reason: "run.fork execution is a product/mutating lifecycle seam split from operator reads"},
+		{Name: "RuntimeContexts", Classification: "split_with_issue_ref", Issue: 1239, Reason: "multi-bundle DB-loaded runtime context routing is conditional product/runtime support, not core operator-read parity"},
+		{Name: "ResetCoordinator", Classification: "split_with_issue_ref", Issue: 1239, RequiresPostgresBaseline: true, Reason: "destructive reset coordinator remains split from operator-read parity"},
+		{Name: "ResetQuiescer", Classification: "split_with_issue_ref", Issue: 1239, RequiresPostgresBaseline: true, Reason: "destructive reset quiescer remains split from operator-read parity"},
+		{Name: "ResetCleaner", Classification: "split_with_issue_ref", Issue: 1239, RequiresPostgresBaseline: true, Reason: "destructive reset cleaner remains split from operator-read parity"},
 	}
-	for name, caps := range classifiedSQLiteOmissions {
-		if caps.postgres == nil {
-			t.Fatalf("classified optional capability %s no longer has a postgres baseline; update #1782 construction-parity guard classification: %s", name, caps.reason)
-		}
-		if caps.sqlite != nil {
-			t.Fatalf("sqlite optional capability %s = %T, want nil until separately gated: %s", name, caps.sqlite, caps.reason)
-		}
+}
+
+func selectedAPICapabilityFieldNames() []string {
+	typ := reflect.TypeOf(selectedAPICapabilities{})
+	out := make([]string, 0, typ.NumField())
+	for i := 0; i < typ.NumField(); i++ {
+		out = append(out, typ.Field(i).Name)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func selectedAPICapabilityField(caps selectedAPICapabilities, name string) (reflect.Value, bool) {
+	value := reflect.ValueOf(caps).FieldByName(name)
+	if !value.IsValid() {
+		return reflect.Value{}, false
+	}
+	return value, true
+}
+
+func selectedAPICapabilityConfigured(value reflect.Value) bool {
+	if !value.IsValid() {
+		return false
+	}
+	switch value.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Pointer, reflect.Slice:
+		return !value.IsNil()
+	default:
+		return !value.IsZero()
 	}
 }
 

--- a/internal/apiv1/public_surface_backend_matrix_test.go
+++ b/internal/apiv1/public_surface_backend_matrix_test.go
@@ -62,12 +62,13 @@ type publicSurfaceMatrixRow struct {
 }
 
 type publicSurfaceProofRef struct {
-	Kind      string `yaml:"kind"`
-	Name      string `yaml:"name,omitempty"`
-	Path      string `yaml:"path,omitempty"`
-	Issue     int    `yaml:"issue,omitempty"`
-	Watchlist string `yaml:"watchlist,omitempty"`
-	Command   string `yaml:"command,omitempty"`
+	Kind      string   `yaml:"kind"`
+	Name      string   `yaml:"name,omitempty"`
+	Path      string   `yaml:"path,omitempty"`
+	Issue     int      `yaml:"issue,omitempty"`
+	Watchlist string   `yaml:"watchlist,omitempty"`
+	Command   string   `yaml:"command,omitempty"`
+	Backends  []string `yaml:"backends,omitempty"`
 }
 
 type publicSurfaceMutatingAPIParityEntry struct {
@@ -505,10 +506,21 @@ func TestPublicSurfaceBackendMatrixRejectsStaleReferences(t *testing.T) {
 			mutate: func(matrix *publicSurfaceBackendMatrix) {
 				entry := publicSurfaceOperatorReadLedgerEntryByMethod(t, matrix, "agent.list")
 				entry.ProofRefs = []publicSurfaceProofRef{
-					{Kind: "go_test", Name: "TestOpenRPCReadOnlyHTTPRuntimeProbes"},
+					{Kind: "go_test", Name: "TestOpenRPCReadOnlyHTTPRuntimeProbes", Backends: []string{"default_sqlite", "explicit_postgres"}},
 				}
 			},
-			want: "operator-read ledger method agent.list dual_backend_api_proof cannot rely only on adjacent fake-store/protocol probes",
+			want: "operator-read ledger method agent.list dual_backend_api_proof missing default_sqlite backend-scoped selected API proof_ref",
+		},
+		{
+			name: "operator-read api ledger rejects missing postgres-scoped dual proof",
+			mutate: func(matrix *publicSurfaceBackendMatrix) {
+				entry := publicSurfaceOperatorReadLedgerEntryByMethod(t, matrix, "agent.list")
+				entry.ProofRefs = []publicSurfaceProofRef{
+					{Kind: "go_test", Name: "TestSQLiteAgentConversationOwnerBacksSupportedAPISurface", Backends: []string{"default_sqlite"}},
+					{Kind: "go_test", Name: "TestOperatorAgentConversationHandlersExposeReadOwner"},
+				}
+			},
+			want: "operator-read ledger method agent.list dual_backend_api_proof missing explicit_postgres backend-scoped selected API proof_ref",
 		},
 		{
 			name: "operator-read api ledger rejects one backend dual proof",
@@ -1015,8 +1027,10 @@ func validatePublicSurfaceOperatorReadLedgerDualProof(label string, entry public
 	if !publicSurfaceSameStringSet(entry.Backends, []string{"default_sqlite", "explicit_postgres"}) {
 		problems = append(problems, fmt.Sprintf("%s dual_backend_api_proof backends = %v, want [default_sqlite explicit_postgres]", label, publicSurfaceSortedStrings(entry.Backends)))
 	}
-	if !publicSurfaceOperatorReadLedgerHasSelectedBackendProof(entry.ProofRefs) {
-		problems = append(problems, fmt.Sprintf("%s dual_backend_api_proof cannot rely only on adjacent fake-store/protocol probes", label))
+	for _, backend := range []string{"default_sqlite", "explicit_postgres"} {
+		if !publicSurfaceOperatorReadLedgerHasSelectedBackendProof(entry.ProofRefs, backend) {
+			problems = append(problems, fmt.Sprintf("%s dual_backend_api_proof missing %s backend-scoped selected API proof_ref", label, backend))
+		}
 	}
 	return problems
 }
@@ -1030,9 +1044,12 @@ func publicSurfaceOperatorReadLedgerHasGoTestProof(refs []publicSurfaceProofRef)
 	return false
 }
 
-func publicSurfaceOperatorReadLedgerHasSelectedBackendProof(refs []publicSurfaceProofRef) bool {
+func publicSurfaceOperatorReadLedgerHasSelectedBackendProof(refs []publicSurfaceProofRef, backend string) bool {
 	for _, ref := range refs {
 		if ref.Kind != "go_test" {
+			continue
+		}
+		if !publicSurfaceHasValue(ref.Backends, backend) {
 			continue
 		}
 		switch ref.Name {
@@ -1052,6 +1069,11 @@ func validatePublicSurfaceMutatingLedgerProofRefs(root, label string, refs []pub
 		if _, ok := allowedPublicSurfaceProofKinds()[kind]; !ok {
 			problems = append(problems, fmt.Sprintf("%s proof_ref kind %q is not allowed", label, kind))
 			continue
+		}
+		for _, backend := range ref.Backends {
+			if backend != "default_sqlite" && backend != "explicit_postgres" {
+				problems = append(problems, fmt.Sprintf("%s proof_ref backend %q is not allowed", label, backend))
+			}
 		}
 		switch kind {
 		case "go_test":

--- a/internal/apiv1/public_surface_backend_matrix_test.go
+++ b/internal/apiv1/public_surface_backend_matrix_test.go
@@ -109,6 +109,11 @@ type publicSurfaceValidationContext struct {
 	servedScenarios        map[string]servedparity.Scenario
 }
 
+type publicSurfaceSelectedOperatorReadAPIProof struct {
+	Methods  []string
+	Backends []string
+}
+
 type publicSurfaceAPIMethodInfo struct {
 	Deprecated  bool
 	Description string
@@ -521,6 +526,17 @@ func TestPublicSurfaceBackendMatrixRejectsStaleReferences(t *testing.T) {
 				}
 			},
 			want: "operator-read ledger method agent.list dual_backend_api_proof missing explicit_postgres backend-scoped selected API proof_ref",
+		},
+		{
+			name: "operator-read api ledger rejects backend-labeled store-only dual proof",
+			mutate: func(matrix *publicSurfaceBackendMatrix) {
+				entry := publicSurfaceOperatorReadLedgerEntryByMethod(t, matrix, "runtime.logs")
+				entry.ProofRefs = []publicSurfaceProofRef{
+					{Kind: "go_test", Name: "TestSQLiteRuntimeLogPersistenceWritesLoggerRowsForObservability", Backends: []string{"default_sqlite"}},
+					{Kind: "go_test", Name: "TestPostgresRuntimeLogPersistencePreservesRunSourceAndLineage", Backends: []string{"explicit_postgres"}},
+				}
+			},
+			want: "operator-read ledger method runtime.logs proof_ref TestSQLiteRuntimeLogPersistenceWritesLoggerRowsForObservability scoped to default_sqlite is not a registered selected API proof for method runtime.logs",
 		},
 		{
 			name: "operator-read api ledger rejects one backend dual proof",
@@ -1028,8 +1044,18 @@ func validatePublicSurfaceOperatorReadLedgerDualProof(label string, entry public
 		problems = append(problems, fmt.Sprintf("%s dual_backend_api_proof backends = %v, want [default_sqlite explicit_postgres]", label, publicSurfaceSortedStrings(entry.Backends)))
 	}
 	for _, backend := range []string{"default_sqlite", "explicit_postgres"} {
-		if !publicSurfaceOperatorReadLedgerHasSelectedBackendProof(entry.ProofRefs, backend) {
+		if !publicSurfaceOperatorReadLedgerHasSelectedBackendProof(entry.ProofRefs, entry.Method, backend) {
 			problems = append(problems, fmt.Sprintf("%s dual_backend_api_proof missing %s backend-scoped selected API proof_ref", label, backend))
+		}
+	}
+	for _, ref := range entry.ProofRefs {
+		if ref.Kind != "go_test" || len(ref.Backends) == 0 {
+			continue
+		}
+		for _, backend := range ref.Backends {
+			if !publicSurfaceOperatorReadProofRefCoversMethodBackend(ref, entry.Method, backend) {
+				problems = append(problems, fmt.Sprintf("%s proof_ref %s scoped to %s is not a registered selected API proof for method %s", label, ref.Name, backend, entry.Method))
+			}
 		}
 	}
 	return problems
@@ -1044,22 +1070,129 @@ func publicSurfaceOperatorReadLedgerHasGoTestProof(refs []publicSurfaceProofRef)
 	return false
 }
 
-func publicSurfaceOperatorReadLedgerHasSelectedBackendProof(refs []publicSurfaceProofRef, backend string) bool {
+func publicSurfaceOperatorReadLedgerHasSelectedBackendProof(refs []publicSurfaceProofRef, method, backend string) bool {
 	for _, ref := range refs {
 		if ref.Kind != "go_test" {
 			continue
 		}
-		if !publicSurfaceHasValue(ref.Backends, backend) {
-			continue
-		}
-		switch ref.Name {
-		case "TestOpenRPCReadOnlyHTTPRuntimeProbes", "TestOpenRPCWebSocketRuntimeProbes":
-			continue
-		default:
+		if publicSurfaceOperatorReadProofRefCoversMethodBackend(ref, method, backend) {
 			return true
 		}
 	}
 	return false
+}
+
+func publicSurfaceOperatorReadProofRefCoversMethodBackend(ref publicSurfaceProofRef, method, backend string) bool {
+	if ref.Kind != "go_test" || !publicSurfaceHasValue(ref.Backends, backend) {
+		return false
+	}
+	proof, ok := publicSurfaceSelectedOperatorReadAPIProofs()[strings.TrimSpace(ref.Name)]
+	if !ok {
+		return false
+	}
+	return publicSurfaceHasValue(proof.Backends, backend) && publicSurfaceHasValue(proof.Methods, method)
+}
+
+func publicSurfaceSelectedOperatorReadAPIProofs() map[string]publicSurfaceSelectedOperatorReadAPIProof {
+	return map[string]publicSurfaceSelectedOperatorReadAPIProof{
+		"TestSQLiteAgentConversationOwnerBacksSupportedAPISurface": {
+			Backends: []string{"default_sqlite"},
+			Methods: []string{
+				"agent.delivery_diagnostics",
+				"agent.diagnose",
+				"agent.get",
+				"agent.list",
+				"conversation.current_for_agent",
+				"conversation.get",
+				"conversation.get_turn",
+				"conversation.list",
+			},
+		},
+		"TestOperatorAgentReadSurfaceLoadAgentDeliveryDiagnosticsPromotesCanonicalOwner": {
+			Backends: []string{"explicit_postgres"},
+			Methods:  []string{"agent.delivery_diagnostics"},
+		},
+		"TestSQLiteAgentDeliveryLifecycleOwnerBacksSupportedAPISurface": {
+			Backends: []string{"default_sqlite"},
+			Methods:  []string{"agent.delivery_lifecycle"},
+		},
+		"TestOperatorAgentReadSurfaceLoadAgentDeliveryLifecyclePostgres": {
+			Backends: []string{"explicit_postgres"},
+			Methods:  []string{"agent.delivery_lifecycle"},
+		},
+		"TestOperatorAgentReadSurfaceLoadAgentDiagnosisUsesSelectedOwners": {
+			Backends: []string{"explicit_postgres"},
+			Methods:  []string{"agent.diagnose"},
+		},
+		"TestOperatorAgentReadSurfaceLoadAgentProjectsSessionAndTurnRefs": {
+			Backends: []string{"explicit_postgres"},
+			Methods:  []string{"agent.get", "conversation.current_for_agent", "conversation.get", "conversation.get_turn"},
+		},
+		"TestOperatorAgentReadSurfaceListAgentsDoesNotDeriveStatusFromActiveLease": {
+			Backends: []string{"explicit_postgres"},
+			Methods:  []string{"agent.list", "conversation.list"},
+		},
+		"TestSQLiteAgentUsageOwnerBacksSupportedAPISurface": {
+			Backends: []string{"default_sqlite"},
+			Methods:  []string{"agent.usage"},
+		},
+		"TestOperatorAgentReadSurfaceLoadAgentUsageSplitsExactAndEstimated": {
+			Backends: []string{"explicit_postgres"},
+			Methods:  []string{"agent.usage"},
+		},
+		"TestSQLiteBundleCatalogOwnerBacksSupportedAPISurface": {
+			Backends: []string{"default_sqlite"},
+			Methods:  []string{"bundle.agents", "bundle.get", "bundle.list"},
+		},
+		"TestBundleCatalogReadSurfaceListGetAgentsAndCursor": {
+			Backends: []string{"explicit_postgres"},
+			Methods:  []string{"bundle.agents", "bundle.get", "bundle.list"},
+		},
+		"TestOperatorEntityHandlersServeContractEntityTypesFromSQLite": {
+			Backends: []string{"default_sqlite"},
+			Methods:  []string{"entity.aggregate", "entity.get", "entity.list"},
+		},
+		"TestOperatorEntityHandlersServeContractEntityTypesFromPostgres": {
+			Backends: []string{"explicit_postgres"},
+			Methods:  []string{"entity.aggregate", "entity.get", "entity.list"},
+		},
+		"TestOperatorEventPublishSQLiteIdempotentFirstEventPublishesWithoutLock": {
+			Backends: []string{"default_sqlite"},
+			Methods:  []string{"event.get", "event.list"},
+		},
+		"TestOperatorEventPublishHandlersPersistEventReportDeliveriesAndReplayIdempotency": {
+			Backends: []string{"explicit_postgres"},
+			Methods:  []string{"event.get", "event.list"},
+		},
+		"TestBuildStoresAcceptsSQLiteSelectedCoreRuntimeStore": {
+			Backends: []string{"default_sqlite"},
+			Methods:  []string{"health.check"},
+		},
+		"TestRunServeRuntimeFreshEmptyPostgresBootstrapsSchemaBeforeDiskContractsServe": {
+			Backends: []string{"explicit_postgres"},
+			Methods:  []string{"health.check"},
+		},
+		"TestOperatorMailboxWriteSupportedSurfacePublishesAndReadsAcrossBackends": {
+			Backends: []string{"default_sqlite", "explicit_postgres"},
+			Methods:  []string{"mailbox.get", "mailbox.list"},
+		},
+		"TestSQLiteRunAPIReadSurface_LoadListAndDiagnoseEvidence": {
+			Backends: []string{"default_sqlite"},
+			Methods:  []string{"run.diagnose", "run.get", "run.list"},
+		},
+		"TestRunAPIReadSurface_LoadAndListRunHeaders": {
+			Backends: []string{"explicit_postgres"},
+			Methods:  []string{"run.diagnose", "run.get", "run.list"},
+		},
+		"TestSQLiteObservabilityOwnerBacksSupportedAPISurfaces": {
+			Backends: []string{"default_sqlite"},
+			Methods:  []string{"run.trace", "runtime.incidents", "runtime.logs"},
+		},
+		"TestPostgresObservabilityOwnerBacksSupportedAPISurfaces": {
+			Backends: []string{"explicit_postgres"},
+			Methods:  []string{"run.trace", "runtime.incidents", "runtime.logs"},
+		},
+	}
 }
 
 func validatePublicSurfaceMutatingLedgerProofRefs(root, label string, refs []publicSurfaceProofRef, ctx publicSurfaceValidationContext, activeTrackers map[string]struct{}) []string {

--- a/internal/apiv1/public_surface_backend_matrix_test.go
+++ b/internal/apiv1/public_surface_backend_matrix_test.go
@@ -18,15 +18,16 @@ import (
 const publicSurfaceBackendMatrixPath = "internal/apiv1/testdata/public_surface_backend_matrix.yaml"
 
 type publicSurfaceBackendMatrix struct {
-	Version        int                                   `yaml:"version"`
-	Kind           string                                `yaml:"kind"`
-	Issue          int                                   `yaml:"issue"`
-	IssueRole      string                                `yaml:"issue_role"`
-	Source         publicSurfaceMatrixSource             `yaml:"source"`
-	Policy         publicSurfaceMatrixPolicy             `yaml:"policy"`
-	ActiveTrackers []complianceActiveTracker             `yaml:"active_trackers"`
-	MutatingLedger []publicSurfaceMutatingAPIParityEntry `yaml:"mutating_api_parity_ledger"`
-	Rows           []publicSurfaceMatrixRow              `yaml:"rows"`
+	Version            int                                       `yaml:"version"`
+	Kind               string                                    `yaml:"kind"`
+	Issue              int                                       `yaml:"issue"`
+	IssueRole          string                                    `yaml:"issue_role"`
+	Source             publicSurfaceMatrixSource                 `yaml:"source"`
+	Policy             publicSurfaceMatrixPolicy                 `yaml:"policy"`
+	ActiveTrackers     []complianceActiveTracker                 `yaml:"active_trackers"`
+	MutatingLedger     []publicSurfaceMutatingAPIParityEntry     `yaml:"mutating_api_parity_ledger"`
+	OperatorReadLedger []publicSurfaceOperatorReadAPIParityEntry `yaml:"operator_read_api_parity_ledger"`
+	Rows               []publicSurfaceMatrixRow                  `yaml:"rows"`
 }
 
 type publicSurfaceMatrixSource struct {
@@ -36,11 +37,12 @@ type publicSurfaceMatrixSource struct {
 }
 
 type publicSurfaceMatrixPolicy struct {
-	ClosureLevel                          string `yaml:"closure_level"`
-	ClaimsParentClosure                   bool   `yaml:"claims_parent_closure"`
-	NamedFullConformanceCommand           string `yaml:"named_full_conformance_command"`
-	RequiredSmokePolicy                   string `yaml:"required_smoke_policy"`
-	MutatingAPIParityClassificationPolicy string `yaml:"mutating_api_parity_classification_policy"`
+	ClosureLevel                              string `yaml:"closure_level"`
+	ClaimsParentClosure                       bool   `yaml:"claims_parent_closure"`
+	NamedFullConformanceCommand               string `yaml:"named_full_conformance_command"`
+	RequiredSmokePolicy                       string `yaml:"required_smoke_policy"`
+	MutatingAPIParityClassificationPolicy     string `yaml:"mutating_api_parity_classification_policy"`
+	OperatorReadAPIParityClassificationPolicy string `yaml:"operator_read_api_parity_classification_policy"`
 }
 
 type publicSurfaceMatrixRow struct {
@@ -82,15 +84,28 @@ type publicSurfaceMutatingAPIParityEntry struct {
 	Notes             string                  `yaml:"notes,omitempty"`
 }
 
+type publicSurfaceOperatorReadAPIParityEntry struct {
+	Method           string                  `yaml:"method"`
+	Classification   string                  `yaml:"classification"`
+	Backends         []string                `yaml:"backends,omitempty"`
+	SpecRef          string                  `yaml:"spec_ref,omitempty"`
+	SplitIssue       int                     `yaml:"split_issue,omitempty"`
+	UnsupportedIssue int                     `yaml:"unsupported_issue,omitempty"`
+	ProofRefs        []publicSurfaceProofRef `yaml:"proof_refs"`
+	Notes            string                  `yaml:"notes,omitempty"`
+}
+
 type publicSurfaceValidationContext struct {
-	apiMethods           map[string]struct{}
-	apiMethodInfo        map[string]publicSurfaceAPIMethodInfo
-	mutatingAPIMethods   map[string]struct{}
-	openRPCMethods       map[string]struct{}
-	openRPCMatrixMethods map[string]struct{}
-	cliCommands          map[string]struct{}
-	goTests              map[string]string
-	servedScenarios      map[string]servedparity.Scenario
+	apiMethods             map[string]struct{}
+	apiMethodInfo          map[string]publicSurfaceAPIMethodInfo
+	mutatingAPIMethods     map[string]struct{}
+	operatorReadAPIMethods map[string]struct{}
+	openRPCMethods         map[string]struct{}
+	openRPCMatrixMethods   map[string]struct{}
+	openRPCMatrixTransport map[string]string
+	cliCommands            map[string]struct{}
+	goTests                map[string]string
+	servedScenarios        map[string]servedparity.Scenario
 }
 
 type publicSurfaceAPIMethodInfo struct {
@@ -445,6 +460,65 @@ func TestPublicSurfaceBackendMatrixRejectsStaleReferences(t *testing.T) {
 			want: "ledger method event.publish dual_backend_served_proof backends = [default_sqlite], want [default_sqlite explicit_postgres]",
 		},
 		{
+			name: "operator-read api ledger rejects unclassified method",
+			mutate: func(matrix *publicSurfaceBackendMatrix) {
+				matrix.OperatorReadLedger = publicSurfaceOperatorReadLedgerExcept(matrix.OperatorReadLedger, "agent.list")
+			},
+			want: "operator-read api parity ledger missing method agent.list",
+		},
+		{
+			name: "operator-read api ledger rejects stale split issue ref",
+			mutate: func(matrix *publicSurfaceBackendMatrix) {
+				entry := publicSurfaceOperatorReadLedgerEntryByMethod(t, matrix, "conversation.fork_list")
+				entry.SplitIssue = 999999
+				entry.ProofRefs = []publicSurfaceProofRef{
+					{Kind: "tracker", Issue: 999999, Watchlist: "runtime_operations.runtime_store_backend_default_and_sqlite_portability"},
+				}
+			},
+			want: "operator-read ledger method conversation.fork_list split issue #999999 is not active",
+		},
+		{
+			name: "operator-read api ledger rejects stale spec ref",
+			mutate: func(matrix *publicSurfaceBackendMatrix) {
+				entry := publicSurfaceOperatorReadLedgerEntryByMethod(t, matrix, "agent.list")
+				entry.Classification = "postgres_only_with_spec_ref"
+				entry.Backends = []string{"postgres_only"}
+				entry.SpecRef = "platform-spec.yaml#api_specification.missing_operator_read_anchor"
+			},
+			want: "operator-read ledger method agent.list spec_ref platform-spec.yaml#api_specification.missing_operator_read_anchor does not resolve",
+		},
+		{
+			name: "operator-read api ledger rejects broad postgres only publication ref",
+			mutate: func(matrix *publicSurfaceBackendMatrix) {
+				entry := publicSurfaceOperatorReadLedgerEntryByMethod(t, matrix, "agent.list")
+				entry.Classification = "postgres_only_with_spec_ref"
+				entry.Backends = []string{"postgres_only"}
+				entry.SpecRef = "platform-spec.yaml#api_specification.method_catalog"
+				entry.ProofRefs = []publicSurfaceProofRef{
+					{Kind: "artifact", Path: "platform-spec.yaml"},
+				}
+			},
+			want: "operator-read ledger method agent.list postgres_only_with_spec_ref spec_ref platform-spec.yaml#api_specification.method_catalog is publication-only, not backend-support authority",
+		},
+		{
+			name: "operator-read api ledger rejects fake-store-only dual proof",
+			mutate: func(matrix *publicSurfaceBackendMatrix) {
+				entry := publicSurfaceOperatorReadLedgerEntryByMethod(t, matrix, "agent.list")
+				entry.ProofRefs = []publicSurfaceProofRef{
+					{Kind: "go_test", Name: "TestOpenRPCReadOnlyHTTPRuntimeProbes"},
+				}
+			},
+			want: "operator-read ledger method agent.list dual_backend_api_proof cannot rely only on adjacent fake-store/protocol probes",
+		},
+		{
+			name: "operator-read api ledger rejects one backend dual proof",
+			mutate: func(matrix *publicSurfaceBackendMatrix) {
+				entry := publicSurfaceOperatorReadLedgerEntryByMethod(t, matrix, "agent.list")
+				entry.Backends = []string{"default_sqlite"}
+			},
+			want: "operator-read ledger method agent.list dual_backend_api_proof backends = [default_sqlite], want [default_sqlite explicit_postgres]",
+		},
+		{
 			name: "mutating api ledger rejects transitive coverage without covered method",
 			mutate: func(matrix *publicSurfaceBackendMatrix) {
 				entry := publicSurfaceMutatingLedgerEntryByMethod(t, matrix, "run.start")
@@ -566,24 +640,36 @@ func newPublicSurfaceValidationContext(t *testing.T, root string) publicSurfaceV
 	for _, method := range api.Conventions.Idempotency.MutatingMethods {
 		mutatingAPIMethods[strings.TrimSpace(method)] = struct{}{}
 	}
+	operatorReadAPIMethods := map[string]struct{}{}
+	for method := range apiMethods {
+		if _, mutating := mutatingAPIMethods[method]; mutating {
+			continue
+		}
+		operatorReadAPIMethods[method] = struct{}{}
+	}
 	openRPCMethods := map[string]struct{}{}
 	for _, method := range doc.Methods {
 		openRPCMethods[strings.TrimSpace(method.Name)] = struct{}{}
 	}
 	openRPCMatrixMethods := map[string]struct{}{}
+	openRPCMatrixTransport := map[string]string{}
 	for _, row := range openRPCMatrix.Methods {
-		openRPCMatrixMethods[strings.TrimSpace(row.Method)] = struct{}{}
+		method := strings.TrimSpace(row.Method)
+		openRPCMatrixMethods[method] = struct{}{}
+		openRPCMatrixTransport[method] = strings.TrimSpace(row.Transport)
 	}
 
 	return publicSurfaceValidationContext{
-		apiMethods:           apiMethods,
-		apiMethodInfo:        apiMethodInfo,
-		mutatingAPIMethods:   mutatingAPIMethods,
-		openRPCMethods:       openRPCMethods,
-		openRPCMatrixMethods: openRPCMatrixMethods,
-		cliCommands:          loadPublicSurfaceCLICommands(t, root),
-		goTests:              goTests,
-		servedScenarios:      loadPublicSurfaceServedParityScenarios(),
+		apiMethods:             apiMethods,
+		apiMethodInfo:          apiMethodInfo,
+		mutatingAPIMethods:     mutatingAPIMethods,
+		operatorReadAPIMethods: operatorReadAPIMethods,
+		openRPCMethods:         openRPCMethods,
+		openRPCMatrixMethods:   openRPCMatrixMethods,
+		openRPCMatrixTransport: openRPCMatrixTransport,
+		cliCommands:            loadPublicSurfaceCLICommands(t, root),
+		goTests:                goTests,
+		servedScenarios:        loadPublicSurfaceServedParityScenarios(),
 	}
 }
 
@@ -638,6 +724,9 @@ func validatePublicSurfaceBackendMatrix(root string, matrix publicSurfaceBackend
 	if _, ok := activeTrackers[trackerKey(1386, "runtime_operations.runtime_store_backend_default_and_sqlite_portability")]; !ok {
 		problems = append(problems, "active_trackers missing #1386 runtime_store_backend_default_and_sqlite_portability")
 	}
+	if _, ok := activeTrackers[trackerKey(1783, "runtime_operations.runtime_store_backend_default_and_sqlite_portability")]; !ok {
+		problems = append(problems, "active_trackers missing #1783 runtime_store_backend_default_and_sqlite_portability")
+	}
 	if _, ok := activeTrackers[trackerKey(1254, "runtime_operations.runtime_store_backend_default_and_sqlite_portability")]; ok {
 		problems = append(problems, "active_trackers must not include closed #1254 runtime_store_backend_default_and_sqlite_portability")
 	}
@@ -648,6 +737,7 @@ func validatePublicSurfaceBackendMatrix(root string, matrix publicSurfaceBackend
 		problems = append(problems, "active_trackers missing operator_surfaces.v1_openrpc_api_conformance watchlist")
 	}
 	problems = append(problems, validatePublicSurfaceMutatingAPIParityLedger(root, matrix.MutatingLedger, ctx, activeTrackers)...)
+	problems = append(problems, validatePublicSurfaceOperatorReadAPIParityLedger(root, matrix.OperatorReadLedger, ctx, activeTrackers)...)
 
 	rowsByID := map[string]publicSurfaceMatrixRow{}
 	requiredRows := requiredPublicSurfaceRows()
@@ -841,6 +931,118 @@ func validatePublicSurfaceMutatingAPIParityLedger(root string, entries []publicS
 		}
 	}
 	return problems
+}
+
+func validatePublicSurfaceOperatorReadAPIParityLedger(root string, entries []publicSurfaceOperatorReadAPIParityEntry, ctx publicSurfaceValidationContext, activeTrackers map[string]struct{}) []string {
+	var problems []string
+	if len(entries) == 0 {
+		return []string{"operator-read api parity ledger is required"}
+	}
+	seen := map[string]struct{}{}
+	for _, entry := range entries {
+		method := strings.TrimSpace(entry.Method)
+		label := fmt.Sprintf("operator-read ledger method %s", method)
+		if method == "" {
+			problems = append(problems, "operator-read api parity ledger entry missing method")
+			continue
+		}
+		if _, exists := seen[method]; exists {
+			problems = append(problems, fmt.Sprintf("%s appears more than once", label))
+		}
+		seen[method] = struct{}{}
+		if _, ok := ctx.operatorReadAPIMethods[method]; !ok {
+			problems = append(problems, fmt.Sprintf("%s is not a non-mutating platform method_catalog method", label))
+		}
+		if _, ok := ctx.apiMethods[method]; !ok {
+			problems = append(problems, fmt.Sprintf("%s missing from platform method_catalog", label))
+		}
+		if _, ok := ctx.openRPCMethods[method]; !ok {
+			problems = append(problems, fmt.Sprintf("%s missing from generated openrpc.json", label))
+		}
+		if len(entry.ProofRefs) == 0 {
+			problems = append(problems, fmt.Sprintf("%s missing proof_refs", label))
+		}
+		problems = append(problems, validatePublicSurfaceMutatingLedgerProofRefs(root, label, entry.ProofRefs, ctx, activeTrackers)...)
+		if _, ok := allowedPublicSurfaceOperatorReadLedgerClassifications()[entry.Classification]; !ok {
+			problems = append(problems, fmt.Sprintf("%s classification %q is not allowed", label, entry.Classification))
+			continue
+		}
+		switch entry.Classification {
+		case "dual_backend_api_proof":
+			problems = append(problems, validatePublicSurfaceOperatorReadLedgerDualProof(label, entry)...)
+		case "different_semantic_concept_with_proof":
+			if !publicSurfaceOperatorReadLedgerHasGoTestProof(entry.ProofRefs) {
+				problems = append(problems, fmt.Sprintf("%s different_semantic_concept_with_proof requires executable go_test proof_ref", label))
+			}
+			if transport := ctx.openRPCMatrixTransport[method]; transport == "http" && !strings.Contains(strings.ToLower(entry.Notes), "non-store") && !strings.Contains(strings.ToLower(entry.Notes), "static") {
+				problems = append(problems, fmt.Sprintf("%s different_semantic_concept_with_proof over HTTP method requires notes naming non-store/static reason", label))
+			}
+		case "postgres_only_with_spec_ref":
+			if !publicSurfaceSameStringSet(entry.Backends, []string{"postgres_only"}) {
+				problems = append(problems, fmt.Sprintf("%s postgres_only_with_spec_ref backends = %v, want [postgres_only]", label, publicSurfaceSortedStrings(entry.Backends)))
+			}
+			if strings.TrimSpace(entry.SpecRef) == "" {
+				problems = append(problems, fmt.Sprintf("%s postgres_only_with_spec_ref missing spec_ref", label))
+			} else if err := publicSurfaceSpecRefExists(root, entry.SpecRef); err != nil {
+				problems = append(problems, fmt.Sprintf("%s spec_ref %s does not resolve: %v", label, entry.SpecRef, err))
+			} else if publicSurfaceSpecRefIsPublicationOnly(entry.SpecRef) {
+				problems = append(problems, fmt.Sprintf("%s postgres_only_with_spec_ref spec_ref %s is publication-only, not backend-support authority", label, entry.SpecRef))
+			}
+		case "split_with_issue_ref":
+			if entry.SplitIssue == 0 {
+				problems = append(problems, fmt.Sprintf("%s split_with_issue_ref missing split_issue", label))
+			} else if !publicSurfaceLedgerHasTrackerIssue(entry.ProofRefs, entry.SplitIssue, activeTrackers) {
+				problems = append(problems, fmt.Sprintf("%s split issue #%d is not active", label, entry.SplitIssue))
+			}
+		case "unsupported_with_issue_ref":
+			if entry.UnsupportedIssue == 0 {
+				problems = append(problems, fmt.Sprintf("%s unsupported_with_issue_ref missing unsupported_issue", label))
+			} else if !publicSurfaceLedgerHasTrackerIssue(entry.ProofRefs, entry.UnsupportedIssue, activeTrackers) {
+				problems = append(problems, fmt.Sprintf("%s unsupported issue #%d is not active", label, entry.UnsupportedIssue))
+			}
+		}
+	}
+	for method := range ctx.operatorReadAPIMethods {
+		if _, ok := seen[method]; !ok {
+			problems = append(problems, fmt.Sprintf("operator-read api parity ledger missing method %s", method))
+		}
+	}
+	return problems
+}
+
+func validatePublicSurfaceOperatorReadLedgerDualProof(label string, entry publicSurfaceOperatorReadAPIParityEntry) []string {
+	var problems []string
+	if !publicSurfaceSameStringSet(entry.Backends, []string{"default_sqlite", "explicit_postgres"}) {
+		problems = append(problems, fmt.Sprintf("%s dual_backend_api_proof backends = %v, want [default_sqlite explicit_postgres]", label, publicSurfaceSortedStrings(entry.Backends)))
+	}
+	if !publicSurfaceOperatorReadLedgerHasSelectedBackendProof(entry.ProofRefs) {
+		problems = append(problems, fmt.Sprintf("%s dual_backend_api_proof cannot rely only on adjacent fake-store/protocol probes", label))
+	}
+	return problems
+}
+
+func publicSurfaceOperatorReadLedgerHasGoTestProof(refs []publicSurfaceProofRef) bool {
+	for _, ref := range refs {
+		if ref.Kind == "go_test" && strings.TrimSpace(ref.Name) != "" {
+			return true
+		}
+	}
+	return false
+}
+
+func publicSurfaceOperatorReadLedgerHasSelectedBackendProof(refs []publicSurfaceProofRef) bool {
+	for _, ref := range refs {
+		if ref.Kind != "go_test" {
+			continue
+		}
+		switch ref.Name {
+		case "TestOpenRPCReadOnlyHTTPRuntimeProbes", "TestOpenRPCWebSocketRuntimeProbes":
+			continue
+		default:
+			return true
+		}
+	}
+	return false
 }
 
 func validatePublicSurfaceMutatingLedgerProofRefs(root, label string, refs []publicSurfaceProofRef, ctx publicSurfaceValidationContext, activeTrackers map[string]struct{}) []string {
@@ -1259,6 +1461,12 @@ func validatePublicSurfacePolicy(policy publicSurfaceMatrixPolicy) []string {
 	} else if !strings.Contains(classificationPolicy, "covered_transitively") || !strings.Contains(strings.ToLower(classificationPolicy), "deprecated wrapper") {
 		problems = append(problems, "policy mutating_api_parity_classification_policy must document covered_transitively deprecated wrapper handling")
 	}
+	operatorReadPolicy := strings.TrimSpace(policy.OperatorReadAPIParityClassificationPolicy)
+	if operatorReadPolicy == "" {
+		problems = append(problems, "policy operator_read_api_parity_classification_policy missing")
+	} else if !strings.Contains(operatorReadPolicy, "dual_backend_api_proof") || !strings.Contains(operatorReadPolicy, "fake-store") || !strings.Contains(operatorReadPolicy, "different_semantic_concept_with_proof") {
+		problems = append(problems, "policy operator_read_api_parity_classification_policy must document dual backend proof, fake-store exclusion, and different concept classification")
+	}
 	return problems
 }
 
@@ -1509,6 +1717,17 @@ func publicSurfaceMutatingLedgerEntryByMethod(t *testing.T, matrix *publicSurfac
 	return nil
 }
 
+func publicSurfaceOperatorReadLedgerEntryByMethod(t *testing.T, matrix *publicSurfaceBackendMatrix, method string) *publicSurfaceOperatorReadAPIParityEntry {
+	t.Helper()
+	for i := range matrix.OperatorReadLedger {
+		if matrix.OperatorReadLedger[i].Method == method {
+			return &matrix.OperatorReadLedger[i]
+		}
+	}
+	t.Fatalf("operator-read api parity ledger method %s not found", method)
+	return nil
+}
+
 func publicSurfaceMutatingLedgerEntry(entries []publicSurfaceMutatingAPIParityEntry, method string) (publicSurfaceMutatingAPIParityEntry, bool) {
 	for _, entry := range entries {
 		if entry.Method == method {
@@ -1683,6 +1902,17 @@ func publicSurfaceMutatingLedgerExcept(entries []publicSurfaceMutatingAPIParityE
 	return out
 }
 
+func publicSurfaceOperatorReadLedgerExcept(entries []publicSurfaceOperatorReadAPIParityEntry, remove string) []publicSurfaceOperatorReadAPIParityEntry {
+	out := entries[:0]
+	for _, entry := range entries {
+		if entry.Method == remove {
+			continue
+		}
+		out = append(out, entry)
+	}
+	return out
+}
+
 func publicSurfaceSameStringSet(actual, want []string) bool {
 	actualSorted := publicSurfaceSortedStrings(actual)
 	wantSorted := publicSurfaceSortedStrings(want)
@@ -1741,6 +1971,16 @@ func allowedPublicSurfaceMutatingLedgerClassifications() map[string]struct{} {
 	return complianceStringSet([]string{
 		"dual_backend_served_proof",
 		"covered_transitively",
+		"postgres_only_with_spec_ref",
+		"unsupported_with_issue_ref",
+		"split_with_issue_ref",
+	})
+}
+
+func allowedPublicSurfaceOperatorReadLedgerClassifications() map[string]struct{} {
+	return complianceStringSet([]string{
+		"dual_backend_api_proof",
+		"different_semantic_concept_with_proof",
 		"postgres_only_with_spec_ref",
 		"unsupported_with_issue_ref",
 		"split_with_issue_ref",

--- a/internal/apiv1/sqlite_observability_supported_surface_test.go
+++ b/internal/apiv1/sqlite_observability_supported_surface_test.go
@@ -14,12 +14,24 @@ import (
 	runtimecorrelation "github.com/division-sh/swarm/internal/runtime/correlation"
 	storepkg "github.com/division-sh/swarm/internal/store"
 	"github.com/division-sh/swarm/internal/store/storetest"
+	"github.com/division-sh/swarm/internal/testutil"
 	"github.com/google/uuid"
 )
 
 func TestSQLiteObservabilityOwnerBacksSupportedAPISurfaces(t *testing.T) {
 	ctx := context.Background()
 	fixture := newSQLiteObservabilitySurfaceFixture(t, ctx)
+	assertObservabilityOwnerBacksSupportedAPISurfaces(t, fixture)
+}
+
+func TestPostgresObservabilityOwnerBacksSupportedAPISurfaces(t *testing.T) {
+	ctx := context.Background()
+	fixture := newPostgresObservabilitySurfaceFixture(t, ctx)
+	assertObservabilityOwnerBacksSupportedAPISurfaces(t, fixture)
+}
+
+func assertObservabilityOwnerBacksSupportedAPISurfaces(t *testing.T, fixture observabilitySurfaceFixture) {
+	t.Helper()
 	readOpts := OperatorReadOptions{
 		Now:           func() time.Time { return fixture.now.Add(time.Minute) },
 		Observability: fixture.store,
@@ -62,21 +74,29 @@ func TestSQLiteObservabilityOwnerBacksSupportedAPISurfaces(t *testing.T) {
 		t.Fatalf("runtime.logs source miss rows = %#v, want none", rows)
 	}
 
+	incidents := rpcCall(t, handler, `{"jsonrpc":"2.0","id":"incidents","method":"runtime.incidents","params":{"component":"scheduler","level":"error","limit":10}}`)
+	if incidents.Error != nil {
+		t.Fatalf("runtime.incidents error = %#v", incidents.Error)
+	}
+	if rows, _ := asMap(t, incidents.Result)["incidents"].([]any); len(rows) != 1 || asMap(t, rows[0])["error_code"] != fixture.incidentCode {
+		t.Fatalf("runtime.incidents rows = %#v, want incident %s", asMap(t, incidents.Result)["incidents"], fixture.incidentCode)
+	}
+
 	server := httptest.NewServer(handler)
 	defer server.Close()
-	assertSQLiteSubscriptionNotification(t, server.URL, "event.subscribe", map[string]any{
+	assertObservabilitySubscriptionNotification(t, server.URL, "event.subscribe", map[string]any{
 		"filter": map[string]any{
 			"run_id":     fixture.runID,
 			"event_name": "trace.visible",
 		},
 		"replay_since": fixture.now.Add(-time.Minute).Format(time.RFC3339Nano),
 	}, "event_id", fixture.eventID)
-	assertSQLiteSubscriptionNotification(t, server.URL, "run.subscribe_trace", map[string]any{
+	assertObservabilitySubscriptionNotification(t, server.URL, "run.subscribe_trace", map[string]any{
 		"run_id":       fixture.runID,
 		"filter":       map[string]any{"event_name": []any{"trace.visible"}},
 		"replay_since": fixture.now.Add(-time.Minute).Format(time.RFC3339Nano),
 	}, "event_id", fixture.eventID)
-	logNotification := assertSQLiteSubscriptionNotification(t, server.URL, "runtime.subscribe_logs", map[string]any{
+	logNotification := assertObservabilitySubscriptionNotification(t, server.URL, "runtime.subscribe_logs", map[string]any{
 		"run_id":       fixture.runID,
 		"component":    "scheduler",
 		"level":        "warn",
@@ -86,7 +106,7 @@ func TestSQLiteObservabilityOwnerBacksSupportedAPISurfaces(t *testing.T) {
 	if got := logNotification["source"]; got != "runtime" {
 		t.Fatalf("runtime.subscribe_logs source = %#v, want runtime", got)
 	}
-	assertSQLiteSubscriptionNoNotification(t, server.URL, "runtime.subscribe_logs", map[string]any{
+	assertObservabilitySubscriptionNoNotification(t, server.URL, "runtime.subscribe_logs", map[string]any{
 		"run_id":       fixture.runID,
 		"component":    "scheduler",
 		"level":        "warn",
@@ -182,22 +202,46 @@ func TestSQLiteRunTraceAPISurfacePaginatesAndUsesMaterializationWindow(t *testin
 	}
 }
 
-type sqliteObservabilitySurfaceFixture struct {
-	store   *storepkg.SQLiteRuntimeStore
-	runID   string
-	eventID string
-	logID   string
-	now     time.Time
+type observabilitySurfaceFixture struct {
+	store        ObservabilityReadStore
+	runID        string
+	eventID      string
+	logID        string
+	incidentCode string
+	now          time.Time
 }
 
-func newSQLiteObservabilitySurfaceFixture(t *testing.T, ctx context.Context) sqliteObservabilitySurfaceFixture {
+func newSQLiteObservabilitySurfaceFixture(t *testing.T, ctx context.Context) observabilitySurfaceFixture {
 	t.Helper()
 	sqliteStore := storetest.StartSQLiteRuntimeStoreWithContext(t, ctx)
+	return newObservabilitySurfaceFixture(t, ctx, sqliteStore)
+}
 
-	now := time.Unix(1700002000, 0).UTC()
+func newPostgresObservabilitySurfaceFixture(t *testing.T, ctx context.Context) observabilitySurfaceFixture {
+	t.Helper()
+	_, db, cleanup := testutil.StartPostgres(t)
+	t.Cleanup(cleanup)
+	pg := &storepkg.PostgresStore{DB: db}
+	if _, err := pg.BindSchemaCapabilities(ctx); err != nil {
+		t.Fatalf("BindSchemaCapabilities postgres: %v", err)
+	}
+	return newObservabilitySurfaceFixture(t, ctx, pg)
+}
+
+type observabilityFixtureStore interface {
+	ObservabilityReadStore
+	PersistEventWithDeliveries(context.Context, events.Event, []string) error
+	MarkEventDeliveryInProgress(context.Context, string, string, string) error
+	runtimepkg.RuntimeLogPersistence
+}
+
+func newObservabilitySurfaceFixture(t *testing.T, ctx context.Context, store observabilityFixtureStore) observabilitySurfaceFixture {
+	t.Helper()
+
+	now := time.Now().UTC().Add(-2 * time.Minute)
 	runID := uuid.NewString()
 	eventID := uuid.NewString()
-	if err := sqliteStore.PersistEventWithDeliveries(ctx, eventtest.PersistedProjection(eventID,
+	if err := store.PersistEventWithDeliveries(ctx, eventtest.PersistedProjection(eventID,
 
 		events.EventType("trace.visible"),
 		"agent-1", "", json.RawMessage(`{"trace":true}`), 0, runID, "", events.EventEnvelope{}, now),
@@ -205,11 +249,11 @@ func newSQLiteObservabilitySurfaceFixture(t *testing.T, ctx context.Context) sql
 		[]string{"agent-1"}); err != nil {
 		t.Fatalf("PersistEventWithDeliveries: %v", err)
 	}
-	if err := sqliteStore.MarkEventDeliveryInProgress(ctx, eventID, "agent-1", "session-1"); err != nil {
+	if err := store.MarkEventDeliveryInProgress(ctx, eventID, "agent-1", "session-1"); err != nil {
 		t.Fatalf("MarkEventDeliveryInProgress: %v", err)
 	}
 
-	logger := runtimepkg.NewRuntimeLogger(sqliteStore)
+	logger := runtimepkg.NewRuntimeLogger(store)
 	logCtx := runtimecorrelation.WithRunID(ctx, runID)
 	if err := logger.Log(logCtx, runtimepkg.RuntimeLogEntry{
 		Level:     "warn",
@@ -218,9 +262,24 @@ func newSQLiteObservabilitySurfaceFixture(t *testing.T, ctx context.Context) sql
 		Action:    "supported_surface",
 		SessionID: "session-1",
 	}); err != nil {
-		t.Fatalf("RuntimeLogger.Log sqlite runtime log: %v", err)
+		t.Fatalf("RuntimeLogger.Log warning runtime log: %v", err)
 	}
-	logs, err := sqliteStore.ListOperatorRuntimeLogs(ctx, storepkg.OperatorRuntimeLogListOptions{
+	incidentCode := "supported_surface_failed"
+	if err := logger.Log(logCtx, runtimepkg.RuntimeLogEntry{
+		Level:     "error",
+		Message:   "runtime failed",
+		Component: "scheduler",
+		Action:    "supported_surface_failed",
+		SessionID: "session-1",
+		Error:     "boom",
+		Detail: map[string]any{
+			"error":      "boom",
+			"error_code": incidentCode,
+		},
+	}); err != nil {
+		t.Fatalf("RuntimeLogger.Log error runtime log: %v", err)
+	}
+	logs, err := store.ListOperatorRuntimeLogs(ctx, storepkg.OperatorRuntimeLogListOptions{
 		RunID:     runID,
 		Component: "scheduler",
 		Level:     "warn",
@@ -232,17 +291,29 @@ func newSQLiteObservabilitySurfaceFixture(t *testing.T, ctx context.Context) sql
 	if len(logs.Logs) != 1 {
 		t.Fatalf("logger-written runtime logs = %#v, want one", logs.Logs)
 	}
+	incidents, err := store.ListOperatorRuntimeIncidents(ctx, storepkg.OperatorRuntimeIncidentListOptions{
+		Component: "scheduler",
+		Level:     "error",
+		Limit:     10,
+	})
+	if err != nil {
+		t.Fatalf("ListOperatorRuntimeIncidents after logger write: %v", err)
+	}
+	if len(incidents.Incidents) != 1 || incidents.Incidents[0].ErrorCode != incidentCode {
+		t.Fatalf("logger-written runtime incidents = %#v, want %s", incidents.Incidents, incidentCode)
+	}
 
-	return sqliteObservabilitySurfaceFixture{
-		store:   sqliteStore,
-		runID:   runID,
-		eventID: eventID,
-		logID:   logs.Logs[0].LogID,
-		now:     now,
+	return observabilitySurfaceFixture{
+		store:        store,
+		runID:        runID,
+		eventID:      eventID,
+		logID:        logs.Logs[0].LogID,
+		incidentCode: incidentCode,
+		now:          now,
 	}
 }
 
-func assertSQLiteSubscriptionNotification(t *testing.T, serverURL, method string, params map[string]any, key, want string) map[string]any {
+func assertObservabilitySubscriptionNotification(t *testing.T, serverURL, method string, params map[string]any, key, want string) map[string]any {
 	t.Helper()
 	conn := dialTestWS(t, serverURL)
 	defer conn.Close()
@@ -264,7 +335,7 @@ func assertSQLiteSubscriptionNotification(t *testing.T, serverURL, method string
 	return result
 }
 
-func assertSQLiteSubscriptionNoNotification(t *testing.T, serverURL, method string, params map[string]any) {
+func assertObservabilitySubscriptionNoNotification(t *testing.T, serverURL, method string, params map[string]any) {
 	t.Helper()
 	conn := dialTestWS(t, serverURL)
 	defer conn.Close()

--- a/internal/apiv1/testdata/public_surface_backend_matrix.yaml
+++ b/internal/apiv1/testdata/public_surface_backend_matrix.yaml
@@ -24,12 +24,23 @@ policy:
     use covered_transitively and must name the covered method, covered harness
     scenario, and live proof refs; this classification must not be used as a
     generic bypass for methods with independent backend-sensitive behavior.
+  operator_read_api_parity_classification_policy: >
+    Every non-mutating public method must be classified as dual_backend_api_proof,
+    postgres_only_with_spec_ref, unsupported_with_issue_ref, split_with_issue_ref,
+    or different_semantic_concept_with_proof. Dual-backend read proof must include
+    selected-backend public-surface evidence for default SQLite and explicit
+    Postgres; fake-store OpenRPC probes and store-unit tests alone do not count
+    as selected-backend parity proof. Non-HTTP subscription/protocol methods must
+    be classified explicitly rather than omitted.
 active_trackers:
   - kind: github_issue
     issue: 1239
     watchlist: runtime_operations.runtime_store_backend_default_and_sqlite_portability
   - kind: github_issue
     issue: 1386
+    watchlist: runtime_operations.runtime_store_backend_default_and_sqlite_portability
+  - kind: github_issue
+    issue: 1783
     watchlist: runtime_operations.runtime_store_backend_default_and_sqlite_portability
   - kind: watchlist
     issue: 0
@@ -150,6 +161,263 @@ mutating_api_parity_ledger:
     classification: split_with_issue_ref
     split_issue: 1386
     proof_refs: [{kind: tracker, issue: 1386, watchlist: runtime_operations.runtime_store_backend_default_and_sqlite_portability}]
+operator_read_api_parity_ledger:
+  - method: agent.delivery_diagnostics
+    classification: dual_backend_api_proof
+    backends: [default_sqlite, explicit_postgres]
+    proof_refs:
+      - {kind: go_test, name: TestOperatorAgentReadSurfaceLoadAgentDeliveryDiagnosticsPromotesCanonicalOwner}
+      - {kind: go_test, name: TestSQLiteAgentConversationOwnerBacksSupportedAPISurface}
+      - {kind: go_test, name: TestOpenRPCReadOnlyHTTPRuntimeProbes}
+  - method: agent.delivery_lifecycle
+    classification: dual_backend_api_proof
+    backends: [default_sqlite, explicit_postgres]
+    proof_refs:
+      - {kind: go_test, name: TestOperatorAgentReadSurfaceLoadAgentDeliveryLifecyclePostgres}
+      - {kind: go_test, name: TestSQLiteRuntimeStoreLoadAgentDeliveryLifecycle}
+      - {kind: go_test, name: TestOpenRPCReadOnlyHTTPRuntimeProbes}
+  - method: agent.diagnose
+    classification: dual_backend_api_proof
+    backends: [default_sqlite, explicit_postgres]
+    proof_refs:
+      - {kind: go_test, name: TestOperatorAgentReadSurfaceLoadAgentDiagnosisUsesSelectedOwners}
+      - {kind: go_test, name: TestSQLiteAgentConversationOwnerBacksSupportedAPISurface}
+      - {kind: go_test, name: TestOpenRPCReadOnlyHTTPRuntimeProbes}
+  - method: agent.get
+    classification: dual_backend_api_proof
+    backends: [default_sqlite, explicit_postgres]
+    proof_refs:
+      - {kind: go_test, name: TestOperatorAgentConversationHandlersExposeReadOwner}
+      - {kind: go_test, name: TestSQLiteAgentConversationOwnerBacksSupportedAPISurface}
+      - {kind: go_test, name: TestOpenRPCReadOnlyHTTPRuntimeProbes}
+  - method: agent.list
+    classification: dual_backend_api_proof
+    backends: [default_sqlite, explicit_postgres]
+    proof_refs:
+      - {kind: go_test, name: TestOperatorAgentConversationHandlersExposeReadOwner}
+      - {kind: go_test, name: TestSQLiteAgentConversationOwnerBacksSupportedAPISurface}
+      - {kind: go_test, name: TestOpenRPCReadOnlyHTTPRuntimeProbes}
+  - method: agent.usage
+    classification: dual_backend_api_proof
+    backends: [default_sqlite, explicit_postgres]
+    proof_refs:
+      - {kind: go_test, name: TestOperatorAgentReadSurfaceLoadAgentUsageSplitsExactAndEstimated}
+      - {kind: go_test, name: TestSQLiteRuntimeStoreLoadAgentUsageSplitsExactAndEstimated}
+      - {kind: go_test, name: TestOpenRPCReadOnlyHTTPRuntimeProbes}
+  - method: bundle.agents
+    classification: dual_backend_api_proof
+    backends: [default_sqlite, explicit_postgres]
+    proof_refs:
+      - {kind: go_test, name: TestOperatorBundleCatalogHandlersExposeStoreOwner}
+      - {kind: go_test, name: TestSQLiteBundleCatalogOwnerBacksSupportedAPISurface}
+      - {kind: go_test, name: TestBundleCatalogReadSurfaceListGetAgentsAndCursor}
+      - {kind: go_test, name: TestOpenRPCReadOnlyHTTPRuntimeProbes}
+  - method: bundle.get
+    classification: dual_backend_api_proof
+    backends: [default_sqlite, explicit_postgres]
+    proof_refs:
+      - {kind: go_test, name: TestOperatorBundleCatalogHandlersExposeStoreOwner}
+      - {kind: go_test, name: TestSQLiteBundleCatalogOwnerBacksSupportedAPISurface}
+      - {kind: go_test, name: TestBundleCatalogReadSurfaceListGetAgentsAndCursor}
+      - {kind: go_test, name: TestOpenRPCReadOnlyHTTPRuntimeProbes}
+  - method: bundle.list
+    classification: dual_backend_api_proof
+    backends: [default_sqlite, explicit_postgres]
+    proof_refs:
+      - {kind: go_test, name: TestOperatorBundleCatalogHandlersExposeStoreOwner}
+      - {kind: go_test, name: TestSQLiteBundleCatalogOwnerBacksSupportedAPISurface}
+      - {kind: go_test, name: TestBundleCatalogReadSurfaceListGetAgentsAndCursor}
+      - {kind: go_test, name: TestOpenRPCReadOnlyHTTPRuntimeProbes}
+  - method: conversation.current_for_agent
+    classification: dual_backend_api_proof
+    backends: [default_sqlite, explicit_postgres]
+    proof_refs:
+      - {kind: go_test, name: TestOperatorAgentConversationHandlersExposeReadOwner}
+      - {kind: go_test, name: TestSQLiteAgentConversationOwnerBacksSupportedAPISurface}
+      - {kind: go_test, name: TestOpenRPCReadOnlyHTTPRuntimeProbes}
+  - method: conversation.fork_list
+    classification: split_with_issue_ref
+    split_issue: 1783
+    proof_refs:
+      - {kind: tracker, issue: 1783, watchlist: runtime_operations.runtime_store_backend_default_and_sqlite_portability}
+    notes: >
+      Current ConversationForkLifecycleStore also carries fork/fork_chat/fork_delete
+      mutations; read promotion requires #1783 interface segregation first.
+  - method: conversation.fork_view
+    classification: split_with_issue_ref
+    split_issue: 1783
+    proof_refs:
+      - {kind: tracker, issue: 1783, watchlist: runtime_operations.runtime_store_backend_default_and_sqlite_portability}
+    notes: >
+      Current ConversationForkLifecycleStore also carries fork/fork_chat/fork_delete
+      mutations; read promotion requires #1783 interface segregation first.
+  - method: conversation.get
+    classification: dual_backend_api_proof
+    backends: [default_sqlite, explicit_postgres]
+    proof_refs:
+      - {kind: go_test, name: TestOperatorAgentConversationHandlersExposeReadOwner}
+      - {kind: go_test, name: TestSQLiteAgentConversationOwnerBacksSupportedAPISurface}
+      - {kind: go_test, name: TestOperatorConversationQuerySourcesRunIDCapabilityMatrix}
+      - {kind: go_test, name: TestOpenRPCReadOnlyHTTPRuntimeProbes}
+  - method: conversation.get_turn
+    classification: dual_backend_api_proof
+    backends: [default_sqlite, explicit_postgres]
+    proof_refs:
+      - {kind: go_test, name: TestOperatorAgentConversationHandlersExposeReadOwner}
+      - {kind: go_test, name: TestSQLiteAgentConversationOwnerBacksSupportedAPISurface}
+      - {kind: go_test, name: TestOperatorConversationQuerySourcesRunIDCapabilityMatrix}
+      - {kind: go_test, name: TestOpenRPCReadOnlyHTTPRuntimeProbes}
+  - method: conversation.list
+    classification: dual_backend_api_proof
+    backends: [default_sqlite, explicit_postgres]
+    proof_refs:
+      - {kind: go_test, name: TestOperatorAgentConversationHandlersExposeReadOwner}
+      - {kind: go_test, name: TestSQLiteAgentConversationOwnerBacksSupportedAPISurface}
+      - {kind: go_test, name: TestOperatorConversationQuerySourcesRunIDCapabilityMatrix}
+      - {kind: go_test, name: TestOpenRPCReadOnlyHTTPRuntimeProbes}
+  - method: entity.aggregate
+    classification: dual_backend_api_proof
+    backends: [default_sqlite, explicit_postgres]
+    proof_refs:
+      - {kind: go_test, name: TestOperatorEntityHandlersServeContractEntityTypesFromSQLite}
+      - {kind: go_test, name: TestOperatorEntityHandlersServeContractEntityTypesFromPostgres}
+      - {kind: go_test, name: TestOperatorEntityHandlersExposeEntityNativeReads}
+  - method: entity.get
+    classification: dual_backend_api_proof
+    backends: [default_sqlite, explicit_postgres]
+    proof_refs:
+      - {kind: go_test, name: TestOperatorEntityHandlersServeContractEntityTypesFromSQLite}
+      - {kind: go_test, name: TestOperatorEntityHandlersServeContractEntityTypesFromPostgres}
+      - {kind: go_test, name: TestOperatorEntityHandlersExposeEntityNativeReads}
+  - method: entity.list
+    classification: dual_backend_api_proof
+    backends: [default_sqlite, explicit_postgres]
+    proof_refs:
+      - {kind: go_test, name: TestOperatorEntityHandlersServeContractEntityTypesFromSQLite}
+      - {kind: go_test, name: TestOperatorEntityHandlersServeContractEntityTypesFromPostgres}
+      - {kind: go_test, name: TestOperatorEntityHandlersExposeEntityNativeReads}
+  - method: event.get
+    classification: dual_backend_api_proof
+    backends: [default_sqlite, explicit_postgres]
+    proof_refs:
+      - {kind: go_test, name: TestSQLObservabilityReader_GetEvent_UsesCanonicalDeliveryRows}
+      - {kind: go_test, name: TestOperatorEventPublishSQLiteIdempotentFirstEventPublishesWithoutLock}
+      - {kind: go_test, name: TestOperatorEventPublishHandlersPersistEventReportDeliveriesAndReplayIdempotency}
+      - {kind: go_test, name: TestOpenRPCReadOnlyHTTPRuntimeProbes}
+  - method: event.list
+    classification: dual_backend_api_proof
+    backends: [default_sqlite, explicit_postgres]
+    proof_refs:
+      - {kind: go_test, name: TestSQLObservabilityReader_ListEvents_UsesCanonicalDeliveryLifecycle}
+      - {kind: go_test, name: TestOperatorEventPublishSQLiteIdempotentFirstEventPublishesWithoutLock}
+      - {kind: go_test, name: TestOperatorEventPublishHandlersPersistEventReportDeliveriesAndReplayIdempotency}
+      - {kind: go_test, name: TestOpenRPCReadOnlyHTTPRuntimeProbes}
+  - method: event.subscribe
+    classification: different_semantic_concept_with_proof
+    backends: [default_sqlite, explicit_postgres]
+    proof_refs:
+      - {kind: go_test, name: TestOpenRPCWebSocketRuntimeProbes}
+    notes: WebSocket subscription/protocol surface, not an operator-read store capability.
+  - method: health.check
+    classification: dual_backend_api_proof
+    backends: [default_sqlite, explicit_postgres]
+    proof_refs:
+      - {kind: go_test, name: TestBuildStoresAcceptsSQLiteSelectedCoreRuntimeStore}
+      - {kind: go_test, name: TestRunServeRuntimeFreshEmptyPostgresBootstrapsSchemaBeforeDiskContractsServe}
+      - {kind: go_test, name: TestOpenRPCReadOnlyHTTPRuntimeProbes}
+  - method: health.ping
+    classification: different_semantic_concept_with_proof
+    backends: [default_sqlite, explicit_postgres]
+    proof_refs:
+      - {kind: go_test, name: TestOpenRPCReadOnlyHTTPRuntimeProbes}
+    notes: Static non-store liveness method; no selected operator-read store is involved.
+  - method: health.subscribe
+    classification: different_semantic_concept_with_proof
+    backends: [default_sqlite, explicit_postgres]
+    proof_refs:
+      - {kind: go_test, name: TestOpenRPCWebSocketRuntimeProbes}
+    notes: WebSocket subscription/protocol surface, not an operator-read store capability.
+  - method: mailbox.get
+    classification: dual_backend_api_proof
+    backends: [default_sqlite, explicit_postgres]
+    proof_refs:
+      - {kind: go_test, name: TestOperatorMailboxWriteSupportedSurfacePublishesAndReadsAcrossBackends}
+      - {kind: go_test, name: TestOpenRPCReadOnlyHTTPRuntimeProbes}
+  - method: mailbox.list
+    classification: dual_backend_api_proof
+    backends: [default_sqlite, explicit_postgres]
+    proof_refs:
+      - {kind: go_test, name: TestOperatorMailboxWriteSupportedSurfacePublishesAndReadsAcrossBackends}
+      - {kind: go_test, name: TestOpenRPCReadOnlyHTTPRuntimeProbes}
+  - method: rpc.unsubscribe
+    classification: different_semantic_concept_with_proof
+    backends: [default_sqlite, explicit_postgres]
+    proof_refs:
+      - {kind: go_test, name: TestOpenRPCWebSocketRuntimeProbes}
+    notes: WebSocket control/protocol surface, not an operator-read store capability.
+  - method: run.diagnose
+    classification: dual_backend_api_proof
+    backends: [default_sqlite, explicit_postgres]
+    proof_refs:
+      - {kind: go_test, name: TestSQLiteRunAPIReadSurface_LoadListAndDiagnoseEvidence}
+      - {kind: go_test, name: TestRunAPIReadSurface_LoadAndListRunHeaders}
+      - {kind: go_test, name: TestOpenRPCReadOnlyHTTPRuntimeProbes}
+  - method: run.get
+    classification: dual_backend_api_proof
+    backends: [default_sqlite, explicit_postgres]
+    proof_refs:
+      - {kind: go_test, name: TestSQLiteRunAPIReadSurface_LoadListAndDiagnoseEvidence}
+      - {kind: go_test, name: TestRunAPIReadSurface_LoadAndListRunHeaders}
+      - {kind: go_test, name: TestOpenRPCReadOnlyHTTPRuntimeProbes}
+  - method: run.list
+    classification: dual_backend_api_proof
+    backends: [default_sqlite, explicit_postgres]
+    proof_refs:
+      - {kind: go_test, name: TestSQLiteRunAPIReadSurface_LoadListAndDiagnoseEvidence}
+      - {kind: go_test, name: TestRunAPIReadSurface_LoadAndListRunHeaders}
+      - {kind: go_test, name: TestOpenRPCReadOnlyHTTPRuntimeProbes}
+  - method: run.subscribe_trace
+    classification: different_semantic_concept_with_proof
+    backends: [default_sqlite, explicit_postgres]
+    proof_refs:
+      - {kind: go_test, name: TestOpenRPCWebSocketRuntimeProbes}
+      - {kind: go_test, name: TestHandlerWebSocketRunSubscribeTraceUsesOwnerReplayAndRunNotFound}
+    notes: WebSocket subscription/protocol surface, not an HTTP operator-read method.
+  - method: run.trace
+    classification: dual_backend_api_proof
+    backends: [default_sqlite, explicit_postgres]
+    proof_refs:
+      - {kind: go_test, name: TestSQLiteRuntimeLogPersistenceWritesLoggerRowsForObservability}
+      - {kind: go_test, name: TestPostgresRuntimeLogPersistencePreservesRunSourceAndLineage}
+      - {kind: go_test, name: TestOpenRPCReadOnlyHTTPRuntimeProbes}
+  - method: runtime.identity
+    classification: different_semantic_concept_with_proof
+    backends: [default_sqlite, explicit_postgres]
+    proof_refs:
+      - {kind: go_test, name: TestOperatorReadHandlersExposeHealthAndRunReadMethods}
+      - {kind: go_test, name: TestOpenRPCReadOnlyHTTPRuntimeProbes}
+    notes: Static non-store runtime identity method; no selected operator-read store is involved.
+  - method: runtime.incidents
+    classification: dual_backend_api_proof
+    backends: [default_sqlite, explicit_postgres]
+    proof_refs:
+      - {kind: go_test, name: TestSQLiteRuntimeLogPersistenceWritesLoggerRowsForObservability}
+      - {kind: go_test, name: TestPostgresRuntimeLogPersistencePreservesRunSourceAndLineage}
+      - {kind: go_test, name: TestOpenRPCReadOnlyHTTPRuntimeProbes}
+  - method: runtime.logs
+    classification: dual_backend_api_proof
+    backends: [default_sqlite, explicit_postgres]
+    proof_refs:
+      - {kind: go_test, name: TestSQLiteRuntimeLogPersistenceWritesLoggerRowsForObservability}
+      - {kind: go_test, name: TestPostgresRuntimeLogPersistencePreservesRunSourceAndLineage}
+      - {kind: go_test, name: TestOpenRPCReadOnlyHTTPRuntimeProbes}
+  - method: runtime.subscribe_logs
+    classification: different_semantic_concept_with_proof
+    backends: [default_sqlite, explicit_postgres]
+    proof_refs:
+      - {kind: go_test, name: TestOpenRPCWebSocketRuntimeProbes}
+      - {kind: go_test, name: TestHandlerWebSocketRuntimeSubscribeLogsUsesOwnerFiltersAndReplay}
+    notes: WebSocket subscription/protocol surface, not an HTTP operator-read method.
 rows:
   - id: serve_contracts_default_sqlite
     surface: default SQLite swarm serve --contracts readiness and API availability

--- a/internal/apiv1/testdata/public_surface_backend_matrix.yaml
+++ b/internal/apiv1/testdata/public_surface_backend_matrix.yaml
@@ -166,42 +166,46 @@ operator_read_api_parity_ledger:
     classification: dual_backend_api_proof
     backends: [default_sqlite, explicit_postgres]
     proof_refs:
-      - {kind: go_test, name: TestOperatorAgentReadSurfaceLoadAgentDeliveryDiagnosticsPromotesCanonicalOwner}
-      - {kind: go_test, name: TestSQLiteAgentConversationOwnerBacksSupportedAPISurface}
+      - {kind: go_test, name: TestOperatorAgentReadSurfaceLoadAgentDeliveryDiagnosticsPromotesCanonicalOwner, backends: [explicit_postgres]}
+      - {kind: go_test, name: TestSQLiteAgentConversationOwnerBacksSupportedAPISurface, backends: [default_sqlite]}
       - {kind: go_test, name: TestOpenRPCReadOnlyHTTPRuntimeProbes}
   - method: agent.delivery_lifecycle
     classification: dual_backend_api_proof
     backends: [default_sqlite, explicit_postgres]
     proof_refs:
-      - {kind: go_test, name: TestOperatorAgentReadSurfaceLoadAgentDeliveryLifecyclePostgres}
+      - {kind: go_test, name: TestOperatorAgentReadSurfaceLoadAgentDeliveryLifecyclePostgres, backends: [explicit_postgres]}
+      - {kind: go_test, name: TestSQLiteAgentDeliveryLifecycleOwnerBacksSupportedAPISurface, backends: [default_sqlite]}
       - {kind: go_test, name: TestSQLiteRuntimeStoreLoadAgentDeliveryLifecycle}
       - {kind: go_test, name: TestOpenRPCReadOnlyHTTPRuntimeProbes}
   - method: agent.diagnose
     classification: dual_backend_api_proof
     backends: [default_sqlite, explicit_postgres]
     proof_refs:
-      - {kind: go_test, name: TestOperatorAgentReadSurfaceLoadAgentDiagnosisUsesSelectedOwners}
-      - {kind: go_test, name: TestSQLiteAgentConversationOwnerBacksSupportedAPISurface}
+      - {kind: go_test, name: TestOperatorAgentReadSurfaceLoadAgentDiagnosisUsesSelectedOwners, backends: [explicit_postgres]}
+      - {kind: go_test, name: TestSQLiteAgentConversationOwnerBacksSupportedAPISurface, backends: [default_sqlite]}
       - {kind: go_test, name: TestOpenRPCReadOnlyHTTPRuntimeProbes}
   - method: agent.get
     classification: dual_backend_api_proof
     backends: [default_sqlite, explicit_postgres]
     proof_refs:
       - {kind: go_test, name: TestOperatorAgentConversationHandlersExposeReadOwner}
-      - {kind: go_test, name: TestSQLiteAgentConversationOwnerBacksSupportedAPISurface}
+      - {kind: go_test, name: TestOperatorAgentReadSurfaceLoadAgentProjectsSessionAndTurnRefs, backends: [explicit_postgres]}
+      - {kind: go_test, name: TestSQLiteAgentConversationOwnerBacksSupportedAPISurface, backends: [default_sqlite]}
       - {kind: go_test, name: TestOpenRPCReadOnlyHTTPRuntimeProbes}
   - method: agent.list
     classification: dual_backend_api_proof
     backends: [default_sqlite, explicit_postgres]
     proof_refs:
       - {kind: go_test, name: TestOperatorAgentConversationHandlersExposeReadOwner}
-      - {kind: go_test, name: TestSQLiteAgentConversationOwnerBacksSupportedAPISurface}
+      - {kind: go_test, name: TestOperatorAgentReadSurfaceListAgentsDoesNotDeriveStatusFromActiveLease, backends: [explicit_postgres]}
+      - {kind: go_test, name: TestSQLiteAgentConversationOwnerBacksSupportedAPISurface, backends: [default_sqlite]}
       - {kind: go_test, name: TestOpenRPCReadOnlyHTTPRuntimeProbes}
   - method: agent.usage
     classification: dual_backend_api_proof
     backends: [default_sqlite, explicit_postgres]
     proof_refs:
-      - {kind: go_test, name: TestOperatorAgentReadSurfaceLoadAgentUsageSplitsExactAndEstimated}
+      - {kind: go_test, name: TestOperatorAgentReadSurfaceLoadAgentUsageSplitsExactAndEstimated, backends: [explicit_postgres]}
+      - {kind: go_test, name: TestSQLiteAgentUsageOwnerBacksSupportedAPISurface, backends: [default_sqlite]}
       - {kind: go_test, name: TestSQLiteRuntimeStoreLoadAgentUsageSplitsExactAndEstimated}
       - {kind: go_test, name: TestOpenRPCReadOnlyHTTPRuntimeProbes}
   - method: bundle.agents
@@ -209,31 +213,32 @@ operator_read_api_parity_ledger:
     backends: [default_sqlite, explicit_postgres]
     proof_refs:
       - {kind: go_test, name: TestOperatorBundleCatalogHandlersExposeStoreOwner}
-      - {kind: go_test, name: TestSQLiteBundleCatalogOwnerBacksSupportedAPISurface}
-      - {kind: go_test, name: TestBundleCatalogReadSurfaceListGetAgentsAndCursor}
+      - {kind: go_test, name: TestSQLiteBundleCatalogOwnerBacksSupportedAPISurface, backends: [default_sqlite]}
+      - {kind: go_test, name: TestBundleCatalogReadSurfaceListGetAgentsAndCursor, backends: [explicit_postgres]}
       - {kind: go_test, name: TestOpenRPCReadOnlyHTTPRuntimeProbes}
   - method: bundle.get
     classification: dual_backend_api_proof
     backends: [default_sqlite, explicit_postgres]
     proof_refs:
       - {kind: go_test, name: TestOperatorBundleCatalogHandlersExposeStoreOwner}
-      - {kind: go_test, name: TestSQLiteBundleCatalogOwnerBacksSupportedAPISurface}
-      - {kind: go_test, name: TestBundleCatalogReadSurfaceListGetAgentsAndCursor}
+      - {kind: go_test, name: TestSQLiteBundleCatalogOwnerBacksSupportedAPISurface, backends: [default_sqlite]}
+      - {kind: go_test, name: TestBundleCatalogReadSurfaceListGetAgentsAndCursor, backends: [explicit_postgres]}
       - {kind: go_test, name: TestOpenRPCReadOnlyHTTPRuntimeProbes}
   - method: bundle.list
     classification: dual_backend_api_proof
     backends: [default_sqlite, explicit_postgres]
     proof_refs:
       - {kind: go_test, name: TestOperatorBundleCatalogHandlersExposeStoreOwner}
-      - {kind: go_test, name: TestSQLiteBundleCatalogOwnerBacksSupportedAPISurface}
-      - {kind: go_test, name: TestBundleCatalogReadSurfaceListGetAgentsAndCursor}
+      - {kind: go_test, name: TestSQLiteBundleCatalogOwnerBacksSupportedAPISurface, backends: [default_sqlite]}
+      - {kind: go_test, name: TestBundleCatalogReadSurfaceListGetAgentsAndCursor, backends: [explicit_postgres]}
       - {kind: go_test, name: TestOpenRPCReadOnlyHTTPRuntimeProbes}
   - method: conversation.current_for_agent
     classification: dual_backend_api_proof
     backends: [default_sqlite, explicit_postgres]
     proof_refs:
       - {kind: go_test, name: TestOperatorAgentConversationHandlersExposeReadOwner}
-      - {kind: go_test, name: TestSQLiteAgentConversationOwnerBacksSupportedAPISurface}
+      - {kind: go_test, name: TestOperatorAgentReadSurfaceLoadAgentProjectsSessionAndTurnRefs, backends: [explicit_postgres]}
+      - {kind: go_test, name: TestSQLiteAgentConversationOwnerBacksSupportedAPISurface, backends: [default_sqlite]}
       - {kind: go_test, name: TestOpenRPCReadOnlyHTTPRuntimeProbes}
   - method: conversation.fork_list
     classification: split_with_issue_ref
@@ -256,7 +261,8 @@ operator_read_api_parity_ledger:
     backends: [default_sqlite, explicit_postgres]
     proof_refs:
       - {kind: go_test, name: TestOperatorAgentConversationHandlersExposeReadOwner}
-      - {kind: go_test, name: TestSQLiteAgentConversationOwnerBacksSupportedAPISurface}
+      - {kind: go_test, name: TestOperatorAgentReadSurfaceLoadAgentProjectsSessionAndTurnRefs, backends: [explicit_postgres]}
+      - {kind: go_test, name: TestSQLiteAgentConversationOwnerBacksSupportedAPISurface, backends: [default_sqlite]}
       - {kind: go_test, name: TestOperatorConversationQuerySourcesRunIDCapabilityMatrix}
       - {kind: go_test, name: TestOpenRPCReadOnlyHTTPRuntimeProbes}
   - method: conversation.get_turn
@@ -264,7 +270,8 @@ operator_read_api_parity_ledger:
     backends: [default_sqlite, explicit_postgres]
     proof_refs:
       - {kind: go_test, name: TestOperatorAgentConversationHandlersExposeReadOwner}
-      - {kind: go_test, name: TestSQLiteAgentConversationOwnerBacksSupportedAPISurface}
+      - {kind: go_test, name: TestOperatorAgentReadSurfaceLoadAgentProjectsSessionAndTurnRefs, backends: [explicit_postgres]}
+      - {kind: go_test, name: TestSQLiteAgentConversationOwnerBacksSupportedAPISurface, backends: [default_sqlite]}
       - {kind: go_test, name: TestOperatorConversationQuerySourcesRunIDCapabilityMatrix}
       - {kind: go_test, name: TestOpenRPCReadOnlyHTTPRuntimeProbes}
   - method: conversation.list
@@ -272,45 +279,46 @@ operator_read_api_parity_ledger:
     backends: [default_sqlite, explicit_postgres]
     proof_refs:
       - {kind: go_test, name: TestOperatorAgentConversationHandlersExposeReadOwner}
-      - {kind: go_test, name: TestSQLiteAgentConversationOwnerBacksSupportedAPISurface}
+      - {kind: go_test, name: TestOperatorAgentReadSurfaceListAgentsDoesNotDeriveStatusFromActiveLease, backends: [explicit_postgres]}
+      - {kind: go_test, name: TestSQLiteAgentConversationOwnerBacksSupportedAPISurface, backends: [default_sqlite]}
       - {kind: go_test, name: TestOperatorConversationQuerySourcesRunIDCapabilityMatrix}
       - {kind: go_test, name: TestOpenRPCReadOnlyHTTPRuntimeProbes}
   - method: entity.aggregate
     classification: dual_backend_api_proof
     backends: [default_sqlite, explicit_postgres]
     proof_refs:
-      - {kind: go_test, name: TestOperatorEntityHandlersServeContractEntityTypesFromSQLite}
-      - {kind: go_test, name: TestOperatorEntityHandlersServeContractEntityTypesFromPostgres}
+      - {kind: go_test, name: TestOperatorEntityHandlersServeContractEntityTypesFromSQLite, backends: [default_sqlite]}
+      - {kind: go_test, name: TestOperatorEntityHandlersServeContractEntityTypesFromPostgres, backends: [explicit_postgres]}
       - {kind: go_test, name: TestOperatorEntityHandlersExposeEntityNativeReads}
   - method: entity.get
     classification: dual_backend_api_proof
     backends: [default_sqlite, explicit_postgres]
     proof_refs:
-      - {kind: go_test, name: TestOperatorEntityHandlersServeContractEntityTypesFromSQLite}
-      - {kind: go_test, name: TestOperatorEntityHandlersServeContractEntityTypesFromPostgres}
+      - {kind: go_test, name: TestOperatorEntityHandlersServeContractEntityTypesFromSQLite, backends: [default_sqlite]}
+      - {kind: go_test, name: TestOperatorEntityHandlersServeContractEntityTypesFromPostgres, backends: [explicit_postgres]}
       - {kind: go_test, name: TestOperatorEntityHandlersExposeEntityNativeReads}
   - method: entity.list
     classification: dual_backend_api_proof
     backends: [default_sqlite, explicit_postgres]
     proof_refs:
-      - {kind: go_test, name: TestOperatorEntityHandlersServeContractEntityTypesFromSQLite}
-      - {kind: go_test, name: TestOperatorEntityHandlersServeContractEntityTypesFromPostgres}
+      - {kind: go_test, name: TestOperatorEntityHandlersServeContractEntityTypesFromSQLite, backends: [default_sqlite]}
+      - {kind: go_test, name: TestOperatorEntityHandlersServeContractEntityTypesFromPostgres, backends: [explicit_postgres]}
       - {kind: go_test, name: TestOperatorEntityHandlersExposeEntityNativeReads}
   - method: event.get
     classification: dual_backend_api_proof
     backends: [default_sqlite, explicit_postgres]
     proof_refs:
       - {kind: go_test, name: TestSQLObservabilityReader_GetEvent_UsesCanonicalDeliveryRows}
-      - {kind: go_test, name: TestOperatorEventPublishSQLiteIdempotentFirstEventPublishesWithoutLock}
-      - {kind: go_test, name: TestOperatorEventPublishHandlersPersistEventReportDeliveriesAndReplayIdempotency}
+      - {kind: go_test, name: TestOperatorEventPublishSQLiteIdempotentFirstEventPublishesWithoutLock, backends: [default_sqlite]}
+      - {kind: go_test, name: TestOperatorEventPublishHandlersPersistEventReportDeliveriesAndReplayIdempotency, backends: [explicit_postgres]}
       - {kind: go_test, name: TestOpenRPCReadOnlyHTTPRuntimeProbes}
   - method: event.list
     classification: dual_backend_api_proof
     backends: [default_sqlite, explicit_postgres]
     proof_refs:
       - {kind: go_test, name: TestSQLObservabilityReader_ListEvents_UsesCanonicalDeliveryLifecycle}
-      - {kind: go_test, name: TestOperatorEventPublishSQLiteIdempotentFirstEventPublishesWithoutLock}
-      - {kind: go_test, name: TestOperatorEventPublishHandlersPersistEventReportDeliveriesAndReplayIdempotency}
+      - {kind: go_test, name: TestOperatorEventPublishSQLiteIdempotentFirstEventPublishesWithoutLock, backends: [default_sqlite]}
+      - {kind: go_test, name: TestOperatorEventPublishHandlersPersistEventReportDeliveriesAndReplayIdempotency, backends: [explicit_postgres]}
       - {kind: go_test, name: TestOpenRPCReadOnlyHTTPRuntimeProbes}
   - method: event.subscribe
     classification: different_semantic_concept_with_proof
@@ -322,8 +330,8 @@ operator_read_api_parity_ledger:
     classification: dual_backend_api_proof
     backends: [default_sqlite, explicit_postgres]
     proof_refs:
-      - {kind: go_test, name: TestBuildStoresAcceptsSQLiteSelectedCoreRuntimeStore}
-      - {kind: go_test, name: TestRunServeRuntimeFreshEmptyPostgresBootstrapsSchemaBeforeDiskContractsServe}
+      - {kind: go_test, name: TestBuildStoresAcceptsSQLiteSelectedCoreRuntimeStore, backends: [default_sqlite]}
+      - {kind: go_test, name: TestRunServeRuntimeFreshEmptyPostgresBootstrapsSchemaBeforeDiskContractsServe, backends: [explicit_postgres]}
       - {kind: go_test, name: TestOpenRPCReadOnlyHTTPRuntimeProbes}
   - method: health.ping
     classification: different_semantic_concept_with_proof
@@ -341,13 +349,13 @@ operator_read_api_parity_ledger:
     classification: dual_backend_api_proof
     backends: [default_sqlite, explicit_postgres]
     proof_refs:
-      - {kind: go_test, name: TestOperatorMailboxWriteSupportedSurfacePublishesAndReadsAcrossBackends}
+      - {kind: go_test, name: TestOperatorMailboxWriteSupportedSurfacePublishesAndReadsAcrossBackends, backends: [default_sqlite, explicit_postgres]}
       - {kind: go_test, name: TestOpenRPCReadOnlyHTTPRuntimeProbes}
   - method: mailbox.list
     classification: dual_backend_api_proof
     backends: [default_sqlite, explicit_postgres]
     proof_refs:
-      - {kind: go_test, name: TestOperatorMailboxWriteSupportedSurfacePublishesAndReadsAcrossBackends}
+      - {kind: go_test, name: TestOperatorMailboxWriteSupportedSurfacePublishesAndReadsAcrossBackends, backends: [default_sqlite, explicit_postgres]}
       - {kind: go_test, name: TestOpenRPCReadOnlyHTTPRuntimeProbes}
   - method: rpc.unsubscribe
     classification: different_semantic_concept_with_proof
@@ -359,22 +367,22 @@ operator_read_api_parity_ledger:
     classification: dual_backend_api_proof
     backends: [default_sqlite, explicit_postgres]
     proof_refs:
-      - {kind: go_test, name: TestSQLiteRunAPIReadSurface_LoadListAndDiagnoseEvidence}
-      - {kind: go_test, name: TestRunAPIReadSurface_LoadAndListRunHeaders}
+      - {kind: go_test, name: TestSQLiteRunAPIReadSurface_LoadListAndDiagnoseEvidence, backends: [default_sqlite]}
+      - {kind: go_test, name: TestRunAPIReadSurface_LoadAndListRunHeaders, backends: [explicit_postgres]}
       - {kind: go_test, name: TestOpenRPCReadOnlyHTTPRuntimeProbes}
   - method: run.get
     classification: dual_backend_api_proof
     backends: [default_sqlite, explicit_postgres]
     proof_refs:
-      - {kind: go_test, name: TestSQLiteRunAPIReadSurface_LoadListAndDiagnoseEvidence}
-      - {kind: go_test, name: TestRunAPIReadSurface_LoadAndListRunHeaders}
+      - {kind: go_test, name: TestSQLiteRunAPIReadSurface_LoadListAndDiagnoseEvidence, backends: [default_sqlite]}
+      - {kind: go_test, name: TestRunAPIReadSurface_LoadAndListRunHeaders, backends: [explicit_postgres]}
       - {kind: go_test, name: TestOpenRPCReadOnlyHTTPRuntimeProbes}
   - method: run.list
     classification: dual_backend_api_proof
     backends: [default_sqlite, explicit_postgres]
     proof_refs:
-      - {kind: go_test, name: TestSQLiteRunAPIReadSurface_LoadListAndDiagnoseEvidence}
-      - {kind: go_test, name: TestRunAPIReadSurface_LoadAndListRunHeaders}
+      - {kind: go_test, name: TestSQLiteRunAPIReadSurface_LoadListAndDiagnoseEvidence, backends: [default_sqlite]}
+      - {kind: go_test, name: TestRunAPIReadSurface_LoadAndListRunHeaders, backends: [explicit_postgres]}
       - {kind: go_test, name: TestOpenRPCReadOnlyHTTPRuntimeProbes}
   - method: run.subscribe_trace
     classification: different_semantic_concept_with_proof
@@ -387,8 +395,8 @@ operator_read_api_parity_ledger:
     classification: dual_backend_api_proof
     backends: [default_sqlite, explicit_postgres]
     proof_refs:
-      - {kind: go_test, name: TestSQLiteRuntimeLogPersistenceWritesLoggerRowsForObservability}
-      - {kind: go_test, name: TestPostgresRuntimeLogPersistencePreservesRunSourceAndLineage}
+      - {kind: go_test, name: TestSQLiteRuntimeLogPersistenceWritesLoggerRowsForObservability, backends: [default_sqlite]}
+      - {kind: go_test, name: TestPostgresRuntimeLogPersistencePreservesRunSourceAndLineage, backends: [explicit_postgres]}
       - {kind: go_test, name: TestOpenRPCReadOnlyHTTPRuntimeProbes}
   - method: runtime.identity
     classification: different_semantic_concept_with_proof
@@ -401,15 +409,15 @@ operator_read_api_parity_ledger:
     classification: dual_backend_api_proof
     backends: [default_sqlite, explicit_postgres]
     proof_refs:
-      - {kind: go_test, name: TestSQLiteRuntimeLogPersistenceWritesLoggerRowsForObservability}
-      - {kind: go_test, name: TestPostgresRuntimeLogPersistencePreservesRunSourceAndLineage}
+      - {kind: go_test, name: TestSQLiteRuntimeLogPersistenceWritesLoggerRowsForObservability, backends: [default_sqlite]}
+      - {kind: go_test, name: TestPostgresRuntimeLogPersistencePreservesRunSourceAndLineage, backends: [explicit_postgres]}
       - {kind: go_test, name: TestOpenRPCReadOnlyHTTPRuntimeProbes}
   - method: runtime.logs
     classification: dual_backend_api_proof
     backends: [default_sqlite, explicit_postgres]
     proof_refs:
-      - {kind: go_test, name: TestSQLiteRuntimeLogPersistenceWritesLoggerRowsForObservability}
-      - {kind: go_test, name: TestPostgresRuntimeLogPersistencePreservesRunSourceAndLineage}
+      - {kind: go_test, name: TestSQLiteRuntimeLogPersistenceWritesLoggerRowsForObservability, backends: [default_sqlite]}
+      - {kind: go_test, name: TestPostgresRuntimeLogPersistencePreservesRunSourceAndLineage, backends: [explicit_postgres]}
       - {kind: go_test, name: TestOpenRPCReadOnlyHTTPRuntimeProbes}
   - method: runtime.subscribe_logs
     classification: different_semantic_concept_with_proof

--- a/internal/apiv1/testdata/public_surface_backend_matrix.yaml
+++ b/internal/apiv1/testdata/public_surface_backend_matrix.yaml
@@ -395,8 +395,8 @@ operator_read_api_parity_ledger:
     classification: dual_backend_api_proof
     backends: [default_sqlite, explicit_postgres]
     proof_refs:
-      - {kind: go_test, name: TestSQLiteRuntimeLogPersistenceWritesLoggerRowsForObservability, backends: [default_sqlite]}
-      - {kind: go_test, name: TestPostgresRuntimeLogPersistencePreservesRunSourceAndLineage, backends: [explicit_postgres]}
+      - {kind: go_test, name: TestSQLiteObservabilityOwnerBacksSupportedAPISurfaces, backends: [default_sqlite]}
+      - {kind: go_test, name: TestPostgresObservabilityOwnerBacksSupportedAPISurfaces, backends: [explicit_postgres]}
       - {kind: go_test, name: TestOpenRPCReadOnlyHTTPRuntimeProbes}
   - method: runtime.identity
     classification: different_semantic_concept_with_proof
@@ -409,15 +409,15 @@ operator_read_api_parity_ledger:
     classification: dual_backend_api_proof
     backends: [default_sqlite, explicit_postgres]
     proof_refs:
-      - {kind: go_test, name: TestSQLiteRuntimeLogPersistenceWritesLoggerRowsForObservability, backends: [default_sqlite]}
-      - {kind: go_test, name: TestPostgresRuntimeLogPersistencePreservesRunSourceAndLineage, backends: [explicit_postgres]}
+      - {kind: go_test, name: TestSQLiteObservabilityOwnerBacksSupportedAPISurfaces, backends: [default_sqlite]}
+      - {kind: go_test, name: TestPostgresObservabilityOwnerBacksSupportedAPISurfaces, backends: [explicit_postgres]}
       - {kind: go_test, name: TestOpenRPCReadOnlyHTTPRuntimeProbes}
   - method: runtime.logs
     classification: dual_backend_api_proof
     backends: [default_sqlite, explicit_postgres]
     proof_refs:
-      - {kind: go_test, name: TestSQLiteRuntimeLogPersistenceWritesLoggerRowsForObservability, backends: [default_sqlite]}
-      - {kind: go_test, name: TestPostgresRuntimeLogPersistencePreservesRunSourceAndLineage, backends: [explicit_postgres]}
+      - {kind: go_test, name: TestSQLiteObservabilityOwnerBacksSupportedAPISurfaces, backends: [default_sqlite]}
+      - {kind: go_test, name: TestPostgresObservabilityOwnerBacksSupportedAPISurfaces, backends: [explicit_postgres]}
       - {kind: go_test, name: TestOpenRPCReadOnlyHTTPRuntimeProbes}
   - method: runtime.subscribe_logs
     classification: different_semantic_concept_with_proof


### PR DESCRIPTION
Closes #1810

## Summary

- Add a selected operator-read construction parity guard that compares every `selectedAPICapabilities` field against a total classification ledger, so SQLite cannot silently omit a Postgres-wired operator-read capability.
- Extend the public surface backend matrix with an operator-read API parity ledger derived from the OpenRPC/method catalog minus mutating methods, including explicit classifications for protocol/static/split methods.
- Add validator negatives for unclassified read methods, stale refs, publication-only spec refs, fake-store-only proof, and one-backend proof.

## Governing refs / context

- `platform-spec.yaml#engine.runtime_store_backend_selection`
- `platform-spec.yaml#engine.runtime_core_persistence_store_contracts.selected_contracts[name=selected_runtime_store_facade]`
- `platform-spec.yaml#api_specification.source_of_truth`
- `platform-spec.yaml#api_specification.method_catalog`
- `platform-spec.yaml#api_specification.conventions.idempotency.mutating_methods`
- `platform-spec.yaml#api_specification.multi_bundle_publication_boundary`
- Adjacent conformance owners: `internal/apiv1/testdata/public_surface_backend_matrix.yaml`, `internal/apiv1/public_surface_backend_matrix_test.go`, `internal/apiv1/openrpc_readonly_runtime_test.go`.

## Semantic owner notes

- New selected-construction owner: the total `selectedAPICapabilities` classification ledger in `cmd/swarm/store_backend_selection_test.go`.
- New operator-read API parity owner: `operator_read_api_parity_ledger` in `internal/apiv1/testdata/public_surface_backend_matrix.yaml`, validated by `internal/apiv1/public_surface_backend_matrix_test.go`.
- Old non-authoritative path: the #1805 seed/delta map for only `AgentConversations` and `BundleCatalog` is no longer sufficient as closure proof.
- This PR does not change runtime behavior and does not claim #1783 compile-complete store/interface closure.

## Validation

- `go test ./cmd/swarm -run 'TestSelectedOperatorReadConstructionParityClassifiesSQLitePostgresDelta|TestBuildStoresAcceptsSQLiteSelectedCoreRuntimeStore' -count=1`
- `go test ./internal/apiv1 -run 'TestPublicSurfaceBackendMatrix|TestOpenRPCReadOnlyHTTPRuntimeProbes|TestOpenRPCWebSocketRuntimeProbes|TestSQLiteAgentConversationOwnerBacksSupportedAPISurface|TestSQLiteBundleCatalogOwnerBacksSupportedAPISurface' -count=1`
- `SWARM_TEST_POSTGRES_DSN='host=127.0.0.1 port=5432 user=postgres password=postgres dbname=postgres sslmode=disable' go test ./internal/apiv1 -run 'TestOperatorEntityHandlersServeContractEntityTypesFromPostgres|TestOperatorEventPublishHandlersPersistEventReportDeliveriesAndReplayIdempotency|TestOperatorAgentReadSurfaceLoadAgentDeliveryLifecyclePostgres|TestPublicSurfaceBackendMatrix|TestOpenRPCReadOnlyHTTPRuntimeProbes|TestOpenRPCWebSocketRuntimeProbes|TestSQLiteAgentConversationOwnerBacksSupportedAPISurface|TestSQLiteBundleCatalogOwnerBacksSupportedAPISurface' -count=1`
- `SWARM_TEST_POSTGRES_DSN='host=127.0.0.1 port=5432 user=postgres password=postgres dbname=postgres sslmode=disable' go test ./internal/store -run 'TestBundleCatalogReadSurfaceListGetAgentsAndCursor|TestPostgresRuntimeLogPersistencePreservesRunSourceAndLineage|TestSQLiteRuntimeLogPersistenceWritesLoggerRowsForObservability|TestSQLiteRunAPIReadSurface_LoadListAndDiagnoseEvidence|TestRunAPIReadSurface_LoadAndListRunHeaders|TestSQLiteRuntimeStoreLoadAgentDeliveryLifecycle|TestSQLiteRuntimeStoreLoadAgentUsageSplitsExactAndEstimated' -count=1`
- `SWARM_TEST_POSTGRES_DSN='host=127.0.0.1 port=5432 user=postgres password=postgres dbname=postgres sslmode=disable' go test ./internal/dashboard/server -run 'TestSQLObservabilityReader_(ListEvents_UsesCanonicalDeliveryLifecycle|GetEvent_UsesCanonicalDeliveryRows)' -count=1`
- `SWARM_TEST_POSTGRES_DSN='host=127.0.0.1 port=5432 user=postgres password=postgres dbname=postgres sslmode=disable' go test ./cmd/swarm -run 'TestRunServeRuntimeFreshEmptyPostgresBootstrapsSchemaBeforeDiskContractsServe|TestSelectedOperatorReadConstructionParityClassifiesSQLitePostgresDelta|TestBuildStoresAcceptsSQLiteSelectedCoreRuntimeStore' -count=1`
- `SWARM_CONFIG=<temp config with isolated swarm_dir> SWARM_CREDENTIALS_FILE=<temp credentials> SWARM_TEST_POSTGRES_DSN='host=127.0.0.1 port=5432 user=postgres password=postgres dbname=postgres sslmode=disable' go test ./...`
