### PR TITLE
[agent-b][issue #1799] Retire runtime LLM config env defaults

### DIFF
--- a/cmd/swarm/env_authority_test.go
+++ b/cmd/swarm/env_authority_test.go
@@ -562,6 +562,56 @@ func TestSwarmEnvGuardBlocksGeneratedBoundaryParentEnv(t *testing.T) {
 	}
 }
 
+func TestSwarmEnvGuardBlocksRetiredRuntimeLLMConfigEnv(t *testing.T) {
+	cases := []struct {
+		name    string
+		value   string
+		want    []string
+		notWant []string
+	}{
+		{name: "SWARM_RUNTIME_RECOVERY_ON_STARTUP", value: "true", want: []string{"env/known_retired: SWARM_RUNTIME_RECOVERY_ON_STARTUP", "runtime.recovery_on_startup"}},
+		{name: "SWARM_LLM_SESSION_LOCK_TTL", value: "1s", want: []string{"env/known_retired: SWARM_LLM_SESSION_LOCK_TTL", "llm.session.lock_ttl"}},
+		{name: "SWARM_LLM_SESSION_ROTATE_AFTER_TURNS", value: "2", want: []string{"env/known_retired: SWARM_LLM_SESSION_ROTATE_AFTER_TURNS", "llm.session.rotate_after_turns"}},
+		{name: "SWARM_LLM_SESSION_ROTATE_ON_PARSE_FAILURES", value: "2", want: []string{"env/known_retired: SWARM_LLM_SESSION_ROTATE_ON_PARSE_FAILURES", "llm.session.rotate_on_parse_failures"}},
+		{name: "SWARM_CLAUDE_API_MAX_RETRIES", value: "7", want: []string{"env/known_retired: SWARM_CLAUDE_API_MAX_RETRIES", "llm.claude_api.max_retries"}},
+		{name: "SWARM_CLAUDE_API_RETRY_BACKOFF", value: "7s", want: []string{"env/known_retired: SWARM_CLAUDE_API_RETRY_BACKOFF", "llm.claude_api.retry_backoff"}},
+		{name: "SWARM_CLAUDE_CLI_COMMAND", value: "false", want: []string{"env/known_retired: SWARM_CLAUDE_CLI_COMMAND", "llm.claude_cli.command"}},
+		{name: "SWARM_CLAUDE_CLI_TIMEOUT", value: "1s", want: []string{"env/known_retired: SWARM_CLAUDE_CLI_TIMEOUT", "llm.claude_cli.timeout"}},
+		{name: "SWARM_CLAUDE_CLI_OUTPUT_FORMAT", value: "bad", want: []string{"env/known_retired: SWARM_CLAUDE_CLI_OUTPUT_FORMAT", "llm.claude_cli.output_format"}},
+		{name: "SWARM_CLAUDE_TIMEOUT_SECONDS", value: "1", want: []string{"env/known_retired: SWARM_CLAUDE_TIMEOUT_SECONDS", "llm.claude_cli.timeout"}},
+		{name: "SWARM_CLAUDE_CLI_RETRIES", value: "7", want: []string{"env/known_retired: SWARM_CLAUDE_CLI_RETRIES", "no supported replacement", "#1803"}, notWant: []string{"llm.claude_cli.retries"}},
+		{name: "SWARM_CLAUDE_CLI_NO_SESSION_PERSISTENCE", value: "true", want: []string{"env/known_retired: SWARM_CLAUDE_CLI_NO_SESSION_PERSISTENCE", "no supported replacement", "#1803"}, notWant: []string{"llm.claude_cli.no_session_persistence"}},
+		{name: "SWARM_CLAUDE_CLI_USE_TMUX", value: "true", want: []string{"env/known_retired: SWARM_CLAUDE_CLI_USE_TMUX", "no supported replacement", "#1803"}, notWant: []string{"llm.claude_cli.use_tmux"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			isolateCLIAPIConfigEnv(t)
+			t.Setenv(tc.name, tc.value)
+
+			var stdout, stderr bytes.Buffer
+			code := executeRootCommandWithOptions(context.Background(), repoRoot(), []string{
+				"serve",
+				"--api-listen-addr", "127.0.0.1:0",
+				"--mcp-listen-addr", "127.0.0.1:0",
+			}, &stdout, &stderr, defaultRootCommandOptions())
+			if code != cliExitValidation {
+				t.Fatalf("code = %d, want %d stdout=%s stderr=%s", code, cliExitValidation, stdout.String(), stderr.String())
+			}
+			output := stdout.String() + stderr.String()
+			for _, want := range tc.want {
+				if !strings.Contains(output, want) {
+					t.Fatalf("output missing %q:\n%s", want, output)
+				}
+			}
+			for _, notWant := range tc.notWant {
+				if strings.Contains(output, notWant) {
+					t.Fatalf("output contains fake replacement %q:\n%s", notWant, output)
+				}
+			}
+		})
+	}
+}
+
 func TestSwarmEnvGuardAllowsTypedDatabasePasswordEnvDelegation(t *testing.T) {
 	isolateCLIAPIConfigEnv(t)
 	t.Setenv("SWARM_DB_PASSWORD", "secret")
@@ -709,6 +759,10 @@ func TestDoctorTargetReportsRuntimeConfigEnvRejectors(t *testing.T) {
 		"SWARM_RUNTIME_MAX_CONCURRENT_AGENTS",
 		"SWARM_OPENAI_COMPATIBLE_BASE_URL",
 		"SWARM_OPENAI_COMPATIBLE_DEFAULT_MODEL",
+		"SWARM_RUNTIME_RECOVERY_ON_STARTUP",
+		"SWARM_CLAUDE_CLI_TIMEOUT",
+		"SWARM_CLAUDE_TIMEOUT_SECONDS",
+		"SWARM_CLAUDE_CLI_RETRIES",
 	}
 	for _, envName := range cases {
 		t.Run(envName, func(t *testing.T) {
@@ -737,6 +791,15 @@ func TestDoctorTargetReportsRuntimeConfigEnvRejectors(t *testing.T) {
 				t.Fatalf("doctor target report OK=true, want env blocker: %#v", report)
 			}
 			assertDoctorTargetEnvFinding(t, report, string(swarmEnvCategoryKnownRetired), envName)
+			if envName == "SWARM_CLAUDE_CLI_RETRIES" {
+				finding := findDoctorTargetEnvFinding(t, report, string(swarmEnvCategoryKnownRetired), envName)
+				if !strings.Contains(finding.Message, "no supported replacement") || !strings.Contains(finding.Message, "#1803") {
+					t.Fatalf("retired inert finding message = %q, want #1803/no replacement", finding.Message)
+				}
+				if strings.Contains(finding.Message+finding.Remediation, "llm.claude_cli.retries") {
+					t.Fatalf("retired inert finding advertises fake replacement: %#v", finding)
+				}
+			}
 		})
 	}
 }
@@ -803,12 +866,18 @@ func assertLocalPreflightFinding(t *testing.T, report localPreflightReport, cate
 
 func assertDoctorTargetEnvFinding(t *testing.T, report doctorTargetReport, code, messagePart string) {
 	t.Helper()
+	_ = findDoctorTargetEnvFinding(t, report, code, messagePart)
+}
+
+func findDoctorTargetEnvFinding(t *testing.T, report doctorTargetReport, code, messagePart string) localPreflightFinding {
+	t.Helper()
 	for _, finding := range report.Env {
 		if finding.Category == localPreflightEnvPrerequisite && finding.Code == code && strings.Contains(finding.Message, messagePart) {
-			return
+			return finding
 		}
 	}
 	t.Fatalf("missing target env finding code=%s message containing %q: %#v", code, messagePart, report.Env)
+	return localPreflightFinding{}
 }
 
 func assertNoDotEnvLoadFailure(t testing.TB, output string) {

--- a/cmd/swarm/env_guard.go
+++ b/cmd/swarm/env_guard.go
@@ -554,6 +554,20 @@ func swarmEnvCatalogEntries() []swarmEnvCatalogEntry {
 	retired := func(name, message, remediation string) swarmEnvCatalogEntry {
 		return e(name, swarmEnvCategoryKnownRetired, swarmEnvAuthorityOwner, "retired", message, remediation)
 	}
+	retiredRuntimeConfig := func(name, key string) swarmEnvCatalogEntry {
+		return retired(
+			name,
+			name+" is retired as runtime/LLM environment source; use "+key,
+			"unset "+name+"; set "+key+" in unified swarm.yaml/runtime config",
+		)
+	}
+	retiredUnsupported := func(name string) swarmEnvCatalogEntry {
+		return retired(
+			name,
+			name+" is retired; this Claude CLI control has no supported replacement and is tracked by #1803",
+			"unset "+name+"; no supported replacement exists for this inert/unsupported Claude CLI control",
+		)
+	}
 	testOnly := func(name string) swarmEnvCatalogEntry {
 		return e(name, swarmEnvCategoryTestQuarantine, swarmEnvAuthorityOwner, "test/debug quarantine", "", "")
 	}
@@ -600,21 +614,21 @@ func swarmEnvCatalogEntries() []swarmEnvCatalogEntry {
 		seeded("SWARM_SYSTEM_SYSTEMD_VOLUME", "platform-spec.yaml#environment_source_authority.workspace_monitor_artifact_debug_slice", "#1600 workspace lifecycle config"),
 		seeded("SWARM_ENTITY_CONTAINER_PREFIX", "platform-spec.yaml#environment_source_authority.workspace_monitor_artifact_debug_slice", "#1600 workspace lifecycle config"),
 		seeded("SWARM_ENTITY_WORKDIR", "platform-spec.yaml#environment_source_authority.workspace_monitor_artifact_debug_slice", "#1600 workspace lifecycle config"),
-		seeded("SWARM_RUNTIME_RECOVERY_ON_STARTUP", "platform-spec.yaml#runtime_storage.runtime_store_backend_selection", "#1600 runtime.recovery_on_startup"),
+		retiredRuntimeConfig("SWARM_RUNTIME_RECOVERY_ON_STARTUP", "runtime.recovery_on_startup"),
 		retired("SWARM_RUNTIME_MAX_CONCURRENT_AGENTS", "SWARM_RUNTIME_MAX_CONCURRENT_AGENTS is unsupported inert runtime control", "remove it; no runtime path enforces this control"),
 		retired("SWARM_RUNTIME_EVENT_POLL_INTERVAL", "SWARM_RUNTIME_EVENT_POLL_INTERVAL is unsupported inert runtime control", "remove it; no runtime path enforces this control"),
-		seeded("SWARM_LLM_SESSION_LOCK_TTL", "platform-spec.yaml#engine.agent_session_management.llm_provider_selection_config_authority", "#1600 llm.session.lock_ttl"),
-		seeded("SWARM_LLM_SESSION_ROTATE_AFTER_TURNS", "platform-spec.yaml#engine.agent_session_management.llm_provider_selection_config_authority", "#1600 llm.session.rotate_after_turns"),
-		seeded("SWARM_LLM_SESSION_ROTATE_ON_PARSE_FAILURES", "platform-spec.yaml#engine.agent_session_management.llm_provider_selection_config_authority", "#1600 llm.session.rotate_on_parse_failures"),
-		seeded("SWARM_CLAUDE_API_MAX_RETRIES", "platform-spec.yaml#engine.agent_session_management.llm_provider_selection_config_authority", "#1600 llm.claude_api.max_retries"),
-		seeded("SWARM_CLAUDE_API_RETRY_BACKOFF", "platform-spec.yaml#engine.agent_session_management.llm_provider_selection_config_authority", "#1600 llm.claude_api.retry_backoff"),
-		seeded("SWARM_CLAUDE_CLI_COMMAND", "platform-spec.yaml#engine.agent_session_management.llm_provider_selection_config_authority", "#1600 llm.claude_cli.command"),
-		seeded("SWARM_CLAUDE_CLI_TIMEOUT", "platform-spec.yaml#engine.agent_session_management.llm_provider_selection_config_authority", "#1600 llm.claude_cli.timeout"),
-		seeded("SWARM_CLAUDE_CLI_OUTPUT_FORMAT", "platform-spec.yaml#engine.agent_session_management.llm_provider_selection_config_authority", "#1600 llm.claude_cli.output_format"),
-		seeded("SWARM_CLAUDE_CLI_RETRIES", "platform-spec.yaml#engine.agent_session_management.llm_provider_selection_config_authority", "#1600 llm.claude_cli.retries"),
-		seeded("SWARM_CLAUDE_CLI_NO_SESSION_PERSISTENCE", "platform-spec.yaml#engine.agent_session_management.llm_provider_selection_config_authority", "#1600 llm.claude_cli.no_session_persistence"),
-		seeded("SWARM_CLAUDE_CLI_USE_TMUX", "platform-spec.yaml#engine.agent_session_management.llm_provider_selection_config_authority", "#1600 llm.claude_cli.use_tmux"),
-		seeded("SWARM_CLAUDE_TIMEOUT_SECONDS", "platform-spec.yaml#engine.agent_session_management.llm_provider_selection_config_authority", "#1600 llm.claude_cli.timeout"),
+		retiredRuntimeConfig("SWARM_LLM_SESSION_LOCK_TTL", "llm.session.lock_ttl"),
+		retiredRuntimeConfig("SWARM_LLM_SESSION_ROTATE_AFTER_TURNS", "llm.session.rotate_after_turns"),
+		retiredRuntimeConfig("SWARM_LLM_SESSION_ROTATE_ON_PARSE_FAILURES", "llm.session.rotate_on_parse_failures"),
+		retiredRuntimeConfig("SWARM_CLAUDE_API_MAX_RETRIES", "llm.claude_api.max_retries"),
+		retiredRuntimeConfig("SWARM_CLAUDE_API_RETRY_BACKOFF", "llm.claude_api.retry_backoff"),
+		retiredRuntimeConfig("SWARM_CLAUDE_CLI_COMMAND", "llm.claude_cli.command"),
+		retiredRuntimeConfig("SWARM_CLAUDE_CLI_TIMEOUT", "llm.claude_cli.timeout"),
+		retiredRuntimeConfig("SWARM_CLAUDE_CLI_OUTPUT_FORMAT", "llm.claude_cli.output_format"),
+		retiredUnsupported("SWARM_CLAUDE_CLI_RETRIES"),
+		retiredUnsupported("SWARM_CLAUDE_CLI_NO_SESSION_PERSISTENCE"),
+		retiredUnsupported("SWARM_CLAUDE_CLI_USE_TMUX"),
+		retiredRuntimeConfig("SWARM_CLAUDE_TIMEOUT_SECONDS", "llm.claude_cli.timeout"),
 		seeded("SWARM_CLAUDE_PERMISSION_MODE", "platform-spec.yaml#engine.agent_session_management.llm_provider_selection_config_authority", "#1600 llm.claude_cli.permission_mode"),
 		seeded("SWARM_CLAUDE_BYPASS_PERMISSIONS", "platform-spec.yaml#engine.agent_session_management.llm_provider_selection_config_authority", "#1600 llm.claude_cli.permission_mode"),
 		seeded("SWARM_CLAUDE_USE_MCP", "platform-spec.yaml#cli_specification.foundations.local_tool_gateway_binding", "#1600 typed Claude CLI transport config"),

--- a/cmd/swarm/main.go
+++ b/cmd/swarm/main.go
@@ -2535,7 +2535,7 @@ func defaultRuntimeConfig() (*config.Config, error) {
 	}
 	cfg := &config.Config{
 		Runtime: config.RuntimeConfig{
-			RecoveryOnStartup: envBool("SWARM_RUNTIME_RECOVERY_ON_STARTUP", false),
+			RecoveryOnStartup: false,
 		},
 		Database: config.DatabaseConfig{
 			Host:     envOrDefault("SWARM_DB_HOST", envOrDefault("PGHOST", "127.0.0.1")),
@@ -2548,21 +2548,21 @@ func defaultRuntimeConfig() (*config.Config, error) {
 		LLM: config.LLMConfig{
 			Backend: llmselection.DefaultBackendID(),
 			Session: config.LLMSessionConfig{
-				LockTTL:               envDuration("SWARM_LLM_SESSION_LOCK_TTL", 10*time.Second),
-				RotateAfterTurns:      envInt("SWARM_LLM_SESSION_ROTATE_AFTER_TURNS", 40),
-				RotateOnParseFailures: envInt("SWARM_LLM_SESSION_ROTATE_ON_PARSE_FAILURES", 3),
+				LockTTL:               10 * time.Second,
+				RotateAfterTurns:      40,
+				RotateOnParseFailures: 3,
 			},
 			ClaudeAPI: config.ClaudeAPIConfig{
-				MaxRetries:   envInt("SWARM_CLAUDE_API_MAX_RETRIES", 1),
-				RetryBackoff: envDuration("SWARM_CLAUDE_API_RETRY_BACKOFF", 2*time.Second),
+				MaxRetries:   1,
+				RetryBackoff: 2 * time.Second,
 			},
 			ClaudeCLI: config.ClaudeCLIConfig{
-				Command:              envOrDefault("SWARM_CLAUDE_CLI_COMMAND", "claude"),
-				Timeout:              envDuration("SWARM_CLAUDE_CLI_TIMEOUT", time.Hour),
-				OutputFormat:         envOrDefault("SWARM_CLAUDE_CLI_OUTPUT_FORMAT", "stream-json"),
-				Retries:              envInt("SWARM_CLAUDE_CLI_RETRIES", 1),
-				NoSessionPersistence: envBool("SWARM_CLAUDE_CLI_NO_SESSION_PERSISTENCE", false),
-				UseTMux:              envBool("SWARM_CLAUDE_CLI_USE_TMUX", false),
+				Command:              "claude",
+				Timeout:              time.Hour,
+				OutputFormat:         "stream-json",
+				Retries:              1,
+				NoSessionPersistence: false,
+				UseTMux:              false,
 			},
 			OpenAICompatible: config.OpenAICompatibleConfig{},
 		},

--- a/cmd/swarm/main_test.go
+++ b/cmd/swarm/main_test.go
@@ -8920,6 +8920,48 @@ func TestDefaultRuntimeConfig_DoesNotInferLLMBackendFromCredentials(t *testing.T
 	}
 }
 
+func TestDefaultRuntimeConfig_IgnoresRetiredRuntimeLLMConfigEnv(t *testing.T) {
+	for key, value := range map[string]string{
+		"SWARM_RUNTIME_RECOVERY_ON_STARTUP":          "true",
+		"SWARM_LLM_SESSION_LOCK_TTL":                 "1s",
+		"SWARM_LLM_SESSION_ROTATE_AFTER_TURNS":       "2",
+		"SWARM_LLM_SESSION_ROTATE_ON_PARSE_FAILURES": "2",
+		"SWARM_CLAUDE_API_MAX_RETRIES":               "7",
+		"SWARM_CLAUDE_API_RETRY_BACKOFF":             "7s",
+		"SWARM_CLAUDE_CLI_COMMAND":                   "false",
+		"SWARM_CLAUDE_CLI_TIMEOUT":                   "1s",
+		"SWARM_CLAUDE_CLI_OUTPUT_FORMAT":             "bad",
+		"SWARM_CLAUDE_CLI_RETRIES":                   "7",
+		"SWARM_CLAUDE_CLI_NO_SESSION_PERSISTENCE":    "true",
+		"SWARM_CLAUDE_CLI_USE_TMUX":                  "true",
+		"SWARM_CLAUDE_TIMEOUT_SECONDS":               "1",
+	} {
+		t.Setenv(key, value)
+	}
+
+	cfg, err := defaultRuntimeConfig()
+	if err != nil {
+		t.Fatalf("defaultRuntimeConfig: %v", err)
+	}
+	if cfg.Runtime.RecoveryOnStartup {
+		t.Fatalf("recovery_on_startup = true, want built-in false")
+	}
+	if cfg.LLM.Session.LockTTL != 10*time.Second || cfg.LLM.Session.RotateAfterTurns != 40 || cfg.LLM.Session.RotateOnParseFailures != 3 {
+		t.Fatalf("session defaults = %#v, want built-ins", cfg.LLM.Session)
+	}
+	if cfg.LLM.ClaudeAPI.MaxRetries != 1 || cfg.LLM.ClaudeAPI.RetryBackoff != 2*time.Second {
+		t.Fatalf("claude_api defaults = %#v, want built-ins", cfg.LLM.ClaudeAPI)
+	}
+	if cfg.LLM.ClaudeCLI.Command != "claude" ||
+		cfg.LLM.ClaudeCLI.Timeout != time.Hour ||
+		cfg.LLM.ClaudeCLI.OutputFormat != "stream-json" ||
+		cfg.LLM.ClaudeCLI.Retries != 1 ||
+		cfg.LLM.ClaudeCLI.NoSessionPersistence ||
+		cfg.LLM.ClaudeCLI.UseTMux {
+		t.Fatalf("claude_cli defaults = %#v, want built-ins", cfg.LLM.ClaudeCLI)
+	}
+}
+
 func TestDefaultRuntimeConfig_RejectsRetiredOpenAICompatibleBaseURLEnv(t *testing.T) {
 	t.Setenv("SWARM_OPENAI_COMPATIBLE_BASE_URL", "https://example.test/v1")
 	cfg, err := defaultRuntimeConfig()
@@ -8928,6 +8970,63 @@ func TestDefaultRuntimeConfig_RejectsRetiredOpenAICompatibleBaseURLEnv(t *testin
 	}
 	if cfg != nil {
 		t.Fatalf("defaultRuntimeConfig cfg = %#v, want nil on retired env", cfg)
+	}
+}
+
+func TestLoadRuntimeConfigWithOptions_PreservesRuntimeLLMTypedConfigValues(t *testing.T) {
+	for key, value := range map[string]string{
+		"SWARM_RUNTIME_RECOVERY_ON_STARTUP":          "false",
+		"SWARM_LLM_SESSION_LOCK_TTL":                 "1s",
+		"SWARM_LLM_SESSION_ROTATE_AFTER_TURNS":       "2",
+		"SWARM_LLM_SESSION_ROTATE_ON_PARSE_FAILURES": "2",
+		"SWARM_CLAUDE_API_MAX_RETRIES":               "1",
+		"SWARM_CLAUDE_API_RETRY_BACKOFF":             "1s",
+		"SWARM_CLAUDE_CLI_COMMAND":                   "false",
+		"SWARM_CLAUDE_CLI_TIMEOUT":                   "1s",
+		"SWARM_CLAUDE_CLI_OUTPUT_FORMAT":             "stream-json",
+		"SWARM_CLAUDE_TIMEOUT_SECONDS":               "1",
+	} {
+		t.Setenv(key, value)
+	}
+
+	repo := t.TempDir()
+	configPath := filepath.Join(repo, "runtime.yaml")
+	writeRuntimeConfigText(t, configPath, strings.Join([]string{
+		"runtime:",
+		"  recovery_on_startup: true",
+		"llm:",
+		"  backend: claude_cli",
+		"  session:",
+		"    lock_ttl: 22s",
+		"    rotate_after_turns: 55",
+		"    rotate_on_parse_failures: 9",
+		"  claude_api:",
+		"    max_retries: 8",
+		"    retry_backoff: 11s",
+		"  claude_cli:",
+		"    command: echo",
+		"    timeout: 44s",
+		"    output_format: json",
+		"    retries: 1",
+		"    no_session_persistence: false",
+	}, "\n")+"\n")
+
+	result, err := loadRuntimeConfigWithOptions(runtimeConfigLoadOptions{RepoRoot: repo, ExplicitPath: configPath})
+	if err != nil {
+		t.Fatalf("loadRuntimeConfigWithOptions: %v", err)
+	}
+	cfg := result.Config
+	if !cfg.Runtime.RecoveryOnStartup {
+		t.Fatalf("runtime.recovery_on_startup = false, want true from config")
+	}
+	if cfg.LLM.Session.LockTTL != 22*time.Second || cfg.LLM.Session.RotateAfterTurns != 55 || cfg.LLM.Session.RotateOnParseFailures != 9 {
+		t.Fatalf("session config = %#v, want typed config values", cfg.LLM.Session)
+	}
+	if cfg.LLM.ClaudeAPI.MaxRetries != 8 || cfg.LLM.ClaudeAPI.RetryBackoff != 11*time.Second {
+		t.Fatalf("claude_api config = %#v, want typed config values", cfg.LLM.ClaudeAPI)
+	}
+	if cfg.LLM.ClaudeCLI.Command != "echo" || cfg.LLM.ClaudeCLI.Timeout != 44*time.Second || cfg.LLM.ClaudeCLI.OutputFormat != "json" {
+		t.Fatalf("claude_cli config = %#v, want typed config values", cfg.LLM.ClaudeCLI)
 	}
 }
 

--- a/internal/runtime/llm/cli_runtime_process.go
+++ b/internal/runtime/llm/cli_runtime_process.go
@@ -9,7 +9,6 @@ import (
 	"io"
 	"os"
 	"os/exec"
-	"strconv"
 	"strings"
 	"time"
 
@@ -249,12 +248,6 @@ func effectiveCLITimeoutForConfig(ctx context.Context, cfg *config.Config) time.
 	if actor, ok := runtimeactors.ActorFromContext(ctx); ok {
 		if strings.TrimSpace(actor.EffectiveEntityID()) == "" && timeout < 300*time.Second {
 			timeout = 300 * time.Second
-		}
-	}
-	// Explicit env override wins (operator emergency control).
-	if raw := strings.TrimSpace(os.Getenv("SWARM_CLAUDE_TIMEOUT_SECONDS")); raw != "" {
-		if seconds, err := strconv.Atoi(raw); err == nil && seconds > 0 {
-			timeout = time.Duration(seconds) * time.Second
 		}
 	}
 	return timeout

--- a/internal/runtime/llm/cli_runtime_process_test.go
+++ b/internal/runtime/llm/cli_runtime_process_test.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/division-sh/swarm/internal/config"
 	runtimeactors "github.com/division-sh/swarm/internal/runtime/core/actors"
@@ -239,5 +240,25 @@ func TestClaudeCLIRuntimePersistOversizedToolResultRelay_PropagatesWorkspaceWrit
 	_, err := runtime.PersistOversizedToolResultRelay(ctx, &Session{ID: "sess-1"}, "sql_execute", []byte(`{"blob":"hello"}`))
 	if err == nil || !strings.Contains(err.Error(), "permission denied") {
 		t.Fatalf("PersistOversizedToolResultRelay err = %v, want permission denied", err)
+	}
+}
+
+func TestEffectiveCLITimeoutForConfigIgnoresRetiredEnvAndPreservesActorFloor(t *testing.T) {
+	t.Setenv("SWARM_CLAUDE_TIMEOUT_SECONDS", "1")
+	cfg := &config.Config{}
+	cfg.LLM.ClaudeCLI.Timeout = 45 * time.Second
+
+	if got := effectiveCLITimeoutForConfig(context.Background(), cfg); got != 45*time.Second {
+		t.Fatalf("timeout without actor = %v, want config timeout", got)
+	}
+
+	globalActorCtx := runtimeactors.WithActor(context.Background(), runtimeactors.AgentConfig{ID: "global-agent"})
+	if got := effectiveCLITimeoutForConfig(globalActorCtx, cfg); got != 300*time.Second {
+		t.Fatalf("timeout for global/no-entity actor = %v, want floor", got)
+	}
+
+	entityActorCtx := runtimeactors.WithActor(context.Background(), runtimeactors.AgentConfig{ID: "entity-agent", EntityID: "customer-1"})
+	if got := effectiveCLITimeoutForConfig(entityActorCtx, cfg); got != 45*time.Second {
+		t.Fatalf("timeout for entity actor = %v, want config timeout", got)
 	}
 }

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -11527,9 +11527,9 @@ environment_source_authority:
       owner: platform-spec.yaml#environment_source_authority.workspace_monitor_artifact_debug_slice
       migration: '#1600 workspace lifecycle config'
     - name: SWARM_RUNTIME_RECOVERY_ON_STARTUP
-      category: seeded_legacy
-      owner: platform-spec.yaml#runtime_storage.runtime_store_backend_selection
-      migration: '#1600 runtime.recovery_on_startup'
+      category: known_retired
+      owner: platform-spec.yaml#environment_source_authority.repo_wide_swarm_env_accepted_set
+      migration: retired
     - name: SWARM_RUNTIME_MAX_CONCURRENT_AGENTS
       category: known_retired
       owner: platform-spec.yaml#environment_source_authority.repo_wide_swarm_env_accepted_set
@@ -11539,53 +11539,53 @@ environment_source_authority:
       owner: platform-spec.yaml#environment_source_authority.repo_wide_swarm_env_accepted_set
       migration: retired
     - name: SWARM_LLM_SESSION_LOCK_TTL
-      category: seeded_legacy
-      owner: platform-spec.yaml#engine.agent_session_management.llm_provider_selection_config_authority
-      migration: '#1600 llm.session.lock_ttl'
+      category: known_retired
+      owner: platform-spec.yaml#environment_source_authority.repo_wide_swarm_env_accepted_set
+      migration: retired
     - name: SWARM_LLM_SESSION_ROTATE_AFTER_TURNS
-      category: seeded_legacy
-      owner: platform-spec.yaml#engine.agent_session_management.llm_provider_selection_config_authority
-      migration: '#1600 llm.session.rotate_after_turns'
+      category: known_retired
+      owner: platform-spec.yaml#environment_source_authority.repo_wide_swarm_env_accepted_set
+      migration: retired
     - name: SWARM_LLM_SESSION_ROTATE_ON_PARSE_FAILURES
-      category: seeded_legacy
-      owner: platform-spec.yaml#engine.agent_session_management.llm_provider_selection_config_authority
-      migration: '#1600 llm.session.rotate_on_parse_failures'
+      category: known_retired
+      owner: platform-spec.yaml#environment_source_authority.repo_wide_swarm_env_accepted_set
+      migration: retired
     - name: SWARM_CLAUDE_API_MAX_RETRIES
-      category: seeded_legacy
-      owner: platform-spec.yaml#engine.agent_session_management.llm_provider_selection_config_authority
-      migration: '#1600 llm.claude_api.max_retries'
+      category: known_retired
+      owner: platform-spec.yaml#environment_source_authority.repo_wide_swarm_env_accepted_set
+      migration: retired
     - name: SWARM_CLAUDE_API_RETRY_BACKOFF
-      category: seeded_legacy
-      owner: platform-spec.yaml#engine.agent_session_management.llm_provider_selection_config_authority
-      migration: '#1600 llm.claude_api.retry_backoff'
+      category: known_retired
+      owner: platform-spec.yaml#environment_source_authority.repo_wide_swarm_env_accepted_set
+      migration: retired
     - name: SWARM_CLAUDE_CLI_COMMAND
-      category: seeded_legacy
-      owner: platform-spec.yaml#engine.agent_session_management.llm_provider_selection_config_authority
-      migration: '#1600 llm.claude_cli.command'
+      category: known_retired
+      owner: platform-spec.yaml#environment_source_authority.repo_wide_swarm_env_accepted_set
+      migration: retired
     - name: SWARM_CLAUDE_CLI_TIMEOUT
-      category: seeded_legacy
-      owner: platform-spec.yaml#engine.agent_session_management.llm_provider_selection_config_authority
-      migration: '#1600 llm.claude_cli.timeout'
+      category: known_retired
+      owner: platform-spec.yaml#environment_source_authority.repo_wide_swarm_env_accepted_set
+      migration: retired
     - name: SWARM_CLAUDE_CLI_OUTPUT_FORMAT
-      category: seeded_legacy
-      owner: platform-spec.yaml#engine.agent_session_management.llm_provider_selection_config_authority
-      migration: '#1600 llm.claude_cli.output_format'
+      category: known_retired
+      owner: platform-spec.yaml#environment_source_authority.repo_wide_swarm_env_accepted_set
+      migration: retired
     - name: SWARM_CLAUDE_CLI_RETRIES
-      category: seeded_legacy
-      owner: platform-spec.yaml#engine.agent_session_management.llm_provider_selection_config_authority
-      migration: '#1600 llm.claude_cli.retries'
+      category: known_retired
+      owner: platform-spec.yaml#environment_source_authority.repo_wide_swarm_env_accepted_set
+      migration: retired
     - name: SWARM_CLAUDE_CLI_NO_SESSION_PERSISTENCE
-      category: seeded_legacy
-      owner: platform-spec.yaml#engine.agent_session_management.llm_provider_selection_config_authority
-      migration: '#1600 llm.claude_cli.no_session_persistence'
+      category: known_retired
+      owner: platform-spec.yaml#environment_source_authority.repo_wide_swarm_env_accepted_set
+      migration: retired
     - name: SWARM_CLAUDE_CLI_USE_TMUX
-      category: seeded_legacy
-      owner: platform-spec.yaml#engine.agent_session_management.llm_provider_selection_config_authority
-      migration: '#1600 llm.claude_cli.use_tmux'
+      category: known_retired
+      owner: platform-spec.yaml#environment_source_authority.repo_wide_swarm_env_accepted_set
+      migration: retired
     - name: SWARM_CLAUDE_TIMEOUT_SECONDS
-      category: seeded_legacy
-      owner: platform-spec.yaml#engine.agent_session_management.llm_provider_selection_config_authority
-      migration: '#1600 llm.claude_cli.timeout'
+      category: known_retired
+      owner: platform-spec.yaml#environment_source_authority.repo_wide_swarm_env_accepted_set
+      migration: retired
     - name: SWARM_CLAUDE_PERMISSION_MODE
       category: seeded_legacy
       owner: platform-spec.yaml#engine.agent_session_management.llm_provider_selection_config_authority
@@ -12141,7 +12141,7 @@ configuration_source_authority:
     - '#1801 unified parser and layered discovery implementation'
     - '#1803 inert/unsupported Claude CLI config-surface cleanup'
     - '#1600 seeded env-row family migrations'
-    - '#1799 paused config-var migration pending this spec lock'
+    - '#1799 runtime/LLM config-default env-row retirement consumes this owner for final key-path guidance'
     - examples/docs cleanup for one `swarm.example.yaml`
     - runtime sharding behavior promotion, if ever desired
     - provider-trigger runtime behavior changes, explicitly not part of #1804


### PR DESCRIPTION
## Summary

Retires the approved #1799 runtime/LLM seeded env row family as a complete child slice.

- Removes production env source authority for runtime/LLM default rows from `defaultRuntimeConfig`.
- Removes the late `SWARM_CLAUDE_TIMEOUT_SECONDS` override from Claude CLI timeout calculation while preserving the global/no-entity actor timeout floor.
- Moves the #1799 rows from `seeded_legacy` to retired guard/spec diagnostics.
- Keeps #1800 safety/transport rows untouched.
- Gives unsupported/inert Claude CLI rows truthful remediation: no supported replacement, tracked by #1803.

Closes #1799

## Governing refs / context

Exact governing refs:

- `platform-spec.yaml#environment_source_authority.repo_wide_swarm_env_accepted_set`
- `platform-spec.yaml#configuration_source_authority.unified_swarm_config`
- `platform-spec.yaml#engine.agent_session_management.llm_provider_selection_config_authority`
- `platform-spec.yaml#cli_specification.foundations.local_tool_gateway_binding`
- #1799 refreshed `Pre-Implementation Coverage Audit`
- #1799 lead gate outcome: `approved as first slice`

## Semantic migration

New canonical owners:

- `runtime.recovery_on_startup`
- `llm.session.lock_ttl`
- `llm.session.rotate_after_turns`
- `llm.session.rotate_on_parse_failures`
- `llm.claude_api.max_retries`
- `llm.claude_api.retry_backoff`
- `llm.claude_cli.command`
- `llm.claude_cli.timeout`
- `llm.claude_cli.output_format`
- no supported replacement for `SWARM_CLAUDE_CLI_RETRIES`, `SWARM_CLAUDE_CLI_NO_SESSION_PERSISTENCE`, or `SWARM_CLAUDE_CLI_USE_TMUX`; cleanup remains tracked by #1803

Old producer/reader/interpreter paths now invalid:

- `cmd/swarm/defaultRuntimeConfig` env reads for the #1799 runtime/LLM rows
- `internal/runtime/llm/effectiveCLITimeoutForConfig` late `SWARM_CLAUDE_TIMEOUT_SECONDS` override
- `cmd/swarm/env_guard.go` `seeded_legacy` catalog entries for the #1799 rows
- `platform-spec.yaml` `seeded_legacy` entries for the #1799 rows

Production paths checked for surviving old behavior:

```sh
rg -n "SWARM_RUNTIME_RECOVERY_ON_STARTUP|SWARM_LLM_SESSION_LOCK_TTL|SWARM_LLM_SESSION_ROTATE_AFTER_TURNS|SWARM_LLM_SESSION_ROTATE_ON_PARSE_FAILURES|SWARM_CLAUDE_API_MAX_RETRIES|SWARM_CLAUDE_API_RETRY_BACKOFF|SWARM_CLAUDE_CLI_COMMAND|SWARM_CLAUDE_CLI_TIMEOUT|SWARM_CLAUDE_CLI_OUTPUT_FORMAT|SWARM_CLAUDE_CLI_RETRIES|SWARM_CLAUDE_CLI_NO_SESSION_PERSISTENCE|SWARM_CLAUDE_CLI_USE_TMUX|SWARM_CLAUDE_TIMEOUT_SECONDS" cmd internal platform-spec.yaml --glob '!**/*_test.go'
```

Result: only `platform-spec.yaml` catalog rows and `cmd/swarm/env_guard.go` retired diagnostics remain outside tests.

Migration is complete for the approved #1799 child class. Parent #1600 remains open.

## Proof

- `go test ./cmd/swarm -run 'TestSwarmEnvGuardBlocksRetiredRuntimeLLMConfigEnv|TestDoctorTargetReportsRuntimeConfigEnvRejectors|TestDefaultRuntimeConfig_IgnoresRetiredRuntimeLLMConfigEnv|TestLoadRuntimeConfigWithOptions_PreservesRuntimeLLMTypedConfigValues|TestRepoWideSwarmEnvAcceptedSetMatchesSpec'`
- `go test ./internal/runtime/llm -run TestEffectiveCLITimeoutForConfigIgnoresRetiredEnvAndPreservesActorFloor`
- `go test ./internal/apispec -run TestPlatformSpecUnifiedConfig`
- `SWARM_CREDENTIALS_FILE=$(mktemp -t swarm-empty-credentials.XXXXXX.json) SWARM_TEST_POSTGRES_DSN='host=127.0.0.1 port=5432 user=postgres password=postgres dbname=postgres sslmode=disable' go test ./...`
- `git diff --check`
