### PR TITLE
[agent-f][issue #1809] Add non-idempotent activity journal

### DIFF
--- a/internal/runtime/activity_validation.go
+++ b/internal/runtime/activity_validation.go
@@ -131,18 +131,21 @@ func validateActivitySpec(source semanticview.Source, flowID, nodeID, handlerEve
 	if len(tool.ResponseMapping) > 0 {
 		errs = append(errs, fmt.Errorf("%s: tool %q uses response_mapping; activity HTTP response mapping is split until the activity dispatcher consumes the HTTP tool response-mapping owner", context, toolID))
 	}
-	if len(tool.Credentials) > 0 || tool.ManagedCredential != nil {
-		errs = append(errs, fmt.Errorf("%s: tool %q uses credentials; credentialed activity HTTP execution is split until activity credential authority is specified", context, toolID))
-	}
 	effectClass := runtimecontracts.NormalizeActivityEffectClass(tool.EffectClass)
 	if effectClass == "" {
-		errs = append(errs, fmt.Errorf("%s: tool %q must declare effect_class; the Stage 1 executable value is read_only", context, toolID))
+		errs = append(errs, fmt.Errorf("%s: tool %q must declare effect_class; executable Stage 1 values are read_only and non_idempotent_write on the activity journal path", context, toolID))
 	} else if effectClass == runtimecontracts.ActivityEffectClassLongRunning {
 		errs = append(errs, fmt.Errorf("%s: tool %q effect_class long_running is split to later durable resume/cancel support", context, toolID))
-	} else if effectClass == runtimecontracts.ActivityEffectClassIdempotentWrite || effectClass == runtimecontracts.ActivityEffectClassNonIdempotentWrite {
-		errs = append(errs, fmt.Errorf("%s: tool %q effect_class %q is split until the activity runtime owns stable attempt/result journaling and idempotency execution", context, toolID, effectClass))
+	} else if effectClass == runtimecontracts.ActivityEffectClassIdempotentWrite {
+		errs = append(errs, fmt.Errorf("%s: tool %q effect_class %q is split until idempotency execution ownership is specified and implemented", context, toolID, effectClass))
 	} else if !runtimecontracts.SupportedActivityEffectClass(effectClass) {
 		errs = append(errs, fmt.Errorf("%s: tool %q effect_class %q is not supported for activities", context, toolID, tool.EffectClass))
+	}
+	if tool.ManagedCredential != nil {
+		errs = append(errs, fmt.Errorf("%s: tool %q uses managed_credential; managed credential activity HTTP execution is split until OAuth/token lifecycle ownership is specified", context, toolID))
+	}
+	if len(tool.Credentials) > 0 && effectClass != runtimecontracts.ActivityEffectClassNonIdempotentWrite {
+		errs = append(errs, fmt.Errorf("%s: tool %q uses static credentials; static credential activity HTTP execution is supported only for non_idempotent_write authored HTTP activities", context, toolID))
 	}
 	errs = append(errs, validateActivityInputAgainstToolSchema(context, activity, tool.InputSchema)...)
 	site := runtimecontracts.ActivitySite{

--- a/internal/runtime/contracts/workflow_contract_activity.go
+++ b/internal/runtime/contracts/workflow_contract_activity.go
@@ -46,7 +46,7 @@ const (
 
 func SupportedActivityEffectClass(effectClass ActivityEffectClass) bool {
 	switch effectClass {
-	case ActivityEffectClassReadOnly:
+	case ActivityEffectClassReadOnly, ActivityEffectClassNonIdempotentWrite:
 		return true
 	default:
 		return false

--- a/internal/runtime/contracts/workflow_contract_activity_test.go
+++ b/internal/runtime/contracts/workflow_contract_activity_test.go
@@ -104,7 +104,7 @@ func TestActivityEffectClassDefaults(t *testing.T) {
 			maxAttempts: 1,
 			backoff:     "none",
 			forkPolicy:  ActivityForkRequireConfirmation,
-			supported:   false,
+			supported:   true,
 		},
 		{
 			name:        "long running split",

--- a/internal/runtime/destructivereset/cleanup_catalog.go
+++ b/internal/runtime/destructivereset/cleanup_catalog.go
@@ -28,6 +28,7 @@ func DefaultPlatformCleanupCatalog() []CleanupCatalogEntry {
 		{Table: "run_fork_selected_contract_branch_divergences", TableKind: CleanupTableKindPlatform, Classification: CleanupDeleteByRunLineage, PredicateOwner: "fork_run_id|source_run_id|fork_event_id -> events.run_id", DeleteOrderGroup: 2},
 		{Table: "run_fork_selected_contract_route_recoveries", TableKind: CleanupTableKindPlatform, Classification: CleanupDeleteByRunLineage, PredicateOwner: "fork_run_id|source_run_id|fork_event_id -> events.run_id", DeleteOrderGroup: 2},
 		{Table: "run_fork_selected_contract_bindings", TableKind: CleanupTableKindPlatform, Classification: CleanupDeleteByRunLineage, PredicateOwner: "fork_run_id|source_run_id|fork_event_id -> events.run_id", DeleteOrderGroup: 2},
+		{Table: "activity_attempts", TableKind: CleanupTableKindPlatform, Classification: CleanupDeleteByRunID, PredicateOwner: "activity_attempts.run_id", DeleteOrderGroup: 3},
 		{Table: "agent_turns", TableKind: CleanupTableKindPlatform, Classification: CleanupDeleteByRunID, PredicateOwner: "agent_turns.run_id", DeleteOrderGroup: 3},
 		{Table: "agent_conversation_audits", TableKind: CleanupTableKindPlatform, Classification: CleanupDeleteMixedRowPolicy, PredicateOwner: "agent_conversation_audits.run_id", DeleteOrderGroup: 3},
 		{Table: "agent_sessions", TableKind: CleanupTableKindPlatform, Classification: CleanupDeleteByRunID, PredicateOwner: "agent_sessions.run_id", DeleteOrderGroup: 3},

--- a/internal/runtime/pipeline/activity_engine.go
+++ b/internal/runtime/pipeline/activity_engine.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -163,13 +164,24 @@ func (d pipelineActivityDispatcher) executeNonIdempotentActivityIntent(ctx conte
 	var terminal ActivityAttemptRecord
 	if err != nil {
 		redacted := runtimemanagedcredentials.RedactString(err.Error(), prepared.secrets...)
-		payload := activityFailurePayload(intent, fmt.Errorf("%s", redacted))
-		terminal = started.withTerminal(ActivityAttemptStatusFailed, activityResultEventID(intent, intent.FailureEvent), intent.FailureEvent, payload, redacted)
+		cause := fmt.Errorf("%s", redacted)
+		status := ActivityAttemptStatusFailed
+		if activityHTTPOutcomeUncertain(err) {
+			status = ActivityAttemptStatusUncertain
+			cause = fmt.Errorf("activity non_idempotent_write provider outcome is uncertain after dispatch: %s", redacted)
+		}
+		payload := activityFailurePayload(intent, cause)
+		terminal = started.withTerminal(status, activityResultEventID(intent, intent.FailureEvent), intent.FailureEvent, payload, cause.Error())
 	} else {
 		payload := activitySuccessPayload(intent, result)
 		terminal = started.withTerminal(ActivityAttemptStatusSucceeded, activityResultEventID(intent, intent.SuccessEvent), intent.SuccessEvent, payload, "")
 	}
-	stored, err := d.coordinator.workflowStore.CompleteActivityAttempt(ctx, terminal)
+	var stored ActivityAttemptRecord
+	if terminal.Status == ActivityAttemptStatusUncertain {
+		stored, err = d.coordinator.workflowStore.MarkActivityAttemptUncertain(ctx, terminal)
+	} else {
+		stored, err = d.coordinator.workflowStore.CompleteActivityAttempt(ctx, terminal)
+	}
 	if err != nil {
 		return err
 	}
@@ -517,12 +529,12 @@ func executePreparedActivityHTTPTool(ctx context.Context, prepared preparedActiv
 	}
 	resp, err := prepared.client.Do(req)
 	if err != nil {
-		return nil, redactActivityError(err, prepared.secrets)
+		return nil, activityHTTPUncertainError{err: redactActivityError(err, prepared.secrets)}
 	}
 	defer resp.Body.Close()
 	raw, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return nil, redactActivityError(err, prepared.secrets)
+		return nil, activityHTTPUncertainError{err: redactActivityError(err, prepared.secrets)}
 	}
 	parsed := parseHTTPActivityResponse(raw)
 	parsed = runtimemanagedcredentials.RedactValue(parsed, prepared.secrets...)
@@ -530,6 +542,26 @@ func executePreparedActivityHTTPTool(ctx context.Context, prepared preparedActiv
 		return nil, fmt.Errorf("activity http tool %s returned status %d: %s", prepared.toolName, resp.StatusCode, strings.TrimSpace(asString(parsed)))
 	}
 	return parsed, nil
+}
+
+type activityHTTPUncertainError struct {
+	err error
+}
+
+func (e activityHTTPUncertainError) Error() string {
+	if e.err == nil {
+		return "activity http outcome uncertain"
+	}
+	return e.err.Error()
+}
+
+func (e activityHTTPUncertainError) Unwrap() error {
+	return e.err
+}
+
+func activityHTTPOutcomeUncertain(err error) bool {
+	var target activityHTTPUncertainError
+	return errors.As(err, &target)
 }
 
 func parseHTTPActivityResponse(raw []byte) any {

--- a/internal/runtime/pipeline/activity_engine.go
+++ b/internal/runtime/pipeline/activity_engine.go
@@ -3,6 +3,7 @@ package pipeline
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -15,7 +16,10 @@ import (
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
 	"github.com/division-sh/swarm/internal/runtime/core/eventidentity"
 	"github.com/division-sh/swarm/internal/runtime/core/identity"
+	runtimecredentials "github.com/division-sh/swarm/internal/runtime/credentials"
 	runtimeengine "github.com/division-sh/swarm/internal/runtime/engine"
+	runtimemanagedcredentials "github.com/division-sh/swarm/internal/runtime/managedcredentials"
+	"github.com/division-sh/swarm/internal/runtime/semanticview"
 	"github.com/google/uuid"
 )
 
@@ -110,12 +114,15 @@ func (d pipelineActivityDispatcher) executeActivityIntent(ctx context.Context, i
 	if !runtimecontracts.SupportedActivityEffectClass(toolEffectClass) {
 		return d.publishActivityFailure(ctx, intent, fmt.Errorf("activity tool %q effect_class %q is not executable in Stage 1", intent.Tool, toolEffectClass))
 	}
+	if toolEffectClass == runtimecontracts.ActivityEffectClassNonIdempotentWrite {
+		return d.executeNonIdempotentActivityIntent(ctx, intent, tool)
+	}
 	maxAttempts := activityRetryMaxAttempts(intent, toolEffectClass)
 	var lastErr error
 	for attempt := 1; attempt <= maxAttempts; attempt++ {
 		attemptIntent := intent
 		attemptIntent.Attempt = attempt
-		result, err := executeActivityHTTPTool(ctx, client, attemptIntent, tool)
+		result, err := d.executeActivityHTTPTool(ctx, client, attemptIntent, tool)
 		if err == nil {
 			return d.publishActivitySuccess(ctx, attemptIntent, result)
 		}
@@ -129,6 +136,44 @@ func (d pipelineActivityDispatcher) executeActivityIntent(ctx context.Context, i
 	failureIntent := intent
 	failureIntent.Attempt = maxAttempts
 	return d.publishActivityFailure(ctx, failureIntent, lastErr)
+}
+
+func (d pipelineActivityDispatcher) executeNonIdempotentActivityIntent(ctx context.Context, intent runtimeengine.ActivityIntent, tool runtimecontracts.ToolSchemaEntry) error {
+	if d.coordinator == nil || d.coordinator.workflowStore == nil || !d.coordinator.workflowStore.Enabled() {
+		return d.publishActivityFailure(ctx, intent, fmt.Errorf("activity tool %s effect_class non_idempotent_write requires the activity_attempts journal", intent.Tool))
+	}
+	client := d.client
+	if client == nil {
+		client = &http.Client{Timeout: 30 * time.Second}
+	}
+	intent.Attempt = 1
+	prepared, err := d.prepareActivityHTTPTool(ctx, client, intent, tool)
+	if err != nil {
+		return d.publishActivityFailure(ctx, intent, err)
+	}
+	startRecord := activityAttemptStartRecord(intent, prepared.inputHash)
+	started, inserted, err := d.coordinator.workflowStore.StartActivityAttempt(ctx, startRecord)
+	if err != nil {
+		return d.publishActivityFailure(ctx, intent, err)
+	}
+	if !inserted {
+		return d.publishExistingActivityAttempt(ctx, intent, started)
+	}
+	result, err := executePreparedActivityHTTPTool(ctx, prepared)
+	var terminal ActivityAttemptRecord
+	if err != nil {
+		redacted := runtimemanagedcredentials.RedactString(err.Error(), prepared.secrets...)
+		payload := activityFailurePayload(intent, fmt.Errorf("%s", redacted))
+		terminal = started.withTerminal(ActivityAttemptStatusFailed, activityResultEventID(intent, intent.FailureEvent), intent.FailureEvent, payload, redacted)
+	} else {
+		payload := activitySuccessPayload(intent, result)
+		terminal = started.withTerminal(ActivityAttemptStatusSucceeded, activityResultEventID(intent, intent.SuccessEvent), intent.SuccessEvent, payload, "")
+	}
+	stored, err := d.coordinator.workflowStore.CompleteActivityAttempt(ctx, terminal)
+	if err != nil {
+		return err
+	}
+	return d.publishJournaledActivityResult(ctx, intent, stored)
 }
 
 func (pc *PipelineCoordinator) handleActivityRequestEvent(ctx context.Context, evt events.Event) (bool, error) {
@@ -351,76 +396,138 @@ func activityIntentFromRequestEvent(evt events.Event) (runtimeengine.ActivityInt
 	return intent, nil
 }
 
-func executeActivityHTTPTool(ctx context.Context, client *http.Client, intent runtimeengine.ActivityIntent, tool runtimecontracts.ToolSchemaEntry) (any, error) {
-	if tool.HTTP == nil {
-		return nil, fmt.Errorf("activity tool %s is missing http block", intent.Tool)
-	}
-	if strings.TrimSpace(tool.RateLimit) != "" || strings.TrimSpace(tool.RateLimitMaxWait) != "" {
-		return nil, fmt.Errorf("activity tool %s uses rate_limit; activity HTTP rate-limit admission is not admitted in Stage 1", intent.Tool)
-	}
-	if len(tool.ResponseMapping) > 0 {
-		return nil, fmt.Errorf("activity tool %s uses response_mapping; activity HTTP response mapping is not admitted in Stage 1", intent.Tool)
-	}
-	if len(tool.Credentials) > 0 || tool.ManagedCredential != nil {
-		return nil, fmt.Errorf("activity tool %s uses credentials; credentialed activity HTTP execution is not admitted in Stage 1", intent.Tool)
-	}
-	env := map[string]any{"input": cloneStringAnyMap(intent.Input)}
-	url, err := resolveActivityHTTPURLTemplate(tool.HTTP.URL, env)
+type preparedActivityHTTPTool struct {
+	toolName  string
+	method    string
+	url       string
+	headers   http.Header
+	body      []byte
+	timeout   time.Duration
+	client    *http.Client
+	secrets   []string
+	inputHash string
+}
+
+func (d pipelineActivityDispatcher) executeActivityHTTPTool(ctx context.Context, client *http.Client, intent runtimeengine.ActivityIntent, tool runtimecontracts.ToolSchemaEntry) (any, error) {
+	prepared, err := d.prepareActivityHTTPTool(ctx, client, intent, tool)
 	if err != nil {
 		return nil, err
 	}
+	return executePreparedActivityHTTPTool(ctx, prepared)
+}
+
+func (d pipelineActivityDispatcher) prepareActivityHTTPTool(ctx context.Context, client *http.Client, intent runtimeengine.ActivityIntent, tool runtimecontracts.ToolSchemaEntry) (preparedActivityHTTPTool, error) {
+	if tool.HTTP == nil {
+		return preparedActivityHTTPTool{}, fmt.Errorf("activity tool %s is missing http block", intent.Tool)
+	}
+	if strings.TrimSpace(tool.RateLimit) != "" || strings.TrimSpace(tool.RateLimitMaxWait) != "" {
+		return preparedActivityHTTPTool{}, fmt.Errorf("activity tool %s uses rate_limit; activity HTTP rate-limit admission is not admitted in Stage 1", intent.Tool)
+	}
+	if len(tool.ResponseMapping) > 0 {
+		return preparedActivityHTTPTool{}, fmt.Errorf("activity tool %s uses response_mapping; activity HTTP response mapping is not admitted in Stage 1", intent.Tool)
+	}
+	if tool.ManagedCredential != nil {
+		return preparedActivityHTTPTool{}, fmt.Errorf("activity tool %s uses managed_credential; managed credential activity HTTP execution is not admitted in Stage 1", intent.Tool)
+	}
+	credentials := map[string]any{}
+	secrets := []string{}
+	if len(tool.Credentials) > 0 {
+		if intent.EffectClass != runtimecontracts.ActivityEffectClassNonIdempotentWrite {
+			return preparedActivityHTTPTool{}, fmt.Errorf("activity tool %s uses static credentials; static credential activity HTTP execution is supported only for non_idempotent_write activities", intent.Tool)
+		}
+		resolved, secretValues, err := d.resolveActivityToolCredentials(ctx, intent, tool.Credentials)
+		if err != nil {
+			return preparedActivityHTTPTool{}, err
+		}
+		credentials = resolved
+		secrets = secretValues
+	}
+	input := cloneStringAnyMap(intent.Input)
+	env := map[string]any{"input": input, "credentials": credentials}
+	url, err := resolveActivityHTTPURLTemplate(tool.HTTP.URL, env)
+	if err != nil {
+		return preparedActivityHTTPTool{}, redactActivityError(err, secrets)
+	}
 	url = strings.TrimSpace(url)
 	if url == "" {
-		return nil, fmt.Errorf("activity tool %s resolved an empty url", intent.Tool)
+		return preparedActivityHTTPTool{}, fmt.Errorf("activity tool %s resolved an empty url", intent.Tool)
 	}
-	var body io.Reader
+	var body []byte
 	if tool.HTTP.Body != nil {
 		resolvedBody, err := resolveActivityTemplateTree(tool.HTTP.Body, env)
 		if err != nil {
-			return nil, err
+			return preparedActivityHTTPTool{}, redactActivityError(err, secrets)
 		}
 		raw, err := json.Marshal(resolvedBody)
 		if err != nil {
-			return nil, err
+			return preparedActivityHTTPTool{}, err
 		}
-		body = bytes.NewReader(raw)
+		body = raw
 	}
 	method := strings.ToUpper(strings.TrimSpace(tool.HTTP.Method))
 	if method == "" {
 		method = http.MethodGet
 	}
-	reqCtx := ctx
-	cancel := func() {}
+	timeout := 30 * time.Second
 	if tool.HTTP.TimeoutSeconds > 0 {
-		reqCtx, cancel = context.WithTimeout(ctx, time.Duration(tool.HTTP.TimeoutSeconds)*time.Second)
+		timeout = time.Duration(tool.HTTP.TimeoutSeconds) * time.Second
 	}
-	defer cancel()
-	req, err := http.NewRequestWithContext(reqCtx, method, url, body)
-	if err != nil {
-		return nil, err
-	}
+	headers := make(http.Header, len(tool.HTTP.Headers))
 	for key, value := range tool.HTTP.Headers {
 		resolved, err := resolveActivityTemplateString(value, env)
 		if err != nil {
-			return nil, err
+			return preparedActivityHTTPTool{}, redactActivityError(err, secrets)
 		}
-		req.Header.Set(strings.TrimSpace(key), strings.TrimSpace(resolved))
+		headers.Set(strings.TrimSpace(key), strings.TrimSpace(resolved))
 	}
-	if body != nil && strings.TrimSpace(req.Header.Get("Content-Type")) == "" {
-		req.Header.Set("Content-Type", "application/json")
+	if len(body) > 0 && strings.TrimSpace(headers.Get("Content-Type")) == "" {
+		headers.Set("Content-Type", "application/json")
 	}
-	resp, err := client.Do(req)
+	if client == nil {
+		client = &http.Client{Timeout: timeout}
+	}
+	return preparedActivityHTTPTool{
+		toolName:  intent.Tool,
+		method:    method,
+		url:       url,
+		headers:   headers,
+		body:      body,
+		timeout:   timeout,
+		client:    client,
+		secrets:   secrets,
+		inputHash: activityInputHash(input),
+	}, nil
+}
+
+func executePreparedActivityHTTPTool(ctx context.Context, prepared preparedActivityHTTPTool) (any, error) {
+	reqCtx, cancel := context.WithTimeout(ctx, prepared.timeout)
+	defer cancel()
+	var body io.Reader
+	if len(prepared.body) > 0 {
+		body = bytes.NewReader(prepared.body)
+	}
+	req, err := http.NewRequestWithContext(reqCtx, prepared.method, prepared.url, body)
 	if err != nil {
-		return nil, err
+		return nil, redactActivityError(err, prepared.secrets)
+	}
+	for key, values := range prepared.headers {
+		for _, value := range values {
+			req.Header.Add(key, value)
+		}
+	}
+	resp, err := prepared.client.Do(req)
+	if err != nil {
+		return nil, redactActivityError(err, prepared.secrets)
 	}
 	defer resp.Body.Close()
 	raw, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return nil, err
+		return nil, redactActivityError(err, prepared.secrets)
 	}
 	parsed := parseHTTPActivityResponse(raw)
+	parsed = runtimemanagedcredentials.RedactValue(parsed, prepared.secrets...)
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, fmt.Errorf("activity http tool %s returned status %d: %s", intent.Tool, resp.StatusCode, strings.TrimSpace(asString(parsed)))
+		return nil, fmt.Errorf("activity http tool %s returned status %d: %s", prepared.toolName, resp.StatusCode, strings.TrimSpace(asString(parsed)))
 	}
 	return parsed, nil
 }
@@ -434,6 +541,54 @@ func parseHTTPActivityResponse(raw []byte) any {
 		return string(raw)
 	}
 	return out
+}
+
+func (d pipelineActivityDispatcher) resolveActivityToolCredentials(ctx context.Context, intent runtimeengine.ActivityIntent, keys []string) (map[string]any, []string, error) {
+	out := make(map[string]any, len(keys))
+	secrets := make([]string, 0, len(keys))
+	store := runtimecredentials.Store(nil)
+	if d.coordinator != nil {
+		store = d.coordinator.credentials
+	}
+	if store == nil {
+		return nil, nil, fmt.Errorf("credential store is not configured")
+	}
+	source := semanticview.Source(nil)
+	if d.coordinator != nil {
+		source = d.coordinator.SemanticSource()
+	}
+	flowID := intent.FlowID.String()
+	for _, key := range keys {
+		key = strings.TrimSpace(key)
+		if key == "" {
+			continue
+		}
+		storeKey, mapped := semanticview.CredentialStoreKeyForFlow(source, flowID, key)
+		if mapped && strings.TrimSpace(storeKey) == "" {
+			return nil, nil, fmt.Errorf("credential %q is not declared and bound for imported package flow %s", key, flowID)
+		}
+		storeKey = strings.TrimSpace(storeKey)
+		if storeKey == "" {
+			return nil, nil, fmt.Errorf("credential %q does not resolve to a deployment credential key", key)
+		}
+		value, ok, err := store.Get(ctx, storeKey)
+		if err != nil {
+			return nil, nil, err
+		}
+		if !ok {
+			return nil, nil, fmt.Errorf("missing credential %q", storeKey)
+		}
+		out[key] = value
+		secrets = append(secrets, value)
+	}
+	return out, secrets, nil
+}
+
+func redactActivityError(err error, secrets []string) error {
+	if err == nil {
+		return nil
+	}
+	return fmt.Errorf("%s", runtimemanagedcredentials.RedactString(err.Error(), secrets...))
 }
 
 func resolveActivityTemplateTree(value any, env map[string]any) (any, error) {
@@ -591,34 +746,48 @@ func activityHTTPURLTemplateValueHasSchemeAuthority(value string) bool {
 }
 
 func (d pipelineActivityDispatcher) publishActivitySuccess(ctx context.Context, intent runtimeengine.ActivityIntent, result any) error {
-	payload := map[string]any{
+	return d.publishActivityResult(ctx, intent, intent.SuccessEvent, activitySuccessPayload(intent, result))
+}
+
+func activitySuccessPayload(intent runtimeengine.ActivityIntent, result any) map[string]any {
+	return map[string]any{
 		"activity_id":  intent.ActivityID,
 		"tool":         intent.Tool,
 		"effect_class": string(intent.EffectClass),
 		"attempt":      intent.Attempt,
 		"result":       result,
 	}
-	return d.publishActivityResult(ctx, intent, intent.SuccessEvent, payload)
 }
 
 func (d pipelineActivityDispatcher) publishActivityFailure(ctx context.Context, intent runtimeengine.ActivityIntent, cause error) error {
-	payload := map[string]any{
+	return d.publishActivityResult(ctx, intent, intent.FailureEvent, activityFailurePayload(intent, cause))
+}
+
+func activityFailurePayload(intent runtimeengine.ActivityIntent, cause error) map[string]any {
+	errText := ""
+	if cause != nil {
+		errText = strings.TrimSpace(cause.Error())
+	}
+	return map[string]any{
 		"activity_id":  intent.ActivityID,
 		"tool":         intent.Tool,
 		"effect_class": string(intent.EffectClass),
 		"attempt":      intent.Attempt,
-		"error":        strings.TrimSpace(cause.Error()),
+		"error":        errText,
 	}
-	return d.publishActivityResult(ctx, intent, intent.FailureEvent, payload)
 }
 
 func (d pipelineActivityDispatcher) publishActivityResult(ctx context.Context, intent runtimeengine.ActivityIntent, eventType string, payload map[string]any) error {
+	return d.publishActivityResultWithID(ctx, intent, activityResultEventID(intent, eventType), eventType, payload)
+}
+
+func (d pipelineActivityDispatcher) publishActivityResultWithID(ctx context.Context, intent runtimeengine.ActivityIntent, eventID, eventType string, payload map[string]any) error {
 	raw, err := json.Marshal(payload)
 	if err != nil {
 		return err
 	}
 	evt := events.NewChildEventWithLineage(
-		activityResultEventID(intent, eventType),
+		eventID,
 		events.EventType(eventType),
 		intent.NodeID.String(),
 		intent.SourceTaskID,
@@ -643,4 +812,69 @@ func (d pipelineActivityDispatcher) publishActivityResult(ctx context.Context, i
 		return nil
 	}
 	return d.coordinator.bus.Publish(ctx, evt)
+}
+
+func (d pipelineActivityDispatcher) publishExistingActivityAttempt(ctx context.Context, intent runtimeengine.ActivityIntent, rec ActivityAttemptRecord) error {
+	rec = rec.normalized()
+	if rec.Status == ActivityAttemptStatusStarted {
+		cause := fmt.Errorf("activity non_idempotent_write attempt %s already started; automatic provider re-dispatch is blocked because the outcome is uncertain", rec.RequestEventID)
+		payload := activityFailurePayload(intent, cause)
+		uncertain := rec.withTerminal(ActivityAttemptStatusUncertain, activityResultEventID(intent, intent.FailureEvent), intent.FailureEvent, payload, cause.Error())
+		stored, err := d.coordinator.workflowStore.MarkActivityAttemptUncertain(ctx, uncertain)
+		if err != nil {
+			return err
+		}
+		return d.publishJournaledActivityResult(ctx, intent, stored)
+	}
+	return d.publishJournaledActivityResult(ctx, intent, rec)
+}
+
+func (d pipelineActivityDispatcher) publishJournaledActivityResult(ctx context.Context, intent runtimeengine.ActivityIntent, rec ActivityAttemptRecord) error {
+	rec = rec.normalized()
+	if rec.ResultEventID == "" || rec.ResultEventType == "" || rec.ResultPayload == nil {
+		return fmt.Errorf("activity attempt %s has no terminal journal result", rec.RequestEventID)
+	}
+	intent.Attempt = rec.Attempt
+	return d.publishActivityResultWithID(ctx, intent, rec.ResultEventID, rec.ResultEventType, rec.ResultPayload)
+}
+
+func activityAttemptStartRecord(intent runtimeengine.ActivityIntent, inputHash string) ActivityAttemptRecord {
+	intent = intent.Normalized()
+	return ActivityAttemptRecord{
+		RequestEventID:  activityRequestEventID(intent),
+		RunID:           intent.SourceRunID,
+		SourceEventID:   intent.SourceEventID,
+		ParentEventID:   intent.ParentEventID,
+		EntityID:        intent.EntityID.String(),
+		FlowInstance:    intent.FlowID.String(),
+		NodeID:          intent.NodeID.String(),
+		HandlerEventKey: intent.HandlerEventKey,
+		ActivityID:      intent.ActivityID,
+		Tool:            intent.Tool,
+		EffectClass:     string(intent.EffectClass),
+		Attempt:         1,
+		Status:          ActivityAttemptStatusStarted,
+		SuccessEvent:    intent.SuccessEvent,
+		FailureEvent:    intent.FailureEvent,
+		InputHash:       inputHash,
+	}
+}
+
+func (rec ActivityAttemptRecord) withTerminal(status, eventID, eventType string, payload map[string]any, errText string) ActivityAttemptRecord {
+	rec = rec.normalized()
+	rec.Status = status
+	rec.ResultEventID = strings.TrimSpace(eventID)
+	rec.ResultEventType = strings.TrimSpace(eventType)
+	rec.ResultPayload = cloneStringAnyMap(payload)
+	rec.Error = strings.TrimSpace(errText)
+	return rec
+}
+
+func activityInputHash(input map[string]any) string {
+	raw, err := json.Marshal(input)
+	if err != nil {
+		raw = []byte(fmt.Sprintf("%#v", input))
+	}
+	sum := sha256.Sum256(raw)
+	return fmt.Sprintf("sha256:%x", sum[:])
 }

--- a/internal/runtime/pipeline/activity_engine.go
+++ b/internal/runtime/pipeline/activity_engine.go
@@ -849,14 +849,7 @@ func (d pipelineActivityDispatcher) publishActivityResultWithID(ctx context.Cont
 func (d pipelineActivityDispatcher) publishExistingActivityAttempt(ctx context.Context, intent runtimeengine.ActivityIntent, rec ActivityAttemptRecord) error {
 	rec = rec.normalized()
 	if rec.Status == ActivityAttemptStatusStarted {
-		cause := fmt.Errorf("activity non_idempotent_write attempt %s already started; automatic provider re-dispatch is blocked because the outcome is uncertain", rec.RequestEventID)
-		payload := activityFailurePayload(intent, cause)
-		uncertain := rec.withTerminal(ActivityAttemptStatusUncertain, activityResultEventID(intent, intent.FailureEvent), intent.FailureEvent, payload, cause.Error())
-		stored, err := d.coordinator.workflowStore.MarkActivityAttemptUncertain(ctx, uncertain)
-		if err != nil {
-			return err
-		}
-		return d.publishJournaledActivityResult(ctx, intent, stored)
+		return nil
 	}
 	return d.publishJournaledActivityResult(ctx, intent, rec)
 }

--- a/internal/runtime/pipeline/activity_engine_test.go
+++ b/internal/runtime/pipeline/activity_engine_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
@@ -417,6 +418,65 @@ func TestPipelineActivityRequestNonIdempotentFailureDoesNotRetry(t *testing.T) {
 	}
 }
 
+func TestPipelineActivityRequestNonIdempotentTransportErrorMarksUncertain(t *testing.T) {
+	ctx := context.Background()
+	runID := uuid.NewString()
+	sourceEventID := uuid.NewString()
+	entityID := uuid.NewString()
+	var calls int
+	source := semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
+		Tools: map[string]runtimecontracts.ToolSchemaEntry{
+			"provider_write": {
+				HandlerType:  "http",
+				EffectClass:  string(runtimecontracts.ActivityEffectClassNonIdempotentWrite),
+				OutputSchema: runtimecontracts.ToolInputSchema{Type: "object"},
+				HTTP:         &runtimecontracts.HTTPToolSpec{Method: "POST", URL: "https://provider.test/write"},
+			},
+		},
+	})
+	bus := &recordingPipelineBus{}
+	db, store := newSQLiteActivityJournalStore(t, ctx)
+	seedActivityRun(t, db, true, runID)
+	pc := NewPipelineCoordinatorWithOptions(bus, db, PipelineCoordinatorOptions{
+		Module:        staticSemanticWorkflowModule{source: source},
+		WorkflowStore: store,
+	})
+	client := &http.Client{Transport: activityRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		calls++
+		if got := req.URL.String(); got != "https://provider.test/write" {
+			t.Fatalf("request URL = %q, want provider URL", got)
+		}
+		return nil, fmt.Errorf("connection reset after dispatch")
+	})}
+	dispatcher := pipelineActivityDispatcher{coordinator: pc, client: client}
+	intent := testNonIdempotentActivityIntent(runID, sourceEventID, entityID)
+	intent.RetryMaxAttempts = 3
+	if err := dispatcher.executeActivityIntent(ctx, intent); err != nil {
+		t.Fatalf("executeActivityIntent: %v", err)
+	}
+	if calls != 1 {
+		t.Fatalf("transport calls = %d, want one post-start dispatch attempt", calls)
+	}
+	if len(bus.publishes) != 1 || bus.publishes[0].Type() != events.EventType(intent.FailureEvent) {
+		t.Fatalf("publishes = %#v, want one failure event", bus.publishes)
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(bus.publishes[0].Payload(), &payload); err != nil {
+		t.Fatalf("payload unmarshal: %v", err)
+	}
+	errText := strings.TrimSpace(asString(payload["error"]))
+	if !strings.Contains(errText, "outcome is uncertain") || !strings.Contains(errText, "connection reset after dispatch") {
+		t.Fatalf("failure error = %q, want uncertain transport outcome", errText)
+	}
+	rec, ok, err := store.LoadActivityAttempt(ctx, activityRequestEventID(intent))
+	if err != nil {
+		t.Fatalf("LoadActivityAttempt: %v", err)
+	}
+	if !ok || rec.Status != ActivityAttemptStatusUncertain {
+		t.Fatalf("journal status = (%v, %q), want uncertain", ok, rec.Status)
+	}
+}
+
 func TestPipelineActivityRequestStartedJournalBlocksProviderRedispatch(t *testing.T) {
 	ctx := context.Background()
 	runID := uuid.NewString()
@@ -576,6 +636,12 @@ func testActivityCredentialStore(t *testing.T, key, value string) runtimecredent
 		}
 	}
 	return store
+}
+
+type activityRoundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f activityRoundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
 }
 
 func newSQLiteActivityJournalStore(t *testing.T, ctx context.Context) (*sql.DB, *WorkflowInstanceStore) {

--- a/internal/runtime/pipeline/activity_engine_test.go
+++ b/internal/runtime/pipeline/activity_engine_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http/httptest"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"testing"
 
 	"github.com/division-sh/swarm/internal/events"
@@ -477,7 +478,7 @@ func TestPipelineActivityRequestNonIdempotentTransportErrorMarksUncertain(t *tes
 	}
 }
 
-func TestPipelineActivityRequestStartedJournalBlocksProviderRedispatch(t *testing.T) {
+func TestPipelineActivityRequestStartedJournalBlocksProviderRedispatchWithoutTerminalizing(t *testing.T) {
 	ctx := context.Background()
 	runID := uuid.NewString()
 	sourceEventID := uuid.NewString()
@@ -526,11 +527,100 @@ func TestPipelineActivityRequestStartedJournalBlocksProviderRedispatch(t *testin
 	if err != nil {
 		t.Fatalf("LoadActivityAttempt: %v", err)
 	}
-	if !ok || rec.Status != ActivityAttemptStatusUncertain {
-		t.Fatalf("journal status = (%v, %q), want uncertain", ok, rec.Status)
+	if !ok || rec.Status != ActivityAttemptStatusStarted {
+		t.Fatalf("journal status = (%v, %q), want started", ok, rec.Status)
 	}
-	if len(bus.publishes) != 1 || bus.publishes[0].Type() != events.EventType(intent.FailureEvent) {
-		t.Fatalf("publishes = %#v, want one failure event from uncertain journal", bus.publishes)
+	if len(bus.publishes) != 0 {
+		t.Fatalf("publishes = %#v, want started duplicate to wait for the in-flight owner", bus.publishes)
+	}
+}
+
+func TestPipelineActivityRequestConcurrentDuplicatePreservesOriginalTerminalResult(t *testing.T) {
+	ctx := context.Background()
+	runID := uuid.NewString()
+	sourceEventID := uuid.NewString()
+	entityID := uuid.NewString()
+	var calls atomic.Int32
+	var released atomic.Bool
+	providerEntered := make(chan struct{})
+	releaseProvider := make(chan struct{})
+	release := func() {
+		if released.CompareAndSwap(false, true) {
+			close(releaseProvider)
+		}
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if calls.Add(1) == 1 {
+			close(providerEntered)
+		}
+		<-releaseProvider
+		_ = json.NewEncoder(w).Encode(map[string]any{"ok": true})
+	}))
+	defer server.Close()
+	defer release()
+
+	source := semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
+		Tools: map[string]runtimecontracts.ToolSchemaEntry{
+			"provider_write": {
+				HandlerType:  "http",
+				EffectClass:  string(runtimecontracts.ActivityEffectClassNonIdempotentWrite),
+				OutputSchema: runtimecontracts.ToolInputSchema{Type: "object"},
+				HTTP:         &runtimecontracts.HTTPToolSpec{Method: "POST", URL: server.URL},
+			},
+		},
+	})
+	bus := &recordingPipelineBus{}
+	db, store := newSQLiteActivityJournalStore(t, ctx)
+	seedActivityRun(t, db, true, runID)
+	pc := NewPipelineCoordinatorWithOptions(bus, db, PipelineCoordinatorOptions{
+		Module:        staticSemanticWorkflowModule{source: source},
+		WorkflowStore: store,
+	})
+	intent := testNonIdempotentActivityIntent(runID, sourceEventID, entityID)
+	request, err := activityRequestEmitIntent(intent)
+	if err != nil {
+		t.Fatalf("activityRequestEmitIntent: %v", err)
+	}
+	firstDone := make(chan error, 1)
+	go func() {
+		_, err := pc.handleEventResult(ctx, request.Event)
+		firstDone <- err
+	}()
+	<-providerEntered
+
+	if _, err := pc.handleEventResult(ctx, request.Event); err != nil {
+		t.Fatalf("duplicate handleEventResult: %v", err)
+	}
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("provider calls after duplicate = %d, want exactly one in-flight dispatch", got)
+	}
+	rec, ok, err := store.LoadActivityAttempt(ctx, activityRequestEventID(intent))
+	if err != nil {
+		t.Fatalf("LoadActivityAttempt before release: %v", err)
+	}
+	if !ok || rec.Status != ActivityAttemptStatusStarted {
+		t.Fatalf("journal before release = (%v, %q), want started", ok, rec.Status)
+	}
+	if len(bus.publishes) != 0 {
+		t.Fatalf("publishes before release = %#v, want duplicate to avoid terminalizing active attempt", bus.publishes)
+	}
+
+	release()
+	if err := <-firstDone; err != nil {
+		t.Fatalf("first handleEventResult: %v", err)
+	}
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("provider calls after success = %d, want exactly one dispatch", got)
+	}
+	rec, ok, err = store.LoadActivityAttempt(ctx, activityRequestEventID(intent))
+	if err != nil {
+		t.Fatalf("LoadActivityAttempt after release: %v", err)
+	}
+	if !ok || rec.Status != ActivityAttemptStatusSucceeded {
+		t.Fatalf("journal after release = (%v, %q), want succeeded", ok, rec.Status)
+	}
+	if len(bus.publishes) != 1 || bus.publishes[0].Type() != events.EventType(intent.SuccessEvent) {
+		t.Fatalf("publishes after release = %#v, want one success event", bus.publishes)
 	}
 }
 

--- a/internal/runtime/pipeline/activity_engine_test.go
+++ b/internal/runtime/pipeline/activity_engine_test.go
@@ -2,17 +2,21 @@ package pipeline
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/division-sh/swarm/internal/events"
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
 	"github.com/division-sh/swarm/internal/runtime/core/identity"
+	runtimecredentials "github.com/division-sh/swarm/internal/runtime/credentials"
 	runtimeengine "github.com/division-sh/swarm/internal/runtime/engine"
 	"github.com/division-sh/swarm/internal/runtime/semanticview"
+	"github.com/google/uuid"
 )
 
 func TestPipelineActivityIntentWriterPersistsDurableActivityRequestEvent(t *testing.T) {
@@ -271,6 +275,262 @@ func TestPipelineActivityRequestFailsClosedForWriteEffectClass(t *testing.T) {
 	}
 }
 
+func TestPipelineActivityRequestExecutesNonIdempotentHTTPToolOnceWithStaticCredentials(t *testing.T) {
+	ctx := context.Background()
+	runID := uuid.NewString()
+	sourceEventID := uuid.NewString()
+	entityID := uuid.NewString()
+	var calls int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		if got := r.Header.Get("Authorization"); got != "Bearer provider-secret" {
+			t.Fatalf("Authorization = %q, want resolved static credential", got)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"echoed_authorization": r.Header.Get("Authorization")})
+	}))
+	defer server.Close()
+
+	credentialStore := testActivityCredentialStore(t, "provider_token", "provider-secret")
+	source := semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
+		Tools: map[string]runtimecontracts.ToolSchemaEntry{
+			"provider_write": {
+				HandlerType:  "http",
+				EffectClass:  string(runtimecontracts.ActivityEffectClassNonIdempotentWrite),
+				Credentials:  []string{"provider_token"},
+				OutputSchema: runtimecontracts.ToolInputSchema{Type: "object"},
+				HTTP: &runtimecontracts.HTTPToolSpec{
+					Method:  "POST",
+					URL:     server.URL,
+					Headers: map[string]string{"Authorization": "Bearer {{credentials.provider_token}}"},
+					Body:    map[string]any{"url": "{{input.url}}"},
+				},
+			},
+		},
+	})
+	bus := &recordingPipelineBus{}
+	db, store := newSQLiteActivityJournalStore(t, ctx)
+	seedActivityRun(t, db, true, runID)
+	pc := NewPipelineCoordinatorWithOptions(bus, db, PipelineCoordinatorOptions{
+		Module:        staticSemanticWorkflowModule{source: source},
+		WorkflowStore: store,
+		Credentials:   credentialStore,
+	})
+	intent := testNonIdempotentActivityIntent(runID, sourceEventID, entityID)
+	request, err := activityRequestEmitIntent(intent)
+	if err != nil {
+		t.Fatalf("activityRequestEmitIntent: %v", err)
+	}
+	handled, err := pc.handleEventResult(ctx, request.Event)
+	if err != nil {
+		t.Fatalf("handleEventResult: %v", err)
+	}
+	if !handled {
+		t.Fatal("handleEventResult handled = false, want true")
+	}
+	if calls != 1 {
+		t.Fatalf("server calls = %d, want exactly one provider write", calls)
+	}
+	if len(bus.publishes) != 1 {
+		t.Fatalf("published events = %d, want 1", len(bus.publishes))
+	}
+	evt := bus.publishes[0]
+	if got := evt.Type(); got != events.EventType(intent.SuccessEvent) {
+		t.Fatalf("event type = %q, want success", got)
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(evt.Payload(), &payload); err != nil {
+		t.Fatalf("payload unmarshal: %v", err)
+	}
+	result := payload["result"].(map[string]any)
+	if got := result["echoed_authorization"]; got != "Bearer [REDACTED]" {
+		t.Fatalf("redacted result authorization = %#v", got)
+	}
+
+	handled, err = pc.handleEventResult(ctx, request.Event)
+	if err != nil {
+		t.Fatalf("duplicate handleEventResult: %v", err)
+	}
+	if !handled {
+		t.Fatal("duplicate handleEventResult handled = false, want true")
+	}
+	if calls != 1 {
+		t.Fatalf("server calls after duplicate = %d, want no re-dispatch", calls)
+	}
+	if len(bus.publishes) != 2 {
+		t.Fatalf("published events after duplicate = %d, want canonical result re-published", len(bus.publishes))
+	}
+	if got, want := bus.publishes[1].ID(), bus.publishes[0].ID(); got != want {
+		t.Fatalf("duplicate result id = %q, want canonical journaled id %q", got, want)
+	}
+}
+
+func TestPipelineActivityRequestNonIdempotentFailureDoesNotRetry(t *testing.T) {
+	ctx := context.Background()
+	runID := uuid.NewString()
+	sourceEventID := uuid.NewString()
+	entityID := uuid.NewString()
+	var calls int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		http.Error(w, "temporary", http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	source := semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
+		Tools: map[string]runtimecontracts.ToolSchemaEntry{
+			"provider_write": {
+				HandlerType:  "http",
+				EffectClass:  string(runtimecontracts.ActivityEffectClassNonIdempotentWrite),
+				OutputSchema: runtimecontracts.ToolInputSchema{Type: "object"},
+				HTTP:         &runtimecontracts.HTTPToolSpec{Method: "POST", URL: server.URL},
+			},
+		},
+	})
+	bus := &recordingPipelineBus{}
+	db, store := newSQLiteActivityJournalStore(t, ctx)
+	seedActivityRun(t, db, true, runID)
+	pc := NewPipelineCoordinatorWithOptions(bus, db, PipelineCoordinatorOptions{
+		Module:        staticSemanticWorkflowModule{source: source},
+		WorkflowStore: store,
+	})
+	intent := testNonIdempotentActivityIntent(runID, sourceEventID, entityID)
+	intent.RetryMaxAttempts = 3
+	request, err := activityRequestEmitIntent(intent)
+	if err != nil {
+		t.Fatalf("activityRequestEmitIntent: %v", err)
+	}
+	if _, err := pc.handleEventResult(ctx, request.Event); err != nil {
+		t.Fatalf("handleEventResult: %v", err)
+	}
+	if calls != 1 {
+		t.Fatalf("server calls = %d, want no automatic retry for non-idempotent write", calls)
+	}
+	if len(bus.publishes) != 1 || bus.publishes[0].Type() != events.EventType(intent.FailureEvent) {
+		t.Fatalf("publishes = %#v, want one failure event", bus.publishes)
+	}
+	rec, ok, err := store.LoadActivityAttempt(ctx, activityRequestEventID(intent))
+	if err != nil {
+		t.Fatalf("LoadActivityAttempt: %v", err)
+	}
+	if !ok || rec.Status != ActivityAttemptStatusFailed {
+		t.Fatalf("journal status = (%v, %q), want failed", ok, rec.Status)
+	}
+}
+
+func TestPipelineActivityRequestStartedJournalBlocksProviderRedispatch(t *testing.T) {
+	ctx := context.Background()
+	runID := uuid.NewString()
+	sourceEventID := uuid.NewString()
+	entityID := uuid.NewString()
+	var calls int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		_ = json.NewEncoder(w).Encode(map[string]any{"ok": true})
+	}))
+	defer server.Close()
+
+	source := semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
+		Tools: map[string]runtimecontracts.ToolSchemaEntry{
+			"provider_write": {
+				HandlerType:  "http",
+				EffectClass:  string(runtimecontracts.ActivityEffectClassNonIdempotentWrite),
+				OutputSchema: runtimecontracts.ToolInputSchema{Type: "object"},
+				HTTP:         &runtimecontracts.HTTPToolSpec{Method: "POST", URL: server.URL},
+			},
+		},
+	})
+	bus := &recordingPipelineBus{}
+	db, store := newSQLiteActivityJournalStore(t, ctx)
+	seedActivityRun(t, db, true, runID)
+	pc := NewPipelineCoordinatorWithOptions(bus, db, PipelineCoordinatorOptions{
+		Module:        staticSemanticWorkflowModule{source: source},
+		WorkflowStore: store,
+	})
+	intent := testNonIdempotentActivityIntent(runID, sourceEventID, entityID)
+	if _, inserted, err := store.StartActivityAttempt(ctx, activityAttemptStartRecord(intent, activityInputHash(intent.Input))); err != nil {
+		t.Fatalf("StartActivityAttempt: %v", err)
+	} else if !inserted {
+		t.Fatal("StartActivityAttempt inserted = false, want seeded started row")
+	}
+	request, err := activityRequestEmitIntent(intent)
+	if err != nil {
+		t.Fatalf("activityRequestEmitIntent: %v", err)
+	}
+	if _, err := pc.handleEventResult(ctx, request.Event); err != nil {
+		t.Fatalf("handleEventResult: %v", err)
+	}
+	if calls != 0 {
+		t.Fatalf("server calls = %d, want started journal to block re-dispatch", calls)
+	}
+	rec, ok, err := store.LoadActivityAttempt(ctx, activityRequestEventID(intent))
+	if err != nil {
+		t.Fatalf("LoadActivityAttempt: %v", err)
+	}
+	if !ok || rec.Status != ActivityAttemptStatusUncertain {
+		t.Fatalf("journal status = (%v, %q), want uncertain", ok, rec.Status)
+	}
+	if len(bus.publishes) != 1 || bus.publishes[0].Type() != events.EventType(intent.FailureEvent) {
+		t.Fatalf("publishes = %#v, want one failure event from uncertain journal", bus.publishes)
+	}
+}
+
+func TestPipelineActivityRequestMissingCredentialFailsBeforeJournalAndDispatch(t *testing.T) {
+	ctx := context.Background()
+	runID := uuid.NewString()
+	sourceEventID := uuid.NewString()
+	entityID := uuid.NewString()
+	var calls int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		_ = json.NewEncoder(w).Encode(map[string]any{"ok": true})
+	}))
+	defer server.Close()
+
+	source := semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
+		Tools: map[string]runtimecontracts.ToolSchemaEntry{
+			"provider_write": {
+				HandlerType:  "http",
+				EffectClass:  string(runtimecontracts.ActivityEffectClassNonIdempotentWrite),
+				Credentials:  []string{"provider_token"},
+				OutputSchema: runtimecontracts.ToolInputSchema{Type: "object"},
+				HTTP: &runtimecontracts.HTTPToolSpec{
+					Method:  "POST",
+					URL:     server.URL,
+					Headers: map[string]string{"Authorization": "Bearer {{credentials.provider_token}}"},
+				},
+			},
+		},
+	})
+	bus := &recordingPipelineBus{}
+	db, store := newSQLiteActivityJournalStore(t, ctx)
+	seedActivityRun(t, db, true, runID)
+	emptyCredentials := testActivityCredentialStore(t, "", "")
+	pc := NewPipelineCoordinatorWithOptions(bus, db, PipelineCoordinatorOptions{
+		Module:        staticSemanticWorkflowModule{source: source},
+		WorkflowStore: store,
+		Credentials:   emptyCredentials,
+	})
+	intent := testNonIdempotentActivityIntent(runID, sourceEventID, entityID)
+	request, err := activityRequestEmitIntent(intent)
+	if err != nil {
+		t.Fatalf("activityRequestEmitIntent: %v", err)
+	}
+	if _, err := pc.handleEventResult(ctx, request.Event); err != nil {
+		t.Fatalf("handleEventResult: %v", err)
+	}
+	if calls != 0 {
+		t.Fatalf("server calls = %d, want missing credential to fail before provider dispatch", calls)
+	}
+	if _, ok, err := store.LoadActivityAttempt(ctx, activityRequestEventID(intent)); err != nil {
+		t.Fatalf("LoadActivityAttempt: %v", err)
+	} else if ok {
+		t.Fatal("activity attempt journal row exists, want missing credential to fail before started journal")
+	}
+	if len(bus.publishes) != 1 || bus.publishes[0].Type() != events.EventType(intent.FailureEvent) {
+		t.Fatalf("publishes = %#v, want one failure event", bus.publishes)
+	}
+}
+
 func testActivityIntent(inputURL string) runtimeengine.ActivityIntent {
 	return runtimeengine.ActivityIntent{
 		ActivityID:    "scanner_source_scrape",
@@ -288,4 +548,96 @@ func testActivityIntent(inputURL string) runtimeengine.ActivityIntent {
 		ChainDepth:    4,
 		Attempt:       1,
 	}.Normalized()
+}
+
+func testNonIdempotentActivityIntent(runID, sourceEventID, entityID string) runtimeengine.ActivityIntent {
+	intent := testActivityIntent("https://example.com/source")
+	intent.Tool = "provider_write"
+	intent.ActivityID = "scanner_provider_write"
+	intent.EffectClass = runtimecontracts.ActivityEffectClassNonIdempotentWrite
+	intent.SuccessEvent = "research.scanner_provider_write.succeeded"
+	intent.FailureEvent = "research.scanner_provider_write.failed"
+	intent.SourceRunID = runID
+	intent.SourceEventID = sourceEventID
+	intent.ParentEventID = sourceEventID
+	intent.EntityID = identity.NormalizeEntityID(entityID)
+	return intent.Normalized()
+}
+
+func testActivityCredentialStore(t *testing.T, key, value string) runtimecredentials.Store {
+	t.Helper()
+	store, err := runtimecredentials.NewFileStore(filepath.Join(t.TempDir(), "credentials.json"))
+	if err != nil {
+		t.Fatalf("NewFileStore: %v", err)
+	}
+	if strings.TrimSpace(key) != "" {
+		if err := store.Set(context.Background(), key, value); err != nil {
+			t.Fatalf("Set credential: %v", err)
+		}
+	}
+	return store
+}
+
+func newSQLiteActivityJournalStore(t *testing.T, ctx context.Context) (*sql.DB, *WorkflowInstanceStore) {
+	t.Helper()
+	name := strings.NewReplacer("/", "_", " ", "_").Replace(t.Name())
+	db, err := sql.Open("sqlite", "file:"+name+"?mode=memory&cache=shared")
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	createActivityJournalSQLiteSchema(t, ctx, db)
+	return db, NewSQLiteWorkflowInstanceStoreWithRuntimeMutationRunner(db, &recordingRuntimeMutationRunner{db: db})
+}
+
+func seedActivityRun(t *testing.T, db *sql.DB, sqlite bool, runID string) {
+	t.Helper()
+	if sqlite {
+		if _, err := db.Exec(`INSERT INTO runs (run_id, status) VALUES (?, 'running')`, runID); err != nil {
+			t.Fatalf("seed sqlite run: %v", err)
+		}
+		return
+	}
+	if _, err := db.Exec(`INSERT INTO runs (run_id, status) VALUES ($1::uuid, 'running')`, runID); err != nil {
+		t.Fatalf("seed postgres run: %v", err)
+	}
+}
+
+func createActivityJournalSQLiteSchema(t *testing.T, ctx context.Context, db *sql.DB) {
+	t.Helper()
+	for _, stmt := range []string{
+		`CREATE TABLE runs (
+			run_id TEXT PRIMARY KEY,
+			status TEXT NOT NULL DEFAULT 'running'
+		)`,
+		`CREATE TABLE activity_attempts (
+			request_event_id TEXT PRIMARY KEY,
+			run_id TEXT NOT NULL,
+			source_event_id TEXT,
+			parent_event_id TEXT,
+			entity_id TEXT,
+			flow_instance TEXT,
+			node_id TEXT NOT NULL,
+			handler_event_key TEXT NOT NULL,
+			activity_id TEXT NOT NULL,
+			tool TEXT NOT NULL,
+			effect_class TEXT NOT NULL,
+			attempt INTEGER NOT NULL DEFAULT 1,
+			status TEXT NOT NULL,
+			success_event TEXT NOT NULL,
+			failure_event TEXT NOT NULL,
+			result_event_id TEXT,
+			result_event_type TEXT,
+			result_payload TEXT,
+			error TEXT,
+			input_hash TEXT NOT NULL,
+			started_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+			completed_at TEXT,
+			updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+		)`,
+	} {
+		if _, err := db.ExecContext(ctx, stmt); err != nil {
+			t.Fatalf("create sqlite activity journal schema: %v", err)
+		}
+	}
 }

--- a/internal/runtime/pipeline/activity_journal.go
+++ b/internal/runtime/pipeline/activity_journal.go
@@ -1,0 +1,481 @@
+package pipeline
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+const (
+	ActivityAttemptStatusStarted   = "started"
+	ActivityAttemptStatusSucceeded = "succeeded"
+	ActivityAttemptStatusFailed    = "failed"
+	ActivityAttemptStatusUncertain = "uncertain"
+)
+
+type ActivityAttemptRecord struct {
+	RequestEventID  string
+	RunID           string
+	SourceEventID   string
+	ParentEventID   string
+	EntityID        string
+	FlowInstance    string
+	NodeID          string
+	HandlerEventKey string
+	ActivityID      string
+	Tool            string
+	EffectClass     string
+	Attempt         int
+	Status          string
+	SuccessEvent    string
+	FailureEvent    string
+	ResultEventID   string
+	ResultEventType string
+	ResultPayload   map[string]any
+	Error           string
+	InputHash       string
+	StartedAt       time.Time
+	CompletedAt     *time.Time
+	UpdatedAt       time.Time
+}
+
+func (s *WorkflowInstanceStore) StartActivityAttempt(ctx context.Context, rec ActivityAttemptRecord) (ActivityAttemptRecord, bool, error) {
+	rec = rec.normalized()
+	rec.Status = ActivityAttemptStatusStarted
+	if err := rec.validateStart(); err != nil {
+		return ActivityAttemptRecord{}, false, err
+	}
+	var out ActivityAttemptRecord
+	var inserted bool
+	err := s.runInPipelineTransaction(ctx, func(txctx context.Context, _ *sql.Tx) error {
+		query := `
+			INSERT INTO activity_attempts (
+				request_event_id, run_id, source_event_id, parent_event_id, entity_id, flow_instance,
+				node_id, handler_event_key, activity_id, tool, effect_class, attempt, status,
+				success_event, failure_event, input_hash
+			) VALUES (
+				?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
+			)
+			ON CONFLICT (request_event_id) DO NOTHING
+		`
+		if !s.isSQLite() {
+			query = `
+				INSERT INTO activity_attempts (
+					request_event_id, run_id, source_event_id, parent_event_id, entity_id, flow_instance,
+					node_id, handler_event_key, activity_id, tool, effect_class, attempt, status,
+					success_event, failure_event, input_hash
+				) VALUES (
+					$1::uuid, $2::uuid, NULLIF($3, '')::uuid, NULLIF($4, '')::uuid, NULLIF($5, '')::uuid, NULLIF($6, ''),
+					$7, $8, $9, $10, $11, $12, $13, $14, $15, $16
+				)
+				ON CONFLICT (request_event_id) DO NOTHING
+			`
+		}
+		res, err := dbExecContext(txctx, s.db, query, rec.RequestEventID, rec.RunID, nullableUUID(rec.SourceEventID), nullableUUID(rec.ParentEventID), nullableUUID(rec.EntityID), nullableString(rec.FlowInstance),
+			rec.NodeID, rec.HandlerEventKey, rec.ActivityID, rec.Tool, rec.EffectClass, rec.Attempt, rec.Status,
+			rec.SuccessEvent, rec.FailureEvent, rec.InputHash)
+		if err != nil {
+			return fmt.Errorf("start activity attempt %s: %w", rec.RequestEventID, err)
+		}
+		rows, _ := res.RowsAffected()
+		inserted = rows > 0
+		loaded, ok, err := s.LoadActivityAttempt(txctx, rec.RequestEventID)
+		if err != nil {
+			return err
+		}
+		if !ok {
+			return fmt.Errorf("activity attempt %s was not readable after start", rec.RequestEventID)
+		}
+		out = loaded
+		return nil
+	})
+	if err != nil {
+		return ActivityAttemptRecord{}, false, err
+	}
+	return out, inserted, nil
+}
+
+func (s *WorkflowInstanceStore) CompleteActivityAttempt(ctx context.Context, rec ActivityAttemptRecord) (ActivityAttemptRecord, error) {
+	rec = rec.normalized()
+	if err := rec.validateTerminal(); err != nil {
+		return ActivityAttemptRecord{}, err
+	}
+	var out ActivityAttemptRecord
+	err := s.runInPipelineTransaction(ctx, func(txctx context.Context, _ *sql.Tx) error {
+		rawPayload, err := json.Marshal(rec.ResultPayload)
+		if err != nil {
+			return fmt.Errorf("marshal activity attempt result payload: %w", err)
+		}
+		query := `
+			UPDATE activity_attempts
+			SET status = ?,
+			    result_event_id = ?,
+			    result_event_type = ?,
+			    result_payload = ?,
+			    error = ?,
+			    completed_at = CURRENT_TIMESTAMP,
+			    updated_at = CURRENT_TIMESTAMP
+			WHERE request_event_id = ?
+			  AND status = 'started'
+		`
+		if !s.isSQLite() {
+			query = `
+				UPDATE activity_attempts
+				SET status = $1,
+				    result_event_id = $2::uuid,
+				    result_event_type = $3,
+				    result_payload = $4::jsonb,
+				    error = NULLIF($5, ''),
+				    completed_at = NOW(),
+				    updated_at = NOW()
+				WHERE request_event_id = $6::uuid
+				  AND status = 'started'
+			`
+		}
+		res, err := dbExecContext(txctx, s.db, query, rec.Status, rec.ResultEventID, rec.ResultEventType, string(rawPayload), nullableString(rec.Error), rec.RequestEventID)
+		if err != nil {
+			return fmt.Errorf("complete activity attempt %s: %w", rec.RequestEventID, err)
+		}
+		rows, _ := res.RowsAffected()
+		loaded, ok, err := s.LoadActivityAttempt(txctx, rec.RequestEventID)
+		if err != nil {
+			return err
+		}
+		if !ok {
+			return fmt.Errorf("activity attempt %s was not found for completion", rec.RequestEventID)
+		}
+		if rows == 0 && loaded.Status == ActivityAttemptStatusStarted {
+			return fmt.Errorf("activity attempt %s remained started after terminal update", rec.RequestEventID)
+		}
+		out = loaded
+		return nil
+	})
+	if err != nil {
+		return ActivityAttemptRecord{}, err
+	}
+	return out, nil
+}
+
+func (s *WorkflowInstanceStore) MarkActivityAttemptUncertain(ctx context.Context, rec ActivityAttemptRecord) (ActivityAttemptRecord, error) {
+	rec = rec.normalized()
+	rec.Status = ActivityAttemptStatusUncertain
+	if err := rec.validateTerminal(); err != nil {
+		return ActivityAttemptRecord{}, err
+	}
+	var out ActivityAttemptRecord
+	err := s.runInPipelineTransaction(ctx, func(txctx context.Context, _ *sql.Tx) error {
+		rawPayload, err := json.Marshal(rec.ResultPayload)
+		if err != nil {
+			return fmt.Errorf("marshal activity attempt uncertain payload: %w", err)
+		}
+		query := `
+			UPDATE activity_attempts
+			SET status = 'uncertain',
+			    result_event_id = ?,
+			    result_event_type = ?,
+			    result_payload = ?,
+			    error = ?,
+			    completed_at = CURRENT_TIMESTAMP,
+			    updated_at = CURRENT_TIMESTAMP
+			WHERE request_event_id = ?
+			  AND status = 'started'
+		`
+		if !s.isSQLite() {
+			query = `
+				UPDATE activity_attempts
+				SET status = 'uncertain',
+				    result_event_id = $1::uuid,
+				    result_event_type = $2,
+				    result_payload = $3::jsonb,
+				    error = NULLIF($4, ''),
+				    completed_at = NOW(),
+				    updated_at = NOW()
+				WHERE request_event_id = $5::uuid
+				  AND status = 'started'
+			`
+		}
+		if _, err := dbExecContext(txctx, s.db, query, rec.ResultEventID, rec.ResultEventType, string(rawPayload), nullableString(rec.Error), rec.RequestEventID); err != nil {
+			return fmt.Errorf("mark activity attempt %s uncertain: %w", rec.RequestEventID, err)
+		}
+		loaded, ok, err := s.LoadActivityAttempt(txctx, rec.RequestEventID)
+		if err != nil {
+			return err
+		}
+		if !ok {
+			return fmt.Errorf("activity attempt %s was not found for uncertain transition", rec.RequestEventID)
+		}
+		out = loaded
+		return nil
+	})
+	if err != nil {
+		return ActivityAttemptRecord{}, err
+	}
+	return out, nil
+}
+
+func (s *WorkflowInstanceStore) LoadActivityAttempt(ctx context.Context, requestEventID string) (ActivityAttemptRecord, bool, error) {
+	requestEventID = strings.TrimSpace(requestEventID)
+	if requestEventID == "" || s == nil || s.db == nil {
+		return ActivityAttemptRecord{}, false, nil
+	}
+	if _, err := uuid.Parse(requestEventID); err != nil {
+		return ActivityAttemptRecord{}, false, fmt.Errorf("activity attempt request_event_id must be a UUID: %w", err)
+	}
+	query := `
+		SELECT request_event_id, run_id, source_event_id, parent_event_id, entity_id, flow_instance,
+		       node_id, handler_event_key, activity_id, tool, effect_class, attempt, status,
+		       success_event, failure_event, result_event_id, result_event_type, result_payload,
+		       error, input_hash, started_at, completed_at, updated_at
+		FROM activity_attempts
+		WHERE request_event_id = ?
+	`
+	if !s.isSQLite() {
+		query = `
+			SELECT request_event_id, run_id, source_event_id, parent_event_id, entity_id, flow_instance,
+			       node_id, handler_event_key, activity_id, tool, effect_class, attempt, status,
+			       success_event, failure_event, result_event_id, result_event_type, result_payload,
+			       error, input_hash, started_at, completed_at, updated_at
+			FROM activity_attempts
+			WHERE request_event_id = $1::uuid
+		`
+	}
+	row := dbQueryRowContext(ctx, s.db, query, requestEventID)
+	rec, err := scanActivityAttempt(row)
+	if err == nil {
+		return rec, true, nil
+	}
+	if err == sql.ErrNoRows {
+		return ActivityAttemptRecord{}, false, nil
+	}
+	return ActivityAttemptRecord{}, false, fmt.Errorf("load activity attempt %s: %w", requestEventID, err)
+}
+
+func scanActivityAttempt(row *sql.Row) (ActivityAttemptRecord, error) {
+	var rec ActivityAttemptRecord
+	var sourceEventID, parentEventID, entityID, flowInstance sql.NullString
+	var resultEventID, resultEventType, errorText sql.NullString
+	var rawPayload any
+	var startedAtRaw, completedAtRaw, updatedAtRaw any
+	if err := row.Scan(
+		&rec.RequestEventID, &rec.RunID, &sourceEventID, &parentEventID, &entityID, &flowInstance,
+		&rec.NodeID, &rec.HandlerEventKey, &rec.ActivityID, &rec.Tool, &rec.EffectClass, &rec.Attempt, &rec.Status,
+		&rec.SuccessEvent, &rec.FailureEvent, &resultEventID, &resultEventType, &rawPayload,
+		&errorText, &rec.InputHash, &startedAtRaw, &completedAtRaw, &updatedAtRaw,
+	); err != nil {
+		return ActivityAttemptRecord{}, err
+	}
+	startedAt, ok, err := decodeActivityAttemptTime(startedAtRaw)
+	if err != nil {
+		return ActivityAttemptRecord{}, fmt.Errorf("decode activity attempt started_at: %w", err)
+	}
+	if ok {
+		rec.StartedAt = startedAt
+	}
+	updatedAt, ok, err := decodeActivityAttemptTime(updatedAtRaw)
+	if err != nil {
+		return ActivityAttemptRecord{}, fmt.Errorf("decode activity attempt updated_at: %w", err)
+	}
+	if ok {
+		rec.UpdatedAt = updatedAt
+	}
+	completedAt, ok, err := decodeActivityAttemptTime(completedAtRaw)
+	if err != nil {
+		return ActivityAttemptRecord{}, fmt.Errorf("decode activity attempt completed_at: %w", err)
+	}
+	if ok {
+		rec.CompletedAt = &completedAt
+	}
+	rec.SourceEventID = sourceEventID.String
+	rec.ParentEventID = parentEventID.String
+	rec.EntityID = entityID.String
+	rec.FlowInstance = flowInstance.String
+	rec.ResultEventID = resultEventID.String
+	rec.ResultEventType = resultEventType.String
+	rec.Error = errorText.String
+	if rawPayload != nil {
+		decoded, err := decodeActivityAttemptPayload(rawPayload)
+		if err != nil {
+			return ActivityAttemptRecord{}, err
+		}
+		rec.ResultPayload = decoded
+	}
+	return rec.normalized(), nil
+}
+
+func decodeActivityAttemptTime(raw any) (time.Time, bool, error) {
+	switch typed := raw.(type) {
+	case nil:
+		return time.Time{}, false, nil
+	case time.Time:
+		if typed.IsZero() {
+			return time.Time{}, false, nil
+		}
+		return typed, true, nil
+	case []byte:
+		return parseActivityAttemptTimeString(string(typed))
+	case string:
+		return parseActivityAttemptTimeString(typed)
+	default:
+		return time.Time{}, false, fmt.Errorf("unsupported timestamp type %T", raw)
+	}
+}
+
+func parseActivityAttemptTimeString(raw string) (time.Time, bool, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return time.Time{}, false, nil
+	}
+	for _, layout := range []string{
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999999Z07:00",
+		"2006-01-02 15:04:05.999999999-07:00",
+		"2006-01-02 15:04:05.999999999Z07:00",
+		"2006-01-02 15:04:05.999999999",
+		"2006-01-02 15:04:05",
+	} {
+		if ts, err := time.Parse(layout, raw); err == nil {
+			return ts, true, nil
+		}
+	}
+	return time.Time{}, false, fmt.Errorf("unsupported timestamp %q", raw)
+}
+
+func decodeActivityAttemptPayload(raw any) (map[string]any, error) {
+	var bytes []byte
+	switch typed := raw.(type) {
+	case nil:
+		return nil, nil
+	case []byte:
+		bytes = typed
+	case string:
+		bytes = []byte(typed)
+	default:
+		bytes, _ = json.Marshal(typed)
+	}
+	if len(strings.TrimSpace(string(bytes))) == 0 {
+		return nil, nil
+	}
+	var out map[string]any
+	if err := json.Unmarshal(bytes, &out); err != nil {
+		return nil, fmt.Errorf("decode activity attempt result_payload: %w", err)
+	}
+	return out, nil
+}
+
+func (rec ActivityAttemptRecord) normalized() ActivityAttemptRecord {
+	rec.RequestEventID = strings.TrimSpace(rec.RequestEventID)
+	rec.RunID = strings.TrimSpace(rec.RunID)
+	rec.SourceEventID = strings.TrimSpace(rec.SourceEventID)
+	rec.ParentEventID = strings.TrimSpace(rec.ParentEventID)
+	rec.EntityID = strings.TrimSpace(rec.EntityID)
+	rec.FlowInstance = strings.TrimSpace(rec.FlowInstance)
+	rec.NodeID = strings.TrimSpace(rec.NodeID)
+	rec.HandlerEventKey = strings.TrimSpace(rec.HandlerEventKey)
+	rec.ActivityID = strings.TrimSpace(rec.ActivityID)
+	rec.Tool = strings.TrimSpace(rec.Tool)
+	rec.EffectClass = strings.TrimSpace(rec.EffectClass)
+	rec.Status = strings.TrimSpace(rec.Status)
+	rec.SuccessEvent = strings.TrimSpace(rec.SuccessEvent)
+	rec.FailureEvent = strings.TrimSpace(rec.FailureEvent)
+	rec.ResultEventID = strings.TrimSpace(rec.ResultEventID)
+	rec.ResultEventType = strings.TrimSpace(rec.ResultEventType)
+	rec.Error = strings.TrimSpace(rec.Error)
+	rec.InputHash = strings.TrimSpace(rec.InputHash)
+	if rec.Attempt <= 0 {
+		rec.Attempt = 1
+	}
+	if rec.ResultPayload == nil && rec.Status != ActivityAttemptStatusStarted {
+		rec.ResultPayload = map[string]any{}
+	}
+	return rec
+}
+
+func (rec ActivityAttemptRecord) validateStart() error {
+	if err := validateActivityAttemptUUID(rec.RequestEventID, "request_event_id"); err != nil {
+		return err
+	}
+	if err := validateActivityAttemptUUID(rec.RunID, "run_id"); err != nil {
+		return err
+	}
+	for field, value := range map[string]string{
+		"source_event_id": rec.SourceEventID,
+		"parent_event_id": rec.ParentEventID,
+		"entity_id":       rec.EntityID,
+	} {
+		if err := validateOptionalActivityAttemptUUID(value, field); err != nil {
+			return err
+		}
+	}
+	if rec.ActivityID == "" || rec.Tool == "" || rec.EffectClass == "" || rec.SuccessEvent == "" || rec.FailureEvent == "" || rec.InputHash == "" {
+		return fmt.Errorf("activity attempt %s is missing required identity fields", rec.RequestEventID)
+	}
+	if rec.EffectClass != "non_idempotent_write" {
+		return fmt.Errorf("activity attempt effect_class %q is not supported by the non-idempotent journal", rec.EffectClass)
+	}
+	if rec.Attempt != 1 {
+		return fmt.Errorf("activity attempt attempt = %d, want 1 for non-idempotent journal", rec.Attempt)
+	}
+	return nil
+}
+
+func (rec ActivityAttemptRecord) validateTerminal() error {
+	if err := validateActivityAttemptUUID(rec.RequestEventID, "request_event_id"); err != nil {
+		return err
+	}
+	if rec.Status != ActivityAttemptStatusSucceeded && rec.Status != ActivityAttemptStatusFailed && rec.Status != ActivityAttemptStatusUncertain {
+		return fmt.Errorf("activity attempt status %q is not terminal", rec.Status)
+	}
+	if err := validateActivityAttemptUUID(rec.ResultEventID, "result_event_id"); err != nil {
+		return err
+	}
+	if rec.ResultEventType == "" {
+		return fmt.Errorf("activity attempt terminal result_event_type is required")
+	}
+	if rec.ResultPayload == nil {
+		return fmt.Errorf("activity attempt terminal result_payload is required")
+	}
+	return nil
+}
+
+func validateActivityAttemptUUID(value, field string) error {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return fmt.Errorf("activity attempt %s is required", field)
+	}
+	if _, err := uuid.Parse(value); err != nil {
+		return fmt.Errorf("activity attempt %s must be a UUID: %w", field, err)
+	}
+	return nil
+}
+
+func validateOptionalActivityAttemptUUID(value, field string) error {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return nil
+	}
+	if _, err := uuid.Parse(value); err != nil {
+		return fmt.Errorf("activity attempt %s must be a UUID when present: %w", field, err)
+	}
+	return nil
+}
+
+func nullableString(value string) any {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return nil
+	}
+	return value
+}
+
+func nullableUUID(value string) any {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return nil
+	}
+	return value
+}

--- a/internal/runtime/pipeline/activity_journal_test.go
+++ b/internal/runtime/pipeline/activity_journal_test.go
@@ -1,0 +1,78 @@
+package pipeline
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+
+	"github.com/division-sh/swarm/internal/testutil"
+	"github.com/google/uuid"
+)
+
+func TestActivityAttemptJournalSQLiteAndPostgres(t *testing.T) {
+	ctx := context.Background()
+	cases := []struct {
+		name  string
+		store func(t *testing.T, ctx context.Context) (*sql.DB, *WorkflowInstanceStore, bool)
+	}{
+		{
+			name: "sqlite",
+			store: func(t *testing.T, ctx context.Context) (*sql.DB, *WorkflowInstanceStore, bool) {
+				db, journal := newSQLiteActivityJournalStore(t, ctx)
+				return db, journal, true
+			},
+		},
+		{
+			name: "postgres",
+			store: func(t *testing.T, ctx context.Context) (*sql.DB, *WorkflowInstanceStore, bool) {
+				_, db, cleanup := testutil.StartPostgres(t)
+				t.Cleanup(cleanup)
+				return db, NewWorkflowInstanceStore(db), false
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			db, journal, sqlite := tc.store(t, ctx)
+			runID := uuid.NewString()
+			seedActivityRun(t, db, sqlite, runID)
+			intent := testNonIdempotentActivityIntent(runID, uuid.NewString(), uuid.NewString())
+			start := activityAttemptStartRecord(intent, activityInputHash(intent.Input))
+
+			started, inserted, err := journal.StartActivityAttempt(ctx, start)
+			if err != nil {
+				t.Fatalf("StartActivityAttempt: %v", err)
+			}
+			if !inserted || started.Status != ActivityAttemptStatusStarted {
+				t.Fatalf("started = (%v, %q), want inserted started", inserted, started.Status)
+			}
+
+			again, inserted, err := journal.StartActivityAttempt(ctx, start)
+			if err != nil {
+				t.Fatalf("duplicate StartActivityAttempt: %v", err)
+			}
+			if inserted || again.RequestEventID != started.RequestEventID || again.Status != ActivityAttemptStatusStarted {
+				t.Fatalf("duplicate start = (%v, %#v), want existing started", inserted, again)
+			}
+
+			payload := activitySuccessPayload(intent, map[string]any{"ok": true})
+			terminal := started.withTerminal(ActivityAttemptStatusSucceeded, activityResultEventID(intent, intent.SuccessEvent), intent.SuccessEvent, payload, "")
+			completed, err := journal.CompleteActivityAttempt(ctx, terminal)
+			if err != nil {
+				t.Fatalf("CompleteActivityAttempt: %v", err)
+			}
+			if completed.Status != ActivityAttemptStatusSucceeded || completed.ResultEventID == "" {
+				t.Fatalf("completed journal = %#v, want succeeded with result event", completed)
+			}
+
+			terminalAgain, inserted, err := journal.StartActivityAttempt(ctx, start)
+			if err != nil {
+				t.Fatalf("terminal duplicate StartActivityAttempt: %v", err)
+			}
+			if inserted || terminalAgain.Status != ActivityAttemptStatusSucceeded {
+				t.Fatalf("terminal duplicate = (%v, %q), want existing succeeded", inserted, terminalAgain.Status)
+			}
+		})
+	}
+}

--- a/internal/runtime/pipeline/coordinator.go
+++ b/internal/runtime/pipeline/coordinator.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/division-sh/swarm/internal/events"
 	"github.com/division-sh/swarm/internal/runtime/core/timeridentity"
+	runtimecredentials "github.com/division-sh/swarm/internal/runtime/credentials"
 	runtimedeadletters "github.com/division-sh/swarm/internal/runtime/deadletters"
 	runtimeengine "github.com/division-sh/swarm/internal/runtime/engine"
 	runtimelifecycleprobe "github.com/division-sh/swarm/internal/runtime/lifecycleprobe"
@@ -58,6 +59,7 @@ type PipelineCoordinator struct {
 	timerScheduleStore      SchedulePersistence
 	mailboxMaterializer     MailboxWriteMaterializationStore
 	eventReceiptsCapability func(context.Context) (bool, error)
+	credentials             runtimecredentials.Store
 	artifactRoot            string
 	bundleFingerprint       string
 
@@ -79,6 +81,7 @@ type PipelineCoordinatorOptions struct {
 	TimerScheduleStore               SchedulePersistence
 	MailboxMaterializer              MailboxWriteMaterializationStore
 	EventReceiptsCapability          func(context.Context) (bool, error)
+	Credentials                      runtimecredentials.Store
 	ArtifactRoot                     string
 	BundleFingerprint                string
 	TestEntityStateHook              func(entityID, state string)
@@ -98,6 +101,10 @@ func NewPipelineCoordinatorWithOptions(bus Bus, db *sql.DB, opts PipelineCoordin
 	if workflowStore == nil {
 		workflowStore = NewWorkflowInstanceStore(db)
 	}
+	credentials := opts.Credentials
+	if credentials == nil {
+		credentials = runtimecredentials.NewEnvStore()
+	}
 	return &PipelineCoordinator{
 		bus:                              bus,
 		db:                               db,
@@ -110,6 +117,7 @@ func NewPipelineCoordinatorWithOptions(bus Bus, db *sql.DB, opts PipelineCoordin
 		timerScheduleStore:               opts.TimerScheduleStore,
 		mailboxMaterializer:              opts.MailboxMaterializer,
 		eventReceiptsCapability:          opts.EventReceiptsCapability,
+		credentials:                      credentials,
 		artifactRoot:                     strings.TrimSpace(opts.ArtifactRoot),
 		bundleFingerprint:                strings.TrimSpace(opts.BundleFingerprint),
 		testEntityStateHook:              opts.TestEntityStateHook,

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -493,6 +493,7 @@ func NewRuntime(ctx context.Context, deps RuntimeDeps) (*Runtime, error) {
 			TimerScheduleStore:               stores.ScheduleStore,
 			MailboxMaterializer:              stores.MailboxMaterializer,
 			EventReceiptsCapability:          boot.EventReceiptCapability,
+			Credentials:                      rt.Credentials,
 			ArtifactRoot:                     artifactRoot,
 			BundleFingerprint:                opts.BundleFingerprint,
 			TestEntityStateHook:              opts.TestEntityStateHook,

--- a/internal/runtime/workflow_validation_test.go
+++ b/internal/runtime/workflow_validation_test.go
@@ -201,42 +201,68 @@ func TestValidateWorkflowContractSurface_DurableActivityMinimalHTTPAccepted(t *t
 	}
 }
 
-func TestValidateWorkflowContractSurface_DurableActivityWriteEffectClassesFailClosed(t *testing.T) {
-	for _, effectClass := range []runtimecontracts.ActivityEffectClass{
-		runtimecontracts.ActivityEffectClassIdempotentWrite,
-		runtimecontracts.ActivityEffectClassNonIdempotentWrite,
-	} {
-		t.Run(string(effectClass), func(t *testing.T) {
-			bundle := testRuntimeWorkflowValidationBundle()
-			bundle.Tools = map[string]runtimecontracts.ToolSchemaEntry{
-				"source_scrape": {
-					HandlerType: "http",
-					EffectClass: string(effectClass),
-					InputSchema: runtimecontracts.ToolInputSchema{
-						Type: "object",
-					},
-					HTTP: &runtimecontracts.HTTPToolSpec{Method: "POST", URL: "https://example.test"},
+func TestValidateWorkflowContractSurface_DurableActivityNonIdempotentWriteAdmitted(t *testing.T) {
+	bundle := testRuntimeWorkflowValidationBundle()
+	bundle.Tools = map[string]runtimecontracts.ToolSchemaEntry{
+		"source_scrape": {
+			HandlerType: "http",
+			EffectClass: string(runtimecontracts.ActivityEffectClassNonIdempotentWrite),
+			Credentials: []string{"provider_token"},
+			InputSchema: runtimecontracts.ToolInputSchema{
+				Type: "object",
+			},
+			HTTP: &runtimecontracts.HTTPToolSpec{Method: "POST", URL: "https://example.test"},
+		},
+	}
+	bundle.Nodes = map[string]runtimecontracts.SystemNodeContract{
+		"scanner": {
+			EventHandlers: map[string]runtimecontracts.SystemNodeEventHandler{
+				"source.requested": {
+					Activity: runtimecontracts.ActivitySpec{Tool: "source_scrape"},
 				},
-			}
-			bundle.Nodes = map[string]runtimecontracts.SystemNodeContract{
-				"scanner": {
-					EventHandlers: map[string]runtimecontracts.SystemNodeEventHandler{
-						"source.requested": {
-							Activity: runtimecontracts.ActivitySpec{Tool: "source_scrape"},
-						},
-					},
+			},
+		},
+	}
+	_, err := ValidateWorkflowContractSurface(context.Background(), semanticview.Wrap(bundle), WorkflowContractValidationOptions{
+		CheckMCPReachable:              false,
+		StrictEmitSchemas:              false,
+		FatalToolImplementationWarning: false,
+		FatalBootWarnings:              false,
+	})
+	if err != nil {
+		t.Fatalf("ValidateWorkflowContractSurface error = %v, want non_idempotent_write admitted", err)
+	}
+}
+
+func TestValidateWorkflowContractSurface_DurableActivityIdempotentWriteFailsClosed(t *testing.T) {
+	bundle := testRuntimeWorkflowValidationBundle()
+	bundle.Tools = map[string]runtimecontracts.ToolSchemaEntry{
+		"source_scrape": {
+			HandlerType: "http",
+			EffectClass: string(runtimecontracts.ActivityEffectClassIdempotentWrite),
+			InputSchema: runtimecontracts.ToolInputSchema{
+				Type: "object",
+			},
+			HTTP: &runtimecontracts.HTTPToolSpec{Method: "POST", URL: "https://example.test"},
+		},
+	}
+	bundle.Nodes = map[string]runtimecontracts.SystemNodeContract{
+		"scanner": {
+			EventHandlers: map[string]runtimecontracts.SystemNodeEventHandler{
+				"source.requested": {
+					Activity: runtimecontracts.ActivitySpec{Tool: "source_scrape"},
 				},
-			}
-			_, err := ValidateWorkflowContractSurface(context.Background(), semanticview.Wrap(bundle), WorkflowContractValidationOptions{
-				CheckMCPReachable:              false,
-				StrictEmitSchemas:              false,
-				FatalToolImplementationWarning: false,
-				FatalBootWarnings:              false,
-			})
-			if err == nil || !strings.Contains(err.Error(), "stable attempt/result journaling and idempotency execution") {
-				t.Fatalf("ValidateWorkflowContractSurface error = %v, want write effect fail-closed", err)
-			}
-		})
+			},
+		},
+	}
+	_, err := ValidateWorkflowContractSurface(context.Background(), semanticview.Wrap(bundle), WorkflowContractValidationOptions{
+		CheckMCPReachable:              false,
+		StrictEmitSchemas:              false,
+		FatalToolImplementationWarning: false,
+		FatalBootWarnings:              false,
+	})
+	if err == nil || !strings.Contains(err.Error(), "idempotency execution ownership") {
+		t.Fatalf("ValidateWorkflowContractSurface error = %v, want idempotent_write fail-closed", err)
 	}
 }
 
@@ -342,6 +368,21 @@ func TestValidateWorkflowContractSurface_DurableActivityHTTPSubfeaturesFailClose
 				tool.RateLimitMaxWait = "0s"
 			},
 			errContains: "uses rate_limit",
+		},
+		{
+			name: "read only static credentials",
+			mutateTool: func(tool *runtimecontracts.ToolSchemaEntry) {
+				tool.Credentials = []string{"provider_token"}
+			},
+			errContains: "static credential activity HTTP execution is supported only for non_idempotent_write",
+		},
+		{
+			name: "managed credentials",
+			mutateTool: func(tool *runtimecontracts.ToolSchemaEntry) {
+				tool.EffectClass = string(runtimecontracts.ActivityEffectClassNonIdempotentWrite)
+				tool.ManagedCredential = &runtimecontracts.ManagedCredentialRef{Key: "provider_oauth"}
+			},
+			errContains: "uses managed_credential",
 		},
 	}
 	for _, tc := range cases {

--- a/internal/store/destructive_reset_cleanup.go
+++ b/internal/store/destructive_reset_cleanup.go
@@ -428,7 +428,7 @@ func destructiveResetCleanupQuery(table, mode string, runIDs []string, includeBu
 			return `SELECT COUNT(*) FROM event_deliveries d WHERE d.run_id = ANY($1::uuid[]) OR EXISTS (SELECT 1 FROM events e WHERE e.event_id = d.event_id AND e.run_id = ANY($1::uuid[]))`, args, nil
 		}
 		return `DELETE FROM event_deliveries d WHERE d.run_id = ANY($1::uuid[]) OR EXISTS (SELECT 1 FROM events e WHERE e.event_id = d.event_id AND e.run_id = ANY($1::uuid[]))`, args, nil
-	case "agent_turns", "agent_conversation_audits", "agent_sessions", "entity_mutations", "entity_state", "run_control_state", "events", "runs":
+	case "activity_attempts", "agent_turns", "agent_conversation_audits", "agent_sessions", "entity_mutations", "entity_state", "run_control_state", "events", "runs":
 		if mode == "count" {
 			return fmt.Sprintf(`SELECT COUNT(*) FROM %s WHERE run_id = ANY($1::uuid[])`, quoteIdent(table)), args, nil
 		}

--- a/internal/store/platformschema/platformschema.go
+++ b/internal/store/platformschema/platformschema.go
@@ -166,6 +166,8 @@ func platformTableOrder(name string) int {
 		return 5
 	case "events":
 		return 10
+	case "activity_attempts":
+		return 11
 	case "run_fork_selected_contract_bindings":
 		return 15
 	case "run_fork_selected_contract_executions":

--- a/internal/store/schema_capabilities.go
+++ b/internal/store/schema_capabilities.go
@@ -51,12 +51,17 @@ type ConversationSchemaCapabilities struct {
 
 type StoreSchemaCapabilities struct {
 	Agents        SchemaFlavor
+	Activity      ActivitySchemaCapabilities
 	EntityState   SchemaFlavor
 	Schedules     SchemaFlavor
 	Mailbox       SchemaFlavor
 	Events        EventSchemaCapabilities
 	Conversations ConversationSchemaCapabilities
 	EntityRunID   bool
+}
+
+type ActivitySchemaCapabilities struct {
+	Attempts SchemaFlavor
 }
 
 type schemaColumnCatalog struct {
@@ -179,6 +184,17 @@ func detectStoreSchemaCapabilities(catalog schemaColumnCatalog) StoreSchemaCapab
 		},
 	)
 	caps.EntityRunID = catalog.hasColumns("entity_state", "run_id")
+	caps.Activity = ActivitySchemaCapabilities{
+		Attempts: detectSchemaFlavor(catalog, "activity_attempts",
+			[]string{
+				"request_event_id", "run_id", "activity_id", "tool", "effect_class",
+				"attempt", "status", "success_event", "failure_event", "result_event_id",
+				"result_event_type", "result_payload", "error", "input_hash",
+				"started_at", "completed_at", "updated_at",
+			},
+			nil,
+		),
+	}
 
 	caps.Events = EventSchemaCapabilities{
 		Log: detectSchemaFlavor(catalog, "events",

--- a/internal/store/schema_capabilities_test.go
+++ b/internal/store/schema_capabilities_test.go
@@ -40,6 +40,12 @@ func TestPostgresStore_BindSchemaCapabilities_CanonicalOptionalVariants(t *testi
 		"outcome", "reason_code", "state_before", "state_after", "side_effects",
 		"duration_ms", "idempotency_key", "processed_at",
 	)
+	addColumns("activity_attempts",
+		"request_event_id", "run_id", "source_event_id", "parent_event_id", "entity_id", "flow_instance",
+		"node_id", "handler_event_key", "activity_id", "tool", "effect_class", "attempt", "status",
+		"success_event", "failure_event", "result_event_id", "result_event_type", "result_payload",
+		"error", "input_hash", "started_at", "completed_at", "updated_at",
+	)
 	addColumns("entity_state",
 		"run_id", "entity_id", "flow_instance", "entity_type", "slug", "name",
 		"current_state", "gates", "fields", "accumulator", "revision",
@@ -96,6 +102,9 @@ func TestPostgresStore_BindSchemaCapabilities_CanonicalOptionalVariants(t *testi
 	}
 	if caps.EntityState != SchemaFlavorCanonical || !caps.EntityRunID {
 		t.Fatalf("entity_state caps = %+v run_id=%v", caps.EntityState, caps.EntityRunID)
+	}
+	if caps.Activity.Attempts != SchemaFlavorCanonical {
+		t.Fatalf("activity attempts flavor = %s", caps.Activity.Attempts)
 	}
 	if caps.Conversations.Sessions != SchemaFlavorCanonical || !caps.Conversations.SessionRunID {
 		t.Fatalf("session caps = %+v", caps.Conversations)

--- a/internal/store/sqlite_schema_test.go
+++ b/internal/store/sqlite_schema_test.go
@@ -22,8 +22,8 @@ func TestSQLiteSchemaStoreBootstrapsPlatformAndGeneratedTables(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GeneratePlatformTableDDLs: %v", err)
 	}
-	if len(platformPlans) != 29 {
-		t.Fatalf("platform table plan count = %d, want 29", len(platformPlans))
+	if len(platformPlans) != 30 {
+		t.Fatalf("platform table plan count = %d, want 30", len(platformPlans))
 	}
 	entityPlans, err := GenerateEntityTableDDLs(runtimecontracts.EntitySchema{
 		Groups: []runtimecontracts.EntitySchemaGroup{{
@@ -86,6 +86,9 @@ func TestSQLiteSchemaStoreBootstrapsPlatformAndGeneratedTables(t *testing.T) {
 	}
 	if caps.EntityState != SchemaFlavorCanonical || !caps.EntityRunID {
 		t.Fatalf("entity_state capability = %s run_id=%v", caps.EntityState, caps.EntityRunID)
+	}
+	if caps.Activity.Attempts != SchemaFlavorCanonical {
+		t.Fatalf("activity attempts capability = %s", caps.Activity.Attempts)
 	}
 	if caps.Events.Log != SchemaFlavorCanonical || !caps.Events.LogRunID || !caps.Events.LogIdempotencyKey || !caps.Events.LogRouteIdentity {
 		t.Fatalf("event log capabilities = %+v", caps.Events)
@@ -485,6 +488,7 @@ func platformTableNamesForSQLiteSchemaTest() []string {
 	return []string{
 		"bundles",
 		"events",
+		"activity_attempts",
 		"run_fork_selected_contract_bindings",
 		"run_fork_selected_contract_executions",
 		"run_fork_selected_contract_branch_divergences",

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -2898,17 +2898,24 @@ handler_specification:
           activity call; diagnostic runtime_log rows are non-authoritative. Generated result event ids are stable for the
           request identity and generated result event type.
       supported_tool_sources:
-        authored_http_tools: Required Stage 1 supported surface for read_only activity execution. The tool must be declared
-          in tools.yaml, resolve to handler_type http, include an http block, and declare effect_class read_only. HTTP tools
-          using credentials, managed_credential, response_mapping, rate_limit, or rate_limit_max_wait are not admitted to
-          activities in Stage 1; those subfeatures require later owner consumption before activity execution may claim them.
+        authored_http_tools: Required Stage 1 supported surface for read_only activity execution and for non_idempotent_write
+          activity execution when the activity_attempts journal owns provider-attempt truth. The tool must be declared in
+          tools.yaml, resolve to handler_type http, and include an http block. read_only tools may retry under the read-only
+          retry policy. non_idempotent_write tools must insert activity_attempts.started before outbound dispatch, must not
+          automatically retry or re-dispatch once an attempt may have reached the provider, and may consume static
+          credentials through the existing credential-store/import-boundary owner. Missing static credentials fail before
+          provider dispatch. HTTP tools using managed_credential, response_mapping, rate_limit, or rate_limit_max_wait are
+          not admitted to activities in Stage 1; those subfeatures require later owner consumption before activity execution
+          may claim them.
         platform_builtin: Not callable from activity in Stage 1; fail closed. This includes `artifact_repo_commit`, which
           remains action-owned under `handler_fields.action.valid_values.artifact_repo_commit` until a separately gated
           write-effect activity migration preserves that action's artifact safety and idempotency guarantees.
         mcp: Not callable from activity in Stage 1. MCP-discovered/self-described effect classes are not authoritative; an
           authored registration-site override is required in a future slice before MCP tools can be activity-callable.
         native_or_generated_tools: Not callable from activity in Stage 1; fail closed.
-        credentialed_http_tools: Split until activity credential authority is specified; fail closed.
+        credentialed_http_tools: Static credentials are admitted only for authored HTTP non_idempotent_write activities and
+          only through the existing credential-store/import-boundary owner. Static credential values must not appear in logs,
+          result payloads, readback, capability output, or errors. Managed credentials/OAuth remain split and fail closed.
       effect_classes:
         read_only:
           retry_default: max_attempts 3, exponential backoff
@@ -2919,8 +2926,12 @@ handler_specification:
           retry_default: max_attempts 2, exponential backoff
           fork_default: reuse_recorded_result
         non_idempotent_write:
-          stage_1_execution: Not executable in Stage 1; split until stable activity attempt/result journaling and idempotency
-            execution ownership are specified and implemented.
+          stage_1_execution: Executable only for authored HTTP tools, with optional static credentials, when the
+            activity_attempts journal is available. The runtime must resolve static credentials before provider dispatch,
+            insert the started attempt row before outbound dispatch, update the row with succeeded, failed, or uncertain
+            terminal state after the outcome, and consume the row on duplicate/redelivered request events before deciding
+            whether dispatch is allowed. Any existing started, uncertain, succeeded, or failed row blocks automatic provider
+            re-dispatch.
           retry_default: max_attempts 1, no retry
           fork_default: require_manual_confirmation
         long_running: Split to a later resume/cancel/journal slice; fail closed in Stage 1.
@@ -6754,9 +6765,9 @@ tool_model:
       description: string — human-readable description of what the tool does
     common_optional_fields:
       handler_type: string — platform_builtin | mcp | http. Default http.
-      effect_class: string — required when the tool is callable from a handler activity. The only executable Stage 1 value
-        is read_only. idempotent_write and non_idempotent_write are reserved until activity attempt/result journaling and
-        idempotency execution ownership are specified and implemented; long_running is reserved for a later durable
+      effect_class: string — required when the tool is callable from a handler activity. Executable Stage 1 values are
+        read_only and non_idempotent_write on the authored HTTP activity_attempts journal path. idempotent_write is reserved
+        until idempotency execution ownership is specified and implemented; long_running is reserved for a later durable
         resume/cancel slice.
       input_schema: object — parameter names and types the tool accepts
       output_schema: object — field names and types the tool returns
@@ -8407,6 +8418,7 @@ platform_tables:
         - run_fork_selected_contract_route_recoveries
         - run_fork_selected_contract_bindings
       delete_by_run_id:
+        - activity_attempts
         - agent_turns
         - agent_sessions
         - entity_mutations
@@ -8463,6 +8475,18 @@ platform_tables:
         \ idx_events_flow (flow_instance, event_name) WHERE flow_instance IS NOT NULL,\n    INDEX idx_events_source_route ((source_route->>'flow_instance'), (source_route->>'entity_id')) WHERE source_route <> '{}'::jsonb,\n    INDEX idx_events_target_route ((target_route->>'flow_instance'), (target_route->>'entity_id')) WHERE target_route <> '{}'::jsonb,\n    INDEX idx_events_global (event_name,\
         \ created_at) WHERE scope = 'global',\n    INDEX idx_events_idempotency (idempotency_key) WHERE idempotency_key\
         \ IS NOT NULL,\n    INDEX idx_events_source (source_event_id) WHERE source_event_id IS NOT NULL\n);"
+    activity_attempts:
+      description: 'Durable attempt/result journal for executable non-idempotent activity calls. A platform.activity_requested
+        event is the request owner; this table is the provider-attempt truth owner after the request is admitted. The
+        runtime must insert the started row before outbound provider dispatch, update the row with the canonical terminal
+        result after the dispatch outcome, and consume the row on request redelivery/replay/restart before deciding whether
+        a provider call may occur. For non_idempotent_write activities, any existing started, uncertain, succeeded, or
+        failed row blocks automatic provider re-dispatch. Generated result events are published from this journaled terminal
+        state. Static credentials are resolved through the existing credential-store/import-boundary owner before the started
+        row is inserted; missing credentials therefore fail before provider dispatch and do not create an attempt row.
+        Managed credentials/OAuth, response_mapping, rate_limit, MCP/platform/native/generated tools, idempotent_write, and
+        long_running remain split/fail-closed.'
+      ddl: "CREATE TABLE activity_attempts (\n    request_event_id UUID PRIMARY KEY,\n    run_id            UUID NOT NULL REFERENCES runs(run_id),\n    source_event_id   UUID,\n    parent_event_id   UUID,\n    entity_id         UUID,\n    flow_instance     TEXT,\n    node_id           TEXT NOT NULL,\n    handler_event_key TEXT NOT NULL,\n    activity_id       TEXT NOT NULL,\n    tool              TEXT NOT NULL,\n    effect_class      TEXT NOT NULL CHECK (effect_class = 'non_idempotent_write'),\n    attempt           INTEGER NOT NULL DEFAULT 1 CHECK (attempt = 1),\n    status            TEXT NOT NULL CHECK (status IN ('started', 'succeeded', 'failed', 'uncertain')),\n    success_event     TEXT NOT NULL,\n    failure_event     TEXT NOT NULL,\n    result_event_id   UUID,\n    result_event_type TEXT,\n    result_payload    JSONB,\n    error             TEXT,\n    input_hash        TEXT NOT NULL,\n    started_at        TIMESTAMPTZ NOT NULL DEFAULT NOW(),\n    completed_at      TIMESTAMPTZ,\n    updated_at        TIMESTAMPTZ NOT NULL DEFAULT NOW(),\n    CHECK ((status = 'started' AND result_event_id IS NULL AND result_event_type IS NULL AND result_payload IS NULL AND error IS NULL AND completed_at IS NULL) OR (status IN ('succeeded', 'failed', 'uncertain') AND result_event_id IS NOT NULL AND result_event_type IS NOT NULL AND result_payload IS NOT NULL AND completed_at IS NOT NULL)),\n    INDEX idx_activity_attempts_run (run_id, started_at),\n    INDEX idx_activity_attempts_activity (run_id, activity_id, tool),\n    INDEX idx_activity_attempts_result_event (result_event_id) WHERE result_event_id IS NOT NULL\n);"
     run_fork_selected_contract_bindings:
       description: Durable selected-contract source binding for timestamp forks. One row binds a fork run to the selected
         contract source identity that was admitted before materialization. This is prerequisite fork-run state for future


### PR DESCRIPTION
Closes #1809.
Part of #1663. #1766 remains open as the Telegram connector proof that consumes this runtime primitive.

## Summary

- Promotes authored HTTP `non_idempotent_write` durable activities from reserved/fail-closed vocabulary into an executable runtime surface.
- Adds the `activity_attempts` platform journal as the canonical provider-attempt/result owner for non-idempotent activities.
- Journals attempt start before outbound dispatch, journals terminal success/failure/uncertain results, and prevents duplicate/redelivered/replayed requests from calling the provider again.
- Includes the approved static credentialed HTTP boundary through the existing credential store owner; missing credentials fail before journal/dispatch and credential values are redacted.

## Governing refs / context

Exact governing refs:

- `platform-spec.yaml` `handler_fields.activity`
- `platform-spec.yaml` `supported_tool_sources`
- `platform-spec.yaml` `effect_classes`
- `platform-spec.yaml` `platform_events.catalog["platform.activity_requested"]`
- `platform-spec.yaml` `platform_tables`

Binding gate:

- #1809 Pre-Implementation Coverage Audit: https://github.com/division-sh/swarm/issues/1809#issuecomment-4906730303
- Gate outcome: `approved as first slice with static credentialed HTTP included`: https://github.com/division-sh/swarm/issues/1809#issuecomment-4906782039

## Semantic migration

New canonical owner: `activity_attempts`, consumed through `internal/runtime/pipeline.WorkflowInstanceStore`.

Old non-authoritative paths now invalid for this chosen class:

- Treating redelivered `platform.activity_requested` as proof the provider was not called.
- Letting `event_deliveries` retry state imply provider-attempt retry authority.
- Using in-memory dispatcher attempts or `runtime_log` as recovery truth.
- Publishing non-idempotent results without a durable terminal journal row.

Production paths checked for surviving old behavior:

- Activity contract validation and runtime validation.
- Activity dispatcher loop and HTTP execution path.
- Static credential resolution through the existing credential store/import-boundary owner.
- Duplicate/redelivered request handling.
- Generated activity success/failure result publication.
- SQLite/Postgres journal persistence and schema capability detection.
- Destructive reset cleanup for the new platform table.

Migration status: complete for executable authored HTTP `non_idempotent_write` activities with static credentials. Managed/OAuth credentials, `idempotent_write`, response mapping, rate limits, non-HTTP tool sources, artifact migration, and Telegram connector proof remain split.

## Validation

Passed after rebase:

```sh
SWARM_CREDENTIALS_FILE=$(mktemp -d)/credentials.json \
SWARM_TEST_POSTGRES_DSN='host=127.0.0.1 port=5432 user=youmew dbname=postgres sslmode=disable' \
PGPASSWORD=postgres \
go test ./internal/runtime/pipeline ./internal/runtime ./internal/runtime/contracts ./internal/store ./internal/runtime/destructivereset
```

Also passed before rebase after the store cleanup fix:

```sh
go test ./internal/runtime/pipeline ./internal/runtime ./internal/runtime/contracts ./internal/store ./internal/runtime/destructivereset ./cmd/swarm ./internal/apiv1
```

Whole-suite attempt:

```sh
SWARM_TEST_POSTGRES_DSN='host=127.0.0.1 port=5432 user=youmew dbname=postgres sslmode=disable' PGPASSWORD=postgres go test ./...
```

That local full-suite run failed before the final store cleanup fix and also surfaced non-diff local-environment/timing failures: `cmd/swarm` saw a real local Claude credential unless `SWARM_CREDENTIALS_FILE` was isolated, and `internal/apiv1` ACK timing passed when rerun alone. The issue-relevant post-fix packages above are green.
