### PR TITLE
[agent-a][issue #1807] Resolve input-pin producer sources

### DIFF
--- a/cmd/swarm/cli_output_test.go
+++ b/cmd/swarm/cli_output_test.go
@@ -690,7 +690,9 @@ terminal_states: [done]
 states: [idle, done]
 pins:
   inputs:
-    events: [task.assigned]
+    events:
+      - name: task.assigned
+        source: external
     reads: [priority]
   outputs:
     events: []

--- a/cmd/swarm/doctor_test.go
+++ b/cmd/swarm/doctor_test.go
@@ -31,6 +31,7 @@ func setDoctorProviderSecret(t *testing.T, key, value string) {
 
 func TestDoctorClaudeCLIPreflightReportsMissingPrerequisites(t *testing.T) {
 	configureDoctorDockerStub(t)
+	t.Setenv("SWARM_CREDENTIALS_FILE", filepath.Join(t.TempDir(), "provider-credentials.json"))
 	t.Setenv("CLAUDE_CODE_OAUTH_TOKEN", "")
 	t.Setenv("SWARM_TEST_DOCKER_IMAGE_MISSING", "1")
 	t.Setenv("SWARM_TOOL_GATEWAY_URL", "")
@@ -625,6 +626,7 @@ func TestDoctorAPIFlagsRequireTargetMode(t *testing.T) {
 
 func TestRunServeRuntimeConsumesLocalClaudePreflightAfterBundleDecision(t *testing.T) {
 	configureDoctorDockerStub(t)
+	t.Setenv("SWARM_CREDENTIALS_FILE", filepath.Join(t.TempDir(), "provider-credentials.json"))
 	t.Setenv("CLAUDE_CODE_OAUTH_TOKEN", "")
 	t.Setenv("SWARM_TOOL_GATEWAY_URL", "")
 	t.Setenv("SWARM_TOOL_GATEWAY_CONTAINER_URL", "")

--- a/cmd/swarm/main_test.go
+++ b/cmd/swarm/main_test.go
@@ -4550,7 +4550,12 @@ terminal_states: [ready]
 states: [initializing, waiting, ready]
 pins:
   inputs:
-    events: [opco.product_initialization_requested, opco.product_review_requested]
+    events:
+      - name: product_initialization_requested
+        event: opco.product_initialization_requested
+      - name: product_review_requested
+        event: opco.product_review_requested
+        source: external
 auto_emit_on_create:
   event: opco.product_initialization_requested
 `)
@@ -9666,7 +9671,9 @@ terminal_states: [done]
 states: [idle, done]
 pins:
   inputs:
-    events: [task.assigned]
+    events:
+      - name: task.assigned
+        source: external
     reads: [priority]
   outputs:
     events: []
@@ -9808,7 +9815,7 @@ func TestRunVerifyCommand_EscalatedWarningUsesBlockingAnalyzerOutput(t *testing.
 	for _, want := range []string{
 		"verify failed: boot verification blocked by policy-escalated findings:",
 		"[BLOCKER] input_pin_wiring @",
-		"no producer path was found in the authored bundle",
+		"no accepted producer source was found in the authored bundle",
 	} {
 		if !strings.Contains(errText, want) {
 			t.Fatalf("verify stderr missing %q:\n%s", want, errText)
@@ -9840,7 +9847,7 @@ func TestRunVerifyCommand_EscalatedWarningUsesBlockingAnalyzerOutput(t *testing.
 	if len(verifyJSON.Warnings) == 0 {
 		t.Fatalf("verify --json warnings = %#v, want input_pin_wiring", verifyJSON.Warnings)
 	}
-	if !verifyFindingOutputsContain(verifyJSON.Warnings, "input_pin_wiring", "semantic_drift_warning", "no producer path was found in the authored bundle") {
+	if !verifyFindingOutputsContain(verifyJSON.Warnings, "input_pin_wiring", "semantic_drift_warning", "no accepted producer source was found in the authored bundle") {
 		t.Fatalf("verify --json warnings = %#v, want structured input_pin_wiring warning", verifyJSON.Warnings)
 	}
 }
@@ -12615,13 +12622,13 @@ func TestVerifyBundle_InputPinProducerPathReturnsWarningSurface(t *testing.T) {
 		t.Fatal("verifyBundle error = nil, want warning-only failure from missing producer path")
 	}
 	for _, want := range []string{
-		"no producer path was found in the authored bundle",
-		"Sibling flow output pin: not found",
-		"Root agent emit_events: not found",
-		"Root node handler emits: not found",
-		"Platform event catalog: not matched",
-		"External source metadata (swarm.source): not found",
-		"Same-flow timer declaration: not found",
+		"no accepted producer source was found in the authored bundle",
+		"Boundary external ingress: not found",
+		"Intrinsic ingress input pin: not found",
+		"Parent connect: not found",
+		"Explicit harness injection: not found",
+		"Platform source: not found",
+		"Internal topology producer: not found",
 	} {
 		if !strings.Contains(err.Error(), want) {
 			t.Fatalf("verifyBundle error = %v, want substring %q", err, want)

--- a/cmd/swarm/main_test.go
+++ b/cmd/swarm/main_test.go
@@ -9796,7 +9796,7 @@ func TestRunVerifyCommand_RejectsBootTimerWithCancelOn(t *testing.T) {
 func TestRunVerifyCommand_EscalatedWarningUsesBlockingAnalyzerOutput(t *testing.T) {
 	t.Setenv("SWARM_BOOT_WARNINGS_FATAL", "true")
 
-	root := writeVerifyMissingPinWarningFixture(t)
+	root := filepath.Join(repoRoot(), "tests", "tier8-boot-verification", "test-boot-state-machine-unreachable")
 	var stdout, stderr bytes.Buffer
 	code := runVerifyCommandWithContractsOutputForTest(
 		context.Background(),
@@ -9814,8 +9814,8 @@ func TestRunVerifyCommand_EscalatedWarningUsesBlockingAnalyzerOutput(t *testing.
 	errText := stderr.String()
 	for _, want := range []string{
 		"verify failed: boot verification blocked by policy-escalated findings:",
-		"[BLOCKER] input_pin_wiring @",
-		"no accepted producer source was found in the authored bundle",
+		"[BLOCKER] semantic_drift_unreachable_state @",
+		"declares state review but no transition path",
 	} {
 		if !strings.Contains(errText, want) {
 			t.Fatalf("verify stderr missing %q:\n%s", want, errText)
@@ -9845,10 +9845,10 @@ func TestRunVerifyCommand_EscalatedWarningUsesBlockingAnalyzerOutput(t *testing.
 		t.Fatalf("verify --json errors = %#v, want warning-only structured failure", verifyJSON.Errors)
 	}
 	if len(verifyJSON.Warnings) == 0 {
-		t.Fatalf("verify --json warnings = %#v, want input_pin_wiring", verifyJSON.Warnings)
+		t.Fatalf("verify --json warnings = %#v, want semantic_drift_unreachable_state", verifyJSON.Warnings)
 	}
-	if !verifyFindingOutputsContain(verifyJSON.Warnings, "input_pin_wiring", "semantic_drift_warning", "no accepted producer source was found in the authored bundle") {
-		t.Fatalf("verify --json warnings = %#v, want structured input_pin_wiring warning", verifyJSON.Warnings)
+	if !verifyFindingOutputsContain(verifyJSON.Warnings, "semantic_drift_unreachable_state", "semantic_drift_warning", "declares state review but no transition path") {
+		t.Fatalf("verify --json warnings = %#v, want structured semantic_drift_unreachable_state warning", verifyJSON.Warnings)
 	}
 }
 
@@ -12614,12 +12614,12 @@ func TestVerifyBundle_EmittedPayloadCompletenessReturnsWarningSurface(t *testing
 	}
 }
 
-func TestVerifyBundle_InputPinProducerPathReturnsWarningSurface(t *testing.T) {
+func TestVerifyBundle_InputPinProducerPathReturnsHardInvaliditySurface(t *testing.T) {
 	t.Setenv("SWARM_BOOT_WARNINGS_FATAL", "true")
 
 	err := verifyBundle(context.Background(), semanticview.Wrap(loadWorkflowValidationBundleAt(t, writeVerifyMissingPinWarningFixture(t))))
 	if err == nil {
-		t.Fatal("verifyBundle error = nil, want warning-only failure from missing producer path")
+		t.Fatal("verifyBundle error = nil, want hard invalidity from missing producer path")
 	}
 	for _, want := range []string{
 		"no accepted producer source was found in the authored bundle",

--- a/internal/apispec/platform_spec_composition_routing_test.go
+++ b/internal/apispec/platform_spec_composition_routing_test.go
@@ -26,7 +26,7 @@ func TestPlatformSpecCompositionRoutingSourceAuthority(t *testing.T) {
 	assertScalarContains(t, mustMappingValue(t, outputPin, "canonical_form"), "MUST include `key`")
 	assertScalarContains(t, mustMappingValue(t, outputPin, "scalar_form"), "fails closed")
 	addressed := mustMappingValue(t, authored, "addressed_input_pin")
-	assertScalarContains(t, mustMappingValue(t, addressed, "canonical_form"), "{name, event, address}")
+	assertScalarContains(t, mustMappingValue(t, addressed, "canonical_form"), "{name, event, source, address}")
 	assertScalarContains(t, mustYAMLPath(t, addressed, "address_fields", "cardinality"), "one and many")
 
 	connect := mustMappingValue(t, authored, "parent_connect")
@@ -221,8 +221,9 @@ func TestPlatformSpecCompositionRoutingCatalogSurfacesConsumeConnectAuthority(t 
 
 	checks := mustYAMLPath(t, root, "engine", "boot_verification", "checks")
 	inputPinWiring := mustSequenceMappingByScalarField(t, checks, "id", "input_pin_wiring")
-	assertScalarContains(t, mustMappingValue(t, inputPinWiring, "trigger"), "parent package.yaml connect entries")
-	assertScalarContains(t, mustMappingValue(t, inputPinWiring, "trigger"), "safe same-name sibling")
+	assertScalarContains(t, mustMappingValue(t, inputPinWiring, "trigger"), "ResolveFlowInputProducer")
+	assertScalarContains(t, mustMappingValue(t, inputPinWiring, "trigger"), "parent connect")
+	assertScalarContains(t, mustMappingValue(t, inputPinWiring, "trigger"), "unique same-name sibling output-pin inference")
 
 	pinTargetResolution := mustSequenceMappingByScalarField(t, checks, "id", "pin_target_resolution")
 	assertScalarContains(t, mustMappingValue(t, pinTargetResolution, "trigger"), "agent emit_events")

--- a/internal/runtime/bootverify/checks.go
+++ b/internal/runtime/bootverify/checks.go
@@ -270,7 +270,7 @@ var bootCheckRegistry = []Check{
 	{ID: "flow_package_wildcard_observe_grant", Severity: SeverityHardInvalidity, Run: checkFlowPackageWildcardObserveGrant},
 	{ID: "output_pin_key_carries_validation", Severity: "error", Run: checkOutputPinKeyCarriesValidation},
 	{ID: "composition_connect_validation", Severity: "error", Run: checkCompositionConnectValidation},
-	{ID: "input_pin_wiring", Severity: "warning", Run: checkInputPinWiring},
+	{ID: "input_pin_wiring", Severity: SeverityHardInvalidity, Run: checkInputPinWiring},
 	{ID: "pin_target_resolution", Severity: "error", Run: checkPinTargetResolution},
 	{ID: "redundant_in_topology_select_entity", Severity: SeverityHardInvalidity, Run: checkRedundantInTopologySelectEntity},
 	{ID: "missing_external_select_entity", Severity: "error", Run: checkMissingExternalSelectEntity},

--- a/internal/runtime/bootverify/flow_package_import_completeness_checks_test.go
+++ b/internal/runtime/bootverify/flow_package_import_completeness_checks_test.go
@@ -203,8 +203,8 @@ func TestRun_FlowPackagePinBindAliasValidationAcceptsValidAliases(t *testing.T) 
 	if got := report.HardInvalidities(); reportContains(got, "flow_package_pin_bind_alias_validation", "invalid") {
 		t.Fatalf("unexpected flow_package_pin_bind_alias_validation invalidity: %#v", got)
 	}
-	if reportContains(report.Warnings(), "input_pin_wiring", "work.requested") {
-		t.Fatalf("input alias should satisfy input pin wiring, got warnings %#v", report.Warnings())
+	if reportContains(report.Errors(), "input_pin_wiring", "work.requested") {
+		t.Fatalf("input alias should satisfy input pin wiring, got errors %#v", report.Errors())
 	}
 }
 

--- a/internal/runtime/bootverify/report.go
+++ b/internal/runtime/bootverify/report.go
@@ -6,6 +6,7 @@ import (
 	"sort"
 	"strings"
 
+	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
 	runtimecredentials "github.com/division-sh/swarm/internal/runtime/credentials"
 	llmselection "github.com/division-sh/swarm/internal/runtime/llm/selection"
 	runtimemanagedcredentials "github.com/division-sh/swarm/internal/runtime/managedcredentials"
@@ -158,6 +159,7 @@ type Options struct {
 	ValidateModelResolution bool
 	LLMProfile              llmselection.Profile
 	ModelAliases            llmselection.ModelAliases
+	HarnessInjections       []runtimecontracts.FlowInputProducerInjection
 }
 
 func Run(ctx context.Context, source semanticview.Source, opts Options) Report {

--- a/internal/runtime/bootverify/report_test.go
+++ b/internal/runtime/bootverify/report_test.go
@@ -567,7 +567,7 @@ func TestRun_MapsEventNoProducerToNamedWarning(t *testing.T) {
 	if report.HasErrors() {
 		t.Fatalf("expected warning-only report, got errors: %#v", report.Errors())
 	}
-	if !reportContains(report.Warnings(), "event_producer_exists", "task.requested") {
+	if !reportContains(report.Warnings(), "event_producer_exists", "ghost.event") {
 		t.Fatalf("expected event_producer_exists warning, got %#v", report.Warnings())
 	}
 }
@@ -590,7 +590,7 @@ func TestRun_MapsDeadDeclaredEventSchemaToNamedWarning(t *testing.T) {
 	for _, want := range []string{
 		"has no active role in the authored bundle",
 		"Handler emits: 0",
-		"External source metadata (swarm.source): no",
+		"Resolver-backed input source or non-input source metadata: no",
 	} {
 		if !reportContains(report.Warnings(), "semantic_drift_dead_event_schema", want) {
 			t.Fatalf("expected semantic_drift_dead_event_schema warning containing %q, got %#v", want, report.Warnings())
@@ -1177,11 +1177,11 @@ func TestRun_PromptRefSatisfiesPromptExistsWarning(t *testing.T) {
 	}
 }
 
-func TestEventProducedExternallyLocal_AllowsAnnotatedSourceText(t *testing.T) {
+func TestNonInputEventMetadataProducerSource_AllowsAnnotatedSourceText(t *testing.T) {
 	t.Parallel()
 
 	entry := runtimecontracts.EventCatalogEntry{Swarm: runtimecontracts.EventSwarmMetadata{Source: "platform (timer system)"}}
-	if !eventProducedExternallyLocal(entry) {
+	if !nonInputEventMetadataProducerSource(entry) {
 		t.Fatal("expected platform source annotation to count as externally produced")
 	}
 }
@@ -4194,36 +4194,38 @@ func setGuardEscalationForBootverifyTest(bundle *runtimecontracts.WorkflowContra
 	bundle.Semantics.NodeHandlers["test-node"]["check.requested"] = handler
 }
 
-func TestRun_ReportsInputPinWiringWarning(t *testing.T) {
+func TestRun_ReportsInputPinWiringHardInvalidity(t *testing.T) {
 	source := loadTier8Fixture(t, "test-boot-missing-pin")
 
 	report := Run(context.Background(), source, Options{})
 
-	if !reportContains(report.Warnings(), "input_pin_wiring", "task.feedback") {
-		t.Fatalf("expected input_pin_wiring warning, got %#v", report.Warnings())
+	if !reportContains(report.Errors(), "input_pin_wiring", "task.feedback") ||
+		!reportContains(report.Errors(), "input_pin_wiring", "Expected a producer proof for input pin target child.task.feedback") ||
+		!reportContains(report.Errors(), "input_pin_wiring", "Do not rely on events.yaml swarm.source") {
+		t.Fatalf("expected input_pin_wiring hard invalidity, got %#v", report.Errors())
 	}
 }
 
-func TestRun_DoesNotWarnForExternalInputPinWithoutEmitter(t *testing.T) {
+func TestRun_DoesNotErrorForExternalInputPinWithoutEmitter(t *testing.T) {
 	bundle := loadTier8FixtureBundle(t, "test-boot-missing-pin")
 	markFlowInputPinSource(t, bundle, "child", "task.feedback", "external")
 
 	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
 
-	if reportContains(report.Warnings(), "input_pin_wiring", "task.feedback") {
-		t.Fatalf("unexpected input_pin_wiring warning for external input, got %#v", report.Warnings())
+	if reportContains(report.Errors(), "input_pin_wiring", "task.feedback") {
+		t.Fatalf("unexpected input_pin_wiring error for external input, got %#v", report.Errors())
 	}
 }
 
-func TestRun_DoesNotWarnForHarnessInjectedInputPinWithoutEmitter(t *testing.T) {
+func TestRun_DoesNotErrorForHarnessInjectedInputPinWithoutEmitter(t *testing.T) {
 	source := loadTier8Fixture(t, "test-boot-missing-pin")
 
 	report := Run(context.Background(), source, Options{
 		HarnessInjections: []runtimecontracts.FlowInputProducerInjection{{FlowID: "child", EventType: "task.feedback"}},
 	})
 
-	if reportContains(report.Warnings(), "input_pin_wiring", "task.feedback") {
-		t.Fatalf("unexpected input_pin_wiring warning for harness-injected input, got %#v", report.Warnings())
+	if reportContains(report.Errors(), "input_pin_wiring", "task.feedback") {
+		t.Fatalf("unexpected input_pin_wiring error for harness-injected input, got %#v", report.Errors())
 	}
 }
 
@@ -4235,9 +4237,9 @@ func TestRun_ConstrainsExternalInputProducerPathToConsumingScope(t *testing.T) {
 
 	var (
 		externalCleared bool
-		plainWarned     bool
+		plainErrored    bool
 	)
-	for _, finding := range report.Warnings() {
+	for _, finding := range report.Errors() {
 		if finding.CheckID != "input_pin_wiring" || !strings.Contains(finding.Message, "ticket.ready") {
 			continue
 		}
@@ -4245,30 +4247,30 @@ func TestRun_ConstrainsExternalInputProducerPathToConsumingScope(t *testing.T) {
 		case "external_consumer":
 			externalCleared = true
 		case "plain_consumer":
-			plainWarned = true
+			plainErrored = true
 		}
 	}
 	if externalCleared {
-		t.Fatalf("unexpected input_pin_wiring warning for external_consumer, got %#v", report.Warnings())
+		t.Fatalf("unexpected input_pin_wiring error for external_consumer, got %#v", report.Errors())
 	}
-	if !plainWarned {
-		t.Fatalf("expected input_pin_wiring warning for plain_consumer, got %#v", report.Warnings())
+	if !plainErrored {
+		t.Fatalf("expected input_pin_wiring error for plain_consumer, got %#v", report.Errors())
 	}
 }
 
-func TestRun_DoesNotWarnForSiblingFlowOutputPinInputProducerPath(t *testing.T) {
+func TestRun_DoesNotErrorForSiblingFlowOutputPinInputProducerPath(t *testing.T) {
 	root := writeCrossFlowPinAmbiguityFixture(t, false)
 	bundle := loadFixtureBundleAt(t, repoRootForBootverifyTest(t), root, runtimecontracts.DefaultPlatformSpecFile(repoRootForBootverifyTest(t)))
 	bundle.Semantics.FlowOutputs["producer_b"] = nil
 
 	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
 
-	if reportContains(report.Warnings(), "input_pin_wiring", "ticket.ready") {
-		t.Fatalf("unexpected input_pin_wiring warning for sibling output pin proof, got %#v", report.Warnings())
+	if reportContains(report.Errors(), "input_pin_wiring", "ticket.ready") {
+		t.Fatalf("unexpected input_pin_wiring error for sibling output pin proof, got %#v", report.Errors())
 	}
 }
 
-func TestRun_DoesNotWarnForRootAgentEmitInputProducerPath(t *testing.T) {
+func TestRun_DoesNotErrorForRootAgentEmitInputProducerPath(t *testing.T) {
 	bundle := loadTier8FixtureBundle(t, "test-boot-missing-pin")
 	bundle.Agents["lifecycle-coordinator"] = runtimecontracts.AgentRegistryEntry{
 		ID:         "lifecycle-coordinator",
@@ -4277,12 +4279,12 @@ func TestRun_DoesNotWarnForRootAgentEmitInputProducerPath(t *testing.T) {
 
 	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
 
-	if reportContains(report.Warnings(), "input_pin_wiring", "task.feedback") {
-		t.Fatalf("unexpected input_pin_wiring warning for root agent emit proof, got %#v", report.Warnings())
+	if reportContains(report.Errors(), "input_pin_wiring", "task.feedback") {
+		t.Fatalf("unexpected input_pin_wiring error for root agent emit proof, got %#v", report.Errors())
 	}
 }
 
-func TestRun_DoesNotWarnForRootNodeHandlerEmitInputProducerPath(t *testing.T) {
+func TestRun_DoesNotErrorForRootNodeHandlerEmitInputProducerPath(t *testing.T) {
 	bundle := loadTier8FixtureBundle(t, "test-boot-missing-pin")
 	node := bundle.Nodes["dispatcher"]
 	node.EventHandlers["task.requested"] = runtimecontracts.SystemNodeEventHandler{
@@ -4293,12 +4295,12 @@ func TestRun_DoesNotWarnForRootNodeHandlerEmitInputProducerPath(t *testing.T) {
 
 	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
 
-	if reportContains(report.Warnings(), "input_pin_wiring", "task.feedback") {
-		t.Fatalf("unexpected input_pin_wiring warning for root handler emit proof, got %#v", report.Warnings())
+	if reportContains(report.Errors(), "input_pin_wiring", "task.feedback") {
+		t.Fatalf("unexpected input_pin_wiring error for root handler emit proof, got %#v", report.Errors())
 	}
 }
 
-func TestRun_DoesNotWarnForPlatformEventCatalogInputProducerPath(t *testing.T) {
+func TestRun_DoesNotErrorForPlatformEventCatalogInputProducerPath(t *testing.T) {
 	bundle := loadTier8FixtureBundle(t, "test-boot-missing-pin")
 	bundle.Platform.PlatformEvents.Catalog = map[string]yaml.Node{
 		"platform.runtime_log": {},
@@ -4311,12 +4313,12 @@ func TestRun_DoesNotWarnForPlatformEventCatalogInputProducerPath(t *testing.T) {
 
 	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
 
-	if reportContains(report.Warnings(), "input_pin_wiring", "platform.runtime_log") {
-		t.Fatalf("unexpected input_pin_wiring warning for platform event proof, got %#v", report.Warnings())
+	if reportContains(report.Errors(), "input_pin_wiring", "platform.runtime_log") {
+		t.Fatalf("unexpected input_pin_wiring error for platform event proof, got %#v", report.Errors())
 	}
 }
 
-func TestRun_DoesNotWarnForSameFlowTimerInputProducerPath(t *testing.T) {
+func TestRun_DoesNotErrorForSameFlowTimerInputProducerPath(t *testing.T) {
 	bundle := loadTier8FixtureBundle(t, "test-boot-missing-pin")
 	node := bundle.Nodes["worker"]
 	node.Timers = append(node.Timers, runtimecontracts.WorkflowTimerContract{
@@ -4335,12 +4337,12 @@ func TestRun_DoesNotWarnForSameFlowTimerInputProducerPath(t *testing.T) {
 
 	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
 
-	if reportContains(report.Warnings(), "input_pin_wiring", "task.feedback") {
-		t.Fatalf("unexpected input_pin_wiring warning for same-flow timer proof, got %#v", report.Warnings())
+	if reportContains(report.Errors(), "input_pin_wiring", "task.feedback") {
+		t.Fatalf("unexpected input_pin_wiring error for same-flow timer proof, got %#v", report.Errors())
 	}
 }
 
-func TestRun_DoesNotUseProducesOrPlannedAsInputProducerPathProof(t *testing.T) {
+func TestRun_DoesNotUseEventMetadataAsInputProducerPathProof(t *testing.T) {
 	t.Parallel()
 
 	cases := []struct {
@@ -4363,6 +4365,14 @@ func TestRun_DoesNotUseProducesOrPlannedAsInputProducerPathProof(t *testing.T) {
 				bundle.Events["task.feedback"] = entry
 			},
 		},
+		{
+			name: "event metadata source external",
+			mutate: func(bundle *runtimecontracts.WorkflowContractBundle) {
+				entry := bundle.Events["task.feedback"]
+				entry.Swarm.Source = "external"
+				bundle.Events["task.feedback"] = entry
+			},
+		},
 	}
 
 	for _, tc := range cases {
@@ -4372,8 +4382,8 @@ func TestRun_DoesNotUseProducesOrPlannedAsInputProducerPathProof(t *testing.T) {
 
 			report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
 
-			if !reportContains(report.Warnings(), "input_pin_wiring", "task.feedback") {
-				t.Fatalf("expected input_pin_wiring warning for %s, got %#v", tc.name, report.Warnings())
+			if !reportContains(report.Errors(), "input_pin_wiring", "task.feedback") {
+				t.Fatalf("expected input_pin_wiring error for %s, got %#v", tc.name, report.Errors())
 			}
 		})
 	}
@@ -5039,7 +5049,12 @@ func TestRun_AllowsRuleConditionReferenceToDeclaredEntityAndEventContext(t *test
 	}}
 	writeFlowHandler(t, bundle, flowID, nodeID, eventType, handler)
 
-	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+	report := Run(context.Background(), semanticview.Wrap(bundle), Options{
+		HarnessInjections: []runtimecontracts.FlowInputProducerInjection{
+			{FlowID: "child", EventType: "task.assigned"},
+			{FlowID: "child", EventType: "task.feedback"},
+		},
+	})
 
 	if report.HasErrors() {
 		t.Fatalf("unexpected rule-condition errors, got %#v", report.Errors())

--- a/internal/runtime/bootverify/report_test.go
+++ b/internal/runtime/bootverify/report_test.go
@@ -102,15 +102,15 @@ func TestFormatSurfaceFindingUsesTypedDiagnosticRendering(t *testing.T) {
 		CheckID:     "input_pin_wiring",
 		Severity:    SeveritySemanticDriftWarn,
 		Location:    "flow.items",
-		Message:     "no producer path was found in the authored bundle",
-		Remediation: "connect a producer or mark the event external",
+		Message:     "no accepted producer source was found in the authored bundle",
+		Remediation: "connect a producer or declare a valid source",
 		Evidence:    []string{"pin: receive"},
 	}
 
 	rendered := FormatSurfaceFinding(warning, false)
 	for _, want := range []string{
-		"[WARN] input_pin_wiring @ flow.items: no producer path was found in the authored bundle",
-		"  remediation: connect a producer or mark the event external",
+		"[WARN] input_pin_wiring @ flow.items: no accepted producer source was found in the authored bundle",
+		"  remediation: connect a producer or declare a valid source",
 		"  evidence:\n    - pin: receive",
 	} {
 		if !strings.Contains(rendered, want) {
@@ -4206,14 +4206,24 @@ func TestRun_ReportsInputPinWiringWarning(t *testing.T) {
 
 func TestRun_DoesNotWarnForExternalInputPinWithoutEmitter(t *testing.T) {
 	bundle := loadTier8FixtureBundle(t, "test-boot-missing-pin")
-	entry := bundle.Events["task.feedback"]
-	entry.Swarm.Source = "external"
-	bundle.Events["task.feedback"] = entry
+	markFlowInputPinSource(t, bundle, "child", "task.feedback", "external")
 
 	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
 
 	if reportContains(report.Warnings(), "input_pin_wiring", "task.feedback") {
 		t.Fatalf("unexpected input_pin_wiring warning for external input, got %#v", report.Warnings())
+	}
+}
+
+func TestRun_DoesNotWarnForHarnessInjectedInputPinWithoutEmitter(t *testing.T) {
+	source := loadTier8Fixture(t, "test-boot-missing-pin")
+
+	report := Run(context.Background(), source, Options{
+		HarnessInjections: []runtimecontracts.FlowInputProducerInjection{{FlowID: "child", EventType: "task.feedback"}},
+	})
+
+	if reportContains(report.Warnings(), "input_pin_wiring", "task.feedback") {
+		t.Fatalf("unexpected input_pin_wiring warning for harness-injected input, got %#v", report.Warnings())
 	}
 }
 
@@ -5995,13 +6005,28 @@ func TestRun_AllowsTemplateFlowInputPinHandlersWithoutCreateEntity(t *testing.T)
 	}
 }
 
-func TestRun_ReportsCrossFlowPinAmbiguityWithoutEscapeHatch(t *testing.T) {
+func TestRun_DoesNotReportCrossFlowPinAmbiguityForSiblingOutputs(t *testing.T) {
 	root := writeCrossFlowPinAmbiguityFixture(t, false)
 	bundle := loadFixtureBundleAt(t, repoRootForBootverifyTest(t), root, runtimecontracts.DefaultPlatformSpecFile(repoRootForBootverifyTest(t)))
 
 	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
 
-	if !reportContains(report.Errors(), "cross_flow_pin_ambiguity_validation", "ticket.ready") {
+	if reportContains(report.Errors(), "cross_flow_pin_ambiguity_validation", "ticket.ready") {
+		t.Fatalf("unexpected cross_flow_pin_ambiguity_validation error for retired sibling-output inference, got %#v", report.Errors())
+	}
+}
+
+func TestRun_ReportsCrossFlowPinAmbiguityForOverlappingBoundarySources(t *testing.T) {
+	bundle := loadTier8FixtureBundle(t, "test-boot-missing-pin")
+	markFlowInputPinSource(t, bundle, "child", "task.feedback", "external")
+	bundle.Semantics.CompositionConnects = append(bundle.Semantics.CompositionConnects, runtimecontracts.FlowPackageConnect{
+		From: ".task.feedback",
+		To:   "child.task.feedback",
+	})
+
+	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+
+	if !reportContains(report.Errors(), "cross_flow_pin_ambiguity_validation", "task.feedback") {
 		t.Fatalf("expected cross_flow_pin_ambiguity_validation error, got %#v", report.Errors())
 	}
 }
@@ -7268,6 +7293,12 @@ flows:
 	writeBootverifyFixtureFile(t, filepath.Join(root, "nodes.yaml"), "{}\n")
 
 	for _, flowID := range []string{"external_consumer", "plain_consumer"} {
+		eventPin := "      - ticket.ready"
+		if flowID == "external_consumer" {
+			eventPin = `
+      - name: ticket.ready
+        source: external`
+		}
 		writeBootverifyFixtureFile(t, filepath.Join(root, "flows", flowID, "schema.yaml"), `
 name: `+flowID+`
 initial_state: idle
@@ -7276,18 +7307,14 @@ states: [idle, done]
 pins:
   inputs:
     events:
-      - ticket.ready
+`+eventPin+`
   outputs:
     events: []
 `)
 		writeBootverifyFixtureFile(t, filepath.Join(root, "flows", flowID, "policy.yaml"), "{}\n")
 		writeBootverifyFixtureFile(t, filepath.Join(root, "flows", flowID, "nodes.yaml"), "{}\n")
 		entry := "ticket.ready:\n  payload:\n    entity_id: string\n"
-		if flowID == "external_consumer" {
-			entry = "ticket.ready:\n  swarm:\n    source: external (manual handoff)\n  entity_id: string\n"
-		} else {
-			entry = "ticket.ready:\n  entity_id: string\n"
-		}
+		entry = "ticket.ready:\n  entity_id: string\n"
 		writeBootverifyFixtureFile(t, filepath.Join(root, "flows", flowID, "events.yaml"), entry)
 	}
 
@@ -8098,6 +8125,104 @@ func renameFlowHandlerEvent(t *testing.T, bundle *runtimecontracts.WorkflowContr
 			}
 		}
 		bundle.Semantics.FlowInputs[flowID] = inputs
+	}
+	renameFlowInputPinEvent(t, bundle, flowID, oldEventType, newEventType)
+}
+
+func markFlowInputPinSource(t *testing.T, bundle *runtimecontracts.WorkflowContractBundle, flowID, eventType, source string) {
+	t.Helper()
+	flowView, ok := bundle.FlowViewByID(flowID)
+	if !ok || flowView == nil {
+		t.Fatalf("flow view %s missing", flowID)
+	}
+	ensureFlowInputEventPins(&flowView.Schema.Pins.Inputs)
+	for idx := range flowView.Schema.Pins.Inputs.EventPins {
+		if strings.TrimSpace(flowView.Schema.Pins.Inputs.EventPins[idx].EventType()) == strings.TrimSpace(eventType) {
+			flowView.Schema.Pins.Inputs.EventPins[idx].Source = source
+		}
+	}
+	if schema, ok := bundle.FlowSchemas[flowID]; ok {
+		ensureFlowInputEventPins(&schema.Pins.Inputs)
+		for idx := range schema.Pins.Inputs.EventPins {
+			if strings.TrimSpace(schema.Pins.Inputs.EventPins[idx].EventType()) == strings.TrimSpace(eventType) {
+				schema.Pins.Inputs.EventPins[idx].Source = source
+			}
+		}
+		bundle.FlowSchemas[flowID] = schema
+	}
+	ensureSemanticFlowInputPins(bundle, flowID)
+	for idx := range bundle.Semantics.FlowInputEventPins[flowID] {
+		if strings.TrimSpace(bundle.Semantics.FlowInputEventPins[flowID][idx].EventType()) == strings.TrimSpace(eventType) {
+			bundle.Semantics.FlowInputEventPins[flowID][idx].Source = source
+		}
+	}
+}
+
+func renameFlowInputPinEvent(t *testing.T, bundle *runtimecontracts.WorkflowContractBundle, flowID, oldEventType, newEventType string) {
+	t.Helper()
+	flowView, ok := bundle.FlowViewByID(flowID)
+	if !ok || flowView == nil {
+		t.Fatalf("flow view %s missing", flowID)
+	}
+	renameFlowInputPins(&flowView.Schema.Pins.Inputs, oldEventType, newEventType)
+	if schema, ok := bundle.FlowSchemas[flowID]; ok {
+		renameFlowInputPins(&schema.Pins.Inputs, oldEventType, newEventType)
+		bundle.FlowSchemas[flowID] = schema
+	}
+	ensureSemanticFlowInputPins(bundle, flowID)
+	for idx := range bundle.Semantics.FlowInputEventPins[flowID] {
+		if strings.TrimSpace(bundle.Semantics.FlowInputEventPins[flowID][idx].EventType()) == strings.TrimSpace(oldEventType) {
+			bundle.Semantics.FlowInputEventPins[flowID][idx].Name = newEventType
+			bundle.Semantics.FlowInputEventPins[flowID][idx].Event = newEventType
+		}
+	}
+}
+
+func renameFlowInputPins(pins *runtimecontracts.FlowInputPins, oldEventType, newEventType string) {
+	if pins == nil {
+		return
+	}
+	for idx, eventType := range pins.Events {
+		if strings.TrimSpace(eventType) == strings.TrimSpace(oldEventType) {
+			pins.Events[idx] = newEventType
+		}
+	}
+	ensureFlowInputEventPins(pins)
+	for idx := range pins.EventPins {
+		if strings.TrimSpace(pins.EventPins[idx].EventType()) == strings.TrimSpace(oldEventType) {
+			pins.EventPins[idx].Name = newEventType
+			pins.EventPins[idx].Event = newEventType
+		}
+	}
+}
+
+func ensureSemanticFlowInputPins(bundle *runtimecontracts.WorkflowContractBundle, flowID string) {
+	if bundle.Semantics.FlowInputEventPins == nil {
+		bundle.Semantics.FlowInputEventPins = map[string][]runtimecontracts.FlowInputEventPin{}
+	}
+	if len(bundle.Semantics.FlowInputEventPins[flowID]) == 0 {
+		inputs := bundle.Semantics.FlowInputs[flowID]
+		pins := make([]runtimecontracts.FlowInputEventPin, 0, len(inputs))
+		for _, eventType := range inputs {
+			eventType = strings.TrimSpace(eventType)
+			if eventType != "" {
+				pins = append(pins, runtimecontracts.FlowInputEventPin{Name: eventType, Event: eventType})
+			}
+		}
+		bundle.Semantics.FlowInputEventPins[flowID] = pins
+	}
+}
+
+func ensureFlowInputEventPins(pins *runtimecontracts.FlowInputPins) {
+	if pins == nil || len(pins.EventPins) > 0 {
+		return
+	}
+	pins.EventPins = make([]runtimecontracts.FlowInputEventPin, 0, len(pins.Events))
+	for _, eventType := range pins.Events {
+		eventType = strings.TrimSpace(eventType)
+		if eventType != "" {
+			pins.EventPins = append(pins.EventPins, runtimecontracts.FlowInputEventPin{Name: eventType, Event: eventType})
+		}
 	}
 }
 

--- a/internal/runtime/bootverify/workflow_accumulator_safety_checks.go
+++ b/internal/runtime/bootverify/workflow_accumulator_safety_checks.go
@@ -6,6 +6,7 @@ import (
 
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
 	"github.com/division-sh/swarm/internal/runtime/core/eventidentity"
+	"github.com/division-sh/swarm/internal/runtime/semanticview"
 )
 
 const (
@@ -46,7 +47,6 @@ func (c *checkerContext) accumulatorSafety() []Finding {
 	}
 	c.accumulatorSafetyLoaded = true
 
-	flowScopedNodes, flowScopedAgents := inputPinRootParticipants(c.source)
 	for nodeID := range c.source.NodeEntries() {
 		nodeID = strings.TrimSpace(nodeID)
 		if nodeID == "" {
@@ -93,7 +93,7 @@ func (c *checkerContext) accumulatorSafety() []Finding {
 					),
 				})
 			}
-			producerPaths := c.accumulatorProducerPaths(flowID, eventType, flowScopedNodes, flowScopedAgents)
+			producerPaths := c.accumulatorProducerPaths(flowID, eventType)
 			if producerPaths.hasAny() {
 				continue
 			}
@@ -158,53 +158,35 @@ func accumulatorFlowLabel(flowID string) string {
 }
 
 type accumulatorProducerPaths struct {
-	inputPaths        inputPinProducerPaths
-	sameFlowNodeEmit  string
-	sameFlowAgentEmit string
+	inputProof inputPinProducerSourceProof
 }
 
 func (p accumulatorProducerPaths) hasAny() bool {
-	if p.inputPaths.hasAny() {
-		return true
-	}
-	for _, detail := range []string{
-		p.sameFlowNodeEmit,
-		p.sameFlowAgentEmit,
-	} {
-		if !strings.HasPrefix(strings.TrimSpace(detail), "not ") {
-			return true
-		}
-	}
-	return false
+	return p.inputProof.hasAny()
 }
 
 func (p accumulatorProducerPaths) message(flowID, nodeID, eventType string) string {
 	return fmt.Sprintf(
-		"Flow %s node %s handler %s accumulates event %s but no accepted producer/source path was found in the authored bundle.\n\nChecked producer paths:\n- Parent connect: %s\n- Sibling flow output pin: %s\n- Root agent emit_events: %s\n- Root node handler emits: %s\n- Platform event catalog: %s\n- External source metadata (swarm.source): %s\n- Same-flow timer declaration: %s\n- Same-flow node handler emits: %s\n- Same-flow agent emit_events: %s\n\nFix one of:\n- Add an accepted producer path for %s\n- Add swarm.source: external to %s's events.yaml entry if produced externally\n- Remove the accumulator if the event is not produced",
+		"Flow %s node %s handler %s accumulates event %s but no accepted producer/source path was found in the authored bundle.\n\nChecked producer source classes:\n- Boundary/external source: %s\n- Parent connect: %s\n- Explicit harness injection: %s\n- Platform source: %s\n- Internal topology producer: %s\n\nFix one of:\n- Add an accepted producer path for %s\n- Register an explicit harness injection for validation-only fixtures\n- Remove the accumulator if the event is not produced",
 		accumulatorFlowLabel(flowID),
 		strings.TrimSpace(nodeID),
 		strings.TrimSpace(eventType),
 		strings.TrimSpace(eventType),
-		p.inputPaths.parentConnect,
-		p.inputPaths.siblingFlowOutputPin,
-		p.inputPaths.rootAgentEmit,
-		p.inputPaths.rootNodeHandlerEmit,
-		p.inputPaths.platformEventCatalog,
-		p.inputPaths.externalSource,
-		p.inputPaths.sameFlowTimer,
-		p.sameFlowNodeEmit,
-		p.sameFlowAgentEmit,
-		strings.TrimSpace(eventType),
+		p.inputProof.detailsForKind(runtimecontracts.FlowInputProducerBoundaryExternalIngress),
+		p.inputProof.detailsForKind(runtimecontracts.FlowInputProducerBoundaryParentConnect),
+		p.inputProof.detailsForKind(runtimecontracts.FlowInputProducerBoundaryHarnessInjection),
+		p.inputProof.detailsForKind(runtimecontracts.FlowInputProducerPlatformSource),
+		p.inputProof.detailsForKind(runtimecontracts.FlowInputProducerInternalTopology),
 		strings.TrimSpace(eventType),
 	)
 }
 
-func (c *checkerContext) accumulatorProducerPaths(flowID, eventType string, flowScopedNodes, flowScopedAgents map[string]struct{}) accumulatorProducerPaths {
-	inputPaths := c.inputPinProducerPaths(flowID, eventType, flowScopedNodes, flowScopedAgents)
+func (c *checkerContext) accumulatorProducerPaths(flowID, eventType string) accumulatorProducerPaths {
 	return accumulatorProducerPaths{
-		inputPaths:        inputPaths,
-		sameFlowNodeEmit:  c.accumulatorSameFlowNodeEmitPath(flowID, eventType),
-		sameFlowAgentEmit: c.accumulatorSameFlowAgentEmitPath(flowID, eventType),
+		inputProof: inputPinProducerSourceProof{resolution: semanticview.ResolveFlowInputProducerWithOptions(c.source, flowID, eventType, runtimecontracts.FlowInputProducerResolutionOptions{
+			HarnessInjections:  c.opts.HarnessInjections,
+			AllowNonInputEvent: true,
+		})},
 	}
 }
 

--- a/internal/runtime/bootverify/workflow_accumulator_safety_checks_test.go
+++ b/internal/runtime/bootverify/workflow_accumulator_safety_checks_test.go
@@ -133,7 +133,7 @@ func TestRun_FailsClosedForAccumulatorInputWithoutProducerPath(t *testing.T) {
 		t.Fatalf("expected %s error, got %#v", checkIDAccumulatorInputProducer, report.Errors())
 	}
 	if !reportContains(report.Errors(), checkIDAccumulatorInputProducer, "Parent connect: not found") ||
-		!reportContains(report.Errors(), checkIDAccumulatorInputProducer, "Same-flow node handler emits: not found") {
+		!reportContains(report.Errors(), checkIDAccumulatorInputProducer, "Internal topology producer: not found") {
 		t.Fatalf("expected producer path audit details, got %#v", report.Errors())
 	}
 }

--- a/internal/runtime/bootverify/workflow_composition_connect_checks_test.go
+++ b/internal/runtime/bootverify/workflow_composition_connect_checks_test.go
@@ -22,8 +22,8 @@ func TestRun_AllowsParentCompositionConnectAsVerifyRouteProof(t *testing.T) {
 	if reportContains(report.Errors(), "pin_target_resolution", "deploy.done") {
 		t.Fatalf("parent connect should satisfy output pin target proof, got %#v", report.Errors())
 	}
-	if reportContains(report.Warnings(), "input_pin_wiring", "deploy.completed") {
-		t.Fatalf("parent connect should satisfy input pin wiring proof, got %#v", report.Warnings())
+	if reportContains(report.Errors(), "input_pin_wiring", "deploy.completed") {
+		t.Fatalf("parent connect should satisfy input pin wiring proof, got %#v", report.Errors())
 	}
 }
 

--- a/internal/runtime/bootverify/workflow_dead_event_schema_checks.go
+++ b/internal/runtime/bootverify/workflow_dead_event_schema_checks.go
@@ -62,7 +62,7 @@ func (c *checkerContext) deadEventSchema() []Finding {
 			CheckID:  "semantic_drift_dead_event_schema",
 			Severity: "warning",
 			Message: fmt.Sprintf(
-				"Event %s declared in %s has no active role in the authored bundle.\n\nChecked usage sites:\n- Handler emits: %d\n- Handler subscribes: %d\n- Agent emit_events: %d\n- Agent subscriptions: %d\n- Timer fire/start/cancel references: %d\n- External source metadata (swarm.source): %s\n- External consumer metadata (swarm.consumer): %s\n- Fan-out emit: %d\n- Auto-emit-on-create: %s\n- Parent connect outputs: %d\n- Parent connect inputs: %d\n\nIf this event is no longer used, remove it from %s.\nIf it is used by an external system, add swarm.source: external or swarm.consumer: ... to document the external role.",
+				"Event %s declared in %s has no active role in the authored bundle.\n\nChecked usage sites:\n- Handler emits: %d\n- Handler subscribes: %d\n- Agent emit_events: %d\n- Agent subscriptions: %d\n- Timer fire/start/cancel references: %d\n- Resolver-backed input source or non-input source metadata: %s\n- External consumer metadata (swarm.consumer): %s\n- Fan-out emit: %d\n- Auto-emit-on-create: %s\n- Parent connect outputs: %d\n- Parent connect inputs: %d\n\nIf this event is no longer used, remove it from %s.\nIf it is used by an external system, add input-pin source: external for true ingress, a parent connect, a harness injection, or non-input swarm.source/swarm.consumer metadata as appropriate.",
 				decl.Canonical,
 				fileLabel,
 				usage.handlerEmits,
@@ -141,7 +141,7 @@ type deadEventDeclaration struct {
 
 func (c *checkerContext) deadEventSchemaUsageFor(decl deadEventDeclaration) deadEventSchemaUsage {
 	usage := deadEventSchemaUsage{
-		externalSource:   deadEventExternalSource(decl.Entry),
+		externalSource:   c.deadEventSourceRole(decl),
 		externalConsumer: deadEventExternalConsumer(decl.Entry),
 	}
 
@@ -370,8 +370,11 @@ func deadEventSameScope(a, b string) bool {
 	return strings.TrimSpace(a) == strings.TrimSpace(b)
 }
 
-func deadEventExternalSource(entry runtimecontracts.EventCatalogEntry) bool {
-	return eventMetadataExternalOrPlatformSource(entry.SwarmSource())
+func (c *checkerContext) deadEventSourceRole(decl deadEventDeclaration) bool {
+	if resolution, ok := c.resolveDeclaredInputProducerSource(decl.FlowID, decl.Canonical); ok {
+		return resolution.HasEvidence()
+	}
+	return nonInputEventMetadataProducerSource(decl.Entry)
 }
 
 func deadEventExternalConsumer(entry runtimecontracts.EventCatalogEntry) bool {

--- a/internal/runtime/bootverify/workflow_event_topology_checks.go
+++ b/internal/runtime/bootverify/workflow_event_topology_checks.go
@@ -168,7 +168,14 @@ func (c *checkerContext) eventWarnings() []Finding {
 		if runtimecontracts.PlatformEventCatalogContains(c.source.PlatformSpec(), ref.Canonical) {
 			continue
 		}
-		if eventProducedExternallyLocal(ref.Entry) || strings.EqualFold(strings.TrimSpace(ref.Entry.SwarmStatus()), "planned") {
+		if resolution, ok := c.resolveDeclaredInputProducerSource(ref.FlowID, ref.Authored); ok {
+			if resolution.HasEvidence() {
+				continue
+			}
+		} else if nonInputEventMetadataProducerSource(ref.Entry) {
+			continue
+		}
+		if strings.EqualFold(strings.TrimSpace(ref.Entry.SwarmStatus()), "planned") {
 			continue
 		}
 		c.eventWarningFindings = append(c.eventWarningFindings, Finding{
@@ -265,14 +272,6 @@ func eventRefProducedLocal(source semanticview.Source, ref semanticview.FlowEven
 
 func eventHasExternalConsumerLocal(entry runtimecontracts.EventCatalogEntry) bool {
 	return len(entry.SwarmConsumer()) > 0
-}
-
-func eventProducedExternallyLocal(entry runtimecontracts.EventCatalogEntry) bool {
-	if len(entry.SwarmProducer()) > 0 {
-		return true
-	}
-	source := strings.ToLower(strings.TrimSpace(entry.SwarmSource()))
-	return strings.HasPrefix(source, "external") || strings.HasPrefix(source, "platform")
 }
 
 func (c *checkerContext) eventCycleDetection() []Finding {

--- a/internal/runtime/bootverify/workflow_flow_boundary_checks.go
+++ b/internal/runtime/bootverify/workflow_flow_boundary_checks.go
@@ -64,8 +64,6 @@ func (c *checkerContext) inputPinWiring() []Finding {
 	}
 	c.inputPinLoaded = true
 
-	flowScopedNodes, flowScopedAgents := inputPinRootParticipants(c.source)
-
 	for flowID := range c.source.FlowSchemaEntries() {
 		flowID = strings.TrimSpace(flowID)
 		if flowID == "" {
@@ -76,14 +74,23 @@ func (c *checkerContext) inputPinWiring() []Finding {
 			if eventType == "" {
 				continue
 			}
-			producerPaths := c.inputPinProducerPaths(flowID, eventType, flowScopedNodes, flowScopedAgents)
-			if producerPaths.hasAny() {
+			producerProof := c.inputPinProducerSourceProof(flowID, eventType)
+			if producerProof.hasAmbiguousBoundary() {
+				c.inputPinFindings = append(c.inputPinFindings, Finding{
+					CheckID:  "input_pin_wiring",
+					Severity: "warning",
+					Message:  producerProof.ambiguousMessage(flowID, eventType),
+					Location: flowID,
+				})
+				continue
+			}
+			if producerProof.hasAny() {
 				continue
 			}
 			c.inputPinFindings = append(c.inputPinFindings, Finding{
 				CheckID:  "input_pin_wiring",
 				Severity: "warning",
-				Message:  producerPaths.message(flowID, eventType),
+				Message:  producerProof.message(flowID, eventType),
 				Location: flowID,
 			})
 		}
@@ -92,313 +99,88 @@ func (c *checkerContext) inputPinWiring() []Finding {
 	return c.inputPinFindings
 }
 
-type inputPinProducerPaths struct {
-	parentConnect        string
-	siblingFlowOutputPin string
-	rootAgentEmit        string
-	rootNodeHandlerEmit  string
-	platformEventCatalog string
-	externalSource       string
-	sameFlowTimer        string
+type inputPinProducerSourceProof struct {
+	resolution runtimecontracts.FlowInputProducerResolution
 }
 
-func (p inputPinProducerPaths) hasAny() bool {
-	for _, detail := range []string{
-		p.parentConnect,
-		p.siblingFlowOutputPin,
-		p.rootAgentEmit,
-		p.rootNodeHandlerEmit,
-		p.platformEventCatalog,
-		p.externalSource,
-		p.sameFlowTimer,
-	} {
-		if !strings.HasPrefix(strings.TrimSpace(detail), "not ") {
-			return true
-		}
-	}
-	return false
+func (p inputPinProducerSourceProof) hasAny() bool {
+	return p.resolution.HasEvidence()
 }
 
-func (p inputPinProducerPaths) message(flowID, eventType string) string {
+func (p inputPinProducerSourceProof) hasAmbiguousBoundary() bool {
+	return p.resolution.HasAmbiguousBoundaryEvidence()
+}
+
+func (p inputPinProducerSourceProof) message(flowID, eventType string) string {
 	flowID = strings.TrimSpace(flowID)
 	eventType = strings.TrimSpace(eventType)
 	return fmt.Sprintf(
-		"Flow %s declares input pin event %s but no producer path was found in the authored bundle.\n\nChecked producer paths:\n- Parent connect: %s\n- Sibling flow output pin: %s\n- Root agent emit_events: %s\n- Root node handler emits: %s\n- Platform event catalog: %s\n- External source metadata (swarm.source): %s\n- Same-flow timer declaration: %s\n\nFix one of:\n- Add a parent package.yaml connect entry to this input pin\n- Add %s to a producing flow's pins.outputs.events\n- Add %s to a root agent's emit_events\n- Add swarm.source: external to %s's events.yaml entry if produced externally",
+		"Flow %s declares input pin event %s but no accepted producer source was found in the authored bundle.\n\nChecked producer source classes:\n- Boundary external ingress: %s\n- Intrinsic ingress input pin: %s\n- Parent connect: %s\n- Explicit harness injection: %s\n- Platform source: %s\n- Internal topology producer: %s\n\nFix one of:\n- Add a parent package.yaml connect entry to this input pin\n- Mark the input event pin with source: external only when it is true external ingress\n- Register an explicit harness injection for validation-only fixtures\n- Use a platform-owned event if this is platform-produced\n- Produce the event through the intra-flow topology, or remove the input pin if it is not boundary-facing",
 		flowID,
 		eventType,
-		p.parentConnect,
-		p.siblingFlowOutputPin,
-		p.rootAgentEmit,
-		p.rootNodeHandlerEmit,
-		p.platformEventCatalog,
-		p.externalSource,
-		p.sameFlowTimer,
-		eventType,
-		eventType,
-		eventType,
+		p.detailsForKind(runtimecontracts.FlowInputProducerBoundaryExternalIngress),
+		p.detailsForKind(runtimecontracts.FlowInputProducerBoundaryIntrinsicIngress),
+		p.detailsForKind(runtimecontracts.FlowInputProducerBoundaryParentConnect),
+		p.detailsForKind(runtimecontracts.FlowInputProducerBoundaryHarnessInjection),
+		p.detailsForKind(runtimecontracts.FlowInputProducerPlatformSource),
+		p.detailsForKind(runtimecontracts.FlowInputProducerInternalTopology),
 	)
 }
 
-func inputPinRootParticipants(source semanticview.Source) (map[string]struct{}, map[string]struct{}) {
-	flowScopedNodes := map[string]struct{}{}
-	flowScopedAgents := map[string]struct{}{}
-	if source == nil {
-		return flowScopedNodes, flowScopedAgents
-	}
-	for _, scope := range source.FlowScopes() {
-		for nodeID := range scope.Nodes {
-			nodeID = strings.TrimSpace(nodeID)
-			if nodeID != "" {
-				flowScopedNodes[nodeID] = struct{}{}
-			}
-		}
-		for agentID := range scope.Agents {
-			agentID = strings.TrimSpace(agentID)
-			if agentID != "" {
-				flowScopedAgents[agentID] = struct{}{}
-			}
-		}
-	}
-	return flowScopedNodes, flowScopedAgents
+func (p inputPinProducerSourceProof) ambiguousMessage(flowID, eventType string) string {
+	return fmt.Sprintf(
+		"Flow %s declares input pin event %s with multiple boundary producer sources: %s. Choose one boundary source so routing cannot infer authority from overlapping ingress mechanisms.",
+		strings.TrimSpace(flowID),
+		strings.TrimSpace(eventType),
+		p.boundaryDetails(),
+	)
 }
 
-func (c *checkerContext) inputPinProducerPaths(flowID, eventType string, flowScopedNodes, flowScopedAgents map[string]struct{}) inputPinProducerPaths {
-	localEvent := eventidentity.Normalize(eventType)
-	canonicalEvent := eventidentity.Normalize(c.source.ResolveFlowEventReference(flowID, eventType))
-	return inputPinProducerPaths{
-		parentConnect:        c.inputPinParentConnectPath(flowID, localEvent),
-		siblingFlowOutputPin: c.inputPinSiblingFlowOutputPath(flowID, localEvent),
-		rootAgentEmit:        c.inputPinRootAgentPath(localEvent, canonicalEvent, flowScopedAgents),
-		rootNodeHandlerEmit:  c.inputPinRootNodeHandlerPath(localEvent, canonicalEvent, flowScopedNodes),
-		platformEventCatalog: inputPinPlatformEventPath(c.source.PlatformSpec(), localEvent),
-		externalSource:       c.inputPinExternalSourcePath(flowID, eventType),
-		sameFlowTimer:        c.inputPinSameFlowTimerPath(flowID, eventType, canonicalEvent),
-	}
-}
-
-func (c *checkerContext) inputPinParentConnectPath(flowID, localEvent string) string {
-	for _, pin := range c.source.FlowInputEventPins(flowID) {
-		if eventidentity.Normalize(pin.EventType()) != localEvent && eventidentity.Normalize(pin.PinName()) != localEvent {
+func (p inputPinProducerSourceProof) detailsForKind(kind string) string {
+	details := make([]string, 0)
+	for _, evidence := range p.resolution.Evidence {
+		if strings.TrimSpace(evidence.Kind) != kind {
 			continue
 		}
-		connects := c.source.CompositionConnectsTo(flowID, pin.PinName())
-		if len(connects) == 0 {
-			return "not found"
+		detail := strings.TrimSpace(evidence.Detail)
+		if detail == "" {
+			detail = strings.TrimSpace(evidence.EventType)
 		}
-		refs := make([]string, 0, len(connects))
-		for _, connect := range connects {
-			refs = append(refs, strings.TrimSpace(connect.From))
-		}
-		sort.Strings(refs)
-		return fmt.Sprintf("found via parent connect from %s", strings.Join(refs, ", "))
-	}
-	return "not found"
-}
-
-func (c *checkerContext) inputPinSiblingFlowOutputPath(flowID, localEvent string) string {
-	aliases := semanticview.ImportBoundaryInputAliases(c.source, flowID, localEvent)
-	if len(aliases) > 0 {
-		patterns := make([]string, 0, len(aliases))
-		for _, alias := range aliases {
-			if pattern := eventidentity.Normalize(alias.EventPattern); pattern != "" {
-				patterns = append(patterns, pattern)
-			}
-		}
-		sort.Strings(patterns)
-		if len(patterns) > 0 {
-			return fmt.Sprintf("found via %s", strings.Join(patterns, ", "))
+		if detail != "" {
+			details = append(details, detail)
 		}
 	}
-	if semanticview.ImportBoundaryInputAliasRequired(c.source, flowID, localEvent) {
+	if len(details) == 0 {
 		return "not found"
 	}
-	matches := map[string]struct{}{}
-	for otherFlowID := range c.source.FlowSchemaEntries() {
-		otherFlowID = strings.TrimSpace(otherFlowID)
-		if otherFlowID == "" || otherFlowID == strings.TrimSpace(flowID) {
-			continue
-		}
-		for _, output := range c.source.FlowOutputEvents(otherFlowID) {
-			if eventidentity.Normalize(output) == localEvent {
-				matches[otherFlowID] = struct{}{}
-				break
-			}
-		}
-	}
-	if len(matches) == 0 {
-		return "not found"
-	}
-	flows := sortedSetKeysLocal(matches)
-	if len(flows) == 1 {
-		return fmt.Sprintf("found in flow %s", flows[0])
-	}
-	return fmt.Sprintf("found in flows %s", strings.Join(flows, ", "))
+	sort.Strings(details)
+	return strings.Join(details, ", ")
 }
 
-func (c *checkerContext) inputPinRootAgentPath(localEvent, canonicalEvent string, flowScopedAgents map[string]struct{}) string {
-	matches := map[string]struct{}{}
-	for agentID, agent := range c.source.AgentEntries() {
-		agentID = strings.TrimSpace(agentID)
-		if agentID == "" {
-			continue
+func (p inputPinProducerSourceProof) boundaryDetails() string {
+	details := make([]string, 0)
+	for _, evidence := range p.resolution.BoundaryEvidence() {
+		detail := strings.TrimSpace(evidence.Detail)
+		if detail == "" {
+			detail = strings.TrimSpace(evidence.Kind)
 		}
-		if _, ok := flowScopedAgents[agentID]; ok {
-			continue
-		}
-		for _, emitted := range agent.EmitEvents {
-			if inputPinRootProducerMatches(c.source, localEvent, canonicalEvent, emitted) {
-				matches[agentID] = struct{}{}
-				break
-			}
+		if detail != "" {
+			details = append(details, detail)
 		}
 	}
-	if len(matches) == 0 {
-		return "not found"
+	if len(details) == 0 {
+		return "none"
 	}
-	agents := sortedSetKeysLocal(matches)
-	if len(agents) == 1 {
-		return fmt.Sprintf("found on agent %s", agents[0])
-	}
-	return fmt.Sprintf("found on agents %s", strings.Join(agents, ", "))
+	sort.Strings(details)
+	return strings.Join(details, ", ")
 }
 
-func (c *checkerContext) inputPinRootNodeHandlerPath(localEvent, canonicalEvent string, flowScopedNodes map[string]struct{}) string {
-	matches := map[string]struct{}{}
-	for nodeID, node := range c.source.NodeEntries() {
-		nodeID = strings.TrimSpace(nodeID)
-		if nodeID == "" {
-			continue
-		}
-		if _, ok := flowScopedNodes[nodeID]; ok {
-			continue
-		}
-		for handlerEvent, handler := range node.EventHandlers {
-			for _, emitted := range handlerEmits(handler) {
-				if inputPinRootProducerMatches(c.source, localEvent, canonicalEvent, emitted) {
-					matches[fmt.Sprintf("%s handler %s", nodeID, strings.TrimSpace(handlerEvent))] = struct{}{}
-					break
-				}
-			}
-		}
+func (c *checkerContext) inputPinProducerSourceProof(flowID, eventType string) inputPinProducerSourceProof {
+	return inputPinProducerSourceProof{
+		resolution: semanticview.ResolveFlowInputProducerWithOptions(c.source, flowID, eventType, runtimecontracts.FlowInputProducerResolutionOptions{
+			HarnessInjections: c.opts.HarnessInjections,
+		}),
 	}
-	if len(matches) == 0 {
-		return "not found"
-	}
-	handlers := sortedSetKeysLocal(matches)
-	if len(handlers) == 1 {
-		return fmt.Sprintf("found on %s", handlers[0])
-	}
-	return fmt.Sprintf("found on %s", strings.Join(handlers, ", "))
-}
-
-func inputPinPlatformEventPath(platform runtimecontracts.PlatformSpecDocument, localEvent string) string {
-	if runtimecontracts.PlatformEventCatalogContains(platform, localEvent) {
-		return "matched"
-	}
-	return "not matched"
-}
-
-func (c *checkerContext) inputPinExternalSourcePath(flowID, eventType string) string {
-	bundle, ok := semanticview.Bundle(c.source)
-	if !ok || bundle == nil {
-		return "not found"
-	}
-	if entry, ok := inputPinRootEventEntry(bundle, flowID, eventType); ok && inputPinExternalSourceMatch(entry.SwarmSource()) {
-		return "found"
-	}
-	if entry, ok := inputPinFlowEventEntry(bundle, flowID, eventType); ok && inputPinExternalSourceMatch(entry.SwarmSource()) {
-		return "found"
-	}
-	return "not found"
-}
-
-func inputPinExternalSourceMatch(source string) bool {
-	return strings.HasPrefix(strings.ToLower(strings.TrimSpace(source)), "external")
-}
-
-func inputPinRootEventEntry(bundle *runtimecontracts.WorkflowContractBundle, flowID, eventType string) (runtimecontracts.EventCatalogEntry, bool) {
-	if bundle == nil {
-		return runtimecontracts.EventCatalogEntry{}, false
-	}
-	for _, candidate := range []string{
-		eventidentity.Normalize(eventType),
-		eventidentity.Normalize(bundle.ResolveFlowEventReference(flowID, eventType)),
-	} {
-		if candidate == "" {
-			continue
-		}
-		if entry, ok := bundle.Events[candidate]; ok {
-			return entry, true
-		}
-	}
-	return runtimecontracts.EventCatalogEntry{}, false
-}
-
-func inputPinFlowEventEntry(bundle *runtimecontracts.WorkflowContractBundle, flowID, eventType string) (runtimecontracts.EventCatalogEntry, bool) {
-	if bundle == nil {
-		return runtimecontracts.EventCatalogEntry{}, false
-	}
-	flowView, ok := bundle.FlowViewByID(flowID)
-	if !ok || flowView == nil {
-		return runtimecontracts.EventCatalogEntry{}, false
-	}
-	candidate := eventidentity.Normalize(eventType)
-	if candidate == "" {
-		return runtimecontracts.EventCatalogEntry{}, false
-	}
-	if entry, ok := flowView.Events[candidate]; ok {
-		return entry, true
-	}
-	return runtimecontracts.EventCatalogEntry{}, false
-}
-
-func (c *checkerContext) inputPinSameFlowTimerPath(flowID, eventType, canonicalEvent string) string {
-	matches := map[string]struct{}{}
-	for _, timer := range c.source.WorkflowTimers() {
-		if strings.TrimSpace(timer.FlowID) != strings.TrimSpace(flowID) {
-			continue
-		}
-		if !inputPinTimerMatches(c.source, flowID, eventType, canonicalEvent, timer.Event) {
-			continue
-		}
-		label := fmt.Sprintf("node %s", strings.TrimSpace(timer.NodeID))
-		if timerID := strings.TrimSpace(timer.ID); timerID != "" {
-			label = fmt.Sprintf("%s timer %s", label, timerID)
-		}
-		matches[label] = struct{}{}
-	}
-	if len(matches) == 0 {
-		return "not found"
-	}
-	timers := sortedSetKeysLocal(matches)
-	if len(timers) == 1 {
-		return fmt.Sprintf("found on %s", timers[0])
-	}
-	return fmt.Sprintf("found on %s", strings.Join(timers, ", "))
-}
-
-func inputPinRootProducerMatches(source semanticview.Source, localEvent, canonicalEvent, candidate string) bool {
-	candidate = eventidentity.Normalize(candidate)
-	if candidate == "" {
-		return false
-	}
-	if candidate == localEvent {
-		return true
-	}
-	if canonicalEvent == "" || source == nil {
-		return false
-	}
-	return eventidentity.Normalize(source.ResolveFlowEventReference("", candidate)) == canonicalEvent
-}
-
-func inputPinTimerMatches(source semanticview.Source, flowID, eventType, canonicalEvent, candidate string) bool {
-	if source == nil {
-		return false
-	}
-	if canonicalEvent != "" && eventidentity.Normalize(source.ResolveFlowEventReference(flowID, candidate)) == canonicalEvent {
-		return true
-	}
-	return eventidentity.Normalize(candidate) == eventidentity.Normalize(eventType)
 }
 
 func (c *checkerContext) crossFlowPinAmbiguityValidation() []Finding {
@@ -416,20 +198,16 @@ func (c *checkerContext) crossFlowPinAmbiguityValidation() []Finding {
 			if eventType == "" {
 				continue
 			}
-			producers := c.source.ResolveFlowInputAutoWire(flowID, eventType).ProducerFlows
-			if len(producers) <= 1 {
-				continue
-			}
-			if compositionConnectsToInput(c.source, flowID, eventType) {
-				continue
-			}
-			if flowHasScopedInputEscapeHatch(c.source, flowID, eventType) {
+			resolution := semanticview.ResolveFlowInputProducerWithOptions(c.source, flowID, eventType, runtimecontracts.FlowInputProducerResolutionOptions{
+				HarnessInjections: c.opts.HarnessInjections,
+			})
+			if !resolution.HasAmbiguousBoundaryEvidence() {
 				continue
 			}
 			c.crossFlowPinAmbiguityFindings = append(c.crossFlowPinAmbiguityFindings, Finding{
 				CheckID:  "cross_flow_pin_ambiguity_validation",
 				Severity: "error",
-				Message:  fmt.Sprintf("flow %s input pin %s is ambiguous across producer flows %s; add an explicit scoped subscription escape hatch", flowID, eventType, strings.Join(producers, ", ")),
+				Message:  fmt.Sprintf("flow %s input pin %s is ambiguous across boundary producer sources %s; choose one boundary source", flowID, eventType, inputPinProducerSourceProof{resolution: resolution}.boundaryDetails()),
 				Location: flowID,
 			})
 		}

--- a/internal/runtime/bootverify/workflow_flow_boundary_checks.go
+++ b/internal/runtime/bootverify/workflow_flow_boundary_checks.go
@@ -77,10 +77,12 @@ func (c *checkerContext) inputPinWiring() []Finding {
 			producerProof := c.inputPinProducerSourceProof(flowID, eventType)
 			if producerProof.hasAmbiguousBoundary() {
 				c.inputPinFindings = append(c.inputPinFindings, Finding{
-					CheckID:  "input_pin_wiring",
-					Severity: "warning",
-					Message:  producerProof.ambiguousMessage(flowID, eventType),
-					Location: flowID,
+					CheckID:     "input_pin_wiring",
+					Severity:    SeverityHardInvalidity,
+					Message:     producerProof.ambiguousMessage(flowID, eventType),
+					Location:    flowID,
+					Remediation: "Choose exactly one boundary producer source for this input pin; do not let routing infer authority from overlapping ingress mechanisms.",
+					Evidence:    producerProof.evidence(),
 				})
 				continue
 			}
@@ -88,10 +90,12 @@ func (c *checkerContext) inputPinWiring() []Finding {
 				continue
 			}
 			c.inputPinFindings = append(c.inputPinFindings, Finding{
-				CheckID:  "input_pin_wiring",
-				Severity: "warning",
-				Message:  producerProof.message(flowID, eventType),
-				Location: flowID,
+				CheckID:     "input_pin_wiring",
+				Severity:    SeverityHardInvalidity,
+				Message:     producerProof.message(flowID, eventType, c.inputPinTargetRefs(flowID, eventType)),
+				Location:    flowID,
+				Remediation: producerProof.remediation(flowID, eventType, c.inputPinTargetRefs(flowID, eventType)),
+				Evidence:    producerProof.evidence(),
 			})
 		}
 	}
@@ -111,20 +115,47 @@ func (p inputPinProducerSourceProof) hasAmbiguousBoundary() bool {
 	return p.resolution.HasAmbiguousBoundaryEvidence()
 }
 
-func (p inputPinProducerSourceProof) message(flowID, eventType string) string {
+func (p inputPinProducerSourceProof) message(flowID, eventType, targetRefs string) string {
 	flowID = strings.TrimSpace(flowID)
 	eventType = strings.TrimSpace(eventType)
+	targetRefs = strings.TrimSpace(targetRefs)
 	return fmt.Sprintf(
-		"Flow %s declares input pin event %s but no accepted producer source was found in the authored bundle.\n\nChecked producer source classes:\n- Boundary external ingress: %s\n- Intrinsic ingress input pin: %s\n- Parent connect: %s\n- Explicit harness injection: %s\n- Platform source: %s\n- Internal topology producer: %s\n\nFix one of:\n- Add a parent package.yaml connect entry to this input pin\n- Mark the input event pin with source: external only when it is true external ingress\n- Register an explicit harness injection for validation-only fixtures\n- Use a platform-owned event if this is platform-produced\n- Produce the event through the intra-flow topology, or remove the input pin if it is not boundary-facing",
+		"Flow %s declares input pin event %s but no accepted producer source was found in the authored bundle. Expected a producer proof for input pin target %s.\n\nChecked producer source classes:\n- Boundary external ingress: %s\n- Intrinsic ingress input pin: %s\n- Parent connect: %s\n- Explicit harness injection: %s\n- Platform source: %s\n- Internal topology producer: %s\n\nFix one of:\n- Add a parent package.yaml connect entry into %s\n- Mark the input event pin with source: external only when it is true intrinsic/external ingress\n- Register an explicit harness injection for validation-only fixtures\n- Use a platform-owned event if this is platform-produced\n- Produce the event through the intra-flow topology, or remove the input pin if it is not boundary-facing\n\nDo not rely on events.yaml swarm.source as input-pin producer proof; event-level source metadata is non-input compatibility/documentation only.",
 		flowID,
 		eventType,
+		targetRefs,
 		p.detailsForKind(runtimecontracts.FlowInputProducerBoundaryExternalIngress),
 		p.detailsForKind(runtimecontracts.FlowInputProducerBoundaryIntrinsicIngress),
 		p.detailsForKind(runtimecontracts.FlowInputProducerBoundaryParentConnect),
 		p.detailsForKind(runtimecontracts.FlowInputProducerBoundaryHarnessInjection),
 		p.detailsForKind(runtimecontracts.FlowInputProducerPlatformSource),
 		p.detailsForKind(runtimecontracts.FlowInputProducerInternalTopology),
+		targetRefs,
 	)
+}
+
+func (p inputPinProducerSourceProof) remediation(flowID, eventType, targetRefs string) string {
+	targetRefs = strings.TrimSpace(targetRefs)
+	if targetRefs == "" {
+		targetRefs = inputPinTargetRef(flowID, eventType)
+	}
+	return fmt.Sprintf("Provide one resolver-backed producer source: parent connect into %s, input-pin source: external for true ingress, explicit harness injection, platform-owned source, or internal topology production.", targetRefs)
+}
+
+func (p inputPinProducerSourceProof) evidence() []string {
+	evidence := make([]string, 0, len(p.resolution.Evidence)+1)
+	evidence = append(evidence, "events.yaml swarm.source is not input-pin producer proof")
+	for _, item := range p.resolution.Evidence {
+		detail := strings.TrimSpace(item.Detail)
+		if detail == "" {
+			detail = strings.TrimSpace(item.EventType)
+		}
+		if detail == "" {
+			detail = strings.TrimSpace(item.Kind)
+		}
+		evidence = append(evidence, fmt.Sprintf("%s: %s", strings.TrimSpace(item.Kind), detail))
+	}
+	return evidence
 }
 
 func (p inputPinProducerSourceProof) ambiguousMessage(flowID, eventType string) string {
@@ -181,6 +212,44 @@ func (c *checkerContext) inputPinProducerSourceProof(flowID, eventType string) i
 			HarnessInjections: c.opts.HarnessInjections,
 		}),
 	}
+}
+
+func (c *checkerContext) inputPinTargetRefs(flowID, eventType string) string {
+	if c.source == nil {
+		return inputPinTargetRef(flowID, eventType)
+	}
+	refs := make([]string, 0)
+	for _, pin := range c.source.FlowInputEventPins(flowID) {
+		if !inputEventMatches(c.source, flowID, pin.EventType(), eventType) &&
+			!inputEventMatches(c.source, flowID, pin.PinName(), eventType) {
+			continue
+		}
+		pinName := strings.TrimSpace(pin.PinName())
+		if pinName == "" {
+			pinName = strings.TrimSpace(pin.EventType())
+		}
+		if pinName == "" {
+			continue
+		}
+		refs = append(refs, inputPinTargetRef(flowID, pinName))
+	}
+	if len(refs) == 0 {
+		refs = append(refs, inputPinTargetRef(flowID, eventType))
+	}
+	sort.Strings(refs)
+	return strings.Join(refs, ", ")
+}
+
+func inputPinTargetRef(flowID, pinName string) string {
+	flowID = strings.TrimSpace(flowID)
+	pinName = strings.TrimSpace(pinName)
+	if flowID == "" {
+		return pinName
+	}
+	if pinName == "" {
+		return flowID
+	}
+	return flowID + "." + pinName
 }
 
 func (c *checkerContext) crossFlowPinAmbiguityValidation() []Finding {

--- a/internal/runtime/bootverify/workflow_input_source_resolution.go
+++ b/internal/runtime/bootverify/workflow_input_source_resolution.go
@@ -1,0 +1,108 @@
+package bootverify
+
+import (
+	"strings"
+
+	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
+	"github.com/division-sh/swarm/internal/runtime/core/eventidentity"
+	"github.com/division-sh/swarm/internal/runtime/semanticview"
+)
+
+func (c *checkerContext) resolveDeclaredInputProducerSource(flowID, eventType string) (runtimecontracts.FlowInputProducerResolution, bool) {
+	return resolveDeclaredInputProducerSource(c.source, flowID, eventType, runtimecontracts.FlowInputProducerResolutionOptions{
+		HarnessInjections: c.opts.HarnessInjections,
+	})
+}
+
+func resolveDeclaredInputProducerSource(source semanticview.Source, flowID, eventType string, opts runtimecontracts.FlowInputProducerResolutionOptions) (runtimecontracts.FlowInputProducerResolution, bool) {
+	if source == nil {
+		return runtimecontracts.FlowInputProducerResolution{}, false
+	}
+	inputEvent := matchingDeclaredInputEvent(source, flowID, eventType)
+	if inputEvent == "" {
+		return runtimecontracts.FlowInputProducerResolution{}, false
+	}
+	return semanticview.ResolveFlowInputProducerWithOptions(source, flowID, inputEvent, opts), true
+}
+
+func matchingDeclaredInputEvent(source semanticview.Source, flowID, eventType string) string {
+	eventType = eventidentity.Normalize(eventType)
+	if source == nil || eventType == "" {
+		return ""
+	}
+	candidates := uniqueNormalizedInputCandidates(
+		eventType,
+		source.ResolveFlowEventReference(flowID, eventType),
+	)
+	proof := semanticview.ResolveFlowEventProof(source, flowID, eventType)
+	candidates = append(candidates, uniqueNormalizedInputCandidates(proof.Authored, proof.Local, proof.Canonical, proof.CatalogKey)...)
+	for _, candidate := range candidates {
+		if source.FlowHasInputEvent(flowID, candidate) {
+			return candidate
+		}
+	}
+	for _, pin := range source.FlowInputEventPins(flowID) {
+		for _, candidate := range candidates {
+			if inputEventMatches(source, flowID, pin.EventType(), candidate) || inputEventMatches(source, flowID, pin.PinName(), candidate) {
+				return pin.EventType()
+			}
+		}
+	}
+	return ""
+}
+
+func inputEventMatches(source semanticview.Source, flowID, declared, candidate string) bool {
+	declared = eventidentity.Normalize(declared)
+	candidate = eventidentity.Normalize(candidate)
+	if declared == "" || candidate == "" {
+		return false
+	}
+	if declared == candidate {
+		return true
+	}
+	if source == nil {
+		return false
+	}
+	if source.FlowEventMatches(flowID, declared, candidate) || source.FlowEventMatches(flowID, candidate, declared) {
+		return true
+	}
+	return eventidentity.Normalize(source.ResolveFlowEventReference(flowID, declared)) == eventidentity.Normalize(source.ResolveFlowEventReference(flowID, candidate))
+}
+
+func uniqueNormalizedInputCandidates(values ...string) []string {
+	seen := map[string]struct{}{}
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		value = eventidentity.Normalize(value)
+		if value == "" {
+			continue
+		}
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		out = append(out, value)
+	}
+	return out
+}
+
+func inputProducerSourceIsExternalNoTarget(resolution runtimecontracts.FlowInputProducerResolution) bool {
+	for _, evidence := range resolution.Evidence {
+		switch strings.TrimSpace(evidence.Kind) {
+		case runtimecontracts.FlowInputProducerBoundaryExternalIngress,
+			runtimecontracts.FlowInputProducerBoundaryIntrinsicIngress,
+			runtimecontracts.FlowInputProducerBoundaryHarnessInjection,
+			runtimecontracts.FlowInputProducerPlatformSource:
+			return true
+		}
+	}
+	return false
+}
+
+func nonInputEventMetadataProducerSource(entry runtimecontracts.EventCatalogEntry) bool {
+	if len(entry.SwarmProducer()) > 0 {
+		return true
+	}
+	source := strings.ToLower(strings.TrimSpace(entry.SwarmSource()))
+	return strings.HasPrefix(source, "external") || strings.HasPrefix(source, "platform")
+}

--- a/internal/runtime/bootverify/workflow_pin_routing_checks.go
+++ b/internal/runtime/bootverify/workflow_pin_routing_checks.go
@@ -33,7 +33,7 @@ func checkPinTargetResolution(c *checkerContext) []Finding {
 		if connectedOutput {
 			continue
 		}
-		if site.Spec.Target.Normalized().Kind == runtimecontracts.EmitTargetKindSender && pinRoutingEventExternalSource(c.source, site.FlowID, site.HandlerEvent) {
+		if site.Spec.Target.Normalized().Kind == runtimecontracts.EmitTargetKindSender && c.pinRoutingEventExternalSource(site.FlowID, site.HandlerEvent) {
 			findings = append(findings, pinTargetFinding(site, "target_sender_empty_source"))
 		}
 	}
@@ -72,7 +72,7 @@ func checkRedundantInTopologySelectEntity(c *checkerContext) []Finding {
 				if !hasSelect && !hasSelectOrCreate {
 					continue
 				}
-				if pinRoutingEventExternalSource(c.source, flowID, eventType) {
+				if c.pinRoutingEventExternalSource(flowID, eventType) {
 					continue
 				}
 				if !pinRoutingAllKnownProducersTargeted(c.source, flowID, eventType) {
@@ -124,7 +124,7 @@ func checkMissingExternalSelectEntity(c *checkerContext) []Finding {
 				if handler.CreateEntity || (handler.SelectEntity != nil && !handler.SelectEntity.Empty()) || (handler.SelectOrCreateEntity != nil && !handler.SelectOrCreateEntity.Empty()) {
 					continue
 				}
-				if !pinRoutingEventExternalSource(c.source, flowID, eventType) {
+				if !c.pinRoutingEventExternalSource(flowID, eventType) {
 					continue
 				}
 				findings = append(findings, Finding{
@@ -274,36 +274,19 @@ func pinRoutingStructuralParentRouteEligible(source semanticview.Source, flowID 
 	return strings.Contains(path, "/")
 }
 
-func pinRoutingEventExternalSource(source semanticview.Source, flowID, eventType string) bool {
-	if source == nil {
+func (c *checkerContext) pinRoutingEventExternalSource(flowID, eventType string) bool {
+	if c.source == nil {
 		return false
 	}
 	eventType = eventidentity.Normalize(eventType)
 	if eventType == "" {
 		return false
 	}
-	if scope, ok := source.FlowScopeByID(flowID); ok {
-		if entry, ok := scope.Events[eventType]; ok && pinRoutingEventEntryExternalSource(entry) {
-			return true
-		}
-		if canonical := eventidentity.Normalize(source.ResolveFlowEventReference(flowID, eventType)); canonical != "" {
-			for local, entry := range scope.Events {
-				if eventidentity.Normalize(source.ResolveFlowEventReference(flowID, local)) == canonical && pinRoutingEventEntryExternalSource(entry) {
-					return true
-				}
-			}
-		}
+	if resolution, ok := c.resolveDeclaredInputProducerSource(flowID, eventType); ok {
+		return inputProducerSourceIsExternalNoTarget(resolution)
 	}
-	proof := semanticview.ResolveFlowEventProof(source, flowID, eventType)
-	if pinRoutingEventEntryExternalSource(proof.Entry) {
-		return true
-	}
-	entry, _, ok := source.ResolveFlowEventCatalogEntry(flowID, eventType)
-	return ok && pinRoutingEventEntryExternalSource(entry)
-}
-
-func pinRoutingEventEntryExternalSource(entry runtimecontracts.EventCatalogEntry) bool {
-	return strings.HasPrefix(strings.ToLower(strings.TrimSpace(entry.SwarmSource())), "external")
+	entry, _, ok := c.source.ResolveFlowEventCatalogEntry(flowID, eventType)
+	return ok && nonInputEventMetadataProducerSource(entry)
 }
 
 func pinRoutingAllKnownProducersTargeted(source semanticview.Source, flowID, eventType string) bool {

--- a/internal/runtime/bootverify/workflow_pin_routing_checks_test.go
+++ b/internal/runtime/bootverify/workflow_pin_routing_checks_test.go
@@ -921,7 +921,10 @@ states: [pending, done]
 terminal_states: [done]
 pins:
   inputs:
-    events: [deploy.requested]
+    events:
+      - name: deploy_requested
+        event: deploy.requested
+        source: external
   outputs:
     events:
       - name: deploy_done
@@ -939,8 +942,6 @@ producer_request:
 `)
 	writePinRoutingVerifyFile(t, filepath.Join(root, "flows", "producer", "events.yaml"), `
 deploy.requested:
-  swarm:
-    source: external
   vertical_id: string
 deploy.done:
   vertical_id: string
@@ -1031,6 +1032,9 @@ func writeSelectEntityDemotionConsumerFlow(t *testing.T, root string, opts selec
         event: deploy.done
 `
 	}
+	if opts.external {
+		inputPin = strings.Replace(inputPin, "        event: deploy.done\n", "        event: deploy.done\n        source: external\n", 1)
+	}
 	writePinRoutingVerifyFile(t, filepath.Join(root, "flows", "consumer", "schema.yaml"), `
 name: consumer
 mode: `+consumerMode+`
@@ -1044,15 +1048,9 @@ pins:
 `)
 	writePinRoutingVerifyFile(t, filepath.Join(root, "flows", "consumer", "policy.yaml"), "{}\n")
 	writePinRoutingVerifyFile(t, filepath.Join(root, "flows", "consumer", "agents.yaml"), "{}\n")
-	externalSource := ""
-	if opts.external {
-		externalSource = `  swarm:
-    source: external (operator webhook)
-`
-	}
 	writePinRoutingVerifyFile(t, filepath.Join(root, "flows", "consumer", "events.yaml"), `
 deploy.done:
-`+externalSource+`  vertical_id: string
+  vertical_id: string
 `)
 	writePinRoutingVerifyFile(t, filepath.Join(root, "flows", "consumer", "entities.yaml"), `
 deployment:

--- a/internal/runtime/bootverify/workflow_timer_checks.go
+++ b/internal/runtime/bootverify/workflow_timer_checks.go
@@ -390,7 +390,10 @@ func (c *checkerContext) timerTriggerEventProduced(timer runtimecontracts.Workfl
 	if c.source == nil {
 		return false
 	}
-	if timerEventProducedByPlatform(c.source, ref) || eventProducedExternallyLocal(ref.Entry) {
+	if resolution, ok := c.resolveDeclaredInputProducerSource(strings.TrimSpace(timer.FlowID), ref.Authored); ok {
+		return resolution.HasEvidence()
+	}
+	if timerEventProducedByPlatform(c.source, ref) || nonInputEventMetadataProducerSource(ref.Entry) {
 		return true
 	}
 	emittedRefs := timerLifecycleEmittedEventRefs(c.source, strings.TrimSpace(timer.ID))

--- a/internal/runtime/bus/eventbus_publish_test.go
+++ b/internal/runtime/bus/eventbus_publish_test.go
@@ -2069,7 +2069,7 @@ func TestEventBusPublish_HumanTaskEventsRouteBySubscriptionOnly(t *testing.T) {
 	requireNoBusEvent(t, ch, "human task event without subscription")
 }
 
-func TestEventBusPublish_LogsRoutedAndSubscribedRecipientsSeparately(t *testing.T) {
+func TestEventBusPublish_DoesNotLogRoutedRecipientForRetiredSiblingAutoWire(t *testing.T) {
 	producer := runtimecontracts.FlowContractView{
 		Paths: runtimecontracts.FlowContractPaths{ID: "producer", Flow: "producer"},
 		Schema: runtimecontracts.FlowSchemaDocument{
@@ -2146,17 +2146,8 @@ func TestEventBusPublish_LogsRoutedAndSubscribedRecipientsSeparately(t *testing.
 			}
 		}
 	}
-	if len(routed) == 0 || routed[0]["id"] != "scan-orchestrator" {
-		t.Fatalf("routed_recipients = %#v, want scan-orchestrator", detail["routed_recipients"])
-	}
-	if got := routed[0]["matched_pattern"]; got != "producer/scan.requested" {
-		t.Fatalf("matched_pattern = %#v, want producer/scan.requested", got)
-	}
-	if got := routed[0]["route_source"]; got != "pin_auto_wire" {
-		t.Fatalf("route_source = %#v, want pin_auto_wire", got)
-	}
-	if got := routed[0]["localized_event"]; got != "scan.requested" {
-		t.Fatalf("localized_event = %#v, want scan.requested", got)
+	if len(routed) != 0 {
+		t.Fatalf("routed_recipients = %#v, want none for retired sibling auto-wire", detail["routed_recipients"])
 	}
 	subs, _ := detail["subscription_recipients"].([]string)
 	if len(subs) == 0 {
@@ -2174,7 +2165,7 @@ func TestEventBusPublish_LogsRoutedAndSubscribedRecipientsSeparately(t *testing.
 	}
 }
 
-func TestEventBusPublish_RecordsPublishDiagnosticsInTurnRecorder(t *testing.T) {
+func TestEventBusPublish_RecordsNoRoutedDiagnosticsForRetiredSiblingAutoWire(t *testing.T) {
 	producer := runtimecontracts.FlowContractView{
 		Paths: runtimecontracts.FlowContractPaths{ID: "producer", Flow: "producer"},
 		Schema: runtimecontracts.FlowSchemaDocument{
@@ -2229,14 +2220,8 @@ func TestEventBusPublish_RecordsPublishDiagnosticsInTurnRecorder(t *testing.T) {
 	if diags[0].EventType != "producer/scan.requested" {
 		t.Fatalf("event_type = %q", diags[0].EventType)
 	}
-	if len(diags[0].RoutedRecipients) != 1 {
-		t.Fatalf("routed_recipients = %#v", diags[0].RoutedRecipients)
-	}
-	if diags[0].RoutedRecipients[0].RouteSource != "pin_auto_wire" {
-		t.Fatalf("route_source = %q", diags[0].RoutedRecipients[0].RouteSource)
-	}
-	if diags[0].RoutedRecipients[0].LocalizedEvent != "scan.requested" {
-		t.Fatalf("localized_event = %q", diags[0].RoutedRecipients[0].LocalizedEvent)
+	if len(diags[0].RoutedRecipients) != 0 {
+		t.Fatalf("routed_recipients = %#v, want none for retired sibling auto-wire", diags[0].RoutedRecipients)
 	}
 }
 

--- a/internal/runtime/bus/eventbus_target_routes_test.go
+++ b/internal/runtime/bus/eventbus_target_routes_test.go
@@ -803,11 +803,11 @@ func TestEventBusPublish_TargetedDynamicFlowFixtureRouteTableNodePersistsSemanti
 		}
 		return false
 	}
-	if !hasRoute("work.assign") {
-		t.Fatalf("materialized routes = %#v, want task-handler local work.assign route; node entries=%v", materialized, sortedStringKeys(bundle.NodeEntries()))
+	if !hasRoute("worker/w-001/work.assign") {
+		t.Fatalf("materialized routes = %#v, want task-handler instance-scoped work.assign route; node entries=%v", materialized, sortedStringKeys(bundle.NodeEntries()))
 	}
-	if hasRoute("worker/w-001/work.assign") {
-		t.Fatalf("materialized routes = %#v, want no selected receiver-carrier route for unrelated target-route fixture", materialized)
+	if subscriberListContainsRouteSource(eb.RouteTable().Resolve("worker/w-001/work.assign"), "task-handler", "worker/w-001", "receiver_carrier") {
+		t.Fatalf("Resolve(worker/w-001/work.assign) = %#v, want no receiver_carrier route for unrelated target-route fixture", eb.RouteTable().Resolve("worker/w-001/work.assign"))
 	}
 	if resolved := eb.RouteTable().Resolve("worker/w-001/work.assign"); subscriberListContainsRouteSource(resolved, "task-handler", "worker/w-001", "receiver_carrier") {
 		t.Fatalf("Resolve(worker/w-001/work.assign) = %#v, want no receiver_carrier route for unrelated target-route fixture", resolved)

--- a/internal/runtime/bus/outbox.go
+++ b/internal/runtime/bus/outbox.go
@@ -191,8 +191,9 @@ func (d engineDispatcher) dispatchIntent(ctx context.Context, intent runtimeengi
 		d.bus.logDispatchQueued(ctx, reason, intent.Event, len(intent.Recipients), len(intent.Recipients) > 0, false)
 		return true, nil
 	}
+	deliveryRoutes := d.bus.deliveryRoutesForPostCommitIntent(ctx, intent.Event.ID())
 	if intent.Recipients == nil {
-		passthrough, deferred, err := d.bus.runInterceptorsForDeliveryRoutes(ctx, intent.Event, d.bus.deliveryRoutesForEvent(ctx, intent.Event.ID()))
+		passthrough, deferred, err := d.bus.runInterceptorsForDeliveryRoutes(ctx, intent.Event, deliveryRoutes)
 		if err != nil {
 			return false, err
 		}
@@ -202,6 +203,7 @@ func (d engineDispatcher) dispatchIntent(ctx context.Context, intent runtimeengi
 			}
 		}
 		if !passthrough {
+			d.bus.clearPendingInternalDeliveryRoutes(intent.Event.ID())
 			return false, nil
 		}
 	}
@@ -212,9 +214,7 @@ func (d engineDispatcher) dispatchIntent(ctx context.Context, intent runtimeengi
 		}
 		return false, err
 	}
-	deliveryRoutes := d.bus.deliveryRoutesForEvent(ctx, intent.Event.ID())
 	pendingInternalRoutes := d.bus.pendingInternalDeliveryRoutes(intent.Event.ID())
-	deliveryRoutes = events.NormalizeDeliveryRoutes(append(deliveryRoutes, pendingInternalRoutes...))
 	if len(recipients) > 0 {
 		deliveryRoutes = events.NormalizeDeliveryRoutes(append(deliveryRoutes, deliveryRoutesFromTargetMap(recipients, "agent", d.bus.deliveryTargetsForEvent(ctx, intent.Event.ID()))...))
 	}
@@ -256,6 +256,12 @@ func (d engineDispatcher) dispatchIntent(ctx context.Context, intent runtimeengi
 		"internal_recipients":        append([]string(nil), internalRecipients...),
 	}, "", 0)
 	return false, nil
+}
+
+func (eb *EventBus) deliveryRoutesForPostCommitIntent(ctx context.Context, eventID string) []events.DeliveryRoute {
+	persistedRoutes := eb.deliveryRoutesForEvent(ctx, eventID)
+	pendingInternalRoutes := eb.pendingInternalDeliveryRoutes(eventID)
+	return events.NormalizeDeliveryRoutes(append(persistedRoutes, pendingInternalRoutes...))
 }
 
 func (d engineDispatcher) dispatchExplicitDirectIntent(ctx context.Context, intent runtimeengine.EmitIntent) error {

--- a/internal/runtime/bus/outbox_test.go
+++ b/internal/runtime/bus/outbox_test.go
@@ -210,6 +210,33 @@ func (interceptingTestHandler) Intercept(_ context.Context, evt events.Event) (b
 	)}, nil
 }
 
+type recordingDeliveryRouteInterceptor struct {
+	mu     sync.Mutex
+	routes []events.DeliveryRoute
+}
+
+func (*recordingDeliveryRouteInterceptor) Intercept(context.Context, events.Event) (bool, []events.Event, error) {
+	return true, nil, nil
+}
+
+func (r *recordingDeliveryRouteInterceptor) InterceptDeliveryRoute(_ context.Context, _ events.Event, route events.DeliveryRoute) (bool, []events.Event, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.routes = append(r.routes, route.Normalized())
+	return false, nil, nil
+}
+
+func (r *recordingDeliveryRouteInterceptor) seen(route events.DeliveryRoute) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for _, got := range events.NormalizeDeliveryRoutes(r.routes) {
+		if got.SubscriberType == route.SubscriberType && got.SubscriberID == route.SubscriberID && got.Target.Normalized() == route.Target.Normalized() {
+			return true
+		}
+	}
+	return false
+}
+
 func TestEngineDispatcherCollectsEmitIntentsWithChainDepth(t *testing.T) {
 	eb, err := runtimebus.NewEventBus(runtimebus.InMemoryEventStore{})
 	if err != nil {
@@ -810,6 +837,67 @@ func TestEngineOutboxAndDispatcher_DeliverInternalSubscribersOutsidePersistedMan
 	if got := evt.EntityID(); got != "ent-1" {
 		t.Fatalf("agent event entity_id = %q, want ent-1", got)
 	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("sql expectations: %v", err)
+	}
+}
+
+func TestEngineOutboxAndDispatcher_RoutesPendingInternalDeliveriesToRouteInterceptors(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectBegin()
+	mock.ExpectCommit()
+
+	tx, err := db.Begin()
+	if err != nil {
+		t.Fatalf("Begin: %v", err)
+	}
+	store := &directRecipientTransactionalStore{}
+	interceptor := &recordingDeliveryRouteInterceptor{}
+	eb, err := runtimebus.NewEventBusWithOptions(store, runtimebus.EventBusOptions{
+		Interceptors: []runtimebus.EventInterceptor{interceptor},
+	})
+	if err != nil {
+		t.Fatalf("NewEventBusWithOptions: %v", err)
+	}
+	internalCh := eb.SubscribeInternal("workflow-runtime", events.EventType("custom.emitted"))
+	defer eb.Unsubscribe("workflow-runtime")
+
+	intent := runtimeengine.EmitIntent{
+		Event: eventtest.RootIngress(
+			"evt-pending-internal-route",
+			events.EventType("custom.emitted"),
+			"",
+			"",
+			[]byte(`{"entity_id":"ent-1"}`),
+			0,
+			"",
+			"",
+			events.EnvelopeForEntityID(events.EventEnvelope{}, "ent-1"),
+			time.Now().UTC(),
+		),
+	}
+	txctx := runtimepipeline.WithPipelineSQLTxContext(context.Background(), tx)
+	if err := eb.EngineOutbox().WriteOutbox(txctx, []runtimeengine.EmitIntent{intent}); err != nil {
+		_ = tx.Rollback()
+		t.Fatalf("WriteOutbox: %v", err)
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatalf("Commit: %v", err)
+	}
+	if err := eb.EngineDispatcher().DispatchPostCommit(context.Background(), []runtimeengine.EmitIntent{intent}); err != nil {
+		t.Fatalf("DispatchPostCommit: %v", err)
+	}
+	wantRoute := events.DeliveryRoute{SubscriberType: "node", SubscriberID: "workflow-runtime"}
+	if !interceptor.seen(wantRoute) {
+		t.Fatalf("delivery route interceptor did not receive pending internal route %#v", wantRoute)
+	}
+	requireNoBusEvent(t, internalCh, "route-intercepted pending internal event")
 
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Fatalf("sql expectations: %v", err)

--- a/internal/runtime/bus/routing_derivation.go
+++ b/internal/runtime/bus/routing_derivation.go
@@ -677,10 +677,21 @@ func routeFlowInputHasExternalProducer(source semanticview.Source, flowID, event
 	if source == nil {
 		return false
 	}
-	if semanticview.ImportBoundaryInputAliasRequired(source, flowID, eventType) {
+	resolution := semanticview.ResolveFlowInputProducer(source, flowID, eventType)
+	switch {
+	case resolution.HasEvidenceKind(runtimecontracts.FlowInputProducerBoundaryExternalIngress):
 		return true
+	case resolution.HasEvidenceKind(runtimecontracts.FlowInputProducerBoundaryIntrinsicIngress):
+		return true
+	case resolution.HasEvidenceKind(runtimecontracts.FlowInputProducerBoundaryParentConnect):
+		return true
+	case resolution.HasEvidenceKind(runtimecontracts.FlowInputProducerBoundaryHarnessInjection):
+		return true
+	case resolution.HasEvidenceKind(runtimecontracts.FlowInputProducerPlatformSource):
+		return true
+	default:
+		return false
 	}
-	return len(source.ResolveFlowInputAutoWire(flowID, eventType).Patterns) > 0
 }
 
 func routeFlowInputHasLoweredConnectReceiver(source semanticview.Source, flowID, eventType string) bool {

--- a/internal/runtime/bus/routing_derivation_test.go
+++ b/internal/runtime/bus/routing_derivation_test.go
@@ -429,7 +429,7 @@ func TestRouteTableTemplateOutputPinWildcardSubscriberResolvesThroughDerivedInst
 	}
 }
 
-func TestDeriveRouteTable_InputPinsAutoWireFromProducerOutput(t *testing.T) {
+func TestDeriveRouteTable_InputPinsDoNotAutoWireFromProducerOutput(t *testing.T) {
 	producer := runtimecontracts.FlowContractView{
 		Paths: runtimecontracts.FlowContractPaths{ID: "producer", Flow: "producer"},
 		Schema: runtimecontracts.FlowSchemaDocument{
@@ -468,19 +468,18 @@ func TestDeriveRouteTable_InputPinsAutoWireFromProducerOutput(t *testing.T) {
 	if err != nil {
 		t.Fatalf("DeriveRouteTable: %v", err)
 	}
-	got := rt.Resolve("producer/scan.requested")
-	if len(got) != 1 || got[0].ID != "scan-orchestrator" {
-		t.Fatalf("Resolve(producer/scan.requested) = %#v, want scan-orchestrator", got)
+	if got := rt.Resolve("producer/scan.requested"); len(got) != 0 {
+		t.Fatalf("Resolve(producer/scan.requested) = %#v, want none for retired sibling auto-wire", got)
 	}
 	if got := rt.Resolve("scan.requested"); len(got) != 0 {
 		t.Fatalf("Resolve(scan.requested) = %#v, want none", got)
 	}
-	if got := rt.Resolve("discovery/scan.requested"); len(got) != 0 {
-		t.Fatalf("Resolve(discovery/scan.requested) = %#v, want none", got)
+	if got := rt.Resolve("discovery/scan.requested"); len(got) != 1 || got[0].ID != "scan-orchestrator" {
+		t.Fatalf("Resolve(discovery/scan.requested) = %#v, want scan-orchestrator local input route", got)
 	}
 }
 
-func TestDeriveRouteTable_HandlerOnlyInputPinsAutoWireFromProducerOutput(t *testing.T) {
+func TestDeriveRouteTable_HandlerOnlyInputPinsDoNotAutoWireFromProducerOutput(t *testing.T) {
 	producer := runtimecontracts.FlowContractView{
 		Paths: runtimecontracts.FlowContractPaths{ID: "producer", Flow: "producer"},
 		Schema: runtimecontracts.FlowSchemaDocument{
@@ -528,9 +527,12 @@ func TestDeriveRouteTable_HandlerOnlyInputPinsAutoWireFromProducerOutput(t *test
 	if err != nil {
 		t.Fatalf("DeriveRouteTable: %v", err)
 	}
-	got := rt.Resolve("producer/scan.requested")
+	if got := rt.Resolve("producer/scan.requested"); len(got) != 0 {
+		t.Fatalf("Resolve(producer/scan.requested) = %#v, want none for retired sibling auto-wire", got)
+	}
+	got := rt.Resolve("consumer/scan.requested")
 	if len(got) != 1 || got[0].ID != "consumer-node" {
-		t.Fatalf("Resolve(producer/scan.requested) = %#v, want consumer-node", got)
+		t.Fatalf("Resolve(consumer/scan.requested) = %#v, want consumer-node local input route", got)
 	}
 }
 

--- a/internal/runtime/contracts/workflow_contract_accessors.go
+++ b/internal/runtime/contracts/workflow_contract_accessors.go
@@ -581,51 +581,8 @@ func (b *WorkflowContractBundle) FlowHasOutputEvent(flowID, eventType string) bo
 	return b.flowEventScope(flowID).HasOutput(eventType)
 }
 func (b *WorkflowContractBundle) ResolveFlowInputAutoWire(targetFlowID, eventType string) FlowInputAutoWireResolution {
-	targetFlowID = strings.TrimSpace(targetFlowID)
 	eventType = eventidentity.Normalize(eventType)
-	if b == nil || targetFlowID == "" || eventType == "" || !b.FlowHasInputEvent(targetFlowID, eventType) {
-		return FlowInputAutoWireResolution{EventType: eventType}
-	}
-
-	out := FlowInputAutoWireResolution{EventType: eventType}
-	seenPatterns := make(map[string]struct{})
-	appendPattern := func(value string) {
-		value = eventidentity.Normalize(value)
-		if value == "" {
-			return
-		}
-		if _, ok := seenPatterns[value]; ok {
-			return
-		}
-		seenPatterns[value] = struct{}{}
-		out.Patterns = append(out.Patterns, value)
-	}
-
-	for _, view := range b.ProjectViews() {
-		if _, ok := view.Events[eventType]; ok {
-			appendPattern(eventType)
-		}
-	}
-
-	seenFlows := make(map[string]struct{})
-	for _, view := range b.FlowViews() {
-		flowID := strings.TrimSpace(view.Paths.ID)
-		if flowID == "" || flowID == targetFlowID || !b.FlowHasOutputEvent(flowID, eventType) {
-			continue
-		}
-		if _, ok := seenFlows[flowID]; ok {
-			continue
-		}
-		seenFlows[flowID] = struct{}{}
-		out.ProducerFlows = append(out.ProducerFlows, flowID)
-	}
-
-	sort.Strings(out.ProducerFlows)
-	if len(out.ProducerFlows) == 1 {
-		appendPattern(b.ResolveFlowEventReference(out.ProducerFlows[0], eventType))
-	}
-	sort.Strings(out.Patterns)
-	return out
+	return FlowInputAutoWireResolution{EventType: eventType}
 }
 func (b *WorkflowContractBundle) FlowInputProducerPatterns(targetFlowID, eventType string) []string {
 	return append([]string{}, b.ResolveFlowInputAutoWire(targetFlowID, eventType).Patterns...)

--- a/internal/runtime/contracts/workflow_contract_accessors_test.go
+++ b/internal/runtime/contracts/workflow_contract_accessors_test.go
@@ -40,7 +40,7 @@ func TestFlowStatesRootScopeExcludesChildFlowStates(t *testing.T) {
 	}
 }
 
-func TestResolveFlowInputAutoWire_ReturnsScopedProducerForUniquePinMatch(t *testing.T) {
+func TestResolveFlowInputAutoWire_DoesNotInferSiblingProducerForUniquePinMatch(t *testing.T) {
 	producer := FlowContractView{
 		Paths: FlowContractPaths{ID: "producer", Flow: "producer"},
 		Schema: FlowSchemaDocument{
@@ -71,15 +71,15 @@ func TestResolveFlowInputAutoWire_ReturnsScopedProducerForUniquePinMatch(t *test
 	}
 
 	resolution := bundle.ResolveFlowInputAutoWire("consumer", "scan.requested")
-	if got, want := resolution.ProducerFlows, []string{"producer"}; len(got) != len(want) || got[0] != want[0] {
-		t.Fatalf("ProducerFlows = %#v, want %#v", got, want)
+	if len(resolution.ProducerFlows) != 0 {
+		t.Fatalf("ProducerFlows = %#v, want none for retired sibling auto-wire", resolution.ProducerFlows)
 	}
-	if got, want := resolution.Patterns, []string{"producer/scan.requested"}; len(got) != len(want) || got[0] != want[0] {
-		t.Fatalf("Patterns = %#v, want %#v", got, want)
+	if len(resolution.Patterns) != 0 {
+		t.Fatalf("Patterns = %#v, want none for retired sibling auto-wire", resolution.Patterns)
 	}
 }
 
-func TestResolveFlowInputAutoWire_FailsClosedOnAmbiguousPinMatch(t *testing.T) {
+func TestResolveFlowInputAutoWire_DoesNotExposeAmbiguousSiblingProducerFallback(t *testing.T) {
 	producerA := FlowContractView{
 		Paths: FlowContractPaths{ID: "producer_a", Flow: "producer_a"},
 		Schema: FlowSchemaDocument{
@@ -120,10 +120,10 @@ func TestResolveFlowInputAutoWire_FailsClosedOnAmbiguousPinMatch(t *testing.T) {
 	}
 
 	resolution := bundle.ResolveFlowInputAutoWire("consumer", "ticket.ready")
-	if got, want := resolution.ProducerFlows, []string{"producer_a", "producer_b"}; len(got) != len(want) || got[0] != want[0] || got[1] != want[1] {
-		t.Fatalf("ProducerFlows = %#v, want %#v", got, want)
+	if len(resolution.ProducerFlows) != 0 {
+		t.Fatalf("ProducerFlows = %#v, want none for retired sibling auto-wire", resolution.ProducerFlows)
 	}
 	if len(resolution.Patterns) != 0 {
-		t.Fatalf("Patterns = %#v, want none for ambiguous auto-wire", resolution.Patterns)
+		t.Fatalf("Patterns = %#v, want none for retired sibling auto-wire", resolution.Patterns)
 	}
 }

--- a/internal/runtime/contracts/workflow_contract_connect.go
+++ b/internal/runtime/contracts/workflow_contract_connect.go
@@ -19,8 +19,9 @@ func (p FlowInputEventPin) EventType() string {
 
 func (p FlowInputEventPin) normalized() FlowInputEventPin {
 	out := FlowInputEventPin{
-		Name:  strings.TrimSpace(p.Name),
-		Event: strings.TrimSpace(p.Event),
+		Name:   strings.TrimSpace(p.Name),
+		Event:  strings.TrimSpace(p.Event),
+		Source: strings.ToLower(strings.TrimSpace(p.Source)),
 	}
 	if out.Event == "" {
 		out.Event = out.Name

--- a/internal/runtime/contracts/workflow_contract_types.go
+++ b/internal/runtime/contracts/workflow_contract_types.go
@@ -2,6 +2,7 @@ package contracts
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/division-sh/swarm/internal/runtime/core/paths"
@@ -116,7 +117,160 @@ type FlowInputAutoWireResolution struct {
 	EventType     string
 	Patterns      []string
 	ProducerFlows []string
+	Evidence      []FlowInputProducerEvidence
 }
+
+type FlowInputProducerResolution struct {
+	FlowID    string
+	EventType string
+	Evidence  []FlowInputProducerEvidence
+}
+
+type FlowInputProducerEvidence struct {
+	Kind      string
+	FlowID    string
+	EventType string
+	Pin       string
+	Pattern   string
+	Detail    string
+}
+
+const (
+	FlowInputProducerBoundaryExternalIngress  = "boundary_external_ingress"
+	FlowInputProducerBoundaryIntrinsicIngress = "boundary_intrinsic_ingress"
+	FlowInputProducerBoundaryParentConnect    = "boundary_parent_connect"
+	FlowInputProducerBoundaryHarnessInjection = "boundary_harness_injection"
+	FlowInputProducerPlatformSource           = "platform_source"
+	FlowInputProducerInternalTopology         = "internal_topology_producer"
+	FlowInputProducerMissing                  = "missing"
+	FlowInputProducerAmbiguous                = "ambiguous"
+	FlowInputProducerInvalidContext           = "invalid_context"
+)
+
+type FlowInputProducerResolutionOptions struct {
+	HarnessInjections  []FlowInputProducerInjection
+	AllowNonInputEvent bool
+}
+
+type FlowInputProducerInjection struct {
+	FlowID    string
+	EventType string
+}
+
+func (r FlowInputProducerResolution) HasEvidence() bool {
+	for _, evidence := range r.Evidence {
+		if FlowInputProducerEvidenceKindIsProof(evidence.Kind) {
+			return true
+		}
+	}
+	return false
+}
+
+func (r FlowInputProducerResolution) HasEvidenceKind(kind string) bool {
+	kind = strings.TrimSpace(kind)
+	if kind == "" {
+		return false
+	}
+	for _, evidence := range r.Evidence {
+		if strings.TrimSpace(evidence.Kind) == kind {
+			return true
+		}
+	}
+	return false
+}
+
+func FlowInputProducerEvidenceKindIsProof(kind string) bool {
+	switch strings.TrimSpace(kind) {
+	case FlowInputProducerBoundaryExternalIngress,
+		FlowInputProducerBoundaryIntrinsicIngress,
+		FlowInputProducerBoundaryParentConnect,
+		FlowInputProducerBoundaryHarnessInjection,
+		FlowInputProducerPlatformSource,
+		FlowInputProducerInternalTopology:
+		return true
+	default:
+		return false
+	}
+}
+
+func (r FlowInputProducerResolution) BoundaryEvidence() []FlowInputProducerEvidence {
+	out := make([]FlowInputProducerEvidence, 0)
+	for _, evidence := range r.Evidence {
+		switch strings.TrimSpace(evidence.Kind) {
+		case FlowInputProducerBoundaryExternalIngress,
+			FlowInputProducerBoundaryIntrinsicIngress,
+			FlowInputProducerBoundaryParentConnect,
+			FlowInputProducerBoundaryHarnessInjection:
+			out = append(out, evidence)
+		}
+	}
+	return out
+}
+
+func (r FlowInputProducerResolution) HasAmbiguousBoundaryEvidence() bool {
+	seen := map[string]struct{}{}
+	for _, evidence := range r.BoundaryEvidence() {
+		key := strings.TrimSpace(evidence.Kind) + "|" + strings.TrimSpace(evidence.FlowID) + "|" + strings.TrimSpace(evidence.Pin) + "|" + strings.TrimSpace(evidence.EventType)
+		if key == "" {
+			continue
+		}
+		seen[key] = struct{}{}
+	}
+	return len(seen) > 1
+}
+
+func (r FlowInputProducerResolution) ProducerPatterns() []string {
+	seen := map[string]struct{}{}
+	for _, evidence := range r.Evidence {
+		if !FlowInputProducerEvidenceKindIsProof(evidence.Kind) {
+			continue
+		}
+		pattern := strings.TrimSpace(evidence.Pattern)
+		if pattern == "" {
+			continue
+		}
+		seen[pattern] = struct{}{}
+	}
+	out := make([]string, 0, len(seen))
+	for pattern := range seen {
+		out = append(out, pattern)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func (r FlowInputProducerResolution) ProducerFlows() []string {
+	seen := map[string]struct{}{}
+	for _, evidence := range r.Evidence {
+		if !FlowInputProducerEvidenceKindIsProof(evidence.Kind) {
+			continue
+		}
+		if strings.TrimSpace(evidence.Kind) == FlowInputProducerInternalTopology {
+			continue
+		}
+		flowID := strings.TrimSpace(evidence.FlowID)
+		if flowID == "" {
+			continue
+		}
+		seen[flowID] = struct{}{}
+	}
+	out := make([]string, 0, len(seen))
+	for flowID := range seen {
+		out = append(out, flowID)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func (r FlowInputProducerResolution) AutoWireResolution() FlowInputAutoWireResolution {
+	return FlowInputAutoWireResolution{
+		EventType:     strings.TrimSpace(r.EventType),
+		Patterns:      r.ProducerPatterns(),
+		ProducerFlows: r.ProducerFlows(),
+		Evidence:      append([]FlowInputProducerEvidence{}, r.Evidence...),
+	}
+}
+
 type HandlerTransitionSemantic struct {
 	ID                   string
 	NodeID               string
@@ -1055,6 +1209,7 @@ type FlowOutputPins struct {
 type FlowInputEventPin struct {
 	Name    string               `yaml:"name"`
 	Event   string               `yaml:"event"`
+	Source  string               `yaml:"source"`
 	Address *FlowInputPinAddress `yaml:"address"`
 }
 type FlowOutputEventPin struct {

--- a/internal/runtime/contracts/workflow_contract_yaml_flow.go
+++ b/internal/runtime/contracts/workflow_contract_yaml_flow.go
@@ -267,6 +267,13 @@ func decodeFlowInputPinEventNode(node *yaml.Node) (FlowInputEventPin, error) {
 			if err := value.Decode(&out.Event); err != nil {
 				return FlowInputEventPin{}, fmt.Errorf("input event pin event: %w", err)
 			}
+		case "source":
+			if err := value.Decode(&out.Source); err != nil {
+				return FlowInputEventPin{}, fmt.Errorf("input event pin source: %w", err)
+			}
+			if source := strings.ToLower(strings.TrimSpace(out.Source)); source != "" && source != "external" {
+				return FlowInputEventPin{}, fmt.Errorf("input event pin source must be external")
+			}
 		case "address":
 			var address FlowInputPinAddress
 			if err := value.Decode(&address); err != nil {

--- a/internal/runtime/pipeline/final_flow_instance_authoring_delivery_test.go
+++ b/internal/runtime/pipeline/final_flow_instance_authoring_delivery_test.go
@@ -103,6 +103,75 @@ func TestFinalFlowInstanceAuthoringFixturePipelineDispatchPersistsSingletonConta
 	assertNoFinalFlowInstanceAuthoringContainedWorkflowInstance(t, db, workflowStore, ctx, "coordinator/lead-42")
 }
 
+func TestFinalFlowInstanceAuthoringFixturePipelineDispatchLocalizesTemplateInputConnectEvent(t *testing.T) {
+	bundle := finalflowinstanceauthoring.LoadBundle(t, finalflowinstanceauthoring.Options{})
+	source := semanticview.Wrap(bundle)
+	_, db, cleanup := testutil.StartPostgres(t)
+	t.Cleanup(cleanup)
+	pc, workflowStore := newFinalFlowInstanceAuthoringPipelineCoordinator(t, db, bundle, source)
+	ctx := testPipelineCoordinatorRunContext(t, pc)
+	instanceID := "ti-account-42"
+	flowInstance := finalflowinstanceauthoring.TemplateFlowID + "/" + instanceID
+	entityID := FlowInstanceEntityID(flowInstance)
+	if err := workflowStore.Create(ctx, WorkflowInstance{
+		InstanceID:      instanceID,
+		StorageRef:      flowInstance,
+		WorkflowName:    finalflowinstanceauthoring.TemplateFlowID,
+		WorkflowVersion: bundle.WorkflowVersion(),
+		CurrentState:    "pending",
+		Metadata: map[string]any{
+			"entity_id":   entityID,
+			"flow_path":   flowInstance,
+			"instance_id": instanceID,
+			"account_id":  "acct-42",
+		},
+	}); err != nil {
+		t.Fatalf("seed account_case workflow instance: %v", err)
+	}
+
+	target := events.RouteIdentity{
+		FlowID:       finalflowinstanceauthoring.TemplateFlowID,
+		FlowInstance: flowInstance,
+		EntityID:     entityID,
+	}
+	evt := eventtest.RootIngress(
+		uuid.NewString(),
+		events.EventType(finalflowinstanceauthoring.ProducerFlowID+"/"+finalflowinstanceauthoring.ProducerOutput),
+		finalflowinstanceauthoring.ProducerFlowID,
+		"",
+		json.RawMessage(`{"source_account_id":"acct-42","score":"91","decision":"approved"}`),
+		0,
+		testPipelineRunID,
+		"",
+		events.EnvelopeForTargetRoute(events.EventEnvelope{}, target),
+		time.Now().UTC(),
+	)
+	seedFinalFlowInstanceAuthoringEvent(t, db, ctx, evt)
+	seedFinalFlowInstanceAuthoringNodeDelivery(t, db, ctx, evt.ID(), finalflowinstanceauthoring.TemplateNodeID, target)
+
+	handled, err := pc.dispatchWorkflowNodeEventResult(ctx, evt)
+	if err != nil {
+		t.Fatalf("dispatchWorkflowNodeEventResult: %v", err)
+	}
+	if !handled {
+		t.Fatal("dispatchWorkflowNodeEventResult handled = false, want account_case handler delivery")
+	}
+	loaded, ok, err := workflowStore.Load(ctx, entityID)
+	if err != nil {
+		t.Fatalf("workflowStore.Load(%s): %v", entityID, err)
+	}
+	if !ok {
+		t.Fatalf("workflowStore.Load(%s) ok=false", entityID)
+	}
+	if loaded.WorkflowName != finalflowinstanceauthoring.TemplateFlowID || loaded.CurrentState != "reviewed" {
+		t.Fatalf("loaded account_case = storage:%q workflow:%q state:%q, want account_case/reviewed", loaded.StorageRef, loaded.WorkflowName, loaded.CurrentState)
+	}
+	if loaded.Metadata["account_id"] != "acct-42" || loaded.Metadata["score"] != "91" || loaded.Metadata["decision"] != "approved" {
+		t.Fatalf("loaded account_case metadata = %#v, want account_id/score/decision from routed payload", loaded.Metadata)
+	}
+	assertFinalFlowInstanceAuthoringDeliveryStatus(t, db, evt.ID(), finalflowinstanceauthoring.TemplateNodeID, "delivered")
+}
+
 func TestFinalFlowInstanceAuthoringFixturePipelineRejectsContainedItemDeliveryTarget(t *testing.T) {
 	bundle := finalflowinstanceauthoring.LoadBundle(t, finalflowinstanceauthoring.Options{})
 	source := semanticview.Wrap(bundle)

--- a/internal/runtime/pipeline/workflow_nodes.go
+++ b/internal/runtime/pipeline/workflow_nodes.go
@@ -123,7 +123,7 @@ func workflowNodePolicyForDelivery(source semanticview.Source, node WorkflowNode
 			return policy, true
 		}
 	}
-	return WorkflowEventPolicy{}, false
+	return deriveWorkflowEventPolicy(source, resolved.HandlerEventKey, strings.TrimSpace(resolved.Handler.AdvancesTo) != ""), true
 }
 
 func workflowNodePolicyForEventType(policies map[string]WorkflowEventPolicy, eventType string) (WorkflowEventPolicy, bool) {
@@ -279,11 +279,14 @@ func workflowNodeConcreteInstanceLocalEventType(source semanticview.Source, node
 	if staticFlowPath == "" {
 		staticFlowPath = flowID
 	}
-	if !eventTypeBelongsToNodeStaticFlow(rawEventType, staticFlowPath) {
-		return ""
-	}
 	handlerKeys := workflowNodeHandlerEventKeys(source, nodeID)
 	if len(handlerKeys) == 0 {
+		return ""
+	}
+	if localized := workflowNodeTargetRouteLocalEventType(flowID, staticFlowPath, handlerKeys, rawEventType, evt.TargetRoute()); localized != "" {
+		return localized
+	}
+	if !eventTypeBelongsToNodeStaticFlow(rawEventType, staticFlowPath) {
 		return ""
 	}
 	for _, flowInstance := range workflowNodeConcreteReceiverScopes(evt) {
@@ -300,6 +303,28 @@ func workflowNodeConcreteInstanceLocalEventType(source semanticview.Source, node
 	}
 	remainder := strings.TrimPrefix(rawEventType, staticFlowPath+"/")
 	if !strings.Contains(remainder, "/") {
+		return ""
+	}
+	for _, key := range handlerKeys {
+		key = eventidentity.Normalize(key)
+		if key != "" && strings.HasSuffix(rawEventType, "/"+key) {
+			return key
+		}
+	}
+	return ""
+}
+
+func workflowNodeTargetRouteLocalEventType(flowID, staticFlowPath string, handlerKeys []string, rawEventType string, target events.RouteIdentity) string {
+	target = target.Normalized()
+	flowID = eventidentity.Normalize(flowID)
+	staticFlowPath = eventidentity.Normalize(staticFlowPath)
+	rawEventType = eventidentity.Normalize(rawEventType)
+	if flowID == "" || staticFlowPath == "" || rawEventType == "" || len(handlerKeys) == 0 {
+		return ""
+	}
+	targetFlowID := eventidentity.Normalize(target.FlowID)
+	targetFlowInstance := eventidentity.Normalize(target.FlowInstance)
+	if targetFlowID != flowID && (targetFlowInstance == "" || !strings.HasPrefix(targetFlowInstance, staticFlowPath+"/")) {
 		return ""
 	}
 	for _, key := range handlerKeys {

--- a/internal/runtime/pipeline/workflow_nodes_test.go
+++ b/internal/runtime/pipeline/workflow_nodes_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/division-sh/swarm/internal/runtime/semanticview"
 )
 
-func TestWorkflowFlowInputProducerAliases_IncludeProducerScopedAlias(t *testing.T) {
+func TestWorkflowFlowInputProducerAliases_DoNotInferSiblingProducerAlias(t *testing.T) {
 	producer := runtimecontracts.FlowContractView{
 		Paths: runtimecontracts.FlowContractPaths{ID: "producer", Flow: "producer"},
 		Schema: runtimecontracts.FlowSchemaDocument{
@@ -50,15 +50,12 @@ func TestWorkflowFlowInputProducerAliases_IncludeProducerScopedAlias(t *testing.
 	}
 
 	aliases := workflowFlowInputProducerAliases(semanticview.Wrap(bundle), "discovery", "scan.requested")
-	for _, candidate := range aliases {
-		if candidate == "producer/scan.requested" {
-			return
-		}
+	if len(aliases) != 0 {
+		t.Fatalf("aliases = %#v, want none for retired sibling auto-wire", aliases)
 	}
-	t.Fatalf("aliases = %#v, want producer/scan.requested", aliases)
 }
 
-func TestWorkflowFlowInputProducerAliases_AutoWireCrossFlowInputPinsToProducerScopedEvent(t *testing.T) {
+func TestWorkflowFlowInputProducerAliases_DoNotAutoWireCrossFlowInputPinsToProducerScopedEvent(t *testing.T) {
 	scoring := runtimecontracts.FlowContractView{
 		Paths: runtimecontracts.FlowContractPaths{ID: "scoring", Flow: "scoring"},
 		Schema: runtimecontracts.FlowSchemaDocument{
@@ -95,12 +92,9 @@ func TestWorkflowFlowInputProducerAliases_AutoWireCrossFlowInputPinsToProducerSc
 	}
 
 	aliases := workflowFlowInputProducerAliases(semanticview.Wrap(bundle), "validation", "vertical.shortlisted")
-	for _, alias := range aliases {
-		if alias == "scoring/vertical.shortlisted" {
-			return
-		}
+	if len(aliases) != 0 {
+		t.Fatalf("aliases = %#v, want none for retired sibling auto-wire", aliases)
 	}
-	t.Fatalf("aliases = %#v, want scoring/vertical.shortlisted", aliases)
 }
 
 func TestWorkflowNodeExternalEventType_ExternalizesLocalFlowOutputs(t *testing.T) {
@@ -117,7 +111,7 @@ func TestWorkflowNodeExternalEventType_ExternalizesLocalFlowOutputs(t *testing.T
 	}
 }
 
-func TestLoadWorkflowNodes_UsesHandlerKeysForCrossFlowPinAutoWire(t *testing.T) {
+func TestLoadWorkflowNodes_DoesNotUseSiblingOutputForCrossFlowPinAutoWire(t *testing.T) {
 	producer := runtimecontracts.FlowContractView{
 		Paths: runtimecontracts.FlowContractPaths{ID: "producer", Flow: "producer"},
 		Schema: runtimecontracts.FlowSchemaDocument{
@@ -183,10 +177,12 @@ func TestLoadWorkflowNodes_UsesHandlerKeysForCrossFlowPinAutoWire(t *testing.T) 
 	}
 	for _, subscription := range nodes[0].Subscriptions {
 		if string(subscription) == "producer/scan.requested" {
-			return
+			t.Fatalf("Subscriptions = %#v, want no retired sibling auto-wire alias", nodes[0].Subscriptions)
 		}
 	}
-	t.Fatalf("Subscriptions = %#v, want producer/scan.requested", nodes[0].Subscriptions)
+	if !workflowNodeHasSubscriptionForTest(nodes[0], "scan.requested") {
+		t.Fatalf("Subscriptions = %#v, want local scan.requested", nodes[0].Subscriptions)
+	}
 }
 
 func TestLoadWorkflowNodes_UsesEffectiveFactsForMinimizedSystemNode(t *testing.T) {
@@ -290,6 +286,64 @@ func TestLoadWorkflowNodes_UsesImportBoundaryOutputAliasForWildcardParentSubscri
 	}
 	if got := resolved.HandlerEventKey; got != "parent.lead_enriched" {
 		t.Fatalf("handler event key = %q, want parent.lead_enriched", got)
+	}
+}
+
+func TestWorkflowNodeHandlerResolution_LocalizesProducerScopedEventThroughTargetRoute(t *testing.T) {
+	accountCase := runtimecontracts.FlowContractView{
+		Paths: runtimecontracts.FlowContractPaths{ID: "account_case", Flow: "account_case"},
+		Schema: runtimecontracts.FlowSchemaDocument{
+			Mode: "template",
+			Pins: runtimecontracts.FlowPins{
+				Inputs: runtimecontracts.FlowInputPins{EventPins: []runtimecontracts.FlowInputEventPin{{
+					Name:  "account_ready",
+					Event: "account.ready",
+				}}},
+			},
+		},
+		Path: "account_case",
+		Nodes: map[string]runtimecontracts.SystemNodeContract{
+			"account-case-worker": {
+				ID:           "account-case-worker",
+				SubscribesTo: []string{"account.ready"},
+				EventHandlers: map[string]runtimecontracts.SystemNodeEventHandler{
+					"account.ready": {},
+				},
+			},
+		},
+	}
+	root := runtimecontracts.FlowContractView{Children: []runtimecontracts.FlowContractView{accountCase}}
+	source := semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
+		Semantics: runtimecontracts.WorkflowSemanticView{
+			NodeHandlers: map[string]map[string]runtimecontracts.SystemNodeEventHandler{
+				"account-case-worker": {
+					"account.ready": {},
+				},
+			},
+		},
+		FlowTree: flowmodel.Tree[runtimecontracts.FlowContractView]{
+			Root: &root,
+			ByID: map[string]*runtimecontracts.FlowContractView{
+				"account_case": &root.Children[0],
+			},
+		},
+	})
+	evt := eventtest.RootIngress("", "intake/account.ready", "", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Unix(1, 0).UTC())
+	evt = eventtest.TargetRouted(evt, events.RouteIdentity{
+		FlowID:       "account_case",
+		FlowInstance: "account_case/ti-1",
+		EntityID:     "entity-1",
+	})
+	if got := workflowNodeTargetRouteLocalEventType("account_case", "account_case", []string{"account.ready"}, "intake/account.ready", evt.TargetRoute()); got != "account.ready" {
+		t.Fatalf("target-route localized event = %q, want account.ready", got)
+	}
+
+	resolved := workflowNodeEventHandlerResolutionForDelivery(source, "account-case-worker", evt)
+	if !resolved.Matched {
+		t.Fatal("expected account-case-worker handler to resolve through target route")
+	}
+	if got := resolved.HandlerEventKey; got != "account.ready" {
+		t.Fatalf("handler event key = %q, want account.ready", got)
 	}
 }
 

--- a/internal/runtime/runforkadmission/contract_frontier_test.go
+++ b/internal/runtime/runforkadmission/contract_frontier_test.go
@@ -314,7 +314,7 @@ func testContractFrontierSource(nodeID string) semanticview.Source {
 		Nodes: map[string]runtimecontracts.SystemNodeContract{
 			nodeID: {
 				ID:           nodeID,
-				SubscribesTo: []string{"scan.requested"},
+				SubscribesTo: []string{"producer/scan.requested"},
 			},
 		},
 	}
@@ -323,6 +323,10 @@ func testContractFrontierSource(nodeID string) semanticview.Source {
 		Semantics: runtimecontracts.WorkflowSemanticView{
 			Name:    "test-workflow",
 			Version: "v-test",
+			CompositionConnects: []runtimecontracts.FlowPackageConnect{{
+				From: "producer.scan.requested",
+				To:   "consumer.scan.requested",
+			}},
 		},
 		FlowTree: flowmodel.Tree[runtimecontracts.FlowContractView]{
 			Root: &root,

--- a/internal/runtime/semanticview/flow_input_producer.go
+++ b/internal/runtime/semanticview/flow_input_producer.go
@@ -1,0 +1,341 @@
+package semanticview
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
+	"github.com/division-sh/swarm/internal/runtime/core/eventidentity"
+)
+
+func ResolveFlowInputProducer(source Source, flowID, eventType string) runtimecontracts.FlowInputProducerResolution {
+	return ResolveFlowInputProducerWithOptions(source, flowID, eventType, runtimecontracts.FlowInputProducerResolutionOptions{})
+}
+
+func ResolveFlowInputProducerWithOptions(source Source, flowID, eventType string, opts runtimecontracts.FlowInputProducerResolutionOptions) runtimecontracts.FlowInputProducerResolution {
+	flowID = strings.TrimSpace(flowID)
+	eventType = eventidentity.Normalize(eventType)
+	out := runtimecontracts.FlowInputProducerResolution{FlowID: flowID, EventType: eventType}
+	appendEvidence := func(evidence runtimecontracts.FlowInputProducerEvidence) {
+		evidence.Kind = strings.TrimSpace(evidence.Kind)
+		evidence.FlowID = strings.TrimSpace(evidence.FlowID)
+		evidence.EventType = eventidentity.Normalize(evidence.EventType)
+		evidence.Pin = strings.TrimSpace(evidence.Pin)
+		evidence.Pattern = eventidentity.Normalize(evidence.Pattern)
+		evidence.Detail = strings.TrimSpace(evidence.Detail)
+		if evidence.Kind == "" {
+			return
+		}
+		for _, existing := range out.Evidence {
+			if existing.Kind == evidence.Kind &&
+				existing.FlowID == evidence.FlowID &&
+				existing.EventType == evidence.EventType &&
+				existing.Pin == evidence.Pin &&
+				existing.Pattern == evidence.Pattern &&
+				existing.Detail == evidence.Detail {
+				return
+			}
+		}
+		out.Evidence = append(out.Evidence, evidence)
+	}
+
+	if source == nil || eventType == "" {
+		appendEvidence(runtimecontracts.FlowInputProducerEvidence{
+			Kind:   runtimecontracts.FlowInputProducerInvalidContext,
+			Detail: "semantic source and input event are required",
+		})
+		return out
+	}
+	isInputEvent := source.FlowHasInputEvent(flowID, eventType)
+	if !isInputEvent && !opts.AllowNonInputEvent {
+		appendEvidence(runtimecontracts.FlowInputProducerEvidence{
+			Kind:      runtimecontracts.FlowInputProducerInvalidContext,
+			EventType: eventType,
+			Detail:    "event is not declared as a flow input",
+		})
+		return out
+	}
+
+	if isInputEvent && !opts.AllowNonInputEvent {
+		appendBoundaryIngressEvidence(source, flowID, eventType, opts, appendEvidence)
+		appendParentConnectEvidence(source, flowID, eventType, appendEvidence)
+	} else {
+		if isInputEvent {
+			appendParentConnectEvidence(source, flowID, eventType, appendEvidence)
+		}
+		appendExternalMetadataEvidence(source, flowID, eventType, appendEvidence)
+	}
+	appendHarnessInjectionEvidence(flowID, eventType, opts, appendEvidence)
+	appendPlatformSourceEvidence(source, flowID, eventType, appendEvidence)
+	appendInternalTopologyEvidence(source, flowID, eventType, appendEvidence)
+
+	sort.SliceStable(out.Evidence, func(i, j int) bool {
+		left := flowInputProducerEvidenceSortKey(out.Evidence[i])
+		right := flowInputProducerEvidenceSortKey(out.Evidence[j])
+		return left < right
+	})
+	return out
+}
+
+func appendBoundaryIngressEvidence(source Source, flowID, eventType string, opts runtimecontracts.FlowInputProducerResolutionOptions, appendEvidence func(runtimecontracts.FlowInputProducerEvidence)) {
+	if flowID == "" && !opts.AllowNonInputEvent {
+		appendEvidence(runtimecontracts.FlowInputProducerEvidence{
+			Kind:      runtimecontracts.FlowInputProducerBoundaryExternalIngress,
+			EventType: eventType,
+			Detail:    "root input pin is externally ingressible",
+		})
+		return
+	}
+	for _, pin := range flowInputPinsForEvent(source, flowID, eventType) {
+		if strings.TrimSpace(pin.Source) != "external" {
+			continue
+		}
+		appendEvidence(runtimecontracts.FlowInputProducerEvidence{
+			Kind:      runtimecontracts.FlowInputProducerBoundaryIntrinsicIngress,
+			EventType: eventType,
+			Pin:       pin.PinName(),
+			Detail:    "input pin declares source: external",
+		})
+	}
+}
+
+func appendParentConnectEvidence(source Source, flowID, eventType string, appendEvidence func(runtimecontracts.FlowInputProducerEvidence)) {
+	for _, alias := range ImportBoundaryInputAliases(source, flowID, eventType) {
+		appendEvidence(runtimecontracts.FlowInputProducerEvidence{
+			Kind:      runtimecontracts.FlowInputProducerBoundaryParentConnect,
+			FlowID:    strings.TrimSpace(alias.FlowID),
+			EventType: alias.ParentEvent,
+			Pin:       alias.Pin,
+			Pattern:   alias.EventPattern,
+			Detail:    "import-boundary input bind",
+		})
+	}
+	for _, pin := range flowInputPinsForEvent(source, flowID, eventType) {
+		connects := source.CompositionConnectsTo(flowID, pin.PinName())
+		if len(connects) == 0 {
+			continue
+		}
+		for _, connect := range connects {
+			ref, _ := connect.FromRef()
+			appendEvidence(runtimecontracts.FlowInputProducerEvidence{
+				Kind:      runtimecontracts.FlowInputProducerBoundaryParentConnect,
+				FlowID:    ref.FlowID,
+				EventType: eventType,
+				Pin:       pin.PinName(),
+				Detail:    fmt.Sprintf("parent connect from %s", strings.TrimSpace(connect.From)),
+			})
+		}
+	}
+}
+
+func appendHarnessInjectionEvidence(flowID, eventType string, opts runtimecontracts.FlowInputProducerResolutionOptions, appendEvidence func(runtimecontracts.FlowInputProducerEvidence)) {
+	for _, injection := range opts.HarnessInjections {
+		if strings.TrimSpace(injection.FlowID) != flowID || eventidentity.Normalize(injection.EventType) != eventType {
+			continue
+		}
+		appendEvidence(runtimecontracts.FlowInputProducerEvidence{
+			Kind:      runtimecontracts.FlowInputProducerBoundaryHarnessInjection,
+			FlowID:    flowID,
+			EventType: eventType,
+			Detail:    "explicit validation harness injection",
+		})
+	}
+}
+
+func appendPlatformSourceEvidence(source Source, flowID, eventType string, appendEvidence func(runtimecontracts.FlowInputProducerEvidence)) {
+	if source == nil {
+		return
+	}
+	candidates := uniqueFlowInputProducerEvents(eventType, source.ResolveFlowEventReference(flowID, eventType))
+	for _, candidate := range candidates {
+		if runtimecontracts.PlatformEventCatalogContains(source.PlatformSpec(), candidate) {
+			appendEvidence(runtimecontracts.FlowInputProducerEvidence{
+				Kind:      runtimecontracts.FlowInputProducerPlatformSource,
+				EventType: candidate,
+				Detail:    "platform event catalog",
+			})
+			return
+		}
+	}
+	entry, _, ok := source.ResolveFlowEventCatalogEntry(flowID, eventType)
+	if ok && eventMetadataPlatformSource(entry.SwarmSource()) {
+		appendEvidence(runtimecontracts.FlowInputProducerEvidence{
+			Kind:      runtimecontracts.FlowInputProducerPlatformSource,
+			EventType: eventType,
+			Detail:    "event metadata swarm.source: platform",
+		})
+	}
+}
+
+func appendExternalMetadataEvidence(source Source, flowID, eventType string, appendEvidence func(runtimecontracts.FlowInputProducerEvidence)) {
+	entry, _, ok := source.ResolveFlowEventCatalogEntry(flowID, eventType)
+	if !ok || !eventMetadataExternalSource(entry.SwarmSource()) {
+		return
+	}
+	appendEvidence(runtimecontracts.FlowInputProducerEvidence{
+		Kind:      runtimecontracts.FlowInputProducerBoundaryExternalIngress,
+		EventType: eventType,
+		Detail:    "event metadata swarm.source: external",
+	})
+}
+
+func appendInternalTopologyEvidence(source Source, flowID, eventType string, appendEvidence func(runtimecontracts.FlowInputProducerEvidence)) {
+	localEvent := eventidentity.Normalize(eventType)
+	canonicalEvent := eventidentity.Normalize(source.ResolveFlowEventReference(flowID, eventType))
+	if canonicalEvent == "" {
+		canonicalEvent = eventType
+	}
+	if schema, ok := source.FlowSchemaByID(flowID); ok {
+		if flowInputProducerEventMatches(source, flowID, localEvent, canonicalEvent, schema.AutoEmitOnCreate.Event) {
+			detail := "root auto_emit_on_create"
+			if flowID != "" {
+				detail = fmt.Sprintf("flow %s auto_emit_on_create", flowID)
+			}
+			appendEvidence(runtimecontracts.FlowInputProducerEvidence{
+				Kind:      runtimecontracts.FlowInputProducerInternalTopology,
+				EventType: eventType,
+				Detail:    detail,
+			})
+		}
+	}
+	for _, scope := range source.FlowScopes() {
+		producerFlowID := strings.TrimSpace(scope.ID)
+		if producerFlowID == "" || producerFlowID == flowID {
+			continue
+		}
+		for _, output := range scope.OutputEvents {
+			if !flowInputProducerEventMatches(source, producerFlowID, localEvent, canonicalEvent, output) {
+				continue
+			}
+			appendEvidence(runtimecontracts.FlowInputProducerEvidence{
+				Kind:      runtimecontracts.FlowInputProducerInternalTopology,
+				EventType: eventType,
+				Detail:    fmt.Sprintf("sibling flow %s output pin", producerFlowID),
+			})
+			break
+		}
+	}
+	for nodeID, node := range source.NodeEntries() {
+		nodeID = strings.TrimSpace(nodeID)
+		nodeSource, _ := source.NodeContractSource(nodeID)
+		nodeFlowID := strings.TrimSpace(nodeSource.FlowID)
+		for handlerEvent, handler := range node.EventHandlers {
+			for _, emitted := range runtimecontracts.HandlerEmitEvents(handler) {
+				if !flowInputProducerEventMatches(source, nodeFlowID, localEvent, canonicalEvent, emitted) {
+					continue
+				}
+				appendEvidence(runtimecontracts.FlowInputProducerEvidence{
+					Kind:      runtimecontracts.FlowInputProducerInternalTopology,
+					EventType: eventType,
+					Detail:    fmt.Sprintf("node %s handler %s emits", nodeID, strings.TrimSpace(handlerEvent)),
+				})
+			}
+		}
+	}
+	for agentID, agent := range source.AgentEntries() {
+		agentID = strings.TrimSpace(agentID)
+		agentSource, _ := source.AgentContractSource(agentID)
+		agentFlowID := strings.TrimSpace(agentSource.FlowID)
+		for _, emitted := range agent.EmitEvents {
+			if !flowInputProducerEventMatches(source, agentFlowID, localEvent, canonicalEvent, emitted) {
+				continue
+			}
+			appendEvidence(runtimecontracts.FlowInputProducerEvidence{
+				Kind:      runtimecontracts.FlowInputProducerInternalTopology,
+				EventType: eventType,
+				Detail:    fmt.Sprintf("agent %s emit_events", agentID),
+			})
+		}
+	}
+	for _, timer := range source.WorkflowTimers() {
+		timerFlowID := strings.TrimSpace(timer.FlowID)
+		if !flowInputProducerEventMatches(source, timerFlowID, localEvent, canonicalEvent, timer.Event) {
+			continue
+		}
+		detail := fmt.Sprintf("timer in flow %s", timerFlowID)
+		if timerFlowID == "" {
+			detail = "root timer"
+		}
+		if timerID := strings.TrimSpace(timer.ID); timerID != "" {
+			detail += " " + timerID
+		}
+		appendEvidence(runtimecontracts.FlowInputProducerEvidence{
+			Kind:      runtimecontracts.FlowInputProducerInternalTopology,
+			EventType: eventType,
+			Detail:    detail,
+		})
+	}
+}
+
+func flowInputPinsForEvent(source Source, flowID, eventType string) []runtimecontracts.FlowInputEventPin {
+	eventType = eventidentity.Normalize(eventType)
+	if source == nil || eventType == "" {
+		return nil
+	}
+	out := make([]runtimecontracts.FlowInputEventPin, 0)
+	for _, pin := range source.FlowInputEventPins(flowID) {
+		if eventidentity.Normalize(pin.EventType()) != eventType && eventidentity.Normalize(pin.PinName()) != eventType {
+			continue
+		}
+		out = append(out, pin)
+	}
+	return out
+}
+
+func flowInputProducerEventMatches(source Source, flowID, localEvent, canonicalEvent, candidate string) bool {
+	candidate = eventidentity.Normalize(candidate)
+	localEvent = eventidentity.Normalize(localEvent)
+	canonicalEvent = eventidentity.Normalize(canonicalEvent)
+	if candidate == "" || canonicalEvent == "" {
+		return false
+	}
+	if candidate == localEvent || eventidentity.MatchPattern(localEvent, candidate) || eventidentity.MatchPattern(candidate, localEvent) {
+		return true
+	}
+	if candidate == canonicalEvent {
+		return true
+	}
+	if source == nil {
+		return false
+	}
+	resolved := eventidentity.Normalize(source.ResolveFlowEventReference(flowID, candidate))
+	return resolved == canonicalEvent ||
+		eventidentity.MatchPattern(canonicalEvent, resolved) ||
+		eventidentity.MatchPattern(resolved, canonicalEvent)
+}
+
+func uniqueFlowInputProducerEvents(values ...string) []string {
+	seen := map[string]struct{}{}
+	for _, value := range values {
+		value = eventidentity.Normalize(value)
+		if value != "" {
+			seen[value] = struct{}{}
+		}
+	}
+	out := make([]string, 0, len(seen))
+	for value := range seen {
+		out = append(out, value)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func eventMetadataPlatformSource(source string) bool {
+	return strings.HasPrefix(strings.ToLower(strings.TrimSpace(source)), "platform")
+}
+
+func eventMetadataExternalSource(source string) bool {
+	return strings.HasPrefix(strings.ToLower(strings.TrimSpace(source)), "external")
+}
+
+func flowInputProducerEvidenceSortKey(evidence runtimecontracts.FlowInputProducerEvidence) string {
+	return strings.Join([]string{
+		strings.TrimSpace(evidence.Kind),
+		strings.TrimSpace(evidence.FlowID),
+		strings.TrimSpace(evidence.EventType),
+		strings.TrimSpace(evidence.Pin),
+		strings.TrimSpace(evidence.Pattern),
+		strings.TrimSpace(evidence.Detail),
+	}, "\x00")
+}

--- a/internal/runtime/semanticview/flow_input_producer_test.go
+++ b/internal/runtime/semanticview/flow_input_producer_test.go
@@ -1,0 +1,197 @@
+package semanticview
+
+import (
+	"testing"
+
+	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
+	"github.com/division-sh/swarm/internal/runtime/flowmodel"
+	"gopkg.in/yaml.v3"
+)
+
+func TestResolveFlowInputProducer_ClassifiesIntrinsicInputPinSource(t *testing.T) {
+	source := flowInputProducerFixture(runtimecontracts.FlowInputEventPin{
+		Name:   "work.requested",
+		Event:  "work.requested",
+		Source: "external",
+	}, nil)
+
+	resolution := ResolveFlowInputProducer(source, "worker", "work.requested")
+
+	if !resolution.HasEvidenceKind(runtimecontracts.FlowInputProducerBoundaryIntrinsicIngress) {
+		t.Fatalf("evidence = %#v, want intrinsic ingress", resolution.Evidence)
+	}
+	if len(resolution.ProducerPatterns()) != 0 {
+		t.Fatalf("patterns = %#v, want none for intrinsic ingress", resolution.ProducerPatterns())
+	}
+}
+
+func TestResolveFlowInputProducer_ClassifiesRootBoundaryExternalIngress(t *testing.T) {
+	bundle := &runtimecontracts.WorkflowContractBundle{
+		RootSchema: &runtimecontracts.FlowSchemaDocument{
+			Pins: runtimecontracts.FlowPins{
+				Inputs: runtimecontracts.FlowInputPins{Events: []string{"work.requested"}},
+			},
+		},
+	}
+
+	resolution := ResolveFlowInputProducer(Wrap(bundle), "", "work.requested")
+
+	if !resolution.HasEvidenceKind(runtimecontracts.FlowInputProducerBoundaryExternalIngress) {
+		t.Fatalf("evidence = %#v, want boundary external ingress", resolution.Evidence)
+	}
+}
+
+func TestResolveFlowInputProducer_ClassifiesParentConnectWithoutRoutePattern(t *testing.T) {
+	source := flowInputProducerFixture(runtimecontracts.FlowInputEventPin{
+		Name:  "work.requested",
+		Event: "work.requested",
+	}, []runtimecontracts.FlowPackageConnect{{From: ".work.requested", To: "worker.work.requested"}})
+
+	resolution := ResolveFlowInputProducer(source, "worker", "work.requested")
+
+	if !resolution.HasEvidenceKind(runtimecontracts.FlowInputProducerBoundaryParentConnect) {
+		t.Fatalf("evidence = %#v, want parent connect", resolution.Evidence)
+	}
+	if len(resolution.ProducerPatterns()) != 0 {
+		t.Fatalf("patterns = %#v, want none for direct parent connect route proof", resolution.ProducerPatterns())
+	}
+}
+
+func TestResolveFlowInputProducer_ClassifiesHarnessInjection(t *testing.T) {
+	source := flowInputProducerFixture(runtimecontracts.FlowInputEventPin{
+		Name:  "work.requested",
+		Event: "work.requested",
+	}, nil)
+
+	resolution := ResolveFlowInputProducerWithOptions(source, "worker", "work.requested", runtimecontracts.FlowInputProducerResolutionOptions{
+		HarnessInjections: []runtimecontracts.FlowInputProducerInjection{{FlowID: "worker", EventType: "work.requested"}},
+	})
+
+	if !resolution.HasEvidenceKind(runtimecontracts.FlowInputProducerBoundaryHarnessInjection) {
+		t.Fatalf("evidence = %#v, want harness injection", resolution.Evidence)
+	}
+}
+
+func TestResolveFlowInputProducer_ClassifiesPlatformSource(t *testing.T) {
+	source := flowInputProducerFixture(runtimecontracts.FlowInputEventPin{
+		Name:  "platform.runtime_log",
+		Event: "platform.runtime_log",
+	}, nil)
+
+	resolution := ResolveFlowInputProducer(source, "worker", "platform.runtime_log")
+
+	if !resolution.HasEvidenceKind(runtimecontracts.FlowInputProducerPlatformSource) {
+		t.Fatalf("evidence = %#v, want platform source", resolution.Evidence)
+	}
+}
+
+func TestResolveFlowInputProducer_ClassifiesInternalTopologyWithoutAutoWirePattern(t *testing.T) {
+	source := flowInputProducerFixture(runtimecontracts.FlowInputEventPin{
+		Name:  "work.requested",
+		Event: "work.requested",
+	}, nil)
+
+	resolution := ResolveFlowInputProducer(source, "worker", "work.requested")
+
+	if !resolution.HasEvidenceKind(runtimecontracts.FlowInputProducerInternalTopology) {
+		t.Fatalf("evidence = %#v, want internal topology producer", resolution.Evidence)
+	}
+	if len(resolution.ProducerPatterns()) != 0 {
+		t.Fatalf("patterns = %#v, want no sibling-output auto-wire pattern", resolution.ProducerPatterns())
+	}
+	if got := resolution.AutoWireResolution().ProducerFlows; len(got) != 0 {
+		t.Fatalf("ProducerFlows = %#v, want none for internal topology proof", got)
+	}
+}
+
+func TestResolveFlowInputProducer_ClassifiesAutoEmitOnCreateAsInternalTopology(t *testing.T) {
+	source := flowInputProducerFixture(runtimecontracts.FlowInputEventPin{
+		Name:  "work.created",
+		Event: "work.created",
+	}, nil)
+	bundle, ok := Bundle(source)
+	if !ok || bundle == nil {
+		t.Fatal("expected bundle source")
+	}
+	worker := bundle.FlowSchemas["worker"]
+	worker.AutoEmitOnCreate = runtimecontracts.AutoEmitOnCreateContract{Event: "work.created"}
+	worker.Pins.Inputs.Events = []string{"work.created"}
+	worker.Pins.Inputs.EventPins = []runtimecontracts.FlowInputEventPin{{
+		Name:  "work.created",
+		Event: "work.created",
+	}}
+	bundle.FlowSchemas["worker"] = worker
+	bundle.FlowTree.ByID["worker"].Schema = worker
+
+	resolution := ResolveFlowInputProducer(source, "worker", "work.created")
+
+	if !resolution.HasEvidenceKind(runtimecontracts.FlowInputProducerInternalTopology) {
+		t.Fatalf("evidence = %#v, want auto_emit_on_create internal topology proof", resolution.Evidence)
+	}
+}
+
+func TestResolveFlowInputProducer_ReportsMissingAndInvalidContext(t *testing.T) {
+	source := flowInputProducerFixture(runtimecontracts.FlowInputEventPin{
+		Name:  "work.requested",
+		Event: "work.requested",
+	}, nil)
+
+	missing := ResolveFlowInputProducer(source, "worker", "work.missing")
+	if missing.HasEvidence() || !missing.HasEvidenceKind(runtimecontracts.FlowInputProducerInvalidContext) {
+		t.Fatalf("missing input evidence = %#v, want invalid context outcome without proof", missing.Evidence)
+	}
+
+	noProducer := flowInputProducerFixture(runtimecontracts.FlowInputEventPin{
+		Name:  "work.unproduced",
+		Event: "work.unproduced",
+	}, nil)
+	resolution := ResolveFlowInputProducer(noProducer, "worker", "work.unproduced")
+	if resolution.HasEvidence() {
+		t.Fatalf("evidence = %#v, want no producer proof", resolution.Evidence)
+	}
+}
+
+func flowInputProducerFixture(inputPin runtimecontracts.FlowInputEventPin, connects []runtimecontracts.FlowPackageConnect) Source {
+	producer := runtimecontracts.FlowContractView{
+		Paths: runtimecontracts.FlowContractPaths{ID: "producer", Flow: "producer"},
+		Schema: runtimecontracts.FlowSchemaDocument{
+			Pins: runtimecontracts.FlowPins{
+				Outputs: runtimecontracts.FlowOutputPins{Events: []string{"work.requested"}},
+			},
+		},
+		Path: "producer",
+	}
+	worker := runtimecontracts.FlowContractView{
+		Paths: runtimecontracts.FlowContractPaths{ID: "worker", Flow: "worker"},
+		Schema: runtimecontracts.FlowSchemaDocument{
+			Pins: runtimecontracts.FlowPins{
+				Inputs: runtimecontracts.FlowInputPins{
+					Events:    []string{inputPin.EventType()},
+					EventPins: []runtimecontracts.FlowInputEventPin{inputPin},
+				},
+			},
+		},
+		Path: "worker",
+	}
+	root := runtimecontracts.FlowContractView{Children: []runtimecontracts.FlowContractView{producer, worker}}
+	bundle := &runtimecontracts.WorkflowContractBundle{
+		FlowTree: flowmodel.Tree[runtimecontracts.FlowContractView]{
+			Root: &root,
+			ByID: map[string]*runtimecontracts.FlowContractView{
+				"producer": &root.Children[0],
+				"worker":   &root.Children[1],
+			},
+		},
+		FlowSchemas: map[string]runtimecontracts.FlowSchemaDocument{
+			"producer": producer.Schema,
+			"worker":   worker.Schema,
+		},
+		Semantics: runtimecontracts.WorkflowSemanticView{
+			CompositionConnects: connects,
+		},
+	}
+	bundle.Platform.PlatformEvents.Catalog = map[string]yaml.Node{
+		"platform.runtime_log": {},
+	}
+	return Wrap(bundle)
+}

--- a/internal/runtime/semanticview/import_boundary_aliases.go
+++ b/internal/runtime/semanticview/import_boundary_aliases.go
@@ -65,29 +65,7 @@ func ImportBoundaryFlowSites(scope ProjectScope) []ImportBoundaryFlowSite {
 }
 
 func ResolveFlowInputAutoWire(source Source, targetFlowID, eventType string) runtimecontracts.FlowInputAutoWireResolution {
-	targetFlowID = strings.TrimSpace(targetFlowID)
-	eventType = eventidentity.Normalize(eventType)
-	if source == nil || targetFlowID == "" || eventType == "" || !source.FlowHasInputEvent(targetFlowID, eventType) {
-		return runtimecontracts.FlowInputAutoWireResolution{EventType: eventType}
-	}
-	if importRequiresInput(source, targetFlowID, eventType) {
-		out := runtimecontracts.FlowInputAutoWireResolution{EventType: eventType}
-		seen := map[string]struct{}{}
-		for _, alias := range ImportBoundaryInputAliases(source, targetFlowID, eventType) {
-			pattern := eventidentity.Normalize(alias.EventPattern)
-			if pattern == "" {
-				continue
-			}
-			if _, ok := seen[pattern]; ok {
-				continue
-			}
-			seen[pattern] = struct{}{}
-			out.Patterns = append(out.Patterns, pattern)
-		}
-		sort.Strings(out.Patterns)
-		return out
-	}
-	return rawResolveFlowInputAutoWire(source, targetFlowID, eventType)
+	return ResolveFlowInputProducer(source, targetFlowID, eventType).AutoWireResolution()
 }
 
 func FlowInputProducerPatterns(source Source, targetFlowID, eventType string) []string {
@@ -405,51 +383,6 @@ func importRequiresInput(source Source, flowID, eventType string) bool {
 		}
 	}
 	return false
-}
-
-func rawResolveFlowInputAutoWire(source Source, targetFlowID, eventType string) runtimecontracts.FlowInputAutoWireResolution {
-	if bundle, ok := Bundle(source); ok && bundle != nil {
-		return bundle.ResolveFlowInputAutoWire(targetFlowID, eventType)
-	}
-	out := runtimecontracts.FlowInputAutoWireResolution{EventType: eventidentity.Normalize(eventType)}
-	if source == nil || targetFlowID == "" || out.EventType == "" || !source.FlowHasInputEvent(targetFlowID, out.EventType) {
-		return out
-	}
-	seenPatterns := map[string]struct{}{}
-	appendPattern := func(value string) {
-		value = eventidentity.Normalize(value)
-		if value == "" {
-			return
-		}
-		if _, ok := seenPatterns[value]; ok {
-			return
-		}
-		seenPatterns[value] = struct{}{}
-		out.Patterns = append(out.Patterns, value)
-	}
-	for _, scope := range source.ProjectScopes() {
-		if _, ok := scope.Events[out.EventType]; ok {
-			appendPattern(out.EventType)
-		}
-	}
-	seenFlows := map[string]struct{}{}
-	for _, scope := range source.FlowScopes() {
-		flowID := strings.TrimSpace(scope.ID)
-		if flowID == "" || flowID == targetFlowID || !source.FlowHasOutputEvent(flowID, out.EventType) {
-			continue
-		}
-		if _, ok := seenFlows[flowID]; ok {
-			continue
-		}
-		seenFlows[flowID] = struct{}{}
-		out.ProducerFlows = append(out.ProducerFlows, flowID)
-	}
-	sort.Strings(out.ProducerFlows)
-	if len(out.ProducerFlows) == 1 {
-		appendPattern(importBoundaryFlowEventReference(source, out.ProducerFlows[0], out.EventType))
-	}
-	sort.Strings(out.Patterns)
-	return out
 }
 
 func importBoundaryScopeIndexes(source Source) (map[string]ProjectScope, map[string][]FlowScope) {

--- a/internal/runtime/semanticview/import_boundary_aliases_test.go
+++ b/internal/runtime/semanticview/import_boundary_aliases_test.go
@@ -15,6 +15,10 @@ func TestImportBoundaryPinAliasesResolveInputAndOutputBindings(t *testing.T) {
 	if got, want := resolution.Patterns, []string{"parent.lead_captured"}; len(got) != len(want) || got[0] != want[0] {
 		t.Fatalf("ResolveFlowInputAutoWire patterns = %#v, want %#v", got, want)
 	}
+	proof := runtimecontracts.FlowInputProducerResolution{Evidence: resolution.Evidence}
+	if !proof.HasEvidenceKind(runtimecontracts.FlowInputProducerBoundaryParentConnect) {
+		t.Fatalf("ResolveFlowInputAutoWire evidence = %#v, want parent connect", resolution.Evidence)
+	}
 	if !ImportBoundaryInputAliasRequired(source, "worker", "work.requested") {
 		t.Fatal("expected work.requested to require import-boundary input alias")
 	}

--- a/internal/runtime/testfixtures/fanoutpinroute/fixture.go
+++ b/internal/runtime/testfixtures/fanoutpinroute/fixture.go
@@ -94,6 +94,7 @@ pins:
     events:
       - name: batch_classify_completed
         event: batch.classify.completed
+        source: external
   outputs:
 `+coordinatorOutputPinYAML(opts))
 	writeFile(t, filepath.Join(root, "flows", "coordinator", "policy.yaml"), "{}\n")

--- a/internal/runtime/testfixtures/finalflowinstanceauthoring/fixture.go
+++ b/internal/runtime/testfixtures/finalflowinstanceauthoring/fixture.go
@@ -171,6 +171,7 @@ pins:
     events:
       - name: request_received
         event: request.received
+        source: external
   outputs:
     events:
       - name: account_ready
@@ -313,6 +314,7 @@ pins:
     events:
       - name: lead_observed
         event: lead.observed
+        source: external
   outputs:
     events: []
 `)

--- a/internal/runtime/testfixtures/singletoncoordinatorpilot/fixture.go
+++ b/internal/runtime/testfixtures/singletoncoordinatorpilot/fixture.go
@@ -84,6 +84,7 @@ pins:
     events:
       - name: lead_observed
         event: lead.observed
+        source: external
   outputs:
     events: []
 `)

--- a/internal/runtime/testfixtures/templateflowpilot/fixture.go
+++ b/internal/runtime/testfixtures/templateflowpilot/fixture.go
@@ -86,6 +86,7 @@ pins:
     events:
       - name: intake_received
         event: intake.received
+        source: external
   outputs:
     events:
       - name: validation_requested

--- a/internal/runtime/workflow_validation.go
+++ b/internal/runtime/workflow_validation.go
@@ -7,6 +7,7 @@ import (
 
 	runtimeauthority "github.com/division-sh/swarm/internal/runtime/authority"
 	runtimebootverify "github.com/division-sh/swarm/internal/runtime/bootverify"
+	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
 	runtimecredentials "github.com/division-sh/swarm/internal/runtime/credentials"
 	llmselection "github.com/division-sh/swarm/internal/runtime/llm/selection"
 	runtimemanagedcredentials "github.com/division-sh/swarm/internal/runtime/managedcredentials"
@@ -25,6 +26,7 @@ type WorkflowContractValidationOptions struct {
 	ValidateLLMModelResolution     bool
 	LLMProfile                     llmselection.Profile
 	ModelAliases                   llmselection.ModelAliases
+	HarnessInjections              []runtimecontracts.FlowInputProducerInjection
 }
 
 type WorkflowContractValidationResult struct {
@@ -61,6 +63,7 @@ func ValidateWorkflowContractSurface(ctx context.Context, source semanticview.So
 		ValidateModelResolution: opts.ValidateLLMModelResolution,
 		LLMProfile:              opts.LLMProfile,
 		ModelAliases:            opts.ModelAliases,
+		HarnessInjections:       opts.HarnessInjections,
 	})
 	if result.BootReport.HasErrors() {
 		return result, fmt.Errorf("boot verification failed:\n%s", formatWorkflowValidationFindings(result.BootReport.Errors(), true))

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -498,6 +498,21 @@ contract_formats:
         flow_model.flow_package.composition_routing and engine.cross_flow_routing for details.
         Explicit scoped subscriptions (e.g., scoring/vertical.shortlisted) remain an escape hatch for
         cases outside the pin/connect interface.'
+      input_source_resolution:
+        canonical_owner: internal/runtime/semanticview.ResolveFlowInputProducer
+        rule: |
+          Flow input producer proof is resolved once through a typed source taxonomy and consumed by boot verification,
+          RouteTable derivation, and workflow-node subscription projection. The accepted proof classes are boundary external
+          ingress, intrinsic input-pin ingress (`source: external` on the input pin), parent connect, explicit harness
+          injection, platform source, and internal topology producer. Internal topology producer proof proves the event is
+          produced inside the authored topology by sibling flow outputs, root/flow agent or node emits, timers, fan_out,
+          or root/flow `auto_emit_on_create`, but it MUST NOT generate producer-scoped auto-wire route patterns.
+          Direct parent connect proof proves the input is satisfied, but concrete delivery authority remains the connect
+          RoutePlan, not a raw subscription fallback.
+        retired_paths: |
+          Unique same-name sibling output-pin inference is retired as producer-pattern authority. `swarm.source: external`
+          on events.yaml is not input-pin producer proof; it remains external metadata for non-input event roles such as
+          dead-event and accumulator producer-source checks.
       delivery_rules:
         owning_node: If a system node subscribes_to the event → that node owns it
         dual_delivery: If a node AND agents subscribe → route to both
@@ -3426,8 +3441,8 @@ engine:
       emit_events: Always local names. The platform externalizes at emission time.
       events_yaml: Always local names. Flow-scoped at load time.
       pins: Always local names. Parent connect binds output pins to receiver input pins for topology; same-name pin matching
-        is only a safe analyzer inference when unambiguous. Target rules materialize concrete instance recipients after
-        connect lowering or explicit escape-hatch targeting.
+        is not route or producer authority. Target rules materialize concrete instance recipients after connect lowering or
+        explicit escape-hatch targeting.
     wildcards:
       description: Pattern matching for subscriptions across flow instances. Wildcards do not override target filtering when event.target or event.target_set is set.
       patterns:
@@ -3568,8 +3583,8 @@ engine:
         as absolute from root. Wildcards expand to matching paths.
     - step: 7
       name: validate_pins
-      action: 'For each flow: required input event pins must be satisfied by parent connect topology, safe unambiguous inference,
-        explicit external source metadata, or another accepted producer path. Pin-declared output emits consume
+      action: 'For each flow: required input event pins must be satisfied by the canonical input-source resolver: parent connect
+        topology, input pin source:external, explicit harness injection, platform source, or internal topology producer. Pin-declared output emits consume
         flow_model.flow_package.composition_routing: lowered parent connect supplies singular event.target or fan-out
         event.target_set route facts; explicit target is only the dynamic escape hatch; structural ParentRoute and eligible
         static-child delivery-entity routing are fallback paths when no lowered connect route applies; broadcast:true is the
@@ -5643,10 +5658,10 @@ engine:
       severity: warning
       scope: per-flow
       trigger: 'A flow''s required input event pin (from schema.yaml pins.inputs.events) has no satisfiable authored producer
-        path on the static verify surface. The warning checks parent package.yaml connect entries, safe same-name sibling
-        flow output-pin inference, root agent emit_events, root node handler emit sites, exact platform_events catalog matches,
-        swarm.source values starting with external, and same-flow timer declarations. It does not use produces or swarm.status:
-        planned as input-pin proof.'
+        source on the static verify surface. The warning consumes internal/runtime/semanticview.ResolveFlowInputProducer
+        evidence: boundary external ingress, intrinsic input-pin source:external, parent connect, explicit harness injection,
+        platform source, and internal topology producer. It does not use unique same-name sibling output-pin inference as
+        producer-pattern authority, events.yaml swarm.source:external as input-pin proof, produces, or swarm.status: planned.'
       when: boot-only
     - id: accumulate_all_bounded_escape
       severity: warning
@@ -5664,10 +5679,11 @@ engine:
       severity: hard_invalidity
       scope: per-handler
       trigger: A handler declares an accumulator over an input event but the authored bundle has no accepted static producer
-        or source path for that event. Accepted paths are parent connect, safe sibling output pin inference, root agent
-        emit_events, root node handler emits, exact platform event catalog matches, swarm.source external metadata, same-flow
-        timers, same-flow node handler emits, and same-flow agent emit_events. produces declarations and swarm.status planned
-        do not satisfy this proof.
+        or source path for that event. This check consumes the same canonical producer-source resolver as input_pin_wiring
+        with non-input producer checking enabled. Accepted proof classes are external event metadata for non-input events,
+        parent connect, explicit harness injection, platform source, and internal topology producer (including handler emits,
+        agent emit_events, flow output pins, and timers). produces declarations and swarm.status planned do not satisfy this
+        proof.
       when: boot-only
     - id: pin_target_resolution
       severity: error
@@ -7595,9 +7611,10 @@ flow_model:
           location: schema.yaml pins.inputs.events
           canonical_form: >
             An input event pin MAY be authored as an object when it needs receiver address resolution:
-            `{name, event, address}`. `name` is the local public input pin name. `event` is the local event
-            identity accepted by the receiver handler. `address` declares how the receiver entity or flow instance
-            is selected for in-topology delivery.
+            `{name, event, source, address}`. `name` is the local public input pin name. `event` is the local event
+            identity accepted by the receiver handler. `source` is optional and currently valid only as `external`,
+            declaring explicit intrinsic external ingress for this input pin. `address` declares how the receiver entity or
+            flow instance is selected for in-topology delivery.
           scalar_form: >
             A scalar input event pin remains valid only for receivers that need no explicit addressed-input descriptor
             routing or where the parent connect/lowering rule supplies a complete receiver route from static topology or
@@ -8173,7 +8190,7 @@ flow_model:
     description: Flows have typed input/output pins, like IC chips in a circuit. The platform validates pin wiring at boot.
     input_event_pins:
       description: Events the flow subscribes to through its public receiver interface. Required pins must be wired by parent
-        connect, a safe analyzer inference, an explicit external source, or another accepted producer path.
+        connect, input pin source:external, explicit harness injection, platform source, or internal topology producer proof.
       required: true
     output_event_pins:
       description: Events the flow emits across its public interface. Optional, but when an emit site emits one of these
@@ -12343,7 +12360,7 @@ static_analyzer:
     - contract_formats.event_schema
     scope:
       description: For every flow input pin event declared in schema.yaml pins.inputs.events, verify that at least one accepted
-        producer path exists in the authored bundle on the static verify surface.
+        producer source exists in the authored bundle through the canonical input-source resolver on the static verify surface.
       applies_to:
       - schema.yaml pins.inputs.events
       excludes:
@@ -12352,25 +12369,27 @@ static_analyzer:
       - multi-hop reachability or liveness
       - produces-based proof
       - swarm.status-based lifecycle suppression
-    accepted_producer_paths:
+    accepted_producer_sources:
+      boundary_external_ingress:
+        rule: A root input pin is externally ingressible by boundary contract.
+      intrinsic_input_pin_ingress:
+        rule: 'A child/template/static flow input pin explicitly declares source: external.'
       parent_connect:
-        rule: Parent package.yaml connect binds a producer output pin to this receiver input pin and lowers to a concrete route plan.
-      sibling_flow_output_pin:
-        rule: Another flow declares the same local event name in schema.yaml pins.outputs.events and the analyzer can prove
-          this is the unique safe inference for parent connect topology.
-      root_agent_emit_events:
-        rule: A root-level agent declares the event in emit_events.
-      root_node_handler_emits:
-        rule: A root-level system node emits the event from handler top-level emit, rules emit, on_complete emit, accumulate.on_timeout
-          emit, or fan_out emit.
-      platform_event_catalog:
-        rule: The input pin event exactly matches a platform_events.catalog key.
-      external_source_annotation:
-        rule: The consuming flow or root event entry for the event has swarm.source beginning with external.
-      same_flow_timer_declaration:
-        rule: A timer declared within the consuming flow fires the same event.
-    rule: Emit warning when none of the accepted producer-path forms are found. The finding message must say no producer path
-      was found in the authored bundle and list the checked producer-path forms.
+        rule: Parent package.yaml connect binds a producer output pin to this receiver input pin and lowers to a concrete RoutePlan.
+      harness_injection:
+        rule: Validation/test harness declares an explicit injected flow/event source.
+      platform_source:
+        rule: The input pin event exactly matches a platform_events.catalog key or accepted platform source proof.
+      internal_topology_producer:
+        rule: Authored handlers, agents, flow output pins, or timers produce the event inside the topology; this proof does not
+          generate producer-scoped route patterns.
+    retired_producer_paths:
+      sibling_flow_output_auto_wire:
+        rule: Unique same-name sibling output pin inference is not producer-pattern authority and MUST NOT create auto-wire aliases.
+      event_swarm_source_external:
+        rule: 'events.yaml swarm.source: external is not input-pin proof. Use input pin source: external for intrinsic ingress.'
+    rule: Emit warning when none of the accepted producer-source forms are found. The finding message must say no accepted producer
+      source was found in the authored bundle and list the checked source classes.
   slice_3a_pin_target_resolution:
     id: pin_target_resolution
     domain: semantic_validity

--- a/tests/tier12-runtime-tools/test-flow-data-access/flows/support/events.yaml
+++ b/tests/tier12-runtime-tools/test-flow-data-access/flows/support/events.yaml
@@ -1,3 +1,1 @@
-support.requested:
-  swarm:
-    source: external
+support.requested: {}

--- a/tests/tier12-runtime-tools/test-flow-data-access/flows/support/schema.yaml
+++ b/tests/tier12-runtime-tools/test-flow-data-access/flows/support/schema.yaml
@@ -2,4 +2,7 @@ name: support
 mode: static
 pins:
   inputs:
-    events: [support.requested]
+    events:
+      - name: support_requested
+        event: support.requested
+        source: external

--- a/tests/tier8-boot-verification/test-boot-event-no-producer/schema.yaml
+++ b/tests/tier8-boot-verification/test-boot-event-no-producer/schema.yaml
@@ -3,6 +3,6 @@ terminal_states: [done]
 states: [pending, done]
 pins:
   inputs:
-    events: [task.requested, ghost.event]
+    events: [task.requested]
   outputs:
     events: [task.completed]

--- a/tests/tier8-boot-verification/test-boot-prompt-stub/events.yaml
+++ b/tests/tier8-boot-verification/test-boot-prompt-stub/events.yaml
@@ -1,4 +1,8 @@
 task.requested:
+  swarm:
+    source: external
   task_type: string
 task.completed:
+  swarm:
+    consumer: external
   result: string

--- a/tests/tier8-boot-verification/test-boot-prompt-stub/schema.yaml
+++ b/tests/tier8-boot-verification/test-boot-prompt-stub/schema.yaml
@@ -3,6 +3,9 @@ terminal_states: [done]
 states: [pending, done]
 pins:
   inputs:
-    events: [task.requested]
+    events:
+      - name: task.requested
+        event: task.requested
+        source: external
   outputs:
     events: []

--- a/tests/tier9-composition-patterns/test-compose-create-instance-config/flows/worker/schema.yaml
+++ b/tests/tier9-composition-patterns/test-compose-create-instance-config/flows/worker/schema.yaml
@@ -13,6 +13,9 @@ instance_variables:
   owner: Owner
 pins:
   inputs:
-    events: [task.assign]
+    events:
+      - name: task_assign
+        event: task.assign
+        source: external
   outputs:
     events: [task.done]


### PR DESCRIPTION
## Summary

- Introduces `semanticview.ResolveFlowInputProducer` as the canonical input-pin producer-source resolver.
- Moves bootverify, route derivation, workflow-node projection, accumulator checks, and import-boundary alias consumers to that resolver.
- Retires unique same-name sibling-output auto-wire and `events.yaml swarm.source: external` as input-pin producer proof.
- Adds explicit input-pin `source: external`, harness injection options, source taxonomy evidence, and route-scoped EventBus/Pipeline delivery proof.
- Updates `platform-spec.yaml` to make the resolver and retired paths authoritative.

Closes #1807.

## Governing refs / context

- `platform-spec.yaml#contract_formats.event_schema.routing_derivation.input_source_resolution`
- `platform-spec.yaml#flow_model.flow_package.composition_routing.addressed_input_pin`
- `platform-spec.yaml#static_analyzer_semantic_drift.slice_3_input_pin_wiring`
- Binding issue/gate context: #1807, #1786, #1738, #1789, #1712.

## Semantic migration

- New canonical owner: `internal/runtime/semanticview.ResolveFlowInputProducer` plus `runtimecontracts.FlowInputProducerResolution` / evidence classes.
- Old producer/reader/writer paths now invalid or non-authoritative: `WorkflowContractBundle.ResolveFlowInputAutoWire` sibling inference, raw import-boundary auto-wire fallback, unique sibling-output route pattern projection, bootverify-local input producer lists, and `events.yaml swarm.source: external` as input-pin proof.
- Production paths checked: bootverify `input_pin_wiring`, `cross_flow_pin_ambiguity_validation`, `accumulator_input_producer_path`; route derivation `routeFlowInputHasExternalProducer` and `routeResolveSubscriberPatterns`; workflow-node projection/execution; import-boundary alias projection; EventBus route-scoped post-commit dispatch.
- Migration complete for the approved #1807 child boundary. General non-input event metadata and dead-event external-role accounting remain separate concepts.

## Tests

- PASS: `SWARM_TEST_POSTGRES_DSN='host=127.0.0.1 port=5432 user=youmew dbname=postgres sslmode=disable' PGPASSWORD=postgres go test ./internal/runtime/semanticview ./internal/runtime/bootverify ./internal/runtime/pipeline ./internal/runtime/bus ./internal/runtime ./internal/runtime/runforkadmission ./internal/apispec ./cmd/swarm`
- PASS: `go test ./internal/runtime/bootverify -run 'TestRun_ReportsInputPinMissingProducerPath|TestRun_InputPin|TestFormatSurfaceFindingUsesTypedDiagnosticRendering' -count=1`
- ATTEMPTED: `SWARM_TEST_POSTGRES_DSN='host=127.0.0.1 port=5432 user=youmew dbname=postgres sslmode=disable' PGPASSWORD=postgres go test ./...`; failed in `internal/store` cleanup while dropping an isolated host-Postgres database under concurrent local test groups. No #1807 assertion failure was observed.