### PR TITLE
[agent-e][issue #1811] Enforce remediation diagnostics

### DIFF
--- a/cmd/swarm/api_consumption_boundary_test.go
+++ b/cmd/swarm/api_consumption_boundary_test.go
@@ -232,8 +232,8 @@ func TestCLIRuntimeStateCommandsRequireSharedAPITokenBeforeRequest(t *testing.T)
 				t.Fatalf("code = %d, want %d stdout=%s stderr=%s", code, cliExitValidation, stdout.String(), stderr.String())
 			}
 			for _, want := range []string{
-				"env/known_retired: SWARM_BUILDER_AUTH_TOKEN",
-				"env/known_retired: SWARM_OPERATOR_AUTH_TOKEN",
+				"env/known_retired @ SWARM_BUILDER_AUTH_TOKEN:",
+				"env/known_retired @ SWARM_OPERATOR_AUTH_TOKEN:",
 				"not accepted as API auth fallback",
 			} {
 				if !strings.Contains(stderr.String(), want) {

--- a/cmd/swarm/doctor_test.go
+++ b/cmd/swarm/doctor_test.go
@@ -293,11 +293,11 @@ func TestDoctorClaudeCLIPreflightBlocksGeneratedGatewayParentEnv(t *testing.T) {
 		t.Fatalf("code = %d, want %d stdout=%s stderr=%s", code, cliExitRuntime, stdout.String(), stderr.String())
 	}
 	for _, want := range []string{
-		"[BLOCKER] env/generated_boundary: SWARM_TOOL_GATEWAY_URL",
-		"[BLOCKER] env/generated_boundary: SWARM_TOOL_GATEWAY_CONTAINER_URL",
-		"[BLOCKER] env/known_retired: SWARM_TOOL_GATEWAY_TOKEN",
-		"[WARNING] gateway_prerequisite/swarm_tool_gateway_url_retired",
-		"[WARNING] gateway_prerequisite/swarm_tool_gateway_container_url_retired",
+		"[BLOCKER] env/generated_boundary @ doctor: SWARM_TOOL_GATEWAY_URL",
+		"[BLOCKER] env/generated_boundary @ doctor: SWARM_TOOL_GATEWAY_CONTAINER_URL",
+		"[BLOCKER] env/known_retired @ doctor: SWARM_TOOL_GATEWAY_TOKEN",
+		"[WARN] gateway_prerequisite/swarm_tool_gateway_url_retired @ doctor:",
+		"[WARN] gateway_prerequisite/swarm_tool_gateway_container_url_retired @ doctor:",
 		"SWARM_TOOL_GATEWAY_URL is retired and not accepted as gateway endpoint configuration",
 		"unset SWARM_TOOL_GATEWAY_URL; local serve/run derives the gateway binding from the bound MCP listener and ignores this retired URL",
 	} {
@@ -764,8 +764,10 @@ func TestPlatformSpecLocalClaudeCLIPreflightAdmissionPromoted(t *testing.T) {
 	if !strings.Contains(doctor.Owner, "local_target_resolution_authority") {
 		t.Fatalf("doctor command catalog missing target owner: %#v", doctor)
 	}
-	if !strings.Contains(doctor.Behavior, "without starting runtime") || !strings.Contains(doctor.Behavior, "DB state") || !strings.Contains(doctor.Behavior, "--target") {
-		t.Fatalf("doctor behavior missing runtime/DB boundary: %s", doctor.Behavior)
+	for _, want := range []string{"without starting runtime", "DB state", "--target", "shared typed diagnostic list renderer", "[BLOCKER]", "existing doctor/preflight report shape"} {
+		if !strings.Contains(doctor.Behavior, want) {
+			t.Fatalf("doctor behavior missing %q: %s", want, doctor.Behavior)
+		}
 	}
 }
 

--- a/cmd/swarm/env_authority_test.go
+++ b/cmd/swarm/env_authority_test.go
@@ -420,7 +420,7 @@ func TestSwarmEnvGuardBlocksUnknownWithSuggestion(t *testing.T) {
 		t.Fatalf("code = %d, want %d stdout=%s stderr=%s", code, cliExitValidation, stdout.String(), stderr.String())
 	}
 	for _, want := range []string{
-		"[BLOCKER] env/unknown_stale: SWARM_WORSKPACE_IMAGE",
+		"[BLOCKER] env/unknown_stale @ SWARM_WORSKPACE_IMAGE:",
 		"did you mean SWARM_WORKSPACE_IMAGE",
 		"unset SWARM_WORSKPACE_IMAGE",
 	} {
@@ -504,7 +504,7 @@ func TestSwarmEnvGuardDoesNotSkipWhenHelpIsCommandData(t *testing.T) {
 				t.Fatalf("code = %d, want %d stdout=%s stderr=%s", code, cliExitValidation, stdout.String(), stderr.String())
 			}
 			for _, want := range []string{
-				"[BLOCKER] env/unknown_stale: SWARM_WORSKPACE_IMAGE",
+				"[BLOCKER] env/unknown_stale @ SWARM_WORSKPACE_IMAGE:",
 				"did you mean SWARM_WORKSPACE_IMAGE",
 			} {
 				if !strings.Contains(stderr.String(), want) {
@@ -529,7 +529,7 @@ func TestSwarmEnvGuardDoesNotSkipVersionServerEqualsTrue(t *testing.T) {
 		t.Fatalf("code = %d, want %d stdout=%s stderr=%s", code, cliExitValidation, stdout.String(), stderr.String())
 	}
 	for _, want := range []string{
-		"[BLOCKER] env/unknown_stale: SWARM_WORSKPACE_IMAGE",
+		"[BLOCKER] env/unknown_stale @ SWARM_WORSKPACE_IMAGE:",
 		"did you mean SWARM_WORKSPACE_IMAGE",
 	} {
 		if !strings.Contains(stderr.String(), want) {
@@ -552,7 +552,7 @@ func TestSwarmEnvGuardBlocksGeneratedBoundaryParentEnv(t *testing.T) {
 		t.Fatalf("code = %d, want %d stdout=%s stderr=%s", code, cliExitValidation, stdout.String(), stderr.String())
 	}
 	for _, want := range []string{
-		"[BLOCKER] env/generated_boundary: SWARM_TOOL_GATEWAY_URL",
+		"[BLOCKER] env/generated_boundary @ SWARM_TOOL_GATEWAY_URL:",
 		"generated final-boundary env must be injected by Swarm",
 		"unset SWARM_TOOL_GATEWAY_URL",
 	} {
@@ -569,19 +569,19 @@ func TestSwarmEnvGuardBlocksRetiredRuntimeLLMConfigEnv(t *testing.T) {
 		want    []string
 		notWant []string
 	}{
-		{name: "SWARM_RUNTIME_RECOVERY_ON_STARTUP", value: "true", want: []string{"env/known_retired: SWARM_RUNTIME_RECOVERY_ON_STARTUP", "runtime.recovery_on_startup"}},
-		{name: "SWARM_LLM_SESSION_LOCK_TTL", value: "1s", want: []string{"env/known_retired: SWARM_LLM_SESSION_LOCK_TTL", "llm.session.lock_ttl"}},
-		{name: "SWARM_LLM_SESSION_ROTATE_AFTER_TURNS", value: "2", want: []string{"env/known_retired: SWARM_LLM_SESSION_ROTATE_AFTER_TURNS", "llm.session.rotate_after_turns"}},
-		{name: "SWARM_LLM_SESSION_ROTATE_ON_PARSE_FAILURES", value: "2", want: []string{"env/known_retired: SWARM_LLM_SESSION_ROTATE_ON_PARSE_FAILURES", "llm.session.rotate_on_parse_failures"}},
-		{name: "SWARM_CLAUDE_API_MAX_RETRIES", value: "7", want: []string{"env/known_retired: SWARM_CLAUDE_API_MAX_RETRIES", "llm.claude_api.max_retries"}},
-		{name: "SWARM_CLAUDE_API_RETRY_BACKOFF", value: "7s", want: []string{"env/known_retired: SWARM_CLAUDE_API_RETRY_BACKOFF", "llm.claude_api.retry_backoff"}},
-		{name: "SWARM_CLAUDE_CLI_COMMAND", value: "false", want: []string{"env/known_retired: SWARM_CLAUDE_CLI_COMMAND", "llm.claude_cli.command"}},
-		{name: "SWARM_CLAUDE_CLI_TIMEOUT", value: "1s", want: []string{"env/known_retired: SWARM_CLAUDE_CLI_TIMEOUT", "llm.claude_cli.timeout"}},
-		{name: "SWARM_CLAUDE_CLI_OUTPUT_FORMAT", value: "bad", want: []string{"env/known_retired: SWARM_CLAUDE_CLI_OUTPUT_FORMAT", "llm.claude_cli.output_format"}},
-		{name: "SWARM_CLAUDE_TIMEOUT_SECONDS", value: "1", want: []string{"env/known_retired: SWARM_CLAUDE_TIMEOUT_SECONDS", "llm.claude_cli.timeout"}},
-		{name: "SWARM_CLAUDE_CLI_RETRIES", value: "7", want: []string{"env/known_retired: SWARM_CLAUDE_CLI_RETRIES", "no supported replacement", "#1803"}, notWant: []string{"llm.claude_cli.retries"}},
-		{name: "SWARM_CLAUDE_CLI_NO_SESSION_PERSISTENCE", value: "true", want: []string{"env/known_retired: SWARM_CLAUDE_CLI_NO_SESSION_PERSISTENCE", "no supported replacement", "#1803"}, notWant: []string{"llm.claude_cli.no_session_persistence"}},
-		{name: "SWARM_CLAUDE_CLI_USE_TMUX", value: "true", want: []string{"env/known_retired: SWARM_CLAUDE_CLI_USE_TMUX", "no supported replacement", "#1803"}, notWant: []string{"llm.claude_cli.use_tmux"}},
+		{name: "SWARM_RUNTIME_RECOVERY_ON_STARTUP", value: "true", want: []string{"env/known_retired @ SWARM_RUNTIME_RECOVERY_ON_STARTUP", "runtime.recovery_on_startup"}},
+		{name: "SWARM_LLM_SESSION_LOCK_TTL", value: "1s", want: []string{"env/known_retired @ SWARM_LLM_SESSION_LOCK_TTL", "llm.session.lock_ttl"}},
+		{name: "SWARM_LLM_SESSION_ROTATE_AFTER_TURNS", value: "2", want: []string{"env/known_retired @ SWARM_LLM_SESSION_ROTATE_AFTER_TURNS", "llm.session.rotate_after_turns"}},
+		{name: "SWARM_LLM_SESSION_ROTATE_ON_PARSE_FAILURES", value: "2", want: []string{"env/known_retired @ SWARM_LLM_SESSION_ROTATE_ON_PARSE_FAILURES", "llm.session.rotate_on_parse_failures"}},
+		{name: "SWARM_CLAUDE_API_MAX_RETRIES", value: "7", want: []string{"env/known_retired @ SWARM_CLAUDE_API_MAX_RETRIES", "llm.claude_api.max_retries"}},
+		{name: "SWARM_CLAUDE_API_RETRY_BACKOFF", value: "7s", want: []string{"env/known_retired @ SWARM_CLAUDE_API_RETRY_BACKOFF", "llm.claude_api.retry_backoff"}},
+		{name: "SWARM_CLAUDE_CLI_COMMAND", value: "false", want: []string{"env/known_retired @ SWARM_CLAUDE_CLI_COMMAND", "llm.claude_cli.command"}},
+		{name: "SWARM_CLAUDE_CLI_TIMEOUT", value: "1s", want: []string{"env/known_retired @ SWARM_CLAUDE_CLI_TIMEOUT", "llm.claude_cli.timeout"}},
+		{name: "SWARM_CLAUDE_CLI_OUTPUT_FORMAT", value: "bad", want: []string{"env/known_retired @ SWARM_CLAUDE_CLI_OUTPUT_FORMAT", "llm.claude_cli.output_format"}},
+		{name: "SWARM_CLAUDE_TIMEOUT_SECONDS", value: "1", want: []string{"env/known_retired @ SWARM_CLAUDE_TIMEOUT_SECONDS", "llm.claude_cli.timeout"}},
+		{name: "SWARM_CLAUDE_CLI_RETRIES", value: "7", want: []string{"env/known_retired @ SWARM_CLAUDE_CLI_RETRIES", "no supported replacement", "#1803"}, notWant: []string{"llm.claude_cli.retries"}},
+		{name: "SWARM_CLAUDE_CLI_NO_SESSION_PERSISTENCE", value: "true", want: []string{"env/known_retired @ SWARM_CLAUDE_CLI_NO_SESSION_PERSISTENCE", "no supported replacement", "#1803"}, notWant: []string{"llm.claude_cli.no_session_persistence"}},
+		{name: "SWARM_CLAUDE_CLI_USE_TMUX", value: "true", want: []string{"env/known_retired @ SWARM_CLAUDE_CLI_USE_TMUX", "no supported replacement", "#1803"}, notWant: []string{"llm.claude_cli.use_tmux"}},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/cmd/swarm/env_guard.go
+++ b/cmd/swarm/env_guard.go
@@ -1,12 +1,12 @@
 package main
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 	"sort"
 	"strings"
 
+	runtimebootverify "github.com/division-sh/swarm/internal/runtime/bootverify"
 	"gopkg.in/yaml.v3"
 )
 
@@ -63,15 +63,19 @@ func (e swarmEnvGuardError) Error() string {
 }
 
 func formatSwarmEnvFinding(finding swarmEnvFinding) string {
-	severity := strings.ToUpper(strings.TrimSpace(finding.Severity))
-	if severity == "" {
-		severity = "INFO"
+	severity := runtimebootverify.SeverityLintEvidence
+	if strings.EqualFold(finding.Severity, "blocker") {
+		severity = runtimebootverify.SeverityHardInvalidity
+	} else if strings.EqualFold(finding.Severity, "warning") {
+		severity = runtimebootverify.SeveritySemanticDriftWarn
 	}
-	line := fmt.Sprintf("[%s] env/%s: %s - %s", severity, finding.Category, finding.Name, finding.Message)
-	if remediation := strings.TrimSpace(finding.Remediation); remediation != "" {
-		line += "\n  remediation: " + remediation
-	}
-	return line
+	return runtimebootverify.FormatTypedDiagnosticFinding(runtimebootverify.TypedDiagnosticFinding{
+		CheckID:     "env/" + strings.TrimSpace(string(finding.Category)),
+		Severity:    severity,
+		Location:    strings.TrimSpace(finding.Name),
+		Message:     strings.TrimSpace(finding.Message),
+		Remediation: strings.TrimSpace(finding.Remediation),
+	}, false)
 }
 
 func validateSwarmEnvForCommand(args []string, repoRoot string) error {

--- a/cmd/swarm/local_preflight.go
+++ b/cmd/swarm/local_preflight.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/division-sh/swarm/internal/config"
+	runtimebootverify "github.com/division-sh/swarm/internal/runtime/bootverify"
 	runtimecredentials "github.com/division-sh/swarm/internal/runtime/credentials"
 	runtimellm "github.com/division-sh/swarm/internal/runtime/llm"
 	llmselection "github.com/division-sh/swarm/internal/runtime/llm/selection"
@@ -372,10 +373,40 @@ func writeLocalPreflightText(out io.Writer, report localPreflightReport) {
 	}
 	fmt.Fprintf(out, "claude_cli preflight: %s\n", status)
 	for _, finding := range report.Findings {
-		fmt.Fprintf(out, "[%s] %s/%s: %s\n", strings.ToUpper(string(finding.Severity)), finding.Category, finding.Code, finding.Message)
-		if finding.Remediation != "" {
-			fmt.Fprintf(out, "  remediation: %s\n", finding.Remediation)
+		fmt.Fprintln(out, formatLocalPreflightFinding(report.Mode, finding))
+	}
+}
+
+func formatLocalPreflightFinding(mode string, finding localPreflightFinding) string {
+	checkID := strings.TrimSpace(string(finding.Category))
+	if code := strings.TrimSpace(finding.Code); code != "" {
+		if checkID != "" {
+			checkID += "/"
 		}
+		checkID += code
+	}
+	location := strings.TrimSpace(mode)
+	if location == "" {
+		location = "local_preflight"
+	}
+	severity, blocking := localPreflightTypedSeverity(finding.Severity)
+	return runtimebootverify.FormatTypedDiagnosticFinding(runtimebootverify.TypedDiagnosticFinding{
+		CheckID:     checkID,
+		Severity:    severity,
+		Location:    location,
+		Message:     strings.TrimSpace(finding.Message),
+		Remediation: strings.TrimSpace(finding.Remediation),
+	}, blocking)
+}
+
+func localPreflightTypedSeverity(severity localPreflightSeverity) (string, bool) {
+	switch severity {
+	case localPreflightSeverityBlocker:
+		return runtimebootverify.SeverityHardInvalidity, false
+	case localPreflightSeverityWarning:
+		return runtimebootverify.SeveritySemanticDriftWarn, false
+	default:
+		return runtimebootverify.SeverityLintEvidence, false
 	}
 }
 

--- a/cmd/swarm/target_resolution.go
+++ b/cmd/swarm/target_resolution.go
@@ -662,10 +662,7 @@ func writeDoctorTargetText(out io.Writer, report doctorTargetReport) {
 	if len(report.Env) > 0 {
 		fmt.Fprintln(out, "env:")
 		for _, finding := range report.Env {
-			fmt.Fprintf(out, "[%s] %s/%s: %s\n", strings.ToUpper(string(finding.Severity)), finding.Category, finding.Code, finding.Message)
-			if finding.Remediation != "" {
-				fmt.Fprintf(out, "  remediation: %s\n", finding.Remediation)
-			}
+			fmt.Fprintln(out, formatLocalPreflightFinding(report.Mode, finding))
 		}
 	}
 	fmt.Fprintf(out, "swarm_dir: %s (source: %s)\n", report.SwarmDir.Path, report.SwarmDir.Source)

--- a/internal/runtime/bootverify/checks.go
+++ b/internal/runtime/bootverify/checks.go
@@ -401,8 +401,8 @@ func (c *checkerContext) promptSchemaGuard() []Finding {
 	}
 	for _, finding := range findings {
 		c.promptSchemaGuardFindings = append(c.promptSchemaGuardFindings, Finding{
-			CheckID:  strings.TrimSpace(finding.CheckID),
-			Severity: finding.Severity,
+			CheckID:  "agent_prompt_lint_structural",
+			Severity: SeverityHardInvalidity,
 			Message:  strings.TrimSpace(finding.Message),
 			Location: strings.TrimSpace(finding.Location),
 		})

--- a/internal/runtime/bootverify/finding_remediation_guard_test.go
+++ b/internal/runtime/bootverify/finding_remediation_guard_test.go
@@ -17,28 +17,20 @@ func TestHardInvalidityFindingLiteralsHaveRemediationAuthority(t *testing.T) {
 
 	var problems []string
 	for _, parsed := range files {
-		ast.Inspect(parsed.file, func(node ast.Node) bool {
-			lit, ok := node.(*ast.CompositeLit)
-			if !ok || !isFindingCompositeLiteral(lit) {
-				return true
-			}
-			if len(lit.Elts) == 0 {
-				return true
-			}
+		inspectFindingCompositeLiterals(parsed.file, func(lit *ast.CompositeLit) {
 			fields := findingLiteralFields(lit)
 			if !findingLiteralIsHardInvalidity(fields, constants) {
-				return true
+				return
 			}
 			if exprHasNonEmptyStringAuthority(fields["Remediation"], constants) {
-				return true
+				return
 			}
 			checkID := resolvedFindingCheckID(fields["CheckID"], constants)
 			if findingCheckIDHasCanonicalRemediationAuthority(checkID) {
-				return true
+				return
 			}
 			pos := parsed.fset.Position(lit.Pos())
 			problems = append(problems, fmt.Sprintf("%s:%d: hard/error Finding literal check_id=%q has no local remediation and no approved remediation authority", filepath.Base(pos.Filename), pos.Line, checkID))
-			return true
 		})
 	}
 	if len(problems) > 0 {
@@ -99,8 +91,43 @@ func bootverifyStringConstants(files []parsedBootverifyFile) map[string]string {
 	return out
 }
 
+func inspectFindingCompositeLiterals(node ast.Node, visit func(*ast.CompositeLit)) {
+	ast.Inspect(node, func(node ast.Node) bool {
+		lit, ok := node.(*ast.CompositeLit)
+		if !ok {
+			return true
+		}
+		if isFindingCompositeLiteral(lit) {
+			if len(lit.Elts) > 0 {
+				visit(lit)
+			}
+			return true
+		}
+		if !isFindingSliceOrArrayCompositeLiteral(lit) {
+			return true
+		}
+		for _, elt := range lit.Elts {
+			inner, ok := elt.(*ast.CompositeLit)
+			if !ok || inner.Type != nil || len(inner.Elts) == 0 {
+				continue
+			}
+			visit(inner)
+		}
+		return true
+	})
+}
+
 func isFindingCompositeLiteral(lit *ast.CompositeLit) bool {
-	switch typ := lit.Type.(type) {
+	return isFindingTypeExpr(lit.Type)
+}
+
+func isFindingSliceOrArrayCompositeLiteral(lit *ast.CompositeLit) bool {
+	array, ok := lit.Type.(*ast.ArrayType)
+	return ok && isFindingTypeExpr(array.Elt)
+}
+
+func isFindingTypeExpr(expr ast.Expr) bool {
+	switch typ := expr.(type) {
 	case *ast.Ident:
 		return typ.Name == "Finding"
 	case *ast.SelectorExpr:

--- a/internal/runtime/bootverify/finding_remediation_guard_test.go
+++ b/internal/runtime/bootverify/finding_remediation_guard_test.go
@@ -38,6 +38,27 @@ func TestHardInvalidityFindingLiteralsHaveRemediationAuthority(t *testing.T) {
 	}
 }
 
+func TestDynamicSeverityFindingLiteralsFailClosed(t *testing.T) {
+	lit := parseSingleFindingLiteral(t, `package bootverify
+
+func example(severity string) Finding {
+	return Finding{
+		CheckID: "missing_dynamic_authority",
+		Severity: severity,
+		Message: "dynamic severity must not bypass hard-invalidity remediation authority",
+		Location: "global",
+	}
+}
+`)
+	fields := findingLiteralFields(lit)
+	if !findingLiteralIsHardInvalidity(fields, nil) {
+		t.Fatalf("dynamic severity Finding literal should be treated as potential hard invalidity")
+	}
+	if findingCheckIDHasCanonicalRemediationAuthority(resolvedFindingCheckID(fields["CheckID"], nil)) {
+		t.Fatalf("test fixture unexpectedly has canonical remediation authority")
+	}
+}
+
 type parsedBootverifyFile struct {
 	fset *token.FileSet
 	file *ast.File
@@ -89,6 +110,23 @@ func bootverifyStringConstants(files []parsedBootverifyFile) map[string]string {
 		}
 	}
 	return out
+}
+
+func parseSingleFindingLiteral(t *testing.T, src string) *ast.CompositeLit {
+	t.Helper()
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "fixture.go", src, 0)
+	if err != nil {
+		t.Fatalf("parse fixture: %v", err)
+	}
+	var findings []*ast.CompositeLit
+	inspectFindingCompositeLiterals(file, func(lit *ast.CompositeLit) {
+		findings = append(findings, lit)
+	})
+	if len(findings) != 1 {
+		t.Fatalf("finding literals = %d, want 1", len(findings))
+	}
+	return findings[0]
 }
 
 func inspectFindingCompositeLiterals(node ast.Node, visit func(*ast.CompositeLit)) {
@@ -156,7 +194,7 @@ func findingLiteralFields(lit *ast.CompositeLit) map[string]ast.Expr {
 func findingLiteralIsHardInvalidity(fields map[string]ast.Expr, constants map[string]string) bool {
 	raw, ok := stringValue(fields["Severity"], constants)
 	if !ok {
-		return fields["Severity"] == nil
+		return true
 	}
 	switch strings.TrimSpace(strings.ToLower(raw)) {
 	case "", legacySeverityError, SeverityHardInvalidity:

--- a/internal/runtime/bootverify/finding_remediation_guard_test.go
+++ b/internal/runtime/bootverify/finding_remediation_guard_test.go
@@ -1,0 +1,191 @@
+package bootverify
+
+import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+func TestHardInvalidityFindingLiteralsHaveRemediationAuthority(t *testing.T) {
+	files := parseBootverifyProductionFiles(t)
+	constants := bootverifyStringConstants(files)
+
+	var problems []string
+	for _, parsed := range files {
+		ast.Inspect(parsed.file, func(node ast.Node) bool {
+			lit, ok := node.(*ast.CompositeLit)
+			if !ok || !isFindingCompositeLiteral(lit) {
+				return true
+			}
+			if len(lit.Elts) == 0 {
+				return true
+			}
+			fields := findingLiteralFields(lit)
+			if !findingLiteralIsHardInvalidity(fields, constants) {
+				return true
+			}
+			if exprHasNonEmptyStringAuthority(fields["Remediation"], constants) {
+				return true
+			}
+			checkID := resolvedFindingCheckID(fields["CheckID"], constants)
+			if findingCheckIDHasCanonicalRemediationAuthority(checkID) {
+				return true
+			}
+			pos := parsed.fset.Position(lit.Pos())
+			problems = append(problems, fmt.Sprintf("%s:%d: hard/error Finding literal check_id=%q has no local remediation and no approved remediation authority", filepath.Base(pos.Filename), pos.Line, checkID))
+			return true
+		})
+	}
+	if len(problems) > 0 {
+		t.Fatalf("hard/error Finding literals without remediation authority:\n%s", strings.Join(problems, "\n"))
+	}
+}
+
+type parsedBootverifyFile struct {
+	fset *token.FileSet
+	file *ast.File
+}
+
+func parseBootverifyProductionFiles(t *testing.T) []parsedBootverifyFile {
+	t.Helper()
+	paths, err := filepath.Glob("*.go")
+	if err != nil {
+		t.Fatalf("glob bootverify go files: %v", err)
+	}
+	out := make([]parsedBootverifyFile, 0, len(paths))
+	for _, path := range paths {
+		if strings.HasSuffix(path, "_test.go") {
+			continue
+		}
+		fset := token.NewFileSet()
+		file, err := parser.ParseFile(fset, path, nil, 0)
+		if err != nil {
+			t.Fatalf("parse %s: %v", path, err)
+		}
+		out = append(out, parsedBootverifyFile{fset: fset, file: file})
+	}
+	return out
+}
+
+func bootverifyStringConstants(files []parsedBootverifyFile) map[string]string {
+	out := map[string]string{}
+	for _, parsed := range files {
+		for _, decl := range parsed.file.Decls {
+			gen, ok := decl.(*ast.GenDecl)
+			if !ok || gen.Tok != token.CONST {
+				continue
+			}
+			for _, spec := range gen.Specs {
+				valueSpec, ok := spec.(*ast.ValueSpec)
+				if !ok {
+					continue
+				}
+				for i, name := range valueSpec.Names {
+					if i >= len(valueSpec.Values) {
+						continue
+					}
+					if value, ok := stringValue(valueSpec.Values[i], out); ok {
+						out[name.Name] = value
+					}
+				}
+			}
+		}
+	}
+	return out
+}
+
+func isFindingCompositeLiteral(lit *ast.CompositeLit) bool {
+	switch typ := lit.Type.(type) {
+	case *ast.Ident:
+		return typ.Name == "Finding"
+	case *ast.SelectorExpr:
+		return typ.Sel.Name == "Finding"
+	default:
+		return false
+	}
+}
+
+func findingLiteralFields(lit *ast.CompositeLit) map[string]ast.Expr {
+	out := map[string]ast.Expr{}
+	for _, elt := range lit.Elts {
+		kv, ok := elt.(*ast.KeyValueExpr)
+		if !ok {
+			continue
+		}
+		key, ok := kv.Key.(*ast.Ident)
+		if !ok {
+			continue
+		}
+		out[key.Name] = kv.Value
+	}
+	return out
+}
+
+func findingLiteralIsHardInvalidity(fields map[string]ast.Expr, constants map[string]string) bool {
+	raw, ok := stringValue(fields["Severity"], constants)
+	if !ok {
+		return fields["Severity"] == nil
+	}
+	switch strings.TrimSpace(strings.ToLower(raw)) {
+	case "", legacySeverityError, SeverityHardInvalidity:
+		return true
+	default:
+		return false
+	}
+}
+
+func exprHasNonEmptyStringAuthority(expr ast.Expr, constants map[string]string) bool {
+	if expr == nil {
+		return false
+	}
+	value, ok := stringValue(expr, constants)
+	return !ok || strings.TrimSpace(value) != ""
+}
+
+func resolvedFindingCheckID(expr ast.Expr, constants map[string]string) string {
+	if value, ok := stringValue(expr, constants); ok {
+		return strings.TrimSpace(value)
+	}
+	if expr == nil {
+		return "workflow_contract_validation"
+	}
+	return ""
+}
+
+func findingCheckIDHasCanonicalRemediationAuthority(checkID string) bool {
+	checkID = strings.TrimSpace(checkID)
+	if checkID == "" {
+		return false
+	}
+	if _, ok := stableHardInvalidityRemediation[checkID]; ok {
+		return true
+	}
+	_, ok := routingRemediationSplitCheckIDs[checkID]
+	return ok
+}
+
+func stringValue(expr ast.Expr, constants map[string]string) (string, bool) {
+	switch value := expr.(type) {
+	case nil:
+		return "", false
+	case *ast.BasicLit:
+		if value.Kind != token.STRING {
+			return "", false
+		}
+		unquoted, err := strconv.Unquote(value.Value)
+		if err != nil {
+			return "", false
+		}
+		return unquoted, true
+	case *ast.Ident:
+		resolved, ok := constants[value.Name]
+		return resolved, ok
+	default:
+		return "", false
+	}
+}

--- a/internal/runtime/bootverify/report.go
+++ b/internal/runtime/bootverify/report.go
@@ -38,15 +38,30 @@ const (
 
 var stableHardInvalidityRemediation = map[string]string{
 	"agent_permission_validation":             "Grant the required agent permission or remove the unauthorized tool/action from the contract.",
+	"agent_prompt_lint_structural":            "Fix the agent prompt lint declaration so it uses supported structural fields, or remove the unsupported prompt lint entry.",
+	"accumulator_entity_projection":           "Fix the accumulator projection so it writes declared entity fields through the supported accumulator projection shape.",
+	"accumulator_input_producer_path":         "Add an accepted producer/source path for the accumulated input event or change the accumulator to consume an event that has one.",
+	"accumulator_timeout_requires_timeout_ms": "Add a positive timeout_ms for timeout completion mode or change the accumulator completion mode.",
+	"compute_module_value_rows":               "Fix the compute module value rows so each referenced module and value shape is declared consistently.",
 	"condition_expression_validation":         "Fix the condition expression so it references declared fields and uses supported CEL syntax.",
+	"condition_payload_alignment":             "Fix condition input references so they read declared payload fields for the triggering event.",
+	"config_from_payload_alignment":           "Fix config_from_payload references so they read declared payload fields for the triggering event.",
+	"contained_state_operation_compliance":    "Fix contained state operations so they target declared contained-state fields through supported syntax.",
+	"credential_key_exists":                   "Configure the required credential or fix access to the credential store used by verifier credential checks.",
 	"data_accumulation_expression_validation": "Fix the data_accumulation expression so it references declared fields and uses supported CEL syntax.",
+	"dialect_compliance":                      "Replace the unsupported contract dialect form with the promoted platform-spec shape or remove it.",
 	"emit_field_expression_validation":        "Fix the emit field expression so it references declared fields and uses supported CEL syntax.",
 	"entity_write_target_compliance":          "Update the entity write target to a declared writable entity field or remove the invalid write.",
+	"entity_writer_coverage":                  "Add a supported writer for each required entity field or remove/relax the field requirement in the contract.",
+	"event_cycle_detection":                   "Break the event cycle by changing one handler emission, transition, or subscription so the static event graph is acyclic.",
+	"event_runtime_wiring_validation":         "Add the missing runtime handler/owner for the event or remove the event transition that requires runtime handling.",
+	"expression_field_reference_validation":   "Fix the expression field reference so it uses the supported namespace and declared field path.",
 	"event_metadata_authority":                "Move platform-owned event metadata out of authored business payload declarations.",
 	"flow_boundary_create_entity_validation":  "Fix the cross-flow create_entity declaration so it preserves the receiving flow boundary.",
 	"flow_data_access_validation":             "Use the supported flow data access form for the referenced field or remove the unsupported access.",
 	"flow_package_dependency_binding":         "Declare the required imported package binding or remove the unresolved dependency reference.",
 	"flow_package_import_completeness":        "Complete the imported package dependency binding or remove the incomplete import.",
+	"flow_package_wildcard_observe_grant":     "Replace wildcard observe grants with explicit package dependency grants for each observed event.",
 	"gate_schema_validation":                  "Fix the gate declaration so it uses supported gate fields and value types.",
 	"generated_tool_schema_closure":           "Fix the generated tool schema inputs/outputs so they close over declared contract types.",
 	"handler_field_compliance":                "Move the unsupported handler field to its promoted location or remove it.",
@@ -55,10 +70,14 @@ var stableHardInvalidityRemediation = map[string]string{
 	"managed_credential_state":                "Configure the required managed credential or remove the dependency that requires it.",
 	"missing_external_select_entity":          "Add an explicit select_entity/select_or_create_entity for the external input or make the event topology in-flow.",
 	"native_tools_valid":                      "Fix the native tool declaration so it references a supported runtime tool surface.",
+	"node_state_schema_typed_counterpart":     "Add the typed node-state counterpart required by the schema or remove the unsupported jsonb-only state field.",
+	"output_pin_key_carries_validation":       "Declare the output pin key/carries fields and ensure every authored emit site populates those payload fields.",
 	"payload_field_coverage":                  "Populate every required emitted payload field or make the target event schema optional where appropriate.",
 	"platform_namespace_violation":            "Rename authored business fields away from platform-reserved namespace roots.",
 	"platform_version_compatibility":          "Update the contract platform_version range or run with a compatible Swarm platform version.",
 	"policy_conflict_detection":               "Resolve the conflicting policy declarations so only one authoritative value remains.",
+	"policy_sheet_lookup_value_rows":          "Fix the policy sheet lookup value rows so each lookup key and target value is declared consistently.",
+	"policy_sheet_validation_value_rows":      "Fix the policy sheet validation value rows so each row matches the declared policy sheet schema.",
 	"primary_entity_validation":               "Declare a valid primary entity or remove the stateful surface that requires one.",
 	"prompt_exists":                           "Add the referenced prompt file or update the agent prompt_ref.",
 	"redundant_in_topology_select_entity":     "Remove redundant select_entity/select_or_create_entity from an in-topology handler.",
@@ -66,6 +85,7 @@ var stableHardInvalidityRemediation = map[string]string{
 	"required_agents_match":                   "Update required agent declarations so subscriptions and emitted events match the contract topology.",
 	"required_mcp_tool_availability":          "Expose the required MCP tool from the configured server or update the agent tool requirement.",
 	"select_entity_validation":                "Fix the select_entity/select_or_create_entity declaration so it uses supported source and target fields.",
+	"semantic_drift_payload_completeness":     "Populate every required payload field for emitted events or update the event schema to match the emitted payload.",
 	"single_node_per_event":                   "Ensure only one system node owns the exact event handler or split the event ownership.",
 	"singleton_coordinator_validation":        "Fix the singleton coordinator declaration so it names supported contained state fields.",
 	"state_machine_coherence":                 "Fix the state machine declarations so initial, terminal, and transition states are declared consistently.",
@@ -128,7 +148,7 @@ func WithEvidence(evidence ...string) FindingOption {
 	}
 }
 
-func NewFinding(checkID, severity, location, message string, opts ...FindingOption) Finding {
+func newFinding(checkID, severity, location, message string, opts ...FindingOption) Finding {
 	f := Finding{
 		CheckID:  checkID,
 		Severity: severity,
@@ -144,7 +164,7 @@ func NewFinding(checkID, severity, location, message string, opts ...FindingOpti
 }
 
 func NewHardInvalidityFinding(checkID, location, message, remediation string, evidence ...string) Finding {
-	return NewFinding(checkID, SeverityHardInvalidity, location, message, WithRemediation(remediation), WithEvidence(evidence...))
+	return newFinding(checkID, SeverityHardInvalidity, location, message, WithRemediation(remediation), WithEvidence(evidence...))
 }
 
 type Report struct {

--- a/internal/runtime/bootverify/report.go
+++ b/internal/runtime/bootverify/report.go
@@ -73,6 +73,7 @@ var stableHardInvalidityRemediation = map[string]string{
 	"node_state_schema_typed_counterpart":     "Add the typed node-state counterpart required by the schema or remove the unsupported jsonb-only state field.",
 	"output_pin_key_carries_validation":       "Declare the output pin key/carries fields and ensure every authored emit site populates those payload fields.",
 	"payload_field_coverage":                  "Populate every required emitted payload field or make the target event schema optional where appropriate.",
+	"platform_tool_usage_hints":               "Fix platform tool usage hints so every referenced tool exists and every required usage hint is declared.",
 	"platform_namespace_violation":            "Rename authored business fields away from platform-reserved namespace roots.",
 	"platform_version_compatibility":          "Update the contract platform_version range or run with a compatible Swarm platform version.",
 	"policy_conflict_detection":               "Resolve the conflicting policy declarations so only one authoritative value remains.",
@@ -148,23 +149,15 @@ func WithEvidence(evidence ...string) FindingOption {
 	}
 }
 
-func newFinding(checkID, severity, location, message string, opts ...FindingOption) Finding {
-	f := Finding{
-		CheckID:  checkID,
-		Severity: severity,
-		Location: location,
-		Message:  message,
-	}
-	for _, opt := range opts {
-		if opt != nil {
-			opt(&f)
-		}
-	}
-	return f
-}
-
 func NewHardInvalidityFinding(checkID, location, message, remediation string, evidence ...string) Finding {
-	return newFinding(checkID, SeverityHardInvalidity, location, message, WithRemediation(remediation), WithEvidence(evidence...))
+	return Finding{
+		CheckID:     checkID,
+		Severity:    SeverityHardInvalidity,
+		Location:    location,
+		Message:     message,
+		Remediation: remediation,
+		Evidence:    evidence,
+	}
 }
 
 type Report struct {

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -5781,9 +5781,10 @@ engine:
     implementation_notes:
       framework: Each check is a named function that receives the loaded contract bundle and returns a list of findings. Each
         finding has the check ID, severity, message, location (flow, node, agent, or event name), optional evidence, and
-        optional remediation. Hard-invalidity/error findings must carry remediation by construction or through the canonical
-        report normalization path, except for explicitly split/gate-recorded unsettled remediation language. The boot sequence runs
-        all checks after contract loading and before starting nodes/agents.
+        optional remediation. Hard-invalidity/error findings must carry remediation by construction through the remediation-bearing
+        hard-invalidity constructor or have stable/split remediation authority admitted by an AST/lint production-code guard; canonical
+        report normalization remains a runtime safety net, not the proof of authoring completeness. The boot sequence runs all checks
+        after contract loading and before starting nodes/agents.
       always_on: All checks run on every boot. There is no mechanism to disable individual checks. Acknowledged warnings
         (builder feature) are a UI concern, not a runtime concern.
       scope_meaning: per-flow checks run once per flow in the tree. per-node checks run once per node. per-agent checks run
@@ -15389,7 +15390,9 @@ cli_specification:
         owner. `--target` is a separate fast local-target diagnostic mode owned by
         cli_specification.foundations.local_target_resolution_authority; it reports Swarm-dir, project-root, API target,
         pending context/identity facts, current store/data facts, command classes, and split siblings without backend
-        preflight or local state writes. JSON output is supported for scripts.
+        preflight or local state writes. Human typed findings render through the shared typed diagnostic list renderer
+        as `[BLOCKER]`, `[WARN]`, or `[INFO]` lines with remediation when present. JSON output is supported for scripts
+        and remains the existing doctor/preflight report shape.
       split_scope:
       - workspace image build
       - local API connection discovery files


### PR DESCRIPTION
## Summary

- route local preflight, env guard, and doctor target human typed diagnostics through the shared bootverify typed renderer
- enforce hard/error verifier finding remediation authority with `NewHardInvalidityFinding`, stable/split remediation maps, and an AST guard over production `Finding{}` literals
- update the platform spec so construction enforcement and shared doctor/preflight human rendering are authoritative while preserving JSON/data-model shapes

## Governing refs / context

Closes #1811
Part of #1790

Binding context:
- #1811 Pre-Implementation Coverage Audit and independent gate review
- `platform-spec.yaml` boot verification implementation notes for finding remediation authority
- `platform-spec.yaml` doctor command catalog for shared typed diagnostic list rendering
- #1797 / PR #1806 as the already-merged remediation/evidence content slice

## Semantic migration

Canonical owners after this change:
- `internal/runtime/bootverify.NewHardInvalidityFinding` for remediation-bearing hard invalidity construction
- `internal/runtime/bootverify.stableHardInvalidityRemediation` and `routingRemediationSplitCheckIDs` for approved stable/split remediation authority
- `internal/runtime/bootverify.FormatTypedDiagnosticFinding` for human typed diagnostic rendering
- `platform-spec.yaml` for the public construction/rendering contract

Old producer/reader paths now invalid or non-authoritative:
- raw hard/error `Finding{}` literals without local remediation or approved remediation authority now fail the AST guard test
- local handcrafted doctor/preflight/env typed text formatting is replaced by the shared renderer
- `Report.Add` remains a runtime safety net, not the proof of authoring completeness

Production paths checked for surviving old behavior:
- `writeLocalPreflightText`
- `formatSwarmEnvFinding`
- `writeDoctorTargetText`
- existing verify/describe renderer surfaces from #1797

Migration completeness: complete for the #1811 first-slice boundary. Source maps, routing-specific remediation copy, and broader diagnostic data-model convergence remain tracked outside this PR.

## Validation

Host Postgres was used for local tests:

```sh
SWARM_TEST_POSTGRES_DSN='host=127.0.0.1 port=5432 user=youmew dbname=postgres sslmode=disable' \
PGPASSWORD=postgres \
go test ./...
```

Result: pass.

Focused checks also passed before the final full-suite run:

```sh
go test ./cmd/swarm
go test ./internal/runtime/bootverify -count=1
```
