### PR TITLE
[agent-b][issue #1833] Retire store DB env authority

### DIFF
--- a/cmd/swarm/doctor_test.go
+++ b/cmd/swarm/doctor_test.go
@@ -89,7 +89,6 @@ func TestDoctorClaudeCLIPreflightJSONReportsOKWithoutDB(t *testing.T) {
 	t.Setenv("SWARM_TOOL_GATEWAY_URL", "")
 	t.Setenv("SWARM_TOOL_GATEWAY_CONTAINER_URL", "")
 	t.Setenv("SWARM_TOOL_GATEWAY_TOKEN", "")
-	t.Setenv(storebackend.EnvSQLitePath, filepath.Join(t.TempDir(), "must-not-be-used.db"))
 
 	args := doctorClaudeArgs(t, writeDoctorClaudeConfig(t), true)
 	var stdout, stderr bytes.Buffer
@@ -493,8 +492,6 @@ func TestDoctorTargetConsumesRuntimeConfigStoreAndData(t *testing.T) {
 	repo := writeDoctorTargetRepo(t)
 	sqlitePath := filepath.Join(t.TempDir(), "configured-dev.db")
 	dataDir := filepath.Join(t.TempDir(), "configured-data")
-	t.Setenv(storebackend.EnvStoreBackend, storebackend.BackendPostgres.String())
-	t.Setenv(storebackend.EnvSQLitePath, filepath.Join(t.TempDir(), "env-dev.db"))
 	configPath := writeDoctorTargetRuntimeConfig(t, `
 store:
   backend: sqlite

--- a/cmd/swarm/env_authority_test.go
+++ b/cmd/swarm/env_authority_test.go
@@ -618,14 +618,14 @@ func TestSwarmEnvGuardBlocksRetiredStoreDatabaseConfigEnv(t *testing.T) {
 		value string
 		want  []string
 	}{
-		{name: "SWARM_STORE_BACKEND", value: "postgres", want: []string{"env/known_retired: SWARM_STORE_BACKEND", "--store or store.backend"}},
-		{name: "SWARM_SQLITE_PATH", value: "dev.db", want: []string{"env/known_retired: SWARM_SQLITE_PATH", "store.sqlite.path"}},
-		{name: "SWARM_DB_HOST", value: "db.example.test", want: []string{"env/known_retired: SWARM_DB_HOST", "database.host"}},
-		{name: "SWARM_DB_PORT", value: "15432", want: []string{"env/known_retired: SWARM_DB_PORT", "database.port"}},
-		{name: "SWARM_DB_NAME", value: "swarm_test", want: []string{"env/known_retired: SWARM_DB_NAME", "database.name"}},
-		{name: "SWARM_DB_USER", value: "swarm_user", want: []string{"env/known_retired: SWARM_DB_USER", "database.user"}},
-		{name: "SWARM_DB_SSLMODE", value: "require", want: []string{"env/known_retired: SWARM_DB_SSLMODE", "database.sslmode"}},
-		{name: "SWARM_DB_POOL_SIZE", value: "9", want: []string{"env/known_retired: SWARM_DB_POOL_SIZE", "database.pool_size"}},
+		{name: "SWARM_STORE_BACKEND", value: "postgres", want: []string{"env/known_retired", "SWARM_STORE_BACKEND", "--store or store.backend"}},
+		{name: "SWARM_SQLITE_PATH", value: "dev.db", want: []string{"env/known_retired", "SWARM_SQLITE_PATH", "store.sqlite.path"}},
+		{name: "SWARM_DB_HOST", value: "db.example.test", want: []string{"env/known_retired", "SWARM_DB_HOST", "database.host"}},
+		{name: "SWARM_DB_PORT", value: "15432", want: []string{"env/known_retired", "SWARM_DB_PORT", "database.port"}},
+		{name: "SWARM_DB_NAME", value: "swarm_test", want: []string{"env/known_retired", "SWARM_DB_NAME", "database.name"}},
+		{name: "SWARM_DB_USER", value: "swarm_user", want: []string{"env/known_retired", "SWARM_DB_USER", "database.user"}},
+		{name: "SWARM_DB_SSLMODE", value: "require", want: []string{"env/known_retired", "SWARM_DB_SSLMODE", "database.sslmode"}},
+		{name: "SWARM_DB_POOL_SIZE", value: "9", want: []string{"env/known_retired", "SWARM_DB_POOL_SIZE", "database.pool_size"}},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/cmd/swarm/env_authority_test.go
+++ b/cmd/swarm/env_authority_test.go
@@ -612,6 +612,45 @@ func TestSwarmEnvGuardBlocksRetiredRuntimeLLMConfigEnv(t *testing.T) {
 	}
 }
 
+func TestSwarmEnvGuardBlocksRetiredStoreDatabaseConfigEnv(t *testing.T) {
+	cases := []struct {
+		name  string
+		value string
+		want  []string
+	}{
+		{name: "SWARM_STORE_BACKEND", value: "postgres", want: []string{"env/known_retired: SWARM_STORE_BACKEND", "--store or store.backend"}},
+		{name: "SWARM_SQLITE_PATH", value: "dev.db", want: []string{"env/known_retired: SWARM_SQLITE_PATH", "store.sqlite.path"}},
+		{name: "SWARM_DB_HOST", value: "db.example.test", want: []string{"env/known_retired: SWARM_DB_HOST", "database.host"}},
+		{name: "SWARM_DB_PORT", value: "15432", want: []string{"env/known_retired: SWARM_DB_PORT", "database.port"}},
+		{name: "SWARM_DB_NAME", value: "swarm_test", want: []string{"env/known_retired: SWARM_DB_NAME", "database.name"}},
+		{name: "SWARM_DB_USER", value: "swarm_user", want: []string{"env/known_retired: SWARM_DB_USER", "database.user"}},
+		{name: "SWARM_DB_SSLMODE", value: "require", want: []string{"env/known_retired: SWARM_DB_SSLMODE", "database.sslmode"}},
+		{name: "SWARM_DB_POOL_SIZE", value: "9", want: []string{"env/known_retired: SWARM_DB_POOL_SIZE", "database.pool_size"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			isolateCLIAPIConfigEnv(t)
+			t.Setenv(tc.name, tc.value)
+
+			var stdout, stderr bytes.Buffer
+			code := executeRootCommandWithOptions(context.Background(), repoRoot(), []string{
+				"serve",
+				"--api-listen-addr", "127.0.0.1:0",
+				"--mcp-listen-addr", "127.0.0.1:0",
+			}, &stdout, &stderr, defaultRootCommandOptions())
+			if code != cliExitValidation {
+				t.Fatalf("code = %d, want %d stdout=%s stderr=%s", code, cliExitValidation, stdout.String(), stderr.String())
+			}
+			output := stdout.String() + stderr.String()
+			for _, want := range tc.want {
+				if !strings.Contains(output, want) {
+					t.Fatalf("output missing %q:\n%s", want, output)
+				}
+			}
+		})
+	}
+}
+
 func TestSwarmEnvGuardAllowsTypedDatabasePasswordEnvDelegation(t *testing.T) {
 	isolateCLIAPIConfigEnv(t)
 	t.Setenv("SWARM_DB_PASSWORD", "secret")
@@ -763,6 +802,14 @@ func TestDoctorTargetReportsRuntimeConfigEnvRejectors(t *testing.T) {
 		"SWARM_CLAUDE_CLI_TIMEOUT",
 		"SWARM_CLAUDE_TIMEOUT_SECONDS",
 		"SWARM_CLAUDE_CLI_RETRIES",
+		"SWARM_STORE_BACKEND",
+		"SWARM_SQLITE_PATH",
+		"SWARM_DB_HOST",
+		"SWARM_DB_PORT",
+		"SWARM_DB_NAME",
+		"SWARM_DB_USER",
+		"SWARM_DB_SSLMODE",
+		"SWARM_DB_POOL_SIZE",
 	}
 	for _, envName := range cases {
 		t.Run(envName, func(t *testing.T) {

--- a/cmd/swarm/env_guard.go
+++ b/cmd/swarm/env_guard.go
@@ -561,6 +561,13 @@ func swarmEnvCatalogEntries() []swarmEnvCatalogEntry {
 			"unset "+name+"; set "+key+" in unified swarm.yaml/runtime config",
 		)
 	}
+	retiredStoreDatabaseConfig := func(name, key string) swarmEnvCatalogEntry {
+		return retired(
+			name,
+			name+" is retired as store/database environment source; use "+key,
+			"unset "+name+"; set "+key+" in unified swarm.yaml/runtime config",
+		)
+	}
 	retiredUnsupported := func(name string) swarmEnvCatalogEntry {
 		return retired(
 			name,
@@ -585,14 +592,14 @@ func swarmEnvCatalogEntries() []swarmEnvCatalogEntry {
 		retired("SWARM_PLATFORM_SPEC_PATH", "SWARM_PLATFORM_SPEC_PATH is not promoted", "use --platform-spec or config platform_spec_path where supported"),
 		retired("SWARM_DIR", "SWARM_DIR is not promoted as state directory authority", "use --swarm-dir or config swarm_dir"),
 		retired("SWARM_HOME", "SWARM_HOME is not promoted as state directory authority", "use --swarm-dir or config swarm_dir"),
-		seeded("SWARM_STORE_BACKEND", "platform-spec.yaml#runtime_storage.runtime_store_backend_selection", "#1637 store.backend"),
-		seeded("SWARM_SQLITE_PATH", "platform-spec.yaml#runtime_storage.runtime_store_backend_selection.sqlite_path", "#1637 store.sqlite.path"),
-		seeded("SWARM_DB_HOST", "platform-spec.yaml#runtime_storage.runtime_store_backend_selection.postgres_connection_details", "#1637 database.host"),
-		seeded("SWARM_DB_PORT", "platform-spec.yaml#runtime_storage.runtime_store_backend_selection.postgres_connection_details", "#1637 database.port"),
-		seeded("SWARM_DB_NAME", "platform-spec.yaml#runtime_storage.runtime_store_backend_selection.postgres_connection_details", "#1637 database.name"),
-		seeded("SWARM_DB_USER", "platform-spec.yaml#runtime_storage.runtime_store_backend_selection.postgres_connection_details", "#1637 database.user"),
-		seeded("SWARM_DB_SSLMODE", "platform-spec.yaml#runtime_storage.runtime_store_backend_selection.postgres_connection_details", "#1637 database.sslmode"),
-		seeded("SWARM_DB_POOL_SIZE", "platform-spec.yaml#runtime_storage.runtime_store_backend_selection.postgres_connection_details", "#1637 database.pool_size"),
+		retiredStoreDatabaseConfig("SWARM_STORE_BACKEND", "--store or store.backend"),
+		retiredStoreDatabaseConfig("SWARM_SQLITE_PATH", "store.sqlite.path"),
+		retiredStoreDatabaseConfig("SWARM_DB_HOST", "database.host"),
+		retiredStoreDatabaseConfig("SWARM_DB_PORT", "database.port"),
+		retiredStoreDatabaseConfig("SWARM_DB_NAME", "database.name"),
+		retiredStoreDatabaseConfig("SWARM_DB_USER", "database.user"),
+		retiredStoreDatabaseConfig("SWARM_DB_SSLMODE", "database.sslmode"),
+		retiredStoreDatabaseConfig("SWARM_DB_POOL_SIZE", "database.pool_size"),
 		retired("SWARM_DB_PASSWORD", "SWARM_DB_PASSWORD is not read implicitly; it is accepted only when explicitly named by database.password_env", "unset SWARM_DB_PASSWORD or declare database.password_env: SWARM_DB_PASSWORD in the runtime config"),
 		seeded("SWARM_WORKSPACE_DATA_SOURCE", "platform-spec.yaml#workspace_model.data_source_authority", "#1600 workspace.data_source"),
 		seeded("SWARM_WORKSPACE_BACKEND", "platform-spec.yaml#workspace_model.workspace_backend_selection", "#1600 workspace.backend"),

--- a/cmd/swarm/local_runtime_state.go
+++ b/cmd/swarm/local_runtime_state.go
@@ -149,17 +149,11 @@ func resolveRuntimeStoreSelectionWithDefault(repo string, storeMode string, stor
 	if cfg == nil {
 		return storebackend.Selection{}, fmt.Errorf("runtime config is required")
 	}
-	envBackend, envBackendSet := os.LookupEnv(storebackend.EnvStoreBackend)
-	envSQLitePath, envSQLitePathSet := os.LookupEnv(storebackend.EnvSQLitePath)
 	return storebackend.Resolve(storebackend.Input{
 		RepoRoot:                repo,
 		FlagBackend:             storeMode,
 		FlagBackendSet:          storeModeSet,
-		EnvBackend:              envBackend,
-		EnvBackendSet:           envBackendSet,
 		ConfigBackend:           cfg.Store.Backend,
-		EnvSQLitePath:           envSQLitePath,
-		EnvSQLitePathSet:        envSQLitePathSet,
 		ConfigSQLitePath:        cfg.Store.SQLite.Path,
 		DefaultSQLitePath:       defaultSQLitePath,
 		DefaultSQLitePathSource: defaultSQLiteSource,

--- a/cmd/swarm/main.go
+++ b/cmd/swarm/main.go
@@ -2538,12 +2538,12 @@ func defaultRuntimeConfig() (*config.Config, error) {
 			RecoveryOnStartup: false,
 		},
 		Database: config.DatabaseConfig{
-			Host:     envOrDefault("SWARM_DB_HOST", envOrDefault("PGHOST", "127.0.0.1")),
-			Port:     envInt("SWARM_DB_PORT", envInt("PGPORT", 5432)),
-			Name:     envOrDefault("SWARM_DB_NAME", envOrDefault("PGDATABASE", "swarm")),
-			User:     envOrDefault("SWARM_DB_USER", envOrDefault("PGUSER", "postgres")),
-			SSLMode:  envOrDefault("SWARM_DB_SSLMODE", "disable"),
-			PoolSize: envInt("SWARM_DB_POOL_SIZE", 5),
+			Host:     "127.0.0.1",
+			Port:     5432,
+			Name:     "swarm",
+			User:     "postgres",
+			SSLMode:  "disable",
+			PoolSize: 5,
 		},
 		LLM: config.LLMConfig{
 			Backend: llmselection.DefaultBackendID(),
@@ -2586,51 +2586,6 @@ func rejectUnsupportedRuntimeControlEnv() error {
 	}
 	sort.Strings(unsupported)
 	return fmt.Errorf("unsupported inert runtime controls configured: %s", strings.Join(unsupported, ", "))
-}
-
-func envOrDefault(key, fallback string) string {
-	if value := strings.TrimSpace(os.Getenv(key)); value != "" {
-		return value
-	}
-	return fallback
-}
-
-func envInt(key string, fallback int) int {
-	raw := strings.TrimSpace(os.Getenv(key))
-	if raw == "" {
-		return fallback
-	}
-	value, err := strconv.Atoi(raw)
-	if err != nil {
-		return fallback
-	}
-	return value
-}
-
-func envDuration(key string, fallback time.Duration) time.Duration {
-	raw := strings.TrimSpace(os.Getenv(key))
-	if raw == "" {
-		return fallback
-	}
-	value, err := time.ParseDuration(raw)
-	if err != nil {
-		return fallback
-	}
-	return value
-}
-
-func envBool(key string, fallback bool) bool {
-	raw := strings.TrimSpace(strings.ToLower(os.Getenv(key)))
-	switch raw {
-	case "1", "true", "yes", "on":
-		return true
-	case "0", "false", "no", "off":
-		return false
-	case "":
-		return fallback
-	default:
-		return fallback
-	}
 }
 
 func normalizeContractsRoot(path string) (string, error) {

--- a/cmd/swarm/main_test.go
+++ b/cmd/swarm/main_test.go
@@ -3965,7 +3965,6 @@ func TestRunServeRuntimeEventPublishRunIDFollowUpServedPathDefaultSQLite(t *test
 	unsetStoreSelectorEnv(t)
 	stubServeRuntimeWorkspaceLifecycle(t)
 	sqlitePath := filepath.Join(t.TempDir(), ".swarm", "dev.db")
-	t.Setenv(storebackend.EnvSQLitePath, sqlitePath)
 	contractsPath := writeServedEventPublishFollowUpFixture(t)
 	bundleHash := servedEventPublishFixtureBundleHash(t, contractsPath)
 	probe := lifecycletest.New(t, lifecycletest.WithTimeout(servedEventPublishLifecycleProbeWaitTimeout))
@@ -3982,7 +3981,7 @@ func TestRunServeRuntimeEventPublishRunIDFollowUpServedPathDefaultSQLite(t *test
 		return stores, err
 	}
 	endpoint, _ := startServedEventPublishFollowUpRuntime(t, serveOptions{
-		ConfigPath:              writeServeRuntimeTestConfig(t),
+		ConfigPath:              writeStoreBackendRuntimeConfig(t, storebackend.BackendSQLite.String(), sqlitePath),
 		ContractsPath:           contractsPath,
 		PlatformSpecPath:        defaultPlatformSpecPath,
 		APIListenAddr:           "127.0.0.1:0",
@@ -4030,7 +4029,6 @@ func TestRunServeRuntimeEventPublishTargetRouteServedPathDefaultSQLite(t *testin
 	unsetStoreSelectorEnv(t)
 	stubServeRuntimeWorkspaceLifecycle(t)
 	sqlitePath := filepath.Join(t.TempDir(), ".swarm", "dev.db")
-	t.Setenv(storebackend.EnvSQLitePath, sqlitePath)
 	contractsPath := writeServedEventPublishTargetRouteFixture(t)
 	bundleHash := servedEventPublishFixtureBundleHash(t, contractsPath)
 	probe := lifecycletest.New(t, lifecycletest.WithTimeout(servedEventPublishLifecycleProbeWaitTimeout))
@@ -4047,7 +4045,7 @@ func TestRunServeRuntimeEventPublishTargetRouteServedPathDefaultSQLite(t *testin
 		return stores, err
 	}
 	endpoint, _ := startServedEventPublishFollowUpRuntime(t, serveOptions{
-		ConfigPath:              writeServeRuntimeTestConfig(t),
+		ConfigPath:              writeStoreBackendRuntimeConfig(t, storebackend.BackendSQLite.String(), sqlitePath),
 		ContractsPath:           contractsPath,
 		PlatformSpecPath:        defaultPlatformSpecPath,
 		APIListenAddr:           "127.0.0.1:0",
@@ -4095,7 +4093,6 @@ func TestRunServeRuntimeEventPublishExistingRunActiveLoadServedPathDefaultSQLite
 	unsetStoreSelectorEnv(t)
 	stubServeRuntimeWorkspaceLifecycle(t)
 	sqlitePath := filepath.Join(t.TempDir(), ".swarm", "dev.db")
-	t.Setenv(storebackend.EnvSQLitePath, sqlitePath)
 	contractsPath := writeServedEventPublishActiveLoadFixture(t)
 	bundleHash := servedEventPublishFixtureBundleHash(t, contractsPath)
 	probe := lifecycletest.New(t, lifecycletest.WithTimeout(servedEventPublishLifecycleProbeWaitTimeout))
@@ -4115,7 +4112,7 @@ func TestRunServeRuntimeEventPublishExistingRunActiveLoadServedPathDefaultSQLite
 		return stores, err
 	}
 	endpoint, _ := startServedEventPublishFollowUpRuntime(t, serveOptions{
-		ConfigPath:              writeServeRuntimeTestConfig(t),
+		ConfigPath:              writeStoreBackendRuntimeConfig(t, storebackend.BackendSQLite.String(), sqlitePath),
 		ContractsPath:           contractsPath,
 		PlatformSpecPath:        defaultPlatformSpecPath,
 		APIListenAddr:           "127.0.0.1:0",
@@ -4195,7 +4192,6 @@ func runServedDynamicAutoEmitSQLiteProof(t *testing.T) {
 	unsetStoreSelectorEnv(t)
 	stubServeRuntimeWorkspaceLifecycle(t)
 	sqlitePath := filepath.Join(t.TempDir(), ".swarm", "dev.db")
-	t.Setenv(storebackend.EnvSQLitePath, sqlitePath)
 	contractsPath := writeServedDynamicAutoEmitFixture(t)
 	bundleHash := servedEventPublishFixtureBundleHash(t, contractsPath)
 	blocked := make(chan servedEventPublishPreHandlerProof, 1)
@@ -4218,7 +4214,7 @@ func runServedDynamicAutoEmitSQLiteProof(t *testing.T) {
 		hook   runtimepipeline.WorkflowNodeHandlerStartHook
 	)
 	endpoint, _ := startServedEventPublishFollowUpRuntime(t, serveOptions{
-		ConfigPath:              writeServeRuntimeTestConfig(t),
+		ConfigPath:              writeStoreBackendRuntimeConfig(t, storebackend.BackendSQLite.String(), sqlitePath),
 		ContractsPath:           contractsPath,
 		PlatformSpecPath:        defaultPlatformSpecPath,
 		APIListenAddr:           "127.0.0.1:0",
@@ -6244,9 +6240,8 @@ func TestRunServeRuntimePassesDataFlagToWorkspaceLifecycle(t *testing.T) {
 func TestRunServeRuntimeHostWorkspaceBackendBootsWithoutDockerForSystemOnlyFlow(t *testing.T) {
 	t.Setenv("SWARM_DOCKER_BIN", filepath.Join(t.TempDir(), "missing-docker"))
 	t.Setenv("SWARM_WORKSPACE_HOST_ROOT", filepath.Join(t.TempDir(), "host-workspaces"))
-	t.Setenv(storebackend.EnvSQLitePath, filepath.Join(t.TempDir(), "runtime.db"))
 	dataDir := t.TempDir()
-	configPath := writeServeRuntimeTestConfig(t)
+	configPath := writeStoreBackendRuntimeConfig(t, storebackend.BackendSQLite.String(), filepath.Join(t.TempDir(), "runtime.db"))
 
 	serve := startServeRuntimeTestProcess(t, serveOptions{
 		ConfigPath:           configPath,
@@ -6275,10 +6270,9 @@ func TestRunServeRuntimeHostWorkspaceBackendBootsWithoutDockerForSystemOnlyFlow(
 
 func TestRunServeRuntimeNoAgentDefaultBootsWithoutDocker(t *testing.T) {
 	t.Setenv("SWARM_DOCKER_BIN", filepath.Join(t.TempDir(), "missing-docker"))
-	t.Setenv(storebackend.EnvSQLitePath, filepath.Join(t.TempDir(), "runtime.db"))
 
 	serve := startServeRuntimeTestProcess(t, serveOptions{
-		ConfigPath:           writeServeRuntimeTestConfig(t),
+		ConfigPath:           writeStoreBackendRuntimeConfig(t, storebackend.BackendSQLite.String(), filepath.Join(t.TempDir(), "runtime.db")),
 		ContractsPath:        filepath.Join("tests", "tier1-primitives", "test-emits-single"),
 		DataSource:           t.TempDir(),
 		PlatformSpecPath:     defaultPlatformSpecPath,
@@ -6306,10 +6300,9 @@ func TestRunServeRuntimeNoAgentDefaultBootsWithoutDocker(t *testing.T) {
 func TestRunServeRuntimeAPIAgentDefaultHostBootsWithoutDocker(t *testing.T) {
 	t.Setenv("SWARM_DOCKER_BIN", filepath.Join(t.TempDir(), "missing-docker"))
 	t.Setenv("SWARM_WORKSPACE_HOST_ROOT", filepath.Join(t.TempDir(), "host-workspaces"))
-	t.Setenv(storebackend.EnvSQLitePath, filepath.Join(t.TempDir(), "runtime.db"))
 
 	serve := startServeRuntimeTestProcess(t, serveOptions{
-		ConfigPath:           writeServeRuntimeTestConfig(t),
+		ConfigPath:           writeStoreBackendRuntimeConfig(t, storebackend.BackendSQLite.String(), filepath.Join(t.TempDir(), "runtime.db")),
 		ContractsPath:        writeServeRuntimeAgentSlugFixture(t, "api-agent-host-default", "api-worker"),
 		DataSource:           t.TempDir(),
 		PlatformSpecPath:     defaultPlatformSpecPath,
@@ -6338,11 +6331,10 @@ func TestRunServeRuntimeAPIAgentDefaultHostBootsWithoutDocker(t *testing.T) {
 
 func TestRunServeRuntimeNativeBashDefaultDockerFailsWithoutDocker(t *testing.T) {
 	t.Setenv("SWARM_DOCKER_BIN", filepath.Join(t.TempDir(), "missing-docker"))
-	t.Setenv(storebackend.EnvSQLitePath, filepath.Join(t.TempDir(), "runtime.db"))
 
 	var out lockedBuffer
 	code := runServeRuntime(context.Background(), repoRoot(), serveOptions{
-		ConfigPath:           writeServeRuntimeTestConfig(t),
+		ConfigPath:           writeStoreBackendRuntimeConfig(t, storebackend.BackendSQLite.String(), filepath.Join(t.TempDir(), "runtime.db")),
 		ContractsPath:        writeServeRuntimeNativeBashFixture(t),
 		DataSource:           t.TempDir(),
 		PlatformSpecPath:     defaultPlatformSpecPath,
@@ -6443,11 +6435,10 @@ func runServeRuntimeFreshEmptySQLiteBootsWithAbandon(t *testing.T, dev bool) {
 	stubServeRuntimeWorkspaceLifecycle(t)
 	unsetStoreSelectorEnv(t)
 	sqlitePath := filepath.Join(t.TempDir(), ".swarm", "dev.db")
-	t.Setenv(storebackend.EnvSQLitePath, sqlitePath)
 	requireBundleMatch := !dev
 	noRequireBundleMatch := dev
 	serve := startServeRuntimeTestProcess(t, serveOptions{
-		ConfigPath:           writeServeRuntimeTestConfig(t),
+		ConfigPath:           writeStoreBackendRuntimeConfig(t, storebackend.BackendSQLite.String(), sqlitePath),
 		ContractsPath:        filepath.Join("tests", "tier8-boot-verification", "test-boot-success"),
 		PlatformSpecPath:     defaultPlatformSpecPath,
 		APIListenAddr:        "127.0.0.1:0",
@@ -6476,7 +6467,6 @@ func TestRunServeRuntimeArtifactRepoCommitFailsBeforeReadinessForUnusableArtifac
 	stubServeRuntimeWorkspaceLifecycle(t)
 	unsetStoreSelectorEnv(t)
 	sqlitePath := filepath.Join(t.TempDir(), ".swarm", "dev.db")
-	t.Setenv(storebackend.EnvSQLitePath, sqlitePath)
 	rootFile := filepath.Join(t.TempDir(), "artifact-root")
 	if err := os.WriteFile(rootFile, []byte("not a directory"), 0o644); err != nil {
 		t.Fatalf("write unusable artifact root: %v", err)
@@ -6485,7 +6475,7 @@ func TestRunServeRuntimeArtifactRepoCommitFailsBeforeReadinessForUnusableArtifac
 
 	var out lockedBuffer
 	code := runServeRuntime(context.Background(), repoRoot(), serveOptions{
-		ConfigPath:           writeServeRuntimeTestConfig(t),
+		ConfigPath:           writeStoreBackendRuntimeConfig(t, storebackend.BackendSQLite.String(), sqlitePath),
 		ContractsPath:        writeArtifactRepoCommitServeFixture(t),
 		PlatformSpecPath:     defaultPlatformSpecPath,
 		StoreMode:            "sqlite",
@@ -6521,7 +6511,6 @@ func TestRunServeRuntimeArtifactRepoCommitFailsBeforeReadinessForBlockedRepoStor
 	stubServeRuntimeWorkspaceLifecycle(t)
 	unsetStoreSelectorEnv(t)
 	sqlitePath := filepath.Join(t.TempDir(), ".swarm", "dev.db")
-	t.Setenv(storebackend.EnvSQLitePath, sqlitePath)
 	artifactRoot := t.TempDir()
 	reposFile := filepath.Join(artifactRoot, "repos")
 	if err := os.WriteFile(reposFile, []byte("not a directory"), 0o644); err != nil {
@@ -6531,7 +6520,7 @@ func TestRunServeRuntimeArtifactRepoCommitFailsBeforeReadinessForBlockedRepoStor
 
 	var out lockedBuffer
 	code := runServeRuntime(context.Background(), repoRoot(), serveOptions{
-		ConfigPath:           writeServeRuntimeTestConfig(t),
+		ConfigPath:           writeStoreBackendRuntimeConfig(t, storebackend.BackendSQLite.String(), sqlitePath),
 		ContractsPath:        writeArtifactRepoCommitServeFixture(t),
 		PlatformSpecPath:     defaultPlatformSpecPath,
 		StoreMode:            "sqlite",
@@ -6568,7 +6557,6 @@ func TestRunServeRuntimeNonArtifactBundleDoesNotExerciseUnusableArtifactRoot(t *
 	stubServeRuntimeWorkspaceLifecycle(t)
 	unsetStoreSelectorEnv(t)
 	sqlitePath := filepath.Join(t.TempDir(), ".swarm", "dev.db")
-	t.Setenv(storebackend.EnvSQLitePath, sqlitePath)
 	rootFile := filepath.Join(t.TempDir(), "artifact-root")
 	if err := os.WriteFile(rootFile, []byte("not a directory"), 0o644); err != nil {
 		t.Fatalf("write unusable artifact root: %v", err)
@@ -6576,7 +6564,7 @@ func TestRunServeRuntimeNonArtifactBundleDoesNotExerciseUnusableArtifactRoot(t *
 	t.Setenv("SWARM_ARTIFACT_ROOT", rootFile)
 
 	serve := startServeRuntimeTestProcess(t, serveOptions{
-		ConfigPath:           writeServeRuntimeTestConfig(t),
+		ConfigPath:           writeStoreBackendRuntimeConfig(t, storebackend.BackendSQLite.String(), sqlitePath),
 		ContractsPath:        filepath.Join("tests", "tier8-boot-verification", "test-boot-success"),
 		PlatformSpecPath:     defaultPlatformSpecPath,
 		StoreMode:            "sqlite",
@@ -6603,10 +6591,9 @@ func TestRunServeRuntimeSQLiteAbandonActiveRunsQuiescesBeforeReadiness(t *testin
 	unsetStoreSelectorEnv(t)
 	sqlitePath := filepath.Join(t.TempDir(), ".swarm", "dev.db")
 	runID, eventID := seedServeRuntimeSQLiteAbandonWork(t, sqlitePath)
-	t.Setenv(storebackend.EnvSQLitePath, sqlitePath)
 	ctx := context.Background()
 	serve := startServeRuntimeTestProcess(t, serveOptions{
-		ConfigPath:         writeServeRuntimeTestConfig(t),
+		ConfigPath:         writeStoreBackendRuntimeConfig(t, storebackend.BackendSQLite.String(), sqlitePath),
 		ContractsPath:      filepath.Join("tests", "tier8-boot-verification", "test-boot-success"),
 		PlatformSpecPath:   defaultPlatformSpecPath,
 		APIListenAddr:      "127.0.0.1:0",
@@ -8832,12 +8819,7 @@ func setPostgresEnvFromDSN(t *testing.T, dsn string) {
 		env string
 		key string
 	}{
-		{"PGHOST", "host"},
-		{"PGPORT", "port"},
-		{"PGDATABASE", "dbname"},
-		{"PGUSER", "user"},
 		{"PGPASSWORD", "password"},
-		{"SWARM_DB_SSLMODE", "sslmode"},
 	} {
 		if value := strings.TrimSpace(values[item.key]); value != "" {
 			t.Setenv(item.env, value)

--- a/cmd/swarm/run_command_test.go
+++ b/cmd/swarm/run_command_test.go
@@ -22,6 +22,7 @@ import (
 func TestRunCommandLocalForegroundConsumesServeOwnerAndV1API(t *testing.T) {
 	isolateCLIAPIConfigEnv(t)
 	payloadPath := writeRunCommandPayloadFile(t, map[string]any{"entity_id": "entity-1"})
+	tracePrinted := make(chan struct{})
 	server, calls, wsRequests := newRunCommandServer(t, runCommandServerOptions{
 		expectedToken: apiv1.DefaultLoopbackAPIToken,
 		rpcResponder: func(req jsonRPCRequest, callIndex int) map[string]any {
@@ -41,8 +42,12 @@ func TestRunCommandLocalForegroundConsumesServeOwnerAndV1API(t *testing.T) {
 				return map[string]any{"run_id": "run-local", "status": "running"}
 			case "run.get":
 				run := validDiagnosticRunHeader("run-local")
-				run["status"] = "completed"
-				run["ended_at"] = "2026-05-13T10:01:00Z"
+				select {
+				case <-tracePrinted:
+					run["status"] = "completed"
+					run["ended_at"] = "2026-05-13T10:01:00Z"
+				default:
+				}
 				return map[string]any{"run": run}
 			default:
 				t.Fatalf("unexpected method[%d] = %q", callIndex, req.Method)
@@ -74,8 +79,9 @@ func TestRunCommandLocalForegroundConsumesServeOwnerAndV1API(t *testing.T) {
 		return 0
 	}
 
-	var stdout, stderr bytes.Buffer
-	code := executeRootCommandWithOptions(context.Background(), repo, []string{"run", "start", "--event", "scan.requested", "--payload", payloadPath, "--config", configPath, "--backend", "claude_cli", "--contracts", "contracts", "--data", "reference-data", "--platform-spec", "platform.yaml"}, &stdout, &stderr, opts)
+	stdout := &notifyingBuffer{needle: "trace event_id=evt-local", notify: tracePrinted}
+	var stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), repo, []string{"run", "start", "--event", "scan.requested", "--payload", payloadPath, "--config", configPath, "--backend", "claude_cli", "--contracts", "contracts", "--data", "reference-data", "--platform-spec", "platform.yaml"}, stdout, &stderr, opts)
 	if code != 0 {
 		t.Fatalf("code = %d stdout=%s stderr=%s", code, stdout.String(), stderr.String())
 	}

--- a/cmd/swarm/store_backend_selection_test.go
+++ b/cmd/swarm/store_backend_selection_test.go
@@ -39,9 +39,9 @@ func TestResolveRuntimeStoreSelectionConsumesCanonicalSources(t *testing.T) {
 		}
 	})
 
-	t.Run("runtime config beats env", func(t *testing.T) {
+	t.Run("runtime config ignores retired env", func(t *testing.T) {
 		unsetStoreSelectorEnv(t)
-		t.Setenv(storebackend.EnvStoreBackend, storebackend.BackendPostgres.String())
+		t.Setenv("SWARM_STORE_BACKEND", storebackend.BackendPostgres.String())
 		got, err := resolveRuntimeStoreSelection(t.TempDir(), storebackend.ActiveDefaultBackend().String(), false, &config.Config{
 			Store: config.StoreConfig{Backend: storebackend.BackendSQLite.String()},
 		})
@@ -53,22 +53,22 @@ func TestResolveRuntimeStoreSelectionConsumesCanonicalSources(t *testing.T) {
 		}
 	})
 
-	t.Run("env fallback remains visible", func(t *testing.T) {
+	t.Run("retired env does not affect rollout default", func(t *testing.T) {
 		unsetStoreSelectorEnv(t)
-		t.Setenv(storebackend.EnvStoreBackend, storebackend.BackendPostgres.String())
+		t.Setenv("SWARM_STORE_BACKEND", storebackend.BackendPostgres.String())
 		got, err := resolveRuntimeStoreSelection(t.TempDir(), storebackend.ActiveDefaultBackend().String(), false, &config.Config{})
 		if err != nil {
 			t.Fatalf("resolveRuntimeStoreSelection: %v", err)
 		}
-		if got.Backend != storebackend.BackendPostgres || got.BackendSource != storebackend.SourceEnvironment {
-			t.Fatalf("selection = %#v, want env fallback postgres", got)
+		if got.Backend != storebackend.BackendSQLite || got.BackendSource != storebackend.SourceRolloutDefault {
+			t.Fatalf("selection = %#v, want retired env to leave rollout default sqlite", got)
 		}
 	})
 
-	t.Run("runtime config sqlite path beats env", func(t *testing.T) {
+	t.Run("runtime config sqlite path ignores retired env", func(t *testing.T) {
 		unsetStoreSelectorEnv(t)
 		repo := t.TempDir()
-		t.Setenv(storebackend.EnvSQLitePath, "env/dev.db")
+		t.Setenv("SWARM_SQLITE_PATH", "env/dev.db")
 		got, err := resolveRuntimeStoreSelection(repo, storebackend.ActiveDefaultBackend().String(), false, &config.Config{
 			Store: config.StoreConfig{
 				Backend: storebackend.BackendSQLite.String(),
@@ -83,23 +83,23 @@ func TestResolveRuntimeStoreSelectionConsumesCanonicalSources(t *testing.T) {
 		}
 	})
 
-	t.Run("env sqlite path fallback remains visible", func(t *testing.T) {
+	t.Run("retired sqlite path env does not affect default", func(t *testing.T) {
 		unsetStoreSelectorEnv(t)
 		repo := t.TempDir()
-		t.Setenv(storebackend.EnvSQLitePath, "env/dev.db")
+		t.Setenv("SWARM_SQLITE_PATH", "env/dev.db")
 		got, err := resolveRuntimeStoreSelection(repo, storebackend.ActiveDefaultBackend().String(), false, &config.Config{})
 		if err != nil {
 			t.Fatalf("resolveRuntimeStoreSelection: %v", err)
 		}
-		if want := filepath.Join(repo, "env", "dev.db"); got.SQLitePath != want || got.SQLitePathSource != storebackend.SourceEnvironment {
-			t.Fatalf("sqlite path = %q source %q, want %q from env fallback", got.SQLitePath, got.SQLitePathSource, want)
+		if !strings.HasSuffix(got.SQLitePath, filepath.Join("stores", "default", "dev.db")) || got.SQLitePathSource != storebackend.SourceSwarmDirDefault {
+			t.Fatalf("sqlite path = %q source %q, want swarm-dir default not retired env", got.SQLitePath, got.SQLitePathSource)
 		}
 	})
 
-	t.Run("flag beats env and config", func(t *testing.T) {
+	t.Run("flag beats config and ignores retired env", func(t *testing.T) {
 		unsetStoreSelectorEnv(t)
 		repo := t.TempDir()
-		t.Setenv(storebackend.EnvStoreBackend, storebackend.BackendPostgres.String())
+		t.Setenv("SWARM_STORE_BACKEND", storebackend.BackendPostgres.String())
 		got, err := resolveRuntimeStoreSelection(repo, storebackend.BackendSQLite.String(), true, &config.Config{
 			Store: config.StoreConfig{
 				Backend: storebackend.BackendPostgres.String(),
@@ -123,8 +123,6 @@ func TestRunServeRuntimeConsumesCanonicalStoreSelectionBeforeStoreConstruction(t
 		name        string
 		storeMode   string
 		storeFlag   bool
-		envBackend  string
-		envPath     string
 		configStore string
 		configPath  string
 		wantBackend storebackend.Backend
@@ -142,24 +140,14 @@ func TestRunServeRuntimeConsumesCanonicalStoreSelectionBeforeStoreConstruction(t
 			name:        "flag postgres reaches store construction",
 			storeMode:   storebackend.BackendPostgres.String(),
 			storeFlag:   true,
-			envBackend:  storebackend.BackendSQLite.String(),
 			configStore: storebackend.BackendSQLite.String(),
 			configPath:  "config/dev.db",
 			wantBackend: storebackend.BackendPostgres,
 			wantSource:  storebackend.SourceFlag,
 		},
 		{
-			name:        "env postgres fallback reaches store construction",
+			name:        "config sqlite reaches store construction",
 			storeMode:   storebackend.ActiveDefaultBackend().String(),
-			envBackend:  storebackend.BackendPostgres.String(),
-			wantBackend: storebackend.BackendPostgres,
-			wantSource:  storebackend.SourceEnvironment,
-		},
-		{
-			name:        "config sqlite beats env selectors before store construction",
-			storeMode:   storebackend.ActiveDefaultBackend().String(),
-			envBackend:  storebackend.BackendPostgres.String(),
-			envPath:     "env/dev.db",
 			configStore: storebackend.BackendSQLite.String(),
 			configPath:  "config/dev.db",
 			wantBackend: storebackend.BackendSQLite,
@@ -177,12 +165,6 @@ func TestRunServeRuntimeConsumesCanonicalStoreSelectionBeforeStoreConstruction(t
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			unsetStoreSelectorEnv(t)
-			if tt.envBackend != "" {
-				t.Setenv(storebackend.EnvStoreBackend, tt.envBackend)
-			}
-			if tt.envPath != "" {
-				t.Setenv(storebackend.EnvSQLitePath, tt.envPath)
-			}
 			oldBuildStores := buildStoresForServe
 			var captured storebackend.Selection
 			buildStoresForServe = func(_ context.Context, selection storebackend.Selection, _ *config.Config) (storeBundle, error) {
@@ -265,13 +247,17 @@ func TestDatabaseEnvDetailsDoNotImplyPostgresSelection(t *testing.T) {
 	t.Setenv("SWARM_DB_USER", "db_env_user")
 	t.Setenv("SWARM_DB_SSLMODE", "require")
 	t.Setenv("SWARM_DB_POOL_SIZE", "9")
+	t.Setenv("PGHOST", "pg-env-host")
+	t.Setenv("PGPORT", "25432")
+	t.Setenv("PGDATABASE", "pg_env_name")
+	t.Setenv("PGUSER", "pg_env_user")
 
 	cfg, err := defaultRuntimeConfig()
 	if err != nil {
 		t.Fatalf("defaultRuntimeConfig: %v", err)
 	}
-	if cfg.Database.Host != "db-env-host" || cfg.Database.Port != 15432 || cfg.Database.Name != "db_env_name" || cfg.Database.User != "db_env_user" || cfg.Database.SSLMode != "require" || cfg.Database.PoolSize != 9 {
-		t.Fatalf("database env fallback not reflected in built-in default config: %#v", cfg.Database)
+	if cfg.Database.Host != "127.0.0.1" || cfg.Database.Port != 5432 || cfg.Database.Name != "swarm" || cfg.Database.User != "postgres" || cfg.Database.SSLMode != "disable" || cfg.Database.PoolSize != 5 {
+		t.Fatalf("database env fallback affected built-in default config: %#v", cfg.Database)
 	}
 	got, err := resolveRuntimeStoreSelection(t.TempDir(), storebackend.ActiveDefaultBackend().String(), false, cfg)
 	if err != nil {
@@ -283,9 +269,7 @@ func TestDatabaseEnvDetailsDoNotImplyPostgresSelection(t *testing.T) {
 }
 
 func TestExplicitRuntimeConfigDatabaseBeatsDatabaseEnv(t *testing.T) {
-	t.Setenv("SWARM_DB_HOST", "db-env-host")
 	t.Setenv("PGHOST", "pg-env-host")
-	t.Setenv("SWARM_DB_PASSWORD", "env-password")
 	t.Setenv("PGPASSWORD", "pg-env-password")
 
 	cfgResult, err := loadRuntimeConfigWithOptions(runtimeConfigLoadOptions{
@@ -789,8 +773,8 @@ func writeStoreDatabaseRuntimeConfig(t *testing.T) string {
 
 func unsetStoreSelectorEnv(t *testing.T) {
 	t.Helper()
-	unsetEnvForTest(t, storebackend.EnvStoreBackend)
-	unsetEnvForTest(t, storebackend.EnvSQLitePath)
+	unsetEnvForTest(t, "SWARM_STORE_BACKEND")
+	unsetEnvForTest(t, "SWARM_SQLITE_PATH")
 }
 
 func unsetEnvForTest(t *testing.T, key string) {

--- a/cmd/swarm/test_command_test.go
+++ b/cmd/swarm/test_command_test.go
@@ -1363,10 +1363,9 @@ func TestSwarmTestServedSQLiteNoLiveLLMProof(t *testing.T) {
 	unsetStoreSelectorEnv(t)
 	stubServeRuntimeWorkspaceLifecycle(t)
 	sqlitePath := filepath.Join(t.TempDir(), ".swarm", "dev.db")
-	t.Setenv(storebackend.EnvSQLitePath, sqlitePath)
 	contractsPath := writeScenarioRunnerFixture(t)
 	endpoint, _ := startServedEventPublishFollowUpRuntime(t, serveOptions{
-		ConfigPath:              writeServeRuntimeTestConfig(t),
+		ConfigPath:              writeStoreBackendRuntimeConfig(t, storebackend.BackendSQLite.String(), sqlitePath),
 		ContractsPath:           contractsPath,
 		PlatformSpecPath:        defaultPlatformSpecPath,
 		APIListenAddr:           "127.0.0.1:0",

--- a/internal/store/backendselection/selection.go
+++ b/internal/store/backendselection/selection.go
@@ -12,9 +12,6 @@ const (
 	BackendPostgres Backend = "postgres"
 	BackendSQLite   Backend = "sqlite"
 
-	EnvStoreBackend = "SWARM_STORE_BACKEND"
-	EnvSQLitePath   = "SWARM_SQLITE_PATH"
-
 	ConfigStoreBackendKey = "store.backend"
 	ConfigSQLitePathKey   = "store.sqlite.path"
 
@@ -25,7 +22,6 @@ type Source string
 
 const (
 	SourceFlag            Source = "flag"
-	SourceEnvironment     Source = "environment"
 	SourceRuntimeConfig   Source = "runtime_config"
 	SourceRolloutDefault  Source = "rollout_default"
 	SourceProjectDefault  Source = "project_default"
@@ -38,13 +34,7 @@ type Input struct {
 	FlagBackend    string
 	FlagBackendSet bool
 
-	EnvBackend    string
-	EnvBackendSet bool
-
 	ConfigBackend string
-
-	EnvSQLitePath    string
-	EnvSQLitePathSet bool
 
 	ConfigSQLitePath string
 
@@ -96,9 +86,6 @@ func resolveBackend(in Input) (Backend, Source, error) {
 	case strings.TrimSpace(in.ConfigBackend) != "":
 		backend, err := parseBackend(in.ConfigBackend, SourceRuntimeConfig)
 		return backend, SourceRuntimeConfig, err
-	case in.EnvBackendSet:
-		backend, err := parseBackend(in.EnvBackend, SourceEnvironment)
-		return backend, SourceEnvironment, err
 	default:
 		return ActiveDefaultBackend(), SourceRolloutDefault, nil
 	}
@@ -124,9 +111,6 @@ func resolveSQLitePath(in Input) (string, Source, error) {
 	case strings.TrimSpace(in.ConfigSQLitePath) != "":
 		path, err := normalizeSQLitePath(in.RepoRoot, in.ConfigSQLitePath, SourceRuntimeConfig)
 		return path, SourceRuntimeConfig, err
-	case in.EnvSQLitePathSet:
-		path, err := normalizeSQLitePath(in.RepoRoot, in.EnvSQLitePath, SourceEnvironment)
-		return path, SourceEnvironment, err
 	default:
 		source := in.DefaultSQLitePathSource
 		if source == "" {

--- a/internal/store/backendselection/selection_test.go
+++ b/internal/store/backendselection/selection_test.go
@@ -15,44 +15,17 @@ func TestResolveBackendSourcePrecedence(t *testing.T) {
 		src  Source
 	}{
 		{
-			name: "flag beats environment and config",
+			name: "flag beats config",
 			in: Input{
 				RepoRoot:                repo,
 				FlagBackend:             "sqlite",
 				FlagBackendSet:          true,
-				EnvBackend:              "postgres",
-				EnvBackendSet:           true,
 				ConfigBackend:           "postgres",
 				DefaultSQLitePath:       filepath.Join(repo, "default.db"),
 				DefaultSQLitePathSource: SourceRolloutDefault,
 			},
 			want: BackendSQLite,
 			src:  SourceFlag,
-		},
-		{
-			name: "runtime config beats environment",
-			in: Input{
-				RepoRoot:                repo,
-				EnvBackend:              "sqlite",
-				EnvBackendSet:           true,
-				ConfigBackend:           "postgres",
-				DefaultSQLitePath:       filepath.Join(repo, "default.db"),
-				DefaultSQLitePathSource: SourceRolloutDefault,
-			},
-			want: BackendPostgres,
-			src:  SourceRuntimeConfig,
-		},
-		{
-			name: "environment fallback beats rollout default",
-			in: Input{
-				RepoRoot:                repo,
-				EnvBackend:              "sqlite",
-				EnvBackendSet:           true,
-				DefaultSQLitePath:       filepath.Join(repo, "default.db"),
-				DefaultSQLitePathSource: SourceRolloutDefault,
-			},
-			want: BackendSQLite,
-			src:  SourceEnvironment,
 		},
 		{
 			name: "runtime config beats rollout default",
@@ -90,7 +63,7 @@ func TestResolveBackendSourcePrecedence(t *testing.T) {
 }
 
 func TestResolveRejectsInvalidSelectedBackend(t *testing.T) {
-	_, err := Resolve(Input{EnvBackend: "mysql", EnvBackendSet: true})
+	_, err := Resolve(Input{ConfigBackend: "mysql"})
 	if err == nil {
 		t.Fatal("Resolve unexpectedly accepted invalid backend")
 	}
@@ -113,20 +86,6 @@ func TestResolveIgnoresInvalidLowerPriorityConfigBackend(t *testing.T) {
 	}
 }
 
-func TestResolveIgnoresInvalidLowerPriorityEnvironmentBackend(t *testing.T) {
-	got, err := Resolve(Input{
-		EnvBackend:    "mysql",
-		EnvBackendSet: true,
-		ConfigBackend: "postgres",
-	})
-	if err != nil {
-		t.Fatalf("Resolve: %v", err)
-	}
-	if got.Backend != BackendPostgres || got.BackendSource != SourceRuntimeConfig {
-		t.Fatalf("selection = %#v, want config-selected postgres", got)
-	}
-}
-
 func TestResolveSQLitePathSources(t *testing.T) {
 	repo := t.TempDir()
 	tests := []struct {
@@ -135,35 +94,6 @@ func TestResolveSQLitePathSources(t *testing.T) {
 		want string
 		src  Source
 	}{
-		{
-			name: "config path beats env path",
-			in: Input{
-				RepoRoot:                repo,
-				FlagBackend:             "sqlite",
-				FlagBackendSet:          true,
-				EnvSQLitePath:           "env/dev.db",
-				EnvSQLitePathSet:        true,
-				ConfigSQLitePath:        "config/dev.db",
-				DefaultSQLitePath:       filepath.Join(repo, "default.db"),
-				DefaultSQLitePathSource: SourceRolloutDefault,
-			},
-			want: filepath.Join(repo, "config", "dev.db"),
-			src:  SourceRuntimeConfig,
-		},
-		{
-			name: "env path fallback beats default",
-			in: Input{
-				RepoRoot:                repo,
-				FlagBackend:             "sqlite",
-				FlagBackendSet:          true,
-				EnvSQLitePath:           "env/dev.db",
-				EnvSQLitePathSet:        true,
-				DefaultSQLitePath:       filepath.Join(repo, "default.db"),
-				DefaultSQLitePathSource: SourceRolloutDefault,
-			},
-			want: filepath.Join(repo, "env", "dev.db"),
-			src:  SourceEnvironment,
-		},
 		{
 			name: "config path beats default",
 			in: Input{
@@ -203,17 +133,15 @@ func TestResolveSQLitePathSources(t *testing.T) {
 	}
 }
 
-func TestResolveRejectsEmptyExplicitSQLitePath(t *testing.T) {
+func TestResolveRejectsEmptyDefaultSQLitePath(t *testing.T) {
 	_, err := Resolve(Input{
-		FlagBackend:      "sqlite",
-		FlagBackendSet:   true,
-		EnvSQLitePath:    " ",
-		EnvSQLitePathSet: true,
+		FlagBackend:    "sqlite",
+		FlagBackendSet: true,
 	})
 	if err == nil {
-		t.Fatal("Resolve unexpectedly accepted empty explicit SQLite path")
+		t.Fatal("Resolve unexpectedly accepted empty default SQLite path")
 	}
-	if !strings.Contains(err.Error(), "sqlite path from environment must be non-empty") {
+	if !strings.Contains(err.Error(), "sqlite path from rollout_default must be non-empty") {
 		t.Fatalf("error = %v, want empty path guidance", err)
 	}
 }

--- a/internal/store/postgres.go
+++ b/internal/store/postgres.go
@@ -30,18 +30,32 @@ type PostgresStore struct {
 type EventPayloadValidator func(eventType string, payload []byte) error
 
 func DSNFromConfig(cfg config.DatabaseConfig, password string) string {
-	sslMode := cfg.SSLMode
+	host := strings.TrimSpace(cfg.Host)
+	if host == "" {
+		host = "127.0.0.1"
+	}
+	port := cfg.Port
+	if port == 0 {
+		port = 5432
+	}
+	name := strings.TrimSpace(cfg.Name)
+	if name == "" {
+		name = "swarm"
+	}
+	sslMode := strings.TrimSpace(cfg.SSLMode)
 	if sslMode == "" {
 		sslMode = "disable"
 	}
-	parts := []string{
-		postgresKeywordParam("host", cfg.Host),
-		fmt.Sprintf("port=%d", cfg.Port),
-		postgresKeywordParam("dbname", cfg.Name),
-		postgresKeywordParam("sslmode", sslMode),
+	user := strings.TrimSpace(cfg.User)
+	if user == "" {
+		user = "postgres"
 	}
-	if cfg.User != "" {
-		parts = append(parts, postgresKeywordParam("user", cfg.User))
+	parts := []string{
+		postgresKeywordParam("host", host),
+		fmt.Sprintf("port=%d", port),
+		postgresKeywordParam("dbname", name),
+		postgresKeywordParam("sslmode", sslMode),
+		postgresKeywordParam("user", user),
 	}
 	if password != "" {
 		parts = append(parts, postgresKeywordParam("password", password))

--- a/internal/store/postgres_helpers_test.go
+++ b/internal/store/postgres_helpers_test.go
@@ -80,6 +80,35 @@ func TestDSNFromConfigQuotesKeywordValues(t *testing.T) {
 	}
 }
 
+func TestDSNFromConfigPinsDefaultNonSecretKeywordsAgainstPGEnv(t *testing.T) {
+	t.Setenv("PGHOST", "env-host")
+	t.Setenv("PGPORT", "15432")
+	t.Setenv("PGDATABASE", "env-db")
+	t.Setenv("PGUSER", "env-user")
+	t.Setenv("PGSSLMODE", "require")
+
+	dsn := DSNFromConfig(config.DatabaseConfig{}, "secret")
+	for _, want := range []string{
+		`host='127.0.0.1'`,
+		"port=5432",
+		`dbname='swarm'`,
+		`sslmode='disable'`,
+		`user='postgres'`,
+	} {
+		if !strings.Contains(dsn, want) {
+			t.Fatalf("DSNFromConfig() = %q, want pinned default keyword %q", dsn, want)
+		}
+	}
+	for _, notWant := range []string{"env-host", "15432", "env-db", "env-user", "require"} {
+		if strings.Contains(dsn, notWant) {
+			t.Fatalf("DSNFromConfig() = %q, leaked PG env value %q", dsn, notWant)
+		}
+	}
+	if _, err := pq.NewConnector(dsn); err != nil {
+		t.Fatalf("pq.NewConnector(%q): %v", dsn, err)
+	}
+}
+
 func TestPostgresStore_HelpersAndDescriptors(t *testing.T) {
 	dsn, _, cleanup := testutil.StartPostgres(t)
 	defer cleanup()

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -3892,6 +3892,8 @@ engine:
         postgres. They are not generic backend selectors and must not imply backend selection by presence alone.
         Non-secret connection details are owned by typed runtime/unified config and built-in local defaults only.
         SWARM_DB_* and implicit PG* variables are retired ambient sources and MUST NOT be read as fallback authority.
+        Postgres DSN construction MUST emit canonical host, port, dbname, sslmode, and user keywords from typed config
+        or built-in defaults so lib/pq cannot fill omitted non-secret fields from PG* environment variables.
     postgres_password_source_authority:
       owner: typed database password resolver consumed before Postgres DSN construction
       config_fields:

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -3828,7 +3828,7 @@ engine:
     backend_ids:
       postgres:
         status: active_supported_runtime_backend
-        meaning: External Postgres runtime store. Postgres remains explicitly selectable for production and existing operator deployments through flag, runtime config, or deprecated environment fallback.
+        meaning: External Postgres runtime store. Postgres remains explicitly selectable for production and existing operator deployments through flag or typed runtime/unified config only.
       sqlite:
         status: active_local_dev_default_runtime_backend
         meaning: >
@@ -3841,28 +3841,22 @@ engine:
       source_order:
       - flag
       - runtime_config
-      - deprecated_environment
       - rollout_default
       flag:
         command: swarm serve
         name: --store <backend>
       runtime_config:
         backend_key: store.backend
-      deprecated_environment:
-        backend: SWARM_STORE_BACKEND
-        status: deprecated_transition_fallback
-        rule: Environment fallback remains visible for transition only and MUST NOT outrank typed runtime config.
       rollout_default:
         active_no_selection_default: sqlite
         postgres_opt_in_backend: postgres
         rule: >
           No-selection local/dev runtime startup resolves to SQLite. Postgres remains explicitly selectable through
-          --store postgres, store.backend=postgres, or deprecated SWARM_STORE_BACKEND=postgres fallback and remains the
-          production/external backend.
+          --store postgres or store.backend=postgres and remains the production/external backend. SWARM_STORE_BACKEND is
+          a retired environment source and MUST NOT affect backend selection.
     sqlite_path:
       canonical_owner: internal/store/backendselection SQLite path resolver
       runtime_config_key: store.sqlite.path
-      deprecated_environment: SWARM_SQLITE_PATH
       default_authority: platform-spec.yaml#cli_specification.foundations.local_runtime_state_authority
       project_default_path: .swarm/stores/dev.db
       no_project_default_path: <swarm-dir>/stores/default/dev.db
@@ -3870,8 +3864,8 @@ engine:
       legacy_repo_relative_path: .swarm/dev.db
       source_order:
       - runtime_config
-      - deprecated_environment
       - local_runtime_state_default
+      retired_environment: SWARM_SQLITE_PATH
       lifecycle:
       - Project-local startup whose canonical project root matches the active repo root uses `<project-root>/.swarm/stores/dev.db`.
       - Startup with no project uses `<swarm-dir>/stores/default/dev.db`.
@@ -3881,7 +3875,7 @@ engine:
       - The SQLite file is persistent until the operator deletes it.
       - The runtime must never silently replace the local/dev SQLite store with an in-memory database.
     postgres_connection_details:
-      env_vars:
+      retired_env_vars:
       - SWARM_DB_HOST
       - SWARM_DB_PORT
       - SWARM_DB_NAME
@@ -3894,10 +3888,10 @@ engine:
       - PGUSER
       config_prefix: database.*
       rule: >
-        Existing non-secret SWARM_DB_* / PG* variables and database.* config keys are Postgres connection details after the canonical
-        selector resolves to postgres. They are not generic backend selectors and must not imply backend selection by
-        presence alone. Non-secret connection details are owned by typed runtime config, with environment variables retained
-        only as deprecated transition fallback or deliberate external Postgres compatibility.
+        Non-secret database.* config keys are Postgres connection details after the canonical selector resolves to
+        postgres. They are not generic backend selectors and must not imply backend selection by presence alone.
+        Non-secret connection details are owned by typed runtime/unified config and built-in local defaults only.
+        SWARM_DB_* and implicit PG* variables are retired ambient sources and MUST NOT be read as fallback authority.
     postgres_password_source_authority:
       owner: typed database password resolver consumed before Postgres DSN construction
       config_fields:
@@ -11411,37 +11405,37 @@ environment_source_authority:
       owner: platform-spec.yaml#environment_source_authority.repo_wide_swarm_env_accepted_set
       migration: retired
     - name: SWARM_STORE_BACKEND
-      category: seeded_legacy
-      owner: platform-spec.yaml#runtime_storage.runtime_store_backend_selection
-      migration: '#1637 store.backend'
+      category: known_retired
+      owner: platform-spec.yaml#environment_source_authority.repo_wide_swarm_env_accepted_set
+      migration: retired
     - name: SWARM_SQLITE_PATH
-      category: seeded_legacy
-      owner: platform-spec.yaml#runtime_storage.runtime_store_backend_selection.sqlite_path
-      migration: '#1637 store.sqlite.path'
+      category: known_retired
+      owner: platform-spec.yaml#environment_source_authority.repo_wide_swarm_env_accepted_set
+      migration: retired
     - name: SWARM_DB_HOST
-      category: seeded_legacy
-      owner: platform-spec.yaml#runtime_storage.runtime_store_backend_selection.postgres_connection_details
-      migration: '#1637 database.host'
+      category: known_retired
+      owner: platform-spec.yaml#environment_source_authority.repo_wide_swarm_env_accepted_set
+      migration: retired
     - name: SWARM_DB_PORT
-      category: seeded_legacy
-      owner: platform-spec.yaml#runtime_storage.runtime_store_backend_selection.postgres_connection_details
-      migration: '#1637 database.port'
+      category: known_retired
+      owner: platform-spec.yaml#environment_source_authority.repo_wide_swarm_env_accepted_set
+      migration: retired
     - name: SWARM_DB_NAME
-      category: seeded_legacy
-      owner: platform-spec.yaml#runtime_storage.runtime_store_backend_selection.postgres_connection_details
-      migration: '#1637 database.name'
+      category: known_retired
+      owner: platform-spec.yaml#environment_source_authority.repo_wide_swarm_env_accepted_set
+      migration: retired
     - name: SWARM_DB_USER
-      category: seeded_legacy
-      owner: platform-spec.yaml#runtime_storage.runtime_store_backend_selection.postgres_connection_details
-      migration: '#1637 database.user'
+      category: known_retired
+      owner: platform-spec.yaml#environment_source_authority.repo_wide_swarm_env_accepted_set
+      migration: retired
     - name: SWARM_DB_SSLMODE
-      category: seeded_legacy
-      owner: platform-spec.yaml#runtime_storage.runtime_store_backend_selection.postgres_connection_details
-      migration: '#1637 database.sslmode'
+      category: known_retired
+      owner: platform-spec.yaml#environment_source_authority.repo_wide_swarm_env_accepted_set
+      migration: retired
     - name: SWARM_DB_POOL_SIZE
-      category: seeded_legacy
-      owner: platform-spec.yaml#runtime_storage.runtime_store_backend_selection.postgres_connection_details
-      migration: '#1637 database.pool_size'
+      category: known_retired
+      owner: platform-spec.yaml#environment_source_authority.repo_wide_swarm_env_accepted_set
+      migration: retired
     - name: SWARM_DB_PASSWORD
       category: known_retired
       owner: platform-spec.yaml#environment_source_authority.repo_wide_swarm_env_accepted_set
@@ -14830,8 +14824,8 @@ cli_specification:
       store_resolution:
         sqlite_source_order:
         - store.sqlite.path
-        - SWARM_SQLITE_PATH
         - project_default_or_swarm_dir_default
+        retired_environment: SWARM_SQLITE_PATH
         project_default: <project-root>/.swarm/stores/dev.db
         no_project_default: <swarm-dir>/stores/default/dev.db
         borrowed_project_default: <swarm-dir>/stores/projects/<project-key>/dev.db


### PR DESCRIPTION
## Summary

Retires store/DB non-secret environment source authority for #1833:

- removes `SWARM_STORE_BACKEND` / `SWARM_SQLITE_PATH` from the canonical store selector inputs
- removes `SWARM_DB_*` and `PGHOST` / `PGPORT` / `PGDATABASE` / `PGUSER` fallback reads from `defaultRuntimeConfig`
- moves the eight SWARM rows from `seeded_legacy` to `known_retired` in the env guard/spec accepted set
- preserves typed config and explicit `database.password_env` password delegation semantics

Closes #1833
Part of #1600

## Governing refs / context

- `platform-spec.yaml#environment_source_authority.repo_wide_swarm_env_accepted_set`
- `platform-spec.yaml#runtime_storage.runtime_store_backend_selection`
- `platform-spec.yaml#runtime_storage.runtime_store_backend_selection.postgres_connection_details`
- `platform-spec.yaml#cli_specification.foundations.local_runtime_state_authority`
- Issue #1833 pre-audit and approved lead gate: first-slice retirement of store/DB non-secret env authority, including same-concept PG fallback readers.

## Semantic migration

- New canonical owner: `internal/store/backendselection` consumes flag/config/local-state default only for store backend and SQLite path.
- New canonical owner: typed runtime/unified config and built-in defaults own non-secret DB connection details.
- Old producer/reader paths now invalid: `SWARM_STORE_BACKEND`, `SWARM_SQLITE_PATH`, `SWARM_DB_HOST`, `SWARM_DB_PORT`, `SWARM_DB_NAME`, `SWARM_DB_USER`, `SWARM_DB_SSLMODE`, `SWARM_DB_POOL_SIZE`, plus implicit `PGHOST`, `PGPORT`, `PGDATABASE`, `PGUSER` fallback reads.
- Production paths checked for surviving old behavior: direct production grep for `os.Getenv` / `os.LookupEnv` against all in-scope retired SWARM and PG names is clean; remaining references are guard diagnostics, tests, or spec migration/retirement text.
- Migration complete for the approved #1833 child slice.

## Verification

- `go test ./internal/store/backendselection`
- `SWARM_CREDENTIALS_FILE=$(mktemp -t swarm-creds.XXXXXX) SWARM_TEST_POSTGRES_DSN='host=127.0.0.1 port=5432 user=postgres password=postgres dbname=postgres sslmode=disable' go test ./cmd/swarm -run 'TestResolveRuntimeStoreSelectionConsumesCanonicalSources|TestRunServeRuntimeConsumesCanonicalStoreSelectionBeforeStoreConstruction|TestDatabaseEnvDetailsDoNotImplyPostgresSelection|TestExplicitRuntimeConfigDatabaseBeatsDatabaseEnv|TestPostgresDSNFromConfig|TestSwarmEnvGuardBlocksRetiredStoreDatabaseConfigEnv|TestSwarmEnvGuardAllowsTypedDatabasePasswordEnvDelegation|TestDoctorTargetReportsRuntimeConfigEnvRejectors|TestRepoWideSwarmEnvAcceptedSetMatchesSpec'`
- `SWARM_CREDENTIALS_FILE=$(mktemp -t swarm-creds.XXXXXX) SWARM_TEST_POSTGRES_DSN='host=127.0.0.1 port=5432 user=postgres password=postgres dbname=postgres sslmode=disable' go test ./cmd/swarm`
- `SWARM_CREDENTIALS_FILE=$(mktemp -t swarm-creds.XXXXXX) SWARM_TEST_POSTGRES_DSN='host=127.0.0.1 port=5432 user=postgres password=postgres dbname=postgres sslmode=disable' go test ./...`
