### PR TITLE
[agent-f][issue #1766] Add Telegram connector proof

### DIFF
--- a/cmd/swarm/doctor_test.go
+++ b/cmd/swarm/doctor_test.go
@@ -18,20 +18,32 @@ import (
 
 func setDoctorProviderSecret(t *testing.T, key, value string) {
 	t.Helper()
+	setDoctorProviderSecrets(t, map[string]string{key: value})
+}
+
+func setDoctorEmptyProviderSecrets(t *testing.T) {
+	t.Helper()
+	setDoctorProviderSecrets(t, nil)
+}
+
+func setDoctorProviderSecrets(t *testing.T, values map[string]string) {
+	t.Helper()
 	path := filepath.Join(t.TempDir(), "provider-credentials.json")
 	t.Setenv("SWARM_CREDENTIALS_FILE", path)
 	store, err := runtimecredentials.NewFileStore(path)
 	if err != nil {
 		t.Fatalf("NewFileStore: %v", err)
 	}
-	if err := store.Set(context.Background(), key, value); err != nil {
-		t.Fatalf("Set provider credential: %v", err)
+	for key, value := range values {
+		if err := store.Set(context.Background(), key, value); err != nil {
+			t.Fatalf("Set provider credential: %v", err)
+		}
 	}
 }
 
 func TestDoctorClaudeCLIPreflightReportsMissingPrerequisites(t *testing.T) {
 	configureDoctorDockerStub(t)
-	t.Setenv("SWARM_CREDENTIALS_FILE", filepath.Join(t.TempDir(), "provider-credentials.json"))
+	setDoctorEmptyProviderSecrets(t)
 	t.Setenv("CLAUDE_CODE_OAUTH_TOKEN", "")
 	t.Setenv("SWARM_TEST_DOCKER_IMAGE_MISSING", "1")
 	t.Setenv("SWARM_TOOL_GATEWAY_URL", "")
@@ -173,6 +185,48 @@ func TestDoctorClaudeCLIPreflightSkipsCredentialForAgentFreeContracts(t *testing
 		if strings.Contains(stdout.String(), forbidden) {
 			t.Fatalf("doctor output contains %q for agent-free source:\n%s", forbidden, stdout.String())
 		}
+	}
+}
+
+func TestDoctorClaudeCLIPreflightReportsTelegramConnectorToolSurface(t *testing.T) {
+	t.Setenv("CLAUDE_CODE_OAUTH_TOKEN", "")
+	t.Setenv("SWARM_TOOL_GATEWAY_URL", "")
+	t.Setenv("SWARM_TOOL_GATEWAY_CONTAINER_URL", "")
+	t.Setenv("SWARM_TOOL_GATEWAY_TOKEN", "")
+	setDoctorProviderSecret(t, "telegram_bot_token", "provider-secret")
+
+	args := doctorClaudeArgs(t, writeDoctorClaudeConfig(t), true)
+	for i := 0; i+1 < len(args); i++ {
+		if args[i] == "--contracts" {
+			args[i+1] = writeDoctorTelegramConnectorContractsFixture(t)
+			break
+		}
+	}
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), repoRoot(), args, &stdout, &stderr, defaultRootCommandOptions())
+	if code != 0 {
+		t.Fatalf("code = %d stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	var report localPreflightReport
+	if err := json.Unmarshal(stdout.Bytes(), &report); err != nil {
+		t.Fatalf("parse doctor json: %v\n%s", err, stdout.String())
+	}
+	if !localPreflightReportHasCode(report, "provider_connector_telegram_send_message") {
+		t.Fatalf("report missing telegram connector finding: %#v", report.Findings)
+	}
+	for _, want := range []string{
+		"CAN send Telegram messages via api.telegram.org",
+		"CAN lower through platform.activity_requested",
+		"CAN journal non-idempotent attempts in activity_attempts",
+		"CANNOT expose credential values",
+		"requires telegram_bot_token=BOUND",
+	} {
+		if !localPreflightReportFindingContains(report, "provider_connector_telegram_send_message", want) {
+			t.Fatalf("telegram connector finding missing %q: %#v", want, report.Findings)
+		}
+	}
+	if strings.Contains(stdout.String(), "provider-secret") {
+		t.Fatalf("doctor report leaked provider secret:\n%s", stdout.String())
 	}
 }
 
@@ -623,7 +677,7 @@ func TestDoctorAPIFlagsRequireTargetMode(t *testing.T) {
 
 func TestRunServeRuntimeConsumesLocalClaudePreflightAfterBundleDecision(t *testing.T) {
 	configureDoctorDockerStub(t)
-	t.Setenv("SWARM_CREDENTIALS_FILE", filepath.Join(t.TempDir(), "provider-credentials.json"))
+	setDoctorEmptyProviderSecrets(t)
 	t.Setenv("CLAUDE_CODE_OAUTH_TOKEN", "")
 	t.Setenv("SWARM_TOOL_GATEWAY_URL", "")
 	t.Setenv("SWARM_TOOL_GATEWAY_CONTAINER_URL", "")
@@ -971,6 +1025,37 @@ terminal_states:
 	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "events.yaml"), "{}\n")
 	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "policy.yaml"), "{}\n")
 	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "tools.yaml"), "{}\n")
+	return root
+}
+
+func writeDoctorTelegramConnectorContractsFixture(t *testing.T) string {
+	t.Helper()
+	root := writeDoctorAgentFreeContractsFixture(t)
+	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "tools.yaml"), `
+telegram.send_message:
+  category: provider_connector
+  description: send Telegram messages
+  handler_type: http
+  effect_class: non_idempotent_write
+  credentials:
+    - telegram_bot_token
+  input_schema:
+    type: object
+    required: [chat_id, text]
+    properties:
+      chat_id:
+        type: string
+      text:
+        type: string
+  output_schema:
+    type: object
+  http:
+    method: POST
+    url: https://api.telegram.org/bot{{credentials.telegram_bot_token}}/sendMessage
+    body:
+      chat_id: "{{input.chat_id}}"
+      text: "{{input.text}}"
+`)
 	return root
 }
 

--- a/cmd/swarm/local_preflight.go
+++ b/cmd/swarm/local_preflight.go
@@ -121,6 +121,7 @@ func runLocalClaudeCLIPreflight(ctx context.Context, req localPreflightRequest) 
 		report.add(localPreflightWorkspacePrerequisite, "contract_source_load_failed", localPreflightSeverityBlocker, localPreflightStatusFailed, err.Error(), "fix the selected --contracts and --platform-spec paths")
 		return report.finalize()
 	}
+	appendProviderConnectorToolSurfaceFindings(ctx, &report, source)
 	workspaceBackend, err := decideWorkspaceBackend(req.WorkspaceBackend, req.Config, source)
 	if err != nil {
 		report.add(localPreflightWorkspacePrerequisite, "workspace_backend_decision_failed", localPreflightSeverityBlocker, localPreflightStatusFailed, err.Error(), "fix workspace.backend, workspace.allow_exec_on_host, or the selected contract capabilities")

--- a/cmd/swarm/provider_connector_tools.go
+++ b/cmd/swarm/provider_connector_tools.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/division-sh/swarm/internal/providerconnectors"
+	"github.com/division-sh/swarm/internal/runtime/semanticview"
+)
+
+func appendProviderConnectorToolSurfaceFindings(ctx context.Context, report *localPreflightReport, source semanticview.Source) {
+	if report == nil || source == nil {
+		return
+	}
+	discovered, err := providerconnectors.Surfaces(ctx, source, nil)
+	if err != nil {
+		report.add(localPreflightProviderPackPrerequisite, "provider_connector_surface_failed", localPreflightSeverityBlocker, localPreflightStatusFailed, err.Error(), "fix provider connector tool declarations")
+		return
+	}
+	if len(discovered) == 0 {
+		return
+	}
+	store, err := buildProviderCredentialStore()
+	if err != nil {
+		report.add(localPreflightProviderPackPrerequisite, "provider_connector_credential_store_unavailable", localPreflightSeverityBlocker, localPreflightStatusFailed, err.Error(), "fix the local credential store used by swarm secrets")
+		return
+	}
+	surfaces, err := providerconnectors.Surfaces(ctx, source, store)
+	if err != nil {
+		report.add(localPreflightProviderPackPrerequisite, "provider_connector_surface_failed", localPreflightSeverityBlocker, localPreflightStatusFailed, err.Error(), "fix provider connector tool declarations")
+		return
+	}
+	sort.SliceStable(surfaces, func(i, j int) bool {
+		return strings.TrimSpace(surfaces[i].ToolID) < strings.TrimSpace(surfaces[j].ToolID)
+	})
+	for _, surface := range surfaces {
+		report.add(localPreflightProviderPackPrerequisite, "provider_connector_"+connectorFindingCode(surface.ToolID), localPreflightSeverityInfo, localPreflightStatusOK, providerConnectorSurfaceMessage(surface), "")
+	}
+}
+
+func providerConnectorSurfaceMessage(surface providerconnectors.Surface) string {
+	return fmt.Sprintf("provider connector tool %s %s %s requires %s",
+		strings.TrimSpace(surface.ToolID),
+		formatProviderConnectorSurfaceVerbs("CAN", surface.Can),
+		formatProviderConnectorSurfaceVerbs("CANNOT", surface.Cannot),
+		formatProviderConnectorRequirements(surface.Requires),
+	)
+}
+
+func formatProviderConnectorSurfaceVerbs(verb string, items []string) string {
+	if len(items) == 0 {
+		return strings.TrimSpace(verb) + " none"
+	}
+	parts := make([]string, 0, len(items))
+	for _, item := range items {
+		item = strings.TrimSpace(item)
+		if item == "" {
+			continue
+		}
+		parts = append(parts, strings.TrimSpace(verb)+" "+item)
+	}
+	if len(parts) == 0 {
+		return strings.TrimSpace(verb) + " none"
+	}
+	return strings.Join(parts, "; ")
+}
+
+func formatProviderConnectorRequirements(requirements []providerconnectors.RequirementStatus) string {
+	if len(requirements) == 0 {
+		return "none"
+	}
+	parts := make([]string, 0, len(requirements))
+	for _, requirement := range requirements {
+		status := "UNBOUND"
+		if requirement.Bound {
+			status = "BOUND"
+		}
+		parts = append(parts, strings.TrimSpace(requirement.Name)+"="+status)
+	}
+	return strings.Join(parts, "; ")
+}
+
+func connectorFindingCode(toolID string) string {
+	toolID = strings.TrimSpace(strings.ToLower(toolID))
+	toolID = strings.NewReplacer(".", "_", "-", "_", " ", "_").Replace(toolID)
+	return strings.Trim(toolID, "_")
+}

--- a/internal/providerconnectors/providerconnectors.go
+++ b/internal/providerconnectors/providerconnectors.go
@@ -1,0 +1,303 @@
+package providerconnectors
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"reflect"
+	"sort"
+	"strings"
+
+	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
+	runtimecredentials "github.com/division-sh/swarm/internal/runtime/credentials"
+	"github.com/division-sh/swarm/internal/runtime/semanticview"
+)
+
+const Category = "provider_connector"
+
+type RequirementStatus struct {
+	Name  string
+	Bound bool
+}
+
+type Surface struct {
+	ToolID       string
+	Provider     string
+	Action       string
+	EndpointHost string
+	EffectClass  string
+	Can          []string
+	Cannot       []string
+	Requires     []RequirementStatus
+}
+
+func ValidateSource(source semanticview.Source) []error {
+	if source == nil {
+		return nil
+	}
+	tools := source.ToolEntries()
+	names := make([]string, 0, len(tools))
+	for name := range tools {
+		names = append(names, strings.TrimSpace(name))
+	}
+	sort.Strings(names)
+	var errs []error
+	for _, name := range names {
+		tool := tools[name]
+		if !isProviderConnector(tool) {
+			continue
+		}
+		errs = append(errs, validateTool(name, tool)...)
+	}
+	errs = append(errs, validateProviderConnectorAgentExposure(source)...)
+	return errs
+}
+
+func Surfaces(ctx context.Context, source semanticview.Source, store runtimecredentials.Store) ([]Surface, error) {
+	if source == nil {
+		return nil, nil
+	}
+	tools := source.ToolEntries()
+	names := make([]string, 0, len(tools))
+	for name := range tools {
+		names = append(names, strings.TrimSpace(name))
+	}
+	sort.Strings(names)
+	out := make([]Surface, 0)
+	for _, name := range names {
+		tool := tools[name]
+		if !isProviderConnector(tool) {
+			continue
+		}
+		surface, err := surfaceForTool(ctx, source, name, tool, store)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, surface)
+	}
+	return out, nil
+}
+
+func isProviderConnector(tool runtimecontracts.ToolSchemaEntry) bool {
+	return strings.EqualFold(strings.TrimSpace(tool.Category), Category)
+}
+
+func validateTool(toolID string, tool runtimecontracts.ToolSchemaEntry) []error {
+	context := fmt.Sprintf("provider connector tool %q", strings.TrimSpace(toolID))
+	var errs []error
+	provider, action, ok := splitToolID(toolID)
+	if !ok {
+		errs = append(errs, fmt.Errorf("%s must use <provider>.<action> id form", context))
+	}
+	if provider == "" || action == "" {
+		errs = append(errs, fmt.Errorf("%s must declare non-empty provider and action identity", context))
+	}
+	handlerType := strings.TrimSpace(strings.ToLower(tool.HandlerType))
+	if handlerType != "" && handlerType != "http" {
+		errs = append(errs, fmt.Errorf("%s handler_type %q is not supported; provider connectors use authored HTTP tools", context, tool.HandlerType))
+	}
+	if tool.HTTP == nil {
+		errs = append(errs, fmt.Errorf("%s is missing http block", context))
+	} else {
+		if strings.TrimSpace(tool.HTTP.Method) == "" {
+			errs = append(errs, fmt.Errorf("%s must declare http.method explicitly", context))
+		}
+		if strings.TrimSpace(tool.HTTP.URL) == "" {
+			errs = append(errs, fmt.Errorf("%s must declare http.url", context))
+		}
+	}
+	effectClass := runtimecontracts.NormalizeActivityEffectClass(tool.EffectClass)
+	if effectClass != runtimecontracts.ActivityEffectClassNonIdempotentWrite {
+		errs = append(errs, fmt.Errorf("%s effect_class must be non_idempotent_write for the Stage 1 connector proof", context))
+	}
+	if len(tool.Credentials) == 0 {
+		errs = append(errs, fmt.Errorf("%s must declare at least one static credential binding", context))
+	}
+	if tool.ManagedCredential != nil {
+		errs = append(errs, fmt.Errorf("%s uses managed_credential; managed credential connector execution is split", context))
+	}
+	if len(tool.ResponseMapping) > 0 {
+		errs = append(errs, fmt.Errorf("%s uses response_mapping; connector activity response mapping is split", context))
+	}
+	if strings.TrimSpace(tool.RateLimit) != "" || strings.TrimSpace(tool.RateLimitMaxWait) != "" {
+		errs = append(errs, fmt.Errorf("%s uses rate_limit; connector activity rate-limit admission is split", context))
+	}
+	return errs
+}
+
+func validateProviderConnectorAgentExposure(source semanticview.Source) []error {
+	if source == nil {
+		return nil
+	}
+	agents := source.AgentEntries()
+	agentIDs := make([]string, 0, len(agents))
+	for agentID := range agents {
+		agentIDs = append(agentIDs, strings.TrimSpace(agentID))
+	}
+	sort.Strings(agentIDs)
+	var errs []error
+	for _, agentID := range agentIDs {
+		entry := agents[agentID]
+		for _, toolID := range entry.ConfiguredTools() {
+			toolID = strings.TrimSpace(toolID)
+			if toolID == "" {
+				continue
+			}
+			tool, ok := source.ToolEntryForAgent(agentID, toolID)
+			if !ok || !isProviderConnector(tool) {
+				continue
+			}
+			errs = append(errs, fmt.Errorf("agent %q must not expose provider connector tool %q directly; connectors execute through platform.activity_requested and activity_attempts", agentID, toolID))
+		}
+	}
+	return errs
+}
+
+func surfaceForTool(ctx context.Context, source semanticview.Source, toolID string, tool runtimecontracts.ToolSchemaEntry, store runtimecredentials.Store) (Surface, error) {
+	provider, action, _ := splitToolID(toolID)
+	host := ""
+	if tool.HTTP != nil {
+		parsed, err := url.Parse(strings.TrimSpace(tool.HTTP.URL))
+		if err == nil {
+			host = strings.TrimSpace(parsed.Host)
+		}
+	}
+	requires := make([]RequirementStatus, 0, len(tool.Credentials))
+	flowID, err := connectorToolFlowID(source, toolID, tool)
+	if err != nil {
+		return Surface{}, err
+	}
+	for _, key := range tool.Credentials {
+		key = strings.TrimSpace(key)
+		if key == "" {
+			continue
+		}
+		storeKey := key
+		if resolved, mapped := semanticview.CredentialStoreKeyForFlow(source, flowID, key); mapped {
+			storeKey = strings.TrimSpace(resolved)
+		}
+		bound := false
+		if store != nil && storeKey != "" {
+			_, ok, err := store.Get(ctx, storeKey)
+			if err != nil {
+				return Surface{}, err
+			}
+			bound = ok
+		}
+		requires = append(requires, RequirementStatus{Name: key, Bound: bound})
+	}
+	sort.Slice(requires, func(i, j int) bool {
+		return requires[i].Name < requires[j].Name
+	})
+	actionLabel := connectorActionLabel(provider, action, tool)
+	can := []string{
+		strings.TrimSpace(actionLabel + endpointSuffix(host)),
+		"lower through platform.activity_requested",
+		"journal non-idempotent attempts in activity_attempts",
+	}
+	return Surface{
+		ToolID:       strings.TrimSpace(toolID),
+		Provider:     provider,
+		Action:       action,
+		EndpointHost: host,
+		EffectClass:  string(runtimecontracts.NormalizeActivityEffectClass(tool.EffectClass)),
+		Can:          can,
+		Cannot: []string{
+			"bypass activity_attempts",
+			"retry non_idempotent_write automatically",
+			"expose credential values",
+		},
+		Requires: requires,
+	}, nil
+}
+
+func connectorToolFlowID(source semanticview.Source, toolID string, tool runtimecontracts.ToolSchemaEntry) (string, error) {
+	if source == nil {
+		return "", nil
+	}
+	toolID = strings.TrimSpace(toolID)
+	flowIDs := map[string]struct{}{}
+	for _, scope := range source.ProjectScopes() {
+		if scopedToolMatches(scope.Tools, toolID, tool) {
+			if flowID := strings.TrimSpace(scope.OwningFlowID); flowID != "" {
+				flowIDs[flowID] = struct{}{}
+			}
+		}
+	}
+	for _, scope := range source.FlowScopes() {
+		if scopedToolMatches(scope.Tools, toolID, tool) {
+			if flowID := strings.TrimSpace(scope.ID); flowID != "" {
+				flowIDs[flowID] = struct{}{}
+			}
+		}
+	}
+	if len(flowIDs) == 0 {
+		return "", nil
+	}
+	if len(flowIDs) > 1 {
+		ids := make([]string, 0, len(flowIDs))
+		for id := range flowIDs {
+			ids = append(ids, id)
+		}
+		sort.Strings(ids)
+		return "", fmt.Errorf("provider connector tool %q has ambiguous flow credential scopes: %s", toolID, strings.Join(ids, ", "))
+	}
+	for id := range flowIDs {
+		return id, nil
+	}
+	return "", nil
+}
+
+func scopedToolMatches(tools map[string]runtimecontracts.ToolSchemaEntry, toolID string, tool runtimecontracts.ToolSchemaEntry) bool {
+	scoped, ok := tools[strings.TrimSpace(toolID)]
+	return ok && reflect.DeepEqual(scoped, tool)
+}
+
+func splitToolID(toolID string) (string, string, bool) {
+	parts := strings.Split(strings.TrimSpace(toolID), ".")
+	if len(parts) != 2 {
+		return "", "", false
+	}
+	provider := normalizeToken(parts[0])
+	action := normalizeToken(parts[1])
+	return provider, action, provider != "" && action != ""
+}
+
+func normalizeToken(raw string) string {
+	raw = strings.TrimSpace(strings.ToLower(raw))
+	raw = strings.ReplaceAll(raw, "-", "_")
+	raw = strings.ReplaceAll(raw, " ", "_")
+	return strings.Trim(raw, "_")
+}
+
+func connectorActionLabel(provider, action string, tool runtimecontracts.ToolSchemaEntry) string {
+	if label := normalizeDisplayLabel(tool.Description); label != "" {
+		return label
+	}
+	actionLabel := strings.ReplaceAll(action, "_", " ")
+	if providerLabel := titleToken(provider); providerLabel != "" {
+		actionLabel = strings.TrimSpace(actionLabel + " via " + providerLabel)
+	}
+	return actionLabel
+}
+
+func normalizeDisplayLabel(raw string) string {
+	label := strings.Join(strings.Fields(strings.TrimSpace(raw)), " ")
+	return strings.TrimSpace(strings.TrimRight(label, "."))
+}
+
+func titleToken(raw string) string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return ""
+	}
+	return strings.ToUpper(raw[:1]) + raw[1:]
+}
+
+func endpointSuffix(host string) string {
+	host = strings.TrimSpace(host)
+	if host == "" {
+		return ""
+	}
+	return " via " + host
+}

--- a/internal/providerconnectors/providerconnectors_test.go
+++ b/internal/providerconnectors/providerconnectors_test.go
@@ -1,0 +1,238 @@
+package providerconnectors
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
+	runtimecredentials "github.com/division-sh/swarm/internal/runtime/credentials"
+	"github.com/division-sh/swarm/internal/runtime/semanticview"
+)
+
+func TestValidateSourceAcceptsTelegramProviderConnectorHTTPActivityTool(t *testing.T) {
+	source := semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
+		Tools: map[string]runtimecontracts.ToolSchemaEntry{
+			"telegram.send_message": telegramConnectorTool("https://api.telegram.org"),
+		},
+	})
+
+	if errs := ValidateSource(source); len(errs) != 0 {
+		t.Fatalf("ValidateSource errors = %#v, want none", errs)
+	}
+}
+
+func TestValidateSourceRejectsUnsupportedProviderConnectorShape(t *testing.T) {
+	source := semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
+		Tools: map[string]runtimecontracts.ToolSchemaEntry{
+			"telegram.send_message": {
+				Category:        Category,
+				HandlerType:     "http",
+				EffectClass:     string(runtimecontracts.ActivityEffectClassReadOnly),
+				Credentials:     nil,
+				HTTP:            &runtimecontracts.HTTPToolSpec{Method: "POST", URL: "https://api.telegram.org"},
+				RateLimit:       "1/s",
+				ResponseMapping: map[string]any{"ok": "{{response.body.ok}}"},
+			},
+		},
+	})
+
+	errs := ValidateSource(source)
+	joined := joinErrors(errs)
+	for _, want := range []string{
+		"effect_class must be non_idempotent_write",
+		"must declare at least one static credential binding",
+		"uses response_mapping",
+		"uses rate_limit",
+	} {
+		if !strings.Contains(joined, want) {
+			t.Fatalf("ValidateSource errors = %q, want %q", joined, want)
+		}
+	}
+}
+
+func TestValidateSourceRejectsAgentExposureOfProviderConnector(t *testing.T) {
+	source := semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
+		Agents: map[string]runtimecontracts.AgentRegistryEntry{
+			"sender": {ID: "sender", Tools: []string{"telegram.send_message"}},
+		},
+		Tools: map[string]runtimecontracts.ToolSchemaEntry{
+			"telegram.send_message": telegramConnectorTool("https://api.telegram.org"),
+		},
+	})
+
+	errs := ValidateSource(source)
+	joined := joinErrors(errs)
+	if !strings.Contains(joined, `agent "sender" must not expose provider connector tool "telegram.send_message" directly`) {
+		t.Fatalf("ValidateSource errors = %q, want direct exposure rejection", joined)
+	}
+}
+
+func TestSurfacesReportBoundAndUnboundRequirementsWithoutSecretValues(t *testing.T) {
+	ctx := context.Background()
+	source := semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
+		Tools: map[string]runtimecontracts.ToolSchemaEntry{
+			"telegram.send_message": telegramConnectorTool("https://api.telegram.org"),
+		},
+	})
+	store, err := runtimecredentials.NewFileStore(filepath.Join(t.TempDir(), "credentials.json"))
+	if err != nil {
+		t.Fatalf("NewFileStore: %v", err)
+	}
+	if err := store.Set(ctx, "telegram_bot_token", "provider-secret"); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+
+	surfaces, err := Surfaces(ctx, source, store)
+	if err != nil {
+		t.Fatalf("Surfaces: %v", err)
+	}
+	if len(surfaces) != 1 {
+		t.Fatalf("surfaces = %#v, want one", surfaces)
+	}
+	surface := surfaces[0]
+	if surface.ToolID != "telegram.send_message" || surface.Provider != "telegram" || surface.Action != "send_message" {
+		t.Fatalf("surface identity = %#v", surface)
+	}
+	if len(surface.Requires) != 1 || surface.Requires[0].Name != "telegram_bot_token" || !surface.Requires[0].Bound {
+		t.Fatalf("requirements = %#v, want bound telegram_bot_token", surface.Requires)
+	}
+	if strings.Contains(strings.Join(surface.Can, " ")+strings.Join(surface.Cannot, " "), "provider-secret") {
+		t.Fatal("surface leaked credential value")
+	}
+
+	unbound, err := Surfaces(ctx, source, nil)
+	if err != nil {
+		t.Fatalf("Surfaces without store: %v", err)
+	}
+	if len(unbound) != 1 || len(unbound[0].Requires) != 1 || unbound[0].Requires[0].Bound {
+		t.Fatalf("unbound requirements = %#v", unbound)
+	}
+}
+
+func TestSurfacesResolveImportedFlowCredentialBindings(t *testing.T) {
+	ctx := context.Background()
+	tool := telegramConnectorTool("https://api.telegram.org")
+	source := providerConnectorScopedSource{
+		Source: semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
+			Tools: map[string]runtimecontracts.ToolSchemaEntry{
+				"telegram.send_message": tool,
+			},
+		}),
+		projectScopes: []semanticview.ProjectScope{
+			{
+				Key: "",
+				Manifest: runtimecontracts.ProjectPackageDocument{
+					Flows: []runtimecontracts.ProjectFlowRef{
+						{
+							ID:   "worker",
+							Flow: "worker",
+							Bind: runtimecontracts.FlowPackageBind{
+								Credentials: map[string]string{
+									"telegram_bot_token": "tenant_telegram_bot_token",
+								},
+							},
+						},
+					},
+				},
+			},
+			{
+				Key: "flows/worker",
+				Manifest: runtimecontracts.ProjectPackageDocument{
+					Requires: runtimecontracts.FlowPackageRequires{
+						Credentials: []string{"telegram_bot_token"},
+					},
+				},
+			},
+		},
+		flowScopes: []semanticview.FlowScope{
+			{
+				ID:         "worker",
+				PackageKey: "flows/worker",
+				Tools: map[string]runtimecontracts.ToolSchemaEntry{
+					"telegram.send_message": tool,
+				},
+			},
+		},
+	}
+	store, err := runtimecredentials.NewFileStore(filepath.Join(t.TempDir(), "credentials.json"))
+	if err != nil {
+		t.Fatalf("NewFileStore: %v", err)
+	}
+	if err := store.Set(ctx, "tenant_telegram_bot_token", "provider-secret"); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+
+	surfaces, err := Surfaces(ctx, source, store)
+	if err != nil {
+		t.Fatalf("Surfaces: %v", err)
+	}
+	if len(surfaces) != 1 {
+		t.Fatalf("surfaces = %#v, want one", surfaces)
+	}
+	if len(surfaces[0].Requires) != 1 || surfaces[0].Requires[0].Name != "telegram_bot_token" || !surfaces[0].Requires[0].Bound {
+		t.Fatalf("requirements = %#v, want package-local telegram_bot_token marked bound via deployment binding", surfaces[0].Requires)
+	}
+}
+
+type providerConnectorScopedSource struct {
+	semanticview.Source
+	projectScopes []semanticview.ProjectScope
+	flowScopes    []semanticview.FlowScope
+}
+
+func (s providerConnectorScopedSource) ProjectScopes() []semanticview.ProjectScope {
+	return append([]semanticview.ProjectScope(nil), s.projectScopes...)
+}
+
+func (s providerConnectorScopedSource) FlowScopes() []semanticview.FlowScope {
+	return append([]semanticview.FlowScope(nil), s.flowScopes...)
+}
+
+func (s providerConnectorScopedSource) FlowScopeByID(id string) (semanticview.FlowScope, bool) {
+	id = strings.TrimSpace(id)
+	for _, scope := range s.flowScopes {
+		if strings.TrimSpace(scope.ID) == id {
+			return scope, true
+		}
+	}
+	return semanticview.FlowScope{}, false
+}
+
+func telegramConnectorTool(baseURL string) runtimecontracts.ToolSchemaEntry {
+	return runtimecontracts.ToolSchemaEntry{
+		Category:    Category,
+		Description: "send Telegram messages",
+		HandlerType: "http",
+		EffectClass: string(runtimecontracts.ActivityEffectClassNonIdempotentWrite),
+		Credentials: []string{"telegram_bot_token"},
+		InputSchema: runtimecontracts.ToolInputSchema{
+			Type: "object",
+			Properties: map[string]runtimecontracts.ToolInputSchema{
+				"chat_id": {Type: "string"},
+				"text":    {Type: "string"},
+			},
+			Required: []string{"chat_id", "text"},
+		},
+		OutputSchema: runtimecontracts.ToolInputSchema{Type: "object"},
+		HTTP: &runtimecontracts.HTTPToolSpec{
+			Method: "POST",
+			URL:    strings.TrimRight(baseURL, "/") + "/bot{{credentials.telegram_bot_token}}/sendMessage",
+			Body: map[string]any{
+				"chat_id": "{{input.chat_id}}",
+				"text":    "{{input.text}}",
+			},
+		},
+	}
+}
+
+func joinErrors(errs []error) string {
+	parts := make([]string, 0, len(errs))
+	for _, err := range errs {
+		if err != nil {
+			parts = append(parts, err.Error())
+		}
+	}
+	return strings.Join(parts, "\n")
+}

--- a/internal/runtime/pipeline/activity_engine_test.go
+++ b/internal/runtime/pipeline/activity_engine_test.go
@@ -5,19 +5,24 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
 	"strings"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/division-sh/swarm/internal/events"
+	"github.com/division-sh/swarm/internal/events/eventtest"
+	"github.com/division-sh/swarm/internal/providertriggers"
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
 	"github.com/division-sh/swarm/internal/runtime/core/identity"
 	runtimecredentials "github.com/division-sh/swarm/internal/runtime/credentials"
 	runtimeengine "github.com/division-sh/swarm/internal/runtime/engine"
 	"github.com/division-sh/swarm/internal/runtime/semanticview"
+	"github.com/division-sh/swarm/internal/testutil"
 	"github.com/google/uuid"
 )
 
@@ -366,6 +371,152 @@ func TestPipelineActivityRequestExecutesNonIdempotentHTTPToolOnceWithStaticCrede
 	}
 }
 
+func TestPipelineActivityRequestTelegramConnectorRoundTripThroughInboundDelivery(t *testing.T) {
+	ctx := context.Background()
+	for _, tc := range []struct {
+		name  string
+		setup func(t *testing.T, ctx context.Context) (*sql.DB, *WorkflowInstanceStore, bool)
+	}{
+		{
+			name: "sqlite",
+			setup: func(t *testing.T, ctx context.Context) (*sql.DB, *WorkflowInstanceStore, bool) {
+				db, store := newSQLiteActivityJournalStore(t, ctx)
+				return db, store, true
+			},
+		},
+		{
+			name: "postgres",
+			setup: func(t *testing.T, ctx context.Context) (*sql.DB, *WorkflowInstanceStore, bool) {
+				_, db, _ := testutil.StartPostgres(t)
+				return db, NewWorkflowInstanceStore(db), false
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			db, store, sqlite := tc.setup(t, ctx)
+			runTelegramConnectorRoundTripThroughInboundDelivery(t, ctx, db, store, sqlite)
+		})
+	}
+}
+
+func runTelegramConnectorRoundTripThroughInboundDelivery(t *testing.T, ctx context.Context, db *sql.DB, store *WorkflowInstanceStore, sqlite bool) {
+	t.Helper()
+	runID := uuid.NewString()
+	entityID := uuid.NewString()
+	seedActivityRun(t, db, sqlite, runID)
+
+	var calls int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		if got := r.URL.Path; got != "/botprovider-secret/sendMessage" {
+			t.Fatalf("telegram path = %q, want token path sendMessage", got)
+		}
+		if got := r.Header.Get("Content-Type"); !strings.Contains(got, "application/json") {
+			t.Fatalf("Content-Type = %q, want application/json", got)
+		}
+		raw, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("ReadAll request body: %v", err)
+		}
+		var body map[string]any
+		if err := json.Unmarshal(raw, &body); err != nil {
+			t.Fatalf("decode Telegram request body %s: %v", raw, err)
+		}
+		if got := asString(body["chat_id"]); got != "42" {
+			t.Fatalf("chat_id = %#v, want 42", body["chat_id"])
+		}
+		if got := asString(body["text"]); got != "reply: hello from telegram" {
+			t.Fatalf("text = %#v, want reply text", body["text"])
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"ok": true,
+			"result": map[string]any{
+				"message_id": 99,
+				"chat":       map[string]any{"id": 42},
+				"text":       "reply: hello from telegram",
+			},
+		})
+	}))
+	defer server.Close()
+
+	delivery, inboundEvent := acceptedTelegramInboundDeliveryEvent(t, entityID, runID)
+	chatID, incomingText := telegramInboundChatAndText(t, delivery.Payload)
+	credentialStore := testActivityCredentialStore(t, "telegram_bot_token", "provider-secret")
+	source := semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
+		Tools: map[string]runtimecontracts.ToolSchemaEntry{
+			"telegram.send_message": testTelegramConnectorTool(server.URL),
+		},
+	})
+	bus := &recordingPipelineBus{}
+	pc := NewPipelineCoordinatorWithOptions(bus, db, PipelineCoordinatorOptions{
+		Module:        staticSemanticWorkflowModule{source: source},
+		WorkflowStore: store,
+		Credentials:   credentialStore,
+	})
+	intent := testNonIdempotentActivityIntent(runID, inboundEvent.ID(), entityID)
+	intent.Tool = "telegram.send_message"
+	intent.ActivityID = "telegram_send_message"
+	intent.Input = map[string]any{"chat_id": chatID, "text": "reply: " + incomingText}
+	intent.SuccessEvent = "telegram.send_message.succeeded"
+	intent.FailureEvent = "telegram.send_message.failed"
+	intent.SourceTaskID = inboundEvent.TaskID()
+	intent.ParentEventID = inboundEvent.ID()
+	intent.ChainDepth = inboundEvent.ChainDepth()
+	intent = intent.Normalized()
+	request, err := activityRequestEmitIntent(intent)
+	if err != nil {
+		t.Fatalf("activityRequestEmitIntent: %v", err)
+	}
+
+	handled, err := pc.handleEventResult(ctx, request.Event)
+	if err != nil {
+		t.Fatalf("handleEventResult: %v", err)
+	}
+	if !handled {
+		t.Fatal("handleEventResult handled = false, want true")
+	}
+	if calls != 1 {
+		t.Fatalf("Telegram calls = %d, want exactly one", calls)
+	}
+	if len(bus.publishes) != 1 {
+		t.Fatalf("published events = %d, want one generated activity result", len(bus.publishes))
+	}
+	resultEvent := bus.publishes[0]
+	if resultEvent.Type() != events.EventType(intent.SuccessEvent) {
+		t.Fatalf("result event type = %q, want %q", resultEvent.Type(), intent.SuccessEvent)
+	}
+	if resultEvent.ParentEventID() != inboundEvent.ID() {
+		t.Fatalf("result parent event id = %q, want inbound event id %q", resultEvent.ParentEventID(), inboundEvent.ID())
+	}
+	if strings.Contains(string(resultEvent.Payload()), "provider-secret") {
+		t.Fatalf("result payload leaked credential: %s", resultEvent.Payload())
+	}
+	rec, ok, err := store.LoadActivityAttempt(ctx, activityRequestEventID(intent))
+	if err != nil {
+		t.Fatalf("LoadActivityAttempt: %v", err)
+	}
+	if !ok || rec.Status != ActivityAttemptStatusSucceeded {
+		t.Fatalf("activity attempt = (%v, %q), want succeeded", ok, rec.Status)
+	}
+
+	handled, err = pc.handleEventResult(ctx, request.Event)
+	if err != nil {
+		t.Fatalf("duplicate handleEventResult: %v", err)
+	}
+	if !handled {
+		t.Fatal("duplicate handleEventResult handled = false, want true")
+	}
+	if calls != 1 {
+		t.Fatalf("Telegram calls after duplicate = %d, want no redispatch", calls)
+	}
+	if len(bus.publishes) != 2 {
+		t.Fatalf("published events after duplicate = %d, want journaled result replay", len(bus.publishes))
+	}
+	if got, want := bus.publishes[1].ID(), resultEvent.ID(); got != want {
+		t.Fatalf("duplicate result id = %q, want journaled id %q", got, want)
+	}
+}
+
 func TestPipelineActivityRequestNonIdempotentFailureDoesNotRetry(t *testing.T) {
 	ctx := context.Background()
 	runID := uuid.NewString()
@@ -681,6 +832,61 @@ func TestPipelineActivityRequestMissingCredentialFailsBeforeJournalAndDispatch(t
 	}
 }
 
+func TestPipelineActivityRequestTelegramConnectorMissingTokenFailsBeforeJournalAndDispatch(t *testing.T) {
+	ctx := context.Background()
+	runID := uuid.NewString()
+	sourceEventID := uuid.NewString()
+	entityID := uuid.NewString()
+	var calls int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		_ = json.NewEncoder(w).Encode(map[string]any{"ok": true})
+	}))
+	defer server.Close()
+
+	source := semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
+		Tools: map[string]runtimecontracts.ToolSchemaEntry{
+			"telegram.send_message": testTelegramConnectorTool(server.URL),
+		},
+	})
+	bus := &recordingPipelineBus{}
+	db, store := newSQLiteActivityJournalStore(t, ctx)
+	seedActivityRun(t, db, true, runID)
+	pc := NewPipelineCoordinatorWithOptions(bus, db, PipelineCoordinatorOptions{
+		Module:        staticSemanticWorkflowModule{source: source},
+		WorkflowStore: store,
+		Credentials:   testActivityCredentialStore(t, "", ""),
+	})
+	intent := testNonIdempotentActivityIntent(runID, sourceEventID, entityID)
+	intent.Tool = "telegram.send_message"
+	intent.ActivityID = "telegram_send_message"
+	intent.Input = map[string]any{"chat_id": "42", "text": "reply"}
+	intent.SuccessEvent = "telegram.send_message.succeeded"
+	intent.FailureEvent = "telegram.send_message.failed"
+	intent = intent.Normalized()
+	request, err := activityRequestEmitIntent(intent)
+	if err != nil {
+		t.Fatalf("activityRequestEmitIntent: %v", err)
+	}
+	if _, err := pc.handleEventResult(ctx, request.Event); err != nil {
+		t.Fatalf("handleEventResult: %v", err)
+	}
+	if calls != 0 {
+		t.Fatalf("Telegram calls = %d, want missing token to fail before dispatch", calls)
+	}
+	if _, ok, err := store.LoadActivityAttempt(ctx, activityRequestEventID(intent)); err != nil {
+		t.Fatalf("LoadActivityAttempt: %v", err)
+	} else if ok {
+		t.Fatal("activity attempt journal row exists, want missing token to fail before started journal")
+	}
+	if len(bus.publishes) != 1 || bus.publishes[0].Type() != events.EventType(intent.FailureEvent) {
+		t.Fatalf("publishes = %#v, want one failure event", bus.publishes)
+	}
+	if strings.Contains(string(bus.publishes[0].Payload()), "provider-secret") {
+		t.Fatalf("failure payload leaked credential: %s", bus.publishes[0].Payload())
+	}
+}
+
 func testActivityIntent(inputURL string) runtimeengine.ActivityIntent {
 	return runtimeengine.ActivityIntent{
 		ActivityID:    "scanner_source_scrape",
@@ -726,6 +932,104 @@ func testActivityCredentialStore(t *testing.T, key, value string) runtimecredent
 		}
 	}
 	return store
+}
+
+func testTelegramConnectorTool(baseURL string) runtimecontracts.ToolSchemaEntry {
+	return runtimecontracts.ToolSchemaEntry{
+		Category:    "provider_connector",
+		Description: "send Telegram messages",
+		HandlerType: "http",
+		EffectClass: string(runtimecontracts.ActivityEffectClassNonIdempotentWrite),
+		Credentials: []string{"telegram_bot_token"},
+		OutputSchema: runtimecontracts.ToolInputSchema{
+			Type: "object",
+		},
+		HTTP: &runtimecontracts.HTTPToolSpec{
+			Method: "POST",
+			URL:    strings.TrimRight(baseURL, "/") + "/bot{{credentials.telegram_bot_token}}/sendMessage",
+			Body: map[string]any{
+				"chat_id": "{{input.chat_id}}",
+				"text":    "{{input.text}}",
+			},
+		},
+	}
+}
+
+func acceptedTelegramInboundDeliveryEvent(t *testing.T, entityID, runID string) (providertriggers.Delivery, events.Event) {
+	t.Helper()
+	payload := map[string]any{
+		"update_id": float64(123456789),
+		"message": map[string]any{
+			"message_id": float64(7),
+			"chat":       map[string]any{"id": float64(42)},
+			"text":       "hello from telegram",
+		},
+	}
+	body := []byte(`{"update_id":123456789,"message":{"message_id":7,"chat":{"id":42},"text":"hello from telegram"}}`)
+	req := providertriggers.Request{
+		Provider: "telegram",
+		Target: providertriggers.Target{
+			EntityID:      entityID,
+			WebhookSecret: "telegram-secret",
+		},
+		Body:      body,
+		Headers:   make(http.Header),
+		Payload:   payload,
+		Received:  time.Unix(1710000000, 0).UTC(),
+		UserAgent: "telegram-test",
+	}
+	req.Headers.Set("X-Telegram-Bot-Api-Secret-Token", "telegram-secret")
+	delivery, err := providertriggers.DefaultRegistry().Accept(req)
+	if err != nil {
+		t.Fatalf("Accept Telegram inbound delivery: %v", err)
+	}
+	if delivery.EventName != "inbound.telegram" || delivery.ProviderEventID != "123456789" {
+		t.Fatalf("delivery = %+v, want inbound.telegram update", delivery)
+	}
+	raw, err := json.Marshal(delivery.Payload)
+	if err != nil {
+		t.Fatalf("marshal inbound delivery payload: %v", err)
+	}
+	evt := eventtest.RootIngress(
+		uuid.NewSHA1(uuid.NameSpaceURL, []byte("swarm:telegram-inbound:"+delivery.ProviderEventID)).String(),
+		delivery.EventName,
+		"telegram",
+		"telegram-update-7",
+		raw,
+		1,
+		runID,
+		"",
+		events.EventEnvelope{
+			EntityID: entityID,
+			Source: events.RouteIdentity{
+				EntityID: entityID,
+			},
+		},
+		time.Unix(1710000000, 0).UTC(),
+	)
+	return delivery, evt
+}
+
+func telegramInboundChatAndText(t *testing.T, payload map[string]any) (string, string) {
+	t.Helper()
+	rawPayload, ok := payload["payload"].(map[string]any)
+	if !ok {
+		t.Fatalf("inbound payload = %#v, want payload object", payload["payload"])
+	}
+	message, ok := rawPayload["message"].(map[string]any)
+	if !ok {
+		t.Fatalf("telegram message = %#v, want object", rawPayload["message"])
+	}
+	chat, ok := message["chat"].(map[string]any)
+	if !ok {
+		t.Fatalf("telegram chat = %#v, want object", message["chat"])
+	}
+	chatID := asString(chat["id"])
+	text := asString(message["text"])
+	if chatID == "" || text == "" {
+		t.Fatalf("telegram chat/text = %q/%q, want non-empty", chatID, text)
+	}
+	return chatID, text
 }
 
 type activityRoundTripFunc func(*http.Request) (*http.Response, error)

--- a/internal/runtime/telegram_connector_supported_surface_test.go
+++ b/internal/runtime/telegram_connector_supported_surface_test.go
@@ -1,0 +1,926 @@
+package runtime_test
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/division-sh/swarm/internal/events"
+	"github.com/division-sh/swarm/internal/events/eventtest"
+	runtimepkg "github.com/division-sh/swarm/internal/runtime"
+	runtimebus "github.com/division-sh/swarm/internal/runtime/bus"
+	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
+	runtimecorrelation "github.com/division-sh/swarm/internal/runtime/correlation"
+	runtimecredentials "github.com/division-sh/swarm/internal/runtime/credentials"
+	runtimeengine "github.com/division-sh/swarm/internal/runtime/engine"
+	runtimepipeline "github.com/division-sh/swarm/internal/runtime/pipeline"
+	"github.com/division-sh/swarm/internal/runtime/semanticview"
+	"github.com/division-sh/swarm/internal/store"
+	"github.com/division-sh/swarm/internal/store/storetest"
+	"github.com/division-sh/swarm/internal/testutil"
+)
+
+func TestTelegramConnectorSupportedSurfaceRoundTripThroughInboundGateway(t *testing.T) {
+	t.Run("postgres", func(t *testing.T) {
+		_, db, cleanup := testutil.StartPostgres(t)
+		t.Cleanup(cleanup)
+
+		const (
+			runID        = "6a000000-0000-0000-0000-000000000001"
+			entityID     = "6a000000-0000-0000-0000-000000000002"
+			flowInstance = "telegram-connector-supported-surface-pg"
+		)
+		ctx := runtimecorrelation.WithRunID(context.Background(), runID)
+		pg := &store.PostgresStore{DB: db}
+		workflowStore := runtimepipeline.NewWorkflowInstanceStore(db)
+		seedPostgresInboundGatewayRuntime(t, ctx, db, pg, runID, entityID, flowInstance, "customer-a", "telegram", "telegram-secret", "telegram-supported-surface-observer")
+		seedTelegramConnectorSupportedSurfaceWorkflowVersion(t, ctx, db, flowInstance, false)
+
+		runTelegramConnectorSupportedSurfaceRoundTrip(t, telegramConnectorSupportedSurfaceBackend{
+			name:          "postgres",
+			ctx:           ctx,
+			db:            db,
+			eventStore:    pg,
+			inboundStore:  pg,
+			workflowStore: workflowStore,
+			runID:         runID,
+			entityID:      entityID,
+			flowInstance:  flowInstance,
+			sqlite:        false,
+		})
+	})
+
+	t.Run("sqlite", func(t *testing.T) {
+		const (
+			runID        = "6b000000-0000-0000-0000-000000000001"
+			entityID     = "6b000000-0000-0000-0000-000000000002"
+			flowInstance = "telegram-connector-supported-surface-sqlite"
+		)
+		ctx := runtimecorrelation.WithRunID(context.Background(), runID)
+		sqliteStore := storetest.StartSQLiteRuntimeStoreWithContext(t, ctx)
+		workflowStore := runtimepipeline.NewSQLiteWorkflowInstanceStoreWithRuntimeMutationRunner(sqliteStore.DB, sqliteStore)
+		seedSQLiteInboundGatewayRuntime(t, ctx, sqliteStore, runID, entityID, flowInstance, "customer-a", "telegram", "telegram-secret", "telegram-supported-surface-observer")
+		seedTelegramConnectorSupportedSurfaceWorkflowVersion(t, ctx, sqliteStore.DB, flowInstance, true)
+
+		runTelegramConnectorSupportedSurfaceRoundTrip(t, telegramConnectorSupportedSurfaceBackend{
+			name:          "sqlite",
+			ctx:           ctx,
+			db:            sqliteStore.DB,
+			eventStore:    sqliteStore,
+			inboundStore:  sqliteStore,
+			workflowStore: workflowStore,
+			runID:         runID,
+			entityID:      entityID,
+			flowInstance:  flowInstance,
+			sqlite:        true,
+		})
+	})
+}
+
+type telegramConnectorSupportedSurfaceBackend struct {
+	name          string
+	ctx           context.Context
+	db            *sql.DB
+	eventStore    runtimebus.EventStore
+	inboundStore  runtimepkg.InboundPersistence
+	workflowStore *runtimepipeline.WorkflowInstanceStore
+	runID         string
+	entityID      string
+	flowInstance  string
+	sqlite        bool
+}
+
+type telegramConnectorSupportedSurfaceCall struct {
+	path string
+	body map[string]any
+	raw  string
+}
+
+func runTelegramConnectorSupportedSurfaceRoundTrip(t *testing.T, backend telegramConnectorSupportedSurfaceBackend) {
+	t.Helper()
+	calls := make(chan telegramConnectorSupportedSurfaceCall, 4)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		raw, err := io.ReadAll(r.Body)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		var body map[string]any
+		if err := json.Unmarshal(raw, &body); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		calls <- telegramConnectorSupportedSurfaceCall{
+			path: r.URL.Path,
+			body: body,
+			raw:  string(raw),
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"ok": true,
+			"result": map[string]any{
+				"message_id": 99,
+				"chat":       map[string]any{"id": 42},
+				"text":       body["text"],
+			},
+		})
+	}))
+	defer server.Close()
+
+	credentialStore := telegramConnectorSupportedSurfaceCredentialStore(t, "telegram_bot_token", "provider-secret")
+	source := telegramConnectorSupportedSurfaceSource(server.URL)
+	var pc *runtimepipeline.PipelineCoordinator
+	bus, err := runtimebus.NewEventBusWithOptions(backend.eventStore, runtimebus.EventBusOptions{
+		ContractBundle: source,
+		InterceptorProvider: func() []runtimebus.EventInterceptor {
+			if pc == nil {
+				return nil
+			}
+			return []runtimebus.EventInterceptor{pc}
+		},
+	})
+	if err != nil {
+		t.Fatalf("%s NewEventBusWithOptions: %v", backend.name, err)
+	}
+	pc = startTelegramConnectorSupportedSurfaceCoordinator(t, backend.ctx, bus, backend.db, backend.workflowStore, source, credentialStore)
+
+	gateway := runtimepkg.NewInboundGateway(bus, nil, nil, backend.inboundStore)
+	webhookPath := fmt.Sprintf("/webhooks/%s/telegram", backend.entityID)
+	validBody := []byte(`{"update_id":123456789,"message":{"message_id":7,"chat":{"id":42},"text":"hello from telegram"}}`)
+	validReq := newSignedTelegramRequest(webhookPath, "telegram-secret", validBody).WithContext(backend.ctx)
+	validRec := httptest.NewRecorder()
+	gateway.Handler().ServeHTTP(validRec, validReq)
+	if validRec.Code != http.StatusAccepted {
+		t.Fatalf("%s gateway status = %d, want 202 body=%s", backend.name, validRec.Code, validRec.Body.String())
+	}
+	if strings.Contains(validRec.Body.String(), "telegram-secret") || strings.Contains(validRec.Body.String(), "provider-secret") {
+		t.Fatalf("%s gateway response leaked a Telegram secret: %s", backend.name, validRec.Body.String())
+	}
+
+	call := requireTelegramConnectorSupportedSurfaceCall(t, calls, backend.name, backend)
+	if call.path != "/botprovider-secret/sendMessage" {
+		t.Fatalf("%s Telegram path = %q, want token path sendMessage", backend.name, call.path)
+	}
+	if got := telegramConnectorSupportedSurfaceString(call.body["chat_id"]); got != "42" {
+		t.Fatalf("%s chat_id = %#v, want 42", backend.name, call.body["chat_id"])
+	}
+	if got := telegramConnectorSupportedSurfaceString(call.body["text"]); got != "hello from telegram" {
+		t.Fatalf("%s text = %#v, want inbound text", backend.name, call.body["text"])
+	}
+
+	waitForInboundBusQuiescence(t, bus)
+
+	inboundEventID := loadTelegramConnectorSupportedSurfaceInboundEventID(t, backend, "123456789")
+	if got := countTelegramConnectorSupportedSurfaceNodeDeliveries(t, backend, inboundEventID, telegramConnectorSupportedSurfaceNodeID); got != 1 {
+		t.Fatalf("%s node delivery rows for inbound event = %d, want 1", backend.name, got)
+	}
+
+	attempt := waitForTelegramConnectorSupportedSurfaceTerminalActivityAttempt(t, backend)
+	if attempt.Status != runtimepipeline.ActivityAttemptStatusSucceeded {
+		t.Fatalf("%s activity attempt status = %q, want succeeded", backend.name, attempt.Status)
+	}
+	if attempt.SourceEventID != inboundEventID {
+		t.Fatalf("%s activity attempt source_event_id = %q, want inbound event %q", backend.name, attempt.SourceEventID, inboundEventID)
+	}
+	if got := telegramConnectorSupportedSurfaceString(attempt.ResultPayload["result"]); strings.Contains(got, "provider-secret") {
+		t.Fatalf("%s activity result leaked provider token: %s", backend.name, got)
+	}
+	requireTelegramConnectorSupportedSurfaceEventEventually(t, backend, attempt.ResultEventID, attempt.ResultEventType)
+
+	duplicateReq := newSignedTelegramRequest(webhookPath, "telegram-secret", validBody).WithContext(backend.ctx)
+	duplicateRec := httptest.NewRecorder()
+	gateway.Handler().ServeHTTP(duplicateRec, duplicateReq)
+	if duplicateRec.Code != http.StatusOK {
+		t.Fatalf("%s duplicate gateway status = %d, want 200 body=%s", backend.name, duplicateRec.Code, duplicateRec.Body.String())
+	}
+	waitForInboundBusQuiescence(t, bus)
+	requireNoTelegramConnectorSupportedSurfaceCall(t, calls, backend.name, "duplicate webhook")
+	if got := countTelegramConnectorSupportedSurfaceActivityAttempts(t, backend); got != 1 {
+		t.Fatalf("%s activity attempts after duplicate webhook = %d, want 1", backend.name, got)
+	}
+
+	requestEvent := loadTelegramConnectorSupportedSurfaceActivityRequestEvent(t, backend, attempt.RequestEventID)
+	if err := bus.EngineDispatcher().DispatchPostCommit(backend.ctx, []runtimeengine.EmitIntent{{Event: requestEvent}}); err != nil {
+		t.Fatalf("%s duplicate activity request dispatch: %v", backend.name, err)
+	}
+	waitForInboundBusQuiescence(t, bus)
+	requireNoTelegramConnectorSupportedSurfaceCall(t, calls, backend.name, "duplicate activity request")
+	if got := countTelegramConnectorSupportedSurfaceActivityAttempts(t, backend); got != 1 {
+		t.Fatalf("%s activity attempts after duplicate activity request = %d, want 1", backend.name, got)
+	}
+
+	assertTelegramConnectorSupportedSurfaceNoStoredSecret(t, backend, "provider-secret")
+	assertTelegramConnectorSupportedSurfaceMissingToken(t, backend, server.URL, calls)
+}
+
+func assertTelegramConnectorSupportedSurfaceMissingToken(t *testing.T, backend telegramConnectorSupportedSurfaceBackend, baseURL string, calls <-chan telegramConnectorSupportedSurfaceCall) {
+	t.Helper()
+	credentialStore := telegramConnectorSupportedSurfaceCredentialStore(t, "", "")
+	source := telegramConnectorSupportedSurfaceSource(baseURL)
+	var pc *runtimepipeline.PipelineCoordinator
+	bus, err := runtimebus.NewEventBusWithOptions(backend.eventStore, runtimebus.EventBusOptions{
+		ContractBundle: source,
+		InterceptorProvider: func() []runtimebus.EventInterceptor {
+			if pc == nil {
+				return nil
+			}
+			return []runtimebus.EventInterceptor{pc}
+		},
+	})
+	if err != nil {
+		t.Fatalf("%s missing-token NewEventBusWithOptions: %v", backend.name, err)
+	}
+	pc = startTelegramConnectorSupportedSurfaceCoordinator(t, backend.ctx, bus, backend.db, backend.workflowStore, source, credentialStore)
+
+	gateway := runtimepkg.NewInboundGateway(bus, nil, nil, backend.inboundStore)
+	webhookPath := fmt.Sprintf("/webhooks/%s/telegram", backend.entityID)
+	missingTokenBody := []byte(`{"update_id":123456790,"message":{"message_id":8,"chat":{"id":42},"text":"missing token"}}`)
+	req := newSignedTelegramRequest(webhookPath, "telegram-secret", missingTokenBody).WithContext(backend.ctx)
+	rec := httptest.NewRecorder()
+	gateway.Handler().ServeHTTP(rec, req)
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("%s missing-token gateway status = %d, want 202 body=%s", backend.name, rec.Code, rec.Body.String())
+	}
+	waitForInboundBusQuiescence(t, bus)
+	requireNoTelegramConnectorSupportedSurfaceCall(t, calls, backend.name, "missing token")
+	if got := countTelegramConnectorSupportedSurfaceActivityAttemptsForEvent(t, backend, "123456790"); got != 0 {
+		t.Fatalf("%s missing-token activity attempts = %d, want 0", backend.name, got)
+	}
+	if got := countTelegramConnectorSupportedSurfaceFailureEventsForEvent(t, backend, "123456790"); got != 1 {
+		t.Fatalf("%s missing-token generated failure events = %d, want 1", backend.name, got)
+	}
+	assertTelegramConnectorSupportedSurfaceNoStoredSecret(t, backend, "provider-secret")
+}
+
+const telegramConnectorSupportedSurfaceNodeID = "telegram-responder"
+
+func telegramConnectorSupportedSurfaceSource(baseURL string) semanticview.Source {
+	handler := runtimecontracts.SystemNodeEventHandler{
+		Activity: runtimecontracts.ActivitySpec{
+			ID:   "telegram_send_message",
+			Tool: "telegram.send_message",
+			Input: map[string]runtimecontracts.ExpressionValue{
+				"chat_id": runtimecontracts.CELExpression("payload.payload.message.chat.id"),
+				"text":    runtimecontracts.CELExpression("payload.payload.message.text"),
+			},
+		},
+	}
+	node := runtimecontracts.SystemNodeContract{
+		ID:            telegramConnectorSupportedSurfaceNodeID,
+		ExecutionType: runtimecontracts.SystemNodeExecutionType,
+		EventHandlers: map[string]runtimecontracts.SystemNodeEventHandler{
+			"inbound.telegram": handler,
+		},
+	}
+	return semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
+		RootSchema: &runtimecontracts.FlowSchemaDocument{
+			Pins: runtimecontracts.FlowPins{
+				Inputs: runtimecontracts.FlowInputPins{
+					Events: []string{"inbound.telegram"},
+				},
+			},
+		},
+		Nodes: map[string]runtimecontracts.SystemNodeContract{
+			telegramConnectorSupportedSurfaceNodeID: node,
+		},
+		Tools: map[string]runtimecontracts.ToolSchemaEntry{
+			"telegram.send_message": telegramConnectorSupportedSurfaceTool(baseURL),
+		},
+		Semantics: runtimecontracts.WorkflowSemanticView{
+			Name:    "telegram_connector_supported_surface",
+			Version: "1.0.0",
+			EffectiveNodes: map[string]runtimecontracts.SystemNodeEffectiveSemantics{
+				telegramConnectorSupportedSurfaceNodeID: {
+					ID:                   telegramConnectorSupportedSurfaceNodeID,
+					ExecutionType:        runtimecontracts.SystemNodeExecutionType,
+					RuntimeSubscriptions: []string{"inbound.telegram"},
+				},
+			},
+			NodeHandlers: map[string]map[string]runtimecontracts.SystemNodeEventHandler{
+				telegramConnectorSupportedSurfaceNodeID: {
+					"inbound.telegram": handler,
+				},
+			},
+			EventOwners: map[string][]string{
+				"inbound.telegram": {telegramConnectorSupportedSurfaceNodeID},
+			},
+		},
+	})
+}
+
+func telegramConnectorSupportedSurfaceTool(baseURL string) runtimecontracts.ToolSchemaEntry {
+	return runtimecontracts.ToolSchemaEntry{
+		Category:    "provider_connector",
+		Description: "send Telegram messages",
+		HandlerType: "http",
+		EffectClass: string(runtimecontracts.ActivityEffectClassNonIdempotentWrite),
+		Credentials: []string{"telegram_bot_token"},
+		OutputSchema: runtimecontracts.ToolInputSchema{
+			Type: "object",
+		},
+		HTTP: &runtimecontracts.HTTPToolSpec{
+			Method: "POST",
+			URL:    strings.TrimRight(baseURL, "/") + "/bot{{credentials.telegram_bot_token}}/sendMessage",
+			Body: map[string]any{
+				"chat_id": "{{input.chat_id}}",
+				"text":    "{{input.text}}",
+			},
+		},
+	}
+}
+
+type telegramConnectorSupportedSurfaceModule struct {
+	source  semanticview.Source
+	nodes   []runtimepipeline.WorkflowNode
+	guards  runtimepipeline.GuardRegistry
+	actions runtimepipeline.ActionRegistry
+}
+
+func (m telegramConnectorSupportedSurfaceModule) SemanticSource() semanticview.Source {
+	return m.source
+}
+
+func (m telegramConnectorSupportedSurfaceModule) WorkflowDefinition() *runtimepipeline.WorkflowDefinition {
+	return nil
+}
+
+func (m telegramConnectorSupportedSurfaceModule) WorkflowNodes() []runtimepipeline.WorkflowNode {
+	return append([]runtimepipeline.WorkflowNode(nil), m.nodes...)
+}
+
+func (m telegramConnectorSupportedSurfaceModule) GuardRegistry() runtimepipeline.GuardRegistry {
+	return m.guards
+}
+
+func (m telegramConnectorSupportedSurfaceModule) ActionRegistry() runtimepipeline.ActionRegistry {
+	return m.actions
+}
+
+func startTelegramConnectorSupportedSurfaceCoordinator(
+	t *testing.T,
+	ctx context.Context,
+	bus *runtimebus.EventBus,
+	db *sql.DB,
+	workflowStore *runtimepipeline.WorkflowInstanceStore,
+	source semanticview.Source,
+	credentialStore runtimecredentials.Store,
+) *runtimepipeline.PipelineCoordinator {
+	t.Helper()
+	nodes, err := runtimepipeline.LoadWorkflowNodes(source)
+	if err != nil {
+		t.Fatalf("LoadWorkflowNodes: %v", err)
+	}
+	module := telegramConnectorSupportedSurfaceModule{
+		source:  source,
+		nodes:   nodes,
+		guards:  runtimepipeline.NewContractGuardRegistry(source),
+		actions: runtimepipeline.NewContractActionRegistry(source),
+	}
+	pc := runtimepipeline.NewPipelineCoordinatorWithOptions(bus, db, runtimepipeline.PipelineCoordinatorOptions{
+		Module:        module,
+		WorkflowStore: workflowStore,
+		Credentials:   credentialStore,
+		EventReceiptsCapability: func(context.Context) (bool, error) {
+			return true, nil
+		},
+	})
+	subscribed := make(chan struct{}, 1)
+	pc.SetTestSubscribeHook(func() {
+		select {
+		case subscribed <- struct{}{}:
+		default:
+		}
+	})
+	runCtx, cancel := context.WithCancel(ctx)
+	t.Cleanup(cancel)
+	go pc.Run(runCtx)
+	select {
+	case <-subscribed:
+	case <-time.After(5 * time.Second):
+		t.Fatal("pipeline coordinator did not subscribe")
+	}
+	return pc
+}
+
+func telegramConnectorSupportedSurfaceCredentialStore(t *testing.T, key, value string) runtimecredentials.Store {
+	t.Helper()
+	store, err := runtimecredentials.NewFileStore(filepath.Join(t.TempDir(), "credentials.json"))
+	if err != nil {
+		t.Fatalf("NewFileStore: %v", err)
+	}
+	if strings.TrimSpace(key) != "" {
+		if err := store.Set(context.Background(), key, value); err != nil {
+			t.Fatalf("Set credential: %v", err)
+		}
+	}
+	return store
+}
+
+func seedTelegramConnectorSupportedSurfaceWorkflowVersion(t *testing.T, ctx context.Context, db *sql.DB, flowInstance string, sqlite bool) {
+	t.Helper()
+	if sqlite {
+		if _, err := db.ExecContext(ctx, `
+			UPDATE flow_instances
+			SET config = json_set(COALESCE(config, '{}'), '$.workflow_version', '1.0.0')
+			WHERE instance_id = ?
+		`, flowInstance); err != nil {
+			t.Fatalf("seed sqlite workflow version: %v", err)
+		}
+		return
+	}
+	if _, err := db.ExecContext(ctx, `
+		UPDATE flow_instances
+		SET config = jsonb_set(COALESCE(config, '{}'::jsonb), '{workflow_version}', '"1.0.0"'::jsonb, true)
+		WHERE instance_id = $1
+	`, flowInstance); err != nil {
+		t.Fatalf("seed postgres workflow version: %v", err)
+	}
+}
+
+func requireTelegramConnectorSupportedSurfaceCall(t *testing.T, calls <-chan telegramConnectorSupportedSurfaceCall, backendName string, backend telegramConnectorSupportedSurfaceBackend) telegramConnectorSupportedSurfaceCall {
+	t.Helper()
+	select {
+	case call := <-calls:
+		return call
+	case <-time.After(5 * time.Second):
+		t.Fatalf("%s timed out waiting for fake Telegram dispatch; diagnostics: %s", backendName, telegramConnectorSupportedSurfaceDiagnostics(t, backend))
+		return telegramConnectorSupportedSurfaceCall{}
+	}
+}
+
+func requireNoTelegramConnectorSupportedSurfaceCall(t *testing.T, calls <-chan telegramConnectorSupportedSurfaceCall, backend, context string) {
+	t.Helper()
+	select {
+	case call := <-calls:
+		t.Fatalf("%s %s: unexpected fake Telegram dispatch: path=%s body=%s", backend, context, call.path, call.raw)
+	default:
+	}
+}
+
+func loadTelegramConnectorSupportedSurfaceInboundEventID(t *testing.T, backend telegramConnectorSupportedSurfaceBackend, providerEventID string) string {
+	t.Helper()
+	return loadTelegramConnectorSupportedSurfaceInboundEventIDByRun(t, backend, backend.runID, providerEventID)
+}
+
+func loadTelegramConnectorSupportedSurfaceInboundEventIDByRun(t *testing.T, backend telegramConnectorSupportedSurfaceBackend, runID, providerEventID string) string {
+	t.Helper()
+	var eventID string
+	var err error
+	if backend.sqlite {
+		err = backend.db.QueryRowContext(backend.ctx, `
+			SELECT event_id
+			FROM events
+			WHERE run_id = ?
+			  AND entity_id = ?
+			  AND event_name = 'inbound.telegram'
+			  AND json_extract(payload, '$.provider_event_id') = ?
+			ORDER BY created_at DESC
+			LIMIT 1
+		`, runID, backend.entityID, providerEventID).Scan(&eventID)
+	} else {
+		err = backend.db.QueryRowContext(backend.ctx, `
+			SELECT event_id::text
+			FROM events
+			WHERE run_id = $1::uuid
+			  AND entity_id = $2::uuid
+			  AND event_name = 'inbound.telegram'
+			  AND payload->>'provider_event_id' = $3
+			ORDER BY created_at DESC
+			LIMIT 1
+		`, runID, backend.entityID, providerEventID).Scan(&eventID)
+	}
+	if err != nil {
+		t.Fatalf("%s load inbound event id for %s: %v", backend.name, providerEventID, err)
+	}
+	return eventID
+}
+
+func countTelegramConnectorSupportedSurfaceNodeDeliveries(t *testing.T, backend telegramConnectorSupportedSurfaceBackend, eventID, nodeID string) int {
+	t.Helper()
+	var count int
+	var err error
+	if backend.sqlite {
+		err = backend.db.QueryRowContext(backend.ctx, `
+			SELECT COUNT(*)
+			FROM event_deliveries
+			WHERE event_id = ?
+			  AND subscriber_type = 'node'
+			  AND subscriber_id = ?
+		`, eventID, nodeID).Scan(&count)
+	} else {
+		err = backend.db.QueryRowContext(backend.ctx, `
+			SELECT COUNT(*)
+			FROM event_deliveries
+			WHERE event_id = $1::uuid
+			  AND subscriber_type = 'node'
+			  AND subscriber_id = $2
+		`, eventID, nodeID).Scan(&count)
+	}
+	if err != nil {
+		t.Fatalf("%s count node deliveries: %v", backend.name, err)
+	}
+	return count
+}
+
+func loadTelegramConnectorSupportedSurfaceActivityAttempt(t *testing.T, backend telegramConnectorSupportedSurfaceBackend) runtimepipeline.ActivityAttemptRecord {
+	t.Helper()
+	rec, ok, err := tryLoadTelegramConnectorSupportedSurfaceActivityAttempt(backend)
+	if err != nil {
+		t.Fatalf("%s load activity attempt: %v", backend.name, err)
+	}
+	if !ok {
+		t.Fatalf("%s activity attempt not found", backend.name)
+	}
+	return rec
+}
+
+func waitForTelegramConnectorSupportedSurfaceTerminalActivityAttempt(t *testing.T, backend telegramConnectorSupportedSurfaceBackend) runtimepipeline.ActivityAttemptRecord {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	var last runtimepipeline.ActivityAttemptRecord
+	var saw bool
+	for {
+		rec, ok, err := tryLoadTelegramConnectorSupportedSurfaceActivityAttempt(backend)
+		if err != nil {
+			t.Fatalf("%s load activity attempt while waiting: %v", backend.name, err)
+		}
+		if ok {
+			last = rec
+			saw = true
+			if rec.Status != runtimepipeline.ActivityAttemptStatusStarted {
+				return rec
+			}
+		}
+		if time.Now().After(deadline) {
+			if saw {
+				t.Fatalf("%s activity attempt did not reach terminal status; last=%q diagnostics: %s", backend.name, last.Status, telegramConnectorSupportedSurfaceDiagnostics(t, backend))
+			}
+			t.Fatalf("%s activity attempt was not created; diagnostics: %s", backend.name, telegramConnectorSupportedSurfaceDiagnostics(t, backend))
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func tryLoadTelegramConnectorSupportedSurfaceActivityAttempt(backend telegramConnectorSupportedSurfaceBackend) (runtimepipeline.ActivityAttemptRecord, bool, error) {
+	var requestEventID string
+	var err error
+	if backend.sqlite {
+		err = backend.db.QueryRowContext(backend.ctx, `
+			SELECT request_event_id
+			FROM activity_attempts
+			WHERE run_id = ?
+			  AND tool = 'telegram.send_message'
+			ORDER BY started_at ASC
+			LIMIT 1
+		`, backend.runID).Scan(&requestEventID)
+	} else {
+		err = backend.db.QueryRowContext(backend.ctx, `
+			SELECT request_event_id::text
+			FROM activity_attempts
+			WHERE run_id = $1::uuid
+			  AND tool = 'telegram.send_message'
+			ORDER BY started_at ASC
+			LIMIT 1
+		`, backend.runID).Scan(&requestEventID)
+	}
+	if err == sql.ErrNoRows {
+		return runtimepipeline.ActivityAttemptRecord{}, false, nil
+	}
+	if err != nil {
+		return runtimepipeline.ActivityAttemptRecord{}, false, err
+	}
+	rec, ok, err := backend.workflowStore.LoadActivityAttempt(backend.ctx, requestEventID)
+	if err != nil {
+		return runtimepipeline.ActivityAttemptRecord{}, false, err
+	}
+	return rec, ok, nil
+}
+
+func countTelegramConnectorSupportedSurfaceActivityAttempts(t *testing.T, backend telegramConnectorSupportedSurfaceBackend) int {
+	t.Helper()
+	var count int
+	var err error
+	if backend.sqlite {
+		err = backend.db.QueryRowContext(backend.ctx, `
+			SELECT COUNT(*)
+			FROM activity_attempts
+			WHERE run_id = ?
+			  AND tool = 'telegram.send_message'
+		`, backend.runID).Scan(&count)
+	} else {
+		err = backend.db.QueryRowContext(backend.ctx, `
+			SELECT COUNT(*)
+			FROM activity_attempts
+			WHERE run_id = $1::uuid
+			  AND tool = 'telegram.send_message'
+		`, backend.runID).Scan(&count)
+	}
+	if err != nil {
+		t.Fatalf("%s count activity attempts: %v", backend.name, err)
+	}
+	return count
+}
+
+func countTelegramConnectorSupportedSurfaceActivityAttemptsForEvent(t *testing.T, backend telegramConnectorSupportedSurfaceBackend, providerEventID string) int {
+	t.Helper()
+	inboundEventID := loadTelegramConnectorSupportedSurfaceInboundEventIDByRun(t, backend, backend.runID, providerEventID)
+	var count int
+	var err error
+	if backend.sqlite {
+		err = backend.db.QueryRowContext(backend.ctx, `
+			SELECT COUNT(*)
+			FROM activity_attempts
+			WHERE run_id = ?
+			  AND tool = 'telegram.send_message'
+			  AND source_event_id = ?
+		`, backend.runID, inboundEventID).Scan(&count)
+	} else {
+		err = backend.db.QueryRowContext(backend.ctx, `
+			SELECT COUNT(*)
+			FROM activity_attempts
+			WHERE run_id = $1::uuid
+			  AND tool = 'telegram.send_message'
+			  AND source_event_id = $2::uuid
+		`, backend.runID, inboundEventID).Scan(&count)
+	}
+	if err != nil {
+		t.Fatalf("%s count activity attempts for provider event %s: %v", backend.name, providerEventID, err)
+	}
+	return count
+}
+
+func countTelegramConnectorSupportedSurfaceFailureEventsForEvent(t *testing.T, backend telegramConnectorSupportedSurfaceBackend, providerEventID string) int {
+	t.Helper()
+	inboundEventID := loadTelegramConnectorSupportedSurfaceInboundEventIDByRun(t, backend, backend.runID, providerEventID)
+	var count int
+	var err error
+	if backend.sqlite {
+		err = backend.db.QueryRowContext(backend.ctx, `
+			SELECT COUNT(*)
+			FROM events
+			WHERE run_id = ?
+			  AND event_name = 'telegram_send_message.failed'
+			  AND source_event_id = ?
+		`, backend.runID, inboundEventID).Scan(&count)
+	} else {
+		err = backend.db.QueryRowContext(backend.ctx, `
+			SELECT COUNT(*)
+			FROM events
+			WHERE run_id = $1::uuid
+			  AND event_name = 'telegram_send_message.failed'
+			  AND source_event_id = $2::uuid
+		`, backend.runID, inboundEventID).Scan(&count)
+	}
+	if err != nil {
+		t.Fatalf("%s count failure events for provider event %s: %v", backend.name, providerEventID, err)
+	}
+	return count
+}
+
+func requireTelegramConnectorSupportedSurfaceEventEventually(t *testing.T, backend telegramConnectorSupportedSurfaceBackend, eventID, eventType string) {
+	t.Helper()
+	if strings.TrimSpace(eventID) == "" || strings.TrimSpace(eventType) == "" {
+		t.Fatalf("%s result event identity missing: id=%q type=%q", backend.name, eventID, eventType)
+	}
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		if telegramConnectorSupportedSurfaceEventExists(t, backend, eventID, eventType) {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("%s event rows for %s/%s = 0, want 1; diagnostics: %s", backend.name, eventID, eventType, telegramConnectorSupportedSurfaceDiagnostics(t, backend))
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func telegramConnectorSupportedSurfaceEventExists(t *testing.T, backend telegramConnectorSupportedSurfaceBackend, eventID, eventType string) bool {
+	t.Helper()
+	var count int
+	var err error
+	if backend.sqlite {
+		err = backend.db.QueryRowContext(backend.ctx, `
+			SELECT COUNT(*)
+			FROM events
+			WHERE event_id = ?
+			  AND event_name = ?
+		`, eventID, eventType).Scan(&count)
+	} else {
+		err = backend.db.QueryRowContext(backend.ctx, `
+			SELECT COUNT(*)
+			FROM events
+			WHERE event_id = $1::uuid
+			  AND event_name = $2
+		`, eventID, eventType).Scan(&count)
+	}
+	if err != nil {
+		t.Fatalf("%s require event %s/%s: %v", backend.name, eventID, eventType, err)
+	}
+	return count == 1
+}
+
+func loadTelegramConnectorSupportedSurfaceActivityRequestEvent(t *testing.T, backend telegramConnectorSupportedSurfaceBackend, eventID string) events.Event {
+	t.Helper()
+	var raw []byte
+	var created time.Time
+	var err error
+	if backend.sqlite {
+		var payload string
+		var createdRaw string
+		err = backend.db.QueryRowContext(backend.ctx, `
+			SELECT payload, created_at
+			FROM events
+			WHERE event_id = ?
+			  AND event_name = 'platform.activity_requested'
+		`, eventID).Scan(&payload, &createdRaw)
+		raw = []byte(payload)
+		created, _ = time.Parse(time.RFC3339Nano, createdRaw)
+		if created.IsZero() {
+			created = time.Now().UTC()
+		}
+	} else {
+		err = backend.db.QueryRowContext(backend.ctx, `
+			SELECT payload, created_at
+			FROM events
+			WHERE event_id = $1::uuid
+			  AND event_name = 'platform.activity_requested'
+		`, eventID).Scan(&raw, &created)
+	}
+	if err != nil {
+		t.Fatalf("%s load activity request event %s: %v", backend.name, eventID, err)
+	}
+	return eventtest.PersistedProjection(
+		eventID,
+		events.EventType("platform.activity_requested"),
+		"workflow-runtime",
+		"",
+		raw,
+		2,
+		backend.runID,
+		"",
+		events.EventEnvelope{EntityID: backend.entityID},
+		created,
+	)
+}
+
+func assertTelegramConnectorSupportedSurfaceNoStoredSecret(t *testing.T, backend telegramConnectorSupportedSurfaceBackend, secret string) {
+	t.Helper()
+	var eventLeaks int
+	var attemptLeaks int
+	var err error
+	if backend.sqlite {
+		err = backend.db.QueryRowContext(backend.ctx, `
+			SELECT COUNT(*)
+			FROM events
+			WHERE run_id = ?
+			  AND payload LIKE '%' || ? || '%'
+		`, backend.runID, secret).Scan(&eventLeaks)
+		if err == nil {
+			err = backend.db.QueryRowContext(backend.ctx, `
+				SELECT COUNT(*)
+				FROM activity_attempts
+				WHERE run_id = ?
+				  AND (
+					COALESCE(result_payload, '') LIKE '%' || ? || '%'
+					OR COALESCE(error, '') LIKE '%' || ? || '%'
+				  )
+			`, backend.runID, secret, secret).Scan(&attemptLeaks)
+		}
+	} else {
+		err = backend.db.QueryRowContext(backend.ctx, `
+			SELECT COUNT(*)
+			FROM events
+			WHERE run_id = $1::uuid
+			  AND payload::text LIKE '%' || $2 || '%'
+		`, backend.runID, secret).Scan(&eventLeaks)
+		if err == nil {
+			err = backend.db.QueryRowContext(backend.ctx, `
+				SELECT COUNT(*)
+				FROM activity_attempts
+				WHERE run_id = $1::uuid
+				  AND (
+					COALESCE(result_payload::text, '') LIKE '%' || $2 || '%'
+					OR COALESCE(error, '') LIKE '%' || $2 || '%'
+				  )
+			`, backend.runID, secret).Scan(&attemptLeaks)
+		}
+	}
+	if err != nil {
+		t.Fatalf("%s no-secret query: %v", backend.name, err)
+	}
+	if eventLeaks != 0 || attemptLeaks != 0 {
+		t.Fatalf("%s stored secret leaks: events=%d activity_attempts=%d", backend.name, eventLeaks, attemptLeaks)
+	}
+}
+
+func telegramConnectorSupportedSurfaceDiagnostics(t *testing.T, backend telegramConnectorSupportedSurfaceBackend) string {
+	t.Helper()
+	type row struct {
+		name   string
+		query  string
+		args   []any
+		sqlite string
+	}
+	rows := []row{
+		{
+			name:   "events",
+			query:  `SELECT COUNT(*) FROM events WHERE run_id = $1::uuid`,
+			sqlite: `SELECT COUNT(*) FROM events WHERE run_id = ?`,
+			args:   []any{backend.runID},
+		},
+		{
+			name:   "inbound_telegram_events",
+			query:  `SELECT COUNT(*) FROM events WHERE run_id = $1::uuid AND event_name = 'inbound.telegram'`,
+			sqlite: `SELECT COUNT(*) FROM events WHERE run_id = ? AND event_name = 'inbound.telegram'`,
+			args:   []any{backend.runID},
+		},
+		{
+			name:   "node_deliveries",
+			query:  `SELECT COUNT(*) FROM event_deliveries WHERE run_id = $1::uuid AND subscriber_type = 'node' AND subscriber_id = $2`,
+			sqlite: `SELECT COUNT(*) FROM event_deliveries WHERE run_id = ? AND subscriber_type = 'node' AND subscriber_id = ?`,
+			args:   []any{backend.runID, telegramConnectorSupportedSurfaceNodeID},
+		},
+		{
+			name:   "activity_requests",
+			query:  `SELECT COUNT(*) FROM events WHERE run_id = $1::uuid AND event_name = 'platform.activity_requested'`,
+			sqlite: `SELECT COUNT(*) FROM events WHERE run_id = ? AND event_name = 'platform.activity_requested'`,
+			args:   []any{backend.runID},
+		},
+		{
+			name:   "activity_attempts",
+			query:  `SELECT COUNT(*) FROM activity_attempts WHERE run_id = $1::uuid`,
+			sqlite: `SELECT COUNT(*) FROM activity_attempts WHERE run_id = ?`,
+			args:   []any{backend.runID},
+		},
+		{
+			name:   "dead_letters",
+			query:  `SELECT COUNT(*) FROM dead_letters WHERE entity_id = $1::uuid`,
+			sqlite: `SELECT COUNT(*) FROM dead_letters WHERE entity_id = ?`,
+			args:   []any{backend.entityID},
+		},
+	}
+	parts := make([]string, 0, len(rows))
+	for _, r := range rows {
+		query := r.query
+		if backend.sqlite {
+			query = r.sqlite
+		}
+		var count int
+		if err := backend.db.QueryRowContext(backend.ctx, query, r.args...).Scan(&count); err != nil {
+			parts = append(parts, r.name+"=ERR("+err.Error()+")")
+			continue
+		}
+		parts = append(parts, fmt.Sprintf("%s=%d", r.name, count))
+	}
+	parts = append(parts, "delivery_status="+telegramConnectorSupportedSurfaceScalarDiagnostic(t, backend,
+		`SELECT COALESCE(status, '') || ':' || COALESCE(reason_code, '') || ':' || COALESCE(last_error, '') FROM event_deliveries WHERE run_id = $1::uuid AND subscriber_type = 'node' AND subscriber_id = $2 ORDER BY created_at DESC LIMIT 1`,
+		`SELECT COALESCE(status, '') || ':' || COALESCE(reason_code, '') || ':' || COALESCE(last_error, '') FROM event_deliveries WHERE run_id = ? AND subscriber_type = 'node' AND subscriber_id = ? ORDER BY created_at DESC LIMIT 1`,
+		backend.runID, telegramConnectorSupportedSurfaceNodeID))
+	parts = append(parts, "dead_letter="+telegramConnectorSupportedSurfaceScalarDiagnostic(t, backend,
+		`SELECT COALESCE(failure_type, '') || ':' || COALESCE(error_message, '') FROM dead_letters WHERE entity_id = $1::uuid ORDER BY created_at DESC LIMIT 1`,
+		`SELECT COALESCE(failure_type, '') || ':' || COALESCE(error_message, '') FROM dead_letters WHERE entity_id = ? ORDER BY created_at DESC LIMIT 1`,
+		backend.entityID))
+	return strings.Join(parts, " ")
+}
+
+func telegramConnectorSupportedSurfaceScalarDiagnostic(t *testing.T, backend telegramConnectorSupportedSurfaceBackend, pgQuery, sqliteQuery string, args ...any) string {
+	t.Helper()
+	query := pgQuery
+	if backend.sqlite {
+		query = sqliteQuery
+	}
+	var value string
+	if err := backend.db.QueryRowContext(backend.ctx, query, args...).Scan(&value); err != nil {
+		if err == sql.ErrNoRows {
+			return "<none>"
+		}
+		return "ERR(" + err.Error() + ")"
+	}
+	return value
+}
+
+func telegramConnectorSupportedSurfaceString(value any) string {
+	switch v := value.(type) {
+	case nil:
+		return ""
+	case string:
+		return v
+	case json.Number:
+		return v.String()
+	case float64:
+		return fmt.Sprintf("%.0f", v)
+	case int:
+		return fmt.Sprintf("%d", v)
+	case int64:
+		return fmt.Sprintf("%d", v)
+	default:
+		return fmt.Sprint(v)
+	}
+}

--- a/internal/runtime/workflow_validation.go
+++ b/internal/runtime/workflow_validation.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/division-sh/swarm/internal/providerconnectors"
 	runtimeauthority "github.com/division-sh/swarm/internal/runtime/authority"
 	runtimebootverify "github.com/division-sh/swarm/internal/runtime/bootverify"
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
@@ -104,6 +105,10 @@ func ValidateWorkflowContractSurface(ctx context.Context, source semanticview.So
 	activityErrors := validateDurableActivitySurface(source)
 	if len(activityErrors) > 0 {
 		return result, fmt.Errorf("durable activity validation failed:\n%s", formatValidationErrors(activityErrors))
+	}
+	connectorErrors := providerconnectors.ValidateSource(source)
+	if len(connectorErrors) > 0 {
+		return result, fmt.Errorf("provider connector validation failed:\n%s", formatValidationErrors(connectorErrors))
 	}
 
 	return result, nil

--- a/internal/runtime/workflow_validation_test.go
+++ b/internal/runtime/workflow_validation_test.go
@@ -234,6 +234,81 @@ func TestValidateWorkflowContractSurface_DurableActivityNonIdempotentWriteAdmitt
 	}
 }
 
+func TestValidateWorkflowContractSurface_TelegramProviderConnectorToolAdmitted(t *testing.T) {
+	bundle := testRuntimeWorkflowValidationBundle()
+	bundle.Tools = map[string]runtimecontracts.ToolSchemaEntry{
+		"telegram.send_message": {
+			Category:    "provider_connector",
+			Description: "send Telegram messages",
+			HandlerType: "http",
+			EffectClass: string(runtimecontracts.ActivityEffectClassNonIdempotentWrite),
+			Credentials: []string{"telegram_bot_token"},
+			InputSchema: runtimecontracts.ToolInputSchema{
+				Type:     "object",
+				Required: []string{"chat_id", "text"},
+				Properties: map[string]runtimecontracts.ToolInputSchema{
+					"chat_id": {Type: "string"},
+					"text":    {Type: "string"},
+				},
+			},
+			OutputSchema: runtimecontracts.ToolInputSchema{Type: "object"},
+			HTTP: &runtimecontracts.HTTPToolSpec{
+				Method: "POST",
+				URL:    "https://api.telegram.org/bot{{credentials.telegram_bot_token}}/sendMessage",
+				Body: map[string]any{
+					"chat_id": "{{input.chat_id}}",
+					"text":    "{{input.text}}",
+				},
+			},
+		},
+	}
+	bundle.Nodes = map[string]runtimecontracts.SystemNodeContract{
+		"responder": {
+			EventHandlers: map[string]runtimecontracts.SystemNodeEventHandler{
+				"inbound.telegram": {
+					Activity: runtimecontracts.ActivitySpec{
+						Tool: "telegram.send_message",
+						Input: map[string]runtimecontracts.ExpressionValue{
+							"chat_id": runtimecontracts.CELExpression("payload.payload.message.chat.id"),
+							"text":    runtimecontracts.CELExpression(`"hello"`),
+						},
+					},
+				},
+			},
+		},
+	}
+	_, err := ValidateWorkflowContractSurface(context.Background(), semanticview.Wrap(bundle), WorkflowContractValidationOptions{
+		CheckMCPReachable:              false,
+		StrictEmitSchemas:              false,
+		FatalToolImplementationWarning: false,
+		FatalBootWarnings:              false,
+	})
+	if err != nil {
+		t.Fatalf("ValidateWorkflowContractSurface error = %v, want Telegram connector admitted", err)
+	}
+}
+
+func TestValidateWorkflowContractSurface_ProviderConnectorToolFailsClosedForUnsupportedShape(t *testing.T) {
+	bundle := testRuntimeWorkflowValidationBundle()
+	bundle.Tools = map[string]runtimecontracts.ToolSchemaEntry{
+		"telegram.send_message": {
+			Category:    "provider_connector",
+			HandlerType: "http",
+			EffectClass: string(runtimecontracts.ActivityEffectClassReadOnly),
+			HTTP:        &runtimecontracts.HTTPToolSpec{Method: "POST", URL: "https://api.telegram.org/bot{{credentials.telegram_bot_token}}/sendMessage"},
+		},
+	}
+	_, err := ValidateWorkflowContractSurface(context.Background(), semanticview.Wrap(bundle), WorkflowContractValidationOptions{
+		CheckMCPReachable:              false,
+		StrictEmitSchemas:              false,
+		FatalToolImplementationWarning: false,
+		FatalBootWarnings:              false,
+	})
+	if err == nil || !strings.Contains(err.Error(), "provider connector validation failed") || !strings.Contains(err.Error(), "effect_class must be non_idempotent_write") {
+		t.Fatalf("ValidateWorkflowContractSurface error = %v, want provider connector fail-closed", err)
+	}
+}
+
 func TestValidateWorkflowContractSurface_DurableActivityIdempotentWriteFailsClosed(t *testing.T) {
 	bundle := testRuntimeWorkflowValidationBundle()
 	bundle.Tools = map[string]runtimecontracts.ToolSchemaEntry{

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -6330,6 +6330,30 @@ tool_model:
       \ Domain to check (e.g., example.com)\n  http:\n    method: GET\n    url: \"https://api.domainr.com/v2/status?domain={{input.domain}}\"\
       \n    headers:\n      Authorization: \"Bearer {{credentials.domainr_api_key}}\"\n  response_mapping:\n    available:\
       \ \"{{response.body.status[0].summary}}\"\n  credentials:\n    - domainr_api_key"
+  provider_connector_tools:
+    description: >
+      Stage 1 flow-local outbound provider connectors are authored HTTP tools in tools.yaml, marked with
+      `category: provider_connector`, and executed only through handler `activity` requests. The category is a readback and
+      validation profile, not a new runtime dispatcher: dispatch remains owned by the HTTP activity executor and
+      non-idempotent writes remain owned by `activity_attempts`.
+    canonical_owners:
+      declaration: "tools.yaml ToolSchemaEntry with `category: provider_connector`."
+      execution: "handler `activity` lowering to `platform.activity_requested`."
+      non_idempotent_journal: "`activity_attempts`."
+      credentials: "static credential store keys listed under tool `credentials`."
+      readback: "local preflight/doctor provider connector CAN/CANNOT/BOUND/UNBOUND findings."
+      display: "first CAN action label is derived from the authored tool `description`; if absent, it falls back to normalized `<action> via <Provider>`."
+    stage_1_profile:
+      required:
+      - "tool id MUST use `<provider>.<action>` form."
+      - "`handler_type` MUST resolve to `http` and include an `http` block with explicit `method` and `url`."
+      - "`effect_class` MUST be `non_idempotent_write`."
+      - "at least one static credential key MUST be declared under `credentials`."
+      forbidden:
+      - "`managed_credential`; managed OAuth/token lifecycle is a separate owner."
+      - "`response_mapping`; connector response mapping is split until specified."
+      - "`rate_limit` and `rate_limit_max_wait`; connector admission/rate limiting is split until specified."
+      - "direct runtime provider adapter code, connector-pack body/envelope execution, or bespoke connector dispatch."
   credential_store:
     description: Secure storage for API keys, tokens, and other credentials referenced by MCP servers and HTTP tools. The
       platform provides a typed interface with a layered resolution model.
@@ -6820,6 +6844,8 @@ tool_model:
     required_fields:
       description: string — human-readable description of what the tool does
     common_optional_fields:
+      category: string — optional semantic profile marker. `provider_connector` means the tool must satisfy
+        tool_model.provider_connector_tools.
       handler_type: string — platform_builtin | mcp | http. Default http.
       effect_class: string — required when the tool is callable from a handler activity. Executable Stage 1 values are
         read_only and non_idempotent_write on the authored HTTP activity_attempts journal path. idempotent_write is reserved


### PR DESCRIPTION
Closes #1766
Part of #1663
Consumes #1809

## Summary

- Adds a flow-local `provider_connector` tools.yaml profile for outbound provider connector proofs.
- Adds `telegram.send_message` validation/readback semantics while keeping execution on authored HTTP `activity` and `activity_attempts`.
- Proves Telegram inbound-to-outbound round trip through existing `inbound.telegram` provider trigger delivery and generated `platform.activity_requested` result events.

## Governing Refs / Context

Exact governing spec sections:

- `platform-spec.yaml#tool_model.http_tool_definition`
- `platform-spec.yaml#tool_model.provider_connector_tools`
- `platform-spec.yaml#tool_model.custom_tool_schema`
- `platform-spec.yaml#handler activity / platform.activity_requested`
- `platform-spec.yaml#activity_attempts`
- `platform-spec.yaml#provider trigger Telegram inbound / inbound.telegram`
- `platform-spec.yaml#credential_store`

Binding gate context: #1766 approved first-slice boundary for flow-local Telegram outbound connector proof through tools.yaml + handler activity + generated activity result events, static Telegram bot token, non-idempotent `activity_attempts`, and existing #1764 `inbound.telegram`.

## Semantic Migration / Owner Notes

New canonical owner for flow-local outbound connector validation/readback:

- `internal/providerconnectors` validates `category: provider_connector` tools and derives CAN/CANNOT/BOUND/UNBOUND local preflight surfaces.

Existing canonical owners preserved:

- Execution: authored HTTP activity executor.
- Request/result event path: `platform.activity_requested` generated by handler activity lowering.
- Non-idempotent write exactly-once guard: `activity_attempts`.
- Secrets: static credential store keys listed in tool `credentials`.
- Inbound chat-id source: existing `inbound.telegram` provider trigger manifest/runtime path.

Old paths now invalid/non-authoritative for this slice:

- No `policy.connectors` surface.
- No connector-pack body/envelope execution.
- No `ChatNotifier` or direct Telegram runtime adapter.
- No new outbound dispatch/journal/retry path.

Production paths checked for surviving old behavior:

- Validation consumes tools.yaml `ToolSchemaEntry` through `ValidateWorkflowContractSurface`.
- Doctor/local preflight reads the same semantic source and the same provider credential store.
- Runtime execution remains through `pipelineActivityDispatcher` and `activity_attempts` only.

Migration completeness: complete for #1766 first-slice Telegram outbound connector proof; broader outbound connector architecture remains under the parent stream.

## Tests

Run after rebasing onto `origin/master`:

```sh
SWARM_TEST_POSTGRES_DSN='host=127.0.0.1 port=5432 user=youmew dbname=postgres sslmode=disable' PGPASSWORD=postgres go test ./...
```

Supported-surface proof included:

- SQLite and Postgres Telegram connector runtime round-trip proof.
- Missing token fails before provider dispatch and before `activity_attempts` row.
- Duplicate/redelivered activity request replays journaled result and does not call fake Telegram twice.
- Doctor/preflight reports BOUND/UNBOUND connector surface without leaking token values.
