### PR TITLE
[agent-g][issue #1783] Enforce selected store role completeness

### DIFF
--- a/cmd/swarm/main.go
+++ b/cmd/swarm/main.go
@@ -2687,7 +2687,12 @@ func buildStores(ctx context.Context, selection storebackend.Selection, cfg *con
 		if _, err := pg.BindSchemaCapabilities(ctx); err != nil {
 			return storeBundle{}, err
 		}
-		return selectedPostgresStoreBundle(pg, cfg), nil
+		bundle := selectedPostgresStoreBundle(pg, cfg)
+		if err := validateSelectedStoreBundleRoles(selection.Backend, bundle); err != nil {
+			closeDB(pg.DB)
+			return storeBundle{}, err
+		}
+		return bundle, nil
 	case storebackend.BackendSQLite:
 		sqliteStore, err := store.NewSQLiteRuntimeStore(selection.SQLitePath)
 		if err != nil {
@@ -2735,6 +2740,10 @@ func buildStores(ctx context.Context, selection storebackend.Selection, cfg *con
 			RunStalledReader:            sqliteStore,
 		}
 		bundle.APIOptionalCapabilityBuilder = selectedSQLiteAPIOptionalCapabilityBuilder(sqliteStore)
+		if err := validateSelectedStoreBundleRoles(selection.Backend, bundle); err != nil {
+			_ = sqliteStore.Close()
+			return storeBundle{}, err
+		}
 		return bundle, nil
 	default:
 		return storeBundle{}, fmt.Errorf("store backend selection is required; supported backends: %s, %s", storebackend.BackendPostgres, storebackend.BackendSQLite)

--- a/cmd/swarm/store_facade_guard_test.go
+++ b/cmd/swarm/store_facade_guard_test.go
@@ -62,6 +62,11 @@ func selectedStoreFacadeProducerBackendReferences(path, body string) []string {
 			"closeDB(f.stores.SQLDB)",
 			"return f.stores.SQLDB",
 		},
+		filepath.Join("cmd", "swarm", "store_roles.go"): {
+			"var _ selectedConcreteRuntimeStore = (*store.PostgresStore)(nil)",
+			"Name: \"Postgres\"",
+			"Name: \"RuntimeSQLDB\"",
+		},
 	}
 	forbidden := []string{
 		"stores.Postgres",

--- a/cmd/swarm/store_roles.go
+++ b/cmd/swarm/store_roles.go
@@ -1,0 +1,203 @@
+package main
+
+import (
+	"fmt"
+	"reflect"
+	"sort"
+	"strings"
+
+	apiv1 "github.com/division-sh/swarm/internal/apiv1"
+	"github.com/division-sh/swarm/internal/runtime"
+	"github.com/division-sh/swarm/internal/runtime/budgetspend"
+	runtimebus "github.com/division-sh/swarm/internal/runtime/bus"
+	runtimeingress "github.com/division-sh/swarm/internal/runtime/ingress"
+	runtimellm "github.com/division-sh/swarm/internal/runtime/llm"
+	runtimemanager "github.com/division-sh/swarm/internal/runtime/manager"
+	runtimepipeline "github.com/division-sh/swarm/internal/runtime/pipeline"
+	runtimerunquiescence "github.com/division-sh/swarm/internal/runtime/runquiescence"
+	runtimestartupownership "github.com/division-sh/swarm/internal/runtime/startupownership"
+	runtimetools "github.com/division-sh/swarm/internal/runtime/tools"
+	"github.com/division-sh/swarm/internal/store"
+	storebackend "github.com/division-sh/swarm/internal/store/backendselection"
+)
+
+// selectedConcreteRuntimeStore is the compile-complete shared role set that the
+// selected Postgres and SQLite runtime stores must both implement. Selected
+// construction still wraps non-store roles such as pipeline and Postgres
+// sessions, but those wrappers are validated by selectedStoreBundleRoleLedger.
+type selectedConcreteRuntimeStore interface {
+	apiv1.Pinger
+	selectedSchemaCapabilityBinder
+
+	runtime.RuntimeLogPersistence
+	store.SchemaBootstrapper
+	runtimebus.EventStore
+	runtimellm.ConversationPersistence
+	runtimemanager.ManagerPersistence
+	runtimepipeline.SchedulePersistence
+	runtimepipeline.MailboxWriteMaterializationStore
+	runtimetools.MailboxPersistence
+	runtimetools.EntityPersistence
+	runtimetools.HumanTaskPersistence
+	budgetspend.Store
+	runtime.InboundPersistence
+	runtimeingress.Store
+	runtimellm.TurnPersistence
+	runtimestartupownership.Store
+
+	apiv1.MailboxAPIStore
+	apiv1.ObservabilityReadStore
+	apiv1.AgentUsageReadStore
+	apiv1.AgentDeliveryLifecycleReadStore
+	apiv1.APIIdempotencyStore
+	apiv1.RunReadStore
+	apiv1.EntityReadStore
+	apiv1.AgentConversationReadStore
+	apiv1.RunBundleContextStore
+	apiv1.BundleCatalogReadStore
+	apiv1.TestSetupStore
+
+	runtimerunquiescence.ServeAbandonStore
+	runStalledReadStore
+}
+
+var _ selectedConcreteRuntimeStore = (*store.PostgresStore)(nil)
+var _ selectedConcreteRuntimeStore = (*store.SQLiteRuntimeStore)(nil)
+
+type selectedStoreRoleBackends uint8
+
+const (
+	selectedStoreRolePostgres selectedStoreRoleBackends = 1 << iota
+	selectedStoreRoleSQLite
+	selectedStoreRoleBoth = selectedStoreRolePostgres | selectedStoreRoleSQLite
+)
+
+func (b selectedStoreRoleBackends) includes(backend storebackend.Backend) bool {
+	switch backend {
+	case storebackend.BackendPostgres:
+		return b&selectedStoreRolePostgres != 0
+	case storebackend.BackendSQLite:
+		return b&selectedStoreRoleSQLite != 0
+	default:
+		return false
+	}
+}
+
+type selectedStoreRoleClassification string
+
+const (
+	selectedStoreRoleConstructionOwner         selectedStoreRoleClassification = "construction_only_backend_owner"
+	selectedStoreRoleWorkspaceProcessDB        selectedStoreRoleClassification = "workspace_and_process_db_capability"
+	selectedStoreRoleRawRuntimeSQLException    selectedStoreRoleClassification = "raw_runtime_sql_exception"
+	selectedStoreRoleLegacyConstructionBlocker selectedStoreRoleClassification = "legacy_construction_blocker"
+	selectedStoreRoleCoreRuntime               selectedStoreRoleClassification = "core_runtime_store"
+	selectedStoreRolePublicAPIReadControl      selectedStoreRoleClassification = "public_api_read_and_control_capability"
+	selectedStoreRoleServeControl              selectedStoreRoleClassification = "serve_control_capability"
+	selectedStoreRoleOptionalClassifier        selectedStoreRoleClassification = "optional_capability_classifier"
+	selectedStoreRoleOptionalProductWiredBoth  selectedStoreRoleClassification = "optional_product_capability_wired_both"
+	selectedStoreRoleOptionalProductPostgres   selectedStoreRoleClassification = "optional_product_capability_postgres_only"
+)
+
+type selectedStoreBundleRoleEntry struct {
+	Name           string
+	Classification selectedStoreRoleClassification
+	RequiredOn     selectedStoreRoleBackends
+	ForbiddenOn    selectedStoreRoleBackends
+	Issue          int
+	SpecRef        string
+	Reason         string
+}
+
+func selectedStoreBundleRoleLedger() []selectedStoreBundleRoleEntry {
+	const selectedFacadeSpec = "platform-spec.yaml#runtime_storage.runtime_core_persistence_store_contracts.selected_contracts[name=selected_runtime_store_facade]"
+	const rawSQLSpec = "platform-spec.yaml#runtime_storage.runtime_core_persistence_store_contracts.selected_contracts[name=selected_runtime_store_facade].raw_sql_policy"
+	const backendSpec = "platform-spec.yaml#runtime_storage.runtime_store_backend_selection"
+	return []selectedStoreBundleRoleEntry{
+		{Name: "Postgres", Classification: selectedStoreRoleConstructionOwner, RequiredOn: selectedStoreRolePostgres, ForbiddenOn: selectedStoreRoleSQLite, SpecRef: selectedFacadeSpec, Reason: "concrete Postgres owner is construction-only and must not represent selected capability authority"},
+		{Name: "SQLDB", Classification: selectedStoreRoleWorkspaceProcessDB, RequiredOn: selectedStoreRoleBoth, SpecRef: rawSQLSpec, Reason: "raw process/workspace DB handle is allowed only for close/health/workspace lifecycle capability"},
+		{Name: "RuntimeSQLDB", Classification: selectedStoreRoleRawRuntimeSQLException, RequiredOn: selectedStoreRolePostgres, ForbiddenOn: selectedStoreRoleSQLite, Issue: 1783, SpecRef: rawSQLSpec, Reason: "raw runtime SQL remains a tracked Postgres-only exception and must stay omitted for SQLite"},
+		{Name: "Database", Classification: selectedStoreRolePublicAPIReadControl, RequiredOn: selectedStoreRoleBoth, SpecRef: selectedFacadeSpec, Reason: "health/readiness pinger is a selected public control capability"},
+		{Name: "RuntimeLogStore", Classification: selectedStoreRoleCoreRuntime, RequiredOn: selectedStoreRoleBoth, SpecRef: selectedFacadeSpec, Reason: "runtime diagnostics/log persistence is required for selected runtime construction"},
+		{Name: "RuntimeBlocker", Classification: selectedStoreRoleLegacyConstructionBlocker, ForbiddenOn: selectedStoreRoleBoth, Issue: 1087, SpecRef: backendSpec, Reason: "successful selected construction must not carry a residual fail-closed construction blocker"},
+		{Name: "SchemaBootstrapper", Classification: selectedStoreRoleCoreRuntime, RequiredOn: selectedStoreRoleBoth, SpecRef: selectedFacadeSpec, Reason: "schema/bootstrap capability is required before selected runtime persistence executes"},
+		{Name: "EventStore", Classification: selectedStoreRoleCoreRuntime, RequiredOn: selectedStoreRoleBoth, SpecRef: selectedFacadeSpec, Reason: "event append/read persistence is a required selected runtime capability"},
+		{Name: "PipelineStore", Classification: selectedStoreRoleCoreRuntime, RequiredOn: selectedStoreRoleBoth, SpecRef: selectedFacadeSpec, Reason: "workflow instance persistence wrapper is required for runtime construction"},
+		{Name: "SessionRegistry", Classification: selectedStoreRoleCoreRuntime, RequiredOn: selectedStoreRoleBoth, SpecRef: selectedFacadeSpec, Reason: "LLM session registry is required for runtime construction"},
+		{Name: "ConversationStore", Classification: selectedStoreRoleCoreRuntime, RequiredOn: selectedStoreRoleBoth, SpecRef: selectedFacadeSpec, Reason: "conversation persistence is required for runtime construction"},
+		{Name: "ManagerStore", Classification: selectedStoreRoleCoreRuntime, RequiredOn: selectedStoreRoleBoth, SpecRef: selectedFacadeSpec, Reason: "manager/agent/entity schema persistence is required for runtime construction"},
+		{Name: "ScheduleStore", Classification: selectedStoreRoleCoreRuntime, RequiredOn: selectedStoreRoleBoth, SpecRef: selectedFacadeSpec, Reason: "timer/schedule persistence is required for runtime construction"},
+		{Name: "MailboxMaterializer", Classification: selectedStoreRoleCoreRuntime, RequiredOn: selectedStoreRoleBoth, SpecRef: selectedFacadeSpec, Reason: "mailbox_write materialization is required for runtime construction"},
+		{Name: "MailboxStore", Classification: selectedStoreRoleCoreRuntime, RequiredOn: selectedStoreRoleBoth, SpecRef: selectedFacadeSpec, Reason: "tool mailbox persistence is required for runtime construction"},
+		{Name: "ToolEntityStore", Classification: selectedStoreRoleCoreRuntime, RequiredOn: selectedStoreRoleBoth, SpecRef: selectedFacadeSpec, Reason: "tool entity persistence is required for runtime construction"},
+		{Name: "HumanTaskStore", Classification: selectedStoreRoleCoreRuntime, RequiredOn: selectedStoreRoleBoth, SpecRef: selectedFacadeSpec, Reason: "human task persistence is required for runtime construction"},
+		{Name: "BudgetSpendStore", Classification: selectedStoreRoleCoreRuntime, RequiredOn: selectedStoreRoleBoth, SpecRef: selectedFacadeSpec, Reason: "budget/spend persistence is required for runtime construction"},
+		{Name: "InboundStore", Classification: selectedStoreRoleCoreRuntime, RequiredOn: selectedStoreRoleBoth, SpecRef: selectedFacadeSpec, Reason: "inbound webhook persistence is required for runtime construction"},
+		{Name: "MailboxAPIStore", Classification: selectedStoreRolePublicAPIReadControl, RequiredOn: selectedStoreRoleBoth, SpecRef: selectedFacadeSpec, Reason: "mailbox API owner is a selected public control capability"},
+		{Name: "ObservabilityStore", Classification: selectedStoreRolePublicAPIReadControl, RequiredOn: selectedStoreRoleBoth, SpecRef: selectedFacadeSpec, Reason: "observability/event/log/trace reads are selected public read capabilities"},
+		{Name: "AgentUsageStore", Classification: selectedStoreRolePublicAPIReadControl, RequiredOn: selectedStoreRoleBoth, SpecRef: selectedFacadeSpec, Reason: "agent.usage reads are selected public read capabilities"},
+		{Name: "AgentDeliveryLifecycleStore", Classification: selectedStoreRolePublicAPIReadControl, RequiredOn: selectedStoreRoleBoth, SpecRef: selectedFacadeSpec, Reason: "agent delivery lifecycle reads are selected public read capabilities"},
+		{Name: "RuntimeIngressStore", Classification: selectedStoreRoleCoreRuntime, RequiredOn: selectedStoreRoleBoth, SpecRef: selectedFacadeSpec, Reason: "runtime ingress persistence/control is required for runtime construction"},
+		{Name: "IdempotencyStore", Classification: selectedStoreRolePublicAPIReadControl, RequiredOn: selectedStoreRoleBoth, SpecRef: selectedFacadeSpec, Reason: "API idempotency is a selected public control capability"},
+		{Name: "TurnStore", Classification: selectedStoreRoleCoreRuntime, RequiredOn: selectedStoreRoleBoth, SpecRef: selectedFacadeSpec, Reason: "turn persistence is required for runtime construction"},
+		{Name: "StartupOwnership", Classification: selectedStoreRoleCoreRuntime, RequiredOn: selectedStoreRoleBoth, SpecRef: selectedFacadeSpec, Reason: "startup ownership persistence is required for runtime construction"},
+		{Name: "RunQuiescenceStore", Classification: selectedStoreRoleServeControl, RequiredOn: selectedStoreRoleBoth, SpecRef: selectedFacadeSpec, Reason: "serve abandon-active-runs quiescence is a selected control capability"},
+		{Name: "RunReadStore", Classification: selectedStoreRolePublicAPIReadControl, RequiredOn: selectedStoreRoleBoth, SpecRef: selectedFacadeSpec, Reason: "run.get/list/diagnose reads are selected public read capabilities"},
+		{Name: "EntityReadStore", Classification: selectedStoreRolePublicAPIReadControl, RequiredOn: selectedStoreRoleBoth, SpecRef: selectedFacadeSpec, Reason: "entity.get/list/aggregate reads are selected public read capabilities"},
+		{Name: "AgentConversationReadStore", Classification: selectedStoreRolePublicAPIReadControl, RequiredOn: selectedStoreRoleBoth, Issue: 1782, SpecRef: selectedFacadeSpec, Reason: "agent/conversation reads were promoted as pure operator-read capabilities"},
+		{Name: "RunBundleContextStore", Classification: selectedStoreRolePublicAPIReadControl, RequiredOn: selectedStoreRoleBoth, SpecRef: selectedFacadeSpec, Reason: "served event.publish run-bundle context reads are selected public read capabilities"},
+		{Name: "BundleRuntimeCatalogStore", Classification: selectedStoreRoleOptionalProductPostgres, RequiredOn: selectedStoreRolePostgres, ForbiddenOn: selectedStoreRoleSQLite, Issue: 1239, SpecRef: selectedFacadeSpec, Reason: "DB-loaded bundle runtime catalog remains Postgres-only until separately promoted"},
+		{Name: "BundleSourceCatalogStore", Classification: selectedStoreRoleOptionalProductPostgres, RequiredOn: selectedStoreRolePostgres, ForbiddenOn: selectedStoreRoleSQLite, Issue: 1386, SpecRef: selectedFacadeSpec, Reason: "bundle source catalog writes/register/delete are optional product lifecycle capabilities"},
+		{Name: "RunBundleAvailabilityStore", Classification: selectedStoreRoleOptionalProductPostgres, RequiredOn: selectedStoreRolePostgres, ForbiddenOn: selectedStoreRoleSQLite, Issue: 1239, SpecRef: selectedFacadeSpec, Reason: "active bundle availability admission is a Postgres-backed optional product capability"},
+		{Name: "StartupRecoveryStore", Classification: selectedStoreRoleOptionalProductPostgres, RequiredOn: selectedStoreRolePostgres, ForbiddenOn: selectedStoreRoleSQLite, Issue: 1239, SpecRef: selectedFacadeSpec, Reason: "startup recovery remains split from local-dev SQLite runtime construction"},
+		{Name: "RunStalledReader", Classification: selectedStoreRoleOptionalProductWiredBoth, RequiredOn: selectedStoreRoleBoth, SpecRef: selectedFacadeSpec, Reason: "run-stalled monitor reads are wired on both selected stores and must not silently disappear"},
+		{Name: "APIOptionalCapabilityBuilder", Classification: selectedStoreRoleOptionalClassifier, RequiredOn: selectedStoreRoleBoth, Issue: 1810, SpecRef: selectedFacadeSpec, Reason: "optional public capabilities are produced through the explicit selected classifier"},
+		{Name: "RunForkRuntimeOwner", Classification: selectedStoreRoleOptionalProductPostgres, RequiredOn: selectedStoreRolePostgres, ForbiddenOn: selectedStoreRoleSQLite, Issue: 1386, SpecRef: selectedFacadeSpec, Reason: "selected-contract run.fork runtime lifecycle remains Postgres-only until separately promoted"},
+	}
+}
+
+func validateSelectedStoreBundleRoles(backend storebackend.Backend, stores storeBundle) error {
+	if backend != storebackend.BackendPostgres && backend != storebackend.BackendSQLite {
+		return fmt.Errorf("selected store role validation requires postgres or sqlite backend, got %q", backend)
+	}
+	value := reflect.ValueOf(stores)
+	var missing []string
+	var forbidden []string
+	for _, entry := range selectedStoreBundleRoleLedger() {
+		field := value.FieldByName(entry.Name)
+		if !field.IsValid() {
+			return fmt.Errorf("selected store role ledger names unknown storeBundle field %q", entry.Name)
+		}
+		configured := selectedStoreBundleRoleConfigured(field)
+		if entry.RequiredOn.includes(backend) && !configured {
+			missing = append(missing, entry.Name)
+		}
+		if entry.ForbiddenOn.includes(backend) && configured {
+			forbidden = append(forbidden, entry.Name)
+		}
+	}
+	if len(missing) == 0 && len(forbidden) == 0 {
+		return nil
+	}
+	sort.Strings(missing)
+	sort.Strings(forbidden)
+	parts := make([]string, 0, 2)
+	if len(missing) > 0 {
+		parts = append(parts, "missing required roles: "+strings.Join(missing, ", "))
+	}
+	if len(forbidden) > 0 {
+		parts = append(parts, "forbidden roles configured: "+strings.Join(forbidden, ", "))
+	}
+	return fmt.Errorf("selected %s store bundle failed role validation: %s", backend, strings.Join(parts, "; "))
+}
+
+func selectedStoreBundleRoleConfigured(value reflect.Value) bool {
+	if !value.IsValid() {
+		return false
+	}
+	switch value.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Pointer, reflect.Slice:
+		return !value.IsNil()
+	default:
+		return !value.IsZero()
+	}
+}

--- a/cmd/swarm/store_roles_test.go
+++ b/cmd/swarm/store_roles_test.go
@@ -1,0 +1,124 @@
+package main
+
+import (
+	"context"
+	"database/sql"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/division-sh/swarm/internal/config"
+	"github.com/division-sh/swarm/internal/store"
+	storebackend "github.com/division-sh/swarm/internal/store/backendselection"
+)
+
+func TestSelectedStoreBundleRoleLedgerCoversStoreBundleFields(t *testing.T) {
+	typ := reflect.TypeOf(storeBundle{})
+	fields := make(map[string]struct{}, typ.NumField())
+	for i := 0; i < typ.NumField(); i++ {
+		fields[typ.Field(i).Name] = struct{}{}
+	}
+
+	seen := map[string]struct{}{}
+	for _, entry := range selectedStoreBundleRoleLedger() {
+		if strings.TrimSpace(entry.Name) == "" {
+			t.Fatal("selected store role ledger contains empty field name")
+		}
+		if _, ok := fields[entry.Name]; !ok {
+			t.Fatalf("selected store role ledger names unknown storeBundle field %s", entry.Name)
+		}
+		if _, ok := seen[entry.Name]; ok {
+			t.Fatalf("selected store role ledger classifies %s more than once", entry.Name)
+		}
+		seen[entry.Name] = struct{}{}
+		if entry.Classification == "" {
+			t.Fatalf("selected store role ledger field %s missing classification", entry.Name)
+		}
+		if strings.TrimSpace(entry.Reason) == "" {
+			t.Fatalf("selected store role ledger field %s missing reason", entry.Name)
+		}
+		if strings.TrimSpace(entry.SpecRef) == "" && entry.Issue == 0 {
+			t.Fatalf("selected store role ledger field %s missing live spec or issue ref", entry.Name)
+		}
+		if entry.RequiredOn == 0 && entry.ForbiddenOn == 0 {
+			t.Fatalf("selected store role ledger field %s must declare required or forbidden backend coverage", entry.Name)
+		}
+	}
+
+	var missing []string
+	for name := range fields {
+		if _, ok := seen[name]; !ok {
+			missing = append(missing, name)
+		}
+	}
+	sort.Strings(missing)
+	if len(missing) > 0 {
+		t.Fatalf("selected store role ledger missing storeBundle fields: %s", strings.Join(missing, ", "))
+	}
+}
+
+func TestValidateSelectedStoreBundleRolesAcceptsSQLiteBuildStores(t *testing.T) {
+	stores := buildSQLiteSelectedStoreBundleForRoleTest(t)
+	if err := validateSelectedStoreBundleRoles(storebackend.BackendSQLite, stores); err != nil {
+		t.Fatalf("validate selected sqlite store roles: %v", err)
+	}
+	if stores.RuntimeSQLDB != nil {
+		t.Fatalf("sqlite RuntimeSQLDB = %#v, want nil raw runtime SQL handle", stores.RuntimeSQLDB)
+	}
+}
+
+func TestValidateSelectedStoreBundleRolesAcceptsPostgresSelectedBundle(t *testing.T) {
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("open inert sql handle for selected postgres role projection: %v", err)
+	}
+	t.Cleanup(func() { closeDB(db) })
+
+	stores := selectedPostgresStoreBundle(&store.PostgresStore{DB: db}, &config.Config{})
+	if err := validateSelectedStoreBundleRoles(storebackend.BackendPostgres, stores); err != nil {
+		t.Fatalf("validate selected postgres store roles: %v", err)
+	}
+}
+
+func TestValidateSelectedStoreBundleRolesFailsClosedForMissingRequiredCoreRole(t *testing.T) {
+	stores := buildSQLiteSelectedStoreBundleForRoleTest(t)
+	stores.RuntimeLogStore = nil
+
+	err := validateSelectedStoreBundleRoles(storebackend.BackendSQLite, stores)
+	if err == nil {
+		t.Fatal("expected selected role validation to fail for missing RuntimeLogStore")
+	}
+	if !strings.Contains(err.Error(), "RuntimeLogStore") {
+		t.Fatalf("selected role validation error = %v, want RuntimeLogStore named", err)
+	}
+}
+
+func TestValidateSelectedStoreBundleRolesFailsClosedForSQLiteRawRuntimeSQL(t *testing.T) {
+	stores := buildSQLiteSelectedStoreBundleForRoleTest(t)
+	stores.RuntimeSQLDB = stores.SQLDB
+
+	err := validateSelectedStoreBundleRoles(storebackend.BackendSQLite, stores)
+	if err == nil {
+		t.Fatal("expected selected role validation to reject SQLite raw runtime SQL handle")
+	}
+	if !strings.Contains(err.Error(), "RuntimeSQLDB") {
+		t.Fatalf("selected role validation error = %v, want RuntimeSQLDB named", err)
+	}
+}
+
+func buildSQLiteSelectedStoreBundleForRoleTest(t *testing.T) storeBundle {
+	t.Helper()
+	stores, err := buildStores(context.Background(), storebackend.Selection{
+		Backend:          storebackend.BackendSQLite,
+		BackendSource:    storebackend.SourceFlag,
+		SQLitePath:       filepath.Join(t.TempDir(), "dev.db"),
+		SQLitePathSource: storebackend.SourceRolloutDefault,
+	}, &config.Config{})
+	if err != nil {
+		t.Fatalf("buildStores(sqlite): %v", err)
+	}
+	t.Cleanup(func() { closeDB(stores.SQLDB) })
+	return stores
+}


### PR DESCRIPTION
## Summary

Part of #1783.

This PR closes the approved first slice: compile-complete selected core role interfaces plus explicit optional capability classification for selected store construction.

It adds:
- `selectedConcreteRuntimeStore` compile-time assertions for `*store.PostgresStore` and `*store.SQLiteRuntimeStore`.
- A `selectedStoreBundleRoleLedger` that classifies every `storeBundle` field as core runtime, public API/control, optional product, raw SQL exception, workspace/process DB, or construction-only.
- `validateSelectedStoreBundleRoles` in `buildStores` so successful Postgres/SQLite construction fails closed if a required selected role is missing or if SQLite receives a forbidden raw runtime SQL handle.
- Tests proving role-ledger coverage, SQLite/Postgres construction role completeness, missing-core fail-closed behavior, SQLite raw runtime SQL rejection, and continued producer-side backend-branching guard coverage.

## Governing Refs

Exact governing spec refs:
- `platform-spec.yaml#runtime_storage.runtime_store_backend_selection`
- `platform-spec.yaml#runtime_storage.runtime_core_persistence_store_contracts`
- `platform-spec.yaml#runtime_storage.runtime_core_persistence_store_contracts.selected_contracts[name=selected_runtime_store_facade]`
- `platform-spec.yaml#runtime_storage.runtime_core_persistence_store_contracts.selected_contracts[name=selected_runtime_store_facade].raw_sql_policy`
- `platform-spec.yaml#runtime_storage.runtime_core_persistence_store_contracts.selected_contracts[name=backend_neutral_runtime_mutation_write_boundary]`

This implements the existing selected-runtime facade contract; it does not change platform semantics, so no `platform-spec.yaml` edit is required.

## Semantic Migration

New canonical owner for this slice:
- `cmd/swarm/store_roles.go:selectedConcreteRuntimeStore`
- `cmd/swarm/store_roles.go:selectedStoreBundleRoleLedger`
- `cmd/swarm/store_roles.go:validateSelectedStoreBundleRoles`

Old non-authoritative path now invalid:
- successful selected construction can no longer silently return a missing required core/public selected role as a nil `storeBundle` field;
- SQLite selected construction cannot accidentally pass `RuntimeSQLDB` as a raw runtime SQL fallback;
- optional/backend-specific capabilities are classified in the selected role ledger instead of being indistinguishable from accidental omissions.

Production paths checked for surviving old behavior:
- `buildStores` Postgres branch validates selected roles before returning;
- `buildStores` SQLite branch validates selected roles before returning;
- `selectedRuntimeStoreFacade.runtimeStores` remains the runtime projection owner;
- `selectedRuntimeStoreFacade.apiCapabilities` remains the API projection owner;
- #1810 operator-read construction ledger remains green and continues splitting `ConversationForks`.

Migration status: complete for the approved first-slice class. Full #1783 parent tails remain open: raw SQL/TX producer migration, transaction/unit-of-work migration, ConversationFork read/lifecycle segregation, and optional product parity.

## Proof

Commands run:
- `go test ./cmd/swarm -run 'TestSelectedStoreBundleRoleLedgerCoversStoreBundleFields|TestValidateSelectedStoreBundleRoles|TestSelectedStoreFacadeOwnsProducerBackendBranching|TestSelectedStoreFacadeBackendBranchingGuardRejectsProducerFixture|TestSelectedOperatorReadConstructionParityClassifiesSQLitePostgresDelta' -count=1`
- `go test ./cmd/swarm -run 'TestSelectedStoreBundleRoleLedgerCoversStoreBundleFields|TestValidateSelectedStoreBundleRoles' -count=1`
- `SWARM_TEST_POSTGRES_DSN='host=127.0.0.1 port=5432 user=postgres password=postgres dbname=postgres sslmode=disable' go test ./cmd/swarm -count=1`
- `SWARM_TEST_POSTGRES_DSN='host=127.0.0.1 port=5432 user=postgres password=postgres dbname=postgres sslmode=disable' go test ./internal/store -count=1`
- `SWARM_TEST_POSTGRES_DSN='host=127.0.0.1 port=5432 user=postgres password=postgres dbname=postgres sslmode=disable' go test ./internal/apiv1 -count=1`
- `SWARM_TEST_POSTGRES_DSN='host=127.0.0.1 port=5432 user=postgres password=postgres dbname=postgres sslmode=disable' go test ./...`

Note: `go test ./cmd/swarm -count=1` without `SWARM_TEST_POSTGRES_DSN` was blocked by the repo test helper trying Docker on this machine. Rerun with the host local Postgres DSN passed.
