### PR TITLE
[agent-a][issue #1835] Add create instance resolution slice

### DIFF
--- a/internal/runtime/bootverify/workflow_composition_connect_checks.go
+++ b/internal/runtime/bootverify/workflow_composition_connect_checks.go
@@ -15,6 +15,7 @@ func checkCompositionConnectValidation(c *checkerContext) []Finding {
 		return nil
 	}
 	var findings []Finding
+	findings = append(findings, validateInputPinResolutions(c.source)...)
 	for _, connect := range c.source.CompositionConnects() {
 		findings = append(findings, validateCompositionConnect(c.source, connect)...)
 	}
@@ -200,6 +201,18 @@ func compositionReceiverAddressRequired(schema runtimecontracts.FlowSchemaDocume
 
 func validateCompositionConnectInstanceKey(source semanticview.Source, connect runtimecontracts.FlowPackageConnect, outputPin runtimecontracts.FlowOutputEventPin, inputPin runtimecontracts.FlowInputEventPin, producerFlowID, receiverFlowID string) []Finding {
 	adapter := connect.Using.Instance
+	if !inputPin.Resolution.Empty() {
+		if inputPin.Resolution.Mode == runtimecontracts.FlowInputResolutionModeCreate && strings.TrimSpace(connect.Delivery) != "" && strings.TrimSpace(connect.Delivery) != "one" {
+			return []Finding{compositionConnectFinding(connect, "instance_resolution_invalid", "resolution mode create requires delivery one", receiverFlowID)}
+		}
+		if adapter.Declared {
+			return []Finding{compositionConnectFinding(connect, "instance_resolution_invalid", "connect.using.instance is incompatible with input pin resolution", receiverFlowID)}
+		}
+		if len(connect.Map) > 0 {
+			return []Finding{compositionConnectFinding(connect, "instance_resolution_invalid", "connect.map is incompatible with input pin resolution", receiverFlowID)}
+		}
+		return nil
+	}
 	if inputPin.Address != nil {
 		if adapter.Declared {
 			return []Finding{compositionConnectFinding(connect, "connect_key_adapter_invalid", "connect.using.instance is valid only for addressless template receiver instance-key routes", receiverFlowID)}
@@ -264,6 +277,111 @@ func validateCompositionConnectInstanceKey(source semanticview.Source, connect r
 		}
 	}
 	return nil
+}
+
+func validateInputPinResolutions(source semanticview.Source) []Finding {
+	if source == nil {
+		return nil
+	}
+	var findings []Finding
+	for flowID := range source.FlowSchemaEntries() {
+		flowID = strings.TrimSpace(flowID)
+		if flowID == "" {
+			continue
+		}
+		for _, pin := range source.FlowInputEventPins(flowID) {
+			if pin.Resolution.Empty() {
+				continue
+			}
+			findings = append(findings, validateInputPinResolution(source, flowID, pin)...)
+		}
+	}
+	return findings
+}
+
+func validateInputPinResolution(source semanticview.Source, flowID string, pin runtimecontracts.FlowInputEventPin) []Finding {
+	var findings []Finding
+	resolution := pin.Resolution
+	location := flowID
+	if pin.Address != nil {
+		return []Finding{inputPinResolutionFinding(flowID, pin, "instance_resolution_invalid", "input pin resolution is incompatible with legacy address", location)}
+	}
+	switch resolution.Mode {
+	case runtimecontracts.FlowInputResolutionModeCreate:
+		return validateCreateInputPinResolution(source, flowID, pin)
+	case runtimecontracts.FlowInputResolutionModeSelect,
+		runtimecontracts.FlowInputResolutionModeSelectOrCreate,
+		runtimecontracts.FlowInputResolutionModeFanIn,
+		runtimecontracts.FlowInputResolutionModeFanOut,
+		runtimecontracts.FlowInputResolutionModeReply:
+		findings = append(findings, inputPinResolutionFinding(flowID, pin, "instance_resolution_unimplemented", fmt.Sprintf("resolution mode %q is design-locked but not runnable in this slice", resolution.Mode), location))
+	case "":
+		findings = append(findings, inputPinResolutionFinding(flowID, pin, "instance_resolution_invalid", "resolution.mode is required", location))
+	default:
+		findings = append(findings, inputPinResolutionFinding(flowID, pin, "instance_resolution_invalid", fmt.Sprintf("resolution mode %q is not supported", resolution.Mode), location))
+	}
+	return findings
+}
+
+func validateCreateInputPinResolution(source semanticview.Source, flowID string, pin runtimecontracts.FlowInputEventPin) []Finding {
+	var findings []Finding
+	resolution := pin.Resolution
+	location := flowID
+	if resolution.Aggregation != "" || resolution.Window != "" || len(resolution.DedupBy) > 0 || resolution.Singleton != "" || resolution.RepliesTo != "" || resolution.CorrelationKey != "" {
+		findings = append(findings, inputPinResolutionFinding(flowID, pin, "instance_resolution_invalid", "resolution mode create may only declare instance_key and carries", location))
+	}
+	bundle, ok := semanticview.Bundle(source)
+	if !ok || bundle == nil {
+		return append(findings, inputPinResolutionFinding(flowID, pin, "receiver_instance_key_unavailable", "receiver instance key owner is unavailable for input pin resolution", location))
+	}
+	instance, err := bundle.ResolveFlowTemplateInstance(flowID)
+	if err != nil {
+		return append(findings, inputPinResolutionFinding(flowID, pin, "receiver_instance_key_invalid", err.Error(), location))
+	}
+	mint := strings.TrimSpace(resolution.InstanceKey.Mint)
+	switch mint {
+	case runtimecontracts.FlowInputResolutionMintUUID, runtimecontracts.FlowInputResolutionMintEventID:
+	default:
+		findings = append(findings, inputPinResolutionFinding(flowID, pin, "instance_resolution_invalid", fmt.Sprintf("resolution mode create mint %q must be uuid or event_id", mint), location))
+	}
+	as := strings.TrimSpace(resolution.InstanceKey.As)
+	if as == "" {
+		findings = append(findings, inputPinResolutionFinding(flowID, pin, "instance_resolution_invalid", "resolution mode create requires instance_key.as", location))
+		return findings
+	}
+	if len(instance.By) != 1 || strings.TrimSpace(instance.By[0]) != as {
+		findings = append(findings, inputPinResolutionFinding(flowID, pin, "instance_resolution_invalid", fmt.Sprintf("resolution mode create instance_key.as %q must match the receiver's single instance.by field %v", as, instance.By), location))
+	}
+	carry, ok := pin.Carries[as]
+	if !ok {
+		findings = append(findings, inputPinResolutionFinding(flowID, pin, "instance_resolution_invalid", fmt.Sprintf("resolution mode create must carry %s from instance.key.%s", as, as), location))
+		return findings
+	}
+	wantFrom := "instance.key." + as
+	if strings.TrimSpace(carry.From) != wantFrom {
+		findings = append(findings, inputPinResolutionFinding(flowID, pin, "instance_resolution_invalid", fmt.Sprintf("carry %s must use from: %s", as, wantFrom), location))
+	}
+	if carry.Type != "" {
+		targetType, err := compositionConnectTargetType(source, flowID, "entity."+as)
+		if err != nil {
+			findings = append(findings, inputPinResolutionFinding(flowID, pin, "receiver_instance_key_invalid", err.Error(), location))
+		} else if !compositionConnectTypesCompatible(carry.Type, targetType) {
+			findings = append(findings, inputPinResolutionFinding(flowID, pin, "key_types_incompatible", fmt.Sprintf("carry %s type %s is incompatible with receiver entity.%s type %s", as, carry.Type, as, targetType), location))
+		}
+	}
+	return findings
+}
+
+func inputPinResolutionFinding(flowID string, pin runtimecontracts.FlowInputEventPin, reason, detail, location string) Finding {
+	if strings.TrimSpace(location) == "" {
+		location = flowID
+	}
+	return Finding{
+		CheckID:  "composition_connect_validation",
+		Severity: "error",
+		Message:  fmt.Sprintf("input pin %s.%s resolution is invalid: %s: %s", strings.TrimSpace(flowID), strings.TrimSpace(pin.PinName()), reason, detail),
+		Location: location,
+	}
 }
 
 func validateCompositionConnectInstanceKeyAdapter(source semanticview.Source, connect runtimecontracts.FlowPackageConnect, adapter runtimecontracts.FlowPackageConnectInstanceAdapter, carries, receiverFields []string, outputPin runtimecontracts.FlowOutputEventPin, producerFlowID, receiverFlowID string) []Finding {

--- a/internal/runtime/bootverify/workflow_composition_connect_checks_test.go
+++ b/internal/runtime/bootverify/workflow_composition_connect_checks_test.go
@@ -61,6 +61,84 @@ func TestRun_AllowsTemplateInstanceKeyCompositionConnectWithoutAddress(t *testin
 	}
 }
 
+func TestRun_AllowsCreateInputResolutionCompositionConnect(t *testing.T) {
+	root := writeCreateResolutionCompositionConnectFixture(t, createResolutionCompositionFixtureOptions{
+		mode:         runtimecontracts.FlowInputResolutionModeCreate,
+		mint:         runtimecontracts.FlowInputResolutionMintUUID,
+		includeCarry: true,
+	})
+	bundle := loadFixtureBundleAt(t, repoRootForBootverifyTest(t), root, runtimecontracts.DefaultPlatformSpecFile(repoRootForBootverifyTest(t)))
+
+	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+
+	if reportContains(report.Errors(), "composition_connect_validation", "") {
+		t.Fatalf("unexpected composition_connect_validation error: %#v", report.Errors())
+	}
+	if reportContains(report.Errors(), "template_instance_validation", "") {
+		t.Fatalf("unexpected template_instance_validation error: %#v", report.Errors())
+	}
+	if reportContains(report.Errors(), "input_pin_wiring", "validation.requested") {
+		t.Fatalf("parent connect should satisfy create-resolution input pin wiring proof, got %#v", report.Errors())
+	}
+}
+
+func TestRun_FailsClosedForInvalidCreateInputResolution(t *testing.T) {
+	tests := []struct {
+		name string
+		opts createResolutionCompositionFixtureOptions
+		want string
+	}{
+		{
+			name: "non-create modes are design-locked but not runnable",
+			opts: createResolutionCompositionFixtureOptions{
+				mode:         runtimecontracts.FlowInputResolutionModeSelect,
+				mint:         runtimecontracts.FlowInputResolutionMintUUID,
+				includeCarry: true,
+			},
+			want: "instance_resolution_unimplemented",
+		},
+		{
+			name: "invalid mint",
+			opts: createResolutionCompositionFixtureOptions{
+				mode:         runtimecontracts.FlowInputResolutionModeCreate,
+				mint:         "random",
+				includeCarry: true,
+			},
+			want: "mint \"random\" must be uuid or event_id",
+		},
+		{
+			name: "missing carried instance key",
+			opts: createResolutionCompositionFixtureOptions{
+				mode: runtimecontracts.FlowInputResolutionModeCreate,
+				mint: runtimecontracts.FlowInputResolutionMintUUID,
+			},
+			want: "must carry validation_case_id from instance.key.validation_case_id",
+		},
+		{
+			name: "legacy connect using instance is incompatible",
+			opts: createResolutionCompositionFixtureOptions{
+				mode:          runtimecontracts.FlowInputResolutionModeCreate,
+				mint:          runtimecontracts.FlowInputResolutionMintUUID,
+				includeCarry:  true,
+				usingInstance: true,
+			},
+			want: "connect.using.instance is incompatible with input pin resolution",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			root := writeCreateResolutionCompositionConnectFixture(t, tc.opts)
+			bundle := loadFixtureBundleAt(t, repoRootForBootverifyTest(t), root, runtimecontracts.DefaultPlatformSpecFile(repoRootForBootverifyTest(t)))
+
+			report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+
+			if !reportContains(report.Errors(), "composition_connect_validation", tc.want) {
+				t.Fatalf("expected composition_connect_validation %q, got %#v", tc.want, report.Errors())
+			}
+		})
+	}
+}
+
 func TestRun_AllowsCompositeTemplateInstanceKeyCompositionConnectWithoutAddress(t *testing.T) {
 	root := writeCompositionConnectBootverifyFixture(t, compositionConnectFixtureOptions{
 		consumerMode:                   "template",
@@ -1001,6 +1079,124 @@ deployment:
     _unused_reason: composition connect topology proof field
 `)
 	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "consumer", "nodes.yaml"), "{}\n")
+}
+
+type createResolutionCompositionFixtureOptions struct {
+	mode          string
+	mint          string
+	includeCarry  bool
+	usingInstance bool
+}
+
+func writeCreateResolutionCompositionConnectFixture(t *testing.T, opts createResolutionCompositionFixtureOptions) string {
+	t.Helper()
+	root := t.TempDir()
+	usingBlock := ""
+	if opts.usingInstance {
+		usingBlock = `
+    using:
+      instance:
+        source: validation_case_id
+        target: validation_case_id`
+	}
+	writeBootverifyFixtureFile(t, filepath.Join(root, "package.yaml"), `
+name: create-resolution-composition-connect
+version: "1.0.0"
+platform_version: ">=0.7.0 <0.8.0"
+flows:
+  - id: producer
+    flow: producer
+    mode: static
+  - id: validator
+    flow: validator
+    mode: template
+connect:
+  - from: producer.validation_requested
+    to: validator.validation_requested
+    delivery: one`+usingBlock+`
+`)
+	writeBootverifyFixtureFile(t, filepath.Join(root, "schema.yaml"), "name: create-resolution-composition-connect\n")
+	writeBootverifyFixtureFile(t, filepath.Join(root, "policy.yaml"), "{}\n")
+	writeBootverifyFixtureFile(t, filepath.Join(root, "tools.yaml"), "{}\n")
+	writeBootverifyFixtureFile(t, filepath.Join(root, "agents.yaml"), "{}\n")
+	writeBootverifyFixtureFile(t, filepath.Join(root, "events.yaml"), "{}\n")
+	writeBootverifyFixtureFile(t, filepath.Join(root, "nodes.yaml"), "{}\n")
+	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "producer", "schema.yaml"), `
+name: producer
+mode: static
+pins:
+  outputs:
+    events:
+      - name: validation_requested
+        event: validation.requested
+`)
+	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "producer", "policy.yaml"), "{}\n")
+	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "producer", "agents.yaml"), "{}\n")
+	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "producer", "entities.yaml"), "{}\n")
+	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "producer", "events.yaml"), `
+validation.triggered:
+  candidate: string
+validation.requested:
+  candidate: string
+`)
+	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "producer", "nodes.yaml"), `
+producer-node:
+  id: producer-node
+  execution_type: system_node
+  subscribes_to: [validation.triggered]
+  event_handlers:
+    validation.triggered:
+      emit:
+        event: validation.requested
+        fields:
+          candidate: payload.candidate
+`)
+	carriesBlock := ""
+	if opts.includeCarry {
+		carriesBlock = `
+        carries:
+          validation_case_id:
+            from: instance.key.validation_case_id
+            type: uuid`
+	}
+	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "validator", "schema.yaml"), `
+name: validator
+mode: template
+instance:
+  by: validation_case_id
+  on_missing: reject
+  on_conflict: reject
+pins:
+  inputs:
+    events:
+      - name: validation_requested
+        event: validation.requested
+        resolution:
+          mode: `+opts.mode+`
+          instance_key:
+            mint: `+opts.mint+`
+            as: validation_case_id`+carriesBlock+`
+`)
+	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "validator", "policy.yaml"), "{}\n")
+	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "validator", "agents.yaml"), "{}\n")
+	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "validator", "events.yaml"), `
+validation.requested:
+  candidate: string
+  validation_case_id: uuid
+`)
+	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "validator", "entities.yaml"), `
+validation_case:
+  validation_case_id:
+    type: uuid
+`)
+	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "validator", "nodes.yaml"), `
+validator-node:
+  id: validator-node-{validation_case_id}
+  execution_type: system_node
+  event_handlers:
+    validation.requested: {}
+`)
+	return root
 }
 
 func writeCompositionConnectProducerFlow(t *testing.T, root string, opts compositionConnectFixtureOptions) {

--- a/internal/runtime/bus/connect_route_plan_dispatch_test.go
+++ b/internal/runtime/bus/connect_route_plan_dispatch_test.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -116,20 +118,49 @@ func (s *connectRoutePlanLifecycleStore) Activate(ctx context.Context, req runti
 		}
 	}
 	s.activations = append(s.activations, req)
-	verticalID, _ := req.Metadata["vertical_id"].(string)
 	s.flowInstances = append(s.flowInstances, ActiveFlowInstanceDescriptor{
 		InstanceID:    req.Instance.InstanceID,
 		EntityID:      req.Instance.EntityID,
 		FlowInstance:  req.Instance.InstancePath,
 		FlowTemplate:  req.Instance.TemplateID,
-		AddressFields: map[string]string{"entity.vertical_id": verticalID},
+		AddressFields: connectRoutePlanActivationAddressFields(req.Metadata),
 	})
 	if s.bus == nil {
 		return nil
 	}
 	return s.bus.AddFlowInstanceRouteContext(ctx, FlowInstanceRouteMaterializationRequest{
-		Identity: req.Instance.Route(),
+		Identity:            req.Instance.Route(),
+		ActivationVariables: connectRoutePlanActivationVariables(req),
 	})
+}
+
+func connectRoutePlanActivationAddressFields(metadata map[string]any) map[string]string {
+	out := map[string]string{}
+	for key, raw := range metadata {
+		key = strings.TrimSpace(key)
+		if key == "" || key == "entity_type" || key == "instance_kind" || key == "last_source_event" {
+			continue
+		}
+		value := strings.TrimSpace(fmt.Sprint(raw))
+		if value != "" {
+			out["entity."+key] = value
+		}
+	}
+	return out
+}
+
+func connectRoutePlanActivationVariables(req runtimepipeline.FlowInstanceActivationRequest) map[string]string {
+	out := map[string]string{}
+	for _, values := range []map[string]any{req.Config, req.Metadata} {
+		for key, raw := range values {
+			key = strings.TrimSpace(key)
+			value := strings.TrimSpace(fmt.Sprint(raw))
+			if key != "" && value != "" {
+				out[key] = value
+			}
+		}
+	}
+	return out
 }
 
 func (s *targetRouteMemoryStore) UpsertCommittedReplayScope(_ context.Context, eventID string, scope runtimereplayclaim.CommittedReplayScope) error {
@@ -853,6 +884,130 @@ func TestEventBusPublish_ConnectRoutePlanCreatesTemplateInstanceOnMissingCreate(
 	}
 	if got := store.flowInstanceDescriptorCalls; got != 0 {
 		t.Fatalf("replay descriptor calls = %d, want 0 because lifecycle-created persisted route/scope is authoritative", got)
+	}
+}
+
+func TestEventBusPublish_ConnectRoutePlanCreateResolutionMintsUUIDAndCarriesInstanceKey(t *testing.T) {
+	source := connectRoutePlanCreateResolutionSource(t, runtimecontracts.FlowInputResolutionMintUUID)
+	store := &connectRoutePlanLifecycleStore{
+		connectRoutePlanDescriptorStore: &connectRoutePlanDescriptorStore{
+			targetRouteMemoryStore: newTargetRouteMemoryStore(),
+		},
+	}
+	eb, err := NewEventBusWithOptions(store, EventBusOptions{
+		ContractBundle:            source,
+		TemplateInstanceActivator: store.Activate,
+	})
+	if err != nil {
+		t.Fatalf("NewEventBusWithOptions: %v", err)
+	}
+	store.bus = eb
+	eventID := uuid.NewString()
+	evt := eventtest.RootIngress(eventID,
+		events.EventType("producer/validation.requested"), "", "", json.RawMessage(`{"candidate":"acct-1"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())
+
+	preflight, err := eb.CheckPublishRecipientPlan(context.Background(), evt)
+	if err != nil {
+		t.Fatalf("CheckPublishRecipientPlan: %v", err)
+	}
+	if preflight.TargetFailure != "" || len(preflight.DeliveryRoutes) != 1 {
+		t.Fatalf("preflight failure/routes = %q/%#v, want one preview route", preflight.TargetFailure, preflight.DeliveryRoutes)
+	}
+	if got := len(store.activations); got != 0 {
+		t.Fatalf("preflight activations = %d, want 0", got)
+	}
+
+	if err := eb.Publish(context.Background(), evt); err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+	if len(store.activations) != 1 {
+		t.Fatalf("activations = %d, want 1", len(store.activations))
+	}
+	activation := store.activations[0]
+	minted, _ := activation.Metadata["validation_case_id"].(string)
+	if _, err := uuid.Parse(minted); err != nil {
+		t.Fatalf("minted validation_case_id = %q, want uuid: %v", minted, err)
+	}
+	if minted == eventID {
+		t.Fatalf("minted validation_case_id = source event id %q, want deterministic uuid mint distinct from event_id mint", minted)
+	}
+	if activation.Config["validation_case_id"] != minted || activation.Metadata["validation_case_id"] != minted {
+		t.Fatalf("activation config/metadata = %#v/%#v, want carried validation_case_id %q", activation.Config, activation.Metadata, minted)
+	}
+	if got := activation.Metadata["last_source_event"]; got != eventID {
+		t.Fatalf("last_source_event = %v, want %q", got, eventID)
+	}
+	want := events.DeliveryRoute{
+		SubscriberType: "node",
+		SubscriberID:   "validator-node-" + minted,
+		Target: events.RouteIdentity{
+			FlowID:       "validator",
+			FlowInstance: activation.Instance.InstancePath,
+			EntityID:     activation.Instance.EntityID,
+		},
+	}
+	if !deliveryRoutesContain(store.routes[eventID], want) || len(store.routes[eventID]) != 1 {
+		t.Fatalf("persisted delivery routes = %#v, want create-resolution route %#v", store.routes[eventID], want)
+	}
+
+	replayTarget := eb.SubscribeInternal(want.SubscriberID)
+	store.flowInstanceDescriptorCalls = 0
+	if err := eb.Publish(context.Background(), evt); err != nil {
+		t.Fatalf("Publish same event retry: %v", err)
+	}
+	if len(store.activations) != 1 {
+		t.Fatalf("same-event retry activations = %d, want committed replay without a second activation", len(store.activations))
+	}
+	if got := store.flowInstanceDescriptorCalls; got != 0 {
+		t.Fatalf("same-event retry descriptor calls = %d, want committed replay without descriptor lookup", got)
+	}
+	replayed := requireBusEvent(t, replayTarget, "create resolution same-event committed replay")
+	if replayed.FlowInstance() != activation.Instance.InstancePath || replayed.EntityID() != activation.Instance.EntityID {
+		t.Fatalf("same-event replay target = flow_instance:%q entity:%q, want persisted %q/%q",
+			replayed.FlowInstance(), replayed.EntityID(), activation.Instance.InstancePath, activation.Instance.EntityID)
+	}
+}
+
+func TestEventBusPublish_ConnectRoutePlanCreateResolutionCanMintFromEventID(t *testing.T) {
+	source := connectRoutePlanCreateResolutionSource(t, runtimecontracts.FlowInputResolutionMintEventID)
+	store := &connectRoutePlanLifecycleStore{
+		connectRoutePlanDescriptorStore: &connectRoutePlanDescriptorStore{
+			targetRouteMemoryStore: newTargetRouteMemoryStore(),
+		},
+	}
+	eb, err := NewEventBusWithOptions(store, EventBusOptions{
+		ContractBundle:            source,
+		TemplateInstanceActivator: store.Activate,
+	})
+	if err != nil {
+		t.Fatalf("NewEventBusWithOptions: %v", err)
+	}
+	store.bus = eb
+	eventID := uuid.NewString()
+	evt := eventtest.RootIngress(eventID,
+		events.EventType("producer/validation.requested"), "", "", json.RawMessage(`{"candidate":"acct-1"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())
+
+	if err := eb.Publish(context.Background(), evt); err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+	if len(store.activations) != 1 {
+		t.Fatalf("activations = %d, want 1", len(store.activations))
+	}
+	activation := store.activations[0]
+	if activation.Metadata["validation_case_id"] != eventID || activation.Config["validation_case_id"] != eventID {
+		t.Fatalf("activation config/metadata = %#v/%#v, want event_id-minted validation_case_id %q", activation.Config, activation.Metadata, eventID)
+	}
+	want := events.DeliveryRoute{
+		SubscriberType: "node",
+		SubscriberID:   "validator-node-" + eventID,
+		Target: events.RouteIdentity{
+			FlowID:       "validator",
+			FlowInstance: activation.Instance.InstancePath,
+			EntityID:     activation.Instance.EntityID,
+		},
+	}
+	if !deliveryRoutesContain(store.routes[eventID], want) || len(store.routes[eventID]) != 1 {
+		t.Fatalf("persisted delivery routes = %#v, want event_id create-resolution route %#v", store.routes[eventID], want)
 	}
 }
 
@@ -2018,8 +2173,102 @@ func connectRoutePlanInstanceKeyBroadcastSource(t testing.TB) semanticview.Sourc
 	return semanticview.Wrap(bundle)
 }
 
+func connectRoutePlanCreateResolutionSource(t testing.TB, mint string) semanticview.Source {
+	t.Helper()
+	repoRoot, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd: %v", err)
+	}
+	repoRoot = filepath.Clean(filepath.Join(repoRoot, "..", "..", ".."))
+	root := writeConnectRoutePlanCreateResolutionFixture(t, mint)
+	bundle, err := runtimecontracts.LoadWorkflowContractBundleWithOverrides(repoRoot, root, runtimecontracts.DefaultPlatformSpecFile(repoRoot))
+	if err != nil {
+		t.Fatalf("LoadWorkflowContractBundleWithOverrides: %v", err)
+	}
+	return semanticview.Wrap(bundle)
+}
+
 func writeConnectRoutePlanInstanceKeyFixture(t testing.TB) string {
 	return writeConnectRoutePlanInstanceKeyFixtureWithDelivery(t, "one")
+}
+
+func writeConnectRoutePlanCreateResolutionFixture(t testing.TB, mint string) string {
+	t.Helper()
+	root := t.TempDir()
+	writeConnectRoutePlanBusFixtureFile(t, filepath.Join(root, "package.yaml"), `
+name: create-resolution-connect-route-plan-bus
+version: "1.0.0"
+platform_version: ">=0.7.0 <0.8.0"
+flows:
+  - id: producer
+    flow: producer
+    mode: static
+  - id: validator
+    flow: validator
+    mode: template
+connect:
+  - from: producer.validation_requested
+    to: validator.validation_requested
+    delivery: one
+`)
+	writeConnectRoutePlanBusFixtureFile(t, filepath.Join(root, "schema.yaml"), "name: create-resolution-connect-route-plan-bus\n")
+	writeConnectRoutePlanBusFixtureFile(t, filepath.Join(root, "policy.yaml"), "{}\n")
+	writeConnectRoutePlanBusFixtureFile(t, filepath.Join(root, "tools.yaml"), "{}\n")
+	writeConnectRoutePlanBusFixtureFile(t, filepath.Join(root, "agents.yaml"), "{}\n")
+	writeConnectRoutePlanBusFixtureFile(t, filepath.Join(root, "events.yaml"), "{}\n")
+	writeConnectRoutePlanBusFixtureFile(t, filepath.Join(root, "nodes.yaml"), "{}\n")
+	writeConnectRoutePlanBusFixtureFile(t, filepath.Join(root, "flows", "producer", "schema.yaml"), `
+name: producer
+mode: static
+pins:
+  outputs:
+    events:
+      - name: validation_requested
+        event: validation.requested
+`)
+	writeConnectRoutePlanBusFixtureFile(t, filepath.Join(root, "flows", "producer", "policy.yaml"), "{}\n")
+	writeConnectRoutePlanBusFixtureFile(t, filepath.Join(root, "flows", "producer", "agents.yaml"), "{}\n")
+	writeConnectRoutePlanBusFixtureFile(t, filepath.Join(root, "flows", "producer", "events.yaml"), "validation.requested:\n  candidate: string\n")
+	writeConnectRoutePlanBusFixtureFile(t, filepath.Join(root, "flows", "producer", "entities.yaml"), "{}\n")
+	writeConnectRoutePlanBusFixtureFile(t, filepath.Join(root, "flows", "producer", "nodes.yaml"), "{}\n")
+	writeConnectRoutePlanBusFixtureFile(t, filepath.Join(root, "flows", "validator", "schema.yaml"), `
+name: validator
+mode: template
+instance:
+  by: validation_case_id
+  on_missing: reject
+  on_conflict: reject
+pins:
+  inputs:
+    events:
+      - name: validation_requested
+        event: validation.requested
+        resolution:
+          mode: create
+          instance_key:
+            mint: `+mint+`
+            as: validation_case_id
+        carries:
+          validation_case_id:
+            from: instance.key.validation_case_id
+            type: uuid
+`)
+	writeConnectRoutePlanBusFixtureFile(t, filepath.Join(root, "flows", "validator", "policy.yaml"), "{}\n")
+	writeConnectRoutePlanBusFixtureFile(t, filepath.Join(root, "flows", "validator", "agents.yaml"), "{}\n")
+	writeConnectRoutePlanBusFixtureFile(t, filepath.Join(root, "flows", "validator", "events.yaml"), "validation.requested:\n  candidate: string\n  validation_case_id: uuid\n")
+	writeConnectRoutePlanBusFixtureFile(t, filepath.Join(root, "flows", "validator", "entities.yaml"), `
+validation_case:
+  validation_case_id:
+    type: uuid
+`)
+	writeConnectRoutePlanBusFixtureFile(t, filepath.Join(root, "flows", "validator", "nodes.yaml"), `
+validator-node:
+  id: validator-node-{validation_case_id}
+  execution_type: system_node
+  event_handlers:
+    validation.requested: {}
+`)
+	return root
 }
 
 func writeConnectRoutePlanRenamedInstanceKeyFixture(t testing.TB) string {

--- a/internal/runtime/bus/connect_route_plan_dispatch_test.go
+++ b/internal/runtime/bus/connect_route_plan_dispatch_test.go
@@ -968,6 +968,43 @@ func TestEventBusPublish_ConnectRoutePlanCreateResolutionMintsUUIDAndCarriesInst
 	}
 }
 
+func TestEventBusCheckPublishRecipientPlan_ConnectRoutePlanCreateResolutionAdmitsEmptyEventID(t *testing.T) {
+	source := connectRoutePlanCreateResolutionSource(t, runtimecontracts.FlowInputResolutionMintUUID)
+	store := &connectRoutePlanLifecycleStore{
+		connectRoutePlanDescriptorStore: &connectRoutePlanDescriptorStore{
+			targetRouteMemoryStore: newTargetRouteMemoryStore(),
+		},
+	}
+	eb, err := NewEventBusWithOptions(store, EventBusOptions{
+		ContractBundle:            source,
+		TemplateInstanceActivator: store.Activate,
+	})
+	if err != nil {
+		t.Fatalf("NewEventBusWithOptions: %v", err)
+	}
+	store.bus = eb
+	evt := eventtest.RootIngress("",
+		events.EventType("producer/validation.requested"), "", "", json.RawMessage(`{"candidate":"acct-1"}`), 0, "", "", events.EventEnvelope{}, time.Time{})
+
+	preflight, err := eb.CheckPublishRecipientPlan(context.Background(), evt)
+	if err != nil {
+		t.Fatalf("CheckPublishRecipientPlan: %v", err)
+	}
+	if preflight.TargetFailure != "" || len(preflight.DeliveryRoutes) != 1 {
+		t.Fatalf("preflight failure/routes = %q/%#v, want one admitted preview route", preflight.TargetFailure, preflight.DeliveryRoutes)
+	}
+	if got := len(store.activations); got != 0 {
+		t.Fatalf("preflight activations = %d, want 0", got)
+	}
+	previewTarget := preflight.DeliveryRoutes[0].Target
+	if previewTarget.FlowID != "validator" || previewTarget.FlowInstance == "" || previewTarget.EntityID == "" {
+		t.Fatalf("preview target = %#v, want minted validator route from admitted event id", previewTarget)
+	}
+	if routes := store.routes; len(routes) != 0 {
+		t.Fatalf("preflight persisted routes = %#v, want none", routes)
+	}
+}
+
 func TestEventBusPublish_ConnectRoutePlanCreateResolutionCanMintFromEventID(t *testing.T) {
 	source := connectRoutePlanCreateResolutionSource(t, runtimecontracts.FlowInputResolutionMintEventID)
 	store := &connectRoutePlanLifecycleStore{

--- a/internal/runtime/bus/eventbus_publish.go
+++ b/internal/runtime/bus/eventbus_publish.go
@@ -1627,7 +1627,11 @@ func (eb *EventBus) CheckPublishRecipientPlan(ctx context.Context, evt events.Ev
 			return PublishRecipientPlan{}, fmt.Errorf("%w for %s: %v", ErrPayloadValidation, strings.TrimSpace(string(evt.Type())), err)
 		}
 	}
-	plan, err := eb.planSubscribedRoutePlan(withTemplateInstanceLifecyclePreview(ctx), evt, false)
+	ictx, evt, err := admitEventForPublish(ctx, evt, time.Now(), "")
+	if err != nil {
+		return PublishRecipientPlan{}, err
+	}
+	plan, err := eb.planSubscribedRoutePlan(withTemplateInstanceLifecyclePreview(ictx), evt, false)
 	if err != nil {
 		return PublishRecipientPlan{}, err
 	}

--- a/internal/runtime/bus/template_instance_lifecycle.go
+++ b/internal/runtime/bus/template_instance_lifecycle.go
@@ -124,7 +124,7 @@ func (o templateInstanceLifecycleOwner) Materialize(ctx context.Context, evt eve
 	if plan.ResolutionKind != runtimepinrouting.ConnectResolutionInstanceKey || plan.InstanceKey == nil {
 		return runtimepinrouting.ConnectRoutePlanMaterialization{}, TemplateInstanceLifecycleDecision{}, false, nil
 	}
-	material, failure := runtimepinrouting.InstanceKeyMaterialForConnectRoutePlan(plan, values)
+	material, failure := instanceKeyMaterialForTemplateLifecycle(evt, plan, values)
 	if failure != "" {
 		return runtimepinrouting.ConnectRoutePlanMaterialization{Failure: failure}, TemplateInstanceLifecycleDecision{}, true, nil
 	}
@@ -140,6 +140,10 @@ func (o templateInstanceLifecycleOwner) Materialize(ctx context.Context, evt eve
 	}
 	onMissing := strings.TrimSpace(instanceContract.OnMissing)
 	onConflict := strings.TrimSpace(instanceContract.OnConflict)
+	if plan.InstanceKey != nil && strings.TrimSpace(plan.InstanceKey.Mode) == runtimecontracts.FlowInputResolutionModeCreate {
+		onMissing = "create"
+		onConflict = "reuse"
+	}
 	matches := runtimepinrouting.InstanceKeyDescriptorRoutesForConnectRoutePlan(plan, keyMaterial, descriptors)
 	if len(matches) > 1 {
 		return runtimepinrouting.ConnectRoutePlanMaterialization{Failure: runtimepinrouting.ConnectFailureTargetAmbiguous}, TemplateInstanceLifecycleDecision{}, true, nil
@@ -186,6 +190,13 @@ func (o templateInstanceLifecycleOwner) Materialize(ctx context.Context, evt eve
 	decision.InstancePath = matches[0].FlowInstance
 	decision.EntityID = matches[0].EntityID
 	return templateInstanceLifecycleMaterialization(plan, matches), decision, true, nil
+}
+
+func instanceKeyMaterialForTemplateLifecycle(evt events.Event, plan runtimepinrouting.ConnectRoutePlan, values map[string]string) (runtimepinrouting.ConnectRoutePlanInstanceKeyMaterial, runtimepinrouting.ConnectRoutePlanFailure) {
+	if plan.InstanceKey != nil && strings.TrimSpace(plan.InstanceKey.Mint) != "" {
+		return runtimepinrouting.MintedInstanceKeyMaterialForConnectRoutePlan(plan, evt.ID())
+	}
+	return runtimepinrouting.InstanceKeyMaterialForConnectRoutePlan(plan, values)
 }
 
 func (o templateInstanceLifecycleOwner) resolveInstanceContract(plan runtimepinrouting.ConnectRoutePlan, material runtimepinrouting.ConnectRoutePlanInstanceKeyMaterial) (runtimecontracts.TemplateInstanceContract, runtimepinrouting.ConnectRoutePlanFailure) {

--- a/internal/runtime/contracts/workflow_contract_connect.go
+++ b/internal/runtime/contracts/workflow_contract_connect.go
@@ -19,9 +19,11 @@ func (p FlowInputEventPin) EventType() string {
 
 func (p FlowInputEventPin) normalized() FlowInputEventPin {
 	out := FlowInputEventPin{
-		Name:   strings.TrimSpace(p.Name),
-		Event:  strings.TrimSpace(p.Event),
-		Source: strings.ToLower(strings.TrimSpace(p.Source)),
+		Name:       strings.TrimSpace(p.Name),
+		Event:      strings.TrimSpace(p.Event),
+		Source:     strings.ToLower(strings.TrimSpace(p.Source)),
+		Resolution: p.Resolution.normalized(),
+		Carries:    p.Carries.normalized(),
 	}
 	if out.Event == "" {
 		out.Event = out.Name
@@ -31,6 +33,78 @@ func (p FlowInputEventPin) normalized() FlowInputEventPin {
 		out.Address = &address
 	}
 	return out
+}
+
+func (c FlowInputPinCarries) normalized() FlowInputPinCarries {
+	if len(c) == 0 {
+		return nil
+	}
+	out := FlowInputPinCarries{}
+	keys := make([]string, 0, len(c))
+	for key := range c {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	for _, key := range keys {
+		name := strings.TrimSpace(key)
+		if name == "" {
+			continue
+		}
+		carry := c[key].normalized()
+		if carry.From == "" && carry.Type == "" {
+			continue
+		}
+		out[name] = carry
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+func (c FlowInputPinCarry) normalized() FlowInputPinCarry {
+	return FlowInputPinCarry{
+		From: strings.TrimSpace(c.From),
+		Type: strings.TrimSpace(c.Type),
+	}
+}
+
+func (r FlowInputPinResolution) Empty() bool {
+	r = r.normalized()
+	return r.Mode == "" &&
+		r.InstanceKey.Empty() &&
+		r.Aggregation == "" &&
+		r.Window == "" &&
+		len(r.DedupBy) == 0 &&
+		r.Singleton == "" &&
+		r.RepliesTo == "" &&
+		r.CorrelationKey == ""
+}
+
+func (r FlowInputPinResolution) normalized() FlowInputPinResolution {
+	return FlowInputPinResolution{
+		Mode:           strings.ToLower(strings.TrimSpace(r.Mode)),
+		InstanceKey:    r.InstanceKey.normalized(),
+		Aggregation:    strings.ToLower(strings.TrimSpace(r.Aggregation)),
+		Window:         strings.TrimSpace(r.Window),
+		DedupBy:        normalizeStringListPreserveOrder(r.DedupBy),
+		Singleton:      strings.TrimSpace(r.Singleton),
+		RepliesTo:      strings.TrimSpace(r.RepliesTo),
+		CorrelationKey: strings.TrimSpace(r.CorrelationKey),
+	}
+}
+
+func (k FlowInputPinResolutionInstanceKey) Empty() bool {
+	k = k.normalized()
+	return k.From == "" && k.Mint == "" && k.As == ""
+}
+
+func (k FlowInputPinResolutionInstanceKey) normalized() FlowInputPinResolutionInstanceKey {
+	return FlowInputPinResolutionInstanceKey{
+		From: strings.TrimSpace(k.From),
+		Mint: strings.ToLower(strings.TrimSpace(k.Mint)),
+		As:   strings.TrimSpace(k.As),
+	}
 }
 
 func (p FlowOutputEventPin) PinName() string {

--- a/internal/runtime/contracts/workflow_contract_types.go
+++ b/internal/runtime/contracts/workflow_contract_types.go
@@ -1119,6 +1119,20 @@ const (
 	FlowModeSingleton = "singleton"
 )
 
+const (
+	FlowInputResolutionModeCreate         = "create"
+	FlowInputResolutionModeSelect         = "select"
+	FlowInputResolutionModeSelectOrCreate = "select-or-create"
+	FlowInputResolutionModeFanIn          = "fan-in"
+	FlowInputResolutionModeFanOut         = "fan-out"
+	FlowInputResolutionModeReply          = "reply"
+)
+
+const (
+	FlowInputResolutionMintUUID    = "uuid"
+	FlowInputResolutionMintEventID = "event_id"
+)
+
 type FlowToolSurfaceContract struct {
 	RoleScopedEntityTools bool `yaml:"role_scoped_entity_tools"`
 }
@@ -1207,10 +1221,12 @@ type FlowOutputPins struct {
 	Writes    []string             `yaml:"writes"`
 }
 type FlowInputEventPin struct {
-	Name    string               `yaml:"name"`
-	Event   string               `yaml:"event"`
-	Source  string               `yaml:"source"`
-	Address *FlowInputPinAddress `yaml:"address"`
+	Name       string                 `yaml:"name"`
+	Event      string                 `yaml:"event"`
+	Source     string                 `yaml:"source"`
+	Address    *FlowInputPinAddress   `yaml:"address"`
+	Resolution FlowInputPinResolution `yaml:"resolution"`
+	Carries    FlowInputPinCarries    `yaml:"carries"`
 }
 type FlowOutputEventPin struct {
 	Name    string   `yaml:"name"`
@@ -1218,12 +1234,32 @@ type FlowOutputEventPin struct {
 	Key     string   `yaml:"key"`
 	Carries []string `yaml:"carries"`
 }
+type FlowInputPinCarries map[string]FlowInputPinCarry
+type FlowInputPinCarry struct {
+	From string `yaml:"from"`
+	Type string `yaml:"type"`
+}
 type FlowInputPinAddress struct {
 	By          string `yaml:"by"`
 	Source      string `yaml:"source"`
 	Target      string `yaml:"target"`
 	Cardinality string `yaml:"cardinality"`
 	Mode        string `yaml:"mode"`
+}
+type FlowInputPinResolution struct {
+	Mode           string                            `yaml:"mode"`
+	InstanceKey    FlowInputPinResolutionInstanceKey `yaml:"instance_key"`
+	Aggregation    string                            `yaml:"aggregation"`
+	Window         string                            `yaml:"window"`
+	DedupBy        []string                          `yaml:"dedup_by"`
+	Singleton      string                            `yaml:"singleton"`
+	RepliesTo      string                            `yaml:"replies_to"`
+	CorrelationKey string                            `yaml:"correlation_key"`
+}
+type FlowInputPinResolutionInstanceKey struct {
+	From string `yaml:"from"`
+	Mint string `yaml:"mint"`
+	As   string `yaml:"as"`
 }
 type FlowPackageConnect struct {
 	PackageKey string                           `yaml:"-"`

--- a/internal/runtime/contracts/workflow_contract_yaml_flow.go
+++ b/internal/runtime/contracts/workflow_contract_yaml_flow.go
@@ -280,6 +280,14 @@ func decodeFlowInputPinEventNode(node *yaml.Node) (FlowInputEventPin, error) {
 				return FlowInputEventPin{}, fmt.Errorf("input event pin address: %w", err)
 			}
 			out.Address = &address
+		case "resolution":
+			if err := value.Decode(&out.Resolution); err != nil {
+				return FlowInputEventPin{}, fmt.Errorf("input event pin resolution: %w", err)
+			}
+		case "carries":
+			if err := value.Decode(&out.Carries); err != nil {
+				return FlowInputEventPin{}, fmt.Errorf("input event pin carries: %w", err)
+			}
 		default:
 			return FlowInputEventPin{}, fmt.Errorf("UNDEFINED-FIELD: input event pin field %q not in platform spec", key)
 		}
@@ -360,6 +368,170 @@ func decodeFlowOutputPinCarriesNode(node *yaml.Node) ([]string, error) {
 	default:
 		return nil, fmt.Errorf("carries must be a string or sequence")
 	}
+}
+
+func (c *FlowInputPinCarries) UnmarshalYAML(node *yaml.Node) error {
+	if c == nil {
+		return nil
+	}
+	if node == nil || node.Kind == 0 {
+		*c = nil
+		return nil
+	}
+	if node.Kind != yaml.MappingNode {
+		return fmt.Errorf("input pin carries must be a mapping")
+	}
+	out := FlowInputPinCarries{}
+	for i := 0; i+1 < len(node.Content); i += 2 {
+		name := strings.TrimSpace(node.Content[i].Value)
+		value := node.Content[i+1]
+		if name == "" {
+			continue
+		}
+		var carry FlowInputPinCarry
+		if err := value.Decode(&carry); err != nil {
+			return fmt.Errorf("carry %s: %w", name, err)
+		}
+		out[name] = carry.normalized()
+	}
+	*c = out.normalized()
+	return nil
+}
+
+func (c *FlowInputPinCarry) UnmarshalYAML(node *yaml.Node) error {
+	if c == nil {
+		return nil
+	}
+	if node == nil || node.Kind == 0 {
+		*c = FlowInputPinCarry{}
+		return nil
+	}
+	if node.Kind != yaml.MappingNode {
+		return fmt.Errorf("input pin carry must be a mapping")
+	}
+	var out FlowInputPinCarry
+	for i := 0; i+1 < len(node.Content); i += 2 {
+		key := strings.TrimSpace(node.Content[i].Value)
+		value := node.Content[i+1]
+		switch key {
+		case "":
+			continue
+		case "from":
+			if err := value.Decode(&out.From); err != nil {
+				return fmt.Errorf("carry.from: %w", err)
+			}
+		case "type":
+			if err := value.Decode(&out.Type); err != nil {
+				return fmt.Errorf("carry.type: %w", err)
+			}
+		default:
+			return fmt.Errorf("UNDEFINED-FIELD: input event pin carry field %q not in platform spec", key)
+		}
+	}
+	*c = out.normalized()
+	return nil
+}
+
+func (r *FlowInputPinResolution) UnmarshalYAML(node *yaml.Node) error {
+	if r == nil {
+		return nil
+	}
+	if node == nil || node.Kind == 0 {
+		*r = FlowInputPinResolution{}
+		return nil
+	}
+	if node.Kind != yaml.MappingNode {
+		return fmt.Errorf("input pin resolution must be a mapping")
+	}
+	var out FlowInputPinResolution
+	for i := 0; i+1 < len(node.Content); i += 2 {
+		key := strings.TrimSpace(node.Content[i].Value)
+		value := node.Content[i+1]
+		switch key {
+		case "":
+			continue
+		case "mode":
+			if err := value.Decode(&out.Mode); err != nil {
+				return fmt.Errorf("resolution.mode: %w", err)
+			}
+		case "instance_key":
+			if err := value.Decode(&out.InstanceKey); err != nil {
+				return fmt.Errorf("resolution.instance_key: %w", err)
+			}
+		case "aggregation":
+			if err := value.Decode(&out.Aggregation); err != nil {
+				return fmt.Errorf("resolution.aggregation: %w", err)
+			}
+		case "window":
+			if err := value.Decode(&out.Window); err != nil {
+				return fmt.Errorf("resolution.window: %w", err)
+			}
+		case "dedup_by":
+			dedup, err := decodeFlowOutputPinCarriesNode(value)
+			if err != nil {
+				return fmt.Errorf("resolution.dedup_by: %w", err)
+			}
+			out.DedupBy = dedup
+		case "singleton":
+			if err := value.Decode(&out.Singleton); err != nil {
+				return fmt.Errorf("resolution.singleton: %w", err)
+			}
+		case "replies_to":
+			if err := value.Decode(&out.RepliesTo); err != nil {
+				return fmt.Errorf("resolution.replies_to: %w", err)
+			}
+		case "correlation_key":
+			if err := value.Decode(&out.CorrelationKey); err != nil {
+				return fmt.Errorf("resolution.correlation_key: %w", err)
+			}
+		default:
+			return fmt.Errorf("UNDEFINED-FIELD: input event pin resolution field %q not in platform spec", key)
+		}
+	}
+	*r = out.normalized()
+	return nil
+}
+
+func (k *FlowInputPinResolutionInstanceKey) UnmarshalYAML(node *yaml.Node) error {
+	if k == nil {
+		return nil
+	}
+	if node == nil || node.Kind == 0 {
+		*k = FlowInputPinResolutionInstanceKey{}
+		return nil
+	}
+	if node.Kind == yaml.ScalarNode {
+		*k = (FlowInputPinResolutionInstanceKey{From: strings.TrimSpace(node.Value)}).normalized()
+		return nil
+	}
+	if node.Kind != yaml.MappingNode {
+		return fmt.Errorf("resolution.instance_key must be a string or mapping")
+	}
+	var out FlowInputPinResolutionInstanceKey
+	for i := 0; i+1 < len(node.Content); i += 2 {
+		key := strings.TrimSpace(node.Content[i].Value)
+		value := node.Content[i+1]
+		switch key {
+		case "":
+			continue
+		case "from":
+			if err := value.Decode(&out.From); err != nil {
+				return fmt.Errorf("instance_key.from: %w", err)
+			}
+		case "mint":
+			if err := value.Decode(&out.Mint); err != nil {
+				return fmt.Errorf("instance_key.mint: %w", err)
+			}
+		case "as":
+			if err := value.Decode(&out.As); err != nil {
+				return fmt.Errorf("instance_key.as: %w", err)
+			}
+		default:
+			return fmt.Errorf("UNDEFINED-FIELD: input event pin resolution.instance_key field %q not in platform spec", key)
+		}
+	}
+	*k = out.normalized()
+	return nil
 }
 
 func (a *FlowInputPinAddress) UnmarshalYAML(node *yaml.Node) error {

--- a/internal/runtime/contracts/workflow_contract_yaml_test.go
+++ b/internal/runtime/contracts/workflow_contract_yaml_test.go
@@ -454,6 +454,161 @@ pins:
 	}
 }
 
+func TestFlowSchemaDocumentDecode_PreservesInputPinResolutionModes(t *testing.T) {
+	var doc FlowSchemaDocument
+	if err := yaml.Unmarshal([]byte(`
+name: resolution-pins
+pins:
+  inputs:
+    events:
+      - name: create_requested
+        event: validation.requested
+        resolution:
+          mode: create
+          instance_key:
+            mint: uuid
+            as: validation_case_id
+        carries:
+          validation_case_id:
+            from: instance.key.validation_case_id
+            type: uuid
+      - name: select_requested
+        event: account.selected
+        resolution:
+          mode: select
+          instance_key: account_id
+      - name: select_or_create_requested
+        event: account.requested
+        resolution:
+          mode: select-or-create
+          instance_key:
+            from: payload.account_id
+      - name: fan_in_requested
+        event: report.ready
+        resolution:
+          mode: fan-in
+          aggregation: stream
+          window: report_period
+          dedup_by: [event.id, payload.operating_id]
+          singleton: portfolio/default
+      - name: fan_out_requested
+        event: operating.requested
+        resolution:
+          mode: fan-out
+          instance_key: operating_id
+      - name: reply_received
+        event: provider.replied
+        resolution:
+          mode: reply
+          replies_to: provider_requested
+          correlation_key: payload.provider_request_id
+`), &doc); err != nil {
+		t.Fatalf("yaml.Unmarshal: %v", err)
+	}
+	pins := doc.Pins.Inputs.EventPins
+	if len(pins) != 6 {
+		t.Fatalf("input EventPins len = %d, want 6", len(pins))
+	}
+	create := pins[0]
+	if got, want := create.Resolution.Mode, FlowInputResolutionModeCreate; got != want {
+		t.Fatalf("create Resolution.Mode = %q, want %q", got, want)
+	}
+	if got, want := create.Resolution.InstanceKey.Mint, FlowInputResolutionMintUUID; got != want {
+		t.Fatalf("create Resolution.InstanceKey.Mint = %q, want %q", got, want)
+	}
+	if got, want := create.Resolution.InstanceKey.As, "validation_case_id"; got != want {
+		t.Fatalf("create Resolution.InstanceKey.As = %q, want %q", got, want)
+	}
+	carry := create.Carries["validation_case_id"]
+	if got, want := carry.From, "instance.key.validation_case_id"; got != want {
+		t.Fatalf("create carry From = %q, want %q", got, want)
+	}
+	if got, want := carry.Type, "uuid"; got != want {
+		t.Fatalf("create carry Type = %q, want %q", got, want)
+	}
+	if got, want := pins[1].Resolution.InstanceKey.From, "account_id"; got != want {
+		t.Fatalf("select instance_key scalar = %q, want %q", got, want)
+	}
+	if got, want := pins[2].Resolution.InstanceKey.From, "payload.account_id"; got != want {
+		t.Fatalf("select-or-create instance_key.from = %q, want %q", got, want)
+	}
+	if got, want := pins[3].Resolution.Aggregation, "stream"; got != want {
+		t.Fatalf("fan-in aggregation = %q, want %q", got, want)
+	}
+	if got, want := strings.Join(pins[3].Resolution.DedupBy, ","), "event.id,payload.operating_id"; got != want {
+		t.Fatalf("fan-in dedup_by = %q, want %q", got, want)
+	}
+	if got, want := pins[4].Resolution.Mode, FlowInputResolutionModeFanOut; got != want {
+		t.Fatalf("fan-out mode = %q, want %q", got, want)
+	}
+	if got, want := pins[5].Resolution.RepliesTo, "provider_requested"; got != want {
+		t.Fatalf("reply replies_to = %q, want %q", got, want)
+	}
+}
+
+func TestFlowSchemaDocumentDecode_RejectsUnsupportedInputPinResolutionFields(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+	}{
+		{
+			name: "resolution",
+			body: `
+name: invalid-resolution
+pins:
+  inputs:
+    events:
+      - name: requested
+        event: work.requested
+        resolution:
+          mode: create
+          unsupported: true
+`,
+		},
+		{
+			name: "instance_key",
+			body: `
+name: invalid-resolution-instance-key
+pins:
+  inputs:
+    events:
+      - name: requested
+        event: work.requested
+        resolution:
+          mode: create
+          instance_key:
+            mint: uuid
+            as: work_id
+            unsupported: true
+`,
+		},
+		{
+			name: "carries",
+			body: `
+name: invalid-resolution-carries
+pins:
+  inputs:
+    events:
+      - name: requested
+        event: work.requested
+        carries:
+          work_id:
+            from: instance.key.work_id
+            unsupported: true
+`,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var doc FlowSchemaDocument
+			err := yaml.Unmarshal([]byte(tc.body), &doc)
+			if err == nil || !strings.Contains(err.Error(), "UNDEFINED-FIELD") {
+				t.Fatalf("yaml.Unmarshal error = %v, want UNDEFINED-FIELD", err)
+			}
+		})
+	}
+}
+
 func TestFlowSchemaDocumentDecode_RejectsUnsupportedOutputPinFields(t *testing.T) {
 	var doc FlowSchemaDocument
 	err := yaml.Unmarshal([]byte(`

--- a/internal/runtime/core/pinrouting/connect_route_plan.go
+++ b/internal/runtime/core/pinrouting/connect_route_plan.go
@@ -1,6 +1,9 @@
 package pinrouting
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
 	"sort"
 	"strings"
 
@@ -56,6 +59,7 @@ const (
 	ConnectFailureTargetUnresolved           ConnectRoutePlanFailure = "route_plan_target_unresolved"
 	ConnectFailureTargetAmbiguous            ConnectRoutePlanFailure = "route_plan_target_ambiguous"
 	ConnectFailureInstanceKeyAdapterInvalid  ConnectRoutePlanFailure = "route_plan_instance_key_adapter_invalid"
+	ConnectFailureInstanceResolutionInvalid  ConnectRoutePlanFailure = "route_plan_instance_resolution_invalid"
 	ConnectFailureInstanceConflict           ConnectRoutePlanFailure = "route_plan_instance_conflict"
 	ConnectFailureLifecycleUnavailable       ConnectRoutePlanFailure = "route_plan_lifecycle_unavailable"
 )
@@ -87,8 +91,11 @@ type ConnectRoutePlanMapEntry struct {
 }
 
 type ConnectRoutePlanInstanceKey struct {
+	Mode       string
 	Fields     []string
 	Mappings   []ConnectRoutePlanInstanceKeyMapping
+	Mint       string
+	As         string
 	OnMissing  string
 	OnConflict string
 }
@@ -390,6 +397,9 @@ func InstanceKeyMaterialForConnectRoutePlan(plan ConnectRoutePlan, matchValues m
 	if instanceKey == nil || len(instanceKey.Fields) == 0 {
 		return ConnectRoutePlanInstanceKeyMaterial{}, ConnectFailureReceiverAddressRuleMissing
 	}
+	if strings.TrimSpace(instanceKey.Mint) != "" {
+		return ConnectRoutePlanInstanceKeyMaterial{}, ConnectFailureAddressValueMissing
+	}
 	values := make(map[string]any, len(instanceKey.Fields))
 	mappings := connectInstanceKeyMaterializationMappings(instanceKey)
 	for _, mapping := range mappings {
@@ -420,6 +430,59 @@ func InstanceKeyMaterialForConnectRoutePlan(plan ConnectRoutePlan, matchValues m
 		Values: values,
 		Keys:   append([]runtimecontracts.TemplateInstanceKeyValue{}, keys...),
 	}, ""
+}
+
+func MintedInstanceKeyMaterialForConnectRoutePlan(plan ConnectRoutePlan, eventID string) (ConnectRoutePlanInstanceKeyMaterial, ConnectRoutePlanFailure) {
+	instanceKey := plan.InstanceKey
+	if instanceKey == nil || len(instanceKey.Fields) == 0 {
+		return ConnectRoutePlanInstanceKeyMaterial{}, ConnectFailureReceiverAddressRuleMissing
+	}
+	mint := strings.TrimSpace(instanceKey.Mint)
+	as := strings.TrimSpace(instanceKey.As)
+	eventID = strings.TrimSpace(eventID)
+	if mint == "" || as == "" || eventID == "" {
+		return ConnectRoutePlanInstanceKeyMaterial{}, ConnectFailureAddressValueMissing
+	}
+	value := ""
+	switch mint {
+	case runtimecontracts.FlowInputResolutionMintUUID:
+		value = deterministicResolutionUUID(plan, eventID)
+	case runtimecontracts.FlowInputResolutionMintEventID:
+		value = eventID
+	default:
+		return ConnectRoutePlanInstanceKeyMaterial{}, ConnectFailureInstanceResolutionInvalid
+	}
+	values := map[string]any{as: value}
+	keys, err := (runtimecontracts.TemplateInstanceContract{
+		FlowID: plan.Receiver.FlowID,
+		By:     append([]string{}, instanceKey.Fields...),
+	}).CanonicalKeyMaterial(values)
+	if err != nil {
+		return ConnectRoutePlanInstanceKeyMaterial{}, ConnectFailureAddressValueMissing
+	}
+	return ConnectRoutePlanInstanceKeyMaterial{
+		Values: values,
+		Keys:   append([]runtimecontracts.TemplateInstanceKeyValue{}, keys...),
+	}, ""
+}
+
+func deterministicResolutionUUID(plan ConnectRoutePlan, eventID string) string {
+	h := sha256.New()
+	_, _ = h.Write([]byte(strings.TrimSpace(eventID)))
+	_, _ = h.Write([]byte{0})
+	_, _ = h.Write([]byte(strings.TrimSpace(plan.Receiver.FlowID)))
+	_, _ = h.Write([]byte{0})
+	_, _ = h.Write([]byte(strings.TrimSpace(plan.Receiver.Pin)))
+	_, _ = h.Write([]byte{0})
+	if plan.InstanceKey != nil {
+		_, _ = h.Write([]byte(strings.TrimSpace(plan.InstanceKey.As)))
+	}
+	sum := h.Sum(nil)
+	b := append([]byte{}, sum[:16]...)
+	b[6] = (b[6] & 0x0f) | 0x50
+	b[8] = (b[8] & 0x3f) | 0x80
+	encoded := hex.EncodeToString(b)
+	return fmt.Sprintf("%s-%s-%s-%s-%s", encoded[0:8], encoded[8:12], encoded[12:16], encoded[16:20], encoded[20:32])
 }
 
 func InstanceKeyDescriptorRoutesForConnectRoutePlan(plan ConnectRoutePlan, keyMaterial []runtimecontracts.TemplateInstanceKeyValue, descriptors []Descriptor) []events.RouteIdentity {
@@ -507,6 +570,19 @@ func connectInstanceKey(source semanticview.Source, connect runtimecontracts.Flo
 	if source == nil {
 		return nil, ConnectRoutePlanIssue{}
 	}
+	resolution := inputPin.Resolution
+	if !resolution.Empty() {
+		if inputPin.Address != nil {
+			return nil, ConnectRoutePlanIssue{Connect: connect, Failure: ConnectFailureInstanceResolutionInvalid, Detail: "input pin resolution is incompatible with legacy address"}
+		}
+		if adapter.Declared {
+			return nil, ConnectRoutePlanIssue{Connect: connect, Failure: ConnectFailureInstanceResolutionInvalid, Detail: "connect.using.instance is incompatible with input pin resolution"}
+		}
+		if len(connect.Map) > 0 {
+			return nil, ConnectRoutePlanIssue{Connect: connect, Failure: ConnectFailureInstanceResolutionInvalid, Detail: "connect.map is incompatible with input pin resolution"}
+		}
+		return connectResolutionInstanceKey(source, connect, inputPin, resolution, delivery, receiverFlowID)
+	}
 	if inputPin.Address != nil {
 		if adapter.Declared {
 			return nil, ConnectRoutePlanIssue{Connect: connect, Failure: ConnectFailureInstanceKeyAdapterInvalid, Detail: "connect.using.instance requires an addressless receiver input"}
@@ -560,6 +636,42 @@ func connectInstanceKey(source semanticview.Source, connect runtimecontracts.Flo
 		Mappings:   mappings,
 		OnMissing:  strings.TrimSpace(instance.OnMissing),
 		OnConflict: strings.TrimSpace(instance.OnConflict),
+	}, ConnectRoutePlanIssue{}
+}
+
+func connectResolutionInstanceKey(source semanticview.Source, connect runtimecontracts.FlowPackageConnect, inputPin runtimecontracts.FlowInputEventPin, resolution runtimecontracts.FlowInputPinResolution, delivery ConnectRoutePlanDelivery, receiverFlowID string) (*ConnectRoutePlanInstanceKey, ConnectRoutePlanIssue) {
+	if resolution.Mode != runtimecontracts.FlowInputResolutionModeCreate {
+		return nil, ConnectRoutePlanIssue{Connect: connect, Failure: ConnectFailureInstanceResolutionInvalid, Detail: fmt.Sprintf("resolution mode %q is design-locked but not runnable in this slice", resolution.Mode)}
+	}
+	if delivery != ConnectDeliveryOne {
+		return nil, ConnectRoutePlanIssue{Connect: connect, Failure: ConnectFailureDeliveryTopologyInvalid, Detail: "resolution mode create requires delivery one"}
+	}
+	bundle, ok := semanticview.Bundle(source)
+	if !ok {
+		return nil, ConnectRoutePlanIssue{Connect: connect, Failure: ConnectFailureLifecycleUnavailable, Detail: "receiver instance contract owner is unavailable"}
+	}
+	instance, err := bundle.ResolveFlowTemplateInstance(receiverFlowID)
+	if err != nil {
+		return nil, ConnectRoutePlanIssue{Connect: connect, Failure: ConnectFailureInstanceResolutionInvalid, Detail: err.Error()}
+	}
+	mint := strings.TrimSpace(resolution.InstanceKey.Mint)
+	as := strings.TrimSpace(resolution.InstanceKey.As)
+	switch mint {
+	case runtimecontracts.FlowInputResolutionMintUUID, runtimecontracts.FlowInputResolutionMintEventID:
+	default:
+		return nil, ConnectRoutePlanIssue{Connect: connect, Failure: ConnectFailureInstanceResolutionInvalid, Detail: fmt.Sprintf("resolution mode create mint %q must be uuid or event_id", mint)}
+	}
+	fields := normalizedStringList(instance.By)
+	if as == "" || len(fields) != 1 || fields[0] != as {
+		return nil, ConnectRoutePlanIssue{Connect: connect, Failure: ConnectFailureInstanceResolutionInvalid, Detail: fmt.Sprintf("resolution mode create instance_key.as %q must match the receiver's single instance.by field %v", as, fields)}
+	}
+	return &ConnectRoutePlanInstanceKey{
+		Mode:       runtimecontracts.FlowInputResolutionModeCreate,
+		Fields:     fields,
+		Mint:       mint,
+		As:         as,
+		OnMissing:  "create",
+		OnConflict: "reuse",
 	}, ConnectRoutePlanIssue{}
 }
 

--- a/internal/runtime/core/pinrouting/connect_route_plan_test.go
+++ b/internal/runtime/core/pinrouting/connect_route_plan_test.go
@@ -127,6 +127,60 @@ func TestLowerCompositionConnectRoutePlansUsesTemplateInstanceKey(t *testing.T) 
 	}
 }
 
+func TestLowerCompositionConnectRoutePlansUsesCreateInputResolution(t *testing.T) {
+	repoRoot, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd: %v", err)
+	}
+	repoRoot = filepath.Clean(filepath.Join(repoRoot, "..", "..", "..", ".."))
+	root := writeCreateResolutionConnectRoutePlanPackageFixture(t, runtimecontracts.FlowInputResolutionMintUUID)
+	bundle, err := runtimecontracts.LoadWorkflowContractBundleWithOverrides(repoRoot, root, runtimecontracts.DefaultPlatformSpecFile(repoRoot))
+	if err != nil {
+		t.Fatalf("LoadWorkflowContractBundleWithOverrides: %v", err)
+	}
+
+	plans, issues := LowerCompositionConnectRoutePlans(semanticview.Wrap(bundle))
+	if len(issues) != 0 {
+		t.Fatalf("issues = %#v, want none", issues)
+	}
+	if len(plans) != 1 {
+		t.Fatalf("plans = %#v, want one", plans)
+	}
+	plan := plans[0]
+	if plan.InstanceKey == nil {
+		t.Fatal("InstanceKey = nil, want create resolution instance-key evidence")
+	}
+	if got, want := plan.ResolutionKind, ConnectResolutionInstanceKey; got != want {
+		t.Fatalf("ResolutionKind = %q, want %q", got, want)
+	}
+	if plan.Source.Key != "" || len(plan.Source.Carries) != 0 {
+		t.Fatalf("Source key/carries = %q/%#v, want create resolution independent of producer output key", plan.Source.Key, plan.Source.Carries)
+	}
+	if got, want := plan.InstanceKey.Mode, runtimecontracts.FlowInputResolutionModeCreate; got != want {
+		t.Fatalf("InstanceKey.Mode = %q, want %q", got, want)
+	}
+	if got, want := plan.InstanceKey.Mint, runtimecontracts.FlowInputResolutionMintUUID; got != want {
+		t.Fatalf("InstanceKey.Mint = %q, want %q", got, want)
+	}
+	if got, want := plan.InstanceKey.As, "validation_case_id"; got != want {
+		t.Fatalf("InstanceKey.As = %q, want %q", got, want)
+	}
+	if got, want := plan.InstanceKey.OnMissing, "create"; got != want {
+		t.Fatalf("InstanceKey.OnMissing = %q, want %q", got, want)
+	}
+	if got, want := plan.InstanceKey.OnConflict, "reuse"; got != want {
+		t.Fatalf("InstanceKey.OnConflict = %q, want %q", got, want)
+	}
+	eventID := "11111111-1111-4111-8111-111111111111"
+	material, failure := MintedInstanceKeyMaterialForConnectRoutePlan(plan, eventID)
+	if failure != "" {
+		t.Fatalf("MintedInstanceKeyMaterialForConnectRoutePlan failure = %q", failure)
+	}
+	if len(material.Keys) != 1 || material.Keys[0].Field != "validation_case_id" || material.Keys[0].Value == "" || material.Keys[0].Value == eventID {
+		t.Fatalf("minted material = %#v, want deterministic uuid material distinct from event id", material)
+	}
+}
+
 func TestLowerCompositionConnectRoutePlansUsesRenamedInstanceKeyAdapter(t *testing.T) {
 	repoRoot, err := os.Getwd()
 	if err != nil {
@@ -957,6 +1011,72 @@ deployment:
 
 func writeInstanceKeyConnectRoutePlanPackageFixture(t *testing.T) string {
 	return writeInstanceKeyConnectRoutePlanPackageFixtureWithDelivery(t, "one")
+}
+
+func writeCreateResolutionConnectRoutePlanPackageFixture(t *testing.T, mint string) string {
+	t.Helper()
+	root := t.TempDir()
+	writeConnectRoutePlanFixtureFile(t, filepath.Join(root, "package.yaml"), `
+name: create-resolution-connect-route-plan-package
+version: "1.0.0"
+platform_version: ">=0.7.0 <0.8.0"
+flows:
+  - id: producer
+    flow: producer
+    mode: static
+  - id: validator
+    flow: validator
+    mode: template
+connect:
+  - from: producer.validation_requested
+    to: validator.validation_requested
+    delivery: one
+`)
+	writeConnectRoutePlanFixtureFile(t, filepath.Join(root, "schema.yaml"), "name: create-resolution-connect-route-plan-package\n")
+	writeConnectRoutePlanFixtureFile(t, filepath.Join(root, "policy.yaml"), "{}\n")
+	writeConnectRoutePlanFixtureFile(t, filepath.Join(root, "tools.yaml"), "{}\n")
+	writeConnectRoutePlanFixtureFile(t, filepath.Join(root, "agents.yaml"), "{}\n")
+	writeConnectRoutePlanFixtureFile(t, filepath.Join(root, "events.yaml"), "{}\n")
+	writeConnectRoutePlanFixtureFile(t, filepath.Join(root, "nodes.yaml"), "{}\n")
+	writeConnectRoutePlanFlowFixture(t, root, "producer", `
+pins:
+  outputs:
+    events:
+      - name: validation_requested
+        event: validation.requested
+`, "validation.requested:\n  candidate: string\n", "{}\n")
+	writeConnectRoutePlanFixtureFile(t, filepath.Join(root, "flows", "validator", "schema.yaml"), `
+name: validator
+mode: template
+instance:
+  by: validation_case_id
+  on_missing: reject
+  on_conflict: reject
+pins:
+  inputs:
+    events:
+      - name: validation_requested
+        event: validation.requested
+        resolution:
+          mode: create
+          instance_key:
+            mint: `+mint+`
+            as: validation_case_id
+        carries:
+          validation_case_id:
+            from: instance.key.validation_case_id
+            type: uuid
+`)
+	writeConnectRoutePlanFixtureFile(t, filepath.Join(root, "flows", "validator", "policy.yaml"), "{}\n")
+	writeConnectRoutePlanFixtureFile(t, filepath.Join(root, "flows", "validator", "agents.yaml"), "{}\n")
+	writeConnectRoutePlanFixtureFile(t, filepath.Join(root, "flows", "validator", "nodes.yaml"), "{}\n")
+	writeConnectRoutePlanFixtureFile(t, filepath.Join(root, "flows", "validator", "events.yaml"), "validation.requested:\n  candidate: string\n  validation_case_id: uuid\n")
+	writeConnectRoutePlanFixtureFile(t, filepath.Join(root, "flows", "validator", "entities.yaml"), `
+validation_case:
+  validation_case_id:
+    type: uuid
+`)
+	return root
 }
 
 func writeInstanceKeyConnectRoutePlanPackageFixtureWithDelivery(t *testing.T, delivery string) string {

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -7945,6 +7945,140 @@ flow_model:
             handler lookup, direct delivery, producer target, producer
             broadcast:true, receiver select_entity/select_or_create_entity, and
             explicit create_flow_instance are not lifecycle authority.
+        implementation_slice_1835:
+          status: spec_locked_create_mode_runnable_remaining_modes_fail_closed
+          canonical_spec_owner: platform-spec.yaml#flow_model.flow_package.composition_routing.route_plan_lowering.implementation_slice_1835
+          canonical_code_owner: internal/runtime/contracts.FlowInputPinResolution + internal/runtime/core/pinrouting.ConnectRoutePlan.InstanceKey + internal/runtime/bus.templateInstanceLifecycleOwner + internal/runtime/bootverify.composition_connect_validation
+          rule: |
+            Receiver input pins may declare an explicit instance-resolution
+            contract under `resolution:{mode,...}`. This receiver-side contract
+            is the canonical authoring owner for new instance routing semantics;
+            route planning consumes it as typed contract data and lowers it into
+            ConnectRoutePlan evidence before EventBus delivery. Runtime must not
+            infer resolution authority from producer emit targets, live
+            subscribers, delivery rows, replay rows, route-table lookup before a
+            selected target, or handler lookup.
+
+            PR1 spec-locks every approved mode but only makes
+            `resolution.mode: create` runnable. All other locked modes are
+            recognized by contracts and verifier and fail closed as
+            design-locked/not-runnable until their implementation slices land.
+            Static root ingress, parent-connect static delivery, and
+            harness-injected inputs remain existing #1807 input-source / connect
+            behavior; they are not instance-resolution runtime modes.
+          authoring_shape: |
+            pins:
+              inputs:
+                events:
+                  - name: validation_requested
+                    event: validation.requested
+                    resolution:
+                      mode: create
+                      instance_key:
+                        mint: uuid
+                        as: validation_case_id
+                    carries:
+                      validation_case_id:
+                        from: instance.key.validation_case_id
+                        type: uuid
+          modes:
+            create:
+              status: runnable_in_1835_pr1
+              contract: >
+                `mode: create` mints the receiver template instance key at the
+                boundary, carries that key as `instance.key.<as>`, creates the
+                receiver instance if absent, and reuses the same keyed instance
+                on replay or duplicate delivery. The receiver flow MUST be
+                `mode: template`, MUST have a single `instance.by` field in this
+                slice, and `instance_key.as` MUST equal that field. The input pin
+                MUST declare a matching `carries.<field>.from:
+                instance.key.<field>` entry so downstream route rendering and
+                lifecycle activation consume the same canonical key material.
+              mint:
+                uuid: >
+                  Deterministically mints a UUID-shaped instance key from the
+                  source event id plus receiver flow, receiver pin, and
+                  `instance_key.as`. It is replay-stable: the same committed
+                  event resolves to the same receiver instance and does not
+                  create another instance.
+                event_id: >
+                  Carries the source event id directly as the receiver instance
+                  key. The source event id must be present and non-empty.
+              runtime_policy: >
+                The lowered plan internally uses create/reuse lifecycle
+                semantics for this new resolution surface. Legacy
+                `instance.on_missing/on_conflict` remains authoritative only for
+                legacy addressless template instance-key composition; it does
+                not override `resolution.mode:create`.
+              fail_closed:
+              - missing, empty, or unsupported mint
+              - missing instance_key.as
+              - instance_key.as not matching the receiver single instance.by
+              - missing carries.<as>.from: instance.key.<as>
+              - type-incompatible carried key
+              - combined legacy input address
+              - combined connect.using.instance or connect.map
+              - delivery topology other than one
+              - unavailable template lifecycle activator
+            select:
+              status: spec_locked_not_runnable_in_1835_pr1
+              contract: >
+                Select routes to exactly one existing receiver instance by an
+                explicit instance key. Missing or ambiguous target is invalid;
+                this mode never creates an instance.
+            select-or-create:
+              status: spec_locked_not_runnable_in_1835_pr1
+              contract: >
+                Select-or-create resolves by explicit key and atomically creates
+                exactly one receiver instance when absent. Concurrent deliveries
+                for the same key must converge on one instance or fail closed.
+            fan-in:
+              status: spec_locked_not_runnable_in_1835_pr1
+              contract: >
+                Fan-in routes many source deliveries into one receiver instance
+                or aggregation context. `aggregation: stream|barrier` is the
+                locked sub-semantics selector. Stream delivers each accepted
+                event into the receiver context; barrier waits for the declared
+                close condition/window before releasing an aggregate result.
+            fan-out:
+              status: spec_locked_not_runnable_in_1835_pr1
+              contract: >
+                Fan-out routes one input event to a concrete set of receiver
+                instances selected by the route plan. Producer-authored
+                `target:{flow,match}` and broadcast rescue remain invalid for
+                common package topology; the route plan owns target-set
+                materialization.
+            reply:
+              status: spec_locked_not_runnable_in_1835_pr1
+              contract: >
+                Reply routes a response back to the originating request
+                instance. By default the platform mints and threads origin
+                instance identity plus request correlation from stable request
+                event identity. An explicit correlation override is reserved for
+                provider-supplied request/idempotency ids.
+          legacy_same_concept_seams:
+            non_authoritative_for_new_resolution_surface:
+            - flow.instance.by/on_missing/on_conflict as authoring shorthand for `resolution`
+            - TemplateInstanceContract as a standalone resolution authoring surface
+            - connect.using.instance for receiver-declared `resolution`
+            - route planning reconstructed from producer output key/carries when `resolution` is declared
+            - templateInstanceLifecycleOwner as a separate syntax interpreter
+            - create_flow_instance action syntax
+            - select_entity / select_or_create_entity
+            - producer target.flow / target.match / broadcast:true
+            migration_note: >
+              These seams remain only as legacy or adjacent owners until #1738
+              and #1827 retire old routing mechanisms after the new resolution
+              model is proven. They may be consumed as implementation substrate
+              when explicitly named here, but they do not own the new
+              `resolution:{mode,...}` semantics.
+          proof_obligations:
+          - contracts decode every locked mode and reject unknown resolution fields fail-closed
+          - bootverify accepts valid create resolution and rejects non-create modes as not runnable in this slice
+          - route-plan lowering records create mode, mint kind, carried `as` field, create/reuse lifecycle policy, and does not require producer output key/carries
+          - EventBus publish/preflight creates a missing receiver instance through the canonical lifecycle path
+          - downstream receiver routes can render the carried minted instance key from activation variables
+          - same committed event replay reuses persisted delivery route/scope and does not create another receiver instance
         implementation_slice_1546:
           status: merge_bearing_runtime_behavior
           canonical_code_owner: internal/runtime/core/pinrouting.ConnectRoutePlan.InstanceKey.Mappings + internal/runtime/bus.connectRoutePlanResolver


### PR DESCRIPTION
Part of #1835

## Summary

This PR design-locks the canonical `resolution:{mode,...}` instance-resolution model in `platform-spec.yaml` and adds the first runnable slice: `resolution.mode:create` with runtime-minted instance keys.

The create slice now supports `instance_key.mint: uuid|event_id`, carries the minted key through `instance.key.<field>`, validates the shape in bootverify, lowers it through connect route planning, and proves lifecycle activation plus replay/idempotency through EventBus integration tests.

## Governing Refs / Binding Context

- #1835 issue body/thread.
- #1835 design-lock decision: https://github.com/division-sh/swarm/issues/1835#issuecomment-4909318905
- #1835 pre-audit: https://github.com/division-sh/swarm/issues/1835#issuecomment-4909332367
- #1835 gate outcome: https://github.com/division-sh/swarm/issues/1835#issuecomment-4910257235
- Authoritative merge artifact: `platform-spec.yaml` -> `flow_model.flow_package.composition_routing.route_plan_lowering.implementation_slice_1835`.
- Adjacent governing context: #1786 routing model, #164 instance lifecycle, #1828 runnable examples, #1738/#1827 E1a retirement trackers, and #1807 input-source recognition.

## Semantic Migration

New canonical owner for this slice:

- `platform-spec.yaml` documents all six resolution modes and the PR1 create runtime contract.
- `FlowInputPinResolution` / `FlowInputPinResolutionInstanceKey` / `FlowInputPinCarries` are the typed contract owners.
- Strict YAML decode preserves and rejects unsupported `resolution`, `instance_key`, and `carries` fields.
- Bootverify consumes the typed owner and validates/fails closed on create-mode shapes.
- Connect route planning lowers `mode:create` to canonical route-plan instance key metadata.
- Template lifecycle consumes the lowered route-plan metadata to activate/reuse the minted instance.

Old/non-authoritative paths classified:

- `flow.instance.by/on_missing/on_conflict`, `TemplateInstanceContract`, `connect.using.instance`, `connect.map`, route planning legacy instance mapping, `templateInstanceLifecycleOwner`, `create_flow_instance`, `select_entity` / `select_or_create_entity`, and `target.flow` / `target.match` remain legacy or sibling seams tracked by #1738/#1827/#164/#1835.
- This PR does not retire legacy spellings; it makes `resolution.mode:create` canonical for new create-resolution semantics.
- Migration is complete for the chosen PR1 create-resolution slice. The full #1835 parent remains open for select, select-or-create, fan-in, fan-out, reply, and E1a retirement proof.

Production paths checked for surviving old behavior:

- Contract decode/normalization.
- Bootverify composition connect validation.
- Connect route-plan lowering.
- EventBus preflight/publish/replay route delivery.
- Template instance lifecycle activation/materialization.
- Existing static ingress/connect/harness behavior remains under #1807/connect, not new create resolution runtime.

## Validation

- `git diff --check`
- `ruby -e 'require "yaml"; YAML.load_file("platform-spec.yaml"); puts "yaml ok"'`
- `SWARM_TEST_POSTGRES_DSN='host=127.0.0.1 port=5432 user=youmew dbname=postgres sslmode=disable' PGPASSWORD=postgres go test ./...`
