### PR TITLE
[agent-b][issue #1843] Retire workspace tooling env authority

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,13 +33,12 @@ jobs:
         run: docker build -t swarm-workspace:latest -f Dockerfile.workspace .
 
       - name: Prove no-selector SQLite local run
-        env:
-          SWARM_WORKSPACE_DATA_SOURCE: ${{ github.workspace }}/data
         run: |
           payload=$(mktemp)
           printf '{"entity_id":"11111111-1111-4111-8111-111111111111"}\n' > "$payload"
           ./swarm run start \
             --contracts tests/tier1-primitives/test-emits-single \
+            --data "${{ github.workspace }}/data" \
             --event item.received \
             --payload "$payload" \
             --api-port 18091

--- a/cmd/swarm/builder_project_supervisor.go
+++ b/cmd/swarm/builder_project_supervisor.go
@@ -100,7 +100,7 @@ func newRuntimeProjectSupervisor(
 			if err != nil {
 				return nil, workspaceBackendSelection{}, err
 			}
-			lifecycle, err := configuredWorkspaceLifecycleForBackend(stores.facade().workspaceDB(), contractsRoot, source, mountSources, decision)
+			lifecycle, err := configuredWorkspaceLifecycleForBackend(stores.facade().workspaceDB(), cfg, contractsRoot, source, mountSources, decision)
 			if err != nil {
 				return nil, decision, err
 			}

--- a/cmd/swarm/builder_project_supervisor_test.go
+++ b/cmd/swarm/builder_project_supervisor_test.go
@@ -438,7 +438,7 @@ func TestRuntimeProjectSupervisorOpenProjectNoAgentSkipsWorkspaceLifecycle(t *te
 		if err != nil {
 			return nil, workspaceBackendSelection{}, err
 		}
-		lifecycle, err := configuredWorkspaceLifecycleForBackend(stores.facade().workspaceDB(), contractsRoot, source, mountSources, decision)
+		lifecycle, err := configuredWorkspaceLifecycleForBackend(stores.facade().workspaceDB(), supervisor.cfg, contractsRoot, source, mountSources, decision)
 		if err != nil {
 			return nil, decision, err
 		}

--- a/cmd/swarm/cli.go
+++ b/cmd/swarm/cli.go
@@ -108,7 +108,7 @@ with 'swarm run trace', 'swarm event list', and 'swarm mailbox'.`,
 	}
 	addToGroup(commandGroupStart,
 		newDoctorCommand(ctx, repo),
-		newWorkspaceCommand(ctx),
+		newWorkspaceCommand(ctx, opts.repoRoot),
 		newContextCommand(ctx, opts),
 		newServeCommand(ctx, repo, opts.runServe),
 		newVersionCommand(opts),

--- a/cmd/swarm/doctor.go
+++ b/cmd/swarm/doctor.go
@@ -138,7 +138,7 @@ func runDoctorCommand(ctx context.Context, repo string, cmd *cobra.Command, opts
 	workspaceBackend, err := resolveWorkspaceBackend(opts.workspaceBackend, opts.workspaceBackendSet, cfgResult.Config)
 	if err != nil {
 		report := newReport()
-		report.add(localPreflightWorkspacePrerequisite, "workspace_backend_invalid", localPreflightSeverityBlocker, localPreflightStatusFailed, err.Error(), "fix --workspace-backend, workspace.backend, or SWARM_WORKSPACE_BACKEND")
+		report.add(localPreflightWorkspacePrerequisite, "workspace_backend_invalid", localPreflightSeverityBlocker, localPreflightStatusFailed, err.Error(), "fix --workspace-backend or workspace.backend")
 		return returnLocalPreflightResult(cmd, report.finalize(), opts.asJSON)
 	}
 	cliCfg, err := loadCLIAPIConfigFile()
@@ -164,7 +164,7 @@ func runDoctorCommand(ctx context.Context, repo string, cmd *cobra.Command, opts
 	})
 	if err != nil {
 		report := newReport()
-		report.add(localPreflightWorkspacePrerequisite, "workspace_data_source_invalid", localPreflightSeverityBlocker, localPreflightStatusFailed, err.Error(), "fix --data, workspace.data_source, or SWARM_WORKSPACE_DATA_SOURCE")
+		report.add(localPreflightWorkspacePrerequisite, "workspace_data_source_invalid", localPreflightSeverityBlocker, localPreflightStatusFailed, err.Error(), "fix --data or workspace.data_source")
 		return returnLocalPreflightResult(cmd, report.finalize(), opts.asJSON)
 	}
 	report := runLocalClaudeCLIPreflight(ctx, localPreflightRequest{

--- a/cmd/swarm/doctor_test.go
+++ b/cmd/swarm/doctor_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"net"
 	"os"
 	"path/filepath"
@@ -42,7 +43,7 @@ func setDoctorProviderSecrets(t *testing.T, values map[string]string) {
 }
 
 func TestDoctorClaudeCLIPreflightReportsMissingPrerequisites(t *testing.T) {
-	configureDoctorDockerStub(t)
+	dockerBin := configureDoctorDockerStub(t)
 	setDoctorEmptyProviderSecrets(t)
 	t.Setenv("CLAUDE_CODE_OAUTH_TOKEN", "")
 	t.Setenv("SWARM_TEST_DOCKER_IMAGE_MISSING", "1")
@@ -51,7 +52,7 @@ func TestDoctorClaudeCLIPreflightReportsMissingPrerequisites(t *testing.T) {
 	t.Setenv("SWARM_TOOL_GATEWAY_TOKEN", "")
 
 	var stdout, stderr bytes.Buffer
-	code := executeRootCommandWithOptions(context.Background(), repoRoot(), doctorClaudeArgs(t, writeDoctorClaudeConfig(t), false), &stdout, &stderr, defaultRootCommandOptions())
+	code := executeRootCommandWithOptions(context.Background(), repoRoot(), doctorClaudeArgs(t, writeDoctorClaudeConfig(t, dockerBin), false), &stdout, &stderr, defaultRootCommandOptions())
 	if code != cliExitRuntime {
 		t.Fatalf("code = %d, want %d stdout=%s stderr=%s", code, cliExitRuntime, stdout.String(), stderr.String())
 	}
@@ -60,7 +61,7 @@ func TestDoctorClaudeCLIPreflightReportsMissingPrerequisites(t *testing.T) {
 		"backend_prerequisite/missing_backend_credential",
 		"workspace_prerequisite/workspace_image_unavailable",
 		"swarm secrets set CLAUDE_CODE_OAUTH_TOKEN",
-		"set SWARM_WORKSPACE_IMAGE",
+		"set workspace.image",
 	} {
 		if !strings.Contains(stdout.String(), want) {
 			t.Fatalf("doctor output missing %q:\n%s", want, stdout.String())
@@ -72,7 +73,7 @@ func TestDoctorClaudeCLIPreflightReportsMissingPrerequisites(t *testing.T) {
 }
 
 func TestDoctorClaudeCLIPreflightReportsMissingDocker(t *testing.T) {
-	configureDoctorDockerStub(t)
+	dockerBin := configureDoctorDockerStub(t)
 	setDoctorProviderSecret(t, "CLAUDE_CODE_OAUTH_TOKEN", "oauth-token")
 	t.Setenv("SWARM_TEST_DOCKER_UNAVAILABLE", "1")
 	t.Setenv("SWARM_TOOL_GATEWAY_URL", "")
@@ -80,14 +81,14 @@ func TestDoctorClaudeCLIPreflightReportsMissingDocker(t *testing.T) {
 	t.Setenv("SWARM_TOOL_GATEWAY_TOKEN", "")
 
 	var stdout, stderr bytes.Buffer
-	code := executeRootCommandWithOptions(context.Background(), repoRoot(), doctorClaudeArgs(t, writeDoctorClaudeConfig(t), false), &stdout, &stderr, defaultRootCommandOptions())
+	code := executeRootCommandWithOptions(context.Background(), repoRoot(), doctorClaudeArgs(t, writeDoctorClaudeConfig(t, dockerBin), false), &stdout, &stderr, defaultRootCommandOptions())
 	if code != cliExitRuntime {
 		t.Fatalf("code = %d, want %d stdout=%s stderr=%s", code, cliExitRuntime, stdout.String(), stderr.String())
 	}
 	for _, want := range []string{
 		"workspace_prerequisite/docker_unavailable",
 		"docker is not available",
-		"start Docker or set SWARM_DOCKER_BIN",
+		"start Docker, set workspace.docker_bin",
 	} {
 		if !strings.Contains(stdout.String(), want) {
 			t.Fatalf("doctor output missing %q:\n%s", want, stdout.String())
@@ -96,14 +97,14 @@ func TestDoctorClaudeCLIPreflightReportsMissingDocker(t *testing.T) {
 }
 
 func TestDoctorClaudeCLIPreflightJSONReportsOKWithoutDB(t *testing.T) {
-	configureDoctorDockerStub(t)
+	dockerBin := configureDoctorDockerStub(t)
 	t.Setenv("CLAUDE_CODE_OAUTH_TOKEN", "stale-oauth-token")
 	setDoctorProviderSecret(t, "CLAUDE_CODE_OAUTH_TOKEN", "oauth-token")
 	t.Setenv("SWARM_TOOL_GATEWAY_URL", "")
 	t.Setenv("SWARM_TOOL_GATEWAY_CONTAINER_URL", "")
 	t.Setenv("SWARM_TOOL_GATEWAY_TOKEN", "")
 
-	args := doctorClaudeArgs(t, writeDoctorClaudeConfig(t), true)
+	args := doctorClaudeArgs(t, writeDoctorClaudeConfig(t, dockerBin), true)
 	var stdout, stderr bytes.Buffer
 	code := executeRootCommandWithOptions(context.Background(), repoRoot(), args, &stdout, &stderr, defaultRootCommandOptions())
 	if code != 0 {
@@ -158,7 +159,7 @@ func TestDoctorClaudeCLIPreflightSkipsCredentialForAgentFreeContracts(t *testing
 	t.Setenv("SWARM_TOOL_GATEWAY_CONTAINER_URL", "")
 	t.Setenv("SWARM_TOOL_GATEWAY_TOKEN", "")
 
-	args := doctorClaudeArgs(t, writeDoctorClaudeConfig(t), false)
+	args := doctorClaudeArgs(t, writeDoctorClaudeConfig(t, ""), false)
 	for i := 0; i+1 < len(args); i++ {
 		if args[i] == "--contracts" {
 			args[i+1] = writeDoctorAgentFreeContractsFixture(t)
@@ -195,7 +196,7 @@ func TestDoctorClaudeCLIPreflightReportsTelegramConnectorToolSurface(t *testing.
 	t.Setenv("SWARM_TOOL_GATEWAY_TOKEN", "")
 	setDoctorProviderSecret(t, "telegram_bot_token", "provider-secret")
 
-	args := doctorClaudeArgs(t, writeDoctorClaudeConfig(t), true)
+	args := doctorClaudeArgs(t, writeDoctorClaudeConfig(t, ""), true)
 	for i := 0; i+1 < len(args); i++ {
 		if args[i] == "--contracts" {
 			args[i+1] = writeDoctorTelegramConnectorContractsFixture(t)
@@ -231,7 +232,7 @@ func TestDoctorClaudeCLIPreflightReportsTelegramConnectorToolSurface(t *testing.
 }
 
 func TestDoctorClaudeCLIPreflightReportsMissingWorkspaceCLI(t *testing.T) {
-	configureDoctorDockerStub(t)
+	dockerBin := configureDoctorDockerStub(t)
 	setDoctorProviderSecret(t, "CLAUDE_CODE_OAUTH_TOKEN", "oauth-token")
 	t.Setenv("SWARM_TEST_DOCKER_CLI_MISSING", "1")
 	t.Setenv("SWARM_TOOL_GATEWAY_URL", "")
@@ -239,7 +240,7 @@ func TestDoctorClaudeCLIPreflightReportsMissingWorkspaceCLI(t *testing.T) {
 	t.Setenv("SWARM_TOOL_GATEWAY_TOKEN", "")
 
 	var stdout, stderr bytes.Buffer
-	code := executeRootCommandWithOptions(context.Background(), repoRoot(), doctorClaudeArgs(t, writeDoctorClaudeConfig(t), false), &stdout, &stderr, defaultRootCommandOptions())
+	code := executeRootCommandWithOptions(context.Background(), repoRoot(), doctorClaudeArgs(t, writeDoctorClaudeConfig(t, dockerBin), false), &stdout, &stderr, defaultRootCommandOptions())
 	if code != cliExitRuntime {
 		t.Fatalf("code = %d, want %d stdout=%s stderr=%s", code, cliExitRuntime, stdout.String(), stderr.String())
 	}
@@ -256,7 +257,7 @@ func TestDoctorClaudeCLIPreflightReportsMissingWorkspaceCLI(t *testing.T) {
 }
 
 func TestDoctorClaudeCLIPreflightReportsBrokenWorkspaceCLI(t *testing.T) {
-	configureDoctorDockerStub(t)
+	dockerBin := configureDoctorDockerStub(t)
 	setDoctorProviderSecret(t, "CLAUDE_CODE_OAUTH_TOKEN", "oauth-token")
 	t.Setenv("SWARM_TEST_DOCKER_CLI_BROKEN", "1")
 	t.Setenv("SWARM_TOOL_GATEWAY_URL", "")
@@ -264,7 +265,7 @@ func TestDoctorClaudeCLIPreflightReportsBrokenWorkspaceCLI(t *testing.T) {
 	t.Setenv("SWARM_TOOL_GATEWAY_TOKEN", "")
 
 	var stdout, stderr bytes.Buffer
-	code := executeRootCommandWithOptions(context.Background(), repoRoot(), doctorClaudeArgs(t, writeDoctorClaudeConfig(t), false), &stdout, &stderr, defaultRootCommandOptions())
+	code := executeRootCommandWithOptions(context.Background(), repoRoot(), doctorClaudeArgs(t, writeDoctorClaudeConfig(t, dockerBin), false), &stdout, &stderr, defaultRootCommandOptions())
 	if code != cliExitRuntime {
 		t.Fatalf("code = %d, want %d stdout=%s stderr=%s", code, cliExitRuntime, stdout.String(), stderr.String())
 	}
@@ -286,7 +287,7 @@ func TestDoctorClaudeCLIPreflightUsesCredentialStoreForContractSecrets(t *testin
 	t.Setenv("SWARM_TOOL_GATEWAY_CONTAINER_URL", "")
 	t.Setenv("SWARM_TOOL_GATEWAY_TOKEN", "")
 
-	args := doctorClaudeArgs(t, writeDoctorClaudeConfig(t), false)
+	args := doctorClaudeArgs(t, writeDoctorClaudeConfig(t, ""), false)
 	for i := 0; i+1 < len(args); i++ {
 		if args[i] == "--contracts" {
 			args[i+1] = writeSecretsCommandContractsFixture(t)
@@ -315,7 +316,7 @@ func TestDoctorClaudeCLIPreflightReportsRetiredBackendEnv(t *testing.T) {
 	setDoctorProviderSecret(t, "CLAUDE_CODE_OAUTH_TOKEN", "oauth-token")
 
 	var stdout, stderr bytes.Buffer
-	code := executeRootCommandWithOptions(context.Background(), repoRoot(), doctorClaudeArgs(t, writeDoctorClaudeConfig(t), false), &stdout, &stderr, defaultRootCommandOptions())
+	code := executeRootCommandWithOptions(context.Background(), repoRoot(), doctorClaudeArgs(t, writeDoctorClaudeConfig(t, ""), false), &stdout, &stderr, defaultRootCommandOptions())
 	if code != cliExitRuntime {
 		t.Fatalf("code = %d, want %d stdout=%s stderr=%s", code, cliExitRuntime, stdout.String(), stderr.String())
 	}
@@ -331,7 +332,7 @@ func TestDoctorClaudeCLIPreflightReportsRetiredBackendEnv(t *testing.T) {
 }
 
 func TestDoctorClaudeCLIPreflightBlocksGeneratedGatewayParentEnv(t *testing.T) {
-	configureDoctorDockerStub(t)
+	dockerBin := configureDoctorDockerStub(t)
 	setDoctorProviderSecret(t, "CLAUDE_CODE_OAUTH_TOKEN", "oauth-token")
 	t.Setenv("SWARM_TOOL_GATEWAY_TOKEN", "operator-token")
 
@@ -339,7 +340,7 @@ func TestDoctorClaudeCLIPreflightBlocksGeneratedGatewayParentEnv(t *testing.T) {
 	t.Setenv("SWARM_TOOL_GATEWAY_URL", "http://127.0.0.1:"+mcpPort)
 	t.Setenv("SWARM_TOOL_GATEWAY_CONTAINER_URL", "http://host.docker.internal:"+mcpPort)
 
-	args := doctorClaudeArgs(t, writeDoctorClaudeConfig(t), false)
+	args := doctorClaudeArgs(t, writeDoctorClaudeConfig(t, dockerBin), false)
 	args = append(args[:len(args)-4], "--api-listen-addr", "127.0.0.1:0", "--mcp-listen-addr", "127.0.0.1:"+mcpPort)
 	var stdout, stderr bytes.Buffer
 	code := executeRootCommandWithOptions(context.Background(), repoRoot(), args, &stdout, &stderr, defaultRootCommandOptions())
@@ -676,7 +677,7 @@ func TestDoctorAPIFlagsRequireTargetMode(t *testing.T) {
 }
 
 func TestRunServeRuntimeConsumesLocalClaudePreflightAfterBundleDecision(t *testing.T) {
-	configureDoctorDockerStub(t)
+	dockerBin := configureDoctorDockerStub(t)
 	setDoctorEmptyProviderSecrets(t)
 	t.Setenv("CLAUDE_CODE_OAUTH_TOKEN", "")
 	t.Setenv("SWARM_TOOL_GATEWAY_URL", "")
@@ -685,7 +686,7 @@ func TestRunServeRuntimeConsumesLocalClaudePreflightAfterBundleDecision(t *testi
 
 	var out bytes.Buffer
 	code := runServeRuntime(context.Background(), repoRoot(), serveOptions{
-		ConfigPath:         writeDoctorClaudeConfig(t),
+		ConfigPath:         writeDoctorClaudeConfig(t, dockerBin),
 		ContractsPath:      doctorAgentContractsPath,
 		DataSource:         t.TempDir(),
 		PlatformSpecPath:   defaultPlatformSpecPath,
@@ -947,14 +948,21 @@ func doctorClaudeArgs(t *testing.T, configPath string, asJSON bool) []string {
 
 const doctorAgentContractsPath = "tests/tier8-boot-verification/test-boot-prompt-stub"
 
-func writeDoctorClaudeConfig(t *testing.T) string {
+func writeDoctorClaudeConfig(t *testing.T, dockerBin string) string {
 	t.Helper()
 	path := filepath.Join(t.TempDir(), "claude.yaml")
+	workspace := []string{
+		"workspace:",
+		"  data_source: " + t.TempDir(),
+		"  image: doctor-test-image:latest",
+	}
+	if strings.TrimSpace(dockerBin) != "" {
+		workspace = append(workspace, fmt.Sprintf("  docker_bin: %q", dockerBin))
+	}
 	writeRuntimeConfigText(t, path, strings.Join([]string{
 		"runtime:",
 		"  recovery_on_startup: false",
-		"workspace:",
-		"  data_source: " + t.TempDir(),
+		strings.Join(workspace, "\n"),
 		"llm:",
 		"  backend: claude_cli",
 		"  session:",
@@ -1059,7 +1067,7 @@ telegram.send_message:
 	return root
 }
 
-func configureDoctorDockerStub(t *testing.T) {
+func configureDoctorDockerStub(t *testing.T) string {
 	t.Helper()
 	path := filepath.Join(t.TempDir(), "docker")
 	script := `#!/bin/sh
@@ -1101,9 +1109,7 @@ esac
 	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
 		t.Fatalf("write docker stub: %v", err)
 	}
-	t.Setenv("SWARM_DOCKER_BIN", path)
-	t.Setenv("SWARM_WORKSPACE_IMAGE", "doctor-test-image:latest")
-	t.Setenv("SWARM_WORKSPACE_VOLUMES_FROM", "")
+	return path
 }
 
 func freeDoctorTCPPort(t *testing.T) string {

--- a/cmd/swarm/env_authority_test.go
+++ b/cmd/swarm/env_authority_test.go
@@ -65,7 +65,7 @@ func TestDoctorCommandIgnoresMalformedRepoDotEnv(t *testing.T) {
 	code := executeRootCommandWithOptions(context.Background(), repo, []string{
 		"doctor",
 		"--backend", "claude_cli",
-		"--config", writeDoctorClaudeConfig(t),
+		"--config", writeDoctorClaudeConfig(t, ""),
 		"--contracts", contractsRoot,
 		"--platform-spec", defaultPlatformSpecPath,
 		"--data", t.TempDir(),
@@ -199,13 +199,13 @@ func TestPlatformSpecIssue1640EnvClassificationCoversRetainedSlice(t *testing.T)
 	}
 
 	authority := spec.EnvironmentSourceAuthority.WorkspaceMonitorArtifactDebugSlice
-	if authority.PromotedBy != "#1640" || authority.ParentTracker != "#1600" || authority.ImplementationStatus != "classification_spec_lock_only" {
+	if authority.PromotedBy != "#1640" || authority.ParentTracker != "#1600" || authority.ImplementationStatus != "classification_updated_by_1843" {
 		t.Fatalf("#1640 env authority status = promoted_by:%q parent:%q status:%q", authority.PromotedBy, authority.ParentTracker, authority.ImplementationStatus)
 	}
 	if !strings.Contains(authority.CanonicalOwner, "environment_source_authority.workspace_monitor_artifact_debug_slice") {
 		t.Fatalf("#1640 canonical owner = %q", authority.CanonicalOwner)
 	}
-	for _, want := range []string{"classification authority", "#1731", "does not implement unknown-env", "Public docs"} {
+	for _, want := range []string{"classification authority", "#1731", "guard/doctor enforcement", "Public docs"} {
 		if !strings.Contains(authority.Scope+authority.ClassificationRule+authority.PublicDocQuarantine.Rule, want) {
 			t.Fatalf("#1640 env authority missing %q:\n%#v", want, authority)
 		}
@@ -215,9 +215,9 @@ func TestPlatformSpecIssue1640EnvClassificationCoversRetainedSlice(t *testing.T)
 	}
 
 	for name, wantDisposition := range map[string]string{
-		"existing_config_owned_workspace_sources":     "existing_config_owned_env_source",
-		"production_bootstrap_or_deployment_plumbing": "keep_env_first_slice_bootstrap_or_deployment_plumbing",
-		"internal_workspace_lifecycle_names":          "keep_env_first_slice_internal_runtime_plumbing",
+		"existing_config_owned_workspace_sources":     "retired_by_1843_to_flags_or_typed_workspace_config",
+		"production_bootstrap_or_deployment_plumbing": "retired_by_1843_to_workspace_config_or_internal_defaults",
+		"internal_workspace_lifecycle_names":          "retired_by_1843_internal_generated_defaults",
 		"runtime_private_storage_and_observability":   "keep_env_first_slice_runtime_private_storage_or_observability",
 		"internal_prompt_and_spec_helpers":            "keep_env_first_slice_internal_developer_helper",
 		"debug_and_test_quarantine":                   "keep_env_first_slice_debug_or_test_quarantine",

--- a/cmd/swarm/env_guard.go
+++ b/cmd/swarm/env_guard.go
@@ -572,6 +572,27 @@ func swarmEnvCatalogEntries() []swarmEnvCatalogEntry {
 			"unset "+name+"; set "+key+" in unified swarm.yaml/runtime config",
 		)
 	}
+	retiredWorkspaceConfig := func(name, key string) swarmEnvCatalogEntry {
+		return retired(
+			name,
+			name+" is retired as workspace/tooling environment source; use "+key,
+			"unset "+name+"; set "+key+" in unified swarm.yaml/runtime config",
+		)
+	}
+	retiredWorkspaceFlagOrConfig := func(name, replacement string) swarmEnvCatalogEntry {
+		return retired(
+			name,
+			name+" is retired as workspace/tooling environment source; use "+replacement,
+			"unset "+name+"; use "+replacement,
+		)
+	}
+	retiredWorkspaceInternal := func(name string) swarmEnvCatalogEntry {
+		return retired(
+			name,
+			name+" is retired as workspace lifecycle environment source; this value is internal runtime plumbing",
+			"unset "+name+"; no supported env replacement exists",
+		)
+	}
 	retiredUnsupported := func(name string) swarmEnvCatalogEntry {
 		return retired(
 			name,
@@ -605,26 +626,26 @@ func swarmEnvCatalogEntries() []swarmEnvCatalogEntry {
 		retiredStoreDatabaseConfig("SWARM_DB_SSLMODE", "database.sslmode"),
 		retiredStoreDatabaseConfig("SWARM_DB_POOL_SIZE", "database.pool_size"),
 		retired("SWARM_DB_PASSWORD", "SWARM_DB_PASSWORD is not read implicitly; it is accepted only when explicitly named by database.password_env", "unset SWARM_DB_PASSWORD or declare database.password_env: SWARM_DB_PASSWORD in the runtime config"),
-		seeded("SWARM_WORKSPACE_DATA_SOURCE", "platform-spec.yaml#workspace_model.data_source_authority", "#1600 workspace.data_source"),
-		seeded("SWARM_WORKSPACE_BACKEND", "platform-spec.yaml#workspace_model.workspace_backend_selection", "#1600 workspace.backend"),
-		seeded("SWARM_DOCKER_BIN", "platform-spec.yaml#environment_source_authority.workspace_monitor_artifact_debug_slice", "#1600 workspace/tooling config"),
-		seeded("SWARM_WORKSPACE_IMAGE", "platform-spec.yaml#workspace_model.runtime_image_packaging", "#1600 workspace.image"),
-		seeded("SWARM_WORKSPACE_HOST_ROOT", "platform-spec.yaml#workspace_model.workspace_backend_selection", "#1600 workspace.host_root"),
-		seeded("SWARM_WORKSPACE_VOLUMES_FROM", "platform-spec.yaml#workspace_model.data_source_authority", "#1600 workspace volumes config"),
-		seeded("SWARM_WORKSPACE_NETWORK", "platform-spec.yaml#environment_source_authority.workspace_monitor_artifact_debug_slice", "#1600 workspace network config"),
-		seeded("SWARM_WORKSPACE_DATA_MOUNT", "platform-spec.yaml#environment_source_authority.workspace_monitor_artifact_debug_slice", "#1600 workspace mount config"),
-		seeded("SWARM_WORKSPACE_CONTRACTS_SOURCE", "platform-spec.yaml#environment_source_authority.workspace_monitor_artifact_debug_slice", "#1600 workspace contracts source config"),
-		seeded("SWARM_WORKSPACE_CONTRACTS_MOUNT", "platform-spec.yaml#environment_source_authority.workspace_monitor_artifact_debug_slice", "#1600 workspace contracts mount config"),
-		seeded("SWARM_SCAFFOLD_CONTAINER", "platform-spec.yaml#environment_source_authority.workspace_monitor_artifact_debug_slice", "#1600 workspace lifecycle config"),
-		seeded("SWARM_SCAFFOLD_WORKDIR", "platform-spec.yaml#environment_source_authority.workspace_monitor_artifact_debug_slice", "#1600 workspace lifecycle config"),
-		seeded("SWARM_SCAFFOLD_VOLUME", "platform-spec.yaml#environment_source_authority.workspace_monitor_artifact_debug_slice", "#1600 workspace lifecycle config"),
-		seeded("SWARM_SYSTEM_CONTAINER", "platform-spec.yaml#environment_source_authority.workspace_monitor_artifact_debug_slice", "#1600 workspace lifecycle config"),
-		seeded("SWARM_SYSTEM_WORKDIR", "platform-spec.yaml#environment_source_authority.workspace_monitor_artifact_debug_slice", "#1600 workspace lifecycle config"),
-		seeded("SWARM_SYSTEM_ENTITIES_VOLUME", "platform-spec.yaml#environment_source_authority.workspace_monitor_artifact_debug_slice", "#1600 workspace lifecycle config"),
-		seeded("SWARM_SYSTEM_NGINX_VOLUME", "platform-spec.yaml#environment_source_authority.workspace_monitor_artifact_debug_slice", "#1600 workspace lifecycle config"),
-		seeded("SWARM_SYSTEM_SYSTEMD_VOLUME", "platform-spec.yaml#environment_source_authority.workspace_monitor_artifact_debug_slice", "#1600 workspace lifecycle config"),
-		seeded("SWARM_ENTITY_CONTAINER_PREFIX", "platform-spec.yaml#environment_source_authority.workspace_monitor_artifact_debug_slice", "#1600 workspace lifecycle config"),
-		seeded("SWARM_ENTITY_WORKDIR", "platform-spec.yaml#environment_source_authority.workspace_monitor_artifact_debug_slice", "#1600 workspace lifecycle config"),
+		retiredWorkspaceFlagOrConfig("SWARM_WORKSPACE_DATA_SOURCE", "--data or workspace.data_source"),
+		retiredWorkspaceFlagOrConfig("SWARM_WORKSPACE_BACKEND", "--workspace-backend or workspace.backend"),
+		retiredWorkspaceFlagOrConfig("SWARM_DOCKER_BIN", "--docker-bin for workspace build or workspace.docker_bin"),
+		retiredWorkspaceFlagOrConfig("SWARM_WORKSPACE_IMAGE", "--image for workspace build or workspace.image"),
+		retiredWorkspaceConfig("SWARM_WORKSPACE_HOST_ROOT", "workspace.host_root"),
+		retiredWorkspaceConfig("SWARM_WORKSPACE_VOLUMES_FROM", "workspace.volumes_from"),
+		retiredWorkspaceConfig("SWARM_WORKSPACE_NETWORK", "workspace.network"),
+		retiredWorkspaceInternal("SWARM_WORKSPACE_DATA_MOUNT"),
+		retiredWorkspaceFlagOrConfig("SWARM_WORKSPACE_CONTRACTS_SOURCE", "--contracts"),
+		retiredWorkspaceInternal("SWARM_WORKSPACE_CONTRACTS_MOUNT"),
+		retiredWorkspaceInternal("SWARM_SCAFFOLD_CONTAINER"),
+		retiredWorkspaceInternal("SWARM_SCAFFOLD_WORKDIR"),
+		retiredWorkspaceInternal("SWARM_SCAFFOLD_VOLUME"),
+		retiredWorkspaceInternal("SWARM_SYSTEM_CONTAINER"),
+		retiredWorkspaceInternal("SWARM_SYSTEM_WORKDIR"),
+		retiredWorkspaceInternal("SWARM_SYSTEM_ENTITIES_VOLUME"),
+		retiredWorkspaceInternal("SWARM_SYSTEM_NGINX_VOLUME"),
+		retiredWorkspaceInternal("SWARM_SYSTEM_SYSTEMD_VOLUME"),
+		retiredWorkspaceInternal("SWARM_ENTITY_CONTAINER_PREFIX"),
+		retiredWorkspaceInternal("SWARM_ENTITY_WORKDIR"),
 		retiredRuntimeConfig("SWARM_RUNTIME_RECOVERY_ON_STARTUP", "runtime.recovery_on_startup"),
 		retired("SWARM_RUNTIME_MAX_CONCURRENT_AGENTS", "SWARM_RUNTIME_MAX_CONCURRENT_AGENTS is unsupported inert runtime control", "remove it; no runtime path enforces this control"),
 		retired("SWARM_RUNTIME_EVENT_POLL_INTERVAL", "SWARM_RUNTIME_EVENT_POLL_INTERVAL is unsupported inert runtime control", "remove it; no runtime path enforces this control"),

--- a/cmd/swarm/local_preflight.go
+++ b/cmd/swarm/local_preflight.go
@@ -171,7 +171,7 @@ func runLocalClaudeCLIPreflight(ctx context.Context, req localPreflightRequest) 
 		}
 		report.add(localPreflightBackendPrerequisite, "backend_credential_present", localPreflightSeverityInfo, localPreflightStatusOK, message, "")
 	}
-	report.checkWorkspace(ctx, source, contractsRoot, req.MountSources, workspaceBackend, req.Config.LLM.ClaudeCLI.Command)
+	report.checkWorkspace(ctx, req.Config, source, contractsRoot, req.MountSources, workspaceBackend, req.Config.LLM.ClaudeCLI.Command)
 	return report.finalize()
 }
 
@@ -308,8 +308,8 @@ func (r *localPreflightReport) checkContractSecrets(ctx context.Context, source 
 	}
 }
 
-func (r *localPreflightReport) checkWorkspace(ctx context.Context, source semanticview.Source, contractsRoot string, mountSources workspaceMountSources, backend workspaceBackendSelection, claudeCLICommand string) {
-	workspaces, err := configuredWorkspaceLifecycleForServe(nil, contractsRoot, source, mountSources, backend)
+func (r *localPreflightReport) checkWorkspace(ctx context.Context, cfg *config.Config, source semanticview.Source, contractsRoot string, mountSources workspaceMountSources, backend workspaceBackendSelection, claudeCLICommand string) {
+	workspaces, err := configuredWorkspaceLifecycleForServe(nil, cfg, contractsRoot, source, mountSources, backend)
 	if err != nil {
 		r.add(localPreflightWorkspacePrerequisite, "workspace_config_invalid", localPreflightSeverityBlocker, localPreflightStatusFailed, err.Error(), "fix workspace backend or mount configuration")
 		return
@@ -328,12 +328,12 @@ func (r *localPreflightReport) checkWorkspace(ctx context.Context, source semant
 		return
 	}
 	if err := dockerManager.CheckDockerAvailable(ctx); err != nil {
-		r.add(localPreflightWorkspacePrerequisite, "docker_unavailable", localPreflightSeverityBlocker, localPreflightStatusFailed, err.Error(), "start Docker or set SWARM_DOCKER_BIN to a working Docker-compatible CLI")
+		r.add(localPreflightWorkspacePrerequisite, "docker_unavailable", localPreflightSeverityBlocker, localPreflightStatusFailed, err.Error(), "start Docker, set workspace.docker_bin in runtime config, or pass --docker-bin to `swarm workspace build`")
 	} else {
 		r.add(localPreflightWorkspacePrerequisite, "docker_available", localPreflightSeverityInfo, localPreflightStatusOK, "Docker is reachable", "")
 	}
 	if err := dockerManager.CheckWorkspaceImageAvailable(ctx); err != nil {
-		r.add(localPreflightWorkspacePrerequisite, "workspace_image_unavailable", localPreflightSeverityBlocker, localPreflightStatusFailed, err.Error(), "run `swarm workspace build --backend claude_cli`, pull the configured workspace image, or set SWARM_WORKSPACE_IMAGE")
+		r.add(localPreflightWorkspacePrerequisite, "workspace_image_unavailable", localPreflightSeverityBlocker, localPreflightStatusFailed, err.Error(), "run `swarm workspace build --backend claude_cli`, pull the configured workspace image, or set workspace.image")
 	} else {
 		r.add(localPreflightWorkspacePrerequisite, "workspace_image_available", localPreflightSeverityInfo, localPreflightStatusOK, "workspace image is available", "")
 	}

--- a/cmd/swarm/local_runtime_state.go
+++ b/cmd/swarm/local_runtime_state.go
@@ -180,9 +180,11 @@ func legacyProjectSQLiteStoreError(project localRuntimeStateProject, selection s
 }
 
 func resolveWorkspaceMountSourcesForLocalState(repoRoot string, flagDataSource string, cfg *config.Config, project localRuntimeStateProject, createDefault bool) (workspaceMountSources, error) {
-	envDataSource, envDataSourceSet := os.LookupEnv(envWorkspaceDataSource)
 	configDataSource, configDataSourceSet := runtimeConfigWorkspaceDataSource(cfg)
-	volumesFrom, volumesFromSet := os.LookupEnv(envWorkspaceVolumesFrom)
+	volumesFrom, volumesFromSet, err := runtimeConfigWorkspaceVolumesFrom(cfg)
+	if err != nil {
+		return workspaceMountSources{}, err
+	}
 	defaultDataSource := ""
 	defaultSource := ""
 	if project.ProjectLocal && strings.TrimSpace(project.CanonicalProjectRoot) != "" {
@@ -194,8 +196,6 @@ func resolveWorkspaceMountSourcesForLocalState(repoRoot string, flagDataSource s
 		FlagDataSource:          flagDataSource,
 		ConfigDataSource:        configDataSource,
 		ConfigDataSourceSet:     configDataSourceSet,
-		EnvDataSource:           envDataSource,
-		EnvDataSourceSet:        envDataSourceSet,
 		VolumesFrom:             volumesFrom,
 		VolumesFromSet:          volumesFromSet,
 		DefaultDataSource:       defaultDataSource,

--- a/cmd/swarm/main.go
+++ b/cmd/swarm/main.go
@@ -76,8 +76,8 @@ const (
 var (
 	buildStoresForServe                  = buildStores
 	runtimeConfigExecutablePath          = os.Executable
-	configuredWorkspaceLifecycleForServe = func(db *sql.DB, contractsRoot string, source semanticview.Source, mountSources workspaceMountSources, backend workspaceBackendSelection) (serveWorkspaceLifecycle, error) {
-		return configuredWorkspaceLifecycleForBackend(db, contractsRoot, source, mountSources, backend)
+	configuredWorkspaceLifecycleForServe = func(db *sql.DB, cfg *config.Config, contractsRoot string, source semanticview.Source, mountSources workspaceMountSources, backend workspaceBackendSelection) (serveWorkspaceLifecycle, error) {
+		return configuredWorkspaceLifecycleForBackend(db, cfg, contractsRoot, source, mountSources, backend)
 	}
 )
 
@@ -698,7 +698,7 @@ func buildServeRuntimeBundleContext(req serveRuntimeBundleContextRequest) (serve
 	}
 	bootIdentity := loaded.bootIdentity
 	bootIdentity.BundleHash = strings.TrimSpace(bundleSourceFact.BundleHash)
-	workspaces, err := configuredWorkspaceLifecycleForServe(req.Stores.SQLDB, loaded.contractsRoot, loaded.source, req.MountSources, req.WorkspaceBackend)
+	workspaces, err := configuredWorkspaceLifecycleForServe(req.Stores.SQLDB, req.Config, loaded.contractsRoot, loaded.source, req.MountSources, req.WorkspaceBackend)
 	if err != nil {
 		return serveRuntimeBundleContext{}, fmt.Errorf("configure workspaces: %w", err)
 	}
@@ -973,7 +973,7 @@ func runServeRuntime(ctx context.Context, repo string, opts serveOptions) int {
 		log.Printf("serve abandon active runs complete: runs=%d deliveries=%d pipeline_receipts=%d", len(result.Runs), len(result.Deliveries), result.PipelineReceiptCount)
 	}
 	if recoveryStore := storeFacade.startupRecoveryStore(); recoveryStore != nil {
-		recoveryWorkspaces, err := configuredWorkspaceLifecycleForServe(storeFacade.workspaceDB(), loadedBundle.contractsRoot, source, mountSources, primaryWorkspaceBackend)
+		recoveryWorkspaces, err := configuredWorkspaceLifecycleForServe(storeFacade.workspaceDB(), cfg, loadedBundle.contractsRoot, source, mountSources, primaryWorkspaceBackend)
 		if err != nil {
 			slog.Error("configure recovery workspaces", "error", err)
 			return 1
@@ -1815,7 +1815,7 @@ func runForkRuntimeOwnerHarness(ctx context.Context, repo string, args []string,
 			}
 			return 1
 		}
-		workspaces, err := configuredWorkspaceLifecycleForBackend(storeFacade.workspaceDB(), contractsRoot, source, mountSources, workspaceBackend)
+		workspaces, err := configuredWorkspaceLifecycleForBackend(storeFacade.workspaceDB(), cfg, contractsRoot, source, mountSources, workspaceBackend)
 		if err != nil {
 			if out != nil {
 				fmt.Fprintf(out, "fork failed: configure workspaces: %v\n", err)
@@ -3455,28 +3455,31 @@ func buildProviderCredentialStore() (runtimecredentials.Store, error) {
 	return credentialFileStore()
 }
 
-func configuredWorkspaceLifecycle(db *sql.DB, contractsRoot string, source semanticview.Source, mountSources workspaceMountSources) (*workspace.DockerManager, error) {
+func configuredWorkspaceLifecycle(db *sql.DB, cfg *config.Config, contractsRoot string, source semanticview.Source, mountSources workspaceMountSources) (*workspace.DockerManager, error) {
 	manager := workspace.NewDockerManager(db)
-	cfg := workspace.DefaultDockerConfig()
+	workspaceCfg, err := dockerWorkspaceConfigFromRuntimeConfig(cfg)
+	if err != nil {
+		return nil, err
+	}
 	if dataSource := strings.TrimSpace(mountSources.DataSource); dataSource != "" {
-		if volumesFrom := strings.TrimSpace(cfg.WorkspaceVolumesFrom); volumesFrom != "" {
+		if volumesFrom := strings.TrimSpace(workspaceCfg.WorkspaceVolumesFrom); volumesFrom != "" {
 			sourceLabel := strings.TrimSpace(mountSources.DataSourceSource)
 			if sourceLabel == "" {
 				sourceLabel = "explicit data source"
 			}
-			return nil, fmt.Errorf("workspace data source from %s cannot be combined with SWARM_WORKSPACE_VOLUMES_FROM=%s", sourceLabel, volumesFrom)
+			return nil, fmt.Errorf("workspace data source from %s cannot be combined with workspace.volumes_from=%s", sourceLabel, volumesFrom)
 		}
-		cfg.SharedDataSource = dataSource
+		workspaceCfg.SharedDataSource = dataSource
 	}
 	if contractsDir := strings.TrimSpace(contractsRoot); contractsDir != "" {
-		cfg.ContractsSource = contractsDir
+		workspaceCfg.ContractsSource = contractsDir
 	}
-	manager.SetConfig(cfg)
+	manager.SetConfig(workspaceCfg)
 	manager.SetSemanticSource(source)
 	return manager, nil
 }
 
-func configuredWorkspaceLifecycleForBackend(db *sql.DB, contractsRoot string, source semanticview.Source, mountSources workspaceMountSources, backend workspaceBackendSelection) (serveWorkspaceLifecycle, error) {
+func configuredWorkspaceLifecycleForBackend(db *sql.DB, cfg *config.Config, contractsRoot string, source semanticview.Source, mountSources workspaceMountSources, backend workspaceBackendSelection) (serveWorkspaceLifecycle, error) {
 	selected := strings.TrimSpace(backend.Backend)
 	if selected == "" {
 		return nil, fmt.Errorf("workspace backend decision is required")
@@ -3485,9 +3488,9 @@ func configuredWorkspaceLifecycleForBackend(db *sql.DB, contractsRoot string, so
 	case workspaceBackendNone:
 		return nil, nil
 	case workspace.BackendDocker:
-		return configuredWorkspaceLifecycle(db, contractsRoot, source, mountSources)
+		return configuredWorkspaceLifecycle(db, cfg, contractsRoot, source, mountSources)
 	case workspace.BackendHost:
-		return configuredHostWorkspaceLifecycle(db, contractsRoot, source, mountSources)
+		return configuredHostWorkspaceLifecycle(db, cfg, contractsRoot, source, mountSources)
 	default:
 		sourceLabel := strings.TrimSpace(backend.Source)
 		if sourceLabel == "" {
@@ -3497,19 +3500,26 @@ func configuredWorkspaceLifecycleForBackend(db *sql.DB, contractsRoot string, so
 	}
 }
 
-func configuredHostWorkspaceLifecycle(db *sql.DB, contractsRoot string, source semanticview.Source, mountSources workspaceMountSources) (*workspace.HostManager, error) {
-	if volumesFrom := strings.TrimSpace(os.Getenv("SWARM_WORKSPACE_VOLUMES_FROM")); volumesFrom != "" {
-		return nil, fmt.Errorf("host workspace backend cannot consume SWARM_WORKSPACE_VOLUMES_FROM=%s", volumesFrom)
+func configuredHostWorkspaceLifecycle(db *sql.DB, cfg *config.Config, contractsRoot string, source semanticview.Source, mountSources workspaceMountSources) (*workspace.HostManager, error) {
+	if cfg != nil && cfg.Workspace.VolumesFromConfigured() {
+		volumesFrom := strings.TrimSpace(cfg.Workspace.VolumesFrom)
+		if volumesFrom == "" {
+			return nil, fmt.Errorf("workspace.volumes_from must be non-empty when configured")
+		}
+		return nil, fmt.Errorf("host workspace backend cannot consume workspace.volumes_from=%s", volumesFrom)
 	}
 	manager := workspace.NewHostManager(db)
-	cfg := workspace.DefaultHostConfig()
+	workspaceCfg, err := hostWorkspaceConfigFromRuntimeConfig(cfg)
+	if err != nil {
+		return nil, err
+	}
 	if dataSource := strings.TrimSpace(mountSources.DataSource); dataSource != "" {
-		cfg.SharedDataSource = dataSource
+		workspaceCfg.SharedDataSource = dataSource
 	}
 	if contractsDir := strings.TrimSpace(contractsRoot); contractsDir != "" {
-		cfg.ContractsSource = contractsDir
+		workspaceCfg.ContractsSource = contractsDir
 	}
-	manager.SetConfig(cfg)
+	manager.SetConfig(workspaceCfg)
 	manager.SetSemanticSource(source)
 	return manager, nil
 }

--- a/cmd/swarm/main_test.go
+++ b/cmd/swarm/main_test.go
@@ -1699,14 +1699,12 @@ homepage: https://division.sh
 }
 
 func TestConfiguredWorkspaceLifecycleDoesNotInventSourceRootDataSource(t *testing.T) {
-	t.Setenv("SWARM_WORKSPACE_DATA_SOURCE", "")
-	t.Setenv("SWARM_WORKSPACE_CONTRACTS_SOURCE", "")
 	contractsDir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(contractsDir, "package.yaml"), []byte("name: test\n"), 0o644); err != nil {
 		t.Fatalf("write package.yaml: %v", err)
 	}
 
-	manager, err := configuredWorkspaceLifecycle(nil, contractsDir, semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{}), workspaceMountSources{})
+	manager, err := configuredWorkspaceLifecycle(nil, nil, contractsDir, semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{}), workspaceMountSources{})
 	if err != nil {
 		t.Fatalf("configuredWorkspaceLifecycle: %v", err)
 	}
@@ -1717,15 +1715,13 @@ func TestConfiguredWorkspaceLifecycleDoesNotInventSourceRootDataSource(t *testin
 }
 
 func TestConfiguredWorkspaceLifecycleUsesExplicitDataAndContractsSources(t *testing.T) {
-	t.Setenv("SWARM_WORKSPACE_DATA_SOURCE", "")
-	t.Setenv("SWARM_WORKSPACE_CONTRACTS_SOURCE", "")
 	dataDir := t.TempDir()
 	contractsDir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(contractsDir, "package.yaml"), []byte("name: test\n"), 0o644); err != nil {
 		t.Fatalf("write package.yaml: %v", err)
 	}
 
-	manager, err := configuredWorkspaceLifecycle(nil, contractsDir, semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{}), workspaceMountSources{
+	manager, err := configuredWorkspaceLifecycle(nil, nil, contractsDir, semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{}), workspaceMountSources{
 		DataSource:       dataDir,
 		DataSourceSource: "--data",
 	})
@@ -1738,15 +1734,13 @@ func TestConfiguredWorkspaceLifecycleUsesExplicitDataAndContractsSources(t *test
 }
 
 func TestConfiguredWorkspaceLifecycleFailsClosedForUnreadableDataSource(t *testing.T) {
-	t.Setenv("SWARM_WORKSPACE_DATA_SOURCE", "")
-	t.Setenv("SWARM_WORKSPACE_CONTRACTS_SOURCE", "")
 	missingDataDir := filepath.Join(t.TempDir(), "missing-data")
 	contractsDir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(contractsDir, "package.yaml"), []byte("name: test\n"), 0o644); err != nil {
 		t.Fatalf("write package.yaml: %v", err)
 	}
 
-	manager, err := configuredWorkspaceLifecycle(nil, contractsDir, semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{}), workspaceMountSources{
+	manager, err := configuredWorkspaceLifecycle(nil, nil, contractsDir, semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{}), workspaceMountSources{
 		DataSource:       missingDataDir,
 		DataSourceSource: "--data",
 	})
@@ -1760,26 +1754,24 @@ func TestConfiguredWorkspaceLifecycleFailsClosedForUnreadableDataSource(t *testi
 }
 
 func TestConfiguredWorkspaceLifecycleRejectsExplicitDataSourceWithVolumesFrom(t *testing.T) {
-	t.Setenv("SWARM_WORKSPACE_VOLUMES_FROM", "swarm-orchestrator")
-	_, err := configuredWorkspaceLifecycle(nil, t.TempDir(), semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{}), workspaceMountSources{
+	cfg := &config.Config{Workspace: config.WorkspaceConfig{VolumesFrom: "swarm-orchestrator"}}
+	_, err := configuredWorkspaceLifecycle(nil, cfg, t.TempDir(), semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{}), workspaceMountSources{
 		DataSource:       t.TempDir(),
 		DataSourceSource: "workspace.data_source",
 	})
-	if err == nil || !strings.Contains(err.Error(), "cannot be combined with SWARM_WORKSPACE_VOLUMES_FROM") {
+	if err == nil || !strings.Contains(err.Error(), "cannot be combined with workspace.volumes_from") {
 		t.Fatalf("configuredWorkspaceLifecycle error = %v, want volumes-from conflict", err)
 	}
 }
 
 func TestConfiguredWorkspaceLifecycleForBackendSelectsHostWithoutDocker(t *testing.T) {
-	t.Setenv("SWARM_WORKSPACE_VOLUMES_FROM", "")
-	t.Setenv("SWARM_WORKSPACE_HOST_ROOT", filepath.Join(t.TempDir(), "host-workspaces"))
-	t.Setenv("SWARM_DOCKER_BIN", filepath.Join(t.TempDir(), "missing-docker"))
+	cfg := &config.Config{Workspace: config.WorkspaceConfig{HostRoot: filepath.Join(t.TempDir(), "host-workspaces")}}
 	dataDir := t.TempDir()
 	contractsDir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(contractsDir, "package.yaml"), []byte("name: test\n"), 0o644); err != nil {
 		t.Fatalf("write package.yaml: %v", err)
 	}
-	lifecycle, err := configuredWorkspaceLifecycleForBackend(nil, contractsDir, semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{}), workspaceMountSources{
+	lifecycle, err := configuredWorkspaceLifecycleForBackend(nil, cfg, contractsDir, semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{}), workspaceMountSources{
 		DataSource:       dataDir,
 		DataSourceSource: "--data",
 	}, workspaceBackendSelection{Backend: workspace.BackendHost, Source: "--workspace-backend"})
@@ -1799,12 +1791,12 @@ func TestConfiguredWorkspaceLifecycleForBackendSelectsHostWithoutDocker(t *testi
 }
 
 func TestConfiguredWorkspaceLifecycleForBackendRejectsHostVolumesFrom(t *testing.T) {
-	t.Setenv("SWARM_WORKSPACE_VOLUMES_FROM", "swarm-orchestrator")
-	_, err := configuredWorkspaceLifecycleForBackend(nil, t.TempDir(), semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{}), workspaceMountSources{
+	cfg := &config.Config{Workspace: config.WorkspaceConfig{VolumesFrom: "swarm-orchestrator"}}
+	_, err := configuredWorkspaceLifecycleForBackend(nil, cfg, t.TempDir(), semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{}), workspaceMountSources{
 		DataSource:       t.TempDir(),
 		DataSourceSource: "--data",
 	}, workspaceBackendSelection{Backend: workspace.BackendHost, Source: "--workspace-backend"})
-	if err == nil || !strings.Contains(err.Error(), "host workspace backend cannot consume SWARM_WORKSPACE_VOLUMES_FROM") {
+	if err == nil || !strings.Contains(err.Error(), "host workspace backend cannot consume workspace.volumes_from") {
 		t.Fatalf("configuredWorkspaceLifecycleForBackend error = %v, want host volumes-from rejection", err)
 	}
 }
@@ -1813,8 +1805,7 @@ func TestResolveWorkspaceMountSourcesPrecedence(t *testing.T) {
 	repoRoot := t.TempDir()
 	flagDir := filepath.Join(repoRoot, "flag-data")
 	configDir := filepath.Join(repoRoot, "config-data")
-	envDir := filepath.Join(repoRoot, "env-data")
-	for _, dir := range []string{flagDir, configDir, envDir} {
+	for _, dir := range []string{flagDir, configDir} {
 		if err := os.MkdirAll(dir, 0o755); err != nil {
 			t.Fatalf("mkdir %s: %v", dir, err)
 		}
@@ -1824,8 +1815,6 @@ func TestResolveWorkspaceMountSourcesPrecedence(t *testing.T) {
 		RepoRoot:         repoRoot,
 		FlagDataSource:   "flag-data",
 		ConfigDataSource: "config-data",
-		EnvDataSource:    "env-data",
-		EnvDataSourceSet: true,
 	})
 	if err != nil {
 		t.Fatalf("resolve workspace mount sources: %v", err)
@@ -1838,28 +1827,12 @@ func TestResolveWorkspaceMountSourcesPrecedence(t *testing.T) {
 		RepoRoot:            repoRoot,
 		ConfigDataSource:    "config-data",
 		ConfigDataSourceSet: true,
-		EnvDataSource:       "env-data",
-		EnvDataSourceSet:    true,
 	})
 	if err != nil {
 		t.Fatalf("resolve config workspace mount source: %v", err)
 	}
 	if result.DataSource != configDir || result.DataSourceSource != "workspace.data_source" {
 		t.Fatalf("config precedence result = %#v, want source %q from workspace.data_source", result, configDir)
-	}
-
-	result, err = resolveWorkspaceMountSourcesFromInput(workspaceDataSourceInput{
-		RepoRoot:         repoRoot,
-		EnvDataSource:    "env-data",
-		EnvDataSourceSet: true,
-		ConfigDataSource: " ",
-		FlagDataSource:   " ",
-	})
-	if err != nil {
-		t.Fatalf("resolve env workspace mount source: %v", err)
-	}
-	if result.DataSource != envDir || result.DataSourceSource != envWorkspaceDataSource {
-		t.Fatalf("env precedence result = %#v, want source %q from %s", result, envDir, envWorkspaceDataSource)
 	}
 
 	result, err = resolveWorkspaceMountSourcesFromInput(workspaceDataSourceInput{
@@ -1880,38 +1853,23 @@ func TestResolveWorkspaceMountSourcesPrecedence(t *testing.T) {
 	}
 }
 
-func TestResolveWorkspaceMountSourcesRejectsEmptyConfigBeforeEnvFallback(t *testing.T) {
+func TestResolveWorkspaceMountSourcesRejectsEmptyConfigBeforeAlternateOrDefault(t *testing.T) {
 	repoRoot := t.TempDir()
-	envDir := t.TempDir()
 	result, err := resolveWorkspaceMountSourcesFromInput(workspaceDataSourceInput{
-		RepoRoot:            repoRoot,
-		ConfigDataSource:    " \t ",
-		ConfigDataSourceSet: true,
-		EnvDataSource:       envDir,
-		EnvDataSourceSet:    true,
+		RepoRoot:                repoRoot,
+		ConfigDataSource:        " \t ",
+		ConfigDataSourceSet:     true,
+		VolumesFrom:             "swarm-orchestrator",
+		VolumesFromSet:          true,
+		DefaultDataSource:       filepath.Join(repoRoot, defaultWorkspaceDataSourceRelativePath),
+		DefaultDataSourceSource: defaultWorkspaceDataSourceSource,
+		CreateDefaultDataSource: true,
 	})
 	if err == nil || !strings.Contains(err.Error(), "workspace.data_source") || !strings.Contains(err.Error(), "must be non-empty") {
 		t.Fatalf("resolve workspace mount sources error = %v, want empty workspace.data_source rejection", err)
 	}
 	if result.DataSource != "" || result.DataSourceSource != "workspace.data_source" {
-		t.Fatalf("workspace mount sources = %#v, want no env fallback and workspace.data_source source label", result)
-	}
-}
-
-func TestResolveWorkspaceMountSourcesRejectsEmptyEnvBeforeDefault(t *testing.T) {
-	repoRoot := t.TempDir()
-	result, err := resolveWorkspaceMountSourcesFromInput(workspaceDataSourceInput{
-		RepoRoot:         repoRoot,
-		EnvDataSource:    " \t ",
-		EnvDataSourceSet: true,
-		VolumesFrom:      "swarm-orchestrator",
-		VolumesFromSet:   true,
-	})
-	if err == nil || !strings.Contains(err.Error(), envWorkspaceDataSource) || !strings.Contains(err.Error(), "must be non-empty") {
-		t.Fatalf("resolve workspace mount sources error = %v, want empty env rejection", err)
-	}
-	if result.DataSource != "" || result.DataSourceSource != envWorkspaceDataSource {
-		t.Fatalf("workspace mount sources = %#v, want no default or volumes-from fallback and env source label", result)
+		t.Fatalf("workspace mount sources = %#v, want no alternate/default fallback and workspace.data_source source label", result)
 	}
 	if _, err := os.Stat(filepath.Join(repoRoot, defaultWorkspaceDataSourceRelativePath)); !os.IsNotExist(err) {
 		t.Fatalf("default data source stat error = %v, want not created", err)
@@ -1990,11 +1948,9 @@ func TestResolveWorkspaceMountSourcesUsesVolumesFromAlternateWithoutDefault(t *t
 	}
 }
 
-func TestResolveWorkspaceMountSourcesReadsRuntimeConfigAndEnvFallback(t *testing.T) {
+func TestResolveWorkspaceMountSourcesReadsRuntimeConfigAndRejectsEmptyConfig(t *testing.T) {
 	repoRoot := t.TempDir()
 	configDir := t.TempDir()
-	envDir := t.TempDir()
-	t.Setenv(envWorkspaceDataSource, envDir)
 
 	result, err := resolveWorkspaceMountSources(repoRoot, "", &config.Config{
 		Workspace: config.WorkspaceConfig{DataSource: configDir},
@@ -2004,14 +1960,6 @@ func TestResolveWorkspaceMountSourcesReadsRuntimeConfigAndEnvFallback(t *testing
 	}
 	if result.DataSource != configDir || result.DataSourceSource != "workspace.data_source" {
 		t.Fatalf("config-backed workspace mount sources = %#v, want %q from workspace.data_source", result, configDir)
-	}
-
-	result, err = resolveWorkspaceMountSources(repoRoot, "", &config.Config{})
-	if err != nil {
-		t.Fatalf("resolve env workspace mount sources: %v", err)
-	}
-	if result.DataSource != envDir || result.DataSourceSource != envWorkspaceDataSource {
-		t.Fatalf("env-backed workspace mount sources = %#v, want %q from %s", result, envDir, envWorkspaceDataSource)
 	}
 
 	configPath := filepath.Join(t.TempDir(), "swarm.yaml")
@@ -2033,7 +1981,7 @@ func TestResolveWorkspaceMountSourcesReadsRuntimeConfigAndEnvFallback(t *testing
 	}
 	result, err = resolveWorkspaceMountSources(repoRoot, "", cfg)
 	if err == nil || !strings.Contains(err.Error(), "workspace.data_source") || !strings.Contains(err.Error(), "must be non-empty") {
-		t.Fatalf("resolve empty configured workspace source error = %v, want fail-closed config rejection before env fallback", err)
+		t.Fatalf("resolve empty configured workspace source error = %v, want fail-closed config rejection", err)
 	}
 	if result.DataSource != "" || result.DataSourceSource != "workspace.data_source" {
 		t.Fatalf("empty configured workspace source result = %#v, want no env fallback", result)
@@ -2046,8 +1994,6 @@ func TestResolveWorkspaceBackendPrecedence(t *testing.T) {
 		FlagSet:       true,
 		ConfigBackend: workspace.BackendDocker,
 		ConfigSet:     true,
-		EnvBackend:    workspace.BackendDocker,
-		EnvSet:        true,
 	})
 	if err != nil {
 		t.Fatalf("resolve workspace backend flag precedence: %v", err)
@@ -2059,25 +2005,12 @@ func TestResolveWorkspaceBackendPrecedence(t *testing.T) {
 	result, err = resolveWorkspaceBackendFromInput(workspaceBackendInput{
 		ConfigBackend: workspace.BackendHost,
 		ConfigSet:     true,
-		EnvBackend:    workspace.BackendDocker,
-		EnvSet:        true,
 	})
 	if err != nil {
 		t.Fatalf("resolve workspace backend config precedence: %v", err)
 	}
 	if result.Backend != workspace.BackendHost || result.Source != "workspace.backend" {
 		t.Fatalf("config precedence result = %#v, want host from workspace.backend", result)
-	}
-
-	result, err = resolveWorkspaceBackendFromInput(workspaceBackendInput{
-		EnvBackend: workspace.BackendHost,
-		EnvSet:     true,
-	})
-	if err != nil {
-		t.Fatalf("resolve workspace backend env precedence: %v", err)
-	}
-	if result.Backend != workspace.BackendHost || result.Source != envWorkspaceBackend {
-		t.Fatalf("env precedence result = %#v, want host from %s", result, envWorkspaceBackend)
 	}
 
 	result, err = resolveWorkspaceBackendFromInput(workspaceBackendInput{})
@@ -2093,11 +2026,9 @@ func TestResolveWorkspaceBackendRejectsEmptyConfigBeforeEnvFallback(t *testing.T
 	result, err := resolveWorkspaceBackendFromInput(workspaceBackendInput{
 		ConfigBackend: " \t ",
 		ConfigSet:     true,
-		EnvBackend:    workspace.BackendHost,
-		EnvSet:        true,
 	})
 	if err == nil || !strings.Contains(err.Error(), "workspace.backend") || !strings.Contains(err.Error(), "must be non-empty") {
-		t.Fatalf("resolve empty configured workspace backend error = %v, want fail-closed config rejection before env fallback", err)
+		t.Fatalf("resolve empty configured workspace backend error = %v, want fail-closed config rejection", err)
 	}
 	if result.Backend != "" || result.Source != "workspace.backend" {
 		t.Fatalf("empty configured workspace backend result = %#v, want no env fallback", result)
@@ -2226,7 +2157,7 @@ func TestPlatformSpecWorkspaceDataSourceAuthorityPromoted(t *testing.T) {
 				CanonicalOwner                 string   `yaml:"canonical_owner"`
 				CLIFlag                        string   `yaml:"cli_flag"`
 				ConfigKey                      string   `yaml:"config_key"`
-				EnvVar                         string   `yaml:"env_var"`
+				RetiredEnvVar                  string   `yaml:"retired_env_var"`
 				SourceOrder                    []string `yaml:"source_order"`
 				DefaultBehavior                string   `yaml:"default_behavior"`
 				FailureBehavior                string   `yaml:"failure_behavior"`
@@ -2244,7 +2175,7 @@ func TestPlatformSpecWorkspaceDataSourceAuthorityPromoted(t *testing.T) {
 						Owner      string   `yaml:"owner"`
 						Flag       string   `yaml:"flag"`
 						ConfigKey  string   `yaml:"config_key"`
-						EnvVar     string   `yaml:"env_var"`
+						RetiredEnv string   `yaml:"retired_env_var"`
 						Consumers  []string `yaml:"consumers"`
 					} `yaml:"workspace_data_source_authority"`
 				} `yaml:"serve"`
@@ -2274,10 +2205,10 @@ func TestPlatformSpecWorkspaceDataSourceAuthorityPromoted(t *testing.T) {
 	if !strings.Contains(authority.CanonicalOwner, "workspace_model.data_source_authority") {
 		t.Fatalf("workspace data source canonical owner = %q", authority.CanonicalOwner)
 	}
-	if authority.CLIFlag != "--data" || authority.ConfigKey != "workspace.data_source" || authority.EnvVar != envWorkspaceDataSource {
+	if authority.CLIFlag != "--data" || authority.ConfigKey != "workspace.data_source" || authority.RetiredEnvVar != "SWARM_WORKSPACE_DATA_SOURCE" {
 		t.Fatalf("workspace data source selectors = %#v", authority)
 	}
-	for _, want := range []string{"--data", "workspace.data_source", envWorkspaceDataSource, defaultWorkspaceDataSourceSource} {
+	for _, want := range []string{"--data", "workspace.data_source", defaultWorkspaceDataSourceSource} {
 		if !stringSliceContains(authority.SourceOrder, want) {
 			t.Fatalf("workspace data source order missing %q: %#v", want, authority.SourceOrder)
 		}
@@ -2321,7 +2252,7 @@ func TestPlatformSpecWorkspaceBackendSelectionPromoted(t *testing.T) {
 				CLIFlag              string   `yaml:"cli_flag"`
 				ConfigKey            string   `yaml:"config_key"`
 				UnsafeConfigKey      string   `yaml:"unsafe_config_key"`
-				LegacyEnvVar         string   `yaml:"legacy_env_var"`
+				RetiredEnvVar        string   `yaml:"retired_env_var"`
 				SourceOrder          []string `yaml:"source_order"`
 				DefaultBackend       string   `yaml:"default_backend"`
 				CapabilityClasses    map[string]struct {
@@ -2330,9 +2261,9 @@ func TestPlatformSpecWorkspaceBackendSelectionPromoted(t *testing.T) {
 				Backends map[string]struct {
 					Behavior      string `yaml:"behavior"`
 					WorkspaceRoot struct {
-						EnvVar  string `yaml:"env_var"`
-						Default string `yaml:"default"`
-						Rule    string `yaml:"rule"`
+						ConfigKey string `yaml:"config_key"`
+						Default   string `yaml:"default"`
+						Rule      string `yaml:"rule"`
 					} `yaml:"workspace_root"`
 				} `yaml:"backends"`
 				FailureBehavior []string `yaml:"failure_behavior"`
@@ -2349,7 +2280,7 @@ func TestPlatformSpecWorkspaceBackendSelectionPromoted(t *testing.T) {
 						Flag            string   `yaml:"flag"`
 						ConfigKey       string   `yaml:"config_key"`
 						UnsafeConfigKey string   `yaml:"unsafe_config_key"`
-						LegacyEnvVar    string   `yaml:"legacy_env_var"`
+						RetiredEnvVar   string   `yaml:"retired_env_var"`
 						DefaultBackend  string   `yaml:"default_backend"`
 						Consumers       []string `yaml:"consumers"`
 					} `yaml:"workspace_backend_selection"`
@@ -2371,10 +2302,10 @@ func TestPlatformSpecWorkspaceBackendSelectionPromoted(t *testing.T) {
 	if !strings.Contains(authority.CanonicalOwner, "workspace_model.workspace_backend_selection") {
 		t.Fatalf("workspace backend canonical owner = %q", authority.CanonicalOwner)
 	}
-	if authority.CLIFlag != "--workspace-backend <docker|host>" || authority.ConfigKey != "workspace.backend" || authority.UnsafeConfigKey != "workspace.allow_exec_on_host" || authority.LegacyEnvVar != envWorkspaceBackend {
+	if authority.CLIFlag != "--workspace-backend <docker|host>" || authority.ConfigKey != "workspace.backend" || authority.UnsafeConfigKey != "workspace.allow_exec_on_host" || authority.RetiredEnvVar != "SWARM_WORKSPACE_BACKEND" {
 		t.Fatalf("workspace backend selectors = %#v", authority)
 	}
-	for _, want := range []string{"loaded contract execution capability", "--workspace-backend", "workspace.backend", envWorkspaceBackend} {
+	for _, want := range []string{"loaded contract execution capability", "--workspace-backend", "workspace.backend"} {
 		if !stringSliceContains(authority.SourceOrder, want) {
 			t.Fatalf("workspace backend order missing %q: %#v", want, authority.SourceOrder)
 		}
@@ -2399,7 +2330,7 @@ func TestPlatformSpecWorkspaceBackendSelectionPromoted(t *testing.T) {
 	if !ok || !strings.Contains(hostBackend.Behavior, "workspace.allow_exec_on_host") || !strings.Contains(hostBackend.Behavior, "MUST NOT require Docker") {
 		t.Fatalf("host backend spec missing local-dev no-Docker behavior: %#v", authority.Backends)
 	}
-	if hostBackend.WorkspaceRoot.EnvVar != workspace.EnvHostWorkspaceRoot || hostBackend.WorkspaceRoot.Default != "~/.swarm/workspaces" {
+	if hostBackend.WorkspaceRoot.ConfigKey != "workspace.host_root" || hostBackend.WorkspaceRoot.Default != "~/.swarm/workspaces" {
 		t.Fatalf("host workspace root spec = %#v", hostBackend.WorkspaceRoot)
 	}
 	for _, want := range []string{"canonical/evaluated paths", "Every host lifecycle consumer", "symlink escapes"} {
@@ -2407,7 +2338,7 @@ func TestPlatformSpecWorkspaceBackendSelectionPromoted(t *testing.T) {
 			t.Fatalf("host workspace root rule missing %q:\n%s", want, hostBackend.WorkspaceRoot.Rule)
 		}
 	}
-	for _, want := range []string{"Unsupported backend", "Empty explicit backend", "SWARM_WORKSPACE_VOLUMES_FROM", "Claude CLI", "SWARM_WORKSPACE_BACKEND=host", "conversation.fork_chat", "native command execution"} {
+	for _, want := range []string{"Unsupported backend", "Empty explicit backend", "workspace.volumes_from", "Claude CLI", "SWARM_WORKSPACE_BACKEND=host", "conversation.fork_chat", "native command execution"} {
 		if !joinedContains(authority.FailureBehavior, want) {
 			t.Fatalf("workspace backend failure behavior missing %q: %#v", want, authority.FailureBehavior)
 		}
@@ -2426,7 +2357,7 @@ func TestPlatformSpecWorkspaceBackendSelectionPromoted(t *testing.T) {
 	if command.PromotedBy != "#1138" || command.Owner != "workspace_model.workspace_backend_selection" || command.Flag != "--workspace-backend <docker|host>" {
 		t.Fatalf("serve command workspace backend authority = %#v", command)
 	}
-	if command.ConfigKey != "workspace.backend" || command.UnsafeConfigKey != "workspace.allow_exec_on_host" || command.LegacyEnvVar != envWorkspaceBackend || command.DefaultBackend != "capability-derived" {
+	if command.ConfigKey != "workspace.backend" || command.UnsafeConfigKey != "workspace.allow_exec_on_host" || command.RetiredEnvVar != "SWARM_WORKSPACE_BACKEND" || command.DefaultBackend != "capability-derived" {
 		t.Fatalf("serve command workspace backend selectors = %#v", command)
 	}
 	for _, want := range []string{"serve boot", "run start", "Builder project reload", "selected-contract run-fork", "verify/describe/doctor", "conversation.fork_chat"} {
@@ -2842,7 +2773,7 @@ func TestPlatformSpecLocalCLITestWorkspaceCLIAvailabilityPromoted(t *testing.T) 
 			t.Fatalf("local cli_test workspace cli availability scope missing %q:\n%s", want, availability.Scope)
 		}
 	}
-	for _, want := range []string{"startup validation MUST prove", "before readiness or event delivery", "Docker image inspection", "existing container reuse", "SWARM_WORKSPACE_IMAGE"} {
+	for _, want := range []string{"startup validation MUST prove", "before readiness or event delivery", "Docker image inspection", "existing container reuse", "workspace.image"} {
 		if !strings.Contains(availability.WorkspaceCLIRule, want) {
 			t.Fatalf("workspace cli rule missing %q:\n%s", want, availability.WorkspaceCLIRule)
 		}
@@ -6243,10 +6174,13 @@ func TestRunServeRuntimePassesDataFlagToWorkspaceLifecycle(t *testing.T) {
 }
 
 func TestRunServeRuntimeHostWorkspaceBackendBootsWithoutDockerForSystemOnlyFlow(t *testing.T) {
-	t.Setenv("SWARM_DOCKER_BIN", filepath.Join(t.TempDir(), "missing-docker"))
-	t.Setenv("SWARM_WORKSPACE_HOST_ROOT", filepath.Join(t.TempDir(), "host-workspaces"))
+	missingDocker := filepath.Join(t.TempDir(), "missing-docker")
+	hostRoot := filepath.Join(t.TempDir(), "host-workspaces")
 	dataDir := t.TempDir()
-	configPath := writeStoreBackendRuntimeConfig(t, storebackend.BackendSQLite.String(), filepath.Join(t.TempDir(), "runtime.db"))
+	configPath := writeStoreBackendRuntimeConfigWithWorkspaceFields(t, storebackend.BackendSQLite.String(), filepath.Join(t.TempDir(), "runtime.db"), []string{
+		fmt.Sprintf("  docker_bin: %q", missingDocker),
+		fmt.Sprintf("  host_root: %q", hostRoot),
+	})
 
 	serve := startServeRuntimeTestProcess(t, serveOptions{
 		ConfigPath:           configPath,
@@ -6274,10 +6208,12 @@ func TestRunServeRuntimeHostWorkspaceBackendBootsWithoutDockerForSystemOnlyFlow(
 }
 
 func TestRunServeRuntimeNoAgentDefaultBootsWithoutDocker(t *testing.T) {
-	t.Setenv("SWARM_DOCKER_BIN", filepath.Join(t.TempDir(), "missing-docker"))
+	missingDocker := filepath.Join(t.TempDir(), "missing-docker")
 
 	serve := startServeRuntimeTestProcess(t, serveOptions{
-		ConfigPath:           writeStoreBackendRuntimeConfig(t, storebackend.BackendSQLite.String(), filepath.Join(t.TempDir(), "runtime.db")),
+		ConfigPath: writeStoreBackendRuntimeConfigWithWorkspaceFields(t, storebackend.BackendSQLite.String(), filepath.Join(t.TempDir(), "runtime.db"), []string{
+			fmt.Sprintf("  docker_bin: %q", missingDocker),
+		}),
 		ContractsPath:        filepath.Join("tests", "tier1-primitives", "test-emits-single"),
 		DataSource:           t.TempDir(),
 		PlatformSpecPath:     defaultPlatformSpecPath,
@@ -6303,11 +6239,14 @@ func TestRunServeRuntimeNoAgentDefaultBootsWithoutDocker(t *testing.T) {
 }
 
 func TestRunServeRuntimeAPIAgentDefaultHostBootsWithoutDocker(t *testing.T) {
-	t.Setenv("SWARM_DOCKER_BIN", filepath.Join(t.TempDir(), "missing-docker"))
-	t.Setenv("SWARM_WORKSPACE_HOST_ROOT", filepath.Join(t.TempDir(), "host-workspaces"))
+	missingDocker := filepath.Join(t.TempDir(), "missing-docker")
+	hostRoot := filepath.Join(t.TempDir(), "host-workspaces")
 
 	serve := startServeRuntimeTestProcess(t, serveOptions{
-		ConfigPath:           writeStoreBackendRuntimeConfig(t, storebackend.BackendSQLite.String(), filepath.Join(t.TempDir(), "runtime.db")),
+		ConfigPath: writeStoreBackendRuntimeConfigWithWorkspaceFields(t, storebackend.BackendSQLite.String(), filepath.Join(t.TempDir(), "runtime.db"), []string{
+			fmt.Sprintf("  docker_bin: %q", missingDocker),
+			fmt.Sprintf("  host_root: %q", hostRoot),
+		}),
 		ContractsPath:        writeServeRuntimeAgentSlugFixture(t, "api-agent-host-default", "api-worker"),
 		DataSource:           t.TempDir(),
 		PlatformSpecPath:     defaultPlatformSpecPath,
@@ -6335,11 +6274,13 @@ func TestRunServeRuntimeAPIAgentDefaultHostBootsWithoutDocker(t *testing.T) {
 }
 
 func TestRunServeRuntimeNativeBashDefaultDockerFailsWithoutDocker(t *testing.T) {
-	t.Setenv("SWARM_DOCKER_BIN", filepath.Join(t.TempDir(), "missing-docker"))
+	missingDocker := filepath.Join(t.TempDir(), "missing-docker")
 
 	var out lockedBuffer
 	code := runServeRuntime(context.Background(), repoRoot(), serveOptions{
-		ConfigPath:           writeStoreBackendRuntimeConfig(t, storebackend.BackendSQLite.String(), filepath.Join(t.TempDir(), "runtime.db")),
+		ConfigPath: writeStoreBackendRuntimeConfigWithWorkspaceFields(t, storebackend.BackendSQLite.String(), filepath.Join(t.TempDir(), "runtime.db"), []string{
+			fmt.Sprintf("  docker_bin: %q", missingDocker),
+		}),
 		ContractsPath:        writeServeRuntimeNativeBashFixture(t),
 		DataSource:           t.TempDir(),
 		PlatformSpecPath:     defaultPlatformSpecPath,
@@ -6874,7 +6815,7 @@ func TestRunServeRuntimeMultiContextClaudeCLIFailsClosedBeforePrimaryGatewayOrFo
 
 	var out lockedBuffer
 	code := runServeRuntime(ctx, repoRoot(), serveOptions{
-		ConfigPath:         writeDoctorClaudeConfig(t),
+		ConfigPath:         writeDoctorClaudeConfig(t, ""),
 		Backend:            "claude_cli",
 		BundleHash:         firstHash,
 		BundleHashes:       []string{secondHash},
@@ -7113,7 +7054,7 @@ func seedServeRuntimeSQLiteAbandonWork(t *testing.T, sqlitePath string) (string,
 func stubServeRuntimeWorkspaceLifecycle(t *testing.T) {
 	t.Helper()
 	oldWorkspaceLifecycle := configuredWorkspaceLifecycleForServe
-	configuredWorkspaceLifecycleForServe = func(*sql.DB, string, semanticview.Source, workspaceMountSources, workspaceBackendSelection) (serveWorkspaceLifecycle, error) {
+	configuredWorkspaceLifecycleForServe = func(*sql.DB, *config.Config, string, semanticview.Source, workspaceMountSources, workspaceBackendSelection) (serveWorkspaceLifecycle, error) {
 		return serveRuntimeWorkspaceStub{}, nil
 	}
 	t.Cleanup(func() {
@@ -7150,7 +7091,7 @@ func installServeRuntimePostgresTestStoresForDatabase(t *testing.T, workspaceFac
 		}
 		return selectedPostgresStoreBundle(runtimePG, cfg), nil
 	}
-	configuredWorkspaceLifecycleForServe = func(_ *sql.DB, _ string, _ semanticview.Source, mountSources workspaceMountSources, _ workspaceBackendSelection) (serveWorkspaceLifecycle, error) {
+	configuredWorkspaceLifecycleForServe = func(_ *sql.DB, _ *config.Config, _ string, _ semanticview.Source, mountSources workspaceMountSources, _ workspaceBackendSelection) (serveWorkspaceLifecycle, error) {
 		return workspaceFactory(mountSources), nil
 	}
 	t.Cleanup(func() {
@@ -11298,7 +11239,7 @@ func TestRunServeRuntimeVerboseEmitsPlatformSpecBootSequence(t *testing.T) {
 		}
 		return selectedPostgresStoreBundle(runtimePG, cfg), nil
 	}
-	configuredWorkspaceLifecycleForServe = func(*sql.DB, string, semanticview.Source, workspaceMountSources, workspaceBackendSelection) (serveWorkspaceLifecycle, error) {
+	configuredWorkspaceLifecycleForServe = func(*sql.DB, *config.Config, string, semanticview.Source, workspaceMountSources, workspaceBackendSelection) (serveWorkspaceLifecycle, error) {
 		return serveRuntimeWorkspaceStub{}, nil
 	}
 	t.Cleanup(func() {
@@ -11371,7 +11312,7 @@ func TestRunServeRuntimeListenerBindFailuresExitBeforeReadiness(t *testing.T) {
 				}
 				return selectedPostgresStoreBundle(runtimePG, cfg), nil
 			}
-			configuredWorkspaceLifecycleForServe = func(*sql.DB, string, semanticview.Source, workspaceMountSources, workspaceBackendSelection) (serveWorkspaceLifecycle, error) {
+			configuredWorkspaceLifecycleForServe = func(*sql.DB, *config.Config, string, semanticview.Source, workspaceMountSources, workspaceBackendSelection) (serveWorkspaceLifecycle, error) {
 				return serveRuntimeWorkspaceStub{}, nil
 			}
 			t.Cleanup(func() {
@@ -11487,7 +11428,7 @@ func TestRunServeRuntimeDevClaudeCLIStaleGatewayEnvUsesTypedBinding(t *testing.T
 
 	bindingCh := make(chan toolgateway.Binding, 1)
 	opts := serveOptions{
-		ConfigPath:         writeDoctorClaudeConfig(t),
+		ConfigPath:         writeDoctorClaudeConfig(t, ""),
 		Backend:            "claude_cli",
 		ContractsPath:      filepath.Join("tests", "tier8-boot-verification", "test-boot-success"),
 		DataSource:         t.TempDir(),
@@ -11554,7 +11495,7 @@ func TestStartLocalRunServeClaudeCLIStaleGatewayEnvUsesTypedBinding(t *testing.T
 
 	stop, err := startLocalRunServe(context.Background(), repoRoot(), runCommandOptions{
 		apiOptions:       apiOpts,
-		configPath:       writeDoctorClaudeConfig(t),
+		configPath:       writeDoctorClaudeConfig(t, ""),
 		backend:          "claude_cli",
 		contractsPath:    filepath.Join("tests", "tier8-boot-verification", "test-boot-success"),
 		dataSource:       t.TempDir(),
@@ -11617,7 +11558,7 @@ func TestRunServeRuntimeNonDevClaudeCLIRetiredGatewayURLEnvFailsClosed(t *testin
 			t.Setenv(tt.env, tt.value)
 
 			assertRunServeRuntimeRetiredGatewayURLAdmissionFailure(t, tt.env, serveOptions{
-				ConfigPath:         writeDoctorClaudeConfig(t),
+				ConfigPath:         writeDoctorClaudeConfig(t, ""),
 				Backend:            "claude_cli",
 				ContractsPath:      filepath.Join("tests", "tier8-boot-verification", "test-boot-success"),
 				DataSource:         t.TempDir(),
@@ -11639,7 +11580,7 @@ func TestRunServeRuntimeBundleHashRetiredGatewayURLEnvFailsBeforeStartupSideEffe
 	t.Setenv("SWARM_TOOL_GATEWAY_TOKEN", "")
 
 	assertRunServeRuntimeRetiredGatewayURLAdmissionFailure(t, "SWARM_TOOL_GATEWAY_URL", serveOptions{
-		ConfigPath:         writeDoctorClaudeConfig(t),
+		ConfigPath:         writeDoctorClaudeConfig(t, ""),
 		Backend:            "claude_cli",
 		ContractsPath:      filepath.Join("tests", "tier8-boot-verification", "test-boot-success"),
 		DataSource:         t.TempDir(),
@@ -11749,7 +11690,7 @@ func localPreflightReportHasFinding(report localPreflightReport, code string, se
 func stubServeWorkspaceLifecycleForTest(t *testing.T) {
 	t.Helper()
 	oldWorkspaceLifecycle := configuredWorkspaceLifecycleForServe
-	configuredWorkspaceLifecycleForServe = func(*sql.DB, string, semanticview.Source, workspaceMountSources, workspaceBackendSelection) (serveWorkspaceLifecycle, error) {
+	configuredWorkspaceLifecycleForServe = func(*sql.DB, *config.Config, string, semanticview.Source, workspaceMountSources, workspaceBackendSelection) (serveWorkspaceLifecycle, error) {
 		return serveRuntimeWorkspaceStub{}, nil
 	}
 	t.Cleanup(func() {
@@ -11837,7 +11778,7 @@ func TestRunServeRuntimeAbandonActiveRunsQuiescesBeforeBundleMatchAdmission(t *t
 		}
 		return selectedPostgresStoreBundle(runtimePG, cfg), nil
 	}
-	configuredWorkspaceLifecycleForServe = func(*sql.DB, string, semanticview.Source, workspaceMountSources, workspaceBackendSelection) (serveWorkspaceLifecycle, error) {
+	configuredWorkspaceLifecycleForServe = func(*sql.DB, *config.Config, string, semanticview.Source, workspaceMountSources, workspaceBackendSelection) (serveWorkspaceLifecycle, error) {
 		return serveRuntimeWorkspaceStub{}, nil
 	}
 	t.Cleanup(func() {
@@ -12527,11 +12468,21 @@ func parseServeBootProgressRows(t *testing.T, output string) []serveBootProgress
 
 func writeServeRuntimeTestConfig(t *testing.T) string {
 	t.Helper()
+	return writeServeRuntimeTestConfigWithWorkspaceFields(t, nil)
+}
+
+func writeServeRuntimeTestConfigWithWorkspaceFields(t *testing.T, workspaceFields []string) string {
+	t.Helper()
 	configText := strings.Join([]string{
 		"runtime:",
 		"  recovery_on_startup: false",
 		"workspace:",
 		"  data_source: " + t.TempDir(),
+	}, "\n") + "\n"
+	if len(workspaceFields) > 0 {
+		configText += strings.Join(workspaceFields, "\n") + "\n"
+	}
+	configText += strings.Join([]string{
 		"llm:",
 		"  backend: anthropic",
 		"  session:",
@@ -12542,6 +12493,38 @@ func writeServeRuntimeTestConfig(t *testing.T) string {
 	path := filepath.Join(t.TempDir(), "swarm.yaml")
 	if err := os.WriteFile(path, []byte(configText), 0o644); err != nil {
 		t.Fatalf("write serve runtime config: %v", err)
+	}
+	return path
+}
+
+func writeStoreBackendRuntimeConfigWithWorkspaceFields(t *testing.T, backend string, sqlitePath string, workspaceFields []string) string {
+	t.Helper()
+	lines := []string{
+		"runtime:",
+		"  recovery_on_startup: false",
+		"workspace:",
+		"  data_source: " + t.TempDir(),
+	}
+	lines = append(lines, workspaceFields...)
+	if strings.TrimSpace(backend) != "" || strings.TrimSpace(sqlitePath) != "" {
+		lines = append(lines,
+			"store:",
+			"  backend: "+backend,
+			"  sqlite:",
+			"    path: "+sqlitePath,
+		)
+	}
+	lines = append(lines,
+		"llm:",
+		"  backend: anthropic",
+		"  session:",
+		"    lock_ttl: 10s",
+		"    rotate_after_turns: 40",
+		"    rotate_on_parse_failures: 3",
+	)
+	path := filepath.Join(t.TempDir(), "swarm.yaml")
+	if err := os.WriteFile(path, []byte(strings.Join(lines, "\n")+"\n"), 0o644); err != nil {
+		t.Fatalf("write runtime config: %v", err)
 	}
 	return path
 }

--- a/cmd/swarm/target_resolution.go
+++ b/cmd/swarm/target_resolution.go
@@ -536,7 +536,7 @@ func resolveDoctorTargetData(repo string, opts doctorOptions, project localRunti
 		return doctorTargetPath{Status: "missing", Detail: err.Error()}
 	}
 	if strings.TrimSpace(mountSources.DataSource) == "" {
-		return doctorTargetPath{Source: envWorkspaceVolumesFrom, Status: "no_host_data_dir", Detail: "workspace volumes_from supplies container mounts"}
+		return doctorTargetPath{Source: "workspace.volumes_from", Status: "no_host_data_dir", Detail: "workspace volumes_from supplies container mounts"}
 	}
 	return doctorTargetPath{
 		Path:   mountSources.DataSource,

--- a/cmd/swarm/workspace_backend.go
+++ b/cmd/swarm/workspace_backend.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"os"
 	"sort"
 	"strings"
 
@@ -12,11 +11,7 @@ import (
 	workspace "github.com/division-sh/swarm/internal/runtime/workspace"
 )
 
-const (
-	envWorkspaceBackend = "SWARM_WORKSPACE_BACKEND"
-
-	workspaceBackendNone = "none"
-)
+const workspaceBackendNone = "none"
 
 type workspaceCapabilityClass string
 
@@ -47,22 +42,16 @@ type workspaceBackendInput struct {
 	ConfigBackend string
 	ConfigSet     bool
 
-	EnvBackend string
-	EnvSet     bool
-
 	AllowExecOnHost bool
 }
 
 func resolveWorkspaceBackend(flagBackend string, flagSet bool, cfg *config.Config) (workspaceBackendSelection, error) {
-	envBackend, envSet := os.LookupEnv(envWorkspaceBackend)
 	configBackend, configSet := runtimeConfigWorkspaceBackend(cfg)
 	return resolveWorkspaceBackendFromInput(workspaceBackendInput{
 		FlagBackend:     flagBackend,
 		FlagSet:         flagSet,
 		ConfigBackend:   configBackend,
 		ConfigSet:       configSet,
-		EnvBackend:      envBackend,
-		EnvSet:          envSet,
 		AllowExecOnHost: runtimeConfigAllowExecOnHost(cfg),
 	})
 }
@@ -100,13 +89,6 @@ func resolveWorkspaceBackendFromInput(in workspaceBackendInput) (workspaceBacken
 			Source:             "workspace.backend",
 			PreferenceExplicit: true,
 			AllowExecOnHost:    in.AllowExecOnHost,
-		}, err
-	case in.EnvSet:
-		backend, err := normalizeWorkspaceBackend(in.EnvBackend, envWorkspaceBackend)
-		return workspaceBackendSelection{
-			Backend:            backend,
-			Source:             envWorkspaceBackend,
-			PreferenceExplicit: true,
 		}, err
 	default:
 		return workspaceBackendSelection{Source: "capability-derived"}, nil
@@ -176,7 +158,7 @@ func decideWorkspaceBackend(preference workspaceBackendSelection, cfg *config.Co
 				case "workspace.backend":
 					return decision, fmt.Errorf("workspace.backend: host grants agent execution on this machine for %s; set workspace.allow_exec_on_host: true or use Docker", workspaceBackendReasonSummary(reasons))
 				default:
-					return decision, fmt.Errorf("%s=host cannot authorize unsafe host execution for %s; use --workspace-backend host for one command or workspace.backend: host with workspace.allow_exec_on_host: true", envWorkspaceBackend, workspaceBackendReasonSummary(reasons))
+					return decision, fmt.Errorf("workspace backend host cannot authorize unsafe host execution for %s; use --workspace-backend host for one command or workspace.backend: host with workspace.allow_exec_on_host: true", workspaceBackendReasonSummary(reasons))
 				}
 			}
 			decision.UnsafeHost = true

--- a/cmd/swarm/workspace_backend_decision_test.go
+++ b/cmd/swarm/workspace_backend_decision_test.go
@@ -107,7 +107,7 @@ func TestWorkspaceBackendDecisionCapabilityMatrix(t *testing.T) {
 			agents: map[string]runtimecontracts.AgentRegistryEntry{
 				"worker": {ID: "worker", NativeTools: map[string]any{"bash": true}},
 			},
-			preference: workspaceBackendSelection{Backend: workspace.BackendHost, Source: envWorkspaceBackend, PreferenceExplicit: true},
+			preference: workspaceBackendSelection{Backend: workspace.BackendHost, Source: "SWARM_WORKSPACE_BACKEND", PreferenceExplicit: true},
 			wantErr:    "cannot authorize unsafe host execution",
 		},
 		{
@@ -144,7 +144,7 @@ func TestWorkspaceBackendDecisionCapabilityMatrix(t *testing.T) {
 }
 
 func TestConfiguredWorkspaceLifecycleForBackendNoWorkspace(t *testing.T) {
-	lifecycle, err := configuredWorkspaceLifecycleForBackend(nil, "", semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{}), workspaceMountSources{}, workspaceBackendSelection{Backend: workspaceBackendNone, Source: "capability-derived", NoWorkspace: true})
+	lifecycle, err := configuredWorkspaceLifecycleForBackend(nil, nil, "", semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{}), workspaceMountSources{}, workspaceBackendSelection{Backend: workspaceBackendNone, Source: "capability-derived", NoWorkspace: true})
 	if err != nil {
 		t.Fatalf("configuredWorkspaceLifecycleForBackend: %v", err)
 	}

--- a/cmd/swarm/workspace_build.go
+++ b/cmd/swarm/workspace_build.go
@@ -11,29 +11,32 @@ import (
 	"strings"
 	"time"
 
+	"github.com/division-sh/swarm/internal/config"
 	"github.com/division-sh/swarm/internal/platform"
-	workspace "github.com/division-sh/swarm/internal/runtime/workspace"
 	"github.com/spf13/cobra"
 )
 
 const workspaceBuildClaudeCommand = "claude"
 
 type workspaceBuildOptions struct {
-	backend string
-	image   string
+	backend    string
+	configPath string
+	repoRoot   string
+	image      string
+	dockerBin  string
 }
 
-func newWorkspaceCommand(ctx context.Context) *cobra.Command {
+func newWorkspaceCommand(ctx context.Context, repoRoot string) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "workspace",
 		Short: "Manage local workspace setup.",
 	}
-	cmd.AddCommand(newWorkspaceBuildCommand(ctx))
+	cmd.AddCommand(newWorkspaceBuildCommand(ctx, repoRoot))
 	return cmd
 }
 
-func newWorkspaceBuildCommand(ctx context.Context) *cobra.Command {
-	opts := workspaceBuildOptions{}
+func newWorkspaceBuildCommand(ctx context.Context, repoRoot string) *cobra.Command {
+	opts := workspaceBuildOptions{repoRoot: strings.TrimSpace(repoRoot)}
 	cmd := &cobra.Command{
 		Use:   "build --backend claude_cli [--image <tag>]",
 		Short: "Build and validate a local workspace image.",
@@ -47,6 +50,13 @@ func newWorkspaceBuildCommand(ctx context.Context) *cobra.Command {
 				return fmt.Errorf("unsupported workspace build backend %q; only claude_cli is supported", strings.TrimSpace(opts.backend))
 			}
 			opts.backend = backend
+			if cmd.Flags().Changed("docker-bin") {
+				dockerBin, err := normalizeWorkspaceBuildDockerBin(opts.dockerBin, "--docker-bin")
+				if err != nil {
+					return err
+				}
+				opts.dockerBin = dockerBin
+			}
 			if cmd.Flags().Changed("image") {
 				image, err := normalizeWorkspaceBuildImage(opts.image, "--image")
 				if err != nil {
@@ -65,15 +75,29 @@ func newWorkspaceBuildCommand(ctx context.Context) *cobra.Command {
 		},
 	}
 	cmd.Flags().StringVar(&opts.backend, "backend", opts.backend, "Workspace image build backend to materialize: claude_cli")
-	cmd.Flags().StringVar(&opts.image, "image", opts.image, "Workspace image tag to build; defaults to SWARM_WORKSPACE_IMAGE or swarm-workspace:latest")
+	cmd.Flags().StringVar(&opts.configPath, "config", opts.configPath, "Optional path to Swarm runtime config for workspace.image/workspace.docker_bin")
+	cmd.Flags().StringVar(&opts.image, "image", opts.image, "Workspace image tag to build; defaults to workspace.image or swarm-workspace:latest")
+	cmd.Flags().StringVar(&opts.dockerBin, "docker-bin", opts.dockerBin, "Docker-compatible CLI binary; defaults to workspace.docker_bin or docker")
 	return cmd
 }
 
 func runWorkspaceBuildCommand(ctx context.Context, out io.Writer, opts workspaceBuildOptions) error {
+	var cfg *config.Config
+	if configPath := strings.TrimSpace(opts.configPath); configPath != "" {
+		cfgResult, err := loadRuntimeConfigWithOptions(runtimeConfigLoadOptions{RepoRoot: opts.repoRoot, ExplicitPath: configPath})
+		if err != nil {
+			return fmt.Errorf("workspace image build failed: load config: %w", err)
+		}
+		cfg = cfgResult.Config
+	}
 	image := strings.TrimSpace(opts.image)
 	if image == "" {
 		var err error
-		image, err = normalizeWorkspaceBuildImage(workspace.ConfiguredWorkspaceImageFromEnv(), "SWARM_WORKSPACE_IMAGE")
+		image, err = workspaceImageFromRuntimeConfigOrDefault(cfg)
+		if err != nil {
+			return fmt.Errorf("workspace image build failed: %w", err)
+		}
+		image, err = normalizeWorkspaceBuildImage(image, "workspace.image")
 		if err != nil {
 			return err
 		}
@@ -88,9 +112,16 @@ func runWorkspaceBuildCommand(ctx context.Context, out io.Writer, opts workspace
 	}
 	defer cleanup()
 
-	dockerBin := workspace.EnvOrDefault("SWARM_DOCKER_BIN", "docker")
+	dockerBin := strings.TrimSpace(opts.dockerBin)
+	if dockerBin == "" {
+		var err error
+		dockerBin, err = workspaceDockerBinFromRuntimeConfigOrDefault(cfg)
+		if err != nil {
+			return fmt.Errorf("workspace image build failed: %w", err)
+		}
+	}
 	if _, err := runWorkspaceBuildDocker(ctx, dockerBin, "version", "--format", "{{.Server.Version}}"); err != nil {
-		return fmt.Errorf("workspace image build failed: Docker is not available via %q; start Docker or set SWARM_DOCKER_BIN to a working Docker-compatible CLI: %w", dockerBin, err)
+		return fmt.Errorf("workspace image build failed: Docker is not available via %q; start Docker, set workspace.docker_bin, or pass --docker-bin: %w", dockerBin, err)
 	}
 
 	if out != nil {
@@ -119,7 +150,7 @@ func runWorkspaceBuildCommand(ctx context.Context, out io.Writer, opts workspace
 		"-lc", `command -v -- "$1" >/dev/null && "$1" --version >/dev/null`,
 		"swarm-cli-proof", workspaceBuildClaudeCommand,
 	); err != nil {
-		return fmt.Errorf("workspace image validation failed: configured Claude CLI command %q cannot execute in workspace image %q; build or pull a workspace image that includes a runnable Claude CLI, or set SWARM_WORKSPACE_IMAGE/--image to a compatible image: %w", workspaceBuildClaudeCommand, image, err)
+		return fmt.Errorf("workspace image validation failed: configured Claude CLI command %q cannot execute in workspace image %q; build or pull a workspace image that includes a runnable Claude CLI, set workspace.image, or pass --image with a compatible image: %w", workspaceBuildClaudeCommand, image, err)
 	}
 	if _, err := runWorkspaceBuildDocker(ctx, dockerBin, "tag", tempImage, image); err != nil {
 		return fmt.Errorf("workspace image build failed to publish validated image %q: %w", image, err)
@@ -128,6 +159,17 @@ func runWorkspaceBuildCommand(ctx context.Context, out io.Writer, opts workspace
 		fmt.Fprintf(out, "Workspace image %s is ready for claude_cli\n", image)
 	}
 	return nil
+}
+
+func normalizeWorkspaceBuildDockerBin(raw, source string) (string, error) {
+	dockerBin := strings.TrimSpace(raw)
+	if dockerBin == "" {
+		return "", fmt.Errorf("workspace docker binary from %s must be non-empty", source)
+	}
+	if strings.ContainsAny(dockerBin, "\r\n") {
+		return "", fmt.Errorf("workspace docker binary from %s must not contain newlines", source)
+	}
+	return dockerBin, nil
 }
 
 func temporaryWorkspaceBuildImageTag() string {

--- a/cmd/swarm/workspace_build_test.go
+++ b/cmd/swarm/workspace_build_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -15,11 +16,10 @@ func TestWorkspaceBuildClaudeCLIUsesEmbeddedBuildPlanFromTempCWD(t *testing.T) {
 	sourceRoot := repoRoot()
 	tempCWD := t.TempDir()
 	chdirForTest(t, tempCWD)
-	callsPath := configureWorkspaceBuildDockerStub(t)
-	t.Setenv("SWARM_WORKSPACE_IMAGE", "")
+	stub := configureWorkspaceBuildDockerStub(t)
 
 	var stdout, stderr bytes.Buffer
-	code := executeRootCommandWithOptions(context.Background(), tempCWD, []string{"workspace", "build", "--backend", "claude_cli"}, &stdout, &stderr, defaultRootCommandOptions())
+	code := executeRootCommandWithOptions(context.Background(), tempCWD, []string{"workspace", "build", "--backend", "claude_cli", "--docker-bin", stub.dockerPath}, &stdout, &stderr, defaultRootCommandOptions())
 	if code != cliExitOK {
 		t.Fatalf("code = %d stdout=%s stderr=%s", code, stdout.String(), stderr.String())
 	}
@@ -36,7 +36,7 @@ func TestWorkspaceBuildClaudeCLIUsesEmbeddedBuildPlanFromTempCWD(t *testing.T) {
 		}
 	}
 
-	calls := readWorkspaceBuildDockerCalls(t, callsPath)
+	calls := readWorkspaceBuildDockerCalls(t, stub.callsPath)
 	if len(calls) != 5 {
 		t.Fatalf("docker call count = %d, want 5:\n%s", len(calls), strings.Join(calls, "\n"))
 	}
@@ -83,32 +83,67 @@ func TestWorkspaceBuildClaudeCLIUsesEmbeddedBuildPlanFromTempCWD(t *testing.T) {
 }
 
 func TestWorkspaceBuildClaudeCLIImageOverride(t *testing.T) {
-	callsPath := configureWorkspaceBuildDockerStub(t)
-	t.Setenv("SWARM_WORKSPACE_IMAGE", "env-image:latest")
+	stub := configureWorkspaceBuildDockerStub(t)
 
 	var stdout, stderr bytes.Buffer
-	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"workspace", "build", "--backend", "claude_cli", "--image", "custom/image:test"}, &stdout, &stderr, defaultRootCommandOptions())
+	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"workspace", "build", "--backend", "claude_cli", "--docker-bin", stub.dockerPath, "--image", "custom/image:test"}, &stdout, &stderr, defaultRootCommandOptions())
 	if code != cliExitOK {
 		t.Fatalf("code = %d stdout=%s stderr=%s", code, stdout.String(), stderr.String())
 	}
-	calls := strings.Join(readWorkspaceBuildDockerCalls(t, callsPath), "\n")
+	calls := strings.Join(readWorkspaceBuildDockerCalls(t, stub.callsPath), "\n")
 	if !strings.Contains(calls, "tag swarm-workspace-build-") || !strings.Contains(calls, " custom/image:test") {
 		t.Fatalf("docker calls did not use --image override:\n%s", calls)
 	}
 	if strings.Contains(calls, "build -t custom/image:test") || strings.Contains(calls, "run --rm --entrypoint sh custom/image:test") {
 		t.Fatalf("docker calls published or validated final image before validation completed:\n%s", calls)
 	}
-	if strings.Contains(calls, "env-image:latest") {
-		t.Fatalf("docker calls used env image despite --image override:\n%s", calls)
+}
+
+func TestWorkspaceBuildConfigPathResolvesFromDiscoveredRepoRoot(t *testing.T) {
+	repo := t.TempDir()
+	if err := os.WriteFile(filepath.Join(repo, "go.mod"), []byte("module workspace-build-config-test\n"), 0o644); err != nil {
+		t.Fatalf("write go.mod: %v", err)
+	}
+	stub := configureWorkspaceBuildDockerStub(t)
+	writeRuntimeConfigText(t, filepath.Join(repo, "swarm.yaml"), strings.Join([]string{
+		"runtime:",
+		"  recovery_on_startup: false",
+		"workspace:",
+		"  image: repo-config-image:test",
+		fmt.Sprintf("  docker_bin: %q", stub.dockerPath),
+		"llm:",
+		"  backend: anthropic",
+		"  session:",
+		"    lock_ttl: 10s",
+		"    rotate_after_turns: 40",
+		"    rotate_on_parse_failures: 3",
+	}, "\n")+"\n")
+	subdir := filepath.Join(repo, "nested", "child")
+	if err := os.MkdirAll(subdir, 0o755); err != nil {
+		t.Fatalf("mkdir nested cwd: %v", err)
+	}
+	chdirForTest(t, subdir)
+
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), "", []string{"workspace", "build", "--backend", "claude_cli", "--config", "swarm.yaml"}, &stdout, &stderr, defaultRootCommandOptions())
+	if code != cliExitOK {
+		t.Fatalf("code = %d stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	calls := strings.Join(readWorkspaceBuildDockerCalls(t, stub.callsPath), "\n")
+	if !strings.Contains(calls, " repo-config-image:test") {
+		t.Fatalf("docker calls did not use workspace.image from repo-root config:\n%s", calls)
+	}
+	if strings.Contains(calls, " swarm-workspace:latest") {
+		t.Fatalf("docker calls used default image instead of repo-root config:\n%s", calls)
 	}
 }
 
 func TestWorkspaceBuildClaudeCLIFailsOnDockerBuildError(t *testing.T) {
-	configureWorkspaceBuildDockerStub(t)
+	stub := configureWorkspaceBuildDockerStub(t)
 	t.Setenv("SWARM_TEST_DOCKER_FAIL_BUILD", "1")
 
 	var stdout, stderr bytes.Buffer
-	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"workspace", "build", "--backend", "claude_cli"}, &stdout, &stderr, defaultRootCommandOptions())
+	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"workspace", "build", "--backend", "claude_cli", "--docker-bin", stub.dockerPath}, &stdout, &stderr, defaultRootCommandOptions())
 	if code != cliExitRuntime {
 		t.Fatalf("code = %d, want %d stdout=%s stderr=%s", code, cliExitRuntime, stdout.String(), stderr.String())
 	}
@@ -120,11 +155,11 @@ func TestWorkspaceBuildClaudeCLIFailsOnDockerBuildError(t *testing.T) {
 }
 
 func TestWorkspaceBuildClaudeCLIFailsOnValidationError(t *testing.T) {
-	callsPath := configureWorkspaceBuildDockerStub(t)
+	stub := configureWorkspaceBuildDockerStub(t)
 	t.Setenv("SWARM_TEST_DOCKER_FAIL_VALIDATE", "1")
 
 	var stdout, stderr bytes.Buffer
-	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"workspace", "build", "--backend", "claude_cli"}, &stdout, &stderr, defaultRootCommandOptions())
+	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"workspace", "build", "--backend", "claude_cli", "--docker-bin", stub.dockerPath}, &stdout, &stderr, defaultRootCommandOptions())
 	if code != cliExitRuntime {
 		t.Fatalf("code = %d, want %d stdout=%s stderr=%s", code, cliExitRuntime, stdout.String(), stderr.String())
 	}
@@ -133,7 +168,7 @@ func TestWorkspaceBuildClaudeCLIFailsOnValidationError(t *testing.T) {
 			t.Fatalf("stderr missing %q:\n%s", want, stderr.String())
 		}
 	}
-	calls := strings.Join(readWorkspaceBuildDockerCalls(t, callsPath), "\n")
+	calls := strings.Join(readWorkspaceBuildDockerCalls(t, stub.callsPath), "\n")
 	if strings.Contains(calls, "\ntag ") || strings.HasPrefix(calls, "tag ") {
 		t.Fatalf("docker calls published final image after validation failure:\n%s", calls)
 	}
@@ -143,14 +178,14 @@ func TestWorkspaceBuildClaudeCLIFailsOnValidationError(t *testing.T) {
 }
 
 func TestWorkspaceBuildClaudeCLIFailsOnUnavailableDocker(t *testing.T) {
-	t.Setenv("SWARM_DOCKER_BIN", filepath.Join(t.TempDir(), "missing-docker"))
+	missingDocker := filepath.Join(t.TempDir(), "missing-docker")
 
 	var stdout, stderr bytes.Buffer
-	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"workspace", "build", "--backend", "claude_cli"}, &stdout, &stderr, defaultRootCommandOptions())
+	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"workspace", "build", "--backend", "claude_cli", "--docker-bin", missingDocker}, &stdout, &stderr, defaultRootCommandOptions())
 	if code != cliExitRuntime {
 		t.Fatalf("code = %d, want %d stdout=%s stderr=%s", code, cliExitRuntime, stdout.String(), stderr.String())
 	}
-	for _, want := range []string{"Docker is not available", "SWARM_DOCKER_BIN"} {
+	for _, want := range []string{"Docker is not available", "--docker-bin"} {
 		if !strings.Contains(stderr.String(), want) {
 			t.Fatalf("stderr missing %q:\n%s", want, stderr.String())
 		}
@@ -224,7 +259,7 @@ func TestWorkspaceBuildSpecAuthorityPromoted(t *testing.T) {
 			t.Fatalf("build plan rule missing %q:\n%s", want, owner.BuildPlanRule)
 		}
 	}
-	for _, want := range []string{"SWARM_WORKSPACE_IMAGE", "swarm-workspace:latest", "--image"} {
+	for _, want := range []string{"workspace.image", "swarm-workspace:latest", "--image"} {
 		if !strings.Contains(owner.ImageTargetRule, want) {
 			t.Fatalf("image target rule missing %q:\n%s", want, owner.ImageTargetRule)
 		}
@@ -244,10 +279,10 @@ func TestWorkspaceBuildSpecAuthorityPromoted(t *testing.T) {
 		}
 	}
 	row := spec.CLISpecification.CommandCatalog.WorkspaceBuild
-	if row.Command != "swarm workspace build --backend claude_cli [--image <tag>]" || row.ImplementationStatus != "implemented_first_slice" || row.Owner != "workspace_model.local_workspace_image_build_authority" {
+	if row.Command != "swarm workspace build --backend claude_cli [--config <path>] [--image <tag>] [--docker-bin <path>]" || row.ImplementationStatus != "implemented_first_slice" || row.Owner != "workspace_model.local_workspace_image_build_authority" {
 		t.Fatalf("workspace_build command catalog row = %#v", row)
 	}
-	for _, want := range []string{"embedded/materialized", "temporary image tag", "SWARM_DOCKER_BIN", "SWARM_WORKSPACE_IMAGE", "claude --version"} {
+	for _, want := range []string{"embedded/materialized", "temporary image tag", "workspace.docker_bin", "workspace.image", "claude --version"} {
 		if !strings.Contains(row.Behavior, want) {
 			t.Fatalf("workspace_build behavior missing %q:\n%s", want, row.Behavior)
 		}
@@ -257,7 +292,12 @@ func TestWorkspaceBuildSpecAuthorityPromoted(t *testing.T) {
 	}
 }
 
-func configureWorkspaceBuildDockerStub(t *testing.T) string {
+type workspaceBuildDockerStub struct {
+	callsPath  string
+	dockerPath string
+}
+
+func configureWorkspaceBuildDockerStub(t *testing.T) workspaceBuildDockerStub {
 	t.Helper()
 	dir := t.TempDir()
 	callsPath := filepath.Join(dir, "docker.calls")
@@ -301,11 +341,10 @@ esac
 	if err := os.WriteFile(dockerPath, []byte(script), 0o755); err != nil {
 		t.Fatalf("write fake docker: %v", err)
 	}
-	t.Setenv("SWARM_DOCKER_BIN", dockerPath)
 	t.Setenv("SWARM_TEST_DOCKER_CALLS", callsPath)
 	t.Setenv("SWARM_TEST_DOCKER_FAIL_BUILD", "")
 	t.Setenv("SWARM_TEST_DOCKER_FAIL_VALIDATE", "")
-	return callsPath
+	return workspaceBuildDockerStub{callsPath: callsPath, dockerPath: dockerPath}
 }
 
 func workspaceBuildTaggedImageFromCall(t *testing.T, call string) string {

--- a/cmd/swarm/workspace_data_source.go
+++ b/cmd/swarm/workspace_data_source.go
@@ -10,9 +10,6 @@ import (
 )
 
 const (
-	envWorkspaceDataSource  = "SWARM_WORKSPACE_DATA_SOURCE"
-	envWorkspaceVolumesFrom = "SWARM_WORKSPACE_VOLUMES_FROM"
-
 	defaultWorkspaceDataSourceRelativePath = ".swarm/data"
 	defaultWorkspaceDataSourceSource       = "project_default"
 )
@@ -30,9 +27,6 @@ type workspaceDataSourceInput struct {
 	ConfigDataSource    string
 	ConfigDataSourceSet bool
 
-	EnvDataSource    string
-	EnvDataSourceSet bool
-
 	VolumesFrom    string
 	VolumesFromSet bool
 
@@ -49,9 +43,6 @@ func resolveWorkspaceMountSourcesFromInput(in workspaceDataSourceInput) (workspa
 	case in.ConfigDataSourceSet:
 		path, err := normalizeWorkspaceDataSourcePath(in.RepoRoot, in.ConfigDataSource, "workspace.data_source")
 		return workspaceMountSources{DataSource: path, DataSourceSource: "workspace.data_source"}, err
-	case in.EnvDataSourceSet:
-		path, err := normalizeWorkspaceDataSourcePath(in.RepoRoot, in.EnvDataSource, envWorkspaceDataSource)
-		return workspaceMountSources{DataSource: path, DataSourceSource: envWorkspaceDataSource}, err
 	case in.VolumesFromSet && strings.TrimSpace(in.VolumesFrom) != "":
 		return workspaceMountSources{}, nil
 	case strings.TrimSpace(in.DefaultDataSource) != "":
@@ -66,7 +57,7 @@ func resolveWorkspaceMountSourcesFromInput(in workspaceDataSourceInput) (workspa
 		}
 		return workspaceMountSources{DataSource: path, DataSourceSource: defaultWorkspaceDataSourceSourceLabel(in.DefaultDataSourceSource)}, nil
 	default:
-		return workspaceMountSources{}, fmt.Errorf("workspace data source is required: pass --data, set workspace.data_source, set %s, or run from a project with a managed %s default", envWorkspaceDataSource, defaultWorkspaceDataSourceRelativePath)
+		return workspaceMountSources{}, fmt.Errorf("workspace data source is required: pass --data, set workspace.data_source, or run from a project with a managed %s default", defaultWorkspaceDataSourceRelativePath)
 	}
 }
 

--- a/cmd/swarm/workspace_runtime_config.go
+++ b/cmd/swarm/workspace_runtime_config.go
@@ -1,0 +1,112 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/division-sh/swarm/internal/config"
+	workspace "github.com/division-sh/swarm/internal/runtime/workspace"
+)
+
+func workspaceConfigValue(raw string, configured bool, key string) (string, bool, error) {
+	if !configured && strings.TrimSpace(raw) == "" {
+		return "", false, nil
+	}
+	value := strings.TrimSpace(raw)
+	if value == "" {
+		return "", true, fmt.Errorf("%s must be non-empty when configured", key)
+	}
+	return value, true, nil
+}
+
+func runtimeConfigWorkspaceImage(cfg *config.Config) (string, bool, error) {
+	if cfg == nil {
+		return "", false, nil
+	}
+	return workspaceConfigValue(cfg.Workspace.Image, cfg.Workspace.ImageConfigured(), "workspace.image")
+}
+
+func runtimeConfigWorkspaceDockerBin(cfg *config.Config) (string, bool, error) {
+	if cfg == nil {
+		return "", false, nil
+	}
+	return workspaceConfigValue(cfg.Workspace.DockerBin, cfg.Workspace.DockerBinConfigured(), "workspace.docker_bin")
+}
+
+func runtimeConfigWorkspaceHostRoot(cfg *config.Config) (string, bool, error) {
+	if cfg == nil {
+		return "", false, nil
+	}
+	return workspaceConfigValue(cfg.Workspace.HostRoot, cfg.Workspace.HostRootConfigured(), "workspace.host_root")
+}
+
+func runtimeConfigWorkspaceVolumesFrom(cfg *config.Config) (string, bool, error) {
+	if cfg == nil {
+		return "", false, nil
+	}
+	return workspaceConfigValue(cfg.Workspace.VolumesFrom, cfg.Workspace.VolumesFromConfigured(), "workspace.volumes_from")
+}
+
+func runtimeConfigWorkspaceNetwork(cfg *config.Config) (string, bool, error) {
+	if cfg == nil {
+		return "", false, nil
+	}
+	return workspaceConfigValue(cfg.Workspace.Network, cfg.Workspace.NetworkConfigured(), "workspace.network")
+}
+
+func workspaceImageFromRuntimeConfigOrDefault(cfg *config.Config) (string, error) {
+	image, ok, err := runtimeConfigWorkspaceImage(cfg)
+	if err != nil {
+		return "", err
+	}
+	if ok {
+		return image, nil
+	}
+	return workspace.DefaultWorkspaceImage(), nil
+}
+
+func workspaceDockerBinFromRuntimeConfigOrDefault(cfg *config.Config) (string, error) {
+	dockerBin, ok, err := runtimeConfigWorkspaceDockerBin(cfg)
+	if err != nil {
+		return "", err
+	}
+	if ok {
+		return dockerBin, nil
+	}
+	return workspace.DefaultDockerBin(), nil
+}
+
+func dockerWorkspaceConfigFromRuntimeConfig(cfg *config.Config) (workspace.DockerConfig, error) {
+	out := workspace.DefaultDockerConfig()
+	if image, ok, err := runtimeConfigWorkspaceImage(cfg); err != nil {
+		return out, err
+	} else if ok {
+		out.WorkspaceImage = image
+	}
+	if dockerBin, ok, err := runtimeConfigWorkspaceDockerBin(cfg); err != nil {
+		return out, err
+	} else if ok {
+		out.DockerBin = dockerBin
+	}
+	if network, ok, err := runtimeConfigWorkspaceNetwork(cfg); err != nil {
+		return out, err
+	} else if ok {
+		out.WorkspaceNetwork = network
+	}
+	if volumesFrom, ok, err := runtimeConfigWorkspaceVolumesFrom(cfg); err != nil {
+		return out, err
+	} else if ok {
+		out.WorkspaceVolumesFrom = volumesFrom
+	}
+	return out, nil
+}
+
+func hostWorkspaceConfigFromRuntimeConfig(cfg *config.Config) (workspace.HostConfig, error) {
+	out := workspace.DefaultHostConfig()
+	if hostRoot, ok, err := runtimeConfigWorkspaceHostRoot(cfg); err != nil {
+		return out, err
+	} else if ok {
+		out.WorkspaceRoot = hostRoot
+	}
+	return out, nil
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -67,10 +67,20 @@ type WorkspaceConfig struct {
 	DataSource      string `yaml:"data_source"`
 	Backend         string `yaml:"backend"`
 	AllowExecOnHost bool   `yaml:"allow_exec_on_host"`
+	Image           string `yaml:"image"`
+	DockerBin       string `yaml:"docker_bin"`
+	HostRoot        string `yaml:"host_root"`
+	VolumesFrom     string `yaml:"volumes_from"`
+	Network         string `yaml:"network"`
 
 	dataSourceSet      bool
 	backendSet         bool
 	allowExecOnHostSet bool
+	imageSet           bool
+	dockerBinSet       bool
+	hostRootSet        bool
+	volumesFromSet     bool
+	networkSet         bool
 }
 
 func (w *WorkspaceConfig) UnmarshalYAML(value *yaml.Node) error {
@@ -89,6 +99,16 @@ func (w *WorkspaceConfig) UnmarshalYAML(value *yaml.Node) error {
 				w.backendSet = true
 			case "allow_exec_on_host":
 				w.allowExecOnHostSet = true
+			case "image":
+				w.imageSet = true
+			case "docker_bin":
+				w.dockerBinSet = true
+			case "host_root":
+				w.hostRootSet = true
+			case "volumes_from":
+				w.volumesFromSet = true
+			case "network":
+				w.networkSet = true
 			}
 		}
 	}
@@ -105,6 +125,26 @@ func (w WorkspaceConfig) BackendConfigured() bool {
 
 func (w WorkspaceConfig) AllowExecOnHostConfigured() bool {
 	return w.allowExecOnHostSet || w.AllowExecOnHost
+}
+
+func (w WorkspaceConfig) ImageConfigured() bool {
+	return w.imageSet || strings.TrimSpace(w.Image) != ""
+}
+
+func (w WorkspaceConfig) DockerBinConfigured() bool {
+	return w.dockerBinSet || strings.TrimSpace(w.DockerBin) != ""
+}
+
+func (w WorkspaceConfig) HostRootConfigured() bool {
+	return w.hostRootSet || strings.TrimSpace(w.HostRoot) != ""
+}
+
+func (w WorkspaceConfig) VolumesFromConfigured() bool {
+	return w.volumesFromSet || strings.TrimSpace(w.VolumesFrom) != ""
+}
+
+func (w WorkspaceConfig) NetworkConfigured() bool {
+	return w.networkSet || strings.TrimSpace(w.Network) != ""
 }
 
 type LLMConfig struct {

--- a/internal/runtime/conformance/persisted_surfaces_test.go
+++ b/internal/runtime/conformance/persisted_surfaces_test.go
@@ -424,7 +424,6 @@ printf '{"result":"ok"}'
 	if err := os.WriteFile(fakeDocker, []byte(script), 0o755); err != nil {
 		t.Fatalf("write fake docker: %v", err)
 	}
-	t.Setenv("SWARM_DOCKER_BIN", fakeDocker)
 	t.Setenv("SWARM_FAKE_DOCKER_STATE", dockerState)
 	t.Setenv("CLAUDE_CODE_OAUTH_TOKEN", "stale-oauth-token")
 
@@ -434,6 +433,9 @@ printf '{"result":"ok"}'
 		t.Fatalf("NewEventBus: %v", err)
 	}
 	runtime := runtimellm.NewClaudeCLIRuntimeWithOptions(&config.Config{
+		Workspace: config.WorkspaceConfig{
+			DockerBin: fakeDocker,
+		},
 		LLM: config.LLMConfig{
 			ClaudeCLI: config.ClaudeCLIConfig{
 				Command:      "claude",

--- a/internal/runtime/llm/cli_runtime_process.go
+++ b/internal/runtime/llm/cli_runtime_process.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"os"
 	"os/exec"
 	"strings"
 	"time"
@@ -288,10 +287,7 @@ func (r *ClaudeCLIRuntime) buildCommand(ctx context.Context, args []string, targ
 		return nil, err
 	}
 	if execTarget.Mode == workspace.ExecutionModeDockerContainer {
-		dockerBin := strings.TrimSpace(os.Getenv("SWARM_DOCKER_BIN"))
-		if dockerBin == "" {
-			dockerBin = "docker"
-		}
+		dockerBin := configuredWorkspaceDockerBin(r.cfg)
 		dockerArgs := []string{"exec", "-i"}
 		gatewayURL := r.toolGateway.WorkspaceMCPURL()
 		if gatewayURL != "" {

--- a/internal/runtime/llm/cli_runtime_process_test.go
+++ b/internal/runtime/llm/cli_runtime_process_test.go
@@ -139,7 +139,6 @@ func TestClaudeCLIRuntimeBuildCommand_UsesContainerReachableMCPGatewayURL(t *tes
 
 func TestClaudeCLIRuntimeRunWithInput_MissingWorkspaceCLIUsesActionableDiagnostic(t *testing.T) {
 	t.Setenv("CLAUDE_CODE_OAUTH_TOKEN", "stale-oauth-token")
-	t.Setenv("SWARM_WORKSPACE_IMAGE", "swarm-workspace:test")
 
 	tempDir := t.TempDir()
 	scriptPath := filepath.Join(tempDir, "fake-docker.sh")
@@ -152,9 +151,10 @@ exit 127
 	if err := os.WriteFile(scriptPath, []byte(script), 0o755); err != nil {
 		t.Fatalf("write fake docker script: %v", err)
 	}
-	t.Setenv("SWARM_DOCKER_BIN", scriptPath)
 
 	cfg := &config.Config{}
+	cfg.Workspace.DockerBin = scriptPath
+	cfg.Workspace.Image = "swarm-workspace:test"
 	cfg.LLM.ClaudeCLI.Command = "claude"
 	cfg.LLM.ClaudeCLI.OutputFormat = "json"
 	runtime := NewClaudeCLIRuntime(cfg, sessions.NewInMemoryRegistry(0), "worker-1", nil, nil, nil, nil, nil)
@@ -177,15 +177,15 @@ exit 127
 }
 
 func TestWorkspaceCLIDiagnosticError_MatchesAbsolutePathNoSuchFile(t *testing.T) {
-	t.Setenv("SWARM_WORKSPACE_IMAGE", "swarm-workspace:absolute")
 	cfg := &config.Config{}
+	cfg.Workspace.Image = "swarm-workspace:absolute"
 	cfg.LLM.ClaudeCLI.Command = "/usr/local/bin/claude"
 
 	err := workspaceCLIDiagnosticError(cfg, &workspace.Target{Container: "swarm-agent-market-research"}, `OCI runtime exec failed: exec failed: unable to start container process: exec: "/usr/local/bin/claude": stat /usr/local/bin/claude: no such file or directory: unknown`)
 	if !errors.Is(err, ErrClaudeWorkspaceCLIUnavailable) {
 		t.Fatalf("workspaceCLIDiagnosticError error = %v, want ErrClaudeWorkspaceCLIUnavailable", err)
 	}
-	for _, want := range []string{`"/usr/local/bin/claude"`, `"swarm-agent-market-research"`, `"swarm-workspace:absolute"`, "set SWARM_WORKSPACE_IMAGE"} {
+	for _, want := range []string{`"/usr/local/bin/claude"`, `"swarm-agent-market-research"`, `"swarm-workspace:absolute"`, "set workspace.image"} {
 		if !strings.Contains(err.Error(), want) {
 			t.Fatalf("workspaceCLIDiagnosticError error missing %q:\n%v", want, err)
 		}

--- a/internal/runtime/llm/cli_runtime_startup_probe_test.go
+++ b/internal/runtime/llm/cli_runtime_startup_probe_test.go
@@ -46,9 +46,9 @@ printf '%s\n' '{"type":"system","subtype":"init","session_id":"provider-startup-
 	if err := os.WriteFile(scriptPath, []byte(script), 0o755); err != nil {
 		t.Fatalf("write fake docker script: %v", err)
 	}
-	t.Setenv("SWARM_DOCKER_BIN", scriptPath)
 
 	cfg := &config.Config{}
+	cfg.Workspace.DockerBin = scriptPath
 	cfg.LLM.ClaudeCLI.OutputFormat = "stream-json"
 	cfg.LLM.ClaudeCLI.Command = "claude"
 
@@ -127,10 +127,10 @@ printf '%s\n' '{"type":"system","subtype":"init","session_id":"provider-startup-
 	if err := os.WriteFile(scriptPath, []byte(script), 0o755); err != nil {
 		t.Fatalf("write fake docker script: %v", err)
 	}
-	t.Setenv("SWARM_DOCKER_BIN", scriptPath)
 	t.Setenv("CAPTURE_PATH", capturePath)
 
 	cfg := &config.Config{}
+	cfg.Workspace.DockerBin = scriptPath
 	cfg.LLM.ClaudeCLI.OutputFormat = "stream-json"
 	cfg.LLM.ClaudeCLI.Command = "claude"
 
@@ -181,7 +181,6 @@ func TestClaudeCLIRuntimeProbeStartupVisibleToolSurface_MissingWorkspaceCLIIsAct
 	t.Setenv("SWARM_CLAUDE_USE_MCP", "1")
 	t.Setenv("SWARM_TOOL_GATEWAY_CONTAINER_URL", "http://host.docker.internal:8081")
 	t.Setenv("SWARM_TOOL_GATEWAY_TOKEN", "gateway-token")
-	t.Setenv("SWARM_WORKSPACE_IMAGE", "swarm-workspace:test")
 	t.Setenv("CLAUDE_CODE_OAUTH_TOKEN", "stale-oauth-token")
 
 	tempDir := t.TempDir()
@@ -195,9 +194,10 @@ exit 127
 	if err := os.WriteFile(scriptPath, []byte(script), 0o755); err != nil {
 		t.Fatalf("write fake docker script: %v", err)
 	}
-	t.Setenv("SWARM_DOCKER_BIN", scriptPath)
 
 	cfg := &config.Config{}
+	cfg.Workspace.DockerBin = scriptPath
+	cfg.Workspace.Image = "swarm-workspace:test"
 	cfg.LLM.ClaudeCLI.OutputFormat = "stream-json"
 	cfg.LLM.ClaudeCLI.Command = "claude"
 
@@ -230,7 +230,7 @@ exit 127
 		`"swarm-agent-market-research"`,
 		`"swarm-workspace:test"`,
 		"remove stale workspace containers",
-		"set SWARM_WORKSPACE_IMAGE",
+		"set workspace.image",
 	} {
 		if !strings.Contains(err.Error(), want) {
 			t.Fatalf("ProbeStartupVisibleToolSurface error missing %q:\n%v", want, err)

--- a/internal/runtime/llm/cli_runtime_supported_path_test.go
+++ b/internal/runtime/llm/cli_runtime_supported_path_test.go
@@ -78,10 +78,10 @@ func TestConversationStep_ClaudeCLIFirstTurnPreservesSupportedReadFileSurface(t 
 	if err := os.WriteFile(scriptPath, []byte(script), 0o755); err != nil {
 		t.Fatalf("write fake docker script: %v", err)
 	}
-	t.Setenv("SWARM_DOCKER_BIN", scriptPath)
 	t.Setenv("FAKE_DOCKER_CAPTURE_DIR", captureDir)
 
 	cfg := &config.Config{}
+	cfg.Workspace.DockerBin = scriptPath
 	cfg.LLM.ClaudeCLI.OutputFormat = "stream-json"
 	cfg.LLM.ClaudeCLI.Command = "claude"
 

--- a/internal/runtime/llm/cli_runtime_workspace_diagnostics.go
+++ b/internal/runtime/llm/cli_runtime_workspace_diagnostics.go
@@ -2,7 +2,6 @@ package llm
 
 import (
 	"fmt"
-	"os"
 	"strings"
 
 	"github.com/division-sh/swarm/internal/config"
@@ -23,11 +22,8 @@ func workspaceCLIDiagnosticError(cfg *config.Config, target *workspace.Target, r
 	if target != nil && strings.TrimSpace(target.Container) != "" {
 		container = strings.TrimSpace(target.Container)
 	}
-	image := strings.TrimSpace(os.Getenv("SWARM_WORKSPACE_IMAGE"))
-	if image == "" {
-		image = workspace.ConfiguredWorkspaceImageFromEnv()
-	}
-	return fmt.Errorf("%w: local cli_test workspace cannot execute configured Claude CLI command %q in container %q (workspace image %q or an existing stale/incompatible workspace container is missing the CLI); build or pull a workspace image that includes the Claude CLI, remove stale workspace containers, or set SWARM_WORKSPACE_IMAGE to a compatible image: %s", ErrClaudeWorkspaceCLIUnavailable, command, container, image, summary)
+	image := configuredWorkspaceImage(cfg)
+	return fmt.Errorf("%w: local cli_test workspace cannot execute configured Claude CLI command %q in container %q (workspace image %q or an existing stale/incompatible workspace container is missing the CLI); build or pull a workspace image that includes the Claude CLI, remove stale workspace containers, or set workspace.image to a compatible image: %s", ErrClaudeWorkspaceCLIUnavailable, command, container, image, summary)
 }
 
 func configuredClaudeCLICommand(cfg *config.Config) string {

--- a/internal/runtime/llm/cli_tool_result_relay.go
+++ b/internal/runtime/llm/cli_tool_result_relay.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"os"
 	"os/exec"
 	"path"
 	"strings"
@@ -108,10 +107,7 @@ func (r *ClaudeCLIRuntime) runWorkspaceCommand(ctx context.Context, target *work
 	if r != nil && r.execWorkspaceFn != nil {
 		return r.execWorkspaceFn(ctx, target, stdin, args...)
 	}
-	dockerBin := strings.TrimSpace(os.Getenv("SWARM_DOCKER_BIN"))
-	if dockerBin == "" {
-		dockerBin = "docker"
-	}
+	dockerBin := configuredWorkspaceDockerBin(r.cfg)
 	dockerArgs := []string{"exec", "-i"}
 	if strings.TrimSpace(execTarget.Workdir) != "" {
 		dockerArgs = append(dockerArgs, "-w", execTarget.Workdir)

--- a/internal/runtime/llm/provider_admission_test.go
+++ b/internal/runtime/llm/provider_admission_test.go
@@ -408,7 +408,7 @@ func TestClaudeCLIProviderAdmissionRejectsBeforeSubprocessDispatch(t *testing.T)
 	scriptPath, countFile := writeProviderAdmissionFakeDocker(t, `cat >/dev/null
 printf '%s\n' '{"result":"done"}'
 `)
-	t.Setenv("SWARM_DOCKER_BIN", scriptPath)
+	cfg.Workspace.DockerBin = scriptPath
 	target := &workspace.Target{Container: "swarm-agent", Workdir: "/workspace"}
 	profile := mustAdmissionProfile(t, llmselection.BackendClaudeCLI)
 	model := mustAdmissionModel(t, profile, llmselection.ModelAliasRegular)
@@ -452,7 +452,7 @@ if [ "$count" = "1" ]; then
 fi
 printf '%s\n' '{"result":"done"}'
 `)
-	t.Setenv("SWARM_DOCKER_BIN", scriptPath)
+	cfg.Workspace.DockerBin = scriptPath
 	target := &workspace.Target{Container: "swarm-agent", Workdir: "/workspace"}
 
 	_, fallback, err := runtime.runWithPromptTransportFallback(ctx, []string{"--print"}, target, "hello", MonitorTurnMeta{})

--- a/internal/runtime/llm/workspace_config.go
+++ b/internal/runtime/llm/workspace_config.go
@@ -1,0 +1,26 @@
+package llm
+
+import (
+	"strings"
+
+	"github.com/division-sh/swarm/internal/config"
+	workspace "github.com/division-sh/swarm/internal/runtime/workspace"
+)
+
+func configuredWorkspaceDockerBin(cfg *config.Config) string {
+	if cfg != nil {
+		if dockerBin := strings.TrimSpace(cfg.Workspace.DockerBin); dockerBin != "" {
+			return dockerBin
+		}
+	}
+	return workspace.DefaultDockerBin()
+}
+
+func configuredWorkspaceImage(cfg *config.Config) string {
+	if cfg != nil {
+		if image := strings.TrimSpace(cfg.Workspace.Image); image != "" {
+			return image
+		}
+	}
+	return workspace.DefaultWorkspaceImage()
+}

--- a/internal/runtime/tools/executor_native.go
+++ b/internal/runtime/tools/executor_native.go
@@ -337,10 +337,7 @@ func (e *Executor) runWorkspaceCommand(ctx context.Context, target *workspace.Ta
 	var cmd *exec.Cmd
 	switch execTarget.Mode {
 	case workspace.ExecutionModeDockerContainer:
-		dockerBin := strings.TrimSpace(os.Getenv("SWARM_DOCKER_BIN"))
-		if dockerBin == "" {
-			dockerBin = "docker"
-		}
+		dockerBin := workspaceDockerBin(e.cfg)
 		dockerArgs := []string{"exec", "-i"}
 		if workdir := strings.TrimSpace(execTarget.Workdir); workdir != "" {
 			dockerArgs = append(dockerArgs, "-w", workdir)

--- a/internal/runtime/tools/executor_native_host_test.go
+++ b/internal/runtime/tools/executor_native_host_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/division-sh/swarm/internal/config"
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
 	models "github.com/division-sh/swarm/internal/runtime/core/actors"
 	llm "github.com/division-sh/swarm/internal/runtime/llm"
@@ -67,8 +68,7 @@ func TestNativeWorkspaceCommandFailsClosedForHostTargetWithoutBackingPath(t *tes
 func TestNativeWorkspaceCommandDoesNotFallbackFromDockerToHost(t *testing.T) {
 	marker := filepath.Join(t.TempDir(), "fallback-marker")
 	missingDocker := filepath.Join(t.TempDir(), "missing-docker")
-	t.Setenv("SWARM_DOCKER_BIN", missingDocker)
-	exec := &Executor{}
+	exec := &Executor{cfg: &config.Config{Workspace: config.WorkspaceConfig{DockerBin: missingDocker}}}
 	_, _, exitCode, err := exec.runWorkspaceCommand(context.Background(), &workspace.Target{
 		Backend:   workspace.BackendDocker,
 		Container: "swarm-agent",

--- a/internal/runtime/tools/workspace_config.go
+++ b/internal/runtime/tools/workspace_config.go
@@ -1,0 +1,17 @@
+package tools
+
+import (
+	"strings"
+
+	"github.com/division-sh/swarm/internal/config"
+	workspace "github.com/division-sh/swarm/internal/runtime/workspace"
+)
+
+func workspaceDockerBin(cfg *config.Config) string {
+	if cfg != nil {
+		if dockerBin := strings.TrimSpace(cfg.Workspace.DockerBin); dockerBin != "" {
+			return dockerBin
+		}
+	}
+	return workspace.DefaultDockerBin()
+}

--- a/internal/runtime/workspace/host_manager.go
+++ b/internal/runtime/workspace/host_manager.go
@@ -15,8 +15,6 @@ import (
 	models "github.com/division-sh/swarm/internal/runtime/core/actors"
 )
 
-const EnvHostWorkspaceRoot = "SWARM_WORKSPACE_HOST_ROOT"
-
 type HostConfig struct {
 	WorkspaceRoot       string
 	SharedDataSource    string
@@ -35,11 +33,11 @@ type HostManager struct {
 
 func DefaultHostConfig() HostConfig {
 	return HostConfig{
-		WorkspaceRoot:       EnvOrDefault(EnvHostWorkspaceRoot, defaultHostWorkspaceRoot()),
+		WorkspaceRoot:       defaultHostWorkspaceRoot(),
 		SharedDataSource:    "",
-		DataMountPoint:      EnvOrDefault("SWARM_WORKSPACE_DATA_MOUNT", "/data"),
-		ContractsSource:     EnvOrDefault("SWARM_WORKSPACE_CONTRACTS_SOURCE", ""),
-		ContractsMountPoint: EnvOrDefault("SWARM_WORKSPACE_CONTRACTS_MOUNT", "/opt/swarm/contracts"),
+		DataMountPoint:      "/data",
+		ContractsSource:     "",
+		ContractsMountPoint: "/opt/swarm/contracts",
 	}
 }
 

--- a/internal/runtime/workspace/host_manager_test.go
+++ b/internal/runtime/workspace/host_manager_test.go
@@ -31,7 +31,6 @@ func TestHostManagerValidatesSourcesAndCreatesSystemWorkspacesWithoutDocker(t *t
 	if err := manager.ValidateSource(context.Background(), source); err != nil {
 		t.Fatalf("ValidateSource: %v", err)
 	}
-	t.Setenv("SWARM_DOCKER_BIN", filepath.Join(t.TempDir(), "missing-docker"))
 	if err := manager.EnsureSystemWorkspaces(context.Background()); err != nil {
 		t.Fatalf("EnsureSystemWorkspaces: %v", err)
 	}

--- a/internal/runtime/workspace/manager.go
+++ b/internal/runtime/workspace/manager.go
@@ -63,10 +63,23 @@ type DevEntityContainerCleaner interface {
 }
 
 const DevEntityCleanupOperationName = "swarm.serve.dev.entity_container_cleanup"
-const defaultWorkspaceImage = "swarm-workspace:latest"
 
-func ConfiguredWorkspaceImageFromEnv() string {
-	return EnvOrDefault("SWARM_WORKSPACE_IMAGE", defaultWorkspaceImage)
+const (
+	defaultDockerBin        = "docker"
+	defaultWorkspaceImage   = "swarm-workspace:latest"
+	defaultWorkspaceNetwork = "mas_default"
+)
+
+func DefaultDockerBin() string {
+	return defaultDockerBin
+}
+
+func DefaultWorkspaceImage() string {
+	return defaultWorkspaceImage
+}
+
+func DefaultWorkspaceNetwork() string {
+	return defaultWorkspaceNetwork
 }
 
 type DockerConfig struct {
@@ -94,24 +107,24 @@ type DockerConfig struct {
 
 func DefaultDockerConfig() DockerConfig {
 	return DockerConfig{
-		DockerBin:             EnvOrDefault("SWARM_DOCKER_BIN", "docker"),
-		WorkspaceImage:        ConfiguredWorkspaceImageFromEnv(),
-		WorkspaceNetwork:      EnvOrDefault("SWARM_WORKSPACE_NETWORK", "mas_default"),
-		WorkspaceVolumesFrom:  EnvOrDefault("SWARM_WORKSPACE_VOLUMES_FROM", ""),
+		DockerBin:             defaultDockerBin,
+		WorkspaceImage:        defaultWorkspaceImage,
+		WorkspaceNetwork:      defaultWorkspaceNetwork,
+		WorkspaceVolumesFrom:  "",
 		SharedDataSource:      "",
-		DataMountPoint:        EnvOrDefault("SWARM_WORKSPACE_DATA_MOUNT", "/data"),
-		ContractsSource:       EnvOrDefault("SWARM_WORKSPACE_CONTRACTS_SOURCE", ""),
-		ContractsMountPoint:   EnvOrDefault("SWARM_WORKSPACE_CONTRACTS_MOUNT", "/opt/swarm/contracts"),
-		ScaffoldContainer:     EnvOrDefault("SWARM_SCAFFOLD_CONTAINER", "swarm-scaffold"),
-		ScaffoldWorkdir:       EnvOrDefault("SWARM_SCAFFOLD_WORKDIR", "/opt/swarm/scaffold"),
-		ScaffoldVolume:        EnvOrDefault("SWARM_SCAFFOLD_VOLUME", "scaffold"),
-		SystemContainer:       EnvOrDefault("SWARM_SYSTEM_CONTAINER", "swarm-system"),
-		SystemWorkdir:         EnvOrDefault("SWARM_SYSTEM_WORKDIR", "/opt/swarm"),
-		SystemEntitiesVolume:  EnvOrDefault("SWARM_SYSTEM_ENTITIES_VOLUME", "entities"),
-		SystemNginxVolume:     EnvOrDefault("SWARM_SYSTEM_NGINX_VOLUME", "nginx"),
-		SystemSystemdVolume:   EnvOrDefault("SWARM_SYSTEM_SYSTEMD_VOLUME", "systemd"),
-		EntityContainerPrefix: EnvOrDefault("SWARM_ENTITY_CONTAINER_PREFIX", "swarm-"),
-		EntityWorkdir:         EnvOrDefault("SWARM_ENTITY_WORKDIR", "/workspace"),
+		DataMountPoint:        "/data",
+		ContractsSource:       "",
+		ContractsMountPoint:   "/opt/swarm/contracts",
+		ScaffoldContainer:     "swarm-scaffold",
+		ScaffoldWorkdir:       "/opt/swarm/scaffold",
+		ScaffoldVolume:        "scaffold",
+		SystemContainer:       "swarm-system",
+		SystemWorkdir:         "/opt/swarm",
+		SystemEntitiesVolume:  "entities",
+		SystemNginxVolume:     "nginx",
+		SystemSystemdVolume:   "systemd",
+		EntityContainerPrefix: "swarm-",
+		EntityWorkdir:         "/workspace",
 	}
 }
 
@@ -305,7 +318,7 @@ func (m *DockerManager) CheckWorkspaceCLICommandAvailable(ctx context.Context, c
 		command = "claude"
 	}
 	if _, err := m.RunDocker(ctx, "run", "--rm", "--entrypoint", "sh", image, "-lc", `command -v -- "$1" >/dev/null && "$1" --version >/dev/null`, "swarm-cli-proof", command); err != nil {
-		return fmt.Errorf("workspace prerequisite failed: configured Claude CLI command %q cannot execute in workspace image %q; build or pull a workspace image that includes a runnable Claude CLI, remove stale workspace containers, or set SWARM_WORKSPACE_IMAGE to a compatible image: %w", command, image, err)
+		return fmt.Errorf("workspace prerequisite failed: configured Claude CLI command %q cannot execute in workspace image %q; build or pull a workspace image that includes a runnable Claude CLI, remove stale workspace containers, or set workspace.image to a compatible image: %w", command, image, err)
 	}
 	return nil
 }
@@ -781,7 +794,7 @@ func (m *DockerManager) ensureWorkspaceImage(ctx context.Context) error {
 		return fmt.Errorf("workspace prerequisite failed: workspace image is required")
 	}
 	if _, err := m.RunDocker(ctx, "image", "inspect", image); err != nil {
-		return fmt.Errorf("workspace prerequisite failed: workspace image %s is not available; build or pull the image before startup, or set SWARM_WORKSPACE_IMAGE to an available image: %w", image, err)
+		return fmt.Errorf("workspace prerequisite failed: workspace image %s is not available; build or pull the image before startup, or set workspace.image to an available image: %w", image, err)
 	}
 	return nil
 }
@@ -1296,12 +1309,4 @@ func SanitizeSlug(raw string) string {
 		return ""
 	}
 	return out
-}
-
-func EnvOrDefault(key, fallback string) string {
-	v := strings.TrimSpace(os.Getenv(key))
-	if v == "" {
-		return fallback
-	}
-	return v
 }

--- a/internal/runtime/workspace/manager_test.go
+++ b/internal/runtime/workspace/manager_test.go
@@ -369,9 +369,6 @@ func TestResolveWorkspace_FailsClosedWithoutInjectedSourceForWorkspaceClassScope
 }
 
 func TestDefaultDockerConfigDoesNotDeriveSourceRootMounts(t *testing.T) {
-	t.Setenv("SWARM_WORKSPACE_DATA_SOURCE", "")
-	t.Setenv("SWARM_WORKSPACE_CONTRACTS_SOURCE", "")
-
 	cfg := DefaultDockerConfig()
 	if cfg.SharedDataSource != "" {
 		t.Fatalf("SharedDataSource = %q, want no source-root default", cfg.SharedDataSource)
@@ -382,17 +379,12 @@ func TestDefaultDockerConfigDoesNotDeriveSourceRootMounts(t *testing.T) {
 }
 
 func TestDefaultDockerConfigLeavesDataSourceToCommandResolver(t *testing.T) {
-	dataDir := t.TempDir()
-	contractsDir := t.TempDir()
-	t.Setenv("SWARM_WORKSPACE_DATA_SOURCE", dataDir)
-	t.Setenv("SWARM_WORKSPACE_CONTRACTS_SOURCE", contractsDir)
-
 	cfg := DefaultDockerConfig()
 	if cfg.SharedDataSource != "" {
-		t.Fatalf("SharedDataSource = %q, want command-level resolver to own SWARM_WORKSPACE_DATA_SOURCE", cfg.SharedDataSource)
+		t.Fatalf("SharedDataSource = %q, want command-level resolver to own workspace.data_source", cfg.SharedDataSource)
 	}
-	if cfg.ContractsSource != contractsDir {
-		t.Fatalf("ContractsSource = %q, want %q", cfg.ContractsSource, contractsDir)
+	if cfg.ContractsSource != "" {
+		t.Fatalf("ContractsSource = %q, want command-level resolver to own contracts source", cfg.ContractsSource)
 	}
 }
 
@@ -429,7 +421,7 @@ func TestEnsurePrereqs_CreatesMissingNetworkAndFailsClosedForMissingImage(t *tes
 	if !strings.Contains(err.Error(), "workspace image test-image:latest is not available") {
 		t.Fatalf("EnsurePrereqs error = %v, want missing image diagnostic", err)
 	}
-	if !strings.Contains(err.Error(), "set SWARM_WORKSPACE_IMAGE") {
+	if !strings.Contains(err.Error(), "set workspace.image") {
 		t.Fatalf("EnsurePrereqs error = %v, want configured image remediation", err)
 	}
 

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -11554,85 +11554,85 @@ environment_source_authority:
       owner: platform-spec.yaml#environment_source_authority.repo_wide_swarm_env_accepted_set
       migration: retired
     - name: SWARM_WORKSPACE_DATA_SOURCE
-      category: seeded_legacy
-      owner: platform-spec.yaml#workspace_model.data_source_authority
-      migration: '#1600 workspace.data_source'
+      category: known_retired
+      owner: platform-spec.yaml#environment_source_authority.repo_wide_swarm_env_accepted_set
+      migration: retired
     - name: SWARM_WORKSPACE_BACKEND
-      category: seeded_legacy
-      owner: platform-spec.yaml#workspace_model.workspace_backend_selection
-      migration: '#1600 workspace.backend'
+      category: known_retired
+      owner: platform-spec.yaml#environment_source_authority.repo_wide_swarm_env_accepted_set
+      migration: retired
     - name: SWARM_DOCKER_BIN
-      category: seeded_legacy
-      owner: platform-spec.yaml#environment_source_authority.workspace_monitor_artifact_debug_slice
-      migration: '#1600 workspace/tooling config'
+      category: known_retired
+      owner: platform-spec.yaml#environment_source_authority.repo_wide_swarm_env_accepted_set
+      migration: retired
     - name: SWARM_WORKSPACE_IMAGE
-      category: seeded_legacy
-      owner: platform-spec.yaml#workspace_model.runtime_image_packaging
-      migration: '#1600 workspace.image'
+      category: known_retired
+      owner: platform-spec.yaml#environment_source_authority.repo_wide_swarm_env_accepted_set
+      migration: retired
     - name: SWARM_WORKSPACE_HOST_ROOT
-      category: seeded_legacy
-      owner: platform-spec.yaml#workspace_model.workspace_backend_selection
-      migration: '#1600 workspace.host_root'
+      category: known_retired
+      owner: platform-spec.yaml#environment_source_authority.repo_wide_swarm_env_accepted_set
+      migration: retired
     - name: SWARM_WORKSPACE_VOLUMES_FROM
-      category: seeded_legacy
-      owner: platform-spec.yaml#workspace_model.data_source_authority
-      migration: '#1600 workspace volumes config'
+      category: known_retired
+      owner: platform-spec.yaml#environment_source_authority.repo_wide_swarm_env_accepted_set
+      migration: retired
     - name: SWARM_WORKSPACE_NETWORK
-      category: seeded_legacy
-      owner: platform-spec.yaml#environment_source_authority.workspace_monitor_artifact_debug_slice
-      migration: '#1600 workspace network config'
+      category: known_retired
+      owner: platform-spec.yaml#environment_source_authority.repo_wide_swarm_env_accepted_set
+      migration: retired
     - name: SWARM_WORKSPACE_DATA_MOUNT
-      category: seeded_legacy
-      owner: platform-spec.yaml#environment_source_authority.workspace_monitor_artifact_debug_slice
-      migration: '#1600 workspace mount config'
+      category: known_retired
+      owner: platform-spec.yaml#environment_source_authority.repo_wide_swarm_env_accepted_set
+      migration: retired
     - name: SWARM_WORKSPACE_CONTRACTS_SOURCE
-      category: seeded_legacy
-      owner: platform-spec.yaml#environment_source_authority.workspace_monitor_artifact_debug_slice
-      migration: '#1600 workspace contracts source config'
+      category: known_retired
+      owner: platform-spec.yaml#environment_source_authority.repo_wide_swarm_env_accepted_set
+      migration: retired
     - name: SWARM_WORKSPACE_CONTRACTS_MOUNT
-      category: seeded_legacy
-      owner: platform-spec.yaml#environment_source_authority.workspace_monitor_artifact_debug_slice
-      migration: '#1600 workspace contracts mount config'
+      category: known_retired
+      owner: platform-spec.yaml#environment_source_authority.repo_wide_swarm_env_accepted_set
+      migration: retired
     - name: SWARM_SCAFFOLD_CONTAINER
-      category: seeded_legacy
-      owner: platform-spec.yaml#environment_source_authority.workspace_monitor_artifact_debug_slice
-      migration: '#1600 workspace lifecycle config'
+      category: known_retired
+      owner: platform-spec.yaml#environment_source_authority.repo_wide_swarm_env_accepted_set
+      migration: retired
     - name: SWARM_SCAFFOLD_WORKDIR
-      category: seeded_legacy
-      owner: platform-spec.yaml#environment_source_authority.workspace_monitor_artifact_debug_slice
-      migration: '#1600 workspace lifecycle config'
+      category: known_retired
+      owner: platform-spec.yaml#environment_source_authority.repo_wide_swarm_env_accepted_set
+      migration: retired
     - name: SWARM_SCAFFOLD_VOLUME
-      category: seeded_legacy
-      owner: platform-spec.yaml#environment_source_authority.workspace_monitor_artifact_debug_slice
-      migration: '#1600 workspace lifecycle config'
+      category: known_retired
+      owner: platform-spec.yaml#environment_source_authority.repo_wide_swarm_env_accepted_set
+      migration: retired
     - name: SWARM_SYSTEM_CONTAINER
-      category: seeded_legacy
-      owner: platform-spec.yaml#environment_source_authority.workspace_monitor_artifact_debug_slice
-      migration: '#1600 workspace lifecycle config'
+      category: known_retired
+      owner: platform-spec.yaml#environment_source_authority.repo_wide_swarm_env_accepted_set
+      migration: retired
     - name: SWARM_SYSTEM_WORKDIR
-      category: seeded_legacy
-      owner: platform-spec.yaml#environment_source_authority.workspace_monitor_artifact_debug_slice
-      migration: '#1600 workspace lifecycle config'
+      category: known_retired
+      owner: platform-spec.yaml#environment_source_authority.repo_wide_swarm_env_accepted_set
+      migration: retired
     - name: SWARM_SYSTEM_ENTITIES_VOLUME
-      category: seeded_legacy
-      owner: platform-spec.yaml#environment_source_authority.workspace_monitor_artifact_debug_slice
-      migration: '#1600 workspace lifecycle config'
+      category: known_retired
+      owner: platform-spec.yaml#environment_source_authority.repo_wide_swarm_env_accepted_set
+      migration: retired
     - name: SWARM_SYSTEM_NGINX_VOLUME
-      category: seeded_legacy
-      owner: platform-spec.yaml#environment_source_authority.workspace_monitor_artifact_debug_slice
-      migration: '#1600 workspace lifecycle config'
+      category: known_retired
+      owner: platform-spec.yaml#environment_source_authority.repo_wide_swarm_env_accepted_set
+      migration: retired
     - name: SWARM_SYSTEM_SYSTEMD_VOLUME
-      category: seeded_legacy
-      owner: platform-spec.yaml#environment_source_authority.workspace_monitor_artifact_debug_slice
-      migration: '#1600 workspace lifecycle config'
+      category: known_retired
+      owner: platform-spec.yaml#environment_source_authority.repo_wide_swarm_env_accepted_set
+      migration: retired
     - name: SWARM_ENTITY_CONTAINER_PREFIX
-      category: seeded_legacy
-      owner: platform-spec.yaml#environment_source_authority.workspace_monitor_artifact_debug_slice
-      migration: '#1600 workspace lifecycle config'
+      category: known_retired
+      owner: platform-spec.yaml#environment_source_authority.repo_wide_swarm_env_accepted_set
+      migration: retired
     - name: SWARM_ENTITY_WORKDIR
-      category: seeded_legacy
-      owner: platform-spec.yaml#environment_source_authority.workspace_monitor_artifact_debug_slice
-      migration: '#1600 workspace lifecycle config'
+      category: known_retired
+      owner: platform-spec.yaml#environment_source_authority.repo_wide_swarm_env_accepted_set
+      migration: retired
     - name: SWARM_RUNTIME_RECOVERY_ON_STARTUP
       category: known_retired
       owner: platform-spec.yaml#environment_source_authority.repo_wide_swarm_env_accepted_set
@@ -11824,32 +11824,32 @@ environment_source_authority:
   workspace_monitor_artifact_debug_slice:
     promoted_by: '#1640'
     parent_tracker: '#1600'
-    implementation_status: classification_spec_lock_only
+    implementation_status: classification_updated_by_1843
     canonical_owner: platform-spec.yaml#environment_source_authority.workspace_monitor_artifact_debug_slice
     scope: >
-      Merge-bearing classification authority for the retained #1640 first slice: workspace Docker/host environment sources,
-      local workspace image/bootstrap knobs, runtime-private artifact and monitor roots, prompt/spec helper path overrides,
-      and debug/test environment toggles. This owner records the current source-authority disposition and public-doc quarantine
-      for those envs. It does not implement unknown-env guarding, typed env delegation, doctor env reporting, generated-boundary
-      enforcement, or parent-wide accepted-set ownership; those are split to #1731.
+      Merge-bearing classification authority for the #1640 workspace/monitor/artifact/debug inventory. #1843 retired the
+      workspace Docker/host environment sources, local workspace image/bootstrap knobs, and legacy internal
+      scaffold/system/entity lifecycle rows from parent-process env authority. Runtime-private artifact and monitor roots,
+      prompt/spec helper path overrides, and debug/test environment toggles remain classified here until later children.
+      This owner records current source-authority disposition and public-doc quarantine for those envs; repo-wide
+      guard/doctor enforcement remains owned by #1731.
     classification_rule: >
-      Every env listed here is either governed by an existing typed owner, retained as first-slice production bootstrap /
-      deployment plumbing, retained as internal developer helper source, quarantined as debug/test-only, or explicitly governed
-      by another owner. Public docs and templates MUST NOT present these envs as normal setup. A future migration may move any
-      retained env into typed config or typed delegation only through a later gate; #1640 does not create env-over-config
-      precedence or dual semantic ownership.
+      Every env listed here is either retired by a later child, governed by an existing typed owner, retained as a tracked
+      residual helper/debug source, quarantined as debug/test-only, or explicitly governed by another owner. Public docs and
+      templates MUST NOT present these envs as normal setup. #1640 does not create env-over-config precedence or dual
+      semantic ownership.
     classifications:
       existing_config_owned_workspace_sources:
-        disposition: existing_config_owned_env_source
+        disposition: retired_by_1843_to_flags_or_typed_workspace_config
         owner: workspace_model.data_source_authority and workspace_model.workspace_backend_selection
         env_vars:
         - SWARM_WORKSPACE_DATA_SOURCE
         - SWARM_WORKSPACE_BACKEND
         rule: >
-          These envs already have canonical owners and source order. #1640 classifies them for the retained workspace env
-          inventory only; any removal, typed delegation, or accepted-set guard behavior belongs to #1731 or a later child.
+          These envs historically overlapped existing workspace owners. #1843 removes them from source order and accepted-set
+          seeded status: use `--data` / `workspace.data_source` and `--workspace-backend` / `workspace.backend` instead.
       production_bootstrap_or_deployment_plumbing:
-        disposition: keep_env_first_slice_bootstrap_or_deployment_plumbing
+        disposition: retired_by_1843_to_workspace_config_or_internal_defaults
         owner: workspace_model.runtime_image_packaging, workspace_model.local_workspace_image_build_authority, workspace_model.data_source_authority, workspace_model.workspace_backend_selection, and workspace lifecycle config construction
         env_vars:
         - SWARM_DOCKER_BIN
@@ -11861,14 +11861,13 @@ environment_source_authority:
         - SWARM_WORKSPACE_CONTRACTS_SOURCE
         - SWARM_WORKSPACE_CONTRACTS_MOUNT
         rule: >
-          These envs remain live first-slice workspace/bootstrap inputs because current local Docker/host workspace lifecycle
-          consumers read them before a single typed workspace runtime config owner exists. `SWARM_DOCKER_BIN` is production
-          host-tool bootstrap/plumbing, not debug/test. `SWARM_WORKSPACE_IMAGE` is the current local workspace image selector
-          consumed by startup and `swarm workspace build`. Mount/network/volumes envs are deployment plumbing and MUST NOT be
-          advertised as ordinary project setup. Promotion to typed config or typed env delegation is split to #1731 or later
-          accepted migration children.
+          #1843 removes these envs as live parent-process workspace/bootstrap inputs. `SWARM_DOCKER_BIN` moves to
+          `workspace.docker_bin` or explicit `--docker-bin` for `swarm workspace build`; `SWARM_WORKSPACE_IMAGE` moves to
+          `workspace.image` or explicit `--image`; host root, volumes-from, and network move to typed workspace config.
+          Data/contract mount destinations are internal generated defaults with no env replacement, and contracts source is
+          selected through the contracts path owner / `--contracts`.
       internal_workspace_lifecycle_names:
-        disposition: keep_env_first_slice_internal_runtime_plumbing
+        disposition: retired_by_1843_internal_generated_defaults
         owner: internal/runtime/workspace Docker lifecycle configuration
         env_vars:
         - SWARM_SCAFFOLD_CONTAINER
@@ -11882,9 +11881,9 @@ environment_source_authority:
         - SWARM_ENTITY_CONTAINER_PREFIX
         - SWARM_ENTITY_WORKDIR
         rule: >
-          These are internal local Docker lifecycle naming/workdir knobs. They are not product contract fields, public setup
-          guidance, or proof that container identity is semantically configurable by agents. They remain implementation
-          plumbing until a later typed deployment-config owner promotes or removes them.
+          #1843 removes these rows as live env inputs. They are fixed internal local Docker lifecycle naming/workdir defaults,
+          not product contract fields, public setup guidance, or proof that container identity is semantically configurable by
+          agents.
       runtime_private_storage_and_observability:
         disposition: keep_env_first_slice_runtime_private_storage_or_observability
         owner: runtime_storage.artifact_root and runtime monitor sink
@@ -12070,6 +12069,11 @@ configuration_source_authority:
             data_source: project_contained_path_or_elevated
             backend: project_safe
             allow_exec_on_host: elevated
+            image: elevated
+            docker_bin: elevated
+            host_root: elevated
+            volumes_from: elevated
+            network: elevated
           owner: workspace_model.workspace_backend_selection
         llm:
           trust: project_safe_unless_key_is_marked_elevated
@@ -12213,7 +12217,11 @@ configuration_source_authority:
         SWARM_DB_POOL_SIZE: database.pool_size
         SWARM_WORKSPACE_DATA_SOURCE: workspace.data_source
         SWARM_WORKSPACE_BACKEND: workspace.backend
-        SWARM_WORKSPACE_IMAGE: workspace.image, pending workspace schema child
+        SWARM_DOCKER_BIN: workspace.docker_bin or --docker-bin for workspace build
+        SWARM_WORKSPACE_IMAGE: workspace.image or --image for workspace build
+        SWARM_WORKSPACE_HOST_ROOT: workspace.host_root
+        SWARM_WORKSPACE_VOLUMES_FROM: workspace.volumes_from
+        SWARM_WORKSPACE_NETWORK: workspace.network
         SWARM_ARTIFACT_ROOT: paths.artifact_root
         SWARM_MONITOR_DIR: paths.monitor_dir
         SWARM_PROMPTS_DIR: paths.prompts_dir
@@ -12267,7 +12275,7 @@ workspace_model:
       `runtime.Caller` / Go source paths as a runtime asset root, or walk for `go.mod` to recover build material.
     mount_source_rule: >
       Host sources for `/data` and `/opt/swarm/contracts` MUST come from `workspace_model.data_source_authority`,
-      explicit deployment configuration, environment, config/CLI path resolution, or an already selected workflow/project
+      explicit deployment configuration, config/CLI path resolution, or an already selected workflow/project
       root passed by the command owner. Default workspace runtime configuration MUST NOT derive those mount sources from
       the Swarm source checkout except for the promoted `.swarm/data` managed local default owned by
       `workspace_model.data_source_authority`.
@@ -12284,7 +12292,7 @@ workspace_model:
       `claude_cli` proof flows. This owner is an explicit operator setup surface. It is separate from runtime startup:
       runtime startup consumes `workspace_model.runtime_image_packaging` and MUST remain fail-closed inspect-only when the
       configured image is missing or unusable.
-    command_surface: swarm workspace build --backend claude_cli [--image <tag>]
+    command_surface: swarm workspace build --backend claude_cli [--config <path>] [--image <tag>] [--docker-bin <path>]
     build_plan_rule: >
       The command MUST use an embedded/materialized workspace Dockerfile or equivalent embedded build plan. It MUST NOT
       locate build material by walking for a source checkout, reading repo-root `Dockerfile.workspace`, using
@@ -12300,9 +12308,13 @@ workspace_model:
         source-authority change promotes explicit version flags.
     image_target_rule: >
       Without `--image`, the command MUST target the same configured workspace image consumed by `swarm serve` Docker
-      startup: `SWARM_WORKSPACE_IMAGE` when set, otherwise `swarm-workspace:latest`. `--image <tag>` is an explicit
-      setup-only override and MUST fail closed when empty or syntactically invalid. The override does not change runtime
-      configuration by itself; operators must still run serve with the matching configured image when overriding.
+      startup: `workspace.image` from an explicit config when provided, otherwise `swarm-workspace:latest`. `--image <tag>`
+      is an explicit setup-only override and MUST fail closed when empty or syntactically invalid. The override does not
+      change runtime configuration by itself; operators must still run serve with the matching configured image when
+      overriding.
+    docker_bin_rule: >
+      The command MUST use `--docker-bin` when provided, otherwise `workspace.docker_bin` from an explicit config when
+      provided, otherwise the built-in `docker` default. `SWARM_DOCKER_BIN` is retired and MUST NOT be read as a fallback.
     validation_rule: >
       The command MUST build into a temporary image tag first and MUST NOT publish/replace the configured runtime image
       tag until validation passes. After build, the command MUST validate the temporary image by running a harmless
@@ -12324,18 +12336,17 @@ workspace_model:
       cleanup remain split.
     cli_flag: --data
     config_key: workspace.data_source
-    env_var: SWARM_WORKSPACE_DATA_SOURCE
+    retired_env_var: SWARM_WORKSPACE_DATA_SOURCE
     source_order:
     - --data
     - workspace.data_source
-    - SWARM_WORKSPACE_DATA_SOURCE
     - project_default
     default_behavior: >
-      If no explicit path source is selected and no deployment alternate such as `SWARM_WORKSPACE_VOLUMES_FROM` is active,
+      If no explicit path source is selected and no deployment alternate such as `workspace.volumes_from` is active,
       the local runtime state resolver MUST select and create `<project-root>/.swarm/data` with mode 0755 only when the canonical
       contracts project root is the active repo root or is under it. If there is no project, or the command points at a borrowed
       contracts root outside the active repo root, startup MUST fail closed with guidance to pass `--data` or configure
-      `workspace.data_source`/`SWARM_WORKSPACE_DATA_SOURCE`; it MUST NOT create cwd-relative `.swarm/data` or pollute the
+      `workspace.data_source`; it MUST NOT create cwd-relative `.swarm/data` or pollute the
       borrowed contracts tree. The runtime MUST NOT synthesize `/data` from the Swarm source checkout or from a repo-local
       `data/` directory unless that path was explicitly selected through the authoritative source order.
     path_resolution_rule: >
@@ -12346,12 +12357,12 @@ workspace_model:
       invalid and MUST NOT fall through to environment or default sources. Default directory creation failures fail closed
       before workspace lifecycle construction.
     volumes_from_conflict_rule: >
-      `SWARM_WORKSPACE_VOLUMES_FROM` is an explicit Docker deployment alternate, not a fallback path source. If no explicit
-      `/data` path source is selected and `SWARM_WORKSPACE_VOLUMES_FROM` is active, the command resolver MUST NOT
+      `workspace.volumes_from` is an explicit Docker deployment alternate, not a fallback path source. If no explicit
+      `/data` path source is selected and `workspace.volumes_from` is active, the command resolver MUST NOT
       materialize or override with `.swarm/data`; Docker workspace validation consumes the alternate shared mounts instead.
-      `SWARM_WORKSPACE_VOLUMES_FROM` MUST NOT be combined with an explicit `/data` path source from `--data`,
-      `workspace.data_source`, or `SWARM_WORKSPACE_DATA_SOURCE`; startup must fail closed on that conflict. Host backend
-      startup continues to reject `SWARM_WORKSPACE_VOLUMES_FROM`.
+      `workspace.volumes_from` MUST NOT be combined with an explicit `/data` path source from `--data` or
+      `workspace.data_source`; startup must fail closed on that conflict. Host backend startup continues to reject
+      `workspace.volumes_from`.
     read_policy: >
       `/data` remains read-only, global, and opaque to the platform. Source authority does not permit indexing, mutating,
       validating contents beyond mount readability, or folding runtime `/data` into workflow bundle identity.
@@ -12365,6 +12376,8 @@ workspace_model:
     retired_non_authoritative_sources:
     - repoRoot/data derivation in cmd/swarm configuredWorkspaceLifecycle
     - lower-level Docker default ownership of SWARM_WORKSPACE_DATA_SOURCE
+    - parent-process SWARM_WORKSPACE_DATA_SOURCE
+    - parent-process SWARM_WORKSPACE_VOLUMES_FROM
     split_scope:
     - '#1137 Compose/Postgres onboarding and Compose ./data:/data:ro deployment shape'
     - '#1138/#1213 host workspace backend execution parity'
@@ -12385,12 +12398,11 @@ workspace_model:
     cli_flag: --workspace-backend <docker|host>
     config_key: workspace.backend
     unsafe_config_key: workspace.allow_exec_on_host
-    legacy_env_var: SWARM_WORKSPACE_BACKEND
+    retired_env_var: SWARM_WORKSPACE_BACKEND
     source_order:
     - loaded contract execution capability
     - --workspace-backend preference / unsafe host opt-out
     - workspace.backend preference plus workspace.allow_exec_on_host for persistent unsafe host opt-out
-    - SWARM_WORKSPACE_BACKEND legacy preference, not unsafe opt-out authority
     default_backend: capability-derived
     capability_classes:
       none:
@@ -12439,7 +12451,7 @@ workspace_model:
           semantics are explicitly promoted. `workspace.backend: host` alone is insufficient for exec-capable bundles; it
           must be paired with `workspace.allow_exec_on_host: true` and the runtime must print a loud warning every boot.
         workspace_root:
-          env_var: SWARM_WORKSPACE_HOST_ROOT
+          config_key: workspace.host_root
           default: ~/.swarm/workspaces
           rule: >
             The host workspace root is platform-managed and writable. Startup MUST create/validate required workspace roots and
@@ -12449,13 +12461,13 @@ workspace_model:
             host workspace root.
     failure_behavior:
     - Unsupported backend names fail closed before runtime construction.
-    - Empty explicit backend sources from the flag, config, or legacy environment fail closed instead of falling through.
-    - Host backend MUST reject `SWARM_WORKSPACE_VOLUMES_FROM`; the host backend consumes explicit path authorities, not Docker
+    - Empty explicit backend sources from the flag or config fail closed instead of falling through.
+    - Host backend MUST reject `workspace.volumes_from`; the host backend consumes explicit path authorities, not Docker
       volume inheritance.
     - Host backend MUST fail closed for Claude CLI/provider execution unless a future gate promotes that support. Host native
       command execution is supported only as trusted/unsafe explicit host-mode execution through
       `workspace_execution_target_capability`; unsupported native tool execution MUST still fail closed.
-    - A legacy environment value such as `SWARM_WORKSPACE_BACKEND=host` MUST NOT act as the unsafe host opt-out for
+    - A retired environment value such as `SWARM_WORKSPACE_BACKEND=host` MUST NOT act as the unsafe host opt-out for
       exec-capable bundles.
     - conversation.fork_chat MUST consume the same decision owner. It MUST NOT preserve implicit primary-workspace
       inheritance or discover required isolation only by failing inside the LLM process startup path.
@@ -14286,7 +14298,7 @@ cli_specification:
         failures MUST fail closed with an actionable startup diagnostic naming the
         configured Claude CLI command, the resolved container, the configured
         workspace image, and remediation to build or pull an image containing the
-        Claude CLI, remove stale workspace containers, or set SWARM_WORKSPACE_IMAGE
+        Claude CLI, remove stale workspace containers, or set `workspace.image`
         to a compatible image.
       consumers:
       - 'local `swarm serve` runtime startup for agent-present `cli_test` bundles'
@@ -15038,8 +15050,7 @@ cli_specification:
         source_order:
         - --data
         - workspace.data_source
-        - SWARM_WORKSPACE_DATA_SOURCE
-        - SWARM_WORKSPACE_VOLUMES_FROM deployment alternate
+        - workspace.volumes_from deployment alternate
         - project_default
         project_default: <project-root>/.swarm/data
         rule: >
@@ -15633,17 +15644,18 @@ cli_specification:
         through entity.get
       - no live LLM credentials, ProviderContract mock/local activation, or cataloge2e private scenario format is required
     workspace_build:
-      command: swarm workspace build --backend claude_cli [--image <tag>]
+      command: swarm workspace build --backend claude_cli [--config <path>] [--image <tag>] [--docker-bin <path>]
       group: getting_started
       tier: should_have
       implementation_status: implemented_first_slice
       owner: workspace_model.local_workspace_image_build_authority
       behavior: >
         Builds and validates the local Docker workspace image for `claude_cli` proof flows using the embedded/materialized
-        workspace build plan. The command uses `SWARM_DOCKER_BIN` when set, builds into a temporary image tag, targets
-        `SWARM_WORKSPACE_IMAGE` or `swarm-workspace:latest` by default, accepts explicit `--image <tag>` for setup-only
-        override, passes the approved `claude_cli` build args, validates that the temporary image can execute
-        `claude --version`, and only then tags the validated image as the configured target.
+        workspace build plan. The command uses `--docker-bin` when set, otherwise `workspace.docker_bin` from explicit
+        config, otherwise the built-in `docker` default. It builds into a temporary image tag, targets `--image`,
+        `workspace.image`, or `swarm-workspace:latest` by default, passes the approved `claude_cli` build args, validates
+        that the temporary image can execute `claude --version`, and only then tags the validated image as the configured
+        target. `SWARM_DOCKER_BIN` and `SWARM_WORKSPACE_IMAGE` are retired and must not be read as fallback sources.
       boundaries:
       - no runtime startup auto-build
       - no source-checkout Dockerfile lookup or go.mod walk
@@ -15771,7 +15783,7 @@ cli_specification:
         owner: workspace_model.data_source_authority
         flag: --data <path>
         config_key: workspace.data_source
-        env_var: SWARM_WORKSPACE_DATA_SOURCE
+        retired_env_var: SWARM_WORKSPACE_DATA_SOURCE
         rule: >
           `swarm serve` MUST resolve the agent-visible `/data` source through
           `workspace_model.data_source_authority` before constructing any workspace lifecycle. The command MUST NOT
@@ -15791,14 +15803,15 @@ cli_specification:
         flag: --workspace-backend <docker|host>
         config_key: workspace.backend
         unsafe_config_key: workspace.allow_exec_on_host
-        legacy_env_var: SWARM_WORKSPACE_BACKEND
+        retired_env_var: SWARM_WORKSPACE_BACKEND
         default_backend: capability-derived
         rule: >
           `swarm serve` MUST resolve the effective workspace backend requirement through
           `workspace_model.workspace_backend_selection` after loading the selected contract source and before constructing
           any workspace lifecycle. No-agent bundles default to no workspace lifecycle, non-exec API/runtime-mediated bundles
           default to host, and exec-capable bundles require Docker unless the operator takes the explicit loud unsafe host
-          opt-out. `SWARM_WORKSPACE_BACKEND` is a legacy preference input and MUST NOT be the unsafe host opt-out authority.
+          opt-out. `SWARM_WORKSPACE_BACKEND` is retired and MUST NOT be read as a backend preference or unsafe host opt-out
+          authority.
         consumers:
         - serve boot workspace lifecycle
         - local foreground run start


### PR DESCRIPTION
Closes #1843
Part of #1600

## Summary

Retires parent-process `SWARM_*` source authority for the full #1843 workspace/tooling/container-launch class. The 20 scoped rows are no longer production configuration sources; public selectors move to flags/typed config, and internal lifecycle rows become hard-coded/internal defaults with retired env guard/doctor remediation.

## Governing Context

Binding refs/context:

- `platform-spec.yaml#environment_source_authority.repo_wide_swarm_env_accepted_set`
- `platform-spec.yaml#environment_source_authority.workspace_monitor_artifact_debug_slice`
- `platform-spec.yaml#configuration_source_authority.unified_swarm_config`
- `platform-spec.yaml#workspace_model.data_source_authority`
- `platform-spec.yaml#workspace_model.workspace_backend_selection`
- `platform-spec.yaml#workspace_model.runtime_image_packaging`
- `platform-spec.yaml#workspace_model.local_workspace_image_build_authority`
- #1843 Pre-Implementation Coverage Audit and Gate B approval

## Semantic Migration

New canonical owners after this change:

- `platform-spec.yaml` accepted env set for retired row classification and guard/doctor behavior.
- Typed config keys: `workspace.data_source`, `workspace.backend`, `workspace.image`, `workspace.docker_bin`, `workspace.host_root`, `workspace.volumes_from`, `workspace.network`.
- Explicit invocation flags: `--data`, `--workspace-backend`, `swarm workspace build --image`, `swarm workspace build --docker-bin`.
- Internal lifecycle defaults for data/contracts mounts and scaffold/system/entity wiring.

Old producer/reader paths now invalid:

- `DefaultDockerConfig` / `DefaultHostConfig` env reads.
- Workspace data/backend env resolver branches.
- Workspace build env image/docker-bin fallbacks.
- LLM/tool Docker exec `SWARM_DOCKER_BIN` readers.
- CI/test setup using the in-scope rows as normal configuration.

Production paths checked for surviving old behavior:

- env guard / doctor accepted-set classification.
- workspace data/backend resolvers.
- Docker and host lifecycle construction.
- workspace build.
- LLM Docker exec and native tool Docker exec.
- doctor/preflight diagnostics.
- CI recipe and in-scope tests.
- production grep for the 20 row names and old env helper names outside `cmd/swarm/env_guard.go`.

Migration completeness: complete for the #1843 20-row chosen class. #1600 remains open for other env families.

## Tests

Passed:

- `git diff --check origin/master...HEAD`
- production in-scope bypass grep: no matches outside `cmd/swarm/env_guard.go`
- in-scope test `Setenv` grep: no matches
- `go test ./cmd/swarm -run 'TestResolveWorkspaceMountSources|TestResolveWorkspaceBackend|TestRepoWideSwarmEnvAcceptedSetMatchesSpec|TestWorkspaceMonitorArtifactDebugSlice|TestPublicEnvTemplate|TestSwarmEnvGuard|TestWorkspaceBuild'`
- `go test ./internal/runtime/llm ./internal/runtime/tools ./internal/runtime/workspace -run 'TestClaudeCLIRuntimeProbeStartupVisibleToolSurface|TestClaudeCLIRuntimeRunWithInput_MissingWorkspaceCLIUsesActionableDiagnostic|TestWorkspaceCLIDiagnosticError|TestConversationStep_ClaudeCLIFirstTurnPreservesSupportedReadFileSurface|TestClaudeCLIProviderAdmissionRejectsBeforeSubprocessDispatch|TestClaudeCLIPromptFallbackConsumesAdmissionPerSubprocessAttempt|TestNativeWorkspaceCommandDoesNotFallbackFromDockerToHost|TestDefaultDockerConfig|TestEnsurePrereqs_CreatesMissingNetworkAndFailsClosedForMissingImage|TestDefaultHostConfig'`

Attempted:

- `go test ./...` failed in local environment because the shared Postgres/Docker test helper cannot reach `/var/run/docker.sock`: `failed to connect to the docker API at unix:///var/run/docker.sock ... connect: no such file or directory`.
