### PR TITLE
[agent-e][issue #1840] Remove internal tracker refs from diagnostics

### DIFF
--- a/cmd/swarm/doctor_test.go
+++ b/cmd/swarm/doctor_test.go
@@ -340,8 +340,8 @@ func TestDoctorTargetHumanExplainsResolutionWithoutPreflight(t *testing.T) {
 		"store_path: " + filepath.Join(canonicalRepo, ".swarm", "stores", "dev.db"),
 		"data_dir: " + filepath.Join(canonicalRepo, ".swarm", "data"),
 		"command_classes:",
-		"#1614",
-		"#1615 store/data migration and swarm run start semantics (implemented)",
+		"read_only_inspection: implemented",
+		"store/data migration and swarm run start semantics are implemented",
 	} {
 		if !strings.Contains(stdout.String(), want) {
 			t.Fatalf("doctor target output missing %q:\n%s", want, stdout.String())

--- a/cmd/swarm/env_authority_test.go
+++ b/cmd/swarm/env_authority_test.go
@@ -579,9 +579,9 @@ func TestSwarmEnvGuardBlocksRetiredRuntimeLLMConfigEnv(t *testing.T) {
 		{name: "SWARM_CLAUDE_CLI_TIMEOUT", value: "1s", want: []string{"env/known_retired @ SWARM_CLAUDE_CLI_TIMEOUT", "llm.claude_cli.timeout"}},
 		{name: "SWARM_CLAUDE_CLI_OUTPUT_FORMAT", value: "bad", want: []string{"env/known_retired @ SWARM_CLAUDE_CLI_OUTPUT_FORMAT", "llm.claude_cli.output_format"}},
 		{name: "SWARM_CLAUDE_TIMEOUT_SECONDS", value: "1", want: []string{"env/known_retired @ SWARM_CLAUDE_TIMEOUT_SECONDS", "llm.claude_cli.timeout"}},
-		{name: "SWARM_CLAUDE_CLI_RETRIES", value: "7", want: []string{"env/known_retired @ SWARM_CLAUDE_CLI_RETRIES", "no supported replacement", "#1803"}, notWant: []string{"llm.claude_cli.retries"}},
-		{name: "SWARM_CLAUDE_CLI_NO_SESSION_PERSISTENCE", value: "true", want: []string{"env/known_retired @ SWARM_CLAUDE_CLI_NO_SESSION_PERSISTENCE", "no supported replacement", "#1803"}, notWant: []string{"llm.claude_cli.no_session_persistence"}},
-		{name: "SWARM_CLAUDE_CLI_USE_TMUX", value: "true", want: []string{"env/known_retired @ SWARM_CLAUDE_CLI_USE_TMUX", "no supported replacement", "#1803"}, notWant: []string{"llm.claude_cli.use_tmux"}},
+		{name: "SWARM_CLAUDE_CLI_RETRIES", value: "7", want: []string{"env/known_retired @ SWARM_CLAUDE_CLI_RETRIES", "no supported replacement"}, notWant: []string{"llm.claude_cli.retries", "#1803"}},
+		{name: "SWARM_CLAUDE_CLI_NO_SESSION_PERSISTENCE", value: "true", want: []string{"env/known_retired @ SWARM_CLAUDE_CLI_NO_SESSION_PERSISTENCE", "no supported replacement"}, notWant: []string{"llm.claude_cli.no_session_persistence", "#1803"}},
+		{name: "SWARM_CLAUDE_CLI_USE_TMUX", value: "true", want: []string{"env/known_retired @ SWARM_CLAUDE_CLI_USE_TMUX", "no supported replacement"}, notWant: []string{"llm.claude_cli.use_tmux", "#1803"}},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -840,8 +840,11 @@ func TestDoctorTargetReportsRuntimeConfigEnvRejectors(t *testing.T) {
 			assertDoctorTargetEnvFinding(t, report, string(swarmEnvCategoryKnownRetired), envName)
 			if envName == "SWARM_CLAUDE_CLI_RETRIES" {
 				finding := findDoctorTargetEnvFinding(t, report, string(swarmEnvCategoryKnownRetired), envName)
-				if !strings.Contains(finding.Message, "no supported replacement") || !strings.Contains(finding.Message, "#1803") {
-					t.Fatalf("retired inert finding message = %q, want #1803/no replacement", finding.Message)
+				if !strings.Contains(finding.Message, "no supported replacement") {
+					t.Fatalf("retired inert finding message = %q, want no replacement guidance", finding.Message)
+				}
+				if strings.Contains(finding.Message+finding.Remediation, "#1803") {
+					t.Fatalf("retired inert finding leaks internal issue ref: %#v", finding)
 				}
 				if strings.Contains(finding.Message+finding.Remediation, "llm.claude_cli.retries") {
 					t.Fatalf("retired inert finding advertises fake replacement: %#v", finding)

--- a/cmd/swarm/env_guard.go
+++ b/cmd/swarm/env_guard.go
@@ -553,7 +553,8 @@ func swarmEnvCatalogEntries() []swarmEnvCatalogEntry {
 		return swarmEnvCatalogEntry{Prefix: prefix, Category: category, Owner: owner, Migration: migration, Message: message, Remediation: remediation}
 	}
 	seeded := func(name, owner, migration string) swarmEnvCatalogEntry {
-		return e(name, swarmEnvCategorySeededLegacy, owner, migration, "", "migrate "+name+" through "+migration+" and then remove it from the seeded accepted set")
+		target := swarmEnvUserFacingMigrationTarget(name, migration)
+		return e(name, swarmEnvCategorySeededLegacy, owner, migration, "", "migrate "+name+" to "+target+" and then remove it from the seeded accepted set")
 	}
 	retired := func(name, message, remediation string) swarmEnvCatalogEntry {
 		return e(name, swarmEnvCategoryKnownRetired, swarmEnvAuthorityOwner, "retired", message, remediation)
@@ -575,7 +576,7 @@ func swarmEnvCatalogEntries() []swarmEnvCatalogEntry {
 	retiredUnsupported := func(name string) swarmEnvCatalogEntry {
 		return retired(
 			name,
-			name+" is retired; this Claude CLI control has no supported replacement and is tracked by #1803",
+			name+" is retired; this Claude CLI control has no supported replacement",
 			"unset "+name+"; no supported replacement exists for this inert/unsupported Claude CLI control",
 		)
 	}
@@ -673,4 +674,18 @@ func swarmEnvCatalogEntries() []swarmEnvCatalogEntry {
 		retired("SWARM_BUILDER_AUTH_TOKEN", "SWARM_BUILDER_AUTH_TOKEN is not accepted as API auth fallback", "use token files, context descriptor auth, or configured auth sources"),
 		retired("SWARM_OPERATOR_AUTH_TOKEN", "SWARM_OPERATOR_AUTH_TOKEN is not accepted as API auth fallback", "use token files, context descriptor auth, or configured auth sources"),
 	}
+}
+
+func swarmEnvUserFacingMigrationTarget(name, migration string) string {
+	switch strings.TrimSpace(name) {
+	case "SWARM_API_LISTEN_ADDR":
+		return "serve_api_listen_addr or --api-listen-addr"
+	case "SWARM_MCP_LISTEN_ADDR":
+		return "serve_mcp_listen_addr or --mcp-listen-addr"
+	}
+	parts := strings.Fields(strings.TrimSpace(migration))
+	if len(parts) > 1 && strings.HasPrefix(parts[0], "#") {
+		return strings.Join(parts[1:], " ")
+	}
+	return strings.TrimSpace(migration)
 }

--- a/cmd/swarm/local_context_registry.go
+++ b/cmd/swarm/local_context_registry.go
@@ -563,7 +563,7 @@ func validateLocalContextEntry(ctx context.Context, entry localContextEntry, cal
 	desc := entry.Descriptor
 	if desc.Transport == localContextTransportUnix {
 		entry.Status = localContextStatusUnsupportedTransport
-		entry.Detail = "unix descriptor is schema-valid but IPC dialing is split to #1576"
+		entry.Detail = "unix descriptor is schema-valid but IPC dialing is not supported yet"
 		return entry
 	}
 	rpcEndpoint, err := cliAPIRPCEndpointFromServer(desc.APIServer, "descriptor api_server")

--- a/cmd/swarm/main.go
+++ b/cmd/swarm/main.go
@@ -1114,7 +1114,7 @@ func runServeRuntime(ctx context.Context, repo string, opts serveOptions) int {
 	var ready atomic.Bool
 	supervisor := newRuntimeProjectSupervisor(repo, resolvedPlatformSpecPath, cfg, stores, &ready, mountSources, workspaceBackendPreference, credentialStore, providerCredentialStore, contractsRoot, bundle, source, rt, opts.Dev)
 	if len(pinnedBundleHashes) > 0 {
-		supervisor.DisableSourceReplacement("swarm serve --bundle-hash pins persisted bundle contexts for the process; dynamic project reload is split to RuntimeContextManager Load/Unload work")
+		supervisor.DisableSourceReplacement("swarm serve --bundle-hash pins persisted bundle contexts for the process; dynamic project reload is not supported in this mode")
 	}
 	defer func() {
 		if err := closeAdditionalServeRuntimeContexts(context.Background(), runtimeContexts[1:], opts); err != nil {
@@ -3347,7 +3347,7 @@ func validateServeMultiContextToolGatewayAdmission(cfg *config.Config, loadedBun
 	if profile.ID != llmselection.BackendClaudeCLI {
 		return nil
 	}
-	return fmt.Errorf("multi-context swarm serve --bundle-hash with llm.backend=claude_cli is unsupported by #1568 first-slice source authority: ToolGatewayBinding, MCP /mcp and /tools routes, and forkchat sandbox runtime are single-context until a separately gated context-aware gateway router exists; use one --bundle-hash or a non-claude_cli backend")
+	return fmt.Errorf("multi-context swarm serve --bundle-hash with llm.backend=claude_cli is not supported in this configuration: ToolGatewayBinding, MCP /mcp and /tools routes, and forkchat sandbox runtime are single-context; use one --bundle-hash or a non-claude_cli backend")
 }
 
 var retiredToolGatewayURLEnvNames = []string{"SWARM_TOOL_GATEWAY_URL", "SWARM_TOOL_GATEWAY_CONTAINER_URL"}

--- a/cmd/swarm/main_test.go
+++ b/cmd/swarm/main_test.go
@@ -6731,7 +6731,7 @@ func TestValidateServeMultiContextToolGatewayAdmission(t *testing.T) {
 			name:        "multi context claude backend fails closed",
 			cfg:         claudeCfg,
 			loaded:      twoContexts,
-			wantErr:     "multi-context swarm serve --bundle-hash with llm.backend=claude_cli is unsupported",
+			wantErr:     "multi-context swarm serve --bundle-hash with llm.backend=claude_cli is not supported in this configuration",
 			wantDetails: true,
 		},
 		{
@@ -6755,7 +6755,7 @@ func TestValidateServeMultiContextToolGatewayAdmission(t *testing.T) {
 				t.Fatalf("validateServeMultiContextToolGatewayAdmission err = %v, want %q", err, tt.wantErr)
 			}
 			if tt.wantDetails {
-				for _, want := range []string{"ToolGatewayBinding", "MCP /mcp and /tools routes", "forkchat sandbox runtime", "context-aware gateway router"} {
+				for _, want := range []string{"ToolGatewayBinding", "MCP /mcp and /tools routes", "forkchat sandbox runtime", "single-context"} {
 					if !strings.Contains(err.Error(), want) {
 						t.Fatalf("admission error missing %q:\n%s", want, err.Error())
 					}
@@ -6898,7 +6898,7 @@ func TestRunServeRuntimeMultiContextClaudeCLIFailsClosedBeforePrimaryGatewayOrFo
 		"ToolGatewayBinding",
 		"MCP /mcp and /tools routes",
 		"forkchat sandbox runtime",
-		"context-aware gateway router",
+		"single-context",
 	} {
 		if !strings.Contains(out.String(), want) {
 			t.Fatalf("serve output missing %q:\n%s", want, out.String())

--- a/cmd/swarm/target_resolution.go
+++ b/cmd/swarm/target_resolution.go
@@ -563,7 +563,7 @@ func doctorTargetCommandClasses() []doctorTargetCommandClass {
 		},
 		{
 			Name:        "read_only_inspection",
-			Status:      "implemented_#1614",
+			Status:      "implemented",
 			Fallthrough: "may use selected/global/default target only outside a project or when a project has no known context; stale/mismatched/corrupt/multiple project contexts fail closed",
 			Commands: []string{
 				"swarm run list",
@@ -597,7 +597,7 @@ func doctorTargetCommandClasses() []doctorTargetCommandClass {
 		},
 		{
 			Name:        "mutating_runtime_state",
-			Status:      "implemented_#1614",
+			Status:      "implemented",
 			Fallthrough: "must not fall through to selected/global/default from inside a project with no live project context; requires explicit target or live project context",
 			Commands: []string{
 				"swarm event publish",
@@ -619,7 +619,7 @@ func doctorTargetCommandClasses() []doctorTargetCommandClass {
 		},
 		{
 			Name:        "control_destructive",
-			Status:      "implemented_#1614",
+			Status:      "implemented",
 			Fallthrough: "requires explicit or unambiguous selected target plus existing command confirmation rules",
 			Commands:    []string{"swarm control pause", "swarm control stop", "swarm control nuke"},
 		},
@@ -634,9 +634,9 @@ func doctorTargetCommandClasses() []doctorTargetCommandClass {
 
 func doctorTargetSplitSiblings() []string {
 	return []string{
-		"#1614 project-scoped serve/API command targeting",
-		"#1615 store/data migration and swarm run start semantics (implemented)",
-		"#1576 transport-aware descriptors and IPC/ephemeral-port direction",
+		"project-scoped serve/API command targeting remains a broader targeting follow-up",
+		"store/data migration and swarm run start semantics are implemented",
+		"transport-aware descriptors and IPC/ephemeral-port direction remain broader targeting follow-up",
 	}
 }
 

--- a/cmd/swarm/user_facing_diagnostic_issue_ref_guard_test.go
+++ b/cmd/swarm/user_facing_diagnostic_issue_ref_guard_test.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"regexp"
+	"testing"
+)
+
+var commandUserFacingDiagnosticInternalRefPattern = regexp.MustCompile(`#\d{3,}|\bimplemented_[A-Za-z0-9_#-]+\b|\b(?:tracked by|split to|unsupported by|first-slice source authority)\b`)
+
+func TestSwarmEnvUserFacingDiagnosticsDoNotLeakInternalIssueRefs(t *testing.T) {
+	for _, entry := range swarmEnvCatalogEntries() {
+		name := entry.Name
+		if name == "" {
+			name = entry.Prefix + "EXAMPLE"
+		}
+		finding := findingForSwarmEnvEntry(name, entry)
+		assertNoUserFacingIssueRef(t, "env message "+name, finding.Message)
+		assertNoUserFacingIssueRef(t, "env remediation "+name, finding.Remediation)
+		assertNoUserFacingIssueRef(t, "env rendered "+name, formatSwarmEnvFinding(finding))
+	}
+}
+
+func TestDoctorTargetUserFacingDiagnosticsDoNotLeakInternalIssueRefs(t *testing.T) {
+	for _, class := range doctorTargetCommandClasses() {
+		assertNoUserFacingIssueRef(t, "target command class "+class.Name+" status", class.Status)
+		assertNoUserFacingIssueRef(t, "target command class "+class.Name+" fallthrough", class.Fallthrough)
+	}
+	for _, sibling := range doctorTargetSplitSiblings() {
+		assertNoUserFacingIssueRef(t, "target split sibling", sibling)
+	}
+
+	entry := validateLocalContextEntry(nil, localContextEntry{Status: localContextStatusOK, Descriptor: localContextDescriptor{Transport: localContextTransportUnix}}, nil)
+	assertNoUserFacingIssueRef(t, "local context detail", entry.Detail)
+}
+
+func assertNoUserFacingIssueRef(t *testing.T, label, text string) {
+	t.Helper()
+	if commandUserFacingDiagnosticInternalRefPattern.MatchString(text) {
+		t.Fatalf("%s leaks internal issue/tracker ref: %q", label, text)
+	}
+}

--- a/internal/apispec/cli_diagnostic_issue_ref_guard_test.go
+++ b/internal/apispec/cli_diagnostic_issue_ref_guard_test.go
@@ -1,0 +1,74 @@
+package apispec
+
+import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+var userFacingDiagnosticInternalRefPattern = regexp.MustCompile(`#\d{3,}|\bimplemented_[A-Za-z0-9_#-]+\b|\b(?:tracked by|split to|unsupported by|first-slice source authority)\b`)
+
+func TestUserFacingDiagnosticIssueRefPatternRejectsInternalIssues(t *testing.T) {
+	for _, text := range []string{
+		"tracked by #1234",
+		"implemented_#1614",
+		"implemented_first_slice",
+		"split to #1176",
+		"first-slice source authority",
+	} {
+		if !userFacingDiagnosticInternalRefPattern.MatchString(text) {
+			t.Fatalf("internal-ref guard did not match %q", text)
+		}
+	}
+}
+
+func TestUserFacingDiagnosticSourcesDoNotLeakInternalIssueRefs(t *testing.T) {
+	files := []string{
+		"cmd/swarm/main.go",
+		"cmd/swarm/target_resolution.go",
+		"cmd/swarm/local_context_registry.go",
+		"internal/runtime/bootverify/workflow_composition_connect_checks.go",
+		"internal/runtime/bootverify/workflow_output_pin_key_carries_checks.go",
+		"internal/runtime/contracts/workflow_contract_tree.go",
+		"internal/runtime/contracts/workflow_contract_types.go",
+		"internal/runtime/contracts/workflow_contract_yaml_flow.go",
+		"internal/apiv1/operator_runtime_control.go",
+		"internal/apiv1/operator_agent_control.go",
+		"internal/apiv1/operator_mailbox.go",
+	}
+
+	var problems []string
+	for _, rel := range files {
+		path := filepath.Join(repoRoot(t), rel)
+		fset := token.NewFileSet()
+		file, err := parser.ParseFile(fset, path, nil, 0)
+		if err != nil {
+			t.Fatalf("parse %s: %v", rel, err)
+		}
+		ast.Inspect(file, func(node ast.Node) bool {
+			lit, ok := node.(*ast.BasicLit)
+			if !ok || lit.Kind != token.STRING {
+				return true
+			}
+			value, err := strconv.Unquote(lit.Value)
+			if err != nil {
+				return true
+			}
+			if !userFacingDiagnosticInternalRefPattern.MatchString(value) {
+				return true
+			}
+			pos := fset.Position(lit.Pos())
+			problems = append(problems, fmt.Sprintf("%s:%d: user-facing diagnostic source leaks internal tracker ref in %q", rel, pos.Line, value))
+			return true
+		})
+	}
+	if len(problems) > 0 {
+		t.Fatalf("user-facing diagnostic issue/tracker refs are forbidden by platform-spec.yaml#cli_specification.foundations.output_contract.diagnostic_convention:\n%s", strings.Join(problems, "\n"))
+	}
+}

--- a/internal/apiv1/operator_agent_control.go
+++ b/internal/apiv1/operator_agent_control.go
@@ -130,7 +130,7 @@ func executeAgentSendDirective(ctx context.Context, req Request, opts OperatorRe
 
 func executeAgentRestart(ctx context.Context, req Request, opts OperatorReadOptions, now time.Time) (any, error) {
 	if multiRuntimeContextMode(opts) {
-		return nil, runtimeContextRequiredError(req.Method, "agent restart is ambiguous in multi-context DB-loaded mode; per-context agent control is split to #1176")
+		return nil, runtimeContextRequiredError(req.Method, "agent restart is not supported in multi-context DB-loaded mode without an explicit runtime context")
 	}
 	agentID, err := requiredStringParam(req.Params, "agent_id")
 	if err != nil {
@@ -174,7 +174,7 @@ func executeAgentRestart(ctx context.Context, req Request, opts OperatorReadOpti
 
 func executeAgentReplayBacklog(ctx context.Context, req Request, opts OperatorReadOptions, now time.Time) (any, error) {
 	if multiRuntimeContextMode(opts) {
-		return nil, runtimeContextRequiredError(req.Method, "agent backlog replay is ambiguous in multi-context DB-loaded mode; per-context agent control is split to #1176")
+		return nil, runtimeContextRequiredError(req.Method, "agent backlog replay is not supported in multi-context DB-loaded mode without an explicit runtime context")
 	}
 	agentID, err := requiredStringParam(req.Params, "agent_id")
 	if err != nil {

--- a/internal/apiv1/operator_mailbox.go
+++ b/internal/apiv1/operator_mailbox.go
@@ -207,7 +207,7 @@ func executeMailboxDecision(ctx context.Context, req Request, opts OperatorReadO
 	action := strings.ToLower(strings.TrimSpace(decision.Action))
 	if action == "approved" || action == "approve" {
 		if multiRuntimeContextMode(opts) {
-			return nil, runtimeContextRequiredError(req.Method, "mailbox approval event publishing is ambiguous in multi-context DB-loaded mode; per-context mailbox approval routing is split to #1176")
+			return nil, runtimeContextRequiredError(req.Method, "mailbox approval event publishing is not supported in multi-context DB-loaded mode without an explicit runtime context")
 		}
 		mutationPublisher, ok := opts.Events.(EventMutationPublisher)
 		if !ok || mutationPublisher == nil {

--- a/internal/apiv1/operator_runtime_control.go
+++ b/internal/apiv1/operator_runtime_control.go
@@ -42,7 +42,7 @@ func OperatorRuntimeControlHandlers(opts OperatorReadOptions) map[string]MethodH
 
 func executeRuntimeIngressControl(ctx context.Context, req Request, opts OperatorReadOptions, now time.Time, pause bool) (any, error) {
 	if multiRuntimeContextMode(opts) {
-		return nil, runtimeContextRequiredError(req.Method, "runtime ingress control is ambiguous in multi-context DB-loaded mode; dynamic per-context runtime control is split to #1176")
+		return nil, runtimeContextRequiredError(req.Method, "runtime ingress control is not supported in multi-context DB-loaded mode without an explicit runtime context")
 	}
 	idempotencyKey, _, err := optionalStringParam(req.Params, "idempotency_key")
 	if err != nil {

--- a/internal/runtime/bootverify/workflow_composition_connect_checks.go
+++ b/internal/runtime/bootverify/workflow_composition_connect_checks.go
@@ -414,7 +414,7 @@ func compositionConnectTargetIndexed(source semanticview.Source, flowID, expr st
 			return nil
 		}
 		if strings.Contains(fieldPath, ".") {
-			return fmt.Errorf("receiver target %s uses a nested entity path; #1479 supports only top-level indexed entity fields as descriptor/index route evidence", expr)
+			return fmt.Errorf("receiver target %s uses a nested entity path; descriptor/index route evidence supports only top-level indexed entity fields", expr)
 		}
 		contract, ok := entityruntime.ResolveForFlow(source, flowID)
 		if !ok {

--- a/internal/runtime/bootverify/workflow_output_pin_key_carries_checks.go
+++ b/internal/runtime/bootverify/workflow_output_pin_key_carries_checks.go
@@ -213,7 +213,7 @@ func outputPinKeyCarriesSourceType(source semanticview.Source, flowID string, pi
 		return "", fmt.Errorf("producer output pin %s must declare key before it can supply %s", pin.PinName(), expr)
 	}
 	if field != key {
-		return "", fmt.Errorf("source expression %s does not match producer output pin key %s; renamed-key adapters are tracked by #1546", expr, key)
+		return "", fmt.Errorf("source expression %s does not match producer output pin key %s; renamed-key adapters are not supported", expr, key)
 	}
 	carries := outputPinCarries(pin)
 	if !outputPinStringSetContains(carries, key) {

--- a/internal/runtime/contracts/load_validation_test.go
+++ b/internal/runtime/contracts/load_validation_test.go
@@ -592,8 +592,8 @@ func TestAgentRegistryEntryRejectsUnsupportedLayerSyntaxAndUnknownFields(t *test
 		body     string
 		contains string
 	}{
-		{name: "profile", body: "profile: cheap\n", contains: "reserved for a later #1685/#1703 gate"},
-		{name: "runtime_id_template", body: "runtime_id_template: worker-{entity_id}\n", contains: "reserved for a later #1685/#1703 gate"},
+		{name: "profile", body: "profile: cheap\n", contains: "reserved for future agent-defaults/profile support"},
+		{name: "runtime_id_template", body: "runtime_id_template: worker-{entity_id}\n", contains: "reserved for future agent-defaults/profile support"},
 		{name: "unknown", body: "surprise_field: true\n", contains: "UNDEFINED-FIELD"},
 	}
 	for _, tt := range tests {

--- a/internal/runtime/contracts/workflow_contract_tree.go
+++ b/internal/runtime/contracts/workflow_contract_tree.go
@@ -107,7 +107,7 @@ func normalizeAgentRegistryEntries(entries map[string]AgentRegistryEntry, source
 func validateAgentRegistryMapKey(key, sourceFile string) error {
 	switch strings.TrimSpace(key) {
 	case "agent_defaults", "agent_profiles", "profiles":
-		return fmt.Errorf("UNSUPPORTED: %s key %q is reserved for a later #1685 gate and is not accepted by Layer 1 platform defaults", strings.TrimSpace(sourceFile), key)
+		return fmt.Errorf("UNSUPPORTED: %s key %q is reserved for future platform-defaults support and is not accepted by Layer 1 platform defaults", strings.TrimSpace(sourceFile), key)
 	default:
 		return nil
 	}

--- a/internal/runtime/contracts/workflow_contract_types.go
+++ b/internal/runtime/contracts/workflow_contract_types.go
@@ -1699,7 +1699,7 @@ func validateAgentRegistryEntryYAMLFields(value *yaml.Node) (map[string]bool, er
 			case "subscribes_to":
 				return nil, fmt.Errorf("RETIRED: agent field subscribes_to is retired for agents.yaml; use subscriptions")
 			case "profile", "agent_defaults", "agent_profiles", "runtime_id_template":
-				return nil, fmt.Errorf("UNSUPPORTED: agent field %s is reserved for a later #1685/#1703 gate and is not accepted by Layer 1 platform defaults", field)
+				return nil, fmt.Errorf("UNSUPPORTED: agent field %s is reserved for future agent-defaults/profile support and is not accepted by Layer 1 platform defaults", field)
 			default:
 				if !supportedAgentRegistryEntryField(field) {
 					return nil, fmt.Errorf("UNDEFINED-FIELD: agent field %s is not supported", field)

--- a/internal/runtime/contracts/workflow_contract_yaml_flow.go
+++ b/internal/runtime/contracts/workflow_contract_yaml_flow.go
@@ -66,7 +66,7 @@ func validateRuleFieldNodes(node *yaml.Node) error {
 		case "policy":
 			return fmt.Errorf("UNSUPPORTED-POLICY-SHEET-ROW: rule field %q would create a second policy-sheet authoring owner; enhance rules in place", key)
 		case "temporal", "join", "loop", "collection", "schedule":
-			return fmt.Errorf("UNSUPPORTED-POLICY-SHEET-ROW: rule field %q is outside the #1713 selection-row scope", key)
+			return fmt.Errorf("UNSUPPORTED-POLICY-SHEET-ROW: rule field %q is outside the promoted selection-row scope", key)
 		}
 		if _, ok := allowed[key]; !ok {
 			return fmt.Errorf("UNDEFINED-FIELD: rule field %q not in platform spec", key)


### PR DESCRIPTION
## Summary

Closes #1840.

Removes internal GitHub issue/tracker references from currently known production user-facing diagnostics and adds structural guards so the same class cannot quietly reappear in the swept surfaces.

## Governing Refs / Context

- Pre-audit: https://github.com/division-sh/swarm/issues/1840#issuecomment-4910419833
- Gate outcome: https://github.com/division-sh/swarm/issues/1840#issuecomment-4910451377
- `platform-spec.yaml#cli_specification.foundations.output_contract.diagnostic_convention`
- `diagnostic_content_rules.no_internal_issue_or_tracker_refs`
- `user_facing_surface` and `internal_metadata_exemption`
- Adjacent verifier owner: `engine.boot_verification.severity_behavior.surface_fatality.text_rendering`

## Scope

- Rewrites user-facing verifier, CLI, doctor/env-guard, target, local-context, API, and contract-load messages that previously exposed internal issue refs or tracker wording.
- Keeps internal source-authority/spec/test metadata intact where it is not user-facing.
- Adds apispec and command-level guards for the swept user-facing diagnostic sources and rendered env/doctor diagnostics.
- Does not claim broader #1821/#1712 route-through/output-conformance closure.

## Semantic Migration

- New canonical owner: the platform-spec diagnostic convention forbidding internal issue/tracker refs in user-facing diagnostics.
- Old non-authoritative path now invalid: production diagnostic strings that explain behavior by naming internal issue numbers or planning labels.
- Production paths checked: verifier/bootverify errors, selected CLI errors, doctor/env guard output, target/local context diagnostics, API runtime-context errors, and contract-load validation errors listed in #1840.
- Migration completeness: complete for the approved first-slice known production user-facing leaks; broader output-conformance remains with #1821/#1712.

## Verification

- `SWARM_TEST_POSTGRES_DSN='host=127.0.0.1 port=5432 user=youmew dbname=postgres sslmode=disable' PGPASSWORD=postgres go test ./internal/apispec ./cmd/swarm ./internal/runtime/bootverify ./internal/runtime/contracts ./internal/apiv1`
- `SWARM_TEST_POSTGRES_DSN='host=127.0.0.1 port=5432 user=youmew dbname=postgres sslmode=disable' PGPASSWORD=postgres go test ./...`