### PR TITLE
[agent-a][issue #1835] Add select instance resolution

### DIFF
--- a/internal/runtime/bootverify/workflow_composition_connect_checks.go
+++ b/internal/runtime/bootverify/workflow_composition_connect_checks.go
@@ -202,8 +202,11 @@ func compositionReceiverAddressRequired(schema runtimecontracts.FlowSchemaDocume
 func validateCompositionConnectInstanceKey(source semanticview.Source, connect runtimecontracts.FlowPackageConnect, outputPin runtimecontracts.FlowOutputEventPin, inputPin runtimecontracts.FlowInputEventPin, producerFlowID, receiverFlowID string) []Finding {
 	adapter := connect.Using.Instance
 	if !inputPin.Resolution.Empty() {
-		if inputPin.Resolution.Mode == runtimecontracts.FlowInputResolutionModeCreate && strings.TrimSpace(connect.Delivery) != "" && strings.TrimSpace(connect.Delivery) != "one" {
-			return []Finding{compositionConnectFinding(connect, "instance_resolution_invalid", "resolution mode create requires delivery one", receiverFlowID)}
+		switch inputPin.Resolution.Mode {
+		case runtimecontracts.FlowInputResolutionModeCreate, runtimecontracts.FlowInputResolutionModeSelect:
+			if strings.TrimSpace(connect.Delivery) != "" && strings.TrimSpace(connect.Delivery) != "one" {
+				return []Finding{compositionConnectFinding(connect, "instance_resolution_invalid", fmt.Sprintf("resolution mode %s requires delivery one", inputPin.Resolution.Mode), receiverFlowID)}
+			}
 		}
 		if adapter.Declared {
 			return []Finding{compositionConnectFinding(connect, "instance_resolution_invalid", "connect.using.instance is incompatible with input pin resolution", receiverFlowID)}
@@ -309,8 +312,9 @@ func validateInputPinResolution(source semanticview.Source, flowID string, pin r
 	switch resolution.Mode {
 	case runtimecontracts.FlowInputResolutionModeCreate:
 		return validateCreateInputPinResolution(source, flowID, pin)
-	case runtimecontracts.FlowInputResolutionModeSelect,
-		runtimecontracts.FlowInputResolutionModeSelectOrCreate,
+	case runtimecontracts.FlowInputResolutionModeSelect:
+		return validateSelectInputPinResolution(source, flowID, pin)
+	case runtimecontracts.FlowInputResolutionModeSelectOrCreate,
 		runtimecontracts.FlowInputResolutionModeFanIn,
 		runtimecontracts.FlowInputResolutionModeFanOut,
 		runtimecontracts.FlowInputResolutionModeReply:
@@ -319,6 +323,53 @@ func validateInputPinResolution(source semanticview.Source, flowID string, pin r
 		findings = append(findings, inputPinResolutionFinding(flowID, pin, "instance_resolution_invalid", "resolution.mode is required", location))
 	default:
 		findings = append(findings, inputPinResolutionFinding(flowID, pin, "instance_resolution_invalid", fmt.Sprintf("resolution mode %q is not supported", resolution.Mode), location))
+	}
+	return findings
+}
+
+func validateSelectInputPinResolution(source semanticview.Source, flowID string, pin runtimecontracts.FlowInputEventPin) []Finding {
+	var findings []Finding
+	resolution := pin.Resolution
+	location := flowID
+	if resolution.Aggregation != "" || resolution.Window != "" || len(resolution.DedupBy) > 0 || resolution.Singleton != "" || resolution.RepliesTo != "" || resolution.CorrelationKey != "" || resolution.InstanceKey.Mint != "" || resolution.InstanceKey.As != "" {
+		findings = append(findings, inputPinResolutionFinding(flowID, pin, "instance_resolution_invalid", "resolution mode select may only declare instance_key and carries", location))
+	}
+	bundle, ok := semanticview.Bundle(source)
+	if !ok || bundle == nil {
+		return append(findings, inputPinResolutionFinding(flowID, pin, "receiver_instance_key_unavailable", "receiver instance key owner is unavailable for input pin resolution", location))
+	}
+	instance, err := bundle.ResolveFlowTemplateInstance(flowID)
+	if err != nil {
+		return append(findings, inputPinResolutionFinding(flowID, pin, "receiver_instance_key_invalid", err.Error(), location))
+	}
+	key := strings.TrimSpace(resolution.InstanceKey.From)
+	if key == "" {
+		findings = append(findings, inputPinResolutionFinding(flowID, pin, "instance_resolution_invalid", "resolution mode select requires instance_key to name a carried field", location))
+		return findings
+	}
+	if len(instance.By) != 1 {
+		findings = append(findings, inputPinResolutionFinding(flowID, pin, "instance_resolution_invalid", fmt.Sprintf("resolution mode select requires exactly one receiver instance.by field, got %v", instance.By), location))
+		return findings
+	}
+	if strings.TrimSpace(instance.By[0]) != key {
+		findings = append(findings, inputPinResolutionFinding(flowID, pin, "instance_resolution_invalid", fmt.Sprintf("resolution mode select instance_key %q must match the receiver's single instance.by field %v", key, instance.By), location))
+	}
+	carry, ok := pin.Carries[key]
+	if !ok {
+		findings = append(findings, inputPinResolutionFinding(flowID, pin, "instance_resolution_invalid", fmt.Sprintf("resolution mode select instance_key %s must name a declared carries.%s field", key, key), location))
+		return findings
+	}
+	wantFrom := "payload." + key
+	if strings.TrimSpace(carry.From) != wantFrom {
+		findings = append(findings, inputPinResolutionFinding(flowID, pin, "instance_resolution_invalid", fmt.Sprintf("carry %s must use from: %s for resolution mode select", key, wantFrom), location))
+	}
+	if carry.Type != "" {
+		targetType, err := compositionConnectTargetType(source, flowID, "entity."+key)
+		if err != nil {
+			findings = append(findings, inputPinResolutionFinding(flowID, pin, "receiver_instance_key_invalid", err.Error(), location))
+		} else if !compositionConnectTypesCompatible(carry.Type, targetType) {
+			findings = append(findings, inputPinResolutionFinding(flowID, pin, "key_types_incompatible", fmt.Sprintf("carry %s type %s is incompatible with receiver entity.%s type %s", key, carry.Type, key, targetType), location))
+		}
 	}
 	return findings
 }

--- a/internal/runtime/bootverify/workflow_composition_connect_checks_test.go
+++ b/internal/runtime/bootverify/workflow_composition_connect_checks_test.go
@@ -82,6 +82,84 @@ func TestRun_AllowsCreateInputResolutionCompositionConnect(t *testing.T) {
 	}
 }
 
+func TestRun_AllowsSelectInputResolutionCompositionConnect(t *testing.T) {
+	root := writeSelectResolutionCompositionConnectFixture(t, selectResolutionCompositionFixtureOptions{})
+	bundle := loadFixtureBundleAt(t, repoRootForBootverifyTest(t), root, runtimecontracts.DefaultPlatformSpecFile(repoRootForBootverifyTest(t)))
+
+	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+
+	if reportContains(report.Errors(), "composition_connect_validation", "") {
+		t.Fatalf("unexpected composition_connect_validation error: %#v", report.Errors())
+	}
+	if reportContains(report.Errors(), "template_instance_validation", "") {
+		t.Fatalf("unexpected template_instance_validation error: %#v", report.Errors())
+	}
+	if reportContains(report.Errors(), "input_pin_wiring", "account.ready") {
+		t.Fatalf("parent connect should satisfy select-resolution input pin wiring proof, got %#v", report.Errors())
+	}
+}
+
+func TestRun_FailsClosedForInvalidSelectInputResolution(t *testing.T) {
+	tests := []struct {
+		name string
+		opts selectResolutionCompositionFixtureOptions
+		want string
+	}{
+		{
+			name: "undeclared carried key",
+			opts: selectResolutionCompositionFixtureOptions{instanceKey: "missing_account_id"},
+			want: "instance_key missing_account_id must name a declared carries.missing_account_id field",
+		},
+		{
+			name: "composite receiver key",
+			opts: selectResolutionCompositionFixtureOptions{compositeKey: true},
+			want: "requires exactly one receiver instance.by field",
+		},
+		{
+			name: "type mismatch",
+			opts: selectResolutionCompositionFixtureOptions{carryType: "integer"},
+			want: "key_types_incompatible",
+		},
+		{
+			name: "legacy address is incompatible",
+			opts: selectResolutionCompositionFixtureOptions{legacyAddress: true},
+			want: "input pin resolution is incompatible with legacy address",
+		},
+		{
+			name: "legacy connect using instance is incompatible",
+			opts: selectResolutionCompositionFixtureOptions{usingInstance: true},
+			want: "connect.using.instance is incompatible with input pin resolution",
+		},
+		{
+			name: "legacy connect map is incompatible",
+			opts: selectResolutionCompositionFixtureOptions{connectMap: true},
+			want: "connect.map is incompatible with input pin resolution",
+		},
+		{
+			name: "non-template receiver",
+			opts: selectResolutionCompositionFixtureOptions{receiverMode: "static"},
+			want: "INVALID-TEMPLATE-INSTANCE",
+		},
+		{
+			name: "wrong delivery",
+			opts: selectResolutionCompositionFixtureOptions{delivery: "many"},
+			want: "resolution mode select requires delivery one",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			root := writeSelectResolutionCompositionConnectFixture(t, tc.opts)
+			bundle := loadFixtureBundleAt(t, repoRootForBootverifyTest(t), root, runtimecontracts.DefaultPlatformSpecFile(repoRootForBootverifyTest(t)))
+
+			report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+
+			if !reportContains(report.Errors(), "composition_connect_validation", tc.want) {
+				t.Fatalf("expected composition_connect_validation %q, got %#v", tc.want, report.Errors())
+			}
+		})
+	}
+}
+
 func TestRun_FailsClosedForInvalidCreateInputResolution(t *testing.T) {
 	tests := []struct {
 		name string
@@ -91,7 +169,7 @@ func TestRun_FailsClosedForInvalidCreateInputResolution(t *testing.T) {
 		{
 			name: "non-create modes are design-locked but not runnable",
 			opts: createResolutionCompositionFixtureOptions{
-				mode:         runtimecontracts.FlowInputResolutionModeSelect,
+				mode:         runtimecontracts.FlowInputResolutionModeSelectOrCreate,
 				mint:         runtimecontracts.FlowInputResolutionMintUUID,
 				includeCarry: true,
 			},
@@ -1086,6 +1164,145 @@ type createResolutionCompositionFixtureOptions struct {
 	mint          string
 	includeCarry  bool
 	usingInstance bool
+}
+
+type selectResolutionCompositionFixtureOptions struct {
+	instanceKey   string
+	carryType     string
+	receiverMode  string
+	delivery      string
+	compositeKey  bool
+	legacyAddress bool
+	usingInstance bool
+	connectMap    bool
+}
+
+func writeSelectResolutionCompositionConnectFixture(t *testing.T, opts selectResolutionCompositionFixtureOptions) string {
+	t.Helper()
+	root := t.TempDir()
+	receiverMode := strings.TrimSpace(opts.receiverMode)
+	if receiverMode == "" {
+		receiverMode = "template"
+	}
+	delivery := strings.TrimSpace(opts.delivery)
+	if delivery == "" {
+		delivery = "one"
+	}
+	instanceKey := strings.TrimSpace(opts.instanceKey)
+	if instanceKey == "" {
+		instanceKey = "account_id"
+	}
+	carryType := strings.TrimSpace(opts.carryType)
+	if carryType == "" {
+		carryType = "string"
+	}
+	instanceBy := "account_id"
+	eventsFields := "  account_id: string\n"
+	if opts.compositeKey {
+		instanceBy = "[account_id, region]"
+		eventsFields += "  region: string\n"
+	}
+	usingBlock := ""
+	if opts.usingInstance {
+		usingBlock = `
+    using:
+      instance:
+        source: account_id
+        target: account_id`
+	}
+	mapBlock := ""
+	if opts.connectMap {
+		mapBlock = `
+    map:
+      account_id:
+        source: payload.account_id
+        target: entity.account_id`
+	}
+	addressBlock := ""
+	if opts.legacyAddress {
+		addressBlock = `
+        address:
+          by: account_id
+          source: payload.account_id
+          target: entity.account_id
+          cardinality: one`
+	}
+	writeBootverifyFixtureFile(t, filepath.Join(root, "package.yaml"), `
+name: select-resolution-composition-connect
+version: "1.0.0"
+platform_version: ">=0.7.0 <0.8.0"
+flows:
+  - id: producer
+    flow: producer
+    mode: static
+  - id: account
+    flow: account
+    mode: `+receiverMode+`
+connect:
+  - from: producer.account_ready
+    to: account.account_ready
+    delivery: `+delivery+usingBlock+mapBlock+`
+`)
+	writeBootverifyFixtureFile(t, filepath.Join(root, "schema.yaml"), "name: select-resolution-composition-connect\n")
+	writeBootverifyFixtureFile(t, filepath.Join(root, "policy.yaml"), "{}\n")
+	writeBootverifyFixtureFile(t, filepath.Join(root, "tools.yaml"), "{}\n")
+	writeBootverifyFixtureFile(t, filepath.Join(root, "agents.yaml"), "{}\n")
+	writeBootverifyFixtureFile(t, filepath.Join(root, "events.yaml"), "{}\n")
+	writeBootverifyFixtureFile(t, filepath.Join(root, "nodes.yaml"), "{}\n")
+	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "producer", "schema.yaml"), `
+name: producer
+mode: static
+pins:
+  outputs:
+    events:
+      - name: account_ready
+        event: account.ready
+`)
+	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "producer", "policy.yaml"), "{}\n")
+	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "producer", "agents.yaml"), "{}\n")
+	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "producer", "entities.yaml"), "{}\n")
+	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "producer", "events.yaml"), "account.ready:\n"+eventsFields)
+	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "producer", "nodes.yaml"), "{}\n")
+	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "account", "schema.yaml"), `
+name: account
+mode: `+receiverMode+`
+instance:
+  by: `+instanceBy+`
+  on_missing: create
+  on_conflict: reuse
+pins:
+  inputs:
+    events:
+      - name: account_ready
+        event: account.ready`+addressBlock+`
+        resolution:
+          mode: select
+          instance_key: `+instanceKey+`
+        carries:
+          account_id:
+            from: payload.account_id
+            type: `+carryType+`
+`)
+	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "account", "policy.yaml"), "{}\n")
+	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "account", "agents.yaml"), "{}\n")
+	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "account", "events.yaml"), "account.ready:\n"+eventsFields)
+	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "account", "entities.yaml"), `
+account_state:
+  account_id:
+    type: string
+    _unused_reason: composition select route key test field
+  region:
+    type: string
+    _unused_reason: composition select composite-key test field
+`)
+	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "account", "nodes.yaml"), `
+account-node:
+  id: account-node-{account_id}
+  execution_type: system_node
+  event_handlers:
+    account.ready: {}
+`)
+	return root
 }
 
 func writeCreateResolutionCompositionConnectFixture(t *testing.T, opts createResolutionCompositionFixtureOptions) string {

--- a/internal/runtime/bus/connect_route_plan_dispatch.go
+++ b/internal/runtime/bus/connect_route_plan_dispatch.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/division-sh/swarm/internal/events"
+	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
 	runtimeflowidentity "github.com/division-sh/swarm/internal/runtime/core/flowidentity"
 	runtimepinrouting "github.com/division-sh/swarm/internal/runtime/core/pinrouting"
 	runtimecorrelation "github.com/division-sh/swarm/internal/runtime/correlation"
@@ -92,6 +93,9 @@ func (r connectRoutePlanResolver) Plan(ctx context.Context, evt events.Event) (c
 			out.ExtraDetail["connect_route_plan_failure"] = string(materialized.Failure)
 			out.ExtraDetail["connect_route_plan_source_event"] = plan.Source.ResolvedEvent
 			out.ExtraDetail["connect_route_plan_receiver_event"] = plan.Receiver.ResolvedEvent
+			for key, value := range connectRoutePlanFailureDetail(plan, materialized.Failure, values, descriptors) {
+				out.ExtraDetail[key] = value
+			}
 			return out, nil
 		}
 		if !decision.Empty() {
@@ -385,6 +389,71 @@ func connectRoutePlanTargetFailure(failure runtimepinrouting.ConnectRoutePlanFai
 		return ""
 	}
 	return runtimepinrouting.TargetFailure(strings.TrimSpace(string(failure)))
+}
+
+func connectRoutePlanFailureDetail(plan runtimepinrouting.ConnectRoutePlan, failure runtimepinrouting.ConnectRoutePlanFailure, values map[string]string, descriptors []runtimepinrouting.Descriptor) map[string]any {
+	if plan.InstanceKey == nil || strings.TrimSpace(plan.InstanceKey.Mode) != runtimecontracts.FlowInputResolutionModeSelect {
+		return nil
+	}
+	fields := plan.InstanceKey.Fields
+	if len(fields) != 1 {
+		return nil
+	}
+	keyField := strings.TrimSpace(fields[0])
+	if keyField == "" {
+		return nil
+	}
+	out := map[string]any{
+		"connect_route_plan_resolution_mode":     runtimecontracts.FlowInputResolutionModeSelect,
+		"connect_route_plan_receiver_flow":       strings.TrimSpace(plan.Receiver.FlowID),
+		"connect_route_plan_instance_key_field":  keyField,
+		"connect_route_plan_failure_remediation": connectRoutePlanSelectRemediation(plan, failure, keyField, ""),
+	}
+	material, materialFailure := runtimepinrouting.InstanceKeyMaterialForConnectRoutePlan(plan, values)
+	if materialFailure != "" {
+		if failure == runtimepinrouting.ConnectFailureAddressValueMissing {
+			out["connect_route_plan_failure_remediation"] = connectRoutePlanSelectRemediation(plan, failure, keyField, "")
+		}
+		return out
+	}
+	keyValue := ""
+	for _, key := range material.Keys {
+		if strings.TrimSpace(key.Field) == keyField {
+			keyValue = strings.TrimSpace(key.Value)
+			break
+		}
+	}
+	if keyValue != "" {
+		out["connect_route_plan_instance_key_value"] = keyValue
+	}
+	if failure == runtimepinrouting.ConnectFailureTargetAmbiguous {
+		out["connect_route_plan_matched_instance_count"] = len(runtimepinrouting.InstanceKeyDescriptorRoutesForConnectRoutePlan(plan, material.Keys, descriptors))
+	}
+	out["connect_route_plan_failure_remediation"] = connectRoutePlanSelectRemediation(plan, failure, keyField, keyValue)
+	return out
+}
+
+func connectRoutePlanSelectRemediation(plan runtimepinrouting.ConnectRoutePlan, failure runtimepinrouting.ConnectRoutePlanFailure, keyField, keyValue string) string {
+	receiverFlow := strings.TrimSpace(plan.Receiver.FlowID)
+	if receiverFlow == "" {
+		receiverFlow = "receiver flow"
+	}
+	keyLabel := strings.TrimSpace(keyField)
+	if keyLabel == "" {
+		keyLabel = "instance key"
+	}
+	valueText := ""
+	if value := strings.TrimSpace(keyValue); value != "" {
+		valueText = " = " + value
+	}
+	switch failure {
+	case runtimepinrouting.ConnectFailureAddressValueMissing:
+		return fmt.Sprintf("Provide payload.%s before publishing to %s; resolution mode select requires a carried key value.", keyLabel, receiverFlow)
+	case runtimepinrouting.ConnectFailureTargetAmbiguous:
+		return fmt.Sprintf("Ensure exactly one active %s instance has %s%s; resolution mode select cannot choose between multiple matches.", receiverFlow, keyLabel, valueText)
+	default:
+		return fmt.Sprintf("Create or connect exactly one active %s instance with %s%s before publishing; resolution mode select never creates a missing instance.", receiverFlow, keyLabel, valueText)
+	}
 }
 
 func connectRoutePlanMatchValues(evt events.Event) map[string]string {

--- a/internal/runtime/bus/connect_route_plan_dispatch_test.go
+++ b/internal/runtime/bus/connect_route_plan_dispatch_test.go
@@ -1048,6 +1048,194 @@ func TestEventBusPublish_ConnectRoutePlanCreateResolutionCanMintFromEventID(t *t
 	}
 }
 
+func TestEventBusPublish_ConnectRoutePlanSelectResolutionRoutesExistingInstanceAndReplaysCommittedRoute(t *testing.T) {
+	source := connectRoutePlanSelectResolutionSourceWithPolicy(t, "create", "reuse")
+	store := &connectRoutePlanLifecycleStore{
+		connectRoutePlanDescriptorStore: &connectRoutePlanDescriptorStore{
+			targetRouteMemoryStore: newTargetRouteMemoryStore(),
+			flowInstances: []ActiveFlowInstanceDescriptor{{
+				InstanceID:    "one",
+				EntityID:      "ent-1",
+				FlowInstance:  "account/one",
+				AddressFields: map[string]string{"entity.account_id": "acct-1"},
+			}},
+		},
+	}
+	eb, err := NewEventBusWithOptions(store, EventBusOptions{
+		ContractBundle:            source,
+		TemplateInstanceActivator: store.Activate,
+	})
+	if err != nil {
+		t.Fatalf("NewEventBusWithOptions: %v", err)
+	}
+	store.bus = eb
+	if err := eb.AddFlowInstanceRoute(FlowInstanceRouteMaterializationRequest{Identity: runtimeflowidentity.DeriveRoute("account", "one")}); err != nil {
+		t.Fatalf("AddFlowInstanceRoute(one): %v", err)
+	}
+	eventID := uuid.NewString()
+	evt := eventtest.RootIngress(eventID,
+		events.EventType("producer/account.ready"), "", "", json.RawMessage(`{"account_id":"acct-1"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())
+
+	want := events.DeliveryRoute{SubscriberType: "node", SubscriberID: "account-node-one", Target: events.RouteIdentity{FlowID: "account", FlowInstance: "account/one", EntityID: "ent-1"}}
+
+	preflight, err := eb.CheckPublishRecipientPlan(context.Background(), evt)
+	if err != nil {
+		t.Fatalf("CheckPublishRecipientPlan: %v", err)
+	}
+	if preflight.TargetFailure != "" {
+		t.Fatalf("preflight target failure = %q, want none", preflight.TargetFailure)
+	}
+	if !deliveryRoutesContain(preflight.DeliveryRoutes, want) || len(preflight.DeliveryRoutes) != 1 {
+		t.Fatalf("preflight delivery routes = %#v, want select existing route %#v", preflight.DeliveryRoutes, want)
+	}
+	if got := len(store.activations); got != 0 {
+		t.Fatalf("preflight activations = %d, want 0 for select", got)
+	}
+
+	if err := eb.Publish(context.Background(), evt); err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+	if got := len(store.activations); got != 0 {
+		t.Fatalf("publish activations = %d, want 0 because select never creates", got)
+	}
+	if !deliveryRoutesContain(store.routes[eventID], want) || len(store.routes[eventID]) != 1 {
+		t.Fatalf("persisted delivery routes = %#v, want select existing route %#v", store.routes[eventID], want)
+	}
+
+	replayTarget := eb.SubscribeInternal("account-node-one")
+	store.flowInstances = []ActiveFlowInstanceDescriptor{{
+		InstanceID:    "drift",
+		EntityID:      "ent-drift",
+		FlowInstance:  "account/drift",
+		AddressFields: map[string]string{"entity.account_id": "acct-1"},
+	}}
+	store.flowInstanceDescriptorCalls = 0
+	if err := eb.AddFlowInstanceRoute(FlowInstanceRouteMaterializationRequest{Identity: runtimeflowidentity.DeriveRoute("account", "drift")}); err != nil {
+		t.Fatalf("AddFlowInstanceRoute(drift): %v", err)
+	}
+	if err := eb.PublishPersistedRecipients(context.Background(), evt, nil); err != nil {
+		t.Fatalf("PublishPersistedRecipients: %v", err)
+	}
+	replayed := requireBusEvent(t, replayTarget, "select resolution committed replay")
+	if replayed.FlowInstance() != "account/one" || replayed.EntityID() != "ent-1" {
+		t.Fatalf("replayed delivery target = flow_instance:%q entity:%q, want persisted account/one ent-1", replayed.FlowInstance(), replayed.EntityID())
+	}
+	if got := store.flowInstanceDescriptorCalls; got != 0 {
+		t.Fatalf("replay descriptor calls = %d, want 0 because persisted route/scope is authoritative", got)
+	}
+}
+
+func TestEventBusPublish_ConnectRoutePlanSelectResolutionFailsClosedForTargetGaps(t *testing.T) {
+	tests := []struct {
+		name          string
+		flowInstances []ActiveFlowInstanceDescriptor
+		addRoutes     []string
+		wantFailure   runtimepinrouting.TargetFailure
+		wantDetail    map[string]any
+	}{
+		{
+			name: "missing existing instance does not create",
+			flowInstances: []ActiveFlowInstanceDescriptor{{
+				InstanceID:    "other",
+				EntityID:      "ent-other",
+				FlowInstance:  "account/other",
+				AddressFields: map[string]string{"entity.account_id": "acct-2"},
+			}},
+			addRoutes:   []string{"other"},
+			wantFailure: runtimepinrouting.TargetFailure(runtimepinrouting.ConnectFailureTargetUnresolved),
+			wantDetail: map[string]any{
+				"connect_route_plan_receiver_flow":      "account",
+				"connect_route_plan_instance_key_field": "account_id",
+				"connect_route_plan_instance_key_value": "acct-1",
+			},
+		},
+		{
+			name: "ambiguous existing instances fail closed",
+			flowInstances: []ActiveFlowInstanceDescriptor{
+				{InstanceID: "one", EntityID: "ent-1", FlowInstance: "account/one", AddressFields: map[string]string{"entity.account_id": "acct-1"}},
+				{InstanceID: "two", EntityID: "ent-2", FlowInstance: "account/two", AddressFields: map[string]string{"entity.account_id": "acct-1"}},
+			},
+			addRoutes:   []string{"one", "two"},
+			wantFailure: runtimepinrouting.TargetFailure(runtimepinrouting.ConnectFailureTargetAmbiguous),
+			wantDetail: map[string]any{
+				"connect_route_plan_receiver_flow":          "account",
+				"connect_route_plan_instance_key_field":     "account_id",
+				"connect_route_plan_instance_key_value":     "acct-1",
+				"connect_route_plan_matched_instance_count": 2,
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			source := connectRoutePlanSelectResolutionSourceWithPolicy(t, "create", "reuse")
+			store := &connectRoutePlanLifecycleStore{
+				connectRoutePlanDescriptorStore: &connectRoutePlanDescriptorStore{
+					targetRouteMemoryStore: newTargetRouteMemoryStore(),
+					flowInstances:          tc.flowInstances,
+				},
+			}
+			eb, err := NewEventBusWithOptions(store, EventBusOptions{
+				ContractBundle:            source,
+				TemplateInstanceActivator: store.Activate,
+			})
+			if err != nil {
+				t.Fatalf("NewEventBusWithOptions: %v", err)
+			}
+			store.bus = eb
+			for _, instanceID := range tc.addRoutes {
+				if err := eb.AddFlowInstanceRoute(FlowInstanceRouteMaterializationRequest{Identity: runtimeflowidentity.DeriveRoute("account", instanceID)}); err != nil {
+					t.Fatalf("AddFlowInstanceRoute(%s): %v", instanceID, err)
+				}
+			}
+			raw := eb.Subscribe("raw-source-listener", events.EventType("producer/account.ready"), events.EventType("account.ready"))
+			defer eb.Unsubscribe("raw-source-listener")
+			eventID := uuid.NewString()
+			evt := eventtest.RootIngress(eventID,
+				events.EventType("producer/account.ready"), "", "", json.RawMessage(`{"account_id":"acct-1"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())
+
+			routePlan, err := eb.planSubscribedRoutePlan(context.Background(), evt, false)
+			if err != nil {
+				t.Fatalf("planSubscribedRoutePlan: %v", err)
+			}
+			if routePlan.AuthorityState != RoutePlanAuthorityCanonicalFailedClosed || routePlan.AuthorityOwner != routePlanSourceConnectRoutePlan {
+				t.Fatalf("route plan authority = %q/%q, want fail-closed connect route plan", routePlan.AuthorityState, routePlan.AuthorityOwner)
+			}
+			if routePlan.TargetFailure != tc.wantFailure {
+				t.Fatalf("target failure = %q, want %q", routePlan.TargetFailure, tc.wantFailure)
+			}
+			for key, want := range tc.wantDetail {
+				if got := routePlan.ExtraDetail[key]; got != want {
+					t.Fatalf("route plan detail %s = %#v, want %#v; all detail %#v", key, got, want, routePlan.ExtraDetail)
+				}
+			}
+			if remediation, _ := routePlan.ExtraDetail["connect_route_plan_failure_remediation"].(string); !strings.Contains(remediation, "select") || !strings.Contains(remediation, "account") || !strings.Contains(remediation, "account_id") {
+				t.Fatalf("remediation = %q, want select/account/account_id user-facing detail", remediation)
+			}
+
+			plan, err := eb.CheckPublishRecipientPlan(context.Background(), evt)
+			if err != nil {
+				t.Fatalf("CheckPublishRecipientPlan: %v", err)
+			}
+			if got, want := plan.TargetFailure, string(tc.wantFailure); got != want {
+				t.Fatalf("preflight target failure = %q, want %q", got, want)
+			}
+			if got := len(store.activations); got != 0 {
+				t.Fatalf("preflight activations = %d, want 0 because select never creates", got)
+			}
+			if err := eb.Publish(context.Background(), evt); err != nil {
+				t.Fatalf("Publish: %v", err)
+			}
+			if got := len(store.activations); got != 0 {
+				t.Fatalf("publish activations = %d, want 0 because select never creates", got)
+			}
+			if routes := store.routes[eventID]; len(routes) != 0 {
+				t.Fatalf("persisted delivery routes = %#v, want none for fail-closed select", routes)
+			}
+			requireNoConnectRoutePlanBusEvent(t, raw, "source/raw subscriber fallback")
+		})
+	}
+}
+
 func TestEventBusPublish_ConnectRoutePlanLifecycleCreateRefreshesDescriptorsForLaterPlans(t *testing.T) {
 	source := connectRoutePlanInstanceKeyMultiInputSourceWithPolicy(t, "create", "reuse")
 	store := &connectRoutePlanLifecycleStore{
@@ -2225,6 +2413,21 @@ func connectRoutePlanCreateResolutionSource(t testing.TB, mint string) semanticv
 	return semanticview.Wrap(bundle)
 }
 
+func connectRoutePlanSelectResolutionSourceWithPolicy(t testing.TB, onMissing, onConflict string) semanticview.Source {
+	t.Helper()
+	repoRoot, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd: %v", err)
+	}
+	repoRoot = filepath.Clean(filepath.Join(repoRoot, "..", "..", ".."))
+	root := writeConnectRoutePlanSelectResolutionFixtureWithPolicy(t, onMissing, onConflict)
+	bundle, err := runtimecontracts.LoadWorkflowContractBundleWithOverrides(repoRoot, root, runtimecontracts.DefaultPlatformSpecFile(repoRoot))
+	if err != nil {
+		t.Fatalf("LoadWorkflowContractBundleWithOverrides: %v", err)
+	}
+	return semanticview.Wrap(bundle)
+}
+
 func writeConnectRoutePlanInstanceKeyFixture(t testing.TB) string {
 	return writeConnectRoutePlanInstanceKeyFixtureWithDelivery(t, "one")
 }
@@ -2304,6 +2507,83 @@ validator-node:
   execution_type: system_node
   event_handlers:
     validation.requested: {}
+`)
+	return root
+}
+
+func writeConnectRoutePlanSelectResolutionFixtureWithPolicy(t testing.TB, onMissing, onConflict string) string {
+	t.Helper()
+	root := t.TempDir()
+	writeConnectRoutePlanBusFixtureFile(t, filepath.Join(root, "package.yaml"), `
+name: select-resolution-connect-route-plan-bus
+version: "1.0.0"
+platform_version: ">=0.7.0 <0.8.0"
+flows:
+  - id: producer
+    flow: producer
+    mode: static
+  - id: account
+    flow: account
+    mode: template
+connect:
+  - from: producer.account_ready
+    to: account.account_ready
+    delivery: one
+`)
+	writeConnectRoutePlanBusFixtureFile(t, filepath.Join(root, "schema.yaml"), "name: select-resolution-connect-route-plan-bus\n")
+	writeConnectRoutePlanBusFixtureFile(t, filepath.Join(root, "policy.yaml"), "{}\n")
+	writeConnectRoutePlanBusFixtureFile(t, filepath.Join(root, "tools.yaml"), "{}\n")
+	writeConnectRoutePlanBusFixtureFile(t, filepath.Join(root, "agents.yaml"), "{}\n")
+	writeConnectRoutePlanBusFixtureFile(t, filepath.Join(root, "events.yaml"), "{}\n")
+	writeConnectRoutePlanBusFixtureFile(t, filepath.Join(root, "nodes.yaml"), "{}\n")
+	writeConnectRoutePlanBusFixtureFile(t, filepath.Join(root, "flows", "producer", "schema.yaml"), `
+name: producer
+mode: static
+pins:
+  outputs:
+    events:
+      - name: account_ready
+        event: account.ready
+`)
+	writeConnectRoutePlanBusFixtureFile(t, filepath.Join(root, "flows", "producer", "policy.yaml"), "{}\n")
+	writeConnectRoutePlanBusFixtureFile(t, filepath.Join(root, "flows", "producer", "agents.yaml"), "{}\n")
+	writeConnectRoutePlanBusFixtureFile(t, filepath.Join(root, "flows", "producer", "events.yaml"), "account.ready:\n  account_id: string\n")
+	writeConnectRoutePlanBusFixtureFile(t, filepath.Join(root, "flows", "producer", "entities.yaml"), "{}\n")
+	writeConnectRoutePlanBusFixtureFile(t, filepath.Join(root, "flows", "producer", "nodes.yaml"), "{}\n")
+	writeConnectRoutePlanBusFixtureFile(t, filepath.Join(root, "flows", "account", "schema.yaml"), `
+name: account
+mode: template
+instance:
+  by: account_id
+  on_missing: `+onMissing+`
+  on_conflict: `+onConflict+`
+pins:
+  inputs:
+    events:
+      - name: account_ready
+        event: account.ready
+        resolution:
+          mode: select
+          instance_key: account_id
+        carries:
+          account_id:
+            from: payload.account_id
+            type: string
+`)
+	writeConnectRoutePlanBusFixtureFile(t, filepath.Join(root, "flows", "account", "policy.yaml"), "{}\n")
+	writeConnectRoutePlanBusFixtureFile(t, filepath.Join(root, "flows", "account", "agents.yaml"), "{}\n")
+	writeConnectRoutePlanBusFixtureFile(t, filepath.Join(root, "flows", "account", "events.yaml"), "account.ready:\n  account_id: string\n")
+	writeConnectRoutePlanBusFixtureFile(t, filepath.Join(root, "flows", "account", "entities.yaml"), `
+account_state:
+  account_id:
+    type: string
+`)
+	writeConnectRoutePlanBusFixtureFile(t, filepath.Join(root, "flows", "account", "nodes.yaml"), `
+account-node:
+  id: account-node-{instance_id}
+  execution_type: system_node
+  event_handlers:
+    account.ready: {}
 `)
 	return root
 }

--- a/internal/runtime/bus/template_instance_lifecycle.go
+++ b/internal/runtime/bus/template_instance_lifecycle.go
@@ -140,9 +140,15 @@ func (o templateInstanceLifecycleOwner) Materialize(ctx context.Context, evt eve
 	}
 	onMissing := strings.TrimSpace(instanceContract.OnMissing)
 	onConflict := strings.TrimSpace(instanceContract.OnConflict)
-	if plan.InstanceKey != nil && strings.TrimSpace(plan.InstanceKey.Mode) == runtimecontracts.FlowInputResolutionModeCreate {
-		onMissing = "create"
-		onConflict = "reuse"
+	if plan.InstanceKey != nil {
+		switch strings.TrimSpace(plan.InstanceKey.Mode) {
+		case runtimecontracts.FlowInputResolutionModeCreate:
+			onMissing = "create"
+			onConflict = "reuse"
+		case runtimecontracts.FlowInputResolutionModeSelect:
+			onMissing = "reject"
+			onConflict = "reject"
+		}
 	}
 	matches := runtimepinrouting.InstanceKeyDescriptorRoutesForConnectRoutePlan(plan, keyMaterial, descriptors)
 	if len(matches) > 1 {

--- a/internal/runtime/conformance/template_flow_pilot_conformance_test.go
+++ b/internal/runtime/conformance/template_flow_pilot_conformance_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/division-sh/swarm/internal/runtime/semanticview"
 	"github.com/division-sh/swarm/internal/runtime/testfixtures/fanoutpinroute"
 	"github.com/division-sh/swarm/internal/runtime/testfixtures/templateflowpilot"
+	"github.com/division-sh/swarm/internal/runtime/testfixtures/templateselectexisting"
 )
 
 func TestTemplateFlowPilotConformance_CoversInstanceCenteredAuthoringOwners(t *testing.T) {
@@ -121,6 +122,53 @@ func TestTemplateFlowPilotConformance_FailClosedMatrix(t *testing.T) {
 				t.Fatalf("expected hard invalidity %s containing %q, got %#v", tc.checkID, tc.wantMessage, report.HardInvalidities())
 			}
 		})
+	}
+}
+
+func TestTemplateSelectExistingConformance_CoversResolutionSelectOwner(t *testing.T) {
+	source := templateselectexisting.LoadSource(t)
+	report := runtimebootverify.Run(context.Background(), source, runtimebootverify.Options{})
+	if got := report.HardInvalidities(); len(got) != 0 {
+		t.Fatalf("template-select-existing hard invalidities = %#v, want none", got)
+	}
+
+	plans, issues := runtimepinrouting.LowerCompositionConnectRoutePlans(source)
+	if len(issues) != 0 {
+		t.Fatalf("LowerCompositionConnectRoutePlans issues = %#v, want none", issues)
+	}
+	if len(plans) != 1 {
+		t.Fatalf("LowerCompositionConnectRoutePlans = %#v, want one select route plan", plans)
+	}
+	plan := plans[0]
+	if plan.Source.FlowID != templateselectexisting.ProducerFlowID || plan.Source.Pin != templateselectexisting.ProducerOutputPin {
+		t.Fatalf("route plan source = %#v, want %s.%s", plan.Source, templateselectexisting.ProducerFlowID, templateselectexisting.ProducerOutputPin)
+	}
+	if plan.Receiver.FlowID != templateselectexisting.TemplateFlowID || plan.Receiver.Pin != templateselectexisting.TemplateInputPin || plan.Receiver.Mode != "template" {
+		t.Fatalf("route plan receiver = %#v, want template %s.%s", plan.Receiver, templateselectexisting.TemplateFlowID, templateselectexisting.TemplateInputPin)
+	}
+	if plan.ResolutionKind != runtimepinrouting.ConnectResolutionInstanceKey || !plan.RequiresRuntimeResolution {
+		t.Fatalf("route plan resolution = %s runtime=%v, want runtime instance-key select", plan.ResolutionKind, plan.RequiresRuntimeResolution)
+	}
+	if plan.InstanceKey == nil || plan.InstanceKey.Mode != "select" || strings.Join(plan.InstanceKey.Fields, ",") != templateselectexisting.TemplateInstanceBy {
+		t.Fatalf("route plan instance key = %#v, want select/account_id", plan.InstanceKey)
+	}
+	if len(plan.InstanceKey.Mappings) != 1 || plan.InstanceKey.Mappings[0].Source != templateselectexisting.TemplateInstanceBy || plan.InstanceKey.Mappings[0].Target != templateselectexisting.TemplateInstanceBy || !plan.InstanceKey.Mappings[0].Explicit {
+		t.Fatalf("route plan mappings = %#v, want explicit account_id -> account_id", plan.InstanceKey.Mappings)
+	}
+
+	materialized := runtimepinrouting.MaterializeConnectRoutePlan(plan, runtimepinrouting.ConnectRoutePlanMaterializationInput{
+		MatchValues: map[string]string{"payload.account_id": "acct-1"},
+		Descriptors: []runtimepinrouting.Descriptor{{
+			EntityID:      "ent-1",
+			FlowInstance:  "account/one",
+			AddressFields: map[string]string{"entity.account_id": "acct-1"},
+		}},
+	})
+	if materialized.Failure != "" {
+		t.Fatalf("MaterializeConnectRoutePlan failure = %q, want none", materialized.Failure)
+	}
+	if materialized.Target.FlowInstance != "account/one" || materialized.Target.EntityID != "ent-1" {
+		t.Fatalf("materialized target = %#v, want account/one ent-1", materialized.Target)
 	}
 }
 

--- a/internal/runtime/core/pinrouting/connect_route_plan.go
+++ b/internal/runtime/core/pinrouting/connect_route_plan.go
@@ -687,8 +687,8 @@ func connectSelectResolutionInstanceKey(source semanticview.Source, connect runt
 	if delivery != ConnectDeliveryOne {
 		return nil, ConnectRoutePlanIssue{Connect: connect, Failure: ConnectFailureDeliveryTopologyInvalid, Detail: "resolution mode select requires delivery one"}
 	}
-	if strings.TrimSpace(resolution.InstanceKey.Mint) != "" || strings.TrimSpace(resolution.InstanceKey.As) != "" {
-		return nil, ConnectRoutePlanIssue{Connect: connect, Failure: ConnectFailureInstanceResolutionInvalid, Detail: "resolution mode select may not declare instance_key.mint or instance_key.as"}
+	if resolution.Aggregation != "" || resolution.Window != "" || len(resolution.DedupBy) > 0 || resolution.Singleton != "" || resolution.RepliesTo != "" || resolution.CorrelationKey != "" || strings.TrimSpace(resolution.InstanceKey.Mint) != "" || strings.TrimSpace(resolution.InstanceKey.As) != "" {
+		return nil, ConnectRoutePlanIssue{Connect: connect, Failure: ConnectFailureInstanceResolutionInvalid, Detail: "resolution mode select may only declare instance_key and carries"}
 	}
 	bundle, ok := semanticview.Bundle(source)
 	if !ok {

--- a/internal/runtime/core/pinrouting/connect_route_plan.go
+++ b/internal/runtime/core/pinrouting/connect_route_plan.go
@@ -640,9 +640,17 @@ func connectInstanceKey(source semanticview.Source, connect runtimecontracts.Flo
 }
 
 func connectResolutionInstanceKey(source semanticview.Source, connect runtimecontracts.FlowPackageConnect, inputPin runtimecontracts.FlowInputEventPin, resolution runtimecontracts.FlowInputPinResolution, delivery ConnectRoutePlanDelivery, receiverFlowID string) (*ConnectRoutePlanInstanceKey, ConnectRoutePlanIssue) {
-	if resolution.Mode != runtimecontracts.FlowInputResolutionModeCreate {
+	switch resolution.Mode {
+	case runtimecontracts.FlowInputResolutionModeCreate:
+		return connectCreateResolutionInstanceKey(source, connect, resolution, delivery, receiverFlowID)
+	case runtimecontracts.FlowInputResolutionModeSelect:
+		return connectSelectResolutionInstanceKey(source, connect, inputPin, resolution, delivery, receiverFlowID)
+	default:
 		return nil, ConnectRoutePlanIssue{Connect: connect, Failure: ConnectFailureInstanceResolutionInvalid, Detail: fmt.Sprintf("resolution mode %q is design-locked but not runnable in this slice", resolution.Mode)}
 	}
+}
+
+func connectCreateResolutionInstanceKey(source semanticview.Source, connect runtimecontracts.FlowPackageConnect, resolution runtimecontracts.FlowInputPinResolution, delivery ConnectRoutePlanDelivery, receiverFlowID string) (*ConnectRoutePlanInstanceKey, ConnectRoutePlanIssue) {
 	if delivery != ConnectDeliveryOne {
 		return nil, ConnectRoutePlanIssue{Connect: connect, Failure: ConnectFailureDeliveryTopologyInvalid, Detail: "resolution mode create requires delivery one"}
 	}
@@ -672,6 +680,46 @@ func connectResolutionInstanceKey(source semanticview.Source, connect runtimecon
 		As:         as,
 		OnMissing:  "create",
 		OnConflict: "reuse",
+	}, ConnectRoutePlanIssue{}
+}
+
+func connectSelectResolutionInstanceKey(source semanticview.Source, connect runtimecontracts.FlowPackageConnect, inputPin runtimecontracts.FlowInputEventPin, resolution runtimecontracts.FlowInputPinResolution, delivery ConnectRoutePlanDelivery, receiverFlowID string) (*ConnectRoutePlanInstanceKey, ConnectRoutePlanIssue) {
+	if delivery != ConnectDeliveryOne {
+		return nil, ConnectRoutePlanIssue{Connect: connect, Failure: ConnectFailureDeliveryTopologyInvalid, Detail: "resolution mode select requires delivery one"}
+	}
+	if strings.TrimSpace(resolution.InstanceKey.Mint) != "" || strings.TrimSpace(resolution.InstanceKey.As) != "" {
+		return nil, ConnectRoutePlanIssue{Connect: connect, Failure: ConnectFailureInstanceResolutionInvalid, Detail: "resolution mode select may not declare instance_key.mint or instance_key.as"}
+	}
+	bundle, ok := semanticview.Bundle(source)
+	if !ok {
+		return nil, ConnectRoutePlanIssue{Connect: connect, Failure: ConnectFailureLifecycleUnavailable, Detail: "receiver instance contract owner is unavailable"}
+	}
+	instance, err := bundle.ResolveFlowTemplateInstance(receiverFlowID)
+	if err != nil {
+		return nil, ConnectRoutePlanIssue{Connect: connect, Failure: ConnectFailureInstanceResolutionInvalid, Detail: err.Error()}
+	}
+	fields := normalizedStringList(instance.By)
+	key := strings.TrimSpace(resolution.InstanceKey.From)
+	if key == "" {
+		return nil, ConnectRoutePlanIssue{Connect: connect, Failure: ConnectFailureInstanceResolutionInvalid, Detail: "resolution mode select requires instance_key to name a carried field"}
+	}
+	if len(fields) != 1 || fields[0] != key {
+		return nil, ConnectRoutePlanIssue{Connect: connect, Failure: ConnectFailureInstanceResolutionInvalid, Detail: fmt.Sprintf("resolution mode select instance_key %q must match the receiver's single instance.by field %v", key, fields)}
+	}
+	carry, ok := inputPin.Carries[key]
+	if !ok {
+		return nil, ConnectRoutePlanIssue{Connect: connect, Failure: ConnectFailureInstanceResolutionInvalid, Detail: fmt.Sprintf("resolution mode select instance_key %s must name declared carries.%s", key, key)}
+	}
+	wantFrom := "payload." + key
+	if strings.TrimSpace(carry.From) != wantFrom {
+		return nil, ConnectRoutePlanIssue{Connect: connect, Failure: ConnectFailureInstanceResolutionInvalid, Detail: fmt.Sprintf("resolution mode select carry %s must use from: %s", key, wantFrom)}
+	}
+	return &ConnectRoutePlanInstanceKey{
+		Mode:       runtimecontracts.FlowInputResolutionModeSelect,
+		Fields:     fields,
+		Mappings:   []ConnectRoutePlanInstanceKeyMapping{{Source: key, Target: key, Explicit: true}},
+		OnMissing:  "reject",
+		OnConflict: "reject",
 	}, ConnectRoutePlanIssue{}
 }
 

--- a/internal/runtime/core/pinrouting/connect_route_plan.go
+++ b/internal/runtime/core/pinrouting/connect_route_plan.go
@@ -714,6 +714,15 @@ func connectSelectResolutionInstanceKey(source semanticview.Source, connect runt
 	if strings.TrimSpace(carry.From) != wantFrom {
 		return nil, ConnectRoutePlanIssue{Connect: connect, Failure: ConnectFailureInstanceResolutionInvalid, Detail: fmt.Sprintf("resolution mode select carry %s must use from: %s", key, wantFrom)}
 	}
+	if strings.TrimSpace(carry.Type) != "" {
+		targetType, err := connectResolutionReceiverEntityFieldType(source, receiverFlowID, key)
+		if err != nil {
+			return nil, ConnectRoutePlanIssue{Connect: connect, Failure: ConnectFailureInstanceResolutionInvalid, Detail: err.Error()}
+		}
+		if !connectResolutionTypesCompatible(carry.Type, targetType) {
+			return nil, ConnectRoutePlanIssue{Connect: connect, Failure: ConnectFailureInstanceResolutionInvalid, Detail: fmt.Sprintf("key_types_incompatible: carry %s type %s is incompatible with receiver entity.%s type %s", key, carry.Type, key, targetType)}
+		}
+	}
 	return &ConnectRoutePlanInstanceKey{
 		Mode:       runtimecontracts.FlowInputResolutionModeSelect,
 		Fields:     fields,
@@ -721,6 +730,38 @@ func connectSelectResolutionInstanceKey(source semanticview.Source, connect runt
 		OnMissing:  "reject",
 		OnConflict: "reject",
 	}, ConnectRoutePlanIssue{}
+}
+
+func connectResolutionReceiverEntityFieldType(source semanticview.Source, receiverFlowID, field string) (string, error) {
+	contract, ok := entityruntime.ResolveForFlow(source, receiverFlowID)
+	if !ok {
+		return "", fmt.Errorf("receiver flow %s has no entity contract for entity.%s", receiverFlowID, field)
+	}
+	resolved, err := entityruntime.ResolveLeafField(contract, field)
+	if err != nil {
+		return "", fmt.Errorf("receiver entity.%s is invalid: %v", field, err)
+	}
+	return resolved.Type, nil
+}
+
+func connectResolutionTypesCompatible(sourceType, targetType string) bool {
+	sourceType = connectResolutionTypeFamily(sourceType)
+	targetType = connectResolutionTypeFamily(targetType)
+	return sourceType != "" && targetType != "" && sourceType == targetType
+}
+
+func connectResolutionTypeFamily(raw string) string {
+	raw = strings.ToLower(strings.TrimSpace(raw))
+	switch raw {
+	case "string", "text", "uuid", "timestamp":
+		return "string"
+	case "integer", "number", "numeric", "float", "double", "real":
+		return "number"
+	case "boolean", "bool":
+		return "boolean"
+	default:
+		return raw
+	}
 }
 
 func connectInstanceKeyMaterializationMappings(instanceKey *ConnectRoutePlanInstanceKey) []ConnectRoutePlanInstanceKeyMapping {

--- a/internal/runtime/core/pinrouting/connect_route_plan_test.go
+++ b/internal/runtime/core/pinrouting/connect_route_plan_test.go
@@ -181,6 +181,85 @@ func TestLowerCompositionConnectRoutePlansUsesCreateInputResolution(t *testing.T
 	}
 }
 
+func TestLowerCompositionConnectRoutePlansUsesSelectInputResolution(t *testing.T) {
+	repoRoot, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd: %v", err)
+	}
+	repoRoot = filepath.Clean(filepath.Join(repoRoot, "..", "..", "..", ".."))
+	root := writeSelectResolutionConnectRoutePlanPackageFixture(t)
+	bundle, err := runtimecontracts.LoadWorkflowContractBundleWithOverrides(repoRoot, root, runtimecontracts.DefaultPlatformSpecFile(repoRoot))
+	if err != nil {
+		t.Fatalf("LoadWorkflowContractBundleWithOverrides: %v", err)
+	}
+
+	plans, issues := LowerCompositionConnectRoutePlans(semanticview.Wrap(bundle))
+	if len(issues) != 0 {
+		t.Fatalf("issues = %#v, want none", issues)
+	}
+	if len(plans) != 1 {
+		t.Fatalf("plans = %#v, want one", plans)
+	}
+	plan := plans[0]
+	if plan.InstanceKey == nil {
+		t.Fatal("InstanceKey = nil, want select resolution instance-key evidence")
+	}
+	if got, want := plan.ResolutionKind, ConnectResolutionInstanceKey; got != want {
+		t.Fatalf("ResolutionKind = %q, want %q", got, want)
+	}
+	if !plan.RequiresRuntimeResolution {
+		t.Fatal("select resolution should require runtime descriptor resolution")
+	}
+	if got, want := plan.InstanceKey.Mode, runtimecontracts.FlowInputResolutionModeSelect; got != want {
+		t.Fatalf("InstanceKey.Mode = %q, want %q", got, want)
+	}
+	if got, want := plan.InstanceKey.OnMissing, "reject"; got != want {
+		t.Fatalf("InstanceKey.OnMissing = %q, want %q", got, want)
+	}
+	if got, want := plan.InstanceKey.OnConflict, "reject"; got != want {
+		t.Fatalf("InstanceKey.OnConflict = %q, want %q", got, want)
+	}
+	if len(plan.InstanceKey.Fields) != 1 || plan.InstanceKey.Fields[0] != "account_id" {
+		t.Fatalf("InstanceKey.Fields = %#v, want [account_id]", plan.InstanceKey.Fields)
+	}
+	if len(plan.InstanceKey.Mappings) != 1 || plan.InstanceKey.Mappings[0].Source != "account_id" || plan.InstanceKey.Mappings[0].Target != "account_id" || !plan.InstanceKey.Mappings[0].Explicit {
+		t.Fatalf("InstanceKey.Mappings = %#v, want explicit account_id -> account_id", plan.InstanceKey.Mappings)
+	}
+
+	materialized := MaterializeConnectRoutePlan(plan, ConnectRoutePlanMaterializationInput{
+		MatchValues: map[string]string{"payload.account_id": "acct-1"},
+		Descriptors: []Descriptor{{
+			EntityID:      "ent-1",
+			FlowInstance:  "account/one",
+			AddressFields: map[string]string{"entity.account_id": "acct-1"},
+		}},
+	})
+	if materialized.Failure != "" {
+		t.Fatalf("Failure = %q, want empty", materialized.Failure)
+	}
+	if got, want := materialized.Target.FlowInstance, "account/one"; got != want {
+		t.Fatalf("Target.FlowInstance = %q, want %q", got, want)
+	}
+
+	missing := MaterializeConnectRoutePlan(plan, ConnectRoutePlanMaterializationInput{
+		MatchValues: map[string]string{"payload.account_id": "acct-1"},
+	})
+	if missing.Failure != ConnectFailureTargetUnresolved {
+		t.Fatalf("missing Failure = %q, want %q", missing.Failure, ConnectFailureTargetUnresolved)
+	}
+
+	ambiguous := MaterializeConnectRoutePlan(plan, ConnectRoutePlanMaterializationInput{
+		MatchValues: map[string]string{"payload.account_id": "acct-1"},
+		Descriptors: []Descriptor{
+			{EntityID: "ent-1", FlowInstance: "account/one", AddressFields: map[string]string{"entity.account_id": "acct-1"}},
+			{EntityID: "ent-2", FlowInstance: "account/two", AddressFields: map[string]string{"entity.account_id": "acct-1"}},
+		},
+	})
+	if ambiguous.Failure != ConnectFailureTargetAmbiguous {
+		t.Fatalf("ambiguous Failure = %q, want %q", ambiguous.Failure, ConnectFailureTargetAmbiguous)
+	}
+}
+
 func TestLowerCompositionConnectRoutePlansUsesRenamedInstanceKeyAdapter(t *testing.T) {
 	repoRoot, err := os.Getwd()
 	if err != nil {
@@ -1075,6 +1154,70 @@ pins:
 validation_case:
   validation_case_id:
     type: uuid
+`)
+	return root
+}
+
+func writeSelectResolutionConnectRoutePlanPackageFixture(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	writeConnectRoutePlanFixtureFile(t, filepath.Join(root, "package.yaml"), `
+name: select-resolution-connect-route-plan-package
+version: "1.0.0"
+platform_version: ">=0.7.0 <0.8.0"
+flows:
+  - id: producer
+    flow: producer
+    mode: static
+  - id: account
+    flow: account
+    mode: template
+connect:
+  - from: producer.account_ready
+    to: account.account_ready
+    delivery: one
+`)
+	writeConnectRoutePlanFixtureFile(t, filepath.Join(root, "schema.yaml"), "name: select-resolution-connect-route-plan-package\n")
+	writeConnectRoutePlanFixtureFile(t, filepath.Join(root, "policy.yaml"), "{}\n")
+	writeConnectRoutePlanFixtureFile(t, filepath.Join(root, "tools.yaml"), "{}\n")
+	writeConnectRoutePlanFixtureFile(t, filepath.Join(root, "agents.yaml"), "{}\n")
+	writeConnectRoutePlanFixtureFile(t, filepath.Join(root, "events.yaml"), "{}\n")
+	writeConnectRoutePlanFixtureFile(t, filepath.Join(root, "nodes.yaml"), "{}\n")
+	writeConnectRoutePlanFlowFixture(t, root, "producer", `
+pins:
+  outputs:
+    events:
+      - name: account_ready
+        event: account.ready
+`, "account.ready:\n  account_id: string\n", "{}\n")
+	writeConnectRoutePlanFixtureFile(t, filepath.Join(root, "flows", "account", "schema.yaml"), `
+name: account
+mode: template
+instance:
+  by: account_id
+  on_missing: create
+  on_conflict: reuse
+pins:
+  inputs:
+    events:
+      - name: account_ready
+        event: account.ready
+        resolution:
+          mode: select
+          instance_key: account_id
+        carries:
+          account_id:
+            from: payload.account_id
+            type: string
+`)
+	writeConnectRoutePlanFixtureFile(t, filepath.Join(root, "flows", "account", "policy.yaml"), "{}\n")
+	writeConnectRoutePlanFixtureFile(t, filepath.Join(root, "flows", "account", "agents.yaml"), "{}\n")
+	writeConnectRoutePlanFixtureFile(t, filepath.Join(root, "flows", "account", "nodes.yaml"), "{}\n")
+	writeConnectRoutePlanFixtureFile(t, filepath.Join(root, "flows", "account", "events.yaml"), "account.ready:\n  account_id: string\n")
+	writeConnectRoutePlanFixtureFile(t, filepath.Join(root, "flows", "account", "entities.yaml"), `
+account_state:
+  account_id:
+    type: string
 `)
 	return root
 }

--- a/internal/runtime/core/pinrouting/connect_route_plan_test.go
+++ b/internal/runtime/core/pinrouting/connect_route_plan_test.go
@@ -3,6 +3,7 @@ package pinrouting
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
@@ -257,6 +258,30 @@ func TestLowerCompositionConnectRoutePlansUsesSelectInputResolution(t *testing.T
 	})
 	if ambiguous.Failure != ConnectFailureTargetAmbiguous {
 		t.Fatalf("ambiguous Failure = %q, want %q", ambiguous.Failure, ConnectFailureTargetAmbiguous)
+	}
+}
+
+func TestLowerCompositionConnectRoutePlansRejectsExtraSelectResolutionFields(t *testing.T) {
+	repoRoot, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd: %v", err)
+	}
+	repoRoot = filepath.Clean(filepath.Join(repoRoot, "..", "..", "..", ".."))
+	root := writeSelectResolutionConnectRoutePlanPackageFixtureWithExtraResolution(t, "          aggregation: stream\n")
+	bundle, err := runtimecontracts.LoadWorkflowContractBundleWithOverrides(repoRoot, root, runtimecontracts.DefaultPlatformSpecFile(repoRoot))
+	if err != nil {
+		t.Fatalf("LoadWorkflowContractBundleWithOverrides: %v", err)
+	}
+
+	plans, issues := LowerCompositionConnectRoutePlans(semanticview.Wrap(bundle))
+	if len(plans) != 0 {
+		t.Fatalf("plans = %#v, want none for invalid select resolution", plans)
+	}
+	if len(issues) != 1 {
+		t.Fatalf("issues = %#v, want one fail-closed issue", issues)
+	}
+	if issues[0].Failure != ConnectFailureInstanceResolutionInvalid || !strings.Contains(issues[0].Detail, "may only declare instance_key and carries") {
+		t.Fatalf("issue = %#v, want instance resolution invalid for extra select field", issues[0])
 	}
 }
 
@@ -1159,6 +1184,10 @@ validation_case:
 }
 
 func writeSelectResolutionConnectRoutePlanPackageFixture(t *testing.T) string {
+	return writeSelectResolutionConnectRoutePlanPackageFixtureWithExtraResolution(t, "")
+}
+
+func writeSelectResolutionConnectRoutePlanPackageFixtureWithExtraResolution(t *testing.T, extraResolution string) string {
 	t.Helper()
 	root := t.TempDir()
 	writeConnectRoutePlanFixtureFile(t, filepath.Join(root, "package.yaml"), `
@@ -1205,6 +1234,7 @@ pins:
         resolution:
           mode: select
           instance_key: account_id
+`+extraResolution+`
         carries:
           account_id:
             from: payload.account_id

--- a/internal/runtime/core/pinrouting/connect_route_plan_test.go
+++ b/internal/runtime/core/pinrouting/connect_route_plan_test.go
@@ -285,6 +285,33 @@ func TestLowerCompositionConnectRoutePlansRejectsExtraSelectResolutionFields(t *
 	}
 }
 
+func TestLowerCompositionConnectRoutePlansRejectsSelectCarryTypeMismatch(t *testing.T) {
+	repoRoot, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd: %v", err)
+	}
+	repoRoot = filepath.Clean(filepath.Join(repoRoot, "..", "..", "..", ".."))
+	root := writeSelectResolutionConnectRoutePlanPackageFixtureWithOptions(t, selectResolutionConnectRoutePlanFixtureOptions{
+		accountIDEntityType: "integer",
+		accountIDCarryType:  "string",
+	})
+	bundle, err := runtimecontracts.LoadWorkflowContractBundleWithOverrides(repoRoot, root, runtimecontracts.DefaultPlatformSpecFile(repoRoot))
+	if err != nil {
+		t.Fatalf("LoadWorkflowContractBundleWithOverrides: %v", err)
+	}
+
+	plans, issues := LowerCompositionConnectRoutePlans(semanticview.Wrap(bundle))
+	if len(plans) != 0 {
+		t.Fatalf("plans = %#v, want none for invalid select resolution", plans)
+	}
+	if len(issues) != 1 {
+		t.Fatalf("issues = %#v, want one fail-closed issue", issues)
+	}
+	if issues[0].Failure != ConnectFailureInstanceResolutionInvalid || !strings.Contains(issues[0].Detail, "key_types_incompatible") {
+		t.Fatalf("issue = %#v, want instance resolution invalid for select carry type mismatch", issues[0])
+	}
+}
+
 func TestLowerCompositionConnectRoutePlansUsesRenamedInstanceKeyAdapter(t *testing.T) {
 	repoRoot, err := os.Getwd()
 	if err != nil {
@@ -1184,11 +1211,29 @@ validation_case:
 }
 
 func writeSelectResolutionConnectRoutePlanPackageFixture(t *testing.T) string {
-	return writeSelectResolutionConnectRoutePlanPackageFixtureWithExtraResolution(t, "")
+	return writeSelectResolutionConnectRoutePlanPackageFixtureWithOptions(t, selectResolutionConnectRoutePlanFixtureOptions{})
 }
 
 func writeSelectResolutionConnectRoutePlanPackageFixtureWithExtraResolution(t *testing.T, extraResolution string) string {
+	return writeSelectResolutionConnectRoutePlanPackageFixtureWithOptions(t, selectResolutionConnectRoutePlanFixtureOptions{extraResolution: extraResolution})
+}
+
+type selectResolutionConnectRoutePlanFixtureOptions struct {
+	extraResolution     string
+	accountIDEntityType string
+	accountIDCarryType  string
+}
+
+func writeSelectResolutionConnectRoutePlanPackageFixtureWithOptions(t *testing.T, options selectResolutionConnectRoutePlanFixtureOptions) string {
 	t.Helper()
+	accountIDEntityType := strings.TrimSpace(options.accountIDEntityType)
+	if accountIDEntityType == "" {
+		accountIDEntityType = "string"
+	}
+	accountIDCarryType := strings.TrimSpace(options.accountIDCarryType)
+	if accountIDCarryType == "" {
+		accountIDCarryType = "string"
+	}
 	root := t.TempDir()
 	writeConnectRoutePlanFixtureFile(t, filepath.Join(root, "package.yaml"), `
 name: select-resolution-connect-route-plan-package
@@ -1234,11 +1279,11 @@ pins:
         resolution:
           mode: select
           instance_key: account_id
-`+extraResolution+`
+`+options.extraResolution+`
         carries:
           account_id:
             from: payload.account_id
-            type: string
+            type: `+accountIDCarryType+`
 `)
 	writeConnectRoutePlanFixtureFile(t, filepath.Join(root, "flows", "account", "policy.yaml"), "{}\n")
 	writeConnectRoutePlanFixtureFile(t, filepath.Join(root, "flows", "account", "agents.yaml"), "{}\n")
@@ -1247,7 +1292,7 @@ pins:
 	writeConnectRoutePlanFixtureFile(t, filepath.Join(root, "flows", "account", "entities.yaml"), `
 account_state:
   account_id:
-    type: string
+    type: `+accountIDEntityType+`
 `)
 	return root
 }

--- a/internal/runtime/testfixtures/templateselectexisting/fixture.go
+++ b/internal/runtime/testfixtures/templateselectexisting/fixture.go
@@ -1,0 +1,157 @@
+package templateselectexisting
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
+	"github.com/division-sh/swarm/internal/runtime/semanticview"
+)
+
+const (
+	PackageName = "template-select-existing"
+
+	ProducerFlowID    = "producer"
+	ProducerOutputPin = "account_ready"
+	ProducerOutput    = "account.ready"
+
+	TemplateFlowID     = "account"
+	TemplateInputPin   = "account_ready"
+	TemplateInput      = "account.ready"
+	TemplateInstanceBy = "account_id"
+)
+
+func LoadBundle(t testing.TB) *runtimecontracts.WorkflowContractBundle {
+	t.Helper()
+	root := Write(t)
+	bundle, err := runtimecontracts.LoadWorkflowContractBundleWithOverrides(repoRoot(t), root, runtimecontracts.DefaultPlatformSpecFile(repoRoot(t)))
+	if err != nil {
+		t.Fatalf("LoadWorkflowContractBundleWithOverrides: %v", err)
+	}
+	return bundle
+}
+
+func LoadSource(t testing.TB) semanticview.Source {
+	t.Helper()
+	return semanticview.Wrap(LoadBundle(t))
+}
+
+func Write(t testing.TB) string {
+	t.Helper()
+	root := t.TempDir()
+	writeRoot(t, root)
+	writeProducer(t, root)
+	writeTemplate(t, root)
+	return root
+}
+
+func writeRoot(t testing.TB, root string) {
+	t.Helper()
+	writeFile(t, filepath.Join(root, "package.yaml"), `
+name: template-select-existing
+version: "1.0.0"
+platform_version: ">=0.7.0 <0.8.0"
+flows:
+  - id: producer
+    flow: producer
+    mode: static
+  - id: account
+    flow: account
+    mode: template
+connect:
+  - from: producer.account_ready
+    to: account.account_ready
+    delivery: one
+`)
+	writeFile(t, filepath.Join(root, "schema.yaml"), "name: template-select-existing\n")
+	writeFile(t, filepath.Join(root, "policy.yaml"), "{}\n")
+	writeFile(t, filepath.Join(root, "tools.yaml"), "{}\n")
+	writeFile(t, filepath.Join(root, "agents.yaml"), "{}\n")
+	writeFile(t, filepath.Join(root, "events.yaml"), "{}\n")
+	writeFile(t, filepath.Join(root, "nodes.yaml"), "{}\n")
+}
+
+func writeProducer(t testing.TB, root string) {
+	t.Helper()
+	writeFile(t, filepath.Join(root, "flows", "producer", "schema.yaml"), `
+name: producer
+mode: static
+pins:
+  outputs:
+    events:
+      - name: account_ready
+        event: account.ready
+`)
+	writeFile(t, filepath.Join(root, "flows", "producer", "policy.yaml"), "{}\n")
+	writeFile(t, filepath.Join(root, "flows", "producer", "agents.yaml"), "{}\n")
+	writeFile(t, filepath.Join(root, "flows", "producer", "entities.yaml"), "{}\n")
+	writeFile(t, filepath.Join(root, "flows", "producer", "events.yaml"), `
+account.ready:
+  account_id: string
+`)
+	writeFile(t, filepath.Join(root, "flows", "producer", "nodes.yaml"), "{}\n")
+}
+
+func writeTemplate(t testing.TB, root string) {
+	t.Helper()
+	writeFile(t, filepath.Join(root, "flows", "account", "schema.yaml"), `
+name: account
+mode: template
+instance:
+  by: account_id
+  on_missing: create
+  on_conflict: reuse
+pins:
+  inputs:
+    events:
+      - name: account_ready
+        event: account.ready
+        resolution:
+          mode: select
+          instance_key: account_id
+        carries:
+          account_id:
+            from: payload.account_id
+            type: string
+`)
+	writeFile(t, filepath.Join(root, "flows", "account", "policy.yaml"), "{}\n")
+	writeFile(t, filepath.Join(root, "flows", "account", "agents.yaml"), "{}\n")
+	writeFile(t, filepath.Join(root, "flows", "account", "events.yaml"), `
+account.ready:
+  account_id: string
+`)
+	writeFile(t, filepath.Join(root, "flows", "account", "entities.yaml"), `
+account_state:
+  account_id:
+    type: string
+    _unused_reason: template-select-existing route key fixture field
+`)
+	writeFile(t, filepath.Join(root, "flows", "account", "nodes.yaml"), `
+account-node:
+  id: account-node-{instance_id}
+  execution_type: system_node
+  event_handlers:
+    account.ready: {}
+`)
+}
+
+func repoRoot(t testing.TB) string {
+	t.Helper()
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("resolve repo root")
+	}
+	return filepath.Clean(filepath.Join(filepath.Dir(file), "..", "..", "..", ".."))
+}
+
+func writeFile(t testing.TB, path, contents string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("MkdirAll(%s): %v", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, []byte(contents), 0o644); err != nil {
+		t.Fatalf("WriteFile(%s): %v", path, err)
+	}
+}

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -7976,7 +7976,7 @@ flow_model:
             broadcast:true, receiver select_entity/select_or_create_entity, and
             explicit create_flow_instance are not lifecycle authority.
         implementation_slice_1835:
-          status: spec_locked_create_mode_runnable_remaining_modes_fail_closed
+          status: spec_locked_create_and_select_modes_runnable_remaining_modes_fail_closed
           canonical_spec_owner: platform-spec.yaml#flow_model.flow_package.composition_routing.route_plan_lowering.implementation_slice_1835
           canonical_code_owner: internal/runtime/contracts.FlowInputPinResolution + internal/runtime/core/pinrouting.ConnectRoutePlan.InstanceKey + internal/runtime/bus.templateInstanceLifecycleOwner + internal/runtime/bootverify.composition_connect_validation
           rule: |
@@ -7989,13 +7989,15 @@ flow_model:
             subscribers, delivery rows, replay rows, route-table lookup before a
             selected target, or handler lookup.
 
-            PR1 spec-locks every approved mode but only makes
-            `resolution.mode: create` runnable. All other locked modes are
-            recognized by contracts and verifier and fail closed as
-            design-locked/not-runnable until their implementation slices land.
-            Static root ingress, parent-connect static delivery, and
-            harness-injected inputs remain existing #1807 input-source / connect
-            behavior; they are not instance-resolution runtime modes.
+            PR1 spec-locks every approved mode and makes
+            `resolution.mode: create` runnable. PR2 makes
+            `resolution.mode: select` runnable for a single declared carried
+            key. All other locked modes are recognized by contracts and
+            verifier and fail closed as design-locked/not-runnable until their
+            implementation slices land. Static root ingress, parent-connect
+            static delivery, and harness-injected inputs remain existing #1807
+            input-source / connect behavior; they are not instance-resolution
+            runtime modes.
           authoring_shape: |
             pins:
               inputs:
@@ -8051,11 +8053,37 @@ flow_model:
               - delivery topology other than one
               - unavailable template lifecycle activator
             select:
-              status: spec_locked_not_runnable_in_1835_pr1
+              status: runnable_in_1835_pr2
               contract: >
-                Select routes to exactly one existing receiver instance by an
-                explicit instance key. Missing or ambiguous target is invalid;
-                this mode never creates an instance.
+                Select routes to exactly one existing receiver template
+                instance by a declared carried key. The input pin declares the
+                seam identity once under `carries.<field>`, and
+                `resolution.instance_key` MUST name that carried field. In this
+                slice the receiver flow MUST be `mode: template`, MUST have a
+                single `instance.by` field, and that field MUST equal
+                `resolution.instance_key`. The carry MUST use `from:
+                payload.<field>` and may declare a type compatible with the
+                receiver `entity.<field>`. The lowered route plan records
+                `Mode: select`, the single field mapping, runtime descriptor
+                resolution, and reject/reject lifecycle policy. Missing or
+                ambiguous target is invalid; this mode never creates an
+                instance and receiver legacy `on_missing:create` does not
+                override select semantics. Target-failure diagnostics MUST name
+                the receiver flow, key field, key value when available, and an
+                imperative remediation.
+              fail_closed:
+              - missing or empty instance_key
+              - instance_key not naming declared carries.<field>
+              - receiver not mode: template
+              - receiver instance.by missing, composite, or not equal to instance_key
+              - carry source not payload.<field>
+              - type-incompatible carried key
+              - combined legacy input address
+              - combined connect.using.instance or connect.map
+              - delivery topology other than one
+              - missing target instance
+              - ambiguous target instance
+              - any activation attempt for a missing target
             select-or-create:
               status: spec_locked_not_runnable_in_1835_pr1
               contract: >
@@ -8104,11 +8132,16 @@ flow_model:
               `resolution:{mode,...}` semantics.
           proof_obligations:
           - contracts decode every locked mode and reject unknown resolution fields fail-closed
-          - bootverify accepts valid create resolution and rejects non-create modes as not runnable in this slice
+          - bootverify accepts valid create/select resolution and rejects other non-create modes as not runnable in this slice
           - route-plan lowering records create mode, mint kind, carried `as` field, create/reuse lifecycle policy, and does not require producer output key/carries
           - EventBus publish/preflight creates a missing receiver instance through the canonical lifecycle path
           - downstream receiver routes can render the carried minted instance key from activation variables
           - same committed event replay reuses persisted delivery route/scope and does not create another receiver instance
+          - route-plan lowering records select mode, declared carried key mapping, runtime descriptor resolution, and reject/reject lifecycle policy
+          - EventBus publish/preflight for select routes to exactly one existing receiver instance
+          - missing/ambiguous select target failures fail closed with receiver/key/value/remediation detail and no activation
+          - same committed select event replay reuses persisted delivery route/scope and does not reselect after descriptor drift
+          - standalone #1828 `template-select-existing` conformance fixture verifies and materializes through the canonical select route plan
         implementation_slice_1546:
           status: merge_bearing_runtime_behavior
           canonical_code_owner: internal/runtime/core/pinrouting.ConnectRoutePlan.InstanceKey.Mappings + internal/runtime/bus.connectRoutePlanResolver


### PR DESCRIPTION
Part of #1835

## Summary
- Makes `resolution.mode: select` runnable for the approved PR2 boundary: single-field carried-key selection of exactly one existing template instance.
- Updates `platform-spec.yaml` `implementation_slice_1835` from create-only runnable to create+select runnable, with select fail-closed semantics and proof obligations.
- Adds bootverify, route-plan, EventBus preflight/publish/replay integration, and #1828 `template-select-existing` conformance fixture coverage.

## Governing Refs / Context
- #1835 body/thread and Gate A approval comment: approved as first slice for PR2 `resolution.mode:select`.
- #1828 tracker repair: `template-select-existing` added to the runnable example inventory.
- #1786 routing-model record: declarative instance resolution, carried identity at the seam, `target:{flow,match}` banned.
- #164 instance lifecycle owner: select routes to existing instances; create/select-or-create lifecycle remains separate.
- Authoritative spec updated in this PR: `platform-spec.yaml#flow_model.flow_package.composition_routing.route_plan_lowering.implementation_slice_1835`.

## Semantic Migration Notes
- New canonical owner: receiver input-pin `resolution:{mode: select, instance_key: <declared-carry>}` plus `carries.<field>.from: payload.<field>` lowered through `ConnectRoutePlan.InstanceKey`.
- Old producer/reader/writer paths now invalid for this surface: legacy input `address`, `connect.using.instance`, `connect.map`, producer target/broadcast routing, and `select_entity`/`select_or_create_entity` are not select-resolution authority.
- Production paths checked for surviving old behavior: bootverify rejects legacy address/connect adapters/maps combined with `resolution`; route-plan lowering uses `Mode: select`; lifecycle forces reject/reject so receiver `on_missing:create` cannot create under select.
- Migration complete for the chosen child slice: yes, for single-field carried-key `resolution.mode:select`. Parent #1835 remains open for select-or-create, fan-in/fan-out, reply, empire counterpart proofs, and later E1a retirements.

## Proof
- `go test ./internal/runtime/bootverify`
- `go test ./internal/runtime/core/pinrouting`
- `SWARM_TEST_POSTGRES_DSN='host=127.0.0.1 port=5432 user=youmew dbname=postgres sslmode=disable' PGPASSWORD=postgres go test ./internal/runtime/bus`
- `SWARM_TEST_POSTGRES_DSN='host=127.0.0.1 port=5432 user=youmew dbname=postgres sslmode=disable' PGPASSWORD=postgres go test ./internal/runtime/conformance`
- `SWARM_TEST_POSTGRES_DSN='host=127.0.0.1 port=5432 user=youmew dbname=postgres sslmode=disable' PGPASSWORD=postgres go test ./...`
