### PR TITLE
[agent-e][issue #1813] Translate runtime transport diagnostics

### DIFF
--- a/cmd/swarm/agent_deliveries_test.go
+++ b/cmd/swarm/agent_deliveries_test.go
@@ -228,7 +228,7 @@ func TestAgentDeliveriesFailClosedOnRPCAndMalformedResponses(t *testing.T) {
 				http.Error(w, "unauthorized", http.StatusUnauthorized)
 			},
 			wantCode:   cliExitAuth,
-			wantStderr: "v1 RPC HTTP 401",
+			wantStderr: "rejected the request with status 401",
 		},
 		{
 			name: "agent not found",

--- a/cmd/swarm/agent_diagnose_test.go
+++ b/cmd/swarm/agent_diagnose_test.go
@@ -164,7 +164,7 @@ func TestAgentDiagnoseFailClosedOnRPCAndMalformedResponses(t *testing.T) {
 				http.Error(w, "unauthorized", http.StatusUnauthorized)
 			},
 			wantCode:   cliExitAuth,
-			wantStderr: "v1 RPC HTTP 401",
+			wantStderr: "rejected the request with status 401",
 		},
 		{
 			name: "agent not found",

--- a/cmd/swarm/agent_directive.go
+++ b/cmd/swarm/agent_directive.go
@@ -60,23 +60,23 @@ func newAgentDirectiveCommand(opts rootCommandOptions) *cobra.Command {
 func runAgentDirectiveCommand(ctx context.Context, out, errOut io.Writer, args []string, opts agentDirectiveCommandOptions) error {
 	agentID, directive, err := validateAgentDirectiveArgs(args)
 	if err != nil {
-		fmt.Fprintln(errOut, err)
+		writeCLIAPIError(errOut, err)
 		return commandExitError{code: agentDirectiveExitValidation}
 	}
 
 	client, err := newCLIAPIClient(opts.apiOptions)
 	if err != nil {
-		fmt.Fprintln(errOut, err)
+		writeCLIAPIError(errOut, err)
 		return commandExitError{code: agentDirectiveErrorExitCode(err)}
 	}
 
 	var result agentDirectiveResult
 	if err := client.call(ctx, agentDirectiveMethod, opts.params(agentID, directive), &result); err != nil {
-		fmt.Fprintln(errOut, err)
+		writeCLIAPIError(errOut, err)
 		return commandExitError{code: agentDirectiveErrorExitCode(err)}
 	}
 	if err := validateAgentDirectiveResult(result); err != nil {
-		fmt.Fprintln(errOut, err)
+		writeCLIAPIError(errOut, err)
 		return commandExitError{code: agentDirectiveExitRuntime}
 	}
 	writeAgentDirectiveResult(out, agentID, result)

--- a/cmd/swarm/agent_directive_test.go
+++ b/cmd/swarm/agent_directive_test.go
@@ -187,7 +187,7 @@ func TestAgentDirectiveMapsFailureExitCodes(t *testing.T) {
 				http.Error(w, "unauthorized", http.StatusUnauthorized)
 			},
 			wantCode:   4,
-			wantStderr: "v1 RPC HTTP 401",
+			wantStderr: "rejected the request with status 401",
 		},
 		{
 			name: "http runtime failure exits three",
@@ -195,7 +195,7 @@ func TestAgentDirectiveMapsFailureExitCodes(t *testing.T) {
 				http.Error(w, "unavailable", http.StatusServiceUnavailable)
 			},
 			wantCode:   3,
-			wantStderr: "v1 RPC HTTP 503",
+			wantStderr: "returned status 503",
 		},
 		{
 			name: "agent not found exits five",

--- a/cmd/swarm/agent_replay.go
+++ b/cmd/swarm/agent_replay.go
@@ -70,23 +70,23 @@ func newAgentReplayCommand(opts rootCommandOptions) *cobra.Command {
 func runAgentReplayCommand(ctx context.Context, out, errOut io.Writer, args []string, opts agentReplayCommandOptions) error {
 	agentID, eventID, err := validateAgentReplayArgs(args, opts.eventID)
 	if err != nil {
-		fmt.Fprintln(errOut, err)
+		writeCLIAPIError(errOut, err)
 		return commandExitError{code: agentReplayExitValidation}
 	}
 
 	client, err := newCLIAPIClient(opts.apiOptions)
 	if err != nil {
-		fmt.Fprintln(errOut, err)
+		writeCLIAPIError(errOut, err)
 		return commandExitError{code: agentReplayErrorExitCode(err)}
 	}
 
 	var result agentReplayResult
 	if err := client.call(ctx, agentReplayMethod, opts.params(agentID, eventID), &result); err != nil {
-		fmt.Fprintln(errOut, err)
+		writeCLIAPIError(errOut, err)
 		return commandExitError{code: agentReplayErrorExitCode(err)}
 	}
 	if err := validateAgentReplayResult(result, agentID, eventID); err != nil {
-		fmt.Fprintln(errOut, err)
+		writeCLIAPIError(errOut, err)
 		return commandExitError{code: agentReplayExitRuntime}
 	}
 	writeAgentReplayResult(out, result)

--- a/cmd/swarm/agent_replay_backlog.go
+++ b/cmd/swarm/agent_replay_backlog.go
@@ -47,23 +47,23 @@ func newAgentReplayBacklogCommand(opts rootCommandOptions) *cobra.Command {
 func runAgentReplayBacklogCommand(ctx context.Context, out, errOut io.Writer, args []string, opts agentReplayBacklogCommandOptions) error {
 	agentID, err := validateAgentReplayBacklogArgs(args)
 	if err != nil {
-		fmt.Fprintln(errOut, err)
+		writeCLIAPIError(errOut, err)
 		return commandExitError{code: agentReplayBacklogExitValidation}
 	}
 
 	client, err := newCLIAPIClient(opts.apiOptions)
 	if err != nil {
-		fmt.Fprintln(errOut, err)
+		writeCLIAPIError(errOut, err)
 		return commandExitError{code: agentReplayBacklogErrorExitCode(err)}
 	}
 
 	var result agentReplayBacklogResult
 	if err := client.call(ctx, agentReplayBacklogMethod, opts.params(agentID), &result); err != nil {
-		fmt.Fprintln(errOut, err)
+		writeCLIAPIError(errOut, err)
 		return commandExitError{code: agentReplayBacklogErrorExitCode(err)}
 	}
 	if err := validateAgentReplayBacklogResult(result); err != nil {
-		fmt.Fprintln(errOut, err)
+		writeCLIAPIError(errOut, err)
 		return commandExitError{code: agentReplayBacklogExitRuntime}
 	}
 	writeAgentReplayBacklogResult(out, agentID, result)

--- a/cmd/swarm/agent_replay_backlog_test.go
+++ b/cmd/swarm/agent_replay_backlog_test.go
@@ -149,7 +149,7 @@ func TestAgentReplayBacklogMapsFailureExitCodes(t *testing.T) {
 				http.Error(w, "unauthorized", http.StatusUnauthorized)
 			},
 			wantCode:   4,
-			wantStderr: "v1 RPC HTTP 401",
+			wantStderr: "rejected the request with status 401",
 		},
 		{
 			name: "http runtime failure exits three",
@@ -157,7 +157,7 @@ func TestAgentReplayBacklogMapsFailureExitCodes(t *testing.T) {
 				http.Error(w, "unavailable", http.StatusServiceUnavailable)
 			},
 			wantCode:   3,
-			wantStderr: "v1 RPC HTTP 503",
+			wantStderr: "returned status 503",
 		},
 		{
 			name: "agent not found exits five",

--- a/cmd/swarm/agent_replay_test.go
+++ b/cmd/swarm/agent_replay_test.go
@@ -192,7 +192,7 @@ func TestAgentReplayMapsFailureExitCodes(t *testing.T) {
 				http.Error(w, "unauthorized", http.StatusUnauthorized)
 			},
 			wantCode:   4,
-			wantStderr: "v1 RPC HTTP 401",
+			wantStderr: "rejected the request with status 401",
 		},
 		{
 			name: "http runtime failure exits three",
@@ -200,7 +200,7 @@ func TestAgentReplayMapsFailureExitCodes(t *testing.T) {
 				http.Error(w, "unavailable", http.StatusServiceUnavailable)
 			},
 			wantCode:   3,
-			wantStderr: "v1 RPC HTTP 503",
+			wantStderr: "returned status 503",
 		},
 		{
 			name: "event not found exits five",

--- a/cmd/swarm/agent_restart.go
+++ b/cmd/swarm/agent_restart.go
@@ -46,23 +46,23 @@ func newAgentRestartCommand(opts rootCommandOptions) *cobra.Command {
 func runAgentRestartCommand(ctx context.Context, out, errOut io.Writer, args []string, opts agentRestartCommandOptions) error {
 	agentID, err := validateAgentRestartArgs(args)
 	if err != nil {
-		fmt.Fprintln(errOut, err)
+		writeCLIAPIError(errOut, err)
 		return commandExitError{code: agentRestartExitValidation}
 	}
 
 	client, err := newCLIAPIClient(opts.apiOptions)
 	if err != nil {
-		fmt.Fprintln(errOut, err)
+		writeCLIAPIError(errOut, err)
 		return commandExitError{code: agentRestartErrorExitCode(err)}
 	}
 
 	var result agentRestartResult
 	if err := client.call(ctx, agentRestartMethod, opts.params(agentID), &result); err != nil {
-		fmt.Fprintln(errOut, err)
+		writeCLIAPIError(errOut, err)
 		return commandExitError{code: agentRestartErrorExitCode(err)}
 	}
 	if err := validateAgentRestartResult(result); err != nil {
-		fmt.Fprintln(errOut, err)
+		writeCLIAPIError(errOut, err)
 		return commandExitError{code: agentRestartExitRuntime}
 	}
 	writeAgentRestartResult(out, agentID)

--- a/cmd/swarm/agent_restart_test.go
+++ b/cmd/swarm/agent_restart_test.go
@@ -145,7 +145,7 @@ func TestAgentRestartMapsFailureExitCodes(t *testing.T) {
 				http.Error(w, "unauthorized", http.StatusUnauthorized)
 			},
 			wantCode:   4,
-			wantStderr: "v1 RPC HTTP 401",
+			wantStderr: "rejected the request with status 401",
 		},
 		{
 			name: "http runtime failure exits three",
@@ -153,7 +153,7 @@ func TestAgentRestartMapsFailureExitCodes(t *testing.T) {
 				http.Error(w, "unavailable", http.StatusServiceUnavailable)
 			},
 			wantCode:   3,
-			wantStderr: "v1 RPC HTTP 503",
+			wantStderr: "returned status 503",
 		},
 		{
 			name: "agent not found exits five",

--- a/cmd/swarm/agents_test.go
+++ b/cmd/swarm/agents_test.go
@@ -211,7 +211,7 @@ func TestAgentReadCommandsFailClosedOnRPCAndMalformedResponses(t *testing.T) {
 				http.Error(w, "unauthorized", http.StatusUnauthorized)
 			},
 			wantCode:   4,
-			wantStderr: "v1 RPC HTTP 401",
+			wantStderr: "rejected the request with status 401",
 		},
 		{
 			name: "list missing agents",

--- a/cmd/swarm/cli_api.go
+++ b/cmd/swarm/cli_api.go
@@ -636,6 +636,7 @@ func applicationErrorDetailValue(value any) string {
 
 type cliAPIHTTPError struct {
 	surface    string
+	endpoint   string
 	statusCode int
 	message    string
 }
@@ -646,9 +647,67 @@ func (e *cliAPIHTTPError) Error() string {
 	}
 	surface := strings.TrimSpace(e.surface)
 	if surface == "" {
-		surface = "v1 RPC"
+		surface = "runtime API"
 	}
-	return fmt.Sprintf("%s HTTP %d: %s", surface, e.statusCode, e.message)
+	return fmt.Sprintf("%s returned status %d", surface, e.statusCode)
+}
+
+type cliAPITransportError struct {
+	surface   string
+	endpoint  string
+	operation string
+	err       error
+}
+
+func (e *cliAPITransportError) Error() string {
+	if e == nil {
+		return ""
+	}
+	surface := strings.TrimSpace(e.surface)
+	if surface == "" {
+		surface = "runtime API"
+	}
+	operation := strings.TrimSpace(e.operation)
+	if operation == "" {
+		operation = "request"
+	}
+	return fmt.Sprintf("%s %s failed", surface, operation)
+}
+
+func (e *cliAPITransportError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.err
+}
+
+type cliAPIProtocolError struct {
+	surface   string
+	endpoint  string
+	operation string
+	err       error
+}
+
+func (e *cliAPIProtocolError) Error() string {
+	if e == nil {
+		return ""
+	}
+	surface := strings.TrimSpace(e.surface)
+	if surface == "" {
+		surface = "runtime API"
+	}
+	operation := strings.TrimSpace(e.operation)
+	if operation == "" {
+		operation = "response"
+	}
+	return fmt.Sprintf("%s invalid %s", surface, operation)
+}
+
+func (e *cliAPIProtocolError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.err
 }
 
 func (c *cliAPIClient) call(ctx context.Context, method string, params map[string]any, result any) error {
@@ -671,32 +730,32 @@ func (c *cliAPIClient) call(ctx context.Context, method string, params map[strin
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
-		return fmt.Errorf("v1 RPC request failed: %w", err)
+		return &cliAPITransportError{surface: "runtime API", endpoint: c.endpoint, operation: "request", err: err}
 	}
 	defer resp.Body.Close()
 
 	raw, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
 	if err != nil {
-		return fmt.Errorf("read v1 RPC response: %w", err)
+		return &cliAPITransportError{surface: "runtime API", endpoint: c.endpoint, operation: "response read", err: err}
 	}
 	if resp.StatusCode != http.StatusOK {
 		message := strings.TrimSpace(string(raw))
 		if message == "" {
 			message = http.StatusText(resp.StatusCode)
 		}
-		return &cliAPIHTTPError{statusCode: resp.StatusCode, message: message}
+		return &cliAPIHTTPError{surface: "runtime API", endpoint: c.endpoint, statusCode: resp.StatusCode, message: message}
 	}
 
 	var envelope jsonRPCResponse
 	if err := json.Unmarshal(raw, &envelope); err != nil {
-		return fmt.Errorf("decode JSON-RPC response: %w", err)
+		return &cliAPIProtocolError{surface: "runtime API", endpoint: c.endpoint, operation: "response", err: err}
 	}
 	if envelope.JSONRPC != "2.0" {
-		return fmt.Errorf("malformed JSON-RPC response: jsonrpc=%q", envelope.JSONRPC)
+		return &cliAPIProtocolError{surface: "runtime API", endpoint: c.endpoint, operation: "response", err: fmt.Errorf("jsonrpc=%q", envelope.JSONRPC)}
 	}
 	responseID, ok := envelope.ID.(string)
 	if !ok || responseID != requestID {
-		return fmt.Errorf("malformed JSON-RPC response: id=%s, want %q", formatJSONRPCID(envelope.ID), requestID)
+		return &cliAPIProtocolError{surface: "runtime API", endpoint: c.endpoint, operation: "response", err: fmt.Errorf("id=%s, want %q", formatJSONRPCID(envelope.ID), requestID)}
 	}
 	if envelope.Error != nil {
 		return envelope.Error

--- a/cmd/swarm/cli_errors.go
+++ b/cmd/swarm/cli_errors.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
+	"strings"
 )
 
 const (
@@ -84,9 +86,7 @@ func cliAPIErrorExitCode(err error, classifier cliAPIErrorClassifier) int {
 }
 
 func returnCLIAPIError(errOut io.Writer, err error, classifier cliAPIErrorClassifier) error {
-	if errOut != nil {
-		fmt.Fprintln(errOut, err)
-	}
+	writeCLIAPIError(errOut, err)
 	return commandExitError{code: cliAPIErrorExitCode(err, classifier)}
 }
 
@@ -95,6 +95,152 @@ func returnCLIValidationError(errOut io.Writer, err error) error {
 		fmt.Fprintln(errOut, err)
 	}
 	return commandExitError{code: cliExitValidation}
+}
+
+func writeCLIAPIError(errOut io.Writer, err error) {
+	if errOut == nil || err == nil {
+		return
+	}
+	fmt.Fprintln(errOut, formatCLIAPIError(err))
+}
+
+func formatCLIAPIError(err error) string {
+	if err == nil {
+		return ""
+	}
+	if diagnostic, ok := cliAPITransportDiagnosticParts(err); ok {
+		lines := []string{"ERROR: " + cliAPIProblemWithWrapper(err, diagnostic.leaf, diagnostic.problem)}
+		lines = append(lines, diagnostic.evidence...)
+		lines = append(lines, diagnostic.remediation...)
+		return strings.Join(lines, "\n")
+	}
+	return err.Error()
+}
+
+func formatCLIAPITransportDetail(err error) string {
+	if err == nil {
+		return ""
+	}
+	if diagnostic, ok := cliAPITransportDiagnosticParts(err); ok {
+		return cliAPIProblemWithWrapper(err, diagnostic.leaf, diagnostic.problem)
+	}
+	return err.Error()
+}
+
+type cliAPITransportDiagnostic struct {
+	leaf        error
+	problem     string
+	evidence    []string
+	remediation []string
+}
+
+func cliAPITransportDiagnosticParts(err error) (cliAPITransportDiagnostic, bool) {
+	var transportErr *cliAPITransportError
+	if errors.As(err, &transportErr) {
+		target := cliAPIDiagnosticTarget(transportErr.endpoint)
+		problem := fmt.Sprintf("cannot reach the Swarm runtime at %s.", target)
+		return cliAPITransportDiagnostic{
+			leaf:    transportErr,
+			problem: problem,
+			remediation: []string{
+				"  Is the runtime running? Start one with `swarm serve` (or `swarm serve --dev` for local development).",
+				"  Check the selected target with `swarm context current`; override with --api-server.",
+			},
+		}, true
+	}
+	var protocolErr *cliAPIProtocolError
+	if errors.As(err, &protocolErr) {
+		target := cliAPIDiagnosticTarget(protocolErr.endpoint)
+		problem := fmt.Sprintf("the Swarm runtime at %s returned an invalid API response.", target)
+		var evidence []string
+		if protocolErr.err != nil {
+			if text := strings.TrimSpace(protocolErr.err.Error()); text != "" {
+				evidence = []string{"  Evidence: " + text}
+			}
+		}
+		return cliAPITransportDiagnostic{
+			leaf:     protocolErr,
+			problem:  problem,
+			evidence: evidence,
+			remediation: []string{
+				"  Check the selected target with `swarm context current`; override with --api-server.",
+				"  If this is a local runtime, restart it with `swarm serve`.",
+			},
+		}, true
+	}
+	var httpErr *cliAPIHTTPError
+	if errors.As(err, &httpErr) {
+		target := cliAPIDiagnosticTarget(httpErr.endpoint)
+		status := httpErr.statusCode
+		if status == http.StatusUnauthorized || status == http.StatusForbidden {
+			problem := fmt.Sprintf("the Swarm runtime at %s rejected the request with status %d.", target, status)
+			return cliAPITransportDiagnostic{
+				leaf:    httpErr,
+				problem: problem,
+				remediation: []string{
+					"  Check API credentials with --api-token-file or the selected context.",
+					"  Check the selected target with `swarm context current`; override with --api-server.",
+				},
+			}, true
+		}
+		problem := fmt.Sprintf("the Swarm runtime at %s returned status %d.", target, status)
+		return cliAPITransportDiagnostic{
+			leaf:    httpErr,
+			problem: problem,
+			remediation: []string{
+				"  Check the runtime with `swarm health` or restart it with `swarm serve`.",
+				"  Check the selected target with `swarm context current`; override with --api-server.",
+			},
+		}, true
+	}
+	return cliAPITransportDiagnostic{}, false
+}
+
+func cliAPIProblemWithWrapper(err, leaf error, problem string) string {
+	full := strings.TrimSpace(err.Error())
+	leafText := strings.TrimSpace(leaf.Error())
+	if err != leaf && full != "" && leafText != "" && full != leafText && strings.HasSuffix(full, leafText) {
+		prefix := strings.TrimSpace(strings.TrimSuffix(full, leafText))
+		if prefix != "" {
+			return prefix + " " + problem
+		}
+	}
+	return problem
+}
+
+func cliAPIDiagnosticTarget(endpoint string) string {
+	trimmed := strings.TrimSpace(endpoint)
+	if trimmed == "" {
+		return "the selected target"
+	}
+	parsed, err := url.Parse(trimmed)
+	if err != nil {
+		return trimmed
+	}
+	host := strings.TrimSpace(parsed.Host)
+	if host == "" {
+		return trimmed
+	}
+	path := strings.TrimRight(parsed.Path, "/")
+	for _, suffix := range []string{cliAPIRPCPath, cliAPIWSPath} {
+		if path == suffix {
+			path = ""
+			break
+		}
+		if strings.HasSuffix(path, suffix) {
+			path = strings.TrimRight(strings.TrimSuffix(path, suffix), "/")
+			break
+		}
+	}
+	if path == "" || path == "/" {
+		return host
+	}
+	return host + path
+}
+
+func cliAPIIsTransportFailure(err error) bool {
+	var transportErr *cliAPITransportError
+	return errors.As(err, &transportErr)
 }
 
 func cliCodeInSet(code string, codes []string) bool {

--- a/cmd/swarm/cli_errors_test.go
+++ b/cmd/swarm/cli_errors_test.go
@@ -34,7 +34,7 @@ func TestCLIAPIErrorExitCodeClassifiesSharedCategories(t *testing.T) {
 		{name: "rpc conflict", err: rpcError("IDEMPOTENCY_CONFLICT"), want: cliExitConflict},
 		{name: "rpc state conflict", err: rpcError("RUN_ALREADY_TERMINAL"), want: cliExitConflict},
 		{name: "unknown rpc", err: rpcError("UNKNOWN_CODE"), want: cliExitRuntime},
-		{name: "transport", err: fmt.Errorf("v1 RPC request failed: %w", errors.New("connection refused")), want: cliExitRuntime},
+		{name: "transport", err: &cliAPITransportError{surface: "runtime API", endpoint: "http://127.0.0.1:1/v1/rpc", operation: "request", err: errors.New("connection refused")}, want: cliExitRuntime},
 		{name: "malformed response", err: errors.New("malformed JSON-RPC response: jsonrpc=\"1.0\""), want: cliExitRuntime},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -42,6 +42,92 @@ func TestCLIAPIErrorExitCodeClassifiesSharedCategories(t *testing.T) {
 				t.Fatalf("exit = %d, want %d", got, tc.want)
 			}
 		})
+	}
+}
+
+func TestCLIAPITransportDiagnosticRendersUserFacingRuntimeTarget(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		err  error
+		want []string
+	}{
+		{
+			name: "transport",
+			err:  &cliAPITransportError{surface: "runtime API", endpoint: "http://127.0.0.1:1/v1/rpc", operation: "request", err: errors.New("connection refused")},
+			want: []string{
+				"ERROR: cannot reach the Swarm runtime at 127.0.0.1:1.",
+				"Is the runtime running?",
+				"Check the selected target with `swarm context current`; override with --api-server.",
+			},
+		},
+		{
+			name: "http auth",
+			err:  &cliAPIHTTPError{surface: "runtime API", endpoint: "http://127.0.0.1:8081/proxy/v1/rpc", statusCode: 401, message: "unauthorized"},
+			want: []string{
+				"ERROR: the Swarm runtime at 127.0.0.1:8081/proxy rejected the request with status 401.",
+				"Check API credentials",
+			},
+		},
+		{
+			name: "http runtime",
+			err:  &cliAPIHTTPError{surface: "runtime API", endpoint: "http://127.0.0.1:8081/v1/rpc", statusCode: 503, message: "unavailable"},
+			want: []string{
+				"ERROR: the Swarm runtime at 127.0.0.1:8081 returned status 503.",
+				"Check the runtime with `swarm health`",
+			},
+		},
+		{
+			name: "protocol",
+			err:  &cliAPIProtocolError{surface: "runtime event stream", endpoint: "ws://127.0.0.1:8081/v1/ws", operation: "subscription response", err: errors.New("bad jsonrpc")},
+			want: []string{
+				"ERROR: the Swarm runtime at 127.0.0.1:8081 returned an invalid API response.",
+				"Check the selected target with `swarm context current`; override with --api-server.",
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := formatCLIAPIError(tc.err)
+			for _, want := range tc.want {
+				if !strings.Contains(got, want) {
+					t.Fatalf("diagnostic = %q, want substring %q", got, want)
+				}
+			}
+			for _, forbidden := range []string{"v1 RPC", "v1 WS", "/v1/rpc", "/v1/ws", "Post ", "dial tcp", "connection refused"} {
+				if strings.Contains(got, forbidden) {
+					t.Fatalf("diagnostic = %q, must not leak %q", got, forbidden)
+				}
+			}
+		})
+	}
+}
+
+func TestCLIAPITransportDiagnosticPreservesWrapperContext(t *testing.T) {
+	err := fmt.Errorf("scenario.yaml: step 2: %w", &cliAPITransportError{
+		surface:   "runtime API",
+		endpoint:  "http://127.0.0.1:1/v1/rpc",
+		operation: "request",
+		err:       errors.New("connection refused"),
+	})
+
+	got := formatCLIAPIError(err)
+	for _, want := range []string{
+		"ERROR: scenario.yaml: step 2: cannot reach the Swarm runtime at 127.0.0.1:1.",
+		"Is the runtime running?",
+		"Check the selected target with `swarm context current`; override with --api-server.",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("diagnostic = %q, want substring %q", got, want)
+		}
+	}
+	for _, forbidden := range []string{"runtime API request failed", "connection refused", "/v1/rpc"} {
+		if strings.Contains(got, forbidden) {
+			t.Fatalf("diagnostic = %q, must not leak %q", got, forbidden)
+		}
+	}
+
+	detail := formatCLIAPITransportDetail(err)
+	if want := "scenario.yaml: step 2: cannot reach the Swarm runtime at 127.0.0.1:1."; detail != want {
+		t.Fatalf("detail = %q, want %q", detail, want)
 	}
 }
 

--- a/cmd/swarm/cli_ws.go
+++ b/cmd/swarm/cli_ws.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/gorilla/websocket"
+)
+
+func cliAPIReadWebSocketJSON(conn *websocket.Conn, surface, endpoint, operation string, out any) error {
+	_, raw, err := conn.ReadMessage()
+	if err != nil {
+		return &cliAPITransportError{surface: surface, endpoint: endpoint, operation: operation, err: err}
+	}
+	if err := json.Unmarshal(raw, out); err != nil {
+		return &cliAPIProtocolError{surface: surface, endpoint: endpoint, operation: operation, err: err}
+	}
+	return nil
+}
+
+func cliAPIWebSocketHTTPError(surface, endpoint string, resp *http.Response) error {
+	if resp == nil {
+		return nil
+	}
+	message := http.StatusText(resp.StatusCode)
+	if resp.Body != nil {
+		defer resp.Body.Close()
+		raw, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+		if err == nil && strings.TrimSpace(string(raw)) != "" {
+			message = strings.TrimSpace(string(raw))
+		}
+	}
+	return &cliAPIHTTPError{surface: surface, endpoint: endpoint, statusCode: resp.StatusCode, message: message}
+}
+
+func cliAPIIsNormalWebSocketClose(err error) bool {
+	if err == nil {
+		return false
+	}
+	var transportErr *cliAPITransportError
+	if errors.As(err, &transportErr) {
+		err = transportErr.err
+	}
+	if err == nil {
+		return false
+	}
+	return websocket.IsCloseError(err, websocket.CloseNormalClosure, websocket.CloseGoingAway) ||
+		strings.Contains(err.Error(), "use of closed network connection")
+}

--- a/cmd/swarm/cli_ws_test.go
+++ b/cmd/swarm/cli_ws_test.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gorilla/websocket"
+)
+
+func TestCLIAPIReadWebSocketJSONClassifiesMalformedPayloadAsProtocol(t *testing.T) {
+	upgrader := websocket.Upgrader{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			t.Errorf("upgrade websocket: %v", err)
+			return
+		}
+		defer conn.Close()
+		if err := conn.WriteMessage(websocket.TextMessage, []byte(`{`)); err != nil {
+			t.Errorf("write malformed payload: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	endpoint := "ws" + strings.TrimPrefix(server.URL, "http")
+	conn, _, err := websocket.DefaultDialer.DialContext(context.Background(), endpoint, nil)
+	if err != nil {
+		t.Fatalf("dial websocket: %v", err)
+	}
+	defer conn.Close()
+
+	var out map[string]any
+	err = cliAPIReadWebSocketJSON(conn, "runtime event stream", endpoint, "subscription response", &out)
+	if err == nil {
+		t.Fatal("expected malformed websocket payload error")
+	}
+	var protocolErr *cliAPIProtocolError
+	if !errors.As(err, &protocolErr) {
+		t.Fatalf("error = %T %v, want cliAPIProtocolError", err, err)
+	}
+	if cliAPIIsTransportFailure(err) {
+		t.Fatalf("malformed websocket payload must not be classified as transport: %v", err)
+	}
+	if traceFollowRetryableSubscribeError(err) || traceFollowRetryableStreamError(err) {
+		t.Fatalf("malformed websocket payload must not be retryable transport: %v", err)
+	}
+	got := formatCLIAPIError(err)
+	if want := "ERROR: the Swarm runtime at " + strings.TrimPrefix(endpoint, "ws://") + " returned an invalid API response."; !strings.Contains(got, want) {
+		t.Fatalf("diagnostic = %q, want substring %q", got, want)
+	}
+	if strings.Contains(got, "cannot reach") {
+		t.Fatalf("diagnostic = %q, must not render as transport failure", got)
+	}
+}

--- a/cmd/swarm/control_mailbox_test.go
+++ b/cmd/swarm/control_mailbox_test.go
@@ -540,7 +540,7 @@ func TestMailboxSurfacesTransportAndRPCFailures(t *testing.T) {
 				_, _ = w.Write([]byte(`{"error":"invalid bearer token"}`))
 			},
 			wantCode:   4,
-			wantStderr: "v1 RPC HTTP 401",
+			wantStderr: "rejected the request with status 401",
 		},
 		{
 			name: "malformed response",
@@ -548,7 +548,7 @@ func TestMailboxSurfacesTransportAndRPCFailures(t *testing.T) {
 				_, _ = w.Write([]byte(`{`))
 			},
 			wantCode:   3,
-			wantStderr: "decode JSON-RPC response",
+			wantStderr: "returned an invalid API response",
 		},
 		{
 			name: "malformed result",
@@ -570,7 +570,7 @@ func TestMailboxSurfacesTransportAndRPCFailures(t *testing.T) {
 				})
 			},
 			wantCode:   3,
-			wantStderr: "malformed JSON-RPC response: id",
+			wantStderr: "returned an invalid API response",
 		},
 		{
 			name: "missing json rpc id",
@@ -586,7 +586,7 @@ func TestMailboxSurfacesTransportAndRPCFailures(t *testing.T) {
 				})
 			},
 			wantCode:   3,
-			wantStderr: "malformed JSON-RPC response: id=<missing>",
+			wantStderr: "returned an invalid API response",
 		},
 		{
 			name: "json rpc application error",
@@ -648,7 +648,7 @@ func TestMailboxReadCommandsFailClosedOnRPCAndMalformedResponses(t *testing.T) {
 				_, _ = w.Write([]byte(`{"error":"invalid bearer token"}`))
 			},
 			wantCode:   4,
-			wantStderr: "v1 RPC HTTP 401",
+			wantStderr: "rejected the request with status 401",
 		},
 		{
 			name: "list malformed missing items",

--- a/cmd/swarm/control_nuke.go
+++ b/cmd/swarm/control_nuke.go
@@ -140,7 +140,7 @@ func newControlNukeCommand(opts rootCommandOptions) *cobra.Command {
 func runControlNukeCommand(ctx context.Context, out, errOut io.Writer, opts runtimeNukeCommandOptions) error {
 	idempotencyKey, err := optionalNonBlankNukeFlag("--idempotency-key", opts.idempotencyKey, opts.idempotencyKeySet)
 	if err != nil {
-		fmt.Fprintln(errOut, err)
+		writeCLIAPIError(errOut, err)
 		return commandExitError{code: 2}
 	}
 	if !opts.dryRun && !opts.yes {
@@ -161,7 +161,7 @@ func runControlNukeCommand(ctx context.Context, out, errOut io.Writer, opts runt
 
 	client, err := newCLIAPIClient(opts.apiOptions)
 	if err != nil {
-		fmt.Fprintln(errOut, err)
+		writeCLIAPIError(errOut, err)
 		return commandExitError{code: runtimeNukeErrorExitCode(err)}
 	}
 	params := map[string]any{"dry_run": opts.dryRun}
@@ -170,11 +170,11 @@ func runControlNukeCommand(ctx context.Context, out, errOut io.Writer, opts runt
 	}
 	var result runtimeNukeResult
 	if err := client.call(ctx, runtimeNukeMethod, params, &result); err != nil {
-		fmt.Fprintln(errOut, err)
+		writeCLIAPIError(errOut, err)
 		return commandExitError{code: runtimeNukeErrorExitCode(err)}
 	}
 	if err := validateRuntimeNukeResult(result); err != nil {
-		fmt.Fprintln(errOut, err)
+		writeCLIAPIError(errOut, err)
 		return commandExitError{code: 3}
 	}
 	writeRuntimeNukeResult(out, result)

--- a/cmd/swarm/control_nuke_test.go
+++ b/cmd/swarm/control_nuke_test.go
@@ -315,7 +315,7 @@ func TestControlNukeMapsFailureExitCodes(t *testing.T) {
 				_, _ = w.Write([]byte(`{"error":"invalid bearer token"}`))
 			},
 			wantCode:   4,
-			wantStderr: "v1 RPC HTTP 401",
+			wantStderr: "rejected the request with status 401",
 		},
 		{
 			name:     "missing token exits four before request",
@@ -333,7 +333,7 @@ func TestControlNukeMapsFailureExitCodes(t *testing.T) {
 				_, _ = w.Write([]byte(`{`))
 			},
 			wantCode:   3,
-			wantStderr: "decode JSON-RPC response",
+			wantStderr: "returned an invalid API response",
 		},
 		{
 			name:  "malformed result exits three",
@@ -376,7 +376,7 @@ func TestControlNukeTransportFailureExitsThree(t *testing.T) {
 	if code != 3 {
 		t.Fatalf("code = %d, want 3 stdout=%s stderr=%s", code, stdout.String(), stderr.String())
 	}
-	if !strings.Contains(stderr.String(), "v1 RPC request failed") {
+	if !strings.Contains(stderr.String(), "cannot reach the Swarm runtime") {
 		t.Fatalf("stderr = %q, want transport failure", stderr.String())
 	}
 }

--- a/cmd/swarm/control_run.go
+++ b/cmd/swarm/control_run.go
@@ -106,12 +106,12 @@ func controlCommandTitle(action string) string {
 func runControlRunCommand(ctx context.Context, out, errOut io.Writer, args []string, opts controlRunCommandOptions) error {
 	runID, err := validateControlRunTarget(args, opts.all)
 	if err != nil {
-		fmt.Fprintln(errOut, err)
+		writeCLIAPIError(errOut, err)
 		return commandExitError{code: controlCommandExitCodeValidation}
 	}
 	idempotencyKey, err := optionalNonEmptyFlag("--idempotency-key", opts.idempotencyKey, opts.idempotencyKeySet)
 	if err != nil {
-		fmt.Fprintln(errOut, err)
+		writeCLIAPIError(errOut, err)
 		return commandExitError{code: controlCommandExitCodeValidation}
 	}
 	if opts.all && opts.action == "stop" && idempotencyKey != "" {
@@ -129,7 +129,7 @@ func runControlRunCommand(ctx context.Context, out, errOut io.Writer, args []str
 	}
 	client, err := newCLIAPIClient(opts.apiOptions)
 	if err != nil {
-		fmt.Fprintln(errOut, err)
+		writeCLIAPIError(errOut, err)
 		return commandExitError{code: controlCommandErrorExitCode(err)}
 	}
 
@@ -142,7 +142,7 @@ func runControlRunCommand(ctx context.Context, out, errOut io.Writer, args []str
 			return commandExitError{code: controlCommandExitCodeRuntimeError}
 		}
 		if err := callControlOK(ctx, client, opts.allMethod, controlRunParams("", idempotencyKey)); err != nil {
-			fmt.Fprintln(errOut, err)
+			writeCLIAPIError(errOut, err)
 			return commandExitError{code: controlCommandErrorExitCode(err)}
 		}
 		writeControlOK(out, opts.action, "runtime", "")
@@ -150,7 +150,7 @@ func runControlRunCommand(ctx context.Context, out, errOut io.Writer, args []str
 	}
 
 	if err := callControlOK(ctx, client, opts.runMethod, controlRunParams(runID, idempotencyKey)); err != nil {
-		fmt.Fprintln(errOut, err)
+		writeCLIAPIError(errOut, err)
 		return commandExitError{code: controlCommandErrorExitCode(err)}
 	}
 	writeControlOK(out, opts.action, "run", runID)
@@ -199,7 +199,7 @@ func callControlOK(ctx context.Context, client *cliAPIClient, method string, par
 func runControlStopAllCommand(ctx context.Context, out, errOut io.Writer, client *cliAPIClient) error {
 	runIDs, err := listControlStopAllRunIDs(ctx, client)
 	if err != nil {
-		fmt.Fprintln(errOut, err)
+		writeCLIAPIError(errOut, err)
 		return commandExitError{code: controlCommandErrorExitCode(err)}
 	}
 	failures := []controlStopAllFailure{}
@@ -332,8 +332,12 @@ func writeControlStopAllFailures(errOut io.Writer, failures []controlStopAllFail
 		return
 	}
 	for _, failure := range failures {
-		fmt.Fprintf(errOut, "control stop failed: run_id=%s error=%v\n", failure.runID, failure.err)
+		writeCLIAPIError(errOut, controlStopAllFailureError(failure))
 	}
+}
+
+func controlStopAllFailureError(failure controlStopAllFailure) error {
+	return fmt.Errorf("control stop failed: run_id=%s: %w", failure.runID, failure.err)
 }
 
 func controlStopAllExitCode(failures []controlStopAllFailure) int {

--- a/cmd/swarm/control_run_test.go
+++ b/cmd/swarm/control_run_test.go
@@ -323,7 +323,7 @@ func TestControlRunFailsClosedOnTransportRPCAndMalformedResponses(t *testing.T) 
 				_, _ = w.Write([]byte(`{"error":"invalid bearer token"}`))
 			},
 			wantCode:   4,
-			wantStderr: "v1 RPC HTTP 401",
+			wantStderr: "rejected the request with status 401",
 		},
 		{
 			name: "run not found",
@@ -343,7 +343,7 @@ func TestControlRunFailsClosedOnTransportRPCAndMalformedResponses(t *testing.T) 
 				_, _ = w.Write([]byte(`{`))
 			},
 			wantCode:   3,
-			wantStderr: "decode JSON-RPC response",
+			wantStderr: "returned an invalid API response",
 		},
 		{
 			name: "malformed ok result",
@@ -571,6 +571,54 @@ func TestControlStopAllReportsPartialFailures(t *testing.T) {
 	for _, want := range []string{"control stop failed: run_id=run-b", "RUN_ALREADY_TERMINAL"} {
 		if !strings.Contains(stderr.String(), want) {
 			t.Fatalf("stderr missing %q:\n%s", want, stderr.String())
+		}
+	}
+}
+
+func TestControlStopAllPerRunHTTPFailureUsesSharedDiagnostic(t *testing.T) {
+	setCLIAPITestToken(t, "test-token")
+	var captured []jsonRPCRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req jsonRPCRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Errorf("decode request: %v", err)
+		}
+		captured = append(captured, req)
+		switch len(captured) {
+		case 1:
+			writeJSONRPCResult(t, w, req.ID, map[string]any{"runs": []map[string]any{
+				controlRunHeaderResult("run-a", "running"),
+			}})
+		case 2:
+			writeJSONRPCResult(t, w, req.ID, map[string]any{"runs": []any{}})
+		case 3:
+			http.Error(w, "runtime unavailable", http.StatusServiceUnavailable)
+		default:
+			t.Fatalf("unexpected request %d: %#v", len(captured), req)
+		}
+	}))
+	defer server.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"control", "stop", "--all", "--yes"}, &stdout, &stderr, testRootCommandOptions(server))
+	if code != 3 {
+		t.Fatalf("code = %d, want 3 stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "control stop partial: scope=all matched=1 stopped=0 failed=1") {
+		t.Fatalf("stdout = %q, want partial summary", stdout.String())
+	}
+	for _, want := range []string{
+		"ERROR: control stop failed: run_id=run-a: the Swarm runtime at ",
+		"returned status 503",
+		"Check the runtime with `swarm health`",
+	} {
+		if !strings.Contains(stderr.String(), want) {
+			t.Fatalf("stderr missing %q:\n%s", want, stderr.String())
+		}
+	}
+	for _, forbidden := range []string{"runtime API returned status", "/v1/rpc"} {
+		if strings.Contains(stderr.String(), forbidden) {
+			t.Fatalf("stderr = %q, must not contain %q", stderr.String(), forbidden)
 		}
 	}
 }

--- a/cmd/swarm/conversations_test.go
+++ b/cmd/swarm/conversations_test.go
@@ -256,7 +256,7 @@ func TestConversationCommandsMapRuntimeFailuresAndMalformedResults(t *testing.T)
 				http.Error(w, "unauthorized", http.StatusUnauthorized)
 			},
 			wantCode:   4,
-			wantStderr: "v1 RPC HTTP 401",
+			wantStderr: "rejected the request with status 401",
 		},
 		{
 			name: "list missing conversations exits three",

--- a/cmd/swarm/diagnostics.go
+++ b/cmd/swarm/diagnostics.go
@@ -13,10 +13,9 @@ import (
 )
 
 const (
-	traceFollowMaxReconnects    = 3
-	traceFollowInitialBackoff   = 250 * time.Millisecond
-	traceFollowMaximumBackoff   = time.Second
-	traceFollowRetryableReadErr = "read run.subscribe_trace notification:"
+	traceFollowMaxReconnects  = 3
+	traceFollowInitialBackoff = 250 * time.Millisecond
+	traceFollowMaximumBackoff = time.Second
 )
 
 var traceDeliverySummaryStatuses = []string{"pending", "in_progress", "delivered", "failed", "dead_letter"}
@@ -869,7 +868,7 @@ func followDiagnosticTraceCommand(ctx context.Context, out, errOut io.Writer, cl
 	wsEndpoint, err := runCommandWebSocketEndpoint(client.endpoint)
 	if err != nil {
 		if errOut != nil {
-			fmt.Fprintln(errOut, err)
+			writeCLIAPIError(errOut, err)
 		}
 		return commandExitError{code: runCommandErrorExitCode(err)}
 	}
@@ -887,7 +886,7 @@ func followDiagnosticTraceCommand(ctx context.Context, out, errOut io.Writer, cl
 			}
 			if reconnectsRemaining == 0 || !traceFollowRetryableSubscribeError(err) {
 				if errOut != nil {
-					fmt.Fprintln(errOut, err)
+					writeCLIAPIError(errOut, err)
 				}
 				return commandExitError{code: runCommandErrorExitCode(err)}
 			}
@@ -915,9 +914,7 @@ func followDiagnosticTraceCommand(ctx context.Context, out, errOut io.Writer, cl
 			continue
 		}
 		if reconnectsRemaining == 0 || !traceFollowRetryableStreamError(streamErr) {
-			if errOut != nil {
-				fmt.Fprintln(errOut, streamErr)
-			}
+			writeCLIAPIError(errOut, streamErr)
 			return commandExitError{code: runCommandErrorExitCode(streamErr)}
 		}
 		reconnectsRemaining--
@@ -999,12 +996,8 @@ func traceFollowRetryableSubscribeError(err error) bool {
 	if errors.As(err, &rpcErr) {
 		return false
 	}
-	msg := err.Error()
-	if strings.HasPrefix(msg, "v1 WS dial failed:") || strings.HasPrefix(msg, "write run.subscribe_trace request:") {
+	if cliAPIIsTransportFailure(err) {
 		return true
-	}
-	if strings.HasPrefix(msg, "read run.subscribe_trace response:") {
-		return traceFollowTransportErrorText(msg)
 	}
 	return false
 }
@@ -1013,30 +1006,8 @@ func traceFollowRetryableStreamError(err error) bool {
 	if err == nil {
 		return false
 	}
-	msg := err.Error()
-	if !strings.HasPrefix(msg, traceFollowRetryableReadErr) {
-		return false
-	}
-	return traceFollowTransportErrorText(msg)
-}
-
-func traceFollowTransportErrorText(msg string) bool {
-	msg = strings.ToLower(msg)
-	if msg == "eof" || strings.HasSuffix(msg, ": eof") {
+	if cliAPIIsTransportFailure(err) {
 		return true
-	}
-	for _, fragment := range []string{
-		"websocket: close",
-		"unexpected eof",
-		"connection reset",
-		"connection refused",
-		"broken pipe",
-		"i/o timeout",
-		"use of closed network connection",
-	} {
-		if strings.Contains(msg, fragment) {
-			return true
-		}
 	}
 	return false
 }

--- a/cmd/swarm/diagnostics_test.go
+++ b/cmd/swarm/diagnostics_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
@@ -1049,17 +1050,18 @@ func TestTraceFollowRetriesRetryableReadFailure(t *testing.T) {
 	}
 }
 
-func TestTraceFollowClassifiesPlainEOFAsRetryableTransportClose(t *testing.T) {
-	for _, msg := range []string{
-		"read run.subscribe_trace response: EOF",
-		"read run.subscribe_trace notification: EOF",
-		"EOF",
-	} {
-		t.Run(msg, func(t *testing.T) {
-			if !traceFollowTransportErrorText(msg) {
-				t.Fatalf("traceFollowTransportErrorText(%q) = false, want true", msg)
-			}
-		})
+func TestTraceFollowClassifiesTypedTransportAsRetryable(t *testing.T) {
+	err := &cliAPITransportError{
+		surface:   "runtime event stream",
+		endpoint:  "ws://127.0.0.1:8081/v1/ws",
+		operation: "notification read",
+		err:       io.ErrUnexpectedEOF,
+	}
+	if !traceFollowRetryableSubscribeError(err) {
+		t.Fatal("traceFollowRetryableSubscribeError = false, want true")
+	}
+	if !traceFollowRetryableStreamError(err) {
+		t.Fatal("traceFollowRetryableStreamError = false, want true")
 	}
 }
 
@@ -1355,7 +1357,7 @@ func TestDiagnosticsFailClosedOnAPIAndMalformedResults(t *testing.T) {
 				_, _ = w.Write([]byte(`{"error":"invalid bearer token"}`))
 			},
 			wantCode:   4,
-			wantStderr: "v1 RPC HTTP 401",
+			wantStderr: "rejected the request with status 401",
 		},
 		{
 			name: "json rpc run not found",

--- a/cmd/swarm/entities_test.go
+++ b/cmd/swarm/entities_test.go
@@ -357,7 +357,7 @@ func TestEntityCommandsMapRuntimeFailuresAndMalformedResults(t *testing.T) {
 				http.Error(w, "unauthorized", http.StatusUnauthorized)
 			},
 			wantCode:   4,
-			wantStderr: "v1 RPC HTTP 401",
+			wantStderr: "rejected the request with status 401",
 		},
 		{
 			name: "list missing entities exits three",

--- a/cmd/swarm/event_publish.go
+++ b/cmd/swarm/event_publish.go
@@ -104,23 +104,23 @@ func newEventPublishCommand(opts rootCommandOptions) *cobra.Command {
 func runEventPublishCommand(ctx context.Context, out, errOut io.Writer, args []string, opts eventPublishCommandOptions) error {
 	eventName, params, err := opts.params(args)
 	if err != nil {
-		fmt.Fprintln(errOut, err)
+		writeCLIAPIError(errOut, err)
 		return commandExitError{code: eventPublishExitValidation}
 	}
 
 	client, err := newCLIAPIClient(opts.apiOptions)
 	if err != nil {
-		fmt.Fprintln(errOut, err)
+		writeCLIAPIError(errOut, err)
 		return commandExitError{code: eventPublishErrorExitCode(err)}
 	}
 
 	var result eventPublishResult
 	if err := client.call(ctx, eventPublishMethod, params, &result); err != nil {
-		fmt.Fprintln(errOut, err)
+		writeCLIAPIError(errOut, err)
 		return commandExitError{code: eventPublishErrorExitCode(err)}
 	}
 	if err := validateEventPublishResult(result); err != nil {
-		fmt.Fprintln(errOut, err)
+		writeCLIAPIError(errOut, err)
 		return commandExitError{code: eventPublishExitRuntime}
 	}
 	writeEventPublishResult(out, eventName, result)

--- a/cmd/swarm/event_publish_test.go
+++ b/cmd/swarm/event_publish_test.go
@@ -560,7 +560,7 @@ func TestEventPublishMapsFailureExitCodes(t *testing.T) {
 				http.Error(w, "unauthorized", http.StatusUnauthorized)
 			},
 			wantCode:   4,
-			wantStderr: "v1 RPC HTTP 401",
+			wantStderr: "rejected the request with status 401",
 		},
 		{
 			name: "http runtime exits three",
@@ -568,7 +568,7 @@ func TestEventPublishMapsFailureExitCodes(t *testing.T) {
 				http.Error(w, "unavailable", http.StatusServiceUnavailable)
 			},
 			wantCode:   3,
-			wantStderr: "v1 RPC HTTP 503",
+			wantStderr: "returned status 503",
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {

--- a/cmd/swarm/events.go
+++ b/cmd/swarm/events.go
@@ -149,6 +149,7 @@ type eventSubscriptionNotification struct {
 
 type eventSubscription struct {
 	conn           *websocket.Conn
+	endpoint       string
 	subscriptionID string
 	events         chan eventFull
 	errs           chan error
@@ -291,21 +292,21 @@ func bindEventFilterFlags(cmd *cobra.Command, opts *eventFilterOptions) {
 func runEventListCommand(ctx context.Context, out, errOut io.Writer, opts eventListCommandOptions) error {
 	params, err := opts.params()
 	if err != nil {
-		fmt.Fprintln(errOut, err)
+		writeCLIAPIError(errOut, err)
 		return commandExitError{code: eventObservationExitValidation}
 	}
 	client, err := newCLIAPIClient(opts.apiOptions)
 	if err != nil {
-		fmt.Fprintln(errOut, err)
+		writeCLIAPIError(errOut, err)
 		return commandExitError{code: eventObservationErrorExitCode(err)}
 	}
 	var result eventListResult
 	if err := client.call(ctx, eventObservationMethodList, params, &result); err != nil {
-		fmt.Fprintln(errOut, err)
+		writeCLIAPIError(errOut, err)
 		return commandExitError{code: eventObservationErrorExitCode(err)}
 	}
 	if err := validateEventListResult(result); err != nil {
-		fmt.Fprintln(errOut, err)
+		writeCLIAPIError(errOut, err)
 		return commandExitError{code: eventObservationExitRuntime}
 	}
 	writeEventListResult(out, result)
@@ -320,16 +321,16 @@ func runEventViewCommand(ctx context.Context, out, errOut io.Writer, opts rootCo
 	}
 	client, err := newCLIAPIClient(opts)
 	if err != nil {
-		fmt.Fprintln(errOut, err)
+		writeCLIAPIError(errOut, err)
 		return commandExitError{code: eventObservationErrorExitCode(err)}
 	}
 	var result eventFull
 	if err := client.call(ctx, eventObservationMethodGet, map[string]any{"event_id": eventID}, &result); err != nil {
-		fmt.Fprintln(errOut, err)
+		writeCLIAPIError(errOut, err)
 		return commandExitError{code: eventObservationErrorExitCode(err)}
 	}
 	if err := validateEventFull("event.get result", result); err != nil {
-		fmt.Fprintln(errOut, err)
+		writeCLIAPIError(errOut, err)
 		return commandExitError{code: eventObservationExitRuntime}
 	}
 	writeEventDetailResult(out, result)
@@ -339,21 +340,21 @@ func runEventViewCommand(ctx context.Context, out, errOut io.Writer, opts rootCo
 func runEventReplayCommand(ctx context.Context, out, errOut io.Writer, args []string, opts eventReplayCommandOptions) error {
 	eventID, subscribers, err := validateEventReplayArgs(args, opts.subscribers)
 	if err != nil {
-		fmt.Fprintln(errOut, err)
+		writeCLIAPIError(errOut, err)
 		return commandExitError{code: eventReplayExitValidation}
 	}
 	client, err := newCLIAPIClient(opts.apiOptions)
 	if err != nil {
-		fmt.Fprintln(errOut, err)
+		writeCLIAPIError(errOut, err)
 		return commandExitError{code: eventReplayErrorExitCode(err)}
 	}
 	var result eventReplayResult
 	if err := client.call(ctx, eventReplayMethod, opts.params(eventID, subscribers), &result); err != nil {
-		fmt.Fprintln(errOut, err)
+		writeCLIAPIError(errOut, err)
 		return commandExitError{code: eventReplayErrorExitCode(err)}
 	}
 	if err := validateEventReplayResult(result, eventID); err != nil {
-		fmt.Fprintln(errOut, err)
+		writeCLIAPIError(errOut, err)
 		return commandExitError{code: eventReplayExitRuntime}
 	}
 	writeEventReplayResult(out, result)
@@ -363,22 +364,22 @@ func runEventReplayCommand(ctx context.Context, out, errOut io.Writer, args []st
 func runEventFollowCommand(ctx context.Context, out, errOut io.Writer, opts eventFollowCommandOptions) error {
 	params, err := opts.params()
 	if err != nil {
-		fmt.Fprintln(errOut, err)
+		writeCLIAPIError(errOut, err)
 		return commandExitError{code: eventObservationExitValidation}
 	}
 	client, err := newCLIAPIClient(opts.apiOptions)
 	if err != nil {
-		fmt.Fprintln(errOut, err)
+		writeCLIAPIError(errOut, err)
 		return commandExitError{code: eventObservationErrorExitCode(err)}
 	}
 	wsEndpoint, err := runCommandWebSocketEndpoint(client.endpoint)
 	if err != nil {
-		fmt.Fprintln(errOut, err)
+		writeCLIAPIError(errOut, err)
 		return commandExitError{code: eventObservationErrorExitCode(err)}
 	}
 	sub, err := subscribeEvents(ctx, wsEndpoint, client.token, params)
 	if err != nil {
-		fmt.Fprintln(errOut, err)
+		writeCLIAPIError(errOut, err)
 		return commandExitError{code: eventObservationErrorExitCode(err)}
 	}
 	defer sub.close()
@@ -392,7 +393,7 @@ func runEventFollowCommand(ctx context.Context, out, errOut io.Writer, opts even
 				select {
 				case err := <-sub.errs:
 					if err != nil {
-						fmt.Fprintln(errOut, err)
+						writeCLIAPIError(errOut, err)
 						return commandExitError{code: eventObservationErrorExitCode(err)}
 					}
 				default:
@@ -402,7 +403,7 @@ func runEventFollowCommand(ctx context.Context, out, errOut io.Writer, opts even
 			writeEventFollowEvent(out, event)
 		case err := <-sub.errs:
 			if err != nil {
-				fmt.Fprintln(errOut, err)
+				writeCLIAPIError(errOut, err)
 				return commandExitError{code: eventObservationErrorExitCode(err)}
 			}
 		}
@@ -742,9 +743,9 @@ func subscribeEvents(ctx context.Context, wsEndpoint, token string, params map[s
 	conn, resp, err := websocket.DefaultDialer.DialContext(ctx, wsEndpoint, header)
 	if err != nil {
 		if resp != nil {
-			return nil, eventObservationWSHTTPError(resp)
+			return nil, cliAPIWebSocketHTTPError("runtime event stream", wsEndpoint, resp)
 		}
-		return nil, fmt.Errorf("v1 WS dial failed: %w", err)
+		return nil, &cliAPITransportError{surface: "runtime event stream", endpoint: wsEndpoint, operation: "dial", err: err}
 	}
 	requestID := "swarm-cli:" + eventObservationMethodSubscribe
 	if err := conn.WriteJSON(jsonRPCRequest{
@@ -754,20 +755,20 @@ func subscribeEvents(ctx context.Context, wsEndpoint, token string, params map[s
 		Params:  params,
 	}); err != nil {
 		conn.Close()
-		return nil, fmt.Errorf("write event.subscribe request: %w", err)
+		return nil, &cliAPITransportError{surface: "runtime event stream", endpoint: wsEndpoint, operation: "subscription request", err: err}
 	}
 	var envelope jsonRPCResponse
-	if err := conn.ReadJSON(&envelope); err != nil {
+	if err := cliAPIReadWebSocketJSON(conn, "runtime event stream", wsEndpoint, "subscription response", &envelope); err != nil {
 		conn.Close()
-		return nil, fmt.Errorf("read event.subscribe response: %w", err)
+		return nil, err
 	}
 	if envelope.JSONRPC != "2.0" {
 		conn.Close()
-		return nil, fmt.Errorf("malformed event.subscribe response: jsonrpc=%q", envelope.JSONRPC)
+		return nil, &cliAPIProtocolError{surface: "runtime event stream", endpoint: wsEndpoint, operation: "subscription response", err: fmt.Errorf("jsonrpc=%q", envelope.JSONRPC)}
 	}
 	if id, ok := envelope.ID.(string); !ok || id != requestID {
 		conn.Close()
-		return nil, fmt.Errorf("malformed event.subscribe response: id=%s, want %q", formatJSONRPCID(envelope.ID), requestID)
+		return nil, &cliAPIProtocolError{surface: "runtime event stream", endpoint: wsEndpoint, operation: "subscription response", err: fmt.Errorf("id=%s, want %q", formatJSONRPCID(envelope.ID), requestID)}
 	}
 	if envelope.Error != nil {
 		conn.Close()
@@ -776,14 +777,15 @@ func subscribeEvents(ctx context.Context, wsEndpoint, token string, params map[s
 	var result eventSubscriptionResult
 	if err := json.Unmarshal(envelope.Result, &result); err != nil {
 		conn.Close()
-		return nil, fmt.Errorf("decode event.subscribe result: %w", err)
+		return nil, &cliAPIProtocolError{surface: "runtime event stream", endpoint: wsEndpoint, operation: "subscription result", err: err}
 	}
 	if strings.TrimSpace(result.SubscriptionID) == "" {
 		conn.Close()
-		return nil, fmt.Errorf("malformed event.subscribe result: subscription_id is required")
+		return nil, &cliAPIProtocolError{surface: "runtime event stream", endpoint: wsEndpoint, operation: "subscription result", err: fmt.Errorf("subscription_id is required")}
 	}
 	sub := &eventSubscription{
 		conn:           conn,
+		endpoint:       wsEndpoint,
 		subscriptionID: result.SubscriptionID,
 		events:         make(chan eventFull, 16),
 		errs:           make(chan error, 1),
@@ -792,43 +794,28 @@ func subscribeEvents(ctx context.Context, wsEndpoint, token string, params map[s
 	return sub, nil
 }
 
-func eventObservationWSHTTPError(resp *http.Response) error {
-	if resp == nil {
-		return nil
-	}
-	message := http.StatusText(resp.StatusCode)
-	if resp.Body != nil {
-		defer resp.Body.Close()
-		raw, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
-		if err == nil && strings.TrimSpace(string(raw)) != "" {
-			message = strings.TrimSpace(string(raw))
-		}
-	}
-	return &cliAPIHTTPError{surface: "v1 WS", statusCode: resp.StatusCode, message: message}
-}
-
 func (s *eventSubscription) readLoop() {
 	defer close(s.events)
 	for {
 		var notification eventSubscriptionNotification
-		if err := s.conn.ReadJSON(&notification); err != nil {
-			if websocket.IsCloseError(err, websocket.CloseNormalClosure, websocket.CloseGoingAway) || strings.Contains(err.Error(), "use of closed network connection") {
+		if err := cliAPIReadWebSocketJSON(s.conn, "runtime event stream", s.endpoint, "notification read", &notification); err != nil {
+			if cliAPIIsNormalWebSocketClose(err) {
 				return
 			}
-			s.reportError(fmt.Errorf("read event.subscribe notification: %w", err))
+			s.reportError(err)
 			return
 		}
 		if notification.JSONRPC != "2.0" || notification.Method != "rpc.subscription" {
-			s.reportError(fmt.Errorf("malformed event.subscribe notification"))
+			s.reportError(&cliAPIProtocolError{surface: "runtime event stream", endpoint: s.endpoint, operation: "notification", err: fmt.Errorf("malformed event.subscribe notification")})
 			return
 		}
 		if notification.Params.Subscription != s.subscriptionID {
-			s.reportError(fmt.Errorf("malformed event.subscribe notification: subscription mismatch"))
+			s.reportError(&cliAPIProtocolError{surface: "runtime event stream", endpoint: s.endpoint, operation: "notification", err: fmt.Errorf("subscription mismatch")})
 			return
 		}
 		event := notification.Params.Result
 		if err := validateEventFull("event.subscribe notification", event); err != nil {
-			s.reportError(err)
+			s.reportError(&cliAPIProtocolError{surface: "runtime event stream", endpoint: s.endpoint, operation: "notification", err: err})
 			return
 		}
 		select {

--- a/cmd/swarm/events_test.go
+++ b/cmd/swarm/events_test.go
@@ -427,7 +427,7 @@ func TestEventsMapFailureExitCodes(t *testing.T) {
 				http.Error(w, "unauthorized", http.StatusUnauthorized)
 			},
 			wantCode:   4,
-			wantStderr: "v1 RPC HTTP 401",
+			wantStderr: "rejected the request with status 401",
 		},
 		{
 			name: "event replay http auth exits four",
@@ -436,7 +436,7 @@ func TestEventsMapFailureExitCodes(t *testing.T) {
 				http.Error(w, "unauthorized", http.StatusUnauthorized)
 			},
 			wantCode:   4,
-			wantStderr: "v1 RPC HTTP 401",
+			wantStderr: "rejected the request with status 401",
 		},
 		{
 			name: "event replay http runtime exits three",
@@ -445,7 +445,7 @@ func TestEventsMapFailureExitCodes(t *testing.T) {
 				http.Error(w, "unavailable", http.StatusServiceUnavailable)
 			},
 			wantCode:   3,
-			wantStderr: "v1 RPC HTTP 503",
+			wantStderr: "returned status 503",
 		},
 		{
 			name: "unknown rpc error exits three",
@@ -737,7 +737,7 @@ func TestEventsFollowMapsHandshakeAuthToAuthExit(t *testing.T) {
 	if wsCalls.Load() != 1 {
 		t.Fatalf("ws calls = %d, want 1", wsCalls.Load())
 	}
-	if !strings.Contains(stderr.String(), "v1 WS HTTP 401") {
+	if !strings.Contains(stderr.String(), "rejected the request with status 401") {
 		t.Fatalf("stderr = %q, want WS auth status", stderr.String())
 	}
 }

--- a/cmd/swarm/incidents_test.go
+++ b/cmd/swarm/incidents_test.go
@@ -169,7 +169,7 @@ func TestIncidentsMapRuntimeFailuresAndMalformedResults(t *testing.T) {
 				http.Error(w, "unauthorized", http.StatusUnauthorized)
 			},
 			wantCode:   4,
-			wantStderr: "v1 RPC HTTP 401",
+			wantStderr: "rejected the request with status 401",
 		},
 		{
 			name: "http runtime exits three",
@@ -177,7 +177,7 @@ func TestIncidentsMapRuntimeFailuresAndMalformedResults(t *testing.T) {
 				http.Error(w, "unavailable", http.StatusServiceUnavailable)
 			},
 			wantCode:   3,
-			wantStderr: "v1 RPC HTTP 503",
+			wantStderr: "returned status 503",
 		},
 		{
 			name: "unknown rpc error exits three",

--- a/cmd/swarm/local_context_registry.go
+++ b/cmd/swarm/local_context_registry.go
@@ -584,7 +584,7 @@ func validateLocalContextEntry(ctx context.Context, entry localContextEntry, cal
 	identity, err := caller.callRuntimeIdentity(ctx, rpcEndpoint, token)
 	if err != nil {
 		entry.Status = classifyLocalContextIdentityError(err)
-		entry.Detail = err.Error()
+		entry.Detail = formatCLIAPITransportDetail(err)
 		return entry
 	}
 	if strings.TrimSpace(identity.RuntimeInstanceID) == "" {
@@ -634,6 +634,10 @@ func classifyLocalContextIdentityError(err error) string {
 		default:
 			return localContextStatusStaleDescriptor
 		}
+	}
+	var protocolErr *cliAPIProtocolError
+	if errors.As(err, &protocolErr) {
+		return localContextStatusStaleDescriptor
 	}
 	var netErr net.Error
 	if errors.As(err, &netErr) {

--- a/cmd/swarm/local_context_registry_test.go
+++ b/cmd/swarm/local_context_registry_test.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"errors"
-	"net"
 	"os"
 	"path/filepath"
 	"strings"
@@ -108,6 +107,7 @@ func TestLocalContextValidationTaxonomy(t *testing.T) {
 		desc       localContextDescriptor
 		caller     *fakeRuntimeIdentityCaller
 		wantStatus string
+		wantDetail string
 		wantCalls  int
 	}{
 		{
@@ -127,8 +127,9 @@ func TestLocalContextValidationTaxonomy(t *testing.T) {
 		{
 			name:       "no server",
 			desc:       testLocalContextDescriptor("down", "runtime-a"),
-			caller:     &fakeRuntimeIdentityCaller{err: &net.DNSError{Err: "no such host"}},
+			caller:     &fakeRuntimeIdentityCaller{err: &cliAPITransportError{surface: "runtime API", endpoint: "http://127.0.0.1:19001/v1/rpc", operation: "request", err: errors.New("connection refused")}},
 			wantStatus: localContextStatusNoServer,
+			wantDetail: "cannot reach the Swarm runtime at 127.0.0.1:19001.",
 			wantCalls:  1,
 		},
 		{
@@ -152,6 +153,14 @@ func TestLocalContextValidationTaxonomy(t *testing.T) {
 			got := validateLocalContextEntry(context.Background(), entry, tt.caller)
 			if got.Status != tt.wantStatus {
 				t.Fatalf("status = %q, want %q detail=%s", got.Status, tt.wantStatus, got.Detail)
+			}
+			if tt.wantDetail != "" && !strings.Contains(got.Detail, tt.wantDetail) {
+				t.Fatalf("detail = %q, want substring %q", got.Detail, tt.wantDetail)
+			}
+			for _, forbidden := range []string{"v1 RPC", "/v1/rpc", "Post ", "dial tcp", "connection refused"} {
+				if strings.Contains(got.Detail, forbidden) {
+					t.Fatalf("detail = %q, must not leak %q", got.Detail, forbidden)
+				}
 			}
 			if tt.caller.calls != tt.wantCalls {
 				t.Fatalf("calls = %d, want %d", tt.caller.calls, tt.wantCalls)

--- a/cmd/swarm/logs.go
+++ b/cmd/swarm/logs.go
@@ -79,6 +79,7 @@ type runtimeLogSubscriptionNotification struct {
 
 type runtimeLogSubscription struct {
 	conn           *websocket.Conn
+	endpoint       string
 	subscriptionID string
 	logs           chan runtimeLogEntry
 	errs           chan error
@@ -348,9 +349,9 @@ func subscribeRuntimeLogs(ctx context.Context, wsEndpoint, token string, params 
 	conn, resp, err := websocket.DefaultDialer.DialContext(ctx, wsEndpoint, header)
 	if err != nil {
 		if resp != nil {
-			return nil, runtimeLogsWSHTTPError(resp)
+			return nil, cliAPIWebSocketHTTPError("runtime log stream", wsEndpoint, resp)
 		}
-		return nil, fmt.Errorf("v1 WS dial failed: %w", err)
+		return nil, &cliAPITransportError{surface: "runtime log stream", endpoint: wsEndpoint, operation: "dial", err: err}
 	}
 	requestID := "swarm-cli:" + runtimeLogsMethodSubscribe
 	if err := conn.WriteJSON(jsonRPCRequest{
@@ -360,20 +361,20 @@ func subscribeRuntimeLogs(ctx context.Context, wsEndpoint, token string, params 
 		Params:  params,
 	}); err != nil {
 		conn.Close()
-		return nil, fmt.Errorf("write runtime.subscribe_logs request: %w", err)
+		return nil, &cliAPITransportError{surface: "runtime log stream", endpoint: wsEndpoint, operation: "subscription request", err: err}
 	}
 	var envelope jsonRPCResponse
-	if err := conn.ReadJSON(&envelope); err != nil {
+	if err := cliAPIReadWebSocketJSON(conn, "runtime log stream", wsEndpoint, "subscription response", &envelope); err != nil {
 		conn.Close()
-		return nil, fmt.Errorf("read runtime.subscribe_logs response: %w", err)
+		return nil, err
 	}
 	if envelope.JSONRPC != "2.0" {
 		conn.Close()
-		return nil, fmt.Errorf("malformed runtime.subscribe_logs response: jsonrpc=%q", envelope.JSONRPC)
+		return nil, &cliAPIProtocolError{surface: "runtime log stream", endpoint: wsEndpoint, operation: "subscription response", err: fmt.Errorf("jsonrpc=%q", envelope.JSONRPC)}
 	}
 	if id, ok := envelope.ID.(string); !ok || id != requestID {
 		conn.Close()
-		return nil, fmt.Errorf("malformed runtime.subscribe_logs response: id=%s, want %q", formatJSONRPCID(envelope.ID), requestID)
+		return nil, &cliAPIProtocolError{surface: "runtime log stream", endpoint: wsEndpoint, operation: "subscription response", err: fmt.Errorf("id=%s, want %q", formatJSONRPCID(envelope.ID), requestID)}
 	}
 	if envelope.Error != nil {
 		conn.Close()
@@ -382,14 +383,15 @@ func subscribeRuntimeLogs(ctx context.Context, wsEndpoint, token string, params 
 	var result runtimeLogSubscriptionResult
 	if err := json.Unmarshal(envelope.Result, &result); err != nil {
 		conn.Close()
-		return nil, fmt.Errorf("decode runtime.subscribe_logs result: %w", err)
+		return nil, &cliAPIProtocolError{surface: "runtime log stream", endpoint: wsEndpoint, operation: "subscription result", err: err}
 	}
 	if strings.TrimSpace(result.SubscriptionID) == "" {
 		conn.Close()
-		return nil, fmt.Errorf("malformed runtime.subscribe_logs result: subscription_id is required")
+		return nil, &cliAPIProtocolError{surface: "runtime log stream", endpoint: wsEndpoint, operation: "subscription result", err: fmt.Errorf("subscription_id is required")}
 	}
 	sub := &runtimeLogSubscription{
 		conn:           conn,
+		endpoint:       wsEndpoint,
 		subscriptionID: result.SubscriptionID,
 		logs:           make(chan runtimeLogEntry, 16),
 		errs:           make(chan error, 1),
@@ -398,43 +400,28 @@ func subscribeRuntimeLogs(ctx context.Context, wsEndpoint, token string, params 
 	return sub, nil
 }
 
-func runtimeLogsWSHTTPError(resp *http.Response) error {
-	if resp == nil {
-		return nil
-	}
-	message := http.StatusText(resp.StatusCode)
-	if resp.Body != nil {
-		defer resp.Body.Close()
-		raw, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
-		if err == nil && strings.TrimSpace(string(raw)) != "" {
-			message = strings.TrimSpace(string(raw))
-		}
-	}
-	return &cliAPIHTTPError{surface: "v1 WS", statusCode: resp.StatusCode, message: message}
-}
-
 func (s *runtimeLogSubscription) readLoop() {
 	defer close(s.logs)
 	for {
 		var notification runtimeLogSubscriptionNotification
-		if err := s.conn.ReadJSON(&notification); err != nil {
-			if websocket.IsCloseError(err, websocket.CloseNormalClosure, websocket.CloseGoingAway) || strings.Contains(err.Error(), "use of closed network connection") {
+		if err := cliAPIReadWebSocketJSON(s.conn, "runtime log stream", s.endpoint, "notification read", &notification); err != nil {
+			if cliAPIIsNormalWebSocketClose(err) {
 				return
 			}
-			s.reportError(fmt.Errorf("read runtime.subscribe_logs notification: %w", err))
+			s.reportError(err)
 			return
 		}
 		if notification.JSONRPC != "2.0" || notification.Method != "rpc.subscription" {
-			s.reportError(fmt.Errorf("malformed runtime.subscribe_logs notification"))
+			s.reportError(&cliAPIProtocolError{surface: "runtime log stream", endpoint: s.endpoint, operation: "notification", err: fmt.Errorf("malformed runtime.subscribe_logs notification")})
 			return
 		}
 		if notification.Params.Subscription != s.subscriptionID {
-			s.reportError(fmt.Errorf("malformed runtime.subscribe_logs notification: subscription mismatch"))
+			s.reportError(&cliAPIProtocolError{surface: "runtime log stream", endpoint: s.endpoint, operation: "notification", err: fmt.Errorf("subscription mismatch")})
 			return
 		}
 		log := notification.Params.Result
 		if err := validateRuntimeLogEntry("runtime.subscribe_logs notification", log); err != nil {
-			s.reportError(err)
+			s.reportError(&cliAPIProtocolError{surface: "runtime log stream", endpoint: s.endpoint, operation: "notification", err: err})
 			return
 		}
 		select {

--- a/cmd/swarm/logs_test.go
+++ b/cmd/swarm/logs_test.go
@@ -223,7 +223,7 @@ func TestLogsMapRuntimeFailuresAndMalformedResults(t *testing.T) {
 				http.Error(w, "unauthorized", http.StatusUnauthorized)
 			},
 			wantCode:   4,
-			wantStderr: "v1 RPC HTTP 401",
+			wantStderr: "rejected the request with status 401",
 		},
 		{
 			name: "http runtime exits three",
@@ -232,7 +232,7 @@ func TestLogsMapRuntimeFailuresAndMalformedResults(t *testing.T) {
 				http.Error(w, "unavailable", http.StatusServiceUnavailable)
 			},
 			wantCode:   3,
-			wantStderr: "v1 RPC HTTP 503",
+			wantStderr: "returned status 503",
 		},
 		{
 			name: "unknown rpc error exits three",
@@ -464,7 +464,7 @@ func TestLogsFollowMapsHandshakeAuthToAuthExit(t *testing.T) {
 	if wsCalls.Load() != 1 {
 		t.Fatalf("ws calls = %d, want 1", wsCalls.Load())
 	}
-	if !strings.Contains(stderr.String(), "v1 WS HTTP 401") {
+	if !strings.Contains(stderr.String(), "rejected the request with status 401") {
 		t.Fatalf("stderr = %q, want WS auth status", stderr.String())
 	}
 }

--- a/cmd/swarm/run_command.go
+++ b/cmd/swarm/run_command.go
@@ -76,6 +76,7 @@ type runTraceNotification struct {
 
 type runTraceSubscription struct {
 	conn           *websocket.Conn
+	endpoint       string
 	subscriptionID string
 	rows           chan diagnosticRunTraceRow
 	errs           chan error
@@ -126,12 +127,12 @@ func runCommandChangedFlags(cmd *cobra.Command) map[string]bool {
 
 func runRunCommand(ctx context.Context, repo string, out, errOut io.Writer, opts runCommandOptions) error {
 	if err := opts.validate(); err != nil {
-		fmt.Fprintln(errOut, err)
+		writeCLIAPIError(errOut, err)
 		return commandExitError{code: 2}
 	}
 	apiOpts, wsEndpoint, err := opts.runtimeEndpoints()
 	if err != nil {
-		fmt.Fprintln(errOut, err)
+		writeCLIAPIError(errOut, err)
 		return commandExitError{code: 2}
 	}
 	apiOpts.disableLocalTargeting = true
@@ -143,7 +144,7 @@ func runRunCommand(ctx context.Context, repo string, out, errOut io.Writer, opts
 
 	payload, err := loadRunCommandPayload(opts.payloadPath)
 	if err != nil {
-		fmt.Fprintln(errOut, err)
+		writeCLIAPIError(errOut, err)
 		return commandExitError{code: 2}
 	}
 
@@ -153,16 +154,16 @@ func runRunCommand(ctx context.Context, repo string, out, errOut io.Writer, opts
 		var err error
 		opts, err = opts.withLocalForegroundServeAuth()
 		if err != nil {
-			fmt.Fprintln(errOut, err)
+			writeCLIAPIError(errOut, err)
 			return commandExitError{code: runCommandErrorExitCode(err)}
 		}
 		if _, err := newCLIAPIClient(opts.apiOptions); err != nil {
-			fmt.Fprintln(errOut, err)
+			writeCLIAPIError(errOut, err)
 			return commandExitError{code: runCommandErrorExitCode(err)}
 		}
 		stopLocal, err = startLocalRunServe(ctx, repo, opts)
 		if err != nil {
-			fmt.Fprintln(errOut, err)
+			writeCLIAPIError(errOut, err)
 			return commandExitError{code: runCommandErrorExitCode(err)}
 		}
 		defer stopLocal()
@@ -170,12 +171,12 @@ func runRunCommand(ctx context.Context, repo string, out, errOut io.Writer, opts
 
 	client, err := newCLIAPIClient(opts.apiOptions)
 	if err != nil {
-		fmt.Fprintln(errOut, err)
+		writeCLIAPIError(errOut, err)
 		return commandExitError{code: runCommandErrorExitCode(err)}
 	}
 	health, err := runCommandHealth(ctx, client)
 	if err != nil {
-		fmt.Fprintln(errOut, err)
+		writeCLIAPIError(errOut, err)
 		return commandExitError{code: runCommandErrorExitCode(err)}
 	}
 	if expected := strings.TrimSpace(opts.bundleFingerprint); expected != "" && expected != health.Bundle.Fingerprint {
@@ -185,7 +186,7 @@ func runRunCommand(ctx context.Context, repo string, out, errOut io.Writer, opts
 	traceReplaySince := time.Now().UTC()
 	start, err := runCommandStart(ctx, client, health, opts, payload)
 	if err != nil {
-		fmt.Fprintln(errOut, err)
+		writeCLIAPIError(errOut, err)
 		return commandExitError{code: runCommandErrorExitCode(err)}
 	}
 	writeRunCommandStarted(out, start)
@@ -542,13 +543,13 @@ func validateRunStartResult(result runStartResult) error {
 func runReattachCommand(ctx context.Context, out, errOut io.Writer, opts runCommandOptions, wsEndpoint string) error {
 	client, err := newCLIAPIClient(opts.apiOptions)
 	if err != nil {
-		fmt.Fprintln(errOut, err)
+		writeCLIAPIError(errOut, err)
 		return commandExitError{code: runCommandErrorExitCode(err)}
 	}
 	runID := strings.TrimSpace(opts.reattachRunID)
 	run, err := runCommandGet(ctx, client, runID)
 	if err != nil {
-		fmt.Fprintln(errOut, err)
+		writeCLIAPIError(errOut, err)
 		return commandExitError{code: runCommandErrorExitCode(err)}
 	}
 	if runCommandTerminalStatus(run.Status) {
@@ -562,7 +563,7 @@ func runReattachCommand(ctx context.Context, out, errOut io.Writer, opts runComm
 func followRunCommand(ctx context.Context, out, errOut io.Writer, client *cliAPIClient, opts runCommandOptions, wsEndpoint, runID string, replaySince *time.Time, stopOnInterrupt bool) error {
 	sub, err := subscribeRunTrace(ctx, wsEndpoint, client.token, runID, replaySince, nil)
 	if err != nil {
-		fmt.Fprintln(errOut, err)
+		writeCLIAPIError(errOut, err)
 		return commandExitError{code: runCommandErrorExitCode(err)}
 	}
 	defer sub.close()
@@ -578,7 +579,8 @@ func followRunCommand(ctx context.Context, out, errOut io.Writer, client *cliAPI
 		case <-ctx.Done():
 			if stopOnInterrupt {
 				if err := runCommandStop(context.Background(), client, runID); err != nil {
-					fmt.Fprintf(errOut, "interrupted; run.stop failed: %v\n", err)
+					fmt.Fprintln(errOut, "interrupted; run.stop failed")
+					writeCLIAPIError(errOut, err)
 					return commandExitError{code: 130}
 				}
 			}
@@ -596,13 +598,13 @@ func followRunCommand(ctx context.Context, out, errOut io.Writer, client *cliAPI
 			writeRunCommandTraceRow(out, row)
 		case err := <-sub.errs:
 			if err != nil {
-				fmt.Fprintln(errOut, err)
+				writeCLIAPIError(errOut, err)
 				return commandExitError{code: runCommandErrorExitCode(err)}
 			}
 		case <-ticker.C:
 			run, err := runCommandGet(ctx, client, runID)
 			if err != nil {
-				fmt.Fprintln(errOut, err)
+				writeCLIAPIError(errOut, err)
 				return commandExitError{code: runCommandErrorExitCode(err)}
 			}
 			if runCommandTerminalStatus(run.Status) {
@@ -615,9 +617,12 @@ func followRunCommand(ctx context.Context, out, errOut io.Writer, client *cliAPI
 
 func subscribeRunTrace(ctx context.Context, wsEndpoint, token, runID string, replaySince *time.Time, extraParams map[string]any) (*runTraceSubscription, error) {
 	header := http.Header{"Authorization": []string{"Bearer " + token}}
-	conn, _, err := websocket.DefaultDialer.DialContext(ctx, wsEndpoint, header)
+	conn, resp, err := websocket.DefaultDialer.DialContext(ctx, wsEndpoint, header)
 	if err != nil {
-		return nil, fmt.Errorf("v1 WS dial failed: %w", err)
+		if resp != nil {
+			return nil, cliAPIWebSocketHTTPError("runtime event stream", wsEndpoint, resp)
+		}
+		return nil, &cliAPITransportError{surface: "runtime event stream", endpoint: wsEndpoint, operation: "dial", err: err}
 	}
 	requestID := "swarm-cli:" + runCommandMethodSubscribeTrace
 	params := map[string]any{"run_id": runID}
@@ -634,20 +639,20 @@ func subscribeRunTrace(ctx context.Context, wsEndpoint, token, runID string, rep
 		Params:  params,
 	}); err != nil {
 		conn.Close()
-		return nil, fmt.Errorf("write run.subscribe_trace request: %w", err)
+		return nil, &cliAPITransportError{surface: "runtime event stream", endpoint: wsEndpoint, operation: "subscription request", err: err}
 	}
 	var envelope jsonRPCResponse
-	if err := conn.ReadJSON(&envelope); err != nil {
+	if err := cliAPIReadWebSocketJSON(conn, "runtime event stream", wsEndpoint, "subscription response", &envelope); err != nil {
 		conn.Close()
-		return nil, fmt.Errorf("read run.subscribe_trace response: %w", err)
+		return nil, err
 	}
 	if envelope.JSONRPC != "2.0" {
 		conn.Close()
-		return nil, fmt.Errorf("malformed run.subscribe_trace response: jsonrpc=%q", envelope.JSONRPC)
+		return nil, &cliAPIProtocolError{surface: "runtime event stream", endpoint: wsEndpoint, operation: "subscription response", err: fmt.Errorf("jsonrpc=%q", envelope.JSONRPC)}
 	}
 	if id, ok := envelope.ID.(string); !ok || id != requestID {
 		conn.Close()
-		return nil, fmt.Errorf("malformed run.subscribe_trace response: id=%s, want %q", formatJSONRPCID(envelope.ID), requestID)
+		return nil, &cliAPIProtocolError{surface: "runtime event stream", endpoint: wsEndpoint, operation: "subscription response", err: fmt.Errorf("id=%s, want %q", formatJSONRPCID(envelope.ID), requestID)}
 	}
 	if envelope.Error != nil {
 		conn.Close()
@@ -656,14 +661,15 @@ func subscribeRunTrace(ctx context.Context, wsEndpoint, token, runID string, rep
 	var result runTraceSubscriptionResult
 	if err := json.Unmarshal(envelope.Result, &result); err != nil {
 		conn.Close()
-		return nil, fmt.Errorf("decode run.subscribe_trace result: %w", err)
+		return nil, &cliAPIProtocolError{surface: "runtime event stream", endpoint: wsEndpoint, operation: "subscription result", err: err}
 	}
 	if strings.TrimSpace(result.SubscriptionID) == "" {
 		conn.Close()
-		return nil, fmt.Errorf("malformed run.subscribe_trace result: subscription_id is required")
+		return nil, &cliAPIProtocolError{surface: "runtime event stream", endpoint: wsEndpoint, operation: "subscription result", err: fmt.Errorf("subscription_id is required")}
 	}
 	sub := &runTraceSubscription{
 		conn:           conn,
+		endpoint:       wsEndpoint,
 		subscriptionID: result.SubscriptionID,
 		rows:           make(chan diagnosticRunTraceRow, 16),
 		errs:           make(chan error, 1),
@@ -676,24 +682,24 @@ func (s *runTraceSubscription) readLoop() {
 	defer close(s.rows)
 	for {
 		var notification runTraceNotification
-		if err := s.conn.ReadJSON(&notification); err != nil {
-			if websocket.IsCloseError(err, websocket.CloseNormalClosure, websocket.CloseGoingAway) || strings.Contains(err.Error(), "use of closed network connection") {
+		if err := cliAPIReadWebSocketJSON(s.conn, "runtime event stream", s.endpoint, "notification read", &notification); err != nil {
+			if cliAPIIsNormalWebSocketClose(err) {
 				return
 			}
-			s.reportError(fmt.Errorf("read run.subscribe_trace notification: %w", err))
+			s.reportError(err)
 			return
 		}
 		if notification.JSONRPC != "2.0" || notification.Method != "rpc.subscription" {
-			s.reportError(fmt.Errorf("malformed run.subscribe_trace notification"))
+			s.reportError(&cliAPIProtocolError{surface: "runtime event stream", endpoint: s.endpoint, operation: "notification", err: fmt.Errorf("malformed run.subscribe_trace notification")})
 			return
 		}
 		if notification.Params.Subscription != s.subscriptionID {
-			s.reportError(fmt.Errorf("malformed run.subscribe_trace notification: subscription mismatch"))
+			s.reportError(&cliAPIProtocolError{surface: "runtime event stream", endpoint: s.endpoint, operation: "notification", err: fmt.Errorf("subscription mismatch")})
 			return
 		}
 		row := notification.Params.Result
 		if err := validateRunCommandTraceRow(row); err != nil {
-			s.reportError(err)
+			s.reportError(&cliAPIProtocolError{surface: "runtime event stream", endpoint: s.endpoint, operation: "notification", err: err})
 			return
 		}
 		select {

--- a/cmd/swarm/run_command_test.go
+++ b/cmd/swarm/run_command_test.go
@@ -656,7 +656,7 @@ func TestRunCommandLocalReadinessAuthFailureFailsFast(t *testing.T) {
 	if !serveCanceled.Load() {
 		t.Fatal("local serve hook was not canceled after readiness auth failure")
 	}
-	if !strings.Contains(stderr.String(), "v1 RPC HTTP 401") {
+	if !strings.Contains(stderr.String(), "rejected the request with status 401") {
 		t.Fatalf("stderr = %q, want auth failure", stderr.String())
 	}
 }
@@ -754,6 +754,49 @@ func TestRunCommandMalformedWebSocketFailuresExitThree(t *testing.T) {
 				t.Fatalf("stderr = %q, want %q", stderr.String(), tc.wantStderr)
 			}
 		})
+	}
+}
+
+func TestRunCommandWebSocketHandshakeHTTPErrorUsesSharedDiagnostic(t *testing.T) {
+	setCLIAPITestToken(t, "test-token")
+	payloadPath := writeRunCommandPayloadFile(t, map[string]any{"ok": true})
+	server, _, _ := newRunCommandServer(t, runCommandServerOptions{
+		rpcResponder: func(req jsonRPCRequest, _ int) map[string]any {
+			switch req.Method {
+			case "health.check":
+				return runCommandHealthResult()
+			case "run.start":
+				return map[string]any{"run_id": "run-ws-auth", "status": "running"}
+			default:
+				t.Fatalf("unexpected method = %q", req.Method)
+			}
+			return nil
+		},
+		wsHTTPStatus: http.StatusUnauthorized,
+		wsHTTPBody:   "invalid bearer token",
+	})
+	defer server.Close()
+
+	opts := testRunCommandOptions(server)
+	opts.runStatusPoll = time.Hour
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"run", "start", "--connect", server.URL, "--event", "scan.requested", "--payload", payloadPath}, &stdout, &stderr, opts)
+	if code != 4 {
+		t.Fatalf("code = %d, want 4 stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	for _, want := range []string{
+		"ERROR: the Swarm runtime at ",
+		"rejected the request with status 401",
+		"Check API credentials",
+	} {
+		if !strings.Contains(stderr.String(), want) {
+			t.Fatalf("stderr = %q, want substring %q", stderr.String(), want)
+		}
+	}
+	for _, forbidden := range []string{"cannot reach", "runtime event stream dial failed", "/v1/ws"} {
+		if strings.Contains(stderr.String(), forbidden) {
+			t.Fatalf("stderr = %q, must not contain %q", stderr.String(), forbidden)
+		}
 	}
 }
 
@@ -874,6 +917,8 @@ type runCommandServerOptions struct {
 	wsSubscribed         chan struct{}
 	wsSubscriptionResult map[string]any
 	wsCloseAfterRows     bool
+	wsHTTPStatus         int
+	wsHTTPBody           string
 	expectedToken        string
 	strictAuth           bool
 }
@@ -917,6 +962,14 @@ func newRunCommandServer(t *testing.T, opts runCommandServerOptions) (*httptest.
 					return
 				}
 				t.Errorf("WS Authorization = %q, want bearer token", got)
+			}
+			if opts.wsHTTPStatus != 0 {
+				body := opts.wsHTTPBody
+				if body == "" {
+					body = http.StatusText(opts.wsHTTPStatus)
+				}
+				http.Error(w, body, opts.wsHTTPStatus)
+				return
 			}
 			conn, err := upgrader.Upgrade(w, r, nil)
 			if err != nil {

--- a/cmd/swarm/secrets.go
+++ b/cmd/swarm/secrets.go
@@ -557,7 +557,7 @@ func dash(value string) string {
 
 func returnSecretsRuntimeError(errOut io.Writer, err error) error {
 	if errOut != nil {
-		fmt.Fprintln(errOut, err)
+		writeCLIAPIError(errOut, err)
 	}
 	return commandExitError{code: cliExitRuntime}
 }
@@ -565,7 +565,7 @@ func returnSecretsRuntimeError(errOut io.Writer, err error) error {
 func returnSecretsStoreError(errOut io.Writer, err error) error {
 	if errors.Is(err, runtimecredentials.ErrStoreLocked) {
 		if errOut != nil {
-			fmt.Fprintln(errOut, err)
+			writeCLIAPIError(errOut, err)
 		}
 		return commandExitError{code: cliExitConflict}
 	}

--- a/cmd/swarm/test_command.go
+++ b/cmd/swarm/test_command.go
@@ -236,7 +236,7 @@ func runScenarioTestCommand(ctx context.Context, repoRoot string, out, errOut io
 	}
 	client, err := newCLIAPIClient(opts.apiOptions)
 	if err != nil {
-		fmt.Fprintln(errOut, err)
+		writeCLIAPIError(errOut, err)
 		return commandExitError{code: scenarioTestAPIErrorExitCode(err)}
 	}
 	runner := scenarioRunner{
@@ -250,7 +250,7 @@ func runScenarioTestCommand(ctx context.Context, repoRoot string, out, errOut io
 	}
 	for _, file := range files {
 		if err := runner.runScenarioFile(ctx, file); err != nil {
-			fmt.Fprintln(errOut, err)
+			writeCLIAPIError(errOut, err)
 			return commandExitError{code: scenarioTestAPIErrorExitCode(err)}
 		}
 	}
@@ -2142,7 +2142,7 @@ func scenarioStringSliceContains(values []string, want string) bool {
 }
 
 func returnScenarioTestValidationError(errOut io.Writer, err error) error {
-	fmt.Fprintln(errOut, err)
+	writeCLIAPIError(errOut, err)
 	return commandExitError{code: scenarioTestExitValidation}
 }
 

--- a/cmd/swarm/version_command_test.go
+++ b/cmd/swarm/version_command_test.go
@@ -170,7 +170,7 @@ func TestVersionServerFailsClosedOnAPIAndMalformedResults(t *testing.T) {
 				_, _ = w.Write([]byte(`{"error":"invalid bearer token"}`))
 			},
 			wantCode:   4,
-			wantStderr: "v1 RPC HTTP 401",
+			wantStderr: "rejected the request with status 401",
 		},
 		{
 			name: "json rpc error",
@@ -200,7 +200,7 @@ func TestVersionServerFailsClosedOnAPIAndMalformedResults(t *testing.T) {
 				_ = json.NewEncoder(w).Encode(map[string]any{"jsonrpc": "1.0", "id": req.ID, "result": validVersionHealthResult()})
 			},
 			wantCode:   3,
-			wantStderr: "malformed JSON-RPC response",
+			wantStderr: "returned an invalid API response",
 		},
 		{
 			name: "malformed health result",
@@ -255,7 +255,7 @@ func TestVersionServerFailsClosedOnTransportError(t *testing.T) {
 	if strings.TrimSpace(stdout.String()) != "" {
 		t.Fatalf("stdout = %q, want empty", stdout.String())
 	}
-	if !strings.Contains(stderr.String(), "v1 RPC request failed") {
+	if !strings.Contains(stderr.String(), "cannot reach the Swarm runtime") {
 		t.Fatalf("stderr = %q, want transport failure", stderr.String())
 	}
 }


### PR DESCRIPTION
## Summary

Closes #1813.

This PR closes the approved `cli.runtime_transport_diagnostic_translation` failure class by routing CLI runtime RPC/WS transport, HTTP status, and protocol-response failures through one shared user-facing formatter.

## Governing References

- `platform-spec.yaml#cli_specification.foundations.output_contract.stdout_stderr_boundary`
- `platform-spec.yaml#cli_specification.foundations.output_contract.diagnostic_convention`
- #1712 connection-error prose and CLI output/error UX parent
- #1813 issue body and approved pre-audit gate on the issue thread

## Semantic Migration

- New canonical owner: shared CLI runtime API diagnostic formatting in `cmd/swarm/cli_errors.go`, backed by typed runtime API errors from `cmd/swarm/cli_api.go` and WS subscription helpers.
- Old invalid producer/reader paths: raw `v1 RPC request failed`, `v1 RPC HTTP ...`, `v1 WS HTTP ...`, `v1 WS dial failed`, raw JSON-RPC protocol parse strings as primary user-facing diagnostics, command-local `fmt.Fprintln(errOut, err)` for runtime API/WS transport paths, and raw runtime identity probe detail storage.
- Production paths checked/migrated: central `returnCLIAPIError`, direct-print runtime API command families, run trace follow, event follow, logs follow, runtime identity context/target detail, RPC HTTP status, RPC network/read failure, WS dial/setup/read failure, and trace follow retry classification.
- Migration completeness: complete for the approved #1813 child class. Broader CLI output-conformance remains tracked by #1712/#1821.

## Tests

Run with host Postgres as requested:

```sh
SWARM_TEST_POSTGRES_DSN='host=127.0.0.1 port=5432 user=youmew dbname=postgres sslmode=disable' PGPASSWORD=postgres go test ./cmd/swarm -run 'TestCLIAPI|TestLocalContextValidationTaxonomy|TestVersionServerFailsClosedOnTransportError|TestControlNukeTransportFailureExitsThree|TestTraceFollowClassifiesTypedTransportAsRetryable' -count=1 -p=1
SWARM_TEST_POSTGRES_DSN='host=127.0.0.1 port=5432 user=youmew dbname=postgres sslmode=disable' PGPASSWORD=postgres go test -p=1 ./cmd/swarm
SWARM_TEST_POSTGRES_DSN='host=127.0.0.1 port=5432 user=youmew dbname=postgres sslmode=disable' PGPASSWORD=postgres go test ./...
```
