### PR TITLE
[agent-f][issue #1855] Add connector pack imports

### DIFF
--- a/cmd/swarm/provider_connector_tools.go
+++ b/cmd/swarm/provider_connector_tools.go
@@ -14,6 +14,12 @@ func appendProviderConnectorToolSurfaceFindings(ctx context.Context, report *loc
 	if report == nil || source == nil {
 		return
 	}
+	var err error
+	source, err = providerconnectors.SourceWithConnectorPackImports(source)
+	if err != nil {
+		report.add(localPreflightProviderPackPrerequisite, "provider_connector_pack_import_failed", localPreflightSeverityBlocker, localPreflightStatusFailed, err.Error(), "fix provider connector pack imports")
+		return
+	}
 	discovered, err := providerconnectors.Surfaces(ctx, source, nil)
 	if err != nil {
 		report.add(localPreflightProviderPackPrerequisite, "provider_connector_surface_failed", localPreflightSeverityBlocker, localPreflightStatusFailed, err.Error(), "fix provider connector tool declarations")

--- a/internal/packs/envelope.go
+++ b/internal/packs/envelope.go
@@ -18,10 +18,12 @@ import (
 )
 
 const (
-	EnvelopeFileName = "pack.yaml"
-	ManifestFileName = "trigger.yaml"
+	EnvelopeFileName          = "pack.yaml"
+	TriggerManifestFileName   = "trigger.yaml"
+	ConnectorManifestFileName = "connector.yaml"
 
-	TypeTrigger = "trigger"
+	TypeTrigger   = "trigger"
+	TypeConnector = "connector"
 
 	ProvenancePlatform = "platform"
 	ProvenanceExternal = "external"
@@ -51,10 +53,13 @@ type Capabilities struct {
 }
 
 type CanCapabilities struct {
-	ReceiveHTTPSRoute    string   `yaml:"receive_https_route" json:"receive_https_route"`
-	VerifySecret         string   `yaml:"verify_secret,omitempty" json:"verify_secret,omitempty"`
-	EmitEvents           []string `yaml:"emit_events" json:"emit_events"`
-	PersistDedupeMarkers bool     `yaml:"persist_dedupe_markers" json:"persist_dedupe_markers"`
+	ReceiveHTTPSRoute       string   `yaml:"receive_https_route,omitempty" json:"receive_https_route,omitempty"`
+	VerifySecret            string   `yaml:"verify_secret,omitempty" json:"verify_secret,omitempty"`
+	EmitEvents              []string `yaml:"emit_events,omitempty" json:"emit_events,omitempty"`
+	PersistDedupeMarkers    bool     `yaml:"persist_dedupe_markers,omitempty" json:"persist_dedupe_markers,omitempty"`
+	CallProviderAction      string   `yaml:"call_provider_action,omitempty" json:"call_provider_action,omitempty"`
+	LowerThroughActivity    bool     `yaml:"lower_through_activity,omitempty" json:"lower_through_activity,omitempty"`
+	JournalActivityAttempts bool     `yaml:"journal_activity_attempts,omitempty" json:"journal_activity_attempts,omitempty"`
 }
 
 type Requires struct {
@@ -91,14 +96,29 @@ func Load(fsys fs.FS, dir, runningPlatformVersion string) (Loaded, error) {
 	if err := envelope.ValidateCommon(runningPlatformVersion); err != nil {
 		return Loaded{}, err
 	}
-	manifestBody, err := fs.ReadFile(fsys, path.Join(dir, ManifestFileName))
+	manifestFile := ManifestFileNameForType(envelope.Type)
+	if manifestFile == "" {
+		return Loaded{}, fmt.Errorf("pack %q has unsupported type %q", envelope.ID, envelope.Type)
+	}
+	manifestBody, err := fs.ReadFile(fsys, path.Join(dir, manifestFile))
 	if err != nil {
-		return Loaded{}, fmt.Errorf("read pack manifest %q: %w", path.Join(dir, ManifestFileName), err)
+		return Loaded{}, fmt.Errorf("read pack manifest %q: %w", path.Join(dir, manifestFile), err)
 	}
 	if err := envelope.VerifyManifestHash(manifestBody); err != nil {
 		return Loaded{}, err
 	}
 	return Loaded{Envelope: envelope, ManifestBody: manifestBody, Directory: dir}, nil
+}
+
+func ManifestFileNameForType(packType string) string {
+	switch strings.TrimSpace(packType) {
+	case TypeTrigger:
+		return TriggerManifestFileName
+	case TypeConnector:
+		return ConnectorManifestFileName
+	default:
+		return ""
+	}
 }
 
 func ParseEnvelope(body []byte) (Envelope, error) {
@@ -128,7 +148,9 @@ func (e Envelope) ValidateCommon(runningPlatformVersion string) error {
 	if err := platform.ValidateProductPlatformVersion(e.PlatformVersion, runningPlatformVersion); err != nil {
 		return fmt.Errorf("pack %q platform_version is incompatible: %w", id, err)
 	}
-	if strings.TrimSpace(e.Type) != TypeTrigger {
+	switch strings.TrimSpace(e.Type) {
+	case TypeTrigger, TypeConnector:
+	default:
 		return fmt.Errorf("pack %q has unsupported type %q", id, e.Type)
 	}
 	if strings.TrimSpace(e.ManifestHash) == "" {
@@ -139,7 +161,7 @@ func (e Envelope) ValidateCommon(runningPlatformVersion string) error {
 	default:
 		return fmt.Errorf("pack %q has unsupported provenance source %q", id, e.Provenance.Source)
 	}
-	if err := e.Capabilities.Validate(id); err != nil {
+	if err := e.Capabilities.ValidateForType(id, strings.TrimSpace(e.Type)); err != nil {
 		return err
 	}
 	if err := e.Requires.Validate(id); err != nil {
@@ -178,8 +200,26 @@ func (e Envelope) VerifyManifestHash(manifestBody []byte) error {
 }
 
 func (c Capabilities) Validate(packID string) error {
+	return c.ValidateForType(packID, TypeTrigger)
+}
+
+func (c Capabilities) ValidateForType(packID, packType string) error {
+	switch strings.TrimSpace(packType) {
+	case TypeTrigger:
+		return c.validateTrigger(packID)
+	case TypeConnector:
+		return c.validateConnector(packID)
+	default:
+		return fmt.Errorf("pack %q has unsupported type %q", packID, packType)
+	}
+}
+
+func (c Capabilities) validateTrigger(packID string) error {
 	if strings.TrimSpace(c.Can.ReceiveHTTPSRoute) == "" {
 		return fmt.Errorf("pack %q capabilities.can.receive_https_route is required", packID)
+	}
+	if strings.TrimSpace(c.Can.CallProviderAction) != "" || c.Can.LowerThroughActivity || c.Can.JournalActivityAttempts {
+		return fmt.Errorf("pack %q trigger capabilities must not declare connector capability fields", packID)
 	}
 	if len(c.Can.EmitEvents) == 0 {
 		return fmt.Errorf("pack %q capabilities.can.emit_events is required", packID)
@@ -191,6 +231,30 @@ func (c Capabilities) Validate(packID string) error {
 	}
 	if !c.Can.PersistDedupeMarkers {
 		return fmt.Errorf("pack %q capabilities.can.persist_dedupe_markers must be true", packID)
+	}
+	if len(c.Cannot) == 0 {
+		return fmt.Errorf("pack %q capabilities.cannot is required", packID)
+	}
+	for _, item := range c.Cannot {
+		if strings.TrimSpace(item) == "" {
+			return fmt.Errorf("pack %q capabilities.cannot must not contain empty entries", packID)
+		}
+	}
+	return nil
+}
+
+func (c Capabilities) validateConnector(packID string) error {
+	if strings.TrimSpace(c.Can.CallProviderAction) == "" {
+		return fmt.Errorf("pack %q capabilities.can.call_provider_action is required", packID)
+	}
+	if strings.TrimSpace(c.Can.ReceiveHTTPSRoute) != "" || strings.TrimSpace(c.Can.VerifySecret) != "" || len(c.Can.EmitEvents) > 0 || c.Can.PersistDedupeMarkers {
+		return fmt.Errorf("pack %q connector capabilities must not declare trigger capability fields", packID)
+	}
+	if !c.Can.LowerThroughActivity {
+		return fmt.Errorf("pack %q capabilities.can.lower_through_activity must be true", packID)
+	}
+	if !c.Can.JournalActivityAttempts {
+		return fmt.Errorf("pack %q capabilities.can.journal_activity_attempts must be true", packID)
 	}
 	if len(c.Cannot) == 0 {
 		return fmt.Errorf("pack %q capabilities.cannot is required", packID)
@@ -227,17 +291,27 @@ func RequiresEqual(a, b Requires) bool {
 }
 
 func (e Envelope) Surface(boundSecrets map[string]bool) CapabilitySurface {
-	can := []string{
-		"receive HTTPS route " + strings.TrimSpace(e.Capabilities.Can.ReceiveHTTPSRoute),
-	}
-	if secret := strings.TrimSpace(e.Capabilities.Can.VerifySecret); secret != "" {
-		can = append(can, "verify named secret "+secret)
-	}
-	for _, event := range e.Capabilities.Can.EmitEvents {
-		can = append(can, "emit named event "+strings.TrimSpace(event))
-	}
-	if e.Capabilities.Can.PersistDedupeMarkers {
-		can = append(can, "persist dedupe markers")
+	can := []string{}
+	switch strings.TrimSpace(e.Type) {
+	case TypeConnector:
+		can = append(can, "call provider action "+strings.TrimSpace(e.Capabilities.Can.CallProviderAction))
+		if e.Capabilities.Can.LowerThroughActivity {
+			can = append(can, "lower through platform.activity_requested")
+		}
+		if e.Capabilities.Can.JournalActivityAttempts {
+			can = append(can, "journal non-idempotent attempts in activity_attempts")
+		}
+	default:
+		can = append(can, "receive HTTPS route "+strings.TrimSpace(e.Capabilities.Can.ReceiveHTTPSRoute))
+		if secret := strings.TrimSpace(e.Capabilities.Can.VerifySecret); secret != "" {
+			can = append(can, "verify named secret "+secret)
+		}
+		for _, event := range e.Capabilities.Can.EmitEvents {
+			can = append(can, "emit named event "+strings.TrimSpace(event))
+		}
+		if e.Capabilities.Can.PersistDedupeMarkers {
+			can = append(can, "persist dedupe markers")
+		}
 	}
 	cannot := append([]string(nil), e.Capabilities.Cannot...)
 	sort.Strings(cannot)

--- a/internal/providerconnectors/packs.go
+++ b/internal/providerconnectors/packs.go
@@ -1,0 +1,491 @@
+package providerconnectors
+
+import (
+	"bytes"
+	"embed"
+	"fmt"
+	"io/fs"
+	"path"
+	"sort"
+	"strings"
+
+	"github.com/division-sh/swarm/internal/packs"
+	"github.com/division-sh/swarm/internal/platform"
+	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
+	"github.com/division-sh/swarm/internal/runtime/semanticview"
+	"gopkg.in/yaml.v3"
+)
+
+//go:embed packs/*/pack.yaml packs/*/connector.yaml
+var builtinConnectorPackFS embed.FS
+
+const connectorPackRoot = "packs"
+
+type ConnectorManifest struct {
+	Provider string                                      `yaml:"provider"`
+	Tools    map[string]runtimecontracts.ToolSchemaEntry `yaml:"tools"`
+}
+
+type LoadedPack struct {
+	Envelope     packs.Envelope
+	Manifest     ConnectorManifest
+	ManifestBody []byte
+	Directory    string
+	Source       string
+}
+
+type PackRegistry struct {
+	byProvider map[string]map[string]LoadedPack
+}
+
+var defaultPackRegistry = mustDefaultPackRegistry()
+
+func DefaultPackRegistry() *PackRegistry {
+	return defaultPackRegistry
+}
+
+func BuiltinTool(provider, toolID string) (runtimecontracts.ToolSchemaEntry, bool) {
+	pack, ok := DefaultPackRegistry().Lookup(provider, toolID)
+	if !ok {
+		return runtimecontracts.ToolSchemaEntry{}, false
+	}
+	tool, ok := pack.Manifest.Tools[strings.TrimSpace(toolID)]
+	return tool, ok
+}
+
+func mustDefaultPackRegistry() *PackRegistry {
+	runningVersion, err := platform.PlatformVersion()
+	if err != nil {
+		panic(err)
+	}
+	registry, err := LoadBuiltinPackRegistry(runningVersion)
+	if err != nil {
+		panic(err)
+	}
+	return registry
+}
+
+func LoadBuiltinPackRegistry(runningPlatformVersion string) (*PackRegistry, error) {
+	entries, err := fs.ReadDir(builtinConnectorPackFS, connectorPackRoot)
+	if err != nil {
+		return nil, fmt.Errorf("read built-in provider connector packs: %w", err)
+	}
+	loaded := make([]LoadedPack, 0, len(entries))
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		dir := path.Join(connectorPackRoot, entry.Name())
+		pack, err := LoadPackFS(builtinConnectorPackFS, dir, runningPlatformVersion)
+		if err != nil {
+			return nil, err
+		}
+		loaded = append(loaded, pack)
+	}
+	return NewPackRegistry(loaded...)
+}
+
+func NewPackRegistry(loaded ...LoadedPack) (*PackRegistry, error) {
+	registry := &PackRegistry{byProvider: map[string]map[string]LoadedPack{}}
+	for _, pack := range loaded {
+		provider := normalizeToken(pack.Manifest.Provider)
+		if provider == "" {
+			return nil, fmt.Errorf("provider connector pack %q has empty provider", pack.Envelope.ID)
+		}
+		if registry.byProvider[provider] == nil {
+			registry.byProvider[provider] = map[string]LoadedPack{}
+		}
+		source := firstNonEmpty(pack.Source, pack.Envelope.Provenance.Source+":"+pack.Envelope.ID)
+		names := manifestToolNames(pack.Manifest)
+		for _, toolID := range names {
+			if existing, exists := registry.byProvider[provider][toolID]; exists {
+				existingSource := firstNonEmpty(existing.Source, existing.Envelope.Provenance.Source+":"+existing.Envelope.ID)
+				return nil, fmt.Errorf("duplicate provider connector pack tool %q for provider %q from %s and %s", toolID, provider, existingSource, source)
+			}
+			pack.Source = source
+			registry.byProvider[provider][toolID] = pack
+		}
+	}
+	return registry, nil
+}
+
+func (r *PackRegistry) Lookup(provider, toolID string) (LoadedPack, bool) {
+	if r == nil {
+		return LoadedPack{}, false
+	}
+	provider = normalizeToken(provider)
+	toolID = strings.TrimSpace(toolID)
+	if provider == "" || toolID == "" {
+		return LoadedPack{}, false
+	}
+	byTool := r.byProvider[provider]
+	if byTool == nil {
+		return LoadedPack{}, false
+	}
+	pack, ok := byTool[toolID]
+	return pack, ok
+}
+
+func LoadPackFS(fsys fs.FS, dir, runningPlatformVersion string) (LoadedPack, error) {
+	loaded, err := packs.Load(fsys, dir, runningPlatformVersion)
+	if err != nil {
+		return LoadedPack{}, err
+	}
+	if strings.TrimSpace(loaded.Envelope.Type) != packs.TypeConnector {
+		return LoadedPack{}, fmt.Errorf("provider connector pack %q has unsupported type %q", loaded.Envelope.ID, loaded.Envelope.Type)
+	}
+	manifest, err := parseConnectorManifestStrict(loaded.ManifestBody)
+	if err != nil {
+		return LoadedPack{}, fmt.Errorf("parse connector manifest for pack %q: %w", loaded.Envelope.ID, err)
+	}
+	if err := manifest.Validate(); err != nil {
+		return LoadedPack{}, fmt.Errorf("validate connector manifest for pack %q: %w", loaded.Envelope.ID, err)
+	}
+	expectedCapabilities := DerivedCapabilities(manifest)
+	if !packs.CapabilitiesEqual(loaded.Envelope.Capabilities, expectedCapabilities) {
+		return LoadedPack{}, fmt.Errorf("pack %q capabilities do not match connector manifest", loaded.Envelope.ID)
+	}
+	expectedRequires := DerivedRequires(manifest)
+	if !packs.RequiresEqual(loaded.Envelope.Requires, expectedRequires) {
+		return LoadedPack{}, fmt.Errorf("pack %q requires do not match connector manifest", loaded.Envelope.ID)
+	}
+	return LoadedPack{
+		Envelope:     loaded.Envelope,
+		Manifest:     manifest,
+		ManifestBody: loaded.ManifestBody,
+		Directory:    loaded.Directory,
+		Source:       loaded.Envelope.Provenance.Source + ":" + loaded.Envelope.ID,
+	}, nil
+}
+
+func parseConnectorManifestStrict(body []byte) (ConnectorManifest, error) {
+	var manifest ConnectorManifest
+	decoder := yaml.NewDecoder(bytes.NewReader(body))
+	decoder.KnownFields(true)
+	if err := decoder.Decode(&manifest); err != nil {
+		return ConnectorManifest{}, err
+	}
+	return manifest, nil
+}
+
+func (m ConnectorManifest) Validate() error {
+	provider := normalizeToken(m.Provider)
+	if provider == "" {
+		return fmt.Errorf("connector manifest provider is required")
+	}
+	names := manifestToolNames(m)
+	if len(names) == 0 {
+		return fmt.Errorf("connector manifest tools are required")
+	}
+	if len(names) > 1 {
+		return fmt.Errorf("connector manifest provider %q declares %d tools; this first slice supports one connector action per pack", provider, len(names))
+	}
+	for _, toolID := range names {
+		tool := m.Tools[toolID]
+		if !isProviderConnector(tool) {
+			return fmt.Errorf("connector manifest tool %q must declare category %q", toolID, Category)
+		}
+		toolProvider, _, ok := splitToolID(toolID)
+		if !ok {
+			return fmt.Errorf("connector manifest tool %q must use <provider>.<action> id form", toolID)
+		}
+		if toolProvider != provider {
+			return fmt.Errorf("connector manifest tool %q provider %q does not match manifest provider %q", toolID, toolProvider, provider)
+		}
+		if errs := validateTool(toolID, tool); len(errs) > 0 {
+			return fmt.Errorf("%s", joinValidationErrors(errs))
+		}
+	}
+	return nil
+}
+
+func DerivedCapabilities(manifest ConnectorManifest) packs.Capabilities {
+	names := manifestToolNames(manifest)
+	toolID := ""
+	if len(names) > 0 {
+		toolID = names[0]
+	}
+	return packs.Capabilities{
+		Can: packs.CanCapabilities{
+			CallProviderAction:      strings.TrimSpace(toolID),
+			LowerThroughActivity:    true,
+			JournalActivityAttempts: true,
+		},
+		Cannot: []string{
+			"bypass activity_attempts",
+			"retry non_idempotent_write automatically",
+			"expose credential values",
+		},
+	}
+}
+
+func DerivedRequires(manifest ConnectorManifest) packs.Requires {
+	seen := map[string]struct{}{}
+	var secrets []string
+	for _, toolID := range manifestToolNames(manifest) {
+		for _, credential := range manifest.Tools[toolID].Credentials {
+			credential = strings.TrimSpace(credential)
+			if credential == "" {
+				continue
+			}
+			if _, exists := seen[credential]; exists {
+				continue
+			}
+			seen[credential] = struct{}{}
+			secrets = append(secrets, credential)
+		}
+	}
+	sort.Strings(secrets)
+	return packs.Requires{Secrets: secrets}
+}
+
+func SourceWithConnectorPackImports(source semanticview.Source) (semanticview.Source, error) {
+	return SourceWithConnectorPackImportsFromRegistry(source, DefaultPackRegistry())
+}
+
+func SourceWithConnectorPackImportsFromRegistry(source semanticview.Source, registry *PackRegistry) (semanticview.Source, error) {
+	if source == nil {
+		return nil, nil
+	}
+	type applied interface {
+		ConnectorPackImportsApplied() bool
+	}
+	if wrapped, ok := source.(applied); ok && wrapped.ConnectorPackImportsApplied() {
+		return source, nil
+	}
+	imports := connectorPackImportsFromSource(source)
+	if len(imports) == 0 {
+		return source, nil
+	}
+	if registry == nil {
+		return nil, fmt.Errorf("provider connector pack registry is required")
+	}
+	existing := existingToolSources(source)
+	importedTools := map[string]runtimecontracts.ToolSchemaEntry{}
+	importSources := map[string]string{}
+	importedByProjectScope := map[string]map[string]runtimecontracts.ToolSchemaEntry{}
+	for _, item := range imports {
+		if item.provider == "" {
+			return nil, fmt.Errorf("provider connector pack import in %s must declare provider", item.source)
+		}
+		if item.toolID == "" {
+			return nil, fmt.Errorf("provider connector pack import in %s must declare tool", item.source)
+		}
+		provider, _, ok := splitToolID(item.toolID)
+		if !ok {
+			return nil, fmt.Errorf("provider connector pack import %s tool %q must use <provider>.<action> id form", item.source, item.toolID)
+		}
+		if provider != item.provider {
+			return nil, fmt.Errorf("provider connector pack import %s tool %q provider %q does not match import provider %q", item.source, item.toolID, provider, item.provider)
+		}
+		pack, found := registry.Lookup(item.provider, item.toolID)
+		if !found {
+			return nil, fmt.Errorf("provider connector pack import %s references unknown tool %q for provider %q", item.source, item.toolID, item.provider)
+		}
+		if existingSources := existing[item.toolID]; len(existingSources) > 0 {
+			return nil, fmt.Errorf("provider connector tool %q collision between connector pack import %s and %s; remove one, or rename the flow-local tool", item.toolID, item.source, strings.Join(existingSources, ", "))
+		}
+		if prior, exists := importSources[item.toolID]; exists {
+			return nil, fmt.Errorf("provider connector tool %q collision between connector pack imports %s and %s; remove one import", item.toolID, prior, item.source)
+		}
+		tool := pack.Manifest.Tools[item.toolID]
+		importedTools[item.toolID] = tool
+		importSources[item.toolID] = item.source
+		if importedByProjectScope[item.projectScopeKey] == nil {
+			importedByProjectScope[item.projectScopeKey] = map[string]runtimecontracts.ToolSchemaEntry{}
+		}
+		importedByProjectScope[item.projectScopeKey][item.toolID] = tool
+	}
+	return connectorPackSource{
+		Source:                 source,
+		importedTools:          importedTools,
+		importedByProjectScope: importedByProjectScope,
+	}, nil
+}
+
+type connectorPackImport struct {
+	provider        string
+	toolID          string
+	projectScopeKey string
+	source          string
+}
+
+func connectorPackImportsFromSource(source semanticview.Source) []connectorPackImport {
+	var out []connectorPackImport
+	for _, scope := range source.ProjectScopes() {
+		scopeKey := strings.TrimSpace(scope.Key)
+		sourceName := projectScopeSourceName(scope)
+		for _, item := range scope.Manifest.ConnectorPacks.Imports {
+			provider := normalizeToken(item.Provider)
+			toolID := strings.TrimSpace(item.Tool)
+			if provider == "" && toolID == "" {
+				continue
+			}
+			out = append(out, connectorPackImport{
+				provider:        provider,
+				toolID:          toolID,
+				projectScopeKey: scopeKey,
+				source:          sourceName + " connector_packs.imports",
+			})
+		}
+	}
+	return out
+}
+
+type connectorPackSource struct {
+	semanticview.Source
+	importedTools          map[string]runtimecontracts.ToolSchemaEntry
+	importedByProjectScope map[string]map[string]runtimecontracts.ToolSchemaEntry
+}
+
+func (s connectorPackSource) BaseSemanticSource() semanticview.Source {
+	return s.Source
+}
+
+func (s connectorPackSource) ConnectorPackImportsApplied() bool {
+	return true
+}
+
+func (s connectorPackSource) ToolEntries() map[string]runtimecontracts.ToolSchemaEntry {
+	out := map[string]runtimecontracts.ToolSchemaEntry{}
+	for key, value := range s.Source.ToolEntries() {
+		out[key] = value
+	}
+	for key, value := range s.importedTools {
+		out[key] = value
+	}
+	return out
+}
+
+func (s connectorPackSource) ProjectScopes() []semanticview.ProjectScope {
+	scopes := s.Source.ProjectScopes()
+	out := make([]semanticview.ProjectScope, 0, len(scopes))
+	for _, scope := range scopes {
+		scope.Tools = cloneToolMap(scope.Tools)
+		for toolID, tool := range s.importedByProjectScope[strings.TrimSpace(scope.Key)] {
+			scope.Tools[toolID] = tool
+		}
+		out = append(out, scope)
+	}
+	return out
+}
+
+func (s connectorPackSource) ToolEntryForAgent(agentID, toolID string) (runtimecontracts.ToolSchemaEntry, bool) {
+	if tool, ok := s.Source.ToolEntryForAgent(agentID, toolID); ok {
+		return tool, true
+	}
+	tool, ok := s.importedTools[strings.TrimSpace(toolID)]
+	return tool, ok
+}
+
+func existingToolSources(source semanticview.Source) map[string][]string {
+	out := map[string][]string{}
+	for _, scope := range source.ProjectScopes() {
+		sourceName := projectScopeSourceName(scope)
+		for toolID := range scope.Tools {
+			toolID = strings.TrimSpace(toolID)
+			if toolID != "" {
+				out[toolID] = appendIfMissing(out[toolID], sourceName)
+			}
+		}
+	}
+	for _, scope := range source.FlowScopes() {
+		sourceName := flowScopeSourceName(scope)
+		for toolID := range scope.Tools {
+			toolID = strings.TrimSpace(toolID)
+			if toolID != "" {
+				out[toolID] = appendIfMissing(out[toolID], sourceName)
+			}
+		}
+	}
+	for toolID := range source.ToolEntries() {
+		toolID = strings.TrimSpace(toolID)
+		if toolID == "" {
+			continue
+		}
+		if _, exists := out[toolID]; exists {
+			continue
+		}
+		out[toolID] = []string{"merged tool source"}
+	}
+	for key := range out {
+		sort.Strings(out[key])
+	}
+	return out
+}
+
+func manifestToolNames(manifest ConnectorManifest) []string {
+	names := make([]string, 0, len(manifest.Tools))
+	for name := range manifest.Tools {
+		name = strings.TrimSpace(name)
+		if name != "" {
+			names = append(names, name)
+		}
+	}
+	sort.Strings(names)
+	return names
+}
+
+func cloneToolMap(in map[string]runtimecontracts.ToolSchemaEntry) map[string]runtimecontracts.ToolSchemaEntry {
+	out := map[string]runtimecontracts.ToolSchemaEntry{}
+	for key, value := range in {
+		out[key] = value
+	}
+	return out
+}
+
+func projectScopeSourceName(scope semanticview.ProjectScope) string {
+	key := strings.TrimSpace(scope.Key)
+	if key == "" {
+		key = "."
+	}
+	return "package " + key
+}
+
+func flowScopeSourceName(scope semanticview.FlowScope) string {
+	id := strings.TrimSpace(scope.ID)
+	if id == "" {
+		id = strings.TrimSpace(scope.Path)
+	}
+	if id == "" {
+		id = strings.TrimSpace(scope.PackageKey)
+	}
+	if id == "" {
+		id = "unknown"
+	}
+	return "flow " + id
+}
+
+func appendIfMissing(values []string, value string) []string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return values
+	}
+	for _, existing := range values {
+		if existing == value {
+			return values
+		}
+	}
+	return append(values, value)
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if value = strings.TrimSpace(value); value != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func joinValidationErrors(errs []error) string {
+	parts := make([]string, 0, len(errs))
+	for _, err := range errs {
+		if err == nil {
+			continue
+		}
+		parts = append(parts, strings.TrimSpace(err.Error()))
+	}
+	sort.Strings(parts)
+	return strings.Join(parts, "; ")
+}

--- a/internal/providerconnectors/packs/telegram/connector.yaml
+++ b/internal/providerconnectors/packs/telegram/connector.yaml
@@ -1,0 +1,27 @@
+provider: telegram
+tools:
+  telegram.send_message:
+    category: provider_connector
+    description: send Telegram messages
+    handler_type: http
+    effect_class: non_idempotent_write
+    credentials:
+      - telegram_bot_token
+    input_schema:
+      type: object
+      properties:
+        chat_id:
+          type: string
+        text:
+          type: string
+      required:
+        - chat_id
+        - text
+    output_schema:
+      type: object
+    http:
+      method: POST
+      url: https://api.telegram.org/bot{{credentials.telegram_bot_token}}/sendMessage
+      body:
+        chat_id: "{{input.chat_id}}"
+        text: "{{input.text}}"

--- a/internal/providerconnectors/packs/telegram/pack.yaml
+++ b/internal/providerconnectors/packs/telegram/pack.yaml
@@ -1,0 +1,22 @@
+id: provider.telegram.connector
+version: 0.1.0
+platform_version: ">=0.7.0 <0.8.0"
+type: connector
+manifest_hash: sha256:f983e4df5b934a2322781aac992179b3d520c416e41e70e1963ee29a5bf08026
+provenance:
+  source: platform
+capabilities:
+  can:
+    call_provider_action: telegram.send_message
+    lower_through_activity: true
+    journal_activity_attempts: true
+  cannot:
+    - bypass activity_attempts
+    - retry non_idempotent_write automatically
+    - expose credential values
+requires:
+  secrets:
+    - telegram_bot_token
+tests:
+  - providerconnectors/telegram_pack
+  - runtime/telegram_connector_supported_surface

--- a/internal/providerconnectors/providerconnectors_test.go
+++ b/internal/providerconnectors/providerconnectors_test.go
@@ -2,9 +2,13 @@ package providerconnectors
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"io/fs"
 	"path/filepath"
 	"strings"
 	"testing"
+	"testing/fstest"
 
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
 	runtimecredentials "github.com/division-sh/swarm/internal/runtime/credentials"
@@ -176,6 +180,171 @@ func TestSurfacesResolveImportedFlowCredentialBindings(t *testing.T) {
 	}
 }
 
+func TestDefaultPackRegistryLoadsTelegramFromVerifiedPlatformPack(t *testing.T) {
+	tool, ok := BuiltinTool("telegram", "telegram.send_message")
+	if !ok {
+		t.Fatal("BuiltinTool telegram.send_message not found")
+	}
+	if !isProviderConnector(tool) {
+		t.Fatalf("builtin telegram tool category = %q, want %q", tool.Category, Category)
+	}
+	if strings.Contains(tool.HTTP.URL, "provider-secret") {
+		t.Fatal("builtin telegram tool leaked a concrete credential value")
+	}
+}
+
+func TestProviderConnectorPackVerificationFailsClosed(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(t *testing.T, files fstest.MapFS)
+		want   string
+	}{
+		{
+			name: "platform pack bad exact byte hash",
+			mutate: func(t *testing.T, files fstest.MapFS) {
+				files["connector.yaml"].Data = append(files["connector.yaml"].Data, '\n')
+			},
+			want: "manifest_hash mismatch",
+		},
+		{
+			name: "unknown connector manifest field",
+			mutate: func(t *testing.T, files fstest.MapFS) {
+				files["connector.yaml"].Data = append(files["connector.yaml"].Data, []byte("unexpected: true\n")...)
+				rewriteConnectorPackHash(t, files)
+			},
+			want: "field unexpected not found",
+		},
+		{
+			name: "capability declaration drift",
+			mutate: func(t *testing.T, files fstest.MapFS) {
+				replaceConnectorPackFile(t, files, "pack.yaml", "call_provider_action: telegram.send_message", "call_provider_action: telegram.other")
+			},
+			want: "capabilities do not match",
+		},
+		{
+			name: "requires declaration drift",
+			mutate: func(t *testing.T, files fstest.MapFS) {
+				replaceConnectorPackFile(t, files, "pack.yaml", "telegram_bot_token", "other_token")
+			},
+			want: "requires do not match",
+		},
+		{
+			name: "unknown envelope field",
+			mutate: func(t *testing.T, files fstest.MapFS) {
+				files["pack.yaml"].Data = append(files["pack.yaml"].Data, []byte("unexpected: true\n")...)
+			},
+			want: "field unexpected not found",
+		},
+		{
+			name: "missing tests metadata",
+			mutate: func(t *testing.T, files fstest.MapFS) {
+				replaceConnectorPackFile(t, files, "pack.yaml", "tests:\n  - providerconnectors/telegram_pack\n  - runtime/telegram_connector_supported_surface\n", "tests: []\n")
+			},
+			want: "tests are required",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			files := connectorPackTestFS(t, "telegram")
+			tc.mutate(t, files)
+			_, err := LoadPackFS(files, ".", "0.7.0")
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("LoadPackFS error = %v, want containing %q", err, tc.want)
+			}
+		})
+	}
+}
+
+func TestConnectorPackImportRequiresExplicitEnableAndReportsSurface(t *testing.T) {
+	ambient := providerConnectorScopedSource{
+		Source:        semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{}),
+		projectScopes: []semanticview.ProjectScope{{Key: "."}},
+	}
+	ambientSource, err := SourceWithConnectorPackImports(ambient)
+	if err != nil {
+		t.Fatalf("SourceWithConnectorPackImports ambient: %v", err)
+	}
+	if _, exists := ambientSource.ToolEntries()["telegram.send_message"]; exists {
+		t.Fatal("ambient source exposed telegram.send_message without explicit import")
+	}
+
+	explicit := providerConnectorScopedSource{
+		Source: semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{}),
+		projectScopes: []semanticview.ProjectScope{
+			projectScopeWithConnectorPackImport(".", "telegram", "telegram.send_message"),
+		},
+	}
+	source, err := SourceWithConnectorPackImports(explicit)
+	if err != nil {
+		t.Fatalf("SourceWithConnectorPackImports explicit: %v", err)
+	}
+	tool, exists := source.ToolEntries()["telegram.send_message"]
+	if !exists {
+		t.Fatal("explicit import did not expose telegram.send_message")
+	}
+	if tool.Category != Category {
+		t.Fatalf("imported tool category = %q, want %q", tool.Category, Category)
+	}
+	if errs := ValidateSource(source); len(errs) != 0 {
+		t.Fatalf("ValidateSource imported connector errors = %#v", errs)
+	}
+	surfaces, err := Surfaces(context.Background(), source, nil)
+	if err != nil {
+		t.Fatalf("Surfaces: %v", err)
+	}
+	if len(surfaces) != 1 || surfaces[0].ToolID != "telegram.send_message" {
+		t.Fatalf("surfaces = %#v, want telegram.send_message", surfaces)
+	}
+	if len(surfaces[0].Requires) != 1 || surfaces[0].Requires[0].Name != "telegram_bot_token" || surfaces[0].Requires[0].Bound {
+		t.Fatalf("surface requirements = %#v, want unbound telegram_bot_token", surfaces[0].Requires)
+	}
+}
+
+func TestConnectorPackImportRejectsCollisionsAndNamesSources(t *testing.T) {
+	source := providerConnectorScopedSource{
+		Source: semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
+			Tools: map[string]runtimecontracts.ToolSchemaEntry{
+				"telegram.send_message": telegramConnectorTool("https://api.telegram.org"),
+			},
+		}),
+		projectScopes: []semanticview.ProjectScope{
+			projectScopeWithConnectorPackImport(".", "telegram", "telegram.send_message"),
+		},
+	}
+
+	_, err := SourceWithConnectorPackImports(source)
+	if err == nil {
+		t.Fatal("SourceWithConnectorPackImports succeeded, want collision")
+	}
+	for _, want := range []string{`provider connector tool "telegram.send_message" collision`, "package . connector_packs.imports", "merged tool source", "remove one"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("collision error = %q, want containing %q", err.Error(), want)
+		}
+	}
+}
+
+func TestValidateSourceRejectsDirectAgentExposureOfImportedProviderConnector(t *testing.T) {
+	source, err := SourceWithConnectorPackImports(providerConnectorScopedSource{
+		Source: semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
+			Agents: map[string]runtimecontracts.AgentRegistryEntry{
+				"sender": {ID: "sender", Tools: []string{"telegram.send_message"}},
+			},
+		}),
+		projectScopes: []semanticview.ProjectScope{
+			projectScopeWithConnectorPackImport(".", "telegram", "telegram.send_message"),
+		},
+	})
+	if err != nil {
+		t.Fatalf("SourceWithConnectorPackImports: %v", err)
+	}
+	errs := ValidateSource(source)
+	joined := joinErrors(errs)
+	if !strings.Contains(joined, `agent "sender" must not expose provider connector tool "telegram.send_message" directly`) {
+		t.Fatalf("ValidateSource errors = %q, want imported direct exposure rejection", joined)
+	}
+}
+
 type providerConnectorScopedSource struct {
 	semanticview.Source
 	projectScopes []semanticview.ProjectScope
@@ -225,6 +394,48 @@ func telegramConnectorTool(baseURL string) runtimecontracts.ToolSchemaEntry {
 			},
 		},
 	}
+}
+
+func projectScopeWithConnectorPackImport(key, provider, tool string) semanticview.ProjectScope {
+	return semanticview.ProjectScope{
+		Key: key,
+		Manifest: runtimecontracts.ProjectPackageDocument{
+			ConnectorPacks: runtimecontracts.ConnectorPackImports{
+				Imports: []runtimecontracts.ConnectorPackImport{{Provider: provider, Tool: tool}},
+			},
+		},
+	}
+}
+
+func connectorPackTestFS(t *testing.T, provider string) fstest.MapFS {
+	t.Helper()
+	out := fstest.MapFS{}
+	for _, file := range []string{"pack.yaml", "connector.yaml"} {
+		body, err := fs.ReadFile(builtinConnectorPackFS, "packs/"+provider+"/"+file)
+		if err != nil {
+			t.Fatalf("read builtin connector pack file %s/%s: %v", provider, file, err)
+		}
+		out[file] = &fstest.MapFile{Data: append([]byte(nil), body...)}
+	}
+	return out
+}
+
+func rewriteConnectorPackHash(t *testing.T, files fstest.MapFS) {
+	t.Helper()
+	sum := sha256.Sum256(files["connector.yaml"].Data)
+	hash := "sha256:" + hex.EncodeToString(sum[:])
+	replaceConnectorPackFile(t, files, "pack.yaml", "manifest_hash: sha256:f983e4df5b934a2322781aac992179b3d520c416e41e70e1963ee29a5bf08026", "manifest_hash: "+hash)
+}
+
+func replaceConnectorPackFile(t *testing.T, files fstest.MapFS, name, old, new string) {
+	t.Helper()
+	file := files[name]
+	body := string(file.Data)
+	if !strings.Contains(body, old) {
+		t.Fatalf("%s missing %q", name, old)
+	}
+	body = strings.Replace(body, old, new, 1)
+	file.Data = []byte(body)
 }
 
 func joinErrors(errs []error) string {

--- a/internal/runtime/contracts/workflow_contract_connector_packs_test.go
+++ b/internal/runtime/contracts/workflow_contract_connector_packs_test.go
@@ -1,0 +1,41 @@
+package contracts
+
+import (
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestProjectPackageDocumentConnectorPacksStrictDecode(t *testing.T) {
+	var doc ProjectPackageDocument
+	if err := yaml.Unmarshal([]byte(`
+name: demo
+connector_packs:
+  imports:
+    - provider: telegram
+      tool: telegram.send_message
+`), &doc); err != nil {
+		t.Fatalf("Unmarshal connector_packs: %v", err)
+	}
+	if len(doc.ConnectorPacks.Imports) != 1 {
+		t.Fatalf("imports = %#v, want one", doc.ConnectorPacks.Imports)
+	}
+	got := doc.ConnectorPacks.Imports[0]
+	if got.Provider != "telegram" || got.Tool != "telegram.send_message" {
+		t.Fatalf("import = %#v, want normalized telegram.send_message", got)
+	}
+
+	var invalid ProjectPackageDocument
+	err := yaml.Unmarshal([]byte(`
+name: demo
+connector_packs:
+  imports:
+    - provider: telegram
+      tool: telegram.send_message
+      shadow: true
+`), &invalid)
+	if err == nil || !strings.Contains(err.Error(), `connector_packs.imports field "shadow" not in platform spec`) {
+		t.Fatalf("Unmarshal invalid connector_packs error = %v, want strict field failure", err)
+	}
+}

--- a/internal/runtime/contracts/workflow_contract_types.go
+++ b/internal/runtime/contracts/workflow_contract_types.go
@@ -978,8 +978,18 @@ type ProjectPackageDocument struct {
 	Children        []ProjectPackageRef  `yaml:"children"`
 	Subpackages     []ProjectPackageRef  `yaml:"subpackages"`
 	Connect         []FlowPackageConnect `yaml:"connect"`
+	ConnectorPacks  ConnectorPackImports `yaml:"connector_packs"`
 	Handoffs        []ProjectHandoff     `yaml:"handoffs"`
 	EntitySchema    EntitySchema         `yaml:"entity_schema"`
+}
+
+type ConnectorPackImports struct {
+	Imports []ConnectorPackImport `yaml:"imports"`
+}
+
+type ConnectorPackImport struct {
+	Provider string `yaml:"provider"`
+	Tool     string `yaml:"tool"`
 }
 
 type TypeCatalogDocument struct {

--- a/internal/runtime/contracts/workflow_contract_yaml_wave1.go
+++ b/internal/runtime/contracts/workflow_contract_yaml_wave1.go
@@ -33,6 +33,7 @@ var projectPackageDocumentFields = map[string]struct{}{
 	"children":         {},
 	"subpackages":      {},
 	"connect":          {},
+	"connector_packs":  {},
 	"handoffs":         {},
 }
 
@@ -58,6 +59,7 @@ func (p *ProjectPackageDocument) UnmarshalYAML(node *yaml.Node) error {
 		Children        []ProjectPackageRef  `yaml:"children"`
 		Subpackages     []ProjectPackageRef  `yaml:"subpackages"`
 		Connect         []FlowPackageConnect `yaml:"connect"`
+		ConnectorPacks  ConnectorPackImports `yaml:"connector_packs"`
 		Handoffs        []ProjectHandoff     `yaml:"handoffs"`
 	}
 	if err := node.Decode(&aux); err != nil {
@@ -95,6 +97,7 @@ func (p *ProjectPackageDocument) UnmarshalYAML(node *yaml.Node) error {
 		Children:        append([]ProjectPackageRef(nil), aux.Children...),
 		Subpackages:     append([]ProjectPackageRef(nil), aux.Subpackages...),
 		Connect:         cloneFlowPackageConnects(aux.Connect),
+		ConnectorPacks:  aux.ConnectorPacks.normalized(),
 		Handoffs:        append([]ProjectHandoff(nil), aux.Handoffs...),
 	}
 	return nil
@@ -224,6 +227,96 @@ func (b *FlowPackageBind) UnmarshalYAML(node *yaml.Node) error {
 	}
 	*b = out.normalized()
 	return nil
+}
+
+func (c *ConnectorPackImports) UnmarshalYAML(node *yaml.Node) error {
+	if c == nil {
+		return nil
+	}
+	if node == nil || node.Kind == 0 {
+		*c = ConnectorPackImports{}
+		return nil
+	}
+	if node.Kind != yaml.MappingNode {
+		return fmt.Errorf("connector_packs must be a mapping")
+	}
+	var out ConnectorPackImports
+	for i := 0; i+1 < len(node.Content); i += 2 {
+		key := strings.TrimSpace(node.Content[i].Value)
+		value := node.Content[i+1]
+		switch key {
+		case "":
+			continue
+		case "imports":
+			if err := value.Decode(&out.Imports); err != nil {
+				return fmt.Errorf("connector_packs.imports: %w", err)
+			}
+		default:
+			return fmt.Errorf("UNDEFINED-FIELD: connector_packs field %q not in platform spec", key)
+		}
+	}
+	*c = out.normalized()
+	return nil
+}
+
+func (i *ConnectorPackImport) UnmarshalYAML(node *yaml.Node) error {
+	if i == nil {
+		return nil
+	}
+	if node == nil || node.Kind == 0 {
+		*i = ConnectorPackImport{}
+		return nil
+	}
+	if node.Kind != yaml.MappingNode {
+		return fmt.Errorf("connector_packs.imports entries must be mappings")
+	}
+	var out ConnectorPackImport
+	for j := 0; j+1 < len(node.Content); j += 2 {
+		key := strings.TrimSpace(node.Content[j].Value)
+		value := node.Content[j+1]
+		switch key {
+		case "":
+			continue
+		case "provider":
+			if err := value.Decode(&out.Provider); err != nil {
+				return fmt.Errorf("provider: %w", err)
+			}
+		case "tool":
+			if err := value.Decode(&out.Tool); err != nil {
+				return fmt.Errorf("tool: %w", err)
+			}
+		default:
+			return fmt.Errorf("UNDEFINED-FIELD: connector_packs.imports field %q not in platform spec", key)
+		}
+	}
+	*i = out.normalized()
+	return nil
+}
+
+func (c ConnectorPackImports) normalized() ConnectorPackImports {
+	out := ConnectorPackImports{Imports: make([]ConnectorPackImport, 0, len(c.Imports))}
+	for _, item := range c.Imports {
+		item = item.normalized()
+		if item.Provider == "" && item.Tool == "" {
+			continue
+		}
+		out.Imports = append(out.Imports, item)
+	}
+	return out
+}
+
+func (i ConnectorPackImport) normalized() ConnectorPackImport {
+	return ConnectorPackImport{
+		Provider: normalizeConnectorPackToken(i.Provider),
+		Tool:     strings.TrimSpace(i.Tool),
+	}
+}
+
+func normalizeConnectorPackToken(raw string) string {
+	raw = strings.TrimSpace(strings.ToLower(raw))
+	raw = strings.ReplaceAll(raw, "-", "_")
+	raw = strings.ReplaceAll(raw, " ", "_")
+	return strings.Trim(raw, "_")
 }
 
 func (r FlowPackageRequires) normalized() FlowPackageRequires {

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/division-sh/swarm/internal/config"
 	"github.com/division-sh/swarm/internal/events"
+	"github.com/division-sh/swarm/internal/providerconnectors"
 	"github.com/division-sh/swarm/internal/providertriggers"
 	runtimeagents "github.com/division-sh/swarm/internal/runtime/agents"
 	runtimeauthority "github.com/division-sh/swarm/internal/runtime/authority"
@@ -278,6 +279,26 @@ func ensureWorkflowBootWiring(opts RuntimeOptions) error {
 	return nil
 }
 
+type connectorPackWorkflowModule struct {
+	runtimepipeline.WorkflowModule
+	source semanticview.Source
+}
+
+func (m connectorPackWorkflowModule) SemanticSource() semanticview.Source {
+	return m.source
+}
+
+func workflowModuleWithConnectorPacks(module runtimepipeline.WorkflowModule) (runtimepipeline.WorkflowModule, semanticview.Source, error) {
+	if module == nil {
+		return nil, nil, nil
+	}
+	source, err := providerconnectors.SourceWithConnectorPackImports(module.SemanticSource())
+	if err != nil {
+		return nil, nil, err
+	}
+	return connectorPackWorkflowModule{WorkflowModule: module, source: source}, source, nil
+}
+
 func bootWarningsFatal() bool {
 	return runtimeEnvBool("SWARM_BOOT_WARNINGS_FATAL", true)
 }
@@ -326,10 +347,21 @@ func (deps RuntimeDeps) validated() (validatedRuntimeDeps, error) {
 	if blocker := strings.TrimSpace(stores.ConstructionBlocker); blocker != "" {
 		return validatedRuntimeDeps{}, fmt.Errorf("runtime store boundary is not construction-ready: %s", blocker)
 	}
+	var source semanticview.Source
+	if opts.WorkflowModule != nil {
+		workflowModule, wrappedSource, err := workflowModuleWithConnectorPacks(opts.WorkflowModule)
+		if err != nil {
+			return validatedRuntimeDeps{}, fmt.Errorf("provider connector pack import failed: %w", err)
+		}
+		opts.WorkflowModule = workflowModule
+		source = wrappedSource
+	}
 	if err := ensureWorkflowBootWiring(opts); err != nil {
 		return validatedRuntimeDeps{}, fmt.Errorf("workflow contract validation failed: %w", err)
 	}
-	source := opts.WorkflowModule.SemanticSource()
+	if source == nil {
+		source = opts.WorkflowModule.SemanticSource()
+	}
 	if err := validateSelectedBackendModelAliasesForDeclaredAgents(cfg, source); err != nil {
 		return validatedRuntimeDeps{}, fmt.Errorf("llm model alias validation failed: %w", err)
 	}

--- a/internal/runtime/semanticview/bundle_source.go
+++ b/internal/runtime/semanticview/bundle_source.go
@@ -32,6 +32,12 @@ func Bundle(source Source) (*runtimecontracts.WorkflowContractBundle, bool) {
 		}
 		return typed.bundle, true
 	default:
+		type baseSourceProvider interface {
+			BaseSemanticSource() Source
+		}
+		if provider, ok := source.(baseSourceProvider); ok && provider.BaseSemanticSource() != nil {
+			return Bundle(provider.BaseSemanticSource())
+		}
 		return nil, false
 	}
 }

--- a/internal/runtime/telegram_connector_supported_surface_test.go
+++ b/internal/runtime/telegram_connector_supported_surface_test.go
@@ -15,6 +15,8 @@ import (
 
 	"github.com/division-sh/swarm/internal/events"
 	"github.com/division-sh/swarm/internal/events/eventtest"
+	"github.com/division-sh/swarm/internal/packs"
+	"github.com/division-sh/swarm/internal/providerconnectors"
 	runtimepkg "github.com/division-sh/swarm/internal/runtime"
 	runtimebus "github.com/division-sh/swarm/internal/runtime/bus"
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
@@ -135,7 +137,7 @@ func runTelegramConnectorSupportedSurfaceRoundTrip(t *testing.T, backend telegra
 	defer server.Close()
 
 	credentialStore := telegramConnectorSupportedSurfaceCredentialStore(t, "telegram_bot_token", "provider-secret")
-	source := telegramConnectorSupportedSurfaceSource(server.URL)
+	source := telegramConnectorSupportedSurfaceSource(t, server.URL)
 	var pc *runtimepipeline.PipelineCoordinator
 	bus, err := runtimebus.NewEventBusWithOptions(backend.eventStore, runtimebus.EventBusOptions{
 		ContractBundle: source,
@@ -223,7 +225,7 @@ func runTelegramConnectorSupportedSurfaceRoundTrip(t *testing.T, backend telegra
 func assertTelegramConnectorSupportedSurfaceMissingToken(t *testing.T, backend telegramConnectorSupportedSurfaceBackend, baseURL string, calls <-chan telegramConnectorSupportedSurfaceCall) {
 	t.Helper()
 	credentialStore := telegramConnectorSupportedSurfaceCredentialStore(t, "", "")
-	source := telegramConnectorSupportedSurfaceSource(baseURL)
+	source := telegramConnectorSupportedSurfaceSource(t, baseURL)
 	var pc *runtimepipeline.PipelineCoordinator
 	bus, err := runtimebus.NewEventBusWithOptions(backend.eventStore, runtimebus.EventBusOptions{
 		ContractBundle: source,
@@ -261,7 +263,8 @@ func assertTelegramConnectorSupportedSurfaceMissingToken(t *testing.T, backend t
 
 const telegramConnectorSupportedSurfaceNodeID = "telegram-responder"
 
-func telegramConnectorSupportedSurfaceSource(baseURL string) semanticview.Source {
+func telegramConnectorSupportedSurfaceSource(t *testing.T, baseURL string) semanticview.Source {
+	t.Helper()
 	handler := runtimecontracts.SystemNodeEventHandler{
 		Activity: runtimecontracts.ActivitySpec{
 			ID:   "telegram_send_message",
@@ -279,7 +282,7 @@ func telegramConnectorSupportedSurfaceSource(baseURL string) semanticview.Source
 			"inbound.telegram": handler,
 		},
 	}
-	return semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
+	base := semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
 		RootSchema: &runtimecontracts.FlowSchemaDocument{
 			Pins: runtimecontracts.FlowPins{
 				Inputs: runtimecontracts.FlowInputPins{
@@ -289,9 +292,6 @@ func telegramConnectorSupportedSurfaceSource(baseURL string) semanticview.Source
 		},
 		Nodes: map[string]runtimecontracts.SystemNodeContract{
 			telegramConnectorSupportedSurfaceNodeID: node,
-		},
-		Tools: map[string]runtimecontracts.ToolSchemaEntry{
-			"telegram.send_message": telegramConnectorSupportedSurfaceTool(baseURL),
 		},
 		Semantics: runtimecontracts.WorkflowSemanticView{
 			Name:    "telegram_connector_supported_surface",
@@ -313,27 +313,70 @@ func telegramConnectorSupportedSurfaceSource(baseURL string) semanticview.Source
 			},
 		},
 	})
-}
-
-func telegramConnectorSupportedSurfaceTool(baseURL string) runtimecontracts.ToolSchemaEntry {
-	return runtimecontracts.ToolSchemaEntry{
-		Category:    "provider_connector",
-		Description: "send Telegram messages",
-		HandlerType: "http",
-		EffectClass: string(runtimecontracts.ActivityEffectClassNonIdempotentWrite),
-		Credentials: []string{"telegram_bot_token"},
-		OutputSchema: runtimecontracts.ToolInputSchema{
-			Type: "object",
-		},
-		HTTP: &runtimecontracts.HTTPToolSpec{
-			Method: "POST",
-			URL:    strings.TrimRight(baseURL, "/") + "/bot{{credentials.telegram_bot_token}}/sendMessage",
-			Body: map[string]any{
-				"chat_id": "{{input.chat_id}}",
-				"text":    "{{input.text}}",
+	importSource := telegramConnectorSupportedSurfacePackImportSource{
+		Source: base,
+		projectScopes: []semanticview.ProjectScope{
+			{
+				Key: ".",
+				Manifest: runtimecontracts.ProjectPackageDocument{
+					ConnectorPacks: runtimecontracts.ConnectorPackImports{
+						Imports: []runtimecontracts.ConnectorPackImport{{Provider: "telegram", Tool: "telegram.send_message"}},
+					},
+				},
 			},
 		},
 	}
+	source, err := providerconnectors.SourceWithConnectorPackImportsFromRegistry(importSource, telegramConnectorSupportedSurfacePackRegistry(t, baseURL))
+	if err != nil {
+		t.Fatalf("SourceWithConnectorPackImportsFromRegistry: %v", err)
+	}
+	return source
+}
+
+func telegramConnectorSupportedSurfacePackRegistry(t *testing.T, baseURL string) *providerconnectors.PackRegistry {
+	t.Helper()
+	tool, ok := providerconnectors.BuiltinTool("telegram", "telegram.send_message")
+	if !ok {
+		t.Fatal("provider connector pack telegram.send_message not found")
+	}
+	if tool.HTTP == nil {
+		t.Fatal("provider connector pack telegram.send_message missing http block")
+	}
+	httpSpec := *tool.HTTP
+	tool.HTTP = &httpSpec
+	tool.HTTP.URL = strings.TrimRight(baseURL, "/") + "/bot{{credentials.telegram_bot_token}}/sendMessage"
+	registry, err := providerconnectors.NewPackRegistry(providerconnectors.LoadedPack{
+		Envelope: packs.Envelope{
+			ID: "provider.telegram.connector",
+			Provenance: packs.Provenance{
+				Source: packs.ProvenancePlatform,
+			},
+		},
+		Manifest: providerconnectors.ConnectorManifest{
+			Provider: "telegram",
+			Tools: map[string]runtimecontracts.ToolSchemaEntry{
+				"telegram.send_message": tool,
+			},
+		},
+		Source: "test:provider.telegram.connector",
+	})
+	if err != nil {
+		t.Fatalf("NewPackRegistry: %v", err)
+	}
+	return registry
+}
+
+type telegramConnectorSupportedSurfacePackImportSource struct {
+	semanticview.Source
+	projectScopes []semanticview.ProjectScope
+}
+
+func (s telegramConnectorSupportedSurfacePackImportSource) BaseSemanticSource() semanticview.Source {
+	return s.Source
+}
+
+func (s telegramConnectorSupportedSurfacePackImportSource) ProjectScopes() []semanticview.ProjectScope {
+	return append([]semanticview.ProjectScope(nil), s.projectScopes...)
 }
 
 type telegramConnectorSupportedSurfaceModule struct {

--- a/internal/runtime/workflow_validation.go
+++ b/internal/runtime/workflow_validation.go
@@ -56,6 +56,11 @@ func ValidateWorkflowContractSurface(ctx context.Context, source semanticview.So
 	if source == nil {
 		return result, fmt.Errorf("semantic source is required")
 	}
+	var err error
+	source, err = providerconnectors.SourceWithConnectorPackImports(source)
+	if err != nil {
+		return result, fmt.Errorf("provider connector pack import failed: %w", err)
+	}
 
 	result.BootReport = runtimebootverify.Run(ctx, source, runtimebootverify.Options{
 		Credentials:             opts.Credentials,

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -6332,12 +6332,15 @@ tool_model:
       \ \"{{response.body.status[0].summary}}\"\n  credentials:\n    - domainr_api_key"
   provider_connector_tools:
     description: >
-      Stage 1 flow-local outbound provider connectors are authored HTTP tools in tools.yaml, marked with
-      `category: provider_connector`, and executed only through handler `activity` requests. The category is a readback and
-      validation profile, not a new runtime dispatcher: dispatch remains owned by the HTTP activity executor and
-      non-idempotent writes remain owned by `activity_attempts`.
+      Outbound provider connectors are authored HTTP tools represented by the existing `ToolSchemaEntry` model with
+      `category: provider_connector`, and executed only through handler `activity` requests. Connector declarations may be
+      flow-local entries in tools.yaml or explicitly imported connector-pack bodies, but both routes must produce the same
+      canonical `ToolSchemaEntry` object. The category is a readback and validation profile, not a new runtime dispatcher:
+      dispatch remains owned by the HTTP activity executor and non-idempotent writes remain owned by `activity_attempts`.
     canonical_owners:
-      declaration: "tools.yaml ToolSchemaEntry with `category: provider_connector`."
+      declaration: "ToolSchemaEntry with `category: provider_connector`, authored in tools.yaml or imported from a verified connector pack."
+      pack_import: "package.yaml `connector_packs.imports[]` enables specific packed connector tools; omitted imports expose nothing."
+      pack_envelope: "internal/packs universal envelope plus internal/providerconnectors connector body verifier."
       execution: "handler `activity` lowering to `platform.activity_requested`."
       non_idempotent_journal: "`activity_attempts`."
       credentials: "static credential store keys listed under tool `credentials`."
@@ -6353,7 +6356,34 @@ tool_model:
       - "`managed_credential`; managed OAuth/token lifecycle is a separate owner."
       - "`response_mapping`; connector response mapping is split until specified."
       - "`rate_limit` and `rate_limit_max_wait`; connector admission/rate limiting is split until specified."
-      - "direct runtime provider adapter code, connector-pack body/envelope execution, or bespoke connector dispatch."
+      - "direct runtime provider adapter code or bespoke connector dispatch."
+    connector_pack_profile:
+      status: "first slice: Telegram connector pack proof"
+      body_file: connector.yaml
+      import_syntax: >
+        package.yaml `connector_packs.imports[]` entries name `provider` and `tool`. The import is an explicit enablement
+        gate: packed connectors MUST NOT become ambient global tools and MUST NOT appear in tool readback, activity
+        validation, agent surfaces, or execution unless imported.
+      body_rule: >
+        The connector body wraps/carries real `ToolSchemaEntry` values. The body MUST NOT define a second connector DSL,
+        second validator, second execution model, or provider-specific Go adapter path.
+      verification_rule: >
+        The envelope hash is over the exact connector.yaml bytes. The loader parses the envelope with strict known fields,
+        verifies the exact byte hash, parses connector.yaml through the normal tool schema owner, validates the
+        provider_connector profile, derives connector capabilities/requires mechanically from the tool declaration, and
+        rejects any declared capability or requirement drift.
+      capability_surface: >
+        Connector pack CAN/CANNOT/BOUND/UNBOUND readback is kind-specific. Connector CAN rows include calling the declared
+        provider action, lowering through `platform.activity_requested`, and journaling non-idempotent attempts in
+        `activity_attempts`. Connector CANNOT rows include bypassing `activity_attempts`, automatically retrying
+        non-idempotent writes, or exposing credential values.
+      collision_policy: >
+        No packed-vs-packed or packed-vs-flow-local connector shadowing is allowed in this slice. Any duplicate tool id
+        fails closed before runtime construction and names both sources with remediation to remove one source or rename the
+        flow-local tool.
+      unbound_requirement_policy: >
+        Pack import may succeed with an unbound credential name. Runtime activity dispatch must fail closed before the
+        provider HTTP call and before creating an `activity_attempts` row when a required static credential is unavailable.
   credential_store:
     description: Secure storage for API keys, tokens, and other credentials referenced by MCP servers and HTTP tools. The
       platform provides a typed interface with a layered resolution model.
@@ -6542,14 +6572,16 @@ tool_model:
       A selected configured provider must consume a provider-trigger manifest for signing, replay checks, delivery-id
       extraction, event-type extraction, event naming, acknowledgement timing, and redaction.
     pack_envelope_source_authority:
-      owner: internal/packs universal envelope plus internal/providertriggers trigger body verifier
+      owner: internal/packs universal envelope plus body-specific verifiers such as internal/providertriggers and internal/providerconnectors
       status: >
-        E5 source-authority path. Provider-trigger packs wrap the frozen provider-trigger manifest vocabulary in a
-        universal pack envelope before registration. The envelope is a trust/admission artifact, not a provider-specific
-        adapter and not a new provider-trigger vocabulary owner. First-party configured-provider manifests are platform
-        packs, not embed-only trust fixtures. Runtime config declares external provider-trigger pack directories at
+        E5 source-authority path. Provider-trigger packs and provider-connector packs wrap their body-specific canonical
+        vocabulary in a universal pack envelope before registration/import. The envelope is a trust/admission artifact, not
+        a provider-specific adapter and not a new body vocabulary owner. First-party configured-provider manifests are
+        platform packs, not embed-only trust fixtures. Runtime config declares external provider-trigger pack directories at
         `provider_triggers.packs.external_dirs`; `swarm serve` resolves those directories at boot and fails closed before
-        runtime construction if any declared pack cannot be verified.
+        runtime construction if any declared pack cannot be verified. Connector packs in this first slice are built-in
+        platform packs explicitly imported by package.yaml `connector_packs.imports[]`; external connector-pack directories
+        require a later gated surface.
       envelope_fields:
         id: >
           Required stable pack identity. Values must be normalized ASCII identifiers and must not be inferred from directory
@@ -6559,10 +6591,10 @@ tool_model:
           Required compatibility range checked with the same platform-version constraint grammar used by package admission.
           Missing, malformed, or incompatible ranges fail pack import before provider registration.
         type: >
-          Required pack body type. The first supported body type is `trigger`; other pack body types require their own
+          Required pack body type. Supported body types are `trigger` and `connector`. New body types require their own
           gated proof cases.
         manifest_hash: >
-          Required SHA-256 hash of the exact trigger manifest bytes carried by the pack, formatted as `sha256:<hex>`.
+          Required SHA-256 hash of the exact body manifest bytes carried by the pack, formatted as `sha256:<hex>`.
           Implementations MUST NOT hash re-serialized YAML or semantic object forms because those are not stable contract
           bytes.
         provenance: >
@@ -6570,7 +6602,7 @@ tool_model:
           review/readback classification but does not create verification shortcuts.
         capabilities: >
           Required declared capability surface. The loader derives canonical capabilities mechanically from the accepted
-          trigger manifest and requires the declared block to equal the derived block in canonical form. Drift, extra
+          body manifest and requires the declared block to equal the derived block in canonical form. Drift, extra
           capabilities, missing capabilities, or narrative/manual capability truth fail import.
         requires: >
           Required dependency declaration surface for resources such as `webhook_signing.<provider>`. Declared requirements
@@ -6583,13 +6615,13 @@ tool_model:
       - read declared external pack directories from `provider_triggers.packs.external_dirs`
       - parse envelope with strict known fields
       - validate id/version/platform_version/type/provenance/tests metadata
-      - read trigger manifest bytes
-      - verify manifest_hash against exact trigger manifest bytes
-      - parse and validate trigger manifest through `internal/providertriggers`
-      - derive trigger capabilities and requires mechanically from the manifest
+      - read body manifest bytes selected by pack type, such as trigger.yaml or connector.yaml
+      - verify manifest_hash against exact body manifest bytes
+      - parse and validate the body manifest through the matching body-specific owner
+      - derive body capabilities and requires mechanically from the manifest
       - compare declared capabilities/requires to derived values
-      - reject provider-name collisions across first-party packs and external packs
-      - register only verified trigger manifests
+      - reject provider-name/tool-name collisions according to the body-specific collision rule
+      - register/import only verified body manifests
       trust_tiers: >
         Trust tiers differ by provenance value and by readback/operational policy only. First-party bundled packs and
         future external packs use the identical verifier path. No pack is trusted merely because the platform ships it.
@@ -6604,6 +6636,8 @@ tool_model:
         undeclared events, or touch unbound resources. Requirement readback marks each declared secret as BOUND or UNBOUND
         without exposing secret values. `swarm doctor` is the first operator surface for this readback and renders the same
         verified first-party and declared external provider-trigger pack capability surface that serve admits at boot.
+        Connector-pack readback uses connector-specific CAN/CANNOT rows defined by `tool_model.provider_connector_tools`;
+        trigger rows MUST NOT be reused to describe connector proof.
       unbound_requirement_policy: >
         A missing deployment binding for a declared signing secret does not reject pack import. Runtime webhook admission
         still fails closed before signature verification, dedupe marker persistence, or event publish when a required
@@ -7491,6 +7525,7 @@ flow_model:
         - children
         - subpackages
         - connect
+        - connector_packs
         - handoffs
         retired_fields:
           entity_schema: >
@@ -7518,6 +7553,12 @@ flow_model:
           Optional downstream metadata map. Keys MUST be namespaced as domain.tld/name and values MUST be strings.
           Swarm stores and projects this map for catalog/read-model consumers but does not interpret its values for
           runtime semantics.
+        connector_packs: >
+          Optional explicit provider-connector pack imports. The first supported shape is
+          `connector_packs.imports[]` with required `provider` and `tool` fields. Each imported tool must resolve to a
+          verified built-in connector pack, must produce a normal `ToolSchemaEntry` with `category: provider_connector`,
+          and must fail closed on unknown fields, unknown providers/tools, provider/tool mismatch, or collision with any
+          packed or flow-local tool id. Omission imports no connector tools.
       catalog_consumption:
         owner: bundle catalog projection
         rule: >


### PR DESCRIPTION
## Summary

Closes #1855.
Part of #1837.

This adds the first outbound connector pack proof by making a verified connector pack import a normal `ToolSchemaEntry` into the same provider connector source model used by `tools.yaml`. The Telegram connector is now pack data loaded through `internal/packs` + `internal/providerconnectors`; there is no second connector DSL, runtime dispatcher, provider adapter, or ambient global tool exposure.

## Governing Refs / Context

- `platform-spec.yaml`: `tool_model.provider_connector_tools`
- `platform-spec.yaml`: `tool_model.provider_trigger_adapters.pack_envelope_source_authority`
- `platform-spec.yaml`: `flow_model.flow_package.manifest_self_facts.fields.connector_packs`
- Binding issue/gate context: #1855 design lock and approved pre-implementation gate comment.

## Semantic Migration

- New canonical owner: `ToolSchemaEntry` with `category: provider_connector`, consumed by `internal/providerconnectors` validation/readback and existing activity lowering/execution.
- New pack authority: `internal/packs` owns the universal envelope/hash/type checks; `internal/providerconnectors` owns connector body verification, derived capabilities/requires equality, and explicit import into the semantic source.
- Old producer/reader/writer path now invalid: concrete outbound connector semantics must not live as provider-specific Go adapters, a second pack-side connector model, ambient packed tools, or concrete provider sections in the platform spec.
- Production paths checked for surviving old behavior: workflow validation, runtime boot source wrapping, provider connector preflight/readback, activity execution/journaling, prompt resolver bundle unwrap, provider trigger pack regression, and direct-agent connector exposure rejection.
- Migration completeness: complete for the #1855 first connector-pack proof class. Parent #1837 remains open for external connector pack directories/provenance, broader provider corpus, OAuth/managed credentials, response mapping/rate limits, and the pre-existing hardcoded mailbox Telegram notifier reconciliation.

## Validation

- `go test ./internal/packs ./internal/providerconnectors ./internal/providertriggers ./internal/runtime/contracts ./internal/runtime ./cmd/swarm -run 'TestProviderConnector|TestConnectorPack|TestDefaultPackRegistry|TestProjectPackageDocumentConnectorPacksStrictDecode|TestTelegramConnectorSupportedSurfaceRoundTripThroughInboundGateway|TestProviderTriggerPack' -count=1`
- `SWARM_TEST_POSTGRES_DSN='host=127.0.0.1 port=5432 user=youmew dbname=postgres sslmode=disable' PGPASSWORD=postgres go test ./internal/runtime -run TestTelegramConnectorSupportedSurfaceRoundTripThroughInboundGateway -count=1`
- `SWARM_TEST_POSTGRES_DSN='host=127.0.0.1 port=5432 user=youmew dbname=postgres sslmode=disable' PGPASSWORD=postgres go test ./...`
