### PR TITLE
[agent-c][issue #1845] Add explicit lifecycle stages

### DIFF
--- a/cmd/swarm/describe.go
+++ b/cmd/swarm/describe.go
@@ -16,6 +16,7 @@ type describeCommandOptions struct {
 	contractsPath    string
 	platformSpecPath string
 	configPath       string
+	graph            bool
 	output           cliOutputOptions
 	logging          cliLoggingOptions
 }
@@ -58,6 +59,7 @@ func newDescribeCommand(ctx context.Context, repo string, rootOpts rootCommandOp
 	}
 	cmd.Flags().StringVar(&opts.contractsPath, "contracts", opts.contractsPath, "Path to Swarm contract bundle root")
 	cmd.Flags().StringVar(&opts.platformSpecPath, "platform-spec", opts.platformSpecPath, "Path to platform spec yaml")
+	cmd.Flags().BoolVar(&opts.graph, "graph", opts.graph, "Render the per-flow lifecycle stage graph")
 	bindCLIOutputFlags(cmd, &opts.output)
 	bindCLILoggingFlags(cmd, &opts.logging)
 	return cmd
@@ -111,7 +113,7 @@ func runDescribeCommandWithOutput(ctx context.Context, repo string, opts describ
 	}
 	workspaceBackendDetail := workspaceBackendDecisionDetail(workspaceBackend)
 	report := runtimebootverify.Run(ctx, source, runtimebootverify.Options{})
-	view, err := authoringview.Build(ctx, source, authoringview.BuildOptions{BootReport: &report})
+	view, err := authoringview.Build(ctx, source, authoringview.BuildOptions{BootReport: &report, IncludeStageGraph: opts.graph})
 	if err != nil {
 		if errOut != nil {
 			fmt.Fprintf(errOut, "describe failed: %v\n", err)
@@ -171,6 +173,56 @@ func writeDescribeText(out io.Writer, view authoringview.View, workspaceBackendD
 		fmt.Fprintln(out, "connect route plans:")
 		for _, plan := range view.ConnectRoutePlans {
 			fmt.Fprintf(out, "  - %s.%s -> %s.%s resolution=%s delivery=%s\n", plan.Source.FlowID, plan.Source.Pin, plan.Receiver.FlowID, plan.Receiver.Pin, plan.ResolutionKind, plan.Delivery)
+		}
+	}
+	if len(view.StageGraphs) > 0 {
+		fmt.Fprintln(out, "stage graph:")
+		for _, graph := range view.StageGraphs {
+			label := strings.TrimSpace(graph.FlowID)
+			if label == "" {
+				label = "root"
+			}
+			if strings.TrimSpace(graph.FlowPath) != "" {
+				label += " (" + strings.TrimSpace(graph.FlowPath) + ")"
+			}
+			fmt.Fprintf(out, "  flow %s:\n", label)
+			if len(graph.Nodes) > 0 {
+				fmt.Fprintln(out, "    nodes:")
+				for _, node := range graph.Nodes {
+					markers := make([]string, 0, 2)
+					if node.Initial {
+						markers = append(markers, "initial")
+					}
+					if node.Terminal {
+						markers = append(markers, "terminal")
+					}
+					suffix := ""
+					if len(markers) > 0 {
+						suffix = " [" + strings.Join(markers, ",") + "]"
+					}
+					if strings.TrimSpace(node.Description) != "" {
+						suffix += " - " + strings.TrimSpace(node.Description)
+					}
+					fmt.Fprintf(out, "      - %s%s\n", node.ID, suffix)
+				}
+			}
+			if len(graph.Edges) > 0 {
+				fmt.Fprintln(out, "    edges:")
+				for _, edge := range graph.Edges {
+					from := strings.Join(edge.From, ",")
+					if from == "" {
+						from = "<none>"
+					}
+					detail := strings.TrimSpace(edge.Source)
+					if strings.TrimSpace(edge.NodeID) != "" {
+						detail += " " + strings.TrimSpace(edge.NodeID)
+					}
+					if strings.TrimSpace(edge.EventType) != "" {
+						detail += " on " + strings.TrimSpace(edge.EventType)
+					}
+					fmt.Fprintf(out, "      - %s -> %s (%s)\n", from, edge.To, strings.TrimSpace(detail))
+				}
+			}
 		}
 	}
 	if len(view.Diagnostics) > 0 {

--- a/cmd/swarm/describe_test.go
+++ b/cmd/swarm/describe_test.go
@@ -174,6 +174,81 @@ func TestDescribeCommandJSONRendersRootPrimaryEntity(t *testing.T) {
 	}
 }
 
+func TestDescribeCommandGraphRendersStageGraph(t *testing.T) {
+	contractsRoot := writeDescribeStageGraphContracts(t)
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), repoRoot(), []string{
+		"describe",
+		"--contracts", contractsRoot,
+		"--graph",
+		"--json",
+	}, &stdout, &stderr, defaultRootCommandOptions())
+	if code != 0 {
+		t.Fatalf("describe --graph --json code = %d stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	var output describeCommandOutput
+	if err := json.Unmarshal(stdout.Bytes(), &output); err != nil {
+		t.Fatalf("decode describe graph json: %v\n%s", err, stdout.String())
+	}
+	if len(output.StageGraphs) != 1 {
+		t.Fatalf("stage graphs = %#v, want one support graph", output.StageGraphs)
+	}
+	graph := output.StageGraphs[0]
+	if graph.FlowID != "support" || graph.FlowPath != "support" {
+		t.Fatalf("graph identity = %#v, want support namespace", graph)
+	}
+	if len(graph.Nodes) != 3 {
+		t.Fatalf("graph nodes = %#v, want waiting/active/done", graph.Nodes)
+	}
+	if !graph.Nodes[0].Initial || graph.Nodes[0].ID != "waiting" {
+		t.Fatalf("first graph node = %#v, want waiting initial", graph.Nodes[0])
+	}
+	var terminalDone bool
+	for _, node := range graph.Nodes {
+		if node.ID == "done" && node.Terminal {
+			terminalDone = true
+		}
+	}
+	if !terminalDone {
+		t.Fatalf("graph nodes = %#v, want terminal done", graph.Nodes)
+	}
+	if len(graph.Edges) == 0 {
+		t.Fatalf("graph edges missing: %#v", graph)
+	}
+	var foundOpenedAdvance bool
+	for _, edge := range graph.Edges {
+		if edge.Source == "handler.advances_to" && edge.NodeID == "support-node" && edge.EventType == "ticket.opened" && edge.To == "active" {
+			foundOpenedAdvance = true
+		}
+	}
+	if !foundOpenedAdvance {
+		t.Fatalf("graph edges = %#v, want ticket.opened handler.advances_to edge to active", graph.Edges)
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	code = executeRootCommandWithOptions(context.Background(), repoRoot(), []string{
+		"describe",
+		"--contracts", contractsRoot,
+		"--graph",
+	}, &stdout, &stderr, defaultRootCommandOptions())
+	if code != 0 {
+		t.Fatalf("describe --graph code = %d stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	text := stdout.String()
+	for _, want := range []string{
+		"stage graph:",
+		"flow support (support):",
+		"waiting [initial]",
+		"done [terminal]",
+		"handler.advances_to support-node on ticket.opened",
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("describe --graph output missing %q:\n%s", want, text)
+		}
+	}
+}
+
 func writeDescribeDefaultedTemplatePolicyContracts(t testing.TB) string {
 	t.Helper()
 	root := t.TempDir()
@@ -211,6 +286,61 @@ pins:
 	writeDescribeTestFile(t, filepath.Join(root, "flows", "scoring", "entities.yaml"), `
 account:
   account_id: uuid
+`)
+	return root
+}
+
+func writeDescribeStageGraphContracts(t testing.TB) string {
+	t.Helper()
+	root := t.TempDir()
+	writeDescribeTestFile(t, filepath.Join(root, "package.yaml"), `
+name: stage-graph
+version: "1.0.0"
+platform_version: ">=0.7.0 <0.8.0"
+flows:
+  - id: support
+    flow: support
+`)
+	writeDescribeTestFile(t, filepath.Join(root, "schema.yaml"), "name: stage-graph\n")
+	writeDescribeTestFile(t, filepath.Join(root, "policy.yaml"), "{}\n")
+	writeDescribeTestFile(t, filepath.Join(root, "tools.yaml"), "{}\n")
+	writeDescribeTestFile(t, filepath.Join(root, "agents.yaml"), "{}\n")
+	writeDescribeTestFile(t, filepath.Join(root, "events.yaml"), "{}\n")
+	writeDescribeTestFile(t, filepath.Join(root, "nodes.yaml"), "{}\n")
+	writeDescribeTestFile(t, filepath.Join(root, "flows", "support", "schema.yaml"), `
+name: support
+stages:
+  waiting:
+    initial: true
+  active: {}
+  done:
+    terminal: true
+`)
+	writeDescribeTestFile(t, filepath.Join(root, "flows", "support", "policy.yaml"), "{}\n")
+	writeDescribeTestFile(t, filepath.Join(root, "flows", "support", "tools.yaml"), "{}\n")
+	writeDescribeTestFile(t, filepath.Join(root, "flows", "support", "agents.yaml"), "{}\n")
+	writeDescribeTestFile(t, filepath.Join(root, "flows", "support", "events.yaml"), `
+ticket.opened:
+  entity_id: string
+ticket.closed:
+  entity_id: string
+`)
+	writeDescribeTestFile(t, filepath.Join(root, "flows", "support", "entities.yaml"), `
+ticket: {}
+`)
+	writeDescribeTestFile(t, filepath.Join(root, "flows", "support", "nodes.yaml"), `
+support-node:
+  id: support-node
+  execution_type: system_node
+  subscribes_to:
+    - ticket.opened
+    - ticket.closed
+  event_handlers:
+    ticket.opened:
+      create_entity: true
+      advances_to: active
+    ticket.closed:
+      advances_to: done
 `)
 	return root
 }

--- a/internal/digest/source.go
+++ b/internal/digest/source.go
@@ -21,7 +21,7 @@ func NewSource(db *sql.DB, source semanticview.Source) (*Source, error) {
 	if source == nil {
 		return nil, fmt.Errorf("semantic source is required for digest reads")
 	}
-	return newSource(db, source.WorkflowTerminalStages())
+	return newSource(db, source.FlowTerminalStages(""))
 }
 
 func newSource(db *sql.DB, terminalStates []string) (*Source, error) {

--- a/internal/digest/source_test.go
+++ b/internal/digest/source_test.go
@@ -22,6 +22,36 @@ func TestNewSource_RequiresTerminalStates(t *testing.T) {
 	}
 }
 
+func TestNewSourceUsesRootTerminalStagesNotChildAggregate(t *testing.T) {
+	_, db, cleanup := testutil.StartPostgres(t)
+	t.Cleanup(cleanup)
+
+	source, err := NewSource(db, semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
+		RootSchema: &runtimecontracts.FlowSchemaDocument{
+			StageDeclarations: runtimecontracts.FlowStageDeclarations{
+				Declared: true,
+				Entries: []runtimecontracts.FlowStageDeclaration{
+					{ID: "ready", Initial: true},
+					{ID: "done"},
+					{ID: "archived", Terminal: true},
+				},
+			},
+		},
+		Semantics: runtimecontracts.WorkflowSemanticView{
+			TerminalStages: []string{"done", "archived"},
+			FlowTerminal: map[string][]string{
+				"child": {"done"},
+			},
+		},
+	}))
+	if err != nil {
+		t.Fatalf("NewSource: %v", err)
+	}
+	if got, want := source.terminalStates, []string{"archived"}; len(got) != len(want) || got[0] != want[0] {
+		t.Fatalf("terminalStates = %#v, want root-only %#v", got, want)
+	}
+}
+
 func TestSource_FiltersTerminalStatesFromDigestReads(t *testing.T) {
 	_, db, cleanup := testutil.StartPostgres(t)
 	t.Cleanup(cleanup)

--- a/internal/runtime/authoringview/view.go
+++ b/internal/runtime/authoringview/view.go
@@ -435,11 +435,15 @@ func buildStageGraphForFlow(source semanticview.Source, flowID, label, path stri
 
 func stageDescriptionsForFlow(source semanticview.Source, flowID string) map[string]string {
 	out := map[string]string{}
+	if source == nil {
+		return out
+	}
 	flowID = strings.TrimSpace(flowID)
-	for _, stage := range source.WorkflowStages() {
-		if strings.TrimSpace(stage.Phase) != flowID {
-			continue
-		}
+	schema, ok := stageDescriptionSchemaForFlow(source, flowID)
+	if !ok || !schema.StageDeclarations.Declared {
+		return out
+	}
+	for _, stage := range schema.StageDeclarations.Entries {
 		id := strings.TrimSpace(stage.ID)
 		if id == "" {
 			continue
@@ -447,6 +451,20 @@ func stageDescriptionsForFlow(source semanticview.Source, flowID string) map[str
 		out[id] = strings.TrimSpace(stage.Description)
 	}
 	return out
+}
+
+type stageDescriptionRootSchemaProvider interface {
+	RootFlowSchema() (runtimecontracts.FlowSchemaDocument, bool)
+}
+
+func stageDescriptionSchemaForFlow(source semanticview.Source, flowID string) (runtimecontracts.FlowSchemaDocument, bool) {
+	if flowID == "" {
+		if provider, ok := source.(stageDescriptionRootSchemaProvider); ok {
+			return provider.RootFlowSchema()
+		}
+		return runtimecontracts.FlowSchemaDocument{}, false
+	}
+	return source.FlowSchemaByID(flowID)
 }
 
 func buildStageGraphEdgesForFlow(source semanticview.Source, flowID, initial string, states []string, terminalSet map[string]struct{}) []StageGraphEdgeView {

--- a/internal/runtime/authoringview/view.go
+++ b/internal/runtime/authoringview/view.go
@@ -20,6 +20,7 @@ type View struct {
 	SourceAuthority   string                 `json:"source_authority"`
 	Root              RootView               `json:"root"`
 	Flows             []FlowView             `json:"flows"`
+	StageGraphs       []StageGraphView       `json:"stage_graphs,omitempty"`
 	ConnectRoutePlans []ConnectRoutePlanView `json:"connect_route_plans"`
 	RoutePlanIssues   []RoutePlanIssueView   `json:"route_plan_issues,omitempty"`
 	Diagnostics       []DiagnosticView       `json:"diagnostics,omitempty"`
@@ -71,6 +72,28 @@ type FlowSourceFiles struct {
 	Nodes    string `json:"nodes,omitempty"`
 	Events   string `json:"events,omitempty"`
 	Agents   string `json:"agents,omitempty"`
+}
+
+type StageGraphView struct {
+	FlowID   string               `json:"flow_id"`
+	FlowPath string               `json:"flow_path,omitempty"`
+	Nodes    []StageGraphNodeView `json:"nodes"`
+	Edges    []StageGraphEdgeView `json:"edges"`
+}
+
+type StageGraphNodeView struct {
+	ID          string `json:"id"`
+	Initial     bool   `json:"initial,omitempty"`
+	Terminal    bool   `json:"terminal,omitempty"`
+	Description string `json:"description,omitempty"`
+}
+
+type StageGraphEdgeView struct {
+	From      []string `json:"from,omitempty"`
+	To        string   `json:"to"`
+	Source    string   `json:"source"`
+	NodeID    string   `json:"node_id,omitempty"`
+	EventType string   `json:"event_type,omitempty"`
 }
 
 type RequiredAgentsView struct {
@@ -241,7 +264,8 @@ type DiagnosticView struct {
 }
 
 type BuildOptions struct {
-	BootReport *runtimebootverify.Report
+	BootReport        *runtimebootverify.Report
+	IncludeStageGraph bool
 }
 
 func Build(_ context.Context, source semanticview.Source, opts BuildOptions) (View, error) {
@@ -271,6 +295,9 @@ func Build(_ context.Context, source semanticview.Source, opts BuildOptions) (Vi
 				"runtime/bootverify.Report",
 			},
 		},
+	}
+	if opts.IncludeStageGraph {
+		view.StageGraphs = buildStageGraphs(source, bundle)
 	}
 	return view, nil
 }
@@ -354,6 +381,176 @@ func buildFlows(source semanticview.Source, bundle *runtimecontracts.WorkflowCon
 		}
 		item.ContainedOperations = opsByFlow[flowID]
 		out = append(out, item)
+	}
+	return out
+}
+
+func buildStageGraphs(source semanticview.Source, bundle *runtimecontracts.WorkflowContractBundle) []StageGraphView {
+	if source == nil || bundle == nil {
+		return nil
+	}
+	graphs := make([]StageGraphView, 0, len(bundle.FlowViews())+1)
+	if graph := buildStageGraphForFlow(source, "", "root", ""); len(graph.Nodes) > 0 || len(graph.Edges) > 0 {
+		graphs = append(graphs, graph)
+	}
+	for _, flow := range bundle.FlowViews() {
+		flowID := strings.TrimSpace(flow.Paths.ID)
+		if flowID == "" {
+			continue
+		}
+		path := strings.Trim(strings.TrimSpace(flow.Path), "/")
+		if graph := buildStageGraphForFlow(source, flowID, flowID, path); len(graph.Nodes) > 0 || len(graph.Edges) > 0 {
+			graphs = append(graphs, graph)
+		}
+	}
+	return graphs
+}
+
+func buildStageGraphForFlow(source semanticview.Source, flowID, label, path string) StageGraphView {
+	initial := strings.TrimSpace(source.FlowInitialStage(flowID))
+	terminalSet := authoringStringSet(source.FlowTerminalStages(flowID))
+	states := source.FlowStates(flowID)
+	nodes := make([]StageGraphNodeView, 0, len(states))
+	stageDescriptions := stageDescriptionsForFlow(source, flowID)
+	for _, state := range states {
+		state = strings.TrimSpace(state)
+		if state == "" {
+			continue
+		}
+		_, terminal := terminalSet[state]
+		nodes = append(nodes, StageGraphNodeView{
+			ID:          state,
+			Initial:     initial != "" && state == initial,
+			Terminal:    terminal,
+			Description: strings.TrimSpace(stageDescriptions[state]),
+		})
+	}
+	return StageGraphView{
+		FlowID:   strings.TrimSpace(label),
+		FlowPath: strings.TrimSpace(path),
+		Nodes:    nodes,
+		Edges:    buildStageGraphEdgesForFlow(source, flowID, initial, states, terminalSet),
+	}
+}
+
+func stageDescriptionsForFlow(source semanticview.Source, flowID string) map[string]string {
+	out := map[string]string{}
+	flowID = strings.TrimSpace(flowID)
+	for _, stage := range source.WorkflowStages() {
+		if strings.TrimSpace(stage.Phase) != flowID {
+			continue
+		}
+		id := strings.TrimSpace(stage.ID)
+		if id == "" {
+			continue
+		}
+		out[id] = strings.TrimSpace(stage.Description)
+	}
+	return out
+}
+
+func buildStageGraphEdgesForFlow(source semanticview.Source, flowID, initial string, states []string, terminalSet map[string]struct{}) []StageGraphEdgeView {
+	stateSet := authoringStringSet(states)
+	nonTerminal := make([]string, 0, len(states))
+	for _, state := range states {
+		state = strings.TrimSpace(state)
+		if state == "" {
+			continue
+		}
+		if _, ok := terminalSet[state]; ok {
+			continue
+		}
+		nonTerminal = append(nonTerminal, state)
+	}
+	edges := make([]StageGraphEdgeView, 0)
+	nodes := source.NodeEntries()
+	nodeIDs := make([]string, 0, len(nodes))
+	for nodeID := range nodes {
+		if nodeID = strings.TrimSpace(nodeID); nodeID != "" {
+			nodeIDs = append(nodeIDs, nodeID)
+		}
+	}
+	sort.Strings(nodeIDs)
+	for _, nodeID := range nodeIDs {
+		node := nodes[nodeID]
+		if nodeID == "" {
+			continue
+		}
+		sourceInfo, ok := source.NodeContractSource(nodeID)
+		if !ok || strings.TrimSpace(sourceInfo.FlowID) != strings.TrimSpace(flowID) {
+			continue
+		}
+		eventTypes := make([]string, 0, len(node.EventHandlers))
+		for eventType := range node.EventHandlers {
+			if eventType = strings.TrimSpace(eventType); eventType != "" {
+				eventTypes = append(eventTypes, eventType)
+			}
+		}
+		sort.Strings(eventTypes)
+		for _, eventType := range eventTypes {
+			handler := node.EventHandlers[eventType]
+			from := append([]string{}, nonTerminal...)
+			if handler.CreateEntity {
+				from = nil
+				if strings.TrimSpace(initial) != "" {
+					from = []string{strings.TrimSpace(initial)}
+				}
+			}
+			edges = appendStageGraphEdge(edges, from, handler.AdvancesTo, stateSet, "handler.advances_to", nodeID, eventType)
+			for _, rule := range handler.OnComplete {
+				edges = appendStageGraphEdge(edges, from, rule.AdvancesTo, stateSet, "handler.on_complete", nodeID, eventType)
+			}
+			for _, rule := range handler.Rules {
+				edges = appendStageGraphEdge(edges, from, rule.AdvancesTo, stateSet, "handler.rules", nodeID, eventType)
+			}
+		}
+	}
+	sort.Slice(edges, func(i, j int) bool {
+		left := edges[i]
+		right := edges[j]
+		if strings.Join(left.From, "\x00") != strings.Join(right.From, "\x00") {
+			return strings.Join(left.From, "\x00") < strings.Join(right.From, "\x00")
+		}
+		if left.To != right.To {
+			return left.To < right.To
+		}
+		if left.Source != right.Source {
+			return left.Source < right.Source
+		}
+		if left.NodeID != right.NodeID {
+			return left.NodeID < right.NodeID
+		}
+		return left.EventType < right.EventType
+	})
+	return edges
+}
+
+func appendStageGraphEdge(edges []StageGraphEdgeView, from []string, target string, stateSet map[string]struct{}, source, nodeID, eventType string) []StageGraphEdgeView {
+	target = strings.TrimSpace(target)
+	if target == "" {
+		return edges
+	}
+	if len(stateSet) > 0 {
+		if _, ok := stateSet[target]; !ok {
+			return edges
+		}
+	}
+	return append(edges, StageGraphEdgeView{
+		From:      append([]string{}, from...),
+		To:        target,
+		Source:    strings.TrimSpace(source),
+		NodeID:    strings.TrimSpace(nodeID),
+		EventType: strings.TrimSpace(eventType),
+	})
+}
+
+func authoringStringSet(values []string) map[string]struct{} {
+	out := make(map[string]struct{}, len(values))
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value != "" {
+			out[value] = struct{}{}
+		}
 	}
 	return out
 }

--- a/internal/runtime/bootverify/checks.go
+++ b/internal/runtime/bootverify/checks.go
@@ -924,7 +924,13 @@ func (c *checkerContext) stateMachineCoherence() []Finding {
 		return c.stateFindings
 	}
 	c.stateLoaded = true
-	for flowID := range c.source.FlowSchemaEntries() {
+	for _, entry := range lifecycleFlowSchemas(c.source) {
+		flowID := entry.flowID
+		schema := entry.schema
+		c.stateFindings = append(c.stateFindings, stageDeclarationCoherenceFindings(flowID, schema)...)
+		if strings.TrimSpace(flowID) == "" && !schema.UsesAuthoredStages() {
+			continue
+		}
 		states := stringSet(c.source.FlowStates(flowID))
 		initial := strings.TrimSpace(c.source.FlowInitialStage(flowID))
 		if initial != "" {
@@ -1514,11 +1520,7 @@ func flowIsStateless(source semanticview.Source, flowID string) bool {
 	if source == nil {
 		return false
 	}
-	schema, ok := source.FlowSchemaByID(strings.TrimSpace(flowID))
-	if !ok {
-		return false
-	}
-	return strings.TrimSpace(schema.InitialState) == "" && len(schema.States) == 0
+	return strings.TrimSpace(source.FlowInitialStage(strings.TrimSpace(flowID))) == "" && len(source.FlowStates(strings.TrimSpace(flowID))) == 0
 }
 
 func nodeFlowID(source semanticview.Source, nodeID string) string {
@@ -1536,12 +1538,8 @@ func declaredStatesForFlow(source semanticview.Source, flowID string) map[string
 	var states []string
 	var terminals []string
 	if flowID == "" {
-		for _, stage := range source.WorkflowStages() {
-			if id := strings.TrimSpace(stage.ID); id != "" {
-				states = append(states, id)
-			}
-		}
-		terminals = source.WorkflowTerminalStages()
+		states = source.FlowStates("")
+		terminals = source.FlowTerminalStages("")
 	} else {
 		states = source.FlowStates(flowID)
 		terminals = source.FlowTerminalStages(flowID)
@@ -1553,6 +1551,87 @@ func declaredStatesForFlow(source semanticview.Source, flowID string) map[string
 		}
 	}
 	return out
+}
+
+type lifecycleFlowSchemaEntry struct {
+	flowID string
+	schema runtimecontracts.FlowSchemaDocument
+}
+
+type rootFlowSchemaProvider interface {
+	RootFlowSchema() (runtimecontracts.FlowSchemaDocument, bool)
+}
+
+func lifecycleFlowSchemas(source semanticview.Source) []lifecycleFlowSchemaEntry {
+	if source == nil {
+		return nil
+	}
+	out := make([]lifecycleFlowSchemaEntry, 0, len(source.FlowSchemaEntries())+1)
+	if provider, ok := source.(rootFlowSchemaProvider); ok {
+		if schema, ok := provider.RootFlowSchema(); ok {
+			out = append(out, lifecycleFlowSchemaEntry{flowID: "", schema: schema})
+		}
+	}
+	for flowID, schema := range source.FlowSchemaEntries() {
+		flowID = strings.TrimSpace(flowID)
+		if flowID == "" {
+			continue
+		}
+		out = append(out, lifecycleFlowSchemaEntry{flowID: flowID, schema: schema})
+	}
+	return out
+}
+
+func flowUsesAuthoredStages(source semanticview.Source, flowID string) bool {
+	flowID = strings.TrimSpace(flowID)
+	for _, entry := range lifecycleFlowSchemas(source) {
+		if strings.TrimSpace(entry.flowID) == flowID {
+			return entry.schema.UsesAuthoredStages()
+		}
+	}
+	return false
+}
+
+func stageDeclarationCoherenceFindings(flowID string, schema runtimecontracts.FlowSchemaDocument) []Finding {
+	if !schema.UsesAuthoredStages() {
+		return nil
+	}
+	label := validationFlowLabel(flowID)
+	location := strings.TrimSpace(flowID)
+	if location == "" {
+		location = "root"
+	}
+	findings := make([]Finding, 0, 3)
+	if schema.HasLegacyLifecycleFields() {
+		findings = append(findings, Finding{
+			CheckID:  "state_machine_coherence",
+			Severity: "error",
+			Message:  fmt.Sprintf("flow %s declares stages and legacy lifecycle fields; stages is mutually exclusive with initial_state, states, and terminal_states", label),
+			Location: location,
+		})
+	}
+	if len(schema.StageDeclarations.Entries) == 0 {
+		return findings
+	}
+	initialCount := schema.StageDeclarations.InitialCount()
+	if initialCount != 1 {
+		findings = append(findings, Finding{
+			CheckID:  "state_machine_coherence",
+			Severity: "error",
+			Message:  fmt.Sprintf("flow %s stages must declare exactly one initial stage; got %d", label, initialCount),
+			Location: location,
+		})
+	}
+	terminalCount := schema.StageDeclarations.TerminalCount()
+	if terminalCount == 0 {
+		findings = append(findings, Finding{
+			CheckID:  "state_machine_coherence",
+			Severity: "error",
+			Message:  fmt.Sprintf("flow %s stages must declare at least one terminal stage", label),
+			Location: location,
+		})
+	}
+	return findings
 }
 
 func validationFlowLabel(flowID string) string {

--- a/internal/runtime/bootverify/report_test.go
+++ b/internal/runtime/bootverify/report_test.go
@@ -5607,6 +5607,28 @@ func TestRun_RejectsCreateEntityForStatefulStaticInputPinHandlers(t *testing.T) 
 	}
 }
 
+func TestRun_RejectsCreateEntityForStagedStatefulStaticInputPinHandlers(t *testing.T) {
+	bundle := loadFixtureBundle(t, filepath.Join("tests", "tier11-flow-composition", "test-child-flow-pin-wiring"))
+	flowID := "child"
+	useStagedLifecycleForFlow(t, bundle, flowID, "pending", []string{"pending", "done"}, []string{"done"})
+	flowView, ok := bundle.FlowViewByID(flowID)
+	if !ok || flowView == nil {
+		t.Fatalf("flow view %s missing", flowID)
+	}
+	for nodeID, node := range flowView.Nodes {
+		for eventType, handler := range node.EventHandlers {
+			handler.CreateEntity = true
+			writeFlowHandler(t, bundle, flowID, nodeID, eventType, handler)
+		}
+	}
+
+	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+
+	if !reportContains(report.Errors(), "flow_boundary_create_entity_validation", "static multi-row entity ownership is retired") {
+		t.Fatalf("expected retired static create_entity error for staged flow, got %#v", report.Errors())
+	}
+}
+
 func TestRun_RejectsCallerSelectedEntityIDForRootNormalInputPinMaterializers(t *testing.T) {
 	root := writeRootDefaultStaticInputPinFixtureWithOptions(t, rootDefaultStaticInputPinFixtureOptions{
 		DeclareEntityID: true,

--- a/internal/runtime/bootverify/report_test.go
+++ b/internal/runtime/bootverify/report_test.go
@@ -2578,6 +2578,58 @@ func TestRun_WarnsWhenDeclaredStateIsUnreachable(t *testing.T) {
 	}
 }
 
+func TestRun_ErrorsWhenDeclaredStageIsUnreachable(t *testing.T) {
+	root := writeStagedReachabilityFixture(t)
+	bundle := loadFixtureBundleAt(t, repoRootForBootverifyTest(t), root, runtimecontracts.DefaultPlatformSpecFile(repoRootForBootverifyTest(t)))
+
+	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+
+	if !reportContains(report.Errors(), "semantic_drift_unreachable_state", "declares stage review but no transition path from initial stage waiting reaches review") {
+		t.Fatalf("expected hard semantic_drift_unreachable_state error for staged lifecycle, got errors=%#v warnings=%#v", report.Errors(), report.Warnings())
+	}
+	if reportContains(report.Warnings(), "semantic_drift_unreachable_state", "review") {
+		t.Fatalf("unexpected staged lifecycle warning; want hard error, got %#v", report.Warnings())
+	}
+}
+
+func TestRun_ErrorsWhenStagesMixWithLegacyLifecycleFields(t *testing.T) {
+	root := writeStagedLifecycleFixture(t, `
+name: support
+initial_state: waiting
+stages:
+  waiting:
+    initial: true
+  done:
+    terminal: true
+`)
+	bundle := loadFixtureBundleAt(t, repoRootForBootverifyTest(t), root, runtimecontracts.DefaultPlatformSpecFile(repoRootForBootverifyTest(t)))
+
+	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+
+	if !reportContains(report.Errors(), "state_machine_coherence", "declares stages and legacy lifecycle fields") {
+		t.Fatalf("expected mixed lifecycle owner error, got %#v", report.Errors())
+	}
+}
+
+func TestRun_ErrorsWhenStagesMissInitialOrTerminal(t *testing.T) {
+	root := writeStagedLifecycleFixture(t, `
+name: support
+stages:
+  waiting: {}
+  done: {}
+`)
+	bundle := loadFixtureBundleAt(t, repoRootForBootverifyTest(t), root, runtimecontracts.DefaultPlatformSpecFile(repoRootForBootverifyTest(t)))
+
+	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+
+	if !reportContains(report.Errors(), "state_machine_coherence", "must declare exactly one initial stage") {
+		t.Fatalf("expected missing initial stage error, got %#v", report.Errors())
+	}
+	if !reportContains(report.Errors(), "state_machine_coherence", "must declare at least one terminal stage") {
+		t.Fatalf("expected missing terminal stage error, got %#v", report.Errors())
+	}
+}
+
 func TestRun_DoesNotWarnWhenOnCompleteBranchReachesDeclaredState(t *testing.T) {
 	root := writeStateReachabilityFixture(t)
 	bundle := loadFixtureBundleAt(t, repoRootForBootverifyTest(t), root, runtimecontracts.DefaultPlatformSpecFile(repoRootForBootverifyTest(t)))
@@ -7449,6 +7501,67 @@ initial_state: waiting
 terminal_states: [done]
 states: [waiting, active, review, done]
 `)
+	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "support", "entities.yaml"), `
+ticket: {}
+`)
+	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "support", "policy.yaml"), "{}\n")
+	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "support", "events.yaml"), `
+ticket.opened:
+  entity_id: string
+ticket.closed:
+  entity_id: string
+`)
+	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "support", "nodes.yaml"), `
+support-node:
+  id: support-node
+  execution_type: system_node
+  subscribes_to:
+    - ticket.opened
+    - ticket.closed
+  event_handlers:
+    ticket.opened:
+      create_entity: true
+      advances_to: active
+    ticket.closed:
+      advances_to: done
+`)
+
+	return root
+}
+
+func writeStagedReachabilityFixture(t *testing.T) string {
+	return writeStagedLifecycleFixture(t, `
+name: support
+stages:
+  waiting:
+    initial: true
+  active: {}
+  review: {}
+  done:
+    terminal: true
+`)
+}
+
+func writeStagedLifecycleFixture(t *testing.T, schema string) string {
+	t.Helper()
+	root := t.TempDir()
+
+	writeBootverifyFixtureFile(t, filepath.Join(root, "package.yaml"), `
+name: staged-lifecycle
+version: "1.0.0"
+platform_version: ">=0.7.0 <0.8.0"
+flows:
+  - id: support
+    flow: support
+    mode: static
+`)
+	writeBootverifyFixtureFile(t, filepath.Join(root, "schema.yaml"), "name: staged-lifecycle\n")
+	writeBootverifyFixtureFile(t, filepath.Join(root, "policy.yaml"), "{}\n")
+	writeBootverifyFixtureFile(t, filepath.Join(root, "tools.yaml"), "{}\n")
+	writeBootverifyFixtureFile(t, filepath.Join(root, "agents.yaml"), "{}\n")
+	writeBootverifyFixtureFile(t, filepath.Join(root, "events.yaml"), "{}\n")
+
+	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "support", "schema.yaml"), schema)
 	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "support", "entities.yaml"), `
 ticket: {}
 `)

--- a/internal/runtime/bootverify/workflow_flow_boundary_checks.go
+++ b/internal/runtime/bootverify/workflow_flow_boundary_checks.go
@@ -346,7 +346,7 @@ func (c *checkerContext) selectEntityValidation() []Finding {
 						Location: location,
 					})
 				}
-				if retiredStaticMultiEntityAcquisitionFlow(validationScope.schema) {
+				if validationScope.retiredStatic {
 					findings = append(findings, Finding{
 						CheckID:  "select_entity_validation",
 						Severity: "error",
@@ -362,7 +362,7 @@ func (c *checkerContext) selectEntityValidation() []Finding {
 						Location: location,
 					})
 				}
-				if strings.TrimSpace(validationScope.schema.InitialState) == "" {
+				if !validationScope.stateful {
 					findings = append(findings, Finding{
 						CheckID:  "select_entity_validation",
 						Severity: "error",
@@ -537,7 +537,7 @@ func (c *checkerContext) flowBoundaryCreateEntityValidation() []Finding {
 		if strings.EqualFold(strings.TrimSpace(validationScope.schema.Mode), "template") {
 			continue
 		}
-		if strings.TrimSpace(validationScope.schema.InitialState) == "" {
+		if !validationScope.stateful {
 			continue
 		}
 		if len(validationScope.inputs) == 0 {
@@ -553,7 +553,7 @@ func (c *checkerContext) flowBoundaryCreateEntityValidation() []Finding {
 				if _, ok := validationScope.inputs[eventType]; !ok {
 					continue
 				}
-				if retiredStaticMultiEntityAcquisitionFlow(validationScope.schema) {
+				if validationScope.retiredStatic {
 					if handler.CreateEntity {
 						c.flowBoundaryCreateEntityFindings = append(c.flowBoundaryCreateEntityFindings, Finding{
 							CheckID:  "flow_boundary_create_entity_validation",
@@ -575,7 +575,7 @@ func (c *checkerContext) flowBoundaryCreateEntityValidation() []Finding {
 					}
 					continue
 				}
-				if normalPrimaryEntityFlow(validationScope.schema) &&
+				if validationScope.normalPrimary &&
 					bootverifyHandlerMaterializesEntity(c.source, validationScope.semanticFlowID, handler) &&
 					flowInputEventDeclaresPayloadField(c.source, validationScope.semanticFlowID, eventType, "entity_id") {
 					c.flowBoundaryCreateEntityFindings = append(c.flowBoundaryCreateEntityFindings, Finding{
@@ -585,7 +585,7 @@ func (c *checkerContext) flowBoundaryCreateEntityValidation() []Finding {
 						Location: validationScope.displayFlowID,
 					})
 				}
-				if normalPrimaryEntityFlow(validationScope.schema) {
+				if validationScope.normalPrimary {
 					continue
 				}
 				if handler.CreateEntity {
@@ -613,6 +613,9 @@ type flowAcquisitionValidationScope struct {
 	displayFlowID  string
 	semanticFlowID string
 	schema         runtimecontracts.FlowSchemaDocument
+	stateful       bool
+	retiredStatic  bool
+	normalPrimary  bool
 	inputs         map[string]struct{}
 	nodes          map[string]runtimecontracts.SystemNodeContract
 }
@@ -630,10 +633,14 @@ func (c *checkerContext) flowAcquisitionValidationScopes() []flowAcquisitionVali
 			}
 		}
 		if len(rootNodes) > 0 {
+			schema := *bundle.RootSchema
 			scopes = append(scopes, flowAcquisitionValidationScope{
 				displayFlowID:  "root",
 				semanticFlowID: "",
-				schema:         *bundle.RootSchema,
+				schema:         schema,
+				stateful:       bootverifyFlowStateful(c.source, "", schema),
+				retiredStatic:  retiredStaticMultiEntityAcquisitionFlow(c.source, "", schema),
+				normalPrimary:  normalPrimaryEntityFlow(c.source, "", schema),
 				inputs:         normalizeStringSet(bundle.RootSchema.Pins.Inputs.Events),
 				nodes:          rootNodes,
 			})
@@ -652,6 +659,9 @@ func (c *checkerContext) flowAcquisitionValidationScopes() []flowAcquisitionVali
 			displayFlowID:  flowID,
 			semanticFlowID: flowID,
 			schema:         schema,
+			stateful:       bootverifyFlowStateful(c.source, flowID, schema),
+			retiredStatic:  retiredStaticMultiEntityAcquisitionFlow(c.source, flowID, schema),
+			normalPrimary:  normalPrimaryEntityFlow(c.source, flowID, schema),
 			inputs:         normalizeStringSet(c.source.FlowInputEvents(flowID)),
 			nodes:          scope.Nodes,
 		})
@@ -659,17 +669,31 @@ func (c *checkerContext) flowAcquisitionValidationScopes() []flowAcquisitionVali
 	return scopes
 }
 
-func retiredStaticMultiEntityAcquisitionFlow(schema runtimecontracts.FlowSchemaDocument) bool {
+func bootverifyFlowInitialStage(source semanticview.Source, flowID string, schema runtimecontracts.FlowSchemaDocument) string {
+	if initial := strings.TrimSpace(schema.LoweredInitialState()); initial != "" || schema.UsesAuthoredStages() || schema.HasLegacyLifecycleFields() {
+		return initial
+	}
+	if source == nil {
+		return ""
+	}
+	return strings.TrimSpace(source.FlowInitialStage(strings.TrimSpace(flowID)))
+}
+
+func bootverifyFlowStateful(source semanticview.Source, flowID string, schema runtimecontracts.FlowSchemaDocument) bool {
+	return bootverifyFlowInitialStage(source, flowID, schema) != ""
+}
+
+func retiredStaticMultiEntityAcquisitionFlow(source semanticview.Source, flowID string, schema runtimecontracts.FlowSchemaDocument) bool {
 	mode := strings.TrimSpace(schema.Mode)
-	return strings.TrimSpace(schema.InitialState) != "" && strings.EqualFold(mode, runtimecontracts.FlowModeStatic)
+	return bootverifyFlowStateful(source, flowID, schema) && strings.EqualFold(mode, runtimecontracts.FlowModeStatic)
 }
 
 func retiredStaticMultiEntityAcquisitionMessage(flowID, eventType, nodeID, label string) string {
 	return fmt.Sprintf("flow %s handler %s on node %s uses %s, but stateful static multi-row entity ownership is retired; model this as one primary entity with contained state, a mode: template flow instance, a mode: singleton coordinator, or a child flow", flowID, eventType, nodeID, label)
 }
 
-func normalPrimaryEntityFlow(schema runtimecontracts.FlowSchemaDocument) bool {
-	return strings.TrimSpace(schema.InitialState) != "" && strings.TrimSpace(schema.Mode) == ""
+func normalPrimaryEntityFlow(source semanticview.Source, flowID string, schema runtimecontracts.FlowSchemaDocument) bool {
+	return bootverifyFlowStateful(source, flowID, schema) && strings.TrimSpace(schema.Mode) == ""
 }
 
 func flowInputEventDeclaresPayloadField(source semanticview.Source, flowID, eventType, field string) bool {

--- a/internal/runtime/bootverify/workflow_pin_routing_checks.go
+++ b/internal/runtime/bootverify/workflow_pin_routing_checks.go
@@ -58,7 +58,7 @@ func checkRedundantInTopologySelectEntity(c *checkerContext) []Finding {
 	findings := []Finding{}
 	for flowID, schema := range c.source.FlowSchemaEntries() {
 		flowID = strings.TrimSpace(flowID)
-		if flowID == "" || strings.TrimSpace(schema.InitialState) == "" {
+		if flowID == "" || !bootverifyFlowStateful(c.source, flowID, schema) {
 			continue
 		}
 		scope, ok := c.source.FlowScopeByID(flowID)
@@ -98,13 +98,13 @@ func checkMissingExternalSelectEntity(c *checkerContext) []Finding {
 	findings := []Finding{}
 	for flowID, schema := range c.source.FlowSchemaEntries() {
 		flowID = strings.TrimSpace(flowID)
-		if flowID == "" || strings.TrimSpace(schema.InitialState) == "" || strings.EqualFold(strings.TrimSpace(schema.Mode), "template") {
+		if flowID == "" || !bootverifyFlowStateful(c.source, flowID, schema) || strings.EqualFold(strings.TrimSpace(schema.Mode), "template") {
 			continue
 		}
-		if retiredStaticMultiEntityAcquisitionFlow(schema) {
+		if retiredStaticMultiEntityAcquisitionFlow(c.source, flowID, schema) {
 			continue
 		}
-		if normalPrimaryEntityFlow(schema) {
+		if normalPrimaryEntityFlow(c.source, flowID, schema) {
 			continue
 		}
 		inputs := normalizeStringSet(c.source.FlowInputEvents(flowID))

--- a/internal/runtime/bootverify/workflow_pin_routing_checks_test.go
+++ b/internal/runtime/bootverify/workflow_pin_routing_checks_test.go
@@ -150,6 +150,24 @@ func TestRedundantInTopologySelectEntityFailsClosedForParentConnect(t *testing.T
 	}
 }
 
+func TestRedundantInTopologySelectEntityFailsClosedForStagedParentConnect(t *testing.T) {
+	bundle := loadSelectEntityDemotionBundle(t, selectEntityDemotionFixtureOptions{
+		consumerMode: "static",
+		acquisition:  "select_entity",
+		withProducer: true,
+	})
+	useStagedLifecycleForFlow(t, bundle, "consumer", "pending", []string{"pending", "done"}, []string{"done"})
+
+	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+
+	if !reportContains(report.Errors(), "redundant_in_topology_select_entity", "instance.by plus parent connect") {
+		t.Fatalf("expected redundant_in_topology_select_entity hard invalidity for staged flow, got errors=%#v warnings=%#v", report.Errors(), report.Warnings())
+	}
+	if reportContains(report.Warnings(), "redundant_in_topology_select_entity", "") {
+		t.Fatalf("redundant_in_topology_select_entity must not remain warning-only for staged flow, got %#v", report.Warnings())
+	}
+}
+
 func TestRedundantInTopologySelectOrCreateEntityFailsClosedForParentConnect(t *testing.T) {
 	bundle := loadSelectEntityDemotionBundle(t, selectEntityDemotionFixtureOptions{
 		consumerMode: "static",
@@ -1086,6 +1104,64 @@ consumer-node:
     deploy.done:
 ` + acquisitionBlock + `      advances_to: done
 `
+}
+
+func useStagedLifecycleForFlow(t *testing.T, bundle *runtimecontracts.WorkflowContractBundle, flowID, initial string, states, terminals []string) {
+	t.Helper()
+	if bundle == nil {
+		t.Fatal("bundle is nil")
+	}
+	flowID = strings.TrimSpace(flowID)
+	if flowID == "" {
+		t.Fatal("flowID is required")
+	}
+	schema, ok := bundle.FlowSchemas[flowID]
+	if !ok {
+		t.Fatalf("flow schema %s missing", flowID)
+	}
+	terminalSet := map[string]struct{}{}
+	for _, terminal := range terminals {
+		terminal = strings.TrimSpace(terminal)
+		if terminal != "" {
+			terminalSet[terminal] = struct{}{}
+		}
+	}
+	entries := make([]runtimecontracts.FlowStageDeclaration, 0, len(states))
+	for _, state := range states {
+		state = strings.TrimSpace(state)
+		if state == "" {
+			continue
+		}
+		_, terminal := terminalSet[state]
+		entries = append(entries, runtimecontracts.FlowStageDeclaration{
+			ID:       state,
+			Initial:  state == strings.TrimSpace(initial),
+			Terminal: terminal,
+		})
+	}
+	schema.InitialState = ""
+	schema.InitialStateDeclared = false
+	schema.States = nil
+	schema.StatesDeclared = false
+	schema.TerminalStates = nil
+	schema.TerminalStatesDeclared = false
+	schema.StageDeclarations = runtimecontracts.FlowStageDeclarations{Declared: true, Entries: entries}
+	bundle.FlowSchemas[flowID] = schema
+	if bundle.Semantics.FlowInitial == nil {
+		bundle.Semantics.FlowInitial = map[string]string{}
+	}
+	if bundle.Semantics.FlowStates == nil {
+		bundle.Semantics.FlowStates = map[string][]string{}
+	}
+	if bundle.Semantics.FlowTerminal == nil {
+		bundle.Semantics.FlowTerminal = map[string][]string{}
+	}
+	bundle.Semantics.FlowInitial[flowID] = schema.LoweredInitialState()
+	bundle.Semantics.FlowStates[flowID] = schema.LoweredStates()
+	bundle.Semantics.FlowTerminal[flowID] = schema.LoweredTerminalStates()
+	if view, ok := bundle.FlowViewByID(flowID); ok && view != nil {
+		view.Schema = schema
+	}
 }
 
 type pinRoutingVerifySourceFixture struct {

--- a/internal/runtime/bootverify/workflow_primary_entity_checks.go
+++ b/internal/runtime/bootverify/workflow_primary_entity_checks.go
@@ -41,7 +41,7 @@ func checkPrimaryEntityValidation(c *checkerContext) []Finding {
 		entities, _ := bundle.FlowEntityContractsByID(flowID)
 		hasEntityDeclaration := strings.TrimSpace(schema.Entity) != ""
 		hasEntityContracts := len(entities) > 0
-		statefulNormal := strings.TrimSpace(schema.InitialState) != "" && strings.TrimSpace(schema.Mode) == ""
+		statefulNormal := normalPrimaryEntityFlow(c.source, flowID, schema)
 		if !hasEntityDeclaration && !hasEntityContracts && !statefulNormal {
 			continue
 		}

--- a/internal/runtime/bootverify/workflow_primary_entity_checks_test.go
+++ b/internal/runtime/bootverify/workflow_primary_entity_checks_test.go
@@ -53,6 +53,28 @@ pins:
 	}
 }
 
+func TestRun_RejectsMissingPrimaryEntityForStagedStatefulNormalFlow(t *testing.T) {
+	bundle := loadPrimaryEntityFixtureBundle(t, `
+name: scoring
+stages:
+  pending:
+    initial: true
+  done:
+    terminal: true
+pins:
+  inputs:
+    events: []
+  outputs:
+    events: []
+`, "")
+
+	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+
+	if !reportContains(report.Errors(), "primary_entity_validation", "has no declared entity types") {
+		t.Fatalf("expected missing primary_entity_validation error for staged stateful flow, got %#v", report.Errors())
+	}
+}
+
 func TestRun_AllowsStatelessFlowWithoutPrimaryEntity(t *testing.T) {
 	bundle := loadPrimaryEntityFixtureBundle(t, `
 name: scoring

--- a/internal/runtime/bootverify/workflow_state_machine_reachability_checks.go
+++ b/internal/runtime/bootverify/workflow_state_machine_reachability_checks.go
@@ -18,9 +18,10 @@ func (c *checkerContext) stateReachability() []Finding {
 	}
 	c.stateReachabilityLoaded = true
 
-	for flowID := range c.source.FlowSchemaEntries() {
-		flowID = strings.TrimSpace(flowID)
-		if flowID == "" {
+	for _, entry := range lifecycleFlowSchemas(c.source) {
+		flowID := strings.TrimSpace(entry.flowID)
+		usesStages := flowUsesAuthoredStages(c.source, flowID)
+		if flowID == "" && !usesStages {
 			continue
 		}
 		initial := strings.TrimSpace(c.source.FlowInitialStage(flowID))
@@ -49,23 +50,47 @@ func (c *checkerContext) stateReachability() []Finding {
 
 		reachableList := strings.Join(sortedSetKeys(reachable), ", ")
 		unreachableList := strings.Join(sortedSetKeys(unreachable), ", ")
+		declaredNoun := "state"
+		ownerField := "states"
+		initialField := "initial_state"
+		if usesStages {
+			declaredNoun = "stage"
+			ownerField = "stages"
+			initialField = "initial stage"
+		}
 		for _, state := range sortedSetKeys(unreachable) {
+			message := fmt.Sprintf(
+				"flow %s declares %s %s but no transition path from %s %s reaches %s in the authored handler graph.\n\nReachable states: %s\nUnreachable states: %s",
+				validationFlowLabel(flowID),
+				declaredNoun,
+				state,
+				initialField,
+				initial,
+				state,
+				reachableList,
+				unreachableList,
+			)
+			remediation := fmt.Sprintf(
+				"If %s is intentionally unused, remove it from schema.yaml %s. If %s should be reachable, add a handler transition carrier that reaches %s.",
+				state,
+				ownerField,
+				state,
+				state,
+			)
+			if usesStages {
+				c.stateReachabilityFindings = append(c.stateReachabilityFindings, NewHardInvalidityFinding(
+					"semantic_drift_unreachable_state",
+					validationFlowLabel(flowID),
+					message,
+					remediation,
+				))
+				continue
+			}
 			c.stateReachabilityFindings = append(c.stateReachabilityFindings, Finding{
 				CheckID:  "semantic_drift_unreachable_state",
-				Severity: "warning",
-				Message: fmt.Sprintf(
-					"flow %s declares state %s but no transition path from initial_state %s reaches %s in the authored handler graph.\n\nReachable states: %s\nUnreachable states: %s\n\nIf %s is intentionally unused, remove it from schema.yaml states.\nIf %s should be reachable, add a handler with advances_to: %s.",
-					flowID,
-					state,
-					initial,
-					state,
-					reachableList,
-					unreachableList,
-					state,
-					state,
-					state,
-				),
-				Location: flowID,
+				Severity: SeveritySemanticDriftWarn,
+				Message:  message + "\n\n" + remediation,
+				Location: validationFlowLabel(flowID),
 			})
 		}
 	}

--- a/internal/runtime/bootverify/workflow_timer_checks.go
+++ b/internal/runtime/bootverify/workflow_timer_checks.go
@@ -473,15 +473,7 @@ func flowStatesForTimer(source semanticview.Source, flowID string) []string {
 	if flowID != "" {
 		return source.FlowStates(flowID)
 	}
-	stages := source.WorkflowStages()
-	out := make([]string, 0, len(stages))
-	for _, stage := range stages {
-		name := strings.TrimSpace(stage.ID)
-		if name != "" {
-			out = append(out, name)
-		}
-	}
-	return out
+	return source.FlowStates("")
 }
 
 func participantExistsLocal(source semanticview.Source, participant string) bool {

--- a/internal/runtime/budget.go
+++ b/internal/runtime/budget.go
@@ -64,6 +64,10 @@ type budgetThresholds struct {
 }
 
 func NewBudgetTracker(store budgetspend.Store, bus *runtimebus.EventBus, cfg *config.Config, mailbox runtimetools.MailboxPersistence, logger *RuntimeLogger, source semanticview.Source) *BudgetTracker {
+	var terminalStates []string
+	if source != nil {
+		terminalStates = source.FlowTerminalStages("")
+	}
 	return &BudgetTracker{
 		store:          store,
 		bus:            bus,
@@ -72,7 +76,7 @@ func NewBudgetTracker(store budgetspend.Store, bus *runtimebus.EventBus, cfg *co
 		mailbox:        mailbox,
 		mailboxFrom:    "runtime",
 		thresholds:     budgetThresholdsFromSource(source),
-		terminalStates: normalizeBudgetStateList(source.WorkflowTerminalStages()),
+		terminalStates: normalizeBudgetStateList(terminalStates),
 		lastState:      make(map[string]string),
 	}
 }

--- a/internal/runtime/budget_test.go
+++ b/internal/runtime/budget_test.go
@@ -36,6 +36,31 @@ func TestBudgetTracker_KeepsTerminalStatesInstanceOwned(t *testing.T) {
 	}
 }
 
+func TestBudgetTrackerUsesRootTerminalStagesNotChildAggregate(t *testing.T) {
+	tracker := NewBudgetTracker(nil, nil, nil, nil, nil, semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
+		RootSchema: &runtimecontracts.FlowSchemaDocument{
+			StageDeclarations: runtimecontracts.FlowStageDeclarations{
+				Declared: true,
+				Entries: []runtimecontracts.FlowStageDeclaration{
+					{ID: "ready", Initial: true},
+					{ID: "done"},
+					{ID: "archived", Terminal: true},
+				},
+			},
+		},
+		Semantics: runtimecontracts.WorkflowSemanticView{
+			TerminalStages: []string{"done", "archived"},
+			FlowTerminal: map[string][]string{
+				"child": {"done"},
+			},
+		},
+	}))
+
+	if got, want := tracker.TerminalInstanceStates(), []string{"archived"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("TerminalInstanceStates() = %#v, want root-only %#v", got, want)
+	}
+}
+
 func TestBudgetTracker_RecordLLMUsagePersistsUsageAccounting(t *testing.T) {
 	store := &budgetSpendStoreCapture{}
 	tracker := &BudgetTracker{store: store}

--- a/internal/runtime/bus/run_completion.go
+++ b/internal/runtime/bus/run_completion.go
@@ -31,7 +31,7 @@ func (eb *EventBus) normalRunCompletionTerminalStates() ([]string, map[string][]
 	if source == nil {
 		return nil, nil
 	}
-	workflowTerminals := normalizeRunCompletionStates(source.WorkflowTerminalStages())
+	workflowTerminals := normalizeRunCompletionStates(source.FlowTerminalStages(""))
 	flowTerminals := map[string][]string{}
 	addFlowTerminals := func(key string, states []string) {
 		key = strings.Trim(strings.TrimSpace(key), "/")

--- a/internal/runtime/bus/run_completion_test.go
+++ b/internal/runtime/bus/run_completion_test.go
@@ -2,10 +2,13 @@ package bus
 
 import (
 	"context"
+	"reflect"
 	"testing"
 
 	"github.com/division-sh/swarm/internal/events"
 	"github.com/division-sh/swarm/internal/events/eventtest"
+	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
+	"github.com/division-sh/swarm/internal/runtime/semanticview"
 	"time"
 )
 
@@ -14,6 +17,8 @@ type normalRunCompletionTestStore struct {
 	pipelineReceipts []string
 	standaloneEvents []string
 	normalEvents     []string
+	workflowTerms    []string
+	flowTerms        map[string][]string
 }
 
 func (s *normalRunCompletionTestStore) UpsertPipelineReceipt(_ context.Context, eventID, _, _ string) error {
@@ -26,8 +31,15 @@ func (s *normalRunCompletionTestStore) ConvergeStandaloneRuntimePlatformRun(_ co
 	return nil
 }
 
-func (s *normalRunCompletionTestStore) ConvergeNormalRunCompletion(_ context.Context, eventID string, _ []string, _ map[string][]string) error {
+func (s *normalRunCompletionTestStore) ConvergeNormalRunCompletion(_ context.Context, eventID string, workflowTerminals []string, flowTerminals map[string][]string) error {
 	s.normalEvents = append(s.normalEvents, eventID)
+	s.workflowTerms = append([]string{}, workflowTerminals...)
+	if flowTerminals != nil {
+		s.flowTerms = make(map[string][]string, len(flowTerminals))
+		for key, states := range flowTerminals {
+			s.flowTerms[key] = append([]string{}, states...)
+		}
+	}
 	return nil
 }
 
@@ -63,5 +75,59 @@ func TestEventBusStandalonePlatformConvergenceAlsoProbesNormalRunCompletion(t *t
 	}
 	if len(store.normalEvents) != 1 || store.normalEvents[0] != "event-2" {
 		t.Fatalf("normal completion events = %#v, want event-2", store.normalEvents)
+	}
+}
+
+func TestEventBusNormalRunCompletionUsesRootTerminalStatesNotChildAggregate(t *testing.T) {
+	store := &normalRunCompletionTestStore{}
+	eb, err := NewEventBusWithOptions(store, EventBusOptions{
+		ContractBundle: semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
+			Package: runtimecontracts.ProjectPackageDocument{Name: "root-workflow"},
+			RootSchema: &runtimecontracts.FlowSchemaDocument{
+				StageDeclarations: runtimecontracts.FlowStageDeclarations{
+					Declared: true,
+					Entries: []runtimecontracts.FlowStageDeclaration{
+						{ID: "ready", Initial: true},
+						{ID: "done"},
+						{ID: "archived", Terminal: true},
+					},
+				},
+			},
+			Paths: runtimecontracts.ContractPaths{Flows: []runtimecontracts.FlowContractPaths{
+				{ID: "child", Flow: "child"},
+			}},
+			FlowSchemas: map[string]runtimecontracts.FlowSchemaDocument{
+				"child": {
+					StageDeclarations: runtimecontracts.FlowStageDeclarations{
+						Declared: true,
+						Entries: []runtimecontracts.FlowStageDeclaration{
+							{ID: "ready", Initial: true},
+							{ID: "done", Terminal: true},
+						},
+					},
+				},
+			},
+			Semantics: runtimecontracts.WorkflowSemanticView{
+				Name:           "root-workflow",
+				TerminalStages: []string{"done", "archived"},
+				FlowTerminal: map[string][]string{
+					"child": {"done"},
+				},
+			},
+		}),
+	})
+	if err != nil {
+		t.Fatalf("NewEventBusWithOptions: %v", err)
+	}
+
+	if err := eb.ConvergeNormalRunCompletionForEvent(context.Background(), "event-3"); err != nil {
+		t.Fatalf("ConvergeNormalRunCompletionForEvent: %v", err)
+	}
+
+	if got, want := store.workflowTerms, []string{"archived"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("workflow terminals = %#v, want root-only %#v", got, want)
+	}
+	if got, want := store.flowTerms["child"], []string{"done"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("child flow terminals = %#v, want %#v", got, want)
 	}
 }

--- a/internal/runtime/contracts/workflow_contract_accessors.go
+++ b/internal/runtime/contracts/workflow_contract_accessors.go
@@ -390,15 +390,7 @@ func rootSchemaStates(root *FlowSchemaDocument) []string {
 	if root == nil {
 		return nil
 	}
-	out := make([]string, 0, len(root.States))
-	for _, state := range root.States {
-		state = strings.TrimSpace(state)
-		if state == "" {
-			continue
-		}
-		out = append(out, state)
-	}
-	return out
+	return root.LoweredStates()
 }
 
 func (b *WorkflowContractBundle) FlowTerminalStages(flowID string) []string {
@@ -406,13 +398,23 @@ func (b *WorkflowContractBundle) FlowTerminalStages(flowID string) []string {
 		return nil
 	}
 	flowID = strings.TrimSpace(flowID)
+	if flowID == "" {
+		return rootSchemaTerminalStates(b.RootSchema)
+	}
 	if terminal := b.Semantics.FlowTerminal[flowID]; len(terminal) > 0 {
 		return append([]string{}, terminal...)
 	}
 	if flowID != "" && flowID == b.WorkflowName() {
-		return append([]string{}, b.Semantics.TerminalStages...)
+		return rootSchemaTerminalStates(b.RootSchema)
 	}
 	return nil
+}
+
+func rootSchemaTerminalStates(root *FlowSchemaDocument) []string {
+	if root == nil {
+		return nil
+	}
+	return root.LoweredTerminalStates()
 }
 func (b *WorkflowContractBundle) FlowNamespace(flowID string) string {
 	if b == nil {

--- a/internal/runtime/contracts/workflow_contract_accessors.go
+++ b/internal/runtime/contracts/workflow_contract_accessors.go
@@ -375,6 +375,9 @@ func (b *WorkflowContractBundle) FlowStates(flowID string) []string {
 	}
 	flowID = strings.TrimSpace(flowID)
 	if flowID == "" {
+		if b.RootSchema == nil {
+			return workflowSemanticRootStates(b.Semantics)
+		}
 		return rootSchemaStates(b.RootSchema)
 	}
 	if states := b.Semantics.FlowStates[flowID]; len(states) > 0 {
@@ -384,6 +387,26 @@ func (b *WorkflowContractBundle) FlowStates(flowID string) []string {
 		return rootSchemaStates(b.RootSchema)
 	}
 	return nil
+}
+
+func workflowSemanticRootStates(semantics WorkflowSemanticView) []string {
+	out := make([]string, 0, len(semantics.Stages))
+	seen := make(map[string]struct{}, len(semantics.Stages))
+	for _, stage := range semantics.Stages {
+		if strings.TrimSpace(stage.Phase) != "" {
+			continue
+		}
+		id := strings.TrimSpace(stage.ID)
+		if id == "" {
+			continue
+		}
+		if _, ok := seen[id]; ok {
+			continue
+		}
+		seen[id] = struct{}{}
+		out = append(out, id)
+	}
+	return out
 }
 
 func rootSchemaStates(root *FlowSchemaDocument) []string {
@@ -399,6 +422,9 @@ func (b *WorkflowContractBundle) FlowTerminalStages(flowID string) []string {
 	}
 	flowID = strings.TrimSpace(flowID)
 	if flowID == "" {
+		if b.RootSchema == nil {
+			return append([]string{}, b.Semantics.TerminalStages...)
+		}
 		return rootSchemaTerminalStates(b.RootSchema)
 	}
 	if terminal := b.Semantics.FlowTerminal[flowID]; len(terminal) > 0 {

--- a/internal/runtime/contracts/workflow_contract_accessors_test.go
+++ b/internal/runtime/contracts/workflow_contract_accessors_test.go
@@ -40,6 +40,59 @@ func TestFlowStatesRootScopeExcludesChildFlowStates(t *testing.T) {
 	}
 }
 
+func TestAuthoredStagesLowerPerFlowScopedLifecycle(t *testing.T) {
+	bundle := &WorkflowContractBundle{
+		Package: ProjectPackageDocument{Name: "root-workflow", Version: "1.0.0"},
+		RootSchema: &FlowSchemaDocument{
+			StageDeclarations: FlowStageDeclarations{
+				Declared: true,
+				Entries: []FlowStageDeclaration{
+					{ID: "ready", Initial: true},
+					{ID: "done", Terminal: true},
+				},
+			},
+		},
+		Paths: ContractPaths{Flows: []FlowContractPaths{
+			{ID: "child", Flow: "child"},
+		}},
+		FlowSchemas: map[string]FlowSchemaDocument{
+			"child": {
+				StageDeclarations: FlowStageDeclarations{
+					Declared: true,
+					Entries: []FlowStageDeclaration{
+						{ID: "ready", Initial: true},
+						{ID: "done", Terminal: true},
+					},
+				},
+			},
+		},
+	}
+	populateWorkflowSemantics(bundle)
+
+	if got, want := bundle.FlowInitialStage(""), "ready"; got != want {
+		t.Fatalf("FlowInitialStage(root) = %q, want %q", got, want)
+	}
+	if got, want := bundle.FlowStates(""), []string{"ready", "done"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("FlowStates(root) = %#v, want %#v", got, want)
+	}
+	if got, want := bundle.FlowTerminalStages("child"), []string{"done"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("FlowTerminalStages(child) = %#v, want %#v", got, want)
+	}
+	stages := bundle.WorkflowStages()
+	if len(stages) != 4 {
+		t.Fatalf("WorkflowStages length = %d, want root+child scoped duplicates", len(stages))
+	}
+	var childReady bool
+	for _, stage := range stages {
+		if stage.ID == "ready" && stage.Phase == "child" {
+			childReady = true
+		}
+	}
+	if !childReady {
+		t.Fatalf("WorkflowStages = %#v, want child-scoped ready stage", stages)
+	}
+}
+
 func TestResolveFlowInputAutoWire_DoesNotInferSiblingProducerForUniquePinMatch(t *testing.T) {
 	producer := FlowContractView{
 		Paths: FlowContractPaths{ID: "producer", Flow: "producer"},

--- a/internal/runtime/contracts/workflow_contract_accessors_test.go
+++ b/internal/runtime/contracts/workflow_contract_accessors_test.go
@@ -36,7 +36,7 @@ func TestFlowStatesRootScopeExcludesChildFlowStates(t *testing.T) {
 		t.Fatalf("FlowStates(child) = %#v, want %#v", got, want)
 	}
 	if got := bundle.WorkflowStages(); len(got) != 4 {
-		t.Fatalf("WorkflowStages length = %d, want aggregate root+child states", len(got))
+		t.Fatalf("WorkflowStages length = %d, want runtime-safe aggregate root+child states", len(got))
 	}
 }
 
@@ -78,9 +78,15 @@ func TestAuthoredStagesLowerPerFlowScopedLifecycle(t *testing.T) {
 	if got, want := bundle.FlowTerminalStages("child"), []string{"done"}; !reflect.DeepEqual(got, want) {
 		t.Fatalf("FlowTerminalStages(child) = %#v, want %#v", got, want)
 	}
+	if got, want := bundle.FlowInitialStage("child"), "ready"; got != want {
+		t.Fatalf("FlowInitialStage(child) = %q, want %q", got, want)
+	}
+	if got, want := bundle.FlowStates("child"), []string{"ready", "done"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("FlowStates(child) = %#v, want %#v", got, want)
+	}
 	stages := bundle.WorkflowStages()
-	if len(stages) != 4 {
-		t.Fatalf("WorkflowStages length = %d, want root+child scoped duplicates", len(stages))
+	if len(stages) != 2 {
+		t.Fatalf("WorkflowStages length = %d, want runtime-safe deduped aggregate", len(stages))
 	}
 	var childReady bool
 	for _, stage := range stages {
@@ -88,8 +94,8 @@ func TestAuthoredStagesLowerPerFlowScopedLifecycle(t *testing.T) {
 			childReady = true
 		}
 	}
-	if !childReady {
-		t.Fatalf("WorkflowStages = %#v, want child-scoped ready stage", stages)
+	if childReady {
+		t.Fatalf("WorkflowStages = %#v, want child duplicate hidden from global runtime aggregate", stages)
 	}
 }
 

--- a/internal/runtime/contracts/workflow_contract_semantics.go
+++ b/internal/runtime/contracts/workflow_contract_semantics.go
@@ -66,9 +66,9 @@ func populateWorkflowSemantics(bundle *WorkflowContractBundle) {
 		if flowID == "" {
 			continue
 		}
-		semantics.FlowInitial[flowID] = strings.TrimSpace(schema.InitialState)
-		semantics.FlowStates[flowID] = append([]string{}, schema.States...)
-		semantics.FlowTerminal[flowID] = append([]string{}, schema.TerminalStates...)
+		semantics.FlowInitial[flowID] = schema.LoweredInitialState()
+		semantics.FlowStates[flowID] = schema.LoweredStates()
+		semantics.FlowTerminal[flowID] = schema.LoweredTerminalStates()
 		assignedNamespace := strings.TrimSpace(flowAssignedNamespace(bundle.Paths.Flows, flowID))
 		if assignedNamespace == "" {
 			assignedNamespace = strings.TrimSpace(schema.NamespacePrefix)
@@ -657,23 +657,20 @@ func rootSchemaInitialStage(root *FlowSchemaDocument) string {
 	if root == nil {
 		return ""
 	}
-	return strings.TrimSpace(root.InitialState)
+	return root.LoweredInitialState()
 }
 
 func deriveWorkflowStages(root *FlowSchemaDocument, paths []FlowContractPaths, schemas map[string]FlowSchemaDocument) []WorkflowStageContract {
 	out := make([]WorkflowStageContract, 0)
 	seen := make(map[string]struct{})
 	if root != nil {
-		for _, state := range root.States {
-			state = strings.TrimSpace(state)
-			if state == "" {
+		for _, stage := range root.LoweredWorkflowStages("") {
+			key := workflowStageScopeKey("", stage.ID)
+			if _, exists := seen[key]; exists {
 				continue
 			}
-			if _, exists := seen[state]; exists {
-				continue
-			}
-			seen[state] = struct{}{}
-			out = append(out, WorkflowStageContract{ID: state})
+			seen[key] = struct{}{}
+			out = append(out, stage)
 		}
 	}
 	for _, flow := range paths {
@@ -682,29 +679,27 @@ func deriveWorkflowStages(root *FlowSchemaDocument, paths []FlowContractPaths, s
 		if !ok {
 			continue
 		}
-		for _, state := range schema.States {
-			state = strings.TrimSpace(state)
-			if state == "" {
+		for _, stage := range schema.LoweredWorkflowStages(flowID) {
+			key := workflowStageScopeKey(flowID, stage.ID)
+			if _, exists := seen[key]; exists {
 				continue
 			}
-			if _, exists := seen[state]; exists {
-				continue
-			}
-			seen[state] = struct{}{}
-			out = append(out, WorkflowStageContract{
-				ID:    state,
-				Phase: flowID,
-			})
+			seen[key] = struct{}{}
+			out = append(out, stage)
 		}
 	}
 	return out
+}
+
+func workflowStageScopeKey(flowID, stageID string) string {
+	return strings.TrimSpace(flowID) + "\x00" + strings.TrimSpace(stageID)
 }
 
 func deriveWorkflowTerminalStages(root *FlowSchemaDocument, paths []FlowContractPaths, schemas map[string]FlowSchemaDocument) []string {
 	out := make([]string, 0)
 	seen := make(map[string]struct{})
 	if root != nil {
-		for _, state := range root.TerminalStates {
+		for _, state := range root.LoweredTerminalStates() {
 			state = strings.TrimSpace(state)
 			if state == "" {
 				continue
@@ -722,7 +717,7 @@ func deriveWorkflowTerminalStages(root *FlowSchemaDocument, paths []FlowContract
 		if !ok {
 			continue
 		}
-		for _, state := range schema.TerminalStates {
+		for _, state := range schema.LoweredTerminalStates() {
 			state = strings.TrimSpace(state)
 			if state == "" {
 				continue

--- a/internal/runtime/contracts/workflow_contract_semantics.go
+++ b/internal/runtime/contracts/workflow_contract_semantics.go
@@ -665,7 +665,7 @@ func deriveWorkflowStages(root *FlowSchemaDocument, paths []FlowContractPaths, s
 	seen := make(map[string]struct{})
 	if root != nil {
 		for _, stage := range root.LoweredWorkflowStages("") {
-			key := workflowStageScopeKey("", stage.ID)
+			key := strings.TrimSpace(stage.ID)
 			if _, exists := seen[key]; exists {
 				continue
 			}
@@ -680,7 +680,7 @@ func deriveWorkflowStages(root *FlowSchemaDocument, paths []FlowContractPaths, s
 			continue
 		}
 		for _, stage := range schema.LoweredWorkflowStages(flowID) {
-			key := workflowStageScopeKey(flowID, stage.ID)
+			key := strings.TrimSpace(stage.ID)
 			if _, exists := seen[key]; exists {
 				continue
 			}
@@ -689,10 +689,6 @@ func deriveWorkflowStages(root *FlowSchemaDocument, paths []FlowContractPaths, s
 		}
 	}
 	return out
-}
-
-func workflowStageScopeKey(flowID, stageID string) string {
-	return strings.TrimSpace(flowID) + "\x00" + strings.TrimSpace(stageID)
 }
 
 func deriveWorkflowTerminalStages(root *FlowSchemaDocument, paths []FlowContractPaths, schemas map[string]FlowSchemaDocument) []string {

--- a/internal/runtime/contracts/workflow_contract_stages.go
+++ b/internal/runtime/contracts/workflow_contract_stages.go
@@ -1,0 +1,231 @@
+package contracts
+
+import (
+	"fmt"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+type FlowStageDeclarations struct {
+	Declared bool
+	Entries  []FlowStageDeclaration
+}
+
+type FlowStageDeclaration struct {
+	ID          string `yaml:"-"`
+	Initial     bool   `yaml:"initial"`
+	Terminal    bool   `yaml:"terminal"`
+	Description string `yaml:"description"`
+}
+
+func (d *FlowStageDeclarations) UnmarshalYAML(node *yaml.Node) error {
+	if d == nil {
+		return nil
+	}
+	*d = FlowStageDeclarations{Declared: true}
+	if node == nil || node.Kind == 0 {
+		return nil
+	}
+	if node.Kind == yaml.ScalarNode && strings.EqualFold(strings.TrimSpace(node.Tag), "!!null") {
+		return fmt.Errorf("stages must be a mapping or explicit empty sequence")
+	}
+	if node.Kind == yaml.SequenceNode {
+		if len(node.Content) == 0 {
+			return nil
+		}
+		return fmt.Errorf("stages must be a keyed mapping; only stages: [] is allowed as the explicit stateless form")
+	}
+	if node.Kind != yaml.MappingNode {
+		return fmt.Errorf("stages must be a keyed mapping or explicit empty sequence")
+	}
+	seen := map[string]struct{}{}
+	out := make([]FlowStageDeclaration, 0, len(node.Content)/2)
+	for i := 0; i+1 < len(node.Content); i += 2 {
+		key := strings.TrimSpace(node.Content[i].Value)
+		if key == "" {
+			return fmt.Errorf("stages contains an empty stage id")
+		}
+		if _, ok := seen[key]; ok {
+			return fmt.Errorf("stages contains duplicate stage id %q", key)
+		}
+		seen[key] = struct{}{}
+		var stage FlowStageDeclaration
+		if err := node.Content[i+1].Decode(&stage); err != nil {
+			return fmt.Errorf("stage %q: %w", key, err)
+		}
+		stage.ID = key
+		out = append(out, stage)
+	}
+	d.Entries = out
+	return nil
+}
+
+func (s *FlowStageDeclaration) UnmarshalYAML(node *yaml.Node) error {
+	if s == nil {
+		return nil
+	}
+	if node == nil || node.Kind == 0 {
+		*s = FlowStageDeclaration{}
+		return nil
+	}
+	if node.Kind == yaml.ScalarNode && strings.EqualFold(strings.TrimSpace(node.Tag), "!!null") {
+		*s = FlowStageDeclaration{}
+		return nil
+	}
+	if node.Kind != yaml.MappingNode {
+		return fmt.Errorf("stage declaration must be a mapping")
+	}
+	allowed := map[string]struct{}{
+		"initial":     {},
+		"terminal":    {},
+		"description": {},
+	}
+	for i := 0; i+1 < len(node.Content); i += 2 {
+		key := strings.TrimSpace(node.Content[i].Value)
+		if _, ok := allowed[key]; !ok {
+			return fmt.Errorf("UNDEFINED-FIELD: stage field %q not in platform spec", key)
+		}
+	}
+	type alias FlowStageDeclaration
+	var aux alias
+	if err := node.Decode(&aux); err != nil {
+		return err
+	}
+	*s = FlowStageDeclaration(aux)
+	return nil
+}
+
+func (d FlowStageDeclarations) StageIDs() []string {
+	out := make([]string, 0, len(d.Entries))
+	for _, stage := range d.Entries {
+		id := strings.TrimSpace(stage.ID)
+		if id != "" {
+			out = append(out, id)
+		}
+	}
+	return out
+}
+
+func (d FlowStageDeclarations) InitialStage() string {
+	for _, stage := range d.Entries {
+		if stage.Initial {
+			return strings.TrimSpace(stage.ID)
+		}
+	}
+	return ""
+}
+
+func (d FlowStageDeclarations) TerminalStages() []string {
+	out := make([]string, 0, len(d.Entries))
+	for _, stage := range d.Entries {
+		if stage.Terminal {
+			id := strings.TrimSpace(stage.ID)
+			if id != "" {
+				out = append(out, id)
+			}
+		}
+	}
+	return out
+}
+
+func (d FlowStageDeclarations) WorkflowStages(phase string) []WorkflowStageContract {
+	out := make([]WorkflowStageContract, 0, len(d.Entries))
+	for _, stage := range d.Entries {
+		id := strings.TrimSpace(stage.ID)
+		if id == "" {
+			continue
+		}
+		out = append(out, WorkflowStageContract{
+			ID:          id,
+			Phase:       strings.TrimSpace(phase),
+			Description: strings.TrimSpace(stage.Description),
+		})
+	}
+	return out
+}
+
+func (d FlowStageDeclarations) InitialCount() int {
+	count := 0
+	for _, stage := range d.Entries {
+		if stage.Initial {
+			count++
+		}
+	}
+	return count
+}
+
+func (d FlowStageDeclarations) TerminalCount() int {
+	count := 0
+	for _, stage := range d.Entries {
+		if stage.Terminal {
+			count++
+		}
+	}
+	return count
+}
+
+func (d FlowStageDeclarations) IsExplicitStateless() bool {
+	return d.Declared && len(d.Entries) == 0
+}
+
+func (s FlowSchemaDocument) UsesAuthoredStages() bool {
+	return s.StageDeclarations.Declared
+}
+
+func (s FlowSchemaDocument) HasLegacyLifecycleFields() bool {
+	return s.InitialStateDeclared || s.StatesDeclared || s.TerminalStatesDeclared
+}
+
+func (s FlowSchemaDocument) LoweredInitialState() string {
+	if s.StageDeclarations.Declared {
+		return s.StageDeclarations.InitialStage()
+	}
+	return strings.TrimSpace(s.InitialState)
+}
+
+func (s FlowSchemaDocument) LoweredStates() []string {
+	if s.StageDeclarations.Declared {
+		return s.StageDeclarations.StageIDs()
+	}
+	out := make([]string, 0, len(s.States))
+	for _, state := range s.States {
+		state = strings.TrimSpace(state)
+		if state != "" {
+			out = append(out, state)
+		}
+	}
+	return out
+}
+
+func (s FlowSchemaDocument) LoweredTerminalStates() []string {
+	if s.StageDeclarations.Declared {
+		return s.StageDeclarations.TerminalStages()
+	}
+	out := make([]string, 0, len(s.TerminalStates))
+	for _, state := range s.TerminalStates {
+		state = strings.TrimSpace(state)
+		if state != "" {
+			out = append(out, state)
+		}
+	}
+	return out
+}
+
+func (s FlowSchemaDocument) LoweredWorkflowStages(phase string) []WorkflowStageContract {
+	if s.StageDeclarations.Declared {
+		return s.StageDeclarations.WorkflowStages(phase)
+	}
+	out := make([]WorkflowStageContract, 0, len(s.States))
+	for _, state := range s.States {
+		state = strings.TrimSpace(state)
+		if state == "" {
+			continue
+		}
+		out = append(out, WorkflowStageContract{
+			ID:    state,
+			Phase: strings.TrimSpace(phase),
+		})
+	}
+	return out
+}

--- a/internal/runtime/contracts/workflow_contract_types.go
+++ b/internal/runtime/contracts/workflow_contract_types.go
@@ -1111,10 +1111,14 @@ type FlowSchemaDocument struct {
 	Entity                 string                          `yaml:"entity"`
 	Instance               FlowTemplateInstanceDeclaration `yaml:"instance"`
 	InitialState           string                          `yaml:"initial_state"`
+	InitialStateDeclared   bool                            `yaml:"-"`
 	NamespacePrefix        string                          `yaml:"-"`
 	NamespaceRule          string                          `yaml:"-"`
 	TerminalStates         []string                        `yaml:"terminal_states"`
+	TerminalStatesDeclared bool                            `yaml:"-"`
 	States                 []string                        `yaml:"states"`
+	StatesDeclared         bool                            `yaml:"-"`
+	StageDeclarations      FlowStageDeclarations           `yaml:"stages"`
 	Pins                   FlowPins                        `yaml:"pins"`
 	ToolSurface            FlowToolSurfaceContract         `yaml:"tool_surface"`
 	RequiredAgents         []FlowRequiredAgent             `yaml:"required_agents"`

--- a/internal/runtime/contracts/workflow_contract_yaml.go
+++ b/internal/runtime/contracts/workflow_contract_yaml.go
@@ -48,6 +48,9 @@ func (d *FlowSchemaDocument) UnmarshalYAML(node *yaml.Node) error {
 		return err
 	}
 	*d = FlowSchemaDocument(aux)
+	d.InitialStateDeclared = hasYAMLMappingKey(node, "initial_state")
+	d.StatesDeclared = hasYAMLMappingKey(node, "states")
+	d.TerminalStatesDeclared = hasYAMLMappingKey(node, "terminal_states")
 	d.RequiredAgentsDeclared = hasYAMLMappingKey(node, "required_agents")
 	return nil
 }
@@ -61,6 +64,7 @@ func validateFlowSchemaDocumentFields(node *yaml.Node) error {
 		"initial_state":       {},
 		"terminal_states":     {},
 		"states":              {},
+		"stages":              {},
 		"pins":                {},
 		"tool_surface":        {},
 		"required_agents":     {},

--- a/internal/runtime/contracts/workflow_contract_yaml_test.go
+++ b/internal/runtime/contracts/workflow_contract_yaml_test.go
@@ -125,6 +125,66 @@ requires:
 	}
 }
 
+func TestFlowSchemaDocumentDecodeStagesKeyedMap(t *testing.T) {
+	var doc FlowSchemaDocument
+	if err := yaml.Unmarshal([]byte(`
+name: validation
+stages:
+  queued:
+    initial: true
+    description: Waiting for work
+  approved:
+    terminal: true
+`), &doc); err != nil {
+		t.Fatalf("yaml.Unmarshal: %v", err)
+	}
+	if !doc.UsesAuthoredStages() {
+		t.Fatalf("UsesAuthoredStages = false, want true")
+	}
+	if got, want := doc.LoweredInitialState(), "queued"; got != want {
+		t.Fatalf("LoweredInitialState = %q, want %q", got, want)
+	}
+	if got, want := doc.LoweredStates(), []string{"queued", "approved"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("LoweredStates = %#v, want %#v", got, want)
+	}
+	if got, want := doc.LoweredTerminalStates(), []string{"approved"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("LoweredTerminalStates = %#v, want %#v", got, want)
+	}
+	stages := doc.LoweredWorkflowStages("validation")
+	if len(stages) != 2 || stages[0].ID != "queued" || stages[0].Phase != "validation" || stages[0].Description != "Waiting for work" {
+		t.Fatalf("LoweredWorkflowStages = %#v", stages)
+	}
+}
+
+func TestFlowSchemaDocumentDecodeStagesExplicitEmpty(t *testing.T) {
+	var doc FlowSchemaDocument
+	if err := yaml.Unmarshal([]byte(`
+name: discovery
+stages: []
+`), &doc); err != nil {
+		t.Fatalf("yaml.Unmarshal: %v", err)
+	}
+	if !doc.UsesAuthoredStages() {
+		t.Fatalf("UsesAuthoredStages = false, want true")
+	}
+	if len(doc.LoweredStates()) != 0 || doc.LoweredInitialState() != "" || len(doc.LoweredTerminalStates()) != 0 {
+		t.Fatalf("lowered explicit stateless lifecycle = initial %q states %#v terminals %#v, want empty", doc.LoweredInitialState(), doc.LoweredStates(), doc.LoweredTerminalStates())
+	}
+}
+
+func TestFlowSchemaDocumentDecodeRejectsNonEmptyStageSequence(t *testing.T) {
+	var doc FlowSchemaDocument
+	err := yaml.Unmarshal([]byte(`
+name: validation
+stages:
+  - id: queued
+    initial: true
+`), &doc)
+	if err == nil || !strings.Contains(err.Error(), "stages must be a keyed mapping") {
+		t.Fatalf("yaml.Unmarshal error = %v, want keyed mapping rejection", err)
+	}
+}
+
 func TestProjectPackageDocumentDecode_ListPolicyRequiresAreRequiredNoDefault(t *testing.T) {
 	var doc ProjectPackageDocument
 	if err := yaml.Unmarshal([]byte(`

--- a/internal/runtime/engine/executor.go
+++ b/internal/runtime/engine/executor.go
@@ -3087,7 +3087,7 @@ func (e *Executor) applyGuardFailure(frame *executionFrame, spec *runtimecontrac
 	case GuardFailureKill:
 		frame.result.Status = OutcomeKilled
 		frame.result.ActionsExecuted = append(frame.result.ActionsExecuted, "kill")
-		if killedState := e.killStateTarget(); killedState != "" {
+		if killedState := e.killStateTarget(frame.req.FlowID.String()); killedState != "" {
 			frame.result.NextState = killedState
 			frame.state.State.CurrentState = killedState
 			frame.result.StateMutation.NextState = killedState
@@ -3123,18 +3123,25 @@ func (e *Executor) applyGuardFailure(frame *executionFrame, spec *runtimecontrac
 	}
 }
 
-func (e *Executor) killStateTarget() string {
+func (e *Executor) killStateTarget(flowID string) string {
 	if e == nil || e.deps.Source == nil {
 		return ""
 	}
-	for _, stage := range e.deps.Source.WorkflowTerminalStages() {
+	flowID = strings.TrimSpace(flowID)
+	terminals := e.deps.Source.FlowTerminalStages(flowID)
+	states := e.deps.Source.FlowStates(flowID)
+	if flowID != "" && len(terminals) == 0 && len(states) == 0 {
+		terminals = e.deps.Source.FlowTerminalStages("")
+		states = e.deps.Source.FlowStates("")
+	}
+	for _, stage := range terminals {
 		if strings.EqualFold(strings.TrimSpace(stage), "killed") {
 			return strings.TrimSpace(stage)
 		}
 	}
-	for _, stage := range e.deps.Source.WorkflowStages() {
-		if strings.EqualFold(strings.TrimSpace(stage.ID), "killed") {
-			return strings.TrimSpace(stage.ID)
+	for _, stage := range states {
+		if strings.EqualFold(strings.TrimSpace(stage), "killed") {
+			return strings.TrimSpace(stage)
 		}
 	}
 	return ""

--- a/internal/runtime/manager/flow_activation.go
+++ b/internal/runtime/manager/flow_activation.go
@@ -81,7 +81,7 @@ func (am *AgentManager) ActivateFlowInstance(ctx context.Context, req runtimepip
 		return fmt.Errorf("derive flow entity id for %s", flowPath)
 	}
 	parentEntityID := strings.TrimSpace(instance.ParentEntityID)
-	initialState := strings.TrimSpace(schema.InitialState)
+	initialState := strings.TrimSpace(schema.LoweredInitialState())
 	if initialState == "" {
 		initialState = strings.TrimSpace(req.InitialState)
 	}

--- a/internal/runtime/manager/flow_activation_test.go
+++ b/internal/runtime/manager/flow_activation_test.go
@@ -436,6 +436,33 @@ func TestActivateFlowInstanceAddsDerivedRouteTableInstance(t *testing.T) {
 	}
 }
 
+func TestActivateFlowInstanceUsesStagedInitialState(t *testing.T) {
+	bus := &flowActivationTestBus{}
+	store := &flowActivationTestInstanceStore{}
+	am := newFlowActivationManager(bus, store)
+	bundle := testFlowBundle("")
+	schema := bundle.FlowSchemas["review"]
+	schema.StageDeclarations = runtimecontracts.FlowStageDeclarations{
+		Declared: true,
+		Entries: []runtimecontracts.FlowStageDeclaration{
+			{ID: "queued", Initial: true},
+			{ID: "done", Terminal: true},
+		},
+	}
+	bundle.FlowSchemas["review"] = schema
+
+	req := testActivationRequest(bundle, "review", "inst-1", "ent-1", "review/inst-1")
+	if err := am.ActivateFlowInstance(context.Background(), req); err != nil {
+		t.Fatalf("ActivateFlowInstance: %v", err)
+	}
+	if len(store.creates) != 1 {
+		t.Fatalf("creates = %d, want 1", len(store.creates))
+	}
+	if got := store.creates[0].CurrentState; got != "queued" {
+		t.Fatalf("created instance current state = %q, want queued", got)
+	}
+}
+
 func TestActivateFlowInstancePassesActivationConfigToRouteMaterialization(t *testing.T) {
 	bus := &flowActivationTestBus{}
 	am := newFlowActivationManager(bus, &flowActivationTestInstanceStore{})

--- a/internal/runtime/pipeline/engine_adapter.go
+++ b/internal/runtime/pipeline/engine_adapter.go
@@ -675,22 +675,27 @@ func (r pipelineEngineGuardRunner) EvaluateGuard(ctx context.Context, id identit
 		}
 		return strings.TrimSpace(asString(payload["mailbox_decision_id"])) != "", true, nil
 	case "not_in_terminal_state", "not_in_terminal_stage":
-		if pc.SemanticSource() == nil {
+		source := pc.SemanticSource()
+		if source == nil {
 			return true, true, nil
 		}
 		currentState := strings.TrimSpace(string(state.Stage))
 		if currentState == "" {
 			return true, true, nil
 		}
+		flowID := strings.TrimSpace(execCtx.Request.FlowID.String())
+		for _, candidateFlowID := range terminalStateFlowCandidates(source, flowID, *state) {
+			if terminalStageContains(source.FlowTerminalStages(candidateFlowID), currentState) {
+				return false, true, nil
+			}
+			if stageSetContains(source.FlowStates(candidateFlowID), currentState) {
+				return true, true, nil
+			}
+		}
 		workflow := pc.WorkflowDefinition()
 		if workflow != nil {
 			if stage, ok := workflow.Stage(state.Stage); ok {
 				return !stage.Terminal, true, nil
-			}
-		}
-		for _, terminal := range pc.SemanticSource().WorkflowTerminalStages() {
-			if strings.EqualFold(strings.TrimSpace(terminal), currentState) {
-				return false, true, nil
 			}
 		}
 		return true, true, nil
@@ -1068,6 +1073,9 @@ func (pc *PipelineCoordinator) isTerminalFlowState(flowID, state string) bool {
 			if strings.EqualFold(strings.TrimSpace(terminal), state) {
 				return true
 			}
+		}
+		if len(source.FlowStates(flowID)) > 0 {
+			return false
 		}
 	}
 	workflow := pc.WorkflowDefinition()

--- a/internal/runtime/pipeline/engine_bridge.go
+++ b/internal/runtime/pipeline/engine_bridge.go
@@ -187,7 +187,7 @@ func (pc *PipelineCoordinator) executeNodeContractHandler(
 	if !handler.CreateEntity && entityID != "" && originalEntityID != "" && originalEntityID != entityID && strings.TrimSpace(triggerCtx.State.EntityID) == "" {
 		triggerCtx.State.EntityID = entityID
 	}
-	if terminalStateHandlerRejected(pc, triggerCtx.State, handler) {
+	if terminalStateHandlerRejected(pc, flowID, triggerCtx.State, handler) {
 		outcome := &handlerExecutionOutcome{
 			Status:          HandlerOutcomeTerminalReject,
 			GuardsEvaluated: []string{"not_in_terminal_state"},
@@ -436,7 +436,7 @@ func handlerOutcomeStatusFromEngine(status runtimeengine.OutcomeStatus) HandlerO
 	}
 }
 
-func terminalStateHandlerRejected(pc *PipelineCoordinator, state WorkflowState, _ runtimecontracts.SystemNodeEventHandler) bool {
+func terminalStateHandlerRejected(pc *PipelineCoordinator, flowID string, state WorkflowState, _ runtimecontracts.SystemNodeEventHandler) bool {
 	if pc == nil {
 		return false
 	}
@@ -444,18 +444,82 @@ func terminalStateHandlerRejected(pc *PipelineCoordinator, state WorkflowState, 
 	if currentState == "" {
 		return false
 	}
+	source := pc.SemanticSource()
+	if source != nil {
+		for _, candidateFlowID := range terminalStateFlowCandidates(source, flowID, state) {
+			if terminalStageContains(source.FlowTerminalStages(candidateFlowID), currentState) {
+				return true
+			}
+			if stageSetContains(source.FlowStates(candidateFlowID), currentState) {
+				return false
+			}
+		}
+	}
 	workflow := pc.WorkflowDefinition()
 	if workflow != nil {
 		if stage, ok := workflow.Stage(state.Stage); ok {
 			return stage.Terminal
 		}
 	}
-	source := pc.SemanticSource()
-	if source == nil {
+	return false
+}
+
+func terminalStateFlowCandidates(source semanticview.Source, flowID string, state WorkflowState) []string {
+	seen := map[string]struct{}{}
+	out := []string{}
+	add := func(candidate string) {
+		candidate = strings.TrimSpace(candidate)
+		if candidate == "" {
+			return
+		}
+		if _, ok := seen[candidate]; ok {
+			return
+		}
+		seen[candidate] = struct{}{}
+		out = append(out, candidate)
+	}
+	add(flowIDForWorkflowState(source, state))
+	add(flowID)
+	return out
+}
+
+func flowIDForWorkflowState(source semanticview.Source, state WorkflowState) string {
+	if source == nil || len(state.Metadata) == 0 {
+		return ""
+	}
+	flowPath := strings.Trim(strings.TrimSpace(asString(state.Metadata["flow_path"])), "/")
+	if flowPath == "" {
+		return ""
+	}
+	bestID := ""
+	bestLen := -1
+	for _, scope := range source.FlowScopes() {
+		path := strings.Trim(strings.TrimSpace(scope.Path), "/")
+		if path == "" {
+			continue
+		}
+		if flowPath != path && !strings.HasPrefix(flowPath, path+"/") {
+			continue
+		}
+		if len(path) > bestLen {
+			bestLen = len(path)
+			bestID = strings.TrimSpace(scope.ID)
+		}
+	}
+	return bestID
+}
+
+func terminalStageContains(stages []string, current string) bool {
+	return stageSetContains(stages, current)
+}
+
+func stageSetContains(stages []string, current string) bool {
+	current = strings.TrimSpace(current)
+	if current == "" {
 		return false
 	}
-	for _, terminal := range source.WorkflowTerminalStages() {
-		if strings.EqualFold(strings.TrimSpace(terminal), currentState) {
+	for _, stage := range stages {
+		if strings.EqualFold(strings.TrimSpace(stage), current) {
 			return true
 		}
 	}

--- a/internal/runtime/pipeline/workflow.go
+++ b/internal/runtime/pipeline/workflow.go
@@ -302,14 +302,6 @@ func LoadWorkflowDefinition(source semanticview.Source) (*WorkflowDefinition, er
 	if name == "" {
 		return nil, fmt.Errorf("workflow.name missing from contract bundle semantics")
 	}
-	terminalStages := source.WorkflowTerminalStages()
-	terminal := make(map[string]struct{}, len(terminalStages))
-	for _, stageID := range terminalStages {
-		stageID = strings.TrimSpace(stageID)
-		if stageID != "" {
-			terminal[stageID] = struct{}{}
-		}
-	}
 	stageContracts := source.WorkflowStages()
 	stages := make([]WorkflowStage, 0, len(stageContracts))
 	for _, stage := range stageContracts {
@@ -317,12 +309,11 @@ func LoadWorkflowDefinition(source semanticview.Source) (*WorkflowDefinition, er
 		if stageID == "" {
 			continue
 		}
-		_, isTerminal := terminal[stageID]
 		stages = append(stages, WorkflowStage{
 			Name:        WorkflowStateID(stageID),
 			Phase:       strings.TrimSpace(stage.Phase),
 			Description: strings.TrimSpace(stage.Description),
-			Terminal:    isTerminal,
+			Terminal:    workflowStageContractTerminal(source, stage),
 		})
 	}
 	actionInstructions := source.ActionInstructions()
@@ -381,6 +372,22 @@ func LoadWorkflowDefinition(source semanticview.Source) (*WorkflowDefinition, er
 		})
 	}
 	return NewWorkflowDefinition(name, stages, transitions), nil
+}
+
+func workflowStageContractTerminal(source semanticview.Source, stage runtimecontracts.WorkflowStageContract) bool {
+	if source == nil {
+		return false
+	}
+	stageID := strings.TrimSpace(stage.ID)
+	if stageID == "" {
+		return false
+	}
+	for _, terminal := range source.FlowTerminalStages(strings.TrimSpace(stage.Phase)) {
+		if strings.TrimSpace(terminal) == stageID {
+			return true
+		}
+	}
+	return false
 }
 
 func workflowTransitionFromStages(raw any) []WorkflowStateID {

--- a/internal/runtime/pipeline/workflow_terminal_test.go
+++ b/internal/runtime/pipeline/workflow_terminal_test.go
@@ -1,6 +1,11 @@
 package pipeline
 
-import "testing"
+import (
+	"testing"
+
+	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
+	"github.com/division-sh/swarm/internal/runtime/semanticview"
+)
 
 func TestWorkflowDefinition_BlocksTerminalExitByDefault(t *testing.T) {
 	workflow := NewWorkflowDefinition("demo", []WorkflowStage{
@@ -36,5 +41,43 @@ func TestWorkflowDefinition_AllowsExplicitTerminalExit(t *testing.T) {
 	})
 	if !workflow.CanTransition(WorkflowState{Stage: "done"}, "reopened") {
 		t.Fatal("expected explicit allow_terminal_exit transition to pass")
+	}
+}
+
+func TestLoadWorkflowDefinitionUsesFlowScopedTerminalOwnership(t *testing.T) {
+	bundle := &runtimecontracts.WorkflowContractBundle{
+		Package: runtimecontracts.ProjectPackageDocument{Name: "demo", Version: "1.0.0"},
+		RootSchema: &runtimecontracts.FlowSchemaDocument{
+			StageDeclarations: runtimecontracts.FlowStageDeclarations{
+				Declared: true,
+				Entries: []runtimecontracts.FlowStageDeclaration{
+					{ID: "ready", Initial: true},
+					{ID: "done"},
+				},
+			},
+		},
+		Semantics: runtimecontracts.WorkflowSemanticView{
+			Name: "demo",
+			Stages: []runtimecontracts.WorkflowStageContract{
+				{ID: "ready"},
+				{ID: "done"},
+			},
+			TerminalStages: []string{"done"},
+			FlowTerminal: map[string][]string{
+				"child": []string{"done"},
+			},
+		},
+	}
+
+	workflow, err := LoadWorkflowDefinition(semanticview.Wrap(bundle))
+	if err != nil {
+		t.Fatalf("LoadWorkflowDefinition: %v", err)
+	}
+	done, ok := workflow.Stage("done")
+	if !ok {
+		t.Fatal("missing done stage")
+	}
+	if done.Terminal {
+		t.Fatalf("done terminal = true, want false because only child flow owns done as terminal")
 	}
 }

--- a/internal/runtime/semanticview/bundle_source.go
+++ b/internal/runtime/semanticview/bundle_source.go
@@ -104,6 +104,14 @@ func (s bundleSource) FlowSchemaEntries() map[string]runtimecontracts.FlowSchema
 	}
 	return out
 }
+
+func (s bundleSource) RootFlowSchema() (runtimecontracts.FlowSchemaDocument, bool) {
+	if s.bundle == nil || s.bundle.RootSchema == nil {
+		return runtimecontracts.FlowSchemaDocument{}, false
+	}
+	return *s.bundle.RootSchema, true
+}
+
 func (s bundleSource) FlowInitialStage(flowID string) string {
 	return s.bundle.FlowInitialStage(flowID)
 }

--- a/internal/store/runtime_mutation.go
+++ b/internal/store/runtime_mutation.go
@@ -3,6 +3,7 @@ package store
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -107,6 +108,9 @@ func (s *SQLiteRuntimeStore) runRuntimeMutation(ctx context.Context, label strin
 				if err := ctx.Err(); err != nil {
 					return err
 				}
+				if hasCtxDeadline && errors.Is(attemptErr, context.DeadlineExceeded) && !time.Now().Before(ctxDeadline) {
+					return context.DeadlineExceeded
+				}
 				return sqliteRuntimeMutationRetryBudgetError(label, lastErr)
 			}
 			return nil
@@ -114,6 +118,9 @@ func (s *SQLiteRuntimeStore) runRuntimeMutation(ctx context.Context, label strin
 		if attemptErr != nil {
 			if err := ctx.Err(); err != nil {
 				return err
+			}
+			if hasCtxDeadline && errors.Is(attemptErr, context.DeadlineExceeded) && !time.Now().Before(ctxDeadline) {
+				return context.DeadlineExceeded
 			}
 			return sqliteRuntimeMutationRetryBudgetError(label, lastErr)
 		}

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -206,10 +206,11 @@ contract_formats:
     rule: A flow with no agents needs no prompts/. A flow with no handlers needs no nodes.yaml. A flow with no events needs
       no events.yaml.
   flow_schema:
-    description: Canonical `schema.yaml` flow declaration surface for state machine and pin declarations.
+    description: Canonical `schema.yaml` flow declaration surface for lifecycle stage-node and pin declarations.
     owner_file: contracts/flows/<flow>/schema.yaml
     bundle_scope_exception: contracts/schema.yaml for the root flow
     owned_concepts:
+    - stages
     - initial_state
     - terminal_states
     - states
@@ -218,6 +219,24 @@ contract_formats:
     rule: Flow reachability, declared state membership, and flow-local pin event declarations resolve against this parsed
       owner. Runtime liveness and temporal progress are separate runtime concerns. Entity ownership is not selected in
       schema.yaml for normal flows; the single flow-owned `entities.yaml` entry is authoritative.
+    stages_authoring:
+      status: merge_bearing_first_slice
+      implementation_tracker: '#1845'
+      rule: >
+        `stages:` is the canonical lifecycle node authoring owner for staged
+        bundles. It is a keyed mapping whose keys are per-flow stage IDs and
+        whose values carry declaration metadata such as `initial: true`,
+        `terminal: true`, and `description`. It lowers to the existing
+        `initial_state` / `states` / `terminal_states` kernel. It does not
+        replace transition-edge carriers; handlers still contribute edges
+        through `advances_to`, `rules`, and `on_complete` in this slice.
+      stateless_form: >
+        `stages: []` is the explicit stateless form for staged bundles.
+      mutual_exclusion: >
+        `stages:` is mutually exclusive with legacy lifecycle authoring fields
+        `initial_state`, `states`, and `terminal_states` in the same schema.
+        Legacy fields remain accepted as explicit legacy/kernel input until a
+        later migration removes them from public authoring.
   entity_schema:
     description: |
       `package.yaml.entity_schema` is retired. Authoritative entity
@@ -1934,8 +1953,10 @@ runtime_enforcement:
 state_machine_authority:
   description: |
     The flow state machine declared in schema.yaml is the authority for
-    entity lifecycle phase. State is flow-scoped, not per-entity-type,
-    and Wave 1 assumes one entity type per flow.
+    entity lifecycle phase. For staged bundles, `stages:` is the canonical
+    lifecycle node authoring owner and lowers to the existing state-machine
+    kernel. State is flow-scoped, not per-entity-type, and Wave 1 assumes one
+    entity type per flow.
   rules:
     state_field_is_implicit: |
       Authors do not declare a state_field anywhere. _entity.current_state is
@@ -1944,8 +1965,13 @@ state_machine_authority:
       named current_state remains ordinary business data and is read as
       entity.current_state; it is not the lifecycle state carrier.
     stateless_flows: |
-      Stateless flows declare initial_state: null, states: [], and
-      terminal_states: []. For them, _entity.current_state is null.
+      Staged stateless flows declare stages: []. Legacy stateless flows may
+      declare initial_state: null, states: [], and terminal_states: []. For
+      them, _entity.current_state is null.
+    stages_are_flat_and_flow_scoped: |
+      Stage IDs are scoped to the flow that declares them. Nested/statechart
+      hierarchy is not part of this slice. Flow composition owns hierarchy
+      between parent and child flow instances.
     not_field_presence_authority: |
       The state machine answers lifecycle questions, not field-write
       status questions.
@@ -3763,7 +3789,8 @@ engine:
       within the handler atomic boundary.
     entity_state:
       description: A single string value representing where the entity is in the flow lifecycle. Set by advances_to in handler
-        execution. Initial value from schema.yaml initial_state. Terminal values from schema.yaml terminal_states.
+        execution. For staged bundles, initial and terminal values are lowered from schema.yaml stages. For legacy bundles,
+        initial value comes from schema.yaml initial_state and terminal values from schema.yaml terminal_states.
       storage: Entity table, state column, indexed.
       mutation: Only via advances_to or on_complete branch. Never by agents directly.
     accumulator_state:
@@ -5484,7 +5511,10 @@ engine:
     - id: state_machine_coherence
       severity: error
       scope: per-flow
-      trigger: An advances_to target is not in the flow's declared states list. Or initial_state is not in states.
+      trigger: >-
+        An advances_to target is not in the flow's lowered declared state list. Or the lifecycle declaration is malformed:
+        legacy initial_state is not in states, staged lifecycle mixes stages with legacy lifecycle fields, a non-empty
+        stages mapping lacks exactly one initial stage, or a non-empty stages mapping declares no terminal stage.
       when: boot-only
     - id: required_agents_match
       severity: error
@@ -7476,8 +7506,15 @@ flow_model:
           instance declaration/policy, output pin `key`/`carries`, connect
           route plans, explicit and implicit key mappings,
           singleton/coordinator boundaries, typed contained-state operations,
-          and retired static multi-entity diagnostics without becoming a new
-          semantic owner or reimplementing verifier/runtime decisions.
+          lifecycle stage graphs requested with `--graph`, and retired static
+          multi-entity diagnostics without becoming a new semantic owner or
+          reimplementing verifier/runtime decisions.
+        graph_rule: >
+          `swarm describe --graph` renders the per-flow lifecycle stage graph
+          from the canonical lowered lifecycle owner and the existing transition
+          carriers. It must show flow namespace, nodes, initial/terminal markers,
+          edges, and edge source. It is projection-only and MUST NOT introduce a
+          second transition-authoring owner.
         source_location_rule: >
           Diagnostics in the expanded view must carry check_id, message,
           remediation/evidence when available from the verifier finding owner,
@@ -13355,7 +13392,8 @@ static_analyzer:
       terminal_states:
         rule: terminal states are sinks in this slice.
     rule: Emit warning when a declared state is unreachable from initial_state in the authored transition graph. Keep invalid
-      undeclared advances_to targets on hard-invalid state_machine_coherence.
+      undeclared advances_to targets on hard-invalid state_machine_coherence. For staged bundles, the same unreachable
+      lifecycle-node condition is hard-invalid because `stages:` is the canonical lifecycle node authoring owner.
   slice_5_dead_declared_event_schema_surface:
     id: semantic_drift_dead_event_schema
     domain: semantic_drift


### PR DESCRIPTION
## Summary

- Adds `schema.yaml` `stages:` as the canonical lifecycle node authoring surface for staged bundles, lowering into the existing `initial_state` / `states` / `terminal_states` kernel.
- Wires lowered lifecycle state through contract parsing, semantics/accessors, semantic view, bootverify coherence/reachability/timer checks, and `swarm describe --graph`.
- Keeps `advances_to`, `rules`, and `on_complete` as the transition-edge carriers; no runtime state-machine replacement and no transition-authoring migration in this PR.
- Updates authoritative `platform-spec.yaml` for the staged lifecycle owner and graph projection.
- Non-closure-bearing test reliability fix: tightens SQLite runtime mutation retry deadline classification so caller-deadline expiry is reported as `context.DeadlineExceeded`, stabilizing the required full-suite proof.

Closes #1845

## Governing Refs / Context

- Issue #1845 and approved implementation gate:
  - Pre-Implementation Coverage Audit: https://github.com/division-sh/swarm/issues/1845#issuecomment-4910806572
  - Gate outcome: https://github.com/division-sh/swarm/issues/1845#issuecomment-4910838010
- Exact / adjacent authoritative spec sections updated in this PR:
  - `contract_formats.flow_schema`
  - `state_machine_authority`
  - `engine.state_management.entity_state`
  - `engine.boot_verification.state_machine_coherence`
  - `flow_model.authoring_view.expand_minimize_tooling`
  - `static_analyzer.slice_4_state_machine_reachability`
- `docs/IMPLEMENTER_GUIDELINES.md` and `docs/SEMANTIC_DRIFT.md` are absent in this checkout; the binding implementation context is the issue thread, recorded gate, `CONTRIBUTING.md`, and `platform-spec.yaml`.

## Semantic Migration

- New canonical owner: `schema.yaml` `stages:` for lifecycle node authoring in staged bundles.
- Old producer / reader / writer path now invalid for staged bundles: `initial_state`, `states`, and `terminal_states` cannot be mixed with `stages:` in the same schema.
- Legacy fields remain accepted only as the approved legacy/kernel input surface until a later migration retires them from public authoring.
- Production paths checked for surviving old behavior:
  - flow schema YAML parsing and unknown-field rejection
  - lifecycle lowering into workflow semantics/accessors
  - root/child flow scoped state access
  - semantic view source accessors
  - bootverify `state_machine_coherence`, staged reachability, and timer state checks
  - `swarm describe --graph` projection
- Migration completeness: complete for the approved #1845 first slice. Transition-authoring, nested hierarchy, temporal/join/loop rows, and later lifecycle authoring migrations remain explicitly out of scope.

## Tests

- `SWARM_TEST_POSTGRES_DSN='host=127.0.0.1 port=5432 user=youmew dbname=postgres sslmode=disable' PGPASSWORD=postgres go test -p 1 ./...`
- `go test ./internal/store -run TestSQLiteRuntimeStore_RunRuntimeMutationStopsRetryOnContextDeadline -count=20`
- `go run ./cmd/swarm-openrpc-gen --check`
