### PR TITLE
[agent-g][issue #1864] Add served parity for run/runtime controls

### DIFF
--- a/cmd/swarm/main_test.go
+++ b/cmd/swarm/main_test.go
@@ -4106,6 +4106,227 @@ func TestServedParityHarnessEventPublishDynamicAutoEmitLifecycle(t *testing.T) {
 	servedparity.Run(t, scenario, runServedDynamicAutoEmitBackendProof)
 }
 
+func TestServedParityHarnessRunControlLifecycle(t *testing.T) {
+	scenarios := []servedparity.Scenario{
+		servedparity.MustScenario(servedparity.ScenarioRunPauseControlLifecycle),
+		servedparity.MustScenario(servedparity.ScenarioRunContinueControlLifecycle),
+		servedparity.MustScenario(servedparity.ScenarioRunStopControlLifecycle),
+	}
+	servedparity.RunScenarioGroup(t, scenarios, runServedRunControlBackendProof)
+}
+
+func TestServedParityHarnessRuntimeIngressControlLifecycle(t *testing.T) {
+	scenarios := []servedparity.Scenario{
+		servedparity.MustScenario(servedparity.ScenarioRuntimePauseIngressLifecycle),
+		servedparity.MustScenario(servedparity.ScenarioRuntimeResumeIngressLifecycle),
+	}
+	servedparity.RunScenarioGroup(t, scenarios, runServedRuntimeIngressControlBackendProof)
+}
+
+type servedControlProofRuntime struct {
+	Endpoint   string
+	DB         *sql.DB
+	Backend    string
+	BundleHash string
+	Probe      *lifecycletest.Probe
+}
+
+func startServedControlProofRuntime(t *testing.T, backend servedparity.Backend) servedControlProofRuntime {
+	t.Helper()
+	switch backend {
+	case servedparity.BackendDefaultSQLite:
+		unsetStoreSelectorEnv(t)
+		stubServeRuntimeWorkspaceLifecycle(t)
+		sqlitePath := filepath.Join(t.TempDir(), ".swarm", "dev.db")
+		contractsPath := writeServedEventPublishFollowUpFixture(t)
+		bundleHash := servedEventPublishFixtureBundleHash(t, contractsPath)
+		probe := lifecycletest.New(t, lifecycletest.WithTimeout(servedEventPublishLifecycleProbeWaitTimeout))
+		oldBuildStores := buildStoresForServe
+		t.Cleanup(func() {
+			buildStoresForServe = oldBuildStores
+		})
+		var servedDB *sql.DB
+		buildStoresForServe = func(ctx context.Context, selection storebackend.Selection, cfg *config.Config) (storeBundle, error) {
+			stores, err := oldBuildStores(ctx, selection, cfg)
+			if err == nil {
+				servedDB = stores.SQLDB
+			}
+			return stores, err
+		}
+		endpoint, _ := startServedEventPublishFollowUpRuntime(t, serveOptions{
+			ConfigPath:              writeStoreBackendRuntimeConfig(t, storebackend.BackendSQLite.String(), sqlitePath),
+			ContractsPath:           contractsPath,
+			PlatformSpecPath:        defaultPlatformSpecPath,
+			APIListenAddr:           "127.0.0.1:0",
+			MCPListenAddr:           "127.0.0.1:0",
+			SelfCheck:               true,
+			RequireBundleMatch:      false,
+			NoRequireBundleMatch:    true,
+			Verbose:                 true,
+			TestLifecycleProbe:      probe,
+			TestOutboxSweeperConfig: servedEventPublishProofOutboxSweeperConfig(),
+		})
+		if servedDB == nil {
+			t.Fatal("served sqlite SQLDB is required for control served parity proof")
+		}
+		return servedControlProofRuntime{Endpoint: endpoint, DB: servedDB, Backend: "sqlite", BundleHash: bundleHash, Probe: probe}
+	case servedparity.BackendExplicitPostgres:
+		_, db, _ := installServeRuntimeEmptyPostgresTestStores(t, func() serveWorkspaceLifecycle {
+			return serveRuntimeWorkspaceStub{}
+		})
+		contractsPath := writeServedEventPublishFollowUpFixture(t)
+		bundleHash := servedEventPublishFixtureBundleHash(t, contractsPath)
+		probe := lifecycletest.New(t, lifecycletest.WithTimeout(servedEventPublishLifecycleProbeWaitTimeout))
+		endpoint, _ := startServedEventPublishFollowUpRuntime(t, serveOptions{
+			ConfigPath:              writeServeRuntimeTestConfig(t),
+			ContractsPath:           contractsPath,
+			PlatformSpecPath:        defaultPlatformSpecPath,
+			StoreMode:               "postgres",
+			StoreModeSet:            true,
+			APIListenAddr:           "127.0.0.1:0",
+			MCPListenAddr:           "127.0.0.1:0",
+			SelfCheck:               true,
+			RequireBundleMatch:      false,
+			Verbose:                 true,
+			TestLifecycleProbe:      probe,
+			TestOutboxSweeperConfig: servedEventPublishProofOutboxSweeperConfig(),
+		})
+		return servedControlProofRuntime{Endpoint: endpoint, DB: db, Backend: "postgres", BundleHash: bundleHash, Probe: probe}
+	default:
+		t.Fatalf("unknown served control backend %q", backend)
+		return servedControlProofRuntime{}
+	}
+}
+
+func runServedRunControlBackendProof(t *testing.T, backend servedparity.Backend) {
+	t.Helper()
+	rt := startServedControlProofRuntime(t, backend)
+	runServedRunControlLifecycleProof(t, rt)
+}
+
+func runServedRuntimeIngressControlBackendProof(t *testing.T, backend servedparity.Backend) {
+	t.Helper()
+	t.Cleanup(runtimebus.ResumeRuntimeIngress)
+	rt := startServedControlProofRuntime(t, backend)
+	runServedRuntimeIngressControlLifecycleProof(t, rt)
+}
+
+func runServedRunControlLifecycleProof(t *testing.T, rt servedControlProofRuntime) {
+	t.Helper()
+	runID, initialEventID, entityID := createServedControlWaitingRun(t, rt, "run-control-release")
+
+	pauseKey := "issue-1864-" + rt.Backend + "-run-pause"
+	requireServedOKJSONRPC(t, rt.Endpoint, "run.pause", map[string]any{
+		"run_id":          runID,
+		"idempotency_key": pauseKey,
+	})
+	requireServedRunControlState(t, rt.DB, rt.Backend, runID, "paused", "paused")
+	requireServedRunStatus(t, rt.Endpoint, runID, "paused")
+	requireServedControlAPIIdempotencyRows(t, rt.DB, rt.Backend, "run.pause", pauseKey, 1)
+	requireServedOKJSONRPC(t, rt.Endpoint, "run.pause", map[string]any{
+		"run_id":          runID,
+		"idempotency_key": pauseKey,
+	})
+	requireServedControlAPIIdempotencyRows(t, rt.DB, rt.Backend, "run.pause", pauseKey, 1)
+
+	queued := requireServedEventPublishRPCResult(t, rt.Endpoint, map[string]any{
+		"event_name":      "thing.reviewed",
+		"run_id":          runID,
+		"source_event_id": initialEventID,
+		"payload":         map[string]any{"note": "queued while run paused"},
+		"idempotency_key": "issue-1864-" + rt.Backend + "-run-queued",
+	})
+	if queued.RunID != runID || queued.SourceEventID != initialEventID || queued.NewRunCreated || queued.EventID == "" {
+		t.Fatalf("%s queued event.publish result = %#v, want existing paused run", rt.Backend, queued)
+	}
+	waitServedEventPublishDeliveryStatusCountForRun(t, rt.DB, rt.Backend, runID, queued.EventID, "node", "entity-writer", "pending", 1)
+	requireNoServedDeliveryStatusDuring(t, rt.DB, rt.Backend, queued.EventID, "node", "entity-writer", "delivered", 250*time.Millisecond)
+
+	continueKey := "issue-1864-" + rt.Backend + "-run-continue"
+	requireServedOKJSONRPC(t, rt.Endpoint, "run.continue", map[string]any{
+		"run_id":          runID,
+		"idempotency_key": continueKey,
+	})
+	requireServedRunControlState(t, rt.DB, rt.Backend, runID, "running", "running", "completed")
+	requireServedControlAPIIdempotencyRows(t, rt.DB, rt.Backend, "run.continue", continueKey, 1)
+	requireServedOKJSONRPC(t, rt.Endpoint, "run.continue", map[string]any{
+		"run_id":          runID,
+		"idempotency_key": continueKey,
+	})
+	requireServedControlAPIIdempotencyRows(t, rt.DB, rt.Backend, "run.continue", continueKey, 1)
+	waitServedEventPublishDeliveryStatusCountForRun(t, rt.DB, rt.Backend, runID, queued.EventID, "node", "entity-writer", "delivered", 1)
+	requireServedEventPublishEntityState(t, rt.DB, rt.Backend, runID, entityID, "done")
+	requireServedRunStatus(t, rt.Endpoint, runID, "completed")
+	requireServedParitySettlementPostconditions(t, rt.Endpoint, runID, servedparity.MustScenario(servedparity.ScenarioRunContinueControlLifecycle))
+
+	stopRunID, pendingEventID := seedServedRunControlPendingRunWithAgentDelivery(t, rt.DB, rt.Backend)
+	stopKey := "issue-1864-" + rt.Backend + "-run-stop"
+	requireServedOKJSONRPC(t, rt.Endpoint, "run.stop", map[string]any{
+		"run_id":          stopRunID,
+		"idempotency_key": stopKey,
+	})
+	requireServedRunControlState(t, rt.DB, rt.Backend, stopRunID, "stopped", "cancelled")
+	requireServedStoppedPendingDelivery(t, rt.DB, rt.Backend, pendingEventID, "agent-pending")
+	requireServedControlAPIIdempotencyRows(t, rt.DB, rt.Backend, "run.stop", stopKey, 1)
+	requireServedOKJSONRPC(t, rt.Endpoint, "run.stop", map[string]any{
+		"run_id":          stopRunID,
+		"idempotency_key": stopKey,
+	})
+	requireServedControlAPIIdempotencyRows(t, rt.DB, rt.Backend, "run.stop", stopKey, 1)
+	requireServedRunStatus(t, rt.Endpoint, stopRunID, "cancelled")
+	requireServedParitySettlementPostconditions(t, rt.Endpoint, stopRunID, servedparity.MustScenario(servedparity.ScenarioRunStopControlLifecycle))
+}
+
+func runServedRuntimeIngressControlLifecycleProof(t *testing.T, rt servedControlProofRuntime) {
+	t.Helper()
+	pauseKey := "issue-1864-" + rt.Backend + "-runtime-pause"
+	requireServedOKJSONRPC(t, rt.Endpoint, "runtime.pause", map[string]any{
+		"idempotency_key": pauseKey,
+	})
+	requireServedRuntimeIngressState(t, rt.DB, rt.Backend, "paused", "platform.paused")
+	requireServedControlAPIIdempotencyRows(t, rt.DB, rt.Backend, "runtime.pause", pauseKey, 1)
+	requireServedOKJSONRPC(t, rt.Endpoint, "runtime.pause", map[string]any{
+		"idempotency_key": pauseKey,
+	})
+	requireServedControlAPIIdempotencyRows(t, rt.DB, rt.Backend, "runtime.pause", pauseKey, 1)
+	requireServedEventNameCount(t, rt.DB, rt.Backend, "platform.paused", 1)
+	duplicatePause := requireServedJSONRPCError(t, rt.Endpoint, "runtime.pause", map[string]any{})
+	if duplicatePause.Data["code"] != apiv1.RuntimeAlreadyPausedCode {
+		t.Fatalf("%s duplicate runtime.pause data = %#v, want %s", rt.Backend, duplicatePause.Data, apiv1.RuntimeAlreadyPausedCode)
+	}
+
+	queued := requireServedEventPublishRPCResult(t, rt.Endpoint, map[string]any{
+		"event_name":      "thing.unhandled",
+		"bundle_hash":     rt.BundleHash,
+		"payload":         map[string]any{"note": "queued while runtime paused"},
+		"idempotency_key": "issue-1864-" + rt.Backend + "-runtime-queued",
+	})
+	if !queued.NewRunCreated || queued.RunID == "" || queued.EventID == "" {
+		t.Fatalf("%s runtime-paused event.publish result = %#v, want new queued run", rt.Backend, queued)
+	}
+	requireNoServedReceiptOutcomeDuring(t, rt.DB, rt.Backend, queued.EventID, "platform", "pipeline", "success", 250*time.Millisecond)
+
+	resumeKey := "issue-1864-" + rt.Backend + "-runtime-resume"
+	requireServedOKJSONRPC(t, rt.Endpoint, "runtime.resume", map[string]any{
+		"idempotency_key": resumeKey,
+	})
+	requireServedRuntimeIngressState(t, rt.DB, rt.Backend, "running", "platform.resumed")
+	requireServedControlAPIIdempotencyRows(t, rt.DB, rt.Backend, "runtime.resume", resumeKey, 1)
+	requireServedOKJSONRPC(t, rt.Endpoint, "runtime.resume", map[string]any{
+		"idempotency_key": resumeKey,
+	})
+	requireServedControlAPIIdempotencyRows(t, rt.DB, rt.Backend, "runtime.resume", resumeKey, 1)
+	requireServedEventNameCount(t, rt.DB, rt.Backend, "platform.resumed", 1)
+	duplicateResume := requireServedJSONRPCError(t, rt.Endpoint, "runtime.resume", map[string]any{})
+	if duplicateResume.Data["code"] != apiv1.RuntimeNotPausedCode {
+		t.Fatalf("%s duplicate runtime.resume data = %#v, want %s", rt.Backend, duplicateResume.Data, apiv1.RuntimeNotPausedCode)
+	}
+
+	waitServedEventPublishReceiptOutcomeCount(t, rt.DB, rt.Backend, queued.EventID, "platform", "pipeline", "success", 1)
+	requireServedRunStatus(t, rt.Endpoint, queued.RunID, "running")
+	requireServedParitySettlementPostconditions(t, rt.Endpoint, queued.RunID, servedparity.MustScenario(servedparity.ScenarioRuntimeResumeIngressLifecycle))
+}
+
 func runServedDynamicAutoEmitBackendProof(t *testing.T, backend servedparity.Backend) {
 	t.Helper()
 	switch backend {
@@ -4318,7 +4539,335 @@ func requireServedParitySettlementPostconditions(t *testing.T, endpoint, runID s
 		}
 		time.Sleep(50 * time.Millisecond)
 	}
-	t.Fatalf("served parity scenario %s settlement did not quiesce for run %s: %#v", scenario.ID, runID, last.TestQuiescence)
+	t.Fatalf("served parity scenario %s settlement did not quiesce for run %s: ready=%v active_deliveries=%d unsettled_pipeline_events=%d due_timers=%d active_session_leases=%d",
+		scenario.ID,
+		runID,
+		boolPointerValue(last.TestQuiescence.Ready),
+		intPointerValue(last.TestQuiescence.ActiveDeliveries),
+		intPointerValue(last.TestQuiescence.UnsettledPipelineEvents),
+		intPointerValue(last.TestQuiescence.DueTimers),
+		intPointerValue(last.TestQuiescence.ActiveSessionLeases),
+	)
+}
+
+func createServedControlWaitingRun(t *testing.T, rt servedControlProofRuntime, suffix string) (runID, eventID, entityID string) {
+	t.Helper()
+	result := requireServedEventPublishRPCResult(t, rt.Endpoint, map[string]any{
+		"event_name":      "thing.created",
+		"bundle_hash":     rt.BundleHash,
+		"payload":         map[string]any{"amount": 7, "who": suffix},
+		"idempotency_key": "issue-1864-" + rt.Backend + "-" + suffix,
+	})
+	if !result.NewRunCreated || result.RunID == "" || result.EventID == "" {
+		t.Fatalf("%s control seed event.publish result = %#v, want new run", rt.Backend, result)
+	}
+	waitForServedEventPublishNodeDeliveryLifecycle(t, rt.DB, rt.Backend, result.RunID, result.EventID, rt.Probe)
+	entityID = requireServedEventPublishEntityState(t, rt.DB, rt.Backend, result.RunID, "", "waiting")
+	requireServedRunStatus(t, rt.Endpoint, result.RunID, "running")
+	return result.RunID, result.EventID, entityID
+}
+
+func requireServedOKJSONRPC(t *testing.T, endpoint, method string, params map[string]any) {
+	t.Helper()
+	var result map[string]any
+	requireServedJSONRPCResult(t, endpoint, method, params, &result)
+	if result["ok"] != true {
+		t.Fatalf("%s result = %#v, want ok=true", method, result)
+	}
+}
+
+func requireServedControlAPIIdempotencyRows(t *testing.T, db *sql.DB, backend, method, key string, want int) {
+	t.Helper()
+	if got := servedEventPublishAPIIdempotencyCount(t, db, backend, method, key); got != want {
+		t.Fatalf("%s api_idempotency rows for %s/%s = %d, want %d", backend, method, key, got, want)
+	}
+}
+
+func requireServedRunControlState(t *testing.T, db *sql.DB, backend, runID, wantControlStatus string, allowedRunStatuses ...string) {
+	t.Helper()
+	allowed := map[string]bool{}
+	for _, status := range allowedRunStatuses {
+		status = strings.TrimSpace(status)
+		if status != "" {
+			allowed[status] = true
+		}
+	}
+	deadline := time.Now().Add(servedProofPollDeadline)
+	var lastRunStatus, lastControlStatus, lastReason, lastControlledBy string
+	for time.Now().Before(deadline) {
+		runStatus, controlStatus, reason, controlledBy := servedRunControlState(t, db, backend, runID)
+		lastRunStatus, lastControlStatus, lastReason, lastControlledBy = runStatus, controlStatus, reason, controlledBy
+		if controlStatus == wantControlStatus && allowed[runStatus] {
+			return
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+	t.Fatalf("%s run_control_state for %s = run:%s control:%s reason:%s by:%s, want control=%s run in %v",
+		backend, runID, lastRunStatus, lastControlStatus, lastReason, lastControlledBy, wantControlStatus, allowedRunStatuses)
+}
+
+func servedRunControlState(t *testing.T, db *sql.DB, backend, runID string) (runStatus, controlStatus, reason, controlledBy string) {
+	t.Helper()
+	var query string
+	var args []any
+	switch backend {
+	case "postgres":
+		query = `
+			SELECT r.status, COALESCE(rc.control_status, ''), COALESCE(rc.reason, ''), COALESCE(rc.controlled_by, '')
+			FROM runs r
+			LEFT JOIN run_control_state rc ON rc.run_id = r.run_id
+			WHERE r.run_id = $1::uuid
+		`
+		args = []any{runID}
+	case "sqlite":
+		query = `
+			SELECT r.status, COALESCE(rc.control_status, ''), COALESCE(rc.reason, ''), COALESCE(rc.controlled_by, '')
+			FROM runs r
+			LEFT JOIN run_control_state rc ON rc.run_id = r.run_id
+			WHERE r.run_id = ?
+		`
+		args = []any{runID}
+	default:
+		t.Fatalf("unknown proof backend %q", backend)
+	}
+	if err := db.QueryRowContext(context.Background(), query, args...).Scan(&runStatus, &controlStatus, &reason, &controlledBy); err != nil {
+		t.Fatalf("%s load run control state for %s: %v", backend, runID, err)
+	}
+	return strings.TrimSpace(runStatus), strings.TrimSpace(controlStatus), strings.TrimSpace(reason), strings.TrimSpace(controlledBy)
+}
+
+func seedServedRunControlPendingRunWithAgentDelivery(t *testing.T, db *sql.DB, backend string) (string, string) {
+	t.Helper()
+	runID := uuid.NewString()
+	eventID := uuid.NewString()
+	deliveryID := uuid.NewString()
+	now := time.Now().UTC()
+	switch backend {
+	case "postgres":
+		if _, err := db.ExecContext(context.Background(), `
+			INSERT INTO runs (run_id, status, bundle_source, started_at)
+			VALUES ($1::uuid, 'running', 'legacy', $2)
+		`, runID, now); err != nil {
+			t.Fatalf("seed postgres run-control pending run: %v", err)
+		}
+		if _, err := db.ExecContext(context.Background(), `
+			INSERT INTO events (event_id, run_id, event_name, scope, payload, produced_by, produced_by_type, created_at)
+			VALUES ($1::uuid, $2::uuid, 'control.stop.pending', 'global', '{}'::jsonb, 'test', 'agent', $3)
+		`, eventID, runID, now); err != nil {
+			t.Fatalf("seed postgres run-control pending event: %v", err)
+		}
+		if _, err := db.ExecContext(context.Background(), `
+				INSERT INTO event_deliveries (delivery_id, run_id, event_id, subscriber_type, subscriber_id, status, created_at)
+				VALUES ($1::uuid, $2::uuid, $3::uuid, 'agent', 'agent-pending', 'pending', $4)
+			`, deliveryID, runID, eventID, now); err != nil {
+			t.Fatalf("seed postgres run-control pending delivery: %v", err)
+		}
+		if _, err := db.ExecContext(context.Background(), `
+				INSERT INTO event_receipts (
+					event_id, subscriber_type, subscriber_id, outcome, reason_code, side_effects, processed_at
+				)
+				VALUES (
+					$1::uuid, 'platform', 'pipeline', 'success', 'pipeline_persisted',
+					'{"manager_status":"processed","reason_code":"pipeline_persisted"}'::jsonb, $2
+				)
+			`, eventID, now); err != nil {
+			t.Fatalf("seed postgres run-control pipeline receipt: %v", err)
+		}
+	case "sqlite":
+		if _, err := db.ExecContext(context.Background(), `
+				INSERT INTO runs (run_id, status, bundle_source, started_at)
+				VALUES (?, 'running', 'legacy', ?)
+			`, runID, now); err != nil {
+			t.Fatalf("seed sqlite run-control pending run: %v", err)
+		}
+		if _, err := db.ExecContext(context.Background(), `
+			INSERT INTO events (event_id, run_id, event_name, scope, payload, produced_by, produced_by_type, created_at)
+			VALUES (?, ?, 'control.stop.pending', 'global', '{}', 'test', 'agent', ?)
+		`, eventID, runID, now); err != nil {
+			t.Fatalf("seed sqlite run-control pending event: %v", err)
+		}
+		if _, err := db.ExecContext(context.Background(), `
+				INSERT INTO event_deliveries (delivery_id, run_id, event_id, subscriber_type, subscriber_id, status, created_at)
+				VALUES (?, ?, ?, 'agent', 'agent-pending', 'pending', ?)
+			`, deliveryID, runID, eventID, now); err != nil {
+			t.Fatalf("seed sqlite run-control pending delivery: %v", err)
+		}
+		if _, err := db.ExecContext(context.Background(), `
+				INSERT INTO event_receipts (
+					receipt_id, event_id, subscriber_type, subscriber_id, outcome, reason_code, side_effects, processed_at
+				)
+				VALUES (
+					?, ?, 'platform', 'pipeline', 'success', 'pipeline_persisted',
+					'{"manager_status":"processed","reason_code":"pipeline_persisted"}', ?
+				)
+			`, uuid.NewString(), eventID, now); err != nil {
+			t.Fatalf("seed sqlite run-control pipeline receipt: %v", err)
+		}
+	default:
+		t.Fatalf("unknown proof backend %q", backend)
+	}
+	return runID, eventID
+}
+
+func requireServedStoppedPendingDelivery(t *testing.T, db *sql.DB, backend, eventID, subscriberID string) {
+	t.Helper()
+	deadline := time.Now().Add(servedProofPollDeadline)
+	var lastStatus, lastReason string
+	for time.Now().Before(deadline) {
+		status, reason := servedDeliveryStatusReason(t, db, backend, eventID, "agent", subscriberID)
+		lastStatus, lastReason = status, reason
+		if status == "dead_letter" && reason == "run_stopped" {
+			waitServedEventPublishReceiptOutcomeCount(t, db, backend, eventID, "agent", subscriberID, "dead_letter", 1)
+			waitServedEventPublishReceiptOutcomeCount(t, db, backend, eventID, "platform", "pipeline", "success", 1)
+			return
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+	t.Fatalf("%s stopped pending delivery %s/%s = %s/%s, want dead_letter/run_stopped", backend, eventID, subscriberID, lastStatus, lastReason)
+}
+
+func servedDeliveryStatusReason(t *testing.T, db *sql.DB, backend, eventID, subscriberType, subscriberID string) (status, reason string) {
+	t.Helper()
+	var query string
+	var args []any
+	switch backend {
+	case "postgres":
+		query = `
+			SELECT status, COALESCE(reason_code, '')
+			FROM event_deliveries
+			WHERE event_id = $1::uuid AND subscriber_type = $2 AND subscriber_id = $3
+		`
+		args = []any{eventID, subscriberType, subscriberID}
+	case "sqlite":
+		query = `
+			SELECT status, COALESCE(reason_code, '')
+			FROM event_deliveries
+			WHERE event_id = ? AND subscriber_type = ? AND subscriber_id = ?
+		`
+		args = []any{eventID, subscriberType, subscriberID}
+	default:
+		t.Fatalf("unknown proof backend %q", backend)
+	}
+	if err := db.QueryRowContext(context.Background(), query, args...).Scan(&status, &reason); err != nil {
+		t.Fatalf("%s load delivery status/reason for %s: %v", backend, eventID, err)
+	}
+	return strings.TrimSpace(status), strings.TrimSpace(reason)
+}
+
+func requireNoServedDeliveryStatusDuring(t *testing.T, db *sql.DB, backend, eventID, subscriberType, subscriberID, status string, duration time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(duration)
+	for time.Now().Before(deadline) {
+		if got := servedEventPublishDeliveryStatusCount(t, db, backend, eventID, subscriberType, subscriberID, status); got != 0 {
+			t.Fatalf("%s delivery count for event=%s subscriber=%s/%s status=%q = %d during blocked interval, want 0",
+				backend, eventID, subscriberType, subscriberID, status, got)
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+}
+
+func requireNoServedReceiptOutcomeDuring(t *testing.T, db *sql.DB, backend, eventID, subscriberType, subscriberID, outcome string, duration time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(duration)
+	for time.Now().Before(deadline) {
+		if got := servedEventPublishReceiptOutcomeCount(t, db, backend, eventID, subscriberType, subscriberID, outcome); got != 0 {
+			t.Fatalf("%s receipt count for event=%s subscriber=%s/%s outcome=%q = %d during blocked interval, want 0",
+				backend, eventID, subscriberType, subscriberID, outcome, got)
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+}
+
+func requireServedRuntimeIngressState(t *testing.T, db *sql.DB, backend, wantStatus, wantTransitionEventName string) {
+	t.Helper()
+	deadline := time.Now().Add(servedProofPollDeadline)
+	var lastStatus, lastEventID, lastEventName string
+	for time.Now().Before(deadline) {
+		status, eventID := servedRuntimeIngressState(t, db, backend)
+		lastStatus, lastEventID = status, eventID
+		if eventID != "" {
+			lastEventName = servedEventNameByID(t, db, backend, eventID)
+		}
+		if status == wantStatus && (wantTransitionEventName == "" || lastEventName == wantTransitionEventName) {
+			return
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+	t.Fatalf("%s runtime_ingress_state = status:%s transition_event:%s/%s, want %s/%s",
+		backend, lastStatus, lastEventID, lastEventName, wantStatus, wantTransitionEventName)
+}
+
+func servedRuntimeIngressState(t *testing.T, db *sql.DB, backend string) (status, transitionEventID string) {
+	t.Helper()
+	var query string
+	switch backend {
+	case "postgres":
+		query = `SELECT status, COALESCE(transition_event_id::text, '') FROM runtime_ingress_state WHERE id = 1`
+	case "sqlite":
+		query = `SELECT status, COALESCE(transition_event_id, '') FROM runtime_ingress_state WHERE id = 1`
+	default:
+		t.Fatalf("unknown proof backend %q", backend)
+	}
+	if err := db.QueryRowContext(context.Background(), query).Scan(&status, &transitionEventID); err != nil {
+		t.Fatalf("%s load runtime ingress state: %v", backend, err)
+	}
+	return strings.TrimSpace(status), strings.TrimSpace(transitionEventID)
+}
+
+func servedEventNameByID(t *testing.T, db *sql.DB, backend, eventID string) string {
+	t.Helper()
+	var query string
+	var args []any
+	switch backend {
+	case "postgres":
+		query = `SELECT event_name FROM events WHERE event_id = $1::uuid`
+		args = []any{eventID}
+	case "sqlite":
+		query = `SELECT event_name FROM events WHERE event_id = ?`
+		args = []any{eventID}
+	default:
+		t.Fatalf("unknown proof backend %q", backend)
+	}
+	var name string
+	if err := db.QueryRowContext(context.Background(), query, args...).Scan(&name); err != nil {
+		t.Fatalf("%s load event name for %s: %v", backend, eventID, err)
+	}
+	return strings.TrimSpace(name)
+}
+
+func requireServedEventNameCount(t *testing.T, db *sql.DB, backend, eventName string, want int) {
+	t.Helper()
+	deadline := time.Now().Add(servedProofPollDeadline)
+	var got int
+	for time.Now().Before(deadline) {
+		got = servedEventNameCount(t, db, backend, eventName)
+		if got == want {
+			return
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+	t.Fatalf("%s events named %s = %d, want %d", backend, eventName, got, want)
+}
+
+func servedEventNameCount(t *testing.T, db *sql.DB, backend, eventName string) int {
+	t.Helper()
+	var query string
+	var args []any
+	switch backend {
+	case "postgres":
+		query = `SELECT COUNT(*) FROM events WHERE event_name = $1`
+		args = []any{eventName}
+	case "sqlite":
+		query = `SELECT COUNT(*) FROM events WHERE event_name = ?`
+		args = []any{eventName}
+	default:
+		t.Fatalf("unknown proof backend %q", backend)
+	}
+	var count int
+	if err := db.QueryRowContext(context.Background(), query, args...).Scan(&count); err != nil {
+		t.Fatalf("%s count event name %s: %v", backend, eventName, err)
+	}
+	return count
 }
 
 func writeServedEventPublishFollowUpFixture(t *testing.T) string {
@@ -4335,7 +4884,7 @@ terminal_states: [done]
 states: [new, waiting, done]
 pins:
   inputs:
-    events: [thing.created]
+    events: [thing.created, thing.unhandled]
 `)
 	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "entities.yaml"), `
 widget:
@@ -5769,6 +6318,21 @@ func waitServedEventPublishDeliveryStatusCount(t *testing.T, db *sql.DB, backend
 		time.Sleep(25 * time.Millisecond)
 	}
 	t.Fatalf("%s delivery count for event=%s subscriber=%s/%s status=%q = %d, want %d", backend, eventID, subscriberType, subscriberID, status, got, want)
+}
+
+func waitServedEventPublishDeliveryStatusCountForRun(t *testing.T, db *sql.DB, backend, runID, eventID, subscriberType, subscriberID, status string, want int) {
+	t.Helper()
+	deadline := time.Now().Add(servedProofPollDeadline)
+	var got int
+	for time.Now().Before(deadline) {
+		got = servedEventPublishDeliveryStatusCount(t, db, backend, eventID, subscriberType, subscriberID, status)
+		if got == want {
+			return
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+	t.Fatalf("%s delivery count for event=%s subscriber=%s/%s status=%q = %d, want %d\n%s",
+		backend, eventID, subscriberType, subscriberID, status, got, want, servedEventPublishDebugSummary(t, db, backend, runID))
 }
 
 func servedEventPublishDeliveryStatusCount(t *testing.T, db *sql.DB, backend, eventID, subscriberType, subscriberID string, statuses ...string) int {

--- a/internal/apiv1/testdata/public_surface_backend_matrix.yaml
+++ b/internal/apiv1/testdata/public_surface_backend_matrix.yaml
@@ -42,6 +42,9 @@ active_trackers:
   - kind: github_issue
     issue: 1783
     watchlist: runtime_operations.runtime_store_backend_default_and_sqlite_portability
+  - kind: github_issue
+    issue: 1864
+    watchlist: runtime_operations.runtime_store_backend_default_and_sqlite_portability
   - kind: watchlist
     issue: 0
     watchlist: operator_surfaces.v1_openrpc_api_conformance
@@ -98,17 +101,38 @@ mutating_api_parity_ledger:
       covered transitively by the event.publish servedparity scenario rather
       than by a dedicated wrapper scenario.
   - method: run.stop
-    classification: split_with_issue_ref
-    split_issue: 1386
-    proof_refs: [{kind: tracker, issue: 1386, watchlist: runtime_operations.runtime_store_backend_default_and_sqlite_portability}]
+    classification: dual_backend_served_proof
+    backends: [default_sqlite, explicit_postgres]
+    scenario: run_stop_control_lifecycle
+    proof_refs:
+      - kind: go_test
+        name: TestServedParityHarnessRunControlLifecycle
+    notes: >
+      Shared served harness proves real /v1/rpc run.stop on default SQLite and
+      explicit Postgres, including persisted stop state, pending-agent delivery
+      abandonment, idempotency replay, and generic settlement postconditions.
   - method: run.pause
-    classification: split_with_issue_ref
-    split_issue: 1386
-    proof_refs: [{kind: tracker, issue: 1386, watchlist: runtime_operations.runtime_store_backend_default_and_sqlite_portability}]
+    classification: dual_backend_served_proof
+    backends: [default_sqlite, explicit_postgres]
+    scenario: run_pause_control_lifecycle
+    proof_refs:
+      - kind: go_test
+        name: TestServedParityHarnessRunControlLifecycle
+    notes: >
+      Shared served harness proves real /v1/rpc run.pause on default SQLite and
+      explicit Postgres, including run_control_state persistence, run-scoped
+      dispatch gating, idempotency replay, and generic settlement postconditions.
   - method: run.continue
-    classification: split_with_issue_ref
-    split_issue: 1386
-    proof_refs: [{kind: tracker, issue: 1386, watchlist: runtime_operations.runtime_store_backend_default_and_sqlite_portability}]
+    classification: dual_backend_served_proof
+    backends: [default_sqlite, explicit_postgres]
+    scenario: run_continue_control_lifecycle
+    proof_refs:
+      - kind: go_test
+        name: TestServedParityHarnessRunControlLifecycle
+    notes: >
+      Shared served harness proves real /v1/rpc run.continue on default SQLite
+      and explicit Postgres, including release of run-scoped queued work exactly
+      through the EventBus owner, idempotency replay, and generic settlement.
   - method: mailbox.approve
     classification: split_with_issue_ref
     split_issue: 1386
@@ -134,13 +158,29 @@ mutating_api_parity_ledger:
     split_issue: 1386
     proof_refs: [{kind: tracker, issue: 1386, watchlist: runtime_operations.runtime_store_backend_default_and_sqlite_portability}]
   - method: runtime.pause
-    classification: split_with_issue_ref
-    split_issue: 1386
-    proof_refs: [{kind: tracker, issue: 1386, watchlist: runtime_operations.runtime_store_backend_default_and_sqlite_portability}]
+    classification: dual_backend_served_proof
+    backends: [default_sqlite, explicit_postgres]
+    scenario: runtime_pause_ingress_lifecycle
+    proof_refs:
+      - kind: go_test
+        name: TestServedParityHarnessRuntimeIngressControlLifecycle
+    notes: >
+      Shared served harness proves real /v1/rpc runtime.pause on default SQLite
+      and explicit Postgres, including persisted runtime_ingress_state,
+      platform.paused transition event, queued ingress blocking, idempotency
+      replay, and generic settlement postconditions.
   - method: runtime.resume
-    classification: split_with_issue_ref
-    split_issue: 1386
-    proof_refs: [{kind: tracker, issue: 1386, watchlist: runtime_operations.runtime_store_backend_default_and_sqlite_portability}]
+    classification: dual_backend_served_proof
+    backends: [default_sqlite, explicit_postgres]
+    scenario: runtime_resume_ingress_lifecycle
+    proof_refs:
+      - kind: go_test
+        name: TestServedParityHarnessRuntimeIngressControlLifecycle
+    notes: >
+      Shared served harness proves real /v1/rpc runtime.resume on default SQLite
+      and explicit Postgres, including persisted running state, platform.resumed
+      transition event, queued ingress release, idempotency replay, and generic
+      settlement postconditions.
   - method: runtime.nuke
     classification: split_with_issue_ref
     split_issue: 1386

--- a/internal/servedparity/servedparity.go
+++ b/internal/servedparity/servedparity.go
@@ -23,7 +23,14 @@ const (
 	PostconditionNoUnfiredDueTimers      Postcondition = "no_unfired_due_timers"
 )
 
-const ScenarioEventPublishDynamicAutoEmitLifecycle = "event_publish_dynamic_auto_emit_lifecycle"
+const (
+	ScenarioEventPublishDynamicAutoEmitLifecycle = "event_publish_dynamic_auto_emit_lifecycle"
+	ScenarioRunStopControlLifecycle              = "run_stop_control_lifecycle"
+	ScenarioRunPauseControlLifecycle             = "run_pause_control_lifecycle"
+	ScenarioRunContinueControlLifecycle          = "run_continue_control_lifecycle"
+	ScenarioRuntimePauseIngressLifecycle         = "runtime_pause_ingress_lifecycle"
+	ScenarioRuntimeResumeIngressLifecycle        = "runtime_resume_ingress_lifecycle"
+)
 
 type Scenario struct {
 	ID             string
@@ -52,6 +59,25 @@ func Scenarios() []Scenario {
 				PostconditionNoUnfiredDueTimers,
 			},
 		},
+		servedControlScenario(ScenarioRunStopControlLifecycle, "run.stop", "TestServedParityHarnessRunControlLifecycle"),
+		servedControlScenario(ScenarioRunPauseControlLifecycle, "run.pause", "TestServedParityHarnessRunControlLifecycle"),
+		servedControlScenario(ScenarioRunContinueControlLifecycle, "run.continue", "TestServedParityHarnessRunControlLifecycle"),
+		servedControlScenario(ScenarioRuntimePauseIngressLifecycle, "runtime.pause", "TestServedParityHarnessRuntimeIngressControlLifecycle"),
+		servedControlScenario(ScenarioRuntimeResumeIngressLifecycle, "runtime.resume", "TestServedParityHarnessRuntimeIngressControlLifecycle"),
+	}
+}
+
+func servedControlScenario(id, apiMethod, testName string) Scenario {
+	return Scenario{
+		ID:        id,
+		APIMethod: apiMethod,
+		TestName:  testName,
+		Backends:  append([]Backend(nil), RequiredBackends...),
+		Postconditions: []Postcondition{
+			PostconditionNoNonTerminalDeliveries,
+			PostconditionNoPendingPipelineEvents,
+			PostconditionNoUnfiredDueTimers,
+		},
 	}
 }
 
@@ -75,18 +101,54 @@ func MustScenario(id string) Scenario {
 
 func Run(t *testing.T, scenario Scenario, run func(*testing.T, Backend)) {
 	t.Helper()
-	if strings.TrimSpace(scenario.ID) == "" {
-		t.Fatal("served parity scenario missing id")
-	}
-	if len(scenario.Backends) == 0 {
-		t.Fatalf("served parity scenario %s missing backends", scenario.ID)
-	}
+	requireValidScenario(t, scenario)
 	for _, backend := range scenario.Backends {
 		backend := backend
 		t.Run(string(backend), func(t *testing.T) {
 			run(t, backend)
 		})
 	}
+}
+
+func RunScenarioGroup(t *testing.T, scenarios []Scenario, run func(*testing.T, Backend)) {
+	t.Helper()
+	if len(scenarios) == 0 {
+		t.Fatal("served parity scenario group is empty")
+	}
+	for _, scenario := range scenarios {
+		requireValidScenario(t, scenario)
+		if !sameBackends(scenarios[0].Backends, scenario.Backends) {
+			t.Fatalf("served parity scenario %s backends = %v, want group backends %v", scenario.ID, scenario.Backends, scenarios[0].Backends)
+		}
+	}
+	for _, backend := range scenarios[0].Backends {
+		backend := backend
+		t.Run(string(backend), func(t *testing.T) {
+			run(t, backend)
+		})
+	}
+}
+
+func requireValidScenario(t *testing.T, scenario Scenario) {
+	t.Helper()
+	if strings.TrimSpace(scenario.ID) == "" {
+		t.Fatal("served parity scenario missing id")
+	}
+	if len(scenario.Backends) == 0 {
+		t.Fatalf("served parity scenario %s missing backends", scenario.ID)
+	}
+}
+
+func sameBackends(a, b []Backend) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
 }
 
 func SettlementPostconditionFailures(scenario Scenario, counts SettlementCounts) []string {

--- a/internal/store/run_control.go
+++ b/internal/store/run_control.go
@@ -313,18 +313,32 @@ func (s *PostgresStore) abandonPendingRunDeliveriesTx(ctx context.Context, tx *s
 	for eventID := range eventsTouched {
 		var active bool
 		if err := tx.QueryRowContext(ctx, `
-			SELECT EXISTS (
-				SELECT 1
-				FROM event_deliveries
-				WHERE event_id = $1::uuid
+				SELECT EXISTS (
+					SELECT 1
+					FROM event_deliveries
+					WHERE event_id = $1::uuid
 				  AND status IN ('pending', 'in_progress')
 			)
 		`, eventID).Scan(&active); err != nil {
 			return 0, fmt.Errorf("check stopped run event active deliveries: %w", err)
 		}
 		if !active {
-			if err := s.upsertPipelineReceiptSpec(ctx, tx, eventID, "error", "run stopped"); err != nil {
-				return 0, fmt.Errorf("mark stopped run pipeline receipt: %w", err)
+			var hasPipelineReceipt bool
+			if err := tx.QueryRowContext(ctx, `
+					SELECT EXISTS (
+						SELECT 1
+						FROM event_receipts
+						WHERE event_id = $1::uuid
+						  AND subscriber_type = 'platform'
+						  AND subscriber_id = 'pipeline'
+					)
+				`, eventID).Scan(&hasPipelineReceipt); err != nil {
+				return 0, fmt.Errorf("check stopped run pipeline receipt: %w", err)
+			}
+			if !hasPipelineReceipt {
+				if err := s.upsertPipelineReceiptSpec(ctx, tx, eventID, "error", "run stopped"); err != nil {
+					return 0, fmt.Errorf("mark stopped run pipeline receipt: %w", err)
+				}
 			}
 		}
 	}

--- a/internal/store/run_control.go
+++ b/internal/store/run_control.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	runtimemanager "github.com/division-sh/swarm/internal/runtime/manager"
 	runtimeruncontrol "github.com/division-sh/swarm/internal/runtime/runcontrol"
 	storerunlifecycle "github.com/division-sh/swarm/internal/store/runlifecycle"
 )
@@ -260,30 +261,35 @@ func (s *PostgresStore) abandonPendingRunDeliveriesTx(ctx context.Context, tx *s
 		return 0, fmt.Errorf("run stop requires canonical event_deliveries.run_id")
 	}
 	rows, err := tx.QueryContext(ctx, `
-		SELECT d.event_id::text, d.subscriber_id
+		SELECT d.delivery_id::text, d.event_id::text, d.subscriber_type, d.subscriber_id, COALESCE(d.retry_count, 0)
 		FROM event_deliveries d
 		WHERE d.run_id = $1::uuid
-		  AND d.subscriber_type = 'agent'
 		  AND d.status = 'pending'
-		ORDER BY d.event_id::text ASC, d.subscriber_id ASC
+		ORDER BY d.event_id::text ASC, d.subscriber_type ASC, d.subscriber_id ASC, d.delivery_id::text ASC
+		FOR UPDATE
 	`, runID)
 	if err != nil {
 		return 0, fmt.Errorf("query pending run deliveries: %w", err)
 	}
 	defer rows.Close()
 	type target struct {
-		eventID string
-		agentID string
+		deliveryID     string
+		eventID        string
+		subscriberType string
+		subscriberID   string
+		retryCount     int
 	}
 	targets := []target{}
 	for rows.Next() {
 		var item target
-		if err := rows.Scan(&item.eventID, &item.agentID); err != nil {
+		if err := rows.Scan(&item.deliveryID, &item.eventID, &item.subscriberType, &item.subscriberID, &item.retryCount); err != nil {
 			return 0, fmt.Errorf("scan pending run delivery: %w", err)
 		}
+		item.deliveryID = strings.TrimSpace(item.deliveryID)
 		item.eventID = strings.TrimSpace(item.eventID)
-		item.agentID = strings.TrimSpace(item.agentID)
-		if item.eventID != "" && item.agentID != "" {
+		item.subscriberType = strings.TrimSpace(item.subscriberType)
+		item.subscriberID = strings.TrimSpace(item.subscriberID)
+		if item.deliveryID != "" && item.eventID != "" && item.subscriberType != "" && item.subscriberID != "" {
 			targets = append(targets, item)
 		}
 	}
@@ -293,19 +299,12 @@ func (s *PostgresStore) abandonPendingRunDeliveriesTx(ctx context.Context, tx *s
 	eventsTouched := map[string]struct{}{}
 	abandoned := 0
 	for _, item := range targets {
-		delivery, err := s.lockAgentDeliveryTx(ctx, tx, item.eventID, item.agentID)
+		applied, err := s.abandonPendingRunDeliveryTx(ctx, tx, item.deliveryID, item.eventID, item.subscriberType, item.subscriberID, item.retryCount)
 		if err != nil {
 			return 0, err
 		}
-		if !delivery.found || strings.TrimSpace(delivery.status) != "pending" {
+		if !applied {
 			continue
-		}
-		if _, err := s.applyDeliveryBackedTerminalTransitionTx(ctx, tx, item.eventID, item.agentID, delivery, deliveryBackedTerminalTransitionRequest{
-			reasonCode:   "run_stopped",
-			errorText:    "run stopped",
-			retryAdvance: 0,
-		}); err != nil {
-			return 0, fmt.Errorf("abandon stopped run delivery: %w", err)
 		}
 		eventsTouched[item.eventID] = struct{}{}
 		abandoned++
@@ -343,4 +342,75 @@ func (s *PostgresStore) abandonPendingRunDeliveriesTx(ctx context.Context, tx *s
 		}
 	}
 	return abandoned, nil
+}
+
+func (s *PostgresStore) abandonPendingRunDeliveryTx(ctx context.Context, tx *sql.Tx, deliveryID, eventID, subscriberType, subscriberID string, retryCount int) (bool, error) {
+	reasonCode := "run_stopped"
+	errorText := "run stopped"
+	res, err := tx.ExecContext(ctx, `
+		UPDATE event_deliveries
+		SET status = 'dead_letter',
+		    retry_count = $2,
+		    reason_code = $3,
+		    last_error = $4,
+		    active_session_id = NULL,
+		    started_at = COALESCE(started_at, created_at),
+		    delivered_at = now()
+		WHERE delivery_id = $1::uuid
+		  AND status = 'pending'
+	`, deliveryID, retryCount, reasonCode, errorText)
+	if err != nil {
+		return false, fmt.Errorf("abandon stopped run delivery %s: %w", deliveryID, err)
+	}
+	if rows, _ := res.RowsAffected(); rows == 0 {
+		return false, nil
+	}
+	switch subscriberType {
+	case "agent":
+		state := agentReceiptWriteState{
+			finalStatus:  runtimemanager.ReceiptStatusDeadLetter,
+			retryCount:   retryCount,
+			reasonCode:   reasonCode,
+			errorText:    errorText,
+			deliveryCode: "dead_letter",
+		}
+		if err := s.upsertAgentReceiptRowTx(ctx, tx, eventID, subscriberID, state); err != nil {
+			return false, fmt.Errorf("abandon stopped run agent receipt: %w", err)
+		}
+	case "node":
+		if err := s.upsertStoppedRunNodeReceiptTx(ctx, tx, eventID, subscriberID, reasonCode); err != nil {
+			return false, err
+		}
+	default:
+		return false, fmt.Errorf("unsupported stopped run delivery subscriber_type %q", subscriberType)
+	}
+	return true, nil
+}
+
+func (s *PostgresStore) upsertStoppedRunNodeReceiptTx(ctx context.Context, tx *sql.Tx, eventID, nodeID, reasonCode string) error {
+	res, err := tx.ExecContext(ctx, `
+		INSERT INTO event_receipts (
+			event_id, subscriber_type, subscriber_id, entity_id, flow_instance,
+			outcome, reason_code, side_effects, processed_at
+		)
+		SELECT
+			e.event_id, 'node', $2, e.entity_id, e.flow_instance,
+			'dead_letter', NULLIF($3, ''), '{}'::jsonb, now()
+		FROM events e
+		WHERE e.event_id = $1::uuid
+		ON CONFLICT (event_id, subscriber_type, subscriber_id) DO UPDATE SET
+			entity_id = EXCLUDED.entity_id,
+			flow_instance = EXCLUDED.flow_instance,
+			outcome = EXCLUDED.outcome,
+			reason_code = EXCLUDED.reason_code,
+			side_effects = EXCLUDED.side_effects,
+			processed_at = now()
+	`, eventID, nodeID, reasonCode)
+	if err != nil {
+		return fmt.Errorf("upsert stopped run node receipt: %w", err)
+	}
+	if rows, err := res.RowsAffected(); err == nil && rows == 0 {
+		return fmt.Errorf("upsert stopped run node receipt: event %s not found", eventID)
+	}
+	return nil
 }

--- a/internal/store/run_control_test.go
+++ b/internal/store/run_control_test.go
@@ -31,7 +31,13 @@ func TestPostgresStore_RunControlTransitionsAndStopAbandonsPendingWork(t *testin
 		INSERT INTO event_deliveries (run_id, event_id, subscriber_type, subscriber_id, status, created_at)
 		VALUES ($1::uuid, $2::uuid, 'agent', 'agent-pending', 'pending', now())
 	`, runID, eventID); err != nil {
-		t.Fatalf("seed pending delivery: %v", err)
+		t.Fatalf("seed pending agent delivery: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO event_deliveries (run_id, event_id, subscriber_type, subscriber_id, status, created_at)
+		VALUES ($1::uuid, $2::uuid, 'node', 'node-pending', 'pending', now())
+	`, runID, eventID); err != nil {
+		t.Fatalf("seed pending node delivery: %v", err)
 	}
 
 	if _, err := pg.PauseRunControl(ctx, runtimeruncontrol.TransitionRequest{RunID: runID, Reason: "test", ControlledBy: "test", Now: time.Now().UTC()}); err != nil {
@@ -44,8 +50,8 @@ func TestPostgresStore_RunControlTransitionsAndStopAbandonsPendingWork(t *testin
 	if err != nil {
 		t.Fatalf("StopRunControl: %v", err)
 	}
-	if state.Status != "cancelled" || state.ControlStatus != "stopped" || state.AbandonedDeliveries != 1 {
-		t.Fatalf("stop state = %+v, want cancelled/stopped/1", state)
+	if state.Status != "cancelled" || state.ControlStatus != "stopped" || state.AbandonedDeliveries != 2 {
+		t.Fatalf("stop state = %+v, want cancelled/stopped/2", state)
 	}
 
 	var deliveryStatus, reasonCode string
@@ -59,6 +65,31 @@ func TestPostgresStore_RunControlTransitionsAndStopAbandonsPendingWork(t *testin
 	}
 	if deliveryStatus != "dead_letter" || reasonCode != "run_stopped" {
 		t.Fatalf("stopped delivery = %s/%s, want dead_letter/run_stopped", deliveryStatus, reasonCode)
+	}
+	if err := db.QueryRowContext(ctx, `
+		SELECT status, COALESCE(reason_code, '')
+		FROM event_deliveries
+		WHERE event_id = $1::uuid
+		  AND subscriber_type = 'node'
+		  AND subscriber_id = 'node-pending'
+	`, eventID).Scan(&deliveryStatus, &reasonCode); err != nil {
+		t.Fatalf("load stopped node delivery: %v", err)
+	}
+	if deliveryStatus != "dead_letter" || reasonCode != "run_stopped" {
+		t.Fatalf("stopped node delivery = %s/%s, want dead_letter/run_stopped", deliveryStatus, reasonCode)
+	}
+	var nodeReceiptOutcome, nodeReceiptReason string
+	if err := db.QueryRowContext(ctx, `
+		SELECT outcome, COALESCE(reason_code, '')
+		FROM event_receipts
+		WHERE event_id = $1::uuid
+		  AND subscriber_type = 'node'
+		  AND subscriber_id = 'node-pending'
+	`, eventID).Scan(&nodeReceiptOutcome, &nodeReceiptReason); err != nil {
+		t.Fatalf("load stopped node receipt: %v", err)
+	}
+	if nodeReceiptOutcome != "dead_letter" || nodeReceiptReason != "run_stopped" {
+		t.Fatalf("stopped node receipt = %s/%s, want dead_letter/run_stopped", nodeReceiptOutcome, nodeReceiptReason)
 	}
 	var receiptCount int
 	if err := db.QueryRowContext(ctx, `

--- a/internal/store/sqlite_runtime.go
+++ b/internal/store/sqlite_runtime.go
@@ -653,7 +653,7 @@ func (s *SQLiteRuntimeStore) sqliteRunControlTransition(ctx context.Context, req
 		case "continue":
 			state, err = sqliteContinueRunControl(txctx, tx, state, req)
 		case "stop":
-			state, err = sqliteStopRunControl(txctx, tx, state, req)
+			state, err = s.sqliteStopRunControl(txctx, tx, state, req)
 		default:
 			err = fmt.Errorf("unsupported run control action %q", action)
 		}

--- a/internal/store/sqlite_runtime_delivery_replay.go
+++ b/internal/store/sqlite_runtime_delivery_replay.go
@@ -573,6 +573,78 @@ func (s *SQLiteRuntimeStore) UpsertEventReceipt(ctx context.Context, eventID, ag
 	})
 }
 
+func (s *SQLiteRuntimeStore) applySQLiteDeliveryBackedTerminalTransitionTx(
+	ctx context.Context,
+	tx *sql.Tx,
+	eventID, agentID string,
+	delivery lockedAgentDelivery,
+	req deliveryBackedTerminalTransitionRequest,
+) (runtimemanager.EventReceipt, error) {
+	if !delivery.found {
+		return runtimemanager.EventReceipt{}, fmt.Errorf("apply sqlite delivery-backed terminal transition: delivery row required")
+	}
+	reasonCode := strings.TrimSpace(req.reasonCode)
+	if reasonCode == "" {
+		return runtimemanager.EventReceipt{}, fmt.Errorf("apply sqlite delivery-backed terminal transition: reason_code required")
+	}
+	if req.retryAdvance < 0 {
+		return runtimemanager.EventReceipt{}, fmt.Errorf("apply sqlite delivery-backed terminal transition: retry advance must be non-negative")
+	}
+	state := agentReceiptWriteState{
+		finalStatus:  runtimemanager.ReceiptStatusDeadLetter,
+		retryCount:   delivery.retryCount + req.retryAdvance,
+		reasonCode:   reasonCode,
+		errorText:    strings.TrimSpace(req.errorText),
+		deliveryCode: "dead_letter",
+	}
+	now := s.now()
+	if _, err := tx.ExecContext(ctx, `
+		UPDATE event_deliveries
+		SET status = ?,
+		    retry_count = ?,
+		    reason_code = ?,
+		    last_error = ?,
+		    active_session_id = NULL,
+		    delivered_at = ?
+		WHERE event_id = ?
+		  AND subscriber_type = 'agent'
+		  AND subscriber_id = ?
+	`, state.deliveryCode, state.retryCount, sqliteNullString(state.reasonCode), sqliteNullString(state.errorText), now, eventID, agentID); err != nil {
+		return runtimemanager.EventReceipt{}, fmt.Errorf("sync sqlite event delivery terminal state: %w", err)
+	}
+	sideEffects, err := marshalAgentReceiptSideEffects(newAgentReceiptSideEffects(state.finalStatus, state.reasonCode, state.retryCount, state.errorText))
+	if err != nil {
+		return runtimemanager.EventReceipt{}, fmt.Errorf("marshal sqlite terminal agent receipt side effects: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, `
+		INSERT INTO event_receipts (
+			receipt_id, event_id, subscriber_type, subscriber_id, entity_id, flow_instance,
+			outcome, reason_code, side_effects, processed_at
+		)
+		SELECT
+			?, e.event_id, 'agent', ?, e.entity_id, e.flow_instance,
+			?, ?, ?, ?
+		FROM events e
+		WHERE e.event_id = ?
+		ON CONFLICT(event_id, subscriber_type, subscriber_id) DO UPDATE SET
+			entity_id = excluded.entity_id,
+			flow_instance = excluded.flow_instance,
+			outcome = excluded.outcome,
+			reason_code = excluded.reason_code,
+			side_effects = excluded.side_effects,
+			processed_at = excluded.processed_at
+	`, uuid.NewString(), agentID, mapManagerReceiptStatusToOutcome(state.finalStatus), sqliteNullString(state.reasonCode), string(sideEffects), now, eventID); err != nil {
+		return runtimemanager.EventReceipt{}, fmt.Errorf("upsert sqlite terminal event receipt row: %w", err)
+	}
+	return runtimemanager.EventReceipt{
+		EventID:    strings.TrimSpace(eventID),
+		AgentID:    strings.TrimSpace(agentID),
+		Status:     runtimemanager.ReceiptStatusDeadLetter,
+		RetryCount: state.retryCount,
+		Error:      state.errorText,
+	}, nil
+}
+
 func (s *SQLiteRuntimeStore) GetEventReceipt(ctx context.Context, eventID, agentID string) (runtimemanager.EventReceipt, bool, error) {
 	eventID = strings.TrimSpace(eventID)
 	agentID = strings.TrimSpace(agentID)

--- a/internal/store/sqlite_runtime_mailbox_schedule.go
+++ b/internal/store/sqlite_runtime_mailbox_schedule.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	runtimemanager "github.com/division-sh/swarm/internal/runtime/manager"
 	runtimepipeline "github.com/division-sh/swarm/internal/runtime/pipeline"
 	runtimeruncontrol "github.com/division-sh/swarm/internal/runtime/runcontrol"
 	runtimetools "github.com/division-sh/swarm/internal/runtime/tools"
@@ -543,30 +544,34 @@ func (s *SQLiteRuntimeStore) sqliteStopRunControl(ctx context.Context, tx *sql.T
 
 func (s *SQLiteRuntimeStore) sqliteAbandonPendingRunDeliveriesTx(ctx context.Context, tx *sql.Tx, runID string) (int, error) {
 	rows, err := tx.QueryContext(ctx, `
-		SELECT event_id, subscriber_id
+		SELECT delivery_id, event_id, subscriber_type, subscriber_id, COALESCE(retry_count, 0)
 		FROM event_deliveries
 		WHERE run_id = ?
-		  AND subscriber_type = 'agent'
 		  AND status = 'pending'
-		ORDER BY event_id ASC, subscriber_id ASC
+		ORDER BY event_id ASC, subscriber_type ASC, subscriber_id ASC, delivery_id ASC
 	`, runID)
 	if err != nil {
 		return 0, fmt.Errorf("query sqlite pending run deliveries: %w", err)
 	}
 	defer rows.Close()
 	type target struct {
-		eventID string
-		agentID string
+		deliveryID     string
+		eventID        string
+		subscriberType string
+		subscriberID   string
+		retryCount     int
 	}
 	targets := []target{}
 	for rows.Next() {
 		var item target
-		if err := rows.Scan(&item.eventID, &item.agentID); err != nil {
+		if err := rows.Scan(&item.deliveryID, &item.eventID, &item.subscriberType, &item.subscriberID, &item.retryCount); err != nil {
 			return 0, fmt.Errorf("scan sqlite pending run delivery: %w", err)
 		}
+		item.deliveryID = strings.TrimSpace(item.deliveryID)
 		item.eventID = strings.TrimSpace(item.eventID)
-		item.agentID = strings.TrimSpace(item.agentID)
-		if item.eventID != "" && item.agentID != "" {
+		item.subscriberType = strings.TrimSpace(item.subscriberType)
+		item.subscriberID = strings.TrimSpace(item.subscriberID)
+		if item.deliveryID != "" && item.eventID != "" && item.subscriberType != "" && item.subscriberID != "" {
 			targets = append(targets, item)
 		}
 	}
@@ -577,19 +582,12 @@ func (s *SQLiteRuntimeStore) sqliteAbandonPendingRunDeliveriesTx(ctx context.Con
 	eventsTouched := map[string]struct{}{}
 	abandoned := 0
 	for _, item := range targets {
-		delivery, err := s.sqliteLockAgentDeliveryTx(ctx, tx, item.eventID, item.agentID)
+		applied, err := s.sqliteAbandonPendingRunDeliveryTx(ctx, tx, item.deliveryID, item.eventID, item.subscriberType, item.subscriberID, item.retryCount)
 		if err != nil {
 			return 0, err
 		}
-		if !delivery.found || strings.TrimSpace(delivery.status) != "pending" {
+		if !applied {
 			continue
-		}
-		if _, err := s.applySQLiteDeliveryBackedTerminalTransitionTx(ctx, tx, item.eventID, item.agentID, delivery, deliveryBackedTerminalTransitionRequest{
-			reasonCode:   "run_stopped",
-			errorText:    "run stopped",
-			retryAdvance: 0,
-		}); err != nil {
-			return 0, fmt.Errorf("abandon sqlite stopped run delivery: %w", err)
 		}
 		eventsTouched[item.eventID] = struct{}{}
 		abandoned++
@@ -627,4 +625,100 @@ func (s *SQLiteRuntimeStore) sqliteAbandonPendingRunDeliveriesTx(ctx context.Con
 		}
 	}
 	return abandoned, nil
+}
+
+func (s *SQLiteRuntimeStore) sqliteAbandonPendingRunDeliveryTx(ctx context.Context, tx *sql.Tx, deliveryID, eventID, subscriberType, subscriberID string, retryCount int) (bool, error) {
+	reasonCode := "run_stopped"
+	errorText := "run stopped"
+	now := s.now()
+	res, err := tx.ExecContext(ctx, `
+		UPDATE event_deliveries
+		SET status = 'dead_letter',
+		    retry_count = ?,
+		    reason_code = ?,
+		    last_error = ?,
+		    active_session_id = NULL,
+		    started_at = COALESCE(started_at, created_at),
+		    delivered_at = ?
+		WHERE delivery_id = ?
+		  AND status = 'pending'
+	`, retryCount, reasonCode, errorText, now, deliveryID)
+	if err != nil {
+		return false, fmt.Errorf("abandon sqlite stopped run delivery %s: %w", deliveryID, err)
+	}
+	if rows, _ := res.RowsAffected(); rows == 0 {
+		return false, nil
+	}
+	switch subscriberType {
+	case "agent":
+		state := agentReceiptWriteState{
+			finalStatus:  runtimemanager.ReceiptStatusDeadLetter,
+			retryCount:   retryCount,
+			reasonCode:   reasonCode,
+			errorText:    errorText,
+			deliveryCode: "dead_letter",
+		}
+		if err := s.upsertSQLiteStoppedRunAgentReceiptTx(ctx, tx, eventID, subscriberID, state, now); err != nil {
+			return false, err
+		}
+	case "node":
+		if err := s.upsertSQLiteStoppedRunNodeReceiptTx(ctx, tx, eventID, subscriberID, reasonCode, now); err != nil {
+			return false, err
+		}
+	default:
+		return false, fmt.Errorf("unsupported sqlite stopped run delivery subscriber_type %q", subscriberType)
+	}
+	return true, nil
+}
+
+func (s *SQLiteRuntimeStore) upsertSQLiteStoppedRunAgentReceiptTx(ctx context.Context, tx *sql.Tx, eventID, agentID string, state agentReceiptWriteState, now time.Time) error {
+	sideEffects, err := marshalAgentReceiptSideEffects(newAgentReceiptSideEffects(state.finalStatus, state.reasonCode, state.retryCount, state.errorText))
+	if err != nil {
+		return fmt.Errorf("marshal sqlite stopped run agent receipt side effects: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, `
+		INSERT INTO event_receipts (
+			receipt_id, event_id, subscriber_type, subscriber_id, entity_id, flow_instance,
+			outcome, reason_code, side_effects, processed_at
+		)
+		SELECT
+			?, e.event_id, 'agent', ?, e.entity_id, e.flow_instance,
+			?, ?, ?, ?
+		FROM events e
+		WHERE e.event_id = ?
+		ON CONFLICT(event_id, subscriber_type, subscriber_id) DO UPDATE SET
+			entity_id = excluded.entity_id,
+			flow_instance = excluded.flow_instance,
+			outcome = excluded.outcome,
+			reason_code = excluded.reason_code,
+			side_effects = excluded.side_effects,
+			processed_at = excluded.processed_at
+	`, uuid.NewString(), agentID, mapManagerReceiptStatusToOutcome(state.finalStatus), sqliteNullString(state.reasonCode), string(sideEffects), now, eventID); err != nil {
+		return fmt.Errorf("upsert sqlite stopped run agent receipt: %w", err)
+	}
+	return nil
+}
+
+func (s *SQLiteRuntimeStore) upsertSQLiteStoppedRunNodeReceiptTx(ctx context.Context, tx *sql.Tx, eventID, nodeID, reasonCode string, now time.Time) error {
+	if _, err := tx.ExecContext(ctx, `
+		INSERT INTO event_receipts (
+			receipt_id, event_id, subscriber_type, subscriber_id, entity_id, flow_instance,
+			outcome, reason_code, side_effects, processed_at
+		)
+		SELECT
+			?, e.event_id, 'node', ?, e.entity_id, e.flow_instance,
+			'dead_letter', ?, '{}', ?
+		FROM events e
+		WHERE e.event_id = ?
+		ON CONFLICT(event_id, subscriber_type, subscriber_id) DO UPDATE SET
+			entity_id = excluded.entity_id,
+			flow_instance = excluded.flow_instance,
+			outcome = excluded.outcome,
+			reason_code = excluded.reason_code,
+			side_effects = excluded.side_effects,
+			processed_at = excluded.processed_at
+	`, uuid.NewString(), nodeID, sqliteNullString(reasonCode), now, eventID); err != nil {
+		return fmt.Errorf("upsert sqlite stopped run node receipt: %w", err)
+	}
+	return nil
 }

--- a/internal/store/sqlite_runtime_mailbox_schedule.go
+++ b/internal/store/sqlite_runtime_mailbox_schedule.go
@@ -508,13 +508,17 @@ func sqliteContinueRunControl(ctx context.Context, tx *sql.Tx, state runtimerunc
 	return state, nil
 }
 
-func sqliteStopRunControl(ctx context.Context, tx *sql.Tx, state runtimeruncontrol.State, req runtimeruncontrol.TransitionRequest) (runtimeruncontrol.State, error) {
+func (s *SQLiteRuntimeStore) sqliteStopRunControl(ctx context.Context, tx *sql.Tx, state runtimeruncontrol.State, req runtimeruncontrol.TransitionRequest) (runtimeruncontrol.State, error) {
 	switch state.Status {
 	case "running", "paused":
 	case "completed", "failed", "cancelled", "forked":
 		return runtimeruncontrol.State{}, &runtimeruncontrol.StateError{Err: runtimeruncontrol.ErrAlreadyTerminal, RunID: state.RunID, CurrentStatus: state.Status}
 	default:
 		return runtimeruncontrol.State{}, fmt.Errorf("unsupported run status %q", state.Status)
+	}
+	abandoned, err := s.sqliteAbandonPendingRunDeliveriesTx(ctx, tx, state.RunID)
+	if err != nil {
+		return runtimeruncontrol.State{}, err
 	}
 	if _, err := tx.ExecContext(ctx, `UPDATE runs SET status = 'cancelled', ended_at = COALESCE(ended_at, ?) WHERE run_id = ?`, req.Now.UTC(), state.RunID); err != nil {
 		return runtimeruncontrol.State{}, fmt.Errorf("stop sqlite run: %w", err)
@@ -533,5 +537,94 @@ func sqliteStopRunControl(ctx context.Context, tx *sql.Tx, state runtimeruncontr
 	state.Reason = req.Reason
 	state.ControlledBy = req.ControlledBy
 	state.UpdatedAt = req.Now.UTC()
+	state.AbandonedDeliveries = abandoned
 	return state, nil
+}
+
+func (s *SQLiteRuntimeStore) sqliteAbandonPendingRunDeliveriesTx(ctx context.Context, tx *sql.Tx, runID string) (int, error) {
+	rows, err := tx.QueryContext(ctx, `
+		SELECT event_id, subscriber_id
+		FROM event_deliveries
+		WHERE run_id = ?
+		  AND subscriber_type = 'agent'
+		  AND status = 'pending'
+		ORDER BY event_id ASC, subscriber_id ASC
+	`, runID)
+	if err != nil {
+		return 0, fmt.Errorf("query sqlite pending run deliveries: %w", err)
+	}
+	defer rows.Close()
+	type target struct {
+		eventID string
+		agentID string
+	}
+	targets := []target{}
+	for rows.Next() {
+		var item target
+		if err := rows.Scan(&item.eventID, &item.agentID); err != nil {
+			return 0, fmt.Errorf("scan sqlite pending run delivery: %w", err)
+		}
+		item.eventID = strings.TrimSpace(item.eventID)
+		item.agentID = strings.TrimSpace(item.agentID)
+		if item.eventID != "" && item.agentID != "" {
+			targets = append(targets, item)
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return 0, fmt.Errorf("read sqlite pending run deliveries: %w", err)
+	}
+
+	eventsTouched := map[string]struct{}{}
+	abandoned := 0
+	for _, item := range targets {
+		delivery, err := s.sqliteLockAgentDeliveryTx(ctx, tx, item.eventID, item.agentID)
+		if err != nil {
+			return 0, err
+		}
+		if !delivery.found || strings.TrimSpace(delivery.status) != "pending" {
+			continue
+		}
+		if _, err := s.applySQLiteDeliveryBackedTerminalTransitionTx(ctx, tx, item.eventID, item.agentID, delivery, deliveryBackedTerminalTransitionRequest{
+			reasonCode:   "run_stopped",
+			errorText:    "run stopped",
+			retryAdvance: 0,
+		}); err != nil {
+			return 0, fmt.Errorf("abandon sqlite stopped run delivery: %w", err)
+		}
+		eventsTouched[item.eventID] = struct{}{}
+		abandoned++
+	}
+	for eventID := range eventsTouched {
+		var active bool
+		if err := tx.QueryRowContext(ctx, `
+				SELECT EXISTS (
+					SELECT 1
+					FROM event_deliveries
+					WHERE event_id = ?
+				  AND status IN ('pending', 'in_progress')
+			)
+		`, eventID).Scan(&active); err != nil {
+			return 0, fmt.Errorf("check sqlite stopped run event active deliveries: %w", err)
+		}
+		if !active {
+			var hasPipelineReceipt bool
+			if err := tx.QueryRowContext(ctx, `
+					SELECT EXISTS (
+						SELECT 1
+						FROM event_receipts
+						WHERE event_id = ?
+						  AND subscriber_type = 'platform'
+						  AND subscriber_id = 'pipeline'
+					)
+				`, eventID).Scan(&hasPipelineReceipt); err != nil {
+				return 0, fmt.Errorf("check sqlite stopped run pipeline receipt: %w", err)
+			}
+			if !hasPipelineReceipt {
+				if err := s.UpsertPipelineReceiptTx(ctx, tx, eventID, "error", "run stopped"); err != nil {
+					return 0, fmt.Errorf("mark sqlite stopped run pipeline receipt: %w", err)
+				}
+			}
+		}
+	}
+	return abandoned, nil
 }

--- a/internal/store/sqlite_runtime_test.go
+++ b/internal/store/sqlite_runtime_test.go
@@ -247,7 +247,8 @@ func TestSQLiteRuntimeStore_RunControlStopAbandonsPendingWork(t *testing.T) {
 	store := newBootstrappedSQLiteRuntimeStoreForTest(t)
 	runID := uuid.NewString()
 	eventID := uuid.NewString()
-	deliveryID := uuid.NewString()
+	agentDeliveryID := uuid.NewString()
+	nodeDeliveryID := uuid.NewString()
 	now := time.Now().UTC()
 	if _, err := store.DB.ExecContext(ctx, `
 		INSERT INTO runs (run_id, status, bundle_source, started_at)
@@ -264,8 +265,14 @@ func TestSQLiteRuntimeStore_RunControlStopAbandonsPendingWork(t *testing.T) {
 	if _, err := store.DB.ExecContext(ctx, `
 		INSERT INTO event_deliveries (delivery_id, run_id, event_id, subscriber_type, subscriber_id, status, active_session_id, created_at)
 		VALUES (?, ?, ?, 'agent', 'agent-pending', 'pending', ?, ?)
-	`, deliveryID, runID, eventID, uuid.NewString(), now); err != nil {
-		t.Fatalf("seed sqlite pending delivery: %v", err)
+	`, agentDeliveryID, runID, eventID, uuid.NewString(), now); err != nil {
+		t.Fatalf("seed sqlite pending agent delivery: %v", err)
+	}
+	if _, err := store.DB.ExecContext(ctx, `
+		INSERT INTO event_deliveries (delivery_id, run_id, event_id, subscriber_type, subscriber_id, status, active_session_id, created_at)
+		VALUES (?, ?, ?, 'node', 'node-pending', 'pending', ?, ?)
+	`, nodeDeliveryID, runID, eventID, uuid.NewString(), now); err != nil {
+		t.Fatalf("seed sqlite pending node delivery: %v", err)
 	}
 
 	state, err := store.StopRunControl(ctx, runtimeruncontrol.TransitionRequest{
@@ -277,8 +284,8 @@ func TestSQLiteRuntimeStore_RunControlStopAbandonsPendingWork(t *testing.T) {
 	if err != nil {
 		t.Fatalf("StopRunControl: %v", err)
 	}
-	if state.Status != "cancelled" || state.ControlStatus != "stopped" || state.AbandonedDeliveries != 1 {
-		t.Fatalf("stop state = %+v, want cancelled/stopped/1", state)
+	if state.Status != "cancelled" || state.ControlStatus != "stopped" || state.AbandonedDeliveries != 2 {
+		t.Fatalf("stop state = %+v, want cancelled/stopped/2", state)
 	}
 
 	var deliveryStatus, reasonCode, lastError, activeSession string
@@ -293,6 +300,18 @@ func TestSQLiteRuntimeStore_RunControlStopAbandonsPendingWork(t *testing.T) {
 	if deliveryStatus != "dead_letter" || reasonCode != "run_stopped" || lastError != "run stopped" || activeSession != "" {
 		t.Fatalf("stopped sqlite delivery = %s/%s/%q active=%q, want dead_letter/run_stopped/run stopped/no active session", deliveryStatus, reasonCode, lastError, activeSession)
 	}
+	if err := store.DB.QueryRowContext(ctx, `
+		SELECT status, COALESCE(reason_code, ''), COALESCE(last_error, ''), COALESCE(active_session_id, '')
+		FROM event_deliveries
+		WHERE event_id = ?
+		  AND subscriber_type = 'node'
+		  AND subscriber_id = 'node-pending'
+	`, eventID).Scan(&deliveryStatus, &reasonCode, &lastError, &activeSession); err != nil {
+		t.Fatalf("load stopped sqlite node delivery: %v", err)
+	}
+	if deliveryStatus != "dead_letter" || reasonCode != "run_stopped" || lastError != "run stopped" || activeSession != "" {
+		t.Fatalf("stopped sqlite node delivery = %s/%s/%q active=%q, want dead_letter/run_stopped/run stopped/no active session", deliveryStatus, reasonCode, lastError, activeSession)
+	}
 
 	var agentOutcome, agentReason string
 	if err := store.DB.QueryRowContext(ctx, `
@@ -306,6 +325,19 @@ func TestSQLiteRuntimeStore_RunControlStopAbandonsPendingWork(t *testing.T) {
 	}
 	if agentOutcome != "dead_letter" || agentReason != "run_stopped" {
 		t.Fatalf("stopped sqlite agent receipt = %s/%s, want dead_letter/run_stopped", agentOutcome, agentReason)
+	}
+	var nodeOutcome, nodeReason string
+	if err := store.DB.QueryRowContext(ctx, `
+		SELECT outcome, COALESCE(reason_code, '')
+		FROM event_receipts
+		WHERE event_id = ?
+		  AND subscriber_type = 'node'
+		  AND subscriber_id = 'node-pending'
+	`, eventID).Scan(&nodeOutcome, &nodeReason); err != nil {
+		t.Fatalf("load stopped sqlite node receipt: %v", err)
+	}
+	if nodeOutcome != "dead_letter" || nodeReason != "run_stopped" {
+		t.Fatalf("stopped sqlite node receipt = %s/%s, want dead_letter/run_stopped", nodeOutcome, nodeReason)
 	}
 
 	var pipelineOutcome string

--- a/internal/store/sqlite_runtime_test.go
+++ b/internal/store/sqlite_runtime_test.go
@@ -242,6 +242,87 @@ func TestSQLiteRuntimeStoreSelectedCoreContracts(t *testing.T) {
 	}
 }
 
+func TestSQLiteRuntimeStore_RunControlStopAbandonsPendingWork(t *testing.T) {
+	ctx := context.Background()
+	store := newBootstrappedSQLiteRuntimeStoreForTest(t)
+	runID := uuid.NewString()
+	eventID := uuid.NewString()
+	deliveryID := uuid.NewString()
+	now := time.Now().UTC()
+	if _, err := store.DB.ExecContext(ctx, `
+		INSERT INTO runs (run_id, status, bundle_source, started_at)
+		VALUES (?, 'running', 'legacy', ?)
+	`, runID, now); err != nil {
+		t.Fatalf("seed sqlite run: %v", err)
+	}
+	if _, err := store.DB.ExecContext(ctx, `
+		INSERT INTO events (event_id, run_id, event_name, scope, payload, produced_by, produced_by_type, created_at)
+		VALUES (?, ?, 'custom.stop', 'global', '{}', 'test', 'agent', ?)
+	`, eventID, runID, now); err != nil {
+		t.Fatalf("seed sqlite event: %v", err)
+	}
+	if _, err := store.DB.ExecContext(ctx, `
+		INSERT INTO event_deliveries (delivery_id, run_id, event_id, subscriber_type, subscriber_id, status, active_session_id, created_at)
+		VALUES (?, ?, ?, 'agent', 'agent-pending', 'pending', ?, ?)
+	`, deliveryID, runID, eventID, uuid.NewString(), now); err != nil {
+		t.Fatalf("seed sqlite pending delivery: %v", err)
+	}
+
+	state, err := store.StopRunControl(ctx, runtimeruncontrol.TransitionRequest{
+		RunID:        runID,
+		Reason:       "test",
+		ControlledBy: "test",
+		Now:          now.Add(time.Second),
+	})
+	if err != nil {
+		t.Fatalf("StopRunControl: %v", err)
+	}
+	if state.Status != "cancelled" || state.ControlStatus != "stopped" || state.AbandonedDeliveries != 1 {
+		t.Fatalf("stop state = %+v, want cancelled/stopped/1", state)
+	}
+
+	var deliveryStatus, reasonCode, lastError, activeSession string
+	if err := store.DB.QueryRowContext(ctx, `
+		SELECT status, COALESCE(reason_code, ''), COALESCE(last_error, ''), COALESCE(active_session_id, '')
+		FROM event_deliveries
+		WHERE event_id = ?
+		  AND subscriber_id = 'agent-pending'
+	`, eventID).Scan(&deliveryStatus, &reasonCode, &lastError, &activeSession); err != nil {
+		t.Fatalf("load stopped sqlite delivery: %v", err)
+	}
+	if deliveryStatus != "dead_letter" || reasonCode != "run_stopped" || lastError != "run stopped" || activeSession != "" {
+		t.Fatalf("stopped sqlite delivery = %s/%s/%q active=%q, want dead_letter/run_stopped/run stopped/no active session", deliveryStatus, reasonCode, lastError, activeSession)
+	}
+
+	var agentOutcome, agentReason string
+	if err := store.DB.QueryRowContext(ctx, `
+		SELECT outcome, COALESCE(reason_code, '')
+		FROM event_receipts
+		WHERE event_id = ?
+		  AND subscriber_type = 'agent'
+		  AND subscriber_id = 'agent-pending'
+	`, eventID).Scan(&agentOutcome, &agentReason); err != nil {
+		t.Fatalf("load stopped sqlite agent receipt: %v", err)
+	}
+	if agentOutcome != "dead_letter" || agentReason != "run_stopped" {
+		t.Fatalf("stopped sqlite agent receipt = %s/%s, want dead_letter/run_stopped", agentOutcome, agentReason)
+	}
+
+	var pipelineOutcome string
+	if err := store.DB.QueryRowContext(ctx, `
+		SELECT outcome
+		FROM event_receipts
+		WHERE event_id = ?
+		  AND subscriber_type = 'platform'
+		  AND subscriber_id = 'pipeline'
+	`, eventID).Scan(&pipelineOutcome); err != nil {
+		t.Fatalf("load stopped sqlite pipeline receipt: %v", err)
+	}
+	if pipelineOutcome != "dead_letter" {
+		t.Fatalf("stopped sqlite pipeline receipt = %s, want dead_letter", pipelineOutcome)
+	}
+}
+
 func TestSQLiteRuntimeStoreUpsertAgentConsumesActivePipelineTransaction(t *testing.T) {
 	ctx := runtimecorrelation.WithRunID(context.Background(), uuid.NewString())
 	store := newBootstrappedSQLiteRuntimeStoreForTest(t)

--- a/openrpc.json
+++ b/openrpc.json
@@ -6625,7 +6625,7 @@
     },
     {
       "name": "run.stop",
-      "description": "Stop an in-progress run. Pending events are abandoned; in-flight handlers complete or roll back per their own semantics. The selected run-control store terminalizes pending same-run agent deliveries as `dead_letter` with `reason_code=run_stopped`. For events that already have a platform/pipeline receipt, run.stop preserves that receipt as the authoritative routing outcome while terminalizing the pending delivery. When a stopped event lacks a platform/pipeline receipt and no active delivery remains, the store writes a stopped-run pipeline dead-letter so missing-pipeline-receipt replay cannot resurrect abandoned work.\n",
+      "description": "Stop an in-progress run. Pending events are abandoned; in-flight handlers complete or roll back per their own semantics. The selected run-control store terminalizes pending same-run `event_deliveries` rows for canonical runtime subscriber types (`agent` and `node`) as `dead_letter` with `reason_code=run_stopped`, and writes the matching agent or node receipt. For events that already have a platform/pipeline receipt, run.stop preserves that receipt as the authoritative routing outcome while terminalizing the pending delivery. When a stopped event lacks a platform/pipeline receipt and no active delivery remains, the store writes a stopped-run pipeline dead-letter so missing-pipeline-receipt replay cannot resurrect abandoned work.\n",
       "params": [
         {
           "name": "run_id",

--- a/openrpc.json
+++ b/openrpc.json
@@ -6625,7 +6625,7 @@
     },
     {
       "name": "run.stop",
-      "description": "Stop an in-progress run. Pending events are abandoned; in-flight handlers complete or roll back per their own semantics.",
+      "description": "Stop an in-progress run. Pending events are abandoned; in-flight handlers complete or roll back per their own semantics. The selected run-control store terminalizes pending same-run agent deliveries as `dead_letter` with `reason_code=run_stopped`. For events that already have a platform/pipeline receipt, run.stop preserves that receipt as the authoritative routing outcome while terminalizing the pending delivery. When a stopped event lacks a platform/pipeline receipt and no active delivery remains, the store writes a stopped-run pipeline dead-letter so missing-pipeline-receipt replay cannot resurrect abandoned work.\n",
       "params": [
         {
           "name": "run_id",

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -22731,8 +22731,13 @@ api_specification:
       - IDEMPOTENCY_CONFLICT
     run.stop:
       tier: must_have
-      description: Stop an in-progress run. Pending events are abandoned; in-flight handlers complete or roll back per their
-        own semantics.
+      description: >
+        Stop an in-progress run. Pending events are abandoned; in-flight handlers complete or roll back per their
+        own semantics. The selected run-control store terminalizes pending same-run agent deliveries as
+        `dead_letter` with `reason_code=run_stopped`. For events that already have a platform/pipeline receipt,
+        run.stop preserves that receipt as the authoritative routing outcome while terminalizing the pending
+        delivery. When a stopped event lacks a platform/pipeline receipt and no active delivery remains, the store
+        writes a stopped-run pipeline dead-letter so missing-pipeline-receipt replay cannot resurrect abandoned work.
       scope:
         required:
         - write:runs

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -22733,11 +22733,13 @@ api_specification:
       tier: must_have
       description: >
         Stop an in-progress run. Pending events are abandoned; in-flight handlers complete or roll back per their
-        own semantics. The selected run-control store terminalizes pending same-run agent deliveries as
-        `dead_letter` with `reason_code=run_stopped`. For events that already have a platform/pipeline receipt,
-        run.stop preserves that receipt as the authoritative routing outcome while terminalizing the pending
-        delivery. When a stopped event lacks a platform/pipeline receipt and no active delivery remains, the store
-        writes a stopped-run pipeline dead-letter so missing-pipeline-receipt replay cannot resurrect abandoned work.
+        own semantics. The selected run-control store terminalizes pending same-run `event_deliveries` rows for
+        canonical runtime subscriber types (`agent` and `node`) as `dead_letter` with
+        `reason_code=run_stopped`, and writes the matching agent or node receipt. For events that already have a
+        platform/pipeline receipt, run.stop preserves that receipt as the authoritative routing outcome while
+        terminalizing the pending delivery. When a stopped event lacks a platform/pipeline receipt and no active
+        delivery remains, the store writes a stopped-run pipeline dead-letter so missing-pipeline-receipt replay
+        cannot resurrect abandoned work.
       scope:
         required:
         - write:runs


### PR DESCRIPTION
## Summary

Closes #1864.
Closes #1872.
Part of #1386.
Part of #1239.

Adds served dual-backend parity proof for the non-destructive run/runtime control family:

- `run.stop`
- `run.pause`
- `run.continue`
- `runtime.pause`
- `runtime.resume`

Also fixes the absorbed #1872 behavior blocker at the selected store/runtime-control owner: SQLite `run.stop` now abandons pending agent deliveries as `dead_letter/run_stopped`, matching the selected Postgres run-control behavior. The shared run.stop owner now preserves an existing platform/pipeline success receipt and only synthesizes a stopped-run pipeline dead-letter when that receipt is missing, so already-routed pending deliveries can honestly reach test quiescence without reclassifying routing success.

## Governing refs / binding context

- `platform-spec.yaml#api_specification.conventions.idempotency.mutating_methods`
- `platform-spec.yaml#api_specification.method_catalog.run.stop`
- `platform-spec.yaml#api_specification.method_catalog.run.pause`
- `platform-spec.yaml#api_specification.method_catalog.run.continue`
- `platform-spec.yaml#api_specification.method_catalog.runtime.pause`
- `platform-spec.yaml#api_specification.method_catalog.runtime.resume`
- `platform-spec.yaml#api_specification.conventions.runtime_ingress`
- `platform-spec.yaml#runtime_storage.run_control_state`
- `platform-spec.yaml#runtime_status_model.pause_resume`
- `platform-spec.yaml#runtime_storage.runtime_store_backend_selection`
- `platform-spec.yaml#runtime_storage.runtime_core_persistence_store_contracts`
- `platform-spec.yaml#runtime_storage.runtime_core_persistence_store_contracts.selected_contracts[name=selected_runtime_store_facade]`
- `platform-spec.yaml#runtime_storage.runtime_core_persistence_store_contracts.selected_contracts[name=backend_neutral_runtime_mutation_write_boundary]`
- #1864 pre-audit and gate outcome
- #1872 absorbed tracker repair

## Semantic migration

- New canonical proof owner: `internal/servedparity` scenarios plus `internal/apiv1/testdata/public_surface_backend_matrix.yaml` ledger rows.
- Old invalid proof paths: handler-only, store-only, fake-server CLI-only, or one-backend proof claims for these five public mutating methods.
- Behavior owner changed for #1872: selected SQLite runtime store/run-control owner now terminalizes pending agent deliveries on `run.stop`; the API handler is unchanged.
- Shared run.stop receipt behavior: the store owner no longer rewrites an existing platform/pipeline receipt for already-routed events; it still writes a stopped-run pipeline dead-letter when the receipt is missing.
- Production paths checked for surviving old behavior: real `/v1/rpc` default SQLite and explicit Postgres served paths, selected store run-control methods, public-surface matrix validator, and servedparity scenario registry.
- Migration completeness: complete for #1864's chosen child class and #1872's absorbed manifestation. #1386/#1239 remain open for sibling mutating parity tails outside this child.

## Proof

- `SWARM_TEST_POSTGRES_DSN='host=127.0.0.1 port=5432 user=postgres password=postgres dbname=postgres sslmode=disable' go test ./cmd/swarm -run 'TestServedParityHarness(RuntimeIngressControlLifecycle|RunControlLifecycle)' -count=1`
- `SWARM_TEST_POSTGRES_DSN='host=127.0.0.1 port=5432 user=postgres password=postgres dbname=postgres sslmode=disable' go test ./internal/store -run 'TestPostgresStore_RunControlTransitionsAndStopAbandonsPendingWork|TestSQLiteRuntimeStore_RunControlStopAbandonsPendingWork|TestSQLiteRuntimeStoreSelectedCoreContracts' -count=1`
- `SWARM_TEST_POSTGRES_DSN='host=127.0.0.1 port=5432 user=postgres password=postgres dbname=postgres sslmode=disable' go test ./internal/apiv1 -run 'TestOperatorRunControl|TestOperatorRuntimeControl|TestPublicSurfaceBackendMatrix' -count=1`
- `go test ./internal/servedparity -count=1`
- `SWARM_TEST_POSTGRES_DSN='host=127.0.0.1 port=5432 user=postgres password=postgres dbname=postgres sslmode=disable' go vet ./...`
- `SWARM_TEST_POSTGRES_DSN='host=127.0.0.1 port=5432 user=postgres password=postgres dbname=postgres sslmode=disable' go test ./...`