### PR TITLE
[agent-e][issue #1874] Add typed loader diagnostics

### DIFF
--- a/cmd/swarm/bundle_test.go
+++ b/cmd/swarm/bundle_test.go
@@ -749,8 +749,8 @@ func TestBundleCommandsRejectInvalidInputBeforeRequest(t *testing.T) {
 		{name: "register blank idempotency", args: []string{"bundle", "register", envelopePath, "--data-blob", dataBlobPath, "--idempotency-key", " "}, wantStderr: "--idempotency-key must be non-empty"},
 		{name: "register contracts with envelope", args: []string{"bundle", "register", envelopePath, "--contracts", contractsDir}, wantStderr: "--contracts cannot be combined with a registration envelope argument"},
 		{name: "register contracts with data blob", args: []string{"bundle", "register", "--contracts", contractsDir, "--data-blob", dataBlobPath}, wantStderr: "--data-blob cannot be used with --contracts"},
-		{name: "register contracts typo child under bundle", args: []string{"bundle", "register", "--contracts", invalidChildContractsDir}, wantStderr: "resolve contracts"},
-		{name: "register contracts missing package", args: []string{"bundle", "register", "--contracts", invalidContractsDir}, wantStderr: "resolve contracts"},
+		{name: "register contracts typo child under bundle", args: []string{"bundle", "register", "--contracts", invalidChildContractsDir}, wantStderr: "no Swarm package manifest was found"},
+		{name: "register contracts missing package", args: []string{"bundle", "register", "--contracts", invalidContractsDir}, wantStderr: "no Swarm package manifest was found"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			calls.Store(0)

--- a/cmd/swarm/cli_errors.go
+++ b/cmd/swarm/cli_errors.go
@@ -7,6 +7,8 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+
+	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
 )
 
 const (
@@ -96,7 +98,7 @@ func returnCLIAPIError(errOut io.Writer, err error, classifier cliAPIErrorClassi
 
 func returnCLIValidationError(errOut io.Writer, err error) error {
 	if errOut != nil {
-		fmt.Fprintln(errOut, err)
+		fmt.Fprintln(errOut, formatCLIAPIError(err))
 	}
 	return commandExitError{code: cliExitValidation}
 }
@@ -112,6 +114,9 @@ func formatCLIAPIError(err error) string {
 	if err == nil {
 		return ""
 	}
+	if diagnostic, ok := runtimecontracts.AsLoaderDiagnostic(err); ok {
+		return formatCLILoaderDiagnostic(diagnostic)
+	}
 	if diagnostic, ok := cliAPITransportDiagnosticParts(err); ok {
 		lines := []string{"ERROR: " + cliAPIProblemWithWrapper(err, diagnostic.leaf, diagnostic.problem)}
 		lines = append(lines, diagnostic.evidence...)
@@ -119,6 +124,30 @@ func formatCLIAPIError(err error) string {
 		return strings.Join(lines, "\n")
 	}
 	return err.Error()
+}
+
+func formatCLILoaderDiagnostic(diagnostic *runtimecontracts.LoaderDiagnostic) string {
+	if diagnostic == nil {
+		return ""
+	}
+	problem := strings.TrimSpace(diagnostic.Problem)
+	if problem == "" {
+		problem = strings.TrimSpace(diagnostic.RawCause)
+	}
+	if problem == "" {
+		problem = "contract loader validation failed."
+	}
+	lines := []string{"ERROR: " + problem}
+	if location := diagnostic.Location.String(); location != "" {
+		lines = append(lines, "  Location: "+location)
+	}
+	if len(diagnostic.ValidOptions) > 0 {
+		lines = append(lines, "  Valid options: "+strings.Join(diagnostic.ValidOptions, ", "))
+	}
+	if remediation := strings.TrimSpace(diagnostic.Remediation); remediation != "" {
+		lines = append(lines, "  Remediation: "+remediation)
+	}
+	return strings.Join(lines, "\n")
 }
 
 func formatCLIAPITransportDetail(err error) string {

--- a/cmd/swarm/cli_errors_test.go
+++ b/cmd/swarm/cli_errors_test.go
@@ -131,6 +131,18 @@ func TestCLIAPITransportDiagnosticPreservesWrapperContext(t *testing.T) {
 	}
 }
 
+func TestCLIAPIErrorDoesNotClassifyGenericYAMLAsContractLoaderDiagnostic(t *testing.T) {
+	err := errors.New("load runtime config: yaml: unmarshal errors:\n  line 1: cannot unmarshal !!str `oops` into config.Config")
+
+	got := formatCLIAPIError(err)
+	if got != err.Error() {
+		t.Fatalf("diagnostic = %q, want original error %q", got, err.Error())
+	}
+	if strings.Contains(got, "contract YAML has a value with the wrong shape") {
+		t.Fatalf("diagnostic misclassified generic YAML as contract loader error: %q", got)
+	}
+}
+
 func TestJSONRPCErrorRendersStandardErrorDiagnostics(t *testing.T) {
 	data, err := json.Marshal(map[string]any{
 		"correlation_id": "corr-event-publish",

--- a/cmd/swarm/describe.go
+++ b/cmd/swarm/describe.go
@@ -91,16 +91,12 @@ func runDescribeCommandWithOutput(ctx context.Context, repo string, opts describ
 	}
 	contractsRoot, err := normalizeContractsRoot(resolvedPaths.ContractsPath)
 	if err != nil {
-		if errOut != nil {
-			fmt.Fprintf(errOut, "describe failed: resolve contracts: %v\n", err)
-		}
+		writeCLIAPIError(errOut, err)
 		return cliExitValidation
 	}
 	_, bundle, err := newSwarmWorkflowModule(repo, contractsRoot, resolvedPaths.PlatformSpecPath)
 	if err != nil {
-		if errOut != nil {
-			fmt.Fprintf(errOut, "describe failed: load Swarm contracts: %v\n", err)
-		}
+		writeCLIAPIError(errOut, err)
 		return cliExitValidation
 	}
 	source := semanticview.Wrap(bundle)

--- a/cmd/swarm/describe_test.go
+++ b/cmd/swarm/describe_test.go
@@ -122,7 +122,7 @@ func TestDescribeMissingContractsIsValidationExit(t *testing.T) {
 	if stdout.String() != "" {
 		t.Fatalf("describe missing contracts stdout = %q, want empty", stdout.String())
 	}
-	if got := stderr.String(); !strings.Contains(got, "describe failed: resolve contracts: contracts path is required") {
+	if got := stderr.String(); !strings.Contains(got, "ERROR: a contracts directory is required.") || !strings.Contains(got, "Remediation: Pass a contracts directory") {
 		t.Fatalf("describe missing contracts stderr = %q", got)
 	}
 }

--- a/cmd/swarm/local_preflight.go
+++ b/cmd/swarm/local_preflight.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/division-sh/swarm/internal/config"
 	runtimebootverify "github.com/division-sh/swarm/internal/runtime/bootverify"
+	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
 	runtimecredentials "github.com/division-sh/swarm/internal/runtime/credentials"
 	runtimellm "github.com/division-sh/swarm/internal/runtime/llm"
 	llmselection "github.com/division-sh/swarm/internal/runtime/llm/selection"
@@ -119,7 +120,15 @@ func runLocalClaudeCLIPreflight(ctx context.Context, req localPreflightRequest) 
 
 	source, contractsRoot, err := loadLocalPreflightSource(req.RepoRoot, req.ResolvedPaths)
 	if err != nil {
-		report.add(localPreflightWorkspacePrerequisite, "contract_source_load_failed", localPreflightSeverityBlocker, localPreflightStatusFailed, err.Error(), "fix the selected --contracts and --platform-spec paths")
+		message := err.Error()
+		remediation := "fix the selected --contracts and --platform-spec paths"
+		if diagnostic, ok := runtimecontracts.AsLoaderDiagnostic(err); ok {
+			message = diagnostic.Problem
+			if strings.TrimSpace(diagnostic.Remediation) != "" {
+				remediation = diagnostic.Remediation
+			}
+		}
+		report.add(localPreflightWorkspacePrerequisite, "contract_source_load_failed", localPreflightSeverityBlocker, localPreflightStatusFailed, message, remediation)
 		return report.finalize()
 	}
 	appendProviderConnectorToolSurfaceFindings(ctx, &report, source)
@@ -348,7 +357,7 @@ func (r *localPreflightReport) checkWorkspace(ctx context.Context, cfg *config.C
 func loadLocalPreflightSource(repo string, paths cliContractPlatformSpecPaths) (semanticview.Source, string, error) {
 	contractsRoot, err := normalizeContractsRoot(paths.ContractsPath)
 	if err != nil {
-		return nil, "", fmt.Errorf("resolve contracts: %w", err)
+		return nil, "", err
 	}
 	_, bundle, err := newSwarmWorkflowModule(assetCommandRepoRoot(repo), contractsRoot, paths.PlatformSpecPath)
 	if err != nil {

--- a/cmd/swarm/main.go
+++ b/cmd/swarm/main.go
@@ -591,7 +591,7 @@ func loadServeRuntimeBundle(ctx context.Context, repo string, stores storeBundle
 	}
 	contractsRoot, err := normalizeContractsRoot(resolvedPaths.ContractsPath)
 	if err != nil {
-		return serveRuntimeBundle{}, fmt.Errorf("resolve contracts: %w", err)
+		return serveRuntimeBundle{}, err
 	}
 	module, bundle, err := newSwarmWorkflowModule(repo, contractsRoot, resolvedPaths.PlatformSpecPath)
 	if err != nil {
@@ -908,8 +908,14 @@ func runServeRuntime(ctx context.Context, repo string, opts serveOptions) int {
 	}
 	loadedBundles, err := loadServeRuntimeBundles(ctx, repo, stores, resolvedPaths, opts)
 	if err != nil {
-		reporter.emit(4, "bundle_load", "FAILED", err.Error())
-		log.Printf("load Swarm contracts: %v", err)
+		detail := err.Error()
+		if _, ok := runtimecontracts.AsLoaderDiagnostic(err); ok {
+			detail = formatCLIAPIError(err)
+			log.Print(detail)
+		} else {
+			log.Printf("load Swarm contracts: %v", err)
+		}
+		reporter.emit(4, "bundle_load", "FAILED", detail)
 		return 1
 	}
 	if len(loadedBundles) == 0 {
@@ -1393,10 +1399,8 @@ func runVerifyCommandWithOutput(ctx context.Context, repo string, opts verifyCom
 	resolvedPlatformSpecPath := resolvedPaths.PlatformSpecPath
 	contractsRoot, err := normalizeContractsRoot(resolvedContractsPath)
 	if err != nil {
-		if errOut != nil {
-			fmt.Fprintf(errOut, "verify failed: resolve contracts: %v\n", err)
-		}
-		return 1
+		writeCLIAPIError(errOut, err)
+		return cliExitValidation
 	}
 	validationOpts, err := verifyWorkflowContractValidationOptions(repo)
 	if err != nil {
@@ -1406,10 +1410,8 @@ func runVerifyCommandWithOutput(ctx context.Context, repo string, opts verifyCom
 		return 1
 	}
 	if _, bundle, err := newSwarmWorkflowModule(repo, contractsRoot, resolvedPlatformSpecPath); err != nil {
-		if errOut != nil {
-			fmt.Fprintf(errOut, "verify failed: load Swarm contracts: %v\n", err)
-		}
-		return 1
+		writeCLIAPIError(errOut, err)
+		return cliExitValidation
 	} else {
 		source := semanticview.Wrap(bundle)
 		workspaceBackend, err := resolveWorkspaceBackendDiagnostic(repo, source)
@@ -1722,17 +1724,13 @@ func runForkRuntimeOwnerHarness(ctx context.Context, repo string, args []string,
 		if contracts := strings.TrimSpace(*contractsPath); contracts != "" {
 			contractsRoot, err := normalizeContractsRoot(resolveContractsPath(repo, contracts))
 			if err != nil {
-				if out != nil {
-					fmt.Fprintf(out, "fork failed: resolve contracts: %v\n", err)
-				}
-				return 1
+				writeForkContractLoadError(out, "fork failed: resolve contracts", err)
+				return cliExitValidation
 			}
 			_, bundle, err := newSwarmWorkflowModule(repo, contractsRoot, resolvePath(repo, *platformSpecPath))
 			if err != nil {
-				if out != nil {
-					fmt.Fprintf(out, "fork failed: load selected contracts: %v\n", err)
-				}
-				return 1
+				writeForkContractLoadError(out, "fork failed: load selected contracts", err)
+				return cliExitValidation
 			}
 			source := semanticview.Wrap(bundle)
 			selection := runtimerunforkadmission.SelectedContractSelection(source, contractsRoot)
@@ -1764,17 +1762,13 @@ func runForkRuntimeOwnerHarness(ctx context.Context, repo string, args []string,
 	if modeCount == 0 && selectedContractsRequested {
 		contractsRoot, err := normalizeContractsRoot(resolveContractsPath(repo, *contractsPath))
 		if err != nil {
-			if out != nil {
-				fmt.Fprintf(out, "fork failed: resolve contracts: %v\n", err)
-			}
-			return 1
+			writeForkContractLoadError(out, "fork failed: resolve contracts", err)
+			return cliExitValidation
 		}
 		_, bundle, err := newSwarmWorkflowModule(repo, contractsRoot, resolvePath(repo, *platformSpecPath))
 		if err != nil {
-			if out != nil {
-				fmt.Fprintf(out, "fork failed: load selected contracts: %v\n", err)
-			}
-			return 1
+			writeForkContractLoadError(out, "fork failed: load selected contracts", err)
+			return cliExitValidation
 		}
 		source := semanticview.Wrap(bundle)
 		credentialStore, err := buildCredentialStore()
@@ -1889,17 +1883,13 @@ func runForkRuntimeOwnerHarness(ctx context.Context, repo string, args []string,
 
 		contractsRoot, err := normalizeContractsRoot(resolveContractsPath(repo, contracts))
 		if err != nil {
-			if out != nil {
-				fmt.Fprintf(out, "fork failed: resolve contracts: %v\n", err)
-			}
-			return 1
+			writeForkContractLoadError(out, "fork failed: resolve contracts", err)
+			return cliExitValidation
 		}
 		_, bundle, err := newSwarmWorkflowModule(repo, contractsRoot, resolvePath(repo, *platformSpecPath))
 		if err != nil {
-			if out != nil {
-				fmt.Fprintf(out, "fork failed: load selected contracts: %v\n", err)
-			}
-			return 1
+			writeForkContractLoadError(out, "fork failed: load selected contracts", err)
+			return cliExitValidation
 		}
 		source := semanticview.Wrap(bundle)
 		admission, err := runtimerunforkadmission.AdmitContractFrontier(runtimerunforkadmission.ContractFrontierRequest{
@@ -1972,6 +1962,17 @@ func runForkRuntimeOwnerHarness(ctx context.Context, repo string, args []string,
 	}
 	printRunForkPlan(out, plan)
 	return 0
+}
+
+func writeForkContractLoadError(out io.Writer, prefix string, err error) {
+	if out == nil || err == nil {
+		return
+	}
+	if _, ok := runtimecontracts.AsLoaderDiagnostic(err); ok {
+		writeCLIAPIError(out, err)
+		return
+	}
+	fmt.Fprintf(out, "%s: %v\n", strings.TrimSpace(prefix), err)
 }
 
 func printRunForkActivation(w io.Writer, result store.RunForkActivation) {
@@ -2559,7 +2560,7 @@ func rejectUnsupportedRuntimeControlEnv() error {
 func normalizeContractsRoot(path string) (string, error) {
 	root := strings.TrimSpace(path)
 	if root == "" {
-		return "", errors.New("contracts path is required")
+		return "", runtimecontracts.NewContractsPathRequiredDiagnostic()
 	}
 	root = filepath.Clean(root)
 	if regularFileExists(filepath.Join(root, "package.yaml")) {
@@ -2568,7 +2569,7 @@ func normalizeContractsRoot(path string) (string, error) {
 	if filepath.Base(root) == "package.yaml" && regularFileExists(root) {
 		return filepath.Dir(root), nil
 	}
-	return "", fmt.Errorf("no package.yaml found under %s", path)
+	return "", runtimecontracts.NewMissingPackageDiagnostic(path)
 }
 
 func asString(v any) string {

--- a/cmd/swarm/main_test.go
+++ b/cmd/swarm/main_test.go
@@ -1697,7 +1697,7 @@ homepage: https://division.sh
 	if code == 0 {
 		t.Fatalf("runVerifyCommand exit code = 0, output = %q", buf.String())
 	}
-	for _, want := range []string{"verify failed: load Swarm contracts:", "UNDEFINED-FIELD", "homepage"} {
+	for _, want := range []string{"ERROR: package.yaml field \"homepage\" is not supported.", "Valid options:", "Remediation:"} {
 		if !strings.Contains(buf.String(), want) {
 			t.Fatalf("verify output missing %q:\n%s", want, buf.String())
 		}
@@ -7907,13 +7907,13 @@ func TestCLI_VerifyPreservesLocalContractCarveOut(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 	missingContracts := filepath.Join(t.TempDir(), "missing")
 	code := executeRootCommand(context.Background(), t.TempDir(), []string{"verify", "--contracts", missingContracts}, &stdout, &stderr)
-	if code != 1 {
-		t.Fatalf("verify code = %d, want 1 stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	if code != cliExitValidation {
+		t.Fatalf("verify code = %d, want %d stderr=%s stdout=%s", code, cliExitValidation, stderr.String(), stdout.String())
 	}
 	if strings.TrimSpace(stdout.String()) != "" {
 		t.Fatalf("verify stdout = %q, want empty on error", stdout.String())
 	}
-	if !strings.Contains(stderr.String(), "verify failed: resolve contracts") {
+	if !strings.Contains(stderr.String(), "ERROR: no Swarm package manifest was found") {
 		t.Fatalf("verify stderr = %q, want local contract resolution failure", stderr.String())
 	}
 }
@@ -10117,11 +10117,392 @@ func TestRunVerifyCommand_BadContractsPath(t *testing.T) {
 				t.Fatal("expected non-zero exit code")
 			}
 			out := buf.String()
-			if !strings.Contains(out, "verify failed: resolve contracts") {
+			if !strings.Contains(out, "ERROR: no Swarm package manifest was found") {
 				t.Fatalf("output = %q", out)
 			}
 			if !strings.Contains(out, tc.path) {
 				t.Fatalf("output does not name explicit path %q:\n%s", tc.path, out)
+			}
+		})
+	}
+}
+
+func TestRunVerifyCommandFormatsPreBootLoaderDiagnostics(t *testing.T) {
+	tests := []struct {
+		name     string
+		write    func(t *testing.T, root string)
+		wants    []string
+		notWants []string
+	}{
+		{
+			name: "package yaml syntax",
+			write: func(t *testing.T, root string) {
+				writeWorkflowValidationFixtureFile(t, filepath.Join(root, "package.yaml"), `
+name: invalid-yaml
+flows:
+  - [broken
+`)
+			},
+			wants: []string{
+				"ERROR: contract YAML could not be parsed.",
+				"Location:",
+				"package.yaml",
+				"Remediation: Fix the YAML syntax, then run the command again.",
+			},
+			notWants: []string{"yaml: line", "did not find expected", "parse ", "load Swarm contracts", "resolve contracts"},
+		},
+		{
+			name: "package document mapping shape",
+			write: func(t *testing.T, root string) {
+				writeWorkflowValidationFixtureFile(t, filepath.Join(root, "package.yaml"), `invalid-package-shape`)
+			},
+			wants: []string{
+				"ERROR: package.yaml must be a mapping.",
+				"Location:",
+				"package.yaml:package.yaml",
+				"Remediation: Use a package.yaml mapping with fields like name, version, flows, and packages.",
+			},
+			notWants: []string{"package.yaml must be a mapping\n", "parse ", "load Swarm contracts", "resolve contracts"},
+		},
+		{
+			name: "schema document mapping shape",
+			write: func(t *testing.T, root string) {
+				writeWorkflowValidationFixtureFile(t, filepath.Join(root, "package.yaml"), `
+name: invalid-schema-shape
+version: "1.0.0"
+flows: []
+`)
+				writeWorkflowValidationFixtureFile(t, filepath.Join(root, "schema.yaml"), `invalid-schema-shape`)
+			},
+			wants: []string{
+				"ERROR: schema.yaml must be a mapping.",
+				"Location:",
+				"schema.yaml:schema.yaml",
+				"Remediation: Use a schema.yaml mapping with fields like name, states, pins, and entity.",
+			},
+			notWants: []string{"flow schema document must be a mapping", "parse ", "load Swarm contracts", "resolve contracts"},
+		},
+		{
+			name: "schema field valid options",
+			write: func(t *testing.T, root string) {
+				writeWorkflowValidationFixtureFile(t, filepath.Join(root, "package.yaml"), `
+name: invalid-schema-field
+version: "1.0.0"
+flows: []
+`)
+				writeWorkflowValidationFixtureFile(t, filepath.Join(root, "schema.yaml"), `
+name: invalid-schema-field
+bogus: true
+`)
+			},
+			wants: []string{
+				"ERROR: schema field \"bogus\" is not supported.",
+				"Location:",
+				"schema.yaml:schema",
+				"Valid options:",
+				"auto_emit_on_create",
+				"terminal_states",
+				"Remediation: Use one of the supported schema fields.",
+			},
+			notWants: []string{"UNDEFINED-FIELD", "not in platform spec", "load Swarm contracts", "resolve contracts"},
+		},
+		{
+			name: "stage field valid options",
+			write: func(t *testing.T, root string) {
+				writeWorkflowValidationFixtureFile(t, filepath.Join(root, "package.yaml"), `
+name: invalid-stage-field
+version: "1.0.0"
+flows: []
+`)
+				writeWorkflowValidationFixtureFile(t, filepath.Join(root, "schema.yaml"), `
+name: invalid-stage-field
+stages:
+  queued:
+    surprise: true
+`)
+			},
+			wants: []string{
+				"ERROR: stage field \"surprise\" is not supported.",
+				"Location:",
+				"schema.yaml:stage",
+				"Valid options:",
+				"description",
+				"initial",
+				"terminal",
+				"Remediation: Use one of the supported stage fields.",
+			},
+			notWants: []string{"UNDEFINED-FIELD", "not in platform spec", "load Swarm contracts", "resolve contracts"},
+		},
+		{
+			name: "package flows entries shape",
+			write: func(t *testing.T, root string) {
+				writeWorkflowValidationFixtureFile(t, filepath.Join(root, "package.yaml"), `
+name: invalid-package-flow-shape
+version: "1.0.0"
+flows:
+  - child
+`)
+				writeWorkflowValidationFixtureFile(t, filepath.Join(root, "schema.yaml"), `name: invalid-package-flow-shape`)
+			},
+			wants: []string{
+				"ERROR: package.yaml flows entries must be mappings with id, flow, and optional mode.",
+				"Location:",
+				"package.yaml:package.yaml.flows",
+				"Remediation: Use entries like `flows: [{id: child, flow: child, mode: child}]`.",
+			},
+			notWants: []string{"yaml: unmarshal errors", "cannot unmarshal", "contracts.ProjectFlowRef", "load Swarm contracts", "resolve contracts"},
+		},
+		{
+			name: "package requires field valid options",
+			write: func(t *testing.T, root string) {
+				writeWorkflowValidationFixtureFile(t, filepath.Join(root, "package.yaml"), `
+name: invalid-package-requires-field
+version: "1.0.0"
+requires:
+  surprise: true
+flows: []
+`)
+				writeWorkflowValidationFixtureFile(t, filepath.Join(root, "schema.yaml"), `name: invalid-package-requires-field`)
+			},
+			wants: []string{
+				"ERROR: requires field \"surprise\" is not supported.",
+				"Location:",
+				"package.yaml:requires",
+				"Valid options:",
+				"inputs",
+				"platform_version",
+				"Remediation: Use one of the supported requires fields.",
+			},
+			notWants: []string{"UNDEFINED-FIELD", "not in platform spec", "load Swarm contracts", "resolve contracts"},
+		},
+		{
+			name: "agent field valid options",
+			write: func(t *testing.T, root string) {
+				writeWorkflowValidationFixtureFile(t, filepath.Join(root, "package.yaml"), `
+name: invalid-agent-field
+version: "1.0.0"
+flows: []
+`)
+				writeWorkflowValidationFixtureFile(t, filepath.Join(root, "schema.yaml"), `name: invalid-agent-field`)
+				writeWorkflowValidationFixtureFile(t, filepath.Join(root, "agents.yaml"), `
+reviewer:
+  role: reviewer
+  model: regular
+  subscriptions: [item.received]
+  surprise: true
+`)
+			},
+			wants: []string{
+				"ERROR: agent field \"surprise\" is not supported.",
+				"Location:",
+				"agents.yaml:agent",
+				"Valid options:",
+				"model",
+				"subscriptions",
+				"Remediation: Use one of the supported agent fields.",
+			},
+			notWants: []string{"parse ", "UNDEFINED-FIELD", "not in platform spec", "load Swarm contracts", "resolve contracts"},
+		},
+		{
+			name: "handler field valid options",
+			write: func(t *testing.T, root string) {
+				writeWorkflowValidationFixtureFile(t, filepath.Join(root, "package.yaml"), `
+name: invalid-handler-mailbox-write
+version: "1.0.0"
+flows: []
+`)
+				writeWorkflowValidationFixtureFile(t, filepath.Join(root, "schema.yaml"), `
+name: invalid-handler-mailbox-write
+initial_state: pending
+terminal_states: [done]
+states: [pending, done]
+pins:
+  inputs:
+    events: [item.received]
+  outputs:
+    events: [item.processed]
+`)
+				writeWorkflowValidationFixtureFile(t, filepath.Join(root, "events.yaml"), "item.received:\nitem.processed: {}\n")
+				writeWorkflowValidationFixtureFile(t, filepath.Join(root, "policy.yaml"), "{}\n")
+				writeWorkflowValidationFixtureFile(t, filepath.Join(root, "agents.yaml"), "{}\n")
+				writeWorkflowValidationFixtureFile(t, filepath.Join(root, "nodes.yaml"), `
+test-node:
+  id: test-node
+  execution_type: system_node
+  subscribes_to: [item.received]
+  produces: [item.processed]
+  event_handlers:
+    item.received:
+      mailbox_write: {}
+      advances_to: done
+`)
+			},
+			wants: []string{
+				"ERROR: handler field \"mailbox_write\" is not supported.",
+				"Valid options:",
+				"action",
+				"on_success",
+				"Remediation: Use the supported action field",
+			},
+			notWants: []string{"UNDEFINED-FIELD", "load Swarm contracts", "resolve contracts"},
+		},
+		{
+			name: "guard on fail field valid options",
+			write: func(t *testing.T, root string) {
+				writeWorkflowValidationFixtureFile(t, filepath.Join(root, "package.yaml"), `
+name: invalid-guard-on-fail-field
+version: "1.0.0"
+flows: []
+`)
+				writeWorkflowValidationFixtureFile(t, filepath.Join(root, "schema.yaml"), `
+name: invalid-guard-on-fail-field
+initial_state: pending
+terminal_states: [done]
+states: [pending, done]
+pins:
+  inputs:
+    events: [item.received]
+  outputs:
+    events: [item.processed]
+`)
+				writeWorkflowValidationFixtureFile(t, filepath.Join(root, "events.yaml"), "item.received:\nitem.processed: {}\n")
+				writeWorkflowValidationFixtureFile(t, filepath.Join(root, "policy.yaml"), "{}\n")
+				writeWorkflowValidationFixtureFile(t, filepath.Join(root, "agents.yaml"), "{}\n")
+				writeWorkflowValidationFixtureFile(t, filepath.Join(root, "nodes.yaml"), `
+test-node:
+  id: test-node
+  execution_type: system_node
+  subscribes_to: [item.received]
+  produces: [item.processed]
+  event_handlers:
+    item.received:
+      guard:
+        id: gatekeeper
+        on_fail:
+          reject: true
+      advances_to: done
+`)
+			},
+			wants: []string{
+				"ERROR: guard.on_fail field \"reject\" is not supported.",
+				"Location:",
+				"nodes.yaml:guard.on_fail",
+				"Valid options:",
+				"escalate",
+				"Remediation: Use one of the supported guard.on_fail fields.",
+			},
+			notWants: []string{"action", "emit", "reason", "UNDEFINED-FIELD", "not in platform spec", "load Swarm contracts", "resolve contracts"},
+		},
+		{
+			name: "node field valid options",
+			write: func(t *testing.T, root string) {
+				writeWorkflowValidationFixtureFile(t, filepath.Join(root, "package.yaml"), `
+name: invalid-node-field
+version: "1.0.0"
+flows: []
+`)
+				writeWorkflowValidationFixtureFile(t, filepath.Join(root, "schema.yaml"), `
+name: invalid-node-field
+initial_state: pending
+terminal_states: [done]
+states: [pending, done]
+pins:
+  inputs:
+    events: [item.received]
+  outputs:
+    events: [item.processed]
+`)
+				writeWorkflowValidationFixtureFile(t, filepath.Join(root, "events.yaml"), "item.received:\nitem.processed: {}\n")
+				writeWorkflowValidationFixtureFile(t, filepath.Join(root, "policy.yaml"), "{}\n")
+				writeWorkflowValidationFixtureFile(t, filepath.Join(root, "agents.yaml"), "{}\n")
+				writeWorkflowValidationFixtureFile(t, filepath.Join(root, "nodes.yaml"), `
+test-node:
+  id: test-node
+  execution_type: system_node
+  subscribes_to: [item.received]
+  produces: [item.processed]
+  bogus: true
+`)
+			},
+			wants: []string{
+				"ERROR: node field \"bogus\" is not supported.",
+				"Location:",
+				"nodes.yaml:node",
+				"Valid options:",
+				"event_handlers",
+				"execution_type",
+				"Remediation: Use one of the supported node fields.",
+			},
+			notWants: []string{"UNDEFINED-FIELD", "not in platform spec", "load Swarm contracts", "resolve contracts"},
+		},
+		{
+			name: "input event pin required shape",
+			write: func(t *testing.T, root string) {
+				writeWorkflowValidationFixtureFile(t, filepath.Join(root, "package.yaml"), `
+name: invalid-input-pin
+version: "1.0.0"
+flows: []
+`)
+				writeWorkflowValidationFixtureFile(t, filepath.Join(root, "schema.yaml"), `
+name: invalid-input-pin
+pins:
+  inputs:
+    events:
+      - event: item.received
+`)
+			},
+			wants: []string{
+				"ERROR: input event pins must name the pin or use a scalar event name.",
+				"Location:",
+				"schema.yaml.pins.inputs.events",
+				"Remediation: Use `events: [item.received]`",
+			},
+			notWants: []string{"input event pin name is required", "load Swarm contracts", "resolve contracts"},
+		},
+		{
+			name: "output event pin required shape",
+			write: func(t *testing.T, root string) {
+				writeWorkflowValidationFixtureFile(t, filepath.Join(root, "package.yaml"), `
+name: invalid-output-pin
+version: "1.0.0"
+flows: []
+`)
+				writeWorkflowValidationFixtureFile(t, filepath.Join(root, "schema.yaml"), `
+name: invalid-output-pin
+pins:
+  outputs:
+    events:
+      - event: item.processed
+`)
+			},
+			wants: []string{
+				"ERROR: output event pins must name the pin or use a scalar event name.",
+				"Location:",
+				"schema.yaml.pins.outputs.events",
+				"Remediation: Use `events: [item.processed]`",
+			},
+			notWants: []string{"output event pin name is required", "load Swarm contracts", "resolve contracts"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			root := t.TempDir()
+			tt.write(t, root)
+			var buf bytes.Buffer
+			code := runVerifyCommandWithContractsForTest(context.Background(), repoRoot(), root, &buf)
+			if code != cliExitValidation {
+				t.Fatalf("code = %d, want %d output=%s", code, cliExitValidation, buf.String())
+			}
+			out := buf.String()
+			for _, want := range tt.wants {
+				if !strings.Contains(out, want) {
+					t.Fatalf("output missing %q:\n%s", want, out)
+				}
+			}
+			for _, notWant := range tt.notWants {
+				if strings.Contains(out, notWant) {
+					t.Fatalf("output contains %q:\n%s", notWant, out)
+				}
 			}
 		})
 	}
@@ -10732,7 +11113,7 @@ accumulator:
 	if code == 0 {
 		t.Fatalf("expected non-zero exit code, output = %q", buf.String())
 	}
-	if out := buf.String(); !strings.Contains(out, "verify failed: load Swarm contracts:") || !strings.Contains(out, "state_schema field type") {
+	if out := buf.String(); !strings.Contains(out, "state_schema field type") {
 		t.Fatalf("unexpected output = %q", out)
 	}
 }

--- a/cmd/swarm/secrets_test.go
+++ b/cmd/swarm/secrets_test.go
@@ -258,7 +258,7 @@ func TestSecretsCheckMissingContractsIsValidationExit(t *testing.T) {
 	if stdout != "" {
 		t.Fatalf("secrets check missing contracts stdout = %q, want empty", stdout)
 	}
-	if !strings.Contains(stderr, "resolve contracts: contracts path is required") {
+	if !strings.Contains(stderr, "ERROR: a contracts directory is required.") || !strings.Contains(stderr, "Remediation: Pass a contracts directory") {
 		t.Fatalf("secrets check missing contracts stderr = %q", stderr)
 	}
 }

--- a/internal/apiv1/operator_bundle_register.go
+++ b/internal/apiv1/operator_bundle_register.go
@@ -242,6 +242,14 @@ func buildBundleRegistrationProjection(params bundleRegistrationParams, runtimeC
 	}
 	bundle, err := runtimecontracts.LoadWorkflowContractBundleWithOverrides(repoRoot, root, platformSpec)
 	if err != nil {
+		if diagnostic, ok := runtimecontracts.AsLoaderDiagnostic(err); ok {
+			return runtimecontracts.BundleCatalogProjection{}, NewInvalidParamsError(map[string]any{
+				"field":       "content_yaml",
+				"reason":      diagnostic.Problem,
+				"remediation": diagnostic.Remediation,
+				"diagnostic":  diagnostic,
+			})
+		}
 		return runtimecontracts.BundleCatalogProjection{}, NewInvalidParamsError(map[string]any{"field": "content_yaml", "reason": "bundle registration envelope does not materialize a valid workflow contract bundle", "error": err.Error()})
 	}
 	if err := runtimecontracts.ValidateBundlePlatformVersionCompatibility(bundle); err != nil {

--- a/internal/apiv1/operator_bundle_register_test.go
+++ b/internal/apiv1/operator_bundle_register_test.go
@@ -1,0 +1,60 @@
+package apiv1
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
+)
+
+func TestBundleRegistrationProjectionReturnsStructuredLoaderDiagnostic(t *testing.T) {
+	repo := repoRoot(t)
+	contentYAML := `
+api_version: swarm.bundle.register.v1
+files:
+  - path: package.yaml
+    text: |
+      name: invalid-loader-shape
+      version: "1.0.0"
+      flows:
+        - child
+  - path: schema.yaml
+    text: |
+      name: invalid-loader-shape
+`
+	_, err := buildBundleRegistrationProjection(bundleRegistrationParams{
+		ContentYAML: contentYAML,
+	}, bundleRegistrationRuntimeContext{
+		RepoRoot:         repo,
+		PlatformSpecPath: runtimecontracts.DefaultPlatformSpecFile(repo),
+	})
+	if err == nil {
+		t.Fatal("buildBundleRegistrationProjection succeeded, want invalid params")
+	}
+	var invalid *InvalidParamsError
+	if !errors.As(err, &invalid) {
+		t.Fatalf("error = %T %v, want InvalidParamsError", err, err)
+	}
+	details, ok := invalid.Details.(map[string]any)
+	if !ok {
+		t.Fatalf("details = %T, want map", invalid.Details)
+	}
+	if details["field"] != "content_yaml" {
+		t.Fatalf("field = %v, want content_yaml", details["field"])
+	}
+	reason, _ := details["reason"].(string)
+	if !strings.Contains(reason, "package.yaml flows entries must be mappings") {
+		t.Fatalf("reason = %q, want package.yaml flows shape", reason)
+	}
+	diagnostic, ok := details["diagnostic"].(*runtimecontracts.LoaderDiagnostic)
+	if !ok {
+		t.Fatalf("diagnostic = %T, want *LoaderDiagnostic", details["diagnostic"])
+	}
+	if diagnostic.Code != "contract_loader.package_flows_shape" {
+		t.Fatalf("diagnostic code = %q, want package flows shape", diagnostic.Code)
+	}
+	if strings.Contains(reason, "yaml:") || strings.Contains(reason, "ProjectFlowRef") {
+		t.Fatalf("reason leaked raw loader internals: %q", reason)
+	}
+}

--- a/internal/runtime/contracts/bundle_hash_test.go
+++ b/internal/runtime/contracts/bundle_hash_test.go
@@ -401,8 +401,9 @@ func TestBundleCatalogRuntimeLoaderRejectsUnknownPackageManifestField(t *testing
 		ContentYAML: contentYAML,
 		DataBlob:    projection.DataBlob,
 	})
-	if err == nil || !strings.Contains(err.Error(), "UNDEFINED-FIELD") || !strings.Contains(err.Error(), "homepage") {
-		t.Fatalf("LoadBundleCatalogRuntimeSource error = %v, want homepage UNDEFINED-FIELD", err)
+	diagnostic, ok := AsLoaderDiagnostic(err)
+	if !ok || diagnostic.Code != "contract_loader.undefined_field" || !strings.Contains(diagnostic.Problem, "homepage") {
+		t.Fatalf("LoadBundleCatalogRuntimeSource error = %v, want homepage loader diagnostic", err)
 	}
 }
 

--- a/internal/runtime/contracts/load_validation_test.go
+++ b/internal/runtime/contracts/load_validation_test.go
@@ -367,7 +367,7 @@ func TestLoadWorkflowContractBundleRejectsRetiredPublicNodeAndSchemaFields(t *te
 			name:        "schema namespace is not public schema YAML",
 			schemaExtra: "namespace: legacy\n",
 			nodes:       "{}\n",
-			wantErr:     "UNDEFINED-FIELD",
+			wantErr:     "schema field \"namespace\" is not supported",
 		},
 		{
 			name:        "node idempotency table is retired public YAML",
@@ -594,7 +594,7 @@ func TestAgentRegistryEntryRejectsUnsupportedLayerSyntaxAndUnknownFields(t *test
 	}{
 		{name: "profile", body: "profile: cheap\n", contains: "reserved for future agent-defaults/profile support"},
 		{name: "runtime_id_template", body: "runtime_id_template: worker-{entity_id}\n", contains: "reserved for future agent-defaults/profile support"},
-		{name: "unknown", body: "surprise_field: true\n", contains: "UNDEFINED-FIELD"},
+		{name: "unknown", body: "surprise_field: true\n", contains: `agent field "surprise_field" is not supported.`},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -949,7 +949,7 @@ func TestLoadWorkflowContractBundleRejectsTier8DialectFixtures(t *testing.T) {
 		{name: "advances_to list", fixture: "test-boot-advances-to-list", contains: "DIALECT-ADV-LIST"},
 		{name: "guard scalar", fixture: "test-boot-dialect-guard", contains: "DIALECT-GUARD"},
 		{name: "on_complete dict", fixture: "test-boot-on-complete-dict", contains: "DIALECT-OC-ORDER"},
-		{name: "undefined handler field", fixture: "test-boot-handler-field-undefined", contains: "UNDEFINED-FIELD"},
+		{name: "undefined handler field", fixture: "test-boot-handler-field-undefined", contains: "handler field \"custom_logic\" is not supported"},
 		{name: "deprecated handler field", fixture: "test-boot-deprecated-field", contains: "DEPRECATED"},
 	}
 	for _, tc := range cases {

--- a/internal/runtime/contracts/loader_diagnostics.go
+++ b/internal/runtime/contracts/loader_diagnostics.go
@@ -1,0 +1,439 @@
+package contracts
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+type LoaderDiagnosticLocation struct {
+	File     string `json:"file,omitempty"`
+	YAMLPath string `json:"yaml_path,omitempty"`
+	Line     int    `json:"line,omitempty"`
+	Column   int    `json:"column,omitempty"`
+}
+
+func (l LoaderDiagnosticLocation) String() string {
+	file := strings.TrimSpace(l.File)
+	path := strings.TrimSpace(l.YAMLPath)
+	switch {
+	case file != "" && path != "":
+		return file + ":" + path
+	case file != "":
+		return file
+	case path != "":
+		return path
+	default:
+		return ""
+	}
+}
+
+type LoaderDiagnostic struct {
+	Code         string                   `json:"code"`
+	Location     LoaderDiagnosticLocation `json:"location,omitempty"`
+	Problem      string                   `json:"problem"`
+	Remediation  string                   `json:"remediation,omitempty"`
+	ValidOptions []string                 `json:"valid_options,omitempty"`
+	RawCause     string                   `json:"raw_cause,omitempty"`
+
+	cause error
+}
+
+func (d *LoaderDiagnostic) Error() string {
+	if d == nil {
+		return ""
+	}
+	if problem := strings.TrimSpace(d.Problem); problem != "" {
+		return problem
+	}
+	return strings.TrimSpace(d.RawCause)
+}
+
+func (d *LoaderDiagnostic) Unwrap() error {
+	if d == nil {
+		return nil
+	}
+	return d.cause
+}
+
+func (d *LoaderDiagnostic) withLocation(location LoaderDiagnosticLocation) *LoaderDiagnostic {
+	if d == nil {
+		return nil
+	}
+	out := *d
+	if strings.TrimSpace(out.Location.File) == "" {
+		out.Location.File = strings.TrimSpace(location.File)
+	}
+	if strings.TrimSpace(out.Location.YAMLPath) == "" {
+		out.Location.YAMLPath = strings.TrimSpace(location.YAMLPath)
+	}
+	if out.Location.Line == 0 {
+		out.Location.Line = location.Line
+	}
+	if out.Location.Column == 0 {
+		out.Location.Column = location.Column
+	}
+	return &out
+}
+
+func AsLoaderDiagnostic(err error) (*LoaderDiagnostic, bool) {
+	if err == nil {
+		return nil, false
+	}
+	var diagnostic *LoaderDiagnostic
+	if errors.As(err, &diagnostic) && diagnostic != nil {
+		return diagnostic, true
+	}
+	return nil, false
+}
+
+func NewContractsPathRequiredDiagnostic() *LoaderDiagnostic {
+	return &LoaderDiagnostic{
+		Code:        "contract_loader.contracts_path_required",
+		Problem:     "a contracts directory is required.",
+		Remediation: "Pass a contracts directory with --contracts, or run from a project containing package.yaml.",
+	}
+}
+
+func NewMissingPackageDiagnostic(path string) *LoaderDiagnostic {
+	target := strings.TrimSpace(path)
+	if target == "" {
+		target = "."
+	}
+	return &LoaderDiagnostic{
+		Code:        "contract_loader.package_manifest_missing",
+		Problem:     fmt.Sprintf("no Swarm package manifest was found under %s.", target),
+		Remediation: "Create package.yaml and schema.yaml at the contracts root. Minimal package.yaml: `name: <flow-name>`; `version: 0.1.0`.",
+		Location: LoaderDiagnosticLocation{
+			File: target,
+		},
+	}
+}
+
+func NewUndefinedFieldDiagnostic(context, key string, allowed map[string]struct{}) *LoaderDiagnostic {
+	context = strings.TrimSpace(context)
+	key = strings.TrimSpace(key)
+	if context == "" {
+		context = "contract"
+	}
+	options := sortedLoaderFieldOptions(allowed)
+	remediation := fmt.Sprintf("Use one of the supported %s fields.", context)
+	if context == "handler" && key == "mailbox_write" {
+		remediation = "Use the supported action field, for example `action: {id: mailbox_write, mailbox: {...}}`."
+	}
+	return &LoaderDiagnostic{
+		Code:         "contract_loader.undefined_field",
+		Problem:      fmt.Sprintf("%s field %q is not supported.", context, key),
+		Remediation:  remediation,
+		ValidOptions: options,
+		Location: LoaderDiagnosticLocation{
+			YAMLPath: context,
+		},
+	}
+}
+
+func NewExpectedShapeDiagnostic(code, yamlPath, problem, remediation string, cause error) *LoaderDiagnostic {
+	return &LoaderDiagnostic{
+		Code:        strings.TrimSpace(code),
+		Problem:     strings.TrimSpace(problem),
+		Remediation: strings.TrimSpace(remediation),
+		RawCause:    rawCauseString(cause),
+		cause:       cause,
+		Location: LoaderDiagnosticLocation{
+			YAMLPath: strings.TrimSpace(yamlPath),
+		},
+	}
+}
+
+func NewYAMLParseDiagnostic(cause error) *LoaderDiagnostic {
+	return NewExpectedShapeDiagnostic(
+		"contract_loader.yaml_parse",
+		"",
+		"contract YAML could not be parsed.",
+		"Fix the YAML syntax, then run the command again.",
+		cause,
+	)
+}
+
+func NewPackageDocumentMappingDiagnostic(cause error) *LoaderDiagnostic {
+	return NewExpectedShapeDiagnostic(
+		"contract_loader.package_manifest_mapping",
+		"package.yaml",
+		"package.yaml must be a mapping.",
+		"Use a package.yaml mapping with fields like name, version, flows, and packages.",
+		cause,
+	)
+}
+
+func NewSchemaDocumentMappingDiagnostic(cause error) *LoaderDiagnostic {
+	return NewExpectedShapeDiagnostic(
+		"contract_loader.schema_mapping",
+		"schema.yaml",
+		"schema.yaml must be a mapping.",
+		"Use a schema.yaml mapping with fields like name, states, pins, and entity.",
+		cause,
+	)
+}
+
+func NewOutputEventPinNameRequiredDiagnostic(cause error) *LoaderDiagnostic {
+	return NewExpectedShapeDiagnostic(
+		"contract_loader.output_event_pin_name_required",
+		"schema.yaml.pins.outputs.events",
+		"output event pins must name the pin or use a scalar event name.",
+		"Use `events: [item.processed]` or `events: [{name: item_processed, event: item.processed}]`.",
+		cause,
+	)
+}
+
+func wrapLoaderDiagnosticFile(err error, file string) error {
+	if err == nil {
+		return nil
+	}
+	if diagnostic, ok := AsLoaderDiagnostic(err); ok {
+		return diagnostic.withLocation(LoaderDiagnosticLocation{File: file})
+	}
+	if diagnostic, ok := diagnoseLegacyLoaderError(err); ok {
+		return diagnostic.withLocation(LoaderDiagnosticLocation{File: file})
+	}
+	return fmt.Errorf("parse %s: %w", file, err)
+}
+
+func loaderDiagnosticForPackageDecode(err error) error {
+	if err == nil {
+		return nil
+	}
+	if diagnostic, ok := AsLoaderDiagnostic(err); ok {
+		return diagnostic
+	}
+	raw := err.Error()
+	if strings.Contains(raw, "ProjectFlowRef") {
+		return NewExpectedShapeDiagnostic(
+			"contract_loader.package_flows_shape",
+			"package.yaml.flows",
+			"package.yaml flows entries must be mappings with id, flow, and optional mode.",
+			"Use entries like `flows: [{id: child, flow: child, mode: child}]`.",
+			err,
+		)
+	}
+	if strings.Contains(raw, "ProjectPackageRef") {
+		return NewExpectedShapeDiagnostic(
+			"contract_loader.package_imports_shape",
+			"package.yaml.packages",
+			"package.yaml package entries must be mappings with id and path or package.",
+			"Use entries like `packages: [{id: shared, path: flows/shared}]`.",
+			err,
+		)
+	}
+	return err
+}
+
+func diagnoseLegacyLoaderError(err error) (*LoaderDiagnostic, bool) {
+	if err == nil {
+		return nil, false
+	}
+	raw := strings.TrimSpace(err.Error())
+	if raw == "" {
+		return nil, false
+	}
+	if diagnostic, ok := diagnoseLegacyUndefinedField(err, raw); ok {
+		return diagnostic, true
+	}
+	if isYAMLParseError(raw) {
+		return NewYAMLParseDiagnostic(err), true
+	}
+	if strings.Contains(raw, "package.yaml must be a mapping") {
+		return NewPackageDocumentMappingDiagnostic(err), true
+	}
+	if strings.Contains(raw, "flow schema document must be a mapping") {
+		return NewSchemaDocumentMappingDiagnostic(err), true
+	}
+	if strings.Contains(raw, "input event pin name is required") {
+		return NewExpectedShapeDiagnostic(
+			"contract_loader.input_event_pin_name_required",
+			"schema.yaml.pins.inputs.events",
+			"input event pins must name the pin or use a scalar event name.",
+			"Use `events: [item.received]` or `events: [{name: item_received, event: item.received, source: external}]`.",
+			err,
+		), true
+	}
+	if strings.Contains(raw, "output event pin name is required") {
+		return NewOutputEventPinNameRequiredDiagnostic(err), true
+	}
+	if strings.Contains(raw, "ProjectFlowRef") {
+		return NewExpectedShapeDiagnostic(
+			"contract_loader.package_flows_shape",
+			"package.yaml.flows",
+			"package.yaml flows entries must be mappings with id, flow, and optional mode.",
+			"Use entries like `flows: [{id: child, flow: child, mode: child}]`.",
+			err,
+		), true
+	}
+	if isKnownContractLoaderShapeError(raw) {
+		return NewExpectedShapeDiagnostic(
+			"contract_loader.yaml_shape",
+			"",
+			"contract YAML has a value with the wrong shape.",
+			"Use the authored YAML shape described by the contract field and run the command again.",
+			err,
+		), true
+	}
+	return nil, false
+}
+
+func isYAMLParseError(raw string) bool {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return false
+	}
+	return strings.HasPrefix(raw, "yaml: line ") ||
+		strings.Contains(raw, ": did not find expected ") ||
+		strings.Contains(raw, ": could not find expected ") ||
+		strings.Contains(raw, ": found unexpected ") ||
+		strings.Contains(raw, ": mapping values are not allowed ")
+}
+
+func isKnownContractLoaderShapeError(raw string) bool {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return false
+	}
+	return strings.Contains(raw, "yaml: unmarshal errors:") ||
+		strings.Contains(raw, "cannot unmarshal !!") ||
+		strings.Contains(raw, "into contracts.")
+}
+
+var legacyUndefinedFieldPattern = regexp.MustCompile(`UNDEFINED-FIELD:\s+(.+?)\s+(?:field|option)\s+"([^"]+)"\s+not in platform spec`)
+
+func diagnoseLegacyUndefinedField(err error, raw string) (*LoaderDiagnostic, bool) {
+	match := legacyUndefinedFieldPattern.FindStringSubmatch(raw)
+	if len(match) != 3 {
+		return nil, false
+	}
+	context := strings.TrimSpace(match[1])
+	key := strings.TrimSpace(match[2])
+	diagnostic := NewUndefinedFieldDiagnostic(context, key, loaderFieldOptionsForContext(context))
+	diagnostic.RawCause = rawCauseString(err)
+	diagnostic.cause = err
+	return diagnostic, true
+}
+
+func loaderFieldOptionsForContext(context string) map[string]struct{} {
+	switch strings.TrimSpace(context) {
+	case "package.yaml":
+		return projectPackageDocumentFields
+	case "schema":
+		return flowSchemaDocumentFields
+	case "stage":
+		return stageDeclarationFieldOptions
+	case "node":
+		return systemNodeContractFields
+	case "handler":
+		return handlerFieldOptions
+	case "action":
+		return actionFieldOptions
+	case "input event pin":
+		return inputEventPinFieldOptions
+	case "output event pin":
+		return outputEventPinFieldOptions
+	case "input event pin carry":
+		return inputEventPinCarryFieldOptions
+	case "input event pin resolution":
+		return inputEventPinResolutionFieldOptions
+	case "input event pin resolution.instance_key":
+		return inputEventPinResolutionInstanceKeyFieldOptions
+	case "input event pin address":
+		return inputEventPinAddressFieldOptions
+	case "rule":
+		return ruleFieldOptions
+	case "template instance":
+		return templateInstanceFieldOptions
+	case "compute":
+		return computeFieldOptions
+	case "guard.on_fail":
+		return guardOnFailFieldOptions
+	case "guard.on_fail.escalate":
+		return guardOnFailEscalateFieldOptions
+	case "accumulate":
+		return accumulateFieldOptions
+	case "fan_out":
+		return fanOutFieldOptions
+	case "emit":
+		return emitFieldOptions
+	case "on_success":
+		return onSuccessFieldOptions
+	case "activity":
+		return activityFieldOptions
+	case "emit.target":
+		return emitTargetFieldOptions
+	case "mailbox":
+		return mailboxFieldOptions
+	case "artifact_repo":
+		return artifactRepoFieldOptions
+	case "artifact_repo.files":
+		return artifactRepoFilesFieldOptions
+	case "artifact_repo.files.schema":
+		return artifactRepoFilesSchemaFieldOptions
+	case "artifact_repo.output":
+		return artifactRepoOutputFieldOptions
+	case "artifact_repo.limits":
+		return artifactRepoLimitsFieldOptions
+	case "select_entity", "select_or_create_entity":
+		return entitySelectionFieldOptions
+	case "agent":
+		return agentRegistryEntryFieldOptions
+	case "requires":
+		return flowPackageRequiresFieldOptions
+	case "bind":
+		return flowPackageBindFieldOptions
+	case "connector_packs":
+		return connectorPackFieldOptions
+	case "connector_packs.imports":
+		return connectorPackImportFieldOptions
+	case "requires.policy":
+		return flowPackageRequiresPolicyFieldOptions
+	case "connect":
+		return flowPackageConnectFieldOptions
+	case "connect using":
+		return flowPackageConnectUsingFieldOptions
+	case "connect using instance":
+		return flowPackageConnectInstanceFieldOptions
+	case "connect map":
+		return flowPackageConnectMapFieldOptions
+	case "type catalog":
+		return typeCatalogFieldOptions
+	case "type metadata":
+		return typeMetadataFieldOptions
+	case "entity metadata":
+		return entityMetadataFieldOptions
+	case "length":
+		return schemaLengthRefinementFieldOptions
+	case "range":
+		return schemaRangeRefinementFieldOptions
+	default:
+		return nil
+	}
+}
+
+func sortedLoaderFieldOptions(fields map[string]struct{}) []string {
+	if len(fields) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(fields))
+	for key := range fields {
+		key = strings.TrimSpace(key)
+		if key != "" {
+			out = append(out, key)
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+func rawCauseString(err error) string {
+	if err == nil {
+		return ""
+	}
+	return strings.TrimSpace(err.Error())
+}

--- a/internal/runtime/contracts/workflow_contract_connector_packs_test.go
+++ b/internal/runtime/contracts/workflow_contract_connector_packs_test.go
@@ -35,7 +35,7 @@ connector_packs:
       tool: telegram.send_message
       shadow: true
 `), &invalid)
-	if err == nil || !strings.Contains(err.Error(), `connector_packs.imports field "shadow" not in platform spec`) {
+	if err == nil || !strings.Contains(err.Error(), `connector_packs.imports field "shadow" is not supported.`) {
 		t.Fatalf("Unmarshal invalid connector_packs error = %v, want strict field failure", err)
 	}
 }

--- a/internal/runtime/contracts/workflow_contract_emit_lowering_test.go
+++ b/internal/runtime/contracts/workflow_contract_emit_lowering_test.go
@@ -153,7 +153,7 @@ summary:
 payload:
   interest_score: payload
 `), &spec)
-	if err == nil || !strings.Contains(err.Error(), `UNDEFINED-FIELD: mailbox field "from"`) {
+	if err == nil || !strings.Contains(err.Error(), `mailbox field "from" is not supported.`) {
 		t.Fatalf("yaml.Unmarshal error = %v, want mailbox from-field rejection", err)
 	}
 }

--- a/internal/runtime/contracts/workflow_contract_paths.go
+++ b/internal/runtime/contracts/workflow_contract_paths.go
@@ -455,7 +455,7 @@ func loadYAMLFile(path string, target any) error {
 		return fmt.Errorf("read %s: %w", path, err)
 	}
 	if err := yaml.Unmarshal(raw, target); err != nil {
-		return fmt.Errorf("parse %s: %w", path, err)
+		return wrapLoaderDiagnosticFile(err, path)
 	}
 	return nil
 }

--- a/internal/runtime/contracts/workflow_contract_policy_sheet.go
+++ b/internal/runtime/contracts/workflow_contract_policy_sheet.go
@@ -1197,7 +1197,7 @@ func validatePolicySheetMappingKeys(node *yaml.Node, label string, allowed map[s
 			continue
 		}
 		if _, ok := allowed[key]; !ok {
-			return fmt.Errorf("UNDEFINED-FIELD: %s field %q not in platform spec", label, key)
+			return NewUndefinedFieldDiagnostic(label, key, allowed)
 		}
 	}
 	return nil

--- a/internal/runtime/contracts/workflow_contract_stages.go
+++ b/internal/runtime/contracts/workflow_contract_stages.go
@@ -19,6 +19,12 @@ type FlowStageDeclaration struct {
 	Description string `yaml:"description"`
 }
 
+var stageDeclarationFieldOptions = map[string]struct{}{
+	"initial":     {},
+	"terminal":    {},
+	"description": {},
+}
+
 func (d *FlowStageDeclarations) UnmarshalYAML(node *yaml.Node) error {
 	if d == nil {
 		return nil
@@ -76,15 +82,10 @@ func (s *FlowStageDeclaration) UnmarshalYAML(node *yaml.Node) error {
 	if node.Kind != yaml.MappingNode {
 		return fmt.Errorf("stage declaration must be a mapping")
 	}
-	allowed := map[string]struct{}{
-		"initial":     {},
-		"terminal":    {},
-		"description": {},
-	}
 	for i := 0; i+1 < len(node.Content); i += 2 {
 		key := strings.TrimSpace(node.Content[i].Value)
-		if _, ok := allowed[key]; !ok {
-			return fmt.Errorf("UNDEFINED-FIELD: stage field %q not in platform spec", key)
+		if _, ok := stageDeclarationFieldOptions[key]; !ok {
+			return NewUndefinedFieldDiagnostic("stage", key, stageDeclarationFieldOptions)
 		}
 	}
 	type alias FlowStageDeclaration

--- a/internal/runtime/contracts/workflow_contract_types.go
+++ b/internal/runtime/contracts/workflow_contract_types.go
@@ -1752,7 +1752,7 @@ func validateAgentRegistryEntryYAMLFields(value *yaml.Node) (map[string]bool, er
 				return nil, fmt.Errorf("UNSUPPORTED: agent field %s is reserved for future agent-defaults/profile support and is not accepted by Layer 1 platform defaults", field)
 			default:
 				if !supportedAgentRegistryEntryField(field) {
-					return nil, fmt.Errorf("UNDEFINED-FIELD: agent field %s is not supported", field)
+					return nil, NewUndefinedFieldDiagnostic("agent", field, agentRegistryEntryFieldOptions)
 				}
 			}
 		}
@@ -1760,16 +1760,33 @@ func validateAgentRegistryEntryYAMLFields(value *yaml.Node) (map[string]bool, er
 	return authoredFields, nil
 }
 
+var agentRegistryEntryFieldOptions = map[string]struct{}{
+	"id":                 {},
+	"type":               {},
+	"role":               {},
+	"prompt_ref":         {},
+	"entity_writes":      {},
+	"permissions":        {},
+	"permissions_bundle": {},
+	"workspace_class":    {},
+	"manager_fallback":   {},
+	"node_type":          {},
+	"model":              {},
+	"mode":               {},
+	"max_turns_per_task": {},
+	"subscriptions":      {},
+	"prompt_inputs":      {},
+	"tools":              {},
+	"native_tools":       {},
+	"flow_data_access":   {},
+	"criteria":           {},
+	"emit_events":        {},
+	"implementation":     {},
+}
+
 func supportedAgentRegistryEntryField(field string) bool {
-	switch strings.TrimSpace(field) {
-	case "id", "type", "role", "prompt_ref", "entity_writes",
-		"permissions", "permissions_bundle", "workspace_class", "manager_fallback",
-		"node_type", "model", "mode", "max_turns_per_task", "subscriptions",
-		"prompt_inputs", "tools", "native_tools", "flow_data_access", "criteria", "emit_events", "implementation":
-		return true
-	default:
-		return false
-	}
+	_, ok := agentRegistryEntryFieldOptions[strings.TrimSpace(field)]
+	return ok
 }
 
 func (e AgentRegistryEntry) ConfiguredTools() []string {

--- a/internal/runtime/contracts/workflow_contract_yaml.go
+++ b/internal/runtime/contracts/workflow_contract_yaml.go
@@ -37,7 +37,7 @@ func (d *FlowSchemaDocument) UnmarshalYAML(node *yaml.Node) error {
 		return nil
 	}
 	if node.Kind != yaml.MappingNode {
-		return fmt.Errorf("flow schema document must be a mapping")
+		return NewSchemaDocumentMappingDiagnostic(nil)
 	}
 	if err := validateFlowSchemaDocumentFields(node); err != nil {
 		return err
@@ -55,22 +55,23 @@ func (d *FlowSchemaDocument) UnmarshalYAML(node *yaml.Node) error {
 	return nil
 }
 
+var flowSchemaDocumentFields = map[string]struct{}{
+	"name":                {},
+	"mode":                {},
+	"entity":              {},
+	"instance":            {},
+	"initial_state":       {},
+	"terminal_states":     {},
+	"states":              {},
+	"stages":              {},
+	"pins":                {},
+	"tool_surface":        {},
+	"required_agents":     {},
+	"instance_variables":  {},
+	"auto_emit_on_create": {},
+}
+
 func validateFlowSchemaDocumentFields(node *yaml.Node) error {
-	allowed := map[string]struct{}{
-		"name":                {},
-		"mode":                {},
-		"entity":              {},
-		"instance":            {},
-		"initial_state":       {},
-		"terminal_states":     {},
-		"states":              {},
-		"stages":              {},
-		"pins":                {},
-		"tool_surface":        {},
-		"required_agents":     {},
-		"instance_variables":  {},
-		"auto_emit_on_create": {},
-	}
 	retired := map[string]string{
 		"namespace_prefix": "schema namespace_prefix is retired; flow namespace is derived from the package tree",
 		"namespace_rule":   "schema namespace_rule is retired; namespace override semantics require a separate spec owner",
@@ -83,8 +84,8 @@ func validateFlowSchemaDocumentFields(node *yaml.Node) error {
 		if reason, ok := retired[key]; ok {
 			return fmt.Errorf("RETIRED: schema field %q is retired; %s", key, reason)
 		}
-		if _, ok := allowed[key]; !ok {
-			return fmt.Errorf("UNDEFINED-FIELD: schema field %q not in platform spec", key)
+		if _, ok := flowSchemaDocumentFields[key]; !ok {
+			return NewUndefinedFieldDiagnostic("schema", key, flowSchemaDocumentFields)
 		}
 	}
 	return nil
@@ -113,19 +114,20 @@ func (n *SystemNodeContract) UnmarshalYAML(node *yaml.Node) error {
 	return nil
 }
 
+var systemNodeContractFields = map[string]struct{}{
+	"id":             {},
+	"description":    {},
+	"execution_type": {},
+	"subscribes_to":  {},
+	"produces":       {},
+	"state_table":    {},
+	"timers":         {},
+	"event_handlers": {},
+	"state_schema":   {},
+	"gate_state":     {},
+}
+
 func validateSystemNodeContractFields(node *yaml.Node) error {
-	allowed := map[string]struct{}{
-		"id":             {},
-		"description":    {},
-		"execution_type": {},
-		"subscribes_to":  {},
-		"produces":       {},
-		"state_table":    {},
-		"timers":         {},
-		"event_handlers": {},
-		"state_schema":   {},
-		"gate_state":     {},
-	}
 	retired := map[string]string{
 		"permissions":       "node permissions are not public node YAML authority",
 		"implementation":    "executor binding is not public node YAML authority",
@@ -140,8 +142,8 @@ func validateSystemNodeContractFields(node *yaml.Node) error {
 		if reason, ok := retired[key]; ok {
 			return fmt.Errorf("RETIRED: node field %q is retired; %s", key, reason)
 		}
-		if _, ok := allowed[key]; !ok {
-			return fmt.Errorf("UNDEFINED-FIELD: node field %q not in platform spec", key)
+		if _, ok := systemNodeContractFields[key]; !ok {
+			return NewUndefinedFieldDiagnostic("node", key, systemNodeContractFields)
 		}
 	}
 	return nil

--- a/internal/runtime/contracts/workflow_contract_yaml_flow.go
+++ b/internal/runtime/contracts/workflow_contract_yaml_flow.go
@@ -31,26 +31,6 @@ func validateRuleFieldNodes(node *yaml.Node) error {
 	if node == nil || node.Kind != yaml.MappingNode {
 		return nil
 	}
-	allowed := map[string]struct{}{
-		"id":                {},
-		"description":       {},
-		"condition":         {},
-		"when":              {},
-		"case":              {},
-		"range":             {},
-		"lookup":            {},
-		"validate":          {},
-		"compute_module":    {},
-		"else":              {},
-		"default":           {},
-		"advances_to":       {},
-		"emit":              {},
-		"action":            {},
-		"activity":          {},
-		"data_accumulation": {},
-		"compute":           {},
-		"fan_out":           {},
-	}
 	for i := 0; i+1 < len(node.Content); i += 2 {
 		key := strings.TrimSpace(node.Content[i].Value)
 		if key == "" {
@@ -68,11 +48,38 @@ func validateRuleFieldNodes(node *yaml.Node) error {
 		case "temporal", "join", "loop", "collection", "schedule":
 			return fmt.Errorf("UNSUPPORTED-POLICY-SHEET-ROW: rule field %q is outside the promoted selection-row scope", key)
 		}
-		if _, ok := allowed[key]; !ok {
-			return fmt.Errorf("UNDEFINED-FIELD: rule field %q not in platform spec", key)
+		if _, ok := ruleFieldOptions[key]; !ok {
+			return NewUndefinedFieldDiagnostic("rule", key, ruleFieldOptions)
 		}
 	}
 	return nil
+}
+
+var ruleFieldOptions = map[string]struct{}{
+	"id":                {},
+	"description":       {},
+	"condition":         {},
+	"when":              {},
+	"case":              {},
+	"range":             {},
+	"lookup":            {},
+	"validate":          {},
+	"compute_module":    {},
+	"else":              {},
+	"default":           {},
+	"advances_to":       {},
+	"emit":              {},
+	"action":            {},
+	"activity":          {},
+	"data_accumulation": {},
+	"compute":           {},
+	"fan_out":           {},
+}
+
+var templateInstanceFieldOptions = map[string]struct{}{
+	"by":          {},
+	"on_missing":  {},
+	"on_conflict": {},
 }
 
 func (p *FlowInputPins) UnmarshalYAML(node *yaml.Node) error {
@@ -165,7 +172,7 @@ func (i *FlowTemplateInstanceDeclaration) UnmarshalYAML(node *yaml.Node) error {
 			}
 			out.OnConflict = strings.TrimSpace(out.OnConflict)
 		default:
-			return fmt.Errorf("UNDEFINED-FIELD: template instance field %q not in platform spec", key)
+			return NewUndefinedFieldDiagnostic("template instance", key, templateInstanceFieldOptions)
 		}
 	}
 	*i = out
@@ -241,6 +248,61 @@ func decodeFlowOutputPinEventsNode(node *yaml.Node) ([]string, []FlowOutputEvent
 	return events, pins, nil
 }
 
+var inputEventPinFieldOptions = map[string]struct{}{
+	"name":       {},
+	"event":      {},
+	"source":     {},
+	"address":    {},
+	"resolution": {},
+	"carries":    {},
+}
+
+var outputEventPinFieldOptions = map[string]struct{}{
+	"name":    {},
+	"event":   {},
+	"key":     {},
+	"carries": {},
+}
+
+var inputEventPinCarryFieldOptions = map[string]struct{}{
+	"from": {},
+	"type": {},
+}
+
+var inputEventPinResolutionFieldOptions = map[string]struct{}{
+	"mode":            {},
+	"instance_key":    {},
+	"aggregation":     {},
+	"window":          {},
+	"dedup_by":        {},
+	"singleton":       {},
+	"replies_to":      {},
+	"correlation_key": {},
+}
+
+var inputEventPinResolutionInstanceKeyFieldOptions = map[string]struct{}{
+	"from": {},
+	"mint": {},
+	"as":   {},
+}
+
+var inputEventPinAddressFieldOptions = map[string]struct{}{
+	"by":          {},
+	"source":      {},
+	"target":      {},
+	"cardinality": {},
+	"mode":        {},
+}
+
+var computeFieldOptions = map[string]struct{}{
+	"operation":   {},
+	"tiers":       {},
+	"keys":        {},
+	"params":      {},
+	"store_as":    {},
+	"description": {},
+}
+
 func decodeFlowInputPinEventNode(node *yaml.Node) (FlowInputEventPin, error) {
 	if node == nil || node.Kind == 0 {
 		return FlowInputEventPin{}, nil
@@ -289,12 +351,18 @@ func decodeFlowInputPinEventNode(node *yaml.Node) (FlowInputEventPin, error) {
 				return FlowInputEventPin{}, fmt.Errorf("input event pin carries: %w", err)
 			}
 		default:
-			return FlowInputEventPin{}, fmt.Errorf("UNDEFINED-FIELD: input event pin field %q not in platform spec", key)
+			return FlowInputEventPin{}, NewUndefinedFieldDiagnostic("input event pin", key, inputEventPinFieldOptions)
 		}
 	}
 	out = out.normalized()
 	if out.PinName() == "" {
-		return FlowInputEventPin{}, fmt.Errorf("input event pin name is required")
+		return FlowInputEventPin{}, NewExpectedShapeDiagnostic(
+			"contract_loader.input_event_pin_name_required",
+			"schema.yaml.pins.inputs.events",
+			"input event pins must name the pin or use a scalar event name.",
+			"Use `events: [item.received]` or `events: [{name: item_received, event: item.received, source: external}]`.",
+			nil,
+		)
 	}
 	return out, nil
 }
@@ -336,12 +404,12 @@ func decodeFlowOutputPinEventNode(node *yaml.Node) (FlowOutputEventPin, error) {
 			}
 			out.Carries = carries
 		default:
-			return FlowOutputEventPin{}, fmt.Errorf("UNDEFINED-FIELD: output event pin field %q not in platform spec", key)
+			return FlowOutputEventPin{}, NewUndefinedFieldDiagnostic("output event pin", key, outputEventPinFieldOptions)
 		}
 	}
 	out = out.normalized()
 	if out.PinName() == "" {
-		return FlowOutputEventPin{}, fmt.Errorf("output event pin name is required")
+		return FlowOutputEventPin{}, NewOutputEventPinNameRequiredDiagnostic(nil)
 	}
 	return out, nil
 }
@@ -425,7 +493,7 @@ func (c *FlowInputPinCarry) UnmarshalYAML(node *yaml.Node) error {
 				return fmt.Errorf("carry.type: %w", err)
 			}
 		default:
-			return fmt.Errorf("UNDEFINED-FIELD: input event pin carry field %q not in platform spec", key)
+			return NewUndefinedFieldDiagnostic("input event pin carry", key, inputEventPinCarryFieldOptions)
 		}
 	}
 	*c = out.normalized()
@@ -485,7 +553,7 @@ func (r *FlowInputPinResolution) UnmarshalYAML(node *yaml.Node) error {
 				return fmt.Errorf("resolution.correlation_key: %w", err)
 			}
 		default:
-			return fmt.Errorf("UNDEFINED-FIELD: input event pin resolution field %q not in platform spec", key)
+			return NewUndefinedFieldDiagnostic("input event pin resolution", key, inputEventPinResolutionFieldOptions)
 		}
 	}
 	*r = out.normalized()
@@ -527,7 +595,7 @@ func (k *FlowInputPinResolutionInstanceKey) UnmarshalYAML(node *yaml.Node) error
 				return fmt.Errorf("instance_key.as: %w", err)
 			}
 		default:
-			return fmt.Errorf("UNDEFINED-FIELD: input event pin resolution.instance_key field %q not in platform spec", key)
+			return NewUndefinedFieldDiagnostic("input event pin resolution.instance_key", key, inputEventPinResolutionInstanceKeyFieldOptions)
 		}
 	}
 	*k = out.normalized()
@@ -573,7 +641,7 @@ func (a *FlowInputPinAddress) UnmarshalYAML(node *yaml.Node) error {
 				return fmt.Errorf("address.mode: %w", err)
 			}
 		default:
-			return fmt.Errorf("UNDEFINED-FIELD: input event pin address field %q not in platform spec", key)
+			return NewUndefinedFieldDiagnostic("input event pin address", key, inputEventPinAddressFieldOptions)
 		}
 	}
 	*a = out.normalized()
@@ -642,23 +710,15 @@ func validateComputeFieldNodes(node *yaml.Node) error {
 	if node == nil || node.Kind != yaml.MappingNode {
 		return nil
 	}
-	allowed := map[string]struct{}{
-		"operation":   {},
-		"tiers":       {},
-		"keys":        {},
-		"params":      {},
-		"store_as":    {},
-		"description": {},
-	}
 	for i := 0; i+1 < len(node.Content); i += 2 {
 		key := strings.TrimSpace(node.Content[i].Value)
 		if key == "" {
 			continue
 		}
-		if _, ok := allowed[key]; ok {
+		if _, ok := computeFieldOptions[key]; ok {
 			continue
 		}
-		return fmt.Errorf("UNDEFINED-FIELD: compute field %q not in platform spec", key)
+		return NewUndefinedFieldDiagnostic("compute", key, computeFieldOptions)
 	}
 	return nil
 }

--- a/internal/runtime/contracts/workflow_contract_yaml_handlers.go
+++ b/internal/runtime/contracts/workflow_contract_yaml_handlers.go
@@ -155,10 +155,11 @@ func (e *EmitSpec) UnmarshalYAML(node *yaml.Node) error {
 	case yaml.MappingNode:
 		for i := 0; i+1 < len(node.Content); i += 2 {
 			key := strings.TrimSpace(node.Content[i].Value)
-			switch key {
-			case "", "event", "from", "fields", "target", "broadcast":
-			default:
-				return fmt.Errorf("UNDEFINED-FIELD: emit field %q not in platform spec", key)
+			if key == "" {
+				continue
+			}
+			if _, ok := emitFieldOptions[key]; !ok {
+				return NewUndefinedFieldDiagnostic("emit", key, emitFieldOptions)
 			}
 		}
 		var event string
@@ -215,6 +216,93 @@ func (e *EmitSpec) UnmarshalYAML(node *yaml.Node) error {
 	}
 }
 
+var emitFieldOptions = map[string]struct{}{
+	"event":     {},
+	"from":      {},
+	"fields":    {},
+	"target":    {},
+	"broadcast": {},
+}
+
+var onSuccessFieldOptions = map[string]struct{}{
+	"emit": {},
+}
+
+var activityFieldOptions = map[string]struct{}{
+	"id":    {},
+	"tool":  {},
+	"input": {},
+}
+
+var emitTargetFieldOptions = map[string]struct{}{
+	"instance_id":  {},
+	"flow":         {},
+	"match":        {},
+	"allow_fanout": {},
+}
+
+var mailboxFieldOptions = map[string]struct{}{
+	"item_type":     {},
+	"severity":      {},
+	"summary":       {},
+	"entity_id":     {},
+	"flow_instance": {},
+	"payload":       {},
+}
+
+var artifactRepoFieldOptions = map[string]struct{}{
+	"provider":        {},
+	"repo_id":         {},
+	"namespace":       {},
+	"partition_key":   {},
+	"display_slug":    {},
+	"request_id":      {},
+	"author":          {},
+	"provenance":      {},
+	"allowed_paths":   {},
+	"files":           {},
+	"output":          {},
+	"limits":          {},
+	"success_event":   {},
+	"success_payload": {},
+	"failure_event":   {},
+	"failure_payload": {},
+}
+
+var artifactRepoFilesFieldOptions = map[string]struct{}{
+	"path":         {},
+	"content":      {},
+	"content_type": {},
+	"schema":       {},
+	"max_bytes":    {},
+}
+
+var artifactRepoFilesSchemaFieldOptions = map[string]struct{}{
+	"type":            {},
+	"required_fields": {},
+}
+
+var artifactRepoOutputFieldOptions = map[string]struct{}{
+	"repo_url":             {},
+	"current_ref":          {},
+	"file_manifest":        {},
+	"status":               {},
+	"failure_reason":       {},
+	"last_request_id":      {},
+	"last_source_event_id": {},
+}
+
+var artifactRepoLimitsFieldOptions = map[string]struct{}{
+	"max_yaml_bytes":     {},
+	"max_markdown_bytes": {},
+	"max_text_bytes":     {},
+	"max_repo_bytes":     {},
+}
+
+var entitySelectionFieldOptions = map[string]struct{}{
+	"by": {},
+}
+
 func (s *HandlerOnSuccessSpec) UnmarshalYAML(node *yaml.Node) error {
 	if s == nil {
 		return nil
@@ -228,10 +316,11 @@ func (s *HandlerOnSuccessSpec) UnmarshalYAML(node *yaml.Node) error {
 	}
 	for i := 0; i+1 < len(node.Content); i += 2 {
 		key := strings.TrimSpace(node.Content[i].Value)
-		switch key {
-		case "", "emit":
-		default:
-			return fmt.Errorf("UNDEFINED-FIELD: on_success field %q not in platform spec", key)
+		if key == "" {
+			continue
+		}
+		if _, ok := onSuccessFieldOptions[key]; !ok {
+			return NewUndefinedFieldDiagnostic("on_success", key, onSuccessFieldOptions)
 		}
 	}
 	var aux struct {
@@ -260,10 +349,11 @@ func (a *ActivitySpec) UnmarshalYAML(node *yaml.Node) error {
 	}
 	for i := 0; i+1 < len(node.Content); i += 2 {
 		key := strings.TrimSpace(node.Content[i].Value)
-		switch key {
-		case "", "id", "tool", "input":
-		default:
-			return fmt.Errorf("UNDEFINED-FIELD: activity field %q not in platform spec", key)
+		if key == "" {
+			continue
+		}
+		if _, ok := activityFieldOptions[key]; !ok {
+			return NewUndefinedFieldDiagnostic("activity", key, activityFieldOptions)
 		}
 	}
 	var out ActivitySpec
@@ -332,10 +422,11 @@ func decodeEmitTargetNode(node *yaml.Node) (EmitTargetSpec, error) {
 	case yaml.MappingNode:
 		for i := 0; i+1 < len(node.Content); i += 2 {
 			key := strings.TrimSpace(node.Content[i].Value)
-			switch key {
-			case "", "instance_id", "flow", "match", "allow_fanout":
-			default:
-				return EmitTargetSpec{}, fmt.Errorf("UNDEFINED-FIELD: emit.target field %q not in platform spec", key)
+			if key == "" {
+				continue
+			}
+			if _, ok := emitTargetFieldOptions[key]; !ok {
+				return EmitTargetSpec{}, NewUndefinedFieldDiagnostic("emit.target", key, emitTargetFieldOptions)
 			}
 		}
 		var out EmitTargetSpec
@@ -422,21 +513,13 @@ func (m *MailboxWriteSpec) UnmarshalYAML(node *yaml.Node) error {
 	if node.Kind != yaml.MappingNode {
 		return fmt.Errorf("INVALID-MAILBOX-WRITE: mailbox must be a mapping")
 	}
-	allowed := map[string]struct{}{
-		"item_type":     {},
-		"severity":      {},
-		"summary":       {},
-		"entity_id":     {},
-		"flow_instance": {},
-		"payload":       {},
-	}
 	for i := 0; i+1 < len(node.Content); i += 2 {
 		key := strings.TrimSpace(node.Content[i].Value)
 		if key == "" {
 			continue
 		}
-		if _, ok := allowed[key]; !ok {
-			return fmt.Errorf("UNDEFINED-FIELD: mailbox field %q not in platform spec", key)
+		if _, ok := mailboxFieldOptions[key]; !ok {
+			return NewUndefinedFieldDiagnostic("mailbox", key, mailboxFieldOptions)
 		}
 	}
 	var out MailboxWriteSpec
@@ -515,31 +598,13 @@ func (s *ArtifactRepoSpec) UnmarshalYAML(node *yaml.Node) error {
 	if node.Kind != yaml.MappingNode {
 		return fmt.Errorf("INVALID-ARTIFACT-REPO: artifact_repo must be a mapping")
 	}
-	allowed := map[string]struct{}{
-		"provider":        {},
-		"repo_id":         {},
-		"namespace":       {},
-		"partition_key":   {},
-		"display_slug":    {},
-		"request_id":      {},
-		"author":          {},
-		"provenance":      {},
-		"allowed_paths":   {},
-		"files":           {},
-		"output":          {},
-		"limits":          {},
-		"success_event":   {},
-		"success_payload": {},
-		"failure_event":   {},
-		"failure_payload": {},
-	}
 	for i := 0; i+1 < len(node.Content); i += 2 {
 		key := strings.TrimSpace(node.Content[i].Value)
 		if key == "" {
 			continue
 		}
-		if _, ok := allowed[key]; !ok {
-			return fmt.Errorf("UNDEFINED-FIELD: artifact_repo field %q not in platform spec", key)
+		if _, ok := artifactRepoFieldOptions[key]; !ok {
+			return NewUndefinedFieldDiagnostic("artifact_repo", key, artifactRepoFieldOptions)
 		}
 	}
 	type alias ArtifactRepoSpec
@@ -562,20 +627,13 @@ func (f *ArtifactRepoFileSpec) UnmarshalYAML(node *yaml.Node) error {
 	if node.Kind != yaml.MappingNode {
 		return fmt.Errorf("INVALID-ARTIFACT-REPO: artifact_repo.files entries must be mappings")
 	}
-	allowed := map[string]struct{}{
-		"path":         {},
-		"content":      {},
-		"content_type": {},
-		"schema":       {},
-		"max_bytes":    {},
-	}
 	for i := 0; i+1 < len(node.Content); i += 2 {
 		key := strings.TrimSpace(node.Content[i].Value)
 		if key == "" {
 			continue
 		}
-		if _, ok := allowed[key]; !ok {
-			return fmt.Errorf("UNDEFINED-FIELD: artifact_repo.files field %q not in platform spec", key)
+		if _, ok := artifactRepoFilesFieldOptions[key]; !ok {
+			return NewUndefinedFieldDiagnostic("artifact_repo.files", key, artifactRepoFilesFieldOptions)
 		}
 	}
 	type alias ArtifactRepoFileSpec
@@ -598,17 +656,13 @@ func (s *ArtifactRepoSchemaSpec) UnmarshalYAML(node *yaml.Node) error {
 	if node.Kind != yaml.MappingNode {
 		return fmt.Errorf("INVALID-ARTIFACT-REPO: artifact_repo.files.schema must be a mapping")
 	}
-	allowed := map[string]struct{}{
-		"type":            {},
-		"required_fields": {},
-	}
 	for i := 0; i+1 < len(node.Content); i += 2 {
 		key := strings.TrimSpace(node.Content[i].Value)
 		if key == "" {
 			continue
 		}
-		if _, ok := allowed[key]; !ok {
-			return fmt.Errorf("UNDEFINED-FIELD: artifact_repo.files.schema field %q not in platform spec", key)
+		if _, ok := artifactRepoFilesSchemaFieldOptions[key]; !ok {
+			return NewUndefinedFieldDiagnostic("artifact_repo.files.schema", key, artifactRepoFilesSchemaFieldOptions)
 		}
 	}
 	type alias ArtifactRepoSchemaSpec
@@ -631,22 +685,13 @@ func (o *ArtifactRepoOutputSpec) UnmarshalYAML(node *yaml.Node) error {
 	if node.Kind != yaml.MappingNode {
 		return fmt.Errorf("INVALID-ARTIFACT-REPO: artifact_repo.output must be a mapping")
 	}
-	allowed := map[string]struct{}{
-		"repo_url":             {},
-		"current_ref":          {},
-		"file_manifest":        {},
-		"status":               {},
-		"failure_reason":       {},
-		"last_request_id":      {},
-		"last_source_event_id": {},
-	}
 	for i := 0; i+1 < len(node.Content); i += 2 {
 		key := strings.TrimSpace(node.Content[i].Value)
 		if key == "" {
 			continue
 		}
-		if _, ok := allowed[key]; !ok {
-			return fmt.Errorf("UNDEFINED-FIELD: artifact_repo.output field %q not in platform spec", key)
+		if _, ok := artifactRepoOutputFieldOptions[key]; !ok {
+			return NewUndefinedFieldDiagnostic("artifact_repo.output", key, artifactRepoOutputFieldOptions)
 		}
 	}
 	type alias ArtifactRepoOutputSpec
@@ -669,19 +714,13 @@ func (l *ArtifactRepoLimitsSpec) UnmarshalYAML(node *yaml.Node) error {
 	if node.Kind != yaml.MappingNode {
 		return fmt.Errorf("INVALID-ARTIFACT-REPO: artifact_repo.limits must be a mapping")
 	}
-	allowed := map[string]struct{}{
-		"max_yaml_bytes":     {},
-		"max_markdown_bytes": {},
-		"max_text_bytes":     {},
-		"max_repo_bytes":     {},
-	}
 	for i := 0; i+1 < len(node.Content); i += 2 {
 		key := strings.TrimSpace(node.Content[i].Value)
 		if key == "" {
 			continue
 		}
-		if _, ok := allowed[key]; !ok {
-			return fmt.Errorf("UNDEFINED-FIELD: artifact_repo.limits field %q not in platform spec", key)
+		if _, ok := artifactRepoLimitsFieldOptions[key]; !ok {
+			return NewUndefinedFieldDiagnostic("artifact_repo.limits", key, artifactRepoLimitsFieldOptions)
 		}
 	}
 	type alias ArtifactRepoLimitsSpec
@@ -1101,46 +1140,47 @@ func decodeAdvancesToNode(node *yaml.Node) (string, error) {
 	return decodeScalarStringNode(node)
 }
 
+var handlerFieldOptions = map[string]struct{}{
+	"action":                  {},
+	"activity":                {},
+	"description":             {},
+	"_note":                   {},
+	"evidence_target":         {},
+	"create_entity":           {},
+	"select_entity":           {},
+	"select_or_create_entity": {},
+	"emit":                    {},
+	"on_success":              {},
+	"guard":                   {},
+	"advances_to":             {},
+	"sets_gate":               {},
+	"clear_gates":             {},
+	"data_accumulation":       {},
+	"condition":               {},
+	"completion_rule":         {},
+	"logic":                   {},
+	"policy_ref":              {},
+	"on_complete":             {},
+	"rules":                   {},
+	"accumulate":              {},
+	"compute":                 {},
+	"query":                   {},
+	"fan_out":                 {},
+	"group_by":                {},
+	"filter":                  {},
+	"reduce":                  {},
+	"count":                   {},
+	"clear":                   {},
+	"template":                {},
+	"instance_id_from":        {},
+	"config_from":             {},
+	"from":                    {},
+	"dedup_by":                {},
+}
+
 func validateHandlerFieldNodes(node *yaml.Node) error {
 	if node == nil || node.Kind != yaml.MappingNode {
 		return nil
-	}
-	allowed := map[string]struct{}{
-		"action":                  {},
-		"activity":                {},
-		"description":             {},
-		"_note":                   {},
-		"evidence_target":         {},
-		"create_entity":           {},
-		"select_entity":           {},
-		"select_or_create_entity": {},
-		"emit":                    {},
-		"on_success":              {},
-		"guard":                   {},
-		"advances_to":             {},
-		"sets_gate":               {},
-		"clear_gates":             {},
-		"data_accumulation":       {},
-		"condition":               {},
-		"completion_rule":         {},
-		"logic":                   {},
-		"policy_ref":              {},
-		"on_complete":             {},
-		"rules":                   {},
-		"accumulate":              {},
-		"compute":                 {},
-		"query":                   {},
-		"fan_out":                 {},
-		"group_by":                {},
-		"filter":                  {},
-		"reduce":                  {},
-		"count":                   {},
-		"clear":                   {},
-		"template":                {},
-		"instance_id_from":        {},
-		"config_from":             {},
-		"from":                    {},
-		"dedup_by":                {},
 	}
 	deprecated := map[string]struct{}{
 		"condition":          {},
@@ -1168,8 +1208,8 @@ func validateHandlerFieldNodes(node *yaml.Node) error {
 		if key == "on_complete" && node.Content[i+1].Kind == yaml.MappingNode {
 			return fmt.Errorf("DIALECT-OC-ORDER: on_complete is dict, must be ordered list")
 		}
-		if _, ok := allowed[key]; !ok {
-			return fmt.Errorf("UNDEFINED-FIELD: handler field %q not in platform spec", key)
+		if _, ok := handlerFieldOptions[key]; !ok {
+			return NewUndefinedFieldDiagnostic("handler", key, handlerFieldOptions)
 		}
 	}
 	return nil
@@ -1384,16 +1424,13 @@ func decodeEntitySelectionSpecNode(node *yaml.Node, label string) (*SelectEntity
 	if node.Kind != yaml.MappingNode {
 		return nil, fmt.Errorf("INVALID-SELECT-ENTITY: %s must be a mapping", label)
 	}
-	allowed := map[string]struct{}{
-		"by": {},
-	}
 	for i := 0; i+1 < len(node.Content); i += 2 {
 		key := strings.TrimSpace(node.Content[i].Value)
 		if key == "" {
 			continue
 		}
-		if _, ok := allowed[key]; !ok {
-			return nil, fmt.Errorf("UNDEFINED-FIELD: %s field %q not in platform spec", label, key)
+		if _, ok := entitySelectionFieldOptions[key]; !ok {
+			return nil, NewUndefinedFieldDiagnostic(label, key, entitySelectionFieldOptions)
 		}
 	}
 	var aux struct {
@@ -1440,6 +1477,15 @@ func (a *ActionSpec) UnmarshalYAML(node *yaml.Node) error {
 	return nil
 }
 
+var actionFieldOptions = map[string]struct{}{
+	"id":               {},
+	"template":         {},
+	"instance_id_from": {},
+	"config_from":      {},
+	"mailbox":          {},
+	"artifact_repo":    {},
+}
+
 func decodeActionSpecNode(node *yaml.Node) (ActionSpec, error) {
 	if node == nil || node.Kind == 0 {
 		return ActionSpec{}, nil
@@ -1455,27 +1501,19 @@ func decodeActionSpecNode(node *yaml.Node) (ActionSpec, error) {
 		}
 		return ActionSpec{ID: actionID}, nil
 	case yaml.MappingNode:
-		allowed := map[string]struct{}{
-			"id":               {},
-			"template":         {},
-			"instance_id_from": {},
-			"config_from":      {},
-			"mailbox":          {},
-			"artifact_repo":    {},
-		}
 		for i := 0; i+1 < len(node.Content); i += 2 {
 			key := strings.TrimSpace(node.Content[i].Value)
 			if key == "" {
 				continue
 			}
-			if _, ok := allowed[key]; ok {
+			if _, ok := actionFieldOptions[key]; ok {
 				continue
 			}
 			switch key {
 			case "type", "flow_template", "instance_id":
 				return ActionSpec{}, fmt.Errorf("DEPRECATED: legacy action field %q is not supported; use action: create_flow_instance with template, instance_id_from, and config_from siblings", key)
 			default:
-				return ActionSpec{}, fmt.Errorf("UNDEFINED-FIELD: action field %q not in platform spec", key)
+				return ActionSpec{}, NewUndefinedFieldDiagnostic("action", key, actionFieldOptions)
 			}
 		}
 		var aux struct {
@@ -1540,7 +1578,7 @@ func decodeConfigFromSpecNode(node *yaml.Node) (*ConfigFromSpec, error) {
 	}
 	spec := &ConfigFromSpec{Bindings: map[string]string{}}
 	if hasYAMLMappingKey(node, "policy_keys") {
-		return nil, fmt.Errorf("UNDEFINED-FIELD: config_from field %q not in platform spec", "policy_keys")
+		return nil, NewUndefinedFieldDiagnostic("config_from", "policy_keys", nil)
 	}
 	for i := 0; i+1 < len(node.Content); i += 2 {
 		key := strings.TrimSpace(node.Content[i].Value)

--- a/internal/runtime/contracts/workflow_contract_yaml_rules.go
+++ b/internal/runtime/contracts/workflow_contract_yaml_rules.go
@@ -75,7 +75,7 @@ func decodeGuardOnFailNode(node *yaml.Node) (string, GuardFailureSpec, error) {
 				}
 				escalation = &decoded
 			default:
-				return "", GuardFailureSpec{}, fmt.Errorf("UNDEFINED-FIELD: guard.on_fail field %q not in platform spec", key)
+				return "", GuardFailureSpec{}, NewUndefinedFieldDiagnostic("guard.on_fail", key, guardOnFailFieldOptions)
 			}
 		}
 		if escalation == nil {
@@ -124,13 +124,23 @@ func decodeGuardEscalationNode(node *yaml.Node) (EmitSpec, error) {
 				}
 				fields = decoded
 			default:
-				return EmitSpec{}, fmt.Errorf("UNDEFINED-FIELD: guard.on_fail.escalate field %q not in platform spec", key)
+				return EmitSpec{}, NewUndefinedFieldDiagnostic("guard.on_fail.escalate", key, guardOnFailEscalateFieldOptions)
 			}
 		}
 		return EmitSpec{Event: strings.TrimSpace(event), From: strings.TrimSpace(from), Fields: fields}, nil
 	default:
 		return EmitSpec{}, fmt.Errorf("guard.on_fail.escalate must be a mapping with event and optional fields")
 	}
+}
+
+var guardOnFailFieldOptions = map[string]struct{}{
+	"escalate": {},
+}
+
+var guardOnFailEscalateFieldOptions = map[string]struct{}{
+	"event":  {},
+	"from":   {},
+	"fields": {},
 }
 
 func (a *AccumulateSpec) UnmarshalYAML(node *yaml.Node) error {
@@ -181,28 +191,29 @@ func validateAccumulateFieldNodes(node *yaml.Node) error {
 	if node == nil || node.Kind != yaml.MappingNode {
 		return nil
 	}
-	allowed := map[string]struct{}{
-		"into":          {},
-		"expected_from": {},
-		"from":          {},
-		"description":   {},
-		"dedup_by":      {},
-		"threshold":     {},
-		"timeout_ms":    {},
-		"completion":    {},
-		"on_complete":   {},
-		"on_timeout":    {},
-	}
 	for i := 0; i+1 < len(node.Content); i += 2 {
 		key := strings.TrimSpace(node.Content[i].Value)
 		if key == "" {
 			continue
 		}
-		if _, ok := allowed[key]; !ok {
-			return fmt.Errorf("UNDEFINED-FIELD: accumulate field %q not in platform spec", key)
+		if _, ok := accumulateFieldOptions[key]; !ok {
+			return NewUndefinedFieldDiagnostic("accumulate", key, accumulateFieldOptions)
 		}
 	}
 	return nil
+}
+
+var accumulateFieldOptions = map[string]struct{}{
+	"into":          {},
+	"expected_from": {},
+	"from":          {},
+	"description":   {},
+	"dedup_by":      {},
+	"threshold":     {},
+	"timeout_ms":    {},
+	"completion":    {},
+	"on_complete":   {},
+	"on_timeout":    {},
 }
 
 func (f *FanOutSpec) UnmarshalYAML(node *yaml.Node) error {
@@ -232,10 +243,6 @@ func validateFanOutFieldNodes(node *yaml.Node) error {
 	if node == nil || node.Kind != yaml.MappingNode {
 		return nil
 	}
-	allowed := map[string]struct{}{
-		"items_from": {},
-		"emit":       {},
-	}
 	for i := 0; i+1 < len(node.Content); i += 2 {
 		key := strings.TrimSpace(node.Content[i].Value)
 		if key == "" {
@@ -249,11 +256,16 @@ func validateFanOutFieldNodes(node *yaml.Node) error {
 		case "emit_mapping":
 			return fmt.Errorf("RETIRED: fan_out field %q is retired; move per-item payload ownership into fan_out.emit", key)
 		}
-		if _, ok := allowed[key]; !ok {
-			return fmt.Errorf("UNDEFINED-FIELD: fan_out field %q not in platform spec", key)
+		if _, ok := fanOutFieldOptions[key]; !ok {
+			return NewUndefinedFieldDiagnostic("fan_out", key, fanOutFieldOptions)
 		}
 	}
 	return nil
+}
+
+var fanOutFieldOptions = map[string]struct{}{
+	"items_from": {},
+	"emit":       {},
 }
 
 func (g *GroupBySpec) UnmarshalYAML(node *yaml.Node) error {

--- a/internal/runtime/contracts/workflow_contract_yaml_test.go
+++ b/internal/runtime/contracts/workflow_contract_yaml_test.go
@@ -9,6 +9,15 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+func containsString(values []string, target string) bool {
+	for _, value := range values {
+		if value == target {
+			return true
+		}
+	}
+	return false
+}
+
 func TestProjectPackageDocumentDecode_PreservesRequiresAndImportBinds(t *testing.T) {
 	var doc ProjectPackageDocument
 	if err := yaml.Unmarshal([]byte(`
@@ -252,7 +261,7 @@ func TestProjectPackageDocumentDecode_RejectsStrictSelfFactDrift(t *testing.T) {
 name: invalid
 category: examples
 `,
-			wantErr: "UNDEFINED-FIELD",
+			wantErr: "not supported",
 		},
 		{
 			name: "unknown homepage",
@@ -260,7 +269,7 @@ category: examples
 name: invalid
 homepage: https://division.sh
 `,
-			wantErr: "UNDEFINED-FIELD",
+			wantErr: "not supported",
 		},
 		{
 			name: "unknown capabilities",
@@ -268,7 +277,7 @@ homepage: https://division.sh
 name: invalid
 capabilities: []
 `,
-			wantErr: "UNDEFINED-FIELD",
+			wantErr: "not supported",
 		},
 		{
 			name: "loose license alias",
@@ -371,7 +380,7 @@ requires:
     provider.threshold:
       fallback: 0.8
 `,
-			wantErr: "UNDEFINED-FIELD",
+			wantErr: `requires.policy field "fallback" is not supported.`,
 		},
 		{
 			name: "policy requirement must be mapping",
@@ -390,7 +399,7 @@ name: invalid
 requires:
   inputz: [work.requested]
 `,
-			wantErr: "UNDEFINED-FIELD",
+			wantErr: `requires field "inputz" is not supported.`,
 		},
 		{
 			name: "bind inputs must be mapping",
@@ -413,7 +422,7 @@ packages:
     bind:
       credential: {}
 `,
-			wantErr: "UNDEFINED-FIELD",
+			wantErr: `bind field "credential" is not supported.`,
 		},
 		{
 			name: "unknown connect field",
@@ -424,7 +433,7 @@ connect:
     to: consumer.ready
     topic: unsupported
 `,
-			wantErr: "UNDEFINED-FIELD",
+			wantErr: `connect field "topic" is not supported.`,
 		},
 	}
 	for _, tc := range tests {
@@ -509,8 +518,8 @@ pins:
           by: vertical_id
           unsupported: nope
 `), &doc)
-	if err == nil || !strings.Contains(err.Error(), "UNDEFINED-FIELD") {
-		t.Fatalf("yaml.Unmarshal error = %v, want UNDEFINED-FIELD", err)
+	if err == nil || !strings.Contains(err.Error(), `input event pin address field "unsupported" is not supported.`) {
+		t.Fatalf("yaml.Unmarshal error = %v, want typed address field rejection", err)
 	}
 }
 
@@ -662,8 +671,8 @@ pins:
 		t.Run(tc.name, func(t *testing.T) {
 			var doc FlowSchemaDocument
 			err := yaml.Unmarshal([]byte(tc.body), &doc)
-			if err == nil || !strings.Contains(err.Error(), "UNDEFINED-FIELD") {
-				t.Fatalf("yaml.Unmarshal error = %v, want UNDEFINED-FIELD", err)
+			if err == nil || !strings.Contains(err.Error(), "is not supported") {
+				t.Fatalf("yaml.Unmarshal error = %v, want typed field rejection", err)
 			}
 		})
 	}
@@ -680,21 +689,22 @@ pins:
         event: deploy.done
         unknown: nope
 `), &doc)
-	if err == nil || !strings.Contains(err.Error(), "UNDEFINED-FIELD") {
-		t.Fatalf("yaml.Unmarshal error = %v, want UNDEFINED-FIELD", err)
+	if err == nil || !strings.Contains(err.Error(), "not supported") {
+		t.Fatalf("yaml.Unmarshal error = %v, want unsupported field", err)
 	}
 }
 
 func TestFlowSchemaDocumentDecode_RejectsRetiredAndUnsupportedTopLevelFields(t *testing.T) {
 	tests := []struct {
-		name    string
-		field   string
-		wantErr string
+		name         string
+		field        string
+		wantErr      string
+		wantDiagCode string
 	}{
 		{name: "namespace_prefix", field: "namespace_prefix: worker", wantErr: "RETIRED"},
 		{name: "namespace_rule", field: "namespace_rule: path", wantErr: "RETIRED"},
-		{name: "namespace", field: "namespace: worker", wantErr: "UNDEFINED-FIELD"},
-		{name: "unknown", field: "legacy_owner: worker", wantErr: "UNDEFINED-FIELD"},
+		{name: "namespace", field: "namespace: worker", wantErr: "schema field \"namespace\" is not supported.", wantDiagCode: "contract_loader.undefined_field"},
+		{name: "unknown", field: "legacy_owner: worker", wantErr: "schema field \"legacy_owner\" is not supported.", wantDiagCode: "contract_loader.undefined_field"},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -702,6 +712,29 @@ func TestFlowSchemaDocumentDecode_RejectsRetiredAndUnsupportedTopLevelFields(t *
 			err := yaml.Unmarshal([]byte("name: invalid-schema\n"+tc.field+"\n"), &doc)
 			if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
 				t.Fatalf("yaml.Unmarshal error = %v, want %q", err, tc.wantErr)
+			}
+			if tc.wantDiagCode == "" {
+				return
+			}
+			diagnostic, ok := AsLoaderDiagnostic(err)
+			if !ok {
+				t.Fatalf("yaml.Unmarshal error = %T %v, want LoaderDiagnostic", err, err)
+			}
+			if diagnostic.Code != tc.wantDiagCode {
+				t.Fatalf("diagnostic code = %q, want %q", diagnostic.Code, tc.wantDiagCode)
+			}
+			if len(diagnostic.ValidOptions) == 0 {
+				t.Fatalf("diagnostic valid options empty: %#v", diagnostic)
+			}
+			foundTerminalStates := false
+			for _, option := range diagnostic.ValidOptions {
+				if option == "terminal_states" {
+					foundTerminalStates = true
+					break
+				}
+			}
+			if !foundTerminalStates {
+				t.Fatalf("diagnostic valid options = %#v, want terminal_states", diagnostic.ValidOptions)
 			}
 		})
 	}
@@ -841,8 +874,8 @@ instance:
   on_conflict: reject
   fallback: legacy
 `), &doc)
-	if err == nil || !strings.Contains(err.Error(), "UNDEFINED-FIELD") {
-		t.Fatalf("yaml.Unmarshal error = %v, want UNDEFINED-FIELD", err)
+	if err == nil || !strings.Contains(err.Error(), `template instance field "fallback" is not supported.`) {
+		t.Fatalf("yaml.Unmarshal error = %v, want typed template instance field rejection", err)
 	}
 }
 
@@ -854,8 +887,8 @@ compute:
   store_as: entity.composite
   expression: "weighted_average(accumulated.scores, accumulated.weights)"
 `), &rule)
-	if err == nil || !strings.Contains(err.Error(), "UNDEFINED-FIELD") {
-		t.Fatalf("yaml.Unmarshal error = %v, want UNDEFINED-FIELD", err)
+	if err == nil || !strings.Contains(err.Error(), `compute field "expression" is not supported.`) {
+		t.Fatalf("yaml.Unmarshal error = %v, want typed compute field rejection", err)
 	}
 }
 
@@ -908,8 +941,15 @@ rules:
     condition: "else"
     sets_gate: approved
 `), &handler)
-	if err == nil || !strings.Contains(err.Error(), `UNDEFINED-FIELD: rule field "sets_gate"`) {
+	if err == nil || !strings.Contains(err.Error(), `rule field "sets_gate" is not supported.`) {
 		t.Fatalf("yaml.Unmarshal error = %v, want rule-level sets_gate rejection", err)
+	}
+	diagnostic, ok := AsLoaderDiagnostic(err)
+	if !ok {
+		t.Fatalf("yaml.Unmarshal error = %T %v, want LoaderDiagnostic", err, err)
+	}
+	if !containsString(diagnostic.ValidOptions, "advances_to") || !containsString(diagnostic.ValidOptions, "emit") {
+		t.Fatalf("diagnostic valid options = %#v, want rule options", diagnostic.ValidOptions)
 	}
 }
 
@@ -1651,8 +1691,8 @@ compute:
   keys:
     numeric_keys: [score]
 `), &rule)
-	if err == nil || !strings.Contains(err.Error(), "UNDEFINED-FIELD") {
-		t.Fatalf("yaml.Unmarshal error = %v, want UNDEFINED-FIELD", err)
+	if err == nil || !strings.Contains(err.Error(), `compute field "output_field" is not supported.`) {
+		t.Fatalf("yaml.Unmarshal error = %v, want typed compute field rejection", err)
 	}
 }
 
@@ -1888,15 +1928,16 @@ func TestFlowSchemaDocumentDecode_TracksRequiredAgentsPresence(t *testing.T) {
 
 func TestSystemNodeContractDecode_RejectsRetiredAndUnsupportedTopLevelFields(t *testing.T) {
 	tests := []struct {
-		name    string
-		field   string
-		wantErr string
+		name         string
+		field        string
+		wantErr      string
+		wantDiagCode string
 	}{
 		{name: "permissions", field: "permissions: [create_flow_instance]", wantErr: "RETIRED"},
 		{name: "implementation", field: "implementation: builtin", wantErr: "RETIRED"},
 		{name: "owned_transitions", field: "owned_transitions: [ticket-open]", wantErr: "RETIRED"},
 		{name: "idempotency_table", field: "idempotency_table: worker_idempotency", wantErr: "RETIRED"},
-		{name: "unknown", field: "legacy_owner: worker", wantErr: "UNDEFINED-FIELD"},
+		{name: "unknown", field: "legacy_owner: worker", wantErr: "node field \"legacy_owner\" is not supported.", wantDiagCode: "contract_loader.undefined_field"},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -1904,6 +1945,29 @@ func TestSystemNodeContractDecode_RejectsRetiredAndUnsupportedTopLevelFields(t *
 			err := yaml.Unmarshal([]byte("id: worker\n"+tc.field+"\n"), &node)
 			if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
 				t.Fatalf("yaml.Unmarshal error = %v, want %q", err, tc.wantErr)
+			}
+			if tc.wantDiagCode == "" {
+				return
+			}
+			diagnostic, ok := AsLoaderDiagnostic(err)
+			if !ok {
+				t.Fatalf("yaml.Unmarshal error = %T %v, want LoaderDiagnostic", err, err)
+			}
+			if diagnostic.Code != tc.wantDiagCode {
+				t.Fatalf("diagnostic code = %q, want %q", diagnostic.Code, tc.wantDiagCode)
+			}
+			if len(diagnostic.ValidOptions) == 0 {
+				t.Fatalf("diagnostic valid options empty: %#v", diagnostic)
+			}
+			foundEventHandlers := false
+			for _, option := range diagnostic.ValidOptions {
+				if option == "event_handlers" {
+					foundEventHandlers = true
+					break
+				}
+			}
+			if !foundEventHandlers {
+				t.Fatalf("diagnostic valid options = %#v, want event_handlers", diagnostic.ValidOptions)
 			}
 		})
 	}
@@ -1996,6 +2060,29 @@ emit:
 `), &spec)
 	if err == nil || !strings.Contains(err.Error(), `fan_out field "target" is retired`) {
 		t.Fatalf("yaml.Unmarshal error = %v, want retired fan_out target rejection", err)
+	}
+}
+
+func TestFanOutSpecDecode_RejectsUnknownFieldWithCanonicalOptions(t *testing.T) {
+	var spec FanOutSpec
+	err := yaml.Unmarshal([]byte(`
+items_from: payload.items
+foreach: payload.items
+emit:
+  event: routed.item
+`), &spec)
+	if err == nil {
+		t.Fatal("expected unknown fan_out field rejection")
+	}
+	diagnostic, ok := AsLoaderDiagnostic(err)
+	if !ok {
+		t.Fatalf("yaml.Unmarshal error = %T %v, want LoaderDiagnostic", err, err)
+	}
+	if got := diagnostic.Problem; got != `fan_out field "foreach" is not supported.` {
+		t.Fatalf("diagnostic problem = %q, want unknown fan_out field problem", got)
+	}
+	if !reflect.DeepEqual(diagnostic.ValidOptions, []string{"emit", "items_from"}) {
+		t.Fatalf("diagnostic valid options = %#v, want emit/items_from", diagnostic.ValidOptions)
 	}
 }
 
@@ -2270,8 +2357,8 @@ select_entity:
   where:
     vertical_id: payload.vertical_id
 `), &handler)
-	if err == nil || !strings.Contains(err.Error(), "UNDEFINED-FIELD") {
-		t.Fatalf("yaml.Unmarshal error = %v, want UNDEFINED-FIELD", err)
+	if err == nil || !strings.Contains(err.Error(), `select_entity field "where" is not supported.`) {
+		t.Fatalf("yaml.Unmarshal error = %v, want typed select_entity field rejection", err)
 	}
 }
 
@@ -2307,8 +2394,8 @@ select_or_create_entity:
   where:
     repo_id: payload.repo_id
 `), &handler)
-	if err == nil || !strings.Contains(err.Error(), "UNDEFINED-FIELD") {
-		t.Fatalf("yaml.Unmarshal error = %v, want UNDEFINED-FIELD", err)
+	if err == nil || !strings.Contains(err.Error(), `select_or_create_entity field "where" is not supported.`) {
+		t.Fatalf("yaml.Unmarshal error = %v, want typed select_or_create_entity field rejection", err)
 	}
 }
 
@@ -2545,7 +2632,7 @@ check: payload.score >= policy.threshold
 on_fail:
   reject: true
 `,
-			wantErr: "UNDEFINED-FIELD",
+			wantErr: `guard.on_fail field "reject" is not supported.`,
 		},
 	}
 	for _, tc := range tests {
@@ -2556,6 +2643,51 @@ on_fail:
 				t.Fatalf("yaml.Unmarshal error = %v, want %q", err, tc.wantErr)
 			}
 		})
+	}
+}
+
+func TestGuardSpecDecode_RejectsUnknownOnFailFieldWithCanonicalOptions(t *testing.T) {
+	var spec GuardSpec
+	err := yaml.Unmarshal([]byte(`
+id: score_check
+check: payload.score >= policy.threshold
+on_fail:
+  reject: true
+`), &spec)
+	if err == nil {
+		t.Fatal("expected unknown guard.on_fail field rejection")
+	}
+	diagnostic, ok := AsLoaderDiagnostic(err)
+	if !ok {
+		t.Fatalf("yaml.Unmarshal error = %T %v, want LoaderDiagnostic", err, err)
+	}
+	if got := diagnostic.Problem; got != `guard.on_fail field "reject" is not supported.` {
+		t.Fatalf("diagnostic problem = %q, want unknown guard.on_fail field problem", got)
+	}
+	if !reflect.DeepEqual(diagnostic.ValidOptions, []string{"escalate"}) {
+		t.Fatalf("diagnostic valid options = %#v, want only escalate", diagnostic.ValidOptions)
+	}
+}
+
+func TestAccumulateSpecDecode_RejectsUnknownFieldWithCanonicalOptions(t *testing.T) {
+	var spec AccumulateSpec
+	err := yaml.Unmarshal([]byte(`
+into: entity.items
+source: payload.items
+`), &spec)
+	if err == nil {
+		t.Fatal("expected unknown accumulate field rejection")
+	}
+	diagnostic, ok := AsLoaderDiagnostic(err)
+	if !ok {
+		t.Fatalf("yaml.Unmarshal error = %T %v, want LoaderDiagnostic", err, err)
+	}
+	if got := diagnostic.Problem; got != `accumulate field "source" is not supported.` {
+		t.Fatalf("diagnostic problem = %q, want unknown accumulate field problem", got)
+	}
+	want := []string{"completion", "dedup_by", "description", "expected_from", "from", "into", "on_complete", "on_timeout", "threshold", "timeout_ms"}
+	if !reflect.DeepEqual(diagnostic.ValidOptions, want) {
+		t.Fatalf("diagnostic valid options = %#v, want %#v", diagnostic.ValidOptions, want)
 	}
 }
 
@@ -3049,8 +3181,8 @@ instance_id_from: payload.worker_id
 config_from:
   policy_keys: [priority_profile]
 `), &handler)
-	if err == nil || !strings.Contains(err.Error(), "UNDEFINED-FIELD") {
-		t.Fatalf("yaml.Unmarshal error = %v, want UNDEFINED-FIELD", err)
+	if err == nil || !strings.Contains(err.Error(), `config_from field "policy_keys" is not supported.`) {
+		t.Fatalf("yaml.Unmarshal error = %v, want typed config_from field rejection", err)
 	}
 }
 
@@ -3123,8 +3255,8 @@ action:
       literal: Review validation package
     implicit_payload: true
 `), &handler)
-	if err == nil || !strings.Contains(err.Error(), "UNDEFINED-FIELD") {
-		t.Fatalf("yaml.Unmarshal error = %v, want UNDEFINED-FIELD", err)
+	if err == nil || !strings.Contains(err.Error(), `mailbox field "implicit_payload" is not supported.`) {
+		t.Fatalf("yaml.Unmarshal error = %v, want typed mailbox field rejection", err)
 	}
 }
 
@@ -3260,8 +3392,8 @@ action:
     provider: local_git
     shell: git commit
 `), &handler)
-	if err == nil || !strings.Contains(err.Error(), "UNDEFINED-FIELD") {
-		t.Fatalf("yaml.Unmarshal error = %v, want UNDEFINED-FIELD", err)
+	if err == nil || !strings.Contains(err.Error(), `artifact_repo field "shell" is not supported.`) {
+		t.Fatalf("yaml.Unmarshal error = %v, want typed artifact_repo field rejection", err)
 	}
 }
 
@@ -3359,7 +3491,14 @@ dedup_by: payload.dimension
 	err := yaml.Unmarshal([]byte(`
 legacy_buffer: dimensions_received
 `), &spec)
-	if err == nil || !strings.Contains(err.Error(), "UNDEFINED-FIELD") {
-		t.Fatalf("yaml.Unmarshal error = %v, want UNDEFINED-FIELD", err)
+	if err == nil || !strings.Contains(err.Error(), `accumulate field "legacy_buffer" is not supported.`) {
+		t.Fatalf("yaml.Unmarshal error = %v, want typed accumulate field rejection", err)
+	}
+	diagnostic, ok := AsLoaderDiagnostic(err)
+	if !ok {
+		t.Fatalf("yaml.Unmarshal error = %T %v, want LoaderDiagnostic", err, err)
+	}
+	if !containsString(diagnostic.ValidOptions, "into") || !containsString(diagnostic.ValidOptions, "on_complete") {
+		t.Fatalf("diagnostic valid options = %#v, want accumulate options", diagnostic.ValidOptions)
 	}
 }

--- a/internal/runtime/contracts/workflow_contract_yaml_wave1.go
+++ b/internal/runtime/contracts/workflow_contract_yaml_wave1.go
@@ -108,7 +108,7 @@ func validateProjectPackageDocumentFields(node *yaml.Node) error {
 		return nil
 	}
 	if node.Kind != yaml.MappingNode {
-		return fmt.Errorf("package.yaml must be a mapping")
+		return NewPackageDocumentMappingDiagnostic(nil)
 	}
 	for i := 0; i+1 < len(node.Content); i += 2 {
 		key := strings.TrimSpace(node.Content[i].Value)
@@ -116,7 +116,7 @@ func validateProjectPackageDocumentFields(node *yaml.Node) error {
 			continue
 		}
 		if _, ok := projectPackageDocumentFields[key]; !ok {
-			return fmt.Errorf("UNDEFINED-FIELD: package.yaml field %q not in platform spec", key)
+			return NewUndefinedFieldDiagnostic("package.yaml", key, projectPackageDocumentFields)
 		}
 	}
 	return nil
@@ -132,6 +132,87 @@ func yamlMappingValue(node *yaml.Node, key string) *yaml.Node {
 		}
 	}
 	return nil
+}
+
+var flowPackageRequiresFieldOptions = map[string]struct{}{
+	"inputs":           {},
+	"outputs":          {},
+	"policy":           {},
+	"credentials":      {},
+	"platform_version": {},
+}
+
+var flowPackageBindFieldOptions = map[string]struct{}{
+	"inputs":      {},
+	"outputs":     {},
+	"policy":      {},
+	"credentials": {},
+	"observe":     {},
+}
+
+var connectorPackFieldOptions = map[string]struct{}{
+	"imports": {},
+}
+
+var connectorPackImportFieldOptions = map[string]struct{}{
+	"provider": {},
+	"tool":     {},
+}
+
+var flowPackageRequiresPolicyFieldOptions = map[string]struct{}{
+	"default":     {},
+	"type":        {},
+	"description": {},
+	"required":    {},
+}
+
+var flowPackageConnectFieldOptions = map[string]struct{}{
+	"from":     {},
+	"to":       {},
+	"adapter":  {},
+	"using":    {},
+	"map":      {},
+	"delivery": {},
+	"reply":    {},
+}
+
+var flowPackageConnectUsingFieldOptions = map[string]struct{}{
+	"instance": {},
+}
+
+var flowPackageConnectInstanceFieldOptions = map[string]struct{}{
+	"source": {},
+	"target": {},
+}
+
+var flowPackageConnectMapFieldOptions = map[string]struct{}{
+	"source": {},
+	"target": {},
+}
+
+var typeCatalogFieldOptions = map[string]struct{}{
+	"scalars": {},
+	"enums":   {},
+	"types":   {},
+}
+
+var typeMetadataFieldOptions = map[string]struct{}{
+	"_description": {},
+}
+
+var entityMetadataFieldOptions = map[string]struct{}{
+	"_description": {},
+	"_owner":       {},
+}
+
+var schemaLengthRefinementFieldOptions = map[string]struct{}{
+	"min": {},
+	"max": {},
+}
+
+var schemaRangeRefinementFieldOptions = map[string]struct{}{
+	"min": {},
+	"max": {},
 }
 
 func (r *FlowPackageRequires) UnmarshalYAML(node *yaml.Node) error {
@@ -176,7 +257,7 @@ func (r *FlowPackageRequires) UnmarshalYAML(node *yaml.Node) error {
 				return fmt.Errorf("requires.platform_version: %w", err)
 			}
 		default:
-			return fmt.Errorf("UNDEFINED-FIELD: requires field %q not in platform spec", key)
+			return NewUndefinedFieldDiagnostic("requires", key, flowPackageRequiresFieldOptions)
 		}
 	}
 	*r = out.normalized()
@@ -222,7 +303,7 @@ func (b *FlowPackageBind) UnmarshalYAML(node *yaml.Node) error {
 				return fmt.Errorf("bind.observe: %w", err)
 			}
 		default:
-			return fmt.Errorf("UNDEFINED-FIELD: bind field %q not in platform spec", key)
+			return NewUndefinedFieldDiagnostic("bind", key, flowPackageBindFieldOptions)
 		}
 	}
 	*b = out.normalized()
@@ -252,7 +333,7 @@ func (c *ConnectorPackImports) UnmarshalYAML(node *yaml.Node) error {
 				return fmt.Errorf("connector_packs.imports: %w", err)
 			}
 		default:
-			return fmt.Errorf("UNDEFINED-FIELD: connector_packs field %q not in platform spec", key)
+			return NewUndefinedFieldDiagnostic("connector_packs", key, connectorPackFieldOptions)
 		}
 	}
 	*c = out.normalized()
@@ -286,7 +367,7 @@ func (i *ConnectorPackImport) UnmarshalYAML(node *yaml.Node) error {
 				return fmt.Errorf("tool: %w", err)
 			}
 		default:
-			return fmt.Errorf("UNDEFINED-FIELD: connector_packs.imports field %q not in platform spec", key)
+			return NewUndefinedFieldDiagnostic("connector_packs.imports", key, connectorPackImportFieldOptions)
 		}
 	}
 	*i = out.normalized()
@@ -390,7 +471,7 @@ func decodeFlowPackagePolicyDefault(node *yaml.Node) (any, bool, error) {
 		case "type", "description", "required":
 			continue
 		default:
-			return nil, false, fmt.Errorf("UNDEFINED-FIELD: requires.policy option %q not in platform spec", key)
+			return nil, false, NewUndefinedFieldDiagnostic("requires.policy", key, flowPackageRequiresPolicyFieldOptions)
 		}
 	}
 	return out, hasDefault, nil
@@ -497,7 +578,7 @@ func (c *FlowPackageConnect) UnmarshalYAML(node *yaml.Node) error {
 				return fmt.Errorf("connect.reply: %w", err)
 			}
 		default:
-			return fmt.Errorf("UNDEFINED-FIELD: connect field %q not in platform spec", key)
+			return NewUndefinedFieldDiagnostic("connect", key, flowPackageConnectFieldOptions)
 		}
 	}
 	*c = out.normalized()
@@ -527,7 +608,7 @@ func (u *FlowPackageConnectUsing) UnmarshalYAML(node *yaml.Node) error {
 				return fmt.Errorf("connect.using.instance: %w", err)
 			}
 		default:
-			return fmt.Errorf("UNDEFINED-FIELD: connect using field %q not in platform spec", key)
+			return NewUndefinedFieldDiagnostic("connect using", key, flowPackageConnectUsingFieldOptions)
 		}
 	}
 	*u = out.normalized()
@@ -565,7 +646,7 @@ func (a *FlowPackageConnectInstanceAdapter) UnmarshalYAML(node *yaml.Node) error
 			}
 			out.Target = target
 		default:
-			return fmt.Errorf("UNDEFINED-FIELD: connect using instance field %q not in platform spec", key)
+			return NewUndefinedFieldDiagnostic("connect using instance", key, flowPackageConnectInstanceFieldOptions)
 		}
 	}
 	*a = out.normalized()
@@ -626,7 +707,7 @@ func (m *FlowPackageConnectMap) UnmarshalYAML(node *yaml.Node) error {
 				return fmt.Errorf("connect map target: %w", err)
 			}
 		default:
-			return fmt.Errorf("UNDEFINED-FIELD: connect map field %q not in platform spec", key)
+			return NewUndefinedFieldDiagnostic("connect map", key, flowPackageConnectMapFieldOptions)
 		}
 	}
 	*m = FlowPackageConnectMap{
@@ -690,7 +771,7 @@ func (d *TypeCatalogDocument) UnmarshalYAML(node *yaml.Node) error {
 				return err
 			}
 		default:
-			return fmt.Errorf("UNDEFINED-FIELD: type catalog field %q not in platform spec", key)
+			return NewUndefinedFieldDiagnostic("type catalog", key, typeCatalogFieldOptions)
 		}
 	}
 	*d = doc
@@ -757,7 +838,7 @@ func (n *NamedTypeDecl) UnmarshalYAML(node *yaml.Node) error {
 				}
 				decl.Description = text
 			default:
-				return fmt.Errorf("UNDEFINED-FIELD: type metadata field %q not in platform spec", key)
+				return NewUndefinedFieldDiagnostic("type metadata", key, typeMetadataFieldOptions)
 			}
 			continue
 		}
@@ -852,7 +933,7 @@ func (e *EntityContract) UnmarshalYAML(node *yaml.Node) error {
 			case "_state_model":
 				return fmt.Errorf("RETIRED: entity field %q is retired; state authority is implicit from schema.yaml", key)
 			default:
-				return fmt.Errorf("UNDEFINED-FIELD: entity metadata field %q not in platform spec", key)
+				return NewUndefinedFieldDiagnostic("entity metadata", key, entityMetadataFieldOptions)
 			}
 			continue
 		}
@@ -984,9 +1065,9 @@ func decodeWave1FieldNode(node *yaml.Node, opts wave1FieldNodeOptions) (wave1Par
 				listOf = listValue
 				continue
 			case "initial", "immutable", "indexed", "_unused_reason", "_unused_reader_reason", "materialize_from", "project":
-				return wave1ParsedFieldNode{}, fmt.Errorf("UNDEFINED-FIELD: %s field %q not in platform spec", opts.Context, key)
+				return wave1ParsedFieldNode{}, NewUndefinedFieldDiagnostic(opts.Context, key, allowed)
 			default:
-				return wave1ParsedFieldNode{}, fmt.Errorf("UNDEFINED-FIELD: %s field %q not in platform spec", opts.Context, key)
+				return wave1ParsedFieldNode{}, NewUndefinedFieldDiagnostic(opts.Context, key, allowed)
 			}
 		}
 		switch key {
@@ -1032,7 +1113,7 @@ func decodeWave1FieldNode(node *yaml.Node, opts wave1FieldNodeOptions) (wave1Par
 			field.Refinements.EqualTo = target
 		case "citation":
 			if !opts.AllowCitation {
-				return wave1ParsedFieldNode{}, fmt.Errorf("UNDEFINED-FIELD: %s field %q not in platform spec", opts.Context, key)
+				return wave1ParsedFieldNode{}, NewUndefinedFieldDiagnostic(opts.Context, key, allowed)
 			}
 			var citation CriteriaCitation
 			if err := value.Decode(&citation); err != nil {
@@ -1145,7 +1226,7 @@ func decodeSchemaLengthRefinement(node *yaml.Node) (SchemaLengthRefinement, erro
 			}
 			out.Max = &max
 		default:
-			return SchemaLengthRefinement{}, fmt.Errorf("UNDEFINED-FIELD: length field %q not in platform spec", key)
+			return SchemaLengthRefinement{}, NewUndefinedFieldDiagnostic("length", key, schemaLengthRefinementFieldOptions)
 		}
 	}
 	if out.Min == nil && out.Max == nil {
@@ -1187,7 +1268,7 @@ func decodeSchemaRangeRefinement(node *yaml.Node) (SchemaRangeRefinement, error)
 			}
 			out.Max = &max
 		default:
-			return SchemaRangeRefinement{}, fmt.Errorf("UNDEFINED-FIELD: range field %q not in platform spec", key)
+			return SchemaRangeRefinement{}, NewUndefinedFieldDiagnostic("range", key, schemaRangeRefinementFieldOptions)
 		}
 	}
 	if out.Min == nil && out.Max == nil {


### PR DESCRIPTION
## Summary
- add `runtime/contracts.LoaderDiagnostic` as the typed owner for pre-bootverify contract-loader diagnostics (`code`, `location`, `problem`, `remediation`, `valid_options`, `raw_cause`)
- route missing-contracts roots, loader YAML shape failures, undefined loader fields, and selected expected-shape failures through the typed owner
- render loader diagnostics through the shared CLI error formatter for verify/describe/bundle/secrets style validation paths, and return structured loader diagnostics from bundle registration API invalid-param details

## Governing refs/context
- Closes #1874
- Approved gate: #1874 lead gate `approved as first slice` for `contract_loader.pre_bootverify_diagnostic_authority`
- `platform-spec.yaml` `cli_specification.foundations.output_contract.diagnostic_convention`: user-facing diagnostics use author-facing problem/remediation, raw causes only as secondary/debug evidence
- `platform-spec.yaml` `cli_specification.foundations.stdout_stderr_boundary`: CLI failures remain stderr text; this PR does not add a JSON error body for failed `--json` commands
- `platform-spec.yaml` `contract_formats.file_layout` / `minimum_flow_package` and `flow_package.manifest_self_facts`: package/schema layout and strict manifest field authority

## Semantic migration
- New canonical owner: `internal/runtime/contracts.LoaderDiagnostic` and constructors/classifiers in `loader_diagnostics.go`
- Old producer/reader paths now invalid for this class: raw `parse <file>: yaml...` loader headlines, raw `contracts.ProjectFlowRef` YAML type errors, raw `UNDEFINED-FIELD` display for migrated loader field sets, and string-only missing `package.yaml` / contracts-path errors
- Production paths checked/migrated: `loadYAMLFile`, package manifest strict fields, handler/action/input-output pin field owners, `swarm verify`, `swarm describe`, validation-error paths shared by bundle/secrets/test-style commands, and bundle registration projection/API invalid-param details
- Migration complete for the approved first-slice class; broader source-mapped line/column diagnostics remain tracked by #1746 and whole-command output conformance remains tracked by #1821

## Tests
- `SWARM_TEST_POSTGRES_DSN='host=127.0.0.1 port=5432 user=youmew dbname=postgres sslmode=disable' PGPASSWORD=postgres go test ./internal/runtime/contracts ./cmd/swarm ./internal/apiv1`
- `SWARM_TEST_POSTGRES_DSN='host=127.0.0.1 port=5432 user=youmew dbname=postgres sslmode=disable' PGPASSWORD=postgres go test ./...`