### PR TITLE
[agent-f][issue #1876] Add Slack managed connector pack

### DIFF
--- a/cmd/swarm/doctor_test.go
+++ b/cmd/swarm/doctor_test.go
@@ -11,8 +11,10 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 
 	runtimecredentials "github.com/division-sh/swarm/internal/runtime/credentials"
+	runtimemanagedcredentials "github.com/division-sh/swarm/internal/runtime/managedcredentials"
 	storebackend "github.com/division-sh/swarm/internal/store/backendselection"
 	"gopkg.in/yaml.v3"
 )
@@ -38,6 +40,21 @@ func setDoctorProviderSecrets(t *testing.T, values map[string]string) {
 	for key, value := range values {
 		if err := store.Set(context.Background(), key, value); err != nil {
 			t.Fatalf("Set provider credential: %v", err)
+		}
+	}
+}
+
+func setDoctorManagedCredentials(t *testing.T, records ...runtimemanagedcredentials.Record) {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "managed-credentials.json")
+	t.Setenv("SWARM_MANAGED_CREDENTIALS_FILE", path)
+	store, err := runtimemanagedcredentials.NewFileStore(path)
+	if err != nil {
+		t.Fatalf("NewFileStore managed credentials: %v", err)
+	}
+	for _, record := range records {
+		if err := store.Put(context.Background(), record); err != nil {
+			t.Fatalf("Put managed credential: %v", err)
 		}
 	}
 }
@@ -228,6 +245,63 @@ func TestDoctorClaudeCLIPreflightReportsTelegramConnectorToolSurface(t *testing.
 	}
 	if strings.Contains(stdout.String(), "provider-secret") {
 		t.Fatalf("doctor report leaked provider secret:\n%s", stdout.String())
+	}
+}
+
+func TestDoctorClaudeCLIPreflightReportsSlackManagedConnectorPackSurface(t *testing.T) {
+	t.Setenv("CLAUDE_CODE_OAUTH_TOKEN", "")
+	t.Setenv("SWARM_TOOL_GATEWAY_URL", "")
+	t.Setenv("SWARM_TOOL_GATEWAY_CONTAINER_URL", "")
+	t.Setenv("SWARM_TOOL_GATEWAY_TOKEN", "")
+	setDoctorEmptyProviderSecrets(t)
+	setDoctorManagedCredentials(t, runtimemanagedcredentials.Record{
+		Key:          "slack_oauth",
+		Provider:     "slack",
+		GrantType:    runtimemanagedcredentials.GrantAuthorizationCodePKCE,
+		TokenURL:     "https://slack.com/api/oauth.v2.access",
+		ClientID:     "client-id",
+		ClientSecret: "client-secret",
+		Scopes:       []string{"chat:write"},
+		AccessToken:  "xoxb-secret",
+		RefreshToken: "refresh-secret",
+		Status:       runtimemanagedcredentials.StatusConnected,
+		ExpiresAt:    time.Now().Add(time.Hour),
+	})
+
+	args := doctorClaudeArgs(t, writeDoctorClaudeConfig(t, ""), true)
+	for i := 0; i+1 < len(args); i++ {
+		if args[i] == "--contracts" {
+			args[i+1] = writeDoctorSlackConnectorPackContractsFixture(t)
+			break
+		}
+	}
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), repoRoot(), args, &stdout, &stderr, defaultRootCommandOptions())
+	if code != 0 {
+		t.Fatalf("code = %d stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	var report localPreflightReport
+	if err := json.Unmarshal(stdout.Bytes(), &report); err != nil {
+		t.Fatalf("parse doctor json: %v\n%s", err, stdout.String())
+	}
+	if !localPreflightReportHasCode(report, "provider_connector_slack_post_message") {
+		t.Fatalf("report missing slack connector finding: %#v", report.Findings)
+	}
+	for _, want := range []string{
+		"CAN post Slack messages via slack.com",
+		"CAN lower through platform.activity_requested",
+		"CAN journal non-idempotent attempts in activity_attempts",
+		"CANNOT expose credential values",
+		"requires managed_credential:slack_oauth=CONNECTED",
+	} {
+		if !localPreflightReportFindingContains(report, "provider_connector_slack_post_message", want) {
+			t.Fatalf("slack connector finding missing %q: %#v", want, report.Findings)
+		}
+	}
+	for _, secret := range []string{"xoxb-secret", "refresh-secret", "client-secret"} {
+		if strings.Contains(stdout.String(), secret) {
+			t.Fatalf("doctor report leaked managed credential secret %q:\n%s", secret, stdout.String())
+		}
 	}
 }
 
@@ -1064,6 +1138,23 @@ telegram.send_message:
       chat_id: "{{input.chat_id}}"
       text: "{{input.text}}"
 `)
+	return root
+}
+
+func writeDoctorSlackConnectorPackContractsFixture(t *testing.T) string {
+	t.Helper()
+	root := writeDoctorAgentFreeContractsFixture(t)
+	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "package.yaml"), `
+name: agent-free-doctor
+version: "1.0.0"
+platform_version: ">=0.7.0 <0.8.0"
+connector_packs:
+  imports:
+    - provider: slack
+      tool: slack.post_message
+flows: []
+`)
+	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "tools.yaml"), "{}\n")
 	return root
 }
 

--- a/cmd/swarm/provider_connector_tools.go
+++ b/cmd/swarm/provider_connector_tools.go
@@ -33,7 +33,15 @@ func appendProviderConnectorToolSurfaceFindings(ctx context.Context, report *loc
 		report.add(localPreflightProviderPackPrerequisite, "provider_connector_credential_store_unavailable", localPreflightSeverityBlocker, localPreflightStatusFailed, err.Error(), "fix the local credential store used by swarm secrets")
 		return
 	}
-	surfaces, err := providerconnectors.Surfaces(ctx, source, store)
+	managedStore, err := buildManagedCredentialStore()
+	if err != nil {
+		report.add(localPreflightProviderPackPrerequisite, "provider_connector_managed_credential_store_unavailable", localPreflightSeverityBlocker, localPreflightStatusFailed, err.Error(), "fix the local managed credential store used by swarm connections")
+		return
+	}
+	surfaces, err := providerconnectors.SurfacesWithOptions(ctx, source, providerconnectors.SurfaceOptions{
+		StaticCredentials:  store,
+		ManagedCredentials: managedStore,
+	})
 	if err != nil {
 		report.add(localPreflightProviderPackPrerequisite, "provider_connector_surface_failed", localPreflightSeverityBlocker, localPreflightStatusFailed, err.Error(), "fix provider connector tool declarations")
 		return
@@ -80,10 +88,16 @@ func formatProviderConnectorRequirements(requirements []providerconnectors.Requi
 	parts := make([]string, 0, len(requirements))
 	for _, requirement := range requirements {
 		status := "UNBOUND"
-		if requirement.Bound {
+		if strings.TrimSpace(requirement.Status) != "" {
+			status = strings.TrimSpace(requirement.Status)
+		} else if requirement.Bound {
 			status = "BOUND"
 		}
-		parts = append(parts, strings.TrimSpace(requirement.Name)+"="+status)
+		name := strings.TrimSpace(requirement.Name)
+		if strings.TrimSpace(requirement.Kind) == "managed_credential" {
+			name = "managed_credential:" + name
+		}
+		parts = append(parts, name+"="+status)
 	}
 	return strings.Join(parts, "; ")
 }

--- a/internal/packs/envelope.go
+++ b/internal/packs/envelope.go
@@ -63,7 +63,8 @@ type CanCapabilities struct {
 }
 
 type Requires struct {
-	Secrets []string `yaml:"secrets" json:"secrets"`
+	Secrets            []string `yaml:"secrets" json:"secrets"`
+	ManagedCredentials []string `yaml:"managed_credentials" json:"managed_credentials"`
 }
 
 type Loaded struct {
@@ -73,8 +74,10 @@ type Loaded struct {
 }
 
 type RequirementStatus struct {
-	Name  string
-	Bound bool
+	Kind   string
+	Name   string
+	Status string
+	Bound  bool
 }
 
 type CapabilitySurface struct {
@@ -279,6 +282,17 @@ func (r Requires) Validate(packID string) error {
 		}
 		seen[secret] = struct{}{}
 	}
+	managedSeen := map[string]struct{}{}
+	for _, credential := range r.ManagedCredentials {
+		credential = strings.TrimSpace(credential)
+		if credential == "" {
+			return fmt.Errorf("pack %q requires.managed_credentials must not contain empty entries", packID)
+		}
+		if _, exists := managedSeen[credential]; exists {
+			return fmt.Errorf("pack %q requires.managed_credentials contains duplicate %q", packID, credential)
+		}
+		managedSeen[credential] = struct{}{}
+	}
 	return nil
 }
 
@@ -291,6 +305,10 @@ func RequiresEqual(a, b Requires) bool {
 }
 
 func (e Envelope) Surface(boundSecrets map[string]bool) CapabilitySurface {
+	return e.SurfaceWithRequirements(boundSecrets, nil)
+}
+
+func (e Envelope) SurfaceWithRequirements(boundSecrets, boundManagedCredentials map[string]bool) CapabilitySurface {
 	can := []string{}
 	switch strings.TrimSpace(e.Type) {
 	case TypeConnector:
@@ -315,12 +333,29 @@ func (e Envelope) Surface(boundSecrets map[string]bool) CapabilitySurface {
 	}
 	cannot := append([]string(nil), e.Capabilities.Cannot...)
 	sort.Strings(cannot)
-	requirements := make([]RequirementStatus, 0, len(e.Requires.Secrets))
+	requirements := make([]RequirementStatus, 0, len(e.Requires.Secrets)+len(e.Requires.ManagedCredentials))
 	for _, secret := range e.Requires.Secrets {
 		secret = strings.TrimSpace(secret)
-		requirements = append(requirements, RequirementStatus{Name: secret, Bound: boundSecrets[secret]})
+		bound := boundSecrets[secret]
+		status := "UNBOUND"
+		if bound {
+			status = "BOUND"
+		}
+		requirements = append(requirements, RequirementStatus{Kind: "secret", Name: secret, Status: status, Bound: bound})
+	}
+	for _, credential := range e.Requires.ManagedCredentials {
+		credential = strings.TrimSpace(credential)
+		bound := boundManagedCredentials[credential]
+		status := "UNBOUND"
+		if bound {
+			status = "CONNECTED"
+		}
+		requirements = append(requirements, RequirementStatus{Kind: "managed_credential", Name: credential, Status: status, Bound: bound})
 	}
 	sort.Slice(requirements, func(i, j int) bool {
+		if requirements[i].Kind != requirements[j].Kind {
+			return requirements[i].Kind < requirements[j].Kind
+		}
 		return requirements[i].Name < requirements[j].Name
 	})
 	return CapabilitySurface{Can: can, Cannot: cannot, Requires: requirements}

--- a/internal/providerconnectors/packs.go
+++ b/internal/providerconnectors/packs.go
@@ -220,23 +220,36 @@ func DerivedCapabilities(manifest ConnectorManifest) packs.Capabilities {
 }
 
 func DerivedRequires(manifest ConnectorManifest) packs.Requires {
-	seen := map[string]struct{}{}
+	seenSecrets := map[string]struct{}{}
+	seenManaged := map[string]struct{}{}
 	var secrets []string
+	var managedCredentials []string
 	for _, toolID := range manifestToolNames(manifest) {
-		for _, credential := range manifest.Tools[toolID].Credentials {
+		tool := manifest.Tools[toolID]
+		for _, credential := range tool.Credentials {
 			credential = strings.TrimSpace(credential)
 			if credential == "" {
 				continue
 			}
-			if _, exists := seen[credential]; exists {
+			if _, exists := seenSecrets[credential]; exists {
 				continue
 			}
-			seen[credential] = struct{}{}
+			seenSecrets[credential] = struct{}{}
 			secrets = append(secrets, credential)
+		}
+		if tool.ManagedCredential != nil {
+			credential := strings.TrimSpace(tool.ManagedCredential.Key)
+			if credential != "" {
+				if _, exists := seenManaged[credential]; !exists {
+					seenManaged[credential] = struct{}{}
+					managedCredentials = append(managedCredentials, credential)
+				}
+			}
 		}
 	}
 	sort.Strings(secrets)
-	return packs.Requires{Secrets: secrets}
+	sort.Strings(managedCredentials)
+	return packs.Requires{Secrets: secrets, ManagedCredentials: managedCredentials}
 }
 
 func SourceWithConnectorPackImports(source semanticview.Source) (semanticview.Source, error) {

--- a/internal/providerconnectors/packs/slack/connector.yaml
+++ b/internal/providerconnectors/packs/slack/connector.yaml
@@ -1,0 +1,32 @@
+provider: slack
+tools:
+  slack.post_message:
+    category: provider_connector
+    description: post Slack messages
+    handler_type: http
+    effect_class: non_idempotent_write
+    managed_credential:
+      key: slack_oauth
+      scopes:
+        - chat:write
+    input_schema:
+      type: object
+      properties:
+        channel:
+          type: string
+        text:
+          type: string
+      required:
+        - channel
+        - text
+    output_schema:
+      type: object
+    response_success:
+      path: response.body.ok
+      equals: true
+    http:
+      method: POST
+      url: https://slack.com/api/chat.postMessage
+      body:
+        channel: "{{input.channel}}"
+        text: "{{input.text}}"

--- a/internal/providerconnectors/packs/slack/pack.yaml
+++ b/internal/providerconnectors/packs/slack/pack.yaml
@@ -1,0 +1,22 @@
+id: provider.slack.connector
+version: 0.1.0
+platform_version: ">=0.7.0 <0.8.0"
+type: connector
+manifest_hash: sha256:7222305e4ec813fa7eb6ecc8c2b9154fae6d9ec9f5fea1a20f75e31f20c1bfa4
+provenance:
+  source: platform
+capabilities:
+  can:
+    call_provider_action: slack.post_message
+    lower_through_activity: true
+    journal_activity_attempts: true
+  cannot:
+    - bypass activity_attempts
+    - retry non_idempotent_write automatically
+    - expose credential values
+requires:
+  managed_credentials:
+    - slack_oauth
+tests:
+  - providerconnectors/slack_pack
+  - runtime/slack_connector_managed_credential_supported_surface

--- a/internal/providerconnectors/providerconnectors.go
+++ b/internal/providerconnectors/providerconnectors.go
@@ -10,14 +10,17 @@ import (
 
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
 	runtimecredentials "github.com/division-sh/swarm/internal/runtime/credentials"
+	runtimemanagedcredentials "github.com/division-sh/swarm/internal/runtime/managedcredentials"
 	"github.com/division-sh/swarm/internal/runtime/semanticview"
 )
 
 const Category = "provider_connector"
 
 type RequirementStatus struct {
-	Name  string
-	Bound bool
+	Kind   string
+	Name   string
+	Status string
+	Bound  bool
 }
 
 type Surface struct {
@@ -29,6 +32,11 @@ type Surface struct {
 	Can          []string
 	Cannot       []string
 	Requires     []RequirementStatus
+}
+
+type SurfaceOptions struct {
+	StaticCredentials  runtimecredentials.Store
+	ManagedCredentials runtimemanagedcredentials.Store
 }
 
 func ValidateSource(source semanticview.Source) []error {
@@ -54,6 +62,10 @@ func ValidateSource(source semanticview.Source) []error {
 }
 
 func Surfaces(ctx context.Context, source semanticview.Source, store runtimecredentials.Store) ([]Surface, error) {
+	return SurfacesWithOptions(ctx, source, SurfaceOptions{StaticCredentials: store})
+}
+
+func SurfacesWithOptions(ctx context.Context, source semanticview.Source, opts SurfaceOptions) ([]Surface, error) {
 	if source == nil {
 		return nil, nil
 	}
@@ -69,7 +81,7 @@ func Surfaces(ctx context.Context, source semanticview.Source, store runtimecred
 		if !isProviderConnector(tool) {
 			continue
 		}
-		surface, err := surfaceForTool(ctx, source, name, tool, store)
+		surface, err := surfaceForTool(ctx, source, name, tool, opts)
 		if err != nil {
 			return nil, err
 		}
@@ -110,19 +122,123 @@ func validateTool(toolID string, tool runtimecontracts.ToolSchemaEntry) []error 
 	if effectClass != runtimecontracts.ActivityEffectClassNonIdempotentWrite {
 		errs = append(errs, fmt.Errorf("%s effect_class must be non_idempotent_write for the Stage 1 connector proof", context))
 	}
-	if len(tool.Credentials) == 0 {
-		errs = append(errs, fmt.Errorf("%s must declare at least one static credential binding", context))
+	hasStaticCredentials := len(tool.Credentials) > 0
+	hasManagedCredential := tool.ManagedCredential != nil
+	if hasStaticCredentials && hasManagedCredential {
+		errs = append(errs, fmt.Errorf("%s must not declare both static credentials and managed_credential; connector auth has one authoritative credential mode", context))
+	} else if !hasStaticCredentials && !hasManagedCredential {
+		errs = append(errs, fmt.Errorf("%s must declare exactly one credential binding mode: static credentials or managed_credential", context))
 	}
-	if tool.ManagedCredential != nil {
-		errs = append(errs, fmt.Errorf("%s uses managed_credential; managed credential connector execution is split", context))
+	if hasManagedCredential {
+		key := strings.TrimSpace(tool.ManagedCredential.Key)
+		if key == "" {
+			errs = append(errs, fmt.Errorf("%s managed_credential.key is required", context))
+		}
 	}
 	if len(tool.ResponseMapping) > 0 {
 		errs = append(errs, fmt.Errorf("%s uses response_mapping; connector activity response mapping is split", context))
+	}
+	if tool.ResponseSuccess != nil {
+		errs = append(errs, validateResponseSuccess(context, *tool.ResponseSuccess)...)
+	}
+	if required, ok := requiredResponseSuccessForProviderAction(provider, action); ok {
+		if tool.ResponseSuccess == nil {
+			errs = append(errs, fmt.Errorf("%s must declare response_success %s == %s; this provider action can return HTTP 2xx for provider-level failure", context, required.Path, asConnectorScalar(required.Equals)))
+		} else if !responseSuccessMatches(*tool.ResponseSuccess, required) {
+			errs = append(errs, fmt.Errorf("%s response_success must be %s == %s for this provider action", context, required.Path, asConnectorScalar(required.Equals)))
+		}
 	}
 	if strings.TrimSpace(tool.RateLimit) != "" || strings.TrimSpace(tool.RateLimitMaxWait) != "" {
 		errs = append(errs, fmt.Errorf("%s uses rate_limit; connector activity rate-limit admission is split", context))
 	}
 	return errs
+}
+
+func validateResponseSuccess(context string, check runtimecontracts.HTTPResponseSuccess) []error {
+	path := strings.TrimSpace(check.Path)
+	var errs []error
+	if path == "" {
+		errs = append(errs, fmt.Errorf("%s response_success.path is required", context))
+	} else if !strings.HasPrefix(path, "response.") {
+		errs = append(errs, fmt.Errorf("%s response_success.path must start with response.", context))
+	}
+	if check.Equals == nil {
+		errs = append(errs, fmt.Errorf("%s response_success.equals is required", context))
+	} else if !responseSuccessScalar(check.Equals) {
+		errs = append(errs, fmt.Errorf("%s response_success.equals must be a scalar value", context))
+	}
+	return errs
+}
+
+func responseSuccessScalar(value any) bool {
+	switch value.(type) {
+	case string, bool, int, int64, float64, float32, uint, uint64:
+		return true
+	default:
+		return false
+	}
+}
+
+func requiredResponseSuccessForProviderAction(provider, action string) (runtimecontracts.HTTPResponseSuccess, bool) {
+	switch normalizeToken(provider) + "." + normalizeToken(action) {
+	case "slack.post_message":
+		return runtimecontracts.HTTPResponseSuccess{Path: "response.body.ok", Equals: true}, true
+	default:
+		return runtimecontracts.HTTPResponseSuccess{}, false
+	}
+}
+
+func responseSuccessMatches(got, want runtimecontracts.HTTPResponseSuccess) bool {
+	return strings.TrimSpace(got.Path) == strings.TrimSpace(want.Path) && responseSuccessValuesEqual(got.Equals, want.Equals)
+}
+
+func responseSuccessValuesEqual(got, want any) bool {
+	switch wantTyped := want.(type) {
+	case bool:
+		gotTyped, ok := got.(bool)
+		return ok && gotTyped == wantTyped
+	case string:
+		gotTyped, ok := got.(string)
+		return ok && gotTyped == wantTyped
+	case int:
+		gotFloat, ok := responseSuccessFloat(got)
+		return ok && gotFloat == float64(wantTyped)
+	case int64:
+		gotFloat, ok := responseSuccessFloat(got)
+		return ok && gotFloat == float64(wantTyped)
+	case float64:
+		gotFloat, ok := responseSuccessFloat(got)
+		return ok && gotFloat == wantTyped
+	case float32:
+		gotFloat, ok := responseSuccessFloat(got)
+		return ok && gotFloat == float64(wantTyped)
+	default:
+		return fmt.Sprint(got) == fmt.Sprint(want)
+	}
+}
+
+func responseSuccessFloat(value any) (float64, bool) {
+	switch typed := value.(type) {
+	case int:
+		return float64(typed), true
+	case int64:
+		return float64(typed), true
+	case float64:
+		return typed, true
+	case float32:
+		return float64(typed), true
+	default:
+		return 0, false
+	}
+}
+
+func asConnectorScalar(value any) string {
+	switch typed := value.(type) {
+	case string:
+		return typed
+	default:
+		return fmt.Sprint(typed)
+	}
 }
 
 func validateProviderConnectorAgentExposure(source semanticview.Source) []error {
@@ -153,7 +269,7 @@ func validateProviderConnectorAgentExposure(source semanticview.Source) []error 
 	return errs
 }
 
-func surfaceForTool(ctx context.Context, source semanticview.Source, toolID string, tool runtimecontracts.ToolSchemaEntry, store runtimecredentials.Store) (Surface, error) {
+func surfaceForTool(ctx context.Context, source semanticview.Source, toolID string, tool runtimecontracts.ToolSchemaEntry, opts SurfaceOptions) (Surface, error) {
 	provider, action, _ := splitToolID(toolID)
 	host := ""
 	if tool.HTTP != nil {
@@ -162,7 +278,7 @@ func surfaceForTool(ctx context.Context, source semanticview.Source, toolID stri
 			host = strings.TrimSpace(parsed.Host)
 		}
 	}
-	requires := make([]RequirementStatus, 0, len(tool.Credentials))
+	requires := make([]RequirementStatus, 0, len(tool.Credentials)+1)
 	flowID, err := connectorToolFlowID(source, toolID, tool)
 	if err != nil {
 		return Surface{}, err
@@ -177,16 +293,53 @@ func surfaceForTool(ctx context.Context, source semanticview.Source, toolID stri
 			storeKey = strings.TrimSpace(resolved)
 		}
 		bound := false
-		if store != nil && storeKey != "" {
-			_, ok, err := store.Get(ctx, storeKey)
+		if opts.StaticCredentials != nil && storeKey != "" {
+			_, ok, err := opts.StaticCredentials.Get(ctx, storeKey)
 			if err != nil {
 				return Surface{}, err
 			}
 			bound = ok
 		}
-		requires = append(requires, RequirementStatus{Name: key, Bound: bound})
+		status := "UNBOUND"
+		if bound {
+			status = "BOUND"
+		}
+		requires = append(requires, RequirementStatus{Kind: "secret", Name: key, Status: status, Bound: bound})
+	}
+	if tool.ManagedCredential != nil {
+		key := strings.TrimSpace(tool.ManagedCredential.Key)
+		if key != "" {
+			storeKey := key
+			if resolved, mapped := semanticview.CredentialStoreKeyForFlow(source, flowID, key); mapped {
+				storeKey = strings.TrimSpace(resolved)
+			}
+			status := "UNBOUND"
+			bound := false
+			if opts.ManagedCredentials != nil && strings.TrimSpace(storeKey) != "" {
+				record, ok, err := opts.ManagedCredentials.Get(ctx, storeKey)
+				if err != nil {
+					return Surface{}, err
+				}
+				if ok {
+					desc := record.Descriptor()
+					status = strings.ToUpper(strings.TrimSpace(desc.Status))
+					bound = desc.Status == runtimemanagedcredentials.StatusConnected
+					if bound && !managedCredentialScopesCover(desc.Scopes, tool.ManagedCredential.Scopes) {
+						status = strings.ToUpper(runtimemanagedcredentials.StatusScopeInsufficient)
+						bound = false
+					}
+				}
+			}
+			if strings.TrimSpace(status) == "" {
+				status = "UNBOUND"
+			}
+			requires = append(requires, RequirementStatus{Kind: "managed_credential", Name: key, Status: status, Bound: bound})
+		}
 	}
 	sort.Slice(requires, func(i, j int) bool {
+		if requires[i].Kind != requires[j].Kind {
+			return requires[i].Kind < requires[j].Kind
+		}
 		return requires[i].Name < requires[j].Name
 	})
 	actionLabel := connectorActionLabel(provider, action, tool)
@@ -209,6 +362,43 @@ func surfaceForTool(ctx context.Context, source semanticview.Source, toolID stri
 		},
 		Requires: requires,
 	}, nil
+}
+
+func managedCredentialScopesCover(actual, required []string) bool {
+	if len(required) == 0 {
+		return true
+	}
+	have := map[string]struct{}{}
+	for _, scope := range normalizeStringSet(actual) {
+		have[scope] = struct{}{}
+	}
+	for _, scope := range normalizeStringSet(required) {
+		if _, ok := have[scope]; !ok {
+			return false
+		}
+	}
+	return true
+}
+
+func normalizeStringSet(values []string) []string {
+	if len(values) == 0 {
+		return nil
+	}
+	seen := map[string]struct{}{}
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		out = append(out, value)
+	}
+	sort.Strings(out)
+	return out
 }
 
 func connectorToolFlowID(source semanticview.Source, toolID string, tool runtimecontracts.ToolSchemaEntry) (string, error) {

--- a/internal/providerconnectors/providerconnectors_test.go
+++ b/internal/providerconnectors/providerconnectors_test.go
@@ -9,9 +9,11 @@ import (
 	"strings"
 	"testing"
 	"testing/fstest"
+	"time"
 
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
 	runtimecredentials "github.com/division-sh/swarm/internal/runtime/credentials"
+	runtimemanagedcredentials "github.com/division-sh/swarm/internal/runtime/managedcredentials"
 	"github.com/division-sh/swarm/internal/runtime/semanticview"
 )
 
@@ -46,13 +48,73 @@ func TestValidateSourceRejectsUnsupportedProviderConnectorShape(t *testing.T) {
 	joined := joinErrors(errs)
 	for _, want := range []string{
 		"effect_class must be non_idempotent_write",
-		"must declare at least one static credential binding",
+		"must declare exactly one credential binding mode",
 		"uses response_mapping",
 		"uses rate_limit",
 	} {
 		if !strings.Contains(joined, want) {
 			t.Fatalf("ValidateSource errors = %q, want %q", joined, want)
 		}
+	}
+}
+
+func TestValidateSourceAcceptsSlackManagedCredentialProviderConnectorHTTPActivityTool(t *testing.T) {
+	source := semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
+		Tools: map[string]runtimecontracts.ToolSchemaEntry{
+			"slack.post_message": slackConnectorTool("https://slack.com/api/chat.postMessage"),
+		},
+	})
+
+	if errs := ValidateSource(source); len(errs) != 0 {
+		t.Fatalf("ValidateSource errors = %#v, want none", errs)
+	}
+}
+
+func TestValidateSourceRejectsMixedStaticAndManagedProviderConnectorCredentials(t *testing.T) {
+	tool := slackConnectorTool("https://slack.com/api/chat.postMessage")
+	tool.Credentials = []string{"slack_bot_token"}
+	source := semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
+		Tools: map[string]runtimecontracts.ToolSchemaEntry{
+			"slack.post_message": tool,
+		},
+	})
+
+	errs := ValidateSource(source)
+	joined := joinErrors(errs)
+	if !strings.Contains(joined, "must not declare both static credentials and managed_credential") {
+		t.Fatalf("ValidateSource errors = %q, want mixed auth rejection", joined)
+	}
+}
+
+func TestValidateSourceRejectsSlackPostMessageWithoutRequiredResponseSuccess(t *testing.T) {
+	tool := slackConnectorTool("https://slack.com/api/chat.postMessage")
+	tool.ResponseSuccess = nil
+	source := semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
+		Tools: map[string]runtimecontracts.ToolSchemaEntry{
+			"slack.post_message": tool,
+		},
+	})
+
+	errs := ValidateSource(source)
+	joined := joinErrors(errs)
+	if !strings.Contains(joined, "must declare response_success response.body.ok == true") {
+		t.Fatalf("ValidateSource errors = %q, want required Slack response_success rejection", joined)
+	}
+}
+
+func TestValidateSourceRejectsMalformedProviderConnectorResponseSuccess(t *testing.T) {
+	tool := slackConnectorTool("https://slack.com/api/chat.postMessage")
+	tool.ResponseSuccess = &runtimecontracts.HTTPResponseSuccess{Path: "body.ok", Equals: true}
+	source := semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
+		Tools: map[string]runtimecontracts.ToolSchemaEntry{
+			"slack.post_message": tool,
+		},
+	})
+
+	errs := ValidateSource(source)
+	joined := joinErrors(errs)
+	if !strings.Contains(joined, "response_success.path must start with response.") {
+		t.Fatalf("ValidateSource errors = %q, want response_success path rejection", joined)
 	}
 }
 
@@ -70,6 +132,75 @@ func TestValidateSourceRejectsAgentExposureOfProviderConnector(t *testing.T) {
 	joined := joinErrors(errs)
 	if !strings.Contains(joined, `agent "sender" must not expose provider connector tool "telegram.send_message" directly`) {
 		t.Fatalf("ValidateSource errors = %q, want direct exposure rejection", joined)
+	}
+}
+
+func TestSurfacesReportManagedCredentialRequirementsWithoutSecretValues(t *testing.T) {
+	ctx := context.Background()
+	source := semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
+		Tools: map[string]runtimecontracts.ToolSchemaEntry{
+			"slack.post_message": slackConnectorTool("https://slack.com/api/chat.postMessage"),
+		},
+	})
+	store := runtimemanagedcredentials.NewMemoryStore(runtimemanagedcredentials.Record{
+		Key:          "slack_oauth",
+		Provider:     "slack",
+		GrantType:    runtimemanagedcredentials.GrantAuthorizationCodePKCE,
+		TokenURL:     "https://slack.com/api/oauth.v2.access",
+		ClientID:     "client-id",
+		ClientSecret: "client-secret",
+		Scopes:       []string{"chat:write"},
+		AccessToken:  "xoxb-access-secret",
+		RefreshToken: "refresh-secret",
+		Status:       runtimemanagedcredentials.StatusConnected,
+		ExpiresAt:    time.Now().Add(time.Hour),
+	})
+
+	surfaces, err := SurfacesWithOptions(ctx, source, SurfaceOptions{ManagedCredentials: store})
+	if err != nil {
+		t.Fatalf("SurfacesWithOptions: %v", err)
+	}
+	if len(surfaces) != 1 {
+		t.Fatalf("surfaces = %#v, want one", surfaces)
+	}
+	requires := surfaces[0].Requires
+	if len(requires) != 1 || requires[0].Kind != "managed_credential" || requires[0].Name != "slack_oauth" || !requires[0].Bound || requires[0].Status != "CONNECTED" {
+		t.Fatalf("requirements = %#v, want connected managed slack_oauth", requires)
+	}
+	rendered := strings.Join(surfaces[0].Can, " ") + strings.Join(surfaces[0].Cannot, " ") + joinRequirementStatuses(requires)
+	for _, secret := range []string{"xoxb-access-secret", "refresh-secret", "client-secret"} {
+		if strings.Contains(rendered, secret) {
+			t.Fatalf("surface leaked managed credential secret %q: %s", secret, rendered)
+		}
+	}
+
+	unbound, err := SurfacesWithOptions(ctx, source, SurfaceOptions{})
+	if err != nil {
+		t.Fatalf("SurfacesWithOptions without store: %v", err)
+	}
+	if len(unbound) != 1 || len(unbound[0].Requires) != 1 || unbound[0].Requires[0].Bound || unbound[0].Requires[0].Status != "UNBOUND" {
+		t.Fatalf("unbound managed requirements = %#v", unbound)
+	}
+
+	insufficient := runtimemanagedcredentials.NewMemoryStore(runtimemanagedcredentials.Record{
+		Key:          "slack_oauth",
+		Provider:     "slack",
+		GrantType:    runtimemanagedcredentials.GrantAuthorizationCodePKCE,
+		TokenURL:     "https://slack.com/api/oauth.v2.access",
+		ClientID:     "client-id",
+		ClientSecret: "client-secret",
+		Scopes:       []string{"channels:read"},
+		AccessToken:  "xoxb-access-secret",
+		RefreshToken: "refresh-secret",
+		Status:       runtimemanagedcredentials.StatusConnected,
+		ExpiresAt:    time.Now().Add(time.Hour),
+	})
+	scopeSurfaces, err := SurfacesWithOptions(ctx, source, SurfaceOptions{ManagedCredentials: insufficient})
+	if err != nil {
+		t.Fatalf("SurfacesWithOptions insufficient scopes: %v", err)
+	}
+	if len(scopeSurfaces) != 1 || len(scopeSurfaces[0].Requires) != 1 || scopeSurfaces[0].Requires[0].Bound || scopeSurfaces[0].Requires[0].Status != "SCOPE_INSUFFICIENT" {
+		t.Fatalf("scope-insufficient managed requirements = %#v, want SCOPE_INSUFFICIENT unbound", scopeSurfaces)
 	}
 }
 
@@ -193,6 +324,28 @@ func TestDefaultPackRegistryLoadsTelegramFromVerifiedPlatformPack(t *testing.T) 
 	}
 }
 
+func TestDefaultPackRegistryLoadsSlackManagedCredentialPack(t *testing.T) {
+	tool, ok := BuiltinTool("slack", "slack.post_message")
+	if !ok {
+		t.Fatal("BuiltinTool slack.post_message not found")
+	}
+	if !isProviderConnector(tool) {
+		t.Fatalf("builtin slack tool category = %q, want %q", tool.Category, Category)
+	}
+	if tool.ManagedCredential == nil || tool.ManagedCredential.Key != "slack_oauth" {
+		t.Fatalf("builtin slack managed credential = %#v, want slack_oauth", tool.ManagedCredential)
+	}
+	if tool.ResponseSuccess == nil || tool.ResponseSuccess.Path != "response.body.ok" || tool.ResponseSuccess.Equals != true {
+		t.Fatalf("builtin slack response_success = %#v, want response.body.ok true", tool.ResponseSuccess)
+	}
+	if len(tool.Credentials) != 0 {
+		t.Fatalf("builtin slack static credentials = %#v, want none", tool.Credentials)
+	}
+	if strings.Contains(tool.HTTP.URL, "xoxb") || strings.Contains(tool.HTTP.URL, "secret") {
+		t.Fatal("builtin slack tool leaked a concrete credential value")
+	}
+}
+
 func TestProviderConnectorPackVerificationFailsClosed(t *testing.T) {
 	tests := []struct {
 		name   string
@@ -256,6 +409,15 @@ func TestProviderConnectorPackVerificationFailsClosed(t *testing.T) {
 	}
 }
 
+func TestSlackConnectorPackRequiresManagedCredentialDriftFailsClosed(t *testing.T) {
+	files := connectorPackTestFS(t, "slack")
+	replaceConnectorPackFile(t, files, "pack.yaml", "slack_oauth", "other_oauth")
+	_, err := LoadPackFS(files, ".", "0.7.0")
+	if err == nil || !strings.Contains(err.Error(), "requires do not match") {
+		t.Fatalf("LoadPackFS error = %v, want managed requires drift failure", err)
+	}
+}
+
 func TestConnectorPackImportRequiresExplicitEnableAndReportsSurface(t *testing.T) {
 	ambient := providerConnectorScopedSource{
 		Source:        semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{}),
@@ -298,6 +460,51 @@ func TestConnectorPackImportRequiresExplicitEnableAndReportsSurface(t *testing.T
 	}
 	if len(surfaces[0].Requires) != 1 || surfaces[0].Requires[0].Name != "telegram_bot_token" || surfaces[0].Requires[0].Bound {
 		t.Fatalf("surface requirements = %#v, want unbound telegram_bot_token", surfaces[0].Requires)
+	}
+}
+
+func TestSlackConnectorPackImportRequiresExplicitEnableAndReportsManagedSurface(t *testing.T) {
+	ambient := providerConnectorScopedSource{
+		Source:        semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{}),
+		projectScopes: []semanticview.ProjectScope{{Key: "."}},
+	}
+	ambientSource, err := SourceWithConnectorPackImports(ambient)
+	if err != nil {
+		t.Fatalf("SourceWithConnectorPackImports ambient: %v", err)
+	}
+	if _, exists := ambientSource.ToolEntries()["slack.post_message"]; exists {
+		t.Fatal("ambient source exposed slack.post_message without explicit import")
+	}
+
+	explicit := providerConnectorScopedSource{
+		Source: semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{}),
+		projectScopes: []semanticview.ProjectScope{
+			projectScopeWithConnectorPackImport(".", "slack", "slack.post_message"),
+		},
+	}
+	source, err := SourceWithConnectorPackImports(explicit)
+	if err != nil {
+		t.Fatalf("SourceWithConnectorPackImports explicit: %v", err)
+	}
+	tool, exists := source.ToolEntries()["slack.post_message"]
+	if !exists {
+		t.Fatal("explicit import did not expose slack.post_message")
+	}
+	if tool.Category != Category || tool.ManagedCredential == nil || tool.ManagedCredential.Key != "slack_oauth" {
+		t.Fatalf("imported tool = %#v, want provider_connector managed slack_oauth", tool)
+	}
+	if errs := ValidateSource(source); len(errs) != 0 {
+		t.Fatalf("ValidateSource imported Slack connector errors = %#v", errs)
+	}
+	surfaces, err := SurfacesWithOptions(context.Background(), source, SurfaceOptions{})
+	if err != nil {
+		t.Fatalf("SurfacesWithOptions: %v", err)
+	}
+	if len(surfaces) != 1 || surfaces[0].ToolID != "slack.post_message" {
+		t.Fatalf("surfaces = %#v, want slack.post_message", surfaces)
+	}
+	if len(surfaces[0].Requires) != 1 || surfaces[0].Requires[0].Kind != "managed_credential" || surfaces[0].Requires[0].Name != "slack_oauth" || surfaces[0].Requires[0].Bound {
+		t.Fatalf("surface requirements = %#v, want unbound managed slack_oauth", surfaces[0].Requires)
 	}
 }
 
@@ -396,6 +603,40 @@ func telegramConnectorTool(baseURL string) runtimecontracts.ToolSchemaEntry {
 	}
 }
 
+func slackConnectorTool(url string) runtimecontracts.ToolSchemaEntry {
+	return runtimecontracts.ToolSchemaEntry{
+		Category:    Category,
+		Description: "post Slack messages",
+		HandlerType: "http",
+		EffectClass: string(runtimecontracts.ActivityEffectClassNonIdempotentWrite),
+		ManagedCredential: &runtimecontracts.ManagedCredentialRef{
+			Key:    "slack_oauth",
+			Scopes: []string{"chat:write"},
+		},
+		InputSchema: runtimecontracts.ToolInputSchema{
+			Type: "object",
+			Properties: map[string]runtimecontracts.ToolInputSchema{
+				"channel": {Type: "string"},
+				"text":    {Type: "string"},
+			},
+			Required: []string{"channel", "text"},
+		},
+		OutputSchema: runtimecontracts.ToolInputSchema{Type: "object"},
+		ResponseSuccess: &runtimecontracts.HTTPResponseSuccess{
+			Path:   "response.body.ok",
+			Equals: true,
+		},
+		HTTP: &runtimecontracts.HTTPToolSpec{
+			Method: "POST",
+			URL:    strings.TrimSpace(url),
+			Body: map[string]any{
+				"channel": "{{input.channel}}",
+				"text":    "{{input.text}}",
+			},
+		},
+	}
+}
+
 func projectScopeWithConnectorPackImport(key, provider, tool string) semanticview.ProjectScope {
 	return semanticview.ProjectScope{
 		Key: key,
@@ -424,7 +665,7 @@ func rewriteConnectorPackHash(t *testing.T, files fstest.MapFS) {
 	t.Helper()
 	sum := sha256.Sum256(files["connector.yaml"].Data)
 	hash := "sha256:" + hex.EncodeToString(sum[:])
-	replaceConnectorPackFile(t, files, "pack.yaml", "manifest_hash: sha256:f983e4df5b934a2322781aac992179b3d520c416e41e70e1963ee29a5bf08026", "manifest_hash: "+hash)
+	replaceConnectorPackHashLine(t, files, hash)
 }
 
 func replaceConnectorPackFile(t *testing.T, files fstest.MapFS, name, old, new string) {
@@ -438,6 +679,20 @@ func replaceConnectorPackFile(t *testing.T, files fstest.MapFS, name, old, new s
 	file.Data = []byte(body)
 }
 
+func replaceConnectorPackHashLine(t *testing.T, files fstest.MapFS, hash string) {
+	t.Helper()
+	file := files["pack.yaml"]
+	lines := strings.Split(string(file.Data), "\n")
+	for i, line := range lines {
+		if strings.HasPrefix(line, "manifest_hash: ") {
+			lines[i] = "manifest_hash: " + hash
+			file.Data = []byte(strings.Join(lines, "\n"))
+			return
+		}
+	}
+	t.Fatal("pack.yaml missing manifest_hash line")
+}
+
 func joinErrors(errs []error) string {
 	parts := make([]string, 0, len(errs))
 	for _, err := range errs {
@@ -446,4 +701,12 @@ func joinErrors(errs []error) string {
 		}
 	}
 	return strings.Join(parts, "\n")
+}
+
+func joinRequirementStatuses(requirements []RequirementStatus) string {
+	parts := make([]string, 0, len(requirements))
+	for _, req := range requirements {
+		parts = append(parts, req.Kind+":"+req.Name+"="+req.Status)
+	}
+	return strings.Join(parts, "; ")
 }

--- a/internal/runtime/activity_validation.go
+++ b/internal/runtime/activity_validation.go
@@ -142,7 +142,15 @@ func validateActivitySpec(source semanticview.Source, flowID, nodeID, handlerEve
 		errs = append(errs, fmt.Errorf("%s: tool %q effect_class %q is not supported for activities", context, toolID, tool.EffectClass))
 	}
 	if tool.ManagedCredential != nil {
-		errs = append(errs, fmt.Errorf("%s: tool %q uses managed_credential; managed credential activity HTTP execution is split until OAuth/token lifecycle ownership is specified", context, toolID))
+		if len(tool.Credentials) > 0 {
+			errs = append(errs, fmt.Errorf("%s: tool %q must not declare both static credentials and managed_credential for activity HTTP execution", context, toolID))
+		}
+		if !strings.EqualFold(strings.TrimSpace(tool.Category), "provider_connector") || effectClass != runtimecontracts.ActivityEffectClassNonIdempotentWrite {
+			errs = append(errs, fmt.Errorf("%s: tool %q uses managed_credential; managed credential activity HTTP execution is supported only for non_idempotent_write provider connector tools", context, toolID))
+		}
+		if strings.TrimSpace(tool.ManagedCredential.Key) == "" {
+			errs = append(errs, fmt.Errorf("%s: tool %q managed_credential.key is required", context, toolID))
+		}
 	}
 	if len(tool.Credentials) > 0 && effectClass != runtimecontracts.ActivityEffectClassNonIdempotentWrite {
 		errs = append(errs, fmt.Errorf("%s: tool %q uses static credentials; static credential activity HTTP execution is supported only for non_idempotent_write authored HTTP activities", context, toolID))

--- a/internal/runtime/contracts/workflow_contract_types.go
+++ b/internal/runtime/contracts/workflow_contract_types.go
@@ -1788,8 +1788,14 @@ type ToolSchemaEntry struct {
 	OutputSchema       ToolInputSchema       `yaml:"output_schema"`
 	HTTP               *HTTPToolSpec         `yaml:"http"`
 	ResponseMapping    map[string]any        `yaml:"response_mapping"`
+	ResponseSuccess    *HTTPResponseSuccess  `yaml:"response_success"`
 	Credentials        []string              `yaml:"credentials"`
 	ManagedCredential  *ManagedCredentialRef `yaml:"managed_credential"`
+}
+
+type HTTPResponseSuccess struct {
+	Path   string `yaml:"path"`
+	Equals any    `yaml:"equals"`
 }
 type PlatformSpecDocument struct {
 	Platform struct {

--- a/internal/runtime/contracts/workflow_contract_yaml_schema.go
+++ b/internal/runtime/contracts/workflow_contract_yaml_schema.go
@@ -271,6 +271,9 @@ func (t *ToolSchemaEntry) UnmarshalYAML(node *yaml.Node) error {
 	t.Permission = strings.TrimSpace(t.Permission)
 	t.RequiredPermission = strings.TrimSpace(t.RequiredPermission)
 	t.Credentials = normalizeStrings(t.Credentials)
+	if t.ResponseSuccess != nil {
+		t.ResponseSuccess.Path = strings.TrimSpace(t.ResponseSuccess.Path)
+	}
 	if t.ManagedCredential != nil {
 		t.ManagedCredential.Key = strings.TrimSpace(t.ManagedCredential.Key)
 		t.ManagedCredential.Header = strings.TrimSpace(t.ManagedCredential.Header)

--- a/internal/runtime/pipeline/activity_engine.go
+++ b/internal/runtime/pipeline/activity_engine.go
@@ -176,6 +176,12 @@ func (d pipelineActivityDispatcher) executeNonIdempotentActivityIntent(ctx conte
 		client = &http.Client{Timeout: 30 * time.Second}
 	}
 	intent.Attempt = 1
+	requestEventID := activityRequestEventID(intent)
+	if existing, ok, err := d.coordinator.workflowStore.LoadActivityAttempt(ctx, requestEventID); err != nil {
+		return d.publishActivityFailure(ctx, intent, err)
+	} else if ok {
+		return d.publishExistingActivityAttempt(ctx, intent, existing)
+	}
 	prepared, err := d.prepareActivityHTTPTool(ctx, client, intent, tool)
 	if err != nil {
 		return d.publishActivityFailure(ctx, intent, err)
@@ -514,15 +520,17 @@ func activityIntentFromRequestEvent(evt events.Event) (runtimeengine.ActivityInt
 }
 
 type preparedActivityHTTPTool struct {
-	toolName  string
-	method    string
-	url       string
-	headers   http.Header
-	body      []byte
-	timeout   time.Duration
-	client    *http.Client
-	secrets   []string
-	inputHash string
+	toolName    string
+	method      string
+	url         string
+	headers     http.Header
+	body        []byte
+	timeout     time.Duration
+	client      *http.Client
+	secrets     []string
+	managedAuth *activityManagedHTTPAuth
+	success     *runtimecontracts.HTTPResponseSuccess
+	inputHash   string
 }
 
 func (d pipelineActivityDispatcher) executeActivityHTTPTool(ctx context.Context, client *http.Client, intent runtimeengine.ActivityIntent, tool runtimecontracts.ToolSchemaEntry) (any, error) {
@@ -543,11 +551,11 @@ func (d pipelineActivityDispatcher) prepareActivityHTTPTool(ctx context.Context,
 	if len(tool.ResponseMapping) > 0 {
 		return preparedActivityHTTPTool{}, fmt.Errorf("activity tool %s uses response_mapping; activity HTTP response mapping is not admitted in Stage 1", intent.Tool)
 	}
-	if tool.ManagedCredential != nil {
-		return preparedActivityHTTPTool{}, fmt.Errorf("activity tool %s uses managed_credential; managed credential activity HTTP execution is not admitted in Stage 1", intent.Tool)
-	}
 	credentials := map[string]any{}
 	secrets := []string{}
+	if len(tool.Credentials) > 0 && tool.ManagedCredential != nil {
+		return preparedActivityHTTPTool{}, fmt.Errorf("activity tool %s must not declare both static credentials and managed_credential", intent.Tool)
+	}
 	if len(tool.Credentials) > 0 {
 		if intent.EffectClass != runtimecontracts.ActivityEffectClassNonIdempotentWrite {
 			return preparedActivityHTTPTool{}, fmt.Errorf("activity tool %s uses static credentials; static credential activity HTTP execution is supported only for non_idempotent_write activities", intent.Tool)
@@ -558,6 +566,11 @@ func (d pipelineActivityDispatcher) prepareActivityHTTPTool(ctx context.Context,
 		}
 		credentials = resolved
 		secrets = secretValues
+	}
+	if tool.ManagedCredential != nil {
+		if intent.EffectClass != runtimecontracts.ActivityEffectClassNonIdempotentWrite || !strings.EqualFold(strings.TrimSpace(tool.Category), "provider_connector") {
+			return preparedActivityHTTPTool{}, fmt.Errorf("activity tool %s uses managed_credential; managed credential activity HTTP execution is supported only for non_idempotent_write provider connector activities", intent.Tool)
+		}
 	}
 	input := cloneStringAnyMap(intent.Input)
 	env := map[string]any{"input": input, "credentials": credentials}
@@ -603,50 +616,277 @@ func (d pipelineActivityDispatcher) prepareActivityHTTPTool(ctx context.Context,
 	if client == nil {
 		client = &http.Client{Timeout: timeout}
 	}
+	managedAuth, err := d.resolveActivityManagedCredential(ctx, client, intent, tool)
+	if err != nil {
+		return preparedActivityHTTPTool{}, redactActivityError(err, secrets)
+	}
+	if managedAuth != nil {
+		if err := applyActivityManagedCredentialHeader(headers, managedAuth, false); err != nil {
+			return preparedActivityHTTPTool{}, redactActivityError(err, append(secrets, managedAuth.SecretValues()...))
+		}
+		secrets = append(secrets, managedAuth.SecretValues()...)
+	}
 	return preparedActivityHTTPTool{
-		toolName:  intent.Tool,
-		method:    method,
-		url:       url,
-		headers:   headers,
-		body:      body,
-		timeout:   timeout,
-		client:    client,
-		secrets:   secrets,
-		inputHash: activityInputHash(input),
+		toolName:    intent.Tool,
+		method:      method,
+		url:         url,
+		headers:     headers,
+		body:        body,
+		timeout:     timeout,
+		client:      client,
+		secrets:     secrets,
+		managedAuth: managedAuth,
+		success:     cloneActivityResponseSuccess(tool.ResponseSuccess),
+		inputHash:   activityInputHash(input),
 	}, nil
 }
 
 func executePreparedActivityHTTPTool(ctx context.Context, prepared preparedActivityHTTPTool) (any, error) {
 	reqCtx, cancel := context.WithTimeout(ctx, prepared.timeout)
 	defer cancel()
-	var body io.Reader
-	if len(prepared.body) > 0 {
-		body = bytes.NewReader(prepared.body)
-	}
-	req, err := http.NewRequestWithContext(reqCtx, prepared.method, prepared.url, body)
-	if err != nil {
-		return nil, redactActivityError(err, prepared.secrets)
-	}
-	for key, values := range prepared.headers {
-		for _, value := range values {
-			req.Header.Add(key, value)
+	refreshedAfterUnauthorized := false
+	for {
+		var body io.Reader
+		if len(prepared.body) > 0 {
+			body = bytes.NewReader(prepared.body)
 		}
+		req, err := http.NewRequestWithContext(reqCtx, prepared.method, prepared.url, body)
+		if err != nil {
+			return nil, redactActivityError(err, prepared.secrets)
+		}
+		for key, values := range prepared.headers {
+			for _, value := range values {
+				req.Header.Add(key, value)
+			}
+		}
+		resp, err := prepared.client.Do(req)
+		if err != nil {
+			return nil, activityHTTPUncertainError{err: redactActivityError(err, prepared.secrets)}
+		}
+		raw, readErr := io.ReadAll(resp.Body)
+		_ = resp.Body.Close()
+		if readErr != nil {
+			return nil, activityHTTPUncertainError{err: redactActivityError(readErr, prepared.secrets)}
+		}
+		parsed := parseHTTPActivityResponse(raw)
+		parsed = runtimemanagedcredentials.RedactValue(parsed, prepared.secrets...)
+		if prepared.managedAuth != nil && resp.StatusCode == http.StatusUnauthorized && !refreshedAfterUnauthorized {
+			refreshedAfterUnauthorized = true
+			token, record, refreshErr := prepared.managedAuth.TokenSource.Refresh(ctx, prepared.managedAuth.StoreKey)
+			if refreshErr != nil {
+				return nil, fmt.Errorf("%s", runtimemanagedcredentials.RedactString(refreshErr.Error(), append(prepared.secrets, record.SecretValues()...)...))
+			}
+			prepared.managedAuth.Token = token
+			prepared.managedAuth.Record = record
+			prepared.secrets = append(prepared.secrets, prepared.managedAuth.SecretValues()...)
+			if err := applyActivityManagedCredentialHeader(prepared.headers, prepared.managedAuth, true); err != nil {
+				return nil, redactActivityError(err, prepared.secrets)
+			}
+			continue
+		}
+		if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+			return nil, fmt.Errorf("activity http tool %s returned status %d: %s", prepared.toolName, resp.StatusCode, strings.TrimSpace(asString(parsed)))
+		}
+		responseEnv := map[string]any{
+			"response": map[string]any{
+				"status":  resp.StatusCode,
+				"headers": flattenActivityHTTPHeaders(resp.Header),
+				"body":    parsed,
+			},
+		}
+		if err := evaluateActivityHTTPResponseSuccess(prepared.toolName, prepared.success, responseEnv, prepared.secrets); err != nil {
+			return nil, err
+		}
+		return parsed, nil
 	}
-	resp, err := prepared.client.Do(req)
+}
+
+func cloneActivityResponseSuccess(check *runtimecontracts.HTTPResponseSuccess) *runtimecontracts.HTTPResponseSuccess {
+	if check == nil {
+		return nil
+	}
+	out := *check
+	return &out
+}
+
+func evaluateActivityHTTPResponseSuccess(toolName string, check *runtimecontracts.HTTPResponseSuccess, responseEnv map[string]any, secrets []string) error {
+	if check == nil {
+		return nil
+	}
+	path := strings.TrimSpace(check.Path)
+	if path == "" {
+		return fmt.Errorf("activity http tool %s response_success.path is required", strings.TrimSpace(toolName))
+	}
+	got, ok := workflowExpressionLookupPath(responseEnv, path)
+	if !ok {
+		return fmt.Errorf("activity http tool %s response_success path %q did not resolve", strings.TrimSpace(toolName), path)
+	}
+	if activityResponseSuccessValuesEqual(got, check.Equals) {
+		return nil
+	}
+	return fmt.Errorf("%s", runtimemanagedcredentials.RedactString(
+		fmt.Sprintf("activity http tool %s response_success failed: %s = %s, want %s", strings.TrimSpace(toolName), path, asString(got), asString(check.Equals)),
+		secrets...,
+	))
+}
+
+func activityResponseSuccessValuesEqual(got, want any) bool {
+	switch wantTyped := want.(type) {
+	case bool:
+		gotTyped, ok := got.(bool)
+		return ok && gotTyped == wantTyped
+	case string:
+		gotTyped, ok := got.(string)
+		return ok && gotTyped == wantTyped
+	case int:
+		gotFloat, ok := activityResponseSuccessFloat(got)
+		return ok && gotFloat == float64(wantTyped)
+	case int64:
+		gotFloat, ok := activityResponseSuccessFloat(got)
+		return ok && gotFloat == float64(wantTyped)
+	case float64:
+		gotFloat, ok := activityResponseSuccessFloat(got)
+		return ok && gotFloat == wantTyped
+	case float32:
+		gotFloat, ok := activityResponseSuccessFloat(got)
+		return ok && gotFloat == float64(wantTyped)
+	default:
+		return fmt.Sprint(got) == fmt.Sprint(want)
+	}
+}
+
+func activityResponseSuccessFloat(value any) (float64, bool) {
+	switch typed := value.(type) {
+	case int:
+		return float64(typed), true
+	case int64:
+		return float64(typed), true
+	case float64:
+		return typed, true
+	case float32:
+		return float64(typed), true
+	case json.Number:
+		parsed, err := typed.Float64()
+		return parsed, err == nil
+	default:
+		return 0, false
+	}
+}
+
+func flattenActivityHTTPHeaders(headers http.Header) map[string]any {
+	out := make(map[string]any, len(headers))
+	for key, values := range headers {
+		key = strings.ToLower(strings.TrimSpace(key))
+		if key == "" || len(values) == 0 {
+			continue
+		}
+		if len(values) == 1 {
+			out[key] = values[0]
+			continue
+		}
+		items := make([]any, 0, len(values))
+		for _, value := range values {
+			items = append(items, value)
+		}
+		out[key] = items
+	}
+	return out
+}
+
+type activityManagedHTTPAuth struct {
+	StoreKey    string
+	Token       string
+	Record      runtimemanagedcredentials.Record
+	Header      string
+	Prefix      string
+	TokenSource *runtimemanagedcredentials.TokenSource
+}
+
+func (a *activityManagedHTTPAuth) SecretValues() []string {
+	if a == nil {
+		return nil
+	}
+	secrets := a.Record.SecretValues()
+	token := strings.TrimSpace(a.Token)
+	if token != "" {
+		secrets = append(secrets, token)
+	}
+	return secrets
+}
+
+func (d pipelineActivityDispatcher) resolveActivityManagedCredential(ctx context.Context, client *http.Client, intent runtimeengine.ActivityIntent, tool runtimecontracts.ToolSchemaEntry) (*activityManagedHTTPAuth, error) {
+	if tool.ManagedCredential == nil {
+		return nil, nil
+	}
+	ref := *tool.ManagedCredential
+	key := strings.TrimSpace(ref.Key)
+	if key == "" {
+		return nil, fmt.Errorf("activity tool %s managed_credential.key is required", intent.Tool)
+	}
+	source := semanticview.Source(nil)
+	var store runtimemanagedcredentials.Store
+	if d.coordinator != nil {
+		source = d.coordinator.SemanticSource()
+		store = d.coordinator.managedCredentials
+	}
+	flowID := intent.FlowID.String()
+	storeKey, mapped := semanticview.CredentialStoreKeyForFlow(source, flowID, key)
+	if mapped && strings.TrimSpace(storeKey) == "" {
+		return nil, fmt.Errorf("managed credential %q is not declared and bound for imported package flow %s", key, flowID)
+	}
+	storeKey = strings.TrimSpace(storeKey)
+	if storeKey == "" {
+		return nil, fmt.Errorf("managed credential %q does not resolve to a deployment credential key", key)
+	}
+	tokenSource := &runtimemanagedcredentials.TokenSource{
+		Store:      store,
+		HTTPClient: client,
+	}
+	token, record, err := tokenSource.AccessToken(ctx, runtimemanagedcredentials.AccessTokenRequest{
+		Key:    storeKey,
+		Scopes: ref.Scopes,
+	})
 	if err != nil {
-		return nil, activityHTTPUncertainError{err: redactActivityError(err, prepared.secrets)}
+		return nil, fmt.Errorf("%s", runtimemanagedcredentials.RedactString(err.Error(), record.SecretValues()...))
 	}
-	defer resp.Body.Close()
-	raw, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, activityHTTPUncertainError{err: redactActivityError(err, prepared.secrets)}
+	header := strings.TrimSpace(ref.Header)
+	if header == "" {
+		header = "Authorization"
 	}
-	parsed := parseHTTPActivityResponse(raw)
-	parsed = runtimemanagedcredentials.RedactValue(parsed, prepared.secrets...)
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, fmt.Errorf("activity http tool %s returned status %d: %s", prepared.toolName, resp.StatusCode, strings.TrimSpace(asString(parsed)))
+	prefix := strings.TrimSpace(ref.Prefix)
+	if prefix == "" && strings.EqualFold(header, "Authorization") {
+		prefix = "Bearer"
 	}
-	return parsed, nil
+	return &activityManagedHTTPAuth{
+		StoreKey:    storeKey,
+		Token:       token,
+		Record:      record,
+		Header:      header,
+		Prefix:      prefix,
+		TokenSource: tokenSource,
+	}, nil
+}
+
+func applyActivityManagedCredentialHeader(headers http.Header, auth *activityManagedHTTPAuth, replace bool) error {
+	if auth == nil {
+		return nil
+	}
+	header := strings.TrimSpace(auth.Header)
+	if header == "" {
+		header = "Authorization"
+	}
+	if existing := strings.TrimSpace(headers.Get(header)); existing != "" && !replace {
+		return fmt.Errorf("managed credential cannot set %s because the header is already configured", header)
+	}
+	value := strings.TrimSpace(auth.Token)
+	if value == "" {
+		return fmt.Errorf("managed credential %q did not provide an access token", auth.StoreKey)
+	}
+	if prefix := strings.TrimSpace(auth.Prefix); prefix != "" {
+		value = prefix + " " + value
+	}
+	headers.Set(header, value)
+	return nil
 }
 
 type activityHTTPUncertainError struct {

--- a/internal/runtime/pipeline/coordinator.go
+++ b/internal/runtime/pipeline/coordinator.go
@@ -16,6 +16,7 @@ import (
 	runtimedeadletters "github.com/division-sh/swarm/internal/runtime/deadletters"
 	runtimeengine "github.com/division-sh/swarm/internal/runtime/engine"
 	runtimelifecycleprobe "github.com/division-sh/swarm/internal/runtime/lifecycleprobe"
+	runtimemanagedcredentials "github.com/division-sh/swarm/internal/runtime/managedcredentials"
 	"github.com/google/uuid"
 )
 
@@ -60,6 +61,7 @@ type PipelineCoordinator struct {
 	mailboxMaterializer     MailboxWriteMaterializationStore
 	eventReceiptsCapability func(context.Context) (bool, error)
 	credentials             runtimecredentials.Store
+	managedCredentials      runtimemanagedcredentials.Store
 	artifactRoot            string
 	bundleFingerprint       string
 
@@ -82,6 +84,7 @@ type PipelineCoordinatorOptions struct {
 	MailboxMaterializer              MailboxWriteMaterializationStore
 	EventReceiptsCapability          func(context.Context) (bool, error)
 	Credentials                      runtimecredentials.Store
+	ManagedCredentials               runtimemanagedcredentials.Store
 	ArtifactRoot                     string
 	BundleFingerprint                string
 	TestEntityStateHook              func(entityID, state string)
@@ -118,6 +121,7 @@ func NewPipelineCoordinatorWithOptions(bus Bus, db *sql.DB, opts PipelineCoordin
 		mailboxMaterializer:              opts.MailboxMaterializer,
 		eventReceiptsCapability:          opts.EventReceiptsCapability,
 		credentials:                      credentials,
+		managedCredentials:               opts.ManagedCredentials,
 		artifactRoot:                     strings.TrimSpace(opts.ArtifactRoot),
 		bundleFingerprint:                strings.TrimSpace(opts.BundleFingerprint),
 		testEntityStateHook:              opts.TestEntityStateHook,

--- a/internal/runtime/runforkexecution/execution.go
+++ b/internal/runtime/runforkexecution/execution.go
@@ -303,11 +303,13 @@ func selectedContractForkEvent(forkRunID, forkEventID string, sourceEvent store.
 	)
 }
 
-func newSelectedContractPipeline(bus *runtimebus.EventBus, store *store.PostgresStore, loaded LoadedSelectedContractSource) *runtimepipeline.PipelineCoordinator {
+func newSelectedContractPipeline(bus *runtimebus.EventBus, store *store.PostgresStore, loaded LoadedSelectedContractSource, agentRuntime SelectedContractAgentRuntimeOptions) *runtimepipeline.PipelineCoordinator {
 	return runtimepipeline.NewPipelineCoordinatorWithOptions(bus, store.DB, runtimepipeline.PipelineCoordinatorOptions{
 		Module:                  loaded.Module,
 		MailboxMaterializer:     store,
 		EventReceiptsCapability: store.CanonicalEventReceiptsCapability,
+		Credentials:             agentRuntime.Credentials,
+		ManagedCredentials:      agentRuntime.ManagedCredentials,
 	})
 }
 

--- a/internal/runtime/runforkexecution/runtime_container.go
+++ b/internal/runtime/runforkexecution/runtime_container.go
@@ -152,7 +152,7 @@ func (c selectedContractForkLocalRuntimeContainer) Publish(ctx context.Context) 
 	if err != nil {
 		return nil, fmt.Errorf("create selected-contract fork-local runtime container bus: %w", err)
 	}
-	pipeline := newSelectedContractPipeline(bus, req.Store, req.LoadedSource)
+	pipeline := newSelectedContractPipeline(bus, req.Store, req.LoadedSource, req.AgentRuntime.Options)
 	bus.SetInterceptors(pipeline)
 
 	runCtx := selectedContractRuntimeContainerLineageContext(ctx, c.proof)

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -526,6 +526,7 @@ func NewRuntime(ctx context.Context, deps RuntimeDeps) (*Runtime, error) {
 			MailboxMaterializer:              stores.MailboxMaterializer,
 			EventReceiptsCapability:          boot.EventReceiptCapability,
 			Credentials:                      rt.Credentials,
+			ManagedCredentials:               rt.ManagedCredentials,
 			ArtifactRoot:                     artifactRoot,
 			BundleFingerprint:                opts.BundleFingerprint,
 			TestEntityStateHook:              opts.TestEntityStateHook,

--- a/internal/runtime/slack_connector_managed_credential_supported_surface_test.go
+++ b/internal/runtime/slack_connector_managed_credential_supported_surface_test.go
@@ -1,0 +1,854 @@
+package runtime_test
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/division-sh/swarm/internal/events"
+	"github.com/division-sh/swarm/internal/events/eventtest"
+	"github.com/division-sh/swarm/internal/packs"
+	"github.com/division-sh/swarm/internal/providerconnectors"
+	runtimepkg "github.com/division-sh/swarm/internal/runtime"
+	runtimebus "github.com/division-sh/swarm/internal/runtime/bus"
+	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
+	runtimecorrelation "github.com/division-sh/swarm/internal/runtime/correlation"
+	runtimeengine "github.com/division-sh/swarm/internal/runtime/engine"
+	runtimemanagedcredentials "github.com/division-sh/swarm/internal/runtime/managedcredentials"
+	runtimepipeline "github.com/division-sh/swarm/internal/runtime/pipeline"
+	"github.com/division-sh/swarm/internal/runtime/semanticview"
+	"github.com/division-sh/swarm/internal/store"
+	"github.com/division-sh/swarm/internal/store/storetest"
+	"github.com/division-sh/swarm/internal/testutil"
+)
+
+func TestSlackManagedCredentialConnectorPackRoundTripThroughActivityJournal(t *testing.T) {
+	t.Run("postgres", func(t *testing.T) {
+		_, db, cleanup := testutil.StartPostgres(t)
+		t.Cleanup(cleanup)
+
+		const (
+			runID        = "7a000000-0000-0000-0000-000000000001"
+			entityID     = "7a000000-0000-0000-0000-000000000002"
+			flowInstance = "slack-connector-managed-credential-pg"
+		)
+		ctx := runtimecorrelation.WithRunID(context.Background(), runID)
+		pg := &store.PostgresStore{DB: db}
+		workflowStore := runtimepipeline.NewWorkflowInstanceStore(db)
+		seedPostgresInboundGatewayRuntime(t, ctx, db, pg, runID, entityID, flowInstance, "customer-a", "telegram", "telegram-secret", "slack-managed-credential-observer")
+		seedTelegramConnectorSupportedSurfaceWorkflowVersion(t, ctx, db, flowInstance, false)
+
+		runSlackManagedCredentialConnectorSurface(t, slackManagedConnectorBackend{
+			name:          "postgres",
+			ctx:           ctx,
+			db:            db,
+			eventStore:    pg,
+			inboundStore:  pg,
+			workflowStore: workflowStore,
+			runID:         runID,
+			entityID:      entityID,
+			sqlite:        false,
+		})
+	})
+
+	t.Run("sqlite", func(t *testing.T) {
+		const (
+			runID        = "7b000000-0000-0000-0000-000000000001"
+			entityID     = "7b000000-0000-0000-0000-000000000002"
+			flowInstance = "slack-connector-managed-credential-sqlite"
+		)
+		ctx := runtimecorrelation.WithRunID(context.Background(), runID)
+		sqliteStore := storetest.StartSQLiteRuntimeStoreWithContext(t, ctx)
+		workflowStore := runtimepipeline.NewSQLiteWorkflowInstanceStoreWithRuntimeMutationRunner(sqliteStore.DB, sqliteStore)
+		seedSQLiteInboundGatewayRuntime(t, ctx, sqliteStore, runID, entityID, flowInstance, "customer-a", "telegram", "telegram-secret", "slack-managed-credential-observer")
+		seedTelegramConnectorSupportedSurfaceWorkflowVersion(t, ctx, sqliteStore.DB, flowInstance, true)
+
+		runSlackManagedCredentialConnectorSurface(t, slackManagedConnectorBackend{
+			name:          "sqlite",
+			ctx:           ctx,
+			db:            sqliteStore.DB,
+			eventStore:    sqliteStore,
+			inboundStore:  sqliteStore,
+			workflowStore: workflowStore,
+			runID:         runID,
+			entityID:      entityID,
+			sqlite:        true,
+		})
+	})
+}
+
+type slackManagedConnectorBackend struct {
+	name          string
+	ctx           context.Context
+	db            *sql.DB
+	eventStore    runtimebus.EventStore
+	inboundStore  runtimepkg.InboundPersistence
+	workflowStore *runtimepipeline.WorkflowInstanceStore
+	runID         string
+	entityID      string
+	sqlite        bool
+}
+
+type slackManagedConnectorCall struct {
+	auth string
+	body map[string]any
+	raw  string
+}
+
+func runSlackManagedCredentialConnectorSurface(t *testing.T, backend slackManagedConnectorBackend) {
+	t.Helper()
+	fake := newFakeSlackManagedConnectorServer(t)
+	defer fake.server.Close()
+
+	managedStore := runtimemanagedcredentials.NewMemoryStore(runtimemanagedcredentials.Record{
+		Key:          "slack_oauth",
+		Provider:     "slack",
+		GrantType:    runtimemanagedcredentials.GrantAuthorizationCodePKCE,
+		TokenURL:     fake.server.URL + "/oauth.v2.access",
+		ClientID:     "client-id",
+		ClientSecret: "client-secret",
+		Scopes:       []string{"chat:write"},
+		AccessToken:  "expired-token",
+		RefreshToken: "refresh-secret",
+		Status:       runtimemanagedcredentials.StatusConnected,
+		ExpiresAt:    time.Now().Add(-time.Hour),
+	})
+	source := slackManagedConnectorSource(t, fake.server.URL)
+	bus, pc := startSlackManagedConnectorBusAndCoordinator(t, backend, source, managedStore)
+	gateway := runtimepkg.NewInboundGateway(bus, nil, nil, backend.inboundStore)
+	webhookPath := fmt.Sprintf("/webhooks/%s/telegram", backend.entityID)
+
+	publishTelegramMessageToSlack(t, backend, bus, gateway, webhookPath, "123456789", "hello from telegram")
+	firstCall := fake.requireSideEffectCall(t, backend.name, "refresh-before-use")
+	if firstCall.auth != "Bearer fresh-token" {
+		t.Fatalf("%s first Slack auth = %q, want Bearer fresh-token", backend.name, firstCall.auth)
+	}
+	if got := slackManagedConnectorString(firstCall.body["channel"]); got != "C123" {
+		t.Fatalf("%s first Slack channel = %#v, want C123", backend.name, firstCall.body["channel"])
+	}
+	if got := slackManagedConnectorString(firstCall.body["text"]); got != "hello from telegram" {
+		t.Fatalf("%s first Slack text = %#v, want inbound text", backend.name, firstCall.body["text"])
+	}
+	firstInboundEventID := loadSlackManagedConnectorInboundEventID(t, backend, "123456789")
+	firstAttempt := waitForSlackManagedConnectorTerminalActivityAttempt(t, backend, firstInboundEventID)
+	if firstAttempt.Status != runtimepipeline.ActivityAttemptStatusSucceeded {
+		t.Fatalf("%s first activity attempt status = %q, want succeeded", backend.name, firstAttempt.Status)
+	}
+	requireSlackManagedConnectorResultEventEventually(t, backend, firstAttempt.ResultEventID, firstAttempt.ResultEventType)
+	if got := fake.refreshCount(); got != 1 {
+		t.Fatalf("%s refresh-before-use token refreshes = %d, want 1", backend.name, got)
+	}
+
+	publishTelegramMessageToSlack(t, backend, bus, gateway, webhookPath, "123456790", "needs 401 refresh")
+	secondCall := fake.requireSideEffectCall(t, backend.name, "refresh-on-401")
+	if secondCall.auth != "Bearer after-401-token" {
+		t.Fatalf("%s second Slack auth = %q, want Bearer after-401-token", backend.name, secondCall.auth)
+	}
+	secondInboundEventID := loadSlackManagedConnectorInboundEventID(t, backend, "123456790")
+	secondAttempt := waitForSlackManagedConnectorTerminalActivityAttempt(t, backend, secondInboundEventID)
+	if secondAttempt.Status != runtimepipeline.ActivityAttemptStatusSucceeded {
+		t.Fatalf("%s second activity attempt status = %q, want succeeded", backend.name, secondAttempt.Status)
+	}
+	if got := fake.refreshCount(); got != 2 {
+		t.Fatalf("%s token refreshes after 401 = %d, want 2", backend.name, got)
+	}
+	if got := fake.providerHTTPRequestCount(); got != 3 {
+		t.Fatalf("%s Slack HTTP requests = %d, want 3 (success, 401, retry success)", backend.name, got)
+	}
+
+	requestEvent := loadSlackManagedConnectorActivityRequestEvent(t, backend, secondAttempt.RequestEventID)
+	if err := bus.EngineDispatcher().DispatchPostCommit(backend.ctx, []runtimeengine.EmitIntent{{Event: requestEvent}}); err != nil {
+		t.Fatalf("%s duplicate activity request dispatch: %v", backend.name, err)
+	}
+	waitForInboundBusQuiescence(t, bus)
+	fake.requireNoSideEffectCall(t, backend.name, "duplicate activity request")
+	if got := fake.refreshCount(); got != 2 {
+		t.Fatalf("%s token refreshes after duplicate = %d, want still 2", backend.name, got)
+	}
+	if got := countSlackManagedConnectorActivityAttempts(t, backend); got != 2 {
+		t.Fatalf("%s activity attempts after duplicate = %d, want 2", backend.name, got)
+	}
+
+	publishTelegramMessageToSlack(t, backend, bus, gateway, webhookPath, "123456792", "provider ok false")
+	fake.requireNoSideEffectCall(t, backend.name, "response_success ok false")
+	okFalseInboundEventID := loadSlackManagedConnectorInboundEventID(t, backend, "123456792")
+	okFalseAttempt := waitForSlackManagedConnectorTerminalActivityAttempt(t, backend, okFalseInboundEventID)
+	if okFalseAttempt.Status != runtimepipeline.ActivityAttemptStatusFailed {
+		t.Fatalf("%s ok:false activity attempt status = %q, want failed", backend.name, okFalseAttempt.Status)
+	}
+	requireSlackManagedConnectorResultEventEventually(t, backend, okFalseAttempt.ResultEventID, okFalseAttempt.ResultEventType)
+	if got := countSlackManagedConnectorFailureEventsForSource(t, backend, okFalseInboundEventID); got != 1 {
+		t.Fatalf("%s ok:false failure events = %d, want 1", backend.name, got)
+	}
+	if got := fake.providerHTTPRequestCount(); got != 4 {
+		t.Fatalf("%s Slack HTTP requests after ok:false = %d, want 4", backend.name, got)
+	}
+
+	assertSlackManagedConnectorMissingCredential(t, backend, fake.server.URL)
+	_ = pc
+	for _, secret := range []string{"expired-token", "fresh-token", "after-401-token", "refresh-secret", "client-secret"} {
+		assertSlackManagedConnectorNoStoredSecret(t, backend, secret)
+	}
+}
+
+type fakeSlackManagedConnectorServer struct {
+	server      *httptest.Server
+	tokenCalls  atomic.Int64
+	slackCalls  atomic.Int64
+	sideEffects chan slackManagedConnectorCall
+}
+
+func newFakeSlackManagedConnectorServer(t *testing.T) *fakeSlackManagedConnectorServer {
+	t.Helper()
+	fake := &fakeSlackManagedConnectorServer{sideEffects: make(chan slackManagedConnectorCall, 8)}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/oauth.v2.access", func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		if got := r.Form.Get("grant_type"); got != "refresh_token" {
+			http.Error(w, "unexpected grant_type "+got, http.StatusBadRequest)
+			return
+		}
+		if got := r.Form.Get("refresh_token"); got != "refresh-secret" {
+			http.Error(w, "unexpected refresh token", http.StatusBadRequest)
+			return
+		}
+		call := fake.tokenCalls.Add(1)
+		token := "fresh-token"
+		if call >= 2 {
+			token = "after-401-token"
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"access_token":  token,
+			"refresh_token": "refresh-secret",
+			"token_type":    "Bearer",
+			"expires_in":    3600,
+			"scope":         "chat:write",
+		})
+	})
+	mux.HandleFunc("/api/chat.postMessage", func(w http.ResponseWriter, r *http.Request) {
+		fake.slackCalls.Add(1)
+		raw, err := io.ReadAll(r.Body)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		var body map[string]any
+		if err := json.Unmarshal(raw, &body); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		auth := r.Header.Get("Authorization")
+		text := slackManagedConnectorString(body["text"])
+		if auth == "Bearer fresh-token" && text == "needs 401 refresh" {
+			w.WriteHeader(http.StatusUnauthorized)
+			_ = json.NewEncoder(w).Encode(map[string]any{"ok": false, "error": "token_expired"})
+			return
+		}
+		if auth != "Bearer fresh-token" && auth != "Bearer after-401-token" {
+			w.WriteHeader(http.StatusUnauthorized)
+			_ = json.NewEncoder(w).Encode(map[string]any{"ok": false, "error": "bad_token"})
+			return
+		}
+		if text == "provider ok false" {
+			_ = json.NewEncoder(w).Encode(map[string]any{"ok": false, "error": "channel_not_found"})
+			return
+		}
+		call := slackManagedConnectorCall{auth: auth, body: body, raw: string(raw)}
+		fake.sideEffects <- call
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"ok":      true,
+			"channel": body["channel"],
+			"message": map[string]any{
+				"text": body["text"],
+			},
+		})
+	})
+	fake.server = httptest.NewServer(mux)
+	return fake
+}
+
+func (f *fakeSlackManagedConnectorServer) requireSideEffectCall(t *testing.T, backend, context string) slackManagedConnectorCall {
+	t.Helper()
+	select {
+	case call := <-f.sideEffects:
+		return call
+	case <-time.After(5 * time.Second):
+		t.Fatalf("%s %s: timed out waiting for fake Slack side effect", backend, context)
+		return slackManagedConnectorCall{}
+	}
+}
+
+func (f *fakeSlackManagedConnectorServer) requireNoSideEffectCall(t *testing.T, backend, context string) {
+	t.Helper()
+	select {
+	case call := <-f.sideEffects:
+		t.Fatalf("%s %s: unexpected fake Slack side effect: auth=%s body=%s", backend, context, call.auth, call.raw)
+	default:
+	}
+}
+
+func (f *fakeSlackManagedConnectorServer) refreshCount() int {
+	return int(f.tokenCalls.Load())
+}
+
+func (f *fakeSlackManagedConnectorServer) providerHTTPRequestCount() int {
+	return int(f.slackCalls.Load())
+}
+
+func publishTelegramMessageToSlack(t *testing.T, backend slackManagedConnectorBackend, bus *runtimebus.EventBus, gateway *runtimepkg.InboundGateway, webhookPath, updateID, text string) {
+	t.Helper()
+	body := []byte(fmt.Sprintf(`{"update_id":%s,"message":{"message_id":7,"chat":{"id":42},"text":%q}}`, updateID, text))
+	req := newSignedTelegramRequest(webhookPath, "telegram-secret", body).WithContext(backend.ctx)
+	rec := httptest.NewRecorder()
+	gateway.Handler().ServeHTTP(rec, req)
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("%s gateway status for update %s = %d, want 202 body=%s", backend.name, updateID, rec.Code, rec.Body.String())
+	}
+	waitForInboundBusQuiescence(t, bus)
+}
+
+func slackManagedConnectorSource(t *testing.T, baseURL string) semanticview.Source {
+	t.Helper()
+	handler := runtimecontracts.SystemNodeEventHandler{
+		Activity: runtimecontracts.ActivitySpec{
+			ID:   "slack_post_message",
+			Tool: "slack.post_message",
+			Input: map[string]runtimecontracts.ExpressionValue{
+				"channel": runtimecontracts.CELExpression(`"C123"`),
+				"text":    runtimecontracts.CELExpression("payload.payload.message.text"),
+			},
+		},
+	}
+	const nodeID = "slack-responder"
+	node := runtimecontracts.SystemNodeContract{
+		ID:            nodeID,
+		ExecutionType: runtimecontracts.SystemNodeExecutionType,
+		EventHandlers: map[string]runtimecontracts.SystemNodeEventHandler{
+			"inbound.telegram": handler,
+		},
+	}
+	base := semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
+		RootSchema: &runtimecontracts.FlowSchemaDocument{
+			Pins: runtimecontracts.FlowPins{
+				Inputs: runtimecontracts.FlowInputPins{
+					Events: []string{"inbound.telegram"},
+				},
+			},
+		},
+		Nodes: map[string]runtimecontracts.SystemNodeContract{nodeID: node},
+		Semantics: runtimecontracts.WorkflowSemanticView{
+			Name:    "slack_connector_managed_credential_supported_surface",
+			Version: "1.0.0",
+			EffectiveNodes: map[string]runtimecontracts.SystemNodeEffectiveSemantics{
+				nodeID: {
+					ID:                   nodeID,
+					ExecutionType:        runtimecontracts.SystemNodeExecutionType,
+					RuntimeSubscriptions: []string{"inbound.telegram"},
+				},
+			},
+			NodeHandlers: map[string]map[string]runtimecontracts.SystemNodeEventHandler{
+				nodeID: {"inbound.telegram": handler},
+			},
+			EventOwners: map[string][]string{
+				"inbound.telegram": {nodeID},
+			},
+		},
+	})
+	importSource := slackManagedConnectorPackImportSource{
+		Source: base,
+		projectScopes: []semanticview.ProjectScope{
+			{
+				Key: ".",
+				Manifest: runtimecontracts.ProjectPackageDocument{
+					ConnectorPacks: runtimecontracts.ConnectorPackImports{
+						Imports: []runtimecontracts.ConnectorPackImport{{Provider: "slack", Tool: "slack.post_message"}},
+					},
+				},
+			},
+		},
+	}
+	source, err := providerconnectors.SourceWithConnectorPackImportsFromRegistry(importSource, slackManagedConnectorPackRegistry(t, baseURL))
+	if err != nil {
+		t.Fatalf("SourceWithConnectorPackImportsFromRegistry: %v", err)
+	}
+	return source
+}
+
+func slackManagedConnectorPackRegistry(t *testing.T, baseURL string) *providerconnectors.PackRegistry {
+	t.Helper()
+	tool, ok := providerconnectors.BuiltinTool("slack", "slack.post_message")
+	if !ok {
+		t.Fatal("provider connector pack slack.post_message not found")
+	}
+	if tool.HTTP == nil {
+		t.Fatal("provider connector pack slack.post_message missing http block")
+	}
+	httpSpec := *tool.HTTP
+	tool.HTTP = &httpSpec
+	tool.HTTP.URL = strings.TrimRight(baseURL, "/") + "/api/chat.postMessage"
+	registry, err := providerconnectors.NewPackRegistry(providerconnectors.LoadedPack{
+		Envelope: packs.Envelope{
+			ID: "provider.slack.connector",
+			Provenance: packs.Provenance{
+				Source: packs.ProvenancePlatform,
+			},
+		},
+		Manifest: providerconnectors.ConnectorManifest{
+			Provider: "slack",
+			Tools: map[string]runtimecontracts.ToolSchemaEntry{
+				"slack.post_message": tool,
+			},
+		},
+		Source: "test:provider.slack.connector",
+	})
+	if err != nil {
+		t.Fatalf("NewPackRegistry: %v", err)
+	}
+	return registry
+}
+
+type slackManagedConnectorPackImportSource struct {
+	semanticview.Source
+	projectScopes []semanticview.ProjectScope
+}
+
+func (s slackManagedConnectorPackImportSource) BaseSemanticSource() semanticview.Source {
+	return s.Source
+}
+
+func (s slackManagedConnectorPackImportSource) ProjectScopes() []semanticview.ProjectScope {
+	return append([]semanticview.ProjectScope(nil), s.projectScopes...)
+}
+
+type slackManagedConnectorModule struct {
+	source  semanticview.Source
+	nodes   []runtimepipeline.WorkflowNode
+	guards  runtimepipeline.GuardRegistry
+	actions runtimepipeline.ActionRegistry
+}
+
+func (m slackManagedConnectorModule) SemanticSource() semanticview.Source {
+	return m.source
+}
+
+func (m slackManagedConnectorModule) WorkflowDefinition() *runtimepipeline.WorkflowDefinition {
+	return nil
+}
+
+func (m slackManagedConnectorModule) WorkflowNodes() []runtimepipeline.WorkflowNode {
+	return append([]runtimepipeline.WorkflowNode(nil), m.nodes...)
+}
+
+func (m slackManagedConnectorModule) GuardRegistry() runtimepipeline.GuardRegistry {
+	return m.guards
+}
+
+func (m slackManagedConnectorModule) ActionRegistry() runtimepipeline.ActionRegistry {
+	return m.actions
+}
+
+func startSlackManagedConnectorBusAndCoordinator(t *testing.T, backend slackManagedConnectorBackend, source semanticview.Source, managedStore runtimemanagedcredentials.Store) (*runtimebus.EventBus, *runtimepipeline.PipelineCoordinator) {
+	t.Helper()
+	var pc *runtimepipeline.PipelineCoordinator
+	bus, err := runtimebus.NewEventBusWithOptions(backend.eventStore, runtimebus.EventBusOptions{
+		ContractBundle: source,
+		InterceptorProvider: func() []runtimebus.EventInterceptor {
+			if pc == nil {
+				return nil
+			}
+			return []runtimebus.EventInterceptor{pc}
+		},
+	})
+	if err != nil {
+		t.Fatalf("%s NewEventBusWithOptions: %v", backend.name, err)
+	}
+	nodes, err := runtimepipeline.LoadWorkflowNodes(source)
+	if err != nil {
+		t.Fatalf("%s LoadWorkflowNodes: %v", backend.name, err)
+	}
+	module := slackManagedConnectorModule{
+		source:  source,
+		nodes:   nodes,
+		guards:  runtimepipeline.NewContractGuardRegistry(source),
+		actions: runtimepipeline.NewContractActionRegistry(source),
+	}
+	pc = runtimepipeline.NewPipelineCoordinatorWithOptions(bus, backend.db, runtimepipeline.PipelineCoordinatorOptions{
+		Module:             module,
+		WorkflowStore:      backend.workflowStore,
+		ManagedCredentials: managedStore,
+		EventReceiptsCapability: func(context.Context) (bool, error) {
+			return true, nil
+		},
+	})
+	subscribed := make(chan struct{}, 1)
+	pc.SetTestSubscribeHook(func() {
+		select {
+		case subscribed <- struct{}{}:
+		default:
+		}
+	})
+	runCtx, cancel := context.WithCancel(backend.ctx)
+	t.Cleanup(cancel)
+	go pc.Run(runCtx)
+	select {
+	case <-subscribed:
+	case <-time.After(5 * time.Second):
+		t.Fatal("pipeline coordinator did not subscribe")
+	}
+	return bus, pc
+}
+
+func assertSlackManagedConnectorMissingCredential(t *testing.T, backend slackManagedConnectorBackend, baseURL string) {
+	t.Helper()
+	source := slackManagedConnectorSource(t, baseURL)
+	bus, _ := startSlackManagedConnectorBusAndCoordinator(t, backend, source, runtimemanagedcredentials.NewMemoryStore())
+	gateway := runtimepkg.NewInboundGateway(bus, nil, nil, backend.inboundStore)
+	webhookPath := fmt.Sprintf("/webhooks/%s/telegram", backend.entityID)
+	publishTelegramMessageToSlack(t, backend, bus, gateway, webhookPath, "123456791", "missing credential")
+	inboundEventID := loadSlackManagedConnectorInboundEventID(t, backend, "123456791")
+	if got := countSlackManagedConnectorActivityAttemptsForSource(t, backend, inboundEventID); got != 0 {
+		t.Fatalf("%s missing managed credential activity attempts = %d, want 0", backend.name, got)
+	}
+	if got := countSlackManagedConnectorFailureEventsForSource(t, backend, inboundEventID); got != 1 {
+		t.Fatalf("%s missing managed credential failure events = %d, want 1", backend.name, got)
+	}
+}
+
+func loadSlackManagedConnectorInboundEventID(t *testing.T, backend slackManagedConnectorBackend, providerEventID string) string {
+	t.Helper()
+	var eventID string
+	var err error
+	if backend.sqlite {
+		err = backend.db.QueryRowContext(backend.ctx, `
+			SELECT event_id
+			FROM events
+			WHERE run_id = ?
+			  AND entity_id = ?
+			  AND event_name = 'inbound.telegram'
+			  AND json_extract(payload, '$.provider_event_id') = ?
+			ORDER BY created_at DESC
+			LIMIT 1
+		`, backend.runID, backend.entityID, providerEventID).Scan(&eventID)
+	} else {
+		err = backend.db.QueryRowContext(backend.ctx, `
+			SELECT event_id::text
+			FROM events
+			WHERE run_id = $1::uuid
+			  AND entity_id = $2::uuid
+			  AND event_name = 'inbound.telegram'
+			  AND payload->>'provider_event_id' = $3
+			ORDER BY created_at DESC
+			LIMIT 1
+		`, backend.runID, backend.entityID, providerEventID).Scan(&eventID)
+	}
+	if err != nil {
+		t.Fatalf("%s load inbound event id for %s: %v", backend.name, providerEventID, err)
+	}
+	return eventID
+}
+
+func waitForSlackManagedConnectorTerminalActivityAttempt(t *testing.T, backend slackManagedConnectorBackend, sourceEventID string) runtimepipeline.ActivityAttemptRecord {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	var last runtimepipeline.ActivityAttemptRecord
+	var saw bool
+	for {
+		rec, ok, err := tryLoadSlackManagedConnectorActivityAttempt(backend, sourceEventID)
+		if err != nil {
+			t.Fatalf("%s load activity attempt while waiting: %v", backend.name, err)
+		}
+		if ok {
+			last = rec
+			saw = true
+			if rec.Status != runtimepipeline.ActivityAttemptStatusStarted {
+				return rec
+			}
+		}
+		if time.Now().After(deadline) {
+			if saw {
+				t.Fatalf("%s activity attempt did not reach terminal status; last=%q", backend.name, last.Status)
+			}
+			t.Fatalf("%s activity attempt for source event %s was not created", backend.name, sourceEventID)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func tryLoadSlackManagedConnectorActivityAttempt(backend slackManagedConnectorBackend, sourceEventID string) (runtimepipeline.ActivityAttemptRecord, bool, error) {
+	var requestEventID string
+	var err error
+	if backend.sqlite {
+		err = backend.db.QueryRowContext(backend.ctx, `
+			SELECT request_event_id
+			FROM activity_attempts
+			WHERE run_id = ?
+			  AND tool = 'slack.post_message'
+			  AND source_event_id = ?
+			ORDER BY started_at ASC
+			LIMIT 1
+		`, backend.runID, sourceEventID).Scan(&requestEventID)
+	} else {
+		err = backend.db.QueryRowContext(backend.ctx, `
+			SELECT request_event_id::text
+			FROM activity_attempts
+			WHERE run_id = $1::uuid
+			  AND tool = 'slack.post_message'
+			  AND source_event_id = $2::uuid
+			ORDER BY started_at ASC
+			LIMIT 1
+		`, backend.runID, sourceEventID).Scan(&requestEventID)
+	}
+	if err == sql.ErrNoRows {
+		return runtimepipeline.ActivityAttemptRecord{}, false, nil
+	}
+	if err != nil {
+		return runtimepipeline.ActivityAttemptRecord{}, false, err
+	}
+	rec, ok, err := backend.workflowStore.LoadActivityAttempt(backend.ctx, requestEventID)
+	if err != nil {
+		return runtimepipeline.ActivityAttemptRecord{}, false, err
+	}
+	return rec, ok, nil
+}
+
+func countSlackManagedConnectorActivityAttempts(t *testing.T, backend slackManagedConnectorBackend) int {
+	t.Helper()
+	var count int
+	var err error
+	if backend.sqlite {
+		err = backend.db.QueryRowContext(backend.ctx, `
+			SELECT COUNT(*)
+			FROM activity_attempts
+			WHERE run_id = ?
+			  AND tool = 'slack.post_message'
+		`, backend.runID).Scan(&count)
+	} else {
+		err = backend.db.QueryRowContext(backend.ctx, `
+			SELECT COUNT(*)
+			FROM activity_attempts
+			WHERE run_id = $1::uuid
+			  AND tool = 'slack.post_message'
+		`, backend.runID).Scan(&count)
+	}
+	if err != nil {
+		t.Fatalf("%s count activity attempts: %v", backend.name, err)
+	}
+	return count
+}
+
+func countSlackManagedConnectorActivityAttemptsForSource(t *testing.T, backend slackManagedConnectorBackend, sourceEventID string) int {
+	t.Helper()
+	var count int
+	var err error
+	if backend.sqlite {
+		err = backend.db.QueryRowContext(backend.ctx, `
+			SELECT COUNT(*)
+			FROM activity_attempts
+			WHERE run_id = ?
+			  AND tool = 'slack.post_message'
+			  AND source_event_id = ?
+		`, backend.runID, sourceEventID).Scan(&count)
+	} else {
+		err = backend.db.QueryRowContext(backend.ctx, `
+			SELECT COUNT(*)
+			FROM activity_attempts
+			WHERE run_id = $1::uuid
+			  AND tool = 'slack.post_message'
+			  AND source_event_id = $2::uuid
+		`, backend.runID, sourceEventID).Scan(&count)
+	}
+	if err != nil {
+		t.Fatalf("%s count activity attempts for source event %s: %v", backend.name, sourceEventID, err)
+	}
+	return count
+}
+
+func countSlackManagedConnectorFailureEventsForSource(t *testing.T, backend slackManagedConnectorBackend, sourceEventID string) int {
+	t.Helper()
+	var count int
+	var err error
+	if backend.sqlite {
+		err = backend.db.QueryRowContext(backend.ctx, `
+			SELECT COUNT(*)
+			FROM events
+			WHERE run_id = ?
+			  AND event_name = 'slack_post_message.failed'
+			  AND source_event_id = ?
+		`, backend.runID, sourceEventID).Scan(&count)
+	} else {
+		err = backend.db.QueryRowContext(backend.ctx, `
+			SELECT COUNT(*)
+			FROM events
+			WHERE run_id = $1::uuid
+			  AND event_name = 'slack_post_message.failed'
+			  AND source_event_id = $2::uuid
+		`, backend.runID, sourceEventID).Scan(&count)
+	}
+	if err != nil {
+		t.Fatalf("%s count failure events for source event %s: %v", backend.name, sourceEventID, err)
+	}
+	return count
+}
+
+func requireSlackManagedConnectorResultEventEventually(t *testing.T, backend slackManagedConnectorBackend, eventID, eventType string) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		if slackManagedConnectorEventExists(t, backend, eventID, eventType) {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("%s event row for %s/%s not found", backend.name, eventID, eventType)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func slackManagedConnectorEventExists(t *testing.T, backend slackManagedConnectorBackend, eventID, eventType string) bool {
+	t.Helper()
+	var count int
+	var err error
+	if backend.sqlite {
+		err = backend.db.QueryRowContext(backend.ctx, `
+			SELECT COUNT(*)
+			FROM events
+			WHERE event_id = ?
+			  AND event_name = ?
+		`, eventID, eventType).Scan(&count)
+	} else {
+		err = backend.db.QueryRowContext(backend.ctx, `
+			SELECT COUNT(*)
+			FROM events
+			WHERE event_id = $1::uuid
+			  AND event_name = $2
+		`, eventID, eventType).Scan(&count)
+	}
+	if err != nil {
+		t.Fatalf("%s require event %s/%s: %v", backend.name, eventID, eventType, err)
+	}
+	return count == 1
+}
+
+func loadSlackManagedConnectorActivityRequestEvent(t *testing.T, backend slackManagedConnectorBackend, eventID string) events.Event {
+	t.Helper()
+	var raw []byte
+	var created time.Time
+	var err error
+	if backend.sqlite {
+		var payload string
+		var createdRaw string
+		err = backend.db.QueryRowContext(backend.ctx, `
+			SELECT payload, created_at
+			FROM events
+			WHERE event_id = ?
+			  AND event_name = 'platform.activity_requested'
+		`, eventID).Scan(&payload, &createdRaw)
+		raw = []byte(payload)
+		created, _ = time.Parse(time.RFC3339Nano, createdRaw)
+		if created.IsZero() {
+			created = time.Now().UTC()
+		}
+	} else {
+		err = backend.db.QueryRowContext(backend.ctx, `
+			SELECT payload, created_at
+			FROM events
+			WHERE event_id = $1::uuid
+			  AND event_name = 'platform.activity_requested'
+		`, eventID).Scan(&raw, &created)
+	}
+	if err != nil {
+		t.Fatalf("%s load activity request event %s: %v", backend.name, eventID, err)
+	}
+	return eventtest.PersistedProjection(
+		eventID,
+		events.EventType("platform.activity_requested"),
+		"workflow-runtime",
+		"",
+		raw,
+		2,
+		backend.runID,
+		"",
+		events.EventEnvelope{EntityID: backend.entityID},
+		created,
+	)
+}
+
+func assertSlackManagedConnectorNoStoredSecret(t *testing.T, backend slackManagedConnectorBackend, secret string) {
+	t.Helper()
+	var eventLeaks int
+	var attemptLeaks int
+	var err error
+	if backend.sqlite {
+		err = backend.db.QueryRowContext(backend.ctx, `
+			SELECT COUNT(*)
+			FROM events
+			WHERE run_id = ?
+			  AND payload LIKE '%' || ? || '%'
+		`, backend.runID, secret).Scan(&eventLeaks)
+		if err == nil {
+			err = backend.db.QueryRowContext(backend.ctx, `
+				SELECT COUNT(*)
+				FROM activity_attempts
+				WHERE run_id = ?
+				  AND (
+					COALESCE(result_payload, '') LIKE '%' || ? || '%'
+					OR COALESCE(error, '') LIKE '%' || ? || '%'
+				  )
+			`, backend.runID, secret, secret).Scan(&attemptLeaks)
+		}
+	} else {
+		err = backend.db.QueryRowContext(backend.ctx, `
+			SELECT COUNT(*)
+			FROM events
+			WHERE run_id = $1::uuid
+			  AND payload::text LIKE '%' || $2 || '%'
+		`, backend.runID, secret).Scan(&eventLeaks)
+		if err == nil {
+			err = backend.db.QueryRowContext(backend.ctx, `
+				SELECT COUNT(*)
+				FROM activity_attempts
+				WHERE run_id = $1::uuid
+				  AND (
+					COALESCE(result_payload::text, '') LIKE '%' || $2 || '%'
+					OR COALESCE(error, '') LIKE '%' || $2 || '%'
+				  )
+			`, backend.runID, secret).Scan(&attemptLeaks)
+		}
+	}
+	if err != nil {
+		t.Fatalf("%s no-secret query for %q: %v", backend.name, secret, err)
+	}
+	if eventLeaks != 0 || attemptLeaks != 0 {
+		t.Fatalf("%s stored secret %q leaks: events=%d activity_attempts=%d", backend.name, secret, eventLeaks, attemptLeaks)
+	}
+}
+
+func slackManagedConnectorString(value any) string {
+	switch v := value.(type) {
+	case nil:
+		return ""
+	case string:
+		return v
+	case json.Number:
+		return v.String()
+	case float64:
+		return fmt.Sprintf("%.0f", v)
+	case int:
+		return fmt.Sprintf("%d", v)
+	case int64:
+		return fmt.Sprintf("%d", v)
+	default:
+		return fmt.Sprint(v)
+	}
+}

--- a/internal/runtime/tools/executor_http.go
+++ b/internal/runtime/tools/executor_http.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"time"
 
+	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
 	models "github.com/division-sh/swarm/internal/runtime/core/actors"
 	runtimemanagedcredentials "github.com/division-sh/swarm/internal/runtime/managedcredentials"
 	"github.com/division-sh/swarm/internal/runtime/semanticview"
@@ -281,9 +282,6 @@ func (e *Executor) execHTTPRequestOnce(ctx context.Context, method, url string, 
 	if resp.StatusCode >= 400 {
 		return nil, httpToolStatusError{ToolName: tool.Name, StatusCode: resp.StatusCode, Body: parsedBody, Secrets: secrets}
 	}
-	if len(tool.ResponseMapping) == 0 {
-		return parsedBody, nil
-	}
 	responseEnv := map[string]any{
 		"response": map[string]any{
 			"status":  resp.StatusCode,
@@ -291,7 +289,77 @@ func (e *Executor) execHTTPRequestOnce(ctx context.Context, method, url string, 
 			"body":    parsedBody,
 		},
 	}
+	if err := evaluateHTTPResponseSuccess(tool.Name, tool.ResponseSuccess, responseEnv, secrets); err != nil {
+		return nil, err
+	}
+	if len(tool.ResponseMapping) == 0 {
+		return parsedBody, nil
+	}
 	return resolveTemplateTree(tool.ResponseMapping, responseEnv)
+}
+
+func evaluateHTTPResponseSuccess(toolName string, check *runtimecontracts.HTTPResponseSuccess, responseEnv map[string]any, secrets []string) error {
+	if check == nil {
+		return nil
+	}
+	path := strings.TrimSpace(check.Path)
+	if path == "" {
+		return fmt.Errorf("http tool %s response_success.path is required", strings.TrimSpace(toolName))
+	}
+	got, err := lookupTemplatePath(responseEnv, path)
+	if err != nil {
+		return fmt.Errorf("http tool %s response_success path %q did not resolve", strings.TrimSpace(toolName), path)
+	}
+	if responseSuccessValuesEqual(got, check.Equals) {
+		return nil
+	}
+	return fmt.Errorf("%s", runtimemanagedcredentials.RedactString(
+		fmt.Sprintf("http tool %s response_success failed: %s = %s, want %s", strings.TrimSpace(toolName), path, asString(got), asString(check.Equals)),
+		secrets...,
+	))
+}
+
+func responseSuccessValuesEqual(got, want any) bool {
+	switch wantTyped := want.(type) {
+	case bool:
+		gotTyped, ok := got.(bool)
+		return ok && gotTyped == wantTyped
+	case string:
+		gotTyped, ok := got.(string)
+		return ok && gotTyped == wantTyped
+	case int:
+		gotFloat, ok := responseSuccessFloat(got)
+		return ok && gotFloat == float64(wantTyped)
+	case int64:
+		gotFloat, ok := responseSuccessFloat(got)
+		return ok && gotFloat == float64(wantTyped)
+	case float64:
+		gotFloat, ok := responseSuccessFloat(got)
+		return ok && gotFloat == wantTyped
+	case float32:
+		gotFloat, ok := responseSuccessFloat(got)
+		return ok && gotFloat == float64(wantTyped)
+	default:
+		return fmt.Sprint(got) == fmt.Sprint(want)
+	}
+}
+
+func responseSuccessFloat(value any) (float64, bool) {
+	switch typed := value.(type) {
+	case int:
+		return float64(typed), true
+	case int64:
+		return float64(typed), true
+	case float64:
+		return typed, true
+	case float32:
+		return float64(typed), true
+	case json.Number:
+		parsed, err := typed.Float64()
+		return parsed, err == nil
+	default:
+		return 0, false
+	}
 }
 
 func (e *Executor) execMCPTool(ctx context.Context, actor models.AgentConfig, tool RegisteredTool, input any) (any, error) {

--- a/internal/runtime/tools/registry.go
+++ b/internal/runtime/tools/registry.go
@@ -32,6 +32,7 @@ type RegisteredTool struct {
 	GeneratedSchema    bool
 	HTTP               *runtimecontracts.HTTPToolSpec
 	ResponseMapping    map[string]any
+	ResponseSuccess    *runtimecontracts.HTTPResponseSuccess
 	Credentials        []string
 	ManagedCredential  *runtimecontracts.ManagedCredentialRef
 	RateLimit          externalDispatchRateLimitConfig
@@ -239,10 +240,19 @@ func registeredToolFromContract(name string, entry runtimecontracts.ToolSchemaEn
 		OutputSchema:       outputSchema,
 		HTTP:               entry.HTTP,
 		ResponseMapping:    deepCloneMap(entry.ResponseMapping),
+		ResponseSuccess:    cloneResponseSuccess(entry.ResponseSuccess),
 		Credentials:        append([]string{}, entry.Credentials...),
 		ManagedCredential:  cloneManagedCredentialRef(entry.ManagedCredential),
 		RateLimit:          rateLimit,
 	}, true, nil
+}
+
+func cloneResponseSuccess(check *runtimecontracts.HTTPResponseSuccess) *runtimecontracts.HTTPResponseSuccess {
+	if check == nil {
+		return nil
+	}
+	out := *check
+	return &out
 }
 
 func cloneManagedCredentialRef(ref *runtimecontracts.ManagedCredentialRef) *runtimecontracts.ManagedCredentialRef {

--- a/internal/runtime/workflow_validation_test.go
+++ b/internal/runtime/workflow_validation_test.go
@@ -288,6 +288,124 @@ func TestValidateWorkflowContractSurface_TelegramProviderConnectorToolAdmitted(t
 	}
 }
 
+func TestValidateWorkflowContractSurface_SlackManagedCredentialProviderConnectorToolAdmitted(t *testing.T) {
+	bundle := testRuntimeWorkflowValidationBundle()
+	bundle.Tools = map[string]runtimecontracts.ToolSchemaEntry{
+		"slack.post_message": {
+			Category:    "provider_connector",
+			Description: "post Slack messages",
+			HandlerType: "http",
+			EffectClass: string(runtimecontracts.ActivityEffectClassNonIdempotentWrite),
+			ManagedCredential: &runtimecontracts.ManagedCredentialRef{
+				Key:    "slack_oauth",
+				Scopes: []string{"chat:write"},
+			},
+			InputSchema: runtimecontracts.ToolInputSchema{
+				Type:     "object",
+				Required: []string{"channel", "text"},
+				Properties: map[string]runtimecontracts.ToolInputSchema{
+					"channel": {Type: "string"},
+					"text":    {Type: "string"},
+				},
+			},
+			OutputSchema: runtimecontracts.ToolInputSchema{Type: "object"},
+			ResponseSuccess: &runtimecontracts.HTTPResponseSuccess{
+				Path:   "response.body.ok",
+				Equals: true,
+			},
+			HTTP: &runtimecontracts.HTTPToolSpec{
+				Method: "POST",
+				URL:    "https://slack.com/api/chat.postMessage",
+				Body: map[string]any{
+					"channel": "{{input.channel}}",
+					"text":    "{{input.text}}",
+				},
+			},
+		},
+	}
+	bundle.Nodes = map[string]runtimecontracts.SystemNodeContract{
+		"responder": {
+			EventHandlers: map[string]runtimecontracts.SystemNodeEventHandler{
+				"inbound.telegram": {
+					Activity: runtimecontracts.ActivitySpec{
+						Tool: "slack.post_message",
+						Input: map[string]runtimecontracts.ExpressionValue{
+							"channel": runtimecontracts.CELExpression(`"C123"`),
+							"text":    runtimecontracts.CELExpression(`"hello"`),
+						},
+					},
+				},
+			},
+		},
+	}
+	_, err := ValidateWorkflowContractSurface(context.Background(), semanticview.Wrap(bundle), WorkflowContractValidationOptions{
+		CheckMCPReachable:              false,
+		StrictEmitSchemas:              false,
+		FatalToolImplementationWarning: false,
+		FatalBootWarnings:              false,
+	})
+	if err != nil {
+		t.Fatalf("ValidateWorkflowContractSurface error = %v, want Slack managed connector admitted", err)
+	}
+}
+
+func TestValidateWorkflowContractSurface_SlackManagedCredentialProviderConnectorRequiresResponseSuccess(t *testing.T) {
+	bundle := testRuntimeWorkflowValidationBundle()
+	bundle.Tools = map[string]runtimecontracts.ToolSchemaEntry{
+		"slack.post_message": {
+			Category:    "provider_connector",
+			Description: "post Slack messages",
+			HandlerType: "http",
+			EffectClass: string(runtimecontracts.ActivityEffectClassNonIdempotentWrite),
+			ManagedCredential: &runtimecontracts.ManagedCredentialRef{
+				Key:    "slack_oauth",
+				Scopes: []string{"chat:write"},
+			},
+			InputSchema: runtimecontracts.ToolInputSchema{
+				Type:     "object",
+				Required: []string{"channel", "text"},
+				Properties: map[string]runtimecontracts.ToolInputSchema{
+					"channel": {Type: "string"},
+					"text":    {Type: "string"},
+				},
+			},
+			OutputSchema: runtimecontracts.ToolInputSchema{Type: "object"},
+			HTTP: &runtimecontracts.HTTPToolSpec{
+				Method: "POST",
+				URL:    "https://slack.com/api/chat.postMessage",
+				Body: map[string]any{
+					"channel": "{{input.channel}}",
+					"text":    "{{input.text}}",
+				},
+			},
+		},
+	}
+	bundle.Nodes = map[string]runtimecontracts.SystemNodeContract{
+		"responder": {
+			EventHandlers: map[string]runtimecontracts.SystemNodeEventHandler{
+				"inbound.telegram": {
+					Activity: runtimecontracts.ActivitySpec{
+						Tool: "slack.post_message",
+						Input: map[string]runtimecontracts.ExpressionValue{
+							"channel": runtimecontracts.CELExpression(`"C123"`),
+							"text":    runtimecontracts.CELExpression(`"hello"`),
+						},
+					},
+				},
+			},
+		},
+	}
+	_, err := ValidateWorkflowContractSurface(context.Background(), semanticview.Wrap(bundle), WorkflowContractValidationOptions{
+		CheckMCPReachable:              false,
+		StrictEmitSchemas:              false,
+		FatalToolImplementationWarning: false,
+		FatalBootWarnings:              false,
+	})
+	if err == nil || !strings.Contains(err.Error(), "provider connector validation failed") || !strings.Contains(err.Error(), "must declare response_success response.body.ok == true") {
+		t.Fatalf("ValidateWorkflowContractSurface error = %v, want Slack response_success fail-closed", err)
+	}
+}
+
 func TestValidateWorkflowContractSurface_ProviderConnectorToolFailsClosedForUnsupportedShape(t *testing.T) {
 	bundle := testRuntimeWorkflowValidationBundle()
 	bundle.Tools = map[string]runtimecontracts.ToolSchemaEntry{

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -2918,13 +2918,16 @@ handler_specification:
       supported_tool_sources:
         authored_http_tools: Required Stage 1 supported surface for read_only activity execution and for non_idempotent_write
           activity execution when the activity_attempts journal owns provider-attempt truth. The tool must be declared in
-          tools.yaml, resolve to handler_type http, and include an http block. read_only tools may retry under the read-only
-          retry policy. non_idempotent_write tools must insert activity_attempts.started before outbound dispatch, must not
-          automatically retry or re-dispatch once an attempt may have reached the provider, and may consume static
-          credentials through the existing credential-store/import-boundary owner. Missing static credentials fail before
-          provider dispatch. HTTP tools using managed_credential, response_mapping, rate_limit, or rate_limit_max_wait are
-          not admitted to activities in Stage 1; those subfeatures require later owner consumption before activity execution
-          may claim them.
+          tools.yaml or imported as a connector pack, resolve to handler_type http, and include an http block. read_only
+          tools may retry under the read-only retry policy. non_idempotent_write tools must check the existing
+          activity_attempts row for the request identity before credential resolution or outbound preparation, must insert
+          activity_attempts.started before outbound dispatch, must not automatically retry or re-dispatch once an attempt
+          may have reached the provider, and may consume static credentials through the existing credential-store/import-
+          boundary owner or managed credentials through `tool_model.managed_credential_store` when the tool is a
+          provider_connector. Missing static or managed credentials fail before provider dispatch. HTTP tools using
+          response_success are admitted as a provider response success predicate and fail the activity when the predicate
+          is false or unresolved. HTTP tools using response_mapping, rate_limit, or rate_limit_max_wait are not admitted to
+          activities in Stage 1; those subfeatures require later owner consumption before activity execution may claim them.
         platform_builtin: Not callable from activity in Stage 1; fail closed. This includes `artifact_repo_commit`, which
           remains action-owned under `handler_fields.action.valid_values.artifact_repo_commit` until a separately gated
           write-effect activity migration preserves that action's artifact safety and idempotency guarantees.
@@ -2932,8 +2935,10 @@ handler_specification:
           authored registration-site override is required in a future slice before MCP tools can be activity-callable.
         native_or_generated_tools: Not callable from activity in Stage 1; fail closed.
         credentialed_http_tools: Static credentials are admitted only for authored HTTP non_idempotent_write activities and
-          only through the existing credential-store/import-boundary owner. Static credential values must not appear in logs,
-          result payloads, readback, capability output, or errors. Managed credentials/OAuth remain split and fail closed.
+          only through the existing credential-store/import-boundary owner. Managed credentials are admitted only for
+          non_idempotent_write provider_connector HTTP activities and only through `tool_model.managed_credential_store`.
+          Static and managed credential values must not appear in logs, result payloads, readback, capability output, or
+          errors.
       effect_classes:
         read_only:
           retry_default: max_attempts 3, exponential backoff
@@ -2944,12 +2949,13 @@ handler_specification:
           retry_default: max_attempts 2, exponential backoff
           fork_default: reuse_recorded_result
         non_idempotent_write:
-          stage_1_execution: Executable only for authored HTTP tools, with optional static credentials, when the
-            activity_attempts journal is available. The runtime must resolve static credentials before provider dispatch,
-            insert the started attempt row before outbound dispatch, update the row with succeeded, failed, or uncertain
-            terminal state after the outcome, and consume the row on duplicate/redelivered request events before deciding
-            whether dispatch is allowed. Any existing started, uncertain, succeeded, or failed row blocks automatic provider
-            re-dispatch.
+          stage_1_execution: Executable only for authored HTTP tools, with optional static credentials or managed
+            credentials for provider_connector tools, when the activity_attempts journal is available. The runtime must
+            consume the row on duplicate/redelivered request events before credential resolution or provider preparation,
+            resolve admitted credentials before provider dispatch, insert the started attempt row before outbound dispatch,
+            update the row with succeeded, failed, or uncertain terminal state after the outcome, and consume the row on
+            duplicate/redelivered request events before deciding whether dispatch is allowed. Any existing started,
+            uncertain, succeeded, or failed row blocks automatic provider re-dispatch and managed credential refresh.
           retry_default: max_attempts 1, no retry
           fork_default: require_manual_confirmation
         long_running: Split to a later resume/cancel/journal slice; fail closed in Stage 1.
@@ -6275,6 +6281,12 @@ tool_model:
         output_schema: object — field names and types the tool returns (for documentation and LLM context)
         response_mapping: object — maps response body fields to tool output fields. If omitted, the entire response body is
           returned as the tool result.
+        response_success: >
+          object — optional provider success predicate evaluated after a 2xx HTTP response is parsed and before the tool
+          result is accepted. Fields: path is a response-rooted dotted path such as `response.body.ok`; equals is the
+          expected scalar value. Missing paths or unequal values fail closed. This is not response mapping and does not shape
+          output; it only prevents providers that encode failure inside HTTP 2xx bodies from being journaled as successful
+          calls.
         credentials: list of strings — credential store key names this tool needs. The platform resolves them from the credential
           store at call time and makes them available as {{credentials.key}} in templates.
         managed_credential: >
@@ -6293,12 +6305,13 @@ tool_model:
     template_resolution:
       description: Template variables in url, headers, body, and response_mapping are resolved at tool call time. URL
         template resolution is context-aware and performs URL-component percent-encoding for embedded substitutions;
-        headers, body, and response_mapping resolve raw semantic values.
+        headers, body, and response_mapping resolve raw semantic values. response_success is not a template expansion
+        field; it evaluates its response-rooted path against parsed HTTP response data.
       variables:
         input: Tool call arguments from the agent. Accessed as {{input.field_name}}.
         credentials: Values from the credential store for keys listed in the tool's credentials field. Accessed as {{credentials.key_name}}.
-        response: HTTP response data. Available only in response_mapping. Accessed as {{response.body}}, {{response.status}},
-          {{response.headers.header_name}}.
+        response: HTTP response data. Available only in response_success and response_mapping. Accessed as
+          {{response.body}}, {{response.status}}, {{response.headers.header_name}}.
       missing_variable: If a required template variable cannot be resolved (missing input field, missing credential), the tool
         call fails with an error returned to the agent. The platform does not make the HTTP request.
       managed_credentials: >
@@ -6347,22 +6360,25 @@ tool_model:
       pack_envelope: "internal/packs universal envelope plus internal/providerconnectors connector body verifier."
       execution: "handler `activity` lowering to `platform.activity_requested`."
       non_idempotent_journal: "`activity_attempts`."
-      credentials: "static credential store keys listed under tool `credentials`."
-      readback: "local preflight/doctor provider connector CAN/CANNOT/BOUND/UNBOUND findings."
+      credentials: "static credential store keys listed under tool `credentials`, or managed credential handles listed under tool `managed_credential`; exactly one credential mode owns connector auth."
+      readback: "local preflight/doctor provider connector CAN/CANNOT plus typed requirement status findings."
       display: "first CAN action label is derived from the authored tool `description`; if absent, it falls back to normalized `<action> via <Provider>`."
     stage_1_profile:
       required:
       - "tool id MUST use `<provider>.<action>` form."
       - "`handler_type` MUST resolve to `http` and include an `http` block with explicit `method` and `url`."
       - "`effect_class` MUST be `non_idempotent_write`."
-      - "at least one static credential key MUST be declared under `credentials`."
+      - "exactly one credential mode MUST be declared: either static credential keys under `credentials` or one managed credential handle under `managed_credential`."
+      - "If the provider can return HTTP 2xx for provider-level failure, the connector MUST declare `response_success` so the activity journal does not record that provider failure as success."
+      known_response_success_requirements:
+      - "Slack Web API `slack.post_message` MUST declare `response_success.path: response.body.ok` and `response_success.equals: true` whether authored locally or imported from the Slack connector pack."
       forbidden:
-      - "`managed_credential`; managed OAuth/token lifecycle is a separate owner."
+      - "declaring both static `credentials` and `managed_credential`; dual auth ownership is forbidden."
       - "`response_mapping`; connector response mapping is split until specified."
       - "`rate_limit` and `rate_limit_max_wait`; connector admission/rate limiting is split until specified."
       - "direct runtime provider adapter code or bespoke connector dispatch."
     connector_pack_profile:
-      status: "first slice: Telegram connector pack proof"
+      status: "first slices: Telegram static connector pack proof plus Slack managed-credential connector pack proof"
       body_file: connector.yaml
       import_syntax: >
         package.yaml `connector_packs.imports[]` entries name `provider` and `tool`. The import is an explicit enablement
@@ -6377,17 +6393,23 @@ tool_model:
         provider_connector profile, derives connector capabilities/requires mechanically from the tool declaration, and
         rejects any declared capability or requirement drift.
       capability_surface: >
-        Connector pack CAN/CANNOT/BOUND/UNBOUND readback is kind-specific. Connector CAN rows include calling the declared
-        provider action, lowering through `platform.activity_requested`, and journaling non-idempotent attempts in
+        Connector pack CAN/CANNOT/readback is kind-specific. Connector CAN rows include calling the declared provider
+        action, lowering through `platform.activity_requested`, and journaling non-idempotent attempts in
         `activity_attempts`. Connector CANNOT rows include bypassing `activity_attempts`, automatically retrying
-        non-idempotent writes, or exposing credential values.
+        non-idempotent writes, or exposing credential values. Requirement rows are typed: static secret requirements render
+        BOUND/UNBOUND from the static credential store, while managed credential requirements render managed credential
+        lifecycle status such as CONNECTED, UNCONNECTED, PENDING_CONSENT, REFRESH_FAILED, or SCOPE_INSUFFICIENT without
+        exposing token values.
       collision_policy: >
         No packed-vs-packed or packed-vs-flow-local connector shadowing is allowed in this slice. Any duplicate tool id
         fails closed before runtime construction and names both sources with remediation to remove one source or rename the
         flow-local tool.
       unbound_requirement_policy: >
         Pack import may succeed with an unbound credential name. Runtime activity dispatch must fail closed before the
-        provider HTTP call and before creating an `activity_attempts` row when a required static credential is unavailable.
+        provider HTTP call and before creating an `activity_attempts` row when a required static credential or managed
+        credential is unavailable, unconnected, pending, refresh_failed, scope-insufficient, unsupported, or unbound.
+        Duplicate/redelivered activity requests with an existing activity_attempts row must reuse the journaled result
+        before resolving managed credentials and MUST NOT refresh or dispatch again.
   credential_store:
     description: Secure storage for API keys, tokens, and other credentials referenced by MCP servers and HTTP tools. The
       platform provides a typed interface with a layered resolution model.
@@ -6479,7 +6501,8 @@ tool_model:
     - client_credentials as the first non-consent grant variant
     - access token, refresh token when present, expiry, scopes, provider/account identity, grant type, status, refresh
       policy, and failure evidence
-    - direct Executor.Execute, served /tools/{name}, and MCP tools/call HTTP-tool entry points
+    - direct Executor.Execute, served /tools/{name}, MCP tools/call HTTP-tool entry points, and provider_connector activity
+      execution on the `activity_attempts` path
     non_goals:
     - multi-tenant per-user token vault or end-user account selection
     - provider trigger/webhook adapters; those extend existing inbound.webhook in a separate owner
@@ -6522,9 +6545,11 @@ tool_model:
       packages.
     refresh_rule: >
       Before request dispatch, the resolver returns a valid access token or fails closed. It refreshes before use when the
-      access token is absent or expires within the configured refresh window. For provider 401 responses, the HTTP executor
-      refreshes once and retries the request once. Refresh failure sets refresh_failed state with redacted failure evidence
-      and returns a redacted runtime error.
+      access token is absent or expires within the configured refresh window. For provider 401 responses, supported HTTP
+      executors refresh once and retry the request once. For non_idempotent_write provider_connector activity execution,
+      the activity_attempts journal must be checked before managed credential resolution on duplicate/redelivered requests;
+      an existing row blocks refresh and provider redispatch. Refresh failure sets refresh_failed state with redacted failure
+      evidence and returns a redacted runtime error.
     operator_surface:
       command: swarm connections connect|callback|status|disconnect
       rule: >
@@ -6537,7 +6562,9 @@ tool_model:
     boot_validation: >
       Boot/verify consumes managed_credential requirements and reports managed_credential_state for missing, pending,
       refresh_failed, scope_insufficient, or otherwise unusable records. When boot warnings are fatal, these findings block
-      startup. Execution still fails closed even when boot warnings are non-fatal.
+      startup. Connector readback/doctor MUST compare declared tool scopes against connected record scopes and surface
+      scope_insufficient rather than connected/bound when the record does not cover every declared scope. Execution still
+      fails closed even when boot warnings are non-fatal.
     redaction_guarantee: >
       Access tokens, refresh tokens, client secrets, authorization codes, PKCE verifier/state, and provider errors containing
       those values MUST NOT be returned through logs, events, dead letters, tool results, metadata, or CLI/API/status
@@ -6609,9 +6636,9 @@ tool_model:
           body manifest and requires the declared block to equal the derived block in canonical form. Drift, extra
           capabilities, missing capabilities, or narrative/manual capability truth fail import.
         requires: >
-          Required dependency declaration surface for resources such as `webhook_signing.<provider>`. Declared requirements
-          describe binding needs and readback state; they do not make an otherwise valid pack invalid merely because the
-          deployment has not bound the secret yet.
+          Required typed dependency declaration surface for resources such as `webhook_signing.<provider>`, static connector
+          secrets, and managed connector credentials. Declared requirements describe binding needs and readback state; they
+          do not make an otherwise valid pack invalid merely because the deployment has not bound the requirement yet.
         tests: >
           Required metadata in this slice. Entries must parse as non-empty test references. Executing pack-declared tests is
           a later gated harness; current behavioral proof remains the provider-trigger conformance/runtime suite.
@@ -6641,11 +6668,14 @@ tool_model:
         without exposing secret values. `swarm doctor` is the first operator surface for this readback and renders the same
         verified first-party and declared external provider-trigger pack capability surface that serve admits at boot.
         Connector-pack readback uses connector-specific CAN/CANNOT rows defined by `tool_model.provider_connector_tools`;
-        trigger rows MUST NOT be reused to describe connector proof.
+        trigger rows MUST NOT be reused to describe connector proof. Connector requirement readback is typed and may include
+        static secrets or managed credentials with their own lifecycle statuses.
       unbound_requirement_policy: >
-        A missing deployment binding for a declared signing secret does not reject pack import. Runtime webhook admission
-        still fails closed before signature verification, dedupe marker persistence, or event publish when a required
-        signing secret is unavailable.
+        A missing deployment binding for a declared signing secret, static connector secret, or managed connector credential
+        does not reject pack import. Runtime webhook admission still fails closed before signature verification, dedupe
+        marker persistence, or event publish when a required signing secret is unavailable. Runtime connector activity
+        dispatch still fails closed before provider dispatch and before creating a new activity_attempts row when a required
+        connector credential is unavailable or unusable.
       first_party_pack_migration: >
         GitHub, Slack, Stripe, Twilio, Shopify, Typeform, Intercom, and Telegram provider-trigger manifests are first-party
         bundled packs loaded through this envelope path. There is no permanent built-in-control exemption for
@@ -6897,6 +6927,7 @@ tool_model:
     http_fields:
       http: object — HTTP request template (see http_tool_definition.schema.http_block)
       response_mapping: object — maps response fields to output fields
+      response_success: object — optional response-rooted success predicate, evaluated before accepting a 2xx HTTP result
       credentials: list of strings — credential store keys
       managed_credential: object — managed OAuth/token credential reference; supported only for handler_type http
       rate_limit: string — optional external dispatch admission rate, supported only when handler_type resolves to http.


### PR DESCRIPTION
## Summary

- Add a built-in Slack connector pack carrying a normal `ToolSchemaEntry` for `slack.post_message`, imported explicitly through `connector_packs.imports`.
- Extend pack requirements/readback to model typed requirements: static secrets and managed credentials.
- Allow managed credentials only for approved provider connector HTTP non-idempotent writes, with fail-closed validation and runtime behavior.
- Prove Slack OAuth-backed connector execution through the existing activity journal path, including refresh-before-use, refresh-on-401, replay, and no-secret-leak cases.

Closes #1876
Related to #1458, #1650, #1855, #1766, #1839, #1862, #1870, #1871, #1663

## Governing Refs / Context

Exact governing spec sections updated or consumed:

- `tool_model.http_tool_definition`
- `tool_model.managed_credential_store`
- `tool_model.provider_connector_tools`
- `handler_specification.handler_fields.activity`
- `platform_tables.activity_attempts`
- `internal/runtime/managedcredentials`
- `internal/runtime/tools/executor_http.go`
- `internal/providerconnectors`
- `internal/packs`

## Semantic Migration

New canonical owners after this change:

- Connector declaration model: existing `ToolSchemaEntry` remains the single semantic owner.
- Pack dependency declarations: `internal/packs.Requires`, now typed as static secrets and managed credentials.
- Provider connector validation/readback: `internal/providerconnectors`.
- Managed credential token lifecycle: `internal/runtime/managedcredentials`.
- Non-idempotent connector execution and replay: `activity_attempts` plus the runtime activity path.

Old paths now invalid / non-authoritative:

- Provider connector validation can no longer assume static credentials are the only supported credential shape.
- Pack `requires.secrets` can no longer represent all connector dependency requirements.
- Activity validation/runtime can no longer blanket-reject managed credentials for approved `provider_connector` + `non_idempotent_write` HTTP activity profiles.
- Replay can no longer prepare/refresh credentials before checking for an existing `activity_attempts` row.

Production paths checked for surviving old behavior:

- Pack load and connector import.
- Provider connector validation/readback and doctor output.
- Workflow validation.
- Runtime main pipeline and selected run-fork pipeline wiring.
- Direct HTTP/static connector regressions.
- Slack managed connector supported-surface runtime proof.
- Existing Telegram static connector supported-surface regression.

Migration completeness: complete for the #1876 Slack OAuth-backed connector pack child slice. Parent #1458 remains open for broader managed credential/provider OAuth coverage.

## Tests

Focused supported-surface and regression proof:

```sh
SWARM_TEST_POSTGRES_DSN='host=127.0.0.1 port=5432 user=youmew dbname=postgres sslmode=disable' PGPASSWORD=postgres go test ./internal/packs ./internal/providerconnectors ./internal/runtime/managedcredentials ./internal/runtime/tools ./internal/runtime ./internal/runtime/pipeline ./cmd/swarm -run 'Test.*ManagedCredential|TestProviderConnector|TestConnectorPack|TestDefaultPackRegistry|TestSlack|TestValidateWorkflowContractSurface_TelegramProviderConnectorToolAdmitted|TestValidateWorkflowContractSurface_ProviderConnectorToolFailsClosedForUnsupportedShape|TestTelegramConnectorSupportedSurfaceRoundTripThroughInboundGateway/sqlite|TestPipelineActivity|TestDoctorClaudeCLIPreflightReportsSlackManagedConnectorPackSurface|TestDoctorClaudeCLIPreflightReportsTelegramConnectorToolSurface' -count=1
```

Whole suite, serialized after local concurrent-test pressure:

```sh
SWARM_TEST_POSTGRES_DSN='host=127.0.0.1 port=5432 user=youmew dbname=postgres sslmode=disable' PGPASSWORD=postgres go test -p 1 ./...
```

Required whole suite:

```sh
SWARM_TEST_POSTGRES_DSN='host=127.0.0.1 port=5432 user=youmew dbname=postgres sslmode=disable' PGPASSWORD=postgres go test ./...
```
