### PR TITLE
[agent-a][issue #1835] Add select-or-create instance resolution

### DIFF
--- a/internal/runtime/bootverify/workflow_composition_connect_checks.go
+++ b/internal/runtime/bootverify/workflow_composition_connect_checks.go
@@ -203,7 +203,7 @@ func validateCompositionConnectInstanceKey(source semanticview.Source, connect r
 	adapter := connect.Using.Instance
 	if !inputPin.Resolution.Empty() {
 		switch inputPin.Resolution.Mode {
-		case runtimecontracts.FlowInputResolutionModeCreate, runtimecontracts.FlowInputResolutionModeSelect:
+		case runtimecontracts.FlowInputResolutionModeCreate, runtimecontracts.FlowInputResolutionModeSelect, runtimecontracts.FlowInputResolutionModeSelectOrCreate:
 			if strings.TrimSpace(connect.Delivery) != "" && strings.TrimSpace(connect.Delivery) != "one" {
 				return []Finding{compositionConnectFinding(connect, "instance_resolution_invalid", fmt.Sprintf("resolution mode %s requires delivery one", inputPin.Resolution.Mode), receiverFlowID)}
 			}
@@ -312,10 +312,9 @@ func validateInputPinResolution(source semanticview.Source, flowID string, pin r
 	switch resolution.Mode {
 	case runtimecontracts.FlowInputResolutionModeCreate:
 		return validateCreateInputPinResolution(source, flowID, pin)
-	case runtimecontracts.FlowInputResolutionModeSelect:
-		return validateSelectInputPinResolution(source, flowID, pin)
-	case runtimecontracts.FlowInputResolutionModeSelectOrCreate,
-		runtimecontracts.FlowInputResolutionModeFanIn,
+	case runtimecontracts.FlowInputResolutionModeSelect, runtimecontracts.FlowInputResolutionModeSelectOrCreate:
+		return validateCarriedKeyInputPinResolution(source, flowID, pin, resolution.Mode)
+	case runtimecontracts.FlowInputResolutionModeFanIn,
 		runtimecontracts.FlowInputResolutionModeFanOut,
 		runtimecontracts.FlowInputResolutionModeReply:
 		findings = append(findings, inputPinResolutionFinding(flowID, pin, "instance_resolution_unimplemented", fmt.Sprintf("resolution mode %q is design-locked but not runnable in this slice", resolution.Mode), location))
@@ -327,12 +326,12 @@ func validateInputPinResolution(source semanticview.Source, flowID string, pin r
 	return findings
 }
 
-func validateSelectInputPinResolution(source semanticview.Source, flowID string, pin runtimecontracts.FlowInputEventPin) []Finding {
+func validateCarriedKeyInputPinResolution(source semanticview.Source, flowID string, pin runtimecontracts.FlowInputEventPin, mode string) []Finding {
 	var findings []Finding
 	resolution := pin.Resolution
 	location := flowID
 	if resolution.Aggregation != "" || resolution.Window != "" || len(resolution.DedupBy) > 0 || resolution.Singleton != "" || resolution.RepliesTo != "" || resolution.CorrelationKey != "" || resolution.InstanceKey.Mint != "" || resolution.InstanceKey.As != "" {
-		findings = append(findings, inputPinResolutionFinding(flowID, pin, "instance_resolution_invalid", "resolution mode select may only declare instance_key and carries", location))
+		findings = append(findings, inputPinResolutionFinding(flowID, pin, "instance_resolution_invalid", fmt.Sprintf("resolution mode %s may only declare instance_key and carries", mode), location))
 	}
 	bundle, ok := semanticview.Bundle(source)
 	if !ok || bundle == nil {
@@ -344,24 +343,24 @@ func validateSelectInputPinResolution(source semanticview.Source, flowID string,
 	}
 	key := strings.TrimSpace(resolution.InstanceKey.From)
 	if key == "" {
-		findings = append(findings, inputPinResolutionFinding(flowID, pin, "instance_resolution_invalid", "resolution mode select requires instance_key to name a carried field", location))
+		findings = append(findings, inputPinResolutionFinding(flowID, pin, "instance_resolution_invalid", fmt.Sprintf("resolution mode %s requires instance_key to name a carried field", mode), location))
 		return findings
 	}
 	if len(instance.By) != 1 {
-		findings = append(findings, inputPinResolutionFinding(flowID, pin, "instance_resolution_invalid", fmt.Sprintf("resolution mode select requires exactly one receiver instance.by field, got %v", instance.By), location))
+		findings = append(findings, inputPinResolutionFinding(flowID, pin, "instance_resolution_invalid", fmt.Sprintf("resolution mode %s requires exactly one receiver instance.by field, got %v", mode, instance.By), location))
 		return findings
 	}
 	if strings.TrimSpace(instance.By[0]) != key {
-		findings = append(findings, inputPinResolutionFinding(flowID, pin, "instance_resolution_invalid", fmt.Sprintf("resolution mode select instance_key %q must match the receiver's single instance.by field %v", key, instance.By), location))
+		findings = append(findings, inputPinResolutionFinding(flowID, pin, "instance_resolution_invalid", fmt.Sprintf("resolution mode %s instance_key %q must match the receiver's single instance.by field %v", mode, key, instance.By), location))
 	}
 	carry, ok := pin.Carries[key]
 	if !ok {
-		findings = append(findings, inputPinResolutionFinding(flowID, pin, "instance_resolution_invalid", fmt.Sprintf("resolution mode select instance_key %s must name a declared carries.%s field", key, key), location))
+		findings = append(findings, inputPinResolutionFinding(flowID, pin, "instance_resolution_invalid", fmt.Sprintf("resolution mode %s instance_key %s must name a declared carries.%s field", mode, key, key), location))
 		return findings
 	}
 	wantFrom := "payload." + key
 	if strings.TrimSpace(carry.From) != wantFrom {
-		findings = append(findings, inputPinResolutionFinding(flowID, pin, "instance_resolution_invalid", fmt.Sprintf("carry %s must use from: %s for resolution mode select", key, wantFrom), location))
+		findings = append(findings, inputPinResolutionFinding(flowID, pin, "instance_resolution_invalid", fmt.Sprintf("carry %s must use from: %s for resolution mode %s", key, wantFrom, mode), location))
 	}
 	if carry.Type != "" {
 		targetType, err := compositionConnectTargetType(source, flowID, "entity."+key)

--- a/internal/runtime/bootverify/workflow_composition_connect_checks_test.go
+++ b/internal/runtime/bootverify/workflow_composition_connect_checks_test.go
@@ -169,15 +169,15 @@ func TestRun_FailsClosedForInvalidSelectInputResolution(t *testing.T) {
 		for _, tc := range tests {
 			t.Run(mode+"/"+tc.name, func(t *testing.T) {
 				tc.opts.mode = mode
-			root := writeSelectResolutionCompositionConnectFixture(t, tc.opts)
-			bundle := loadFixtureBundleAt(t, repoRootForBootverifyTest(t), root, runtimecontracts.DefaultPlatformSpecFile(repoRootForBootverifyTest(t)))
+				root := writeSelectResolutionCompositionConnectFixture(t, tc.opts)
+				bundle := loadFixtureBundleAt(t, repoRootForBootverifyTest(t), root, runtimecontracts.DefaultPlatformSpecFile(repoRootForBootverifyTest(t)))
 
-			report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+				report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
 
-			if !reportContains(report.Errors(), "composition_connect_validation", tc.want) {
-				t.Fatalf("expected composition_connect_validation %q, got %#v", tc.want, report.Errors())
-			}
-		})
+				if !reportContains(report.Errors(), "composition_connect_validation", tc.want) {
+					t.Fatalf("expected composition_connect_validation %q, got %#v", tc.want, report.Errors())
+				}
+			})
 		}
 	}
 }

--- a/internal/runtime/bootverify/workflow_composition_connect_checks_test.go
+++ b/internal/runtime/bootverify/workflow_composition_connect_checks_test.go
@@ -99,6 +99,25 @@ func TestRun_AllowsSelectInputResolutionCompositionConnect(t *testing.T) {
 	}
 }
 
+func TestRun_AllowsSelectOrCreateInputResolutionCompositionConnect(t *testing.T) {
+	root := writeSelectResolutionCompositionConnectFixture(t, selectResolutionCompositionFixtureOptions{
+		mode: runtimecontracts.FlowInputResolutionModeSelectOrCreate,
+	})
+	bundle := loadFixtureBundleAt(t, repoRootForBootverifyTest(t), root, runtimecontracts.DefaultPlatformSpecFile(repoRootForBootverifyTest(t)))
+
+	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+
+	if reportContains(report.Errors(), "composition_connect_validation", "") {
+		t.Fatalf("unexpected composition_connect_validation error: %#v", report.Errors())
+	}
+	if reportContains(report.Errors(), "template_instance_validation", "") {
+		t.Fatalf("unexpected template_instance_validation error: %#v", report.Errors())
+	}
+	if reportContains(report.Errors(), "input_pin_wiring", "account.ready") {
+		t.Fatalf("parent connect should satisfy select-or-create-resolution input pin wiring proof, got %#v", report.Errors())
+	}
+}
+
 func TestRun_FailsClosedForInvalidSelectInputResolution(t *testing.T) {
 	tests := []struct {
 		name string
@@ -143,11 +162,13 @@ func TestRun_FailsClosedForInvalidSelectInputResolution(t *testing.T) {
 		{
 			name: "wrong delivery",
 			opts: selectResolutionCompositionFixtureOptions{delivery: "many"},
-			want: "resolution mode select requires delivery one",
+			want: "requires delivery one",
 		},
 	}
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
+	for _, mode := range []string{runtimecontracts.FlowInputResolutionModeSelect, runtimecontracts.FlowInputResolutionModeSelectOrCreate} {
+		for _, tc := range tests {
+			t.Run(mode+"/"+tc.name, func(t *testing.T) {
+				tc.opts.mode = mode
 			root := writeSelectResolutionCompositionConnectFixture(t, tc.opts)
 			bundle := loadFixtureBundleAt(t, repoRootForBootverifyTest(t), root, runtimecontracts.DefaultPlatformSpecFile(repoRootForBootverifyTest(t)))
 
@@ -157,6 +178,7 @@ func TestRun_FailsClosedForInvalidSelectInputResolution(t *testing.T) {
 				t.Fatalf("expected composition_connect_validation %q, got %#v", tc.want, report.Errors())
 			}
 		})
+		}
 	}
 }
 
@@ -167,9 +189,9 @@ func TestRun_FailsClosedForInvalidCreateInputResolution(t *testing.T) {
 		want string
 	}{
 		{
-			name: "non-create modes are design-locked but not runnable",
+			name: "non-runnable modes are design-locked but not runnable",
 			opts: createResolutionCompositionFixtureOptions{
-				mode:         runtimecontracts.FlowInputResolutionModeSelectOrCreate,
+				mode:         runtimecontracts.FlowInputResolutionModeFanIn,
 				mint:         runtimecontracts.FlowInputResolutionMintUUID,
 				includeCarry: true,
 			},
@@ -1167,6 +1189,7 @@ type createResolutionCompositionFixtureOptions struct {
 }
 
 type selectResolutionCompositionFixtureOptions struct {
+	mode          string
 	instanceKey   string
 	carryType     string
 	receiverMode  string
@@ -1191,6 +1214,10 @@ func writeSelectResolutionCompositionConnectFixture(t *testing.T, opts selectRes
 	instanceKey := strings.TrimSpace(opts.instanceKey)
 	if instanceKey == "" {
 		instanceKey = "account_id"
+	}
+	mode := strings.TrimSpace(opts.mode)
+	if mode == "" {
+		mode = runtimecontracts.FlowInputResolutionModeSelect
 	}
 	carryType := strings.TrimSpace(opts.carryType)
 	if carryType == "" {
@@ -1276,7 +1303,7 @@ pins:
       - name: account_ready
         event: account.ready`+addressBlock+`
         resolution:
-          mode: select
+          mode: `+mode+`
           instance_key: `+instanceKey+`
         carries:
           account_id:

--- a/internal/runtime/bus/connect_route_plan_dispatch.go
+++ b/internal/runtime/bus/connect_route_plan_dispatch.go
@@ -46,7 +46,7 @@ func newConnectRoutePlanResolver(source semanticview.Source, routeTable *RouteTa
 		plans:           append([]runtimepinrouting.ConnectRoutePlan(nil), plans...),
 		issues:          append([]runtimepinrouting.ConnectRoutePlanIssue(nil), issues...),
 		loadDescriptors: loadDescriptors,
-		lifecycle:       newTemplateInstanceLifecycleOwner(source, loadDescriptors, activator),
+		lifecycle:       newTemplateInstanceLifecycleOwner(source, routeTable, loadDescriptors, activator),
 	}
 }
 

--- a/internal/runtime/bus/connect_route_plan_dispatch.go
+++ b/internal/runtime/bus/connect_route_plan_dispatch.go
@@ -392,7 +392,11 @@ func connectRoutePlanTargetFailure(failure runtimepinrouting.ConnectRoutePlanFai
 }
 
 func connectRoutePlanFailureDetail(plan runtimepinrouting.ConnectRoutePlan, failure runtimepinrouting.ConnectRoutePlanFailure, values map[string]string, descriptors []runtimepinrouting.Descriptor) map[string]any {
-	if plan.InstanceKey == nil || strings.TrimSpace(plan.InstanceKey.Mode) != runtimecontracts.FlowInputResolutionModeSelect {
+	if plan.InstanceKey == nil {
+		return nil
+	}
+	mode := strings.TrimSpace(plan.InstanceKey.Mode)
+	if mode != runtimecontracts.FlowInputResolutionModeSelect && mode != runtimecontracts.FlowInputResolutionModeSelectOrCreate {
 		return nil
 	}
 	fields := plan.InstanceKey.Fields
@@ -404,15 +408,15 @@ func connectRoutePlanFailureDetail(plan runtimepinrouting.ConnectRoutePlan, fail
 		return nil
 	}
 	out := map[string]any{
-		"connect_route_plan_resolution_mode":     runtimecontracts.FlowInputResolutionModeSelect,
+		"connect_route_plan_resolution_mode":     mode,
 		"connect_route_plan_receiver_flow":       strings.TrimSpace(plan.Receiver.FlowID),
 		"connect_route_plan_instance_key_field":  keyField,
-		"connect_route_plan_failure_remediation": connectRoutePlanSelectRemediation(plan, failure, keyField, ""),
+		"connect_route_plan_failure_remediation": connectRoutePlanInstanceResolutionRemediation(plan, failure, keyField, "", mode),
 	}
 	material, materialFailure := runtimepinrouting.InstanceKeyMaterialForConnectRoutePlan(plan, values)
 	if materialFailure != "" {
 		if failure == runtimepinrouting.ConnectFailureAddressValueMissing {
-			out["connect_route_plan_failure_remediation"] = connectRoutePlanSelectRemediation(plan, failure, keyField, "")
+			out["connect_route_plan_failure_remediation"] = connectRoutePlanInstanceResolutionRemediation(plan, failure, keyField, "", mode)
 		}
 		return out
 	}
@@ -429,11 +433,11 @@ func connectRoutePlanFailureDetail(plan runtimepinrouting.ConnectRoutePlan, fail
 	if failure == runtimepinrouting.ConnectFailureTargetAmbiguous {
 		out["connect_route_plan_matched_instance_count"] = len(runtimepinrouting.InstanceKeyDescriptorRoutesForConnectRoutePlan(plan, material.Keys, descriptors))
 	}
-	out["connect_route_plan_failure_remediation"] = connectRoutePlanSelectRemediation(plan, failure, keyField, keyValue)
+	out["connect_route_plan_failure_remediation"] = connectRoutePlanInstanceResolutionRemediation(plan, failure, keyField, keyValue, mode)
 	return out
 }
 
-func connectRoutePlanSelectRemediation(plan runtimepinrouting.ConnectRoutePlan, failure runtimepinrouting.ConnectRoutePlanFailure, keyField, keyValue string) string {
+func connectRoutePlanInstanceResolutionRemediation(plan runtimepinrouting.ConnectRoutePlan, failure runtimepinrouting.ConnectRoutePlanFailure, keyField, keyValue, mode string) string {
 	receiverFlow := strings.TrimSpace(plan.Receiver.FlowID)
 	if receiverFlow == "" {
 		receiverFlow = "receiver flow"
@@ -448,11 +452,14 @@ func connectRoutePlanSelectRemediation(plan runtimepinrouting.ConnectRoutePlan, 
 	}
 	switch failure {
 	case runtimepinrouting.ConnectFailureAddressValueMissing:
-		return fmt.Sprintf("Provide payload.%s before publishing to %s; resolution mode select requires a carried key value.", keyLabel, receiverFlow)
+		return fmt.Sprintf("Provide payload.%s before publishing to %s; resolution mode %s requires a carried key value.", keyLabel, receiverFlow, mode)
 	case runtimepinrouting.ConnectFailureTargetAmbiguous:
-		return fmt.Sprintf("Ensure exactly one active %s instance has %s%s; resolution mode select cannot choose between multiple matches.", receiverFlow, keyLabel, valueText)
+		return fmt.Sprintf("Ensure exactly one active %s instance has %s%s; resolution mode %s cannot choose between multiple matches.", receiverFlow, keyLabel, valueText, mode)
 	default:
-		return fmt.Sprintf("Create or connect exactly one active %s instance with %s%s before publishing; resolution mode select never creates a missing instance.", receiverFlow, keyLabel, valueText)
+		if mode == runtimecontracts.FlowInputResolutionModeSelectOrCreate {
+			return fmt.Sprintf("Ensure %s can create or reuse exactly one active instance with %s%s; resolution mode %s must converge on one instance.", receiverFlow, keyLabel, valueText, mode)
+		}
+		return fmt.Sprintf("Create or connect exactly one active %s instance with %s%s before publishing; resolution mode %s never creates a missing instance.", receiverFlow, keyLabel, valueText, mode)
 	}
 }
 

--- a/internal/runtime/bus/connect_route_plan_dispatch_test.go
+++ b/internal/runtime/bus/connect_route_plan_dispatch_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -52,6 +53,11 @@ type connectRoutePlanLifecycleStore struct {
 	*connectRoutePlanDescriptorStore
 	bus         *EventBus
 	activations []runtimepipeline.FlowInstanceActivationRequest
+}
+
+type connectRoutePlanConcurrentLifecycleStore struct {
+	*connectRoutePlanLifecycleStore
+	mu sync.Mutex
 }
 
 type targetRouteMemoryEventMutation struct {
@@ -132,6 +138,53 @@ func (s *connectRoutePlanLifecycleStore) Activate(ctx context.Context, req runti
 		Identity:            req.Instance.Route(),
 		ActivationVariables: connectRoutePlanActivationVariables(req),
 	})
+}
+
+func (s *connectRoutePlanConcurrentLifecycleStore) ListActiveFlowInstanceDescriptors(ctx context.Context) ([]ActiveFlowInstanceDescriptor, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.flowInstanceDescriptorCalls++
+	return append([]ActiveFlowInstanceDescriptor(nil), s.flowInstances...), nil
+}
+
+func (s *connectRoutePlanConcurrentLifecycleStore) Activate(ctx context.Context, req runtimepipeline.FlowInstanceActivationRequest) error {
+	s.mu.Lock()
+	for _, descriptor := range s.flowInstances {
+		descriptor = descriptor.Normalized()
+		if descriptor.InstanceID == req.Instance.InstanceID || descriptor.FlowInstance == req.Instance.InstancePath {
+			s.mu.Unlock()
+			return errors.New("flow instance already exists")
+		}
+	}
+	s.activations = append(s.activations, req)
+	s.flowInstances = append(s.flowInstances, ActiveFlowInstanceDescriptor{
+		InstanceID:    req.Instance.InstanceID,
+		EntityID:      req.Instance.EntityID,
+		FlowInstance:  req.Instance.InstancePath,
+		FlowTemplate:  req.Instance.TemplateID,
+		AddressFields: connectRoutePlanActivationAddressFields(req.Metadata),
+	})
+	bus := s.bus
+	s.mu.Unlock()
+	if bus == nil {
+		return nil
+	}
+	return bus.AddFlowInstanceRouteContext(ctx, FlowInstanceRouteMaterializationRequest{
+		Identity:            req.Instance.Route(),
+		ActivationVariables: connectRoutePlanActivationVariables(req),
+	})
+}
+
+func (s *connectRoutePlanConcurrentLifecycleStore) ActivationCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.activations)
+}
+
+func (s *connectRoutePlanConcurrentLifecycleStore) FlowInstanceDescriptors() []ActiveFlowInstanceDescriptor {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]ActiveFlowInstanceDescriptor(nil), s.flowInstances...)
 }
 
 func connectRoutePlanActivationAddressFields(metadata map[string]any) map[string]string {
@@ -1233,6 +1286,246 @@ func TestEventBusPublish_ConnectRoutePlanSelectResolutionFailsClosedForTargetGap
 			}
 			requireNoConnectRoutePlanBusEvent(t, raw, "source/raw subscriber fallback")
 		})
+	}
+}
+
+func TestEventBusPublish_ConnectRoutePlanSelectOrCreateResolutionReusesCreatesAndReplaysCommittedRoute(t *testing.T) {
+	source := connectRoutePlanSelectOrCreateResolutionSourceWithPolicy(t, "reject", "reject")
+	store := &connectRoutePlanLifecycleStore{
+		connectRoutePlanDescriptorStore: &connectRoutePlanDescriptorStore{
+			targetRouteMemoryStore: newTargetRouteMemoryStore(),
+			flowInstances: []ActiveFlowInstanceDescriptor{{
+				InstanceID:    "one",
+				EntityID:      "ent-1",
+				FlowInstance:  "account/one",
+				AddressFields: map[string]string{"entity.account_id": "acct-1"},
+			}},
+		},
+	}
+	eb, err := NewEventBusWithOptions(store, EventBusOptions{
+		ContractBundle:            source,
+		TemplateInstanceActivator: store.Activate,
+	})
+	if err != nil {
+		t.Fatalf("NewEventBusWithOptions: %v", err)
+	}
+	store.bus = eb
+	if err := eb.AddFlowInstanceRoute(FlowInstanceRouteMaterializationRequest{Identity: runtimeflowidentity.DeriveRoute("account", "one")}); err != nil {
+		t.Fatalf("AddFlowInstanceRoute(one): %v", err)
+	}
+	existingID := uuid.NewString()
+	existing := eventtest.RootIngress(existingID,
+		events.EventType("producer/account.ready"), "", "", json.RawMessage(`{"account_id":"acct-1"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())
+	existingWant := events.DeliveryRoute{SubscriberType: "node", SubscriberID: "account-node-one", Target: events.RouteIdentity{FlowID: "account", FlowInstance: "account/one", EntityID: "ent-1"}}
+
+	preflight, err := eb.CheckPublishRecipientPlan(context.Background(), existing)
+	if err != nil {
+		t.Fatalf("CheckPublishRecipientPlan(existing): %v", err)
+	}
+	if preflight.TargetFailure != "" || !deliveryRoutesContain(preflight.DeliveryRoutes, existingWant) || len(preflight.DeliveryRoutes) != 1 {
+		t.Fatalf("existing preflight failure/routes = %q/%#v, want existing route %#v", preflight.TargetFailure, preflight.DeliveryRoutes, existingWant)
+	}
+	if got := len(store.activations); got != 0 {
+		t.Fatalf("existing preflight activations = %d, want 0", got)
+	}
+	if err := eb.Publish(context.Background(), existing); err != nil {
+		t.Fatalf("Publish(existing): %v", err)
+	}
+	if got := len(store.activations); got != 0 {
+		t.Fatalf("existing publish activations = %d, want 0 because select-or-create reuses exact match", got)
+	}
+	if !deliveryRoutesContain(store.routes[existingID], existingWant) || len(store.routes[existingID]) != 1 {
+		t.Fatalf("existing persisted routes = %#v, want %#v", store.routes[existingID], existingWant)
+	}
+
+	missingID := uuid.NewString()
+	missing := eventtest.RootIngress(missingID,
+		events.EventType("producer/account.ready"), "", "", json.RawMessage(`{"account_id":"acct-2"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())
+	preflight, err = eb.CheckPublishRecipientPlan(context.Background(), missing)
+	if err != nil {
+		t.Fatalf("CheckPublishRecipientPlan(missing): %v", err)
+	}
+	if preflight.TargetFailure != "" || len(preflight.DeliveryRoutes) != 1 {
+		t.Fatalf("missing preflight failure/routes = %q/%#v, want preview route", preflight.TargetFailure, preflight.DeliveryRoutes)
+	}
+	if got := len(store.activations); got != 0 {
+		t.Fatalf("missing preflight activations = %d, want 0 preview-only", got)
+	}
+	if err := eb.Publish(context.Background(), missing); err != nil {
+		t.Fatalf("Publish(missing): %v", err)
+	}
+	if got := len(store.activations); got != 1 {
+		t.Fatalf("missing publish activations = %d, want 1 create", got)
+	}
+	activation := store.activations[0]
+	if activation.Config["template_instance_on_missing"] != "create" || activation.Config["template_instance_on_conflict"] != "reuse" {
+		t.Fatalf("activation policy config = %#v, want canonical select-or-create create/reuse", activation.Config)
+	}
+	if activation.Config["account_id"] != "acct-2" || activation.Metadata["account_id"] != "acct-2" {
+		t.Fatalf("activation config/metadata = %#v/%#v, want carried account_id acct-2", activation.Config, activation.Metadata)
+	}
+	createdWant := events.DeliveryRoute{
+		SubscriberType: "node",
+		SubscriberID:   "account-node-" + activation.Instance.InstanceID,
+		Target: events.RouteIdentity{
+			FlowID:       "account",
+			FlowInstance: activation.Instance.InstancePath,
+			EntityID:     activation.Instance.EntityID,
+		},
+	}
+	if !deliveryRoutesContain(store.routes[missingID], createdWant) || len(store.routes[missingID]) != 1 {
+		t.Fatalf("missing persisted routes = %#v, want created route %#v", store.routes[missingID], createdWant)
+	}
+
+	retryID := uuid.NewString()
+	retry := eventtest.RootIngress(retryID,
+		events.EventType("producer/account.ready"), "", "", json.RawMessage(`{"account_id":"acct-2"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())
+	if err := eb.Publish(context.Background(), retry); err != nil {
+		t.Fatalf("Publish(retry): %v", err)
+	}
+	if got := len(store.activations); got != 1 {
+		t.Fatalf("retry activations = %d, want reuse without second activation", got)
+	}
+	if !deliveryRoutesContain(store.routes[retryID], createdWant) || len(store.routes[retryID]) != 1 {
+		t.Fatalf("retry persisted routes = %#v, want reused route %#v", store.routes[retryID], createdWant)
+	}
+
+	replayTarget := eb.SubscribeInternal("account-node-" + activation.Instance.InstanceID)
+	store.flowInstances = []ActiveFlowInstanceDescriptor{{
+		InstanceID:    "drift",
+		EntityID:      "ent-drift",
+		FlowInstance:  "account/drift",
+		AddressFields: map[string]string{"entity.account_id": "acct-2"},
+	}}
+	store.flowInstanceDescriptorCalls = 0
+	if err := eb.AddFlowInstanceRoute(FlowInstanceRouteMaterializationRequest{Identity: runtimeflowidentity.DeriveRoute("account", "drift")}); err != nil {
+		t.Fatalf("AddFlowInstanceRoute(drift): %v", err)
+	}
+	if err := eb.PublishPersistedRecipients(context.Background(), missing, nil); err != nil {
+		t.Fatalf("PublishPersistedRecipients: %v", err)
+	}
+	replayed := requireBusEvent(t, replayTarget, "select-or-create committed replay")
+	if replayed.FlowInstance() != activation.Instance.InstancePath || replayed.EntityID() != activation.Instance.EntityID {
+		t.Fatalf("replayed target = flow_instance:%q entity:%q, want persisted %s/%s",
+			replayed.FlowInstance(), replayed.EntityID(), activation.Instance.InstancePath, activation.Instance.EntityID)
+	}
+	if got := store.flowInstanceDescriptorCalls; got != 0 {
+		t.Fatalf("replay descriptor calls = %d, want 0 because persisted route/scope is authoritative", got)
+	}
+}
+
+func TestEventBusPublish_ConnectRoutePlanSelectOrCreateResolutionFailsClosedForAmbiguousTarget(t *testing.T) {
+	source := connectRoutePlanSelectOrCreateResolutionSourceWithPolicy(t, "reject", "reject")
+	store := &connectRoutePlanLifecycleStore{
+		connectRoutePlanDescriptorStore: &connectRoutePlanDescriptorStore{
+			targetRouteMemoryStore: newTargetRouteMemoryStore(),
+			flowInstances: []ActiveFlowInstanceDescriptor{
+				{InstanceID: "one", EntityID: "ent-1", FlowInstance: "account/one", AddressFields: map[string]string{"entity.account_id": "acct-1"}},
+				{InstanceID: "two", EntityID: "ent-2", FlowInstance: "account/two", AddressFields: map[string]string{"entity.account_id": "acct-1"}},
+			},
+		},
+	}
+	eb, err := NewEventBusWithOptions(store, EventBusOptions{
+		ContractBundle:            source,
+		TemplateInstanceActivator: store.Activate,
+	})
+	if err != nil {
+		t.Fatalf("NewEventBusWithOptions: %v", err)
+	}
+	store.bus = eb
+	for _, instanceID := range []string{"one", "two"} {
+		if err := eb.AddFlowInstanceRoute(FlowInstanceRouteMaterializationRequest{Identity: runtimeflowidentity.DeriveRoute("account", instanceID)}); err != nil {
+			t.Fatalf("AddFlowInstanceRoute(%s): %v", instanceID, err)
+		}
+	}
+	eventID := uuid.NewString()
+	evt := eventtest.RootIngress(eventID,
+		events.EventType("producer/account.ready"), "", "", json.RawMessage(`{"account_id":"acct-1"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())
+
+	routePlan, err := eb.planSubscribedRoutePlan(context.Background(), evt, false)
+	if err != nil {
+		t.Fatalf("planSubscribedRoutePlan: %v", err)
+	}
+	if routePlan.AuthorityState != RoutePlanAuthorityCanonicalFailedClosed || routePlan.TargetFailure != runtimepinrouting.TargetFailure(runtimepinrouting.ConnectFailureTargetAmbiguous) {
+		t.Fatalf("route plan authority/failure = %q/%q, want fail-closed ambiguous", routePlan.AuthorityState, routePlan.TargetFailure)
+	}
+	if got := routePlan.ExtraDetail["connect_route_plan_matched_instance_count"]; got != 2 {
+		t.Fatalf("matched count detail = %#v, want 2; all detail %#v", got, routePlan.ExtraDetail)
+	}
+	if remediation, _ := routePlan.ExtraDetail["connect_route_plan_failure_remediation"].(string); !strings.Contains(remediation, "select-or-create") || !strings.Contains(remediation, "account") || !strings.Contains(remediation, "account_id") {
+		t.Fatalf("remediation = %q, want select-or-create/account/account_id detail", remediation)
+	}
+	if err := eb.Publish(context.Background(), evt); err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+	if got := len(store.activations); got != 0 {
+		t.Fatalf("activations = %d, want 0 on ambiguous fail-closed", got)
+	}
+	if routes := store.routes[eventID]; len(routes) != 0 {
+		t.Fatalf("persisted routes = %#v, want none for ambiguous fail-closed", routes)
+	}
+}
+
+func TestEventBusPublish_ConnectRoutePlanSelectOrCreateResolutionConcurrentSameKeyConverges(t *testing.T) {
+	source := connectRoutePlanSelectOrCreateResolutionSourceWithPolicy(t, "reject", "reject")
+	base := &connectRoutePlanLifecycleStore{
+		connectRoutePlanDescriptorStore: &connectRoutePlanDescriptorStore{
+			targetRouteMemoryStore: newTargetRouteMemoryStore(),
+		},
+	}
+	store := &connectRoutePlanConcurrentLifecycleStore{connectRoutePlanLifecycleStore: base}
+	eb, err := NewEventBusWithOptions(store, EventBusOptions{
+		ContractBundle:            source,
+		TemplateInstanceActivator: store.Activate,
+	})
+	if err != nil {
+		t.Fatalf("NewEventBusWithOptions: %v", err)
+	}
+	store.bus = eb
+	eventIDs := []string{uuid.NewString(), uuid.NewString()}
+	errs := make(chan error, len(eventIDs))
+	var wg sync.WaitGroup
+	for _, eventID := range eventIDs {
+		eventID := eventID
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			evt := eventtest.RootIngress(eventID,
+				events.EventType("producer/account.ready"), "", "", json.RawMessage(`{"account_id":"acct-race"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())
+			errs <- eb.Publish(context.Background(), evt)
+		}()
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		if err != nil {
+			t.Fatalf("concurrent Publish returned error: %v", err)
+		}
+	}
+	if got := store.ActivationCount(); got != 1 {
+		t.Fatalf("activations = %d, want one same-key select-or-create activation", got)
+	}
+	descriptors := store.FlowInstanceDescriptors()
+	if len(descriptors) != 1 {
+		t.Fatalf("descriptors = %#v, want one same-key descriptor", descriptors)
+	}
+	want := events.DeliveryRoute{
+		SubscriberType: "node",
+		SubscriberID:   "account-node-" + descriptors[0].InstanceID,
+		Target: events.RouteIdentity{
+			FlowID:       "account",
+			FlowInstance: descriptors[0].FlowInstance,
+			EntityID:     descriptors[0].EntityID,
+		},
+	}
+	for _, eventID := range eventIDs {
+		routes, err := store.ListEventDeliveryRoutes(context.Background(), eventID)
+		if err != nil {
+			t.Fatalf("ListEventDeliveryRoutes(%s): %v", eventID, err)
+		}
+		if !deliveryRoutesContain(routes, want) || len(routes) != 1 {
+			t.Fatalf("routes[%s] = %#v, want converged same-key route %#v", eventID, routes, want)
+		}
 	}
 }
 
@@ -2415,12 +2708,22 @@ func connectRoutePlanCreateResolutionSource(t testing.TB, mint string) semanticv
 
 func connectRoutePlanSelectResolutionSourceWithPolicy(t testing.TB, onMissing, onConflict string) semanticview.Source {
 	t.Helper()
+	return connectRoutePlanCarriedKeyResolutionSourceWithPolicy(t, runtimecontracts.FlowInputResolutionModeSelect, onMissing, onConflict)
+}
+
+func connectRoutePlanSelectOrCreateResolutionSourceWithPolicy(t testing.TB, onMissing, onConflict string) semanticview.Source {
+	t.Helper()
+	return connectRoutePlanCarriedKeyResolutionSourceWithPolicy(t, runtimecontracts.FlowInputResolutionModeSelectOrCreate, onMissing, onConflict)
+}
+
+func connectRoutePlanCarriedKeyResolutionSourceWithPolicy(t testing.TB, mode, onMissing, onConflict string) semanticview.Source {
+	t.Helper()
 	repoRoot, err := os.Getwd()
 	if err != nil {
 		t.Fatalf("Getwd: %v", err)
 	}
 	repoRoot = filepath.Clean(filepath.Join(repoRoot, "..", "..", ".."))
-	root := writeConnectRoutePlanSelectResolutionFixtureWithPolicy(t, onMissing, onConflict)
+	root := writeConnectRoutePlanCarriedKeyResolutionFixtureWithPolicy(t, mode, onMissing, onConflict)
 	bundle, err := runtimecontracts.LoadWorkflowContractBundleWithOverrides(repoRoot, root, runtimecontracts.DefaultPlatformSpecFile(repoRoot))
 	if err != nil {
 		t.Fatalf("LoadWorkflowContractBundleWithOverrides: %v", err)
@@ -2513,7 +2816,16 @@ validator-node:
 
 func writeConnectRoutePlanSelectResolutionFixtureWithPolicy(t testing.TB, onMissing, onConflict string) string {
 	t.Helper()
+	return writeConnectRoutePlanCarriedKeyResolutionFixtureWithPolicy(t, runtimecontracts.FlowInputResolutionModeSelect, onMissing, onConflict)
+}
+
+func writeConnectRoutePlanCarriedKeyResolutionFixtureWithPolicy(t testing.TB, mode, onMissing, onConflict string) string {
+	t.Helper()
 	root := t.TempDir()
+	mode = strings.TrimSpace(mode)
+	if mode == "" {
+		mode = runtimecontracts.FlowInputResolutionModeSelect
+	}
 	writeConnectRoutePlanBusFixtureFile(t, filepath.Join(root, "package.yaml"), `
 name: select-resolution-connect-route-plan-bus
 version: "1.0.0"
@@ -2563,7 +2875,7 @@ pins:
       - name: account_ready
         event: account.ready
         resolution:
-          mode: select
+          mode: `+mode+`
           instance_key: account_id
         carries:
           account_id:

--- a/internal/runtime/bus/connect_route_plan_dispatch_test.go
+++ b/internal/runtime/bus/connect_route_plan_dispatch_test.go
@@ -51,8 +51,9 @@ type connectRoutePlanMutationStore struct {
 
 type connectRoutePlanLifecycleStore struct {
 	*connectRoutePlanDescriptorStore
-	bus         *EventBus
-	activations []runtimepipeline.FlowInstanceActivationRequest
+	bus                             *EventBus
+	activations                     []runtimepipeline.FlowInstanceActivationRequest
+	failAfterDescriptorWithoutRoute error
 }
 
 type connectRoutePlanConcurrentLifecycleStore struct {
@@ -131,6 +132,9 @@ func (s *connectRoutePlanLifecycleStore) Activate(ctx context.Context, req runti
 		FlowTemplate:  req.Instance.TemplateID,
 		AddressFields: connectRoutePlanActivationAddressFields(req.Metadata),
 	})
+	if s.failAfterDescriptorWithoutRoute != nil {
+		return s.failAfterDescriptorWithoutRoute
+	}
 	if s.bus == nil {
 		return nil
 	}
@@ -1411,6 +1415,47 @@ func TestEventBusPublish_ConnectRoutePlanSelectOrCreateResolutionReusesCreatesAn
 	}
 	if got := store.flowInstanceDescriptorCalls; got != 0 {
 		t.Fatalf("replay descriptor calls = %d, want 0 because persisted route/scope is authoritative", got)
+	}
+}
+
+func TestEventBusPublish_ConnectRoutePlanSelectOrCreateResolutionDoesNotReuseUnroutableActivationFailure(t *testing.T) {
+	source := connectRoutePlanSelectOrCreateResolutionSourceWithPolicy(t, "reject", "reject")
+	store := &connectRoutePlanLifecycleStore{
+		connectRoutePlanDescriptorStore: &connectRoutePlanDescriptorStore{
+			targetRouteMemoryStore: newTargetRouteMemoryStore(),
+		},
+		failAfterDescriptorWithoutRoute: errors.New("route installation failed"),
+	}
+	eb, err := NewEventBusWithOptions(store, EventBusOptions{
+		ContractBundle:            source,
+		TemplateInstanceActivator: store.Activate,
+	})
+	if err != nil {
+		t.Fatalf("NewEventBusWithOptions: %v", err)
+	}
+	store.bus = eb
+	eventID := uuid.NewString()
+	evt := eventtest.RootIngress(eventID,
+		events.EventType("producer/account.ready"), "", "", json.RawMessage(`{"account_id":"acct-partial"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())
+
+	err = eb.Publish(context.Background(), evt)
+	if err == nil {
+		t.Fatal("Publish succeeded, want activation error preserved for unroutable descriptor")
+	}
+	if !strings.Contains(err.Error(), "route installation failed") {
+		t.Fatalf("Publish error = %v, want original activation failure", err)
+	}
+	if got := len(store.activations); got != 1 {
+		t.Fatalf("activations = %d, want one failed activation attempt", got)
+	}
+	if got := len(store.flowInstances); got != 1 {
+		t.Fatalf("flow instance descriptors = %d, want descriptor visible from failed activation", got)
+	}
+	if routes := eb.RouteTable().MaterializedRoutes(store.activations[0].Instance.Route()); len(routes) != 0 {
+		t.Fatalf("materialized routes after failed activation = %#v, want none", routes)
+	}
+	if routes := store.routes[eventID]; len(routes) != 0 {
+		t.Fatalf("persisted delivery routes = %#v, want none when activation failure is preserved", routes)
 	}
 }
 

--- a/internal/runtime/bus/eventbus_target_routes_test.go
+++ b/internal/runtime/bus/eventbus_target_routes_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -21,6 +22,7 @@ import (
 )
 
 type targetRouteMemoryStore struct {
+	mu          sync.Mutex
 	events      map[string]events.Event
 	routes      map[string][]events.DeliveryRoute
 	scopes      map[string]replayclaim.CommittedReplayScope
@@ -39,6 +41,8 @@ func newTargetRouteMemoryStore() *targetRouteMemoryStore {
 }
 
 func (s *targetRouteMemoryStore) AppendEvent(_ context.Context, evt events.Event) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	s.events[evt.ID()] = evt
 	return nil
 }
@@ -48,6 +52,8 @@ func (s *targetRouteMemoryStore) InsertEventDeliveries(_ context.Context, _ stri
 }
 
 func (s *targetRouteMemoryStore) ListEventDeliveryRecipients(_ context.Context, eventID string) ([]string, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	var out []string
 	for _, route := range s.routes[eventID] {
 		if route.SubscriberType == "agent" {
@@ -60,6 +66,8 @@ func (s *targetRouteMemoryStore) ListEventDeliveryRecipients(_ context.Context, 
 func (s *targetRouteMemoryStore) SupportsPersistedReplay() bool { return true }
 
 func (s *targetRouteMemoryStore) PersistEventWithDeliveryRouteSetAndScope(_ context.Context, evt events.Event, deliveryRoutes []events.DeliveryRoute, scope replayclaim.CommittedReplayScope) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	s.events[evt.ID()] = evt
 	s.routes[evt.ID()] = events.NormalizeDeliveryRoutes(deliveryRoutes)
 	s.scopes[evt.ID()] = scope
@@ -67,10 +75,14 @@ func (s *targetRouteMemoryStore) PersistEventWithDeliveryRouteSetAndScope(_ cont
 }
 
 func (s *targetRouteMemoryStore) ListEventDeliveryRoutes(_ context.Context, eventID string) ([]events.DeliveryRoute, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	return append([]events.DeliveryRoute(nil), s.routes[eventID]...), nil
 }
 
 func (s *targetRouteMemoryStore) UpsertPipelineReceipt(_ context.Context, eventID, status, errText string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	if s.receipts == nil {
 		s.receipts = map[string]string{}
 	}
@@ -83,10 +95,14 @@ func (s *targetRouteMemoryStore) UpsertPipelineReceipt(_ context.Context, eventI
 }
 
 func (s *targetRouteMemoryStore) ListEventsMissingPipelineReceipt(context.Context, time.Time, int) ([]events.PersistedReplayEvent, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	return append([]events.PersistedReplayEvent(nil), s.missing...), nil
 }
 
 func (s *targetRouteMemoryStore) ClaimPipelineReplay(_ context.Context, eventID string) (runtimeownership.Lease, bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	if s.claimed == nil {
 		s.claimed = map[string]bool{}
 	}
@@ -103,8 +119,12 @@ type targetRouteMemoryLease struct {
 }
 
 func (l targetRouteMemoryLease) Release(context.Context) error {
-	if l.store != nil && l.store.claimed != nil {
-		delete(l.store.claimed, l.eventID)
+	if l.store != nil {
+		l.store.mu.Lock()
+		defer l.store.mu.Unlock()
+		if l.store.claimed != nil {
+			delete(l.store.claimed, l.eventID)
+		}
 	}
 	return nil
 }
@@ -365,6 +385,8 @@ func deliveryRoutesContain(routes []events.DeliveryRoute, want events.DeliveryRo
 }
 
 func (s *targetRouteMemoryStore) LoadCommittedReplayScope(_ context.Context, eventID string) (replayclaim.CommittedReplayScope, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	scope := s.scopes[eventID]
 	if scope == "" {
 		return "", replayclaim.ErrMissingCommittedReplayScope

--- a/internal/runtime/bus/template_instance_lifecycle.go
+++ b/internal/runtime/bus/template_instance_lifecycle.go
@@ -148,6 +148,9 @@ func (o templateInstanceLifecycleOwner) Materialize(ctx context.Context, evt eve
 		case runtimecontracts.FlowInputResolutionModeSelect:
 			onMissing = "reject"
 			onConflict = "reject"
+		case runtimecontracts.FlowInputResolutionModeSelectOrCreate:
+			onMissing = "create"
+			onConflict = "reuse"
 		}
 	}
 	matches := runtimepinrouting.InstanceKeyDescriptorRoutesForConnectRoutePlan(plan, keyMaterial, descriptors)
@@ -180,6 +183,19 @@ func (o templateInstanceLifecycleOwner) Materialize(ctx context.Context, evt eve
 		return runtimepinrouting.ConnectRoutePlanMaterialization{Failure: failure}, TemplateInstanceLifecycleDecision{}, true, nil
 	}
 	if err := o.activate(ctx, req); err != nil {
+		if templateInstanceLifecycleCanReuseAfterActivationError(plan, onMissing, onConflict) {
+			refreshed, refreshErr := o.reloadDescriptors(ctx)
+			if refreshErr != nil {
+				return runtimepinrouting.ConnectRoutePlanMaterialization{}, TemplateInstanceLifecycleDecision{}, true, refreshErr
+			}
+			matches = runtimepinrouting.InstanceKeyDescriptorRoutesForConnectRoutePlan(plan, keyMaterial, refreshed)
+			if len(matches) == 1 {
+				return templateInstanceLifecycleMaterialization(plan, matches), o.decision(plan, evt, keyMaterial, onMissing, onConflict, matches[0], templateInstanceLifecycleActionReused), true, nil
+			}
+			if len(matches) > 1 {
+				return runtimepinrouting.ConnectRoutePlanMaterialization{Failure: runtimepinrouting.ConnectFailureTargetAmbiguous}, decision, true, nil
+			}
+		}
 		return runtimepinrouting.ConnectRoutePlanMaterialization{}, TemplateInstanceLifecycleDecision{}, true, fmt.Errorf("activate connect-time template instance %s: %w", req.Instance.InstancePath, err)
 	}
 	refreshed, err := o.reloadDescriptors(ctx)
@@ -324,6 +340,13 @@ func templateInstanceLifecycleExistingAction(onMissing, onConflict string) strin
 		return templateInstanceLifecycleActionReused
 	}
 	return templateInstanceLifecycleActionSelectedExisting
+}
+
+func templateInstanceLifecycleCanReuseAfterActivationError(plan runtimepinrouting.ConnectRoutePlan, onMissing, onConflict string) bool {
+	if plan.InstanceKey == nil || strings.TrimSpace(plan.InstanceKey.Mode) != runtimecontracts.FlowInputResolutionModeSelectOrCreate {
+		return false
+	}
+	return strings.TrimSpace(onMissing) == "create" && strings.TrimSpace(onConflict) == "reuse"
 }
 
 func templateInstanceLifecycleParentRoute(evt events.Event, plan runtimepinrouting.ConnectRoutePlan) runtimeflowidentity.ParentRoute {

--- a/internal/runtime/bus/template_instance_lifecycle.go
+++ b/internal/runtime/bus/template_instance_lifecycle.go
@@ -26,6 +26,7 @@ type templateInstanceLifecyclePreviewKey struct{}
 
 type templateInstanceLifecycleOwner struct {
 	source          semanticview.Source
+	routeTable      *RouteTable
 	loadDescriptors connectRoutePlanDescriptorLoader
 	activate        runtimepipeline.FlowInstanceActivator
 }
@@ -43,9 +44,10 @@ type TemplateInstanceLifecycleDecision struct {
 	SourceEventID string
 }
 
-func newTemplateInstanceLifecycleOwner(source semanticview.Source, loadDescriptors connectRoutePlanDescriptorLoader, activate runtimepipeline.FlowInstanceActivator) templateInstanceLifecycleOwner {
+func newTemplateInstanceLifecycleOwner(source semanticview.Source, routeTable *RouteTable, loadDescriptors connectRoutePlanDescriptorLoader, activate runtimepipeline.FlowInstanceActivator) templateInstanceLifecycleOwner {
 	return templateInstanceLifecycleOwner{
 		source:          source,
+		routeTable:      routeTable,
 		loadDescriptors: loadDescriptors,
 		activate:        activate,
 	}
@@ -189,7 +191,7 @@ func (o templateInstanceLifecycleOwner) Materialize(ctx context.Context, evt eve
 				return runtimepinrouting.ConnectRoutePlanMaterialization{}, TemplateInstanceLifecycleDecision{}, true, refreshErr
 			}
 			matches = runtimepinrouting.InstanceKeyDescriptorRoutesForConnectRoutePlan(plan, keyMaterial, refreshed)
-			if len(matches) == 1 {
+			if len(matches) == 1 && templateInstanceLifecycleMatchIsRoutable(o.routeTable, plan, matches[0]) {
 				return templateInstanceLifecycleMaterialization(plan, matches), o.decision(plan, evt, keyMaterial, onMissing, onConflict, matches[0], templateInstanceLifecycleActionReused), true, nil
 			}
 			if len(matches) > 1 {
@@ -347,6 +349,24 @@ func templateInstanceLifecycleCanReuseAfterActivationError(plan runtimepinroutin
 		return false
 	}
 	return strings.TrimSpace(onMissing) == "create" && strings.TrimSpace(onConflict) == "reuse"
+}
+
+func templateInstanceLifecycleMatchIsRoutable(routeTable *RouteTable, plan runtimepinrouting.ConnectRoutePlan, target events.RouteIdentity) bool {
+	if routeTable == nil {
+		return false
+	}
+	target = target.Normalized()
+	if target.Empty() {
+		return false
+	}
+	for _, key := range connectReceiverCarrierRouteKeys(plan, target) {
+		for _, subscriber := range routeTable.Resolve(key) {
+			if connectSubscriberMatchesTarget(subscriber, target) {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func templateInstanceLifecycleParentRoute(evt events.Event, plan runtimepinrouting.ConnectRoutePlan) runtimeflowidentity.ParentRoute {

--- a/internal/runtime/conformance/template_flow_pilot_conformance_test.go
+++ b/internal/runtime/conformance/template_flow_pilot_conformance_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/division-sh/swarm/internal/runtime/testfixtures/fanoutpinroute"
 	"github.com/division-sh/swarm/internal/runtime/testfixtures/templateflowpilot"
 	"github.com/division-sh/swarm/internal/runtime/testfixtures/templateselectexisting"
+	"github.com/division-sh/swarm/internal/runtime/testfixtures/templateselectorcreate"
 )
 
 func TestTemplateFlowPilotConformance_CoversInstanceCenteredAuthoringOwners(t *testing.T) {
@@ -153,6 +154,56 @@ func TestTemplateSelectExistingConformance_CoversResolutionSelectOwner(t *testin
 		t.Fatalf("route plan instance key = %#v, want select/account_id", plan.InstanceKey)
 	}
 	if len(plan.InstanceKey.Mappings) != 1 || plan.InstanceKey.Mappings[0].Source != templateselectexisting.TemplateInstanceBy || plan.InstanceKey.Mappings[0].Target != templateselectexisting.TemplateInstanceBy || !plan.InstanceKey.Mappings[0].Explicit {
+		t.Fatalf("route plan mappings = %#v, want explicit account_id -> account_id", plan.InstanceKey.Mappings)
+	}
+
+	materialized := runtimepinrouting.MaterializeConnectRoutePlan(plan, runtimepinrouting.ConnectRoutePlanMaterializationInput{
+		MatchValues: map[string]string{"payload.account_id": "acct-1"},
+		Descriptors: []runtimepinrouting.Descriptor{{
+			EntityID:      "ent-1",
+			FlowInstance:  "account/one",
+			AddressFields: map[string]string{"entity.account_id": "acct-1"},
+		}},
+	})
+	if materialized.Failure != "" {
+		t.Fatalf("MaterializeConnectRoutePlan failure = %q, want none", materialized.Failure)
+	}
+	if materialized.Target.FlowInstance != "account/one" || materialized.Target.EntityID != "ent-1" {
+		t.Fatalf("materialized target = %#v, want account/one ent-1", materialized.Target)
+	}
+}
+
+func TestTemplateSelectOrCreateConformance_CoversResolutionSelectOrCreateOwner(t *testing.T) {
+	source := templateselectorcreate.LoadSource(t)
+	report := runtimebootverify.Run(context.Background(), source, runtimebootverify.Options{})
+	if got := report.HardInvalidities(); len(got) != 0 {
+		t.Fatalf("template-select-or-create hard invalidities = %#v, want none", got)
+	}
+
+	plans, issues := runtimepinrouting.LowerCompositionConnectRoutePlans(source)
+	if len(issues) != 0 {
+		t.Fatalf("LowerCompositionConnectRoutePlans issues = %#v, want none", issues)
+	}
+	if len(plans) != 1 {
+		t.Fatalf("LowerCompositionConnectRoutePlans = %#v, want one select-or-create route plan", plans)
+	}
+	plan := plans[0]
+	if plan.Source.FlowID != templateselectorcreate.ProducerFlowID || plan.Source.Pin != templateselectorcreate.ProducerOutputPin {
+		t.Fatalf("route plan source = %#v, want %s.%s", plan.Source, templateselectorcreate.ProducerFlowID, templateselectorcreate.ProducerOutputPin)
+	}
+	if plan.Receiver.FlowID != templateselectorcreate.TemplateFlowID || plan.Receiver.Pin != templateselectorcreate.TemplateInputPin || plan.Receiver.Mode != "template" {
+		t.Fatalf("route plan receiver = %#v, want template %s.%s", plan.Receiver, templateselectorcreate.TemplateFlowID, templateselectorcreate.TemplateInputPin)
+	}
+	if plan.ResolutionKind != runtimepinrouting.ConnectResolutionInstanceKey || !plan.RequiresRuntimeResolution {
+		t.Fatalf("route plan resolution = %s runtime=%v, want runtime instance-key select-or-create", plan.ResolutionKind, plan.RequiresRuntimeResolution)
+	}
+	if plan.InstanceKey == nil || plan.InstanceKey.Mode != "select-or-create" || strings.Join(plan.InstanceKey.Fields, ",") != templateselectorcreate.TemplateInstanceBy {
+		t.Fatalf("route plan instance key = %#v, want select-or-create/account_id", plan.InstanceKey)
+	}
+	if plan.InstanceKey.OnMissing != "create" || plan.InstanceKey.OnConflict != "reuse" {
+		t.Fatalf("route plan lifecycle policy = %s/%s, want create/reuse", plan.InstanceKey.OnMissing, plan.InstanceKey.OnConflict)
+	}
+	if len(plan.InstanceKey.Mappings) != 1 || plan.InstanceKey.Mappings[0].Source != templateselectorcreate.TemplateInstanceBy || plan.InstanceKey.Mappings[0].Target != templateselectorcreate.TemplateInstanceBy || !plan.InstanceKey.Mappings[0].Explicit {
 		t.Fatalf("route plan mappings = %#v, want explicit account_id -> account_id", plan.InstanceKey.Mappings)
 	}
 

--- a/internal/runtime/conformance/testdata/route_authority_drift_inventory.yaml
+++ b/internal/runtime/conformance/testdata/route_authority_drift_inventory.yaml
@@ -71,6 +71,7 @@ search_dimensions:
     minimum_matching_files: 4
     required_paths:
       - internal/runtime/bus/connect_route_plan_dispatch.go
+      - internal/runtime/bus/template_instance_lifecycle.go
       - internal/runtime/runforkadmission/contract_frontier.go
       - internal/runtime/runforkadmission/selected_route_history.go
       - internal/runtime/runstart/root_inputs.go
@@ -82,6 +83,7 @@ search_dimensions:
     required_paths:
       - platform-spec.yaml
       - internal/runtime/bus/connect_route_plan_dispatch.go
+      - internal/runtime/bus/template_instance_lifecycle.go
       - internal/runtime/bus/connect_route_plan_dispatch_test.go
       - internal/runtime/bus/eventbus_target_routes_test.go
       - internal/runtime/bus/routing_derivation.go
@@ -404,6 +406,7 @@ seam_families:
     paths:
       - internal/runtime/conformance/testdata/route_authority_matrix.yaml
       - internal/runtime/bus/connect_route_plan_dispatch.go
+      - internal/runtime/bus/template_instance_lifecycle.go
       - internal/runtime/runforkadmission/contract_frontier.go
       - internal/runtime/runforkadmission/selected_route_history.go
       - internal/runtime/runstart/root_inputs.go
@@ -412,13 +415,16 @@ seam_families:
       RouteTable.Resolve must be classified by role. EventBus lowered-connect
       use is post-identity receiver-carrier lookup; runstart/runfork uses are
       separate admission/readiness route-fact consumers, not publish-time route
-      authority.
+      authority. The template lifecycle owner uses this only after a failed
+      select-or-create activation to prove the matching descriptor is already
+      routable before treating the error as same-key convergence.
   - id: receiver_carrier_evidence
     layer: live_dispatch_non_authority
     classification: valid_consumer
     paths:
       - platform-spec.yaml
       - internal/runtime/bus/connect_route_plan_dispatch.go
+      - internal/runtime/bus/template_instance_lifecycle.go
       - internal/runtime/bus/connect_route_plan_dispatch_test.go
       - internal/runtime/bus/eventbus_target_routes_test.go
       - internal/runtime/bus/routing_derivation.go
@@ -433,7 +439,9 @@ seam_families:
     notes: >
       Receiver carriers are concrete dispatch evidence after a lowered plan
       selects target identity. They must not repair or replace the route
-      authority decision.
+      authority decision. The template lifecycle owner may consume them only to
+      avoid swallowing a failed activation whose descriptor is visible but whose
+      receiver route was never installed.
   - id: descriptor_evidence_non_authority
     layer: descriptor_evidence_non_authority
     classification: non_authoritative_observer_projection

--- a/internal/runtime/core/pinrouting/connect_route_plan.go
+++ b/internal/runtime/core/pinrouting/connect_route_plan.go
@@ -643,8 +643,8 @@ func connectResolutionInstanceKey(source semanticview.Source, connect runtimecon
 	switch resolution.Mode {
 	case runtimecontracts.FlowInputResolutionModeCreate:
 		return connectCreateResolutionInstanceKey(source, connect, resolution, delivery, receiverFlowID)
-	case runtimecontracts.FlowInputResolutionModeSelect:
-		return connectSelectResolutionInstanceKey(source, connect, inputPin, resolution, delivery, receiverFlowID)
+	case runtimecontracts.FlowInputResolutionModeSelect, runtimecontracts.FlowInputResolutionModeSelectOrCreate:
+		return connectCarriedKeyResolutionInstanceKey(source, connect, inputPin, resolution, delivery, receiverFlowID)
 	default:
 		return nil, ConnectRoutePlanIssue{Connect: connect, Failure: ConnectFailureInstanceResolutionInvalid, Detail: fmt.Sprintf("resolution mode %q is design-locked but not runnable in this slice", resolution.Mode)}
 	}
@@ -683,12 +683,13 @@ func connectCreateResolutionInstanceKey(source semanticview.Source, connect runt
 	}, ConnectRoutePlanIssue{}
 }
 
-func connectSelectResolutionInstanceKey(source semanticview.Source, connect runtimecontracts.FlowPackageConnect, inputPin runtimecontracts.FlowInputEventPin, resolution runtimecontracts.FlowInputPinResolution, delivery ConnectRoutePlanDelivery, receiverFlowID string) (*ConnectRoutePlanInstanceKey, ConnectRoutePlanIssue) {
+func connectCarriedKeyResolutionInstanceKey(source semanticview.Source, connect runtimecontracts.FlowPackageConnect, inputPin runtimecontracts.FlowInputEventPin, resolution runtimecontracts.FlowInputPinResolution, delivery ConnectRoutePlanDelivery, receiverFlowID string) (*ConnectRoutePlanInstanceKey, ConnectRoutePlanIssue) {
+	mode := strings.TrimSpace(resolution.Mode)
 	if delivery != ConnectDeliveryOne {
-		return nil, ConnectRoutePlanIssue{Connect: connect, Failure: ConnectFailureDeliveryTopologyInvalid, Detail: "resolution mode select requires delivery one"}
+		return nil, ConnectRoutePlanIssue{Connect: connect, Failure: ConnectFailureDeliveryTopologyInvalid, Detail: fmt.Sprintf("resolution mode %s requires delivery one", mode)}
 	}
 	if resolution.Aggregation != "" || resolution.Window != "" || len(resolution.DedupBy) > 0 || resolution.Singleton != "" || resolution.RepliesTo != "" || resolution.CorrelationKey != "" || strings.TrimSpace(resolution.InstanceKey.Mint) != "" || strings.TrimSpace(resolution.InstanceKey.As) != "" {
-		return nil, ConnectRoutePlanIssue{Connect: connect, Failure: ConnectFailureInstanceResolutionInvalid, Detail: "resolution mode select may only declare instance_key and carries"}
+		return nil, ConnectRoutePlanIssue{Connect: connect, Failure: ConnectFailureInstanceResolutionInvalid, Detail: fmt.Sprintf("resolution mode %s may only declare instance_key and carries", mode)}
 	}
 	bundle, ok := semanticview.Bundle(source)
 	if !ok {
@@ -701,18 +702,18 @@ func connectSelectResolutionInstanceKey(source semanticview.Source, connect runt
 	fields := normalizedStringList(instance.By)
 	key := strings.TrimSpace(resolution.InstanceKey.From)
 	if key == "" {
-		return nil, ConnectRoutePlanIssue{Connect: connect, Failure: ConnectFailureInstanceResolutionInvalid, Detail: "resolution mode select requires instance_key to name a carried field"}
+		return nil, ConnectRoutePlanIssue{Connect: connect, Failure: ConnectFailureInstanceResolutionInvalid, Detail: fmt.Sprintf("resolution mode %s requires instance_key to name a carried field", mode)}
 	}
 	if len(fields) != 1 || fields[0] != key {
-		return nil, ConnectRoutePlanIssue{Connect: connect, Failure: ConnectFailureInstanceResolutionInvalid, Detail: fmt.Sprintf("resolution mode select instance_key %q must match the receiver's single instance.by field %v", key, fields)}
+		return nil, ConnectRoutePlanIssue{Connect: connect, Failure: ConnectFailureInstanceResolutionInvalid, Detail: fmt.Sprintf("resolution mode %s instance_key %q must match the receiver's single instance.by field %v", mode, key, fields)}
 	}
 	carry, ok := inputPin.Carries[key]
 	if !ok {
-		return nil, ConnectRoutePlanIssue{Connect: connect, Failure: ConnectFailureInstanceResolutionInvalid, Detail: fmt.Sprintf("resolution mode select instance_key %s must name declared carries.%s", key, key)}
+		return nil, ConnectRoutePlanIssue{Connect: connect, Failure: ConnectFailureInstanceResolutionInvalid, Detail: fmt.Sprintf("resolution mode %s instance_key %s must name declared carries.%s", mode, key, key)}
 	}
 	wantFrom := "payload." + key
 	if strings.TrimSpace(carry.From) != wantFrom {
-		return nil, ConnectRoutePlanIssue{Connect: connect, Failure: ConnectFailureInstanceResolutionInvalid, Detail: fmt.Sprintf("resolution mode select carry %s must use from: %s", key, wantFrom)}
+		return nil, ConnectRoutePlanIssue{Connect: connect, Failure: ConnectFailureInstanceResolutionInvalid, Detail: fmt.Sprintf("resolution mode %s carry %s must use from: %s", mode, key, wantFrom)}
 	}
 	if strings.TrimSpace(carry.Type) != "" {
 		targetType, err := connectResolutionReceiverEntityFieldType(source, receiverFlowID, key)
@@ -723,12 +724,18 @@ func connectSelectResolutionInstanceKey(source semanticview.Source, connect runt
 			return nil, ConnectRoutePlanIssue{Connect: connect, Failure: ConnectFailureInstanceResolutionInvalid, Detail: fmt.Sprintf("key_types_incompatible: carry %s type %s is incompatible with receiver entity.%s type %s", key, carry.Type, key, targetType)}
 		}
 	}
+	onMissing := "reject"
+	onConflict := "reject"
+	if mode == runtimecontracts.FlowInputResolutionModeSelectOrCreate {
+		onMissing = "create"
+		onConflict = "reuse"
+	}
 	return &ConnectRoutePlanInstanceKey{
-		Mode:       runtimecontracts.FlowInputResolutionModeSelect,
+		Mode:       mode,
 		Fields:     fields,
 		Mappings:   []ConnectRoutePlanInstanceKeyMapping{{Source: key, Target: key, Explicit: true}},
-		OnMissing:  "reject",
-		OnConflict: "reject",
+		OnMissing:  onMissing,
+		OnConflict: onConflict,
 	}, ConnectRoutePlanIssue{}
 }
 

--- a/internal/runtime/core/pinrouting/connect_route_plan_test.go
+++ b/internal/runtime/core/pinrouting/connect_route_plan_test.go
@@ -261,6 +261,69 @@ func TestLowerCompositionConnectRoutePlansUsesSelectInputResolution(t *testing.T
 	}
 }
 
+func TestLowerCompositionConnectRoutePlansUsesSelectOrCreateInputResolution(t *testing.T) {
+	repoRoot, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd: %v", err)
+	}
+	repoRoot = filepath.Clean(filepath.Join(repoRoot, "..", "..", "..", ".."))
+	root := writeSelectResolutionConnectRoutePlanPackageFixtureWithOptions(t, selectResolutionConnectRoutePlanFixtureOptions{
+		mode: runtimecontracts.FlowInputResolutionModeSelectOrCreate,
+	})
+	bundle, err := runtimecontracts.LoadWorkflowContractBundleWithOverrides(repoRoot, root, runtimecontracts.DefaultPlatformSpecFile(repoRoot))
+	if err != nil {
+		t.Fatalf("LoadWorkflowContractBundleWithOverrides: %v", err)
+	}
+
+	plans, issues := LowerCompositionConnectRoutePlans(semanticview.Wrap(bundle))
+	if len(issues) != 0 {
+		t.Fatalf("issues = %#v, want none", issues)
+	}
+	if len(plans) != 1 {
+		t.Fatalf("plans = %#v, want one", plans)
+	}
+	plan := plans[0]
+	if plan.InstanceKey == nil {
+		t.Fatal("InstanceKey = nil, want select-or-create resolution instance-key evidence")
+	}
+	if got, want := plan.ResolutionKind, ConnectResolutionInstanceKey; got != want {
+		t.Fatalf("ResolutionKind = %q, want %q", got, want)
+	}
+	if !plan.RequiresRuntimeResolution {
+		t.Fatal("select-or-create resolution should require runtime descriptor resolution")
+	}
+	if got, want := plan.InstanceKey.Mode, runtimecontracts.FlowInputResolutionModeSelectOrCreate; got != want {
+		t.Fatalf("InstanceKey.Mode = %q, want %q", got, want)
+	}
+	if got, want := plan.InstanceKey.OnMissing, "create"; got != want {
+		t.Fatalf("InstanceKey.OnMissing = %q, want %q", got, want)
+	}
+	if got, want := plan.InstanceKey.OnConflict, "reuse"; got != want {
+		t.Fatalf("InstanceKey.OnConflict = %q, want %q", got, want)
+	}
+	if len(plan.InstanceKey.Fields) != 1 || plan.InstanceKey.Fields[0] != "account_id" {
+		t.Fatalf("InstanceKey.Fields = %#v, want [account_id]", plan.InstanceKey.Fields)
+	}
+	if len(plan.InstanceKey.Mappings) != 1 || plan.InstanceKey.Mappings[0].Source != "account_id" || plan.InstanceKey.Mappings[0].Target != "account_id" || !plan.InstanceKey.Mappings[0].Explicit {
+		t.Fatalf("InstanceKey.Mappings = %#v, want explicit account_id -> account_id", plan.InstanceKey.Mappings)
+	}
+
+	materialized := MaterializeConnectRoutePlan(plan, ConnectRoutePlanMaterializationInput{
+		MatchValues: map[string]string{"payload.account_id": "acct-1"},
+		Descriptors: []Descriptor{{
+			EntityID:      "ent-1",
+			FlowInstance:  "account/one",
+			AddressFields: map[string]string{"entity.account_id": "acct-1"},
+		}},
+	})
+	if materialized.Failure != "" {
+		t.Fatalf("Failure = %q, want empty", materialized.Failure)
+	}
+	if got, want := materialized.Target.FlowInstance, "account/one"; got != want {
+		t.Fatalf("Target.FlowInstance = %q, want %q", got, want)
+	}
+}
+
 func TestLowerCompositionConnectRoutePlansRejectsExtraSelectResolutionFields(t *testing.T) {
 	repoRoot, err := os.Getwd()
 	if err != nil {
@@ -309,6 +372,34 @@ func TestLowerCompositionConnectRoutePlansRejectsSelectCarryTypeMismatch(t *test
 	}
 	if issues[0].Failure != ConnectFailureInstanceResolutionInvalid || !strings.Contains(issues[0].Detail, "key_types_incompatible") {
 		t.Fatalf("issue = %#v, want instance resolution invalid for select carry type mismatch", issues[0])
+	}
+}
+
+func TestLowerCompositionConnectRoutePlansRejectsSelectOrCreateCarryTypeMismatch(t *testing.T) {
+	repoRoot, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd: %v", err)
+	}
+	repoRoot = filepath.Clean(filepath.Join(repoRoot, "..", "..", "..", ".."))
+	root := writeSelectResolutionConnectRoutePlanPackageFixtureWithOptions(t, selectResolutionConnectRoutePlanFixtureOptions{
+		mode:                runtimecontracts.FlowInputResolutionModeSelectOrCreate,
+		accountIDEntityType: "integer",
+		accountIDCarryType:  "string",
+	})
+	bundle, err := runtimecontracts.LoadWorkflowContractBundleWithOverrides(repoRoot, root, runtimecontracts.DefaultPlatformSpecFile(repoRoot))
+	if err != nil {
+		t.Fatalf("LoadWorkflowContractBundleWithOverrides: %v", err)
+	}
+
+	plans, issues := LowerCompositionConnectRoutePlans(semanticview.Wrap(bundle))
+	if len(plans) != 0 {
+		t.Fatalf("plans = %#v, want none for invalid select-or-create resolution", plans)
+	}
+	if len(issues) != 1 {
+		t.Fatalf("issues = %#v, want one fail-closed issue", issues)
+	}
+	if issues[0].Failure != ConnectFailureInstanceResolutionInvalid || !strings.Contains(issues[0].Detail, "key_types_incompatible") {
+		t.Fatalf("issue = %#v, want instance resolution invalid for select-or-create carry type mismatch", issues[0])
 	}
 }
 
@@ -1219,6 +1310,7 @@ func writeSelectResolutionConnectRoutePlanPackageFixtureWithExtraResolution(t *t
 }
 
 type selectResolutionConnectRoutePlanFixtureOptions struct {
+	mode                string
 	extraResolution     string
 	accountIDEntityType string
 	accountIDCarryType  string
@@ -1233,6 +1325,10 @@ func writeSelectResolutionConnectRoutePlanPackageFixtureWithOptions(t *testing.T
 	accountIDCarryType := strings.TrimSpace(options.accountIDCarryType)
 	if accountIDCarryType == "" {
 		accountIDCarryType = "string"
+	}
+	mode := strings.TrimSpace(options.mode)
+	if mode == "" {
+		mode = runtimecontracts.FlowInputResolutionModeSelect
 	}
 	root := t.TempDir()
 	writeConnectRoutePlanFixtureFile(t, filepath.Join(root, "package.yaml"), `
@@ -1277,7 +1373,7 @@ pins:
       - name: account_ready
         event: account.ready
         resolution:
-          mode: select
+          mode: `+mode+`
           instance_key: account_id
 `+options.extraResolution+`
         carries:

--- a/internal/runtime/testfixtures/templateselectorcreate/fixture.go
+++ b/internal/runtime/testfixtures/templateselectorcreate/fixture.go
@@ -1,0 +1,157 @@
+package templateselectorcreate
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
+	"github.com/division-sh/swarm/internal/runtime/semanticview"
+)
+
+const (
+	PackageName = "template-select-or-create"
+
+	ProducerFlowID    = "producer"
+	ProducerOutputPin = "account_ready"
+	ProducerOutput    = "account.ready"
+
+	TemplateFlowID     = "account"
+	TemplateInputPin   = "account_ready"
+	TemplateInput      = "account.ready"
+	TemplateInstanceBy = "account_id"
+)
+
+func LoadBundle(t testing.TB) *runtimecontracts.WorkflowContractBundle {
+	t.Helper()
+	root := Write(t)
+	bundle, err := runtimecontracts.LoadWorkflowContractBundleWithOverrides(repoRoot(t), root, runtimecontracts.DefaultPlatformSpecFile(repoRoot(t)))
+	if err != nil {
+		t.Fatalf("LoadWorkflowContractBundleWithOverrides: %v", err)
+	}
+	return bundle
+}
+
+func LoadSource(t testing.TB) semanticview.Source {
+	t.Helper()
+	return semanticview.Wrap(LoadBundle(t))
+}
+
+func Write(t testing.TB) string {
+	t.Helper()
+	root := t.TempDir()
+	writeRoot(t, root)
+	writeProducer(t, root)
+	writeTemplate(t, root)
+	return root
+}
+
+func writeRoot(t testing.TB, root string) {
+	t.Helper()
+	writeFile(t, filepath.Join(root, "package.yaml"), `
+name: template-select-or-create
+version: "1.0.0"
+platform_version: ">=0.7.0 <0.8.0"
+flows:
+  - id: producer
+    flow: producer
+    mode: static
+  - id: account
+    flow: account
+    mode: template
+connect:
+  - from: producer.account_ready
+    to: account.account_ready
+    delivery: one
+`)
+	writeFile(t, filepath.Join(root, "schema.yaml"), "name: template-select-or-create\n")
+	writeFile(t, filepath.Join(root, "policy.yaml"), "{}\n")
+	writeFile(t, filepath.Join(root, "tools.yaml"), "{}\n")
+	writeFile(t, filepath.Join(root, "agents.yaml"), "{}\n")
+	writeFile(t, filepath.Join(root, "events.yaml"), "{}\n")
+	writeFile(t, filepath.Join(root, "nodes.yaml"), "{}\n")
+}
+
+func writeProducer(t testing.TB, root string) {
+	t.Helper()
+	writeFile(t, filepath.Join(root, "flows", "producer", "schema.yaml"), `
+name: producer
+mode: static
+pins:
+  outputs:
+    events:
+      - name: account_ready
+        event: account.ready
+`)
+	writeFile(t, filepath.Join(root, "flows", "producer", "policy.yaml"), "{}\n")
+	writeFile(t, filepath.Join(root, "flows", "producer", "agents.yaml"), "{}\n")
+	writeFile(t, filepath.Join(root, "flows", "producer", "entities.yaml"), "{}\n")
+	writeFile(t, filepath.Join(root, "flows", "producer", "events.yaml"), `
+account.ready:
+  account_id: string
+`)
+	writeFile(t, filepath.Join(root, "flows", "producer", "nodes.yaml"), "{}\n")
+}
+
+func writeTemplate(t testing.TB, root string) {
+	t.Helper()
+	writeFile(t, filepath.Join(root, "flows", "account", "schema.yaml"), `
+name: account
+mode: template
+instance:
+  by: account_id
+  on_missing: reject
+  on_conflict: reject
+pins:
+  inputs:
+    events:
+      - name: account_ready
+        event: account.ready
+        resolution:
+          mode: select-or-create
+          instance_key: account_id
+        carries:
+          account_id:
+            from: payload.account_id
+            type: string
+`)
+	writeFile(t, filepath.Join(root, "flows", "account", "policy.yaml"), "{}\n")
+	writeFile(t, filepath.Join(root, "flows", "account", "agents.yaml"), "{}\n")
+	writeFile(t, filepath.Join(root, "flows", "account", "events.yaml"), `
+account.ready:
+  account_id: string
+`)
+	writeFile(t, filepath.Join(root, "flows", "account", "entities.yaml"), `
+account_state:
+  account_id:
+    type: string
+    _unused_reason: template-select-or-create route key fixture field
+`)
+	writeFile(t, filepath.Join(root, "flows", "account", "nodes.yaml"), `
+account-node:
+  id: account-node-{instance_id}
+  execution_type: system_node
+  event_handlers:
+    account.ready: {}
+`)
+}
+
+func repoRoot(t testing.TB) string {
+	t.Helper()
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("resolve repo root")
+	}
+	return filepath.Clean(filepath.Join(filepath.Dir(file), "..", "..", "..", ".."))
+}
+
+func writeFile(t testing.TB, path, contents string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("MkdirAll(%s): %v", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, []byte(contents), 0o644); err != nil {
+		t.Fatalf("WriteFile(%s): %v", path, err)
+	}
+}

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -8017,7 +8017,7 @@ flow_model:
             broadcast:true, receiver select_entity/select_or_create_entity, and
             explicit create_flow_instance are not lifecycle authority.
         implementation_slice_1835:
-          status: spec_locked_create_and_select_modes_runnable_remaining_modes_fail_closed
+          status: spec_locked_create_select_and_select_or_create_modes_runnable_remaining_modes_fail_closed
           canonical_spec_owner: platform-spec.yaml#flow_model.flow_package.composition_routing.route_plan_lowering.implementation_slice_1835
           canonical_code_owner: internal/runtime/contracts.FlowInputPinResolution + internal/runtime/core/pinrouting.ConnectRoutePlan.InstanceKey + internal/runtime/bus.templateInstanceLifecycleOwner + internal/runtime/bootverify.composition_connect_validation
           rule: |
@@ -8033,12 +8033,15 @@ flow_model:
             PR1 spec-locks every approved mode and makes
             `resolution.mode: create` runnable. PR2 makes
             `resolution.mode: select` runnable for a single declared carried
-            key. All other locked modes are recognized by contracts and
-            verifier and fail closed as design-locked/not-runnable until their
-            implementation slices land. Static root ingress, parent-connect
-            static delivery, and harness-injected inputs remain existing #1807
-            input-source / connect behavior; they are not instance-resolution
-            runtime modes.
+            key. PR3 makes `resolution.mode: select-or-create` runnable for
+            the same single declared carried-key boundary, with lifecycle/store
+            convergence on exactly one receiver instance for concurrent same-key
+            missing deliveries. All other locked modes are recognized by
+            contracts and verifier and fail closed as
+            design-locked/not-runnable until their implementation slices land.
+            Static root ingress, parent-connect static delivery, and
+            harness-injected inputs remain existing #1807 input-source /
+            connect behavior; they are not instance-resolution runtime modes.
           authoring_shape: |
             pins:
               inputs:
@@ -8126,11 +8129,36 @@ flow_model:
               - ambiguous target instance
               - any activation attempt for a missing target
             select-or-create:
-              status: spec_locked_not_runnable_in_1835_pr1
+              status: runnable_in_1835_pr3
               contract: >
-                Select-or-create resolves by explicit key and atomically creates
-                exactly one receiver instance when absent. Concurrent deliveries
-                for the same key must converge on one instance or fail closed.
+                Select-or-create routes to exactly one existing receiver
+                template instance by a declared carried key, or creates exactly
+                one receiver instance when no exact match exists. The authoring
+                contract is the same single-field carried-key boundary as
+                `select`: `carries.<field>` declares the seam identity once,
+                `resolution.instance_key` MUST name that carry, the receiver
+                flow MUST be `mode: template`, and its single `instance.by`
+                field MUST equal the key. The lowered route plan records
+                `Mode: select-or-create`, explicit field mapping, runtime
+                descriptor resolution, and create/reuse lifecycle policy.
+                Missing targets create through the canonical template lifecycle
+                owner; exact existing matches reuse; ambiguous matches fail
+                closed. Concurrent deliveries for the same missing key MUST
+                converge on one receiver instance or fail closed without
+                duplicating the receiver key.
+              fail_closed:
+              - missing or empty instance_key
+              - instance_key not naming declared carries.<field>
+              - receiver not mode: template
+              - receiver instance.by missing, composite, or not equal to instance_key
+              - carry source not payload.<field>
+              - type-incompatible carried key
+              - combined legacy input address
+              - combined connect.using.instance or connect.map
+              - delivery topology other than one
+              - ambiguous target instance
+              - unavailable template lifecycle activator
+              - activation/create race that cannot reload exactly one matching instance
             fan-in:
               status: spec_locked_not_runnable_in_1835_pr1
               contract: >
@@ -8173,7 +8201,7 @@ flow_model:
               `resolution:{mode,...}` semantics.
           proof_obligations:
           - contracts decode every locked mode and reject unknown resolution fields fail-closed
-          - bootverify accepts valid create/select resolution and rejects other non-create modes as not runnable in this slice
+          - bootverify accepts valid create/select/select-or-create resolution and rejects other non-runnable modes as not runnable in this slice
           - route-plan lowering records create mode, mint kind, carried `as` field, create/reuse lifecycle policy, and does not require producer output key/carries
           - EventBus publish/preflight creates a missing receiver instance through the canonical lifecycle path
           - downstream receiver routes can render the carried minted instance key from activation variables
@@ -8183,6 +8211,13 @@ flow_model:
           - missing/ambiguous select target failures fail closed with receiver/key/value/remediation detail and no activation
           - same committed select event replay reuses persisted delivery route/scope and does not reselect after descriptor drift
           - standalone #1828 `template-select-existing` conformance fixture verifies and materializes through the canonical select route plan
+          - route-plan lowering records select-or-create mode, declared carried key mapping, runtime descriptor resolution, and create/reuse lifecycle policy
+          - EventBus publish/preflight for select-or-create reuses exactly one existing receiver instance
+          - EventBus publish/preflight for select-or-create creates exactly one missing receiver instance through the canonical lifecycle path
+          - concurrent same-key select-or-create deliveries converge on one receiver instance or fail closed without duplicate key ownership
+          - ambiguous select-or-create target failures fail closed with receiver/key/value/remediation detail and no activation
+          - same committed select-or-create event replay reuses persisted delivery route/scope and does not reselect or recreate after descriptor drift
+          - standalone #1828 `template-select-or-create` conformance fixture verifies and materializes through the canonical select-or-create route plan
         implementation_slice_1546:
           status: merge_bearing_runtime_behavior
           canonical_code_owner: internal/runtime/core/pinrouting.ConnectRoutePlan.InstanceKey.Mappings + internal/runtime/bus.connectRoutePlanResolver


### PR DESCRIPTION
Part of #1835

## Summary
- Makes `resolution.mode: select-or-create` runnable for the approved single-field carried-key template boundary.
- Lowers select-or-create through the canonical connect route plan owner with `Mode: select-or-create`, explicit carried-key mapping, descriptor resolution, and create/reuse lifecycle policy.
- Routes runtime materialization through the template lifecycle owner: exact existing match reuses, missing match creates, ambiguous match fails closed, same-key create races reload and converge on one instance or fail closed.
- Updates `platform-spec.yaml` and adds the #1828 `template-select-or-create` conformance fixture.

## Governing refs / context
- #1835 approved gate: first slice for `resolution.mode: select-or-create` after the posted Pre-Implementation Coverage Audit.
- Authoritative spec: `platform-spec.yaml#flow_model.flow_package.composition_routing.route_plan_lowering.implementation_slice_1835`.
- Binding boundary: single-field carried key only; `carries.<field>` declares seam identity; `resolution.instance_key` names that carried key; receiver is `mode: template`; receiver `instance.by` is exactly that one key; delivery is `one`.

## Semantic Migration
- New canonical owners: `internal/runtime/contracts.FlowInputPinResolution`, `internal/runtime/core/pinrouting.ConnectRoutePlan.InstanceKey`, `internal/runtime/bus.templateInstanceLifecycleOwner`, and `internal/runtime/bootverify.composition_connect_validation`.
- Old non-authoritative paths invalid for this child slice: `select_or_create_entity`, `create_flow_instance`, producer `target` / `broadcast` route authority, `connect.using.instance`, `connect.map`, delivery/readback/replay rows as semantic routing authority.
- Production paths checked: bootverify input-pin/connect validation, connect route-plan lowering, EventBus preflight/materialization, template lifecycle activation/reload, committed route replay, and conformance fixture materialization.
- Migration completeness: complete for the approved `select-or-create` child class; broader #1835 modes remain open.

## Proof
- `SWARM_TEST_POSTGRES_DSN='host=127.0.0.1 port=5432 user=youmew dbname=postgres sslmode=disable' PGPASSWORD=postgres go test ./internal/runtime/bootverify ./internal/runtime/core/pinrouting ./internal/runtime/bus ./internal/runtime/conformance ./internal/apispec -count=1 -timeout=8m`
- `SWARM_TEST_POSTGRES_DSN='host=127.0.0.1 port=5432 user=youmew dbname=postgres sslmode=disable' PGPASSWORD=postgres GOMAXPROCS=4 go test -p 1 ./...`

Note: an earlier full-suite run with `-p 2` hit load-sensitive failures in unrelated `internal/apiv1` and `internal/runtime/cataloge2e`; both isolated reruns passed, and the serialized full suite passed.
