### PR TITLE
[agent-c][issue #1723] Close fork replay resume record

### DIFF
--- a/cmd/swarm/main.go
+++ b/cmd/swarm/main.go
@@ -1983,10 +1983,10 @@ func printRunForkActivation(w io.Writer, result store.RunForkActivation) {
 	fmt.Fprintf(w, "Fork Run: %s status=%s\n", result.ForkRunID, result.ForkRunStatus)
 	fmt.Fprintf(w, "Source Run: %s status=%s\n", result.SourceRunID, result.SourceRunStatus)
 	fmt.Fprintf(w, "Fork Point: %s (%s) at %s\n", result.ForkPoint.EventName, result.ForkPoint.EventID, result.ForkPoint.Timestamp.Format(time.RFC3339Nano))
-	fmt.Fprintf(w, "Summary: activated=%t source_frozen=%t historical_replay_blocked=%t materialized_entities=%d\n",
+	fmt.Fprintf(w, "Summary: activated=%t source_frozen=%t replay_resume_blocked=%t materialized_entities=%d\n",
 		result.Activated,
 		result.SourceFrozen,
-		result.HistoricalReplayBlocked,
+		result.ReplayResumeBlocked,
 		result.MaterializedEntityCount,
 	)
 	if result.DeliveryEventReplay != nil {

--- a/cmd/swarm/main_test.go
+++ b/cmd/swarm/main_test.go
@@ -8475,7 +8475,7 @@ func TestRunForkRuntimeOwnerHarness_DryRunJSONReportsDeliveryEventReplayReady(t 
 	if err := json.Unmarshal(buf.Bytes(), &plan); err != nil {
 		t.Fatalf("decode fork plan json: %v\n%s", err, buf.String())
 	}
-	if !plan.ExecutionReady || !plan.ReplayResumeAdmission.DeliveryEventReplayReady || !plan.ReplayResumeAdmission.HistoricalReplaySupported {
+	if !plan.ExecutionReady || !plan.ReplayResumeAdmission.DeliveryEventReplayReady || !plan.ReplayResumeAdmission.BoundedReplaySupported {
 		t.Fatalf("dry-run replay admission = execution:%v admission:%#v", plan.ExecutionReady, plan.ReplayResumeAdmission)
 	}
 	if plan.ReplayResumeAdmission.StateOnlyExecutionReady {
@@ -8975,7 +8975,7 @@ func TestRunForkRuntimeOwnerHarness_ActivateUsesCanonicalStoreOwnerJSON(t *testi
 	if err := json.Unmarshal(buf.Bytes(), &result); err != nil {
 		t.Fatalf("decode fork activation json: %v\n%s", err, buf.String())
 	}
-	if !result.Activated || !result.SourceFrozen || !result.HistoricalReplayBlocked {
+	if !result.Activated || !result.SourceFrozen || !result.ReplayResumeBlocked {
 		t.Fatalf("activation result = %#v", result)
 	}
 	if result.ReplayResumeAdmission.Owner != store.RunForkReplayResumeAdmissionOwner || !result.ReplayResumeAdmission.StateOnlyExecutionReady {

--- a/cmd/swarm/main_test.go
+++ b/cmd/swarm/main_test.go
@@ -4681,15 +4681,7 @@ func seedServedRunControlPendingRunWithAgentDelivery(t *testing.T, db *sql.DB, b
 			`, deliveryID, runID, eventID, now); err != nil {
 			t.Fatalf("seed postgres run-control pending delivery: %v", err)
 		}
-		if _, err := tx.ExecContext(ctx, `
-				INSERT INTO event_receipts (
-					event_id, subscriber_type, subscriber_id, outcome, reason_code, side_effects, processed_at
-				)
-				VALUES (
-					$1::uuid, 'platform', 'pipeline', 'success', 'pipeline_persisted',
-					'{"manager_status":"processed","reason_code":"pipeline_persisted"}'::jsonb, $2
-				)
-			`, eventID, now); err != nil {
+		if err := (&store.PostgresStore{DB: db}).UpsertPipelineReceiptTx(ctx, tx, eventID, "processed", ""); err != nil {
 			t.Fatalf("seed postgres run-control pipeline receipt: %v", err)
 		}
 	case "sqlite":
@@ -4711,15 +4703,8 @@ func seedServedRunControlPendingRunWithAgentDelivery(t *testing.T, db *sql.DB, b
 			`, deliveryID, runID, eventID, now); err != nil {
 			t.Fatalf("seed sqlite run-control pending delivery: %v", err)
 		}
-		if _, err := tx.ExecContext(ctx, `
-				INSERT INTO event_receipts (
-					receipt_id, event_id, subscriber_type, subscriber_id, outcome, reason_code, side_effects, processed_at
-				)
-				VALUES (
-					?, ?, 'platform', 'pipeline', 'success', 'pipeline_persisted',
-					'{"manager_status":"processed","reason_code":"pipeline_persisted"}', ?
-				)
-			`, uuid.NewString(), eventID, now); err != nil {
+		sqliteStore := &store.SQLiteRuntimeStore{SQLiteSchemaStore: &store.SQLiteSchemaStore{DB: db}}
+		if err := sqliteStore.UpsertPipelineReceiptTx(ctx, tx, eventID, "processed", ""); err != nil {
 			t.Fatalf("seed sqlite run-control pipeline receipt: %v", err)
 		}
 	default:

--- a/internal/runtime/bus/sweeper.go
+++ b/internal/runtime/bus/sweeper.go
@@ -178,23 +178,30 @@ func (eb *EventBus) ReleaseRunQueue(ctx context.Context, runID string, lookback 
 	if !participates {
 		return 0, nil
 	}
+	since := time.Now().Add(-lookback)
+	redelivered := 0
+	seen := map[string]struct{}{}
 	if lister, ok := eb.store.(interface {
 		ListEventsWithPendingDeliveriesForRun(context.Context, string, time.Time, int) ([]events.PersistedReplayEvent, error)
 	}); ok && lister != nil {
-		records, err := lister.ListEventsWithPendingDeliveriesForRun(ctx, runID, time.Now().Add(-lookback), limit)
+		records, err := lister.ListEventsWithPendingDeliveriesForRun(ctx, runID, since, limit)
 		if err != nil {
 			return 0, err
 		}
-		redelivered := 0
 		for _, record := range records {
 			evt := record.Event
-			if replayErr := strings.TrimSpace(record.ReplayError); replayErr != "" {
-				eb.markPipelineReceipt(ctx, evt.ID(), "error", replayErr)
+			eventID := strings.TrimSpace(evt.ID())
+			if eventID == "" {
 				continue
 			}
-			recipients, err := eb.authoritativeRecipientsForEvent(ctx, evt.ID())
+			seen[eventID] = struct{}{}
+			if replayErr := strings.TrimSpace(record.ReplayError); replayErr != "" {
+				eb.markPipelineReceipt(ctx, eventID, "error", replayErr)
+				continue
+			}
+			recipients, err := eb.authoritativeRecipientsForEvent(ctx, eventID)
 			if err != nil {
-				eb.markPipelineReceipt(ctx, evt.ID(), "error", err.Error())
+				eb.markPipelineReceipt(ctx, eventID, "error", err.Error())
 				return redelivered, err
 			}
 			if err := eb.publishPersistedRecipients(ctx, evt, recipients, true); err != nil {
@@ -203,24 +210,29 @@ func (eb *EventBus) ReleaseRunQueue(ctx context.Context, runID string, lookback 
 				}
 				return redelivered, err
 			}
-			eb.markPipelineReceipt(ctx, evt.ID(), "processed", "")
+			eb.markPipelineReceipt(ctx, eventID, "processed", "")
 			redelivered++
 		}
-		return redelivered, nil
 	}
 	lister, ok := eb.store.(interface {
 		ListEventsMissingPipelineReceiptForRun(context.Context, string, time.Time, int) ([]events.PersistedReplayEvent, error)
 	})
 	if !ok || lister == nil {
-		return 0, nil
+		return redelivered, nil
 	}
-	records, err := lister.ListEventsMissingPipelineReceiptForRun(ctx, runID, time.Now().Add(-lookback), limit)
+	records, err := lister.ListEventsMissingPipelineReceiptForRun(ctx, runID, since, limit)
 	if err != nil {
-		return 0, err
+		return redelivered, err
 	}
-	redelivered := 0
 	for _, record := range records {
 		evt := record.Event
+		eventID := strings.TrimSpace(evt.ID())
+		if eventID == "" {
+			continue
+		}
+		if _, exists := seen[eventID]; exists {
+			continue
+		}
 		lease, claimed, err := replayStore.ClaimPipelineReplay(ctx, evt.ID())
 		if err != nil {
 			return redelivered, err

--- a/internal/runtime/conformance/fork_replay_resume_design_record_test.go
+++ b/internal/runtime/conformance/fork_replay_resume_design_record_test.go
@@ -1,0 +1,558 @@
+package conformance
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/division-sh/swarm/internal/store"
+	"gopkg.in/yaml.v3"
+)
+
+const forkReplayResumeDesignRecordPath = "internal/runtime/conformance/testdata/fork_replay_resume_design_record.yaml"
+
+type forkReplayResumeDesignRecord struct {
+	Version             int                         `yaml:"version"`
+	Kind                string                      `yaml:"kind"`
+	Issue               int                         `yaml:"issue"`
+	ParentIssue         int                         `yaml:"parent_issue"`
+	SourceRefs          forkReplayResumeSourceRefs  `yaml:"source_refs"`
+	Policy              forkReplayResumePolicy      `yaml:"policy"`
+	Watchlist           forkReplayResumeWatchlist   `yaml:"watchlist"`
+	StaleLanguagePolicy forkReplayResumeStalePolicy `yaml:"stale_language_policy"`
+	Successors          []forkReplayResumeSuccessor `yaml:"successors"`
+	Rows                []forkReplayResumeDesignRow `yaml:"rows"`
+}
+
+type forkReplayResumeSourceRefs struct {
+	PreAuditComment     string `yaml:"pre_audit_comment"`
+	GateComment         string `yaml:"gate_comment"`
+	LockedDesignComment string `yaml:"locked_design_comment"`
+	PlatformSpec        string `yaml:"platform_spec"`
+}
+
+type forkReplayResumePolicy struct {
+	ClosureLevel                 string `yaml:"closure_level"`
+	ClaimsRuntimeBehaviorChange  bool   `yaml:"claims_runtime_behavior_change"`
+	ClaimsFullHistoricalResume   bool   `yaml:"claims_full_historical_resume"`
+	RuntimeBehaviorChangeAllowed bool   `yaml:"runtime_behavior_change_allowed"`
+	RequiredFullTestCommand      string `yaml:"required_full_test_command"`
+}
+
+type forkReplayResumeWatchlist struct {
+	Node                string `yaml:"node"`
+	PrivateRepo         string `yaml:"private_repo"`
+	ExternalRepairOwner string `yaml:"external_repair_owner"`
+	Mapping             string `yaml:"mapping"`
+}
+
+type forkReplayResumeStalePolicy struct {
+	ForbiddenPhrases            []string                           `yaml:"forbidden_phrases"`
+	ForbiddenPublicReadbackKeys []string                           `yaml:"forbidden_public_readback_keys"`
+	LegacyIdentifierSentinels   []forkReplayResumeLegacyIdentifier `yaml:"legacy_identifier_sentinels"`
+}
+
+type forkReplayResumeLegacyIdentifier struct {
+	Identifier string `yaml:"identifier"`
+	Reason     string `yaml:"reason"`
+}
+
+type forkReplayResumeSuccessor struct {
+	Issue   int    `yaml:"issue"`
+	Role    string `yaml:"role"`
+	Concept string `yaml:"concept"`
+}
+
+type forkReplayResumeDesignRow struct {
+	ID               string                     `yaml:"id"`
+	Fact             string                     `yaml:"fact"`
+	Disposition      string                     `yaml:"disposition"`
+	Owner            string                     `yaml:"owner"`
+	BlockerCodes     []string                   `yaml:"blocker_codes"`
+	EnforcementPoint string                     `yaml:"enforcement_point"`
+	ProofRefs        []forkReplayResumeProofRef `yaml:"proof_refs"`
+	Rationale        string                     `yaml:"rationale"`
+}
+
+type forkReplayResumeProofRef struct {
+	Kind  string `yaml:"kind"`
+	Name  string `yaml:"name,omitempty"`
+	Issue int    `yaml:"issue,omitempty"`
+}
+
+func TestForkReplayResumeDesignRecordCoversBoundedModel(t *testing.T) {
+	root := conformanceRepoRoot(t)
+	record := loadForkReplayResumeDesignRecord(t, root)
+	ctx := forkReplayResumeValidationContext{
+		goTests: collectGoTestNames(t, root),
+	}
+	if problems := validateForkReplayResumeDesignRecord(root, record, ctx); len(problems) > 0 {
+		t.Fatalf("fork replay/resume design record validation failed:\n- %s", strings.Join(problems, "\n- "))
+	}
+}
+
+func TestForkReplayResumeDesignRecordRejectsStaleOrUnmappedClaims(t *testing.T) {
+	root := conformanceRepoRoot(t)
+	base := loadForkReplayResumeDesignRecord(t, root)
+	ctx := forkReplayResumeValidationContext{
+		goTests: collectGoTestNames(t, root),
+	}
+	tests := []struct {
+		name   string
+		mutate func(*forkReplayResumeDesignRecord)
+		want   string
+	}{
+		{
+			name: "runtime behavior claim",
+			mutate: func(record *forkReplayResumeDesignRecord) {
+				record.Policy.ClaimsRuntimeBehaviorChange = true
+			},
+			want: "policy claims_runtime_behavior_change = true, want false",
+		},
+		{
+			name: "full resume claim",
+			mutate: func(record *forkReplayResumeDesignRecord) {
+				record.Policy.ClaimsFullHistoricalResume = true
+			},
+			want: "policy claims_full_historical_resume = true, want false",
+		},
+		{
+			name: "missing delivery pending row",
+			mutate: func(record *forkReplayResumeDesignRecord) {
+				record.Rows = forkReplayResumeRowsExcept(record.Rows, "delivery_pending_history")
+			},
+			want: "rows missing required fact delivery_pending_history",
+		},
+		{
+			name: "fail closed row without blocker",
+			mutate: func(record *forkReplayResumeDesignRecord) {
+				row := forkReplayResumeRowByID(t, record, "delivery_in_progress_history")
+				row.BlockerCodes = nil
+			},
+			want: "delivery_in_progress_history fail-closed row missing blocker_codes",
+		},
+		{
+			name: "unmapped blocker",
+			mutate: func(record *forkReplayResumeDesignRecord) {
+				for i := range record.Rows {
+					record.Rows[i].BlockerCodes = forkReplayResumeStringsExcept(record.Rows[i].BlockerCodes, store.RunForkBlockerTimerHistoryUnproven)
+				}
+			},
+			want: "blocker code timer_history_unproven is not mapped by any row",
+		},
+		{
+			name: "stale proof test",
+			mutate: func(record *forkReplayResumeDesignRecord) {
+				row := forkReplayResumeRowByID(t, record, "delivery_pending_history")
+				row.ProofRefs[0].Name = "TestMissingForkReplayResumeProof"
+			},
+			want: "delivery_pending_history go_test proof_ref TestMissingForkReplayResumeProof does not resolve",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			record := base
+			record.Rows = append([]forkReplayResumeDesignRow(nil), base.Rows...)
+			tc.mutate(&record)
+			problems := validateForkReplayResumeDesignRecord(root, record, ctx)
+			if !routeAuthorityProblemsContain(problems, tc.want) {
+				t.Fatalf("validation problems missing %q:\n- %s", tc.want, strings.Join(problems, "\n- "))
+			}
+		})
+	}
+}
+
+type forkReplayResumeValidationContext struct {
+	goTests map[string]bool
+}
+
+func loadForkReplayResumeDesignRecord(t *testing.T, root string) forkReplayResumeDesignRecord {
+	t.Helper()
+	raw, err := os.ReadFile(filepath.Join(root, forkReplayResumeDesignRecordPath))
+	if err != nil {
+		t.Fatalf("read fork replay/resume design record: %v", err)
+	}
+	var record forkReplayResumeDesignRecord
+	if err := yaml.Unmarshal(raw, &record); err != nil {
+		t.Fatalf("parse fork replay/resume design record: %v", err)
+	}
+	return record
+}
+
+func validateForkReplayResumeDesignRecord(root string, record forkReplayResumeDesignRecord, ctx forkReplayResumeValidationContext) []string {
+	var problems []string
+	if record.Version != 1 {
+		problems = append(problems, fmt.Sprintf("version = %d, want 1", record.Version))
+	}
+	if record.Kind != "fork_replay_resume_design_record" {
+		problems = append(problems, fmt.Sprintf("kind = %q, want fork_replay_resume_design_record", record.Kind))
+	}
+	if record.Issue != 1723 || record.ParentIssue != 564 {
+		problems = append(problems, fmt.Sprintf("issue/parent = #%d/#%d, want #1723/#564", record.Issue, record.ParentIssue))
+	}
+	problems = append(problems, validateForkReplayResumeRefs(root, record.SourceRefs)...)
+	problems = append(problems, validateForkReplayResumePolicy(record.Policy)...)
+	problems = append(problems, validateForkReplayResumeWatchlist(record.Watchlist)...)
+	problems = append(problems, validateForkReplayResumeStalePolicy(root, record.StaleLanguagePolicy)...)
+	problems = append(problems, validateForkReplayResumeSuccessors(record.Successors)...)
+
+	rowsByFact := map[string]forkReplayResumeDesignRow{}
+	blockerRows := map[string]string{}
+	for _, row := range record.Rows {
+		problems = append(problems, validateForkReplayResumeRow(root, row, ctx)...)
+		fact := strings.TrimSpace(row.Fact)
+		if _, exists := rowsByFact[fact]; exists {
+			problems = append(problems, fmt.Sprintf("rows duplicate fact %s", fact))
+		}
+		rowsByFact[fact] = row
+		for _, blocker := range row.BlockerCodes {
+			blocker = strings.TrimSpace(blocker)
+			if blocker == "" {
+				continue
+			}
+			blockerRows[blocker] = row.ID
+		}
+	}
+	for _, fact := range requiredForkReplayResumeFacts() {
+		if _, ok := rowsByFact[fact]; !ok {
+			problems = append(problems, fmt.Sprintf("rows missing required fact %s", fact))
+		}
+	}
+	for _, blocker := range requiredForkReplayResumeBlockers() {
+		if _, ok := blockerRows[blocker]; !ok {
+			problems = append(problems, fmt.Sprintf("blocker code %s is not mapped by any row", blocker))
+		}
+	}
+	sort.Strings(problems)
+	return problems
+}
+
+func validateForkReplayResumeRefs(root string, refs forkReplayResumeSourceRefs) []string {
+	var problems []string
+	for label, value := range map[string]string{
+		"pre_audit_comment":     refs.PreAuditComment,
+		"gate_comment":          refs.GateComment,
+		"locked_design_comment": refs.LockedDesignComment,
+	} {
+		if !strings.Contains(value, "github.com/division-sh/swarm/issues/1723#issuecomment-") {
+			problems = append(problems, fmt.Sprintf("source_refs %s missing #1723 issue comment URL", label))
+		}
+	}
+	if refs.PlatformSpec != "platform-spec.yaml" {
+		problems = append(problems, fmt.Sprintf("source_refs platform_spec = %q, want platform-spec.yaml", refs.PlatformSpec))
+	} else if _, err := os.Stat(filepath.Join(root, refs.PlatformSpec)); err != nil {
+		problems = append(problems, "source_refs platform_spec path does not exist")
+	}
+	return problems
+}
+
+func validateForkReplayResumePolicy(policy forkReplayResumePolicy) []string {
+	var problems []string
+	if policy.ClosureLevel != "spec_design_conformance_closure" {
+		problems = append(problems, fmt.Sprintf("policy closure_level = %q, want spec_design_conformance_closure", policy.ClosureLevel))
+	}
+	if policy.ClaimsRuntimeBehaviorChange {
+		problems = append(problems, "policy claims_runtime_behavior_change = true, want false")
+	}
+	if policy.ClaimsFullHistoricalResume {
+		problems = append(problems, "policy claims_full_historical_resume = true, want false")
+	}
+	if policy.RuntimeBehaviorChangeAllowed {
+		problems = append(problems, "policy runtime_behavior_change_allowed = true, want false")
+	}
+	if strings.TrimSpace(policy.RequiredFullTestCommand) != "go test ./..." {
+		problems = append(problems, fmt.Sprintf("policy required_full_test_command = %q, want go test ./...", policy.RequiredFullTestCommand))
+	}
+	return problems
+}
+
+func validateForkReplayResumeWatchlist(watchlist forkReplayResumeWatchlist) []string {
+	var problems []string
+	if watchlist.Node != "timestamp_fork_replay_resume_ownership" {
+		problems = append(problems, fmt.Sprintf("watchlist node = %q, want timestamp_fork_replay_resume_ownership", watchlist.Node))
+	}
+	if watchlist.PrivateRepo != "swarm-docs" {
+		problems = append(problems, fmt.Sprintf("watchlist private_repo = %q, want swarm-docs", watchlist.PrivateRepo))
+	}
+	if watchlist.ExternalRepairOwner != "lead_after_merge" {
+		problems = append(problems, fmt.Sprintf("watchlist external_repair_owner = %q, want lead_after_merge", watchlist.ExternalRepairOwner))
+	}
+	for _, fragment := range []string{"#1723", "#564", "#1721", "#1722"} {
+		if !strings.Contains(watchlist.Mapping, fragment) {
+			problems = append(problems, fmt.Sprintf("watchlist mapping missing %s", fragment))
+		}
+	}
+	return problems
+}
+
+func validateForkReplayResumeStalePolicy(root string, policy forkReplayResumeStalePolicy) []string {
+	var problems []string
+	if len(policy.LegacyIdentifierSentinels) == 0 {
+		problems = append(problems, "stale_language_policy missing legacy_identifier_sentinels")
+	}
+	for _, sentinel := range policy.LegacyIdentifierSentinels {
+		if strings.TrimSpace(sentinel.Identifier) == "" || strings.TrimSpace(sentinel.Reason) == "" {
+			problems = append(problems, "legacy_identifier_sentinel missing identifier or reason")
+		}
+	}
+	scanPaths := []string{
+		"platform-spec.yaml",
+		"internal/store",
+		"internal/runtime/runforkexecution",
+		"cmd/swarm",
+	}
+	for _, rel := range scanPaths {
+		path := filepath.Join(root, rel)
+		if err := filepath.WalkDir(path, func(path string, d os.DirEntry, err error) error {
+			if err != nil {
+				return err
+			}
+			if d.IsDir() {
+				return nil
+			}
+			if filepath.Ext(path) != ".go" && filepath.Base(path) != "platform-spec.yaml" {
+				return nil
+			}
+			raw, err := os.ReadFile(path)
+			if err != nil {
+				return err
+			}
+			lower := strings.ToLower(string(raw))
+			for _, phrase := range policy.ForbiddenPhrases {
+				phrase = strings.ToLower(strings.TrimSpace(phrase))
+				if phrase != "" && strings.Contains(lower, phrase) {
+					problems = append(problems, fmt.Sprintf("forbidden stale phrase %q still appears in %s", phrase, conformanceRelPath(root, path)))
+				}
+			}
+			for _, key := range policy.ForbiddenPublicReadbackKeys {
+				key = strings.TrimSpace(key)
+				if key != "" && strings.Contains(string(raw), key) {
+					problems = append(problems, fmt.Sprintf("forbidden public readback key %q still appears in %s", key, conformanceRelPath(root, path)))
+				}
+			}
+			return nil
+		}); err != nil {
+			problems = append(problems, fmt.Sprintf("scan stale language under %s: %v", rel, err))
+		}
+	}
+	return problems
+}
+
+func validateForkReplayResumeSuccessors(successors []forkReplayResumeSuccessor) []string {
+	var problems []string
+	seen := map[int]forkReplayResumeSuccessor{}
+	for _, successor := range successors {
+		seen[successor.Issue] = successor
+		if strings.TrimSpace(successor.Role) == "" || strings.TrimSpace(successor.Concept) == "" {
+			problems = append(problems, fmt.Sprintf("successor #%d missing role or concept", successor.Issue))
+		}
+	}
+	if _, ok := seen[1721]; !ok {
+		problems = append(problems, "successors missing #1721")
+	}
+	if _, ok := seen[1722]; !ok {
+		problems = append(problems, "successors missing #1722")
+	}
+	return problems
+}
+
+func validateForkReplayResumeRow(root string, row forkReplayResumeDesignRow, ctx forkReplayResumeValidationContext) []string {
+	var problems []string
+	id := strings.TrimSpace(row.ID)
+	if id == "" {
+		return []string{"row missing id"}
+	}
+	if strings.TrimSpace(row.Fact) == "" {
+		problems = append(problems, fmt.Sprintf("%s missing fact", id))
+	}
+	if _, ok := allowedForkReplayResumeDispositions()[row.Disposition]; !ok {
+		problems = append(problems, fmt.Sprintf("%s disposition %q is not allowed", id, row.Disposition))
+	}
+	if strings.TrimSpace(row.Owner) == "" {
+		problems = append(problems, fmt.Sprintf("%s missing owner", id))
+	}
+	if strings.TrimSpace(row.EnforcementPoint) == "" {
+		problems = append(problems, fmt.Sprintf("%s missing enforcement_point", id))
+	} else if row.EnforcementPoint != "issue-tracker" {
+		path := filepath.Join(root, filepath.Clean(row.EnforcementPoint))
+		if filepath.IsAbs(row.EnforcementPoint) || strings.HasPrefix(filepath.Clean(row.EnforcementPoint), "..") {
+			problems = append(problems, fmt.Sprintf("%s enforcement_point %s must be repo-relative", id, row.EnforcementPoint))
+		} else if _, err := os.Stat(path); err != nil {
+			problems = append(problems, fmt.Sprintf("%s enforcement_point %s does not exist", id, row.EnforcementPoint))
+		}
+	}
+	if strings.Contains(row.Disposition, "fail_closed") && len(row.BlockerCodes) == 0 {
+		problems = append(problems, fmt.Sprintf("%s fail-closed row missing blocker_codes", id))
+	}
+	if len(row.ProofRefs) == 0 {
+		problems = append(problems, fmt.Sprintf("%s missing proof_refs", id))
+	}
+	if strings.TrimSpace(row.Rationale) == "" {
+		problems = append(problems, fmt.Sprintf("%s missing rationale", id))
+	}
+	for _, ref := range row.ProofRefs {
+		problems = append(problems, validateForkReplayResumeProofRef(id, ref, ctx)...)
+	}
+	return problems
+}
+
+func validateForkReplayResumeProofRef(rowID string, ref forkReplayResumeProofRef, ctx forkReplayResumeValidationContext) []string {
+	var problems []string
+	switch ref.Kind {
+	case "go_test":
+		if strings.TrimSpace(ref.Name) == "" {
+			problems = append(problems, fmt.Sprintf("%s go_test proof_ref missing name", rowID))
+			return problems
+		}
+		if !ctx.goTests[ref.Name] {
+			problems = append(problems, fmt.Sprintf("%s go_test proof_ref %s does not resolve", rowID, ref.Name))
+		}
+	case "issue":
+		if ref.Issue <= 0 {
+			problems = append(problems, fmt.Sprintf("%s issue proof_ref missing issue", rowID))
+		}
+	default:
+		problems = append(problems, fmt.Sprintf("%s proof_ref kind %q is not allowed", rowID, ref.Kind))
+	}
+	return problems
+}
+
+func requiredForkReplayResumeFacts() []string {
+	return []string{
+		store.RunForkReplayResumeFactEntityStateSnapshot,
+		store.RunForkReplayResumeFactDeliveryCompletedHistory,
+		store.RunForkReplayResumeFactDeliveryPendingHistory,
+		store.RunForkReplayResumeFactDeliveryInProgressHistory,
+		store.RunForkReplayResumeFactDeliveryFailedHistory,
+		store.RunForkReplayResumeFactDeliveryDeadLetterHistory,
+		store.RunForkReplayResumeFactCommittedReplayScope,
+		store.RunForkReplayResumeFactTimerHistory,
+		store.RunForkReplayResumeFactRouteHistory,
+		store.RunForkReplayResumeFactSessionHistory,
+		store.RunForkReplayResumeFactConversationAuditHistory,
+		store.RunForkReplayResumeFactActiveTurnHistory,
+		store.RunForkReplayResumeFactSourceAdvanced,
+		store.RunForkReplayResumeFactForkReplayState,
+		store.RunForkReplayResumeFactContractSwap,
+		store.RunForkReplayResumeFactHistoricalReplayExecution,
+		store.RunForkHistoricalReplayFactSourceEvents,
+		store.RunForkHistoricalReplayFactEventDeliveries,
+		store.RunForkHistoricalReplayFactReceipts,
+		store.RunForkHistoricalReplayFactDeadLetters,
+		store.RunForkHistoricalReplayFactRetryIdempotency,
+		store.RunForkHistoricalReplayFactEmittedFollowUps,
+		store.RunForkHistoricalReplayFactTimers,
+		store.RunForkHistoricalReplayFactRoutes,
+		store.RunForkHistoricalReplayFactSessions,
+		store.RunForkHistoricalReplayFactTurns,
+		store.RunForkHistoricalReplayFactAudits,
+		store.RunForkHistoricalReplayFactNonAgentNodeSystemWork,
+		store.RunForkHistoricalReplayFactSourceAdvancedPostTFacts,
+		store.RunForkHistoricalReplayFactRuntimeRestartRecovery,
+		store.RunForkHistoricalReplayFactCLIApiDashboardOperator,
+		"selected_contract_prerequisite_blockers",
+		"memoized_reexecution_reserved",
+	}
+}
+
+func requiredForkReplayResumeBlockers() []string {
+	return []string{
+		store.RunForkBlockerDeliveryHistoryUnproven,
+		store.RunForkBlockerNonAgentDeliveryReplayUnsupported,
+		store.RunForkBlockerCommittedReplayScopeReplayUnsupported,
+		store.RunForkBlockerTimerHistoryUnproven,
+		store.RunForkBlockerFlowRouteHistoryUnproven,
+		store.RunForkBlockerSessionHistoryUnproven,
+		store.RunForkBlockerConversationAuditUnproven,
+		store.RunForkBlockerActiveTurnHistoryUnproven,
+		store.RunForkBlockerEntitySnapshotMetadataUnproven,
+		store.RunForkBlockerSelectedContractExecutionModelNonMutating,
+		store.RunForkBlockerSelectedContractExecutionAdmissionNonMutating,
+		store.RunForkBlockerSelectedContractSourceReplayUnsupported,
+		store.RunForkBlockerSelectedContractRouteAdmissionNonMutating,
+		store.RunForkBlockerSelectedContractRouteTopologyNonMutating,
+		store.RunForkBlockerSelectedContractDynamicRouteTopologyUnproven,
+		store.RunForkBlockerSelectedContractRecipientPlanningNonMutating,
+		store.RunForkBlockerSelectedContractAgentHandlerMaterializationUnsupported,
+		store.RunForkBlockerContractSwapBootResumeAdmissionNonMutating,
+		store.RunForkBlockerContractSwapRouteRecoveryMissing,
+		store.RunForkBlockerHistoricalReplayExecutionAdmissionNonMutating,
+		store.RunForkBlockerContractFrontierExecutionUnsupported,
+		store.RunForkBlockerContractFrontierRouteUnresolved,
+		"source_events_advanced_after_fork_point",
+		"source_timers_advanced_after_fork_point",
+		"source_routes_advanced_after_fork_point",
+		"source_committed_replay_scope_advanced_after_fork_point",
+		"source_active_conversation_session_coupling_after_fork_point",
+		"fork_events_already_exist",
+		"fork_sessions_already_exist",
+		"fork_conversation_audits_already_exist",
+		"fork_turns_already_exist",
+	}
+}
+
+func allowedForkReplayResumeDispositions() map[string]struct{} {
+	values := []string{
+		store.RunForkReplayResumeDispositionReconstruct,
+		store.RunForkReplayResumeDispositionForkReplay,
+		store.RunForkReplayResumeDispositionLineageOnly,
+		store.RunForkReplayResumeDispositionFailClosedBlocker,
+		store.RunForkReplayResumeDispositionSplitSibling,
+		store.RunForkReplayResumeDispositionNoHistoricalAction,
+		store.RunForkHistoricalReplayAdmissionExecutableForkWork,
+		store.RunForkHistoricalReplayAdmissionReconstructedForkState,
+		store.RunForkHistoricalReplayAdmissionLineageOnlyEvidence,
+		store.RunForkHistoricalReplayAdmissionFailClosedBlocker,
+		store.RunForkHistoricalReplayAdmissionSplitSibling,
+		"fail_closed_or_reconstruct",
+		"fail_closed_or_lineage",
+		"reserved_future",
+	}
+	out := make(map[string]struct{}, len(values))
+	for _, value := range values {
+		out[value] = struct{}{}
+	}
+	return out
+}
+
+func forkReplayResumeRowByID(t *testing.T, record *forkReplayResumeDesignRecord, id string) *forkReplayResumeDesignRow {
+	t.Helper()
+	for i := range record.Rows {
+		if record.Rows[i].ID == id {
+			return &record.Rows[i]
+		}
+	}
+	t.Fatalf("row %s not found", id)
+	return nil
+}
+
+func forkReplayResumeRowsExcept(rows []forkReplayResumeDesignRow, id string) []forkReplayResumeDesignRow {
+	out := make([]forkReplayResumeDesignRow, 0, len(rows))
+	for _, row := range rows {
+		if row.ID != id {
+			out = append(out, row)
+		}
+	}
+	return out
+}
+
+func forkReplayResumeStringsExcept(values []string, unwanted string) []string {
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		if value != unwanted {
+			out = append(out, value)
+		}
+	}
+	return out
+}
+
+func conformanceRelPath(root, path string) string {
+	rel, err := filepath.Rel(root, path)
+	if err != nil {
+		return path
+	}
+	return rel
+}

--- a/internal/runtime/conformance/testdata/fork_replay_resume_design_record.yaml
+++ b/internal/runtime/conformance/testdata/fork_replay_resume_design_record.yaml
@@ -1,0 +1,428 @@
+version: 1
+kind: fork_replay_resume_design_record
+issue: 1723
+parent_issue: 564
+source_refs:
+  pre_audit_comment: https://github.com/division-sh/swarm/issues/1723#issuecomment-4917732636
+  gate_comment: https://github.com/division-sh/swarm/issues/1723#issuecomment-4917849951
+  locked_design_comment: https://github.com/division-sh/swarm/issues/1723#issuecomment-4917722298
+  platform_spec: platform-spec.yaml
+policy:
+  closure_level: spec_design_conformance_closure
+  claims_runtime_behavior_change: false
+  claims_full_historical_resume: false
+  runtime_behavior_change_allowed: false
+  required_full_test_command: go test ./...
+watchlist:
+  node: timestamp_fork_replay_resume_ownership
+  private_repo: swarm-docs
+  external_repair_owner: lead_after_merge
+  mapping: "#1723 closes #564 product promise by bounded re-execution; #1721 and #1722 stay successor tripwires."
+stale_language_policy:
+  forbidden_phrases:
+    - full historical resume
+    - historical resume
+    - full historical replay/resume
+    - future full historical
+    - product-complete historical replay/resume
+    - system knows what was unfinished
+  forbidden_public_readback_keys:
+    - historical_replay_supported
+    - historical_replay_required
+    - historical_replay_blocked
+    - full_replay_resume_supported
+  legacy_identifier_sentinels:
+    - identifier: RunForkHistoricalReplayExecutionOwner
+      reason: "Legacy-named bounded owner retained to avoid broad internal migration; current closure is delivery_event_replay_ready plus approved bounded children only."
+    - identifier: RunForkHistoricalReplayExecutionAdmissionOwner
+      reason: "Legacy-named admission owner retained as non-mutating matrix owner."
+    - identifier: RunForkHistoricalReplayContractSwapBootResumeOwner
+      reason: "Legacy-named selected-contract child retained; bounded to selected-frontier delivery_event_replay_ready."
+    - identifier: RunForkHistoricalReplayTimerReconstructionOwner
+      reason: "Legacy-named timer child retained for approved active-at-T timer reconstruction."
+    - identifier: RunForkHistoricalReplayFact*
+      reason: "Legacy-named fact-family constants retained as internal matrix vocabulary."
+    - identifier: RunForkHistoricalReplayAdmission*
+      reason: "Legacy-named admission disposition constants retained as internal matrix vocabulary."
+    - identifier: runtime.run_fork.historical_replay_execution*
+      reason: "Legacy string owner prefix retained as internal owner sentinel; spec defines it as bounded re-execution, not full resume."
+successors:
+  - issue: 1721
+    role: reserved_sixth_classification
+    concept: memoized agent-turn re-execution for byte-identical inputs
+  - issue: 1722
+    role: split_successor
+    concept: fleet fork and divergence reporting
+rows:
+  - id: entity_state_snapshot
+    fact: entity_state_snapshot
+    disposition: fail_closed_or_reconstruct
+    owner: runtime.run_fork.materialized_entity_snapshot_metadata
+    blocker_codes: [entity_snapshot_metadata_unproven]
+    enforcement_point: internal/store/run_fork_materializer.go
+    proof_refs:
+      - {kind: go_test, name: TestRunForkPlanner_ReconstructsEntityStateAtForkPointFromMutations}
+      - {kind: go_test, name: TestRunForkMaterializer_CreatesPausedForkRunAndSnapshotWithoutResuming}
+    rationale: "Current entity state is reconstructed from append-only entity_mutations and materialized only after metadata proof."
+
+  - id: delivery_completed_history
+    fact: delivery_completed_history
+    disposition: lineage_only
+    owner: store.run_fork.replay_resume_admission
+    enforcement_point: internal/store/run_fork_replay_resume_admission.go
+    proof_refs:
+      - {kind: go_test, name: TestRunForkPlanner_DoesNotReportPostForkCompletionAsCompletedAtFork}
+      - {kind: go_test, name: TestRunForkPlanner_SuppressesPostForkTerminalMetadata}
+    rationale: "Completed source deliveries and receipts are lineage/proof only; they are not re-delivered into the fork."
+
+  - id: delivery_pending_history
+    fact: delivery_pending_history
+    disposition: fork_replay
+    owner: store.run_fork.replay_resume_admission
+    enforcement_point: internal/store/run_fork_replay_resume_admission.go
+    proof_refs:
+      - {kind: go_test, name: TestRunForkPlanner_PendingUnstartedDeliveryIsDeliveryEventReplayReady}
+      - {kind: go_test, name: TestRunForkActivation_ReplaysSafePendingDeliveryWithForkLocalLineage}
+    rationale: "Only pending unstarted agent deliveries with no session/receipt/start metadata enter delivery_event_replay_ready."
+
+  - id: delivery_in_progress_history
+    fact: delivery_in_progress_history
+    disposition: fail_closed_blocker
+    owner: store.run_fork.replay_resume_admission
+    blocker_codes: [delivery_history_unproven]
+    enforcement_point: internal/store/run_fork_replay_resume_admission.go
+    proof_refs:
+      - {kind: go_test, name: TestRunForkActivation_FailsClosedForInProgressDeliveryAndMissingLineage}
+      - {kind: go_test, name: TestRunForkPlanner_RunScopedActiveSessionAndTurnRemainBlockers}
+    rationale: "In-progress delivery state is not append-only replay truth and cannot be resumed from current rows."
+
+  - id: delivery_failed_history
+    fact: delivery_failed_history
+    disposition: fail_closed_blocker
+    owner: store.run_fork.replay_resume_admission
+    blocker_codes: [delivery_history_unproven]
+    enforcement_point: internal/store/run_fork_replay_resume_admission.go
+    proof_refs:
+      - {kind: go_test, name: TestRunForkPlanner_ClassifiesPendingWorkAndNamedBlockers}
+    rationale: "Failed/retryable delivery state needs retry/idempotency ownership and is not admitted by the M0 primitive."
+
+  - id: delivery_dead_letter_history
+    fact: delivery_dead_letter_history
+    disposition: fail_closed_blocker
+    owner: store.run_fork.replay_resume_admission
+    blocker_codes: [delivery_history_unproven]
+    enforcement_point: internal/store/run_fork_replay_resume_admission.go
+    proof_refs:
+      - {kind: go_test, name: TestRunForkPlanner_ScopesDeadLettersToMatchingDelivery}
+    rationale: "Dead-letter source outcomes are source-run lineage and do not suppress or authorize fork work."
+
+  - id: committed_replay_scope
+    fact: committed_replay_scope
+    disposition: fail_closed_blocker
+    owner: store.run_fork.replay_resume_admission
+    blocker_codes: [committed_replay_scope_replay_unsupported]
+    enforcement_point: internal/store/run_fork_replay_resume_admission.go
+    proof_refs:
+      - {kind: go_test, name: TestRunForkPlanner_ReplayScopeMarkerRemainsCommittedReplayBlocker}
+      - {kind: go_test, name: TestSelectedContractExecutionMaterializationTreatsSourceReplayScopeMarkersAsLineage}
+    rationale: "Committed same-run replay markers are proof lineage, not timestamp-fork executable work."
+
+  - id: timer_history
+    fact: timer_history
+    disposition: fail_closed_or_reconstruct
+    owner: store.run_fork.replay_resume_admission
+    blocker_codes: [timer_history_unproven]
+    enforcement_point: internal/store/run_fork_timer_reconstruction.go
+    proof_refs:
+      - {kind: go_test, name: TestRunForkPlanner_RelevantTimerAndRouteRemainBlockers}
+      - {kind: go_test, name: TestSelectedContractExecutionMaterializationReconstructsActiveTimer}
+      - {kind: go_test, name: TestSelectedContractExecutionMaterializationFailsClosedForUnsupportedTimerHistory}
+    rationale: "Timer current rows block by default; approved active-at-T timer reconstruction writes fresh fork-local timer rows."
+
+  - id: flow_route_history
+    fact: flow_route_history
+    disposition: fail_closed_blocker
+    owner: store.run_fork.replay_resume_admission
+    blocker_codes: [flow_route_history_unproven]
+    enforcement_point: internal/store/run_fork_replay_resume_admission.go
+    proof_refs:
+      - {kind: go_test, name: TestRunForkPlanner_RelevantTimerAndRouteRemainBlockers}
+      - {kind: go_test, name: TestRecordRunForkSelectedContractRouteRecoveryRoundTripsForkLocalEvidence}
+    rationale: "Source/current route rows are not copied; fork-local route proof is a separately gated sibling."
+
+  - id: session_history
+    fact: session_history
+    disposition: fail_closed_blocker
+    owner: store.run_fork.replay_resume_admission
+    blocker_codes: [session_history_unproven]
+    enforcement_point: internal/store/run_fork_replay_resume_admission.go
+    proof_refs:
+      - {kind: go_test, name: TestRunForkPlanner_RunScopedActiveSessionAndTurnRemainBlockers}
+      - {kind: go_test, name: TestExecuteSelectedContractRunForkTreatsSourceConversationHistoryAsLineage}
+    rationale: "Source sessions are never copied or reused as fork-local runtime truth."
+
+  - id: conversation_audit_history
+    fact: conversation_audit_history
+    disposition: fail_closed_blocker
+    owner: store.run_fork.replay_resume_admission
+    blocker_codes: [conversation_audit_history_unproven]
+    enforcement_point: internal/store/run_fork_replay_resume_admission.go
+    proof_refs:
+      - {kind: go_test, name: TestRunForkPlanner_ActiveConversationAuditRemainsPolicyBlocker}
+      - {kind: go_test, name: TestExecuteSelectedContractRunForkTreatsSourceConversationHistoryAsLineage}
+    rationale: "Source audit rows lack fork-point termination proof and remain lineage-only under selected policies."
+
+  - id: active_turn_history
+    fact: active_turn_history
+    disposition: fail_closed_blocker
+    owner: store.run_fork.replay_resume_admission
+    blocker_codes: [active_turn_history_unproven]
+    enforcement_point: internal/store/run_fork_replay_resume_admission.go
+    proof_refs:
+      - {kind: go_test, name: TestRunForkPlanner_RunScopedActiveSessionAndTurnRemainBlockers}
+    rationale: "Active turns cannot be reconstructed from current rows and are not resumed."
+
+  - id: source_advanced_after_fork_point
+    fact: source_advanced_after_fork_point
+    disposition: fail_closed_or_lineage
+    owner: runtime.run_fork.selected_contract_execution.source_advanced_conversation_history_policy
+    blocker_codes:
+      - source_events_advanced_after_fork_point
+      - source_timers_advanced_after_fork_point
+      - source_routes_advanced_after_fork_point
+      - source_committed_replay_scope_advanced_after_fork_point
+      - source_active_conversation_session_coupling_after_fork_point
+    enforcement_point: internal/store/run_fork_selected_contract_execution_mutation.go
+    proof_refs:
+      - {kind: go_test, name: TestExecuteSelectedContractRunForkBranchesWhenSourceAdvancedAfterForkPoint}
+      - {kind: go_test, name: TestPostTSourceTimerFailsClosedForSelectedContractActivation}
+      - {kind: go_test, name: TestPostTSourceReplayScopeMarkerFailsClosedForSelectedContractActivation}
+    rationale: "Post-T source advancement is branch-divergence lineage only where a selected owner admits it; otherwise it blocks."
+
+  - id: fork_replay_state
+    fact: fork_replay_state
+    disposition: fail_closed_blocker
+    owner: store.run_fork.activation
+    blocker_codes:
+      - fork_events_already_exist
+      - fork_sessions_already_exist
+      - fork_conversation_audits_already_exist
+      - fork_turns_already_exist
+    enforcement_point: internal/store/run_fork_activation.go
+    proof_refs:
+      - {kind: go_test, name: TestRunForkActivation_FailsClosedForForkReplayStateWithTaxonomy}
+      - {kind: go_test, name: TestRunForkActivation_FailsClosedForForkSessionAndTurnReplayState}
+    rationale: "Activation cannot resume a fork that already contains fork-local runtime state outside the admitted owner."
+
+  - id: contract_swap
+    fact: contract_swap
+    disposition: split_sibling
+    owner: runtime.run_fork.contract_swap_boot_resume_admission
+    blocker_codes:
+      - contract_swap_boot_resume_admission_non_mutating
+      - contract_swap_route_recovery_missing
+    enforcement_point: internal/runtime/runforkexecution/contract_swap_admission.go
+    proof_refs:
+      - {kind: go_test, name: TestBuildContractSwapBootResumeAdmissionConsumesCanonicalPrerequisites}
+      - {kind: go_test, name: TestBuildContractSwapBootResumeAdmissionFailsClosedWithoutRouteRecovery}
+    rationale: "Contract-swap readiness is non-mutating prerequisite evidence; mutation is limited to admitted selected-frontier work."
+
+  - id: historical_replay_execution
+    fact: historical_replay_execution
+    disposition: split_sibling
+    owner: runtime.run_fork.historical_replay_execution_admission
+    blocker_codes: [historical_replay_execution_admission_non_mutating]
+    enforcement_point: internal/runtime/runforkexecution/historical_replay_admission.go
+    proof_refs:
+      - {kind: go_test, name: TestBuildHistoricalReplayExecutionAdmissionClassifiesFactsAndConsumesOwners}
+      - {kind: go_test, name: TestBuildHistoricalReplayExecutionConsumesAdmissionForDeliveryEventReplayMutation}
+    rationale: "Legacy-named runtime owner validates the matrix and admits only bounded delivery_event_replay_ready work today."
+
+  - id: source_events
+    fact: source_events
+    disposition: lineage_only_evidence
+    owner: runtime.run_fork.historical_replay_execution_admission
+    enforcement_point: internal/runtime/runforkexecution/historical_replay_admission.go
+    proof_refs:
+      - {kind: go_test, name: TestBuildHistoricalReplayExecutionAdmissionClassifiesFactsAndConsumesOwners}
+    rationale: "Source events are payload/lineage evidence; fork execution mints new fork-local events."
+
+  - id: event_deliveries
+    fact: event_deliveries
+    disposition: executable_fork_work
+    owner: runtime.run_fork.historical_replay_execution
+    blocker_codes:
+      - delivery_history_unproven
+      - non_agent_delivery_replay_unsupported
+      - committed_replay_scope_replay_unsupported
+    enforcement_point: internal/runtime/runforkexecution/historical_replay_admission.go
+    proof_refs:
+      - {kind: go_test, name: TestBuildHistoricalReplayExecutionAdmissionReportsReplayablePrimitiveWithoutMutation}
+      - {kind: go_test, name: TestBuildHistoricalReplayExecutionRejectsTaxonomyReadyWithoutOwnerWork}
+    rationale: "Only owner-authorized delivery_event_replay_ready work becomes executable; all other delivery histories block or become lineage."
+
+  - id: receipts
+    fact: receipts
+    disposition: lineage_only_evidence
+    owner: runtime.run_fork.historical_replay_execution_admission
+    enforcement_point: internal/runtime/runforkexecution/historical_replay_admission.go
+    proof_refs:
+      - {kind: go_test, name: TestBuildHistoricalReplayExecutionAdmissionClassifiesFactsAndConsumesOwners}
+    rationale: "Source receipts are outcomes, not fork suppressors."
+
+  - id: dead_letters
+    fact: dead_letters
+    disposition: lineage_only_evidence
+    owner: runtime.run_fork.historical_replay_execution_admission
+    enforcement_point: internal/runtime/runforkexecution/historical_replay_admission.go
+    proof_refs:
+      - {kind: go_test, name: TestBuildHistoricalReplayExecutionAdmissionClassifiesFactsAndConsumesOwners}
+    rationale: "Source dead letters are source outcomes and never suppress fork-local work."
+
+  - id: retry_idempotency
+    fact: retry_idempotency
+    disposition: split_sibling
+    owner: runtime.run_fork.historical_replay_execution_admission
+    enforcement_point: internal/runtime/runforkexecution/historical_replay_admission.go
+    proof_refs:
+      - {kind: go_test, name: TestBuildHistoricalReplayExecutionAdmissionClassifiesFactsAndConsumesOwners}
+    rationale: "Retry/idempotency semantics need a later owner; source state cannot be reused as fork truth."
+
+  - id: emitted_follow_ups
+    fact: emitted_follow_ups
+    disposition: split_sibling
+    owner: runtime.run_fork.historical_replay_execution_admission
+    enforcement_point: internal/runtime/runforkexecution/historical_replay_admission.go
+    proof_refs:
+      - {kind: go_test, name: TestBuildHistoricalReplayExecutionAdmissionClassifiesFactsAndConsumesOwners}
+    rationale: "Follow-ups are regenerated by fork-local execution when supported, not copied."
+
+  - id: timers
+    fact: timers
+    disposition: reconstructed_fork_local_state
+    owner: runtime.run_fork.historical_replay_execution.timer_reconstruction
+    blocker_codes: [timer_history_unproven]
+    enforcement_point: internal/runtime/runforkexecution/historical_replay_admission.go
+    proof_refs:
+      - {kind: go_test, name: TestBuildHistoricalReplayExecutionAdmissionReportsTimerReconstructionOwner}
+      - {kind: go_test, name: TestSelectedContractTimerReconstructionFailsClosedForInvalidPayload}
+    rationale: "Only active source timers with approved lineage can be reconstructed as fresh fork-local rows."
+
+  - id: routes
+    fact: routes
+    disposition: split_sibling
+    owner: runtime.run_fork.selected_contract_route_recovery
+    blocker_codes:
+      - flow_route_history_unproven
+      - selected_contract_route_admission_non_mutating
+      - selected_contract_route_topology_non_mutating
+      - selected_contract_dynamic_route_topology_unproven
+    enforcement_point: internal/runtime/runforkexecution/historical_replay_admission.go
+    proof_refs:
+      - {kind: go_test, name: TestBuildContractSwapBootResumeAdmissionFailsClosedWithoutRouteRecovery}
+      - {kind: go_test, name: TestRecordRunForkSelectedContractRouteRecoveryRoundTripsForkLocalEvidence}
+    rationale: "Route truth remains a separate fork-local owner; source/current route rows are not copied."
+
+  - id: sessions
+    fact: sessions
+    disposition: lineage_only_evidence
+    owner: runtime.run_fork.historical_replay_execution.selected_contract_session_turn_audit_lineage_policy
+    blocker_codes: [session_history_unproven]
+    enforcement_point: internal/runtime/runforkexecution/historical_replay_admission.go
+    proof_refs:
+      - {kind: go_test, name: TestBuildHistoricalReplayExecutionAdmissionReportsSelectedContractConversationLineageOwner}
+    rationale: "Source sessions may be lineage/no-action evidence only under selected policies."
+
+  - id: turns
+    fact: turns
+    disposition: lineage_only_evidence
+    owner: runtime.run_fork.historical_replay_execution.selected_contract_session_turn_audit_lineage_policy
+    blocker_codes: [active_turn_history_unproven]
+    enforcement_point: internal/runtime/runforkexecution/historical_replay_admission.go
+    proof_refs:
+      - {kind: go_test, name: TestBuildHistoricalReplayExecutionAdmissionReportsSelectedContractConversationLineageOwner}
+    rationale: "Source turns are not copied or resumed."
+
+  - id: audits
+    fact: audits
+    disposition: lineage_only_evidence
+    owner: runtime.run_fork.historical_replay_execution.selected_contract_session_turn_audit_lineage_policy
+    blocker_codes: [conversation_audit_history_unproven]
+    enforcement_point: internal/runtime/runforkexecution/historical_replay_admission.go
+    proof_refs:
+      - {kind: go_test, name: TestBuildHistoricalReplayExecutionAdmissionReportsSelectedContractConversationLineageOwner}
+    rationale: "Source audit rows are lineage/no-action evidence only."
+
+  - id: non_agent_node_system_work
+    fact: non_agent_node_system_work
+    disposition: fail_closed_blocker
+    owner: store.run_fork.replay_resume_admission
+    blocker_codes:
+      - non_agent_delivery_replay_unsupported
+      - selected_contract_agent_handler_materialization_unsupported
+      - selected_contract_source_replay_unsupported
+    enforcement_point: internal/runtime/runforkexecution/historical_replay_admission.go
+    proof_refs:
+      - {kind: go_test, name: TestRunForkPlanner_NodePendingDeliveryRemainsBlocked}
+      - {kind: go_test, name: TestRunForkPlanner_NonAgentDeliveryStatesRemainNamedBlockers}
+    rationale: "Node/system/non-agent replay needs handler, idempotency, receipt, and side-effect semantics outside this closure."
+
+  - id: source_advanced_post_t_facts
+    fact: source_advanced_post_t_facts
+    disposition: fail_closed_or_lineage
+    owner: runtime.run_fork.selected_contract_execution.source_advanced_conversation_history_policy
+    blocker_codes:
+      - source_events_advanced_after_fork_point
+      - source_timers_advanced_after_fork_point
+      - source_routes_advanced_after_fork_point
+      - source_committed_replay_scope_advanced_after_fork_point
+      - source_active_conversation_session_coupling_after_fork_point
+    enforcement_point: internal/runtime/runforkexecution/historical_replay_admission.go
+    proof_refs:
+      - {kind: go_test, name: TestBuildHistoricalReplayExecutionAdmissionReportsSelectedContractSourceAdvancedConversationHistoryOwner}
+      - {kind: go_test, name: TestExecuteSelectedContractRunForkTreatsPostTSourceConversationHistoryAsBranchDivergence}
+    rationale: "Post-T source facts are source-run divergence evidence, not fork suppressors."
+
+  - id: runtime_restart_recovery
+    fact: runtime_restart_recovery
+    disposition: split_sibling
+    owner: runtime.run_fork.historical_replay_execution.delivery_event_replay_ready_recovery
+    enforcement_point: internal/runtime/runforkexecution/historical_replay_admission.go
+    proof_refs:
+      - {kind: go_test, name: TestRunForkActivation_ReplaysSafePendingDeliveryWithForkLocalLineage}
+    rationale: "Restart recovery consumes fresh fork-local rows for admitted delivery_event_replay_ready work only."
+
+  - id: cli_api_dashboard_operator_consumers
+    fact: cli_api_dashboard_operator_consumers
+    disposition: split_sibling
+    owner: store.run_fork.replay_resume_admission
+    enforcement_point: cmd/swarm/main.go
+    proof_refs:
+      - {kind: go_test, name: TestRunForkRuntimeOwnerHarness_DryRunJSONReportsDeliveryEventReplayReady}
+      - {kind: go_test, name: TestRunForkRuntimeOwnerHarness_ActivateUsesCanonicalStoreOwnerJSON}
+    rationale: "Operator surfaces are readback consumers only and must not compute fork admission semantics."
+
+  - id: selected_contract_prerequisite_blockers
+    fact: selected_contract_prerequisite_blockers
+    disposition: fail_closed_blocker
+    owner: runtime.run_fork.selected_contract_execution_admission
+    blocker_codes:
+      - selected_contract_execution_model_non_mutating
+      - selected_contract_execution_admission_non_mutating
+      - selected_contract_recipient_planning_non_mutating
+      - contract_frontier_execution_unsupported
+      - contract_frontier_route_unresolved
+    enforcement_point: internal/runtime/runforkexecution/activation_gate.go
+    proof_refs:
+      - {kind: go_test, name: TestActivateSelectedContractRunForkPreservesPlannerBlockersBeforeMutation}
+      - {kind: go_test, name: TestRunForkRuntimeOwnerHarness_DryRunContractsAddsContractFrontierAdmissionJSON}
+    rationale: "Selected-contract prerequisite failures remain blockers/readback; this PR does not promote them to execution."
+
+  - id: memoized_reexecution_reserved
+    fact: memoized_reexecution_reserved
+    disposition: reserved_future
+    owner: "#1721"
+    enforcement_point: issue-tracker
+    proof_refs:
+      - {kind: issue, issue: 1721}
+    rationale: "Reserved sixth classification for byte-identical agent-turn memoized re-execution; not implemented here."

--- a/internal/runtime/runcontrol/controller.go
+++ b/internal/runtime/runcontrol/controller.go
@@ -159,16 +159,36 @@ func (c *Controller) Continue(ctx context.Context, req TransitionRequest) (Trans
 	}
 	result := TransitionResult{RunID: state.RunID, Status: StatusRunning}
 	if c.queue != nil {
-		released, err := c.queue.ReleaseRunQueue(ctx, state.RunID, c.releaseLookback, c.releaseLimit)
-		if err != nil {
-			// The persisted transition is already committed. A transient queue-release
-			// failure must not turn run.continue into a false external failure because
-			// retrying would observe the run as no longer paused.
-			return result, nil
-		}
-		result.ReleasedDeliveries = released
+		result.ReleasedDeliveries = c.releaseQueuedAfterContinue(ctx, state.RunID)
 	}
 	return result, nil
+}
+
+func (c *Controller) releaseQueuedAfterContinue(ctx context.Context, runID string) int {
+	if c == nil || c.queue == nil {
+		return 0
+	}
+	const attempts = 3
+	const retryDelay = 25 * time.Millisecond
+	releasedTotal := 0
+	for attempt := 0; attempt < attempts; attempt++ {
+		released, err := c.queue.ReleaseRunQueue(ctx, runID, c.releaseLookback, c.releaseLimit)
+		if err == nil {
+			releasedTotal += released
+			if released > 0 {
+				return releasedTotal
+			}
+		}
+		if attempt == attempts-1 {
+			return releasedTotal
+		}
+		select {
+		case <-ctx.Done():
+			return releasedTotal
+		case <-time.After(retryDelay):
+		}
+	}
+	return releasedTotal
 }
 
 func (c *Controller) QueueableRunDispatchBlocked(ctx context.Context, runID string) (bool, error) {

--- a/internal/runtime/runcontrol/controller_test.go
+++ b/internal/runtime/runcontrol/controller_test.go
@@ -31,6 +31,23 @@ func TestControllerContinueDoesNotFailAfterCommittedTransitionWhenReleaseFails(t
 	}
 }
 
+func TestControllerContinueRetriesTransientEmptyQueueRelease(t *testing.T) {
+	store := &fakeRunControlStore{}
+	queue := &fakeRunControlQueue{releases: []int{0, 1}}
+	controller := NewController(store, queue, Options{})
+
+	result, err := controller.Continue(context.Background(), TransitionRequest{RunID: "run-1"})
+	if err != nil {
+		t.Fatalf("Continue() error = %v, want nil", err)
+	}
+	if result.ReleasedDeliveries != 1 {
+		t.Fatalf("released deliveries = %d, want 1 after retry", result.ReleasedDeliveries)
+	}
+	if queue.calls != 2 {
+		t.Fatalf("queue release calls = %d, want 2", queue.calls)
+	}
+}
+
 type fakeRunControlStore struct {
 	continued bool
 }
@@ -53,12 +70,20 @@ func (s *fakeRunControlStore) RunDispatchBlocked(context.Context, string) (bool,
 }
 
 type fakeRunControlQueue struct {
-	called bool
-	err    error
+	called   bool
+	calls    int
+	err      error
+	releases []int
 }
 
 func (q *fakeRunControlQueue) ReleaseRunQueue(context.Context, string, time.Duration, int) (int, error) {
 	q.called = true
+	q.calls++
+	if len(q.releases) > 0 {
+		released := q.releases[0]
+		q.releases = q.releases[1:]
+		return released, nil
+	}
 	if q.err != nil {
 		return 0, q.err
 	}

--- a/internal/runtime/runforkexecution/activation_gate.go
+++ b/internal/runtime/runforkexecution/activation_gate.go
@@ -254,7 +254,7 @@ func ActivateSelectedContractRunFork(ctx context.Context, req SelectedContractAc
 		}
 		return result, nil
 	}
-	if plan.ReplayResumeAdmission.HistoricalReplayRequired {
+	if plan.ReplayResumeAdmission.ReplayResumeFactsPresent {
 		return result, fmt.Errorf("selected-contract activation gate blocks historical replay before mutation; blockers: %s", selectedContractBlockerCodes(plan.UnsupportedBlockers))
 	}
 	if frontier.FrontierEventCount > 0 {

--- a/internal/runtime/runforkexecution/activation_gate_test.go
+++ b/internal/runtime/runforkexecution/activation_gate_test.go
@@ -111,10 +111,10 @@ func TestActivateSelectedContractRunForkRequiresConcreteStoreForReplayMutation(t
 		CreatedAt:      time.Unix(1700001000, 0).UTC(),
 	}}
 	plan.ReplayResumeAdmission = store.RunForkReplayResumeAdmission{
-		Owner:                     store.RunForkReplayResumeAdmissionOwner,
-		DeliveryEventReplayReady:  true,
-		HistoricalReplayRequired:  true,
-		HistoricalReplaySupported: true,
+		Owner:                    store.RunForkReplayResumeAdmissionOwner,
+		DeliveryEventReplayReady: true,
+		ReplayResumeFactsPresent: true,
+		BoundedReplaySupported:   true,
 	}
 	fakeStore := &fakeSelectedContractActivationStore{binding: binding, bindingOK: true, plan: plan}
 	loader := &fakeSelectedContractSourceLoader{loaded: testLoadedSelectedSource(binding.ContractSelection)}
@@ -249,7 +249,7 @@ func TestActivateSelectedContractRunForkPreservesPlannerBlockersBeforeMutation(t
 	plan := testSelectedContractStateOnlyPlan(binding)
 	plan.ExecutionReady = false
 	plan.ReplayResumeAdmission.StateOnlyExecutionReady = false
-	plan.ReplayResumeAdmission.HistoricalReplayRequired = true
+	plan.ReplayResumeAdmission.ReplayResumeFactsPresent = true
 	plan.UnsupportedBlockers = []store.RunForkUnsupportedBlocker{{
 		Code:    store.RunForkBlockerSessionHistoryUnproven,
 		Message: "session history is not reconstructable",

--- a/internal/runtime/runforkexecution/contract_swap_admission.go
+++ b/internal/runtime/runforkexecution/contract_swap_admission.go
@@ -38,7 +38,7 @@ func BuildContractSwapBootResumeAdmission(req ContractSwapBootResumeAdmissionReq
 	}
 	blockers = appendRunForkUnsupportedBlocker(blockers, store.RunForkUnsupportedBlocker{
 		Code:    store.RunForkBlockerContractSwapBootResumeAdmissionNonMutating,
-		Message: "contract-swap boot/resume admission is non-mutating; full historical replay/resume remains separately gated",
+		Message: "contract-swap boot/resume admission is non-mutating; bounded fork re-execution remains separately gated",
 	})
 	if req.RouteRecovery == nil {
 		blockers = appendRunForkUnsupportedBlocker(blockers, store.RunForkUnsupportedBlocker{
@@ -194,7 +194,7 @@ func contractSwapBootResumeBlockedSiblings() []store.RunForkSelectedContractExec
 		{
 			Concept:     "sessions_turns_audits",
 			Disposition: store.RunForkSelectedContractDispositionBlockedSibling,
-			Reason:      "source session, turn, and audit reconstruction remains under historical replay/resume siblings",
+			Reason:      "source session, turn, and audit reconstruction remains under bounded fork re-execution siblings",
 		},
 		{
 			Concept:     "node_system_non_agent_execution",

--- a/internal/runtime/runforkexecution/contract_swap_admission_test.go
+++ b/internal/runtime/runforkexecution/contract_swap_admission_test.go
@@ -14,7 +14,7 @@ func TestBuildContractSwapBootResumeAdmissionConsumesCanonicalPrerequisites(t *t
 	selectedAdmission := testContractSwapSelectedExecutionAdmission(selection)
 	replayAdmission := store.RunForkReplayResumeAdmission{
 		Owner:                    store.RunForkReplayResumeAdmissionOwner,
-		HistoricalReplayRequired: true,
+		ReplayResumeFactsPresent: true,
 		Dispositions: []store.RunForkReplayResumeDisposition{{
 			Fact:        store.RunForkReplayResumeFactTimerHistory,
 			Disposition: store.RunForkReplayResumeDispositionFailClosedBlocker,

--- a/internal/runtime/runforkexecution/contract_swap_execution.go
+++ b/internal/runtime/runforkexecution/contract_swap_execution.go
@@ -134,8 +134,8 @@ func validateContractSwapHistoricalReplayExecution(admission store.RunForkHistor
 		strings.TrimSpace(execution.ForkEventID) != strings.TrimSpace(admission.ForkEventID) {
 		return fmt.Errorf("contract-swap historical replay execution parent execution identity mismatch")
 	}
-	if execution.FullReplayResumeSupported {
-		return fmt.Errorf("contract-swap historical replay execution first slice cannot consume full replay/resume execution")
+	if !execution.FullReplayUnsupported {
+		return fmt.Errorf("contract-swap historical replay execution first slice cannot consume broader source-run replay execution")
 	}
 	if !execution.DeliveryEventReplayReady ||
 		execution.EventDeliveriesAdmission.Fact != store.RunForkHistoricalReplayFactEventDeliveries ||

--- a/internal/runtime/runforkexecution/historical_replay_admission.go
+++ b/internal/runtime/runforkexecution/historical_replay_admission.go
@@ -132,7 +132,7 @@ func BuildHistoricalReplayExecution(req HistoricalReplayExecutionRequest) (store
 		SourceRunID:                strings.TrimSpace(admission.SourceRunID),
 		ForkEventID:                strings.TrimSpace(admission.ForkEventID),
 		ClosureLevel:               "canonical_owner_promotion_with_delivery_event_replay_ready_only",
-		FullReplayResumeSupported:  false,
+		FullReplayUnsupported:      true,
 		DeliveryEventReplayReady:   true,
 		EventDeliveriesAdmission:   eventDeliveries,
 		FactAdmissions:             append([]store.RunForkHistoricalReplayFactAdmission(nil), admission.FactAdmissions...),
@@ -174,7 +174,7 @@ func BuildHistoricalReplayExecutionAdmission(req HistoricalReplayExecutionAdmiss
 	}
 	blockers = appendRunForkUnsupportedBlocker(blockers, store.RunForkUnsupportedBlocker{
 		Code:    store.RunForkBlockerHistoricalReplayExecutionAdmissionNonMutating,
-		Message: "historical replay execution admission is non-mutating; full replay/resume mutation remains separately gated",
+		Message: "historical replay execution admission is non-mutating; bounded fork re-execution mutation remains separately gated",
 	})
 
 	var routeTopologyOwner, recipientPlanningOwner string
@@ -582,7 +582,7 @@ func historicalReplayExecutionBlockedSiblings(items []store.RunForkSelectedContr
 		Concept:     "full_historical_replay_execution",
 		Disposition: store.RunForkSelectedContractDispositionBlockedSibling,
 		Owner:       store.RunForkHistoricalReplayExecutionOwner,
-		Reason:      "this child mutates only delivery_event_replay_ready; full replay/resume remains under #564",
+		Reason:      "this child mutates only delivery_event_replay_ready; broader source-run replay remains under successor ownership",
 	})
 	return out
 }
@@ -655,7 +655,7 @@ func historicalReplayRequiredConsumers() []store.RunForkSelectedContractExecutio
 			Concept:     "selected_contract_execution",
 			Disposition: store.RunForkSelectedContractDispositionPrerequisite,
 			Owner:       store.RunForkSelectedContractExecutionOwner,
-			Reason:      "supported selected-contract execution remains a prerequisite proof, not a replacement for full replay/resume",
+			Reason:      "supported selected-contract execution remains a prerequisite proof, not a replacement for broader source-run replay",
 		},
 		{
 			Concept:     "event_bus_publish",
@@ -733,7 +733,7 @@ func historicalReplayInvalidPaths() []store.RunForkSelectedContractExecutionBoun
 		{
 			Concept:     "selected_frontier_execution_as_full_replay",
 			Disposition: store.RunForkSelectedContractDispositionInvalid,
-			Reason:      "supported selected frontier execution does not prove full historical replay/resume",
+			Reason:      "supported selected frontier execution does not prove broader source-run resumption",
 		},
 		{
 			Concept:     "cli_api_dashboard_owned_replay",

--- a/internal/runtime/runforkexecution/historical_replay_admission_test.go
+++ b/internal/runtime/runforkexecution/historical_replay_admission_test.go
@@ -13,7 +13,7 @@ func TestBuildHistoricalReplayExecutionAdmissionClassifiesFactsAndConsumesOwners
 	routeRecovery := testContractSwapRouteRecovery(selectedAdmission)
 	replayAdmission := store.RunForkReplayResumeAdmission{
 		Owner:                    store.RunForkReplayResumeAdmissionOwner,
-		HistoricalReplayRequired: true,
+		ReplayResumeFactsPresent: true,
 		Dispositions: []store.RunForkReplayResumeDisposition{
 			{
 				Fact:        store.RunForkReplayResumeFactDeliveryDeadLetterHistory,
@@ -182,7 +182,7 @@ func TestBuildHistoricalReplayExecutionAdmissionReportsTimerReconstructionOwner(
 	routeRecovery := testContractSwapRouteRecovery(selectedAdmission)
 	replayAdmission := store.RunForkReplayResumeAdmission{
 		Owner:                    store.RunForkReplayResumeAdmissionOwner,
-		HistoricalReplayRequired: true,
+		ReplayResumeFactsPresent: true,
 		Dispositions: []store.RunForkReplayResumeDisposition{{
 			Fact:           store.RunForkReplayResumeFactTimerHistory,
 			Disposition:    store.RunForkReplayResumeDispositionReconstruct,
@@ -455,7 +455,7 @@ func TestBuildHistoricalReplayExecutionConsumesAdmissionForDeliveryEventReplayMu
 		t.Fatalf("event deliveries admission = %#v", execution.EventDeliveriesAdmission)
 	}
 	if execution.ClosureLevel != "canonical_owner_promotion_with_delivery_event_replay_ready_only" ||
-		execution.FullReplayResumeSupported ||
+		!execution.FullReplayUnsupported ||
 		len(execution.FactAdmissions) != 15 ||
 		len(execution.RequiredConsumers) == 0 {
 		t.Fatalf("execution broad owner accounting = %#v", execution)

--- a/internal/store/run_fork_activation.go
+++ b/internal/store/run_fork_activation.go
@@ -30,7 +30,7 @@ type RunForkActivation struct {
 	ForkPoint                 RunForkPoint                             `json:"fork_point"`
 	Activated                 bool                                     `json:"activated"`
 	SourceFrozen              bool                                     `json:"source_frozen"`
-	HistoricalReplayBlocked   bool                                     `json:"historical_replay_blocked"`
+	ReplayResumeBlocked       bool                                     `json:"replay_resume_blocked"`
 	ReplayResumeAdmission     RunForkReplayResumeAdmission             `json:"replay_resume_admission"`
 	UnsupportedBlockers       []RunForkUnsupportedBlocker              `json:"unsupported_blockers,omitempty"`
 	MaterializedEntityCount   int                                      `json:"materialized_entity_count"`
@@ -122,7 +122,7 @@ func (s *PostgresStore) ActivateRunFork(ctx context.Context, req RunForkActivate
 		ForkRunStatus:           lineage.ForkStatus,
 		SourceRunStatus:         lineage.SourceRunStatus,
 		ForkPoint:               RunForkPoint{Input: lineage.ForkEventID, EventID: lineage.ForkEventID, EventName: lineage.ForkEventName, Timestamp: lineage.ForkEventTime},
-		HistoricalReplayBlocked: true,
+		ReplayResumeBlocked:     true,
 		MaterializedEntityCount: len(lineage.EntityIDs),
 	}
 	if lineage.ForkStatus != RunForkMaterializedStatus {

--- a/internal/store/run_fork_materializer_test.go
+++ b/internal/store/run_fork_materializer_test.go
@@ -95,10 +95,10 @@ func TestRunForkMaterializer_CreatesPausedForkRunAndSnapshotWithoutResuming(t *t
 	if result.ReplayResumeAdmission.Owner != RunForkReplayResumeAdmissionOwner {
 		t.Fatalf("taxonomy owner = %q, want %q", result.ReplayResumeAdmission.Owner, RunForkReplayResumeAdmissionOwner)
 	}
-	if !result.ReplayResumeAdmission.StateOnlyExecutionReady || result.ReplayResumeAdmission.HistoricalReplaySupported {
-		t.Fatalf("taxonomy flags = state_only:%v historical_supported:%v, want true/false",
+	if !result.ReplayResumeAdmission.StateOnlyExecutionReady || result.ReplayResumeAdmission.BoundedReplaySupported {
+		t.Fatalf("taxonomy flags = state_only:%v bounded_supported:%v, want true/false",
 			result.ReplayResumeAdmission.StateOnlyExecutionReady,
-			result.ReplayResumeAdmission.HistoricalReplaySupported,
+			result.ReplayResumeAdmission.BoundedReplaySupported,
 		)
 	}
 
@@ -722,7 +722,7 @@ func TestRunForkMaterializer_FailsClosedOnRepeatAndUnsupportedBlockers(t *testin
 	if err == nil || !strings.Contains(err.Error(), RunForkBlockerNonAgentDeliveryReplayUnsupported) {
 		t.Fatalf("MaterializeRunFork error = %v, want non-agent delivery blocker", err)
 	}
-	if blocked.ReplayResumeAdmission.Owner != RunForkReplayResumeAdmissionOwner || !blocked.ReplayResumeAdmission.HistoricalReplayRequired {
+	if blocked.ReplayResumeAdmission.Owner != RunForkReplayResumeAdmissionOwner || !blocked.ReplayResumeAdmission.ReplayResumeFactsPresent {
 		t.Fatalf("blocked taxonomy = %#v, want owner and historical replay required", blocked.ReplayResumeAdmission)
 	}
 	if !runForkTestHasDisposition(blocked.ReplayResumeAdmission, RunForkReplayResumeFactDeliveryInProgressHistory) {
@@ -789,8 +789,8 @@ func TestRunForkActivation_ActivatesMaterializedForkAndFreezesSource(t *testing.
 	if !activated.Activated || !activated.SourceFrozen {
 		t.Fatalf("activation flags = activated:%v frozen:%v", activated.Activated, activated.SourceFrozen)
 	}
-	if !activated.HistoricalReplayBlocked {
-		t.Fatal("HistoricalReplayBlocked = false, want true for activation-only boundary")
+	if !activated.ReplayResumeBlocked {
+		t.Fatal("ReplayResumeBlocked = false, want true for activation-only boundary")
 	}
 	if activated.ReplayResumeAdmission.Owner != RunForkReplayResumeAdmissionOwner || !activated.ReplayResumeAdmission.StateOnlyExecutionReady {
 		t.Fatalf("activation taxonomy = %#v, want owner and state-only ready", activated.ReplayResumeAdmission)
@@ -1340,7 +1340,7 @@ func TestRunForkActivation_FailsClosedForInProgressDeliveryAndMissingLineage(t *
 	if err == nil || !strings.Contains(err.Error(), RunForkBlockerNonAgentDeliveryReplayUnsupported) {
 		t.Fatalf("ActivateRunFork in-progress delivery error = %v, want non-agent delivery blocker", err)
 	}
-	if blocked.ReplayResumeAdmission.Owner != RunForkReplayResumeAdmissionOwner || !blocked.ReplayResumeAdmission.HistoricalReplayRequired {
+	if blocked.ReplayResumeAdmission.Owner != RunForkReplayResumeAdmissionOwner || !blocked.ReplayResumeAdmission.ReplayResumeFactsPresent {
 		t.Fatalf("blocked activation taxonomy = %#v, want owner and historical replay required", blocked.ReplayResumeAdmission)
 	}
 

--- a/internal/store/run_fork_planner_test.go
+++ b/internal/store/run_fork_planner_test.go
@@ -206,8 +206,8 @@ func TestRunForkPlanner_ClassifiesPendingWorkAndNamedBlockers(t *testing.T) {
 	if plan.ReplayResumeAdmission.StateOnlyExecutionReady {
 		t.Fatal("taxonomy StateOnlyExecutionReady = true, want false")
 	}
-	if !plan.ReplayResumeAdmission.HistoricalReplayRequired || plan.ReplayResumeAdmission.HistoricalReplaySupported {
-		t.Fatalf("taxonomy replay flags = required:%v supported:%v, want required true/supported false", plan.ReplayResumeAdmission.HistoricalReplayRequired, plan.ReplayResumeAdmission.HistoricalReplaySupported)
+	if !plan.ReplayResumeAdmission.ReplayResumeFactsPresent || plan.ReplayResumeAdmission.BoundedReplaySupported {
+		t.Fatalf("taxonomy replay flags = required:%v supported:%v, want required true/supported false", plan.ReplayResumeAdmission.ReplayResumeFactsPresent, plan.ReplayResumeAdmission.BoundedReplaySupported)
 	}
 	blockers := map[string]bool{}
 	for _, blocker := range plan.UnsupportedBlockers {
@@ -283,7 +283,7 @@ func TestRunForkPlanner_PendingUnstartedDeliveryIsDeliveryEventReplayReady(t *te
 	if plan.ReplayResumeAdmission.StateOnlyExecutionReady {
 		t.Fatal("StateOnlyExecutionReady = true, want false because delivery/event replay is required")
 	}
-	if !plan.ReplayResumeAdmission.DeliveryEventReplayReady || !plan.ReplayResumeAdmission.HistoricalReplayRequired || !plan.ReplayResumeAdmission.HistoricalReplaySupported {
+	if !plan.ReplayResumeAdmission.DeliveryEventReplayReady || !plan.ReplayResumeAdmission.ReplayResumeFactsPresent || !plan.ReplayResumeAdmission.BoundedReplaySupported {
 		t.Fatalf("replay flags = %#v, want delivery-event replay ready and supported", plan.ReplayResumeAdmission)
 	}
 	for _, disposition := range plan.ReplayResumeAdmission.Dispositions {
@@ -608,11 +608,11 @@ func TestRunForkPlanner_StateOnlyPlanExecutionReadyWithEmptyAndUnrelatedTimerRou
 	if plan.ReplayResumeAdmission.Owner != RunForkReplayResumeAdmissionOwner {
 		t.Fatalf("taxonomy owner = %q, want %q", plan.ReplayResumeAdmission.Owner, RunForkReplayResumeAdmissionOwner)
 	}
-	if !plan.ReplayResumeAdmission.StateOnlyExecutionReady || plan.ReplayResumeAdmission.HistoricalReplayRequired || plan.ReplayResumeAdmission.HistoricalReplaySupported {
-		t.Fatalf("taxonomy flags = state_only:%v historical_required:%v historical_supported:%v, want true/false/false",
+	if !plan.ReplayResumeAdmission.StateOnlyExecutionReady || plan.ReplayResumeAdmission.ReplayResumeFactsPresent || plan.ReplayResumeAdmission.BoundedReplaySupported {
+		t.Fatalf("taxonomy flags = state_only:%v historical_required:%v bounded_supported:%v, want true/false/false",
 			plan.ReplayResumeAdmission.StateOnlyExecutionReady,
-			plan.ReplayResumeAdmission.HistoricalReplayRequired,
-			plan.ReplayResumeAdmission.HistoricalReplaySupported,
+			plan.ReplayResumeAdmission.ReplayResumeFactsPresent,
+			plan.ReplayResumeAdmission.BoundedReplaySupported,
 		)
 	}
 	if !runForkTestHasDisposition(plan.ReplayResumeAdmission, RunForkReplayResumeFactEntityStateSnapshot) {

--- a/internal/store/run_fork_replay_resume_admission.go
+++ b/internal/store/run_fork_replay_resume_admission.go
@@ -49,13 +49,13 @@ const (
 )
 
 type RunForkReplayResumeAdmission struct {
-	Owner                     string                           `json:"owner"`
-	StateOnlyExecutionReady   bool                             `json:"state_only_execution_ready"`
-	DeliveryEventReplayReady  bool                             `json:"delivery_event_replay_ready"`
-	HistoricalReplaySupported bool                             `json:"historical_replay_supported"`
-	HistoricalReplayRequired  bool                             `json:"historical_replay_required"`
-	Dispositions              []RunForkReplayResumeDisposition `json:"dispositions,omitempty"`
-	UnsupportedBlockers       []RunForkUnsupportedBlocker      `json:"unsupported_blockers,omitempty"`
+	Owner                    string                           `json:"owner"`
+	StateOnlyExecutionReady  bool                             `json:"state_only_execution_ready"`
+	DeliveryEventReplayReady bool                             `json:"delivery_event_replay_ready"`
+	BoundedReplaySupported   bool                             `json:"bounded_replay_supported"`
+	ReplayResumeFactsPresent bool                             `json:"replay_resume_facts_present"`
+	Dispositions             []RunForkReplayResumeDisposition `json:"dispositions,omitempty"`
+	UnsupportedBlockers      []RunForkUnsupportedBlocker      `json:"unsupported_blockers,omitempty"`
 }
 
 type RunForkReplayResumeDisposition struct {
@@ -82,12 +82,12 @@ func runForkReplayResumeAdmission(evidence runForkAdmissionEvidence) RunForkRepl
 		{
 			Fact:        RunForkReplayResumeFactHistoricalReplayExecution,
 			Disposition: RunForkReplayResumeDispositionSplitSibling,
-			Message:     "historical replay execution remains a separate gated child; this admission taxonomy is non-mutating",
+			Message:     "bounded fork re-execution remains a separate gated child; this admission taxonomy is non-mutating",
 		},
 		{
 			Fact:        RunForkReplayResumeFactContractSwap,
 			Disposition: RunForkReplayResumeDispositionSplitSibling,
-			Message:     "contract-swap execution belongs to full historical resume and is not implemented by this admission taxonomy",
+			Message:     "contract-swap execution belongs to bounded selected-frontier fork re-execution and is not implemented by this admission taxonomy",
 		},
 	}
 	blockers := []RunForkUnsupportedBlocker{}
@@ -173,13 +173,13 @@ func runForkReplayResumeAdmission(evidence runForkAdmissionEvidence) RunForkRepl
 	deliveryEventReplayReady := hasReplayableDeliveryEvent && len(blockers) == 0
 	stateOnlyExecutionReady := len(blockers) == 0 && !hasHistoricalReplayRequirement
 	return RunForkReplayResumeAdmission{
-		Owner:                     RunForkReplayResumeAdmissionOwner,
-		StateOnlyExecutionReady:   stateOnlyExecutionReady,
-		DeliveryEventReplayReady:  deliveryEventReplayReady,
-		HistoricalReplaySupported: deliveryEventReplayReady,
-		HistoricalReplayRequired:  hasHistoricalReplayRequirement,
-		Dispositions:              dispositions,
-		UnsupportedBlockers:       blockers,
+		Owner:                    RunForkReplayResumeAdmissionOwner,
+		StateOnlyExecutionReady:  stateOnlyExecutionReady,
+		DeliveryEventReplayReady: deliveryEventReplayReady,
+		BoundedReplaySupported:   deliveryEventReplayReady,
+		ReplayResumeFactsPresent: hasHistoricalReplayRequirement,
+		Dispositions:             dispositions,
+		UnsupportedBlockers:      blockers,
 	}
 }
 
@@ -314,8 +314,8 @@ func runForkReplayResumeAdmissionWithBlocker(admission RunForkReplayResumeAdmiss
 	}
 	admission.StateOnlyExecutionReady = false
 	admission.DeliveryEventReplayReady = false
-	admission.HistoricalReplaySupported = false
-	admission.HistoricalReplayRequired = true
+	admission.BoundedReplaySupported = false
+	admission.ReplayResumeFactsPresent = true
 	admission.UnsupportedBlockers = appendRunForkBlocker(admission.UnsupportedBlockers, blocker)
 	admission.Dispositions = append(admission.Dispositions, RunForkReplayResumeDisposition{
 		Fact:        fact,
@@ -405,11 +405,11 @@ func runForkReplayResumeBlocker(code string) RunForkUnsupportedBlocker {
 	default:
 		code = strings.TrimSpace(code)
 		if code == "" {
-			code = "historical_replay_unproven"
+			code = "fork_reexecution_unproven"
 		}
 		return RunForkUnsupportedBlocker{
 			Code:    code,
-			Message: fmt.Sprintf("timestamp-fork historical replay/resume is not proven for %s by the canonical admission taxonomy", code),
+			Message: fmt.Sprintf("timestamp-fork bounded re-execution is not proven for %s by the canonical admission taxonomy", code),
 		}
 	}
 }

--- a/internal/store/run_fork_selected_contract_conversation_lineage.go
+++ b/internal/store/run_fork_selected_contract_conversation_lineage.go
@@ -266,7 +266,7 @@ func runForkReplayResumeAdmissionRecalculateReadiness(admission RunForkReplayRes
 	}
 	admission.DeliveryEventReplayReady = hasReplayableDeliveryEvent && len(admission.UnsupportedBlockers) == 0
 	admission.StateOnlyExecutionReady = len(admission.UnsupportedBlockers) == 0 && !hasHistoricalReplayRequirement
-	admission.HistoricalReplayRequired = hasHistoricalReplayRequirement
-	admission.HistoricalReplaySupported = admission.DeliveryEventReplayReady
+	admission.ReplayResumeFactsPresent = hasHistoricalReplayRequirement
+	admission.BoundedReplaySupported = admission.DeliveryEventReplayReady
 	return admission
 }

--- a/internal/store/run_fork_selected_contract_execution.go
+++ b/internal/store/run_fork_selected_contract_execution.go
@@ -292,7 +292,7 @@ type RunForkHistoricalReplayExecution struct {
 	SourceRunID                string                                     `json:"source_run_id"`
 	ForkEventID                string                                     `json:"fork_event_id"`
 	ClosureLevel               string                                     `json:"closure_level"`
-	FullReplayResumeSupported  bool                                       `json:"full_replay_resume_supported"`
+	FullReplayUnsupported      bool                                       `json:"full_replay_unsupported"`
 	DeliveryEventReplayReady   bool                                       `json:"delivery_event_replay_ready"`
 	EventDeliveriesAdmission   RunForkHistoricalReplayFactAdmission       `json:"event_deliveries_admission"`
 	FactAdmissions             []RunForkHistoricalReplayFactAdmission     `json:"fact_admissions,omitempty"`

--- a/internal/store/run_fork_selected_contract_execution_mutation.go
+++ b/internal/store/run_fork_selected_contract_execution_mutation.go
@@ -291,7 +291,7 @@ func (s *PostgresStore) ActivateRunForkForSelectedContractExecution(ctx context.
 		ForkRunStatus:           lineage.ForkStatus,
 		SourceRunStatus:         lineage.SourceRunStatus,
 		ForkPoint:               RunForkPoint{Input: lineage.ForkEventID, EventID: lineage.ForkEventID, EventName: lineage.ForkEventName, Timestamp: lineage.ForkEventTime},
-		HistoricalReplayBlocked: true,
+		ReplayResumeBlocked:     true,
 		MaterializedEntityCount: len(lineage.EntityIDs),
 	}
 	if lineage.ForkStatus != RunForkMaterializedStatus {

--- a/internal/store/run_fork_timer_reconstruction.go
+++ b/internal/store/run_fork_timer_reconstruction.go
@@ -78,7 +78,7 @@ func runForkReplayResumeAdmissionWithTimerReconstruction(admission RunForkReplay
 		admission.Dispositions[i].Classification = RunForkHistoricalReplayAdmissionReconstructedForkState
 		admission.Dispositions[i].Message = fmt.Sprintf("%s reconstructs %d active fork-local timer(s) under the fork run_id", RunForkHistoricalReplayTimerReconstructionOwner, len(reconstruction.Rows))
 	}
-	admission.HistoricalReplaySupported = len(admission.UnsupportedBlockers) == 0
+	admission.BoundedReplaySupported = len(admission.UnsupportedBlockers) == 0
 	return admission
 }
 

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -9589,9 +9589,13 @@ run_model:
       - dashboard alert UI
       - CLI alert rendering
   fork:
-    description: 'Fork creates a new run by reconstructing full system state at a point in time, optionally
-      loading new contracts, and resuming execution. The system automatically determines which events need
-      to be re-delivered. The original run is frozen. The forked run gets independent execution.'
+    description: 'Fork creates an isolated run by reconstructing provable current state at a point in time,
+      optionally loading selected contracts, and then executing only owner-admitted fork-local work. The supported
+      model is bounded re-execution from inputs: delivery_event_replay_ready pending unstarted agent deliveries,
+      selected-contract frontier execution, and approved timer reconstruction. The system does not infer arbitrary
+      unfinished work; in-progress delivery, session, turn, audit, non-agent, route, retry/idempotency, and other
+      unsupported historical facts remain permanently fail-closed unless a later issue names a concrete consumer and
+      proves a new owner.'
     command: 'public CLI: `swarm run fork <source-run-id> [--bundle-hash <bundle_hash>] [--at-event <event-id>] [--idempotency-key <key>]`, consuming /v1/rpc run.fork'
     dry_run_command: 'retired in v1 CLI; historical `swarm fork --dry-run` is not a supported operator command'
     materialize_only_command: 'retired in v1 CLI; historical `swarm fork --materialize-only` is not a supported operator command'
@@ -9651,9 +9655,9 @@ run_model:
       unstarted source agent deliveries whose fork-local event/delivery rows can be created under the fork run_id with
       explicit source lineage and a direct committed replay-scope marker for the existing persisted delivery/recovery
       consumer. It does not authorize source event_id copying, node delivery replay, delivered/completed redelivery,
-      receipt-only redelivery, session/turn/timer/route reconstruction, contract swap execution, or full runtime replay
-      mutation. Full historical resume remains separately gated even when state-only activation or delivery/event replay
-      is ready.'
+      receipt-only redelivery, session/turn/timer/route reconstruction, contract swap execution, or runtime-wide replay
+      mutation. There is no separately promised arbitrary source-run resume lane: unsupported fact families remain
+      fail-closed unless a consumer-named successor promotes a new owner.'
     selected_contract_readiness_classifier: 'Selected-contract timestamp-fork readiness explanation is owned by
       runtime.run_fork.selected_contract_readiness_classifier. This owner is non-mutating and consumes the canonical
       store planner, store.run_fork.replay_resume_admission, runtime.run_fork.contract_frontier_admission, selected
@@ -9718,7 +9722,7 @@ run_model:
       MUST NOT be copied into the fork, reused as fork-local runtime truth, or used as selected-fork suppressors. Fresh
       fork-local conversation rows may appear only through normal selected fork runtime execution under the fork run_id.
       Pending or in-progress source delivery/session coupling, fork-local pre-existing conversation rows, generic/state-only
-      activation, full historical replay/resume, timers, routes, non-agent replay, restart recovery, and operator surfaces
+      activation, broad source-run resumption, timers, routes, non-agent replay, restart recovery, and operator surfaces
       remain fail-closed or split siblings unless separately approved.'
     selected_contract_active_source_delivery_conversation_coupling_policy: 'Mutating selected-contract timestamp-fork
       execution may consume runtime.run_fork.selected_contract_execution.active_source_delivery_conversation_coupling_policy
@@ -9948,12 +9952,12 @@ run_model:
       recovery, or any missing/stale selected binding/source evidence. It
       MUST NOT run handlers, create fork-local events or event_deliveries, copy source rows, write receipts, dead
       letters, idempotency state, emitted follow-up events, timers, sessions, turns, route rows, API/UI state, or
-      otherwise implement mutating historical replay/resume. CLI, API, dashboard, Builder, route helpers, delivery
+      otherwise implement mutating source-run resume. CLI, API, dashboard, Builder, route helpers, delivery
       writers, and pipeline boot paths may consume this owner but MUST NOT compute contract-swap boot/resume readiness
       independently.'
-    historical_replay_execution_admission: 'Full historical replay/resume execution admission is owned by
-      runtime.run_fork.historical_replay_execution_admission. This owner is non-mutating and establishes the authority
-      boundary for the future runtime.run_fork.historical_replay_execution owner. It consumes the canonical
+    historical_replay_execution_admission: 'Bounded fork re-execution admission is owned by
+      runtime.run_fork.historical_replay_execution_admission. This legacy-named owner is non-mutating and establishes
+      the authority boundary for the runtime.run_fork.historical_replay_execution owner. It consumes the canonical
       store.run_fork.replay_resume_admission taxonomy plus selected-contract execution admission, selected binding,
       selected route topology, selected recipient planning, selected route recovery when present, and
       runtime.run_fork.contract_swap_boot_resume_admission when selected/swap evidence exists. For non-selected
@@ -9967,11 +9971,11 @@ run_model:
       store.run_fork.replay_resume_admission. This owner MUST NOT run handlers, create or copy events or
       event_deliveries, write receipts, dead letters, retry/idempotency state, emitted follow-up events, timers,
       sessions, turns, route rows, API/UI/dashboard state, suppress fork work from source outcomes, or treat selected
-      frontier execution as full historical replay/resume proof. CLI, API, dashboard, Builder, route helpers, delivery
+      frontier execution as proof of broader source-run resumption. CLI, API, dashboard, Builder, route helpers, delivery
       writers, runtime recovery, and pipeline boot paths may consume this owner but MUST NOT compute historical replay
       execution admission independently.'
-    historical_replay_execution: 'Mutating historical replay/resume execution authority is owned by
-      runtime.run_fork.historical_replay_execution. The owner consumes runtime.run_fork.historical_replay_execution_admission
+    historical_replay_execution: 'Mutating bounded fork re-execution authority is owned by
+      runtime.run_fork.historical_replay_execution. This legacy-named owner consumes runtime.run_fork.historical_replay_execution_admission
       and the canonical store.run_fork.replay_resume_admission taxonomy, validates that every historical source fact
       family has exactly one executable, reconstructed, lineage-only, fail-closed, or split-sibling classification, and
       emits the executable work set that downstream store/runtime writers may mutate. The current supported closure
@@ -9982,7 +9986,7 @@ run_model:
       blockers, or authorize full scheduler/recovery replay beyond run-scoped timer claim/fire/reload identity. The
       selected-contract contract-swap child runtime.run_fork.historical_replay_execution.contract_swap_boot_resume may
       execute only already-admitted delivery_event_replay_ready work under selected/swapped contracts. Full
-      product-complete historical replay/resume for routes, sessions, turns, audits, non-agent/node/system work,
+      product-complete source-run resumption for routes, sessions, turns, audits, non-agent/node/system work,
       broader contract-swap boot/resume, generic source-advanced policy, broader restart recovery, and API/UI/dashboard
       surfaces remains unsupported unless separately approved.
       Activation, store delivery-event replay, recovery, selected/contract-swap consumers, route
@@ -10006,8 +10010,9 @@ run_model:
       runtime restart state, and CLI/API/dashboard/Builder state are lineage-only, fail-closed blockers, split siblings,
       or consumers; they MUST NOT become selected-fork recipient truth, executable fork work, or fork suppressors. This
       child MUST NOT use store.run_fork.delivery_event_replay as-is when that writer preserves source subscriber
-      recipients, MUST NOT treat runtime.run_fork.selected_contract_execution as full replay/resume proof, and MUST NOT
-      make CLI/API/dashboard/Builder semantic owners. Product-complete #564 historical replay/resume remains open.'
+      recipients, MUST NOT treat runtime.run_fork.selected_contract_execution as broader source-run replay proof, and MUST NOT
+      make CLI/API/dashboard/Builder semantic owners. This bounded selected-frontier contract-swap child is not a
+      promise of broader source-run resumption; #564 closes through the fact matrix and successor issues #1721/#1722.'
     historical_replay_delivery_event_replay_execution: 'The first mutating historical replay execution child is owned by
       runtime.run_fork.historical_replay_execution and is limited to the already-admitted
       delivery_event_replay_ready primitive. It consumes runtime.run_fork.historical_replay_execution_admission before
@@ -10036,8 +10041,8 @@ run_model:
       state, emitted follow-ups, and post-fork source outcomes are lineage/proof only and MUST NOT become executable
       fork work or recovery suppressors. ClaimPipelineReplay remains the duplicate/race owner for fork replay event IDs.
       This owner MUST NOT reconstruct timers, routes, sessions, turns, audits, non-agent/node/system work,
-      contract-swap boot/resume, runtime-wide restart recovery, API/UI/dashboard state, or close the broader #564/#549
-      historical replay/resume parents.'
+      contract-swap boot/resume, runtime-wide restart recovery, API/UI/dashboard state, or close successor concepts
+      such as #1721 memoized re-execution or #1722 fleet fork reporting.'
     event_id_shorthand: 'When --at receives an event ID, the system resolves it to that event''s created_at
       timestamp. Under the hood, fork is always timestamp-based. The event ID is a convenience for pinpointing
       a moment without looking up timestamps manually.'
@@ -10067,7 +10072,7 @@ run_model:
         runtime.run_fork.historical_replay_execution consuming historical replay execution admission and owner-authorized
         executable delivery work, then atomically mark the source run forked and the fork run running. Activation/store
         does not authorize replay directly from replay_resume_admission or RunForkPlan pending rows. Future runtime work uses the fork
-        run_id, fork-local entity_state rows, and fork-local pending delivery rows; full historical replay remains
+        run_id, fork-local entity_state rows, and fork-local pending delivery rows; broader source-run replay remains
         unsupported outside the gated delivery/event primitive.'
       3b1_selected_contract_readiness_classifier: 'For selected-contract timestamp-fork dry-run/explain, the
         runtime.run_fork.selected_contract_readiness_classifier owner consumes existing planner, replay taxonomy,
@@ -10094,7 +10099,7 @@ run_model:
         reconstruction. Source conversation rows are never copied into the fork, reused as fork-local runtime truth, or
         used as selected-fork suppressors. Fresh fork-local conversation rows may be written only by normal selected fork
         runtime execution under the fork run_id. Pending or in-progress source delivery/session coupling, fork-local
-        pre-existing conversation rows, generic/state-only activation, full historical replay/resume, timers, routes,
+        pre-existing conversation rows, generic/state-only activation, broad source-run resumption, timers, routes,
         non-agent replay, restart recovery, and operator surfaces remain fail-closed or split siblings unless
         independently approved.'
       3d_selected_contract_timer_route_policy: 'For selected-contract mutating fork execution, source timer and route
@@ -10189,8 +10194,7 @@ run_model:
         runtime.run_fork.selected_contract_execution.fork_local_runtime_container and the normal runtime pipeline, records selected
         execution lineage, writes fork-local outcomes, consumes the fork-local runtime/platform event lineage policy for
         causally parented runtime control outputs, consumes typed runtime lineage before persisting runtime diagnostic
-        lineage, and regenerates follow-up events under the fork run_id. This is
-        not full historical resume: route
+        lineage, and regenerates follow-up events under the fork run_id. This bounded owner does not include route
         persistence/recovery, timer reconstruction, session/turn/audit reconstruction, non-agent replay, contract-swap
         boot/resume beyond selected frontier execution, runtime restart recovery, and UI/API ownership remain separate
         parents or siblings. At/before-T source session/turn/audit facts may be admitted only as lineage/no-action
@@ -10256,20 +10260,20 @@ run_model:
         fork-local work. This owner is non-mutating and does not authorize handler execution, delivery writes, receipts,
         dead letters, idempotency, emitted follow-ups, timers, sessions, turns, non-agent replay, route row mutation, or
         API/UI state.'
-      3j_historical_replay_execution_admission: 'Before any future full historical replay/resume mutation,
+      3j_historical_replay_execution_admission: 'Before any owner-authorized bounded fork re-execution mutation,
         runtime.run_fork.historical_replay_execution_admission classifies every historical source fact family under one
-        runtime authority. It consumes replay_resume_admission, selected-contract execution admission, route topology,
+        legacy-named runtime authority. It consumes replay_resume_admission, selected-contract execution admission, route topology,
         recipient planning, route recovery evidence when present, and contract-swap boot/resume admission when those
         prerequisites exist. It is
         admission/model only: it does not run handlers, create fork-local rows, copy source rows, write outcomes, replay
-        timers, reconstruct sessions/turns/audits, mutate routes, or own API/dashboard state. Full mutation remains
-        with the separately gated runtime.run_fork.historical_replay_execution owner.'
-      3j1_historical_replay_execution_owner: 'The mutating authority for historical replay/resume is
+        timers, reconstruct sessions/turns/audits, mutate routes, or own API/dashboard state. Mutation is limited to
+        separately admitted bounded children of runtime.run_fork.historical_replay_execution.'
+      3j1_historical_replay_execution_owner: 'The legacy-named mutating authority for bounded fork re-execution is
         runtime.run_fork.historical_replay_execution. It consumes the admission fact matrix, validates exactly one
         classification for every source fact family, exposes the currently executable fork work set, and keeps unsupported
         fact families explicit as fail-closed blockers or split siblings. Its current supported mutation scope is only
-        delivery_event_replay_ready; this closes canonical owner promotion, not product-complete historical replay/resume
-        for every future fact family.'
+        delivery_event_replay_ready plus approved selected-contract/timer children; it does not promise product-complete
+        resumption for every source fact family.'
       3j2_historical_replay_contract_swap_boot_resume_execution: 'For selected or swapped contracts, the bounded
         mutating contract-swap boot/resume child is
         runtime.run_fork.historical_replay_execution.contract_swap_boot_resume. It consumes the promoted historical
@@ -10294,18 +10298,22 @@ run_model:
         rows and source outcomes are lineage/proof only and never suppress fork-local recovery. This is a restart
         durability child only; timers, routes, sessions, turns, audits, non-agent replay, contract-swap boot/resume,
         runtime-wide restart recovery, and API/UI/dashboard surfaces remain split under #564/#549/#618.'
-      4_boot: 'Load contracts (new path if --contracts specified, otherwise same contracts as source run).
-        Validate contracts against reconstructed state. Boot the pipeline with the new run context.'
-      5_resume: 'Re-deliver all pending events under the new run_id. The normal event loop takes over.
-        No manual event selection — the system knows what was unfinished.'
+      4_boot: 'Load the selected contracts when provided, otherwise reuse the source contract identity, and validate
+        them against the reconstructed fork-local state and admitted fork fact matrix. Boot only the fork-local runtime
+        context required by approved owners; boot does not reconstruct source sessions, turns, audits, routes,
+        idempotency, or arbitrary in-flight work.'
+      5_resume: 'Execute only owner-admitted fork-local work under the new run_id. Today that means the
+        delivery_event_replay_ready primitive, selected-contract frontier execution when independently admitted, and
+        timer reconstruction where the timer owner has proven active-at-T lineage. Unsupported historical fact families
+        fail closed with typed blockers; the platform never infers unfinished source work from current rows.'
     parallel_safety: 'Timestamp-based fork handles parallel agent execution naturally. At timestamp T, all
       concurrent branches either committed their mutations or did not. No DAG traversal, no branch
       classification, no sibling carry-over logic. The reconstructed state is simply "what was the world at T."'
-    contract_swap: 'When --contracts specifies a new contract path, the intended full historical replay/resume behavior
-      is that admitted re-delivered events use the new handler logic uniformly with no mixed-version state. This product
-      intent is not itself an execution owner. Runtime/store readiness for full boot/resume is governed by
-      runtime.run_fork.contract_swap_boot_resume_admission, and mutating replay/resume requires separately approved
-      owners for any admitted historical work.'
+    contract_swap: 'When --contracts specifies a new contract path, any admitted fork-local delivery/event work must use
+      the selected handler logic uniformly with no mixed-version state. This intent is not itself an execution owner.
+      Runtime/store readiness for selected-contract boot/resume is governed by
+      runtime.run_fork.contract_swap_boot_resume_admission, and mutation remains limited to separately approved bounded
+      owners for admitted fork work.'
     timestamp_precision: 'Events committed in the same millisecond are disambiguated by (created_at, event_id)
       composite ordering. The fork point is inclusive: mutations from the target moment are included in
       reconstructed state. Only mutations strictly after T are undone.'


### PR DESCRIPTION
## Summary

Closes #1723
Closes #564

This PR closes the accepted #564 model at spec/design/conformance level: timestamp fork is bounded fork re-execution from provable inputs, not arbitrary full historical resume.

## Governing Refs

- `platform-spec.yaml` `run_model.fork`
- `platform-spec.yaml` `run_model.fork.semantics.4_boot`
- `platform-spec.yaml` `run_model.fork.semantics.5_resume`
- `platform-spec.yaml` `run_model.fork.replay_resume_admission_taxonomy`
- #1723 pre-audit and approved lead gate
- #564 closure audit posted on #564 before this PR

## Semantic Migration

New canonical truth:

- `platform-spec.yaml` defines bounded fork re-execution: `delivery_event_replay_ready`, selected-contract frontier execution when independently admitted, approved timer reconstruction, and typed fail-closed unsupported historical facts.
- `store.run_fork.replay_resume_admission` remains the runtime admission taxonomy owner.
- Legacy-named `runtime.run_fork.historical_replay_execution*` owners are explicitly sentinel-listed and defined as bounded fork re-execution owners, not a full-resume lane.
- `internal/runtime/conformance/testdata/fork_replay_resume_design_record.yaml` is the machine-checked design record for the fact matrix.

Old non-authoritative paths now invalid:

- Any product/spec/readback promise of full historical resume or inferred unfinished-work resume.
- Public/readback keys `historical_replay_supported`, `historical_replay_required`, `historical_replay_blocked`, and `full_replay_resume_supported`.

Production paths checked for surviving old behavior:

- `platform-spec.yaml`
- `internal/store/run_fork_*`
- `internal/runtime/runforkexecution/*`
- `cmd/swarm` readback and tests
- conformance stale-vocabulary scans

Migration completeness:

- Complete for spec, public/readback vocabulary, and design-record/conformance closure.
- Broad internal legacy identifiers are intentionally retained only as a closed sentinel set in the design record.
- #1721 and #1722 remain successor references only.

## Tests

Passed:

- `ruby -e 'require "yaml"; YAML.load_file("platform-spec.yaml"); YAML.load_file("internal/runtime/conformance/testdata/fork_replay_resume_design_record.yaml"); puts "yaml ok"'`
- `rg -n "full replay/resume|historical replay/resume|full runtime replay|full historical resume|historical resume|full historical replay/resume|future full historical|product-complete.*historical|system knows what was unfinished" platform-spec.yaml internal/store internal/runtime/runforkexecution cmd/swarm` (no matches)
- `go test ./internal/runtime/conformance -run 'TestForkReplayResume|TestDeterministicWorkLadderArtifactRepoDispositionPromotedToPlatformSpec|TestRouteAuthorityMatrix' -count=1`
- `go test ./internal/runtime/runforkexecution -run 'TestBuildHistoricalReplayExecutionAdmission|TestBuildHistoricalReplayExecutionConsumes|TestBuildContractSwapBootResumeAdmission|TestActivateSelectedContractRunForkPreservesPlannerBlockers' -count=1`
- `go test ./... -run '^$'`

Attempted but locally blocked:

- `go test ./...` reached many Postgres-backed tests and failed because local Docker/Postgres is unavailable: `failed to connect to the docker API at unix:///var/run/docker.sock`. No `SWARM_TEST_POSTGRES_DSN` is set in this environment.