### PR TITLE
[agent-g][issue #1823] Add boot-floor workspace backend conformance

### DIFF
--- a/cmd/swarm/boot_floor_conformance_test.go
+++ b/cmd/swarm/boot_floor_conformance_test.go
@@ -1,0 +1,139 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	runtimepkg "github.com/division-sh/swarm/internal/runtime"
+	runtimellm "github.com/division-sh/swarm/internal/runtime/llm"
+	workspace "github.com/division-sh/swarm/internal/runtime/workspace"
+	storebackend "github.com/division-sh/swarm/internal/store/backendselection"
+)
+
+func TestBootFloorConformanceNativeBashHostOptOutIsLoudUnsafe(t *testing.T) {
+	isolateCLIAPIConfigEnv(t)
+	missingDocker := filepath.Join(t.TempDir(), "missing-docker")
+	hostRoot := filepath.Join(t.TempDir(), "host-workspaces")
+
+	serve := startServeRuntimeTestProcess(t, serveOptions{
+		ConfigPath: writeStoreBackendRuntimeConfigWithWorkspaceFields(t, storebackend.BackendSQLite.String(), filepath.Join(t.TempDir(), "runtime.db"), []string{
+			fmt.Sprintf("  docker_bin: %q", missingDocker),
+			fmt.Sprintf("  host_root: %q", hostRoot),
+		}),
+		ContractsPath:        writeServeRuntimeNativeBashFixture(t),
+		DataSource:           t.TempDir(),
+		WorkspaceBackend:     workspace.BackendHost,
+		WorkspaceBackendSet:  true,
+		PlatformSpecPath:     defaultPlatformSpecPath,
+		StoreMode:            storebackend.ActiveDefaultBackend().String(),
+		APIListenAddr:        "127.0.0.1:0",
+		MCPListenAddr:        "127.0.0.1:0",
+		SelfCheck:            true,
+		RequireBundleMatch:   false,
+		ShutdownGrace:        runtimepkg.DefaultShutdownGrace,
+		Verbose:              true,
+		NoRequireBundleMatch: true,
+		TestLLMRuntime:       bootFloorNativeFallbackRuntime{},
+	})
+	serve.waitForReadyLine()
+	if code := serve.stop(); code != 0 {
+		t.Fatalf("runServeRuntime code = %d\noutput:\n%s", code, serve.outputString())
+	}
+	output := serve.outputString()
+	for _, want := range []string{
+		"workspace backend: host",
+		"native_tools.bash",
+		"UNSAFE: grants the agent execution on this machine",
+	} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("serve output missing %q:\n%s", want, output)
+		}
+	}
+	if strings.Contains(strings.ToLower(output), "docker is not available") {
+		t.Fatalf("host opt-out serve output shows Docker dependency despite explicit host backend:\n%s", output)
+	}
+}
+
+func TestBootFloorConformanceVerifyDescribeReportNativeBashWorkspaceRequirement(t *testing.T) {
+	isolateCLIAPIConfigEnv(t)
+	contractsRoot := writeServeRuntimeNativeBashFixture(t)
+
+	t.Run("verify text", func(t *testing.T) {
+		opts := defaultVerifyCommandOptions()
+		opts.contractsPath = contractsRoot
+
+		var stdout, stderr bytes.Buffer
+		code := runVerifyCommandWithOutput(context.Background(), repoRoot(), opts, &stdout, &stderr)
+		if code != 0 {
+			t.Fatalf("verify code = %d stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+		}
+		assertBootFloorWorkspaceRequirementOutput(t, stdout.String())
+	})
+
+	t.Run("verify json", func(t *testing.T) {
+		opts := defaultVerifyCommandOptions()
+		opts.contractsPath = contractsRoot
+		opts.output.asJSON = true
+
+		var stdout, stderr bytes.Buffer
+		code := runVerifyCommandWithOutput(context.Background(), repoRoot(), opts, &stdout, &stderr)
+		if code != 0 {
+			t.Fatalf("verify --json code = %d stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+		}
+		if strings.TrimSpace(stderr.String()) != "" {
+			t.Fatalf("verify --json stderr = %q, want empty", stderr.String())
+		}
+		output := decodeOutputJSON[verifyCommandResult](t, stdout.String())
+		assertBootFloorWorkspaceRequirementOutput(t, output.WorkspaceBackend)
+	})
+
+	t.Run("describe text", func(t *testing.T) {
+		var stdout, stderr bytes.Buffer
+		code := executeRootCommandWithOptions(context.Background(), repoRoot(), []string{
+			"describe",
+			"--contracts", contractsRoot,
+		}, &stdout, &stderr, defaultRootCommandOptions())
+		if code != 0 {
+			t.Fatalf("describe code = %d stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+		}
+		assertBootFloorWorkspaceRequirementOutput(t, stdout.String())
+	})
+
+	t.Run("describe json", func(t *testing.T) {
+		var stdout, stderr bytes.Buffer
+		code := executeRootCommandWithOptions(context.Background(), repoRoot(), []string{
+			"describe",
+			"--contracts", contractsRoot,
+			"--json",
+		}, &stdout, &stderr, defaultRootCommandOptions())
+		if code != 0 {
+			t.Fatalf("describe --json code = %d stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+		}
+		if strings.TrimSpace(stderr.String()) != "" {
+			t.Fatalf("describe --json stderr = %q, want empty", stderr.String())
+		}
+		output := decodeOutputJSON[describeCommandOutput](t, stdout.String())
+		assertBootFloorWorkspaceRequirementOutput(t, output.WorkspaceBackend)
+	})
+}
+
+func assertBootFloorWorkspaceRequirementOutput(t *testing.T, output string) {
+	t.Helper()
+	for _, want := range []string{"workspace backend: docker", "native_tools.bash"} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("output missing %q:\n%s", want, output)
+		}
+	}
+}
+
+type bootFloorNativeFallbackRuntime struct {
+	runtimellm.NoopRuntime
+}
+
+func (bootFloorNativeFallbackRuntime) ProviderContract() runtimellm.ProviderContract {
+	return runtimellm.OpenAIResponsesProviderContract()
+}

--- a/cmd/swarm/boot_floor_conformance_test.go
+++ b/cmd/swarm/boot_floor_conformance_test.go
@@ -123,7 +123,7 @@ func TestBootFloorConformanceVerifyDescribeReportNativeBashWorkspaceRequirement(
 
 func assertBootFloorWorkspaceRequirementOutput(t *testing.T, output string) {
 	t.Helper()
-	for _, want := range []string{"workspace backend: docker", "native_tools.bash"} {
+	for _, want := range []string{"workspace backend: docker", "agent native-bash-worker", "native_tools.bash"} {
 		if !strings.Contains(output, want) {
 			t.Fatalf("output missing %q:\n%s", want, output)
 		}


### PR DESCRIPTION
Closes #1823
Part of #1716

## Summary
- Adds named boot-floor conformance coverage for capability-driven workspace backend selection.
- Proves explicit `--workspace-backend host` unsafe native-bash opt-out emits the loud host warning instead of silently failing on Docker absence.
- Proves `verify` and `describe` report the native-bash workspace backend requirement in both text and JSON forms.

## Governing refs / context
- `platform-spec.yaml#workspace_model.workspace_backend_selection`
- `platform-spec.yaml#cli_specification.command_catalog.serve.workspace_backend_selection`
- Binding gate: #1823 pre-audit and lead gate approval, scoped to `m0_boot_floor_workspace_backend_conformance_gap`.

No runtime semantics or platform-spec semantics changed. This PR does not claim closure of #746, #1213, full Claude/provider host execution, Docker-equivalent host isolation, Compose/Postgres onboarding, or #995.

## Validation
- PASS: `go test ./cmd/swarm -run 'TestBootFloorConformance|TestRunServeRuntime(NoAgentDefaultBootsWithoutDocker|APIAgentDefaultHostBootsWithoutDocker|NativeBashDefaultDockerFailsWithoutDocker)|TestPlatformSpecWorkspaceBackendSelectionPromoted|TestWorkspaceBackendDecisionCapabilityMatrix|TestWorkspaceAdmittedForkChatExecutor(RejectsClaudeCLIWithoutDocker|AllowsAPIBackend)|TestRuntimeProjectSupervisorOpenProject(NoAgentSkipsWorkspaceLifecycle|RejectsNilLifecycleWithoutNoWorkspaceDecision)' -count=1`
- PASS: `SWARM_TEST_POSTGRES_DSN='host=127.0.0.1 port=5432 user=postgres password=postgres dbname=postgres sslmode=disable' PGPASSWORD=postgres go test ./cmd/swarm -run 'TestBootFloorConformance|TestServedParityHarnessRunControlLifecycle' -count=1`
- ATTEMPTED: `go test ./...` with default Docker-backed Postgres harness failed locally because Docker is unavailable at `/var/run/docker.sock`.
- ATTEMPTED: `SWARM_TEST_POSTGRES_DSN='host=127.0.0.1 port=5432 user=postgres password=postgres dbname=postgres sslmode=disable' PGPASSWORD=postgres go test -p 1 ./...` failed in existing `TestServedParityHarnessRunControlLifecycle/explicit_postgres` under broad package execution with a pending delivery; the same parity test passes when run focused and when run with the new conformance tests.

## Semantic migration
None. New tests only; no producer/reader/writer migration.
