### PR TITLE
[agent-a][issue #1873] Align accumulator transition carriers

### DIFF
--- a/cmd/swarm/describe_test.go
+++ b/cmd/swarm/describe_test.go
@@ -197,8 +197,8 @@ func TestDescribeCommandGraphRendersStageGraph(t *testing.T) {
 	if graph.FlowID != "support" || graph.FlowPath != "support" {
 		t.Fatalf("graph identity = %#v, want support namespace", graph)
 	}
-	if len(graph.Nodes) != 3 {
-		t.Fatalf("graph nodes = %#v, want waiting/active/done", graph.Nodes)
+	if len(graph.Nodes) != 5 {
+		t.Fatalf("graph nodes = %#v, want waiting/active/review/timed_out/done", graph.Nodes)
 	}
 	if !graph.Nodes[0].Initial || graph.Nodes[0].ID != "waiting" {
 		t.Fatalf("first graph node = %#v, want waiting initial", graph.Nodes[0])
@@ -216,13 +216,27 @@ func TestDescribeCommandGraphRendersStageGraph(t *testing.T) {
 		t.Fatalf("graph edges missing: %#v", graph)
 	}
 	var foundOpenedAdvance bool
+	var foundAccumulateComplete bool
+	var foundAccumulateTimeout bool
 	for _, edge := range graph.Edges {
 		if edge.Source == "handler.advances_to" && edge.NodeID == "support-node" && edge.EventType == "ticket.opened" && edge.To == "active" {
 			foundOpenedAdvance = true
 		}
+		if edge.Source == "handler.accumulate.on_complete" && edge.NodeID == "support-node" && edge.EventType == "ticket.closed" && edge.To == "review" {
+			foundAccumulateComplete = true
+		}
+		if edge.Source == "handler.accumulate.on_timeout" && edge.NodeID == "support-node" && edge.EventType == "ticket.closed" && edge.To == "timed_out" {
+			foundAccumulateTimeout = true
+		}
 	}
 	if !foundOpenedAdvance {
 		t.Fatalf("graph edges = %#v, want ticket.opened handler.advances_to edge to active", graph.Edges)
+	}
+	if !foundAccumulateComplete {
+		t.Fatalf("graph edges = %#v, want ticket.closed handler.accumulate.on_complete edge to review", graph.Edges)
+	}
+	if !foundAccumulateTimeout {
+		t.Fatalf("graph edges = %#v, want ticket.closed handler.accumulate.on_timeout edge to timed_out", graph.Edges)
 	}
 
 	stdout.Reset()
@@ -242,9 +256,36 @@ func TestDescribeCommandGraphRendersStageGraph(t *testing.T) {
 		"waiting [initial]",
 		"done [terminal]",
 		"handler.advances_to support-node on ticket.opened",
+		"handler.accumulate.on_complete support-node on ticket.closed",
+		"handler.accumulate.on_timeout support-node on ticket.closed",
 	} {
 		if !strings.Contains(text, want) {
 			t.Fatalf("describe --graph output missing %q:\n%s", want, text)
+		}
+	}
+}
+
+func TestVerifyCommandAcceptsAccumulatorTransitionCarrierFixture(t *testing.T) {
+	contractsRoot := writeDescribeStageGraphContracts(t)
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), repoRoot(), []string{
+		"verify",
+		"--contracts", contractsRoot,
+		"--json",
+	}, &stdout, &stderr, defaultRootCommandOptions())
+	if code != 0 {
+		t.Fatalf("verify --json code = %d stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if stderr.String() != "" {
+		t.Fatalf("verify --json stderr = %q, want empty", stderr.String())
+	}
+	output := decodeOutputJSON[verifyCommandResult](t, stdout.String())
+	if !output.OK {
+		t.Fatalf("verify --json output = %#v, want ok", output)
+	}
+	for _, warning := range output.Warnings {
+		if warning.CheckID == "semantic_drift_unreachable_state" && (strings.Contains(warning.Message, "review") || strings.Contains(warning.Message, "timed_out")) {
+			t.Fatalf("verify warnings = %#v, want accumulator carrier states reachable", output.Warnings)
 		}
 	}
 }
@@ -313,6 +354,8 @@ stages:
   waiting:
     initial: true
   active: {}
+  review: {}
+  timed_out: {}
   done:
     terminal: true
 `)
@@ -321,9 +364,16 @@ stages:
 	writeDescribeTestFile(t, filepath.Join(root, "flows", "support", "agents.yaml"), "{}\n")
 	writeDescribeTestFile(t, filepath.Join(root, "flows", "support", "events.yaml"), `
 ticket.opened:
+  swarm:
+    source: external
   entity_id: string
 ticket.closed:
+  swarm:
+    source: external
   entity_id: string
+accumulate.timeout:
+  swarm:
+    source: platform
 `)
 	writeDescribeTestFile(t, filepath.Join(root, "flows", "support", "entities.yaml"), `
 ticket: {}
@@ -341,6 +391,14 @@ support-node:
       advances_to: active
     ticket.closed:
       advances_to: done
+      accumulate:
+        completion: timeout
+        timeout_ms: 1000
+        on_complete:
+          - condition: "true"
+            advances_to: review
+        on_timeout:
+          advances_to: timed_out
 `)
 	return root
 }

--- a/internal/runtime/authoringview/view.go
+++ b/internal/runtime/authoringview/view.go
@@ -514,12 +514,8 @@ func buildStageGraphEdgesForFlow(source semanticview.Source, flowID, initial str
 					from = []string{strings.TrimSpace(initial)}
 				}
 			}
-			edges = appendStageGraphEdge(edges, from, handler.AdvancesTo, stateSet, "handler.advances_to", nodeID, eventType)
-			for _, rule := range handler.OnComplete {
-				edges = appendStageGraphEdge(edges, from, rule.AdvancesTo, stateSet, "handler.on_complete", nodeID, eventType)
-			}
-			for _, rule := range handler.Rules {
-				edges = appendStageGraphEdge(edges, from, rule.AdvancesTo, stateSet, "handler.rules", nodeID, eventType)
+			for _, carrier := range runtimecontracts.HandlerAdvanceCarriers(handler) {
+				edges = appendStageGraphEdge(edges, from, carrier.AdvancesTo, stateSet, carrier.Source(), nodeID, eventType)
 			}
 		}
 	}

--- a/internal/runtime/bootverify/checks.go
+++ b/internal/runtime/bootverify/checks.go
@@ -1642,28 +1642,7 @@ func validationFlowLabel(flowID string) string {
 }
 
 func handlerAdvanceTargets(handler runtimecontracts.SystemNodeEventHandler) []string {
-	out := make([]string, 0, 8)
-	if target := strings.TrimSpace(handler.AdvancesTo); target != "" {
-		out = append(out, target)
-	}
-	for _, rule := range handler.Rules {
-		if target := strings.TrimSpace(rule.AdvancesTo); target != "" {
-			out = append(out, target)
-		}
-	}
-	for _, rule := range handler.OnComplete {
-		if target := strings.TrimSpace(rule.AdvancesTo); target != "" {
-			out = append(out, target)
-		}
-	}
-	if handler.Accumulate != nil {
-		for _, rule := range handler.Accumulate.OnComplete {
-			if target := strings.TrimSpace(rule.AdvancesTo); target != "" {
-				out = append(out, target)
-			}
-		}
-	}
-	return out
+	return runtimecontracts.HandlerAdvanceTargets(handler)
 }
 
 func uniqueFindings(items []Finding) []Finding {

--- a/internal/runtime/bootverify/report_test.go
+++ b/internal/runtime/bootverify/report_test.go
@@ -14,6 +14,7 @@ import (
 
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
 	"github.com/division-sh/swarm/internal/runtime/core/paths"
+	"github.com/division-sh/swarm/internal/runtime/core/timeridentity"
 	runtimepipeline "github.com/division-sh/swarm/internal/runtime/pipeline"
 	"github.com/division-sh/swarm/internal/runtime/semanticview"
 	"gopkg.in/yaml.v3"
@@ -2668,7 +2669,7 @@ func TestRun_DoesNotWarnWhenRuleBranchReachesDeclaredState(t *testing.T) {
 	}
 }
 
-func TestRun_DoesNotUseAccumulateOnCompleteAsReachabilityProof(t *testing.T) {
+func TestRun_DoesNotWarnWhenAccumulateOnCompleteBranchReachesDeclaredState(t *testing.T) {
 	root := writeStateReachabilityFixture(t)
 	bundle := loadFixtureBundleAt(t, repoRootForBootverifyTest(t), root, runtimecontracts.DefaultPlatformSpecFile(repoRootForBootverifyTest(t)))
 	node := bundle.Nodes["support-node"]
@@ -2684,8 +2685,54 @@ func TestRun_DoesNotUseAccumulateOnCompleteAsReachabilityProof(t *testing.T) {
 
 	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
 
-	if !reportContains(report.Warnings(), "semantic_drift_unreachable_state", "review") {
-		t.Fatalf("expected semantic_drift_unreachable_state warning when only accumulate.on_complete reaches review, got %#v", report.Warnings())
+	if reportContains(report.Warnings(), "semantic_drift_unreachable_state", "review") {
+		t.Fatalf("unexpected semantic_drift_unreachable_state warning when accumulate.on_complete reaches review, got %#v", report.Warnings())
+	}
+}
+
+func TestRun_DoesNotWarnWhenAccumulateOnTimeoutBranchReachesDeclaredState(t *testing.T) {
+	root := writeStateReachabilityFixture(t)
+	bundle := loadFixtureBundleAt(t, repoRootForBootverifyTest(t), root, runtimecontracts.DefaultPlatformSpecFile(repoRootForBootverifyTest(t)))
+	node := bundle.Nodes["support-node"]
+	handler := node.EventHandlers["ticket.closed"]
+	handler.Accumulate = &runtimecontracts.AccumulateSpec{
+		Completion: runtimecontracts.ParseAccumulateCompletion("timeout"),
+		TimeoutMS:  1000,
+		OnTimeout: &runtimecontracts.HandlerRuleEntry{
+			Condition:  "true",
+			AdvancesTo: "review",
+		},
+	}
+	node.EventHandlers["ticket.closed"] = handler
+	bundle.Nodes["support-node"] = node
+
+	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+
+	if reportContains(report.Warnings(), "semantic_drift_unreachable_state", "review") {
+		t.Fatalf("unexpected semantic_drift_unreachable_state warning when accumulate.on_timeout reaches review, got %#v", report.Warnings())
+	}
+}
+
+func TestRun_PreservesStateMachineCoherenceErrorWhenInvalidAccumulateTimeoutTargetExists(t *testing.T) {
+	root := writeStateReachabilityFixture(t)
+	bundle := loadFixtureBundleAt(t, repoRootForBootverifyTest(t), root, runtimecontracts.DefaultPlatformSpecFile(repoRootForBootverifyTest(t)))
+	node := bundle.Nodes["support-node"]
+	handler := node.EventHandlers["ticket.closed"]
+	handler.Accumulate = &runtimecontracts.AccumulateSpec{
+		Completion: runtimecontracts.ParseAccumulateCompletion("timeout"),
+		TimeoutMS:  1000,
+		OnTimeout: &runtimecontracts.HandlerRuleEntry{
+			Condition:  "true",
+			AdvancesTo: "bogus_state",
+		},
+	}
+	node.EventHandlers["ticket.closed"] = handler
+	bundle.Nodes["support-node"] = node
+
+	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+
+	if !reportContains(report.Errors(), "state_machine_coherence", "bogus_state") {
+		t.Fatalf("expected state_machine_coherence error for invalid accumulate.on_timeout target, got %#v", report.Errors())
 	}
 }
 
@@ -6689,6 +6736,48 @@ func TestRun_AllowsTimerCancelStateReachableFromEventStartContext(t *testing.T) 
 	report := Run(context.Background(), semanticview.Wrap(loadFixtureBundleAt(t, repoRoot, root, platformSpec)), Options{})
 	if reportContains(report.Errors(), "timer_validation", "cancel_on state done is not reachable") {
 		t.Fatalf("unexpected timer_validation event-start cancel-state reachability error, got %#v", report.Errors())
+	}
+}
+
+func TestTimerReachabilityConsumesAccumulatorTransitionCarriers(t *testing.T) {
+	root := writeStateReachabilityFixture(t)
+	bundle := loadFixtureBundleAt(t, repoRootForBootverifyTest(t), root, runtimecontracts.DefaultPlatformSpecFile(repoRootForBootverifyTest(t)))
+	node := bundle.Nodes["support-node"]
+	handler := node.EventHandlers["ticket.closed"]
+	handler.Accumulate = &runtimecontracts.AccumulateSpec{
+		Completion: runtimecontracts.ParseAccumulateCompletion("timeout"),
+		TimeoutMS:  1000,
+		OnComplete: []runtimecontracts.HandlerRuleEntry{{
+			Condition:  "true",
+			AdvancesTo: "review",
+		}},
+		OnTimeout: &runtimecontracts.HandlerRuleEntry{
+			Condition:  "true",
+			AdvancesTo: "active",
+		},
+	}
+	node.EventHandlers["ticket.closed"] = handler
+	bundle.Nodes["support-node"] = node
+
+	source := semanticview.Wrap(bundle)
+	declaredStates := map[string]struct{}{"waiting": {}, "active": {}, "review": {}, "done": {}}
+	trigger, err := timeridentity.ParseStartTrigger("event:ticket.closed")
+	if err != nil {
+		t.Fatalf("ParseStartTrigger: %v", err)
+	}
+	activationStates := timerActivationStates(source, runtimecontracts.WorkflowTimerContract{FlowID: "support"}, trigger, "waiting", declaredStates)
+	for _, want := range []string{"active", "review"} {
+		if _, ok := activationStates[want]; !ok {
+			t.Fatalf("timer activation states = %#v, want accumulator carrier target %s", activationStates, want)
+		}
+	}
+
+	edges := timerCancelStateGraphEdges(source, runtimecontracts.WorkflowTimerContract{FlowID: "support", Event: "timer.reminder"}, "waiting", declaredStates)
+	if _, ok := edges["waiting"]["review"]; !ok {
+		t.Fatalf("timer cancel graph edges = %#v, want accumulator on_complete edge to review", edges)
+	}
+	if _, ok := edges["waiting"]["active"]; !ok {
+		t.Fatalf("timer cancel graph edges = %#v, want accumulator on_timeout edge to active", edges)
 	}
 }
 

--- a/internal/runtime/bootverify/workflow_state_machine_reachability_checks.go
+++ b/internal/runtime/bootverify/workflow_state_machine_reachability_checks.go
@@ -167,21 +167,7 @@ func authoredStateGraphEdgesFiltered(
 }
 
 func authoredReachabilityTargets(handler runtimecontracts.SystemNodeEventHandler) []string {
-	out := make([]string, 0, len(handler.Rules)+len(handler.OnComplete)+1)
-	if target := strings.TrimSpace(handler.AdvancesTo); target != "" {
-		out = append(out, target)
-	}
-	for _, rule := range handler.OnComplete {
-		if target := strings.TrimSpace(rule.AdvancesTo); target != "" {
-			out = append(out, target)
-		}
-	}
-	for _, rule := range handler.Rules {
-		if target := strings.TrimSpace(rule.AdvancesTo); target != "" {
-			out = append(out, target)
-		}
-	}
-	return out
+	return runtimecontracts.HandlerAdvanceTargets(handler)
 }
 
 func authoredNonTerminalStates(source semanticview.Source, flowID string, declaredStates map[string]struct{}) []string {

--- a/internal/runtime/contracts/workflow_contract_effective.go
+++ b/internal/runtime/contracts/workflow_contract_effective.go
@@ -238,7 +238,7 @@ func EffectiveSystemNodeExecutionType(node SystemNodeContract) string {
 
 func EffectiveSystemNodeSubscriptions(node SystemNodeContract) []string {
 	seen := make(map[string]struct{})
-	out := make([]string, 0, len(node.SubscribesTo)+len(node.EventHandlers))
+	out := make([]string, 0, len(node.SubscribesTo)+len(node.EventHandlers)+1)
 	appendSubscription := func(value string) {
 		value = eventidentity.Normalize(value)
 		if value == "" {
@@ -256,8 +256,21 @@ func EffectiveSystemNodeSubscriptions(node SystemNodeContract) []string {
 	for eventType := range node.EventHandlers {
 		appendSubscription(eventType)
 	}
+	for _, handler := range node.EventHandlers {
+		if handlerRequiresAccumulatorTimeoutSubscription(handler) {
+			appendSubscription("accumulate.timeout")
+			break
+		}
+	}
 	sort.Strings(out)
 	return out
+}
+
+func handlerRequiresAccumulatorTimeoutSubscription(handler SystemNodeEventHandler) bool {
+	if handler.Accumulate == nil {
+		return false
+	}
+	return handler.Accumulate.Completion.Mode == AccumulateModeTimeout || handler.Accumulate.OnTimeout != nil
 }
 
 func EffectiveSystemNodeProduces(node SystemNodeContract) []string {

--- a/internal/runtime/contracts/workflow_contract_semantics.go
+++ b/internal/runtime/contracts/workflow_contract_semantics.go
@@ -307,7 +307,7 @@ func sortedGuardActionEntries(entries map[string]GuardActionEntry) []GuardAction
 	return out
 }
 func deriveWorkflowTransitionContract(transition HandlerTransitionSemantic) (WorkflowTransitionContract, bool) {
-	to := strings.TrimSpace(transition.AdvancesTo)
+	to := handlerLevelAdvanceTarget(transition)
 	if to == "" {
 		return WorkflowTransitionContract{}, false
 	}
@@ -328,43 +328,70 @@ func deriveWorkflowTransitionContract(transition HandlerTransitionSemantic) (Wor
 	return out, strings.TrimSpace(out.ID) != "" && strings.TrimSpace(out.Trigger) != ""
 }
 
+func handlerLevelAdvanceTarget(transition HandlerTransitionSemantic) string {
+	for _, carrier := range HandlerTransitionAdvanceCarriers(transition) {
+		if carrier.Kind == HandlerAdvanceCarrierHandler {
+			return strings.TrimSpace(carrier.AdvancesTo)
+		}
+	}
+	return ""
+}
+
 func deriveAccumulateTimeoutTransition(transition HandlerTransitionSemantic) (WorkflowTransitionContract, bool) {
-	if transition.Accumulate == nil || transition.Accumulate.OnTimeout == nil {
-		return WorkflowTransitionContract{}, false
+	for _, carrier := range HandlerTransitionAdvanceCarriers(transition) {
+		if carrier.Kind != HandlerAdvanceCarrierAccumulateOnTimeout {
+			continue
+		}
+		return WorkflowTransitionContract{
+			ID:      strings.TrimSpace(transition.ID) + ":on_timeout",
+			From:    []string{"*"},
+			To:      strings.TrimSpace(carrier.AdvancesTo),
+			Trigger: "accumulate.timeout",
+			Node:    strings.TrimSpace(transition.NodeID),
+		}, true
 	}
-	to := strings.TrimSpace(transition.Accumulate.OnTimeout.AdvancesTo)
-	if to == "" {
-		return WorkflowTransitionContract{}, false
-	}
-	return WorkflowTransitionContract{
-		ID:      strings.TrimSpace(transition.ID) + ":on_timeout",
-		From:    []string{"*"},
-		To:      to,
-		Trigger: "accumulate.timeout",
-		Node:    strings.TrimSpace(transition.NodeID),
-	}, true
+	return WorkflowTransitionContract{}, false
 }
 
 func deriveRuleTransitions(transition HandlerTransitionSemantic) []WorkflowTransitionContract {
-	rules := append([]HandlerRuleEntry{}, transition.OnComplete...)
-	if len(rules) == 0 && transition.Accumulate != nil {
-		rules = append(rules, transition.Accumulate.OnComplete...)
-	}
-	nonHandlerRuleCount := len(rules)
-	rules = append(rules, transition.Rules...)
-	out := make([]WorkflowTransitionContract, 0, len(rules))
-	for idx, rule := range rules {
-		to := strings.TrimSpace(rule.AdvancesTo)
-		if to == "" && idx >= nonHandlerRuleCount && strings.TrimSpace(rule.Action.ID) != "" {
-			to = strings.TrimSpace(transition.AdvancesTo)
+	carriers := HandlerTransitionAdvanceCarriers(transition)
+	out := make([]WorkflowTransitionContract, 0, len(carriers))
+	defaultIDIndex := 0
+	for _, carrier := range carriers {
+		switch carrier.Kind {
+		case HandlerAdvanceCarrierOnComplete, HandlerAdvanceCarrierRules, HandlerAdvanceCarrierAccumulateOnComplete:
+		default:
+			continue
 		}
+		rule := carrier.Rule
+		id := strings.TrimSpace(rule.ID)
+		if id == "" {
+			id = fmt.Sprintf("%s:rule:%d", strings.TrimSpace(transition.ID), defaultIDIndex)
+		}
+		defaultIDIndex++
+		out = append(out, WorkflowTransitionContract{
+			ID:      id,
+			From:    []string{"*"},
+			To:      strings.TrimSpace(carrier.AdvancesTo),
+			Trigger: strings.TrimSpace(transition.EventType),
+			Node:    strings.TrimSpace(transition.NodeID),
+			Actions: actionIDsForRule(rule),
+		})
+	}
+	handlerAdvanceTo := handlerLevelAdvanceTarget(transition)
+	for _, rule := range transition.Rules {
+		if strings.TrimSpace(rule.AdvancesTo) != "" || strings.TrimSpace(rule.Action.ID) == "" {
+			continue
+		}
+		to := handlerAdvanceTo
 		if to == "" {
 			continue
 		}
 		id := strings.TrimSpace(rule.ID)
 		if id == "" {
-			id = fmt.Sprintf("%s:rule:%d", strings.TrimSpace(transition.ID), idx)
+			id = fmt.Sprintf("%s:rule:%d", strings.TrimSpace(transition.ID), defaultIDIndex)
 		}
+		defaultIDIndex++
 		out = append(out, WorkflowTransitionContract{
 			ID:      id,
 			From:    []string{"*"},

--- a/internal/runtime/contracts/workflow_contract_semantics_test.go
+++ b/internal/runtime/contracts/workflow_contract_semantics_test.go
@@ -55,6 +55,44 @@ func TestWorkflowSemanticsRuleActionUsesHandlerAdvancesToFallback(t *testing.T) 
 	}
 }
 
+func TestWorkflowSemanticsDerivesTopLevelAndAccumulateCompletionTransitions(t *testing.T) {
+	bundle := &WorkflowContractBundle{
+		Nodes: map[string]SystemNodeContract{
+			"fan-in-node": {
+				EventHandlers: map[string]SystemNodeEventHandler{
+					"component.scaffolded": {
+						OnComplete: []HandlerRuleEntry{{
+							ID:         "top-complete",
+							Condition:  "true",
+							AdvancesTo: "top_review",
+						}},
+						Accumulate: &AccumulateSpec{
+							OnComplete: []HandlerRuleEntry{{
+								ID:         "accumulate-complete",
+								Condition:  "accumulated.count >= 3",
+								AdvancesTo: "launch_review",
+							}},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	populateWorkflowSemantics(bundle)
+
+	transitions := map[string]WorkflowTransitionContract{}
+	for _, transition := range bundle.WorkflowTransitions() {
+		transitions[transition.ID] = transition
+	}
+	if got := transitions["top-complete"].To; got != "top_review" {
+		t.Fatalf("top-level on_complete transition To = %q, want top_review; transitions=%#v", got, transitions)
+	}
+	if got := transitions["accumulate-complete"].To; got != "launch_review" {
+		t.Fatalf("accumulate.on_complete transition To = %q, want launch_review; transitions=%#v", got, transitions)
+	}
+}
+
 func TestWorkflowSemanticsDerivesEffectiveSystemNodeFacts(t *testing.T) {
 	bundle := &WorkflowContractBundle{
 		Nodes: map[string]SystemNodeContract{

--- a/internal/runtime/contracts/workflow_contract_semantics_test.go
+++ b/internal/runtime/contracts/workflow_contract_semantics_test.go
@@ -151,7 +151,7 @@ func TestWorkflowSemanticsDerivesEffectiveSystemNodeFacts(t *testing.T) {
 	if got, want := effective.ExecutionType, SystemNodeExecutionType; got != want {
 		t.Fatalf("effective execution type = %q, want %q", got, want)
 	}
-	if got, want := effective.RuntimeSubscriptions, []string{"task.review", "task.rules", "task.start", "task.timeout"}; !reflect.DeepEqual(got, want) {
+	if got, want := effective.RuntimeSubscriptions, []string{"accumulate.timeout", "task.review", "task.rules", "task.start", "task.timeout"}; !reflect.DeepEqual(got, want) {
 		t.Fatalf("effective subscriptions = %#v, want %#v", got, want)
 	}
 	if got, want := effective.Produces, []string{"task.approved", "task.child", "task.done", "task.expired", "task.rules.else", "task.rules.then"}; !reflect.DeepEqual(got, want) {

--- a/internal/runtime/contracts/workflow_transition_carriers.go
+++ b/internal/runtime/contracts/workflow_transition_carriers.go
@@ -1,0 +1,98 @@
+package contracts
+
+import "strings"
+
+type HandlerAdvanceCarrierKind string
+
+const (
+	HandlerAdvanceCarrierHandler              HandlerAdvanceCarrierKind = "handler.advances_to"
+	HandlerAdvanceCarrierOnComplete           HandlerAdvanceCarrierKind = "handler.on_complete"
+	HandlerAdvanceCarrierRules                HandlerAdvanceCarrierKind = "handler.rules"
+	HandlerAdvanceCarrierAccumulateOnComplete HandlerAdvanceCarrierKind = "handler.accumulate.on_complete"
+	HandlerAdvanceCarrierAccumulateOnTimeout  HandlerAdvanceCarrierKind = "handler.accumulate.on_timeout"
+)
+
+// HandlerAdvanceCarrier describes one authored handler site that can carry an advances_to target.
+type HandlerAdvanceCarrier struct {
+	Kind       HandlerAdvanceCarrierKind
+	AdvancesTo string
+	Rule       HandlerRuleEntry
+	RuleIndex  int
+	RuleID     string
+}
+
+// Source returns the stable source label used by verifier and authoring projections.
+func (c HandlerAdvanceCarrier) Source() string {
+	return string(c.Kind)
+}
+
+// HandlerAdvanceCarriers returns the complete authored advances_to carrier set for a handler.
+func HandlerAdvanceCarriers(handler SystemNodeEventHandler) []HandlerAdvanceCarrier {
+	return handlerAdvanceCarriers(handler.AdvancesTo, handler.OnComplete, handler.Rules, handler.Accumulate)
+}
+
+// HandlerTransitionAdvanceCarriers returns the complete authored advances_to carrier set for a semantic transition.
+func HandlerTransitionAdvanceCarriers(transition HandlerTransitionSemantic) []HandlerAdvanceCarrier {
+	return handlerAdvanceCarriers(transition.AdvancesTo, transition.OnComplete, transition.Rules, transition.Accumulate)
+}
+
+// HandlerAdvanceTargets returns the carrier targets without source metadata.
+func HandlerAdvanceTargets(handler SystemNodeEventHandler) []string {
+	carriers := HandlerAdvanceCarriers(handler)
+	out := make([]string, 0, len(carriers))
+	for _, carrier := range carriers {
+		if target := strings.TrimSpace(carrier.AdvancesTo); target != "" {
+			out = append(out, target)
+		}
+	}
+	return out
+}
+
+func handlerAdvanceCarriers(
+	advancesTo string,
+	onComplete []HandlerRuleEntry,
+	rules []HandlerRuleEntry,
+	accumulate *AccumulateSpec,
+) []HandlerAdvanceCarrier {
+	out := make([]HandlerAdvanceCarrier, 0, 1+len(onComplete)+len(rules))
+	if target := strings.TrimSpace(advancesTo); target != "" {
+		out = append(out, HandlerAdvanceCarrier{
+			Kind:       HandlerAdvanceCarrierHandler,
+			AdvancesTo: target,
+			RuleIndex:  -1,
+		})
+	}
+	appendRuleCarriers := func(kind HandlerAdvanceCarrierKind, entries []HandlerRuleEntry) {
+		for idx, rule := range entries {
+			target := strings.TrimSpace(rule.AdvancesTo)
+			if target == "" {
+				continue
+			}
+			out = append(out, HandlerAdvanceCarrier{
+				Kind:       kind,
+				AdvancesTo: target,
+				Rule:       rule,
+				RuleIndex:  idx,
+				RuleID:     strings.TrimSpace(rule.ID),
+			})
+		}
+	}
+	appendRuleCarriers(HandlerAdvanceCarrierOnComplete, onComplete)
+	appendRuleCarriers(HandlerAdvanceCarrierRules, rules)
+	if accumulate != nil {
+		appendRuleCarriers(HandlerAdvanceCarrierAccumulateOnComplete, accumulate.OnComplete)
+		if accumulate.OnTimeout != nil {
+			rule := *accumulate.OnTimeout
+			if target := strings.TrimSpace(rule.AdvancesTo); target != "" {
+				out = append(out, HandlerAdvanceCarrier{
+					Kind:       HandlerAdvanceCarrierAccumulateOnTimeout,
+					AdvancesTo: target,
+					Rule:       rule,
+					RuleIndex:  0,
+					RuleID:     strings.TrimSpace(rule.ID),
+				})
+			}
+		}
+	}
+	return out
+}

--- a/internal/runtime/engine/executor.go
+++ b/internal/runtime/engine/executor.go
@@ -1624,23 +1624,33 @@ func (e *Executor) stepOnComplete(frame *executionFrame) error {
 		frame.rule == frame.req.Handler.Accumulate.OnTimeout {
 		return nil
 	}
-	rules := frame.req.Handler.OnComplete
-	ruleSource := handlerRuleSourceOnComplete
-	if len(rules) == 0 && frame.req.Handler.Accumulate != nil {
-		rules = frame.req.Handler.Accumulate.OnComplete
-		ruleSource = handlerRuleSourceAccumulateOnComplete
+	topLevelRules := frame.req.Handler.OnComplete
+	var accumulateRules []runtimecontracts.HandlerRuleEntry
+	if frame.req.Handler.Accumulate != nil {
+		accumulateRules = frame.req.Handler.Accumulate.OnComplete
 	}
-	if frame.result.AccumulatorCompletionDiagnostics.Relevant && len(rules) > 0 {
+	if frame.result.AccumulatorCompletionDiagnostics.Relevant && (len(topLevelRules) > 0 || len(accumulateRules) > 0) {
 		frame.result.AccumulatorCompletionDiagnostics.OnCompleteDeclared = true
 	}
-	rule, err := e.selectRule(frame, rules)
+	ruleSource := handlerRuleSourceOnComplete
+	rule, err := e.selectRule(frame, topLevelRules)
 	if err != nil {
 		if frame.result.AccumulatorCompletionDiagnostics.Relevant {
 			frame.result.AccumulatorCompletionDiagnostics.EvaluationOutcome = AccumulatorCompletionEvaluationFailed
 		}
 		return err
 	}
-	if frame.result.AccumulatorCompletionDiagnostics.Relevant && len(rules) > 0 {
+	if rule == nil && len(accumulateRules) > 0 {
+		ruleSource = handlerRuleSourceAccumulateOnComplete
+		rule, err = e.selectRule(frame, accumulateRules)
+		if err != nil {
+			if frame.result.AccumulatorCompletionDiagnostics.Relevant {
+				frame.result.AccumulatorCompletionDiagnostics.EvaluationOutcome = AccumulatorCompletionEvaluationFailed
+			}
+			return err
+		}
+	}
+	if frame.result.AccumulatorCompletionDiagnostics.Relevant && (len(topLevelRules) > 0 || len(accumulateRules) > 0) {
 		frame.result.AccumulatorCompletionDiagnostics.EvaluationOutcome = AccumulatorCompletionEvaluationSucceeded
 	}
 	if rule != nil {

--- a/internal/runtime/engine/executor_test.go
+++ b/internal/runtime/engine/executor_test.go
@@ -1383,6 +1383,43 @@ func TestExecutor_AccumulatorProjectionSkipsDeclaredOnCompleteNoMatch(t *testing
 	}
 }
 
+func TestExecutor_AccumulatorOnCompleteMatchesWhenTopLevelOnCompleteDoesNot(t *testing.T) {
+	exec := newAccumulatorProjectionTestExecutor(t, stubEvaluator{bools: map[string]bool{
+		"payload.score > 100": false,
+	}})
+	handler := runtimecontracts.SystemNodeEventHandler{
+		OnComplete: []runtimecontracts.HandlerRuleEntry{{
+			ID:         "top-level",
+			Condition:  "payload.score > 100",
+			AdvancesTo: "top_review",
+		}},
+		Accumulate: &runtimecontracts.AccumulateSpec{
+			ExpectedFrom: "entity.expected_dimensions",
+			ExpectedPath: runtimecontracts.RefExpression("entity.expected_dimensions").RefPath,
+			Completion:   runtimecontracts.ParseAccumulateCompletion("all"),
+			DedupBy:      "payload.dimension",
+			DedupPath:    runtimecontracts.RefExpression("payload.dimension").RefPath,
+			OnComplete: []runtimecontracts.HandlerRuleEntry{{
+				ID:         "accumulate-complete",
+				Condition:  "else",
+				AdvancesTo: "launch_review",
+			}},
+		},
+	}
+	result := executeAccumulatorProjectionTestEvent(t, exec, handler, testStateSnapshot(
+		"pending",
+		map[string]any{"expected_dimensions": []any{"market"}},
+		nil,
+		map[string]map[string]any{},
+	))
+	if got, want := result.RuleID, "accumulate-complete"; got != want {
+		t.Fatalf("RuleID = %q, want %q", got, want)
+	}
+	if got, want := result.NextState, "launch_review"; got != want {
+		t.Fatalf("NextState = %q, want %q", got, want)
+	}
+}
+
 func TestExecutor_AccumulatorProjectionSkipsIncompleteAccumulation(t *testing.T) {
 	exec := newAccumulatorProjectionTestExecutor(t, nil)
 	handler := runtimecontracts.SystemNodeEventHandler{

--- a/internal/runtime/pipeline/engine_bridge.go
+++ b/internal/runtime/pipeline/engine_bridge.go
@@ -119,7 +119,7 @@ func findAccumulationTimeoutHandlerForBucket(source interface {
 	if source == nil || !bucket.Valid() {
 		return runtimecontracts.SystemNodeEventHandler{}, false
 	}
-	if _, ok := source.NodeEntries()[bucket.NodeID]; !ok || !containsString(source.NodeRuntimeSubscriptions(bucket.NodeID), "accumulate.timeout") {
+	if _, ok := source.NodeEntries()[bucket.NodeID]; !ok {
 		return runtimecontracts.SystemNodeEventHandler{}, false
 	}
 	for eventType, candidate := range source.NodeEventHandlers(bucket.NodeID) {

--- a/internal/runtime/pipeline/node_declarative.go
+++ b/internal/runtime/pipeline/node_declarative.go
@@ -199,7 +199,7 @@ func (n *DeclarativeNode) HandleEvent(ctx context.Context, evt Event) (*HandlerO
 			}
 		}
 	}
-	if !ok && isAccumulationTimeoutEvent(events.EventType(eventType)) && containsEventType(n.Subscriptions(), events.EventType(eventType)) {
+	if !ok && isAccumulationTimeoutEvent(events.EventType(eventType)) {
 		if bucket, bucketOK := timeridentity.ParseAccumulatorBucketRef(parsePayloadMap(evt.Payload())); bucketOK && bucket.NodeID == n.NodeID() {
 			for candidateEventType, candidate := range n.contract.EventHandlers {
 				if strings.TrimSpace(candidateEventType) != bucket.EventType {

--- a/internal/runtime/pipeline/timeout_selection_test.go
+++ b/internal/runtime/pipeline/timeout_selection_test.go
@@ -26,6 +26,27 @@ func (r *recordingExecutionEngine) ExecuteHandlerSteps(_ context.Context, handle
 	return &HandlerOutcome{Handled: true}, nil
 }
 
+func timeoutSourceWithoutAuthoredAccumulatorTimeoutSubscription() semanticview.Source {
+	return semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
+		Nodes: map[string]runtimecontracts.SystemNodeContract{
+			"test-node": {
+				ID:           "test-node",
+				SubscribesTo: []string{"item.arrived"},
+				EventHandlers: map[string]runtimecontracts.SystemNodeEventHandler{
+					"item.arrived": {
+						Accumulate: &runtimecontracts.AccumulateSpec{
+							Completion: runtimecontracts.ParseAccumulateCompletion("timeout"),
+							OnTimeout: &runtimecontracts.HandlerRuleEntry{
+								ID: "timeout",
+							},
+						},
+					},
+				},
+			},
+		},
+	})
+}
+
 func TestFindAccumulationTimeoutHandlerForBucket_OnTimeoutFixture(t *testing.T) {
 	repoRoot := filepath.Clean(filepath.Join("..", "..", ".."))
 	fixtureRoot := filepath.Join(repoRoot, "tests", "tier2-accumulation", "test-accumulate-on-timeout")
@@ -49,6 +70,21 @@ func TestFindAccumulationTimeoutHandlerForBucket_OnTimeoutFixture(t *testing.T) 
 	}
 }
 
+func TestFindAccumulationTimeoutHandlerForBucket_DerivesTimeoutSubscription(t *testing.T) {
+	source := timeoutSourceWithoutAuthoredAccumulatorTimeoutSubscription()
+	subscriptions := source.NodeRuntimeSubscriptions("test-node")
+	if !containsString(subscriptions, "accumulate.timeout") {
+		t.Fatalf("runtime subscriptions = %#v, want derived accumulate.timeout", subscriptions)
+	}
+	handler, ok := findAccumulationTimeoutHandlerForBucket(source, timeridentity.NewAccumulatorBucketRef("test-node", "item.arrived"))
+	if !ok {
+		t.Fatal("expected timeout handler")
+	}
+	if handler.Accumulate == nil || handler.Accumulate.OnTimeout == nil {
+		t.Fatalf("handler missing accumulate on_timeout: %#v", handler.Accumulate)
+	}
+}
+
 func TestDeclarativeNodeHandleEvent_SelectsOnTimeoutAccumulatorHandler(t *testing.T) {
 	repoRoot := filepath.Clean(filepath.Join("..", "..", ".."))
 	fixtureRoot := filepath.Join(repoRoot, "tests", "tier2-accumulation", "test-accumulate-on-timeout")
@@ -60,6 +96,31 @@ func TestDeclarativeNodeHandleEvent_SelectsOnTimeoutAccumulatorHandler(t *testin
 	entry := bundle.NodeEntries()["test-node"]
 	engine := &recordingExecutionEngine{}
 	node := NewNode(entry, semanticview.Wrap(bundle), engine, nil)
+	handled := node.Handle(context.Background(), eventtest.RootIngress("", "accumulate.timeout", "", "", mustJSON(map[string]any{
+		"timer_handle": map[string]any{
+			"kind": "accumulation_timeout",
+			"bucket": map[string]any{
+				"node_id":    "test-node",
+				"event_type": "item.arrived",
+			},
+		},
+	}), 0, "", "", events.EventEnvelope{}, time.Time{}))
+	if !handled {
+		t.Fatal("expected timeout event to be handled")
+	}
+	if !engine.called {
+		t.Fatal("expected execution engine to be called")
+	}
+	if got := engine.handlerEventKey; got != "item.arrived" {
+		t.Fatalf("handler event key = %q, want item.arrived", got)
+	}
+}
+
+func TestDeclarativeNodeHandleEvent_SelectsOnTimeoutAccumulatorHandlerWithoutAuthoredSubscription(t *testing.T) {
+	source := timeoutSourceWithoutAuthoredAccumulatorTimeoutSubscription()
+	entry := source.NodeEntries()["test-node"]
+	engine := &recordingExecutionEngine{}
+	node := NewNode(entry, source, engine, nil)
 	handled := node.Handle(context.Background(), eventtest.RootIngress("", "accumulate.timeout", "", "", mustJSON(map[string]any{
 		"timer_handle": map[string]any{
 			"kind": "accumulation_timeout",

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -2046,6 +2046,8 @@ handler_specification:
   on_complete_vs_rules:
     description: Mutually exclusive. A handler uses on_complete OR rules, never both.
     on_complete: Ordered list of {condition, advances_to, emit} — first match wins. Used after accumulation/computation.
+      If handler-level on_complete and accumulate.on_complete are both declared, handler-level on_complete is evaluated first;
+      when no handler-level branch matches, accumulate.on_complete is evaluated as the accumulator-completion branch surface.
     rules: Current concrete spelling of the ordered policy-sheet authoring construct for handler-phase selection. Existing
       condition rules and typed selection rows lower to the canonical selected-branch owner. Retired `handler.branch`
       syntax is unsupported and must fail closed instead of being interpreted, lowered, or preserved as compatibility syntax.
@@ -3133,7 +3135,9 @@ handler_specification:
           as node-key-{instance_id} are subscriber naming templates, not a separate semantic node identity owner.
         execution_type: string — if omitted, defaults to "system_node"; any explicit non-system_node value is invalid.
         subscribes_to: list of event names this node receives. Exact handler-triggered subscriptions are derived from
-          event_handlers keys when omitted. Wildcard/import-boundary escape-hatch subscriptions remain explicit.
+          event_handlers keys when omitted. Accumulator timeout delivery is platform-owned; handlers with timeout-mode
+          accumulate or accumulate.on_timeout derive the intrinsic accumulate.timeout runtime subscription. Wildcard/import-boundary
+          escape-hatch subscriptions remain explicit.
         produces: list of event names this node emits. Omit for ordinary nodes; the effective production surface is derived
           from supported declarative emit sites. If present, this is an explicit authored assertion checked against actual
           emits.
@@ -3145,7 +3149,8 @@ handler_specification:
       effective_semantics:
         id: YAML map key, with same-value explicit id accepted during migration
         execution_type: system_node
-        runtime_subscriptions: union of explicit subscribes_to entries and event_handlers keys
+        runtime_subscriptions: union of explicit subscribes_to entries, event_handlers keys, and intrinsic platform runtime
+          events required by declared handler primitives such as accumulate.timeout
         produces: events derived from supported declarative emit sites
     description: Complete specification for system nodes — the deterministic components that orchestrate state transitions.
       Every field used in nodes.yaml must be defined here.
@@ -3872,9 +3877,13 @@ engine:
       threshold: Proceed when received count reaches a configured number.
       timeout: Proceed when a timer fires, regardless of how many items arrived. Partial results available.
     on_complete: When completion condition is met, the handler continues to the remaining steps (compute, on_complete branches,
-      advances_to, emit). The accumulated data is available to these steps.
+      advances_to, emit). The accumulated data is available to these steps. Handler-level on_complete branches are evaluated
+      first; if no handler-level branch matches and accumulate.on_complete branches are declared, those accumulator-completion
+      branches are evaluated through the same selected-branch owner.
     on_timeout: If the handler declares accumulate.on_timeout, the platform executes that branch when the timer fires before
-      completion. Partial accumulated data is available. Typically used to proceed with whatever data arrived.
+      completion. Partial accumulated data is available. Typically used to proceed with whatever data arrived. The platform
+      emits and routes accumulate.timeout intrinsically to the owning handler bucket; authors do not declare accumulate.timeout
+      in subscribes_to to make the timeout branch deliverable.
     idempotency: Duplicate arrivals (same item, same entity) are ignored. The received list is a set, not a list. Crash recovery
       replays events through the same tracking — already-received items are skipped, accumulator state is consistent.
     cleanup: After completion fires and the handler commits, the accumulator record can be archived or deleted. The entity

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -5347,10 +5347,11 @@ engine:
       cancel_state_reachability: >
         For timers started by state:<name> or event:<name>, cancel_on state:<name> must be reachable after every possible
         timer activation context in the authored transition graph. start_on state:<name> uses that state as the activation
-        context. start_on event:<name> derives activation states from same-flow handlers for that event: explicit advances_to,
-        on_complete advances_to, and rules advances_to targets are post-handler activation states; a handler with no authored
-        state target uses its authored source states. The timer's own fire event is not valid proof of a pre-fire cancellation
-        path. The activation state itself is not sufficient proof unless an authored post-activation transition reaches the
+        context. start_on event:<name> derives activation states from same-flow handlers for that event: handler-level advances_to,
+        on_complete advances_to, rules advances_to, accumulate.on_complete advances_to, and accumulate.on_timeout advances_to
+        targets are post-handler activation states; a handler with no authored state target uses its authored source states.
+        The timer's own fire event is not valid proof of a pre-fire cancellation path. The activation state itself is not
+        sufficient proof unless an authored post-activation transition reaches the
         cancel state from that activation state. Missing activation proof or any derived activation state with no
         post-activation path is a boot error. start_on boot state-cancel reachability is left to explicit boot-start
         scheduling semantics and is not closed by this rule.
@@ -7543,6 +7544,7 @@ flow_model:
         graph_rule: >
           `swarm describe --graph` renders the per-flow lifecycle stage graph
           from the canonical lowered lifecycle owner and the existing transition
+          carriers, including accumulator completion and timeout `advances_to`
           carriers. It must show flow namespace, nodes, initial/terminal markers,
           edges, and edge source. It is projection-only and MUST NOT introduce a
           second transition-authoring owner.
@@ -13426,6 +13428,7 @@ static_analyzer:
     - handler_specification.handler_fields.advances_to
     - handler_specification.handler_fields.on_complete
     - handler_specification.handler_fields.rules
+    - handler_specification.handler_fields.accumulate
     - contract_formats.flow_schema
     scope:
       description: For every stateful flow, verify that each declared state is reachable from initial_state in the authored
@@ -13444,6 +13447,10 @@ static_analyzer:
         rule: on_complete branches with advances_to contribute possible edges.
       rules_branches:
         rule: rules branches with advances_to contribute possible edges.
+      accumulate_on_complete_branches:
+        rule: accumulate.on_complete branches with advances_to contribute possible edges.
+      accumulate_on_timeout_branch:
+        rule: accumulate.on_timeout with advances_to contributes a possible edge.
     source_state_derivation:
       create_entity_handlers:
         rule: create_entity handlers source from initial_state only.


### PR DESCRIPTION
## Summary

Closes #1873.

This PR canonicalizes authored handler `advances_to` transition carriers across the supported verifier, contract semantics, timer graph, and describe graph surfaces.

Changed carrier set:
- `handler.advances_to`
- `handler.on_complete[*].advances_to`
- `handler.rules[*].advances_to`
- `handler.accumulate.on_complete[*].advances_to`
- `handler.accumulate.on_timeout.advances_to`

## Governing Refs / Context

Exact authoritative spec refs updated in this PR:
- `platform-spec.yaml` `static_analyzer.slice_4_state_machine_reachability.transition_carriers`
- `platform-spec.yaml` `engine.timer_model.boot_validation.cancel_state_reachability`
- `platform-spec.yaml` `flow_model.authoring_tooling.expand_minimize_tooling.graph_rule`

Binding issue/audit context:
- #1873 issue body
- #1873 `Pre-Implementation Coverage Audit — Gate A Repair 2 / Describe Graph Widening`
- #1873 lead gate outcome: `approved`

## Semantic Migration

New canonical owner:
- `internal/runtime/contracts.HandlerAdvanceCarriers` / `HandlerAdvanceTargets`

Old non-authoritative paths now invalid:
- `internal/runtime/bootverify` private reachability target list
- `internal/runtime/bootverify` separate state-machine target-validation target list
- `internal/runtime/contracts` nested-only accumulator completion transition derivation
- `internal/runtime/authoringview` local handler/top-level-complete/rules-only stage graph derivation

Production paths checked for surviving old behavior:
- bootverify reachability graph and state-machine target validation now delegate to the contracts owner
- timer activation/cancel graph paths execute through the corrected bootverify graph/target path
- contract transition derivation consumes the contracts carrier owner
- `authoringview.Build` / `swarm describe --graph` consumes the contracts carrier owner
- runtime/pipeline and flow-boundary lifecycle classifiers were checked and already enumerate accumulator completion/timeout branches; they are not the transition-carrier projection owner

Migration complete: yes, for the approved #1873 working class.

## Validation

Ran after rebasing onto current `origin/master`:

```sh
SWARM_TEST_POSTGRES_DSN='host=127.0.0.1 port=5432 user=youmew dbname=postgres sslmode=disable' PGPASSWORD=postgres go test -count=1 ./...
```

Focused supported-surface coverage included:
- `cmd/swarm` verify command accepts the accumulator-carrier fixture with `review` / `timed_out` reachable.
- `cmd/swarm describe --graph` renders `handler.accumulate.on_complete` and `handler.accumulate.on_timeout` edges.
- bootverify reachability covers accumulator completion and timeout.
- bootverify target validation rejects invalid accumulator timeout targets.
- timer activation/cancel graph consumers use the same corrected carrier path.
- contract semantics derives both top-level and nested accumulator completion transitions when both exist.
