### PR TITLE
[agent-e][issue #1821] Add CLI output conformance registry

### DIFF
--- a/cmd/swarm/cli_output_conformance_registry_test.go
+++ b/cmd/swarm/cli_output_conformance_registry_test.go
@@ -22,6 +22,7 @@ type cliOutputConformanceRegistryRow struct {
 	Classification string
 	ExceptionRule  string
 	OwnerIssue     string
+	FactOwner      string
 	Reason         string
 	Node           *yaml.Node
 }
@@ -118,6 +119,14 @@ var cliOutputGrandfatheredNonSharedRows = map[string]string{
 	"swarm context prune":          "split",
 }
 
+var cliOutputExpectedFactOwners = map[string]string{
+	"swarm bundle list":     "/v1/rpc bundle.list",
+	"swarm bundle show":     "/v1/rpc bundle.get",
+	"swarm bundle agents":   "/v1/rpc bundle.agents",
+	"swarm bundle register": "/v1/rpc bundle.register",
+	"swarm bundle delete":   "/v1/rpc bundle.delete",
+}
+
 func cliOutputConformanceRegistryRows(t *testing.T) map[string]cliOutputConformanceRegistryRow {
 	t.Helper()
 	spec := loadCLISpecification(t)
@@ -150,6 +159,7 @@ func cliOutputConformanceRegistryRows(t *testing.T) map[string]cliOutputConforma
 			Classification: strings.TrimSpace(cliOutputRegistryScalar(node, "classification")),
 			ExceptionRule:  strings.TrimSpace(cliOutputRegistryScalar(node, "exception_rule")),
 			OwnerIssue:     strings.TrimSpace(cliOutputRegistryScalar(node, "owner_issue")),
+			FactOwner:      strings.TrimSpace(cliOutputRegistryScalar(node, "fact_owner")),
 			Reason:         strings.TrimSpace(cliOutputRegistryScalar(node, "reason")),
 			Node:           node,
 		}
@@ -271,6 +281,9 @@ func TestCLIOutputConformanceRegistryRowsAreWellFormed(t *testing.T) {
 					t.Errorf("%s: shared_output row missing %s", row.Key, key)
 				}
 			}
+			if want := cliOutputExpectedFactOwners[command]; want != "" && row.FactOwner != want {
+				t.Errorf("%s: shared_output command %q fact_owner = %q, want %q", row.Key, command, row.FactOwner, want)
+			}
 		case "exception":
 			if got := cliOutputGrandfatheredNonSharedRows[command]; got != row.Classification {
 				t.Errorf("%s: exception command %q is not in the grandfathered non-shared allowlist with classification exception", row.Key, command)
@@ -309,6 +322,15 @@ func TestCLIOutputConformanceRegistryRowsAreWellFormed(t *testing.T) {
 	}
 }
 
+func TestCLIOutputConformanceExceptionRulesDoNotContradictRegistry(t *testing.T) {
+	rows := cliOutputConformanceRegistryRows(t)
+	for _, command := range cliOutputAbsentCommandRows(t) {
+		if _, ok := rows["swarm "+command]; ok {
+			t.Errorf("absent_command_rows lists %q, but output_conformance_registry has a visible row for %q", command, "swarm "+command)
+		}
+	}
+}
+
 func cliOutputExceptionRuleNames(t *testing.T) map[string]bool {
 	t.Helper()
 	spec := loadCLISpecification(t)
@@ -319,6 +341,30 @@ func cliOutputExceptionRuleNames(t *testing.T) map[string]bool {
 	out := map[string]bool{}
 	for i := 0; i+1 < len(rules.Content); i += 2 {
 		out[rules.Content[i].Value] = true
+	}
+	return out
+}
+
+func cliOutputAbsentCommandRows(t *testing.T) []string {
+	t.Helper()
+	spec := loadCLISpecification(t)
+	foundations := driftMappingValue(spec, "foundations")
+	outputContract := driftMappingValue(foundations, "output_contract")
+	exceptionRules := driftMappingValue(outputContract, "exception_rules")
+	absent := driftMappingValue(exceptionRules, "absent_command_rows")
+	if absent == nil || absent.Kind != yaml.MappingNode {
+		t.Fatal("output_contract.exception_rules.absent_command_rows not found")
+	}
+	commands := driftMappingValue(absent, "commands")
+	if commands == nil {
+		return nil
+	}
+	if commands.Kind != yaml.SequenceNode {
+		t.Fatalf("output_contract.exception_rules.absent_command_rows.commands kind = %v, want sequence", commands.Kind)
+	}
+	out := make([]string, 0, len(commands.Content))
+	for _, command := range commands.Content {
+		out = append(out, strings.TrimSpace(command.Value))
 	}
 	return out
 }

--- a/cmd/swarm/cli_output_conformance_registry_test.go
+++ b/cmd/swarm/cli_output_conformance_registry_test.go
@@ -1,0 +1,405 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
+)
+
+type cliOutputConformanceRegistryRow struct {
+	Key            string
+	Command        string
+	Classification string
+	ExceptionRule  string
+	OwnerIssue     string
+	Reason         string
+	Node           *yaml.Node
+}
+
+type cliOutputSharedOwnerProof struct {
+	Constructor string
+	Runner      string
+}
+
+var cliOutputSharedOwnerProofs = map[string]cliOutputSharedOwnerProof{
+	"swarm version":           {Constructor: "newVersionCommand", Runner: "runVersionCommand"},
+	"swarm verify":            {Constructor: "newVerifyCommand", Runner: "runVerifyCommandWithOutput"},
+	"swarm run list":          {Constructor: "newRunsCommand", Runner: "runDiagnosticRunListCommand"},
+	"swarm run status":        {Constructor: "newStatusCommand", Runner: "runDiagnosticRunCommand"},
+	"swarm run fork":          {Constructor: "newForkCommand", Runner: "runForkCommand"},
+	"swarm health":            {Constructor: "newHealthCommand", Runner: "runDiagnosticHealthCommand"},
+	"swarm conversation list": {Constructor: "newConversationsListCommand", Runner: "runConversationsListCommand"},
+	"swarm conversation view": {Constructor: "newConversationViewCommand", Runner: "runConversationViewCommand"},
+	"swarm conversation turn": {Constructor: "newConversationTurnCommand", Runner: "runConversationTurnCommand"},
+	"swarm bundle list":       {Constructor: "newBundleListCommand", Runner: "runBundleListCommand"},
+	"swarm bundle show":       {Constructor: "newBundleShowCommand", Runner: "runBundleShowCommand"},
+	"swarm bundle agents":     {Constructor: "newBundleAgentsCommand", Runner: "runBundleAgentsCommand"},
+	"swarm bundle register":   {Constructor: "newBundleRegisterCommand", Runner: "runBundleRegisterCommand"},
+	"swarm bundle delete":     {Constructor: "newBundleDeleteCommand", Runner: "runBundleDeleteCommand"},
+	"swarm forkchat new":      {Constructor: "newForkChatNewCommand", Runner: "runForkChatNewCommand"},
+	"swarm forkchat resume":   {Constructor: "newForkChatResumeCommand", Runner: "runForkChatResumeCommand"},
+	"swarm forkchat list":     {Constructor: "newForkChatListCommand", Runner: "runForkChatListCommand"},
+	"swarm forkchat view":     {Constructor: "newForkChatViewCommand", Runner: "runForkChatViewCommand"},
+	"swarm forkchat delete":   {Constructor: "newForkChatDeleteCommand", Runner: "runForkChatDeleteCommand"},
+	"swarm describe":          {Constructor: "newDescribeCommand", Runner: "runDescribeCommandWithOutput"},
+}
+
+var cliOutputGrandfatheredNonSharedRows = map[string]string{
+	"swarm":                        "exception",
+	"swarm help":                   "exception",
+	"swarm completion":             "exception",
+	"swarm doctor":                 "split",
+	"swarm test":                   "split",
+	"swarm workspace":              "exception",
+	"swarm workspace build":        "split",
+	"swarm secrets":                "exception",
+	"swarm secrets set":            "split",
+	"swarm secrets list":           "split",
+	"swarm secrets check":          "split",
+	"swarm secrets rm":             "split",
+	"swarm connections":            "exception",
+	"swarm connections connect":    "split",
+	"swarm connections callback":   "split",
+	"swarm connections status":     "split",
+	"swarm connections disconnect": "split",
+	"swarm serve":                  "exception",
+	"swarm run":                    "exception",
+	"swarm run start":              "split",
+	"swarm run trace":              "split",
+	"swarm mailbox":                "exception",
+	"swarm mailbox list":           "split",
+	"swarm mailbox view":           "split",
+	"swarm mailbox approve":        "split",
+	"swarm mailbox reject":         "split",
+	"swarm mailbox defer":          "split",
+	"swarm control":                "exception",
+	"swarm control pause":          "split",
+	"swarm control continue":       "split",
+	"swarm control stop":           "split",
+	"swarm control nuke":           "split",
+	"swarm agent":                  "exception",
+	"swarm agent list":             "split",
+	"swarm agent view":             "split",
+	"swarm agent diagnose":         "split",
+	"swarm agent deliveries":       "split",
+	"swarm agent restart":          "split",
+	"swarm agent replay":           "split",
+	"swarm agent replay-backlog":   "split",
+	"swarm agent directive":        "split",
+	"swarm event":                  "exception",
+	"swarm event list":             "split",
+	"swarm event follow":           "split",
+	"swarm event view":             "split",
+	"swarm event replay":           "split",
+	"swarm event publish":          "split",
+	"swarm conversation":           "exception",
+	"swarm bundle":                 "exception",
+	"swarm bundle build":           "split",
+	"swarm forkchat":               "exception",
+	"swarm entity":                 "exception",
+	"swarm entity list":            "split",
+	"swarm entity view":            "split",
+	"swarm entity aggregate":       "split",
+	"swarm logs":                   "split",
+	"swarm incidents":              "split",
+	"swarm context":                "exception",
+	"swarm context current":        "split",
+	"swarm context list":           "split",
+	"swarm context prune":          "split",
+}
+
+func cliOutputConformanceRegistryRows(t *testing.T) map[string]cliOutputConformanceRegistryRow {
+	t.Helper()
+	spec := loadCLISpecification(t)
+	foundations := driftMappingValue(spec, "foundations")
+	outputContract := driftMappingValue(foundations, "output_contract")
+	commandSupport := driftMappingValue(outputContract, "command_support")
+	registry := driftMappingValue(commandSupport, "output_conformance_registry")
+	if registry == nil {
+		t.Fatal("output_conformance_registry not found")
+	}
+	rows := driftMappingValue(registry, "rows")
+	if rows == nil || rows.Kind != yaml.MappingNode {
+		t.Fatal("output_conformance_registry.rows not found")
+	}
+	out := map[string]cliOutputConformanceRegistryRow{}
+	for i := 0; i+1 < len(rows.Content); i += 2 {
+		key := rows.Content[i].Value
+		node := rows.Content[i+1]
+		command := strings.TrimSpace(cliOutputRegistryScalar(node, "command"))
+		if command == "" {
+			t.Errorf("registry row %s: missing command", key)
+			continue
+		}
+		if _, exists := out[command]; exists {
+			t.Errorf("registry command %q appears more than once", command)
+		}
+		out[command] = cliOutputConformanceRegistryRow{
+			Key:            key,
+			Command:        command,
+			Classification: strings.TrimSpace(cliOutputRegistryScalar(node, "classification")),
+			ExceptionRule:  strings.TrimSpace(cliOutputRegistryScalar(node, "exception_rule")),
+			OwnerIssue:     strings.TrimSpace(cliOutputRegistryScalar(node, "owner_issue")),
+			Reason:         strings.TrimSpace(cliOutputRegistryScalar(node, "reason")),
+			Node:           node,
+		}
+	}
+	return out
+}
+
+func cliOutputRegistryScalar(node *yaml.Node, key string) string {
+	value := driftMappingValue(node, key)
+	if value == nil {
+		return ""
+	}
+	return value.Value
+}
+
+func visibleCLICommandPaths(t *testing.T) map[string]*cobra.Command {
+	t.Helper()
+	var out, errOut bytes.Buffer
+	root := newRootCommand(context.Background(), t.TempDir(), &out, &errOut)
+	root.InitDefaultHelpCmd()
+	paths := map[string]*cobra.Command{}
+	var walk func(cmd *cobra.Command, path []string)
+	walk = func(cmd *cobra.Command, path []string) {
+		if cmd.Hidden {
+			return
+		}
+		key := strings.Join(path, " ")
+		paths[key] = cmd
+		for _, child := range cmd.Commands() {
+			if child.Hidden {
+				continue
+			}
+			walk(child, append(path, child.Name()))
+		}
+	}
+	walk(root, []string{root.Name()})
+	return paths
+}
+
+func TestCLIOutputConformanceRegistryCoversVisibleCommandTree(t *testing.T) {
+	rows := cliOutputConformanceRegistryRows(t)
+	visible := visibleCLICommandPaths(t)
+	for command := range visible {
+		if _, ok := rows[command]; !ok {
+			t.Errorf("visible command %q missing from output_conformance_registry", command)
+		}
+	}
+	for command := range rows {
+		if _, ok := visible[command]; !ok {
+			t.Errorf("output_conformance_registry command %q is not visible in the Cobra tree", command)
+		}
+	}
+}
+
+func TestCLIOutputConformanceRegistryCoversImplementedCommandCatalogRows(t *testing.T) {
+	rows := cliOutputConformanceRegistryRows(t)
+	catalog := driftMappingValue(loadCLISpecification(t), "command_catalog")
+	if catalog == nil {
+		t.Fatal("command_catalog not found")
+	}
+	checked := 0
+	for i := 0; i+1 < len(catalog.Content); i += 2 {
+		rowName := catalog.Content[i].Value
+		row := catalog.Content[i+1]
+		command := driftMappingValue(row, "command")
+		status := driftMappingValue(row, "implementation_status")
+		if command == nil || status == nil {
+			continue
+		}
+		if !strings.HasPrefix(status.Value, "implemented") && status.Value != "partial" {
+			continue
+		}
+		if rowName == "root" {
+			checked++
+			if _, ok := rows["swarm"]; !ok {
+				t.Errorf("command_catalog.root: implemented command %q missing output_conformance_registry row", command.Value)
+			}
+			continue
+		}
+		path := commandPathTokens(command.Value)
+		if len(path) == 0 {
+			t.Errorf("command_catalog.%s: cannot derive command path from %q", rowName, command.Value)
+			continue
+		}
+		checked++
+		registryCommand := "swarm " + strings.Join(path, " ")
+		if _, ok := rows[registryCommand]; !ok {
+			t.Errorf("command_catalog.%s: implemented command %q missing output_conformance_registry row", rowName, registryCommand)
+		}
+	}
+	if checked < 40 {
+		t.Fatalf("implemented command_catalog rows checked = %d, want >= 40; row detection broken", checked)
+	}
+}
+
+func TestCLIOutputConformanceRegistryRowsAreWellFormed(t *testing.T) {
+	rows := cliOutputConformanceRegistryRows(t)
+	visible := visibleCLICommandPaths(t)
+	exceptionRules := cliOutputExceptionRuleNames(t)
+	issueRef := regexp.MustCompile(`^#\d+$`)
+	for command, row := range rows {
+		switch row.Classification {
+		case "shared_output":
+			if _, ok := cliOutputGrandfatheredNonSharedRows[command]; ok {
+				t.Errorf("%s: command %q migrated to shared_output but still appears in the non-shared grandfather list", row.Key, command)
+			}
+			cmd := visible[command]
+			if cmd == nil {
+				t.Errorf("%s: shared_output row does not resolve to a visible command", row.Key)
+				continue
+			}
+			for _, flag := range []string{cliOutputJSONFlag, cliOutputQuietFlag, cliOutputNoColorFlag} {
+				if cmd.Flags().Lookup(flag) == nil {
+					t.Errorf("%s: shared_output command %q missing --%s flag from the shared output owner", row.Key, command, flag)
+				}
+			}
+			for _, key := range []string{"fact_owner", "json_shape", "quiet_values"} {
+				if driftMappingValue(row.Node, key) == nil {
+					t.Errorf("%s: shared_output row missing %s", row.Key, key)
+				}
+			}
+		case "exception":
+			if got := cliOutputGrandfatheredNonSharedRows[command]; got != row.Classification {
+				t.Errorf("%s: exception command %q is not in the grandfathered non-shared allowlist with classification exception", row.Key, command)
+			}
+			if row.ExceptionRule == "" {
+				t.Errorf("%s: exception row missing exception_rule", row.Key)
+			} else if !exceptionRules[row.ExceptionRule] {
+				t.Errorf("%s: exception_rule %q is not declared under output_contract.exception_rules", row.Key, row.ExceptionRule)
+			}
+			if row.OwnerIssue != "" {
+				t.Errorf("%s: exception row must not carry owner_issue %q", row.Key, row.OwnerIssue)
+			}
+		case "split":
+			if got := cliOutputGrandfatheredNonSharedRows[command]; got != row.Classification {
+				t.Errorf("%s: split command %q is not in the grandfathered non-shared allowlist with classification split", row.Key, command)
+			}
+			if !issueRef.MatchString(row.OwnerIssue) {
+				t.Errorf("%s: split row owner_issue = %q, want #<digits>", row.Key, row.OwnerIssue)
+			}
+			if strings.TrimSpace(row.Reason) == "" {
+				t.Errorf("%s: split row missing reason", row.Key)
+			}
+		default:
+			t.Errorf("%s: unknown classification %q", row.Key, row.Classification)
+		}
+	}
+	for command, classification := range cliOutputGrandfatheredNonSharedRows {
+		row, ok := rows[command]
+		if !ok {
+			t.Errorf("grandfathered non-shared command %q has no registry row", command)
+			continue
+		}
+		if row.Classification != classification {
+			t.Errorf("grandfathered non-shared command %q classification = %q, want %q", command, row.Classification, classification)
+		}
+	}
+}
+
+func cliOutputExceptionRuleNames(t *testing.T) map[string]bool {
+	t.Helper()
+	spec := loadCLISpecification(t)
+	rules := driftMappingValue(driftMappingValue(driftMappingValue(spec, "foundations"), "output_contract"), "exception_rules")
+	if rules == nil || rules.Kind != yaml.MappingNode {
+		t.Fatal("output_contract.exception_rules not found")
+	}
+	out := map[string]bool{}
+	for i := 0; i+1 < len(rules.Content); i += 2 {
+		out[rules.Content[i].Value] = true
+	}
+	return out
+}
+
+func TestCLIOutputConformanceSharedRowsConsumeSharedOwner(t *testing.T) {
+	rows := cliOutputConformanceRegistryRows(t)
+	calls := cliOutputFunctionCalls(t)
+	for command, row := range rows {
+		proof, hasProof := cliOutputSharedOwnerProofs[command]
+		if row.Classification == "shared_output" {
+			if !hasProof {
+				t.Errorf("%s: shared_output command %q missing shared owner proof metadata", row.Key, command)
+				continue
+			}
+			if !calls[proof.Constructor]["bindCLIOutputFlags"] {
+				t.Errorf("%s: constructor %s does not call bindCLIOutputFlags", row.Key, proof.Constructor)
+			}
+			if !calls[proof.Runner]["renderCLIOutput"] {
+				t.Errorf("%s: runner %s does not call renderCLIOutput", row.Key, proof.Runner)
+			}
+			continue
+		}
+		if hasProof {
+			t.Errorf("%s: non-shared command %q has stale shared owner proof metadata", row.Key, command)
+		}
+	}
+	for command := range cliOutputSharedOwnerProofs {
+		row, ok := rows[command]
+		if !ok {
+			t.Errorf("shared owner proof for %q has no registry row", command)
+			continue
+		}
+		if row.Classification != "shared_output" {
+			t.Errorf("shared owner proof for %q points at %s row", command, row.Classification)
+		}
+	}
+}
+
+func cliOutputFunctionCalls(t *testing.T) map[string]map[string]bool {
+	t.Helper()
+	root := driftTestRepoRoot(t)
+	dir := filepath.Join(root, "cmd", "swarm")
+	calls := map[string]map[string]bool{}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read %s: %v", dir, err)
+	}
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		path := filepath.Join(dir, name)
+		file, err := parser.ParseFile(token.NewFileSet(), path, nil, 0)
+		if err != nil {
+			t.Fatalf("parse %s: %v", path, err)
+		}
+		for _, decl := range file.Decls {
+			fn, ok := decl.(*ast.FuncDecl)
+			if !ok || fn.Body == nil {
+				continue
+			}
+			if calls[fn.Name.Name] == nil {
+				calls[fn.Name.Name] = map[string]bool{}
+			}
+			ast.Inspect(fn.Body, func(node ast.Node) bool {
+				call, ok := node.(*ast.CallExpr)
+				if !ok {
+					return true
+				}
+				ident, ok := call.Fun.(*ast.Ident)
+				if !ok {
+					return true
+				}
+				switch ident.Name {
+				case "bindCLIOutputFlags", "renderCLIOutput":
+					calls[fn.Name.Name][ident.Name] = true
+				}
+				return true
+			})
+		}
+	}
+	return calls
+}

--- a/internal/apispec/cli_topology_spec_test.go
+++ b/internal/apispec/cli_topology_spec_test.go
@@ -75,9 +75,10 @@ func TestCLICommandCatalogRowsDeclareContractBearingGroups(t *testing.T) {
 func TestCLIVerifyJSONShapeIncludesStructuredFailureFindings(t *testing.T) {
 	outputContract := mustMappingValue(t, mustMappingValue(t, cliSpecification(t), "foundations"), "output_contract")
 	commandSupport := mustMappingValue(t, outputContract, "command_support")
-	implemented := mustMappingValue(t, commandSupport, "implemented_output_mode_first_slice")
-	consumers := mustMappingValue(t, implemented, "consumers")
-	verify := mustMappingValue(t, consumers, "verify")
+	registry := mustMappingValue(t, commandSupport, "output_conformance_registry")
+	rows := mustMappingValue(t, registry, "rows")
+	verify := mustMappingValue(t, rows, "verify")
+	assertScalarValue(t, mustMappingValue(t, verify, "classification"), "shared_output")
 	jsonShape := mustMappingValue(t, verify, "json_shape")
 
 	for _, want := range []string{
@@ -107,6 +108,38 @@ func TestCLIVerifyJSONShapeIncludesStructuredFailureFindings(t *testing.T) {
 	} {
 		assertScalarContains(t, mustMappingValue(t, humanStreams, "stderr"), want)
 	}
+}
+
+func TestCLIOutputConformanceRegistryPromotedAsCurrentStateOwner(t *testing.T) {
+	outputContract := mustMappingValue(t, mustMappingValue(t, cliSpecification(t), "foundations"), "output_contract")
+	commandSupport := mustMappingValue(t, outputContract, "command_support")
+	if mappingValue(commandSupport, "currently_implemented_consumers") != nil {
+		t.Fatal("command_support.currently_implemented_consumers must not remain as a second output-conformance registry")
+	}
+	if mappingValue(commandSupport, "implemented_output_mode_first_slice") != nil {
+		t.Fatal("command_support.implemented_output_mode_first_slice must not remain as a second output-conformance registry")
+	}
+	if mappingValue(commandSupport, "implemented_color_policy_first_slice") != nil {
+		t.Fatal("command_support.implemented_color_policy_first_slice must not remain as a second output-conformance registry")
+	}
+
+	registry := mustMappingValue(t, commandSupport, "output_conformance_registry")
+	assertScalarValue(t, mustMappingValue(t, registry, "promoted_by"), "#1821")
+	assertScalarValue(t, mustMappingValue(t, registry, "canonical_owner"), "platform-spec.yaml#cli_specification.foundations.output_contract.command_support.output_conformance_registry")
+	assertScalarValue(t, mustMappingValue(t, registry, "implementation_owner"), "cmd/swarm/cli_output_conformance_registry_test.go")
+	assertScalarContains(t, mustMappingValue(t, registry, "rule"), "single living current-state authority")
+	assertScalarContains(t, mustMappingValue(t, mustMappingValue(t, registry, "ratchet_rules"), "full_catalog_coverage"), "Unclassified rows fail closed")
+	assertScalarContains(t, mustMappingValue(t, mustMappingValue(t, registry, "ratchet_rules"), "no_output_byte_changes"), "does not change command output bytes")
+
+	values := mustMappingValue(t, registry, "classification_values")
+	for _, key := range []string{"shared_output", "exception", "split"} {
+		if mappingValue(values, key) == nil {
+			t.Fatalf("output_conformance_registry.classification_values missing %s", key)
+		}
+	}
+
+	color := mustMappingValue(t, outputContract, "color_control")
+	assertScalarContains(t, mustMappingValue(t, color, "consumer_registry"), "output_conformance_registry")
 }
 
 func TestCLIDiagnosticConventionPromotedToOutputContract(t *testing.T) {

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -14737,15 +14737,11 @@ cli_specification:
           log_level: >
             `--log-level`, config-file `log_level`, and universal/repeatable verbosity are not color controls.
             Their source-of-truth disposition is governed by cli_specification.foundations.cli_logging_policy.
-        consumers:
-        - version
-        - verify
-        - health
-        - runs
-        - status
-        - conversations_list
-        - conversation_view
-        - conversation_turn
+        consumer_registry: >
+          Current color-policy consumers are exactly
+          `cli_specification.foundations.output_contract.command_support.output_conformance_registry.rows`
+          entries classified as `shared_output`. Do not maintain a second consumer list here; the registry is the
+          living current-state owner.
       stdout_stderr_boundary: >
         Successful load-bearing output renders only to stdout. Errors, warnings, retired-namespace migration text,
         validation failures, auth failures, transport/API failures, and diagnostics render to stderr under
@@ -14889,137 +14885,481 @@ cli_specification:
           All implemented, non-retired CLI v2 command rows are output-mode eligible unless this contract or their
           command row declares an exception. Eligibility means a later implementation slice must either consume the
           shared output owner for the row or explicitly split the row before adding output-mode behavior.
-        currently_implemented_consumers:
-        - version
-        - verify
-        - runs
-        - status
-        - trace
-        - mailbox_list
-        - mailbox_view
-        - mailbox_approve
-        - mailbox_reject
-        - mailbox_defer
-        - health
-        - control_pause
-        - control_continue
-        - control_stop
-        - control_nuke
-        - agents_list
-        - agent_view
-        - agent_restart
-        - agent_replay
-        - agent_replay_backlog
-        - agent_directive
-        - events_list
-        - events_follow
-        - event_view
-        - event_replay
-        - event_publish
-        - logs
-        - incidents
-        - entities_list
-        - entity_view
-        - entity_aggregate
-        - conversations_list
-        - conversation_view
-        - conversation_turn
-        - run
-        implemented_output_mode_first_slice:
-          implemented_by: '#920'
-          failure_class: runtime.cli.v2.output_mode_renderer_first_slice_diagnostic_local_conversation_read_consumers
-          owner: cmd/swarm shared output-mode renderer
+        output_conformance_registry:
+          promoted_by: '#1821'
+          canonical_owner: platform-spec.yaml#cli_specification.foundations.output_contract.command_support.output_conformance_registry
+          implementation_owner: cmd/swarm/cli_output_conformance_registry_test.go
           status: implemented
           rule: >
-            These currently implemented consumers accept `--json` and `--quiet` through the shared output-mode
-            owner. `--json` renders exactly one JSON document plus newline using canonical local/API result structs.
-            `--quiet` renders only the declared load-bearing values below. `--json --quiet` fails with CLI validation
-            exit 2 before local contract verification, API calls, runtime boot, or other side effects.
-          consumers:
+            This registry is the single living current-state authority for CLI command output-route conformance.
+            Every visible command surface must be classified as exactly one of `shared_output`, `exception`, or
+            `split`. The registry is a ratchet, not a migration: adding a visible command without a row fails
+            closed, new commands default to `shared_output`, and any command whose output would need to change to
+            pass must stay `split` with an owner issue until that owner lands.
+          classification_values:
+            shared_output: >
+              The command consumes the shared `cmd/swarm` output-mode/color owner for successful output. It accepts
+              `--json`, `--quiet`, and `--no-color` through the shared helper path.
+            exception: >
+              The command is an explicit help/process/retired-style surface that does not consume output modes and
+              is governed by an exception rule.
+            split: >
+              The command is implemented, but shared-output route-through, table rendering, argument formatting,
+              ID resolution, vocabulary, or another output class remains tracked by a named owner issue. Split rows
+              are removal candidates; they must shrink as owner children land.
+          ratchet_rules:
+            full_catalog_coverage: >
+              The conformance guard must cover every implemented, non-retired command_catalog row and every visible
+              Cobra command path. Unclassified rows fail closed.
+            new_command_default: >
+              New command paths must be classified as `shared_output` unless an explicit review decision adds a
+              narrower exception or split owner. Exception and split growth is reviewable churn, not a silent default.
+            split_owner_required: >
+              A split row must cite a real owner issue. A missing canonical owner is classified as split; the guard
+              must not require a missing formatter/resolver by implication.
+            no_output_byte_changes: >
+              This registry slice does not change command output bytes. A command that needs byte changes to pass
+              remains split and is migrated under its owner issue.
+          rows:
+            root:
+              command: swarm
+              classification: exception
+              exception_rule: root_help_completion
+            help:
+              command: swarm help
+              classification: exception
+              exception_rule: root_help_completion
+            completion:
+              command: swarm completion
+              classification: exception
+              exception_rule: root_help_completion
             version:
+              command: swarm version
+              classification: shared_output
               fact_owner: local binary metadata from injected release metadata, Go build info, and embedded platform-spec version; /v1/rpc health.check when --server is supplied
               json_shape: local binary metadata object with binary_version, module_version, platform_version, commit, built, go_version, goos, and goarch; with --server includes a server health.check object
               quiet_values:
               - binary_version
               - server_bundle_fingerprint when --server is supplied
+            doctor:
+              command: swarm doctor
+              classification: split
+              owner_issue: '#1712'
+              reason: doctor has typed diagnostic output and JSON mode, but has not been migrated to the shared successful-output mode owner.
+            test:
+              command: swarm test
+              classification: split
+              owner_issue: '#1712'
+              reason: deterministic scenario-runner output is implemented, but output-mode route-through remains part of the CLI output umbrella.
+            workspace:
+              command: swarm workspace
+              classification: exception
+              exception_rule: group_help
+            workspace_build:
+              command: swarm workspace build
+              classification: split
+              owner_issue: '#1712'
+              reason: workspace image build emits process-progress text and has no shared output-mode owner yet.
+            secrets:
+              command: swarm secrets
+              classification: exception
+              exception_rule: group_help
+            secrets_set:
+              command: swarm secrets set
+              classification: split
+              owner_issue: '#1712'
+              reason: local secret metadata output has not been migrated to the shared output-mode owner.
+            secrets_list:
+              command: swarm secrets list
+              classification: split
+              owner_issue: '#1814'
+              reason: secret list table/default text remains on the table-renderer migration path.
+            secrets_check:
+              command: swarm secrets check
+              classification: split
+              owner_issue: '#1712'
+              reason: manual JSON/default text remains outside the shared output-mode owner.
+            secrets_rm:
+              command: swarm secrets rm
+              classification: split
+              owner_issue: '#1712'
+              reason: local secret metadata output has not been migrated to the shared output-mode owner.
+            connections:
+              command: swarm connections
+              classification: exception
+              exception_rule: group_help
+            connections_connect:
+              command: swarm connections connect
+              classification: split
+              owner_issue: '#1712'
+              reason: managed-credential command output has not been migrated to the shared output-mode owner.
+            connections_callback:
+              command: swarm connections callback
+              classification: split
+              owner_issue: '#1712'
+              reason: managed-credential command output has not been migrated to the shared output-mode owner.
+            connections_status:
+              command: swarm connections status
+              classification: split
+              owner_issue: '#1814'
+              reason: status table/default text remains on the table-renderer migration path.
+            connections_disconnect:
+              command: swarm connections disconnect
+              classification: split
+              owner_issue: '#1712'
+              reason: managed-credential command output has not been migrated to the shared output-mode owner.
+            serve:
+              command: swarm serve
+              classification: exception
+              exception_rule: serve_daemon_process
+            run_group:
+              command: swarm run # live run command group help
+              classification: exception
+              exception_rule: group_help
+            run:
+              command: swarm run start
+              classification: split
+              owner_issue: '#1712'
+              reason: run start foreground/follow output is outside this zero-byte-change registry slice.
             verify:
+              command: swarm verify
+              classification: shared_output
               fact_owner: local contract verification
               json_shape: >
                 object with ok, contracts, workspace_backend, errors, warnings, and lint_evidence. `errors`, `warnings`,
                 and `lint_evidence` are arrays of structured boot verification findings with canonical `check_id`,
                 `severity`, `location`, and `message` fields plus optional additive `remediation` and `evidence` fields.
-                Existing fields are stable and MUST NOT be renamed; `message` remains the problem text. `--json` renders this same object for structured boot
-                verification failures with `ok: false` instead of requiring consumers to parse human stderr.
+                Existing fields are stable and MUST NOT be renamed; `message` remains the problem text. `--json` renders
+                this same object for structured boot verification failures with `ok: false` instead of requiring consumers
+                to parse human stderr.
               human_text_streams:
                 stdout: "successful load-bearing `verify ok: contracts=...` result only"
                 stderr: "analyzer diagnostics and advisory findings rendered as typed diagnostic lists with `[BLOCKER]`, `[WARN]`, or `[INFO]`; single command-outcome failures still use `ERROR:`/`WARNING:`"
               quiet_values:
               - ok
-            health:
-              fact_owner: /v1/rpc health.check
-              json_shape: health.check result object
-              quiet_values:
-              - healthy when alive, ready, db_ok, and runtime_ok are all true; unhealthy otherwise
             runs:
+              command: swarm run list
+              classification: shared_output
               fact_owner: /v1/rpc run.list
               json_shape: run.list result object
               quiet_values:
               - run_id, one per returned run, in API result order
             status:
+              command: swarm run status
+              classification: shared_output
               fact_owner: /v1/rpc run.diagnose; /v1/rpc run.get when --no-diagnose is supplied
               json_shape: run.diagnose result object, or run.get result object for --no-diagnose
               quiet_values:
               - run_id and operational_state for diagnose mode
               - run_id and run status for --no-diagnose mode
+            trace:
+              command: swarm run trace
+              classification: split
+              owner_issue: '#1814'
+              reason: trace table/follow rendering remains on the shared table/display migration path.
+            run_fork:
+              command: swarm run fork
+              classification: shared_output
+              fact_owner: /v1/rpc run.fork
+              json_shape: run.fork result object
+              quiet_values:
+              - forked run_id
+            mailbox:
+              command: swarm mailbox
+              classification: exception
+              exception_rule: group_help
+            mailbox_list:
+              command: swarm mailbox list
+              classification: split
+              owner_issue: '#1712'
+              reason: mailbox discovery output is implemented but not routed through the shared output-mode owner.
+            mailbox_view:
+              command: swarm mailbox view
+              classification: split
+              owner_issue: '#1712'
+              reason: mailbox detail output is implemented but not routed through the shared output-mode owner.
+            mailbox_approve:
+              command: swarm mailbox approve
+              classification: split
+              owner_issue: '#1712'
+              reason: mailbox decision output is implemented but not routed through the shared output-mode owner.
+            mailbox_reject:
+              command: swarm mailbox reject
+              classification: split
+              owner_issue: '#1712'
+              reason: mailbox decision output is implemented but not routed through the shared output-mode owner.
+            mailbox_defer:
+              command: swarm mailbox defer
+              classification: split
+              owner_issue: '#1712'
+              reason: mailbox decision output is implemented but not routed through the shared output-mode owner.
+            health:
+              command: swarm health
+              classification: shared_output
+              fact_owner: /v1/rpc health.check
+              json_shape: health.check result object
+              quiet_values:
+              - healthy when alive, ready, db_ok, and runtime_ok are all true; unhealthy otherwise
+            control:
+              command: swarm control
+              classification: exception
+              exception_rule: group_help
+            control_pause:
+              command: swarm control pause
+              classification: split
+              owner_issue: '#1712'
+              reason: run-control mutation output is implemented but not routed through the shared output-mode owner.
+            control_continue:
+              command: swarm control continue
+              classification: split
+              owner_issue: '#1712'
+              reason: run-control mutation output is implemented but not routed through the shared output-mode owner.
+            control_stop:
+              command: swarm control stop
+              classification: split
+              owner_issue: '#1712'
+              reason: run-control mutation output is implemented but not routed through the shared output-mode owner.
+            control_nuke:
+              command: swarm control nuke
+              classification: split
+              owner_issue: '#1712'
+              reason: destructive control output is implemented but not routed through the shared output-mode owner.
+            agent:
+              command: swarm agent
+              classification: exception
+              exception_rule: group_help
+            agents_list:
+              command: swarm agent list
+              classification: split
+              owner_issue: '#1814'
+              reason: agent list table/default text remains on the table-renderer migration path.
+            agent_view:
+              command: swarm agent view
+              classification: split
+              owner_issue: '#1817'
+              reason: agent detail vocabulary/sectioning remains on the vocabulary/status-detail migration path.
+            agent_diagnose:
+              command: swarm agent diagnose
+              classification: split
+              owner_issue: '#1817'
+              reason: agent diagnostic vocabulary/sectioning remains on the vocabulary/status-detail migration path.
+            agent_deliveries:
+              command: swarm agent deliveries
+              classification: split
+              owner_issue: '#1817'
+              reason: agent delivery detail vocabulary/sectioning remains on the vocabulary/status-detail migration path.
+            agent_restart:
+              command: swarm agent restart
+              classification: split
+              owner_issue: '#1712'
+              reason: agent mutation output is implemented but not routed through the shared output-mode owner.
+            agent_replay:
+              command: swarm agent replay
+              classification: split
+              owner_issue: '#1712'
+              reason: agent mutation output is implemented but not routed through the shared output-mode owner.
+            agent_replay_backlog:
+              command: swarm agent replay-backlog
+              classification: split
+              owner_issue: '#1712'
+              reason: agent mutation output is implemented but not routed through the shared output-mode owner.
+            agent_directive:
+              command: swarm agent directive
+              classification: split
+              owner_issue: '#1712'
+              reason: agent directive output is implemented but not routed through the shared output-mode owner.
+            event:
+              command: swarm event
+              classification: exception
+              exception_rule: group_help
+            events_list:
+              command: swarm event list
+              classification: split
+              owner_issue: '#1814'
+              reason: event list table/default text remains on the table-renderer migration path.
+            events_follow:
+              command: swarm event follow
+              classification: split
+              owner_issue: '#1712'
+              reason: event follow stream output is implemented but not routed through the shared output-mode owner.
+            event_view:
+              command: swarm event view
+              classification: split
+              owner_issue: '#1814'
+              reason: event detail text remains on the display-policy migration path.
+            event_replay:
+              command: swarm event replay
+              classification: split
+              owner_issue: '#1712'
+              reason: event replay output is implemented but not routed through the shared output-mode owner.
+            event_publish:
+              command: swarm event publish
+              classification: split
+              owner_issue: '#1712'
+              reason: event publish output is implemented but not routed through the shared output-mode owner.
+            conversation:
+              command: swarm conversation
+              classification: exception
+              exception_rule: group_help
             conversations_list:
+              command: swarm conversation list
+              classification: shared_output
               fact_owner: /v1/rpc conversation.list
               json_shape: conversation.list result object
               quiet_values:
               - session_id, one per returned conversation, in API result order
             conversation_view:
+              command: swarm conversation view
+              classification: shared_output
               fact_owner: /v1/rpc conversation.get
               json_shape: conversation.get result object
               quiet_values:
               - session_id
             conversation_turn:
+              command: swarm conversation turn
+              classification: shared_output
               fact_owner: /v1/rpc conversation.get_turn
               json_shape: conversation.get_turn result object
               quiet_values:
               - session_id, turn_index, and outcome/status summary
-        implemented_color_policy_first_slice:
-          implemented_by: '#931'
-          failure_class: runtime.cli.v2.output_color_precedence_for_shared_renderer_consumers
-          owner: cmd/swarm shared output-mode/color policy renderer
-          status: implemented
-          rule: >
-            These consumers accept `--no-color` and consume non-empty `NO_COLOR` through the shared renderer owner.
-            The policy applies only to default human text. Machine-readable JSON/quiet output and error rendering
-            are not rewritten by the color policy. Unsupported surfaces remain fail-closed before side effects.
-          consumers:
-          - version
-          - verify
-          - health
-          - runs
-          - status
-          - conversations_list
-          - conversation_view
-          - conversation_turn
-        implemented_consumer_residuals:
-          logs: >
-            `swarm logs` is implemented for default-text snapshot and follow in #876 and is no longer an absent
-            command row. JSON/quiet/shared-renderer behavior remains governed by the output_contract and may be
-            implemented by the separate #794/#848/#735 output-mode/shared-renderer tail; #876 does not add
-            command-local output-mode flags or semantics.
-          incidents: >
-            `swarm incidents` is implemented for default-text read-only listing in #886 and is no longer an absent
-            command row. JSON/quiet/shared-renderer behavior remains governed by the output_contract and may be
-            implemented by the separate #794/#848/#735 output-mode/shared-renderer tail; #886 does not add
-            command-local output-mode flags or semantics.
-          entities: >
-            `swarm entity list`, `swarm entity view`, and `swarm entity aggregate` are implemented for
-            default-text read-only entity discovery in #892 and are no longer absent command rows. JSON/quiet/shared-renderer
-            behavior remains governed by the output_contract and may be implemented by the separate #794/#848/#735
-            output-mode/shared-renderer tail; #892 does not add command-local output-mode flags or semantics.
+            bundle:
+              command: swarm bundle
+              classification: exception
+              exception_rule: group_help
+            bundle_list:
+              command: swarm bundle list
+              classification: shared_output
+              fact_owner: local bundle inventory
+              json_shape: bundle list result object
+              quiet_values:
+              - bundle_hash, one per returned bundle
+            bundle_show:
+              command: swarm bundle show
+              classification: shared_output
+              fact_owner: local bundle inventory
+              json_shape: bundle detail result object
+              quiet_values:
+              - bundle_hash
+            bundle_agents:
+              command: swarm bundle agents
+              classification: shared_output
+              fact_owner: local bundle inventory
+              json_shape: bundle agents result object
+              quiet_values:
+              - agent id, one per returned agent
+            bundle_build:
+              command: swarm bundle build
+              classification: split
+              owner_issue: '#1712'
+              reason: bundle build report output is not yet routed through the shared output-mode owner.
+            bundle_register:
+              command: swarm bundle register
+              classification: shared_output
+              fact_owner: local bundle catalog registration
+              json_shape: bundle registration result object
+              quiet_values:
+              - bundle_hash
+            bundle_delete:
+              command: swarm bundle delete
+              classification: shared_output
+              fact_owner: local bundle catalog deletion
+              json_shape: bundle delete result object
+              quiet_values:
+              - bundle_hash
+            forkchat:
+              command: swarm forkchat
+              classification: exception
+              exception_rule: group_help
+            forkchat_new:
+              command: swarm forkchat new
+              classification: shared_output
+              fact_owner: /v1/rpc conversation.fork and optional /v1/rpc conversation.fork_chat
+              json_shape: forkchat new result object
+              quiet_values:
+              - fork_id
+            forkchat_resume:
+              command: swarm forkchat resume
+              classification: shared_output
+              fact_owner: /v1/rpc conversation.fork_chat
+              json_shape: forkchat resume result object
+              quiet_values:
+              - turn_id
+            forkchat_list:
+              command: swarm forkchat list
+              classification: shared_output
+              fact_owner: /v1/rpc conversation.fork_list
+              json_shape: forkchat list result object
+              quiet_values:
+              - fork_id, one per returned fork
+            forkchat_view:
+              command: swarm forkchat view
+              classification: shared_output
+              fact_owner: /v1/rpc conversation.fork_view
+              json_shape: forkchat view result object
+              quiet_values:
+              - fork_id
+            forkchat_delete:
+              command: swarm forkchat delete
+              classification: shared_output
+              fact_owner: /v1/rpc conversation.fork_delete
+              json_shape: forkchat delete result object
+              quiet_values:
+              - fork_id
+            entity:
+              command: swarm entity
+              classification: exception
+              exception_rule: group_help
+            entities_list:
+              command: swarm entity list
+              classification: split
+              owner_issue: '#1814'
+              reason: entity list table/default text remains on the table-renderer migration path.
+            entity_view:
+              command: swarm entity view
+              classification: split
+              owner_issue: '#1814'
+              reason: entity detail text remains on the display-policy migration path.
+            entity_aggregate:
+              command: swarm entity aggregate
+              classification: split
+              owner_issue: '#1814'
+              reason: entity aggregate table/default text remains on the table-renderer migration path.
+            logs:
+              command: swarm logs
+              classification: split
+              owner_issue: '#1819'
+              reason: logs formatting remains on the dedicated logs-formatting owner.
+            incidents:
+              command: swarm incidents
+              classification: split
+              owner_issue: '#1814'
+              reason: incident table/default text remains on the table-renderer migration path.
+            context:
+              command: swarm context
+              classification: exception
+              exception_rule: group_help
+            context_current:
+              command: swarm context current
+              classification: split
+              owner_issue: '#1712'
+              reason: context output has manual JSON/default text and no shared output-mode owner yet.
+            context_list:
+              command: swarm context list
+              classification: split
+              owner_issue: '#1814'
+              reason: context list output remains on the table/display migration path.
+            context_prune:
+              command: swarm context prune
+              classification: split
+              owner_issue: '#1712'
+              reason: context prune output has manual JSON/default text and no shared output-mode owner yet.
+            describe:
+              command: swarm describe
+              classification: shared_output
+              fact_owner: local authoring view
+              json_shape: describe authoring view result object
+              quiet_values:
+              - flow ids and summary values declared by the command implementation
       exception_rules:
         root_help_completion:
           commands:
@@ -15030,6 +15370,11 @@ cli_specification:
             Root help, help topics, and shell completion generation are default-text/script surfaces. They do not
             consume JSON/quiet output modes unless a later tracked spec row explicitly promotes that behavior.
             Unsupported output-mode flags on these surfaces fail before side effects with CLI validation exit 2.
+        group_help:
+          rule: >
+            Group-only command paths that exist to list child commands are default-text help/navigation surfaces.
+            They do not consume JSON/quiet output modes unless a later tracked command row explicitly promotes that
+            behavior. Their child commands are classified independently in the output conformance registry.
         serve_daemon_process:
           commands:
           - serve

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -15229,21 +15229,21 @@ cli_specification:
             bundle_list:
               command: swarm bundle list
               classification: shared_output
-              fact_owner: local bundle inventory
+              fact_owner: /v1/rpc bundle.list
               json_shape: bundle list result object
               quiet_values:
               - bundle_hash, one per returned bundle
             bundle_show:
               command: swarm bundle show
               classification: shared_output
-              fact_owner: local bundle inventory
+              fact_owner: /v1/rpc bundle.get
               json_shape: bundle detail result object
               quiet_values:
               - bundle_hash
             bundle_agents:
               command: swarm bundle agents
               classification: shared_output
-              fact_owner: local bundle inventory
+              fact_owner: /v1/rpc bundle.agents
               json_shape: bundle agents result object
               quiet_values:
               - agent id, one per returned agent
@@ -15255,14 +15255,14 @@ cli_specification:
             bundle_register:
               command: swarm bundle register
               classification: shared_output
-              fact_owner: local bundle catalog registration
+              fact_owner: /v1/rpc bundle.register
               json_shape: bundle registration result object
               quiet_values:
               - bundle_hash
             bundle_delete:
               command: swarm bundle delete
               classification: shared_output
-              fact_owner: local bundle catalog deletion
+              fact_owner: /v1/rpc bundle.delete
               json_shape: bundle delete result object
               quiet_values:
               - bundle_hash
@@ -15394,8 +15394,7 @@ cli_specification:
             resurrect legacy behavior, make API/runtime calls, or convert migration messages into successful
             machine-readable output.
         absent_command_rows:
-          commands:
-          - forkchat
+          commands: []
           rule: >
             Absent or blocked command rows do not receive output-mode implementation from #848. Their future
             implementation children consume this contract only after their command/API/runtime owner is promoted.


### PR DESCRIPTION
## Summary

- Promote `output_conformance_registry` as the single living CLI output-conformance state owner in `platform-spec.yaml`.
- Add a fail-closed registry guard covering visible Cobra paths and implemented command-catalog rows.
- Validate `shared_output`, `exception`, and `split` row semantics, including a grandfathered non-shared allowlist so split/exception growth is explicit.
- Reconcile the old duplicate spec consumer lists so they cannot remain a second registry.

Part of #1821.

## Governing refs / context

- `platform-spec.yaml#cli_specification.foundations.output_contract`
- `platform-spec.yaml#cli_specification.foundations.output_contract.command_support.output_conformance_registry`
- #1821 lead ruling: registry-bound ratchet guard, zero-output-byte-change first slice
- #1821 Pre-Implementation Coverage Audit and independent gate outcome
- Parent umbrella: #1712
- Split owners cited by registry rows: #1814, #1817, #1819, plus #1712 umbrella rows where no narrower owner is promoted yet
- Completed adjacent diagnostic issue-ref guard: #1840

## Semantic migration accounting

- New canonical owner: `platform-spec.yaml#cli_specification.foundations.output_contract.command_support.output_conformance_registry`
- Implementation owner: `cmd/swarm/cli_output_conformance_registry_test.go`
- Old non-authoritative paths now invalid: `currently_implemented_consumers`, `implemented_output_mode_first_slice`, and `implemented_color_policy_first_slice` as living current-state registries.
- Production paths checked for surviving old behavior: no production command code changed; this is a spec/test conformance slice only.
- Migration completeness: complete for the approved `cli.output_conformance_registry_ratchet` slice; broader command-output migrations remain tracked under #1712/#1821 and split owners.

## Tests

Passed:

- `go test ./cmd/swarm -run 'TestCLIOutputConformance|TestNoRetiredSpellingsInUnstructuredSources'`
- `go test ./internal/apispec -run 'TestCLI(OutputConformance|VerifyJSONShape)'`

Attempted required full suite with host Postgres:

- `SWARM_TEST_POSTGRES_DSN='host=127.0.0.1 port=5432 user=youmew dbname=postgres sslmode=disable' PGPASSWORD=postgres go test ./...`

Result: failed in unrelated `cmd/swarm` served-parity test `TestServedParityHarnessRunControlLifecycle/explicit_postgres` with a pending `entity-writer` delivery for `thing.reviewed`; this PR changes only spec/test conformance files and does not touch runtime delivery code.