### PR TITLE
[agent-f][issue #1893] Microsoft Graph client credentials connector proof

### DIFF
--- a/internal/providerconnectors/packs/microsoft_graph/connector.yaml
+++ b/internal/providerconnectors/packs/microsoft_graph/connector.yaml
@@ -1,0 +1,41 @@
+provider: microsoft_graph
+tools:
+  microsoft_graph.send_mail:
+    category: provider_connector
+    description: send Microsoft Graph mail
+    handler_type: http
+    effect_class: non_idempotent_write
+    managed_credential:
+      key: microsoft_graph_app
+      scopes:
+        - https://graph.microsoft.com/.default
+    input_schema:
+      type: object
+      properties:
+        user_id:
+          type: string
+        to_recipients:
+          type: array
+          items:
+            type: object
+        subject:
+          type: string
+        content:
+          type: string
+      required:
+        - user_id
+        - to_recipients
+        - subject
+        - content
+    output_schema:
+      type: object
+    http:
+      method: POST
+      url: https://graph.microsoft.com/v1.0/users/{{input.user_id}}/sendMail
+      body:
+        message:
+          subject: "{{input.subject}}"
+          body:
+            contentType: Text
+            content: "{{input.content}}"
+          toRecipients: "{{input.to_recipients}}"

--- a/internal/providerconnectors/packs/microsoft_graph/pack.yaml
+++ b/internal/providerconnectors/packs/microsoft_graph/pack.yaml
@@ -1,0 +1,22 @@
+id: provider.microsoft_graph.connector
+version: 0.1.0
+platform_version: ">=0.7.0 <0.8.0"
+type: connector
+manifest_hash: sha256:e13f54ad54f94612a030a11814e159b7edfc3e7d3de682b8e8f6ca9d2dd22267
+provenance:
+  source: platform
+capabilities:
+  can:
+    call_provider_action: microsoft_graph.send_mail
+    lower_through_activity: true
+    journal_activity_attempts: true
+  cannot:
+    - bypass activity_attempts
+    - retry non_idempotent_write automatically
+    - expose credential values
+requires:
+  managed_credentials:
+    - microsoft_graph_app
+tests:
+  - providerconnectors/microsoft_graph_pack
+  - runtime/microsoft_graph_connector_client_credentials_supported_surface

--- a/internal/providerconnectors/providerconnectors_test.go
+++ b/internal/providerconnectors/providerconnectors_test.go
@@ -382,6 +382,37 @@ func TestDefaultPackRegistryLoadsNotionManagedCredentialPack(t *testing.T) {
 	}
 }
 
+func TestDefaultPackRegistryLoadsMicrosoftGraphManagedCredentialPack(t *testing.T) {
+	tool, ok := BuiltinTool("microsoft_graph", "microsoft_graph.send_mail")
+	if !ok {
+		t.Fatal("BuiltinTool microsoft_graph.send_mail not found")
+	}
+	if !isProviderConnector(tool) {
+		t.Fatalf("builtin Microsoft Graph tool category = %q, want %q", tool.Category, Category)
+	}
+	if tool.ManagedCredential == nil || tool.ManagedCredential.Key != "microsoft_graph_app" {
+		t.Fatalf("builtin Microsoft Graph managed credential = %#v, want microsoft_graph_app", tool.ManagedCredential)
+	}
+	if got := strings.Join(tool.ManagedCredential.Scopes, " "); got != "https://graph.microsoft.com/.default" {
+		t.Fatalf("builtin Microsoft Graph scopes = %q, want Graph .default resource scope", got)
+	}
+	if managedcredentialmodel.NormalizeGrantModel(tool.ManagedCredential.GrantModel) != managedcredentialmodel.GrantModelScope {
+		t.Fatalf("builtin Microsoft Graph grant_model = %q, want scope_grant", tool.ManagedCredential.GrantModel)
+	}
+	if !managedcredentialmodel.TokenRequestProfileEqual(tool.ManagedCredential.TokenRequest, managedcredentialmodel.DefaultTokenRequestProfile()) {
+		t.Fatalf("builtin Microsoft Graph token_request = %#v, want default post/form", tool.ManagedCredential.TokenRequest)
+	}
+	if tool.HTTP == nil || tool.HTTP.Method != "POST" || !strings.Contains(tool.HTTP.URL, "/v1.0/users/{{input.user_id}}/sendMail") {
+		t.Fatalf("builtin Microsoft Graph http = %#v, want sendMail POST endpoint", tool.HTTP)
+	}
+	if len(tool.Credentials) != 0 {
+		t.Fatalf("builtin Microsoft Graph static credentials = %#v, want none", tool.Credentials)
+	}
+	if strings.Contains(tool.HTTP.URL, "secret") || strings.Contains(tool.HTTP.URL, "token") {
+		t.Fatal("builtin Microsoft Graph tool leaked a concrete credential value")
+	}
+}
+
 func TestNotionConnectorPackReportsWorkspaceGrantAndTokenProfileRequirement(t *testing.T) {
 	ctx := context.Background()
 	source, err := SourceWithConnectorPackImports(providerConnectorScopedSource{
@@ -427,6 +458,57 @@ func TestNotionConnectorPackReportsWorkspaceGrantAndTokenProfileRequirement(t *t
 	}
 	if len(mismatch) != 1 || len(mismatch[0].Requires) != 1 || mismatch[0].Requires[0].Bound || mismatch[0].Requires[0].Status != "SCOPE_INSUFFICIENT" {
 		t.Fatalf("mismatch requirement = %#v, want fail-closed token profile mismatch", mismatch)
+	}
+}
+
+func TestMicrosoftGraphConnectorPackReportsDefaultScopeManagedCredentialRequirement(t *testing.T) {
+	ctx := context.Background()
+	source, err := SourceWithConnectorPackImports(providerConnectorScopedSource{
+		Source: semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{}),
+		projectScopes: []semanticview.ProjectScope{
+			projectScopeWithConnectorPackImport(".", "microsoft_graph", "microsoft_graph.send_mail"),
+		},
+	})
+	if err != nil {
+		t.Fatalf("SourceWithConnectorPackImports: %v", err)
+	}
+
+	unbound, err := SurfacesWithOptions(ctx, source, SurfaceOptions{})
+	if err != nil {
+		t.Fatalf("SurfacesWithOptions unbound: %v", err)
+	}
+	if len(unbound) != 1 || len(unbound[0].Requires) != 1 {
+		t.Fatalf("unbound surfaces = %#v, want one Microsoft Graph managed credential requirement", unbound)
+	}
+	requirement := unbound[0].Requires[0]
+	if requirement.Kind != "managed_credential" || requirement.Name != "microsoft_graph_app" || requirement.Bound || requirement.Status != "UNBOUND" {
+		t.Fatalf("unbound requirement = %#v, want unbound microsoft_graph_app", requirement)
+	}
+	if requirement.GrantModel != managedcredentialmodel.GrantModelScope || !managedcredentialmodel.TokenRequestProfileEqual(requirement.TokenRequest, managedcredentialmodel.DefaultTokenRequestProfile()) {
+		t.Fatalf("unbound requirement shape = %#v, want scope_grant post/form", requirement)
+	}
+	if got := strings.Join(requirement.Scopes, " "); got != "https://graph.microsoft.com/.default" {
+		t.Fatalf("unbound requirement scopes = %q, want Graph .default resource scope", got)
+	}
+
+	matchingStore := runtimemanagedcredentials.NewMemoryStore(microsoftGraphConnectedRecord())
+	bound, err := SurfacesWithOptions(ctx, source, SurfaceOptions{ManagedCredentials: matchingStore})
+	if err != nil {
+		t.Fatalf("SurfacesWithOptions bound: %v", err)
+	}
+	if len(bound) != 1 || len(bound[0].Requires) != 1 || !bound[0].Requires[0].Bound || bound[0].Requires[0].Status != "CONNECTED" {
+		t.Fatalf("bound requirement = %#v, want connected Microsoft Graph credential", bound)
+	}
+
+	wrongScope := microsoftGraphConnectedRecord()
+	wrongScope.Scopes = []string{"Mail.Send"}
+	wrongScopeStore := runtimemanagedcredentials.NewMemoryStore(wrongScope)
+	mismatch, err := SurfacesWithOptions(ctx, source, SurfaceOptions{ManagedCredentials: wrongScopeStore})
+	if err != nil {
+		t.Fatalf("SurfacesWithOptions mismatch: %v", err)
+	}
+	if len(mismatch) != 1 || len(mismatch[0].Requires) != 1 || mismatch[0].Requires[0].Bound || mismatch[0].Requires[0].Status != "SCOPE_INSUFFICIENT" {
+		t.Fatalf("mismatch requirement = %#v, want fail-closed .default scope mismatch", mismatch)
 	}
 }
 
@@ -739,6 +821,23 @@ func notionConnectedRecord() runtimemanagedcredentials.Record {
 		},
 		AccessToken:  "notion-access-secret",
 		RefreshToken: "notion-refresh-secret",
+		Status:       runtimemanagedcredentials.StatusConnected,
+		ExpiresAt:    time.Now().Add(time.Hour),
+	}
+}
+
+func microsoftGraphConnectedRecord() runtimemanagedcredentials.Record {
+	return runtimemanagedcredentials.Record{
+		Key:          "microsoft_graph_app",
+		Provider:     "microsoft_graph",
+		GrantType:    runtimemanagedcredentials.GrantClientCredentials,
+		TokenURL:     "https://login.microsoftonline.com/tenant/oauth2/v2.0/token",
+		ClientID:     "graph-client",
+		ClientSecret: "graph-secret",
+		Scopes:       []string{"https://graph.microsoft.com/.default"},
+		GrantModel:   managedcredentialmodel.GrantModelScope,
+		TokenRequest: managedcredentialmodel.DefaultTokenRequestProfile(),
+		AccessToken:  "graph-access-secret",
 		Status:       runtimemanagedcredentials.StatusConnected,
 		ExpiresAt:    time.Now().Add(time.Hour),
 	}

--- a/internal/runtime/managedcredentials/store_test.go
+++ b/internal/runtime/managedcredentials/store_test.go
@@ -349,6 +349,87 @@ func TestTokenSourceClientCredentialsRefreshBeforeUseAndFailureEvidence(t *testi
 	}
 }
 
+func TestTokenSourceClientCredentialsUsesMicrosoftDefaultScopeAndNeverRefreshToken(t *testing.T) {
+	ctx := context.Background()
+	var requests []url.Values
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err != nil {
+			t.Fatalf("ParseForm: %v", err)
+		}
+		form := url.Values{}
+		for key, values := range r.Form {
+			form[key] = append([]string(nil), values...)
+		}
+		requests = append(requests, form)
+		token := "graph-first-token"
+		if len(requests) > 1 {
+			token = "graph-second-token"
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"access_token": token,
+			"expires_in":   1,
+		})
+	}))
+	defer server.Close()
+
+	now := time.Date(2026, 7, 8, 12, 0, 0, 0, time.UTC)
+	store := NewMemoryStore()
+	source := TokenSource{
+		Store: store,
+		Now: func() time.Time {
+			return now
+		},
+	}
+	record, err := source.ConnectClientCredentials(ctx, ClientCredentialsRequest{
+		Key:          "microsoft_graph_app",
+		Provider:     "microsoft_graph",
+		TokenURL:     server.URL,
+		ClientID:     "graph-client",
+		ClientSecret: "graph-secret",
+		Scopes:       []string{"https://graph.microsoft.com/.default"},
+	})
+	if err != nil {
+		t.Fatalf("ConnectClientCredentials: %v", err)
+	}
+	if record.RefreshToken != "" {
+		t.Fatalf("client_credentials record refresh_token = %q, want none", record.RefreshToken)
+	}
+	now = now.Add(2 * time.Second)
+	token, record, err := source.AccessToken(ctx, AccessTokenRequest{
+		Key:    "microsoft_graph_app",
+		Scopes: []string{"https://graph.microsoft.com/.default"},
+	})
+	if err != nil {
+		t.Fatalf("AccessToken re-acquire: %v", err)
+	}
+	if token != "graph-second-token" || record.AccessToken != "graph-second-token" {
+		t.Fatalf("re-acquired token = (%q, %q), want graph-second-token", token, record.AccessToken)
+	}
+	if record.RefreshToken != "" {
+		t.Fatalf("re-acquired client_credentials record refresh_token = %q, want none", record.RefreshToken)
+	}
+	if len(requests) != 2 {
+		t.Fatalf("token endpoint requests = %d, want 2", len(requests))
+	}
+	for i, form := range requests {
+		if got := form.Get("grant_type"); got != "client_credentials" {
+			t.Fatalf("request %d grant_type = %q, want client_credentials", i+1, got)
+		}
+		if got := form.Get("client_id"); got != "graph-client" {
+			t.Fatalf("request %d client_id = %q, want graph-client", i+1, got)
+		}
+		if got := form.Get("client_secret"); got != "graph-secret" {
+			t.Fatalf("request %d client_secret = %q, want graph-secret", i+1, got)
+		}
+		if got := form.Get("scope"); got != "https://graph.microsoft.com/.default" {
+			t.Fatalf("request %d scope = %q, want Graph .default resource scope", i+1, got)
+		}
+		if got := form.Get("refresh_token"); got != "" {
+			t.Fatalf("request %d refresh_token = %q, want none for client_credentials", i+1, got)
+		}
+	}
+}
+
 func TestTokenSourceRefreshUsesBasicJSONTokenRequestProfileAndRotatesRefreshToken(t *testing.T) {
 	ctx := context.Background()
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/runtime/microsoft_graph_connector_client_credentials_supported_surface_test.go
+++ b/internal/runtime/microsoft_graph_connector_client_credentials_supported_surface_test.go
@@ -108,6 +108,9 @@ func runMicrosoftGraphClientCredentialsConnectorSurface(t *testing.T, backend sl
 	if got := microsoftGraphConnectorString(firstCall.body["message"]); !strings.Contains(got, "send first mail") || !strings.Contains(got, "recipient@example.com") {
 		t.Fatalf("%s first Graph message = %#v, want subject/body/recipient from activity input", backend.name, firstCall.body["message"])
 	}
+	if recipients := microsoftGraphMessageRecipients(firstCall.body); len(recipients) != 1 {
+		t.Fatalf("%s first Graph toRecipients = %#v, want one JSON array recipient", backend.name, microsoftGraphMessageValue(firstCall.body, "toRecipients"))
+	}
 	firstInboundEventID := loadSlackManagedConnectorInboundEventID(t, backend, "323456789")
 	firstAttempt := waitForMicrosoftGraphTerminalActivityAttempt(t, backend, firstInboundEventID)
 	if firstAttempt.Status != runtimepipeline.ActivityAttemptStatusSucceeded {
@@ -251,6 +254,10 @@ func newFakeMicrosoftGraphConnectorServer(t *testing.T) *fakeMicrosoftGraphConne
 		var body map[string]any
 		if err := json.Unmarshal(raw, &body); err != nil {
 			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		if recipients := microsoftGraphMessageRecipients(body); len(recipients) != 1 {
+			http.Error(w, "toRecipients must be a JSON array", http.StatusBadRequest)
 			return
 		}
 		auth := r.Header.Get("Authorization")
@@ -608,8 +615,20 @@ func countMicrosoftGraphFailureEventsForSource(t *testing.T, backend slackManage
 }
 
 func microsoftGraphMessageSubject(body map[string]any) string {
+	return slackManagedConnectorString(microsoftGraphMessageValue(body, "subject"))
+}
+
+func microsoftGraphMessageRecipients(body map[string]any) []any {
+	recipients, _ := microsoftGraphMessageValue(body, "toRecipients").([]any)
+	return recipients
+}
+
+func microsoftGraphMessageValue(body map[string]any, key string) any {
 	message, _ := body["message"].(map[string]any)
-	return slackManagedConnectorString(message["subject"])
+	if message == nil {
+		return nil
+	}
+	return message[key]
 }
 
 func microsoftGraphConnectorString(value any) string {

--- a/internal/runtime/microsoft_graph_connector_client_credentials_supported_surface_test.go
+++ b/internal/runtime/microsoft_graph_connector_client_credentials_supported_surface_test.go
@@ -1,0 +1,621 @@
+package runtime_test
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/division-sh/swarm/internal/packs"
+	"github.com/division-sh/swarm/internal/providerconnectors"
+	runtimepkg "github.com/division-sh/swarm/internal/runtime"
+	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
+	runtimecorrelation "github.com/division-sh/swarm/internal/runtime/correlation"
+	runtimeengine "github.com/division-sh/swarm/internal/runtime/engine"
+	runtimemanagedcredentials "github.com/division-sh/swarm/internal/runtime/managedcredentials"
+	managedcredentialmodel "github.com/division-sh/swarm/internal/runtime/managedcredentials/model"
+	runtimepipeline "github.com/division-sh/swarm/internal/runtime/pipeline"
+	"github.com/division-sh/swarm/internal/runtime/semanticview"
+	"github.com/division-sh/swarm/internal/store"
+	"github.com/division-sh/swarm/internal/store/storetest"
+	"github.com/division-sh/swarm/internal/testutil"
+)
+
+func TestMicrosoftGraphClientCredentialsConnectorPackRoundTripThroughActivityJournal(t *testing.T) {
+	t.Run("postgres", func(t *testing.T) {
+		_, db, cleanup := testutil.StartPostgres(t)
+		t.Cleanup(cleanup)
+
+		const (
+			runID        = "8c000000-0000-0000-0000-000000000001"
+			entityID     = "8c000000-0000-0000-0000-000000000002"
+			flowInstance = "microsoft-graph-connector-client-credentials-pg"
+		)
+		ctx := runtimecorrelation.WithRunID(context.Background(), runID)
+		pg := &store.PostgresStore{DB: db}
+		workflowStore := runtimepipeline.NewWorkflowInstanceStore(db)
+		seedPostgresInboundGatewayRuntime(t, ctx, db, pg, runID, entityID, flowInstance, "customer-a", "telegram", "telegram-secret", "microsoft-graph-client-credentials-observer")
+		seedTelegramConnectorSupportedSurfaceWorkflowVersion(t, ctx, db, flowInstance, false)
+
+		runMicrosoftGraphClientCredentialsConnectorSurface(t, slackManagedConnectorBackend{
+			name:          "postgres",
+			ctx:           ctx,
+			db:            db,
+			eventStore:    pg,
+			inboundStore:  pg,
+			workflowStore: workflowStore,
+			runID:         runID,
+			entityID:      entityID,
+			sqlite:        false,
+		})
+	})
+
+	t.Run("sqlite", func(t *testing.T) {
+		const (
+			runID        = "8d000000-0000-0000-0000-000000000001"
+			entityID     = "8d000000-0000-0000-0000-000000000002"
+			flowInstance = "microsoft-graph-connector-client-credentials-sqlite"
+		)
+		ctx := runtimecorrelation.WithRunID(context.Background(), runID)
+		sqliteStore := storetest.StartSQLiteRuntimeStoreWithContext(t, ctx)
+		workflowStore := runtimepipeline.NewSQLiteWorkflowInstanceStoreWithRuntimeMutationRunner(sqliteStore.DB, sqliteStore)
+		seedSQLiteInboundGatewayRuntime(t, ctx, sqliteStore, runID, entityID, flowInstance, "customer-a", "telegram", "telegram-secret", "microsoft-graph-client-credentials-observer")
+		seedTelegramConnectorSupportedSurfaceWorkflowVersion(t, ctx, sqliteStore.DB, flowInstance, true)
+
+		runMicrosoftGraphClientCredentialsConnectorSurface(t, slackManagedConnectorBackend{
+			name:          "sqlite",
+			ctx:           ctx,
+			db:            sqliteStore.DB,
+			eventStore:    sqliteStore,
+			inboundStore:  sqliteStore,
+			workflowStore: workflowStore,
+			runID:         runID,
+			entityID:      entityID,
+			sqlite:        true,
+		})
+	})
+}
+
+type microsoftGraphConnectorCall struct {
+	auth string
+	body map[string]any
+	raw  string
+}
+
+func runMicrosoftGraphClientCredentialsConnectorSurface(t *testing.T, backend slackManagedConnectorBackend) {
+	t.Helper()
+	fake := newFakeMicrosoftGraphConnectorServer(t)
+	defer fake.server.Close()
+
+	managedStore := runtimemanagedcredentials.NewMemoryStore(microsoftGraphClientCredentialsRecord(fake.server.URL, "expired-token", time.Now().Add(-time.Hour)))
+	source := microsoftGraphConnectorSource(t, fake.server.URL)
+	bus, pc := startSlackManagedConnectorBusAndCoordinator(t, backend, source, managedStore)
+	gateway := runtimepkg.NewInboundGateway(bus, nil, nil, backend.inboundStore)
+	webhookPath := fmt.Sprintf("/webhooks/%s/telegram", backend.entityID)
+
+	publishTelegramMessageToSlack(t, backend, bus, gateway, webhookPath, "323456789", "send first mail")
+	firstCall := fake.requireSideEffectCall(t, backend.name, "client_credentials refresh-before-use")
+	if firstCall.auth != "Bearer graph-fresh-token" {
+		t.Fatalf("%s first Graph auth = %q, want Bearer graph-fresh-token", backend.name, firstCall.auth)
+	}
+	if got := microsoftGraphConnectorString(firstCall.body["message"]); !strings.Contains(got, "send first mail") || !strings.Contains(got, "recipient@example.com") {
+		t.Fatalf("%s first Graph message = %#v, want subject/body/recipient from activity input", backend.name, firstCall.body["message"])
+	}
+	firstInboundEventID := loadSlackManagedConnectorInboundEventID(t, backend, "323456789")
+	firstAttempt := waitForMicrosoftGraphTerminalActivityAttempt(t, backend, firstInboundEventID)
+	if firstAttempt.Status != runtimepipeline.ActivityAttemptStatusSucceeded {
+		t.Fatalf("%s first activity attempt status = %q, want succeeded", backend.name, firstAttempt.Status)
+	}
+	requireSlackManagedConnectorResultEventEventually(t, backend, firstAttempt.ResultEventID, firstAttempt.ResultEventType)
+	if got := fake.tokenRequestCount(); got != 1 {
+		t.Fatalf("%s client_credentials token requests after refresh-before-use = %d, want 1", backend.name, got)
+	}
+	if got := fake.refreshTokenValues(); len(got) != 0 {
+		t.Fatalf("%s token endpoint received refresh_token values = %#v, want none for client_credentials", backend.name, got)
+	}
+
+	publishTelegramMessageToSlack(t, backend, bus, gateway, webhookPath, "323456790", "needs 401 refresh")
+	secondCall := fake.requireSideEffectCall(t, backend.name, "client_credentials re-acquire-on-401")
+	if secondCall.auth != "Bearer graph-after-401-token" {
+		t.Fatalf("%s second Graph auth = %q, want Bearer graph-after-401-token", backend.name, secondCall.auth)
+	}
+	secondInboundEventID := loadSlackManagedConnectorInboundEventID(t, backend, "323456790")
+	secondAttempt := waitForMicrosoftGraphTerminalActivityAttempt(t, backend, secondInboundEventID)
+	if secondAttempt.Status != runtimepipeline.ActivityAttemptStatusSucceeded {
+		t.Fatalf("%s second activity attempt status = %q, want succeeded", backend.name, secondAttempt.Status)
+	}
+	if got := fake.tokenRequestCount(); got != 2 {
+		t.Fatalf("%s client_credentials token requests after 401 = %d, want 2", backend.name, got)
+	}
+	if got := fake.providerHTTPRequestCount(); got != 3 {
+		t.Fatalf("%s Graph HTTP requests = %d, want 3 (success, 401, retry success)", backend.name, got)
+	}
+
+	requestEvent := loadSlackManagedConnectorActivityRequestEvent(t, backend, secondAttempt.RequestEventID)
+	if err := bus.EngineDispatcher().DispatchPostCommit(backend.ctx, []runtimeengine.EmitIntent{{Event: requestEvent}}); err != nil {
+		t.Fatalf("%s duplicate activity request dispatch: %v", backend.name, err)
+	}
+	waitForInboundBusQuiescence(t, bus)
+	fake.requireNoSideEffectCall(t, backend.name, "duplicate activity request")
+	if got := fake.tokenRequestCount(); got != 2 {
+		t.Fatalf("%s client_credentials token requests after duplicate = %d, want still 2", backend.name, got)
+	}
+	if got := countMicrosoftGraphActivityAttempts(t, backend); got != 2 {
+		t.Fatalf("%s activity attempts after duplicate = %d, want 2", backend.name, got)
+	}
+
+	publishTelegramMessageToSlack(t, backend, bus, gateway, webhookPath, "323456791", "provider 429 fixture")
+	fake.requireNoSideEffectCall(t, backend.name, "429 fixture")
+	rateLimitInboundEventID := loadSlackManagedConnectorInboundEventID(t, backend, "323456791")
+	rateLimitAttempt := waitForMicrosoftGraphTerminalActivityAttempt(t, backend, rateLimitInboundEventID)
+	if rateLimitAttempt.Status != runtimepipeline.ActivityAttemptStatusFailed {
+		t.Fatalf("%s 429 activity attempt status = %q, want failed", backend.name, rateLimitAttempt.Status)
+	}
+	if !strings.Contains(rateLimitAttempt.Error, "TooManyRequests") || !strings.Contains(rateLimitAttempt.Error, "429") {
+		t.Fatalf("%s 429 attempt error = %q, want Graph TooManyRequests fixture shape", backend.name, rateLimitAttempt.Error)
+	}
+	requireSlackManagedConnectorResultEventEventually(t, backend, rateLimitAttempt.ResultEventID, rateLimitAttempt.ResultEventType)
+	if got := countMicrosoftGraphFailureEventsForSource(t, backend, rateLimitInboundEventID); got != 1 {
+		t.Fatalf("%s 429 failure events = %d, want 1", backend.name, got)
+	}
+
+	assertMicrosoftGraphManagedCredentialFailureBeforeDispatch(t, backend, fake, "missing credential", "323456792", runtimemanagedcredentials.NewMemoryStore())
+	unconnected := microsoftGraphClientCredentialsRecord(fake.server.URL, "", time.Now().Add(time.Hour))
+	unconnected.Status = runtimemanagedcredentials.StatusUnconnected
+	assertMicrosoftGraphManagedCredentialFailureBeforeDispatch(t, backend, fake, "unconnected credential", "323456793", runtimemanagedcredentials.NewMemoryStore(unconnected))
+	scopeInsufficient := microsoftGraphClientCredentialsRecord(fake.server.URL, "scope-mismatch-token", time.Now().Add(time.Hour))
+	scopeInsufficient.Scopes = []string{"Mail.Send"}
+	assertMicrosoftGraphManagedCredentialFailureBeforeDispatch(t, backend, fake, "scope-insufficient credential", "323456794", runtimemanagedcredentials.NewMemoryStore(scopeInsufficient))
+
+	_ = pc
+	for _, secret := range []string{"expired-token", "graph-fresh-token", "graph-after-401-token", "graph-client-secret", "scope-mismatch-token"} {
+		assertSlackManagedConnectorNoStoredSecret(t, backend, secret)
+	}
+}
+
+type fakeMicrosoftGraphConnectorServer struct {
+	server        *httptest.Server
+	tokenCalls    atomic.Int64
+	graphCalls    atomic.Int64
+	refreshTokens []string
+	sideEffects   chan microsoftGraphConnectorCall
+}
+
+func newFakeMicrosoftGraphConnectorServer(t *testing.T) *fakeMicrosoftGraphConnectorServer {
+	t.Helper()
+	fake := &fakeMicrosoftGraphConnectorServer{sideEffects: make(chan microsoftGraphConnectorCall, 8)}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/tenant/oauth2/v2.0/token", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "bad method", http.StatusMethodNotAllowed)
+			return
+		}
+		if got := r.Header.Get("Content-Type"); !strings.HasPrefix(got, "application/x-www-form-urlencoded") {
+			http.Error(w, "bad content type", http.StatusBadRequest)
+			return
+		}
+		if err := r.ParseForm(); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		if got := r.Form.Get("grant_type"); got != "client_credentials" {
+			http.Error(w, "unexpected grant_type "+got, http.StatusBadRequest)
+			return
+		}
+		if got := r.Form.Get("client_id"); got != "graph-client" {
+			http.Error(w, "unexpected client_id", http.StatusBadRequest)
+			return
+		}
+		if got := r.Form.Get("client_secret"); got != "graph-client-secret" {
+			http.Error(w, "unexpected client_secret", http.StatusBadRequest)
+			return
+		}
+		if got := r.Form.Get("scope"); got != "https://graph.microsoft.com/.default" {
+			http.Error(w, "unexpected scope "+got, http.StatusBadRequest)
+			return
+		}
+		if refresh := strings.TrimSpace(r.Form.Get("refresh_token")); refresh != "" {
+			fake.refreshTokens = append(fake.refreshTokens, refresh)
+			http.Error(w, "client_credentials must not send refresh_token", http.StatusBadRequest)
+			return
+		}
+		call := fake.tokenCalls.Add(1)
+		access := "graph-fresh-token"
+		if call >= 2 {
+			access = "graph-after-401-token"
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"access_token": access,
+			"token_type":   "Bearer",
+			"expires_in":   3600,
+		})
+	})
+	mux.HandleFunc("/v1.0/users/user@example.com/sendMail", func(w http.ResponseWriter, r *http.Request) {
+		call := fake.graphCalls.Add(1)
+		raw, err := io.ReadAll(r.Body)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		if r.Method != http.MethodPost {
+			http.Error(w, "bad method", http.StatusMethodNotAllowed)
+			return
+		}
+		var body map[string]any
+		if err := json.Unmarshal(raw, &body); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		auth := r.Header.Get("Authorization")
+		subject := microsoftGraphMessageSubject(body)
+		if auth == "Bearer graph-fresh-token" && subject == "needs 401 refresh" {
+			w.WriteHeader(http.StatusUnauthorized)
+			_ = json.NewEncoder(w).Encode(map[string]any{"error": map[string]any{"code": "InvalidAuthenticationToken", "message": "token expired"}})
+			return
+		}
+		if auth != "Bearer graph-fresh-token" && auth != "Bearer graph-after-401-token" {
+			w.WriteHeader(http.StatusUnauthorized)
+			_ = json.NewEncoder(w).Encode(map[string]any{"error": map[string]any{"code": "InvalidAuthenticationToken", "message": "bad token"}})
+			return
+		}
+		if subject == "provider 429 fixture" {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			_ = json.NewEncoder(w).Encode(map[string]any{"error": map[string]any{"code": "TooManyRequests", "message": "slow down"}})
+			return
+		}
+		if call < 1 {
+			http.Error(w, "unreachable", http.StatusInternalServerError)
+			return
+		}
+		fake.sideEffects <- microsoftGraphConnectorCall{auth: auth, body: body, raw: string(raw)}
+		w.WriteHeader(http.StatusAccepted)
+	})
+	fake.server = httptest.NewServer(mux)
+	return fake
+}
+
+func (f *fakeMicrosoftGraphConnectorServer) requireSideEffectCall(t *testing.T, backend, context string) microsoftGraphConnectorCall {
+	t.Helper()
+	select {
+	case call := <-f.sideEffects:
+		return call
+	case <-time.After(5 * time.Second):
+		t.Fatalf("%s %s: timed out waiting for fake Microsoft Graph side effect", backend, context)
+		return microsoftGraphConnectorCall{}
+	}
+}
+
+func (f *fakeMicrosoftGraphConnectorServer) requireNoSideEffectCall(t *testing.T, backend, context string) {
+	t.Helper()
+	select {
+	case call := <-f.sideEffects:
+		t.Fatalf("%s %s: unexpected fake Microsoft Graph side effect: auth=%s body=%s", backend, context, call.auth, call.raw)
+	default:
+	}
+}
+
+func (f *fakeMicrosoftGraphConnectorServer) tokenRequestCount() int {
+	return int(f.tokenCalls.Load())
+}
+
+func (f *fakeMicrosoftGraphConnectorServer) providerHTTPRequestCount() int {
+	return int(f.graphCalls.Load())
+}
+
+func (f *fakeMicrosoftGraphConnectorServer) refreshTokenValues() []string {
+	return append([]string(nil), f.refreshTokens...)
+}
+
+func microsoftGraphClientCredentialsRecord(baseURL, accessToken string, expiresAt time.Time) runtimemanagedcredentials.Record {
+	return runtimemanagedcredentials.Record{
+		Key:          "microsoft_graph_app",
+		Provider:     "microsoft_graph",
+		GrantType:    runtimemanagedcredentials.GrantClientCredentials,
+		TokenURL:     strings.TrimRight(baseURL, "/") + "/tenant/oauth2/v2.0/token",
+		ClientID:     "graph-client",
+		ClientSecret: "graph-client-secret",
+		Scopes:       []string{"https://graph.microsoft.com/.default"},
+		GrantModel:   managedcredentialmodel.GrantModelScope,
+		TokenRequest: managedcredentialmodel.DefaultTokenRequestProfile(),
+		AccessToken:  accessToken,
+		Status:       runtimemanagedcredentials.StatusConnected,
+		ExpiresAt:    expiresAt,
+	}
+}
+
+func microsoftGraphConnectorSource(t *testing.T, baseURL string) semanticview.Source {
+	t.Helper()
+	handler := runtimecontracts.SystemNodeEventHandler{
+		Activity: runtimecontracts.ActivitySpec{
+			ID:   "microsoft_graph_send_mail",
+			Tool: "microsoft_graph.send_mail",
+			Input: map[string]runtimecontracts.ExpressionValue{
+				"user_id": runtimecontracts.LiteralExpression("user@example.com"),
+				"to_recipients": runtimecontracts.LiteralExpression([]map[string]any{
+					{
+						"emailAddress": map[string]any{
+							"address": "recipient@example.com",
+						},
+					},
+				}),
+				"subject": runtimecontracts.CELExpression("payload.payload.message.text"),
+				"content": runtimecontracts.CELExpression("payload.payload.message.text"),
+			},
+		},
+	}
+	const nodeID = "microsoft-graph-responder"
+	node := runtimecontracts.SystemNodeContract{
+		ID:            nodeID,
+		ExecutionType: runtimecontracts.SystemNodeExecutionType,
+		EventHandlers: map[string]runtimecontracts.SystemNodeEventHandler{
+			"inbound.telegram": handler,
+		},
+	}
+	base := semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
+		RootSchema: &runtimecontracts.FlowSchemaDocument{
+			Pins: runtimecontracts.FlowPins{
+				Inputs: runtimecontracts.FlowInputPins{
+					Events: []string{"inbound.telegram"},
+				},
+			},
+		},
+		Nodes: map[string]runtimecontracts.SystemNodeContract{nodeID: node},
+		Semantics: runtimecontracts.WorkflowSemanticView{
+			Name:    "microsoft_graph_connector_client_credentials_supported_surface",
+			Version: "1.0.0",
+			EffectiveNodes: map[string]runtimecontracts.SystemNodeEffectiveSemantics{
+				nodeID: {
+					ID:                   nodeID,
+					ExecutionType:        runtimecontracts.SystemNodeExecutionType,
+					RuntimeSubscriptions: []string{"inbound.telegram"},
+				},
+			},
+			NodeHandlers: map[string]map[string]runtimecontracts.SystemNodeEventHandler{
+				nodeID: {"inbound.telegram": handler},
+			},
+			EventOwners: map[string][]string{
+				"inbound.telegram": {nodeID},
+			},
+		},
+	})
+	importSource := slackManagedConnectorPackImportSource{
+		Source: base,
+		projectScopes: []semanticview.ProjectScope{
+			{
+				Key: ".",
+				Manifest: runtimecontracts.ProjectPackageDocument{
+					ConnectorPacks: runtimecontracts.ConnectorPackImports{
+						Imports: []runtimecontracts.ConnectorPackImport{{Provider: "microsoft_graph", Tool: "microsoft_graph.send_mail"}},
+					},
+				},
+			},
+		},
+	}
+	source, err := providerconnectors.SourceWithConnectorPackImportsFromRegistry(importSource, microsoftGraphConnectorPackRegistry(t, baseURL))
+	if err != nil {
+		t.Fatalf("SourceWithConnectorPackImportsFromRegistry: %v", err)
+	}
+	return source
+}
+
+func microsoftGraphConnectorPackRegistry(t *testing.T, baseURL string) *providerconnectors.PackRegistry {
+	t.Helper()
+	tool, ok := providerconnectors.BuiltinTool("microsoft_graph", "microsoft_graph.send_mail")
+	if !ok {
+		t.Fatal("provider connector pack microsoft_graph.send_mail not found")
+	}
+	if tool.HTTP == nil {
+		t.Fatal("provider connector pack microsoft_graph.send_mail missing http block")
+	}
+	httpSpec := *tool.HTTP
+	tool.HTTP = &httpSpec
+	tool.HTTP.URL = strings.TrimRight(baseURL, "/") + "/v1.0/users/{{input.user_id}}/sendMail"
+	registry, err := providerconnectors.NewPackRegistry(providerconnectors.LoadedPack{
+		Envelope: packs.Envelope{
+			ID: "provider.microsoft_graph.connector",
+			Provenance: packs.Provenance{
+				Source: packs.ProvenancePlatform,
+			},
+		},
+		Manifest: providerconnectors.ConnectorManifest{
+			Provider: "microsoft_graph",
+			Tools: map[string]runtimecontracts.ToolSchemaEntry{
+				"microsoft_graph.send_mail": tool,
+			},
+		},
+		Source: "test:provider.microsoft_graph.connector",
+	})
+	if err != nil {
+		t.Fatalf("NewPackRegistry: %v", err)
+	}
+	return registry
+}
+
+func assertMicrosoftGraphManagedCredentialFailureBeforeDispatch(t *testing.T, backend slackManagedConnectorBackend, fake *fakeMicrosoftGraphConnectorServer, label, updateID string, managedStore runtimemanagedcredentials.Store) {
+	t.Helper()
+	tokenRequestsBefore := fake.tokenRequestCount()
+	graphRequestsBefore := fake.providerHTTPRequestCount()
+	source := microsoftGraphConnectorSource(t, fake.server.URL)
+	bus, _ := startSlackManagedConnectorBusAndCoordinator(t, backend, source, managedStore)
+	gateway := runtimepkg.NewInboundGateway(bus, nil, nil, backend.inboundStore)
+	webhookPath := fmt.Sprintf("/webhooks/%s/telegram", backend.entityID)
+	publishTelegramMessageToSlack(t, backend, bus, gateway, webhookPath, updateID, label)
+	inboundEventID := loadSlackManagedConnectorInboundEventID(t, backend, updateID)
+	fake.requireNoSideEffectCall(t, backend.name, label)
+	if got := fake.tokenRequestCount(); got != tokenRequestsBefore {
+		t.Fatalf("%s %s token requests = %d, want unchanged %d", backend.name, label, got, tokenRequestsBefore)
+	}
+	if got := fake.providerHTTPRequestCount(); got != graphRequestsBefore {
+		t.Fatalf("%s %s Graph HTTP requests = %d, want unchanged %d", backend.name, label, got, graphRequestsBefore)
+	}
+	if got := countMicrosoftGraphActivityAttemptsForSource(t, backend, inboundEventID); got != 0 {
+		t.Fatalf("%s %s activity attempts = %d, want 0", backend.name, label, got)
+	}
+	if got := countMicrosoftGraphFailureEventsForSource(t, backend, inboundEventID); got != 1 {
+		t.Fatalf("%s %s failure events = %d, want 1", backend.name, label, got)
+	}
+}
+
+func waitForMicrosoftGraphTerminalActivityAttempt(t *testing.T, backend slackManagedConnectorBackend, sourceEventID string) runtimepipeline.ActivityAttemptRecord {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	var last runtimepipeline.ActivityAttemptRecord
+	var saw bool
+	for {
+		rec, ok, err := tryLoadMicrosoftGraphActivityAttempt(backend, sourceEventID)
+		if err != nil {
+			t.Fatalf("%s load activity attempt while waiting: %v", backend.name, err)
+		}
+		if ok {
+			last = rec
+			saw = true
+			if rec.Status != runtimepipeline.ActivityAttemptStatusStarted {
+				return rec
+			}
+		}
+		if time.Now().After(deadline) {
+			if saw {
+				t.Fatalf("%s activity attempt did not reach terminal status; last=%q", backend.name, last.Status)
+			}
+			t.Fatalf("%s activity attempt for source event %s was not created", backend.name, sourceEventID)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func tryLoadMicrosoftGraphActivityAttempt(backend slackManagedConnectorBackend, sourceEventID string) (runtimepipeline.ActivityAttemptRecord, bool, error) {
+	var requestEventID string
+	var err error
+	if backend.sqlite {
+		err = backend.db.QueryRowContext(backend.ctx, `
+			SELECT request_event_id
+			FROM activity_attempts
+			WHERE run_id = ?
+			  AND tool = 'microsoft_graph.send_mail'
+			  AND source_event_id = ?
+			ORDER BY started_at ASC
+			LIMIT 1
+		`, backend.runID, sourceEventID).Scan(&requestEventID)
+	} else {
+		err = backend.db.QueryRowContext(backend.ctx, `
+			SELECT request_event_id::text
+			FROM activity_attempts
+			WHERE run_id = $1::uuid
+			  AND tool = 'microsoft_graph.send_mail'
+			  AND source_event_id = $2::uuid
+			ORDER BY started_at ASC
+			LIMIT 1
+		`, backend.runID, sourceEventID).Scan(&requestEventID)
+	}
+	if err == sql.ErrNoRows {
+		return runtimepipeline.ActivityAttemptRecord{}, false, nil
+	}
+	if err != nil {
+		return runtimepipeline.ActivityAttemptRecord{}, false, err
+	}
+	rec, ok, err := backend.workflowStore.LoadActivityAttempt(backend.ctx, requestEventID)
+	if err != nil {
+		return runtimepipeline.ActivityAttemptRecord{}, false, err
+	}
+	return rec, ok, nil
+}
+
+func countMicrosoftGraphActivityAttempts(t *testing.T, backend slackManagedConnectorBackend) int {
+	t.Helper()
+	var count int
+	var err error
+	if backend.sqlite {
+		err = backend.db.QueryRowContext(backend.ctx, `
+			SELECT COUNT(*)
+			FROM activity_attempts
+			WHERE run_id = ?
+			  AND tool = 'microsoft_graph.send_mail'
+		`, backend.runID).Scan(&count)
+	} else {
+		err = backend.db.QueryRowContext(backend.ctx, `
+			SELECT COUNT(*)
+			FROM activity_attempts
+			WHERE run_id = $1::uuid
+			  AND tool = 'microsoft_graph.send_mail'
+		`, backend.runID).Scan(&count)
+	}
+	if err != nil {
+		t.Fatalf("%s count activity attempts: %v", backend.name, err)
+	}
+	return count
+}
+
+func countMicrosoftGraphActivityAttemptsForSource(t *testing.T, backend slackManagedConnectorBackend, sourceEventID string) int {
+	t.Helper()
+	var count int
+	var err error
+	if backend.sqlite {
+		err = backend.db.QueryRowContext(backend.ctx, `
+			SELECT COUNT(*)
+			FROM activity_attempts
+			WHERE run_id = ?
+			  AND tool = 'microsoft_graph.send_mail'
+			  AND source_event_id = ?
+		`, backend.runID, sourceEventID).Scan(&count)
+	} else {
+		err = backend.db.QueryRowContext(backend.ctx, `
+			SELECT COUNT(*)
+			FROM activity_attempts
+			WHERE run_id = $1::uuid
+			  AND tool = 'microsoft_graph.send_mail'
+			  AND source_event_id = $2::uuid
+		`, backend.runID, sourceEventID).Scan(&count)
+	}
+	if err != nil {
+		t.Fatalf("%s count activity attempts for source event %s: %v", backend.name, sourceEventID, err)
+	}
+	return count
+}
+
+func countMicrosoftGraphFailureEventsForSource(t *testing.T, backend slackManagedConnectorBackend, sourceEventID string) int {
+	t.Helper()
+	var count int
+	var err error
+	if backend.sqlite {
+		err = backend.db.QueryRowContext(backend.ctx, `
+			SELECT COUNT(*)
+			FROM events
+			WHERE run_id = ?
+			  AND event_name = 'microsoft_graph_send_mail.failed'
+			  AND source_event_id = ?
+		`, backend.runID, sourceEventID).Scan(&count)
+	} else {
+		err = backend.db.QueryRowContext(backend.ctx, `
+			SELECT COUNT(*)
+			FROM events
+			WHERE run_id = $1::uuid
+			  AND event_name = 'microsoft_graph_send_mail.failed'
+			  AND source_event_id = $2::uuid
+		`, backend.runID, sourceEventID).Scan(&count)
+	}
+	if err != nil {
+		t.Fatalf("%s count failure events for source event %s: %v", backend.name, sourceEventID, err)
+	}
+	return count
+}
+
+func microsoftGraphMessageSubject(body map[string]any) string {
+	message, _ := body["message"].(map[string]any)
+	return slackManagedConnectorString(message["subject"])
+}
+
+func microsoftGraphConnectorString(value any) string {
+	raw, err := json.Marshal(value)
+	if err != nil {
+		return fmt.Sprint(value)
+	}
+	return string(raw)
+}

--- a/internal/runtime/pipeline/activity_engine.go
+++ b/internal/runtime/pipeline/activity_engine.go
@@ -973,7 +973,7 @@ func redactActivityError(err error, secrets []string) error {
 func resolveActivityTemplateTree(value any, env map[string]any) (any, error) {
 	switch typed := value.(type) {
 	case string:
-		return resolveActivityTemplateString(typed, env)
+		return resolveActivityTemplateValue(typed, env)
 	case map[string]any:
 		out := make(map[string]any, len(typed))
 		for key, value := range typed {
@@ -997,6 +997,22 @@ func resolveActivityTemplateTree(value any, env map[string]any) (any, error) {
 	default:
 		return value, nil
 	}
+}
+
+func resolveActivityTemplateValue(template string, env map[string]any) (any, error) {
+	out := strings.TrimSpace(template)
+	matches, err := activityTemplateMatches(out)
+	if err != nil {
+		return nil, err
+	}
+	if len(matches) == 1 && matches[0].start == 0 && matches[0].end == len(out) {
+		value, ok := workflowExpressionLookupPath(env, matches[0].expr)
+		if !ok {
+			return nil, fmt.Errorf("activity template expression %q did not resolve", matches[0].expr)
+		}
+		return value, nil
+	}
+	return resolveActivityTemplateString(out, env)
 }
 
 func resolveActivityTemplateString(template string, env map[string]any) (string, error) {

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -6423,7 +6423,7 @@ tool_model:
       - "`rate_limit` and `rate_limit_max_wait`; connector admission/rate limiting is split until specified."
       - "direct runtime provider adapter code or bespoke connector dispatch."
     connector_pack_profile:
-      status: "first slices: Telegram static connector pack proof, Slack managed-credential connector pack proof, and Notion Basic+JSON workspace-grant connector proof"
+      status: "first slices: Telegram static connector pack proof, Slack managed-credential connector pack proof, Notion Basic+JSON workspace-grant connector proof, and Microsoft Graph client_credentials `.default` connector proof"
       body_file: connector.yaml
       import_syntax: >
         package.yaml `connector_packs.imports[]` entries name `provider` and `tool`. The import is an explicit enablement
@@ -6605,6 +6605,14 @@ tool_model:
       an existing row blocks refresh and provider redispatch. Refresh failure sets refresh_failed state with redacted failure
       evidence and returns a redacted runtime error. Auth-code exchange, refresh, and client_credentials all consume the same
       record token_request profile; provider-specific token endpoint behavior is data, not a provider branch in the engine.
+    client_credentials_resource_scope_policy: >
+      Client-credentials connector packs may declare provider resource scopes such as
+      `https://graph.microsoft.com/.default` under `managed_credential.scopes` with `grant_model: scope_grant`. Readback,
+      boot, and execution prove only that the connected managed credential record covers the declared resource scope,
+      grant_model, token_request profile, lifecycle state, and bearer-token acquisition/re-acquisition. They MUST NOT claim
+      provider-specific app-role, delegated-scope, or admin-consent readiness unless a separate source-authoritative owner
+      for those permission claims is specified and implemented. Client-credentials refresh/re-acquisition repeats the
+      `grant_type=client_credentials` token request and MUST NOT require or send a refresh token.
     operator_surface:
       command: swarm connections connect|callback|status|disconnect
       rule: >


### PR DESCRIPTION
## Summary

- Add built-in `microsoft_graph.send_mail` as connector-pack data, imported explicitly through `connector_packs.imports[]`.
- Use `managed_credential.key: microsoft_graph_app` with `https://graph.microsoft.com/.default` as the scope/resource requirement; no app-role or admin-consent preflight claim.
- Add managed credential, pack/readback, and SQLite/Postgres runtime proofs against fake Microsoft identity + fake Microsoft Graph endpoints.

Closes #1893
Part of #1458
Related to #1862, #1870, #1869

## Governing refs / context

Authoritative spec refs updated or consumed:

- `platform-spec.yaml` activity supported tool sources and `activity_attempts` ordering.
- `platform-spec.yaml` HTTP tool `managed_credential` contract.
- `platform-spec.yaml` `provider_connector_tools` and connector pack profile.
- `platform-spec.yaml` `managed_credential_store`, including the new client-credentials resource-scope policy.
- `platform-spec.yaml` pack envelope/source authority and `connector_packs.imports[]`.

Binding issue context: #1893 approved gate as first slice under #1458/#1862. Graph app-role/JWT/admin-consent preflight remains watchlist-only; this PR proves token acquisition/resource-scope coverage and runtime dispatch, not provider-side permission readiness.

## Semantic ownership / migration

Canonical owners after the change:

- Connector declaration: normal `ToolSchemaEntry` with `category: provider_connector`.
- Pack admission: `internal/packs` envelope plus `internal/providerconnectors` connector verifier.
- Credential lifecycle: `internal/runtime/managedcredentials` and `managed_credential_store`.
- Non-idempotent dispatch/replay: `activity_attempts` through the HTTP activity executor.

Old producer / reader / writer path now invalid: none existed for Microsoft Graph. This PR intentionally does not add a Graph Go adapter, runtime branch, second connector DSL, static `Authorization` interpolation path, rate-limit handling, or app-role introspection owner.

Production paths checked for surviving old behavior: `rg` found no Microsoft Graph pack/runtime branch before the change; implementation adds only pack data and tests. Migration is complete for the chosen #1893 child class.

## Validation

- `go test ./internal/providerconnectors -run 'Test(DefaultPackRegistryLoadsMicrosoftGraph|MicrosoftGraphConnectorPack|ConnectorPack|SlackConnectorPack|NotionConnectorPack)' -count=1`
- `go test ./internal/runtime/managedcredentials -run 'TestTokenSourceClientCredentials' -count=1`
- `SWARM_TEST_POSTGRES_DSN='host=127.0.0.1 port=5432 user=youmew dbname=postgres sslmode=disable' PGPASSWORD=postgres go test ./internal/runtime -run 'Test(MicrosoftGraphClientCredentialsConnectorPackRoundTripThroughActivityJournal|SlackManagedCredentialConnectorPackRoundTripThroughActivityJournal|NotionManagedCredentialConnectorPackRoundTripThroughActivityJournal)' -count=1`
- `SWARM_TEST_POSTGRES_DSN='host=127.0.0.1 port=5432 user=youmew dbname=postgres sslmode=disable' PGPASSWORD=postgres go test ./...`
