### PR TITLE
[agent-a][issue #1890] Make fan-in stream resolution runnable

### DIFF
--- a/.github/test-shards/go-test-shards.json
+++ b/.github/test-shards/go-test-shards.json
@@ -60,6 +60,7 @@
         "github.com/division-sh/swarm/internal/events",
         "github.com/division-sh/swarm/internal/packs",
         "github.com/division-sh/swarm/internal/runtime/accprojection",
+        "github.com/division-sh/swarm/internal/runtime/accumulator",
         "github.com/division-sh/swarm/internal/runtime/authoringview",
         "github.com/division-sh/swarm/internal/runtime/authority",
         "github.com/division-sh/swarm/internal/runtime/bootverify",

--- a/.github/test-shards/go-test-shards.json
+++ b/.github/test-shards/go-test-shards.json
@@ -45,6 +45,7 @@
         "github.com/division-sh/swarm/internal/runtime/runstalled",
         "github.com/division-sh/swarm/internal/runtime/startupownership",
         "github.com/division-sh/swarm/internal/runtime/testfixtures/sealedpackage",
+        "github.com/division-sh/swarm/internal/runtime/testfixtures/templatefanin",
         "github.com/division-sh/swarm/internal/runtime/testfixtures/templateselectorcreate",
         "github.com/division-sh/swarm/internal/store/backendselection",
         "github.com/division-sh/swarm/internal/testtiming"

--- a/cmd/swarm/main_test.go
+++ b/cmd/swarm/main_test.go
@@ -4398,7 +4398,7 @@ func runServedRunControlLifecycleProof(t *testing.T, rt servedControlProofRuntim
 	waitServedEventPublishDeliveryStatusCountForRun(t, rt.DB, rt.Backend, runID, queued.EventID, "node", "entity-writer", "delivered", 1)
 	requireServedEventPublishEntityState(t, rt.DB, rt.Backend, runID, entityID, "done")
 	requireServedRunStatus(t, rt.Endpoint, runID, "completed")
-	requireServedParitySettlementPostconditions(t, rt.Endpoint, runID, servedparity.MustScenario(servedparity.ScenarioRunContinueControlLifecycle))
+	requireServedParitySettlementPostconditions(t, rt.Endpoint, rt.DB, rt.Backend, runID, servedparity.MustScenario(servedparity.ScenarioRunContinueControlLifecycle))
 
 	stopRunID, pendingEventID := seedServedRunControlPendingRunWithAgentDelivery(t, rt.DB, rt.Backend)
 	stopKey := "issue-1864-" + rt.Backend + "-" + stopRunID + "-run-stop"
@@ -4415,7 +4415,7 @@ func runServedRunControlLifecycleProof(t *testing.T, rt servedControlProofRuntim
 	})
 	requireServedControlAPIIdempotencyRows(t, rt.DB, rt.Backend, "run.stop", stopKey, 1)
 	requireServedRunStatus(t, rt.Endpoint, stopRunID, "cancelled")
-	requireServedParitySettlementPostconditions(t, rt.Endpoint, stopRunID, servedparity.MustScenario(servedparity.ScenarioRunStopControlLifecycle))
+	requireServedParitySettlementPostconditions(t, rt.Endpoint, rt.DB, rt.Backend, stopRunID, servedparity.MustScenario(servedparity.ScenarioRunStopControlLifecycle))
 }
 
 func runServedRuntimeIngressControlLifecycleProof(t *testing.T, rt servedControlProofRuntime) {
@@ -4466,7 +4466,7 @@ func runServedRuntimeIngressControlLifecycleProof(t *testing.T, rt servedControl
 
 	waitServedEventPublishReceiptOutcomeCount(t, rt.DB, rt.Backend, queued.EventID, "platform", "pipeline", "success", 1)
 	requireServedRunStatus(t, rt.Endpoint, queued.RunID, "running")
-	requireServedParitySettlementPostconditions(t, rt.Endpoint, queued.RunID, servedparity.MustScenario(servedparity.ScenarioRuntimeResumeIngressLifecycle))
+	requireServedParitySettlementPostconditions(t, rt.Endpoint, rt.DB, rt.Backend, queued.RunID, servedparity.MustScenario(servedparity.ScenarioRuntimeResumeIngressLifecycle))
 }
 
 type servedMailboxDecisionFixture struct {
@@ -4520,9 +4520,7 @@ func runServedMailboxApproveDecisionLifecycleProof(t *testing.T, rt servedContro
 	if already.Data["code"] != apiv1.MailboxAlreadyDecidedCode {
 		t.Fatalf("%s mailbox.reject already-decided data = %#v, want %s", rt.Backend, already.Data, apiv1.MailboxAlreadyDecidedCode)
 	}
-	requireServedParitySettlementPostconditionsWithDebug(t, rt.Endpoint, fixture.RunID, servedparity.MustScenario(servedparity.ScenarioMailboxApproveDecisionLifecycle), func() string {
-		return servedEventPublishDebugSummary(t, rt.DB, rt.Backend, fixture.RunID)
-	})
+	requireServedParitySettlementPostconditions(t, rt.Endpoint, rt.DB, rt.Backend, fixture.RunID, servedparity.MustScenario(servedparity.ScenarioMailboxApproveDecisionLifecycle))
 }
 
 func runServedMailboxRejectDecisionLifecycleProof(t *testing.T, rt servedControlProofRuntime) {
@@ -4550,9 +4548,7 @@ func runServedMailboxRejectDecisionLifecycleProof(t *testing.T, rt servedControl
 	})
 	requireServedMailboxReplay(t, rejectReplay, rejected)
 	requireServedMailboxEventCount(t, rt.DB, rt.Backend, "mailbox.item_decided", fixture.RejectID, 1)
-	requireServedParitySettlementPostconditionsWithDebug(t, rt.Endpoint, fixture.RunID, servedparity.MustScenario(servedparity.ScenarioMailboxRejectDecisionLifecycle), func() string {
-		return servedEventPublishDebugSummary(t, rt.DB, rt.Backend, fixture.RunID)
-	})
+	requireServedParitySettlementPostconditions(t, rt.Endpoint, rt.DB, rt.Backend, fixture.RunID, servedparity.MustScenario(servedparity.ScenarioMailboxRejectDecisionLifecycle))
 }
 
 func runServedMailboxDeferDecisionLifecycleProof(t *testing.T, rt servedControlProofRuntime) {
@@ -4580,9 +4576,13 @@ func runServedMailboxDeferDecisionLifecycleProof(t *testing.T, rt servedControlP
 	})
 	requireServedMailboxReplay(t, deferReplay, deferred)
 	requireServedMailboxEventCount(t, rt.DB, rt.Backend, "mailbox.item_deferred", fixture.DeferID, 1)
-	requireServedParitySettlementPostconditionsWithDebug(t, rt.Endpoint, fixture.RunID, servedparity.MustScenario(servedparity.ScenarioMailboxDeferDecisionLifecycle), func() string {
-		return servedEventPublishDebugSummary(t, rt.DB, rt.Backend, fixture.RunID)
-	})
+	for _, scenarioID := range []string{
+		servedparity.ScenarioMailboxApproveDecisionLifecycle,
+		servedparity.ScenarioMailboxRejectDecisionLifecycle,
+		servedparity.ScenarioMailboxDeferDecisionLifecycle,
+	} {
+		requireServedParitySettlementPostconditions(t, rt.Endpoint, rt.DB, rt.Backend, fixture.RunID, servedparity.MustScenario(scenarioID))
+	}
 }
 
 func runServedTestSetupEntitiesLifecycleProof(t *testing.T, rt servedControlProofRuntime) {
@@ -4647,7 +4647,7 @@ func runServedTestSetupEntitiesLifecycleProof(t *testing.T, rt servedControlProo
 	}
 	requireServedControlAPIIdempotencyRows(t, rt.DB, rt.Backend, "test.setup_entities", key, 1)
 	requireServedTestSetupPersistence(t, rt.DB, rt.Backend, runID, entityID, rt.BundleHash)
-	requireServedParitySettlementPostconditions(t, rt.Endpoint, runID, servedparity.MustScenario(servedparity.ScenarioTestSetupEntitiesLifecycle))
+	requireServedParitySettlementPostconditions(t, rt.Endpoint, rt.DB, rt.Backend, runID, servedparity.MustScenario(servedparity.ScenarioTestSetupEntitiesLifecycle))
 }
 
 func requireServedTestSetupPersistence(t *testing.T, db *sql.DB, backend, runID, entityID, bundleHash string) {
@@ -4772,24 +4772,73 @@ func seedServedMailboxDecisionFixture(t *testing.T, db *sql.DB, backend string) 
 	ctx := context.Background()
 	switch backend {
 	case "postgres":
-		if _, err := db.ExecContext(ctx, `INSERT INTO runs (run_id, status, started_at) VALUES ($1::uuid, 'running', $2)`, fixture.RunID, now); err != nil {
+		tx, err := db.BeginTx(ctx, nil)
+		if err != nil {
+			t.Fatalf("seed postgres mailbox proof tx: %v", err)
+		}
+		committed := false
+		defer func() {
+			if !committed {
+				_ = tx.Rollback()
+			}
+		}()
+		if _, err := tx.ExecContext(ctx, `INSERT INTO runs (run_id, status, started_at) VALUES ($1::uuid, 'running', $2)`, fixture.RunID, now); err != nil {
 			t.Fatalf("seed postgres mailbox proof run: %v", err)
 		}
-		pgStore := &store.PostgresStore{DB: db}
-		if err := seedServedMailboxDecisionSourceEvent(ctx, pgStore, fixture, now); err != nil {
+		if _, err := tx.ExecContext(ctx, `
+			INSERT INTO events (
+				event_id, run_id, event_name, entity_id, flow_instance, scope,
+				payload, produced_by, produced_by_type, created_at
+			) VALUES (
+				$1::uuid, $2::uuid, 'review.requested', $3::uuid, $4, 'entity',
+				'{"request":true}'::jsonb, 'operator', 'external', $5
+		)
+	`, fixture.SourceEventID, fixture.RunID, fixture.EntityID, fixture.SourceFlow, now); err != nil {
 			t.Fatalf("seed postgres mailbox proof source event: %v", err)
 		}
+		if err := (&store.PostgresStore{DB: db}).UpsertPipelineReceiptTx(ctx, tx, fixture.SourceEventID, "processed", ""); err != nil {
+			t.Fatalf("seed postgres mailbox proof source event pipeline receipt: %v", err)
+		}
+		if err := tx.Commit(); err != nil {
+			t.Fatalf("commit postgres mailbox proof seed: %v", err)
+		}
+		committed = true
 		seedServedMailboxDecisionItem(t, db, backend, fixture.ApproveID, fixture, "review_request", "approve item", `{"title":"approve item"}`, nil)
 		seedServedMailboxDecisionItem(t, db, backend, fixture.RejectID, fixture, "approval", "reject item", `{"title":"reject item"}`, nil)
 		seedServedMailboxDecisionItem(t, db, backend, fixture.DeferID, fixture, "operational_decision", "defer item", `{"title":"defer item"}`, &fixture.DeferExpires)
 	case "sqlite":
-		if _, err := db.ExecContext(ctx, `INSERT INTO runs (run_id, status, started_at) VALUES (?, 'running', ?)`, fixture.RunID, now); err != nil {
+		tx, err := db.BeginTx(ctx, nil)
+		if err != nil {
+			t.Fatalf("seed sqlite mailbox proof tx: %v", err)
+		}
+		committed := false
+		defer func() {
+			if !committed {
+				_ = tx.Rollback()
+			}
+		}()
+		if _, err := tx.ExecContext(ctx, `INSERT INTO runs (run_id, status, started_at) VALUES (?, 'running', ?)`, fixture.RunID, now); err != nil {
 			t.Fatalf("seed sqlite mailbox proof run: %v", err)
 		}
-		sqliteStore := &store.SQLiteRuntimeStore{SQLiteSchemaStore: &store.SQLiteSchemaStore{DB: db}}
-		if err := seedServedMailboxDecisionSourceEvent(ctx, sqliteStore, fixture, now); err != nil {
+		if _, err := tx.ExecContext(ctx, `
+			INSERT INTO events (
+				event_id, run_id, event_name, entity_id, flow_instance, scope,
+				payload, produced_by, produced_by_type, created_at
+			) VALUES (
+				?, ?, 'review.requested', ?, ?, 'entity',
+				'{"request":true}', 'operator', 'external', ?
+		)
+	`, fixture.SourceEventID, fixture.RunID, fixture.EntityID, fixture.SourceFlow, now); err != nil {
 			t.Fatalf("seed sqlite mailbox proof source event: %v", err)
 		}
+		sqliteStore := &store.SQLiteRuntimeStore{SQLiteSchemaStore: &store.SQLiteSchemaStore{DB: db}}
+		if err := sqliteStore.UpsertPipelineReceiptTx(ctx, tx, fixture.SourceEventID, "processed", ""); err != nil {
+			t.Fatalf("seed sqlite mailbox proof source event pipeline receipt: %v", err)
+		}
+		if err := tx.Commit(); err != nil {
+			t.Fatalf("commit sqlite mailbox proof seed: %v", err)
+		}
+		committed = true
 		seedServedMailboxDecisionItem(t, db, backend, fixture.ApproveID, fixture, "review_request", "approve item", `{"title":"approve item"}`, nil)
 		seedServedMailboxDecisionItem(t, db, backend, fixture.RejectID, fixture, "approval", "reject item", `{"title":"reject item"}`, nil)
 		seedServedMailboxDecisionItem(t, db, backend, fixture.DeferID, fixture, "operational_decision", "defer item", `{"title":"defer item"}`, &fixture.DeferExpires)
@@ -5385,15 +5434,15 @@ func runServedDynamicAutoEmitProof(t *testing.T, endpoint string, db *sql.DB, ba
 	requireServedRunDiagnoseOperationalState(t, endpoint, runID, "completed")
 	requireServedStatusCLIReadback(t, endpoint, runID, "status=completed")
 	requireServedReplayNoDeliveryHistoryNoMutation(t, endpoint, db, backend, autoEventID, "issue-1384-"+backend+"-replay-child-node-only")
-	requireServedParitySettlementPostconditions(t, endpoint, runID, servedparity.MustScenario(servedparity.ScenarioEventPublishDynamicAutoEmitLifecycle))
+	requireServedParitySettlementPostconditions(t, endpoint, db, backend, runID, servedparity.MustScenario(servedparity.ScenarioEventPublishDynamicAutoEmitLifecycle))
 }
 
-func requireServedParitySettlementPostconditions(t *testing.T, endpoint, runID string, scenario servedparity.Scenario) {
+func requireServedParitySettlementPostconditions(t *testing.T, endpoint string, db *sql.DB, backend, runID string, scenario servedparity.Scenario) {
 	t.Helper()
-	requireServedParitySettlementPostconditionsWithDebug(t, endpoint, runID, scenario, nil)
+	requireServedParitySettlementPostconditionsWithDebug(t, endpoint, db, backend, runID, scenario, nil)
 }
 
-func requireServedParitySettlementPostconditionsWithDebug(t *testing.T, endpoint, runID string, scenario servedparity.Scenario, debug func() string) {
+func requireServedParitySettlementPostconditionsWithDebug(t *testing.T, endpoint string, db *sql.DB, backend, runID string, scenario servedparity.Scenario, debug func() string) {
 	t.Helper()
 	var last diagnosticRunDiagnosisResult
 	deadline := time.Now().Add(servedProofPollDeadline)
@@ -5418,6 +5467,8 @@ func requireServedParitySettlementPostconditionsWithDebug(t *testing.T, endpoint
 	extra := ""
 	if debug != nil {
 		extra = "\n" + debug()
+	} else {
+		extra = "\n" + servedEventPublishDebugSummary(t, db, backend, runID)
 	}
 	t.Fatalf("served parity scenario %s settlement did not quiesce for run %s: ready=%v active_deliveries=%d unsettled_pipeline_events=%d due_timers=%d active_session_leases=%d%s",
 		scenario.ID,

--- a/internal/runtime/accumulator/effective_spec.go
+++ b/internal/runtime/accumulator/effective_spec.go
@@ -1,0 +1,106 @@
+package accumulator
+
+import (
+	"fmt"
+	"strings"
+
+	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
+	runtimeeventidentity "github.com/division-sh/swarm/internal/runtime/core/eventidentity"
+	"github.com/division-sh/swarm/internal/runtime/core/paths"
+	"github.com/division-sh/swarm/internal/runtime/semanticview"
+)
+
+func EffectiveSpecForHandler(source semanticview.Source, flowID, nodeID, handlerEvent string, spec *runtimecontracts.AccumulateSpec) (*runtimecontracts.AccumulateSpec, error) {
+	if spec == nil {
+		return nil, nil
+	}
+	pin, ok, err := FanInInputPinForHandler(source, flowID, nodeID, handlerEvent)
+	if err != nil {
+		return nil, err
+	}
+	if !ok {
+		return spec, nil
+	}
+	handlerEvent = strings.TrimSpace(handlerEvent)
+	if handlerEvent == "" {
+		handlerEvent = strings.TrimSpace(pin.EventType())
+	}
+	if dedup := strings.TrimSpace(spec.DedupBy); dedup != "" {
+		return nil, fmt.Errorf("receiver handler %s.%s accumulate.dedup_by %q must not redeclare fan-in dedup_by; declare it once on the receiver input pin resolution", strings.TrimSpace(nodeID), handlerEvent, dedup)
+	}
+	if window := strings.TrimSpace(spec.Window); window != "" {
+		return nil, fmt.Errorf("receiver handler %s.%s accumulate.window %q must not redeclare fan-in window; declare it once on the receiver input pin resolution", strings.TrimSpace(nodeID), handlerEvent, window)
+	}
+	resolution := pin.Resolution
+	window := strings.TrimSpace(resolution.Window)
+	if window == "" {
+		return nil, fmt.Errorf("resolution mode fan-in stream requires window for receiver input pin %s.%s", strings.TrimSpace(flowID), pin.PinName())
+	}
+	dedupBy := normalizedStrings(resolution.DedupBy)
+	if len(dedupBy) == 0 {
+		return nil, fmt.Errorf("resolution mode fan-in stream requires dedup_by for receiver input pin %s.%s; sender identity is not an implicit default", strings.TrimSpace(flowID), pin.PinName())
+	}
+	if len(dedupBy) != 1 {
+		return nil, fmt.Errorf("resolution mode fan-in stream supports exactly one dedup_by field in this slice for receiver input pin %s.%s, got %v", strings.TrimSpace(flowID), pin.PinName(), dedupBy)
+	}
+	effective := *spec
+	effective.Window = window
+	effective.WindowPath = paths.Parse(window)
+	effective.DedupBy = dedupBy[0]
+	effective.DedupPath = paths.Parse(dedupBy[0])
+	return &effective, nil
+}
+
+func FanInInputPinForHandler(source semanticview.Source, flowID, nodeID, handlerEvent string) (runtimecontracts.FlowInputEventPin, bool, error) {
+	if source == nil {
+		return runtimecontracts.FlowInputEventPin{}, false, nil
+	}
+	flowID = strings.TrimSpace(flowID)
+	handlerEvent = strings.TrimSpace(handlerEvent)
+	if flowID == "" || handlerEvent == "" {
+		return runtimecontracts.FlowInputEventPin{}, false, nil
+	}
+	var matched runtimecontracts.FlowInputEventPin
+	var matchedPins []string
+	for _, pin := range source.FlowInputEventPins(flowID) {
+		if pin.Resolution.Mode != runtimecontracts.FlowInputResolutionModeFanIn {
+			continue
+		}
+		if fanInInputPinMatchesHandlerEvent(source, flowID, pin, handlerEvent) {
+			matched = pin
+			matchedPins = append(matchedPins, pin.PinName())
+		}
+	}
+	if len(matchedPins) > 1 {
+		return runtimecontracts.FlowInputEventPin{}, false, fmt.Errorf("receiver handler %s.%s matches multiple fan-in input pins %v; fan-in accumulator semantics require exactly one receiver input pin owner", strings.TrimSpace(nodeID), handlerEvent, matchedPins)
+	}
+	if len(matchedPins) == 1 {
+		return matched, true, nil
+	}
+	return runtimecontracts.FlowInputEventPin{}, false, nil
+}
+
+func fanInInputPinMatchesHandlerEvent(source semanticview.Source, flowID string, pin runtimecontracts.FlowInputEventPin, handlerEvent string) bool {
+	handlerEvent = strings.TrimSpace(handlerEvent)
+	inputEvent := strings.TrimSpace(pin.EventType())
+	if source == nil || handlerEvent == "" || inputEvent == "" {
+		return false
+	}
+	if source.FlowEventMatches(flowID, handlerEvent, inputEvent) {
+		return true
+	}
+	resolvedInput := runtimeeventidentity.Normalize(source.ResolveFlowEventReference(flowID, inputEvent))
+	handler := runtimeeventidentity.Normalize(handlerEvent)
+	return handler == resolvedInput || handler == runtimeeventidentity.Normalize(inputEvent) || handler == runtimeeventidentity.Normalize(pin.PinName())
+}
+
+func normalizedStrings(values []string) []string {
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value != "" {
+			out = append(out, value)
+		}
+	}
+	return out
+}

--- a/internal/runtime/bootverify/workflow_composition_connect_checks.go
+++ b/internal/runtime/bootverify/workflow_composition_connect_checks.go
@@ -6,6 +6,7 @@ import (
 
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
 	"github.com/division-sh/swarm/internal/runtime/core/eventidentity"
+	runtimeflowidentity "github.com/division-sh/swarm/internal/runtime/core/flowidentity"
 	"github.com/division-sh/swarm/internal/runtime/entityruntime"
 	"github.com/division-sh/swarm/internal/runtime/semanticview"
 )
@@ -203,7 +204,7 @@ func validateCompositionConnectInstanceKey(source semanticview.Source, connect r
 	adapter := connect.Using.Instance
 	if !inputPin.Resolution.Empty() {
 		switch inputPin.Resolution.Mode {
-		case runtimecontracts.FlowInputResolutionModeCreate, runtimecontracts.FlowInputResolutionModeSelect, runtimecontracts.FlowInputResolutionModeSelectOrCreate:
+		case runtimecontracts.FlowInputResolutionModeCreate, runtimecontracts.FlowInputResolutionModeSelect, runtimecontracts.FlowInputResolutionModeSelectOrCreate, runtimecontracts.FlowInputResolutionModeFanIn:
 			if strings.TrimSpace(connect.Delivery) != "" && strings.TrimSpace(connect.Delivery) != "one" {
 				return []Finding{compositionConnectFinding(connect, "instance_resolution_invalid", fmt.Sprintf("resolution mode %s requires delivery one", inputPin.Resolution.Mode), receiverFlowID)}
 			}
@@ -314,8 +315,9 @@ func validateInputPinResolution(source semanticview.Source, flowID string, pin r
 		return validateCreateInputPinResolution(source, flowID, pin)
 	case runtimecontracts.FlowInputResolutionModeSelect, runtimecontracts.FlowInputResolutionModeSelectOrCreate:
 		return validateCarriedKeyInputPinResolution(source, flowID, pin, resolution.Mode)
-	case runtimecontracts.FlowInputResolutionModeFanIn,
-		runtimecontracts.FlowInputResolutionModeFanOut,
+	case runtimecontracts.FlowInputResolutionModeFanIn:
+		return validateFanInInputPinResolution(source, flowID, pin)
+	case runtimecontracts.FlowInputResolutionModeFanOut,
 		runtimecontracts.FlowInputResolutionModeReply:
 		findings = append(findings, inputPinResolutionFinding(flowID, pin, "instance_resolution_unimplemented", fmt.Sprintf("resolution mode %q is design-locked but not runnable in this slice", resolution.Mode), location))
 	case "":
@@ -324,6 +326,146 @@ func validateInputPinResolution(source semanticview.Source, flowID string, pin r
 		findings = append(findings, inputPinResolutionFinding(flowID, pin, "instance_resolution_invalid", fmt.Sprintf("resolution mode %q is not supported", resolution.Mode), location))
 	}
 	return findings
+}
+
+func validateFanInInputPinResolution(source semanticview.Source, flowID string, pin runtimecontracts.FlowInputEventPin) []Finding {
+	var findings []Finding
+	resolution := pin.Resolution
+	location := flowID
+	if !resolution.InstanceKey.Empty() || resolution.RepliesTo != "" || resolution.CorrelationKey != "" {
+		findings = append(findings, inputPinResolutionFinding(flowID, pin, "instance_resolution_invalid", "resolution mode fan-in may only declare aggregation, window, dedup_by, singleton, and carries", location))
+	}
+	if resolution.Aggregation != "stream" {
+		findings = append(findings, inputPinResolutionFinding(flowID, pin, "instance_resolution_invalid", fmt.Sprintf("resolution mode fan-in supports only aggregation: stream in this slice, got %q", resolution.Aggregation), location))
+	}
+	window := strings.TrimSpace(resolution.Window)
+	if window == "" {
+		findings = append(findings, inputPinResolutionFinding(flowID, pin, "instance_resolution_invalid", "resolution mode fan-in stream requires window", location))
+	} else if !validTopLevelPayloadPath(window) {
+		findings = append(findings, inputPinResolutionFinding(flowID, pin, "instance_resolution_invalid", fmt.Sprintf("resolution mode fan-in window %q must be one top-level payload field", window), location))
+	} else if !inputPinPayloadFieldExists(source, flowID, pin, window) {
+		findings = append(findings, inputPinResolutionFinding(flowID, pin, "instance_resolution_invalid", fmt.Sprintf("resolution mode fan-in window field %q is not declared on the receiver input event payload", window), location))
+	}
+	dedup, dedupOK, dedupDetail := validateFanInDedupBy(source, flowID, pin, resolution.DedupBy)
+	if !dedupOK {
+		findings = append(findings, inputPinResolutionFinding(flowID, pin, "instance_resolution_invalid", dedupDetail, location))
+	}
+	singleton := strings.Trim(strings.TrimSpace(resolution.Singleton), "/")
+	if singleton == "" {
+		findings = append(findings, inputPinResolutionFinding(flowID, pin, "instance_resolution_invalid", "resolution mode fan-in stream requires explicit singleton receiver identity", location))
+	} else {
+		bundle, ok := semanticview.Bundle(source)
+		if !ok || bundle == nil {
+			findings = append(findings, inputPinResolutionFinding(flowID, pin, "receiver_singleton_unavailable", "receiver singleton coordinator owner is unavailable for input pin resolution", location))
+		} else if _, err := bundle.ResolveFlowSingletonCoordinator(flowID); err != nil {
+			findings = append(findings, inputPinResolutionFinding(flowID, pin, "receiver_singleton_invalid", err.Error(), location))
+		}
+		scopeKey := strings.Trim(strings.TrimSpace(runtimeflowidentity.ScopeKey(source, flowID)), "/")
+		if scopeKey != "" && singleton != scopeKey && !strings.HasPrefix(singleton, scopeKey+"/") {
+			findings = append(findings, inputPinResolutionFinding(flowID, pin, "instance_resolution_invalid", fmt.Sprintf("resolution mode fan-in singleton %q must be the receiver singleton route or a child of %q", singleton, scopeKey), location))
+		}
+	}
+	if dedupOK && window != "" {
+		findings = append(findings, validateFanInAccumulatorConsistency(source, flowID, pin, dedup, window)...)
+	}
+	return findings
+}
+
+func validateFanInDedupBy(source semanticview.Source, flowID string, pin runtimecontracts.FlowInputEventPin, dedupBy []string) (string, bool, string) {
+	dedupBy = normalizedConnectAdapterFields(dedupBy)
+	if len(dedupBy) == 0 {
+		return "", false, "resolution mode fan-in stream requires dedup_by; sender identity is not an implicit default"
+	}
+	if len(dedupBy) != 1 {
+		return "", false, fmt.Sprintf("resolution mode fan-in stream supports exactly one dedup_by field in this slice, got %v", dedupBy)
+	}
+	dedup := strings.TrimSpace(dedupBy[0])
+	if dedup == "event.id" {
+		return dedup, true, ""
+	}
+	if !validTopLevelPayloadPath(dedup) {
+		return "", false, fmt.Sprintf("resolution mode fan-in dedup_by %q must be event.id or one top-level payload field", dedup)
+	}
+	if !inputPinPayloadFieldExists(source, flowID, pin, dedup) {
+		return "", false, fmt.Sprintf("resolution mode fan-in dedup_by field %q is not declared on the receiver input event payload", dedup)
+	}
+	return dedup, true, ""
+}
+
+func validateFanInAccumulatorConsistency(source semanticview.Source, flowID string, pin runtimecontracts.FlowInputEventPin, dedup, window string) []Finding {
+	var findings []Finding
+	scope, ok := source.FlowScopeByID(flowID)
+	if !ok {
+		return []Finding{inputPinResolutionFinding(flowID, pin, "receiver_flow_missing", fmt.Sprintf("receiver flow %s does not exist", flowID), flowID)}
+	}
+	matchedHandler := false
+	for nodeID := range scope.Nodes {
+		for handlerEvent, handler := range source.NodeEventHandlers(nodeID) {
+			if !fanInHandlerMatchesInputEvent(source, flowID, handlerEvent, pin.EventType()) {
+				continue
+			}
+			matchedHandler = true
+			if handler.Accumulate == nil {
+				findings = append(findings, inputPinResolutionFinding(flowID, pin, "instance_resolution_invalid", fmt.Sprintf("receiver handler %s.%s for fan-in input must declare accumulate", nodeID, handlerEvent), flowID))
+				continue
+			}
+			if strings.TrimSpace(handler.Accumulate.DedupBy) != dedup {
+				findings = append(findings, inputPinResolutionFinding(flowID, pin, "instance_resolution_invalid", fmt.Sprintf("receiver handler %s.%s accumulate.dedup_by %q must match fan-in dedup_by %q", nodeID, handlerEvent, handler.Accumulate.DedupBy, dedup), flowID))
+			}
+			if strings.TrimSpace(handler.Accumulate.Window) != window {
+				findings = append(findings, inputPinResolutionFinding(flowID, pin, "instance_resolution_invalid", fmt.Sprintf("receiver handler %s.%s accumulate.window %q must match fan-in window %q", nodeID, handlerEvent, handler.Accumulate.Window, window), flowID))
+			}
+		}
+	}
+	if !matchedHandler {
+		findings = append(findings, inputPinResolutionFinding(flowID, pin, "instance_resolution_invalid", fmt.Sprintf("receiver flow %s has no handler for fan-in input event %s", flowID, pin.EventType()), flowID))
+	}
+	return findings
+}
+
+func fanInHandlerMatchesInputEvent(source semanticview.Source, flowID, handlerEvent, inputEvent string) bool {
+	handlerEvent = strings.TrimSpace(handlerEvent)
+	inputEvent = strings.TrimSpace(inputEvent)
+	if handlerEvent == "" || inputEvent == "" {
+		return false
+	}
+	if source.FlowEventMatches(flowID, handlerEvent, inputEvent) {
+		return true
+	}
+	resolvedInput := eventidentity.Normalize(source.ResolveFlowEventReference(flowID, inputEvent))
+	return eventidentity.Normalize(handlerEvent) == resolvedInput || eventidentity.Normalize(handlerEvent) == eventidentity.Normalize(inputEvent)
+}
+
+func validTopLevelPayloadPath(path string) bool {
+	path = strings.TrimSpace(path)
+	if !strings.HasPrefix(path, "payload.") {
+		return false
+	}
+	field := strings.TrimSpace(strings.TrimPrefix(path, "payload."))
+	return field != "" && !strings.Contains(field, ".")
+}
+
+func inputPinPayloadFieldExists(source semanticview.Source, flowID string, pin runtimecontracts.FlowInputEventPin, path string) bool {
+	field := strings.TrimSpace(strings.TrimPrefix(strings.TrimSpace(path), "payload."))
+	if field == "" || strings.Contains(field, ".") {
+		return false
+	}
+	if carry, ok := pin.Carries[field]; ok && strings.TrimSpace(carry.From) == "payload."+field {
+		return true
+	}
+	entry, _, ok := source.ResolveFlowEventCatalogEntry(flowID, pin.EventType())
+	if !ok {
+		return false
+	}
+	if _, ok := entry.Payload.Properties[field]; ok {
+		return true
+	}
+	for _, required := range append(entry.Required, entry.Payload.Required...) {
+		if strings.TrimSpace(required) == field {
+			return true
+		}
+	}
+	return false
 }
 
 func validateCarriedKeyInputPinResolution(source semanticview.Source, flowID string, pin runtimecontracts.FlowInputEventPin, mode string) []Finding {

--- a/internal/runtime/bootverify/workflow_composition_connect_checks.go
+++ b/internal/runtime/bootverify/workflow_composition_connect_checks.go
@@ -346,7 +346,7 @@ func validateFanInInputPinResolution(source semanticview.Source, flowID string, 
 	} else if !inputPinPayloadFieldExists(source, flowID, pin, window) {
 		findings = append(findings, inputPinResolutionFinding(flowID, pin, "instance_resolution_invalid", fmt.Sprintf("resolution mode fan-in window field %q is not declared on the receiver input event payload", window), location))
 	}
-	dedup, dedupOK, dedupDetail := validateFanInDedupBy(source, flowID, pin, resolution.DedupBy)
+	_, dedupOK, dedupDetail := validateFanInDedupBy(source, flowID, pin, resolution.DedupBy)
 	if !dedupOK {
 		findings = append(findings, inputPinResolutionFinding(flowID, pin, "instance_resolution_invalid", dedupDetail, location))
 	}
@@ -366,7 +366,7 @@ func validateFanInInputPinResolution(source semanticview.Source, flowID string, 
 		}
 	}
 	if dedupOK && window != "" {
-		findings = append(findings, validateFanInAccumulatorConsistency(source, flowID, pin, dedup, window)...)
+		findings = append(findings, validateFanInAccumulatorConsistency(source, flowID, pin)...)
 	}
 	return findings
 }
@@ -392,7 +392,7 @@ func validateFanInDedupBy(source semanticview.Source, flowID string, pin runtime
 	return dedup, true, ""
 }
 
-func validateFanInAccumulatorConsistency(source semanticview.Source, flowID string, pin runtimecontracts.FlowInputEventPin, dedup, window string) []Finding {
+func validateFanInAccumulatorConsistency(source semanticview.Source, flowID string, pin runtimecontracts.FlowInputEventPin) []Finding {
 	var findings []Finding
 	scope, ok := source.FlowScopeByID(flowID)
 	if !ok {
@@ -409,11 +409,11 @@ func validateFanInAccumulatorConsistency(source semanticview.Source, flowID stri
 				findings = append(findings, inputPinResolutionFinding(flowID, pin, "instance_resolution_invalid", fmt.Sprintf("receiver handler %s.%s for fan-in input must declare accumulate", nodeID, handlerEvent), flowID))
 				continue
 			}
-			if strings.TrimSpace(handler.Accumulate.DedupBy) != dedup {
-				findings = append(findings, inputPinResolutionFinding(flowID, pin, "instance_resolution_invalid", fmt.Sprintf("receiver handler %s.%s accumulate.dedup_by %q must match fan-in dedup_by %q", nodeID, handlerEvent, handler.Accumulate.DedupBy, dedup), flowID))
+			if dedup := strings.TrimSpace(handler.Accumulate.DedupBy); dedup != "" {
+				findings = append(findings, inputPinResolutionFinding(flowID, pin, "instance_resolution_invalid", fmt.Sprintf("receiver handler %s.%s accumulate.dedup_by %q must not redeclare fan-in dedup_by; declare it once on the receiver input pin resolution", nodeID, handlerEvent, dedup), flowID))
 			}
-			if strings.TrimSpace(handler.Accumulate.Window) != window {
-				findings = append(findings, inputPinResolutionFinding(flowID, pin, "instance_resolution_invalid", fmt.Sprintf("receiver handler %s.%s accumulate.window %q must match fan-in window %q", nodeID, handlerEvent, handler.Accumulate.Window, window), flowID))
+			if window := strings.TrimSpace(handler.Accumulate.Window); window != "" {
+				findings = append(findings, inputPinResolutionFinding(flowID, pin, "instance_resolution_invalid", fmt.Sprintf("receiver handler %s.%s accumulate.window %q must not redeclare fan-in window; declare it once on the receiver input pin resolution", nodeID, handlerEvent, window), flowID))
 			}
 		}
 	}

--- a/internal/runtime/bootverify/workflow_composition_connect_checks_test.go
+++ b/internal/runtime/bootverify/workflow_composition_connect_checks_test.go
@@ -275,8 +275,8 @@ func TestRun_FailsClosedForInvalidFanInStreamInputResolution(t *testing.T) {
 		{name: "missing singleton", opts: templatefanin.Options{MissingSingleton: true}, want: "requires explicit singleton"},
 		{name: "wrong singleton", opts: templatefanin.Options{WrongSingleton: true}, want: "must be the receiver singleton route or a child"},
 		{name: "non-singleton receiver", opts: templatefanin.Options{NonSingletonReceiver: true}, want: "is not mode: singleton"},
-		{name: "accumulator dedup mismatch", opts: templatefanin.Options{AccumulateDedupMismatch: true}, want: "accumulate.dedup_by"},
-		{name: "accumulator window mismatch", opts: templatefanin.Options{AccumulateWindowMismatch: true}, want: "accumulate.window"},
+		{name: "accumulator dedup redeclaration", opts: templatefanin.Options{AccumulateDedupMismatch: true}, want: "accumulate.dedup_by \"payload.operating_id\" must not redeclare fan-in dedup_by"},
+		{name: "accumulator window redeclaration", opts: templatefanin.Options{AccumulateWindowMismatch: true}, want: "accumulate.window \"payload.operating_id\" must not redeclare fan-in window"},
 		{name: "wrong delivery", opts: templatefanin.Options{DeliveryMany: true}, want: "requires delivery one"},
 		{name: "legacy map", opts: templatefanin.Options{LegacyConnectMap: true}, want: "connect.map is incompatible with input pin resolution"},
 	}

--- a/internal/runtime/bootverify/workflow_composition_connect_checks_test.go
+++ b/internal/runtime/bootverify/workflow_composition_connect_checks_test.go
@@ -241,12 +241,24 @@ func TestRun_FailsClosedForInvalidCreateInputResolution(t *testing.T) {
 }
 
 func TestRun_AllowsFanInStreamInputResolution(t *testing.T) {
-	source := templatefanin.LoadSource(t, templatefanin.Options{})
+	tests := []struct {
+		name string
+		opts templatefanin.Options
+	}{
+		{name: "payload field dedup", opts: templatefanin.Options{}},
+		{name: "event id dedup", opts: templatefanin.Options{EventIDDedup: true}},
+	}
 
-	report := Run(context.Background(), source, Options{})
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			source := templatefanin.LoadSource(t, tc.opts)
 
-	if got := reportContains(report.Errors(), "composition_connect_validation", "fan-in"); got {
-		t.Fatalf("fan-in stream fixture composition_connect_validation errors = %#v, want none", report.Errors())
+			report := Run(context.Background(), source, Options{})
+
+			if got := reportContains(report.Errors(), "composition_connect_validation", "fan-in"); got {
+				t.Fatalf("fan-in stream fixture composition_connect_validation errors = %#v, want none", report.Errors())
+			}
+		})
 	}
 }
 
@@ -262,6 +274,7 @@ func TestRun_FailsClosedForInvalidFanInStreamInputResolution(t *testing.T) {
 		{name: "barrier remains unrunnable", opts: templatefanin.Options{BarrierAggregation: true}, want: "supports only aggregation: stream"},
 		{name: "missing singleton", opts: templatefanin.Options{MissingSingleton: true}, want: "requires explicit singleton"},
 		{name: "wrong singleton", opts: templatefanin.Options{WrongSingleton: true}, want: "must be the receiver singleton route or a child"},
+		{name: "non-singleton receiver", opts: templatefanin.Options{NonSingletonReceiver: true}, want: "is not mode: singleton"},
 		{name: "accumulator dedup mismatch", opts: templatefanin.Options{AccumulateDedupMismatch: true}, want: "accumulate.dedup_by"},
 		{name: "accumulator window mismatch", opts: templatefanin.Options{AccumulateWindowMismatch: true}, want: "accumulate.window"},
 		{name: "wrong delivery", opts: templatefanin.Options{DeliveryMany: true}, want: "requires delivery one"},

--- a/internal/runtime/bootverify/workflow_composition_connect_checks_test.go
+++ b/internal/runtime/bootverify/workflow_composition_connect_checks_test.go
@@ -275,6 +275,8 @@ func TestRun_FailsClosedForInvalidFanInStreamInputResolution(t *testing.T) {
 		{name: "missing singleton", opts: templatefanin.Options{MissingSingleton: true}, want: "requires explicit singleton"},
 		{name: "wrong singleton", opts: templatefanin.Options{WrongSingleton: true}, want: "must be the receiver singleton route or a child"},
 		{name: "non-singleton receiver", opts: templatefanin.Options{NonSingletonReceiver: true}, want: "is not mode: singleton"},
+		{name: "missing receiver handler", opts: templatefanin.Options{MissingReceiverHandler: true}, want: "has no handler for fan-in input event operating.reported"},
+		{name: "missing accumulate", opts: templatefanin.Options{MissingAccumulate: true}, want: "for fan-in input must declare accumulate"},
 		{name: "accumulator dedup redeclaration", opts: templatefanin.Options{AccumulateDedupMismatch: true}, want: "accumulate.dedup_by \"payload.operating_id\" must not redeclare fan-in dedup_by"},
 		{name: "accumulator window redeclaration", opts: templatefanin.Options{AccumulateWindowMismatch: true}, want: "accumulate.window \"payload.operating_id\" must not redeclare fan-in window"},
 		{name: "wrong delivery", opts: templatefanin.Options{DeliveryMany: true}, want: "requires delivery one"},

--- a/internal/runtime/bootverify/workflow_composition_connect_checks_test.go
+++ b/internal/runtime/bootverify/workflow_composition_connect_checks_test.go
@@ -8,6 +8,7 @@ import (
 
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
 	"github.com/division-sh/swarm/internal/runtime/semanticview"
+	"github.com/division-sh/swarm/internal/runtime/testfixtures/templatefanin"
 )
 
 func TestRun_AllowsParentCompositionConnectAsVerifyRouteProof(t *testing.T) {
@@ -191,7 +192,7 @@ func TestRun_FailsClosedForInvalidCreateInputResolution(t *testing.T) {
 		{
 			name: "non-runnable modes are design-locked but not runnable",
 			opts: createResolutionCompositionFixtureOptions{
-				mode:         runtimecontracts.FlowInputResolutionModeFanIn,
+				mode:         runtimecontracts.FlowInputResolutionModeFanOut,
 				mint:         runtimecontracts.FlowInputResolutionMintUUID,
 				includeCarry: true,
 			},
@@ -234,6 +235,46 @@ func TestRun_FailsClosedForInvalidCreateInputResolution(t *testing.T) {
 
 			if !reportContains(report.Errors(), "composition_connect_validation", tc.want) {
 				t.Fatalf("expected composition_connect_validation %q, got %#v", tc.want, report.Errors())
+			}
+		})
+	}
+}
+
+func TestRun_AllowsFanInStreamInputResolution(t *testing.T) {
+	source := templatefanin.LoadSource(t, templatefanin.Options{})
+
+	report := Run(context.Background(), source, Options{})
+
+	if got := reportContains(report.Errors(), "composition_connect_validation", "fan-in"); got {
+		t.Fatalf("fan-in stream fixture composition_connect_validation errors = %#v, want none", report.Errors())
+	}
+}
+
+func TestRun_FailsClosedForInvalidFanInStreamInputResolution(t *testing.T) {
+	tests := []struct {
+		name string
+		opts templatefanin.Options
+		want string
+	}{
+		{name: "missing dedup", opts: templatefanin.Options{MissingDedup: true}, want: "requires dedup_by"},
+		{name: "dedup tuple", opts: templatefanin.Options{DedupTuple: true}, want: "supports exactly one dedup_by field"},
+		{name: "missing window", opts: templatefanin.Options{MissingWindow: true}, want: "requires window"},
+		{name: "barrier remains unrunnable", opts: templatefanin.Options{BarrierAggregation: true}, want: "supports only aggregation: stream"},
+		{name: "missing singleton", opts: templatefanin.Options{MissingSingleton: true}, want: "requires explicit singleton"},
+		{name: "wrong singleton", opts: templatefanin.Options{WrongSingleton: true}, want: "must be the receiver singleton route or a child"},
+		{name: "accumulator dedup mismatch", opts: templatefanin.Options{AccumulateDedupMismatch: true}, want: "accumulate.dedup_by"},
+		{name: "accumulator window mismatch", opts: templatefanin.Options{AccumulateWindowMismatch: true}, want: "accumulate.window"},
+		{name: "wrong delivery", opts: templatefanin.Options{DeliveryMany: true}, want: "requires delivery one"},
+		{name: "legacy map", opts: templatefanin.Options{LegacyConnectMap: true}, want: "connect.map is incompatible with input pin resolution"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			source := templatefanin.LoadSource(t, tc.opts)
+
+			report := Run(context.Background(), source, Options{})
+
+			if !reportContains(report.Errors(), "composition_connect_validation", tc.want) {
+				t.Fatalf("expected fan-in composition_connect_validation %q, got %#v", tc.want, report.Errors())
 			}
 		})
 	}

--- a/internal/runtime/bootverify/workflow_flow_boundary_checks.go
+++ b/internal/runtime/bootverify/workflow_flow_boundary_checks.go
@@ -597,6 +597,9 @@ func (c *checkerContext) flowBoundaryCreateEntityValidation() []Finding {
 				if handler.SelectOrCreateEntity != nil && !handler.SelectOrCreateEntity.Empty() {
 					continue
 				}
+				if flowInputHandlerUsesResolutionMode(c.source, validationScope.semanticFlowID, eventType, runtimecontracts.FlowInputResolutionModeFanIn) {
+					continue
+				}
 				c.flowBoundaryCreateEntityFindings = append(c.flowBoundaryCreateEntityFindings, Finding{
 					CheckID:  "flow_boundary_create_entity_validation",
 					Severity: "error",
@@ -705,6 +708,36 @@ func flowInputEventDeclaresPayloadField(source semanticview.Source, flowID, even
 	}
 	proof := semanticview.ResolveFlowEventProof(source, flowID, eventType)
 	return eventEntryDeclaresPayloadField(proof.Entry, field)
+}
+
+func flowInputHandlerUsesResolutionMode(source semanticview.Source, flowID, handlerEvent, mode string) bool {
+	if source == nil {
+		return false
+	}
+	handlerEvent = strings.TrimSpace(handlerEvent)
+	mode = strings.TrimSpace(mode)
+	if handlerEvent == "" || mode == "" {
+		return false
+	}
+	for _, pin := range source.FlowInputEventPins(flowID) {
+		if strings.TrimSpace(pin.Resolution.Mode) != mode {
+			continue
+		}
+		pinEvent := strings.TrimSpace(pin.EventType())
+		if pinEvent == "" {
+			continue
+		}
+		if source.FlowEventMatches(flowID, handlerEvent, pinEvent) {
+			return true
+		}
+		handler := eventidentity.Normalize(handlerEvent)
+		if handler == eventidentity.Normalize(source.ResolveFlowEventReference(flowID, pinEvent)) ||
+			handler == eventidentity.Normalize(pinEvent) ||
+			handler == eventidentity.Normalize(pin.PinName()) {
+			return true
+		}
+	}
+	return false
 }
 
 func eventEntryDeclaresPayloadField(entry runtimecontracts.EventCatalogEntry, field string) bool {

--- a/internal/runtime/bus/connect_route_plan_dispatch.go
+++ b/internal/runtime/bus/connect_route_plan_dispatch.go
@@ -236,13 +236,29 @@ func (r connectRoutePlanResolver) resolveSelectedReceiverCarriers(plan runtimepi
 	out := make([]Subscriber, 0, len(keys))
 	for _, key := range keys {
 		for _, subscriber := range r.routeTable.Resolve(key) {
-			if !connectSubscriberMatchesTarget(subscriber, target) {
+			if !connectSubscriberMatchesPlanTarget(plan, subscriber, target) {
 				continue
 			}
 			out = append(out, subscriber)
 		}
 	}
 	return dedupeSubscribers(out)
+}
+
+func connectSubscriberMatchesPlanTarget(plan runtimepinrouting.ConnectRoutePlan, subscriber Subscriber, target events.RouteIdentity) bool {
+	if connectSubscriberMatchesTarget(subscriber, target) {
+		return true
+	}
+	if plan.FanIn == nil {
+		return false
+	}
+	path := strings.Trim(strings.TrimSpace(subscriber.Path), "/")
+	receiverPath := strings.Trim(strings.TrimSpace(plan.Receiver.FlowPath), "/")
+	targetPath := strings.Trim(strings.TrimSpace(target.FlowInstance), "/")
+	if path == "" || receiverPath == "" || targetPath == "" || path != receiverPath {
+		return false
+	}
+	return targetPath == receiverPath || strings.HasPrefix(targetPath, receiverPath+"/")
 }
 
 func (r connectRoutePlanResolver) connectIssueMatchesEvent(issue runtimepinrouting.ConnectRoutePlanIssue, evt events.Event) bool {

--- a/internal/runtime/conformance/fan_in_stream_conformance_test.go
+++ b/internal/runtime/conformance/fan_in_stream_conformance_test.go
@@ -85,6 +85,70 @@ func TestFanInStreamConformance_RoutesToSingletonAndKernelEnforcesWindowedDedup(
 	}
 }
 
+func TestFanInStreamConformance_EventIDDedupUsesEventIdentity(t *testing.T) {
+	ctx := context.Background()
+	source := templatefanin.LoadSource(t, templatefanin.Options{EventIDDedup: true})
+	report := runtimebootverify.Run(ctx, source, runtimebootverify.Options{})
+	if got := report.HardInvalidities(); len(got) != 0 {
+		t.Fatalf("fan-in stream event.id hard invalidities = %#v, want none", got)
+	}
+
+	store := &fanInStreamMemoryStore{}
+	eb, err := bus.NewEventBusWithOptions(store, bus.EventBusOptions{
+		ContractBundle: source,
+		TemplateInstanceActivator: func(context.Context, runtimepipeline.FlowInstanceActivationRequest) error {
+			t.Fatal("fan-in stream routes to an explicit singleton; template activation is not authoritative")
+			return nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewEventBusWithOptions: %v", err)
+	}
+	exec, err := runtimeengine.NewExecutor(runtimeengine.RuntimeDependencies{
+		Source:     source,
+		StateRepo:  fanOutPinRouteStateRepo{},
+		TxRunner:   fanOutPinRouteTxRunner{},
+		Locker:     fanOutPinRouteLocker{},
+		Outbox:     fanOutPinRouteOutbox{},
+		Dispatcher: fanOutPinRouteDispatcher{},
+	}, nil)
+	if err != nil {
+		t.Fatalf("NewExecutor: %v", err)
+	}
+	handler, ok := source.NodeEventHandler(templatefanin.ReceiverNodeID, templatefanin.ReceiverEvent)
+	if !ok {
+		t.Fatalf("receiver handler %s/%s missing", templatefanin.ReceiverNodeID, templatefanin.ReceiverEvent)
+	}
+
+	state := runtimeengine.StateSnapshot{
+		EntityID:     "portfolio-entity",
+		CurrentState: "active",
+		StateCarrier: runtimeengine.NewStateCarrier(map[string]any{}, nil, nil),
+	}
+	target := events.RouteIdentity{
+		FlowID:       templatefanin.ReceiverFlowID,
+		FlowInstance: templatefanin.ReceiverFlowInstance,
+	}.Normalized()
+
+	first := fanInStreamEvent(source.ResolveFlowEventReference(templatefanin.ProducerFlowID, templatefanin.ProducerEvent), "evt-fanin-event-id", "operating/a", "report-1", "2026-Q1", 100)
+	state = fanInStreamPublishAndExecute(t, ctx, eb, store, exec, handler, state, first, target)
+	if got := fanInStreamAccumulatorItemCount(t, state.StateCarrier.StateBuckets, "2026-Q1"); got != 1 {
+		t.Fatalf("Q1 accumulator items after first = %d, want 1", got)
+	}
+
+	sameEventDifferentPayloadKey := fanInStreamEvent(source.ResolveFlowEventReference(templatefanin.ProducerFlowID, templatefanin.ProducerEvent), "evt-fanin-event-id", "operating/b", "report-2", "2026-Q1", 200)
+	state = fanInStreamPublishAndExecute(t, ctx, eb, store, exec, handler, state, sameEventDifferentPayloadKey, target)
+	if got := fanInStreamAccumulatorItemCount(t, state.StateCarrier.StateBuckets, "2026-Q1"); got != 1 {
+		t.Fatalf("Q1 accumulator items after same event id = %d, want 1", got)
+	}
+
+	nextEvent := fanInStreamEvent(source.ResolveFlowEventReference(templatefanin.ProducerFlowID, templatefanin.ProducerEvent), "evt-fanin-event-id-2", "operating/c", "report-2", "2026-Q1", 300)
+	state = fanInStreamPublishAndExecute(t, ctx, eb, store, exec, handler, state, nextEvent, target)
+	if got := fanInStreamAccumulatorItemCount(t, state.StateCarrier.StateBuckets, "2026-Q1"); got != 2 {
+		t.Fatalf("Q1 accumulator items after distinct event id = %d, want 2", got)
+	}
+}
+
 type fanInStreamMemoryStore struct {
 	bus.InMemoryEventStore
 	events         map[string]events.Event

--- a/internal/runtime/conformance/fan_in_stream_conformance_test.go
+++ b/internal/runtime/conformance/fan_in_stream_conformance_test.go
@@ -1,0 +1,260 @@
+package conformance
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/division-sh/swarm/internal/events"
+	"github.com/division-sh/swarm/internal/events/eventtest"
+	runtimebootverify "github.com/division-sh/swarm/internal/runtime/bootverify"
+	"github.com/division-sh/swarm/internal/runtime/bus"
+	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
+	runtimeidentity "github.com/division-sh/swarm/internal/runtime/core/identity"
+	"github.com/division-sh/swarm/internal/runtime/core/timeridentity"
+	runtimeengine "github.com/division-sh/swarm/internal/runtime/engine"
+	runtimepipeline "github.com/division-sh/swarm/internal/runtime/pipeline"
+	runtimereplayclaim "github.com/division-sh/swarm/internal/runtime/replayclaim"
+	"github.com/division-sh/swarm/internal/runtime/testfixtures/templatefanin"
+)
+
+func TestFanInStreamConformance_RoutesToSingletonAndKernelEnforcesWindowedDedup(t *testing.T) {
+	ctx := context.Background()
+	source := templatefanin.LoadSource(t, templatefanin.Options{})
+	report := runtimebootverify.Run(ctx, source, runtimebootverify.Options{})
+	if got := report.HardInvalidities(); len(got) != 0 {
+		t.Fatalf("fan-in stream hard invalidities = %#v, want none", got)
+	}
+
+	store := &fanInStreamMemoryStore{}
+	eb, err := bus.NewEventBusWithOptions(store, bus.EventBusOptions{
+		ContractBundle: source,
+		TemplateInstanceActivator: func(context.Context, runtimepipeline.FlowInstanceActivationRequest) error {
+			t.Fatal("fan-in stream routes to an explicit singleton; template activation is not authoritative")
+			return nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewEventBusWithOptions: %v", err)
+	}
+	exec, err := runtimeengine.NewExecutor(runtimeengine.RuntimeDependencies{
+		Source:     source,
+		StateRepo:  fanOutPinRouteStateRepo{},
+		TxRunner:   fanOutPinRouteTxRunner{},
+		Locker:     fanOutPinRouteLocker{},
+		Outbox:     fanOutPinRouteOutbox{},
+		Dispatcher: fanOutPinRouteDispatcher{},
+	}, nil)
+	if err != nil {
+		t.Fatalf("NewExecutor: %v", err)
+	}
+	handler, ok := source.NodeEventHandler(templatefanin.ReceiverNodeID, templatefanin.ReceiverEvent)
+	if !ok {
+		t.Fatalf("receiver handler %s/%s missing", templatefanin.ReceiverNodeID, templatefanin.ReceiverEvent)
+	}
+
+	state := runtimeengine.StateSnapshot{
+		EntityID:     "portfolio-entity",
+		CurrentState: "active",
+		StateCarrier: runtimeengine.NewStateCarrier(map[string]any{}, nil, nil),
+	}
+	target := events.RouteIdentity{
+		FlowID:       templatefanin.ReceiverFlowID,
+		FlowInstance: templatefanin.ReceiverFlowInstance,
+	}.Normalized()
+	first := fanInStreamEvent(source.ResolveFlowEventReference(templatefanin.ProducerFlowID, templatefanin.ProducerEvent), "evt-fanin-a", "operating/a", "report-1", "2026-Q1", 100)
+	state = fanInStreamPublishAndExecute(t, ctx, eb, store, exec, handler, state, first, target)
+	if got := fanInStreamAccumulatorItemCount(t, state.StateCarrier.StateBuckets, "2026-Q1"); got != 1 {
+		t.Fatalf("Q1 accumulator items after first = %d, want 1", got)
+	}
+
+	duplicate := fanInStreamEvent(source.ResolveFlowEventReference(templatefanin.ProducerFlowID, templatefanin.ProducerEvent), "evt-fanin-b", "operating/b", "report-1", "2026-Q1", 200)
+	state = fanInStreamPublishAndExecute(t, ctx, eb, store, exec, handler, state, duplicate, target)
+	if got := fanInStreamAccumulatorItemCount(t, state.StateCarrier.StateBuckets, "2026-Q1"); got != 1 {
+		t.Fatalf("Q1 accumulator items after duplicate = %d, want 1", got)
+	}
+
+	nextWindow := fanInStreamEvent(source.ResolveFlowEventReference(templatefanin.ProducerFlowID, templatefanin.ProducerEvent), "evt-fanin-c", "operating/c", "report-1", "2026-Q2", 300)
+	state = fanInStreamPublishAndExecute(t, ctx, eb, store, exec, handler, state, nextWindow, target)
+	if got := fanInStreamAccumulatorItemCount(t, state.StateCarrier.StateBuckets, "2026-Q1"); got != 1 {
+		t.Fatalf("Q1 accumulator items after Q2 = %d, want 1", got)
+	}
+	if got := fanInStreamAccumulatorItemCount(t, state.StateCarrier.StateBuckets, "2026-Q2"); got != 1 {
+		t.Fatalf("Q2 accumulator items = %d, want 1", got)
+	}
+}
+
+type fanInStreamMemoryStore struct {
+	bus.InMemoryEventStore
+	events         map[string]events.Event
+	deliveryRoutes map[string][]events.DeliveryRoute
+	scopes         map[string]runtimereplayclaim.CommittedReplayScope
+}
+
+func (s *fanInStreamMemoryStore) SupportsPersistedReplay() bool { return true }
+
+func (s *fanInStreamMemoryStore) PersistEventWithDeliveryRouteSetAndScope(_ context.Context, evt events.Event, routes []events.DeliveryRoute, scope runtimereplayclaim.CommittedReplayScope) error {
+	if s.events == nil {
+		s.events = map[string]events.Event{}
+	}
+	if s.deliveryRoutes == nil {
+		s.deliveryRoutes = map[string][]events.DeliveryRoute{}
+	}
+	if s.scopes == nil {
+		s.scopes = map[string]runtimereplayclaim.CommittedReplayScope{}
+	}
+	s.events[evt.ID()] = evt
+	s.deliveryRoutes[evt.ID()] = events.NormalizeDeliveryRoutes(routes)
+	s.scopes[evt.ID()] = scope
+	return nil
+}
+
+func (s *fanInStreamMemoryStore) InsertEventDeliveryRoutes(_ context.Context, eventID string, routes []events.DeliveryRoute) error {
+	if s.deliveryRoutes == nil {
+		s.deliveryRoutes = map[string][]events.DeliveryRoute{}
+	}
+	s.deliveryRoutes[eventID] = events.NormalizeDeliveryRoutes(routes)
+	return nil
+}
+
+func (s *fanInStreamMemoryStore) ListEventDeliveryRoutes(_ context.Context, eventID string) ([]events.DeliveryRoute, error) {
+	return append([]events.DeliveryRoute(nil), s.deliveryRoutes[eventID]...), nil
+}
+
+func (s *fanInStreamMemoryStore) UpsertCommittedReplayScope(_ context.Context, eventID string, scope runtimereplayclaim.CommittedReplayScope) error {
+	if s.scopes == nil {
+		s.scopes = map[string]runtimereplayclaim.CommittedReplayScope{}
+	}
+	s.scopes[eventID] = scope
+	return nil
+}
+
+func (s *fanInStreamMemoryStore) LoadCommittedReplayScope(_ context.Context, eventID string) (runtimereplayclaim.CommittedReplayScope, error) {
+	scope := s.scopes[eventID]
+	if scope == "" {
+		return "", runtimereplayclaim.ErrMissingCommittedReplayScope
+	}
+	return scope, nil
+}
+
+func (s *fanInStreamMemoryStore) ListEventDeliveryRecipients(context.Context, string) ([]string, error) {
+	return nil, nil
+}
+
+func fanInStreamPublishAndExecute(
+	t *testing.T,
+	ctx context.Context,
+	eb *bus.EventBus,
+	store *fanInStreamMemoryStore,
+	exec *runtimeengine.Executor,
+	handler runtimecontracts.SystemNodeEventHandler,
+	state runtimeengine.StateSnapshot,
+	evt events.Event,
+	target events.RouteIdentity,
+) runtimeengine.StateSnapshot {
+	t.Helper()
+	preflight, err := eb.CheckPublishRecipientPlan(ctx, evt)
+	if err != nil {
+		t.Fatalf("CheckPublishRecipientPlan(%s): %v", evt.ID(), err)
+	}
+	if preflight.TargetFailure != "" || !fanInStreamRoutesContain(preflight.DeliveryRoutes, target) {
+		t.Fatalf("preflight for %s = failure:%q routes:%#v, want singleton target %#v", evt.ID(), preflight.TargetFailure, preflight.DeliveryRoutes, target)
+	}
+	if err := eb.Publish(ctx, evt); err != nil {
+		t.Fatalf("Publish(%s): %v", evt.ID(), err)
+	}
+	if !fanInStreamRoutesContain(store.deliveryRoutes[evt.ID()], target) {
+		t.Fatalf("persisted routes for %s = %#v, want singleton target %#v", evt.ID(), store.deliveryRoutes[evt.ID()], target)
+	}
+	if got := store.scopes[evt.ID()]; got != runtimereplayclaim.CommittedReplayScopeSubscribed {
+		t.Fatalf("committed replay scope for %s = %q, want subscribed", evt.ID(), got)
+	}
+	if err := eb.PublishPersistedRecipients(ctx, evt, nil); err != nil {
+		t.Fatalf("PublishPersistedRecipients(%s): %v", evt.ID(), err)
+	}
+	result, err := exec.Execute(ctx, runtimeengine.ExecutionRequest{
+		EntityID:        state.EntityID,
+		NodeID:          runtimeidentity.NodeID(templatefanin.ReceiverNodeID),
+		FlowID:          runtimeidentity.FlowID(templatefanin.ReceiverFlowID),
+		Event:           evt,
+		HandlerEventKey: templatefanin.ReceiverEvent,
+		Handler:         handler,
+		ProducerRoute:   target,
+		State:           state,
+		MaxDepth:        10,
+		ChainDepth:      0,
+		ExecutionID:     evt.ID(),
+	})
+	if err != nil {
+		t.Fatalf("Execute(%s): %v", evt.ID(), err)
+	}
+	return runtimeengine.StateSnapshot{
+		EntityID:     state.EntityID,
+		CurrentState: state.CurrentState,
+		StateCarrier: result.StateMutation.StateCarrier,
+	}
+}
+
+func fanInStreamEvent(eventType, id, flowInstance, reportID, periodID string, revenue int) events.Event {
+	payload, _ := json.Marshal(map[string]any{
+		"portfolio_id": "portfolio-default",
+		"report_id":    reportID,
+		"period_id":    periodID,
+		"operating_id": flowInstance,
+		"revenue":      revenue,
+	})
+	return eventtest.RootIngress(
+		id,
+		events.EventType(eventType),
+		"",
+		"",
+		payload,
+		0,
+		"run-fanin-stream",
+		"",
+		events.EnvelopeForSourceRoute(events.EventEnvelope{}, events.RouteIdentity{
+			FlowID:       templatefanin.ProducerFlowID,
+			FlowInstance: flowInstance,
+			EntityID:     flowInstance + "-entity",
+		}),
+		time.Now().UTC(),
+	)
+}
+
+func fanInStreamRoutesContain(routes []events.DeliveryRoute, target events.RouteIdentity) bool {
+	target = target.Normalized()
+	for _, route := range events.NormalizeDeliveryRoutes(routes) {
+		if route.SubscriberType == "node" && route.SubscriberID == templatefanin.ReceiverNodeID &&
+			route.Target.FlowID == target.FlowID && route.Target.FlowInstance == target.FlowInstance {
+			return true
+		}
+	}
+	return false
+}
+
+func fanInStreamAccumulatorItemCount(t *testing.T, buckets map[string]map[string]any, window string) int {
+	t.Helper()
+	key := timeridentity.NewAccumulatorWindowBucketRef(templatefanin.ReceiverNodeID, templatefanin.ReceiverEvent, window).Key()
+	nodeBucket, ok := buckets[templatefanin.ReceiverNodeID]
+	if !ok {
+		t.Fatalf("receiver node bucket missing from %#v", buckets)
+	}
+	accumulators, ok := nodeBucket["handler_accumulators"].(map[string]any)
+	if !ok {
+		t.Fatalf("handler accumulator map missing from %#v", nodeBucket)
+	}
+	raw, ok := accumulators[key].(map[string]any)
+	if !ok {
+		t.Fatalf("window accumulator %q missing from %#v", key, accumulators)
+	}
+	switch items := raw["items"].(type) {
+	case []map[string]any:
+		return len(items)
+	case []any:
+		return len(items)
+	default:
+		t.Fatalf("accumulator items have unexpected shape: %#v", raw["items"])
+		return 0
+	}
+}

--- a/internal/runtime/conformance/fan_in_stream_conformance_test.go
+++ b/internal/runtime/conformance/fan_in_stream_conformance_test.go
@@ -11,6 +11,7 @@ import (
 	runtimebootverify "github.com/division-sh/swarm/internal/runtime/bootverify"
 	"github.com/division-sh/swarm/internal/runtime/bus"
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
+	runtimeflowidentity "github.com/division-sh/swarm/internal/runtime/core/flowidentity"
 	runtimeidentity "github.com/division-sh/swarm/internal/runtime/core/identity"
 	"github.com/division-sh/swarm/internal/runtime/core/timeridentity"
 	runtimeengine "github.com/division-sh/swarm/internal/runtime/engine"
@@ -55,13 +56,13 @@ func TestFanInStreamConformance_RoutesToSingletonAndKernelEnforcesWindowedDedup(
 	}
 
 	state := runtimeengine.StateSnapshot{
-		EntityID:     "portfolio-entity",
 		CurrentState: "active",
 		StateCarrier: runtimeengine.NewStateCarrier(map[string]any{}, nil, nil),
 	}
 	target := events.RouteIdentity{
 		FlowID:       templatefanin.ReceiverFlowID,
 		FlowInstance: templatefanin.ReceiverFlowInstance,
+		EntityID:     runtimeflowidentity.EntityID(templatefanin.ReceiverFlowInstance),
 	}.Normalized()
 	first := fanInStreamEvent(source.ResolveFlowEventReference(templatefanin.ProducerFlowID, templatefanin.ProducerEvent), "evt-fanin-a", "operating/a", "report-1", "2026-Q1", 100)
 	state = fanInStreamPublishAndExecute(t, ctx, eb, store, exec, handler, state, first, target)
@@ -121,13 +122,13 @@ func TestFanInStreamConformance_EventIDDedupUsesEventIdentity(t *testing.T) {
 	}
 
 	state := runtimeengine.StateSnapshot{
-		EntityID:     "portfolio-entity",
 		CurrentState: "active",
 		StateCarrier: runtimeengine.NewStateCarrier(map[string]any{}, nil, nil),
 	}
 	target := events.RouteIdentity{
 		FlowID:       templatefanin.ReceiverFlowID,
 		FlowInstance: templatefanin.ReceiverFlowInstance,
+		EntityID:     runtimeflowidentity.EntityID(templatefanin.ReceiverFlowInstance),
 	}.Normalized()
 
 	first := fanInStreamEvent(source.ResolveFlowEventReference(templatefanin.ProducerFlowID, templatefanin.ProducerEvent), "evt-fanin-event-id", "operating/a", "report-1", "2026-Q1", 100)
@@ -228,8 +229,12 @@ func fanInStreamPublishAndExecute(
 	if err := eb.Publish(ctx, evt); err != nil {
 		t.Fatalf("Publish(%s): %v", evt.ID(), err)
 	}
-	if !fanInStreamRoutesContain(store.deliveryRoutes[evt.ID()], target) {
+	deliveryTarget, ok := fanInStreamTargetRoute(store.deliveryRoutes[evt.ID()], target)
+	if !ok {
 		t.Fatalf("persisted routes for %s = %#v, want singleton target %#v", evt.ID(), store.deliveryRoutes[evt.ID()], target)
+	}
+	if deliveryTarget.EntityID == "" {
+		t.Fatalf("persisted route for %s has empty entity_id: %#v", evt.ID(), deliveryTarget)
 	}
 	if got := store.scopes[evt.ID()]; got != runtimereplayclaim.CommittedReplayScopeSubscribed {
 		t.Fatalf("committed replay scope for %s = %q, want subscribed", evt.ID(), got)
@@ -237,15 +242,20 @@ func fanInStreamPublishAndExecute(
 	if err := eb.PublishPersistedRecipients(ctx, evt, nil); err != nil {
 		t.Fatalf("PublishPersistedRecipients(%s): %v", evt.ID(), err)
 	}
+	delivered := eventtest.TargetRouted(evt, deliveryTarget)
+	if got := delivered.EntityID(); got != deliveryTarget.EntityID {
+		t.Fatalf("delivered event %s entity_id = %q, want delivery target entity %q", evt.ID(), got, deliveryTarget.EntityID)
+	}
+	executionState := state
+	executionState.EntityID = ""
 	result, err := exec.Execute(ctx, runtimeengine.ExecutionRequest{
-		EntityID:        state.EntityID,
 		NodeID:          runtimeidentity.NodeID(templatefanin.ReceiverNodeID),
 		FlowID:          runtimeidentity.FlowID(templatefanin.ReceiverFlowID),
-		Event:           evt,
+		Event:           delivered,
 		HandlerEventKey: templatefanin.ReceiverEvent,
 		Handler:         handler,
 		ProducerRoute:   target,
-		State:           state,
+		State:           executionState,
 		MaxDepth:        10,
 		ChainDepth:      0,
 		ExecutionID:     evt.ID(),
@@ -254,7 +264,7 @@ func fanInStreamPublishAndExecute(
 		t.Fatalf("Execute(%s): %v", evt.ID(), err)
 	}
 	return runtimeengine.StateSnapshot{
-		EntityID:     state.EntityID,
+		EntityID:     runtimeidentity.EntityID(deliveryTarget.EntityID),
 		CurrentState: state.CurrentState,
 		StateCarrier: result.StateMutation.StateCarrier,
 	}
@@ -287,14 +297,20 @@ func fanInStreamEvent(eventType, id, flowInstance, reportID, periodID string, re
 }
 
 func fanInStreamRoutesContain(routes []events.DeliveryRoute, target events.RouteIdentity) bool {
+	_, ok := fanInStreamTargetRoute(routes, target)
+	return ok
+}
+
+func fanInStreamTargetRoute(routes []events.DeliveryRoute, target events.RouteIdentity) (events.RouteIdentity, bool) {
 	target = target.Normalized()
 	for _, route := range events.NormalizeDeliveryRoutes(routes) {
 		if route.SubscriberType == "node" && route.SubscriberID == templatefanin.ReceiverNodeID &&
-			route.Target.FlowID == target.FlowID && route.Target.FlowInstance == target.FlowInstance {
-			return true
+			route.Target.FlowID == target.FlowID && route.Target.FlowInstance == target.FlowInstance &&
+			route.Target.EntityID == target.EntityID {
+			return route.Target, true
 		}
 	}
-	return false
+	return events.RouteIdentity{}, false
 }
 
 func fanInStreamAccumulatorItemCount(t *testing.T, buckets map[string]map[string]any, window string) int {

--- a/internal/runtime/conformance/testdata/route_authority_matrix.yaml
+++ b/internal/runtime/conformance/testdata/route_authority_matrix.yaml
@@ -326,6 +326,8 @@ rows:
       - {kind: issue, issue: 1890}
       - {kind: go_test, name: TestLowerCompositionConnectRoutePlansUsesTemplateInstanceKey}
       - {kind: go_test, name: TestLowerCompositionConnectRoutePlansUsesFanInStreamSingularTarget}
+      - {kind: go_test, name: TestLowerCompositionConnectRoutePlansAllowsFanInStreamEventIDDedup}
+      - {kind: go_test, name: TestLowerCompositionConnectRoutePlansFailsClosedForInvalidFanInStream}
       - {kind: go_test, name: TestLowerCompositionConnectRoutePlansPreservesAddressedTemplateRoute}
       - {kind: go_test, name: TestLowerCompositionConnectRoutePlansBroadcastBeatsInstanceKey}
       - {kind: go_test, name: TestLowerCompositionConnectRoutePlansUsesRenamedInstanceKeyAdapter}
@@ -339,6 +341,7 @@ rows:
       - {kind: go_test, name: TestEventBusPublish_ConnectRoutePlanFailsClosedForRenamedTemplateInstanceKeySourceGap}
       - {kind: go_test, name: TestEventBusPublish_ConnectRoutePlanFailsClosedForUnsupportedBusinessFieldTarget}
       - {kind: go_test, name: TestFanInStreamConformance_RoutesToSingletonAndKernelEnforcesWindowedDedup}
+      - {kind: go_test, name: TestFanInStreamConformance_EventIDDedupUsesEventIdentity}
     notes: >
       ConnectRoutePlan is a typed route-intent input, not an untracked string
       fallback. #1545 records the selected route authority in ResolutionKind so

--- a/internal/runtime/conformance/testdata/route_authority_matrix.yaml
+++ b/internal/runtime/conformance/testdata/route_authority_matrix.yaml
@@ -323,7 +323,9 @@ rows:
       - {kind: issue, issue: 1494}
       - {kind: issue, issue: 1545}
       - {kind: issue, issue: 1546}
+      - {kind: issue, issue: 1890}
       - {kind: go_test, name: TestLowerCompositionConnectRoutePlansUsesTemplateInstanceKey}
+      - {kind: go_test, name: TestLowerCompositionConnectRoutePlansUsesFanInStreamSingularTarget}
       - {kind: go_test, name: TestLowerCompositionConnectRoutePlansPreservesAddressedTemplateRoute}
       - {kind: go_test, name: TestLowerCompositionConnectRoutePlansBroadcastBeatsInstanceKey}
       - {kind: go_test, name: TestLowerCompositionConnectRoutePlansUsesRenamedInstanceKeyAdapter}
@@ -336,6 +338,7 @@ rows:
       - {kind: go_test, name: TestEventBusPublish_ConnectRoutePlanFailsClosedForTemplateInstanceKeyGaps}
       - {kind: go_test, name: TestEventBusPublish_ConnectRoutePlanFailsClosedForRenamedTemplateInstanceKeySourceGap}
       - {kind: go_test, name: TestEventBusPublish_ConnectRoutePlanFailsClosedForUnsupportedBusinessFieldTarget}
+      - {kind: go_test, name: TestFanInStreamConformance_RoutesToSingletonAndKernelEnforcesWindowedDedup}
     notes: >
       ConnectRoutePlan is a typed route-intent input, not an untracked string
       fallback. #1545 records the selected route authority in ResolutionKind so

--- a/internal/runtime/contracts/workflow_contract_types.go
+++ b/internal/runtime/contracts/workflow_contract_types.go
@@ -458,6 +458,8 @@ type AccumulateSpec struct {
 	ExpectedFrom string               `yaml:"expected_from"`
 	From         string               `yaml:"from"`
 	Description  string               `yaml:"description"`
+	Window       string               `yaml:"window"`
+	WindowPath   paths.Path           `yaml:"-"`
 	ExpectedPath paths.Path           `yaml:"-"`
 	DedupBy      string               `yaml:"dedup_by"`
 	DedupPath    paths.Path           `yaml:"-"`

--- a/internal/runtime/contracts/workflow_contract_yaml_rules.go
+++ b/internal/runtime/contracts/workflow_contract_yaml_rules.go
@@ -155,6 +155,7 @@ func (a *AccumulateSpec) UnmarshalYAML(node *yaml.Node) error {
 		ExpectedFrom string    `yaml:"expected_from"`
 		From         string    `yaml:"from"`
 		Description  string    `yaml:"description"`
+		Window       string    `yaml:"window"`
 		DedupBy      string    `yaml:"dedup_by"`
 		Threshold    int       `yaml:"threshold"`
 		TimeoutMS    int       `yaml:"timeout_ms"`
@@ -170,6 +171,8 @@ func (a *AccumulateSpec) UnmarshalYAML(node *yaml.Node) error {
 		ExpectedFrom: strings.TrimSpace(aux.ExpectedFrom),
 		From:         strings.TrimSpace(aux.From),
 		Description:  strings.TrimSpace(aux.Description),
+		Window:       strings.TrimSpace(aux.Window),
+		WindowPath:   paths.Parse(aux.Window),
 		ExpectedPath: paths.Parse(aux.ExpectedFrom),
 		DedupBy:      strings.TrimSpace(aux.DedupBy),
 		DedupPath:    paths.Parse(aux.DedupBy),
@@ -208,6 +211,7 @@ var accumulateFieldOptions = map[string]struct{}{
 	"expected_from": {},
 	"from":          {},
 	"description":   {},
+	"window":        {},
 	"dedup_by":      {},
 	"threshold":     {},
 	"timeout_ms":    {},

--- a/internal/runtime/contracts/workflow_contract_yaml_test.go
+++ b/internal/runtime/contracts/workflow_contract_yaml_test.go
@@ -2802,7 +2802,7 @@ source: payload.items
 	if got := diagnostic.Problem; got != `accumulate field "source" is not supported.` {
 		t.Fatalf("diagnostic problem = %q, want unknown accumulate field problem", got)
 	}
-	want := []string{"completion", "dedup_by", "description", "expected_from", "from", "into", "on_complete", "on_timeout", "threshold", "timeout_ms"}
+	want := []string{"completion", "dedup_by", "description", "expected_from", "from", "into", "on_complete", "on_timeout", "threshold", "timeout_ms", "window"}
 	if !reflect.DeepEqual(diagnostic.ValidOptions, want) {
 		t.Fatalf("diagnostic valid options = %#v, want %#v", diagnostic.ValidOptions, want)
 	}

--- a/internal/runtime/core/pinrouting/connect_route_plan.go
+++ b/internal/runtime/core/pinrouting/connect_route_plan.go
@@ -106,6 +106,13 @@ type ConnectRoutePlanInstanceKeyMapping struct {
 	Explicit bool
 }
 
+type ConnectRoutePlanFanIn struct {
+	Aggregation string
+	Window      string
+	DedupBy     []string
+	Singleton   string
+}
+
 type ConnectRoutePlan struct {
 	PackageKey                string
 	Source                    ConnectRoutePlanEndpoint
@@ -116,6 +123,7 @@ type ConnectRoutePlan struct {
 	ResolutionKind            ConnectRoutePlanResolutionKind
 	Address                   *ConnectRoutePlanAddress
 	InstanceKey               *ConnectRoutePlanInstanceKey
+	FanIn                     *ConnectRoutePlanFanIn
 	Map                       []ConnectRoutePlanMapEntry
 	Reply                     map[string]string
 	Target                    events.RouteIdentity
@@ -211,6 +219,10 @@ func LowerCompositionConnectRoutePlan(source semanticview.Source, connect runtim
 	if instanceKeyIssue.Failure != "" {
 		return ConnectRoutePlan{}, instanceKeyIssue
 	}
+	fanIn, fanInIssue := connectFanIn(source, connect, inputPin, delivery, to.FlowID)
+	if fanInIssue.Failure != "" {
+		return ConnectRoutePlan{}, fanInIssue
+	}
 	if receiverRequiresRuntimeResolution(receiverScope) && address == nil && instanceKey == nil && delivery != ConnectDeliveryBroadcast {
 		return ConnectRoutePlan{}, ConnectRoutePlanIssue{Connect: connect, Failure: ConnectFailureReceiverAddressRuleMissing, Detail: to.FlowID}
 	}
@@ -237,11 +249,15 @@ func LowerCompositionConnectRoutePlan(source semanticview.Source, connect runtim
 		),
 		Address:     address,
 		InstanceKey: instanceKey,
+		FanIn:       fanIn,
 		Map:         connectMapEntries(connect.Map),
 		Reply:       cloneStringMap(connect.Reply),
 	}
 	if !receiverRequiresRuntimeResolution(receiverScope) {
 		route := staticConnectRoute(source, to.FlowID)
+		if fanIn != nil {
+			route = fanInSingletonRoute(to.FlowID, fanIn.Singleton)
+		}
 		if !route.Empty() {
 			switch targetKind {
 			case ConnectTargetKindTarget, ConnectTargetKindReply:
@@ -645,9 +661,72 @@ func connectResolutionInstanceKey(source semanticview.Source, connect runtimecon
 		return connectCreateResolutionInstanceKey(source, connect, resolution, delivery, receiverFlowID)
 	case runtimecontracts.FlowInputResolutionModeSelect, runtimecontracts.FlowInputResolutionModeSelectOrCreate:
 		return connectCarriedKeyResolutionInstanceKey(source, connect, inputPin, resolution, delivery, receiverFlowID)
+	case runtimecontracts.FlowInputResolutionModeFanIn:
+		return nil, ConnectRoutePlanIssue{}
 	default:
 		return nil, ConnectRoutePlanIssue{Connect: connect, Failure: ConnectFailureInstanceResolutionInvalid, Detail: fmt.Sprintf("resolution mode %q is design-locked but not runnable in this slice", resolution.Mode)}
 	}
+}
+
+func connectFanIn(source semanticview.Source, connect runtimecontracts.FlowPackageConnect, inputPin runtimecontracts.FlowInputEventPin, delivery ConnectRoutePlanDelivery, receiverFlowID string) (*ConnectRoutePlanFanIn, ConnectRoutePlanIssue) {
+	if inputPin.Resolution.Empty() || inputPin.Resolution.Mode != runtimecontracts.FlowInputResolutionModeFanIn {
+		return nil, ConnectRoutePlanIssue{}
+	}
+	resolution := inputPin.Resolution
+	if delivery != ConnectDeliveryOne {
+		return nil, ConnectRoutePlanIssue{Connect: connect, Failure: ConnectFailureDeliveryTopologyInvalid, Detail: "resolution mode fan-in requires delivery one"}
+	}
+	if !resolution.InstanceKey.Empty() || resolution.RepliesTo != "" || resolution.CorrelationKey != "" {
+		return nil, ConnectRoutePlanIssue{Connect: connect, Failure: ConnectFailureInstanceResolutionInvalid, Detail: "resolution mode fan-in may only declare aggregation, window, dedup_by, singleton, and carries"}
+	}
+	if resolution.Aggregation != "stream" {
+		return nil, ConnectRoutePlanIssue{Connect: connect, Failure: ConnectFailureInstanceResolutionInvalid, Detail: fmt.Sprintf("resolution mode fan-in supports only aggregation: stream in this slice, got %q", resolution.Aggregation)}
+	}
+	window := strings.TrimSpace(resolution.Window)
+	if window == "" {
+		return nil, ConnectRoutePlanIssue{Connect: connect, Failure: ConnectFailureInstanceResolutionInvalid, Detail: "resolution mode fan-in stream requires window"}
+	}
+	dedupBy := normalizedStringList(resolution.DedupBy)
+	if len(dedupBy) == 0 {
+		return nil, ConnectRoutePlanIssue{Connect: connect, Failure: ConnectFailureInstanceResolutionInvalid, Detail: "resolution mode fan-in stream requires dedup_by; sender identity is not an implicit default"}
+	}
+	if len(dedupBy) != 1 {
+		return nil, ConnectRoutePlanIssue{Connect: connect, Failure: ConnectFailureInstanceResolutionInvalid, Detail: fmt.Sprintf("resolution mode fan-in stream supports exactly one dedup_by field in this slice, got %v", dedupBy)}
+	}
+	if !connectFanInDedupSupported(dedupBy[0]) {
+		return nil, ConnectRoutePlanIssue{Connect: connect, Failure: ConnectFailureInstanceResolutionInvalid, Detail: fmt.Sprintf("resolution mode fan-in dedup_by %q must be event.id or one top-level payload field", dedupBy[0])}
+	}
+	if !connectFanInPayloadFieldSupported(window) {
+		return nil, ConnectRoutePlanIssue{Connect: connect, Failure: ConnectFailureInstanceResolutionInvalid, Detail: fmt.Sprintf("resolution mode fan-in window %q must be one top-level payload field", window)}
+	}
+	singleton := strings.Trim(strings.TrimSpace(resolution.Singleton), "/")
+	if singleton == "" {
+		return nil, ConnectRoutePlanIssue{Connect: connect, Failure: ConnectFailureInstanceResolutionInvalid, Detail: "resolution mode fan-in stream requires explicit singleton receiver identity"}
+	}
+	scopeKey := strings.Trim(strings.TrimSpace(runtimeflowidentity.ScopeKey(source, receiverFlowID)), "/")
+	if scopeKey != "" && singleton != scopeKey && !strings.HasPrefix(singleton, scopeKey+"/") {
+		return nil, ConnectRoutePlanIssue{Connect: connect, Failure: ConnectFailureInstanceResolutionInvalid, Detail: fmt.Sprintf("resolution mode fan-in singleton %q must be the receiver singleton route or a child of %q", singleton, scopeKey)}
+	}
+	return &ConnectRoutePlanFanIn{
+		Aggregation: resolution.Aggregation,
+		Window:      window,
+		DedupBy:     dedupBy,
+		Singleton:   singleton,
+	}, ConnectRoutePlanIssue{}
+}
+
+func connectFanInDedupSupported(dedup string) bool {
+	dedup = strings.TrimSpace(dedup)
+	return dedup == "event.id" || connectFanInPayloadFieldSupported(dedup)
+}
+
+func connectFanInPayloadFieldSupported(path string) bool {
+	path = strings.TrimSpace(path)
+	if !strings.HasPrefix(path, "payload.") {
+		return false
+	}
+	field := strings.TrimSpace(strings.TrimPrefix(path, "payload."))
+	return field != "" && !strings.Contains(field, ".")
 }
 
 func connectCreateResolutionInstanceKey(source semanticview.Source, connect runtimecontracts.FlowPackageConnect, resolution runtimecontracts.FlowInputPinResolution, delivery ConnectRoutePlanDelivery, receiverFlowID string) (*ConnectRoutePlanInstanceKey, ConnectRoutePlanIssue) {
@@ -935,6 +1014,18 @@ func staticConnectRoute(source semanticview.Source, flowID string) events.RouteI
 		FlowID:       strings.TrimSpace(flowID),
 		FlowInstance: flowInstance,
 		EntityID:     runtimeflowidentity.EntityID(flowInstance),
+	}.Normalized()
+}
+
+func fanInSingletonRoute(flowID, singleton string) events.RouteIdentity {
+	singleton = strings.Trim(strings.TrimSpace(singleton), "/")
+	if strings.TrimSpace(flowID) == "" || singleton == "" {
+		return events.RouteIdentity{}
+	}
+	return events.RouteIdentity{
+		FlowID:       strings.TrimSpace(flowID),
+		FlowInstance: singleton,
+		EntityID:     runtimeflowidentity.EntityID(singleton),
 	}.Normalized()
 }
 

--- a/internal/runtime/core/pinrouting/connect_route_plan.go
+++ b/internal/runtime/core/pinrouting/connect_route_plan.go
@@ -682,6 +682,13 @@ func connectFanIn(source semanticview.Source, connect runtimecontracts.FlowPacka
 	if resolution.Aggregation != "stream" {
 		return nil, ConnectRoutePlanIssue{Connect: connect, Failure: ConnectFailureInstanceResolutionInvalid, Detail: fmt.Sprintf("resolution mode fan-in supports only aggregation: stream in this slice, got %q", resolution.Aggregation)}
 	}
+	bundle, ok := semanticview.Bundle(source)
+	if !ok || bundle == nil {
+		return nil, ConnectRoutePlanIssue{Connect: connect, Failure: ConnectFailureInstanceResolutionInvalid, Detail: "receiver singleton coordinator owner is unavailable for input pin resolution"}
+	}
+	if _, err := bundle.ResolveFlowSingletonCoordinator(receiverFlowID); err != nil {
+		return nil, ConnectRoutePlanIssue{Connect: connect, Failure: ConnectFailureInstanceResolutionInvalid, Detail: err.Error()}
+	}
 	window := strings.TrimSpace(resolution.Window)
 	if window == "" {
 		return nil, ConnectRoutePlanIssue{Connect: connect, Failure: ConnectFailureInstanceResolutionInvalid, Detail: "resolution mode fan-in stream requires window"}

--- a/internal/runtime/core/pinrouting/connect_route_plan_test.go
+++ b/internal/runtime/core/pinrouting/connect_route_plan_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/division-sh/swarm/internal/runtime/core/flowidentity"
 	"github.com/division-sh/swarm/internal/runtime/flowmodel"
 	"github.com/division-sh/swarm/internal/runtime/semanticview"
+	"github.com/division-sh/swarm/internal/runtime/testfixtures/templatefanin"
 )
 
 func TestLowerCompositionConnectRoutePlansFromLoadedPackageFixture(t *testing.T) {
@@ -46,6 +47,63 @@ func TestLowerCompositionConnectRoutePlansFromLoadedPackageFixture(t *testing.T)
 	}
 	if plan.Target.FlowInstance != "consumer" {
 		t.Fatalf("Target = %#v, want concrete static consumer route", plan.Target)
+	}
+}
+
+func TestLowerCompositionConnectRoutePlansUsesFanInStreamSingularTarget(t *testing.T) {
+	source := templatefanin.LoadSource(t, templatefanin.Options{})
+
+	plans, issues := LowerCompositionConnectRoutePlans(source)
+
+	if len(issues) != 0 {
+		t.Fatalf("LowerCompositionConnectRoutePlans issues = %#v, want none", issues)
+	}
+	if len(plans) != 1 {
+		t.Fatalf("LowerCompositionConnectRoutePlans = %#v, want one fan-in route plan", plans)
+	}
+	plan := plans[0]
+	if plan.FanIn == nil {
+		t.Fatalf("fan-in metadata = nil in %#v", plan)
+	}
+	if plan.FanIn.Aggregation != "stream" || plan.FanIn.Window != "payload.period_id" || len(plan.FanIn.DedupBy) != 1 || plan.FanIn.DedupBy[0] != "payload.report_id" {
+		t.Fatalf("fan-in metadata = %#v, want stream/window/dedup", plan.FanIn)
+	}
+	if plan.TargetKind != ConnectTargetKindTarget || plan.ResolutionKind != ConnectResolutionStatic || plan.Delivery != ConnectDeliveryOne {
+		t.Fatalf("fan-in routing shape = delivery:%s target_kind:%s resolution:%s, want one/target/static", plan.Delivery, plan.TargetKind, plan.ResolutionKind)
+	}
+	if plan.Target.FlowID != templatefanin.ReceiverFlowID || plan.Target.FlowInstance != templatefanin.ReceiverFlowInstance {
+		t.Fatalf("fan-in target = %#v, want receiver singleton %s", plan.Target, templatefanin.ReceiverFlowInstance)
+	}
+}
+
+func TestLowerCompositionConnectRoutePlansFailsClosedForInvalidFanInStream(t *testing.T) {
+	tests := []struct {
+		name    string
+		opts    templatefanin.Options
+		failure ConnectRoutePlanFailure
+		detail  string
+	}{
+		{name: "missing dedup", opts: templatefanin.Options{MissingDedup: true}, failure: ConnectFailureInstanceResolutionInvalid, detail: "requires dedup_by"},
+		{name: "dedup tuple", opts: templatefanin.Options{DedupTuple: true}, failure: ConnectFailureInstanceResolutionInvalid, detail: "exactly one dedup_by"},
+		{name: "missing window", opts: templatefanin.Options{MissingWindow: true}, failure: ConnectFailureInstanceResolutionInvalid, detail: "requires window"},
+		{name: "barrier", opts: templatefanin.Options{BarrierAggregation: true}, failure: ConnectFailureInstanceResolutionInvalid, detail: "aggregation: stream"},
+		{name: "wrong singleton", opts: templatefanin.Options{WrongSingleton: true}, failure: ConnectFailureInstanceResolutionInvalid, detail: "must be the receiver singleton route or a child"},
+		{name: "delivery many", opts: templatefanin.Options{DeliveryMany: true}, failure: ConnectFailureDeliveryTopologyInvalid, detail: "requires delivery one"},
+		{name: "legacy map", opts: templatefanin.Options{LegacyConnectMap: true}, failure: ConnectFailureInstanceResolutionInvalid, detail: "connect.map is incompatible"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			source := templatefanin.LoadSource(t, tc.opts)
+
+			_, issues := LowerCompositionConnectRoutePlans(source)
+
+			if len(issues) != 1 {
+				t.Fatalf("issues = %#v, want one", issues)
+			}
+			if issues[0].Failure != tc.failure || !strings.Contains(issues[0].Detail, tc.detail) {
+				t.Fatalf("issue = %#v, want failure %s containing %q", issues[0], tc.failure, tc.detail)
+			}
+		})
 	}
 }
 

--- a/internal/runtime/core/pinrouting/connect_route_plan_test.go
+++ b/internal/runtime/core/pinrouting/connect_route_plan_test.go
@@ -71,8 +71,8 @@ func TestLowerCompositionConnectRoutePlansUsesFanInStreamSingularTarget(t *testi
 	if plan.TargetKind != ConnectTargetKindTarget || plan.ResolutionKind != ConnectResolutionStatic || plan.Delivery != ConnectDeliveryOne {
 		t.Fatalf("fan-in routing shape = delivery:%s target_kind:%s resolution:%s, want one/target/static", plan.Delivery, plan.TargetKind, plan.ResolutionKind)
 	}
-	if plan.Target.FlowID != templatefanin.ReceiverFlowID || plan.Target.FlowInstance != templatefanin.ReceiverFlowInstance {
-		t.Fatalf("fan-in target = %#v, want receiver singleton %s", plan.Target, templatefanin.ReceiverFlowInstance)
+	if plan.Target.FlowID != templatefanin.ReceiverFlowID || plan.Target.FlowInstance != templatefanin.ReceiverFlowInstance || plan.Target.EntityID != flowidentity.EntityID(templatefanin.ReceiverFlowInstance) {
+		t.Fatalf("fan-in target = %#v, want receiver singleton %s with entity %s", plan.Target, templatefanin.ReceiverFlowInstance, flowidentity.EntityID(templatefanin.ReceiverFlowInstance))
 	}
 }
 

--- a/internal/runtime/core/pinrouting/connect_route_plan_test.go
+++ b/internal/runtime/core/pinrouting/connect_route_plan_test.go
@@ -76,6 +76,23 @@ func TestLowerCompositionConnectRoutePlansUsesFanInStreamSingularTarget(t *testi
 	}
 }
 
+func TestLowerCompositionConnectRoutePlansAllowsFanInStreamEventIDDedup(t *testing.T) {
+	source := templatefanin.LoadSource(t, templatefanin.Options{EventIDDedup: true})
+
+	plans, issues := LowerCompositionConnectRoutePlans(source)
+
+	if len(issues) != 0 {
+		t.Fatalf("LowerCompositionConnectRoutePlans issues = %#v, want none", issues)
+	}
+	if len(plans) != 1 {
+		t.Fatalf("LowerCompositionConnectRoutePlans = %#v, want one fan-in route plan", plans)
+	}
+	plan := plans[0]
+	if plan.FanIn == nil || len(plan.FanIn.DedupBy) != 1 || plan.FanIn.DedupBy[0] != "event.id" {
+		t.Fatalf("fan-in metadata = %#v, want event.id dedup", plan.FanIn)
+	}
+}
+
 func TestLowerCompositionConnectRoutePlansFailsClosedForInvalidFanInStream(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -88,6 +105,7 @@ func TestLowerCompositionConnectRoutePlansFailsClosedForInvalidFanInStream(t *te
 		{name: "missing window", opts: templatefanin.Options{MissingWindow: true}, failure: ConnectFailureInstanceResolutionInvalid, detail: "requires window"},
 		{name: "barrier", opts: templatefanin.Options{BarrierAggregation: true}, failure: ConnectFailureInstanceResolutionInvalid, detail: "aggregation: stream"},
 		{name: "wrong singleton", opts: templatefanin.Options{WrongSingleton: true}, failure: ConnectFailureInstanceResolutionInvalid, detail: "must be the receiver singleton route or a child"},
+		{name: "non-singleton receiver", opts: templatefanin.Options{NonSingletonReceiver: true}, failure: ConnectFailureInstanceResolutionInvalid, detail: "is not mode: singleton"},
 		{name: "delivery many", opts: templatefanin.Options{DeliveryMany: true}, failure: ConnectFailureDeliveryTopologyInvalid, detail: "requires delivery one"},
 		{name: "legacy map", opts: templatefanin.Options{LegacyConnectMap: true}, failure: ConnectFailureInstanceResolutionInvalid, detail: "connect.map is incompatible"},
 	}

--- a/internal/runtime/core/timeridentity/timeridentity.go
+++ b/internal/runtime/core/timeridentity/timeridentity.go
@@ -1,6 +1,7 @@
 package timeridentity
 
 import (
+	"encoding/base64"
 	"fmt"
 	"strconv"
 	"strings"
@@ -38,6 +39,7 @@ type TimerHandle struct {
 type AccumulatorBucketRef struct {
 	NodeID    string
 	EventType string
+	Window    string
 }
 
 func ParseStartTrigger(raw string) (Trigger, error) {
@@ -222,6 +224,12 @@ func NewAccumulatorBucketRef(nodeID, eventType string) AccumulatorBucketRef {
 	}
 }
 
+func NewAccumulatorWindowBucketRef(nodeID, eventType, window string) AccumulatorBucketRef {
+	ref := NewAccumulatorBucketRef(nodeID, eventType)
+	ref.Window = strings.TrimSpace(window)
+	return ref
+}
+
 func ParseAccumulatorBucketRef(payload map[string]any) (AccumulatorBucketRef, bool) {
 	handle, ok := ParseTimerHandle(payload)
 	if !ok || handle.Kind != TimerHandleAccumulationTimeout {
@@ -235,16 +243,25 @@ func ParseAccumulatorBucketKey(key string) (AccumulatorBucketRef, bool) {
 	if key == "" {
 		return AccumulatorBucketRef{}, false
 	}
+	window := ""
+	if base, encoded, ok := strings.Cut(key, "@window="); ok {
+		key = strings.TrimSpace(base)
+		decoded, err := base64.RawURLEncoding.DecodeString(strings.TrimSpace(encoded))
+		if err != nil {
+			return AccumulatorBucketRef{}, false
+		}
+		window = string(decoded)
+	}
 	nodeID, eventType, ok := strings.Cut(key, ":")
 	if !ok {
 		return AccumulatorBucketRef{}, false
 	}
-	bucket := NewAccumulatorBucketRef(nodeID, eventType)
+	bucket := NewAccumulatorWindowBucketRef(nodeID, eventType, window)
 	return bucket, bucket.Valid()
 }
 
 func (r AccumulatorBucketRef) Normalize() AccumulatorBucketRef {
-	return NewAccumulatorBucketRef(r.NodeID, r.EventType)
+	return NewAccumulatorWindowBucketRef(r.NodeID, r.EventType, r.Window)
 }
 
 func (r AccumulatorBucketRef) Valid() bool {
@@ -256,7 +273,11 @@ func (r AccumulatorBucketRef) Key() string {
 	if !r.Valid() {
 		return ""
 	}
-	return r.NodeID + ":" + r.EventType
+	key := r.NodeID + ":" + r.EventType
+	if r.Window == "" {
+		return key
+	}
+	return key + "@window=" + base64.RawURLEncoding.EncodeToString([]byte(r.Window))
 }
 
 func (r AccumulatorBucketRef) PayloadValue() map[string]any {
@@ -264,10 +285,14 @@ func (r AccumulatorBucketRef) PayloadValue() map[string]any {
 	if !r.Valid() {
 		return nil
 	}
-	return map[string]any{
+	payload := map[string]any{
 		"node_id":    r.NodeID,
 		"event_type": r.EventType,
 	}
+	if r.Window != "" {
+		payload["window"] = r.Window
+	}
+	return payload
 }
 
 func stringAnyMap(value any) (map[string]any, bool) {
@@ -283,7 +308,7 @@ func bucketFromAny(value any) (AccumulatorBucketRef, bool) {
 	if !ok {
 		return AccumulatorBucketRef{}, false
 	}
-	bucket := NewAccumulatorBucketRef(asString(payload["node_id"]), asString(payload["event_type"]))
+	bucket := NewAccumulatorWindowBucketRef(asString(payload["node_id"]), asString(payload["event_type"]), asString(payload["window"]))
 	return bucket, bucket.Valid()
 }
 

--- a/internal/runtime/core/timeridentity/timeridentity_test.go
+++ b/internal/runtime/core/timeridentity/timeridentity_test.go
@@ -94,6 +94,28 @@ func TestAccumulationTimeoutHandleRoundTrip(t *testing.T) {
 	}
 }
 
+func TestAccumulationTimeoutHandleRoundTripWithWindow(t *testing.T) {
+	bucket := NewAccumulatorWindowBucketRef("collector", "item.arrived", "2026-Q1:closed")
+	handle := AccumulationTimeoutHandle(bucket)
+	parsedHandle, ok := ParseTimerHandle(handle.PayloadMetadata())
+	if !ok {
+		t.Fatal("expected windowed accumulation timeout handle payload to round trip")
+	}
+	if parsedHandle.Bucket != bucket {
+		t.Fatalf("parsed bucket = %#v, want %#v", parsedHandle.Bucket, bucket)
+	}
+	parsedBucket, ok := ParseAccumulatorBucketKey(bucket.Key())
+	if !ok {
+		t.Fatalf("ParseAccumulatorBucketKey(%q) failed", bucket.Key())
+	}
+	if parsedBucket != bucket {
+		t.Fatalf("parsed bucket key = %#v, want %#v", parsedBucket, bucket)
+	}
+	if got := handle.TaskID(); got == "accumulate_timeout:collector:item.arrived" {
+		t.Fatalf("windowed TaskID() = %q, want distinct from unwindowed bucket", got)
+	}
+}
+
 func TestParseAccumulatorBucketKey(t *testing.T) {
 	bucket, ok := ParseAccumulatorBucketKey("collector:item.arrived")
 	if !ok {

--- a/internal/runtime/engine/executor.go
+++ b/internal/runtime/engine/executor.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/division-sh/swarm/internal/events"
 	"github.com/division-sh/swarm/internal/runtime/accprojection"
+	runtimeaccumulator "github.com/division-sh/swarm/internal/runtime/accumulator"
 	"github.com/division-sh/swarm/internal/runtime/computemodule"
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
 	runtimeeventidentity "github.com/division-sh/swarm/internal/runtime/core/eventidentity"
@@ -1881,92 +1882,16 @@ func (e *Executor) effectiveAccumulatorSpec(frame *executionFrame, spec *runtime
 	if spec == nil {
 		return nil, nil
 	}
-	pin, ok, err := e.fanInInputPinForFrame(frame)
-	if err != nil {
-		return nil, err
-	}
-	if !ok {
+	if e == nil || e.deps.Source == nil || frame == nil {
 		return spec, nil
 	}
-	if dedup := strings.TrimSpace(spec.DedupBy); dedup != "" {
-		return nil, fmt.Errorf("receiver handler %s.%s accumulate.dedup_by %q must not redeclare fan-in dedup_by; declare it once on the receiver input pin resolution", frame.req.NodeID.String(), string(handlerAccumulatorEventType(frame.req)), dedup)
-	}
-	if window := strings.TrimSpace(spec.Window); window != "" {
-		return nil, fmt.Errorf("receiver handler %s.%s accumulate.window %q must not redeclare fan-in window; declare it once on the receiver input pin resolution", frame.req.NodeID.String(), string(handlerAccumulatorEventType(frame.req)), window)
-	}
-	resolution := pin.Resolution
-	window := strings.TrimSpace(resolution.Window)
-	if window == "" {
-		return nil, fmt.Errorf("resolution mode fan-in stream requires window for receiver input pin %s.%s", frame.req.FlowID.String(), pin.PinName())
-	}
-	dedupBy := normalizedStringList(resolution.DedupBy)
-	if len(dedupBy) == 0 {
-		return nil, fmt.Errorf("resolution mode fan-in stream requires dedup_by for receiver input pin %s.%s; sender identity is not an implicit default", frame.req.FlowID.String(), pin.PinName())
-	}
-	if len(dedupBy) != 1 {
-		return nil, fmt.Errorf("resolution mode fan-in stream supports exactly one dedup_by field in this slice for receiver input pin %s.%s, got %v", frame.req.FlowID.String(), pin.PinName(), dedupBy)
-	}
-	effective := *spec
-	effective.Window = window
-	effective.WindowPath = paths.Parse(window)
-	effective.DedupBy = dedupBy[0]
-	effective.DedupPath = paths.Parse(dedupBy[0])
-	return &effective, nil
-}
-
-func (e *Executor) fanInInputPinForFrame(frame *executionFrame) (runtimecontracts.FlowInputEventPin, bool, error) {
-	if e == nil || e.deps.Source == nil || frame == nil {
-		return runtimecontracts.FlowInputEventPin{}, false, nil
-	}
-	flowID := strings.TrimSpace(frame.req.FlowID.String())
-	if flowID == "" {
-		return runtimecontracts.FlowInputEventPin{}, false, nil
-	}
-	handlerEvent := string(handlerAccumulatorEventType(frame.req))
-	var matched runtimecontracts.FlowInputEventPin
-	var matchedPins []string
-	for _, pin := range e.deps.Source.FlowInputEventPins(flowID) {
-		if pin.Resolution.Mode != runtimecontracts.FlowInputResolutionModeFanIn {
-			continue
-		}
-		if e.fanInInputPinMatchesHandlerEvent(flowID, pin, handlerEvent) {
-			matched = pin
-			matchedPins = append(matchedPins, pin.PinName())
-		}
-	}
-	if len(matchedPins) > 1 {
-		return runtimecontracts.FlowInputEventPin{}, false, fmt.Errorf("receiver handler %s.%s matches multiple fan-in input pins %v; fan-in accumulator semantics require exactly one receiver input pin owner", frame.req.NodeID.String(), handlerEvent, matchedPins)
-	}
-	if len(matchedPins) == 1 {
-		return matched, true, nil
-	}
-	return runtimecontracts.FlowInputEventPin{}, false, nil
-}
-
-func (e *Executor) fanInInputPinMatchesHandlerEvent(flowID string, pin runtimecontracts.FlowInputEventPin, handlerEvent string) bool {
-	handlerEvent = strings.TrimSpace(handlerEvent)
-	inputEvent := strings.TrimSpace(pin.EventType())
-	if handlerEvent == "" || inputEvent == "" {
-		return false
-	}
-	if e.deps.Source.FlowEventMatches(flowID, handlerEvent, inputEvent) {
-		return true
-	}
-	resolvedInput := runtimeeventidentity.Normalize(e.deps.Source.ResolveFlowEventReference(flowID, inputEvent))
-	handler := runtimeeventidentity.Normalize(handlerEvent)
-	return handler == resolvedInput || handler == runtimeeventidentity.Normalize(inputEvent) || handler == runtimeeventidentity.Normalize(pin.PinName())
-}
-
-func normalizedStringList(values []string) []string {
-	out := make([]string, 0, len(values))
-	for _, value := range values {
-		value = strings.TrimSpace(value)
-		if value == "" {
-			continue
-		}
-		out = append(out, value)
-	}
-	return out
+	return runtimeaccumulator.EffectiveSpecForHandler(
+		e.deps.Source,
+		frame.req.FlowID.String(),
+		frame.req.NodeID.String(),
+		string(handlerAccumulatorEventType(frame.req)),
+		spec,
+	)
 }
 
 func (e *Executor) projectAccumulatorItems(frame *executionFrame, binding accprojection.Binding, items []map[string]any) ([]any, error) {

--- a/internal/runtime/engine/executor.go
+++ b/internal/runtime/engine/executor.go
@@ -846,6 +846,10 @@ func (e *Executor) stepAccumulate(frame *executionFrame) (bool, error) {
 	if spec == nil {
 		return false, nil
 	}
+	spec, err := e.effectiveAccumulatorSpec(frame, spec)
+	if err != nil {
+		return false, err
+	}
 	frame.result.AccumulatorCompletionDiagnostics.Relevant = true
 	frame.result.AccumulatorCompletionDiagnostics.CompletionMode = spec.Completion.String()
 	frame.result.AccumulatorCompletionDiagnostics.OnCompleteDeclared = len(frame.req.Handler.OnComplete) > 0 || len(spec.OnComplete) > 0
@@ -1037,7 +1041,11 @@ func (e *Executor) executeComputeSpec(frame *executionFrame, spec *runtimecontra
 	if spec == nil {
 		return nil
 	}
-	bucketRef, matched, bucketErr := e.resolveAccumulatorBucketRef(frame, frame.req.Handler.Accumulate)
+	accumulateSpec, effectiveErr := e.effectiveAccumulatorSpec(frame, frame.req.Handler.Accumulate)
+	if effectiveErr != nil {
+		return effectiveErr
+	}
+	bucketRef, matched, bucketErr := e.resolveAccumulatorBucketRef(frame, accumulateSpec)
 	if bucketErr != nil {
 		return bucketErr
 	}
@@ -1790,7 +1798,11 @@ func (e *Executor) stepProjection(frame *executionFrame) error {
 		}
 		return nil
 	}
-	bucketRef, matched, bucketErr := e.resolveAccumulatorBucketRef(frame, frame.req.Handler.Accumulate)
+	accumulateSpec, effectiveErr := e.effectiveAccumulatorSpec(frame, frame.req.Handler.Accumulate)
+	if effectiveErr != nil {
+		return effectiveErr
+	}
+	bucketRef, matched, bucketErr := e.resolveAccumulatorBucketRef(frame, accumulateSpec)
 	if bucketErr != nil {
 		return bucketErr
 	}
@@ -1863,6 +1875,98 @@ func (e *Executor) resolveAccumulatorBucketRef(frame *executionFrame, spec *runt
 	frame.accumulatorBucketRef = bucketRef
 	frame.hasAccumulatorBucketRef = true
 	return bucketRef, true, nil
+}
+
+func (e *Executor) effectiveAccumulatorSpec(frame *executionFrame, spec *runtimecontracts.AccumulateSpec) (*runtimecontracts.AccumulateSpec, error) {
+	if spec == nil {
+		return nil, nil
+	}
+	pin, ok, err := e.fanInInputPinForFrame(frame)
+	if err != nil {
+		return nil, err
+	}
+	if !ok {
+		return spec, nil
+	}
+	if dedup := strings.TrimSpace(spec.DedupBy); dedup != "" {
+		return nil, fmt.Errorf("receiver handler %s.%s accumulate.dedup_by %q must not redeclare fan-in dedup_by; declare it once on the receiver input pin resolution", frame.req.NodeID.String(), string(handlerAccumulatorEventType(frame.req)), dedup)
+	}
+	if window := strings.TrimSpace(spec.Window); window != "" {
+		return nil, fmt.Errorf("receiver handler %s.%s accumulate.window %q must not redeclare fan-in window; declare it once on the receiver input pin resolution", frame.req.NodeID.String(), string(handlerAccumulatorEventType(frame.req)), window)
+	}
+	resolution := pin.Resolution
+	window := strings.TrimSpace(resolution.Window)
+	if window == "" {
+		return nil, fmt.Errorf("resolution mode fan-in stream requires window for receiver input pin %s.%s", frame.req.FlowID.String(), pin.PinName())
+	}
+	dedupBy := normalizedStringList(resolution.DedupBy)
+	if len(dedupBy) == 0 {
+		return nil, fmt.Errorf("resolution mode fan-in stream requires dedup_by for receiver input pin %s.%s; sender identity is not an implicit default", frame.req.FlowID.String(), pin.PinName())
+	}
+	if len(dedupBy) != 1 {
+		return nil, fmt.Errorf("resolution mode fan-in stream supports exactly one dedup_by field in this slice for receiver input pin %s.%s, got %v", frame.req.FlowID.String(), pin.PinName(), dedupBy)
+	}
+	effective := *spec
+	effective.Window = window
+	effective.WindowPath = paths.Parse(window)
+	effective.DedupBy = dedupBy[0]
+	effective.DedupPath = paths.Parse(dedupBy[0])
+	return &effective, nil
+}
+
+func (e *Executor) fanInInputPinForFrame(frame *executionFrame) (runtimecontracts.FlowInputEventPin, bool, error) {
+	if e == nil || e.deps.Source == nil || frame == nil {
+		return runtimecontracts.FlowInputEventPin{}, false, nil
+	}
+	flowID := strings.TrimSpace(frame.req.FlowID.String())
+	if flowID == "" {
+		return runtimecontracts.FlowInputEventPin{}, false, nil
+	}
+	handlerEvent := string(handlerAccumulatorEventType(frame.req))
+	var matched runtimecontracts.FlowInputEventPin
+	var matchedPins []string
+	for _, pin := range e.deps.Source.FlowInputEventPins(flowID) {
+		if pin.Resolution.Mode != runtimecontracts.FlowInputResolutionModeFanIn {
+			continue
+		}
+		if e.fanInInputPinMatchesHandlerEvent(flowID, pin, handlerEvent) {
+			matched = pin
+			matchedPins = append(matchedPins, pin.PinName())
+		}
+	}
+	if len(matchedPins) > 1 {
+		return runtimecontracts.FlowInputEventPin{}, false, fmt.Errorf("receiver handler %s.%s matches multiple fan-in input pins %v; fan-in accumulator semantics require exactly one receiver input pin owner", frame.req.NodeID.String(), handlerEvent, matchedPins)
+	}
+	if len(matchedPins) == 1 {
+		return matched, true, nil
+	}
+	return runtimecontracts.FlowInputEventPin{}, false, nil
+}
+
+func (e *Executor) fanInInputPinMatchesHandlerEvent(flowID string, pin runtimecontracts.FlowInputEventPin, handlerEvent string) bool {
+	handlerEvent = strings.TrimSpace(handlerEvent)
+	inputEvent := strings.TrimSpace(pin.EventType())
+	if handlerEvent == "" || inputEvent == "" {
+		return false
+	}
+	if e.deps.Source.FlowEventMatches(flowID, handlerEvent, inputEvent) {
+		return true
+	}
+	resolvedInput := runtimeeventidentity.Normalize(e.deps.Source.ResolveFlowEventReference(flowID, inputEvent))
+	handler := runtimeeventidentity.Normalize(handlerEvent)
+	return handler == resolvedInput || handler == runtimeeventidentity.Normalize(inputEvent) || handler == runtimeeventidentity.Normalize(pin.PinName())
+}
+
+func normalizedStringList(values []string) []string {
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		out = append(out, value)
+	}
+	return out
 }
 
 func (e *Executor) projectAccumulatorItems(frame *executionFrame, binding accprojection.Binding, items []map[string]any) ([]any, error) {

--- a/internal/runtime/engine/executor.go
+++ b/internal/runtime/engine/executor.go
@@ -19,6 +19,7 @@ import (
 	"github.com/division-sh/swarm/internal/runtime/core/identity"
 	"github.com/division-sh/swarm/internal/runtime/core/paths"
 	runtimepinrouting "github.com/division-sh/swarm/internal/runtime/core/pinrouting"
+	"github.com/division-sh/swarm/internal/runtime/core/timeridentity"
 	"github.com/division-sh/swarm/internal/runtime/core/values"
 	"github.com/division-sh/swarm/internal/runtime/entityruntime"
 	"github.com/division-sh/swarm/internal/runtime/eventschema"
@@ -91,6 +92,8 @@ type executionFrame struct {
 	rule                      *runtimecontracts.HandlerRuleEntry
 	ruleSource                handlerRuleSource
 	payload                   map[string]any
+	accumulatorBucketRef      timeridentity.AccumulatorBucketRef
+	hasAccumulatorBucketRef   bool
 	topLevelDataAccumulation  runtimecontracts.WorkflowDataAccumulation
 	topLevelDataWritesApplied bool
 	ruleDataWritesApplied     bool
@@ -848,19 +851,12 @@ func (e *Executor) stepAccumulate(frame *executionFrame) (bool, error) {
 	frame.result.AccumulatorCompletionDiagnostics.OnCompleteDeclared = len(frame.req.Handler.OnComplete) > 0 || len(spec.OnComplete) > 0
 	frame.result.AccumulatorCompletionDiagnostics.EvaluationOutcome = AccumulatorCompletionEvaluationNotAttempted
 	current := e.currentContext(frame)
-	bucketRef := handlerAccumulatorBucketRef(frame.req)
-	if isAccumulationTimeoutEvent(frame.req.Event.Type()) {
-		parsed, ok := accumulationTimeoutBucketRefFromPayload(frame.payload)
-		if !ok || parsed.NodeID != frame.req.NodeID.String() {
-			return false, nil
-		}
-		bucketRef = parsed
-	} else {
-		var err error
-		bucketRef, err = handlerAccumulatorBucketRefForSpec(frame.req, current, frame.state, spec)
-		if err != nil {
-			return false, err
-		}
+	bucketRef, matched, err := e.resolveAccumulatorBucketRef(frame, spec)
+	if err != nil {
+		return false, err
+	}
+	if !matched {
+		return false, nil
 	}
 	acc, ok := loadAccumulatorForBucket(frame.state.State, bucketRef)
 	if !ok {
@@ -1041,9 +1037,12 @@ func (e *Executor) executeComputeSpec(frame *executionFrame, spec *runtimecontra
 	if spec == nil {
 		return nil
 	}
-	bucketRef, bucketErr := handlerAccumulatorBucketRefForSpec(frame.req, e.currentContext(frame), frame.state, frame.req.Handler.Accumulate)
+	bucketRef, matched, bucketErr := e.resolveAccumulatorBucketRef(frame, frame.req.Handler.Accumulate)
 	if bucketErr != nil {
 		return bucketErr
+	}
+	if !matched {
+		return nil
 	}
 	acc, _ := loadAccumulatorForBucket(frame.state.State, bucketRef)
 	var (
@@ -1791,9 +1790,12 @@ func (e *Executor) stepProjection(frame *executionFrame) error {
 		}
 		return nil
 	}
-	bucketRef, bucketErr := handlerAccumulatorBucketRefForSpec(frame.req, e.currentContext(frame), frame.state, frame.req.Handler.Accumulate)
+	bucketRef, matched, bucketErr := e.resolveAccumulatorBucketRef(frame, frame.req.Handler.Accumulate)
 	if bucketErr != nil {
 		return bucketErr
+	}
+	if !matched {
+		return nil
 	}
 	acc, ok := loadAccumulatorForBucket(frame.state.State, bucketRef)
 	if !ok {
@@ -1836,6 +1838,31 @@ func accumulatorProjectionEligible(frame *executionFrame) bool {
 	}
 	return frame.rule != nil &&
 		(frame.ruleSource == handlerRuleSourceOnComplete || frame.ruleSource == handlerRuleSourceAccumulateOnComplete)
+}
+
+func (e *Executor) resolveAccumulatorBucketRef(frame *executionFrame, spec *runtimecontracts.AccumulateSpec) (timeridentity.AccumulatorBucketRef, bool, error) {
+	if frame == nil {
+		return timeridentity.AccumulatorBucketRef{}, false, nil
+	}
+	if frame.hasAccumulatorBucketRef {
+		return frame.accumulatorBucketRef, true, nil
+	}
+	if isAccumulationTimeoutEvent(frame.req.Event.Type()) {
+		parsed, ok := accumulationTimeoutBucketRefFromPayload(frame.payload)
+		if !ok || parsed.NodeID != frame.req.NodeID.String() {
+			return timeridentity.AccumulatorBucketRef{}, false, nil
+		}
+		frame.accumulatorBucketRef = parsed
+		frame.hasAccumulatorBucketRef = true
+		return parsed, true, nil
+	}
+	bucketRef, err := handlerAccumulatorBucketRefForSpec(frame.req, e.currentContext(frame), frame.state, spec)
+	if err != nil {
+		return timeridentity.AccumulatorBucketRef{}, false, err
+	}
+	frame.accumulatorBucketRef = bucketRef
+	frame.hasAccumulatorBucketRef = true
+	return bucketRef, true, nil
 }
 
 func (e *Executor) projectAccumulatorItems(frame *executionFrame, binding accprojection.Binding, items []map[string]any) ([]any, error) {

--- a/internal/runtime/engine/executor.go
+++ b/internal/runtime/engine/executor.go
@@ -847,6 +847,7 @@ func (e *Executor) stepAccumulate(frame *executionFrame) (bool, error) {
 	frame.result.AccumulatorCompletionDiagnostics.CompletionMode = spec.Completion.String()
 	frame.result.AccumulatorCompletionDiagnostics.OnCompleteDeclared = len(frame.req.Handler.OnComplete) > 0 || len(spec.OnComplete) > 0
 	frame.result.AccumulatorCompletionDiagnostics.EvaluationOutcome = AccumulatorCompletionEvaluationNotAttempted
+	current := e.currentContext(frame)
 	bucketRef := handlerAccumulatorBucketRef(frame.req)
 	if isAccumulationTimeoutEvent(frame.req.Event.Type()) {
 		parsed, ok := accumulationTimeoutBucketRefFromPayload(frame.payload)
@@ -854,6 +855,12 @@ func (e *Executor) stepAccumulate(frame *executionFrame) (bool, error) {
 			return false, nil
 		}
 		bucketRef = parsed
+	} else {
+		var err error
+		bucketRef, err = handlerAccumulatorBucketRefForSpec(frame.req, current, frame.state, spec)
+		if err != nil {
+			return false, err
+		}
 	}
 	acc, ok := loadAccumulatorForBucket(frame.state.State, bucketRef)
 	if !ok {
@@ -862,7 +869,6 @@ func (e *Executor) stepAccumulate(frame *executionFrame) (bool, error) {
 	if strings.TrimSpace(acc.StartedAt) == "" {
 		acc.StartedAt = frame.req.Event.CreatedAt().UTC().Format(time.RFC3339Nano)
 	}
-	current := e.currentContext(frame)
 	expectedIDs, expectedCount := expectedAccumulatorTargets(current, frame.state, spec.ExpectedPath, spec.ExpectedFrom)
 	if len(expectedIDs) > 0 {
 		acc.Expected = append([]string{}, expectedIDs...)
@@ -1035,7 +1041,11 @@ func (e *Executor) executeComputeSpec(frame *executionFrame, spec *runtimecontra
 	if spec == nil {
 		return nil
 	}
-	acc, _ := loadAccumulatorForBucket(frame.state.State, handlerAccumulatorBucketRef(frame.req))
+	bucketRef, bucketErr := handlerAccumulatorBucketRefForSpec(frame.req, e.currentContext(frame), frame.state, frame.req.Handler.Accumulate)
+	if bucketErr != nil {
+		return bucketErr
+	}
+	acc, _ := loadAccumulatorForBucket(frame.state.State, bucketRef)
 	var (
 		value any
 		err   error
@@ -1781,7 +1791,11 @@ func (e *Executor) stepProjection(frame *executionFrame) error {
 		}
 		return nil
 	}
-	acc, ok := loadAccumulatorForBucket(frame.state.State, handlerAccumulatorBucketRef(frame.req))
+	bucketRef, bucketErr := handlerAccumulatorBucketRefForSpec(frame.req, e.currentContext(frame), frame.state, frame.req.Handler.Accumulate)
+	if bucketErr != nil {
+		return bucketErr
+	}
+	acc, ok := loadAccumulatorForBucket(frame.state.State, bucketRef)
 	if !ok {
 		return fmt.Errorf("accumulator projection source missing for node %s event %s", frame.req.NodeID.String(), string(handlerEventType))
 	}

--- a/internal/runtime/engine/executor_enforcement_test.go
+++ b/internal/runtime/engine/executor_enforcement_test.go
@@ -12,6 +12,7 @@ import (
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
 	"github.com/division-sh/swarm/internal/runtime/core/identity"
 	runtimeregistry "github.com/division-sh/swarm/internal/runtime/core/registry"
+	"github.com/division-sh/swarm/internal/runtime/core/timeridentity"
 )
 
 type persistentStateRepo struct {
@@ -305,6 +306,73 @@ func TestExecutor_AccumulateOnTimeoutAppliesRule(t *testing.T) {
 	}
 	if repo.snapshot.CurrentState != "partial" {
 		t.Fatalf("persisted CurrentState = %q", repo.snapshot.CurrentState)
+	}
+}
+
+func TestExecutor_AccumulateOnTimeoutComputeReadsWindowedTimerBucket(t *testing.T) {
+	bucket := timeridentity.NewAccumulatorWindowBucketRef("node-1", "item.arrived", "2026-W10")
+	repo := &persistentStateRepo{
+		found: true,
+		snapshot: StateSnapshot{
+			EntityID:     "entity-1",
+			CurrentState: "collecting",
+			StateCarrier: NewStateCarrier(map[string]any{}, nil, map[string]map[string]any{}),
+		},
+	}
+	storeAccumulatorForBucket(&repo.snapshot, bucket, &Accumulator{
+		ExpectedCount: 3,
+		Received: map[string]bool{
+			"evt-a": true,
+			"evt-b": true,
+		},
+		Items: []map[string]any{
+			{"event_id": "evt-a"},
+			{"event_id": "evt-b"},
+		},
+		StartedAt: "2026-03-15T00:00:00Z",
+	})
+	exec, err := NewExecutor(RuntimeDependencies{
+		Source:     stubSource(),
+		StateRepo:  repo,
+		TxRunner:   stubRunner{},
+		Locker:     stubLocker{},
+		Outbox:     stubOutbox{},
+		Dispatcher: stubDispatcher{},
+	}, nil)
+	if err != nil {
+		t.Fatalf("NewExecutor error: %v", err)
+	}
+	result, err := exec.Execute(context.Background(), ExecutionRequest{
+		EntityID:        "entity-1",
+		NodeID:          "node-1",
+		HandlerEventKey: "item.arrived",
+		Event: eventtest.RootIngress("timeout-1",
+			events.EventType("accumulate.timeout"), "", "", mustEncodeJSON(t, map[string]any{
+				"timer_handle": map[string]any{
+					"kind":   string(timeridentity.TimerHandleAccumulationTimeout),
+					"bucket": bucket.PayloadValue(),
+				},
+			}), 0, "", "", events.EventEnvelope{}, time.Time{}),
+		Handler: runtimecontracts.SystemNodeEventHandler{
+			Accumulate: &runtimecontracts.AccumulateSpec{
+				Completion: runtimecontracts.ParseAccumulateCompletion("all"),
+				Window:     "payload.window_id",
+				OnTimeout: &runtimecontracts.HandlerRuleEntry{
+					ID: "timeout",
+					Compute: &runtimecontracts.ComputeSpec{
+						Operation: runtimecontracts.ComputeOpCount,
+						StoreAs:   "computed.timed_out_count",
+					},
+				},
+			},
+		},
+		State: repo.snapshot,
+	})
+	if err != nil {
+		t.Fatalf("Execute timeout accumulate: %v", err)
+	}
+	if got := result.Computed["timed_out_count"]; got != 2 {
+		t.Fatalf("timed_out_count = %#v, want 2", got)
 	}
 }
 

--- a/internal/runtime/engine/helpers.go
+++ b/internal/runtime/engine/helpers.go
@@ -302,6 +302,22 @@ func handlerAccumulatorBucketRef(req ExecutionRequest) timeridentity.Accumulator
 	return accumulatorBucketRef(req.NodeID, handlerAccumulatorEventType(req))
 }
 
+func handlerAccumulatorBucketRefForSpec(req ExecutionRequest, base BaseContext, state ExecutionState, spec *runtimecontracts.AccumulateSpec) (timeridentity.AccumulatorBucketRef, error) {
+	bucket := handlerAccumulatorBucketRef(req)
+	if spec == nil || strings.TrimSpace(spec.Window) == "" {
+		return bucket, nil
+	}
+	value, ok := resolveContractPath(base, state, spec.WindowPath, spec.Window)
+	if !ok {
+		return timeridentity.AccumulatorBucketRef{}, fmt.Errorf("accumulate.window %q did not resolve for node %s event %s", spec.Window, req.NodeID.String(), string(handlerAccumulatorEventType(req)))
+	}
+	window := strings.TrimSpace(fmt.Sprint(value))
+	if window == "" {
+		return timeridentity.AccumulatorBucketRef{}, fmt.Errorf("accumulate.window %q resolved empty for node %s event %s", spec.Window, req.NodeID.String(), string(handlerAccumulatorEventType(req)))
+	}
+	return timeridentity.NewAccumulatorWindowBucketRef(bucket.NodeID, bucket.EventType, window), nil
+}
+
 func loadAccumulator(state StateSnapshot, nodeID identity.NodeID, eventType events.EventType) (*Accumulator, bool) {
 	return loadAccumulatorForBucket(state, accumulatorBucketRef(nodeID, eventType))
 }

--- a/internal/runtime/microsoft_graph_connector_client_credentials_supported_surface_test.go
+++ b/internal/runtime/microsoft_graph_connector_client_credentials_supported_surface_test.go
@@ -165,9 +165,7 @@ func runMicrosoftGraphClientCredentialsConnectorSurface(t *testing.T, backend sl
 		t.Fatalf("%s 429 attempt error = %q, want Graph TooManyRequests fixture shape", backend.name, rateLimitAttempt.Error)
 	}
 	requireSlackManagedConnectorResultEventEventually(t, backend, rateLimitAttempt.ResultEventID, rateLimitAttempt.ResultEventType)
-	if got := countMicrosoftGraphFailureEventsForSource(t, backend, rateLimitInboundEventID); got != 1 {
-		t.Fatalf("%s 429 failure events = %d, want 1", backend.name, got)
-	}
+	waitForMicrosoftGraphFailureEventsForSource(t, backend, rateLimitInboundEventID, 1, "429")
 
 	assertMicrosoftGraphManagedCredentialFailureBeforeDispatch(t, backend, fake, "missing credential", "323456792", runtimemanagedcredentials.NewMemoryStore())
 	unconnected := microsoftGraphClientCredentialsRecord(fake.server.URL, "", time.Now().Add(time.Hour))
@@ -466,9 +464,7 @@ func assertMicrosoftGraphManagedCredentialFailureBeforeDispatch(t *testing.T, ba
 	if got := countMicrosoftGraphActivityAttemptsForSource(t, backend, inboundEventID); got != 0 {
 		t.Fatalf("%s %s activity attempts = %d, want 0", backend.name, label, got)
 	}
-	if got := countMicrosoftGraphFailureEventsForSource(t, backend, inboundEventID); got != 1 {
-		t.Fatalf("%s %s failure events = %d, want 1", backend.name, label, got)
-	}
+	waitForMicrosoftGraphFailureEventsForSource(t, backend, inboundEventID, 1, label)
 }
 
 func waitForMicrosoftGraphTerminalActivityAttempt(t *testing.T, backend slackManagedConnectorBackend, sourceEventID string) runtimepipeline.ActivityAttemptRecord {
@@ -612,6 +608,22 @@ func countMicrosoftGraphFailureEventsForSource(t *testing.T, backend slackManage
 		t.Fatalf("%s count failure events for source event %s: %v", backend.name, sourceEventID, err)
 	}
 	return count
+}
+
+func waitForMicrosoftGraphFailureEventsForSource(t *testing.T, backend slackManagedConnectorBackend, sourceEventID string, want int, label string) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	var got int
+	for {
+		got = countMicrosoftGraphFailureEventsForSource(t, backend, sourceEventID)
+		if got == want {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("%s %s failure events for source %s = %d, want %d", backend.name, label, sourceEventID, got, want)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
 }
 
 func microsoftGraphMessageSubject(body map[string]any) string {

--- a/internal/runtime/pipeline/workflow_timer_lifecycle.go
+++ b/internal/runtime/pipeline/workflow_timer_lifecycle.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/division-sh/swarm/internal/events"
+	runtimeaccumulator "github.com/division-sh/swarm/internal/runtime/accumulator"
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
 	"github.com/division-sh/swarm/internal/runtime/core/timeridentity"
 	runtimecorrelation "github.com/division-sh/swarm/internal/runtime/correlation"
@@ -299,6 +300,11 @@ func (pc *PipelineCoordinator) reconcileAccumulationTimeoutSchedule(
 	if spec == nil || spec.TimeoutMS <= 0 {
 		return nil
 	}
+	effectiveSpec, err := pc.effectiveAccumulationTimeoutSpec(ctx, nodeID, handlerEventKey, spec)
+	if err != nil {
+		return err
+	}
+	spec = effectiveSpec
 	entityID = strings.TrimSpace(entityID)
 	nodeID = strings.TrimSpace(nodeID)
 	if entityID == "" || nodeID == "" {
@@ -321,6 +327,16 @@ func (pc *PipelineCoordinator) reconcileAccumulationTimeoutSchedule(
 	}
 	sc.At = startedAt.Add(time.Duration(spec.TimeoutMS) * time.Millisecond)
 	return pc.persistWorkflowTimerSchedule(ctx, sc)
+}
+
+func (pc *PipelineCoordinator) effectiveAccumulationTimeoutSpec(ctx context.Context, nodeID, handlerEventKey string, spec *runtimecontracts.AccumulateSpec) (*runtimecontracts.AccumulateSpec, error) {
+	if spec == nil {
+		return nil, nil
+	}
+	if pc == nil || pc.SemanticSource() == nil || pipelineFlowScope(ctx) == "" {
+		return spec, nil
+	}
+	return runtimeaccumulator.EffectiveSpecForHandler(pc.SemanticSource(), pipelineFlowScope(ctx), nodeID, handlerEventKey, spec)
 }
 
 func workflowTimerLifecycleMatches(trigger timeridentity.Trigger, stage, sourceEvent string) bool {

--- a/internal/runtime/pipeline/workflow_timer_lifecycle.go
+++ b/internal/runtime/pipeline/workflow_timer_lifecycle.go
@@ -304,7 +304,7 @@ func (pc *PipelineCoordinator) reconcileAccumulationTimeoutSchedule(
 	if entityID == "" || nodeID == "" {
 		return nil
 	}
-	bucketRef, ok := accumulationTimeoutBucketRef(evt, nodeID, handlerEventKey)
+	bucketRef, ok := accumulationTimeoutBucketRef(evt, nodeID, handlerEventKey, spec)
 	if !ok {
 		return nil
 	}
@@ -344,7 +344,7 @@ func workflowTimerShouldStartOnTransition(timer runtimecontracts.WorkflowTimerCo
 	return ok && workflowTimerLifecycleMatches(startTrigger, nextStage, sourceEvent)
 }
 
-func accumulationTimeoutBucketRef(evt Event, nodeID, handlerEventKey string) (timeridentity.AccumulatorBucketRef, bool) {
+func accumulationTimeoutBucketRef(evt Event, nodeID, handlerEventKey string, spec *runtimecontracts.AccumulateSpec) (timeridentity.AccumulatorBucketRef, bool) {
 	nodeID = strings.TrimSpace(nodeID)
 	if nodeID == "" {
 		return timeridentity.AccumulatorBucketRef{}, false
@@ -355,6 +355,13 @@ func accumulationTimeoutBucketRef(evt Event, nodeID, handlerEventKey string) (ti
 			eventType = strings.TrimSpace(string(evt.Type()))
 		}
 		bucket := timeridentity.NewAccumulatorBucketRef(nodeID, eventType)
+		if spec != nil && strings.TrimSpace(spec.Window) != "" {
+			window, ok := accumulationTimeoutWindowValue(parsePayloadMap(evt.Payload()), spec.Window)
+			if !ok {
+				return timeridentity.AccumulatorBucketRef{}, false
+			}
+			bucket = timeridentity.NewAccumulatorWindowBucketRef(nodeID, eventType, window)
+		}
 		return bucket, bucket.Valid()
 	}
 	bucket, ok := timeridentity.ParseAccumulatorBucketRef(parsePayloadMap(evt.Payload()))
@@ -362,6 +369,21 @@ func accumulationTimeoutBucketRef(evt Event, nodeID, handlerEventKey string) (ti
 		return timeridentity.AccumulatorBucketRef{}, false
 	}
 	return bucket, true
+}
+
+func accumulationTimeoutWindowValue(payload map[string]any, window string) (string, bool) {
+	window = strings.TrimSpace(window)
+	if window == "" {
+		return "", false
+	}
+	if strings.HasPrefix(window, "payload.") {
+		window = strings.TrimPrefix(window, "payload.")
+	}
+	if strings.Contains(window, ".") || window == "" {
+		return "", false
+	}
+	value := strings.TrimSpace(asString(payload[window]))
+	return value, value != ""
 }
 
 func accumulationTimeoutStartedAt(stateBuckets map[string]any, bucketRef timeridentity.AccumulatorBucketRef) (time.Time, bool) {

--- a/internal/runtime/pipeline/workflow_timer_lifecycle_test.go
+++ b/internal/runtime/pipeline/workflow_timer_lifecycle_test.go
@@ -16,6 +16,7 @@ import (
 	runtimecorrelation "github.com/division-sh/swarm/internal/runtime/correlation"
 	"github.com/division-sh/swarm/internal/runtime/flowmodel"
 	"github.com/division-sh/swarm/internal/runtime/semanticview"
+	"github.com/division-sh/swarm/internal/runtime/testfixtures/templatefanin"
 	"github.com/division-sh/swarm/internal/testutil"
 	"github.com/google/uuid"
 )
@@ -1070,6 +1071,104 @@ func TestReconcileAccumulationTimeoutScheduleUsesMatchedHandlerEventKey(t *testi
 	}
 	if _, ok := findAccumulationTimeoutHandlerForBucket(semanticview.Wrap(bundle), handle.Bucket); !ok {
 		t.Fatalf("timeout handler did not resolve for scheduled bucket %#v", handle.Bucket)
+	}
+}
+
+func TestReconcileAccumulationTimeoutScheduleUsesFanInPinDerivedWindow(t *testing.T) {
+	bundle := templatefanin.LoadBundle(t, templatefanin.Options{})
+	module, err := newPipelineFixtureWorkflowModule(bundle)
+	if err != nil {
+		t.Fatalf("newPipelineFixtureWorkflowModule: %v", err)
+	}
+	_, db, cleanup := testutil.StartPostgres(t)
+	t.Cleanup(cleanup)
+
+	store := &recordingSchedulePersistence{}
+	pc := newTimerLifecycleCoordinator(noopPipelineBus{}, db, module, store)
+	if pc == nil {
+		t.Fatal("expected coordinator")
+	}
+	start := time.Now().UTC()
+	handler := runtimecontracts.SystemNodeEventHandler{
+		Accumulate: &runtimecontracts.AccumulateSpec{
+			Into:       "operating_reports",
+			From:       "payload",
+			Completion: runtimecontracts.ParseAccumulateCompletion("timeout"),
+			TimeoutMS:  5000,
+		},
+	}
+	wantBucket := timeridentity.NewAccumulatorWindowBucketRef(templatefanin.ReceiverNodeID, templatefanin.ReceiverEvent, "2026-Q1")
+	stateBuckets := map[string]any{
+		templatefanin.ReceiverNodeID: map[string]any{
+			"handler_accumulators": map[string]any{
+				wantBucket.Key(): map[string]any{
+					"started_at": start.Format(time.RFC3339Nano),
+				},
+			},
+		},
+	}
+	evt := eventtest.RootIngress(
+		"evt-operating-2026-q1",
+		events.EventType(templatefanin.ReceiverEvent),
+		"cataloge2e",
+		"",
+		[]byte(`{"portfolio_id":"portfolio/default","report_id":"report-1","period_id":"2026-Q1","operating_id":"opco-a","revenue":42}`),
+		0,
+		"",
+		"",
+		events.EnvelopeForFlowInstance(events.EnvelopeForEntityID(events.EventEnvelope{}, templatefanin.ReceiverFlowInstance), templatefanin.ReceiverFlowInstance),
+		start,
+	)
+
+	ctx := withPipelineFlowScope(testPipelineCoordinatorRunContext(t, pc), templatefanin.ReceiverFlowID)
+	if err := pc.reconcileAccumulationTimeoutSchedule(ctx, templatefanin.ReceiverFlowInstance, templatefanin.ReceiverNodeID, handler, evt, templatefanin.ReceiverEvent, stateBuckets, true); err != nil {
+		t.Fatalf("reconcileAccumulationTimeoutSchedule: %v", err)
+	}
+	if len(store.schedules) != 1 {
+		t.Fatalf("registered schedules = %d, want 1 for pin-derived window bucket %s", len(store.schedules), wantBucket.Key())
+	}
+	got := store.schedules[0]
+	wantHandle := timeridentity.AccumulationTimeoutHandle(wantBucket)
+	if got.TaskID != wantHandle.TaskID() {
+		t.Fatalf("scheduled task_id = %q, want %q", got.TaskID, wantHandle.TaskID())
+	}
+	if got.At.Before(start.Add(4900*time.Millisecond)) || got.At.After(start.Add(5100*time.Millisecond)) {
+		t.Fatalf("scheduled at = %s, want about %s", got.At.Format(time.RFC3339Nano), start.Add(5*time.Second).Format(time.RFC3339Nano))
+	}
+	payload := parsePayloadMap(got.Payload)
+	handle, ok := timeridentity.ParseTimerHandle(payload)
+	if !ok || handle.Kind != timeridentity.TimerHandleAccumulationTimeout {
+		t.Fatalf("scheduled payload = %#v", payload)
+	}
+	if handle.Bucket.Key() != wantBucket.Key() {
+		t.Fatalf("scheduled payload bucket = %#v, want %s", handle.Bucket, wantBucket.Key())
+	}
+
+	timeoutEvt := eventtest.RootIngress(
+		"evt-timeout-2026-q1",
+		events.EventType("accumulate.timeout"),
+		runtimeWorkflowID,
+		"",
+		mustJSON(map[string]any{
+			"entity_id":     templatefanin.ReceiverFlowInstance,
+			"timer_handle":  handle.PayloadMetadata()["timer_handle"],
+			"timeout_ms":    5000,
+			"flow_instance": templatefanin.ReceiverFlowInstance,
+		}),
+		0,
+		"",
+		"",
+		events.EnvelopeForFlowInstance(events.EnvelopeForEntityID(events.EventEnvelope{}, templatefanin.ReceiverFlowInstance), templatefanin.ReceiverFlowInstance),
+		start.Add(5*time.Second),
+	)
+	if err := pc.reconcileAccumulationTimeoutSchedule(ctx, templatefanin.ReceiverFlowInstance, templatefanin.ReceiverNodeID, handler, timeoutEvt, templatefanin.ReceiverEvent, stateBuckets, false); err != nil {
+		t.Fatalf("reconcileAccumulationTimeoutSchedule timeout cancel: %v", err)
+	}
+	if len(store.cancels) != 1 {
+		t.Fatalf("cancelled schedules = %d, want 1 for pin-derived window bucket %s", len(store.cancels), wantBucket.Key())
+	}
+	if got := store.cancels[0].TaskID; got != wantHandle.TaskID() {
+		t.Fatalf("cancelled task_id = %q, want %q", got, wantHandle.TaskID())
 	}
 }
 

--- a/internal/runtime/testfixtures/templatefanin/fixture.go
+++ b/internal/runtime/testfixtures/templatefanin/fixture.go
@@ -34,6 +34,8 @@ type Options struct {
 	LegacyConnectMap         bool
 	EventIDDedup             bool
 	NonSingletonReceiver     bool
+	MissingReceiverHandler   bool
+	MissingAccumulate        bool
 }
 
 func LoadBundle(t testing.TB, opts Options) *runtimecontracts.WorkflowContractBundle {
@@ -199,13 +201,26 @@ portfolio-collector:
   id: portfolio-collector
   execution_type: system_node
   subscribes_to: [operating.reported]
-  event_handlers:
+`+receiverHandlersYAML(opts))
+}
+
+func receiverHandlersYAML(opts Options) string {
+	if opts.MissingReceiverHandler {
+		return "  event_handlers: {}\n"
+	}
+	if opts.MissingAccumulate {
+		return `  event_handlers:
+    operating.reported:
+      advances_to: active
+`
+	}
+	return `  event_handlers:
     operating.reported:
       accumulate:
         into: operating_reports
         from: payload
-`+accumulateWindowYAML(opts)+accumulateDedupYAML(opts)+`
-`)
+` + accumulateWindowYAML(opts) + accumulateDedupYAML(opts) + `
+`
 }
 
 func aggregationYAML(opts Options) string {

--- a/internal/runtime/testfixtures/templatefanin/fixture.go
+++ b/internal/runtime/testfixtures/templatefanin/fixture.go
@@ -1,0 +1,278 @@
+package templatefanin
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
+	"github.com/division-sh/swarm/internal/runtime/semanticview"
+)
+
+const (
+	ProducerFlowID       = "operating"
+	ProducerOutputPin    = "operating_reported"
+	ProducerEvent        = "operating.reported"
+	ReceiverFlowID       = "portfolio"
+	ReceiverInputPin     = "operating_reported"
+	ReceiverEvent        = "operating.reported"
+	ReceiverNodeID       = "portfolio-collector"
+	ReceiverFlowInstance = "portfolio/default"
+)
+
+type Options struct {
+	MissingDedup             bool
+	DedupTuple               bool
+	MissingWindow            bool
+	BarrierAggregation       bool
+	MissingSingleton         bool
+	WrongSingleton           bool
+	AccumulateDedupMismatch  bool
+	AccumulateWindowMismatch bool
+	DeliveryMany             bool
+	LegacyConnectMap         bool
+}
+
+func LoadBundle(t testing.TB, opts Options) *runtimecontracts.WorkflowContractBundle {
+	t.Helper()
+	bundle, err := LoadBundleResult(t, opts)
+	if err != nil {
+		t.Fatalf("LoadWorkflowContractBundleWithOverrides: %v", err)
+	}
+	return bundle
+}
+
+func LoadBundleResult(t testing.TB, opts Options) (*runtimecontracts.WorkflowContractBundle, error) {
+	t.Helper()
+	root := Write(t, opts)
+	return runtimecontracts.LoadWorkflowContractBundleWithOverrides(repoRoot(t), root, runtimecontracts.DefaultPlatformSpecFile(repoRoot(t)))
+}
+
+func LoadSource(t testing.TB, opts Options) semanticview.Source {
+	t.Helper()
+	return semanticview.Wrap(LoadBundle(t, opts))
+}
+
+func Write(t testing.TB, opts Options) string {
+	t.Helper()
+	root := t.TempDir()
+	writeRoot(t, root, opts)
+	writeOperating(t, root)
+	writePortfolio(t, root, opts)
+	return root
+}
+
+func writeRoot(t testing.TB, root string, opts Options) {
+	t.Helper()
+	writeFile(t, filepath.Join(root, "package.yaml"), `
+name: template-fan-in
+version: "1.0.0"
+platform_version: ">=0.7.0 <0.8.0"
+flows:
+  - id: operating
+    flow: operating
+    mode: template
+  - id: portfolio
+    flow: portfolio/default
+    mode: singleton
+connect:
+  - from: operating.operating_reported
+    to: portfolio.operating_reported
+`+deliveryYAML(opts)+legacyMapYAML(opts))
+	writeFile(t, filepath.Join(root, "schema.yaml"), "name: template-fan-in\n")
+	writeFile(t, filepath.Join(root, "policy.yaml"), "{}\n")
+	writeFile(t, filepath.Join(root, "tools.yaml"), "{}\n")
+	writeFile(t, filepath.Join(root, "agents.yaml"), "{}\n")
+	writeFile(t, filepath.Join(root, "events.yaml"), "{}\n")
+	writeFile(t, filepath.Join(root, "nodes.yaml"), "{}\n")
+}
+
+func deliveryYAML(opts Options) string {
+	if opts.DeliveryMany {
+		return "    delivery: many\n"
+	}
+	return "    delivery: one\n"
+}
+
+func legacyMapYAML(opts Options) string {
+	if !opts.LegacyConnectMap {
+		return ""
+	}
+	return `    map:
+      report_id:
+        source: payload.report_id
+        target: entity.report_id
+`
+}
+
+func writeOperating(t testing.TB, root string) {
+	t.Helper()
+	writeFile(t, filepath.Join(root, "flows", "operating", "schema.yaml"), `
+name: operating
+mode: template
+instance:
+  by: operating_id
+  on_missing: create
+  on_conflict: reuse
+pins:
+  inputs:
+    events: []
+  outputs:
+    events:
+      - name: operating_reported
+        event: operating.reported
+        key: report_id
+        carries: [portfolio_id, report_id, period_id, operating_id, revenue]
+`)
+	writeFile(t, filepath.Join(root, "flows", "operating", "policy.yaml"), "{}\n")
+	writeFile(t, filepath.Join(root, "flows", "operating", "tools.yaml"), "{}\n")
+	writeFile(t, filepath.Join(root, "flows", "operating", "agents.yaml"), "{}\n")
+	writeFile(t, filepath.Join(root, "flows", "operating", "nodes.yaml"), "{}\n")
+	writeFile(t, filepath.Join(root, "flows", "operating", "entities.yaml"), `
+operating_state:
+  operating_id:
+    type: text
+    _unused_reason: template fan-in source identity fixture field
+`)
+	writeFile(t, filepath.Join(root, "flows", "operating", "events.yaml"), `
+operating.reported:
+  portfolio_id: text
+  report_id: text
+  period_id: text
+  operating_id: text
+  revenue: integer
+  required: [portfolio_id, report_id, period_id, operating_id, revenue]
+`)
+}
+
+func writePortfolio(t testing.TB, root string, opts Options) {
+	t.Helper()
+	writeFile(t, filepath.Join(root, "flows", "portfolio", "default", "schema.yaml"), `
+name: portfolio
+mode: singleton
+initial_state: active
+states: [active]
+pins:
+  inputs:
+    events:
+      - name: operating_reported
+        event: operating.reported
+        resolution:
+          mode: fan-in
+          aggregation: `+aggregationYAML(opts)+`
+`+windowYAML(opts)+dedupYAML(opts)+singletonYAML(opts)+`        carries:
+          report_id:
+            from: payload.report_id
+            type: text
+          period_id:
+            from: payload.period_id
+            type: text
+  outputs:
+    events: []
+`)
+	writeFile(t, filepath.Join(root, "flows", "portfolio", "default", "policy.yaml"), "{}\n")
+	writeFile(t, filepath.Join(root, "flows", "portfolio", "default", "tools.yaml"), "{}\n")
+	writeFile(t, filepath.Join(root, "flows", "portfolio", "default", "agents.yaml"), "{}\n")
+	writeFile(t, filepath.Join(root, "flows", "portfolio", "default", "entities.yaml"), `
+portfolio_state:
+  portfolio_id:
+    type: text
+    _unused_reason: singleton fan-in fixture identity field
+  reports:
+    type: map[text]text
+    _unused_reason: singleton fan-in fixture state carrier
+`)
+	writeFile(t, filepath.Join(root, "flows", "portfolio", "default", "events.yaml"), `
+operating.reported:
+  portfolio_id: text
+  report_id: text
+  period_id: text
+  operating_id: text
+  revenue: integer
+  required: [portfolio_id, report_id, period_id, operating_id, revenue]
+`)
+	writeFile(t, filepath.Join(root, "flows", "portfolio", "default", "nodes.yaml"), `
+portfolio-collector:
+  id: portfolio-collector
+  execution_type: system_node
+  subscribes_to: [operating.reported]
+  event_handlers:
+    operating.reported:
+      select_entity:
+        by:
+          portfolio_id: payload.portfolio_id
+      accumulate:
+        into: operating_reports
+        from: payload
+        window: `+accumulateWindowYAML(opts)+`
+        dedup_by: `+accumulateDedupYAML(opts)+`
+`)
+}
+
+func aggregationYAML(opts Options) string {
+	if opts.BarrierAggregation {
+		return "barrier"
+	}
+	return "stream"
+}
+
+func windowYAML(opts Options) string {
+	if opts.MissingWindow {
+		return ""
+	}
+	return "          window: payload.period_id\n"
+}
+
+func dedupYAML(opts Options) string {
+	if opts.MissingDedup {
+		return ""
+	}
+	if opts.DedupTuple {
+		return "          dedup_by: [payload.report_id, payload.operating_id]\n"
+	}
+	return "          dedup_by: payload.report_id\n"
+}
+
+func singletonYAML(opts Options) string {
+	if opts.MissingSingleton {
+		return ""
+	}
+	if opts.WrongSingleton {
+		return "          singleton: treasury/default\n"
+	}
+	return "          singleton: portfolio/default\n"
+}
+
+func accumulateWindowYAML(opts Options) string {
+	if opts.AccumulateWindowMismatch {
+		return "payload.operating_id"
+	}
+	return "payload.period_id"
+}
+
+func accumulateDedupYAML(opts Options) string {
+	if opts.AccumulateDedupMismatch {
+		return "payload.operating_id"
+	}
+	return "payload.report_id"
+}
+
+func repoRoot(t testing.TB) string {
+	t.Helper()
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	return filepath.Clean(filepath.Join(filepath.Dir(file), "..", "..", "..", ".."))
+}
+
+func writeFile(t testing.TB, path, contents string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, []byte(contents), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}

--- a/internal/runtime/testfixtures/templatefanin/fixture.go
+++ b/internal/runtime/testfixtures/templatefanin/fixture.go
@@ -94,7 +94,7 @@ func deliveryYAML(opts Options) string {
 	if opts.DeliveryMany {
 		return "    delivery: many\n"
 	}
-	return "    delivery: one\n"
+	return ""
 }
 
 func legacyMapYAML(opts Options) string {
@@ -201,14 +201,10 @@ portfolio-collector:
   subscribes_to: [operating.reported]
   event_handlers:
     operating.reported:
-      select_entity:
-        by:
-          portfolio_id: payload.portfolio_id
       accumulate:
         into: operating_reports
         from: payload
-        window: `+accumulateWindowYAML(opts)+`
-        dedup_by: `+accumulateDedupYAML(opts)+`
+`+accumulateWindowYAML(opts)+accumulateDedupYAML(opts)+`
 `)
 }
 
@@ -265,19 +261,16 @@ func singletonYAML(opts Options) string {
 
 func accumulateWindowYAML(opts Options) string {
 	if opts.AccumulateWindowMismatch {
-		return "payload.operating_id"
+		return "        window: payload.operating_id\n"
 	}
-	return "payload.period_id"
+	return ""
 }
 
 func accumulateDedupYAML(opts Options) string {
 	if opts.AccumulateDedupMismatch {
-		return "payload.operating_id"
+		return "        dedup_by: payload.operating_id\n"
 	}
-	if opts.EventIDDedup {
-		return "event.id"
-	}
-	return "payload.report_id"
+	return ""
 }
 
 func repoRoot(t testing.TB) string {

--- a/internal/runtime/testfixtures/templatefanin/fixture.go
+++ b/internal/runtime/testfixtures/templatefanin/fixture.go
@@ -32,6 +32,8 @@ type Options struct {
 	AccumulateWindowMismatch bool
 	DeliveryMany             bool
 	LegacyConnectMap         bool
+	EventIDDedup             bool
+	NonSingletonReceiver     bool
 }
 
 func LoadBundle(t testing.TB, opts Options) *runtimecontracts.WorkflowContractBundle {
@@ -75,7 +77,7 @@ flows:
     mode: template
   - id: portfolio
     flow: portfolio/default
-    mode: singleton
+    mode: `+receiverPackageModeYAML(opts)+`
 connect:
   - from: operating.operating_reported
     to: portfolio.operating_reported
@@ -150,7 +152,7 @@ func writePortfolio(t testing.TB, root string, opts Options) {
 	t.Helper()
 	writeFile(t, filepath.Join(root, "flows", "portfolio", "default", "schema.yaml"), `
 name: portfolio
-mode: singleton
+mode: `+receiverSchemaModeYAML(opts)+`
 initial_state: active
 states: [active]
 pins:
@@ -231,7 +233,24 @@ func dedupYAML(opts Options) string {
 	if opts.DedupTuple {
 		return "          dedup_by: [payload.report_id, payload.operating_id]\n"
 	}
+	if opts.EventIDDedup {
+		return "          dedup_by: event.id\n"
+	}
 	return "          dedup_by: payload.report_id\n"
+}
+
+func receiverPackageModeYAML(opts Options) string {
+	if opts.NonSingletonReceiver {
+		return "static"
+	}
+	return "singleton"
+}
+
+func receiverSchemaModeYAML(opts Options) string {
+	if opts.NonSingletonReceiver {
+		return "static"
+	}
+	return "singleton"
 }
 
 func singletonYAML(opts Options) string {
@@ -254,6 +273,9 @@ func accumulateWindowYAML(opts Options) string {
 func accumulateDedupYAML(opts Options) string {
 	if opts.AccumulateDedupMismatch {
 		return "payload.operating_id"
+	}
+	if opts.EventIDDedup {
+		return "event.id"
 	}
 	return "payload.report_id"
 }

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -8445,12 +8445,16 @@ flow_model:
                 fail-closed until evidence requires it. `window` is required and
                 must be one top-level payload field. The route plan reuses
                 singular target delivery and carries fan-in metadata for proof;
-                it MUST NOT introduce a new fan-in target kind. Dedup/window
-                ownership is split deliberately: the pin declares the seam,
-                bootverify proves the receiving handler accumulator uses the
-                same `dedup_by` and `window`, and the accumulate kernel enforces
-                idempotency and window partitioning. EventBus/delivery MUST NOT
-                add an independent fan-in dedup/window owner.
+                it MUST NOT introduce a new fan-in target kind. The receiver
+                input pin is the only authoring owner for fan-in `dedup_by` and
+                `window` semantics. The receiving handler accumulator declares
+                only the accumulator target/source; handler redeclaration of
+                `accumulate.dedup_by` or `accumulate.window` for a fan-in input
+                is invalid. Runtime derives the effective accumulator
+                dedup/window from the matched receiver input pin, and the
+                accumulate kernel enforces idempotency and window partitioning
+                from those derived values. EventBus/delivery MUST NOT add an
+                independent fan-in dedup/window owner.
               fail_closed:
               - aggregation other than stream, including barrier
               - missing or empty singleton
@@ -8463,8 +8467,8 @@ flow_model:
               - receiver not mode: singleton/coordinator
               - missing receiver handler for the input event
               - receiver handler missing accumulate
-              - receiver accumulate.dedup_by not matching pin dedup_by
-              - receiver accumulate.window not matching pin window
+              - receiver handler redeclares accumulate.dedup_by for fan-in
+              - receiver handler redeclares accumulate.window for fan-in
               - combined legacy input address
               - combined connect.using.instance or connect.map
               - delivery topology other than one
@@ -8521,9 +8525,10 @@ flow_model:
           - same committed select-or-create event replay reuses persisted delivery route/scope and does not reselect or recreate after descriptor drift
           - standalone #1828 `template-select-or-create` conformance fixture verifies and materializes through the canonical select-or-create route plan
           - route-plan lowering records fan-in stream metadata, required singleton/window/dedup_by, singular target delivery, and no new target kind
-          - bootverify proves fan-in pin dedup/window declarations match the receiving accumulate handler declarations
+          - bootverify rejects fan-in receiver handler redeclaration of accumulate.dedup_by or accumulate.window
           - EventBus publish/preflight for fan-in stream routes multiple source contributions to the same explicit singleton/coordinator receiver route
-          - receiver accumulator kernel enforces declared dedup_by idempotency and partitions arrivals by declared window
+          - executor derives effective fan-in accumulator dedup/window from the matched receiver input pin, with no handler-local redeclaration
+          - receiver accumulator kernel enforces pin-declared dedup_by idempotency and partitions arrivals by pin-declared window
           - same committed fan-in stream event replay reuses persisted delivery route/scope and does not re-infer receiver identity from sender/source state
           - standalone #1828 `template-fan-in` conformance fixture verifies and materializes through the canonical fan-in stream route plan
         implementation_slice_1546:

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -2273,6 +2273,10 @@ handler_specification:
         on_complete: handler fields to execute when done
         on_timeout: handler fields to execute on timeout
         description: string — human-readable note
+        window: 'string — optional field path for partitioning one logical accumulator into bounded windows (for
+          example payload.period_id). When declared, the runtime resolves the path on each arrival and stores/reads
+          the accumulator under a bucket identity scoped by that window value. Missing or empty runtime window values
+          fail closed for that handler execution.'
         dedup_by: 'string — field path for deduplication. Default: "sender" (sender session ID). Set to a payload field path
           (e.g., "payload.dimension") when accumulating items identified by content rather than sender. Duplicate arrivals
           with the same dedup key are ignored.'
@@ -3899,7 +3903,9 @@ engine:
         event type remains event provenance and must be retained on accumulated
         item metadata and diagnostics. Timeout bucket handles, compute reads,
         and `materialize_from` projection reads must consume the same selected
-        handler event key.
+        handler event key. If `accumulate.window` is declared, the window value
+        is part of the accumulator bucket identity; unwindowed accumulators keep
+        the existing node/event bucket key.
       arrival: 'Each event arrival is identified by its dedup_by key. Default: sender session ID. Can be overridden to a payload
         field (e.g., payload.dimension). If the key was already received, the arrival is ignored (idempotent). If not, it
         is added to the received set and persisted.'
@@ -8275,9 +8281,9 @@ flow_model:
             broadcast:true, receiver select_entity/select_or_create_entity, and
             explicit create_flow_instance are not lifecycle authority.
         implementation_slice_1835:
-          status: spec_locked_create_select_and_select_or_create_modes_runnable_remaining_modes_fail_closed
+          status: spec_locked_create_select_select_or_create_and_fan_in_stream_modes_runnable_remaining_modes_fail_closed
           canonical_spec_owner: platform-spec.yaml#flow_model.flow_package.composition_routing.route_plan_lowering.implementation_slice_1835
-          canonical_code_owner: internal/runtime/contracts.FlowInputPinResolution + internal/runtime/core/pinrouting.ConnectRoutePlan.InstanceKey + internal/runtime/bus.templateInstanceLifecycleOwner + internal/runtime/bootverify.composition_connect_validation
+          canonical_code_owner: internal/runtime/contracts.FlowInputPinResolution + internal/runtime/core/pinrouting.ConnectRoutePlan.InstanceKey/FanIn + internal/runtime/bus.templateInstanceLifecycleOwner/connectRoutePlanResolver + internal/runtime/engine.AccumulateSpec + internal/runtime/bootverify.composition_connect_validation
           rule: |
             Receiver input pins may declare an explicit instance-resolution
             contract under `resolution:{mode,...}`. This receiver-side contract
@@ -8294,8 +8300,11 @@ flow_model:
             key. PR3 makes `resolution.mode: select-or-create` runnable for
             the same single declared carried-key boundary, with lifecycle/store
             convergence on exactly one receiver instance for concurrent same-key
-            missing deliveries. All other locked modes are recognized by
-            contracts and verifier and fail closed as
+            missing deliveries. PR4 makes `resolution.mode: fan-in` runnable
+            only for `aggregation: stream` / bounded windowed delivery into an
+            explicit singleton/coordinator receiver. All other locked modes and
+            fan-in barrier semantics are recognized by contracts and verifier
+            and fail closed as
             design-locked/not-runnable until their implementation slices land.
             Static root ingress, parent-connect static delivery, and
             harness-injected inputs remain existing #1807 input-source /
@@ -8418,13 +8427,48 @@ flow_model:
               - unavailable template lifecycle activator
               - activation/create race that cannot reload exactly one matching instance
             fan-in:
-              status: spec_locked_not_runnable_in_1835_pr1
+              status: stream_windowed_runnable_in_1835_pr4_barrier_fail_closed
               contract: >
                 Fan-in routes many source deliveries into one receiver instance
                 or aggregation context. `aggregation: stream|barrier` is the
                 locked sub-semantics selector. Stream delivers each accepted
                 event into the receiver context; barrier waits for the declared
                 close condition/window before releasing an aggregate result.
+                In the PR4 runnable subset, only `aggregation: stream` is
+                executable. The receiver input pin MUST declare `window`,
+                `dedup_by`, and `singleton`. `singleton` is the explicit
+                receiver route path for the singleton/coordinator instance and
+                MUST be the receiver route or a child of the receiver route; it
+                is never inferred from the sender/source instance. `dedup_by`
+                is required and may be only `event.id` or one top-level
+                `payload.<field>` in this slice; tuple/composite dedup remains
+                fail-closed until evidence requires it. `window` is required and
+                must be one top-level payload field. The route plan reuses
+                singular target delivery and carries fan-in metadata for proof;
+                it MUST NOT introduce a new fan-in target kind. Dedup/window
+                ownership is split deliberately: the pin declares the seam,
+                bootverify proves the receiving handler accumulator uses the
+                same `dedup_by` and `window`, and the accumulate kernel enforces
+                idempotency and window partitioning. EventBus/delivery MUST NOT
+                add an independent fan-in dedup/window owner.
+              fail_closed:
+              - aggregation other than stream, including barrier
+              - missing or empty singleton
+              - singleton outside the receiver route path
+              - missing or empty window
+              - window not naming one top-level payload field
+              - missing or empty dedup_by
+              - dedup_by list/tuple/composite beyond one field
+              - dedup_by other than event.id or one top-level payload field
+              - receiver not mode: singleton/coordinator
+              - missing receiver handler for the input event
+              - receiver handler missing accumulate
+              - receiver accumulate.dedup_by not matching pin dedup_by
+              - receiver accumulate.window not matching pin window
+              - combined legacy input address
+              - combined connect.using.instance or connect.map
+              - delivery topology other than one
+              - producer target.flow / target.match / broadcast rescue
             fan-out:
               status: spec_locked_not_runnable_in_1835_pr1
               contract: >
@@ -8459,7 +8503,7 @@ flow_model:
               `resolution:{mode,...}` semantics.
           proof_obligations:
           - contracts decode every locked mode and reject unknown resolution fields fail-closed
-          - bootverify accepts valid create/select/select-or-create resolution and rejects other non-runnable modes as not runnable in this slice
+          - bootverify accepts valid create/select/select-or-create/fan-in stream resolution and rejects other non-runnable modes as not runnable in this slice
           - route-plan lowering records create mode, mint kind, carried `as` field, create/reuse lifecycle policy, and does not require producer output key/carries
           - EventBus publish/preflight creates a missing receiver instance through the canonical lifecycle path
           - downstream receiver routes can render the carried minted instance key from activation variables
@@ -8476,6 +8520,12 @@ flow_model:
           - ambiguous select-or-create target failures fail closed with receiver/key/value/remediation detail and no activation
           - same committed select-or-create event replay reuses persisted delivery route/scope and does not reselect or recreate after descriptor drift
           - standalone #1828 `template-select-or-create` conformance fixture verifies and materializes through the canonical select-or-create route plan
+          - route-plan lowering records fan-in stream metadata, required singleton/window/dedup_by, singular target delivery, and no new target kind
+          - bootverify proves fan-in pin dedup/window declarations match the receiving accumulate handler declarations
+          - EventBus publish/preflight for fan-in stream routes multiple source contributions to the same explicit singleton/coordinator receiver route
+          - receiver accumulator kernel enforces declared dedup_by idempotency and partitions arrivals by declared window
+          - same committed fan-in stream event replay reuses persisted delivery route/scope and does not re-infer receiver identity from sender/source state
+          - standalone #1828 `template-fan-in` conformance fixture verifies and materializes through the canonical fan-in stream route plan
         implementation_slice_1546:
           status: merge_bearing_runtime_behavior
           canonical_code_owner: internal/runtime/core/pinrouting.ConnectRoutePlan.InstanceKey.Mappings + internal/runtime/bus.connectRoutePlanResolver


### PR DESCRIPTION
## Summary

Closes #1890.

This makes the approved #1835 fan-in stream/windowed child slice runnable. It adds receiver-declared `resolution.mode: fan-in` with `aggregation: stream`, explicit singleton receiver routing, required `dedup_by`/`window` verification, route-plan fan-in metadata, EventBus delivery to the singleton receiver route, and accumulator-kernel windowed bucket enforcement.

The implementation intentionally reuses singular target delivery. It does not add a new fan-in target kind, does not infer receiver authority from the sender, and keeps barrier/fan-out/reply unresolved modes fail-closed for their own children.

## Governing Refs / Context

- `platform-spec.yaml#flow_model.flow_package.composition_routing.route_plan_lowering.implementation_slice_1835`
- `platform-spec.yaml#handler_specification.accumulate`
- `platform-spec.yaml#engine.accumulation_engine`
- Issue #1890 body/thread, approved pre-audit, and Gate A outcome.
- Parent routing design context: #1835, #1786, #1828, #1848, and E1a retirement sequencing.

## Semantic Migration

New canonical owners:

- `runtimecontracts.FlowInputPinResolution` for receiver-declared fan-in stream syntax.
- `pinrouting.ConnectRoutePlan.FanIn` for lowered route-plan fan-in metadata.
- EventBus connect route-plan dispatch for delivering to the explicit singleton receiver route.
- `runtimecontracts.AccumulateSpec.Window`, `timeridentity.AccumulatorBucketRef`, and the engine accumulator kernel for dedup/window enforcement.
- `platform-spec.yaml` for the authoritative runtime contract.

Old paths now invalid or non-authoritative:

- `resolution.mode: fan-in` no longer ends at the generic `instance_resolution_unimplemented` path for the stream/windowed singleton slice.
- Sender/event-context inferred receiver authority is non-authoritative for fan-in.
- Delivery-layer dedup/window semantics are non-authoritative; the seam declares them and the accumulator kernel enforces them.
- `connect.map`, `connect.using.instance`, legacy address fields, fan-in `delivery: many`, missing singleton, missing dedup, missing window, and non-stream aggregation remain fail-closed.

Production paths checked:

- YAML decode and strict option validation.
- Bootverify composition connect validation.
- Connect route-plan lowering.
- EventBus connect route-plan dispatch and persisted-recipient replay.
- Pipeline timeout scheduling.
- Engine accumulate/compute/projection reads.
- Route authority conformance matrix.

Migration completeness:

- Complete for #1890's approved fan-in stream/windowed singleton child class.
- Parent #1835 remains open for fan-in barrier, fan-out, reply, empire counterparts, and E1a legacy routing retirements.

## Validation

- `SWARM_TEST_POSTGRES_DSN='host=127.0.0.1 port=5432 user=youmew dbname=postgres sslmode=disable' PGPASSWORD=postgres go test ./...`
- Focused integration proof: `go test ./internal/runtime/conformance -run TestFanInStreamConformance_RoutesToSingletonAndKernelEnforcesWindowedDedup -count=1`
- Route authority proofs: `go test ./internal/runtime/conformance -run 'TestRouteAuthorityMatrix|TestRouteAuthorityDriftInventory' -count=1`